### PR TITLE
🏗 ✅ Isolate tests by eliminating the use of the global `sinon` sandbox

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -210,8 +210,6 @@
         "before": false,
         "after": false,
         "assert": false,
-        "sinon": true,
-        "sandbox": true,
         "describes": true,
         "allowConsoleError": false,
         "expectAsyncConsoleError": false,

--- a/ads/google/a4a/test/test-line-delimited-response-handler.js
+++ b/ads/google/a4a/test/test-line-delimited-response-handler.js
@@ -22,7 +22,6 @@ import {
 describe('#line-delimited-response-handler', () => {
   let chunkHandlerStub;
   let slotData;
-  let sandbox;
   let win;
   let response;
 
@@ -93,12 +92,7 @@ describe('#line-delimited-response-handler', () => {
   }
 
   beforeEach(() => {
-    sandbox = sinon.sandbox;
-    chunkHandlerStub = sandbox.stub();
-  });
-
-  afterEach(() => {
-    sandbox.restore();
+    chunkHandlerStub = window.sandbox.stub();
   });
 
   describe('stream not supported', () => {
@@ -143,7 +137,6 @@ describe('#line-delimited-response-handler', () => {
 
   describe('streaming', () => {
     let readStub;
-    let sandbox;
 
     function setup() {
       const responseString = generateResponseFormat();
@@ -161,8 +154,7 @@ describe('#line-delimited-response-handler', () => {
     }
 
     beforeEach(() => {
-      sandbox = sinon.sandbox;
-      readStub = sandbox.stub();
+      readStub = window.sandbox.stub();
       response = {
         text: () => Promise.resolve(),
         body: {
@@ -176,10 +168,6 @@ describe('#line-delimited-response-handler', () => {
       win = {
         TextDecoder,
       };
-    });
-
-    afterEach(() => {
-      sandbox.restore();
     });
 
     // TODO(lannka, #15748): Fails on Safari 11.1.0.

--- a/ads/google/a4a/test/test-utils.js
+++ b/ads/google/a4a/test/test-utils.js
@@ -112,16 +112,6 @@ describe('Google A4A utils', () => {
   });
 
   describe('#ActiveView AmpAnalytics integration', () => {
-    let sandbox;
-
-    beforeEach(() => {
-      sandbox = sinon.sandbox;
-    });
-
-    afterEach(() => {
-      sandbox.restore();
-    });
-
     const builtConfig = {
       transport: {beacon: false, xhrpost: false},
       requests: {
@@ -194,7 +184,9 @@ describe('Google A4A utils', () => {
     });
 
     it('should add the correct CSI signals', () => {
-      sandbox.stub(Services, 'documentInfoForDoc').returns({pageViewId: 777});
+      window.sandbox
+        .stub(Services, 'documentInfoForDoc')
+        .returns({pageViewId: 777});
       const mockElement = {
         getAttribute: function(name) {
           switch (name) {
@@ -315,16 +307,6 @@ describe('Google A4A utils', () => {
   });
 
   describe('#googleAdUrl', () => {
-    let sandbox;
-
-    beforeEach(() => {
-      sandbox = sinon.sandbox;
-    });
-
-    afterEach(() => {
-      sandbox.restore();
-    });
-
     it('should set ad position', function() {
       // When ran locally, this test tends to exceed 2000ms timeout.
       this.timeout(5000);
@@ -338,7 +320,7 @@ describe('Google A4A utils', () => {
           'height': '50',
         });
         const impl = new MockA4AImpl(elem);
-        noopMethods(impl, fixture.ampdoc, sandbox);
+        noopMethods(impl, fixture.ampdoc, window.sandbox);
         return fixture.addElement(elem).then(() => {
           return googleAdUrl(impl, '', 0, [], []).then(url1 => {
             expect(url1).to.match(/ady=11/);
@@ -359,7 +341,7 @@ describe('Google A4A utils', () => {
           'height': '50',
         });
         const impl = new MockA4AImpl(elem);
-        noopMethods(impl, fixture.ampdoc, sandbox);
+        noopMethods(impl, fixture.ampdoc, window.sandbox);
         const getRect = () => {
           return {'width': 100, 'height': 200};
         };
@@ -368,7 +350,7 @@ describe('Google A4A utils', () => {
         };
         const getScrollLeft = () => 12;
         const getScrollTop = () => 34;
-        const viewportStub = sandbox.stub(Services, 'viewportForDoc');
+        const viewportStub = window.sandbox.stub(Services, 'viewportForDoc');
         viewportStub.returns({getRect, getSize, getScrollTop, getScrollLeft});
         return fixture.addElement(elem).then(() => {
           return googleAdUrl(impl, '', 0, {}, []).then(url1 => {
@@ -392,7 +374,7 @@ describe('Google A4A utils', () => {
           'data-experiment-id': '123,456',
         });
         const impl = new MockA4AImpl(elem);
-        noopMethods(impl, fixture.ampdoc, sandbox);
+        noopMethods(impl, fixture.ampdoc, window.sandbox);
         return fixture.addElement(elem).then(() => {
           return googleAdUrl(impl, '', 0, {}, ['789', '098']).then(url1 => {
             expect(url1).to.match(/eid=123%2C456%2C789%2C098/);
@@ -412,7 +394,7 @@ describe('Google A4A utils', () => {
           'height': '50',
         });
         const impl = new MockA4AImpl(elem);
-        noopMethods(impl, fixture.ampdoc, sandbox);
+        noopMethods(impl, fixture.ampdoc, window.sandbox);
         impl.win.AMP_CONFIG = {type: 'production'};
         impl.win.location.hash = 'foo,deid=123456,654321,bar';
         return fixture.addElement(elem).then(() => {
@@ -434,7 +416,7 @@ describe('Google A4A utils', () => {
           'height': '50',
         });
         const impl = new MockA4AImpl(elem);
-        noopMethods(impl, fixture.ampdoc, sandbox);
+        noopMethods(impl, fixture.ampdoc, window.sandbox);
         impl.win.gaGlobal = {cid: 'foo', hid: 'bar'};
         return fixture.addElement(elem).then(() => {
           return googleAdUrl(impl, '', 0, [], []).then(url => {
@@ -456,8 +438,8 @@ describe('Google A4A utils', () => {
           'height': '50',
         });
         const impl = new MockA4AImpl(elem);
-        noopMethods(impl, fixture.ampdoc, sandbox);
-        const createElementStub = sandbox.stub(
+        noopMethods(impl, fixture.ampdoc, window.sandbox);
+        const createElementStub = window.sandbox.stub(
           impl.win.document,
           'createElement'
         );
@@ -485,8 +467,8 @@ describe('Google A4A utils', () => {
           'height': '50',
         });
         const impl = new MockA4AImpl(elem);
-        noopMethods(impl, fixture.ampdoc, sandbox);
-        const createElementStub = sandbox.stub(
+        noopMethods(impl, fixture.ampdoc, window.sandbox);
+        const createElementStub = window.sandbox.stub(
           impl.win.document,
           'createElement'
         );
@@ -512,9 +494,9 @@ describe('Google A4A utils', () => {
           'height': '50',
         });
         const impl = new MockA4AImpl(elem);
-        noopMethods(impl, fixture.ampdoc, sandbox);
+        noopMethods(impl, fixture.ampdoc, window.sandbox);
         impl.win.SVGElement = undefined;
-        const createElementStub = sandbox.stub(
+        const createElementStub = window.sandbox.stub(
           impl.win.document,
           'createElement'
         );
@@ -542,11 +524,11 @@ describe('Google A4A utils', () => {
           'height': '50',
         });
         const impl = new MockA4AImpl(elem);
-        noopMethods(impl, fixture.ampdoc, sandbox);
-        sandbox
+        noopMethods(impl, fixture.ampdoc, window.sandbox);
+        window.sandbox
           .stub(Services.viewerForDoc(impl.getAmpDoc()), 'getReferrerUrl')
           .returns(new Promise(() => {}));
-        const createElementStub = sandbox.stub(
+        const createElementStub = window.sandbox.stub(
           impl.win.document,
           'createElement'
         );
@@ -571,7 +553,7 @@ describe('Google A4A utils', () => {
         doc.win = fixture.win;
         const elem = createElementWithAttributes(doc, 'amp-a4a', {});
         const impl = new MockA4AImpl(elem);
-        noopMethods(impl, fixture.ampdoc, sandbox);
+        noopMethods(impl, fixture.ampdoc, window.sandbox);
         return fixture.addElement(elem).then(() => {
           return googleAdUrl(impl, '', Date.now(), [], []).then(url => {
             expect(url).to.match(/[&?]bdt=[1-9][0-9]*[&$]/);
@@ -663,11 +645,11 @@ describe('Google A4A utils', () => {
     });
   });
 
-  describes.fakeWin('#getIdentityTokenRequestUrl', {}, () => {
+  describes.fakeWin('#getIdentityTokenRequestUrl', {}, env => {
     let doc;
     let fakeWin;
     beforeEach(() => {
-      const documentInfoStub = sandbox.stub(Services, 'documentInfoForDoc');
+      const documentInfoStub = env.sandbox.stub(Services, 'documentInfoForDoc');
       doc = {};
       fakeWin = {location: {}};
       documentInfoStub
@@ -719,7 +701,7 @@ describe('Google A4A utils', () => {
   describes.fakeWin('#getIdentityToken', {amp: true, mockFetch: true}, env => {
     beforeEach(() => {
       installXhrService(env.win);
-      const documentInfoStub = sandbox.stub(Services, 'documentInfoForDoc');
+      const documentInfoStub = env.sandbox.stub(Services, 'documentInfoForDoc');
       documentInfoStub
         .withArgs(env.ampdoc)
         .returns({canonicalUrl: 'http://f.blah.com?some_site'});
@@ -818,7 +800,7 @@ describe('Google A4A utils', () => {
     });
 
     it('should handle fetch error', () => {
-      sandbox
+      env.sandbox
         .stub(Services, 'xhrFor')
         .returns({fetchJson: () => Promise.reject('some network failure')});
       return getIdentityToken(env.win, env.ampdoc).then(result =>
@@ -837,7 +819,7 @@ describe('Google A4A utils', () => {
           validLifetimeSecs: '5678',
         })
       );
-      sandbox.stub(Services, 'consentPolicyServiceForDocOrNull').returns(
+      env.sandbox.stub(Services, 'consentPolicyServiceForDocOrNull').returns(
         Promise.resolve({
           whenPolicyResolved: () => CONSENT_POLICY_STATE.SUFFICIENT,
         })
@@ -850,7 +832,7 @@ describe('Google A4A utils', () => {
     it.configure()
       .skipFirefox()
       .run('should not fetch if INSUFFICIENT consent', () => {
-        sandbox.stub(Services, 'consentPolicyServiceForDocOrNull').returns(
+        env.sandbox.stub(Services, 'consentPolicyServiceForDocOrNull').returns(
           Promise.resolve({
             whenPolicyResolved: () => CONSENT_POLICY_STATE.INSUFFICIENT,
           })
@@ -863,7 +845,7 @@ describe('Google A4A utils', () => {
     it.configure()
       .skipFirefox()
       .run('should not fetch if UNKNOWN consent', () => {
-        sandbox.stub(Services, 'consentPolicyServiceForDocOrNull').returns(
+        env.sandbox.stub(Services, 'consentPolicyServiceForDocOrNull').returns(
           Promise.resolve({
             whenPolicyResolved: () => CONSENT_POLICY_STATE.UNKNOWN,
           })
@@ -876,11 +858,9 @@ describe('Google A4A utils', () => {
 
   describe('variables for amp-analytics', () => {
     let a4a;
-    let sandbox;
     let ampdoc;
 
     beforeEach(() => {
-      sandbox = sinon.sandbox;
       return createIframePromise().then(fixture => {
         setupForAdTesting(fixture);
         const element = createElementWithAttributes(fixture.doc, 'amp-a4a', {
@@ -893,10 +873,6 @@ describe('Google A4A utils', () => {
         element.getAmpDoc = () => ampdoc;
         a4a = new MockA4AImpl(element);
       });
-    });
-
-    afterEach(() => {
-      sandbox.restore();
     });
 
     it('should include the correlator', () => {
@@ -934,7 +910,7 @@ describe('Google A4A utils', () => {
     });
 
     it('should include viewer lastVisibleTime', () => {
-      sandbox.stub(ampdoc, 'getLastVisibleTime').returns(300);
+      window.sandbox.stub(ampdoc, 'getLastVisibleTime').returns(300);
 
       const vars = getCsiAmpAnalyticsVariables('trigger', a4a, null);
       expect(vars['viewerLastVisibleTime']).to.be.a('number');
@@ -983,7 +959,7 @@ describe('Google A4A utils', () => {
 
     it('should calculate correlator from PVID and CID if possible', () => {
       const pageViewId = '818181';
-      sandbox.stub(Services, 'documentInfoForDoc').callsFake(() => {
+      env.sandbox.stub(Services, 'documentInfoForDoc').callsFake(() => {
         return {pageViewId};
       });
       const cid = '12345678910';
@@ -1021,7 +997,7 @@ describes.realWin('#groupAmpAdsByType', {amp: true}, env => {
       createResource({type: 'blah'}),
       createResource({}, 'amp-foo'),
     ];
-    sandbox
+    env.sandbox
       .stub(IniLoad, 'getMeasuredResources')
       .callsFake((doc, win, fn) => Promise.resolve(resources.filter(fn)));
     return groupAmpAdsByType(ampdoc, 'doubleclick', () => 'foo').then(
@@ -1051,7 +1027,7 @@ describes.realWin('#groupAmpAdsByType', {amp: true}, env => {
       stickyResource.element
     );
     ampAdResource.element.createdCallback = true;
-    sandbox
+    env.sandbox
       .stub(IniLoad, 'getMeasuredResources')
       .callsFake((doc, win, fn) => Promise.resolve(resources.filter(fn)));
     return groupAmpAdsByType(win, 'doubleclick', () => 'foo').then(result => {
@@ -1082,7 +1058,7 @@ describes.realWin('#groupAmpAdsByType', {amp: true}, env => {
       stickyResource.element
     );
     ampAdResource.element.createdCallback = true;
-    sandbox
+    env.sandbox
       .stub(IniLoad, 'getMeasuredResources')
       .callsFake((doc, win, fn) => Promise.resolve(resources.filter(fn)));
     return groupAmpAdsByType(win, 'doubleclick', element =>

--- a/extensions/amp-3d-gltf/0.1/test/test-amp-3d-gltf.js
+++ b/extensions/amp-3d-gltf/0.1/test/test-amp-3d-gltf.js
@@ -60,7 +60,7 @@ describes.realWin(
       await amp3dGltfEl.build();
 
       const amp3dGltf = amp3dGltfEl.implementation_;
-      sandbox
+      env.sandbox
         .stub(amp3dGltf, 'iframe_')
         .get(() => iframe)
         .set(() => {});
@@ -84,7 +84,7 @@ describes.realWin(
     it.skip('sends toggleAmpViewport(false) when exiting viewport', async () => {
       const amp3dGltf = await createElement();
 
-      const postMessageSpy = sandbox.spy(amp3dGltf, 'postMessage_');
+      const postMessageSpy = env.sandbox.spy(amp3dGltf, 'postMessage_');
       await amp3dGltf.viewportCallback(false);
       expect(postMessageSpy.calledOnce).to.be.true;
       expect(postMessageSpy.firstCall.args[0]).to.equal('action');
@@ -97,7 +97,7 @@ describes.realWin(
     // TODO (#16080): this test times out on Travis. Re-enable when fixed.
     it.skip('sends toggleAmpViewport(true) when entering viewport', async () => {
       const amp3dGltf = await createElement();
-      const postMessageSpy = sandbox.spy(amp3dGltf, 'postMessage_');
+      const postMessageSpy = env.sandbox.spy(amp3dGltf, 'postMessage_');
       await amp3dGltf.viewportCallback(true);
       expect(postMessageSpy.calledOnce).to.be.true;
       expect(postMessageSpy.firstCall.args[0]).to.equal('action');

--- a/extensions/amp-a4a/0.1/test/test-a4a-integration.js
+++ b/extensions/amp-a4a/0.1/test/test-a4a-integration.js
@@ -79,14 +79,12 @@ function expectRenderedInXDomainIframe(element, src) {
 }
 
 describe('integration test: a4a', () => {
-  let sandbox;
   let fixture;
   let fetchMock;
   let adResponse;
   let a4aElement;
   let a4aRegistry;
   beforeEach(async () => {
-    sandbox = sinon.sandbox;
     a4aRegistry = getA4ARegistry();
     a4aRegistry['mock'] = () => {
       return true;
@@ -123,7 +121,6 @@ describe('integration test: a4a', () => {
 
   afterEach(() => {
     fetchMock./*OK*/ restore();
-    sandbox.restore();
     resetScheduledElementForTesting(window, 'amp-a4a');
     delete a4aRegistry['mock'];
   });
@@ -151,7 +148,7 @@ describe('integration test: a4a', () => {
     // TODO(tdrl) Currently layoutCallback rejects, even though something *is*
     // rendered.  This should be fixed in a refactor, and we should change this
     // .catch to a .then.
-    const forceCollapseStub = sandbox.spy(
+    const forceCollapseStub = window.sandbox.spy(
       MockA4AImpl.prototype,
       'forceCollapse'
     );
@@ -169,7 +166,7 @@ describe('integration test: a4a', () => {
   it('should collapse slot when creative response has code 204', async () => {
     adResponse.status = 204;
     adResponse.body = null;
-    const forceCollapseStub = sandbox.spy(
+    const forceCollapseStub = window.sandbox.spy(
       MockA4AImpl.prototype,
       'forceCollapse'
     );
@@ -179,7 +176,7 @@ describe('integration test: a4a', () => {
 
   it('should collapse slot when creative response.arrayBuffer() is empty', async () => {
     adResponse.body = '';
-    const forceCollapseStub = sandbox.spy(
+    const forceCollapseStub = window.sandbox.spy(
       MockA4AImpl.prototype,
       'forceCollapse'
     );
@@ -191,7 +188,7 @@ describe('integration test: a4a', () => {
     await fixture.addElement(a4aElement);
     await expectRenderedInFriendlyIframe(a4aElement, 'Hello, world.');
     const a4a = new MockA4AImpl(a4aElement);
-    const initiateAdRequestMock = sandbox
+    const initiateAdRequestMock = window.sandbox
       .stub(MockA4AImpl.prototype, 'initiateAdRequest')
       .callsFake(() => {
         a4a.adPromise_ = Promise.resolve();
@@ -199,13 +196,16 @@ describe('integration test: a4a', () => {
         // up any unrelated asserts.
         a4a.isRefreshing = false;
       });
-    const tearDownSlotMock = sandbox.stub(
+    const tearDownSlotMock = window.sandbox.stub(
       MockA4AImpl.prototype,
       'tearDownSlot'
     );
     tearDownSlotMock.returns(undefined);
-    const destroyFrameSpy = sandbox.spy(MockA4AImpl.prototype, 'destroyFrame');
-    const callback = sandbox.spy();
+    const destroyFrameSpy = window.sandbox.spy(
+      MockA4AImpl.prototype,
+      'destroyFrame'
+    );
+    const callback = window.sandbox.spy();
     await a4a.refresh(callback);
     expect(initiateAdRequestMock).to.be.called;
     expect(tearDownSlotMock).to.be.called;

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -82,7 +82,6 @@ describe('amp-a4a', () => {
     'allow-top-navigation-by-user-activation',
   ];
 
-  let sandbox;
   let fetchMock;
   let getSigningServiceNamesMock;
   let whenVisibleMock;
@@ -91,17 +90,19 @@ describe('amp-a4a', () => {
   let getResourceStub;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox;
     fetchMock = null;
-    getSigningServiceNamesMock = sandbox.stub(
+    getSigningServiceNamesMock = window.sandbox.stub(
       AmpA4A.prototype,
       'getSigningServiceNames'
     );
-    onCreativeRenderSpy = sandbox.spy(AmpA4A.prototype, 'onCreativeRender');
+    onCreativeRenderSpy = window.sandbox.spy(
+      AmpA4A.prototype,
+      'onCreativeRender'
+    );
     getSigningServiceNamesMock.returns(['google']);
-    whenVisibleMock = sandbox.stub(AmpDoc.prototype, 'whenFirstVisible');
+    whenVisibleMock = window.sandbox.stub(AmpDoc.prototype, 'whenFirstVisible');
     whenVisibleMock.returns(Promise.resolve());
-    getResourceStub = sandbox.stub(AmpA4A.prototype, 'getResource');
+    getResourceStub = window.sandbox.stub(AmpA4A.prototype, 'getResource');
     getResourceStub.returns({
       getUpgradeDelayMs: () => 12345,
     });
@@ -119,7 +120,6 @@ describe('amp-a4a', () => {
       fetchMock./*OK*/ restore();
       fetchMock = null;
     }
-    sandbox.restore();
     resetScheduledElementForTesting(window, 'amp-a4a');
   });
 
@@ -348,7 +348,7 @@ describe('amp-a4a', () => {
       .concat(additionalEvents)
       .forEach(evnt =>
         expect(triggerAnalyticsEventSpy).to.be.calledWith(a4a.element, evnt, {
-          'time': sinon.match.number,
+          'time': window.sandbox.match.number,
         })
       );
   }
@@ -378,7 +378,7 @@ describe('amp-a4a', () => {
       // If rendering type is safeframe, we SHOULD attach a SafeFrame.
       adResponse.headers[RENDERING_TYPE_HEADER] = 'safeframe';
       a4a.buildCallback();
-      const lifecycleEventStub = sandbox.stub(
+      const lifecycleEventStub = window.sandbox.stub(
         a4a,
         'maybeTriggerAnalyticsEvent_'
       );
@@ -393,7 +393,7 @@ describe('amp-a4a', () => {
 
     it('for ios defaults to SafeFrame rendering', async () => {
       const platform = Services.platformFor(fixture.win);
-      sandbox.stub(platform, 'isIos').returns(true);
+      window.sandbox.stub(platform, 'isIos').returns(true);
       a4a = new MockA4AImpl(a4aElement);
       // Make sure there's no signature, so that we go down the 3p iframe path.
       delete adResponse.headers['AMP-Fast-Fetch-Signature'];
@@ -450,7 +450,7 @@ describe('amp-a4a', () => {
     });
 
     it('detachedCallback should destroy FIE and detach frame', async () => {
-      const fieDestroySpy = sandbox./*OK*/ spy(
+      const fieDestroySpy = window.sandbox./*OK*/ spy(
         FriendlyIframeEmbed.prototype,
         'destroy'
       );
@@ -467,7 +467,7 @@ describe('amp-a4a', () => {
       a4a.onLayoutMeasure();
 
       // Never resolve
-      sandbox
+      window.sandbox
         ./*OK*/ stub(FriendlyIframeEmbed.prototype, 'whenIniLoaded')
         .callsFake(() => {
           return new Promise(() => {});
@@ -484,11 +484,11 @@ describe('amp-a4a', () => {
       const iniLoadPromise = new Promise(resolve => {
         iniLoadResolver = resolve;
       });
-      const whenIniLoadedStub = sandbox
+      const whenIniLoadedStub = window.sandbox
         .stub(FriendlyIframeEmbed.prototype, 'whenIniLoaded')
         .callsFake(() => iniLoadPromise);
       a4a.buildCallback();
-      const triggerAnalyticsEventSpy = sandbox.spy(
+      const triggerAnalyticsEventSpy = window.sandbox.spy(
         analytics,
         'triggerAnalyticsEvent'
       );
@@ -501,7 +501,7 @@ describe('amp-a4a', () => {
     });
 
     it('should update embed visibility', async () => {
-      sandbox.stub(a4a, 'isInViewport').callsFake(() => false);
+      window.sandbox.stub(a4a, 'isInViewport').callsFake(() => false);
       a4a.buildCallback();
       a4a.onLayoutMeasure();
       await a4a.layoutCallback();
@@ -519,7 +519,7 @@ describe('amp-a4a', () => {
     });
 
     it('for requests from insecure HTTP pages', async () => {
-      sandbox
+      window.sandbox
         .stub(Services.cryptoFor(fixture.win), 'isPkcsAvailable')
         .returns(false);
       a4a.buildCallback();
@@ -532,13 +532,13 @@ describe('amp-a4a', () => {
     });
 
     it('should fire amp-analytics triggers', async () => {
-      const triggerAnalyticsEventSpy = sandbox.spy(
+      const triggerAnalyticsEventSpy = window.sandbox.spy(
         analytics,
         'triggerAnalyticsEvent'
       );
       a4a.buildCallback();
       a4a.onLayoutMeasure();
-      sandbox
+      window.sandbox
         ./*OK*/ stub(FriendlyIframeEmbed.prototype, 'whenIniLoaded')
         .callsFake(() => Promise.resolve());
       await a4a.layoutCallback();
@@ -546,11 +546,11 @@ describe('amp-a4a', () => {
     });
 
     it('should not fire amp-analytics triggers without config', async () => {
-      sandbox
+      window.sandbox
         .stub(MockA4AImpl.prototype, 'getA4aAnalyticsConfig')
         .callsFake(() => null);
       a4a = new MockA4AImpl(a4aElement);
-      const triggerAnalyticsEventSpy = sandbox.spy(
+      const triggerAnalyticsEventSpy = window.sandbox.spy(
         analytics,
         'triggerAnalyticsEvent'
       );
@@ -561,11 +561,11 @@ describe('amp-a4a', () => {
     });
 
     it('should insert an amp-analytics element', async () => {
-      sandbox
+      window.sandbox
         .stub(MockA4AImpl.prototype, 'getA4aAnalyticsConfig')
         .callsFake(() => ({'foo': 'bar'}));
       a4a = new MockA4AImpl(a4aElement);
-      const insertAnalyticsElementSpy = sandbox.spy(
+      const insertAnalyticsElementSpy = window.sandbox.spy(
         analyticsExtension,
         'insertAnalyticsElement'
       );
@@ -578,11 +578,11 @@ describe('amp-a4a', () => {
     });
 
     it('should not insert an amp-analytics element if config is null', () => {
-      sandbox
+      window.sandbox
         .stub(MockA4AImpl.prototype, 'getA4aAnalyticsConfig')
         .callsFake(() => null);
       a4a = new MockA4AImpl(a4aElement);
-      const insertAnalyticsElementSpy = sandbox.spy(
+      const insertAnalyticsElementSpy = window.sandbox.spy(
         analyticsExtension,
         'insertAnalyticsElement'
       );
@@ -618,7 +618,7 @@ describe('amp-a4a', () => {
       });
       const layoutCallbackPromise = a4a.layoutCallback();
       a4a.unlayoutCallback();
-      const renderNonAmpCreativeSpy = sandbox.spy(
+      const renderNonAmpCreativeSpy = window.sandbox.spy(
         AmpA4A.prototype,
         'renderNonAmpCreative'
       );
@@ -731,7 +731,7 @@ describe('amp-a4a', () => {
     describe('illegal render mode value', () => {
       let devErrLogStub;
       beforeEach(() => {
-        devErrLogStub = sandbox.stub(dev(), 'error');
+        devErrLogStub = window.sandbox.stub(dev(), 'error');
         // If rendering type is unknown, should fall back to cached content
         // iframe and generate an error.
         adResponse.headers[RENDERING_TYPE_HEADER] = 'random illegal value';
@@ -739,7 +739,7 @@ describe('amp-a4a', () => {
       });
 
       it('should render via cached iframe', async () => {
-        const triggerAnalyticsEventSpy = sandbox.spy(
+        const triggerAnalyticsEventSpy = window.sandbox.spy(
           analytics,
           'triggerAnalyticsEvent'
         );
@@ -759,7 +759,7 @@ describe('amp-a4a', () => {
       });
 
       it('should fire amp-analytics triggers for illegal render modes', async () => {
-        const triggerAnalyticsEventSpy = sandbox.spy(
+        const triggerAnalyticsEventSpy = window.sandbox.spy(
           analytics,
           'triggerAnalyticsEvent'
         );
@@ -819,7 +819,7 @@ describe('amp-a4a', () => {
         headerVal => {
           // TODO(wg-ads, #25690): Fails on Travis.
           it.skip(`should not attach a NameFrame when header is ${headerVal}`, async () => {
-            const devStub = sandbox.stub(dev(), 'error');
+            const devStub = window.sandbox.stub(dev(), 'error');
             // Make sure there's no signature, so that we go down the 3p
             // iframe path.
             delete adResponse.headers['AMP-Fast-Fetch-Signature'];
@@ -854,7 +854,7 @@ describe('amp-a4a', () => {
       );
 
       it('should fire amp-analytics triggers for lifecycle stages', async () => {
-        const triggerAnalyticsEventSpy = sandbox.spy(
+        const triggerAnalyticsEventSpy = window.sandbox.spy(
           analytics,
           'triggerAnalyticsEvent'
         );
@@ -928,7 +928,7 @@ describe('amp-a4a', () => {
       ['', 'client_cache', 'nameframe', 'some_random_thing'].forEach(
         headerVal => {
           it(`should not attach a SafeFrame when header is ${headerVal}`, async () => {
-            const devStub = sandbox.stub(dev(), 'error');
+            const devStub = window.sandbox.stub(dev(), 'error');
             // If rendering type is anything but safeframe, we SHOULD NOT
             // attach a SafeFrame.
             adResponse.headers[RENDERING_TYPE_HEADER] = headerVal;
@@ -973,7 +973,7 @@ describe('amp-a4a', () => {
       });
 
       it('should fire amp-analytics triggers for lifecycle stages', async () => {
-        const triggerAnalyticsEventSpy = sandbox.spy(
+        const triggerAnalyticsEventSpy = window.sandbox.spy(
           analytics,
           'triggerAnalyticsEvent'
         );
@@ -1088,7 +1088,10 @@ describe('amp-a4a', () => {
       s.textContent = '.fixed {position:fixed;}';
       doc.head.appendChild(s);
       const a4a = new MockA4AImpl(a4aElement);
-      const renderNonAmpCreativeSpy = sandbox.spy(a4a, 'renderNonAmpCreative');
+      const renderNonAmpCreativeSpy = window.sandbox.spy(
+        a4a,
+        'renderNonAmpCreative'
+      );
       a4a.buildCallback();
       a4a.onLayoutMeasure();
       expect(a4a.adPromise_).to.be.ok;
@@ -1102,7 +1105,7 @@ describe('amp-a4a', () => {
         'hasBeenMeasured': () => true,
         'isMeasureRequested': () => false,
       });
-      const onLayoutMeasureSpy = sandbox.spy(a4a, 'onLayoutMeasure');
+      const onLayoutMeasureSpy = window.sandbox.spy(a4a, 'onLayoutMeasure');
       a4a.resumeCallback();
       expect(onLayoutMeasureSpy).to.be.calledOnce;
       expect(a4a.fromResumeCallback).to.be.true;
@@ -1121,7 +1124,10 @@ describe('amp-a4a', () => {
       s.textContent = '.fixed {position:fixed;}';
       doc.head.appendChild(s);
       const a4a = new MockA4AImpl(a4aElement);
-      const renderAmpCreativeSpy = sandbox.spy(a4a, 'renderAmpCreative_');
+      const renderAmpCreativeSpy = window.sandbox.spy(
+        a4a,
+        'renderAmpCreative_'
+      );
       a4a.buildCallback();
       a4a.onLayoutMeasure();
       expect(a4a.adPromise_).to.be.ok;
@@ -1130,8 +1136,8 @@ describe('amp-a4a', () => {
         renderAmpCreativeSpy.calledOnce,
         'renderAmpCreative_ called exactly once'
       ).to.be.true;
-      sandbox.stub(a4a, 'unlayoutCallback').callsFake(() => false);
-      const onLayoutMeasureSpy = sandbox.spy(a4a, 'onLayoutMeasure');
+      window.sandbox.stub(a4a, 'unlayoutCallback').callsFake(() => false);
+      const onLayoutMeasureSpy = window.sandbox.spy(a4a, 'onLayoutMeasure');
       a4a.resumeCallback();
       expect(onLayoutMeasureSpy).to.not.be.called;
       expect(a4a.fromResumeCallback).to.be.false;
@@ -1153,7 +1159,10 @@ describe('amp-a4a', () => {
       s.textContent = '.fixed {position:fixed;}';
       doc.head.appendChild(s);
       const a4a = new MockA4AImpl(a4aElement);
-      const renderNonAmpCreativeSpy = sandbox.spy(a4a, 'renderNonAmpCreative');
+      const renderNonAmpCreativeSpy = window.sandbox.spy(
+        a4a,
+        'renderNonAmpCreative'
+      );
       a4a.buildCallback();
       a4a.onLayoutMeasure();
       expect(a4a.adPromise_).to.be.ok;
@@ -1163,7 +1172,7 @@ describe('amp-a4a', () => {
         'renderNonAmpCreative called exactly once'
       ).to.be.true;
       a4a.unlayoutCallback();
-      const onLayoutMeasureSpy = sandbox.spy(a4a, 'onLayoutMeasure');
+      const onLayoutMeasureSpy = window.sandbox.spy(a4a, 'onLayoutMeasure');
       getResourceStub.returns({'hasBeenMeasured': () => false});
       a4a.resumeCallback();
       expect(onLayoutMeasureSpy).to.not.be.called;
@@ -1181,27 +1190,30 @@ describe('amp-a4a', () => {
       const a4aElement = createA4aElement(doc);
       const a4a = new MockA4AImpl(a4aElement);
       a4a.releaseType_ = '0';
-      const getAdUrlSpy = sandbox.spy(a4a, 'getAdUrl');
+      const getAdUrlSpy = window.sandbox.spy(a4a, 'getAdUrl');
       const rtcResponse = Promise.resolve([
         {response: 'a', rtcTime: 1, callout: 'https://a.com'},
       ]);
-      const maybeExecuteRealTimeConfigStub = sandbox
+      const maybeExecuteRealTimeConfigStub = window.sandbox
         .stub()
         .returns(rtcResponse);
       AMP.RealTimeConfigManager = RealTimeConfigManager;
-      sandbox
+      window.sandbox
         .stub(AMP.RealTimeConfigManager.prototype, 'maybeExecuteRealTimeConfig')
         .callsFake(maybeExecuteRealTimeConfigStub);
-      const tryExecuteRealTimeConfigSpy = sandbox.spy(
+      const tryExecuteRealTimeConfigSpy = window.sandbox.spy(
         a4a,
         'tryExecuteRealTimeConfig_'
       );
-      const updateLayoutPriorityStub = sandbox.stub(
+      const updateLayoutPriorityStub = window.sandbox.stub(
         a4a,
         'updateLayoutPriority'
       );
-      const renderAmpCreativeSpy = sandbox.spy(a4a, 'renderAmpCreative_');
-      const preloadExtensionSpy = sandbox.spy(
+      const renderAmpCreativeSpy = window.sandbox.spy(
+        a4a,
+        'renderAmpCreative_'
+      );
+      const preloadExtensionSpy = window.sandbox.spy(
         Extensions.prototype,
         'preloadExtension'
       );
@@ -1258,7 +1270,8 @@ describe('amp-a4a', () => {
         )
       ).to.be.ok;
       expect(doc.querySelector('script[src*="amp-font-0.1"]')).to.be.ok;
-      expect(onCreativeRenderSpy.withArgs(sinon.match.object)).to.be.calledOnce;
+      expect(onCreativeRenderSpy.withArgs(window.sandbox.match.object)).to.be
+        .calledOnce;
       expect(updateLayoutPriorityStub).to.be.calledOnce;
       expect(updateLayoutPriorityStub.args[0][0]).to.equal(
         LayoutPriority.CONTENT
@@ -1280,12 +1293,17 @@ describe('amp-a4a', () => {
       const element = createA4aElement(fixture.doc);
       element.setAttribute('type', 'adsense');
       const a4a = new MockA4AImpl(element);
-      const updateLayoutPriorityStub = sandbox.stub(
+      const updateLayoutPriorityStub = window.sandbox.stub(
         a4a,
         'updateLayoutPriority'
       );
-      const renderNonAmpCreativeSpy = sandbox.spy(a4a, 'renderNonAmpCreative');
-      sandbox.stub(a4a, 'maybeValidateAmpCreative').returns(Promise.resolve());
+      const renderNonAmpCreativeSpy = window.sandbox.spy(
+        a4a,
+        'renderNonAmpCreative'
+      );
+      window.sandbox
+        .stub(a4a, 'maybeValidateAmpCreative')
+        .returns(Promise.resolve());
       a4a.onLayoutMeasure();
       await a4a.layoutCallback();
       expect(
@@ -1310,7 +1328,7 @@ describe('amp-a4a', () => {
       const {doc} = fixture;
       const a4aElement = createA4aElement(doc);
       const a4a = new MockA4AImpl(a4aElement);
-      sandbox.stub(a4a, 'getAmpAdMetadata').callsFake(creative => {
+      window.sandbox.stub(a4a, 'getAmpAdMetadata').callsFake(creative => {
         const metaData = AmpA4A.prototype.getAmpAdMetadata.call(a4a, creative);
         metaData.images = [
           'https://prefetch.me.com?a=b',
@@ -1401,8 +1419,8 @@ describe('amp-a4a', () => {
       const {doc} = fixture;
       const a4aElement = createA4aElement(doc);
       const a4a = new MockA4AImpl(a4aElement);
-      const getAdUrlSpy = sandbox.spy(a4a, 'getAdUrl');
-      const updateLayoutPriorityStub = sandbox.stub(
+      const getAdUrlSpy = window.sandbox.spy(a4a, 'getAdUrl');
+      const updateLayoutPriorityStub = window.sandbox.stub(
         a4a,
         'updateLayoutPriority'
       );
@@ -1412,7 +1430,7 @@ describe('amp-a4a', () => {
       }
       a4a.promiseErrorHandler_ = () => {};
       if (opt_failAmpRender) {
-        sandbox
+        window.sandbox
           .stub(a4a, 'renderAmpCreative_')
           .returns(Promise.reject('amp render failure'));
       }
@@ -1434,7 +1452,7 @@ describe('amp-a4a', () => {
       const iframe = a4aElement.getElementsByTagName('iframe')[0];
       if (isValidCreative && !opt_failAmpRender) {
         expect(iframe.getAttribute('src')).to.be.null;
-        expect(onCreativeRenderSpy.withArgs(sinon.match.object)).to.be
+        expect(onCreativeRenderSpy.withArgs(window.sandbox.match.object)).to.be
           .calledOnce;
         expect(updateLayoutPriorityStub).to.be.calledOnce;
         expect(updateLayoutPriorityStub.args[0][0]).to.equal(
@@ -1471,8 +1489,8 @@ describe('amp-a4a', () => {
       const {doc} = fixture;
       const a4aElement = createA4aElement(doc);
       const a4a = new MockA4AImpl(a4aElement);
-      const getAdUrlSpy = sandbox.spy(a4a, 'getAdUrl');
-      const onNetworkFailureSpy = sandbox.spy(a4a, 'onNetworkFailure');
+      const getAdUrlSpy = window.sandbox.spy(a4a, 'getAdUrl');
+      const onNetworkFailureSpy = window.sandbox.spy(a4a, 'onNetworkFailure');
       a4a.buildCallback();
       a4a.onLayoutMeasure();
       expect(a4a.adPromise_).to.be.instanceof(Promise);
@@ -1498,11 +1516,11 @@ describe('amp-a4a', () => {
       const {doc} = fixture;
       const a4aElement = createA4aElement(doc);
       const a4a = new MockA4AImpl(a4aElement);
-      const getAdUrlSpy = sandbox.spy(a4a, 'getAdUrl');
-      sandbox
+      const getAdUrlSpy = window.sandbox.spy(a4a, 'getAdUrl');
+      window.sandbox
         .stub(a4a, 'onNetworkFailure')
         .withArgs(
-          sinon.match(
+          window.sandbox.match(
             val =>
               val.message && val.message.indexOf('XHR Failed fetching') == 0
           ),
@@ -1534,11 +1552,11 @@ describe('amp-a4a', () => {
       const a4aElement = createA4aElement(doc);
       const a4a = new MockA4AImpl(a4aElement);
       a4a.promiseErrorHandler_ = () => {};
-      const getAdUrlSpy = sandbox.spy(a4a, 'getAdUrl');
-      sandbox
+      const getAdUrlSpy = window.sandbox.spy(a4a, 'getAdUrl');
+      window.sandbox
         .stub(a4a, 'onNetworkFailure')
         .withArgs(
-          sinon.match(
+          window.sandbox.match(
             val =>
               val.message && val.message.indexOf('XHR Failed fetching') == 0
           ),
@@ -1640,9 +1658,9 @@ describe('amp-a4a', () => {
         const a4aElement = createA4aElement(doc);
         const a4a = new MockA4AImpl(a4aElement);
         a4a.buildCallback();
-        const forceCollapseSpy = sandbox.spy(a4a, 'forceCollapse');
-        const noContentUISpy = sandbox.spy();
-        const unlayoutUISpy = sandbox.spy();
+        const forceCollapseSpy = window.sandbox.spy(a4a, 'forceCollapse');
+        const noContentUISpy = window.sandbox.spy();
+        const unlayoutUISpy = window.sandbox.spy();
         a4a.uiHandler = {
           applyNoContentUI: () => {
             noContentUISpy();
@@ -1651,7 +1669,9 @@ describe('amp-a4a', () => {
             unlayoutUISpy();
           },
         };
-        sandbox.stub(a4a, 'getLayoutBox').returns({width: 123, height: 456});
+        window.sandbox
+          .stub(a4a, 'getLayoutBox')
+          .returns({width: 123, height: 456});
         a4a.onLayoutMeasure();
         expect(a4a.adPromise_).to.be.ok;
         await a4a.adPromise_;
@@ -1670,7 +1690,7 @@ describe('amp-a4a', () => {
         const attemptChangeSizePromise = new Promise(resolve => {
           attemptChangeSizeResolver = resolve;
         });
-        sandbox
+        window.sandbox
           .stub(AMP.BaseElement.prototype, 'attemptChangeSize')
           .returns(attemptChangeSizePromise);
         a4a.unlayoutCallback();
@@ -1727,10 +1747,10 @@ describe('amp-a4a', () => {
         const {doc} = fixture;
         const a4aElement = createA4aElement(doc);
         a4a = new MockA4AImpl(a4aElement);
-        getAdUrlSpy = sandbox.spy(a4a, 'getAdUrl');
+        getAdUrlSpy = window.sandbox.spy(a4a, 'getAdUrl');
       });
       it('should delay request until within renderOutsideViewport', async () => {
-        sandbox.stub(a4a, 'delayAdRequestEnabled').returns(true);
+        window.sandbox.stub(a4a, 'delayAdRequestEnabled').returns(true);
         let whenWithinViewportResolve;
         getResourceStub.returns({
           getUpgradeDelayMs: () => 1,
@@ -1753,7 +1773,7 @@ describe('amp-a4a', () => {
         return expect(getAdUrlSpy).to.be.calledOnce;
       });
       it('should delay request until numeric value', async () => {
-        sandbox.stub(a4a, 'delayAdRequestEnabled').returns(6);
+        window.sandbox.stub(a4a, 'delayAdRequestEnabled').returns(6);
         let whenWithinViewportResolve;
         getResourceStub.returns({
           getUpgradeDelayMs: () => 1,
@@ -2047,7 +2067,7 @@ describe('amp-a4a', () => {
       const {doc} = fixture;
       a4aElement = createA4aElement(doc);
       a4a = new AmpA4A(a4aElement);
-      sandbox.stub(a4a, 'getFallback').callsFake(() => {
+      window.sandbox.stub(a4a, 'getFallback').callsFake(() => {
         return true;
       });
       a4a.buildCallback();
@@ -2177,7 +2197,7 @@ describe('amp-a4a', () => {
       const a4a = new MockA4AImpl(a4aElement);
       a4a.buildCallback();
       a4a.onLayoutMeasure();
-      const attemptChangeSizeStub = sandbox.stub(
+      const attemptChangeSizeStub = window.sandbox.stub(
         AMP.BaseElement.prototype,
         'attemptChangeSize'
       );
@@ -2203,8 +2223,8 @@ describe('amp-a4a', () => {
       const {doc} = fixture;
       const a4aElement = createA4aElement(doc);
       const a4a = new MockA4AImpl(a4aElement);
-      const getAdUrlSpy = sandbox.spy(a4a, 'getAdUrl');
-      const errorHandlerSpy = sandbox.spy(a4a, 'promiseErrorHandler_');
+      const getAdUrlSpy = window.sandbox.spy(a4a, 'getAdUrl');
+      const errorHandlerSpy = window.sandbox.spy(a4a, 'promiseErrorHandler_');
       a4a.buildCallback();
       a4a.onLayoutMeasure();
       const adPromise = a4a.adPromise_;
@@ -2239,20 +2259,22 @@ describe('amp-a4a', () => {
       });
 
       it('should delay ad url by getConsentPolicyState', async () => {
-        sandbox
+        window.sandbox
           .stub(AMP.BaseElement.prototype, 'getConsentPolicy')
           .returns('default');
         let inResolver;
         const policyPromise = new Promise(resolver => (inResolver = resolver));
-        sandbox.stub(Services, 'consentPolicyServiceForDocOrNull').returns(
-          Promise.resolve({
-            whenPolicyResolved: () => policyPromise,
-            getConsentStringInfo: () => consentString,
-          })
-        );
+        window.sandbox
+          .stub(Services, 'consentPolicyServiceForDocOrNull')
+          .returns(
+            Promise.resolve({
+              whenPolicyResolved: () => policyPromise,
+              getConsentStringInfo: () => consentString,
+            })
+          );
 
-        const getAdUrlSpy = sandbox.spy(a4a, 'getAdUrl');
-        const tryExecuteRealTimeConfigSpy = sandbox.spy(
+        const getAdUrlSpy = window.sandbox.spy(a4a, 'getAdUrl');
+        const tryExecuteRealTimeConfigSpy = window.sandbox.spy(
           a4a,
           'tryExecuteRealTimeConfig_'
         );
@@ -2275,10 +2297,10 @@ describe('amp-a4a', () => {
       });
 
       it('should not wait on consent if no policy', async () => {
-        sandbox
+        window.sandbox
           .stub(AMP.BaseElement.prototype, 'getConsentPolicy')
           .returns(null);
-        const consentServiceSpy = sandbox.spy(
+        const consentServiceSpy = window.sandbox.spy(
           Services,
           'consentPolicyServiceForDocOrNull'
         );
@@ -2289,19 +2311,21 @@ describe('amp-a4a', () => {
       });
 
       it('should pass consent state to getAdUrl', async () => {
-        sandbox
+        window.sandbox
           .stub(AMP.BaseElement.prototype, 'getConsentPolicy')
           .returns('default');
-        sandbox.stub(Services, 'consentPolicyServiceForDocOrNull').returns(
-          Promise.resolve({
-            whenPolicyResolved: () =>
-              Promise.resolve(CONSENT_POLICY_STATE.SUFFICIENT),
-            getConsentStringInfo: () => consentString,
-          })
-        );
+        window.sandbox
+          .stub(Services, 'consentPolicyServiceForDocOrNull')
+          .returns(
+            Promise.resolve({
+              whenPolicyResolved: () =>
+                Promise.resolve(CONSENT_POLICY_STATE.SUFFICIENT),
+              getConsentStringInfo: () => consentString,
+            })
+          );
 
-        const getAdUrlSpy = sandbox.spy(a4a, 'getAdUrl');
-        const tryExecuteRealTimeConfigSpy = sandbox.spy(
+        const getAdUrlSpy = window.sandbox.spy(a4a, 'getAdUrl');
+        const tryExecuteRealTimeConfigSpy = window.sandbox.spy(
           a4a,
           'tryExecuteRealTimeConfig_'
         );
@@ -2321,22 +2345,24 @@ describe('amp-a4a', () => {
 
       it('should return UNKNOWN if consent exception', async () => {
         expectAsyncConsoleError(/Error determining consent state.*consent err/);
-        sandbox
+        window.sandbox
           .stub(AMP.BaseElement.prototype, 'getConsentPolicy')
           .returns('default');
-        sandbox.stub(Services, 'consentPolicyServiceForDocOrNull').returns(
-          Promise.resolve({
-            whenPolicyResolved: () => {
-              throw new Error('consent err!');
-            },
-            getConsentStringInfo: () => {
-              throw new Error('consent err!');
-            },
-          })
-        );
+        window.sandbox
+          .stub(Services, 'consentPolicyServiceForDocOrNull')
+          .returns(
+            Promise.resolve({
+              whenPolicyResolved: () => {
+                throw new Error('consent err!');
+              },
+              getConsentStringInfo: () => {
+                throw new Error('consent err!');
+              },
+            })
+          );
 
-        const getAdUrlSpy = sandbox.spy(a4a, 'getAdUrl');
-        const tryExecuteRealTimeConfigSpy = sandbox.spy(
+        const getAdUrlSpy = window.sandbox.spy(a4a, 'getAdUrl');
+        const tryExecuteRealTimeConfigSpy = window.sandbox.spy(
           a4a,
           'tryExecuteRealTimeConfig_'
         );
@@ -2421,9 +2447,9 @@ describe('amp-a4a', () => {
     let devExpectedErrorStub;
 
     beforeEach(async () => {
-      userErrorStub = sandbox.stub(user(), 'error');
-      userWarnStub = sandbox.stub(user(), 'warn');
-      devExpectedErrorStub = sandbox.stub(dev(), 'expectedError');
+      userErrorStub = window.sandbox.stub(user(), 'error');
+      userWarnStub = window.sandbox.stub(user(), 'warn');
+      devExpectedErrorStub = window.sandbox.stub(dev(), 'expectedError');
       const fixture = await createIframePromise();
       setupForAdTesting(fixture);
       const {doc} = fixture;
@@ -2479,7 +2505,7 @@ describe('amp-a4a', () => {
 
     it('should send an expected error in prod mode with sampling', () => {
       const error = new Error('intentional');
-      sandbox.stub(Math, 'random').callsFake(() => 0.005);
+      window.sandbox.stub(Math, 'random').callsFake(() => 0.005);
       window.__AMP_MODE = {development: false};
       a4a.promiseErrorHandler_(error);
       expect(devExpectedErrorStub).to.be.calledOnce;
@@ -2490,7 +2516,7 @@ describe('amp-a4a', () => {
 
     it('should NOT send an expected error in prod mode with sampling', () => {
       const error = new Error('intentional');
-      sandbox.stub(Math, 'random').callsFake(() => 0.011);
+      window.sandbox.stub(Math, 'random').callsFake(() => 0.011);
       window.__AMP_MODE = {development: false};
       a4a.promiseErrorHandler_(error);
       expect(devExpectedErrorStub).to.not.be.called;
@@ -2536,16 +2562,6 @@ describe('amp-a4a', () => {
   });
 
   describe('refresh', () => {
-    let sandbox;
-
-    beforeEach(() => {
-      sandbox = sinon.sandbox;
-    });
-
-    afterEach(() => {
-      sandbox.restore();
-    });
-
     it('should effectively reset the slot and invoke given callback', async () => {
       const fixture = await createIframePromise();
       setupForAdTesting(fixture);
@@ -2559,22 +2575,28 @@ describe('amp-a4a', () => {
         };
       };
       a4a.mutateElement = func => func();
-      a4a.togglePlaceholder = sandbox.spy();
+      a4a.togglePlaceholder = window.sandbox.spy();
 
       // We don't really care about the behavior of the following methods, so
       // long as they're called the appropriate number of times. We stub them
       // out here because they would otherwise throw errors unrelated to the
       // behavior actually being tested.
-      const initiateAdRequestMock = sandbox.stub(
+      const initiateAdRequestMock = window.sandbox.stub(
         AmpA4A.prototype,
         'initiateAdRequest'
       );
       initiateAdRequestMock.returns(undefined);
-      const tearDownSlotMock = sandbox.stub(AmpA4A.prototype, 'tearDownSlot');
+      const tearDownSlotMock = window.sandbox.stub(
+        AmpA4A.prototype,
+        'tearDownSlot'
+      );
       tearDownSlotMock.returns(undefined);
-      const destroyFrameMock = sandbox.stub(AmpA4A.prototype, 'destroyFrame');
+      const destroyFrameMock = window.sandbox.stub(
+        AmpA4A.prototype,
+        'destroyFrame'
+      );
       destroyFrameMock.returns(undefined);
-      sandbox.stub(analytics, 'triggerAnalyticsEvent');
+      window.sandbox.stub(analytics, 'triggerAnalyticsEvent');
 
       expect(a4a.isRefreshing).to.be.false;
       await a4a.refresh(() => {});
@@ -2598,23 +2620,29 @@ describe('amp-a4a', () => {
         };
       };
       a4a.mutateElement = func => func();
-      a4a.togglePlaceholder = sandbox.spy();
+      a4a.togglePlaceholder = window.sandbox.spy();
 
       // We don't really care about the behavior of the following methods, so
       // long as they're called the appropriate number of times. We stub them
       // out here because they would otherwise throw errors unrelated to the
       // behavior actually being tested.
-      const initiateAdRequestMock = sandbox.stub(
+      const initiateAdRequestMock = window.sandbox.stub(
         AmpA4A.prototype,
         'initiateAdRequest'
       );
       initiateAdRequestMock.returns(undefined);
-      const tearDownSlotMock = sandbox.stub(AmpA4A.prototype, 'tearDownSlot');
+      const tearDownSlotMock = window.sandbox.stub(
+        AmpA4A.prototype,
+        'tearDownSlot'
+      );
       tearDownSlotMock.returns(undefined);
-      const destroyFrameMock = sandbox.stub(AmpA4A.prototype, 'destroyFrame');
+      const destroyFrameMock = window.sandbox.stub(
+        AmpA4A.prototype,
+        'destroyFrame'
+      );
       destroyFrameMock.returns(undefined);
 
-      const triggerAnalyticsEventStub = sandbox.stub(
+      const triggerAnalyticsEventStub = window.sandbox.stub(
         analytics,
         'triggerAnalyticsEvent'
       );
@@ -2637,27 +2665,19 @@ describe('amp-a4a', () => {
         };
       };
       a4a.mutateElement = func => func();
-      a4a.togglePlaceholder = sandbox.spy();
+      a4a.togglePlaceholder = window.sandbox.spy();
 
-      sandbox.stub(AmpA4A.prototype, 'initiateAdRequest').returns(undefined);
-      sandbox.stub(AmpA4A.prototype, 'tearDownSlot').returns(undefined);
-      const callback = sandbox.spy();
+      window.sandbox
+        .stub(AmpA4A.prototype, 'initiateAdRequest')
+        .returns(undefined);
+      window.sandbox.stub(AmpA4A.prototype, 'tearDownSlot').returns(undefined);
+      const callback = window.sandbox.spy();
       await a4a.refresh(callback);
       expect(callback).to.not.be.called;
     });
   });
 
   describe('buildCallback', () => {
-    let sandbox;
-
-    beforeEach(() => {
-      sandbox = sinon.sandbox;
-    });
-
-    afterEach(() => {
-      sandbox.restore();
-    });
-
     it('should set isSinglePageStoryAd to false', async () => {
       const fixture = await createIframePromise();
       const element = createA4aElement(fixture.doc);
@@ -2696,7 +2716,7 @@ describe('amp-a4a', () => {
       });
 
       it('by default not allowed if crypto signature present but no SSL', async () => {
-        sandbox
+        window.sandbox
           .stub(Services.cryptoFor(fixture.win), 'isPkcsAvailable')
           .returns(false);
         a4a.buildCallback();
@@ -2710,10 +2730,10 @@ describe('amp-a4a', () => {
         'allowed if crypto signature present, no SSL, and overrided' +
           ' shouldPreferentialRenderWithoutCrypto',
         async () => {
-          sandbox
+          window.sandbox
             .stub(Services.cryptoFor(fixture.win), 'isPkcsAvailable')
             .returns(false);
-          sandbox
+          window.sandbox
             .stub(AmpA4A.prototype, 'shouldPreferentialRenderWithoutCrypto')
             .callsFake(() => true);
           a4a.buildCallback();
@@ -2726,7 +2746,7 @@ describe('amp-a4a', () => {
       it('not allowed if no crypto signature present', async () => {
         delete adResponse.headers['AMP-Fast-Fetch-Signature'];
         delete adResponse.headers[AMP_SIGNATURE_HEADER];
-        sandbox
+        window.sandbox
           .stub(AmpA4A.prototype, 'shouldPreferentialRenderWithoutCrypto')
           .callsFake(() => true);
         a4a.buildCallback();
@@ -2762,11 +2782,9 @@ describe('amp-a4a', () => {
 describes.realWin('AmpA4a-RTC', {amp: true}, env => {
   let element;
   let a4a;
-  let sandbox;
   let errorSpy;
 
   beforeEach(() => {
-    sandbox = env.sandbox;
     // ensures window location == AMP cache passes
     env.win.__AMP_MODE.test = true;
     const doc = env.win.document;
@@ -2778,7 +2796,7 @@ describes.realWin('AmpA4a-RTC', {amp: true}, env => {
     });
     doc.body.appendChild(element);
     a4a = new AmpA4A(element);
-    errorSpy = sandbox.spy(user(), 'error');
+    errorSpy = env.sandbox.spy(user(), 'error');
   });
 
   describe('#tryExecuteRealTimeConfig', () => {

--- a/extensions/amp-a4a/0.1/test/test-amp-ad-template-helper.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-ad-template-helper.js
@@ -32,7 +32,7 @@ describes.fakeWin('AmpAdTemplateHelper', {amp: true}, env => {
     win = env.win;
     win.__AMP_MODE = {localDev: false};
     doc = win.document;
-    fetchTextMock = sandbox.stub(Xhr.prototype, 'fetchText');
+    fetchTextMock = env.sandbox.stub(Xhr.prototype, 'fetchText');
     ampAdTemplateHelper = new AmpAdTemplateHelper(win);
   });
 

--- a/extensions/amp-a4a/0.1/test/test-cryptographic-validator.js
+++ b/extensions/amp-a4a/0.1/test/test-cryptographic-validator.js
@@ -32,18 +32,12 @@ const realWinConfig = {
 
 describes.realWin('CryptographicValidator', realWinConfig, env => {
   const headers = {'Content-Type': 'application/jwk-set+json'};
-  let sandbox;
   let userErrorStub;
   let validator;
 
   beforeEach(() => {
     validator = new CryptographicValidator();
-    sandbox = sinon.sandbox;
-    userErrorStub = sandbox.stub(user(), 'error');
-  });
-
-  afterEach(() => {
-    sandbox.restore();
+    userErrorStub = env.sandbox.stub(user(), 'error');
   });
 
   it('should have AMP validator result', () => {

--- a/extensions/amp-a4a/0.1/test/test-real-time-config-manager.js
+++ b/extensions/amp-a4a/0.1/test/test-real-time-config-manager.js
@@ -34,15 +34,12 @@ import {isFiniteNumber} from '../../../../src/types';
 describes.realWin('real-time-config-manager', {amp: true}, env => {
   let element;
   let a4aElement;
-  let sandbox;
   let fetchJsonStub;
   let getCalloutParam_, maybeExecuteRealTimeConfig_, validateRtcConfig_;
   let truncUrl_, inflateAndSendRtc_, sendErrorMessage;
   let rtc;
 
   beforeEach(() => {
-    sandbox = env.sandbox;
-
     // Ensures window location == AMP cache passes.
     env.win.__AMP_MODE.test = true;
 
@@ -54,13 +51,13 @@ describes.realWin('real-time-config-manager', {amp: true}, env => {
       'layout': 'fixed',
     });
     doc.body.appendChild(element);
-    fetchJsonStub = sandbox.stub(Xhr.prototype, 'fetchJson');
+    fetchJsonStub = env.sandbox.stub(Xhr.prototype, 'fetchJson');
     a4aElement = new AmpA4A(element);
 
     // RealTimeConfigManager uses the UrlReplacements service scoped to the A4A
     // (FIE), but for testing stub in the parent service for simplicity.
     const urlReplacements = Services.urlReplacementsForDoc(element);
-    sandbox
+    env.sandbox
       .stub(Services, 'urlReplacementsForDoc')
       .withArgs(a4aElement.element)
       .returns(urlReplacements);
@@ -72,10 +69,6 @@ describes.realWin('real-time-config-manager', {amp: true}, env => {
     truncUrl_ = rtc.truncUrl_.bind(rtc);
     inflateAndSendRtc_ = rtc.inflateAndSendRtc_.bind(rtc);
     sendErrorMessage = rtc.sendErrorMessage.bind(rtc);
-  });
-
-  afterEach(() => {
-    sandbox.restore();
   });
 
   function setFetchJsonStubBehavior(params, response, isString, shouldFail) {
@@ -432,7 +425,7 @@ describes.realWin('real-time-config-manager', {amp: true}, env => {
         );
       }
       const calloutCount = 1;
-      sandbox.stub(user(), 'error').callsFake(() => {});
+      env.sandbox.stub(user(), 'error').callsFake(() => {});
       return executeTest({
         vendors,
         inflatedUrls,
@@ -977,10 +970,10 @@ describes.realWin('real-time-config-manager', {amp: true}, env => {
     beforeEach(() => {
       // Make sure that we always send the message, as we are using
       // the check Math.random() < reporting frequency.
-      sandbox.stub(Math, 'random').returns(0);
-      sandbox.stub(Xhr.prototype, 'fetch');
+      env.sandbox.stub(Math, 'random').returns(0);
+      env.sandbox.stub(Xhr.prototype, 'fetch');
       imageMock = {};
-      imageStub = sandbox.stub(env.win, 'Image').returns(imageMock);
+      imageStub = env.sandbox.stub(env.win, 'Image').returns(imageMock);
 
       errorType = RTC_ERROR_ENUM.TIMEOUT;
       errorReportingUrl = 'https://www.example.com?e=ERROR_TYPE&h=HREF';

--- a/extensions/amp-a4a/0.1/test/test-refresh.js
+++ b/extensions/amp-a4a/0.1/test/test-refresh.js
@@ -26,7 +26,6 @@ import {Services} from '../../../../src/services';
 
 describe('refresh', () => {
   let mockA4a;
-  let sandbox;
   const config = {
     visiblePercentageMin: 50,
     totalTimeMin: 0,
@@ -38,21 +37,16 @@ describe('refresh', () => {
     div.setAttribute('style', 'width:1px; height:1px;');
     div.setAttribute('type', 'doubleclick');
     div.setAttribute(DATA_ATTR_NAME, '35');
-    sandbox.replaceGetter(div, 'isConnected', () => true);
+    window.sandbox.replaceGetter(div, 'isConnected', () => true);
     return div;
   }
 
   beforeEach(() => {
-    sandbox = sinon.sandbox;
     mockA4a = {
       win: window,
       element: getTestElement(),
       refresh: () => {},
     };
-  });
-
-  afterEach(() => {
-    sandbox.restore();
   });
 
   describe('refresh-manager', () => {
@@ -93,7 +87,7 @@ describe('refresh', () => {
     });
 
     it('should call convertConfiguration_ and set proper units', () => {
-      const getConfigurationSpy = sandbox.spy(
+      const getConfigurationSpy = window.sandbox.spy(
         RefreshManager.prototype,
         'convertAndSanitizeConfiguration_'
       );
@@ -157,7 +151,7 @@ describe('refresh', () => {
     it('should execute the refresh event correctly', () => {
       // Attach element to DOM, as is necessary for request ampdoc.
       window.document.body.appendChild(mockA4a.element);
-      const refreshSpy = sandbox.spy(mockA4a, 'refresh');
+      const refreshSpy = window.sandbox.spy(mockA4a, 'refresh');
 
       // Ensure initial call to initiateRefreshCycle doesn't trigger refresh, as
       // this can have flaky results.
@@ -202,12 +196,12 @@ describe('refresh', () => {
         y: 0,
       });
 
-      sandbox.stub(Services, 'viewportForDoc').callsFake(() => {
+      window.sandbox.stub(Services, 'viewportForDoc').callsFake(() => {
         return {
           getRect,
         };
       });
-      sandbox.stub(Services, 'ampdoc').callsFake(() => {
+      window.sandbox.stub(Services, 'ampdoc').callsFake(() => {
         return {
           getRootNode: () => {
             return window.document;
@@ -268,7 +262,7 @@ describe('refresh', () => {
     });
 
     it('should not invoke callback', () => {
-      const callbackSpy = sandbox.spy(callback);
+      const callbackSpy = window.sandbox.spy(callback);
       observerWrapper.viewport_ = {
         getRect: () => ({
           top: 10,

--- a/extensions/amp-a4a/0.1/test/test-signature-verifier.js
+++ b/extensions/amp-a4a/0.1/test/test-signature-verifier.js
@@ -36,7 +36,7 @@ describes.fakeWin('SignatureVerifier', {amp: true}, env => {
   /** @param {string} signingServiceName */
   const expectSigningServiceError = signingServiceName => {
     mockDevError
-      .withExactArgs('AMP-A4A', sinon.match(signingServiceName))
+      .withExactArgs('AMP-A4A', env.sandbox.match(signingServiceName))
       .once();
   };
 
@@ -364,7 +364,9 @@ describes.fakeWin('SignatureVerifier', {amp: true}, env => {
         env
           .stubService('crypto', 'verifyPkcs')
           .returns(Promise.reject(new Error(errorMessage)));
-        mockDevError.withExactArgs('AMP-A4A', sinon.match(errorMessage)).once();
+        mockDevError
+          .withExactArgs('AMP-A4A', env.sandbox.match(errorMessage))
+          .once();
         verifier.loadKeyset('service-1');
         return expect(
           verifier.verifyCreativeAndSignature(

--- a/extensions/amp-a4a/0.1/test/test-template-renderer.js
+++ b/extensions/amp-a4a/0.1/test/test-template-renderer.js
@@ -47,7 +47,6 @@ describes.realWin('TemplateRenderer', realWinConfig, env => {
   let renderer;
   let validator;
   let validatorPromise;
-  let sandbox;
 
   beforeEach(() => {
     doc = env.win.document;
@@ -85,11 +84,12 @@ describes.realWin('TemplateRenderer', realWinConfig, env => {
       sentinel: 's-1234',
     };
 
-    sandbox = sinon.sandbox;
-    sandbox.stub(getAmpAdTemplateHelper(env.win), 'fetch').callsFake(url => {
-      expect(url).to.equal(templateUrl);
-      return Promise.resolve(data.adTemplate);
-    });
+    env.sandbox
+      .stub(getAmpAdTemplateHelper(env.win), 'fetch')
+      .callsFake(url => {
+        expect(url).to.equal(templateUrl);
+        return Promise.resolve(data.adTemplate);
+      });
 
     validatorPromise = validator.validate(
       context,
@@ -105,7 +105,6 @@ describes.realWin('TemplateRenderer', realWinConfig, env => {
   });
 
   afterEach(() => {
-    sandbox.restore();
     doc.body.removeChild(containerElement);
   });
 
@@ -180,7 +179,7 @@ describes.realWin('TemplateRenderer', realWinConfig, env => {
 
   it('should insert analytics', () => {
     env.win.AMP.registerTemplate('amp-mustache', AmpMustache);
-    const insertAnalyticsSpy = sandbox.spy(
+    const insertAnalyticsSpy = env.sandbox.spy(
       getAmpAdTemplateHelper(env.win),
       'insertAnalytics'
     );

--- a/extensions/amp-a4a/0.1/test/test-template-validator.js
+++ b/extensions/amp-a4a/0.1/test/test-template-validator.js
@@ -46,15 +46,15 @@ describes.realWin('TemplateValidator', realWinConfig, env => {
   });
 
   describe('AMP Result', () => {
-    let sandbox;
     let validatorPromise;
 
     beforeEach(() => {
-      sandbox = sinon.sandbox;
-      sandbox.stub(getAmpAdTemplateHelper(env.win), 'fetch').callsFake(url => {
-        expect(url).to.equal(templateUrl);
-        return Promise.resolve(data.adTemplate);
-      });
+      env.sandbox
+        .stub(getAmpAdTemplateHelper(env.win), 'fetch')
+        .callsFake(url => {
+          expect(url).to.equal(templateUrl);
+          return Promise.resolve(data.adTemplate);
+        });
 
       validatorPromise = validator.validate(
         {win: env.win},
@@ -69,7 +69,7 @@ describes.realWin('TemplateValidator', realWinConfig, env => {
       );
     });
 
-    afterEach(() => sandbox.restore());
+    afterEach(() => env.sandbox.restore());
 
     it('should have AMP validator result', () => {
       return validatorPromise.then(validatorOutput => {

--- a/extensions/amp-access-laterpay/0.1/test/test-amp-access-laterpay.js
+++ b/extensions/amp-access-laterpay/0.1/test/test-amp-access-laterpay.js
@@ -58,7 +58,7 @@ describes.fakeWin(
         getSource: () => accessSource,
       };
 
-      accessSourceMock = sandbox.mock(accessSource);
+      accessSourceMock = env.sandbox.mock(accessSource);
 
       articleTitle = document.createElement('h1');
       articleTitle.id = 'laterpay-test-title';
@@ -66,7 +66,7 @@ describes.fakeWin(
       document.body.appendChild(articleTitle);
 
       vendor = new LaterpayVendor(accessService, accessSource);
-      xhrMock = sandbox.mock(vendor.xhr_);
+      xhrMock = env.sandbox.mock(vendor.xhr_);
     });
 
     afterEach(() => {
@@ -78,8 +78,8 @@ describes.fakeWin(
     describe('authorize', () => {
       let emptyContainerStub;
       beforeEach(() => {
-        emptyContainerStub = sandbox.stub(vendor, 'emptyContainer_');
-        sandbox.stub(vendor, 'renderPurchaseOverlay_');
+        emptyContainerStub = env.sandbox.stub(vendor, 'emptyContainer_');
+        env.sandbox.stub(vendor, 'renderPurchaseOverlay_');
       });
 
       it('uses a non default region', () => {

--- a/extensions/amp-access-laterpay/0.2/test/test-amp-access-laterpay.js
+++ b/extensions/amp-access-laterpay/0.2/test/test-amp-access-laterpay.js
@@ -65,7 +65,7 @@ describes.fakeWin(
         'payment_model': 'pay_later',
       };
 
-      accessSourceMock = sandbox.mock(accessSource);
+      accessSourceMock = env.sandbox.mock(accessSource);
 
       articleTitle = document.createElement('h1');
       articleTitle.id = 'laterpay-test-title';
@@ -73,7 +73,7 @@ describes.fakeWin(
       document.body.appendChild(articleTitle);
 
       vendor = new LaterpayVendor(accessService, accessSource);
-      xhrMock = sandbox.mock(vendor.xhr_);
+      xhrMock = env.sandbox.mock(vendor.xhr_);
     });
 
     afterEach(() => {
@@ -85,8 +85,8 @@ describes.fakeWin(
     describe('authorize', () => {
       let emptyContainerStub;
       beforeEach(() => {
-        emptyContainerStub = sandbox.stub(vendor, 'emptyContainer_');
-        sandbox.stub(vendor, 'renderPurchaseOverlay_');
+        emptyContainerStub = env.sandbox.stub(vendor, 'emptyContainer_');
+        env.sandbox.stub(vendor, 'renderPurchaseOverlay_');
       });
 
       it('uses a non default region', () => {

--- a/extensions/amp-access-poool/0.1/test/test-amp-access-poool.js
+++ b/extensions/amp-access-poool/0.1/test/test-amp-access-poool.js
@@ -55,10 +55,10 @@ describes.fakeWin(
         getSource: () => accessSource,
       };
 
-      accessSourceMock = sandbox.mock(accessSource);
+      accessSourceMock = env.sandbox.mock(accessSource);
 
       vendor = new PooolVendor(accessService, accessSource);
-      xhrMock = sandbox.mock(vendor.xhr_);
+      xhrMock = env.sandbox.mock(vendor.xhr_);
     });
 
     afterEach(() => {
@@ -73,7 +73,7 @@ describes.fakeWin(
         container = document.createElement('div');
         container.id = 'poool-widget';
         document.body.appendChild(container);
-        sandbox.stub(vendor, 'renderPoool_');
+        env.sandbox.stub(vendor, 'renderPoool_');
       });
 
       afterEach(() => {

--- a/extensions/amp-access-scroll/0.1/test/read-depth-tracker.js
+++ b/extensions/amp-access-scroll/0.1/test/read-depth-tracker.js
@@ -27,7 +27,6 @@ describes.realWin(
     let win;
     let doc;
     let ampdoc;
-    let sandbox;
     let accessSource;
     let readDepthTracker;
 
@@ -35,7 +34,6 @@ describes.realWin(
       win = env.win;
       doc = win.document;
       ampdoc = env.ampdoc;
-      sandbox = env.sandbox;
 
       // Undefined initialization params for AccessSource
       let scheduleViewFn, onReauthorizeFn;
@@ -69,12 +67,12 @@ describes.realWin(
       );
 
       // Stub viewport to fake paragraph positions
-      sandbox
+      env.sandbox
         .stub(readDepthTracker.viewport_, 'getClientRectAsync')
         .callsFake(returnRectPosition);
 
       // Stub updateLastRead_ call to check content sent
-      sandbox.stub(readDepthTracker, 'updateLastRead_');
+      env.sandbox.stub(readDepthTracker, 'updateLastRead_');
     });
 
     function returnRectPosition(paragraph) {

--- a/extensions/amp-access/0.1/test/test-amp-access-client.js
+++ b/extensions/amp-access/0.1/test/test-amp-access-client.js
@@ -42,7 +42,7 @@ describes.realWin(
       context = {
         buildUrl: () => {},
       };
-      contextMock = sandbox.mock(context);
+      contextMock = env.sandbox.mock(context);
     });
 
     afterEach(() => {
@@ -77,7 +77,7 @@ describes.realWin(
       });
 
       it('should allow only lower-than-default timeout in production', () => {
-        sandbox.stub(mode, 'getMode').callsFake(() => {
+        env.sandbox.stub(mode, 'getMode').callsFake(() => {
           return {development: false, localDev: false};
         });
 
@@ -148,7 +148,7 @@ describes.realWin(
 
       beforeEach(() => {
         adapter = new AccessClientAdapter(ampdoc, validConfig, context);
-        xhrMock = sandbox.mock(adapter.xhr_);
+        xhrMock = env.sandbox.mock(adapter.xhr_);
       });
 
       afterEach(() => {
@@ -257,7 +257,7 @@ describes.realWin(
             .expects('sendSignal')
             .withExactArgs(
               'https://acme.com/p?rid=reader1',
-              sinon.match(init => {
+              env.sandbox.match(init => {
                 return (
                   init.method == 'POST' &&
                   init.credentials == 'include' &&
@@ -285,7 +285,7 @@ describes.realWin(
             .expects('sendSignal')
             .withExactArgs(
               'https://acme.com/p?rid=reader1',
-              sinon.match(init => {
+              env.sandbox.match(init => {
                 return (
                   init.method == 'POST' &&
                   init.credentials == 'include' &&

--- a/extensions/amp-access/0.1/test/test-amp-access-iframe.js
+++ b/extensions/amp-access/0.1/test/test-amp-access-iframe.js
@@ -30,11 +30,9 @@ describes.fakeWin(
     let validConfig;
     let context;
     let contextMock;
-    let sandbox;
 
     beforeEach(() => {
       ampdoc = env.ampdoc;
-      sandbox = env.sandbox;
       clock = lolex.install({
         target: ampdoc.win,
         toFake: ['Date', 'setTimeout', 'clearTimeout'],
@@ -51,7 +49,7 @@ describes.fakeWin(
         buildUrl: () => {},
         collectUrlVars: () => {},
       };
-      contextMock = sandbox.mock(context);
+      contextMock = env.sandbox.mock(context);
     });
 
     afterEach(() => {
@@ -120,7 +118,7 @@ describes.fakeWin(
 
     describe('runtime connect', () => {
       it('should NOT connect until necessary', () => {
-        const connectStub = sandbox.stub(Messenger.prototype, 'connect');
+        const connectStub = env.sandbox.stub(Messenger.prototype, 'connect');
         const adapter = new AccessIframeAdapter(ampdoc, validConfig, context);
         expect(adapter.connectedPromise_).to.be.null;
         expect(adapter.iframe_.parentNode).to.be.null;
@@ -128,7 +126,7 @@ describes.fakeWin(
       });
 
       it('should connect on first and only first authorize', () => {
-        const connectStub = sandbox.stub(Messenger.prototype, 'connect');
+        const connectStub = env.sandbox.stub(Messenger.prototype, 'connect');
         const adapter = new AccessIframeAdapter(ampdoc, validConfig, context);
         adapter.authorize();
         expect(adapter.connectedPromise_).to.not.be.null;
@@ -148,7 +146,7 @@ describes.fakeWin(
           )
           .once();
         validConfig['iframeVars'] = ['VAR1', 'VAR2'];
-        const sendStub = sandbox
+        const sendStub = env.sandbox
           .stub(Messenger.prototype, 'sendCommandRsvp')
           .returns(Promise.resolve({}));
         const adapter = new AccessIframeAdapter(ampdoc, validConfig, context);
@@ -180,12 +178,12 @@ describes.fakeWin(
           setItem: () => {},
           removeItem: () => {},
         };
-        storageMock = sandbox.mock(storage);
-        sandbox.defineProperty(ampdoc.win, 'sessionStorage', {
+        storageMock = env.sandbox.mock(storage);
+        env.sandbox.defineProperty(ampdoc.win, 'sessionStorage', {
           get: () => storage,
         });
         adapter = new AccessIframeAdapter(ampdoc, validConfig, context);
-        messengerMock = sandbox.mock(adapter.messenger_);
+        messengerMock = env.sandbox.mock(adapter.messenger_);
       });
 
       afterEach(() => {
@@ -311,7 +309,7 @@ describes.fakeWin(
         });
 
         it('should tolerate storage failures', () => {
-          const devErrorStub = sandbox.stub(dev(), 'error');
+          const devErrorStub = env.sandbox.stub(dev(), 'error');
           storageMock
             .expects('getItem')
             .withExactArgs('amp-access-iframe')

--- a/extensions/amp-access/0.1/test/test-amp-access-other.js
+++ b/extensions/amp-access/0.1/test/test-amp-access-other.js
@@ -30,12 +30,11 @@ describes.realWin('AccessOtherAdapter', {amp: true}, env => {
     context = {
       buildUrl: () => {},
     };
-    contextMock = sandbox.mock(context);
+    contextMock = env.sandbox.mock(context);
   });
 
   afterEach(() => {
     contextMock.verify();
-    sandbox.restore();
   });
 
   describe('config', () => {
@@ -67,8 +66,6 @@ describes.realWin('AccessOtherAdapter', {amp: true}, env => {
     beforeEach(() => {
       adapter = new AccessOtherAdapter(ampdoc, {}, context);
     });
-
-    afterEach(() => {});
 
     it('should disable authorization without fallback object', () => {
       adapter.authorizationResponse_ = null;

--- a/extensions/amp-access/0.1/test/test-amp-access-server-jwt.js
+++ b/extensions/amp-access/0.1/test/test-amp-access-server-jwt.js
@@ -50,7 +50,7 @@ describes.realWin('AccessServerJwtAdapter', {amp: true}, env => {
       buildUrl: () => {},
       collectUrlVars: () => {},
     };
-    contextMock = sandbox.mock(context);
+    contextMock = env.sandbox.mock(context);
   });
 
   afterEach(() => {
@@ -129,9 +129,9 @@ describes.realWin('AccessServerJwtAdapter', {amp: true}, env => {
 
     beforeEach(() => {
       adapter = new AccessServerJwtAdapter(ampdoc, validConfig, context);
-      xhrMock = sandbox.mock(adapter.xhr_);
-      jwtMock = sandbox.mock(adapter.jwtHelper_);
-      docFetcherMock = sandbox.mock(DocumentFetcher);
+      xhrMock = env.sandbox.mock(adapter.xhr_);
+      jwtMock = env.sandbox.mock(adapter.jwtHelper_);
+      docFetcherMock = env.sandbox.mock(DocumentFetcher);
 
       clientAdapter = {
         getAuthorizationUrl: () => validConfig['authorization'],
@@ -140,7 +140,7 @@ describes.realWin('AccessServerJwtAdapter', {amp: true}, env => {
         authorize: () => Promise.resolve({}),
         pingback: () => Promise.resolve(),
       };
-      clientAdapterMock = sandbox.mock(clientAdapter);
+      clientAdapterMock = env.sandbox.mock(clientAdapter);
       adapter.clientAdapter_ = clientAdapter;
 
       adapter.isProxyOrigin_ = true;
@@ -172,7 +172,7 @@ describes.realWin('AccessServerJwtAdapter', {amp: true}, env => {
       it('should fallback to client auth when not on proxy', () => {
         adapter.isProxyOrigin_ = false;
         const p = Promise.resolve();
-        const stub = sandbox
+        const stub = env.sandbox
           .stub(adapter, 'authorizeOnClient_')
           .callsFake(() => p);
         docFetcherMock.expects('fetchDocument').never();
@@ -184,7 +184,7 @@ describes.realWin('AccessServerJwtAdapter', {amp: true}, env => {
       it('should fallback to client auth w/o server state', () => {
         adapter.serverState_ = null;
         const p = Promise.resolve();
-        const stub = sandbox
+        const stub = env.sandbox
           .stub(adapter, 'authorizeOnClient_')
           .callsFake(() => p);
         docFetcherMock.expects('fetchDocument').never();
@@ -195,7 +195,7 @@ describes.realWin('AccessServerJwtAdapter', {amp: true}, env => {
 
       it('should execute via server on proxy and w/server state', () => {
         const p = Promise.resolve();
-        const stub = sandbox
+        const stub = env.sandbox
           .stub(adapter, 'authorizeOnServer_')
           .callsFake(() => p);
         docFetcherMock.expects('fetchDocument').never();
@@ -207,7 +207,7 @@ describes.realWin('AccessServerJwtAdapter', {amp: true}, env => {
       it('should fetch JWT directly via client', () => {
         const authdata = {};
         const jwt = {'amp_authdata': authdata};
-        sandbox
+        env.sandbox
           .stub(adapter, 'fetchJwt_')
           .callsFake(() => Promise.resolve({jwt}));
         docFetcherMock.expects('fetchDocument').never();
@@ -221,7 +221,7 @@ describes.realWin('AccessServerJwtAdapter', {amp: true}, env => {
         const authdata = {};
         const jwt = {'amp_authdata': authdata};
         const encoded = 'rAnDoM';
-        sandbox
+        env.sandbox
           .stub(adapter, 'fetchJwt_')
           .callsFake(() => Promise.resolve({jwt, encoded}));
         const request = serializeQueryString({
@@ -231,7 +231,7 @@ describes.realWin('AccessServerJwtAdapter', {amp: true}, env => {
         });
         docFetcherMock
           .expects('fetchDocument')
-          .withExactArgs(sinon.match.any, 'http://localhost:8000/af', {
+          .withExactArgs(env.sandbox.match.any, 'http://localhost:8000/af', {
             method: 'POST',
             body: request,
             headers: {
@@ -240,7 +240,7 @@ describes.realWin('AccessServerJwtAdapter', {amp: true}, env => {
           })
           .returns(Promise.resolve(responseDoc))
           .once();
-        const replaceSectionsStub = sandbox
+        const replaceSectionsStub = env.sandbox
           .stub(adapter, 'replaceSections_')
           .callsFake(() => {
             return Promise.resolve();
@@ -256,7 +256,7 @@ describes.realWin('AccessServerJwtAdapter', {amp: true}, env => {
         const authdata = {};
         const jwt = {'amp_authdata': authdata};
         const encoded = 'rAnDoM';
-        sandbox
+        env.sandbox
           .stub(adapter, 'fetchJwt_')
           .callsFake(() => Promise.resolve({jwt, encoded}));
         const request = serializeQueryString({
@@ -266,7 +266,7 @@ describes.realWin('AccessServerJwtAdapter', {amp: true}, env => {
         });
         docFetcherMock
           .expects('fetchDocument')
-          .withExactArgs(sinon.match.any, 'http://localhost:8000/af', {
+          .withExactArgs(env.sandbox.match.any, 'http://localhost:8000/af', {
             method: 'POST',
             body: request,
             headers: {
@@ -275,7 +275,7 @@ describes.realWin('AccessServerJwtAdapter', {amp: true}, env => {
           })
           .returns(Promise.reject('intentional'))
           .once();
-        const replaceSectionsStub = sandbox
+        const replaceSectionsStub = env.sandbox
           .stub(adapter, 'replaceSections_')
           .callsFake(() => {
             return Promise.resolve();
@@ -296,7 +296,7 @@ describes.realWin('AccessServerJwtAdapter', {amp: true}, env => {
         const authdata = {};
         const jwt = {'amp_authdata': authdata};
         const encoded = 'rAnDoM';
-        sandbox
+        env.sandbox
           .stub(adapter, 'fetchJwt_')
           .callsFake(() => Promise.resolve({jwt, encoded}));
         const request = serializeQueryString({
@@ -306,7 +306,7 @@ describes.realWin('AccessServerJwtAdapter', {amp: true}, env => {
         });
         docFetcherMock
           .expects('fetchDocument')
-          .withExactArgs(sinon.match.any, 'http://localhost:8000/af', {
+          .withExactArgs(env.sandbox.match.any, 'http://localhost:8000/af', {
             method: 'POST',
             body: request,
             headers: {
@@ -315,7 +315,7 @@ describes.realWin('AccessServerJwtAdapter', {amp: true}, env => {
           })
           .returns(new Promise(() => {})) // Never resolved.
           .once();
-        const replaceSectionsStub = sandbox
+        const replaceSectionsStub = env.sandbox
           .stub(adapter, 'replaceSections_')
           .callsFake(() => {
             return Promise.resolve();
@@ -408,7 +408,7 @@ describes.realWin('AccessServerJwtAdapter', {amp: true}, env => {
           .withExactArgs(encoded)
           .returns(jwt)
           .once();
-        sandbox.stub(adapter, 'shouldBeValidated_').callsFake(() => false);
+        env.sandbox.stub(adapter, 'shouldBeValidated_').callsFake(() => false);
         return adapter.fetchJwt_().then(resp => {
           expect(resp.encoded).to.equal(encoded);
           expect(resp.jwt).to.equal(jwt);
@@ -528,8 +528,8 @@ describes.realWin('AccessServerJwtAdapter', {amp: true}, env => {
           .withExactArgs(encoded, pemPromise)
           .returns(Promise.resolve(jwt))
           .once();
-        sandbox.stub(adapter, 'shouldBeValidated_').callsFake(() => true);
-        const validateStub = sandbox.stub(adapter, 'validateJwt_');
+        env.sandbox.stub(adapter, 'shouldBeValidated_').callsFake(() => true);
+        const validateStub = env.sandbox.stub(adapter, 'validateJwt_');
         return adapter.fetchJwt_().then(resp => {
           expect(resp.encoded).to.equal(encoded);
           expect(resp.jwt).to.equal(jwt);
@@ -582,15 +582,15 @@ describes.realWin('AccessServerJwtAdapter', {amp: true}, env => {
           .expects('decodeAndVerify')
           .withExactArgs(
             encoded,
-            sinon.match(arg => {
+            env.sandbox.match(arg => {
               pemPromise = arg;
               return true;
             })
           )
           .returns(Promise.resolve(jwt))
           .once();
-        sandbox.stub(adapter, 'shouldBeValidated_').callsFake(() => true);
-        const validateStub = sandbox.stub(adapter, 'validateJwt_');
+        env.sandbox.stub(adapter, 'shouldBeValidated_').callsFake(() => true);
+        const validateStub = env.sandbox.stub(adapter, 'validateJwt_');
         return adapter
           .fetchJwt_()
           .then(resp => {
@@ -639,8 +639,8 @@ describes.realWin('AccessServerJwtAdapter', {amp: true}, env => {
           .returns(false)
           .once();
         jwtMock.expects('decodeAndVerify').never();
-        sandbox.stub(adapter, 'shouldBeValidated_').callsFake(() => true);
-        const validateStub = sandbox.stub(adapter, 'validateJwt_');
+        env.sandbox.stub(adapter, 'shouldBeValidated_').callsFake(() => true);
+        const validateStub = env.sandbox.stub(adapter, 'validateJwt_');
         return adapter.fetchJwt_().then(resp => {
           expect(resp.encoded).to.equal(encoded);
           expect(resp.jwt).to.equal(jwt);

--- a/extensions/amp-access/0.1/test/test-amp-access-server.js
+++ b/extensions/amp-access/0.1/test/test-amp-access-server.js
@@ -49,7 +49,7 @@ describes.realWin('AccessServerAdapter', {amp: true}, env => {
       buildUrl: () => {},
       collectUrlVars: () => {},
     };
-    contextMock = sandbox.mock(context);
+    contextMock = env.sandbox.mock(context);
   });
 
   afterEach(() => {
@@ -99,8 +99,8 @@ describes.realWin('AccessServerAdapter', {amp: true}, env => {
 
     beforeEach(() => {
       adapter = new AccessServerAdapter(ampdoc, validConfig, context);
-      xhrMock = sandbox.mock(adapter.xhr_);
-      docFetcherMock = sandbox.mock(DocumentFetcher);
+      xhrMock = env.sandbox.mock(adapter.xhr_);
+      docFetcherMock = env.sandbox.mock(DocumentFetcher);
       clientAdapter = {
         getAuthorizationUrl: () => validConfig['authorization'],
         getAuthorizationTimeout: () => 3000,
@@ -109,7 +109,7 @@ describes.realWin('AccessServerAdapter', {amp: true}, env => {
         authorize: () => Promise.resolve({}),
         pingback: () => Promise.resolve(),
       };
-      clientAdapterMock = sandbox.mock(clientAdapter);
+      clientAdapterMock = env.sandbox.mock(clientAdapter);
       adapter.clientAdapter_ = clientAdapter;
 
       adapter.isProxyOrigin_ = true;
@@ -186,7 +186,7 @@ describes.realWin('AccessServerAdapter', {amp: true}, env => {
         };
         docFetcherMock
           .expects('fetchDocument')
-          .withExactArgs(sinon.match.any, 'http://localhost:8000/af', {
+          .withExactArgs(env.sandbox.match.any, 'http://localhost:8000/af', {
             method: 'POST',
             body: 'request=' + encodeURIComponent(JSON.stringify(request)),
             headers: {
@@ -195,7 +195,7 @@ describes.realWin('AccessServerAdapter', {amp: true}, env => {
           })
           .returns(Promise.resolve(responseDoc))
           .once();
-        const replaceSectionsStub = sandbox
+        const replaceSectionsStub = env.sandbox
           .stub(adapter, 'replaceSections_')
           .callsFake(() => {
             return Promise.resolve();
@@ -232,7 +232,7 @@ describes.realWin('AccessServerAdapter', {amp: true}, env => {
         };
         docFetcherMock
           .expects('fetchDocument')
-          .withExactArgs(sinon.match.any, 'http://localhost:8000/af', {
+          .withExactArgs(env.sandbox.match.any, 'http://localhost:8000/af', {
             method: 'POST',
             body: 'request=' + encodeURIComponent(JSON.stringify(request)),
             headers: {
@@ -276,7 +276,7 @@ describes.realWin('AccessServerAdapter', {amp: true}, env => {
         };
         docFetcherMock
           .expects('fetchDocument')
-          .withExactArgs(sinon.match.any, 'http://localhost:8000/af', {
+          .withExactArgs(env.sandbox.match.any, 'http://localhost:8000/af', {
             method: 'POST',
             body: 'request=' + encodeURIComponent(JSON.stringify(request)),
             headers: {

--- a/extensions/amp-access/0.1/test/test-amp-access-source.js
+++ b/extensions/amp-access/0.1/test/test-amp-access-source.js
@@ -155,7 +155,7 @@ describes.fakeWin(
         onReauthorizeFn,
         element
       );
-      sandbox.stub(source.adapter_, 'getConfig');
+      env.sandbox.stub(source.adapter_, 'getConfig');
       source.getAdapterConfig();
       expect(source.adapter_.getConfig.called).to.be.true;
     });
@@ -232,7 +232,7 @@ describes.fakeWin(
         onReauthorizeFn,
         element
       );
-      const sourceMock = sandbox.mock(source);
+      const sourceMock = env.sandbox.mock(source);
       sourceMock
         .expects('login_')
         .withExactArgs('https://url', '')
@@ -262,7 +262,7 @@ describes.fakeWin(
       win = env.win;
       ampdoc = env.ampdoc;
       document = win.document;
-      clock = sandbox.useFakeTimers();
+      clock = env.sandbox.useFakeTimers();
       clock.tick(0);
 
       cidServiceForDocForTesting(ampdoc);
@@ -356,7 +356,7 @@ describes.fakeWin(
     });
 
     it('should return adapter config', () => {
-      sandbox.stub(source.adapter_, 'getConfig');
+      env.sandbox.stub(source.adapter_, 'getConfig');
       source.getAdapterConfig();
       expect(source.adapter_.getConfig.called).to.be.true;
     });
@@ -381,7 +381,7 @@ describes.fakeWin(
     beforeEach(() => {
       win = env.win;
       ampdoc = env.ampdoc;
-      clock = sandbox.useFakeTimers();
+      clock = env.sandbox.useFakeTimers();
       clock.tick(0);
 
       cidServiceForDocForTesting(ampdoc);
@@ -409,7 +409,7 @@ describes.fakeWin(
         authorize: () => {},
       };
       source.adapter_ = adapter;
-      adapterMock = sandbox.mock(adapter);
+      adapterMock = env.sandbox.mock(adapter);
     });
 
     afterEach(() => {

--- a/extensions/amp-access/0.1/test/test-amp-access-vendor.js
+++ b/extensions/amp-access/0.1/test/test-amp-access-vendor.js
@@ -82,7 +82,7 @@ describes.realWin('AccessVendorAdapter', {amp: true}, env => {
     beforeEach(() => {
       adapter = new AccessVendorAdapter(ampdoc, validConfig);
       vendor = new AccessVendor();
-      vendorMock = sandbox.mock(vendor);
+      vendorMock = env.sandbox.mock(vendor);
       adapter.registerVendor(vendor);
     });
 

--- a/extensions/amp-access/0.1/test/test-amp-access.js
+++ b/extensions/amp-access/0.1/test/test-amp-access.js
@@ -129,7 +129,7 @@ describes.fakeWin(
         'login': 'https://acme.com/l',
       });
       const service = new AccessService(ampdoc);
-      service.startInternal_ = sandbox.spy();
+      service.startInternal_ = env.sandbox.spy();
       service.start_();
       expect(service.startInternal_).to.be.calledOnce;
     });
@@ -141,10 +141,10 @@ describes.fakeWin(
         'login': 'https://acme.com/l',
       });
       const service = new AccessService(ampdoc);
-      service.sources_[0].buildLoginUrls_ = sandbox.spy();
-      service.runAuthorization_ = sandbox.spy();
-      service.scheduleView_ = sandbox.spy();
-      service.listenToBroadcasts_ = sandbox.spy();
+      service.sources_[0].buildLoginUrls_ = env.sandbox.spy();
+      service.runAuthorization_ = env.sandbox.spy();
+      service.scheduleView_ = env.sandbox.spy();
+      service.listenToBroadcasts_ = env.sandbox.spy();
 
       service.startInternal_();
       expect(service.sources_[0].buildLoginUrls_).to.be.calledOnce;
@@ -271,7 +271,7 @@ describes.fakeWin(
       win = env.win;
       ampdoc = env.ampdoc;
       document = win.document;
-      clock = sandbox.useFakeTimers();
+      clock = env.sandbox.useFakeTimers();
       clock.tick(0);
 
       cidServiceForDocForTesting(ampdoc);
@@ -301,9 +301,9 @@ describes.fakeWin(
       elementError.setAttribute('amp-access-hide', '');
       document.body.appendChild(elementError);
 
-      sandbox.stub(ampdoc, 'isVisible').returns(true);
-      sandbox.stub(ampdoc, 'whenFirstVisible').returns(Promise.resolve());
-      sandbox.stub(ampdoc, 'onVisibilityChanged').returns(function() {});
+      env.sandbox.stub(ampdoc, 'isVisible').returns(true);
+      env.sandbox.stub(ampdoc, 'whenFirstVisible').returns(Promise.resolve());
+      env.sandbox.stub(ampdoc, 'onVisibilityChanged').returns(function() {});
 
       service = new AccessService(ampdoc);
       service.viewer_ = {
@@ -318,9 +318,9 @@ describes.fakeWin(
         authorize: () => {},
       };
       service.sources_[0].adapter_ = adapter;
-      adapterMock = sandbox.mock(adapter);
+      adapterMock = env.sandbox.mock(adapter);
 
-      sandbox
+      env.sandbox
         .stub(service.resources_, 'mutateElement')
         .callsFake((unusedElement, mutator) => {
           mutator();
@@ -338,12 +338,12 @@ describes.fakeWin(
       const cid = {
         get: () => {},
       };
-      cidMock = sandbox.mock(cid);
+      cidMock = env.sandbox.mock(cid);
       service.cid_ = Promise.resolve(cid);
 
-      service.analyticsEvent_ = sandbox.spy();
-      service.sources_[0].analyticsEvent_ = sandbox.spy();
-      performanceMock = sandbox.mock(service.performance_);
+      service.analyticsEvent_ = env.sandbox.spy();
+      service.sources_[0].analyticsEvent_ = env.sandbox.spy();
+      performanceMock = env.sandbox.mock(service.performance_);
       performanceMock.expects('onload_').atLeast(0);
     });
 
@@ -369,7 +369,7 @@ describes.fakeWin(
         .expects('get')
         .withExactArgs(
           {scope: 'amp-access', createCookieIfNotPresent: true},
-          sinon.match(() => true)
+          env.sandbox.match(() => true)
         )
         .returns(Promise.resolve(result))
         .once();
@@ -409,7 +409,7 @@ describes.fakeWin(
         .returns(Promise.resolve({access: true}))
         .once();
       expectGetReaderId('reader1');
-      source.buildLoginUrls_ = sandbox.spy();
+      source.buildLoginUrls_ = env.sandbox.spy();
       const firstPromise = service.lastAuthorizationPromises_;
       const promise = service.runAuthorization_();
       expect(firstPromise).not.to.equal(promise);
@@ -510,7 +510,7 @@ describes.fakeWin(
         .returns(Promise.resolve({access: true}))
         .once();
 
-      const applyAuthorizationsStub = sandbox.stub();
+      const applyAuthorizationsStub = env.sandbox.stub();
       service.onApplyAuthorizations(applyAuthorizationsStub);
 
       return service.runAuthorization_().then(() => {
@@ -520,10 +520,10 @@ describes.fakeWin(
 
     it('should run authorization for broadcast events on same origin', () => {
       let broadcastHandler;
-      sandbox.stub(service.viewer_, 'onBroadcast').callsFake(handler => {
+      env.sandbox.stub(service.viewer_, 'onBroadcast').callsFake(handler => {
         broadcastHandler = handler;
       });
-      service.runAuthorization_ = sandbox.spy();
+      service.runAuthorization_ = env.sandbox.spy();
       service.listenToBroadcasts_();
       expect(broadcastHandler).to.exist;
 
@@ -587,7 +587,7 @@ describes.fakeWin(
 
       service = new AccessService(ampdoc);
 
-      mutateElementStub = sandbox
+      mutateElementStub = env.sandbox
         .stub(service.resources_, 'mutateElement')
         .callsFake((unusedElement, mutator) => {
           mutator();
@@ -599,7 +599,7 @@ describes.fakeWin(
           return Promise.resolve();
         },
       };
-      templatesMock = sandbox.mock(service.templates_);
+      templatesMock = env.sandbox.mock(service.templates_);
     });
 
     afterEach(() => {
@@ -647,7 +647,7 @@ describes.fakeWin(
       elementOn.appendChild(template2);
 
       function renderAndCheck() {
-        templatesMock = sandbox.mock(service.templates_);
+        templatesMock = env.sandbox.mock(service.templates_);
         const result1 = document.createElement('div');
         const result2 = document.createElement('div');
         templatesMock
@@ -721,7 +721,7 @@ describes.fakeWin(
       win = env.win;
       ampdoc = env.ampdoc;
       document = win.document;
-      clock = sandbox.useFakeTimers();
+      clock = env.sandbox.useFakeTimers();
 
       cidServiceForDocForTesting(ampdoc);
       installPerformanceService(win);
@@ -738,10 +738,10 @@ describes.fakeWin(
       document.body.appendChild(configElement);
       document.documentElement.classList.remove('amp-access-error');
 
-      isVisibleStub = sandbox.stub(ampdoc, 'isVisible').returns(true);
-      sandbox.stub(ampdoc, 'whenFirstVisible').returns(Promise.resolve());
+      isVisibleStub = env.sandbox.stub(ampdoc, 'isVisible').returns(true);
+      env.sandbox.stub(ampdoc, 'whenFirstVisible').returns(Promise.resolve());
       visibilityChanged = new Observable();
-      sandbox
+      env.sandbox
         .stub(ampdoc, 'onVisibilityChanged')
         .callsFake(callback => visibilityChanged.add(callback));
 
@@ -752,16 +752,16 @@ describes.fakeWin(
         pingback: () => Promise.resolve(),
       };
       service.sources_[0].adapter_ = adapter;
-      adapterMock = sandbox.mock(adapter);
+      adapterMock = env.sandbox.mock(adapter);
 
       const cid = {
         get: () => {},
       };
-      cidMock = sandbox.mock(cid);
+      cidMock = env.sandbox.mock(cid);
       service.cid_ = Promise.resolve(cid);
 
-      service.analyticsEvent_ = sandbox.spy();
-      service.sources_[0].analyticsEvent_ = sandbox.spy();
+      service.analyticsEvent_ = env.sandbox.spy();
+      service.sources_[0].analyticsEvent_ = env.sandbox.spy();
       win.docState_ = {
         onReady: callback => callback(),
       };
@@ -791,14 +791,14 @@ describes.fakeWin(
         .expects('get')
         .withExactArgs(
           {scope: 'amp-access', createCookieIfNotPresent: true},
-          sinon.match(() => true)
+          env.sandbox.match(() => true)
         )
         .returns(Promise.resolve(result))
         .once();
     }
 
     it('should register "viewed" signal after timeout', () => {
-      service.reportViewToServer_ = sandbox.spy();
+      service.reportViewToServer_ = env.sandbox.spy();
       const p = service.reportWhenViewed_(/* timeToView */ 2000);
       return Promise.resolve()
         .then(() => {
@@ -820,7 +820,7 @@ describes.fakeWin(
     });
 
     it('should register "viewed" signal after scroll', () => {
-      service.reportViewToServer_ = sandbox.spy();
+      service.reportViewToServer_ = env.sandbox.spy();
       const p = service.reportWhenViewed_(/* timeToView */ 2000);
       return Promise.resolve()
         .then(() => {
@@ -842,7 +842,7 @@ describes.fakeWin(
     });
 
     it('should register "viewed" signal after click', () => {
-      service.reportViewToServer_ = sandbox.spy();
+      service.reportViewToServer_ = env.sandbox.spy();
       const p = service.reportWhenViewed_(/* timeToView */ 2000);
       return Promise.resolve()
         .then(() => {
@@ -878,7 +878,7 @@ describes.fakeWin(
         lastAuthorizationResolver = resolve;
       });
       const triggerStart = 1; // First event is "access-authorization-received".
-      service.reportViewToServer_ = sandbox.spy();
+      service.reportViewToServer_ = env.sandbox.spy();
       service.reportWhenViewed_(/* timeToView */ 2000);
       return Promise.resolve()
         .then(() => {
@@ -905,7 +905,7 @@ describes.fakeWin(
     });
 
     it('should cancel "viewed" signal after click', () => {
-      service.reportViewToServer_ = sandbox.spy();
+      service.reportViewToServer_ = env.sandbox.spy();
       const p = service.reportWhenViewed_(/* timeToView */ 2000);
       return Promise.resolve()
         .then(() => {
@@ -930,7 +930,7 @@ describes.fakeWin(
         expect(ttv).to.equal(timeToView);
         return Promise.resolve();
       };
-      service.reportViewToServer_ = sandbox.spy();
+      service.reportViewToServer_ = env.sandbox.spy();
       const p1 = service.reportWhenViewed_(timeToView);
       const p2 = service.reportWhenViewed_(timeToView);
       expect(p2).to.equal(p1);
@@ -948,8 +948,8 @@ describes.fakeWin(
     it('should ignore "viewed" monitoring when pingback is disabled', () => {
       adapterMock.expects('isPingbackEnabled').returns(false);
 
-      service.reportWhenViewed_ = sandbox.spy();
-      const broadcastStub = sandbox.stub(service.viewer_, 'broadcast');
+      service.reportWhenViewed_ = env.sandbox.spy();
+      const broadcastStub = env.sandbox.stub(service.viewer_, 'broadcast');
 
       service.scheduleView_(/* timeToView */ 2000);
 
@@ -959,7 +959,7 @@ describes.fakeWin(
     });
 
     it('should re-schedule "viewed" monitoring after visibility change', () => {
-      service.reportViewToServer_ = sandbox.spy();
+      service.reportViewToServer_ = env.sandbox.spy();
 
       service.scheduleView_(/* timeToView */ 2000);
 
@@ -1010,7 +1010,7 @@ describes.fakeWin(
 
     it('should re-start "viewed" monitoring when directly requested', () => {
       service.lastAuthorizationPromise_ = Promise.resolve();
-      const whenViewedSpy = sandbox
+      const whenViewedSpy = env.sandbox
         .stub(service, 'whenViewed_')
         .callsFake(() => {
           return Promise.resolve();
@@ -1080,8 +1080,10 @@ describes.fakeWin(
     });
 
     it('should broadcast "viewed" signal to other documents', () => {
-      service.reportViewToServer_ = sandbox.stub().returns(Promise.resolve());
-      const broadcastStub = sandbox.stub(service.viewer_, 'broadcast');
+      service.reportViewToServer_ = env.sandbox
+        .stub()
+        .returns(Promise.resolve());
+      const broadcastStub = env.sandbox.stub(service.viewer_, 'broadcast');
       const p = service.reportWhenViewed_(/* timeToView */ 2000);
       return Promise.resolve()
         .then(() => {
@@ -1135,8 +1137,8 @@ describes.fakeWin(
       document.body.appendChild(configElement);
       document.documentElement.classList.remove('amp-access-error');
 
-      sandbox.stub(ampdoc, 'isVisible').returns(true);
-      sandbox.stub(ampdoc, 'onVisibilityChanged').returns(function() {});
+      env.sandbox.stub(ampdoc, 'isVisible').returns(true);
+      env.sandbox.stub(ampdoc, 'onVisibilityChanged').returns(function() {});
 
       service = new AccessService(ampdoc);
 
@@ -1145,12 +1147,12 @@ describes.fakeWin(
       };
       service.cid_ = Promise.resolve(cid);
 
-      service.analyticsEvent_ = sandbox.spy();
-      serviceMock = sandbox.mock(service);
+      service.analyticsEvent_ = env.sandbox.spy();
+      serviceMock = env.sandbox.mock(service);
       service.sources_[0].openLoginDialog_ = () => {};
       service.sources_[0].loginUrlMap_[''] = 'https://acme.com/l?rid=R';
-      service.sources_[0].analyticsEvent_ = sandbox.spy();
-      service.sources_[0].getAdapter().postAction = sandbox.spy();
+      service.sources_[0].analyticsEvent_ = env.sandbox.spy();
+      service.sources_[0].getAdapter().postAction = env.sandbox.spy();
 
       service.viewer_ = {
         broadcast: () => {},
@@ -1168,7 +1170,7 @@ describes.fakeWin(
         .expects('runAuthorization_')
         .withExactArgs()
         .once();
-      const event = {preventDefault: sandbox.spy()};
+      const event = {preventDefault: env.sandbox.spy()};
       const invocation = {
         method: 'refresh',
         event,
@@ -1203,7 +1205,7 @@ describes.fakeWin(
       win = env.win;
       ampdoc = env.ampdoc;
       document = win.document;
-      clock = sandbox.useFakeTimers();
+      clock = env.sandbox.useFakeTimers();
 
       cidServiceForDocForTesting(ampdoc);
       installPerformanceService(win);
@@ -1219,24 +1221,24 @@ describes.fakeWin(
       document.body.appendChild(configElement);
       document.documentElement.classList.remove('amp-access-error');
 
-      sandbox.stub(ampdoc, 'isVisible').returns(true);
-      sandbox.stub(ampdoc, 'onVisibilityChanged').returns(function() {});
+      env.sandbox.stub(ampdoc, 'isVisible').returns(true);
+      env.sandbox.stub(ampdoc, 'onVisibilityChanged').returns(function() {});
 
       service = new AccessService(ampdoc);
 
       const cid = {
         get: () => {},
       };
-      cidMock = sandbox.mock(cid);
+      cidMock = env.sandbox.mock(cid);
       service.cid_ = Promise.resolve(cid);
 
-      service.analyticsEvent_ = sandbox.spy();
-      serviceMock = sandbox.mock(service);
-      sourceMock = sandbox.mock(service.sources_[0]);
+      service.analyticsEvent_ = env.sandbox.spy();
+      serviceMock = env.sandbox.mock(service);
+      sourceMock = env.sandbox.mock(service.sources_[0]);
       service.sources_[0].openLoginDialog_ = () => {};
       service.sources_[0].loginUrlMap_[''] = 'https://acme.com/l?rid=R';
-      service.sources_[0].analyticsEvent_ = sandbox.spy();
-      service.sources_[0].getAdapter().postAction = sandbox.spy();
+      service.sources_[0].analyticsEvent_ = env.sandbox.spy();
+      service.sources_[0].getAdapter().postAction = env.sandbox.spy();
 
       service.viewer_ = {
         broadcast: () => {},
@@ -1254,7 +1256,7 @@ describes.fakeWin(
         .expects('loginWithType_')
         .withExactArgs('')
         .once();
-      const event = {preventDefault: sandbox.spy()};
+      const event = {preventDefault: env.sandbox.spy()};
       const invocation = {method: 'login', event, satisfiesTrust: () => false};
       service.handleAction_(invocation);
       expect(event.preventDefault).to.not.be.called;
@@ -1269,7 +1271,7 @@ describes.fakeWin(
         .expects('loginWithType_')
         .withExactArgs('other')
         .once();
-      const event = {preventDefault: sandbox.spy()};
+      const event = {preventDefault: env.sandbox.spy()};
       const invocation = {
         method: 'login-other',
         event,
@@ -1288,7 +1290,7 @@ describes.fakeWin(
         .expects('get')
         .withExactArgs(
           {scope: 'amp-access', createCookieIfNotPresent: true},
-          sinon.match(() => true)
+          env.sandbox.match(() => true)
         )
         .returns(Promise.resolve('reader1'))
         .once();
@@ -1309,7 +1311,7 @@ describes.fakeWin(
         .expects('get')
         .withExactArgs(
           {scope: 'amp-access', createCookieIfNotPresent: true},
-          sinon.match(() => true)
+          env.sandbox.match(() => true)
         )
         .returns(Promise.resolve('reader1'))
         .atLeast(1);
@@ -1348,7 +1350,7 @@ describes.fakeWin(
         .expects('get')
         .withExactArgs(
           {scope: 'amp-access', createCookieIfNotPresent: true},
-          sinon.match(() => true)
+          env.sandbox.match(() => true)
         )
         .returns(Promise.resolve('reader1'))
         .once();
@@ -1361,7 +1363,7 @@ describes.fakeWin(
 
     it('should open dialog in the same microtask', () => {
       const source = service.sources_[0];
-      source.openLoginDialog_ = sandbox.stub();
+      source.openLoginDialog_ = env.sandbox.stub();
       source.openLoginDialog_.returns(new Promise(() => {}));
       service.loginWithType_('');
       expect(source.openLoginDialog_).to.be.calledOnce;
@@ -1384,11 +1386,11 @@ describes.fakeWin(
 
     it('should succeed login with success=true', () => {
       const source = service.sources_[0];
-      const authorizationStub = sandbox
+      const authorizationStub = env.sandbox
         .stub(source, 'runAuthorization')
         .callsFake(() => Promise.resolve());
-      const viewStub = sandbox.stub(source, 'scheduleView_');
-      const broadcastStub = sandbox.stub(service.viewer_, 'broadcast');
+      const viewStub = env.sandbox.stub(source, 'scheduleView_');
+      const broadcastStub = env.sandbox.stub(service.viewer_, 'broadcast');
       sourceMock
         .expects('openLoginDialog_')
         .withExactArgs('https://acme.com/l?rid=R')
@@ -1420,7 +1422,7 @@ describes.fakeWin(
 
     it('should fail login with success=no', () => {
       const source = service.sources_[0];
-      service.runAuthorization_ = sandbox.spy();
+      service.runAuthorization_ = env.sandbox.spy();
       sourceMock
         .expects('openLoginDialog_')
         .withExactArgs('https://acme.com/l?rid=R')
@@ -1440,11 +1442,11 @@ describes.fakeWin(
 
     it('should fail login with empty response, but re-authorize', () => {
       const source = service.sources_[0];
-      const authorizationStub = sandbox
+      const authorizationStub = env.sandbox
         .stub(source, 'runAuthorization')
         .callsFake(() => Promise.resolve());
-      const viewStub = sandbox.stub(source, 'scheduleView_');
-      const broadcastStub = sandbox.stub(service.viewer_, 'broadcast');
+      const viewStub = env.sandbox.stub(source, 'scheduleView_');
+      const broadcastStub = env.sandbox.stub(service.viewer_, 'broadcast');
       sourceMock
         .expects('openLoginDialog_')
         .withExactArgs('https://acme.com/l?rid=R')
@@ -1474,7 +1476,7 @@ describes.fakeWin(
 
     it('should fail login with aborted dialog', () => {
       const source = service.sources_[0];
-      service.runAuthorization_ = sandbox.spy();
+      service.runAuthorization_ = env.sandbox.spy();
       sourceMock
         .expects('openLoginDialog_')
         .withExactArgs('https://acme.com/l?rid=R')
@@ -1509,10 +1511,10 @@ describes.fakeWin(
         'login1': 'https://acme.com/l1?rid=R',
         'login2': 'https://acme.com/l2?rid=R',
       };
-      const authorizationStub = sandbox
+      const authorizationStub = env.sandbox
         .stub(source, 'runAuthorization')
         .callsFake(() => Promise.resolve());
-      const broadcastStub = sandbox.stub(service.viewer_, 'broadcast');
+      const broadcastStub = env.sandbox.stub(service.viewer_, 'broadcast');
       sourceMock
         .expects('openLoginDialog_')
         .withExactArgs('https://acme.com/l2?rid=R')
@@ -1547,9 +1549,9 @@ describes.fakeWin(
         p1Reject = reject;
       });
       const source = service.sources_[0];
-      service.runAuthorization_ = sandbox.spy();
+      service.runAuthorization_ = env.sandbox.spy();
 
-      const openLoginDialogStub = sandbox.stub(source, 'openLoginDialog_');
+      const openLoginDialogStub = env.sandbox.stub(source, 'openLoginDialog_');
       openLoginDialogStub.onCall(0).returns(p1Promise);
       openLoginDialogStub.onCall(1).returns(new Promise(() => {}));
       openLoginDialogStub.onCall(2).throws();
@@ -1581,11 +1583,11 @@ describes.fakeWin(
 
     it('should wait for token exchange post-login with success=true', () => {
       const source = service.sources_[0];
-      const authorizationStub = sandbox
+      const authorizationStub = env.sandbox
         .stub(source, 'runAuthorization')
         .callsFake(() => Promise.resolve());
-      const viewStub = sandbox.stub(source, 'scheduleView_');
-      const broadcastStub = sandbox.stub(service.viewer_, 'broadcast');
+      const viewStub = env.sandbox.stub(source, 'scheduleView_');
+      const broadcastStub = env.sandbox.stub(service.viewer_, 'broadcast');
       sourceMock
         .expects('openLoginDialog_')
         .withExactArgs('https://acme.com/l?rid=R')
@@ -1743,7 +1745,7 @@ describes.fakeWin(
       win = env.win;
       ampdoc = env.ampdoc;
       document = win.document;
-      clock = sandbox.useFakeTimers();
+      clock = env.sandbox.useFakeTimers();
       clock.tick(0);
 
       cidServiceForDocForTesting(ampdoc);
@@ -1806,12 +1808,12 @@ describes.fakeWin(
         postAction: () => {},
       };
       sourceBeer.adapter_ = adapterBeer;
-      adapterBeerMock = sandbox.mock(adapterBeer);
+      adapterBeerMock = env.sandbox.mock(adapterBeer);
 
       sourceDonuts.adapter_ = adapterDonuts;
-      adapterDonutsMock = sandbox.mock(adapterDonuts);
+      adapterDonutsMock = env.sandbox.mock(adapterDonuts);
 
-      sandbox
+      env.sandbox
         .stub(service.resources_, 'mutateElement')
         .callsFake((unusedElement, mutator) => {
           mutator();
@@ -1829,13 +1831,13 @@ describes.fakeWin(
       const cid = {
         get: () => {},
       };
-      cidMock = sandbox.mock(cid);
+      cidMock = env.sandbox.mock(cid);
       service.cid_ = Promise.resolve(cid);
 
-      service.analyticsEvent_ = sandbox.spy();
-      sourceBeer.analyticsEvent_ = sandbox.spy();
-      sourceDonuts.analyticsEvent_ = sandbox.spy();
-      performanceMock = sandbox.mock(service.performance_);
+      service.analyticsEvent_ = env.sandbox.spy();
+      sourceBeer.analyticsEvent_ = env.sandbox.spy();
+      sourceDonuts.analyticsEvent_ = env.sandbox.spy();
+      performanceMock = env.sandbox.mock(service.performance_);
       performanceMock.expects('onload_').atLeast(0);
     });
 
@@ -1862,7 +1864,7 @@ describes.fakeWin(
         .expects('get')
         .withExactArgs(
           {scope: 'amp-access', createCookieIfNotPresent: true},
-          sinon.match(() => true)
+          env.sandbox.match(() => true)
         )
         .returns(Promise.resolve(result))
         .once();
@@ -1932,18 +1934,18 @@ describes.fakeWin(
 
     it('should succeed login flat', () => {
       expectGetReaderId('reader1');
-      const authorizationStub = sandbox
+      const authorizationStub = env.sandbox
         .stub(sourceBeer, 'runAuthorization')
         .callsFake(() => Promise.resolve());
       const viewer = Services.viewerForDoc(ampdoc);
-      const broadcastStub = sandbox.stub(viewer, 'broadcast');
-      const sourceBeerMock = sandbox.mock(sourceBeer);
+      const broadcastStub = env.sandbox.stub(viewer, 'broadcast');
+      const sourceBeerMock = env.sandbox.mock(sourceBeer);
       sourceBeerMock
         .expects('openLoginDialog_')
         .withExactArgs('https://acme.com/l?rid=reader1')
         .returns(Promise.resolve('#success=true'))
         .once();
-      sourceBeer.analyticsEvent_ = sandbox.spy();
+      sourceBeer.analyticsEvent_ = env.sandbox.spy();
       return sourceBeer
         .buildLoginUrls_()
         .then(() => service.loginWithType_('beer'))
@@ -1968,18 +1970,18 @@ describes.fakeWin(
 
     it('should succeed login hierarchy', () => {
       expectGetReaderId('reader1');
-      const authorizationStub = sandbox
+      const authorizationStub = env.sandbox
         .stub(sourceDonuts, 'runAuthorization')
         .callsFake(() => Promise.resolve());
       const viewer = Services.viewerForDoc(ampdoc);
-      const broadcastStub = sandbox.stub(viewer, 'broadcast');
-      const sourceDonutsMock = sandbox.mock(sourceDonuts);
+      const broadcastStub = env.sandbox.stub(viewer, 'broadcast');
+      const sourceDonutsMock = env.sandbox.mock(sourceDonuts);
       sourceDonutsMock
         .expects('openLoginDialog_')
         .withExactArgs('https://acme.com/l?rid=reader1')
         .returns(Promise.resolve('#success=true'))
         .once();
-      sourceDonuts.analyticsEvent_ = sandbox.spy();
+      sourceDonuts.analyticsEvent_ = env.sandbox.spy();
       return sourceDonuts
         .buildLoginUrls_()
         .then(() => service.loginWithType_('donuts-login2'))

--- a/extensions/amp-access/0.1/test/test-amp-login-done-dialog.js
+++ b/extensions/amp-access/0.1/test/test-amp-login-done-dialog.js
@@ -17,7 +17,6 @@
 import {LoginDoneDialog, buildLangSelector} from '../amp-login-done-dialog';
 
 describe('LoginDoneDialog', () => {
-  let sandbox;
   let clock;
   let windowApi;
   let windowMock;
@@ -27,8 +26,7 @@ describe('LoginDoneDialog', () => {
   let closeButton;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox;
-    clock = sandbox.useFakeTimers();
+    clock = window.sandbox.useFakeTimers();
 
     messageListener = undefined;
     closeButton = {};
@@ -40,7 +38,7 @@ describe('LoginDoneDialog', () => {
       location: {
         hash: '#result1',
         search: '',
-        replace: sandbox.spy(),
+        replace: window.sandbox.spy(),
       },
       addEventListener: (type, callback) => {
         if (type == 'message') {
@@ -74,14 +72,10 @@ describe('LoginDoneDialog', () => {
         },
       },
     };
-    windowMock = sandbox.mock(windowApi);
-    openerMock = sandbox.mock(windowApi.opener);
+    windowMock = window.sandbox.mock(windowApi);
+    openerMock = window.sandbox.mock(windowApi.opener);
 
     dialog = new LoginDoneDialog(windowApi);
-  });
-
-  afterEach(() => {
-    sandbox.restore();
   });
 
   function succeed() {
@@ -166,7 +160,7 @@ describe('LoginDoneDialog', () => {
       openerMock
         .expects('postMessage')
         .withExactArgs(
-          sinon.match(arg => {
+          window.sandbox.match(arg => {
             return (
               arg.sentinel == 'amp' &&
               arg.type == 'result' &&
@@ -316,7 +310,7 @@ describe('LoginDoneDialog', () => {
       openerMock
         .expects('postMessage')
         .withExactArgs(
-          sinon.match(arg => {
+          window.sandbox.match(arg => {
             return (
               arg.sentinel == 'amp' &&
               arg.type == 'result' &&
@@ -344,7 +338,7 @@ describe('LoginDoneDialog', () => {
 
     it('should revert to error mode if window is not closed', () => {
       windowMock.expects('close').once();
-      dialog.postbackError_ = sandbox.spy();
+      dialog.postbackError_ = window.sandbox.spy();
       dialog.postbackSuccess_();
       expect(dialog.postbackError_).to.have.not.been.called;
 

--- a/extensions/amp-access/0.1/test/test-iframe-api.js
+++ b/extensions/amp-access/0.1/test/test-iframe-api.js
@@ -32,9 +32,9 @@ describes.fakeWin(
     beforeEach(() => {
       win = env.win;
       const controller = new AccessController();
-      controllerMock = sandbox.mock(controller);
+      controllerMock = env.sandbox.mock(controller);
       iframeApi = new AmpAccessIframeApi(controller, win);
-      messengerMock = sandbox.mock(iframeApi.messenger_);
+      messengerMock = env.sandbox.mock(iframeApi.messenger_);
     });
 
     afterEach(() => {

--- a/extensions/amp-access/0.1/test/test-iframe-messenger.js
+++ b/extensions/amp-access/0.1/test/test-iframe-messenger.js
@@ -33,9 +33,9 @@ describes.fakeWin('Messenger', {}, env => {
       // A port knows the origin, but doesn't always know the source window.
       source = null;
       messenger = new Messenger(win, () => source, 'https://example-sp.com');
-      onCommand = sandbox.spy();
-      addEventListenerSpy = sandbox.spy(win, 'addEventListener');
-      removeEventListenerSpy = sandbox.spy(win, 'removeEventListener');
+      onCommand = env.sandbox.spy();
+      addEventListenerSpy = env.sandbox.spy(win, 'addEventListener');
+      removeEventListenerSpy = env.sandbox.spy(win, 'removeEventListener');
       messenger.connect(onCommand);
     });
 
@@ -82,7 +82,7 @@ describes.fakeWin('Messenger', {}, env => {
 
     it('should send a command once connected', () => {
       source = {
-        postMessage: sandbox.spy(),
+        postMessage: env.sandbox.spy(),
       };
       messenger.sendCommand('start', {a: 1});
       expect(source.postMessage).to.be.calledOnce;
@@ -130,7 +130,7 @@ describes.fakeWin('Messenger', {}, env => {
 
     it('should send and receive a rsvp command', () => {
       source = {
-        postMessage: sandbox.spy(),
+        postMessage: env.sandbox.spy(),
       };
       const promise = messenger.sendCommandRsvp('authorize', {a: 1});
       expect(source.postMessage).to.be.calledOnce;
@@ -162,7 +162,7 @@ describes.fakeWin('Messenger', {}, env => {
 
     it('should increment rvsp', () => {
       source = {
-        postMessage: sandbox.spy(),
+        postMessage: env.sandbox.spy(),
       };
       messenger.sendCommandRsvp('authorize', {});
       expect(source.postMessage.args[0][0]).to.deep.equal({
@@ -183,7 +183,7 @@ describes.fakeWin('Messenger', {}, env => {
 
     it('should send and receive a rsvp command with error', () => {
       source = {
-        postMessage: sandbox.spy(),
+        postMessage: env.sandbox.spy(),
       };
       const promise = messenger.sendCommandRsvp('authorize', {a: 1});
       expect(source.postMessage).to.be.calledOnce;
@@ -227,14 +227,14 @@ describes.fakeWin('Messenger', {}, env => {
       let handlerResponse;
 
       beforeEach(() => {
-        sandbox
+        env.sandbox
           .stub(messenger, 'handleCommand_')
           .callsFake(() => handlerResponse);
         let sendResolver;
         sendPromise = new Promise(resolve => {
           sendResolver = resolve;
         });
-        sendStub = sandbox.stub(messenger, 'sendCommand_').callsFake(() => {
+        sendStub = env.sandbox.stub(messenger, 'sendCommand_').callsFake(() => {
           sendResolver();
         });
         handler = addEventListenerSpy.args[0][1];
@@ -304,11 +304,11 @@ describes.fakeWin('Messenger', {}, env => {
     beforeEach(() => {
       // A host knows the target window, but not the origin.
       target = {
-        postMessage: sandbox.spy(),
+        postMessage: env.sandbox.spy(),
       };
       messenger = new Messenger(win, target, /* targetOrigin */ null);
-      onCommand = sandbox.spy();
-      addEventListenerSpy = sandbox.spy(win, 'addEventListener');
+      onCommand = env.sandbox.spy();
+      addEventListenerSpy = env.sandbox.spy(win, 'addEventListener');
       messenger.connect(onCommand);
     });
 

--- a/extensions/amp-access/0.1/test/test-jwt.js
+++ b/extensions/amp-access/0.1/test/test-jwt.js
@@ -28,16 +28,10 @@ describe('JwtHelper', () => {
   const TOKEN_SIG = 'TJVA95OrM7E2cBab30RMHrHDcEfxjoYZgeFONFh7HgQ';
   const TOKEN = `${TOKEN_HEADER}.${TOKEN_PAYLOAD}.${TOKEN_SIG}`;
 
-  let sandbox;
   let helper;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox;
     helper = new JwtHelper(window);
-  });
-
-  afterEach(() => {
-    sandbox.restore();
   });
 
   describe('decode', () => {
@@ -110,10 +104,6 @@ describe('JwtHelper', () => {
       'o2kQ+X5xK9cipRgEKwIDAQAB\n' +
       '-----END PUBLIC KEY-----';
 
-    beforeEach(() => {});
-
-    afterEach(() => {});
-
     // TODO(aghassemi, 6292): Unskip for Safari after #6292
     it.configure()
       .skipSafari()
@@ -180,7 +170,7 @@ describe('JwtHelper', () => {
         importKey: () => {},
         verify: () => {},
       };
-      subtleMock = sandbox.mock(subtle);
+      subtleMock = window.sandbox.mock(subtle);
 
       windowApi = {
         crypto: {subtle},
@@ -246,8 +236,8 @@ describe('JwtHelper', () => {
         .withExactArgs(
           {name: 'RSASSA-PKCS1-v1_5'},
           key,
-          /* sig */ sinon.match(() => true),
-          /* verifiable */ sinon.match(() => true)
+          /* sig */ window.sandbox.match(() => true),
+          /* verifiable */ window.sandbox.match(() => true)
         )
         .returns(Promise.resolve(true))
         .once();

--- a/extensions/amp-access/0.1/test/test-login-dialog.js
+++ b/extensions/amp-access/0.1/test/test-login-dialog.js
@@ -24,14 +24,12 @@ const RETURN_URL_ESC = encodeURIComponent(
     encodeURIComponent('http://localhost:8000/test-login-dialog')
 );
 
-describes.sandboxed('ViewerLoginDialog', {}, () => {
+describes.sandboxed('ViewerLoginDialog', {}, env => {
   let ampdoc;
   let viewer;
   let windowApi;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox;
-
     viewer = {
       sendMessageAwaitResponse: () => {},
     };
@@ -61,7 +59,7 @@ describes.sandboxed('ViewerLoginDialog', {}, () => {
     windowApi.document.defaultView = windowApi;
     installDocService(windowApi, /* isSingleDoc */ true);
     ampdoc = Services.ampdocServiceFor(windowApi).getSingleDoc();
-    sandbox.stub(ampdoc, 'getParam').callsFake(param => {
+    env.sandbox.stub(ampdoc, 'getParam').callsFake(param => {
       if (param == 'dialog') {
         return '1';
       }
@@ -69,12 +67,8 @@ describes.sandboxed('ViewerLoginDialog', {}, () => {
     });
   });
 
-  afterEach(() => {
-    sandbox.restore();
-  });
-
   it('should delegate to viewer with url', () => {
-    const stub = sandbox
+    const stub = env.sandbox
       .stub(viewer, 'sendMessageAwaitResponse')
       .callsFake(() => Promise.resolve('#success=yes'));
     return openLoginDialog(ampdoc, 'http://acme.com/login').then(res => {
@@ -88,7 +82,7 @@ describes.sandboxed('ViewerLoginDialog', {}, () => {
   });
 
   it('should delegate to viewer with url promise', () => {
-    const stub = sandbox
+    const stub = env.sandbox
       .stub(viewer, 'sendMessageAwaitResponse')
       .callsFake(() => Promise.resolve('#success=yes'));
     const urlPromise = Promise.resolve('http://acme.com/login');
@@ -103,7 +97,7 @@ describes.sandboxed('ViewerLoginDialog', {}, () => {
   });
 
   it('should fail when url promise fails', () => {
-    sandbox
+    env.sandbox
       .stub(viewer, 'sendMessageAwaitResponse')
       .callsFake(() => Promise.resolve('#success=yes'));
     const urlPromise = Promise.reject('expected');
@@ -118,7 +112,7 @@ describes.sandboxed('ViewerLoginDialog', {}, () => {
   });
 
   it('should fail when viewer fails', () => {
-    sandbox
+    env.sandbox
       .stub(viewer, 'sendMessageAwaitResponse')
       .callsFake(() => Promise.reject('expected'));
     return openLoginDialog(ampdoc, 'http://acme.com/login').then(
@@ -132,7 +126,7 @@ describes.sandboxed('ViewerLoginDialog', {}, () => {
   });
 
   it('should have correct URL with other parameters', () => {
-    const stub = sandbox
+    const stub = env.sandbox
       .stub(viewer, 'sendMessageAwaitResponse')
       .callsFake(() => Promise.resolve('#success=yes'));
     const url = 'http://acme.com/login?a=b';
@@ -144,7 +138,7 @@ describes.sandboxed('ViewerLoginDialog', {}, () => {
   });
 
   it('should allow alternative form of return URL', () => {
-    const stub = sandbox
+    const stub = env.sandbox
       .stub(viewer, 'sendMessageAwaitResponse')
       .callsFake(() => Promise.resolve('#success=yes'));
     const url = 'http://acme.com/login?a=b&ret1=RETURN_URL';
@@ -156,7 +150,7 @@ describes.sandboxed('ViewerLoginDialog', {}, () => {
   });
 });
 
-describes.sandboxed('WebLoginDialog', {}, () => {
+describes.sandboxed('WebLoginDialog', {}, env => {
   let clock;
   let viewer;
   let windowApi;
@@ -167,7 +161,7 @@ describes.sandboxed('WebLoginDialog', {}, () => {
   let dialogMock;
 
   beforeEach(() => {
-    clock = sandbox.useFakeTimers();
+    clock = env.sandbox.useFakeTimers();
 
     viewer = {
       getResolvedViewerUrl: () => 'http://localhost:8000/test-login-dialog',
@@ -202,10 +196,10 @@ describes.sandboxed('WebLoginDialog', {}, () => {
     };
     windowApi = windowObj;
     windowApi.document.defaultView = windowApi;
-    windowMock = sandbox.mock(windowApi);
+    windowMock = env.sandbox.mock(windowApi);
     installDocService(windowApi, /* isSingleDoc */ true);
     ampdoc = Services.ampdocServiceFor(windowApi).getSingleDoc();
-    sandbox.stub(ampdoc, 'getParam').returns(null);
+    env.sandbox.stub(ampdoc, 'getParam').returns(null);
 
     dialogUrl = null;
     dialog = {
@@ -217,7 +211,7 @@ describes.sandboxed('WebLoginDialog', {}, () => {
       },
       postMessage: () => {},
     };
-    dialogMock = sandbox.mock(dialog);
+    dialogMock = env.sandbox.mock(dialog);
   });
 
   afterEach(() => {
@@ -236,7 +230,7 @@ describes.sandboxed('WebLoginDialog', {}, () => {
   }
 
   it('should call window.open in the same microtask with url', () => {
-    sandbox.stub(windowApi, 'open').callsFake(() => dialog);
+    env.sandbox.stub(windowApi, 'open').callsFake(() => dialog);
     openLoginDialog(ampdoc, 'http://acme.com/login');
     expect(windowApi.open).to.be.calledOnce;
     expect(windowApi.open.firstCall.args[0]).to.match(
@@ -245,7 +239,7 @@ describes.sandboxed('WebLoginDialog', {}, () => {
   });
 
   it('should call window.open in the same microtask with promise', () => {
-    sandbox.stub(windowApi, 'open').callsFake(() => dialog);
+    env.sandbox.stub(windowApi, 'open').callsFake(() => dialog);
     openLoginDialog(ampdoc, Promise.resolve('http://acme.com/login'));
     expect(windowApi.open).to.be.calledOnce;
     expect(windowApi.open.firstCall.args[0]).to.equal('');
@@ -333,7 +327,7 @@ describes.sandboxed('WebLoginDialog', {}, () => {
     dialogMock
       .expects('postMessage')
       .withExactArgs(
-        sinon.match(arg => {
+        env.sandbox.match(arg => {
           return arg.sentinel == 'amp' && arg.type == 'result-ack';
         }),
         'http://localhost:8000'

--- a/extensions/amp-accordion/0.1/test/test-amp-accordion.js
+++ b/extensions/amp-accordion/0.1/test/test-amp-accordion.js
@@ -417,7 +417,7 @@ describes.realWin(
         const clickEvent = {
           target: headerElements[0],
           currentTarget: headerElements[0],
-          preventDefault: sandbox.spy(),
+          preventDefault: env.sandbox.spy(),
         };
         expect(headerElements[0].parentNode.hasAttribute('expanded')).to.be
           .false;
@@ -443,7 +443,7 @@ describes.realWin(
         const clickEvent = {
           target: child,
           currentTarget: header,
-          preventDefault: sandbox.spy(),
+          preventDefault: env.sandbox.spy(),
         };
         expect(header.parentNode.hasAttribute('expanded')).to.be.false;
         expect(header.getAttribute('aria-expanded')).to.equal('false');
@@ -460,7 +460,7 @@ describes.realWin(
         const clickEvent = {
           target: headerElements[1],
           currentTarget: headerElements[1],
-          preventDefault: sandbox.spy(),
+          preventDefault: env.sandbox.spy(),
         };
         expect(headerElements[1].parentNode.hasAttribute('expanded')).to.be
           .true;
@@ -485,7 +485,7 @@ describes.realWin(
         const aClickEvent = {
           target: a,
           currentTarget: headerElements[0],
-          preventDefault: sandbox.spy(),
+          preventDefault: env.sandbox.spy(),
         };
         ampAccordion.implementation_.clickHandler_(aClickEvent);
         expect(aClickEvent.preventDefault).to.not.have.been.called;
@@ -504,7 +504,7 @@ describes.realWin(
             key: Keys.SPACE,
             target: headerElements[0],
             currentTarget: headerElements[0],
-            preventDefault: sandbox.spy(),
+            preventDefault: env.sandbox.spy(),
           };
           expect(headerElements[0].parentNode.hasAttribute('expanded')).to.be
             .false;
@@ -536,7 +536,7 @@ describes.realWin(
             key: Keys.ENTER,
             target: child,
             currentTarget: headerElements[0],
-            preventDefault: sandbox.spy(),
+            preventDefault: env.sandbox.spy(),
           };
           expect(headerElements[0].parentNode.hasAttribute('expanded')).to.be
             .false;
@@ -566,7 +566,7 @@ describes.realWin(
             key: Keys.ENTER,
             target: headerElements[1],
             currentTarget: headerElements[1],
-            preventDefault: sandbox.spy(),
+            preventDefault: env.sandbox.spy(),
           };
           expect(headerElements[1].parentNode.hasAttribute('expanded')).to.be
             .true;
@@ -599,7 +599,7 @@ describes.realWin(
             key: Keys.UP_ARROW,
             target: headerElements[0],
             currentTarget: headerElements[0],
-            preventDefault: sandbox.spy(),
+            preventDefault: env.sandbox.spy(),
           };
           ampAccordion.implementation_.keyDownHandler_(upArrowEvent);
           expect(doc.activeElement).to.equal(
@@ -609,7 +609,7 @@ describes.realWin(
             key: Keys.DOWN_ARROW,
             target: headerElements[headerElements.length - 1],
             currentTarget: headerElements[headerElements.length - 1],
-            preventDefault: sandbox.spy(),
+            preventDefault: env.sandbox.spy(),
           };
           ampAccordion.implementation_.keyDownHandler_(downArrowEvent);
           expect(doc.activeElement).to.equal(headerElements[0]);
@@ -635,12 +635,12 @@ describes.realWin(
         const clickEventExpandElement = {
           target: headerElements[0],
           currentTarget: headerElements[0],
-          preventDefault: sandbox.spy(),
+          preventDefault: env.sandbox.spy(),
         };
         const clickEventCollapseElement = {
           target: headerElements[1],
           currentTarget: headerElements[1],
-          preventDefault: sandbox.spy(),
+          preventDefault: env.sandbox.spy(),
         };
         expect(Object.keys(impl.currentState_)).to.have.length(0);
         impl.onHeaderPicked_(clickEventExpandElement);
@@ -705,8 +705,8 @@ describes.realWin(
     it('should disable sessionStorage when opt-out', () => {
       return getAmpAccordion().then(ampAccordion => {
         const impl = ampAccordion.implementation_;
-        const setSessionStateSpy = sandbox.spy();
-        const getSessionStateSpy = sandbox.spy();
+        const setSessionStateSpy = env.sandbox.spy();
+        const getSessionStateSpy = env.sandbox.spy();
         impl.win.sessionStorage.setItem = function() {
           setSessionStateSpy();
         };
@@ -721,7 +721,7 @@ describes.realWin(
         const clickEventExpandElement = {
           target: headerElements[0],
           currentTarget: headerElements[0],
-          preventDefault: sandbox.spy(),
+          preventDefault: env.sandbox.spy(),
         };
         impl.onHeaderPicked_(clickEventExpandElement);
         expect(getSessionStateSpy).to.not.have.been.called;
@@ -758,7 +758,7 @@ describes.realWin(
             const clickEventElement = {
               target: headerElements1[0],
               currentTarget: headerElements1[0],
-              preventDefault: sandbox.spy(),
+              preventDefault: env.sandbox.spy(),
             };
             ampAccordion1.implementation_.onHeaderPicked_(clickEventElement);
             const headerElements2 = ampAccordion2.querySelectorAll(
@@ -777,15 +777,15 @@ describes.realWin(
         const impl = ampAccordion.implementation_;
 
         const actions = impl.getActionServiceForTesting();
-        sandbox.stub(actions, 'trigger');
+        env.sandbox.stub(actions, 'trigger');
 
         execute(impl, 'collapse', 123, `acc${counter}sec1`);
 
         expect(actions.trigger).to.be.calledOnce;
         expect(actions.trigger.getCall(0)).to.be.calledWith(
-          /* element */ sinon.match.has('tagName'),
+          /* element */ env.sandbox.match.has('tagName'),
           'collapse',
-          /* event */ sinon.match.has('detail'),
+          /* event */ env.sandbox.match.has('detail'),
           /* trust */ 123
         );
 
@@ -793,9 +793,9 @@ describes.realWin(
 
         expect(actions.trigger).to.be.calledTwice;
         expect(actions.trigger.getCall(1)).to.be.calledWith(
-          /* element */ sinon.match.has('tagName'),
+          /* element */ env.sandbox.match.has('tagName'),
           'expand',
-          /* event */ sinon.match.has('detail'),
+          /* event */ env.sandbox.match.has('detail'),
           /* trust */ 456
         );
       });

--- a/extensions/amp-action-macro/0.1/test/test-amp-action-macro.js
+++ b/extensions/amp-action-macro/0.1/test/test-amp-action-macro.js
@@ -117,7 +117,7 @@ describes.realWin(
       });
 
       it('should register execute action', () => {
-        const registerAction = sandbox.stub(macro, 'registerAction');
+        const registerAction = env.sandbox.stub(macro, 'registerAction');
         macro.buildCallback();
         expect(registerAction).to.have.been.called;
       });
@@ -143,8 +143,8 @@ describes.realWin(
       });
 
       it('should trigger macro action', () => {
-        const actions = {trigger: sandbox.spy()};
-        sandbox.stub(Services, 'actionServiceForDoc').returns(actions);
+        const actions = {trigger: env.sandbox.spy()};
+        env.sandbox.stub(Services, 'actionServiceForDoc').returns(actions);
         const button = doc.createElement('button');
         // Given the caller was called with a valid defined argument alias
         // 'x'.
@@ -165,8 +165,8 @@ describes.realWin(
       });
 
       it('should not allow recursive calls', () => {
-        const actions = {trigger: sandbox.spy()};
-        sandbox.stub(Services, 'actionServiceForDoc').returns(actions);
+        const actions = {trigger: env.sandbox.spy()};
+        env.sandbox.stub(Services, 'actionServiceForDoc').returns(actions);
         // Given the caller is the amp action macro that is also being invoked.
         const callerAction = new ActionInvocation(
           macro,
@@ -186,8 +186,8 @@ describes.realWin(
       });
 
       it('should allow calls to macros defined before itself', () => {
-        const actions = {trigger: sandbox.spy()};
-        sandbox.stub(Services, 'actionServiceForDoc').returns(actions);
+        const actions = {trigger: env.sandbox.spy()};
+        env.sandbox.stub(Services, 'actionServiceForDoc').returns(actions);
         // Given the caller is an amp action macro that was defined before the
         // action macro being invoked.
         const callerAction = new ActionInvocation(
@@ -207,8 +207,8 @@ describes.realWin(
       });
 
       it('should not allow calls to macros defined after itself', () => {
-        const actions = {trigger: sandbox.spy()};
-        sandbox.stub(Services, 'actionServiceForDoc').returns(actions);
+        const actions = {trigger: env.sandbox.spy()};
+        env.sandbox.stub(Services, 'actionServiceForDoc').returns(actions);
         // Given the caller is an amp action macro that was defined after the
         // action macro being invoked.
         const callerAction = new ActionInvocation(

--- a/extensions/amp-ad-custom/0.1/test/test-amp-ad-custom.js
+++ b/extensions/amp-ad-custom/0.1/test/test-amp-ad-custom.js
@@ -73,7 +73,6 @@ describes.realWin('TemplateRenderer', realWinConfig, env => {
   });
 
   afterEach(() => {
-    sandbox.restore();
     doc.body.removeChild(containerElement);
   });
 
@@ -105,10 +104,12 @@ describes.realWin('TemplateRenderer', realWinConfig, env => {
         },
       });
 
-      sandbox.stub(getAmpAdTemplateHelper(env.win), 'fetch').callsFake(url => {
-        expect(url).to.equal(templateUrl);
-        return Promise.resolve(data.adTemplate);
-      });
+      env.sandbox
+        .stub(getAmpAdTemplateHelper(env.win), 'fetch')
+        .callsFake(url => {
+          expect(url).to.equal(templateUrl);
+          return Promise.resolve(data.adTemplate);
+        });
 
       impl.buildCallback();
       impl.getRequestUrl();

--- a/extensions/amp-ad-exit/0.1/test/filters/test-click-delay.js
+++ b/extensions/amp-ad-exit/0.1/test/filters/test-click-delay.js
@@ -23,13 +23,10 @@ describe('click-delay', () => {
     delay: 123,
     startTimingEvent: 'navigationStart',
   };
-  let sandbox;
-  beforeEach(() => (sandbox = sinon.sandbox));
-  afterEach(() => sandbox.restore());
 
   it('should use performance timing', () => {
     const win = {performance: {timing: {'navigationStart': 456}}};
-    sandbox.stub(Date, 'now').returns(123);
+    window.sandbox.stub(Date, 'now').returns(123);
     expect(
       new ClickDelayFilter('foo', DEFAULT_CONFIG, win).intervalStart
     ).to.equal(456);
@@ -60,7 +57,7 @@ describe('click-delay', () => {
               ).to.throw(win.err)
             );
           } else {
-            sandbox.stub(Date, 'now').returns(123);
+            window.sandbox.stub(Date, 'now').returns(123);
             expect(
               new ClickDelayFilter('foo', test.config, test.win).intervalStart
             ).to.equal(123);
@@ -75,7 +72,7 @@ describe('click-delay', () => {
       const filter = new ClickDelayFilter('foo', DEFAULT_CONFIG, {
         performance: {timing: {navigationStart: 1}},
       });
-      const nowStub = sandbox.stub(Date, 'now');
+      const nowStub = window.sandbox.stub(Date, 'now');
       nowStub.onFirstCall().returns(1001);
       expect(filter.filter()).to.be.true;
     });
@@ -84,7 +81,7 @@ describe('click-delay', () => {
       const filter = new ClickDelayFilter('foo', DEFAULT_CONFIG, {
         performance: {timing: {navigationStart: 1}},
       });
-      const nowStub = sandbox.stub(Date, 'now');
+      const nowStub = window.sandbox.stub(Date, 'now');
       nowStub.onFirstCall().returns(1);
       nowStub.onSecondCall().returns(125);
       expect(filter.filter()).to.be.false;

--- a/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
@@ -67,13 +67,13 @@ describes.realWin(
       win = env.win;
       doc = win.document;
       ampdoc = env.ampdoc;
-      sandbox
+      env.sandbox
         .stub(AmpAdNetworkAdsenseImpl.prototype, 'getSigningServiceNames')
         .callsFake(() => {
           return ['google'];
         });
       viewer = win.__AMP_SERVICES.viewer.obj;
-      sandbox
+      env.sandbox
         .stub(viewer, 'getReferrerUrl')
         .callsFake(() => Promise.resolve('https://acme.org/'));
       element = createAdsenseImplElement(
@@ -85,11 +85,11 @@ describes.realWin(
         },
         doc
       );
-      sandbox.stub(element, 'tryUpgrade_').callsFake(() => {});
+      env.sandbox.stub(element, 'tryUpgrade_').callsFake(() => {});
       doc.body.appendChild(element);
       impl = new AmpAdNetworkAdsenseImpl(element);
       impl.win['goog_identity_prom'] = Promise.resolve({});
-      sandbox.stub(Services, 'timerFor').returns({
+      env.sandbox.stub(Services, 'timerFor').returns({
         timeoutPromise: (unused, promise) => {
           if (promise) {
             return promise;
@@ -116,7 +116,7 @@ describes.realWin(
       // amp-ad.
       const iframe = doc.createElement('iframe');
       element.appendChild(iframe);
-      sandbox.stub(element, 'tryUpgrade_').callsFake(() => {});
+      env.sandbox.stub(element, 'tryUpgrade_').callsFake(() => {});
       doc.body.appendChild(element);
       impl = new AmpAdNetworkAdsenseImpl(element);
       impl.buildCallback();
@@ -201,9 +201,9 @@ describes.realWin(
           'layout': 'fixed',
         });
         impl = new AmpAdNetworkAdsenseImpl(element);
-        sandbox.stub(impl, 'getAmpDoc').callsFake(() => ampdoc);
+        env.sandbox.stub(impl, 'getAmpDoc').callsFake(() => ampdoc);
         const extensions = Services.extensionsFor(impl.win);
-        preloadExtensionSpy = sandbox.spy(extensions, 'preloadExtension');
+        preloadExtensionSpy = env.sandbox.spy(extensions, 'preloadExtension');
       });
 
       it('without analytics', () => {
@@ -276,8 +276,10 @@ describes.realWin(
         impl = new AmpAdNetworkAdsenseImpl(element);
         impl.getA4aAnalyticsConfig = () => {};
         impl.buildCallback();
-        sandbox.stub(impl, 'getAmpDoc').callsFake(() => ampdoc);
-        sandbox.stub(env.ampdocService, 'getAmpDoc').callsFake(() => ampdoc);
+        env.sandbox.stub(impl, 'getAmpDoc').callsFake(() => ampdoc);
+        env.sandbox
+          .stub(env.ampdocService, 'getAmpDoc')
+          .callsFake(() => ampdoc);
       });
 
       [true, false].forEach(exp => {
@@ -377,13 +379,13 @@ describes.realWin(
         const ev1 = new Event('click', {bubbles: true});
         ev1.pageX = 10;
         ev1.pageY = 20;
-        sandbox.stub(impl, 'getResource').returns({
+        env.sandbox.stub(impl, 'getResource').returns({
           getUpgradeDelayMs: () => 1,
         });
 
         // Make sure the ad iframe (FIE) has a local URL replacements service.
         const urlReplacements = Services.urlReplacementsForDoc(element);
-        sandbox
+        env.sandbox
           .stub(Services, 'urlReplacementsForDoc')
           .withArgs(a)
           .returns(urlReplacements);
@@ -416,7 +418,7 @@ describes.realWin(
         const ev1 = new Event('click', {bubbles: true});
         ev1.pageX = 10;
         ev1.pageY = 20;
-        sandbox.stub(impl, 'getResource').returns({
+        env.sandbox.stub(impl, 'getResource').returns({
           getUpgradeDelayMs: () => 1,
         });
         impl.buildCallback();
@@ -447,7 +449,7 @@ describes.realWin(
           promiseResolver = resolve;
         });
         const storageContent = {};
-        sandbox.stub(storage, 'set').callsFake((key, value) => {
+        env.sandbox.stub(storage, 'set').callsFake((key, value) => {
           storageContent[key] = value;
           promiseResolver();
           return Promise.resolve();
@@ -669,7 +671,7 @@ describes.realWin(
           .then(url => expect(url).to.match(/eid=[^&]*21062003/));
       });
       it('returns the right URL', () => {
-        sandbox.stub(impl, 'isXhrAllowed').returns(true);
+        env.sandbox.stub(impl, 'isXhrAllowed').returns(true);
         element.setAttribute('data-ad-slot', 'some_slot');
         element.setAttribute('data-language', 'lxz');
         return impl.getAdUrl().then(url => {
@@ -736,7 +738,7 @@ describes.realWin(
           });
         });
         it('sets appropriate is_amp for canonical', () => {
-          sandbox.stub(impl, 'isXhrAllowed').returns(false);
+          env.sandbox.stub(impl, 'isXhrAllowed').returns(false);
           return expect(impl.getAdUrl()).to.eventually.match(
             /(\?|&)is_amp=5(&|$)/
           );
@@ -1009,7 +1011,7 @@ describes.realWin(
           const storage = await Services.storageForDoc(doc);
           const storageContent = {'aas-ca-adsense': true};
 
-          sandbox.stub(storage, 'get').callsFake(key => {
+          env.sandbox.stub(storage, 'get').callsFake(key => {
             return Promise.resolve(storageContent[key]);
           });
         });
@@ -1083,7 +1085,7 @@ describes.realWin(
           const storage = await Services.storageForDoc(doc);
           const storageContent = {'aas-ca-adsense': false};
 
-          sandbox.stub(storage, 'get').callsFake(key => {
+          env.sandbox.stub(storage, 'get').callsFake(key => {
             return Promise.resolve(storageContent[key]);
           });
         });
@@ -1234,7 +1236,7 @@ describes.realWin(
 
     describe('#preconnect', () => {
       it('should preload nameframe', () => {
-        const preloadSpy = sandbox.spy(Preconnect.prototype, 'preload');
+        const preloadSpy = env.sandbox.spy(Preconnect.prototype, 'preload');
         expect(impl.getPreconnectUrls()).to.deep.equal([
           'https://googleads.g.doubleclick.net',
         ]);
@@ -1269,7 +1271,7 @@ describes.realWin(
 
     describe('#checksumVerification', () => {
       it('should call super if missing Algorithm header', () => {
-        sandbox
+        env.sandbox
           .stub(AmpA4A.prototype, 'maybeValidateAmpCreative')
           .returns(Promise.resolve('foo'));
         const creative = '<html><body>This is some text</body></html>';

--- a/extensions/amp-ad-network-adsense-impl/0.1/test/test-responsive-state.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/test/test-responsive-state.js
@@ -66,10 +66,10 @@ describes.realWin(
       };
       const storage = await Services.storageForDoc(doc);
       storageContent = {};
-      sandbox.stub(storage, 'get').callsFake(key => {
+      env.sandbox.stub(storage, 'get').callsFake(key => {
         return Promise.resolve(storageContent[key]);
       });
-      sandbox.stub(storage, 'set').callsFake((key, value) => {
+      env.sandbox.stub(storage, 'set').callsFake((key, value) => {
         storageContent[key] = value;
         return Promise.resolve();
       });

--- a/extensions/amp-ad-network-adzerk-impl/0.1/test/test-amp-ad-network-adzerk-impl.js
+++ b/extensions/amp-ad-network-adzerk-impl/0.1/test/test-amp-ad-network-adzerk-impl.js
@@ -38,7 +38,7 @@ describes.fakeWin('amp-ad-network-adzerk-impl', {amp: true}, env => {
     win.__AMP_MODE = {localDev: false};
     win.AMP.registerTemplate('amp-mustache', AmpMustache);
     doc = win.document;
-    fetchTextMock = sandbox.stub(Xhr.prototype, 'fetchText');
+    fetchTextMock = env.sandbox.stub(Xhr.prototype, 'fetchText');
     element = createElementWithAttributes(doc, 'amp-ad', {
       'type': 'adzerk',
       'width': '320',

--- a/extensions/amp-ad-network-cloudflare-impl/0.1/test/test-amp-ad-network-cloudflare-impl.js
+++ b/extensions/amp-ad-network-cloudflare-impl/0.1/test/test-amp-ad-network-cloudflare-impl.js
@@ -76,12 +76,12 @@ describes.realWin(
       el.setAttribute('type', 'cloudflare');
       el.setAttribute('data-cf-network', 'cloudflare');
       el.setAttribute('src', 'https://firebolt.cloudflaredemo.com/a4a-ad.html');
-      sandbox
+      env.sandbox
         .stub(AmpAdNetworkCloudflareImpl.prototype, 'getSigningServiceNames')
         .callsFake(() => {
           return ['cloudflare', 'cloudflare-dev'];
         });
-      sandbox.stub(vendors, 'NETWORKS').callsFake({
+      env.sandbox.stub(vendors, 'NETWORKS').callsFake({
         cloudflare: {
           base: 'https://firebolt.cloudflaredemo.com',
         },
@@ -92,7 +92,7 @@ describes.realWin(
             'https://cf-test.com/path/ad?width=SLOT_WIDTH&height=SLOT_HEIGHT',
         },
       });
-      sandbox.stub(el, 'tryUpgrade_').callsFake(() => {});
+      env.sandbox.stub(el, 'tryUpgrade_').callsFake(() => {});
       doc.body.appendChild(el);
       cloudflareImpl = new AmpAdNetworkCloudflareImpl(el);
     });

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -155,10 +155,10 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
         'layout': 'fixed',
       });
       impl = new AmpAdNetworkDoubleclickImpl(element);
-      sandbox.stub(impl, 'getAmpDoc').callsFake(() => ampdoc);
+      env.sandbox.stub(impl, 'getAmpDoc').callsFake(() => ampdoc);
       impl.size_ = size;
       const extensions = Services.extensionsFor(impl.win);
-      preloadExtensionSpy = sandbox.spy(extensions, 'preloadExtension');
+      preloadExtensionSpy = env.sandbox.spy(extensions, 'preloadExtension');
     });
 
     afterEach(() => {
@@ -168,7 +168,7 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
     it('should ignore creative-size header for fluid response', () => {
       impl.isFluid_ = true;
       impl.element.setAttribute('height', 'fluid');
-      const resizeSpy = sandbox.spy(impl, 'attemptChangeSize');
+      const resizeSpy = env.sandbox.spy(impl, 'attemptChangeSize');
       expect(
         impl.extractSize({
           get(name) {
@@ -240,7 +240,7 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
       );
     });
     it('should not load delayed impression amp-pixels with fluid + multi-size', () => {
-      sandbox.stub(impl, 'handleResize_');
+      env.sandbox.stub(impl, 'handleResize_');
       impl.isFluid_ = true;
       expect(
         impl.extractSize({
@@ -262,11 +262,11 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
       expect(impl.fluidImpressionUrl_).to.not.be.ok;
     });
     it('should consume pageview state tokens when header is present', () => {
-      const removePageviewStateTokenSpy = sandbox.spy(
+      const removePageviewStateTokenSpy = env.sandbox.spy(
         impl,
         'removePageviewStateToken'
       );
-      const setPageviewStateTokenSpy = sandbox.spy(
+      const setPageviewStateTokenSpy = env.sandbox.spy(
         impl,
         'setPageviewStateToken'
       );
@@ -384,16 +384,18 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
         } else {
           impl.paramterSize = '200x50';
         }
-        sandbox.stub(impl, 'attemptChangeSize').callsFake((height, width) => {
-          impl.element.style.width = `${width}px`;
-          return {
-            catch: () => {},
-          };
-        });
-        sandbox.stub(impl, 'getViewport').callsFake(() => ({
+        env.sandbox
+          .stub(impl, 'attemptChangeSize')
+          .callsFake((height, width) => {
+            impl.element.style.width = `${width}px`;
+            return {
+              catch: () => {},
+            };
+          });
+        env.sandbox.stub(impl, 'getViewport').callsFake(() => ({
           getRect: () => ({width: 400}),
         }));
-        sandbox.stub(impl.element, 'getPageLayoutBox').callsFake(() => ({
+        env.sandbox.stub(impl.element, 'getPageLayoutBox').callsFake(() => ({
           left: 25,
           right: 25,
         }));
@@ -438,23 +440,25 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
       impl = new AmpAdNetworkDoubleclickImpl(element);
       impl.getA4aAnalyticsConfig = () => {};
       impl.buildCallback();
-      sandbox.stub(impl, 'getAmpDoc').callsFake(() => ampdoc);
-      sandbox.stub(env.ampdocService, 'getAmpDoc').callsFake(() => ampdoc);
+      env.sandbox.stub(impl, 'getAmpDoc').callsFake(() => ampdoc);
+      env.sandbox.stub(env.ampdocService, 'getAmpDoc').callsFake(() => ampdoc);
       // Next two lines are to ensure that internal parts not relevant for this
       // test are properly set.
       impl.size_ = {width: 200, height: 50};
       impl.iframe = impl.win.document.createElement('iframe');
       // Temporary fix for local test failure.
-      sandbox.stub(impl, 'getIntersectionElementLayoutBox').callsFake(() => {
-        return {
-          top: 0,
-          bottom: 0,
-          left: 0,
-          right: 0,
-          width: 320,
-          height: 50,
-        };
-      });
+      env.sandbox
+        .stub(impl, 'getIntersectionElementLayoutBox')
+        .callsFake(() => {
+          return {
+            top: 0,
+            bottom: 0,
+            left: 0,
+            right: 0,
+            width: 320,
+            height: 50,
+          };
+        });
     });
 
     [true, false].forEach(exp => {
@@ -548,13 +552,13 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
       const ev1 = new Event('click', {bubbles: true});
       ev1.pageX = 10;
       ev1.pageY = 20;
-      sandbox.stub(impl, 'getResource').returns({
+      env.sandbox.stub(impl, 'getResource').returns({
         getUpgradeDelayMs: () => 1,
       });
 
       // Make sure the ad iframe (FIE) has a local URL replacements service.
       const urlReplacements = Services.urlReplacementsForDoc(element);
-      sandbox
+      env.sandbox
         .stub(Services, 'urlReplacementsForDoc')
         .withArgs(a)
         .returns(urlReplacements);
@@ -587,7 +591,7 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
       const ev1 = new Event('click', {bubbles: true});
       ev1.pageX = 10;
       ev1.pageY = 20;
-      sandbox.stub(impl, 'getResource').returns({
+      env.sandbox.stub(impl, 'getResource').returns({
         getUpgradeDelayMs: () => 1,
       });
       impl.buildCallback();
@@ -612,7 +616,6 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
 
   describe('#getAdUrl', () => {
     beforeEach(() => {
-      const {sandbox} = env;
       element = doc.createElement('amp-ad');
       element.setAttribute('type', 'doubleclick');
       element.setAttribute('data-ad-client', 'doubleclick');
@@ -621,20 +624,22 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
       doc.body.appendChild(element);
       impl = new AmpAdNetworkDoubleclickImpl(element);
       // Temporary fix for local test failure.
-      sandbox.stub(impl, 'getIntersectionElementLayoutBox').callsFake(() => {
-        return {
-          top: 0,
-          bottom: 0,
-          left: 0,
-          right: 0,
-          width: 320,
-          height: 50,
-        };
-      });
+      window.sandbox
+        .stub(impl, 'getIntersectionElementLayoutBox')
+        .callsFake(() => {
+          return {
+            top: 0,
+            bottom: 0,
+            left: 0,
+            right: 0,
+            width: 320,
+            height: 50,
+          };
+        });
 
       // Reproduced from noopMethods in ads/google/a4a/test/test-utils.js,
       // to fix failures when this is run after 'gulp build', without a 'dist'.
-      sandbox.stub(impl, 'getPageLayoutBox').callsFake(() => {
+      window.sandbox.stub(impl, 'getPageLayoutBox').callsFake(() => {
         return {
           top: 11,
           left: 12,
@@ -656,7 +661,7 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
     it('returns the right URL', () => {
       const viewer = Services.viewerForDoc(element);
       // inabox-viewer.getReferrerUrl() returns Promise<string>.
-      sandbox
+      env.sandbox
         .stub(viewer, 'getReferrerUrl')
         .returns(Promise.resolve('http://fake.example/?foo=bar'));
 
@@ -870,7 +875,7 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
       // Reset counter for purpose of this test.
       delete env.win['ampAdGoogleIfiCounter'];
       new AmpAd(element).upgradeCallback();
-      sandbox.stub(AmpA4A.prototype, 'tearDownSlot').callsFake(() => {});
+      env.sandbox.stub(AmpA4A.prototype, 'tearDownSlot').callsFake(() => {});
       return impl.getAdUrl().then(url1 => {
         expect(url1).to.match(/ifi=1/);
         impl.tearDownSlot();
@@ -884,7 +889,7 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
       });
     });
     it('should have google_preview parameter', () => {
-      sandbox
+      env.sandbox
         .stub(impl, 'getLocationQueryParameterValue')
         .withArgs('google_preview')
         .returns('abcdef');
@@ -902,15 +907,21 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
       // We don't really care about the behavior of the following methods, so
       // we'll just stub them out so that refresh() can run without tripping any
       // unrelated errors.
-      sandbox
+      env.sandbox
         .stub(AmpA4A.prototype, 'initiateAdRequest')
         .callsFake(() => (impl.adPromise_ = Promise.resolve()));
-      const tearDownSlotMock = sandbox.stub(AmpA4A.prototype, 'tearDownSlot');
+      const tearDownSlotMock = env.sandbox.stub(
+        AmpA4A.prototype,
+        'tearDownSlot'
+      );
       tearDownSlotMock.returns(undefined);
-      const destroyFrameMock = sandbox.stub(AmpA4A.prototype, 'destroyFrame');
+      const destroyFrameMock = env.sandbox.stub(
+        AmpA4A.prototype,
+        'destroyFrame'
+      );
       destroyFrameMock.returns(undefined);
       impl.mutateElement = func => func();
-      impl.togglePlaceholder = sandbox.spy();
+      impl.togglePlaceholder = env.sandbox.spy();
       impl.win.document.win = impl.win;
       impl.getAmpDoc = () => impl.win.document;
       impl.getResource = () => {
@@ -986,7 +997,7 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
       }));
 
     it('should include msz/psz/fws if in holdback control', () => {
-      sandbox
+      env.sandbox
         .stub(impl, 'randomlySelectUnsetExperiments_')
         .returns({flexAdSlots: '21063173'});
       impl.setPageLevelExperiments();
@@ -999,7 +1010,7 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
     });
 
     it('should not include msz/psz if not in holdback experiment', () => {
-      sandbox
+      env.sandbox
         .stub(impl, 'randomlySelectUnsetExperiments_')
         .returns({flexAdSlots: '21063174'});
       impl.setPageLevelExperiments();
@@ -1037,8 +1048,6 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
   });
 
   describe('#unlayoutCallback', () => {
-    let sandbox;
-
     beforeEach(() => {
       const setup = createImplTag(
         {
@@ -1064,10 +1073,9 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
       impl.element.appendChild(placeholder);
       impl.element.appendChild(fallback);
       impl.size_ = {width: 123, height: 456};
-      sandbox = sinon.sandbox;
     });
 
-    afterEach(() => sandbox.restore());
+    afterEach(() => env.sandbox.restore());
 
     it('should reset state to null on non-FIE unlayoutCallback', () => {
       impl.onCreativeRender();
@@ -1105,7 +1113,7 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
 
     it('should call #unobserve on refreshManager', () => {
       impl.refreshManager_ = {
-        unobserve: sandbox.spy(),
+        unobserve: env.sandbox.spy(),
       };
       impl.unlayoutCallback();
       expect(impl.refreshManager_.unobserve).to.be.calledOnce;
@@ -1151,7 +1159,7 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
      * it has an AMP creative.
      */
     function stubForAmpCreative() {
-      sandbox
+      env.sandbox
         .stub(signatureVerifierFor(impl.win), 'verify')
         .callsFake(() => Promise.resolve(VerificationStatus.OK));
     }
@@ -1199,8 +1207,10 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
       impl.initialSize_ = {width: 200, height: 50};
 
       // Boilerplate stubbing
-      sandbox.stub(impl, 'shouldInitializePromiseChain_').callsFake(() => true);
-      sandbox.stub(impl, 'getPageLayoutBox').callsFake(() => {
+      env.sandbox
+        .stub(impl, 'shouldInitializePromiseChain_')
+        .callsFake(() => true);
+      env.sandbox.stub(impl, 'getPageLayoutBox').callsFake(() => {
         return {
           top: 0,
           bottom: 0,
@@ -1210,18 +1220,18 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
           height: 50,
         };
       });
-      sandbox.stub(impl, 'attemptChangeSize').callsFake((height, width) => {
+      env.sandbox.stub(impl, 'attemptChangeSize').callsFake((height, width) => {
         impl.element.style.height = `${height}px`;
         impl.element.style.width = `${width}px`;
         return Promise.resolve();
       });
-      sandbox.stub(impl, 'getAmpAdMetadata').callsFake(() => {
+      env.sandbox.stub(impl, 'getAmpAdMetadata').callsFake(() => {
         return {
           customElementExtensions: [],
           minifiedCreative: '<html><body>Hello, World!</body></html>',
         };
       });
-      sandbox.stub(impl, 'updateLayoutPriority').callsFake(() => {});
+      env.sandbox.stub(impl, 'updateLayoutPriority').callsFake(() => {});
 
       const keyResponse = {
         body: {'keys': []},
@@ -1239,11 +1249,11 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
 
     it('amp creative - should force iframe to match size of creative', () => {
       stubForAmpCreative();
-      sandbox
+      env.sandbox
         .stub(impl, 'sendXhrRequest')
         .returns(mockSendXhrRequest('150x50', true));
       // Stub ini load otherwise FIE could delay test
-      sandbox
+      env.sandbox
         ./*OK*/ stub(FriendlyIframeEmbed.prototype, 'whenIniLoaded')
         .returns(Promise.resolve());
       impl.buildCallback();
@@ -1257,7 +1267,7 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
     });
 
     it('should force iframe to match size of creative', () => {
-      sandbox
+      env.sandbox
         .stub(impl, 'sendXhrRequest')
         .returns(mockSendXhrRequest('150x50', false));
       impl.buildCallback();
@@ -1272,16 +1282,16 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
 
     it('amp creative - should force iframe to match size of slot', () => {
       stubForAmpCreative();
-      sandbox
+      env.sandbox
         .stub(impl, 'sendXhrRequest')
         .callsFake(() => mockSendXhrRequest(undefined, true));
-      sandbox
+      env.sandbox
         .stub(impl, 'renderViaIframeGet_')
         .callsFake(() =>
           impl.iframeRenderHelper_({src: impl.adUrl_, name: 'name'})
         );
       // Stub ini load otherwise FIE could delay test
-      sandbox
+      env.sandbox
         ./*OK*/ stub(FriendlyIframeEmbed.prototype, 'whenIniLoaded')
         .returns(Promise.resolve());
       // This would normally be set in AmpA4a#buildCallback.
@@ -1297,10 +1307,10 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
     });
 
     it('should force iframe to match size of slot', () => {
-      sandbox
+      env.sandbox
         .stub(impl, 'sendXhrRequest')
         .callsFake(() => mockSendXhrRequest(undefined, false));
-      sandbox
+      env.sandbox
         .stub(impl, 'renderViaIframeGet_')
         .callsFake(() =>
           impl.iframeRenderHelper_({src: impl.adUrl_, name: 'name'})
@@ -1319,12 +1329,12 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
 
     it('should issue an ad request even with bad multi-size data attr', () => {
       stubForAmpCreative();
-      sandbox
+      env.sandbox
         .stub(impl, 'sendXhrRequest')
         .callsFake(() => mockSendXhrRequest(undefined, true));
       impl.element.setAttribute('data-multi-size', '201x50');
       // Stub ini load otherwise FIE could delay test
-      sandbox
+      env.sandbox
         ./*OK*/ stub(FriendlyIframeEmbed.prototype, 'whenIniLoaded')
         .returns(Promise.resolve());
       impl.buildCallback();
@@ -1393,7 +1403,7 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
           },
         },
       };
-      const postMessageSpy = sandbox.spy(env.win.opener, 'postMessage');
+      const postMessageSpy = env.sandbox.spy(env.win.opener, 'postMessage');
       impl.win = env.win;
       return impl
         .postTroubleshootMessage()
@@ -1589,8 +1599,10 @@ describes.realWin(
         });
         impl = new AmpAdNetworkDoubleclickImpl(element);
         impl.getAmpDoc = () => env.ampdoc;
-        isSecureStub = sandbox.stub();
-        sandbox.stub(Services, 'urlForDoc').returns({isSecure: isSecureStub});
+        isSecureStub = env.sandbox.stub();
+        env.sandbox
+          .stub(Services, 'urlForDoc')
+          .returns({isSecure: isSecureStub});
       });
 
       it('should handle null impressions', () => {
@@ -1652,7 +1664,7 @@ describes.realWin(
           'type': 'doubleclick',
         });
         impl = new AmpAdNetworkDoubleclickImpl(element);
-        sandbox
+        env.sandbox
           .stub(impl, 'getResource')
           .returns({whenWithinViewport: () => Promise.resolve()});
       });
@@ -1683,7 +1695,7 @@ describes.realWin(
       });
 
       it('should return renderOutsideViewport boolean', () => {
-        sandbox.stub(impl, 'renderOutsideViewport').returns(false);
+        env.sandbox.stub(impl, 'renderOutsideViewport').returns(false);
         expect(impl.idleRenderOutsideViewport()).to.be.false;
       });
     });
@@ -1698,7 +1710,7 @@ describes.realWin(
         impl = new AmpAdNetworkDoubleclickImpl(element);
         impl.postAdResponseExperimentFeatures['render-idle-vp'] = '4';
         impl.postAdResponseExperimentFeatures['render-idle-throttle'] = 'true';
-        sandbox
+        env.sandbox
           .stub(AmpA4A.prototype, 'renderNonAmpCreative')
           .returns(Promise.resolve());
       });
@@ -1760,16 +1772,16 @@ describes.realWin(
       let randomlySelectUnsetExperimentsStub;
       let extractUrlExperimentIdStub;
       beforeEach(() => {
-        randomlySelectUnsetExperimentsStub = sandbox.stub(
+        randomlySelectUnsetExperimentsStub = env.sandbox.stub(
           impl,
           'randomlySelectUnsetExperiments_'
         );
-        extractUrlExperimentIdStub = sandbox.stub(
+        extractUrlExperimentIdStub = env.sandbox.stub(
           impl,
           'extractUrlExperimentId_'
         );
-        sandbox.stub(AmpA4A.prototype, 'buildCallback').callsFake(() => {});
-        sandbox.stub(impl, 'getAmpDoc').returns({
+        env.sandbox.stub(AmpA4A.prototype, 'buildCallback').callsFake(() => {});
+        env.sandbox.stub(impl, 'getAmpDoc').returns({
           whenFirstVisible: () => new Deferred().promise,
         });
       });
@@ -1863,7 +1875,7 @@ describes.realWin(
 
     describe('#checksumVerification', () => {
       it('should call super if missing Algorithm header', () => {
-        sandbox
+        env.sandbox
           .stub(AmpA4A.prototype, 'maybeValidateAmpCreative')
           .returns(Promise.resolve('foo'));
         const creative = '<html><body>This is some text</body></html>';

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-fluid.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-fluid.js
@@ -98,12 +98,10 @@ describes.realWin('DoubleClick Fast Fetch Fluid', realWinConfig, env => {
   let multiSizeImpl;
   let element;
   let multiSizeElement;
-  let sandbox;
 
   const initialSize = {width: 0, height: 0};
 
   beforeEach(() => {
-    sandbox = env.sandbox;
     env.win.__AMP_MODE.test = true;
     const doc = env.win.document;
     // TODO(a4a-cam@): This is necessary in the short term, until A4A is
@@ -146,7 +144,6 @@ describes.realWin('DoubleClick Fast Fetch Fluid', realWinConfig, env => {
   });
 
   afterEach(() => {
-    sandbox.restore();
     removeSafeframeListener();
     impl.cleanupAfterTest();
     impl = null;
@@ -166,7 +163,7 @@ describes.realWin('DoubleClick Fast Fetch Fluid', realWinConfig, env => {
   });
 
   it('should NOT load delayed impression amp-pixels', () => {
-    const fireDelayedImpressionsSpy = sandbox.spy(
+    const fireDelayedImpressionsSpy = env.sandbox.spy(
       impl,
       'fireDelayedImpressions'
     );
@@ -234,12 +231,12 @@ describes.realWin('DoubleClick Fast Fetch Fluid', realWinConfig, env => {
   });
 
   it('should fire delayed impression ping', () => {
-    createScaffoldingForFluidRendering(impl, sandbox);
-    const connectMessagingChannelSpy = sandbox./*OK*/ spy(
+    createScaffoldingForFluidRendering(impl, env.sandbox);
+    const connectMessagingChannelSpy = env.sandbox./*OK*/ spy(
       impl.safeframeApi_,
       'connectMessagingChannel'
     );
-    const onFluidResizeSpy = sandbox./*OK*/ spy(
+    const onFluidResizeSpy = env.sandbox./*OK*/ spy(
       impl.safeframeApi_,
       'onFluidResize_'
     );
@@ -252,12 +249,12 @@ describes.realWin('DoubleClick Fast Fetch Fluid', realWinConfig, env => {
   });
 
   it('should fire delayed impression ping, if creative partly visible', () => {
-    createScaffoldingForFluidRendering(impl, sandbox, false);
-    const connectMessagingChannelSpy = sandbox./*OK*/ spy(
+    createScaffoldingForFluidRendering(impl, env.sandbox, false);
+    const connectMessagingChannelSpy = env.sandbox./*OK*/ spy(
       impl.safeframeApi_,
       'connectMessagingChannel'
     );
-    const onFluidResizeSpy = sandbox./*OK*/ spy(
+    const onFluidResizeSpy = env.sandbox./*OK*/ spy(
       impl.safeframeApi_,
       'onFluidResize_'
     );
@@ -273,7 +270,7 @@ describes.realWin('DoubleClick Fast Fetch Fluid', realWinConfig, env => {
   });
 
   it('should set height on iframe', () => {
-    createScaffoldingForFluidRendering(impl, sandbox);
+    createScaffoldingForFluidRendering(impl, env.sandbox);
     return impl.adPromise_.then(() => {
       return impl.layoutCallback().then(() => {
         expect(impl.iframe.style.height).to.equal('250px');
@@ -284,9 +281,12 @@ describes.realWin('DoubleClick Fast Fetch Fluid', realWinConfig, env => {
   it('should fire impression for AMP fluid creative', () => {
     impl.iframe = impl.win.document.createElement('iframe');
     impl.win.document.body.appendChild(impl.iframe);
-    sandbox.stub(impl, 'setCssPosition_').returns(mockPromise);
-    sandbox.stub(impl, 'attemptChangeHeight').returns(mockPromise);
-    const delayedImpressionSpy = sandbox.spy(impl, 'fireDelayedImpressions');
+    env.sandbox.stub(impl, 'setCssPosition_').returns(mockPromise);
+    env.sandbox.stub(impl, 'attemptChangeHeight').returns(mockPromise);
+    const delayedImpressionSpy = env.sandbox.spy(
+      impl,
+      'fireDelayedImpressions'
+    );
     impl.buildCallback();
     impl.isFluidRequest_ = true;
     impl.isVerifiedAmpCreative_ = true;
@@ -299,9 +299,12 @@ describes.realWin('DoubleClick Fast Fetch Fluid', realWinConfig, env => {
   it('should fire impression for AMP fluid creative, if partly visible', () => {
     impl.iframe = impl.win.document.createElement('iframe');
     impl.win.document.body.appendChild(impl.iframe);
-    sandbox.stub(impl, 'setCssPosition_').returns(Promise.resolve());
-    sandbox.stub(impl, 'attemptChangeHeight').returns(Promise.reject());
-    const delayedImpressionSpy = sandbox.spy(impl, 'fireDelayedImpressions');
+    env.sandbox.stub(impl, 'setCssPosition_').returns(Promise.resolve());
+    env.sandbox.stub(impl, 'attemptChangeHeight').returns(Promise.reject());
+    const delayedImpressionSpy = env.sandbox.spy(
+      impl,
+      'fireDelayedImpressions'
+    );
     impl.buildCallback();
     impl.isFluidRequest_ = true;
     impl.isVerifiedAmpCreative_ = true;
@@ -318,9 +321,12 @@ describes.realWin('DoubleClick Fast Fetch Fluid', realWinConfig, env => {
   it('should not fire impression for AMP fluid creative', () => {
     impl.iframe = impl.win.document.createElement('iframe');
     impl.win.document.body.appendChild(impl.iframe);
-    sandbox.stub(impl, 'setCssPosition_').returns(Promise.resolve());
-    sandbox.stub(impl, 'attemptChangeHeight').returns(Promise.reject());
-    const delayedImpressionSpy = sandbox.spy(impl, 'fireDelayedImpressions');
+    env.sandbox.stub(impl, 'setCssPosition_').returns(Promise.resolve());
+    env.sandbox.stub(impl, 'attemptChangeHeight').returns(Promise.reject());
+    const delayedImpressionSpy = env.sandbox.spy(
+      impl,
+      'fireDelayedImpressions'
+    );
     impl.buildCallback();
     impl.isFluidRequest_ = true;
     impl.isVerifiedAmpCreative_ = true;
@@ -333,10 +339,15 @@ describes.realWin('DoubleClick Fast Fetch Fluid', realWinConfig, env => {
   it('should set expansion re-attempt flag after initial failure', () => {
     impl.iframe = impl.win.document.createElement('iframe');
     impl.win.document.body.appendChild(impl.iframe);
-    const attemptChangeHeightStub = sandbox.stub(impl, 'attemptChangeHeight');
+    const attemptChangeHeightStub = env.sandbox.stub(
+      impl,
+      'attemptChangeHeight'
+    );
     attemptChangeHeightStub.returns(Promise.reject());
-    sandbox.stub(impl, 'setCssPosition_').returns(Promise.resolve());
-    sandbox.stub(impl, 'attemptToRenderCreative').returns(Promise.resolve());
+    env.sandbox.stub(impl, 'setCssPosition_').returns(Promise.resolve());
+    env.sandbox
+      .stub(impl, 'attemptToRenderCreative')
+      .returns(Promise.resolve());
     impl.buildCallback();
     impl.isFluidRequest_ = true;
     impl.isVerifiedAmpCreative_ = true;
@@ -349,10 +360,15 @@ describes.realWin('DoubleClick Fast Fetch Fluid', realWinConfig, env => {
   it('should re-attempt expansion after initial failure', () => {
     impl.iframe = impl.win.document.createElement('iframe');
     impl.win.document.body.appendChild(impl.iframe);
-    const attemptChangeHeightStub = sandbox.stub(impl, 'attemptChangeHeight');
+    const attemptChangeHeightStub = env.sandbox.stub(
+      impl,
+      'attemptChangeHeight'
+    );
     attemptChangeHeightStub.returns(Promise.resolve());
-    sandbox.stub(impl, 'attemptToRenderCreative').returns(Promise.resolve());
-    sandbox.stub(impl, 'setCssPosition_').returns(mockPromise);
+    env.sandbox
+      .stub(impl, 'attemptToRenderCreative')
+      .returns(Promise.resolve());
+    env.sandbox.stub(impl, 'setCssPosition_').returns(mockPromise);
     impl.buildCallback();
     impl.isFluidRequest_ = true;
     impl.isVerifiedAmpCreative_ = true;
@@ -367,15 +383,20 @@ describes.realWin('DoubleClick Fast Fetch Fluid', realWinConfig, env => {
   it('should set position: static when measuring height on AMP fluid', () => {
     impl.iframe = impl.win.document.createElement('iframe');
     impl.win.document.body.appendChild(impl.iframe);
-    const attemptChangeHeightStub = sandbox.stub(impl, 'attemptChangeHeight');
-    const mutateElementStub = sandbox.stub(impl, 'mutateElement');
+    const attemptChangeHeightStub = env.sandbox.stub(
+      impl,
+      'attemptChangeHeight'
+    );
+    const mutateElementStub = env.sandbox.stub(impl, 'mutateElement');
     attemptChangeHeightStub.returns(Promise.resolve());
     mutateElementStub.returns(Promise.resolve());
-    sandbox.stub(impl, 'attemptToRenderCreative').returns(Promise.resolve());
+    env.sandbox
+      .stub(impl, 'attemptToRenderCreative')
+      .returns(Promise.resolve());
     impl.buildCallback();
     impl.isFluidRequest_ = true;
     impl.isVerifiedAmpCreative_ = true;
-    const setCssPositionSpy = sandbox.spy(impl, 'setCssPosition_');
+    const setCssPositionSpy = env.sandbox.spy(impl, 'setCssPosition_');
     return impl.expandFluidCreative_().then(() => {
       expect(attemptChangeHeightStub).to.be.calledOnce;
       expect(setCssPositionSpy.withArgs('static')).to.be.calledOnce;
@@ -386,15 +407,20 @@ describes.realWin('DoubleClick Fast Fetch Fluid', realWinConfig, env => {
   it('should set position: absoltute back when resizing fails', () => {
     impl.iframe = impl.win.document.createElement('iframe');
     impl.win.document.body.appendChild(impl.iframe);
-    const attemptChangeHeightStub = sandbox.stub(impl, 'attemptChangeHeight');
-    const mutateElementStub = sandbox.stub(impl, 'mutateElement');
+    const attemptChangeHeightStub = env.sandbox.stub(
+      impl,
+      'attemptChangeHeight'
+    );
+    const mutateElementStub = env.sandbox.stub(impl, 'mutateElement');
     attemptChangeHeightStub.returns(Promise.reject());
     mutateElementStub.returns(Promise.resolve());
-    sandbox.stub(impl, 'attemptToRenderCreative').returns(Promise.resolve());
+    env.sandbox
+      .stub(impl, 'attemptToRenderCreative')
+      .returns(Promise.resolve());
     impl.buildCallback();
     impl.isFluidRequest_ = true;
     impl.isVerifiedAmpCreative_ = true;
-    const setCssPositionSpy = sandbox.spy(impl, 'setCssPosition_');
+    const setCssPositionSpy = env.sandbox.spy(impl, 'setCssPosition_');
     return impl.expandFluidCreative_().then(() => {
       expect(attemptChangeHeightStub).to.be.calledOnce;
       expect(setCssPositionSpy.withArgs('static')).to.be.calledOnce;

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-rtc.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-rtc.js
@@ -28,10 +28,8 @@ import {createElementWithAttributes} from '../../../../src/dom';
 describes.realWin('DoubleClick Fast Fetch RTC', {amp: true}, env => {
   let impl;
   let element;
-  let sandbox;
 
   beforeEach(() => {
-    sandbox = env.sandbox;
     env.win.__AMP_MODE.test = true;
     const doc = env.win.document;
     // TODO(a4a-cam@): This is necessary in the short term, until A4A is
@@ -52,7 +50,6 @@ describes.realWin('DoubleClick Fast Fetch RTC', {amp: true}, env => {
   });
 
   afterEach(() => {
-    sandbox.restore();
     impl = null;
   });
 
@@ -406,7 +403,7 @@ describes.realWin('DoubleClick Fast Fetch RTC', {amp: true}, env => {
         'json': JSON.stringify(json),
       });
       env.win.document.body.appendChild(element);
-      sandbox.defineProperty(env.win.document, 'referrer', {
+      env.sandbox.defineProperty(env.win.document, 'referrer', {
         value: 'https://www.google.com/',
       });
       const docInfo = Services.documentInfoForDoc(element);
@@ -484,7 +481,7 @@ describes.realWin('DoubleClick Fast Fetch RTC', {amp: true}, env => {
       );
       impl.populateAdUrlState();
       const viewer = Services.viewerForDoc(impl.getAmpDoc());
-      sandbox.stub(viewer, 'getReferrerUrl').returns(new Promise(() => {}));
+      env.sandbox.stub(viewer, 'getReferrerUrl').returns(new Promise(() => {}));
       const customMacros = impl.getCustomRealTimeConfigMacros_();
       return expect(customMacros.REFERRER(0)).to.eventually.be.undefined;
     });

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-safeframe.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-safeframe.js
@@ -49,7 +49,6 @@ const realWinConfig = {
 describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
   let doubleclickImpl;
   let ampAd;
-  let sandbox;
   let safeframeHost;
   let doc;
   const safeframeChannel = '61393';
@@ -57,7 +56,6 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
   const ampAdWidth = 300;
 
   beforeEach(() => {
-    sandbox = env.sandbox;
     env.win.__AMP_MODE.test = true;
     doc = env.win.document;
     setup(ampAdHeight, ampAdWidth, ampAdHeight, ampAdWidth);
@@ -122,11 +120,11 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
       const safeframeMock = createElementWithAttributes(doc, 'iframe', {});
       ampAd.appendChild(safeframeMock);
       doubleclickImpl.iframe = safeframeMock;
-      const connectMessagingChannelSpy = sandbox./*OK*/ spy(
+      const connectMessagingChannelSpy = env.sandbox./*OK*/ spy(
         safeframeHost,
         'connectMessagingChannel'
       );
-      const postMessageStub = sandbox./*OK*/ stub(
+      const postMessageStub = env.sandbox./*OK*/ stub(
         safeframeMock.contentWindow,
         'postMessage'
       );
@@ -198,7 +196,7 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
 
   describe('getSafeframeNameAttr', () => {
     it('should return name attributes', () => {
-      sandbox.stub(Services, 'documentInfoForDoc').returns({
+      env.sandbox.stub(Services, 'documentInfoForDoc').returns({
         canonicalUrl: 'http://example.org/canonical',
       });
       const attrs = safeframeHost.getSafeframeNameAttr();
@@ -265,7 +263,7 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
     });
 
     it('should not pass canonicalUrl if referrer policy same-origin', () => {
-      sandbox.stub(Services, 'documentInfoForDoc').returns({
+      env.sandbox.stub(Services, 'documentInfoForDoc').returns({
         canonicalUrl: 'http://example.org/canonical',
       });
       const meta = env.win.document.createElement('meta');
@@ -285,7 +283,7 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
     });
 
     it('should not pass canonicalUrl if referrer policy no-referrer', () => {
-      sandbox.stub(Services, 'documentInfoForDoc').returns({
+      env.sandbox.stub(Services, 'documentInfoForDoc').returns({
         canonicalUrl: 'http://example.org/canonical',
       });
       const meta = env.win.document.createElement('meta');
@@ -305,7 +303,7 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
     });
 
     it('should pass canonicalUrl domain if referrer policy origin', () => {
-      sandbox.stub(Services, 'documentInfoForDoc').returns({
+      env.sandbox.stub(Services, 'documentInfoForDoc').returns({
         canonicalUrl: 'http://example.org/canonical/foo?bleh',
       });
       const meta = env.win.document.createElement('meta');
@@ -328,14 +326,14 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
 
   describe('getCurrentGeometry', () => {
     beforeEach(() => {
-      sandbox./*OK*/ stub(safeframeHost.viewport_, 'getSize').returns({
+      env.sandbox./*OK*/ stub(safeframeHost.viewport_, 'getSize').returns({
         height: 1000,
         width: 500,
       });
     });
 
     it('should get current geometry when safeframe fills amp-ad', () => {
-      sandbox
+      env.sandbox
         ./*OK*/ stub(safeframeHost.baseInstance_, 'getPageLayoutBox')
         .returns({
           top: 0,
@@ -360,7 +358,7 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
       doubleclickImpl.iframe_ = safeframeMock;
       safeframeHost.iframe_ = safeframeMock;
 
-      const sendMessageStub = sandbox./*OK*/ stub(
+      const sendMessageStub = env.sandbox./*OK*/ stub(
         safeframeHost,
         'sendMessage_'
       );
@@ -387,7 +385,7 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
     });
 
     it('should get geometry when safeframe does not fill amp-ad', () => {
-      sandbox
+      env.sandbox
         ./*OK*/ stub(safeframeHost.baseInstance_, 'getPageLayoutBox')
         .returns({
           top: 0,
@@ -412,7 +410,7 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
       doubleclickImpl.iframe_ = safeframeMock;
       safeframeHost.iframe_ = safeframeMock;
 
-      const sendMessageStub = sandbox./*OK*/ stub(
+      const sendMessageStub = env.sandbox./*OK*/ stub(
         safeframeHost,
         'sendMessage_'
       );
@@ -440,7 +438,7 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
 
     it('should handle cancellation', () => {
       expectAsyncConsoleError(/cancellation/i, 1);
-      sandbox
+      env.sandbox
         ./*OK*/ stub(safeframeHost.baseInstance_, 'getPageLayoutBox')
         .returns({
           top: 0,
@@ -464,7 +462,7 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
       ampAd.appendChild(safeframeMock);
       doubleclickImpl.iframe_ = safeframeMock;
       safeframeHost.iframe_ = safeframeMock;
-      const sendMessageStub = sandbox./*OK*/ stub(
+      const sendMessageStub = env.sandbox./*OK*/ stub(
         safeframeHost,
         'sendMessage_'
       );
@@ -478,7 +476,7 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
     });
 
     it('should get geometry when scrolled', () => {
-      sandbox
+      env.sandbox
         ./*OK*/ stub(safeframeHost.baseInstance_, 'getPageLayoutBox')
         .returns({
           top: 0,
@@ -506,7 +504,7 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
       // Scroll 100 px
       safeframeHost.viewport_.setScrollTop(50);
 
-      const sendMessageStub = sandbox./*OK*/ stub(
+      const sendMessageStub = env.sandbox./*OK*/ stub(
         safeframeHost,
         'sendMessage_'
       );
@@ -538,11 +536,11 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
       ampAd.appendChild(safeframeMock);
       doubleclickImpl.iframe = safeframeMock;
 
-      const onScrollStub = sandbox./*OK*/ stub(
+      const onScrollStub = env.sandbox./*OK*/ stub(
         safeframeHost.viewport_,
         'onScroll'
       );
-      const onChangedStub = sandbox./*OK*/ stub(
+      const onChangedStub = env.sandbox./*OK*/ stub(
         safeframeHost.viewport_,
         'onChanged'
       );
@@ -551,7 +549,10 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
       sendSetupMessage();
       const maybeUpdateGeometry1 = onScrollStub.firstCall.args[0];
       const maybeUpdateGeometry2 = onChangedStub.firstCall.args[0];
-      const sendMessageStub = sandbox./*OK*/ spy(safeframeHost, 'sendMessage_');
+      const sendMessageStub = env.sandbox./*OK*/ spy(
+        safeframeHost,
+        'sendMessage_'
+      );
       maybeUpdateGeometry1();
       maybeUpdateGeometry2();
 
@@ -584,7 +585,7 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
 
   describe('formatGeom', () => {
     it('should build proper geometry update', () => {
-      sandbox
+      env.sandbox
         ./*OK*/ stub(safeframeHost.baseInstance_, 'getPageLayoutBox')
         .returns({
           top: 200,
@@ -600,7 +601,7 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
         width: 300,
         height: 700,
       };
-      sandbox./*OK*/ stub(safeframeHost.viewport_, 'getSize').returns({
+      env.sandbox./*OK*/ stub(safeframeHost.viewport_, 'getSize').returns({
         width: 500,
         height: 1000,
       });
@@ -634,7 +635,7 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
 
   describe('sendResizeResponse', () => {
     it('should handle cancellation', () => {
-      const sendMessageStub = sandbox./*OK*/ stub(
+      const sendMessageStub = env.sandbox./*OK*/ stub(
         safeframeHost,
         'sendMessage_'
       );
@@ -650,7 +651,7 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
 
   describe('resizeAmpAdAndSafeframe', () => {
     it('should handle cancellation', () => {
-      const sendMessageStub = sandbox./*OK*/ stub(
+      const sendMessageStub = env.sandbox./*OK*/ stub(
         safeframeHost,
         'sendMessage_'
       );
@@ -666,7 +667,7 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
 
   describe('handleFluidMessage', () => {
     it('should handle cancellation', () => {
-      const sendMessageStub = sandbox./*OK*/ stub(
+      const sendMessageStub = env.sandbox./*OK*/ stub(
         safeframeHost,
         'sendMessage_'
       );
@@ -691,7 +692,7 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
     });
 
     function setupForResize() {
-      sandbox.restore();
+      env.sandbox.restore();
       const css = createElementWithAttributes(doc, 'style');
       css.innerHTML =
         '.safeframe' +
@@ -706,12 +707,15 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
       });
       ampAd.appendChild(safeframeMock);
       doubleclickImpl.iframe = safeframeMock;
-      resizeSafeframeSpy = sandbox./*OK*/ spy(safeframeHost, 'resizeSafeframe');
-      sendResizeResponseSpy = sandbox./*OK*/ spy(
+      resizeSafeframeSpy = env.sandbox./*OK*/ spy(
+        safeframeHost,
+        'resizeSafeframe'
+      );
+      sendResizeResponseSpy = env.sandbox./*OK*/ spy(
         safeframeHost,
         'sendResizeResponse'
       );
-      resizeAmpAdAndSafeframeSpy = sandbox./*OK*/ spy(
+      resizeAmpAdAndSafeframeSpy = env.sandbox./*OK*/ spy(
         safeframeHost,
         'resizeAmpAdAndSafeframe'
       );
@@ -719,11 +723,11 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
       safeframeHost.initialWidth_ = ampAdWidth;
       sendSetupMessage();
       sendRegisterDoneMessage();
-      attemptChangeSizeStub = sandbox.stub(
+      attemptChangeSizeStub = env.sandbox.stub(
         doubleclickImpl,
         'attemptChangeSize'
       );
-      sandbox./*OK*/ stub(safeframeHost.viewport_, 'getSize').returns({
+      env.sandbox./*OK*/ stub(safeframeHost.viewport_, 'getSize').returns({
         height: 1000,
         width: 1000,
       });

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-sra.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-sra.js
@@ -64,12 +64,10 @@ const config = {amp: true, allowExternalResources: true};
   tests to fail.
 */
 describes.realWin('Doubleclick SRA', config, env => {
-  let sandbox;
   let doc;
 
   beforeEach(() => {
     doc = env.win.document;
-    sandbox = env.sandbox;
     // ensures window location == AMP cache passes
     env.win.__AMP_MODE.test = true;
   });
@@ -355,9 +353,11 @@ describes.realWin('Doubleclick SRA', config, env => {
         };
         const element1 = createElementWithAttributes(doc, 'amp-ad', config1);
         const impl1 = new AmpAdNetworkDoubleclickImpl(element1);
-        sandbox.stub(impl1, 'getPageLayoutBox').returns({top: 123, left: 456});
+        env.sandbox
+          .stub(impl1, 'getPageLayoutBox')
+          .returns({top: 123, left: 456});
         impl1.experimentIds = [MANUAL_EXPERIMENT_ID];
-        sandbox
+        env.sandbox
           .stub(impl1, 'generateAdKey_')
           .withArgs('50x320')
           .returns('13579');
@@ -384,8 +384,10 @@ describes.realWin('Doubleclick SRA', config, env => {
         };
         const element2 = createElementWithAttributes(doc, 'amp-ad', config2);
         const impl2 = new AmpAdNetworkDoubleclickImpl(element2);
-        sandbox.stub(impl2, 'getPageLayoutBox').returns({top: 789, left: 101});
-        sandbox
+        env.sandbox
+          .stub(impl2, 'getPageLayoutBox')
+          .returns({top: 789, left: 101});
+        env.sandbox
           .stub(impl2, 'generateAdKey_')
           .withArgs('250x300')
           .returns('2468');
@@ -456,12 +458,12 @@ describes.realWin('Doubleclick SRA', config, env => {
           .splice(1)
           .join()
       );
-      sandbox
+      env.sandbox
         .stub(validInstances[0], 'getLocationQueryParameterValue')
         .withArgs('google_preview')
         .returns('abcdef');
       const xhrWithArgs = xhrMock.withArgs(
-        sinon.match(
+        env.sandbox.match(
           new RegExp(
             '^https://securepubads\\.g\\.doubleclick\\.net' +
               '/gampad/ads\\?output=ldjh&impl=fifs&iu_parts=' +
@@ -514,7 +516,7 @@ describes.realWin('Doubleclick SRA', config, env => {
           `\/gampad\/ads\\?iu=${iu}&`
       );
       xhrMock
-        .withArgs(sinon.match(urlRegexp), {
+        .withArgs(env.sandbox.match(urlRegexp), {
           mode: 'cors',
           method: 'GET',
           credentials: 'include',
@@ -565,7 +567,7 @@ describes.realWin('Doubleclick SRA', config, env => {
       const networkValidity = {};
       const doubleclickInstances = [];
       const networkNestHeaders = [];
-      const attemptCollapseSpy = sandbox.spy(
+      const attemptCollapseSpy = env.sandbox.spy(
         BaseElement.prototype,
         'attemptCollapse'
       );
@@ -580,9 +582,9 @@ describes.realWin('Doubleclick SRA', config, env => {
           for (let i = 0; i < instanceCount; i++) {
             const impl = createA4aSraInstance(network.networkId);
             doubleclickInstances.push(impl);
-            sandbox.stub(impl, 'isValidElement').returns(!invalid);
-            sandbox.stub(impl, 'promiseErrorHandler_');
-            sandbox.stub(impl, 'warnOnError');
+            env.sandbox.stub(impl, 'isValidElement').returns(!invalid);
+            env.sandbox.stub(impl, 'promiseErrorHandler_');
+            env.sandbox.stub(impl, 'warnOnError');
             if (invalid) {
               impl.element.setAttribute('data-test-invalid', 'true');
             }
@@ -607,7 +609,7 @@ describes.realWin('Doubleclick SRA', config, env => {
           groupingPromises[networkId] || (groupingPromises[networkId] = [])
         ).push(Promise.resolve(impl));
       });
-      sandbox
+      env.sandbox
         .stub(AmpAdNetworkDoubleclickImpl.prototype, 'groupSlotsForSra')
         .returns(Promise.resolve(groupingPromises));
       let idx = 0;
@@ -692,11 +694,11 @@ describes.realWin('Doubleclick SRA', config, env => {
     }
 
     beforeEach(() => {
-      xhrMock = sandbox.stub(Xhr.prototype, 'fetch');
-      sandbox
+      xhrMock = env.sandbox.stub(Xhr.prototype, 'fetch');
+      env.sandbox
         .stub(AmpA4A.prototype, 'getSigningServiceNames')
         .returns(['google']);
-      sandbox
+      env.sandbox
         .stub(SignatureVerifier.prototype, 'loadKeyset')
         .callsFake(() => {});
     });

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-flexible-ad-slot-utils.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-flexible-ad-slot-utils.js
@@ -136,7 +136,7 @@ describes.realWin('#getFlexibleAdSlotData', {amp: true}, env => {
 
   it('should return the viewport width for CONTAINER layout', () => {
     const element = createResource({} /* config */, 'container');
-    sandbox
+    env.sandbox
       .stub(Services.viewportForDoc(element), 'getSize')
       .returns({width: 300});
     expect(getFlexibleAdSlotData(win, element).parentWidth).to.equal(300);

--- a/extensions/amp-ad-network-gmossp-impl/0.1/test/test-amp-ad-network-gmossp-impl.js
+++ b/extensions/amp-ad-network-gmossp-impl/0.1/test/test-amp-ad-network-gmossp-impl.js
@@ -94,7 +94,7 @@ describes.realWin(
       gmosspImplElem = doc.createElement('amp-ad');
       gmosspImplElem.setAttribute('type', 'gmossp');
       gmosspImplElem.setAttribute('data-use-a4a', 'true');
-      sandbox
+      env.sandbox
         .stub(AmpAdNetworkGmosspImpl.prototype, 'getSigningServiceNames')
         .callsFake(() => {
           return ['google'];

--- a/extensions/amp-ad-network-mytarget-impl/0.1/test/test-amp-ad-network-mytarget-impl.js
+++ b/extensions/amp-ad-network-mytarget-impl/0.1/test/test-amp-ad-network-mytarget-impl.js
@@ -86,7 +86,7 @@ describes.realWin(
       mytargetImplElem.setAttribute('type', 'mytarget');
       mytargetImplElem.setAttribute('data-ad-slot', '197378');
       mytargetImplElem.setAttribute('data-use-a4a', 'true');
-      sandbox
+      env.sandbox
         .stub(AmpAdNetworkMyTargetImpl.prototype, 'getSigningServiceNames')
         .callsFake(() => {
           return ['cloudflare'];

--- a/extensions/amp-ad-network-triplelift-impl/0.1/test/test-amp-ad-network-triplelift-impl.js
+++ b/extensions/amp-ad-network-triplelift-impl/0.1/test/test-amp-ad-network-triplelift-impl.js
@@ -89,7 +89,7 @@ describes.realWin(
         'https://ib.3lift.com/ttj?inv_code=ampforadstest_main_feed'
       );
       tripleliftImplElem.setAttribute('data-use-a4a', 'true');
-      sandbox
+      env.sandbox
         .stub(AmpAdNetworkTripleliftImpl.prototype, 'getSigningServiceNames')
         .callsFake(() => {
           return ['cloudflare'];

--- a/extensions/amp-ad/0.1/test/test-amp-ad-3p-impl.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-3p-impl.js
@@ -59,7 +59,6 @@ describes.realWin(
     allowExternalResources: true,
   },
   env => {
-    let sandbox;
     let ad3p;
     let win;
     let registryBackup;
@@ -72,13 +71,14 @@ describes.realWin(
         delete adConfig[k];
       });
       adConfig['_ping_'] = Object.assign({}, registryBackup['_ping_']);
-      sandbox = env.sandbox;
       win = env.win;
       ad3p = createAmpAd(win);
       win.document.body.appendChild(ad3p.element);
       ad3p.buildCallback();
       // Turn the doc to visible so prefetch will be proceeded.
-      sandbox.stub(env.ampdoc, 'whenFirstVisible').returns(whenFirstVisible);
+      env.sandbox
+        .stub(env.ampdoc, 'whenFirstVisible')
+        .returns(whenFirstVisible);
     });
 
     afterEach(() => {
@@ -120,7 +120,7 @@ describes.realWin(
       });
 
       it('should propagete CID to ad iframe', () => {
-        sandbox.stub(adCid, 'getAdCid').resolves('sentinel123');
+        env.sandbox.stub(adCid, 'getAdCid').resolves('sentinel123');
 
         return ad3p.layoutCallback().then(() => {
           const frame = ad3p.element.querySelector('iframe[src]');
@@ -133,7 +133,7 @@ describes.realWin(
       });
 
       it('should proceed w/o CID', () => {
-        sandbox.stub(adCid, 'getAdCid').resolves(undefined);
+        env.sandbox.stub(adCid, 'getAdCid').resolves(undefined);
         return ad3p.layoutCallback().then(() => {
           const frame = ad3p.element.querySelector('iframe[src]');
           expect(frame).to.be.ok;
@@ -146,10 +146,10 @@ describes.realWin(
 
       it('should propagate consent state to ad iframe', () => {
         ad3p.element.setAttribute('data-block-on-consent', '');
-        sandbox
+        env.sandbox
           .stub(consent, 'getConsentPolicyState')
           .resolves(CONSENT_POLICY_STATE.SUFFICIENT);
-        sandbox
+        env.sandbox
           .stub(consent, 'getConsentPolicySharedData')
           .resolves({a: 1, b: 2});
 
@@ -249,7 +249,7 @@ describes.realWin(
         win.document.head.appendChild(meta);
         ad3p.config.remoteHTMLDisabled = true;
         ad3p.onLayoutMeasure();
-        sandbox.stub(user(), 'error');
+        env.sandbox.stub(user(), 'error');
         return ad3p.layoutCallback().then(() => {
           expect(
             win.document.querySelector(
@@ -286,25 +286,33 @@ describes.realWin(
         });
 
         it('should require unlayout if iframe is not pausable', () => {
-          sandbox
+          env.sandbox
             ./*OK*/ stub(xOriginIframeHandler, 'isPausable')
             .returns(false);
           expect(ad3p.unlayoutOnPause()).to.be.true;
         });
 
         it('should NOT require unlayout if iframe is pausable', () => {
-          sandbox./*OK*/ stub(xOriginIframeHandler, 'isPausable').returns(true);
+          window.sandbox
+            ./*OK*/ stub(xOriginIframeHandler, 'isPausable')
+            .returns(true);
           expect(ad3p.unlayoutOnPause()).to.be.false;
         });
 
         it('should pause iframe', () => {
-          const stub = sandbox./*OK*/ stub(xOriginIframeHandler, 'setPaused');
+          const stub = window.sandbox./*OK*/ stub(
+            xOriginIframeHandler,
+            'setPaused'
+          );
           ad3p.pauseCallback();
           expect(stub).to.be.calledOnce.calledWith(true);
         });
 
         it('should resume iframe', () => {
-          const stub = sandbox./*OK*/ stub(xOriginIframeHandler, 'setPaused');
+          const stub = window.sandbox./*OK*/ stub(
+            xOriginIframeHandler,
+            'setPaused'
+          );
           ad3p.resumeCallback();
           expect(stub).to.be.calledOnce.calledWith(false);
         });
@@ -444,7 +452,7 @@ describes.realWin(
           iframe.style.display = 'block';
           iframe.style.minHeight = '0px';
 
-          const stub = sandbox.stub(ad3p, 'getLayoutBox');
+          const stub = env.sandbox.stub(ad3p, 'getLayoutBox');
           const box = {
             top: 100,
             bottom: 200,
@@ -506,7 +514,10 @@ describes.realWin(
             width: '280',
             height: '280',
           });
-          const attemptChangeSizeSpy = sandbox.spy(impl, 'attemptChangeSize');
+          const attemptChangeSizeSpy = env.sandbox.spy(
+            impl,
+            'attemptChangeSize'
+          );
           expect(impl.buildCallback()).to.be.undefined;
           expect(attemptChangeSizeSpy).to.not.be.called;
         });
@@ -518,7 +529,7 @@ describes.realWin(
             'data-auto-format': 'rspv',
             'data-full-width': '',
           });
-          const attemptChangeSizeSpy = sandbox
+          const attemptChangeSizeSpy = env.sandbox
             .stub(impl, 'attemptChangeSize')
             .callsFake((height, width) => {
               expect(width).to.equal(VIEWPORT_WIDTH);
@@ -538,7 +549,7 @@ describes.realWin(
             'data-auto-format': 'mcrspv',
             'data-full-width': '',
           });
-          const attemptChangeSizeSpy = sandbox
+          const attemptChangeSizeSpy = env.sandbox
             .stub(impl, 'attemptChangeSize')
             .callsFake((height, width) => {
               expect(width).to.equal(VIEWPORT_WIDTH);

--- a/extensions/amp-ad/0.1/test/test-amp-ad-custom.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-custom.js
@@ -20,14 +20,12 @@ import {Services} from '../../../../src/services';
 import {createElementWithAttributes, removeChildren} from '../../../../src/dom';
 
 describes.realWin('Amp custom ad', {amp: true}, env => {
-  let sandbox;
   let win;
   let doc;
 
   beforeEach(() => {
     win = env.win;
     doc = win.document;
-    sandbox = env.sandbox;
   });
 
   it('should get the correct full URLs', () => {
@@ -38,7 +36,7 @@ describes.realWin('Amp custom ad', {amp: true}, env => {
     const urlBase1 = '/examples/custom.ad.example.single.json';
     const elem1 = getCustomAd(doc, urlBase1);
     const ad1 = new AmpAdCustom(elem1);
-    sandbox.stub(ad1, 'getFallback').callsFake(() => {
+    env.sandbox.stub(ad1, 'getFallback').callsFake(() => {
       return null;
     });
     ad1.buildCallback();
@@ -48,7 +46,7 @@ describes.realWin('Amp custom ad', {amp: true}, env => {
     const slot = 'myslot2';
     const elem2 = getCustomAd(doc, urlBase2, slot);
     const ad2 = new AmpAdCustom(elem2);
-    sandbox.stub(ad2, 'getFallback').callsFake(() => {
+    env.sandbox.stub(ad2, 'getFallback').callsFake(() => {
       return null;
     });
     ad2.buildCallback();
@@ -59,7 +57,7 @@ describes.realWin('Amp custom ad', {amp: true}, env => {
     const slot3 = 'myslot3';
     const elem3 = getCustomAd(doc, urlBase34, slot3);
     const ad3 = new AmpAdCustom(elem3);
-    sandbox.stub(ad3, 'getFallback').callsFake(() => {
+    env.sandbox.stub(ad3, 'getFallback').callsFake(() => {
       return null;
     });
     ad3.buildCallback();
@@ -67,7 +65,7 @@ describes.realWin('Amp custom ad', {amp: true}, env => {
     const slot4 = 'myslot4';
     const elem4 = getCustomAd(doc, urlBase34, slot4);
     const ad4 = new AmpAdCustom(elem4);
-    sandbox.stub(ad4, 'getFallback').callsFake(() => {
+    env.sandbox.stub(ad4, 'getFallback').callsFake(() => {
       return null;
     });
     ad4.buildCallback();
@@ -82,7 +80,7 @@ describes.realWin('Amp custom ad', {amp: true}, env => {
   });
 
   it('should perform multiple requests if no `data-slot`', () => {
-    const stub = sandbox.stub(Services, 'xhrFor').callsFake(() => ({
+    const stub = env.sandbox.stub(Services, 'xhrFor').callsFake(() => ({
       fetchJson: () => Promise.resolve({'foo': 1}),
     }));
 

--- a/extensions/amp-ad/0.1/test/test-amp-ad-ui.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-ui.js
@@ -30,18 +30,16 @@ describes.realWin(
     },
   },
   env => {
-    let sandbox;
     let adImpl;
     let uiHandler;
     let adContainer;
     let adElement;
 
     beforeEach(() => {
-      sandbox = env.sandbox;
       adElement = env.win.document.createElement('amp-ad');
       adImpl = new BaseElement(adElement);
       uiHandler = new AmpAdUIHandler(adImpl);
-      sandbox.stub(adHelper, 'getAdContainer').callsFake(() => {
+      env.sandbox.stub(adHelper, 'getAdContainer').callsFake(() => {
         return adContainer;
       });
       adContainer = null;
@@ -50,8 +48,8 @@ describes.realWin(
     describe('applyNoContentUI', () => {
       it('should force collapse ad in sticky ad container', () => {
         adContainer = 'AMP-STICKY-AD';
-        const attemptCollapseSpy = sandbox.spy(adImpl, 'attemptCollapse');
-        const collapseSpy = sandbox
+        const attemptCollapseSpy = env.sandbox.spy(adImpl, 'attemptCollapse');
+        const collapseSpy = env.sandbox
           .stub(adImpl, 'collapse')
           .callsFake(() => {});
         uiHandler.applyNoContentUI();
@@ -64,12 +62,12 @@ describes.realWin(
           'if it is the only and direct child of flying carpet',
         function*() {
           adContainer = 'AMP-FX-FLYING-CARPET';
-          const attemptCollapseSpy = sandbox.spy(adImpl, 'attemptCollapse');
-          const collapseSpy = sandbox
+          const attemptCollapseSpy = env.sandbox.spy(adImpl, 'attemptCollapse');
+          const collapseSpy = env.sandbox
             .stub(adImpl, 'collapse')
             .callsFake(() => {});
 
-          sandbox.stub(dom, 'ancestorElementsByTag').callsFake(() => {
+          env.sandbox.stub(dom, 'ancestorElementsByTag').callsFake(() => {
             return [
               {
                 getImpl: () =>
@@ -93,14 +91,14 @@ describes.realWin(
           'if there is another element',
         function*() {
           adContainer = 'AMP-FX-FLYING-CARPET';
-          const attemptCollapseSpy = sandbox.spy(adImpl, 'attemptCollapse');
-          const collapseSpy = sandbox
+          const attemptCollapseSpy = env.sandbox.spy(adImpl, 'attemptCollapse');
+          const collapseSpy = env.sandbox
             .stub(adImpl, 'collapse')
             .callsFake(() => {});
 
           const otherElement = env.win.document.createElement('div');
 
-          sandbox.stub(dom, 'ancestorElementsByTag').callsFake(() => {
+          env.sandbox.stub(dom, 'ancestorElementsByTag').callsFake(() => {
             return [
               {
                 getImpl: () =>
@@ -124,8 +122,8 @@ describes.realWin(
           'if it is not a direct child of flying carpet.',
         function*() {
           adContainer = 'AMP-FX-FLYING-CARPET';
-          const attemptCollapseSpy = sandbox.spy(adImpl, 'attemptCollapse');
-          const collapseSpy = sandbox
+          const attemptCollapseSpy = env.sandbox.spy(adImpl, 'attemptCollapse');
+          const collapseSpy = env.sandbox
             .stub(adImpl, 'collapse')
             .callsFake(() => {});
 
@@ -133,7 +131,7 @@ describes.realWin(
           adElement.remove();
           otherElement.appendChild(adElement);
 
-          sandbox.stub(dom, 'ancestorElementsByTag').callsFake(() => {
+          env.sandbox.stub(dom, 'ancestorElementsByTag').callsFake(() => {
             return [
               {
                 getImpl: () =>
@@ -165,19 +163,19 @@ describes.realWin(
         env.win.document.body.appendChild(container);
         adImpl = new BaseElement(adElement);
         uiHandler = new AmpAdUIHandler(adImpl);
-        const adAttemptCollapseSpy = sandbox.spy(adImpl, 'attemptCollapse');
+        const adAttemptCollapseSpy = env.sandbox.spy(adImpl, 'attemptCollapse');
         uiHandler.applyNoContentUI();
         expect(adAttemptCollapseSpy).to.not.be.called;
       });
 
       it('should try to collapse element first', () => {
-        sandbox.stub(adImpl, 'getFallback').callsFake(() => {
+        env.sandbox.stub(adImpl, 'getFallback').callsFake(() => {
           return true;
         });
-        const fallbackSpy = sandbox
+        const fallbackSpy = env.sandbox
           .stub(adImpl, 'toggleFallback')
           .callsFake(() => {});
-        const collapseSpy = sandbox
+        const collapseSpy = env.sandbox
           .stub(adImpl, 'attemptCollapse')
           .callsFake(() => {
             expect(fallbackSpy).to.not.been.called;
@@ -192,16 +190,16 @@ describes.realWin(
         const promise = new Promise(resolve_ => {
           resolve = resolve_;
         });
-        const placeholderSpy = sandbox.spy(adImpl, 'togglePlaceholder');
-        const fallbackSpy = sandbox
+        const placeholderSpy = env.sandbox.spy(adImpl, 'togglePlaceholder');
+        const fallbackSpy = env.sandbox
           .stub(adImpl, 'toggleFallback')
           .callsFake(() => {});
-        sandbox
+        env.sandbox
           .stub(uiHandler.baseInstance_, 'attemptCollapse')
           .callsFake(() => {
             return Promise.reject();
           });
-        sandbox
+        env.sandbox
           .stub(uiHandler.baseInstance_, 'mutateElement')
           .callsFake(callback => {
             callback();
@@ -215,22 +213,22 @@ describes.realWin(
       });
 
       it('should apply default holder if not provided', () => {
-        sandbox.stub(adImpl, 'getFallback').callsFake(() => {
+        env.sandbox.stub(adImpl, 'getFallback').callsFake(() => {
           return false;
         });
         let resolve = null;
         const promise = new Promise(resolve_ => {
           resolve = resolve_;
         });
-        sandbox.stub(adImpl, 'attemptCollapse').callsFake(() => {
+        env.sandbox.stub(adImpl, 'attemptCollapse').callsFake(() => {
           return Promise.reject();
         });
-        sandbox.stub(adImpl, 'mutateElement').callsFake(callback => {
+        env.sandbox.stub(adImpl, 'mutateElement').callsFake(callback => {
           callback();
           resolve();
         });
-        sandbox.stub(adImpl, 'togglePlaceholder').callsFake(() => {});
-        sandbox.stub(adImpl, 'toggleFallback').callsFake(() => {});
+        env.sandbox.stub(adImpl, 'togglePlaceholder').callsFake(() => {});
+        env.sandbox.stub(adImpl, 'toggleFallback').callsFake(() => {});
         uiHandler.applyNoContentUI();
         return promise.then(() => {
           const el = adImpl.element.querySelector('[fallback]');
@@ -247,7 +245,7 @@ describes.realWin(
             height: '50px',
           });
           env.win.document.body.appendChild(adElement);
-          sandbox
+          env.sandbox
             .stub(adImpl, 'attemptChangeSize')
             .callsFake((height, width) => {
               expect(height).to.equal(100);
@@ -264,7 +262,7 @@ describes.realWin(
         });
 
         it('should tolerate string input', () => {
-          sandbox
+          env.sandbox
             .stub(adImpl, 'attemptChangeSize')
             .callsFake((height, width) => {
               expect(height).to.equal(100);
@@ -281,7 +279,10 @@ describes.realWin(
         });
 
         it('should reject on special case undefined sizes', () => {
-          const attemptChangeSizeSpy = sandbox.spy(adImpl, 'attemptChangeSize');
+          const attemptChangeSizeSpy = env.sandbox.spy(
+            adImpl,
+            'attemptChangeSize'
+          );
           return uiHandler
             .updateSize(undefined, undefined, 0, 0, {})
             .catch(e => {
@@ -292,7 +293,10 @@ describes.realWin(
 
         it('should reject on special case inside sticky ad', () => {
           adContainer = 'AMP-STICKY-AD';
-          const attemptChangeSizeSpy = sandbox.spy(adImpl, 'attemptChangeSize');
+          const attemptChangeSizeSpy = env.sandbox.spy(
+            adImpl,
+            'attemptChangeSize'
+          );
           return uiHandler.updateSize(100, 400, 0, 0, {}).then(sizes => {
             expect(sizes).to.deep.equal({
               success: false,
@@ -304,7 +308,7 @@ describes.realWin(
         });
 
         it('should reject on attemptChangeSize reject', () => {
-          sandbox.stub(adImpl, 'attemptChangeSize').callsFake(() => {
+          env.sandbox.stub(adImpl, 'attemptChangeSize').callsFake(() => {
             return Promise.reject();
           });
           return uiHandler.updateSize(100, 400, 0, 0, {}).then(sizes => {

--- a/extensions/amp-ad/0.1/test/test-amp-ad-xorigin-iframe-handler.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-xorigin-iframe-handler.js
@@ -27,7 +27,6 @@ import {layoutRectLtwh} from '../../../../src/layout-rect';
 import {toggleExperiment} from '../../../../src/experiments';
 
 describe('amp-ad-xorigin-iframe-handler', () => {
-  let sandbox;
   let ampdoc;
   let adImpl;
   let signals;
@@ -37,7 +36,6 @@ describe('amp-ad-xorigin-iframe-handler', () => {
   let testIndex = 0;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox;
     const ampdocService = Services.ampdocServiceFor(window);
     ampdoc = ampdocService.getSingleDoc();
     const adElement = document.createElement('container-element');
@@ -47,7 +45,7 @@ describe('amp-ad-xorigin-iframe-handler', () => {
     };
     signals = new Signals();
     adElement.signals = () => signals;
-    renderStartedSpy = sandbox.spy();
+    renderStartedSpy = window.sandbox.spy();
     adElement.renderStarted = () => {
       renderStartedSpy();
       signals.signal('render-start');
@@ -70,7 +68,6 @@ describe('amp-ad-xorigin-iframe-handler', () => {
   });
 
   afterEach(() => {
-    sandbox.restore();
     document.body.removeChild(adImpl.element);
   });
 
@@ -82,14 +79,17 @@ describe('amp-ad-xorigin-iframe-handler', () => {
 
       beforeEach(() => {
         adImpl.config = {renderStartImplemented: true};
-        sandbox.stub(adImpl.uiHandler, 'updateSize').callsFake(() => {
+        window.sandbox.stub(adImpl.uiHandler, 'updateSize').callsFake(() => {
           return Promise.resolve({
             success: true,
             newWidth: 114,
             newHeight: 217,
           });
         });
-        noContentSpy = sandbox./*OK*/ spy(iframeHandler, 'freeXOriginIframe');
+        noContentSpy = window.sandbox./*OK*/ spy(
+          iframeHandler,
+          'freeXOriginIframe'
+        );
 
         initPromise = iframeHandler.init(iframe);
       });
@@ -201,7 +201,7 @@ describe('amp-ad-xorigin-iframe-handler', () => {
           sentinel: 'amp3ptest' + testIndex,
           type: 'bootstrap-loaded',
         }).then(() => {
-          const clock = sandbox.useFakeTimers();
+          const clock = window.sandbox.useFakeTimers();
           clock.tick(0);
           const timeoutPromise = Services.timerFor(window).timeoutPromise(
             2000,
@@ -233,7 +233,7 @@ describe('amp-ad-xorigin-iframe-handler', () => {
       it('should be able to use user-error API', () => {
         const err = new Error();
         err.message = 'error test';
-        const userErrorReportSpy = sandbox./*OK*/ spy(
+        const userErrorReportSpy = window.sandbox./*OK*/ spy(
           iframeHandler,
           'userErrorForAnalytics_'
         );
@@ -266,7 +266,7 @@ describe('amp-ad-xorigin-iframe-handler', () => {
     );
 
     it('should trigger visibility on timeout', () => {
-      const clock = sandbox.useFakeTimers();
+      const clock = window.sandbox.useFakeTimers();
       iframe.name = 'test_master';
       initPromise = iframeHandler.init(iframe);
       return new Promise(resolve => {
@@ -298,7 +298,7 @@ describe('amp-ad-xorigin-iframe-handler', () => {
     });
 
     it('should be able to use embed-state API', () => {
-      sandbox./*OK*/ stub(ampdoc, 'isVisible').returns(true);
+      window.sandbox./*OK*/ stub(ampdoc, 'isVisible').returns(true);
       iframe.postMessageToParent({
         type: 'send-embed-state',
         sentinel: 'amp3ptest' + testIndex,
@@ -314,7 +314,7 @@ describe('amp-ad-xorigin-iframe-handler', () => {
     });
 
     it('should be able to use embed-size API, change size deny', () => {
-      sandbox.stub(adImpl.uiHandler, 'updateSize').callsFake(() => {
+      window.sandbox.stub(adImpl.uiHandler, 'updateSize').callsFake(() => {
         return Promise.resolve({
           success: false,
           newWidth: 114,
@@ -338,7 +338,7 @@ describe('amp-ad-xorigin-iframe-handler', () => {
     });
 
     it('should be able to use embed-size API, change size succeed', () => {
-      sandbox.stub(adImpl.uiHandler, 'updateSize').callsFake(() => {
+      window.sandbox.stub(adImpl.uiHandler, 'updateSize').callsFake(() => {
         return Promise.resolve({
           success: true,
           newWidth: 114,
@@ -362,7 +362,7 @@ describe('amp-ad-xorigin-iframe-handler', () => {
     });
 
     it('should be able to use embed-size API to resize height only', () => {
-      sandbox.stub(adImpl.uiHandler, 'updateSize').callsFake(() => {
+      window.sandbox.stub(adImpl.uiHandler, 'updateSize').callsFake(() => {
         return Promise.resolve({
           success: true,
           newWidth: undefined,
@@ -391,14 +391,16 @@ describe('amp-ad-xorigin-iframe-handler', () => {
       iframe.setAttribute('data-amp-3p-sentinel', 'amp3ptest' + testIndex);
       iframe.name = 'test_nomaster';
       iframeHandler.init(iframe);
-      sandbox
+      window.sandbox
         ./*OK*/ stub(iframeHandler.viewport_, 'getClientRectAsync')
         .callsFake(() => {
           return Promise.resolve(layoutRectLtwh(1, 1, 1, 1));
         });
-      sandbox./*OK*/ stub(iframeHandler.viewport_, 'getRect').callsFake(() => {
-        return layoutRectLtwh(1, 1, 1, 1);
-      });
+      window.sandbox
+        ./*OK*/ stub(iframeHandler.viewport_, 'getRect')
+        .callsFake(() => {
+          return layoutRectLtwh(1, 1, 1, 1);
+        });
       iframe.postMessageToParent({
         type: 'send-positions',
         sentinel: 'amp3ptest' + testIndex,

--- a/extensions/amp-ad/0.1/test/test-amp-ad.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad.js
@@ -63,7 +63,7 @@ describes.realWin('Ad loader', {amp: true}, env => {
 
       beforeEach(() => {
         const getUserNotificationStub = stubService(
-          sandbox,
+          window.sandbox,
           win,
           'userNotificationManager',
           'get'
@@ -125,12 +125,12 @@ describes.realWin('Ad loader', {amp: true}, env => {
         };
         ampAdElement.setAttribute('type', 'zort');
         const extensions = Services.extensionsFor(win);
-        const extensionsStub = sandbox
+        const extensionsStub = env.sandbox
           .stub(extensions, 'loadElementClass')
           .withArgs('amp-ad-network-zort-impl')
           .returns(Promise.reject(new Error('I failed!')));
         ampAd = new AmpAd(ampAdElement);
-        sandbox.stub(ampAd.user(), 'error');
+        env.sandbox.stub(ampAd.user(), 'error');
         return ampAd.upgradeCallback().then(baseElement => {
           expect(extensionsStub).to.be.called;
           expect(ampAdElement.getAttribute('data-a4a-upgrade-type')).to.equal(
@@ -165,7 +165,7 @@ describes.realWin('Ad loader', {amp: true}, env => {
           return zortInstance;
         };
         const extensions = Services.extensionsFor(win);
-        const extensionsStub = sandbox
+        const extensionsStub = env.sandbox
           .stub(extensions, 'loadElementClass')
           .withArgs('amp-ad-network-zort-impl')
           .returns(Promise.resolve(zortConstructor));
@@ -194,7 +194,7 @@ describes.realWin('Ad loader', {amp: true}, env => {
           return zortInstance;
         };
         const extensions = Services.extensionsFor(win);
-        const extensionsStub = sandbox
+        const extensionsStub = env.sandbox
           .stub(extensions, 'loadElementClass')
           .withArgs('amp-ad-network-zort-impl')
           .returns(Promise.resolve(zortConstructor));
@@ -223,7 +223,7 @@ describes.realWin('Ad loader', {amp: true}, env => {
           return zortInstance;
         };
         const extensions = Services.extensionsFor(win);
-        const extensionsStub = sandbox
+        const extensionsStub = env.sandbox
           .stub(extensions, 'loadElementClass')
           .withArgs('amp-ad-network-zort-impl')
           .returns(Promise.resolve(zortConstructor));
@@ -247,7 +247,7 @@ describes.realWin('Ad loader', {amp: true}, env => {
           return zortInstance;
         };
         const extensions = Services.extensionsFor(win);
-        const extensionsStub = sandbox
+        const extensionsStub = env.sandbox
           .stub(extensions, 'loadElementClass')
           .withArgs('amp-ad-network-zort-impl')
           .returns(Promise.resolve(zortConstructor));

--- a/extensions/amp-analytics/0.1/test/test-amp-analytics.js
+++ b/extensions/amp-analytics/0.1/test/test-amp-analytics.js
@@ -43,7 +43,7 @@ describes.realWin(
     },
   },
   function(env) {
-    let win, doc, sandbox;
+    let win, doc;
     let configWithCredentials;
     let uidService;
     let crypto;
@@ -96,7 +96,6 @@ describes.realWin(
     beforeEach(() => {
       win = env.win;
       doc = win.document;
-      sandbox = env.sandbox;
       ampdoc = env.ampdoc;
       configWithCredentials = false;
       doc.title = 'Test Title';
@@ -131,7 +130,7 @@ describes.realWin(
       ins = instrumentationServiceForDocForTesting(ampdoc);
       installUserNotificationManagerForTesting(ampdoc);
 
-      const wi = mockWindowInterface(sandbox);
+      const wi = mockWindowInterface(env.sandbox);
       requestVerifier = new ImagePixelVerifier(wi);
       return Services.userNotificationManagerForDoc(doc.head).then(manager => {
         uidService = manager;
@@ -221,7 +220,7 @@ describes.realWin(
         const el = doc.createElement('amp-analytics');
         el.setAttribute('trigger', 'immediate');
         el.textContent = config;
-        const whenFirstVisibleStub = sandbox
+        const whenFirstVisibleStub = env.sandbox
           .stub(ampdoc, 'whenFirstVisible')
           .callsFake(() => new Promise(function() {}));
         doc.body.appendChild(el);
@@ -447,7 +446,7 @@ describes.realWin(
         });
         return waitForNoSendRequest(analytics).then(() => {
           expect(analytics.analyticsGroup_).to.be.ok;
-          const disposeStub = sandbox.stub(
+          const disposeStub = env.sandbox.stub(
             analytics.analyticsGroup_,
             'dispose'
           );
@@ -534,7 +533,7 @@ describes.realWin(
       });
 
       it('expands platform vars', () => {
-        sandbox
+        env.sandbox
           .stub(viewer, 'getReferrerUrl')
           .returns('http://fake.example/?foo=bar');
         const analytics = getAnalyticsTag({
@@ -599,7 +598,7 @@ describes.realWin(
           el1.dataset.varsTest = 'foo';
           analyticsGroup.root_.getRootElement().appendChild(el1);
 
-          const handlerSpy = sandbox.spy();
+          const handlerSpy = env.sandbox.spy();
           analyticsGroup.addTrigger(
             {'on': 'click', 'selector': '.x', 'vars': {'test': 'bar'}},
             handlerSpy
@@ -682,7 +681,7 @@ describes.realWin(
       });
 
       it('expands url-replacements vars', () => {
-        sandbox
+        env.sandbox
           .stub(viewer, 'getReferrerUrl')
           .returns('http://fake.example/?foo=bar');
         const analytics = getAnalyticsTag({
@@ -726,7 +725,7 @@ describes.realWin(
         const urlReplacements = Services.urlReplacementsForDoc(
           analytics.element
         );
-        sandbox
+        env.sandbox
           .stub(urlReplacements.getVariableSource(), 'get')
           .callsFake(function(name) {
             return {
@@ -747,7 +746,7 @@ describes.realWin(
     describe('expand selector', () => {
       it('expands selector with config variable', () => {
         const tracker = ins.root_.getTracker('click', ClickEventTracker);
-        const addStub = sandbox.stub(tracker, 'add');
+        const addStub = env.sandbox.stub(tracker, 'add');
         const analytics = getAnalyticsTag({
           requests: {foo: 'https://example.com/bar'},
           triggers: [{on: 'click', selector: '${foo}', request: 'foo'}],
@@ -763,7 +762,7 @@ describes.realWin(
       function selectorExpansionTest(selector) {
         it('expand selector value: ' + selector, () => {
           const tracker = ins.root_.getTracker('click', ClickEventTracker);
-          const addStub = sandbox.stub(tracker, 'add');
+          const addStub = env.sandbox.stub(tracker, 'add');
           const analytics = getAnalyticsTag({
             requests: {foo: 'https://example.com/bar'},
             triggers: [
@@ -803,7 +802,7 @@ describes.realWin(
 
       it('does not expands selector with platform variable', () => {
         const tracker = ins.root_.getTracker('click', ClickEventTracker);
-        const addStub = sandbox.stub(tracker, 'add');
+        const addStub = env.sandbox.stub(tracker, 'add');
         const analytics = getAnalyticsTag({
           requests: {foo: 'https://example.com/bar'},
           triggers: [{on: 'click', selector: '${title}', request: 'foo'}],
@@ -818,7 +817,7 @@ describes.realWin(
 
     describe('optout by function', () => {
       beforeEach(() => {
-        sandbox.stub(AnalyticsConfig.prototype, 'loadConfig').returns(
+        env.sandbox.stub(AnalyticsConfig.prototype, 'loadConfig').returns(
           Promise.resolve({
             'requests': {
               'foo': {
@@ -871,7 +870,7 @@ describes.realWin(
 
     describe('optout by id', () => {
       beforeEach(() => {
-        sandbox.stub(AnalyticsConfig.prototype, 'loadConfig').returns(
+        env.sandbox.stub(AnalyticsConfig.prototype, 'loadConfig').returns(
           Promise.resolve({
             'requests': {
               'foo': {
@@ -1006,7 +1005,7 @@ describes.realWin(
       it('allows a request through', () => {
         const analytics = getAnalyticsTag(getConfig(1));
 
-        sandbox.stub(crypto, 'uniform').returns(Promise.resolve(0.005));
+        env.sandbox.stub(crypto, 'uniform').returns(Promise.resolve(0.005));
         return waitForSendRequest(analytics).then(() => {
           requestVerifier.verifyRequest('/test1=1');
         });
@@ -1020,11 +1019,11 @@ describes.realWin(
         const urlReplacements = Services.urlReplacementsForDoc(
           analytics.element
         );
-        sandbox.stub(urlReplacements.getVariableSource(), 'get').returns({
+        env.sandbox.stub(urlReplacements.getVariableSource(), 'get').returns({
           async: 0,
           sync: 0,
         });
-        sandbox
+        env.sandbox
           .stub(crypto, 'uniform')
           .withArgs('0')
           .returns(Promise.resolve(0.005));
@@ -1036,7 +1035,7 @@ describes.realWin(
       it('does not allow a request through', () => {
         const analytics = getAnalyticsTag(getConfig(1));
 
-        sandbox.stub(crypto, 'uniform').returns(Promise.resolve(0.1));
+        env.sandbox.stub(crypto, 'uniform').returns(Promise.resolve(0.1));
         return waitForNoSendRequest(analytics);
       });
 
@@ -1149,7 +1148,7 @@ describes.realWin(
         const urlReplacements = Services.urlReplacementsForDoc(
           analytics.element
         );
-        sandbox
+        env.sandbox
           .stub(urlReplacements.getVariableSource(), 'get')
           .returns({sync: 1});
         return waitForSendRequest(analytics).then(() => {
@@ -1189,7 +1188,9 @@ describes.realWin(
         const urlReplacements = Services.urlReplacementsForDoc(
           analytics.element
         );
-        sandbox.stub(urlReplacements.getVariableSource(), 'get').returns(null);
+        env.sandbox
+          .stub(urlReplacements.getVariableSource(), 'get')
+          .returns(null);
 
         return waitForNoSendRequest(analytics);
       });
@@ -1205,7 +1206,7 @@ describes.realWin(
           const urlReplacements = Services.urlReplacementsForDoc(
             analytics.element
           );
-          sandbox
+          env.sandbox
             .stub(urlReplacements.getVariableSource(), 'get')
             .returns({sync: 0});
 
@@ -1224,7 +1225,7 @@ describes.realWin(
           const urlReplacements = Services.urlReplacementsForDoc(
             analytics.element
           );
-          sandbox
+          env.sandbox
             .stub(urlReplacements.getVariableSource(), 'get')
             .returns({sync: false});
 
@@ -1243,7 +1244,7 @@ describes.realWin(
           const urlReplacements = Services.urlReplacementsForDoc(
             analytics.element
           );
-          sandbox
+          env.sandbox
             .stub(urlReplacements.getVariableSource(), 'get')
             .returns({sync: null});
 
@@ -1262,7 +1263,7 @@ describes.realWin(
           const urlReplacements = Services.urlReplacementsForDoc(
             analytics.element
           );
-          sandbox
+          env.sandbox
             .stub(urlReplacements.getVariableSource(), 'get')
             .returns({sync: NaN});
 
@@ -1281,7 +1282,7 @@ describes.realWin(
           const urlReplacements = Services.urlReplacementsForDoc(
             analytics.element
           );
-          sandbox
+          env.sandbox
             .stub(urlReplacements.getVariableSource(), 'get')
             .returns({sync: undefined});
 
@@ -1311,7 +1312,7 @@ describes.realWin(
           const urlReplacements = Services.urlReplacementsForDoc(
             analytics.element
           );
-          sandbox
+          env.sandbox
             .stub(urlReplacements.getVariableSource(), 'get')
             .returns({sync: 1});
           return waitForSendRequest(analytics).then(() => {
@@ -1351,7 +1352,7 @@ describes.realWin(
           const urlReplacements = Services.urlReplacementsForDoc(
             analytics.element
           );
-          sandbox
+          env.sandbox
             .stub(urlReplacements.getVariableSource(), 'get')
             .returns(null);
 
@@ -1373,7 +1374,7 @@ describes.realWin(
           const urlReplacements = Services.urlReplacementsForDoc(
             analytics.element
           );
-          sandbox
+          env.sandbox
             .stub(urlReplacements.getVariableSource(), 'get')
             .returns(null);
 
@@ -1393,7 +1394,7 @@ describes.realWin(
           const urlReplacements = Services.urlReplacementsForDoc(
             analytics.element
           );
-          sandbox
+          env.sandbox
             .stub(urlReplacements.getVariableSource(), 'get')
             .returns('page');
 
@@ -1414,7 +1415,7 @@ describes.realWin(
           }
         );
 
-        sandbox.stub(uidService, 'get').callsFake(id => {
+        env.sandbox.stub(uidService, 'get').callsFake(id => {
           expect(id).to.equal('amp-user-notification1');
           return Promise.resolve();
         });
@@ -1435,7 +1436,7 @@ describes.realWin(
           }
         );
 
-        sandbox.stub(uidService, 'get').callsFake(id => {
+        env.sandbox.stub(uidService, 'get').callsFake(id => {
           expect(id).to.equal('amp-user-notification1');
           return Promise.reject();
         });
@@ -1463,12 +1464,12 @@ describes.realWin(
             }
           );
 
-          sandbox.stub(uidService, 'get').callsFake(id => {
+          env.sandbox.stub(uidService, 'get').callsFake(id => {
             expect(id).to.equal('amp-user-notification1');
             return Promise.reject();
           });
 
-          sandbox.stub(ampdoc, 'isVisible').returns(false);
+          env.sandbox.stub(ampdoc, 'isVisible').returns(false);
           analytics.layoutCallback();
           analytics.resumeCallback();
           analytics.unlayoutCallback();
@@ -1491,7 +1492,7 @@ describes.realWin(
         expectAsyncConsoleError(clickTrackerNotSupportedError);
         // Right now we only whitelist VISIBLE & HIDDEN
         const tracker = ins.root_.getTracker('click', ClickEventTracker);
-        const addStub = sandbox.stub(tracker, 'add');
+        const addStub = env.sandbox.stub(tracker, 'add');
         const analytics = getAnalyticsTag(
           {
             requests: {foo: 'https://example.com/bar'},
@@ -1509,7 +1510,7 @@ describes.realWin(
 
       it('replace selector and selectionMethod when in scope', () => {
         const tracker = ins.root_.getTracker('visible', VisibilityTracker);
-        const addStub = sandbox.stub(tracker, 'add');
+        const addStub = env.sandbox.stub(tracker, 'add');
         const analytics = getAnalyticsTag(
           {
             requests: {foo: 'https://example.com/bar'},
@@ -1683,11 +1684,11 @@ describes.realWin(
         const urlReplacements = Services.urlReplacementsForDoc(
           analytics.element
         );
-        sandbox.stub(urlReplacements.getVariableSource(), 'get').returns({
+        env.sandbox.stub(urlReplacements.getVariableSource(), 'get').returns({
           async: 0,
           sync: 0,
         });
-        sandbox
+        env.sandbox
           .stub(crypto, 'uniform')
           .withArgs('0')
           .returns(Promise.resolve(0.005))
@@ -1714,9 +1715,9 @@ describes.realWin(
         expectAsyncConsoleError(noTriggersError);
         expectAsyncConsoleError(noRequestStringsError);
 
-        sandbox.stub(AnalyticsConfig.prototype, 'loadConfig').resolves({});
+        env.sandbox.stub(AnalyticsConfig.prototype, 'loadConfig').resolves({});
 
-        const linkerStub = sandbox.stub(LinkerManager.prototype, 'init');
+        const linkerStub = env.sandbox.stub(LinkerManager.prototype, 'init');
 
         analytics.buildCallback();
         return analytics.layoutCallback().then(() => {
@@ -1746,13 +1747,13 @@ describes.realWin(
         doc.body.appendChild(el);
         const analytics = new AmpAnalytics(el);
 
-        sandbox
+        env.sandbox
           .stub(AnalyticsConfig.prototype, 'loadConfig')
           .returns(Promise.resolve(sampleconfig));
 
         analytics.buildCallback();
         analytics.preconnectCallback();
-        const initSpy = sandbox.spy(
+        const initSpy = env.sandbox.spy(
           Transport.prototype,
           'maybeInitIframeTransport'
         );
@@ -1796,7 +1797,7 @@ describes.realWin(
           'requests': {'foo': 'https://example.com/bar'},
           'triggers': [{'on': 'visible', 'parentPostMessage': 'foo'}],
         });
-        postMessageSpy = sandbox.spy(analytics.win.parent, 'postMessage');
+        postMessageSpy = env.sandbox.spy(analytics.win.parent, 'postMessage');
         return waitForNoSendRequest(analytics).then(() => {
           return waitForParentPostMessage();
         });
@@ -1807,7 +1808,7 @@ describes.realWin(
           'triggers': [{'on': 'visible', 'parentPostMessage': 'foo'}],
         });
         analytics.element.classList.add('i-amphtml-fie');
-        postMessageSpy = sandbox.spy(analytics.win.parent, 'postMessage');
+        postMessageSpy = env.sandbox.spy(analytics.win.parent, 'postMessage');
         return waitForNoSendRequest(analytics).then(() => {
           return waitForParentPostMessage();
         });
@@ -1823,7 +1824,7 @@ describes.realWin(
             },
           ],
         });
-        postMessageSpy = sandbox.spy(analytics.win.parent, 'postMessage');
+        postMessageSpy = env.sandbox.spy(analytics.win.parent, 'postMessage');
         return waitForNoSendRequest(analytics).then(() => {
           return waitForNoParentPostMessage();
         });
@@ -1836,7 +1837,7 @@ describes.realWin(
           'requests': {'foo': 'https://example.com/bar'},
           'triggers': [{'on': 'visible'}],
         });
-        postMessageSpy = sandbox.spy(analytics.win.parent, 'postMessage');
+        postMessageSpy = env.sandbox.spy(analytics.win.parent, 'postMessage');
         return waitForNoSendRequest(analytics).then(() => {
           return waitForNoParentPostMessage();
         });
@@ -1854,7 +1855,7 @@ describes.realWin(
             },
           ],
         });
-        postMessageSpy = sandbox.spy(analytics.win.parent, 'postMessage');
+        postMessageSpy = env.sandbox.spy(analytics.win.parent, 'postMessage');
         return waitForSendRequest(analytics).then(() => {
           return waitForParentPostMessage(analytics);
         });

--- a/extensions/amp-analytics/0.1/test/test-analytics-group.js
+++ b/extensions/amp-analytics/0.1/test/test-analytics-group.js
@@ -46,7 +46,7 @@ describes.realWin('AnalyticsGroup', {amp: 1}, env => {
   });
 
   it('should reject trigger in a disallowed environment', () => {
-    sandbox.stub(root, 'getType').callsFake(() => 'other');
+    env.sandbox.stub(root, 'getType').callsFake(() => 'other');
     allowConsoleError(() => {
       expect(() => {
         group.addTrigger({on: 'click', selector: '*'});
@@ -55,7 +55,7 @@ describes.realWin('AnalyticsGroup', {amp: 1}, env => {
   });
 
   it('should reject trigger that fails to initialize', () => {
-    sandbox.stub(root, 'getTracker').callsFake(() => {
+    env.sandbox.stub(root, 'getTracker').callsFake(() => {
       throw new Error('intentional');
     });
     expect(() => {
@@ -66,7 +66,7 @@ describes.realWin('AnalyticsGroup', {amp: 1}, env => {
   it('should add "click" trigger', () => {
     const tracker = root.getTracker('click', ClickEventTracker);
     const unlisten = function() {};
-    const stub = sandbox.stub(tracker, 'add').callsFake(() => unlisten);
+    const stub = env.sandbox.stub(tracker, 'add').callsFake(() => unlisten);
     const config = {on: 'click', selector: '*'};
     const handler = function() {};
     expect(group.listeners_).to.be.empty;
@@ -83,7 +83,7 @@ describes.realWin('AnalyticsGroup', {amp: 1}, env => {
       ScrollEventTracker
     );
     const unlisten = function() {};
-    const stub = sandbox.stub(tracker, 'add').callsFake(() => unlisten);
+    const stub = env.sandbox.stub(tracker, 'add').callsFake(() => unlisten);
     const config = {on: 'scroll', selector: '*'};
     const handler = function() {};
     expect(group.listeners_).to.be.empty;
@@ -105,7 +105,7 @@ describes.realWin('AnalyticsGroup', {amp: 1}, env => {
       CustomEventTracker
     );
     const unlisten = function() {};
-    const stub = sandbox.stub(tracker, 'add').callsFake(() => unlisten);
+    const stub = env.sandbox.stub(tracker, 'add').callsFake(() => unlisten);
     const config = {on: 'custom-event-1', selector: '*'};
     const handler = function() {};
     expect(group.listeners_).to.be.empty;
@@ -128,7 +128,7 @@ describes.realWin('AnalyticsGroup', {amp: 1}, env => {
     expect(tracker).to.be.instanceOf(SignalTracker);
 
     const unlisten = function() {};
-    const stub = sandbox.stub(tracker, 'add').callsFake(() => unlisten);
+    const stub = env.sandbox.stub(tracker, 'add').callsFake(() => unlisten);
     const handler = function() {};
     group.addTrigger(config, handler);
     expect(stub).to.be.calledOnce;
@@ -147,7 +147,7 @@ describes.realWin('AnalyticsGroup', {amp: 1}, env => {
     expect(tracker).to.be.instanceOf(IniLoadTracker);
 
     const unlisten = function() {};
-    const stub = sandbox.stub(tracker, 'add').callsFake(() => unlisten);
+    const stub = env.sandbox.stub(tracker, 'add').callsFake(() => unlisten);
     const handler = function() {};
     group.addTrigger(config, handler);
     expect(stub).to.be.calledOnce;
@@ -162,7 +162,7 @@ describes.realWin('AnalyticsGroup', {amp: 1}, env => {
   it('should add "timer" trigger', () => {
     const handler = function() {};
     const unlisten = function() {};
-    const stub = sandbox
+    const stub = env.sandbox
       .stub(TimerEventTracker.prototype, 'add')
       .callsFake(() => unlisten);
     const config = {on: 'timer'};
@@ -182,7 +182,7 @@ describes.realWin('AnalyticsGroup', {amp: 1}, env => {
     expect(tracker).to.be.instanceOf(VisibilityTracker);
 
     const unlisten = function() {};
-    const stub = sandbox.stub(tracker, 'add').callsFake(() => unlisten);
+    const stub = env.sandbox.stub(tracker, 'add').callsFake(() => unlisten);
     const handler = function() {};
     group.addTrigger(config, handler);
     expect(stub).to.be.calledOnce;
@@ -191,12 +191,12 @@ describes.realWin('AnalyticsGroup', {amp: 1}, env => {
 
   it('should add "visible" trigger for hidden', () => {
     const config = {on: 'hidden'};
-    const getTrackerSpy = sandbox.spy(root, 'getTracker');
+    const getTrackerSpy = env.sandbox.spy(root, 'getTracker');
     group.addTrigger(config, () => {});
     expect(getTrackerSpy).to.be.calledWith('visible');
     const tracker = root.getTrackerOptional('visible');
     const unlisten = function() {};
-    const stub = sandbox.stub(tracker, 'add').callsFake(() => unlisten);
+    const stub = env.sandbox.stub(tracker, 'add').callsFake(() => unlisten);
     group.addTrigger(config, () => {});
     expect(stub).to.be.calledWith(analyticsElement, 'hidden', config);
   });

--- a/extensions/amp-analytics/0.1/test/test-analytics-root.js
+++ b/extensions/amp-analytics/0.1/test/test-analytics-root.js
@@ -88,7 +88,7 @@ describes.realWin('AmpdocAnalyticsRoot', {amp: 1}, env => {
     );
 
     // Dispose.
-    const stub = sandbox.stub(tracker, 'dispose');
+    const stub = env.sandbox.stub(tracker, 'dispose');
     root.dispose();
     expect(stub).to.be.calledOnce;
     expect(root.getTrackerOptional(AnalyticsEventType.CUSTOM)).to.be.null;
@@ -104,12 +104,12 @@ describes.realWin('AmpdocAnalyticsRoot', {amp: 1}, env => {
   });
 
   it('should provide the correct rect for ini-load for main doc', () => {
-    const spy = sandbox.spy(IniLoad, 'whenContentIniLoad');
+    const spy = env.sandbox.spy(IniLoad, 'whenContentIniLoad');
     root.whenIniLoaded();
     expect(spy).to.be.calledWith(
       ampdoc,
       win,
-      sinon.match({
+      env.sandbox.match({
         top: 0,
         left: 0,
         width: win.innerWidth,
@@ -120,18 +120,18 @@ describes.realWin('AmpdocAnalyticsRoot', {amp: 1}, env => {
 
   it('should provide the correct rect for ini-load for inabox', () => {
     win.__AMP_MODE = {runtime: 'inabox'};
-    sandbox.stub(viewport, 'getLayoutRect').callsFake(element => {
+    env.sandbox.stub(viewport, 'getLayoutRect').callsFake(element => {
       if (element == win.document.documentElement) {
         return {left: 10, top: 11, width: 100, height: 200};
       }
     });
-    const spy = sandbox.spy(IniLoad, 'whenContentIniLoad');
+    const spy = env.sandbox.spy(IniLoad, 'whenContentIniLoad');
 
     root.whenIniLoaded();
     expect(spy).to.be.calledWith(
       ampdoc,
       win,
-      sinon.match({
+      env.sandbox.match({
         left: 10,
         top: 11,
         width: 100,
@@ -150,8 +150,8 @@ describes.realWin('AmpdocAnalyticsRoot', {amp: 1}, env => {
   });
 
   it('should create correct visiblityManager', () => {
-    sandbox.stub(HostServices, 'isAvailable').callsFake(() => true);
-    sandbox.stub(HostServices, 'visibilityForDoc').callsFake(() => {
+    env.sandbox.stub(HostServices, 'isAvailable').callsFake(() => true);
+    env.sandbox.stub(HostServices, 'visibilityForDoc').callsFake(() => {
       return Promise.resolve(mockVisibilityInterface);
     });
     return root.isUsingHostAPI().then(() => {
@@ -161,8 +161,8 @@ describes.realWin('AmpdocAnalyticsRoot', {amp: 1}, env => {
   });
 
   it('should fallback to correct visibilityManager', () => {
-    sandbox.stub(HostServices, 'isAvailable').callsFake(() => true);
-    sandbox.stub(HostServices, 'visibilityForDoc').callsFake(() => {
+    env.sandbox.stub(HostServices, 'isAvailable').callsFake(() => true);
+    env.sandbox.stub(HostServices, 'visibilityForDoc').callsFake(() => {
       return Promise.reject({
         fallback: true,
       });
@@ -298,7 +298,7 @@ describes.realWin('AmpdocAnalyticsRoot', {amp: 1}, env => {
 
       // Root on `target` element.
       const ampdoc1 = new AmpDocShadow(win, 'https://amce.org/', target);
-      sandbox.stub(ampdoc1, 'whenReady').callsFake(() => {
+      env.sandbox.stub(ampdoc1, 'whenReady').callsFake(() => {
         return Promise.resolve();
       });
       const root1 = new AmpdocAnalyticsRoot(ampdoc1);
@@ -311,7 +311,7 @@ describes.realWin('AmpdocAnalyticsRoot', {amp: 1}, env => {
 
       // // Root on `child` element.
       const ampdoc2 = new AmpDocShadow(win, 'https://amce.org/', child);
-      sandbox.stub(ampdoc2, 'whenReady').callsFake(() => {
+      env.sandbox.stub(ampdoc2, 'whenReady').callsFake(() => {
         return Promise.resolve();
       });
       const root2 = new AmpdocAnalyticsRoot(ampdoc2);
@@ -324,7 +324,7 @@ describes.realWin('AmpdocAnalyticsRoot', {amp: 1}, env => {
 
       // // Root on `other` element.
       const ampdoc3 = new AmpDocShadow(win, 'https://amce.org/', other);
-      sandbox.stub(ampdoc3, 'whenReady').callsFake(() => {
+      env.sandbox.stub(ampdoc3, 'whenReady').callsFake(() => {
         return Promise.resolve();
       });
       const root3 = new AmpdocAnalyticsRoot(ampdoc3);
@@ -356,7 +356,7 @@ describes.realWin('AmpdocAnalyticsRoot', {amp: 1}, env => {
 
   describe('createSelectiveListener', () => {
     function matches(context, target, selector, selectionMethod) {
-      const listener = sandbox.spy();
+      const listener = env.sandbox.spy();
       const selective = root.createSelectiveListener(
         listener,
         context,
@@ -450,7 +450,7 @@ describes.realWin('AmpdocAnalyticsRoot', {amp: 1}, env => {
 
     it('should NOT match nodes not in root', () => {
       expect(matches(body, target, '*')).to.equal(target);
-      sandbox.stub(root, 'contains').callsFake(() => false);
+      env.sandbox.stub(root, 'contains').callsFake(() => false);
       expect(matches(body, target, '*')).to.be.null;
     });
   });
@@ -521,7 +521,7 @@ describes.realWin(
       );
 
       // Dispose.
-      const stub = sandbox.stub(tracker, 'dispose');
+      const stub = env.sandbox.stub(tracker, 'dispose');
       root.dispose();
       expect(stub).to.be.calledOnce;
       expect(root.getTrackerOptional(AnalyticsEventType.CUSTOM)).to.be.null;
@@ -554,7 +554,7 @@ describes.realWin(
     });
 
     it('should resolve ini-load signal', () => {
-      const stub = sandbox
+      const stub = env.sandbox
         .stub(embed, 'whenIniLoaded')
         .callsFake(() => Promise.resolve());
       return root.whenIniLoaded().then(() => {
@@ -643,7 +643,7 @@ describes.realWin(
 
     describe('createSelectiveListener', () => {
       function matches(context, target, selector, selectionMethod) {
-        const listener = sandbox.spy();
+        const listener = env.sandbox.spy();
         const selective = root.createSelectiveListener(
           listener,
           context,
@@ -694,7 +694,7 @@ describes.realWin(
 
       it('should NOT match nodes not in root', () => {
         expect(matches(body, target, '*')).to.equal(target);
-        sandbox.stub(root, 'contains').callsFake(() => false);
+        env.sandbox.stub(root, 'contains').callsFake(() => false);
         expect(matches(body, target, '*')).to.be.null;
       });
     });

--- a/extensions/amp-analytics/0.1/test/test-config.js
+++ b/extensions/amp-analytics/0.1/test/test-config.js
@@ -25,12 +25,10 @@ import {user} from '../../../../src/log';
 describes.realWin('AnalyticsConfig', {amp: false}, env => {
   let win;
   let doc;
-  let sandbox;
 
   beforeEach(() => {
     win = env.win;
     doc = win.document;
-    sandbox = env.sandbox;
   });
 
   afterEach(() => {
@@ -895,7 +893,7 @@ describes.realWin('AnalyticsConfig', {amp: false}, env => {
         {'type': 'test-vendor', 'id': 'analyticsId'}
       );
       const usrObj = user();
-      const spy = sandbox.spy(usrObj, 'warn');
+      const spy = env.sandbox.spy(usrObj, 'warn');
 
       return new AnalyticsConfig(element).loadConfig().then(config => {
         expect(spy).callCount(1);
@@ -924,7 +922,7 @@ describes.realWin('AnalyticsConfig', {amp: false}, env => {
         {'type': 'test-vendor', 'id': 'analyticsId'}
       );
       const usrObj = user();
-      const spy = sandbox.spy(usrObj, 'warn');
+      const spy = env.sandbox.spy(usrObj, 'warn');
 
       return new AnalyticsConfig(element).loadConfig().then(config => {
         expect(spy).callCount(1);
@@ -946,7 +944,7 @@ describes.realWin('AnalyticsConfig', {amp: false}, env => {
       );
 
       const usrObj = user();
-      const spy = sandbox.spy(usrObj, 'warn');
+      const spy = env.sandbox.spy(usrObj, 'warn');
       const xhrStub = stubXhr();
       xhrStub.returns(
         Promise.resolve({
@@ -990,7 +988,7 @@ describes.realWin('AnalyticsConfig', {amp: false}, env => {
   function stubXhr() {
     installDocService(win, true);
 
-    const expandStringStub = sandbox.stub();
+    const expandStringStub = env.sandbox.stub();
     expandStringStub.withArgs('CLIENT_ID(foo)').resolves('amp12345');
     expandStringStub.resolvesArg(0);
 
@@ -998,15 +996,18 @@ describes.realWin('AnalyticsConfig', {amp: false}, env => {
       a: 'b',
     };
     expandStringStub.withArgs('$NOT(foo)', macros).resolves('false');
-    stubService(sandbox, win, 'amp-analytics-variables', 'getMacros').returns(
-      macros
-    );
+    stubService(
+      env.sandbox,
+      win,
+      'amp-analytics-variables',
+      'getMacros'
+    ).returns(macros);
 
-    sandbox.stub(Services, 'urlReplacementsForDoc').returns({
+    env.sandbox.stub(Services, 'urlReplacementsForDoc').returns({
       'expandUrlAsync': url => Promise.resolve(url),
       'expandStringAsync': expandStringStub,
     });
 
-    return stubService(sandbox, win, 'xhr', 'fetchJson');
+    return stubService(env.sandbox, win, 'xhr', 'fetchJson');
   }
 });

--- a/extensions/amp-analytics/0.1/test/test-cookie-writer.js
+++ b/extensions/amp-analytics/0.1/test/test-cookie-writer.js
@@ -31,18 +31,16 @@ describes.realWin(
     runtimeOn: true,
   },
   env => {
-    let sandbox;
     let win;
     let doc;
     let setCookieSpy;
     let element;
 
     beforeEach(() => {
-      sandbox = env.sandbox;
-      setCookieSpy = sandbox.spy();
+      setCookieSpy = env.sandbox.spy();
       win = env.win;
       doc = win.document;
-      sandbox.stub(cookie, 'setCookie').callsFake((win, name, value) => {
+      env.sandbox.stub(cookie, 'setCookie').callsFake((win, name, value) => {
         setCookieSpy(name, value);
       });
       element = doc.createElement('div');
@@ -57,7 +55,7 @@ describes.realWin(
       it('Resolve when no config', () => {
         const config = dict({});
         const cookieWriter = new CookieWriter(win, element, config);
-        expandAndWriteSpy = sandbox.spy(cookieWriter, 'expandAndWrite_');
+        expandAndWriteSpy = env.sandbox.spy(cookieWriter, 'expandAndWrite_');
         return cookieWriter.write().then(() => {
           expect(expandAndWriteSpy).to.not.be.called;
         });
@@ -69,7 +67,7 @@ describes.realWin(
         });
         expectAsyncConsoleError(TAG + ' cookies config must be an object');
         const cookieWriter = new CookieWriter(win, element, config);
-        expandAndWriteSpy = sandbox.spy(cookieWriter, 'expandAndWrite_');
+        expandAndWriteSpy = env.sandbox.spy(cookieWriter, 'expandAndWrite_');
         return cookieWriter.write().then(() => {
           expect(expandAndWriteSpy).to.not.be.called;
         });
@@ -88,7 +86,7 @@ describes.realWin(
         doc.body.appendChild(parent);
         parent.appendChild(element);
         const cookieWriter = new CookieWriter(win, element, config);
-        expandAndWriteSpy = sandbox.spy(cookieWriter, 'expandAndWrite_');
+        expandAndWriteSpy = env.sandbox.spy(cookieWriter, 'expandAndWrite_');
         return cookieWriter.write().then(() => {
           expect(expandAndWriteSpy).to.not.be.called;
         });
@@ -108,7 +106,7 @@ describes.realWin(
         installLinkerReaderService(mockWin);
         installVariableServiceForTesting(doc);
         const cookieWriter = new CookieWriter(mockWin, element, config);
-        expandAndWriteSpy = sandbox.spy(cookieWriter, 'expandAndWrite_');
+        expandAndWriteSpy = env.sandbox.spy(cookieWriter, 'expandAndWrite_');
         return cookieWriter.write().then(() => {
           expect(expandAndWriteSpy).to.not.be.called;
         });
@@ -124,7 +122,7 @@ describes.realWin(
           },
         });
         const cookieWriter = new CookieWriter(win, element, config);
-        expandAndWriteSpy = sandbox.spy(cookieWriter, 'expandAndWrite_');
+        expandAndWriteSpy = env.sandbox.spy(cookieWriter, 'expandAndWrite_');
         return cookieWriter.write().then(() => {
           expect(expandAndWriteSpy).to.not.be.called;
         });
@@ -140,7 +138,7 @@ describes.realWin(
           },
         });
         const cookieWriter = new CookieWriter(win, element, config);
-        expandAndWriteSpy = sandbox.spy(cookieWriter, 'expandAndWrite_');
+        expandAndWriteSpy = env.sandbox.spy(cookieWriter, 'expandAndWrite_');
         return cookieWriter.write().then(() => {
           expect(expandAndWriteSpy).to.not.be.called;
         });
@@ -151,7 +149,7 @@ describes.realWin(
           'cookies': {},
         });
         const cookieWriter = new CookieWriter(win, element, config);
-        expandAndWriteSpy = sandbox.spy(cookieWriter, 'expandAndWrite_');
+        expandAndWriteSpy = env.sandbox.spy(cookieWriter, 'expandAndWrite_');
         return cookieWriter.write().then(() => {
           expect(expandAndWriteSpy).to.not.be.called;
         });
@@ -167,7 +165,7 @@ describes.realWin(
           TAG + ' cookieValue must be configured in an object'
         );
         const cookieWriter = new CookieWriter(win, element, config);
-        expandAndWriteSpy = sandbox.spy(cookieWriter, 'expandAndWrite_');
+        expandAndWriteSpy = env.sandbox.spy(cookieWriter, 'expandAndWrite_');
         return cookieWriter.write().then(() => {
           expect(expandAndWriteSpy).to.not.be.called;
         });
@@ -185,7 +183,7 @@ describes.realWin(
           TAG + ' value is required in the cookieValue object'
         );
         const cookieWriter = new CookieWriter(win, element, config);
-        expandAndWriteSpy = sandbox.spy(cookieWriter, 'expandAndWrite_');
+        expandAndWriteSpy = env.sandbox.spy(cookieWriter, 'expandAndWrite_');
         return cookieWriter.write().then(() => {
           expect(expandAndWriteSpy).to.not.be.called;
         });
@@ -200,7 +198,7 @@ describes.realWin(
           },
         });
         const cookieWriter = new CookieWriter(win, element, config);
-        expandAndWriteSpy = sandbox.spy(cookieWriter, 'expandAndWrite_');
+        expandAndWriteSpy = env.sandbox.spy(cookieWriter, 'expandAndWrite_');
         return cookieWriter.write().then(() => {
           expect(expandAndWriteSpy).to.not.be.called;
         });

--- a/extensions/amp-analytics/0.1/test/test-events.js
+++ b/extensions/amp-analytics/0.1/test/test-events.js
@@ -46,7 +46,7 @@ describes.realWin('Events', {amp: 1}, env => {
     win = env.win;
     ampdoc = env.ampdoc;
     root = new AmpdocAnalyticsRoot(ampdoc);
-    handler = sandbox.spy();
+    handler = env.sandbox.spy();
 
     analyticsElement = win.document.createElement('amp-analytics');
     win.document.body.appendChild(analyticsElement);
@@ -101,7 +101,7 @@ describes.realWin('Events', {amp: 1}, env => {
 
     it('should add listener', () => {
       const selUnlisten = function() {};
-      const selListenerStub = sandbox
+      const selListenerStub = env.sandbox
         .stub(root, 'createSelectiveListener')
         .callsFake(() => selUnlisten);
       tracker.add(
@@ -121,7 +121,7 @@ describes.realWin('Events', {amp: 1}, env => {
     });
 
     it('should add listener with default selection method', () => {
-      const selListenerStub = sandbox.stub(root, 'createSelectiveListener');
+      const selListenerStub = env.sandbox.stub(root, 'createSelectiveListener');
       tracker.add(analyticsElement, 'click', {selector: '*'}, handler);
       expect(selListenerStub.args[0][3]).to.be.null; // Default selection method.
     });
@@ -151,7 +151,7 @@ describes.realWin('Events', {amp: 1}, env => {
       target.click();
       expect(handler).to.be.calledOnce;
 
-      const handler2 = sandbox.spy();
+      const handler2 = env.sandbox.spy();
       tracker.add(analyticsElement, 'click', {selector: '.target'}, handler2);
       child.click();
       expect(handler).to.be.calledTwice;
@@ -160,7 +160,7 @@ describes.realWin('Events', {amp: 1}, env => {
 
     it('should only stop on the first found target', () => {
       tracker.add(analyticsElement, 'click', {selector: '.target'}, handler);
-      const handler2 = sandbox.spy();
+      const handler2 = env.sandbox.spy();
       tracker.add(analyticsElement, 'click', {selector: '.child'}, handler2);
       target.click();
       child.click();
@@ -193,14 +193,14 @@ describes.realWin('Events', {amp: 1}, env => {
     beforeEach(() => {
       tracker = root.getTracker(AnalyticsEventType.SCROLL, ScrollEventTracker);
       fakeViewport = {
-        'getSize': sandbox
+        'getSize': env.sandbox
           .stub()
           .returns({top: 0, left: 0, height: 200, width: 200}),
-        'getScrollTop': sandbox.stub().returns(0),
-        'getScrollLeft': sandbox.stub().returns(0),
-        'getScrollHeight': sandbox.stub().returns(500),
-        'getScrollWidth': sandbox.stub().returns(500),
-        'onChanged': sandbox.stub(),
+        'getScrollTop': env.sandbox.stub().returns(0),
+        'getScrollLeft': env.sandbox.stub().returns(0),
+        'getScrollHeight': env.sandbox.stub().returns(500),
+        'getScrollWidth': env.sandbox.stub().returns(500),
+        'onChanged': env.sandbox.stub(),
       };
       scrollManager = tracker.root_.getScrollManager();
       scrollManager.viewport_ = fakeViewport;
@@ -226,7 +226,7 @@ describes.realWin('Events', {amp: 1}, env => {
         undefined,
         AnalyticsEventType.SCROLL,
         defaultScrollConfig,
-        sandbox.stub()
+        env.sandbox.stub()
       );
       expect(scrollManager.scrollObservable_.getHandlerCount()).to.equal(1);
 
@@ -235,8 +235,8 @@ describes.realWin('Events', {amp: 1}, env => {
     });
 
     it('fires on scroll', () => {
-      const fn1 = sandbox.stub();
-      const fn2 = sandbox.stub();
+      const fn1 = env.sandbox.stub();
+      const fn2 = env.sandbox.stub();
       tracker.add(
         undefined,
         AnalyticsEventType.SCROLL,
@@ -265,10 +265,10 @@ describes.realWin('Events', {amp: 1}, env => {
         };
       }
       expect(fn1).to.have.callCount(2);
-      expect(fn1.getCall(0).calledWithMatch(sinon.match(matcher(0)))).to.be
-        .true;
-      expect(fn1.getCall(1).calledWithMatch(sinon.match(matcher(0)))).to.be
-        .true;
+      expect(fn1.getCall(0).calledWithMatch(env.sandbox.match(matcher(0)))).to
+        .be.true;
+      expect(fn1.getCall(1).calledWithMatch(env.sandbox.match(matcher(0)))).to
+        .be.true;
       expect(fn2).to.have.not.been.called;
 
       // Scroll Down
@@ -277,19 +277,19 @@ describes.realWin('Events', {amp: 1}, env => {
       tracker.root_.getScrollManager().onScroll_(getFakeViewportChangedEvent());
 
       expect(fn1).to.have.callCount(4);
-      expect(fn1.getCall(2).calledWithMatch(sinon.match(matcher(100)))).to.be
-        .true;
-      expect(fn1.getCall(3).calledWithMatch(sinon.match(matcher(100)))).to.be
-        .true;
+      expect(fn1.getCall(2).calledWithMatch(env.sandbox.match(matcher(100)))).to
+        .be.true;
+      expect(fn1.getCall(3).calledWithMatch(env.sandbox.match(matcher(100)))).to
+        .be.true;
       expect(fn2).to.have.callCount(2);
-      expect(fn2.getCall(0).calledWithMatch(sinon.match(matcher(90)))).to.be
-        .true;
-      expect(fn2.getCall(1).calledWithMatch(sinon.match(matcher(90)))).to.be
-        .true;
+      expect(fn2.getCall(0).calledWithMatch(env.sandbox.match(matcher(90)))).to
+        .be.true;
+      expect(fn2.getCall(1).calledWithMatch(env.sandbox.match(matcher(90)))).to
+        .be.true;
     });
 
     it('does not fire duplicates on scroll', () => {
-      const fn1 = sandbox.stub();
+      const fn1 = env.sandbox.stub();
       tracker.add(
         undefined,
         AnalyticsEventType.SCROLL,
@@ -306,7 +306,7 @@ describes.realWin('Events', {amp: 1}, env => {
     });
 
     it('fails gracefully on bad scroll config', () => {
-      const fn1 = sandbox.stub();
+      const fn1 = env.sandbox.stub();
 
       allowConsoleError(() => {
         tracker.add(
@@ -388,8 +388,8 @@ describes.realWin('Events', {amp: 1}, env => {
     });
 
     it('fires events on normalized boundaries.', () => {
-      const fn1 = sandbox.stub();
-      const fn2 = sandbox.stub();
+      const fn1 = env.sandbox.stub();
+      const fn2 = env.sandbox.stub();
       tracker.add(
         undefined,
         AnalyticsEventType.SCROLL,
@@ -423,9 +423,9 @@ describes.realWin('Events', {amp: 1}, env => {
     let getElementSpy;
 
     beforeEach(() => {
-      clock = sandbox.useFakeTimers();
+      clock = env.sandbox.useFakeTimers();
       tracker = root.getTracker(AnalyticsEventType.CUSTOM, CustomEventTracker);
-      getElementSpy = sandbox.spy(root, 'getElement');
+      getElementSpy = env.sandbox.spy(root, 'getElement');
     });
 
     it('should initalize, add listeners and dispose', () => {
@@ -439,7 +439,7 @@ describes.realWin('Events', {amp: 1}, env => {
     });
 
     it('should listen on custom events', () => {
-      const handler2 = sandbox.spy();
+      const handler2 = env.sandbox.spy();
       tracker.add(analyticsElement, 'custom-event-1', {}, handler);
       tracker.add(analyticsElement, 'custom-event-2', {}, handler2);
       tracker.trigger(new AnalyticsEvent(target, 'custom-event-1'));
@@ -493,7 +493,7 @@ describes.realWin('Events', {amp: 1}, env => {
       const child2 = win.document.createElement('div');
       child2.classList.add('child2');
       target.appendChild(child2);
-      const handler2 = sandbox.spy();
+      const handler2 = env.sandbox.spy();
       tracker.add(
         analyticsElement,
         'custom-event',
@@ -530,8 +530,8 @@ describes.realWin('Events', {amp: 1}, env => {
       expect(tracker.buffer_['custom-event-2']).to.have.length(2);
 
       // Listeners added: immediate events fired.
-      const handler2 = sandbox.spy();
-      const handler3 = sandbox.spy();
+      const handler2 = env.sandbox.spy();
+      const handler3 = env.sandbox.spy();
       tracker.add(analyticsElement, 'custom-event-1', {}, handler);
       tracker.add(analyticsElement, 'custom-event-2', {}, handler2);
       tracker.add(analyticsElement, 'custom-event-3', {}, handler3);
@@ -665,10 +665,10 @@ describes.realWin('Events', {amp: 1}, env => {
     let rootTarget;
 
     beforeEach(() => {
-      clock = sandbox.useFakeTimers();
+      clock = env.sandbox.useFakeTimers();
       tracker = root.getTracker(AnalyticsEventType.STORY, AmpStoryEventTracker);
       rootTarget = root.getRootElement();
-      getRootElementSpy = sandbox.spy(root, 'getRootElement');
+      getRootElementSpy = env.sandbox.spy(root, 'getRootElement');
     });
 
     it('should initalize, add listeners, and dispose', () => {
@@ -680,7 +680,7 @@ describes.realWin('Events', {amp: 1}, env => {
     });
 
     it('should listen on story events', () => {
-      const handler2 = sandbox.spy();
+      const handler2 = env.sandbox.spy();
       tracker.add(analyticsElement, 'story-event-1', {}, handler);
       tracker.add(analyticsElement, 'story-event-2', {}, handler2);
       tracker.trigger(new AnalyticsEvent(target, 'story-event-1'));
@@ -707,8 +707,8 @@ describes.realWin('Events', {amp: 1}, env => {
       expect(tracker.buffer_['story-event-2']).to.have.length(2);
 
       // Listeners added: immediate events fired.
-      const handler2 = sandbox.spy();
-      const handler3 = sandbox.spy();
+      const handler2 = env.sandbox.spy();
+      const handler3 = env.sandbox.spy();
       tracker.add(analyticsElement, 'story-event-1', {}, handler);
       tracker.add(analyticsElement, 'story-event-2', {}, handler2);
       tracker.add(
@@ -957,7 +957,7 @@ describes.realWin('Events', {amp: 1}, env => {
       const promise = new Promise(resolve => {
         resolver = resolve;
       });
-      const iniLoadStub = sandbox
+      const iniLoadStub = env.sandbox
         .stub(root, 'whenIniLoaded')
         .callsFake(() => Promise.resolve());
       tracker.add(analyticsElement, 'ini-load', {}, resolver);
@@ -973,7 +973,7 @@ describes.realWin('Events', {amp: 1}, env => {
       const promise = new Promise(resolve => {
         resolver = resolve;
       });
-      const iniLoadStub = sandbox
+      const iniLoadStub = env.sandbox
         .stub(root, 'whenIniLoaded')
         .callsFake(() => Promise.resolve());
       tracker.add(analyticsElement, 'ini-load', {selector: ':root'}, resolver);
@@ -989,7 +989,7 @@ describes.realWin('Events', {amp: 1}, env => {
       const promise = new Promise(resolve => {
         resolver = resolve;
       });
-      const iniLoadStub = sandbox
+      const iniLoadStub = env.sandbox
         .stub(root, 'whenIniLoaded')
         .callsFake(() => Promise.resolve());
       tracker.add(analyticsElement, 'sig1', {selector: ':host'}, resolver);
@@ -1005,7 +1005,7 @@ describes.realWin('Events', {amp: 1}, env => {
       const promise = new Promise(resolve => {
         resolver = resolve;
       });
-      const spy = sandbox.spy(targetSignals, 'whenSignal');
+      const spy = env.sandbox.spy(targetSignals, 'whenSignal');
       tracker.add(
         analyticsElement,
         'ini-load',
@@ -1025,7 +1025,7 @@ describes.realWin('Events', {amp: 1}, env => {
       const promise = new Promise(resolve => {
         resolver = resolve;
       });
-      const spy = sandbox.spy(targetSignals, 'whenSignal');
+      const spy = env.sandbox.spy(targetSignals, 'whenSignal');
       tracker.add(
         analyticsElement,
         'ini-load',
@@ -1073,7 +1073,7 @@ describes.realWin('Events', {amp: 1}, env => {
     });
 
     it('should validate timerSpec', () => {
-      const handler = sandbox.stub();
+      const handler = env.sandbox.stub();
       allowConsoleError(() => {
         expect(() => {
           tracker.add(analyticsElement, AnalyticsEventType.TIMER, {}, handler);
@@ -1214,7 +1214,7 @@ describes.realWin('Events', {amp: 1}, env => {
     });
 
     it('timers start and stop by tracking different events', () => {
-      const fn1 = sandbox.stub();
+      const fn1 = env.sandbox.stub();
       const clickTracker = root.getTracker('click', ClickEventTracker);
       tracker.add(
         analyticsElement,
@@ -1243,12 +1243,12 @@ describes.realWin('Events', {amp: 1}, env => {
       expect(fn1.args[0][0].type).to.equal(AnalyticsEventType.TIMER);
       target.click(); // Stop timer.
 
-      const fn2 = sandbox.stub();
+      const fn2 = env.sandbox.stub();
       const customTracker = root.getTracker(
         AnalyticsEventType.CUSTOM,
         CustomEventTracker
       );
-      const getElementSpy = sandbox.spy(root, 'getElement');
+      const getElementSpy = env.sandbox.spy(root, 'getElement');
       tracker.add(
         analyticsElement,
         AnalyticsEventType.TIMER,
@@ -1289,7 +1289,7 @@ describes.realWin('Events', {amp: 1}, env => {
       'timers started and stopped by the same event on the same target' +
         ' do not have race condition problems',
       () => {
-        const fn1 = sandbox.stub();
+        const fn1 = env.sandbox.stub();
         tracker.add(
           analyticsElement,
           AnalyticsEventType.TIMER,
@@ -1331,7 +1331,7 @@ describes.realWin('Events', {amp: 1}, env => {
     );
 
     it('only fires when the timer interval exceeds the minimum', () => {
-      const fn1 = sandbox.stub();
+      const fn1 = env.sandbox.stub();
       allowConsoleError(() => {
         expect(() => {
           tracker.add(
@@ -1348,7 +1348,7 @@ describes.realWin('Events', {amp: 1}, env => {
       });
       expect(fn1).to.have.not.been.called;
 
-      const fn2 = sandbox.stub();
+      const fn2 = env.sandbox.stub();
       tracker.add(
         analyticsElement,
         AnalyticsEventType.TIMER,
@@ -1366,7 +1366,7 @@ describes.realWin('Events', {amp: 1}, env => {
     });
 
     it('fires on the appropriate interval', () => {
-      const fn1 = sandbox.stub();
+      const fn1 = env.sandbox.stub();
       tracker.add(
         analyticsElement,
         AnalyticsEventType.TIMER,
@@ -1379,7 +1379,7 @@ describes.realWin('Events', {amp: 1}, env => {
       );
       expect(fn1).to.be.calledOnce;
 
-      const fn2 = sandbox.stub();
+      const fn2 = env.sandbox.stub();
       tracker.add(
         analyticsElement,
         AnalyticsEventType.TIMER,
@@ -1392,7 +1392,7 @@ describes.realWin('Events', {amp: 1}, env => {
       );
       expect(fn2).to.be.calledOnce;
 
-      const fn3 = sandbox.stub();
+      const fn3 = env.sandbox.stub();
       tracker.add(
         analyticsElement,
         AnalyticsEventType.TIMER,
@@ -1406,7 +1406,7 @@ describes.realWin('Events', {amp: 1}, env => {
       );
       expect(fn3).to.have.not.been.called;
 
-      const fn4 = sandbox.stub();
+      const fn4 = env.sandbox.stub();
       tracker.add(
         analyticsElement,
         AnalyticsEventType.TIMER,
@@ -1444,7 +1444,7 @@ describes.realWin('Events', {amp: 1}, env => {
     });
 
     it('stops firing after the maxTimerLength is exceeded', () => {
-      const fn1 = sandbox.stub();
+      const fn1 = env.sandbox.stub();
       tracker.add(
         analyticsElement,
         AnalyticsEventType.TIMER,
@@ -1458,7 +1458,7 @@ describes.realWin('Events', {amp: 1}, env => {
       );
       expect(fn1).to.be.calledOnce;
 
-      const fn2 = sandbox.stub();
+      const fn2 = env.sandbox.stub();
       tracker.add(
         analyticsElement,
         AnalyticsEventType.TIMER,
@@ -1472,7 +1472,7 @@ describes.realWin('Events', {amp: 1}, env => {
       );
       expect(fn2).to.be.calledOnce;
 
-      const fn3 = sandbox.stub();
+      const fn3 = env.sandbox.stub();
       tracker.add(
         analyticsElement,
         AnalyticsEventType.TIMER,
@@ -1485,7 +1485,7 @@ describes.realWin('Events', {amp: 1}, env => {
       );
       expect(fn3).to.be.calledOnce;
 
-      const fn4 = sandbox.stub();
+      const fn4 = env.sandbox.stub();
       tracker.add(
         analyticsElement,
         AnalyticsEventType.TIMER,
@@ -1499,7 +1499,7 @@ describes.realWin('Events', {amp: 1}, env => {
         fn4
       );
 
-      const fn5 = sandbox.stub();
+      const fn5 = env.sandbox.stub();
       tracker.add(
         analyticsElement,
         AnalyticsEventType.TIMER,
@@ -1548,7 +1548,7 @@ describes.realWin('Events', {amp: 1}, env => {
     });
 
     it('should unlisten tracker', () => {
-      const fn1 = sandbox.stub();
+      const fn1 = env.sandbox.stub();
       const u1 = tracker.add(
         analyticsElement,
         AnalyticsEventType.TIMER,
@@ -1562,7 +1562,7 @@ describes.realWin('Events', {amp: 1}, env => {
       );
       expect(fn1).to.be.calledOnce;
 
-      const fn2 = sandbox.stub();
+      const fn2 = env.sandbox.stub();
       const u2 = tracker.add(
         analyticsElement,
         AnalyticsEventType.TIMER,
@@ -1589,7 +1589,7 @@ describes.realWin('Events', {amp: 1}, env => {
     });
 
     it('should dispose all trackers', () => {
-      const fn1 = sandbox.stub();
+      const fn1 = env.sandbox.stub();
       tracker.add(
         analyticsElement,
         AnalyticsEventType.TIMER,
@@ -1603,7 +1603,7 @@ describes.realWin('Events', {amp: 1}, env => {
       );
       expect(fn1).to.be.calledOnce;
 
-      const fn2 = sandbox.stub();
+      const fn2 = env.sandbox.stub();
       tracker.add(
         analyticsElement,
         AnalyticsEventType.TIMER,
@@ -1624,7 +1624,7 @@ describes.realWin('Events', {amp: 1}, env => {
     });
 
     it('should create events with timer vars', () => {
-      const handler = sandbox.stub();
+      const handler = env.sandbox.stub();
       tracker.add(
         analyticsElement,
         AnalyticsEventType.TIMER,
@@ -1642,7 +1642,7 @@ describes.realWin('Events', {amp: 1}, env => {
 
       // Fake out the time since clock.tick will not actually advance the time.
       let fakeTime = 1000; // 1 second past epoch
-      sandbox.stub(Date, 'now').callsFake(() => {
+      env.sandbox.stub(Date, 'now').callsFake(() => {
         return fakeTime;
       });
       target.click();
@@ -1691,13 +1691,15 @@ describes.realWin('Events', {amp: 1}, env => {
 
     beforeEach(() => {
       tracker = root.getTracker('visible', VisibilityTracker);
-      visibilityManagerMock = sandbox.mock(root.getVisibilityManager());
-      getAmpElementSpy = sandbox.spy(root, 'getAmpElement');
+      visibilityManagerMock = env.sandbox.mock(root.getVisibilityManager());
+      getAmpElementSpy = env.sandbox.spy(root, 'getAmpElement');
       tracker.waitForTrackers_['ini-load'] = root.getTracker(
         'ini-load',
         IniLoadTracker
       );
-      iniLoadTrackerMock = sandbox.mock(tracker.waitForTrackers_['ini-load']);
+      iniLoadTrackerMock = env.sandbox.mock(
+        tracker.waitForTrackers_['ini-load']
+      );
 
       target.classList.add('i-amphtml-element');
       targetSignals = new Signals();
@@ -1707,10 +1709,10 @@ describes.realWin('Events', {amp: 1}, env => {
         eventResolver = resolve;
       });
 
-      matchEmptySpec = sinon.match(arg => {
+      matchEmptySpec = env.sandbox.match(arg => {
         return Object.keys(arg).length == 0;
       });
-      matchFunc = sinon.match(arg => {
+      matchFunc = env.sandbox.match(arg => {
         if (typeof arg == 'function') {
           const promise = arg();
           if (typeof promise.then == 'function') {
@@ -1719,7 +1721,7 @@ describes.realWin('Events', {amp: 1}, env => {
         }
         return false;
       });
-      saveCallback = sinon.match(arg => {
+      saveCallback = env.sandbox.match(arg => {
         if (typeof arg == 'function') {
           saveCallback.callback = arg;
           return true;
@@ -1737,7 +1739,7 @@ describes.realWin('Events', {amp: 1}, env => {
     });
 
     it('should add doc listener', function*() {
-      const unlisten = sandbox.spy();
+      const unlisten = env.sandbox.spy();
       iniLoadTrackerMock.expects('getRootSignal').never();
       iniLoadTrackerMock.expects('getElementSignal').never();
       visibilityManagerMock
@@ -1764,7 +1766,7 @@ describes.realWin('Events', {amp: 1}, env => {
 
     it('should add root listener', function*() {
       const config = {selector: ':root'};
-      const unlisten = sandbox.spy();
+      const unlisten = env.sandbox.spy();
       iniLoadTrackerMock.expects('getElementSignal').never();
       const readyPromise = Promise.resolve();
       iniLoadTrackerMock
@@ -1790,7 +1792,7 @@ describes.realWin('Events', {amp: 1}, env => {
 
     it('should add host listener and spec', function*() {
       const config = {visibilitySpec: {selector: ':host'}};
-      const unlisten = sandbox.spy();
+      const unlisten = env.sandbox.spy();
       iniLoadTrackerMock.expects('getElementSignal').never();
       const readyPromise = Promise.resolve();
       iniLoadTrackerMock
@@ -1821,7 +1823,7 @@ describes.realWin('Events', {amp: 1}, env => {
 
     it('should add target listener', function*() {
       const config = {visibilitySpec: {selector: '.target'}};
-      const unlisten = sandbox.spy();
+      const unlisten = env.sandbox.spy();
       iniLoadTrackerMock.expects('getRootSignal').once();
       const readyPromise = Promise.resolve();
       iniLoadTrackerMock
@@ -1866,7 +1868,7 @@ describes.realWin('Events', {amp: 1}, env => {
       target.setAttribute('data-vars-foo', 'bar');
 
       const config = {selector: '.target'};
-      const unlisten = sandbox.spy();
+      const unlisten = env.sandbox.spy();
       iniLoadTrackerMock.expects('getRootSignal').never();
       const readyPromise = Promise.resolve();
 
@@ -2000,7 +2002,7 @@ describes.realWin('Events', {amp: 1}, env => {
           'render-start',
           SignalTracker
         );
-        const signalTrackerMock = sandbox.mock(
+        const signalTrackerMock = env.sandbox.mock(
           tracker.waitForTrackers_['render-start']
         );
         signalTrackerMock
@@ -2038,7 +2040,7 @@ describes.realWin('Events', {amp: 1}, env => {
 
     describe('should create correct reportReadyPromise', () => {
       it('with viewer hidden', () => {
-        const stub = sandbox.stub(ampdoc, 'isVisible').returns(false);
+        const stub = env.sandbox.stub(ampdoc, 'isVisible').returns(false);
         const promise = tracker.createReportReadyPromiseForDocumentHidden_();
         return promise.then(() => {
           expect(stub).to.be.calledOnce;
@@ -2049,12 +2051,12 @@ describes.realWin('Events', {amp: 1}, env => {
         const config = {visibilitySpec: {reportWhen: 'documentExit'}};
         const tracker = root.getTracker('visible', VisibilityTracker);
         const deferred = new Deferred();
-        const handlerSpy = sandbox.spy();
+        const handlerSpy = env.sandbox.spy();
         const handler = event => {
           deferred.resolve(event);
           handlerSpy();
         };
-        sandbox.stub(tracker, 'supportsPageHide_').returns(false);
+        env.sandbox.stub(tracker, 'supportsPageHide_').returns(false);
 
         tracker.add(tracker.root, 'visible', config, handler);
 
@@ -2073,7 +2075,7 @@ describes.realWin('Events', {amp: 1}, env => {
         const tracker = root.getTracker('visible', VisibilityTracker);
 
         const deferred = new Deferred();
-        const handlerSpy = sandbox.spy();
+        const handlerSpy = env.sandbox.spy();
         const handler = event => {
           deferred.resolve(event);
           handlerSpy();
@@ -2094,12 +2096,12 @@ describes.realWin('Events', {amp: 1}, env => {
         const config = {visibilitySpec: {reportWhen: 'documentExit'}};
         const tracker = root.getTracker('visible', VisibilityTracker);
         const deferred = new Deferred();
-        const handlerSpy = sandbox.spy();
+        const handlerSpy = env.sandbox.spy();
         const handler = event => {
           deferred.resolve(event);
           handlerSpy();
         };
-        sandbox.stub(tracker, 'supportsPageHide_').returns(true);
+        env.sandbox.stub(tracker, 'supportsPageHide_').returns(true);
 
         tracker.add(tracker.root, 'visible', config, handler);
 
@@ -2122,7 +2124,7 @@ describes.realWin('Events', {amp: 1}, env => {
 
     describe('Unmeasurable with HostAPI', () => {
       beforeEach(() => {
-        sandbox.stub(tracker.root, 'isUsingHostAPI').callsFake(() => {
+        env.sandbox.stub(tracker.root, 'isUsingHostAPI').callsFake(() => {
           return Promise.resolve(true);
         });
       });

--- a/extensions/amp-analytics/0.1/test/test-iframe-transport-client.js
+++ b/extensions/amp-analytics/0.1/test/test-iframe-transport-client.js
@@ -29,19 +29,13 @@ function createUniqueId() {
 }
 
 describe('iframe-transport-client', () => {
-  let sandbox;
   let iframeTransportClient;
   let sentinel;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox;
     sentinel = createUniqueId();
     window.name = JSON.stringify({sentinel, type: 'some-vendor'});
     iframeTransportClient = new IframeTransportClient(window);
-  });
-
-  afterEach(() => {
-    sandbox.restore();
   });
 
   /**
@@ -129,7 +123,7 @@ describe('iframe-transport-client', () => {
   });
 
   it('calls onNewContextInstance', () => {
-    const onNewContextInstanceSpy = sandbox.spy();
+    const onNewContextInstanceSpy = window.sandbox.spy();
     window.onNewContextInstance = ctx => onNewContextInstanceSpy(ctx);
     const ctx = new IframeTransportContext(
       window,
@@ -143,7 +137,7 @@ describe('iframe-transport-client', () => {
   });
 
   it('Sets listener and baseMessage properly', () => {
-    const onNewContextInstanceSpy = sandbox.spy();
+    const onNewContextInstanceSpy = window.sandbox.spy();
     window.onNewContextInstance = ctx => onNewContextInstanceSpy(ctx);
     const ctx = new IframeTransportContext(
       window,
@@ -155,8 +149,8 @@ describe('iframe-transport-client', () => {
     expect(ctx.baseMessage_).to.not.be.null;
     expect(ctx.baseMessage_.creativeId).to.equal('my_creative');
     expect(ctx.baseMessage_.vendor).to.equal('my_vendor');
-    const listener1 = sandbox.spy();
-    const listener2 = sandbox.spy();
+    const listener1 = window.sandbox.spy();
+    const listener2 = window.sandbox.spy();
     ctx.onAnalyticsEvent(listener1);
     expect(ctx.listener_).to.equal(listener1);
     ctx.onAnalyticsEvent(listener2);
@@ -165,7 +159,7 @@ describe('iframe-transport-client', () => {
   });
 
   it('dispatches event', () => {
-    const onNewContextInstanceSpy = sandbox.spy();
+    const onNewContextInstanceSpy = window.sandbox.spy();
     window.onNewContextInstance = ctx => onNewContextInstanceSpy(ctx);
     const ctx = new IframeTransportContext(
       window,
@@ -173,7 +167,7 @@ describe('iframe-transport-client', () => {
       'my_creative',
       'my_vendor'
     );
-    const listener = sandbox.spy();
+    const listener = window.sandbox.spy();
     ctx.onAnalyticsEvent(listener);
     const event = 'Something important happened';
     ctx.dispatch(event);
@@ -183,7 +177,7 @@ describe('iframe-transport-client', () => {
   });
 
   it('sends response', () => {
-    const onNewContextInstanceSpy = sandbox.spy();
+    const onNewContextInstanceSpy = window.sandbox.spy();
     window.onNewContextInstance = ctx => onNewContextInstanceSpy(ctx);
     // This const exists solely to avoid triggering a false positive on the
     // presubmit rule that says you can't call stub() on a cross-domain iframe.
@@ -195,7 +189,7 @@ describe('iframe-transport-client', () => {
       'my_vendor'
     );
     const response = {foo: 'bar', answer: '42'};
-    sandbox.stub(imc, 'sendMessage').callsFake((type, opt_payload) => {
+    window.sandbox.stub(imc, 'sendMessage').callsFake((type, opt_payload) => {
       expect(type).to.equal(MessageType.IFRAME_TRANSPORT_RESPONSE);
       expect(opt_payload).to.not.be.null;
       expect(opt_payload.creativeId).to.equal('my_creative');

--- a/extensions/amp-analytics/0.1/test/test-iframe-transport-message-queue.js
+++ b/extensions/amp-analytics/0.1/test/test-iframe-transport-message-queue.js
@@ -34,8 +34,6 @@ describes.realWin(
       queue = new IframeTransportMessageQueue(env.win, frame);
     });
 
-    afterEach(() => {});
-
     it('is empty when first created ', () => {
       expect(queue.queueSize()).to.equal(0);
     });

--- a/extensions/amp-analytics/0.1/test/test-iframe-transport.js
+++ b/extensions/amp-analytics/0.1/test/test-iframe-transport.js
@@ -24,12 +24,10 @@ import {urls} from '../../../../src/config';
 import {user} from '../../../../src/log';
 
 describes.realWin('amp-analytics.iframe-transport', {amp: true}, env => {
-  let sandbox;
   let iframeTransport;
   const frameUrl = 'http://example.com';
 
   beforeEach(() => {
-    sandbox = env.sandbox;
     iframeTransport = new IframeTransport(
       env.ampdoc.win,
       'some_vendor_type',
@@ -50,7 +48,7 @@ describes.realWin('amp-analytics.iframe-transport', {amp: true}, env => {
   }
 
   it('creates one frame per vendor type', () => {
-    const createCrossDomainIframeSpy = sandbox.spy(
+    const createCrossDomainIframeSpy = env.sandbox.spy(
       iframeTransport,
       'createCrossDomainIframe'
     );
@@ -153,7 +151,7 @@ describes.realWin('amp-analytics.iframe-transport', {amp: true}, env => {
   });
 
   it('creates one PerformanceObserver per vendor type', () => {
-    const createPerformanceObserverSpy = sandbox.spy(
+    const createPerformanceObserverSpy = env.sandbox.spy(
       IframeTransport.prototype,
       'createPerformanceObserver_'
     );
@@ -227,15 +225,15 @@ describes.realWin(
           '/amp4test/compose-doc',
         {body}
       );
-      sandbox.stub(env.ampdoc.win.document.body, 'appendChild');
+      env.sandbox.stub(env.ampdoc.win.document.body, 'appendChild');
       new IframeTransport(
         env.ampdoc.win,
         'some_other_vendor_type',
         {iframe: frameUrl2},
         frameUrl2 + '-3'
       );
-      sandbox.restore();
-      const errorSpy = sandbox.spy(user(), 'error');
+      env.sandbox.restore();
+      const errorSpy = env.sandbox.spy(user(), 'error');
       const {frame} = IframeTransport.getFrameData('some_other_vendor_type');
       frame.setAttribute('style', '');
       env.ampdoc.win.document.body.appendChild(frame);

--- a/extensions/amp-analytics/0.1/test/test-instrumentation.js
+++ b/extensions/amp-analytics/0.1/test/test-instrumentation.js
@@ -46,7 +46,7 @@ describes.realWin('InstrumentationService', {amp: 1}, env => {
     expect(root.ampdoc).to.equal(ampdoc);
     expect(root).to.be.instanceof(AmpdocAnalyticsRoot);
 
-    const stub = sandbox.stub(root, 'dispose');
+    const stub = env.sandbox.stub(root, 'dispose');
     service.dispose();
     expect(stub).to.be.calledOnce;
   });
@@ -56,7 +56,7 @@ describes.realWin('InstrumentationService', {amp: 1}, env => {
       AnalyticsEventType.CUSTOM,
       CustomEventTracker
     );
-    const triggerStub = sandbox.stub(tracker, 'trigger');
+    const triggerStub = env.sandbox.stub(tracker, 'trigger');
     service.triggerEventForTarget(target, 'test-event', {foo: 'bar'});
     expect(triggerStub).to.be.calledOnce;
 
@@ -115,7 +115,7 @@ describes.realWin(
     it('should create embed root for ampdoc-fie', () => {
       const parentAmpdoc = ampdoc;
       ampdoc = new AmpDocFie(win, 'https://example.org', parentAmpdoc);
-      sandbox.stub(Services, 'ampdoc').callsFake(context => {
+      env.sandbox.stub(Services, 'ampdoc').callsFake(context => {
         if (context == win.document) {
           return ampdoc;
         }

--- a/extensions/amp-analytics/0.1/test/test-linker-manager.js
+++ b/extensions/amp-analytics/0.1/test/test-linker-manager.js
@@ -31,7 +31,6 @@ import {mockWindowInterface} from '../../../../testing/test-helper';
 
 // TODO(ccordry): Refactor all these tests with async/await.
 describes.realWin('Linker Manager', {amp: true}, env => {
-  let sandbox;
   let ampdoc;
   let win;
   let doc;
@@ -42,18 +41,17 @@ describes.realWin('Linker Manager', {amp: true}, env => {
   let beforeSubmitStub;
 
   beforeEach(() => {
-    sandbox = env.sandbox;
     ampdoc = env.ampdoc;
     win = env.win;
     doc = win.document;
-    windowInterface = mockWindowInterface(sandbox);
+    windowInterface = mockWindowInterface(env.sandbox);
 
-    beforeSubmitStub = sandbox.stub();
-    sandbox.stub(Services, 'formSubmitForDoc').resolves({
+    beforeSubmitStub = env.sandbox.stub();
+    env.sandbox.stub(Services, 'formSubmitForDoc').resolves({
       beforeSubmit: beforeSubmitStub,
     });
 
-    sandbox.stub(Services, 'documentInfoForDoc').returns({
+    env.sandbox.stub(Services, 'documentInfoForDoc').returns({
       sourceUrl: 'https://amp.source.com/some/path?q=123',
       canonicalUrl: 'https://www.canonical.com/some/path?q=123',
     });
@@ -63,7 +61,7 @@ describes.realWin('Linker Manager', {amp: true}, env => {
 
     anchorClickHandlers = [];
     navigateToHandlers = [];
-    sandbox.stub(Services, 'navigationForDoc').returns({
+    env.sandbox.stub(Services, 'navigationForDoc').returns({
       registerAnchorMutator: (callback, priority) => {
         if (priority === Priority.ANALYTICS_LINKER) {
           anchorClickHandlers.push(callback);
@@ -188,8 +186,8 @@ describes.realWin('Linker Manager', {amp: true}, env => {
         'Safari/537.36'
     );
     windowInterface.getUserLanguage.returns('en-US');
-    sandbox.useFakeTimers(1533329483292);
-    sandbox.stub(Date.prototype, 'getTimezoneOffset').returns(420);
+    env.sandbox.useFakeTimers(1533329483292);
+    env.sandbox.stub(Date.prototype, 'getTimezoneOffset').returns(420);
     doc.title = 'TEST TITLE';
     const config = {
       linkers: {
@@ -272,8 +270,8 @@ describes.realWin('Linker Manager', {amp: true}, env => {
   });
 
   it('should generate a param valid for ingestion 5 min later', () => {
-    const clock = sandbox.useFakeTimers(1533329483292);
-    sandbox.stub(Date.prototype, 'getTimezoneOffset').returns(420);
+    const clock = env.sandbox.useFakeTimers(1533329483292);
+    env.sandbox.stub(Date.prototype, 'getTimezoneOffset').returns(420);
     const config = {
       linkers: {
         enabled: true,
@@ -439,7 +437,9 @@ describes.realWin('Linker Manager', {amp: true}, env => {
     });
 
     it('should match all subdomain and w/o destinationDomains', () => {
-      sandbox.stub(Cookies, 'getHighestAvailableDomain').returns('test.com');
+      env.sandbox
+        .stub(Cookies, 'getHighestAvailableDomain')
+        .returns('test.com');
       const config = {
         linkers: {
           enabled: true,
@@ -470,7 +470,7 @@ describes.realWin('Linker Manager', {amp: true}, env => {
     });
 
     it('should match friendly domain as fallback', () => {
-      sandbox.stub(Cookies, 'getHighestAvailableDomain').returns(null);
+      env.sandbox.stub(Cookies, 'getHighestAvailableDomain').returns(null);
       const config = {
         linkers: {
           enabled: true,
@@ -811,8 +811,8 @@ describes.realWin('Linker Manager', {amp: true}, env => {
 
   function stubPlatform(isSafari, version) {
     const platform = Services.platformFor(ampdoc.win);
-    sandbox.stub(platform, 'isSafari').returns(isSafari);
-    sandbox.stub(platform, 'getMajorVersion').returns(version);
+    env.sandbox.stub(platform, 'isSafari').returns(isSafari);
+    env.sandbox.stub(platform, 'getMajorVersion').returns(version);
   }
 
   describe('form support', () => {
@@ -835,7 +835,7 @@ describes.realWin('Linker Manager', {amp: true}, env => {
 
       return linkerManager.init().then(() => {
         expect(beforeSubmitStub.calledOnce).to.be.true;
-        expect(beforeSubmitStub).to.be.calledWith(sinon.match.func);
+        expect(beforeSubmitStub).to.be.calledWith(env.sandbox.match.func);
       });
     });
 
@@ -860,7 +860,7 @@ describes.realWin('Linker Manager', {amp: true}, env => {
       return linkerManager.init().then(() => {
         const form = createForm();
         form.setAttribute('action', 'https://www.ampproject.com');
-        const setterSpy = sandbox.spy();
+        const setterSpy = env.sandbox.spy();
         linkerManager.handleFormSubmit_({form, actionXhrMutator: setterSpy});
 
         expect(setterSpy.notCalled).to.be.true;
@@ -897,11 +897,11 @@ describes.realWin('Linker Manager', {amp: true}, env => {
         form.setAttribute('action-xhr', 'https://www.ampproject.com');
         form.setAttribute('method', 'get');
 
-        const setterSpy = sandbox.spy();
+        const setterSpy = env.sandbox.spy();
         linkerManager.handleFormSubmit_({form, actionXhrMutator: setterSpy});
         expect(setterSpy).to.be.calledOnce;
         expect(setterSpy).to.be.calledWith(
-          sinon.match(/testLinker=1\*\w{5,7}\*foo*\w+/)
+          env.sandbox.match(/testLinker=1\*\w{5,7}\*foo*\w+/)
         );
       });
     });
@@ -929,12 +929,12 @@ describes.realWin('Linker Manager', {amp: true}, env => {
         form.setAttribute('action-xhr', 'https://www.ampproject.com');
         form.setAttribute('method', 'post');
 
-        const setterSpy = sandbox.spy();
+        const setterSpy = env.sandbox.spy();
         linkerManager.handleFormSubmit_({form, actionXhrMutator: setterSpy});
 
         expect(setterSpy).to.be.calledOnce;
         expect(setterSpy).to.be.calledWith(
-          sinon.match(/testLinker=1\*\w{5,7}\*foo*\w+/)
+          env.sandbox.match(/testLinker=1\*\w{5,7}\*foo*\w+/)
         );
       });
     });
@@ -960,7 +960,7 @@ describes.realWin('Linker Manager', {amp: true}, env => {
       return linkerManager.init().then(() => {
         const form = createForm();
         form.setAttribute('action-xhr', 'https://www.wrongdomain.com');
-        const setterSpy = sandbox.spy();
+        const setterSpy = env.sandbox.spy();
         linkerManager.handleFormSubmit_({form, actionXhrMutator: setterSpy});
         expect(setterSpy).to.not.be.called;
         expect(form.children).to.have.length(0);
@@ -1012,7 +1012,7 @@ describes.realWin('Linker Manager', {amp: true}, env => {
       return Promise.all([p1, p2]).then(() => {
         const form = createForm();
         form.setAttribute('action', 'https://www.source.com');
-        const setterSpy = sandbox.spy();
+        const setterSpy = env.sandbox.spy();
         manager1.handleFormSubmit_({form, actionXhrMutator: setterSpy});
         manager2.handleFormSubmit_({form, actionXhrMutator: setterSpy});
 

--- a/extensions/amp-analytics/0.1/test/test-linker-reader.js
+++ b/extensions/amp-analytics/0.1/test/test-linker-reader.js
@@ -21,17 +21,15 @@ import {
 import {mockWindowInterface} from '../../../../testing/test-helper';
 
 describe('LinkerReader', () => {
-  let sandbox;
   let linkerReader;
   let mockWin;
 
   beforeEach(() => {
     // Can not import from test-linker.js because all test in test-liner.js
     // will be run with the test-linker-reader if we do so.
-    sandbox = sinon.sandbox;
-    sandbox.useFakeTimers(1533329483292);
-    sandbox.stub(Date.prototype, 'getTimezoneOffset').returns(420);
-    mockWin = mockWindowInterface(sandbox);
+    window.sandbox.useFakeTimers(1533329483292);
+    window.sandbox.stub(Date.prototype, 'getTimezoneOffset').returns(420);
+    mockWin = mockWindowInterface(window.sandbox);
     mockWin.getUserAgent.returns(
       'Mozilla/5.0 (X11; Linux x86_64) ' +
         'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.99 ' +
@@ -48,10 +46,6 @@ describe('LinkerReader', () => {
     };
     installLinkerReaderService(mockWin);
     linkerReader = linkerReaderServiceFor(mockWin);
-  });
-
-  afterEach(() => {
-    sandbox.restore();
   });
 
   describe('LinkerReader Service', () => {

--- a/extensions/amp-analytics/0.1/test/test-linker.js
+++ b/extensions/amp-analytics/0.1/test/test-linker.js
@@ -246,24 +246,18 @@ const createLinkerTests = [
 ];
 
 describe('Linker', () => {
-  let sandbox;
   let mockWin;
   beforeEach(() => {
     // Linker uses a timestamp value to generate checksum.
-    sandbox = sinon.sandbox;
-    sandbox.useFakeTimers(BASE_TIME);
-    sandbox.stub(Date.prototype, 'getTimezoneOffset').returns(420);
-    mockWin = mockWindowInterface(sandbox);
+    window.sandbox.useFakeTimers(BASE_TIME);
+    window.sandbox.stub(Date.prototype, 'getTimezoneOffset').returns(420);
+    mockWin = mockWindowInterface(window.sandbox);
     mockWin.getUserAgent.returns(
       'Mozilla/5.0 (X11; Linux x86_64) ' +
         'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.99 ' +
         'Safari/537.36'
     );
     mockWin.getUserLanguage.returns('en-US');
-  });
-
-  afterEach(() => {
-    sandbox.restore();
   });
 
   describe('createLinker', () => {
@@ -284,7 +278,7 @@ describe('Linker', () => {
           expectAsyncConsoleError(TAG + ' ' + test.errorMsg);
         }
         if (test.currentTime) {
-          sandbox.useFakeTimers(test.currentTime);
+          window.sandbox.useFakeTimers(test.currentTime);
         }
         expect(parseLinker(test.value)).to.deep.equal(test.output);
       });

--- a/extensions/amp-analytics/0.1/test/test-requests.js
+++ b/extensions/amp-analytics/0.1/test/test-requests.js
@@ -34,7 +34,7 @@ describes.realWin('Requests', {amp: 1}, env => {
     installVariableServiceForTesting(ampdoc);
     ampdoc.defaultView = env.win;
     clock = lolex.install({target: ampdoc.win});
-    preconnectSpy = sandbox.spy();
+    preconnectSpy = env.sandbox.spy();
     preconnect = {
       url: preconnectSpy,
     };
@@ -61,7 +61,7 @@ describes.realWin('Requests', {amp: 1}, env => {
     describe('send with request origin', () => {
       let spy;
       beforeEach(() => {
-        spy = sandbox.spy();
+        spy = env.sandbox.spy();
       });
 
       it('should prepend request origin', function*() {
@@ -185,7 +185,7 @@ describes.realWin('Requests', {amp: 1}, env => {
 
     describe('batch', () => {
       it('should batch multiple send', function*() {
-        const spy = sandbox.spy();
+        const spy = env.sandbox.spy();
         const r = {'baseUrl': 'r2', 'batchInterval': 1};
         const handler = createRequestHandler(r, spy);
         const expansionOptions = new ExpansionOptions({});
@@ -199,7 +199,7 @@ describes.realWin('Requests', {amp: 1}, env => {
       });
 
       it('should work properly with no batch', function*() {
-        const spy = sandbox.spy();
+        const spy = env.sandbox.spy();
         const r = {'baseUrl': 'r1'};
         const handler = createRequestHandler(r, spy);
         const expansionOptions = new ExpansionOptions({});
@@ -211,7 +211,7 @@ describes.realWin('Requests', {amp: 1}, env => {
 
       it('should preconnect', function*() {
         const r = {'baseUrl': 'r2?cid=CLIENT_ID(scope)&var=${test}'};
-        const handler = createRequestHandler(r, sandbox.spy());
+        const handler = createRequestHandler(r, env.sandbox.spy());
         const expansionOptions = new ExpansionOptions({'test': 'expanded'});
         handler.send({}, {}, expansionOptions, {});
         yield macroTask();
@@ -224,7 +224,7 @@ describes.realWin('Requests', {amp: 1}, env => {
     describe('batch with batchInterval', () => {
       let spy;
       beforeEach(() => {
-        spy = sandbox.spy();
+        spy = env.sandbox.spy();
       });
 
       it('should support number', () => {
@@ -340,7 +340,7 @@ describes.realWin('Requests', {amp: 1}, env => {
     describe('reportWindow', () => {
       let spy;
       beforeEach(() => {
-        spy = sandbox.spy();
+        spy = env.sandbox.spy();
       });
 
       it('should accept reportWindow with number', () => {
@@ -418,7 +418,7 @@ describes.realWin('Requests', {amp: 1}, env => {
 
     describe('batch segments', () => {
       it('should respect config extraUrlParam', function*() {
-        const spy = sandbox.spy();
+        const spy = env.sandbox.spy();
         const r = {'baseUrl': 'r1', 'batchInterval': 1};
         const handler = createRequestHandler(r, spy);
 
@@ -434,7 +434,7 @@ describes.realWin('Requests', {amp: 1}, env => {
       });
 
       it('should respect trigger extraUrlParam', function*() {
-        const spy = sandbox.spy();
+        const spy = env.sandbox.spy();
         const r = {'baseUrl': 'r1', 'batchInterval': 1};
         const handler = createRequestHandler(r, spy);
 
@@ -469,7 +469,7 @@ describes.realWin('Requests', {amp: 1}, env => {
       });
 
       it('should keep extraUrlParam', function*() {
-        const spy = sandbox.spy();
+        const spy = env.sandbox.spy();
         const r = {'baseUrl': 'r1&${extraUrlParams}&r2', 'batchInterval': 1};
         const handler = createRequestHandler(r, spy);
 
@@ -497,7 +497,7 @@ describes.realWin('Requests', {amp: 1}, env => {
 
     describe('batch plugin', () => {
       it('should throw error when defined on non batched request', () => {
-        const spy = sandbox.spy();
+        const spy = env.sandbox.spy();
         const r = {'baseUrl': 'r', 'batchPlugin': '_ping_'};
         try {
           createRequestHandler(r, spy);
@@ -509,7 +509,7 @@ describes.realWin('Requests', {amp: 1}, env => {
       });
 
       it('should throw error with unsupported batchPlugin', () => {
-        const spy = sandbox.spy();
+        const spy = env.sandbox.spy();
         const r = {
           'baseUrl': 'r',
           'batchInterval': 1,
@@ -525,13 +525,13 @@ describes.realWin('Requests', {amp: 1}, env => {
   });
 
   it('should replace dynamic bindings RESOURCE_TIMING', function*() {
-    const spy = sandbox.spy();
+    const spy = env.sandbox.spy();
     const r = {'baseUrl': 'r1&${resourceTiming}'};
     const handler = createRequestHandler(r, spy);
     const expansionOptions = new ExpansionOptions({
       'resourceTiming': 'RESOURCE_TIMING',
     });
-    sandbox
+    env.sandbox
       .stub(ResourceTiming, 'getResourceTiming')
       .returns(Promise.resolve('resource-timing'));
     handler.send({}, {}, expansionOptions);
@@ -540,7 +540,7 @@ describes.realWin('Requests', {amp: 1}, env => {
   });
 
   it('should replace dynamic bindings CONSENT_STATE', function*() {
-    const spy = sandbox.spy();
+    const spy = env.sandbox.spy();
     const r = {'baseUrl': 'r1&$CONSENT_STATEtest&${consentState}test2'};
     const handler = createRequestHandler(r, spy);
     const expansionOptions = new ExpansionOptions({
@@ -552,7 +552,7 @@ describes.realWin('Requests', {amp: 1}, env => {
   });
 
   it('COOKIE read cookie value', function*() {
-    const spy = sandbox.spy();
+    const spy = env.sandbox.spy();
     const r = {'baseUrl': 'r1&c1=COOKIE(test)&c2=${cookie(test)}'};
     let handler = createRequestHandler(r, spy);
     const expansionOptions = new ExpansionOptions({

--- a/extensions/amp-analytics/0.1/test/test-resource-timing.js
+++ b/extensions/amp-analytics/0.1/test/test-resource-timing.js
@@ -101,7 +101,7 @@ describes.realWin('resourceTiming', {amp: true}, env => {
     resourceTimingSpec,
     expectedResult
   ) {
-    sandbox.stub(win.performance, 'getEntriesByType').returns(fakeEntries);
+    env.sandbox.stub(win.performance, 'getEntriesByType').returns(fakeEntries);
     return getResourceTiming(ampdoc, resourceTimingSpec, Date.now()).then(
       result => {
         expect(result).to.equal(expectedResult);
@@ -143,7 +143,7 @@ describes.realWin('resourceTiming', {amp: true}, env => {
       false
     );
     const spec = newResourceTimingSpec();
-    sandbox.stub(win.performance, 'getEntriesByType').returns([entry]);
+    env.sandbox.stub(win.performance, 'getEntriesByType').returns([entry]);
     return getResourceTiming(win, spec, Date.now() - 60 * 1000).then(result => {
       expect(result).to.equal('');
     });
@@ -590,11 +590,14 @@ describes.realWin('resourceTiming', {amp: true}, env => {
 
     // Stub performance.now so that it returns a timestamp after the resource
     // timing entry.
-    const nowStub = sandbox.stub(win.performance, 'now');
+    const nowStub = env.sandbox.stub(win.performance, 'now');
     nowStub.onCall(0).returns(600);
     nowStub.onCall(1).returns(800);
 
-    const getEntriesStub = sandbox.stub(win.performance, 'getEntriesByType');
+    const getEntriesStub = env.sandbox.stub(
+      win.performance,
+      'getEntriesByType'
+    );
     getEntriesStub.onCall(0).returns([initialEntry]);
     getEntriesStub.onCall(1).returns([initialEntry, laterEntry]);
 
@@ -618,7 +621,7 @@ describes.realWin('resourceTiming', {amp: true}, env => {
   it('should not update responseAfter if greater', () => {
     const spec = newResourceTimingSpec();
     spec['responseAfter'] = 1000;
-    sandbox.stub(win.performance, 'now').returns(500);
+    env.sandbox.stub(win.performance, 'now').returns(500);
     return runSerializeTest([], spec, '').then(() => {
       // responseAfter is greater than performance.now(), so it should not be
       // modified.
@@ -638,7 +641,7 @@ describes.realWin('resourceTiming', {amp: true}, env => {
     const entries = new Array(150).fill(entry);
     // Stub performance.now so that it returns a timestamp after the resource
     // timing entry.
-    sandbox.stub(win.performance, 'now').returns(700);
+    env.sandbox.stub(win.performance, 'now').returns(700);
     const spec = newResourceTimingSpec();
     return runSerializeTest(entries, spec, '').then(() => {
       expect(spec['done']).to.be.true;

--- a/extensions/amp-analytics/0.1/test/test-scroll-manager.js
+++ b/extensions/amp-analytics/0.1/test/test-scroll-manager.js
@@ -49,15 +49,15 @@ describes.realWin('ScrollManager', {amp: 1}, env => {
     scrollManager = new ScrollManager(ampdoc);
     root.scrollManager_ = scrollManager;
     fakeViewport = {
-      'getSize': sandbox
+      'getSize': env.sandbox
         .stub()
         .returns({top: 0, left: 0, height: 200, width: 200}),
-      'getScrollTop': sandbox.stub().returns(0),
-      'getScrollLeft': sandbox.stub().returns(0),
-      'getScrollHeight': sandbox.stub().returns(500),
-      'getScrollWidth': sandbox.stub().returns(500),
+      'getScrollTop': env.sandbox.stub().returns(0),
+      'getScrollLeft': env.sandbox.stub().returns(0),
+      'getScrollHeight': env.sandbox.stub().returns(500),
+      'getScrollWidth': env.sandbox.stub().returns(500),
       'onChanged': () => {
-        return sandbox.stub();
+        return env.sandbox.stub();
       },
     };
     scrollManager.viewport_ = fakeViewport;
@@ -66,7 +66,7 @@ describes.realWin('ScrollManager', {amp: 1}, env => {
   it('should initalize, add listeners and dispose', () => {
     expect(scrollManager.scrollObservable_.getHandlerCount()).to.equal(0);
 
-    scrollManager.addScrollHandler(sandbox.stub());
+    scrollManager.addScrollHandler(env.sandbox.stub());
     expect(scrollManager.scrollObservable_.getHandlerCount()).to.equal(1);
 
     scrollManager.dispose();
@@ -79,7 +79,7 @@ describes.realWin('ScrollManager', {amp: 1}, env => {
     () => {
       expect(scrollManager.viewportOnChangedUnlistener_).to.not.be.ok;
 
-      const fn1 = sandbox.stub();
+      const fn1 = env.sandbox.stub();
       scrollManager.addScrollHandler(fn1);
 
       expect(scrollManager.viewportOnChangedUnlistener_).to.be.ok;
@@ -93,8 +93,8 @@ describes.realWin('ScrollManager', {amp: 1}, env => {
   );
 
   it('fires on scroll', () => {
-    const fn1 = sandbox.stub();
-    const fn2 = sandbox.stub();
+    const fn1 = env.sandbox.stub();
+    const fn2 = env.sandbox.stub();
     scrollManager.addScrollHandler(fn1);
     scrollManager.addScrollHandler(fn2);
 
@@ -126,18 +126,22 @@ describes.realWin('ScrollManager', {amp: 1}, env => {
 
     expect(fn1).to.have.callCount(2);
     expect(
-      fn1.getCall(1).calledWithMatch(sinon.match(matcher(expectedScrollEvent)))
+      fn1
+        .getCall(1)
+        .calledWithMatch(env.sandbox.match(matcher(expectedScrollEvent)))
     ).to.be.true;
 
     expect(fn2).to.have.callCount(2);
     expect(
-      fn2.getCall(1).calledWithMatch(sinon.match(matcher(expectedScrollEvent)))
+      fn2
+        .getCall(1)
+        .calledWithMatch(env.sandbox.match(matcher(expectedScrollEvent)))
     ).to.be.true;
   });
 
   it('can remove specifc handlers', () => {
-    const fn1 = sandbox.stub();
-    const fn2 = sandbox.stub();
+    const fn1 = env.sandbox.stub();
+    const fn2 = env.sandbox.stub();
     scrollManager.addScrollHandler(fn1);
     scrollManager.addScrollHandler(fn2);
 

--- a/extensions/amp-analytics/0.1/test/test-transport.js
+++ b/extensions/amp-analytics/0.1/test/test-transport.js
@@ -31,7 +31,6 @@ describes.realWin(
     allowExternalResources: true,
   },
   env => {
-    let sandbox;
     let win;
     let doc;
     let openXhrStub;
@@ -40,12 +39,11 @@ describes.realWin(
     let imagePixelVerifier;
 
     beforeEach(() => {
-      sandbox = env.sandbox;
       win = env.win;
       doc = win.document;
-      openXhrStub = sandbox.stub();
-      sendXhrStub = sandbox.stub();
-      sendBeaconStub = sandbox.stub();
+      openXhrStub = env.sandbox.stub();
+      sendXhrStub = env.sandbox.stub();
+      sendBeaconStub = env.sandbox.stub();
     });
 
     it('prefers beacon over xhrpost and image', () => {
@@ -388,7 +386,7 @@ describes.realWin(
 
         const ampAnalyticsEl = null;
 
-        const preconnectSpy = sandbox.spy();
+        const preconnectSpy = env.sandbox.spy();
         transport.maybeInitIframeTransport(win, ampAnalyticsEl, {
           preload: preconnectSpy,
         });
@@ -414,7 +412,7 @@ describes.realWin(
           'amp-analytics'
         );
 
-        const preconnectSpy = sandbox.spy();
+        const preconnectSpy = env.sandbox.spy();
         transport.maybeInitIframeTransport(win, ampAnalyticsEl, {
           preload: preconnectSpy,
         });
@@ -444,7 +442,7 @@ describes.realWin(
           'amp-analytics'
         );
 
-        const preconnectSpy = sandbox.spy();
+        const preconnectSpy = env.sandbox.spy();
         transport.maybeInitIframeTransport(win, ampAnalyticsEl, {
           preload: preconnectSpy,
         });
@@ -463,7 +461,7 @@ describes.realWin(
           image: true,
           iframe: '//test',
         });
-        const iframeTransportSendRequestSpy = sandbox.spy();
+        const iframeTransportSendRequestSpy = env.sandbox.spy();
         transport.iframeTransport_ = {
           sendRequest: iframeTransportSendRequestSpy,
         };
@@ -476,7 +474,7 @@ describes.realWin(
     });
 
     function setupStubs(beacon, xhr) {
-      const wi = mockWindowInterface(sandbox);
+      const wi = mockWindowInterface(env.sandbox);
       wi.getSendBeacon.returns(beacon ? sendBeaconStub : undefined);
 
       const FakeXMLHttpRequest = () => {

--- a/extensions/amp-analytics/0.1/test/test-variables.js
+++ b/extensions/amp-analytics/0.1/test/test-variables.js
@@ -191,11 +191,9 @@ describes.fakeWin('amp-analytics.VariableService', {amp: true}, env => {
     let doc;
     let win;
     let urlReplacementService;
-    let sandbox;
     let analyticsElement;
 
     beforeEach(() => {
-      sandbox = env.sandbox;
       win = env.win;
       doc = win.document;
       installLinkerReaderService(win);
@@ -217,7 +215,7 @@ describes.fakeWin('amp-analytics.VariableService', {amp: true}, env => {
     }
 
     it('handles consecutive macros in inner arguments', () => {
-      sandbox.useFakeTimers(123456789);
+      env.sandbox.useFakeTimers(123456789);
       win.location.href = 'https://example.com/?test=yes';
       return check(
         '$IF(QUERY_PARAM(test), 1.$SUBSTR(TIMESTAMP, 0, 10)QUERY_PARAM(test), ``)',
@@ -226,7 +224,7 @@ describes.fakeWin('amp-analytics.VariableService', {amp: true}, env => {
     });
 
     it('handles consecutive macros w/o parens in inner arguments', () => {
-      sandbox.useFakeTimers(123456789);
+      env.sandbox.useFakeTimers(123456789);
       win.location.href = 'https://example.com/?test=yes';
       return check('$IF(QUERY_PARAM(test), 1.TIMESTAMP, ``)', '1.123456789');
     });
@@ -237,7 +235,7 @@ describes.fakeWin('amp-analytics.VariableService', {amp: true}, env => {
       }));
 
     it('should not trim right of string before macro', () => {
-      sandbox.useFakeTimers(123456789);
+      env.sandbox.useFakeTimers(123456789);
       win.location.href = 'https://example.com/?test=yes';
       return check(
         '$IF(QUERY_PARAM(test), foo TIMESTAMP, ``)',
@@ -360,7 +358,7 @@ describes.fakeWin('amp-analytics.VariableService', {amp: true}, env => {
 
     it('replaces LINKER_PARAM', () => {
       const linkerReader = linkerReaderServiceFor(win);
-      const linkerReaderStub = sandbox.stub(linkerReader, 'get');
+      const linkerReaderStub = env.sandbox.stub(linkerReader, 'get');
       linkerReaderStub.withArgs('gl', 'cid').returns('a1b2c3');
       linkerReaderStub.withArgs('gl', 'gclid').returns(123);
       return check(

--- a/extensions/amp-analytics/0.1/test/test-vendors.js
+++ b/extensions/amp-analytics/0.1/test/test-vendors.js
@@ -141,7 +141,7 @@ describes.realWin(
                 const analytics = getAnalyticsTag(
                   clearVendorOnlyConfig(config)
                 );
-                sandbox
+                window.sandbox
                   .stub(urlReplacements.getVariableSource(), 'get')
                   .callsFake(function(name) {
                     expect(this.replacements_).to.have.property(name);
@@ -151,7 +151,7 @@ describes.realWin(
                     };
                   });
 
-                sandbox
+                window.sandbox
                   .stub(ExpansionOptions.prototype, 'getVar')
                   .callsFake(function(name) {
                     let val = this.vars[name];

--- a/extensions/amp-analytics/0.1/test/test-visibility-manager-for-mapp.js
+++ b/extensions/amp-analytics/0.1/test/test-visibility-manager-for-mapp.js
@@ -58,11 +58,11 @@ describes.fakeWin('VisibilityManagerForMapp', {amp: true}, env => {
   beforeEach(() => {
     win = env.win;
     ampdoc = env.ampdoc;
-    clock = sandbox.useFakeTimers();
+    clock = env.sandbox.useFakeTimers();
     clock.tick(1);
 
     viewer = win.__AMP_SERVICES.viewer.obj;
-    sandbox.stub(ampdoc, 'getFirstVisibleTime').returns(1);
+    env.sandbox.stub(ampdoc, 'getFirstVisibleTime').returns(1);
     visibilityInterface = new MockVisibilityInterface();
     root = new VisibilityManagerForMApp(ampdoc, visibilityInterface);
 
@@ -158,7 +158,7 @@ describes.fakeWin('VisibilityManagerForMapp', {amp: true}, env => {
     // There's a clock.tick(1) in beforeEach, so firstSeenTime is
     // /*tick*/1 + /*tick*/1 - /*ampdoc.getFirstVisibleTime*/ 1)
     clock.tick(1);
-    const disposed = sandbox.spy();
+    const disposed = env.sandbox.spy();
     const spec = dict({
       'totalTimeMin': 10,
       'visiblePercentageMin': 20,

--- a/extensions/amp-analytics/0.1/test/test-visibility-manager.js
+++ b/extensions/amp-analytics/0.1/test/test-visibility-manager.js
@@ -78,11 +78,11 @@ describes.fakeWin('VisibilityManagerForDoc', {amp: true}, env => {
   beforeEach(() => {
     win = env.win;
     ampdoc = env.ampdoc;
-    clock = sandbox.useFakeTimers();
+    clock = env.sandbox.useFakeTimers();
     clock.tick(1);
 
     viewer = win.__AMP_SERVICES.viewer.obj;
-    sandbox.stub(ampdoc, 'getFirstVisibleTime').returns(1);
+    env.sandbox.stub(ampdoc, 'getFirstVisibleTime').returns(1);
     viewport = win.__AMP_SERVICES.viewport.obj;
     startVisibilityHandlerCount = getVisibilityHandlerCount();
 
@@ -138,7 +138,7 @@ describes.fakeWin('VisibilityManagerForDoc', {amp: true}, env => {
 
   it('should resolve root layout box', () => {
     const rootElement = win.document.documentElement;
-    sandbox.stub(viewport, 'getLayoutRect').callsFake(element => {
+    env.sandbox.stub(viewport, 'getLayoutRect').callsFake(element => {
       if (element == rootElement) {
         return layoutRectLtwh(0, 0, 101, 201);
       }
@@ -156,7 +156,7 @@ describes.fakeWin('VisibilityManagerForDoc', {amp: true}, env => {
     win.__AMP_MODE = {runtime: 'inabox'};
     root = new VisibilityManagerForDoc(ampdoc);
     const rootElement = win.document.documentElement;
-    sandbox.stub(viewport, 'getLayoutRect').callsFake(element => {
+    env.sandbox.stub(viewport, 'getLayoutRect').callsFake(element => {
       if (element == rootElement) {
         return layoutRectLtwh(11, 21, 101, 201);
       }
@@ -343,8 +343,8 @@ describes.fakeWin('VisibilityManagerForDoc', {amp: true}, env => {
   });
 
   it('should dispose everything', () => {
-    const modelsDisposed = sandbox.spy();
-    const modelsCalled = sandbox.spy();
+    const modelsDisposed = env.sandbox.spy();
+    const modelsCalled = env.sandbox.spy();
     const otherTarget = win.document.createElement('div');
     const spec = {totalTimeMin: 10};
     root.listenRoot(spec, null, null, modelsCalled);
@@ -360,7 +360,7 @@ describes.fakeWin('VisibilityManagerForDoc', {amp: true}, env => {
     root.models_.forEach(model => {
       model.unsubscribe(modelsDisposed);
     });
-    const otherUnsubscribes = sandbox.spy();
+    const otherUnsubscribes = env.sandbox.spy();
     root.unsubscribe(otherUnsubscribes);
     root.unsubscribe(otherUnsubscribes);
     const inOb = root.intersectionObserver_;
@@ -428,10 +428,10 @@ describes.fakeWin('VisibilityManagerForDoc', {amp: true}, env => {
     expect(model.getVisibility_()).to.equal(0);
 
     // Trigger tick.
-    sandbox.stub(viewport, 'getRect').callsFake(() => {
+    env.sandbox.stub(viewport, 'getRect').callsFake(() => {
       return layoutRectLtwh(0, 0, 100, 100);
     });
-    sandbox.stub(viewport, 'getLayoutRect').callsFake(element => {
+    env.sandbox.stub(viewport, 'getLayoutRect').callsFake(element => {
       if (element == rootElement) {
         return layoutRectLtwh(0, 50, 100, 100);
       }
@@ -453,10 +453,10 @@ describes.fakeWin('VisibilityManagerForDoc', {amp: true}, env => {
 
   it('should listen on root', () => {
     clock.tick(1);
-    const disposed = sandbox.spy();
+    const disposed = env.sandbox.spy();
     const spec = {totalTimeMin: 10};
     root.listenRoot(spec, null, null, eventResolver);
-    sandbox
+    env.sandbox
       .stub(root, 'getRootLayoutBox')
       .callsFake(() => layoutRectLtwh(11, 21, 101, 201));
 
@@ -474,7 +474,7 @@ describes.fakeWin('VisibilityManagerForDoc', {amp: true}, env => {
     root.setRootVisibility(1);
     expect(model.getVisibility_()).to.equal(1);
 
-    sandbox.stub(model, 'reset_');
+    env.sandbox.stub(model, 'reset_');
     // Fire event.
     clock.tick(11);
     return eventPromise.then(state => {
@@ -498,7 +498,7 @@ describes.fakeWin('VisibilityManagerForDoc', {amp: true}, env => {
 
   it('should listen on root with ready signal', () => {
     clock.tick(1);
-    const disposed = sandbox.spy();
+    const disposed = env.sandbox.spy();
     const spec = {totalTimeMin: 0};
     const readyPromise = Promise.resolve().then(() => {
       clock.tick(21);
@@ -530,7 +530,7 @@ describes.fakeWin('VisibilityManagerForDoc', {amp: true}, env => {
 
   it('should pass func to create readyReportPromise to model', () => {
     let testPromiseResolver;
-    const disposed = sandbox.spy();
+    const disposed = env.sandbox.spy();
     const testPromise = new Promise(resolve => {
       testPromiseResolver = resolve;
     });
@@ -557,7 +557,7 @@ describes.fakeWin('VisibilityManagerForDoc', {amp: true}, env => {
 
   it('should unlisten root', () => {
     clock.tick(1);
-    const disposed = sandbox.spy();
+    const disposed = env.sandbox.spy();
     const spec = {totalTimeMin: 10};
     const unlisten = root.listenRoot(spec, null, null, eventResolver);
 
@@ -574,7 +574,7 @@ describes.fakeWin('VisibilityManagerForDoc', {amp: true}, env => {
 
   it('should listen on a element', () => {
     clock.tick(1);
-    const disposed = sandbox.spy();
+    const disposed = env.sandbox.spy();
     const target = win.document.createElement('div');
     const spec = {totalTimeMin: 10};
     root.listenElement(target, spec, null, null, eventResolver);
@@ -608,7 +608,7 @@ describes.fakeWin('VisibilityManagerForDoc', {amp: true}, env => {
     root.setRootVisibility(1);
     expect(model.getVisibility_()).to.equal(0.3);
 
-    sandbox.stub(model, 'reset_');
+    env.sandbox.stub(model, 'reset_');
     // Fire event.
     clock.tick(11);
     return eventPromise.then(state => {
@@ -689,7 +689,7 @@ describes.fakeWin('VisibilityManagerForDoc', {amp: true}, env => {
     const target = win.document.createElement('div');
 
     // Listen to the first spec.
-    const disposed1 = sandbox.spy();
+    const disposed1 = env.sandbox.spy();
     const spec1 = {totalTimeMin: 10};
     root.listenElement(target, spec1, null, null, eventResolver);
     expect(root.models_).to.have.length(1);
@@ -714,7 +714,7 @@ describes.fakeWin('VisibilityManagerForDoc', {amp: true}, env => {
     expect(trackedElement.intersectionRatio).to.equal(0.3);
 
     // Second spec on the same element.
-    const disposed2 = sandbox.spy();
+    const disposed2 = env.sandbox.spy();
     const spec2 = {totalTimeMin: 20};
     let eventResolver2;
     const eventPromise2 = new Promise(resolve => {
@@ -724,13 +724,13 @@ describes.fakeWin('VisibilityManagerForDoc', {amp: true}, env => {
     expect(root.models_).to.have.length(2);
     const model2 = root.models_[1];
     expect(model2.spec_.totalTimeMin).to.equal(20);
-    sandbox.stub(model2, 'reset_');
+    env.sandbox.stub(model2, 'reset_');
     model2.unsubscribe(disposed2);
     expect(trackedElement.listeners).to.have.length(2);
     // Immediately visible.
     expect(model2.getVisibility_()).to.equal(0.3);
 
-    sandbox.stub(model1, 'reset_');
+    env.sandbox.stub(model1, 'reset_');
     // Fire the first event.
     clock.tick(11);
     return eventPromise
@@ -770,7 +770,7 @@ describes.fakeWin('VisibilityManagerForDoc', {amp: true}, env => {
       },
     };
     const resources = win.__AMP_SERVICES.resources.obj;
-    sandbox
+    env.sandbox
       .stub(resources, 'getResourceForElementOptional')
       .callsFake(() => resource);
     const spec = {totalTimeMin: 10};
@@ -787,7 +787,7 @@ describes.fakeWin('VisibilityManagerForDoc', {amp: true}, env => {
 
     expect(root.models_).to.have.length(1);
     const model = root.models_[0];
-    sandbox.stub(model, 'reset_');
+    env.sandbox.stub(model, 'reset_');
 
     // Fire event.
     clock.tick(11);
@@ -824,12 +824,12 @@ describes.realWin(
       ampdoc = env.ampdoc;
       embed = env.embed;
       embed.host = ampdoc.win.document.createElement('amp-host');
-      clock = sandbox.useFakeTimers();
+      clock = env.sandbox.useFakeTimers();
       clock.tick(1);
 
       viewport = parentWin.__AMP_SERVICES.viewport.obj;
       viewer = parentWin.__AMP_SERVICES.viewer.obj;
-      sandbox.stub(ampdoc, 'getFirstVisibleTime').returns(1);
+      env.sandbox.stub(ampdoc, 'getFirstVisibleTime').returns(1);
 
       parentRoot = new VisibilityManagerForDoc(ampdoc);
       parentWin.IntersectionObserver = IntersectionObserverStub;
@@ -841,7 +841,7 @@ describes.realWin(
     });
 
     it('should dispose with parent', () => {
-      const unsubscribeSpy = sandbox.spy();
+      const unsubscribeSpy = env.sandbox.spy();
       root.unsubscribe(unsubscribeSpy);
 
       expect(parentRoot.children_).to.have.length(1);
@@ -853,7 +853,7 @@ describes.realWin(
     });
 
     it('should remove from parent when disposed', () => {
-      const unsubscribeSpy = sandbox.spy();
+      const unsubscribeSpy = env.sandbox.spy();
       root.unsubscribe(unsubscribeSpy);
 
       expect(parentRoot.children_).to.have.length(1);
@@ -891,7 +891,7 @@ describes.realWin(
     });
 
     it('should resolve root layout box', () => {
-      sandbox.stub(viewport, 'getLayoutRect').callsFake(element => {
+      env.sandbox.stub(viewport, 'getLayoutRect').callsFake(element => {
         if (element == embed.iframe) {
           return layoutRectLtwh(11, 21, 101, 201);
         }
@@ -915,12 +915,12 @@ describes.realWin(
 
     it('should delegate observation to parent', () => {
       const inOb = {
-        observe: sandbox.spy(),
-        unobserve: sandbox.spy(),
+        observe: env.sandbox.spy(),
+        unobserve: env.sandbox.spy(),
       };
       parentRoot.intersectionObserver_ = inOb;
 
-      const listener = sandbox.spy();
+      const listener = env.sandbox.spy();
       const target = win.document.createElement('div');
 
       // Observe.
@@ -938,7 +938,7 @@ describes.realWin(
     });
 
     it('should depend on parent for visibility', () => {
-      const callbackSpy = sandbox.spy();
+      const callbackSpy = env.sandbox.spy();
       const otherTarget = win.document.createElement('div');
       root.listenRoot({}, null, null, callbackSpy);
       expect(root.models_).to.have.length(1);
@@ -1059,8 +1059,8 @@ describes.realWin('VisibilityManager integrated', {amp: true}, env => {
     viewer = win.__AMP_SERVICES.viewer.obj;
     resources = win.__AMP_SERVICES.resources.obj;
 
-    observeSpy = sandbox.stub();
-    unobserveSpy = sandbox.stub();
+    observeSpy = env.sandbox.stub();
+    unobserveSpy = env.sandbox.stub();
     const inob = callback => {
       inObCallback = callback;
       return {
@@ -1069,7 +1069,7 @@ describes.realWin('VisibilityManager integrated', {amp: true}, env => {
       };
     };
     if (nativeIntersectionObserverSupported(ampdoc.win)) {
-      sandbox.stub(win, 'IntersectionObserver').callsFake(inob);
+      env.sandbox.stub(win, 'IntersectionObserver').callsFake(inob);
     } else {
       win.IntersectionObserver = inob;
       win.IntersectionObserverEntry = function() {};
@@ -1090,7 +1090,7 @@ describes.realWin('VisibilityManager integrated', {amp: true}, env => {
       eventResolver2 = resolve;
     });
 
-    sandbox.stub(ampdoc, 'getFirstVisibleTime').callsFake(() => startTime);
+    env.sandbox.stub(ampdoc, 'getFirstVisibleTime').callsFake(() => startTime);
 
     ampElement = doc.createElement('amp-img');
     ampElement.id = 'abc';
@@ -1110,13 +1110,13 @@ describes.realWin('VisibilityManager integrated', {amp: true}, env => {
         }, 4);
       }
     }).then(() => {
-      clock = sandbox.useFakeTimers();
+      clock = env.sandbox.useFakeTimers();
       startTime = 10000;
       clock.tick(startTime);
 
       const resource = resources.getResourceForElement(ampElement);
       scrollTop = 10;
-      sandbox
+      env.sandbox
         .stub(resource, 'getLayoutBox')
         .callsFake(() => layoutRectLtwh(0, scrollTop, 100, 100));
     });
@@ -1467,7 +1467,7 @@ describes.realWin('VisibilityManager integrated', {amp: true}, env => {
     viewer.setVisibilityState_(VisibilityState.VISIBLE);
     visibility = new VisibilityManagerForDoc(ampdoc);
 
-    const spy = sandbox.spy();
+    const spy = env.sandbox.spy();
     visibility.listenElement(
       ampElement,
       {
@@ -1618,7 +1618,7 @@ describes.realWin('VisibilityManager integrated', {amp: true}, env => {
       expect(isModelResolved(model)).to.be.false;
       clock.tick(899); // not yet!
       expect(isModelResolved(model)).to.be.false;
-      sandbox.stub(model, 'reset_');
+      env.sandbox.stub(model, 'reset_');
       clock.tick(1); // now fire
       expect(isModelResolved(model)).to.be.true;
       return eventPromise.then(state => {
@@ -1700,8 +1700,8 @@ describes.realWin(
         'https://example.com',
         shadowRoot
       );
-      sandbox.stub(Services, 'resourcesForDoc').returns({});
-      sandbox.stub(Services, 'viewportForDoc').returns({
+      env.sandbox.stub(Services, 'resourcesForDoc').returns({});
+      env.sandbox.stub(Services, 'viewportForDoc').returns({
         onChanged() {},
       });
     });

--- a/extensions/amp-analytics/0.1/test/test-visibility-model.js
+++ b/extensions/amp-analytics/0.1/test/test-visibility-model.js
@@ -19,7 +19,7 @@ import {VisibilityModel} from '../visibility-model';
 const NO_SPEC = {};
 const NO_CALC = () => 0;
 
-describes.sandboxed('VisibilityModel', {}, () => {
+describes.sandboxed('VisibilityModel', {}, env => {
   let startTime;
   let clock;
 
@@ -31,7 +31,7 @@ describes.sandboxed('VisibilityModel', {}, () => {
   };
 
   beforeEach(() => {
-    clock = sandbox.useFakeTimers();
+    clock = env.sandbox.useFakeTimers();
     startTime = 10000;
     clock.tick(startTime + 1);
   });
@@ -177,9 +177,9 @@ describes.sandboxed('VisibilityModel', {}, () => {
       const vh = new VisibilityModel(NO_SPEC, calcVisibility);
       vh.scheduledUpdateTimeoutId_ = 1;
       vh.scheduleRepeatId_ = 1;
-      const unsubscribeSpy = sandbox.spy();
+      const unsubscribeSpy = env.sandbox.spy();
       vh.unsubscribe(unsubscribeSpy);
-      const removeSpy = sandbox.spy(vh.onTriggerObservable_, 'removeAll');
+      const removeSpy = env.sandbox.spy(vh.onTriggerObservable_, 'removeAll');
 
       vh.dispose();
       expect(vh.scheduledUpdateTimeoutId_).to.be.null;
@@ -192,7 +192,7 @@ describes.sandboxed('VisibilityModel', {}, () => {
     });
 
     it('should update on any visibility event', () => {
-      const updateStub = sandbox.stub(VisibilityModel.prototype, 'update_');
+      const updateStub = env.sandbox.stub(VisibilityModel.prototype, 'update_');
       const vh = new VisibilityModel(NO_SPEC, calcVisibility);
       vh.setReady(true);
       vh.setReady(false);
@@ -200,7 +200,7 @@ describes.sandboxed('VisibilityModel', {}, () => {
     });
 
     it('should NOT update when started visible', () => {
-      const updateStub = sandbox.stub(VisibilityModel.prototype, 'update_');
+      const updateStub = env.sandbox.stub(VisibilityModel.prototype, 'update_');
       visibility = 1;
       const vh = new VisibilityModel(NO_SPEC, calcVisibility);
       expect(updateStub).to.not.be.called;
@@ -211,7 +211,7 @@ describes.sandboxed('VisibilityModel', {}, () => {
     });
 
     it('should NOT update when started invisible', () => {
-      const updateStub = sandbox.stub(VisibilityModel.prototype, 'update_');
+      const updateStub = env.sandbox.stub(VisibilityModel.prototype, 'update_');
       visibility = 0;
       const vh = new VisibilityModel(NO_SPEC, calcVisibility);
       expect(updateStub).to.not.be.called;
@@ -222,7 +222,7 @@ describes.sandboxed('VisibilityModel', {}, () => {
     });
 
     it('should update visibility and ready', () => {
-      const updateStub = sandbox.stub(VisibilityModel.prototype, 'update_');
+      const updateStub = env.sandbox.stub(VisibilityModel.prototype, 'update_');
       visibility = 0;
       const vh = new VisibilityModel(NO_SPEC, calcVisibility);
 
@@ -352,15 +352,15 @@ describes.sandboxed('VisibilityModel', {}, () => {
         },
         NO_CALC
       );
-      updateStub = sandbox.stub(vh, 'update').callsFake(() => {
+      updateStub = env.sandbox.stub(vh, 'update').callsFake(() => {
         if (visibilityValueForTesting) {
           vh.update_(visibilityValueForTesting);
         }
       });
-      sandbox.stub(vh, 'getVisibility_').callsFake(() => {
+      env.sandbox.stub(vh, 'getVisibility_').callsFake(() => {
         return visibilityValueForTesting;
       });
-      eventSpy = vh.eventResolver_ = sandbox.spy();
+      eventSpy = vh.eventResolver_ = env.sandbox.spy();
     });
 
     afterEach(() => {
@@ -368,7 +368,7 @@ describes.sandboxed('VisibilityModel', {}, () => {
     });
 
     it('conditions not met only', () => {
-      sandbox.stub(vh, 'setReady'); // Because it calls update()
+      env.sandbox.stub(vh, 'setReady'); // Because it calls update()
       visibilityValueForTesting = 0.1;
       vh.update_(visibilityValueForTesting);
       expect(vh.scheduledUpdateTimeoutId_).to.be.ok;
@@ -565,7 +565,7 @@ describes.sandboxed('VisibilityModel', {}, () => {
     });
 
     it('conditions met, wait to reset', () => {
-      const resolveSpy = (vh.eventResolver_ = sandbox.spy());
+      const resolveSpy = (vh.eventResolver_ = env.sandbox.spy());
       vh.update_(1);
       vh.continuousTime_ = 10;
       vh.totalVisibleTime_ = 10;
@@ -575,8 +575,8 @@ describes.sandboxed('VisibilityModel', {}, () => {
     });
 
     it('conditions not met, reset', () => {
-      const updateCounterSpy = (vh.updateCounters_ = sandbox.spy());
-      const resetSpy = (vh.reset_ = sandbox.spy());
+      const updateCounterSpy = (vh.updateCounters_ = env.sandbox.spy());
+      const resetSpy = (vh.reset_ = env.sandbox.spy());
       vh.waitToReset_ = true;
       vh.update_(1);
       expect(resetSpy).to.not.be.called;
@@ -882,7 +882,7 @@ describes.sandboxed('VisibilityModel', {}, () => {
         },
         calcVisibility
       );
-      const eventSpy = (vh.eventResolver_ = sandbox.spy());
+      const eventSpy = (vh.eventResolver_ = env.sandbox.spy());
 
       visibility = 0.63;
       vh.update();
@@ -902,7 +902,7 @@ describes.sandboxed('VisibilityModel', {}, () => {
         },
         calcVisibility
       );
-      const eventSpy = (vh.eventResolver_ = sandbox.spy());
+      const eventSpy = (vh.eventResolver_ = env.sandbox.spy());
 
       visibility = 0.49;
       vh.update();
@@ -923,7 +923,7 @@ describes.sandboxed('VisibilityModel', {}, () => {
         },
         calcVisibility
       );
-      const eventSpy = (vh.eventResolver_ = sandbox.spy());
+      const eventSpy = (vh.eventResolver_ = env.sandbox.spy());
 
       visibility = 0.63;
       vh.update();
@@ -942,7 +942,7 @@ describes.sandboxed('VisibilityModel', {}, () => {
       expect(vh.getState(startTime)).to.contains({maxVisiblePercentage: 64});
       expect(eventSpy).to.not.be.called;
 
-      sandbox.stub(vh, 'reset_');
+      env.sandbox.stub(vh, 'reset_');
       clock.tick(1);
       expect(vh.getState(startTime)).to.contains({
         maxVisiblePercentage: 64,
@@ -958,7 +958,7 @@ describes.sandboxed('VisibilityModel', {}, () => {
         },
         calcVisibility
       );
-      const eventSpy = (vh.eventResolver_ = sandbox.spy());
+      const eventSpy = (vh.eventResolver_ = env.sandbox.spy());
 
       visibility = 0.63;
       vh.update();
@@ -986,7 +986,7 @@ describes.sandboxed('VisibilityModel', {}, () => {
       });
       expect(eventSpy).to.not.be.called;
 
-      sandbox.stub(vh, 'reset_');
+      env.sandbox.stub(vh, 'reset_');
       clock.tick(999);
       expect(eventSpy).to.be.calledOnce;
       expect(vh.getState(startTime)).to.contains({
@@ -1003,7 +1003,7 @@ describes.sandboxed('VisibilityModel', {}, () => {
         },
         calcVisibility
       );
-      const eventSpy = (vh.eventResolver_ = sandbox.spy());
+      const eventSpy = (vh.eventResolver_ = env.sandbox.spy());
 
       visibility = 0.05;
       vh.update();
@@ -1019,7 +1019,7 @@ describes.sandboxed('VisibilityModel', {}, () => {
       expect(vh.getState(startTime)).to.contains({maxVisiblePercentage: 11});
       expect(eventSpy).to.not.be.called;
 
-      sandbox.stub(vh, 'reset_');
+      env.sandbox.stub(vh, 'reset_');
       clock.tick(1000);
       expect(eventSpy).to.be.calledOnce;
       expect(vh.getState(startTime)).to.contains({
@@ -1041,7 +1041,7 @@ describes.sandboxed('VisibilityModel', {}, () => {
         },
         calcVisibility
       );
-      const eventSpy = (vh.eventResolver_ = sandbox.spy());
+      const eventSpy = (vh.eventResolver_ = env.sandbox.spy());
 
       visibility = 0.05;
       vh.update();
@@ -1054,7 +1054,7 @@ describes.sandboxed('VisibilityModel', {}, () => {
       expect(vh.getState(startTime)).to.contains({maxVisiblePercentage: 10});
       expect(eventSpy).to.not.be.called;
 
-      sandbox.stub(vh, 'reset_');
+      env.sandbox.stub(vh, 'reset_');
       clock.tick(1000);
       expect(eventSpy).to.be.calledOnce;
       expect(vh.getState(startTime)).to.contains({
@@ -1076,7 +1076,7 @@ describes.sandboxed('VisibilityModel', {}, () => {
         },
         calcVisibility
       );
-      const eventSpy = (vh.eventResolver_ = sandbox.spy());
+      const eventSpy = (vh.eventResolver_ = env.sandbox.spy());
 
       clock.tick(999);
       visibility = 0;
@@ -1093,7 +1093,7 @@ describes.sandboxed('VisibilityModel', {}, () => {
       clock.tick(999);
       expect(eventSpy).to.not.be.called;
 
-      sandbox.stub(vh, 'reset_');
+      env.sandbox.stub(vh, 'reset_');
       clock.tick(1);
       expect(eventSpy).to.be.calledOnce;
       expect(vh.getState(startTime)).to.contains({
@@ -1112,7 +1112,7 @@ describes.sandboxed('VisibilityModel', {}, () => {
         },
         calcVisibility
       );
-      const eventSpy = (vh.eventResolver_ = sandbox.spy());
+      const eventSpy = (vh.eventResolver_ = env.sandbox.spy());
       visibility = 0.99;
       clock.tick(200);
       vh.update();
@@ -1132,8 +1132,8 @@ describes.sandboxed('VisibilityModel', {}, () => {
         },
         calcVisibility
       );
-      const eventSpy = (vh.eventResolver_ = sandbox.spy());
-      sandbox.stub(vh, 'reset_').callsFake(() => {
+      const eventSpy = (vh.eventResolver_ = env.sandbox.spy());
+      env.sandbox.stub(vh, 'reset_').callsFake(() => {
         vh.eventPromise_ = new Promise(unused => {
           vh.eventResolver_ = eventSpy;
         });
@@ -1190,7 +1190,7 @@ describes.sandboxed('VisibilityModel', {}, () => {
         },
         calcVisibility
       );
-      const spy = sandbox.spy();
+      const spy = env.sandbox.spy();
       vh.onTriggerEvent(() => {
         spy();
         vh.maybeDispose();
@@ -1215,7 +1215,7 @@ describes.sandboxed('VisibilityModel', {}, () => {
         },
         calcVisibility
       );
-      const spy = sandbox.spy();
+      const spy = env.sandbox.spy();
       vh.onTriggerEvent(() => {
         spy();
         vh.maybeDispose();

--- a/extensions/amp-animation/0.1/test/test-amp-animation.js
+++ b/extensions/amp-animation/0.1/test/test-amp-animation.js
@@ -63,8 +63,8 @@ describes.sandboxed('AmpAnimation', {}, () => {
         viewer = win.__AMP_SERVICES.viewer.obj;
         viewer.setVisibilityState_('hidden');
         runner = new NativeWebAnimationRunner([]);
-        runnerMock = sandbox.mock(runner);
-        createRunnerStub = sandbox
+        runnerMock = env.sandbox.mock(runner);
+        createRunnerStub = env.sandbox
           .stub(AmpAnimation.prototype, 'createRunner_')
           .callsFake(() => Promise.resolve(runner));
       });
@@ -165,7 +165,7 @@ describes.sandboxed('AmpAnimation', {}, () => {
 
       it('should not activate w/o visibility trigger', function*() {
         const anim = yield createAnim({}, {duration: 1001});
-        const activateStub = sandbox.stub(anim, 'startAction_');
+        const activateStub = env.sandbox.stub(anim, 'startAction_');
         viewer.setVisibilityState_('visible');
         yield anim.layoutCallback();
         expect(activateStub).to.not.be.called;
@@ -176,7 +176,7 @@ describes.sandboxed('AmpAnimation', {}, () => {
           {trigger: 'visibility'},
           {duration: 1001}
         );
-        const activateStub = sandbox.stub(anim, 'startAction_');
+        const activateStub = env.sandbox.stub(anim, 'startAction_');
         viewer.setVisibilityState_('visible');
         yield anim.layoutCallback();
         expect(activateStub).to.be.calledOnce;
@@ -187,7 +187,7 @@ describes.sandboxed('AmpAnimation', {}, () => {
           {trigger: 'visibility'},
           {duration: 1001}
         );
-        const startStub = sandbox.stub(anim, 'startOrResume_');
+        const startStub = env.sandbox.stub(anim, 'startOrResume_');
         anim.startAction_();
         expect(anim.triggered_).to.be.true;
         expect(startStub).to.not.be.called;
@@ -198,7 +198,7 @@ describes.sandboxed('AmpAnimation', {}, () => {
           {trigger: 'visibility'},
           {duration: 1001}
         );
-        const startStub = sandbox.stub(anim, 'startOrResume_');
+        const startStub = env.sandbox.stub(anim, 'startOrResume_');
         viewer.setVisibilityState_('visible');
         anim.startAction_();
         expect(anim.triggered_).to.be.true;
@@ -210,8 +210,8 @@ describes.sandboxed('AmpAnimation', {}, () => {
           {trigger: 'visibility'},
           {duration: 1001}
         );
-        const startStub = sandbox.stub(anim, 'startOrResume_');
-        const pauseStub = sandbox.stub(anim, 'pause_');
+        const startStub = env.sandbox.stub(anim, 'startOrResume_');
+        const pauseStub = env.sandbox.stub(anim, 'pause_');
         anim.startAction_();
         expect(anim.triggered_).to.be.true;
 
@@ -231,8 +231,8 @@ describes.sandboxed('AmpAnimation', {}, () => {
           {trigger: 'visibility'},
           {duration: 1001}
         );
-        const startStub = sandbox.stub(anim, 'startOrResume_');
-        const pauseStub = sandbox.stub(anim, 'pause_');
+        const startStub = env.sandbox.stub(anim, 'startOrResume_');
+        const pauseStub = env.sandbox.stub(anim, 'pause_');
         expect(anim.triggered_).to.be.false;
 
         // Go to visible state.
@@ -251,8 +251,8 @@ describes.sandboxed('AmpAnimation', {}, () => {
           {trigger: 'visibility'},
           {duration: 1001}
         );
-        const startStub = sandbox.stub(anim, 'startOrResume_');
-        const pauseStub = sandbox.stub(anim, 'pause_');
+        const startStub = env.sandbox.stub(anim, 'startOrResume_');
+        const pauseStub = env.sandbox.stub(anim, 'pause_');
         anim.startAction_();
         anim.pausedByAction_ = true;
         expect(anim.triggered_).to.be.true;
@@ -328,7 +328,7 @@ describes.sandboxed('AmpAnimation', {}, () => {
 
       it('should resize from ampdoc viewport', function*() {
         const anim = yield createAnim({}, {duration: 1001});
-        const stub = sandbox.stub(anim, 'onResize_');
+        const stub = env.sandbox.stub(anim, 'onResize_');
         const viewport = win.__AMP_SERVICES.viewport.obj;
 
         // No size changes.
@@ -488,7 +488,7 @@ describes.sandboxed('AmpAnimation', {}, () => {
         });
 
         it('should trigger restart', () => {
-          const cancelStub = sandbox.stub(anim, 'cancel_');
+          const cancelStub = env.sandbox.stub(anim, 'cancel_');
           const args = {};
           const invocation = {
             method: 'restart',
@@ -866,7 +866,7 @@ describes.sandboxed('AmpAnimation', {}, () => {
 
       it("should take resize from embed's window", function*() {
         const anim = yield createAnim({}, {duration: 1001});
-        const stub = sandbox.stub(anim, 'onResize_');
+        const stub = env.sandbox.stub(anim, 'onResize_');
         embed.win.eventListeners.fire({type: 'resize'});
         expect(stub).to.be.calledOnce;
       });

--- a/extensions/amp-animation/0.1/test/test-css-expr.js
+++ b/extensions/amp-animation/0.1/test/test-css-expr.js
@@ -441,14 +441,14 @@ describe('CSS parse', () => {
   });
 });
 
-describes.sandboxed('CSS resolve', {}, () => {
+describes.sandboxed('CSS resolve', {}, env => {
   const normalize = true;
   let context;
   let contextMock;
 
   beforeEach(() => {
     context = new ast.CssContext();
-    contextMock = sandbox.mock(context);
+    contextMock = env.sandbox.mock(context);
   });
 
   afterEach(() => {
@@ -462,7 +462,7 @@ describes.sandboxed('CSS resolve', {}, () => {
 
   it('should not resolve value for a const', () => {
     const node = new ast.CssNode();
-    const nodeMock = sandbox.mock(node);
+    const nodeMock = env.sandbox.mock(node);
     nodeMock
       .expects('css')
       .returns('CSS')
@@ -482,7 +482,7 @@ describes.sandboxed('CSS resolve', {}, () => {
     const node = new ast.CssNode();
     const node2 = new ast.CssNode();
     node2.css = () => 'CSS2';
-    const nodeMock = sandbox.mock(node);
+    const nodeMock = env.sandbox.mock(node);
     nodeMock
       .expects('isConst')
       .returns(false)
@@ -1063,7 +1063,7 @@ describes.sandboxed('CSS resolve', {}, () => {
         dimStack.pop();
         return res;
       };
-      sandbox
+      env.sandbox
         .stub(ast.CssPassthroughNode.prototype, 'resolve')
         .callsFake(function() {
           return new ast.CssPassthroughNode(this.css_ + dimStack.join(''));
@@ -1292,7 +1292,7 @@ describes.sandboxed('CSS resolve', {}, () => {
 
   describe('rand', () => {
     beforeEach(() => {
-      sandbox.stub(Math, 'random').callsFake(() => 0.25);
+      env.sandbox.stub(Math, 'random').callsFake(() => 0.25);
     });
 
     it('should always consider as non-const', () => {

--- a/extensions/amp-animation/0.1/test/test-web-animations.js
+++ b/extensions/amp-animation/0.1/test/test-web-animations.js
@@ -33,7 +33,7 @@ describes.realWin('MeasureScanner', {amp: 1}, env => {
   beforeEach(() => {
     win = env.win;
     doc = win.document;
-    sandbox.stub(win, 'matchMedia').callsFake(query => {
+    env.sandbox.stub(win, 'matchMedia').callsFake(query => {
       if (query == 'match') {
         return {matches: true};
       }
@@ -45,7 +45,7 @@ describes.realWin('MeasureScanner', {amp: 1}, env => {
     if (!win.CSS) {
       win.CSS = {supports: () => {}};
     }
-    sandbox.stub(win.CSS, 'supports').callsFake(condition => {
+    env.sandbox.stub(win.CSS, 'supports').callsFake(condition => {
       if (condition == 'supported: 1') {
         return true;
       }
@@ -54,15 +54,15 @@ describes.realWin('MeasureScanner', {amp: 1}, env => {
       }
       throw new Error('unknown condition: ' + condition);
     });
-    warnStub = sandbox.stub(user(), 'warn');
+    warnStub = env.sandbox.stub(user(), 'warn');
 
     vsync = Services.vsyncFor(win);
-    sandbox.stub(vsync, 'measurePromise').callsFake(callback => {
+    env.sandbox.stub(vsync, 'measurePromise').callsFake(callback => {
       return Promise.resolve(callback());
     });
     resources = Services.resourcesForDoc(env.ampdoc);
     owners = Services.ownersForDoc(env.ampdoc);
-    requireLayoutSpy = sandbox.spy(owners, 'requireLayout');
+    requireLayoutSpy = env.sandbox.spy(owners, 'requireLayout');
 
     target1 = doc.createElement('div');
     target1.id = 'target1';
@@ -87,7 +87,7 @@ describes.realWin('MeasureScanner', {amp: 1}, env => {
       /* vsync */ null,
       /* owners */ null
     );
-    sandbox.stub(builder, 'requireLayout');
+    env.sandbox.stub(builder, 'requireLayout');
     const scanner = builder.createScanner_([]);
     const success = scanner.scan(spec);
     if (success) {
@@ -144,8 +144,8 @@ describes.realWin('MeasureScanner', {amp: 1}, env => {
       );
     });
     expect(warnStub).to.not.be.calledWith(
-      sinon.match.any,
-      sinon.match(arg => {
+      env.sandbox.match.any,
+      env.sandbox.match(arg => {
         return /fractional/.test(arg);
       })
     );
@@ -375,7 +375,7 @@ describes.realWin('MeasureScanner', {amp: 1}, env => {
   });
 
   it('should propagate vars', () => {
-    sandbox.stub(win, 'getComputedStyle').callsFake(target => {
+    env.sandbox.stub(win, 'getComputedStyle').callsFake(target => {
       if (target == target2) {
         return {
           getPropertyValue: prop => {
@@ -683,7 +683,7 @@ describes.realWin('MeasureScanner', {amp: 1}, env => {
   });
 
   it('should parse rand function', () => {
-    sandbox.stub(Math, 'random').callsFake(() => 0.25);
+    env.sandbox.stub(Math, 'random').callsFake(() => 0.25);
     const {keyframes} = scan({
       target: target1,
       keyframes: {
@@ -980,7 +980,7 @@ describes.realWin('MeasureScanner', {amp: 1}, env => {
       vsync,
       /* owners */ null
     );
-    sandbox.stub(builder, 'requireLayout');
+    env.sandbox.stub(builder, 'requireLayout');
     const spec = {target: target1, delay: 101, keyframes: {}};
     const args = {
       'duration': 1001,
@@ -1014,7 +1014,7 @@ describes.realWin('MeasureScanner', {amp: 1}, env => {
       doc.body.appendChild(animation2);
 
       builder = new Builder(win, doc, 'https://acme.org/', vsync, owners);
-      sandbox.stub(builder, 'requireLayout');
+      env.sandbox.stub(builder, 'requireLayout');
       scanner = builder.createScanner_([]);
     });
 
@@ -1267,7 +1267,7 @@ describes.realWin('MeasureScanner', {amp: 1}, env => {
         /* owners */ null
       );
       css = builder.css_;
-      parseSpy = sandbox.spy(css, 'resolveAsNode_');
+      parseSpy = env.sandbox.spy(css, 'resolveAsNode_');
     });
 
     it('should measure styles', () => {
@@ -1284,7 +1284,7 @@ describes.realWin('MeasureScanner', {amp: 1}, env => {
     });
 
     it('should use cache', () => {
-      const spy = sandbox.spy(win, 'getComputedStyle');
+      const spy = env.sandbox.spy(win, 'getComputedStyle');
 
       // First: target1.
       expect(css.measure(target1, 'display')).to.equal('block');
@@ -1390,7 +1390,7 @@ describes.realWin('MeasureScanner', {amp: 1}, env => {
 
     // TODO(dvoytenko, #12476): Make this test work with sinon 4.0.
     it.skip('should read a var', () => {
-      const stub = sandbox.stub(css, 'measure').callsFake(() => '10px');
+      const stub = env.sandbox.stub(css, 'measure').callsFake(() => '10px');
       expect(css.getVar('--var1')).to.be.null;
       expect(warnStub).to.have.callCount(1);
       expect(warnStub.args[0][1]).to.match(/Variable not found/);
@@ -1548,12 +1548,12 @@ describes.realWin('MeasureScanner', {amp: 1}, env => {
     beforeEach(() => {
       amp1 = env.createAmpElement();
       amp2 = env.createAmpElement();
-      sandbox.stub(amp1, 'isUpgraded').callsFake(() => true);
-      sandbox.stub(amp2, 'isUpgraded').callsFake(() => true);
-      sandbox.stub(amp1, 'isBuilt').callsFake(() => true);
-      sandbox.stub(amp2, 'isBuilt').callsFake(() => true);
-      sandbox.stub(amp1, 'whenBuilt').callsFake(() => Promise.resolve());
-      sandbox.stub(amp2, 'whenBuilt').callsFake(() => Promise.resolve());
+      env.sandbox.stub(amp1, 'isUpgraded').callsFake(() => true);
+      env.sandbox.stub(amp2, 'isUpgraded').callsFake(() => true);
+      env.sandbox.stub(amp1, 'isBuilt').callsFake(() => true);
+      env.sandbox.stub(amp2, 'isBuilt').callsFake(() => true);
+      env.sandbox.stub(amp1, 'whenBuilt').callsFake(() => Promise.resolve());
+      env.sandbox.stub(amp2, 'whenBuilt').callsFake(() => Promise.resolve());
       resources.add(amp1);
       resources.add(amp2);
     });
@@ -1588,10 +1588,10 @@ describes.realWin('MeasureScanner', {amp: 1}, env => {
     it.skip('should block AMP elements', () => {
       const r1 = resources.getResourceForElement(amp1);
       const r2 = resources.getResourceForElement(amp2);
-      sandbox.stub(r1, 'whenBuilt').callsFake(() => Promise.resolve());
-      sandbox.stub(r2, 'whenBuilt').callsFake(() => Promise.resolve());
-      sandbox.stub(r1, 'isDisplayed').callsFake(() => true);
-      sandbox.stub(r2, 'isDisplayed').callsFake(() => true);
+      env.sandbox.stub(r1, 'whenBuilt').callsFake(() => Promise.resolve());
+      env.sandbox.stub(r2, 'whenBuilt').callsFake(() => Promise.resolve());
+      env.sandbox.stub(r1, 'isDisplayed').callsFake(() => true);
+      env.sandbox.stub(r2, 'isDisplayed').callsFake(() => true);
       let runner;
       createRunner([
         {target: amp1, keyframes: {}},
@@ -1625,7 +1625,7 @@ describes.realWin('MeasureScanner', {amp: 1}, env => {
   });
 });
 
-describes.sandboxed('NativeWebAnimationRunner', {}, () => {
+describes.sandboxed('NativeWebAnimationRunner', {}, env => {
   let target1, target2;
   let target1Mock, target2Mock;
   let keyframes1, keyframes2;
@@ -1668,20 +1668,20 @@ describes.sandboxed('NativeWebAnimationRunner', {}, () => {
     timing2 = {};
     anim1 = new WebAnimationStub();
     anim2 = new WebAnimationStub();
-    anim1Mock = sandbox.mock(anim1);
-    anim2Mock = sandbox.mock(anim2);
+    anim1Mock = env.sandbox.mock(anim1);
+    anim2Mock = env.sandbox.mock(anim2);
 
     target1 = {style: createStyle(), animate: () => anim1};
-    target1Mock = sandbox.mock(target1);
+    target1Mock = env.sandbox.mock(target1);
     target2 = {style: createStyle(), animate: () => anim2};
-    target2Mock = sandbox.mock(target2);
+    target2Mock = env.sandbox.mock(target2);
 
     runner = new NativeWebAnimationRunner([
       {target: target1, keyframes: keyframes1, timing: timing1},
       {target: target2, keyframes: keyframes2, timing: timing2},
     ]);
 
-    playStateSpy = sandbox.spy();
+    playStateSpy = env.sandbox.spy();
     runner.onPlayStateChanged(playStateSpy);
   });
 
@@ -1972,7 +1972,7 @@ describes.sandboxed('NativeWebAnimationRunner', {}, () => {
     runner.start();
     expect(runner.getPlayState()).to.equal(WebAnimationPlayState.RUNNING);
 
-    sandbox.stub(runner, 'getTotalDuration_').returns(500);
+    env.sandbox.stub(runner, 'getTotalDuration_').returns(500);
     anim1Mock
       .expects('pause')
       .callThrough()

--- a/extensions/amp-apester-media/0.1/test/test-amp-apester-media.js
+++ b/extensions/amp-apester-media/0.1/test/test-amp-apester-media.js
@@ -81,12 +81,12 @@ describes.realWin(
           ? playlistResponse
           : regularResponse;
 
-      changeSizeSpy = sandbox.spy(media.implementation_, 'changeHeight');
-      attemptChangeSizeSpy = sandbox.spy(
+      changeSizeSpy = env.sandbox.spy(media.implementation_, 'changeHeight');
+      attemptChangeSizeSpy = env.sandbox.spy(
         media.implementation_,
         'attemptChangeHeight'
       );
-      xhrMock = sandbox.mock(Services.xhrFor(win));
+      xhrMock = env.sandbox.mock(Services.xhrFor(win));
       if (attributes) {
         xhrMock.expects('fetchJson').returns(
           Promise.resolve({

--- a/extensions/amp-app-banner/0.1/test/test-amp-app-banner.js
+++ b/extensions/amp-app-banner/0.1/test/test-amp-app-banner.js
@@ -84,7 +84,7 @@ describes.realWin(
         manifest.setAttribute('rel', rel);
         manifest.setAttribute('href', manifestObj.href);
         doc.head.appendChild(manifest);
-        sandbox
+        env.sandbox
           .mock(Services.xhrFor(win))
           .expects('fetchJson')
           .returns(
@@ -148,9 +148,11 @@ describes.realWin(
     }
 
     function testRemoveBannerIfDismissed() {
-      sandbox.stub(AbstractAppBanner.prototype, 'isDismissed').callsFake(() => {
-        return Promise.resolve(true);
-      });
+      env.sandbox
+        .stub(AbstractAppBanner.prototype, 'isDismissed')
+        .callsFake(() => {
+          return Promise.resolve(true);
+        });
       return testRemoveBanner();
     }
 
@@ -158,7 +160,7 @@ describes.realWin(
       it('should preconnect to app store', () => {
         return getAppBanner({iosMeta}).then(banner => {
           const impl = banner.implementation_;
-          sandbox.stub(impl.preconnect, 'url');
+          env.sandbox.stub(impl.preconnect, 'url');
           impl.preconnectCallback(true);
           expect(impl.preconnect.url.called).to.be.true;
           expect(impl.preconnect.url).to.be.calledOnce;
@@ -187,7 +189,7 @@ describes.realWin(
       });
 
       it('should parse meta content and setup hrefs', () => {
-        sandbox.spy(AbstractAppBanner.prototype, 'setupOpenButton_');
+        env.sandbox.spy(AbstractAppBanner.prototype, 'setupOpenButton_');
         return getAppBanner({iosMeta}).then(el => {
           expect(
             AbstractAppBanner.prototype.setupOpenButton_
@@ -208,7 +210,7 @@ describes.realWin(
               'should contain app-argument to allow opening an already ' +
               'installed application on iOS.'
           );
-          sandbox.spy(AbstractAppBanner.prototype, 'setupOpenButton_');
+          env.sandbox.spy(AbstractAppBanner.prototype, 'setupOpenButton_');
           return getAppBanner({
             iosMeta: {content: 'app-id=828256236'},
           }).then(el => {
@@ -241,8 +243,8 @@ describes.realWin(
       it('should preconnect to play store and preload manifest', () => {
         return getAppBanner({androidManifest}).then(banner => {
           const impl = banner.implementation_;
-          sandbox.stub(impl.preconnect, 'url');
-          sandbox.stub(impl.preconnect, 'preload');
+          env.sandbox.stub(impl.preconnect, 'url');
+          env.sandbox.stub(impl.preconnect, 'preload');
           impl.preconnectCallback(true);
           expect(impl.preconnect.url.called).to.be.true;
           expect(impl.preconnect.url).to.have.been.calledOnce;
@@ -260,8 +262,8 @@ describes.realWin(
       it('should preconnect to play store and preload origin-manifest', () => {
         return getAppBanner({originManifest: androidManifest}).then(banner => {
           const impl = banner.implementation_;
-          sandbox.stub(impl.preconnect, 'url');
-          sandbox.stub(impl.preconnect, 'preload');
+          env.sandbox.stub(impl.preconnect, 'url');
+          env.sandbox.stub(impl.preconnect, 'preload');
           impl.preconnectCallback(true);
           expect(impl.preconnect.url.called).to.be.true;
           expect(impl.preconnect.url).to.have.been.calledOnce;
@@ -291,7 +293,7 @@ describes.realWin(
       });
 
       it('should parse manifest and set hrefs', () => {
-        sandbox.spy(AbstractAppBanner.prototype, 'setupOpenButton_');
+        env.sandbox.spy(AbstractAppBanner.prototype, 'setupOpenButton_');
         return getAppBanner({androidManifest}).then(el => {
           expect(
             AbstractAppBanner.prototype.setupOpenButton_
@@ -304,7 +306,7 @@ describes.realWin(
       });
 
       it('should parse origin manifest and set hrefs', () => {
-        sandbox.spy(AbstractAppBanner.prototype, 'setupOpenButton_');
+        env.sandbox.spy(AbstractAppBanner.prototype, 'setupOpenButton_');
         return getAppBanner({originManifest: androidManifest}).then(el => {
           expect(
             AbstractAppBanner.prototype.setupOpenButton_
@@ -331,24 +333,24 @@ describes.realWin(
       doc = win.document;
       ampdoc = env.ampdoc;
       const viewer = Services.viewerForDoc(ampdoc);
-      sandbox.stub(viewer, 'isEmbedded').callsFake(() => isEmbedded);
-      sandbox
+      env.sandbox.stub(viewer, 'isEmbedded').callsFake(() => isEmbedded);
+      env.sandbox
         .stub(viewer, 'hasCapability')
         .callsFake(() => hasNavigateToCapability);
       platform = Services.platformFor(win);
-      sandbox.stub(platform, 'isIos').callsFake(() => isIos);
-      sandbox.stub(platform, 'isAndroid').callsFake(() => isAndroid);
-      sandbox.stub(platform, 'isChrome').callsFake(() => isChrome);
-      sandbox.stub(platform, 'isSafari').callsFake(() => isSafari);
-      sandbox.stub(platform, 'isFirefox').callsFake(() => isFirefox);
-      sandbox.stub(platform, 'isEdge').callsFake(() => isEdge);
+      env.sandbox.stub(platform, 'isIos').callsFake(() => isIos);
+      env.sandbox.stub(platform, 'isAndroid').callsFake(() => isAndroid);
+      env.sandbox.stub(platform, 'isChrome').callsFake(() => isChrome);
+      env.sandbox.stub(platform, 'isSafari').callsFake(() => isSafari);
+      env.sandbox.stub(platform, 'isFirefox').callsFake(() => isFirefox);
+      env.sandbox.stub(platform, 'isEdge').callsFake(() => isEdge);
 
       vsync = Services.vsyncFor(win);
-      sandbox.stub(vsync, 'runPromise').callsFake((task, state) => {
+      env.sandbox.stub(vsync, 'runPromise').callsFake((task, state) => {
         runTask(task, state);
         return Promise.resolve();
       });
-      sandbox.stub(vsync, 'run').callsFake(runTask);
+      env.sandbox.stub(vsync, 'run').callsFake(runTask);
     });
 
     describe('Choosing platform', () => {
@@ -569,7 +571,7 @@ describes.realWin(
         const openButton = doc.createElement('button');
         element.appendChild(openButton);
         openButton.setAttribute('open-button', '');
-        openButton.addEventListener = sandbox.spy();
+        openButton.addEventListener = env.sandbox.spy();
         const banner = new AbstractAppBanner(element);
         banner.setupOpenButton_(openButton, 'open-button', 'install-link');
         expect(openButton.addEventListener).to.have.been.calledWith('click');

--- a/extensions/amp-audio/0.1/test/test-amp-audio.js
+++ b/extensions/amp-audio/0.1/test/test-amp-audio.js
@@ -227,7 +227,7 @@ describes.realWin(
         return savedCreateElement.call(doc, name);
       };
       const element = doc.createElement('div');
-      element.toggleFallback = sandbox.spy();
+      element.toggleFallback = env.sandbox.spy();
       const audio = new AmpAudio(element);
       const promise = audio.buildAudioElement();
       doc.createElement = savedCreateElement;

--- a/extensions/amp-auto-ads/0.1/test/test-ad-strategy.js
+++ b/extensions/amp-auto-ads/0.1/test/test-ad-strategy.js
@@ -46,7 +46,7 @@ describes.realWin(
       doc.body.appendChild(container);
       // Stub whenBuilt to resolve immediately to handle upgrade for AdSense
       // to FF impl.
-      sinon
+      env.sandbox
         .stub(win.__AMP_BASE_CE_CLASS.prototype, 'whenBuilt')
         .callsFake(() => Promise.resolve());
     });
@@ -70,7 +70,7 @@ describes.realWin(
       const placements = getPlacementsFromConfigObj(ampdoc, configObj);
       expect(placements).to.have.lengthOf(1);
 
-      const placeAdSpy = sandbox.spy(placements[0], 'placeAd');
+      const placeAdSpy = env.sandbox.spy(placements[0], 'placeAd');
 
       const attributes = {
         'type': 'adsense',
@@ -195,7 +195,7 @@ describes.realWin(
       const placements = getPlacementsFromConfigObj(ampdoc, configObj);
 
       expect(placements).to.have.lengthOf(2);
-      sandbox.stub(placements[0], 'placeAd').callsFake(() => {
+      env.sandbox.stub(placements[0], 'placeAd').callsFake(() => {
         return Promise.resolve(PlacementState.REIZE_FAILED);
       });
 
@@ -503,10 +503,10 @@ describes.realWin(
       const placements = getPlacementsFromConfigObj(ampdoc, configObj);
 
       expect(placements).to.have.lengthOf(2);
-      sandbox.stub(placements[0], 'placeAd').callsFake(() => {
+      env.sandbox.stub(placements[0], 'placeAd').callsFake(() => {
         return Promise.resolve(PlacementState.REIZE_FAILED);
       });
-      sandbox.stub(placements[1], 'placeAd').callsFake(() => {
+      env.sandbox.stub(placements[1], 'placeAd').callsFake(() => {
         return Promise.resolve(PlacementState.REIZE_FAILED);
       });
 

--- a/extensions/amp-auto-ads/0.1/test/test-ad-tracker.js
+++ b/extensions/amp-auto-ads/0.1/test/test-ad-tracker.js
@@ -31,7 +31,7 @@ describes.realWin('ad-tracker', {amp: true}, env => {
     win = env.win;
     doc = win.document;
 
-    sandbox.stub(Utils, 'getElementLayoutBox').callsFake(element => {
+    env.sandbox.stub(Utils, 'getElementLayoutBox').callsFake(element => {
       return Promise.resolve(element.layoutBox);
     });
 
@@ -308,7 +308,7 @@ describes.realWin('getAdConstraintsFromConfigObj', {amp: true}, env => {
   });
 
   it('should get from viewport values', () => {
-    const viewportMock = sandbox.mock(Services.viewportForDoc(ampdoc));
+    const viewportMock = env.sandbox.mock(Services.viewportForDoc(ampdoc));
     viewportMock
       .expects('getHeight')
       .returns(500)

--- a/extensions/amp-auto-ads/0.1/test/test-adsense-network-config.js
+++ b/extensions/amp-auto-ads/0.1/test/test-adsense-network-config.js
@@ -71,7 +71,7 @@ describes.realWin(
           'http://foo.bar/a'.repeat(4050) + 'shouldnt_be_included';
 
         const docInfo = Services.documentInfoForDoc(ampAutoAdsElem);
-        sandbox.stub(docInfo, 'canonicalUrl').callsFake(canonicalUrl);
+        env.sandbox.stub(docInfo, 'canonicalUrl').callsFake(canonicalUrl);
 
         const url = adNetwork.getConfigUrl();
         expect(url).to.contain('ama_t=amp');
@@ -99,7 +99,7 @@ describes.realWin(
       });
 
       it('should get the default ad constraints', () => {
-        const viewportMock = sandbox.mock(
+        const viewportMock = env.sandbox.mock(
           Services.viewportForDoc(env.win.document)
         );
         viewportMock

--- a/extensions/amp-auto-ads/0.1/test/test-amp-auto-ads.js
+++ b/extensions/amp-auto-ads/0.1/test/test-amp-auto-ads.js
@@ -66,7 +66,6 @@ describes.repeated(
 
         let win;
         let doc;
-        let sandbox;
         let container;
         let anchor1;
         let anchor2;
@@ -79,7 +78,6 @@ describes.repeated(
         beforeEach(() => {
           win = env.win;
           doc = win.document;
-          sandbox = env.sandbox;
           const a4aRegistry = getA4ARegistry();
           a4aRegistry['_ping_'] = () => true;
 
@@ -101,11 +99,11 @@ describes.repeated(
           }
 
           const extensions = Services.extensionsFor(win);
-          sandbox
+          env.sandbox
             .stub(extensions, 'loadElementClass')
             .returns(Promise.resolve(el => new FakeA4A(el)));
 
-          const viewportMock = sandbox.mock(Services.viewportForDoc(doc));
+          const viewportMock = env.sandbox.mock(Services.viewportForDoc(doc));
           viewportMock
             .expects('getSize')
             .returns({width: 320, height: 500})
@@ -184,9 +182,9 @@ describes.repeated(
               },
             });
           };
-          sandbox.spy(xhr, 'fetchJson');
+          env.sandbox.spy(xhr, 'fetchJson');
 
-          whenVisible = sandbox.stub(env.ampdoc, 'whenFirstVisible');
+          whenVisible = env.sandbox.stub(env.ampdoc, 'whenFirstVisible');
           whenVisible.returns(Promise.resolve());
         });
 

--- a/extensions/amp-auto-ads/0.1/test/test-anchor-ad-strategy.js
+++ b/extensions/amp-auto-ads/0.1/test/test-anchor-ad-strategy.js
@@ -33,7 +33,7 @@ describes.realWin(
     let attributes;
 
     beforeEach(() => {
-      const viewportMock = sandbox.mock(
+      const viewportMock = env.sandbox.mock(
         Services.viewportForDoc(env.win.document)
       );
       viewportMock

--- a/extensions/amp-auto-ads/0.1/test/test-denakop-network-config.js
+++ b/extensions/amp-auto-ads/0.1/test/test-denakop-network-config.js
@@ -71,7 +71,7 @@ describes.realWin(
           'http://foo.bar/a'.repeat(4050) + 'shouldnt_be_included';
 
         const docInfo = Services.documentInfoForDoc(ampAutoAdsElem);
-        sandbox.stub(docInfo, 'canonicalUrl').callsFake(canonicalUrl);
+        env.sandbox.stub(docInfo, 'canonicalUrl').callsFake(canonicalUrl);
 
         const url = adNetwork.getConfigUrl();
         expect(url).to.contain('ama_t=amp');
@@ -90,7 +90,7 @@ describes.realWin(
       });
 
       it('should get the default ad constraints', () => {
-        const viewportMock = sandbox.mock(
+        const viewportMock = env.sandbox.mock(
           Services.viewportForDoc(env.win.document)
         );
         viewportMock

--- a/extensions/amp-auto-ads/0.1/test/test-doubleclick-network-config.js
+++ b/extensions/amp-auto-ads/0.1/test/test-doubleclick-network-config.js
@@ -85,7 +85,7 @@ describes.realWin(
           'http://foo.bar/a'.repeat(4050) + 'shouldnt_be_included';
 
         const docInfo = Services.documentInfoForDoc(ampAutoAdsElem);
-        sandbox.stub(docInfo, 'canonicalUrl').callsFake(canonicalUrl);
+        env.sandbox.stub(docInfo, 'canonicalUrl').callsFake(canonicalUrl);
 
         const url = adNetwork.getConfigUrl();
         expect(url).to.contain('ama_t=amp');
@@ -103,7 +103,7 @@ describes.realWin(
       });
 
       it('should get the default ad constraints', () => {
-        const viewportMock = sandbox.mock(
+        const viewportMock = env.sandbox.mock(
           Services.viewportForDoc(env.win.document)
         );
         viewportMock

--- a/extensions/amp-auto-ads/0.1/test/test-placement.js
+++ b/extensions/amp-auto-ads/0.1/test/test-placement.js
@@ -54,7 +54,7 @@ describes.realWin(
       doc.body.appendChild(container);
       // Stub whenBuilt to resolve immediately to handle upgrade for AdSense
       // to FF impl.
-      sinon
+      env.sandbox
         .stub(win.__AMP_BASE_CE_CLASS.prototype, 'whenBuilt')
         .callsFake(() => Promise.resolve());
     });
@@ -465,7 +465,7 @@ describes.realWin(
         });
 
         const resources = Services.resourcesForDoc(anchor);
-        sandbox.stub(resources, 'attemptChangeSize').callsFake(() => {
+        env.sandbox.stub(resources, 'attemptChangeSize').callsFake(() => {
           return Promise.reject();
         });
 
@@ -668,10 +668,10 @@ describes.realWin(
         container.appendChild(anchor);
 
         const resource = Services.resourcesForDoc(anchor);
-        sandbox.stub(resource, 'attemptChangeSize').callsFake(() => {
+        env.sandbox.stub(resource, 'attemptChangeSize').callsFake(() => {
           return Promise.resolve();
         });
-        sandbox.stub(resource.viewport_, 'getWidth').callsFake(() => 2000);
+        env.sandbox.stub(resource.viewport_, 'getWidth').callsFake(() => 2000);
 
         const placements = getPlacementsFromConfigObj(
           ampdoc,
@@ -727,13 +727,13 @@ describes.realWin(
         container.appendChild(anchor);
 
         const resource = Services.resourcesForDoc(anchor);
-        sandbox.stub(resource, 'attemptChangeSize').callsFake(() => {
+        env.sandbox.stub(resource, 'attemptChangeSize').callsFake(() => {
           return Promise.resolve();
         });
-        sandbox.stub(win, 'getComputedStyle').callsFake(() => {
+        env.sandbox.stub(win, 'getComputedStyle').callsFake(() => {
           return {direction: 'ltr'};
         });
-        sandbox.stub(Utils, 'getElementLayoutBox').callsFake(() => {
+        env.sandbox.stub(Utils, 'getElementLayoutBox').callsFake(() => {
           return Promise.resolve({left: 20});
         });
 
@@ -781,13 +781,13 @@ describes.realWin(
         container.appendChild(anchor);
 
         const resource = Services.resourcesForDoc(anchor);
-        sandbox.stub(resource, 'attemptChangeSize').callsFake(() => {
+        env.sandbox.stub(resource, 'attemptChangeSize').callsFake(() => {
           return Promise.resolve();
         });
-        sandbox.stub(win, 'getComputedStyle').callsFake(() => {
+        env.sandbox.stub(win, 'getComputedStyle').callsFake(() => {
           return {direction: 'rtl'};
         });
-        sandbox.stub(Utils, 'getElementLayoutBox').callsFake(() => {
+        env.sandbox.stub(Utils, 'getElementLayoutBox').callsFake(() => {
           return Promise.resolve({left: 20});
         });
 
@@ -835,7 +835,7 @@ describes.realWin(
         container.appendChild(anchor);
 
         const resource = Services.resourcesForDoc(anchor);
-        sandbox.stub(resource, 'attemptChangeSize').callsFake(() => {
+        env.sandbox.stub(resource, 'attemptChangeSize').callsFake(() => {
           return Promise.resolve();
         });
 
@@ -881,7 +881,7 @@ describes.realWin(
         container.appendChild(anchor);
 
         const resource = Services.resourcesForDoc(anchor);
-        sandbox.stub(resource, 'attemptChangeSize').callsFake(() => {
+        env.sandbox.stub(resource, 'attemptChangeSize').callsFake(() => {
           return Promise.reject(new Error('Resize failed'));
         });
 
@@ -932,7 +932,7 @@ describes.realWin(
         container.appendChild(anchor);
 
         const resource = Services.resourcesForDoc(anchor);
-        sandbox.stub(resource, 'attemptChangeSize').callsFake(() => {
+        env.sandbox.stub(resource, 'attemptChangeSize').callsFake(() => {
           return Promise.reject(new Error('Resize failed'));
         });
 

--- a/extensions/amp-auto-ads/0.1/test/test-utils.js
+++ b/extensions/amp-auto-ads/0.1/test/test-utils.js
@@ -22,13 +22,11 @@ const BOX = layoutRectLtwh(1, 5, 10, 10);
 
 describes.realWin('amp-auto-ads utils', {amp: true}, env => {
   let win;
-  let sandbox;
   let element;
   let measureStub;
 
   beforeEach(() => {
     win = env.win;
-    sandbox = env.sandbox;
 
     element = env.createAmpElement('amp-foobar');
     win.document.body.appendChild(element);
@@ -37,11 +35,13 @@ describes.realWin('amp-auto-ads utils', {amp: true}, env => {
   describe('getElementLayoutBox', () => {
     beforeEach(() => {
       const viewport = Services.viewportForDoc(element);
-      measureStub = sandbox.stub(viewport, 'getLayoutRect').callsFake(el => {
-        if (el === element) {
-          return BOX;
-        }
-      });
+      measureStub = env.sandbox
+        .stub(viewport, 'getLayoutRect')
+        .callsFake(el => {
+          if (el === element) {
+            return BOX;
+          }
+        });
     });
 
     it('should measure the element', () => {

--- a/extensions/amp-auto-lightbox/0.1/test/test-amp-auto-lightbox.js
+++ b/extensions/amp-auto-lightbox/0.1/test/test-amp-auto-lightbox.js
@@ -52,8 +52,7 @@ describes.realWin(
   },
   env => {
     let html;
-
-    const {any} = sinon.match;
+    let any;
 
     const ldJsonSchemaTypes = Object.keys(ENABLED_LD_JSON_TYPES);
     const ogTypes = [ENABLED_OG_TYPE_ARTICLE];
@@ -104,7 +103,7 @@ describes.realWin(
 
     // necessary since element matching `withArgs` deep equals and overflows
     const matchEquals = comparison =>
-      sinon.match(subject => subject == comparison);
+      env.sandbox.match(subject => subject == comparison);
 
     function mockLoadedSignal(element, isLoadedSuccessfully) {
       const signals = new Signals();
@@ -118,6 +117,7 @@ describes.realWin(
     }
 
     beforeEach(() => {
+      any = env.sandbox.match.any;
       html = htmlFor(env.win.document);
 
       env.sandbox

--- a/extensions/amp-autocomplete/0.1/test/test-amp-autocomplete-init.js
+++ b/extensions/amp-autocomplete/0.1/test/test-amp-autocomplete-init.js
@@ -89,10 +89,13 @@ describes.realWin(
           expect(impl.inputElement_).not.to.be.null;
           expect(impl.container_).not.to.be.null;
           expect(impl.filter_).to.equal('substring');
-          filterAndRenderSpy = sandbox.spy(impl, 'filterDataAndRenderResults_');
-          clearAllSpy = sandbox.spy(impl, 'clearAllItems_');
-          filterSpy = sandbox.spy(impl, 'filterData_');
-          renderSpy = sandbox.spy(impl, 'renderResults_');
+          filterAndRenderSpy = env.sandbox.spy(
+            impl,
+            'filterDataAndRenderResults_'
+          );
+          clearAllSpy = env.sandbox.spy(impl, 'clearAllItems_');
+          filterSpy = env.sandbox.spy(impl, 'filterData_');
+          renderSpy = env.sandbox.spy(impl, 'renderResults_');
           return ampAutocomplete.layoutCallback();
         })
         .then(() => {
@@ -117,10 +120,13 @@ describes.realWin(
           expect(impl.inputElement_).not.to.be.null;
           expect(impl.container_).not.to.be.null;
           expect(impl.filter_).to.equal('substring');
-          filterAndRenderSpy = sandbox.spy(impl, 'filterDataAndRenderResults_');
-          clearAllSpy = sandbox.spy(impl, 'clearAllItems_');
-          filterSpy = sandbox.spy(impl, 'filterData_');
-          renderSpy = sandbox.spy(impl, 'renderResults_');
+          filterAndRenderSpy = env.sandbox.spy(
+            impl,
+            'filterDataAndRenderResults_'
+          );
+          clearAllSpy = env.sandbox.spy(impl, 'clearAllItems_');
+          filterSpy = env.sandbox.spy(impl, 'filterData_');
+          renderSpy = env.sandbox.spy(impl, 'renderResults_');
           return ampAutocomplete.layoutCallback();
         })
         .then(() => {
@@ -148,10 +154,13 @@ describes.realWin(
           expect(impl.inputElement_).not.to.be.null;
           expect(impl.container_).not.to.be.null;
           expect(impl.filter_).to.equal('substring');
-          filterAndRenderSpy = sandbox.spy(impl, 'filterDataAndRenderResults_');
-          clearAllSpy = sandbox.spy(impl, 'clearAllItems_');
-          filterSpy = sandbox.spy(impl, 'filterData_');
-          renderSpy = sandbox.spy(impl, 'renderResults_');
+          filterAndRenderSpy = env.sandbox.spy(
+            impl,
+            'filterDataAndRenderResults_'
+          );
+          clearAllSpy = env.sandbox.spy(impl, 'clearAllItems_');
+          filterSpy = env.sandbox.spy(impl, 'filterData_');
+          renderSpy = env.sandbox.spy(impl, 'renderResults_');
           return ampAutocomplete.layoutCallback();
         })
         .then(() => {

--- a/extensions/amp-autocomplete/0.1/test/test-amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/test/test-amp-autocomplete.js
@@ -58,10 +58,13 @@ describes.realWin(
       let filterAndRenderSpy;
 
       beforeEach(() => {
-        remoteDataSpy = sandbox
+        remoteDataSpy = env.sandbox
           .stub(impl, 'getRemoteData_')
           .resolves(['a', 'b', 'c']);
-        filterAndRenderSpy = sandbox.spy(impl, 'filterDataAndRenderResults_');
+        filterAndRenderSpy = env.sandbox.spy(
+          impl,
+          'filterDataAndRenderResults_'
+        );
       });
 
       it('should resolve when param is {}', () => {
@@ -182,9 +185,9 @@ describes.realWin(
       beforeEach(() => {
         expect(impl.container_).not.to.be.null;
         expect(impl.container_.children.length).to.equal(0);
-        clearAllItemsSpy = sandbox.spy(impl, 'clearAllItems_');
-        filterDataSpy = sandbox.spy(impl, 'filterData_');
-        renderSpy = sandbox.spy(impl, 'renderResults_');
+        clearAllItemsSpy = env.sandbox.spy(impl, 'clearAllItems_');
+        filterDataSpy = env.sandbox.spy(impl, 'filterData_');
+        renderSpy = env.sandbox.spy(impl, 'renderResults_');
       });
 
       it('should only clear if input < minChars_', () => {
@@ -233,7 +236,7 @@ describes.realWin(
     });
 
     it('renderResults_() should update the container_ with plain text', () => {
-      const createSpy = sandbox.spy(impl, 'createElementFromItem_');
+      const createSpy = env.sandbox.spy(impl, 'createElementFromItem_');
       return impl.renderResults_(['apple'], impl.container_).then(() => {
         expect(impl.container_.children.length).to.equal(1);
         expect(impl.container_.children[0].innerText).to.equal('apple');
@@ -251,7 +254,7 @@ describes.realWin(
         renderedChild.setAttribute('data-value', item.value);
         renderedChildren.push(renderedChild);
       });
-      const renderTemplateSpy = sandbox
+      const renderTemplateSpy = env.sandbox
         .stub(impl.templates_, 'renderTemplateArray')
         .returns(Promise.resolve(renderedChildren));
 
@@ -404,9 +407,9 @@ describes.realWin(
           .layoutCallback()
           .then(() => {
             impl.inputElement_.value = 'a';
-            renderSpy = sandbox.spy(impl, 'renderResults_');
-            toggleResultsSpy = sandbox.spy(impl, 'toggleResults_');
-            updateActiveSpy = sandbox.spy(impl, 'updateActiveItem_');
+            renderSpy = env.sandbox.spy(impl, 'renderResults_');
+            toggleResultsSpy = env.sandbox.spy(impl, 'toggleResults_');
+            updateActiveSpy = env.sandbox.spy(impl, 'updateActiveItem_');
             expect(impl.suggestFirst_).to.be.false;
             return impl.inputHandler_();
           })
@@ -423,9 +426,9 @@ describes.realWin(
           .layoutCallback()
           .then(() => {
             impl.inputElement_.value = 'a';
-            renderSpy = sandbox.spy(impl, 'renderResults_');
-            toggleResultsSpy = sandbox.spy(impl, 'toggleResults_');
-            updateActiveSpy = sandbox.spy(impl, 'updateActiveItem_');
+            renderSpy = env.sandbox.spy(impl, 'renderResults_');
+            toggleResultsSpy = env.sandbox.spy(impl, 'toggleResults_');
+            updateActiveSpy = env.sandbox.spy(impl, 'updateActiveItem_');
             impl.suggestFirst_ = true;
             return impl.inputHandler_();
           })
@@ -443,13 +446,13 @@ describes.realWin(
       let displayInputSpy, updateActiveSpy, eventPreventSpy;
 
       beforeEach(() => {
-        displayInputSpy = sandbox.spy(impl, 'displayUserInput_');
-        updateActiveSpy = sandbox.spy(impl, 'updateActiveItem_');
-        eventPreventSpy = sandbox.spy(event, 'preventDefault');
+        displayInputSpy = env.sandbox.spy(impl, 'displayUserInput_');
+        updateActiveSpy = env.sandbox.spy(impl, 'updateActiveItem_');
+        eventPreventSpy = env.sandbox.spy(event, 'preventDefault');
       });
 
       it('should updateActiveItem_ when results showing on Down arrow', () => {
-        sandbox
+        env.sandbox
           .stub(impl, 'resultsShowing_')
           .onFirstCall()
           .returns(true);
@@ -467,7 +470,7 @@ describes.realWin(
       });
 
       it('should displayUserInput_ when looping on Down arrow', () => {
-        sandbox.stub(impl, 'resultsShowing_').returns(true);
+        env.sandbox.stub(impl, 'resultsShowing_').returns(true);
         return element
           .layoutCallback()
           .then(() => {
@@ -485,11 +488,11 @@ describes.realWin(
         return element
           .layoutCallback()
           .then(() => {
-            filterAndRenderSpy = sandbox.spy(
+            filterAndRenderSpy = env.sandbox.spy(
               impl,
               'filterDataAndRenderResults_'
             );
-            toggleResultsSpy = sandbox.spy(impl, 'toggleResults_');
+            toggleResultsSpy = env.sandbox.spy(impl, 'toggleResults_');
             return impl.keyDownHandler_(event);
           })
           .then(() => {
@@ -540,10 +543,10 @@ describes.realWin(
       let selectItemSpy, resetSpy, clearAllSpy, eventPreventSpy;
       function layoutAndSetSpies() {
         return element.layoutCallback().then(() => {
-          eventPreventSpy = sandbox.spy(event, 'preventDefault');
-          selectItemSpy = sandbox.spy(impl, 'selectItem_');
-          resetSpy = sandbox.spy(impl, 'resetActiveElement_');
-          clearAllSpy = sandbox.spy(impl, 'clearAllItems_');
+          eventPreventSpy = env.sandbox.spy(event, 'preventDefault');
+          selectItemSpy = env.sandbox.spy(impl, 'selectItem_');
+          resetSpy = env.sandbox.spy(impl, 'resetActiveElement_');
+          clearAllSpy = env.sandbox.spy(impl, 'clearAllItems_');
         });
       }
 
@@ -565,7 +568,7 @@ describes.realWin(
         return layoutAndSetSpies()
           .then(() => {
             impl.activeElement_ = impl.createElementFromItem_('abc');
-            sandbox.stub(impl, 'resultsShowing_').returns(true);
+            env.sandbox.stub(impl, 'resultsShowing_').returns(true);
             return impl.keyDownHandler_(event);
           })
           .then(() => {
@@ -606,11 +609,11 @@ describes.realWin(
       return element
         .layoutCallback()
         .then(() => {
-          eventPreventSpy = sandbox.spy(event, 'preventDefault');
-          selectItemSpy = sandbox.spy(impl, 'selectItem_');
-          resetSpy = sandbox.spy(impl, 'resetActiveElement_');
-          clearAllSpy = sandbox.spy(impl, 'clearAllItems_');
-          sandbox.stub(impl, 'resultsShowing_').returns(true);
+          eventPreventSpy = env.sandbox.spy(event, 'preventDefault');
+          selectItemSpy = env.sandbox.spy(impl, 'selectItem_');
+          resetSpy = env.sandbox.spy(impl, 'resetActiveElement_');
+          clearAllSpy = env.sandbox.spy(impl, 'clearAllItems_');
+          env.sandbox.stub(impl, 'resultsShowing_').returns(true);
           return impl.keyDownHandler_(event);
         })
         .then(() => {
@@ -645,9 +648,9 @@ describes.realWin(
 
     it('should call keyDownHandler_() on Esc', () => {
       const event = {key: Keys.ESCAPE};
-      const displayInputSpy = sandbox.spy(impl, 'displayUserInput_');
-      const resetSpy = sandbox.spy(impl, 'resetActiveElement_');
-      const toggleResultsSpy = sandbox.spy(impl, 'toggleResults_');
+      const displayInputSpy = env.sandbox.spy(impl, 'displayUserInput_');
+      const resetSpy = env.sandbox.spy(impl, 'resetActiveElement_');
+      const toggleResultsSpy = env.sandbox.spy(impl, 'toggleResults_');
       return element
         .layoutCallback()
         .then(() => {
@@ -674,7 +677,7 @@ describes.realWin(
       impl.inputElement_.value = 'expected';
       impl.activeElement_ = doc.createElement('div');
       expect(impl.userInput_).not.to.equal(impl.inputElement_.value);
-      const fireEventSpy = sandbox.spy(impl, 'fireSelectEvent_');
+      const fireEventSpy = env.sandbox.spy(impl, 'fireSelectEvent_');
       return element
         .layoutCallback()
         .then(() => {
@@ -724,8 +727,8 @@ describes.realWin(
     });
 
     it('should call toggleResultsHandler_()', () => {
-      const toggleResultsSpy = sandbox.spy(impl, 'toggleResults_');
-      const resetSpy = sandbox.spy(impl, 'resetActiveElement_');
+      const toggleResultsSpy = env.sandbox.spy(impl, 'toggleResults_');
+      const resetSpy = env.sandbox.spy(impl, 'resetActiveElement_');
       return element
         .layoutCallback()
         .then(() => {
@@ -748,8 +751,8 @@ describes.realWin(
     });
 
     it('should call selectHandler_() on mousedown', () => {
-      const getItemSpy = sandbox.spy(impl, 'getItemElement_');
-      const selectItemSpy = sandbox.spy(impl, 'selectItem_');
+      const getItemSpy = env.sandbox.spy(impl, 'getItemElement_');
+      const selectItemSpy = env.sandbox.spy(impl, 'selectItem_');
       let mockEl = doc.createElement('div');
       return element
         .layoutCallback()
@@ -773,8 +776,8 @@ describes.realWin(
     });
 
     it('should fire select event from selectItem_', () => {
-      const fireEventSpy = sandbox.spy(impl, 'fireSelectEvent_');
-      const triggerSpy = sandbox.spy(impl.action_, 'trigger');
+      const fireEventSpy = env.sandbox.spy(impl, 'fireSelectEvent_');
+      const triggerSpy = env.sandbox.spy(impl.action_, 'trigger');
       const mockEl = doc.createElement('div');
       return element.layoutCallback().then(() => {
         impl.toggleResults_(true);
@@ -803,7 +806,7 @@ describes.realWin(
           expect(impl.resetActiveElement_()).to.equal();
           expect(impl.activeElement_).to.be.null;
           impl.toggleResults_(true);
-          resetSpy = sandbox.spy(impl, 'resetActiveElement_');
+          resetSpy = env.sandbox.spy(impl, 'resetActiveElement_');
           return impl.updateActiveItem_(1);
         })
         .then(() => {
@@ -882,7 +885,7 @@ describes.realWin(
         return renderedChild;
       });
       renderedChildren[2].setAttribute('data-disabled', '');
-      sandbox
+      env.sandbox
         .stub(impl.templates_, 'renderTemplateArray')
         .returns(Promise.resolve(renderedChildren));
 
@@ -901,9 +904,9 @@ describes.realWin(
 
       beforeEach(() => {
         impl.element.setAttribute('src', 'invalid-path');
-        fallbackSpy = sandbox.spy(impl, 'displayFallback_');
-        toggleFallbackSpy = sandbox.spy(impl, 'toggleFallback');
-        getDataSpy = sandbox
+        fallbackSpy = env.sandbox.spy(impl, 'displayFallback_');
+        toggleFallbackSpy = env.sandbox.spy(impl, 'toggleFallback');
+        getDataSpy = env.sandbox
           .stub(impl, 'getRemoteData_')
           .returns(Promise.reject('Error for test'));
       });
@@ -917,7 +920,7 @@ describes.realWin(
       });
 
       it('should not display fallback before user interaction', () => {
-        sandbox.stub(impl, 'getFallback').returns(true);
+        env.sandbox.stub(impl, 'getFallback').returns(true);
         return element.layoutCallback().then(() => {
           expect(getDataSpy).not.to.have.been.called;
           expect(fallbackSpy).not.to.have.been.called;
@@ -926,7 +929,7 @@ describes.realWin(
       });
 
       it('should display fallback after user interaction if provided', () => {
-        sandbox.stub(impl, 'getFallback').returns(true);
+        env.sandbox.stub(impl, 'getFallback').returns(true);
         return element.layoutCallback().then(() => {
           impl.checkFirstInteractionAndMaybeFetchData_().then(() => {
             expect(getDataSpy).to.have.been.calledOnce;

--- a/extensions/amp-base-carousel/0.1/test/test-responsive-attributes.js
+++ b/extensions/amp-base-carousel/0.1/test/test-responsive-attributes.js
@@ -20,7 +20,7 @@ describe('ResponsiveAttributes', () => {
   let matchMediaStub;
 
   beforeEach(() => {
-    matchMediaStub = sandbox.stub(window, 'matchMedia');
+    matchMediaStub = window.sandbox.stub(window, 'matchMedia');
     matchMediaStub.returns({matches: false});
     matchMediaStub.withArgs('').returns({matches: true});
   });
@@ -29,7 +29,7 @@ describe('ResponsiveAttributes', () => {
     matchMediaStub.withArgs('(min-width: 600px)').returns({matches: true});
     matchMediaStub.withArgs('(min-width: 300px)').returns({matches: true});
 
-    const spy = sandbox.spy();
+    const spy = window.sandbox.spy();
     const ra = new ResponsiveAttributes({
       'one': spy,
     });
@@ -45,7 +45,7 @@ describe('ResponsiveAttributes', () => {
   it('should pass non-matching media queries', () => {
     matchMediaStub.withArgs('(min-width: 300px)').returns({matches: true});
 
-    const spy = sandbox.spy();
+    const spy = window.sandbox.spy();
     const ra = new ResponsiveAttributes({
       'one': spy,
     });
@@ -59,7 +59,7 @@ describe('ResponsiveAttributes', () => {
   });
 
   it('should fall back to the default value', () => {
-    const spy = sandbox.spy();
+    const spy = window.sandbox.spy();
     const ra = new ResponsiveAttributes({
       'one': spy,
     });
@@ -73,7 +73,7 @@ describe('ResponsiveAttributes', () => {
   });
 
   it('should handle empty groups', () => {
-    const spy = sandbox.spy();
+    const spy = window.sandbox.spy();
     const ra = new ResponsiveAttributes({
       'one': spy,
     });
@@ -86,7 +86,7 @@ describe('ResponsiveAttributes', () => {
   it('should update when the matching value changes', () => {
     matchMediaStub.withArgs('(min-width: 600px)').returns({matches: true});
 
-    const spy = sandbox.spy();
+    const spy = window.sandbox.spy();
     const ra = new ResponsiveAttributes({
       'one': spy,
     });
@@ -111,7 +111,7 @@ describe('ResponsiveAttributes', () => {
       },
     });
 
-    const spy = sandbox.spy();
+    const spy = window.sandbox.spy();
     const ra = new ResponsiveAttributes({
       'one': spy,
     });
@@ -130,7 +130,7 @@ describe('ResponsiveAttributes', () => {
   });
 
   it('should clear onchange when the attribute value changes', async () => {
-    const onchangeSpy = sandbox.spy();
+    const onchangeSpy = window.sandbox.spy();
 
     matchMediaStub.withArgs('(min-width: 600px)').returns({
       matches: false,
@@ -139,7 +139,7 @@ describe('ResponsiveAttributes', () => {
       },
     });
 
-    const spy = sandbox.spy();
+    const spy = window.sandbox.spy();
     const ra = new ResponsiveAttributes({
       'one': spy,
     });
@@ -157,7 +157,7 @@ describe('ResponsiveAttributes', () => {
   it('should handle number values', () => {
     matchMediaStub.withArgs('(min-width: 600px)').returns({matches: true});
 
-    const spy = sandbox.spy();
+    const spy = window.sandbox.spy();
     const ra = new ResponsiveAttributes({
       'one': spy,
     });

--- a/extensions/amp-bind/0.1/test/test-amp-state.js
+++ b/extensions/amp-bind/0.1/test/test-amp-state.js
@@ -30,7 +30,6 @@ describes.realWin(
   },
   env => {
     let win;
-    let sandbox;
     let ampdoc;
 
     let element;
@@ -50,30 +49,32 @@ describes.realWin(
     }
 
     beforeEach(() => {
-      ({win, sandbox, ampdoc} = env);
+      ({win, ampdoc} = env);
 
       whenFirstVisiblePromise = new Promise((resolve, reject) => {
         whenFirstVisiblePromiseResolve = resolve;
         whenFirstVisiblePromiseReject = reject;
       });
-      sandbox.stub(ampdoc, 'whenFirstVisible').returns(whenFirstVisiblePromise);
-      sandbox.stub(ampdoc, 'hasBeenVisible').returns(false);
+      env.sandbox
+        .stub(ampdoc, 'whenFirstVisible')
+        .returns(whenFirstVisiblePromise);
+      env.sandbox.stub(ampdoc, 'hasBeenVisible').returns(false);
 
       element = getAmpState();
       ampState = element.implementation_;
 
-      sandbox
+      env.sandbox
         .stub(xhrUtils, 'getViewerAuthTokenIfAvailable')
         .returns(Promise.resolve());
 
       // TODO(choumx): Remove stubbing of private function fetch_() once
       // batchFetchJsonFor() is easily stub-able.
-      sandbox
+      env.sandbox
         .stub(ampState, 'fetch_')
         .returns(Promise.resolve({remote: 'data'}));
 
-      bind = {setState: sandbox.stub()};
-      sandbox.stub(Services, 'bindForDocOrNull').resolves(bind);
+      bind = {setState: env.sandbox.stub()};
+      env.sandbox.stub(Services, 'bindForDocOrNull').resolves(bind);
     });
 
     it('should not fetch until doc is visible', async () => {
@@ -99,10 +100,10 @@ describes.realWin(
 
       expect(ampState.fetch_).to.have.been.calledOnce;
       expect(ampState.fetch_).to.have.been.calledWithExactly(
-        /* ampdoc */ sinon.match.any,
+        /* ampdoc */ env.sandbox.match.any,
         UrlReplacementPolicy.ALL,
-        /* refresh */ sinon.match.falsy,
-        /* token */ sinon.match.falsy
+        /* refresh */ env.sandbox.match.falsy,
+        /* token */ env.sandbox.match.falsy
       );
 
       expect(bind.setState).calledWithMatch(
@@ -115,8 +116,8 @@ describes.realWin(
     it('should trigger "fetch-error" if fetch fails', async () => {
       ampState.fetch_.returns(Promise.reject());
 
-      const actions = {trigger: sandbox.spy()};
-      sandbox.stub(Services, 'actionServiceForDoc').returns(actions);
+      const actions = {trigger: env.sandbox.spy()};
+      env.sandbox.stub(Services, 'actionServiceForDoc').returns(actions);
 
       element.setAttribute('src', 'https://foo.com/bar?baz=1');
       element.build();
@@ -138,19 +139,19 @@ describes.realWin(
     });
 
     it('should register "refresh" action', async () => {
-      sandbox.spy(ampState, 'registerAction');
+      env.sandbox.spy(ampState, 'registerAction');
 
       element.setAttribute('src', 'https://foo.com/bar?baz=1');
       element.build();
 
       expect(ampState.registerAction).calledWithExactly(
         'refresh',
-        sinon.match.any
+        env.sandbox.match.any
       );
     });
 
     it('should fetch on "refresh"', async () => {
-      sandbox.spy(ampState, 'registerAction');
+      env.sandbox.spy(ampState, 'registerAction');
 
       element.setAttribute('src', 'https://foo.com/bar?baz=1');
       element.build();
@@ -273,9 +274,9 @@ describes.realWin(
 
       expect(ampState.fetch_).to.have.been.calledOnce;
       expect(ampState.fetch_).to.have.been.calledWithExactly(
-        /* ampdoc */ sinon.match.any,
+        /* ampdoc */ env.sandbox.match.any,
         UrlReplacementPolicy.ALL,
-        /* refresh */ sinon.match.falsy,
+        /* refresh */ env.sandbox.match.falsy,
         'idToken'
       );
 

--- a/extensions/amp-bind/0.1/test/test-bind-evaluator.js
+++ b/extensions/amp-bind/0.1/test/test-bind-evaluator.js
@@ -19,15 +19,9 @@ import {BindExpression} from '../bind-expression';
 
 describe('BindEvaluator', () => {
   let evaluator;
-  let sandbox;
 
   beforeEach(() => {
     evaluator = new BindEvaluator();
-    sandbox = sinon.sandbox;
-  });
-
-  afterEach(() => {
-    sandbox.restore();
   });
 
   /** @return {number} */
@@ -97,7 +91,7 @@ describe('BindEvaluator', () => {
         expressionString: '1+1',
       },
     ]);
-    const stub = sandbox.stub(BindExpression.prototype, 'evaluate');
+    const stub = window.sandbox.stub(BindExpression.prototype, 'evaluate');
     stub.returns('stubbed');
     evaluator.evaluateBindings({});
     expect(stub.calledOnce).to.be.true;

--- a/extensions/amp-byside-content/0.1/test/test-amp-byside-content.js
+++ b/extensions/amp-byside-content/0.1/test/test-amp-byside-content.js
@@ -31,7 +31,7 @@ describes.realWin(
     beforeEach(() => {
       win = env.win;
       doc = win.document;
-      urlMock = mockServiceForDoc(sandbox, env.ampdoc, 'url-replace', [
+      urlMock = mockServiceForDoc(env.sandbox, env.ampdoc, 'url-replace', [
         'expandUrlAsync',
       ]);
     });
@@ -55,7 +55,7 @@ describes.realWin(
         .then(() => {
           urlMock.expandUrlAsync
             .returns(Promise.resolve(elem.implementation_.baseUrl_))
-            .withArgs(sinon.match.any);
+            .withArgs(env.sandbox.match.any);
           if (opt_beforeLayoutCallback) {
             opt_beforeLayoutCallback(elem);
           }

--- a/extensions/amp-call-tracking/0.1/test/test-amp-call-tracking.js
+++ b/extensions/amp-call-tracking/0.1/test/test-amp-call-tracking.js
@@ -32,7 +32,7 @@ describes.realWin(
     beforeEach(() => {
       win = env.win;
       doc = win.document;
-      xhrMock = sandbox.mock(Services.xhrFor(win));
+      xhrMock = env.sandbox.mock(Services.xhrFor(win));
     });
 
     afterEach(() => {
@@ -65,7 +65,7 @@ describes.realWin(
         .expects('fetchJson')
         .withArgs(
           url,
-          sandbox.match(init => init.credentials == 'include')
+          env.sandbox.match(init => init.credentials == 'include')
         )
         .returns(
           Promise.resolve({

--- a/extensions/amp-carousel/0.1/test/test-base-slide.js
+++ b/extensions/amp-carousel/0.1/test/test-base-slide.js
@@ -51,19 +51,22 @@ describes.fakeWin('BaseSlides', {amp: true}, env => {
   beforeEach(() => {
     win = env.win;
     doc = win.document;
-    buildSlidesSpy = sandbox.spy();
-    onViewportCallbackSpy = sandbox.spy();
-    hasPrevSpy = sandbox.spy();
-    hasNextSpy = sandbox.spy();
-    goCallbackSpy = sandbox.spy();
-    setupAutoplaySpy = sandbox.spy(BaseSlides.prototype, 'setupAutoplay_');
-    buildButtonsSpy = sandbox.spy(BaseSlides.prototype, 'buildButtons');
-    setupGesturesSpy = sandbox.spy(BaseSlides.prototype, 'setupGestures');
-    setControlsStateSpy = sandbox.spy(BaseSlides.prototype, 'setControlsState');
-    hintControlsSpy = sandbox.spy(BaseSlides.prototype, 'hintControls');
-    autoplaySpy = sandbox.spy(BaseSlides.prototype, 'autoplay_');
-    clearAutoplaySpy = sandbox.spy(BaseSlides.prototype, 'clearAutoplay');
-    onViewportCallbackSpy = sandbox.spy(
+    buildSlidesSpy = env.sandbox.spy();
+    onViewportCallbackSpy = env.sandbox.spy();
+    hasPrevSpy = env.sandbox.spy();
+    hasNextSpy = env.sandbox.spy();
+    goCallbackSpy = env.sandbox.spy();
+    setupAutoplaySpy = env.sandbox.spy(BaseSlides.prototype, 'setupAutoplay_');
+    buildButtonsSpy = env.sandbox.spy(BaseSlides.prototype, 'buildButtons');
+    setupGesturesSpy = env.sandbox.spy(BaseSlides.prototype, 'setupGestures');
+    setControlsStateSpy = env.sandbox.spy(
+      BaseSlides.prototype,
+      'setControlsState'
+    );
+    hintControlsSpy = env.sandbox.spy(BaseSlides.prototype, 'hintControls');
+    autoplaySpy = env.sandbox.spy(BaseSlides.prototype, 'autoplay_');
+    clearAutoplaySpy = env.sandbox.spy(BaseSlides.prototype, 'clearAutoplay');
+    onViewportCallbackSpy = env.sandbox.spy(
       BaseSlides.prototype,
       'onViewportCallback'
     );

--- a/extensions/amp-carousel/0.1/test/test-scrollable-carousel.js
+++ b/extensions/amp-carousel/0.1/test/test-scrollable-carousel.js
@@ -40,10 +40,10 @@ describes.realWin(
       env.iframe.height = '200';
 
       owners = Services.ownersForDoc(doc);
-      updateInViewportSpy = sandbox.spy(owners, 'updateInViewport');
-      schedulePauseSpy = sandbox.spy(owners, 'schedulePause');
-      scheduleLayoutSpy = sandbox.spy(owners, 'scheduleLayout');
-      schedulePreloadSpy = sandbox.spy(owners, 'schedulePreload');
+      updateInViewportSpy = env.sandbox.spy(owners, 'updateInViewport');
+      schedulePauseSpy = env.sandbox.spy(owners, 'schedulePause');
+      scheduleLayoutSpy = env.sandbox.spy(owners, 'scheduleLayout');
+      schedulePreloadSpy = env.sandbox.spy(owners, 'schedulePreload');
     });
 
     function getAmpScrollableCarousel() {

--- a/extensions/amp-carousel/0.1/test/test-slidescroll.js
+++ b/extensions/amp-carousel/0.1/test/test-slidescroll.js
@@ -125,7 +125,7 @@ describes.realWin(
     it('should go to the correct slide on button click', () => {
       return getAmpSlideScroll().then(ampSlideScroll => {
         const impl = ampSlideScroll.implementation_;
-        const showSlideSpy = sandbox.spy(impl, 'showSlide_');
+        const showSlideSpy = env.sandbox.spy(impl, 'showSlide_');
 
         impl.goCallback(1);
         expect(showSlideSpy).to.have.been.calledWith(1);
@@ -145,15 +145,15 @@ describes.realWin(
       return getAmpSlideScroll().then(ampSlideScroll => {
         const impl = ampSlideScroll.implementation_;
         const owners = Services.ownersForDoc(impl.element);
-        const updateInViewportSpy = sandbox.spy(owners, 'updateInViewport');
-        const scheduleLayoutSpy = sandbox.spy(owners, 'scheduleLayout');
-        const schedulePreloadSpy = sandbox.spy(owners, 'schedulePreload');
-        const hideRestOfTheSlidesSpy = sandbox.spy(
+        const updateInViewportSpy = env.sandbox.spy(owners, 'updateInViewport');
+        const scheduleLayoutSpy = env.sandbox.spy(owners, 'scheduleLayout');
+        const schedulePreloadSpy = env.sandbox.spy(owners, 'schedulePreload');
+        const hideRestOfTheSlidesSpy = env.sandbox.spy(
           impl,
           'hideRestOfTheSlides_'
         );
-        const setControlsStateSpy = sandbox.spy(impl, 'setControlsState');
-        const analyticsEventSpy = sandbox.spy(impl, 'analyticsEvent_');
+        const setControlsStateSpy = env.sandbox.spy(impl, 'setControlsState');
+        const analyticsEventSpy = env.sandbox.spy(impl, 'analyticsEvent_');
 
         expect(impl.showSlide_(-1)).to.be.false;
         expect(updateInViewportSpy).to.not.have.been.called;
@@ -329,8 +329,8 @@ describes.realWin(
       return getAmpSlideScroll().then(ampSlideScroll => {
         const impl = ampSlideScroll.implementation_;
         const owners = Services.ownersForDoc(impl.element);
-        const schedulePauseSpy = sandbox.spy(owners, 'schedulePause');
-        const hideRestOfTheSlidesSpy = sandbox.spy(
+        const schedulePauseSpy = env.sandbox.spy(owners, 'schedulePause');
+        const hideRestOfTheSlidesSpy = env.sandbox.spy(
           impl,
           'hideRestOfTheSlides_'
         );
@@ -452,7 +452,7 @@ describes.realWin(
     it('should update to the right slide on scroll', () => {
       return getAmpSlideScroll().then(ampSlideScroll => {
         const impl = ampSlideScroll.implementation_;
-        const showSlideSpy = sandbox.spy(impl, 'showSlide_');
+        const showSlideSpy = env.sandbox.spy(impl, 'showSlide_');
 
         impl.vsync_ = {
           mutatePromise: cb => {
@@ -525,7 +525,10 @@ describes.realWin(
     it('should custom snap to the correct slide', () => {
       return getAmpSlideScroll().then(ampSlideScroll => {
         const impl = ampSlideScroll.implementation_;
-        const animateScrollLeftSpy = sandbox.spy(impl, 'animateScrollLeft_');
+        const animateScrollLeftSpy = env.sandbox.spy(
+          impl,
+          'animateScrollLeft_'
+        );
 
         impl.customSnap_(0);
         expect(animateScrollLeftSpy).to.have.been.calledWith(0, 0);
@@ -590,7 +593,10 @@ describes.realWin(
     it('should custom snap to the correct slide - special case', () => {
       return getAmpSlideScroll(null, 2).then(ampSlideScroll => {
         const impl = ampSlideScroll.implementation_;
-        const animateScrollLeftSpy = sandbox.spy(impl, 'animateScrollLeft_');
+        const animateScrollLeftSpy = env.sandbox.spy(
+          impl,
+          'animateScrollLeft_'
+        );
 
         impl.customSnap_(0, 1);
         expect(animateScrollLeftSpy).to.have.been.calledWith(0, 400);
@@ -605,7 +611,7 @@ describes.realWin(
     it('should handle custom elastic scroll', () => {
       return getAmpSlideScroll().then(ampSlideScroll => {
         const impl = ampSlideScroll.implementation_;
-        const customSnapSpy = sandbox
+        const customSnapSpy = env.sandbox
           .stub(impl, 'customSnap_')
           .callsFake(() => {
             return {
@@ -634,7 +640,7 @@ describes.realWin(
     it('should handle layout measures (orientation changes)', async () => {
       const ampSlideScroll = await getAmpSlideScroll();
       const impl = ampSlideScroll.implementation_;
-      const getLayoutWidthStub = sandbox.stub(impl, 'getLayoutWidth');
+      const getLayoutWidthStub = env.sandbox.stub(impl, 'getLayoutWidth');
 
       getLayoutWidthStub.returns(200);
       impl.onLayoutMeasure();
@@ -661,7 +667,7 @@ describes.realWin(
       return getAmpSlideScroll().then(ampSlideScroll => {
         const impl = ampSlideScroll.implementation_;
         const owners = Services.ownersForDoc(impl.element);
-        const scheduleLayoutSpy_ = sandbox.spy(owners, 'scheduleLayout');
+        const scheduleLayoutSpy_ = env.sandbox.spy(owners, 'scheduleLayout');
         impl.slideIndex_ = null;
         impl.layoutCallback();
         expect(scheduleLayoutSpy_).to.have.been.calledWith(
@@ -679,14 +685,6 @@ describes.realWin(
     });
 
     describe('Looping', () => {
-      beforeEach(() => {
-        sandbox = sinon.sandbox;
-      });
-
-      afterEach(() => {
-        sandbox.restore();
-      });
-
       it('should create container and wrappers and show initial slides', () => {
         return getAmpSlideScroll(true).then(ampSlideScroll => {
           const impl = ampSlideScroll.implementation_;
@@ -704,14 +702,17 @@ describes.realWin(
         return getAmpSlideScroll(true).then(ampSlideScroll => {
           const impl = ampSlideScroll.implementation_;
           const owners = Services.ownersForDoc(impl.element);
-          const updateInViewportSpy = sandbox.spy(owners, 'updateInViewport');
-          const scheduleLayoutSpy = sandbox.spy(owners, 'scheduleLayout');
-          const schedulePreloadSpy = sandbox.spy(owners, 'schedulePreload');
-          const hideRestOfTheSlidesSpy = sandbox.spy(
+          const updateInViewportSpy = env.sandbox.spy(
+            owners,
+            'updateInViewport'
+          );
+          const scheduleLayoutSpy = env.sandbox.spy(owners, 'scheduleLayout');
+          const schedulePreloadSpy = env.sandbox.spy(owners, 'schedulePreload');
+          const hideRestOfTheSlidesSpy = env.sandbox.spy(
             impl,
             'hideRestOfTheSlides_'
           );
-          const setControlsStateSpy = sandbox.spy(impl, 'setControlsState');
+          const setControlsStateSpy = env.sandbox.spy(impl, 'setControlsState');
 
           expect(impl.slides_[4].getAttribute('aria-hidden')).to.equal('true');
           expect(impl.slides_[0].getAttribute('aria-hidden')).to.equal('false');
@@ -853,14 +854,17 @@ describes.realWin(
         return getAmpSlideScroll(true, 2).then(ampSlideScroll => {
           const impl = ampSlideScroll.implementation_;
           const owners = Services.ownersForDoc(impl.element);
-          const updateInViewportSpy = sandbox.spy(owners, 'updateInViewport');
-          const scheduleLayoutSpy = sandbox.spy(owners, 'scheduleLayout');
-          const schedulePreloadSpy = sandbox.spy(owners, 'schedulePreload');
-          const hideRestOfTheSlidesSpy = sandbox.spy(
+          const updateInViewportSpy = env.sandbox.spy(
+            owners,
+            'updateInViewport'
+          );
+          const scheduleLayoutSpy = env.sandbox.spy(owners, 'scheduleLayout');
+          const schedulePreloadSpy = env.sandbox.spy(owners, 'schedulePreload');
+          const hideRestOfTheSlidesSpy = env.sandbox.spy(
             impl,
             'hideRestOfTheSlides_'
           );
-          const setControlsStateSpy = sandbox.spy(impl, 'setControlsState');
+          const setControlsStateSpy = env.sandbox.spy(impl, 'setControlsState');
 
           expect(impl.slides_[0].getAttribute('aria-hidden')).to.equal('false');
           expect(impl.slides_[1].getAttribute('aria-hidden')).to.equal('true');
@@ -942,7 +946,7 @@ describes.realWin(
         return getAmpSlideScroll(false, 3, true, true, 0).then(
           ampSlideScroll => {
             const impl = ampSlideScroll.implementation_;
-            const setupAutoplaySpy = sandbox.spy(impl, 'setupAutoplay_');
+            const setupAutoplaySpy = env.sandbox.spy(impl, 'setupAutoplay_');
             expect(setupAutoplaySpy).to.not.have.been.called;
           }
         );
@@ -952,7 +956,7 @@ describes.realWin(
         return getAmpSlideScroll(false, 3, true, true, 2).then(
           ampSlideScroll => {
             const impl = ampSlideScroll.implementation_;
-            const removeAutoplaySpy = sandbox.spy(impl, 'removeAutoplay');
+            const removeAutoplaySpy = env.sandbox.spy(impl, 'removeAutoplay');
             impl.showSlide_(1);
             impl.showSlide_(2);
             expect(impl.loopsMade_).to.equal(1);
@@ -971,8 +975,8 @@ describes.realWin(
         return getAmpSlideScroll(true).then(ampSlideScroll => {
           const impl = ampSlideScroll.implementation_;
           const owners = Services.ownersForDoc(impl.element);
-          const schedulePauseSpy = sandbox.spy(owners, 'schedulePause');
-          const hideRestOfTheSlidesSpy = sandbox.spy(
+          const schedulePauseSpy = env.sandbox.spy(owners, 'schedulePause');
+          const hideRestOfTheSlidesSpy = env.sandbox.spy(
             impl,
             'hideRestOfTheSlides_'
           );
@@ -1122,7 +1126,7 @@ describes.realWin(
       it('should update to the right slide on scroll', () => {
         return getAmpSlideScroll(true).then(ampSlideScroll => {
           const impl = ampSlideScroll.implementation_;
-          const showSlideSpy = sandbox.spy(impl, 'showSlide_');
+          const showSlideSpy = env.sandbox.spy(impl, 'showSlide_');
 
           impl.vsync_ = {
             mutate: cb => {
@@ -1198,7 +1202,10 @@ describes.realWin(
       it('should custom snap to the correct slide', () => {
         return getAmpSlideScroll(true).then(ampSlideScroll => {
           const impl = ampSlideScroll.implementation_;
-          const animateScrollLeftSpy = sandbox.spy(impl, 'animateScrollLeft_');
+          const animateScrollLeftSpy = env.sandbox.spy(
+            impl,
+            'animateScrollLeft_'
+          );
 
           impl.customSnap_(0);
           expect(animateScrollLeftSpy).to.have.been.calledWith(0, 0);
@@ -1225,7 +1232,7 @@ describes.realWin(
       it('should go to the correct slide on button click', () => {
         return getAmpSlideScroll(true).then(ampSlideScroll => {
           const impl = ampSlideScroll.implementation_;
-          const showSlideSpy = sandbox.spy(impl, 'showSlide_');
+          const showSlideSpy = env.sandbox.spy(impl, 'showSlide_');
 
           impl.goCallback(-1);
           expect(showSlideSpy).to.have.been.calledWith(4);
@@ -1247,7 +1254,7 @@ describes.realWin(
           expectAsyncConsoleError(/Invalid \[slide\] value:/, 1);
 
           const impl = ampSlideScroll.implementation_;
-          const showSlideSpy = sandbox.spy(impl, 'showSlide_');
+          const showSlideSpy = env.sandbox.spy(impl, 'showSlide_');
 
           impl.mutatedAttributesCallback({slide: 2});
           expect(showSlideSpy).to.have.been.calledWith(2);
@@ -1265,20 +1272,20 @@ describes.realWin(
       it('should trigger `slideChange` action when user changes slides', () => {
         return getAmpSlideScroll(true).then(ampSlideScroll => {
           const impl = ampSlideScroll.implementation_;
-          const triggerSpy = sandbox.spy(impl.action_, 'trigger');
+          const triggerSpy = env.sandbox.spy(impl.action_, 'trigger');
 
           impl.goCallback(-1, /* animate */ false);
           expect(triggerSpy).to.have.been.calledWith(
             ampSlideScroll,
             'slideChange',
-            /* CustomEvent */ sinon.match.has('detail', {index: 4})
+            /* CustomEvent */ env.sandbox.match.has('detail', {index: 4})
           );
 
           impl.goCallback(1, /* animate */ false);
           expect(triggerSpy).to.have.been.calledWith(
             ampSlideScroll,
             'slideChange',
-            /* CustomEvent */ sinon.match.has('detail', {index: 0})
+            /* CustomEvent */ env.sandbox.match.has('detail', {index: 0})
           );
         });
       });
@@ -1288,7 +1295,7 @@ describes.realWin(
           expectAsyncConsoleError(/Invalid \[slide\] value:/, 4);
 
           const impl = ampSlideScroll.implementation_;
-          const showSlideSpy = sandbox.spy(impl, 'showSlide_');
+          const showSlideSpy = env.sandbox.spy(impl, 'showSlide_');
           const satisfiesTrust = () => true;
 
           let args = {'index': '123'};
@@ -1325,7 +1332,7 @@ describes.realWin(
           doc.body.appendChild(ampSlideScroll);
           return ampSlideScroll.build().then(() => {
             const impl = ampSlideScroll.implementation_;
-            const showSlideSpy = sandbox.spy(impl, 'showSlide_');
+            const showSlideSpy = env.sandbox.spy(impl, 'showSlide_');
             const satisfiesTrust = () => true;
 
             const args = {'index': '3'};
@@ -1350,7 +1357,7 @@ describes.realWin(
           doc.body.appendChild(ampSlideScroll);
           return ampSlideScroll.build().then(() => {
             const impl = ampSlideScroll.implementation_;
-            const showSlideSpy = sandbox.spy(impl, 'showSlide_');
+            const showSlideSpy = env.sandbox.spy(impl, 'showSlide_');
             const satisfiesTrust = () => true;
 
             // Test that showSlide_ due to goToSlide(index=1) is not called before

--- a/extensions/amp-carousel/0.2/test/test-type-slides.js
+++ b/extensions/amp-carousel/0.2/test/test-type-slides.js
@@ -203,7 +203,7 @@ describes.realWin(
 
     describe('slideChange event', () => {
       it('should not dispatch on initial render', async () => {
-        const eventSpy = sandbox.spy();
+        const eventSpy = env.sandbox.spy();
         container.addEventListener('slideChange', eventSpy);
         await getCarousel({loop: false});
 
@@ -211,7 +211,7 @@ describes.realWin(
       });
 
       it('should dispatch when changing slides', async () => {
-        const eventSpy = sandbox.spy();
+        const eventSpy = env.sandbox.spy();
         container.addEventListener('slideChange', eventSpy);
         const carousel = await getCarousel({loop: false});
 
@@ -226,7 +226,7 @@ describes.realWin(
       it('should propagate high trust', async () => {
         const carousel = await getCarousel({loop: false});
         const impl = carousel.implementation_;
-        const triggerSpy = sandbox.spy(impl.action_, 'trigger');
+        const triggerSpy = env.sandbox.spy(impl.action_, 'trigger');
 
         impl.executeAction({
           method: 'goToSlide',
@@ -239,7 +239,7 @@ describes.realWin(
         expect(triggerSpy).to.have.been.calledWith(
           carousel,
           'slideChange',
-          /* CustomEvent */ sinon.match.has('detail', {index: 1}),
+          /* CustomEvent */ env.sandbox.match.has('detail', {index: 1}),
           ActionTrust.HIGH
         );
       });
@@ -247,7 +247,7 @@ describes.realWin(
       it('should propagate low trust', async () => {
         const carousel = await getCarousel({loop: false});
         const impl = carousel.implementation_;
-        const triggerSpy = sandbox.spy(impl.action_, 'trigger');
+        const triggerSpy = env.sandbox.spy(impl.action_, 'trigger');
 
         impl.executeAction({
           method: 'goToSlide',
@@ -260,7 +260,7 @@ describes.realWin(
         expect(triggerSpy).to.have.been.calledWith(
           carousel,
           'slideChange',
-          /* CustomEvent */ sinon.match.has('detail', {index: 1}),
+          /* CustomEvent */ env.sandbox.match.has('detail', {index: 1}),
           ActionTrust.LOW
         );
       });

--- a/extensions/amp-consent/0.1/test/test-amp-consent.js
+++ b/extensions/amp-consent/0.1/test/test-amp-consent.js
@@ -145,7 +145,7 @@ describes.realWin(
         });
 
         it('relative checkConsentHref is resolved', function*() {
-          const fetchSpy = sandbox.spy(xhrServiceMock, 'fetchJson');
+          const fetchSpy = env.sandbox.spy(xhrServiceMock, 'fetchJson');
           consentElement = createConsentElement(
             doc,
             dict({
@@ -158,7 +158,7 @@ describes.realWin(
           );
           const ampConsent = new AmpConsent(consentElement);
           doc.body.appendChild(consentElement);
-          const getUrlStub = sandbox.stub(ampdoc, 'getUrl');
+          const getUrlStub = env.sandbox.stub(ampdoc, 'getUrl');
           // return a cache Url to test origin source being used to resolve.
           getUrlStub.callsFake(() => {
             return 'https://cdn.ampproject.org/v/www.origin.com/foo/?f=0#h';
@@ -285,7 +285,7 @@ describes.realWin(
         consentElement = createConsentElement(doc, defaultConfig);
         doc.body.appendChild(consentElement);
         ampConsent = new AmpConsent(consentElement);
-        actionSpy = sandbox.stub(ampConsent, 'handleAction_');
+        actionSpy = env.sandbox.stub(ampConsent, 'handleAction_');
         ampConsent.enableInteractions_();
         ampIframe = document.createElement('amp-iframe');
         iframe = doc.createElement('iframe');
@@ -385,10 +385,10 @@ describes.realWin(
         consentElement.appendChild(postPromptUI);
         doc.body.appendChild(consentElement);
         ampConsent = new AmpConsent(consentElement);
-        sandbox.stub(ampConsent.vsync_, 'mutate').callsFake(fn => {
+        env.sandbox.stub(ampConsent.vsync_, 'mutate').callsFake(fn => {
           fn();
         });
-        sandbox.stub(ampConsent, 'mutateElement').callsFake(fn => {
+        env.sandbox.stub(ampConsent, 'mutateElement').callsFake(fn => {
           fn();
         });
       });
@@ -396,7 +396,7 @@ describes.realWin(
       it('update current displaying status', function*() {
         ampConsent.buildCallback();
         yield macroTask();
-        updateConsentInstanceStateSpy = sandbox.spy(
+        updateConsentInstanceStateSpy = env.sandbox.spy(
           ampConsent.consentStateManager_,
           'updateConsentInstanceState'
         );
@@ -414,7 +414,7 @@ describes.realWin(
       it('ignore action when no consent prompt is displaying', function*() {
         ampConsent.buildCallback();
         yield macroTask();
-        updateConsentInstanceStateSpy = sandbox.spy(
+        updateConsentInstanceStateSpy = env.sandbox.spy(
           ampConsent.consentStateManager_,
           'updateConsentInstanceState'
         );

--- a/extensions/amp-consent/0.1/test/test-consent-policy-manager.js
+++ b/extensions/amp-consent/0.1/test/test-consent-policy-manager.js
@@ -46,7 +46,7 @@ describes.realWin(
     beforeEach(() => {
       win = env.win;
       ampdoc = env.ampdoc;
-      consentManagerOnChangeSpy = sandbox.spy();
+      consentManagerOnChangeSpy = env.sandbox.spy();
 
       resetServiceForTesting(win, 'consentStateManager');
       registerServiceBuilder(win, 'consentStateManager', function() {
@@ -547,7 +547,7 @@ describes.realWin(
 
       beforeEach(() => {
         manager = new ConsentPolicyManager(ampdoc);
-        sandbox
+        env.sandbox
           .stub(ConsentPolicyInstance.prototype, 'getReadyPromise')
           .callsFake(() => {
             return Promise.resolve();

--- a/extensions/amp-consent/0.1/test/test-consent-state-manager.js
+++ b/extensions/amp-consent/0.1/test/test-consent-state-manager.js
@@ -37,9 +37,9 @@ describes.realWin('ConsentStateManager', {amp: 1}, env => {
     win = env.win;
     ampdoc = env.ampdoc;
     storageValue = {};
-    storageGetSpy = sandbox.spy();
-    storageSetSpy = sandbox.spy();
-    storageRemoveSpy = sandbox.spy();
+    storageGetSpy = env.sandbox.spy();
+    storageSetSpy = env.sandbox.spy();
+    storageRemoveSpy = env.sandbox.spy();
 
     resetServiceForTesting(win, 'storage');
     registerServiceBuilder(win, 'storage', function() {
@@ -169,7 +169,7 @@ describes.realWin('ConsentStateManager', {amp: 1}, env => {
 
       beforeEach(() => {
         manager.registerConsentInstance('test', {});
-        spy = sandbox.spy();
+        spy = env.sandbox.spy();
       });
 
       it('should call handler when consent state changes', () => {
@@ -385,7 +385,7 @@ describes.realWin('ConsentStateManager', {amp: 1}, env => {
       let requestBody;
       let requestSpy;
       beforeEach(() => {
-        requestSpy = sandbox.spy();
+        requestSpy = env.sandbox.spy();
         resetServiceForTesting(win, 'xhr');
         registerServiceBuilder(win, 'xhr', function() {
           return {
@@ -603,7 +603,7 @@ describes.realWin('ConsentStateManager', {amp: 1}, env => {
           const e = new Error('intentional');
           throw e;
         };
-        sandbox.stub(dev(), 'error');
+        env.sandbox.stub(dev(), 'error');
         storageValue['amp-consent:test'] = true;
         return instance.get().then(value => {
           expect(value).to.deep.equal(

--- a/extensions/amp-consent/0.1/test/test-consent-ui.js
+++ b/extensions/amp-consent/0.1/test/test-consent-ui.js
@@ -35,7 +35,6 @@ describes.realWin(
     },
   },
   env => {
-    let sandbox;
     let win;
     let doc;
     let ampdoc;
@@ -44,7 +43,6 @@ describes.realWin(
     let parent;
 
     beforeEach(() => {
-      sandbox = env.sandbox;
       doc = env.win.document;
       ampdoc = env.ampdoc;
       win = env.win;
@@ -80,7 +78,7 @@ describes.realWin(
           return Promise.resolve();
         },
       };
-      Services.ownersForDoc(doc).scheduleLayout = sandbox.mock();
+      Services.ownersForDoc(doc).scheduleLayout = env.sandbox.mock();
       resetServiceForTesting(win, 'consentStateManager');
       registerServiceBuilder(win, 'consentStateManager', function() {
         return Promise.resolve({
@@ -95,14 +93,14 @@ describes.realWin(
       toggleExperiment(win, 'amp-consent-v2', true);
     });
 
-    afterEach(() => sandbox.restore());
+    afterEach(() => env.sandbox.restore());
 
     const getReadyIframeCmpConsentUi = () => {
       const config = dict({
         'promptUISrc': 'https//promptUISrc',
       });
       const consentUI = new ConsentUI(mockInstance, config);
-      const showIframeSpy = sandbox.spy(consentUI, 'showIframe_');
+      const showIframeSpy = env.sandbox.spy(consentUI, 'showIframe_');
       consentUI.show(false);
       consentUI.iframeReady_.resolve();
       return whenCalled(showIframeSpy).then(() => Promise.resolve(consentUI));
@@ -223,8 +221,8 @@ describes.realWin(
           expect(parent.classList.contains('amp-active')).to.be.false;
           expect(parent.classList.contains('amp-hidden')).to.be.false;
 
-          const showIframeSpy = sandbox.spy(consentUI, 'showIframe_');
-          const applyInitialStylesSpy = sandbox.spy(
+          const showIframeSpy = env.sandbox.spy(consentUI, 'showIframe_');
+          const applyInitialStylesSpy = env.sandbox.spy(
             consentUI,
             'applyInitialStyles_'
           );
@@ -356,7 +354,7 @@ describes.realWin(
     describe('ready', () => {
       it('should respond to the ready event', () => {
         return getReadyIframeCmpConsentUi().then(consentUI => {
-          const handleReadyStub = sandbox.stub(consentUI, 'handleReady_');
+          const handleReadyStub = env.sandbox.stub(consentUI, 'handleReady_');
 
           consentUI.ui_ = {
             contentWindow: 'mock-src',
@@ -439,7 +437,7 @@ describes.realWin(
     describe('fullscreen', () => {
       it('should respond to the fullscreen event', () => {
         return getReadyIframeCmpConsentUi().then(consentUI => {
-          const enterFullscreenStub = sandbox.stub(
+          const enterFullscreenStub = env.sandbox.stub(
             consentUI,
             'enterFullscreen_'
           );
@@ -464,7 +462,7 @@ describes.realWin(
           "if the iframe wasn't visible",
         () => {
           return getReadyIframeCmpConsentUi().then(consentUI => {
-            const enterFullscreenStub = sandbox.stub(
+            const enterFullscreenStub = env.sandbox.stub(
               consentUI,
               'enterFullscreen_'
             );
@@ -516,7 +514,7 @@ describes.realWin(
 
           expect(consentUI.scrollEnabled_).to.be.false;
 
-          sandbox
+          env.sandbox
             .stub(consentUI, 'baseInstance_')
             .callsFake(callback => callback());
           consentUI.hide();
@@ -529,7 +527,7 @@ describes.realWin(
           'and show the viewer on hide',
         () => {
           return getReadyIframeCmpConsentUi().then(consentUI => {
-            const sendMessageStub = sandbox.stub(
+            const sendMessageStub = env.sandbox.stub(
               consentUI.viewer_,
               'sendMessage'
             );
@@ -538,7 +536,7 @@ describes.realWin(
 
             expect(sendMessageStub).to.be.calledOnce;
 
-            sandbox
+            env.sandbox
               .stub(consentUI, 'baseInstance_')
               .callsFake(callback => callback());
             consentUI.hide();

--- a/extensions/amp-date-picker/0.1/test/test-amp-date-picker-bind.js
+++ b/extensions/amp-date-picker/0.1/test/test-amp-date-picker-bind.js
@@ -111,8 +111,8 @@ describes.realWin(
         const {picker, layoutCallback} = createDatePicker({
           src: 'https://localhost:8000/examples/date-picker.json',
         });
-        sandbox.stub(picker, 'fetchSrc_').resolves();
-        const setStateSpy = sandbox.spy(picker, 'setState_');
+        env.sandbox.stub(picker, 'fetchSrc_').resolves();
+        const setStateSpy = env.sandbox.spy(picker, 'setState_');
         await layoutCallback();
 
         await picker.mutatedAttributesCallback({

--- a/extensions/amp-date-picker/0.1/test/test-amp-date-picker.js
+++ b/extensions/amp-date-picker/0.1/test/test-amp-date-picker.js
@@ -178,7 +178,7 @@ describes.realWin(
           'layout': 'fixed-height',
           'height': '360',
         });
-        sandbox.stub(picker, 'fetchSrc_').resolves({'date': '2018-01-01'});
+        env.sandbox.stub(picker, 'fetchSrc_').resolves({'date': '2018-01-01'});
 
         return layoutCallback().then(() => {
           expect(picker.state_.date.isSame('2018-01-01')).to.be.true;
@@ -191,7 +191,7 @@ describes.realWin(
           'height': '360',
           'type': 'range',
         });
-        sandbox.stub(picker, 'fetchSrc_').resolves({
+        env.sandbox.stub(picker, 'fetchSrc_').resolves({
           'startDate': '2018-01-01',
           'endDate': '2018-01-02',
         });
@@ -435,7 +435,7 @@ describes.realWin(
             src: 'http://localhost:9876/date-picker/src-data/get',
           });
 
-          sandbox.stub(picker, 'fetchSrc_').resolves({
+          env.sandbox.stub(picker, 'fetchSrc_').resolves({
             blocked: ['2018-01-03'],
             highlighted: ['2018-01-04'],
           });
@@ -476,7 +476,7 @@ describes.realWin(
       describe('iterateDataRange', () => {
         it('should not iterate for an end date before start date ', () => {
           const {picker} = createDatePicker();
-          const spy = sandbox.spy();
+          const spy = env.sandbox.spy();
 
           picker.iterateDateRange_(
             moment('2018-01-03'),
@@ -489,7 +489,7 @@ describes.realWin(
 
         it('should handle both dates being the same', () => {
           const {picker} = createDatePicker();
-          const spy = sandbox.spy();
+          const spy = env.sandbox.spy();
 
           picker.iterateDateRange_(
             moment('2018-01-01'),
@@ -504,7 +504,7 @@ describes.realWin(
 
         it('should handle a null end date as both dates being the same', () => {
           const {picker} = createDatePicker();
-          const spy = sandbox.spy();
+          const spy = env.sandbox.spy();
 
           picker.iterateDateRange_(moment('2018-01-01'), null, spy);
 
@@ -515,7 +515,7 @@ describes.realWin(
 
         it('should handle both dates being different', () => {
           const {picker} = createDatePicker();
-          const spy = sandbox.spy();
+          const spy = env.sandbox.spy();
 
           picker.iterateDateRange_(
             moment('2018-01-01'),
@@ -553,7 +553,7 @@ describes.realWin(
             const input = document.createElement('input');
             input.id = 'date';
             element.appendChild(input);
-            sandbox.stub(picker.input_, 'isTouchDetected').returns(true);
+            env.sandbox.stub(picker.input_, 'isTouchDetected').returns(true);
 
             return picker
               .buildCallback()
@@ -579,7 +579,7 @@ describes.realWin(
           const input = document.createElement('input');
           input.id = 'date';
           element.appendChild(input);
-          sandbox.stub(picker.input_, 'isTouchDetected').returns(false);
+          env.sandbox.stub(picker.input_, 'isTouchDetected').returns(false);
 
           return picker
             .buildCallback()

--- a/extensions/amp-dynamic-css-classes/0.1/test/test-runtime-classes.js
+++ b/extensions/amp-dynamic-css-classes/0.1/test/test-runtime-classes.js
@@ -53,7 +53,7 @@ describes.fakeWin(
         win.navigator.userAgent = userAgent;
       }
       if (referrer !== undefined) {
-        sandbox
+        env.sandbox
           .stub(viewer, 'getUnconfirmedReferrerUrl')
           .callsFake(() => referrer);
       }

--- a/extensions/amp-experiment/0.1/test/test-amp-experiment.js
+++ b/extensions/amp-experiment/0.1/test/test-amp-experiment.js
@@ -135,7 +135,7 @@ describes.realWin(
 
     it('should add attributes to body element for the allocated variants', () => {
       addConfigElement('script');
-      const stub = sandbox.stub(variant, 'allocateVariant');
+      const stub = env.sandbox.stub(variant, 'allocateVariant');
       stub
         .withArgs(ampdoc, 'experiment-1', config['experiment-1'])
         .returns(Promise.resolve('variant-a'));

--- a/extensions/amp-experiment/0.1/test/test-variant.js
+++ b/extensions/amp-experiment/0.1/test/test-variant.js
@@ -28,8 +28,6 @@ describes.sandboxed('allocateVariant', {}, env => {
   let getNotificationStub;
 
   beforeEach(() => {
-    const {sandbox} = env;
-
     fakeWin = {
       Math: {
         random: () => {
@@ -46,8 +44,8 @@ describes.sandboxed('allocateVariant', {}, env => {
 
     fakeHead = {};
 
-    getCidStub = sandbox.stub();
-    sandbox
+    getCidStub = env.sandbox.stub();
+    env.sandbox
       .stub(Services, 'cidForDoc')
       .withArgs(ampdoc)
       .returns(
@@ -56,16 +54,16 @@ describes.sandboxed('allocateVariant', {}, env => {
         })
       );
 
-    uniformStub = sandbox.stub();
-    sandbox
+    uniformStub = env.sandbox.stub();
+    env.sandbox
       .stub(Services, 'cryptoFor')
       .withArgs(fakeWin)
       .returns({
         uniform: uniformStub,
       });
 
-    getNotificationStub = sandbox.stub();
-    sandbox
+    getNotificationStub = env.sandbox.stub();
+    env.sandbox
       .stub(Services, 'userNotificationManagerForDoc')
       .withArgs(fakeHead)
       .returns(
@@ -74,13 +72,13 @@ describes.sandboxed('allocateVariant', {}, env => {
         })
       );
 
-    sandbox
+    env.sandbox
       .stub(Services, 'viewerForDoc')
       .withArgs(ampdoc)
       .returns({});
 
-    sandbox.stub(ampdoc, 'getHeadNode').returns(fakeHead);
-    getParamStub = sandbox.stub(ampdoc, 'getParam').returns(null);
+    env.sandbox.stub(ampdoc, 'getHeadNode').returns(fakeHead);
+    getParamStub = env.sandbox.stub(ampdoc, 'getParam').returns(null);
   });
 
   it('should throw for invalid config', () => {

--- a/extensions/amp-experiment/1.0/test/test-amp-experiment.js
+++ b/extensions/amp-experiment/1.0/test/test-amp-experiment.js
@@ -91,7 +91,7 @@ describes.realWin(
 
     function stubAllocateVariant(sandbox, config) {
       const viewer = Services.viewerForDoc(ampdoc);
-      const stub = sandbox.stub(variant, 'allocateVariant');
+      const stub = env.sandbox.stub(variant, 'allocateVariant');
       stub
         .withArgs(ampdoc, viewer, 'experiment-1', config['experiment-1'])
         .returns(Promise.resolve('variant-a'));
@@ -174,8 +174,8 @@ describes.realWin(
     it('should match the variant to the experiment', () => {
       addConfigElement('script');
 
-      stubAllocateVariant(sandbox, config);
-      const applyStub = sandbox
+      stubAllocateVariant(env.sandbox, config);
+      const applyStub = env.sandbox
         .stub(applyExperiment, 'applyExperimentToVariant')
         .returns(Promise.resolve());
 
@@ -198,12 +198,12 @@ describes.realWin(
       () => {
         addConfigElement('script');
 
-        stubAllocateVariant(sandbox, config);
-        const applyStub = sandbox
+        stubAllocateVariant(env.sandbox, config);
+        const applyStub = env.sandbox
           .stub(applyExperiment, 'applyExperimentToVariant')
           .returns(Promise.resolve());
 
-        sandbox.stub(ampdoc, 'getParam').returns('true');
+        env.sandbox.stub(ampdoc, 'getParam').returns('true');
 
         experiment.buildCallback();
         return Services.variantsForDocOrNull(ampdoc.getHeadNode())

--- a/extensions/amp-experiment/1.0/test/test-attribute-mutation.js
+++ b/extensions/amp-experiment/1.0/test/test-attribute-mutation.js
@@ -313,7 +313,7 @@ describes.realWin(
         const element1 = document.createElement('amp-img');
         const element2 = document.createElement('a');
         elements = [element1, element2];
-        const mutatedAttributesCallbackSpy = sandbox.spy();
+        const mutatedAttributesCallbackSpy = env.sandbox.spy();
         element1.mutatedAttributesCallback = () => {
           mutatedAttributesCallbackSpy();
         };

--- a/extensions/amp-experiment/1.0/test/test-variant.js
+++ b/extensions/amp-experiment/1.0/test/test-variant.js
@@ -29,8 +29,6 @@ describes.sandboxed('allocateVariant', {}, env => {
   let getNotificationStub;
 
   beforeEach(() => {
-    const {sandbox} = env;
-
     fakeWin = {
       Math: {
         random: () => {
@@ -47,8 +45,8 @@ describes.sandboxed('allocateVariant', {}, env => {
 
     fakeHead = {};
 
-    getCidStub = sandbox.stub();
-    sandbox
+    getCidStub = env.sandbox.stub();
+    env.sandbox
       .stub(Services, 'cidForDoc')
       .withArgs(ampdoc)
       .returns(
@@ -57,16 +55,16 @@ describes.sandboxed('allocateVariant', {}, env => {
         })
       );
 
-    uniformStub = sandbox.stub();
-    sandbox
+    uniformStub = env.sandbox.stub();
+    env.sandbox
       .stub(Services, 'cryptoFor')
       .withArgs(fakeWin)
       .returns({
         uniform: uniformStub,
       });
 
-    getNotificationStub = sandbox.stub();
-    sandbox
+    getNotificationStub = env.sandbox.stub();
+    env.sandbox
       .stub(Services, 'userNotificationManagerForDoc')
       .withArgs(fakeHead)
       .returns(
@@ -77,8 +75,8 @@ describes.sandboxed('allocateVariant', {}, env => {
 
     fakeViewer = {};
 
-    sandbox.stub(ampdoc, 'getHeadNode').returns(fakeHead);
-    getParamStub = sandbox.stub(ampdoc, 'getParam').returns('true');
+    env.sandbox.stub(ampdoc, 'getHeadNode').returns(fakeHead);
+    getParamStub = env.sandbox.stub(ampdoc, 'getParam').returns('true');
   });
 
   it('should throw for invalid config', () => {

--- a/extensions/amp-font/0.1/test/test-amp-font.js
+++ b/extensions/amp-font/0.1/test/test-amp-font.js
@@ -64,7 +64,7 @@ describes.repeated(
         }
 
         it('should timeout while loading custom font', function() {
-          sandbox
+          env.sandbox
             .stub(FontLoader.prototype, 'load')
             .returns(Promise.reject('mock rejection'));
           return getAmpFont().then(() => {
@@ -74,7 +74,9 @@ describes.repeated(
         });
 
         it('should load custom font', function() {
-          sandbox.stub(FontLoader.prototype, 'load').returns(Promise.resolve());
+          env.sandbox
+            .stub(FontLoader.prototype, 'load')
+            .returns(Promise.resolve());
           return getAmpFont().then(() => {
             expect(root).to.have.class('comic-amp-font-loaded');
             expect(root).to.not.have.class('comic-amp-font-loading');

--- a/extensions/amp-font/0.1/test/test-fontloader.js
+++ b/extensions/amp-font/0.1/test/test-fontloader.js
@@ -91,15 +91,15 @@ describes.repeated(
               : ampdoc.getBody();
           body = variant.ampdoc === 'single' ? doc.body : root;
 
-          setupLoadWithPolyfillSpy = sandbox.spy(
+          setupLoadWithPolyfillSpy = env.sandbox.spy(
             FontLoader.prototype,
             'loadWithPolyfill_'
           );
-          setupCreateFontComparatorsSpy = sandbox.spy(
+          setupCreateFontComparatorsSpy = env.sandbox.spy(
             FontLoader.prototype,
             'createFontComparators_'
           );
-          setupDisposeSpy = sandbox.spy(FontLoader.prototype, 'dispose_');
+          setupDisposeSpy = env.sandbox.spy(FontLoader.prototype, 'dispose_');
 
           const style = doc.createElement('style');
           style.textContent = FONT_FACE_ + CSS_RULES_;
@@ -108,8 +108,8 @@ describes.repeated(
           textEl.textContent =
             'Neque porro quisquam est qui dolorem ipsum quia dolor';
           body.appendChild(textEl);
-          setupFontCheckSpy = sandbox./*OK*/ spy(doc.fonts, 'check');
-          setupFontLoadSpy = sandbox./*OK*/ spy(doc.fonts, 'load');
+          setupFontCheckSpy = env.sandbox./*OK*/ spy(doc.fonts, 'check');
+          setupFontLoadSpy = env.sandbox./*OK*/ spy(doc.fonts, 'load');
           fontloader = new FontLoader(env.ampdoc);
         });
 
@@ -129,7 +129,7 @@ describes.repeated(
         });
 
         it('should check and load font via polyfill', () => {
-          sandbox
+          env.sandbox
             .stub(FontLoader.prototype, 'canUseNativeApis_')
             .returns(false);
           fontloader
@@ -162,7 +162,7 @@ describes.repeated(
         });
 
         it('should error when font is not available via polyfill', () => {
-          sandbox
+          env.sandbox
             .stub(FontLoader.prototype, 'canUseNativeApis_')
             .returns(false);
           fontloader
@@ -182,12 +182,12 @@ describes.repeated(
         });
 
         it('should check if elements are being created when using polyfill', () => {
-          sandbox
+          env.sandbox
             .stub(FontLoader.prototype, 'canUseNativeApis_')
             .returns(false);
           setupDisposeSpy /*OK*/
             .restore();
-          setupDisposeSpy = sandbox
+          setupDisposeSpy = env.sandbox
             .stub(FontLoader.prototype, 'dispose_')
             .returns(undefined);
           const initialElementsCount = doc.getElementsByTagName('*').length;
@@ -212,7 +212,7 @@ describes.repeated(
           'should check if elements created using the polyfill ' +
             'are disposed',
           () => {
-            sandbox
+            env.sandbox
               .stub(FontLoader.prototype, 'canUseNativeApis_')
               .returns(false);
             const initialElementsCount = doc.getElementsByTagName('*').length;

--- a/extensions/amp-form/0.1/test/integration/test-integration-form.js
+++ b/extensions/amp-form/0.1/test/integration/test-integration-form.js
@@ -39,7 +39,6 @@ describes.realWin(
     const {testServerPort} = window.ampTestRuntimeConfig;
     const baseUrl = `http://localhost:${testServerPort}`;
     let doc;
-    let sandbox;
 
     const realSetTimeout = window.setTimeout;
     const stubSetTimeout = (callback, delay) => {
@@ -51,10 +50,9 @@ describes.realWin(
     };
 
     beforeEach(() => {
-      sandbox = env.sandbox;
       doc = env.win.document;
 
-      sandbox.stub(Services, 'formSubmitForDoc').returns(
+      env.sandbox.stub(Services, 'formSubmitForDoc').returns(
         Promise.resolve(() => {
           fire: () => {};
         })
@@ -148,9 +146,9 @@ describes.realWin(
           on: 'submit:sameform.submit',
         });
         const ampForm = new AmpForm(form, 'sameform');
-        sandbox.spy(ampForm, 'handleXhrSubmit_');
-        sandbox.spy(ampForm, 'handleSubmitAction_');
-        sandbox.spy(ampForm.xhr_, 'fetch');
+        env.sandbox.spy(ampForm, 'handleXhrSubmit_');
+        env.sandbox.spy(ampForm, 'handleSubmitAction_');
+        env.sandbox.spy(ampForm.xhr_, 'fetch');
         const fetch = poll('submit request sent', () =>
           ampForm.xhrSubmitPromiseForTesting()
         );
@@ -209,7 +207,7 @@ describes.realWin(
         // Stubbing timeout to catch async-thrown errors and expect
         // them. These catch errors thrown inside the catch-clause of the
         // xhr request using rethrowAsync.
-        sandbox.stub(window, 'setTimeout').callsFake(stubSetTimeout);
+        env.sandbox.stub(window, 'setTimeout').callsFake(stubSetTimeout);
 
         const form = getForm({
           id: 'form1',
@@ -222,7 +220,7 @@ describes.realWin(
           },
         });
         const ampForm = new AmpForm(form, 'form1');
-        const fetchSpy = sandbox.spy(ampForm.xhr_, 'fetch');
+        const fetchSpy = env.sandbox.spy(ampForm.xhr_, 'fetch');
         const fetch = poll(
           'submit request sent',
           () => fetchSpy.returnValues[0]
@@ -288,7 +286,7 @@ describes.realWin(
         // Stubbing timeout to catch async-thrown errors and expect
         // them. These catch errors thrown inside the catch-clause of the
         // xhr request using rethrowAsync.
-        sandbox.stub(window, 'setTimeout').callsFake(stubSetTimeout);
+        env.sandbox.stub(window, 'setTimeout').callsFake(stubSetTimeout);
 
         const form = getForm({
           id: 'form1',
@@ -301,7 +299,7 @@ describes.realWin(
           },
         });
         const ampForm = new AmpForm(form, 'form1');
-        const fetchSpy = sandbox.spy(ampForm.xhr_, 'fetch');
+        const fetchSpy = env.sandbox.spy(ampForm.xhr_, 'fetch');
         const fetch = poll(
           'submit request sent',
           () => fetchSpy.returnValues[0]
@@ -333,7 +331,7 @@ describes.realWin(
         // Stubbing timeout to catch async-thrown errors and expect
         // them. These catch errors thrown inside the catch-clause of the
         // xhr request using rethrowAsync.
-        sandbox.stub(window, 'setTimeout').callsFake(stubSetTimeout);
+        env.sandbox.stub(window, 'setTimeout').callsFake(stubSetTimeout);
 
         const form = getForm({
           id: 'form1',
@@ -348,7 +346,7 @@ describes.realWin(
           },
         });
         const ampForm = new AmpForm(form, 'form1');
-        const fetchSpy = sandbox.spy(ampForm.xhr_, 'fetch');
+        const fetchSpy = env.sandbox.spy(ampForm.xhr_, 'fetch');
         const fetch = poll(
           'submit request sent',
           () => fetchSpy.returnValues[0]

--- a/extensions/amp-form/0.1/test/test-amp-form-textarea.js
+++ b/extensions/amp-form/0.1/test/test-amp-form-textarea.js
@@ -34,11 +34,9 @@ describes.realWin(
   },
   env => {
     let doc;
-    let sandbox;
     beforeEach(() => {
       doc = env.ampdoc.getRootNode();
       installStylesForDoc(env.ampdoc, CSS, () => {}, false, 'amp-form');
-      sandbox = env.sandbox;
     });
 
     describe('handleInitialOverflowElements', () => {
@@ -95,7 +93,7 @@ describes.realWin(
             return mutator() || Promise.resolve();
           },
         };
-        sandbox.stub(Services, 'resourcesForDoc').returns(fakeResources);
+        env.sandbox.stub(Services, 'resourcesForDoc').returns(fakeResources);
 
         const initialHeight = textarea.clientHeight;
         return maybeResizeTextarea(textarea).then(() => {
@@ -117,7 +115,7 @@ describes.realWin(
             return mutator() || Promise.resolve();
           },
         };
-        sandbox.stub(Services, 'resourcesForDoc').returns(fakeResources);
+        env.sandbox.stub(Services, 'resourcesForDoc').returns(fakeResources);
 
         const initialHeight = textarea.clientHeight;
         return maybeResizeTextarea(textarea).then(() => {
@@ -139,7 +137,7 @@ describes.realWin(
             return mutator() || Promise.resolve();
           },
         };
-        sandbox.stub(Services, 'resourcesForDoc').returns(fakeResources);
+        env.sandbox.stub(Services, 'resourcesForDoc').returns(fakeResources);
 
         const initialHeight = textarea.clientHeight;
         let increasedHeight;
@@ -178,8 +176,8 @@ describes.realWin(
             return mutator() || Promise.resolve();
           },
         };
-        sandbox.stub(Services, 'resourcesForDoc').returns(fakeResources);
-        sandbox
+        env.sandbox.stub(Services, 'resourcesForDoc').returns(fakeResources);
+        env.sandbox
           .stub(eventHelper, 'listenOncePromise')
           .returns(Promise.resolve());
 
@@ -190,7 +188,9 @@ describes.realWin(
           mouseDownEvent = doc.createEventObject();
           mouseDownEvent.type = 'mousedown';
         }
-        sandbox.defineProperty(mouseDownEvent, 'target', {value: textarea});
+        env.sandbox.defineProperty(mouseDownEvent, 'target', {
+          value: textarea,
+        });
         // Given 2 mousedown events on the textarea.
         doc.dispatchEvent(mouseDownEvent);
         doc.dispatchEvent(mouseDownEvent);

--- a/extensions/amp-form/0.1/test/test-amp-form.js
+++ b/extensions/amp-form/0.1/test/test-amp-form.js
@@ -60,7 +60,6 @@ describes.repeated(
         },
       },
       env => {
-        let sandbox;
         let document;
         let timer;
         let createElement;
@@ -68,7 +67,6 @@ describes.repeated(
         let mutateElementStub;
 
         beforeEach(() => {
-          sandbox = env.sandbox;
           document = env.ampdoc.getRootNode();
           timer = Services.timerFor(env.win);
           const ownerDoc = document.ownerDocument || document;
@@ -77,25 +75,27 @@ describes.repeated(
 
           // Force sync mutateElement to make testing easier.
           const resources = Services.resourcesForDoc(env.ampdoc);
-          mutateElementStub = sandbox
+          mutateElementStub = env.sandbox
             .stub(resources, 'mutateElement')
             .callsArg(1);
 
           // This needs to be stubbed to stop the function from,
           // hanging and timing out on tests that make proper XHR requests
-          sandbox.stub(xhrUtils, 'getViewerInterceptResponse').resolves(null);
+          env.sandbox
+            .stub(xhrUtils, 'getViewerInterceptResponse')
+            .resolves(null);
         });
 
-        afterEach(() => sandbox.restore());
+        afterEach(() => env.sandbox.restore());
 
         function getAmpForm(form, canonical = 'https://example.com/amps.html') {
           new AmpFormService(env.ampdoc);
           Services.documentInfoForDoc(env.ampdoc).canonicalUrl = canonical;
           const cidService = cidServiceForDocForTesting(env.ampdoc);
-          sandbox.stub(cidService, 'get').resolves('amp-cid');
+          env.sandbox.stub(cidService, 'get').resolves('amp-cid');
           env.ampdoc.getBody().appendChild(form);
           const ampForm = new AmpForm(form, 'amp-form-test-id');
-          sandbox
+          env.sandbox
             .stub(ampForm.ssrTemplateHelper_, 'isSupported')
             .returns(false);
           return Promise.resolve(ampForm);
@@ -162,7 +162,7 @@ describes.repeated(
 
             // Create stubs that can be used for observing the async input
             const asyncInputValue = 'async-input-value';
-            const getValueStub = sandbox.stub().resolves(asyncInputValue);
+            const getValueStub = env.sandbox.stub().resolves(asyncInputValue);
             asyncInput.getImpl = () =>
               Promise.resolve({
                 getValue: getValueStub,
@@ -190,7 +190,7 @@ describes.repeated(
               // Create stubs that can be used for observing the async input
               const asyncInputValueRequiredAction =
                 'async-input-value-required-action';
-              const getValueStubRequiredAction = sandbox
+              const getValueStubRequiredAction = env.sandbox
                 .stub()
                 .resolves(asyncInputValueRequiredAction);
               asyncInputRequiredAction.getImpl = () =>
@@ -229,9 +229,9 @@ describes.repeated(
               const form = ampForm.form_;
               form.id = 'registration';
               event = {
-                stopImmediatePropagation: sandbox.spy(),
+                stopImmediatePropagation: env.sandbox.spy(),
                 target: form,
-                preventDefault: sandbox.spy(),
+                preventDefault: env.sandbox.spy(),
               };
               const emailInput = createElement('input');
               emailInput.setAttribute('name', 'email');
@@ -240,11 +240,11 @@ describes.repeated(
               form.appendChild(emailInput);
 
               ampForm.method_ = 'GET';
-              sandbox.stub(form, 'submit');
-              sandbox.stub(form, 'checkValidity').returns(true);
-              sandbox.stub(ampForm, 'analyticsEvent_');
+              env.sandbox.stub(form, 'submit');
+              env.sandbox.stub(form, 'checkValidity').returns(true);
+              env.sandbox.stub(ampForm, 'analyticsEvent_');
               ampForm.ssrTemplateHelper_.isSupported.restore();
-              sandbox
+              env.sandbox
                 .stub(ampForm.ssrTemplateHelper_, 'isSupported')
                 .returns(true);
 
@@ -268,9 +268,9 @@ describes.repeated(
           });
 
           it('should server side render submit-success template if enabled', () => {
-            sandbox.spy(xhrUtils, 'setupInput');
-            sandbox.spy(xhrUtils, 'setupAMPCors');
-            sandbox.stub(xhrUtils, 'fromStructuredCloneable');
+            env.sandbox.spy(xhrUtils, 'setupInput');
+            env.sandbox.spy(xhrUtils, 'setupAMPCors');
+            env.sandbox.stub(xhrUtils, 'fromStructuredCloneable');
 
             return getSsrAmpFormPromise.then(ampForm => {
               const form = ampForm.form_;
@@ -279,9 +279,9 @@ describes.repeated(
               template.content.appendChild(createTextNode('Some {{template}}'));
               form.id = 'registration';
               const event = {
-                stopImmediatePropagation: sandbox.spy(),
+                stopImmediatePropagation: env.sandbox.spy(),
                 target: form,
-                preventDefault: sandbox.spy(),
+                preventDefault: env.sandbox.spy(),
               };
               const successTemplateContainer = createElement('div');
               successTemplateContainer.setAttribute('submit-success', '');
@@ -291,18 +291,18 @@ describes.repeated(
 
               form.xhrAction_ = 'https://www.xhr-action.org';
 
-              sandbox
+              env.sandbox
                 .stub(ampForm.viewer_, 'sendMessageAwaitResponse')
                 .resolves({
                   data: {html: '<div>much success</div>'},
                 });
               const renderedTemplate = createElement('div');
               renderedTemplate.innerText = 'much success';
-              sandbox
+              env.sandbox
                 .stub(ampForm.ssrTemplateHelper_.templates_, 'findTemplate')
                 .returns(template);
 
-              const ssr = sandbox.stub(ampForm.ssrTemplateHelper_, 'ssr');
+              const ssr = env.sandbox.stub(ampForm.ssrTemplateHelper_, 'ssr');
               ssr
                 .onFirstCall()
                 .resolves({
@@ -325,8 +325,8 @@ describes.repeated(
                     ampForm.ssrTemplateHelper_.ssr
                   ).to.have.been.calledWith(
                     form,
-                    sinon.match.object,
-                    sinon.match.object
+                    env.sandbox.match.object,
+                    env.sandbox.match.object
                   );
                   return handleSubmitEventPromise;
                 })
@@ -342,9 +342,9 @@ describes.repeated(
           });
 
           it('should server side render submit-error template if enabled', () => {
-            sandbox.spy(xhrUtils, 'setupInput');
-            sandbox.spy(xhrUtils, 'setupAMPCors');
-            sandbox.stub(xhrUtils, 'fromStructuredCloneable');
+            env.sandbox.spy(xhrUtils, 'setupInput');
+            env.sandbox.spy(xhrUtils, 'setupAMPCors');
+            env.sandbox.stub(xhrUtils, 'fromStructuredCloneable');
 
             return getSsrAmpFormPromise.then(ampForm => {
               const form = ampForm.form_;
@@ -353,9 +353,9 @@ describes.repeated(
               template.content.appendChild(createTextNode('Some {{template}}'));
               form.id = 'registration';
               const event = {
-                stopImmediatePropagation: sandbox.spy(),
+                stopImmediatePropagation: env.sandbox.spy(),
                 target: form,
-                preventDefault: sandbox.spy(),
+                preventDefault: env.sandbox.spy(),
               };
               const errorTemplateContainer = createElement('div');
               errorTemplateContainer.setAttribute('submit-error', '');
@@ -365,7 +365,7 @@ describes.repeated(
 
               form.xhrAction_ = 'https://www.xhr-action.org';
 
-              sandbox
+              env.sandbox
                 .stub(ampForm.viewer_, 'sendMessageAwaitResponse')
                 .resolves({
                   data: {
@@ -374,11 +374,11 @@ describes.repeated(
                 });
               const renderedTemplate = createElement('div');
               renderedTemplate.innerText = 'much error';
-              sandbox
+              env.sandbox
                 .stub(ampForm.ssrTemplateHelper_.templates_, 'findTemplate')
                 .returns(template);
 
-              const ssr = sandbox.stub(ampForm.ssrTemplateHelper_, 'ssr');
+              const ssr = env.sandbox.stub(ampForm.ssrTemplateHelper_, 'ssr');
               ssr
                 .onFirstCall()
                 .resolves({
@@ -401,8 +401,8 @@ describes.repeated(
                     ampForm.ssrTemplateHelper_.ssr
                   ).to.have.been.calledWith(
                     form,
-                    sinon.match.object,
-                    sinon.match.object
+                    env.sandbox.match.object,
+                    env.sandbox.match.object
                   );
                   return handleSubmitEventPromise;
                 })
@@ -418,9 +418,9 @@ describes.repeated(
           });
 
           it('should set html bypassing mustache rendering', () => {
-            sandbox.spy(xhrUtils, 'setupInput');
-            sandbox.spy(xhrUtils, 'setupAMPCors');
-            sandbox.stub(xhrUtils, 'fromStructuredCloneable');
+            env.sandbox.spy(xhrUtils, 'setupInput');
+            env.sandbox.spy(xhrUtils, 'setupAMPCors');
+            env.sandbox.stub(xhrUtils, 'fromStructuredCloneable');
 
             return getSsrAmpFormPromise.then(ampForm => {
               const form = ampForm.form_;
@@ -429,9 +429,9 @@ describes.repeated(
               template.content.appendChild(createTextNode('Some {{template}}'));
               form.id = 'registration';
               const event = {
-                stopImmediatePropagation: sandbox.spy(),
+                stopImmediatePropagation: env.sandbox.spy(),
                 target: form,
-                preventDefault: sandbox.spy(),
+                preventDefault: env.sandbox.spy(),
               };
               const successTemplateContainer = createElement('div');
               successTemplateContainer.setAttribute('submit-success', '');
@@ -441,18 +441,18 @@ describes.repeated(
 
               form.xhrAction_ = 'https://www.xhr-action.org';
 
-              sandbox
+              env.sandbox
                 .stub(ampForm.viewer_, 'sendMessageAwaitResponse')
                 .resolves({
                   data: '<div>much success</div>',
                 });
               const renderedTemplate = createElement('div');
               renderedTemplate.innerText = 'much success';
-              sandbox
+              env.sandbox
                 .stub(ampForm.ssrTemplateHelper_.templates_, 'findTemplate')
                 .returns(template);
 
-              const ssr = sandbox.stub(
+              const ssr = env.sandbox.stub(
                 ampForm.ssrTemplateHelper_,
                 'applySsrOrCsrTemplate'
               );
@@ -466,7 +466,10 @@ describes.repeated(
                   html: template,
                 });
 
-              const renderTemplate = sandbox.spy(ampForm, 'renderTemplate_');
+              const renderTemplate = env.sandbox.spy(
+                ampForm,
+                'renderTemplate_'
+              );
 
               const handleSubmitEventPromise = ampForm.handleSubmitEvent_(
                 event
@@ -498,20 +501,20 @@ describes.repeated(
             messageContainer.setAttribute('template', 'successTemplate');
             form.appendChild(messageContainer);
             // Given an unsupported JSON array response.
-            sandbox.stub(ampForm.xhr_, 'fetch').resolves({
+            env.sandbox.stub(ampForm.xhr_, 'fetch').resolves({
               json: () => {
                 return Promise.resolve([]);
               },
             });
             const renderedTemplate = createElement('div');
             renderedTemplate.innerText = 'Hello,';
-            sandbox
+            env.sandbox
               .stub(ampForm.templates_, 'findAndRenderTemplate')
               .resolves(renderedTemplate);
             const event = {
-              stopImmediatePropagation: sandbox.spy(),
+              stopImmediatePropagation: env.sandbox.spy(),
               target: form,
-              preventDefault: sandbox.spy(),
+              preventDefault: env.sandbox.spy(),
             };
 
             const submitEventPromise = ampForm.handleSubmitEvent_(event);
@@ -539,27 +542,27 @@ describes.repeated(
         });
 
         it('should fire the form submit service', () => {
-          const fireStub = sandbox.stub();
-          sandbox.stub(Services, 'formSubmitForDoc').resolves({
+          const fireStub = env.sandbox.stub();
+          env.sandbox.stub(Services, 'formSubmitForDoc').resolves({
             fire: fireStub,
           });
 
           const form = getForm();
           return getAmpForm(form).then(ampForm => {
-            sandbox.stub(ampForm.xhr_, 'fetch').resolves();
-            sandbox.stub(ampForm, 'handleXhrSubmitSuccess_');
+            env.sandbox.stub(ampForm.xhr_, 'fetch').resolves();
+            env.sandbox.stub(ampForm, 'handleXhrSubmitSuccess_');
 
             const event = {
-              stopImmediatePropagation: sandbox.spy(),
+              stopImmediatePropagation: env.sandbox.spy(),
               target: ampForm.form_,
-              preventDefault: sandbox.spy(),
+              preventDefault: env.sandbox.spy(),
             };
 
             return ampForm.handleSubmitEvent_(event).then(() => {
               expect(fireStub.calledOnce).to.be.true;
               return expect(fireStub).calledWith({
                 form,
-                actionXhrMutator: sinon.match.func,
+                actionXhrMutator: env.sandbox.match.func,
               });
             });
           });
@@ -607,7 +610,7 @@ describes.repeated(
         it('should listen to submit, blur and input events', () => {
           const form = getForm();
           document.body.appendChild(form);
-          form.addEventListener = sandbox.spy();
+          form.addEventListener = env.sandbox.spy();
           form.setAttribute('action-xhr', 'https://example.com');
           new AmpForm(form);
           expect(form.addEventListener).to.be.called;
@@ -621,14 +624,14 @@ describes.repeated(
         it('should autofocus elements with the autofocus attribute', () => {
           const form = getForm();
           document.body.appendChild(form);
-          sandbox.stub(form, 'addEventListener');
+          env.sandbox.stub(form, 'addEventListener');
           form.setAttribute('action-xhr', 'https://example.com');
           const button1 = form.querySelector('input');
           button1.setAttribute('autofocus', '');
           new AmpForm(form);
 
           let resolve_ = null;
-          sandbox.stub(env.ampdoc, 'whenNextVisible').returns(
+          env.sandbox.stub(env.ampdoc, 'whenNextVisible').returns(
             new Promise(resolve => {
               resolve_ = resolve;
             })
@@ -659,13 +662,13 @@ describes.repeated(
           const ampForm = new AmpForm(form);
           ampForm.state_ = 'submitting';
           const event = {
-            stopImmediatePropagation: sandbox.spy(),
+            stopImmediatePropagation: env.sandbox.spy(),
             target: form,
-            preventDefault: sandbox.spy(),
+            preventDefault: env.sandbox.spy(),
           };
 
-          sandbox.stub(ampForm.xhr_, 'fetch').resolves();
-          sandbox.spy(form, 'checkValidity');
+          env.sandbox.stub(ampForm.xhr_, 'fetch').resolves();
+          env.sandbox.spy(form, 'checkValidity');
           const submitEventPromise = ampForm.handleSubmitEvent_(event);
           expect(event.stopImmediatePropagation).to.be.called;
 
@@ -682,13 +685,13 @@ describes.repeated(
           document.body.appendChild(form);
           const ampForm = new AmpForm(form);
           const event = {
-            stopImmediatePropagation: sandbox.spy(),
+            stopImmediatePropagation: env.sandbox.spy(),
             target: form,
-            preventDefault: sandbox.spy(),
+            preventDefault: env.sandbox.spy(),
           };
-          sandbox.stub(ampForm.xhr_, 'fetch').resolves();
-          sandbox.stub(ampForm, 'analyticsEvent_');
-          sandbox.spy(form, 'checkValidity');
+          env.sandbox.stub(ampForm.xhr_, 'fetch').resolves();
+          env.sandbox.stub(ampForm, 'analyticsEvent_');
+          env.sandbox.spy(form, 'checkValidity');
           const errorRe = /Only XHR based \(via action-xhr attribute\) submissions are supported/;
           expectAsyncConsoleError(errorRe);
           return ampForm.handleSubmitEvent_(event).catch(() => {
@@ -709,17 +712,17 @@ describes.repeated(
           emailInput.setAttribute('required', '');
           form.appendChild(emailInput);
           const ampForm = new AmpForm(form);
-          sandbox.stub(ampForm.xhr_, 'fetch').resolves();
+          env.sandbox.stub(ampForm.xhr_, 'fetch').resolves();
           const event = {
-            stopImmediatePropagation: sandbox.spy(),
+            stopImmediatePropagation: env.sandbox.spy(),
             target: form,
-            preventDefault: sandbox.spy(),
+            preventDefault: env.sandbox.spy(),
           };
 
-          sandbox.spy(form, 'checkValidity');
-          sandbox.spy(emailInput, 'reportValidity');
+          env.sandbox.spy(form, 'checkValidity');
+          env.sandbox.spy(emailInput, 'reportValidity');
 
-          sandbox.stub(ampForm, 'handleXhrSubmitSuccess_').resolves();
+          env.sandbox.stub(ampForm, 'handleXhrSubmitSuccess_').resolves();
           return ampForm.handleSubmitEvent_(event).then(() => {
             expect(form.hasAttribute('amp-novalidate')).to.be.true;
             document.body.removeChild(form);
@@ -739,12 +742,12 @@ describes.repeated(
           document.body.appendChild(form);
           const ampForm = new AmpForm(form);
           const event = {
-            stopImmediatePropagation: sandbox.spy(),
+            stopImmediatePropagation: env.sandbox.spy(),
             target: form,
-            preventDefault: sandbox.spy(),
+            preventDefault: env.sandbox.spy(),
           };
-          sandbox.stub(ampForm.xhr_, 'fetch').resolves();
-          sandbox.spy(form, 'checkValidity');
+          env.sandbox.stub(ampForm.xhr_, 'fetch').resolves();
+          env.sandbox.spy(form, 'checkValidity');
           const submitErrorRe = /Only XHR based \(via action-xhr attribute\) submissions are supported/;
           expectAsyncConsoleError(submitErrorRe);
           return ampForm.handleSubmitEvent_(event).catch(() => {
@@ -762,20 +765,20 @@ describes.repeated(
             emailInput.setAttribute('type', 'email');
             emailInput.setAttribute('required', '');
             form.appendChild(emailInput);
-            sandbox.spy(form, 'checkValidity');
-            sandbox.stub(ampForm.xhr_, 'fetch').resolves();
+            env.sandbox.spy(form, 'checkValidity');
+            env.sandbox.stub(ampForm.xhr_, 'fetch').resolves();
             const event = {
-              stopImmediatePropagation: sandbox.spy(),
+              stopImmediatePropagation: env.sandbox.spy(),
               target: ampForm.form_,
-              preventDefault: sandbox.spy(),
+              preventDefault: env.sandbox.spy(),
             };
 
             const bubbleEl = env.ampdoc
               .getRootNode()
               .querySelector('.i-amphtml-validation-bubble');
             const validationBubble = bubbleEl['__BUBBLE_OBJ'];
-            sandbox.spy(validationBubble, 'show');
-            sandbox.spy(validationBubble, 'hide');
+            env.sandbox.spy(validationBubble, 'show');
+            env.sandbox.spy(validationBubble, 'hide');
             ampForm.handleSubmitEvent_(event);
             expect(event.stopImmediatePropagation).to.be.called;
             expect(form.checkValidity).to.be.called;
@@ -811,7 +814,7 @@ describes.repeated(
             // Check xhr goes through when form is valid.
             emailInput.value = 'cool@bea.ns';
 
-            sandbox.stub(ampForm, 'handleXhrSubmitSuccess_').resolves();
+            env.sandbox.stub(ampForm, 'handleXhrSubmitSuccess_').resolves();
             const submitEventPromise = ampForm.handleSubmitEvent_(event);
 
             return whenCalled(ampForm.xhr_.fetch).then(() => {
@@ -831,15 +834,15 @@ describes.repeated(
             emailInput.setAttribute('type', 'email');
             emailInput.setAttribute('required', '');
             form.appendChild(emailInput);
-            sandbox.spy(form, 'checkValidity');
-            sandbox.stub(ampForm.xhr_, 'fetch').resolves();
+            env.sandbox.spy(form, 'checkValidity');
+            env.sandbox.stub(ampForm.xhr_, 'fetch').resolves();
             const event = {
-              stopImmediatePropagation: sandbox.spy(),
+              stopImmediatePropagation: env.sandbox.spy(),
               target: ampForm.form_,
-              preventDefault: sandbox.spy(),
+              preventDefault: env.sandbox.spy(),
             };
 
-            sandbox.stub(ampForm, 'handleXhrSubmitSuccess_').resolves();
+            env.sandbox.stub(ampForm, 'handleXhrSubmitSuccess_').resolves();
             const submitEventPromise = ampForm.handleSubmitEvent_(event);
 
             return whenCalled(ampForm.xhr_.fetch).then(() => {
@@ -871,7 +874,7 @@ describes.repeated(
           };
 
           return formPromise.then(ampForm => {
-            sandbox.stub(ampForm.xhr_, 'fetch').rejects(fetchReject);
+            env.sandbox.stub(ampForm.xhr_, 'fetch').rejects(fetchReject);
 
             const form = ampForm.form_;
             const input = form.name;
@@ -890,7 +893,7 @@ describes.repeated(
           const formPromise = getAmpForm(getVerificationForm());
 
           return formPromise.then(ampForm => {
-            const xhrStub = sandbox.stub(ampForm.xhr_, 'fetch');
+            const xhrStub = env.sandbox.stub(ampForm.xhr_, 'fetch');
             xhrStub.onCall(0).rejects({
               response: {
                 status: 400,
@@ -956,7 +959,7 @@ describes.repeated(
           };
 
           return formPromise.then(ampForm => {
-            const fetchStub = sandbox
+            const fetchStub = env.sandbox
               .stub(ampForm.xhr_, 'fetch')
               .rejects(fetchReject);
 
@@ -996,7 +999,7 @@ describes.repeated(
             errorContainer.appendChild(errorTemplate);
             let renderedTemplate = createElement('div');
             renderedTemplate.innerText = 'Error: hello there';
-            sandbox.stub(ampForm.xhr_, 'fetch').rejects({
+            env.sandbox.stub(ampForm.xhr_, 'fetch').rejects({
               response: {
                 status: 400,
                 json() {
@@ -1004,13 +1007,13 @@ describes.repeated(
                 },
               },
             });
-            sandbox
+            env.sandbox
               .stub(ampForm.templates_, 'findAndRenderTemplate')
               .resolves(renderedTemplate);
             const event = {
-              stopImmediatePropagation: sandbox.spy(),
+              stopImmediatePropagation: env.sandbox.spy(),
               target: form,
-              preventDefault: sandbox.spy(),
+              preventDefault: env.sandbox.spy(),
             };
             return ampForm.handleSubmitEvent_(event).then(() => {
               const findTemplateStub = ampForm.templates_.findAndRenderTemplate;
@@ -1050,20 +1053,20 @@ describes.repeated(
             messageContainer.setAttribute('submit-success', '');
             messageContainer.setAttribute('template', 'successTemplate');
             form.appendChild(messageContainer);
-            sandbox.stub(ampForm.xhr_, 'fetch').resolves({
+            env.sandbox.stub(ampForm.xhr_, 'fetch').resolves({
               json: () => {
                 return Promise.resolve({'name': 'John Smith'});
               },
             });
             const renderedTemplate = createElement('div');
             renderedTemplate.innerText = 'Hello, John Smith';
-            sandbox
+            env.sandbox
               .stub(ampForm.templates_, 'findAndRenderTemplate')
               .resolves(renderedTemplate);
             const event = {
-              stopImmediatePropagation: sandbox.spy(),
+              stopImmediatePropagation: env.sandbox.spy(),
               target: form,
-              preventDefault: sandbox.spy(),
+              preventDefault: env.sandbox.spy(),
             };
 
             const submitEventPromise = ampForm.handleSubmitEvent_(event);
@@ -1109,20 +1112,20 @@ describes.repeated(
             const newRender = createElement('div');
             newRender.innerText = 'New Success: What What';
 
-            sandbox.stub(ampForm.xhr_, 'fetch').resolves({
+            env.sandbox.stub(ampForm.xhr_, 'fetch').resolves({
               json: () => {
                 return Promise.resolve({'message': 'What What'});
               },
             });
-            const findAndRenderTemplateStub = sandbox.stub(
+            const findAndRenderTemplateStub = env.sandbox.stub(
               ampForm.templates_,
               'findAndRenderTemplate'
             );
             findAndRenderTemplateStub.resolves(newRender);
             const event = {
-              stopImmediatePropagation: sandbox.spy(),
+              stopImmediatePropagation: env.sandbox.spy(),
               target: form,
-              preventDefault: sandbox.spy(),
+              preventDefault: env.sandbox.spy(),
             };
             ampForm.handleSubmitEvent_(event);
             return whenCalled(findAndRenderTemplateStub)
@@ -1160,29 +1163,29 @@ describes.repeated(
             successContainer.appendChild(successTemplate);
             const renderedTemplate = createElement('div');
 
-            const spyDispatchEvent = sandbox.spy(
+            const spyDispatchEvent = env.sandbox.spy(
               successContainer,
               'dispatchEvent'
             );
-            const spyAppendTemplate = sandbox.spy(
+            const spyAppendTemplate = env.sandbox.spy(
               successContainer,
               'appendChild'
             );
-            sandbox.stub(ampForm.xhr_, 'fetch').resolves({
+            env.sandbox.stub(ampForm.xhr_, 'fetch').resolves({
               json() {
                 return Promise.resolve({'message': 'What What'});
               },
             });
-            const findAndRenderTemplateStub = sandbox.stub(
+            const findAndRenderTemplateStub = env.sandbox.stub(
               ampForm.templates_,
               'findAndRenderTemplate'
             );
             findAndRenderTemplateStub.resolves(renderedTemplate);
 
             const event = {
-              stopImmediatePropagation: sandbox.spy(),
+              stopImmediatePropagation: env.sandbox.spy(),
               target: form,
-              preventDefault: sandbox.spy(),
+              preventDefault: env.sandbox.spy(),
             };
 
             return ampForm.handleSubmitEvent_(event).then(() => {
@@ -1197,7 +1200,10 @@ describes.repeated(
                     type: AmpEvents.DOM_UPDATE,
                     bubbles: true,
                   });
-                  sinon.assert.callOrder(spyAppendTemplate, spyDispatchEvent);
+                  env.sandbox.assert.callOrder(
+                    spyAppendTemplate,
+                    spyDispatchEvent
+                  );
                 });
             });
           });
@@ -1205,15 +1211,15 @@ describes.repeated(
 
         it('should call fetch with the xhr action and form data', () => {
           return getAmpForm(getForm()).then(ampForm => {
-            sandbox.stub(ampForm.xhr_, 'fetch').resolves();
+            env.sandbox.stub(ampForm.xhr_, 'fetch').resolves();
 
             const event = {
-              stopImmediatePropagation: sandbox.spy(),
+              stopImmediatePropagation: env.sandbox.spy(),
               target: ampForm.form_,
-              preventDefault: sandbox.spy(),
+              preventDefault: env.sandbox.spy(),
             };
 
-            sandbox.stub(ampForm, 'handleXhrSubmitSuccess_').resolves();
+            env.sandbox.stub(ampForm, 'handleXhrSubmitSuccess_').resolves();
             const submitEventPromise = ampForm.handleSubmitEvent_(event);
             expect(event.preventDefault).to.be.calledOnce;
 
@@ -1242,15 +1248,15 @@ describes.repeated(
 
         it('should trigger amp-form-submit analytics event with form data', () => {
           return getAmpForm(getForm()).then(ampForm => {
-            sandbox.stub(ampForm.xhr_, 'fetch').resolves({
+            env.sandbox.stub(ampForm.xhr_, 'fetch').resolves({
               json: () => Promise.resolve({}),
             });
-            sandbox.stub(ampForm, 'analyticsEvent_');
+            env.sandbox.stub(ampForm, 'analyticsEvent_');
 
             const event = {
-              stopImmediatePropagation: sandbox.spy(),
+              stopImmediatePropagation: env.sandbox.spy(),
               target: ampForm.form_,
-              preventDefault: sandbox.spy(),
+              preventDefault: env.sandbox.spy(),
             };
             const expectedFormData = {
               'formId': '',
@@ -1298,13 +1304,13 @@ describes.repeated(
             canonicalUrlField.setAttribute('data-amp-replace', 'CANONICAL_URL');
             form.appendChild(canonicalUrlField);
 
-            sandbox.stub(form, 'checkValidity').returns(true);
-            sandbox.stub(ampForm.xhr_, 'fetch').resolves({
+            env.sandbox.stub(form, 'checkValidity').returns(true);
+            env.sandbox.stub(ampForm.xhr_, 'fetch').resolves({
               json: () => Promise.resolve({}),
             });
-            sandbox.spy(ampForm.urlReplacement_, 'expandInputValueAsync');
-            sandbox.stub(ampForm.urlReplacement_, 'expandInputValueSync');
-            sandbox.stub(ampForm, 'analyticsEvent_');
+            env.sandbox.spy(ampForm.urlReplacement_, 'expandInputValueAsync');
+            env.sandbox.stub(ampForm.urlReplacement_, 'expandInputValueSync');
+            env.sandbox.stub(ampForm, 'analyticsEvent_');
 
             // Setup some Promises
             const submitPromise = ampForm.submit_(ActionTrust.HIGH);
@@ -1322,7 +1328,7 @@ describes.repeated(
                 const expectedFormData = {
                   'formId': '',
                   'formFields[name]': 'John Miller',
-                  'formFields[clientId]': sinon.match(/amp-.+/),
+                  'formFields[clientId]': env.sandbox.match(/amp-.+/),
                   'formFields[canonicalUrl]':
                     'https%3A%2F%2Fexample.com%2Famps.html',
                 };
@@ -1355,15 +1361,15 @@ describes.repeated(
           );
           return formPromise.then(ampForm => {
             let fetchResolver;
-            sandbox
+            env.sandbox
               .stub(ampForm.xhr_, 'fetch')
               .returns(new Promise(resolve => (fetchResolver = resolve)));
 
             const form = ampForm.form_;
             const event = {
-              stopImmediatePropagation: sandbox.spy(),
+              stopImmediatePropagation: env.sandbox.spy(),
               target: form,
-              preventDefault: sandbox.spy(),
+              preventDefault: env.sandbox.spy(),
             };
 
             const initialSubmitEventPromise = ampForm.handleSubmitEvent_(event);
@@ -1382,7 +1388,7 @@ describes.repeated(
               expect(form.className).to.not.contain('amp-form-submit-error');
               expect(form.className).to.not.contain('amp-form-submit-success');
               fetchResolver({json: () => Promise.resolve()});
-              sandbox.stub(ampForm, 'maybeHandleRedirect_');
+              env.sandbox.stub(ampForm, 'maybeHandleRedirect_');
 
               return whenCalled(ampForm.maybeHandleRedirect_).then(() => {
                 expect(ampForm.state_).to.equal('submit-success');
@@ -1402,11 +1408,11 @@ describes.repeated(
 
           const actions = {
             installActionHandler: () => {},
-            trigger: sandbox.spy(),
+            trigger: env.sandbox.spy(),
           };
-          sandbox.stub(Services, 'actionServiceForDoc').returns(actions);
+          env.sandbox.stub(Services, 'actionServiceForDoc').returns(actions);
 
-          sandbox.stub(Services, 'xhrFor').returns({
+          env.sandbox.stub(Services, 'xhrFor').returns({
             fetch: () => Promise.resolve({json: () => Promise.resolve()}),
           });
 
@@ -1418,7 +1424,7 @@ describes.repeated(
           expect(actions.trigger.getCall(1)).to.be.calledWith(
             form,
             'submit-success',
-            /* CustomEvent */ sinon.match.has('detail'),
+            /* CustomEvent */ env.sandbox.match.has('detail'),
             ActionTrust.DEFAULT // Expect: ActionTrust.HIGH - 1
           );
 
@@ -1431,7 +1437,7 @@ describes.repeated(
           expect(actions.trigger.getCall(3)).to.be.calledWith(
             form,
             'submit-success',
-            /* CustomEvent */ sinon.match.has('detail'),
+            /* CustomEvent */ env.sandbox.match.has('detail'),
             ActionTrust.LOW // Expect: ActionTrust.DEFAULT - 1
           );
         });
@@ -1439,23 +1445,23 @@ describes.repeated(
         it('should manage form state classes (submitting, success)', () => {
           return getAmpForm(getForm()).then(ampForm => {
             let fetchResolver;
-            sandbox.stub(ampForm.xhr_, 'fetch').returns(
+            env.sandbox.stub(ampForm.xhr_, 'fetch').returns(
               new Promise(resolve => {
                 fetchResolver = resolve;
               })
             );
-            sandbox.stub(ampForm, 'analyticsEvent_');
-            sandbox.stub(ampForm.actions_, 'trigger');
+            env.sandbox.stub(ampForm, 'analyticsEvent_');
+            env.sandbox.stub(ampForm.actions_, 'trigger');
             const form = ampForm.form_;
             const event = {
-              stopImmediatePropagation: sandbox.spy(),
+              stopImmediatePropagation: env.sandbox.spy(),
               target: form,
-              preventDefault: sandbox.spy(),
+              preventDefault: env.sandbox.spy(),
             };
 
             const submitPromise = ampForm.handleSubmitEvent_(event);
 
-            sandbox.spy(ampForm, 'handlePresubmitSuccess_');
+            env.sandbox.spy(ampForm, 'handlePresubmitSuccess_');
             whenCalled(ampForm.handlePresubmitSuccess_).then(() => {
               expect(event.preventDefault).to.be.called;
               expect(ampForm.state_).to.equal('submitting');
@@ -1480,7 +1486,7 @@ describes.repeated(
                 expect(ampForm.actions_.trigger).to.be.calledWith(
                   form,
                   'submit-success',
-                  /** CustomEvent */ sinon.match.has('detail')
+                  /** CustomEvent */ env.sandbox.match.has('detail')
                 );
                 expect(ampForm.analyticsEvent_).to.be.calledWith(
                   'amp-form-submit-success'
@@ -1497,18 +1503,18 @@ describes.repeated(
           return getAmpForm(getForm(/*button1*/ true, /*button2*/ true)).then(
             ampForm => {
               let fetchRejecter;
-              sandbox.stub(ampForm, 'analyticsEvent_');
-              sandbox.stub(ampForm.xhr_, 'fetch').returns(
+              env.sandbox.stub(ampForm, 'analyticsEvent_');
+              env.sandbox.stub(ampForm.xhr_, 'fetch').returns(
                 new Promise((unusedResolve, reject) => {
                   fetchRejecter = reject;
                 })
               );
-              sandbox.stub(ampForm.actions_, 'trigger');
+              env.sandbox.stub(ampForm.actions_, 'trigger');
               const form = ampForm.form_;
               const event = {
-                stopImmediatePropagation: sandbox.spy(),
+                stopImmediatePropagation: env.sandbox.spy(),
                 target: form,
-                preventDefault: sandbox.spy(),
+                preventDefault: env.sandbox.spy(),
               };
 
               const submitEventPromise = ampForm.handleSubmitEvent_(event);
@@ -1536,7 +1542,7 @@ describes.repeated(
                     ampForm.actions_.trigger.calledWith(
                       form,
                       'submit-error',
-                      /** CustomEvent */ sinon.match.has('detail')
+                      /** CustomEvent */ env.sandbox.match.has('detail')
                     )
                   ).to.be.true;
                   expect(ampForm.analyticsEvent_).to.be.calledWith(
@@ -1554,14 +1560,14 @@ describes.repeated(
               ampForm.method_ = 'GET';
               ampForm.form_.setAttribute('method', 'GET');
 
-              sandbox.stub(ampForm.xhr_, 'fetch').resolves();
+              env.sandbox.stub(ampForm.xhr_, 'fetch').resolves();
               const event = {
-                stopImmediatePropagation: sandbox.spy(),
+                stopImmediatePropagation: env.sandbox.spy(),
                 target: ampForm.form_,
-                preventDefault: sandbox.spy(),
+                preventDefault: env.sandbox.spy(),
               };
 
-              sandbox.stub(ampForm, 'handleXhrSubmitSuccess_').resolves();
+              env.sandbox.stub(ampForm, 'handleXhrSubmitSuccess_').resolves();
               const submitEventPromise = ampForm.handleSubmitEvent_(event);
               expect(event.preventDefault).to.be.calledOnce;
 
@@ -1588,7 +1594,7 @@ describes.repeated(
               ampForm.method_ = 'GET';
               form.setAttribute('method', 'GET');
 
-              sandbox.stub(ampForm.xhr_, 'fetch').resolves();
+              env.sandbox.stub(ampForm.xhr_, 'fetch').resolves();
               const fieldset = createElement('fieldset');
               const emailInput = createElement('input');
               emailInput.setAttribute('name', 'email');
@@ -1601,16 +1607,16 @@ describes.repeated(
               fieldset.appendChild(usernameInput);
               form.appendChild(fieldset);
               const event = {
-                stopImmediatePropagation: sandbox.spy(),
+                stopImmediatePropagation: env.sandbox.spy(),
                 target: ampForm.form_,
-                preventDefault: sandbox.spy(),
+                preventDefault: env.sandbox.spy(),
               };
 
               usernameInput.disabled = true;
               usernameInput.value = 'coolbeans';
               emailInput.value = 'cool@bea.ns';
 
-              sandbox.stub(ampForm, 'handleXhrSubmitSuccess_').resolves();
+              env.sandbox.stub(ampForm, 'handleXhrSubmitSuccess_').resolves();
               let submitEventPromise;
               submitEventPromise = ampForm.handleSubmitEvent_(event);
               expect(event.preventDefault).to.be.calledOnce;
@@ -1689,7 +1695,7 @@ describes.repeated(
               ampForm.method_ = 'GET';
               form.setAttribute('method', 'GET');
 
-              sandbox.stub(ampForm.xhr_, 'fetch').resolves();
+              env.sandbox.stub(ampForm.xhr_, 'fetch').resolves();
 
               const otherNamesFS = createElement('fieldset');
               const otherName1Input = createElement('input');
@@ -1748,12 +1754,12 @@ describes.repeated(
               form.appendChild(citySelect);
 
               const event = {
-                stopImmediatePropagation: sandbox.spy(),
+                stopImmediatePropagation: env.sandbox.spy(),
                 target: ampForm.form_,
-                preventDefault: sandbox.spy(),
+                preventDefault: env.sandbox.spy(),
               };
 
-              sandbox.stub(ampForm, 'handleXhrSubmitSuccess_').resolves();
+              env.sandbox.stub(ampForm, 'handleXhrSubmitSuccess_').resolves();
               let submitEventPromise;
               submitEventPromise = ampForm.handleSubmitEvent_(event);
               expect(event.preventDefault).to.be.calledOnce;
@@ -1821,14 +1827,14 @@ describes.repeated(
               emailInput.setAttribute('required', '');
               fieldset.appendChild(emailInput);
               form.appendChild(fieldset);
-              sandbox.spy(form, 'checkValidity');
-              sandbox.spy(emailInput, 'checkValidity');
-              sandbox.spy(fieldset, 'checkValidity');
+              env.sandbox.spy(form, 'checkValidity');
+              env.sandbox.spy(emailInput, 'checkValidity');
+              env.sandbox.spy(fieldset, 'checkValidity');
 
               const event = {
                 target: ampForm.form_,
-                stopImmediatePropagation: sandbox.spy(),
-                preventDefault: sandbox.spy(),
+                stopImmediatePropagation: env.sandbox.spy(),
+                preventDefault: env.sandbox.spy(),
               };
 
               // Submit an invalid form
@@ -1873,10 +1879,10 @@ describes.repeated(
               usernameInput.setAttribute('required', '');
               fieldset.appendChild(usernameInput);
               form.appendChild(fieldset);
-              sandbox.spy(form, 'checkValidity');
-              sandbox.spy(emailInput, 'checkValidity');
-              sandbox.spy(fieldset, 'checkValidity');
-              sandbox.stub(ampForm.xhr_, 'fetch').resolves();
+              env.sandbox.spy(form, 'checkValidity');
+              env.sandbox.spy(emailInput, 'checkValidity');
+              env.sandbox.spy(fieldset, 'checkValidity');
+              env.sandbox.stub(ampForm.xhr_, 'fetch').resolves();
 
               checkUserValidityAfterInteraction_(emailInput);
               expect(form.checkValidity).to.be.called;
@@ -1936,10 +1942,10 @@ describes.repeated(
               emailInput.setAttribute('required', '');
               fieldset.appendChild(emailInput);
               form.appendChild(fieldset);
-              sandbox.spy(form, 'checkValidity');
-              sandbox.spy(emailInput, 'checkValidity');
-              sandbox.spy(fieldset, 'checkValidity');
-              sandbox.stub(ampForm.xhr_, 'fetch').resolves();
+              env.sandbox.spy(form, 'checkValidity');
+              env.sandbox.spy(emailInput, 'checkValidity');
+              env.sandbox.spy(fieldset, 'checkValidity');
+              env.sandbox.stub(ampForm.xhr_, 'fetch').resolves();
 
               emailInput.value = 'cool@bea.ns';
               checkUserValidityAfterInteraction_(emailInput);
@@ -1958,12 +1964,12 @@ describes.repeated(
           document.body.appendChild(form);
           const actions = Services.actionServiceForDoc(form);
 
-          sandbox.stub(actions, 'installActionHandler');
+          env.sandbox.stub(actions, 'installActionHandler');
           const ampForm = new AmpForm(form);
-          sandbox.stub(ampForm.xhr_, 'fetch').resolves();
+          env.sandbox.stub(ampForm.xhr_, 'fetch').resolves();
 
           expect(actions.installActionHandler).to.be.calledWith(form);
-          sandbox.spy(ampForm, 'handleSubmitAction_');
+          env.sandbox.spy(ampForm, 'handleSubmitAction_');
           ampForm.actionHandler_({
             method: 'anything',
             satisfiesTrust: () => true,
@@ -1985,9 +1991,9 @@ describes.repeated(
           document.body.appendChild(form);
 
           const ampForm = new AmpForm(form);
-          sandbox.stub(ampForm.xhr_, 'fetch').resolves();
+          env.sandbox.stub(ampForm.xhr_, 'fetch').resolves();
 
-          sandbox.spy(ampForm, 'handleSubmitAction_');
+          env.sandbox.spy(ampForm, 'handleSubmitAction_');
           ampForm.actionHandler_({
             method: 'submit',
             satisfiesTrust: () => false,
@@ -2013,7 +2019,7 @@ describes.repeated(
 
             ampForm.form_.elements.name.value = 'Jack Sparrow';
 
-            sandbox.spy(ampForm, 'handleClearAction_');
+            env.sandbox.spy(ampForm, 'handleClearAction_');
             ampForm.actionHandler_({
               method: 'anything',
               satisfiesTrust: () => true,
@@ -2104,10 +2110,10 @@ describes.repeated(
             selector.setAttribute('name', 'color');
             form.appendChild(selector);
 
-            sandbox
+            env.sandbox
               .stub(selector, 'whenBuilt')
               .returns(new Promise(unusedResolve => {}));
-            sandbox.spy(ampForm, 'handleSubmitAction_');
+            env.sandbox.spy(ampForm, 'handleSubmitAction_');
 
             const submitPromise = ampForm.actionHandler_({
               method: 'submit',
@@ -2135,13 +2141,13 @@ describes.repeated(
             selector.setAttribute('name', 'color');
             form.appendChild(selector);
 
-            sandbox.stub(selector, 'whenBuilt').returns(
+            env.sandbox.stub(selector, 'whenBuilt').returns(
               new Promise(resolve => {
                 builtPromiseResolver_ = resolve;
               })
             );
-            sandbox.stub(ampForm.xhr_, 'fetch').resolves();
-            sandbox.spy(ampForm, 'handleSubmitAction_');
+            env.sandbox.stub(ampForm.xhr_, 'fetch').resolves();
+            env.sandbox.spy(ampForm, 'handleSubmitAction_');
 
             ampForm.actionHandler_({
               method: 'submit',
@@ -2185,11 +2191,11 @@ describes.repeated(
               );
               form.appendChild(canonicalUrlField);
 
-              sandbox.stub(form, 'checkValidity').returns(true);
-              sandbox.stub(ampForm.xhr_, 'fetch').resolves();
-              sandbox.stub(ampForm, 'handleSubmitSuccess_');
-              sandbox.spy(ampForm.urlReplacement_, 'expandInputValueAsync');
-              sandbox.stub(ampForm.urlReplacement_, 'expandInputValueSync');
+              env.sandbox.stub(form, 'checkValidity').returns(true);
+              env.sandbox.stub(ampForm.xhr_, 'fetch').resolves();
+              env.sandbox.stub(ampForm, 'handleSubmitSuccess_');
+              env.sandbox.spy(ampForm.urlReplacement_, 'expandInputValueAsync');
+              env.sandbox.stub(ampForm.urlReplacement_, 'expandInputValueSync');
 
               const submitPromise = ampForm.submit_(ActionTrust.HIGH);
               expect(ampForm.xhr_.fetch).to.have.not.been.called;
@@ -2236,19 +2242,19 @@ describes.repeated(
               canonicalUrlField.value = 'CANONICAL_URL';
               form.appendChild(canonicalUrlField);
 
-              sandbox.stub(form, 'checkValidity').returns(true);
-              sandbox.stub(ampForm.xhr_, 'fetch').resolves();
-              sandbox.stub(ampForm, 'handleSubmitSuccess_');
-              sandbox
+              env.sandbox.stub(form, 'checkValidity').returns(true);
+              env.sandbox.stub(ampForm.xhr_, 'fetch').resolves();
+              env.sandbox.stub(ampForm, 'handleSubmitSuccess_');
+              env.sandbox
                 .stub(ampForm.urlReplacement_, 'expandInputValueAsync')
                 .returns(
                   new Promise(resolve => {
                     expandAsyncStringResolvers.push(resolve);
                   })
                 );
-              sandbox.stub(ampForm.urlReplacement_, 'expandInputValueSync');
+              env.sandbox.stub(ampForm.urlReplacement_, 'expandInputValueSync');
 
-              sandbox.stub(ampForm, 'handleXhrSubmitSuccess_').resolves();
+              env.sandbox.stub(ampForm, 'handleXhrSubmitSuccess_').resolves();
               const submitPromise = ampForm.submit_(ActionTrust.HIGH);
 
               expect(ampForm.xhr_.fetch).to.have.not.been.called;
@@ -2297,13 +2303,19 @@ describes.repeated(
                 canonicalUrlField.value = 'CANONICAL_URL';
                 form.appendChild(canonicalUrlField);
 
-                sandbox.stub(form, 'submit');
-                sandbox.stub(form, 'checkValidity').returns(true);
-                sandbox.stub(ampForm, 'handleSubmitSuccess_');
-                sandbox.stub(ampForm.urlReplacement_, 'expandInputValueAsync');
-                sandbox.spy(ampForm.urlReplacement_, 'expandInputValueSync');
+                env.sandbox.stub(form, 'submit');
+                env.sandbox.stub(form, 'checkValidity').returns(true);
+                env.sandbox.stub(ampForm, 'handleSubmitSuccess_');
+                env.sandbox.stub(
+                  ampForm.urlReplacement_,
+                  'expandInputValueAsync'
+                );
+                env.sandbox.spy(
+                  ampForm.urlReplacement_,
+                  'expandInputValueSync'
+                );
 
-                sandbox.stub(ampForm, 'handleNonXhrGet_').resolves();
+                env.sandbox.stub(ampForm, 'handleNonXhrGet_').resolves();
                 const submitActionPromise = ampForm.handleSubmitAction_(
                   /* invocation */ {}
                 );
@@ -2372,20 +2384,22 @@ describes.repeated(
             beforeEach(() => {
               form = getForm();
               document.body.appendChild(form);
-              sandbox.stub(form, 'checkValidity').returns(true);
+              env.sandbox.stub(form, 'checkValidity').returns(true);
               ampForm = new AmpForm(form);
               ampForm.target_ = '_top';
 
-              navigateTo = sandbox.spy();
-              sandbox.stub(Services, 'navigationForDoc').returns({navigateTo});
-              sandbox
+              navigateTo = env.sandbox.spy();
+              env.sandbox
+                .stub(Services, 'navigationForDoc')
+                .returns({navigateTo});
+              env.sandbox
                 .stub(ampForm.ssrTemplateHelper_, 'isSupported')
                 .returns(false);
             });
 
             describe('AMP-Redirect-To', () => {
               it('should redirect users if header is set', () => {
-                sandbox.stub(ampForm.xhr_, 'fetch').resolves(fetchResolve);
+                env.sandbox.stub(ampForm.xhr_, 'fetch').resolves(fetchResolve);
                 redirectToValue = 'https://google.com/';
 
                 const submitActionPromise = ampForm.handleSubmitAction_(
@@ -2402,7 +2416,7 @@ describes.repeated(
               });
 
               it('should redirect users if header is set but json rejects', () => {
-                sandbox.stub(ampForm.xhr_, 'fetch').resolves({
+                env.sandbox.stub(ampForm.xhr_, 'fetch').resolves({
                   json: () => Promise.reject(),
                   headers: headersMock,
                 });
@@ -2422,14 +2436,14 @@ describes.repeated(
               });
 
               it('should fail to redirect to non-secure urls', () => {
-                sandbox.stub(ampForm.xhr_, 'fetch').resolves(fetchResolve);
+                env.sandbox.stub(ampForm.xhr_, 'fetch').resolves(fetchResolve);
                 redirectToValue = 'http://google.com/';
 
                 const submitActionPromise = ampForm.handleSubmitAction_(
                   /* invocation */ {}
                 );
                 // Make it a sync error for testing convenience
-                sandbox.stub(user(), 'assert').throws();
+                env.sandbox.stub(user(), 'assert').throws();
 
                 return submitActionPromise.then(
                   () => {
@@ -2442,14 +2456,14 @@ describes.repeated(
               });
 
               it('should fail to redirect to non-absolute urls', () => {
-                sandbox.stub(ampForm.xhr_, 'fetch').resolves(fetchResolve);
+                env.sandbox.stub(ampForm.xhr_, 'fetch').resolves(fetchResolve);
                 redirectToValue = '/hello';
 
                 const submitActionPromise = ampForm.handleSubmitAction_(
                   /* invocation */ {}
                 );
                 // Make it a sync error for testing convenience
-                sandbox.stub(user(), 'assert').throws();
+                env.sandbox.stub(user(), 'assert').throws();
 
                 return submitActionPromise.then(
                   () => {
@@ -2463,14 +2477,14 @@ describes.repeated(
 
               it('should fail to redirect to when target != _top', () => {
                 ampForm.target_ = '_blank';
-                sandbox.stub(ampForm.xhr_, 'fetch').resolves(fetchResolve);
+                env.sandbox.stub(ampForm.xhr_, 'fetch').resolves(fetchResolve);
                 redirectToValue = 'http://google.com/';
 
                 const submitActionPromise = ampForm.handleSubmitAction_(
                   /* invocation */ {}
                 );
                 // Make it a sync error for testing convenience
-                sandbox.stub(user(), 'assert').throws();
+                env.sandbox.stub(user(), 'assert').throws();
 
                 return submitActionPromise.then(
                   () => {
@@ -2483,9 +2497,9 @@ describes.repeated(
               });
 
               it('should redirect on error if header is set', () => {
-                sandbox.stub(ampForm.xhr_, 'fetch').rejects(error);
+                env.sandbox.stub(ampForm.xhr_, 'fetch').rejects(error);
                 redirectToValue = 'https://example2.com/hello';
-                const logSpy = sandbox.stub(user(), 'error');
+                const logSpy = env.sandbox.stub(user(), 'error');
 
                 const submitActionPromise = ampForm.handleSubmitAction_(
                   /* invocation */ {}
@@ -2515,11 +2529,11 @@ describes.repeated(
               // Non XHR Get
               ampForm.method_ = 'GET';
               ampForm.xhrAction_ = null;
-              sandbox.stub(form, 'submit');
-              sandbox.stub(form, 'checkValidity').returns(true);
-              sandbox.stub(ampForm.xhr_, 'fetch').resolves();
+              env.sandbox.stub(form, 'submit');
+              env.sandbox.stub(form, 'checkValidity').returns(true);
+              env.sandbox.stub(ampForm.xhr_, 'fetch').resolves();
 
-              sandbox.stub(ampForm, 'handleXhrSubmitSuccess_').resolves();
+              env.sandbox.stub(ampForm, 'handleXhrSubmitSuccess_').resolves();
               const submitActionPromise = ampForm.handleSubmitAction_(
                 /* invocation */ {}
               );
@@ -2535,13 +2549,13 @@ describes.repeated(
               const form = ampForm.form_;
               ampForm.method_ = 'GET';
               ampForm.xhrAction_ = null;
-              sandbox.stub(form, 'submit');
-              sandbox.stub(form, 'checkValidity').returns(true);
-              sandbox.stub(ampForm.xhr_, 'fetch').resolves();
+              env.sandbox.stub(form, 'submit');
+              env.sandbox.stub(form, 'checkValidity').returns(true);
+              env.sandbox.stub(ampForm.xhr_, 'fetch').resolves();
               const event = {
-                stopImmediatePropagation: sandbox.spy(),
+                stopImmediatePropagation: env.sandbox.spy(),
                 target: form,
-                preventDefault: sandbox.spy(),
+                preventDefault: env.sandbox.spy(),
               };
               return ampForm.handleSubmitEvent_(event).then(() => {
                 expect(form.submit).to.have.not.been.called;
@@ -2559,9 +2573,9 @@ describes.repeated(
               const form = ampForm.form_;
               ampForm.method_ = 'GET';
               ampForm.xhrAction_ = null;
-              sandbox.stub(form, 'submit');
-              sandbox.stub(form, 'checkValidity').returns(true);
-              sandbox.stub(ampForm.xhr_, 'fetch').resolves();
+              env.sandbox.stub(form, 'submit');
+              env.sandbox.stub(form, 'checkValidity').returns(true);
+              env.sandbox.stub(ampForm.xhr_, 'fetch').resolves();
               allowConsoleError(() => {
                 expect(() =>
                   ampForm.handleSubmitAction_(/* invocation */ {})
@@ -2581,9 +2595,9 @@ describes.repeated(
               const form = ampForm.form_;
               ampForm.method_ = 'GET';
               ampForm.xhrAction_ = null;
-              sandbox.stub(form, 'submit');
-              sandbox.stub(form, 'checkValidity').returns(true);
-              sandbox.stub(ampForm.xhr_, 'fetch').resolves();
+              env.sandbox.stub(form, 'submit');
+              env.sandbox.stub(form, 'checkValidity').returns(true);
+              env.sandbox.stub(ampForm.xhr_, 'fetch').resolves();
               allowConsoleError(() => {
                 expect(() =>
                   ampForm.handleSubmitAction_(/* invocation */ {})
@@ -2613,12 +2627,12 @@ describes.repeated(
             // Non XHR Get
             ampForm.method_ = 'GET';
             ampForm.xhrAction_ = null;
-            sandbox.stub(form, 'submit');
-            sandbox.stub(form, 'checkValidity').returns(true);
-            sandbox.stub(ampForm.xhr_, 'fetch').resolves();
-            sandbox.stub(ampForm, 'analyticsEvent_');
+            env.sandbox.stub(form, 'submit');
+            env.sandbox.stub(form, 'checkValidity').returns(true);
+            env.sandbox.stub(ampForm.xhr_, 'fetch').resolves();
+            env.sandbox.stub(ampForm, 'analyticsEvent_');
 
-            sandbox.stub(ampForm, 'handleXhrSubmitSuccess_').resolves();
+            env.sandbox.stub(ampForm, 'handleXhrSubmitSuccess_').resolves();
             const submitActionPromise = ampForm.handleSubmitAction_(
               /* invocation */ {}
             );
@@ -2655,16 +2669,16 @@ describes.repeated(
             form.appendChild(unnamedInput);
 
             let fetchResolver;
-            sandbox.stub(ampForm.xhr_, 'fetch').returns(
+            env.sandbox.stub(ampForm.xhr_, 'fetch').returns(
               new Promise(resolve => {
                 fetchResolver = resolve;
               })
             );
-            sandbox.stub(ampForm, 'analyticsEvent_');
+            env.sandbox.stub(ampForm, 'analyticsEvent_');
             const event = {
-              stopImmediatePropagation: sandbox.spy(),
+              stopImmediatePropagation: env.sandbox.spy(),
               target: form,
-              preventDefault: sandbox.spy(),
+              preventDefault: env.sandbox.spy(),
             };
             ampForm.handleSubmitEvent_(event).then(() => {
               expect(ampForm.state_).to.equal('submitting');
@@ -2709,16 +2723,16 @@ describes.repeated(
             form.appendChild(unnamedInput);
 
             let fetchRejecter;
-            sandbox.stub(ampForm.xhr_, 'fetch').returns(
+            env.sandbox.stub(ampForm.xhr_, 'fetch').returns(
               new Promise((unusedResolve, reject) => {
                 fetchRejecter = reject;
               })
             );
-            sandbox.stub(ampForm, 'analyticsEvent_');
+            env.sandbox.stub(ampForm, 'analyticsEvent_');
             const event = {
-              stopImmediatePropagation: sandbox.spy(),
+              stopImmediatePropagation: env.sandbox.spy(),
               target: form,
-              preventDefault: sandbox.spy(),
+              preventDefault: env.sandbox.spy(),
             };
 
             const submitEventPromise = ampForm.handleSubmitEvent_(event);
@@ -2767,12 +2781,12 @@ describes.repeated(
             canonicalUrlField.value = 'CANONICAL_URL';
             form.appendChild(canonicalUrlField);
 
-            sandbox.stub(form, 'submit');
-            sandbox.stub(form, 'checkValidity').returns(true);
-            sandbox.stub(ampForm.xhr_, 'fetch').resolves();
-            sandbox.stub(ampForm.urlReplacement_, 'expandInputValueAsync');
-            sandbox.spy(ampForm.urlReplacement_, 'expandInputValueSync');
-            sandbox.stub(ampForm, 'analyticsEvent_');
+            env.sandbox.stub(form, 'submit');
+            env.sandbox.stub(form, 'checkValidity').returns(true);
+            env.sandbox.stub(ampForm.xhr_, 'fetch').resolves();
+            env.sandbox.stub(ampForm.urlReplacement_, 'expandInputValueAsync');
+            env.sandbox.spy(ampForm.urlReplacement_, 'expandInputValueSync');
+            env.sandbox.stub(ampForm, 'analyticsEvent_');
             ampForm.handleSubmitAction_(/* invocation */ {});
 
             const expectedFormData = {
@@ -2806,7 +2820,7 @@ describes.repeated(
         });
 
         it('should attach auth token with crossorigin attribute', () => {
-          sandbox.stub(Services, 'viewerAssistanceForDocOrNull').resolves({
+          env.sandbox.stub(Services, 'viewerAssistanceForDocOrNull').resolves({
             getIdTokenPromise: () => Promise.resolve('idToken'),
           });
           return getAmpForm(getForm()).then(ampForm => {
@@ -2829,7 +2843,7 @@ describes.repeated(
               'crossorigin',
               'amp-viewer-auth-token-via-post'
             );
-            sandbox
+            env.sandbox
               .stub(ampForm.xhr_, 'fetch')
               .resolves({json: () => Promise.resolve()});
 
@@ -2852,7 +2866,7 @@ describes.repeated(
               ampForm.method_ = 'GET';
               ampForm.xhrAction_ = null;
 
-              const assertNoSensitiveFieldsStub = sandbox.stub(
+              const assertNoSensitiveFieldsStub = env.sandbox.stub(
                 ampForm,
                 'assertNoSensitiveFields_'
               );
@@ -2871,7 +2885,10 @@ describes.repeated(
               ampForm.method_ = 'GET';
               ampForm.xhrAction_ = null;
 
-              const formElementSubmitSpy = sandbox.spy(ampForm.form_, 'submit');
+              const formElementSubmitSpy = env.sandbox.spy(
+                ampForm.form_,
+                'submit'
+              );
 
               const mockEvent = {
                 preventDefault: () => {},
@@ -2993,7 +3010,7 @@ describes.repeated(
               return getAmpFormWithAsyncInput().then(response => {
                 const {ampForm} = response;
 
-                const handlePresubmitSuccessStub = sandbox.stub(
+                const handlePresubmitSuccessStub = env.sandbox.stub(
                   ampForm,
                   'handlePresubmitSuccess_'
                 );
@@ -3011,7 +3028,7 @@ describes.repeated(
             ).then(response => {
               const {ampForm, getValueStubRequiredAction} = response;
 
-              const handlePresubmitSuccessStub = sandbox.stub(
+              const handlePresubmitSuccessStub = env.sandbox.stub(
                 ampForm,
                 'handlePresubmitSuccess_'
               );
@@ -3032,7 +3049,7 @@ describes.repeated(
                 const getValueError = new Error('amp-async-input-error');
                 getValueStub.rejects(getValueError);
 
-                const stub = sandbox.stub(ampForm, 'handleSubmitFailure_');
+                const stub = env.sandbox.stub(ampForm, 'handleSubmitFailure_');
                 return ampForm.submit_(ActionTrust.HIGH).then(() => {
                   expect(stub).to.be.called;
                   expect(stub).to.be.calledWith(getValueError, {
@@ -3050,7 +3067,7 @@ describes.repeated(
               return getAmpFormWithAsyncInput().then(response => {
                 const {ampForm} = response;
 
-                const setStateStub = sandbox.stub(ampForm, 'setState_');
+                const setStateStub = env.sandbox.stub(ampForm, 'setState_');
 
                 return ampForm.submit_(ActionTrust.HIGH).then(() => {
                   expect(setStateStub).to.be.calledWith('submitting');
@@ -3068,7 +3085,7 @@ describes.repeated(
                 ampForm.method_ = 'GET';
                 ampForm.xhrAction_ = null;
 
-                const setStateStub = sandbox.stub(ampForm, 'setState_');
+                const setStateStub = env.sandbox.stub(ampForm, 'setState_');
 
                 return ampForm.submit_(ActionTrust.HIGH).then(() => {
                   expect(setStateStub).to.be.calledWith('initial');
@@ -3086,7 +3103,7 @@ describes.repeated(
 
                 const getValueError = new Error('amp-async-input-error');
                 getValueStub.rejects(getValueError);
-                const setStateStub = sandbox.stub(ampForm, 'setState_');
+                const setStateStub = env.sandbox.stub(ampForm, 'setState_');
 
                 return ampForm.submit_(ActionTrust.HIGH).then(() => {
                   expect(setStateStub).to.be.calledWith('submit-error');
@@ -3127,7 +3144,7 @@ describes.repeated(
           });
 
           it('clears dirtiness class when submitted successfully with XHR', async () => {
-            sandbox
+            env.sandbox
               .stub(ampForm.xhr_, 'fetch')
               .resolves({json: async () => {}});
 
@@ -3138,7 +3155,7 @@ describes.repeated(
           });
 
           it('does not clear dirtiness class when submission XHR fails', async () => {
-            sandbox.stub(ampForm.xhr_, 'fetch').rejects({});
+            env.sandbox.stub(ampForm.xhr_, 'fetch').rejects({});
 
             changeInput(input, 'Another Name');
             await ampForm.submit_(ActionTrust.HIGH);

--- a/extensions/amp-form/0.1/test/test-form-dirtiness.js
+++ b/extensions/amp-form/0.1/test/test-form-dirtiness.js
@@ -89,7 +89,7 @@ describes.realWin('form-dirtiness', {}, env => {
   beforeEach(() => {
     doc = env.win.document;
     form = getForm(doc);
-    sandbox.stub(Services, 'platformFor').returns({
+    env.sandbox.stub(Services, 'platformFor').returns({
       isIos() {
         return false;
       },

--- a/extensions/amp-form/0.1/test/test-form-proxy.js
+++ b/extensions/amp-form/0.1/test/test-form-proxy.js
@@ -46,24 +46,15 @@ describes.repeated(
   (name, variant) => {
     let form;
     let inputs;
-    let sandbox;
 
-    before(() => {
-      sandbox = sinon.sandbox;
-
+    beforeEach(() => {
       // Stub only to work around the fact that there's no Ampdoc, so the service
       // cannot be retrieved.
       // Otherwise this test would barf because `form` is detached.
-      sandbox.stub(Services, 'urlForDoc').returns({
+      window.sandbox.stub(Services, 'urlForDoc').returns({
         parse: parseUrlDeprecated,
       });
-    });
 
-    after(() => {
-      sandbox.restore();
-    });
-
-    beforeEach(() => {
       form = document.createElement('form');
       form.id = 'form1';
       form.action = 'https://example.org/submit';

--- a/extensions/amp-form/0.1/test/test-form-submit-service.js
+++ b/extensions/amp-form/0.1/test/test-form-submit-service.js
@@ -20,12 +20,7 @@ describe('form-submit-service', () => {
   let submitService;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox;
     submitService = new FormSubmitService();
-  });
-
-  afterEach(() => {
-    sandbox.restore();
   });
 
   it('firing without callbacks should not break', () => {
@@ -33,7 +28,7 @@ describe('form-submit-service', () => {
   });
 
   it('should register & fire one callback', () => {
-    const cb = sandbox.spy();
+    const cb = window.sandbox.spy();
     submitService.beforeSubmit(cb);
 
     const fakeFormEl = {};
@@ -44,7 +39,7 @@ describe('form-submit-service', () => {
   });
 
   it('should register & fire many callbacks', () => {
-    const cb = sandbox.spy();
+    const cb = window.sandbox.spy();
     submitService.beforeSubmit(cb);
     submitService.beforeSubmit(cb);
     submitService.beforeSubmit(cb);

--- a/extensions/amp-form/0.1/test/test-form-validators.js
+++ b/extensions/amp-form/0.1/test/test-form-validators.js
@@ -29,13 +29,12 @@ import {Services} from '../../../../src/services';
 import {ValidationBubble} from '../validation-bubble';
 
 describes.realWin('form-validators', {amp: true}, env => {
-  let sandbox;
   const emailTypeValidationMsg = 'Yo! That email does not look so.. email-y';
   const textPatternValidationMsg = 'Yo! No blank emails';
 
   // Stub validation message for predictable message on any platform.
   function stubValidationMessage(input) {
-    sandbox.defineProperty(input, 'validationMessage', {
+    env.sandbox.defineProperty(input, 'validationMessage', {
       get() {
         return this.fakeValidationMessage_;
       },
@@ -113,11 +112,9 @@ describes.realWin('form-validators', {amp: true}, env => {
   }
 
   beforeEach(() => {
-    sandbox = env.sandbox;
-
     // Force sync mutateElement to make testing easier.
     const resources = Services.resourcesForDoc(env.ampdoc);
-    sandbox.stub(resources, 'mutateElement').callsArg(1);
+    env.sandbox.stub(resources, 'mutateElement').callsArg(1);
   });
 
   describe('getFormValidator', () => {
@@ -158,8 +155,8 @@ describes.realWin('form-validators', {amp: true}, env => {
     });
 
     it('fireValidityEventIfNecessary()', () => {
-      sandbox.stub(form, 'checkValidity').returns(false);
-      sandbox.stub(form, 'dispatchEvent');
+      env.sandbox.stub(form, 'checkValidity').returns(false);
+      env.sandbox.stub(form, 'dispatchEvent');
 
       validator.fireValidityEventIfNecessary();
       expect(form.dispatchEvent).calledOnce;
@@ -191,13 +188,13 @@ describes.realWin('form-validators', {amp: true}, env => {
     });
 
     it('should reports form validity', () => {
-      sandbox.stub(form, 'reportValidity');
+      env.sandbox.stub(form, 'reportValidity');
       validator.report();
       expect(form.reportValidity).to.have.been.called;
     });
 
     it('should fire events on report()', () => {
-      sandbox.stub(form, 'dispatchEvent');
+      env.sandbox.stub(form, 'dispatchEvent');
 
       validator.onBlur({target: form.elements[0]});
       expect(form.dispatchEvent).to.not.be.called;
@@ -242,7 +239,7 @@ describes.realWin('form-validators', {amp: true}, env => {
 
     it('should reports form validity', () => {
       expect(validator.validationBubble_).to.be.instanceOf(ValidationBubble);
-      sandbox.stub(validator.validationBubble_, 'show');
+      env.sandbox.stub(validator.validationBubble_, 'show');
       validator.report();
       expect(doc.activeElement).to.equal(form.elements[0]);
       expect(validator.validationBubble_.show).to.be.calledOnce;
@@ -256,14 +253,14 @@ describes.realWin('form-validators', {amp: true}, env => {
       const mockEvent = {
         target: {},
       };
-      sandbox.stub(validator.validationBubble_, 'hide');
+      env.sandbox.stub(validator.validationBubble_, 'hide');
       validator.onBlur(mockEvent);
       expect(validator.validationBubble_.hide).to.be.calledOnce;
     });
 
     it('should re-validate on input if is is actively reported', () => {
-      sandbox.stub(validator.validationBubble_, 'show');
-      sandbox.stub(validator.validationBubble_, 'hide');
+      env.sandbox.stub(validator.validationBubble_, 'show');
+      env.sandbox.stub(validator.validationBubble_, 'hide');
       validator.onInput({target: form.elements[0]});
       expect(validator.validationBubble_.hide).to.not.be.called;
       expect(validator.validationBubble_.show).to.not.be.called;
@@ -276,7 +273,7 @@ describes.realWin('form-validators', {amp: true}, env => {
         form.elements[0].validationMessage
       );
 
-      sandbox.stub(validator.validationBubble_, 'isActiveOn').returns(true);
+      env.sandbox.stub(validator.validationBubble_, 'isActiveOn').returns(true);
       validator.onInput({target: form.elements[0]});
       expect(form.elements[0].getAttribute('aria-invalid')).to.equal('true');
       expect(validator.validationBubble_.show).to.be.calledTwice;
@@ -287,7 +284,7 @@ describes.realWin('form-validators', {amp: true}, env => {
     });
 
     it('should fire events on report()', () => {
-      sandbox.stub(form, 'dispatchEvent');
+      env.sandbox.stub(form, 'dispatchEvent');
 
       validator.onBlur({target: form.elements[0]});
       expect(form.dispatchEvent).to.not.be.called;
@@ -416,7 +413,7 @@ describes.realWin('form-validators', {amp: true}, env => {
     });
 
     it('should fire events on report()', () => {
-      sandbox.stub(form, 'dispatchEvent');
+      env.sandbox.stub(form, 'dispatchEvent');
 
       validator.onBlur({target: form.elements[0]});
       expect(form.dispatchEvent).to.not.be.called;
@@ -527,7 +524,7 @@ describes.realWin('form-validators', {amp: true}, env => {
     });
 
     it('should fire events on report()', () => {
-      sandbox.stub(form, 'dispatchEvent');
+      env.sandbox.stub(form, 'dispatchEvent');
 
       validator.onBlur({target: form.elements[0]});
       expect(form.dispatchEvent).to.not.be.called;
@@ -615,7 +612,7 @@ describes.realWin('form-validators', {amp: true}, env => {
     });
 
     it('should fire events on onBlur() and onInput()', () => {
-      sandbox.stub(validator, 'fireValidityEventIfNecessary');
+      env.sandbox.stub(validator, 'fireValidityEventIfNecessary');
 
       validator.report();
       expect(validator.fireValidityEventIfNecessary).to.not.be.called;
@@ -751,7 +748,7 @@ describes.realWin('form-validators', {amp: true}, env => {
     });
 
     it('should fire events on report(), onBlur() and onInput()', () => {
-      sandbox.stub(validator, 'fireValidityEventIfNecessary');
+      env.sandbox.stub(validator, 'fireValidityEventIfNecessary');
 
       validator.onBlur({target: form.elements[0]});
       expect(validator.fireValidityEventIfNecessary).calledOnce;

--- a/extensions/amp-form/0.1/test/test-form-verifiers.js
+++ b/extensions/amp-form/0.1/test/test-form-verifiers.js
@@ -21,13 +21,8 @@ import {
 } from '../form-verifiers';
 
 describes.fakeWin('amp-form async verification', {}, env => {
-  let sandbox;
-  beforeEach(() => {
-    sandbox = env.sandbox;
-  });
-
   function stubValidationMessage(input) {
-    sandbox.defineProperty(input, 'validationMessage', {
+    env.sandbox.defineProperty(input, 'validationMessage', {
       get() {
         return this.fakeValidationMessage_;
       },
@@ -37,7 +32,7 @@ describes.fakeWin('amp-form async verification', {}, env => {
     });
 
     const originalSetCustomValidity = input.setCustomValidity.bind(input);
-    sandbox.defineProperty(input, 'setCustomValidity', {
+    env.sandbox.defineProperty(input, 'setCustomValidity', {
       value(message) {
         this.validationMessage = message;
         originalSetCustomValidity(message);
@@ -116,7 +111,7 @@ describes.fakeWin('amp-form async verification', {}, env => {
 
   describe('AsyncVerifier', () => {
     it('should not submit when no element has a value', () => {
-      const xhrSpy = sandbox.spy(() => Promise.resolve());
+      const xhrSpy = env.sandbox.spy(() => Promise.resolve());
       const form = getForm(env.win.document);
       const verifier = getFormVerifier(form, xhrSpy);
       return verifier.onCommit().then(() => {
@@ -128,7 +123,7 @@ describes.fakeWin('amp-form async verification', {}, env => {
       'should submit when an element is filled out, mutated, ' +
         'and committed',
       () => {
-        const xhrSpy = sandbox.spy(() => Promise.resolve());
+        const xhrSpy = env.sandbox.spy(() => Promise.resolve());
         const form = getForm(env.win.document);
         const verifier = getFormVerifier(form, xhrSpy);
 
@@ -154,7 +149,7 @@ describes.fakeWin('amp-form async verification', {}, env => {
           });
         },
       };
-      const xhrSpy = sandbox.spy(() =>
+      const xhrSpy = env.sandbox.spy(() =>
         Promise.reject({
           response: errorResponse,
         })
@@ -187,7 +182,7 @@ describes.fakeWin('amp-form async verification', {}, env => {
             });
           },
         };
-        const xhrStub = sandbox.stub();
+        const xhrStub = env.sandbox.stub();
         xhrStub.onCall(0).returns(Promise.reject({response: errorResponse}));
         xhrStub.onCall(1).returns(Promise.resolve());
 
@@ -233,7 +228,7 @@ describes.fakeWin('amp-form async verification', {}, env => {
             });
           },
         };
-        const xhrSpy = sandbox.spy(() =>
+        const xhrSpy = env.sandbox.spy(() =>
           Promise.reject({
             response: errorResponse,
           })

--- a/extensions/amp-fx-flying-carpet/0.1/test/test-amp-fx-flying-carpet.js
+++ b/extensions/amp-fx-flying-carpet/0.1/test/test-amp-fx-flying-carpet.js
@@ -118,7 +118,7 @@ describes.realWin(
     });
 
     it('should listen to build callback of children', () => {
-      const scheduleLayoutStub = sandbox.stub(
+      const scheduleLayoutStub = env.sandbox.stub(
         Services.ownersForDoc(doc),
         'scheduleLayout'
       );
@@ -214,7 +214,7 @@ describes.realWin(
         const posttext = doc.createTextNode('\n');
         return [pretext, img, posttext];
       }).then(flyingCarpet => {
-        const attemptCollapse = sandbox
+        const attemptCollapse = env.sandbox
           .stub(flyingCarpet.implementation_, 'attemptCollapse')
           .callsFake(() => {
             return Promise.resolve();
@@ -228,7 +228,7 @@ describes.realWin(
     it('should relayout the content', () => {
       return getAmpFlyingCarpet().then(flyingCarpet => {
         const impl = flyingCarpet.implementation_;
-        const scheduleLayoutSpy_ = sandbox.spy(
+        const scheduleLayoutSpy_ = env.sandbox.spy(
           Services.ownersForDoc(impl.element),
           'scheduleLayout'
         );

--- a/extensions/amp-geo/0.1/test/test-amp-geo.js
+++ b/extensions/amp-geo/0.1/test/test-amp-geo.js
@@ -65,7 +65,7 @@ describes.realWin(
     let userErrorStub;
 
     beforeEach(() => {
-      userErrorStub = sandbox.stub(user(), 'error');
+      userErrorStub = env.sandbox.stub(user(), 'error');
       win = env.win;
       doc = win.document;
       ampdoc = env.ampdoc;
@@ -376,7 +376,7 @@ describes.realWin(
 
     it('geo should log an error if unpatched in production. ', () => {
       expectAsyncConsoleError(/GEONOTPATCHED/);
-      sandbox.stub(win.__AMP_MODE, 'localDev').value(false);
+      env.sandbox.stub(win.__AMP_MODE, 'localDev').value(false);
       addConfigElement('script');
 
       geo.buildCallback();

--- a/extensions/amp-gwd-animation/0.1/test/test-amp-gwd-animation.js
+++ b/extensions/amp-gwd-animation/0.1/test/test-amp-gwd-animation.js
@@ -79,7 +79,6 @@ describes.sandboxed('AMP GWD Animation', {}, () => {
           },
         },
         env => {
-          let sandbox;
           let ampdoc;
           let element;
           let impl;
@@ -90,7 +89,6 @@ describes.sandboxed('AMP GWD Animation', {}, () => {
           let runtime;
 
           beforeEach(() => {
-            sandbox = sinon.sandbox;
             ampdoc = env.ampdoc;
             embed = env.embed;
             win = variant.ampdoc == 'fie' ? embed.win : ampdoc.win;
@@ -465,7 +463,7 @@ describes.sandboxed('AMP GWD Animation', {}, () => {
             const triggeredEvents = [];
 
             const actionService = Services.actionServiceForDoc(element);
-            sandbox
+            env.sandbox
               .stub(actionService, 'trigger')
               .callsFake((target, name, event) => {
                 triggeredAmpEventNames.push(name);
@@ -509,9 +507,9 @@ describes.sandboxed('AMP GWD Animation', {}, () => {
     let actionService;
 
     beforeEach(() => {
-      actionService = {setActions: sandbox.stub()};
+      actionService = {setActions: window.sandbox.stub()};
       element = document.createElement('div');
-      sandbox
+      window.sandbox
         .stub(Services, 'actionServiceForDoc')
         .withArgs(element)
         .returns(actionService);
@@ -547,7 +545,7 @@ describes.sandboxed('AMP GWD Animation', {}, () => {
       const target = document.createElement('div');
       target.setAttribute('on', 'event2:node2.hide');
       // FIE should have its own ActionService.
-      const fieActionService = {setActions: sandbox.stub()};
+      const fieActionService = {setActions: window.sandbox.stub()};
       Services.actionServiceForDoc.withArgs(target).returns(fieActionService);
       // Provide `target` as the service context to simulate FIE case.
       addAction(target, target, 'event1', 'node1.foo()');

--- a/extensions/amp-iframe/0.1/test/test-amp-iframe.js
+++ b/extensions/amp-iframe/0.1/test/test-amp-iframe.js
@@ -646,7 +646,7 @@ describes.realWin(
         });
         yield waitForAmpIframeLayoutPromise(doc, ampIframe);
         const impl = ampIframe.implementation_;
-        const attemptChangeSize = sandbox.spy(impl, 'attemptChangeSize');
+        const attemptChangeSize = env.sandbox.spy(impl, 'attemptChangeSize');
         impl.updateSize_(217, '114' /* be tolerant to string number */);
         expect(attemptChangeSize).to.be.calledWith(217, 114);
       });
@@ -661,7 +661,7 @@ describes.realWin(
         });
         yield waitForAmpIframeLayoutPromise(doc, ampIframe);
         const impl = ampIframe.implementation_;
-        const attemptChangeSize = sandbox.spy(impl, 'attemptChangeSize');
+        const attemptChangeSize = env.sandbox.spy(impl, 'attemptChangeSize');
         impl.updateSize_(217);
         expect(attemptChangeSize).to.be.calledOnce;
         expect(attemptChangeSize.firstCall.args[0]).to.equal(217);
@@ -679,7 +679,7 @@ describes.realWin(
         });
         yield waitForAmpIframeLayoutPromise(doc, ampIframe);
         const impl = ampIframe.implementation_;
-        const attemptChangeSize = sandbox.spy(impl, 'attemptChangeSize');
+        const attemptChangeSize = env.sandbox.spy(impl, 'attemptChangeSize');
         impl.updateSize_(50, 114);
         expect(attemptChangeSize).to.have.not.been.called;
       });
@@ -694,13 +694,13 @@ describes.realWin(
         });
         yield waitForAmpIframeLayoutPromise(doc, ampIframe);
         const impl = ampIframe.implementation_;
-        const attemptChangeSize = sandbox.spy(impl, 'attemptChangeSize');
+        const attemptChangeSize = env.sandbox.spy(impl, 'attemptChangeSize');
         impl.updateSize_(217, 114);
         expect(attemptChangeSize).to.have.not.been.called;
       });
 
       it('should listen for embed-ready event', function*() {
-        const activateIframeSpy_ = sandbox./*OK*/ spy(
+        const activateIframeSpy_ = window.sandbox./*OK*/ spy(
           AmpIframe.prototype,
           'activateIframe_'
         );
@@ -851,7 +851,7 @@ describes.realWin(
         });
         yield waitForAmpIframeLayoutPromise(doc, ampIframe);
         const impl = ampIframe.implementation_;
-        const stub = sandbox.stub(impl, 'getLayoutBox');
+        const stub = env.sandbox.stub(impl, 'getLayoutBox');
         const box = {
           top: 100,
           bottom: 200,
@@ -969,8 +969,8 @@ describes.realWin(
           });
           yield waitForAmpIframeLayoutPromise(doc, ampIframe);
 
-          const userError = sandbox.stub(user(), 'error');
-          const addEventListener = sandbox.stub(win, 'addEventListener');
+          const userError = env.sandbox.stub(user(), 'error');
+          const addEventListener = env.sandbox.stub(win, 'addEventListener');
           ampIframe.implementation_.executeAction({
             method: 'postMessage',
             args: 'foo-123',
@@ -1000,9 +1000,9 @@ describes.realWin(
           });
           yield waitForAmpIframeLayoutPromise(doc, ampIframe);
 
-          const userError = sandbox.stub(user(), 'error');
-          const actions = {trigger: sandbox.spy()};
-          sandbox.stub(Services, 'actionServiceForDoc').returns(actions);
+          const userError = env.sandbox.stub(user(), 'error');
+          const actions = {trigger: env.sandbox.spy()};
+          env.sandbox.stub(Services, 'actionServiceForDoc').returns(actions);
 
           const impl = ampIframe.implementation_;
           impl.executeAction({
@@ -1018,7 +1018,7 @@ describes.realWin(
             /may only be triggered from a user gesture/
           );
 
-          sandbox.stub(impl, 'isUserGesture_').returns(true);
+          env.sandbox.stub(impl, 'isUserGesture_').returns(true);
           impl.executeAction({
             method: 'postMessage',
             args: 'bar-456',
@@ -1028,9 +1028,9 @@ describes.realWin(
           yield waitForJsInIframe(2);
           // Once for 'loaded-iframe' and once for 'content-iframe'.
           expect(actions.trigger).to.be.calledTwice;
-          const eventMatcher = sinon.match({
+          const eventMatcher = env.sandbox.match({
             type: 'amp-iframe:message',
-            detail: sinon.match({data: 'content-iframe:bar-456'}),
+            detail: env.sandbox.match({data: 'content-iframe:bar-456'}),
           });
           expect(actions.trigger).to.be.calledWith(
             ampIframe,

--- a/extensions/amp-ima-video/0.1/test/test-amp-ima-video.js
+++ b/extensions/amp-ima-video/0.1/test/test-amp-ima-video.js
@@ -103,14 +103,14 @@ describes.realWin(
         removeEventListener() {},
       };
       const adDisplayContainerMock = {initialize() {}};
-      const initSpy = sandbox.spy(adDisplayContainerMock, 'initialize');
+      const initSpy = env.sandbox.spy(adDisplayContainerMock, 'initialize');
       const videoPlayerMock = getVideoPlayerMock();
-      const loadSpy = sandbox.spy(videoPlayerMock, 'load');
+      const loadSpy = env.sandbox.spy(videoPlayerMock, 'load');
       const mockAdsLoader = {requestAds() {}};
       imaVideoObj.setAdsLoaderForTesting(mockAdsLoader);
-      //const playAdsSpy = sandbox.spy(imaVideoObj, 'playAds');
+      //const playAdsSpy = env.sandbox.spy(imaVideoObj, 'playAds');
       //const playAdsFunc = imaVideoObj.playAds;
-      //const playAdsSpy = sandbox.spy(playAdsFunc);
+      //const playAdsSpy = env.sandbox.spy(playAdsFunc);
       imaVideoObj.setBigPlayDivForTesting(bigPlayDivMock);
       imaVideoObj.setAdDisplayContainerForTesting(adDisplayContainerMock);
       imaVideoObj.setVideoPlayerForTesting(videoPlayerMock);
@@ -219,8 +219,8 @@ describes.realWin(
       const mockAdsManager = {};
       mockAdsManager.init = function() {};
       mockAdsManager.start = function() {};
-      const initSpy = sandbox.spy(mockAdsManager, 'init');
-      const startSpy = sandbox.spy(mockAdsManager, 'start');
+      const initSpy = env.sandbox.spy(mockAdsManager, 'init');
+      const startSpy = env.sandbox.spy(mockAdsManager, 'start');
       imaVideoObj.setAdsManagerForTesting(mockAdsManager);
       imaVideoObj.setVideoWidthAndHeightForTesting(100, 200);
 
@@ -241,7 +241,7 @@ describes.realWin(
         src: srcUrl,
         tag: adTagUrl,
       });
-      //const playVideoSpy = sandbox.spy(imaVideoObj, 'playVideo');
+      //const playVideoSpy = env.sandbox.spy(imaVideoObj, 'playVideo');
 
       imaVideoObj.playAds();
 
@@ -263,7 +263,7 @@ describes.realWin(
         tag: adTagUrl,
       });
       const mockAdsLoader = {contentComplete() {}};
-      const completeSpy = sandbox.spy(mockAdsLoader, 'contentComplete');
+      const completeSpy = env.sandbox.spy(mockAdsLoader, 'contentComplete');
       imaVideoObj.setAdsLoaderForTesting(mockAdsLoader);
 
       imaVideoObj.onContentEnded();
@@ -309,8 +309,11 @@ describes.realWin(
           return mockAdsManager;
         },
       };
-      const amleSpy = sandbox.spy(mockAdsManagerLoadedEvent, 'getAdsManager');
-      const addEventListenerSpy = sandbox.spy(
+      const amleSpy = env.sandbox.spy(
+        mockAdsManagerLoadedEvent,
+        'getAdsManager'
+      );
+      const addEventListenerSpy = env.sandbox.spy(
         mockAdsManager,
         'addEventListener'
       );
@@ -370,12 +373,15 @@ describes.realWin(
           return mockAdsManager;
         },
       };
-      const amleSpy = sandbox.spy(mockAdsManagerLoadedEvent, 'getAdsManager');
-      const addEventListenerSpy = sandbox.spy(
+      const amleSpy = env.sandbox.spy(
+        mockAdsManagerLoadedEvent,
+        'getAdsManager'
+      );
+      const addEventListenerSpy = env.sandbox.spy(
         mockAdsManager,
         'addEventListener'
       );
-      const setVolumeSpy = sandbox.spy(mockAdsManager, 'setVolume');
+      const setVolumeSpy = env.sandbox.spy(mockAdsManager, 'setVolume');
       const mockVideoPlayer = {};
       imaVideoObj.setVideoPlayerForTesting(mockVideoPlayer);
       imaVideoObj.setMuteAdsManagerOnLoadedForTesting(true);
@@ -407,7 +413,7 @@ describes.realWin(
         src: srcUrl,
         tag: adTagUrl,
       });
-      //const playVideoSpy = sandbox.spy(imaVideoObj, 'playVideo');
+      //const playVideoSpy = env.sandbox.spy(imaVideoObj, 'playVideo');
 
       imaVideoObj.onAdsLoaderError();
 
@@ -428,8 +434,8 @@ describes.realWin(
         tag: adTagUrl,
       });
       const adsManagerMock = {destroy() {}};
-      const destroySpy = sandbox.spy(adsManagerMock, 'destroy');
-      //const playVideoSpy = sandbox.spy(imaVideoObj, 'playVideo');
+      const destroySpy = env.sandbox.spy(adsManagerMock, 'destroy');
+      //const playVideoSpy = env.sandbox.spy(imaVideoObj, 'playVideo');
       imaVideoObj.setAdsManagerForTesting(adsManagerMock);
 
       imaVideoObj.onAdError();
@@ -451,12 +457,12 @@ describes.realWin(
         tag: adTagUrl,
       });
       const videoMock = getVideoPlayerMock();
-      const removeEventListenerSpy = sandbox.spy(
+      const removeEventListenerSpy = env.sandbox.spy(
         videoMock,
         'removeEventListener'
       );
-      //const hideControlsSpy = sandbox.spy(imaVideoObj, 'hideControls');
-      const pauseSpy = sandbox.spy(videoMock, 'pause');
+      //const hideControlsSpy = env.sandbox.spy(imaVideoObj, 'hideControls');
+      const pauseSpy = env.sandbox.spy(videoMock, 'pause');
       imaVideoObj.setVideoPlayerForTesting(videoMock);
 
       imaVideoObj.onContentPauseRequested();
@@ -486,12 +492,12 @@ describes.realWin(
         tag: adTagUrl,
       });
       const videoMock = getVideoPlayerMock();
-      const removeEventListenerSpy = sandbox.spy(
+      const removeEventListenerSpy = env.sandbox.spy(
         videoMock,
         'removeEventListener'
       );
-      //const hideControlsSpy = sandbox.spy(imaVideoObj, 'hideControls');
-      const pauseSpy = sandbox.spy(videoMock, 'pause');
+      //const hideControlsSpy = env.sandbox.spy(imaVideoObj, 'hideControls');
+      const pauseSpy = env.sandbox.spy(videoMock, 'pause');
       imaVideoObj.setVideoPlayerForTesting(videoMock);
       const adsManagerMock = {resize: () => {}};
       const mockGlobal = {
@@ -503,7 +509,7 @@ describes.realWin(
           },
         },
       };
-      const resizeSpy = sandbox.spy(adsManagerMock, 'resize');
+      const resizeSpy = env.sandbox.spy(adsManagerMock, 'resize');
       imaVideoObj.setAdsManagerDimensionsOnLoadForTesting(100, 200);
       imaVideoObj.setAdsManagerForTesting(adsManagerMock);
 
@@ -597,8 +603,11 @@ describes.realWin(
         tag: adTagUrl,
       });
       const videoMock = getVideoPlayerMock();
-      const addEventListenerSpy = sandbox.spy(videoMock, 'addEventListener');
-      //const playVideoSpy = sandbox.spy(imaVideoObj, 'playVideo');
+      const addEventListenerSpy = env.sandbox.spy(
+        videoMock,
+        'addEventListener'
+      );
+      //const playVideoSpy = env.sandbox.spy(imaVideoObj, 'playVideo');
       imaVideoObj.setVideoPlayerForTesting(videoMock);
       imaVideoObj.setContentCompleteForTesting(false);
 
@@ -625,8 +634,11 @@ describes.realWin(
         tag: adTagUrl,
       });
       const videoMock = getVideoPlayerMock();
-      const addEventListenerSpy = sandbox.spy(videoMock, 'addEventListener');
-      //const playVideoSpy = sandbox.spy(imaVideoObj, 'playVideo');
+      const addEventListenerSpy = env.sandbox.spy(
+        videoMock,
+        'addEventListener'
+      );
+      //const playVideoSpy = env.sandbox.spy(imaVideoObj, 'playVideo');
       imaVideoObj.setVideoPlayerForTesting(videoMock);
       imaVideoObj.setContentCompleteForTesting(true);
 
@@ -760,7 +772,10 @@ describes.realWin(
           tag: adTagUrl,
         });
         const videoMock = getVideoPlayerMock();
-        const addEventListenerSpy = sandbox.spy(videoMock, 'addEventListener');
+        const addEventListenerSpy = env.sandbox.spy(
+          videoMock,
+          'addEventListener'
+        );
         imaVideoObj.setVideoPlayerForTesting(videoMock);
         imaVideoObj.setContentCompleteForTesting(true);
 
@@ -816,7 +831,10 @@ describes.realWin(
           tag: adTagUrl,
         });
         const videoMock = getVideoPlayerMock();
-        const addEventListenerSpy = sandbox.spy(videoMock, 'addEventListener');
+        const addEventListenerSpy = env.sandbox.spy(
+          videoMock,
+          'addEventListener'
+        );
         imaVideoObj.setVideoPlayerForTesting(videoMock);
 
         imaVideoObj.onBigPlayClick();
@@ -938,7 +956,7 @@ describes.realWin(
       imaVideoObj.setPlayerStateForTesting(
         imaVideoObj.getPropertiesForTesting().PlayerStates.PAUSED
       );
-      //const playVideoSpy = sandbox.spy(imaVideoObj, 'playVideo');
+      //const playVideoSpy = env.sandbox.spy(imaVideoObj, 'playVideo');
 
       imaVideoObj.onPlayPauseClick();
 
@@ -961,7 +979,7 @@ describes.realWin(
       imaVideoObj.setPlayerStateForTesting(
         imaVideoObj.getPropertiesForTesting().PlayerStates.PLAYING
       );
-      //const pauseVideoSpy = sandbox.spy(imaVideoObj, 'pauseVideo');
+      //const pauseVideoSpy = env.sandbox.spy(imaVideoObj, 'pauseVideo');
 
       imaVideoObj.onPlayPauseClick();
 
@@ -981,7 +999,7 @@ describes.realWin(
         tag: adTagUrl,
       });
       const videoMock = getVideoPlayerMock();
-      const playSpy = sandbox.spy(videoMock, 'play');
+      const playSpy = env.sandbox.spy(videoMock, 'play');
       imaVideoObj.setVideoPlayerForTesting(videoMock);
 
       imaVideoObj.playVideo();
@@ -1009,9 +1027,9 @@ describes.realWin(
         tag: adTagUrl,
       });
       const videoMock = getVideoPlayerMock();
-      const pauseSpy = sandbox.spy(videoMock, 'pause');
+      const pauseSpy = env.sandbox.spy(videoMock, 'pause');
       imaVideoObj.setVideoPlayerForTesting(videoMock);
-      //const showControlsSpy = sandbox.spy(imaVideoObj, 'showControls');
+      //const showControlsSpy = env.sandbox.spy(imaVideoObj, 'showControls');
       imaVideoObj.getPropertiesForTesting().playerState = imaVideoObj.getPropertiesForTesting().PlayerStates.PLAYING;
 
       imaVideoObj.pauseVideo({});
@@ -1041,7 +1059,7 @@ describes.realWin(
       adsManagerMock.setVolume = () => {};
       imaVideoObj.setAdsManagerForTesting(adsManagerMock);
       imaVideoObj.setVideoPlayerMutedForTesting(false);
-      //const pauseVideoSpy = sandbox.spy(imaVideoObj, 'pauseVideo');
+      //const pauseVideoSpy = env.sandbox.spy(imaVideoObj, 'pauseVideo');
 
       imaVideoObj.onMuteUnmuteClick();
 
@@ -1068,7 +1086,7 @@ describes.realWin(
       adsManagerMock.setVolume = () => {};
       imaVideoObj.setAdsManagerForTesting(adsManagerMock);
       imaVideoObj.setVideoPlayerMutedForTesting(true);
-      //const pauseVideoSpy = sandbox.spy(imaVideoObj, 'pauseVideo');
+      //const pauseVideoSpy = env.sandbox.spy(imaVideoObj, 'pauseVideo');
 
       imaVideoObj.onMuteUnmuteClick();
 
@@ -1090,13 +1108,13 @@ describes.realWin(
         tag: adTagUrl,
       });
       const videoMock = getVideoPlayerMock();
-      const pauseSpy = sandbox.spy(videoMock, 'pause');
-      const removeEventListenerSpy = sandbox.spy(
+      const pauseSpy = env.sandbox.spy(videoMock, 'pause');
+      const removeEventListenerSpy = env.sandbox.spy(
         videoMock,
         'removeEventListener'
       );
       imaVideoObj.setVideoPlayerForTesting(videoMock);
-      //const showControlsSpy = sandbox.spy(imaVideoObj, 'showControls');
+      //const showControlsSpy = env.sandbox.spy(imaVideoObj, 'showControls');
       imaVideoObj.getPropertiesForTesting().playerState = imaVideoObj.getPropertiesForTesting().PlayerStates.PLAYING;
 
       imaVideoObj.pauseVideo({type: 'webkitendfullscreen'});

--- a/extensions/amp-image-lightbox/0.1/test/test-amp-image-lightbox.js
+++ b/extensions/amp-image-lightbox/0.1/test/test-amp-image-lightbox.js
@@ -112,9 +112,9 @@ describes.realWin(
     it('should activate all steps', () => {
       return getImageLightbox().then(lightbox => {
         const impl = lightbox.implementation_;
-        const viewportOnChanged = sandbox.spy();
-        const enterLightboxMode = sandbox.spy();
-        const leaveLightboxMode = sandbox.spy();
+        const viewportOnChanged = env.sandbox.spy();
+        const enterLightboxMode = env.sandbox.spy();
+        const leaveLightboxMode = env.sandbox.spy();
         impl.getViewport = () => {
           return {
             onChanged: viewportOnChanged,
@@ -122,7 +122,7 @@ describes.realWin(
             leaveLightboxMode,
           };
         };
-        const historyPush = sandbox.spy();
+        const historyPush = env.sandbox.spy();
         impl.getHistory_ = () => {
           return {
             push: () => {
@@ -131,7 +131,7 @@ describes.realWin(
             },
           };
         };
-        const enter = sandbox.spy();
+        const enter = env.sandbox.spy();
         impl.enter_ = enter;
 
         const ampImage = doc.createElement('amp-img');
@@ -153,18 +153,18 @@ describes.realWin(
         const impl = lightbox.implementation_;
         impl.active_ = true;
         impl.historyId_ = 11;
-        const viewportOnChangedUnsubscribed = sandbox.spy();
+        const viewportOnChangedUnsubscribed = env.sandbox.spy();
         impl.unlistenViewport_ = viewportOnChangedUnsubscribed;
-        const enterLightboxMode = sandbox.spy();
-        const leaveLightboxMode = sandbox.spy();
+        const enterLightboxMode = env.sandbox.spy();
+        const leaveLightboxMode = env.sandbox.spy();
         impl.getViewport = () => {
           return {enterLightboxMode, leaveLightboxMode};
         };
-        const historyPop = sandbox.spy();
+        const historyPop = env.sandbox.spy();
         impl.getHistory_ = () => {
           return {pop: historyPop};
         };
-        const exit = sandbox.spy();
+        const exit = env.sandbox.spy();
         impl.exit_ = exit;
 
         impl.close();
@@ -182,13 +182,13 @@ describes.realWin(
     it('should close on ESC', () => {
       return getImageLightbox().then(lightbox => {
         const impl = lightbox.implementation_;
-        const setupCloseSpy = sandbox.spy(impl, 'close');
-        const nullAddEventListenerSpy = sandbox
+        const setupCloseSpy = env.sandbox.spy(impl, 'close');
+        const nullAddEventListenerSpy = env.sandbox
           .spy(impl.win.document.documentElement, 'addEventListener')
           .withArgs('keydown', null);
-        const viewportOnChanged = sandbox.spy();
-        const enterLightboxMode = sandbox.spy();
-        const leaveLightboxMode = sandbox.spy();
+        const viewportOnChanged = env.sandbox.spy();
+        const enterLightboxMode = env.sandbox.spy();
+        const leaveLightboxMode = env.sandbox.spy();
         impl.getViewport = () => {
           return {
             onChanged: viewportOnChanged,
@@ -196,7 +196,7 @@ describes.realWin(
             leaveLightboxMode,
           };
         };
-        const historyPush = sandbox.spy();
+        const historyPush = env.sandbox.spy();
         impl.getHistory_ = () => {
           return {
             push: () => {
@@ -205,7 +205,7 @@ describes.realWin(
             },
           };
         };
-        const enter = sandbox.spy();
+        const enter = env.sandbox.spy();
         impl.enter_ = enter;
 
         const ampImage = doc.createElement('amp-img');
@@ -235,7 +235,7 @@ describes.realWin(
           };
         };
 
-        const tryFocus = sandbox.spy(dom, 'tryFocus');
+        const tryFocus = env.sandbox.spy(dom, 'tryFocus');
 
         const sourceElement = doc.createElement('amp-img');
         sourceElement.setAttribute('src', 'data:');
@@ -282,16 +282,16 @@ describes.realWin(
       doc = win.document;
       clock = lolex.install();
 
-      sandbox.stub(WindowInterface, 'getDevicePixelRatio').returns(1);
+      env.sandbox.stub(WindowInterface, 'getDevicePixelRatio').returns(1);
       lightbox = {
         element: {
           ownerDocument: doc,
         },
       };
-      lightboxMock = sandbox.mock(lightbox);
-      loadPromiseStub = sandbox.stub().returns(Promise.resolve());
+      lightboxMock = env.sandbox.mock(lightbox);
+      loadPromiseStub = env.sandbox.stub().returns(Promise.resolve());
 
-      sandbox
+      env.sandbox
         .stub(Services.timerFor(win), 'promise')
         .returns(Promise.resolve());
       imageViewer = new ImageViewer(lightbox, win, loadPromiseStub);
@@ -442,7 +442,7 @@ describes.realWin(
     beforeEach(() => {
       win = env.win;
       doc = win.document;
-      sandbox.stub(WindowInterface, 'getDevicePixelRatio').returns(1);
+      env.sandbox.stub(WindowInterface, 'getDevicePixelRatio').returns(1);
       lightbox = {
         close: () => {},
         toggleViewMode: () => {},
@@ -450,7 +450,7 @@ describes.realWin(
           ownerDocument: doc,
         },
       };
-      lightboxMock = sandbox.mock(lightbox);
+      lightboxMock = env.sandbox.mock(lightbox);
 
       imageViewer = new ImageViewer(lightbox, win);
       doc.body.appendChild(imageViewer.getElement());
@@ -533,7 +533,7 @@ describes.realWin(
     });
 
     it('should zoom release', () => {
-      const updateSrc = sandbox.spy();
+      const updateSrc = env.sandbox.spy();
       imageViewer.updateSrc_ = updateSrc;
       imageViewer.onZoomInc_(10, 10, -10, -10);
       return imageViewer.onZoomRelease_(10, 10, -10, -10, 0, 0).then(() => {

--- a/extensions/amp-imgur/0.1/test/test-amp-imgur.js
+++ b/extensions/amp-imgur/0.1/test/test-amp-imgur.js
@@ -67,7 +67,7 @@ describes.realWin(
     it('resizes with JSON String message', () => {
       return getImgur('2CnX7').then(imgur => {
         const impl = imgur.implementation_;
-        const changeHeightSpy = sandbox.spy(impl, 'attemptChangeHeight');
+        const changeHeightSpy = env.sandbox.spy(impl, 'attemptChangeHeight');
         expect(changeHeightSpy).not.to.have.been.called;
         const event = {
           origin: 'https://imgur.com',
@@ -83,7 +83,7 @@ describes.realWin(
     it('resizes with JSON Object message', () => {
       return getImgur('2CnX7').then(imgur => {
         const impl = imgur.implementation_;
-        const changeHeightSpy = sandbox.spy(impl, 'attemptChangeHeight');
+        const changeHeightSpy = env.sandbox.spy(impl, 'attemptChangeHeight');
         expect(changeHeightSpy).not.to.have.been.called;
         const event = {
           origin: 'https://imgur.com',

--- a/extensions/amp-inputmask/0.1/test/test-mask-impl.js
+++ b/extensions/amp-inputmask/0.1/test/test-mask-impl.js
@@ -16,19 +16,19 @@
 
 import {Mask} from '../mask-impl';
 
-describes.sandboxed('amp-inputmask mask-impl', {}, () => {
+describes.sandboxed('amp-inputmask mask-impl', {}, env => {
   class FakeElement {}
 
   describe('config', () => {
     let constructorStub;
 
     beforeEach(() => {
-      constructorStub = sandbox.stub();
+      constructorStub = env.sandbox.stub();
       constructorStub.extendDefaults = function() {};
 
-      sandbox.stub(Mask, 'getInputmask_').returns(constructorStub);
+      env.sandbox.stub(Mask, 'getInputmask_').returns(constructorStub);
 
-      FakeElement.prototype.getAttribute = sandbox.stub();
+      FakeElement.prototype.getAttribute = env.sandbox.stub();
     });
 
     it(

--- a/extensions/amp-instagram/0.1/test/test-amp-instagram.js
+++ b/extensions/amp-instagram/0.1/test/test-amp-instagram.js
@@ -196,7 +196,7 @@ describes.realWin(
       const ins = await getIns('fBwFP', true);
       const impl = ins.implementation_;
       const iframe = ins.querySelector('iframe');
-      const changeHeight = sandbox.spy(impl, 'changeHeight');
+      const changeHeight = env.sandbox.spy(impl, 'changeHeight');
       const newHeight = 977;
       expect(iframe).to.not.be.null;
       sendFakeMessage(ins, iframe, 'MEASURE', {

--- a/extensions/amp-install-serviceworker/0.1/test/test-amp-install-serviceworker.js
+++ b/extensions/amp-install-serviceworker/0.1/test/test-amp-install-serviceworker.js
@@ -50,19 +50,17 @@ describes.realWin(
   },
   env => {
     let doc;
-    let sandbox;
     let container;
     let ampdoc;
     let maybeInstallUrlRewriteStub;
 
     beforeEach(() => {
       doc = env.win.document;
-      sandbox = env.sandbox;
       ampdoc = Services.ampdocServiceFor(env.win).getSingleDoc();
       container = doc.createElement('div');
       env.win.document.body.appendChild(container);
-      stubUrlService(sandbox);
-      maybeInstallUrlRewriteStub = sandbox.stub(
+      stubUrlService(env.sandbox);
+      maybeInstallUrlRewriteStub = env.sandbox.stub(
         AmpInstallServiceWorker.prototype,
         'maybeInstallUrlRewrite_'
       );
@@ -93,8 +91,8 @@ describes.realWin(
         },
       };
       const whenVisible = Promise.resolve();
-      sandbox.stub(ampdoc, 'whenFirstVisible').returns(whenVisible);
-      sandbox.stub(ampdoc, 'isVisible').returns(true);
+      env.sandbox.stub(ampdoc, 'whenFirstVisible').returns(whenVisible);
+      env.sandbox.stub(ampdoc, 'isVisible').returns(true);
       implementation.buildCallback();
       expect(calledSrc).to.be.undefined;
       return Promise.all([whenVisible, loadPromise(implementation.win)]).then(
@@ -132,8 +130,8 @@ describes.realWin(
         },
       };
       const whenVisible = Promise.resolve();
-      sandbox.stub(ampdoc, 'whenFirstVisible').returns(whenVisible);
-      sandbox.stub(ampdoc, 'isVisible').returns(true);
+      env.sandbox.stub(ampdoc, 'whenFirstVisible').returns(whenVisible);
+      env.sandbox.stub(ampdoc, 'isVisible').returns(true);
       implementation.buildCallback();
       expect(calledSrc).to.be.undefined;
       return Promise.all([whenVisible, loadPromise(implementation.win)]).then(
@@ -162,10 +160,10 @@ describes.realWin(
           },
         });
       };
-      const postMessageStub = sandbox.stub();
+      const postMessageStub = env.sandbox.stub();
       const fakeRegistration = {
         installing: {
-          addEventListener: sandbox.spy(eventListener),
+          addEventListener: env.sandbox.spy(eventListener),
         },
         active: {
           postMessage: postMessageStub,
@@ -198,15 +196,15 @@ describes.realWin(
         },
       };
       const whenVisible = Promise.resolve();
-      sandbox.stub(ampdoc, 'whenFirstVisible').returns(whenVisible);
-      sandbox.stub(ampdoc, 'isVisible').returns(true);
+      env.sandbox.stub(ampdoc, 'whenFirstVisible').returns(whenVisible);
+      env.sandbox.stub(ampdoc, 'isVisible').returns(true);
       implementation.buildCallback();
       return Promise.all([whenVisible, loadPromise(implementation.win)]).then(
         () => {
           return p.then(fakeRegistration => {
             expect(
               fakeRegistration.installing.addEventListener
-            ).to.be.calledWith('statechange', sinon.match.func);
+            ).to.be.calledWith('statechange', env.sandbox.match.func);
             expect(postMessageStub).to.be.calledWith(
               JSON.stringify({
                 type: 'AMP__FIRST-VISIT-CACHING',
@@ -228,7 +226,7 @@ describes.realWin(
         install.getAmpDoc = () => ampdoc;
         install.setAttribute('src', 'https://example.com/sw.js');
         const implementation = new AmpInstallServiceWorker(install);
-        const postMessageStub = sandbox.stub();
+        const postMessageStub = env.sandbox.stub();
         const fakeRegistration = {
           active: {
             postMessage: postMessageStub,
@@ -266,8 +264,8 @@ describes.realWin(
           },
         };
         const whenVisible = Promise.resolve();
-        sandbox.stub(ampdoc, 'whenFirstVisible').returns(whenVisible);
-        sandbox.stub(ampdoc, 'isVisible').returns(true);
+        env.sandbox.stub(ampdoc, 'whenFirstVisible').returns(whenVisible);
+        env.sandbox.stub(ampdoc, 'isVisible').returns(true);
         implementation.buildCallback();
         return Promise.all([whenVisible, loadPromise(implementation.win)]).then(
           () => {
@@ -400,8 +398,8 @@ describes.realWin(
           };
         });
         whenVisible = Promise.resolve();
-        sandbox.stub(ampdoc, 'whenFirstVisible').returns(whenVisible);
-        sandbox.stub(ampdoc, 'isVisible').returns(true);
+        env.sandbox.stub(ampdoc, 'whenFirstVisible').returns(whenVisible);
+        env.sandbox.stub(ampdoc, 'isVisible').returns(true);
       });
 
       function testIframe(callCount = 1) {
@@ -416,7 +414,7 @@ describes.realWin(
           iframe.src = 'about:blank';
           appendChild.call(install, iframe);
         };
-        const mutateElement = sandbox.stub(implementation, 'mutateElement');
+        const mutateElement = env.sandbox.stub(implementation, 'mutateElement');
         mutateElement.callsFake(fn => {
           expect(iframe).to.be.undefined;
           const returnedValue = fn();
@@ -500,7 +498,7 @@ describes.fakeWin(
       win = env.win;
       ampdoc = env.ampdoc;
       viewer = win.__AMP_SERVICES.viewer.obj;
-      stubUrlService(sandbox);
+      stubUrlService(env.sandbox);
       element = win.document.createElement('amp-install-serviceworker');
       element.setAttribute('src', 'https://example.com/sw.js');
       // This is a RegExp string.
@@ -518,7 +516,7 @@ describes.fakeWin(
 
     describe('install conditions', () => {
       beforeEach(() => {
-        sandbox.stub(implementation, 'preloadShell_');
+        window.sandbox.stub(implementation, 'preloadShell_');
       });
 
       it('should install rewriter', () => {
@@ -609,15 +607,15 @@ describes.fakeWin(
       let preloadStub;
 
       beforeEach(() => {
-        mutateElementStub = sandbox
+        mutateElementStub = window.sandbox
           .stub(implementation, 'mutateElement')
           .callsFake(callback => callback());
-        preloadStub = sandbox.stub(implementation, 'preloadShell_');
+        preloadStub = env.sandbox.stub(implementation, 'preloadShell_');
         viewer.setVisibilityState_('visible');
       });
 
       it('should start preload wait', () => {
-        const stub = sandbox.stub(implementation, 'waitToPreloadShell_');
+        const stub = env.sandbox.stub(implementation, 'waitToPreloadShell_');
         implementation.maybeInstallUrlRewrite_();
         expect(stub).to.be.calledOnce;
       });
@@ -628,7 +626,7 @@ describes.fakeWin(
           'data-no-service-worker-fallback-shell-url',
           'http://example.com/shell'
         );
-        const stub = sandbox.stub(implementation, 'waitToPreloadShell_');
+        const stub = env.sandbox.stub(implementation, 'waitToPreloadShell_');
         implementation.maybeInstallUrlRewrite_();
         expect(stub).to.not.be.called;
       });
@@ -682,7 +680,7 @@ describes.fakeWin(
       let origHref;
 
       beforeEach(() => {
-        sandbox.stub(implementation, 'preloadShell_');
+        window.sandbox.stub(implementation, 'preloadShell_');
         implementation.maybeInstallUrlRewrite_();
         rewriter = implementation.urlRewriter_;
         anchor = win.document.createElement('a');

--- a/extensions/amp-list/0.1/test/test-amp-list-container.js
+++ b/extensions/amp-list/0.1/test/test-amp-list-container.js
@@ -35,7 +35,6 @@ describes.realWin(
     let win;
     let doc;
     let ampdoc;
-    let sandbox;
     let element, list;
     let templates;
 
@@ -43,25 +42,24 @@ describes.realWin(
       win = env.win;
       doc = win.document;
       ampdoc = env.ampdoc;
-      sandbox = env.sandbox;
 
       templates = {
-        findAndSetHtmlForTemplate: sandbox.stub(),
-        findAndRenderTemplate: sandbox.stub(),
-        findAndRenderTemplateArray: sandbox.stub(),
+        findAndSetHtmlForTemplate: env.sandbox.stub(),
+        findAndRenderTemplate: env.sandbox.stub(),
+        findAndRenderTemplateArray: env.sandbox.stub(),
       };
-      sandbox.stub(Services, 'templatesFor').returns(templates);
-      sandbox.stub(AmpDocService.prototype, 'getAmpDoc').returns(ampdoc);
+      env.sandbox.stub(Services, 'templatesFor').returns(templates);
+      env.sandbox.stub(AmpDocService.prototype, 'getAmpDoc').returns(ampdoc);
 
       element = doc.createElement('amp-list');
       list = new AmpList(element);
 
-      sandbox.stub(list, 'getAmpDoc').returns(ampdoc);
-      sandbox.stub(list, 'getFallback').returns(null);
+      env.sandbox.stub(list, 'getAmpDoc').returns(ampdoc);
+      env.sandbox.stub(list, 'getFallback').returns(null);
 
-      sandbox.stub(list, 'mutateElement').callsFake(mutateElementStub);
-      sandbox.stub(list, 'measureElement').callsFake(measureElementStub);
-      sandbox
+      env.sandbox.stub(list, 'mutateElement').callsFake(mutateElementStub);
+      env.sandbox.stub(list, 'measureElement').callsFake(measureElementStub);
+      env.sandbox
         .stub(list, 'measureMutateElement')
         .callsFake(measureMutateElementStub);
       element.setAttribute('src', '/list');
@@ -70,8 +68,8 @@ describes.realWin(
       element.setAttribute('height', '10');
       doc.body.appendChild(element);
 
-      sandbox.stub(list, 'getOverflowElement').returns(null);
-      sandbox.stub(list, 'fetchList_').returns(Promise.resolve());
+      env.sandbox.stub(list, 'getOverflowElement').returns(null);
+      env.sandbox.stub(list, 'fetchList_').returns(Promise.resolve());
       list.element.changeSize = () => {};
       list.buildCallback();
     });
@@ -90,7 +88,7 @@ describes.realWin(
     });
 
     it('should trigger on bind', async () => {
-      const changeSpy = sandbox.spy(list, 'changeToLayoutContainer_');
+      const changeSpy = env.sandbox.spy(list, 'changeToLayoutContainer_');
       await list.layoutCallback();
       await list.mutatedAttributesCallback({'is-layout-container': true});
       expect(changeSpy).to.be.calledOnce;

--- a/extensions/amp-list/0.1/test/test-amp-list-load-more.js
+++ b/extensions/amp-list/0.1/test/test-amp-list-load-more.js
@@ -40,7 +40,6 @@ describes.realWin(
     let win;
     let doc;
     let ampdoc;
-    let sandbox;
     let element, list;
     let templates;
 
@@ -48,15 +47,14 @@ describes.realWin(
       win = env.win;
       doc = win.document;
       ampdoc = env.ampdoc;
-      sandbox = env.sandbox;
 
       templates = {
-        findAndSetHtmlForTemplate: sandbox.stub(),
-        findAndRenderTemplate: sandbox.stub(),
-        findAndRenderTemplateArray: sandbox.stub(),
+        findAndSetHtmlForTemplate: env.sandbox.stub(),
+        findAndRenderTemplate: env.sandbox.stub(),
+        findAndRenderTemplateArray: env.sandbox.stub(),
       };
-      sandbox.stub(Services, 'templatesFor').returns(templates);
-      sandbox.stub(AmpDocService.prototype, 'getAmpDoc').returns(ampdoc);
+      env.sandbox.stub(Services, 'templatesFor').returns(templates);
+      env.sandbox.stub(AmpDocService.prototype, 'getAmpDoc').returns(ampdoc);
     });
 
     describe('manual', () => {
@@ -64,12 +62,12 @@ describes.realWin(
         element = doc.createElement('amp-list');
         list = new AmpList(element);
 
-        sandbox.stub(list, 'getAmpDoc').returns(ampdoc);
-        sandbox.stub(list, 'getFallback').returns(null);
+        env.sandbox.stub(list, 'getAmpDoc').returns(ampdoc);
+        env.sandbox.stub(list, 'getFallback').returns(null);
 
-        sandbox.stub(list, 'mutateElement').callsFake(mutateElementStub);
-        sandbox.stub(list, 'measureElement').callsFake(measureElementStub);
-        sandbox
+        env.sandbox.stub(list, 'mutateElement').callsFake(mutateElementStub);
+        env.sandbox.stub(list, 'measureElement').callsFake(measureElementStub);
+        env.sandbox
           .stub(list, 'measureMutateElement')
           .callsFake(measureMutateElementStub);
 
@@ -82,14 +80,14 @@ describes.realWin(
         element.style.height = '10px';
         doc.body.appendChild(element);
 
-        sandbox.stub(list, 'getOverflowElement').returns(null);
-        sandbox.stub(list, 'fetchList_').returns(Promise.resolve());
+        env.sandbox.stub(list, 'getOverflowElement').returns(null);
+        env.sandbox.stub(list, 'fetchList_').returns(Promise.resolve());
         list.element.changeSize = () => {};
         list.buildCallback();
       });
 
       it('should create load-more elements after init', async () => {
-        sandbox.stub(list, 'getPlaceholder').returns(null);
+        env.sandbox.stub(list, 'getPlaceholder').returns(null);
         await list.initializeLoadMoreElements_();
 
         expect(
@@ -102,7 +100,7 @@ describes.realWin(
       });
 
       it('should hide load-more-button after init', async () => {
-        sandbox.stub(list, 'getPlaceholder').returns(null);
+        env.sandbox.stub(list, 'getPlaceholder').returns(null);
         await list.initializeLoadMoreElements_();
 
         const button = list.element.querySelector('[load-more-button]');
@@ -114,7 +112,7 @@ describes.realWin(
       });
 
       it('should hide load-more-failed element after init', async () => {
-        sandbox.stub(list, 'getPlaceholder').returns(null);
+        env.sandbox.stub(list, 'getPlaceholder').returns(null);
         await list.initializeLoadMoreElements_();
 
         const failedElement = list.element.querySelector('[load-more-failed]');
@@ -123,7 +121,7 @@ describes.realWin(
       });
 
       it('should hide load-more-loading element after init', async () => {
-        sandbox.stub(list, 'getPlaceholder').returns(null);
+        env.sandbox.stub(list, 'getPlaceholder').returns(null);
         await list.initializeLoadMoreElements_();
 
         const loader = list.element.querySelector('[load-more-loading]');
@@ -132,13 +130,16 @@ describes.realWin(
       });
 
       it('should resize the list to fit a placeholder', async () => {
-        const attemptChangeHeightSpy = sandbox.spy(list, 'attemptChangeHeight');
+        const attemptChangeHeightSpy = env.sandbox.spy(
+          list,
+          'attemptChangeHeight'
+        );
         const placeholder = doc.createElement('div');
         placeholder.setAttribute('placeholder', '');
         placeholder.style.height = '50px';
         placeholder.style.width = '50px';
         list.element.appendChild(placeholder);
-        sandbox.stub(list, 'getPlaceholder').returns(placeholder);
+        env.sandbox.stub(list, 'getPlaceholder').returns(placeholder);
         await list.layoutCallback();
         expect(attemptChangeHeightSpy).to.be.calledOnceWith(50);
       });
@@ -149,12 +150,12 @@ describes.realWin(
         element = doc.createElement('amp-list');
         list = new AmpList(element);
 
-        sandbox.stub(list, 'getAmpDoc').returns(ampdoc);
-        sandbox.stub(list, 'getFallback').returns(null);
+        env.sandbox.stub(list, 'getAmpDoc').returns(ampdoc);
+        env.sandbox.stub(list, 'getFallback').returns(null);
 
-        sandbox.stub(list, 'mutateElement').callsFake(mutateElementStub);
-        sandbox.stub(list, 'measureElement').callsFake(measureElementStub);
-        sandbox
+        env.sandbox.stub(list, 'mutateElement').callsFake(mutateElementStub);
+        env.sandbox.stub(list, 'measureElement').callsFake(measureElementStub);
+        env.sandbox
           .stub(list, 'measureMutateElement')
           .callsFake(measureMutateElementStub);
 
@@ -166,8 +167,8 @@ describes.realWin(
         element.style.height = '10px';
         doc.body.appendChild(element);
 
-        sandbox.stub(list, 'getOverflowElement').returns(null);
-        sandbox
+        env.sandbox.stub(list, 'getOverflowElement').returns(null);
+        env.sandbox
           .stub(list, 'prepareAndSendFetch_')
           .returns(Promise.resolve(HAS_MORE_ITEMS_PAYLOAD));
         list.element.changeSize = () => {};
@@ -175,7 +176,7 @@ describes.realWin(
       });
 
       it('should update the next loading src', async () => {
-        sandbox.stub(list, 'scheduleRender_').returns(Promise.resolve());
+        env.sandbox.stub(list, 'scheduleRender_').returns(Promise.resolve());
         await list.layoutCallback();
         expect(element.getAttribute('src')).to.equal(
           '/list/infinite-scroll?items=2&left=1'
@@ -192,11 +193,11 @@ describes.realWin(
 
         const div2 = doc.createElement('div');
         div2.textContent = '2';
-        sandbox
+        env.sandbox
           .stub(list.ssrTemplateHelper_, 'applySsrOrCsrTemplate')
           .returns(Promise.resolve([]));
-        const updateBindingsStub = sandbox.stub(list, 'updateBindings_');
-        sandbox
+        const updateBindingsStub = env.sandbox.stub(list, 'updateBindings_');
+        env.sandbox
           .stub(list, 'maybeRenderLoadMoreTemplates_')
           .returns(Promise.resolve([]));
         updateBindingsStub.onCall(0).returns(Promise.resolve([div1, div2]));
@@ -207,7 +208,7 @@ describes.realWin(
         div4.textContent = '4';
         updateBindingsStub.onCall(1).returns(Promise.resolve([div3, div4]));
 
-        const renderSpy = sandbox.spy(list, 'render_');
+        const renderSpy = env.sandbox.spy(list, 'render_');
         await list.layoutCallback();
         expect(renderSpy).to.be.calledOnce;
         expect(renderSpy).to.be.calledWith([div1, div2], false);
@@ -223,11 +224,11 @@ describes.realWin(
 
       // TODO(cathyxz) Create a mirror test for automatic amp-list loading once the automatic tests are unskipped
       it('should call focus on the last element after load more is clicked', async () => {
-        sandbox
+        env.sandbox
           .stub(list.ssrTemplateHelper_, 'applySsrOrCsrTemplate')
           .returns(Promise.resolve([]));
-        const updateBindingsStub = sandbox.stub(list, 'updateBindings_');
-        sandbox
+        const updateBindingsStub = env.sandbox.stub(list, 'updateBindings_');
+        env.sandbox
           .stub(list, 'maybeRenderLoadMoreTemplates_')
           .returns(Promise.resolve([]));
 
@@ -236,7 +237,7 @@ describes.realWin(
         const div2 = doc.createElement('div');
         div2.textContent = '2';
         updateBindingsStub.onCall(0).returns(Promise.resolve([div1, div2]));
-        const focusSpy = sandbox.spy(div2, 'focus');
+        const focusSpy = env.sandbox.spy(div2, 'focus');
 
         await list.layoutCallback();
 

--- a/extensions/amp-list/0.1/test/test-amp-list.js
+++ b/extensions/amp-list/0.1/test/test-amp-list.js
@@ -40,7 +40,7 @@ describes.repeated(
         runtimeOn: false,
       },
       env => {
-        let win, doc, ampdoc, sandbox;
+        let win, doc, ampdoc;
         let element, list, listMock;
         let resource, resources;
         let setBindService;
@@ -51,18 +51,19 @@ describes.repeated(
           win = env.win;
           doc = win.document;
           ampdoc = env.ampdoc;
-          sandbox = env.sandbox;
 
           templates = {
-            findAndSetHtmlForTemplate: sandbox.stub(),
-            findAndRenderTemplate: sandbox.stub(),
-            findAndRenderTemplateArray: sandbox.stub(),
+            findAndSetHtmlForTemplate: env.sandbox.stub(),
+            findAndRenderTemplate: env.sandbox.stub(),
+            findAndRenderTemplateArray: env.sandbox.stub(),
           };
-          sandbox.stub(Services, 'templatesFor').returns(templates);
-          sandbox.stub(AmpDocService.prototype, 'getAmpDoc').returns(ampdoc);
+          env.sandbox.stub(Services, 'templatesFor').returns(templates);
+          env.sandbox
+            .stub(AmpDocService.prototype, 'getAmpDoc')
+            .returns(ampdoc);
 
           resource = {
-            resetPendingChangeSize: sandbox.stub(),
+            resetPendingChangeSize: env.sandbox.stub(),
           };
           resources = {
             getResourceForElement: e => (e === element ? resource : null),
@@ -84,13 +85,13 @@ describes.repeated(
           element.appendChild(template);
 
           const {promise, resolve} = new Deferred();
-          sandbox.stub(Services, 'bindForDocOrNull').returns(promise);
+          env.sandbox.stub(Services, 'bindForDocOrNull').returns(promise);
           setBindService = resolve;
 
           ssrTemplateHelper = {
             isSupported: () => false,
             ssr: () => Promise.resolve(),
-            applySsrOrCsrTemplate: sandbox.stub(),
+            applySsrOrCsrTemplate: env.sandbox.stub(),
           };
 
           list = createAmpList(element);
@@ -118,7 +119,7 @@ describes.repeated(
           const list = new AmpList(element);
           list.buildCallback();
           list.ssrTemplateHelper_ = ssrTemplateHelper;
-          listMock = sandbox.mock(list);
+          listMock = env.sandbox.mock(list);
           return list;
         }
 
@@ -298,7 +299,7 @@ describes.repeated(
           });
 
           it('should dispatch DOM_UPDATE event after render', () => {
-            const spy = sandbox.spy(list.container_, 'dispatchEvent');
+            const spy = env.sandbox.spy(list.container_, 'dispatchEvent');
 
             const itemElement = doc.createElement('div');
             expectFetchAndRender(DEFAULT_FETCHED_DATA, [itemElement]);
@@ -313,7 +314,7 @@ describes.repeated(
           });
 
           it('should resize with viewport', () => {
-            const resize = sandbox.spy(list, 'attemptToFit_');
+            const resize = env.sandbox.spy(list, 'attemptToFit_');
             list.layoutCallback().then(() => {
               list.viewport_.resize_();
               expect(resize).to.have.been.called;
@@ -322,8 +323,11 @@ describes.repeated(
 
           // TODO(choumx, #14772): Flaky.
           it.skip('should only process one result at a time for rendering', () => {
-            const doRenderPassSpy = sandbox.spy(list, 'doRenderPass_');
-            const scheduleRenderSpy = sandbox.spy(list.renderPass_, 'schedule');
+            const doRenderPassSpy = env.sandbox.spy(list, 'doRenderPass_');
+            const scheduleRenderSpy = env.sandbox.spy(
+              list.renderPass_,
+              'schedule'
+            );
 
             const items = [{title: 'foo'}];
             const foo = doc.createElement('div');
@@ -397,7 +401,7 @@ describes.repeated(
           });
 
           it('fetch should resolve if `src` is empty', () => {
-            const spy = sandbox.spy(list, 'fetchList_');
+            const spy = env.sandbox.spy(list, 'fetchList_');
             element.setAttribute('src', '');
             return list.layoutCallback().then(() => {
               expect(spy).to.be.called;
@@ -519,8 +523,8 @@ describes.repeated(
           });
 
           it('should trigger "fetch-error" event on fetch failure', function*() {
-            const actions = {trigger: sandbox.spy()};
-            sandbox.stub(Services, 'actionServiceForDoc').returns(actions);
+            const actions = {trigger: env.sandbox.spy()};
+            env.sandbox.stub(Services, 'actionServiceForDoc').returns(actions);
 
             // Stub fetch_() to fail.
             listMock
@@ -537,7 +541,7 @@ describes.repeated(
             expect(actions.trigger).to.be.calledWithExactly(
               list.element,
               'fetch-error',
-              sinon.match.any,
+              env.sandbox.match.any,
               ActionTrust.LOW
             );
           });
@@ -688,11 +692,13 @@ describes.repeated(
 
           describe('SSR templates', () => {
             beforeEach(() => {
-              sandbox.stub(ssrTemplateHelper, 'isSupported').returns(true);
+              env.sandbox.stub(ssrTemplateHelper, 'isSupported').returns(true);
             });
 
             it('should error if proxied fetch fails', () => {
-              sandbox.stub(ssrTemplateHelper, 'ssr').returns(Promise.reject());
+              env.sandbox
+                .stub(ssrTemplateHelper, 'ssr')
+                .returns(Promise.reject());
 
               listMock
                 .expects('toggleLoading')
@@ -708,7 +714,7 @@ describes.repeated(
 
             it('should error if proxied fetch returns invalid data', () => {
               expectAsyncConsoleError(/received no response/, 1);
-              sandbox
+              env.sandbox
                 .stub(ssrTemplateHelper, 'ssr')
                 .returns(Promise.resolve(undefined));
               listMock
@@ -722,7 +728,7 @@ describes.repeated(
 
             it('should error if proxied fetch returns non-2xx status (error) in the response', () => {
               expectAsyncConsoleError(/received no response/, 1);
-              sandbox
+              env.sandbox
                 .stub(ssrTemplateHelper, 'ssr')
                 .returns(Promise.resolve({init: {status: 400}}));
               listMock
@@ -752,7 +758,7 @@ describes.repeated(
               const listItem = document.createElement('div');
               listItem.setAttribute('role', 'item');
               listContainer.appendChild(listItem);
-              sandbox
+              env.sandbox
                 .stub(ssrTemplateHelper, 'ssr')
                 .returns(Promise.resolve({html}));
               ssrTemplateHelper.applySsrOrCsrTemplate.returns(
@@ -773,17 +779,17 @@ describes.repeated(
 
               yield list.layoutCallback();
 
-              const request = sinon.match({
+              const request = env.sandbox.match({
                 xhrUrl:
                   'https://data.com/list.json?__amp_source_origin=about%3Asrcdoc',
-                fetchOpt: sinon.match({
+                fetchOpt: env.sandbox.match({
                   headers: {Accept: 'application/json'},
                   method: 'GET',
                   responseType: 'application/json',
                 }),
               });
-              const attrs = sinon.match({
-                ampListAttributes: sinon.match({
+              const attrs = env.sandbox.match({
+                ampListAttributes: env.sandbox.match({
                   items: 'items',
                   maxItems: null,
                   singleItem: false,
@@ -822,7 +828,7 @@ describes.repeated(
                 .once();
               templates.findAndRenderTemplate.returns(Promise.resolve([]));
               // Act as if a fallback is already displayed.
-              sandbox.stub(list, 'fallbackDisplayed_').callsFake(true);
+              env.sandbox.stub(list, 'fallbackDisplayed_').callsFake(true);
 
               listMock.expects('togglePlaceholder').never();
               listMock
@@ -857,7 +863,7 @@ describes.repeated(
 
           beforeEach(() => {
             bind = {
-              rescan: sandbox.stub().returns(Promise.resolve()),
+              rescan: env.sandbox.stub().returns(Promise.resolve()),
               signals: () => {
                 return {get: unusedName => false};
               },
@@ -917,11 +923,13 @@ describes.repeated(
             "should fetch with viewer auth token if 'crossorigin=" +
               "amp-viewer-auth-token-via-post' attribute is present",
             () => {
-              sandbox.stub(Services, 'viewerAssistanceForDocOrNull').returns(
-                Promise.resolve({
-                  getIdTokenPromise: () => Promise.resolve('idToken'),
-                })
-              );
+              env.sandbox
+                .stub(Services, 'viewerAssistanceForDocOrNull')
+                .returns(
+                  Promise.resolve({
+                    getIdTokenPromise: () => Promise.resolve('idToken'),
+                  })
+                );
               element.setAttribute(
                 'crossorigin',
                 'amp-viewer-auth-token-via-post'
@@ -984,7 +992,7 @@ describes.repeated(
               });
 
               expect(bind.rescan).to.be.calledOnce;
-              expect(bind.rescan).to.be.calledWith([], sinon.match.array);
+              expect(bind.rescan).to.be.calledWith([], env.sandbox.match.array);
             });
           });
 

--- a/extensions/amp-live-list/0.1/test/test-amp-live-list.js
+++ b/extensions/amp-live-list/0.1/test/test-amp-live-list.js
@@ -28,7 +28,6 @@ describes.realWin(
   },
   function(env) {
     let win;
-    let sandbox;
     let ampdoc;
     let liveList;
     let elem;
@@ -37,7 +36,6 @@ describes.realWin(
 
     beforeEach(() => {
       win = env.win;
-      sandbox = sinon.sandbox;
       ampdoc = new AmpDocSingle(win);
       elem = document.createElement('amp-live-list');
       elem.getAmpDoc = () => ampdoc;
@@ -54,10 +52,6 @@ describes.realWin(
         'data-max-items-per-page': 5,
         'data-sort-time': Date.now(),
       };
-    });
-
-    afterEach(() => {
-      sandbox.restore();
     });
 
     function buildElement(elem, attrs) {
@@ -143,7 +137,7 @@ describes.realWin(
       const child = document.createElement('div');
       elem.querySelector('[items]').appendChild(child);
       buildElement(elem, dftAttrs);
-      const stub = sandbox.stub(liveList, 'countAndCacheValidItems_');
+      const stub = env.sandbox.stub(liveList, 'countAndCacheValidItems_');
       expect(stub).to.have.not.been.called;
       liveList.buildCallback();
       expect(stub).to.be.calledOnce;
@@ -159,7 +153,7 @@ describes.realWin(
       elem.querySelector('[items]').appendChild(invalidChild);
 
       buildElement(elem, dftAttrs);
-      const spy = sandbox.spy(liveList, 'countAndCacheValidItems_');
+      const spy = env.sandbox.spy(liveList, 'countAndCacheValidItems_');
       liveList.buildCallback();
       expect(spy).to.have.returned(1);
     });
@@ -312,7 +306,7 @@ describes.realWin(
       it('sends amp-dom-update event on new items', () => {
         buildElement(elem, dftAttrs);
         liveList.buildCallback();
-        const spy = sandbox.spy(liveList, 'sendAmpDomUpdateEvent_');
+        const spy = env.sandbox.spy(liveList, 'sendAmpDomUpdateEvent_');
         const fromServer1 = createFromServer([{id: 'id0'}]);
         liveList.update(fromServer1);
         return liveList.updateAction_().then(() => {
@@ -333,9 +327,9 @@ describes.realWin(
         liveList.buildCallback();
 
         const fromServer1 = createFromServer([{id: 'id1', updateTime: 125}]);
-        const spy = sandbox.spy(liveList, 'sendAmpDomUpdateEvent_');
+        const spy = env.sandbox.spy(liveList, 'sendAmpDomUpdateEvent_');
         // We stub and restore to not trigger `update` calling `updateAction_`.
-        const stub = sinon./*OK*/ stub(liveList, 'updateAction_');
+        const stub = env.sandbox./*OK*/ stub(liveList, 'updateAction_');
         liveList.update(fromServer1);
         stub./*OK*/ restore();
         return liveList.updateAction_().then(() => {
@@ -356,9 +350,9 @@ describes.realWin(
         liveList.buildCallback();
 
         const fromServer1 = createFromServer([{id: 'id1', tombstone: null}]);
-        const spy = sandbox.spy(liveList, 'sendAmpDomUpdateEvent_');
+        const spy = env.sandbox.spy(liveList, 'sendAmpDomUpdateEvent_');
         // We stub and restore to not trigger `update` calling `updateAction_`.
-        const stub = sinon./*OK*/ stub(liveList, 'updateAction_');
+        const stub = env.sandbox./*OK*/ stub(liveList, 'updateAction_');
         liveList.update(fromServer1);
         stub./*OK*/ restore();
         return liveList.updateAction_().then(() => {
@@ -379,9 +373,9 @@ describes.realWin(
         liveList.buildCallback();
 
         const fromServer1 = createFromServer([{id: 'id1', updateTime: 125}]);
-        const spy = sandbox.spy(liveList.itemsSlot_, 'dispatchEvent');
+        const spy = env.sandbox.spy(liveList.itemsSlot_, 'dispatchEvent');
         // We stub and restore to not trigger `update` calling `updateAction_`.
-        const stub = sinon./*OK*/ stub(liveList, 'updateAction_');
+        const stub = env.sandbox./*OK*/ stub(liveList, 'updateAction_');
         liveList.update(fromServer1);
         stub./*OK*/ restore();
         return liveList.updateAction_().then(() => {
@@ -399,7 +393,7 @@ describes.realWin(
         updateLiveListItems.setAttribute('items', '');
         update.appendChild(updateLiveListItems);
         updateLiveListItems.appendChild(document.createElement('div'));
-        const stub = sandbox.stub(liveList, 'countAndCacheValidItems_');
+        const stub = env.sandbox.stub(liveList, 'countAndCacheValidItems_');
         expect(stub).to.have.not.been.called;
         liveList.update(update);
         expect(stub).to.be.calledOnce;
@@ -408,7 +402,7 @@ describes.realWin(
       it('should call updateFixedLayer on update with inserts', () => {
         buildElement(elem, dftAttrs);
         liveList.buildCallback();
-        const spy = sandbox.spy(liveList.viewport_, 'updateFixedLayer');
+        const spy = env.sandbox.spy(liveList.viewport_, 'updateFixedLayer');
         expect(liveList.itemsSlot_.childElementCount).to.equal(0);
         const fromServer1 = createFromServer([{id: 'id0'}]);
         expect(spy).to.have.not.been.called;
@@ -671,7 +665,7 @@ describes.realWin(
         {id: 'id3'},
       ]);
 
-      const spy = sandbox.spy(liveList, 'updateAction_');
+      const spy = env.sandbox.spy(liveList, 'updateAction_');
       liveList.update(fromServer1);
 
       expect(liveList.pendingItemsInsert_).to.have.length(1);
@@ -704,7 +698,7 @@ describes.realWin(
         {id: 'id3'},
       ]);
 
-      const spy = sandbox.spy(liveList, 'updateAction_');
+      const spy = env.sandbox.spy(liveList, 'updateAction_');
       liveList.update(fromServer1);
 
       expect(liveList.pendingItemsInsert_).to.have.length(1);
@@ -727,7 +721,7 @@ describes.realWin(
 
       const fromServer1 = createFromServer([{id: 'id1', updateTime: 125}]);
 
-      const spy = sandbox.spy(liveList, 'updateAction_');
+      const spy = env.sandbox.spy(liveList, 'updateAction_');
       liveList.update(fromServer1);
 
       expect(liveList.pendingItemsInsert_).to.have.length(0);
@@ -754,7 +748,7 @@ describes.realWin(
         {id: 'id3'},
       ]);
 
-      const spy = sandbox.spy(liveList, 'updateAction_');
+      const spy = env.sandbox.spy(liveList, 'updateAction_');
       liveList.update(fromServer1);
 
       expect(liveList.pendingItemsReplace_).to.have.length(1);
@@ -1048,9 +1042,12 @@ describes.realWin(
         elem,
         Object.assign({}, dftAttrs, {'data-max-items-per-page': 2})
       );
-      sandbox.stub(liveList, 'isElementBelowViewport_').returns(true);
+      env.sandbox.stub(liveList, 'isElementBelowViewport_').returns(true);
       liveList.buildCallback();
-      const removeChildSpy = sandbox.spy(liveList.itemsSlot_, 'removeChild');
+      const removeChildSpy = env.sandbox.spy(
+        liveList.itemsSlot_,
+        'removeChild'
+      );
 
       const fromServer1 = createFromServer([{id: 'id3', sortTime: '122'}]);
 
@@ -1095,13 +1092,16 @@ describes.realWin(
         elem,
         Object.assign({}, dftAttrs, {'data-max-items-per-page': 2})
       );
-      const pred = sandbox.stub(liveList, 'isElementBelowViewport_');
+      const pred = env.sandbox.stub(liveList, 'isElementBelowViewport_');
       // id1
       pred.onCall(0).returns(true);
       // Anything else
       pred.returns(false);
       liveList.buildCallback();
-      const removeChildSpy = sandbox.spy(liveList.itemsSlot_, 'removeChild');
+      const removeChildSpy = env.sandbox.spy(
+        liveList.itemsSlot_,
+        'removeChild'
+      );
 
       const fromServer1 = createFromServer([
         {id: 'id3'},
@@ -1159,8 +1159,11 @@ describes.realWin(
       itemsSlot.appendChild(child1);
       buildElement(elem, dftAttrs);
       liveList.buildCallback();
-      sandbox.stub(liveList, 'isElementBelowViewport_').returns(true);
-      const removeChildSpy = sandbox.spy(liveList.itemsSlot_, 'removeChild');
+      env.sandbox.stub(liveList, 'isElementBelowViewport_').returns(true);
+      const removeChildSpy = env.sandbox.spy(
+        liveList.itemsSlot_,
+        'removeChild'
+      );
 
       const fromServer = createFromServer([
         {id: 'id3', sortTime: 110},
@@ -1347,9 +1350,12 @@ describes.realWin(
             'sort': 'ascending',
           })
         );
-        sandbox.stub(liveList, 'isElementAboveViewport_').returns(true);
+        env.sandbox.stub(liveList, 'isElementAboveViewport_').returns(true);
         liveList.buildCallback();
-        const removeChildSpy = sandbox.spy(liveList.itemsSlot_, 'removeChild');
+        const removeChildSpy = env.sandbox.spy(
+          liveList.itemsSlot_,
+          'removeChild'
+        );
 
         const fromServer1 = createFromServer([{id: 'id3', sortTime: '125'}]);
 
@@ -1397,13 +1403,16 @@ describes.realWin(
             'sort': 'ascending',
           })
         );
-        const pred = sandbox.stub(liveList, 'isElementAboveViewport_');
+        const pred = env.sandbox.stub(liveList, 'isElementAboveViewport_');
         // id1
         pred.onCall(0).returns(true);
         // Anything else
         pred.returns(false);
         liveList.buildCallback();
-        const removeChildSpy = sandbox.spy(liveList.itemsSlot_, 'removeChild');
+        const removeChildSpy = env.sandbox.spy(
+          liveList.itemsSlot_,
+          'removeChild'
+        );
 
         const fromServer1 = createFromServer([
           {id: 'id3'},

--- a/extensions/amp-live-list/0.1/test/test-live-list-manager.js
+++ b/extensions/amp-live-list/0.1/test/test-live-list-manager.js
@@ -30,26 +30,26 @@ describes.fakeWin('LiveListManager', {amp: true}, env => {
   let xhrs;
   let clock;
   let ready;
-  let sandbox;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox;
     win = env.win;
     doc = win.document;
     ampdoc = env.ampdoc;
 
-    clock = sandbox.useFakeTimers();
-    xhrs = setUpMockXhrs(sandbox);
+    clock = env.sandbox.useFakeTimers();
+    xhrs = setUpMockXhrs(env.sandbox);
 
     manager = new LiveListManager(ampdoc);
     const docReadyPromise = new Promise(resolve => {
       ready = resolve;
     });
-    sandbox.stub(manager, 'whenDocReady_').returns(docReadyPromise);
-    sandbox.stub(LiveListManager, 'forDoc').returns(Promise.resolve(manager));
+    env.sandbox.stub(manager, 'whenDocReady_').returns(docReadyPromise);
+    env.sandbox
+      .stub(LiveListManager, 'forDoc')
+      .returns(Promise.resolve(manager));
 
     liveList = getLiveList({'data-sort-time': '1111'});
-    sandbox.stub(liveList, 'getInterval').callsFake(() => 5000);
+    env.sandbox.stub(liveList, 'getInterval').callsFake(() => 5000);
   });
 
   function setUpMockXhrs(sandbox) {
@@ -65,10 +65,6 @@ describes.fakeWin('LiveListManager', {amp: true}, env => {
     };
     return xhrs;
   }
-
-  afterEach(() => {
-    sandbox.restore();
-  });
 
   /** @implements {!LiveListInterface} */
   class AmpLiveListMock {
@@ -135,7 +131,7 @@ describes.fakeWin('LiveListManager', {amp: true}, env => {
   });
 
   it('should start poller when doc is ready', () => {
-    sandbox.stub(ampdoc, 'isVisible').returns(true);
+    env.sandbox.stub(ampdoc, 'isVisible').returns(true);
     expect(manager.poller_).to.be.null;
     liveList.buildCallback();
     ready();
@@ -145,7 +141,7 @@ describes.fakeWin('LiveListManager', {amp: true}, env => {
   });
 
   it('should not start poller when no live-list is registered', () => {
-    sandbox.stub(ampdoc, 'isVisible').returns(true);
+    env.sandbox.stub(ampdoc, 'isVisible').returns(true);
     expect(manager.poller_).to.be.null;
     ready();
     return manager.whenDocReady_().then(() => {
@@ -174,7 +170,7 @@ describes.fakeWin('LiveListManager', {amp: true}, env => {
       const fromServer = doc.createElement('div');
       fromServer.appendChild(customSlot);
       fromServer.getElementById = () => {};
-      sandbox.stub(fromServer, 'getElementById').callsFake(id => {
+      env.sandbox.stub(fromServer, 'getElementById').callsFake(id => {
         return fromServer.querySelector(`#${id}`);
       });
 
@@ -199,7 +195,7 @@ describes.fakeWin('LiveListManager', {amp: true}, env => {
   );
 
   it('should get the amp_latest_update_time on doc ready', () => {
-    sandbox.stub(Math, 'random').callsFake(() => 1);
+    env.sandbox.stub(Math, 'random').callsFake(() => 1);
     ready();
     const liveList2 = getLiveList({'data-sort-time': '2222'}, 'id-2');
     liveList.buildCallback();
@@ -422,8 +418,8 @@ describes.fakeWin('LiveListManager', {amp: true}, env => {
     liveList.buildCallback();
     liveList2.buildCallback();
     liveList2.toggle(false);
-    const updateSpy1 = sandbox.spy(liveList, 'update');
-    const updateSpy2 = sandbox.spy(liveList2, 'update');
+    const updateSpy1 = env.sandbox.spy(liveList, 'update');
+    const updateSpy2 = env.sandbox.spy(liveList2, 'update');
 
     expect(liveList.isEnabled()).to.be.true;
     expect(liveList2.isEnabled()).to.be.false;
@@ -466,9 +462,9 @@ describes.fakeWin('LiveListManager', {amp: true}, env => {
   });
 
   it('should back off on transient 415 response', () => {
-    sandbox.stub(Math, 'random').callsFake(() => 1);
+    env.sandbox.stub(Math, 'random').callsFake(() => 1);
     ready();
-    const fetchSpy = sandbox.spy(manager, 'work_');
+    const fetchSpy = env.sandbox.spy(manager, 'work_');
     liveList.buildCallback();
     return manager.whenDocReady_().then(() => {
       const interval = liveList.getInterval();
@@ -510,9 +506,9 @@ describes.fakeWin('LiveListManager', {amp: true}, env => {
   });
 
   it('should back off on transient 500 response', () => {
-    sandbox.stub(Math, 'random').callsFake(() => 1);
+    env.sandbox.stub(Math, 'random').callsFake(() => 1);
     ready();
-    const fetchSpy = sandbox.spy(manager, 'work_');
+    const fetchSpy = env.sandbox.spy(manager, 'work_');
     liveList.buildCallback();
     return manager.whenDocReady_().then(() => {
       const interval = liveList.getInterval();
@@ -554,10 +550,10 @@ describes.fakeWin('LiveListManager', {amp: true}, env => {
   });
 
   it('should recover after transient 415 response', () => {
-    sandbox.stub(Math, 'random').callsFake(() => 1);
-    sandbox.stub(ampdoc, 'isVisible').returns(true);
+    env.sandbox.stub(Math, 'random').callsFake(() => 1);
+    env.sandbox.stub(ampdoc, 'isVisible').returns(true);
     ready();
-    const fetchSpy = sandbox.spy(manager, 'work_');
+    const fetchSpy = env.sandbox.spy(manager, 'work_');
     liveList.buildCallback();
     return manager.whenDocReady_().then(() => {
       const interval = liveList.getInterval();
@@ -604,7 +600,7 @@ describes.fakeWin('LiveListManager', {amp: true}, env => {
       'and immediately fetch when visible',
     () => {
       ready();
-      const fetchSpy = sandbox.spy(manager, 'work_');
+      const fetchSpy = env.sandbox.spy(manager, 'work_');
       expect(fetchSpy).to.have.not.been.called;
       liveList.buildCallback();
       return manager.whenDocReady_().then(() => {
@@ -632,11 +628,11 @@ describes.fakeWin('LiveListManager', {amp: true}, env => {
   );
 
   it('should fetch with url', () => {
-    sandbox.stub(Math, 'random').callsFake(() => 1);
-    sandbox.stub(ampdoc, 'isVisible').returns(true);
+    env.sandbox.stub(Math, 'random').callsFake(() => 1);
+    env.sandbox.stub(ampdoc, 'isVisible').returns(true);
     manager.url_ = 'www.example.com/foo/bar?hello=world#dev=1';
     ready();
-    const fetchSpy = sandbox.spy(manager, 'work_');
+    const fetchSpy = env.sandbox.spy(manager, 'work_');
     liveList.buildCallback();
     return manager.whenDocReady_().then(() => {
       const interval = liveList.getInterval();
@@ -657,12 +653,12 @@ describes.fakeWin('LiveListManager', {amp: true}, env => {
     'should fetch with url from the cache if on publisher origin ' +
       'and is transformed',
     () => {
-      sandbox.stub(Math, 'random').callsFake(() => 1);
-      sandbox.stub(ampdoc, 'isVisible').returns(true);
+      env.sandbox.stub(Math, 'random').callsFake(() => 1);
+      env.sandbox.stub(ampdoc, 'isVisible').returns(true);
       manager.url_ = 'https://www.example.com/foo/bar?hello=world#dev=1';
       manager.isTransformed_ = true;
       ready();
-      const fetchSpy = sandbox.spy(manager, 'work_');
+      const fetchSpy = env.sandbox.spy(manager, 'work_');
       liveList.buildCallback();
       return manager.whenDocReady_().then(() => {
         const interval = liveList.getInterval();
@@ -686,15 +682,15 @@ describes.fakeWin('LiveListManager', {amp: true}, env => {
     'should not fetch with url from the cache if on cache origin ' +
       'and is not transformed',
     () => {
-      sandbox.stub(Math, 'random').callsFake(() => 1);
-      sandbox.stub(ampdoc, 'isVisible').returns(true);
+      env.sandbox.stub(Math, 'random').callsFake(() => 1);
+      env.sandbox.stub(ampdoc, 'isVisible').returns(true);
       manager.url_ = 'www.example.com/foo/bar?hello=world#dev=1';
       manager.isTransformed_ = false;
       manager.location_ =
         'https://cdn.ampproject.org' +
         '/c/s/www.example.com/foo/bar?hello=world#dev=1';
       ready();
-      const fetchSpy = sandbox.spy(manager, 'work_');
+      const fetchSpy = env.sandbox.spy(manager, 'work_');
       liveList.buildCallback();
       return manager.whenDocReady_().then(() => {
         const interval = liveList.getInterval();
@@ -716,8 +712,8 @@ describes.fakeWin('LiveListManager', {amp: true}, env => {
     const doc = [];
     const list1 = getLiveList(undefined, 'id1');
     const list2 = getLiveList(undefined, 'id2');
-    sandbox.stub(list1, 'update').returns(1000);
-    sandbox.stub(list2, 'update').returns(2000);
+    env.sandbox.stub(list1, 'update').returns(1000);
+    env.sandbox.stub(list2, 'update').returns(2000);
     doc.getElementsByTagName = () => {
       return [list1.element, list2.element];
     };
@@ -730,13 +726,13 @@ describes.fakeWin('LiveListManager', {amp: true}, env => {
   });
 
   it('should add amp_latest_update_time on requests', () => {
-    sandbox.stub(Math, 'random').callsFake(() => 1);
-    sandbox.stub(ampdoc, 'isVisible').returns(true);
+    env.sandbox.stub(Math, 'random').callsFake(() => 1);
+    env.sandbox.stub(ampdoc, 'isVisible').returns(true);
     manager.url_ = 'www.example.com/foo/bar?hello=world#dev=1';
-    sandbox.stub(liveList, 'update').returns(2500);
+    env.sandbox.stub(liveList, 'update').returns(2500);
     ready();
     liveList.buildCallback();
-    const fetchSpy = sandbox.spy(manager, 'work_');
+    const fetchSpy = env.sandbox.spy(manager, 'work_');
     return manager.whenDocReady_().then(() => {
       const interval = liveList.getInterval();
       const tick = interval - jitterOffset;
@@ -784,7 +780,9 @@ describes.realWin(
       ampdoc = env.ampdoc;
       extensions = env.extensions;
       manager = new LiveListManager(ampdoc);
-      sandbox.stub(LiveListManager, 'forDoc').returns(Promise.resolve(manager));
+      env.sandbox
+        .stub(LiveListManager, 'forDoc')
+        .returns(Promise.resolve(manager));
     });
 
     it('should install newly discovered script tags on xhr doc', () => {

--- a/extensions/amp-live-list/0.1/test/test-poller.js
+++ b/extensions/amp-live-list/0.1/test/test-poller.js
@@ -18,26 +18,20 @@ import {Poller} from '../poller';
 import {Services} from '../../../../src/services';
 
 describe('Poller', () => {
-  let sandbox;
   let clock;
   let poller;
   let workStub;
   const timer = Services.timerFor(window);
 
   beforeEach(() => {
-    sandbox = sinon.sandbox;
-    clock = sandbox.useFakeTimers();
+    clock = window.sandbox.useFakeTimers();
     const obj = {
       work() {},
     };
-    workStub = sandbox.stub(obj, 'work');
-    sandbox.stub(Math, 'random').callsFake(() => 1);
+    workStub = window.sandbox.stub(obj, 'work');
+    window.sandbox.stub(Math, 'random').callsFake(() => 1);
     const wait = 5000;
     poller = new Poller(window, wait, workStub);
-  });
-
-  afterEach(() => {
-    sandbox.restore();
   });
 
   it('should be initialized in stopped state', () => {
@@ -249,13 +243,13 @@ describe('Poller', () => {
   });
 
   it('should clear timeout ids if stopped', () => {
-    const delaySpy = sandbox.spy(timer, 'delay');
+    const delaySpy = window.sandbox.spy(timer, 'delay');
     const retriableErr = new Error('HTTP Error');
     retriableErr.retriable = true;
     workStub.onCall(0).returns(Promise.reject(retriableErr));
     workStub.onCall(1).returns(Promise.reject(retriableErr));
     workStub.returns(Promise.resolve());
-    const clearSpy = sandbox.spy(timer, 'cancel');
+    const clearSpy = window.sandbox.spy(timer, 'cancel');
 
     expect(poller.lastTimeoutId_).to.be.null;
 

--- a/extensions/amp-mega-menu/0.1/test/test-amp-mega-menu.js
+++ b/extensions/amp-mega-menu/0.1/test/test-amp-mega-menu.js
@@ -28,12 +28,11 @@ describes.realWin(
     },
   },
   env => {
-    let win, doc, element, sandbox;
+    let win, doc, element;
 
     beforeEach(() => {
       win = env.win;
       doc = win.document;
-      sandbox = env.sandbox;
 
       element = getAmpMegaMenu();
       doc.body.appendChild(element);
@@ -204,11 +203,11 @@ describes.realWin(
       await element.unlayoutCallback();
       const impl = element.implementation_;
       const clickEvent = new Event('click');
-      const rootClickSpy = sandbox.spy(impl, 'handleRootClick_');
+      const rootClickSpy = env.sandbox.spy(impl, 'handleRootClick_');
       doc.documentElement.dispatchEvent(clickEvent);
       expect(rootClickSpy).to.not.be.called;
       const keydownEvent = new KeyboardEvent('keydown');
-      const rootKeyDownSpy = sandbox.spy(impl, 'handleRootKeyDown_');
+      const rootKeyDownSpy = env.sandbox.spy(impl, 'handleRootKeyDown_');
       doc.documentElement.dispatchEvent(keydownEvent);
       expect(rootKeyDownSpy).to.not.be.called;
     });

--- a/extensions/amp-mustache/0.1/test/test-amp-mustache.js
+++ b/extensions/amp-mustache/0.1/test/test-amp-mustache.js
@@ -28,18 +28,17 @@ describes.repeated(
     'with template[type=amp-mustache]': {templateType: 'template'},
   },
   (name, variant) => {
-    let sandbox;
     let viewerCanRenderTemplates = false;
 
     beforeEach(() => {
-      sandbox = sinon.sandbox;
-      const getServiceForDocStub = sandbox.stub(service, 'getServiceForDoc');
+      const getServiceForDocStub = window.sandbox.stub(
+        service,
+        'getServiceForDoc'
+      );
       getServiceForDocStub.returns({
         hasCapability: unused => viewerCanRenderTemplates,
       });
     });
-
-    afterEach(() => sandbox.restore());
 
     let innerHtmlSetup;
     let template;
@@ -574,14 +573,14 @@ describes.repeated(
       });
 
       it('should not call mustache parsing', () => {
-        sandbox.spy(mustache, 'parse');
+        window.sandbox.spy(mustache, 'parse');
         template.compileCallback();
         expect(mustache.parse).to.have.not.been.called;
       });
 
       it('should not mustache render but still sanitize html', () => {
-        sandbox.spy(sanitizer, 'sanitizeHtml');
-        sandbox.spy(mustache, 'render');
+        window.sandbox.spy(sanitizer, 'sanitizeHtml');
+        window.sandbox.spy(mustache, 'render');
         template.setHtml('<div>test</div>');
         expect(mustache.render).to.have.not.been.called;
         expect(sanitizer.sanitizeHtml).to.have.been.called;

--- a/extensions/amp-mustache/0.2/test/test-amp-mustache.js
+++ b/extensions/amp-mustache/0.2/test/test-amp-mustache.js
@@ -28,18 +28,17 @@ describes.repeated(
     'with template[type=amp-mustache]': {templateType: 'template'},
   },
   (name, variant) => {
-    let sandbox;
     let viewerCanRenderTemplates = false;
 
     beforeEach(() => {
-      sandbox = sinon.sandbox;
-      const getServiceForDocStub = sandbox.stub(service, 'getServiceForDoc');
+      const getServiceForDocStub = window.sandbox.stub(
+        service,
+        'getServiceForDoc'
+      );
       getServiceForDocStub.returns({
         hasCapability: unused => viewerCanRenderTemplates,
       });
     });
-
-    afterEach(() => sandbox.restore());
 
     // This test suite runs twice. First by creating templates of type template
     // and then by creating templates encapsulated within script.
@@ -566,14 +565,14 @@ describes.repeated(
       });
 
       it('should not call mustache parsing', () => {
-        sandbox.spy(mustache, 'parse');
+        window.sandbox.spy(mustache, 'parse');
         template.compileCallback();
         expect(mustache.parse).to.have.not.been.called;
       });
 
       it('should not mustache render but still purify html', () => {
-        sandbox.spy(purifier, 'purifyHtml');
-        sandbox.spy(mustache, 'render');
+        window.sandbox.spy(purifier, 'purifyHtml');
+        window.sandbox.spy(mustache, 'render');
         template.setHtml('<div>test</div>');
         expect(mustache.render).to.have.not.been.called;
         expect(purifier.purifyHtml).to.have.been.called;

--- a/extensions/amp-next-page/0.1/test/test-amp-next-page.js
+++ b/extensions/amp-next-page/0.1/test/test-amp-next-page.js
@@ -64,14 +64,14 @@ describes.realWin(
 
       ampdoc.getUrl = () => document.location.href;
 
-      fetchDocumentMock = sandbox.mock(DocFetcher);
-      sandbox
+      fetchDocumentMock = env.sandbox.mock(DocFetcher);
+      env.sandbox
         .stub(Services.resourcesForDoc(ampdoc), 'mutateElement')
         .callsFake((unused, mutator) => {
           mutator();
           return Promise.resolve();
         });
-      sandbox.stub(nextPage, 'mutateElement').callsFake(mutator => {
+      env.sandbox.stub(nextPage, 'mutateElement').callsFake(mutator => {
         mutator();
         return Promise.resolve();
       });
@@ -109,9 +109,9 @@ describes.realWin(
       });
 
       it('does not fetch the next document before 3 viewports away', function*() {
-        const xhrMock = sandbox.mock(Services.xhrFor(win));
+        const xhrMock = env.sandbox.mock(Services.xhrFor(win));
         xhrMock.expects('fetch').never();
-        sandbox
+        env.sandbox
           .stub(viewport, 'getClientRectAsync')
           // 4x viewports away
           .resolves(layoutRectLtwh(0, 0, sizes.width, sizes.height * 5));
@@ -124,7 +124,7 @@ describes.realWin(
 
       it('fetches the next document within 3 viewports away', function*() {
         env.fetchMock.get('*', EXAMPLE_PAGE);
-        sandbox
+        env.sandbox
           .stub(viewport, 'getClientRectAsync')
           // 1x viewport away
           .resolves(layoutRectLtwh(0, 0, sizes.width, sizes.height * 2));
@@ -136,14 +136,14 @@ describes.realWin(
       });
 
       it('only fetches the next document once', function*() {
-        const xhrMock = sandbox.mock(Services.xhrFor(win));
+        const xhrMock = env.sandbox.mock(Services.xhrFor(win));
         // Promise which is never resolved.
         xhrMock
           .expects('fetch')
           .returns(new Promise(() => {}))
           .once();
 
-        sandbox
+        env.sandbox
           .stub(viewport, 'getClientRectAsync')
           // 1x viewport away
           .resolves(layoutRectLtwh(0, 0, sizes.width, sizes.height * 2));
@@ -162,12 +162,12 @@ describes.realWin(
           ampdoc,
           'next-page'
         );
-        const attachShadowDocSpy = sandbox.spy(
+        const attachShadowDocSpy = env.sandbox.spy(
           nextPageService.multidocManager_,
           'attachShadowDoc'
         );
 
-        sandbox
+        env.sandbox
           .stub(viewport, 'getClientRectAsync')
           .onFirstCall()
           // 1x viewport away
@@ -200,11 +200,11 @@ describes.realWin(
           ampdoc,
           'next-page'
         );
-        const attachShadowDocSpy = sandbox.spy(
+        const attachShadowDocSpy = env.sandbox.spy(
           nextPageService.multidocManager_,
           'attachShadowDoc'
         );
-        sandbox
+        env.sandbox
           .stub(viewport, 'getClientRectAsync')
           .onFirstCall()
           // 1x viewport away
@@ -229,11 +229,11 @@ describes.realWin(
           ampdoc,
           'next-page'
         );
-        const attachShadowDocSpy = sandbox.spy(
+        const attachShadowDocSpy = env.sandbox.spy(
           nextPageService.multidocManager_,
           'attachShadowDoc'
         );
-        sandbox
+        env.sandbox
           .stub(viewport, 'getClientRectAsync')
           .onFirstCall()
           // 1x viewport away
@@ -268,7 +268,7 @@ describes.realWin(
         const srcUrl = 'https://example.com/config.json';
         element.setAttribute('src', srcUrl);
 
-        const fetchJsonStub = sandbox
+        const fetchJsonStub = env.sandbox
           .stub(Services.batchedXhrFor(win), 'fetchJson')
           .resolves({
             ok: true,
@@ -280,7 +280,7 @@ describes.realWin(
           ampdoc,
           'next-page'
         );
-        const registerSpy = sandbox.spy(nextPageService, 'register');
+        const registerSpy = env.sandbox.spy(nextPageService, 'register');
 
         yield nextPage.buildCallback();
         yield macroTask();
@@ -390,7 +390,7 @@ describes.realWin(
           ampdoc,
           'next-page'
         );
-        const registerSpy = sandbox.spy(nextPageService, 'register');
+        const registerSpy = env.sandbox.spy(nextPageService, 'register');
 
         yield nextPage.buildCallback();
         yield macroTask();
@@ -475,7 +475,7 @@ describes.realWin(
           ampdoc,
           'next-page'
         );
-        const registerSpy = sandbox.spy(nextPageService, 'register');
+        const registerSpy = env.sandbox.spy(nextPageService, 'register');
 
         yield nextPage.buildCallback();
         yield macroTask();
@@ -503,7 +503,7 @@ describes.realWin(
           ampdoc,
           'next-page'
         );
-        const registerSpy = sandbox.spy(nextPageService, 'register');
+        const registerSpy = env.sandbox.spy(nextPageService, 'register');
 
         yield nextPage.buildCallback();
         yield macroTask();
@@ -545,12 +545,12 @@ describes.realWin(
           ampdoc,
           'next-page'
         );
-        const attachShadowDocSpy = sandbox.spy(
+        const attachShadowDocSpy = env.sandbox.spy(
           nextPageService.multidocManager_,
           'attachShadowDoc'
         );
 
-        sandbox
+        env.sandbox
           .stub(viewport, 'getClientRectAsync')
           .onFirstCall()
           // 1x viewport away

--- a/extensions/amp-pan-zoom/0.1/test/test-amp-pan-zoom.js
+++ b/extensions/amp-pan-zoom/0.1/test/test-amp-pan-zoom.js
@@ -31,7 +31,6 @@ describes.realWin(
   env => {
     let win;
     let doc;
-    let sandbox;
     let el;
     let impl;
     let svg;
@@ -68,10 +67,10 @@ describes.realWin(
       doc.body.appendChild(el);
       return el.build().then(() => {
         impl = el.implementation_;
-        sandbox
+        env.sandbox
           .stub(impl, 'measureMutateElement')
           .callsFake(measureMutateElementStub);
-        sandbox
+        env.sandbox
           .stub(impl, 'mutateElement')
           .callsFake(mutate => measureMutateElementStub(undefined, mutate));
       });
@@ -80,7 +79,6 @@ describes.realWin(
     beforeEach(() => {
       win = env.win;
       doc = win.document;
-      sandbox = env.sandbox;
       env.iframe.height = 500;
       env.iframe.width = 400;
     });
@@ -89,7 +87,7 @@ describes.realWin(
       let scheduleLayoutSpy;
       return getPanZoom()
         .then(() => {
-          scheduleLayoutSpy = sandbox.spy(
+          scheduleLayoutSpy = env.sandbox.spy(
             Services.ownersForDoc(impl.element),
             'scheduleLayout'
           );
@@ -330,7 +328,7 @@ describes.realWin(
         await getPanZoom();
         await el.layoutCallback();
         const transformEndPromise = listenOncePromise(el, 'transformEnd');
-        const actionTriggerSpy = sandbox.spy(impl.action_, 'trigger');
+        const actionTriggerSpy = env.sandbox.spy(impl.action_, 'trigger');
         impl.handleDoubleTap({clientX: 10, clientY: 10});
         await transformEndPromise;
         expect(actionTriggerSpy).to.be.calledOnce;
@@ -339,7 +337,7 @@ describes.realWin(
       it('should not trigger while pinch zooming', async function() {
         await getPanZoom();
         await el.layoutCallback();
-        const actionTriggerSpy = sandbox.spy(impl.action_, 'trigger');
+        const actionTriggerSpy = env.sandbox.spy(impl.action_, 'trigger');
         await impl.handlePinch({
           centerClientX: 10,
           centerClientY: 10,
@@ -355,7 +353,7 @@ describes.realWin(
         await getPanZoom();
         await el.layoutCallback();
         const transformEndPromise = listenOncePromise(el, 'transformEnd');
-        const actionTriggerSpy = sandbox.spy(impl.action_, 'trigger');
+        const actionTriggerSpy = env.sandbox.spy(impl.action_, 'trigger');
         impl.handlePinch({
           centerClientX: 10,
           centerClientY: 10,
@@ -371,7 +369,7 @@ describes.realWin(
       it('should not trigger while panning', async function() {
         await getPanZoom();
         await el.layoutCallback();
-        const actionTriggerSpy = sandbox.spy(impl.action_, 'trigger');
+        const actionTriggerSpy = env.sandbox.spy(impl.action_, 'trigger');
         await impl.handleSwipe({
           deltaX: 10,
           deltaY: 10,
@@ -386,7 +384,7 @@ describes.realWin(
         await getPanZoom();
         await el.layoutCallback();
         const transformEndPromise = listenOncePromise(el, 'transformEnd');
-        const actionTriggerSpy = sandbox.spy(impl.action_, 'trigger');
+        const actionTriggerSpy = env.sandbox.spy(impl.action_, 'trigger');
         impl.handleSwipe({
           deltaX: 10,
           deltaY: 10,

--- a/extensions/amp-position-observer/0.1/test/test-amp-position-observer.js
+++ b/extensions/amp-position-observer/0.1/test/test-amp-position-observer.js
@@ -24,7 +24,7 @@ import {RelativePositions, layoutRectLtwh} from '../../../../src/layout-rect';
  * - moves the container in the viewport and tests enter, exit, progress values,
  *   with various ratio and margin configurations
  */
-describes.sandboxed('amp-position-observer', {}, () => {
+describes.sandboxed('amp-position-observer', {}, env => {
   let impl;
   let enterSpy;
   let exitSpy;
@@ -52,9 +52,9 @@ describes.sandboxed('amp-position-observer', {}, () => {
     impl = new AmpVisibilityObserver(elem);
     impl.runOnce_ = runOnce;
     impl.parseAttributes_();
-    enterSpy = sandbox.stub(impl, 'triggerEnter_');
-    exitSpy = sandbox.stub(impl, 'triggerExit_');
-    scrollSpy = sandbox.stub(impl, 'triggerScroll_');
+    enterSpy = env.sandbox.stub(impl, 'triggerEnter_');
+    exitSpy = env.sandbox.stub(impl, 'triggerExit_');
+    scrollSpy = env.sandbox.stub(impl, 'triggerScroll_');
   }
 
   function resetSpies() {

--- a/extensions/amp-recaptcha-input/0.1/test/test-amp-recaptcha-service.js
+++ b/extensions/amp-recaptcha-input/0.1/test/test-amp-recaptcha-service.js
@@ -94,7 +94,7 @@ describes.realWin(
           expect(recaptchaService.unlisteners_.length).to.be.equal(3);
 
           // Stub out the unlisten function
-          const unlistener = sandbox.stub();
+          const unlistener = env.sandbox.stub();
           recaptchaService.unlisteners_[0] = unlistener;
 
           recaptchaService.unregister();
@@ -154,7 +154,7 @@ describes.realWin(
       () => {
         expect(recaptchaService.registeredElementCount_).to.be.equal(0);
 
-        const postMessageStub = sandbox.stub(
+        const postMessageStub = env.sandbox.stub(
           recaptchaService,
           'postMessageToIframe_'
         );

--- a/extensions/amp-script/0.1/test/integration/test-amp-script.js
+++ b/extensions/amp-script/0.1/test/integration/test-amp-script.js
@@ -64,7 +64,9 @@ describe
           // Give event listeners in hydration a moment to attach.
           yield browser.wait(100);
 
-          sandbox.stub(impl.userActivation_, 'isActive').callsFake(() => true);
+          env.sandbox
+            .stub(impl.userActivation_, 'isActive')
+            .callsFake(() => true);
           browser.click('button#hello');
 
           yield poll('mutations applied', () => {
@@ -82,7 +84,9 @@ describe
           // Give event listeners in hydration a moment to attach.
           yield browser.wait(100);
 
-          sandbox.stub(impl.userActivation_, 'isActive').callsFake(() => false);
+          env.sandbox
+            .stub(impl.userActivation_, 'isActive')
+            .callsFake(() => false);
           browser.click('button#hello');
 
           // Give mutations time to apply.
@@ -101,10 +105,12 @@ describe
           // Give event listeners in hydration a moment to attach.
           yield browser.wait(100);
 
-          sandbox.stub(impl.userActivation_, 'isActive').callsFake(() => true);
+          env.sandbox
+            .stub(impl.userActivation_, 'isActive')
+            .callsFake(() => true);
           // TODO(dvoytenko): Find a way to test this with the race condition when
           // the resource is fetched before the first polling iteration.
-          const stub = sandbox.stub(impl.userActivation_, 'expandLongTask');
+          const stub = env.sandbox.stub(impl.userActivation_, 'expandLongTask');
           browser.click('button#long');
           yield poll('long task started', () => {
             return stub.callCount > 0;
@@ -143,7 +149,9 @@ describe
           // Give event listeners in hydration a moment to attach.
           yield browser.wait(100);
 
-          sandbox.stub(impl.userActivation_, 'isActive').callsFake(() => true);
+          env.sandbox
+            .stub(impl.userActivation_, 'isActive')
+            .callsFake(() => true);
           browser.click('button#script');
 
           yield poll('mutations applied', () => {
@@ -164,7 +172,9 @@ describe
           // Give event listeners in hydration a moment to attach.
           yield browser.wait(100);
 
-          sandbox.stub(impl.userActivation_, 'isActive').callsFake(() => true);
+          env.sandbox
+            .stub(impl.userActivation_, 'isActive')
+            .callsFake(() => true);
           browser.click('button#img');
 
           yield poll('mutations applied', () => {
@@ -207,7 +217,9 @@ describe
           // Give event listeners in hydration a moment to attach.
           yield browser.wait(100);
 
-          sandbox.stub(impl.userActivation_, 'isActive').callsFake(() => false);
+          env.sandbox
+            .stub(impl.userActivation_, 'isActive')
+            .callsFake(() => false);
           browser.click('button#hello');
           yield poll('mutations applied', () => {
             const h1 = doc.querySelector('h1');
@@ -246,7 +258,9 @@ describe
           // Give event listeners in hydration a moment to attach.
           yield browser.wait(100);
 
-          sandbox.stub(impl.userActivation_, 'isActive').callsFake(() => false);
+          env.sandbox
+            .stub(impl.userActivation_, 'isActive')
+            .callsFake(() => false);
           browser.click('button#hello');
 
           // Give mutations time to apply.

--- a/extensions/amp-script/0.1/test/unit/test-amp-script.js
+++ b/extensions/amp-script/0.1/test/unit/test-amp-script.js
@@ -25,15 +25,12 @@ import {FakeWindow} from '../../../../../testing/fake-dom';
 import {Services} from '../../../../../src/services';
 
 describes.fakeWin('AmpScript', {amp: {runtimeOn: false}}, env => {
-  let sandbox;
   let element;
   let script;
   let service;
   let xhr;
 
   beforeEach(() => {
-    sandbox = env.sandbox;
-
     element = document.createElement('amp-script');
     env.ampdoc.getBody().appendChild(element);
 
@@ -41,21 +38,21 @@ describes.fakeWin('AmpScript', {amp: {runtimeOn: false}}, env => {
     script.getAmpDoc = () => env.ampdoc;
 
     service = {
-      checkSha384: sandbox.stub(),
+      checkSha384: env.sandbox.stub(),
       sizeLimitExceeded: () => false,
     };
     script.setService(service);
 
     xhr = {
-      fetchText: sandbox.stub(),
+      fetchText: env.sandbox.stub(),
     };
     xhr.fetchText
-      .withArgs(sinon.match(/amp-script-worker-0.1.js/))
+      .withArgs(env.sandbox.match(/amp-script-worker-0.1.js/))
       .resolves({text: () => Promise.resolve('/* noop */')});
-    sandbox.stub(Services, 'xhrFor').returns(xhr);
+    env.sandbox.stub(Services, 'xhrFor').returns(xhr);
 
     // Make @ampproject/worker-dom dependency a no-op for these unit tests.
-    sandbox.stub(WorkerDOM, 'upgrade').resolves();
+    env.sandbox.stub(WorkerDOM, 'upgrade').resolves();
   });
 
   function stubFetch(url, headers, text, responseUrl) {
@@ -69,7 +66,7 @@ describes.fakeWin('AmpScript', {amp: {runtimeOn: false}}, env => {
   }
 
   it('should require JS content-type for same-origin src', () => {
-    sandbox.stub(env.ampdoc, 'getUrl').returns('https://foo.example/');
+    env.sandbox.stub(env.ampdoc, 'getUrl').returns('https://foo.example/');
     element.setAttribute('src', 'https://foo.example/foo.txt');
 
     stubFetch(
@@ -82,7 +79,7 @@ describes.fakeWin('AmpScript', {amp: {runtimeOn: false}}, env => {
   });
 
   it('should check sha384(author_js) for cross-origin src', async () => {
-    sandbox.stub(env.ampdoc, 'getUrl').returns('https://foo.example/');
+    env.sandbox.stub(env.ampdoc, 'getUrl').returns('https://foo.example/');
     element.setAttribute('src', 'https://bar.example/bar.js');
 
     stubFetch(
@@ -97,7 +94,7 @@ describes.fakeWin('AmpScript', {amp: {runtimeOn: false}}, env => {
   });
 
   it('should fail on invalid sha384(author_js) for cross-origin src', () => {
-    sandbox.stub(env.ampdoc, 'getUrl').returns('https://foo.example/');
+    env.sandbox.stub(env.ampdoc, 'getUrl').returns('https://foo.example/');
     element.setAttribute('src', 'https://bar.example/bar.js');
 
     stubFetch(
@@ -111,7 +108,7 @@ describes.fakeWin('AmpScript', {amp: {runtimeOn: false}}, env => {
   });
 
   it('should check response URL to handle redirects', () => {
-    sandbox.stub(env.ampdoc, 'getUrl').returns('https://foo.example/');
+    env.sandbox.stub(env.ampdoc, 'getUrl').returns('https://foo.example/');
     element.setAttribute('src', 'https://foo.example/foo.js');
 
     stubFetch(
@@ -210,14 +207,11 @@ describes.fakeWin('AmpScript', {amp: {runtimeOn: false}}, env => {
 
 describes.fakeWin('AmpScriptService', {amp: {runtimeOn: false}}, env => {
   let crypto;
-  let sandbox;
   let service;
 
   beforeEach(() => {
-    sandbox = env.sandbox;
-
-    crypto = {sha384Base64: sandbox.stub()};
-    sandbox.stub(Services, 'cryptoFor').returns(crypto);
+    crypto = {sha384Base64: env.sandbox.stub()};
+    env.sandbox.stub(Services, 'cryptoFor').returns(crypto);
   });
 
   function createMetaTag(name, content) {
@@ -439,11 +433,11 @@ describe('SanitizerImpl', () => {
         getStateValue: () => {},
         setState: () => {},
       };
-      sandbox.stub(Services, 'bindForDocOrNull').resolves(bind);
+      window.sandbox.stub(Services, 'bindForDocOrNull').resolves(bind);
     });
 
     it('AMP.setState(json)', async () => {
-      sandbox.spy(bind, 'setState');
+      window.sandbox.spy(bind, 'setState');
 
       await s.setStorage(
         StorageLocation.AMP_STATE,
@@ -456,7 +450,7 @@ describe('SanitizerImpl', () => {
     });
 
     it('AMP.setState(not_json)', async () => {
-      sandbox.spy(bind, 'setState');
+      window.sandbox.spy(bind, 'setState');
 
       await s.setStorage(
         StorageLocation.AMP_STATE,
@@ -468,7 +462,7 @@ describe('SanitizerImpl', () => {
     });
 
     it('AMP.getState(string)', async () => {
-      sandbox.stub(bind, 'getStateValue').returns('bar');
+      window.sandbox.stub(bind, 'getStateValue').returns('bar');
 
       const state = await s.getStorage(StorageLocation.AMP_STATE, 'foo');
       expect(state).to.equal('bar');
@@ -478,7 +472,7 @@ describe('SanitizerImpl', () => {
     });
 
     it('AMP.getState()', async () => {
-      sandbox.stub(bind, 'getStateValue').returns({foo: 'bar'});
+      window.sandbox.stub(bind, 'getStateValue').returns({foo: 'bar'});
 
       const state = await s.getStorage(StorageLocation.AMP_STATE, '');
       expect(state).to.deep.equal({foo: 'bar'});

--- a/extensions/amp-script/0.1/test/unit/test-user-activation-tracker.js
+++ b/extensions/amp-script/0.1/test/unit/test-user-activation-tracker.js
@@ -37,7 +37,7 @@ describes.realWin('UserActivationTracker', {}, env => {
     doc.body.appendChild(root);
 
     tracker = new UserActivationTracker(root);
-    clock = sandbox.useFakeTimers();
+    clock = env.sandbox.useFakeTimers();
     clock.tick(1);
   });
 

--- a/extensions/amp-selector/0.1/test/test-amp-selector.js
+++ b/extensions/amp-selector/0.1/test/test-amp-selector.js
@@ -84,7 +84,7 @@ describes.realWin(
 
           ampSelector.appendChild(child);
         }
-        sandbox
+        env.sandbox
           .stub(ampSelector.implementation_, 'getElementsSizes_')
           .resolves(rectArray);
         win.document.body.appendChild(ampSelector);
@@ -104,7 +104,7 @@ describes.realWin(
       it('should build properly', function*() {
         let ampSelector = getSelector({});
         let impl = ampSelector.implementation_;
-        let initSpy = sandbox.spy(impl, 'init_');
+        let initSpy = env.sandbox.spy(impl, 'init_');
         yield ampSelector.build();
         expect(impl.isMultiple_).to.be.false;
         expect(initSpy).to.be.calledOnce;
@@ -119,7 +119,7 @@ describes.realWin(
           },
         });
         impl = ampSelector.implementation_;
-        initSpy = sandbox.spy(impl, 'init_');
+        initSpy = env.sandbox.spy(impl, 'init_');
         yield ampSelector.build();
         expect(impl.isMultiple_).to.be.true;
         expect(initSpy).to.be.calledOnce;
@@ -135,7 +135,7 @@ describes.realWin(
           },
         });
         impl = ampSelector.implementation_;
-        initSpy = sandbox.spy(impl, 'init_');
+        initSpy = env.sandbox.spy(impl, 'init_');
         yield ampSelector.build();
         expect(impl.isMultiple_).to.be.true;
         expect(initSpy).to.be.calledOnce;
@@ -165,8 +165,8 @@ describes.realWin(
         let ampSelector = getSelector({});
         let impl = ampSelector.implementation_;
         impl.mutateElement = fn => fn();
-        let setInputsSpy = sandbox.spy(impl, 'setInputs_');
-        let initSpy = sandbox.spy(impl, 'init_');
+        let setInputsSpy = env.sandbox.spy(impl, 'setInputs_');
+        let initSpy = env.sandbox.spy(impl, 'init_');
         yield ampSelector.build();
         expect(impl.isMultiple_).to.be.false;
         expect(initSpy).to.have.been.calledOnce;
@@ -180,8 +180,8 @@ describes.realWin(
           },
         });
         impl = ampSelector.implementation_;
-        setInputsSpy = sandbox.spy(impl, 'setInputs_');
-        initSpy = sandbox.spy(impl, 'init_');
+        setInputsSpy = env.sandbox.spy(impl, 'setInputs_');
+        initSpy = env.sandbox.spy(impl, 'init_');
         yield ampSelector.build();
         expect(impl.isMultiple_).to.be.false;
         expect(initSpy).to.have.been.calledOnce;
@@ -203,8 +203,8 @@ describes.realWin(
           },
         });
         const impl = ampSelector.implementation_;
-        const initSpy = sandbox.spy(impl, 'init_');
-        const setInputsSpy = sandbox.spy(impl, 'setInputs_');
+        const initSpy = env.sandbox.spy(impl, 'init_');
+        const setInputsSpy = env.sandbox.spy(impl, 'setInputs_');
         yield ampSelector.build();
         expect(impl.isMultiple_).to.be.true;
         expect(initSpy).to.have.been.calledOnce;
@@ -224,8 +224,8 @@ describes.realWin(
           },
         });
         const impl = ampSelector.implementation_;
-        const initSpy = sandbox.spy(impl, 'init_');
-        const setInputsSpy = sandbox.spy(impl, 'setInputs_');
+        const initSpy = env.sandbox.spy(impl, 'init_');
+        const setInputsSpy = env.sandbox.spy(impl, 'setInputs_');
         yield ampSelector.build();
 
         expect(impl.isMultiple_).to.be.true;
@@ -244,9 +244,9 @@ describes.realWin(
         });
 
         const impl = ampSelector.implementation_;
-        const initSpy = sandbox.spy(impl, 'init_');
-        const setInputsSpy = sandbox.spy(impl, 'setInputs_');
-        const clearSelectionSpy = sandbox.spy(impl, 'clearSelection_');
+        const initSpy = env.sandbox.spy(impl, 'init_');
+        const setInputsSpy = env.sandbox.spy(impl, 'setInputs_');
+        const clearSelectionSpy = env.sandbox.spy(impl, 'clearSelection_');
         yield ampSelector.build();
 
         const options = impl.getElementsForTesting();
@@ -276,8 +276,8 @@ describes.realWin(
         });
 
         const impl = ampSelector.implementation_;
-        const initSpy = sandbox.spy(impl, 'init_');
-        const setInputsSpy = sandbox.spy(impl, 'setInputs_');
+        const initSpy = env.sandbox.spy(impl, 'init_');
+        const setInputsSpy = env.sandbox.spy(impl, 'setInputs_');
         yield ampSelector.build();
 
         const options = impl.getElementsForTesting();
@@ -308,8 +308,8 @@ describes.realWin(
         });
 
         const impl = ampSelector.implementation_;
-        const initSpy = sandbox.spy(impl, 'init_');
-        const setInputsSpy = sandbox.spy(impl, 'setInputs_');
+        const initSpy = env.sandbox.spy(impl, 'init_');
+        const setInputsSpy = env.sandbox.spy(impl, 'setInputs_');
         yield ampSelector.build();
 
         const options = impl.getElementsForTesting();
@@ -467,8 +467,8 @@ describes.realWin(
         yield ampSelector.build();
 
         let options = impl.getElementsForTesting();
-        let clearSelectionSpy = sandbox.spy(impl, 'clearSelection_');
-        let setSelectionSpy = sandbox.spy(impl, 'setSelection_');
+        let clearSelectionSpy = env.sandbox.spy(impl, 'clearSelection_');
+        let setSelectionSpy = env.sandbox.spy(impl, 'setSelection_');
         let e = {
           target: options[3],
         };
@@ -511,8 +511,8 @@ describes.realWin(
         yield ampSelector.build();
 
         options = impl.getElementsForTesting();
-        clearSelectionSpy = sandbox.spy(impl, 'clearSelection_');
-        setSelectionSpy = sandbox.spy(impl, 'setSelection_');
+        clearSelectionSpy = env.sandbox.spy(impl, 'clearSelection_');
+        setSelectionSpy = env.sandbox.spy(impl, 'setSelection_');
 
         e = {
           target: options[4],
@@ -553,8 +553,8 @@ describes.realWin(
         impl = ampSelector.implementation_;
         impl.mutateElement = fn => fn();
         yield ampSelector.build();
-        clearSelectionSpy = sandbox.spy(impl, 'clearSelection_');
-        setSelectionSpy = sandbox.spy(impl, 'setSelection_');
+        clearSelectionSpy = env.sandbox.spy(impl, 'clearSelection_');
+        setSelectionSpy = env.sandbox.spy(impl, 'setSelection_');
 
         e = {
           target: impl.element.children[0],
@@ -580,8 +580,8 @@ describes.realWin(
         yield ampSelector.build();
 
         let options = impl.getElementsForTesting();
-        let clearSelectionSpy = sandbox.spy(impl, 'clearSelection_');
-        let setSelectionSpy = sandbox.spy(impl, 'setSelection_');
+        let clearSelectionSpy = env.sandbox.spy(impl, 'clearSelection_');
+        let setSelectionSpy = env.sandbox.spy(impl, 'setSelection_');
 
         keyPress(ampSelector, Keys.ENTER, options[3]);
         expect(options[3].hasAttribute('selected')).to.be.true;
@@ -610,8 +610,8 @@ describes.realWin(
         yield ampSelector.build();
 
         options = impl.getElementsForTesting();
-        clearSelectionSpy = sandbox.spy(impl, 'clearSelection_');
-        setSelectionSpy = sandbox.spy(impl, 'setSelection_');
+        clearSelectionSpy = env.sandbox.spy(impl, 'clearSelection_');
+        setSelectionSpy = env.sandbox.spy(impl, 'setSelection_');
 
         keyPress(ampSelector, Keys.SPACE, options[4]);
         expect(options[4].hasAttribute('selected')).to.be.true;
@@ -645,8 +645,8 @@ describes.realWin(
         impl = ampSelector.implementation_;
         impl.mutateElement = fn => fn();
         yield ampSelector.build();
-        clearSelectionSpy = sandbox.spy(impl, 'clearSelection_');
-        setSelectionSpy = sandbox.spy(impl, 'setSelection_');
+        clearSelectionSpy = env.sandbox.spy(impl, 'clearSelection_');
+        setSelectionSpy = env.sandbox.spy(impl, 'setSelection_');
 
         keyPress(ampSelector, Keys.SPACE, impl.element.children[0]);
         expect(setSelectionSpy).to.not.have.been.called;
@@ -665,7 +665,7 @@ describes.realWin(
         ampSelector.build();
 
         const options = impl.getElementsForTesting();
-        const setInputsSpy = sandbox.spy(impl, 'setInputs_');
+        const setInputsSpy = env.sandbox.spy(impl, 'setInputs_');
 
         expect(options[0].hasAttribute('selected')).to.be.true;
         expect(options[3].hasAttribute('selected')).to.be.false;
@@ -836,7 +836,7 @@ describes.realWin(
         impl.mutateElement = fn => fn();
 
         const options = impl.getElementsForTesting();
-        const triggerSpy = sandbox.spy(impl.action_, 'trigger');
+        const triggerSpy = env.sandbox.spy(impl.action_, 'trigger');
         impl.clickHandler_({target: options[3]});
 
         expect(triggerSpy).to.be.calledOnce;
@@ -862,7 +862,7 @@ describes.realWin(
         const impl = ampSelector.implementation_;
         impl.mutateElement = fn => fn();
 
-        const triggerSpy = sandbox.spy(impl.action_, 'trigger');
+        const triggerSpy = env.sandbox.spy(impl.action_, 'trigger');
         const args = {'index': 3, 'value': true};
         await impl.executeAction({
           method: 'toggle',
@@ -900,7 +900,7 @@ describes.realWin(
         impl.mutateElement = fn => fn();
 
         const options = impl.getElementsForTesting();
-        const triggerSpy = sandbox.spy(impl.action_, 'trigger');
+        const triggerSpy = env.sandbox.spy(impl.action_, 'trigger');
         impl.clickHandler_({target: options[2]});
 
         expect(triggerSpy).to.be.calledOnce;
@@ -934,7 +934,7 @@ describes.realWin(
           ampSelector.children[0].setAttribute('selected', '');
           ampSelector.build();
           const impl = ampSelector.implementation_;
-          const triggerSpy = sandbox.spy(impl.action_, 'trigger');
+          const triggerSpy = env.sandbox.spy(impl.action_, 'trigger');
 
           expect(ampSelector.hasAttribute('multiple')).to.be.false;
           expect(ampSelector.children[0].hasAttribute('selected')).to.be.true;
@@ -975,7 +975,7 @@ describes.realWin(
           ampSelector.children[0].setAttribute('selected', '');
           ampSelector.build();
           const impl = ampSelector.implementation_;
-          const triggerSpy = sandbox.spy(impl.action_, 'trigger');
+          const triggerSpy = env.sandbox.spy(impl.action_, 'trigger');
 
           expect(ampSelector.hasAttribute('multiple')).to.be.false;
           expect(ampSelector.children[0].hasAttribute('selected')).to.be.true;
@@ -1146,7 +1146,7 @@ describes.realWin(
               count: 3,
             },
           });
-          const spy = sandbox.spy(
+          const spy = env.sandbox.spy(
             ampSelector.implementation_,
             'navigationKeyDownHandler_'
           );

--- a/extensions/amp-share-tracking/0.1/test/test-amp-share-tracking.js
+++ b/extensions/amp-share-tracking/0.1/test/test-amp-share-tracking.js
@@ -40,13 +40,16 @@ describes.fakeWin(
     beforeEach(() => {
       win = env.win;
       ampdoc = env.ampdoc;
-      historyGetFragmentStub = sandbox.stub(History.prototype, 'getFragment');
-      historyUpdateFragmentStub = sandbox.stub(
+      historyGetFragmentStub = env.sandbox.stub(
+        History.prototype,
+        'getFragment'
+      );
+      historyUpdateFragmentStub = env.sandbox.stub(
         History.prototype,
         'updateFragment'
       );
-      xhrStub = sandbox.stub(Xhr.prototype, 'fetchJson');
-      randomBytesStub = sandbox.stub(bytes, 'getCryptoRandomBytesArray');
+      xhrStub = env.sandbox.stub(Xhr.prototype, 'fetchJson');
+      randomBytesStub = env.sandbox.stub(bytes, 'getCryptoRandomBytesArray');
       toggleExperiment(win, 'amp-share-tracking', true);
     });
 
@@ -192,7 +195,7 @@ describes.fakeWin(
         'is provided and fallback to Math.random generation',
       () => {
         historyGetFragmentStub.onFirstCall().returns(Promise.resolve(''));
-        sandbox.stub(Math, 'random').returns(0.123456789123456789);
+        env.sandbox.stub(Math, 'random').returns(0.123456789123456789);
         randomBytesStub.onFirstCall().returns(null);
         const ampShareTracking = getAmpShareTracking();
         return Services.shareTrackingForOrNull(ampShareTracking.win).then(

--- a/extensions/amp-sidebar/0.1/test/test-amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/test/test-amp-sidebar.js
@@ -94,19 +94,19 @@ describes.realWin(
         .then(() => {
           const impl = ampSidebar.implementation_;
           if (options.toolbars) {
-            sandbox.stub(timer, 'delay').callsFake(function(callback) {
+            env.sandbox.stub(timer, 'delay').callsFake(function(callback) {
               callback();
             });
           }
-          sandbox.stub(impl, 'mutateElement').callsFake(callback => {
+          env.sandbox.stub(impl, 'mutateElement').callsFake(callback => {
             callback();
             return Promise.resolve();
           });
 
           if (options.stubHistory) {
-            sandbox.stub(impl, 'getHistory_').returns({
-              push: sandbox.stub().resolves(11),
-              pop: sandbox.stub().resolves(11),
+            env.sandbox.stub(impl, 'getHistory_').returns({
+              push: env.sandbox.stub().resolves(11),
+              pop: env.sandbox.stub().resolves(11),
             });
           }
           return ampSidebar;
@@ -198,7 +198,7 @@ describes.realWin(
       it('should create an invisible close button for screen readers only', () => {
         return getAmpSidebar().then(sidebarElement => {
           const impl = sidebarElement.implementation_;
-          impl.close_ = sandbox.spy();
+          impl.close_ = env.sandbox.spy();
           const closeButton = sidebarElement.lastElementChild;
           expect(closeButton).to.exist;
           expect(closeButton.tagName).to.equal('BUTTON');
@@ -220,9 +220,9 @@ describes.realWin(
           target: impl.win,
           toFake: ['Date', 'setTimeout'],
         });
-        const historyPushSpy = sandbox.spy();
-        const historyPopSpy = sandbox.spy();
-        owners.scheduleLayout = sandbox.spy();
+        const historyPushSpy = env.sandbox.spy();
+        const historyPopSpy = env.sandbox.spy();
+        owners.scheduleLayout = env.sandbox.spy();
         impl.getHistory_ = function() {
           return {
             push() {
@@ -293,19 +293,21 @@ describes.realWin(
         const history = impl.getHistory_();
         history.push.firstCall.args[0]();
         await new Promise(resolve => {
-          sandbox.stub(impl.action_, 'trigger').callsFake((element, name) => {
-            if (name == 'sidebarClose') {
-              resolve();
-            }
-          });
+          env.sandbox
+            .stub(impl.action_, 'trigger')
+            .callsFake((element, name) => {
+              if (name == 'sidebarClose') {
+                resolve();
+              }
+            });
         });
 
         expect(sidebarElement).to.have.display('none');
       });
 
       it('close on history back immediately for iOS', async () => {
-        sandbox.stub(platform, 'isIos').returns(true);
-        sandbox.stub(platform, 'isSafari').returns(true);
+        env.sandbox.stub(platform, 'isIos').returns(true);
+        env.sandbox.stub(platform, 'isSafari').returns(true);
 
         const sidebarElement = await getAmpSidebar({'stubHistory': true});
         const impl = sidebarElement.implementation_;
@@ -325,10 +327,10 @@ describes.realWin(
           target: impl.win,
           toFake: ['Date', 'setTimeout'],
         });
-        owners.schedulePause = sandbox.spy();
-        const historyPushSpy = sandbox.spy();
-        const historyPopSpy = sandbox.spy();
-        owners.scheduleLayout = sandbox.spy();
+        owners.schedulePause = env.sandbox.spy();
+        const historyPushSpy = env.sandbox.spy();
+        const historyPopSpy = env.sandbox.spy();
+        owners.scheduleLayout = env.sandbox.spy();
         impl.getHistory_ = function() {
           return {
             push() {
@@ -373,8 +375,8 @@ describes.realWin(
           target: impl.win,
           toFake: ['Date', 'setTimeout'],
         });
-        owners.scheduleLayout = sandbox.spy();
-        owners.schedulePause = sandbox.spy();
+        owners.scheduleLayout = env.sandbox.spy();
+        owners.schedulePause = env.sandbox.spy();
 
         expect(sidebarElement.hasAttribute('open')).to.be.false;
         expect(sidebarElement.hasAttribute('aria-hidden')).to.be.false;
@@ -408,7 +410,7 @@ describes.realWin(
             target: impl.win,
             toFake: ['Date', 'setTimeout'],
           });
-          owners.schedulePause = sandbox.spy();
+          owners.schedulePause = env.sandbox.spy();
 
           expect(sidebarElement.hasAttribute('open')).to.be.false;
           execute(impl, 'open');
@@ -441,8 +443,8 @@ describes.realWin(
             target: impl.win,
             toFake: ['Date', 'setTimeout'],
           });
-          owners.schedulePause = sandbox.spy();
-          owners.scheduleResume = sandbox.spy();
+          owners.schedulePause = env.sandbox.spy();
+          owners.scheduleResume = env.sandbox.spy();
 
           expect(sidebarElement.hasAttribute('open')).to.be.false;
           clock.tick(600);
@@ -480,28 +482,31 @@ describes.realWin(
       });
 
       it.skip('should fix scroll leaks on ios safari', () => {
-        sandbox.stub(platform, 'isIos').returns(true);
-        sandbox.stub(platform, 'isSafari').returns(true);
+        env.sandbox.stub(platform, 'isIos').returns(true);
+        env.sandbox.stub(platform, 'isSafari').returns(true);
         return getAmpSidebar().then(sidebarElement => {
           const impl = sidebarElement.implementation_;
-          sandbox.stub(timer, 'delay').callsFake(function(callback) {
+          env.sandbox.stub(timer, 'delay').callsFake(function(callback) {
             callback();
           });
-          const scrollLeakSpy = sandbox.spy(impl, 'fixIosElasticScrollLeak_');
+          const scrollLeakSpy = env.sandbox.spy(
+            impl,
+            'fixIosElasticScrollLeak_'
+          );
           impl.buildCallback();
           expect(scrollLeakSpy).to.be.calledOnce;
         });
       });
 
       it.skip('should adjust for IOS safari bottom bar', () => {
-        sandbox.stub(platform, 'isIos').returns(true);
-        sandbox.stub(platform, 'isSafari').returns(true);
+        env.sandbox.stub(platform, 'isIos').returns(true);
+        env.sandbox.stub(platform, 'isSafari').returns(true);
         return getAmpSidebar().then(sidebarElement => {
           const impl = sidebarElement.implementation_;
-          sandbox.stub(timer, 'delay').callsFake(function(callback) {
+          env.sandbox.stub(timer, 'delay').callsFake(function(callback) {
             callback();
           });
-          const compensateIosBottombarSpy = sandbox.spy(
+          const compensateIosBottombarSpy = env.sandbox.spy(
             impl,
             'compensateIosBottombar_'
           );
@@ -524,7 +529,7 @@ describes.realWin(
             target: impl.win,
             toFake: ['Date', 'setTimeout'],
           });
-          owners.schedulePause = sandbox.spy();
+          owners.schedulePause = env.sandbox.spy();
           expect(sidebarElement.hasAttribute('open')).to.be.false;
           execute(impl, 'open');
           expect(sidebarElement.hasAttribute('open')).to.be.true;
@@ -536,7 +541,7 @@ describes.realWin(
             eventObj.initEvent('click', true, true);
           }
           const ampDoc = sidebarElement.getAmpDoc();
-          sandbox.stub(ampDoc, 'getUrl').returns(window.location.href);
+          env.sandbox.stub(ampDoc, 'getUrl').returns(window.location.href);
           anchor.dispatchEvent
             ? anchor.dispatchEvent(eventObj)
             : anchor.fireEvent('onkeydown', eventObj);
@@ -553,8 +558,8 @@ describes.realWin(
           const anchor = sidebarElement.getElementsByTagName('a')[0];
           anchor.href = '#newloc';
           const impl = sidebarElement.implementation_;
-          owners.schedulePause = sandbox.spy();
-          sandbox.stub(timer, 'delay').callsFake(function(callback) {
+          owners.schedulePause = env.sandbox.spy();
+          env.sandbox.stub(timer, 'delay').callsFake(function(callback) {
             callback();
           });
           expect(sidebarElement.hasAttribute('open')).to.be.false;
@@ -568,7 +573,7 @@ describes.realWin(
             eventObj.initEvent('click', true, true);
           }
           const ampDoc = sidebarElement.getAmpDoc();
-          sandbox.stub(ampDoc, 'getUrl').returns('http://example.com');
+          env.sandbox.stub(ampDoc, 'getUrl').returns('http://example.com');
           anchor.dispatchEvent
             ? anchor.dispatchEvent(eventObj)
             : anchor.fireEvent('onkeydown', eventObj);
@@ -584,9 +589,9 @@ describes.realWin(
           const anchor = sidebarElement.getElementsByTagName('a')[0];
           anchor.href = '#newloc';
           const impl = sidebarElement.implementation_;
-          owners.schedulePause = sandbox.spy();
+          owners.schedulePause = env.sandbox.spy();
 
-          sandbox.stub(timer, 'delay').callsFake(function(callback) {
+          env.sandbox.stub(timer, 'delay').callsFake(function(callback) {
             callback();
           });
           expect(sidebarElement.hasAttribute('open')).to.be.false;
@@ -600,7 +605,7 @@ describes.realWin(
             eventObj.initEvent('click', true, true);
           }
           const ampDoc = sidebarElement.getAmpDoc();
-          sandbox
+          env.sandbox
             .stub(ampDoc, 'getUrl')
             .returns('http://localhost:9876/context.html?old=context');
           anchor.dispatchEvent
@@ -617,9 +622,9 @@ describes.realWin(
         return getAmpSidebar({stubHistory: true}).then(sidebarElement => {
           const li = sidebarElement.getElementsByTagName('li')[0];
           const impl = sidebarElement.implementation_;
-          owners.schedulePause = sandbox.spy();
+          owners.schedulePause = env.sandbox.spy();
 
-          sandbox.stub(timer, 'delay').callsFake(function(callback) {
+          env.sandbox.stub(timer, 'delay').callsFake(function(callback) {
             callback();
           });
           expect(sidebarElement.hasAttribute('open')).to.be.false;
@@ -645,18 +650,18 @@ describes.realWin(
       it('should trigger actions on open and close', () => {
         return getAmpSidebar({stubHistory: true}).then(sidebarElement => {
           const impl = sidebarElement.implementation_;
-          const triggerSpy = sandbox.spy(impl.action_, 'trigger');
-          sandbox.stub(timer, 'delay').callsFake(function(callback) {
+          const triggerSpy = env.sandbox.spy(impl.action_, 'trigger');
+          env.sandbox.stub(timer, 'delay').callsFake(function(callback) {
             callback();
           });
-          owners.scheduleLayout = sandbox.stub();
+          owners.scheduleLayout = env.sandbox.stub();
 
           execute(impl, 'open', /* trust */ 123);
           expect(triggerSpy).to.be.calledOnce;
           expect(triggerSpy).to.be.calledWith(
             impl.element,
             'sidebarOpen',
-            sinon.match.any,
+            env.sandbox.match.any,
             /* trust */ 123
           );
 
@@ -665,7 +670,7 @@ describes.realWin(
           expect(triggerSpy).to.be.calledWith(
             impl.element,
             'sidebarClose',
-            sinon.match.any,
+            env.sandbox.match.any,
             /* trust */ 456
           );
         });

--- a/extensions/amp-sidebar/0.1/test/test-toolbar.js
+++ b/extensions/amp-sidebar/0.1/test/test-toolbar.js
@@ -24,7 +24,6 @@ import {toArray} from '../../../../src/types';
 adopt(window);
 
 describe('amp-sidebar - toolbar', () => {
-  let sandbox;
   let timer;
 
   function getToolbars(options) {
@@ -44,7 +43,7 @@ describe('amp-sidebar - toolbar', () => {
         },
       };
 
-      sandbox.stub(timer, 'delay').callsFake(function(callback) {
+      window.sandbox.stub(timer, 'delay').callsFake(function(callback) {
         callback();
       });
 
@@ -96,14 +95,6 @@ describe('amp-sidebar - toolbar', () => {
     iframeObject.win.innerWidth;
     callback();
   }
-
-  beforeEach(() => {
-    sandbox = sinon.sandbox;
-  });
-
-  afterEach(() => {
-    sandbox.restore();
-  });
 
   it('toolbar header should error if target element \
    could not be found as it is required.', () => {

--- a/extensions/amp-sidebar/0.2/test/test-amp-sidebar.js
+++ b/extensions/amp-sidebar/0.2/test/test-amp-sidebar.js
@@ -97,19 +97,19 @@ describes.realWin(
         .then(() => {
           const impl = ampSidebar.implementation_;
           if (options.toolbars) {
-            sandbox.stub(timer, 'delay').callsFake(function(callback) {
+            env.sandbox.stub(timer, 'delay').callsFake(function(callback) {
               callback();
             });
           }
-          sandbox.stub(impl, 'mutateElement').callsFake(callback => {
+          env.sandbox.stub(impl, 'mutateElement').callsFake(callback => {
             callback();
             return Promise.resolve();
           });
 
           if (options.stubHistory) {
-            sandbox.stub(impl, 'getHistory_').returns({
-              push: sandbox.stub().resolves(11),
-              pop: sandbox.stub().resolves(11),
+            env.sandbox.stub(impl, 'getHistory_').returns({
+              push: env.sandbox.stub().resolves(11),
+              pop: env.sandbox.stub().resolves(11),
             });
           }
           return ampSidebar;
@@ -201,7 +201,7 @@ describes.realWin(
       it('should create an invisible close button for screen readers only', () => {
         return getAmpSidebar().then(sidebarElement => {
           const impl = sidebarElement.implementation_;
-          impl.close_ = sandbox.spy();
+          impl.close_ = env.sandbox.spy();
           const closeButton = sidebarElement.lastElementChild;
           expect(closeButton).to.exist;
           expect(closeButton.tagName).to.equal('BUTTON');
@@ -223,9 +223,9 @@ describes.realWin(
           target: impl.win,
           toFake: ['Date', 'setTimeout'],
         });
-        const historyPushSpy = sandbox.spy();
-        const historyPopSpy = sandbox.spy();
-        owners.scheduleLayout = sandbox.spy();
+        const historyPushSpy = env.sandbox.spy();
+        const historyPopSpy = env.sandbox.spy();
+        owners.scheduleLayout = env.sandbox.spy();
         impl.getHistory_ = function() {
           return {
             push() {
@@ -293,10 +293,10 @@ describes.realWin(
           target: impl.win,
           toFake: ['Date', 'setTimeout'],
         });
-        owners.schedulePause = sandbox.spy();
-        const historyPushSpy = sandbox.spy();
-        const historyPopSpy = sandbox.spy();
-        owners.scheduleLayout = sandbox.spy();
+        owners.schedulePause = env.sandbox.spy();
+        const historyPushSpy = env.sandbox.spy();
+        const historyPopSpy = env.sandbox.spy();
+        owners.scheduleLayout = env.sandbox.spy();
         impl.getHistory_ = function() {
           return {
             push() {
@@ -341,8 +341,8 @@ describes.realWin(
           target: impl.win,
           toFake: ['Date', 'setTimeout'],
         });
-        owners.scheduleLayout = sandbox.spy();
-        owners.schedulePause = sandbox.spy();
+        owners.scheduleLayout = env.sandbox.spy();
+        owners.schedulePause = env.sandbox.spy();
 
         expect(sidebarElement.hasAttribute('open')).to.be.false;
         expect(sidebarElement.hasAttribute('aria-hidden')).to.be.false;
@@ -376,7 +376,7 @@ describes.realWin(
             target: impl.win,
             toFake: ['Date', 'setTimeout'],
           });
-          owners.schedulePause = sandbox.spy();
+          owners.schedulePause = env.sandbox.spy();
 
           expect(sidebarElement.hasAttribute('open')).to.be.false;
           execute(impl, 'open');
@@ -409,8 +409,8 @@ describes.realWin(
             target: impl.win,
             toFake: ['Date', 'setTimeout'],
           });
-          owners.schedulePause = sandbox.spy();
-          owners.scheduleResume = sandbox.spy();
+          owners.schedulePause = env.sandbox.spy();
+          owners.scheduleResume = env.sandbox.spy();
 
           expect(sidebarElement.hasAttribute('open')).to.be.false;
           clock.tick(600);
@@ -448,28 +448,31 @@ describes.realWin(
       });
 
       it.skip('should fix scroll leaks on ios safari', () => {
-        sandbox.stub(platform, 'isIos').returns(true);
-        sandbox.stub(platform, 'isSafari').returns(true);
+        env.sandbox.stub(platform, 'isIos').returns(true);
+        env.sandbox.stub(platform, 'isSafari').returns(true);
         return getAmpSidebar().then(sidebarElement => {
           const impl = sidebarElement.implementation_;
-          sandbox.stub(timer, 'delay').callsFake(function(callback) {
+          env.sandbox.stub(timer, 'delay').callsFake(function(callback) {
             callback();
           });
-          const scrollLeakSpy = sandbox.spy(impl, 'fixIosElasticScrollLeak_');
+          const scrollLeakSpy = env.sandbox.spy(
+            impl,
+            'fixIosElasticScrollLeak_'
+          );
           impl.buildCallback();
           expect(scrollLeakSpy).to.be.calledOnce;
         });
       });
 
       it.skip('should adjust for IOS safari bottom bar', () => {
-        sandbox.stub(platform, 'isIos').returns(true);
-        sandbox.stub(platform, 'isSafari').returns(true);
+        env.sandbox.stub(platform, 'isIos').returns(true);
+        env.sandbox.stub(platform, 'isSafari').returns(true);
         return getAmpSidebar().then(sidebarElement => {
           const impl = sidebarElement.implementation_;
-          sandbox.stub(timer, 'delay').callsFake(function(callback) {
+          env.sandbox.stub(timer, 'delay').callsFake(function(callback) {
             callback();
           });
-          const compensateIosBottombarSpy = sandbox.spy(
+          const compensateIosBottombarSpy = env.sandbox.spy(
             impl,
             'compensateIosBottombar_'
           );
@@ -492,7 +495,7 @@ describes.realWin(
             target: impl.win,
             toFake: ['Date', 'setTimeout'],
           });
-          owners.schedulePause = sandbox.spy();
+          owners.schedulePause = env.sandbox.spy();
           expect(sidebarElement.hasAttribute('open')).to.be.false;
           execute(impl, 'open');
           expect(sidebarElement.hasAttribute('open')).to.be.true;
@@ -504,7 +507,7 @@ describes.realWin(
             eventObj.initEvent('click', true, true);
           }
           const ampDoc = sidebarElement.getAmpDoc();
-          sandbox.stub(ampDoc, 'getUrl').returns(window.location.href);
+          env.sandbox.stub(ampDoc, 'getUrl').returns(window.location.href);
           anchor.dispatchEvent
             ? anchor.dispatchEvent(eventObj)
             : anchor.fireEvent('onkeydown', eventObj);
@@ -521,8 +524,8 @@ describes.realWin(
           const anchor = sidebarElement.getElementsByTagName('a')[0];
           anchor.href = '#newloc';
           const impl = sidebarElement.implementation_;
-          owners.schedulePause = sandbox.spy();
-          sandbox.stub(timer, 'delay').callsFake(function(callback) {
+          owners.schedulePause = env.sandbox.spy();
+          env.sandbox.stub(timer, 'delay').callsFake(function(callback) {
             callback();
           });
           expect(sidebarElement.hasAttribute('open')).to.be.false;
@@ -537,7 +540,7 @@ describes.realWin(
           }
           const ampDoc = sidebarElement.getAmpDoc();
           // Mocking navigating from example.com -> localhost:9876
-          sandbox.stub(ampDoc, 'getUrl').returns('http://example.com');
+          env.sandbox.stub(ampDoc, 'getUrl').returns('http://example.com');
           anchor.dispatchEvent
             ? anchor.dispatchEvent(eventObj)
             : anchor.fireEvent('onkeydown', eventObj);
@@ -553,9 +556,9 @@ describes.realWin(
           const anchor = sidebarElement.getElementsByTagName('a')[0];
           anchor.href = '#newloc';
           const impl = sidebarElement.implementation_;
-          owners.schedulePause = sandbox.spy();
+          owners.schedulePause = env.sandbox.spy();
 
-          sandbox.stub(timer, 'delay').callsFake(function(callback) {
+          env.sandbox.stub(timer, 'delay').callsFake(function(callback) {
             callback();
           });
           expect(sidebarElement.hasAttribute('open')).to.be.false;
@@ -570,7 +573,7 @@ describes.realWin(
           }
           const ampDoc = sidebarElement.getAmpDoc();
           // Mocking navigating from /context.html?old=context -> /context.html
-          sandbox
+          env.sandbox
             .stub(ampDoc, 'getUrl')
             .returns('http://localhost:9876/context.html?old=context');
 
@@ -588,9 +591,9 @@ describes.realWin(
         return getAmpSidebar({stubHistory: true}).then(sidebarElement => {
           const li = sidebarElement.getElementsByTagName('li')[0];
           const impl = sidebarElement.implementation_;
-          owners.schedulePause = sandbox.spy();
+          owners.schedulePause = env.sandbox.spy();
 
-          sandbox.stub(timer, 'delay').callsFake(function(callback) {
+          env.sandbox.stub(timer, 'delay').callsFake(function(callback) {
             callback();
           });
           expect(sidebarElement.hasAttribute('open')).to.be.false;
@@ -616,18 +619,18 @@ describes.realWin(
       it('should trigger actions on open and close', () => {
         return getAmpSidebar({stubHistory: true}).then(sidebarElement => {
           const impl = sidebarElement.implementation_;
-          const triggerSpy = sandbox.spy(impl.action_, 'trigger');
-          sandbox.stub(timer, 'delay').callsFake(function(callback) {
+          const triggerSpy = env.sandbox.spy(impl.action_, 'trigger');
+          env.sandbox.stub(timer, 'delay').callsFake(function(callback) {
             callback();
           });
-          owners.scheduleLayout = sandbox.stub();
+          owners.scheduleLayout = env.sandbox.stub();
 
           execute(impl, 'open', /* trust */ 123);
           expect(triggerSpy).to.be.calledOnce;
           expect(triggerSpy).to.be.calledWith(
             impl.element,
             'sidebarOpen',
-            sinon.match.any,
+            env.sandbox.match.any,
             /* trust */ 123
           );
 
@@ -636,7 +639,7 @@ describes.realWin(
           expect(triggerSpy).to.be.calledWith(
             impl.element,
             'sidebarClose',
-            sinon.match.any,
+            env.sandbox.match.any,
             /* trust */ 456
           );
         });

--- a/extensions/amp-sidebar/0.2/test/test-toolbar.js
+++ b/extensions/amp-sidebar/0.2/test/test-toolbar.js
@@ -20,8 +20,7 @@ import {Toolbar} from '../toolbar';
 import {createIframePromise} from '../../../../testing/iframe';
 import {toArray} from '../../../../src/types';
 
-describes.realWin('amp-sidebar - toolbar', {}, () => {
-  let sandbox;
+describes.realWin('amp-sidebar - toolbar', {}, env => {
   let timer;
 
   function getToolbars(options) {
@@ -41,7 +40,7 @@ describes.realWin('amp-sidebar - toolbar', {}, () => {
         },
       };
 
-      sandbox.stub(timer, 'delay').callsFake(function(callback) {
+      env.sandbox.stub(timer, 'delay').callsFake(function(callback) {
         callback();
       });
 
@@ -93,14 +92,6 @@ describes.realWin('amp-sidebar - toolbar', {}, () => {
     iframeObject.win.innerWidth;
     callback();
   }
-
-  beforeEach(() => {
-    sandbox = sinon.sandbox;
-  });
-
-  afterEach(() => {
-    sandbox.restore();
-  });
 
   it('toolbar header should error if target element \
    could not be found as it is required.', () => {

--- a/extensions/amp-skimlinks/0.1/test/test-amp-skimlinks.js
+++ b/extensions/amp-skimlinks/0.1/test/test-amp-skimlinks.js
@@ -309,7 +309,7 @@ describes.fakeWin(
 
         it('Should wait until visible to send the impression tracking', () => {
           const isVisibleDefer = new Deferred();
-          sandbox
+          window.sandbox
             .stub(ampdoc, 'whenFirstVisible')
             .returns(isVisibleDefer.promise);
 
@@ -369,7 +369,7 @@ describes.fakeWin(
 
         it('Should wait until visible to send the impression tracking', () => {
           const isVisibleDefer = new Deferred();
-          sandbox
+          window.sandbox
             .stub(ampdoc, 'whenFirstVisible')
             .returns(isVisibleDefer.promise);
 

--- a/extensions/amp-social-share/0.1/test/test-amp-social-share.js
+++ b/extensions/amp-social-share/0.1/test/test-amp-social-share.js
@@ -49,14 +49,14 @@ describes.realWin(
       isIos = false;
       isSafari = false;
       platform = Services.platformFor(win);
-      sandbox.stub(platform, 'isIos').callsFake(() => isIos);
-      sandbox.stub(platform, 'isSafari').callsFake(() => isSafari);
-      sandbox./*OK*/ stub(win, 'open').returns(true);
+      env.sandbox.stub(platform, 'isIos').callsFake(() => isIos);
+      env.sandbox.stub(platform, 'isSafari').callsFake(() => isSafari);
+      env.sandbox./*OK*/ stub(win, 'open').returns(true);
     });
 
     function getShare(type, opt_endpoint, opt_params, opt_target) {
       const share = doc.createElement('amp-social-share');
-      share.addEventListener = sandbox.spy();
+      share.addEventListener = env.sandbox.spy();
       if (opt_endpoint) {
         share.setAttribute('data-share-endpoint', opt_endpoint);
       }

--- a/extensions/amp-standalone/0.1/test/test-amp-standalone.js
+++ b/extensions/amp-standalone/0.1/test/test-amp-standalone.js
@@ -16,7 +16,7 @@
 
 import {StandaloneService} from '../amp-standalone';
 
-describes.sandboxed('amp-standalone', {}, () => {
+describes.sandboxed('amp-standalone', {}, env => {
   let fakeAmpdoc;
 
   beforeEach(() => {
@@ -33,10 +33,10 @@ describes.sandboxed('amp-standalone', {}, () => {
   it('should not react for <button> tags', () => {
     const service = new StandaloneService(fakeAmpdoc);
     class PlatformFake {}
-    PlatformFake.prototype.isSafari = sandbox.stub().returns(true);
-    PlatformFake.prototype.isChrome = sandbox.stub().returns(false);
-    sandbox.stub(service, 'getPlatform_').returns(new PlatformFake());
-    const handlerStub = sandbox.stub(service, 'handleSafariStandalone_');
+    PlatformFake.prototype.isSafari = env.sandbox.stub().returns(true);
+    PlatformFake.prototype.isChrome = env.sandbox.stub().returns(false);
+    env.sandbox.stub(service, 'getPlatform_').returns(new PlatformFake());
+    const handlerStub = env.sandbox.stub(service, 'handleSafariStandalone_');
 
     const fakeEvent = {
       target: {
@@ -52,10 +52,10 @@ describes.sandboxed('amp-standalone', {}, () => {
   it('should react for <a> tags', () => {
     const service = new StandaloneService(fakeAmpdoc);
     class PlatformFake {}
-    PlatformFake.prototype.isSafari = sandbox.stub().returns(true);
-    PlatformFake.prototype.isChrome = sandbox.stub().returns(false);
-    sandbox.stub(service, 'getPlatform_').returns(new PlatformFake());
-    const handlerStub = sandbox.stub(service, 'handleSafariStandalone_');
+    PlatformFake.prototype.isSafari = env.sandbox.stub().returns(true);
+    PlatformFake.prototype.isChrome = env.sandbox.stub().returns(false);
+    env.sandbox.stub(service, 'getPlatform_').returns(new PlatformFake());
+    const handlerStub = env.sandbox.stub(service, 'handleSafariStandalone_');
 
     const fakeEvent = {
       target: {
@@ -73,9 +73,9 @@ describes.sandboxed('amp-standalone', {}, () => {
       fakeAmpdoc.win.origin = 'http://www.example.com';
       const service = new StandaloneService(fakeAmpdoc);
       class PlatformFake {}
-      PlatformFake.prototype.isSafari = sandbox.stub().returns(true);
-      PlatformFake.prototype.isChrome = sandbox.stub().returns(false);
-      sandbox.stub(service, 'getPlatform_').returns(new PlatformFake());
+      PlatformFake.prototype.isSafari = env.sandbox.stub().returns(true);
+      PlatformFake.prototype.isChrome = env.sandbox.stub().returns(false);
+      env.sandbox.stub(service, 'getPlatform_').returns(new PlatformFake());
 
       const fakeEvent = {
         target: {
@@ -98,9 +98,9 @@ describes.sandboxed('amp-standalone', {}, () => {
       fakeAmpdoc.win.origin = 'http://www.example.com';
       const service = new StandaloneService(fakeAmpdoc);
       class PlatformFake {}
-      PlatformFake.prototype.isSafari = sandbox.stub().returns(true);
-      PlatformFake.prototype.isChrome = sandbox.stub().returns(false);
-      sandbox.stub(service, 'getPlatform_').returns(new PlatformFake());
+      PlatformFake.prototype.isSafari = env.sandbox.stub().returns(true);
+      PlatformFake.prototype.isChrome = env.sandbox.stub().returns(false);
+      env.sandbox.stub(service, 'getPlatform_').returns(new PlatformFake());
 
       const fakeEvent = {
         target: {
@@ -119,9 +119,9 @@ describes.sandboxed('amp-standalone', {}, () => {
       fakeAmpdoc.win.origin = 'http://www.example.com';
       const service = new StandaloneService(fakeAmpdoc);
       class PlatformFake {}
-      PlatformFake.prototype.isSafari = sandbox.stub().returns(true);
-      PlatformFake.prototype.isChrome = sandbox.stub().returns(false);
-      sandbox.stub(service, 'getPlatform_').returns(new PlatformFake());
+      PlatformFake.prototype.isSafari = env.sandbox.stub().returns(true);
+      PlatformFake.prototype.isChrome = env.sandbox.stub().returns(false);
+      env.sandbox.stub(service, 'getPlatform_').returns(new PlatformFake());
 
       const fakeEvent = {
         target: {
@@ -142,9 +142,9 @@ describes.sandboxed('amp-standalone', {}, () => {
       fakeAmpdoc.win.origin = 'http://www.example.com';
       const service = new StandaloneService(fakeAmpdoc);
       class PlatformFake {}
-      PlatformFake.prototype.isSafari = sandbox.stub().returns(false);
-      PlatformFake.prototype.isChrome = sandbox.stub().returns(true);
-      sandbox.stub(service, 'getPlatform_').returns(new PlatformFake());
+      PlatformFake.prototype.isSafari = env.sandbox.stub().returns(false);
+      PlatformFake.prototype.isChrome = env.sandbox.stub().returns(true);
+      env.sandbox.stub(service, 'getPlatform_').returns(new PlatformFake());
 
       const fakeEvent = {
         target: {
@@ -163,9 +163,9 @@ describes.sandboxed('amp-standalone', {}, () => {
       fakeAmpdoc.win.origin = 'http://www.example.com';
       const service = new StandaloneService(fakeAmpdoc);
       class PlatformFake {}
-      PlatformFake.prototype.isSafari = sandbox.stub().returns(false);
-      PlatformFake.prototype.isChrome = sandbox.stub().returns(true);
-      sandbox.stub(service, 'getPlatform_').returns(new PlatformFake());
+      PlatformFake.prototype.isSafari = env.sandbox.stub().returns(false);
+      PlatformFake.prototype.isChrome = env.sandbox.stub().returns(true);
+      env.sandbox.stub(service, 'getPlatform_').returns(new PlatformFake());
 
       const fakeEvent = {
         target: {
@@ -184,9 +184,9 @@ describes.sandboxed('amp-standalone', {}, () => {
       fakeAmpdoc.win.origin = 'http://www.example.com';
       const service = new StandaloneService(fakeAmpdoc);
       class PlatformFake {}
-      PlatformFake.prototype.isSafari = sandbox.stub().returns(false);
-      PlatformFake.prototype.isChrome = sandbox.stub().returns(true);
-      sandbox.stub(service, 'getPlatform_').returns(new PlatformFake());
+      PlatformFake.prototype.isSafari = env.sandbox.stub().returns(false);
+      PlatformFake.prototype.isChrome = env.sandbox.stub().returns(true);
+      env.sandbox.stub(service, 'getPlatform_').returns(new PlatformFake());
 
       const fakeEvent = {
         target: {

--- a/extensions/amp-sticky-ad/1.0/test/test-amp-sticky-ad.js
+++ b/extensions/amp-sticky-ad/1.0/test/test-amp-sticky-ad.js
@@ -37,7 +37,6 @@ describes.realWin(
   },
   env => {
     let win;
-    let sandbox;
     let ampStickyAd;
     let ampAd;
     let impl;
@@ -46,7 +45,6 @@ describes.realWin(
     describe('with valid child 1.0', () => {
       beforeEach(() => {
         win = env.win;
-        sandbox = env.sandbox;
         ampStickyAd = win.document.createElement('amp-sticky-ad');
         ampStickyAd.setAttribute('layout', 'nodisplay');
         ampAd = createElementWithAttributes(win.document, 'amp-ad', {
@@ -59,14 +57,14 @@ describes.realWin(
         ampStickyAd.build();
         impl = ampStickyAd.implementation_;
         addToFixedLayerPromise = Promise.resolve();
-        addToFixedLayerStub = sandbox
+        addToFixedLayerStub = env.sandbox
           .stub(impl.viewport_, 'addToFixedLayer')
           .callsFake(() => addToFixedLayerPromise);
       });
 
       // TODO(#16916): Make this test work with synchronous throws.
       it.skip('should listen to scroll event', function*() {
-        const spy = sandbox.spy(impl, 'removeOnScrollListener_');
+        const spy = env.sandbox.spy(impl, 'removeOnScrollListener_');
         expect(impl.scrollUnlisten_).to.be.null;
         yield macroTask();
         // Hack to handle possible unexpected page scroll
@@ -78,16 +76,16 @@ describes.realWin(
       });
 
       it('should not build when scrollTop not greater than 1', () => {
-        const scheduleLayoutSpy = sandbox.spy(
+        const scheduleLayoutSpy = env.sandbox.spy(
           Services.ownersForDoc(impl.element),
           'scheduleLayout'
         );
-        const removeOnScrollListenerSpy = sandbox.spy(
+        const removeOnScrollListenerSpy = env.sandbox.spy(
           impl,
           'removeOnScrollListener_'
         );
-        const getScrollTopSpy = sandbox.spy();
-        const getScrollHeightSpy = sandbox.spy();
+        const getScrollTopSpy = env.sandbox.spy();
+        const getScrollHeightSpy = env.sandbox.spy();
 
         impl.viewport_.getScrollTop = function() {
           getScrollTopSpy();
@@ -108,21 +106,24 @@ describes.realWin(
       });
 
       it('should display once user scroll', () => {
-        const scheduleLayoutSpy = sandbox
+        const scheduleLayoutSpy = env.sandbox
           .stub(impl, 'scheduleLayoutForAd_')
           .callsFake(() => {});
-        const removeOnScrollListenerSpy = sandbox.spy(
+        const removeOnScrollListenerSpy = env.sandbox.spy(
           impl,
           'removeOnScrollListener_'
         );
 
-        const getScrollTopStub = sandbox.stub(impl.viewport_, 'getScrollTop');
+        const getScrollTopStub = env.sandbox.stub(
+          impl.viewport_,
+          'getScrollTop'
+        );
         getScrollTopStub.returns(2);
-        const getSizeStub = sandbox.stub(impl.viewport_, 'getSize');
+        const getSizeStub = env.sandbox.stub(impl.viewport_, 'getSize');
         getSizeStub.returns({
           height: 50,
         });
-        const getScrollHeightStub = sandbox.stub(
+        const getScrollHeightStub = env.sandbox.stub(
           impl.viewport_,
           'getScrollHeight'
         );
@@ -172,8 +173,8 @@ describes.realWin(
       });
 
       it('should create a close button', () => {
-        const addCloseButtonSpy = sandbox.spy(impl, 'addCloseButton_');
-        sandbox.stub(impl, 'scheduleLayoutForAd_').callsFake(() => {});
+        const addCloseButtonSpy = env.sandbox.spy(impl, 'addCloseButton_');
+        env.sandbox.stub(impl, 'scheduleLayoutForAd_').callsFake(() => {});
 
         impl.viewport_.getScrollTop = function() {
           return 100;
@@ -213,7 +214,7 @@ describes.realWin(
         impl.vsync_.mutate = function(callback) {
           callback();
         };
-        const layoutAdSpy = sandbox.spy(impl, 'layoutAd_');
+        const layoutAdSpy = env.sandbox.spy(impl, 'layoutAd_');
         impl.scheduleLayoutForAd_();
         expect(layoutAdSpy).to.not.been.called;
         impl.ad_.signals().signal('built');
@@ -349,7 +350,7 @@ describes.realWin(
       ampStickyAd.build();
       impl = ampStickyAd.implementation_;
       addToFixedLayerPromise = Promise.resolve();
-      sandbox
+      env.sandbox
         .stub(impl.viewport_, 'addToFixedLayer')
         .callsFake(() => addToFixedLayerPromise);
       return ampAd.implementation_.upgradeCallback();
@@ -372,7 +373,7 @@ describes.realWin(
       impl.vsync_.mutate = function(callback) {
         callback();
       };
-      sandbox.defineProperty(impl.element, 'offsetHeight', {value: 20});
+      env.sandbox.defineProperty(impl.element, 'offsetHeight', {value: 20});
 
       impl.display_();
       impl.ad_.signals().signal('built');
@@ -417,7 +418,7 @@ describes.realWin(
       impl.vsync_.mutate = function(callback) {
         callback();
       };
-      sandbox.defineProperty(impl.element, 'offsetHeight', {value: 20});
+      env.sandbox.defineProperty(impl.element, 'offsetHeight', {value: 20});
 
       impl.display_();
       impl.ad_.signals().signal('built');

--- a/extensions/amp-story-auto-ads/0.1/test/test-amp-story-auto-ads.js
+++ b/extensions/amp-story-auto-ads/0.1/test/test-amp-story-auto-ads.js
@@ -57,7 +57,7 @@ describes.realWin(
       win = env.win;
       doc = win.document;
       const viewer = Services.viewerForDoc(env.ampdoc);
-      sandbox.stub(Services, 'viewerForDoc').returns(viewer);
+      env.sandbox.stub(Services, 'viewerForDoc').returns(viewer);
       registerServiceBuilder(win, 'performance', () => ({
         isPerformanceTrackingOn: () => false,
       }));
@@ -72,8 +72,8 @@ describes.realWin(
     describe('service installation', () => {
       let installExtensionForDocStub;
       beforeEach(() => {
-        installExtensionForDocStub = sandbox.spy();
-        sandbox
+        installExtensionForDocStub = env.sandbox.spy();
+        env.sandbox
           .stub(Services.extensionsFor(win), 'installExtensionForDoc')
           .callsFake(installExtensionForDocStub);
         new MockStoryImpl(storyElement);
@@ -132,14 +132,17 @@ describes.realWin(
 
     describe('visible attribute', () => {
       beforeEach(() => {
-        sandbox.stub(autoAds, 'analyticsEvent_').returns(NOOP);
+        env.sandbox.stub(autoAds, 'analyticsEvent_').returns(NOOP);
         autoAds.adPagesCreated_ = 1;
         autoAds.adPageIds_ = {'ad-page-1': 1};
       });
 
       it('sets the visible attribute when showing', () => {
-        const setVisibleStub = sandbox.stub(autoAds, 'setVisibleAttribute_');
-        sandbox.stub(autoAds, 'startNextAdPage_').returns(NOOP);
+        const setVisibleStub = env.sandbox.stub(
+          autoAds,
+          'setVisibleAttribute_'
+        );
+        env.sandbox.stub(autoAds, 'startNextAdPage_').returns(NOOP);
         // Switching to ad page.
         autoAds.handleActivePageChange_(
           /* pageIndex */ 1,
@@ -149,7 +152,7 @@ describes.realWin(
       });
 
       it('removes the visible attribute when showing', () => {
-        const removeVisibleStub = sandbox.stub(
+        const removeVisibleStub = env.sandbox.stub(
           autoAds,
           'removeVisibleAttribute_'
         );
@@ -167,7 +170,7 @@ describes.realWin(
 
       beforeEach(async () => {
         // Force sync mutateElement.
-        sandbox.stub(autoAds, 'mutateElement').callsArg(0);
+        env.sandbox.stub(autoAds, 'mutateElement').callsArg(0);
         addStoryAutoAdsConfig(adElement);
         storeService = getStoreService(win);
         await story.buildCallback();
@@ -212,32 +215,32 @@ describes.realWin(
       it('should fire "story-ad-insert" upon insertion', async () => {
         autoAds.uniquePagesCount_ = 10;
         autoAds.adPagesCreated_ = 1;
-        sandbox.stub(autoAds, 'startNextAdPage_');
-        sandbox
+        env.sandbox.stub(autoAds, 'startNextAdPage_');
+        env.sandbox
           .stub(autoAds, 'tryToPlaceAdAfterPage_')
           .resolves(/* placed */ 1);
-        const analyticsStub = sandbox.stub(autoAds, 'analyticsEvent_');
+        const analyticsStub = env.sandbox.stub(autoAds, 'analyticsEvent_');
         autoAds.handleActivePageChange_(3, 'fakePage');
         await macroTask();
         expect(analyticsStub).to.be.called;
         expect(analyticsStub).to.have.been.calledWithMatch('story-ad-insert', {
-          'insertTime': sinon.match.number,
+          'insertTime': env.sandbox.match.number,
         });
       });
 
       it('should fire "story-ad-discard" upon discarded ad', async () => {
         autoAds.uniquePagesCount_ = 10;
         autoAds.adPagesCreated_ = 1;
-        sandbox.stub(autoAds, 'startNextAdPage_');
-        sandbox
+        env.sandbox.stub(autoAds, 'startNextAdPage_');
+        env.sandbox
           .stub(autoAds, 'tryToPlaceAdAfterPage_')
           .resolves(/* discard */ 2);
-        const analyticsStub = sandbox.stub(autoAds, 'analyticsEvent_');
+        const analyticsStub = env.sandbox.stub(autoAds, 'analyticsEvent_');
         autoAds.handleActivePageChange_(3, 'fakePage');
         await macroTask();
         expect(analyticsStub).to.be.called;
         expect(analyticsStub).to.have.been.calledWithMatch('story-ad-discard', {
-          'discardTime': sinon.match.number,
+          'discardTime': env.sandbox.match.number,
         });
       });
 
@@ -248,13 +251,13 @@ describes.realWin(
         };
         autoAds.setVisibleAttribute_ = NOOP;
         autoAds.adPagesCreated_ = 1;
-        sandbox.stub(autoAds, 'startNextAdPage_');
-        const analyticsStub = sandbox.stub(autoAds, 'analyticsEvent_');
+        env.sandbox.stub(autoAds, 'startNextAdPage_');
+        const analyticsStub = env.sandbox.stub(autoAds, 'analyticsEvent_');
         autoAds.adPageIds_ = {'ad-page-1': 1};
         autoAds.handleActivePageChange_(1, 'ad-page-1');
         expect(analyticsStub).to.be.called;
         expect(analyticsStub).to.have.been.calledWithMatch('story-ad-view', {
-          'viewTime': sinon.match.number,
+          'viewTime': env.sandbox.match.number,
         });
       });
 
@@ -267,13 +270,13 @@ describes.realWin(
         const page = win.document.createElement('amp-story-page');
         page.getImpl = () => Promise.resolve();
 
-        const analyticsStub = sandbox.stub(autoAds, 'analyticsEvent_');
+        const analyticsStub = env.sandbox.stub(autoAds, 'analyticsEvent_');
         autoAds.idOfAdShowing_ = 'ad-page-1';
         autoAds.handleActivePageChange_(1, 'page-3');
 
         expect(analyticsStub).to.be.called;
         expect(analyticsStub).to.have.been.calledWithMatch('story-ad-exit', {
-          'exitTime': sinon.match.number,
+          'exitTime': env.sandbox.match.number,
         });
       });
     });
@@ -281,7 +284,7 @@ describes.realWin(
     describe('development mode', () => {
       it('should immediately insert and navigate to ad page', async () => {
         const storeService = await Services.storyStoreServiceForOrNull(win);
-        const storeStub = sandbox.stub(storeService, 'get');
+        const storeStub = env.sandbox.stub(storeService, 'get');
         storeStub
           .withArgs(StateProperty.CURRENT_PAGE_ID)
           .returns('story-page-0');
@@ -300,7 +303,7 @@ describes.realWin(
         };
         addStoryAutoAdsConfig(adElement, config);
 
-        sandbox
+        env.sandbox
           .stub(StoryAdPage.prototype, 'maybeCreateCta')
           .resolves(/* success */ true);
 
@@ -308,8 +311,8 @@ describes.realWin(
         await autoAds.layoutCallback();
 
         const adPageElement = doc.querySelector('#i-amphtml-ad-page-1');
-        const insertSpy = sandbox.spy(storyImpl, 'insertPage');
-        const dispatchStub = sandbox.spy(storyEvents, 'dispatch');
+        const insertSpy = env.sandbox.spy(storyImpl, 'insertPage');
+        const dispatchStub = env.sandbox.spy(storyEvents, 'dispatch');
 
         const ampAd = doc.querySelector('amp-ad');
         ampAd.signals().signal(CommonSignals.INI_LOAD);
@@ -325,8 +328,8 @@ describes.realWin(
           win,
           adPageElement,
           storyEvents.EventType.SWITCH_PAGE,
-          sinon.match(payload),
-          sinon.match(eventInit)
+          env.sandbox.match(payload),
+          env.sandbox.match(eventInit)
         );
       });
     });

--- a/extensions/amp-story-auto-ads/0.1/test/test-story-ad-analytics.js
+++ b/extensions/amp-story-auto-ads/0.1/test/test-story-ad-analytics.js
@@ -32,7 +32,7 @@ describes.realWin('amp-story-auto-ads:story-ad-analytics', {amp: true}, env => {
     win = env.win;
     ampdoc = env.ampdoc;
     analytics = new StoryAdAnalytics(ampdoc);
-    triggerStub = sandbox.stub(analyticsApi, 'triggerAnalyticsEvent');
+    triggerStub = env.sandbox.stub(analyticsApi, 'triggerAnalyticsEvent');
     const doc = win.document;
     ampStoryAutoAdsEl = doc.createElement('amp-story-auto-ads');
     doc.body.appendChild(ampStoryAutoAdsEl);
@@ -55,7 +55,7 @@ describes.realWin('amp-story-auto-ads:story-ad-analytics', {amp: true}, env => {
         {
           [AnalyticsVars.AD_INDEX]: 1,
           [AnalyticsVars.AD_LOADED]: loadTime,
-          [AnalyticsVars.AD_UNIQUE_ID]: sinon.match.string,
+          [AnalyticsVars.AD_UNIQUE_ID]: env.sandbox.match.string,
         }
       );
     });
@@ -89,7 +89,7 @@ describes.realWin('amp-story-auto-ads:story-ad-analytics', {amp: true}, env => {
           [AnalyticsVars.AD_INDEX]: 2,
           [AnalyticsVars.AD_LOADED]: loadTime,
           [AnalyticsVars.AD_INSERTED]: insertTime,
-          [AnalyticsVars.AD_UNIQUE_ID]: sinon.match.string,
+          [AnalyticsVars.AD_UNIQUE_ID]: env.sandbox.match.string,
         }
       );
     });
@@ -159,7 +159,7 @@ describes.realWin('amp-story-auto-ads:story-ad-analytics', {amp: true}, env => {
           [AnalyticsVars.CTA_TYPE]: 'LEARN',
           [AnalyticsVars.POSITION]: 14,
           [AnalyticsVars.AD_VIEWED]: 12345,
-          [AnalyticsVars.AD_UNIQUE_ID]: sinon.match.string,
+          [AnalyticsVars.AD_UNIQUE_ID]: env.sandbox.match.string,
         }
       );
 
@@ -180,7 +180,7 @@ describes.realWin('amp-story-auto-ads:story-ad-analytics', {amp: true}, env => {
           [AnalyticsVars.CTA_TYPE]: 'SHOP',
           [AnalyticsVars.POSITION]: 7,
           [AnalyticsVars.AD_EXITED]: 56789,
-          [AnalyticsVars.AD_UNIQUE_ID]: sinon.match.string,
+          [AnalyticsVars.AD_UNIQUE_ID]: env.sandbox.match.string,
         }
       );
     });

--- a/extensions/amp-story-auto-ads/0.1/test/test-story-ad-page.js
+++ b/extensions/amp-story-auto-ads/0.1/test/test-story-ad-page.js
@@ -108,7 +108,7 @@ describes.realWin('story-ad-page', {amp: true}, env => {
 
   describe('#hasTimedOut', () => {
     it('should timeout after > 10 seconds', () => {
-      const clock = sandbox.useFakeTimers(1555555555555);
+      const clock = window.sandbox.useFakeTimers(1555555555555);
       storyAdPage.build();
       expect(storyAdPage.hasTimedOut()).to.be.false;
       clock.tick(10009); // 10 second timeout.
@@ -140,7 +140,7 @@ describes.realWin('story-ad-page', {amp: true}, env => {
 
   describe('#registerLoadCallback', () => {
     it('registers given functions and executes when loaded', async () => {
-      const someFunc = sandbox.spy();
+      const someFunc = window.sandbox.spy();
       const pageElement = storyAdPage.build();
       // Stub delegateVideoAutoplay.
       pageElement.getImpl = () => Promise.resolve(pageImplMock);
@@ -363,7 +363,7 @@ describes.realWin('story-ad-page', {amp: true}, env => {
         'https://googleads.g.doubleclick.net/pagead/images/mtad/ad_choices_blue.png'
       );
 
-      const openWindowDialogStub = sandbox.stub(dom, 'openWindowDialog');
+      const openWindowDialogStub = window.sandbox.stub(dom, 'openWindowDialog');
       attribution.click();
       expect(openWindowDialogStub).to.be.calledOnce;
       expect(openWindowDialogStub).to.be.calledWithExactly(
@@ -421,8 +421,10 @@ describes.realWin('story-ad-page', {amp: true}, env => {
 
     beforeEach(() => {
       const storyAnalytics = new StoryAdAnalytics(env.ampdoc);
-      fireEventStub = sandbox.stub(storyAnalytics, 'fireEvent');
-      sandbox.stub(service, 'getServicePromiseForDoc').resolves(storyAnalytics);
+      fireEventStub = window.sandbox.stub(storyAnalytics, 'fireEvent');
+      window.sandbox
+        .stub(service, 'getServicePromiseForDoc')
+        .resolves(storyAnalytics);
       storyAdPage = new StoryAdPage(
         storyAutoAdsEl.getAmpDoc(),
         baseConfig,
@@ -439,7 +441,7 @@ describes.realWin('story-ad-page', {amp: true}, env => {
         pageElement,
         1, // adIndex
         'story-ad-request',
-        {requestTime: sinon.match.number}
+        {requestTime: window.sandbox.match.number}
       );
     });
 
@@ -456,7 +458,7 @@ describes.realWin('story-ad-page', {amp: true}, env => {
         pageElement,
         1, // adIndex
         'story-ad-load',
-        {loadTime: sinon.match.number}
+        {loadTime: window.sandbox.match.number}
       );
     });
 
@@ -482,7 +484,7 @@ describes.realWin('story-ad-page', {amp: true}, env => {
         pageElement,
         1, // adIndex
         'story-ad-click',
-        {clickTime: sinon.match.number}
+        {clickTime: window.sandbox.match.number}
       );
     });
   });

--- a/extensions/amp-story/0.1/test/test-amp-story-consent.js
+++ b/extensions/amp-story/0.1/test/test-amp-story-consent.js
@@ -46,7 +46,7 @@ describes.realWin('amp-story-consent', {amp: true}, env => {
     };
 
     const styles = {'background-color': 'rgb(0, 0, 0)'};
-    getComputedStyleStub = sandbox
+    getComputedStyleStub = env.sandbox
       .stub(win, 'getComputedStyle')
       .returns(styles);
 
@@ -224,7 +224,7 @@ describes.realWin('amp-story-consent', {amp: true}, env => {
   });
 
   it('should whitelist the <amp-consent> actions', () => {
-    const addToWhitelistStub = sandbox.stub(
+    const addToWhitelistStub = env.sandbox.stub(
       storyConsent.actions_,
       'addToWhitelist'
     );
@@ -238,7 +238,7 @@ describes.realWin('amp-story-consent', {amp: true}, env => {
   });
 
   it('should broadcast the amp actions', () => {
-    sandbox.stub(storyConsent.actions_, 'trigger');
+    env.sandbox.stub(storyConsent.actions_, 'trigger');
 
     storyConsent.buildCallback();
 

--- a/extensions/amp-story/0.1/test/test-amp-story-hint.js
+++ b/extensions/amp-story/0.1/test/test-amp-story-hint.js
@@ -32,10 +32,10 @@ describes.fakeWin('amp-story hint layer', {}, env => {
     const storeService = new AmpStoryStoreService(win);
     registerServiceBuilder(win, 'story-store', () => storeService);
 
-    sandbox
+    env.sandbox
       .stub(Services, 'vsyncFor')
       .callsFake(() => ({mutate: task => task()}));
-    sandbox
+    env.sandbox
       .stub(Services, 'timerFor')
       .callsFake(() => ({delay: NOOP, cancel: NOOP}));
 
@@ -49,7 +49,7 @@ describes.fakeWin('amp-story hint layer', {}, env => {
 
   // TODO(@gmajoulet, #21618): Fails in AmpStoryHint.showHint_.
   it.skip('should be able to show navigation help overlay', () => {
-    const hideAfterTimeoutStub = sandbox
+    const hideAfterTimeoutStub = env.sandbox
       .stub(ampStoryHint, 'hideAfterTimeout')
       .callsFake(NOOP);
 
@@ -65,7 +65,7 @@ describes.fakeWin('amp-story hint layer', {}, env => {
 
   // TODO(@gmajoulet, #21618): Fails in AmpStoryHint.showHint_.
   it.skip('should be able to show no previous page help overlay', () => {
-    const hideAfterTimeoutStub = sandbox
+    const hideAfterTimeoutStub = env.sandbox
       .stub(ampStoryHint, 'hideAfterTimeout')
       .callsFake(NOOP);
 

--- a/extensions/amp-story/0.1/test/test-amp-story-info-dialog.js
+++ b/extensions/amp-story/0.1/test/test-amp-story-info-dialog.js
@@ -44,18 +44,18 @@ describes.realWin('amp-story-share-menu', {amp: true}, env => {
     registerServiceBuilder(win, 'story-store', () => storeService);
 
     // Making sure resource tasks run synchronously.
-    sandbox.stub(Services, 'resourcesForDoc').returns({
+    env.sandbox.stub(Services, 'resourcesForDoc').returns({
       mutateElement: (element, callback) => {
         callback();
         return Promise.resolve();
       },
     });
 
-    sandbox.stub(Services, 'localizationServiceV01').returns({
+    env.sandbox.stub(Services, 'localizationServiceV01').returns({
       getLocalizedString: localizedStringId => `string(${localizedStringId})`,
     });
 
-    sandbox.stub(Services, 'viewerForDoc').returns({
+    env.sandbox.stub(Services, 'viewerForDoc').returns({
       isEmbedded: () => embedded,
       sendMessageAwaitResponse: eventType => {
         if (eventType === 'moreInfoLinkUrl') {

--- a/extensions/amp-story/0.1/test/test-amp-story-request-service.js
+++ b/extensions/amp-story/0.1/test/test-amp-story-request-service.js
@@ -28,7 +28,7 @@ describes.fakeWin('amp-story-store-service', {amp: true}, env => {
     storyElement = env.win.document.createElement('div');
     env.win.document.body.appendChild(storyElement);
     requestService = new AmpStoryRequestService(env.win, storyElement);
-    xhrMock = sandbox.mock(requestService.xhr_);
+    xhrMock = env.sandbox.mock(requestService.xhr_);
   });
 
   it('should not load the bookend config if no attribute is set', () => {

--- a/extensions/amp-story/0.1/test/test-amp-story-share-menu.js
+++ b/extensions/amp-story/0.1/test/test-amp-story-share-menu.js
@@ -45,11 +45,11 @@ describes.realWin('amp-story-share-menu', {amp: true}, env => {
       isSystemShareSupported: () => isSystemShareSupported,
       loadRequiredExtensions: () => {},
     };
-    shareWidgetMock = sandbox.mock(shareWidget);
-    sandbox.stub(ShareWidget, 'create').returns(shareWidget);
+    shareWidgetMock = env.sandbox.mock(shareWidget);
+    env.sandbox.stub(ShareWidget, 'create').returns(shareWidget);
 
     // Making sure the vsync tasks run synchronously.
-    sandbox.stub(Services, 'vsyncFor').returns({
+    env.sandbox.stub(Services, 'vsyncFor').returns({
       mutate: fn => fn(),
       run: (vsyncTaskSpec, vsyncState) => {
         vsyncTaskSpec.measure(vsyncState);
@@ -160,7 +160,7 @@ describes.realWin('amp-story-share-menu', {amp: true}, env => {
 
     shareMenu.build();
 
-    const clickCallbackSpy = sandbox.spy();
+    const clickCallbackSpy = env.sandbox.spy();
     shareMenu.element_.addEventListener('click', clickCallbackSpy);
 
     // Toggling the share menu dispatches a click event on the amp-social-share

--- a/extensions/amp-story/0.1/test/test-amp-story-store-service.js
+++ b/extensions/amp-story/0.1/test/test-amp-story-store-service.js
@@ -34,7 +34,7 @@ describes.fakeWin('amp-story-store-service', {}, env => {
   });
 
   it('should subscribe to property mutations and receive the new value', () => {
-    const listenerSpy = sandbox.spy();
+    const listenerSpy = env.sandbox.spy();
     storeService.subscribe(StateProperty.BOOKEND_STATE, listenerSpy);
     storeService.dispatch(Action.TOGGLE_BOOKEND, true);
     expect(listenerSpy).to.have.been.calledOnce;
@@ -42,20 +42,20 @@ describes.fakeWin('amp-story-store-service', {}, env => {
   });
 
   it('should not trigger a listener if another property changed', () => {
-    const listenerSpy = sandbox.spy();
+    const listenerSpy = env.sandbox.spy();
     storeService.subscribe(StateProperty.CAN_INSERT_AUTOMATIC_AD, listenerSpy);
     storeService.dispatch(Action.TOGGLE_BOOKEND, true);
     expect(listenerSpy).to.have.callCount(0);
   });
 
   it('should not trigger a listener on subscribe by default', () => {
-    const listenerSpy = sandbox.spy();
+    const listenerSpy = env.sandbox.spy();
     storeService.subscribe(StateProperty.BOOKEND_STATE, listenerSpy);
     expect(listenerSpy).to.have.callCount(0);
   });
 
   it('should trigger a listener on subscribe if option is set to true', () => {
-    const listenerSpy = sandbox.spy();
+    const listenerSpy = env.sandbox.spy();
     storeService.subscribe(StateProperty.BOOKEND_STATE, listenerSpy, true);
     expect(listenerSpy).to.have.been.calledOnce;
     expect(listenerSpy).to.have.been.calledWith(false);
@@ -85,7 +85,7 @@ describes.fakeWin('amp-story-store-service actions', {}, env => {
   });
 
   it('should toggle the bookend', () => {
-    const listenerSpy = sandbox.spy();
+    const listenerSpy = env.sandbox.spy();
     storeService.subscribe(StateProperty.BOOKEND_STATE, listenerSpy);
     storeService.dispatch(Action.TOGGLE_BOOKEND, true);
     expect(listenerSpy).to.have.been.calledOnce;
@@ -93,7 +93,7 @@ describes.fakeWin('amp-story-store-service actions', {}, env => {
   });
 
   it('should not toggle the bookend if embed mode disables it', () => {
-    const listenerSpy = sandbox.spy();
+    const listenerSpy = env.sandbox.spy();
     storeService.state_[StateProperty.CAN_SHOW_BOOKEND] = false;
     storeService.subscribe(StateProperty.BOOKEND_STATE, listenerSpy);
     storeService.dispatch(Action.TOGGLE_BOOKEND, true);
@@ -101,7 +101,7 @@ describes.fakeWin('amp-story-store-service actions', {}, env => {
   });
 
   it('should toggle the muted state', () => {
-    const listenerSpy = sandbox.spy();
+    const listenerSpy = env.sandbox.spy();
     storeService.subscribe(StateProperty.MUTED_STATE, listenerSpy);
     storeService.dispatch(Action.TOGGLE_MUTED, false);
     expect(listenerSpy).to.have.been.calledOnce;
@@ -109,7 +109,7 @@ describes.fakeWin('amp-story-store-service actions', {}, env => {
   });
 
   it('should toggle the desktop state', () => {
-    const listenerSpy = sandbox.spy();
+    const listenerSpy = env.sandbox.spy();
     storeService.subscribe(StateProperty.DESKTOP_STATE, listenerSpy);
     storeService.dispatch(Action.TOGGLE_DESKTOP, true);
     expect(listenerSpy).to.have.been.calledOnce;
@@ -117,7 +117,7 @@ describes.fakeWin('amp-story-store-service actions', {}, env => {
   });
 
   it('should update the current page id', () => {
-    const listenerSpy = sandbox.spy();
+    const listenerSpy = env.sandbox.spy();
     storeService.subscribe(StateProperty.CURRENT_PAGE_ID, listenerSpy);
     storeService.dispatch(Action.CHANGE_PAGE, {
       id: 'test-page',
@@ -128,7 +128,7 @@ describes.fakeWin('amp-story-store-service actions', {}, env => {
   });
 
   it('should update the current page index', () => {
-    const listenerSpy = sandbox.spy();
+    const listenerSpy = env.sandbox.spy();
     storeService.subscribe(StateProperty.CURRENT_PAGE_INDEX, listenerSpy);
     storeService.dispatch(Action.CHANGE_PAGE, {
       id: 'test-page',
@@ -139,7 +139,7 @@ describes.fakeWin('amp-story-store-service actions', {}, env => {
   });
 
   it('should toggle the has audio state', () => {
-    const listenerSpy = sandbox.spy();
+    const listenerSpy = env.sandbox.spy();
     storeService.subscribe(StateProperty.HAS_AUDIO_STATE, listenerSpy);
     storeService.dispatch(Action.TOGGLE_HAS_AUDIO, true);
     expect(listenerSpy).to.have.been.calledOnce;
@@ -147,7 +147,7 @@ describes.fakeWin('amp-story-store-service actions', {}, env => {
   });
 
   it('should toggle the landscape state', () => {
-    const listenerSpy = sandbox.spy();
+    const listenerSpy = env.sandbox.spy();
     storeService.subscribe(StateProperty.LANDSCAPE_STATE, listenerSpy);
     storeService.dispatch(Action.TOGGLE_LANDSCAPE, true);
     expect(listenerSpy).to.have.been.calledOnce;
@@ -155,7 +155,7 @@ describes.fakeWin('amp-story-store-service actions', {}, env => {
   });
 
   it('should toggle the supported browser state', () => {
-    const listenerSpy = sandbox.spy();
+    const listenerSpy = env.sandbox.spy();
     storeService.subscribe(StateProperty.SUPPORTED_BROWSER_STATE, listenerSpy);
     storeService.dispatch(Action.TOGGLE_SUPPORTED_BROWSER, false);
     expect(listenerSpy).to.have.been.calledOnce;

--- a/extensions/amp-story/0.1/test/test-amp-story-system-layer.js
+++ b/extensions/amp-story/0.1/test/test-amp-story-system-layer.js
@@ -36,15 +36,15 @@ describes.fakeWin('amp-story system layer', {amp: true}, env => {
     progressBarRoot = win.document.createElement('div');
 
     progressBarStub = {
-      build: sandbox.stub().returns(progressBarRoot),
-      getRoot: sandbox.stub().returns(progressBarRoot),
-      setActiveSegmentId: sandbox.spy(),
-      updateProgress: sandbox.spy(),
+      build: env.sandbox.stub().returns(progressBarRoot),
+      getRoot: env.sandbox.stub().returns(progressBarRoot),
+      setActiveSegmentId: env.sandbox.spy(),
+      updateProgress: env.sandbox.spy(),
     };
 
-    sandbox.stub(ProgressBar, 'create').returns(progressBarStub);
+    env.sandbox.stub(ProgressBar, 'create').returns(progressBarStub);
 
-    sandbox.stub(Services, 'vsyncFor').returns({
+    env.sandbox.stub(Services, 'vsyncFor').returns({
       mutate: fn => fn(),
     });
 
@@ -52,7 +52,7 @@ describes.fakeWin('amp-story system layer', {amp: true}, env => {
   });
 
   it.skip('should build UI', () => {
-    const initializeListeners = sandbox
+    const initializeListeners = env.sandbox
       .stub(systemLayer, 'initializeListeners_')
       .callsFake(NOOP);
 
@@ -65,10 +65,10 @@ describes.fakeWin('amp-story system layer', {amp: true}, env => {
 
   // TODO(alanorozco, #12476): Make this test work with sinon 4.0.
   it.skip('should attach event handlers', () => {
-    const rootMock = {addEventListener: sandbox.spy()};
+    const rootMock = {addEventListener: env.sandbox.spy()};
 
-    sandbox.stub(systemLayer, 'root_').callsFake(rootMock);
-    sandbox.stub(systemLayer, 'win_').callsFake(rootMock);
+    env.sandbox.stub(systemLayer, 'root_').callsFake(rootMock);
+    env.sandbox.stub(systemLayer, 'win_').callsFake(rootMock);
 
     systemLayer.initializeListeners_();
 

--- a/extensions/amp-story/0.1/test/test-amp-story.js
+++ b/extensions/amp-story/0.1/test/test-amp-story.js
@@ -104,12 +104,11 @@ describes.realWin(
       story = new AmpStory(element);
       // TODO(alanorozco): Test active page event triggers once the stubbable
       // `Services` module is part of the amphtml-story repo.
-      // sandbox.stub(element.implementation_,
+      // env.sandbox.stub(element.implementation_,
       // 'triggerActiveEventForPage_').callsFake(NOOP);
     });
 
     afterEach(() => {
-      sandbox.restore();
       element.remove();
     });
 
@@ -150,7 +149,7 @@ describes.realWin(
       const firstPageId = 'cover';
       const pageCount = 2;
       createPages(story.element, pageCount, [firstPageId, 'page-1']);
-      const updateActivePageStub = sandbox.stub(
+      const updateActivePageStub = env.sandbox.stub(
         story.navigationState_,
         'updateActivePage'
       );
@@ -167,8 +166,8 @@ describes.realWin(
     it('should preload the bookend if navigating to the last page', () => {
       createPages(story.element, 1, ['cover']);
 
-      const buildBookendStub = sandbox.stub(story.bookend_, 'build');
-      const loadBookendStub = sandbox
+      const buildBookendStub = env.sandbox.stub(story.bookend_, 'build');
+      const loadBookendStub = env.sandbox
         .stub(story.bookend_, 'loadConfig')
         .resolves({});
 
@@ -181,8 +180,8 @@ describes.realWin(
     it('should not preload the bookend if not on the last page', () => {
       createPages(story.element, 2, ['cover']);
 
-      const buildBookendStub = sandbox.stub(story.bookend_, 'build');
-      const loadBookendStub = sandbox
+      const buildBookendStub = env.sandbox.stub(story.bookend_, 'build');
+      const loadBookendStub = env.sandbox
         .stub(story.bookend_, 'loadConfig')
         .resolves({});
 
@@ -195,8 +194,8 @@ describes.realWin(
     it('should prerender/load the share menu', () => {
       createPages(story.element, 1, ['cover']);
 
-      sandbox.stub(story.bookend_, 'build');
-      const buildShareMenuStub = sandbox.stub(story.shareMenu_, 'build');
+      env.sandbox.stub(story.bookend_, 'build');
+      const buildShareMenuStub = env.sandbox.stub(story.shareMenu_, 'build');
 
       return story.layoutCallback().then(() => {
         expect(buildShareMenuStub).to.have.been.calledOnce;
@@ -208,8 +207,8 @@ describes.realWin(
 
       story.storeService_.dispatch(Action.TOGGLE_DESKTOP, true);
 
-      sandbox.stub(story.bookend_, 'build');
-      const buildShareMenuStub = sandbox.stub(story.shareMenu_, 'build');
+      env.sandbox.stub(story.bookend_, 'build');
+      const buildShareMenuStub = env.sandbox.stub(story.shareMenu_, 'build');
 
       return story.layoutCallback().then(() => {
         expect(buildShareMenuStub).to.not.have.been.called;
@@ -218,7 +217,7 @@ describes.realWin(
 
     // TODO(#11639): Re-enable this test.
     it.skip('should hide bookend when CLOSE_BOOKEND is triggered', () => {
-      const hideBookendStub = sandbox.stub(
+      const hideBookendStub = env.sandbox.stub(
         element.implementation_,
         'hideBookend_',
         NOOP
@@ -252,14 +251,14 @@ describes.realWin(
 
       const page = win.document.createElement('div');
 
-      const updateProgressBarStub = sandbox
+      const updateProgressBarStub = env.sandbox
         .stub(impl.systemLayer_, 'updateProgressBar')
         .callsFake(NOOP);
 
       appendEmptyPage(element, /* opt_active */ true);
 
-      sandbox.stub(impl, 'getPageCount').returns(count);
-      sandbox
+      env.sandbox.stub(impl, 'getPageCount').returns(count);
+      env.sandbox
         .stub(impl, 'getPageIndex')
         .withArgs(page)
         .returns(index);
@@ -275,8 +274,8 @@ describes.realWin(
       const impl = element.implementation_;
       const pages = createPages(element, 5);
       const owners = Services.ownersForDoc(impl.element);
-      owners.schedulePause = sandbox.spy();
-      owners.scheduleResume = sandbox.spy();
+      owners.schedulePause = env.sandbox.spy();
+      owners.scheduleResume = env.sandbox.spy();
 
       const oldPage = pages[0];
       const newPage = pages[1];
@@ -305,7 +304,7 @@ describes.realWin(
       expect(pages[1].hasAttribute('active')).to.be.false;
 
       // Stubbing because we need to assert synchronously
-      sandbox
+      env.sandbox
         .stub(element.implementation_, 'mutateElement')
         .callsFake(mutator => {
           mutator();
@@ -336,10 +335,12 @@ describes.realWin(
 
     it('builds and attaches pagination buttons ', () => {
       const paginationButtonsStub = {
-        attach: sandbox.spy(),
-        onNavigationStateChange: sandbox.spy(),
+        attach: env.sandbox.spy(),
+        onNavigationStateChange: env.sandbox.spy(),
       };
-      sandbox.stub(PaginationButtons, 'create').returns(paginationButtonsStub);
+      env.sandbox
+        .stub(PaginationButtons, 'create')
+        .returns(paginationButtonsStub);
       story.buildPaginationButtonsForTesting();
       expect(paginationButtonsStub.attach).to.have.been.calledWith(
         story.element
@@ -349,7 +350,9 @@ describes.realWin(
     it.skip('toggles `i-amphtml-story-landscape` based on height and width', () => {
       story.element.style.width = '11px';
       story.element.style.height = '10px';
-      const isDesktopStub = sandbox.stub(story, 'isDesktop_').returns(false);
+      const isDesktopStub = env.sandbox
+        .stub(story, 'isDesktop_')
+        .returns(false);
       story.vsync_ = {
         run: (task, state) => {
           if (task.measure) {
@@ -376,7 +379,7 @@ describes.realWin(
       const firstPageId = 'page-one';
       const pageCount = 2;
       createPages(story.element, pageCount, [firstPageId, 'page-1']);
-      const dispatchStub = sandbox.stub(story.storeService_, 'dispatch');
+      const dispatchStub = env.sandbox.stub(story.storeService_, 'dispatch');
 
       return story.layoutCallback().then(() => {
         expect(dispatchStub).to.have.been.calledWith(Action.CHANGE_PAGE, {
@@ -389,7 +392,7 @@ describes.realWin(
     it('should update page id in browser history', () => {
       // Have to stub this because tests run in iframe and you can't write
       // history from another domain (about:srcdoc)
-      const replaceStub = sandbox.stub(win.history, 'replaceState');
+      const replaceStub = env.sandbox.stub(win.history, 'replaceState');
       const firstPageId = 'page-zero';
       const pageCount = 2;
       createPages(story.element, pageCount, [firstPageId, 'page-1']);
@@ -406,7 +409,7 @@ describes.realWin(
     it('should NOT update page id in browser history if ad', () => {
       // Have to stub this because tests run in iframe and you can't write
       // history from another domain (about:srcdoc)
-      const replaceStub = sandbox.stub(win.history, 'replaceState');
+      const replaceStub = env.sandbox.stub(win.history, 'replaceState');
       const firstPageId = 'i-amphtml-ad-page-1';
       const pageCount = 2;
       const pages = createPages(story.element, pageCount, [

--- a/extensions/amp-story/0.1/test/test-analytics.js
+++ b/extensions/amp-story/0.1/test/test-analytics.js
@@ -26,7 +26,7 @@ describes.fakeWin('amp-story analytics', {}, env => {
   });
 
   it('should trigger `story-page-visible` on change', () => {
-    const trigger = sandbox.stub(analytics, 'triggerEvent_');
+    const trigger = env.sandbox.stub(analytics, 'triggerEvent_');
 
     analytics.onNavigationStateChange({
       type: StateChangeType.ACTIVE_PAGE,

--- a/extensions/amp-story/0.1/test/test-media-pool.js
+++ b/extensions/amp-story/0.1/test/test-media-pool.js
@@ -30,10 +30,10 @@ describes.realWin('media-pool', {}, env => {
 
   beforeEach(() => {
     win = env.win;
-    sandbox
+    env.sandbox
       .stub(Services, 'vsyncFor')
       .callsFake(() => ({mutate: task => task()}));
-    sandbox.stub(Services, 'timerFor').callsFake(() => ({delay: NOOP}));
+    env.sandbox.stub(Services, 'timerFor').callsFake(() => ({delay: NOOP}));
 
     mediaPool = new MediaPool(win, COUNTS, element => {
       return distanceFnStub(element);

--- a/extensions/amp-story/0.1/test/test-media-tasks.js
+++ b/extensions/amp-story/0.1/test/test-media-tasks.js
@@ -27,27 +27,25 @@ import {
 import {Sources} from '../sources';
 import {toArray} from '../../../../src/types';
 
-describes.realWin('media-tasks', {}, () => {
-  let sandbox;
+describes.realWin('media-tasks', {}, env => {
   let el;
   let vsyncApi;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox;
     el = document.createElement('video');
 
     // Mock vsync
     vsyncApi = {
       mutatePromise: () => {},
     };
-    sandbox.stub(vsyncApi, 'mutatePromise').resolves(callback => {
+    env.sandbox.stub(vsyncApi, 'mutatePromise').resolves(callback => {
       callback();
     });
   });
 
   describe('PauseTask', () => {
     it('should call pause()', () => {
-      const pause = sandbox.spy(el, 'pause');
+      const pause = env.sandbox.spy(el, 'pause');
       const task = new PauseTask();
       task.execute(el);
       expect(pause).to.have.been.called;
@@ -58,7 +56,7 @@ describes.realWin('media-tasks', {}, () => {
     it('should call play() if element was not yet playing', () => {
       expect(el.paused).to.be.true;
 
-      const play = sandbox.spy(el, 'play');
+      const play = env.sandbox.spy(el, 'play');
       const task = new PlayTask();
       task.execute(el);
       expect(play).to.have.been.called;
@@ -68,7 +66,7 @@ describes.realWin('media-tasks', {}, () => {
       el.play();
       expect(el.paused).to.be.false;
 
-      const play = sandbox.spy(el, 'play');
+      const play = env.sandbox.spy(el, 'play');
       const task = new PlayTask();
       task.execute(el);
       expect(play).not.to.have.been.called;
@@ -99,7 +97,7 @@ describes.realWin('media-tasks', {}, () => {
 
   describe('LoadTask', () => {
     it('should call load()', () => {
-      const load = sandbox.spy(el, 'load');
+      const load = env.sandbox.spy(el, 'load');
       const task = new LoadTask();
       task.execute(el);
       expect(load).to.have.been.called;

--- a/extensions/amp-story/0.1/test/test-navigation-state.js
+++ b/extensions/amp-story/0.1/test/test-navigation-state.js
@@ -40,7 +40,7 @@ describes.fakeWin('amp-story navigation state', {ampdoc: 'none'}, env => {
   it('should dispatch active page changes to all observers', () => {
     const observers = Array(5)
       .fill(undefined)
-      .map(() => sandbox.spy());
+      .map(() => env.sandbox.spy());
 
     observers.forEach(observer => navigationState.observe(observer));
 
@@ -48,7 +48,7 @@ describes.fakeWin('amp-story navigation state', {ampdoc: 'none'}, env => {
 
     observers.forEach(observer => {
       expect(observer).to.have.been.calledWith(
-        sandbox.match(
+        env.sandbox.match(
           e =>
             e.type == StateChangeType.ACTIVE_PAGE &&
             e.value.pageIndex === 0 &&
@@ -63,7 +63,7 @@ describes.fakeWin('amp-story navigation state', {ampdoc: 'none'}, env => {
 
     observers.forEach(observer => {
       expect(observer).to.have.been.calledWith(
-        sandbox.match(
+        env.sandbox.match(
           e =>
             e.type == StateChangeType.ACTIVE_PAGE &&
             e.value.pageIndex === 5 &&
@@ -78,7 +78,7 @@ describes.fakeWin('amp-story navigation state', {ampdoc: 'none'}, env => {
 
     observers.forEach(observer => {
       expect(observer).to.have.been.calledWith(
-        sandbox.match(
+        env.sandbox.match(
           e =>
             e.type == StateChangeType.ACTIVE_PAGE &&
             e.value.pageIndex === 2 &&
@@ -91,7 +91,7 @@ describes.fakeWin('amp-story navigation state', {ampdoc: 'none'}, env => {
   });
 
   it('should dispatch END on last page if story does NOT have bookend', () => {
-    const observer = sandbox.spy();
+    const observer = env.sandbox.spy();
 
     navigationState.observe(event => observer(event));
 
@@ -100,7 +100,7 @@ describes.fakeWin('amp-story navigation state', {ampdoc: 'none'}, env => {
     navigationState.updateActivePage(1, 2);
 
     expect(observer).to.have.been.calledWith(
-      sandbox.match(
+      env.sandbox.match(
         e =>
           e.type == StateChangeType.ACTIVE_PAGE &&
           e.value.pageIndex === 1 &&
@@ -109,12 +109,12 @@ describes.fakeWin('amp-story navigation state', {ampdoc: 'none'}, env => {
     );
 
     expect(observer).to.have.been.calledWith(
-      sandbox.match(e => e.type == StateChangeType.END)
+      env.sandbox.match(e => e.type == StateChangeType.END)
     );
   });
 
   it('should NOT dispatch END on last page if story has bookend', () => {
-    const observer = sandbox.spy();
+    const observer = env.sandbox.spy();
 
     navigationState.observe(event => observer(event));
 
@@ -123,7 +123,7 @@ describes.fakeWin('amp-story navigation state', {ampdoc: 'none'}, env => {
     navigationState.updateActivePage(1, 2);
 
     expect(observer).to.have.been.calledWith(
-      sandbox.match(
+      env.sandbox.match(
         e =>
           e.type == StateChangeType.ACTIVE_PAGE &&
           e.value.pageIndex === 1 &&
@@ -132,12 +132,12 @@ describes.fakeWin('amp-story navigation state', {ampdoc: 'none'}, env => {
     );
 
     expect(observer).to.not.have.been.calledWith(
-      sandbox.match(e => e.type == StateChangeType.END)
+      env.sandbox.match(e => e.type == StateChangeType.END)
     );
   });
 
   it('should dispatch BOOKEND_ENTER/END and BOOKEND_EXIT', () => {
-    const observer = sandbox.spy();
+    const observer = env.sandbox.spy();
 
     navigationState.observe(event => observer(event.type));
 

--- a/extensions/amp-story/1.0/test/test-amp-story-bookend.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-bookend.js
@@ -134,7 +134,7 @@ describes.realWin('amp-story-bookend', {amp: true}, env => {
     storyElem.appendChild(bookendElem);
 
     requestService = new AmpStoryRequestService(win, storyElem);
-    sandbox.stub(Services, 'storyRequestService').returns(requestService);
+    env.sandbox.stub(Services, 'storyRequestService').returns(requestService);
 
     const localizationService = new LocalizationService(win);
     registerServiceBuilder(win, 'localization', () => localizationService);
@@ -146,8 +146,8 @@ describes.realWin('amp-story-bookend', {amp: true}, env => {
     analyticsVariables = getVariableService(win);
 
     // Force sync mutateElement.
-    sandbox.stub(bookend, 'mutateElement').callsArg(0);
-    sandbox.stub(bookend, 'getStoryMetadata_').returns(metadata);
+    env.sandbox.stub(bookend, 'mutateElement').callsArg(0);
+    env.sandbox.stub(bookend, 'getStoryMetadata_').returns(metadata);
   });
 
   it('should build the users json', async () => {
@@ -212,7 +212,7 @@ describes.realWin('amp-story-bookend', {amp: true}, env => {
       ],
     };
 
-    sandbox.stub(requestService, 'loadBookendConfig').resolves(userJson);
+    env.sandbox.stub(requestService, 'loadBookendConfig').resolves(userJson);
 
     bookend.build();
     const config = await bookend.loadConfigAndMaybeRenderBookend();
@@ -284,7 +284,7 @@ describes.realWin('amp-story-bookend', {amp: true}, env => {
       ],
     };
 
-    sandbox.stub(requestService, 'loadBookendConfig').resolves(userJson);
+    env.sandbox.stub(requestService, 'loadBookendConfig').resolves(userJson);
 
     bookend.build();
     const config = await bookend.loadConfigAndMaybeRenderBookend();
@@ -318,7 +318,7 @@ describes.realWin('amp-story-bookend', {amp: true}, env => {
         ],
       };
 
-      sandbox.stub(requestService, 'loadBookendConfig').resolves(userJson);
+      env.sandbox.stub(requestService, 'loadBookendConfig').resolves(userJson);
 
       bookend.build();
       await bookend.loadConfigAndMaybeRenderBookend();
@@ -352,8 +352,8 @@ describes.realWin('amp-story-bookend', {amp: true}, env => {
       ],
     };
 
-    sandbox.stub(requestService, 'loadBookendConfig').resolves(userJson);
-    const clickSpy = sandbox.spy();
+    env.sandbox.stub(requestService, 'loadBookendConfig').resolves(userJson);
+    const clickSpy = env.sandbox.spy();
     doc.addEventListener('click', clickSpy);
 
     bookend.build();
@@ -393,8 +393,8 @@ describes.realWin('amp-story-bookend', {amp: true}, env => {
       ],
     };
 
-    sandbox.stub(requestService, 'loadBookendConfig').resolves(userJson);
-    const analyticsSpy = sandbox.spy(analytics, 'triggerEvent');
+    env.sandbox.stub(requestService, 'loadBookendConfig').resolves(userJson);
+    const analyticsSpy = env.sandbox.spy(analytics, 'triggerEvent');
 
     bookend.build();
     await bookend.loadConfigAndMaybeRenderBookend();
@@ -441,8 +441,8 @@ describes.realWin('amp-story-bookend', {amp: true}, env => {
       ],
     };
 
-    sandbox.stub(requestService, 'loadBookendConfig').resolves(userJson);
-    const analyticsSpy = sandbox.spy(analytics, 'triggerEvent');
+    env.sandbox.stub(requestService, 'loadBookendConfig').resolves(userJson);
+    const analyticsSpy = env.sandbox.spy(analytics, 'triggerEvent');
 
     bookend.build();
     await bookend.loadConfigAndMaybeRenderBookend();
@@ -485,7 +485,7 @@ describes.realWin('amp-story-bookend', {amp: true}, env => {
         ],
       };
 
-      sandbox.stub(requestService, 'loadBookendConfig').resolves(userJson);
+      env.sandbox.stub(requestService, 'loadBookendConfig').resolves(userJson);
 
       bookend.build();
       await bookend.loadConfigAndMaybeRenderBookend();
@@ -519,7 +519,7 @@ describes.realWin('amp-story-bookend', {amp: true}, env => {
         ],
       };
 
-      sandbox.stub(requestService, 'loadBookendConfig').resolves(userJson);
+      env.sandbox.stub(requestService, 'loadBookendConfig').resolves(userJson);
 
       bookend.build();
       await bookend.loadConfigAndMaybeRenderBookend();
@@ -559,7 +559,7 @@ describes.realWin('amp-story-bookend', {amp: true}, env => {
         ],
       };
 
-      sandbox.stub(requestService, 'loadBookendConfig').resolves(userJson);
+      env.sandbox.stub(requestService, 'loadBookendConfig').resolves(userJson);
 
       bookend.build();
       await bookend.loadConfigAndMaybeRenderBookend();
@@ -594,7 +594,7 @@ describes.realWin('amp-story-bookend', {amp: true}, env => {
         ],
       };
 
-      sandbox.stub(requestService, 'loadBookendConfig').resolves(userJson);
+      env.sandbox.stub(requestService, 'loadBookendConfig').resolves(userJson);
 
       bookend.build();
       await bookend.loadConfigAndMaybeRenderBookend();
@@ -636,7 +636,7 @@ describes.realWin('amp-story-bookend', {amp: true}, env => {
         ],
       };
 
-      sandbox.stub(requestService, 'loadBookendConfig').resolves(userJson);
+      env.sandbox.stub(requestService, 'loadBookendConfig').resolves(userJson);
 
       bookend.build();
       await bookend.loadConfigAndMaybeRenderBookend();
@@ -671,7 +671,7 @@ describes.realWin('amp-story-bookend', {amp: true}, env => {
         ],
       };
 
-      sandbox.stub(requestService, 'loadBookendConfig').resolves(userJson);
+      env.sandbox.stub(requestService, 'loadBookendConfig').resolves(userJson);
 
       bookend.build();
       await bookend.loadConfigAndMaybeRenderBookend();
@@ -713,7 +713,7 @@ describes.realWin('amp-story-bookend', {amp: true}, env => {
         ],
       };
 
-      sandbox.stub(requestService, 'loadBookendConfig').resolves(userJson);
+      env.sandbox.stub(requestService, 'loadBookendConfig').resolves(userJson);
 
       bookend.build();
       await bookend.loadConfigAndMaybeRenderBookend();
@@ -765,7 +765,7 @@ describes.realWin('amp-story-bookend', {amp: true}, env => {
       'whatsapp',
     ];
 
-    sandbox.stub(requestService, 'loadBookendConfig').resolves(userJson);
+    env.sandbox.stub(requestService, 'loadBookendConfig').resolves(userJson);
 
     bookend.build();
     const config = await bookend.loadConfigAndMaybeRenderBookend();
@@ -792,7 +792,7 @@ describes.realWin('amp-story-bookend', {amp: true}, env => {
       ],
     };
 
-    sandbox.stub(requestService, 'loadBookendConfig').resolves(userJson);
+    env.sandbox.stub(requestService, 'loadBookendConfig').resolves(userJson);
 
     bookend.build();
     const config = await bookend.loadConfigAndMaybeRenderBookend();
@@ -817,9 +817,9 @@ describes.realWin('amp-story-bookend', {amp: true}, env => {
       ],
     };
 
-    const userWarnStub = sandbox.stub(user(), 'warn');
+    const userWarnStub = env.sandbox.stub(user(), 'warn');
 
-    sandbox.stub(requestService, 'loadBookendConfig').resolves(userJson);
+    env.sandbox.stub(requestService, 'loadBookendConfig').resolves(userJson);
 
     bookend.build();
     await bookend.loadConfigAndMaybeRenderBookend();
@@ -1040,7 +1040,7 @@ describes.realWin('amp-story-bookend', {amp: true}, env => {
       ],
     };
 
-    sandbox.stub(requestService, 'loadBookendConfig').resolves(userJson);
+    env.sandbox.stub(requestService, 'loadBookendConfig').resolves(userJson);
 
     bookend.build();
     expectAsyncConsoleError(
@@ -1066,7 +1066,7 @@ describes.realWin('amp-story-bookend', {amp: true}, env => {
       'components': [],
     };
 
-    sandbox.stub(requestService, 'loadBookendConfig').resolves(userJson);
+    env.sandbox.stub(requestService, 'loadBookendConfig').resolves(userJson);
 
     bookend.build();
     const config = await bookend.loadConfigAndMaybeRenderBookend();

--- a/extensions/amp-story/1.0/test/test-amp-story-consent.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-consent.js
@@ -53,7 +53,7 @@ describes.realWin('amp-story-consent', {amp: true}, env => {
     };
 
     const styles = {'background-color': 'rgb(0, 0, 0)'};
-    getComputedStyleStub = sandbox
+    getComputedStyleStub = env.sandbox
       .stub(win, 'getComputedStyle')
       .returns(styles);
 
@@ -263,7 +263,7 @@ describes.realWin('amp-story-consent', {amp: true}, env => {
   });
 
   it('should broadcast the amp actions', () => {
-    sandbox.stub(storyConsent.actions_, 'trigger');
+    env.sandbox.stub(storyConsent.actions_, 'trigger');
 
     storyConsent.buildCallback();
 
@@ -300,7 +300,7 @@ describes.realWin('amp-story-consent', {amp: true}, env => {
     const config = {consents: {ABC: {promptIfUnknownForGeoGroup: 'eea'}}};
     consentConfigEl.textContent = JSON.stringify(config);
 
-    sandbox
+    env.sandbox
       .stub(Services, 'geoForDocOrNull')
       .resolves({matchedISOCountryGroups: ['eea']});
 
@@ -316,7 +316,7 @@ describes.realWin('amp-story-consent', {amp: true}, env => {
     const config = {consents: {ABC: {promptIfUnknownForGeoGroup: 'eea'}}};
     consentConfigEl.textContent = JSON.stringify(config);
 
-    sandbox
+    env.sandbox
       .stub(Services, 'geoForDocOrNull')
       .resolves({matchedISOCountryGroups: ['othergroup']});
 

--- a/extensions/amp-story/1.0/test/test-amp-story-embedded-component.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-embedded-component.js
@@ -44,7 +44,7 @@ describes.realWin('amp-story-embedded-component', {amp: true}, env => {
     addAttributesToElement(clickableEl, {'href': 'https://google.com'});
 
     // Making sure resource tasks run synchronously.
-    sandbox.stub(Services, 'resourcesForDoc').returns({
+    env.sandbox.stub(Services, 'resourcesForDoc').returns({
       mutateElement: (element, callback) => {
         callback();
         return Promise.resolve();
@@ -130,7 +130,7 @@ describes.realWin('amp-story-embedded-component', {amp: true}, env => {
     fakePage.appendChild(clickableEl);
     storeService.dispatch(Action.TOGGLE_INTERACTIVE_COMPONENT, fakeComponent);
 
-    const nextPageSpy = sandbox.spy();
+    const nextPageSpy = env.sandbox.spy();
     parentEl.addEventListener(EventType.NEXT_PAGE, nextPageSpy);
 
     const rightButton = component.focusedStateOverlay_.querySelector(
@@ -151,7 +151,7 @@ describes.realWin('amp-story-embedded-component', {amp: true}, env => {
       storeService.dispatch(Action.TOGGLE_RTL, true);
       storeService.dispatch(Action.TOGGLE_INTERACTIVE_COMPONENT, fakeComponent);
 
-      const previousPageSpy = sandbox.spy();
+      const previousPageSpy = env.sandbox.spy();
       parentEl.addEventListener(EventType.PREVIOUS_PAGE, previousPageSpy);
 
       const rightButton = component.focusedStateOverlay_.querySelector(

--- a/extensions/amp-story/1.0/test/test-amp-story-hint.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-hint.js
@@ -36,10 +36,10 @@ describes.fakeWin('amp-story hint layer', {}, env => {
     const storeService = new AmpStoryStoreService(win);
     registerServiceBuilder(win, 'story-store', () => storeService);
 
-    sandbox
+    env.sandbox
       .stub(Services, 'vsyncFor')
       .callsFake(() => ({mutate: task => task()}));
-    sandbox
+    env.sandbox
       .stub(Services, 'timerFor')
       .callsFake(() => ({delay: NOOP, cancel: NOOP}));
 
@@ -52,7 +52,7 @@ describes.fakeWin('amp-story hint layer', {}, env => {
   });
 
   it('should be able to show navigation help overlay', () => {
-    const hideAfterTimeoutStub = sandbox
+    const hideAfterTimeoutStub = env.sandbox
       .stub(ampStoryHint, 'hideAfterTimeout')
       .callsFake(NOOP);
 
@@ -67,7 +67,7 @@ describes.fakeWin('amp-story hint layer', {}, env => {
   });
 
   it('should be able to show no previous page help overlay', () => {
-    const hideAfterTimeoutStub = sandbox
+    const hideAfterTimeoutStub = env.sandbox
       .stub(ampStoryHint, 'hideAfterTimeout')
       .callsFake(NOOP);
 

--- a/extensions/amp-story/1.0/test/test-amp-story-info-dialog.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-info-dialog.js
@@ -44,18 +44,18 @@ describes.realWin('amp-story-share-menu', {amp: true}, env => {
     registerServiceBuilder(win, 'story-store', () => storeService);
 
     // Making sure resource tasks run synchronously.
-    sandbox.stub(Services, 'resourcesForDoc').returns({
+    env.sandbox.stub(Services, 'resourcesForDoc').returns({
       mutateElement: (element, callback) => {
         callback();
         return Promise.resolve();
       },
     });
 
-    sandbox.stub(Services, 'localizationService').returns({
+    env.sandbox.stub(Services, 'localizationService').returns({
       getLocalizedString: localizedStringId => `string(${localizedStringId})`,
     });
 
-    sandbox.stub(Services, 'viewerForDoc').returns({
+    env.sandbox.stub(Services, 'viewerForDoc').returns({
       isEmbedded: () => embedded,
       sendMessageAwaitResponse: eventType => {
         if (eventType === 'moreInfoLinkUrl') {

--- a/extensions/amp-story/1.0/test/test-amp-story-media-query-service.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-media-query-service.js
@@ -69,24 +69,24 @@ describes.realWin('amp-story-media-query-service', {amp: true}, env => {
   });
 
   it('should add the attribute if the media query matches', async () => {
-    const spy = sandbox.spy();
+    const spy = env.sandbox.spy();
     await mediaQueryService.onMediaQueryMatch('(orientation: landscape)', spy);
     expect(spy).to.have.been.calledOnceWith(true);
   });
 
   it('should not add the attribute if the media query does not match', async () => {
-    const spy = sandbox.spy();
+    const spy = env.sandbox.spy();
     await mediaQueryService.onMediaQueryMatch('(orientation: portrait)', spy);
     expect(spy).to.have.been.calledOnceWith(false);
   });
 
   it('should handle multiple media queries', async () => {
-    const spy1 = sandbox.spy();
+    const spy1 = env.sandbox.spy();
     const p1 = mediaQueryService.onMediaQueryMatch(
       '(orientation: landscape)',
       spy1
     );
-    const spy2 = sandbox.spy();
+    const spy2 = env.sandbox.spy();
     const p2 = mediaQueryService.onMediaQueryMatch('(min-width: 600px)', spy2);
     await Promise.all([p1, p2]);
     expect(spy1).to.have.been.calledOnceWith(true);

--- a/extensions/amp-story/1.0/test/test-amp-story-page.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-page.js
@@ -63,7 +63,7 @@ describes.realWin('amp-story-page', {amp: true}, env => {
     win.document.body.appendChild(story);
 
     page = new AmpStoryPage(element);
-    sandbox.stub(page, 'mutateElement').callsFake(fn => fn());
+    env.sandbox.stub(page, 'mutateElement').callsFake(fn => fn());
   });
 
   afterEach(() => {
@@ -101,7 +101,7 @@ describes.realWin('amp-story-page', {amp: true}, env => {
   });
 
   it('should start the advancement when state becomes active', async () => {
-    const advancementStartStub = sandbox.stub(page.advancement_, 'start');
+    const advancementStartStub = env.sandbox.stub(page.advancement_, 'start');
 
     page.buildCallback();
     await page.layoutCallback();
@@ -111,15 +111,15 @@ describes.realWin('amp-story-page', {amp: true}, env => {
   });
 
   it('should call waitForMedia after layoutCallback resolves', async () => {
-    const spy = sandbox.spy(page, 'waitForMediaLayout_');
+    const spy = env.sandbox.spy(page, 'waitForMediaLayout_');
     page.buildCallback();
     await page.layoutCallback();
     expect(spy).to.have.been.calledOnce;
   });
 
   it('should mark page as loaded after media is loaded', async () => {
-    const waitForMediaLayoutSpy = sandbox.spy(page, 'waitForMediaLayout_');
-    const markPageAsLoadedSpy = sandbox.spy(page, 'markPageAsLoaded_');
+    const waitForMediaLayoutSpy = env.sandbox.spy(page, 'waitForMediaLayout_');
+    const markPageAsLoadedSpy = env.sandbox.spy(page, 'markPageAsLoaded_');
     page.buildCallback();
     await page.layoutCallback();
     expect(markPageAsLoadedSpy).to.have.been.calledAfter(waitForMediaLayoutSpy);
@@ -133,7 +133,7 @@ describes.realWin('amp-story-page', {amp: true}, env => {
 
     page.buildCallback();
     await page.layoutCallback();
-    const animateInStub = sandbox.stub(page.animationManager_, 'animateIn');
+    const animateInStub = env.sandbox.stub(page.animationManager_, 'animateIn');
 
     page.setState(PageState.PLAYING);
 
@@ -141,10 +141,10 @@ describes.realWin('amp-story-page', {amp: true}, env => {
   });
 
   it('should perform media operations when state becomes active', done => {
-    sandbox
+    env.sandbox
       .stub(page.resources_, 'getResourceForElement')
       .returns({isDisplayed: () => true});
-    sandbox.stub(page, 'loadPromise').returns(Promise.resolve());
+    env.sandbox.stub(page, 'loadPromise').returns(Promise.resolve());
 
     const videoEl = win.document.createElement('video');
     videoEl.setAttribute('src', 'https://example.com/video.mp3');
@@ -157,7 +157,7 @@ describes.realWin('amp-story-page', {amp: true}, env => {
       .layoutCallback()
       .then(() => page.mediaPoolPromise_)
       .then(mediaPool => {
-        mediaPoolMock = sandbox.mock(mediaPool);
+        mediaPoolMock = env.sandbox.mock(mediaPool);
         mediaPoolMock
           .expects('register')
           .withExactArgs(videoEl)
@@ -192,7 +192,7 @@ describes.realWin('amp-story-page', {amp: true}, env => {
       url: 'https://amp.dev',
       html: '<video src="https://example.com/video.mp3"></video>',
     });
-    sandbox.stub(page, 'loadPromise').returns(Promise.resolve());
+    env.sandbox.stub(page, 'loadPromise').returns(Promise.resolve());
 
     fiePromise.then(fie => {
       const fieDoc = fie.win.document;
@@ -200,7 +200,7 @@ describes.realWin('amp-story-page', {amp: true}, env => {
 
       let mediaPoolMock;
 
-      sandbox
+      env.sandbox
         .stub(page.resources_, 'getResourceForElement')
         .returns({isDisplayed: () => true});
 
@@ -209,7 +209,7 @@ describes.realWin('amp-story-page', {amp: true}, env => {
         .layoutCallback()
         .then(() => page.mediaPoolPromise_)
         .then(mediaPool => {
-          mediaPoolMock = sandbox.mock(mediaPool);
+          mediaPoolMock = env.sandbox.mock(mediaPool);
           mediaPoolMock
             .expects('register')
             .withExactArgs(videoEl)
@@ -240,7 +240,7 @@ describes.realWin('amp-story-page', {amp: true}, env => {
   });
 
   it('should stop the advancement when state becomes not active', async () => {
-    const advancementStopStub = sandbox.stub(page.advancement_, 'stop');
+    const advancementStopStub = env.sandbox.stub(page.advancement_, 'stop');
 
     page.buildCallback();
     await page.layoutCallback();
@@ -257,7 +257,7 @@ describes.realWin('amp-story-page', {amp: true}, env => {
 
     page.buildCallback();
     await page.layoutCallback();
-    const cancelAllStub = sandbox.stub(page.animationManager_, 'cancelAll');
+    const cancelAllStub = env.sandbox.stub(page.animationManager_, 'cancelAll');
 
     page.setState(PageState.NOT_ACTIVE);
 
@@ -265,7 +265,7 @@ describes.realWin('amp-story-page', {amp: true}, env => {
   });
 
   it('should pause/rewind media when state becomes not active', done => {
-    sandbox
+    env.sandbox
       .stub(page.resources_, 'getResourceForElement')
       .returns({isDisplayed: () => true});
 
@@ -280,7 +280,7 @@ describes.realWin('amp-story-page', {amp: true}, env => {
       .layoutCallback()
       .then(() => page.mediaPoolPromise_)
       .then(mediaPool => {
-        mediaPoolMock = sandbox.mock(mediaPool);
+        mediaPoolMock = env.sandbox.mock(mediaPool);
         mediaPoolMock
           .expects('pause')
           .withExactArgs(videoEl, true /** rewindToBeginning */)
@@ -299,7 +299,7 @@ describes.realWin('amp-story-page', {amp: true}, env => {
   });
 
   it('should stop the advancement when state becomes paused', async () => {
-    const advancementStopStub = sandbox.stub(page.advancement_, 'stop');
+    const advancementStopStub = env.sandbox.stub(page.advancement_, 'stop');
 
     page.buildCallback();
     await page.layoutCallback();
@@ -309,7 +309,7 @@ describes.realWin('amp-story-page', {amp: true}, env => {
   });
 
   it('should pause media when state becomes paused', done => {
-    sandbox
+    env.sandbox
       .stub(page.resources_, 'getResourceForElement')
       .returns({isDisplayed: () => true});
     const videoEl = win.document.createElement('video');
@@ -323,7 +323,7 @@ describes.realWin('amp-story-page', {amp: true}, env => {
       .layoutCallback()
       .then(() => page.mediaPoolPromise_)
       .then(mediaPool => {
-        mediaPoolMock = sandbox.mock(mediaPool);
+        mediaPoolMock = env.sandbox.mock(mediaPool);
         mediaPoolMock
           .expects('pause')
           .withExactArgs(videoEl, false /** rewindToBeginning */)
@@ -439,11 +439,11 @@ describes.realWin('amp-story-page', {amp: true}, env => {
   });
 
   it('should start tracking media performance when entering the page', async () => {
-    sandbox
+    env.sandbox
       .stub(page.resources_, 'getResourceForElement')
       .returns({isDisplayed: () => true});
     isPerformanceTrackingOn = true;
-    const startMeasuringStub = sandbox.stub(
+    const startMeasuringStub = env.sandbox.stub(
       page.mediaPerformanceMetricsService_,
       'startMeasuring'
     );
@@ -460,11 +460,11 @@ describes.realWin('amp-story-page', {amp: true}, env => {
   });
 
   it('should stop tracking media performance when leaving the page', async () => {
-    sandbox
+    env.sandbox
       .stub(page.resources_, 'getResourceForElement')
       .returns({isDisplayed: () => true});
     isPerformanceTrackingOn = true;
-    const stopMeasuringStub = sandbox.stub(
+    const stopMeasuringStub = env.sandbox.stub(
       page.mediaPerformanceMetricsService_,
       'stopMeasuring'
     );
@@ -485,11 +485,11 @@ describes.realWin('amp-story-page', {amp: true}, env => {
   });
 
   it('should not start tracking media performance if tracking is off', async () => {
-    sandbox
+    env.sandbox
       .stub(page.resources_, 'getResourceForElement')
       .returns({isDisplayed: () => true});
     isPerformanceTrackingOn = false;
-    const startMeasuringStub = sandbox.stub(
+    const startMeasuringStub = env.sandbox.stub(
       page.mediaPerformanceMetricsService_,
       'startMeasuring'
     );

--- a/extensions/amp-story/1.0/test/test-amp-story-request-service.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-request-service.js
@@ -32,7 +32,7 @@ describes.fakeWin('amp-story-store-service', {amp: true}, env => {
     storyElement.appendChild(bookendElement);
     env.win.document.body.appendChild(storyElement);
     requestService = new AmpStoryRequestService(env.win, storyElement);
-    xhrMock = sandbox.mock(requestService.xhr_);
+    xhrMock = env.sandbox.mock(requestService.xhr_);
   });
 
   it('should not load the bookend config if no attribute is set', async () => {

--- a/extensions/amp-story/1.0/test/test-amp-story-share-menu.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-share-menu.js
@@ -46,11 +46,11 @@ describes.realWin('amp-story-share-menu', {amp: true}, env => {
       isSystemShareSupported: () => isSystemShareSupported,
       loadRequiredExtensions: () => {},
     };
-    shareWidgetMock = sandbox.mock(shareWidget);
-    sandbox.stub(ShareWidget, 'create').returns(shareWidget);
+    shareWidgetMock = env.sandbox.mock(shareWidget);
+    env.sandbox.stub(ShareWidget, 'create').returns(shareWidget);
 
     // Making sure the vsync tasks run synchronously.
-    sandbox.stub(Services, 'vsyncFor').returns({
+    env.sandbox.stub(Services, 'vsyncFor').returns({
       mutate: fn => fn(),
       run: (vsyncTaskSpec, vsyncState) => {
         vsyncTaskSpec.measure(vsyncState);
@@ -134,7 +134,7 @@ describes.realWin('amp-story-share-menu', {amp: true}, env => {
   it('should hide the share menu on escape key press', () => {
     shareMenu.build();
 
-    const clickCallbackSpy = sandbox.spy();
+    const clickCallbackSpy = env.sandbox.spy();
     win.addEventListener('keyup', clickCallbackSpy);
 
     storeService.dispatch(Action.TOGGLE_SHARE_MENU, true);
@@ -176,7 +176,7 @@ describes.realWin('amp-story-share-menu', {amp: true}, env => {
 
     shareMenu.build();
 
-    const clickCallbackSpy = sandbox.spy();
+    const clickCallbackSpy = env.sandbox.spy();
     shareMenu.element_.addEventListener('click', clickCallbackSpy);
 
     // Toggling the share menu dispatches a click event on the amp-social-share

--- a/extensions/amp-story/1.0/test/test-amp-story-store-service.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-store-service.js
@@ -35,7 +35,7 @@ describes.fakeWin('amp-story-store-service', {}, env => {
   });
 
   it('should subscribe to property mutations and receive the new value', () => {
-    const listenerSpy = sandbox.spy();
+    const listenerSpy = env.sandbox.spy();
     storeService.subscribe(StateProperty.BOOKEND_STATE, listenerSpy);
     storeService.dispatch(Action.TOGGLE_BOOKEND, true);
     expect(listenerSpy).to.have.been.calledOnce;
@@ -43,20 +43,20 @@ describes.fakeWin('amp-story-store-service', {}, env => {
   });
 
   it('should not trigger a listener if another property changed', () => {
-    const listenerSpy = sandbox.spy();
+    const listenerSpy = env.sandbox.spy();
     storeService.subscribe(StateProperty.CAN_INSERT_AUTOMATIC_AD, listenerSpy);
     storeService.dispatch(Action.TOGGLE_BOOKEND, true);
     expect(listenerSpy).to.have.callCount(0);
   });
 
   it('should not trigger a listener on subscribe by default', () => {
-    const listenerSpy = sandbox.spy();
+    const listenerSpy = env.sandbox.spy();
     storeService.subscribe(StateProperty.BOOKEND_STATE, listenerSpy);
     expect(listenerSpy).to.have.callCount(0);
   });
 
   it('should trigger a listener on subscribe if option is set to true', () => {
-    const listenerSpy = sandbox.spy();
+    const listenerSpy = env.sandbox.spy();
     storeService.subscribe(StateProperty.BOOKEND_STATE, listenerSpy, true);
     expect(listenerSpy).to.have.been.calledOnce;
     expect(listenerSpy).to.have.been.calledWith(false);
@@ -86,7 +86,7 @@ describes.fakeWin('amp-story-store-service actions', {}, env => {
   });
 
   it('should toggle the bookend', () => {
-    const listenerSpy = sandbox.spy();
+    const listenerSpy = env.sandbox.spy();
     storeService.subscribe(StateProperty.BOOKEND_STATE, listenerSpy);
     storeService.dispatch(Action.TOGGLE_BOOKEND, true);
     expect(listenerSpy).to.have.been.calledOnce;
@@ -94,7 +94,7 @@ describes.fakeWin('amp-story-store-service actions', {}, env => {
   });
 
   it('should not toggle the bookend if embed mode disables it', () => {
-    const listenerSpy = sandbox.spy();
+    const listenerSpy = env.sandbox.spy();
     storeService.state_[StateProperty.CAN_SHOW_BOOKEND] = false;
     storeService.subscribe(StateProperty.BOOKEND_STATE, listenerSpy);
     storeService.dispatch(Action.TOGGLE_BOOKEND, true);
@@ -102,7 +102,7 @@ describes.fakeWin('amp-story-store-service actions', {}, env => {
   });
 
   it('should toggle the muted state', () => {
-    const listenerSpy = sandbox.spy();
+    const listenerSpy = env.sandbox.spy();
     storeService.subscribe(StateProperty.MUTED_STATE, listenerSpy);
     storeService.dispatch(Action.TOGGLE_MUTED, false);
     expect(listenerSpy).to.have.been.calledOnce;
@@ -110,7 +110,7 @@ describes.fakeWin('amp-story-store-service actions', {}, env => {
   });
 
   it('should toggle the desktop state when setting a UI State', () => {
-    const listenerSpy = sandbox.spy();
+    const listenerSpy = env.sandbox.spy();
     storeService.subscribe(StateProperty.DESKTOP_STATE, listenerSpy);
     storeService.dispatch(Action.TOGGLE_UI, UIType.DESKTOP_PANELS);
     expect(listenerSpy).to.have.been.calledOnce;
@@ -118,7 +118,7 @@ describes.fakeWin('amp-story-store-service actions', {}, env => {
   });
 
   it('should update the current page id', () => {
-    const listenerSpy = sandbox.spy();
+    const listenerSpy = env.sandbox.spy();
     storeService.subscribe(StateProperty.CURRENT_PAGE_ID, listenerSpy);
     storeService.dispatch(Action.CHANGE_PAGE, {
       id: 'test-page',
@@ -129,7 +129,7 @@ describes.fakeWin('amp-story-store-service actions', {}, env => {
   });
 
   it('should update the current page index', () => {
-    const listenerSpy = sandbox.spy();
+    const listenerSpy = env.sandbox.spy();
     storeService.subscribe(StateProperty.CURRENT_PAGE_INDEX, listenerSpy);
     storeService.dispatch(Action.CHANGE_PAGE, {
       id: 'test-page',
@@ -140,7 +140,7 @@ describes.fakeWin('amp-story-store-service actions', {}, env => {
   });
 
   it('should toggle the has audio state', () => {
-    const listenerSpy = sandbox.spy();
+    const listenerSpy = env.sandbox.spy();
     storeService.subscribe(StateProperty.STORY_HAS_AUDIO_STATE, listenerSpy);
     storeService.dispatch(Action.TOGGLE_STORY_HAS_AUDIO, true);
     expect(listenerSpy).to.have.been.calledOnce;
@@ -148,7 +148,7 @@ describes.fakeWin('amp-story-store-service actions', {}, env => {
   });
 
   it('should toggle the viewport warning state', () => {
-    const listenerSpy = sandbox.spy();
+    const listenerSpy = env.sandbox.spy();
     storeService.subscribe(StateProperty.VIEWPORT_WARNING_STATE, listenerSpy);
     storeService.dispatch(Action.TOGGLE_VIEWPORT_WARNING, true);
     expect(listenerSpy).to.have.been.calledOnce;
@@ -156,7 +156,7 @@ describes.fakeWin('amp-story-store-service actions', {}, env => {
   });
 
   it('should toggle the supported browser state', () => {
-    const listenerSpy = sandbox.spy();
+    const listenerSpy = env.sandbox.spy();
     storeService.subscribe(StateProperty.SUPPORTED_BROWSER_STATE, listenerSpy);
     storeService.dispatch(Action.TOGGLE_SUPPORTED_BROWSER, false);
     expect(listenerSpy).to.have.been.calledOnce;
@@ -164,7 +164,7 @@ describes.fakeWin('amp-story-store-service actions', {}, env => {
   });
 
   it('should pause the story when displaying the share menu', () => {
-    const pausedListenerSpy = sandbox.spy();
+    const pausedListenerSpy = env.sandbox.spy();
     storeService.subscribe(StateProperty.PAUSED_STATE, pausedListenerSpy);
     storeService.dispatch(Action.TOGGLE_SHARE_MENU, true);
     expect(pausedListenerSpy).to.have.been.calledOnce;
@@ -172,7 +172,7 @@ describes.fakeWin('amp-story-store-service actions', {}, env => {
   });
 
   it('should pause the story when displaying the bookend', () => {
-    const pausedListenerSpy = sandbox.spy();
+    const pausedListenerSpy = env.sandbox.spy();
     storeService.subscribe(StateProperty.PAUSED_STATE, pausedListenerSpy);
     storeService.dispatch(Action.TOGGLE_BOOKEND, true);
     expect(pausedListenerSpy).to.have.been.calledOnce;
@@ -184,7 +184,7 @@ describes.fakeWin('amp-story-store-service actions', {}, env => {
     storeService.dispatch(Action.TOGGLE_BOOKEND, true);
 
     // Close the bookend.
-    const pausedListenerSpy = sandbox.spy();
+    const pausedListenerSpy = env.sandbox.spy();
     storeService.subscribe(StateProperty.PAUSED_STATE, pausedListenerSpy);
     storeService.dispatch(Action.TOGGLE_BOOKEND, false);
 
@@ -195,7 +195,7 @@ describes.fakeWin('amp-story-store-service actions', {}, env => {
   it('should unpause the story when hiding the share menu', () => {
     storeService.dispatch(Action.TOGGLE_SHARE_MENU, true);
 
-    const pausedListenerSpy = sandbox.spy();
+    const pausedListenerSpy = env.sandbox.spy();
     storeService.subscribe(StateProperty.PAUSED_STATE, pausedListenerSpy);
     storeService.dispatch(Action.TOGGLE_SHARE_MENU, false);
     expect(pausedListenerSpy).to.have.been.calledOnce;
@@ -203,7 +203,7 @@ describes.fakeWin('amp-story-store-service actions', {}, env => {
   });
 
   it('should pause the story when displaying the info dialog', () => {
-    const pausedListenerSpy = sandbox.spy();
+    const pausedListenerSpy = env.sandbox.spy();
     storeService.subscribe(StateProperty.PAUSED_STATE, pausedListenerSpy);
     storeService.dispatch(Action.TOGGLE_INFO_DIALOG, true);
     expect(pausedListenerSpy).to.have.been.calledOnce;
@@ -213,7 +213,7 @@ describes.fakeWin('amp-story-store-service actions', {}, env => {
   it('should unpause the story when hiding the info dialog', () => {
     storeService.dispatch(Action.TOGGLE_INFO_DIALOG, true);
 
-    const pausedListenerSpy = sandbox.spy();
+    const pausedListenerSpy = env.sandbox.spy();
     storeService.subscribe(StateProperty.PAUSED_STATE, pausedListenerSpy);
     storeService.dispatch(Action.TOGGLE_INFO_DIALOG, false);
     expect(pausedListenerSpy).to.have.been.calledOnce;
@@ -238,7 +238,7 @@ describes.fakeWin('amp-story-store-service actions', {}, env => {
 
     storeService.dispatch(Action.ADD_TO_ACTIONS_WHITELIST, action1);
 
-    const actionsListenerSpy = sandbox.spy();
+    const actionsListenerSpy = env.sandbox.spy();
     storeService.subscribe(StateProperty.ACTIONS_WHITELIST, actionsListenerSpy);
 
     storeService.dispatch(Action.ADD_TO_ACTIONS_WHITELIST, action2);
@@ -256,7 +256,7 @@ describes.fakeWin('amp-story-store-service actions', {}, env => {
 
     storeService.dispatch(Action.ADD_TO_ACTIONS_WHITELIST, action1);
 
-    const actionsListenerSpy = sandbox.spy();
+    const actionsListenerSpy = env.sandbox.spy();
     storeService.subscribe(StateProperty.ACTIONS_WHITELIST, actionsListenerSpy);
 
     storeService.dispatch(Action.ADD_TO_ACTIONS_WHITELIST, [action2, action3]);

--- a/extensions/amp-story/1.0/test/test-amp-story-system-layer.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-system-layer.js
@@ -41,14 +41,14 @@ describes.fakeWin('amp-story system layer', {amp: true}, env => {
     progressBarRoot = win.document.createElement('div');
 
     progressBarStub = {
-      build: sandbox.stub().returns(progressBarRoot),
-      getRoot: sandbox.stub().returns(progressBarRoot),
-      updateProgress: sandbox.spy(),
+      build: env.sandbox.stub().returns(progressBarRoot),
+      getRoot: env.sandbox.stub().returns(progressBarRoot),
+      updateProgress: env.sandbox.spy(),
     };
 
-    sandbox.stub(ProgressBar, 'create').returns(progressBarStub);
+    env.sandbox.stub(ProgressBar, 'create').returns(progressBarStub);
 
-    sandbox.stub(Services, 'vsyncFor').returns({
+    env.sandbox.stub(Services, 'vsyncFor').returns({
       mutate: fn => fn(),
     });
 
@@ -56,7 +56,7 @@ describes.fakeWin('amp-story system layer', {amp: true}, env => {
   });
 
   it('should build UI', () => {
-    const initializeListeners = sandbox
+    const initializeListeners = env.sandbox
       .stub(systemLayer, 'initializeListeners_')
       .callsFake(NOOP);
 
@@ -69,10 +69,10 @@ describes.fakeWin('amp-story system layer', {amp: true}, env => {
 
   // TODO(alanorozco, #12476): Make this test work with sinon 4.0.
   it.skip('should attach event handlers', () => {
-    const rootMock = {addEventListener: sandbox.spy()};
+    const rootMock = {addEventListener: env.sandbox.spy()};
 
-    sandbox.stub(systemLayer, 'root_').callsFake(rootMock);
-    sandbox.stub(systemLayer, 'win_').callsFake(rootMock);
+    env.sandbox.stub(systemLayer, 'root_').callsFake(rootMock);
+    env.sandbox.stub(systemLayer, 'win_').callsFake(rootMock);
 
     systemLayer.initializeListeners_();
 

--- a/extensions/amp-story/1.0/test/test-analytics.js
+++ b/extensions/amp-story/1.0/test/test-analytics.js
@@ -33,7 +33,7 @@ describes.fakeWin('amp-story analytics', {}, env => {
   });
 
   it('should trigger `story-page-visible` on change', () => {
-    const trigger = sandbox.stub(analytics, 'triggerEvent');
+    const trigger = env.sandbox.stub(analytics, 'triggerEvent');
 
     storeService.dispatch(Action.CHANGE_PAGE, {
       id: 'test-page',
@@ -44,7 +44,7 @@ describes.fakeWin('amp-story analytics', {}, env => {
   });
 
   it('should trigger `story-last-page-visible` when last page is visible', () => {
-    const trigger = sandbox.stub(analytics, 'triggerEvent');
+    const trigger = env.sandbox.stub(analytics, 'triggerEvent');
 
     storeService.dispatch(Action.SET_PAGE_IDS, ['cover', 'page1', 'page2']);
     storeService.dispatch(Action.CHANGE_PAGE, {
@@ -60,7 +60,7 @@ describes.fakeWin('amp-story analytics', {}, env => {
   });
 
   it('should not mark an event as repeated the first time it fires', () => {
-    const trigger = sandbox.spy(analytics, 'triggerEvent');
+    const trigger = env.sandbox.spy(analytics, 'triggerEvent');
 
     storeService.dispatch(Action.CHANGE_PAGE, {
       id: 'test-page',
@@ -74,7 +74,7 @@ describes.fakeWin('amp-story analytics', {}, env => {
   });
 
   it('should mark event as repeated when fired more than once', () => {
-    const trigger = sandbox.spy(analytics, 'triggerEvent');
+    const trigger = env.sandbox.spy(analytics, 'triggerEvent');
 
     storeService.dispatch(Action.CHANGE_PAGE, {
       id: 'test-page',

--- a/extensions/amp-story/1.0/test/test-full-bleed-animations.js
+++ b/extensions/amp-story/1.0/test/test-full-bleed-animations.js
@@ -46,10 +46,10 @@ describes.realWin(
     beforeEach(() => {
       win = env.win;
 
-      sandbox.stub(win.history, 'replaceState');
+      env.sandbox.stub(win.history, 'replaceState');
 
       const viewer = Services.viewerForDoc(env.ampdoc);
-      sandbox.stub(Services, 'viewerForDoc').returns(viewer);
+      env.sandbox.stub(Services, 'viewerForDoc').returns(viewer);
 
       registerServiceBuilder(win, 'performance', () => ({
         isPerformanceTrackingOn: () => false,

--- a/extensions/amp-story/1.0/test/test-live-story-manager.js
+++ b/extensions/amp-story/1.0/test/test-live-story-manager.js
@@ -51,7 +51,7 @@ describes.realWin(
           page.id = opt_ids && opt_ids[i] ? opt_ids[i] : `-page-${i}`;
           const storyPage = new AmpStoryPage(page);
           page.getImpl = () => Promise.resolve(storyPage);
-          sandbox.stub(storyPage, 'mutateElement').callsFake(fn => fn());
+          env.sandbox.stub(storyPage, 'mutateElement').callsFake(fn => fn());
           container.appendChild(page);
           return page;
         });
@@ -60,8 +60,8 @@ describes.realWin(
     beforeEach(async () => {
       win = env.win;
       const viewer = Services.viewerForDoc(env.ampdoc);
-      sandbox.stub(Services, 'viewerForDoc').returns(viewer);
-      sandbox.stub(win.history, 'replaceState');
+      env.sandbox.stub(Services, 'viewerForDoc').returns(viewer);
+      env.sandbox.stub(win.history, 'replaceState');
 
       registerServiceBuilder(win, 'performance', () => ({
         isPerformanceTrackingOn: () => false,
@@ -129,7 +129,7 @@ describes.realWin(
 
       await ampStory.layoutCallback();
       await ampStory.element.signals().signal(CommonSignals.LOAD_END);
-      const dispatchSpy = sandbox.spy(ampStory.storeService_, 'dispatch');
+      const dispatchSpy = env.sandbox.spy(ampStory.storeService_, 'dispatch');
 
       const newPage = win.document.createElement('amp-story-page');
       // This would normally get added by AmpLiveList.

--- a/extensions/amp-story/1.0/test/test-media-performance-metrics-service.js
+++ b/extensions/amp-story/1.0/test/test-media-performance-metrics-service.js
@@ -39,11 +39,11 @@ describes.fakeWin('media-performance-metrics-service', {}, env => {
 
   beforeEach(() => {
     win = env.win;
-    sandbox
+    env.sandbox
       .stub(Services, 'performanceFor')
       .returns({tickDelta: () => {}, flush: () => {}});
     service = new MediaPerformanceMetricsService();
-    tickStub = sandbox.stub(service.performanceService_, 'tickDelta');
+    tickStub = env.sandbox.stub(service.performanceService_, 'tickDelta');
   });
 
   afterEach(() => {
@@ -51,7 +51,7 @@ describes.fakeWin('media-performance-metrics-service', {}, env => {
   });
 
   it('should record and flush metrics', () => {
-    const flushStub = sandbox.stub(service.performanceService_, 'flush');
+    const flushStub = env.sandbox.stub(service.performanceService_, 'flush');
 
     const video = win.document.createElement('video');
     service.startMeasuring(video);
@@ -67,7 +67,7 @@ describes.fakeWin('media-performance-metrics-service', {}, env => {
   });
 
   it('should record and flush metrics on error', () => {
-    const flushStub = sandbox.stub(service.performanceService_, 'flush');
+    const flushStub = env.sandbox.stub(service.performanceService_, 'flush');
 
     const video = win.document.createElement('video');
     service.startMeasuring(video);
@@ -81,7 +81,7 @@ describes.fakeWin('media-performance-metrics-service', {}, env => {
   });
 
   it('should record and flush metrics for multiple media', () => {
-    const flushStub = sandbox.stub(service.performanceService_, 'flush');
+    const flushStub = env.sandbox.stub(service.performanceService_, 'flush');
 
     const video1 = win.document.createElement('video');
     const video2 = win.document.createElement('video');
@@ -101,7 +101,7 @@ describes.fakeWin('media-performance-metrics-service', {}, env => {
   });
 
   it('should not flush metrics if sendMetrics is false', () => {
-    const flushStub = sandbox.stub(service.performanceService_, 'flush');
+    const flushStub = env.sandbox.stub(service.performanceService_, 'flush');
 
     const video = win.document.createElement('video');
     service.startMeasuring(video);

--- a/extensions/amp-story/1.0/test/test-media-pool.js
+++ b/extensions/amp-story/1.0/test/test-media-pool.js
@@ -30,10 +30,10 @@ describes.realWin('media-pool', {}, env => {
 
   beforeEach(() => {
     win = env.win;
-    sandbox
+    env.sandbox
       .stub(Services, 'vsyncFor')
       .callsFake(() => ({mutate: task => task()}));
-    sandbox.stub(Services, 'timerFor').callsFake(() => ({delay: NOOP}));
+    env.sandbox.stub(Services, 'timerFor').callsFake(() => ({delay: NOOP}));
 
     mediaPool = new MediaPool(win, COUNTS, element => {
       return distanceFnStub(element);

--- a/extensions/amp-story/1.0/test/test-media-tasks.js
+++ b/extensions/amp-story/1.0/test/test-media-tasks.js
@@ -29,27 +29,25 @@ import {toArray} from '../../../../src/types';
 
 describes.realWin('media-tasks', {}, env => {
   let win;
-  let sandbox;
   let el;
   let vsyncApi;
 
   beforeEach(() => {
     win = env.win;
-    sandbox = sinon.sandbox;
     el = document.createElement('video');
 
     // Mock vsync
     vsyncApi = {
       mutatePromise: () => {},
     };
-    sandbox.stub(vsyncApi, 'mutatePromise').resolves(callback => {
+    env.sandbox.stub(vsyncApi, 'mutatePromise').resolves(callback => {
       callback();
     });
   });
 
   describe('PauseTask', () => {
     it('should call pause()', () => {
-      const pause = sandbox.spy(el, 'pause');
+      const pause = env.sandbox.spy(el, 'pause');
       const task = new PauseTask();
       task.execute(el);
       expect(pause).to.have.been.called;
@@ -60,7 +58,7 @@ describes.realWin('media-tasks', {}, env => {
     it('should call play() if element was not yet playing', () => {
       expect(el.paused).to.be.true;
 
-      const play = sandbox.spy(el, 'play');
+      const play = env.sandbox.spy(el, 'play');
       const task = new PlayTask();
       task.execute(el);
       expect(play).to.have.been.called;
@@ -70,7 +68,7 @@ describes.realWin('media-tasks', {}, env => {
       el.play();
       expect(el.paused).to.be.false;
 
-      const play = sandbox.spy(el, 'play');
+      const play = env.sandbox.spy(el, 'play');
       const task = new PlayTask();
       task.execute(el);
       expect(play).not.to.have.been.called;
@@ -101,7 +99,7 @@ describes.realWin('media-tasks', {}, env => {
 
   describe('LoadTask', () => {
     it('should call load()', () => {
-      const load = sandbox.spy(el, 'load');
+      const load = env.sandbox.spy(el, 'load');
       const task = new LoadTask();
       task.execute(el);
       expect(load).to.have.been.called;

--- a/extensions/amp-subscriptions-google/0.1/test/test-amp-subscriptions-google.js
+++ b/extensions/amp-subscriptions-google/0.1/test/test-amp-subscriptions-google.js
@@ -65,12 +65,14 @@ describes.realWin('amp-subscriptions-google', {amp: true}, env => {
     viewer = Services.viewerForDoc(ampdoc);
     ampdoc.params_['viewerUrl'] = 'https://www.google.com/other';
     serviceAdapter = new ServiceAdapter(null);
-    serviceAdapterMock = sandbox.mock(serviceAdapter);
-    sandbox.stub(serviceAdapter, 'getPageConfig').callsFake(() => pageConfig);
+    serviceAdapterMock = env.sandbox.mock(serviceAdapter);
+    env.sandbox
+      .stub(serviceAdapter, 'getPageConfig')
+      .callsFake(() => pageConfig);
     const analytics = new SubscriptionAnalytics(ampdoc.getRootNode());
-    sandbox.stub(serviceAdapter, 'getAnalytics').callsFake(() => analytics);
-    analyticsMock = sandbox.mock(analytics);
-    getEncryptedDocumentKeyStub = sandbox
+    env.sandbox.stub(serviceAdapter, 'getAnalytics').callsFake(() => analytics);
+    analyticsMock = env.sandbox.mock(analytics);
+    getEncryptedDocumentKeyStub = env.sandbox
       .stub(serviceAdapter, 'getEncryptedDocumentKey')
       .callsFake(() => {
         return null;
@@ -81,45 +83,45 @@ describes.realWin('amp-subscriptions-google', {amp: true}, env => {
       subscriptionToken: 'tok1',
     };
     callbacks = {
-      loginRequest: sandbox.stub(
+      loginRequest: env.sandbox.stub(
         ConfiguredRuntime.prototype,
         'setOnLoginRequest'
       ),
-      linkComplete: sandbox.stub(
+      linkComplete: env.sandbox.stub(
         ConfiguredRuntime.prototype,
         'setOnLinkComplete'
       ),
-      flowStarted: sandbox.stub(
+      flowStarted: env.sandbox.stub(
         ConfiguredRuntime.prototype,
         'setOnFlowStarted'
       ),
-      flowCanceled: sandbox.stub(
+      flowCanceled: env.sandbox.stub(
         ConfiguredRuntime.prototype,
         'setOnFlowCanceled'
       ),
-      subscribeRequest: sandbox.stub(
+      subscribeRequest: env.sandbox.stub(
         ConfiguredRuntime.prototype,
         'setOnNativeSubscribeRequest'
       ),
-      subscribeResponse: sandbox.stub(
+      subscribeResponse: env.sandbox.stub(
         ConfiguredRuntime.prototype,
         'setOnPaymentResponse'
       ),
     };
     methods = {
-      reset: sandbox.stub(ConfiguredRuntime.prototype, 'reset'),
-      showContributionOptions: sandbox.stub(
+      reset: env.sandbox.stub(ConfiguredRuntime.prototype, 'reset'),
+      showContributionOptions: env.sandbox.stub(
         ConfiguredRuntime.prototype,
         'showContributionOptions'
       ),
-      showOffers: sandbox.stub(ConfiguredRuntime.prototype, 'showOffers'),
-      showAbbrvOffer: sandbox.stub(
+      showOffers: env.sandbox.stub(ConfiguredRuntime.prototype, 'showOffers'),
+      showAbbrvOffer: env.sandbox.stub(
         ConfiguredRuntime.prototype,
         'showAbbrvOffer'
       ),
-      linkAccount: sandbox.stub(ConfiguredRuntime.prototype, 'linkAccount'),
+      linkAccount: env.sandbox.stub(ConfiguredRuntime.prototype, 'linkAccount'),
     };
-    ackStub = sandbox.stub(Entitlements.prototype, 'ack');
+    ackStub = env.sandbox.stub(Entitlements.prototype, 'ack');
     toggleExperiment(win, 'swg-gpay-api', true);
     toggleExperiment(win, 'nonswgexp', true);
     platform = new GoogleSubscriptionsPlatform(ampdoc, {}, serviceAdapter);
@@ -157,18 +159,20 @@ describes.realWin('amp-subscriptions-google', {amp: true}, env => {
   });
 
   it('should proxy fetch via AMP fetcher', () => {
-    const fetchStub = sandbox.stub(xhr, 'fetchJson').callsFake((url, init) => {
-      expect(url).to.match(/publication\/example.org/);
-      expect(init).to.deep.equal({
-        credentials: 'include',
-        prerenderSafe: true,
+    const fetchStub = env.sandbox
+      .stub(xhr, 'fetchJson')
+      .callsFake((url, init) => {
+        expect(url).to.match(/publication\/example.org/);
+        expect(init).to.deep.equal({
+          credentials: 'include',
+          prerenderSafe: true,
+        });
+        return Promise.resolve({
+          json: () => {
+            return Promise.resolve({entitlements: entitlementResponse});
+          },
+        });
       });
-      return Promise.resolve({
-        json: () => {
-          return Promise.resolve({entitlements: entitlementResponse});
-        },
-      });
-    });
     return platform.getEntitlements().then(ents => {
       expect(ents.service).to.equal(PLATFORM_ID);
       expect(fetchStub).to.be.calledOnce;
@@ -176,24 +180,26 @@ describes.realWin('amp-subscriptions-google', {amp: true}, env => {
   });
 
   it('should proxy fetch non-granting response', () => {
-    const fetchStub = sandbox.stub(xhr, 'fetchJson').callsFake((url, init) => {
-      expect(url).to.match(/publication\/example.org/);
-      expect(init).to.deep.equal({
-        credentials: 'include',
-        prerenderSafe: true,
+    const fetchStub = env.sandbox
+      .stub(xhr, 'fetchJson')
+      .callsFake((url, init) => {
+        expect(url).to.match(/publication\/example.org/);
+        expect(init).to.deep.equal({
+          credentials: 'include',
+          prerenderSafe: true,
+        });
+        return Promise.resolve({
+          json: () => {
+            return Promise.resolve({
+              entitlements: {
+                source: 'subscribe.google.com',
+                products: ['example.org:registered_user'],
+                subscriptionToken: 'tok1',
+              },
+            });
+          },
+        });
       });
-      return Promise.resolve({
-        json: () => {
-          return Promise.resolve({
-            entitlements: {
-              source: 'subscribe.google.com',
-              products: ['example.org:registered_user'],
-              subscriptionToken: 'tok1',
-            },
-          });
-        },
-      });
-    });
     return platform.getEntitlements().then(ents => {
       expect(ents.source).to.equal(PLATFORM_ID);
       expect(ents.granted).to.be.false;
@@ -202,7 +208,7 @@ describes.realWin('amp-subscriptions-google', {amp: true}, env => {
   });
 
   it('should proxy fetch empty response', () => {
-    sandbox.stub(xhr, 'fetchJson').callsFake(() => {
+    env.sandbox.stub(xhr, 'fetchJson').callsFake(() => {
       return Promise.resolve({
         json: () => {
           return Promise.resolve({
@@ -217,7 +223,7 @@ describes.realWin('amp-subscriptions-google', {amp: true}, env => {
   });
 
   it('should ack matching entitlements', () => {
-    sandbox.stub(xhr, 'fetchJson').callsFake(() => {
+    env.sandbox.stub(xhr, 'fetchJson').callsFake(() => {
       return Promise.resolve({
         json: () => {
           return Promise.resolve({entitlements: entitlementResponse});
@@ -230,7 +236,7 @@ describes.realWin('amp-subscriptions-google', {amp: true}, env => {
   });
 
   it('should NOT ack non-matching entitlements', () => {
-    sandbox.stub(xhr, 'fetchJson').callsFake(() => {
+    env.sandbox.stub(xhr, 'fetchJson').callsFake(() => {
       return Promise.resolve({
         json: () => {
           return Promise.resolve({
@@ -391,7 +397,7 @@ describes.realWin('amp-subscriptions-google', {amp: true}, env => {
       () => promise
     );
     const resetPlatformsPromise = new Promise(resolve => {
-      sandbox.stub(serviceAdapter, 'resetPlatforms').callsFake(() => {
+      env.sandbox.stub(serviceAdapter, 'resetPlatforms').callsFake(() => {
         resolve();
       });
     });
@@ -461,7 +467,7 @@ describes.realWin('amp-subscriptions-google', {amp: true}, env => {
   it('should infer the viewer from origin', () => {
     delete ampdoc.params_['viewerUrl'];
     let viewerOrigin = null;
-    sandbox.stub(viewer, 'getViewerOrigin').callsFake(() => viewerOrigin);
+    env.sandbox.stub(viewer, 'getViewerOrigin').callsFake(() => viewerOrigin);
 
     return Promise.resolve()
       .then(() => {
@@ -498,7 +504,10 @@ describes.realWin('amp-subscriptions-google', {amp: true}, env => {
 
   it('should attach button given to decorateUI', () => {
     const elem = env.win.document.createElement('div');
-    const decorateStub = sandbox.stub(platform.runtime_.buttonApi_, 'attach');
+    const decorateStub = env.sandbox.stub(
+      platform.runtime_.buttonApi_,
+      'attach'
+    );
     elem.textContent = 'some html';
     platform.decorateUI(elem, 'subscribe');
     expect(elem.textContent).to.be.equal('');
@@ -507,7 +516,7 @@ describes.realWin('amp-subscriptions-google', {amp: true}, env => {
 
   it('should attach smartbutton given to decorateUI', () => {
     const elem = env.win.document.createElement('div');
-    const attachStub = sandbox.stub(platform.runtime_, 'attachSmartButton');
+    const attachStub = env.sandbox.stub(platform.runtime_, 'attachSmartButton');
     elem.textContent = 'some html';
     elem.setAttribute('subscriptions-lang', 'en');
     platform.decorateUI(elem, 'subscribe-smartbutton');
@@ -517,7 +526,7 @@ describes.realWin('amp-subscriptions-google', {amp: true}, env => {
 
   it('should use light smartbutton theme', () => {
     const elem = env.win.document.createElement('div');
-    const attachStub = sandbox.stub(platform.runtime_, 'attachSmartButton');
+    const attachStub = env.sandbox.stub(platform.runtime_, 'attachSmartButton');
     elem.textContent = 'some html';
     elem.setAttribute('subscriptions-lang', 'en');
     platform.decorateUI(elem, 'subscribe-smartbutton-light');
@@ -527,7 +536,7 @@ describes.realWin('amp-subscriptions-google', {amp: true}, env => {
 
   it('should use dark smartbutton theme', () => {
     const elem = env.win.document.createElement('div');
-    const attachStub = sandbox.stub(platform.runtime_, 'attachSmartButton');
+    const attachStub = env.sandbox.stub(platform.runtime_, 'attachSmartButton');
     elem.textContent = 'some html';
     elem.setAttribute('subscriptions-lang', 'en');
     platform.decorateUI(elem, 'subscribe-smartbutton-dark');
@@ -537,7 +546,7 @@ describes.realWin('amp-subscriptions-google', {amp: true}, env => {
 
   it('should use message text color', () => {
     const elem = env.win.document.createElement('div');
-    const attachStub = sandbox.stub(platform.runtime_, 'attachSmartButton');
+    const attachStub = env.sandbox.stub(platform.runtime_, 'attachSmartButton');
     elem.textContent = 'some html';
     elem.setAttribute('subscriptions-lang', 'en');
     elem.setAttribute('subscriptions-message-text-color', '#09f');
@@ -587,7 +596,7 @@ describes.realWin('amp-subscriptions-google', {amp: true}, env => {
 
   describe('getEntitlements', () => {
     it('should convert granted entitlements to internal shape', () => {
-      sandbox.stub(xhr, 'fetchJson').callsFake(() => {
+      env.sandbox.stub(xhr, 'fetchJson').callsFake(() => {
         return Promise.resolve({
           json: () => {
             return Promise.resolve({entitlements: entitlementResponse});
@@ -603,7 +612,7 @@ describes.realWin('amp-subscriptions-google', {amp: true}, env => {
     });
 
     it('should convert non granted internal shape with granted == false', () => {
-      sandbox.stub(xhr, 'fetchJson').callsFake(() => {
+      env.sandbox.stub(xhr, 'fetchJson').callsFake(() => {
         return Promise.resolve({
           json: () => {
             return Promise.resolve({
@@ -641,7 +650,7 @@ describes.realWin('amp-subscriptions-google', {amp: true}, env => {
     }
 
     it('should treat missing isReadyToPay as false', () => {
-      sandbox.stub(xhr, 'fetchJson').callsFake(() => {
+      env.sandbox.stub(xhr, 'fetchJson').callsFake(() => {
         return Promise.resolve({
           json: () => {
             return Promise.resolve({entitlements: entitlementResponse});
@@ -658,7 +667,7 @@ describes.realWin('amp-subscriptions-google', {amp: true}, env => {
     });
 
     it('should handle isReadyToPay true', () => {
-      sandbox.stub(xhr, 'fetchJson').callsFake(() => {
+      env.sandbox.stub(xhr, 'fetchJson').callsFake(() => {
         return Promise.resolve({
           json: () => {
             return Promise.resolve({
@@ -669,7 +678,7 @@ describes.realWin('amp-subscriptions-google', {amp: true}, env => {
         });
       });
       //#TODO(jpettitt) remove stub when swj.js isRadyToPay is available
-      sandbox
+      env.sandbox
         .stub(platform.runtime_, 'getEntitlements')
         .resolves(fakeEntitlements(true));
 
@@ -683,7 +692,7 @@ describes.realWin('amp-subscriptions-google', {amp: true}, env => {
     });
 
     it('should handle isReadyToPay false', () => {
-      sandbox.stub(xhr, 'fetchJson').callsFake(() => {
+      env.sandbox.stub(xhr, 'fetchJson').callsFake(() => {
         return Promise.resolve({
           json: () => {
             return Promise.resolve({
@@ -694,7 +703,7 @@ describes.realWin('amp-subscriptions-google', {amp: true}, env => {
         });
       });
       //#TODO(jpettitt) remove stub when swj.js isRadyToPay is available
-      sandbox
+      env.sandbox
         .stub(platform.runtime_, 'getEntitlements')
         .resolves(fakeEntitlements(false));
 
@@ -708,7 +717,7 @@ describes.realWin('amp-subscriptions-google', {amp: true}, env => {
     });
 
     it('should call getEncryptedDocumentKey with google.com', () => {
-      sandbox.stub(xhr, 'fetchJson').callsFake(() => {
+      env.sandbox.stub(xhr, 'fetchJson').callsFake(() => {
         return Promise.resolve({
           json: () => {
             return Promise.resolve({entitlements: {}});
@@ -721,7 +730,7 @@ describes.realWin('amp-subscriptions-google', {amp: true}, env => {
     });
 
     it('should not add encryptedDocumentKey parameter to url', () => {
-      const fetchStub = sandbox.stub(xhr, 'fetchJson').callsFake(() => {
+      const fetchStub = env.sandbox.stub(xhr, 'fetchJson').callsFake(() => {
         return Promise.resolve({
           json: () => {
             return Promise.resolve({entitlements: {}});
@@ -736,7 +745,7 @@ describes.realWin('amp-subscriptions-google', {amp: true}, env => {
     });
 
     it('should add encryptedDocumentKey parameter to url', () => {
-      const fetchStub = sandbox.stub(xhr, 'fetchJson').callsFake(() => {
+      const fetchStub = env.sandbox.stub(xhr, 'fetchJson').callsFake(() => {
         return Promise.resolve({
           json: () => {
             return Promise.resolve({entitlements: {}});

--- a/extensions/amp-subscriptions/0.1/test/test-actions.js
+++ b/extensions/amp-subscriptions/0.1/test/test-actions.js
@@ -40,26 +40,28 @@ describes.realWin('Actions', {amp: true}, env => {
 
   beforeEach(() => {
     ampdoc = env.ampdoc;
-    clock = sandbox.useFakeTimers();
+    clock = env.sandbox.useFakeTimers();
     readerIdPromise = Promise.resolve('RD');
     urlBuilder = new UrlBuilder(ampdoc, readerIdPromise);
     urlBuilder.setAuthResponse({
       'a': 'A',
     });
     analytics = new SubscriptionAnalytics(ampdoc.getRootNode());
-    analyticsMock = sandbox.mock(analytics);
-    buildSpy = sandbox.spy(Actions.prototype, 'build');
+    analyticsMock = env.sandbox.mock(analytics);
+    buildSpy = env.sandbox.spy(Actions.prototype, 'build');
     actions = new Actions(ampdoc, urlBuilder, analytics, {
       [Action.LOGIN]: 'https://example.org/login?rid=READER_ID',
       [Action.SUBSCRIBE]:
         'https://example.org/subscribe?rid=READER_ID&a=AUTHDATA(a)',
     });
     openResolver = null;
-    openStub = sandbox.stub(WebLoginDialog.prototype, 'open').callsFake(() => {
-      return new Promise(resolve => {
-        openResolver = resolve;
+    openStub = env.sandbox
+      .stub(WebLoginDialog.prototype, 'open')
+      .callsFake(() => {
+        return new Promise(resolve => {
+          openResolver = resolve;
+        });
       });
-    });
   });
 
   afterEach(() => {

--- a/extensions/amp-subscriptions/0.1/test/test-amp-subscriptions.js
+++ b/extensions/amp-subscriptions/0.1/test/test-amp-subscriptions.js
@@ -99,33 +99,33 @@ describes.fakeWin('AmpSubscriptions', {amp: true}, env => {
     win.document.body.appendChild(element);
     subscriptionService = new SubscriptionService(ampdoc);
     pageConfig = new PageConfig('scenic-2017.appspot.com:news', true);
-    sandbox
+    env.sandbox
       .stub(PageConfigResolver.prototype, 'resolveConfig')
       .callsFake(function() {
         configResolver = this;
         return Promise.resolve(pageConfig);
       });
-    sandbox
+    env.sandbox
       .stub(subscriptionService, 'getPlatformConfig_')
       .callsFake(() => Promise.resolve(serviceConfig));
-    analyticsEventStub = sandbox.stub(
+    analyticsEventStub = env.sandbox.stub(
       subscriptionService.subscriptionAnalytics_,
       'event'
     );
     // isStoryDocument needs to resolve synchronously because of how some of the
     // tests are built.
     isStory = false;
-    sandbox
+    env.sandbox
       .stub(utilsStory, 'isStoryDocument')
       .returns({then: fn => fn(isStory)});
   });
 
   it('should call `initialize_` on start', () => {
-    const localPlatformStub = sandbox.stub(
+    const localPlatformStub = env.sandbox.stub(
       subscriptionService,
       'initializeLocalPlatforms_'
     );
-    const initializeStub = sandbox.spy(subscriptionService, 'initialize_');
+    const initializeStub = env.sandbox.spy(subscriptionService, 'initialize_');
     subscriptionService.start();
     expect(initializeStub).to.be.calledOnce;
     return subscriptionService.initialize_().then(() => {
@@ -138,8 +138,8 @@ describes.fakeWin('AmpSubscriptions', {amp: true}, env => {
 
   describe('start', () => {
     it('should setup store and page on start', () => {
-      sandbox.stub(subscriptionService, 'initializeLocalPlatforms_');
-      const renderLoadingStub = sandbox.spy(
+      env.sandbox.stub(subscriptionService, 'initializeLocalPlatforms_');
+      const renderLoadingStub = env.sandbox.spy(
         subscriptionService.renderer_,
         'toggleLoading'
       );
@@ -156,15 +156,15 @@ describes.fakeWin('AmpSubscriptions', {amp: true}, env => {
     });
 
     it('should start auth flow for short circuiting', () => {
-      const authFlowStub = sandbox.stub(
+      const authFlowStub = env.sandbox.stub(
         subscriptionService,
         'startAuthorizationFlow_'
       );
-      const delegateStub = sandbox.stub(
+      const delegateStub = env.sandbox.stub(
         subscriptionService,
         'delegateAuthToViewer_'
       );
-      sandbox.stub(subscriptionService, 'initialize_').callsFake(() => {
+      env.sandbox.stub(subscriptionService, 'initialize_').callsFake(() => {
         subscriptionService.platformConfig_ = serviceConfig;
         subscriptionService.pageConfig_ = pageConfig;
         subscriptionService.doesViewerProvideAuth_ = true;
@@ -178,11 +178,11 @@ describes.fakeWin('AmpSubscriptions', {amp: true}, env => {
     });
 
     it('should skip everything and unlock document for alwaysGrant', () => {
-      const processStateStub = sandbox.stub(
+      const processStateStub = env.sandbox.stub(
         subscriptionService,
         'processGrantState_'
       );
-      sandbox.stub(subscriptionService, 'initialize_').callsFake(() => {
+      env.sandbox.stub(subscriptionService, 'initialize_').callsFake(() => {
         subscriptionService.platformConfig_ = {
           alwaysGrant: true,
         };
@@ -199,19 +199,19 @@ describes.fakeWin('AmpSubscriptions', {amp: true}, env => {
       'should not skip everything and unlock document for alwaysGrant ' +
         'if viewer provides authorization',
       () => {
-        const processStateStub = sandbox.stub(
+        const processStateStub = env.sandbox.stub(
           subscriptionService,
           'processGrantState_'
         );
-        const authFlowStub = sandbox.stub(
+        const authFlowStub = env.sandbox.stub(
           subscriptionService,
           'startAuthorizationFlow_'
         );
-        const delegateStub = sandbox.stub(
+        const delegateStub = env.sandbox.stub(
           subscriptionService,
           'delegateAuthToViewer_'
         );
-        sandbox.stub(subscriptionService, 'initialize_').callsFake(() => {
+        env.sandbox.stub(subscriptionService, 'initialize_').callsFake(() => {
           subscriptionService.platformConfig_ = {
             alwaysGrant: true,
           };
@@ -231,15 +231,15 @@ describes.fakeWin('AmpSubscriptions', {amp: true}, env => {
     it('should delay the platform selection and activation if story', () => {
       isStory = true;
 
-      const processStateStub = sandbox.stub(
+      const processStateStub = env.sandbox.stub(
         subscriptionService,
         'processGrantState_'
       );
-      const authFlowStub = sandbox.stub(
+      const authFlowStub = env.sandbox.stub(
         subscriptionService,
         'startAuthorizationFlow_'
       );
-      const delegateStub = sandbox.stub(
+      const delegateStub = env.sandbox.stub(
         subscriptionService,
         'delegateAuthToViewer_'
       );
@@ -258,7 +258,7 @@ describes.fakeWin('AmpSubscriptions', {amp: true}, env => {
 
     beforeEach(() => {
       return Services.cidForDoc(ampdoc).then(cid => {
-        cidGet = sandbox
+        cidGet = env.sandbox
           .stub(cid, 'get')
           .callsFake(() => Promise.resolve('cid1'));
       });
@@ -316,16 +316,16 @@ describes.fakeWin('AmpSubscriptions', {amp: true}, env => {
       grantReason: GrantReason.SUBSCRIBER,
     };
     const entitlement = Entitlement.parseFromJson(entitlementData);
-    const factoryStub = sandbox.stub().callsFake(() => platform);
+    const factoryStub = env.sandbox.stub().callsFake(() => platform);
 
     subscriptionService.platformStore_ = new PlatformStore([
       serviceData.serviceId,
     ]);
 
-    platform.getEntitlements = sandbox
+    platform.getEntitlements = env.sandbox
       .stub()
       .callsFake(() => Promise.resolve(entitlement));
-    platform.getServiceId = sandbox.stub().callsFake(() => 'local');
+    platform.getServiceId = env.sandbox.stub().callsFake(() => 'local');
 
     subscriptionService.platformConfig_ = serviceConfig;
     subscriptionService.registerPlatform(serviceData.serviceId, factoryStub);
@@ -423,23 +423,23 @@ describes.fakeWin('AmpSubscriptions', {amp: true}, env => {
         : null;
       const granted = !!grantEntitlementSpec;
       const localPlatform = subscriptionService.platformStore_.getLocalPlatform();
-      sandbox
+      env.sandbox
         .stub(subscriptionService.platformStore_, 'getGrantStatus')
         .callsFake(() => Promise.resolve(granted));
-      sandbox
+      env.sandbox
         .stub(subscriptionService.platformStore_, 'getGrantEntitlement')
         .callsFake(() => Promise.resolve(grantEntitlement));
       subscriptionService.platformStore_.resolveEntitlement(
         entitlementSpec.source,
         entitlement
       );
-      sandbox
+      env.sandbox
         .stub(subscriptionService.platformStore_, 'selectPlatform')
         .callsFake(() => Promise.resolve(localPlatform));
     }
 
     it('should wait for grantStatus/ent and selectPlatform promise', () => {
-      sandbox.stub(subscriptionService, 'fetchEntitlements_');
+      env.sandbox.stub(subscriptionService, 'fetchEntitlements_');
       subscriptionService.start();
       subscriptionService.viewTrackerPromise_ = Promise.resolve();
       return subscriptionService.initialize_().then(() => {
@@ -450,7 +450,7 @@ describes.fakeWin('AmpSubscriptions', {amp: true}, env => {
         const localPlatform = subscriptionService.platformStore_.getLocalPlatform();
         const selectPlatformStub =
           subscriptionService.platformStore_.selectPlatform;
-        const activateStub = sandbox.stub(localPlatform, 'activate');
+        const activateStub = env.sandbox.stub(localPlatform, 'activate');
         expect(localPlatform).to.be.not.null;
         return subscriptionService.selectAndActivatePlatform_().then(() => {
           expect(activateStub).to.be.calledOnce;
@@ -477,7 +477,7 @@ describes.fakeWin('AmpSubscriptions', {amp: true}, env => {
     });
 
     it('should activate with a different grant entitlement', () => {
-      sandbox.stub(subscriptionService, 'fetchEntitlements_');
+      env.sandbox.stub(subscriptionService, 'fetchEntitlements_');
       subscriptionService.start();
       subscriptionService.viewTrackerPromise_ = Promise.resolve();
       return subscriptionService.initialize_().then(() => {
@@ -495,7 +495,7 @@ describes.fakeWin('AmpSubscriptions', {amp: true}, env => {
         const localPlatform = subscriptionService.platformStore_.getLocalPlatform();
         const selectPlatformStub =
           subscriptionService.platformStore_.selectPlatform;
-        const activateStub = sandbox.stub(localPlatform, 'activate');
+        const activateStub = env.sandbox.stub(localPlatform, 'activate');
         expect(localPlatform).to.be.not.null;
         return subscriptionService.selectAndActivatePlatform_().then(() => {
           expect(activateStub).to.be.calledOnce;
@@ -522,7 +522,7 @@ describes.fakeWin('AmpSubscriptions', {amp: true}, env => {
     });
 
     it('should call selectPlatform with preferViewerSupport config', () => {
-      sandbox.stub(subscriptionService, 'fetchEntitlements_');
+      env.sandbox.stub(subscriptionService, 'fetchEntitlements_');
       subscriptionService.start();
       subscriptionService.viewTrackerPromise_ = Promise.resolve();
       return subscriptionService.initialize_().then(() => {
@@ -540,13 +540,13 @@ describes.fakeWin('AmpSubscriptions', {amp: true}, env => {
     });
 
     it('should send paywall activation event', () => {
-      sandbox.stub(subscriptionService, 'fetchEntitlements_');
+      env.sandbox.stub(subscriptionService, 'fetchEntitlements_');
       subscriptionService.start();
       subscriptionService.viewTrackerPromise_ = Promise.resolve();
       return subscriptionService.initialize_().then(() => {
         resolveRequiredPromises({granted: false});
         const localPlatform = subscriptionService.platformStore_.getLocalPlatform();
-        sandbox.stub(localPlatform, 'activate');
+        env.sandbox.stub(localPlatform, 'activate');
         return subscriptionService.selectAndActivatePlatform_().then(() => {
           expect(analyticsEventStub).to.be.calledWith(
             SubscriptionAnalyticsEvents.PLATFORM_ACTIVATED,
@@ -574,14 +574,14 @@ describes.fakeWin('AmpSubscriptions', {amp: true}, env => {
   describe('startAuthorizationFlow_', () => {
     it('should start grantStatus and platform selection', () => {
       subscriptionService.platformStore_ = new PlatformStore(products);
-      const getGrantStatusStub = sandbox
+      const getGrantStatusStub = env.sandbox
         .stub(subscriptionService.platformStore_, 'getGrantStatus')
         .callsFake(() => Promise.resolve());
-      const selectAndActivateStub = sandbox.stub(
+      const selectAndActivateStub = env.sandbox.stub(
         subscriptionService,
         'selectAndActivatePlatform_'
       );
-      const performPingbackStub = sandbox.stub(
+      const performPingbackStub = env.sandbox.stub(
         subscriptionService,
         'performPingback_'
       );
@@ -595,10 +595,10 @@ describes.fakeWin('AmpSubscriptions', {amp: true}, env => {
 
     it('should not call selectAndActivatePlatform based on param', () => {
       subscriptionService.platformStore_ = new PlatformStore(products);
-      const getGrantStatusStub = sandbox
+      const getGrantStatusStub = env.sandbox
         .stub(subscriptionService.platformStore_, 'getGrantStatus')
         .callsFake(() => Promise.resolve());
-      const selectAndActivateStub = sandbox.stub(
+      const selectAndActivateStub = env.sandbox.stub(
         subscriptionService,
         'selectAndActivatePlatform_'
       );
@@ -614,7 +614,7 @@ describes.fakeWin('AmpSubscriptions', {amp: true}, env => {
     let firstVisibleStub;
     beforeEach(() => {
       serviceAdapter = new ServiceAdapter(subscriptionService);
-      firstVisibleStub = sandbox
+      firstVisibleStub = env.sandbox
         .stub(ampdoc, 'whenFirstVisible')
         .callsFake(() => Promise.resolve());
       subscriptionService.pageConfig_ = pageConfig;
@@ -629,10 +629,10 @@ describes.fakeWin('AmpSubscriptions', {amp: true}, env => {
       expect(firstVisibleStub).to.be.called;
     });
     it('should report failure if platform timeouts', done => {
-      sandbox
+      env.sandbox
         .stub(platform, 'getEntitlements')
         .callsFake(() => new Promise(resolve => setTimeout(resolve, 8000)));
-      const failureStub = sandbox.stub(
+      const failureStub = env.sandbox.stub(
         subscriptionService.platformStore_,
         'reportPlatformFailureAndFallback'
       );
@@ -643,10 +643,10 @@ describes.fakeWin('AmpSubscriptions', {amp: true}, env => {
     }).timeout(7000);
 
     it('should report failure if platform reject promise', done => {
-      sandbox
+      env.sandbox
         .stub(platform, 'getEntitlements')
         .callsFake(() => Promise.reject());
-      const failureStub = sandbox.stub(
+      const failureStub = env.sandbox.stub(
         subscriptionService.platformStore_,
         'reportPlatformFailureAndFallback'
       );
@@ -666,10 +666,10 @@ describes.fakeWin('AmpSubscriptions', {amp: true}, env => {
         granted: true,
         grantReason: GrantReason.SUBSCRIBER,
       });
-      sandbox
+      env.sandbox
         .stub(platform, 'getEntitlements')
         .callsFake(() => Promise.resolve(entitlement));
-      const resolveStub = sandbox.stub(
+      const resolveStub = env.sandbox.stub(
         subscriptionService.platformStore_,
         'resolveEntitlement'
       );
@@ -695,11 +695,11 @@ describes.fakeWin('AmpSubscriptions', {amp: true}, env => {
       subscriptionService.platformStore_ = new PlatformStore(['local']);
       subscriptionService.initializeLocalPlatforms_(service);
       subscriptionService.platformStore_.resolvePlatform('local', platform);
-      const resetSubscriptionPlatformSpy = sandbox.spy(
+      const resetSubscriptionPlatformSpy = env.sandbox.spy(
         subscriptionService.platformStore_,
         'resetPlatformStore'
       );
-      sandbox.stub(subscriptionService, 'startAuthorizationFlow_');
+      env.sandbox.stub(subscriptionService, 'startAuthorizationFlow_');
       const origPlatforms = subscriptionService.platformStore_.serviceIds_;
       subscriptionService.resetPlatforms();
       expect(resetSubscriptionPlatformSpy).to.be.calledOnce;
@@ -717,14 +717,14 @@ describes.fakeWin('AmpSubscriptions', {amp: true}, env => {
       subscriptionService.pageConfig_ = pageConfig;
       subscriptionService.platformConfig_ = serviceConfig;
       subscriptionService.doesViewerProvideAuth_ = true;
-      sandbox
+      env.sandbox
         .stub(subscriptionService, 'initialize_')
         .callsFake(() => Promise.resolve());
       sendMessageAwaitResponsePromise = Promise.resolve();
-      sandbox
+      env.sandbox
         .stub(subscriptionService.viewer_, 'sendMessageAwaitResponse')
         .callsFake(() => sendMessageAwaitResponsePromise);
-      fetchEntitlementsStub = sandbox.stub(
+      fetchEntitlementsStub = env.sandbox.stub(
         subscriptionService,
         'fetchEntitlements_'
       );
@@ -788,18 +788,18 @@ describes.fakeWin('AmpSubscriptions', {amp: true}, env => {
       subscriptionService.doesViewerProvidePaywall_ = true;
       subscriptionService.doesViewerProvideAuth_ = true;
       subscriptionService.platformStore_ = new PlatformStore(products);
-      const getGrantStatusStub = sandbox
+      const getGrantStatusStub = env.sandbox
         .stub(subscriptionService.platformStore_, 'getGrantStatus')
         .callsFake(() => Promise.resolve());
-      const selectAndActivateStub = sandbox.stub(
+      const selectAndActivateStub = env.sandbox.stub(
         subscriptionService,
         'selectAndActivatePlatform_'
       );
-      const performPingbackStub = sandbox.stub(
+      const performPingbackStub = env.sandbox.stub(
         subscriptionService,
         'performPingback_'
       );
-      const setGrantStateStub = sandbox.stub(
+      const setGrantStateStub = env.sandbox.stub(
         subscriptionService.renderer_,
         'setGrantState'
       );
@@ -823,7 +823,7 @@ describes.fakeWin('AmpSubscriptions', {amp: true}, env => {
       yield subscriptionService.initialize_();
       // Local platform store not created until initialization.
       const platformStore = subscriptionService.platformStore_;
-      sandbox.stub(platformStore, 'reportPlatformFailureAndFallback');
+      env.sandbox.stub(platformStore, 'reportPlatformFailureAndFallback');
       rejecter();
       // Wait for sendMessageAwaitResponse() to be rejected.
       yield sendMessageAwaitResponsePromise;
@@ -848,7 +848,7 @@ describes.fakeWin('AmpSubscriptions', {amp: true}, env => {
         'local',
         new SubscriptionPlatform()
       );
-      const entitlementStub = sandbox
+      const entitlementStub = env.sandbox
         .stub(subscriptionService.platformStore_, 'getGrantEntitlement')
         .callsFake(() => Promise.resolve(entitlement));
       return subscriptionService.performPingback_().then(() => {
@@ -868,10 +868,10 @@ describes.fakeWin('AmpSubscriptions', {amp: true}, env => {
       const platform = new SubscriptionPlatform();
       platform.isPingbackEnabled = () => true;
       subscriptionService.platformStore_.resolvePlatform('local', platform);
-      sandbox
+      env.sandbox
         .stub(subscriptionService.platformStore_, 'getGrantEntitlement')
         .callsFake(() => Promise.resolve(entitlement));
-      const pingbackStub = sandbox.stub(platform, 'pingback');
+      const pingbackStub = env.sandbox.stub(platform, 'pingback');
       return subscriptionService.performPingback_().then(() => {
         expect(pingbackStub).to.be.calledWith(entitlement);
       });
@@ -890,10 +890,10 @@ describes.fakeWin('AmpSubscriptions', {amp: true}, env => {
       platform.isPingbackEnabled = () => true;
       platform.pingbackReturnsAllEntitlements = () => true;
       subscriptionService.platformStore_.resolvePlatform('local', platform);
-      const entitlementStub = sandbox
+      const entitlementStub = env.sandbox
         .stub(subscriptionService.platformStore_, 'getAllPlatformsEntitlements')
         .callsFake(() => Promise.resolve([entitlement]));
-      const pingbackStub = sandbox.stub(platform, 'pingback');
+      const pingbackStub = env.sandbox.stub(platform, 'pingback');
       return subscriptionService.performPingback_().then(() => {
         expect(entitlementStub).to.be.called;
         expect(pingbackStub).to.be.calledWith([entitlement]);
@@ -906,10 +906,10 @@ describes.fakeWin('AmpSubscriptions', {amp: true}, env => {
       const platform = new SubscriptionPlatform();
       platform.isPingbackEnabled = () => true;
       subscriptionService.platformStore_.resolvePlatform('local', platform);
-      sandbox
+      env.sandbox
         .stub(subscriptionService.platformStore_, 'getGrantEntitlement')
         .callsFake(() => Promise.resolve(null));
-      const pingbackStub = sandbox.stub(platform, 'pingback');
+      const pingbackStub = env.sandbox.stub(platform, 'pingback');
       return subscriptionService.performPingback_().then(() => {
         expect(pingbackStub).to.be.calledWith(Entitlement.empty('local'));
       });
@@ -934,7 +934,7 @@ describes.fakeWin('AmpSubscriptions', {amp: true}, env => {
 
   describe('action delegation', () => {
     it('should call delegateActionToService with serviceId local', () => {
-      const delegateStub = sandbox.stub(
+      const delegateStub = env.sandbox.stub(
         subscriptionService,
         'delegateActionToService'
       );
@@ -950,8 +950,8 @@ describes.fakeWin('AmpSubscriptions', {amp: true}, env => {
         null
       );
       const platform = new SubscriptionPlatform();
-      const executeActionStub = sandbox.stub(platform, 'executeAction');
-      const getPlatformStub = sandbox
+      const executeActionStub = env.sandbox.stub(platform, 'executeAction');
+      const getPlatformStub = env.sandbox
         .stub(subscriptionService.platformStore_, 'onPlatformResolves')
         .callsFake((serviceId, callback) => callback(platform));
       const action = action;
@@ -974,10 +974,10 @@ describes.fakeWin('AmpSubscriptions', {amp: true}, env => {
         'local',
         'swg-google',
       ]);
-      const whenResolveStub = sandbox
+      const whenResolveStub = env.sandbox
         .stub(subscriptionService.platformStore_, 'onPlatformResolves')
         .callsFake((serviceId, callback) => callback(platform));
-      const decorateUIStub = sandbox.stub(platform, 'decorateUI');
+      const decorateUIStub = env.sandbox.stub(platform, 'decorateUI');
       subscriptionService.decorateServiceAction(element, 'swg-google', 'login');
       expect(whenResolveStub).to.be.calledWith(platform.getServiceId());
       expect(decorateUIStub).to.be.calledWith(element);
@@ -990,7 +990,7 @@ describes.fakeWin('AmpSubscriptions', {amp: true}, env => {
         'local',
         'swg-google',
       ]);
-      const loginStub = sandbox.stub(
+      const loginStub = env.sandbox.stub(
         subscriptionService.platformStore_,
         'selectPlatformForLogin'
       );
@@ -1021,7 +1021,7 @@ describes.fakeWin('AmpSubscriptions', {amp: true}, env => {
     });
 
     it('should try to decrypt document', () => {
-      const stub = sandbox.stub(
+      const stub = env.sandbox.stub(
         subscriptionService.cryptoHandler_,
         'tryToDecryptDocument'
       );
@@ -1039,7 +1039,7 @@ describes.fakeWin('AmpSubscriptions', {amp: true}, env => {
           test: 'a1',
         },
       });
-      const stub = sandbox.stub(
+      const stub = env.sandbox.stub(
         subscriptionService.cryptoHandler_,
         'tryToDecryptDocument'
       );
@@ -1067,7 +1067,7 @@ describes.fakeWin('AmpSubscriptions', {amp: true}, env => {
     });
 
     it('should return local reader ID', () => {
-      const stub = sandbox
+      const stub = env.sandbox
         .stub(subscriptionService, 'getReaderId')
         .callsFake(() => Promise.resolve('reader1'));
       return subscriptionService.getAccessReaderId().then(readerId => {

--- a/extensions/amp-subscriptions/0.1/test/test-analytics.js
+++ b/extensions/amp-subscriptions/0.1/test/test-analytics.js
@@ -22,7 +22,7 @@ import {
 } from '../analytics';
 import {user} from '../../../../src/log';
 
-//--> sandbox.stub(ServiceUrl, 'adsUrl', url => serverUrl + url);
+//--> env.sandbox.stub(ServiceUrl, 'adsUrl', url => serverUrl + url);
 
 const TAG = 'amp-subscriptions';
 const OPT_VARS = {'serviceId': 'service1'};
@@ -50,7 +50,7 @@ describes.realWin('SubscriptionAnalytics', {amp: true}, env => {
     let eventStub;
 
     beforeEach(() => {
-      eventStub = sandbox.stub(analytics, 'event');
+      eventStub = env.sandbox.stub(analytics, 'event');
     });
 
     it('should trigger a service event', () => {
@@ -73,8 +73,8 @@ describes.realWin('SubscriptionAnalytics', {amp: true}, env => {
     let ampLogStub;
 
     beforeEach(() => {
-      userLogStub = sandbox.stub(user(), 'info');
-      ampLogStub = sandbox.stub(AmpAnalytics, 'triggerAnalyticsEvent');
+      userLogStub = env.sandbox.stub(user(), 'info');
+      ampLogStub = env.sandbox.stub(AmpAnalytics, 'triggerAnalyticsEvent');
     });
 
     it('should log an event', () => {

--- a/extensions/amp-subscriptions/0.1/test/test-dialog.js
+++ b/extensions/amp-subscriptions/0.1/test/test-dialog.js
@@ -35,8 +35,8 @@ describes.realWin('AmpSubscriptions Dialog', {amp: true}, env => {
     installStylesForDoc(ampdoc, CSS, () => {}, false, 'amp-subscriptions');
     vsync = Services.vsyncFor(ampdoc.win);
     viewport = Services.viewportForDoc(ampdoc);
-    addToFixedLayerSpy = sandbox.stub(viewport, 'addToFixedLayer');
-    updatePaddingSpy = sandbox.stub(viewport, 'updatePaddingBottom');
+    addToFixedLayerSpy = env.sandbox.stub(viewport, 'addToFixedLayer');
+    updatePaddingSpy = env.sandbox.stub(viewport, 'updatePaddingBottom');
     dialog = new Dialog(ampdoc);
     content = createElementWithAttributes(doc, 'div', {
       style: 'height:17px',

--- a/extensions/amp-subscriptions/0.1/test/test-doc-impl.js
+++ b/extensions/amp-subscriptions/0.1/test/test-doc-impl.js
@@ -37,8 +37,8 @@ describes.realWin('DocImpl', {amp: true}, env => {
   it('should resolve body correctly', () => {
     const body = {};
     let bodyAvailable = false;
-    const bodyStub = sandbox.stub(ampdoc, 'getBody').callsFake(() => body);
-    sandbox.stub(ampdoc, 'isBodyAvailable').callsFake(() => bodyAvailable);
+    const bodyStub = env.sandbox.stub(ampdoc, 'getBody').callsFake(() => body);
+    env.sandbox.stub(ampdoc, 'isBodyAvailable').callsFake(() => bodyAvailable);
 
     // Body not available yet.
     expect(configDoc.getBody()).to.be.null;
@@ -51,8 +51,8 @@ describes.realWin('DocImpl', {amp: true}, env => {
   });
 
   it('should delegate ready signals to ampdoc', () => {
-    const readyStub = sandbox.stub(ampdoc, 'isReady');
-    const whenReadyStub = sandbox.stub(ampdoc, 'whenReady');
+    const readyStub = env.sandbox.stub(ampdoc, 'isReady');
+    const whenReadyStub = env.sandbox.stub(ampdoc, 'whenReady');
 
     configDoc.isReady();
     expect(readyStub).to.be.calledOnce;

--- a/extensions/amp-subscriptions/0.1/test/test-local-subscription-rendering.js
+++ b/extensions/amp-subscriptions/0.1/test/test-local-subscription-rendering.js
@@ -51,8 +51,8 @@ describes.realWin('local-subscriptions-rendering', {amp: true}, env => {
       'should call renderActions_ and renderDialog with ' +
         'the entitlements provided',
       () => {
-        const actionRenderStub = sandbox.stub(renderer, 'renderActions_');
-        const dialogRenderStub = sandbox.stub(renderer, 'renderDialog_');
+        const actionRenderStub = env.sandbox.stub(renderer, 'renderActions_');
+        const dialogRenderStub = env.sandbox.stub(renderer, 'renderDialog_');
         renderer.render(entitlementsForService1);
         expect(actionRenderStub).to.be.calledWith(entitlementsForService1);
         expect(dialogRenderStub).to.be.calledWith(entitlementsForService1);
@@ -85,7 +85,10 @@ describes.realWin('local-subscriptions-rendering', {amp: true}, env => {
     });
 
     beforeEach(() => {
-      delegateUIStub = sandbox.stub(serviceAdapter, 'decorateServiceAction');
+      delegateUIStub = env.sandbox.stub(
+        serviceAdapter,
+        'decorateServiceAction'
+      );
     });
 
     function isDisplayed(el) {
@@ -137,8 +140,8 @@ describes.realWin('local-subscriptions-rendering', {amp: true}, env => {
     let dialog0, dialog1, dialog2, dialog3;
 
     beforeEach(() => {
-      templatesMock = sandbox.mock(Services.templatesFor(win));
-      dialogMock = sandbox.mock(renderer.dialog_);
+      templatesMock = env.sandbox.mock(Services.templatesFor(win));
+      dialogMock = env.sandbox.mock(renderer.dialog_);
       dialog0 = createElementWithAttributes(doc, 'div', {
         'id': 'dialog0',
         'subscriptions-dialog': '',
@@ -177,7 +180,7 @@ describes.realWin('local-subscriptions-rendering', {amp: true}, env => {
       dialogMock
         .expects('open')
         .withExactArgs(
-          sinon.match(arg => {
+          env.sandbox.match(arg => {
             content = arg;
             return true;
           }),
@@ -205,7 +208,7 @@ describes.realWin('local-subscriptions-rendering', {amp: true}, env => {
       dialogMock
         .expects('open')
         .withExactArgs(
-          sinon.match(arg => {
+          env.sandbox.match(arg => {
             content = arg;
             return true;
           }),

--- a/extensions/amp-subscriptions/0.1/test/test-local-subscriptions-iframe-platform.js
+++ b/extensions/amp-subscriptions/0.1/test/test-local-subscriptions-iframe-platform.js
@@ -43,17 +43,17 @@ describes.fakeWin('LocalSubscriptionsIframePlatform', {amp: true}, env => {
     ampdoc = env.ampdoc;
     serviceAdapter = new ServiceAdapter(null);
     const analytics = new SubscriptionAnalytics(ampdoc.getRootNode());
-    sandbox.stub(serviceAdapter, 'getAnalytics').callsFake(() => analytics);
-    sandbox
+    env.sandbox.stub(serviceAdapter, 'getAnalytics').callsFake(() => analytics);
+    env.sandbox
       .stub(serviceAdapter, 'getPageConfig')
       .callsFake(() => new PageConfig('example.org:basic', true));
-    sandbox
+    env.sandbox
       .stub(serviceAdapter, 'getDialog')
       .callsFake(() => new Dialog(ampdoc));
-    sandbox
+    env.sandbox
       .stub(serviceAdapter, 'getReaderId')
       .callsFake(() => Promise.resolve('reader1'));
-    sandbox
+    env.sandbox
       .stub(serviceAdapter, 'getEncryptedDocumentKey')
       .callsFake(() => null);
     serviceConfig.services = [
@@ -84,11 +84,7 @@ describes.fakeWin('LocalSubscriptionsIframePlatform', {amp: true}, env => {
       protocol: 'amp-subscriptions',
     };
 
-    builderMock = sandbox.mock(UrlBuilder.prototype);
-  });
-
-  afterEach(() => {
-    sandbox.restore();
+    builderMock = env.sandbox.mock(UrlBuilder.prototype);
   });
 
   it('initializeListeners_ should listen to clicks on rootNode', () => {
@@ -97,7 +93,7 @@ describes.fakeWin('LocalSubscriptionsIframePlatform', {amp: true}, env => {
       serviceConfig.services[0],
       serviceAdapter
     );
-    const domStub = sandbox.stub(
+    const domStub = env.sandbox.stub(
       localSubscriptionPlatform.rootNode_,
       'addEventListener'
     );
@@ -178,7 +174,7 @@ describes.fakeWin('LocalSubscriptionsIframePlatform', {amp: true}, env => {
 
   describe('runtime connect', () => {
     it('should NOT connect until necessary', () => {
-      const connectStub = sandbox.stub(Messenger.prototype, 'connect');
+      const connectStub = env.sandbox.stub(Messenger.prototype, 'connect');
       localSubscriptionPlatform = localSubscriptionPlatformFactory(
         ampdoc,
         serviceConfig.services[0],
@@ -190,7 +186,7 @@ describes.fakeWin('LocalSubscriptionsIframePlatform', {amp: true}, env => {
     });
 
     it('should connect on first and only first authorize', () => {
-      const connectStub = sandbox.stub(Messenger.prototype, 'connect');
+      const connectStub = env.sandbox.stub(Messenger.prototype, 'connect');
       localSubscriptionPlatform = localSubscriptionPlatformFactory(
         ampdoc,
         serviceConfig.services[0],
@@ -221,7 +217,7 @@ describes.fakeWin('LocalSubscriptionsIframePlatform', {amp: true}, env => {
         serviceConfig.services[0],
         serviceAdapter
       );
-      const sendStub = sandbox
+      const sendStub = env.sandbox
         .stub(localSubscriptionPlatform.messenger_, 'sendCommandRsvp')
         .returns(Promise.resolve({}));
       const promise = localSubscriptionPlatform.connect();
@@ -242,7 +238,7 @@ describes.fakeWin('LocalSubscriptionsIframePlatform', {amp: true}, env => {
     let localSubscriptionPlatform;
 
     beforeEach(() => {
-      messengerMock = sandbox.mock(Messenger.prototype);
+      messengerMock = env.sandbox.mock(Messenger.prototype);
       localSubscriptionPlatform = localSubscriptionPlatformFactory(
         ampdoc,
         serviceConfig.services[0],

--- a/extensions/amp-subscriptions/0.1/test/test-local-subscriptions.js
+++ b/extensions/amp-subscriptions/0.1/test/test-local-subscriptions.js
@@ -71,20 +71,20 @@ describes.fakeWin('LocalSubscriptionsPlatform', {amp: true}, env => {
     ampdoc = env.ampdoc;
     serviceAdapter = new ServiceAdapter(null);
     const analytics = new SubscriptionAnalytics(ampdoc.getRootNode());
-    sandbox.stub(serviceAdapter, 'getAnalytics').callsFake(() => analytics);
-    sandbox
+    env.sandbox.stub(serviceAdapter, 'getAnalytics').callsFake(() => analytics);
+    env.sandbox
       .stub(serviceAdapter, 'getScoreFactorStates')
       .callsFake(() => Promise.resolve(fakeScoreStates));
-    sandbox
+    env.sandbox
       .stub(serviceAdapter, 'getPageConfig')
       .callsFake(() => new PageConfig('example.org:basic', true));
-    sandbox
+    env.sandbox
       .stub(serviceAdapter, 'getDialog')
       .callsFake(() => new Dialog(ampdoc));
-    sandbox
+    env.sandbox
       .stub(serviceAdapter, 'getReaderId')
       .callsFake(() => Promise.resolve('reader1'));
-    getEncryptedDocumentKeyStub = sandbox
+    getEncryptedDocumentKeyStub = env.sandbox
       .stub(serviceAdapter, 'getEncryptedDocumentKey')
       .callsFake(() => {
         return null;
@@ -97,7 +97,7 @@ describes.fakeWin('LocalSubscriptionsPlatform', {amp: true}, env => {
   });
 
   it('initializeListeners_ should listen to clicks on rootNode', () => {
-    const domStub = sandbox.stub(
+    const domStub = env.sandbox.stub(
       localSubscriptionPlatform.rootNode_,
       'addEventListener'
     );
@@ -133,7 +133,7 @@ describes.fakeWin('LocalSubscriptionsPlatform', {amp: true}, env => {
   });
 
   it('should fetch the entitlements on getEntitlements', () => {
-    const fetchStub = sandbox
+    const fetchStub = env.sandbox
       .stub(localSubscriptionPlatform.xhr_, 'fetchJson')
       .callsFake(() => Promise.resolve({json: () => Promise.resolve(json)}));
     return localSubscriptionPlatform.getEntitlements().then(ent => {
@@ -146,10 +146,10 @@ describes.fakeWin('LocalSubscriptionsPlatform', {amp: true}, env => {
 
   it('should buildUrl before fetchingAuth', () => {
     const builtUrl = 'builtUrl';
-    const urlBuildingStub = sandbox
+    const urlBuildingStub = env.sandbox
       .stub(localSubscriptionPlatform.urlBuilder_, 'buildUrl')
       .callsFake(() => Promise.resolve(builtUrl));
-    const fetchStub = sandbox
+    const fetchStub = env.sandbox
       .stub(localSubscriptionPlatform.xhr_, 'fetchJson')
       .callsFake(() => Promise.resolve({json: () => Promise.resolve(json)}));
     return localSubscriptionPlatform.getEntitlements().then(() => {
@@ -159,7 +159,7 @@ describes.fakeWin('LocalSubscriptionsPlatform', {amp: true}, env => {
   });
 
   it('should call getEncryptedDocumentKey with local', () => {
-    sandbox
+    env.sandbox
       .stub(localSubscriptionPlatform.xhr_, 'fetchJson')
       .callsFake(() => Promise.resolve({json: () => Promise.resolve(json)}));
     return localSubscriptionPlatform.getEntitlements().then(() => {
@@ -168,7 +168,7 @@ describes.fakeWin('LocalSubscriptionsPlatform', {amp: true}, env => {
   });
 
   it('should add encryptedDocumentKey parameter to url', () => {
-    const fetchStub = sandbox
+    const fetchStub = env.sandbox
       .stub(localSubscriptionPlatform.xhr_, 'fetchJson')
       .callsFake(() => Promise.resolve({json: () => Promise.resolve(json)}));
     getEncryptedDocumentKeyStub.callsFake(() => {
@@ -182,7 +182,7 @@ describes.fakeWin('LocalSubscriptionsPlatform', {amp: true}, env => {
   });
 
   it('should not add encryptedDocumentKey parameter to url', () => {
-    const fetchStub = sandbox
+    const fetchStub = env.sandbox
       .stub(localSubscriptionPlatform.xhr_, 'fetchJson')
       .callsFake(() => Promise.resolve({json: () => Promise.resolve(json)}));
     return localSubscriptionPlatform.getEntitlements().then(() => {
@@ -236,7 +236,7 @@ describes.fakeWin('LocalSubscriptionsPlatform', {amp: true}, env => {
 
     // This must be a sync call to avoid Safari popup blocker issues.
     it('should call executeAction synchronosly when service is "auto"', () => {
-      const executeStub = sandbox.stub(
+      const executeStub = env.sandbox.stub(
         localSubscriptionPlatform,
         'executeAction'
       );
@@ -248,7 +248,7 @@ describes.fakeWin('LocalSubscriptionsPlatform', {amp: true}, env => {
     });
 
     it('should call executeAction with subscriptions-action value', () => {
-      const executeStub = sandbox.stub(
+      const executeStub = env.sandbox.stub(
         localSubscriptionPlatform,
         'executeAction'
       );
@@ -262,11 +262,11 @@ describes.fakeWin('LocalSubscriptionsPlatform', {amp: true}, env => {
       'should delegate action to service specified in ' +
         'subscriptions-service',
       () => {
-        const executeStub = sandbox.stub(
+        const executeStub = env.sandbox.stub(
           localSubscriptionPlatform,
           'executeAction'
         );
-        const delegateStub = sandbox.stub(
+        const delegateStub = env.sandbox.stub(
           localSubscriptionPlatform.serviceAdapter_,
           'delegateActionToService'
         );
@@ -285,14 +285,14 @@ describes.fakeWin('LocalSubscriptionsPlatform', {amp: true}, env => {
         element.removeAttribute('subscriptions-service');
         const platform = {};
         const serviceId = 'serviceId';
-        platform.getServiceId = sandbox.stub().callsFake(() => serviceId);
-        const loginStub = sandbox
+        platform.getServiceId = env.sandbox.stub().callsFake(() => serviceId);
+        const loginStub = env.sandbox
           .stub(
             localSubscriptionPlatform.serviceAdapter_,
             'selectPlatformForLogin'
           )
           .callsFake(() => platform);
-        const delegateStub = sandbox.stub(
+        const delegateStub = env.sandbox.stub(
           localSubscriptionPlatform.serviceAdapter_,
           'delegateActionToService'
         );
@@ -308,19 +308,19 @@ describes.fakeWin('LocalSubscriptionsPlatform', {amp: true}, env => {
       () => {
         element.setAttribute('subscriptions-action', Action.LOGIN);
         element.setAttribute('subscriptions-service', 'auto');
-        const loginStub = sandbox
+        const loginStub = env.sandbox
           .stub(
             localSubscriptionPlatform.serviceAdapter_,
             'selectPlatformForLogin'
           )
           .callsFake(() => platform);
-        const delegateStub = sandbox.stub(
+        const delegateStub = env.sandbox.stub(
           localSubscriptionPlatform.serviceAdapter_,
           'delegateActionToService'
         );
         const platform = {};
         const serviceId = 'serviceId';
-        platform.getServiceId = sandbox.stub().callsFake(() => serviceId);
+        platform.getServiceId = env.sandbox.stub().callsFake(() => serviceId);
         localSubscriptionPlatform.handleClick_(element);
         expect(loginStub).to.be.called;
         expect(delegateStub).to.be.calledWith(Action.LOGIN, serviceId);
@@ -330,21 +330,21 @@ describes.fakeWin('LocalSubscriptionsPlatform', {amp: true}, env => {
     it('should NOT delegate for scoreBasedLogin for non-login action', () => {
       element.setAttribute('subscriptions-action', Action.SUBSCRIBE);
       element.setAttribute('subscriptions-service', 'auto');
-      const loginStub = sandbox.stub(
+      const loginStub = env.sandbox.stub(
         localSubscriptionPlatform.serviceAdapter_,
         'selectPlatformForLogin'
       );
-      const executeStub = sandbox.stub(
+      const executeStub = env.sandbox.stub(
         localSubscriptionPlatform,
         'executeAction'
       );
-      const delegateStub = sandbox.stub(
+      const delegateStub = env.sandbox.stub(
         localSubscriptionPlatform.serviceAdapter_,
         'delegateActionToService'
       );
       const platform = {};
       const serviceId = 'serviceId';
-      platform.getServiceId = sandbox.stub().callsFake(() => serviceId);
+      platform.getServiceId = env.sandbox.stub().callsFake(() => serviceId);
       localSubscriptionPlatform.handleClick_(element);
       expect(loginStub).to.not.be.called;
       expect(delegateStub).to.not.be.called;
@@ -355,10 +355,10 @@ describes.fakeWin('LocalSubscriptionsPlatform', {amp: true}, env => {
   describe('executeAction', () => {
     it('should call executeAction on actions_', () => {
       const actionString = 'action';
-      const executeStub = sandbox
+      const executeStub = env.sandbox
         .stub(localSubscriptionPlatform.actions_, 'execute')
         .callsFake(() => Promise.resolve(true));
-      const resetStub = sandbox.stub(serviceAdapter, 'resetPlatforms');
+      const resetStub = env.sandbox.stub(serviceAdapter, 'resetPlatforms');
       localSubscriptionPlatform.executeAction(actionString);
       expect(executeStub).to.be.calledWith(actionString);
       return executeStub().then(() => {
@@ -369,11 +369,11 @@ describes.fakeWin('LocalSubscriptionsPlatform', {amp: true}, env => {
 
   describe('render', () => {
     it("should call renderer's render method", () => {
-      const renderStub = sandbox.stub(
+      const renderStub = env.sandbox.stub(
         localSubscriptionPlatform.renderer_,
         'render'
       );
-      const stateSub = sandbox
+      const stateSub = env.sandbox
         .stub(localSubscriptionPlatform, 'createRenderState_')
         .callsFake(() => Promise.resolve({foo: 'bar'}));
       localSubscriptionPlatform.activate(entitlement);
@@ -406,7 +406,7 @@ describes.fakeWin('LocalSubscriptionsPlatform', {amp: true}, env => {
     });
 
     it("should reset renderer's on reset", () => {
-      const resetStub = sandbox.stub(
+      const resetStub = env.sandbox.stub(
         localSubscriptionPlatform.renderer_,
         'reset'
       );
@@ -417,7 +417,7 @@ describes.fakeWin('LocalSubscriptionsPlatform', {amp: true}, env => {
 
   describe('pingback', () => {
     it('should call `sendSignal` to the pingback signal', () => {
-      const sendSignalStub = sandbox.stub(
+      const sendSignalStub = env.sandbox.stub(
         localSubscriptionPlatform.xhr_,
         'sendSignal'
       );
@@ -430,7 +430,7 @@ describes.fakeWin('LocalSubscriptionsPlatform', {amp: true}, env => {
       });
     });
     it('pingback should handle multiple entitlements ', () => {
-      const sendSignalStub = sandbox.stub(
+      const sendSignalStub = env.sandbox.stub(
         localSubscriptionPlatform.xhr_,
         'sendSignal'
       );

--- a/extensions/amp-subscriptions/0.1/test/test-platform-store.js
+++ b/extensions/amp-subscriptions/0.1/test/test-platform-store.js
@@ -20,7 +20,7 @@ import {PlatformStore} from '../platform-store';
 import {SubscriptionPlatform} from '../subscription-platform';
 import {user} from '../../../../src/log';
 
-describes.realWin('Platform store', {}, () => {
+describes.realWin('Platform store', {}, env => {
   let platformStore;
   const serviceIds = ['service1', 'service2'];
   const entitlementsForService1 = new Entitlement({
@@ -95,7 +95,7 @@ describes.realWin('Platform store', {}, () => {
   });
 
   it('should call onChange callbacks on every resolve', () => {
-    const cb = sandbox.stub(
+    const cb = env.sandbox.stub(
       platformStore.onEntitlementResolvedCallbacks_,
       'fire'
     );
@@ -200,23 +200,25 @@ describes.realWin('Platform store', {}, () => {
     const anotherPlatformBaseScore = 0;
     beforeEach(() => {
       localPlatform = new SubscriptionPlatform();
-      sandbox.stub(localPlatform, 'getServiceId').callsFake(() => 'local');
-      sandbox
+      env.sandbox.stub(localPlatform, 'getServiceId').callsFake(() => 'local');
+      env.sandbox
         .stub(localPlatform, 'getBaseScore')
         .callsFake(() => localPlatformBaseScore);
       anotherPlatform = new SubscriptionPlatform();
-      sandbox.stub(anotherPlatform, 'getServiceId').callsFake(() => 'another');
-      sandbox
+      env.sandbox
+        .stub(anotherPlatform, 'getServiceId')
+        .callsFake(() => 'another');
+      env.sandbox
         .stub(anotherPlatform, 'getBaseScore')
         .callsFake(() => anotherPlatformBaseScore);
       platformStore.resolvePlatform('another', localPlatform);
       platformStore.resolvePlatform('local', anotherPlatform);
     });
     it('should return sorted array of platforms and weights', () => {
-      sandbox
+      env.sandbox
         .stub(localPlatform, 'getSupportedScoreFactor')
         .callsFake(factor => fakeGetSupportedScoreFactor(factor, {}));
-      sandbox
+      env.sandbox
         .stub(anotherPlatform, 'getSupportedScoreFactor')
         .callsFake(factor => fakeGetSupportedScoreFactor(factor, {}));
 
@@ -249,10 +251,10 @@ describes.realWin('Platform store', {}, () => {
         'is true',
       () => {
         const fakeResult = [entitlementsForService1, entitlementsForService2];
-        const getAllPlatformsStub = sandbox
+        const getAllPlatformsStub = env.sandbox
           .stub(platformStore, 'getAllPlatformsEntitlements')
           .callsFake(() => Promise.resolve(fakeResult));
-        const selectApplicablePlatformStub = sandbox
+        const selectApplicablePlatformStub = env.sandbox
           .stub(platformStore, 'selectApplicablePlatform_')
           .callsFake(() => Promise.resolve());
         return platformStore.selectPlatform(true).then(() => {
@@ -270,13 +272,15 @@ describes.realWin('Platform store', {}, () => {
     let anotherPlatformBaseScore = 0;
     beforeEach(() => {
       localPlatform = new SubscriptionPlatform();
-      sandbox.stub(localPlatform, 'getServiceId').callsFake(() => 'local');
-      sandbox
+      env.sandbox.stub(localPlatform, 'getServiceId').callsFake(() => 'local');
+      env.sandbox
         .stub(localPlatform, 'getBaseScore')
         .callsFake(() => localPlatformBaseScore);
       anotherPlatform = new SubscriptionPlatform();
-      sandbox.stub(anotherPlatform, 'getServiceId').callsFake(() => 'another');
-      sandbox
+      env.sandbox
+        .stub(anotherPlatform, 'getServiceId')
+        .callsFake(() => 'another');
+      env.sandbox
         .stub(anotherPlatform, 'getBaseScore')
         .callsFake(() => anotherPlatformBaseScore);
       platformStore = new PlatformStore(
@@ -336,10 +340,10 @@ describes.realWin('Platform store', {}, () => {
     });
 
     it('should choose local platform if all other conditions are same', () => {
-      sandbox
+      env.sandbox
         .stub(localPlatform, 'getSupportedScoreFactor')
         .callsFake(factor => fakeGetSupportedScoreFactor(factor, {}));
-      sandbox
+      env.sandbox
         .stub(anotherPlatform, 'getSupportedScoreFactor')
         .callsFake(factor => fakeGetSupportedScoreFactor(factor, {}));
 
@@ -365,11 +369,11 @@ describes.realWin('Platform store', {}, () => {
     });
 
     it('should chose platform based on score weight', () => {
-      sandbox
+      env.sandbox
         .stub(localPlatform, 'getSupportedScoreFactor')
         .callsFake(factor => fakeGetSupportedScoreFactor(factor, {}));
       // +9
-      sandbox
+      env.sandbox
         .stub(anotherPlatform, 'getSupportedScoreFactor')
         .callsFake(factor =>
           fakeGetSupportedScoreFactor(factor, {'supportsViewer': 1})
@@ -398,13 +402,13 @@ describes.realWin('Platform store', {}, () => {
 
     it('should chose platform based on multiple factors', () => {
       // +10
-      sandbox
+      env.sandbox
         .stub(localPlatform, 'getSupportedScoreFactor')
         .callsFake(factor =>
           fakeGetSupportedScoreFactor(factor, {'testFactor1': 1})
         );
       // +9
-      sandbox
+      env.sandbox
         .stub(anotherPlatform, 'getSupportedScoreFactor')
         .callsFake(factor =>
           fakeGetSupportedScoreFactor(factor, {'supportsViewer': 1})
@@ -433,13 +437,13 @@ describes.realWin('Platform store', {}, () => {
 
     it('should chose platform specified factors', () => {
       // +10
-      sandbox
+      env.sandbox
         .stub(localPlatform, 'getSupportedScoreFactor')
         .callsFake(factor =>
           fakeGetSupportedScoreFactor(factor, {'testFactor1': 1})
         );
       // +9
-      sandbox
+      env.sandbox
         .stub(anotherPlatform, 'getSupportedScoreFactor')
         .callsFake(factor =>
           fakeGetSupportedScoreFactor(factor, {'supportsViewer': 1})
@@ -468,13 +472,13 @@ describes.realWin('Platform store', {}, () => {
 
     it('should chose platform handle negative factor values', () => {
       // +10, -10
-      sandbox
+      env.sandbox
         .stub(localPlatform, 'getSupportedScoreFactor')
         .callsFake(factor =>
           fakeGetSupportedScoreFactor(factor, {testFactor1: 1, testFactor2: -1})
         );
       // +9
-      sandbox
+      env.sandbox
         .stub(anotherPlatform, 'getSupportedScoreFactor')
         .callsFake(factor =>
           fakeGetSupportedScoreFactor(factor, {'supportsViewer': 1})
@@ -502,10 +506,10 @@ describes.realWin('Platform store', {}, () => {
     });
 
     it('should use baseScore', () => {
-      sandbox
+      env.sandbox
         .stub(localPlatform, 'getSupportedScoreFactor')
         .callsFake(factor => fakeGetSupportedScoreFactor(factor, {}));
-      sandbox
+      env.sandbox
         .stub(anotherPlatform, 'getSupportedScoreFactor')
         .callsFake(factor => fakeGetSupportedScoreFactor(factor, {}));
       localPlatformBaseScore = 1;
@@ -531,16 +535,16 @@ describes.realWin('Platform store', {}, () => {
       );
     });
     it('getScoreFactorStates should return promised score', () => {
-      sandbox
+      env.sandbox
         .stub(localPlatform, 'getSupportedScoreFactor')
         .callsFake(factor => fakeGetSupportedScoreFactor(factor, {}));
       // +9
-      sandbox
+      env.sandbox
         .stub(anotherPlatform, 'getSupportedScoreFactor')
         .callsFake(factor =>
           fakeGetSupportedScoreFactor(factor, {'supportsViewer': 1})
         );
-      sandbox
+      env.sandbox
         .stub(platformStore, 'getEntitlementPromiseFor')
         .callsFake(() => Promise.resolve());
 
@@ -582,17 +586,19 @@ describes.realWin('Platform store', {}, () => {
     beforeEach(() => {
       localFactors = {};
       localPlatform = new SubscriptionPlatform();
-      sandbox.stub(localPlatform, 'getServiceId').callsFake(() => 'local');
+      env.sandbox.stub(localPlatform, 'getServiceId').callsFake(() => 'local');
       // Base score does not matter.
-      sandbox.stub(localPlatform, 'getBaseScore').callsFake(() => 10000);
-      sandbox
+      env.sandbox.stub(localPlatform, 'getBaseScore').callsFake(() => 10000);
+      env.sandbox
         .stub(localPlatform, 'getSupportedScoreFactor')
         .callsFake(factor => localFactors[factor]);
       anotherFactors = {};
       anotherPlatform = new SubscriptionPlatform();
-      sandbox.stub(anotherPlatform, 'getServiceId').callsFake(() => 'another');
-      sandbox.stub(anotherPlatform, 'getBaseScore').callsFake(() => 0);
-      sandbox
+      env.sandbox
+        .stub(anotherPlatform, 'getServiceId')
+        .callsFake(() => 'another');
+      env.sandbox.stub(anotherPlatform, 'getBaseScore').callsFake(() => 0);
+      env.sandbox
         .stub(anotherPlatform, 'getSupportedScoreFactor')
         .callsFake(factor => anotherFactors[factor]);
       // Local is ordered last in this case intentionally.
@@ -625,15 +631,15 @@ describes.realWin('Platform store', {}, () => {
   describe('reportPlatformFailureAndFallback', () => {
     let errorSpy;
     beforeEach(() => {
-      errorSpy = sandbox.spy(user(), 'warn');
+      errorSpy = env.sandbox.spy(user(), 'warn');
     });
     it(
       'should report warning if all platforms fail and resolve ' +
         'local with fallbackEntitlement',
       () => {
         const platform = new SubscriptionPlatform();
-        sandbox.stub(platform, 'getServiceId').callsFake(() => 'local');
-        sandbox
+        env.sandbox.stub(platform, 'getServiceId').callsFake(() => 'local');
+        env.sandbox
           .stub(platformStore, 'getLocalPlatform')
           .callsFake(() => platform);
         platformStore.reportPlatformFailureAndFallback('service1');
@@ -652,14 +658,14 @@ describes.realWin('Platform store', {}, () => {
       () => {
         const platform = new SubscriptionPlatform();
         const anotherPlatform = new SubscriptionPlatform();
-        sandbox.stub(platform, 'getServiceId').callsFake(() => 'local');
-        sandbox
+        env.sandbox.stub(platform, 'getServiceId').callsFake(() => 'local');
+        env.sandbox
           .stub(platformStore, 'getLocalPlatform')
           .callsFake(() => platform);
-        sandbox
+        env.sandbox
           .stub(anotherPlatform, 'getServiceId')
           .callsFake(() => serviceIds[0]);
-        sandbox.stub(anotherPlatform, 'getBaseScore').callsFake(() => 10);
+        env.sandbox.stub(anotherPlatform, 'getBaseScore').callsFake(() => 10);
         platformStore.resolvePlatform(serviceIds[0], anotherPlatform);
         platformStore.resolvePlatform('local', platform);
         platformStore.reportPlatformFailureAndFallback('local');
@@ -683,14 +689,14 @@ describes.realWin('Platform store', {}, () => {
       () => {
         const platform = new SubscriptionPlatform();
         const anotherPlatform = new SubscriptionPlatform();
-        sandbox.stub(platform, 'getServiceId').callsFake(() => 'local');
-        sandbox
+        env.sandbox.stub(platform, 'getServiceId').callsFake(() => 'local');
+        env.sandbox
           .stub(platformStore, 'getLocalPlatform')
           .callsFake(() => platform);
-        sandbox
+        env.sandbox
           .stub(anotherPlatform, 'getServiceId')
           .callsFake(() => serviceIds[0]);
-        sandbox.stub(anotherPlatform, 'getBaseScore').callsFake(() => 10);
+        env.sandbox.stub(anotherPlatform, 'getBaseScore').callsFake(() => 10);
         platformStore.resolvePlatform(serviceIds[0], anotherPlatform);
         platformStore.resolvePlatform('local', platform);
         fallbackEntitlement.grantReason = GrantReason.METERING;
@@ -844,7 +850,7 @@ describes.realWin('Platform store', {}, () => {
 
     beforeEach(() => {
       localPlatform = new SubscriptionPlatform();
-      sandbox.stub(localPlatform, 'getServiceId').callsFake(() => 'local');
+      env.sandbox.stub(localPlatform, 'getServiceId').callsFake(() => 'local');
     });
 
     it(

--- a/extensions/amp-subscriptions/0.1/test/test-renderer.js
+++ b/extensions/amp-subscriptions/0.1/test/test-renderer.js
@@ -93,9 +93,11 @@ describes.realWin(
       installStylesForDoc(ampdoc, CSS, () => {}, false, 'amp-subscriptions');
 
       const resources = Services.resourcesForDoc(ampdoc);
-      sandbox.stub(resources, 'mutateElement').callsFake((element, mutator) => {
-        mutator();
-      });
+      env.sandbox
+        .stub(resources, 'mutateElement')
+        .callsFake((element, mutator) => {
+          mutator();
+        });
 
       unrelated = createElementWithAttributes(doc, 'div', {});
 
@@ -217,7 +219,7 @@ describes.realWin(
       let insertBeforeStub;
 
       beforeEach(() => {
-        insertBeforeStub = sandbox.stub(
+        insertBeforeStub = env.sandbox.stub(
           renderer.ampdoc_.getBody(),
           'insertBefore'
         );

--- a/extensions/amp-subscriptions/0.1/test/test-service-adapter.js
+++ b/extensions/amp-subscriptions/0.1/test/test-service-adapter.js
@@ -56,7 +56,7 @@ describes.realWin(
 
     describe('getEncryptedDocumentKey', () => {
       it('should call getEncryptedDocumentKey of subscription service', () => {
-        const stub = sandbox.stub(
+        const stub = env.sandbox.stub(
           subscriptionService,
           'getEncryptedDocumentKey'
         );
@@ -68,7 +68,7 @@ describes.realWin(
 
     describe('getPageConfig', () => {
       it('should call getPageConfig of subscription service', () => {
-        const stub = sandbox
+        const stub = env.sandbox
           .stub(subscriptionService, 'getPageConfig')
           .callsFake(() => pageConfig);
         serviceAdapter.getPageConfig();
@@ -79,7 +79,7 @@ describes.realWin(
     describe('delegateAction', () => {
       it('should call delegateActionToLocal of subscription service', () => {
         const p = Promise.resolve();
-        const stub = sandbox
+        const stub = env.sandbox
           .stub(serviceAdapter, 'delegateActionToService')
           .callsFake(() => p);
         const action = 'action';
@@ -90,7 +90,7 @@ describes.realWin(
 
       it('should call delegateActionToService of subscription service', () => {
         const p = Promise.resolve();
-        const stub = sandbox
+        const stub = env.sandbox
           .stub(subscriptionService, 'delegateActionToService')
           .callsFake(() => p);
         const action = 'action';
@@ -102,7 +102,7 @@ describes.realWin(
 
     describe('resetPlatforms', () => {
       it('should call initializePlatformStore_', () => {
-        const stub = sandbox.stub(subscriptionService, 'resetPlatforms');
+        const stub = env.sandbox.stub(subscriptionService, 'resetPlatforms');
         serviceAdapter.resetPlatforms();
         expect(stub).to.be.calledOnce;
       });
@@ -110,7 +110,7 @@ describes.realWin(
 
     describe('getDialog', () => {
       it('should call getDialog of subscription service', () => {
-        const stub = sandbox.stub(subscriptionService, 'getDialog');
+        const stub = env.sandbox.stub(subscriptionService, 'getDialog');
         serviceAdapter.getDialog();
         expect(stub).to.be.calledOnce;
       });
@@ -120,7 +120,10 @@ describes.realWin(
       it('should call decorateServiceAction of subscription service', () => {
         const element = win.document.createElement('div');
         const serviceId = 'local';
-        const stub = sandbox.stub(subscriptionService, 'decorateServiceAction');
+        const stub = env.sandbox.stub(
+          subscriptionService,
+          'decorateServiceAction'
+        );
         serviceAdapter.decorateServiceAction(element, serviceId, 'action');
         expect(stub).to.be.calledWith(element, serviceId, 'action');
       });
@@ -129,7 +132,7 @@ describes.realWin(
     describe('getReaderId', () => {
       it('should delegate call to getReaderId', () => {
         const readerIdPromise = Promise.resolve();
-        const stub = sandbox
+        const stub = env.sandbox
           .stub(subscriptionService, 'getReaderId')
           .returns(readerIdPromise);
         const promise = serviceAdapter.getReaderId('service1');

--- a/extensions/amp-subscriptions/0.1/test/test-viewer-platform.js
+++ b/extensions/amp-subscriptions/0.1/test/test-viewer-platform.js
@@ -59,21 +59,21 @@ describes.fakeWin('ViewerSubscriptionPlatform', {amp: true}, env => {
     win = env.win;
     serviceAdapter = new ServiceAdapter(null);
     const analytics = new SubscriptionAnalytics(ampdoc.getRootNode());
-    sandbox.stub(serviceAdapter, 'getAnalytics').callsFake(() => analytics);
-    sandbox
+    env.sandbox.stub(serviceAdapter, 'getAnalytics').callsFake(() => analytics);
+    env.sandbox
       .stub(serviceAdapter, 'getPageConfig')
       .callsFake(() => new PageConfig(currentProductId, true));
-    sandbox
+    env.sandbox
       .stub(serviceAdapter, 'getDialog')
       .callsFake(() => new Dialog(ampdoc));
-    sandbox
+    env.sandbox
       .stub(serviceAdapter, 'getReaderId')
       .callsFake(() => Promise.resolve('reader1'));
-    sandbox
+    env.sandbox
       .stub(serviceAdapter, 'getEncryptedDocumentKey')
       .callsFake(() => Promise.resolve(null));
-    resetPlatformsStub = sandbox.stub(serviceAdapter, 'resetPlatforms');
-    sandbox
+    resetPlatformsStub = env.sandbox.stub(serviceAdapter, 'resetPlatforms');
+    env.sandbox
       .stub(Services.viewerForDoc(ampdoc), 'onMessage')
       .callsFake((message, cb) => {
         messageCallback = cb;
@@ -84,10 +84,10 @@ describes.fakeWin('ViewerSubscriptionPlatform', {amp: true}, env => {
       serviceAdapter,
       origin
     );
-    sandbox
+    env.sandbox
       .stub(viewerPlatform.viewer_, 'sendMessageAwaitResponse')
       .callsFake(() => Promise.resolve(fakeAuthToken));
-    sendAuthTokenStub = sandbox.stub(
+    sendAuthTokenStub = env.sandbox.stub(
       viewerPlatform,
       'sendAuthTokenErrorToViewer_'
     );
@@ -96,7 +96,7 @@ describes.fakeWin('ViewerSubscriptionPlatform', {amp: true}, env => {
   describe('getEntitlements', () => {
     it('should call verify() with authorization and decryptedDocKey', () => {
       const entitlement = {};
-      const verifyAuthTokenStub = sandbox
+      const verifyAuthTokenStub = env.sandbox
         .stub(viewerPlatform, 'verifyAuthToken_')
         .callsFake(() => Promise.resolve(entitlement));
       return viewerPlatform.getEntitlements().then(() => {
@@ -109,7 +109,7 @@ describes.fakeWin('ViewerSubscriptionPlatform', {amp: true}, env => {
 
     it('should send auth rejection message for rejected verification', () => {
       const reason = 'Payload is expired';
-      sandbox
+      env.sandbox
         .stub(viewerPlatform, 'verifyAuthToken_')
         .callsFake(() => Promise.reject(new Error(reason)));
       return viewerPlatform.getEntitlements().catch(() => {
@@ -134,7 +134,7 @@ describes.fakeWin('ViewerSubscriptionPlatform', {amp: true}, env => {
     entitlement.service = 'local';
 
     it('should reject promise for expired payload', () => {
-      sandbox.stub(viewerPlatform.jwtHelper_, 'decode').callsFake(() => {
+      env.sandbox.stub(viewerPlatform.jwtHelper_, 'decode').callsFake(() => {
         return {
           'aud': getWinOrigin(win),
           'exp': Date.now() / 1000 - 10,
@@ -147,7 +147,7 @@ describes.fakeWin('ViewerSubscriptionPlatform', {amp: true}, env => {
     });
 
     it('should reject promise for audience mismatch', () => {
-      sandbox.stub(viewerPlatform.jwtHelper_, 'decode').callsFake(() => {
+      env.sandbox.stub(viewerPlatform.jwtHelper_, 'decode').callsFake(() => {
         return {
           'aud': 'random origin',
           'exp': Math.floor(Date.now() / 1000) + 5 * 60,
@@ -162,7 +162,7 @@ describes.fakeWin('ViewerSubscriptionPlatform', {amp: true}, env => {
     });
 
     it('should resolve promise with entitlement', () => {
-      sandbox.stub(viewerPlatform.jwtHelper_, 'decode').callsFake(() => {
+      env.sandbox.stub(viewerPlatform.jwtHelper_, 'decode').callsFake(() => {
         return {
           'aud': getWinOrigin(win),
           'exp': Math.floor(Date.now() / 1000) + 5 * 60,
@@ -189,7 +189,7 @@ describes.fakeWin('ViewerSubscriptionPlatform', {amp: true}, env => {
     });
 
     it('should resolve promise with entitlement and decryptedDocKey', () => {
-      sandbox.stub(viewerPlatform.jwtHelper_, 'decode').callsFake(() => {
+      env.sandbox.stub(viewerPlatform.jwtHelper_, 'decode').callsFake(() => {
         return {
           'aud': getWinOrigin(win),
           'exp': Math.floor(Date.now() / 1000) + 5 * 60,
@@ -209,7 +209,7 @@ describes.fakeWin('ViewerSubscriptionPlatform', {amp: true}, env => {
       'should resolve granted entitlement, with metering in data if ' +
         'viewer only sends metering',
       () => {
-        sandbox.stub(viewerPlatform.jwtHelper_, 'decode').callsFake(() => {
+        env.sandbox.stub(viewerPlatform.jwtHelper_, 'decode').callsFake(() => {
           return {
             'aud': getWinOrigin(win),
             'exp': Math.floor(Date.now() / 1000) + 5 * 60,
@@ -239,12 +239,15 @@ describes.fakeWin('ViewerSubscriptionPlatform', {amp: true}, env => {
 
   describe('proxy methods', () => {
     it('should delegate getServiceId', () => {
-      const proxyStub = sandbox.stub(viewerPlatform.platform_, 'getServiceId');
+      const proxyStub = env.sandbox.stub(
+        viewerPlatform.platform_,
+        'getServiceId'
+      );
       viewerPlatform.getServiceId();
       expect(proxyStub).to.be.called;
     });
     it('should delegate isPingbackEnabled', () => {
-      const proxyStub = sandbox.stub(
+      const proxyStub = env.sandbox.stub(
         viewerPlatform.platform_,
         'isPingbackEnabled'
       );
@@ -252,12 +255,12 @@ describes.fakeWin('ViewerSubscriptionPlatform', {amp: true}, env => {
       expect(proxyStub).to.be.called;
     });
     it('should delegate pingback', () => {
-      const proxyStub = sandbox.stub(viewerPlatform.platform_, 'pingback');
+      const proxyStub = env.sandbox.stub(viewerPlatform.platform_, 'pingback');
       viewerPlatform.pingback();
       expect(proxyStub).to.be.called;
     });
     it('should delegate getSupportedScoreFactor', () => {
-      const proxyStub = sandbox.stub(
+      const proxyStub = env.sandbox.stub(
         viewerPlatform.platform_,
         'getSupportedScoreFactor'
       );

--- a/extensions/amp-subscriptions/0.1/test/test-viewer-tracker.js
+++ b/extensions/amp-subscriptions/0.1/test/test-viewer-tracker.js
@@ -25,13 +25,13 @@ describes.realWin('ViewerTracker', {amp: true}, env => {
   beforeEach(() => {
     ampdoc = env.ampdoc;
     viewTracker = new ViewerTracker(ampdoc);
-    clock = sandbox.useFakeTimers();
+    clock = env.sandbox.useFakeTimers();
   });
 
   describe('scheduleView', () => {
     it('should call `reportWhenViewed_`, if viewer is visible', () => {
-      const whenViewedStub = sandbox.stub(viewTracker, 'reportWhenViewed_');
-      sandbox.stub(ampdoc, 'isVisible').returns(true);
+      const whenViewedStub = env.sandbox.stub(viewTracker, 'reportWhenViewed_');
+      env.sandbox.stub(ampdoc, 'isVisible').returns(true);
       return viewTracker.scheduleView(2000).then(() => {
         expect(whenViewedStub).to.be.calledOnce;
       });
@@ -39,9 +39,12 @@ describes.realWin('ViewerTracker', {amp: true}, env => {
 
     it('should call `reportWhenViewed_`, when viewer gets visible', () => {
       let visibleState = false;
-      const whenViewedStub = sandbox.stub(viewTracker, 'reportWhenViewed_');
-      const visibilityChangedStub = sandbox.stub(ampdoc, 'onVisibilityChanged');
-      const visibilitySandbox = sandbox
+      const whenViewedStub = env.sandbox.stub(viewTracker, 'reportWhenViewed_');
+      const visibilityChangedStub = env.sandbox.stub(
+        ampdoc,
+        'onVisibilityChanged'
+      );
+      const visibilitySandbox = env.sandbox
         .stub(ampdoc, 'isVisible')
         .callsFake(() => visibleState);
 
@@ -64,7 +67,7 @@ describes.realWin('ViewerTracker', {amp: true}, env => {
 
   describe('reportWhenViewed_', () => {
     it('should call whenViewed_', () => {
-      const whenViewedStub = sandbox
+      const whenViewedStub = env.sandbox
         .stub(viewTracker, 'whenViewed_')
         .callsFake(() => Promise.resolve());
       viewTracker.reportWhenViewed_(2000);

--- a/extensions/amp-twitter/0.1/test/test-amp-twitter.js
+++ b/extensions/amp-twitter/0.1/test/test-amp-twitter.js
@@ -128,7 +128,7 @@ describes.realWin(
     it('should replace iframe after tweetid mutation', async () => {
       const newTweetId = '638793490521001985';
       const ampTwitter = await getAmpTwitter(tweetId);
-      const spy = sandbox.spy(ampTwitter.implementation_, 'toggleLoading');
+      const spy = env.sandbox.spy(ampTwitter.implementation_, 'toggleLoading');
       const iframe = ampTwitter.querySelector('iframe');
       ampTwitter.setAttribute('data-tweetid', newTweetId);
       ampTwitter.mutatedAttributesCallback({'data-tweetid': newTweetId});

--- a/extensions/amp-user-location/0.1/test/test-amp-user-location.js
+++ b/extensions/amp-user-location/0.1/test/test-amp-user-location.js
@@ -121,18 +121,18 @@ describes.realWin(
 
     it('should trigger the "approve" event if user approves geolocation', async () => {
       class UserLocationFake {}
-      UserLocationFake.prototype.requestLocation = sandbox.stub().resolves({
+      UserLocationFake.prototype.requestLocation = env.sandbox.stub().resolves({
         lat: 10,
         lon: -10,
       });
-      sandbox
+      env.sandbox
         .stub(Services, 'userLocationForDocOrNull')
         .resolves(new UserLocationFake());
 
       const element = await newUserLocation();
       const impl = await element.getImpl();
 
-      const triggerSpy = sandbox.spy(impl, 'triggerEvent_');
+      const triggerSpy = env.sandbox.spy(impl, 'triggerEvent_');
       await impl.userLocationInteraction_();
 
       expect(triggerSpy).to.have.been.calledWith(AmpUserLocationEvent.APPROVE, {
@@ -143,17 +143,17 @@ describes.realWin(
 
     it('should trigger the "deny" event if user denies geolocation', async () => {
       class UserLocationFake {}
-      UserLocationFake.prototype.requestLocation = sandbox.stub().rejects({
+      UserLocationFake.prototype.requestLocation = env.sandbox.stub().rejects({
         code: PositionError.PERMISSION_DENIED,
       });
-      sandbox
+      env.sandbox
         .stub(Services, 'userLocationForDocOrNull')
         .resolves(new UserLocationFake());
 
       const element = await newUserLocation();
       const impl = await element.getImpl();
 
-      const triggerSpy = sandbox.spy(impl, 'triggerEvent_');
+      const triggerSpy = env.sandbox.spy(impl, 'triggerEvent_');
       await impl.userLocationInteraction_();
 
       expect(triggerSpy).to.have.been.calledWith(AmpUserLocationEvent.DENY);
@@ -164,21 +164,21 @@ describes.realWin(
         ' denies geolocation',
       async () => {
         class UserLocationFake {}
-        UserLocationFake.prototype.requestLocation = sandbox
+        UserLocationFake.prototype.requestLocation = env.sandbox
           .stub()
           .withArgs({fallback: {lat: 20, lon: -20}})
           .rejects({
             code: PositionError.PERMISSION_DENIED,
             fallback: {source: UserLocationSource.FALLBACK, lat: 20, lon: -20},
           });
-        sandbox
+        env.sandbox
           .stub(Services, 'userLocationForDocOrNull')
           .resolves(new UserLocationFake());
 
         const element = await newUserLocation({fallback: '20,-20'});
         const impl = await element.getImpl();
 
-        const triggerSpy = sandbox.spy(impl, 'triggerEvent_');
+        const triggerSpy = env.sandbox.spy(impl, 'triggerEvent_');
         await impl.userLocationInteraction_();
 
         expect(triggerSpy).to.have.been.calledWith(AmpUserLocationEvent.DENY, {
@@ -193,17 +193,17 @@ describes.realWin(
 
     it('should trigger the "error" event if geolocation timeouts', async () => {
       class UserLocationFake {}
-      UserLocationFake.prototype.requestLocation = sandbox.stub().rejects({
+      UserLocationFake.prototype.requestLocation = env.sandbox.stub().rejects({
         code: PositionError.TIMEOUT,
       });
-      sandbox
+      env.sandbox
         .stub(Services, 'userLocationForDocOrNull')
         .resolves(new UserLocationFake());
 
       const element = await newUserLocation();
       const impl = await element.getImpl();
 
-      const triggerSpy = sandbox.spy(impl, 'triggerEvent_');
+      const triggerSpy = env.sandbox.spy(impl, 'triggerEvent_');
       await impl.userLocationInteraction_();
 
       expect(triggerSpy).to.have.been.calledWith(AmpUserLocationEvent.ERROR);
@@ -214,21 +214,21 @@ describes.realWin(
         'geolocation timeouts',
       async () => {
         class UserLocationFake {}
-        UserLocationFake.prototype.requestLocation = sandbox
+        UserLocationFake.prototype.requestLocation = env.sandbox
           .stub()
           .withArgs({fallback: {lat: 20, lon: -20}})
           .rejects({
             code: PositionError.TIMEOUT,
             fallback: {source: UserLocationSource.FALLBACK, lat: 20, lon: -20},
           });
-        sandbox
+        env.sandbox
           .stub(Services, 'userLocationForDocOrNull')
           .resolves(new UserLocationFake());
 
         const element = await newUserLocation();
         const impl = await element.getImpl();
 
-        const triggerSpy = sandbox.spy(impl, 'triggerEvent_');
+        const triggerSpy = env.sandbox.spy(impl, 'triggerEvent_');
         await impl.userLocationInteraction_();
 
         expect(triggerSpy).to.have.been.calledWith(AmpUserLocationEvent.ERROR, {
@@ -243,17 +243,17 @@ describes.realWin(
 
     it('should trigger the "error" event if geolocation is unavailable', async () => {
       class UserLocationFake {}
-      UserLocationFake.prototype.requestLocation = sandbox
+      UserLocationFake.prototype.requestLocation = env.sandbox
         .stub()
         .rejects({code: PositionError.POSITION_UNAVAILABLE});
-      sandbox
+      env.sandbox
         .stub(Services, 'userLocationForDocOrNull')
         .resolves(new UserLocationFake());
 
       const element = await newUserLocation();
       const impl = await element.getImpl();
 
-      const triggerSpy = sandbox.spy(impl, 'triggerEvent_');
+      const triggerSpy = env.sandbox.spy(impl, 'triggerEvent_');
       await impl.userLocationInteraction_();
 
       expect(triggerSpy).to.have.been.calledWith(AmpUserLocationEvent.ERROR);
@@ -264,17 +264,17 @@ describes.realWin(
         'does not support geolocation',
       async () => {
         class UserLocationFake {}
-        UserLocationFake.prototype.requestLocation = sandbox
+        UserLocationFake.prototype.requestLocation = env.sandbox
           .stub()
           .rejects({code: PositionError.PLATFORM_UNSUPPORTED});
-        sandbox
+        env.sandbox
           .stub(Services, 'userLocationForDocOrNull')
           .resolves(new UserLocationFake());
 
         const element = await newUserLocation();
         const impl = await element.getImpl();
 
-        const triggerSpy = sandbox.spy(impl, 'triggerEvent_');
+        const triggerSpy = env.sandbox.spy(impl, 'triggerEvent_');
         await impl.userLocationInteraction_();
 
         expect(triggerSpy).to.have.been.calledWith(AmpUserLocationEvent.ERROR);

--- a/extensions/amp-user-location/0.1/test/test-config-loader.js
+++ b/extensions/amp-user-location/0.1/test/test-config-loader.js
@@ -113,7 +113,7 @@ describes.fakeWin(
           null,
           'https://example.com/location'
         );
-        sandbox.stub(ConfigLoader.prototype, 'fetch_').resolves({});
+        env.sandbox.stub(ConfigLoader.prototype, 'fetch_').resolves({});
 
         const configLoader = new ConfigLoader(fakeAmpdoc, element);
         const config = await configLoader.getConfig();
@@ -133,7 +133,7 @@ describes.fakeWin(
           null,
           'https://example.com/location'
         );
-        sandbox.stub(ConfigLoader.prototype, 'fetch_').resolves(testConfig);
+        env.sandbox.stub(ConfigLoader.prototype, 'fetch_').resolves(testConfig);
 
         const configLoader = new ConfigLoader(fakeAmpdoc, element);
         const config = await configLoader.getConfig();
@@ -156,7 +156,7 @@ describes.fakeWin(
           null,
           'https://example.com/location'
         );
-        sandbox.stub(ConfigLoader.prototype, 'fetch_').resolves(testConfig);
+        env.sandbox.stub(ConfigLoader.prototype, 'fetch_').resolves(testConfig);
 
         const arrayConfigLoader = new ConfigLoader(fakeAmpdoc, element);
         await expect(
@@ -171,7 +171,9 @@ describes.fakeWin(
           {local: true},
           'https://example.com/location'
         );
-        sandbox.stub(ConfigLoader.prototype, 'fetch_').resolves({remote: true});
+        env.sandbox
+          .stub(ConfigLoader.prototype, 'fetch_')
+          .resolves({remote: true});
 
         const configLoader = new ConfigLoader(fakeAmpdoc, element);
         const config = await configLoader.getConfig();
@@ -184,7 +186,7 @@ describes.fakeWin(
           {local: true},
           'https://example.com/location'
         );
-        sandbox.stub(ConfigLoader.prototype, 'fetch_').callsFake(() => {
+        env.sandbox.stub(ConfigLoader.prototype, 'fetch_').callsFake(() => {
           return new Promise(resolve => {
             setTimeout(() => resolve({remote: true}, 16));
           });
@@ -201,7 +203,7 @@ describes.fakeWin(
           {local: true},
           'https://example.com/location'
         );
-        sandbox
+        env.sandbox
           .stub(ConfigLoader.prototype, 'fetch_')
           .callsFake(
             () =>

--- a/extensions/amp-user-location/0.1/test/test-user-location-service.js
+++ b/extensions/amp-user-location/0.1/test/test-user-location-service.js
@@ -20,7 +20,7 @@ import {PositionError} from '../position-error';
 import {Services} from '../../../../src/services';
 import {UserLocationSource} from '../user-location';
 
-describes.sandboxed('user-location-service', {}, () => {
+describes.sandboxed('user-location-service', {}, env => {
   let win;
   let platformService;
   let viewerService;
@@ -47,23 +47,23 @@ describes.sandboxed('user-location-service', {}, () => {
   beforeEach(() => {
     win = {
       navigator: {
-        geolocation: {getCurrentPosition: sandbox.stub()},
+        geolocation: {getCurrentPosition: env.sandbox.stub()},
         permissions: {
-          query: sandbox.stub().resolves(new FakePermissionStatus()),
+          query: env.sandbox.stub().resolves(new FakePermissionStatus()),
         },
       },
     };
 
     FakeAmpdoc.prototype.win = win;
-    FakeViewerService.prototype.isEmbedded = sandbox.stub().returns(false);
-    FakePlatformService.prototype.isChrome = sandbox.stub().returns(false);
-    FakePermissionStatus.prototype.addEventListener = sandbox.stub();
+    FakeViewerService.prototype.isEmbedded = env.sandbox.stub().returns(false);
+    FakePlatformService.prototype.isChrome = env.sandbox.stub().returns(false);
+    FakePermissionStatus.prototype.addEventListener = env.sandbox.stub();
 
     platformService = new FakePlatformService();
     viewerService = new FakeViewerService();
-    sandbox.stub(Services, 'platformFor').returns(platformService);
-    sandbox.stub(Services, 'viewerForDoc').returns(viewerService);
-    getModeStub = sandbox.stub(mode, 'getMode').returns({});
+    env.sandbox.stub(Services, 'platformFor').returns(platformService);
+    env.sandbox.stub(Services, 'viewerForDoc').returns(viewerService);
+    getModeStub = env.sandbox.stub(mode, 'getMode').returns({});
   });
 
   describe('location requests', () => {

--- a/extensions/amp-user-notification/0.1/test/test-amp-user-notification.js
+++ b/extensions/amp-user-notification/0.1/test/test-amp-user-notification.js
@@ -67,10 +67,10 @@ describes.realWin(
         Services.storageForDoc(el),
       ]).then(services => {
         const userNotificationManager = services[0];
-        sandbox.stub(userNotificationManager, 'registerUserNotification');
+        env.sandbox.stub(userNotificationManager, 'registerUserNotification');
 
         const storage = services[1];
-        storageMock = sandbox.mock(storage);
+        storageMock = env.sandbox.mock(storage);
       });
     });
 
@@ -217,7 +217,7 @@ describes.realWin(
       const impl = el.implementation_;
       impl.buildCallback();
 
-      sandbox.stub(impl, 'getAsyncCid_').throws();
+      env.sandbox.stub(impl, 'getAsyncCid_').throws();
       storageMock
         .expects('get')
         .withExactArgs('amp-user-notification:n1')
@@ -241,10 +241,10 @@ describes.realWin(
         .returns(Promise.resolve(true))
         .never();
 
-      const cidStub = sandbox
+      const cidStub = env.sandbox
         .stub(impl, 'getAsyncCid_')
         .returns(Promise.resolve('12345'));
-      const showEndpointStub = sandbox
+      const showEndpointStub = env.sandbox
         .stub(impl, 'getShowEndpoint_')
         .returns(Promise.resolve({showNotification: true}));
 
@@ -289,10 +289,10 @@ describes.realWin(
         .returns(Promise.resolve(false))
         .once();
 
-      const cidStub = sandbox
+      const cidStub = env.sandbox
         .stub(impl, 'getAsyncCid_')
         .returns(Promise.resolve('12345'));
-      const showEndpointStub = sandbox
+      const showEndpointStub = env.sandbox
         .stub(impl, 'getShowEndpoint_')
         .returns(Promise.resolve({showNotification: true}));
 
@@ -315,10 +315,10 @@ describes.realWin(
         .returns(Promise.resolve(false))
         .once();
 
-      const cidStub = sandbox
+      const cidStub = env.sandbox
         .stub(impl, 'getAsyncCid_')
         .returns(Promise.resolve('12345'));
-      const showEndpointStub = sandbox
+      const showEndpointStub = env.sandbox
         .stub(impl, 'getShowEndpoint_')
         .returns(Promise.resolve({showNotification: false}));
 
@@ -335,7 +335,7 @@ describes.realWin(
       const impl = el.implementation_;
       impl.buildCallback();
 
-      sandbox.stub(impl, 'getAsyncCid_').throws();
+      env.sandbox.stub(impl, 'getAsyncCid_').throws();
       storageMock
         .expects('get')
         .withExactArgs('amp-user-notification:n1')
@@ -361,10 +361,10 @@ describes.realWin(
         .returns(Promise.reject('intentional'))
         .once();
 
-      const cidStub = sandbox
+      const cidStub = env.sandbox
         .stub(impl, 'getAsyncCid_')
         .returns(Promise.resolve('12345'));
-      const showEndpointStub = sandbox
+      const showEndpointStub = env.sandbox
         .stub(impl, 'getShowEndpoint_')
         .returns(Promise.resolve({showNotification: true}));
 
@@ -384,7 +384,7 @@ describes.realWin(
       const impl = el.implementation_;
       impl.buildCallback();
 
-      sandbox.stub(impl, 'getAsyncCid_').throws();
+      env.sandbox.stub(impl, 'getAsyncCid_').throws();
       storageMock
         .expects('get')
         .withExactArgs('amp-user-notification:n1')
@@ -406,7 +406,7 @@ describes.realWin(
         .withExactArgs('amp-user-notification:n1', true)
         .returns(Promise.resolve())
         .once();
-      const postDismissStub = sandbox.stub(impl, 'postDismissEnpoint_');
+      const postDismissStub = env.sandbox.stub(impl, 'postDismissEnpoint_');
 
       impl.dismiss();
       expect(postDismissStub).to.be.calledOnce;
@@ -425,7 +425,7 @@ describes.realWin(
         .withExactArgs('amp-user-notification:n1', true)
         .returns(Promise.resolve())
         .once();
-      const postDismissStub = sandbox.stub(impl, 'postDismissEnpoint_');
+      const postDismissStub = env.sandbox.stub(impl, 'postDismissEnpoint_');
 
       impl.dismiss();
       expect(postDismissStub).to.have.not.been.called;
@@ -445,7 +445,7 @@ describes.realWin(
         .withExactArgs('amp-user-notification:n1', true)
         .returns(Promise.resolve())
         .never();
-      const postDismissStub = sandbox.stub(impl, 'postDismissEnpoint_');
+      const postDismissStub = env.sandbox.stub(impl, 'postDismissEnpoint_');
 
       impl.dismiss();
       expect(postDismissStub).to.be.calledOnce;
@@ -587,7 +587,7 @@ describes.realWin(
         .withExactArgs('amp-user-notification:n1', true)
         .returns(Promise.resolve())
         .never();
-      const postDismissStub = sandbox.stub(impl, 'postDismissEnpoint_');
+      const postDismissStub = env.sandbox.stub(impl, 'postDismissEnpoint_');
 
       impl.dismiss();
       expect(postDismissStub).to.be.calledOnce;
@@ -597,10 +597,10 @@ describes.realWin(
     });
 
     it('should have class `amp-active`', () => {
-      sandbox
+      env.sandbox
         .stub(AmpUserNotification.prototype, 'getAsyncCid_')
         .returns(Promise.resolve('12345'));
-      sandbox
+      env.sandbox
         .stub(AmpUserNotification.prototype, 'getShowEndpoint_')
         .returns(Promise.resolve({showNotification: true}));
 
@@ -608,7 +608,7 @@ describes.realWin(
       const impl = el.implementation_;
       impl.buildCallback();
       impl.dialogPromise_ = Promise.resolve();
-      const addToFixedLayerStub = sandbox.stub(
+      const addToFixedLayerStub = env.sandbox.stub(
         impl.getViewport(),
         'addToFixedLayer'
       );
@@ -626,10 +626,10 @@ describes.realWin(
     });
 
     it('should not have `amp-active`', () => {
-      sandbox
+      env.sandbox
         .stub(AmpUserNotification.prototype, 'getAsyncCid_')
         .returns(Promise.resolve('12345'));
-      sandbox
+      env.sandbox
         .stub(AmpUserNotification.prototype, 'getShowEndpoint_')
         .returns(Promise.resolve({showNotification: false}));
 
@@ -651,13 +651,13 @@ describes.realWin(
     });
 
     it('should have `amp-hidden` and no `amp-active`', () => {
-      sandbox
+      env.sandbox
         .stub(AmpUserNotification.prototype, 'getAsyncCid_')
         .returns(Promise.resolve('12345'));
-      sandbox
+      env.sandbox
         .stub(AmpUserNotification.prototype, 'getShowEndpoint_')
         .returns(Promise.resolve({showNotification: true}));
-      const stub2 = sandbox
+      const stub2 = env.sandbox
         .stub(AmpUserNotification.prototype, 'postDismissEnpoint_')
         .returns(Promise.resolve());
 
@@ -666,7 +666,7 @@ describes.realWin(
       impl.buildCallback();
       impl.dialogPromise_ = Promise.resolve();
       impl.dialogResolve_ = function() {};
-      const removeFromFixedLayerStub = sandbox.stub(
+      const removeFromFixedLayerStub = env.sandbox.stub(
         impl.getViewport(),
         'removeFromFixedLayer'
       );
@@ -798,13 +798,13 @@ describes.realWin(
           resolve2 = resolve;
         });
 
-        const show1 = sandbox.stub(tag, 'show').callsFake(() => {
+        const show1 = env.sandbox.stub(tag, 'show').callsFake(() => {
           return s1;
         });
-        const show2 = sandbox.stub(tag1, 'show').callsFake(() => {
+        const show2 = env.sandbox.stub(tag1, 'show').callsFake(() => {
           return s2;
         });
-        const show3 = sandbox.spy(tag2, 'show');
+        const show3 = env.sandbox.spy(tag2, 'show');
 
         service.registerUserNotification('n1', tag);
         service.registerUserNotification('n2', tag1);
@@ -843,7 +843,7 @@ describes.realWin(
       let optOutOfCidStub;
 
       beforeEach(() => {
-        optOutOfCidStub = sandbox.spy(cidMock, 'optOut');
+        optOutOfCidStub = env.sandbox.spy(cidMock, 'optOut');
       });
 
       it('should call cid.optOut() and dismiss', () => {
@@ -854,7 +854,7 @@ describes.realWin(
         impl.getCidService_ = () => {
           return Promise.resolve(cidMock);
         };
-        dismissSpy = sandbox.spy(impl, 'dismiss');
+        dismissSpy = env.sandbox.spy(impl, 'dismiss');
 
         return impl.optoutOfCid_().then(() => {
           expect(dismissSpy).to.be.calledWithExactly(false);
@@ -874,7 +874,7 @@ describes.realWin(
         impl.getCidService_ = () => {
           return Promise.resolve(cidMock);
         };
-        dismissSpy = sandbox.spy(impl, 'dismiss');
+        dismissSpy = env.sandbox.spy(impl, 'dismiss');
 
         return impl.optoutOfCid_().then(() => {
           expect(dismissSpy).to.be.calledWithExactly(true);

--- a/extensions/amp-video-docking/0.1/test/test-amp-video-docking.js
+++ b/extensions/amp-video-docking/0.1/test/test-amp-video-docking.js
@@ -47,12 +47,10 @@ describes.realWin('↗ 🔲', {amp: true}, env => {
   let viewport;
   let docking;
   let querySelectorStub;
-
+  let any;
   let slotAttr = '';
 
   const viewportSize = {width: 0, height: 0};
-
-  const {any} = sinon.match;
 
   function createAmpElementMock(tag = 'div') {
     const element = env.win.document.createElement(tag);
@@ -86,9 +84,9 @@ describes.realWin('↗ 🔲', {amp: true}, env => {
 
     video.element.signals = video.signals;
 
-    video.pause = sandbox.spy();
-    video.showControls = sandbox.spy();
-    video.hideControls = sandbox.spy();
+    video.pause = env.sandbox.spy();
+    video.showControls = env.sandbox.spy();
+    video.hideControls = env.sandbox.spy();
 
     return video;
   }
@@ -113,7 +111,7 @@ describes.realWin('↗ 🔲', {amp: true}, env => {
 
   function mockAreaWidth(width) {
     viewportSize.width = width;
-    sandbox.stub(docking, 'getRightEdge_').returns(width);
+    env.sandbox.stub(docking, 'getRightEdge_').returns(width);
     return width;
   }
 
@@ -123,7 +121,7 @@ describes.realWin('↗ 🔲', {amp: true}, env => {
 
   function mockAreaHeight(height) {
     viewportSize.height = height;
-    sandbox.stub(docking, 'getBottomEdge_').returns(height);
+    env.sandbox.stub(docking, 'getBottomEdge_').returns(height);
     return height;
   }
 
@@ -136,7 +134,7 @@ describes.realWin('↗ 🔲', {amp: true}, env => {
   }
 
   function stubDockInTransferLayerStep() {
-    return sandbox.stub(docking, 'dockInTransferLayerStep_');
+    return env.sandbox.stub(docking, 'dockInTransferLayerStep_');
   }
 
   function enableComputedStyle(el) {
@@ -146,17 +144,17 @@ describes.realWin('↗ 🔲', {amp: true}, env => {
   function stubControls() {
     const html = htmlFor(env.win.document);
     const controls = {
-      positionOnVsync: sandbox.spy(),
-      enable: sandbox.spy(),
-      disable: sandbox.spy(),
-      hide: sandbox.spy(),
-      setVideo: sandbox.spy(),
+      positionOnVsync: env.sandbox.spy(),
+      enable: env.sandbox.spy(),
+      disable: env.sandbox.spy(),
+      hide: env.sandbox.spy(),
+      setVideo: env.sandbox.spy(),
       overlay: html`
         <div></div>
       `,
     };
 
-    sandbox.stub(docking, 'getControls_').returns(controls);
+    env.sandbox.stub(docking, 'getControls_').returns(controls);
 
     return controls;
   }
@@ -169,8 +167,8 @@ describes.realWin('↗ 🔲', {amp: true}, env => {
 
   beforeEach(() => {
     ampdoc = env.ampdoc;
-
-    querySelectorStub = sandbox.stub(ampdoc.getRootNode(), 'querySelector');
+    any = env.sandbox.match.any;
+    querySelectorStub = env.sandbox.stub(ampdoc.getRootNode(), 'querySelector');
 
     manager = {
       getPlayingState() {
@@ -186,14 +184,14 @@ describes.realWin('↗ 🔲', {amp: true}, env => {
       getSize: () => viewportSize,
     };
 
-    sandbox.stub(Services, 'viewportForDoc').returns(viewport);
-    sandbox.stub(Services, 'videoManagerForDoc').returns(manager);
+    env.sandbox.stub(Services, 'viewportForDoc').returns(viewport);
+    env.sandbox.stub(Services, 'videoManagerForDoc').returns(manager);
 
     const positionObserverMock = {};
 
     docking = new VideoDocking(ampdoc, positionObserverMock);
 
-    sandbox.stub(docking, 'getTimer_').returns({
+    env.sandbox.stub(docking, 'getTimer_').returns({
       promise: () => Promise.resolve(),
     });
   });
@@ -227,7 +225,7 @@ describes.realWin('↗ 🔲', {amp: true}, env => {
 
       video.element.appendChild(internalElement);
 
-      sandbox.stub(env.win, 'requestAnimationFrame').callsArg(0);
+      env.sandbox.stub(env.win, 'requestAnimationFrame').callsArg(0);
 
       getComputedStyle = el => env.win.getComputedStyle(el);
 
@@ -327,7 +325,7 @@ describes.realWin('↗ 🔲', {amp: true}, env => {
       stubControls();
       enableComputedStyle(video.element);
 
-      sandbox.stub(docking, 'getPosterImageSrc_').returns(posterSrc);
+      env.sandbox.stub(docking, 'getPosterImageSrc_').returns(posterSrc);
 
       const x = 30;
       const y = 60;
@@ -624,7 +622,9 @@ describes.realWin('↗ 🔲', {amp: true}, env => {
       const video = {};
       const target = {};
 
-      const dock = sandbox.stub(docking, 'dock_').returns(Promise.resolve());
+      const dock = env.sandbox
+        .stub(docking, 'dock_')
+        .returns(Promise.resolve());
 
       yield docking.dockInTransferLayerStep_(video, target);
 
@@ -634,11 +634,11 @@ describes.realWin('↗ 🔲', {amp: true}, env => {
 
   describe('getTargetArea_', () => {
     it('delegates for slot', () => {
-      const fromPos = sandbox
+      const fromPos = env.sandbox
         .stub(docking, 'getTargetAreaFromPos_')
         .returns('foo');
 
-      const fromSlot = sandbox
+      const fromSlot = env.sandbox
         .stub(docking, 'getTargetAreaFromSlot_')
         .returns('bar');
 
@@ -652,11 +652,11 @@ describes.realWin('↗ 🔲', {amp: true}, env => {
     });
 
     it('delegates for corner', () => {
-      const fromPos = sandbox
+      const fromPos = env.sandbox
         .stub(docking, 'getTargetAreaFromPos_')
         .returns('foo');
 
-      const fromSlot = sandbox
+      const fromSlot = env.sandbox
         .stub(docking, 'getTargetAreaFromSlot_')
         .returns('bar');
 
@@ -787,7 +787,7 @@ describes.realWin('↗ 🔲', {amp: true}, env => {
       const expectedX = slotX;
       const expectedY = slotY - scrollTop;
 
-      sandbox.stub(docking.viewport_, 'getScrollTop').returns(scrollTop);
+      env.sandbox.stub(docking.viewport_, 'getScrollTop').returns(scrollTop);
 
       const {x, y, width, height} = docking.getTargetAreaFromSlot_(
         video,
@@ -830,7 +830,7 @@ describes.realWin('↗ 🔲', {amp: true}, env => {
 
       const expectedY = slotY - scrollTop;
 
-      sandbox.stub(docking.viewport_, 'getScrollTop').returns(scrollTop);
+      env.sandbox.stub(docking.viewport_, 'getScrollTop').returns(scrollTop);
 
       const {x, y, width, height} = docking.getTargetAreaFromSlot_(
         video,
@@ -874,7 +874,7 @@ describes.realWin('↗ 🔲', {amp: true}, env => {
 
       const expectedX = slotX;
 
-      sandbox.stub(docking.viewport_, 'getScrollTop').returns(scrollTop);
+      env.sandbox.stub(docking.viewport_, 'getScrollTop').returns(scrollTop);
 
       const {x, y, width, height} = docking.getTargetAreaFromSlot_(
         video,
@@ -912,13 +912,13 @@ describes.realWin('↗ 🔲', {amp: true}, env => {
       video = createVideo();
       placeElementLtwh(video, videoX, videoY, videoWidth, videoHeight);
 
-      targetAreaStub = sandbox.stub(docking, 'getTargetArea_');
+      targetAreaStub = env.sandbox.stub(docking, 'getTargetArea_');
 
       targetAreaStub.returns(
         layoutRectLtwh(targetX, targetY, targetWidth, targetHeight)
       );
 
-      sandbox.stub(docking.viewport_, 'getScrollTop').returns(scrollTop);
+      env.sandbox.stub(docking.viewport_, 'getScrollTop').returns(scrollTop);
     });
 
     it('returns starting position for step = 0', () => {
@@ -983,10 +983,12 @@ describes.realWin('↗ 🔲', {amp: true}, env => {
 
       placeElementLtwh(video, 0, 0, 400, 300, /* ratio */ 1);
 
-      setCurrentlyDocked = sandbox.stub(docking, 'setCurrentlyDocked_');
-      placeAt = sandbox.stub(docking, 'placeAt_').returns(Promise.resolve());
+      setCurrentlyDocked = env.sandbox.stub(docking, 'setCurrentlyDocked_');
+      placeAt = env.sandbox
+        .stub(docking, 'placeAt_')
+        .returns(Promise.resolve());
 
-      sandbox.stub(docking, 'getDims_').returns(targetDims);
+      env.sandbox.stub(docking, 'getDims_').returns(targetDims);
     });
 
     it('sets currently docked', function*() {
@@ -1052,9 +1054,9 @@ describes.realWin('↗ 🔲', {amp: true}, env => {
     let trigger;
 
     beforeEach(() => {
-      trigger = sandbox.stub(docking, 'trigger_');
+      trigger = env.sandbox.stub(docking, 'trigger_');
 
-      sandbox
+      env.sandbox
         .stub(docking, 'getTargetArea_')
         .withArgs(video, target)
         .returns(targetArea);
@@ -1123,17 +1125,19 @@ describes.realWin('↗ 🔲', {amp: true}, env => {
 
       placeElementLtwh(video, 0, 0, 400, 300, /* ratio */ 1);
 
-      trigger = sandbox.stub(docking, 'trigger_');
-      resetOnUndock = sandbox.stub(docking, 'resetOnUndock_');
-      maybeUpdateStaleYAfterScroll = sandbox
+      trigger = env.sandbox.stub(docking, 'trigger_');
+      resetOnUndock = env.sandbox.stub(docking, 'resetOnUndock_');
+      maybeUpdateStaleYAfterScroll = env.sandbox
         .stub(docking, 'maybeUpdateStaleYAfterScroll_')
         .returns(Promise.resolve());
 
-      placeAt = sandbox.stub(docking, 'placeAt_').returns(Promise.resolve());
+      placeAt = env.sandbox
+        .stub(docking, 'placeAt_')
+        .returns(Promise.resolve());
 
       docking.currentlyDocked_ = {target: 'foo'};
 
-      sandbox
+      env.sandbox
         .stub(docking, 'getDims_')
         .withArgs(video, docking.currentlyDocked_.target, /* step */ 0)
         .returns(targetDims);
@@ -1285,7 +1289,7 @@ describes.realWin('↗ 🔲', {amp: true}, env => {
       it(`animates transition when >= ${inlinePercVis}`, function*() {
         const expectedTransitionDurationMs = 555;
 
-        sandbox
+        env.sandbox
           .stub(docking, 'calculateTransitionDuration_')
           .returns(expectedTransitionDurationMs);
 
@@ -1481,7 +1485,7 @@ describes.realWin('↗ 🔲', {amp: true}, env => {
             /* ratio */ 1 / 3
           );
 
-          sandbox.stub(docking, 'getTopEdge_').returns(topBoundary);
+          env.sandbox.stub(docking, 'getTopEdge_').returns(topBoundary);
 
           docking.updateOnPositionChange_(video);
 
@@ -1512,8 +1516,8 @@ describes.realWin('↗ 🔲', {amp: true}, env => {
         const targetElementTextual = useSlot ? 'video' : 'slot';
 
         it(`triggers action from ${targetElementTextual} element`, () => {
-          const actions = {trigger: sandbox.spy()};
-          sandbox.stub(Services, 'actionServiceForDoc').returns(actions);
+          const actions = {trigger: env.sandbox.spy()};
+          env.sandbox.stub(Services, 'actionServiceForDoc').returns(actions);
 
           const slot = maybeCreateSlotElementLtwh(0, 0, 0, 0);
           const video = createVideo();

--- a/extensions/amp-video-iframe/0.1/test/test-amp-video-iframe.js
+++ b/extensions/amp-video-iframe/0.1/test/test-amp-video-iframe.js
@@ -37,16 +37,17 @@ describes.realWin(
     },
   },
   env => {
-    const {any} = sinon.match;
     const defaultFixture = 'video-iframe.html';
 
     let win;
     let doc;
     let videoManagerStub;
+    let any;
 
     beforeEach(() => {
       win = env.win;
       doc = win.document;
+      any = env.sandbox.match.any;
 
       videoManagerStub = {
         register: env.sandbox.spy(),
@@ -268,8 +269,8 @@ describes.realWin(
 
         videoIframe.implementation_.onMessage_(message);
 
-        expect(postMessage.withArgs(sinon.match(expectedResponseMessage))).to
-          .have.been.calledOnce;
+        expect(postMessage.withArgs(env.sandbox.match(expectedResponseMessage)))
+          .to.have.been.calledOnce;
       });
 
       it('should return 0 if not in autoplay range', async () => {
@@ -300,8 +301,8 @@ describes.realWin(
 
         videoIframe.implementation_.onMessage_(message);
 
-        expect(postMessage.withArgs(sinon.match(expectedResponseMessage))).to
-          .have.been.calledOnce;
+        expect(postMessage.withArgs(env.sandbox.match(expectedResponseMessage)))
+          .to.have.been.calledOnce;
       });
 
       [
@@ -414,7 +415,7 @@ describes.realWin(
 
           expect(
             postMessage.withArgs(
-              sinon.match({
+              env.sandbox.match({
                 event: 'method',
                 method: lowercaseMethod,
               })

--- a/extensions/amp-video/0.1/test/test-amp-video.js
+++ b/extensions/amp-video/0.1/test/test-amp-video.js
@@ -78,7 +78,7 @@ describes.realWin(
         width: 160,
         height: 90,
       });
-      const preloadSpy = sandbox.spy(v.implementation_.preconnect, 'url');
+      const preloadSpy = env.sandbox.spy(v.implementation_.preconnect, 'url');
       v.implementation_.preconnectCallback();
       preloadSpy.should.have.been.calledWithExactly('video.mp4', undefined);
       const video = v.querySelector('video');
@@ -98,7 +98,7 @@ describes.realWin(
         'crossorigin': '',
         'disableremoteplayback': '',
       });
-      const preloadSpy = sandbox.spy(v.implementation_.preconnect, 'url');
+      const preloadSpy = env.sandbox.spy(v.implementation_.preconnect, 'url');
       v.implementation_.preconnectCallback();
       preloadSpy.should.have.been.calledWithExactly('video.mp4', undefined);
       const video = v.querySelector('video');
@@ -135,7 +135,7 @@ describes.realWin(
         },
         sources
       );
-      const preloadSpy = sandbox.spy(v.implementation_.preconnect, 'url');
+      const preloadSpy = env.sandbox.spy(v.implementation_.preconnect, 'url');
       v.implementation_.preconnectCallback();
       preloadSpy.should.have.been.calledWithExactly('video.mp4', undefined);
       const video = v.querySelector('video');
@@ -175,7 +175,7 @@ describes.realWin(
         },
         tracks
       );
-      const preloadSpy = sandbox.spy(v.implementation_.preconnect, 'url');
+      const preloadSpy = env.sandbox.spy(v.implementation_.preconnect, 'url');
       v.implementation_.preconnectCallback();
       preloadSpy.should.have.been.calledWithExactly('video.mp4', undefined);
       const video = v.querySelector('video');
@@ -210,7 +210,7 @@ describes.realWin(
           const v = doc.querySelector('amp-video');
           // preconnectCallback could get called again after this test is done, and
           // trigger an other "start with https://" error that would crash mocha.
-          sandbox.stub(v.implementation_, 'preconnectCallback');
+          env.sandbox.stub(v.implementation_, 'preconnectCallback');
           throw e;
         })
       ).to.be.rejectedWith(/start with/);
@@ -391,7 +391,7 @@ describes.realWin(
       });
       const impl = v.implementation_;
       const video = v.querySelector('video');
-      sandbox.spy(video, 'pause');
+      env.sandbox.spy(video, 'pause');
       impl.pauseCallback();
       expect(video.pause.called).to.be.true;
     });
@@ -406,8 +406,8 @@ describes.realWin(
         null,
         function(element) {
           const impl = element.implementation_;
-          sandbox.stub(impl, 'isVideoSupported_').returns(false);
-          sandbox.spy(impl, 'toggleFallback');
+          env.sandbox.stub(impl, 'isVideoSupported_').returns(false);
+          env.sandbox.spy(impl, 'toggleFallback');
         }
       );
       const impl = v.implementation_;
@@ -417,7 +417,7 @@ describes.realWin(
 
     it('play() should not log promise rejections', async () => {
       const playPromise = Promise.reject('The play() request was interrupted');
-      const catchSpy = sandbox.spy(playPromise, 'catch');
+      const catchSpy = env.sandbox.spy(playPromise, 'catch');
       await getVideo(
         {
           src: 'video.mp4',
@@ -427,7 +427,7 @@ describes.realWin(
         null,
         function(element) {
           const impl = element.implementation_;
-          sandbox.stub(impl.video_, 'play').returns(playPromise);
+          env.sandbox.stub(impl.video_, 'play').returns(playPromise);
           impl.play();
         }
       );
@@ -576,7 +576,7 @@ describes.realWin(
           img.setAttribute('placeholder', '');
           v.getPlaceholder = () => img;
         } else {
-          v.getPlaceholder = sandbox.stub();
+          v.getPlaceholder = env.sandbox.stub();
         }
         if (addBlurClass) {
           img.classList.add('i-amphtml-blurry-placeholder');
@@ -586,7 +586,7 @@ describes.realWin(
         v.appendChild(img);
         v.build();
         const impl = v.implementation_;
-        impl.togglePlaceholder = sandbox.stub();
+        impl.togglePlaceholder = env.sandbox.stub();
         return impl;
       }
 
@@ -658,8 +658,11 @@ describes.realWin(
 
       beforeEach(() => {
         visibilityStubs = {
-          getVisibilityState: sandbox.stub(env.ampdoc, 'getVisibilityState'),
-          whenFirstVisible: sandbox.stub(env.ampdoc, 'whenFirstVisible'),
+          getVisibilityState: env.sandbox.stub(
+            env.ampdoc,
+            'getVisibilityState'
+          ),
+          whenFirstVisible: env.sandbox.stub(env.ampdoc, 'whenFirstVisible'),
         };
         visibilityStubs.getVisibilityState.returns(VisibilityState.PRERENDER);
         visiblePromise = new Promise(resolve => {
@@ -828,7 +831,7 @@ describes.realWin(
         });
 
         it('no cached source', async () => {
-          const preloadStub = sandbox.stub(fakePreconnect, 'url');
+          const preloadStub = window.sandbox.stub(fakePreconnect, 'url');
 
           await getVideo({
             src: 'https://example.com/video.mp4',
@@ -841,7 +844,7 @@ describes.realWin(
         });
 
         it('cached source', async () => {
-          const preloadStub = sandbox.stub(fakePreconnect, 'url');
+          const preloadStub = window.sandbox.stub(fakePreconnect, 'url');
 
           const cachedSource = doc.createElement('source');
           cachedSource.setAttribute(
@@ -869,7 +872,7 @@ describes.realWin(
         });
 
         it('mixed sources', async () => {
-          const preloadStub = sandbox.stub(fakePreconnect, 'url');
+          const preloadStub = window.sandbox.stub(fakePreconnect, 'url');
 
           const source = doc.createElement('source');
           source.setAttribute('src', 'video.mp4');

--- a/extensions/amp-viewer-integration/0.1/test/integration/test-amp-viewer-integration.js
+++ b/extensions/amp-viewer-integration/0.1/test/integration/test-amp-viewer-integration.js
@@ -23,7 +23,7 @@ import {
 import {ViewerForTesting} from '../../viewer-for-testing';
 import {getSourceUrl} from '../../../../../src/url';
 
-describes.sandboxed('AmpViewerIntegration', {}, () => {
+describes.sandboxed('AmpViewerIntegration', {}, env => {
   const ampDocSrc = '/test/fixtures/served/ampdoc-with-messaging.html';
   // TODO(aghassemi): Investigate failure in beforeEach. #10974.
   describe.skip('Handshake', function() {
@@ -55,7 +55,7 @@ describes.sandboxed('AmpViewerIntegration', {}, () => {
     it('should handle unload correctly', () => {
       viewer.confirmHandshake();
       viewer.waitForDocumentLoaded().then(() => {
-        const stub = sandbox.stub(viewer, 'handleUnload_');
+        const stub = env.sandbox.stub(viewer, 'handleUnload_');
         window.eventListeners.fire({type: 'unload'});
         expect(stub).to.be.calledOnce;
       });
@@ -95,7 +95,7 @@ describes.sandboxed('AmpViewerIntegration', {}, () => {
           });
 
           it('should start with the correct message', () => {
-            const sendRequestSpy = sandbox
+            const sendRequestSpy = env.sandbox
               .stub(messaging, 'sendRequest')
               .callsFake(() => {
                 return Promise.resolve();
@@ -119,10 +119,10 @@ describes.sandboxed('AmpViewerIntegration', {}, () => {
           });
 
           it('should not initiate touch handler without capability', () => {
-            sandbox.stub(messaging, 'sendRequest').callsFake(() => {
+            env.sandbox.stub(messaging, 'sendRequest').callsFake(() => {
               return Promise.resolve();
             });
-            const initTouchHandlerStub = sandbox.stub(
+            const initTouchHandlerStub = env.sandbox.stub(
               ampViewerIntegration,
               'initTouchHandler_'
             );
@@ -137,14 +137,14 @@ describes.sandboxed('AmpViewerIntegration', {}, () => {
           });
 
           it('should initiate touch handler with capability', () => {
-            sandbox.stub(messaging, 'sendRequest').callsFake(() => {
+            env.sandbox.stub(messaging, 'sendRequest').callsFake(() => {
               return Promise.resolve();
             });
-            sandbox
+            env.sandbox
               .stub(viewer, 'hasCapability')
               .withArgs('swipe')
               .returns(true);
-            const initTouchHandlerStub = sandbox.stub(
+            const initTouchHandlerStub = env.sandbox.stub(
               ampViewerIntegration,
               'initTouchHandler_'
             );
@@ -157,10 +157,10 @@ describes.sandboxed('AmpViewerIntegration', {}, () => {
           });
 
           it('should not initiate keyboard handler without capability', () => {
-            sandbox.stub(messaging, 'sendRequest').callsFake(() => {
+            env.sandbox.stub(messaging, 'sendRequest').callsFake(() => {
               return Promise.resolve();
             });
-            const initKeyboardHandlerStub = sandbox.stub(
+            const initKeyboardHandlerStub = env.sandbox.stub(
               ampViewerIntegration,
               'initKeyboardHandler_'
             );
@@ -175,14 +175,14 @@ describes.sandboxed('AmpViewerIntegration', {}, () => {
           });
 
           it('should initiate keyboard handler with capability', () => {
-            sandbox.stub(messaging, 'sendRequest').callsFake(() => {
+            env.sandbox.stub(messaging, 'sendRequest').callsFake(() => {
               return Promise.resolve();
             });
-            sandbox
+            env.sandbox
               .stub(viewer, 'hasCapability')
               .withArgs('keyboard')
               .returns(true);
-            const initKeyboardHandlerStub = sandbox.stub(
+            const initKeyboardHandlerStub = env.sandbox.stub(
               ampViewerIntegration,
               'initKeyboardHandler_'
             );
@@ -195,14 +195,14 @@ describes.sandboxed('AmpViewerIntegration', {}, () => {
           });
 
           it('should initiate focus handler with capability', () => {
-            sandbox.stub(messaging, 'sendRequest').callsFake(() => {
+            env.sandbox.stub(messaging, 'sendRequest').callsFake(() => {
               return Promise.resolve();
             });
-            sandbox
+            env.sandbox
               .stub(viewer, 'hasCapability')
               .withArgs('focus-rect')
               .returns(true);
-            const initFocusHandlerStub = sandbox.stub(
+            const initFocusHandlerStub = env.sandbox.stub(
               ampViewerIntegration,
               'initFocusHandler_'
             );
@@ -241,7 +241,7 @@ describes.sandboxed('AmpViewerIntegration', {}, () => {
         port.addEventListener = function() {};
         port.postMessage = function() {};
 
-        postMessageSpy = sandbox.stub(port, 'postMessage').callsFake(() => {
+        postMessageSpy = env.sandbox.stub(port, 'postMessage').callsFake(() => {
           postMessageResolve();
         });
 
@@ -302,8 +302,8 @@ describes.sandboxed('AmpViewerIntegration', {}, () => {
           },
         };
 
-        const resolveSpy = sandbox.stub();
-        const rejectSpy = sandbox.stub();
+        const resolveSpy = env.sandbox.stub();
+        const rejectSpy = env.sandbox.stub();
         const waitingForResponse = {
           '1': {
             resolve: resolveSpy,
@@ -311,7 +311,7 @@ describes.sandboxed('AmpViewerIntegration', {}, () => {
           },
         };
 
-        sandbox
+        env.sandbox
           .stub(messaging, 'waitingForResponse_')
           .callsFake(waitingForResponse);
         messaging.handleMessage_(event);
@@ -337,8 +337,8 @@ describes.sandboxed('AmpViewerIntegration', {}, () => {
           },
         };
 
-        const resolveSpy = sandbox.stub();
-        const rejectSpy = sandbox.stub();
+        const resolveSpy = env.sandbox.stub();
+        const rejectSpy = env.sandbox.stub();
         const waitingForResponse = {
           '1': {
             resolve: resolveSpy,
@@ -346,7 +346,7 @@ describes.sandboxed('AmpViewerIntegration', {}, () => {
           },
         };
 
-        sandbox
+        env.sandbox
           .stub(messaging, 'waitingForResponse_')
           .callsFake(waitingForResponse);
         messaging.handleMessage_(event);
@@ -370,8 +370,8 @@ describes.sandboxed('AmpViewerIntegration', {}, () => {
           },
         };
 
-        const resolveSpy = sandbox.stub();
-        const rejectSpy = sandbox.stub();
+        const resolveSpy = env.sandbox.stub();
+        const rejectSpy = env.sandbox.stub();
         const waitingForResponse = {
           '1': {
             resolve: resolveSpy,
@@ -379,8 +379,8 @@ describes.sandboxed('AmpViewerIntegration', {}, () => {
           },
         };
 
-        const logErrorSpy = sandbox.stub(messaging, 'logError_');
-        sandbox
+        const logErrorSpy = env.sandbox.stub(messaging, 'logError_');
+        env.sandbox
           .stub(messaging, 'waitingForResponse_')
           .callsFake(waitingForResponse);
         messaging.handleMessage_(event);
@@ -439,7 +439,7 @@ describes.sandboxed('AmpViewerIntegration', {}, () => {
         const err = new Error('reason');
         const errString = messaging.errorToString_(err);
         const requestId = 1;
-        const logErrorSpy = sandbox.stub(messaging, 'logError_');
+        const logErrorSpy = env.sandbox.stub(messaging, 'logError_');
         messaging.sendResponseError_(requestId, mName, err);
 
         return postMessagePromise.then(function() {

--- a/extensions/amp-viewer-integration/0.1/test/integration/test-amp-webview-viewer-integration.js
+++ b/extensions/amp-viewer-integration/0.1/test/integration/test-amp-webview-viewer-integration.js
@@ -17,7 +17,7 @@
 import {AmpViewerIntegration} from '../../amp-viewer-integration';
 import {WebviewViewerForTesting} from '../../webview-viewer-for-testing.js';
 
-describes.sandboxed('AmpWebviewViewerIntegration', {}, () => {
+describes.sandboxed('AmpWebviewViewerIntegration', {}, env => {
   const ampDocSrc = '/test/fixtures/served/ampdoc-with-messaging.html';
   // TODO(aghassemi): Investigate failure in beforeEach. #10974.
   describe.skip('Handshake', function() {
@@ -46,7 +46,7 @@ describes.sandboxed('AmpWebviewViewerIntegration', {}, () => {
 
     it('should handle unload correctly', () => {
       return viewer.waitForDocumentLoaded().then(() => {
-        const stub = sandbox.stub(viewer, 'handleUnload_');
+        const stub = env.sandbox.stub(viewer, 'handleUnload_');
         window.eventListeners.fire({type: 'unload'});
         expect(stub).to.be.calledOnce;
       });
@@ -72,7 +72,7 @@ describes.sandboxed('AmpWebviewViewerIntegration', {}, () => {
       });
 
       it('should set source and origin for webview', () => {
-        const stub = sandbox
+        const stub = env.sandbox
           .stub(integr, 'webviewPreHandshakePromise_')
           .callsFake(() => new Promise(() => {}));
         integr.init();

--- a/extensions/amp-viewer-integration/0.1/test/integration/test-messaging-handshake.js
+++ b/extensions/amp-viewer-integration/0.1/test/integration/test-messaging-handshake.js
@@ -101,7 +101,7 @@ describes.sandboxed('AmpViewerMessagingIntegration', {}, () => {
           iframeOrigin,
           'bar'
         ).then(messaging => {
-          const handlerStub = sandbox.stub();
+          const handlerStub = window.sandbox.stub();
           messaging.setDefaultHandler(handlerStub);
           expect(handlerStub).to.not.have.been.called;
         });

--- a/extensions/amp-viewer-integration/0.1/test/integration/test-viewer-initiated-handshake.js
+++ b/extensions/amp-viewer-integration/0.1/test/integration/test-viewer-initiated-handshake.js
@@ -16,7 +16,7 @@
 
 import {WebviewViewerForTesting} from '../../viewer-initiated-handshake-viewer-for-testing';
 
-describes.sandboxed('AmpWebviewViewerIntegration', {}, () => {
+describes.sandboxed('AmpWebviewViewerIntegration', {}, env => {
   const ampDocSrc = '/test/fixtures/served/ampdoc-with-messaging.html';
   // TODO(aghassemi): Investigate failure in beforeEach. #10974.
   describe.skip('Handshake', function() {
@@ -42,7 +42,7 @@ describes.sandboxed('AmpWebviewViewerIntegration', {}, () => {
 
     it('should handle unload correctly', () => {
       viewer.waitForHandshakeResponse().then(() => {
-        const stub = sandbox.stub(viewer, 'handleUnload_');
+        const stub = env.sandbox.stub(viewer, 'handleUnload_');
         window.eventListeners.fire({type: 'unload'});
         expect(stub).to.be.calledOnce;
       });

--- a/extensions/amp-viewer-integration/0.1/test/test-highlight-handler.js
+++ b/extensions/amp-viewer-integration/0.1/test/test-highlight-handler.js
@@ -135,7 +135,7 @@ describes.realWin(
       div1.textContent = 'highlighted text';
       root.appendChild(div1);
 
-      sandbox.stub(docready, 'whenDocumentReady').returns({
+      env.sandbox.stub(docready, 'whenDocumentReady').returns({
         then: cb => {
           docreadyCb = cb;
         },
@@ -144,16 +144,16 @@ describes.realWin(
 
     it('initialize with visibility=visible', () => {
       const {ampdoc} = env;
-      const scrollStub = sandbox.stub(
+      const scrollStub = env.sandbox.stub(
         Services.viewportForDoc(ampdoc),
         'animateScrollIntoView'
       );
       scrollStub.returns(Promise.reject());
-      const sendMsgStub = sandbox.stub(
+      const sendMsgStub = env.sandbox.stub(
         Services.viewerForDoc(ampdoc),
         'sendMessage'
       );
-      const setScrollTop = sandbox.stub(
+      const setScrollTop = env.sandbox.stub(
         Services.viewportForDoc(ampdoc),
         'setScrollTop'
       );
@@ -212,12 +212,12 @@ describes.realWin(
 
     it('initialize with skipRendering', () => {
       const {ampdoc} = env;
-      const scrollStub = sandbox.stub(
+      const scrollStub = env.sandbox.stub(
         Services.viewportForDoc(ampdoc),
         'animateScrollIntoView'
       );
       scrollStub.returns(Promise.reject());
-      const sendMsgStub = sandbox.stub(
+      const sendMsgStub = env.sandbox.stub(
         Services.viewerForDoc(ampdoc),
         'sendMessage'
       );
@@ -246,16 +246,16 @@ describes.realWin(
 
     it('initialize with skipScrollAnimation', () => {
       const {ampdoc} = env;
-      const scrollStub = sandbox.stub(
+      const scrollStub = env.sandbox.stub(
         Services.viewportForDoc(ampdoc),
         'animateScrollIntoView'
       );
       scrollStub.returns(Promise.reject());
-      const sendMsgStub = sandbox.stub(
+      const sendMsgStub = env.sandbox.stub(
         Services.viewerForDoc(ampdoc),
         'sendMessage'
       );
-      const setScrollTop = sandbox.stub(
+      const setScrollTop = env.sandbox.stub(
         Services.viewportForDoc(ampdoc),
         'setScrollTop'
       );
@@ -299,12 +299,12 @@ describes.realWin(
       document.body.appendChild(script);
 
       const {ampdoc} = env;
-      const scrollStub = sandbox.stub(
+      const scrollStub = env.sandbox.stub(
         Services.viewportForDoc(ampdoc),
         'animateScrollIntoView'
       );
       scrollStub.returns(Promise.reject());
-      const sendMsgStub = sandbox.stub(
+      const sendMsgStub = env.sandbox.stub(
         Services.viewerForDoc(ampdoc),
         'sendMessage'
       );
@@ -330,20 +330,20 @@ describes.realWin(
       // If visibility != visible, highlight texts and scroll to the start
       // position of the animation. But do not trigger the animation.
       const {ampdoc} = env;
-      const scrollStub = sandbox.stub(
+      const scrollStub = env.sandbox.stub(
         Services.viewportForDoc(ampdoc),
         'animateScrollIntoView'
       );
       scrollStub.returns(Promise.reject());
-      const sendMsgStub = sandbox.stub(
+      const sendMsgStub = env.sandbox.stub(
         Services.viewerForDoc(ampdoc),
         'sendMessage'
       );
-      const setScrollTop = sandbox.stub(
+      const setScrollTop = env.sandbox.stub(
         Services.viewportForDoc(ampdoc),
         'setScrollTop'
       );
-      sandbox
+      env.sandbox
         .stub(ampdoc, 'getVisibilityState')
         .returns(VisibilityState.PRERENDER);
 
@@ -369,11 +369,11 @@ describes.realWin(
       expect(handler.highlightedNodes_).not.to.be.null;
 
       const viewport = Services.viewportForDoc(env.ampdoc);
-      sandbox
+      env.sandbox
         .stub(viewport, 'getLayoutRect')
         .returns(layoutRectLtwh(0, 500, 100, 50));
-      sandbox.stub(viewport, 'getHeight').returns(300);
-      sandbox.stub(viewport, 'getPaddingTop').returns(50);
+      env.sandbox.stub(viewport, 'getHeight').returns(300);
+      env.sandbox.stub(viewport, 'getPaddingTop').returns(50);
 
       // 525px (The center of the element) - 0.5 * 250px (window height)
       // - 50px (padding top) = 350px.
@@ -386,11 +386,11 @@ describes.realWin(
       expect(handler.highlightedNodes_).not.to.be.null;
 
       const viewport = Services.viewportForDoc(env.ampdoc);
-      sandbox
+      env.sandbox
         .stub(viewport, 'getLayoutRect')
         .returns(layoutRectLtwh(0, 500, 100, 500));
-      sandbox.stub(viewport, 'getHeight').returns(300);
-      sandbox.stub(viewport, 'getPaddingTop').returns(50);
+      env.sandbox.stub(viewport, 'getHeight').returns(300);
+      env.sandbox.stub(viewport, 'getPaddingTop').returns(50);
 
       // Scroll to the top of the element with PAGE_TOP_MARGIN margin
       // because it's too tall.
@@ -407,15 +407,15 @@ describes.realWin(
       // Set up an environment where calcTopToCenterHighlightedNodes_
       // returns 350.
       const viewport = Services.viewportForDoc(env.ampdoc);
-      sandbox
+      env.sandbox
         .stub(viewport, 'getLayoutRect')
         .returns(layoutRectLtwh(0, 500, 100, 50));
-      sandbox.stub(viewport, 'getHeight').returns(300);
-      sandbox.stub(viewport, 'getPaddingTop').returns(50);
+      env.sandbox.stub(viewport, 'getHeight').returns(300);
+      env.sandbox.stub(viewport, 'getPaddingTop').returns(50);
       // The current top is 500.
-      sandbox.stub(viewport, 'getScrollTop').returns(500);
+      env.sandbox.stub(viewport, 'getScrollTop').returns(500);
 
-      const setScrollTopStub = sandbox.stub(viewport, 'setScrollTop');
+      const setScrollTopStub = env.sandbox.stub(viewport, 'setScrollTop');
 
       const param = handler.mayAdjustTop_(400);
       expect(param).to.deep.equal({'nd': 150, 'od': 100});

--- a/extensions/amp-viewer-integration/0.1/test/test-touch-handler.js
+++ b/extensions/amp-viewer-integration/0.1/test/test-touch-handler.js
@@ -62,7 +62,6 @@ describes.fakeWin('TouchHandler', {}, env => {
     }
 
     let win;
-    let sandbox;
     let touchHandler;
     let messaging;
     let listeners;
@@ -87,7 +86,6 @@ describes.fakeWin('TouchHandler', {}, env => {
         expect(listeners[unlistenCount].options).to.equal(options);
         unlistenCount++;
       };
-      sandbox = sinon.sandbox;
       const port = new WindowPortEmulator(
         this.messageHandlers_,
         'origin doesnt matter'
@@ -118,8 +116,11 @@ describes.fakeWin('TouchHandler', {}, env => {
       expect(listeners[0].options.passive).to.be.true;
       expect(listeners[0].options.capture).to.be.false;
       const fakeEvent = fakeTouchEvent('touchstart');
-      const preventDefaultStub = sandbox.stub(fakeEvent, 'preventDefault');
-      const copyTouchEventStub = sandbox.stub(touchHandler, 'copyTouchEvent_');
+      const preventDefaultStub = env.sandbox.stub(fakeEvent, 'preventDefault');
+      const copyTouchEventStub = env.sandbox.stub(
+        touchHandler,
+        'copyTouchEvent_'
+      );
 
       touchHandler.forwardEvent_(fakeEvent);
       expect(copyTouchEventStub).to.have.been.called;
@@ -144,8 +145,8 @@ describes.fakeWin('TouchHandler', {}, env => {
     it('should only cancel touch event when cancelable', () => {
       const fakeEvent = fakeTouchEvent('touchstart');
       fakeEvent.cancelable = false;
-      const preventDefaultStub = sandbox.stub(fakeEvent, 'preventDefault');
-      sandbox.stub(touchHandler, 'copyTouchEvent_');
+      const preventDefaultStub = env.sandbox.stub(fakeEvent, 'preventDefault');
+      env.sandbox.stub(touchHandler, 'copyTouchEvent_');
 
       touchHandler.scrollLockHandler_('some type', /*lock*/ true, false);
       touchHandler.forwardEvent_(fakeEvent);

--- a/extensions/amp-vk/0.1/test/test-amp-vk.js
+++ b/extensions/amp-vk/0.1/test/test-amp-vk.js
@@ -205,7 +205,7 @@ describes.realWin(
       const vkPoll = await createAmpVkElement(POLL_PARAMS);
       const impl = vkPoll.implementation_;
       const iframe = vkPoll.querySelector('iframe');
-      const changeHeight = sandbox.spy(impl, 'changeHeight');
+      const changeHeight = env.sandbox.spy(impl, 'changeHeight');
       const fakeHeight = 555;
       expect(iframe).to.not.be.null;
       generatePostMessage(vkPoll, iframe, fakeHeight);

--- a/extensions/amp-web-push/0.1/test/test-web-push-permission-dialog.js
+++ b/extensions/amp-web-push/0.1/test/test-web-push-permission-dialog.js
@@ -30,7 +30,6 @@ describes.realWin(
   },
   env => {
     let webPush;
-    let sandbox;
     const webPushConfig = {};
     let iframeWindow = null;
 
@@ -70,7 +69,6 @@ describes.realWin(
     }
 
     beforeEach(() => {
-      sandbox = env.sandbox;
       setDefaultConfigParams_();
       webPush = new WebPushService(env.ampdoc);
     });
@@ -78,7 +76,7 @@ describes.realWin(
     // TODO(dvoytenko, #12476): Make this test work with sinon 4.0.
     it.skip('should detect opened as popup', () => {
       return setupPermissionDialogFrame().then(() => {
-        sandbox./*OK*/ stub(iframeWindow, 'opener').callsFake(true);
+        env.sandbox./*OK*/ stub(iframeWindow, 'opener').callsFake(true);
         const isCurrentDialogPopup = iframeWindow._ampWebPushPermissionDialog.isCurrentDialogPopup();
         expect(isCurrentDialogPopup).to.eq(true);
       });
@@ -86,18 +84,18 @@ describes.realWin(
 
     it('should detect opened from redirect', () => {
       return setupPermissionDialogFrame().then(() => {
-        sandbox./*OK*/ stub(iframeWindow, 'opener').callsFake(false);
+        env.sandbox./*OK*/ stub(iframeWindow, 'opener').callsFake(false);
         iframeWindow.fakeLocation = parseUrlDeprecated(
           'https://test.com/?return=' +
             encodeURIComponent('https://another-site.com')
         );
-        sandbox
+        env.sandbox
           ./*OK*/ stub(
             iframeWindow._ampWebPushPermissionDialog,
             'requestNotificationPermission'
           )
           .callsFake(() => Promise.resolve());
-        const spy = sandbox./*OK*/ spy(
+        const spy = env.sandbox./*OK*/ spy(
           iframeWindow._ampWebPushPermissionDialog,
           'isCurrentDialogPopup'
         );
@@ -109,13 +107,13 @@ describes.realWin(
     // TODO(jasonpang): This fails on master under headless Chrome.
     it.skip('should request notification permissions, when opened as popup', () => {
       return setupPermissionDialogFrame().then(() => {
-        sandbox
+        env.sandbox
           ./*OK*/ stub(
             iframeWindow._ampWebPushPermissionDialog,
             'isCurrentDialogPopup'
           )
           .callsFake(() => true);
-        const permissionStub = sandbox
+        const permissionStub = env.sandbox
           ./*OK*/ stub(iframeWindow.Notification, 'requestPermission')
           .callsFake(() => Promise.resolve('default'));
         iframeWindow._ampWebPushPermissionDialog.run();
@@ -126,7 +124,7 @@ describes.realWin(
     // TODO(jasonpang): This fails on master under headless Chrome.
     it.skip('should request notification permissions when redirected', () => {
       return setupPermissionDialogFrame().then(() => {
-        sandbox
+        env.sandbox
           ./*OK*/ stub(
             iframeWindow._ampWebPushPermissionDialog,
             'isCurrentDialogPopup'
@@ -136,7 +134,7 @@ describes.realWin(
           'https://test.com/?return=' +
             encodeURIComponent('https://another-site.com')
         );
-        const permissionStub = sandbox
+        const permissionStub = env.sandbox
           ./*OK*/ stub(iframeWindow.Notification, 'requestPermission')
           .callsFake(() => Promise.resolve('default'));
         iframeWindow._ampWebPushPermissionDialog.run();
@@ -149,7 +147,7 @@ describes.realWin(
       let spy = null;
       return setupPermissionDialogFrame()
         .then(() => {
-          sandbox
+          env.sandbox
             ./*OK*/ stub(
               iframeWindow._ampWebPushPermissionDialog,
               'isCurrentDialogPopup'
@@ -159,16 +157,16 @@ describes.realWin(
             'https://test.com/?return=' +
               encodeURIComponent('https://another-site.com')
           );
-          sandbox
+          env.sandbox
             ./*OK*/ stub(
               iframeWindow._ampWebPushPermissionDialog,
               'requestNotificationPermission'
             )
             .callsFake(() => Promise.resolve());
-          sandbox
+          env.sandbox
             ./*OK*/ stub(iframeWindow.Notification, 'requestPermission')
             .callsFake(() => Promise.resolve('default'));
-          spy = sandbox./*OK*/ spy(
+          spy = env.sandbox./*OK*/ spy(
             iframeWindow._ampWebPushPermissionDialog,
             'redirectToUrl'
           );
@@ -195,7 +193,7 @@ describes.realWin(
 
     it('should show target permission section', () => {
       return setupPermissionDialogFrame().then(() => {
-        sandbox.defineProperty(iframeWindow.Notification, 'permission', {
+        env.sandbox.defineProperty(iframeWindow.Notification, 'permission', {
           enumerable: false,
           writable: false,
           value: 'granted',
@@ -222,7 +220,7 @@ describes.realWin(
           localStorage.getItem('amp-web-push-notification-permission')
         ).to.eq(null);
 
-        sandbox.defineProperty(iframeWindow.Notification, 'permission', {
+        env.sandbox.defineProperty(iframeWindow.Notification, 'permission', {
           enumerable: false,
           writable: false,
           value: 'granted',
@@ -244,7 +242,7 @@ describes.realWin(
         iframeWindow._ampWebPushPermissionDialog.onCloseIconClick_();
         const {document} = iframeWindow;
         const closeElement = document.querySelector('#close');
-        spy = sandbox./*OK*/ spy(
+        spy = env.sandbox./*OK*/ spy(
           iframeWindow._ampWebPushPermissionDialog,
           'closeDialog'
         );

--- a/extensions/amp-web-push/0.1/test/test-web-push-service.js
+++ b/extensions/amp-web-push/0.1/test/test-web-push-service.js
@@ -32,10 +32,8 @@ describes.realWin(
   },
   env => {
     let webPush;
-    let sandbox;
 
     beforeEach(() => {
-      sandbox = env.sandbox;
       webPush = new WebPushService(env.ampdoc);
     });
 
@@ -44,7 +42,7 @@ describes.realWin(
     });
 
     it('should not support environment missing Notification API', () => {
-      sandbox.defineProperty(env.win, 'Notification', {
+      env.sandbox.defineProperty(env.win, 'Notification', {
         enumerable: false,
         writable: false,
         value: undefined,
@@ -53,7 +51,7 @@ describes.realWin(
     });
 
     it('should not support environment missing Service Worker API', () => {
-      sandbox.defineProperty(env.win.navigator, 'serviceWorker', {
+      env.sandbox.defineProperty(env.win.navigator, 'serviceWorker', {
         enumerable: false,
         writable: false,
         value: undefined,
@@ -62,7 +60,7 @@ describes.realWin(
     });
 
     it('should not support environment missing PushManager API', () => {
-      sandbox.defineProperty(env.win, 'PushManager', {
+      env.sandbox.defineProperty(env.win, 'PushManager', {
         enumerable: false,
         writable: false,
         value: undefined,
@@ -72,7 +70,7 @@ describes.realWin(
 
     it('an unsupported environment should prevent initializing', () => {
       // Cause push to not be supported on this environment
-      sandbox.defineProperty(env.win, 'PushManager', {
+      env.sandbox.defineProperty(env.win, 'PushManager', {
         enumerable: false,
         writable: false,
         value: undefined,
@@ -93,12 +91,12 @@ describes.fakeWin(
   env => {
     it('should not support HTTP location', () => {
       env.ampdoc.win.location.resetHref('http://site.com/');
-      sandbox.stub(mode, 'getMode').callsFake(() => {
+      env.sandbox.stub(mode, 'getMode').callsFake(() => {
         return {development: false, test: false};
       });
       expect(env.ampdoc.win.location.href).to.be.equal('http://site.com/');
       const webPush = new WebPushService(env.ampdoc);
-      sandbox
+      env.sandbox
         ./*OK*/ stub(webPush, 'arePushRelatedApisSupported_')
         .callsFake(() => true);
       expect(webPush.environmentSupportsWebPush()).to.eq(false);
@@ -116,7 +114,7 @@ describes.fakeWin(
       env.ampdoc.win.location.resetHref('http://localhost/');
       expect(env.ampdoc.win.location.href).to.be.equal('http://localhost/');
       const webPush = new WebPushService(env.ampdoc);
-      sandbox
+      env.sandbox
         ./*OK*/ stub(webPush, 'arePushRelatedApisSupported_')
         .callsFake(() => true);
       expect(webPush.environmentSupportsWebPush()).to.eq(true);
@@ -133,7 +131,7 @@ describes.fakeWin(
     it('should support localhost HTTP location with port', () => {
       env.ampdoc.win.location.resetHref('http://localhost:8000/');
       const webPush = new WebPushService(env.ampdoc);
-      sandbox
+      env.sandbox
         ./*OK*/ stub(webPush, 'arePushRelatedApisSupported_')
         .callsFake(() => true);
       expect(env.ampdoc.win.location.href).to.be.equal(
@@ -153,7 +151,7 @@ describes.fakeWin(
     it('should support 127.0.0.1 HTTP location', () => {
       env.ampdoc.win.location.resetHref('http://127.0.0.1/');
       const webPush = new WebPushService(env.ampdoc);
-      sandbox
+      env.sandbox
         ./*OK*/ stub(webPush, 'arePushRelatedApisSupported_')
         .callsFake(() => true);
       expect(env.ampdoc.win.location.href).to.be.equal('http://127.0.0.1/');
@@ -171,7 +169,7 @@ describes.fakeWin(
     it('should support 127.0.0.1 HTTP location with port', () => {
       env.ampdoc.win.location.resetHref('http://localhost:9000/');
       const webPush = new WebPushService(env.ampdoc);
-      sandbox
+      env.sandbox
         ./*OK*/ stub(webPush, 'arePushRelatedApisSupported_')
         .callsFake(() => true);
       expect(env.ampdoc.win.location.href).to.be.equal(
@@ -320,17 +318,17 @@ describes.realWin(
       let spy = null;
       return setupHelperIframe()
         .then(() => {
-          spy = sandbox./*OK*/ spy(webPush, 'setWidgetVisibilities');
+          spy = env.sandbox./*OK*/ spy(webPush, 'setWidgetVisibilities');
 
-          sandbox
+          env.sandbox
             ./*OK*/ stub(webPush, 'isQuerySupported_')
             .callsFake(() => Promise.resolve(true));
 
-          sandbox
+          env.sandbox
             ./*OK*/ stub(webPush, 'getCanonicalFrameStorageValue_')
             .callsFake(() => Promise.resolve(NotificationPermission.DENIED));
 
-          sandbox
+          env.sandbox
             ./*OK*/ stub(webPush, 'doesWidgetCategoryMarkupExist_')
             .callsFake(() => true);
           // We've mocked default notification permissions
@@ -355,15 +353,15 @@ describes.realWin(
 
       return setupHelperIframe()
         .then(() => {
-          spy = sandbox./*OK*/ spy(webPush, 'setWidgetVisibilities');
+          spy = env.sandbox./*OK*/ spy(webPush, 'setWidgetVisibilities');
 
-          sandbox
+          env.sandbox
             ./*OK*/ stub(webPush, 'querySubscriptionStateRemotely')
             .callsFake(() => Promise.resolve(true));
-          sandbox
+          env.sandbox
             ./*OK*/ stub(webPush, 'isServiceWorkerActivated')
             .callsFake(() => Promise.resolve(true));
-          sandbox
+          env.sandbox
             ./*OK*/ stub(webPush, 'queryNotificationPermission')
             .callsFake(() => Promise.resolve(NotificationPermission.DEFAULT));
 
@@ -389,12 +387,12 @@ describes.realWin(
 
       return setupHelperIframe()
         .then(() => {
-          spy = sandbox./*OK*/ spy(webPush, 'setWidgetVisibilities');
+          spy = env.sandbox./*OK*/ spy(webPush, 'setWidgetVisibilities');
 
-          sandbox
+          env.sandbox
             ./*OK*/ stub(webPush, 'isServiceWorkerActivated')
             .callsFake(() => Promise.resolve(false));
-          sandbox
+          env.sandbox
             ./*OK*/ stub(webPush, 'queryNotificationPermission')
             .callsFake(() => Promise.resolve(NotificationPermission.DEFAULT));
 
@@ -420,15 +418,15 @@ describes.realWin(
 
       return setupHelperIframe()
         .then(() => {
-          spy = sandbox./*OK*/ spy(webPush, 'setWidgetVisibilities');
+          spy = env.sandbox./*OK*/ spy(webPush, 'setWidgetVisibilities');
 
-          sandbox
+          env.sandbox
             ./*OK*/ stub(webPush, 'querySubscriptionStateRemotely')
             .callsFake(() => Promise.resolve(false));
-          sandbox
+          env.sandbox
             ./*OK*/ stub(webPush, 'isServiceWorkerActivated')
             .callsFake(() => Promise.resolve(true));
-          sandbox
+          env.sandbox
             ./*OK*/ stub(webPush, 'queryNotificationPermission')
             .callsFake(() => Promise.resolve(NotificationPermission.DEFAULT));
 
@@ -521,20 +519,20 @@ describes.realWin(
       let iframeWindowControllerMock = null;
 
       return setupHelperIframe().then(() => {
-        sandbox
+        env.sandbox
           ./*OK*/ stub(webPush, 'isServiceWorkerActivated')
           .callsFake(() => Promise.resolve(true));
-        sandbox./*OK*/ stub(webPush, 'queryNotificationPermission', () =>
+        env.sandbox./*OK*/ stub(webPush, 'queryNotificationPermission', () =>
           Promise.resolve(NotificationPermission.GRANTED)
         );
 
-        iframeWindowControllerMock = sandbox./*OK*/ mock(
+        iframeWindowControllerMock = env.sandbox./*OK*/ mock(
           iframeWindow._ampWebPushHelperFrame
         );
         iframeWindowControllerMock
           .expects('waitUntilWorkerControlsPage')
           .returns(Promise.resolve(true));
-        sandbox
+        env.sandbox
           ./*OK*/ stub(
             iframeWindow._ampWebPushHelperFrame,
             'messageServiceWorker'
@@ -615,7 +613,7 @@ describes.realWin(
 
       return setupHelperIframe()
         .then(() => {
-          helperFrameSwMessageMock = sandbox./*OK*/ mock(
+          helperFrameSwMessageMock = env.sandbox./*OK*/ mock(
             iframeWindow.navigator.serviceWorker
           );
           helperFrameSwMessageMock
@@ -634,13 +632,13 @@ describes.realWin(
       let iframeWindowControllerMock = null;
 
       return setupHelperIframe().then(() => {
-        iframeWindowControllerMock = sandbox./*OK*/ mock(
+        iframeWindowControllerMock = env.sandbox./*OK*/ mock(
           iframeWindow._ampWebPushHelperFrame
         );
         iframeWindowControllerMock
           .expects('waitUntilWorkerControlsPage')
           .returns(Promise.resolve(true));
-        sandbox
+        env.sandbox
           ./*OK*/ stub(
             iframeWindow._ampWebPushHelperFrame,
             'messageServiceWorker'
@@ -658,7 +656,7 @@ describes.realWin(
       let openWindowMock = null;
 
       return setupHelperIframe().then(() => {
-        openWindowMock = sandbox./*OK*/ mock(env.win);
+        openWindowMock = env.sandbox./*OK*/ mock(env.win);
         const returningPopupUrl =
           env.win.location.href +
           '?' +
@@ -776,13 +774,13 @@ describes.realWin(
       let iframeWindowControllerMock = null;
 
       return setupHelperIframe().then(() => {
-        iframeWindowControllerMock = sandbox./*OK*/ mock(
+        iframeWindowControllerMock = env.sandbox./*OK*/ mock(
           iframeWindow._ampWebPushHelperFrame
         );
         iframeWindowControllerMock
           .expects('waitUntilWorkerControlsPage')
           .returns(Promise.resolve(true));
-        sandbox
+        env.sandbox
           ./*OK*/ stub(
             iframeWindow._ampWebPushHelperFrame,
             'messageServiceWorker'
@@ -802,10 +800,10 @@ describes.realWin(
 
       return setupHelperIframe()
         .then(() => {
-          unsubscribeStub = sandbox
+          unsubscribeStub = env.sandbox
             ./*OK*/ stub(webPush, 'unsubscribeFromPushRemotely')
             .callsFake(() => Promise.resolve());
-          updateWidgetStub = sandbox
+          updateWidgetStub = env.sandbox
             ./*OK*/ stub(webPush, 'updateWidgetVisibilities')
             .callsFake(() => Promise.resolve());
 

--- a/extensions/amp-youtube/0.1/test/test-amp-youtube.js
+++ b/extensions/amp-youtube/0.1/test/test-amp-youtube.js
@@ -36,12 +36,10 @@ describes.realWin(
     this.timeout(5000);
     let win, doc;
     let timer;
-    let sandbox;
 
     beforeEach(() => {
       win = env.win;
       doc = win.document;
-      sandbox = env.sandbox;
       timer = Services.timerFor(win);
     });
 
@@ -93,7 +91,7 @@ describes.realWin(
 
       it('should pause if the video is playing', async () => {
         const yt = await getYt({'data-videoid': datasource});
-        sandbox.spy(yt.implementation_, 'pause');
+        env.sandbox.spy(yt.implementation_, 'pause');
         yt.implementation_.pauseCallback();
         expect(yt.implementation_.pause.called).to.be.true;
       });
@@ -164,7 +162,10 @@ describes.realWin(
           'data-param-playsinline': '0',
         });
         const {src} = yt.querySelector('iframe');
-        const preloadSpy = sandbox.spy(yt.implementation_.preconnect, 'url');
+        const preloadSpy = env.sandbox.spy(
+          yt.implementation_.preconnect,
+          'url'
+        );
         yt.implementation_.preconnectCallback();
         preloadSpy.should.have.been.calledWithExactly(src);
       });
@@ -311,12 +312,12 @@ describes.realWin(
         expect(imgPlaceholder).to.not.be.null;
         expect(imgPlaceholder.className).to.not.match(/amp-hidden/);
         // Fake out the 404 image response dimensions of YT.
-        sandbox.defineProperty(imgPlaceholder, 'naturalWidth', {
+        env.sandbox.defineProperty(imgPlaceholder, 'naturalWidth', {
           get() {
             return 120;
           },
         });
-        sandbox.defineProperty(imgPlaceholder, 'naturalHeight', {
+        env.sandbox.defineProperty(imgPlaceholder, 'naturalHeight', {
           get() {
             return 90;
           },
@@ -333,12 +334,12 @@ describes.realWin(
 
     it('should propagate attribute mutations for videoid', async () => {
       const yt = await getYt({'data-videoid': EXAMPLE_VIDEOID});
-      const spy = sandbox.spy(yt.implementation_, 'sendCommand_');
+      const spy = env.sandbox.spy(yt.implementation_, 'sendCommand_');
       yt.setAttribute('data-videoid', 'lBTCB7yLs8Y');
       yt.mutatedAttributesCallback({'data-videoid': 'lBTCB7yLs8Y'});
       expect(spy).to.be.calledWith(
         'loadVideoById',
-        sinon.match(['lBTCB7yLs8Y'])
+        env.sandbox.match(['lBTCB7yLs8Y'])
       );
     });
 
@@ -346,7 +347,7 @@ describes.realWin(
       const yt = await getYt({'data-videoid': EXAMPLE_VIDEOID});
       const placeholder = yt.querySelector('[placeholder]');
       const obj = yt.implementation_;
-      const unlistenSpy = sandbox.spy(obj, 'unlistenMessage_');
+      const unlistenSpy = env.sandbox.spy(obj, 'unlistenMessage_');
       obj.unlayoutCallback();
       expect(unlistenSpy).to.have.been.called;
       expect(yt.querySelector('iframe')).to.be.null;

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "request-promise": "4.2.5",
     "require-hijack": "1.2.1",
     "rocambole": "0.7.0",
-    "sinon": "7.3.2",
+    "sinon": "7.5.0",
     "sinon-chai": "3.3.0",
     "sleep-promise": "8.0.1",
     "tempy": "0.3.0",

--- a/test/_init_tests.js
+++ b/test/_init_tests.js
@@ -37,6 +37,7 @@ import {resetEvtListenerOptsSupportForTesting} from '../src/event-helper-listen'
 import {resetExperimentTogglesForTesting} from '../src/experiments';
 import {setDefaultBootstrapBaseUrlForTesting} from '../src/3p-frame';
 import {setReportError} from '../src/log';
+import sinon from 'sinon'; // eslint-disable-line local/no-import
 import stringify from 'json-stable-stringify';
 
 // Used to print warnings for unexpected console errors.
@@ -45,6 +46,7 @@ let consoleErrorSandbox;
 let testName;
 let expectedAsyncErrors;
 let rethrowAsyncSandbox;
+let consoleInfoLogWarnSandbox;
 const originalConsoleError = console /*OK*/.error;
 
 // Used to clean up global state between tests.
@@ -360,9 +362,10 @@ function restoreConsoleError() {
 function maybeStubConsoleInfoLogWarn() {
   const {verboseLogging} = window.__karma__.config;
   if (!verboseLogging) {
-    sinon.sandbox.stub(console, 'info').callsFake(() => {});
-    sinon.sandbox.stub(console, 'log').callsFake(() => {});
-    sinon.sandbox.stub(console, 'warn').callsFake(() => {});
+    consoleInfoLogWarnSandbox = sinon.createSandbox();
+    consoleInfoLogWarnSandbox.stub(console, 'info').callsFake(() => {});
+    consoleInfoLogWarnSandbox.stub(console, 'log').callsFake(() => {});
+    consoleInfoLogWarnSandbox.stub(console, 'warn').callsFake(() => {});
   }
 }
 
@@ -400,7 +403,7 @@ beforeEach(function() {
   this.timeout(BEFORE_AFTER_TIMEOUT);
   beforeTest();
   testName = this.currentTest.fullTitle();
-  window.sandbox = sinon.sandbox = sinon.createSandbox();
+  window.sandbox = sinon.createSandbox();
   maybeStubConsoleInfoLogWarn();
   preventAsyncErrorThrows();
   warnForConsoleError();
@@ -430,7 +433,10 @@ afterEach(function() {
   that = this;
   const globalState = Object.keys(global);
   const windowState = Object.keys(window);
-  sinon.sandbox.restore();
+  if (consoleInfoLogWarnSandbox) {
+    consoleInfoLogWarnSandbox.restore();
+  }
+  window.sandbox.restore();
   restoreConsoleError();
   restoreAsyncErrorThrows();
   this.timeout(BEFORE_AFTER_TIMEOUT);

--- a/test/integration/test-actions.js
+++ b/test/integration/test-actions.js
@@ -22,11 +22,8 @@ describe
   .retryOnSaucelabs()
   .run('on="..."', () => {
     let fixture;
-    let sandbox;
 
     beforeEach(() => {
-      sandbox = sinon.sandbox;
-
       return createFixtureIframe('test/fixtures/actions.html', 500).then(f => {
         fixture = f;
 
@@ -38,10 +35,6 @@ describe
     function waitForDisplay(element, display) {
       return () => fixture.win.getComputedStyle(element)['display'] === display;
     }
-
-    afterEach(() => {
-      sandbox.restore();
-    });
 
     describe('"tap" event', () => {
       it('<non-AMP element>.toggleVisibility', function*() {
@@ -76,7 +69,10 @@ describe
             // This is brittle but I don't know how else to stub
             // window navigation.
             const navigationService = fixture.win.__AMP_SERVICES.navigation.obj;
-            const navigateTo = sandbox.stub(navigationService, 'navigateTo');
+            const navigateTo = window.sandbox.stub(
+              navigationService,
+              'navigateTo'
+            );
 
             button.click();
             yield poll('navigateTo() called with correct args', () => {
@@ -88,7 +84,7 @@ describe
       it('AMP.print()', function*() {
         const button = fixture.doc.getElementById('printBtn');
 
-        const print = sandbox.stub(fixture.win, 'print');
+        const print = window.sandbox.stub(fixture.win, 'print');
 
         button.click();
         yield poll('print() called once', () => {

--- a/test/integration/test-toggle-display.js
+++ b/test/integration/test-toggle-display.js
@@ -23,12 +23,9 @@ describe
   .retryOnSaucelabs()
   .run('toggle display helper', () => {
     let fixture;
-    let sandbox;
     let img;
 
     beforeEach(() => {
-      sandbox = sinon.sandbox;
-
       return createFixtureIframe('test/fixtures/images.html', 500)
         .then(f => {
           fixture = f;
@@ -39,10 +36,6 @@ describe
         .then(() => {
           img = fixture.doc.querySelector('amp-img');
         });
-    });
-
-    afterEach(() => {
-      sandbox.restore();
     });
 
     describes.repeated(

--- a/test/integration/test-video-manager.js
+++ b/test/integration/test-video-manager.js
@@ -55,7 +55,6 @@ describe
         },
       },
       env => {
-        let sandbox;
         let videoManager;
         let klass;
         let video;
@@ -69,7 +68,7 @@ describe
         });
 
         it('should register common actions', () => {
-          const spy = sandbox.spy(impl, 'registerAction');
+          const spy = env.sandbox.spy(impl, 'registerAction');
           videoManager.register(impl);
 
           expect(spy).to.have.been.calledWith('play');
@@ -93,7 +92,7 @@ describe
           videoManager.register(impl);
 
           const entry = videoManager.getEntryForVideo_(impl);
-          sandbox.stub(entry, 'userInteracted').returns(true);
+          env.sandbox.stub(entry, 'userInteracted').returns(true);
           entry.isVisible_ = true;
           entry.loaded_ = true;
 
@@ -108,7 +107,7 @@ describe
           video.setAttribute('autoplay', '');
           videoManager.register(impl);
 
-          const visibilityStub = sandbox.stub(env.ampdoc, 'isVisible');
+          const visibilityStub = env.sandbox.stub(env.ampdoc, 'isVisible');
           visibilityStub.onFirstCall().returns(true);
 
           const entry = videoManager.getEntryForVideo_(impl);
@@ -130,12 +129,12 @@ describe
             video.setAttribute('autoplay', '');
             videoManager.register(impl);
 
-            const visibilityStub = sandbox.stub(env.ampdoc, 'isVisible');
+            const visibilityStub = env.sandbox.stub(env.ampdoc, 'isVisible');
             visibilityStub.onFirstCall().returns(true);
 
             const entry = videoManager.getEntryForVideo_(impl);
 
-            const supportsAutoplayStub = sandbox.stub(
+            const supportsAutoplayStub = env.sandbox.stub(
               entry,
               'supportsAutoplay_'
             );
@@ -168,7 +167,7 @@ describe
           impl.play();
 
           const entry = videoManager.getEntryForVideo_(impl);
-          sandbox.stub(entry, 'userInteracted').returns(true);
+          env.sandbox.stub(entry, 'userInteracted').returns(true);
           entry.isVisible_ = false;
 
           impl.pause();
@@ -214,7 +213,7 @@ describe
 
           videoManager.register(impl);
 
-          const visibilityStub = sandbox.stub(env.ampdoc, 'isVisible');
+          const visibilityStub = env.sandbox.stub(env.ampdoc, 'isVisible');
           visibilityStub.onFirstCall().returns(true);
 
           const entry = videoManager.getEntryForVideo_(impl);
@@ -256,17 +255,12 @@ describe
         });
 
         beforeEach(() => {
-          sandbox = sinon.sandbox;
           klass = createFakeVideoPlayerClass(env.win);
           video = env.createAmpElement('amp-test-fake-videoplayer', klass);
           env.win.document.body.appendChild(video);
           impl = video.implementation_;
           installVideoManagerForDoc(env.ampdoc);
           videoManager = Services.videoManagerForDoc(env.ampdoc);
-        });
-
-        afterEach(() => {
-          sandbox.restore();
         });
       }
     );
@@ -277,21 +271,14 @@ describe
   .ifChrome()
   .run('Autoplay support', () => {
     const supportsAutoplay = VideoUtils.isAutoplaySupported; // for line length
-
-    let sandbox;
-
     let win;
     let video;
-
     let isLite;
-
     let createElementSpy;
     let setAttributeSpy;
     let playStub;
 
     beforeEach(() => {
-      sandbox = sinon.sandbox;
-
       video = {
         setAttribute() {},
         style: {
@@ -320,17 +307,15 @@ describe
 
       isLite = false;
 
-      createElementSpy = sandbox.spy(doc, 'createElement');
-      setAttributeSpy = sandbox.spy(video, 'setAttribute');
-      playStub = sandbox.stub(video, 'play');
+      createElementSpy = window.sandbox.spy(doc, 'createElement');
+      setAttributeSpy = window.sandbox.spy(video, 'setAttribute');
+      playStub = window.sandbox.stub(video, 'play');
 
       VideoUtils.resetIsAutoplaySupported();
     });
 
     afterEach(() => {
       VideoUtils.resetIsAutoplaySupported();
-
-      sandbox.restore();
     });
 
     it('should create an invisible test video element', () => {

--- a/test/integration/test-video-players-helper.js
+++ b/test/integration/test-video-players-helper.js
@@ -483,7 +483,6 @@ export function runVideoPlayerIntegrationTests(
       this.timeout(TIMEOUT);
 
       let video;
-      let sandbox;
       let playButton;
       let autoFullscreen;
       let isInLandscapeStub;
@@ -496,7 +495,10 @@ export function runVideoPlayerIntegrationTests(
             autoFullscreen = manager.getAutoFullscreenManagerForTesting_();
           }
           if (!isInLandscapeStub) {
-            isInLandscapeStub = sandbox.stub(autoFullscreen, 'isInLandscape');
+            isInLandscapeStub = window.sandbox.stub(
+              autoFullscreen,
+              'isInLandscape'
+            );
           }
           isInLandscapeStub.returns(isLandscape);
         }
@@ -521,7 +523,7 @@ export function runVideoPlayerIntegrationTests(
             return whenPlaying;
           })
           .then(() => {
-            const enter = sandbox.stub(
+            const enter = window.sandbox.stub(
               video.implementation_,
               'fullscreenEnter'
             );
@@ -541,14 +543,6 @@ export function runVideoPlayerIntegrationTests(
         this.timeout(TIMEOUT);
         // Skip autoplay tests if browser does not support autoplay.
         return skipIfAutoplayUnsupported.call(this, window);
-      });
-
-      beforeEach(() => {
-        sandbox = sinon.sandbox;
-      });
-
-      afterEach(() => {
-        sandbox.restore();
       });
     });
 

--- a/test/integration/test-visibility-states.js
+++ b/test/integration/test-visibility-states.js
@@ -36,7 +36,6 @@ t.run('Viewer Visibility State', () => {
     },
     env => {
       let win;
-      let sandbox;
 
       let resources;
       let viewer;
@@ -102,12 +101,11 @@ t.run('Viewer Visibility State', () => {
 
       beforeEach(() => {
         win = env.win;
-        sandbox = env.sandbox;
         notifyPass = noop;
         shouldPass = false;
 
         const vsync = Services.vsyncFor(win);
-        sandbox.stub(vsync, 'mutate').callsFake(mutator => {
+        env.sandbox.stub(vsync, 'mutate').callsFake(mutator => {
           mutator();
         });
 
@@ -115,18 +113,18 @@ t.run('Viewer Visibility State', () => {
           .then(v => {
             viewer = v;
 
-            docHidden = sandbox.stub(win.document, 'hidden').value(false);
+            docHidden = env.sandbox.stub(win.document, 'hidden').value(false);
             if ('visibilityState' in win.document) {
-              docVisibilityState = sandbox
+              docVisibilityState = env.sandbox
                 .stub(win.document, 'visibilityState')
                 .value('visible');
             }
 
             resources = Services.resourcesForDoc(win.document);
             doPass_ = resources.doPass;
-            sandbox.stub(resources, 'doPass').callsFake(doPass);
+            env.sandbox.stub(resources, 'doPass').callsFake(doPass);
             // TODO(jridgewell@): Do not stub private method
-            //unselect = sandbox.stub(resources, 'unselectText_');
+            //unselect = env.sandbox.stub(resources, 'unselectText_');
 
             const img = win.document.createElement('amp-img');
             img.setAttribute('width', 100);
@@ -137,27 +135,30 @@ t.run('Viewer Visibility State', () => {
             return whenUpgradedToCustomElement(img);
           })
           .then(img => {
-            layoutCallback = sandbox.stub(
+            layoutCallback = env.sandbox.stub(
               img.implementation_,
               'layoutCallback'
             );
-            unlayoutCallback = sandbox.stub(
+            unlayoutCallback = env.sandbox.stub(
               img.implementation_,
               'unlayoutCallback'
             );
-            pauseCallback = sandbox.stub(img.implementation_, 'pauseCallback');
-            resumeCallback = sandbox.stub(
+            pauseCallback = env.sandbox.stub(
+              img.implementation_,
+              'pauseCallback'
+            );
+            resumeCallback = env.sandbox.stub(
               img.implementation_,
               'resumeCallback'
             );
-            prerenderAllowed = sandbox.stub(
+            prerenderAllowed = env.sandbox.stub(
               img.implementation_,
               'prerenderAllowed'
             );
-            sandbox
+            env.sandbox
               .stub(img.implementation_, 'isRelayoutNeeded')
               .callsFake(() => true);
-            sandbox
+            env.sandbox
               .stub(img.implementation_, 'isLayoutSupported')
               .callsFake(() => true);
 

--- a/test/unit/3p/test-3p-frame.js
+++ b/test/unit/3p/test-3p-frame.js
@@ -40,13 +40,11 @@ describe
   .ifChrome()
   .run('3p-frame', () => {
     let clock;
-    let sandbox;
     let container;
     let preconnect;
 
     beforeEach(() => {
-      sandbox = sinon.sandbox;
-      clock = sandbox.useFakeTimers();
+      clock = window.sandbox.useFakeTimers();
       container = document.createElement('div');
       document.body.appendChild(container);
       preconnect = preconnectForElement(container);
@@ -54,7 +52,6 @@ describe
 
     afterEach(() => {
       resetBootstrapBaseUrlForTesting(window);
-      sandbox.restore();
       resetCountForTesting();
       const m = document.querySelector('[name="amp-3p-iframe-src"]');
       if (m) {
@@ -162,7 +159,7 @@ describe
       setupElementFunctions(div);
 
       const viewer = Services.viewerForDoc(window.document);
-      const viewerMock = sandbox.mock(viewer);
+      const viewerMock = window.sandbox.mock(viewer);
       viewerMock
         .expects('getUnconfirmedReferrerUrl')
         .returns('http://acme.org/')
@@ -170,7 +167,7 @@ describe
 
       container.appendChild(div);
 
-      sandbox
+      window.sandbox
         .stub(DomFingerprint, 'generate')
         .callsFake(() => 'MY-MOCK-FINGERPRINT');
 
@@ -484,7 +481,9 @@ describe
     });
 
     it('uses a unique name based on domain', () => {
-      const viewerMock = sandbox.mock(Services.viewerForDoc(window.document));
+      const viewerMock = window.sandbox.mock(
+        Services.viewerForDoc(window.document)
+      );
       viewerMock
         .expects('getUnconfirmedReferrerUrl')
         .returns('http://acme.org/')
@@ -620,13 +619,13 @@ describe
       });
 
       it('should return null if the input is not a json', () => {
-        const errorStub = sandbox.stub(dev(), 'error');
+        const errorStub = window.sandbox.stub(dev(), 'error');
         expect(deserializeMessage('amp-other')).to.be.null;
         expect(errorStub).to.not.be.called;
       });
 
       it('should return null if failed to parse the input', () => {
-        const errorStub = sandbox.stub(dev(), 'error');
+        const errorStub = window.sandbox.stub(dev(), 'error');
         expect(deserializeMessage('amp-{"type","sentinel":"msgsentinel"}')).to
           .be.null;
         expect(errorStub).to.be.calledOnce;

--- a/test/unit/3p/test-iframe-messaging-client.js
+++ b/test/unit/3p/test-iframe-messaging-client.js
@@ -29,7 +29,7 @@ describes.realWin('iframe-messaging-client', {}, env => {
     let postMessageStub;
     let hostWindow;
     beforeEach(() => {
-      postMessageStub = sandbox.stub();
+      postMessageStub = env.sandbox.stub();
       hostWindow = {postMessage: postMessageStub};
       client = new IframeMessagingClient(win, hostWindow);
       client.setSentinel('sentinel-123');
@@ -38,7 +38,7 @@ describes.realWin('iframe-messaging-client', {}, env => {
 
     describe('getData', () => {
       it('should get data', () => {
-        const callbackSpy = sandbox.spy();
+        const callbackSpy = env.sandbox.spy();
         client.getData('type-a', {a: 1}, callbackSpy);
         expect(postMessageStub).to.be.calledWith(
           serializeMessage(
@@ -67,7 +67,7 @@ describes.realWin('iframe-messaging-client', {}, env => {
       });
 
       it('should not get data with wrong messageId', () => {
-        const callbackSpy = sandbox.spy();
+        const callbackSpy = env.sandbox.spy();
         client.getData('type-a', {a: 1}, callbackSpy);
         expect(postMessageStub).to.be.calledWith(
           serializeMessage(
@@ -96,7 +96,7 @@ describes.realWin('iframe-messaging-client', {}, env => {
       });
 
       it('should not get data with wrong response type', () => {
-        const callbackSpy = sandbox.spy();
+        const callbackSpy = env.sandbox.spy();
         client.getData('type-a', {a: 1}, callbackSpy);
         expect(postMessageStub).to.be.calledWith(
           serializeMessage(
@@ -125,7 +125,7 @@ describes.realWin('iframe-messaging-client', {}, env => {
       });
 
       it('should have callback called once', () => {
-        const callbackSpy = sandbox.spy();
+        const callbackSpy = env.sandbox.spy();
         client.getData('type-a', {a: 1}, callbackSpy);
         expect(postMessageStub).to.be.calledWith(
           serializeMessage(
@@ -167,7 +167,7 @@ describes.realWin('iframe-messaging-client', {}, env => {
 
     describe('makeRequest', () => {
       it('should send the request via postMessage', () => {
-        const callbackSpy = sandbox.spy();
+        const callbackSpy = env.sandbox.spy();
         client.makeRequest('request-type', 'response-type', callbackSpy);
         expect(postMessageStub).to.be.calledWith(
           serializeMessage(
@@ -193,7 +193,7 @@ describes.realWin('iframe-messaging-client', {}, env => {
 
     describe('requestOnce', () => {
       it('should unlisten after message received', () => {
-        const callbackSpy = sandbox.spy();
+        const callbackSpy = env.sandbox.spy();
         client.requestOnce('request-type', 'response-type', callbackSpy);
         expect(postMessageStub).to.be.calledWith(
           serializeMessage(
@@ -222,7 +222,7 @@ describes.realWin('iframe-messaging-client', {}, env => {
         'should invoke callback on receiving a message of' +
           ' expected response type',
         () => {
-          const callbackSpy = sandbox.spy();
+          const callbackSpy = env.sandbox.spy();
           client.registerCallback('response-type', callbackSpy);
 
           postAmpMessage(
@@ -248,9 +248,9 @@ describes.realWin('iframe-messaging-client', {}, env => {
         'should invoke multiple callbacks on receiving a message of' +
           ' expected response type',
         () => {
-          const callbackSpy1 = sandbox.spy();
-          const callbackSpy2 = sandbox.spy();
-          const irrelevantCallbackSpy = sandbox.spy();
+          const callbackSpy1 = env.sandbox.spy();
+          const callbackSpy2 = env.sandbox.spy();
+          const irrelevantCallbackSpy = env.sandbox.spy();
 
           const expectedResponseObject = {
             type: 'response-type',
@@ -284,7 +284,7 @@ describes.realWin('iframe-messaging-client', {}, env => {
         'should not invoke callback on receiving a message of' +
           ' irrelevant response type',
         () => {
-          const callbackSpy = sandbox.spy();
+          const callbackSpy = env.sandbox.spy();
           client.registerCallback('response-type', callbackSpy);
 
           postAmpMessage(
@@ -296,7 +296,7 @@ describes.realWin('iframe-messaging-client', {}, env => {
       );
 
       it('should not invoke callback on receiving a non-AMP message', () => {
-        const callbackSpy = sandbox.spy();
+        const callbackSpy = env.sandbox.spy();
         client.registerCallback('response-type', callbackSpy);
 
         win.eventListeners.fire({
@@ -317,7 +317,7 @@ describes.realWin('iframe-messaging-client', {}, env => {
         'should not invoke callback on receiving a message ' +
           'not from host window',
         () => {
-          const callbackSpy = sandbox.spy();
+          const callbackSpy = env.sandbox.spy();
           client.registerCallback('response-type', callbackSpy);
           const randomWindow = {};
 
@@ -333,7 +333,7 @@ describes.realWin('iframe-messaging-client', {}, env => {
         'should not invoke callback on receiving a message ' +
           'containing no sentinel',
         () => {
-          const callbackSpy = sandbox.spy();
+          const callbackSpy = env.sandbox.spy();
           client.registerCallback('response-type', callbackSpy);
 
           postAmpMessage({type: 'response-type'}, hostWindow);
@@ -345,7 +345,7 @@ describes.realWin('iframe-messaging-client', {}, env => {
         'should not invoke callback on receiving a message ' +
           'containing wrong sentinel',
         () => {
-          const callbackSpy = sandbox.spy();
+          const callbackSpy = env.sandbox.spy();
           client.registerCallback('response-type', callbackSpy);
 
           postAmpMessage(
@@ -378,9 +378,9 @@ describes.realWin('iframe-messaging-client', {}, env => {
     let hostWindow2;
     let postMessageStub2;
     beforeEach(() => {
-      postMessageStub1 = sandbox.stub();
+      postMessageStub1 = env.sandbox.stub();
       hostWindow1 = {postMessage: postMessageStub1};
-      postMessageStub2 = sandbox.stub();
+      postMessageStub2 = env.sandbox.stub();
       hostWindow2 = {postMessage: postMessageStub2};
       win.parent = hostWindow1;
       hostWindow1.parent = hostWindow2;
@@ -392,7 +392,7 @@ describes.realWin('iframe-messaging-client', {}, env => {
 
     describe('makeRequest', () => {
       it('should broadcast the request via postMessage', () => {
-        const callbackSpy = sandbox.spy();
+        const callbackSpy = env.sandbox.spy();
         client.makeRequest('request-type', 'response-type', callbackSpy);
         expect(postMessageStub1).to.be.calledWith(
           serializeMessage(

--- a/test/unit/ads/test-adplugg.js
+++ b/test/unit/ads/test-adplugg.js
@@ -17,8 +17,7 @@
 import {adplugg} from '../../../ads/adplugg';
 import {createIframePromise} from '../../../testing/iframe';
 
-describes.fakeWin('amp-ad-adplugg-impl', {}, () => {
-  let sandbox;
+describes.fakeWin('amp-ad-adplugg-impl', {}, env => {
   let win;
   let testData;
 
@@ -27,7 +26,6 @@ describes.fakeWin('amp-ad-adplugg-impl', {}, () => {
    */
   beforeEach(() => {
     // Set up our test sandbox.
-    sandbox = sinon.sandbox;
     return createIframePromise(true).then(iframe => {
       // Simulate the iframe that adplugg will be called inside.
       win = iframe.win;
@@ -64,7 +62,6 @@ describes.fakeWin('amp-ad-adplugg-impl', {}, () => {
   afterEach(() => {
     // Reset window properties.
     win.context = {};
-    sandbox.restore();
   });
 
   describe('adplugg', () => {
@@ -105,13 +102,13 @@ describes.fakeWin('amp-ad-adplugg-impl', {}, () => {
 
     it('implement the renderStart API', () => {
       // Set up mocks, spys, etc.
-      const renderStartSpy = sandbox.stub(win.context, 'renderStart');
+      const renderStartSpy = env.sandbox.stub(win.context, 'renderStart');
       win.AdPlugg = {
         push: function() {},
         on: function() {},
       };
-      const AdPluggPushSpy = sandbox.spy(win.AdPlugg, 'push');
-      const AdPluggOnSpy = sandbox.spy(win.AdPlugg, 'on');
+      const AdPluggPushSpy = env.sandbox.spy(win.AdPlugg, 'push');
+      const AdPluggOnSpy = env.sandbox.spy(win.AdPlugg, 'on');
 
       // Call the function.
       adplugg(win, testData);
@@ -134,7 +131,7 @@ describes.fakeWin('amp-ad-adplugg-impl', {}, () => {
 
       // Get the listener function and spy on it
       const listenerFunc = args[2];
-      const listenerFuncSpy = sandbox.spy(listenerFunc);
+      const listenerFuncSpy = env.sandbox.spy(listenerFunc);
 
       // Call the listener function (with a mock Event)
       const event = win.document.createEvent('Event');
@@ -152,7 +149,7 @@ describes.fakeWin('amp-ad-adplugg-impl', {}, () => {
 
     it('implement the noContentAvailable API', () => {
       // Set up mocks, spys, etc.
-      const noContentAvailableSpy = sandbox.stub(
+      const noContentAvailableSpy = env.sandbox.stub(
         win.context,
         'noContentAvailable'
       );
@@ -160,8 +157,8 @@ describes.fakeWin('amp-ad-adplugg-impl', {}, () => {
         push: function() {},
         on: function() {},
       };
-      const AdPluggPushSpy = sandbox.spy(win.AdPlugg, 'push');
-      const AdPluggOnSpy = sandbox.spy(win.AdPlugg, 'on');
+      const AdPluggPushSpy = env.sandbox.spy(win.AdPlugg, 'push');
+      const AdPluggOnSpy = env.sandbox.spy(win.AdPlugg, 'on');
 
       // Call the function.
       adplugg(win, testData);
@@ -184,7 +181,7 @@ describes.fakeWin('amp-ad-adplugg-impl', {}, () => {
 
       // Get the listener function and spy on it
       const listenerFunc = args[2];
-      const listenerFuncSpy = sandbox.spy(listenerFunc);
+      const listenerFuncSpy = env.sandbox.spy(listenerFunc);
 
       // Call the listener function (with a mock Event)
       const event = win.document.createEvent('Event');

--- a/test/unit/ads/test-csa.js
+++ b/test/unit/ads/test-csa.js
@@ -48,12 +48,10 @@ function getAds(type) {
   }
 }
 
-describes.fakeWin('amp-ad-csa-impl', {}, () => {
-  let sandbox;
+describes.fakeWin('amp-ad-csa-impl', {}, env => {
   let win;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox;
     return createIframePromise(true).then(iframe => {
       win = iframe.win;
       win.context = {
@@ -76,7 +74,6 @@ describes.fakeWin('amp-ad-csa-impl', {}, () => {
 
   afterEach(() => {
     win.context = {};
-    sandbox.restore();
   });
 
   describe('inputs', () => {
@@ -92,11 +89,11 @@ describes.fakeWin('amp-ad-csa-impl', {}, () => {
 
     beforeEach(() => {
       // Stub everything out
-      sandbox.stub(_3p, 'loadScript').callsFake((global, url, callback) => {
+      env.sandbox.stub(_3p, 'loadScript').callsFake((global, url, callback) => {
         callback();
       });
       win._googCsa = function() {};
-      googCsaSpy = sandbox.stub(win, '_googCsa');
+      googCsaSpy = env.sandbox.stub(win, '_googCsa');
     });
 
     it('should request AFS', () => {
@@ -170,7 +167,7 @@ describes.fakeWin('amp-ad-csa-impl', {}, () => {
       setContainerHeight('300px');
       setContextHeight(100);
 
-      const requestResizeSpy = sandbox.stub(win.context, 'requestResize');
+      const requestResizeSpy = env.sandbox.stub(win.context, 'requestResize');
 
       // Try to resize when ads are loaded
       resizeIframe(win, 'csacontainer');
@@ -197,7 +194,7 @@ describes.fakeWin('amp-ad-csa-impl', {}, () => {
       setContextHeight(400);
 
       // Set up
-      const requestResizeSpy = sandbox.stub(win.context, 'requestResize');
+      const requestResizeSpy = env.sandbox.stub(win.context, 'requestResize');
       // Try to resize when ads are loaded
       resizeIframe(win, 'csacontainer');
 
@@ -222,7 +219,7 @@ describes.fakeWin('amp-ad-csa-impl', {}, () => {
       setContextHeight(100);
 
       // Set up
-      const requestResizeSpy = sandbox.stub(win.context, 'requestResize');
+      const requestResizeSpy = env.sandbox.stub(win.context, 'requestResize');
       // Try to resize when ads are loaded
       resizeIframe(win, 'csacontainer');
       // Resize requests below the fold succeeed
@@ -247,7 +244,7 @@ describes.fakeWin('amp-ad-csa-impl', {}, () => {
       setContextHeight(400);
 
       // Set up
-      const requestResizeSpy = sandbox.stub(win.context, 'requestResize');
+      const requestResizeSpy = env.sandbox.stub(win.context, 'requestResize');
       // Try to resize when ads are loaded
       resizeIframe(win, 'csacontainer');
       // Resize requests below the fold succeed
@@ -270,7 +267,7 @@ describes.fakeWin('amp-ad-csa-impl', {}, () => {
       setContextHeight(400);
 
       // Set up
-      const noAdsSpy = sandbox.stub(win.context, 'noContentAvailable');
+      const noAdsSpy = env.sandbox.stub(win.context, 'noContentAvailable');
       // No backfill, ads don't load
       callbackWithNoBackfill(win, 'csacontainer', false);
 
@@ -282,9 +279,9 @@ describes.fakeWin('amp-ad-csa-impl', {}, () => {
       setContextHeight(400);
 
       // Set up stubs and spys
-      const noAdsSpy = sandbox.stub(win.context, 'noContentAvailable');
+      const noAdsSpy = env.sandbox.stub(win.context, 'noContentAvailable');
       win._googCsa = function() {};
-      const _googCsaSpy = sandbox.stub(win, '_googCsa').callsFake(() => {});
+      const _googCsaSpy = env.sandbox.stub(win, '_googCsa').callsFake(() => {});
 
       // Ads don't load but there is backfill
       callbackWithBackfill(win, {}, {}, 'csacontainer', false);

--- a/test/unit/inabox/test-inabox-frame-overlay-manager.js
+++ b/test/unit/inabox/test-inabox-frame-overlay-manager.js
@@ -30,20 +30,15 @@ describes.fakeWin('inabox-host:FrameOverlayManager', {}, env => {
 
   beforeEach(() => {
     win = env.win;
-    addEventListenerSpy = sandbox.spy(win, 'addEventListener');
+    addEventListenerSpy = env.sandbox.spy(win, 'addEventListener');
 
     manager = new FrameOverlayManager(win);
-  });
-
-  afterEach(() => {
-    sandbox.reset();
-    sandbox.restore();
   });
 
   it('should listen to window resize event', () => {
     expect(addEventListenerSpy).to.have.been.calledWith(
       'resize',
-      sinon.match.any
+      env.sandbox.match.any
     );
   });
 
@@ -51,30 +46,36 @@ describes.fakeWin('inabox-host:FrameOverlayManager', {}, env => {
     const expandedRect = {a: 2, b: 3};
     const iframe = {};
 
-    const expandFrame = sandbox.spy((win, iframe, onFinish) => {
+    const expandFrame = env.sandbox.spy((win, iframe, onFinish) => {
       onFinish({}, expandedRect);
     });
 
-    const callback = sandbox.spy();
+    const callback = env.sandbox.spy();
 
     stubExpandFrameForTesting(expandFrame);
 
     manager.expandFrame(iframe, callback);
 
     expect(callback).to.have.been.calledWith(expandedRect);
-    expect(expandFrame).to.have.been.calledWith(win, iframe, sinon.match.any);
+    expect(expandFrame).to.have.been.calledWith(
+      win,
+      iframe,
+      env.sandbox.match.any
+    );
   });
 
   it('should collapse frame and execute callback with remeasured box', () => {
     const remeasuredCollapsedRect = {a: 2, b: 3};
     const iframe = {};
 
-    const collapseFrame = sandbox.spy((win, iframe, onFinish, onRemeasure) => {
-      onFinish();
-      onRemeasure(remeasuredCollapsedRect);
-    });
+    const collapseFrame = env.sandbox.spy(
+      (win, iframe, onFinish, onRemeasure) => {
+        onFinish();
+        onRemeasure(remeasuredCollapsedRect);
+      }
+    );
 
-    const callback = sandbox.spy();
+    const callback = env.sandbox.spy();
 
     stubCollapseFrameForTesting(collapseFrame);
     stubExpandFrameForTesting((win, iframe, onFinish) => onFinish({}, {}));
@@ -87,8 +88,8 @@ describes.fakeWin('inabox-host:FrameOverlayManager', {}, env => {
     expect(collapseFrame).to.have.been.calledWith(
       win,
       iframe,
-      sinon.match.any,
-      sinon.match.any
+      env.sandbox.match.any,
+      env.sandbox.match.any
     );
   });
 
@@ -97,12 +98,14 @@ describes.fakeWin('inabox-host:FrameOverlayManager', {}, env => {
 
     const iframe = {};
 
-    const collapseFrame = sandbox.spy((win, iframe, onFinish, onRemeasure) => {
-      onFinish();
-      onRemeasure({});
-    });
+    const collapseFrame = env.sandbox.spy(
+      (win, iframe, onFinish, onRemeasure) => {
+        onFinish();
+        onRemeasure({});
+      }
+    );
 
-    const callback = sandbox.spy();
+    const callback = env.sandbox.spy();
 
     stubCollapseFrameForTesting(collapseFrame);
     stubExpandFrameForTesting((win, iframe, onFinish) =>
@@ -116,8 +119,8 @@ describes.fakeWin('inabox-host:FrameOverlayManager', {}, env => {
     expect(collapseFrame).to.have.been.calledWith(
       win,
       iframe,
-      sinon.match.any,
-      sinon.match.any
+      env.sandbox.match.any,
+      env.sandbox.match.any
     );
   });
 });

--- a/test/unit/inabox/test-inabox-messaging-host.js
+++ b/test/unit/inabox/test-inabox-messaging-host.js
@@ -21,7 +21,6 @@ import {layoutRectLtwh} from '../../../src/layout-rect';
 describes.realWin('inabox-host:messaging', {}, env => {
   let win;
   let host;
-  let sandbox;
   let iframe1;
   let iframe2;
   let iframe3;
@@ -29,7 +28,6 @@ describes.realWin('inabox-host:messaging', {}, env => {
 
   beforeEach(() => {
     win = env.win;
-    sandbox = env.sandbox;
     iframe1 = win.document.createElement('iframe');
     iframe2 = win.document.createElement('iframe');
     iframe3 = win.document.createElement('iframe');
@@ -213,20 +211,24 @@ describes.realWin('inabox-host:messaging', {}, env => {
     let postMessageSpy;
 
     beforeEach(() => {
-      iframe1.contentWindow.postMessage = postMessageSpy = sandbox.stub();
+      iframe1.contentWindow.postMessage = postMessageSpy = env.sandbox.stub();
     });
 
     it('should send position back', () => {
-      sandbox.stub(host.positionObserver_, 'getViewportRect').callsFake(() => {
-        return layoutRectLtwh(10, 10, 100, 100);
-      });
-      sandbox.stub(host.positionObserver_, 'observe').callsFake(() => {});
+      env.sandbox
+        .stub(host.positionObserver_, 'getViewportRect')
+        .callsFake(() => {
+          return layoutRectLtwh(10, 10, 100, 100);
+        });
+      env.sandbox.stub(host.positionObserver_, 'observe').callsFake(() => {});
       iframe1.getBoundingClientRect = () => {
         return layoutRectLtwh(5, 5, 20, 20);
       };
-      sandbox.stub(host.positionObserver_, 'getTargetRect').callsFake(() => {
-        return iframe1.getBoundingClientRect();
-      });
+      env.sandbox
+        .stub(host.positionObserver_, 'getTargetRect')
+        .callsFake(() => {
+          return iframe1.getBoundingClientRect();
+        });
       host.processMessage({
         source: iframe1.contentWindow,
         origin: 'www.example.com',
@@ -264,7 +266,7 @@ describes.realWin('inabox-host:messaging', {}, env => {
         getTargetRect() {},
       };
 
-      iframe1.contentWindow.postMessage = postMessageSpy = sandbox.stub();
+      iframe1.contentWindow.postMessage = postMessageSpy = env.sandbox.stub();
     });
 
     it('should postMessage on position change', () => {
@@ -325,13 +327,13 @@ describes.realWin('inabox-host:messaging', {}, env => {
     let iframePostMessageSpy;
 
     beforeEach(() => {
-      iframe1.contentWindow.postMessage = iframePostMessageSpy = sandbox.stub();
+      iframe1.contentWindow.postMessage = iframePostMessageSpy = env.sandbox.stub();
     });
 
     it('should accept request and expand', () => {
       const boxRect = {a: 1, b: 2}; // we don't care
 
-      const expandFrame = sandbox
+      const expandFrame = env.sandbox
         ./*OK*/ stub(host.frameOverlayManager_, 'expandFrame')
         .callsFake((iframe, callback) => {
           callback(boxRect);
@@ -352,7 +354,7 @@ describes.realWin('inabox-host:messaging', {}, env => {
         iframePostMessageSpy.getCall(0).args[0]
       );
 
-      expect(expandFrame).calledWith(iframe1, sinon.match.any);
+      expect(expandFrame).calledWith(iframe1, env.sandbox.match.any);
       expect(message.type).to.equal('full-overlay-frame-response');
       expect(message.success).to.be.true;
       expect(message.boxRect).to.deep.equal(boxRect);
@@ -361,7 +363,7 @@ describes.realWin('inabox-host:messaging', {}, env => {
     it('should accept reset request and collapse', () => {
       const boxRect = {c: 1, d: 2}; // we don't care
 
-      const collapseFrame = sandbox
+      const collapseFrame = env.sandbox
         ./*OK*/ stub(host.frameOverlayManager_, 'collapseFrame')
         .callsFake((iframe, callback) => {
           callback(boxRect);
@@ -382,7 +384,7 @@ describes.realWin('inabox-host:messaging', {}, env => {
         iframePostMessageSpy.getCall(0).args[0]
       );
 
-      expect(collapseFrame).calledWith(iframe1, sinon.match.any);
+      expect(collapseFrame).calledWith(iframe1, env.sandbox.match.any);
       expect(message.type).to.equal('cancel-full-overlay-frame-response');
       expect(message.success).to.be.true;
       expect(message.boxRect).to.deep.equal(boxRect);
@@ -423,12 +425,12 @@ describes.realWin('inabox-host:messaging', {}, env => {
   }
 
   function breakCanInspectWindowForWindow(win) {
-    sandbox.defineProperty(win['location'], 'href', {
+    env.sandbox.defineProperty(win['location'], 'href', {
       get: () => {
         throw new Error('Error!!');
       },
     });
-    sandbox.defineProperty(win, 'test', {
+    env.sandbox.defineProperty(win, 'test', {
       get: () => {
         throw new Error('Error!!');
       },
@@ -554,7 +556,7 @@ describes.realWin('inabox-host:messaging', {}, env => {
       const frameMockB = iframeObjB.topWin.document.querySelectorAll()[0];
       const iframeObjC = createNestedIframeMocks(6, 0);
       const frameMockC = iframeObjC.topWin.document.querySelectorAll()[0];
-      const observeUnregisterMock = sandbox.spy();
+      const observeUnregisterMock = env.sandbox.spy();
       host = new InaboxMessagingHost(win, [frameMockA, frameMockB, frameMockC]);
       host.getFrameElement_(iframeObjA.source, 'sentinelA');
       host.getFrameElement_(iframeObjB.source, 'sentinelB');

--- a/test/unit/inabox/test-inabox-mutator.js
+++ b/test/unit/inabox/test-inabox-mutator.js
@@ -17,35 +17,33 @@ import {InaboxMutator} from '../../../src/inabox/inabox-mutator';
 import {Services} from '../../../src/services';
 
 describes.realWin('inabox-mutator', {amp: true}, env => {
-  let sandbox;
   let mutator;
   let resource;
   let element;
   let schedulePassStub;
 
   beforeEach(() => {
-    sandbox = env.sandbox;
     element = env.win.document.createElement('div');
 
     const resources = Services.resourcesForDoc(env.ampdoc);
-    sandbox.stub(resources, 'getResourceForElement').callsFake(el => {
+    env.sandbox.stub(resources, 'getResourceForElement').callsFake(el => {
       expect(el).to.equal(element);
       return resource;
     });
-    schedulePassStub = sandbox.stub(resources, 'schedulePass');
+    schedulePassStub = env.sandbox.stub(resources, 'schedulePass');
 
     mutator = new InaboxMutator(env.ampdoc, resources);
 
     resource = {
-      changeSize: sandbox.spy(),
-      completeExpand: sandbox.spy(),
-      completeCollapse: sandbox.spy(),
+      changeSize: env.sandbox.spy(),
+      completeExpand: env.sandbox.spy(),
+      completeCollapse: env.sandbox.spy(),
       getOwner: () => null,
     };
   });
 
   it('changeSize', async () => {
-    const callback = sandbox.spy();
+    const callback = env.sandbox.spy();
     mutator.changeSize(element, 12, 34, callback, {
       top: 4,
       right: 5,
@@ -105,7 +103,7 @@ describes.realWin('inabox-mutator', {amp: true}, env => {
   });
 
   it('measureElement', async () => {
-    const measurerSpy = sandbox.spy();
+    const measurerSpy = env.sandbox.spy();
     const resultPromise = mutator.measureElement(measurerSpy);
     env.flushVsync();
 
@@ -114,7 +112,7 @@ describes.realWin('inabox-mutator', {amp: true}, env => {
   });
 
   it('mutateElement', async () => {
-    const mutatorSpy = sandbox.spy();
+    const mutatorSpy = env.sandbox.spy();
     const resultPromise = mutator.mutateElement(element, mutatorSpy);
     env.flushVsync();
 
@@ -123,8 +121,8 @@ describes.realWin('inabox-mutator', {amp: true}, env => {
   });
 
   it('measureMutateElement', async () => {
-    const measurerSpy = sandbox.spy();
-    const mutatorSpy = sandbox.spy();
+    const measurerSpy = env.sandbox.spy();
+    const mutatorSpy = env.sandbox.spy();
     const resultPromise = mutator.measureMutateElement(
       element,
       measurerSpy,

--- a/test/unit/inabox/test-inabox-resources.js
+++ b/test/unit/inabox/test-inabox-resources.js
@@ -17,12 +17,10 @@ import {InaboxResources} from '../../../src/inabox/inabox-resources';
 
 describes.realWin('inabox-resources', {amp: true}, env => {
   let win;
-  let sandbox;
   let resources;
 
   beforeEach(() => {
     win = env.win;
-    sandbox = env.sandbox;
 
     resources = new InaboxResources(env.ampdoc);
   });
@@ -57,11 +55,11 @@ describes.realWin('inabox-resources', {amp: true}, env => {
   });
 
   it('upgraded', async () => {
-    const schedulePassSpy = sandbox.stub(resources, 'schedulePass');
+    const schedulePassSpy = env.sandbox.stub(resources, 'schedulePass');
     const element1 = env.createAmpElement('amp-foo');
     resources.add(element1);
     const resource1 = resources.getResourceForElement(element1);
-    const buildStub = sandbox.stub(resource1, 'build');
+    const buildStub = env.sandbox.stub(resource1, 'build');
     let resolveBuild;
     buildStub.returns(
       new Promise(resolve => {

--- a/test/unit/inabox/test-inabox-viewport.js
+++ b/test/unit/inabox/test-inabox-viewport.js
@@ -50,7 +50,7 @@ describes.fakeWin('inabox-viewport', {amp: {}}, env => {
   ) {
     const methodName = opt_once ? 'requestOnce' : 'makeRequest';
 
-    return sandbox
+    return env.sandbox
       ./*OK*/ stub(binding.iframeClient_, methodName)
       .callsFake((req, res, cb) => {
         expect(req).to.equal(requestType);
@@ -94,27 +94,23 @@ describes.fakeWin('inabox-viewport', {amp: {}}, env => {
     installIframeMessagingClient(win);
     installPlatformService(win);
     binding = new ViewportBindingInabox(win);
-    sandbox./*OK*/ stub(iframeHelper, 'canInspectWindow').returns(true);
+    env.sandbox./*OK*/ stub(iframeHelper, 'canInspectWindow').returns(true);
     bindingFriendly = new ViewportBindingInabox(win);
-    measureSpy = sandbox.spy();
+    measureSpy = env.sandbox.spy();
     element = {
       getBoundingClientRect() {
         return layoutRectLtwh(0, 0, 100, 100);
       },
       measure: measureSpy,
     };
-    sandbox
+    env.sandbox
       .stub(Services.resourcesForDoc(win.document), 'get')
       .returns([element]);
-    sandbox.stub(Services, 'resourcesPromiseForDoc').returns(
+    env.sandbox.stub(Services, 'resourcesPromiseForDoc').returns(
       new Promise(resolve => {
         resolve();
       })
     );
-  });
-
-  afterEach(() => {
-    sandbox.restore();
   });
 
   describe('should work for size, layoutRect and position observer', () => {
@@ -137,7 +133,7 @@ describes.fakeWin('inabox-viewport', {amp: {}}, env => {
 
     it('same domain', () => {
       binding = bindingFriendly;
-      sandbox
+      env.sandbox
         .stub(PositionObserver.prototype, 'observe')
         .callsFake((e, callback) => {
           topWindowObservable.add(() => callback({viewportRect, targetRect}));
@@ -155,8 +151,8 @@ describes.fakeWin('inabox-viewport', {amp: {}}, env => {
     });
 
     function testPositionCallback() {
-      onScrollCallback = sandbox.spy();
-      onResizeCallback = sandbox.spy();
+      onScrollCallback = env.sandbox.spy();
+      onResizeCallback = env.sandbox.spy();
       binding.onScroll(onScrollCallback);
       binding.onResize(onResizeCallback);
 
@@ -178,7 +174,7 @@ describes.fakeWin('inabox-viewport', {amp: {}}, env => {
       expect(binding.getLayoutRect(element)).to.deep.equal(
         layoutRectLtwh(10, 20, 100, 100)
       );
-      sandbox.reset();
+      env.sandbox.reset();
 
       // Scroll, viewport position changed
       positionCallback({
@@ -192,7 +188,7 @@ describes.fakeWin('inabox-viewport', {amp: {}}, env => {
       expect(binding.getLayoutRect(element)).to.deep.equal(
         layoutRectLtwh(10, 20, 100, 100)
       );
-      sandbox.reset();
+      env.sandbox.reset();
 
       // Resize, viewport size changed
       positionCallback({
@@ -206,11 +202,11 @@ describes.fakeWin('inabox-viewport', {amp: {}}, env => {
       expect(binding.getLayoutRect(element)).to.deep.equal(
         layoutRectLtwh(10, 20, 100, 100)
       );
-      sandbox.reset();
+      env.sandbox.reset();
 
       // DOM change, target position changed
-      sandbox.restore();
-      sandbox
+      env.sandbox.restore();
+      env.sandbox
         .stub(Services.resourcesForDoc(win.document), 'get')
         .returns([element]);
       positionCallback({
@@ -231,14 +227,14 @@ describes.fakeWin('inabox-viewport', {amp: {}}, env => {
     const allResourcesMock = Array(5)
       .fill(undefined)
       .map(() => ({
-        measure: sandbox.spy(),
+        measure: env.sandbox.spy(),
       }));
 
-    sandbox
+    env.sandbox
       .stub(binding, 'getChildResources')
       .callsFake(() => allResourcesMock);
 
-    const prepareContainer = sandbox
+    const prepareContainer = env.sandbox
       .stub(binding, 'prepareBodyForOverlay_')
       .returns(Promise.resolve());
 
@@ -272,7 +268,7 @@ describes.fakeWin('inabox-viewport', {amp: {}}, env => {
   });
 
   it('should reset content and request resize on leave overlay mode', () => {
-    const resetContainer = sandbox
+    const resetContainer = env.sandbox
       .stub(binding, 'resetBodyForOverlay_')
       .returns(Promise.resolve());
 
@@ -300,7 +296,7 @@ describes.fakeWin('inabox-viewport', {amp: {}}, env => {
       height: 300,
     };
 
-    const updateBoxRectStub = sandbox
+    const updateBoxRectStub = env.sandbox
       .stub(binding, 'updateBoxRect_')
       .callsFake(NOOP);
 
@@ -312,7 +308,9 @@ describes.fakeWin('inabox-viewport', {amp: {}}, env => {
       /* opt_once */ true
     );
 
-    sandbox.stub(binding, 'prepareBodyForOverlay_').returns(Promise.resolve());
+    env.sandbox
+      .stub(binding, 'prepareBodyForOverlay_')
+      .returns(Promise.resolve());
 
     yield binding.updateLightboxMode(true);
 
@@ -329,7 +327,7 @@ describes.fakeWin('inabox-viewport', {amp: {}}, env => {
       height: 300,
     };
 
-    const updateBoxRectStub = sandbox
+    const updateBoxRectStub = env.sandbox
       .stub(binding, 'updateBoxRect_')
       .callsFake(NOOP);
 
@@ -341,7 +339,9 @@ describes.fakeWin('inabox-viewport', {amp: {}}, env => {
       /* opt_once */ true
     );
 
-    sandbox.stub(binding, 'resetBodyForOverlay_').returns(Promise.resolve());
+    env.sandbox
+      .stub(binding, 'resetBodyForOverlay_')
+      .returns(Promise.resolve());
 
     yield binding.updateLightboxMode(false);
 
@@ -365,24 +365,24 @@ describes.fakeWin('inabox-viewport', {amp: {}}, env => {
       width: 40,
       height: 30,
     };
-    sandbox
+    env.sandbox
       .stub(FrameOverlayManager.prototype, 'expandFrame')
       .callsFake((i, callback) => {
         callback(boxRect);
       });
-    sandbox
+    env.sandbox
       .stub(FrameOverlayManager.prototype, 'collapseFrame')
       .callsFake((i, callback) => {
         callback(boxRect2);
       });
 
-    const updateBoxRectStub = sandbox
+    const updateBoxRectStub = env.sandbox
       .stub(bindingFriendly, 'updateBoxRect_')
       .callsFake(NOOP);
-    sandbox
+    env.sandbox
       .stub(bindingFriendly, 'prepareBodyForOverlay_')
       .returns(Promise.resolve());
-    sandbox
+    env.sandbox
       .stub(bindingFriendly, 'resetBodyForOverlay_')
       .returns(Promise.resolve());
 
@@ -402,8 +402,8 @@ describes.fakeWin('inabox-viewport', {amp: {}}, env => {
 
     const el = document.createElement('div');
 
-    sandbox.stub(win, 'innerWidth').callsFake(w);
-    sandbox.stub(win, 'innerHeight').callsFake(h);
+    env.sandbox.stub(win, 'innerWidth').callsFake(w);
+    env.sandbox.stub(win, 'innerHeight').callsFake(h);
 
     yield prepareBodyForOverlay(win, el);
 
@@ -453,7 +453,7 @@ describes.fakeWin('inabox-viewport', {amp: {}}, env => {
   });
 
   it('should request the position directly from host if friendly', () => {
-    sandbox
+    env.sandbox
       .stub(PositionObserver.prototype, 'getTargetRect')
       .returns(layoutRectLtwh(10, 20, 100, 100));
     return bindingFriendly.getRootClientRectAsync().then(rect => {
@@ -462,8 +462,11 @@ describes.fakeWin('inabox-viewport', {amp: {}}, env => {
   });
 
   it('should disconnect friendly listener and reconnect again properly', () => {
-    const unobserveFunction = sandbox.spy();
-    const observeFunction = sandbox.stub(PositionObserver.prototype, 'observe');
+    const unobserveFunction = env.sandbox.spy();
+    const observeFunction = env.sandbox.stub(
+      PositionObserver.prototype,
+      'observe'
+    );
     observeFunction.returns(unobserveFunction);
     return bindingFriendly
       .connect()

--- a/test/unit/inabox/test-position-observer.js
+++ b/test/unit/inabox/test-position-observer.js
@@ -63,9 +63,9 @@ describes.realWin('inabox-host:position-observer', {}, env => {
       viewportRect: layoutRectLtwh(0, 0, 200, 300),
       targetRect: layoutRectLtwh(3, 4, 30, 40),
     };
-    const callbackSpy11 = sandbox.stub();
-    const callbackSpy12 = sandbox.stub();
-    const callbackSpy21 = sandbox.stub();
+    const callbackSpy11 = env.sandbox.stub();
+    const callbackSpy12 = env.sandbox.stub();
+    const callbackSpy21 = env.sandbox.stub();
     observer.observe(target1, callbackSpy11);
     expect(callbackSpy11).to.be.calledWith(position1);
     observer.observe(target1, callbackSpy12);

--- a/test/unit/inabox/test-utils.js
+++ b/test/unit/inabox/test-utils.js
@@ -40,16 +40,16 @@ describes.realWin('inabox-utils', {}, env => {
     ampdoc = {win: env.win, getRootNode: () => ({})};
     iniLoadDeferred = new Deferred();
 
-    sandbox
+    env.sandbox
       .stub(IniLoad, 'whenContentIniLoad')
       .returns(iniLoadDeferred.promise);
-    sandbox
+    env.sandbox
       .stub(Services, 'viewportForDoc')
       .withArgs(ampdoc)
       .returns({getLayoutRect: () => ({})});
-    parentPostMessageStub = sandbox.stub();
-    dispatchEventStub = sandbox.stub();
-    initCustomEventStub = sandbox.stub();
+    parentPostMessageStub = env.sandbox.stub();
+    dispatchEventStub = env.sandbox.stub();
+    initCustomEventStub = env.sandbox.stub();
     env.win.parent = {postMessage: parentPostMessageStub};
     env.win.CustomEvent = (type, eventInit) => {
       initCustomEventStub(type, eventInit);

--- a/test/unit/test-3p.js
+++ b/test/unit/test-3p.js
@@ -24,17 +24,14 @@ import {
 } from '../../3p/3p';
 
 describe('3p', () => {
-  let sandbox;
   let clock;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox;
-    clock = sandbox.useFakeTimers();
+    clock = window.sandbox.useFakeTimers();
   });
 
   afterEach(() => {
     clock.tick(1000);
-    sandbox.restore();
   });
 
   describe('validateSrcPrefix()', () => {

--- a/test/unit/test-action.js
+++ b/test/unit/test-action.js
@@ -715,7 +715,7 @@ describes.fakeWin('Action hasResolvableAction', {amp: true}, env => {
   });
 });
 
-describes.sandboxed('Action method', {}, () => {
+describes.sandboxed('Action method', {}, env => {
   let action;
   let getDefaultActionAlias;
   let id;
@@ -724,8 +724,8 @@ describes.sandboxed('Action method', {}, () => {
 
   beforeEach(() => {
     action = actionService();
-    onEnqueue = sandbox.spy();
-    getDefaultActionAlias = sandbox.spy();
+    onEnqueue = env.sandbox.spy();
+    getDefaultActionAlias = env.sandbox.spy();
     targetElement = document.createElement('target');
     id = ('E' + Math.random()).replace('.', '');
     targetElement.setAttribute('on', 'tap:' + id + '.method1');
@@ -857,8 +857,8 @@ describes.sandboxed('Action method', {}, () => {
 
     it('should invoke proper action', () => {
       // Given that an amp action macro is triggered.
-      const invoke_ = sandbox.stub(action, 'invoke_');
-      sandbox
+      const invoke_ = env.sandbox.stub(action, 'invoke_');
+      env.sandbox
         .stub(action.root_, 'getElementById')
         .withArgs('action-macro-id')
         .returns(ampActionMacro);
@@ -899,7 +899,7 @@ describes.sandboxed('Action method', {}, () => {
   });
 });
 
-describes.sandboxed('installActionHandler', {}, () => {
+describes.sandboxed('installActionHandler', {}, env => {
   let action;
 
   beforeEach(() => {
@@ -907,7 +907,7 @@ describes.sandboxed('installActionHandler', {}, () => {
   });
 
   it('should invoke on non-AMP but whitelisted element', () => {
-    const handlerSpy = sandbox.spy();
+    const handlerSpy = env.sandbox.spy();
     const target = document.createElement('form');
     action.installActionHandler(target, handlerSpy);
     action.invoke_(
@@ -933,7 +933,7 @@ describes.sandboxed('installActionHandler', {}, () => {
   });
 
   it('should not check trust level (handler should check)', () => {
-    const handlerSpy = sandbox.spy();
+    const handlerSpy = env.sandbox.spy();
     const target = document.createElement('form');
     action.installActionHandler(target, handlerSpy);
 
@@ -955,7 +955,7 @@ describes.sandboxed('installActionHandler', {}, () => {
   });
 });
 
-describes.sandboxed('Multiple handlers action method', {}, () => {
+describes.sandboxed('Multiple handlers action method', {}, env => {
   let action;
   let getDefaultActionAlias;
   let onEnqueue1, onEnqueue2;
@@ -963,9 +963,9 @@ describes.sandboxed('Multiple handlers action method', {}, () => {
 
   beforeEach(() => {
     action = actionService();
-    onEnqueue1 = sandbox.spy();
-    onEnqueue2 = sandbox.spy();
-    getDefaultActionAlias = sandbox.spy();
+    onEnqueue1 = env.sandbox.spy();
+    onEnqueue2 = env.sandbox.spy();
+    getDefaultActionAlias = env.sandbox.spy();
     targetElement = document.createElement('target');
     targetElement.setAttribute('on', 'tap:foo.method1,bar.method2');
     parent = document.createElement('parent');
@@ -1009,14 +1009,14 @@ describes.sandboxed('Multiple handlers action method', {}, () => {
     const promiseAbc = new Promise(resolve => {
       resolveAbc = resolve;
     });
-    const abc = sandbox.stub().returns(promiseAbc);
+    const abc = env.sandbox.stub().returns(promiseAbc);
     action.addGlobalTarget('ABC', abc);
 
     let resolveXyz;
     const promiseXyz = new Promise(resolve => {
       resolveXyz = resolve;
     });
-    const xyz = sandbox.stub().returns(promiseXyz);
+    const xyz = env.sandbox.stub().returns(promiseXyz);
     action.addGlobalTarget('XYZ', xyz);
 
     const element = document.createElement('target');
@@ -1057,13 +1057,13 @@ describes.sandboxed('Multiple handlers action method', {}, () => {
   });
 });
 
-describes.sandboxed('Action interceptor', {}, () => {
+describes.sandboxed('Action interceptor', {}, env => {
   let clock;
   let action;
   let target;
 
   beforeEach(() => {
-    clock = sandbox.useFakeTimers();
+    clock = env.sandbox.useFakeTimers();
     action = actionService();
     target = document.createElement('target');
     target.setAttribute('id', 'amp-test-1');
@@ -1150,7 +1150,7 @@ describes.sandboxed('Action interceptor', {}, () => {
     expect(getActionHandler()).to.be.undefined;
     expect(getQueue()).to.have.length(2);
 
-    const handler = sandbox.spy();
+    const handler = env.sandbox.spy();
     action.installActionHandler(target, handler);
     expect(getActionHandler()).to.exist;
     expect(handler).to.have.not.been.called;
@@ -1193,7 +1193,7 @@ describes.sandboxed('Action interceptor', {}, () => {
   });
 });
 
-describes.sandboxed('Action common handler', {}, () => {
+describes.sandboxed('Action common handler', {}, env => {
   let action;
   let target;
 
@@ -1206,8 +1206,8 @@ describes.sandboxed('Action common handler', {}, () => {
   });
 
   it('should execute actions registered', () => {
-    const action1 = sandbox.spy();
-    const action2 = sandbox.spy();
+    const action1 = env.sandbox.spy();
+    const action2 = env.sandbox.spy();
     action.addGlobalMethodHandler('action1', action1);
     action.addGlobalMethodHandler('action2', action2);
 
@@ -1243,7 +1243,7 @@ describes.sandboxed('Action common handler', {}, () => {
   });
 
   it('should check trust before invoking action', () => {
-    const handler = sandbox.spy();
+    const handler = env.sandbox.spy();
     action.addGlobalMethodHandler('foo', handler, ActionTrust.HIGH);
 
     action.invoke_(
@@ -1276,7 +1276,7 @@ describes.sandboxed('Action common handler', {}, () => {
   });
 });
 
-describes.sandboxed('Action global target', {}, () => {
+describes.sandboxed('Action global target', {}, env => {
   let action;
 
   beforeEach(() => {
@@ -1284,8 +1284,8 @@ describes.sandboxed('Action global target', {}, () => {
   });
 
   it('should register global target', () => {
-    const target1 = sandbox.spy();
-    const target2 = sandbox.spy();
+    const target1 = env.sandbox.spy();
+    const target2 = env.sandbox.spy();
     const event = {};
     action.addGlobalTarget('target1', target1);
     action.addGlobalTarget('target2', target2);
@@ -1343,12 +1343,12 @@ describes.fakeWin('Core events', {amp: true}, env => {
   beforeEach(() => {
     window = env.win;
     document = window.document;
-    sandbox.stub(window.document, 'addEventListener');
+    env.sandbox.stub(window.document, 'addEventListener');
     const {ampdoc} = env;
     action = new ActionService(ampdoc, document);
     const originalTrigger = action.trigger;
     triggerPromise = new Promise((resolve, reject) => {
-      sandbox.stub(action, 'trigger').callsFake(() => {
+      env.sandbox.stub(action, 'trigger').callsFake(() => {
         try {
           originalTrigger.apply(action, action.trigger.getCall(0).args);
           resolve();
@@ -1384,7 +1384,7 @@ describes.fakeWin('Core events', {amp: true}, env => {
       const event = {
         target: element,
         key: Keys.ENTER,
-        preventDefault: sandbox.stub(),
+        preventDefault: env.sandbox.stub(),
       };
       handler(event);
       expect(event.preventDefault).to.not.have.been.called;
@@ -1405,7 +1405,7 @@ describes.fakeWin('Core events', {amp: true}, env => {
       const event = {
         target: element,
         key: Keys.ENTER,
-        preventDefault: sandbox.stub(),
+        preventDefault: env.sandbox.stub(),
       };
       handler(event);
       // Expect prevent default to have been called.
@@ -1428,7 +1428,7 @@ describes.fakeWin('Core events', {amp: true}, env => {
       const event = {
         target: element,
         key: Keys.ENTER,
-        preventDefault: sandbox.stub(),
+        preventDefault: env.sandbox.stub(),
       };
       handler(event);
       expect(event.preventDefault).to.not.have.been.called;
@@ -1496,7 +1496,7 @@ describes.fakeWin('Core events', {amp: true}, env => {
     expect(action.trigger).to.have.been.calledWith(
       element,
       'change',
-      sinon.match(
+      env.sandbox.match(
         object => object.detail.checked && object.detail.value == 'foo'
       )
     );
@@ -1514,7 +1514,7 @@ describes.fakeWin('Core events', {amp: true}, env => {
     expect(action.trigger).to.have.been.calledWith(
       element,
       'change',
-      sinon.match(e => {
+      env.sandbox.match(e => {
         const {min, max, value, valueAsNumber} = e.detail;
         return (
           min === '0' && max === '10' && value === '5' && valueAsNumber === 5
@@ -1533,7 +1533,7 @@ describes.fakeWin('Core events', {amp: true}, env => {
     expect(action.trigger).to.have.been.calledWith(
       element,
       'change',
-      sinon.match(e => e.detail.value == 'foo')
+      env.sandbox.match(e => e.detail.value == 'foo')
     );
   });
 
@@ -1550,7 +1550,7 @@ describes.fakeWin('Core events', {amp: true}, env => {
     expect(action.trigger).to.have.been.calledWith(
       element,
       'change',
-      sinon.match(object => {
+      env.sandbox.match(object => {
         const {detail} = object;
         return detail.value == 'qux';
       })
@@ -1567,7 +1567,7 @@ describes.fakeWin('Core events', {amp: true}, env => {
     expect(action.trigger).to.have.been.calledWith(
       element,
       'change',
-      sinon.match(object => {
+      env.sandbox.match(object => {
         const {detail} = object;
         return detail.value == 'foo';
       })
@@ -1575,7 +1575,7 @@ describes.fakeWin('Core events', {amp: true}, env => {
   });
 
   it('should trigger input-debounced event on input', () => {
-    sandbox.stub(action, 'invoke_');
+    env.sandbox.stub(action, 'invoke_');
     const handler = window.document.addEventListener.getCall(4).args[1];
     const element = document.createElement('input');
     element.id = 'test';
@@ -1589,7 +1589,7 @@ describes.fakeWin('Core events', {amp: true}, env => {
       expect(action.trigger).to.have.been.calledWith(
         element,
         'input-debounced',
-        sinon.match(event => {
+        env.sandbox.match(event => {
           const {value} = event.target;
           return value == 'foo bar baz';
         })
@@ -1598,7 +1598,7 @@ describes.fakeWin('Core events', {amp: true}, env => {
   });
 
   it('should trigger input-throttled event on input', () => {
-    sandbox.stub(action, 'invoke_');
+    env.sandbox.stub(action, 'invoke_');
     const handler = window.document.addEventListener.getCall(5).args[1];
     const element = document.createElement('input');
     element.id = 'test';
@@ -1612,7 +1612,7 @@ describes.fakeWin('Core events', {amp: true}, env => {
       expect(action.trigger).to.have.been.calledWith(
         element,
         'input-throttled',
-        sinon.match(event => {
+        env.sandbox.match(event => {
           const {value} = event.target;
           return value == 'foo bar baz';
         })
@@ -1766,7 +1766,7 @@ describes.realWin(
           'tap',
           'AMP'
         );
-        sandbox.stub(action, 'error_');
+        env.sandbox.stub(action, 'error_');
         expect(action.invoke_(i)).to.be.null;
         expect(action.error_).to.be.calledWith(
           '"AMP.print" is not whitelisted ' +
@@ -1813,7 +1813,7 @@ describes.realWin(
         'tap',
         'AMP'
       );
-      sandbox.stub(action, 'error_');
+      env.sandbox.stub(action, 'error_');
       expect(action.invoke_(i)).to.be.null;
       expect(action.error_).to.be.calledWith(
         '"AMP.print" is not whitelisted [].'

--- a/test/unit/test-activity.js
+++ b/test/unit/test-activity.js
@@ -26,7 +26,6 @@ import {installVsyncService} from '../../src/service/vsync-impl';
 import {markElementScheduledForTesting} from '../../src/service/custom-element-registry';
 
 describe('Activity getTotalEngagedTime', () => {
-  let sandbox;
   let clock;
   let fakeDoc;
   let fakeWin;
@@ -39,8 +38,7 @@ describe('Activity getTotalEngagedTime', () => {
   let scrollObservable;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox;
-    clock = sandbox.useFakeTimers();
+    clock = window.sandbox.useFakeTimers();
 
     // start at something other than 0
     clock.tick(123456);
@@ -109,15 +107,17 @@ describe('Activity getTotalEngagedTime', () => {
     const whenFirstVisiblePromise = new Promise(resolve => {
       whenFirstVisibleResolve = resolve;
     });
-    sandbox.stub(ampdoc, 'whenFirstVisible').returns(whenFirstVisiblePromise);
-    sandbox.stub(ampdoc, 'onVisibilityChanged').callsFake(handler => {
+    window.sandbox
+      .stub(ampdoc, 'whenFirstVisible')
+      .returns(whenFirstVisiblePromise);
+    window.sandbox.stub(ampdoc, 'onVisibilityChanged').callsFake(handler => {
       return visibilityObservable.add(handler);
     });
 
     installViewportServiceForDoc(ampdoc);
     viewport = Services.viewportForDoc(ampdoc);
 
-    sandbox.stub(viewport, 'onScroll').callsFake(handler => {
+    window.sandbox.stub(viewport, 'onScroll').callsFake(handler => {
       scrollObservable.add(handler);
     });
 
@@ -127,10 +127,6 @@ describe('Activity getTotalEngagedTime', () => {
     return Services.activityForDoc(ampdoc.getHeadNode()).then(a => {
       activity = a;
     });
-  });
-
-  afterEach(() => {
-    sandbox.restore();
   });
 
   it('should have 0 engaged time if there is no activity', () => {
@@ -176,7 +172,9 @@ describe('Activity getTotalEngagedTime', () => {
   });
 
   it('should not accumulate engaged time after inactivity', () => {
-    const isVisibleStub = sandbox.stub(ampdoc, 'isVisible').returns(true);
+    const isVisibleStub = window.sandbox
+      .stub(ampdoc, 'isVisible')
+      .returns(true);
     whenFirstVisibleResolve();
     return ampdoc.whenFirstVisible().then(() => {
       clock.tick(3000);
@@ -207,7 +205,10 @@ describe('Activity getTotalEngagedTime', () => {
     'should set event listeners on the document for' +
       ' "mousedown", "mouseup", "mousemove", "keyup", "keydown"',
     () => {
-      const addEventListenerSpy = sandbox.spy(fakeDoc, 'addEventListener');
+      const addEventListenerSpy = window.sandbox.spy(
+        fakeDoc,
+        'addEventListener'
+      );
       expect(addEventListenerSpy).to.not.have.been.calledWith(
         'mousedown',
         activity.boundHandleActivity_
@@ -241,7 +242,6 @@ describe('Activity getTotalEngagedTime', () => {
 });
 
 describe('Activity getIncrementalEngagedTime', () => {
-  let sandbox;
   let clock;
   let fakeDoc;
   let fakeWin;
@@ -254,8 +254,7 @@ describe('Activity getIncrementalEngagedTime', () => {
   let scrollObservable;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox;
-    clock = sandbox.useFakeTimers();
+    clock = window.sandbox.useFakeTimers();
 
     // start at something other than 0
     clock.tick(123456);
@@ -324,15 +323,17 @@ describe('Activity getIncrementalEngagedTime', () => {
     const whenFirstVisiblePromise = new Promise(resolve => {
       whenFirstVisibleResolve = resolve;
     });
-    sandbox.stub(ampdoc, 'whenFirstVisible').returns(whenFirstVisiblePromise);
-    sandbox.stub(ampdoc, 'onVisibilityChanged').callsFake(handler => {
+    window.sandbox
+      .stub(ampdoc, 'whenFirstVisible')
+      .returns(whenFirstVisiblePromise);
+    window.sandbox.stub(ampdoc, 'onVisibilityChanged').callsFake(handler => {
       return visibilityObservable.add(handler);
     });
 
     installViewportServiceForDoc(ampdoc);
     viewport = Services.viewportForDoc(ampdoc);
 
-    sandbox.stub(viewport, 'onScroll').callsFake(handler => {
+    window.sandbox.stub(viewport, 'onScroll').callsFake(handler => {
       scrollObservable.add(handler);
     });
 
@@ -342,10 +343,6 @@ describe('Activity getIncrementalEngagedTime', () => {
     return Services.activityForDoc(ampdoc.getHeadNode()).then(a => {
       activity = a;
     });
-  });
-
-  afterEach(() => {
-    sandbox.restore();
   });
 
   it('should have 0 seconds of incremental engaged time with no activity', () => {

--- a/test/unit/test-ad-cid.js
+++ b/test/unit/test-ad-cid.js
@@ -23,7 +23,6 @@ import {getAdCid} from '../../src/ad-cid';
 describes.realWin('ad-cid', {amp: true}, env => {
   const cidScope = 'cid-in-ads-test';
   const config = adConfig['_ping_'];
-  let sandbox;
 
   let cidService;
   let clock;
@@ -33,7 +32,6 @@ describes.realWin('ad-cid', {amp: true}, env => {
 
   beforeEach(() => {
     win = env.win;
-    sandbox = env.sandbox;
     clock = lolex.install({
       target: win,
       toFake: ['Date', 'setTimeout', 'clearTimeout'],
@@ -57,7 +55,7 @@ describes.realWin('ad-cid', {amp: true}, env => {
     config.clientIdScope = cidScope;
 
     let getCidStruct;
-    sandbox.stub(cidService, 'get').callsFake(struct => {
+    env.sandbox.stub(cidService, 'get').callsFake(struct => {
       getCidStruct = struct;
       return Promise.resolve('test123');
     });
@@ -76,7 +74,7 @@ describes.realWin('ad-cid', {amp: true}, env => {
     config.clientIdCookieName = 'different-cookie-name';
 
     let getCidStruct;
-    sandbox.stub(cidService, 'get').callsFake(struct => {
+    env.sandbox.stub(cidService, 'get').callsFake(struct => {
       getCidStruct = struct;
       return Promise.resolve('test123');
     });
@@ -92,7 +90,7 @@ describes.realWin('ad-cid', {amp: true}, env => {
 
   it('should return on timeout', () => {
     config.clientIdScope = cidScope;
-    sandbox.stub(cidService, 'get').callsFake(() => {
+    env.sandbox.stub(cidService, 'get').callsFake(() => {
       return Services.timerFor(win).promise(2000);
     });
     const p = getAdCid(adElement).then(cid => {
@@ -109,7 +107,7 @@ describes.realWin('ad-cid', {amp: true}, env => {
 
   it('should return undefined on failed CID', () => {
     config.clientIdScope = cidScope;
-    sandbox.stub(cidService, 'get').callsFake(() => {
+    env.sandbox.stub(cidService, 'get').callsFake(() => {
       return Promise.reject(new Error('nope'));
     });
     return expect(getAdCid(adElement)).to.eventually.be.undefined;

--- a/test/unit/test-alp-handler.js
+++ b/test/unit/test-alp-handler.js
@@ -18,7 +18,6 @@ import {handleClick, warmupDynamic, warmupStatic} from '../../ads/alp/handler';
 import {parseUrlDeprecated} from '../../src/url';
 
 describe('alp-handler', () => {
-  let sandbox;
   let event;
   let anchor;
   let open;
@@ -26,7 +25,6 @@ describe('alp-handler', () => {
   let image;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox;
     image = undefined;
     win = {
       location: {},
@@ -34,32 +32,32 @@ describe('alp-handler', () => {
       Image() {
         image = this;
       },
-      postMessage: sandbox.stub(),
+      postMessage: window.sandbox.stub(),
       _id: 'base-win',
     };
     win.parent = {
-      postMessage: sandbox.stub(),
+      postMessage: window.sandbox.stub(),
       _id: 'p0',
     };
     win.parent.parent = {
-      postMessage: sandbox.stub(),
+      postMessage: window.sandbox.stub(),
       _id: 'p1',
     };
     win.parent.parent.parent = {
-      postMessage: sandbox.stub(),
+      postMessage: window.sandbox.stub(),
       _id: 'p2',
     };
     win.parent.parent.parent.parent = {
-      postMessage: sandbox.stub(),
+      postMessage: window.sandbox.stub(),
       _id: 'p3',
     };
-    open = sandbox.stub(win, 'open').callsFake(() => {
+    open = window.sandbox.stub(win, 'open').callsFake(() => {
       return {};
     });
     const doc = {
       defaultView: win,
       head: {
-        appendChild: sandbox.spy(),
+        appendChild: window.sandbox.spy(),
       },
     };
     win.document = doc;
@@ -72,7 +70,7 @@ describe('alp-handler', () => {
           'https://cdn.ampproject.org/c/www.example.com/amp.html'
         ),
       ownerDocument: doc,
-      getAttribute: sandbox.stub(),
+      getAttribute: window.sandbox.stub(),
       get search() {
         return parseUrlDeprecated(this.href).search;
       },
@@ -81,13 +79,9 @@ describe('alp-handler', () => {
       trusted: true,
       buttons: 0,
       target: anchor,
-      preventDefault: sandbox.spy(),
+      preventDefault: window.sandbox.spy(),
       defaultPrevented: false,
     };
-  });
-
-  afterEach(() => {
-    sandbox.restore();
   });
 
   function simpleSuccess() {
@@ -196,7 +190,7 @@ describe('alp-handler', () => {
   });
 
   it('should perform special navigation if specially asked for', () => {
-    const navigateSpy = sandbox.spy();
+    const navigateSpy = window.sandbox.spy();
     const opt_navigate = val => {
       navigateSpy();
       expect(val).to.equal(

--- a/test/unit/test-amp-context.js
+++ b/test/unit/test-amp-context.js
@@ -23,11 +23,9 @@ describe('3p ampcontext.js', () => {
   let windowPostMessageSpy;
   let windowMessageHandler;
   let win;
-  let sandbox;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox;
-    windowPostMessageSpy = sandbox.spy();
+    windowPostMessageSpy = window.sandbox.spy();
     win = {
       addEventListener: (eventType, handlerFn) => {
         expect(eventType).to.equal('message');
@@ -53,7 +51,6 @@ describe('3p ampcontext.js', () => {
   });
 
   afterEach(() => {
-    sandbox.restore();
     win = undefined;
     windowMessageHandler = undefined;
   });
@@ -169,7 +166,7 @@ describe('3p ampcontext.js', () => {
   it('should be able to send an intersection observer request', () => {
     win.name = generateSerializedAttributes();
     const context = new AmpContext(win);
-    const callbackSpy = sandbox.spy();
+    const callbackSpy = window.sandbox.spy();
 
     // Resetting since a message is sent on construction.
     windowPostMessageSpy.resetHistory();
@@ -214,7 +211,7 @@ describe('3p ampcontext.js', () => {
   it('should send a pM and set callback when onPageVisibilityChange()', () => {
     win.name = generateSerializedAttributes();
     const context = new AmpContext(win);
-    const callbackSpy = sandbox.spy();
+    const callbackSpy = window.sandbox.spy();
     const stopObserving = context.onPageVisibilityChange(callbackSpy);
 
     // window.context should have sent postMessage asking for visibility
@@ -261,8 +258,8 @@ describe('3p ampcontext.js', () => {
     // Resetting since a message is sent on construction.
     windowPostMessageSpy.resetHistory();
 
-    const successCallbackSpy = sandbox.spy();
-    const deniedCallbackSpy = sandbox.spy();
+    const successCallbackSpy = window.sandbox.spy();
+    const deniedCallbackSpy = window.sandbox.spy();
 
     context.onResizeSuccess(successCallbackSpy);
     context.onResizeDenied(deniedCallbackSpy);
@@ -308,8 +305,8 @@ describe('3p ampcontext.js', () => {
     // Resetting since a message is sent on construction.
     windowPostMessageSpy.resetHistory();
 
-    const successCallbackSpy = sandbox.spy();
-    const deniedCallbackSpy = sandbox.spy();
+    const successCallbackSpy = window.sandbox.spy();
+    const deniedCallbackSpy = window.sandbox.spy();
 
     context.onResizeSuccess(successCallbackSpy);
     context.onResizeDenied(deniedCallbackSpy);

--- a/test/unit/test-amp-img.js
+++ b/test/unit/test-amp-img.js
@@ -24,7 +24,6 @@ import {createIframePromise} from '../../testing/iframe';
 import {toggleExperiment} from '../../src/experiments';
 
 describe('amp-img', () => {
-  let sandbox;
   let screenWidth;
   let windowWidth;
   let fixture;
@@ -33,11 +32,10 @@ describe('amp-img', () => {
                         /examples/img/hero@2x.jpg 1282w`;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox;
     screenWidth = 320;
     windowWidth = 320;
-    sandbox.stub(BaseElement.prototype, 'isInViewport').returns(true);
-    sandbox.stub(BaseElement.prototype, 'getViewport').callsFake(() => {
+    window.sandbox.stub(BaseElement.prototype, 'isInViewport').returns(true);
+    window.sandbox.stub(BaseElement.prototype, 'getViewport').callsFake(() => {
       return {
         getWidth: () => windowWidth,
       };
@@ -46,10 +44,6 @@ describe('amp-img', () => {
     return createIframePromise().then(iframeFixture => {
       fixture = iframeFixture;
     });
-  });
-
-  afterEach(() => {
-    sandbox.restore();
   });
 
   function getImg(attributes, children) {
@@ -115,7 +109,7 @@ describe('amp-img', () => {
       height: 200,
     }).then(ampImg => {
       const impl = ampImg.implementation_;
-      sandbox.stub(impl.preconnect, 'url');
+      window.sandbox.stub(impl.preconnect, 'url');
       impl.preconnectCallback(true);
       const preconnecturl = impl.preconnect.url;
       expect(preconnecturl.called).to.be.true;
@@ -145,7 +139,7 @@ describe('amp-img', () => {
       height: 200,
     }).then(ampImg => {
       const impl = ampImg.implementation_;
-      sandbox.stub(impl.preconnect, 'url');
+      window.sandbox.stub(impl.preconnect, 'url');
       impl.preconnectCallback(true);
       expect(impl.preconnect.url.called).to.be.true;
       expect(impl.preconnect.url).to.have.been.calledWith(
@@ -203,16 +197,16 @@ describe('amp-img', () => {
       el.setAttribute('width', 100);
       el.setAttribute('height', 100);
       el.getResources = () => Services.resourcesForDoc(document);
-      el.getPlaceholder = sandbox.stub();
+      el.getPlaceholder = window.sandbox.stub();
       impl = new AmpImg(el);
       impl.createdCallback();
-      sandbox.stub(impl, 'getLayoutWidth').returns(100);
+      window.sandbox.stub(impl, 'getLayoutWidth').returns(100);
       el.toggleFallback = function() {};
       el.togglePlaceholder = function() {};
-      toggleFallbackSpy = sandbox.spy(el, 'toggleFallback');
-      togglePlaceholderSpy = sandbox.spy(el, 'togglePlaceholder');
-      errorSpy = sandbox.spy(impl, 'onImgLoadingError_');
-      toggleSpy = sandbox.spy(impl, 'toggleFallback');
+      toggleFallbackSpy = window.sandbox.spy(el, 'toggleFallback');
+      togglePlaceholderSpy = window.sandbox.spy(el, 'togglePlaceholder');
+      errorSpy = window.sandbox.spy(impl, 'onImgLoadingError_');
+      toggleSpy = window.sandbox.spy(impl, 'toggleFallback');
 
       impl.getVsync = function() {
         return {
@@ -361,7 +355,7 @@ describe('amp-img', () => {
     el.setAttribute('aria-labelledby', 'id2');
     el.setAttribute('aria-describedby', 'id3');
 
-    el.getPlaceholder = sandbox.stub();
+    el.getPlaceholder = window.sandbox.stub();
     const impl = new AmpImg(el);
     impl.getAmpDoc = function() {
       return window.AMP.ampdoc;
@@ -455,7 +449,7 @@ describe('amp-img', () => {
         img.setAttribute('placeholder', '');
         el.getPlaceholder = () => img;
       } else {
-        el.getPlaceholder = sandbox.stub();
+        el.getPlaceholder = window.sandbox.stub();
       }
       if (addBlurClass) {
         img.classList.add('i-amphtml-blurry-placeholder');
@@ -463,8 +457,8 @@ describe('amp-img', () => {
       el.appendChild(img);
       el.getResources = () => Services.resourcesForDoc(document);
       const impl = new AmpImg(el);
-      sandbox.stub(impl, 'getLayoutWidth').returns(200);
-      impl.togglePlaceholder = sandbox.stub();
+      window.sandbox.stub(impl, 'getLayoutWidth').returns(200);
+      impl.togglePlaceholder = window.sandbox.stub();
       return impl;
     }
 
@@ -513,11 +507,11 @@ describe('amp-img', () => {
         el.setAttribute(key, attributes[key]);
       }
       el.getResources = () => Services.resourcesForDoc(document);
-      el.getPlaceholder = sandbox.stub();
+      el.getPlaceholder = window.sandbox.stub();
       const impl = new AmpImg(el);
       impl.createdCallback();
-      sandbox.stub(impl, 'getLayoutWidth').returns(layoutWidth);
-      sandbox.stub(impl, 'getLayout').returns(attributes['layout']);
+      window.sandbox.stub(impl, 'getLayoutWidth').returns(layoutWidth);
+      window.sandbox.stub(impl, 'getLayout').returns(attributes['layout']);
       el.toggleFallback = function() {};
       el.togglePlaceholder = function() {};
 

--- a/test/unit/test-amp-inabox.js
+++ b/test/unit/test-amp-inabox.js
@@ -21,25 +21,20 @@ import {installAmpdocServicesForInabox} from '../../src/inabox/inabox-services';
 
 describe('amp-inabox', () => {
   describes.realWin('installAmpdocServicesForInabox', {amp: false}, env => {
-    let sandbox;
-    beforeEach(() => {
-      sandbox = env.sandbox;
-    });
-
     it('should install same services for inabox', () => {
       let installedServices = [];
       const ampdoc = new AmpDocSingle(env.win);
-      sandbox
+      env.sandbox
         .stub(Service, 'registerServiceBuilderForDoc')
         .callsFake((ampdoc, id) => {
           installedServices.push(id);
         });
-      sandbox
+      env.sandbox
         .stub(Service, 'rejectServicePromiseForDoc')
         .callsFake((ampdoc, id) => {
           installedServices.push(id);
         });
-      sandbox.stub(Service, 'getServiceForDoc').returns({});
+      env.sandbox.stub(Service, 'getServiceForDoc').returns({});
       installAmpdocServices(ampdoc);
 
       const installedServicesByRegularAmp = installedServices.slice(0);

--- a/test/unit/test-amp-pixel.js
+++ b/test/unit/test-amp-pixel.js
@@ -28,7 +28,7 @@ describes.realWin('amp-pixel', {amp: true}, env => {
     whenFirstVisiblePromise = new Promise(resolve => {
       whenFirstVisibleResolver = resolve;
     });
-    sandbox
+    env.sandbox
       .stub(env.ampdoc, 'whenFirstVisible')
       .callsFake(() => whenFirstVisiblePromise);
     createPixel('https://pubads.g.doubleclick.net/activity;dc_iu=1/abc;ord=1?');
@@ -120,7 +120,7 @@ describes.realWin('amp-pixel', {amp: true}, env => {
   });
 
   it('should replace URL parameters', () => {
-    sandbox.stub(Math, 'random').callsFake(() => 111);
+    env.sandbox.stub(Math, 'random').callsFake(() => 111);
     const url = 'https://pubads.g.doubleclick.net/activity;r=RANDOM';
     return trigger(url).then(img => {
       expect(img.src).to.equal(
@@ -174,7 +174,7 @@ describes.realWin(
       whenFirstVisiblePromise = new Promise(resolve => {
         whenFirstVisibleResolver = resolve;
       });
-      sandbox
+      env.sandbox
         .stub(env.ampdoc, 'whenFirstVisible')
         .callsFake(() => whenFirstVisiblePromise);
 

--- a/test/unit/test-ampdoc.js
+++ b/test/unit/test-ampdoc.js
@@ -470,7 +470,7 @@ describes.sandboxed('AmpDocService', {}, () => {
   });
 });
 
-describes.sandboxed('AmpDoc.visibilityState', {}, () => {
+describes.sandboxed('AmpDoc.visibilityState', {}, env => {
   const EMBED_URL = 'https://example.com/embed';
   let clock;
   let win, doc;
@@ -478,22 +478,22 @@ describes.sandboxed('AmpDoc.visibilityState', {}, () => {
   let top, embedSameWindow, embedOtherWindow, embedChild;
 
   beforeEach(() => {
-    clock = sandbox.useFakeTimers();
+    clock = env.sandbox.useFakeTimers();
     clock.tick(1);
 
     doc = {
       body: null,
       visibilityState: 'visible',
-      addEventListener: sandbox.spy(),
-      removeEventListener: sandbox.spy(),
+      addEventListener: env.sandbox.spy(),
+      removeEventListener: env.sandbox.spy(),
     };
     win = {document: doc};
 
     childDoc = {
       body: null,
       visibilityState: 'visible',
-      addEventListener: sandbox.spy(),
-      removeEventListener: sandbox.spy(),
+      addEventListener: env.sandbox.spy(),
+      removeEventListener: env.sandbox.spy(),
     };
     childWin = {document: childDoc};
 
@@ -846,7 +846,7 @@ describes.sandboxed('AmpDoc.visibilityState', {}, () => {
   });
 });
 
-describes.sandboxed('AmpDocSingle', {}, () => {
+describes.sandboxed('AmpDocSingle', {}, env => {
   let ampdoc;
 
   beforeEach(() => {
@@ -895,17 +895,17 @@ describes.sandboxed('AmpDocSingle', {}, () => {
     const win = {document: doc};
 
     let bodyCallback;
-    sandbox.stub(dom, 'waitForBodyOpenPromise').callsFake(() => {
+    env.sandbox.stub(dom, 'waitForBodyOpenPromise').callsFake(() => {
       return new Promise(resolve => {
         bodyCallback = resolve;
       });
     });
     let ready = false;
-    sandbox.stub(docready, 'isDocumentReady').callsFake(() => {
+    env.sandbox.stub(docready, 'isDocumentReady').callsFake(() => {
       return ready;
     });
     let readyCallback;
-    sandbox.stub(docready, 'whenDocumentReady').callsFake(() => {
+    env.sandbox.stub(docready, 'whenDocumentReady').callsFake(() => {
       return new Promise(resolve => {
         readyCallback = resolve;
       });

--- a/test/unit/test-analytics.js
+++ b/test/unit/test-analytics.js
@@ -28,7 +28,6 @@ describes.realWin(
     amp: true,
   },
   env => {
-    let sandbox;
     let timer;
     let ampdoc;
 
@@ -42,15 +41,10 @@ describes.realWin(
       }
 
       beforeEach(() => {
-        sandbox = sinon.sandbox;
         timer = Services.timerFor(env.win);
         ampdoc = env.ampdoc;
-        triggerEventSpy = sandbox.spy();
+        triggerEventSpy = env.sandbox.spy();
         resetServiceForTesting(window, 'amp-analytics-instrumentation');
-      });
-
-      afterEach(() => {
-        sandbox.restore();
       });
 
       it('should not do anything if analytics is not installed', () => {

--- a/test/unit/test-animation.js
+++ b/test/unit/test-animation.js
@@ -17,7 +17,6 @@
 import {Animation} from '../../src/animation';
 
 describe('Animation', () => {
-  let sandbox;
   let vsync;
   let vsyncTasks;
   let anim;
@@ -25,8 +24,7 @@ describe('Animation', () => {
   let contextNode;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox;
-    clock = sandbox.useFakeTimers();
+    clock = window.sandbox.useFakeTimers();
     vsyncTasks = [];
     vsync = {
       canAnimate: () => true,
@@ -42,7 +40,6 @@ describe('Animation', () => {
 
   afterEach(() => {
     expect(vsyncTasks.length).to.equal(0);
-    sandbox.restore();
   });
 
   function runVsync() {

--- a/test/unit/test-base-element.js
+++ b/test/unit/test-base-element.js
@@ -42,7 +42,7 @@ describes.realWin('BaseElement', {amp: true}, env => {
   it('should delegate update priority to resources', () => {
     const resources = win.__AMP_SERVICES.resources.obj;
     customElement.getResources = () => resources;
-    const updateLayoutPriorityStub = sandbox.stub(
+    const updateLayoutPriorityStub = env.sandbox.stub(
       resources,
       'updateLayoutPriority'
     );
@@ -106,7 +106,7 @@ describes.realWin('BaseElement', {amp: true}, env => {
   });
 
   it('should execute registered action', () => {
-    const handler = sandbox.spy();
+    const handler = env.sandbox.spy();
     element.registerAction('method1', handler);
     const invocation = {method: 'method1', satisfiesTrust: () => true};
     element.executeAction(invocation, null, false);
@@ -114,7 +114,7 @@ describes.realWin('BaseElement', {amp: true}, env => {
   });
 
   it('should execute default method by "activate"', () => {
-    const handler = sandbox.spy();
+    const handler = env.sandbox.spy();
     element.registerDefaultAction(handler);
     const invocation = {method: DEFAULT_ACTION, satisfiesTrust: () => true};
     element.executeAction(invocation, null, false);
@@ -122,8 +122,8 @@ describes.realWin('BaseElement', {amp: true}, env => {
   });
 
   it('should not allow two default actions', () => {
-    const handler = sandbox.spy();
-    const anotherHandler = sandbox.spy();
+    const handler = env.sandbox.spy();
+    const anotherHandler = env.sandbox.spy();
     element.registerDefaultAction(handler);
     return allowConsoleError(() => {
       expect(() => {
@@ -133,7 +133,7 @@ describes.realWin('BaseElement', {amp: true}, env => {
   });
 
   it('should check trust before invocation', () => {
-    const handler = sandbox.spy();
+    const handler = env.sandbox.spy();
     const minTrust = 100;
     element.foo = () => {};
     element.registerDefaultAction(handler, 'foo', minTrust);
@@ -174,14 +174,16 @@ describes.realWin('BaseElement', {amp: true}, env => {
     const resources = win.__AMP_SERVICES.resources.obj;
     customElement.getResources = () => resources;
     const resource = new Resource(1, customElement, resources);
-    sandbox
+    env.sandbox
       .stub(resources, 'getResourceForElement')
       .withArgs(customElement)
       .returns(resource);
     const layoutBox = layoutRectLtwh(0, 50, 100, 200);
     const pageLayoutBox = layoutRectLtwh(0, 0, 100, 200);
-    sandbox.stub(resource, 'getLayoutBox').callsFake(() => layoutBox);
-    sandbox.stub(resource, 'getPageLayoutBox').callsFake(() => pageLayoutBox);
+    env.sandbox.stub(resource, 'getLayoutBox').callsFake(() => layoutBox);
+    env.sandbox
+      .stub(resource, 'getPageLayoutBox')
+      .callsFake(() => pageLayoutBox);
     expect(element.getLayoutBox()).to.eql(layoutBox);
     expect(customElement.getLayoutBox()).to.eql(layoutBox);
     expect(element.getPageLayoutBox()).to.eql(pageLayoutBox);

--- a/test/unit/test-batched-json.js
+++ b/test/unit/test-batched-json.js
@@ -19,7 +19,6 @@ import {UrlReplacementPolicy, batchFetchJsonFor} from '../../src/batched-json';
 import {user} from '../../src/log';
 
 describe('batchFetchJsonFor', () => {
-  let sandbox;
   // Fakes.
   const ampdoc = {win: null};
   // Service fakes.
@@ -42,25 +41,21 @@ describe('batchFetchJsonFor', () => {
   }
 
   beforeEach(() => {
-    sandbox = sinon.sandbox;
-
     urlReplacements = {
-      expandUrlAsync: sandbox.stub(),
-      collectUnwhitelistedVarsSync: sandbox.stub(),
+      expandUrlAsync: window.sandbox.stub(),
+      collectUnwhitelistedVarsSync: window.sandbox.stub(),
     };
-    sandbox.stub(Services, 'urlReplacementsForDoc').returns(urlReplacements);
+    window.sandbox
+      .stub(Services, 'urlReplacementsForDoc')
+      .returns(urlReplacements);
 
-    fetchJson = sandbox.stub().returns(
+    fetchJson = window.sandbox.stub().returns(
       Promise.resolve({
         json: () => Promise.resolve(data),
       })
     );
     batchedXhr = {fetchJson};
-    sandbox.stub(Services, 'batchedXhrFor').returns(batchedXhr);
-  });
-
-  afterEach(() => {
-    sandbox.restore();
+    window.sandbox.stub(Services, 'batchedXhrFor').returns(batchedXhr);
   });
 
   describe('URL replacement', () => {
@@ -102,7 +97,7 @@ describe('batchFetchJsonFor', () => {
         .withArgs('https://data.com?x=FOO&y=BAR')
         .returns(Promise.resolve('https://data.com?x=abc&y=BAR'));
 
-      const userError = sandbox.stub(user(), 'error');
+      const userError = window.sandbox.stub(user(), 'error');
       const all = UrlReplacementPolicy.ALL;
       return batchFetchJsonFor(ampdoc, el, {urlReplacement: all}).then(() => {
         expect(fetchJson).to.be.calledWith('https://data.com?x=abc&y=BAR');

--- a/test/unit/test-cache-cid-api.js
+++ b/test/unit/test-cache-cid-api.js
@@ -66,114 +66,57 @@ describes.realWin('cacheCidApi', {amp: true}, env => {
     });
   });
 
-  describe('getScopedCid', () => {
-    beforeEach(() => {
-      viewerMock.isCctEmbedded.returns(true);
-      viewerMock.isProxyOrigin.returns(true);
-    });
-
-    it('should use client ID API from api if everything great', () => {
-      fetchJsonStub.returns(
-        Promise.resolve({
-          json: () => {
-            return Promise.resolve({
-              publisherClientId: 'publisher-client-id-from-cache',
-            });
-          },
-        })
-      );
-      return api.getScopedCid('AMP_ECID_GOOGLE').then(cid => {
-        expect(cid).to.equal(
-          'amp-mJW1ZjoviqBJydzRI8KnitWEpqyhQqDegGCl' +
-            'rvvfkCif_N9oYLdZEB976uJDhYgL'
-        );
-        expect(fetchJsonStub).to.be.calledWith(
-          'https://ampcid.google.com/v1/cache:getClientId?key=AIzaSyDKtqGxnoeIqVM33Uf7hRSa3GJxuzR7mLc',
-          {
-            method: 'POST',
-            ampCors: false,
-            credentials: 'include',
-            mode: 'cors',
-            body: {
-              publisherOrigin: 'about:srcdoc',
-            },
-          }
-        );
+  // TODO(amphtml, #25621): Cannot find atob / btoa on Safari on Sauce Labs.
+  describe
+    .configure()
+    .skipSafari()
+    .run('getScopedCid', () => {
+      beforeEach(() => {
+        viewerMock.isCctEmbedded.returns(true);
+        viewerMock.isProxyOrigin.returns(true);
       });
-    });
 
-    it('should return null if opted out', () => {
-      fetchJsonStub.returns(
-        Promise.resolve({
-          json: () => {
-            return Promise.resolve({
-              optOut: true,
-            });
-          },
-        })
-      );
-      return api.getScopedCid('AMP_ECID_GOOGLE').then(cid => {
-        expect(cid).to.equal(null);
-        expect(fetchJsonStub).to.be.calledWith(
-          'https://ampcid.google.com/v1/cache:getClientId?key=AIzaSyDKtqGxnoeIqVM33Uf7hRSa3GJxuzR7mLc',
-          {
-            method: 'POST',
-            ampCors: false,
-            credentials: 'include',
-            mode: 'cors',
-            body: {
-              publisherOrigin: 'about:srcdoc',
-            },
-          }
-        );
-      });
-    });
-
-    it('should try alternative url if API provides', () => {
-      fetchJsonStub.onCall(0).returns(
-        Promise.resolve({
-          json: () => {
-            return Promise.resolve({
-              alternateUrl: 'https://ampcid.google.co.uk/v1/cache:getClientId',
-            });
-          },
-        })
-      );
-      fetchJsonStub.onCall(1).returns(
-        Promise.resolve({
-          json: () => {
-            return Promise.resolve({
-              publisherClientId: 'publisher-client-id-from-cache',
-            });
-          },
-        })
-      );
-      return api.getScopedCid('AMP_ECID_GOOGLE').then(cid => {
-        expect(cid).to.equal(
-          'amp-mJW1ZjoviqBJydzRI8KnitWEpqyhQqDegGCl' +
-            'rvvfkCif_N9oYLdZEB976uJDhYgL'
-        );
-        expect(fetchJsonStub.getCall(1).args[0]).to.equal(
-          'https://ampcid.google.co.uk/v1/cache:getClientId?key=AIzaSyDKtqGxnoeIqVM33Uf7hRSa3GJxuzR7mLc'
-        );
-      });
-    });
-
-    it('should fail if the request times out', () => {
-      fetchJsonStub.callsFake(() => {
-        return new Promise((resolve, unused) => {
-          clock.setTimeout(resolve, 35000, {
+      it('should use client ID API from api if everything great', () => {
+        fetchJsonStub.returns(
+          Promise.resolve({
             json: () => {
               return Promise.resolve({
                 publisherClientId: 'publisher-client-id-from-cache',
               });
             },
-          });
+          })
+        );
+        return api.getScopedCid('AMP_ECID_GOOGLE').then(cid => {
+          expect(cid).to.equal(
+            'amp-mJW1ZjoviqBJydzRI8KnitWEpqyhQqDegGCl' +
+              'rvvfkCif_N9oYLdZEB976uJDhYgL'
+          );
+          expect(fetchJsonStub).to.be.calledWith(
+            'https://ampcid.google.com/v1/cache:getClientId?key=AIzaSyDKtqGxnoeIqVM33Uf7hRSa3GJxuzR7mLc',
+            {
+              method: 'POST',
+              ampCors: false,
+              credentials: 'include',
+              mode: 'cors',
+              body: {
+                publisherOrigin: 'about:srcdoc',
+              },
+            }
+          );
         });
       });
-      const response = api
-        .getScopedCid('AMP_ECID_GOOGLE')
-        .then(cid => {
+
+      it('should return null if opted out', () => {
+        fetchJsonStub.returns(
+          Promise.resolve({
+            json: () => {
+              return Promise.resolve({
+                optOut: true,
+              });
+            },
+          })
+        );
+        return api.getScopedCid('AMP_ECID_GOOGLE').then(cid => {
           expect(cid).to.equal(null);
           expect(fetchJsonStub).to.be.calledWith(
             'https://ampcid.google.com/v1/cache:getClientId?key=AIzaSyDKtqGxnoeIqVM33Uf7hRSa3GJxuzR7mLc',
@@ -187,10 +130,72 @@ describes.realWin('cacheCidApi', {amp: true}, env => {
               },
             }
           );
-        })
-        .catch(() => {});
-      clock.tick(30000);
-      return response;
+        });
+      });
+
+      it('should try alternative url if API provides', () => {
+        fetchJsonStub.onCall(0).returns(
+          Promise.resolve({
+            json: () => {
+              return Promise.resolve({
+                alternateUrl:
+                  'https://ampcid.google.co.uk/v1/cache:getClientId',
+              });
+            },
+          })
+        );
+        fetchJsonStub.onCall(1).returns(
+          Promise.resolve({
+            json: () => {
+              return Promise.resolve({
+                publisherClientId: 'publisher-client-id-from-cache',
+              });
+            },
+          })
+        );
+        return api.getScopedCid('AMP_ECID_GOOGLE').then(cid => {
+          expect(cid).to.equal(
+            'amp-mJW1ZjoviqBJydzRI8KnitWEpqyhQqDegGCl' +
+              'rvvfkCif_N9oYLdZEB976uJDhYgL'
+          );
+          expect(fetchJsonStub.getCall(1).args[0]).to.equal(
+            'https://ampcid.google.co.uk/v1/cache:getClientId?key=AIzaSyDKtqGxnoeIqVM33Uf7hRSa3GJxuzR7mLc'
+          );
+        });
+      });
+
+      it('should fail if the request times out', () => {
+        fetchJsonStub.callsFake(() => {
+          return new Promise((resolve, unused) => {
+            clock.setTimeout(resolve, 35000, {
+              json: () => {
+                return Promise.resolve({
+                  publisherClientId: 'publisher-client-id-from-cache',
+                });
+              },
+            });
+          });
+        });
+        const response = api
+          .getScopedCid('AMP_ECID_GOOGLE')
+          .then(cid => {
+            expect(cid).to.equal(null);
+            expect(fetchJsonStub).to.be.calledWith(
+              'https://ampcid.google.com/v1/cache:getClientId?key=AIzaSyDKtqGxnoeIqVM33Uf7hRSa3GJxuzR7mLc',
+              {
+                method: 'POST',
+                ampCors: false,
+                credentials: 'include',
+                mode: 'cors',
+                body: {
+                  publisherOrigin: 'about:srcdoc',
+                },
+              }
+            );
+          })
+          .catch(() => {});
+        clock.tick(30000);
+        return response;
+      });
     });
-  });
 });

--- a/test/unit/test-cache-cid-api.js
+++ b/test/unit/test-cache-cid-api.js
@@ -22,17 +22,15 @@ import {mockServiceForDoc, stubService} from '../../testing/test-helper';
 describes.realWin('cacheCidApi', {amp: true}, env => {
   let ampdoc;
   let api;
-  let sandbox;
   let viewerMock;
   let fetchJsonStub;
   let clock;
 
   beforeEach(() => {
     ampdoc = env.ampdoc;
-    sandbox = env.sandbox;
     fetchJsonStub = stubService(env.sandbox, env.win, 'xhr', 'fetchJson');
 
-    viewerMock = mockServiceForDoc(sandbox, ampdoc, 'viewer', [
+    viewerMock = mockServiceForDoc(env.sandbox, ampdoc, 'viewer', [
       'isCctEmbedded',
       'isProxyOrigin',
     ]);

--- a/test/unit/test-chunk.js
+++ b/test/unit/test-chunk.js
@@ -392,7 +392,7 @@ describe('long tasks', () => {
       beforeEach(() => {
         postMessageCalls = 0;
         subscriptions = {};
-        clock = sandbox.useFakeTimers();
+        clock = env.sandbox.useFakeTimers();
         installDocService(env.win, /* isSingleDoc */ true);
         toggleExperiment(env.win, 'macro-after-long-task', true);
 
@@ -488,12 +488,10 @@ describe('onIdle', () => {
   let win;
   let calls;
   let callbackCalled;
-  let sandbox;
   let clock;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox;
-    clock = sandbox.useFakeTimers();
+    clock = window.sandbox.useFakeTimers();
     calls = [];
     callbackCalled = false;
     win = {
@@ -509,10 +507,6 @@ describe('onIdle', () => {
         });
       },
     };
-  });
-
-  afterEach(() => {
-    sandbox.restore();
   });
 
   function markCalled() {

--- a/test/unit/test-cid.js
+++ b/test/unit/test-cid.js
@@ -152,611 +152,632 @@ describes.sandboxed('cid', {}, env => {
     window.localStorage.removeItem('amp-cid');
   });
 
-  describe('with real crypto', () => {
-    it('should hash domain name and scope', () => {
-      // domain name: 'http://www.origin.com'
-      // scope: 'custom-cid-scope'
-      return compare(
-        'custom-cid-scope',
-        'tSSEaSFEU2-vkEO0Mb9HZejJui-npGRhXf3fD3H3iWeYQrjkQOTaRYdPyFTogNXA'
-      );
-    });
-
-    it('should hash domain name and scope', () => {
-      fakeWin.location.href =
-        'https://cdn.ampproject.org/v/www.DIFFERENT.com/foo/?f=0';
-      // domain name: 'http://www.different.com'
-      // scope: 'another-custom-cid-scope'
-      return compare(
-        'another-custom-cid-scope',
-        '25lYHB6Luck8Z5ddpiB-FBbj2pa9zx3WdnJlZVgFneJRcFsDT3kIoPoi6k6-oxrB'
-      );
-    });
-  });
-
-  describe('with crypto stub', () => {
-    const doesNotProvideError = '[CID] Viewer does not provide cap=cid';
-    const invalidFormatError = '[CID] invalid cid format';
-    beforeEach(() => {
-      crypto.sha384Base64 = val => {
-        if (val instanceof Uint8Array) {
-          val = '[' + Array.apply([], val).join(',') + ']';
-        }
-
-        return Promise.resolve('sha384(' + val + ')');
-      };
-    });
-
-    it('should depend on external id e1', () => {
-      clock.tick(123);
-      return compare(
-        'e1',
-        'sha384(sha384([1,2,3,0,0,0,0,0,0,0,0,0,0,0,0,15])http://www.origin.come1)'
-      ).then(() => {
-        expect(storage['amp-cid']).to.be.string;
-        const stored = JSON.parse(storage['amp-cid']);
-        expect(stored.cid).to.equal(
-          'sha384([1,2,3,0,0,0,0,0,0,0,0,0,0,0,0,15])'
+  // TODO(amphtml, #25621): Cannot find atob / btoa on Safari on Sauce Labs.
+  describe
+    .configure()
+    .skipSafari()
+    .run('with real crypto', () => {
+      it('should hash domain name and scope', () => {
+        // domain name: 'http://www.origin.com'
+        // scope: 'custom-cid-scope'
+        return compare(
+          'custom-cid-scope',
+          'tSSEaSFEU2-vkEO0Mb9HZejJui-npGRhXf3fD3H3iWeYQrjkQOTaRYdPyFTogNXA'
         );
-        expect(stored.time).to.equal(123);
       });
-    });
 
-    it('should depend on external id e2', () => {
-      return compare(
-        'e2',
-        'sha384(sha384([1,2,3,0,0,0,0,0,0,0,0,0,0,0,0,15])http://www.origin.come2)'
-      );
-    });
-
-    it('should depend on domain', () => {
-      fakeWin.location.href =
-        'https://cdn.ampproject.org/v/www.DIFFERENT.com/foo/?f=0';
-      return compare(
-        'e2',
-        'sha384(sha384([1,2,3,0,0,0,0,0,0,0,0,0,0,0,0,15])http://www.different.come2)'
-      );
-    });
-
-    it('should fallback to cookie value on custom domain.', () => {
-      fakeWin.location.href = 'https://abc.org/v/www.DIFFERENT.com/foo/?f=0';
-      fakeWin.document.cookie = 'cookie_name=12345;scope_name=54321;';
-      return cid
-        .get(
-          {
-            scope: 'scope_name',
-          },
-          hasConsent
-        )
-        .then(c => {
-          expect(c).to.equal('54321');
-        });
-    });
-
-    it('should fallback to cookie of given name on custom domain.', () => {
-      fakeWin.location.href = 'https://abc.org/v/www.DIFFERENT.com/foo/?f=0';
-      fakeWin.document.cookie = 'cookie_name=12345;scope_name=54321;';
-      return cid
-        .get(
-          {
-            scope: 'scope_name',
-            cookieName: 'cookie_name',
-          },
-          hasConsent
-        )
-        .then(c => {
-          expect(c).to.equal('12345');
-        });
-    });
-
-    it(
-      'should depend fall back to cookies on custom ' +
-        'domain and not create a cookie',
-      () => {
+      it('should hash domain name and scope', () => {
         fakeWin.location.href =
-          'https://some.domain/v/www.DIFFERENT.com/foo/?f=0';
-        fakeWin.document.cookie = 'cookie_name=12345;';
-        return compare('other_cookie', null);
-      }
-    );
-
-    it('should produce golden value', () => {
-      crypto.sha384Base64 = new Crypto(fakeWin).sha384Base64;
-      return compare(
-        'e2',
-        'q0pPfZTWGruPrtURDJHexzs-MgOkt9SJAsAZodzr8tx8hKv8BS62AVpbttaFX8fK'
-      );
-    });
-
-    it('should be stable with respect to a saved seed', () => {
-      const expected =
-        'sha384(sha384([1,2,3,0,0,0,0,0,0,0,0,0,0,0,0,15])http://www.origin.come2)';
-      return compare('e2', expected).then(() => {
-        seed = 2;
-        return compare('e2', expected).then(() => {
-          storage['amp-cid'] = undefined;
-          removeMemoryCacheOfCid();
-          return compare(
-            'e2',
-            'sha384(sha384([' +
-              // 2 because we set the seed to 2
-              '2' +
-              ',2,3,0,0,0,0,0,0,0,0,0,0,0,0,15])http://www.origin.come2)'
-          );
-        });
+          'https://cdn.ampproject.org/v/www.DIFFERENT.com/foo/?f=0';
+        // domain name: 'http://www.different.com'
+        // scope: 'another-custom-cid-scope'
+        return compare(
+          'another-custom-cid-scope',
+          '25lYHB6Luck8Z5ddpiB-FBbj2pa9zx3WdnJlZVgFneJRcFsDT3kIoPoi6k6-oxrB'
+        );
       });
     });
 
-    it('should pick up the cid value from storage', () => {
-      storage['amp-cid'] = JSON.stringify({
-        cid: 'YYY',
-        time: Date.now(),
+  // TODO(amphtml, #25621): Cannot find atob / btoa on Safari on Sauce Labs.
+  describe
+    .configure()
+    .skipSafari()
+    .run('with crypto stub', () => {
+      const doesNotProvideError = '[CID] Viewer does not provide cap=cid';
+      const invalidFormatError = '[CID] invalid cid format';
+      beforeEach(() => {
+        crypto.sha384Base64 = val => {
+          if (val instanceof Uint8Array) {
+            val = '[' + Array.apply([], val).join(',') + ']';
+          }
+
+          return Promise.resolve('sha384(' + val + ')');
+        };
       });
-      return compare('e2', 'sha384(YYYhttp://www.origin.come2)');
-    });
 
-    it('should return empty if opted out', () => {
-      storageGetStub.withArgs('amp-cid-optout').returns(Promise.resolve(true));
-
-      storage['amp-cid'] = JSON.stringify({
-        cid: 'YYY',
-        time: Date.now(),
-      });
-      return compare('e2', '');
-    });
-
-    it('should read from viewer storage if embedded', () => {
-      expectAsyncConsoleError(doesNotProvideError);
-      fakeWin.parent = {};
-      const expectedBaseCid = 'from-viewer';
-      viewerStorage = JSON.stringify({
-        time: 0,
-        cid: expectedBaseCid,
-      });
-      return Promise.all([
-        compare('e1', `sha384(${expectedBaseCid}http://www.origin.come1)`),
-        compare('e2', `sha384(${expectedBaseCid}http://www.origin.come2)`),
-      ])
-        .then(() => {
-          expect(viewerSendMessageStub).to.be.calledOnce;
-          expect(viewerSendMessageStub).to.be.calledWith('cid');
-          seed = 2;
-          // Ensure it's called only once since we cache it in memory.
-          return compare(
-            'e3',
-            `sha384(${expectedBaseCid}http://www.origin.come3)`
-          );
-        })
-        .then(() => {
-          expect(viewerSendMessageStub).to.be.calledOnce;
-          return expect(cid.baseCid_).to.eventually.equal(expectedBaseCid);
-        });
-    });
-
-    it(
-      'should read from viewer storage if embedded and convert cid to ' +
-        'new format',
-      () => {
-        expectAsyncConsoleError(doesNotProvideError);
-        expectAsyncConsoleError(invalidFormatError);
-        fakeWin.parent = {};
-        const expectedBaseCid = 'from-viewer';
-        // baseCid returned by legacy API
-        viewerStorage = expectedBaseCid;
-        return Promise.all([
-          compare('e1', `sha384(${expectedBaseCid}http://www.origin.come1)`),
-          compare('e2', `sha384(${expectedBaseCid}http://www.origin.come2)`),
-        ]).then(() => {
-          expect(viewerSendMessageStub).to.be.calledOnce;
-          expect(viewerSendMessageStub).to.be.calledWith('cid');
-        });
-      }
-    );
-
-    it('should not read from untrusted viewer', () => {
-      fakeWin.parent = {};
-      trustedViewer = false;
-      const viewerBaseCid = 'from-viewer';
-      viewerStorage = JSON.stringify({
-        time: 0,
-        cid: viewerBaseCid,
-      });
-      return Promise.all([
-        compare(
+      it('should depend on external id e1', () => {
+        clock.tick(123);
+        return compare(
           'e1',
           'sha384(sha384([1,2,3,0,0,0,0,0,0,0,0,0,0,0,0,15])http://www.origin.come1)'
-        ),
-        compare(
-          'e2',
-          'sha384(sha384([1,2,3,0,0,0,0,0,0,0,0,0,0,0,0,15])http://www.origin.come2)'
-        ),
-      ]).then(() => {
-        expect(viewerSendMessageStub).to.not.be.called;
-      });
-    });
-
-    it('should store to viewer storage if embedded', () => {
-      expectAsyncConsoleError(doesNotProvideError, 2);
-      fakeWin.parent = {};
-      const expectedBaseCid = 'sha384([1,2,3,0,0,0,0,0,0,0,0,0,0,0,0,15])';
-      return compare('e2', `sha384(${expectedBaseCid}http://www.origin.come2)`)
-        .then(() => {
-          expect(viewerSendMessageStub).to.be.calledWith(
-            'cid',
-            JSON.stringify({
-              time: 0,
-              cid: expectedBaseCid,
-            })
-          );
-          seed = 2;
-          // Ensure it's called only once since we cache it in memory.
-          return compare(
-            'e3',
-            `sha384(${expectedBaseCid}http://www.origin.come3)`
-          );
-        })
-        .then(() => {
-          expect(viewerSendMessageStub).to.be.calledWith(
-            env.sandbox.match.string
-          );
-          return expect(cid.baseCid_).to.eventually.equal(expectedBaseCid);
-        });
-    });
-
-    it('should prefer value in storage if present', () => {
-      fakeWin.parent = {};
-      storage['amp-cid'] = JSON.stringify({
-        cid: 'in-storage',
-        time: Date.now(),
-      });
-      return compare('e2', 'sha384(in-storagehttp://www.origin.come2)');
-    });
-
-    it('should expire on read after 365 days', () => {
-      const expected =
-        'sha384(sha384([1,2,3,0,0,0,0,0,0,0,0,0,0,0,0,15])http://www.origin.come2)';
-      return compare('e2', expected).then(() => {
-        clock.tick(364 * DAY);
-        seed = 2;
-        return compare('e2', expected).then(() => {
-          clock.tick(365 * DAY + 1);
-          removeMemoryCacheOfCid();
-          return compare(
-            'e2',
-            'sha384(sha384([' +
-              // 2 because we set the seed to 2
-              '2' +
-              ',2,3,0,0,0,0,0,0,0,0,0,0,0,0,15])http://www.origin.come2)'
-          );
-        });
-      });
-    });
-
-    it('should expire on read after 365 days when embedded', () => {
-      expectAsyncConsoleError(doesNotProvideError, 3);
-      fakeWin.parent = {};
-      const expectedBaseCid = 'from-viewer';
-      viewerStorage = JSON.stringify({
-        time: 0,
-        cid: expectedBaseCid,
-      });
-
-      const expectedIdFromViewer = 'sha384(from-viewerhttp://www.origin.come2)';
-      const expectedNewId =
-        'sha384(sha384([1,2,3,0,0,0,0,0,0,0,0,0,0,0,0,15])http://www.origin.come2)';
-      return compare('e2', expectedIdFromViewer).then(() => {
-        clock.tick(364 * DAY);
-        return compare('e2', expectedIdFromViewer).then(() => {
-          clock.tick(365 * DAY + 1);
-          removeMemoryCacheOfCid();
-          return compare('e2', expectedNewId);
-        });
-      });
-    });
-
-    it('should set last access time once a day', () => {
-      const expected =
-        'sha384(sha384([1,2,3,0,0,0,0,0,0,0,0,0,0,0,0,15])http://www.origin.come2)';
-      function getStoredTime() {
-        return JSON.parse(storage['amp-cid']).time;
-      }
-      clock.tick(100);
-      return compare('e2', expected).then(() => {
-        seed = 2;
-        expect(getStoredTime()).to.equal(100);
-        removeMemoryCacheOfCid();
-        clock.tick(3600);
-        return compare('e2', expected).then(() => {
-          expect(getStoredTime()).to.equal(100);
-          removeMemoryCacheOfCid();
-          clock.tick(DAY);
-          return compare('e2', expected).then(() => {
-            expect(getStoredTime()).to.equal(100 + 3600 + DAY);
-          });
-        });
-      });
-    });
-
-    it('should set last access time once a day when embedded', () => {
-      expectAsyncConsoleError(doesNotProvideError, 5);
-      fakeWin.parent = {};
-      const expected =
-        'sha384(sha384([1,2,3,0,0,0,0,0,0,0,0,0,0,0,0,15])http://www.origin.come2)';
-      function getStoredTime() {
-        return JSON.parse(viewerStorage).time;
-      }
-      clock.tick(100);
-      return compare('e2', expected).then(() => {
-        seed = 2;
-        expect(getStoredTime()).to.equal(100);
-        removeMemoryCacheOfCid();
-        clock.tick(3600);
-        return compare('e2', expected).then(() => {
-          expect(getStoredTime()).to.equal(100);
-          removeMemoryCacheOfCid();
-          clock.tick(DAY);
-          return compare('e2', expected).then(() => {
-            expect(getStoredTime()).to.equal(100 + 3600 + DAY);
-          });
-        });
-      });
-    });
-
-    it('should wait until after pre-rendering', () => {
-      let nonce = 'not visible';
-      whenFirstVisible = timer.promise(100).then(() => {
-        nonce = 'visible';
-      });
-      const p = cid.get({scope: 'test'}, hasConsent).then(unusedC => {
-        expect(nonce).to.equal('visible');
-      });
-      clock.tick(100);
-      return p;
-    });
-
-    it('should wait for consent', () => {
-      let nonce = 'before';
-      const consent = timer.promise(100).then(() => {
-        nonce = 'timer fired';
-      });
-      const p = cid.get({scope: 'test'}, consent).then(unusedC => {
-        expect(nonce).to.equal('timer fired');
-      });
-      clock.tick(100);
-      return p;
-    });
-
-    it('should fail on failed consent', () => {
-      return expect(cid.get({scope: 'abc'}, Promise.reject())).to.be.rejected;
-    });
-
-    it('should fail on invalid scope', () => {
-      allowConsoleError(() => {
-        expect(() => {
-          cid.get({scope: '$$$'}, Promise.resolve());
-        }).to.throw(/\$\$\$/);
-      });
-    });
-
-    it('should not store until persistence promise resolves', () => {
-      let resolve;
-      const persistencePromise = new Promise(r => {
-        resolve = r;
-      });
-
-      let sha384Promise;
-      crypto.sha384Base64 = val => {
-        if (val instanceof Uint8Array) {
-          val = '[' + Array.apply([], val).join(',') + ']';
-        }
-
-        return (sha384Promise = Promise.resolve('sha384(' + val + ')'));
-      };
-
-      return cid.get({scope: 'e2'}, hasConsent, persistencePromise).then(c => {
-        expect(c).to.equal(
-          'sha384(sha384([1,2,3,0,0,0,0,0,0,0,0,0,0,0,0,15])http://www.origin.come2)'
-        );
-        expect(storage['amp-cid']).to.be.undefined;
-        clock.tick(777);
-        resolve();
-        return Promise.all([persistencePromise, sha384Promise]).then(() => {
+        ).then(() => {
           expect(storage['amp-cid']).to.be.string;
           const stored = JSON.parse(storage['amp-cid']);
           expect(stored.cid).to.equal(
             'sha384([1,2,3,0,0,0,0,0,0,0,0,0,0,0,0,15])'
           );
-          expect(stored.time).to.equal(777);
+          expect(stored.time).to.equal(123);
         });
       });
-    });
 
-    it('should not wait persistence consent for viewer storage', () => {
-      expectAsyncConsoleError(doesNotProvideError, 2);
-      fakeWin.parent = {};
-      const persistencePromise = new Promise(() => {
-        /* never resolves */
-      });
-      return cid.get({scope: 'e2'}, hasConsent, persistencePromise).then(() => {
-        expect(viewerStorage).to.equal(
-          JSON.stringify({
-            time: 0,
-            cid: 'sha384([1,2,3,0,0,0,0,0,0,0,0,0,0,0,0,15])',
-          })
+      it('should depend on external id e2', () => {
+        return compare(
+          'e2',
+          'sha384(sha384([1,2,3,0,0,0,0,0,0,0,0,0,0,0,0,15])http://www.origin.come2)'
         );
       });
-    });
 
-    it('fallback with no window.crypto', () => {
-      fakeWin.crypto = undefined;
-      fakeWin.screen = {
-        width: '111',
-        height: '222',
-      };
-      fakeWin.Math = {
-        random: () => {
-          return 999;
-        },
-      };
-      clock.tick(7777);
-      return compare(
-        'e2',
-        'sha384(sha384(https://cdn.ampproject.org/v' +
-          '/www.origin.com/foo/?f=07777999111222)http://www.origin.come2)'
+      it('should depend on domain', () => {
+        fakeWin.location.href =
+          'https://cdn.ampproject.org/v/www.DIFFERENT.com/foo/?f=0';
+        return compare(
+          'e2',
+          'sha384(sha384([1,2,3,0,0,0,0,0,0,0,0,0,0,0,0,15])http://www.different.come2)'
+        );
+      });
+
+      it('should fallback to cookie value on custom domain.', () => {
+        fakeWin.location.href = 'https://abc.org/v/www.DIFFERENT.com/foo/?f=0';
+        fakeWin.document.cookie = 'cookie_name=12345;scope_name=54321;';
+        return cid
+          .get(
+            {
+              scope: 'scope_name',
+            },
+            hasConsent
+          )
+          .then(c => {
+            expect(c).to.equal('54321');
+          });
+      });
+
+      it('should fallback to cookie of given name on custom domain.', () => {
+        fakeWin.location.href = 'https://abc.org/v/www.DIFFERENT.com/foo/?f=0';
+        fakeWin.document.cookie = 'cookie_name=12345;scope_name=54321;';
+        return cid
+          .get(
+            {
+              scope: 'scope_name',
+              cookieName: 'cookie_name',
+            },
+            hasConsent
+          )
+          .then(c => {
+            expect(c).to.equal('12345');
+          });
+      });
+
+      it(
+        'should depend fall back to cookies on custom ' +
+          'domain and not create a cookie',
+        () => {
+          fakeWin.location.href =
+            'https://some.domain/v/www.DIFFERENT.com/foo/?f=0';
+          fakeWin.document.cookie = 'cookie_name=12345;';
+          return compare('other_cookie', null);
+        }
       );
-    });
 
-    it('should NOT create fallback cookie by default with string scope', () => {
-      fakeWin.location.href = 'https://abc.org/v/www.DIFFERENT.com/foo/?f=0';
-      return cid.get({scope: 'cookie_name'}, hasConsent).then(c => {
-        expect(c).to.not.exist;
-        expect(fakeWin.document.cookie).to.not.exist;
+      it('should produce golden value', () => {
+        crypto.sha384Base64 = new Crypto(fakeWin).sha384Base64;
+        return compare(
+          'e2',
+          'q0pPfZTWGruPrtURDJHexzs-MgOkt9SJAsAZodzr8tx8hKv8BS62AVpbttaFX8fK'
+        );
       });
-    });
 
-    it('should NOT create fallback cookie by default with struct scope', () => {
-      fakeWin.location.href = 'https://abc.org/v/www.DIFFERENT.com/foo/?f=0';
-      return cid.get({scope: 'cookie_name'}, hasConsent).then(c => {
-        expect(c).to.not.exist;
-        expect(fakeWin.document.cookie).to.not.exist;
-      });
-    });
-
-    it('should create fallback cookie when asked', () => {
-      fakeWin.location.href =
-        'https://foo.abc.org/v/www.DIFFERENT.com/foo/?f=0';
-      fakeWin.location.hostname = 'foo.abc.org';
-      fakeWin.crypto.getRandomValues = array => {
-        array[0] = 0;
-        array[1] = 2;
-        array[2] = 4;
-        array[3] = 8;
-        array[4] = 16;
-        array[5] = 32;
-        array[6] = 64;
-        array[7] = 128;
-        array[8] = 255;
-        array[9] = 7;
-        array[10] = 11;
-        array[11] = 22;
-        array[12] = 33;
-        array[13] = 66;
-        array[14] = 200;
-        array[15] = 39;
-      };
-      return cid
-        .get({scope: 'scope_name', createCookieIfNotPresent: true}, hasConsent)
-        .then(c => {
-          expect(c).to.exist;
-          // Since various parties depend on the cookie values, please be careful
-          // about changing the format.
-          expect(c).to.equal('amp-AAIECBAgQID_BwsWIULIJw');
-          expect(fakeWin.document.cookie).to.equal(
-            'scope_name=' +
-              encodeURIComponent(c) +
-              '; path=/' +
-              '; domain=abc.org' +
-              '; expires=Fri, 01 Jan 1971 00:00:00 GMT'
-          ); // 1 year from 0.
+      it('should be stable with respect to a saved seed', () => {
+        const expected =
+          'sha384(sha384([1,2,3,0,0,0,0,0,0,0,0,0,0,0,0,15])http://www.origin.come2)';
+        return compare('e2', expected).then(() => {
+          seed = 2;
+          return compare('e2', expected).then(() => {
+            storage['amp-cid'] = undefined;
+            removeMemoryCacheOfCid();
+            return compare(
+              'e2',
+              'sha384(sha384([' +
+                // 2 because we set the seed to 2
+                '2' +
+                ',2,3,0,0,0,0,0,0,0,0,0,0,0,0,15])http://www.origin.come2)'
+            );
+          });
         });
-    });
+      });
 
-    it('should create fallback cookie with provided name', () => {
-      fakeWin.location.href =
-        'https://foo.abc.org/v/www.DIFFERENT.com/foo/?f=0';
-      fakeWin.location.hostname = 'foo.abc.org';
-      return cid
-        .get(
-          {
-            scope: 'scope_name',
-            createCookieIfNotPresent: true,
-            cookieName: 'cookie_name',
-          },
-          hasConsent
+      it('should pick up the cid value from storage', () => {
+        storage['amp-cid'] = JSON.stringify({
+          cid: 'YYY',
+          time: Date.now(),
+        });
+        return compare('e2', 'sha384(YYYhttp://www.origin.come2)');
+      });
+
+      it('should return empty if opted out', () => {
+        storageGetStub
+          .withArgs('amp-cid-optout')
+          .returns(Promise.resolve(true));
+
+        storage['amp-cid'] = JSON.stringify({
+          cid: 'YYY',
+          time: Date.now(),
+        });
+        return compare('e2', '');
+      });
+
+      it('should read from viewer storage if embedded', () => {
+        expectAsyncConsoleError(doesNotProvideError);
+        fakeWin.parent = {};
+        const expectedBaseCid = 'from-viewer';
+        viewerStorage = JSON.stringify({
+          time: 0,
+          cid: expectedBaseCid,
+        });
+        return Promise.all([
+          compare('e1', `sha384(${expectedBaseCid}http://www.origin.come1)`),
+          compare('e2', `sha384(${expectedBaseCid}http://www.origin.come2)`),
+        ])
+          .then(() => {
+            expect(viewerSendMessageStub).to.be.calledOnce;
+            expect(viewerSendMessageStub).to.be.calledWith('cid');
+            seed = 2;
+            // Ensure it's called only once since we cache it in memory.
+            return compare(
+              'e3',
+              `sha384(${expectedBaseCid}http://www.origin.come3)`
+            );
+          })
+          .then(() => {
+            expect(viewerSendMessageStub).to.be.calledOnce;
+            return expect(cid.baseCid_).to.eventually.equal(expectedBaseCid);
+          });
+      });
+
+      it(
+        'should read from viewer storage if embedded and convert cid to ' +
+          'new format',
+        () => {
+          expectAsyncConsoleError(doesNotProvideError);
+          expectAsyncConsoleError(invalidFormatError);
+          fakeWin.parent = {};
+          const expectedBaseCid = 'from-viewer';
+          // baseCid returned by legacy API
+          viewerStorage = expectedBaseCid;
+          return Promise.all([
+            compare('e1', `sha384(${expectedBaseCid}http://www.origin.come1)`),
+            compare('e2', `sha384(${expectedBaseCid}http://www.origin.come2)`),
+          ]).then(() => {
+            expect(viewerSendMessageStub).to.be.calledOnce;
+            expect(viewerSendMessageStub).to.be.calledWith('cid');
+          });
+        }
+      );
+
+      it('should not read from untrusted viewer', () => {
+        fakeWin.parent = {};
+        trustedViewer = false;
+        const viewerBaseCid = 'from-viewer';
+        viewerStorage = JSON.stringify({
+          time: 0,
+          cid: viewerBaseCid,
+        });
+        return Promise.all([
+          compare(
+            'e1',
+            'sha384(sha384([1,2,3,0,0,0,0,0,0,0,0,0,0,0,0,15])http://www.origin.come1)'
+          ),
+          compare(
+            'e2',
+            'sha384(sha384([1,2,3,0,0,0,0,0,0,0,0,0,0,0,0,15])http://www.origin.come2)'
+          ),
+        ]).then(() => {
+          expect(viewerSendMessageStub).to.not.be.called;
+        });
+      });
+
+      it('should store to viewer storage if embedded', () => {
+        expectAsyncConsoleError(doesNotProvideError, 2);
+        fakeWin.parent = {};
+        const expectedBaseCid = 'sha384([1,2,3,0,0,0,0,0,0,0,0,0,0,0,0,15])';
+        return compare(
+          'e2',
+          `sha384(${expectedBaseCid}http://www.origin.come2)`
         )
-        .then(c => {
-          expect(c).to.exist;
-          expect(c).to.equal('amp-AQIDAAAAAAAAAAAAAAAADw');
+          .then(() => {
+            expect(viewerSendMessageStub).to.be.calledWith(
+              'cid',
+              JSON.stringify({
+                time: 0,
+                cid: expectedBaseCid,
+              })
+            );
+            seed = 2;
+            // Ensure it's called only once since we cache it in memory.
+            return compare(
+              'e3',
+              `sha384(${expectedBaseCid}http://www.origin.come3)`
+            );
+          })
+          .then(() => {
+            expect(viewerSendMessageStub).to.be.calledWith(
+              env.sandbox.match.string
+            );
+            return expect(cid.baseCid_).to.eventually.equal(expectedBaseCid);
+          });
+      });
+
+      it('should prefer value in storage if present', () => {
+        fakeWin.parent = {};
+        storage['amp-cid'] = JSON.stringify({
+          cid: 'in-storage',
+          time: Date.now(),
+        });
+        return compare('e2', 'sha384(in-storagehttp://www.origin.come2)');
+      });
+
+      it('should expire on read after 365 days', () => {
+        const expected =
+          'sha384(sha384([1,2,3,0,0,0,0,0,0,0,0,0,0,0,0,15])http://www.origin.come2)';
+        return compare('e2', expected).then(() => {
+          clock.tick(364 * DAY);
+          seed = 2;
+          return compare('e2', expected).then(() => {
+            clock.tick(365 * DAY + 1);
+            removeMemoryCacheOfCid();
+            return compare(
+              'e2',
+              'sha384(sha384([' +
+                // 2 because we set the seed to 2
+                '2' +
+                ',2,3,0,0,0,0,0,0,0,0,0,0,0,0,15])http://www.origin.come2)'
+            );
+          });
+        });
+      });
+
+      it('should expire on read after 365 days when embedded', () => {
+        expectAsyncConsoleError(doesNotProvideError, 3);
+        fakeWin.parent = {};
+        const expectedBaseCid = 'from-viewer';
+        viewerStorage = JSON.stringify({
+          time: 0,
+          cid: expectedBaseCid,
+        });
+
+        const expectedIdFromViewer =
+          'sha384(from-viewerhttp://www.origin.come2)';
+        const expectedNewId =
+          'sha384(sha384([1,2,3,0,0,0,0,0,0,0,0,0,0,0,0,15])http://www.origin.come2)';
+        return compare('e2', expectedIdFromViewer).then(() => {
+          clock.tick(364 * DAY);
+          return compare('e2', expectedIdFromViewer).then(() => {
+            clock.tick(365 * DAY + 1);
+            removeMemoryCacheOfCid();
+            return compare('e2', expectedNewId);
+          });
+        });
+      });
+
+      it('should set last access time once a day', () => {
+        const expected =
+          'sha384(sha384([1,2,3,0,0,0,0,0,0,0,0,0,0,0,0,15])http://www.origin.come2)';
+        function getStoredTime() {
+          return JSON.parse(storage['amp-cid']).time;
+        }
+        clock.tick(100);
+        return compare('e2', expected).then(() => {
+          seed = 2;
+          expect(getStoredTime()).to.equal(100);
+          removeMemoryCacheOfCid();
+          clock.tick(3600);
+          return compare('e2', expected).then(() => {
+            expect(getStoredTime()).to.equal(100);
+            removeMemoryCacheOfCid();
+            clock.tick(DAY);
+            return compare('e2', expected).then(() => {
+              expect(getStoredTime()).to.equal(100 + 3600 + DAY);
+            });
+          });
+        });
+      });
+
+      it('should set last access time once a day when embedded', () => {
+        expectAsyncConsoleError(doesNotProvideError, 5);
+        fakeWin.parent = {};
+        const expected =
+          'sha384(sha384([1,2,3,0,0,0,0,0,0,0,0,0,0,0,0,15])http://www.origin.come2)';
+        function getStoredTime() {
+          return JSON.parse(viewerStorage).time;
+        }
+        clock.tick(100);
+        return compare('e2', expected).then(() => {
+          seed = 2;
+          expect(getStoredTime()).to.equal(100);
+          removeMemoryCacheOfCid();
+          clock.tick(3600);
+          return compare('e2', expected).then(() => {
+            expect(getStoredTime()).to.equal(100);
+            removeMemoryCacheOfCid();
+            clock.tick(DAY);
+            return compare('e2', expected).then(() => {
+              expect(getStoredTime()).to.equal(100 + 3600 + DAY);
+            });
+          });
+        });
+      });
+
+      it('should wait until after pre-rendering', () => {
+        let nonce = 'not visible';
+        whenFirstVisible = timer.promise(100).then(() => {
+          nonce = 'visible';
+        });
+        const p = cid.get({scope: 'test'}, hasConsent).then(unusedC => {
+          expect(nonce).to.equal('visible');
+        });
+        clock.tick(100);
+        return p;
+      });
+
+      it('should wait for consent', () => {
+        let nonce = 'before';
+        const consent = timer.promise(100).then(() => {
+          nonce = 'timer fired';
+        });
+        const p = cid.get({scope: 'test'}, consent).then(unusedC => {
+          expect(nonce).to.equal('timer fired');
+        });
+        clock.tick(100);
+        return p;
+      });
+
+      it('should fail on failed consent', () => {
+        return expect(cid.get({scope: 'abc'}, Promise.reject())).to.be.rejected;
+      });
+
+      it('should fail on invalid scope', () => {
+        allowConsoleError(() => {
+          expect(() => {
+            cid.get({scope: '$$$'}, Promise.resolve());
+          }).to.throw(/\$\$\$/);
+        });
+      });
+
+      it('should not store until persistence promise resolves', () => {
+        let resolve;
+        const persistencePromise = new Promise(r => {
+          resolve = r;
+        });
+
+        let sha384Promise;
+        crypto.sha384Base64 = val => {
+          if (val instanceof Uint8Array) {
+            val = '[' + Array.apply([], val).join(',') + ']';
+          }
+
+          return (sha384Promise = Promise.resolve('sha384(' + val + ')'));
+        };
+
+        return cid
+          .get({scope: 'e2'}, hasConsent, persistencePromise)
+          .then(c => {
+            expect(c).to.equal(
+              'sha384(sha384([1,2,3,0,0,0,0,0,0,0,0,0,0,0,0,15])http://www.origin.come2)'
+            );
+            expect(storage['amp-cid']).to.be.undefined;
+            clock.tick(777);
+            resolve();
+            return Promise.all([persistencePromise, sha384Promise]).then(() => {
+              expect(storage['amp-cid']).to.be.string;
+              const stored = JSON.parse(storage['amp-cid']);
+              expect(stored.cid).to.equal(
+                'sha384([1,2,3,0,0,0,0,0,0,0,0,0,0,0,0,15])'
+              );
+              expect(stored.time).to.equal(777);
+            });
+          });
+      });
+
+      it('should not wait persistence consent for viewer storage', () => {
+        expectAsyncConsoleError(doesNotProvideError, 2);
+        fakeWin.parent = {};
+        const persistencePromise = new Promise(() => {
+          /* never resolves */
+        });
+        return cid
+          .get({scope: 'e2'}, hasConsent, persistencePromise)
+          .then(() => {
+            expect(viewerStorage).to.equal(
+              JSON.stringify({
+                time: 0,
+                cid: 'sha384([1,2,3,0,0,0,0,0,0,0,0,0,0,0,0,15])',
+              })
+            );
+          });
+      });
+
+      it('fallback with no window.crypto', () => {
+        fakeWin.crypto = undefined;
+        fakeWin.screen = {
+          width: '111',
+          height: '222',
+        };
+        fakeWin.Math = {
+          random: () => {
+            return 999;
+          },
+        };
+        clock.tick(7777);
+        return compare(
+          'e2',
+          'sha384(sha384(https://cdn.ampproject.org/v' +
+            '/www.origin.com/foo/?f=07777999111222)http://www.origin.come2)'
+        );
+      });
+
+      it('should NOT create fallback cookie by default with string scope', () => {
+        fakeWin.location.href = 'https://abc.org/v/www.DIFFERENT.com/foo/?f=0';
+        return cid.get({scope: 'cookie_name'}, hasConsent).then(c => {
+          expect(c).to.not.exist;
+          expect(fakeWin.document.cookie).to.not.exist;
+        });
+      });
+
+      it('should NOT create fallback cookie by default with struct scope', () => {
+        fakeWin.location.href = 'https://abc.org/v/www.DIFFERENT.com/foo/?f=0';
+        return cid.get({scope: 'cookie_name'}, hasConsent).then(c => {
+          expect(c).to.not.exist;
+          expect(fakeWin.document.cookie).to.not.exist;
+        });
+      });
+
+      it('should create fallback cookie when asked', () => {
+        fakeWin.location.href =
+          'https://foo.abc.org/v/www.DIFFERENT.com/foo/?f=0';
+        fakeWin.location.hostname = 'foo.abc.org';
+        fakeWin.crypto.getRandomValues = array => {
+          array[0] = 0;
+          array[1] = 2;
+          array[2] = 4;
+          array[3] = 8;
+          array[4] = 16;
+          array[5] = 32;
+          array[6] = 64;
+          array[7] = 128;
+          array[8] = 255;
+          array[9] = 7;
+          array[10] = 11;
+          array[11] = 22;
+          array[12] = 33;
+          array[13] = 66;
+          array[14] = 200;
+          array[15] = 39;
+        };
+        return cid
+          .get(
+            {scope: 'scope_name', createCookieIfNotPresent: true},
+            hasConsent
+          )
+          .then(c => {
+            expect(c).to.exist;
+            // Since various parties depend on the cookie values, please be careful
+            // about changing the format.
+            expect(c).to.equal('amp-AAIECBAgQID_BwsWIULIJw');
+            expect(fakeWin.document.cookie).to.equal(
+              'scope_name=' +
+                encodeURIComponent(c) +
+                '; path=/' +
+                '; domain=abc.org' +
+                '; expires=Fri, 01 Jan 1971 00:00:00 GMT'
+            ); // 1 year from 0.
+          });
+      });
+
+      it('should create fallback cookie with provided name', () => {
+        fakeWin.location.href =
+          'https://foo.abc.org/v/www.DIFFERENT.com/foo/?f=0';
+        fakeWin.location.hostname = 'foo.abc.org';
+        return cid
+          .get(
+            {
+              scope: 'scope_name',
+              createCookieIfNotPresent: true,
+              cookieName: 'cookie_name',
+            },
+            hasConsent
+          )
+          .then(c => {
+            expect(c).to.exist;
+            expect(c).to.equal('amp-AQIDAAAAAAAAAAAAAAAADw');
+            expect(fakeWin.document.cookie).to.equal(
+              'cookie_name=' +
+                encodeURIComponent(c) +
+                '; path=/' +
+                '; domain=abc.org' +
+                '; expires=Fri, 01 Jan 1971 00:00:00 GMT'
+            ); // 1 year from 0.
+          });
+      });
+
+      it('should update fallback cookie expiration when present', () => {
+        fakeWin.location.href =
+          'https://foo.abc.org/v/www.DIFFERENT.com/foo/?f=0';
+        fakeWin.location.hostname = 'foo.abc.org';
+        fakeWin.document.cookie = 'cookie_name=amp-12345';
+
+        return cid.get({scope: 'cookie_name'}, hasConsent).then(c => {
           expect(fakeWin.document.cookie).to.equal(
             'cookie_name=' +
               encodeURIComponent(c) +
               '; path=/' +
               '; domain=abc.org' +
-              '; expires=Fri, 01 Jan 1971 00:00:00 GMT'
-          ); // 1 year from 0.
+              '; expires=Fri, 01 Jan 1971 00:00:00 GMT' // 1 year from 0.
+          );
         });
-    });
+      });
 
-    it('should update fallback cookie expiration when present', () => {
-      fakeWin.location.href =
-        'https://foo.abc.org/v/www.DIFFERENT.com/foo/?f=0';
-      fakeWin.location.hostname = 'foo.abc.org';
-      fakeWin.document.cookie = 'cookie_name=amp-12345';
+      it('should not update expiration when created externally', () => {
+        fakeWin.location.href =
+          'https://foo.abc.org/v/www.DIFFERENT.com/foo/?f=0';
+        fakeWin.location.hostname = 'foo.abc.org';
+        fakeWin.document.cookie = 'cookie_name=12345';
 
-      return cid.get({scope: 'cookie_name'}, hasConsent).then(c => {
-        expect(fakeWin.document.cookie).to.equal(
-          'cookie_name=' +
-            encodeURIComponent(c) +
-            '; path=/' +
-            '; domain=abc.org' +
-            '; expires=Fri, 01 Jan 1971 00:00:00 GMT' // 1 year from 0.
+        return cid.get({scope: 'cookie_name'}, hasConsent).then(() => {
+          expect(fakeWin.document.cookie).to.equal('cookie_name=12345');
+        });
+      });
+
+      it('should return same value for multiple calls on non-proxied urls', () => {
+        fakeWin.location.href = 'https://abc.org/foo/?f=0';
+        fakeWin.location.hostname = 'foo.abc.org';
+        const cid1 = cid.get(
+          {scope: 'cookie', createCookieIfNotPresent: true},
+          hasConsent
         );
-      });
-    });
-
-    it('should not update expiration when created externally', () => {
-      fakeWin.location.href =
-        'https://foo.abc.org/v/www.DIFFERENT.com/foo/?f=0';
-      fakeWin.location.hostname = 'foo.abc.org';
-      fakeWin.document.cookie = 'cookie_name=12345';
-
-      return cid.get({scope: 'cookie_name'}, hasConsent).then(() => {
-        expect(fakeWin.document.cookie).to.equal('cookie_name=12345');
-      });
-    });
-
-    it('should return same value for multiple calls on non-proxied urls', () => {
-      fakeWin.location.href = 'https://abc.org/foo/?f=0';
-      fakeWin.location.hostname = 'foo.abc.org';
-      const cid1 = cid.get(
-        {scope: 'cookie', createCookieIfNotPresent: true},
-        hasConsent
-      );
-      const cid2 = cid.get(
-        {scope: 'cookie', createCookieIfNotPresent: true},
-        hasConsent
-      );
-      return cid1.then(c1 => {
-        return cid2.then(c2 => {
-          expect(c1).to.equal(c2);
-        });
-      });
-    });
-
-    it('should return same value for multiple calls on proxied urls', () => {
-      fakeWin.location.href = 'https://cdn.ampproject.org/v/abc.org/foo/?f=0';
-      fakeWin.location.hostname = 'cdn.ampproject.org';
-      const cid1 = cid.get(
-        {scope: 'cookie', createCookieIfNotPresent: true},
-        hasConsent
-      );
-      return cid1.then(c1 => {
         const cid2 = cid.get(
           {scope: 'cookie', createCookieIfNotPresent: true},
           hasConsent
         );
-        return cid2.then(c2 => {
-          expect(c1).to.equal(c2);
+        return cid1.then(c1 => {
+          return cid2.then(c2 => {
+            expect(c1).to.equal(c2);
+          });
         });
       });
-    });
 
-    it('should retreive cookie value with . in name', () => {
-      fakeWin.location.href = 'https://abc.org/';
-      fakeWin.document.cookie = '_sp_id.44=4567;';
-      return compare('_sp_id.44', '4567');
+      it('should return same value for multiple calls on proxied urls', () => {
+        fakeWin.location.href = 'https://cdn.ampproject.org/v/abc.org/foo/?f=0';
+        fakeWin.location.hostname = 'cdn.ampproject.org';
+        const cid1 = cid.get(
+          {scope: 'cookie', createCookieIfNotPresent: true},
+          hasConsent
+        );
+        return cid1.then(c1 => {
+          const cid2 = cid.get(
+            {scope: 'cookie', createCookieIfNotPresent: true},
+            hasConsent
+          );
+          return cid2.then(c2 => {
+            expect(c1).to.equal(c2);
+          });
+        });
+      });
+
+      it('should retreive cookie value with . in name', () => {
+        fakeWin.location.href = 'https://abc.org/';
+        fakeWin.document.cookie = '_sp_id.44=4567;';
+        return compare('_sp_id.44', '4567');
+      });
     });
-  });
 
   function compare(externalCidScope, compareValue) {
     return cid.get({scope: externalCidScope}, hasConsent).then(c => {
@@ -801,28 +822,32 @@ describes.realWin('cid', {amp: true}, env => {
     clock.uninstall();
   });
 
-  it('should store CID in cookie when not in Viewer', function*() {
-    env.sandbox
-      .stub(cid.viewerCidApi_, 'isSupported')
-      .returns(Promise.resolve(false));
-    setCookie(win, 'foo', '', 0);
-    const fooCid = yield cid.get(
-      {
-        scope: 'foo',
-        createCookieIfNotPresent: true,
-      },
-      hasConsent
-    );
-    expect(fooCid).to.have.string('amp-');
-    const fooCid2 = yield cid.get(
-      {
-        scope: 'foo',
-        createCookieIfNotPresent: true,
-      },
-      hasConsent
-    );
-    expect(fooCid).to.equal(fooCid2);
-  });
+  // TODO(amphtml, #25621): Cannot find atob / btoa on Safari on Sauce Labs.
+  it.configure().skipSafari(
+    'should store CID in cookie when not in Viewer',
+    function*() {
+      env.sandbox
+        .stub(cid.viewerCidApi_, 'isSupported')
+        .returns(Promise.resolve(false));
+      setCookie(win, 'foo', '', 0);
+      const fooCid = yield cid.get(
+        {
+          scope: 'foo',
+          createCookieIfNotPresent: true,
+        },
+        hasConsent
+      );
+      expect(fooCid).to.have.string('amp-');
+      const fooCid2 = yield cid.get(
+        {
+          scope: 'foo',
+          createCookieIfNotPresent: true,
+        },
+        hasConsent
+      );
+      expect(fooCid).to.equal(fooCid2);
+    }
+  );
 
   it('get method should return CID when in Viewer ', () => {
     env.sandbox
@@ -883,77 +908,83 @@ describes.realWin('cid', {amp: true}, env => {
     yield macroTask();
   });
 
-  describe('pub origin, CID API opt in', () => {
-    beforeEach(() => {
-      env.sandbox.stub(url, 'isProxyOrigin').returns(false);
-      ampdoc.win.document.head.innerHTML +=
-        '<meta name="amp-google-client-id-api" content="googleanalytics">';
-      setCookie(win, '_ga', '', 0);
-    });
+  // TODO(amphtml, #25621): Cannot find atob / btoa on Safari on Sauce Labs.
+  describe
+    .configure()
+    .skipSafari()
+    .run('pub origin, CID API opt in', () => {
+      beforeEach(() => {
+        env.sandbox.stub(url, 'isProxyOrigin').returns(false);
+        ampdoc.win.document.head.innerHTML +=
+          '<meta name="amp-google-client-id-api" content="googleanalytics">';
+        setCookie(win, '_ga', '', 0);
+      });
 
-    afterEach(() => {
-      setCookie(win, '_ga', '', 0);
-    });
+      afterEach(() => {
+        setCookie(win, '_ga', '', 0);
+      });
 
-    it('should use cid api on pub origin if opted in', () => {
-      cid.apiKeyMap_ = {'AMP_ECID_GOOGLE': 'cid-api-key'};
-      const getScopedCidStub = env.sandbox.stub(cid.cidApi_, 'getScopedCid');
-      getScopedCidStub.returns(Promise.resolve('cid-from-api'));
-      return cid
-        .get(
-          {
-            scope: 'AMP_ECID_GOOGLE',
-            cookieName: '_ga',
-            createCookieIfNotPresent: true,
-          },
-          hasConsent
-        )
-        .then(scopedCid => {
-          expect(getScopedCidStub).to.be.calledWith(
-            'cid-api-key',
-            'AMP_ECID_GOOGLE'
-          );
-          expect(scopedCid).to.equal('cid-from-api');
-          expect(getCookie(win, '_ga')).to.equal('cid-from-api');
-        });
-    });
+      it('should use cid api on pub origin if opted in', () => {
+        cid.apiKeyMap_ = {'AMP_ECID_GOOGLE': 'cid-api-key'};
+        const getScopedCidStub = env.sandbox.stub(cid.cidApi_, 'getScopedCid');
+        getScopedCidStub.returns(Promise.resolve('cid-from-api'));
+        return cid
+          .get(
+            {
+              scope: 'AMP_ECID_GOOGLE',
+              cookieName: '_ga',
+              createCookieIfNotPresent: true,
+            },
+            hasConsent
+          )
+          .then(scopedCid => {
+            expect(getScopedCidStub).to.be.calledWith(
+              'cid-api-key',
+              'AMP_ECID_GOOGLE'
+            );
+            expect(scopedCid).to.equal('cid-from-api');
+            expect(getCookie(win, '_ga')).to.equal('cid-from-api');
+          });
+      });
 
-    it('should fallback to cookie if cid api returns nothing', () => {
-      env.sandbox.stub(cid.cidApi_, 'getScopedCid').returns(Promise.resolve());
-      return cid
-        .get(
-          {
-            scope: 'AMP_ECID_GOOGLE',
-            cookieName: '_ga',
-            createCookieIfNotPresent: true,
-          },
-          hasConsent
-        )
-        .then(scopedCid => {
-          expect(scopedCid).to.contain('amp-');
-          expect(getCookie(win, '_ga')).to.equal(scopedCid);
-        });
-    });
+      it('should fallback to cookie if cid api returns nothing', () => {
+        env.sandbox
+          .stub(cid.cidApi_, 'getScopedCid')
+          .returns(Promise.resolve());
+        return cid
+          .get(
+            {
+              scope: 'AMP_ECID_GOOGLE',
+              cookieName: '_ga',
+              createCookieIfNotPresent: true,
+            },
+            hasConsent
+          )
+          .then(scopedCid => {
+            expect(scopedCid).to.contain('amp-');
+            expect(getCookie(win, '_ga')).to.equal(scopedCid);
+          });
+      });
 
-    it('should respect CID API opt out', () => {
-      env.sandbox
-        .stub(cid.cidApi_, 'getScopedCid')
-        .returns(Promise.resolve('$OPT_OUT'));
-      return cid
-        .get(
-          {
-            scope: 'AMP_ECID_GOOGLE',
-            cookieName: '_ga',
-            createCookieIfNotPresent: true,
-          },
-          hasConsent
-        )
-        .then(scopedCid => {
-          expect(scopedCid).to.be.null;
-          expect(getCookie(win, '_ga')).to.be.null;
-        });
+      it('should respect CID API opt out', () => {
+        env.sandbox
+          .stub(cid.cidApi_, 'getScopedCid')
+          .returns(Promise.resolve('$OPT_OUT'));
+        return cid
+          .get(
+            {
+              scope: 'AMP_ECID_GOOGLE',
+              cookieName: '_ga',
+              createCookieIfNotPresent: true,
+            },
+            hasConsent
+          )
+          .then(scopedCid => {
+            expect(scopedCid).to.be.null;
+            expect(getCookie(win, '_ga')).to.be.null;
+          });
+      });
     });
-  });
 
   describe('isScopeOptedIn', () => {
     it('should read predefined clients and custom API keys correctly', () => {

--- a/test/unit/test-crypto.js
+++ b/test/unit/test-crypto.js
@@ -38,82 +38,86 @@ describes.realWin('crypto-impl', {}, env => {
   }
 
   function testSuite(description, win, expectedError) {
-    describe(description, () => {
-      beforeEach(() => {
-        crypto = createCrypto(win || env.win);
-      });
+    // TODO(amphtml, #25621): Cannot find atob / btoa on Safari on Sauce Labs.
+    describe
+      .configure()
+      .skipSafari()
+      .run(description, () => {
+        beforeEach(() => {
+          crypto = createCrypto(win || env.win);
+        });
 
-      it('should hash "abc" in sha384', () => {
-        if (expectedError) {
-          expectAsyncConsoleError(expectedError);
-        }
-        return crypto.sha384('abc').then(buffer => {
-          expect(buffer.length).to.equal(48);
-          expect(buffer[0]).to.equal(203);
-          expect(buffer[1]).to.equal(0);
-          expect(buffer[47]).to.equal(167);
+        it('should hash "abc" in sha384', () => {
+          if (expectedError) {
+            expectAsyncConsoleError(expectedError);
+          }
+          return crypto.sha384('abc').then(buffer => {
+            expect(buffer.length).to.equal(48);
+            expect(buffer[0]).to.equal(203);
+            expect(buffer[1]).to.equal(0);
+            expect(buffer[47]).to.equal(167);
+          });
+        });
+
+        it('should hash [1,2,3] in sha384', () => {
+          if (expectedError) {
+            expectAsyncConsoleError(expectedError);
+          }
+          return crypto.sha384(uint8Array([1, 2, 3])).then(buffer => {
+            expect(buffer.length).to.equal(48);
+            expect(buffer[0]).to.equal(134);
+            expect(buffer[1]).to.equal(34);
+            expect(buffer[47]).to.equal(246);
+          });
+        });
+
+        it('should hash "abc" in sha384Base64', () => {
+          if (expectedError) {
+            expectAsyncConsoleError(expectedError);
+          }
+          return expect(crypto.sha384Base64('abc')).to.eventually.equal(
+            'ywB1P0WjXou1oD1pmsZQBycsMqsO3tFjGotgWkP_W-2AhgcroefMI1i67KE0yCWn'
+          );
+        });
+
+        it('should hash "foobar" in sha384Base64', () => {
+          if (expectedError) {
+            expectAsyncConsoleError(expectedError);
+          }
+          return expect(crypto.sha384Base64('foobar')).to.eventually.equal(
+            'PJww2fZl501RXIQpYNSkUcg6ASX9Pec5LXs3IxrxDHLqWK7fzfiaV2W_kCr5Ps8G'
+          );
+        });
+
+        it('should hash [1,2,3] in sha384', () => {
+          if (expectedError) {
+            expectAsyncConsoleError(expectedError);
+          }
+          return expect(
+            crypto.sha384Base64(uint8Array([1, 2, 3]))
+          ).to.eventually.equal(
+            'hiKdxtL_vqxzgHRBVKpwApHAZDUqDb3H' +
+              'e57T8sjh2sTcMlhn053f8dJim3o5PUf2'
+          );
+        });
+
+        it('should throw when input contains chars out of range [0,255]', () => {
+          allowConsoleError(() => {
+            expect(() => crypto.sha384('abc今')).to.throw();
+            expect(() => crypto.sha384Base64('abc今')).to.throw();
+            expect(() => crypto.uniform('abc今')).to.throw();
+          });
+        });
+
+        it('should hash "abc" to uniform number', () => {
+          if (expectedError) {
+            expectAsyncConsoleError(expectedError);
+          }
+          return crypto.uniform('abc').then(result => {
+            expect(result.toFixed(6)).to.equal('0.792976');
+          });
         });
       });
-
-      it('should hash [1,2,3] in sha384', () => {
-        if (expectedError) {
-          expectAsyncConsoleError(expectedError);
-        }
-        return crypto.sha384(uint8Array([1, 2, 3])).then(buffer => {
-          expect(buffer.length).to.equal(48);
-          expect(buffer[0]).to.equal(134);
-          expect(buffer[1]).to.equal(34);
-          expect(buffer[47]).to.equal(246);
-        });
-      });
-
-      it('should hash "abc" in sha384Base64', () => {
-        if (expectedError) {
-          expectAsyncConsoleError(expectedError);
-        }
-        return expect(crypto.sha384Base64('abc')).to.eventually.equal(
-          'ywB1P0WjXou1oD1pmsZQBycsMqsO3tFjGotgWkP_W-2AhgcroefMI1i67KE0yCWn'
-        );
-      });
-
-      it('should hash "foobar" in sha384Base64', () => {
-        if (expectedError) {
-          expectAsyncConsoleError(expectedError);
-        }
-        return expect(crypto.sha384Base64('foobar')).to.eventually.equal(
-          'PJww2fZl501RXIQpYNSkUcg6ASX9Pec5LXs3IxrxDHLqWK7fzfiaV2W_kCr5Ps8G'
-        );
-      });
-
-      it('should hash [1,2,3] in sha384', () => {
-        if (expectedError) {
-          expectAsyncConsoleError(expectedError);
-        }
-        return expect(
-          crypto.sha384Base64(uint8Array([1, 2, 3]))
-        ).to.eventually.equal(
-          'hiKdxtL_vqxzgHRBVKpwApHAZDUqDb3H' +
-            'e57T8sjh2sTcMlhn053f8dJim3o5PUf2'
-        );
-      });
-
-      it('should throw when input contains chars out of range [0,255]', () => {
-        allowConsoleError(() => {
-          expect(() => crypto.sha384('abc今')).to.throw();
-          expect(() => crypto.sha384Base64('abc今')).to.throw();
-          expect(() => crypto.uniform('abc今')).to.throw();
-        });
-      });
-
-      it('should hash "abc" to uniform number', () => {
-        if (expectedError) {
-          expectAsyncConsoleError(expectedError);
-        }
-        return crypto.uniform('abc').then(result => {
-          expect(result.toFixed(6)).to.equal('0.792976');
-        });
-      });
-    });
   }
 
   function createCrypto(win) {

--- a/test/unit/test-crypto.js
+++ b/test/unit/test-crypto.js
@@ -123,7 +123,7 @@ describes.realWin('crypto-impl', {}, env => {
     installDocService(win, /* isSingleDoc */ true);
     installExtensionsService(win);
     const extensions = Services.extensionsFor(win);
-    sandbox.stub(extensions, 'preloadExtension').callsFake(extensionId => {
+    env.sandbox.stub(extensions, 'preloadExtension').callsFake(extensionId => {
       expect(extensionId).to.equal('amp-crypto-polyfill');
       installCryptoPolyfill(win);
       return Promise.resolve();

--- a/test/unit/test-curve.js
+++ b/test/unit/test-curve.js
@@ -17,16 +17,6 @@
 import {Curves, bezierCurve, getCurve} from '../../src/curve';
 
 describe('Curve', () => {
-  let sandbox;
-
-  beforeEach(() => {
-    sandbox = sinon.sandbox;
-  });
-
-  afterEach(() => {
-    sandbox.restore();
-  });
-
   it('bezierCurve', () => {
     let curve = bezierCurve(0.75, 0, 0.75, 0.9);
     expect(curve(0.2)).to.be.closeTo(0.024374631, 1e-6);

--- a/test/unit/test-custom-element-registry.js
+++ b/test/unit/test-custom-element-registry.js
@@ -85,7 +85,7 @@ describes.realWin('CustomElement register', {amp: true}, env => {
     const script = document.createElement('script');
     script.setAttribute('custom-element', 'amp-element2');
     head.appendChild(script);
-    sandbox.stub(ampdoc, 'getHeadNode').callsFake(() => head);
+    env.sandbox.stub(ampdoc, 'getHeadNode').callsFake(() => head);
 
     stubElementsForDoc(ampdoc);
     expect(ampdoc.declaresExtension('amp-element2')).to.be.true;
@@ -93,7 +93,7 @@ describes.realWin('CustomElement register', {amp: true}, env => {
   });
 
   it('should install pre-stubbed element extension', () => {
-    const stub = sandbox.stub(extensions, 'installExtensionForDoc');
+    const stub = env.sandbox.stub(extensions, 'installExtensionForDoc');
 
     stubElementIfNotKnown(win, 'amp-element2');
     expect(win.__AMP_EXTENDED_ELEMENTS['amp-element2']).to.equal(ElementStub);
@@ -108,7 +108,7 @@ describes.realWin('CustomElement register', {amp: true}, env => {
 
   it('should not install declared pre-stubbed element extension', () => {
     ampdoc.declareExtension('amp-element2');
-    const stub = sandbox.stub(extensions, 'installExtensionForDoc');
+    const stub = env.sandbox.stub(extensions, 'installExtensionForDoc');
 
     stubElementIfNotKnown(win, 'amp-element2');
     expect(win.__AMP_EXTENDED_ELEMENTS['amp-element2']).to.equal(ElementStub);
@@ -122,7 +122,7 @@ describes.realWin('CustomElement register', {amp: true}, env => {
   });
 
   it('should not install declared pre-installed element', () => {
-    const stub = sandbox.stub(extensions, 'installExtensionForDoc');
+    const stub = env.sandbox.stub(extensions, 'installExtensionForDoc');
 
     registerElement(win, 'amp-element1', ConcreteElement);
     expect(win.__AMP_EXTENDED_ELEMENTS['amp-element1']).to.equal(
@@ -200,7 +200,7 @@ describes.realWin('CustomElement register', {amp: true}, env => {
       win = {
         document: doc,
         customElements: {
-          define: sandbox.spy(),
+          define: env.sandbox.spy(),
         },
         Object: {
           create: proto => Object.create(proto),
@@ -278,7 +278,7 @@ describes.realWin('CustomElement register', {amp: true}, env => {
     it('should copy or stub element definitions in a child window', () => {
       stubElementIfNotKnown(win, 'amp-test1');
 
-      const define = sandbox.spy();
+      const define = env.sandbox.spy();
       const childWin = {
         Object,
         HTMLElement,

--- a/test/unit/test-custom-element.js
+++ b/test/unit/test-custom-element.js
@@ -31,7 +31,7 @@ describes.realWin('CustomElement', {amp: true}, env => {
     .configure()
     .skipSafari()
     .run('CustomElement', () => {
-      let win, doc, ampdoc, sandbox;
+      let win, doc, ampdoc;
       let resources;
       let resourcesMock;
       let clock;
@@ -108,12 +108,11 @@ describes.realWin('CustomElement', {amp: true}, env => {
       beforeEach(() => {
         win = env.win;
         doc = win.document;
-        sandbox = env.sandbox;
         ampdoc = env.ampdoc;
         clock = lolex.install({target: win});
         resources = Services.resourcesForDoc(doc);
         resources.isBuildOn_ = true;
-        resourcesMock = sandbox.mock(resources);
+        resourcesMock = env.sandbox.mock(resources);
         container = doc.createElement('div');
         doc.body.appendChild(container);
         chunkInstanceForTesting(env.ampdoc);
@@ -132,18 +131,18 @@ describes.realWin('CustomElement', {amp: true}, env => {
         win.__AMP_EXTENDED_ELEMENTS['amp-stub'] = ElementStub;
         ampdoc.declareExtension('amp-stub');
 
-        testElementCreatedCallback = sandbox.spy();
-        testElementPreconnectCallback = sandbox.spy();
-        testElementFirstAttachedCallback = sandbox.spy();
-        testElementBuildCallback = sandbox.spy();
-        testElementCreatePlaceholderCallback = sandbox.spy();
-        testElementLayoutCallback = sandbox.spy();
-        testElementFirstLayoutCompleted = sandbox.spy();
-        testElementViewportCallback = sandbox.spy();
-        testElementGetInsersectionElementLayoutBox = sandbox.spy();
-        testElementUnlayoutCallback = sandbox.spy();
-        testElementPauseCallback = sandbox.spy();
-        testElementResumeCallback = sandbox.spy();
+        testElementCreatedCallback = env.sandbox.spy();
+        testElementPreconnectCallback = env.sandbox.spy();
+        testElementFirstAttachedCallback = env.sandbox.spy();
+        testElementBuildCallback = env.sandbox.spy();
+        testElementCreatePlaceholderCallback = env.sandbox.spy();
+        testElementLayoutCallback = env.sandbox.spy();
+        testElementFirstLayoutCompleted = env.sandbox.spy();
+        testElementViewportCallback = env.sandbox.spy();
+        testElementGetInsersectionElementLayoutBox = env.sandbox.spy();
+        testElementUnlayoutCallback = env.sandbox.spy();
+        testElementPauseCallback = env.sandbox.spy();
+        testElementResumeCallback = env.sandbox.spy();
       });
 
       afterEach(() => {
@@ -172,7 +171,9 @@ describes.realWin('CustomElement', {amp: true}, env => {
 
       it('Element - createdCallback', () => {
         const element = new ElementClass();
-        const build = sandbox.stub(element, 'build').returns(Promise.resolve());
+        const build = env.sandbox
+          .stub(element, 'build')
+          .returns(Promise.resolve());
 
         expect(element.isBuilt()).to.equal(false);
         expect(element.hasAttributes()).to.equal(false);
@@ -199,7 +200,7 @@ describes.realWin('CustomElement', {amp: true}, env => {
 
       it('StubElement - createdCallback', () => {
         const element = new StubElementClass();
-        sandbox.stub(element, 'build');
+        env.sandbox.stub(element, 'build');
 
         expect(element.isBuilt()).to.equal(false);
         expect(element.hasAttributes()).to.equal(false);
@@ -217,7 +218,7 @@ describes.realWin('CustomElement', {amp: true}, env => {
         expect(testElementCreatedCallback).to.have.not.been.called;
         expect(element.isUpgraded()).to.equal(false);
         // TODO(jeffkaufman, #13422): this test was silently failing.  `build` was
-        // the return value from `sandbox.stub(element, 'build')`.
+        // the return value from `env.sandbox.stub(element, 'build')`.
         //
         // expect(build.calledOnce).to.equal(true);
       });
@@ -225,7 +226,9 @@ describes.realWin('CustomElement', {amp: true}, env => {
       it('Element - should only add classes on first attachedCallback', () => {
         const element = new ElementClass();
         const buildPromise = Promise.resolve();
-        const buildStub = sandbox.stub(element, 'build').returns(buildPromise);
+        const buildStub = env.sandbox
+          .stub(element, 'build')
+          .returns(buildPromise);
 
         expect(element).to.not.have.class('i-amphtml-element');
         expect(element).to.not.have.class('i-amphtml-notbuilt');
@@ -251,7 +254,7 @@ describes.realWin('CustomElement', {amp: true}, env => {
 
       it('Element - handles async connectedCallback when disconnected', () => {
         const element = new ElementClass();
-        sandbox.defineProperty(element, 'isConnected', {
+        env.sandbox.defineProperty(element, 'isConnected', {
           value: false,
         });
 
@@ -270,11 +273,13 @@ describes.realWin('CustomElement', {amp: true}, env => {
         clock.tick(1);
         const element = new ElementClass();
         const buildPromise = Promise.resolve();
-        const buildStub = sandbox.stub(element, 'build').returns(buildPromise);
+        const buildStub = env.sandbox
+          .stub(element, 'build')
+          .returns(buildPromise);
         container.appendChild(element);
         container.removeChild(element);
 
-        sandbox
+        env.sandbox
           .stub(element, 'reconstructWhenReparented')
           .callsFake(() => true);
         element.layoutCount_ = 10;
@@ -294,11 +299,11 @@ describes.realWin('CustomElement', {amp: true}, env => {
       it('Element - should NOT reset on 2nd attachedCallback w/o request', () => {
         clock.tick(1);
         const element = new ElementClass();
-        sandbox.stub(element, 'build').returns(Promise.resolve());
+        env.sandbox.stub(element, 'build').returns(Promise.resolve());
         container.appendChild(element);
         container.removeChild(element);
 
-        sandbox
+        env.sandbox
           .stub(element, 'reconstructWhenReparented')
           .callsFake(() => false);
         element.layoutCount_ = 10;
@@ -334,12 +339,12 @@ describes.realWin('CustomElement', {amp: true}, env => {
 
       it('should tolerate errors in onLayoutMeasure', () => {
         const element = new ElementClass();
-        sandbox
+        env.sandbox
           .stub(element.implementation_, 'onLayoutMeasure')
           .callsFake(() => {
             throw new Error('intentional');
           });
-        const errorStub = sandbox.stub(
+        const errorStub = env.sandbox.stub(
           element,
           'dispatchCustomEventForTesting'
         );
@@ -359,7 +364,7 @@ describes.realWin('CustomElement', {amp: true}, env => {
           'have not changed',
         () => {
           const element = new ElementClass();
-          const onMeasureChangeStub = sandbox.stub(
+          const onMeasureChangeStub = env.sandbox.stub(
             element.implementation_,
             'onMeasureChanged'
           );
@@ -381,7 +386,7 @@ describes.realWin('CustomElement', {amp: true}, env => {
           'have changed',
         () => {
           const element = new ElementClass();
-          const onMeasureChangeStub = sandbox.stub(
+          const onMeasureChangeStub = env.sandbox.stub(
             element.implementation_,
             'onMeasureChanged'
           );
@@ -617,7 +622,7 @@ describes.realWin('CustomElement', {amp: true}, env => {
 
       it('should build on consent sufficient', () => {
         const element = new ElementClass();
-        sandbox
+        env.sandbox
           .stub(Services, 'consentPolicyServiceForDocOrNull')
           .callsFake(() => {
             return Promise.resolve({
@@ -626,7 +631,7 @@ describes.realWin('CustomElement', {amp: true}, env => {
               },
             });
           });
-        sandbox.stub(element, 'getConsentPolicy_').callsFake(() => {
+        env.sandbox.stub(element, 'getConsentPolicy_').callsFake(() => {
           return 'default';
         });
 
@@ -637,7 +642,7 @@ describes.realWin('CustomElement', {amp: true}, env => {
 
       it('should not build on consent insufficient', () => {
         const element = new ElementClass();
-        sandbox
+        env.sandbox
           .stub(Services, 'consentPolicyServiceForDocOrNull')
           .callsFake(() => {
             return Promise.resolve({
@@ -646,7 +651,7 @@ describes.realWin('CustomElement', {amp: true}, env => {
               },
             });
           });
-        sandbox.stub(element, 'getConsentPolicy_').callsFake(() => {
+        env.sandbox.stub(element, 'getConsentPolicy_').callsFake(() => {
           return 'default';
         });
 
@@ -686,9 +691,11 @@ describes.realWin('CustomElement', {amp: true}, env => {
 
       it('should anticipate build errors', () => {
         const element = new ElementClass();
-        sandbox.stub(element.implementation_, 'buildCallback').callsFake(() => {
-          throw new Error('intentional');
-        });
+        env.sandbox
+          .stub(element.implementation_, 'buildCallback')
+          .callsFake(() => {
+            throw new Error('intentional');
+          });
         container.appendChild(element);
         expect(element.isBuilt()).to.be.false;
         expect(element).to.have.class('i-amphtml-notbuilt');
@@ -903,7 +910,7 @@ describes.realWin('CustomElement', {amp: true}, env => {
           .expects('remove')
           .withExactArgs(element)
           .never();
-        sandbox.defineProperty(element, 'isConnected', {
+        env.sandbox.defineProperty(element, 'isConnected', {
           value: true,
         });
         container.removeChild(element);
@@ -1071,7 +1078,7 @@ describes.realWin('CustomElement', {amp: true}, env => {
 
       it('should enqueue actions until built', () => {
         const element = new ElementClass();
-        const handler = sandbox.spy();
+        const handler = env.sandbox.spy();
         element.implementation_.executeAction = handler;
         expect(element.actionQueue_).to.not.equal(null);
 
@@ -1084,7 +1091,7 @@ describes.realWin('CustomElement', {amp: true}, env => {
 
       it('should execute action immediately after built', () => {
         const element = new ElementClass();
-        const handler = sandbox.spy();
+        const handler = env.sandbox.spy();
         element.implementation_.executeAction = handler;
         container.appendChild(element);
         return element.build().then(() => {
@@ -1098,7 +1105,7 @@ describes.realWin('CustomElement', {amp: true}, env => {
 
       it('should dequeue all actions after build', () => {
         const element = new ElementClass();
-        const handler = sandbox.spy();
+        const handler = env.sandbox.spy();
         element.implementation_.executeAction = handler;
 
         const inv1 = {};
@@ -1124,7 +1131,7 @@ describes.realWin('CustomElement', {amp: true}, env => {
 
       it('should NOT enqueue actions when in template', () => {
         const element = new ElementClass();
-        const handler = sandbox.spy();
+        const handler = env.sandbox.spy();
         element.implementation_.executeAction = handler;
         expect(element.actionQueue_).to.not.equal(null);
 
@@ -1149,7 +1156,7 @@ describes.realWin('CustomElement', {amp: true}, env => {
           // path of element.applySizesAndMediaQuery is not behaving consistently
           // in headless mode, thus we mock the calls here. This is fine as we are
           // not testing window behavior.
-          matchMedia = sandbox.stub(
+          matchMedia = env.sandbox.stub(
             element1.ownerDocument.defaultView,
             'matchMedia'
           );
@@ -1378,7 +1385,10 @@ describes.realWin('CustomElement', {amp: true}, env => {
 
       it('should dispatch custom event size-changed when size changed', () => {
         const element = new ElementClass();
-        const spyDispatchEvent = sandbox.spy(element, 'dispatchCustomEvent');
+        const spyDispatchEvent = env.sandbox.spy(
+          element,
+          'dispatchCustomEvent'
+        );
 
         element.changeSize();
 
@@ -1743,7 +1753,7 @@ describes.realWin('CustomElement Service Elements', {amp: true}, env => {
     };
     element.getAmpDoc = () => doc;
     const owners = Services.ownersForDoc(doc);
-    owners.scheduleLayout = sandbox.mock();
+    owners.scheduleLayout = env.sandbox.mock();
     const fallback = element.appendChild(createWithAttr('fallback'));
     element.toggleFallback(true);
     expect(element).to.have.class('amp-notsupported');
@@ -1768,7 +1778,7 @@ describes.realWin('CustomElement Service Elements', {amp: true}, env => {
     };
     element.getAmpDoc = () => doc;
     const owners = Services.ownersForDoc(doc);
-    owners.scheduleLayout = sandbox.mock();
+    owners.scheduleLayout = env.sandbox.mock();
 
     element.appendChild(createWithAttr('fallback'));
     element.toggleFallback(true);
@@ -1813,7 +1823,7 @@ describes.realWin('CustomElement', {amp: true}, env => {
       }
 
       function stubInA4A(isInA4A) {
-        sandbox.stub(element, 'isInA4A').callsFake(() => isInA4A);
+        env.sandbox.stub(element, 'isInA4A').callsFake(() => isInA4A);
       }
 
       beforeEach(() => {
@@ -1830,14 +1840,14 @@ describes.realWin('CustomElement', {amp: true}, env => {
         LOADING_ELEMENTS_['amp-test-loader'.toUpperCase()] = true;
         resources = Services.resourcesForDoc(doc);
         resources.isBuildOn_ = true;
-        resourcesMock = sandbox.mock(resources);
+        resourcesMock = env.sandbox.mock(resources);
         element = new ElementClass();
         element.layoutWidth_ = 300;
         element.layout_ = Layout.FIXED;
         element.setAttribute('layout', 'fixed');
         element.resources_ = resources;
         vsync = Services.vsyncFor(win);
-        sandbox.stub(vsync, 'run').callsFake(task => {
+        env.sandbox.stub(vsync, 'run').callsFake(task => {
           if (task.measure) {
             task.measure();
           }
@@ -1934,7 +1944,7 @@ describes.realWin('CustomElement', {amp: true}, env => {
       it('should cancel loading on render-start', () => {
         stubInA4A(false);
         clock.tick(1);
-        const stub = sandbox.stub(element, 'toggleLoading');
+        const stub = env.sandbox.stub(element, 'toggleLoading');
         element.renderStarted();
         expect(element.signals().get(CommonSignals.RENDER_START)).to.be.ok;
         expect(stub).to.be.calledOnce;
@@ -1999,7 +2009,7 @@ describes.realWin('CustomElement', {amp: true}, env => {
         element.setAttribute('layout', 'fill');
         container.appendChild(element);
         element.prepareLoading_();
-        sandbox
+        env.sandbox
           .stub(element.implementation_, 'isLoadingReused')
           .callsFake(() => true);
         element.toggleLoading(false, {cleanup: true});
@@ -2021,7 +2031,7 @@ describes.realWin('CustomElement', {amp: true}, env => {
       it('should turn off when exits viewport', () => {
         stubInA4A(false);
         element.isInViewport_ = true;
-        const toggle = sandbox.spy(element, 'toggleLoading');
+        const toggle = env.sandbox.spy(element, 'toggleLoading');
         element.viewportCallback(false);
         expect(toggle).to.be.calledOnce;
         expect(toggle.firstCall.args[0]).to.equal(false);
@@ -2030,7 +2040,7 @@ describes.realWin('CustomElement', {amp: true}, env => {
 
       it('should NOT turn off when exits viewport but already laid out', () => {
         stubInA4A(false);
-        const toggle = sandbox.spy(element, 'toggleLoading');
+        const toggle = env.sandbox.spy(element, 'toggleLoading');
         element.layoutCount_ = 1;
         element.viewportCallback(false);
         expect(toggle).to.have.not.been.called;
@@ -2038,7 +2048,7 @@ describes.realWin('CustomElement', {amp: true}, env => {
 
       it('should turn on when enters viewport', () => {
         stubInA4A(false);
-        const toggle = sandbox.spy(element, 'toggleLoading');
+        const toggle = env.sandbox.spy(element, 'toggleLoading');
         element.setAttribute('layout', 'fill');
         container.appendChild(element);
         element.viewportCallback(true);
@@ -2049,7 +2059,7 @@ describes.realWin('CustomElement', {amp: true}, env => {
 
       it('should NOT turn on when enters viewport but already laid out', () => {
         stubInA4A(false);
-        const toggle = sandbox.spy(element, 'toggleLoading');
+        const toggle = env.sandbox.spy(element, 'toggleLoading');
         element.layoutCount_ = 1;
         element.viewportCallback(true);
         clock.tick(1000);
@@ -2058,7 +2068,7 @@ describes.realWin('CustomElement', {amp: true}, env => {
 
       it('should start loading when measured if already in viewport', () => {
         stubInA4A(false);
-        const toggle = sandbox.spy(element, 'toggleLoading');
+        const toggle = env.sandbox.spy(element, 'toggleLoading');
         element.isInViewport_ = true;
         element.setAttribute('layout', 'fill');
         container.appendChild(element);
@@ -2069,7 +2079,7 @@ describes.realWin('CustomElement', {amp: true}, env => {
 
       it('should create loading when measured if in the top window', () => {
         stubInA4A(false);
-        const toggle = sandbox.spy(element, 'toggleLoading');
+        const toggle = env.sandbox.spy(element, 'toggleLoading');
         element.setAttribute('layout', 'fill');
         container.appendChild(element);
         element.updateLayoutBox({top: 0, width: 300});
@@ -2080,7 +2090,7 @@ describes.realWin('CustomElement', {amp: true}, env => {
 
       it('should toggle loading off after layout complete', () => {
         stubInA4A(false);
-        const toggle = sandbox.spy(element, 'toggleLoading');
+        const toggle = env.sandbox.spy(element, 'toggleLoading');
         container.appendChild(element);
         return element.buildingPromise_
           .then(() => {
@@ -2095,8 +2105,8 @@ describes.realWin('CustomElement', {amp: true}, env => {
 
       it('should toggle loading off after layout failed', () => {
         stubInA4A(false);
-        const toggle = sandbox.spy(element, 'toggleLoading');
-        sandbox
+        const toggle = env.sandbox.spy(element, 'toggleLoading');
+        env.sandbox
           .stub(element.implementation_, 'layoutCallback')
           .callsFake(() => {
             return Promise.reject();
@@ -2120,8 +2130,8 @@ describes.realWin('CustomElement', {amp: true}, env => {
 
       it('should disable toggle loading on after layout failed', () => {
         stubInA4A(false);
-        const prepareLoading = sandbox.spy(element, 'prepareLoading_');
-        sandbox
+        const prepareLoading = env.sandbox.spy(element, 'prepareLoading_');
+        env.sandbox
           .stub(element.implementation_, 'layoutCallback')
           .callsFake(() => {
             return Promise.reject();
@@ -2198,7 +2208,7 @@ describes.realWin('CustomElement Overflow Element', {amp: true}, env => {
     );
     win.customElements.define('amp-test-overflow', ElementClass);
     resources = Services.resourcesForDoc(doc);
-    resourcesMock = sandbox.mock(resources);
+    resourcesMock = env.sandbox.mock(resources);
     element = new ElementClass();
     element.layoutWidth_ = 300;
     element.layout_ = Layout.FIXED;
@@ -2207,7 +2217,7 @@ describes.realWin('CustomElement Overflow Element', {amp: true}, env => {
     overflowElement.setAttribute('overflow', '');
     element.appendChild(overflowElement);
     vsync = Services.vsyncFor(win);
-    sandbox.stub(vsync, 'run').callsFake(task => {
+    env.sandbox.stub(vsync, 'run').callsFake(task => {
       if (task.measure) {
         task.measure();
       }

--- a/test/unit/test-document-info.js
+++ b/test/unit/test-document-info.js
@@ -25,15 +25,8 @@ describe
   .configure()
   .skipFirefox()
   .run('document-info', () => {
-    let sandbox;
-
     beforeEach(() => {
-      sandbox = sinon.sandbox;
-      sandbox.stub(CID, 'getRandomString64').returns('abcdef');
-    });
-
-    afterEach(() => {
-      sandbox.restore();
+      window.sandbox.stub(CID, 'getRandomString64').returns('abcdef');
     });
 
     function getWin(links, metas) {
@@ -62,7 +55,7 @@ describe
         }
         const {win} = iframe;
         installDocService(win, /* isSingleDoc */ true);
-        sandbox.stub(win.Math, 'random').callsFake(() => 0.123456789);
+        window.sandbox.stub(win.Math, 'random').callsFake(() => 0.123456789);
         win.__AMP_SERVICES.documentInfo = null;
         installDocumentInfoServiceForDoc(win.document);
         return iframe.win;

--- a/test/unit/test-document-ready.js
+++ b/test/unit/test-document-ready.js
@@ -23,13 +23,11 @@ import {
 } from '../../src/document-ready';
 
 describe('documentReady', () => {
-  let sandbox;
   let testDoc;
   let eventListeners;
   const timer = Services.timerFor(window);
 
   beforeEach(() => {
-    sandbox = sinon.sandbox;
     eventListeners = {};
     testDoc = {
       readyState: 'loading',
@@ -42,10 +40,6 @@ describe('documentReady', () => {
         }
       },
     };
-  });
-
-  afterEach(() => {
-    sandbox.restore();
   });
 
   it('should interpret readyState correctly', () => {
@@ -63,7 +57,7 @@ describe('documentReady', () => {
 
   it('should call callback immediately when ready', () => {
     testDoc.readyState = 'complete';
-    const callback = sandbox.spy();
+    const callback = window.sandbox.spy();
     onDocumentReady(testDoc, callback);
     expect(callback).to.be.calledOnce;
     expect(callback.getCall(0).args).to.deep.equal([testDoc]);
@@ -71,7 +65,7 @@ describe('documentReady', () => {
 
   it('should wait to call callback until ready', () => {
     testDoc.readyState = 'loading';
-    const callback = sandbox.spy();
+    const callback = window.sandbox.spy();
     onDocumentReady(testDoc, callback);
     expect(callback).to.have.not.been.called;
     expect(eventListeners['readystatechange']).to.not.equal(undefined);
@@ -86,7 +80,7 @@ describe('documentReady', () => {
 
   it('should wait to call callback for several loading events', () => {
     testDoc.readyState = 'loading';
-    const callback = sandbox.spy();
+    const callback = window.sandbox.spy();
     onDocumentReady(testDoc, callback);
     expect(callback).to.have.not.been.called;
     expect(eventListeners['readystatechange']).to.not.equal(undefined);
@@ -107,9 +101,9 @@ describe('documentReady', () => {
   describe('whenDocumentReady', () => {
     it('should call callback immediately when ready', () => {
       testDoc.readyState = 'complete';
-      const spy = sandbox.spy();
-      const spy2 = sandbox.spy();
-      const spy3 = sandbox.spy();
+      const spy = window.sandbox.spy();
+      const spy2 = window.sandbox.spy();
+      const spy3 = window.sandbox.spy();
 
       whenDocumentReady(testDoc)
         .then(spy)
@@ -130,7 +124,7 @@ describe('documentReady', () => {
     });
 
     it('should not call callback', () => {
-      const spy = sandbox.spy();
+      const spy = window.sandbox.spy();
       whenDocumentReady(testDoc).then(spy);
       expect(spy).to.have.not.been.called;
       return timer.promise().then(() => {
@@ -140,7 +134,7 @@ describe('documentReady', () => {
 
     it('should wait to call callback until ready', () => {
       testDoc.readyState = 'loading';
-      const callback = sandbox.spy();
+      const callback = window.sandbox.spy();
       whenDocumentReady(testDoc).then(callback);
 
       return timer.promise().then(() => {
@@ -163,9 +157,9 @@ describe('documentReady', () => {
   describe('whenDocumentComplete', () => {
     it('should call callback immediately when complete', () => {
       testDoc.readyState = 'complete';
-      const spy = sandbox.spy();
-      const spy2 = sandbox.spy();
-      const spy3 = sandbox.spy();
+      const spy = window.sandbox.spy();
+      const spy2 = window.sandbox.spy();
+      const spy3 = window.sandbox.spy();
 
       whenDocumentComplete(testDoc)
         .then(spy)
@@ -186,7 +180,7 @@ describe('documentReady', () => {
     });
 
     it('should not call callback', () => {
-      const spy = sandbox.spy();
+      const spy = window.sandbox.spy();
       whenDocumentComplete(testDoc).then(spy);
       expect(spy).to.have.not.been.called;
       return timer.promise().then(() => {
@@ -196,7 +190,7 @@ describe('documentReady', () => {
 
     it('should wait to call callback until ready', () => {
       testDoc.readyState = 'loading';
-      const callback = sandbox.spy();
+      const callback = window.sandbox.spy();
       whenDocumentComplete(testDoc).then(callback);
 
       return timer.promise().then(() => {

--- a/test/unit/test-document-submit.js
+++ b/test/unit/test-document-submit.js
@@ -20,7 +20,7 @@ import {
   onDocumentFormSubmit_,
 } from '../../src/document-submit';
 
-describes.sandboxed('test-document-submit', {}, () => {
+describes.sandboxed('test-document-submit', {}, env => {
   describe('installGlobalSubmitListenerForDoc', () => {
     let ampdoc;
     let headNode;
@@ -50,7 +50,7 @@ describes.sandboxed('test-document-submit', {}, () => {
 
     it('should not register submit listener if amp-form is not registered.', () => {
       ampdoc.getHeadNode().appendChild(createScript('amp-list'));
-      sandbox.spy(rootNode, 'addEventListener');
+      env.sandbox.spy(rootNode, 'addEventListener');
       return installGlobalSubmitListenerForDoc(ampdoc).then(() => {
         expect(rootNode.addEventListener).not.to.have.been.called;
       });
@@ -58,7 +58,7 @@ describes.sandboxed('test-document-submit', {}, () => {
 
     it('should register submit listener if amp-form extension is registered.', () => {
       ampdoc.getHeadNode().appendChild(createScript('amp-form'));
-      sandbox.spy(rootNode, 'addEventListener');
+      env.sandbox.spy(rootNode, 'addEventListener');
       return installGlobalSubmitListenerForDoc(ampdoc).then(() => {
         expect(rootNode.addEventListener).called;
       });
@@ -75,12 +75,12 @@ describes.sandboxed('test-document-submit', {}, () => {
     beforeEach(() => {
       window = env.win;
       document = window.document;
-      preventDefaultSpy = sandbox.spy();
-      stopImmediatePropagationSpy = sandbox.spy();
+      preventDefaultSpy = env.sandbox.spy();
+      stopImmediatePropagationSpy = env.sandbox.spy();
       tgt = document.createElement('form');
       tgt.action = 'https://www.google.com';
       tgt.target = '_blank';
-      tgt.checkValidity = sandbox.stub().returns(true);
+      tgt.checkValidity = env.sandbox.stub().returns(true);
       evt = {
         target: tgt,
         preventDefault: preventDefaultSpy,
@@ -199,15 +199,14 @@ describes.sandboxed('test-document-submit', {}, () => {
     });
 
     it('should prevent submit', () => {
-      tgt.checkValidity = sandbox.stub().returns(false);
+      tgt.checkValidity = env.sandbox.stub().returns(false);
       onDocumentFormSubmit_(evt);
       expect(preventDefaultSpy).to.be.calledOnce;
       expect(tgt.checkValidity).to.be.calledOnce;
-      sandbox.restore();
       preventDefaultSpy.resetHistory();
       tgt.checkValidity.reset();
 
-      tgt.checkValidity = sandbox.stub().returns(false);
+      tgt.checkValidity = env.sandbox.stub().returns(false);
       onDocumentFormSubmit_(evt);
       expect(preventDefaultSpy).to.be.calledOnce;
       expect(tgt.checkValidity).to.be.calledOnce;
@@ -215,14 +214,14 @@ describes.sandboxed('test-document-submit', {}, () => {
 
     it('should not check validity if novalidate provided', () => {
       tgt.setAttribute('novalidate', '');
-      tgt.checkValidity = sandbox.stub().returns(false);
+      tgt.checkValidity = env.sandbox.stub().returns(false);
       onDocumentFormSubmit_(evt);
       expect(preventDefaultSpy).to.have.not.been.called;
       expect(tgt.checkValidity).to.have.not.been.called;
     });
 
     it('should not prevent default', () => {
-      tgt.checkValidity = sandbox.stub().returns(true);
+      tgt.checkValidity = env.sandbox.stub().returns(true);
       onDocumentFormSubmit_(evt);
       expect(preventDefaultSpy).to.have.not.been.called;
       expect(tgt.checkValidity).to.be.calledOnce;
@@ -231,7 +230,7 @@ describes.sandboxed('test-document-submit', {}, () => {
     it('should delegate xhr submit through action service', () => {
       evt.target.setAttribute('action-xhr', 'https://example.com');
       const actionService = Services.actionServiceForDoc(tgt);
-      sandbox.stub(actionService, 'execute');
+      env.sandbox.stub(actionService, 'execute');
       onDocumentFormSubmit_(evt);
       expect(actionService.execute).to.have.been.calledOnce;
       expect(actionService.execute).to.have.been.calledWith(
@@ -248,7 +247,7 @@ describes.sandboxed('test-document-submit', {}, () => {
 
     it('should not delegate non-XHR submit through action service', () => {
       const actionService = Services.actionServiceForDoc(tgt);
-      sandbox.stub(actionService, 'execute');
+      env.sandbox.stub(actionService, 'execute');
       onDocumentFormSubmit_(evt);
       expect(actionService.execute).to.have.not.been.called;
     });

--- a/test/unit/test-dom.js
+++ b/test/unit/test-dom.js
@@ -23,16 +23,9 @@ import {setShadowDomSupportedVersionForTesting} from '../../src/web-components';
 import {toArray} from '../../src/types';
 
 describes.sandboxed('DOM', {}, env => {
-  let sandbox;
-
-  beforeEach(() => {
-    sandbox = env.sandbox;
-  });
-
   afterEach(() => {
     setScopeSelectorSupportedForTesting(undefined);
     setShadowDomSupportedVersionForTesting(undefined);
-    sandbox.restore();
   });
 
   it('should remove all children', () => {
@@ -89,7 +82,7 @@ describes.sandboxed('DOM', {}, env => {
   });
 
   it('isConnectedNode (no Node.p.isConnected)', () => {
-    sandbox.deleteProperty(Node.prototype, 'isConnected');
+    env.sandbox.deleteProperty(Node.prototype, 'isConnected');
     expect(dom.isConnectedNode(document)).to.be.true;
 
     const a = document.createElement('div');
@@ -124,7 +117,7 @@ describes.sandboxed('DOM', {}, env => {
   });
 
   it('rootNodeFor (no Node.p.getRootNode)', () => {
-    sandbox.deleteProperty(Node.prototype, 'getRootNode');
+    env.sandbox.deleteProperty(Node.prototype, 'getRootNode');
 
     const a = document.createElement('div');
     expect(dom.rootNodeFor(a)).to.equal(a);
@@ -197,7 +190,7 @@ describes.sandboxed('DOM', {}, env => {
   });
 
   it('closest should stop search at opt_stopAt', () => {
-    const cbSpy = sandbox.spy();
+    const cbSpy = env.sandbox.spy();
     const cb = el => {
       cbSpy();
       return el.tagName == 'DIV';
@@ -558,11 +551,11 @@ describes.sandboxed('DOM', {}, env => {
     const fragment = document.createDocumentFragment();
     [0, 1, 2].forEach(() => fragment.appendChild(document.createElement('i')));
 
-    const iSpy = sandbox.spy();
+    const iSpy = env.sandbox.spy();
     dom.iterateCursor(fragment.querySelectorAll('i'), iSpy);
     expect(iSpy).to.be.calledThrice;
 
-    const bSpy = sandbox.spy();
+    const bSpy = env.sandbox.spy();
     dom.iterateCursor(fragment.querySelectorAll('b'), bSpy);
     expect(bSpy).to.have.not.been.called;
   });
@@ -570,7 +563,7 @@ describes.sandboxed('DOM', {}, env => {
   it('iterateCursor should allow null elements in a list', () => {
     const list = ['wow', null, 'cool'];
 
-    const spy = sandbox.spy();
+    const spy = env.sandbox.spy();
     dom.iterateCursor(list, spy);
     expect(spy).to.be.calledThrice;
   });
@@ -641,13 +634,13 @@ describes.sandboxed('DOM', {}, env => {
 
     it('should immediately return if child is available', () => {
       parent.appendChild(child);
-      const spy = sandbox.spy();
+      const spy = env.sandbox.spy();
       dom.waitForChild(parent, contains, spy);
       expect(spy).to.be.calledOnce;
     });
 
     it('should wait until child is available', () => {
-      const spy = sandbox.spy();
+      const spy = env.sandbox.spy();
       dom.waitForChild(parent, contains, spy);
       expect(spy).to.have.not.been.called;
 
@@ -667,8 +660,8 @@ describes.sandboxed('DOM', {}, env => {
     it('should prefer MutationObserver and disconnect when done', () => {
       let mutationCallback;
       const mutationObserver = {
-        observe: sandbox.spy(),
-        disconnect: sandbox.spy(),
+        observe: env.sandbox.spy(),
+        disconnect: env.sandbox.spy(),
       };
       const parent = {
         ownerDocument: {
@@ -682,7 +675,7 @@ describes.sandboxed('DOM', {}, env => {
       };
       let checkFuncValue = false;
       const checkFunc = () => checkFuncValue;
-      const spy = sandbox.spy();
+      const spy = env.sandbox.spy();
 
       dom.waitForChild(parent, checkFunc, spy);
       expect(spy).to.have.not.been.called;
@@ -712,7 +705,7 @@ describes.sandboxed('DOM', {}, env => {
           intervalCallback = callback;
           return 123;
         },
-        clearInterval: sandbox.spy(),
+        clearInterval: env.sandbox.spy(),
       };
       const parent = {
         ownerDocument: {
@@ -721,7 +714,7 @@ describes.sandboxed('DOM', {}, env => {
       };
       let checkFuncValue = false;
       const checkFunc = () => checkFuncValue;
-      const spy = sandbox.spy();
+      const spy = env.sandbox.spy();
 
       dom.waitForChild(parent, checkFunc, spy);
       expect(spy).to.have.not.been.called;
@@ -881,7 +874,7 @@ describes.sandboxed('DOM', {}, env => {
           throw new Error('not mocked');
         },
       };
-      windowMock = sandbox.mock(windowApi);
+      windowMock = env.sandbox.mock(windowApi);
     });
 
     afterEach(() => {
@@ -1088,7 +1081,7 @@ describes.sandboxed('DOM', {}, env => {
       const element = {
         focus() {},
       };
-      const focusSpy = sandbox.spy(element, 'focus');
+      const focusSpy = env.sandbox.spy(element, 'focus');
       dom.tryFocus(element);
       expect(focusSpy).to.have.been.called;
     });
@@ -1099,7 +1092,7 @@ describes.sandboxed('DOM', {}, env => {
           throw new Error('Cannot focus');
         },
       };
-      const focusSpy = sandbox.spy(element, 'focus');
+      const focusSpy = env.sandbox.spy(element, 'focus');
       dom.tryFocus(element);
       expect(focusSpy).to.have.been.called;
       expect(focusSpy).to.not.throw;

--- a/test/unit/test-event-helper.js
+++ b/test/unit/test-event-helper.js
@@ -37,7 +37,6 @@ describe('EventHelper', () => {
     return event;
   }
 
-  let sandbox;
   let element;
   let loadObservable;
   let errorObservable;
@@ -45,7 +44,6 @@ describe('EventHelper', () => {
   let removeEventListenerStub;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox;
     loadObservable = new Observable();
     errorObservable = new Observable();
     element = {
@@ -84,8 +82,6 @@ describe('EventHelper', () => {
     // Very important that all listeners are removed.
     expect(loadObservable.getHandlerCount()).to.equal(0);
     expect(errorObservable.getHandlerCount()).to.equal(0);
-
-    sandbox.restore();
   });
 
   it('listen', () => {
@@ -297,7 +293,7 @@ describe('EventHelper', () => {
     expect(native.type).to.equal('foo');
     expect(native.detail).to.deep.equal({bar: 123});
 
-    const initCustomEventSpy = sandbox.spy();
+    const initCustomEventSpy = window.sandbox.spy();
     const win = {};
     win.CustomEvent = {};
     win.document = {};
@@ -320,11 +316,11 @@ describe('EventHelper', () => {
       }
     };
     // Simulate an addEventListener that accepts options
-    addEventListenerStub = sandbox
+    addEventListenerStub = window.sandbox
       .stub(self, 'addEventListener')
       .callsFake(eventListenerStubAcceptOpts);
     // Simulate a removeEventListener that accepts options
-    removeEventListenerStub = sandbox
+    removeEventListenerStub = window.sandbox
       .stub(self, 'removeEventListener')
       .callsFake(eventListenerStubAcceptOpts);
     resetEvtListenerOptsSupportForTesting();
@@ -352,11 +348,11 @@ describe('EventHelper', () => {
       }
     };
     // Simulate an addEventListener that does not accept options
-    addEventListenerStub = sandbox
+    addEventListenerStub = window.sandbox
       .stub(self, 'addEventListener')
       .callsFake(eventListenerStubRejectOpts);
     // Simulate a removeEventListener that does not accept options
-    removeEventListenerStub = sandbox
+    removeEventListenerStub = window.sandbox
       .stub(self, 'removeEventListener')
       .callsFake(eventListenerStubRejectOpts);
     resetEvtListenerOptsSupportForTesting();

--- a/test/unit/test-experiments.js
+++ b/test/unit/test-experiments.js
@@ -106,10 +106,8 @@ describe('experimentToggles', () => {
 
 describe('isExperimentOn', () => {
   let win;
-  let sandbox;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox;
     win = {
       localStorage: fakeLocalStorage(),
       AMP_CONFIG: {},
@@ -118,10 +116,6 @@ describe('isExperimentOn', () => {
         href: 'http://foo.bar',
       },
     };
-  });
-
-  afterEach(() => {
-    sandbox.restore();
   });
 
   function expectExperiment(storedString, experimentId) {
@@ -190,7 +184,7 @@ describe('isExperimentOn', () => {
       win.AMP_CONFIG['e2'] = 0;
       expectExperiment('', 'e2').to.be.false;
 
-      sandbox.stub(Math, 'random').returns(0.5);
+      window.sandbox.stub(Math, 'random').returns(0.5);
       win.AMP_CONFIG['e3'] = 0.3;
       expectExperiment('', 'e3').to.be.false;
 
@@ -205,7 +199,7 @@ describe('isExperimentOn', () => {
     });
 
     it('should cache calc value', () => {
-      sandbox.stub(Math, 'random').returns(0.4);
+      window.sandbox.stub(Math, 'random').returns(0.4);
       win.AMP_CONFIG['e1'] = 0.5;
       win.AMP_CONFIG['e2'] = 0.1;
 
@@ -216,17 +210,14 @@ describe('isExperimentOn', () => {
 });
 
 describe('toggleExperiment', () => {
-  let sandbox;
   let clock;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox;
-    clock = sandbox.useFakeTimers();
+    clock = window.sandbox.useFakeTimers();
     clock.tick(1);
   });
 
   afterEach(() => {
-    sandbox.restore();
     resetExperimentTogglesForTesting(window);
   });
 
@@ -573,7 +564,6 @@ describe('getBinaryType', () => {
 
 describe('experiment branch tests', () => {
   describe('#randomlySelectUnsetExperiments', () => {
-    let sandbox;
     let accurateRandomStub;
     let cachedAccuratePrng;
     let testExperimentSet;
@@ -586,8 +576,7 @@ describe('experiment branch tests', () => {
           branches: ['branch1_id', 'branch2_id'],
         },
       };
-      sandbox = sinon.sandbox;
-      sandbox.win = {
+      window.sandbox.win = {
         location: {
           hostname: 'test.server.name.com',
         },
@@ -599,73 +588,73 @@ describe('experiment branch tests', () => {
           querySelector: () => {},
         },
       };
-      accurateRandomStub = sandbox.stub().returns(-1);
+      accurateRandomStub = window.sandbox.stub().returns(-1);
       cachedAccuratePrng = RANDOM_NUMBER_GENERATORS.accuratePrng;
       RANDOM_NUMBER_GENERATORS.accuratePrng = accurateRandomStub;
     });
 
     afterEach(() => {
-      sandbox.restore();
       RANDOM_NUMBER_GENERATORS.accuratePrng = cachedAccuratePrng;
     });
 
     it('handles empty experiments list', () => {
       // Opt out of experiment.
-      toggleExperiment(sandbox.win, 'testExperimentId', false, true);
-      randomlySelectUnsetExperiments(sandbox.win, {});
+      toggleExperiment(window.sandbox.win, 'testExperimentId', false, true);
+      randomlySelectUnsetExperiments(window.sandbox.win, {});
       expect(
-        isExperimentOn(sandbox.win, 'testExperimentId'),
+        isExperimentOn(window.sandbox.win, 'testExperimentId'),
         'experiment is on'
       ).to.be.false;
-      expect(sandbox.win.__AMP_EXPERIMENT_BRANCHES).to.be.empty;
+      expect(window.sandbox.win.__AMP_EXPERIMENT_BRANCHES).to.be.empty;
     });
 
     it('handles experiment not diverted path', () => {
       // Opt out of experiment.
-      toggleExperiment(sandbox.win, 'testExperimentId', false, true);
-      randomlySelectUnsetExperiments(sandbox.win, testExperimentSet);
+      toggleExperiment(window.sandbox.win, 'testExperimentId', false, true);
+      randomlySelectUnsetExperiments(window.sandbox.win, testExperimentSet);
       expect(
-        isExperimentOn(sandbox.win, 'testExperimentId'),
+        isExperimentOn(window.sandbox.win, 'testExperimentId'),
         'experiment is on'
       ).to.be.false;
-      expect(getExperimentBranch(sandbox.win, 'testExperimentId')).to.not.be.ok;
+      expect(getExperimentBranch(window.sandbox.win, 'testExperimentId')).to.not
+        .be.ok;
     });
 
     it('handles experiment diverted path 1', () => {
       // Force experiment on.
-      toggleExperiment(sandbox.win, 'testExperimentId', true, true);
+      toggleExperiment(window.sandbox.win, 'testExperimentId', true, true);
       // force the control branch to be chosen by making the accurate PRNG
       // return a value < 0.5.
       RANDOM_NUMBER_GENERATORS.accuratePrng.onFirstCall().returns(0.3);
-      randomlySelectUnsetExperiments(sandbox.win, testExperimentSet);
+      randomlySelectUnsetExperiments(window.sandbox.win, testExperimentSet);
       expect(
-        isExperimentOn(sandbox.win, 'testExperimentId'),
+        isExperimentOn(window.sandbox.win, 'testExperimentId'),
         'experiment is on'
       ).to.be.true;
-      expect(getExperimentBranch(sandbox.win, 'testExperimentId')).to.equal(
-        'branch1_id'
-      );
+      expect(
+        getExperimentBranch(window.sandbox.win, 'testExperimentId')
+      ).to.equal('branch1_id');
     });
 
     it('handles experiment diverted path 2', () => {
       // Force experiment on.
-      toggleExperiment(sandbox.win, 'testExperimentId', true, true);
+      toggleExperiment(window.sandbox.win, 'testExperimentId', true, true);
       // Force the experiment branch to be chosen by making the accurate PRNG
       // return a value > 0.5.
       RANDOM_NUMBER_GENERATORS.accuratePrng.onFirstCall().returns(0.6);
-      randomlySelectUnsetExperiments(sandbox.win, testExperimentSet);
+      randomlySelectUnsetExperiments(window.sandbox.win, testExperimentSet);
       expect(
-        isExperimentOn(sandbox.win, 'testExperimentId'),
+        isExperimentOn(window.sandbox.win, 'testExperimentId'),
         'experiment is on'
       ).to.be.true;
-      expect(getExperimentBranch(sandbox.win, 'testExperimentId')).to.equal(
-        'branch2_id'
-      );
+      expect(
+        getExperimentBranch(window.sandbox.win, 'testExperimentId')
+      ).to.equal('branch2_id');
     });
 
     it('picks a branch if traffic eligible', () => {
-      toggleExperiment(sandbox.win, 'expt_0', true, true);
-      sandbox.win.trafficEligible = true;
+      toggleExperiment(window.sandbox.win, 'expt_0', true, true);
+      window.sandbox.win.trafficEligible = true;
       const experimentInfo = {
         'expt_0': {
           isTrafficEligible: win => {
@@ -675,14 +664,14 @@ describe('experiment branch tests', () => {
         },
       };
       RANDOM_NUMBER_GENERATORS.accuratePrng.returns(0.3);
-      randomlySelectUnsetExperiments(sandbox.win, experimentInfo);
-      expect(isExperimentOn(sandbox.win, 'expt_0')).to.be.true;
-      expect(getExperimentBranch(sandbox.win, 'expt_0')).to.equal('0_0');
+      randomlySelectUnsetExperiments(window.sandbox.win, experimentInfo);
+      expect(isExperimentOn(window.sandbox.win, 'expt_0')).to.be.true;
+      expect(getExperimentBranch(window.sandbox.win, 'expt_0')).to.equal('0_0');
     });
 
     it("doesn't pick a branch if traffic ineligible", () => {
-      toggleExperiment(sandbox.win, 'expt_0', true, true);
-      sandbox.win.trafficEligible = false;
+      toggleExperiment(window.sandbox.win, 'expt_0', true, true);
+      window.sandbox.win.trafficEligible = false;
       const experimentInfo = {
         'expt_0': {
           isTrafficEligible: win => {
@@ -692,13 +681,13 @@ describe('experiment branch tests', () => {
         },
       };
       RANDOM_NUMBER_GENERATORS.accuratePrng.returns(0.3);
-      randomlySelectUnsetExperiments(sandbox.win, experimentInfo);
-      expect(isExperimentOn(sandbox.win, 'expt_0')).to.be.true;
-      expect(getExperimentBranch(sandbox.win, 'expt_0')).to.be.null;
+      randomlySelectUnsetExperiments(window.sandbox.win, experimentInfo);
+      expect(isExperimentOn(window.sandbox.win, 'expt_0')).to.be.true;
+      expect(getExperimentBranch(window.sandbox.win, 'expt_0')).to.be.null;
     });
 
     it("doesn't pick a branch if no traffic eligibility function", () => {
-      toggleExperiment(sandbox.win, 'expt_0', true, true);
+      toggleExperiment(window.sandbox.win, 'expt_0', true, true);
       const experimentInfo = {
         'expt_0': {
           isTrafficEligible: undefined,
@@ -706,17 +695,17 @@ describe('experiment branch tests', () => {
         },
       };
       RANDOM_NUMBER_GENERATORS.accuratePrng.returns(0.3);
-      randomlySelectUnsetExperiments(sandbox.win, experimentInfo);
-      expect(isExperimentOn(sandbox.win, 'expt_0')).to.be.true;
-      expect(getExperimentBranch(sandbox.win, 'expt_0')).to.be.null;
+      randomlySelectUnsetExperiments(window.sandbox.win, experimentInfo);
+      expect(isExperimentOn(window.sandbox.win, 'expt_0')).to.be.true;
+      expect(getExperimentBranch(window.sandbox.win, 'expt_0')).to.be.null;
     });
 
     it(
       "doesn't pick a branch if traffic becomes eligible after first " +
         'diversion',
       () => {
-        toggleExperiment(sandbox.win, 'expt_0', true, true);
-        sandbox.win.trafficEligible = false;
+        toggleExperiment(window.sandbox.win, 'expt_0', true, true);
+        window.sandbox.win.trafficEligible = false;
         const experimentInfo = {
           'expt_0': {
             isTrafficEligible: win => {
@@ -727,23 +716,23 @@ describe('experiment branch tests', () => {
         };
         RANDOM_NUMBER_GENERATORS.accuratePrng.returns(0.3);
 
-        randomlySelectUnsetExperiments(sandbox.win, experimentInfo);
-        expect(isExperimentOn(sandbox.win, 'expt_0')).to.be.true;
-        expect(getExperimentBranch(sandbox.win, 'expt_0')).to.be.null;
+        randomlySelectUnsetExperiments(window.sandbox.win, experimentInfo);
+        expect(isExperimentOn(window.sandbox.win, 'expt_0')).to.be.true;
+        expect(getExperimentBranch(window.sandbox.win, 'expt_0')).to.be.null;
 
-        sandbox.win.trafficEligible = true;
+        window.sandbox.win.trafficEligible = true;
 
-        randomlySelectUnsetExperiments(sandbox.win, experimentInfo);
-        expect(isExperimentOn(sandbox.win, 'expt_0')).to.be.true;
-        expect(getExperimentBranch(sandbox.win, 'expt_0')).to.be.null;
+        randomlySelectUnsetExperiments(window.sandbox.win, experimentInfo);
+        expect(isExperimentOn(window.sandbox.win, 'expt_0')).to.be.true;
+        expect(getExperimentBranch(window.sandbox.win, 'expt_0')).to.be.null;
       }
     );
 
     it('handles multiple experiments', () => {
-      toggleExperiment(sandbox.win, 'expt_0', true, true);
-      toggleExperiment(sandbox.win, 'expt_1', false, true);
-      toggleExperiment(sandbox.win, 'expt_2', true, true);
-      toggleExperiment(sandbox.win, 'expt_3', true, true);
+      toggleExperiment(window.sandbox.win, 'expt_0', true, true);
+      toggleExperiment(window.sandbox.win, 'expt_1', false, true);
+      toggleExperiment(window.sandbox.win, 'expt_2', true, true);
+      toggleExperiment(window.sandbox.win, 'expt_3', true, true);
 
       const experimentInfo = {
         'expt_0': {
@@ -761,21 +750,24 @@ describe('experiment branch tests', () => {
         // expt_3 omitted.
       };
       RANDOM_NUMBER_GENERATORS.accuratePrng.returns(0.6);
-      randomlySelectUnsetExperiments(sandbox.win, experimentInfo);
-      expect(isExperimentOn(sandbox.win, 'expt_0'), 'expt_0 is on').to.be.true;
-      expect(isExperimentOn(sandbox.win, 'expt_1'), 'expt_1 is on').to.be.false;
-      expect(isExperimentOn(sandbox.win, 'expt_2'), 'expt_2 is on').to.be.true;
+      randomlySelectUnsetExperiments(window.sandbox.win, experimentInfo);
+      expect(isExperimentOn(window.sandbox.win, 'expt_0'), 'expt_0 is on').to.be
+        .true;
+      expect(isExperimentOn(window.sandbox.win, 'expt_1'), 'expt_1 is on').to.be
+        .false;
+      expect(isExperimentOn(window.sandbox.win, 'expt_2'), 'expt_2 is on').to.be
+        .true;
       // Note: calling isExperimentOn('expt_3') would actually evaluate the
       // frequency for expt_3, possibly enabling it.  Since we wanted it to be
       // omitted altogether, we'll evaluate it only via its branch.
-      expect(getExperimentBranch(sandbox.win, 'expt_0')).to.equal('0_e');
-      expect(getExperimentBranch(sandbox.win, 'expt_1')).to.not.be.ok;
-      expect(getExperimentBranch(sandbox.win, 'expt_2')).to.equal('2_e');
-      expect(getExperimentBranch(sandbox.win, 'expt_3')).to.not.be.ok;
+      expect(getExperimentBranch(window.sandbox.win, 'expt_0')).to.equal('0_e');
+      expect(getExperimentBranch(window.sandbox.win, 'expt_1')).to.not.be.ok;
+      expect(getExperimentBranch(window.sandbox.win, 'expt_2')).to.equal('2_e');
+      expect(getExperimentBranch(window.sandbox.win, 'expt_3')).to.not.be.ok;
     });
 
     it('handles multi-way branches', () => {
-      toggleExperiment(sandbox.win, 'expt_0', true, true);
+      toggleExperiment(window.sandbox.win, 'expt_0', true, true);
       const experimentInfo = {
         'expt_0': {
           isTrafficEligible: () => true,
@@ -783,16 +775,17 @@ describe('experiment branch tests', () => {
         },
       };
       RANDOM_NUMBER_GENERATORS.accuratePrng.returns(0.7);
-      randomlySelectUnsetExperiments(sandbox.win, experimentInfo);
-      expect(isExperimentOn(sandbox.win, 'expt_0'), 'expt_0 is on').to.be.true;
-      expect(getExperimentBranch(sandbox.win, 'expt_0')).to.equal('0_3');
+      randomlySelectUnsetExperiments(window.sandbox.win, experimentInfo);
+      expect(isExperimentOn(window.sandbox.win, 'expt_0'), 'expt_0 is on').to.be
+        .true;
+      expect(getExperimentBranch(window.sandbox.win, 'expt_0')).to.equal('0_3');
     });
 
     it('handles multiple experiments with multi-way branches', () => {
-      toggleExperiment(sandbox.win, 'expt_0', true, true);
-      toggleExperiment(sandbox.win, 'expt_1', false, true);
-      toggleExperiment(sandbox.win, 'expt_2', true, true);
-      toggleExperiment(sandbox.win, 'expt_3', true, true);
+      toggleExperiment(window.sandbox.win, 'expt_0', true, true);
+      toggleExperiment(window.sandbox.win, 'expt_1', false, true);
+      toggleExperiment(window.sandbox.win, 'expt_2', true, true);
+      toggleExperiment(window.sandbox.win, 'expt_3', true, true);
 
       const experimentInfo = {
         'expt_0': {
@@ -810,17 +803,20 @@ describe('experiment branch tests', () => {
       };
       RANDOM_NUMBER_GENERATORS.accuratePrng.onFirstCall().returns(0.7);
       RANDOM_NUMBER_GENERATORS.accuratePrng.onSecondCall().returns(0.3);
-      randomlySelectUnsetExperiments(sandbox.win, experimentInfo);
-      expect(isExperimentOn(sandbox.win, 'expt_0'), 'expt_0 is on').to.be.true;
-      expect(isExperimentOn(sandbox.win, 'expt_1'), 'expt_1 is on').to.be.false;
-      expect(isExperimentOn(sandbox.win, 'expt_2'), 'expt_2 is on').to.be.true;
+      randomlySelectUnsetExperiments(window.sandbox.win, experimentInfo);
+      expect(isExperimentOn(window.sandbox.win, 'expt_0'), 'expt_0 is on').to.be
+        .true;
+      expect(isExperimentOn(window.sandbox.win, 'expt_1'), 'expt_1 is on').to.be
+        .false;
+      expect(isExperimentOn(window.sandbox.win, 'expt_2'), 'expt_2 is on').to.be
+        .true;
       // Note: calling isExperimentOn('expt_3') would actually evaluate the
       // frequency for expt_3, possibly enabling it.  Since we wanted it to be
       // omitted altogether, we'll evaluate it only via its branch.
-      expect(getExperimentBranch(sandbox.win, 'expt_0')).to.equal('0_3');
-      expect(getExperimentBranch(sandbox.win, 'expt_1')).to.not.be.ok;
-      expect(getExperimentBranch(sandbox.win, 'expt_2')).to.equal('2_1');
-      expect(getExperimentBranch(sandbox.win, 'expt_3')).to.not.be.ok;
+      expect(getExperimentBranch(window.sandbox.win, 'expt_0')).to.equal('0_3');
+      expect(getExperimentBranch(window.sandbox.win, 'expt_1')).to.not.be.ok;
+      expect(getExperimentBranch(window.sandbox.win, 'expt_2')).to.equal('2_1');
+      expect(getExperimentBranch(window.sandbox.win, 'expt_3')).to.not.be.ok;
     });
 
     it('should not process the same experiment twice', () => {
@@ -836,42 +832,42 @@ describe('experiment branch tests', () => {
           branches: ['246810', '108642'],
         },
       };
-      toggleExperiment(sandbox.win, 'fooExpt', false, true);
-      randomlySelectUnsetExperiments(sandbox.win, exptAInfo);
-      randomlySelectUnsetExperiments(sandbox.win, exptBInfo);
+      toggleExperiment(window.sandbox.win, 'fooExpt', false, true);
+      randomlySelectUnsetExperiments(window.sandbox.win, exptAInfo);
+      randomlySelectUnsetExperiments(window.sandbox.win, exptBInfo);
       // Even though we tried to set up a second time, using a config
       // parameter that should ensure that the experiment was activated, the
       // experiment framework should evaluate each experiment only once per
       // page and should not enable it.
-      expect(isExperimentOn(sandbox.win, 'fooExpt')).to.be.false;
-      expect(getExperimentBranch(sandbox.win, 'fooExpt')).to.not.be.ok;
+      expect(isExperimentOn(window.sandbox.win, 'fooExpt')).to.be.false;
+      expect(getExperimentBranch(window.sandbox.win, 'fooExpt')).to.not.be.ok;
     });
 
     it('returns empty experiments map', () => {
       // Opt out of experiment.
-      toggleExperiment(sandbox.win, 'testExperimentId', false, true);
-      const exps = randomlySelectUnsetExperiments(sandbox.win, {});
+      toggleExperiment(window.sandbox.win, 'testExperimentId', false, true);
+      const exps = randomlySelectUnsetExperiments(window.sandbox.win, {});
       expect(exps).to.be.empty;
     });
 
     it('returns map with experiment diverted path 1', () => {
       // Force experiment on.
-      toggleExperiment(sandbox.win, 'testExperimentId', true, true);
+      toggleExperiment(window.sandbox.win, 'testExperimentId', true, true);
       // force the control branch to be chosen by making the accurate PRNG
       // return a value < 0.5.
       RANDOM_NUMBER_GENERATORS.accuratePrng.onFirstCall().returns(0.3);
       const exps = randomlySelectUnsetExperiments(
-        sandbox.win,
+        window.sandbox.win,
         testExperimentSet
       );
       expect(exps).to.deep.equal({'testExperimentId': 'branch1_id'});
     });
 
     it('returns map with multiple experiments with multi-way branches', () => {
-      toggleExperiment(sandbox.win, 'expt_0', true, true);
-      toggleExperiment(sandbox.win, 'expt_1', false, true);
-      toggleExperiment(sandbox.win, 'expt_2', true, true);
-      toggleExperiment(sandbox.win, 'expt_3', true, true);
+      toggleExperiment(window.sandbox.win, 'expt_0', true, true);
+      toggleExperiment(window.sandbox.win, 'expt_1', false, true);
+      toggleExperiment(window.sandbox.win, 'expt_2', true, true);
+      toggleExperiment(window.sandbox.win, 'expt_3', true, true);
 
       const experimentInfo = {
         'expt_0': {
@@ -889,7 +885,10 @@ describe('experiment branch tests', () => {
       };
       RANDOM_NUMBER_GENERATORS.accuratePrng.onFirstCall().returns(0.7);
       RANDOM_NUMBER_GENERATORS.accuratePrng.onSecondCall().returns(0.3);
-      const exps = randomlySelectUnsetExperiments(sandbox.win, experimentInfo);
+      const exps = randomlySelectUnsetExperiments(
+        window.sandbox.win,
+        experimentInfo
+      );
 
       expect(exps).to.deep.equal({
         'expt_0': '0_3',

--- a/test/unit/test-exponential-backoff.js
+++ b/test/unit/test-exponential-backoff.js
@@ -20,17 +20,11 @@ import {
 } from '../../src/exponential-backoff';
 
 describe('exponentialBackoff', () => {
-  let sandbox;
   let clock;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox;
-    clock = sandbox.useFakeTimers();
-    sandbox.stub(Math, 'random').callsFake(() => 1);
-  });
-
-  afterEach(() => {
-    sandbox.restore();
+    clock = window.sandbox.useFakeTimers();
+    window.sandbox.stub(Math, 'random').callsFake(() => 1);
   });
 
   it('should backoff exponentially', () => {

--- a/test/unit/test-extension-analytics.js
+++ b/test/unit/test-extension-analytics.js
@@ -40,18 +40,12 @@ describes.realWin(
     let win;
 
     describe('insertAnalyticsElement', () => {
-      let sandbox;
       class MockInstrumentation {}
 
       beforeEach(() => {
-        sandbox = sinon.sandbox;
         timer = Services.timerFor(env.win);
         ampdoc = env.ampdoc;
         win = env.win;
-      });
-
-      afterEach(() => {
-        sandbox.restore();
       });
 
       [true, false].forEach(disableImmediate => {
@@ -111,16 +105,10 @@ describes.realWin(
     describe('CustomEventReporterBuilder', () => {
       let builder;
       let parent;
-      let sandbox;
 
       beforeEach(() => {
-        sandbox = sinon.sandbox;
         parent = document.createElement('div');
         builder = new CustomEventReporterBuilder(parent);
-      });
-
-      afterEach(() => {
-        sandbox.restore();
       });
 
       it('track event with one request', () => {
@@ -250,7 +238,6 @@ describes.realWin(
       let builder;
       let parentEle;
       let reporter;
-      let sandbox;
       let ampdoc;
       let triggerEventSpy;
 
@@ -262,8 +249,7 @@ describes.realWin(
 
       beforeEach(() => {
         ampdoc = env.ampdoc;
-        sandbox = sinon.sandbox;
-        triggerEventSpy = sandbox.spy();
+        triggerEventSpy = env.sandbox.spy();
         resetServiceForTesting(env.win, 'amp-analytics-instrumentation');
         registerServiceBuilderForDoc(
           ampdoc,
@@ -281,10 +267,6 @@ describes.realWin(
         builder = new CustomEventReporterBuilder(parentEle);
         reporter = builder.track('test', 'fake.com').build();
         return buildPromise;
-      });
-
-      afterEach(() => {
-        sandbox.restore();
       });
 
       it('replace eventType with new name', function*() {

--- a/test/unit/test-extensions.js
+++ b/test/unit/test-extensions.js
@@ -30,11 +30,9 @@ describes.sandboxed('Extensions', {}, () => {
     let win;
     let extensions;
     let timeoutCallback;
-    let sandbox;
 
     beforeEach(() => {
       win = env.win;
-      sandbox = env.sandbox;
       win.setTimeout = cb => {
         timeoutCallback = cb;
       };
@@ -329,7 +327,7 @@ describes.sandboxed('Extensions', {}, () => {
     });
 
     it('should install elements in shadow doc', () => {
-      sandbox
+      env.sandbox
         .stub(Services.ampdocServiceFor(win), 'isSingleDoc')
         .callsFake(() => false);
       expect(
@@ -403,14 +401,14 @@ describes.sandboxed('Extensions', {}, () => {
 
     // TODO(#16916): Make this test work with synchronous throws.
     it.skip('should install all doc factories to shadow doc', () => {
-      sandbox
+      env.sandbox
         .stub(Services.ampdocServiceFor(win), 'isSingleDoc')
         .callsFake(() => false);
-      const factory1 = sandbox.spy();
+      const factory1 = env.sandbox.spy();
       const factory2 = function() {
         throw new Error('intentional');
       };
-      const factory3 = sandbox.spy();
+      const factory3 = env.sandbox.spy();
       extensions.registerExtension(
         'amp-ext',
         () => {
@@ -467,8 +465,8 @@ describes.sandboxed('Extensions', {}, () => {
 
     it('should install auto undeclared services for single-doc', () => {
       const ampdoc = Services.ampdocServiceFor(win).getSingleDoc();
-      const factory1Spy = sandbox.spy();
-      const factory2Spy = sandbox.spy();
+      const factory1Spy = env.sandbox.spy();
+      const factory2Spy = env.sandbox.spy();
       const factory1 = function() {
         factory1Spy();
         return {a: 1};
@@ -496,8 +494,8 @@ describes.sandboxed('Extensions', {}, () => {
 
     it('should skip non-auto undeclared services for single-doc', () => {
       const ampdoc = Services.ampdocServiceFor(win).getSingleDoc();
-      const factory1 = sandbox.spy();
-      const factory2 = sandbox.spy();
+      const factory1 = env.sandbox.spy();
+      const factory2 = env.sandbox.spy();
 
       // Manually preload extension, which would make it non-auto.
       extensions.preloadExtension('amp-test');
@@ -528,8 +526,8 @@ describes.sandboxed('Extensions', {}, () => {
       const ampdoc = Services.ampdocServiceFor(win).getSingleDoc();
       ampdoc.declareExtension('amp-test');
 
-      const factory1Spy = sandbox.spy();
-      const factory2Spy = sandbox.spy();
+      const factory1Spy = env.sandbox.spy();
+      const factory2Spy = env.sandbox.spy();
       const factory1 = function() {
         factory1Spy();
         return {a: 1};
@@ -556,16 +554,16 @@ describes.sandboxed('Extensions', {}, () => {
 
     // TODO(#16916): Make this test work with synchronous throws.
     it.skip('should install all services to doc', () => {
-      sandbox
+      env.sandbox
         .stub(Services.ampdocServiceFor(win), 'isSingleDoc')
         .callsFake(() => false);
-      const factory1 = sandbox.spy();
-      const factory2Spy = sandbox.spy();
+      const factory1 = env.sandbox.spy();
+      const factory2Spy = env.sandbox.spy();
       const factory2 = function() {
         factory2Spy();
         throw new Error('intentional');
       };
-      const factory3 = sandbox.spy();
+      const factory3 = env.sandbox.spy();
       extensions.registerExtension(
         'amp-ext',
         () => {
@@ -641,11 +639,10 @@ describes.sandboxed('Extensions', {}, () => {
 
     beforeEach(() => {
       win = env.win;
-      sandbox = env.sandbox;
 
-      sandbox.stub(Services, 'ampdocServiceFor').returns(null);
+      env.sandbox.stub(Services, 'ampdocServiceFor').returns(null);
       extensions = new Extensions(win);
-      sandbox.stub(extensions, 'preloadExtension');
+      env.sandbox.stub(extensions, 'preloadExtension');
     });
 
     it('should devAssert if script cannot be found', () => {
@@ -909,7 +906,7 @@ describes.sandboxed('Extensions', {}, () => {
       });
 
       it('should insert extension script correctly', () => {
-        const loadSpy = sandbox.spy(extensions, 'preloadExtension');
+        const loadSpy = env.sandbox.spy(extensions, 'preloadExtension');
         expect(
           doc.head.querySelectorAll('[custom-element="amp-test"]')
         ).to.have.length(0);
@@ -959,7 +956,7 @@ describes.sandboxed('Extensions', {}, () => {
       });
 
       it('should reuse the load if already started', () => {
-        const loadSpy = sandbox.spy(extensions, 'preloadExtension');
+        const loadSpy = env.sandbox.spy(extensions, 'preloadExtension');
         const extHolder = extensions.getExtensionHolder_('amp-test');
         extHolder.scriptPresent = true;
         const promise1 = extensions.installExtensionForDoc(ampdoc, 'amp-test');
@@ -981,8 +978,8 @@ describes.sandboxed('Extensions', {}, () => {
       });
 
       it('should install doc services', () => {
-        const factory1Spy = sandbox.spy();
-        const factory2Spy = sandbox.spy();
+        const factory1Spy = env.sandbox.spy();
+        const factory2Spy = env.sandbox.spy();
         const factory1 = function() {
           factory1Spy();
           return {a: 1};
@@ -1032,9 +1029,9 @@ describes.sandboxed('Extensions', {}, () => {
 
       // TODO(#16916): Make this test work with synchronous throws.
       it.skip('should survive factory failures', () => {
-        const factory1Spy = sandbox.spy();
-        const factory2Spy = sandbox.spy();
-        const factory3Spy = sandbox.spy();
+        const factory1Spy = env.sandbox.spy();
+        const factory2Spy = env.sandbox.spy();
+        const factory3Spy = env.sandbox.spy();
         const factory1 = function() {
           factory1Spy();
           return {a: 1};

--- a/test/unit/test-finite-state-machine.js
+++ b/test/unit/test-finite-state-machine.js
@@ -18,23 +18,17 @@ import {FiniteStateMachine} from '../../src/finite-state-machine';
 
 describe('Finite State Machine', () => {
   describe('simple machines', () => {
-    let sandbox;
     let fsm;
     let spy;
     let other;
 
     beforeEach(() => {
-      sandbox = sinon.sandbox;
       fsm = new FiniteStateMachine('init');
-      spy = sandbox.spy();
-      other = sandbox.spy();
+      spy = window.sandbox.spy();
+      other = window.sandbox.spy();
 
       fsm.addTransition('init', 'start', spy);
       fsm.addTransition('init', 'other', other);
-    });
-
-    afterEach(() => {
-      sandbox.restore();
     });
 
     it('invokes callbacks on transition', () => {

--- a/test/unit/test-fixed-layer.js
+++ b/test/unit/test-fixed-layer.js
@@ -544,7 +544,7 @@ describes.sandboxed('FixedLayer', {}, () => {
       });
 
       it('should add and remove element directly', () => {
-        const updateStub = sandbox.stub(fixedLayer, 'update');
+        const updateStub = window.sandbox.stub(fixedLayer, 'update');
         expect(fixedLayer.elements_).to.have.length(5);
 
         // Add.
@@ -890,7 +890,7 @@ describes.sandboxed('FixedLayer', {}, () => {
         expect(state['F0'].top).to.equal('0px');
 
         // Update to transient padding.
-        sandbox.stub(fixedLayer, 'update').callsFake(() => {});
+        window.sandbox.stub(fixedLayer, 'update').callsFake(() => {});
         fixedLayer.updatePaddingTop(22, /* transient */ true);
         vsyncTasks[0].measure(state);
         expect(state['F0'].fixed).to.be.true;
@@ -1160,7 +1160,7 @@ describes.sandboxed('FixedLayer', {}, () => {
         element1.setAttribute('style', 'bottom: 10px');
         element1.style.bottom = '10px';
 
-        const userError = sandbox.stub(user(), 'error');
+        const userError = window.sandbox.stub(user(), 'error');
         fixedLayer.setup();
         // Expect error regarding inline styles.
         expect(userError).calledWithMatch(
@@ -1197,7 +1197,7 @@ describes.sandboxed('FixedLayer', {}, () => {
 
           element1.computedStyle['display'] = '';
 
-          sandbox.stub(timer, 'delay').callsFake(callback => {
+          window.sandbox.stub(timer, 'delay').callsFake(callback => {
             callback();
           });
           return mutationObserver
@@ -1217,7 +1217,7 @@ describes.sandboxed('FixedLayer', {}, () => {
       });
 
       it('should ignore descendants of already-tracked elements', () => {
-        const updateStub = sandbox.stub(fixedLayer, 'update');
+        const updateStub = window.sandbox.stub(fixedLayer, 'update');
         expect(fixedLayer.elements_).to.have.length(5);
 
         element1.appendChild(element6);
@@ -1229,7 +1229,7 @@ describes.sandboxed('FixedLayer', {}, () => {
       });
 
       it('should replace descendants of tracked elements', () => {
-        const updateStub = sandbox.stub(fixedLayer, 'update');
+        const updateStub = window.sandbox.stub(fixedLayer, 'update');
         expect(fixedLayer.elements_).to.have.length(5);
 
         element6.appendChild(element1);
@@ -1564,7 +1564,7 @@ describes.sandboxed('FixedLayer', {}, () => {
       element1.setAttribute('style', 'bottom: 10px');
       element1.style.bottom = '10px';
 
-      const userError = sandbox.stub(user(), 'error');
+      const userError = window.sandbox.stub(user(), 'error');
       fixedLayer.setup();
       // Expect error regarding inline styles.
       expect(userError).calledWithMatch(
@@ -1601,7 +1601,7 @@ describes.sandboxed('FixedLayer', {}, () => {
 
         element1.computedStyle['display'] = '';
 
-        sandbox.stub(timer, 'delay').callsFake(callback => {
+        window.sandbox.stub(timer, 'delay').callsFake(callback => {
           callback();
         });
         return mutationObserver

--- a/test/unit/test-focus-history.js
+++ b/test/unit/test-focus-history.js
@@ -18,7 +18,6 @@ import {FocusHistory} from '../../src/focus-history';
 import {installTimerService} from '../../src/service/timer-impl';
 
 describe('FocusHistory', () => {
-  let sandbox;
   let clock;
   let testDoc;
   let eventListeners;
@@ -27,8 +26,7 @@ describe('FocusHistory', () => {
   let focusHistory;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox;
-    clock = sandbox.useFakeTimers();
+    clock = window.sandbox.useFakeTimers();
 
     eventListeners = {};
     testDoc = {
@@ -52,10 +50,6 @@ describe('FocusHistory', () => {
     };
     installTimerService(testWindow);
     focusHistory = new FocusHistory(testWindow, 10000);
-  });
-
-  afterEach(() => {
-    sandbox.restore();
   });
 
   it('should subscribe to focus events', () => {

--- a/test/unit/test-font-stylesheet-timeout.js
+++ b/test/unit/test-font-stylesheet-timeout.js
@@ -28,22 +28,20 @@ describes.realWin(
       .run('font-stylesheet-timeout', () => {
         let clock;
         let win;
-        let sandbox;
         let readyState;
         let responseStart;
         beforeEach(() => {
-          sandbox = env.sandbox;
-          clock = sandbox.useFakeTimers();
+          clock = env.sandbox.useFakeTimers();
           win = env.win;
           win.setTimeout = self.setTimeout;
           readyState = 'interactive';
           responseStart = 0;
-          sandbox.defineProperty(win.document, 'readyState', {
+          env.sandbox.defineProperty(win.document, 'readyState', {
             get() {
               return readyState;
             },
           });
-          sandbox.defineProperty(win.performance.timing, 'responseStart', {
+          env.sandbox.defineProperty(win.performance.timing, 'responseStart', {
             get() {
               return responseStart;
             },
@@ -198,7 +196,7 @@ describes.realWin(
               null,
             ];
             let index = 0;
-            sandbox.defineProperty(win.document, 'fonts', {
+            env.sandbox.defineProperty(win.document, 'fonts', {
               get: () => {
                 return {
                   values: () => {

--- a/test/unit/test-form-data-wrapper.js
+++ b/test/unit/test-form-data-wrapper.js
@@ -68,7 +68,7 @@ describes.realWin('FormDataWrapper', {}, env => {
         afterEach(scenario.afterEach);
 
         beforeEach(() => {
-          sandbox.stub(Services, 'platformFor').returns({
+          env.sandbox.stub(Services, 'platformFor').returns({
             isIos() {
               return false;
             },
@@ -410,7 +410,7 @@ describes.realWin('FormDataWrapper', {}, env => {
 
     describe('Ios11NativeFormDataWrapper', () => {
       beforeEach(() => {
-        sandbox.stub(Services, 'platformFor').returns({
+        env.sandbox.stub(Services, 'platformFor').returns({
           isIos() {
             return true;
           },

--- a/test/unit/test-form.js
+++ b/test/unit/test-form.js
@@ -23,10 +23,8 @@ import {
 
 describes.realWin('getFormAsObject', {}, env => {
   let form;
-  let sandbox;
 
   beforeEach(() => {
-    sandbox = env.sandbox;
     form = env.win.document.createElement('form');
     env.win.document.body.appendChild(form);
   });
@@ -249,7 +247,7 @@ describes.realWin('getFormAsObject', {}, env => {
     input2.value = 'quux';
     form.appendChild(input2);
 
-    sandbox.defineProperty(form, 'ownerDocument', {
+    env.sandbox.defineProperty(form, 'ownerDocument', {
       get() {
         return {activeElement: input};
       },
@@ -272,7 +270,7 @@ describes.realWin('getFormAsObject', {}, env => {
 
     expect(getFormAsObject(form)).to.deep.equal({'foo': ['bar']});
 
-    sandbox.defineProperty(form, 'ownerDocument', {
+    env.sandbox.defineProperty(form, 'ownerDocument', {
       get() {
         return {activeElement: input2};
       },
@@ -291,7 +289,7 @@ describes.realWin('getFormAsObject', {}, env => {
     input2.value = 'quux';
     form.appendChild(input2);
 
-    sandbox.defineProperty(form, 'ownerDocument', {
+    env.sandbox.defineProperty(form, 'ownerDocument', {
       get() {
         return {activeElement: env.win.document.body};
       },
@@ -312,7 +310,7 @@ describes.realWin('getFormAsObject', {}, env => {
 
     expect(getFormAsObject(form)).to.deep.equal({'foo': ['bar']});
 
-    sandbox.defineProperty(form, 'ownerDocument', {
+    env.sandbox.defineProperty(form, 'ownerDocument', {
       get() {
         return {activeElement: input2};
       },

--- a/test/unit/test-friendly-iframe-embed.js
+++ b/test/unit/test-friendly-iframe-embed.js
@@ -59,18 +59,20 @@ describes.realWin('friendly-iframe-embed', {amp: true}, env => {
     const ampdocService = {
       installFieDoc: () => {},
     };
-    extensionsMock = sandbox.mock(extensions);
-    resourcesMock = sandbox.mock(resources);
-    ampdocServiceMock = sandbox.mock(ampdocService);
-    sandbox.stub(Services, 'ampdocServiceFor').callsFake(() => ampdocService);
+    extensionsMock = env.sandbox.mock(extensions);
+    resourcesMock = env.sandbox.mock(resources);
+    ampdocServiceMock = env.sandbox.mock(ampdocService);
+    env.sandbox
+      .stub(Services, 'ampdocServiceFor')
+      .callsFake(() => ampdocService);
 
     iframe = document.createElement('iframe');
 
-    installExtensionsInChildWindowStub = sandbox
+    installExtensionsInChildWindowStub = env.sandbox
       .stub(FriendlyIframeEmbed.prototype, 'installExtensionsInChildWindow')
       .returns(Promise.resolve());
 
-    installExtensionsInFieStub = sandbox
+    installExtensionsInFieStub = env.sandbox
       .stub(FriendlyIframeEmbed.prototype, 'installExtensionsInFie')
       .returns(Promise.resolve());
   });
@@ -84,11 +86,10 @@ describes.realWin('friendly-iframe-embed', {amp: true}, env => {
     ampdocServiceMock.verify();
     setSrcdocSupportedForTesting(undefined);
     toggleAmpdocFieForTesting(window, false);
-    sandbox.restore();
   });
 
   function stubViewportScrollTop(scrollTop) {
-    sandbox.stub(Services, 'viewportForDoc').returns({
+    env.sandbox.stub(Services, 'viewportForDoc').returns({
       getScrollTop: () => scrollTop,
     });
   }
@@ -175,7 +176,7 @@ describes.realWin('friendly-iframe-embed', {amp: true}, env => {
     // AmpDoc is created.
     const ampdocSignals = new Signals();
     const ampdoc = {
-      setReady: sandbox.spy(),
+      setReady: env.sandbox.spy(),
       signals: () => ampdocSignals,
     };
     let childWinForAmpDoc;
@@ -183,12 +184,12 @@ describes.realWin('friendly-iframe-embed', {amp: true}, env => {
       .expects('installFieDoc')
       .withExactArgs(
         'https://acme.org/url1',
-        sinon.match(arg => {
+        env.sandbox.match(arg => {
           // Match childWin argument.
           childWinForAmpDoc = arg;
           return true;
         }),
-        sinon.match(arg => {
+        env.sandbox.match(arg => {
           // Match options with no signals.
           expect(arg && arg.signals).to.not.be.ok;
           return true;
@@ -208,7 +209,7 @@ describes.realWin('friendly-iframe-embed', {amp: true}, env => {
     const readyPromise = new Promise(resolve => {
       readyResolver = resolve;
     });
-    sandbox
+    env.sandbox
       .stub(FriendlyIframeEmbed.prototype, 'whenReady')
       .callsFake(() => readyPromise);
 
@@ -222,8 +223,8 @@ describes.realWin('friendly-iframe-embed', {amp: true}, env => {
         expect(childWinForAmpDoc).to.equal(embed.win);
         expect(ampdoc).to.equal(embed.ampdoc);
         expect(installExtensionsInFieStub).to.be.calledWithMatch(
-          sinon.match.any,
-          sinon.match.same(ampdoc)
+          env.sandbox.match.any,
+          env.sandbox.match.same(ampdoc)
         );
         expect(ampdoc.setReady).to.not.be.called;
         readyResolver();
@@ -241,13 +242,13 @@ describes.realWin('friendly-iframe-embed', {amp: true}, env => {
     const hostSignals = new Signals();
     const host = document.createElement('div');
     host.signals = () => hostSignals;
-    host.renderStarted = sandbox.spy();
+    host.renderStarted = env.sandbox.spy();
     host.getLayoutBox = () => layoutRectLtwh(10, 10, 100, 200);
 
     // AmpDoc is created.
     let ampdocSignals = null;
     const ampdoc = {
-      setReady: sandbox.spy(),
+      setReady: env.sandbox.spy(),
       signals: () => ampdocSignals,
     };
     let childWinForAmpDoc;
@@ -255,12 +256,12 @@ describes.realWin('friendly-iframe-embed', {amp: true}, env => {
       .expects('installFieDoc')
       .withExactArgs(
         'https://acme.org/url1',
-        sinon.match(arg => {
+        env.sandbox.match(arg => {
           // Match childWin argument.
           childWinForAmpDoc = arg;
           return true;
         }),
-        sinon.match(arg => {
+        env.sandbox.match(arg => {
           // Match options with no signals.
           ampdocSignals = arg && arg.signals;
           expect(ampdocSignals).to.be.ok;
@@ -281,7 +282,7 @@ describes.realWin('friendly-iframe-embed', {amp: true}, env => {
     const readyPromise = new Promise(resolve => {
       readyResolver = resolve;
     });
-    sandbox
+    env.sandbox
       .stub(FriendlyIframeEmbed.prototype, 'whenReady')
       .callsFake(() => readyPromise);
 
@@ -296,8 +297,8 @@ describes.realWin('friendly-iframe-embed', {amp: true}, env => {
         expect(childWinForAmpDoc).to.equal(embed.win);
         expect(ampdoc).to.equal(embed.ampdoc);
         expect(installExtensionsInFieStub).to.be.calledWithMatch(
-          sinon.match.any,
-          sinon.match.same(ampdoc)
+          env.sandbox.match.any,
+          env.sandbox.match.same(ampdoc)
         );
         expect(ampdoc.setReady).to.not.be.called;
         readyResolver();
@@ -325,8 +326,8 @@ describes.realWin('friendly-iframe-embed', {amp: true}, env => {
     });
     return embedPromise.then(embed => {
       expect(installExtensionsInChildWindowStub).to.be.calledWith(
-        sinon.match.any,
-        sinon.match.same(embed.win)
+        env.sandbox.match.any,
+        env.sandbox.match.same(embed.win)
       );
     });
   });
@@ -349,7 +350,7 @@ describes.realWin('friendly-iframe-embed', {amp: true}, env => {
   });
 
   it.skip('should install and dispose services', () => {
-    const disposeSpy = sandbox.spy();
+    const disposeSpy = env.sandbox.spy();
     const embedService = {
       dispose: disposeSpy,
     };
@@ -378,9 +379,9 @@ describes.realWin('friendly-iframe-embed', {amp: true}, env => {
     // AmpDoc is created.
     const ampdocSignals = new Signals();
     const ampdoc = {
-      setReady: sandbox.spy(),
+      setReady: env.sandbox.spy(),
       signals: () => ampdocSignals,
-      dispose: sandbox.spy(),
+      dispose: env.sandbox.spy(),
     };
     ampdocServiceMock
       .expects('installFieDoc')
@@ -394,7 +395,7 @@ describes.realWin('friendly-iframe-embed', {amp: true}, env => {
       .returns(Promise.resolve())
       .once();
 
-    sandbox
+    env.sandbox
       .stub(FriendlyIframeEmbed.prototype, 'whenReady')
       .returns(Promise.resolve());
 
@@ -422,7 +423,7 @@ describes.realWin('friendly-iframe-embed', {amp: true}, env => {
     return embedPromise.then(embed => {
       expect(installExtensionsInChildWindowStub).to.be.calledOnce;
       expect(embed.isVisible()).to.be.false;
-      const spy = sandbox.spy();
+      const spy = env.sandbox.spy();
       embed.onVisibilityChanged(spy);
 
       setFriendlyIframeEmbedVisible(embed, false);
@@ -440,7 +441,7 @@ describes.realWin('friendly-iframe-embed', {amp: true}, env => {
     const host = document.createElement('amp-host');
     const hostSignals = new Signals();
     host.signals = () => hostSignals;
-    host.renderStarted = sandbox.spy();
+    host.renderStarted = env.sandbox.spy();
     host.getLayoutBox = () => layoutRectLtwh(10, 10, 100, 200);
     const embedPromise = installFriendlyIframeEmbed(iframe, document.body, {
       url: 'https://acme.org/url1',
@@ -458,8 +459,8 @@ describes.realWin('friendly-iframe-embed', {amp: true}, env => {
     resourcesMock
       .expects('getResourcesInRect')
       .withExactArgs(
-        sinon.match(arg => arg == iframe.contentWindow),
-        sinon.match(
+        env.sandbox.match(arg => arg == iframe.contentWindow),
+        env.sandbox.match(
           arg =>
             arg.left == 0 &&
             arg.top == 0 &&
@@ -497,8 +498,8 @@ describes.realWin('friendly-iframe-embed', {amp: true}, env => {
     resourcesMock
       .expects('getResourcesInRect')
       .withExactArgs(
-        sinon.match(arg => arg == iframe.contentWindow),
-        sinon.match(
+        env.sandbox.match(arg => arg == iframe.contentWindow),
+        env.sandbox.match(
           arg =>
             arg.left == 10 &&
             arg.top == 10 &&
@@ -698,7 +699,7 @@ describes.realWin('friendly-iframe-embed', {amp: true}, env => {
       const container = {
         appendChild: child => {
           document.body.appendChild(child);
-          eventListenerSpy = sandbox.spy(
+          eventListenerSpy = env.sandbox.spy(
             child.contentWindow,
             'addEventListener'
           );
@@ -729,7 +730,7 @@ describes.realWin('friendly-iframe-embed', {amp: true}, env => {
     beforeEach(() => {
       setSrcdocSupportedForTesting(true);
 
-      clock = sandbox.useFakeTimers();
+      clock = env.sandbox.useFakeTimers();
 
       polls = [];
       win = {
@@ -778,7 +779,7 @@ describes.realWin('friendly-iframe-embed', {amp: true}, env => {
       container = {
         appendChild: () => {},
       };
-      renderStartStub = sandbox.stub(
+      renderStartStub = env.sandbox.stub(
         FriendlyIframeEmbed.prototype,
         'startRender_'
       );
@@ -921,7 +922,7 @@ describes.realWin('friendly-iframe-embed', {amp: true}, env => {
 
       parent.appendChild(iframe);
 
-      sandbox
+      env.sandbox
         ./*OK*/ stub(iframe, 'getBoundingClientRect')
         .returns(layoutRectLtwh(x, y, w, h));
 
@@ -934,8 +935,8 @@ describes.realWin('friendly-iframe-embed', {amp: true}, env => {
         Promise.resolve()
       );
 
-      sandbox.stub(fie, 'getResources_').returns(resourcesMock);
-      sandbox.stub(fie, 'getBodyElement').returns(bodyElementMock);
+      env.sandbox.stub(fie, 'getResources_').returns(resourcesMock);
+      env.sandbox.stub(fie, 'getBodyElement').returns(bodyElementMock);
 
       fie.win = win;
 
@@ -1052,7 +1053,7 @@ describes.realWin('installExtensionsInChildWindow', {amp: true}, env => {
     resetScheduledElementForTesting(parentWin, 'amp-test');
     installExtensionsService(parentWin);
     extensions = Services.extensionsFor(parentWin);
-    extensionsMock = sandbox.mock(extensions);
+    extensionsMock = env.sandbox.mock(extensions);
 
     [
       'urlForDoc',
@@ -1064,8 +1065,8 @@ describes.realWin('installExtensionsInChildWindow', {amp: true}, env => {
       class FakeService {
         static installInEmbedWindow() {}
       }
-      sandbox.stub(FakeService, 'installInEmbedWindow');
-      sandbox.stub(Services, s).returns(new FakeService());
+      env.sandbox.stub(FakeService, 'installInEmbedWindow');
+      env.sandbox.stub(Services, s).returns(new FakeService());
     });
 
     iframe = parentWin.document.createElement('iframe');
@@ -1205,7 +1206,7 @@ describes.realWin('installExtensionsInChildWindow', {amp: true}, env => {
     class FooService {
       static installInEmbedWindow() {}
     }
-    sandbox.stub(FooService, 'installInEmbedWindow');
+    env.sandbox.stub(FooService, 'installInEmbedWindow');
     registerServiceBuilder(
       parentWin,
       'fake-service-foo',
@@ -1216,7 +1217,7 @@ describes.realWin('installExtensionsInChildWindow', {amp: true}, env => {
     class BarService {
       static installInEmbedWindow() {}
     }
-    sandbox.stub(BarService, 'installInEmbedWindow');
+    env.sandbox.stub(BarService, 'installInEmbedWindow');
     registerServiceBuilder(
       parentWin,
       'fake-service-bar',
@@ -1330,7 +1331,7 @@ describes.realWin('installExtensionsInFie', {amp: true}, env => {
     resetScheduledElementForTesting(parentWin, 'amp-test');
     installExtensionsService(parentWin);
     extensions = Services.extensionsFor(parentWin);
-    extensionsMock = sandbox.mock(extensions);
+    extensionsMock = env.sandbox.mock(extensions);
     const ampdocService = Services.ampdocServiceFor(parentWin);
     updateFieModeForTesting(ampdocService, true);
 
@@ -1486,7 +1487,7 @@ describes.realWin('installExtensionsInFie', {amp: true}, env => {
   });
 
   it('should adopt extension services', () => {
-    const fooConstructorSpy = sandbox.spy();
+    const fooConstructorSpy = env.sandbox.spy();
     class FooService {
       constructor(arg) {
         fooConstructorSpy(arg);
@@ -1499,7 +1500,7 @@ describes.realWin('installExtensionsInFie', {amp: true}, env => {
       /* opt_instantiate */ false
     );
 
-    const barConstructorSpy = sandbox.spy();
+    const barConstructorSpy = env.sandbox.spy();
     class BarService {
       constructor(arg) {
         barConstructorSpy(arg);

--- a/test/unit/test-gesture-recognizers.js
+++ b/test/unit/test-gesture-recognizers.js
@@ -24,15 +24,12 @@ import {
 import {Gestures} from '../../src/gesture';
 
 describe('TapRecognizer', () => {
-  let sandbox;
   let element;
   let recognizer;
   let gestures;
   let gesturesMock;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox;
-
     element = {
       addEventListener: (unusedEventType, unusedHandler) => {},
       ownerDocument: {
@@ -41,14 +38,13 @@ describe('TapRecognizer', () => {
     };
 
     gestures = new Gestures(element);
-    gesturesMock = sandbox.mock(gestures);
+    gesturesMock = window.sandbox.mock(gestures);
 
     recognizer = new TapRecognizer(gestures);
   });
 
   afterEach(() => {
     gesturesMock.verify();
-    sandbox.restore();
   });
 
   it('should allow single-point touchstart', () => {
@@ -112,7 +108,7 @@ describe('TapRecognizer', () => {
       .expects('signalEmit_')
       .withExactArgs(
         recognizer,
-        sinon.match(data => {
+        window.sandbox.match(data => {
           return (
             data.clientX == 101 && data.clientY == 201 && data.target === target
           );
@@ -129,15 +125,12 @@ describe('TapRecognizer', () => {
 });
 
 describe('DoubletapRecognizer', () => {
-  let sandbox;
   let element;
   let recognizer;
   let gestures;
   let gesturesMock;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox;
-
     element = {
       addEventListener: (unusedEventType, unusedHandler) => {},
       ownerDocument: {
@@ -146,14 +139,13 @@ describe('DoubletapRecognizer', () => {
     };
 
     gestures = new Gestures(element);
-    gesturesMock = sandbox.mock(gestures);
+    gesturesMock = window.sandbox.mock(gestures);
 
     recognizer = new DoubletapRecognizer(gestures);
   });
 
   afterEach(() => {
     gesturesMock.verify();
-    sandbox.restore();
   });
 
   it('should allow single-point touchstart', () => {
@@ -229,7 +221,7 @@ describe('DoubletapRecognizer', () => {
       .expects('signalEmit_')
       .withExactArgs(
         recognizer,
-        sinon.match(data => {
+        window.sandbox.match(data => {
           return data.clientX == 101 && data.clientY == 201;
         }),
         null
@@ -245,7 +237,6 @@ describe('DoubletapRecognizer', () => {
 });
 
 describe('SwipeXYRecognizer', () => {
-  let sandbox;
   let element;
   let clock;
   let recognizer;
@@ -253,8 +244,7 @@ describe('SwipeXYRecognizer', () => {
   let gesturesMock;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox;
-    clock = sandbox.useFakeTimers();
+    clock = window.sandbox.useFakeTimers();
 
     element = {
       addEventListener: (unusedEventType, unusedHandler) => {},
@@ -264,14 +254,13 @@ describe('SwipeXYRecognizer', () => {
     };
 
     gestures = new Gestures(element);
-    gesturesMock = sandbox.mock(gestures);
+    gesturesMock = window.sandbox.mock(gestures);
 
     recognizer = new SwipeXYRecognizer(gestures);
   });
 
   afterEach(() => {
     gesturesMock.verify();
-    sandbox.restore();
   });
 
   function diff(value, compare, error) {
@@ -338,7 +327,7 @@ describe('SwipeXYRecognizer', () => {
       .expects('signalEmit_')
       .withExactArgs(
         recognizer,
-        sinon.match(data => {
+        window.sandbox.match(data => {
           return (
             data.first === true &&
             data.last === false &&
@@ -376,7 +365,7 @@ describe('SwipeXYRecognizer', () => {
       .expects('signalEmit_')
       .withExactArgs(
         recognizer,
-        sinon.match(data => {
+        window.sandbox.match(data => {
           return (
             data.first === false &&
             data.last === false &&
@@ -412,7 +401,7 @@ describe('SwipeXYRecognizer', () => {
       .expects('signalEmit_')
       .withExactArgs(
         recognizer,
-        sinon.match(data => {
+        window.sandbox.match(data => {
           return (
             data.first === false &&
             data.last === true &&
@@ -446,7 +435,7 @@ describe('SwipeXYRecognizer', () => {
       .expects('signalEmit_')
       .withExactArgs(
         recognizer,
-        sinon.match(data => {
+        window.sandbox.match(data => {
           return (
             data.first === false &&
             data.last === true &&
@@ -510,7 +499,6 @@ describe('SwipeXYRecognizer', () => {
 });
 
 describe('TapzoomRecognizer', () => {
-  let sandbox;
   let element;
   let clock;
   let recognizer;
@@ -518,8 +506,7 @@ describe('TapzoomRecognizer', () => {
   let gesturesMock;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox;
-    clock = sandbox.useFakeTimers();
+    clock = window.sandbox.useFakeTimers();
 
     element = {
       addEventListener: (unusedEventType, unusedHandler) => {},
@@ -529,14 +516,13 @@ describe('TapzoomRecognizer', () => {
     };
 
     gestures = new Gestures(element);
-    gesturesMock = sandbox.mock(gestures);
+    gesturesMock = window.sandbox.mock(gestures);
 
     recognizer = new TapzoomRecognizer(gestures);
   });
 
   afterEach(() => {
     gesturesMock.verify();
-    sandbox.restore();
   });
 
   it('should allow single-point touchstart', () => {
@@ -636,7 +622,7 @@ describe('TapzoomRecognizer', () => {
       .expects('signalEmit_')
       .withExactArgs(
         recognizer,
-        sinon.match(data => {
+        window.sandbox.match(data => {
           return (
             data.first === true &&
             data.last === false &&
@@ -669,7 +655,7 @@ describe('TapzoomRecognizer', () => {
       .expects('signalEmit_')
       .withExactArgs(
         recognizer,
-        sinon.match(data => {
+        window.sandbox.match(data => {
           return (
             data.first === false &&
             data.last === false &&
@@ -705,7 +691,7 @@ describe('TapzoomRecognizer', () => {
       .expects('signalEmit_')
       .withExactArgs(
         recognizer,
-        sinon.match(data => {
+        window.sandbox.match(data => {
           return (
             data.first === false &&
             data.last === true &&
@@ -730,7 +716,6 @@ describe('TapzoomRecognizer', () => {
 });
 
 describe('PinchRecognizer', () => {
-  let sandbox;
   let element;
   let clock;
   let recognizer;
@@ -738,8 +723,7 @@ describe('PinchRecognizer', () => {
   let gesturesMock;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox;
-    clock = sandbox.useFakeTimers();
+    clock = window.sandbox.useFakeTimers();
 
     element = {
       addEventListener: (unusedEventType, unusedHandler) => {},
@@ -749,14 +733,13 @@ describe('PinchRecognizer', () => {
     };
 
     gestures = new Gestures(element);
-    gesturesMock = sandbox.mock(gestures);
+    gesturesMock = window.sandbox.mock(gestures);
 
     recognizer = new PinchRecognizer(gestures);
   });
 
   afterEach(() => {
     gesturesMock.verify();
-    sandbox.restore();
   });
 
   function diff(value, compare, error) {
@@ -886,7 +869,7 @@ describe('PinchRecognizer', () => {
       .expects('signalEmit_')
       .withExactArgs(
         recognizer,
-        sinon.match(data => {
+        window.sandbox.match(data => {
           return (
             data.first === true &&
             data.last === false &&
@@ -941,7 +924,7 @@ describe('PinchRecognizer', () => {
       .expects('signalEmit_')
       .withExactArgs(
         recognizer,
-        sinon.match(unusedData => true),
+        window.sandbox.match(unusedData => true),
         null
       )
       .once();
@@ -958,7 +941,7 @@ describe('PinchRecognizer', () => {
       .expects('signalEmit_')
       .withExactArgs(
         recognizer,
-        sinon.match(data => {
+        window.sandbox.match(data => {
           return (
             data.first === false &&
             data.last === false &&
@@ -999,7 +982,7 @@ describe('PinchRecognizer', () => {
       .expects('signalEmit_')
       .withExactArgs(
         recognizer,
-        sinon.match(unusedData => true),
+        window.sandbox.match(unusedData => true),
         null
       )
       .once();
@@ -1011,7 +994,7 @@ describe('PinchRecognizer', () => {
       .expects('signalEmit_')
       .withExactArgs(
         recognizer,
-        sinon.match(data => {
+        window.sandbox.match(data => {
           return (
             data.first === false &&
             data.last === true &&
@@ -1050,7 +1033,7 @@ describe('PinchRecognizer', () => {
       .expects('signalEmit_')
       .withExactArgs(
         recognizer,
-        sinon.match(unusedData => true),
+        window.sandbox.match(unusedData => true),
         null
       )
       .once();
@@ -1062,7 +1045,7 @@ describe('PinchRecognizer', () => {
       .expects('signalEmit_')
       .withExactArgs(
         recognizer,
-        sinon.match(data => {
+        window.sandbox.match(data => {
           return (
             data.first === false &&
             data.last === true &&
@@ -1106,7 +1089,7 @@ describe('PinchRecognizer', () => {
       .expects('signalEmit_')
       .withExactArgs(
         recognizer,
-        sinon.match(data => {
+        window.sandbox.match(data => {
           return (
             data.centerClientX == 100 &&
             data.centerClientY == 100 &&
@@ -1127,7 +1110,7 @@ describe('PinchRecognizer', () => {
       .expects('signalEmit_')
       .withExactArgs(
         recognizer,
-        sinon.match(data => {
+        window.sandbox.match(data => {
           return (
             data.centerClientX == 100 &&
             data.centerClientY == 100 &&

--- a/test/unit/test-gesture.js
+++ b/test/unit/test-gesture.js
@@ -29,7 +29,6 @@ describe('Gestures', () => {
     }
   }
 
-  let sandbox;
   let element;
   let clock;
   let recognizer;
@@ -39,8 +38,7 @@ describe('Gestures', () => {
   let onGesture;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox;
-    clock = sandbox.useFakeTimers();
+    clock = window.sandbox.useFakeTimers();
 
     eventListeners = {};
     element = {
@@ -55,18 +53,17 @@ describe('Gestures', () => {
       },
     };
 
-    onGesture = sandbox.spy();
+    onGesture = window.sandbox.spy();
 
     gestures = Gestures.get(element);
     gestures.onGesture(TestRecognizer, onGesture);
     expect(gestures.recognizers_.length).to.equal(1);
     recognizer = gestures.recognizers_[0];
-    recognizerMock = sandbox.mock(recognizer);
+    recognizerMock = window.sandbox.mock(recognizer);
   });
 
   afterEach(() => {
     recognizerMock.verify();
-    sandbox.restore();
   });
 
   function sendEvent(event) {
@@ -76,7 +73,7 @@ describe('Gestures', () => {
   }
 
   it('onPointerDown should be called', () => {
-    const handler = sandbox.spy();
+    const handler = window.sandbox.spy();
     gestures.onPointerDown(handler);
     sendEvent({type: 'touchstart'});
     expect(handler).to.be.calledOnce;
@@ -284,7 +281,7 @@ describe('Gestures', () => {
 
   it('should allow youngest to start', () => {
     gestures.onGesture(Test2Recognizer, () => {});
-    const recognizer2Mock = sandbox.mock(gestures.recognizers_[1]);
+    const recognizer2Mock = window.sandbox.mock(gestures.recognizers_[1]);
 
     gestures.ready_[0] = 10;
     gestures.ready_[1] = 9;
@@ -299,8 +296,8 @@ describe('Gestures', () => {
   it('should allow event to propagate when nothing happening', () => {
     const event = {
       type: 'touchend',
-      preventDefault: sandbox.spy(),
-      stopPropagation: sandbox.spy(),
+      preventDefault: window.sandbox.spy(),
+      stopPropagation: window.sandbox.spy(),
     };
     eventListeners[event.type](event);
     expect(event.preventDefault).to.have.not.been.called;
@@ -311,8 +308,8 @@ describe('Gestures', () => {
     gestures.eventing_ = recognizer;
     const event = {
       type: 'touchend',
-      preventDefault: sandbox.spy(),
-      stopPropagation: sandbox.spy(),
+      preventDefault: window.sandbox.spy(),
+      stopPropagation: window.sandbox.spy(),
     };
     eventListeners[event.type](event);
     expect(event.preventDefault).to.be.calledOnce;
@@ -327,8 +324,8 @@ describe('Gestures', () => {
 
     const event = {
       type: 'touchend',
-      preventDefault: sandbox.spy(),
-      stopPropagation: sandbox.spy(),
+      preventDefault: window.sandbox.spy(),
+      stopPropagation: window.sandbox.spy(),
     };
     eventListeners[event.type](event);
     expect(event.preventDefault).to.be.calledOnce;
@@ -340,8 +337,8 @@ describe('Gestures', () => {
     gestures.ready_[0] = 1;
     const event = {
       type: 'touchend',
-      preventDefault: sandbox.spy(),
-      stopPropagation: sandbox.spy(),
+      preventDefault: window.sandbox.spy(),
+      stopPropagation: window.sandbox.spy(),
     };
     eventListeners[event.type](event);
     expect(event.preventDefault).to.be.calledOnce;
@@ -352,8 +349,8 @@ describe('Gestures', () => {
     gestures.pending_[0] = 1;
     let event = {
       type: 'touchend',
-      preventDefault: sandbox.spy(),
-      stopPropagation: sandbox.spy(),
+      preventDefault: window.sandbox.spy(),
+      stopPropagation: window.sandbox.spy(),
     };
     eventListeners[event.type](event);
     expect(event.preventDefault).to.be.calledOnce;
@@ -362,8 +359,8 @@ describe('Gestures', () => {
     clock.tick(10);
     event = {
       type: 'touchend',
-      preventDefault: sandbox.spy(),
-      stopPropagation: sandbox.spy(),
+      preventDefault: window.sandbox.spy(),
+      stopPropagation: window.sandbox.spy(),
     };
     eventListeners[event.type](event);
     expect(event.preventDefault).to.have.not.been.called;
@@ -383,7 +380,7 @@ describe('Gestures', () => {
   it('should remove listeners and shared cache instance on cleanup', () => {
     const eventNames = ['touchstart', 'touchend', 'touchmove', 'touchcancel'];
     const prop = '__AMP_Gestures';
-    const removeSpy = sandbox.spy(element, 'removeEventListener');
+    const removeSpy = window.sandbox.spy(element, 'removeEventListener');
 
     expect(element[prop]).to.exist;
 
@@ -396,7 +393,6 @@ describe('Gestures', () => {
   });
 
   describe('Gestures - with shouldNotPreventdefault', () => {
-    let sandbox;
     let element;
     let clock;
     let recognizer;
@@ -406,8 +402,7 @@ describe('Gestures', () => {
     let onGesture;
 
     beforeEach(() => {
-      sandbox = sinon.sandbox;
-      clock = sandbox.useFakeTimers();
+      clock = window.sandbox.useFakeTimers();
 
       eventListeners = {};
       element = {
@@ -419,26 +414,25 @@ describe('Gestures', () => {
         },
       };
 
-      onGesture = sandbox.spy();
+      onGesture = window.sandbox.spy();
 
       gestures = Gestures.get(element, /* shouldNotPreventDefault */ true);
       gestures.onGesture(TestRecognizer, onGesture);
       expect(gestures.recognizers_.length).to.equal(1);
       recognizer = gestures.recognizers_[0];
-      recognizerMock = sandbox.mock(recognizer);
+      recognizerMock = window.sandbox.mock(recognizer);
     });
 
     afterEach(() => {
       recognizerMock.verify();
-      sandbox.restore();
     });
 
     it('should cancel event when eventing', () => {
       gestures.eventing_ = recognizer;
       const event = {
         type: 'touchend',
-        preventDefault: sandbox.spy(),
-        stopPropagation: sandbox.spy(),
+        preventDefault: window.sandbox.spy(),
+        stopPropagation: window.sandbox.spy(),
       };
       eventListeners[event.type](event);
       expect(event.preventDefault).to.have.not.been.called;
@@ -453,8 +447,8 @@ describe('Gestures', () => {
 
       const event = {
         type: 'touchend',
-        preventDefault: sandbox.spy(),
-        stopPropagation: sandbox.spy(),
+        preventDefault: window.sandbox.spy(),
+        stopPropagation: window.sandbox.spy(),
       };
       eventListeners[event.type](event);
       expect(event.preventDefault).to.have.not.been.called;
@@ -466,8 +460,8 @@ describe('Gestures', () => {
       gestures.ready_[0] = 1;
       const event = {
         type: 'touchend',
-        preventDefault: sandbox.spy(),
-        stopPropagation: sandbox.spy(),
+        preventDefault: window.sandbox.spy(),
+        stopPropagation: window.sandbox.spy(),
       };
       eventListeners[event.type](event);
       expect(event.preventDefault).to.have.not.been.called;
@@ -478,8 +472,8 @@ describe('Gestures', () => {
       gestures.pending_[0] = 1;
       let event = {
         type: 'touchend',
-        preventDefault: sandbox.spy(),
-        stopPropagation: sandbox.spy(),
+        preventDefault: window.sandbox.spy(),
+        stopPropagation: window.sandbox.spy(),
       };
       eventListeners[event.type](event);
       expect(event.preventDefault).to.have.not.been.called;
@@ -488,8 +482,8 @@ describe('Gestures', () => {
       clock.tick(10);
       event = {
         type: 'touchend',
-        preventDefault: sandbox.spy(),
-        stopPropagation: sandbox.spy(),
+        preventDefault: window.sandbox.spy(),
+        stopPropagation: window.sandbox.spy(),
       };
       eventListeners[event.type](event);
       expect(event.preventDefault).to.have.not.been.called;
@@ -498,7 +492,6 @@ describe('Gestures', () => {
   });
 
   describe('Gestures - with shouldStopPropagation', () => {
-    let sandbox;
     let element;
     let recognizer;
     let recognizerMock;
@@ -507,8 +500,6 @@ describe('Gestures', () => {
     let onGesture;
 
     beforeEach(() => {
-      sandbox = sinon.sandbox;
-
       eventListeners = {};
       element = {
         addEventListener: (eventType, handler) => {
@@ -519,7 +510,7 @@ describe('Gestures', () => {
         },
       };
 
-      onGesture = sandbox.spy();
+      onGesture = window.sandbox.spy();
 
       gestures = Gestures.get(
         element,
@@ -529,18 +520,17 @@ describe('Gestures', () => {
       gestures.onGesture(TestRecognizer, onGesture);
       expect(gestures.recognizers_.length).to.equal(1);
       recognizer = gestures.recognizers_[0];
-      recognizerMock = sandbox.mock(recognizer);
+      recognizerMock = window.sandbox.mock(recognizer);
     });
 
     afterEach(() => {
       recognizerMock.verify();
-      sandbox.restore();
     });
 
     it('should stop event from propagating', () => {
       const event = {
         type: 'touchend',
-        stopPropagation: sandbox.spy(),
+        stopPropagation: window.sandbox.spy(),
       };
       eventListeners[event.type](event);
       expect(event.stopPropagation).to.have.be.calledOnce;

--- a/test/unit/test-hidden-observer.js
+++ b/test/unit/test-hidden-observer.js
@@ -24,12 +24,11 @@ describes.fakeWin(
   },
   env => {
     let hiddenObserver;
-    let sandbox;
     let MutationObserver;
 
     function setupSingletonMutationObserver(opt_cb = () => {}) {
       const mo = new FakeMutationObserver(opt_cb);
-      MutationObserver = sandbox.stub().callsFake(function() {
+      MutationObserver = env.sandbox.stub().callsFake(function() {
         return mo;
       });
       env.win.MutationObserver = MutationObserver;
@@ -37,7 +36,6 @@ describes.fakeWin(
     }
 
     beforeEach(() => {
-      sandbox = env.sandbox;
       hiddenObserver = Services.hiddenObserverForDoc(
         env.win.document.documentElement
       );
@@ -45,7 +43,7 @@ describes.fakeWin(
 
     it('initializes mutation observer on first listen', () => {
       const mo = setupSingletonMutationObserver();
-      const observe = sandbox.spy(mo, 'observe');
+      const observe = env.sandbox.spy(mo, 'observe');
 
       hiddenObserver.add(() => {});
 
@@ -55,7 +53,7 @@ describes.fakeWin(
 
     it('keeps mutation observer on second listen', () => {
       const mo = setupSingletonMutationObserver();
-      const observe = sandbox.spy(mo, 'observe');
+      const observe = env.sandbox.spy(mo, 'observe');
 
       hiddenObserver.add(() => {});
       hiddenObserver.add(() => {});
@@ -66,7 +64,7 @@ describes.fakeWin(
 
     it('frees mutation observer after last unlisten', () => {
       const mo = setupSingletonMutationObserver();
-      const disconnect = sandbox.spy(mo, 'disconnect');
+      const disconnect = env.sandbox.spy(mo, 'disconnect');
 
       const unlisten = hiddenObserver.add(() => {});
       unlisten();
@@ -76,7 +74,7 @@ describes.fakeWin(
 
     it('keeps mutation observer after second-to-last unlisten', () => {
       const mo = setupSingletonMutationObserver();
-      const disconnect = sandbox.spy(mo, 'disconnect');
+      const disconnect = env.sandbox.spy(mo, 'disconnect');
 
       const unlisten = hiddenObserver.add(() => {});
       const unlisten2 = hiddenObserver.add(() => {});
@@ -89,7 +87,7 @@ describes.fakeWin(
     });
 
     it('passes MutationRecords to handler', function*() {
-      const stub = sandbox.stub();
+      const stub = env.sandbox.stub();
       const mo = setupSingletonMutationObserver(stub);
 
       const mutation = {};

--- a/test/unit/test-history.js
+++ b/test/unit/test-history.js
@@ -41,7 +41,7 @@ describes.fakeWin(
 
     beforeEach(() => {
       installTimerService(env.win);
-      clock = sandbox.useFakeTimers();
+      clock = env.sandbox.useFakeTimers();
 
       const binding = {
         cleanup: () => {},
@@ -56,7 +56,7 @@ describes.fakeWin(
         getFragment: () => {},
         updateFragment: () => {},
       };
-      bindingMock = sandbox.mock(binding);
+      bindingMock = env.sandbox.mock(binding);
 
       history = new History(new AmpDocSingle(env.win), binding);
     });
@@ -72,7 +72,7 @@ describes.fakeWin(
     });
 
     it('should push new state', () => {
-      const onPop = sandbox.spy();
+      const onPop = env.sandbox.spy();
       bindingMock
         .expects('push')
         .returns(Promise.resolve({stackIndex: 11}))
@@ -86,7 +86,7 @@ describes.fakeWin(
     });
 
     it('should pop previously pushed state', () => {
-      const onPop = sandbox.spy();
+      const onPop = env.sandbox.spy();
       bindingMock
         .expects('push')
         .returns(Promise.resolve({stackIndex: 11}))
@@ -111,7 +111,7 @@ describes.fakeWin(
     });
 
     it('should return and call callback when history popped', () => {
-      const onPop = sandbox.spy();
+      const onPop = env.sandbox.spy();
       bindingMock
         .expects('push')
         .withExactArgs(undefined)
@@ -135,7 +135,7 @@ describes.fakeWin(
     });
 
     it('should return and call callback with state when history popped', () => {
-      const onPop = sandbox.spy();
+      const onPop = env.sandbox.spy();
       const title = 'TITLE';
       bindingMock
         .expects('push')
@@ -163,7 +163,7 @@ describes.fakeWin(
     });
 
     it('should replace previously pushed state', () => {
-      const onPop = sandbox.spy();
+      const onPop = env.sandbox.spy();
       const pushState = {title: 'pushState'};
       const replaceState = {title: 'replaceState'};
       bindingMock
@@ -192,7 +192,7 @@ describes.fakeWin(
     });
 
     it('should get previously pushed state', () => {
-      const onPop = sandbox.spy();
+      const onPop = env.sandbox.spy();
       const state = {title: 'title'};
       bindingMock
         .expects('push')
@@ -236,7 +236,7 @@ describes.fakeWin(
     });
 
     it('should pop previously pushed state via goBack', () => {
-      const onPop = sandbox.spy();
+      const onPop = env.sandbox.spy();
       const popState = {title: 'title'};
       bindingMock
         .expects('push')
@@ -346,14 +346,14 @@ describes.sandboxed('History install', {}, () => {
   });
 });
 
-describes.sandboxed('HistoryBindingNatural', {}, () => {
+describes.sandboxed('HistoryBindingNatural', {}, env => {
   let clock;
   let onStateUpdated;
   let history;
 
   beforeEach(() => {
-    clock = sandbox.useFakeTimers();
-    onStateUpdated = sandbox.spy();
+    clock = env.sandbox.useFakeTimers();
+    onStateUpdated = env.sandbox.spy();
     history = new HistoryBindingNatural_(window);
     history.setOnStateUpdated(onStateUpdated);
   });
@@ -425,7 +425,7 @@ describes.sandboxed('HistoryBindingNatural', {}, () => {
     'should not pass in `url` argument to original replace state if ' +
       'parameter is undefined',
     () => {
-      const replaceStateSpy = sandbox.spy();
+      const replaceStateSpy = env.sandbox.spy();
       const windowStub = {
         history: {
           replaceState: replaceStateSpy,
@@ -631,7 +631,7 @@ describes.sandboxed('HistoryBindingNatural', {}, () => {
   });
 });
 
-describes.sandboxed('HistoryBindingVirtual', {}, () => {
+describes.sandboxed('HistoryBindingVirtual', {}, env => {
   let history;
   let viewer;
   let capabilityStub;
@@ -640,11 +640,11 @@ describes.sandboxed('HistoryBindingVirtual', {}, () => {
   let onHistoryPopped;
 
   beforeEach(() => {
-    onStateUpdated = sandbox.spy();
-    capabilityStub = sandbox.stub();
+    onStateUpdated = env.sandbox.spy();
+    capabilityStub = env.sandbox.stub();
     viewer = {
-      onMessage: sandbox.stub().returns(() => {}),
-      sendMessageAwaitResponse: sandbox.stub().returns(Promise.resolve()),
+      onMessage: env.sandbox.stub().returns(() => {}),
+      sendMessageAwaitResponse: env.sandbox.stub().returns(Promise.resolve()),
       hasCapability: capabilityStub,
     };
     history = new HistoryBindingVirtual_(window, viewer);
@@ -735,7 +735,7 @@ describes.sandboxed('HistoryBindingVirtual', {}, () => {
 
     it('viewer supports responses', () => {
       viewer.sendMessageAwaitResponse
-        .withArgs('popHistory', sinon.match({stackIndex: 0}))
+        .withArgs('popHistory', env.sandbox.match({stackIndex: 0}))
         .returns(Promise.resolve({stackIndex: -123, title: 'title'}));
 
       return history.pop(0).then(state => {
@@ -752,7 +752,7 @@ describes.sandboxed('HistoryBindingVirtual', {}, () => {
 
     it('handles bad viewer responses', () => {
       viewer.sendMessageAwaitResponse
-        .withArgs('popHistory', sinon.match({stackIndex: 0}))
+        .withArgs('popHistory', env.sandbox.match({stackIndex: 0}))
         .returns(Promise.resolve(true));
 
       return history.pop(0).then(state => {
@@ -936,7 +936,7 @@ describes.fakeWin(
 
     beforeEach(() => {
       installTimerService(env.win);
-      clock = sandbox.useFakeTimers();
+      clock = env.sandbox.useFakeTimers();
     });
 
     afterEach(() => {
@@ -973,7 +973,7 @@ describes.fakeWin(
         },
         sendMessageAwaitResponse: () => Promise.resolve(),
       };
-      const viewerMock = sandbox.mock(viewer);
+      const viewerMock = env.sandbox.mock(viewer);
       history = new History(
         new AmpDocSingle(env.win),
         new HistoryBindingVirtual_(env.win, viewer)
@@ -1017,7 +1017,7 @@ describes.fakeWin('Get and update fragment', {}, env => {
       hasCapability: () => {},
       sendMessageAwaitResponse: () => {},
     };
-    viewerMock = sandbox.mock(viewer);
+    viewerMock = env.sandbox.mock(viewer);
   });
 
   afterEach(() => {
@@ -1040,7 +1040,7 @@ describes.fakeWin('Get and update fragment', {}, env => {
 
   it('should update fragment on Natural', () => {
     env.win.location.href = 'http://www.example.com#foo';
-    const replaceStateSpy = sandbox.spy();
+    const replaceStateSpy = env.sandbox.spy();
     env.win.history.replaceState = replaceStateSpy;
     history = new History(
       new AmpDocSingle(env.win),
@@ -1061,7 +1061,7 @@ describes.fakeWin('Get and update fragment', {}, env => {
       'if the url does not contain fragment previously',
     () => {
       env.win.location.href = 'http://www.example.com';
-      const replaceStateSpy = sandbox.spy();
+      const replaceStateSpy = env.sandbox.spy();
       env.win.history.replaceState = replaceStateSpy;
       history = new History(
         new AmpDocSingle(env.win),

--- a/test/unit/test-ie-media-bug.js
+++ b/test/unit/test-ie-media-bug.js
@@ -18,7 +18,6 @@ import {checkAndFix} from '../../src/service/ie-media-bug';
 import {dev} from '../../src/log';
 
 describe('ie-media-bug', () => {
-  let sandbox;
   let clock;
   let windowApi, windowMock;
   let platform;
@@ -26,13 +25,12 @@ describe('ie-media-bug', () => {
   let devErrorStub;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox;
-    clock = sandbox.useFakeTimers();
+    clock = window.sandbox.useFakeTimers();
     platform = {
       isIe: () => false,
     };
-    platformMock = sandbox.mock(platform);
-    devErrorStub = sandbox.stub(dev(), 'error');
+    platformMock = window.sandbox.mock(platform);
+    devErrorStub = window.sandbox.stub(dev(), 'error');
 
     windowApi = {
       innerWidth: 320,
@@ -40,13 +38,12 @@ describe('ie-media-bug', () => {
       clearInterval: () => {},
       matchMedia: () => {},
     };
-    windowMock = sandbox.mock(windowApi);
+    windowMock = window.sandbox.mock(windowApi);
   });
 
   afterEach(() => {
     platformMock.verify();
     windowMock.verify();
-    sandbox.restore();
   });
 
   it('should bypass polling for non-IE browsers', () => {
@@ -85,7 +82,7 @@ describe('ie-media-bug', () => {
     windowMock
       .expects('setInterval')
       .withExactArgs(
-        sinon.match(arg => {
+        window.sandbox.match(arg => {
           intervalCallback = arg;
           return true;
         }),
@@ -103,7 +100,7 @@ describe('ie-media-bug', () => {
 
     // Second pass.
     clock.tick(10);
-    windowMock = sandbox.mock(windowApi);
+    windowMock = window.sandbox.mock(windowApi);
     windowMock
       .expects('matchMedia')
       .withExactArgs('(min-width: 319px) AND (max-width: 321px)')
@@ -117,7 +114,7 @@ describe('ie-media-bug', () => {
 
     // Third pass - succeed.
     clock.tick(10);
-    windowMock = sandbox.mock(windowApi);
+    windowMock = window.sandbox.mock(windowApi);
     windowMock
       .expects('matchMedia')
       .withExactArgs('(min-width: 319px) AND (max-width: 321px)')
@@ -150,7 +147,7 @@ describe('ie-media-bug', () => {
     windowMock
       .expects('setInterval')
       .withExactArgs(
-        sinon.match(arg => {
+        window.sandbox.match(arg => {
           intervalCallback = arg;
           return true;
         }),

--- a/test/unit/test-iframe-helper.js
+++ b/test/unit/test-iframe-helper.js
@@ -31,7 +31,6 @@ describe
       '/test/fixtures/served/iframe-intersection-outer.html';
 
     let testIframe;
-    let sandbox;
     let container;
 
     function insert(iframe) {
@@ -39,17 +38,12 @@ describe
     }
 
     beforeEach(() => {
-      sandbox = sinon.sandbox;
       return createIframePromise().then(c => {
         container = c;
         const i = c.doc.createElement('iframe');
         i.src = iframeSrc;
         testIframe = i;
       });
-    });
-
-    afterEach(() => {
-      sandbox.restore();
     });
 
     it('should assert src in iframe', () => {
@@ -212,9 +206,10 @@ describe
       });
     });
 
-    it('should set sentinel on postMessage data', () => {
+    // TODO(wg-runtime, #25587): Results in a cross-origin frame error.
+    it.skip('should set sentinel on postMessage data', () => {
       insert(testIframe);
-      const postMessageSpy = sinon /*OK*/
+      const postMessageSpy = window.sandbox /*OK*/
         .spy(testIframe.contentWindow, 'postMessage');
       IframeHelper.postMessage(
         testIframe,

--- a/test/unit/test-impression.js
+++ b/test/unit/test-impression.js
@@ -28,7 +28,6 @@ import {toggleExperiment} from '../../src/experiments';
 import {user} from '../../src/log';
 
 describe('impression', () => {
-  let sandbox;
   let ampdoc;
   let viewer;
   let xhr;
@@ -37,15 +36,14 @@ describe('impression', () => {
   let warnStub;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox;
     ampdoc = Services.ampdoc(window.document);
     viewer = Services.viewerForDoc(window.document);
-    sandbox.stub(viewer, 'getParam');
-    sandbox.stub(viewer, 'hasCapability');
+    window.sandbox.stub(viewer, 'getParam');
+    window.sandbox.stub(viewer, 'hasCapability');
     xhr = Services.xhrFor(window);
     expect(xhr.fetchJson).to.exist;
-    const stub = sandbox.stub(xhr, 'fetchJson');
-    warnStub = sandbox.stub(user(), 'warn');
+    const stub = window.sandbox.stub(xhr, 'fetchJson');
+    warnStub = window.sandbox.stub(user(), 'warn');
     stub.returns(
       Promise.resolve({
         json() {
@@ -53,12 +51,12 @@ describe('impression', () => {
         },
       })
     );
-    sandbox.stub(ampdoc, 'whenFirstVisible').returns(Promise.resolve());
+    window.sandbox.stub(ampdoc, 'whenFirstVisible').returns(Promise.resolve());
     isTrustedViewer = false;
-    sandbox.stub(viewer, 'isTrustedViewer').callsFake(() => {
+    window.sandbox.stub(viewer, 'isTrustedViewer').callsFake(() => {
       return Promise.resolve(isTrustedViewer);
     });
-    sandbox.stub(viewer, 'getReferrerUrl').callsFake(() => {
+    window.sandbox.stub(viewer, 'getReferrerUrl').callsFake(() => {
       return Promise.resolve(referrer);
     });
     resetTrackImpressionPromiseForTesting();
@@ -66,7 +64,6 @@ describe('impression', () => {
 
   afterEach(() => {
     toggleExperiment(window, 'alp', false);
-    sandbox.restore();
   });
 
   it('should do nothing if the experiment is off', () => {
@@ -88,7 +85,7 @@ describe('impression', () => {
     viewer.hasCapability.withArgs('replaceUrl').returns(true);
     viewer.getParam.withArgs('replaceUrl').returns('https://www.example.com');
     viewer.getParam.withArgs('click').returns('https://www.example.com');
-    const clock = sandbox.useFakeTimers();
+    const clock = window.sandbox.useFakeTimers();
     maybeTrackImpression(window);
     clock.tick(8001);
     return getTrackImpressionPromise();
@@ -99,11 +96,13 @@ describe('impression', () => {
     viewer.hasCapability.withArgs('replaceUrl').returns(true);
     viewer.getParam.withArgs('replaceUrl').returns('https://www.example.com');
     viewer.getParam.withArgs('click').returns('https://www.example.com');
-    sandbox.stub(viewer, 'sendMessageAwaitResponse').callsFake(message => {
-      if (message == 'getReplaceUrl') {
-        return Promise.resolve({'replaceUrl': undefined});
-      }
-    });
+    window.sandbox
+      .stub(viewer, 'sendMessageAwaitResponse')
+      .callsFake(message => {
+        if (message == 'getReplaceUrl') {
+          return Promise.resolve({'replaceUrl': undefined});
+        }
+      });
     xhr.fetchJson.returns(
       Promise.resolve({
         json() {
@@ -135,7 +134,7 @@ describe('impression', () => {
     });
 
     it('should invoke click URL with experiment on', function*() {
-      sandbox.spy(viewer, 'sendMessageAwaitResponse');
+      window.sandbox.spy(viewer, 'sendMessageAwaitResponse');
       toggleExperiment(window, 'alp', true);
       isTrustedViewer = false;
       viewer.getParam.withArgs('click').returns('https://www.example.com');
@@ -193,7 +192,7 @@ describe('impression', () => {
         })
       );
       const {href} = window.location;
-      const clock = sandbox.useFakeTimers();
+      const clock = window.sandbox.useFakeTimers();
       maybeTrackImpression(window);
       clock.tick(8001);
       return getTrackImpressionPromise().then(() => {
@@ -285,7 +284,7 @@ describe('impression', () => {
   describe('replaceUrl', () => {
     it('do nothing if no init replaceUrl param', function*() {
       toggleExperiment(window, 'alp', true);
-      sandbox.spy(viewer, 'replaceUrl');
+      window.sandbox.spy(viewer, 'replaceUrl');
       viewer.hasCapability.withArgs('replaceUrl').returns(true);
       maybeTrackImpression(window);
       yield macroTask();
@@ -311,7 +310,7 @@ describe('impression', () => {
 
     it('should request replaceUrl if viewer signals', function*() {
       toggleExperiment(window, 'alp', true);
-      sandbox.spy(viewer, 'sendMessageAwaitResponse');
+      window.sandbox.spy(viewer, 'sendMessageAwaitResponse');
       viewer.getParam.withArgs('replaceUrl').returns('http://www.example.com');
       viewer.hasCapability.withArgs('replaceUrl').returns(true);
       maybeTrackImpression(window);
@@ -324,11 +323,13 @@ describe('impression', () => {
       viewer.getParam.withArgs('click').returns(undefined);
       viewer.getParam.withArgs('replaceUrl').returns('http://www.example.com');
       viewer.hasCapability.withArgs('replaceUrl').returns(true);
-      sandbox.stub(viewer, 'sendMessageAwaitResponse').callsFake(message => {
-        if (message == 'getReplaceUrl') {
-          return Promise.resolve({'replaceUrl': undefined});
-        }
-      });
+      window.sandbox
+        .stub(viewer, 'sendMessageAwaitResponse')
+        .callsFake(message => {
+          if (message == 'getReplaceUrl') {
+            return Promise.resolve({'replaceUrl': undefined});
+          }
+        });
       maybeTrackImpression(window);
       return getTrackImpressionPromise();
     });
@@ -337,14 +338,16 @@ describe('impression', () => {
       toggleExperiment(window, 'alp', true);
       viewer.getParam.withArgs('replaceUrl').returns('http://www.example.com');
       viewer.hasCapability.withArgs('replaceUrl').returns(true);
-      sandbox.stub(viewer, 'sendMessageAwaitResponse').callsFake(message => {
-        if (message == 'getReplaceUrl') {
-          return Promise.resolve({
-            'replaceUrl':
-              'http://localhost:9876/v/s/f.com/?gclid=1234&amp_js_v=1',
-          });
-        }
-      });
+      window.sandbox
+        .stub(viewer, 'sendMessageAwaitResponse')
+        .callsFake(message => {
+          if (message == 'getReplaceUrl') {
+            return Promise.resolve({
+              'replaceUrl':
+                'http://localhost:9876/v/s/f.com/?gclid=1234&amp_js_v=1',
+            });
+          }
+        });
       const prevHref = window.location.href;
       window.history.replaceState(
         null,
@@ -392,8 +395,6 @@ describe('impression', () => {
       windowApi = new WindowApi();
       windowApi.location = {};
     });
-
-    afterEach(() => {});
 
     it('should append gclid and gclsrc from window href', () => {
       const target = window.document.createElement('a');

--- a/test/unit/test-ini-load.js
+++ b/test/unit/test-ini-load.js
@@ -21,13 +21,11 @@ import {whenContentIniLoad} from '../../src/ini-load';
 describes.realWin('friendly-iframe-embed', {amp: true}, env => {
   let win, doc;
   let ampdoc;
-  let sandbox;
 
   beforeEach(() => {
     win = env.win;
     doc = win.document;
     ampdoc = env.ampdoc;
-    sandbox = env.sandbox;
   });
 
   it('should find and await all visible content elements in given rect', async () => {
@@ -37,7 +35,7 @@ describes.realWin('friendly-iframe-embed', {amp: true}, env => {
     const context = doc.createElement('div');
     doc.body.appendChild(context);
     const resources = Services.resourcesForDoc(ampdoc);
-    sandbox.stub(resources, 'get').returns([
+    env.sandbox.stub(resources, 'get').returns([
       (content1 = resource(win, 'amp-img')),
       (content2 = resource(win, 'amp-video')),
       resource(win, 'amp-img', false), // resource outside rect

--- a/test/unit/test-input.js
+++ b/test/unit/test-input.js
@@ -19,7 +19,6 @@ import {installTimerService} from '../../src/service/timer-impl.js';
 import {stubService} from '../../testing/test-helper';
 
 describe('Input', () => {
-  let sandbox;
   let clock;
   let input;
   let eventListeners;
@@ -27,8 +26,7 @@ describe('Input', () => {
   let documentApi;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox;
-    clock = sandbox.useFakeTimers();
+    clock = window.sandbox.useFakeTimers();
 
     eventListeners = {};
 
@@ -53,10 +51,6 @@ describe('Input', () => {
     installTimerService(windowApi);
 
     input = new Input(windowApi);
-  });
-
-  afterEach(() => {
-    sandbox.restore();
   });
 
   it('should initialize in touch mode', () => {

--- a/test/unit/test-intersection-observer-polyfill.js
+++ b/test/unit/test-intersection-observer-polyfill.js
@@ -38,7 +38,7 @@ const fakeAmpDoc = {
 };
 installHiddenObserverForDoc(fakeAmpDoc);
 
-describes.sandboxed('IntersectionObserverApi', {}, () => {
+describes.sandboxed('IntersectionObserverApi', {}, env => {
   let onScrollSpy;
   let onChangeSpy;
   let testDoc;
@@ -78,11 +78,11 @@ describes.sandboxed('IntersectionObserverApi', {}, () => {
   }
 
   beforeEach(() => {
-    onScrollSpy = sandbox.spy();
-    onChangeSpy = sandbox.spy();
+    onScrollSpy = env.sandbox.spy();
+    onChangeSpy = env.sandbox.spy();
     testIframe = getIframe(iframeSrc);
-    sandbox.stub(AmpDocService.prototype, 'getAmpDoc').returns(fakeAmpDoc);
-    sandbox.stub(Services, 'viewportForDoc').callsFake(() => {
+    env.sandbox.stub(AmpDocService.prototype, 'getAmpDoc').returns(fakeAmpDoc);
+    env.sandbox.stub(Services, 'viewportForDoc').callsFake(() => {
       return mockViewport;
     });
     testDoc = {defaultView: window};
@@ -120,7 +120,7 @@ describes.sandboxed('IntersectionObserverApi', {}, () => {
     };
     ioApi = new IntersectionObserverApi(baseElement, testIframe);
     insert(testIframe);
-    tickSpy = sandbox.spy(ioApi.intersectionObserver_, 'tick');
+    tickSpy = env.sandbox.spy(ioApi.intersectionObserver_, 'tick');
   });
 
   afterEach(() => {
@@ -144,7 +144,10 @@ describes.sandboxed('IntersectionObserverApi', {}, () => {
     };
     ioApi = new IntersectionObserverApi(baseElement, testIframe);
     insert(testIframe);
-    const inViewportTickSpy = sandbox.spy(ioApi.intersectionObserver_, 'tick');
+    const inViewportTickSpy = env.sandbox.spy(
+      ioApi.intersectionObserver_,
+      'tick'
+    );
     ioApi.startSendingIntersection_();
     expect(inViewportTickSpy).to.be.calledOnce;
     expect(onChangeSpy).to.be.calledTwice;
@@ -168,11 +171,11 @@ describes.sandboxed('IntersectionObserverApi', {}, () => {
   });
 
   it('should destroy correctly', () => {
-    const subscriptionApiDestroySpy = sandbox.spy(
+    const subscriptionApiDestroySpy = env.sandbox.spy(
       ioApi.subscriptionApi_,
       'destroy'
     );
-    const polyfillDisconnectSpy = sandbox.spy(
+    const polyfillDisconnectSpy = env.sandbox.spy(
       ioApi.intersectionObserver_,
       'disconnect'
     );
@@ -186,10 +189,10 @@ describes.sandboxed('IntersectionObserverApi', {}, () => {
   });
 });
 
-describes.sandboxed('getIntersectionChangeEntry', {}, () => {
+describes.sandboxed('getIntersectionChangeEntry', {}, env => {
   beforeEach(() => {
-    sandbox.stub(performance, 'now').callsFake(() => 100);
-    sandbox.stub(AmpDocService.prototype, 'getAmpDoc').returns(fakeAmpDoc);
+    env.sandbox.stub(performance, 'now').callsFake(() => 100);
+    env.sandbox.stub(AmpDocService.prototype, 'getAmpDoc').returns(fakeAmpDoc);
   });
 
   it('without owner', () => {
@@ -237,11 +240,11 @@ describes.sandboxed('getIntersectionChangeEntry', {}, () => {
   });
 });
 
-describes.sandboxed('IntersectionObserverPolyfill', {}, () => {
+describes.sandboxed('IntersectionObserverPolyfill', {}, env => {
   beforeEach(() => {
-    sandbox.stub(performance, 'now').callsFake(() => 100);
-    sandbox.stub(AmpDocService.prototype, 'getAmpDoc').returns(fakeAmpDoc);
-    sandbox.stub(Services, 'ampdoc').callsFake(() => fakeAmpDoc);
+    env.sandbox.stub(performance, 'now').callsFake(() => 100);
+    env.sandbox.stub(AmpDocService.prototype, 'getAmpDoc').returns(fakeAmpDoc);
+    env.sandbox.stub(Services, 'ampdoc').callsFake(() => fakeAmpDoc);
   });
 
   describe('threshold', () => {
@@ -333,17 +336,17 @@ describes.sandboxed('IntersectionObserverPolyfill', {}, () => {
 
     let io;
     beforeEach(() => {
-      callbackSpy = sandbox.spy();
+      callbackSpy = env.sandbox.spy();
       io = new IntersectionObserverPolyfill(callbackSpy);
 
-      sandbox.stub(Services, 'viewportForDoc').callsFake(() => {
+      env.sandbox.stub(Services, 'viewportForDoc').callsFake(() => {
         return {
           getRect: () => {
             return layoutRectLtwh(50, 100, 150, 200);
           },
         };
       });
-      sandbox.stub(Services, 'resourcesForDoc').callsFake(() => {
+      env.sandbox.stub(Services, 'resourcesForDoc').callsFake(() => {
         return {
           onNextPass: callback => {
             callback();

--- a/test/unit/test-intersection-observer.js
+++ b/test/unit/test-intersection-observer.js
@@ -23,14 +23,8 @@ import {createAmpElementForTesting} from '../../src/custom-element';
 import {layoutRectLtwh} from '../../src/layout-rect';
 
 describe('getIntersectionChangeEntry', () => {
-  let sandbox;
   beforeEach(() => {
-    sandbox = sinon.sandbox;
-    sandbox.useFakeTimers();
-  });
-
-  afterEach(() => {
-    sandbox.restore();
+    window.sandbox.useFakeTimers();
   });
 
   it('intersect correctly base', () => {
@@ -342,7 +336,6 @@ describe('IntersectionObserver', () => {
     location.port +
     '/test/fixtures/served/iframe-intersection.html';
 
-  let sandbox;
   let testIframe;
   let element;
   let getIntersectionChangeEntrySpy;
@@ -362,19 +355,18 @@ describe('IntersectionObserver', () => {
   }
 
   beforeEach(() => {
-    sandbox = sinon.sandbox;
-    clock = sandbox.useFakeTimers();
-    testElementCreatedCallback = sandbox.spy();
-    testElementPreconnectCallback = sandbox.spy();
-    testElementFirstAttachedCallback = sandbox.spy();
-    testElementBuildCallback = sandbox.spy();
-    testElementLayoutCallback = sandbox.spy();
-    testElementFirstLayoutCompleted = sandbox.spy();
-    testElementViewportCallback = sandbox.spy();
-    testElementGetInsersectionElementLayoutBox = sandbox.spy();
-    getIntersectionChangeEntrySpy = sandbox.spy();
-    onScrollSpy = sandbox.spy();
-    onChangeSpy = sandbox.spy();
+    clock = window.sandbox.useFakeTimers();
+    testElementCreatedCallback = window.sandbox.spy();
+    testElementPreconnectCallback = window.sandbox.spy();
+    testElementFirstAttachedCallback = window.sandbox.spy();
+    testElementBuildCallback = window.sandbox.spy();
+    testElementLayoutCallback = window.sandbox.spy();
+    testElementFirstLayoutCompleted = window.sandbox.spy();
+    testElementViewportCallback = window.sandbox.spy();
+    testElementGetInsersectionElementLayoutBox = window.sandbox.spy();
+    getIntersectionChangeEntrySpy = window.sandbox.spy();
+    onScrollSpy = window.sandbox.spy();
+    onChangeSpy = window.sandbox.spy();
     testIframe = getIframe(iframeSrc);
     element = new ElementClass();
     element.win = window;
@@ -409,14 +401,13 @@ describe('IntersectionObserver', () => {
   });
 
   afterEach(() => {
-    sandbox.restore();
     testIframe.parentNode.removeChild(testIframe);
   });
 
   it('should not send intersection', () => {
     const ioInstance = new IntersectionObserver(element, testIframe);
     insert(testIframe);
-    const postMessageSpy = sinon /*OK*/
+    const postMessageSpy = window.sandbox /*OK*/
       .spy(testIframe.contentWindow, 'postMessage');
     ioInstance.sendElementIntersection_();
     expect(postMessageSpy).to.have.not.been.called;
@@ -490,7 +481,7 @@ describe('IntersectionObserver', () => {
   });
 
   it('should init listeners when element is in viewport', () => {
-    const fireSpy = sandbox.spy(IntersectionObserver.prototype, 'fire');
+    const fireSpy = window.sandbox.spy(IntersectionObserver.prototype, 'fire');
     const ioInstance = new IntersectionObserver(element, testIframe);
     insert(testIframe);
     ioInstance.onViewportCallback(true);
@@ -501,7 +492,7 @@ describe('IntersectionObserver', () => {
   });
 
   it('should unlisten listeners when element is out of viewport', () => {
-    const fireSpy = sandbox.spy(IntersectionObserver.prototype, 'fire');
+    const fireSpy = window.sandbox.spy(IntersectionObserver.prototype, 'fire');
     const ioInstance = new IntersectionObserver(element, testIframe);
     insert(testIframe);
     ioInstance.onViewportCallback(true);

--- a/test/unit/test-layout-delay-meter.js
+++ b/test/unit/test-layout-delay-meter.js
@@ -28,22 +28,20 @@ describes.realWin(
   },
   env => {
     let win;
-    let sandbox;
     let meter;
     let tickSpy;
     let clock;
 
     beforeEach(() => {
-      sandbox = env.sandbox;
       win = env.win;
       installPerformanceService(win);
       const perf = Services.performanceFor(win);
-      sandbox.stub(perf, 'isPerformanceTrackingOn').callsFake(() => true);
+      env.sandbox.stub(perf, 'isPerformanceTrackingOn').callsFake(() => true);
       clock = lolex.install({
         target: win,
         toFake: ['Date', 'setTimeout', 'clearTimeout'],
       });
-      tickSpy = sandbox.spy(perf, 'tickDelta');
+      tickSpy = env.sandbox.spy(perf, 'tickDelta');
 
       meter = new LayoutDelayMeter(win, 2);
     });

--- a/test/unit/test-log.js
+++ b/test/unit/test-log.js
@@ -36,20 +36,17 @@ describe('Logging', () => {
   const RETURNS_ERROR = () => LogLevel.ERROR;
   const RETURNS_OFF = () => LogLevel.OFF;
 
-  let sandbox;
   let mode;
   let win;
   let logSpy;
   let timeoutSpy;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox;
-
     mode = {};
     window.__AMP_MODE = mode;
 
-    logSpy = sandbox.spy();
-    timeoutSpy = sandbox.spy();
+    logSpy = window.sandbox.spy();
+    timeoutSpy = window.sandbox.spy();
     win = {
       console: {
         log: logSpy,
@@ -58,12 +55,10 @@ describe('Logging', () => {
       setTimeout: timeoutSpy,
       __AMP_REPORT_ERROR: error => error,
     };
-    sandbox.stub(self, '__AMP_REPORT_ERROR').callsFake(error => error);
+    window.sandbox.stub(self, '__AMP_REPORT_ERROR').callsFake(error => error);
   });
 
   afterEach(() => {
-    sandbox.restore();
-    sandbox = null;
     window.__AMP_MODE = undefined;
   });
 
@@ -628,7 +623,7 @@ describe('Logging', () => {
     let clock;
 
     beforeEach(() => {
-      clock = sandbox.useFakeTimers();
+      clock = window.sandbox.useFakeTimers();
       restoreAsyncErrorThrows();
     });
 
@@ -732,20 +727,17 @@ describe('Logging', () => {
   });
 
   describe('embed error', () => {
-    let sandbox;
     let iframe;
     let element;
     let element1;
     let element2;
 
     beforeEach(() => {
-      sandbox = sinon.sandbox;
       iframe = document.createElement('iframe');
       document.body.appendChild(iframe);
     });
 
     afterEach(() => {
-      sandbox.restore();
       document.body.removeChild(iframe);
     });
 

--- a/test/unit/test-mediasession-helper.js
+++ b/test/unit/test-mediasession-helper.js
@@ -55,7 +55,7 @@ const schemaTemplate = `
 }
 `;
 
-describes.sandboxed('MediaSessionAPI Helper Functions', {}, () => {
+describes.sandboxed('MediaSessionAPI Helper Functions', {}, env => {
   let element;
   let ampdoc;
   let favicon;
@@ -65,7 +65,7 @@ describes.sandboxed('MediaSessionAPI Helper Functions', {}, () => {
 
   beforeEach(() => {
     element = {};
-    sandbox
+    env.sandbox
       .stub(Services, 'urlForDoc')
       .withArgs(element)
       .returns({isProtocolValid});

--- a/test/unit/test-motion.js
+++ b/test/unit/test-motion.js
@@ -51,15 +51,13 @@ describe('Motion calcVelocity', () => {
 });
 
 describe('Motion continueMotion', () => {
-  let sandbox;
   let clock;
   let vsync;
   let vsyncTasks;
   let contextNode;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox;
-    clock = sandbox.useFakeTimers();
+    clock = window.sandbox.useFakeTimers();
     vsyncTasks = [];
     vsync = {
       runAnimMutateSeries: (unusedContextNode, mutator) => {
@@ -68,10 +66,6 @@ describe('Motion continueMotion', () => {
       },
     };
     contextNode = document.createElement('div');
-  });
-
-  afterEach(() => {
-    sandbox.restore();
   });
 
   function testContinuation(maxVelocity, haltAfterTime) {

--- a/test/unit/test-navigation.js
+++ b/test/unit/test-navigation.js
@@ -67,26 +67,26 @@ describes.sandboxed('Navigation', {}, () => {
         handler = Services.navigationForDoc(documentElement);
         handler.isIframed_ = true;
 
-        decorationSpy = sandbox.spy(Impression, 'getExtraParamsUrl');
+        decorationSpy = env.sandbox.spy(Impression, 'getExtraParamsUrl');
 
-        handleNavSpy = sandbox.spy(handler, 'handleNavigation_');
+        handleNavSpy = env.sandbox.spy(handler, 'handleNavigation_');
 
-        handleCustomProtocolSpy = sandbox.spy(
+        handleCustomProtocolSpy = env.sandbox.spy(
           handler,
           'handleCustomProtocolClick_'
         );
 
         win.open = function() {};
-        winOpenStub = sandbox.stub(win, 'open').callsFake(() => {
+        winOpenStub = env.sandbox.stub(win, 'open').callsFake(() => {
           return {};
         });
 
         const viewport = Services.viewportForDoc(doc);
-        scrollIntoViewStub = sandbox.stub(viewport, 'scrollIntoView');
+        scrollIntoViewStub = env.sandbox.stub(viewport, 'scrollIntoView');
 
         const history = Services.historyForDoc(doc);
         replaceStateForTargetPromise = Promise.resolve();
-        replaceStateForTargetStub = sandbox
+        replaceStateForTargetStub = env.sandbox
           .stub(history, 'replaceStateForTarget')
           .callsFake(() => replaceStateForTargetPromise);
 
@@ -100,7 +100,7 @@ describes.sandboxed('Navigation', {}, () => {
         doc.body.appendChild(customAnchor);
 
         const urlReplacements = Services.urlReplacementsForDoc(documentElement);
-        const urlReplacementStub = sandbox.stub(
+        const urlReplacementStub = env.sandbox.stub(
           Services,
           'urlReplacementsForDoc'
         );
@@ -221,19 +221,19 @@ describes.sandboxed('Navigation', {}, () => {
         });
 
         it('verify order of operations', () => {
-          const expandVars = sandbox.spy(handler, 'expandVarsForAnchor_');
-          const parseUrl = sandbox.spy(handler, 'parseUrl_');
+          const expandVars = env.sandbox.spy(handler, 'expandVarsForAnchor_');
+          const parseUrl = env.sandbox.spy(handler, 'parseUrl_');
           const obj = {
             callback: () => {},
           };
-          const linkRuleSpy = sandbox.spy(obj, 'callback');
+          const linkRuleSpy = env.sandbox.spy(obj, 'callback');
           handler.registerAnchorMutator(linkRuleSpy, 1);
           handler.handle_(event);
           // Verify that the expansion of variables occurs first
           // followed by the anchor transformation and then the parsing
           // of the possibly mutated anchor href into the location object
           // for navigation.handleNavClick.
-          sinon.assert.callOrder(expandVars, linkRuleSpy, parseUrl);
+          env.sandbox.assert.callOrder(expandVars, linkRuleSpy, parseUrl);
           expect(expandVars).to.be.calledOnce;
           // Verify that parseUrl is called once when the variables are
           // expanded, then after the anchor mutators and then once more
@@ -581,7 +581,9 @@ describes.sandboxed('Navigation', {}, () => {
         });
 
         it('should delegate navigation if viewer supports A2A', () => {
-          const stub = sandbox.stub(handler, 'navigateToAmpUrl').returns(true);
+          const stub = env.sandbox
+            .stub(handler, 'navigateToAmpUrl')
+            .returns(true);
 
           handler.handle_(event);
 
@@ -598,7 +600,9 @@ describes.sandboxed('Navigation', {}, () => {
         });
 
         it('should behave normally if viewer does not support A2A', () => {
-          const stub = sandbox.stub(handler, 'navigateToAmpUrl').returns(false);
+          const stub = env.sandbox
+            .stub(handler, 'navigateToAmpUrl')
+            .returns(false);
 
           handler.handle_(event);
 
@@ -639,7 +643,7 @@ describes.sandboxed('Navigation', {}, () => {
             'https://cdn.ampproject.org/c/s/www.pub.com/dir/page.html';
           const urlService = Services.urlForDoc(doc.documentElement);
 
-          sandbox.stub(urlService, 'getSourceUrl').callsFake(url => {
+          env.sandbox.stub(urlService, 'getSourceUrl').callsFake(url => {
             expect(url).to.equal('abc.html');
             return 'https://www.pub.com/dir/abc.html';
           });
@@ -659,8 +663,11 @@ describes.sandboxed('Navigation', {}, () => {
           meta.setAttribute('content', 'feature-foo, action-bar');
           ampdoc.getRootNode().head.appendChild(meta);
 
-          const send = sandbox.stub(handler.viewer_, 'sendMessage');
-          const hasCapability = sandbox.stub(handler.viewer_, 'hasCapability');
+          const send = env.sandbox.stub(handler.viewer_, 'sendMessage');
+          const hasCapability = env.sandbox.stub(
+            handler.viewer_,
+            'hasCapability'
+          );
           hasCapability.returns(true);
           expect(win.location.href).to.equal('https://www.pub.com/');
 
@@ -739,14 +746,14 @@ describes.sandboxed('Navigation', {}, () => {
               (ampdoc.__AMP_SERVICES && ampdoc.__AMP_SERVICES.navigation) ||
               win.__AMP_SERVICES.navigation
             ).obj;
-            winOpenStub = sandbox.stub(win, 'open').callsFake(() => {
+            winOpenStub = env.sandbox.stub(win, 'open').callsFake(() => {
               return {};
             });
             const viewport = parentWin.__AMP_SERVICES.viewport.obj;
-            scrollIntoViewStub = sandbox.stub(viewport, 'scrollIntoView');
+            scrollIntoViewStub = env.sandbox.stub(viewport, 'scrollIntoView');
             const history = parentWin.__AMP_SERVICES.history.obj;
             replaceStateForTargetPromise = Promise.resolve();
-            replaceStateForTargetStub = sandbox
+            replaceStateForTargetStub = env.sandbox
               .stub(history, 'replaceStateForTarget')
               .callsFake(() => replaceStateForTargetPromise);
 
@@ -761,7 +768,7 @@ describes.sandboxed('Navigation', {}, () => {
             const urlReplacements = Services.urlReplacementsForDoc(
               documentElement
             );
-            sandbox
+            env.sandbox
               .stub(Services, 'urlReplacementsForDoc')
               .withArgs(anchor)
               .returns(urlReplacements);

--- a/test/unit/test-notification-ui-manager.js
+++ b/test/unit/test-notification-ui-manager.js
@@ -25,9 +25,9 @@ describes.realWin('NotificationUiManager', {amp: 1}, () => {
     let p1, p2, p3;
     beforeEach(() => {
       manager = new NotificationUiManager();
-      showSpy1 = sandbox.spy();
-      showSpy2 = sandbox.spy();
-      showSpy3 = sandbox.spy();
+      showSpy1 = window.sandbox.spy();
+      showSpy2 = window.sandbox.spy();
+      showSpy3 = window.sandbox.spy();
 
       p1 = new Promise(resolve => {
         resolve1 = resolve;
@@ -81,7 +81,7 @@ describes.realWin('NotificationUiManager', {amp: 1}, () => {
     });
 
     it('queue empty handler', function*() {
-      const handler = sandbox.spy();
+      const handler = window.sandbox.spy();
       manager.registerUI(show1);
       manager.registerUI(show2);
       manager.onQueueEmpty(handler);
@@ -93,7 +93,7 @@ describes.realWin('NotificationUiManager', {amp: 1}, () => {
     });
 
     it('queue not empty handler', function*() {
-      const handler = sandbox.spy();
+      const handler = window.sandbox.spy();
       manager.onQueueNotEmpty(handler);
       manager.registerUI(show1);
       manager.registerUI(show2);

--- a/test/unit/test-observable.js
+++ b/test/unit/test-observable.js
@@ -17,16 +17,10 @@
 import {Observable} from '../../src/observable';
 
 describe('Observable', () => {
-  let sandbox;
   let observable;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox;
     observable = new Observable();
-  });
-
-  afterEach(() => {
-    sandbox.restore();
   });
 
   it('add-remove-fire', () => {

--- a/test/unit/test-origin-experiments.js
+++ b/test/unit/test-origin-experiments.js
@@ -31,17 +31,16 @@ describes.fakeWin('OriginExperiments', {amp: true}, env => {
   let ampdoc;
   let isPkcsAvailable;
   let originExperiments;
-  let sandbox;
   let win;
   let error;
 
   beforeEach(() => {
-    ({win, ampdoc, sandbox} = env);
+    ({win, ampdoc} = env);
 
     const crypto = Services.cryptoFor(win);
-    isPkcsAvailable = sandbox.stub(crypto, 'isPkcsAvailable').returns(true);
+    isPkcsAvailable = env.sandbox.stub(crypto, 'isPkcsAvailable').returns(true);
 
-    error = sandbox.stub(user(), 'error');
+    error = env.sandbox.stub(user(), 'error');
 
     originExperiments = new OriginExperiments(ampdoc);
   });

--- a/test/unit/test-origin-experiments.js
+++ b/test/unit/test-origin-experiments.js
@@ -86,25 +86,33 @@ describes.fakeWin('OriginExperiments', {amp: true}, env => {
     expect(error).calledWithMatch(TAG, 'Failed to verify experiment token');
   });
 
-  it('should return true for valid token with matching origin', function*() {
-    setupMetaTagWith(token);
-    win.location.href = 'https://origin.com';
+  // TODO(amphtml, #25621): Cannot find atob / btoa on Safari on Sauce Labs.
+  it.configure().skipSafari(
+    'should return true for valid token with matching origin',
+    function*() {
+      setupMetaTagWith(token);
+      win.location.href = 'https://origin.com';
 
-    const experiments = originExperiments.getExperiments();
-    expect(experiments).to.eventually.deep.equal(['foo']);
-    yield experiments;
-    expect(error).to.not.be.called;
-  });
+      const experiments = originExperiments.getExperiments();
+      expect(experiments).to.eventually.deep.equal(['foo']);
+      yield experiments;
+      expect(error).to.not.be.called;
+    }
+  );
 
-  it('should return false if experiment is not in config', function*() {
-    setupMetaTagWith(token);
-    win.location.href = 'https://origin.com';
+  // TODO(amphtml, #25621): Cannot find atob / btoa on Safari on Sauce Labs.
+  it.configure().skipSafari(
+    'should return false if experiment is not in config',
+    function*() {
+      setupMetaTagWith(token);
+      win.location.href = 'https://origin.com';
 
-    const experiments = originExperiments.getExperiments();
-    expect(experiments).to.eventually.deep.equal([]);
-    yield experiments;
-    expect(error).to.not.be.called;
-  });
+      const experiments = originExperiments.getExperiments();
+      expect(experiments).to.eventually.deep.equal([]);
+      yield experiments;
+      expect(error).to.not.be.called;
+    }
+  );
 });
 
 describes.fakeWin('TokenMaster', {amp: true}, env => {
@@ -119,116 +127,122 @@ describes.fakeWin('TokenMaster', {amp: true}, env => {
   let tokenWithBadConfigLength;
   let tokenWithBadSignature;
 
-  // Generate test tokens once since generating keys is slow.
-  beforeEach(() => {
-    const crypto = Services.cryptoFor(env.win);
-    const url = Services.urlForDoc(env.ampdoc.getHeadNode());
-    tokenMaster = new TokenMaster(crypto, url);
+  // TODO(amphtml, #25621): Cannot find atob / btoa on Safari on Sauce Labs.
+  describe
+    .configure()
+    .skipSafari()
+    .run('TokenMaster', () => {
+      // Generate test tokens once since generating keys is slow.
+      beforeEach(() => {
+        const crypto = Services.cryptoFor(env.win);
+        const url = Services.urlForDoc(env.ampdoc.getHeadNode());
+        tokenMaster = new TokenMaster(crypto, url);
 
-    return tokenMaster.generateKeys().then(keyPair => {
-      ({publicKey, privateKey} = keyPair);
+        return tokenMaster.generateKeys().then(keyPair => {
+          ({publicKey, privateKey} = keyPair);
 
-      const config = {
-        origin: 'https://origin.com',
-        experiment: 'origin',
-        expiration: Date.now() + 1000 * 1000, // 1000s in the future.
-      };
-      const expired = {
-        origin: 'https://origin.com',
-        experiment: 'expired',
-        expiration: Date.now() - 1000, // 1s in the past.
-      };
+          const config = {
+            origin: 'https://origin.com',
+            experiment: 'origin',
+            expiration: Date.now() + 1000 * 1000, // 1000s in the future.
+          };
+          const expired = {
+            origin: 'https://origin.com',
+            experiment: 'expired',
+            expiration: Date.now() - 1000, // 1s in the past.
+          };
 
-      return Promise.all([
-        tokenMaster.generateToken(0, config, privateKey),
-        tokenMaster.generateToken(42, config, privateKey),
-        tokenMaster.generateToken(0, expired, privateKey),
-      ]).then(results => {
-        token = results[0];
-        tokenWithBadVersion = results[1];
-        tokenWithExpiredExperiment = results[2];
+          return Promise.all([
+            tokenMaster.generateToken(0, config, privateKey),
+            tokenMaster.generateToken(42, config, privateKey),
+            tokenMaster.generateToken(0, expired, privateKey),
+          ]).then(results => {
+            token = results[0];
+            tokenWithBadVersion = results[1];
+            tokenWithExpiredExperiment = results[2];
 
-        // Generate token with bad signature by truncating.
-        tokenWithBadSignature = token.slice(0, token.length - 5);
+            // Generate token with bad signature by truncating.
+            tokenWithBadSignature = token.slice(0, token.length - 5);
 
-        // Generate token with bad config length by hand.
-        const data = new Uint8Array(5);
-        new DataView(data.buffer).setUint32(1, 999, false); // 999 length.
-        tokenWithBadConfigLength = btoa(bytesToString(data));
+            // Generate token with bad config length by hand.
+            const data = new Uint8Array(5);
+            new DataView(data.buffer).setUint32(1, 999, false); // 999 length.
+            tokenWithBadConfigLength = btoa(bytesToString(data));
+          });
+        });
+      });
+
+      it('should throw for an unknown token version number', () => {
+        const verify = tokenMaster.verifyToken(
+          tokenWithBadVersion,
+          'https://origin.com',
+          publicKey
+        );
+        return expect(verify).to.eventually.be.rejectedWith(
+          'Unrecognized token version: 42'
+        );
+      });
+
+      it('should throw if config length exceeds byte length', () => {
+        const verify = tokenMaster.verifyToken(
+          tokenWithBadConfigLength,
+          'https://origin.com',
+          publicKey
+        );
+        return expect(verify).to.eventually.be.rejectedWith(
+          'Unexpected config length: 999'
+        );
+      });
+
+      it('should throw if signature cannot be verified', () => {
+        const verify = tokenMaster.verifyToken(
+          tokenWithBadSignature,
+          'https://origin.com',
+          publicKey
+        );
+        return expect(verify).to.eventually.be.rejectedWith(
+          'Failed to verify token signature.'
+        );
+      });
+
+      it('should throw if approved origin is not current origin', () => {
+        const verify = tokenMaster.verifyToken(
+          token,
+          'https://not-origin.com',
+          publicKey
+        );
+        return expect(verify).to.eventually.be.rejectedWith(
+          /does not match window/
+        );
+      });
+
+      it('should return false if trial has expired', () => {
+        const verify = tokenMaster.verifyToken(
+          tokenWithExpiredExperiment,
+          'https://origin.com',
+          publicKey
+        );
+        return expect(verify).to.eventually.be.rejectedWith(
+          'Experiment "expired" has expired.'
+        );
+      });
+
+      it('should return true for a well-formed, unexpired token', () => {
+        const verify = tokenMaster.verifyToken(
+          token,
+          'https://origin.com',
+          publicKey
+        );
+        return expect(verify).to.eventually.be.fulfilled;
+      });
+
+      it('should ignore trailing slash on location', () => {
+        const verify = tokenMaster.verifyToken(
+          token,
+          'https://origin.com/',
+          publicKey
+        );
+        return expect(verify).to.eventually.be.fulfilled;
       });
     });
-  });
-
-  it('should throw for an unknown token version number', () => {
-    const verify = tokenMaster.verifyToken(
-      tokenWithBadVersion,
-      'https://origin.com',
-      publicKey
-    );
-    return expect(verify).to.eventually.be.rejectedWith(
-      'Unrecognized token version: 42'
-    );
-  });
-
-  it('should throw if config length exceeds byte length', () => {
-    const verify = tokenMaster.verifyToken(
-      tokenWithBadConfigLength,
-      'https://origin.com',
-      publicKey
-    );
-    return expect(verify).to.eventually.be.rejectedWith(
-      'Unexpected config length: 999'
-    );
-  });
-
-  it('should throw if signature cannot be verified', () => {
-    const verify = tokenMaster.verifyToken(
-      tokenWithBadSignature,
-      'https://origin.com',
-      publicKey
-    );
-    return expect(verify).to.eventually.be.rejectedWith(
-      'Failed to verify token signature.'
-    );
-  });
-
-  it('should throw if approved origin is not current origin', () => {
-    const verify = tokenMaster.verifyToken(
-      token,
-      'https://not-origin.com',
-      publicKey
-    );
-    return expect(verify).to.eventually.be.rejectedWith(
-      /does not match window/
-    );
-  });
-
-  it('should return false if trial has expired', () => {
-    const verify = tokenMaster.verifyToken(
-      tokenWithExpiredExperiment,
-      'https://origin.com',
-      publicKey
-    );
-    return expect(verify).to.eventually.be.rejectedWith(
-      'Experiment "expired" has expired.'
-    );
-  });
-
-  it('should return true for a well-formed, unexpired token', () => {
-    const verify = tokenMaster.verifyToken(
-      token,
-      'https://origin.com',
-      publicKey
-    );
-    return expect(verify).to.eventually.be.fulfilled;
-  });
-
-  it('should ignore trailing slash on location', () => {
-    const verify = tokenMaster.verifyToken(
-      token,
-      'https://origin.com/',
-      publicKey
-    );
-    return expect(verify).to.eventually.be.fulfilled;
-  });
 });

--- a/test/unit/test-owners.js
+++ b/test/unit/test-owners.js
@@ -28,13 +28,11 @@ describes.realWin(
     let owners;
     let parent;
     let children;
-    let sandbox;
     let scheduleLayoutOrPreloadStub;
 
     beforeEach(() => {
       win = env.win;
       doc = win.document;
-      sandbox = env.sandbox;
       owners = Services.ownersForDoc(env.ampdoc);
       resources = Services.resourcesForDoc(env.ampdoc);
       resources.isRuntimeOn_ = false;
@@ -56,7 +54,7 @@ describes.realWin(
           children[0].appendChild(children[i]);
         }
       }
-      scheduleLayoutOrPreloadStub = sandbox.stub(
+      scheduleLayoutOrPreloadStub = env.sandbox.stub(
         resources,
         'scheduleLayoutOrPreload'
       );
@@ -64,7 +62,7 @@ describes.realWin(
 
     function createElement() {
       const element = env.createAmpElement('amp-test');
-      sandbox.stub(element, 'isUpgraded').returns(true);
+      env.sandbox.stub(element, 'isUpgraded').returns(true);
       return element;
     }
 
@@ -75,11 +73,11 @@ describes.realWin(
       const element = createElement();
       const resource = new Resource(id, element, resources);
       resource.state_ = state;
-      sandbox.stub(resource, 'measure').callsFake(() => {
+      env.sandbox.stub(resource, 'measure').callsFake(() => {
         resource.state_ = ResourceState.READY_FOR_LAYOUT;
       });
       resource.isDisplayedForTesting = true;
-      sandbox
+      env.sandbox
         .stub(resource, 'isDisplayed')
         .callsFake(() => resource.isDisplayedForTesting);
       resource.isInViewport = () => true;
@@ -121,8 +119,8 @@ describes.realWin(
       });
 
       it('should call pauseCallback on custom element', () => {
-        const stub1 = sandbox.stub(children[1], 'pauseCallback');
-        const stub2 = sandbox.stub(children[2], 'pauseCallback');
+        const stub1 = env.sandbox.stub(children[1], 'pauseCallback');
+        const stub2 = env.sandbox.stub(children[2], 'pauseCallback');
 
         owners.schedulePause(parent, children);
         expect(stub1.calledOnce).to.be.true;
@@ -130,9 +128,9 @@ describes.realWin(
       });
 
       it('should call unlayoutCallback when unlayoutOnPause', () => {
-        const stub1 = sandbox.stub(children[1], 'unlayoutCallback');
-        const stub2 = sandbox.stub(children[2], 'unlayoutCallback');
-        sandbox.stub(children[1], 'unlayoutOnPause').returns(true);
+        const stub1 = env.sandbox.stub(children[1], 'unlayoutCallback');
+        const stub2 = env.sandbox.stub(children[2], 'unlayoutCallback');
+        env.sandbox.stub(children[1], 'unlayoutOnPause').returns(true);
 
         owners.schedulePause(parent, children);
         expect(stub1.calledOnce).to.be.true;
@@ -166,14 +164,14 @@ describes.realWin(
       });
 
       it('should call resumeCallback on paused custom elements', () => {
-        const stub1 = sandbox.stub(children[1], 'resumeCallback');
+        const stub1 = env.sandbox.stub(children[1], 'resumeCallback');
 
         owners.scheduleResume(parent, children);
         expect(stub1.calledOnce).to.be.true;
       });
 
       it('should call resumeCallback on non-paused custom elements', () => {
-        const stub2 = sandbox.stub(children[2], 'resumeCallback');
+        const stub2 = env.sandbox.stub(children[2], 'resumeCallback');
 
         owners.scheduleResume(parent, children);
         expect(stub2.calledOnce).to.be.true;
@@ -200,7 +198,7 @@ describes.realWin(
           ResourceState.NOT_BUILT
         );
         let buildResource;
-        sandbox.stub(resource1, 'whenBuilt').returns(
+        env.sandbox.stub(resource1, 'whenBuilt').returns(
           new Promise(resolve => {
             buildResource = resolve;
           })
@@ -233,8 +231,8 @@ describes.realWin(
       });
 
       it('should schedule on custom element with multiple children', () => {
-        const stub1 = sandbox.stub(children[1], 'unlayoutCallback');
-        const stub2 = sandbox.stub(children[2], 'unlayoutCallback');
+        const stub1 = env.sandbox.stub(children[1], 'unlayoutCallback');
+        const stub2 = env.sandbox.stub(children[2], 'unlayoutCallback');
         owners.scheduleUnlayout(parent, children);
         expect(stub1.called).to.be.true;
         expect(stub2.called).to.be.true;
@@ -310,8 +308,8 @@ describes.realWin(
           if (!resource) {
             return;
           }
-          sandbox.stub(resource, 'whenBuilt').returns(Promise.resolve());
-          sandbox.stub(resource, 'loadedOnce').returns(Promise.resolve());
+          env.sandbox.stub(resource, 'whenBuilt').returns(Promise.resolve());
+          env.sandbox.stub(resource, 'loadedOnce').returns(Promise.resolve());
         });
       });
 

--- a/test/unit/test-pass.js
+++ b/test/unit/test-pass.js
@@ -18,14 +18,12 @@ import {Pass} from '../../src/pass';
 import {Services} from '../../src/services';
 
 describe('Pass', () => {
-  let sandbox;
   let pass;
   let timerMock;
   let handlerCalled;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox;
-    timerMock = sandbox.mock(Services.timerFor(window));
+    timerMock = window.sandbox.mock(Services.timerFor(window));
     handlerCalled = 0;
     pass = new Pass(window, () => {
       handlerCalled++;
@@ -35,7 +33,6 @@ describe('Pass', () => {
   afterEach(() => {
     expect(handlerCalled).to.equal(0);
     timerMock.verify();
-    sandbox.restore();
   });
 
   it('handler called', () => {
@@ -43,7 +40,7 @@ describe('Pass', () => {
     timerMock
       .expects('delay')
       .withExactArgs(
-        sinon.match(value => {
+        window.sandbox.match(value => {
           delayedFunc = value;
           return true;
         }),
@@ -65,7 +62,7 @@ describe('Pass', () => {
   it('schedule no delay', () => {
     timerMock
       .expects('delay')
-      .withExactArgs(sinon.match.func, 0)
+      .withExactArgs(window.sandbox.match.func, 0)
       .returns(1)
       .once();
     timerMock.expects('cancel').never();
@@ -75,7 +72,7 @@ describe('Pass', () => {
   it('schedule with delay', () => {
     timerMock
       .expects('delay')
-      .withExactArgs(sinon.match.func, 111)
+      .withExactArgs(window.sandbox.match.func, 111)
       .returns(1)
       .once();
     timerMock.expects('cancel').never();
@@ -85,7 +82,7 @@ describe('Pass', () => {
   it('schedule later', () => {
     timerMock
       .expects('delay')
-      .withExactArgs(sinon.match.func, 111)
+      .withExactArgs(window.sandbox.match.func, 111)
       .returns(1)
       .once();
     timerMock.expects('cancel').never();
@@ -98,12 +95,12 @@ describe('Pass', () => {
   it('schedule earlier', () => {
     timerMock
       .expects('delay')
-      .withExactArgs(sinon.match.func, 222)
+      .withExactArgs(window.sandbox.match.func, 222)
       .returns(1)
       .once();
     timerMock
       .expects('delay')
-      .withExactArgs(sinon.match.func, 111)
+      .withExactArgs(window.sandbox.match.func, 111)
       .returns(2)
       .once();
     timerMock
@@ -128,7 +125,7 @@ describe('Pass', () => {
     timerMock
       .expects('delay')
       .withExactArgs(
-        sinon.match(value => {
+        window.sandbox.match(value => {
           delayedFunc0 = value;
           return true;
         }),
@@ -139,7 +136,7 @@ describe('Pass', () => {
     timerMock
       .expects('delay')
       .withExactArgs(
-        sinon.match(value => {
+        window.sandbox.match(value => {
           delayedFunc1 = value;
           return true;
         }),

--- a/test/unit/test-performance.js
+++ b/test/unit/test-performance.js
@@ -23,7 +23,6 @@ import {installPerformanceService} from '../../src/service/performance-impl';
 import {installRuntimeServices} from '../../src/service/core-services';
 
 describes.realWin('performance', {amp: true}, env => {
-  let sandbox;
   let perf;
   let clock;
   let win;
@@ -31,7 +30,6 @@ describes.realWin('performance', {amp: true}, env => {
 
   beforeEach(() => {
     win = env.win;
-    sandbox = env.sandbox;
     ampdoc = env.ampdoc;
     clock = lolex.install({
       target: win,
@@ -158,7 +156,7 @@ describes.realWin('performance', {amp: true}, env => {
 
       beforeEach(() => {
         viewer = Services.viewerForDoc(ampdoc);
-        viewerSendMessageStub = sandbox.stub(viewer, 'sendMessage');
+        viewerSendMessageStub = env.sandbox.stub(viewer, 'sendMessage');
       });
 
       describe('config', () => {
@@ -166,11 +164,11 @@ describes.realWin('performance', {amp: true}, env => {
           'should configure correctly when viewer is embedded and supports ' +
             'csi',
           () => {
-            sandbox
+            env.sandbox
               .stub(viewer, 'getParam')
               .withArgs('csi')
               .returns('1');
-            sandbox.stub(viewer, 'isEmbedded').returns(true);
+            env.sandbox.stub(viewer, 'isEmbedded').returns(true);
             perf.coreServicesAvailable().then(() => {
               expect(perf.isPerformanceTrackingOn()).to.be.true;
             });
@@ -181,11 +179,11 @@ describes.realWin('performance', {amp: true}, env => {
           'should configure correctly when viewer is embedded and does ' +
             'NOT support csi',
           () => {
-            sandbox
+            env.sandbox
               .stub(viewer, 'getParam')
               .withArgs('csi')
               .returns('0');
-            sandbox.stub(viewer, 'isEmbedded').returns(true);
+            env.sandbox.stub(viewer, 'isEmbedded').returns(true);
             perf.coreServicesAvailable().then(() => {
               expect(perf.isPerformanceTrackingOn()).to.be.false;
             });
@@ -196,11 +194,11 @@ describes.realWin('performance', {amp: true}, env => {
           'should configure correctly when viewer is embedded and does ' +
             'NOT support csi',
           () => {
-            sandbox
+            env.sandbox
               .stub(viewer, 'getParam')
               .withArgs('csi')
               .returns(null);
-            sandbox.stub(viewer, 'isEmbedded').returns(true);
+            env.sandbox.stub(viewer, 'isEmbedded').returns(true);
             perf.coreServicesAvailable().then(() => {
               expect(perf.isPerformanceTrackingOn()).to.be.false;
             });
@@ -208,11 +206,11 @@ describes.realWin('performance', {amp: true}, env => {
         );
 
         it('should configure correctly when viewer is not embedded', () => {
-          sandbox
+          env.sandbox
             .stub(viewer, 'getParam')
             .withArgs('csi')
             .returns(null);
-          sandbox.stub(viewer, 'isEmbedded').returns(false);
+          env.sandbox.stub(viewer, 'isEmbedded').returns(false);
           perf.coreServicesAvailable().then(() => {
             expect(perf.isPerformanceTrackingOn()).to.be.false;
           });
@@ -221,11 +219,13 @@ describes.realWin('performance', {amp: true}, env => {
 
       describe('channel established', () => {
         it('should flush events when channel is ready', () => {
-          sandbox
+          env.sandbox
             .stub(viewer, 'getParam')
             .withArgs('csi')
             .returns(null);
-          sandbox.stub(viewer, 'whenMessagingReady').returns(Promise.resolve());
+          env.sandbox
+            .stub(viewer, 'whenMessagingReady')
+            .returns(Promise.resolve());
           expect(perf.isMessagingReady_).to.be.false;
           const promise = perf.coreServicesAvailable();
           expect(perf.events_.length).to.equal(0);
@@ -237,7 +237,7 @@ describes.realWin('performance', {amp: true}, env => {
           expect(perf.events_.length).to.equal(2);
           expect(perf.isMessagingReady_).to.be.false;
 
-          const flushSpy = sandbox.spy(perf, 'flush');
+          const flushSpy = env.sandbox.spy(perf, 'flush');
           expect(flushSpy).to.have.callCount(0);
           perf.flush();
           expect(flushSpy).to.have.callCount(1);
@@ -249,7 +249,7 @@ describes.realWin('performance', {amp: true}, env => {
             expect(perf.isMessagingReady_).to.be.true;
             const msrCalls = viewerSendMessageStub.withArgs(
               'tick',
-              sinon.match(arg => arg.label == 'msr')
+              env.sandbox.match(arg => arg.label == 'msr')
             );
             expect(msrCalls).to.be.calledOnce;
             expect(msrCalls.args[0][1]).to.be.jsonEqual({
@@ -264,7 +264,7 @@ describes.realWin('performance', {amp: true}, env => {
 
       describe('channel not established', () => {
         it('should not flush anything', () => {
-          sandbox.stub(viewer, 'whenMessagingReady').returns(null);
+          env.sandbox.stub(viewer, 'whenMessagingReady').returns(null);
           expect(perf.isMessagingReady_).to.be.false;
 
           expect(perf.events_.length).to.equal(0);
@@ -276,7 +276,7 @@ describes.realWin('performance', {amp: true}, env => {
           expect(perf.events_.length).to.equal(2);
           expect(perf.isMessagingReady_).to.be.false;
 
-          const flushSpy = sandbox.spy(perf, 'flush');
+          const flushSpy = env.sandbox.spy(perf, 'flush');
           expect(flushSpy).to.have.callCount(0);
           perf.flush();
           expect(flushSpy).to.have.callCount(1);
@@ -299,9 +299,9 @@ describes.realWin('performance', {amp: true}, env => {
         let firstVisibleTime;
 
         beforeEach(() => {
-          tickDeltaStub = sandbox.stub(perf, 'tickDelta');
+          tickDeltaStub = env.sandbox.stub(perf, 'tickDelta');
           firstVisibleTime = null;
-          sandbox
+          env.sandbox
             .stub(ampdoc, 'getFirstVisibleTime')
             .callsFake(() => firstVisibleTime);
         });
@@ -350,11 +350,11 @@ describes.realWin('performance', {amp: true}, env => {
 
       describe('and performanceTracking is off', () => {
         beforeEach(() => {
-          sandbox
+          env.sandbox
             .stub(viewer, 'getParam')
             .withArgs('csi')
             .returns(null);
-          sandbox.stub(viewer, 'isEmbedded').returns(false);
+          env.sandbox.stub(viewer, 'isEmbedded').returns(false);
         });
 
         it('should not forward queued ticks', () => {
@@ -404,12 +404,14 @@ describes.realWin('performance', {amp: true}, env => {
 
       describe('and performanceTracking is on', () => {
         beforeEach(() => {
-          sandbox
+          env.sandbox
             .stub(viewer, 'getParam')
             .withArgs('csi')
             .returns('1');
-          sandbox.stub(viewer, 'isEmbedded').returns(true);
-          sandbox.stub(viewer, 'whenMessagingReady').returns(Promise.resolve());
+          env.sandbox.stub(viewer, 'isEmbedded').returns(true);
+          env.sandbox
+            .stub(viewer, 'whenMessagingReady')
+            .returns(Promise.resolve());
         });
 
         it('should forward all queued tick events', () => {
@@ -461,7 +463,7 @@ describes.realWin('performance', {amp: true}, env => {
             expect(
               viewerSendMessageStub.withArgs(
                 'tick',
-                sinon.match(arg => arg.label == 'start0')
+                env.sandbox.match(arg => arg.label == 'start0')
               ).args[0][1]
             ).to.be.jsonEqual({
               label: 'start0',
@@ -470,7 +472,7 @@ describes.realWin('performance', {amp: true}, env => {
             expect(
               viewerSendMessageStub.withArgs(
                 'tick',
-                sinon.match(arg => arg.label == 'start1')
+                env.sandbox.match(arg => arg.label == 'start1')
               ).args[0][1]
             ).to.be.jsonEqual({
               label: 'start1',
@@ -482,7 +484,9 @@ describes.realWin('performance', {amp: true}, env => {
         it('should call the flush callback', () => {
           // Make sure "first visible" arrives after "channel ready".
           const firstVisiblePromise = new Promise(() => {});
-          sandbox.stub(ampdoc, 'whenFirstVisible').returns(firstVisiblePromise);
+          env.sandbox
+            .stub(ampdoc, 'whenFirstVisible')
+            .returns(firstVisiblePromise);
           expect(viewerSendMessageStub.withArgs('sendCsi')).to.have.callCount(
             0
           );
@@ -521,8 +525,8 @@ describes.realWin('performance', {amp: true}, env => {
 
   it('should wait for visible resources', () => {
     const resources = Services.resourcesForDoc(ampdoc);
-    sandbox.stub(resources, 'whenFirstPass').returns(Promise.resolve());
-    const whenContentIniLoadStub = sandbox
+    env.sandbox.stub(resources, 'whenFirstPass').returns(Promise.resolve());
+    const whenContentIniLoadStub = env.sandbox
       .stub(IniLoad, 'whenContentIniLoad')
       .returns(Promise.resolve());
     perf.resources_ = resources;
@@ -531,7 +535,7 @@ describes.realWin('performance', {amp: true}, env => {
       expect(whenContentIniLoadStub).to.be.calledWith(
         perf.win.document.documentElement,
         perf.win,
-        sinon.match(
+        env.sandbox.match(
           arg =>
             arg.left == 0 &&
             arg.top == 0 &&
@@ -553,7 +557,7 @@ describes.realWin('performance', {amp: true}, env => {
     let whenViewportLayoutCompleteResolve;
 
     function stubHasBeenVisible(visibility) {
-      sandbox.stub(ampdoc, 'hasBeenVisible').returns(visibility);
+      env.sandbox.stub(ampdoc, 'hasBeenVisible').returns(visibility);
     }
 
     function getPerformanceMarks() {
@@ -562,10 +566,10 @@ describes.realWin('performance', {amp: true}, env => {
 
     beforeEach(() => {
       viewer = Services.viewerForDoc(ampdoc);
-      sandbox.stub(viewer, 'whenMessagingReady').returns(Promise.resolve());
-      viewerSendMessageStub = sandbox.stub(viewer, 'sendMessage');
+      env.sandbox.stub(viewer, 'whenMessagingReady').returns(Promise.resolve());
+      viewerSendMessageStub = env.sandbox.stub(viewer, 'sendMessage');
 
-      tickSpy = sandbox.spy(perf, 'tick');
+      tickSpy = env.sandbox.spy(perf, 'tick');
 
       whenFirstVisiblePromise = new Promise(resolve => {
         whenFirstVisibleResolve = resolve;
@@ -575,8 +579,10 @@ describes.realWin('performance', {amp: true}, env => {
         whenViewportLayoutCompleteResolve = resolve;
       });
 
-      sandbox.stub(ampdoc, 'whenFirstVisible').returns(whenFirstVisiblePromise);
-      sandbox
+      env.sandbox
+        .stub(ampdoc, 'whenFirstVisible')
+        .returns(whenFirstVisiblePromise);
+      env.sandbox
         .stub(perf, 'whenViewportLayoutComplete_')
         .returns(whenViewportLayoutCompletePromise);
       return viewer.whenMessagingReady();
@@ -592,11 +598,11 @@ describes.realWin('performance', {amp: true}, env => {
       it('should call prerenderComplete on viewer', () => {
         clock.tick(100);
         whenFirstVisibleResolve();
-        sandbox
+        env.sandbox
           .stub(viewer, 'getParam')
           .withArgs('csi')
           .returns('1');
-        sandbox.stub(viewer, 'isEmbedded').returns(true);
+        env.sandbox.stub(viewer, 'isEmbedded').returns(true);
         return ampdoc.whenFirstVisible().then(() => {
           clock.tick(400);
           whenViewportLayoutCompleteResolve();
@@ -620,7 +626,7 @@ describes.realWin('performance', {amp: true}, env => {
       it('should call prerenderComplete on viewer even if csi is off', () => {
         clock.tick(100);
         whenFirstVisibleResolve();
-        sandbox
+        env.sandbox
           .stub(viewer, 'getParam')
           .withArgs('csi')
           .returns(null);
@@ -693,11 +699,11 @@ describes.realWin('performance', {amp: true}, env => {
       });
 
       it('should call prerenderComplete on viewer', () => {
-        sandbox
+        env.sandbox
           .stub(viewer, 'getParam')
           .withArgs('csi')
           .returns('1');
-        sandbox.stub(viewer, 'isEmbedded').returns(true);
+        env.sandbox.stub(viewer, 'isEmbedded').returns(true);
         clock.tick(300);
         whenViewportLayoutCompleteResolve();
         return perf.whenViewportLayoutComplete_().then(() => {
@@ -731,19 +737,17 @@ describes.realWin('performance with experiment', {amp: true}, env => {
   let win;
   let perf;
   let viewerSendMessageStub;
-  let sandbox;
 
   beforeEach(() => {
     win = env.win;
-    sandbox = env.sandbox;
     const viewer = Services.viewerForDoc(env.ampdoc);
-    viewerSendMessageStub = sandbox.stub(viewer, 'sendMessage');
-    sandbox.stub(viewer, 'whenMessagingReady').returns(Promise.resolve());
-    sandbox
+    viewerSendMessageStub = env.sandbox.stub(viewer, 'sendMessage');
+    env.sandbox.stub(viewer, 'whenMessagingReady').returns(Promise.resolve());
+    env.sandbox
       .stub(viewer, 'getParam')
       .withArgs('csi')
       .returns('1');
-    sandbox.stub(viewer, 'isEmbedded').returns(true);
+    env.sandbox.stub(viewer, 'isEmbedded').returns(true);
     installPerformanceService(win);
     perf = Services.performanceFor(win);
   });
@@ -768,7 +772,7 @@ describes.realWin('performance with experiment', {amp: true}, env => {
       perf.flush();
       expect(viewerSendMessageStub).to.be.calledWith(
         'sendCsi',
-        sandbox.match(payload => {
+        env.sandbox.match(payload => {
           const experiments = payload.ampexp.split(',');
           expect(experiments).to.have.length(3);
           expect(experiments).to.have.members([
@@ -1109,21 +1113,21 @@ describes.realWin('PeformanceObserver metrics', {amp: true}, env => {
 
       const unresolvedPromise = new Promise(() => {});
       const viewportSize = {width: 0, height: 0};
-      sandbox.stub(Services, 'ampdoc').returns({
+      env.sandbox.stub(Services, 'ampdoc').returns({
         hasBeenVisible: () => {},
         onVisibilityChanged: () => {},
         whenFirstVisible: () => unresolvedPromise,
         getVisibilityState: () => viewerVisibilityState,
       });
-      sandbox.stub(Services, 'viewerForDoc').returns({
+      env.sandbox.stub(Services, 'viewerForDoc').returns({
         isEmbedded: () => {},
         whenMessagingReady: () => {},
       });
-      sandbox.stub(Services, 'resourcesForDoc').returns({
+      env.sandbox.stub(Services, 'resourcesForDoc').returns({
         getResourcesInRect: () => unresolvedPromise,
         whenFirstPass: () => Promise.resolve(),
       });
-      sandbox.stub(Services, 'viewportForDoc').returns({
+      env.sandbox.stub(Services, 'viewportForDoc').returns({
         getSize: () => viewportSize,
       });
     });
@@ -1146,9 +1150,13 @@ describes.realWin('PeformanceObserver metrics', {amp: true}, env => {
     it('for browsers that support the visibilitychange event', () => {
       // Specify an Android Chrome user agent, which supports the
       // visibilitychange event.
-      sandbox.stub(Services.platformFor(fakeWin), 'isAndroid').returns(true);
-      sandbox.stub(Services.platformFor(fakeWin), 'isChrome').returns(true);
-      sandbox.stub(Services.platformFor(fakeWin), 'isSafari').returns(false);
+      env.sandbox
+        .stub(Services.platformFor(fakeWin), 'isAndroid')
+        .returns(true);
+      env.sandbox.stub(Services.platformFor(fakeWin), 'isChrome').returns(true);
+      env.sandbox
+        .stub(Services.platformFor(fakeWin), 'isSafari')
+        .returns(false);
 
       // Document should be initially visible.
       expect(fakeWin.document.visibilityState).to.equal('visible');
@@ -1200,9 +1208,13 @@ describes.realWin('PeformanceObserver metrics', {amp: true}, env => {
 
     it('forwards layout jank metric on viewer visibility change to inactive', () => {
       // Specify an Android Chrome user agent.
-      sandbox.stub(Services.platformFor(fakeWin), 'isAndroid').returns(true);
-      sandbox.stub(Services.platformFor(fakeWin), 'isChrome').returns(true);
-      sandbox.stub(Services.platformFor(fakeWin), 'isSafari').returns(false);
+      env.sandbox
+        .stub(Services.platformFor(fakeWin), 'isAndroid')
+        .returns(true);
+      env.sandbox.stub(Services.platformFor(fakeWin), 'isChrome').returns(true);
+      env.sandbox
+        .stub(Services.platformFor(fakeWin), 'isSafari')
+        .returns(false);
 
       // Fake layoutJank that occured before the Performance service is started.
       fakeWin.performance.getEntriesByType.withArgs('layoutJank').returns([
@@ -1272,21 +1284,21 @@ describes.realWin('PeformanceObserver metrics', {amp: true}, env => {
 
       const unresolvedPromise = new Promise(() => {});
       const viewportSize = {width: 0, height: 0};
-      sandbox.stub(Services, 'ampdoc').returns({
+      env.sandbox.stub(Services, 'ampdoc').returns({
         hasBeenVisible: () => {},
         onVisibilityChanged: () => {},
         whenFirstVisible: () => unresolvedPromise,
         getVisibilityState: () => viewerVisibilityState,
       });
-      sandbox.stub(Services, 'viewerForDoc').returns({
+      env.sandbox.stub(Services, 'viewerForDoc').returns({
         isEmbedded: () => {},
         whenMessagingReady: () => {},
       });
-      sandbox.stub(Services, 'resourcesForDoc').returns({
+      env.sandbox.stub(Services, 'resourcesForDoc').returns({
         getResourcesInRect: () => unresolvedPromise,
         whenFirstPass: () => Promise.resolve(),
       });
-      sandbox.stub(Services, 'viewportForDoc').returns({
+      env.sandbox.stub(Services, 'viewportForDoc').returns({
         getSize: () => viewportSize,
       });
     });
@@ -1309,9 +1321,13 @@ describes.realWin('PeformanceObserver metrics', {amp: true}, env => {
     it('for Chrome 76', () => {
       // Specify an Android Chrome user agent, which supports the
       // visibilitychange event.
-      sandbox.stub(Services.platformFor(fakeWin), 'isAndroid').returns(true);
-      sandbox.stub(Services.platformFor(fakeWin), 'isChrome').returns(true);
-      sandbox.stub(Services.platformFor(fakeWin), 'isSafari').returns(false);
+      env.sandbox
+        .stub(Services.platformFor(fakeWin), 'isAndroid')
+        .returns(true);
+      env.sandbox.stub(Services.platformFor(fakeWin), 'isChrome').returns(true);
+      env.sandbox
+        .stub(Services.platformFor(fakeWin), 'isSafari')
+        .returns(false);
 
       // Fake the Performance API.
       fakeWin.PerformanceObserver.supportedEntryTypes = ['layoutShift'];
@@ -1370,9 +1386,13 @@ describes.realWin('PeformanceObserver metrics', {amp: true}, env => {
     it('for Chrome 77', () => {
       // Specify an Android Chrome user agent, which supports the
       // visibilitychange event.
-      sandbox.stub(Services.platformFor(fakeWin), 'isAndroid').returns(true);
-      sandbox.stub(Services.platformFor(fakeWin), 'isChrome').returns(true);
-      sandbox.stub(Services.platformFor(fakeWin), 'isSafari').returns(false);
+      env.sandbox
+        .stub(Services.platformFor(fakeWin), 'isAndroid')
+        .returns(true);
+      env.sandbox.stub(Services.platformFor(fakeWin), 'isChrome').returns(true);
+      env.sandbox
+        .stub(Services.platformFor(fakeWin), 'isSafari')
+        .returns(false);
 
       // Fake the Performance API.
       fakeWin.PerformanceObserver.supportedEntryTypes = ['layout-shift'];
@@ -1443,9 +1463,13 @@ describes.realWin('PeformanceObserver metrics', {amp: true}, env => {
 
     it('when the viewer visibility changes to inactive', () => {
       // Specify an Android Chrome user agent.
-      sandbox.stub(Services.platformFor(fakeWin), 'isAndroid').returns(true);
-      sandbox.stub(Services.platformFor(fakeWin), 'isChrome').returns(true);
-      sandbox.stub(Services.platformFor(fakeWin), 'isSafari').returns(false);
+      env.sandbox
+        .stub(Services.platformFor(fakeWin), 'isAndroid')
+        .returns(true);
+      env.sandbox.stub(Services.platformFor(fakeWin), 'isChrome').returns(true);
+      env.sandbox
+        .stub(Services.platformFor(fakeWin), 'isSafari')
+        .returns(false);
 
       // Fake the Performance API.
       fakeWin.PerformanceObserver.supportedEntryTypes = ['layout-shift'];

--- a/test/unit/test-platform.js
+++ b/test/unit/test-platform.js
@@ -71,7 +71,7 @@ describe('Platform', () => {
         standalone: standAloneBoolean,
         userAgent: userAgentString,
       },
-      matchMedia: sandbox.stub().returns({matches: true}),
+      matchMedia: window.sandbox.stub().returns({matches: true}),
     });
     expect(platform.isStandalone()).to.equal(isStandalone);
   }

--- a/test/unit/test-polyfill-document-contains.js
+++ b/test/unit/test-polyfill-document-contains.js
@@ -17,7 +17,6 @@
 import {install} from '../../src/polyfills/document-contains';
 
 describe('HTMLDocument.contains', () => {
-  let sandbox;
   let fakeWinWithContains;
   let fakeWinWithoutContains;
   let nativeContains;
@@ -28,8 +27,6 @@ describe('HTMLDocument.contains', () => {
   let disconnectedChild;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox;
-
     fakeWinWithContains = {
       HTMLDocument: class {
         contains() {}
@@ -59,7 +56,6 @@ describe('HTMLDocument.contains', () => {
     if (connectedElement.parentNode) {
       connectedElement.parentNode.removeChild(connectedElement);
     }
-    sandbox.restore();
   });
 
   it('should NOT override an existing method', () => {

--- a/test/unit/test-polyfill-domtokenlist-toggle.js
+++ b/test/unit/test-polyfill-domtokenlist-toggle.js
@@ -27,7 +27,6 @@ describes.fakeWin(
     },
   },
   env => {
-    let sandbox;
     let originalToggle;
     let originalAdd;
     let element;
@@ -35,7 +34,6 @@ describes.fakeWin(
     beforeEach(() => {
       originalToggle = env.win.DOMTokenList.prototype.toggle;
       originalAdd = env.win.DOMTokenList.prototype.add;
-      sandbox = sinon.sandbox;
 
       element = env.win.document.createElement('div');
       env.win.document.body.appendChild(element);
@@ -47,7 +45,6 @@ describes.fakeWin(
       if (element.parentNode) {
         element.parentNode.removeChild(element);
       }
-      sandbox.restore();
     });
 
     it('should NOT override toggle in non-IE browsers', () => {
@@ -76,7 +73,6 @@ describes.fakeWin(
     },
   },
   env => {
-    let sandbox;
     let originalToggle;
     let originalAdd;
     let element;
@@ -84,7 +80,6 @@ describes.fakeWin(
     beforeEach(() => {
       originalToggle = env.win.DOMTokenList.prototype.toggle;
       originalAdd = env.win.DOMTokenList.prototype.add;
-      sandbox = sinon.sandbox;
 
       element = env.win.document.createElement('div');
       env.win.document.body.appendChild(element);
@@ -96,7 +91,6 @@ describes.fakeWin(
       if (element.parentNode) {
         element.parentNode.removeChild(element);
       }
-      sandbox.restore();
     });
 
     it('should polyfill DOMTokenList.toggle API', () => {

--- a/test/unit/test-position-observer.js
+++ b/test/unit/test-position-observer.js
@@ -38,7 +38,7 @@ describes.realWin('PositionObserver', {amp: 1}, env => {
     beforeEach(() => {
       clock = lolex.install({target: ampdoc.win});
       posOb = new PositionObserver(ampdoc);
-      sandbox.stub(posOb.vsync_, 'measure').callsFake(callback => {
+      env.sandbox.stub(posOb.vsync_, 'measure').callsFake(callback => {
         win.setTimeout(callback, 1);
       });
       elem = win.document.createElement('div');
@@ -65,7 +65,7 @@ describes.realWin('PositionObserver', {amp: 1}, env => {
 
     describe('API functions includes observe/unobserve/changeFidelity', () => {
       it('should observe identical element and start', () => {
-        const spy = sandbox.spy(posOb, 'startCallback_');
+        const spy = env.sandbox.spy(posOb, 'startCallback_');
         posOb.observe(elem, PositionObserverFidelity.LOW, () => {});
         posOb.observe(elem1, PositionObserverFidelity.LOW, () => {});
         expect(posOb.workers_).to.have.length(2);
@@ -73,7 +73,7 @@ describes.realWin('PositionObserver', {amp: 1}, env => {
       });
 
       it('should unobserve and stop', () => {
-        const spy = sandbox.spy(posOb, 'stopCallback_');
+        const spy = env.sandbox.spy(posOb, 'stopCallback_');
         posOb.observe(elem, PositionObserverFidelity.LOW, () => {});
         posOb.observe(elem1, PositionObserverFidelity.LOW, () => {});
         posOb.unobserve(elem);
@@ -88,12 +88,14 @@ describes.realWin('PositionObserver', {amp: 1}, env => {
       let top;
       beforeEach(() => {
         top = 0;
-        sandbox.stub(posOb.viewport_, 'getClientRectAsync').callsFake(() => {
-          return Promise.resolve(layoutRectLtwh(0, top, 0, 0));
-        });
+        env.sandbox
+          .stub(posOb.viewport_, 'getClientRectAsync')
+          .callsFake(() => {
+            return Promise.resolve(layoutRectLtwh(0, top, 0, 0));
+          });
       });
       it('should update new position with scroll event', function*() {
-        const spy = sandbox.spy();
+        const spy = env.sandbox.spy();
         posOb.observe(elem, PositionObserverFidelity.HIGH, spy);
         clock.tick(2);
         yield macroTask();
@@ -119,7 +121,7 @@ describes.realWin('PositionObserver', {amp: 1}, env => {
       });
 
       it('should not update if element position does not change', function*() {
-        const spy = sandbox.spy();
+        const spy = env.sandbox.spy();
         posOb.observe(elem, PositionObserverFidelity.HIGH, spy);
         yield macroTask();
         expect(spy).to.be.calledOnce;
@@ -133,15 +135,17 @@ describes.realWin('PositionObserver', {amp: 1}, env => {
       let top;
       beforeEach(() => {
         top = 0;
-        sandbox.stub(posOb.viewport_, 'getClientRectAsync').callsFake(() => {
-          return Promise.resolve(layoutRectLtwh(2, top, 20, 10));
-        });
+        env.sandbox
+          .stub(posOb.viewport_, 'getClientRectAsync')
+          .callsFake(() => {
+            return Promise.resolve(layoutRectLtwh(2, top, 20, 10));
+          });
       });
 
       it('overlap with viewport', function*() {
         const viewport = Services.viewportForDoc(ampdoc);
         const sizes = viewport.getSize();
-        const spy = sandbox.spy();
+        const spy = env.sandbox.spy();
         top = 1;
         posOb.observe(elem, PositionObserverFidelity.HIGH, spy);
         yield macroTask();
@@ -180,7 +184,7 @@ describes.realWin('PositionObserver', {amp: 1}, env => {
         });
         const viewport = Services.viewportForDoc(ampdoc);
         const sizes = viewport.getSize();
-        const spy = sandbox.spy();
+        const spy = env.sandbox.spy();
         posOb.observe(elem, PositionObserverFidelity.HIGH, spy);
         yield macroTask();
         spy.resetHistory();

--- a/test/unit/test-preconnect.js
+++ b/test/unit/test-preconnect.js
@@ -24,7 +24,6 @@ import {
 } from '../../src/preconnect';
 
 describe('preconnect', () => {
-  let sandbox;
   let iframeClock;
   let clock;
   let preconnect;
@@ -57,7 +56,7 @@ describe('preconnect', () => {
       const element = document.createElement('div');
       iframe.win.document.body.appendChild(element);
       preconnect = preconnectForElement(element);
-      sandbox.stub(preconnect, 'getAmpdoc_').returns({
+      window.sandbox.stub(preconnect, 'getAmpdoc_').returns({
         whenFirstVisible: () => visiblePromise,
       });
       return iframe;
@@ -71,20 +70,18 @@ describe('preconnect', () => {
     // to test for preload/preconnect support.
     preloadSupported = false;
     preconnectSupported = false;
-    sandbox = sinon.sandbox;
-    clock = sandbox.useFakeTimers();
+    clock = window.sandbox.useFakeTimers();
   });
 
   afterEach(() => {
     clock.tick(200000);
-    sandbox.restore();
     setPreconnectFeaturesForTesting(null);
   });
 
   it('should preconnect', () => {
     isSafari = false;
     return getPreconnectIframe().then(iframe => {
-      const open = sandbox.spy(XMLHttpRequest.prototype, 'open');
+      const open = window.sandbox.spy(XMLHttpRequest.prototype, 'open');
       preconnect.url('https://a.preconnect.com/foo/bar');
       preconnect.url('https://a.preconnect.com/other');
       preconnect.url(javascriptUrlPrefix + ':alert()');
@@ -120,7 +117,7 @@ describe('preconnect', () => {
   it('should preconnect to origins', async function() {
     isSafari = false;
     const iframe = await getPreconnectIframe();
-    sandbox.stub(Services, 'documentInfoForDoc').returns({
+    window.sandbox.stub(Services, 'documentInfoForDoc').returns({
       sourceUrl: 'https://sourceurl.com/',
       canonicalUrl: 'https://canonicalurl.com/',
     });
@@ -136,7 +133,7 @@ describe('preconnect', () => {
     isSafari = false;
     preconnectSupported = true;
     return getPreconnectIframe().then(iframe => {
-      const open = sandbox.spy(XMLHttpRequest.prototype, 'open');
+      const open = window.sandbox.spy(XMLHttpRequest.prototype, 'open');
       preconnect.url('https://a.preconnect.com/foo/bar');
       preconnect.url('https://a.preconnect.com/other');
       preconnect.url(javascriptUrlPrefix + ':alert()');
@@ -170,8 +167,8 @@ describe('preconnect', () => {
     isSafari = true;
     return getPreconnectIframe().then(iframe => {
       clock.tick(1485531293690);
-      const open = sandbox.spy(XMLHttpRequest.prototype, 'open');
-      const send = sandbox.spy(XMLHttpRequest.prototype, 'send');
+      const open = window.sandbox.spy(XMLHttpRequest.prototype, 'open');
+      const send = window.sandbox.spy(XMLHttpRequest.prototype, 'send');
       preconnect.url('https://s.preconnect.com/foo/bar');
       preconnect.url('https://s.preconnect.com/other');
       preconnect.url(javascriptUrlPrefix + ':alert()');

--- a/test/unit/test-pull-to-refresh.js
+++ b/test/unit/test-pull-to-refresh.js
@@ -17,14 +17,11 @@
 import {PullToRefreshBlocker} from '../../src/pull-to-refresh';
 
 describe('PullToRefreshBlocker', () => {
-  let sandbox;
   let eventListeners;
   let viewportMock;
   let blocker;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox;
-
     eventListeners = {};
     const documentApi = {
       addEventListener: (eventType, handler) => {
@@ -40,7 +37,7 @@ describe('PullToRefreshBlocker', () => {
     const viewportApi = {
       getScrollTop: () => 0,
     };
-    viewportMock = sandbox.mock(viewportApi);
+    viewportMock = window.sandbox.mock(viewportApi);
 
     blocker = new PullToRefreshBlocker(documentApi, viewportApi);
   });
@@ -48,7 +45,6 @@ describe('PullToRefreshBlocker', () => {
   afterEach(() => {
     viewportMock.verify();
     blocker.cleanup();
-    sandbox.restore();
   });
 
   function sendEvent(event, opt_prevetDefault) {
@@ -127,7 +123,7 @@ describe('PullToRefreshBlocker', () => {
     sendEvent({type: 'touchstart', touches: [{clientY: 111}]});
     expect(blocker.tracking_).to.equal(true);
 
-    const preventDefault = sandbox.spy();
+    const preventDefault = window.sandbox.spy();
     sendEvent({type: 'touchmove', touches: [{clientY: 112}]}, preventDefault);
     expect(blocker.tracking_).to.equal(false);
     expect(preventDefault).to.be.calledOnce;
@@ -142,7 +138,7 @@ describe('PullToRefreshBlocker', () => {
     sendEvent({type: 'touchstart', touches: [{clientY: 111}]});
     expect(blocker.tracking_).to.equal(true);
 
-    const preventDefault = sandbox.spy();
+    const preventDefault = window.sandbox.spy();
     sendEvent({type: 'touchmove', touches: [{clientY: 100}]}, preventDefault);
     expect(blocker.tracking_).to.equal(false);
     expect(preventDefault).to.have.not.been.called;
@@ -157,7 +153,7 @@ describe('PullToRefreshBlocker', () => {
     sendEvent({type: 'touchstart', touches: [{clientY: 111}]});
     expect(blocker.tracking_).to.equal(true);
 
-    const preventDefault = sandbox.spy();
+    const preventDefault = window.sandbox.spy();
     sendEvent({type: 'touchmove', touches: [{clientY: 111}]}, preventDefault);
     expect(blocker.tracking_).to.equal(true);
     expect(preventDefault).to.have.not.been.called;

--- a/test/unit/test-render-delaying-services.js
+++ b/test/unit/test-render-delaying-services.js
@@ -25,7 +25,6 @@ import {macroTask} from '../../testing/yield';
 
 describe('waitForServices', () => {
   let win;
-  let sandbox;
   let clock;
   let dynamicCssResolve;
   let experimentResolve;
@@ -34,8 +33,7 @@ describe('waitForServices', () => {
   let variantStub;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox;
-    const getService = sandbox.stub(service, 'getServicePromise');
+    const getService = window.sandbox.stub(service, 'getServicePromise');
     dynamicCssResolve = waitForService(getService, 'amp-dynamic-css-classes');
     experimentResolve = waitForService(getService, 'amp-experiment');
 
@@ -45,7 +43,7 @@ describe('waitForServices', () => {
       },
     };
     variantResolve = waitForService(getService, 'variant', variantService);
-    variantStub = sandbox
+    variantStub = window.sandbox
       .stub(variantService, 'whenReady')
       .returns(Promise.resolve());
 
@@ -57,7 +55,6 @@ describe('waitForServices', () => {
 
   afterEach(() => {
     clock.uninstall();
-    sandbox.restore();
   });
 
   it('should resolve if no blocking services is presented', () => {
@@ -128,7 +125,7 @@ describe('waitForServices', () => {
 
 function waitForService(getService, serviceId, service) {
   let resolve = null;
-  getService.withArgs(sinon.match.any, serviceId).returns(
+  getService.withArgs(window.sandbox.match.any, serviceId).returns(
     new Promise(r => {
       resolve = r.bind(this, service);
     })

--- a/test/unit/test-resource.js
+++ b/test/unit/test-resource.js
@@ -28,30 +28,28 @@ describes.realWin('Resource', {amp: true}, env => {
   let elementMock;
   let resources;
   let resource;
-  let sandbox;
 
   beforeEach(() => {
     win = env.win;
     doc = win.document;
-    sandbox = env.sandbox;
 
     element = env.createAmpElement('amp-fake-element');
     doc.body.appendChild(element);
-    sandbox
+    env.sandbox
       .stub(element, 'getLayoutPriority')
       .callsFake(() => LayoutPriority.ADS);
-    elementMock = sandbox.mock(element);
+    elementMock = env.sandbox.mock(element);
 
     const viewer = Services.viewerForDoc(doc);
-    sandbox.stub(viewer, 'isRuntimeOn').callsFake(() => false);
-    sandbox
+    env.sandbox.stub(viewer, 'isRuntimeOn').callsFake(() => false);
+    env.sandbox
       .stub(ResourcesImpl.prototype, 'rebuildDomWhenReady_')
       .callsFake(() => {});
     resources = new ResourcesImpl(env.ampdoc);
     resource = new Resource(1, element, resources);
 
     const vsync = Services.vsyncFor(win);
-    sandbox.stub(vsync, 'mutate').callsFake(mutator => {
+    env.sandbox.stub(vsync, 'mutate').callsFake(mutator => {
       mutator();
     });
 
@@ -118,7 +116,7 @@ describes.realWin('Resource', {amp: true}, env => {
   });
 
   it('should blacklist on build failure', () => {
-    sandbox
+    env.sandbox
       .stub(resource, 'maybeReportErrorOnBuildFailure')
       .callsFake(() => {});
     elementMock
@@ -190,7 +188,7 @@ describes.realWin('Resource', {amp: true}, env => {
       elementMock
         .expects('updateLayoutBox')
         .withExactArgs(
-          sinon.match(data => {
+          env.sandbox.match(data => {
             return data.width == 111 && data.height == 222;
           }),
           true
@@ -218,7 +216,7 @@ describes.realWin('Resource', {amp: true}, env => {
       elementMock
         .expects('updateLayoutBox')
         .withExactArgs(
-          sinon.match(data => {
+          env.sandbox.match(data => {
             return data.width == 0 && data.height == 0;
           }),
           false
@@ -234,11 +232,11 @@ describes.realWin('Resource', {amp: true}, env => {
       .returns(false)
       .atLeast(1);
     const viewport = Services.viewportForDoc(resource.element);
-    sandbox
+    env.sandbox
       .stub(viewport, 'getLayoutRect')
       .returns(layoutRectLtwh(0, 100, 300, 100));
-    sandbox.stub(viewport, 'isDeclaredFixed').returns(false);
-    sandbox.stub(viewport, 'supportsPositionFixed').returns(true);
+    env.sandbox.stub(viewport, 'isDeclaredFixed').returns(false);
+    env.sandbox.stub(viewport, 'supportsPositionFixed').returns(true);
     expect(() => {
       resource.measure();
     }).to.not.throw();
@@ -280,7 +278,7 @@ describes.realWin('Resource', {amp: true}, env => {
       elementMock
         .expects('updateLayoutBox')
         .withExactArgs(
-          sinon.match(data => {
+          env.sandbox.match(data => {
             return data.width == 111 && data.height == 222;
           }),
           true
@@ -441,8 +439,8 @@ describes.realWin('Resource', {amp: true}, env => {
       .returns(layoutRectLtwh(0, 0, 10, 10))
       .once();
     const viewport = Services.viewportForDoc(resource.element);
-    sandbox.stub(viewport, 'getScrollTop').returns(11);
-    sandbox.defineProperty(element, 'offsetParent', {
+    env.sandbox.stub(viewport, 'getScrollTop').returns(11);
+    env.sandbox.defineProperty(element, 'offsetParent', {
       value: {
         isAlwaysFixed: () => true,
       },
@@ -465,13 +463,13 @@ describes.realWin('Resource', {amp: true}, env => {
       .once();
 
     const viewport = Services.viewportForDoc(resource.element);
-    sandbox.stub(viewport, 'getScrollTop').returns(11);
+    env.sandbox.stub(viewport, 'getScrollTop').returns(11);
 
     const fixedParent = doc.createElement('div');
     fixedParent.style.position = 'fixed';
     doc.body.appendChild(fixedParent);
     fixedParent.appendChild(element);
-    sandbox.stub(viewport, 'isDeclaredFixed').callsFake(el => {
+    env.sandbox.stub(viewport, 'isDeclaredFixed').callsFake(el => {
       if (el == element) {
         return false;
       }
@@ -488,8 +486,8 @@ describes.realWin('Resource', {amp: true}, env => {
 
   describe('getPageLayoutBoxAsync', () => {
     it('should return layout box when the resource has NOT been measured', () => {
-      sandbox.stub(element, 'isUpgraded').returns(true);
-      sandbox
+      env.sandbox.stub(element, 'isUpgraded').returns(true);
+      env.sandbox
         .stub(element, 'getBoundingClientRect')
         .returns(layoutRectLtwh(0, 0, 10, 10));
       return expect(resource.getPageLayoutBoxAsync()).to.eventually.eql(
@@ -498,8 +496,8 @@ describes.realWin('Resource', {amp: true}, env => {
     });
 
     it('should return layout box when the resource has been measured', () => {
-      sandbox.stub(element, 'isUpgraded').returns(true);
-      sandbox
+      env.sandbox.stub(element, 'isUpgraded').returns(true);
+      env.sandbox
         .stub(element, 'getBoundingClientRect')
         .returns(layoutRectLtwh(0, 0, 10, 10));
       resource.measure();
@@ -514,7 +512,7 @@ describes.realWin('Resource', {amp: true}, env => {
 
     beforeEach(() => {
       element.setAttribute('placeholder', '');
-      sandbox.defineProperty(element, 'parentElement', {
+      env.sandbox.defineProperty(element, 'parentElement', {
         value: doc.createElement('amp-iframe'),
         configurable: true,
         writable: true,
@@ -588,15 +586,15 @@ describes.realWin('Resource', {amp: true}, env => {
     elementMock
       .expects('updateLayoutBox')
       .withExactArgs(
-        sinon.match(data => {
+        env.sandbox.match(data => {
           return data.width == 0 && data.height == 0;
         })
       )
       .once();
     const owner = {
-      collapsedCallback: sandbox.spy(),
+      collapsedCallback: env.sandbox.spy(),
     };
-    sandbox.stub(resource, 'getOwner').callsFake(() => {
+    env.sandbox.stub(resource, 'getOwner').callsFake(() => {
       return owner;
     });
     resource.completeCollapse();
@@ -611,7 +609,7 @@ describes.realWin('Resource', {amp: true}, env => {
     resource.completeCollapse();
     resource.layoutBox_ = {left: 11, top: 12, width: 0, height: 0};
     resource.isFixed_ = false;
-    resource.requestMeasure = sandbox.stub();
+    resource.requestMeasure = env.sandbox.stub();
 
     resource.completeExpand();
     expect(resource.element).to.not.have.display('none');
@@ -840,7 +838,7 @@ describes.realWin('Resource', {amp: true}, env => {
     let resolveWithinViewportSpy;
     beforeEach(
       () =>
-        (resolveWithinViewportSpy = sandbox.spy(
+        (resolveWithinViewportSpy = env.sandbox.spy(
           resource,
           'resolveDeferredsWhenWithinViewports_'
         ))
@@ -1113,8 +1111,8 @@ describes.realWin('Resource', {amp: true}, env => {
       });
 
       it('should call disconnect on remove for built ele', () => {
-        sandbox.stub(element, 'isConnected').value(false);
-        const remove = sandbox.spy(resources, 'remove');
+        env.sandbox.stub(element, 'isConnected').value(false);
+        const remove = env.sandbox.spy(resources, 'remove');
         resource.disconnect();
         expect(remove).to.have.been.called;
         expect(Resource.forElementOptional(resource.element)).to.not.exist;
@@ -1122,7 +1120,7 @@ describes.realWin('Resource', {amp: true}, env => {
 
       it('should call disconnected regardless of isConnected', () => {
         // element is already connected to DOM
-        const spy = sandbox.spy(resources, 'remove');
+        const spy = env.sandbox.spy(resources, 'remove');
         resource.disconnect();
         expect(spy).to.have.been.called;
         expect(Resource.forElementOptional(resource.element)).to.not.exist;
@@ -1146,7 +1144,6 @@ describes.realWin('Resource', {amp: true}, env => {
 });
 
 describe('Resource idleRenderOutsideViewport', () => {
-  let sandbox;
   let element;
   let resources;
   let resource;
@@ -1154,9 +1151,7 @@ describe('Resource idleRenderOutsideViewport', () => {
   let isWithinViewportRatio;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox;
-    sandbox = sinon.sandbox;
-    idleRenderOutsideViewport = sandbox.stub();
+    idleRenderOutsideViewport = window.sandbox.stub();
     element = {
       idleRenderOutsideViewport,
       ownerDocument: {defaultView: window},
@@ -1181,11 +1176,10 @@ describe('Resource idleRenderOutsideViewport', () => {
     };
     resources = new ResourcesImpl(new AmpDocSingle(window));
     resource = new Resource(1, element, resources);
-    isWithinViewportRatio = sandbox.stub(resource, 'isWithinViewportRatio');
-  });
-
-  afterEach(() => {
-    sandbox.restore();
+    isWithinViewportRatio = window.sandbox.stub(
+      resource,
+      'isWithinViewportRatio'
+    );
   });
 
   it('should return true if isWithinViewportRatio', () => {
@@ -1202,7 +1196,6 @@ describe('Resource idleRenderOutsideViewport', () => {
 });
 
 describes.realWin('Resource renderOutsideViewport', {amp: true}, env => {
-  let sandbox;
   let element;
   let resources;
   let resource;
@@ -1211,17 +1204,17 @@ describes.realWin('Resource renderOutsideViewport', {amp: true}, env => {
   let resolveWithinViewportSpy;
 
   beforeEach(() => {
-    sandbox = env.sandbox;
-
     element = env.createAmpElement('amp-fake-element');
     env.win.document.body.appendChild(element);
 
     resources = new ResourcesImpl(env.ampdoc);
     resource = new Resource(1, element, resources);
     viewport = Services.viewportForDoc(env.ampdoc);
-    renderOutsideViewport = sandbox.stub(element, 'renderOutsideViewport');
-    sandbox.stub(viewport, 'getRect').returns(layoutRectLtwh(0, 0, 100, 100));
-    resolveWithinViewportSpy = sandbox.spy(
+    renderOutsideViewport = env.sandbox.stub(element, 'renderOutsideViewport');
+    env.sandbox
+      .stub(viewport, 'getRect')
+      .returns(layoutRectLtwh(0, 0, 100, 100));
+    resolveWithinViewportSpy = env.sandbox.spy(
       resource,
       'resolveDeferredsWhenWithinViewports_'
     );
@@ -1248,7 +1241,7 @@ describes.realWin('Resource renderOutsideViewport', {amp: true}, env => {
 
         describe('when element is owned', () => {
           beforeEach(() => {
-            sandbox.stub(resource, 'hasOwner').callsFake(() => true);
+            env.sandbox.stub(resource, 'hasOwner').callsFake(() => true);
           });
 
           it('should allow rendering when bottom falls outside', () => {
@@ -1284,7 +1277,7 @@ describes.realWin('Resource renderOutsideViewport', {amp: true}, env => {
 
         describe('when element is owned', () => {
           beforeEach(() => {
-            sandbox.stub(resource, 'hasOwner').callsFake(() => true);
+            env.sandbox.stub(resource, 'hasOwner').callsFake(() => true);
           });
 
           it('should allow rendering when scrolling towards', () => {
@@ -1320,7 +1313,7 @@ describes.realWin('Resource renderOutsideViewport', {amp: true}, env => {
 
         describe('when element is owned', () => {
           beforeEach(() => {
-            sandbox.stub(resource, 'hasOwner').callsFake(() => true);
+            env.sandbox.stub(resource, 'hasOwner').callsFake(() => true);
           });
 
           it('should allow rendering when scrolling towards', () => {
@@ -1361,7 +1354,7 @@ describes.realWin('Resource renderOutsideViewport', {amp: true}, env => {
 
         describe('when element is owned', () => {
           beforeEach(() => {
-            sandbox.stub(resource, 'hasOwner').callsFake(() => true);
+            env.sandbox.stub(resource, 'hasOwner').callsFake(() => true);
           });
 
           it('should allow rendering', () => {
@@ -1402,7 +1395,7 @@ describes.realWin('Resource renderOutsideViewport', {amp: true}, env => {
 
         describe('when element is owned', () => {
           beforeEach(() => {
-            sandbox.stub(resource, 'hasOwner').callsFake(() => true);
+            env.sandbox.stub(resource, 'hasOwner').callsFake(() => true);
           });
 
           it('should allow rendering when scrolling towards', () => {
@@ -1438,7 +1431,7 @@ describes.realWin('Resource renderOutsideViewport', {amp: true}, env => {
 
         describe('when element is owned', () => {
           beforeEach(() => {
-            sandbox.stub(resource, 'hasOwner').callsFake(() => true);
+            env.sandbox.stub(resource, 'hasOwner').callsFake(() => true);
           });
 
           it('should allow rendering when scrolling towards', () => {
@@ -1479,7 +1472,7 @@ describes.realWin('Resource renderOutsideViewport', {amp: true}, env => {
 
         describe('when element is owned', () => {
           beforeEach(() => {
-            sandbox.stub(resource, 'hasOwner').callsFake(() => true);
+            env.sandbox.stub(resource, 'hasOwner').callsFake(() => true);
           });
 
           it('should allow rendering', () => {
@@ -1522,7 +1515,7 @@ describes.realWin('Resource renderOutsideViewport', {amp: true}, env => {
 
         describe('when element is owned', () => {
           beforeEach(() => {
-            sandbox.stub(resource, 'hasOwner').callsFake(() => true);
+            env.sandbox.stub(resource, 'hasOwner').callsFake(() => true);
           });
 
           it('should allow rendering when bottom falls outside', () => {
@@ -1558,7 +1551,7 @@ describes.realWin('Resource renderOutsideViewport', {amp: true}, env => {
 
         describe('when element is owned', () => {
           beforeEach(() => {
-            sandbox.stub(resource, 'hasOwner').callsFake(() => true);
+            env.sandbox.stub(resource, 'hasOwner').callsFake(() => true);
           });
 
           it('should allow rendering when scrolling towards', () => {
@@ -1594,7 +1587,7 @@ describes.realWin('Resource renderOutsideViewport', {amp: true}, env => {
 
         describe('when element is owned', () => {
           beforeEach(() => {
-            sandbox.stub(resource, 'hasOwner').callsFake(() => true);
+            env.sandbox.stub(resource, 'hasOwner').callsFake(() => true);
           });
 
           it('should allow rendering when scrolling towards', () => {
@@ -1635,7 +1628,7 @@ describes.realWin('Resource renderOutsideViewport', {amp: true}, env => {
 
         describe('when element is owned', () => {
           beforeEach(() => {
-            sandbox.stub(resource, 'hasOwner').callsFake(() => true);
+            env.sandbox.stub(resource, 'hasOwner').callsFake(() => true);
           });
 
           it('should allow rendering', () => {
@@ -1676,7 +1669,7 @@ describes.realWin('Resource renderOutsideViewport', {amp: true}, env => {
 
         describe('when element is owned', () => {
           beforeEach(() => {
-            sandbox.stub(resource, 'hasOwner').callsFake(() => true);
+            env.sandbox.stub(resource, 'hasOwner').callsFake(() => true);
           });
 
           it('should allow rendering when scrolling towards', () => {
@@ -1712,7 +1705,7 @@ describes.realWin('Resource renderOutsideViewport', {amp: true}, env => {
 
         describe('when element is owned', () => {
           beforeEach(() => {
-            sandbox.stub(resource, 'hasOwner').callsFake(() => true);
+            env.sandbox.stub(resource, 'hasOwner').callsFake(() => true);
           });
 
           it('should allow rendering when scrolling towards', () => {
@@ -1753,7 +1746,7 @@ describes.realWin('Resource renderOutsideViewport', {amp: true}, env => {
 
         describe('when element is owned', () => {
           beforeEach(() => {
-            sandbox.stub(resource, 'hasOwner').callsFake(() => true);
+            env.sandbox.stub(resource, 'hasOwner').callsFake(() => true);
           });
 
           it('should allow rendering', () => {
@@ -1797,7 +1790,7 @@ describes.realWin('Resource renderOutsideViewport', {amp: true}, env => {
 
       describe('when element is owned', () => {
         beforeEach(() => {
-          sandbox.stub(resource, 'hasOwner').callsFake(() => true);
+          env.sandbox.stub(resource, 'hasOwner').callsFake(() => true);
         });
 
         it('should allow rendering when bottom falls outside', () => {
@@ -1833,7 +1826,7 @@ describes.realWin('Resource renderOutsideViewport', {amp: true}, env => {
 
       describe('when element is owned', () => {
         beforeEach(() => {
-          sandbox.stub(resource, 'hasOwner').callsFake(() => true);
+          env.sandbox.stub(resource, 'hasOwner').callsFake(() => true);
         });
 
         it('should allow rendering when scrolling towards', () => {
@@ -1869,7 +1862,7 @@ describes.realWin('Resource renderOutsideViewport', {amp: true}, env => {
 
       describe('when element is owned', () => {
         beforeEach(() => {
-          sandbox.stub(resource, 'hasOwner').callsFake(() => true);
+          env.sandbox.stub(resource, 'hasOwner').callsFake(() => true);
         });
 
         it('should allow rendering when scrolling towards', () => {
@@ -1910,7 +1903,7 @@ describes.realWin('Resource renderOutsideViewport', {amp: true}, env => {
 
       describe('when element is owned', () => {
         beforeEach(() => {
-          sandbox.stub(resource, 'hasOwner').callsFake(() => true);
+          env.sandbox.stub(resource, 'hasOwner').callsFake(() => true);
         });
 
         it('should allow rendering', () => {
@@ -1951,7 +1944,7 @@ describes.realWin('Resource renderOutsideViewport', {amp: true}, env => {
 
       describe('when element is owned', () => {
         beforeEach(() => {
-          sandbox.stub(resource, 'hasOwner').callsFake(() => true);
+          env.sandbox.stub(resource, 'hasOwner').callsFake(() => true);
         });
 
         it('should allow rendering when scrolling towards', () => {
@@ -1987,7 +1980,7 @@ describes.realWin('Resource renderOutsideViewport', {amp: true}, env => {
 
       describe('when element is owned', () => {
         beforeEach(() => {
-          sandbox.stub(resource, 'hasOwner').callsFake(() => true);
+          env.sandbox.stub(resource, 'hasOwner').callsFake(() => true);
         });
 
         it('should allow rendering when scrolling towards', () => {
@@ -2028,7 +2021,7 @@ describes.realWin('Resource renderOutsideViewport', {amp: true}, env => {
 
       describe('when element is owned', () => {
         beforeEach(() => {
-          sandbox.stub(resource, 'hasOwner').callsFake(() => true);
+          env.sandbox.stub(resource, 'hasOwner').callsFake(() => true);
         });
 
         it('should allow rendering', () => {
@@ -2074,7 +2067,7 @@ describes.realWin('Resource renderOutsideViewport', {amp: true}, env => {
 
       describe('when element is owned', () => {
         beforeEach(() => {
-          sandbox.stub(resource, 'hasOwner').callsFake(() => true);
+          env.sandbox.stub(resource, 'hasOwner').callsFake(() => true);
         });
 
         it('should allow rendering', () => {
@@ -2120,7 +2113,7 @@ describes.realWin('Resource renderOutsideViewport', {amp: true}, env => {
 
       describe('when element is owned', () => {
         beforeEach(() => {
-          sandbox.stub(resource, 'hasOwner').callsFake(() => true);
+          env.sandbox.stub(resource, 'hasOwner').callsFake(() => true);
         });
 
         it('should allow rendering', () => {
@@ -2166,7 +2159,7 @@ describes.realWin('Resource renderOutsideViewport', {amp: true}, env => {
 
       describe('when element is owned', () => {
         beforeEach(() => {
-          sandbox.stub(resource, 'hasOwner').callsFake(() => true);
+          env.sandbox.stub(resource, 'hasOwner').callsFake(() => true);
         });
 
         it('should allow rendering', () => {
@@ -2212,7 +2205,7 @@ describes.realWin('Resource renderOutsideViewport', {amp: true}, env => {
 
       describe('when element is owned', () => {
         beforeEach(() => {
-          sandbox.stub(resource, 'hasOwner').callsFake(() => true);
+          env.sandbox.stub(resource, 'hasOwner').callsFake(() => true);
         });
 
         it('should allow rendering', () => {
@@ -2237,7 +2230,7 @@ describes.realWin('Resource renderOutsideViewport', {amp: true}, env => {
 
   describe('whenWithinViewport', () => {
     it('should resolve correctly', () => {
-      sandbox
+      env.sandbox
         .stub(resource, 'isWithinViewportRatio')
         .withArgs(3)
         .onCall(0)
@@ -2261,17 +2254,17 @@ describes.realWin('Resource renderOutsideViewport', {amp: true}, env => {
     });
 
     it('should resolve immediately if already laid out', () => {
-      sandbox.stub(resource, 'isLayoutPending').returns(false);
+      env.sandbox.stub(resource, 'isLayoutPending').returns(false);
       return resource.whenWithinViewport();
     });
 
     it('should resolve correctly with float', () => {
-      const isWithinViewportRatioStub = sandbox.stub(
+      const isWithinViewportRatioStub = env.sandbox.stub(
         resource,
         'isWithinViewportRatio'
       );
       const ratio = {};
-      sandbox.stub(resource, 'getDistanceViewportRatio').returns(ratio);
+      env.sandbox.stub(resource, 'getDistanceViewportRatio').returns(ratio);
       isWithinViewportRatioStub.withArgs(1.25).returns(false);
       isWithinViewportRatioStub.withArgs(1.25, ratio).returns(true);
       const promise = resource.whenWithinViewport(1.25);

--- a/test/unit/test-resources.js
+++ b/test/unit/test-resources.js
@@ -32,25 +32,24 @@ const NO_EVENT = undefined;
 
 /*eslint "google-camelcase/google-camelcase": 0*/
 describe('Resources', () => {
-  let sandbox;
   let clock;
   let resources;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox;
-    clock = sandbox.useFakeTimers();
+    clock = window.sandbox.useFakeTimers();
     resources = new ResourcesImpl(new AmpDocSingle(window));
     resources.isRuntimeOn_ = false;
   });
 
   afterEach(() => {
-    sandbox.restore();
     resources.pass_.cancel();
   });
 
   it('should calculate correct calcTaskScore', () => {
     const viewportRect = layoutRectLtwh(0, 100, 300, 400);
-    sandbox.stub(resources.viewport_, 'getRect').callsFake(() => viewportRect);
+    window.sandbox
+      .stub(resources.viewport_, 'getRect')
+      .callsFake(() => viewportRect);
 
     // Task 1 is right in the middle of the viewport and priority 0
     const task_in_viewport_p0 = {
@@ -281,7 +280,7 @@ describe('Resources', () => {
         applySizesAndMediaQuery: () => {},
       };
       resources.visible_ = false;
-      sandbox
+      window.sandbox
         .stub(resources.ampdoc, 'getVisibilityState')
         .returns(VisibilityState.PRERENDER);
       resources.scheduleLayoutOrPreload(resource, true);
@@ -304,7 +303,7 @@ describe('Resources', () => {
       applySizesAndMediaQuery: () => {},
     };
     resources.visible_ = false;
-    sandbox
+    window.sandbox
       .stub(resources.ampdoc, 'getVisibilityState')
       .returns(VisibilityState.PRERENDER);
     resources.scheduleLayoutOrPreload(resource, true);
@@ -327,7 +326,7 @@ describe('Resources', () => {
       applySizesAndMediaQuery: () => {},
     };
     resources.visible_ = false;
-    sandbox
+    window.sandbox
       .stub(resources.ampdoc, 'getVisibilityState')
       .returns(VisibilityState.HIDDEN);
     resources.scheduleLayoutOrPreload(resource, true);
@@ -480,21 +479,15 @@ describes.fakeWin(
   env => {
     let win;
     let clock;
-    let sandbox;
     let resources;
     let schedulePassStub;
 
     beforeEach(() => {
       win = env.win;
-      sandbox = sinon.sandbox;
-      clock = sandbox.useFakeTimers();
+      clock = env.sandbox.useFakeTimers();
       resources = Services.resourcesForDoc(win.document.body);
       resources.relayoutAll_ = false;
-      schedulePassStub = sandbox.stub(resources, 'schedulePass');
-    });
-
-    afterEach(() => {
-      sandbox.restore();
+      schedulePassStub = env.sandbox.stub(resources, 'schedulePass');
     });
 
     it('should run a full reload pass on window.onload', () => {
@@ -628,14 +621,14 @@ describes.realWin('Resources discoverWork', {amp: true}, env => {
     element.getBoundingClientRect = () => rect;
     element.applySizesAndMediaQuery = () => {};
     element.layoutCallback = () => Promise.resolve();
-    element.viewportCallback = sandbox.spy();
+    element.viewportCallback = env.sandbox.spy();
     element.prerenderAllowed = () => true;
     element.renderOutsideViewport = () => true;
     element.isRelayoutNeeded = () => true;
     element.pauseCallback = () => {};
     element.unlayoutCallback = () => true;
     element.unlayoutOnPause = () => true;
-    element.togglePlaceholder = () => sandbox.spy();
+    element.togglePlaceholder = () => env.sandbox.spy();
     element.fakeComputedStyle = {
       marginTop: '0px',
       marginRight: '0px',
@@ -650,26 +643,24 @@ describes.realWin('Resources discoverWork', {amp: true}, env => {
     const resource = new Resource(id, createElement(rect), resources);
     resource.state_ = ResourceState.READY_FOR_LAYOUT;
     resource.layoutBox_ = rect;
-    // sandbox.stub(resource, 'isDisplayed').returns(true);
+    // env.sandbox.stub(resource, 'isDisplayed').returns(true);
     return resource;
   }
 
-  let sandbox;
   let viewportMock;
   let resources;
   let resource1, resource2;
 
   beforeEach(() => {
-    sandbox = env.sandbox;
     toggleExperiment(window, 'amp-force-prerender-visible-elements', true);
     const viewer = Services.viewerForDoc(env.ampdoc);
-    sandbox.stub(viewer, 'isRuntimeOn').returns(true);
+    env.sandbox.stub(viewer, 'isRuntimeOn').returns(true);
     resources = new ResourcesImpl(env.ampdoc);
     resources.remeasurePass_.schedule = () => {};
     resources.pass_.schedule = () => {};
-    viewportMock = sandbox.mock(resources.viewport_);
+    viewportMock = env.sandbox.mock(resources.viewport_);
 
-    sandbox.stub(env.win, 'getComputedStyle').callsFake(el => {
+    env.sandbox.stub(env.win, 'getComputedStyle').callsFake(el => {
       return el.fakeComputedStyle
         ? el.fakeComputedStyle
         : window.getComputedStyle(el);
@@ -687,14 +678,13 @@ describes.realWin('Resources discoverWork', {amp: true}, env => {
   afterEach(() => {
     toggleExperiment(window, 'amp-force-prerender-visible-elements', false);
     viewportMock.verify();
-    sandbox.restore();
   });
 
   it('should set ready-scan signal on first ready pass after amp init', () => {
     resources.isRuntimeOn_ = true;
     resources.documentReady_ = true;
     resources.firstPassAfterDocumentReady_ = true;
-    sandbox.stub(resources.visibilityStateMachine_, 'setState');
+    env.sandbox.stub(resources.visibilityStateMachine_, 'setState');
     resources.doPass();
     expect(resources.ampdoc.signals().get('ready-scan')).to.be.null;
     resources.ampInitComplete();
@@ -705,12 +695,15 @@ describes.realWin('Resources discoverWork', {amp: true}, env => {
 
   it('should measure unbuilt elements', () => {
     resources.visible_ = true;
-    sandbox
+    env.sandbox
       .stub(resources.ampdoc, 'getVisibilityState')
       .returns(VisibilityState.VISIBLE);
     viewportMock.expects('getRect').returns(layoutRectLtwh(0, 0, 300, 400));
     resource1.isBuilt = () => false;
-    const mediaSpy = sandbox.stub(resource1.element, 'applySizesAndMediaQuery');
+    const mediaSpy = env.sandbox.stub(
+      resource1.element,
+      'applySizesAndMediaQuery'
+    );
     expect(resource1.hasBeenMeasured()).to.be.false;
     resource1.isBuilt = () => false;
 
@@ -722,7 +715,7 @@ describes.realWin('Resources discoverWork', {amp: true}, env => {
 
   it('should render two screens when visible', () => {
     resources.visible_ = true;
-    sandbox
+    env.sandbox
       .stub(resources.ampdoc, 'getVisibilityState')
       .returns(VisibilityState.VISIBLE);
     viewportMock.expects('getRect').returns(layoutRectLtwh(0, 0, 300, 400));
@@ -738,7 +731,7 @@ describes.realWin('Resources discoverWork', {amp: true}, env => {
     resource1.state_ = ResourceState.LAYOUT_COMPLETE;
     resource2.state_ = ResourceState.LAYOUT_COMPLETE;
     resources.visible_ = true;
-    sandbox
+    env.sandbox
       .stub(resources.ampdoc, 'getVisibilityState')
       .returns(VisibilityState.VISIBLE);
     viewportMock.expects('getRect').returns(layoutRectLtwh(0, 0, 300, 400));
@@ -758,7 +751,7 @@ describes.realWin('Resources discoverWork', {amp: true}, env => {
     resource2.element.getBoundingClientRect = () =>
       layoutRectLtwh(10, 1010, 100, 101);
     resources.visible_ = true;
-    sandbox
+    env.sandbox
       .stub(resources.ampdoc, 'getVisibilityState')
       .returns(VisibilityState.VISIBLE);
     resources.relayoutAll_ = false;
@@ -776,7 +769,7 @@ describes.realWin('Resources discoverWork', {amp: true}, env => {
 
   it('should prerender only one screen with prerenderSize = 1', () => {
     resources.visible_ = false;
-    sandbox
+    env.sandbox
       .stub(resources.ampdoc, 'getVisibilityState')
       .returns(VisibilityState.PRERENDER);
     resources.prerenderSize_ = 1;
@@ -790,7 +783,7 @@ describes.realWin('Resources discoverWork', {amp: true}, env => {
 
   it('should NOT prerender anything with prerenderSize = 0', () => {
     resources.visible_ = false;
-    sandbox
+    env.sandbox
       .stub(resources.ampdoc, 'getVisibilityState')
       .returns(VisibilityState.PRERENDER);
     resources.prerenderSize_ = 0;
@@ -806,19 +799,19 @@ describes.realWin('Resources discoverWork', {amp: true}, env => {
     resource1.state_ = ResourceState.LAYOUT_COMPLETE;
     resource2.state_ = ResourceState.LAYOUT_COMPLETE;
     resources.visible_ = true;
-    sandbox
+    env.sandbox
       .stub(resources.ampdoc, 'getVisibilityState')
       .returns(VisibilityState.VISIBLE);
     viewportMock.expects('getRect').returns(layoutRectLtwh(0, 0, 300, 400));
 
-    const resource1MeasureStub = sandbox
+    const resource1MeasureStub = env.sandbox
       .stub(resource1, 'measure')
       .callsFake(resource1.measure.bind(resource1));
-    const resource1UnloadStub = sandbox.stub(resource1, 'unload');
-    const resource2MeasureStub = sandbox
+    const resource1UnloadStub = env.sandbox.stub(resource1, 'unload');
+    const resource2MeasureStub = env.sandbox
       .stub(resource2, 'measure')
       .callsFake(resource2.measure.bind(resource2));
-    const resource2UnloadStub = sandbox.stub(resource2, 'unload');
+    const resource2UnloadStub = env.sandbox.stub(resource2, 'unload');
 
     // 1st pass: measure for the first time.
     resources.discoverWork_();
@@ -861,7 +854,7 @@ describes.realWin('Resources discoverWork', {amp: true}, env => {
     resource1.layoutCallback = new Promise(unusedResolve => {});
     resource1.unlayoutCallback = () => true;
 
-    sandbox
+    env.sandbox
       .stub(resources.ampdoc, 'getVisibilityState')
       .returns(VisibilityState.VISIBLE);
     viewportMock
@@ -908,7 +901,7 @@ describes.realWin('Resources discoverWork', {amp: true}, env => {
     expect(resources.queue_.getSize()).to.equal(1);
     expect(resources.queue_.tasks_[0].resource).to.equal(resource1);
 
-    const measureSpy = sandbox.spy(resource1, 'measure');
+    const measureSpy = env.sandbox.spy(resource1, 'measure');
     resources.work_();
     expect(resources.exec_.getSize()).to.equal(1);
     expect(measureSpy).to.be.calledOnce;
@@ -928,11 +921,13 @@ describes.realWin('Resources discoverWork', {amp: true}, env => {
     expect(resources.queue_.getSize()).to.equal(1);
     expect(resources.queue_.tasks_[0].resource).to.equal(resource1);
 
-    const measureSpy = sandbox.spy(resource1, 'measure');
-    const layoutCanceledSpy = sandbox.spy(resource1, 'layoutCanceled');
-    sandbox.stub(resource1, 'isInViewport').callsFake(() => false);
-    sandbox.stub(resource1, 'renderOutsideViewport').callsFake(() => false);
-    sandbox.stub(resource1, 'idleRenderOutsideViewport').callsFake(() => false);
+    const measureSpy = env.sandbox.spy(resource1, 'measure');
+    const layoutCanceledSpy = env.sandbox.spy(resource1, 'layoutCanceled');
+    env.sandbox.stub(resource1, 'isInViewport').callsFake(() => false);
+    env.sandbox.stub(resource1, 'renderOutsideViewport').callsFake(() => false);
+    env.sandbox
+      .stub(resource1, 'idleRenderOutsideViewport')
+      .callsFake(() => false);
     resources.work_();
     expect(resources.exec_.getSize()).to.equal(0);
     expect(measureSpy).to.be.calledOnce;
@@ -945,10 +940,12 @@ describes.realWin('Resources discoverWork', {amp: true}, env => {
     expect(resources.queue_.getSize()).to.equal(1);
     expect(resources.queue_.tasks_[0].resource).to.equal(resource1);
 
-    const measureSpy = sandbox.spy(resource1, 'measure');
-    sandbox.stub(resource1, 'isInViewport').callsFake(() => false);
-    sandbox.stub(resource1, 'renderOutsideViewport').callsFake(() => false);
-    sandbox.stub(resource1, 'idleRenderOutsideViewport').callsFake(() => false);
+    const measureSpy = env.sandbox.spy(resource1, 'measure');
+    env.sandbox.stub(resource1, 'isInViewport').callsFake(() => false);
+    env.sandbox.stub(resource1, 'renderOutsideViewport').callsFake(() => false);
+    env.sandbox
+      .stub(resource1, 'idleRenderOutsideViewport')
+      .callsFake(() => false);
     resources.work_();
     expect(resources.exec_.getSize()).to.equal(1);
     expect(measureSpy).to.be.calledOnce;
@@ -961,14 +958,14 @@ describes.realWin('Resources discoverWork', {amp: true}, env => {
     expect(resources.queue_.tasks_[0].resource).to.equal(resource1);
 
     resources.visible_ = false;
-    sandbox
+    env.sandbox
       .stub(resources.ampdoc, 'getVisibilityState')
       .callsFake(() => 'prerender');
-    sandbox.stub(resource1, 'isInViewport').callsFake(() => true);
-    sandbox.stub(resource1, 'prerenderAllowed').callsFake(() => true);
+    env.sandbox.stub(resource1, 'isInViewport').callsFake(() => true);
+    env.sandbox.stub(resource1, 'prerenderAllowed').callsFake(() => true);
 
-    const measureSpy = sandbox.spy(resource1, 'measure');
-    const layoutCanceledSpy = sandbox.spy(resource1, 'layoutCanceled');
+    const measureSpy = env.sandbox.spy(resource1, 'measure');
+    const layoutCanceledSpy = env.sandbox.spy(resource1, 'layoutCanceled');
     resources.work_();
     expect(resources.exec_.getSize()).to.equal(1);
     expect(measureSpy).to.be.calledOnce;
@@ -982,14 +979,14 @@ describes.realWin('Resources discoverWork', {amp: true}, env => {
     expect(resources.queue_.tasks_[0].resource).to.equal(resource1);
 
     resources.visible_ = false;
-    sandbox
+    env.sandbox
       .stub(resources.ampdoc, 'getVisibilityState')
       .callsFake(() => 'prerender');
-    sandbox.stub(resource1, 'isInViewport').callsFake(() => true);
-    sandbox.stub(resource1, 'prerenderAllowed').callsFake(() => false);
+    env.sandbox.stub(resource1, 'isInViewport').callsFake(() => true);
+    env.sandbox.stub(resource1, 'prerenderAllowed').callsFake(() => false);
 
-    const measureSpy = sandbox.spy(resource1, 'measure');
-    const layoutCanceledSpy = sandbox.spy(resource1, 'layoutCanceled');
+    const measureSpy = env.sandbox.spy(resource1, 'measure');
+    const layoutCanceledSpy = env.sandbox.spy(resource1, 'layoutCanceled');
     resources.work_();
     expect(resources.exec_.getSize()).to.equal(0);
     expect(measureSpy).to.be.calledOnce;
@@ -1003,14 +1000,14 @@ describes.realWin('Resources discoverWork', {amp: true}, env => {
     expect(resources.queue_.tasks_[0].resource).to.equal(resource1);
 
     resources.visible_ = false;
-    sandbox
+    env.sandbox
       .stub(resources.ampdoc, 'getVisibilityState')
       .callsFake(() => 'hidden');
-    sandbox.stub(resource1, 'isInViewport').callsFake(() => true);
-    sandbox.stub(resource1, 'prerenderAllowed').callsFake(() => true);
+    env.sandbox.stub(resource1, 'isInViewport').callsFake(() => true);
+    env.sandbox.stub(resource1, 'prerenderAllowed').callsFake(() => true);
 
-    const measureSpy = sandbox.spy(resource1, 'measure');
-    const layoutCanceledSpy = sandbox.spy(resource1, 'layoutCanceled');
+    const measureSpy = env.sandbox.spy(resource1, 'measure');
+    const layoutCanceledSpy = env.sandbox.spy(resource1, 'layoutCanceled');
     resources.work_();
     expect(resources.exec_.getSize()).to.equal(0);
     expect(measureSpy).to.be.calledOnce;
@@ -1022,12 +1019,12 @@ describes.realWin('Resources discoverWork', {amp: true}, env => {
   // it.configure().skipSafari().run(
   it.skip('should update inViewport before scheduling layouts', () => {
     resources.visible_ = true;
-    sandbox
+    env.sandbox
       .stub(resources.ampdoc, 'getVisibilityState')
       .returns(VisibilityState.VISIBLE);
     viewportMock.expects('getRect').returns(layoutRectLtwh(0, 0, 300, 400));
-    const setInViewport = sandbox.spy(resource1, 'setInViewport');
-    const schedule = sandbox.spy(resources, 'scheduleLayoutOrPreload');
+    const setInViewport = env.sandbox.spy(resource1, 'setInViewport');
+    const schedule = env.sandbox.spy(resources, 'scheduleLayoutOrPreload');
 
     resources.discoverWork_();
 
@@ -1036,10 +1033,10 @@ describes.realWin('Resources discoverWork', {amp: true}, env => {
   });
 
   it('should build resource when not built', () => {
-    const buildResourceSpy = sandbox.spy(resources, 'buildResourceUnsafe_');
-    sandbox.stub(resources, 'schedule_');
+    const buildResourceSpy = env.sandbox.spy(resources, 'buildResourceUnsafe_');
+    env.sandbox.stub(resources, 'schedule_');
     resources.documentReady_ = true;
-    resource1.element.isBuilt = sandbox
+    resource1.element.isBuilt = env.sandbox
       .stub()
       .onFirstCall()
       .returns(true)
@@ -1047,7 +1044,7 @@ describes.realWin('Resources discoverWork', {amp: true}, env => {
       .returns(false);
     resource2.element.idleRenderOutsideViewport = () => false;
     resource1.state_ = ResourceState.NOT_BUILT;
-    resource1.build = sandbox.spy();
+    resource1.build = env.sandbox.spy();
 
     resources.discoverWork_();
 
@@ -1060,11 +1057,11 @@ describes.realWin('Resources discoverWork', {amp: true}, env => {
   });
 
   it('should build resource when not built and before doc ready', () => {
-    const buildResourceSpy = sandbox.spy(resources, 'buildResourceUnsafe_');
-    sandbox.stub(resources, 'schedule_');
+    const buildResourceSpy = env.sandbox.spy(resources, 'buildResourceUnsafe_');
+    env.sandbox.stub(resources, 'schedule_');
     resources.documentReady_ = false;
-    sandbox.stub(resource1.element, 'nextSibling').returns({});
-    resource1.element.isBuilt = sandbox
+    env.sandbox.stub(resource1.element, 'nextSibling').returns({});
+    resource1.element.isBuilt = env.sandbox
       .stub()
       .onFirstCall()
       .returns(false)
@@ -1072,7 +1069,7 @@ describes.realWin('Resources discoverWork', {amp: true}, env => {
       .returns(true);
     resource2.element.idleRenderOutsideViewport = () => false;
     resource1.state_ = ResourceState.NOT_BUILT;
-    resource1.build = sandbox.spy();
+    resource1.build = env.sandbox.spy();
 
     resources.discoverWork_();
 
@@ -1084,16 +1081,16 @@ describes.realWin('Resources discoverWork', {amp: true}, env => {
   });
 
   it('should NOT build non-prerenderable resources in prerender', () => {
-    sandbox
+    env.sandbox
       .stub(resources.ampdoc, 'getVisibilityState')
       .returns(VisibilityState.PRERENDER);
-    sandbox.stub(resources, 'schedule_');
+    env.sandbox.stub(resources, 'schedule_');
     resources.documentReady_ = true;
 
     resource1.element.isBuilt = () => false;
     resource1.prerenderAllowed = () => false;
     resource1.state_ = ResourceState.NOT_BUILT;
-    resource1.build = sandbox.spy();
+    resource1.build = env.sandbox.spy();
     resource2.element.idleRenderOutsideViewport = () => false;
 
     resources.discoverWork_();
@@ -1102,8 +1099,8 @@ describes.realWin('Resources discoverWork', {amp: true}, env => {
   });
 
   it('should NOT build when quota reached', () => {
-    sandbox.stub(resources.ampdoc, 'hasBeenVisible').callsFake(() => false);
-    sandbox.stub(resources, 'schedule_');
+    env.sandbox.stub(resources.ampdoc, 'hasBeenVisible').callsFake(() => false);
+    env.sandbox.stub(resources, 'schedule_');
     resources.documentReady_ = true;
     resources.buildAttemptsCount_ = 21; // quota is 20
 
@@ -1112,15 +1109,15 @@ describes.realWin('Resources discoverWork', {amp: true}, env => {
     resource1.prerenderAllowed = () => true;
     resource1.isBuildRenderBlocking = () => false;
     resource1.state_ = ResourceState.NOT_BUILT;
-    resource1.build = sandbox.spy();
+    resource1.build = env.sandbox.spy();
 
     resources.buildOrScheduleBuildForResource_(resource1);
     expect(resource1.build).to.not.be.called;
   });
 
   it('should build render blocking resource even if quota is reached', () => {
-    sandbox.stub(resources.ampdoc, 'hasBeenVisible').callsFake(() => false);
-    sandbox.stub(resources, 'schedule_');
+    env.sandbox.stub(resources.ampdoc, 'hasBeenVisible').callsFake(() => false);
+    env.sandbox.stub(resources, 'schedule_');
     resources.documentReady_ = true;
     resources.buildAttemptsCount_ = 21; // quota is 20
 
@@ -1129,16 +1126,16 @@ describes.realWin('Resources discoverWork', {amp: true}, env => {
     resource1.prerenderAllowed = () => true;
     resource1.isBuildRenderBlocking = () => true;
     resource1.state_ = ResourceState.NOT_BUILT;
-    resource1.build = sandbox.spy();
+    resource1.build = env.sandbox.spy();
 
     resources.buildOrScheduleBuildForResource_(resource1);
     expect(resource1.build).to.be.called;
   });
 
   it('should layout resource if outside viewport but idle', () => {
-    const schedulePassStub = sandbox.stub(resources, 'schedulePass');
+    const schedulePassStub = env.sandbox.stub(resources, 'schedulePass');
     resources.documentReady_ = true;
-    sandbox.stub(resource1.element, 'nextSibling').returns({});
+    env.sandbox.stub(resource1.element, 'nextSibling').returns({});
     resource1.element.isBuilt = () => true;
     resource1.element.renderOutsideViewport = () => false;
     resource1.element.idleRenderOutsideViewport = () => true;
@@ -1152,14 +1149,14 @@ describes.realWin('Resources discoverWork', {amp: true}, env => {
   });
 
   it('should force build resources during discoverWork layout phase', () => {
-    const buildResourceSpy = sandbox.spy(resources, 'buildResourceUnsafe_');
-    sandbox.stub(resources, 'schedule_');
+    const buildResourceSpy = env.sandbox.spy(resources, 'buildResourceUnsafe_');
+    env.sandbox.stub(resources, 'schedule_');
     resources.documentReady_ = true;
     // Emulates a resource not building.
-    resource1.element.isBuilt = sandbox.stub().returns(false);
+    resource1.element.isBuilt = env.sandbox.stub().returns(false);
     resource2.element.idleRenderOutsideViewport = () => false;
     resource1.state_ = ResourceState.NOT_BUILT;
-    resource1.build = sandbox.spy();
+    resource1.build = env.sandbox.spy();
 
     resources.discoverWork_();
 
@@ -1184,7 +1181,7 @@ describes.realWin('Resources discoverWork', {amp: true}, env => {
       resources.documentReady_ = true;
       resources.firstPassAfterDocumentReady_ = true;
 
-      const passCallback = sandbox.spy();
+      const passCallback = env.sandbox.spy();
       resources.onNextPass(passCallback);
 
       resources.doPass();
@@ -1211,12 +1208,15 @@ describes.realWin(
     beforeEach(() => {
       win = env.win;
       resources = win.__AMP_SERVICES.resources.obj;
-      viewerSendMessageStub = sandbox.stub(resources.viewer_, 'sendMessage');
-      viewportContentHeightChangedStub = sandbox.stub(
+      viewerSendMessageStub = env.sandbox.stub(
+        resources.viewer_,
+        'sendMessage'
+      );
+      viewportContentHeightChangedStub = env.sandbox.stub(
         resources.viewport_,
         'contentHeightChanged'
       );
-      sandbox.stub(resources.vsync_, 'run').callsFake(task => {
+      env.sandbox.stub(resources.vsync_, 'run').callsFake(task => {
         task.measure({});
       });
     });
@@ -1229,9 +1229,11 @@ describes.realWin(
     });
 
     it('should send contentHeight to viewer if height was changed', () => {
-      sandbox.stub(resources.viewport_, 'getContentHeight').callsFake(() => {
-        return 200;
-      });
+      env.sandbox
+        .stub(resources.viewport_, 'getContentHeight')
+        .callsFake(() => {
+          return 200;
+        });
       resources.maybeChangeHeight_ = true;
 
       resources.doPass();
@@ -1258,9 +1260,11 @@ describes.realWin(
     });
 
     it('should send contentHeight to viewer if viewport resizes', () => {
-      sandbox.stub(resources.viewport_, 'getContentHeight').callsFake(() => {
-        return 200;
-      });
+      env.sandbox
+        .stub(resources.viewport_, 'getContentHeight')
+        .callsFake(() => {
+          return 200;
+        });
       resources.viewport_.changed_(/* relayoutAll */ true, /* velocity */ 0);
       resources.doPass();
 
@@ -1294,7 +1298,7 @@ describe('Resources changeSize', () => {
       getBoundingClientRect: () => rect,
       applySizesAndMediaQuery: () => {},
       layoutCallback: () => Promise.resolve(),
-      viewportCallback: sandbox.spy(),
+      viewportCallback: window.sandbox.spy(),
       prerenderAllowed: () => true,
       renderOutsideViewport: () => false,
       unlayoutCallback: () => true,
@@ -1303,7 +1307,7 @@ describe('Resources changeSize', () => {
       isRelayoutNeeded: () => true,
       contains: unused_otherElement => false,
       updateLayoutBox: () => {},
-      togglePlaceholder: () => sandbox.spy(),
+      togglePlaceholder: () => window.sandbox.spy(),
       overflowCallback: (
         unused_overflown,
         unused_requestedHeight,
@@ -1325,19 +1329,17 @@ describe('Resources changeSize', () => {
     resource.element['__AMP__RESOURCE'] = resource;
     resource.state_ = ResourceState.READY_FOR_LAYOUT;
     resource.initialLayoutBox_ = resource.layoutBox_ = rect;
-    resource.changeSize = sandbox.spy();
+    resource.changeSize = window.sandbox.spy();
     return resource;
   }
 
-  let sandbox;
   let clock;
   let viewportMock;
   let resources;
   let resource1, resource2;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox;
-    clock = sandbox.useFakeTimers();
+    clock = window.sandbox.useFakeTimers();
     resources = new ResourcesImpl(new AmpDocSingle(window));
     resources.isRuntimeOn_ = false;
     resources.win = {
@@ -1352,11 +1354,11 @@ describe('Resources changeSize', () => {
     };
     installPlatformService(resources.win);
     const platform = Services.platformFor(resources.win);
-    sandbox.stub(platform, 'isIe').returns(false);
+    window.sandbox.stub(platform, 'isIe').returns(false);
 
     installInputService(resources.win);
 
-    viewportMock = sandbox.mock(resources.viewport_);
+    viewportMock = window.sandbox.mock(resources.viewport_);
 
     resource1 = createResource(1, layoutRectLtwh(10, 10, 100, 100));
     resource2 = createResource(2, layoutRectLtwh(10, 1010, 100, 100));
@@ -1365,7 +1367,6 @@ describe('Resources changeSize', () => {
 
   afterEach(() => {
     viewportMock.verify();
-    sandbox.restore();
   });
 
   it('should schedule separate requests', () => {
@@ -1585,8 +1586,8 @@ describe('Resources changeSize', () => {
 
   it('should measure non-measured elements', () => {
     resource1.initialLayoutBox_ = null;
-    resource1.measure = sandbox.spy();
-    resource2.measure = sandbox.spy();
+    resource1.measure = window.sandbox.spy();
+    resource2.measure = window.sandbox.spy();
 
     resources.scheduleChangeSize_(
       resource1,
@@ -1628,7 +1629,7 @@ describe('Resources changeSize', () => {
     let viewportRect;
 
     beforeEach(() => {
-      overflowCallbackSpy = sandbox.spy();
+      overflowCallbackSpy = window.sandbox.spy();
       resource1.element.overflowCallback = overflowCallbackSpy;
 
       viewportRect = {top: 2, left: 0, right: 100, bottom: 200, height: 200};
@@ -1643,12 +1644,12 @@ describe('Resources changeSize', () => {
         bottom: 50,
         height: 50,
       };
-      vsyncSpy = sandbox.stub(resources.vsync_, 'run');
+      vsyncSpy = window.sandbox.stub(resources.vsync_, 'run');
       resources.visible_ = true;
     });
 
     it('should NOT change size when height is unchanged', () => {
-      const callback = sandbox.spy();
+      const callback = window.sandbox.spy();
       resource1.layoutBox_ = {
         top: 10,
         left: 0,
@@ -1673,7 +1674,7 @@ describe('Resources changeSize', () => {
     });
 
     it('should NOT change size when height and margins are unchanged', () => {
-      const callback = sandbox.spy();
+      const callback = window.sandbox.spy();
       resource1.layoutBox_ = {
         top: 10,
         left: 0,
@@ -1709,7 +1710,7 @@ describe('Resources changeSize', () => {
     });
 
     it('should change size when margins but not height changed', () => {
-      const callback = sandbox.spy();
+      const callback = window.sandbox.spy();
       resource1.layoutBox_ = {
         top: 10,
         left: 0,
@@ -1762,7 +1763,7 @@ describe('Resources changeSize', () => {
       .skipSafari()
       .run('should change size when document is invisible', () => {
         resources.visible_ = false;
-        sandbox
+        window.sandbox
           .stub(resources.ampdoc, 'getVisibilityState')
           .returns(VisibilityState.PRERENDER);
         resources.scheduleChangeSize_(
@@ -1942,7 +1943,7 @@ describe('Resources changeSize', () => {
           .returns(10000)
           .atLeast(1);
 
-        const callback = sandbox.spy();
+        const callback = window.sandbox.spy();
         resource1.layoutBox_ = {
           top: 100,
           left: 0,
@@ -2730,14 +2731,14 @@ describes.realWin('Resources mutateElement and collapse', {amp: true}, env => {
     element.getBoundingClientRect = () => rect;
     element.applySizesAndMediaQuery = () => {};
     element.layoutCallback = () => Promise.resolve();
-    element.viewportCallback = sandbox.spy();
+    element.viewportCallback = env.sandbox.spy();
     element.prerenderAllowed = () => true;
     element.renderOutsideViewport = () => true;
     element.isRelayoutNeeded = () => true;
     element.pauseCallback = () => {};
     element.unlayoutCallback = () => true;
     element.unlayoutOnPause = () => true;
-    element.togglePlaceholder = () => sandbox.spy();
+    element.togglePlaceholder = () => env.sandbox.spy();
 
     env.win.document.body.appendChild(element);
     return element;
@@ -2752,12 +2753,11 @@ describes.realWin('Resources mutateElement and collapse', {amp: true}, env => {
     resource.element['__AMP__RESOURCE'] = resource;
     resource.state_ = ResourceState.READY_FOR_LAYOUT;
     resource.layoutBox_ = rect;
-    resource.changeSize = sandbox.spy();
-    resource.completeCollapse = sandbox.spy();
+    resource.changeSize = env.sandbox.spy();
+    resource.completeCollapse = env.sandbox.spy();
     return resource;
   }
 
-  let sandbox;
   let viewportMock;
   let resources;
   let resource1, resource2;
@@ -2766,10 +2766,9 @@ describes.realWin('Resources mutateElement and collapse', {amp: true}, env => {
   let resource1RequestMeasureStub, resource2RequestMeasureStub;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox;
     resources = new ResourcesImpl(env.ampdoc);
     resources.isRuntimeOn_ = false;
-    viewportMock = sandbox.mock(resources.viewport_);
+    viewportMock = env.sandbox.mock(resources.viewport_);
     resources.vsync_ = {
       mutate: callback => callback(),
       measure: callback => callback(),
@@ -2793,15 +2792,15 @@ describes.realWin('Resources mutateElement and collapse', {amp: true}, env => {
         }
       },
     };
-    relayoutTopStub = sandbox.stub(resources, 'setRelayoutTop_');
-    sandbox.stub(resources, 'schedulePass');
+    relayoutTopStub = env.sandbox.stub(resources, 'setRelayoutTop_');
+    env.sandbox.stub(resources, 'schedulePass');
 
     resource1 = createResource(1, layoutRectLtwh(10, 10, 100, 100));
     resource2 = createResource(2, layoutRectLtwh(10, 1010, 100, 100));
     resources.owners_ = [resource1, resource2];
 
-    resource1RequestMeasureStub = sandbox.stub(resource1, 'requestMeasure');
-    resource2RequestMeasureStub = sandbox.stub(resource2, 'requestMeasure');
+    resource1RequestMeasureStub = env.sandbox.stub(resource1, 'requestMeasure');
+    resource2RequestMeasureStub = env.sandbox.stub(resource2, 'requestMeasure');
 
     parent1 = createElement(
       layoutRectLtwh(10, 10, 100, 100),
@@ -2826,11 +2825,10 @@ describes.realWin('Resources mutateElement and collapse', {amp: true}, env => {
 
   afterEach(() => {
     viewportMock.verify();
-    sandbox.restore();
   });
 
   it('should mutate from visible to invisible', () => {
-    const mutateSpy = sandbox.spy();
+    const mutateSpy = env.sandbox.spy();
     const promise = resources.mutateElement(parent1, () => {
       parent1.getBoundingClientRect = () => layoutRectLtwh(0, 0, 0, 0);
       mutateSpy();
@@ -2845,7 +2843,7 @@ describes.realWin('Resources mutateElement and collapse', {amp: true}, env => {
   });
 
   it('should mutate from visible to invisible on itself', () => {
-    const mutateSpy = sandbox.spy();
+    const mutateSpy = env.sandbox.spy();
     const promise = resources.mutateElement(resource1.element, () => {
       resource1.element.getBoundingClientRect = () =>
         layoutRectLtwh(0, 0, 0, 0);
@@ -2861,7 +2859,7 @@ describes.realWin('Resources mutateElement and collapse', {amp: true}, env => {
   });
 
   it('should mutate from invisible to visible', () => {
-    const mutateSpy = sandbox.spy();
+    const mutateSpy = env.sandbox.spy();
     parent1.getBoundingClientRect = () => layoutRectLtwh(0, 0, 0, 0);
     const promise = resources.mutateElement(parent1, () => {
       parent1.getBoundingClientRect = () => layoutRectLtwh(10, 10, 100, 100);
@@ -2877,7 +2875,7 @@ describes.realWin('Resources mutateElement and collapse', {amp: true}, env => {
   });
 
   it('should mutate from visible to visible', () => {
-    const mutateSpy = sandbox.spy();
+    const mutateSpy = env.sandbox.spy();
     parent1.getBoundingClientRect = () => layoutRectLtwh(10, 10, 100, 100);
     const promise = resources.mutateElement(parent1, () => {
       parent1.getBoundingClientRect = () => layoutRectLtwh(10, 1010, 100, 100);
@@ -2900,7 +2898,7 @@ describes.realWin('Resources mutateElement and collapse', {amp: true}, env => {
     // When attemptChangeSize succeed, resources manager will measure the new
     // scrollHeight, and we need to make sure the newScrollHeight is measured
     // after setting element display:none
-    sandbox.stub(resources.viewport_, 'getRect').callsFake(() => {
+    env.sandbox.stub(resources.viewport_, 'getRect').callsFake(() => {
       return {
         top: 1500,
         bottom: 1800,
@@ -2915,7 +2913,7 @@ describes.realWin('Resources mutateElement and collapse', {amp: true}, env => {
       promiseResolve = resolve;
     });
     let index = 0;
-    sandbox.stub(resources.viewport_, 'getScrollHeight').callsFake(() => {
+    env.sandbox.stub(resources.viewport_, 'getScrollHeight').callsFake(() => {
       // In change element size above viewport path, getScrollHeight will be
       // called twice. And we care that the last measurement is correct,
       // which requires it to be measured after element dispaly set to none.
@@ -2942,7 +2940,7 @@ describes.realWin('Resources mutateElement and collapse', {amp: true}, env => {
   });
 
   it('attemptCollapse should complete collapse if resize succeed', () => {
-    sandbox
+    env.sandbox
       .stub(resources, 'scheduleChangeSize_')
       .callsFake(
         (resource, newHeight, newWidth, newMargins, event, force, callback) => {
@@ -2954,7 +2952,7 @@ describes.realWin('Resources mutateElement and collapse', {amp: true}, env => {
   });
 
   it('attemptCollapse should NOT complete collapse if resize fail', () => {
-    sandbox
+    env.sandbox
       .stub(resources, 'scheduleChangeSize_')
       .callsFake(
         (resource, newHeight, newWidth, newMargins, event, force, callback) => {
@@ -3020,7 +3018,7 @@ describes.fakeWin('Resources.add/upgrade/remove', {amp: true}, env => {
         return signals;
       },
     };
-    element.build = sandbox.stub().returns(Promise.resolve());
+    element.build = env.sandbox.stub().returns(Promise.resolve());
     return element;
   }
 
@@ -3034,7 +3032,7 @@ describes.fakeWin('Resources.add/upgrade/remove', {amp: true}, env => {
 
   function stubBuild(resource) {
     const origBuild = resource.build;
-    sandbox.stub(resource, 'build').callsFake(() => {
+    env.sandbox.stub(resource, 'build').callsFake(() => {
       resource.buildPromise = origBuild.call(resource);
       return resource.buildPromise;
     });
@@ -3043,7 +3041,7 @@ describes.fakeWin('Resources.add/upgrade/remove', {amp: true}, env => {
 
   beforeEach(() => {
     const infPromise = new Promise(() => {});
-    sandbox.stub(env.ampdoc, 'whenReady').callsFake(() => infPromise);
+    env.sandbox.stub(env.ampdoc, 'whenReady').callsFake(() => infPromise);
     resources = new ResourcesImpl(env.ampdoc);
     resources.isBuildOn_ = true;
     resources.pendingBuildResources_ = [];
@@ -3055,10 +3053,8 @@ describes.fakeWin('Resources.add/upgrade/remove', {amp: true}, env => {
     resource2 = child2['__AMP__RESOURCE'];
   });
 
-  afterEach(() => {});
-
   it('should enforce that viewport is ready for first add', () => {
-    const ensureViewportReady = sandbox.stub(
+    const ensureViewportReady = env.sandbox.stub(
       resources.viewport_,
       'ensureReadyForElements'
     );
@@ -3071,7 +3067,7 @@ describes.fakeWin('Resources.add/upgrade/remove', {amp: true}, env => {
   });
 
   it('should build elements immediately if the document is ready', () => {
-    const schedulePassStub = sandbox.stub(resources, 'schedulePass');
+    const schedulePassStub = env.sandbox.stub(resources, 'schedulePass');
     child1.isBuilt = () => false;
     child2.isBuilt = () => false;
     resources.documentReady_ = false;
@@ -3093,9 +3089,9 @@ describes.fakeWin('Resources.add/upgrade/remove', {amp: true}, env => {
   it.configure().skipSafari(
     'should not schedule pass when immediate build fails',
     () => {
-      const schedulePassStub = sandbox.stub(resources, 'schedulePass');
+      const schedulePassStub = env.sandbox.stub(resources, 'schedulePass');
       child1.isBuilt = () => false;
-      const child1BuildSpy = sandbox.spy();
+      const child1BuildSpy = env.sandbox.spy();
       child1.build = () => {
         // Emulate an error happening during an element build.
         child1BuildSpy();
@@ -3125,7 +3121,7 @@ describes.fakeWin('Resources.add/upgrade/remove', {amp: true}, env => {
     () => {
       child1.isBuilt = () => false;
       child2.isBuilt = () => false;
-      resources.buildReadyResources_ = sandbox.spy();
+      resources.buildReadyResources_ = env.sandbox.spy();
       resources.documentReady_ = false;
       resources.add(child1);
       resources.upgraded(child1);
@@ -3149,7 +3145,7 @@ describes.fakeWin('Resources.add/upgrade/remove', {amp: true}, env => {
     let schedulePassStub;
 
     beforeEach(() => {
-      schedulePassStub = sandbox.stub(resources, 'schedulePass');
+      schedulePassStub = env.sandbox.stub(resources, 'schedulePass');
       resources.isBuildOn_ = true;
       resources.documentReady_ = false;
       resource1 = stubBuild(resource1);
@@ -3209,7 +3205,7 @@ describes.fakeWin('Resources.add/upgrade/remove', {amp: true}, env => {
 
       child1.parentNode = parent;
       parent.nextSibling = true;
-      sandbox.stub(resources.ampdoc, 'getRootNode').callsFake(() => parent);
+      env.sandbox.stub(resources.ampdoc, 'getRootNode').callsFake(() => parent);
       resources.buildReadyResources_();
       expect(child1.build.called).to.be.false;
       expect(resources.pendingBuildResources_.length).to.be.equal(1);
@@ -3226,7 +3222,7 @@ describes.fakeWin('Resources.add/upgrade/remove', {amp: true}, env => {
       const newChild = createElementWithResource(3)[0];
       newChild.nextSibling = true;
       const newResource = newChild['__AMP__RESOURCE'];
-      const child1BuildSpy = sandbox.spy();
+      const child1BuildSpy = env.sandbox.spy();
       child1.nextSibling = child2;
       child1.build = () => {
         // Simulate parent elements adding children elements to simulate
@@ -3263,7 +3259,7 @@ describes.fakeWin('Resources.add/upgrade/remove', {amp: true}, env => {
           resource1,
           resource2,
         ];
-        const child1BuildSpy = sandbox.spy();
+        const child1BuildSpy = env.sandbox.spy();
         child1.build = () => {
           // Emulate an error happening during an element build.
           child1BuildSpy();
@@ -3303,7 +3299,7 @@ describes.fakeWin('Resources.add/upgrade/remove', {amp: true}, env => {
       () => {
         resources.documentReady_ = true;
         resources.pendingBuildResources_ = [resource1];
-        const child1BuildSpy = sandbox.spy();
+        const child1BuildSpy = env.sandbox.spy();
         child1.build = () => {
           // Emulate an error happening during an element build.
           child1BuildSpy();
@@ -3332,8 +3328,8 @@ describes.fakeWin('Resources.add/upgrade/remove', {amp: true}, env => {
       child1.isBuilt = () => true;
       resources.add(child1);
       const resource = child1['__AMP__RESOURCE'];
-      const pauseOnRemoveStub = sandbox.stub(resource, 'pauseOnRemove');
-      const disconnectStub = sandbox.stub(resource, 'disconnect');
+      const pauseOnRemoveStub = env.sandbox.stub(resource, 'pauseOnRemove');
+      const disconnectStub = env.sandbox.stub(resource, 'disconnect');
       resources.remove(child1);
       expect(resources.get()).to.not.contain(resource);
       expect(pauseOnRemoveStub).to.be.calledOnce;
@@ -3346,7 +3342,7 @@ describes.fakeWin('Resources.add/upgrade/remove', {amp: true}, env => {
     let resource;
 
     beforeEach(() => {
-      scheduleBuildStub = sandbox.stub(
+      scheduleBuildStub = env.sandbox.stub(
         resources,
         'buildOrScheduleBuildForResource_'
       );

--- a/test/unit/test-runtime.js
+++ b/test/unit/test-runtime.js
@@ -42,7 +42,6 @@ describes.fakeWin(
   },
   env => {
     let win;
-    let sandbox;
     let clock;
     let ampdocService;
     let ampdocServiceMock;
@@ -50,8 +49,7 @@ describes.fakeWin(
 
     beforeEach(() => {
       win = env.win;
-      sandbox = env.sandbox;
-      clock = sandbox.useFakeTimers();
+      clock = env.sandbox.useFakeTimers();
       extensionElementIndex = 0;
       ampdocService = {
         isSingleDoc: () => true,
@@ -59,7 +57,7 @@ describes.fakeWin(
         getAmpDoc: () => null,
         installShadowDoc_: () => null,
       };
-      ampdocServiceMock = sandbox.mock(ampdocService);
+      ampdocServiceMock = env.sandbox.mock(ampdocService);
       win.AMP = [];
       win.__AMP_SERVICES = {
         ampdoc: {obj: ampdocService},
@@ -124,21 +122,21 @@ describes.fakeWin(
 
     it('should NOT set cursor:pointer on document element on non-IOS', () => {
       const platform = Services.platformFor(win);
-      sandbox.stub(platform, 'isIos').returns(false);
+      env.sandbox.stub(platform, 'isIos').returns(false);
       adopt(win);
       expect(win.document.documentElement.style.cursor).to.not.be.ok;
     });
 
     it('should set cursor:pointer on document element on IOS', () => {
       const platform = Services.platformFor(win);
-      sandbox.stub(platform, 'isIos').returns(true);
+      env.sandbox.stub(platform, 'isIos').returns(true);
       adopt(win);
       expect(win.document.documentElement.style.cursor).to.equal('pointer');
     });
 
     it('should set cursor:pointer on IOS in shadow-doc', () => {
       const platform = Services.platformFor(win);
-      sandbox.stub(platform, 'isIos').returns(true);
+      env.sandbox.stub(platform, 'isIos').returns(true);
       adoptShadowMode(win);
       expect(win.document.documentElement.style.cursor).to.equal('pointer');
     });
@@ -208,7 +206,7 @@ describes.fakeWin(
       // JS executing before the rest of the doc has been parsed.
       const {body} = win.document;
       let accessedOnce = false;
-      sandbox.defineProperty(win.document, 'body', {
+      env.sandbox.defineProperty(win.document, 'body', {
         get: () => {
           if (accessedOnce) {
             return body;
@@ -476,7 +474,9 @@ describes.fakeWin(
       const bodyPromise = new Promise(resolve => {
         bodyResolver = resolve;
       });
-      sandbox.stub(dom, 'waitForBodyOpenPromise').callsFake(() => bodyPromise);
+      env.sandbox
+        .stub(dom, 'waitForBodyOpenPromise')
+        .callsFake(() => bodyPromise);
 
       function skipMicro() {
         return Promise.resolve().then(() => Promise.resolve());
@@ -554,7 +554,9 @@ describes.fakeWin(
       const bodyPromise = new Promise(resolve => {
         bodyResolver = resolve;
       });
-      sandbox.stub(dom, 'waitForBodyOpenPromise').callsFake(() => bodyPromise);
+      env.sandbox
+        .stub(dom, 'waitForBodyOpenPromise')
+        .callsFake(() => bodyPromise);
 
       function skipMicro() {
         return Promise.resolve().then(() => Promise.resolve());
@@ -701,7 +703,10 @@ describes.fakeWin(
       it('should register element without CSS', function*() {
         const ampdoc = ampdocService.getSingleDoc();
         const servicePromise = getServicePromise(win, 'amp-ext');
-        const installStylesStub = sandbox.stub(styles, 'installStylesForDoc');
+        const installStylesStub = env.sandbox.stub(
+          styles,
+          'installStylesForDoc'
+        );
 
         ampdoc.declareExtension('amp-ext');
         win.AMP.push({
@@ -739,7 +744,7 @@ describes.fakeWin(
         const ampdoc = Services.ampdocServiceFor(win).getSingleDoc();
         const servicePromise = getServicePromise(win, 'amp-ext');
         let installStylesCallback;
-        const installStylesStub = sandbox
+        const installStylesStub = env.sandbox
           .stub(styles, 'installStylesForDoc')
           .callsFake((doc, cssText, cb) => {
             installStylesCallback = cb;
@@ -872,7 +877,10 @@ describes.fakeWin(
 
       it('should register element without CSS', function*() {
         const servicePromise = getServicePromise(win, 'amp-ext');
-        const installStylesStub = sandbox.stub(styles, 'installStylesForDoc');
+        const installStylesStub = env.sandbox.stub(
+          styles,
+          'installStylesForDoc'
+        );
 
         win.AMP.push({
           n: 'amp-ext',
@@ -915,7 +923,7 @@ describes.fakeWin(
       it('should register element with CSS', function*() {
         const servicePromise = getServicePromise(win, 'amp-ext');
         let installStylesCallback;
-        const installStylesStub = sandbox
+        const installStylesStub = env.sandbox
           .stub(styles, 'installStylesForDoc')
           .callsFake((doc, cssText, cb) => {
             installStylesCallback = cb;
@@ -1012,7 +1020,7 @@ describes.realWin(
     beforeEach(() => {
       win = env.win;
       extensions = env.extensions;
-      extensionsMock = sandbox.mock(extensions);
+      extensionsMock = env.sandbox.mock(extensions);
       ampdocService = env.ampdocService;
     });
 
@@ -1030,21 +1038,21 @@ describes.realWin(
 
       beforeEach(() => {
         deactivateChunking();
-        clock = sandbox.useFakeTimers();
+        clock = env.sandbox.useFakeTimers();
         hostElement = win.document.createElement('div');
         importDoc = win.document.implementation.createHTMLDocument('');
         importDoc.body.appendChild(win.document.createElement('child'));
         createShadowRoot(hostElement);
         ampdoc = null;
 
-        sandbox
+        env.sandbox
           .stub(ampdocService, 'installShadowDoc')
           .callsFake((url, shadowRoot, options) => {
             expect(url).to.equal(docUrl);
             expect(shadowRoot).to.equal(getShadowRoot(hostElement));
             return (ampdoc = new AmpDocShadow(win, url, shadowRoot, options));
           });
-        sandbox.stub(ampdocService, 'getAmpDoc').callsFake(node => {
+        env.sandbox.stub(ampdocService, 'getAmpDoc').callsFake(node => {
           expect(node).to.equal(getShadowRoot(hostElement));
           return ampdoc;
         });
@@ -1364,7 +1372,7 @@ describes.realWin(
         expect(amp.close).to.be.a('function');
         expect(ampdoc.getVisibilityState()).to.equal('visible');
 
-        viewer.dispose = sandbox.spy();
+        viewer.dispose = env.sandbox.spy();
         amp.close().then(() => {
           expect(ampdoc.getVisibilityState()).to.equal('inactive');
           expect(viewer.dispose).to.be.calledOnce;
@@ -1397,14 +1405,14 @@ describes.realWin(
           createShadowRoot(hostElement);
           ampdoc = null;
 
-          sandbox
+          env.sandbox
             .stub(ampdocService, 'installShadowDoc')
             .callsFake((url, shadowRoot, options) => {
               expect(url).to.equal(docUrl);
               expect(shadowRoot).to.equal(getShadowRoot(hostElement));
               return (ampdoc = new AmpDocShadow(win, url, shadowRoot, options));
             });
-          sandbox.stub(ampdocService, 'getAmpDoc').callsFake(node => {
+          env.sandbox.stub(ampdocService, 'getAmpDoc').callsFake(node => {
             expect(node).to.equal(getShadowRoot(hostElement));
             return ampdoc;
           });
@@ -1766,7 +1774,7 @@ describes.realWin(
             expect(shadowDoc.close).to.be.a('function');
             expect(ampdoc.getVisibilityState()).to.equal('visible');
 
-            viewer.dispose = sandbox.spy();
+            viewer.dispose = env.sandbox.spy();
             shadowDoc.close().then(() => {
               expect(ampdoc.getVisibilityState()).to.equal('inactive');
               expect(viewer.dispose).to.be.calledOnce;
@@ -1786,13 +1794,13 @@ describes.realWin(
         let ampdocServiceMock;
 
         beforeEach(() => {
-          ampdocServiceMock = sandbox.mock(env.ampdocService);
+          ampdocServiceMock = env.sandbox.mock(env.ampdocService);
 
           if (isStubbedDocumentContains) {
             // Some browsers implement document.contains wrong, and it returns
             // `false` even when this is incorrect. Repeat these tests with the
             // faulty implementation.
-            sandbox.stub(win.document, 'contains').returns(false);
+            env.sandbox.stub(win.document, 'contains').returns(false);
           }
 
           doc1 = attach('https://example.org/doc1');
@@ -1815,23 +1823,23 @@ describes.realWin(
             .expects('installShadowDoc')
             .withArgs(
               docUrl,
-              sinon.match(arg => arg == getShadowRoot(hostElement))
+              env.sandbox.match(arg => arg == getShadowRoot(hostElement))
             )
             .returns(ampdoc)
             .atLeast(0);
           ampdocServiceMock
             .expects('getAmpDoc')
             .withExactArgs(
-              sinon.match(arg => arg == getShadowRoot(hostElement))
+              env.sandbox.match(arg => arg == getShadowRoot(hostElement))
             )
             .returns(ampdoc)
             .atLeast(0);
 
           const amp = win.AMP.attachShadowDoc(hostElement, importDoc, docUrl);
           const viewer = getServiceForDoc(ampdoc, 'viewer');
-          const broadcastReceived = sandbox.spy();
+          const broadcastReceived = env.sandbox.spy();
           viewer.onBroadcast(broadcastReceived);
-          const onMessage = sandbox.stub();
+          const onMessage = env.sandbox.stub();
           amp.onMessage(function(eventType, data) {
             if (eventType == 'ignore') {
               return Promise.resolve();

--- a/test/unit/test-service.js
+++ b/test/unit/test-service.js
@@ -39,23 +39,13 @@ import {loadPromise} from '../../src/event-helper';
 import {toggleAmpdocFieForTesting} from '../../src/ampdoc-fie';
 
 describe('service', () => {
-  let sandbox;
-
-  beforeEach(() => {
-    sandbox = sinon.sandbox;
-  });
-
-  afterEach(() => {
-    sandbox.restore();
-  });
-
   describe('disposable interface', () => {
     let disposable;
     let nonDisposable;
 
     beforeEach(() => {
       nonDisposable = {};
-      disposable = {dispose: sandbox.spy()};
+      disposable = {dispose: window.sandbox.spy()};
     });
 
     it('should test disposable interface', () => {
@@ -85,7 +75,7 @@ describe('service', () => {
           this.count = ++count;
         }
       };
-      factory = sandbox.spy(() => {
+      factory = window.sandbox.spy(() => {
         return new Class();
       });
       resetServiceForTesting(window, 'a');
@@ -243,7 +233,7 @@ describe('service', () => {
           this.count = ++count;
         }
       };
-      factory = sandbox.spy(function() {
+      factory = window.sandbox.spy(function() {
         return new Class();
       });
       windowApi = {
@@ -255,7 +245,7 @@ describe('service', () => {
         isSingleDoc: () => false,
         win: windowApi,
       };
-      ampdocMock = sandbox.mock(ampdoc);
+      ampdocMock = window.sandbox.mock(ampdoc);
       ampdocServiceApi = {getAmpDoc: () => ampdoc};
       registerServiceBuilder(windowApi, 'ampdoc', function() {
         return ampdocServiceApi;
@@ -451,7 +441,7 @@ describe('service', () => {
     it('should dispose disposable services', () => {
       const disposableFactory = function() {
         return {
-          dispose: sandbox.spy(),
+          dispose: window.sandbox.spy(),
         };
       };
       registerServiceBuilderForDoc(node, 'a', disposableFactory);
@@ -459,7 +449,7 @@ describe('service', () => {
 
       registerServiceBuilderForDoc(node, 'b', function() {
         return {
-          dispose: sandbox.stub().throws('intentional'),
+          dispose: window.sandbox.stub().throws('intentional'),
         };
       });
       const disposableWithError = getServiceForDoc(node, 'b');
@@ -573,7 +563,7 @@ describe('service', () => {
           isSingleDoc: () => false,
           win: windowApi,
         };
-        sandbox.stub(ampdocServiceApi, 'getAmpDoc').callsFake(node => {
+        window.sandbox.stub(ampdocServiceApi, 'getAmpDoc').callsFake(node => {
           if (node == childWinNode || node == grandChildWinNode) {
             return childAmpdoc;
           }
@@ -599,7 +589,7 @@ describe('service', () => {
           win: windowApi,
         };
         registerServiceBuilderForDoc(childAmpdoc, 'c', factory);
-        sandbox.stub(ampdocServiceApi, 'getAmpDoc').callsFake(node => {
+        window.sandbox.stub(ampdocServiceApi, 'getAmpDoc').callsFake(node => {
           if (node == childWinNode || node == grandChildWinNode) {
             return childAmpdoc;
           }
@@ -663,7 +653,7 @@ describe('service', () => {
           },
         };
         nonEmbeddable = {};
-        embeddable = {installInEmbedWindow: sandbox.spy()};
+        embeddable = {installInEmbedWindow: window.sandbox.spy()};
         registerServiceBuilderForDoc(ampdoc, 'embeddable', function() {
           return embeddable;
         });

--- a/test/unit/test-shadow-embed.js
+++ b/test/unit/test-shadow-embed.js
@@ -312,7 +312,7 @@ describes.sandboxed('shadow-embed', {}, () => {
 
     beforeEach(() => {
       setShadowDomStreamingSupportedForTesting(undefined);
-      createHTMLDocumentSpy = sandbox.spy();
+      createHTMLDocumentSpy = window.sandbox.spy();
       isFirefox = false;
       const platform = {
         isFirefox: () => isFirefox,
@@ -374,8 +374,8 @@ describes.sandboxed('shadow-embed', {}, () => {
         beforeEach(() => {
           win = env.win;
           writer = new ShadowDomWriterStreamer(win);
-          onBodySpy = sandbox.spy();
-          onBodyChunkSpy = sandbox.spy();
+          onBodySpy = env.sandbox.spy();
+          onBodyChunkSpy = env.sandbox.spy();
           onBodyPromise = new Promise(resolve => {
             writer.onBody(parsedDoc => {
               resolve(parsedDoc.body);
@@ -503,8 +503,8 @@ describes.sandboxed('shadow-embed', {}, () => {
     beforeEach(() => {
       win = env.win;
       writer = new ShadowDomWriterBulk(win);
-      onBodySpy = sandbox.spy();
-      onBodyChunkSpy = sandbox.spy();
+      onBodySpy = env.sandbox.spy();
+      onBodyChunkSpy = env.sandbox.spy();
       onBodyPromise = new Promise(resolve => {
         writer.onBody(parsedDoc => {
           resolve(parsedDoc.body);

--- a/test/unit/test-ssr-template-helper.js
+++ b/test/unit/test-ssr-template-helper.js
@@ -25,7 +25,6 @@ describes.fakeWin(
   env => {
     let ampdoc;
     let hasCapabilityStub;
-    let sandbox;
     let ssrTemplateHelper;
     const sourceComponent = 'amp-list';
     let maybeFindTemplateStub;
@@ -35,12 +34,11 @@ describes.fakeWin(
 
     beforeEach(() => {
       ampdoc = env.ampdoc;
-      sandbox = sinon.sandbox;
       win = env.win;
       templates = Services.templatesFor(win);
       viewer = Services.viewerForDoc(ampdoc);
-      hasCapabilityStub = sandbox.stub(viewer, 'hasCapability');
-      maybeFindTemplateStub = sandbox.stub(templates, 'maybeFindTemplate');
+      hasCapabilityStub = env.sandbox.stub(viewer, 'hasCapability');
+      maybeFindTemplateStub = env.sandbox.stub(templates, 'maybeFindTemplate');
       ssrTemplateHelper = new SsrTemplateHelper(
         sourceComponent,
         viewer,
@@ -52,7 +50,6 @@ describes.fakeWin(
       win.document.documentElement.removeAttribute(
         'allow-viewer-render-template'
       );
-      sandbox.restore();
     });
 
     describe('isSupported', () => {
@@ -96,7 +93,7 @@ describes.fakeWin(
             'ampCors': true,
           },
         };
-        const sendMessage = sandbox.spy(viewer, 'sendMessageAwaitResponse');
+        const sendMessage = env.sandbox.spy(viewer, 'sendMessageAwaitResponse');
         maybeFindTemplateStub.returns(null);
         const templates = {
           successTemplate: {'innerHTML': '<div>much success</div>'},
@@ -142,15 +139,15 @@ describes.fakeWin(
           true
         );
         hasCapabilityStub.withArgs('viewerRenderTemplate').returns(true);
-        findAndSetHtmlForTemplate = sandbox.stub(
+        findAndSetHtmlForTemplate = env.sandbox.stub(
           templates,
           'findAndSetHtmlForTemplate'
         );
-        findAndRenderTemplate = sandbox.stub(
+        findAndRenderTemplate = env.sandbox.stub(
           templates,
           'findAndRenderTemplate'
         );
-        findAndRenderTemplateArray = sandbox.stub(
+        findAndRenderTemplateArray = env.sandbox.stub(
           templates,
           'findAndRenderTemplateArray'
         );

--- a/test/unit/test-standard-actions.js
+++ b/test/unit/test-standard-actions.js
@@ -29,7 +29,7 @@ import {setParentWindow} from '../../src/service';
 import {toggle} from '../../src/style';
 import {user} from '../../src/log';
 
-describes.sandboxed('StandardActions', {}, () => {
+describes.sandboxed('StandardActions', {}, env => {
   let standardActions;
   let mutateElementStub;
   let scrollStub;
@@ -42,19 +42,19 @@ describes.sandboxed('StandardActions', {}, () => {
   function createAmpElement() {
     const element = createElement();
     element.classList.add('i-amphtml-element');
-    element.collapse = sandbox.stub();
-    element.expand = sandbox.stub();
+    element.collapse = env.sandbox.stub();
+    element.expand = env.sandbox.stub();
     return element;
   }
 
   function stubMutate(methodName) {
-    return sandbox
+    return env.sandbox
       .stub(standardActions.resources_, methodName)
       .callsFake((unusedElement, mutator) => mutator());
   }
 
   function expectElementMutatedAsync(element) {
-    expect(mutateElementStub.withArgs(element, sinon.match.any)).to.be
+    expect(mutateElementStub.withArgs(element, env.sandbox.match.any)).to.be
       .calledOnce;
   }
 
@@ -107,15 +107,15 @@ describes.sandboxed('StandardActions', {}, () => {
   }
 
   function stubPlatformIsIos(isIos = true) {
-    sandbox.stub(Services, 'platformFor').returns({isIos: () => isIos});
+    env.sandbox.stub(Services, 'platformFor').returns({isIos: () => isIos});
   }
 
   beforeEach(() => {
     ampdoc = new AmpDocSingle(window);
-    sandbox.stub(AmpDocService.prototype, 'getAmpDoc').returns(ampdoc);
+    env.sandbox.stub(AmpDocService.prototype, 'getAmpDoc').returns(ampdoc);
     standardActions = new StandardActions(ampdoc);
     mutateElementStub = stubMutate('mutateElement');
-    scrollStub = sandbox.stub(
+    scrollStub = env.sandbox.stub(
       standardActions.viewport_,
       'animateScrollIntoView'
     );
@@ -263,7 +263,7 @@ describes.sandboxed('StandardActions', {}, () => {
           const node = html`
             <input autofocus />
           `;
-          node.focus = sandbox.spy();
+          node.focus = env.sandbox.spy();
 
           standardActions.handleShow_(trustedInvocation({node}));
 
@@ -278,7 +278,7 @@ describes.sandboxed('StandardActions', {}, () => {
           const node = html`
             <input autofocus />
           `;
-          node.focus = sandbox.spy();
+          node.focus = env.sandbox.spy();
 
           wrapper.firstElementChild.appendChild(node);
           standardActions.handleShow_(trustedInvocation({node: wrapper}));
@@ -291,7 +291,7 @@ describes.sandboxed('StandardActions', {}, () => {
           const node = html`
             <input />
           `;
-          node.focus = sandbox.spy();
+          node.focus = env.sandbox.spy();
 
           standardActions.handleShow_(trustedInvocation({node}));
 
@@ -306,7 +306,7 @@ describes.sandboxed('StandardActions', {}, () => {
         const node = html`
           <input autofocus />
         `;
-        node.focus = sandbox.spy();
+        node.focus = env.sandbox.spy();
 
         standardActions.handleShow_(trustedInvocation({node}));
 
@@ -323,7 +323,7 @@ describes.sandboxed('StandardActions', {}, () => {
         const node = html`
           <input autofocus />
         `;
-        node.focus = sandbox.spy();
+        node.focus = env.sandbox.spy();
 
         wrapper.firstElementChild.appendChild(node);
         standardActions.handleShow_(trustedInvocation({node: wrapper}));
@@ -336,7 +336,7 @@ describes.sandboxed('StandardActions', {}, () => {
         const node = html`
           <input />
         `;
-        node.focus = sandbox.spy();
+        node.focus = env.sandbox.spy();
 
         standardActions.handleShow_(trustedInvocation({node}));
 
@@ -578,7 +578,7 @@ describes.sandboxed('StandardActions', {}, () => {
     it('should handle normal element', () => {
       const element = createElement();
       const invocation = trustedInvocation({node: element});
-      const focusStub = sandbox.stub(element, 'focus');
+      const focusStub = env.sandbox.stub(element, 'focus');
       standardActions.handleFocus_(invocation);
       expect(focusStub).to.be.calledOnce;
     });
@@ -586,7 +586,7 @@ describes.sandboxed('StandardActions', {}, () => {
     it('should handle AmpElement', () => {
       const element = createAmpElement();
       const invocation = trustedInvocation({node: element});
-      const focusStub = sandbox.stub(element, 'focus');
+      const focusStub = env.sandbox.stub(element, 'focus');
       standardActions.handleFocus_(invocation);
       expect(focusStub).to.be.calledOnce;
     });
@@ -614,8 +614,8 @@ describes.sandboxed('StandardActions', {}, () => {
       let navigator;
 
       beforeEach(() => {
-        navigator = {navigateTo: sandbox.stub()};
-        sandbox.stub(Services, 'navigationForDoc').returns(navigator);
+        navigator = {navigateTo: env.sandbox.stub()};
+        env.sandbox.stub(Services, 'navigationForDoc').returns(navigator);
 
         // Fake ActionInvocation.
         invocation.method = 'navigateTo';
@@ -681,7 +681,7 @@ describes.sandboxed('StandardActions', {}, () => {
       );
 
       it('should check throwIfCannotNavigate() for AMP elements', function*() {
-        const userError = sandbox.stub(user(), 'error');
+        const userError = env.sandbox.stub(user(), 'error');
 
         invocation.caller.tagName = 'AMP-FOO';
 
@@ -729,16 +729,16 @@ describes.sandboxed('StandardActions', {}, () => {
       let winCloseStub;
 
       beforeEach(() => {
-        navigateToStub = sandbox
+        navigateToStub = env.sandbox
           .stub(standardActions, 'handleNavigateTo_')
           .returns(Promise.resolve());
 
-        closeOrNavigateToSpy = sandbox.spy(
+        closeOrNavigateToSpy = env.sandbox.spy(
           standardActions,
           'handleCloseOrNavigateTo_'
         );
 
-        winCloseStub = sandbox.stub(win, 'close');
+        winCloseStub = env.sandbox.stub(win, 'close');
         winCloseStub.callsFake(() => {
           win.closed = true;
         });
@@ -781,7 +781,7 @@ describes.sandboxed('StandardActions', {}, () => {
       it('should NOT close if in multi-doc', async () => {
         win.opener = {};
         win.parent = win;
-        sandbox.stub(ampdoc, 'isSingleDoc').returns(false);
+        env.sandbox.stub(ampdoc, 'isSingleDoc').returns(false);
         await standardActions.handleAmpTarget_(invocation);
         expect(winCloseStub).to.be.not.called;
       });
@@ -789,7 +789,7 @@ describes.sandboxed('StandardActions', {}, () => {
       it('should navigate if not allowed to close', async () => {
         win.opener = null;
         win.parent = win;
-        sandbox.stub(ampdoc, 'isSingleDoc').returns(false);
+        env.sandbox.stub(ampdoc, 'isSingleDoc').returns(false);
         await standardActions.handleAmpTarget_(invocation);
         expect(winCloseStub).to.be.not.called;
         expect(navigateToStub).to.be.called;
@@ -809,7 +809,7 @@ describes.sandboxed('StandardActions', {}, () => {
     it('should implement goBack', () => {
       installHistoryServiceForDoc(ampdoc);
       const history = Services.historyForDoc(ampdoc);
-      const goBackStub = sandbox.stub(history, 'goBack');
+      const goBackStub = env.sandbox.stub(history, 'goBack');
       invocation.method = 'goBack';
       standardActions.handleAmpTarget_(invocation);
       expect(goBackStub).to.be.calledOnce;
@@ -817,7 +817,7 @@ describes.sandboxed('StandardActions', {}, () => {
 
     it('should implement optoutOfCid', function*() {
       const cid = cidServiceForDocForTesting(ampdoc);
-      const optoutStub = sandbox.stub(cid, 'optOut');
+      const optoutStub = env.sandbox.stub(cid, 'optOut');
       invocation.method = 'optoutOfCid';
       standardActions.handleAmpTarget_(invocation);
       yield macroTask();
@@ -827,11 +827,11 @@ describes.sandboxed('StandardActions', {}, () => {
     it('should implement setState()', () => {
       const element = createElement();
 
-      const bind = {invoke: sandbox.stub()};
+      const bind = {invoke: env.sandbox.stub()};
       // Bind.invoke() doesn't actually resolve with a value,
       // but add one here to check that the promise is chained.
       bind.invoke.returns(Promise.resolve('set-state-complete'));
-      sandbox
+      env.sandbox
         .stub(Services, 'bindForDocOrNull')
         .withArgs(element)
         .returns(Promise.resolve(bind));
@@ -852,11 +852,11 @@ describes.sandboxed('StandardActions', {}, () => {
     it('should implement pushState()', () => {
       const element = createElement();
 
-      const bind = {invoke: sandbox.stub()};
+      const bind = {invoke: env.sandbox.stub()};
       // Bind.invoke() doesn't actually resolve with a value,
       // but add one here to check that the promise is chained.
       bind.invoke.returns(Promise.resolve('push-state-complete'));
-      sandbox
+      env.sandbox
         .stub(Services, 'bindForDocOrNull')
         .withArgs(element)
         .returns(Promise.resolve(bind));
@@ -878,7 +878,7 @@ describes.sandboxed('StandardActions', {}, () => {
       const windowApi = {
         print: () => {},
       };
-      const printStub = sandbox.stub(windowApi, 'print');
+      const printStub = env.sandbox.stub(windowApi, 'print');
 
       invocation.method = 'print';
       invocation.node = {
@@ -897,8 +897,10 @@ describes.sandboxed('StandardActions', {}, () => {
       };
       invocation.node = ampdoc;
       const element = createElement();
-      const elStub = sandbox.stub(ampdoc, 'getElementById').returns(element);
-      const scrollStub = sandbox
+      const elStub = env.sandbox
+        .stub(ampdoc, 'getElementById')
+        .returns(element);
+      const scrollStub = env.sandbox
         .stub(standardActions, 'handleScrollTo_')
         .returns('scrollToResponsePromise');
       const result = standardActions.handleAmpTarget_(invocation);
@@ -918,11 +920,11 @@ describes.sandboxed('StandardActions', {}, () => {
       setParentWindow(embedWin, window);
 
       embedActions = {
-        addGlobalTarget: sandbox.spy(),
-        addGlobalMethodHandler: sandbox.spy(),
+        addGlobalTarget: env.sandbox.spy(),
+        addGlobalMethodHandler: env.sandbox.spy(),
       };
       const embedElement = embedWin.document.documentElement;
-      sandbox
+      env.sandbox
         .stub(Services, 'actionServiceForDoc')
         .withArgs(embedElement)
         .returns(embedActions);
@@ -938,16 +940,19 @@ describes.sandboxed('StandardActions', {}, () => {
 
       // Global targets.
       expect(target).to.be.calledOnce;
-      expect(target).to.be.calledWith('AMP', sinon.match.func);
+      expect(target).to.be.calledWith('AMP', env.sandbox.match.func);
 
       // Global actions.
       expect(handler).to.have.callCount(6);
-      expect(handler).to.be.calledWith('hide', sinon.match.func);
-      expect(handler).to.be.calledWith('show', sinon.match.func);
-      expect(handler).to.be.calledWith('toggleVisibility', sinon.match.func);
-      expect(handler).to.be.calledWith('scrollTo', sinon.match.func);
-      expect(handler).to.be.calledWith('focus', sinon.match.func);
-      expect(handler).to.be.calledWith('toggleClass', sinon.match.func);
+      expect(handler).to.be.calledWith('hide', env.sandbox.match.func);
+      expect(handler).to.be.calledWith('show', env.sandbox.match.func);
+      expect(handler).to.be.calledWith(
+        'toggleVisibility',
+        env.sandbox.match.func
+      );
+      expect(handler).to.be.calledWith('scrollTo', env.sandbox.match.func);
+      expect(handler).to.be.calledWith('focus', env.sandbox.match.func);
+      expect(handler).to.be.calledWith('toggleClass', env.sandbox.match.func);
     });
   });
 });

--- a/test/unit/test-storage.js
+++ b/test/unit/test-storage.js
@@ -33,325 +33,332 @@ describes.sandboxed('Storage', {}, env => {
   let ampdoc;
   let viewerBroadcastHandler;
 
-  beforeEach(() => {
-    viewerBroadcastHandler = undefined;
-    viewer = {
-      onBroadcast: handler => {
-        viewerBroadcastHandler = handler;
-      },
-      broadcast: () => {},
-    };
-    viewerMock = env.sandbox.mock(viewer);
+  // TODO(amphtml, #25621): Cannot find atob / btoa on Safari on Sauce Labs.
+  describe
+    .configure()
+    .skipSafari()
+    .run('Storage', () => {
+      beforeEach(() => {
+        viewerBroadcastHandler = undefined;
+        viewer = {
+          onBroadcast: handler => {
+            viewerBroadcastHandler = handler;
+          },
+          broadcast: () => {},
+        };
+        viewerMock = env.sandbox.mock(viewer);
 
-    windowApi = {
-      document: {},
-      location: 'https://acme.com/document1',
-    };
-    ampdoc = new AmpDocSingle(windowApi);
+        windowApi = {
+          document: {},
+          location: 'https://acme.com/document1',
+        };
+        ampdoc = new AmpDocSingle(windowApi);
 
-    binding = {
-      loadBlob: () => {},
-      saveBlob: () => {},
-    };
-    bindingMock = env.sandbox.mock(binding);
+        binding = {
+          loadBlob: () => {},
+          saveBlob: () => {},
+        };
+        bindingMock = env.sandbox.mock(binding);
 
-    storage = new Storage(ampdoc, viewer, binding);
-    storage.start_();
-  });
-
-  function expectStorage(keyValues) {
-    const list = [];
-    for (const k in keyValues) {
-      list.push(
-        storage.get(k).then(value => {
-          const expectedValue = keyValues[k];
-          expect(value).to.equal(expectedValue, `For "${k}"`);
-        })
-      );
-    }
-    return Promise.all(list);
-  }
-
-  it('should configure store correctly', () => {
-    const store1 = new Store({});
-    store1.set('key1', 'value1');
-    store1.set('key2', 'value2');
-    bindingMock
-      .expects('loadBlob')
-      .withExactArgs('https://acme.com')
-      .returns(Promise.resolve(btoa(JSON.stringify(store1.obj))))
-      .once();
-    return storage
-      .get('key1')
-      .then(() => {
-        return storage.storePromise_;
-      })
-      .then(store => {
-        expect(store.maxValues_).to.equal(8);
+        storage = new Storage(ampdoc, viewer, binding);
+        storage.start_();
       });
-  });
 
-  it('should initialize empty store with prototype-less objects', () => {
-    bindingMock
-      .expects('loadBlob')
-      .withExactArgs('https://acme.com')
-      .returns(Promise.resolve(null))
-      .once();
-    return storage
-      .get('key1')
-      .then(() => {
-        return storage.storePromise_;
-      })
-      .then(store => {
-        expect(store.obj.__proto__).to.be.undefined;
-        expect(store.values_.__proto__).to.be.undefined;
-      });
-  });
-
-  it('should restore store with prototype-less objects', () => {
-    const store1 = new Store({});
-    store1.set('key1', 'value1');
-    store1.set('key2', 'value2');
-    bindingMock
-      .expects('loadBlob')
-      .withExactArgs('https://acme.com')
-      .returns(Promise.resolve(btoa(JSON.stringify(store1.obj))))
-      .once();
-    return storage
-      .get('key1')
-      .then(() => {
-        return storage.storePromise_;
-      })
-      .then(store => {
-        expect(store.obj.__proto__).to.be.undefined;
-        expect(store.values_.__proto__).to.be.undefined;
-      });
-  });
-
-  it('should get the value first time and reuse store', () => {
-    const store1 = new Store({});
-    store1.set('key1', 'value1');
-    store1.set('key2', 'value2');
-    bindingMock
-      .expects('loadBlob')
-      .withExactArgs('https://acme.com')
-      .returns(Promise.resolve(btoa(JSON.stringify(store1.obj))))
-      .once();
-    expect(storage.storePromise_).to.not.exist;
-    const promise = storage.get('key1');
-    return promise.then(value => {
-      expect(value).to.equal('value1');
-      const store1Promise = storage.storePromise_;
-      expect(store1Promise).to.exist;
-
-      // Repeat.
-      return storage.get('key2').then(value2 => {
-        expect(value2).to.equal('value2');
-        expect(storage.storePromise_).to.equal(store1Promise);
-      });
-    });
-  });
-
-  it('should get the value from first ever request and reuse store', () => {
-    bindingMock
-      .expects('loadBlob')
-      .withExactArgs('https://acme.com')
-      .returns(Promise.resolve(null))
-      .once();
-    expect(storage.storePromise_).to.not.exist;
-    const promise = storage.get('key1');
-    return promise.then(value => {
-      expect(value).to.be.undefined;
-      const store1Promise = storage.storePromise_;
-      expect(store1Promise).to.exist;
-
-      // Repeat.
-      return storage.get('key2').then(value2 => {
-        expect(value2).to.be.undefined;
-        expect(storage.storePromise_).to.equal(store1Promise);
-      });
-    });
-  });
-
-  it('should recover from binding failure', () => {
-    bindingMock
-      .expects('loadBlob')
-      .withExactArgs('https://acme.com')
-      .returns(Promise.reject('intentional'))
-      .once();
-    expect(storage.storePromise_).to.not.exist;
-    const promise = storage.get('key1');
-    return promise.then(value => {
-      expect(value).to.be.undefined;
-      expect(storage.storePromise_).to.exist;
-    });
-  });
-
-  it('should recover from binding error', () => {
-    bindingMock
-      .expects('loadBlob')
-      .withExactArgs('https://acme.com')
-      .returns(Promise.resolve('UNKNOWN FORMAT'))
-      .once();
-    expect(storage.storePromise_).to.not.exist;
-    const promise = storage.get('key1');
-    return promise.then(value => {
-      expect(value).to.be.undefined;
-      expect(storage.storePromise_).to.exist;
-    });
-  });
-
-  it('should save the value first time and reuse store', () => {
-    const store1 = new Store({});
-    store1.set('key1', 'value1');
-    store1.set('key2', 'value2');
-    bindingMock
-      .expects('loadBlob')
-      .withExactArgs('https://acme.com')
-      .returns(Promise.resolve(btoa(JSON.stringify(store1.obj))))
-      .once();
-    bindingMock
-      .expects('saveBlob')
-      .withExactArgs(
-        'https://acme.com',
-        env.sandbox.match(arg => {
-          const store2 = new Store(JSON.parse(atob(arg)));
-          return (
-            store2.get('key1') !== undefined && store2.get('key2') !== undefined
+      function expectStorage(keyValues) {
+        const list = [];
+        for (const k in keyValues) {
+          list.push(
+            storage.get(k).then(value => {
+              const expectedValue = keyValues[k];
+              expect(value).to.equal(expectedValue, `For "${k}"`);
+            })
           );
-        })
-      )
-      .returns(Promise.resolve())
-      .twice();
-    viewerMock
-      .expects('broadcast')
-      .withExactArgs(
-        env.sandbox.match(arg => {
-          return (
-            arg['type'] == 'amp-storage-reset' &&
-            arg['origin'] == 'https://acme.com'
-          );
-        })
-      )
-      .twice();
-    expect(storage.storePromise_).to.not.exist;
-    const promise = storage.set('key1', true);
-    return promise
-      .then(() => {
-        const store1Promise = storage.storePromise_;
-        expect(store1Promise).to.exist;
+        }
+        return Promise.all(list);
+      }
 
-        // Repeat.
-        return storage.set('key2', true).then(() => {
-          expect(storage.storePromise_).to.equal(store1Promise);
-        });
-      })
-      .then(() => {
-        return expectStorage({
-          'key1': true,
-          'key2': true,
+      it('should configure store correctly', () => {
+        const store1 = new Store({});
+        store1.set('key1', 'value1');
+        store1.set('key2', 'value2');
+        bindingMock
+          .expects('loadBlob')
+          .withExactArgs('https://acme.com')
+          .returns(Promise.resolve(btoa(JSON.stringify(store1.obj))))
+          .once();
+        return storage
+          .get('key1')
+          .then(() => {
+            return storage.storePromise_;
+          })
+          .then(store => {
+            expect(store.maxValues_).to.equal(8);
+          });
+      });
+
+      it('should initialize empty store with prototype-less objects', () => {
+        bindingMock
+          .expects('loadBlob')
+          .withExactArgs('https://acme.com')
+          .returns(Promise.resolve(null))
+          .once();
+        return storage
+          .get('key1')
+          .then(() => {
+            return storage.storePromise_;
+          })
+          .then(store => {
+            expect(store.obj.__proto__).to.be.undefined;
+            expect(store.values_.__proto__).to.be.undefined;
+          });
+      });
+
+      it('should restore store with prototype-less objects', () => {
+        const store1 = new Store({});
+        store1.set('key1', 'value1');
+        store1.set('key2', 'value2');
+        bindingMock
+          .expects('loadBlob')
+          .withExactArgs('https://acme.com')
+          .returns(Promise.resolve(btoa(JSON.stringify(store1.obj))))
+          .once();
+        return storage
+          .get('key1')
+          .then(() => {
+            return storage.storePromise_;
+          })
+          .then(store => {
+            expect(store.obj.__proto__).to.be.undefined;
+            expect(store.values_.__proto__).to.be.undefined;
+          });
+      });
+
+      it('should get the value first time and reuse store', () => {
+        const store1 = new Store({});
+        store1.set('key1', 'value1');
+        store1.set('key2', 'value2');
+        bindingMock
+          .expects('loadBlob')
+          .withExactArgs('https://acme.com')
+          .returns(Promise.resolve(btoa(JSON.stringify(store1.obj))))
+          .once();
+        expect(storage.storePromise_).to.not.exist;
+        const promise = storage.get('key1');
+        return promise.then(value => {
+          expect(value).to.equal('value1');
+          const store1Promise = storage.storePromise_;
+          expect(store1Promise).to.exist;
+
+          // Repeat.
+          return storage.get('key2').then(value2 => {
+            expect(value2).to.equal('value2');
+            expect(storage.storePromise_).to.equal(store1Promise);
+          });
         });
       });
-  });
 
-  it('should remove the key first time and reuse store', () => {
-    const store1 = new Store({});
-    store1.set('key1', 'value1');
-    store1.set('key2', 'value2');
-    bindingMock
-      .expects('loadBlob')
-      .withExactArgs('https://acme.com')
-      .returns(Promise.resolve(btoa(JSON.stringify(store1.obj))))
-      .once();
-    bindingMock
-      .expects('saveBlob')
-      .withExactArgs(
-        'https://acme.com',
-        env.sandbox.match(arg => {
-          const store2 = new Store(JSON.parse(atob(arg)));
-          return store2.get('key1') === undefined;
-        })
-      )
-      .returns(Promise.resolve())
-      .twice();
-    viewerMock
-      .expects('broadcast')
-      .withExactArgs(
-        env.sandbox.match(arg => {
-          return (
-            arg['type'] == 'amp-storage-reset' &&
-            arg['origin'] == 'https://acme.com'
-          );
-        })
-      )
-      .twice();
-    expect(storage.storePromise_).to.not.exist;
-    const promise = storage.remove('key1');
-    return promise
-      .then(() => {
-        const store1Promise = storage.storePromise_;
-        expect(store1Promise).to.exist;
+      it('should get the value from first ever request and reuse store', () => {
+        bindingMock
+          .expects('loadBlob')
+          .withExactArgs('https://acme.com')
+          .returns(Promise.resolve(null))
+          .once();
+        expect(storage.storePromise_).to.not.exist;
+        const promise = storage.get('key1');
+        return promise.then(value => {
+          expect(value).to.be.undefined;
+          const store1Promise = storage.storePromise_;
+          expect(store1Promise).to.exist;
 
-        // Repeat.
-        return storage.remove('key2').then(() => {
-          expect(storage.storePromise_).to.equal(store1Promise);
-        });
-      })
-      .then(() => {
-        return expectStorage({
-          'key1': undefined,
-          'key2': undefined,
+          // Repeat.
+          return storage.get('key2').then(value2 => {
+            expect(value2).to.be.undefined;
+            expect(storage.storePromise_).to.equal(store1Promise);
+          });
         });
       });
-  });
 
-  it('should react to reset messages', () => {
-    const store1 = new Store({});
-    store1.set('key1', 'value1');
-    bindingMock
-      .expects('loadBlob')
-      .withExactArgs('https://acme.com')
-      .returns(Promise.resolve(btoa(JSON.stringify(store1.obj))))
-      .twice();
-    return storage.get('key1').then(value => {
-      expect(value).to.equal('value1');
-      const store1Promise = storage.storePromise_;
-      expect(store1Promise).to.exist;
-
-      // Issue broadcast event.
-      viewerBroadcastHandler({
-        'type': 'amp-storage-reset',
-        'origin': 'https://acme.com',
+      it('should recover from binding failure', () => {
+        bindingMock
+          .expects('loadBlob')
+          .withExactArgs('https://acme.com')
+          .returns(Promise.reject('intentional'))
+          .once();
+        expect(storage.storePromise_).to.not.exist;
+        const promise = storage.get('key1');
+        return promise.then(value => {
+          expect(value).to.be.undefined;
+          expect(storage.storePromise_).to.exist;
+        });
       });
-      expect(storage.storePromise_).to.not.exist;
-      return storage.get('key1').then(value => {
-        expect(value).to.equal('value1');
-        expect(storage.storePromise_).to.exist;
+
+      it('should recover from binding error', () => {
+        bindingMock
+          .expects('loadBlob')
+          .withExactArgs('https://acme.com')
+          .returns(Promise.resolve('UNKNOWN FORMAT'))
+          .once();
+        expect(storage.storePromise_).to.not.exist;
+        const promise = storage.get('key1');
+        return promise.then(value => {
+          expect(value).to.be.undefined;
+          expect(storage.storePromise_).to.exist;
+        });
+      });
+
+      it('should save the value first time and reuse store', () => {
+        const store1 = new Store({});
+        store1.set('key1', 'value1');
+        store1.set('key2', 'value2');
+        bindingMock
+          .expects('loadBlob')
+          .withExactArgs('https://acme.com')
+          .returns(Promise.resolve(btoa(JSON.stringify(store1.obj))))
+          .once();
+        bindingMock
+          .expects('saveBlob')
+          .withExactArgs(
+            'https://acme.com',
+            env.sandbox.match(arg => {
+              const store2 = new Store(JSON.parse(atob(arg)));
+              return (
+                store2.get('key1') !== undefined &&
+                store2.get('key2') !== undefined
+              );
+            })
+          )
+          .returns(Promise.resolve())
+          .twice();
+        viewerMock
+          .expects('broadcast')
+          .withExactArgs(
+            env.sandbox.match(arg => {
+              return (
+                arg['type'] == 'amp-storage-reset' &&
+                arg['origin'] == 'https://acme.com'
+              );
+            })
+          )
+          .twice();
+        expect(storage.storePromise_).to.not.exist;
+        const promise = storage.set('key1', true);
+        return promise
+          .then(() => {
+            const store1Promise = storage.storePromise_;
+            expect(store1Promise).to.exist;
+
+            // Repeat.
+            return storage.set('key2', true).then(() => {
+              expect(storage.storePromise_).to.equal(store1Promise);
+            });
+          })
+          .then(() => {
+            return expectStorage({
+              'key1': true,
+              'key2': true,
+            });
+          });
+      });
+
+      it('should remove the key first time and reuse store', () => {
+        const store1 = new Store({});
+        store1.set('key1', 'value1');
+        store1.set('key2', 'value2');
+        bindingMock
+          .expects('loadBlob')
+          .withExactArgs('https://acme.com')
+          .returns(Promise.resolve(btoa(JSON.stringify(store1.obj))))
+          .once();
+        bindingMock
+          .expects('saveBlob')
+          .withExactArgs(
+            'https://acme.com',
+            env.sandbox.match(arg => {
+              const store2 = new Store(JSON.parse(atob(arg)));
+              return store2.get('key1') === undefined;
+            })
+          )
+          .returns(Promise.resolve())
+          .twice();
+        viewerMock
+          .expects('broadcast')
+          .withExactArgs(
+            env.sandbox.match(arg => {
+              return (
+                arg['type'] == 'amp-storage-reset' &&
+                arg['origin'] == 'https://acme.com'
+              );
+            })
+          )
+          .twice();
+        expect(storage.storePromise_).to.not.exist;
+        const promise = storage.remove('key1');
+        return promise
+          .then(() => {
+            const store1Promise = storage.storePromise_;
+            expect(store1Promise).to.exist;
+
+            // Repeat.
+            return storage.remove('key2').then(() => {
+              expect(storage.storePromise_).to.equal(store1Promise);
+            });
+          })
+          .then(() => {
+            return expectStorage({
+              'key1': undefined,
+              'key2': undefined,
+            });
+          });
+      });
+
+      it('should react to reset messages', () => {
+        const store1 = new Store({});
+        store1.set('key1', 'value1');
+        bindingMock
+          .expects('loadBlob')
+          .withExactArgs('https://acme.com')
+          .returns(Promise.resolve(btoa(JSON.stringify(store1.obj))))
+          .twice();
+        return storage.get('key1').then(value => {
+          expect(value).to.equal('value1');
+          const store1Promise = storage.storePromise_;
+          expect(store1Promise).to.exist;
+
+          // Issue broadcast event.
+          viewerBroadcastHandler({
+            'type': 'amp-storage-reset',
+            'origin': 'https://acme.com',
+          });
+          expect(storage.storePromise_).to.not.exist;
+          return storage.get('key1').then(value => {
+            expect(value).to.equal('value1');
+            expect(storage.storePromise_).to.exist;
+          });
+        });
+      });
+
+      it('should ignore unrelated reset messages', () => {
+        const store1 = new Store({});
+        store1.set('key1', 'value1');
+        bindingMock
+          .expects('loadBlob')
+          .withExactArgs('https://acme.com')
+          .returns(Promise.resolve(btoa(JSON.stringify(store1.obj))))
+          .twice();
+        return storage.get('key1').then(value => {
+          expect(value).to.equal('value1');
+          const store1Promise = storage.storePromise_;
+          expect(store1Promise).to.exist;
+
+          // Issue broadcast event.
+          viewerBroadcastHandler({
+            'type': 'amp-storage-reset',
+            'origin': 'OTHER',
+          });
+          expect(storage.storePromise_).to.exist;
+        });
       });
     });
-  });
-
-  it('should ignore unrelated reset messages', () => {
-    const store1 = new Store({});
-    store1.set('key1', 'value1');
-    bindingMock
-      .expects('loadBlob')
-      .withExactArgs('https://acme.com')
-      .returns(Promise.resolve(btoa(JSON.stringify(store1.obj))))
-      .twice();
-    return storage.get('key1').then(value => {
-      expect(value).to.equal('value1');
-      const store1Promise = storage.storePromise_;
-      expect(store1Promise).to.exist;
-
-      // Issue broadcast event.
-      viewerBroadcastHandler({
-        'type': 'amp-storage-reset',
-        'origin': 'OTHER',
-      });
-      expect(storage.storePromise_).to.exist;
-    });
-  });
 });
 
 describes.sandboxed('Store', {}, env => {

--- a/test/unit/test-storage.js
+++ b/test/unit/test-storage.js
@@ -23,7 +23,7 @@ import {
 } from '../../src/service/storage-impl';
 import {dev} from '../../src/log';
 
-describes.sandboxed('Storage', {}, () => {
+describes.sandboxed('Storage', {}, env => {
   let storage;
   let binding;
   let bindingMock;
@@ -41,7 +41,7 @@ describes.sandboxed('Storage', {}, () => {
       },
       broadcast: () => {},
     };
-    viewerMock = sandbox.mock(viewer);
+    viewerMock = env.sandbox.mock(viewer);
 
     windowApi = {
       document: {},
@@ -53,7 +53,7 @@ describes.sandboxed('Storage', {}, () => {
       loadBlob: () => {},
       saveBlob: () => {},
     };
-    bindingMock = sandbox.mock(binding);
+    bindingMock = env.sandbox.mock(binding);
 
     storage = new Storage(ampdoc, viewer, binding);
     storage.start_();
@@ -214,7 +214,7 @@ describes.sandboxed('Storage', {}, () => {
       .expects('saveBlob')
       .withExactArgs(
         'https://acme.com',
-        sinon.match(arg => {
+        env.sandbox.match(arg => {
           const store2 = new Store(JSON.parse(atob(arg)));
           return (
             store2.get('key1') !== undefined && store2.get('key2') !== undefined
@@ -226,7 +226,7 @@ describes.sandboxed('Storage', {}, () => {
     viewerMock
       .expects('broadcast')
       .withExactArgs(
-        sinon.match(arg => {
+        env.sandbox.match(arg => {
           return (
             arg['type'] == 'amp-storage-reset' &&
             arg['origin'] == 'https://acme.com'
@@ -267,7 +267,7 @@ describes.sandboxed('Storage', {}, () => {
       .expects('saveBlob')
       .withExactArgs(
         'https://acme.com',
-        sinon.match(arg => {
+        env.sandbox.match(arg => {
           const store2 = new Store(JSON.parse(atob(arg)));
           return store2.get('key1') === undefined;
         })
@@ -277,7 +277,7 @@ describes.sandboxed('Storage', {}, () => {
     viewerMock
       .expects('broadcast')
       .withExactArgs(
-        sinon.match(arg => {
+        env.sandbox.match(arg => {
           return (
             arg['type'] == 'amp-storage-reset' &&
             arg['origin'] == 'https://acme.com'
@@ -354,12 +354,12 @@ describes.sandboxed('Storage', {}, () => {
   });
 });
 
-describes.sandboxed('Store', {}, () => {
+describes.sandboxed('Store', {}, env => {
   let clock;
   let store;
 
   beforeEach(() => {
-    clock = sandbox.useFakeTimers();
+    clock = env.sandbox.useFakeTimers();
     store = new Store({}, 2);
   });
 
@@ -468,7 +468,7 @@ describes.sandboxed('Store', {}, () => {
   });
 });
 
-describes.sandboxed('LocalStorageBinding', {}, () => {
+describes.sandboxed('LocalStorageBinding', {}, env => {
   let windowApi;
   let localStorageMock;
   let binding;
@@ -480,12 +480,12 @@ describes.sandboxed('LocalStorageBinding', {}, () => {
         setItem: () => {},
       },
     };
-    localStorageMock = sandbox.mock(windowApi.localStorage);
+    localStorageMock = env.sandbox.mock(windowApi.localStorage);
     binding = new LocalStorageBinding(windowApi);
   });
 
   it('should throw if localStorage is not supported', () => {
-    const errorSpy = sandbox.spy(dev(), 'expectedError');
+    const errorSpy = env.sandbox.spy(dev(), 'expectedError');
 
     expect(errorSpy).to.have.not.been.called;
     new LocalStorageBinding(windowApi);
@@ -619,7 +619,7 @@ describes.sandboxed('LocalStorageBinding', {}, () => {
   });
 
   it('should bypass saving to localStorage if getItem throws', () => {
-    const setItemSpy = sandbox.spy(windowApi.localStorage, 'setItem');
+    const setItemSpy = env.sandbox.spy(windowApi.localStorage, 'setItem');
 
     localStorageMock
       .expects('getItem')
@@ -640,7 +640,7 @@ describes.sandboxed('LocalStorageBinding', {}, () => {
   });
 });
 
-describes.sandboxed('ViewerStorageBinding', {}, () => {
+describes.sandboxed('ViewerStorageBinding', {}, env => {
   let viewer;
   let viewerMock;
   let binding;
@@ -649,7 +649,7 @@ describes.sandboxed('ViewerStorageBinding', {}, () => {
     viewer = {
       sendMessageAwaitResponse: () => {},
     };
-    viewerMock = sandbox.mock(viewer);
+    viewerMock = env.sandbox.mock(viewer);
     binding = new ViewerStorageBinding(viewer);
   });
 
@@ -658,7 +658,7 @@ describes.sandboxed('ViewerStorageBinding', {}, () => {
       .expects('sendMessageAwaitResponse')
       .withExactArgs(
         'loadStore',
-        sinon.match(arg => {
+        env.sandbox.match(arg => {
           return arg['origin'] == 'https://acme.com';
         })
       )
@@ -674,7 +674,7 @@ describes.sandboxed('ViewerStorageBinding', {}, () => {
       .expects('sendMessageAwaitResponse')
       .withExactArgs(
         'loadStore',
-        sinon.match(arg => {
+        env.sandbox.match(arg => {
           return arg['origin'] == 'https://acme.com';
         })
       )
@@ -690,7 +690,7 @@ describes.sandboxed('ViewerStorageBinding', {}, () => {
       .expects('sendMessageAwaitResponse')
       .withExactArgs(
         'loadStore',
-        sinon.match(arg => {
+        env.sandbox.match(arg => {
           return arg['origin'] == 'https://acme.com';
         })
       )
@@ -712,7 +712,7 @@ describes.sandboxed('ViewerStorageBinding', {}, () => {
       .expects('sendMessageAwaitResponse')
       .withExactArgs(
         'saveStore',
-        sinon.match(arg => {
+        env.sandbox.match(arg => {
           return arg['origin'] == 'https://acme.com' && arg['blob'] == 'BLOB1';
         })
       )
@@ -726,7 +726,7 @@ describes.sandboxed('ViewerStorageBinding', {}, () => {
       .expects('sendMessageAwaitResponse')
       .withExactArgs(
         'saveStore',
-        sinon.match(() => true)
+        env.sandbox.match(() => true)
       )
       .returns(Promise.reject('unknown'))
       .once();

--- a/test/unit/test-style-installer.js
+++ b/test/unit/test-style-installer.js
@@ -38,10 +38,10 @@ describe('Styles', () => {
       ampdoc = env.ampdoc;
       installPerformanceService(win);
       const perf = Services.performanceFor(win);
-      tickSpy = sandbox.spy(perf, 'tick');
+      tickSpy = env.sandbox.spy(perf, 'tick');
       resources = Services.resourcesForDoc(ampdoc);
-      schedulePassSpy = sandbox.spy(resources, 'schedulePass');
-      waitForServicesStub = sandbox.stub(rds, 'waitForServices');
+      schedulePassSpy = env.sandbox.spy(resources, 'schedulePass');
+      waitForServicesStub = env.sandbox.stub(rds, 'waitForServices');
       styles.setBodyMadeVisibleForTesting(false);
     });
 
@@ -88,7 +88,10 @@ describe('Styles', () => {
         setTimeout(resolve, 0);
       }).then(() => {
         expect(tickSpy.withArgs('mbv')).to.be.calledOnce;
-        expect(schedulePassSpy).to.not.be.calledWith(sinon.match.number, true);
+        expect(schedulePassSpy).to.not.be.calledWith(
+          env.sandbox.match.number,
+          true
+        );
         expect(ampdoc.signals().get('render-start')).to.be.ok;
       });
     });

--- a/test/unit/test-style.js
+++ b/test/unit/test-style.js
@@ -17,16 +17,6 @@
 import * as st from '../../src/style';
 
 describe('Style', () => {
-  let sandbox;
-
-  beforeEach(() => {
-    sandbox = sinon.sandbox;
-  });
-
-  afterEach(() => {
-    sandbox.restore();
-  });
-
   it('toggle', () => {
     const element = document.createElement('div');
 
@@ -75,7 +65,7 @@ describe('Style', () => {
   });
 
   it('setImportantStyles with vendor prefix', () => {
-    const spy = sandbox.spy();
+    const spy = window.sandbox.spy();
     const element = {
       style: {
         WebkitTransitionDurationImportant: '',

--- a/test/unit/test-task-queue.js
+++ b/test/unit/test-task-queue.js
@@ -17,18 +17,12 @@
 import {TaskQueue} from '../../src/service/task-queue';
 
 describe('TaskQueue', () => {
-  let sandbox;
   let clock;
   let queue;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox;
-    clock = sandbox.useFakeTimers();
+    clock = window.sandbox.useFakeTimers();
     queue = new TaskQueue();
-  });
-
-  afterEach(() => {
-    sandbox.restore();
   });
 
   it('should enqueue and dequeue', () => {

--- a/test/unit/test-timer.js
+++ b/test/unit/test-timer.js
@@ -17,26 +17,23 @@
 import {Timer} from '../../src/service/timer-impl';
 
 describes.fakeWin('Timer', {}, env => {
-  let sandbox;
   let windowMock;
   let timer;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox;
     const WindowApi = function() {};
     WindowApi.prototype.setTimeout = function(unusedCallback, unusedDelay) {};
     WindowApi.prototype.clearTimeout = function(unusedTimerId) {};
     WindowApi.prototype.document = {};
     WindowApi.prototype.Promise = window.Promise;
     const windowApi = new WindowApi();
-    windowMock = sandbox.mock(windowApi);
+    windowMock = env.sandbox.mock(windowApi);
 
     timer = new Timer(windowApi);
   });
 
   afterEach(() => {
     windowMock.verify();
-    sandbox.restore();
   });
 
   it('delay', () => {
@@ -90,7 +87,7 @@ describes.fakeWin('Timer', {}, env => {
     windowMock
       .expects('setTimeout')
       .withExactArgs(
-        sinon.match(value => {
+        env.sandbox.match(value => {
           value();
           return true;
         }),
@@ -111,7 +108,7 @@ describes.fakeWin('Timer', {}, env => {
     windowMock
       .expects('setTimeout')
       .withExactArgs(
-        sinon.match(value => {
+        env.sandbox.match(value => {
           value();
           return true;
         }),
@@ -138,7 +135,7 @@ describes.fakeWin('Timer', {}, env => {
     windowMock
       .expects('setTimeout')
       .withExactArgs(
-        sinon.match(unusedValue => {
+        env.sandbox.match(unusedValue => {
           // No timeout
           return true;
         }),
@@ -159,7 +156,7 @@ describes.fakeWin('Timer', {}, env => {
     windowMock
       .expects('setTimeout')
       .withExactArgs(
-        sinon.match(value => {
+        env.sandbox.match(value => {
           // Immediate timeout
           value();
           return true;
@@ -200,7 +197,7 @@ describes.fakeWin('Timer', {}, env => {
 
   it('poll - clears out interval when complete', () => {
     const realTimer = new Timer(env.win);
-    const clearIntervalStub = sandbox.stub();
+    const clearIntervalStub = env.sandbox.stub();
     env.win.clearInterval = clearIntervalStub;
     return realTimer
       .poll(111, () => {

--- a/test/unit/test-transition.js
+++ b/test/unit/test-transition.js
@@ -17,19 +17,9 @@
 import * as tr from '../../src/transition';
 
 describe('Transition', () => {
-  let sandbox;
-
-  beforeEach(() => {
-    sandbox = sinon.sandbox;
-  });
-
-  afterEach(() => {
-    sandbox.restore();
-  });
-
   it('all', () => {
-    const func1 = sandbox.spy();
-    const func2 = sandbox.spy();
+    const func1 = window.sandbox.spy();
+    const func2 = window.sandbox.spy();
     const all = tr.all([func1, func2]);
 
     expect(func1).to.have.not.been.called;

--- a/test/unit/test-url-replacements.js
+++ b/test/unit/test-url-replacements.js
@@ -50,2139 +50,2219 @@ describes.sandboxed('UrlReplacements', {}, env => {
   let userErrorStub;
   let ampdoc;
 
-  beforeEach(() => {
-    canonical = 'https://canonical.com/doc1';
-    userErrorStub = env.sandbox.stub(user(), 'error');
-  });
+  // TODO(amphtml, #25621): Cannot find atob / btoa on Safari on Sauce Labs.
+  describe
+    .configure()
+    .skipSafari()
+    .run('UrlReplacements', () => {
+      beforeEach(() => {
+        canonical = 'https://canonical.com/doc1';
+        userErrorStub = env.sandbox.stub(user(), 'error');
+      });
 
-  function getReplacements(opt_options) {
-    return createIframePromise().then(iframe => {
-      ampdoc = iframe.ampdoc;
-      iframe.doc.title = 'Pixel Test';
-      const link = iframe.doc.createElement('link');
-      link.setAttribute('href', 'https://pinterest.com:8080/pin1');
-      link.setAttribute('rel', 'canonical');
-      iframe.doc.head.appendChild(link);
-      iframe.win.__AMP_SERVICES.documentInfo = null;
-      installDocumentInfoServiceForDoc(iframe.ampdoc);
-      resetScheduledElementForTesting(iframe.win, 'amp-analytics');
-      resetScheduledElementForTesting(iframe.win, 'amp-experiment');
-      resetScheduledElementForTesting(iframe.win, 'amp-share-tracking');
-      if (opt_options) {
-        if (opt_options.withCid) {
-          markElementScheduledForTesting(iframe.win, 'amp-analytics');
-          cidServiceForDocForTesting(iframe.ampdoc);
-          installCryptoService(iframe.win);
-        }
-        if (opt_options.withActivity) {
-          markElementScheduledForTesting(iframe.win, 'amp-analytics');
-          installActivityServiceForTesting(iframe.ampdoc);
-        }
-        if (opt_options.withVariant) {
-          markElementScheduledForTesting(iframe.win, 'amp-experiment');
-          registerServiceBuilder(iframe.win, 'variant', function() {
-            return {
-              getVariants: () =>
-                Promise.resolve({
-                  'x1': 'v1',
-                  'x2': null,
-                }),
-            };
-          });
-        }
-        if (opt_options.withShareTracking) {
-          markElementScheduledForTesting(iframe.win, 'amp-share-tracking');
-          registerServiceBuilder(iframe.win, 'share-tracking', function() {
-            return Promise.resolve({
-              incomingFragment: '12345',
-              outgoingFragment: '54321',
-            });
-          });
-        }
-        if (opt_options.withStoryVariableService) {
-          markElementScheduledForTesting(iframe.win, 'amp-story');
-          registerServiceBuilder(iframe.win, 'story-variable', function() {
-            return Promise.resolve({
-              pageIndex: 546,
-              pageId: 'id-123',
-            });
-          });
-        }
-        if (opt_options.withViewerIntegrationVariableService) {
-          markElementScheduledForTesting(iframe.win, 'amp-viewer-integration');
-          registerServiceBuilder(
-            iframe.win,
-            'viewer-integration-variable',
-            function() {
-              return Promise.resolve(
-                opt_options.withViewerIntegrationVariableService
+      function getReplacements(opt_options) {
+        return createIframePromise().then(iframe => {
+          ampdoc = iframe.ampdoc;
+          iframe.doc.title = 'Pixel Test';
+          const link = iframe.doc.createElement('link');
+          link.setAttribute('href', 'https://pinterest.com:8080/pin1');
+          link.setAttribute('rel', 'canonical');
+          iframe.doc.head.appendChild(link);
+          iframe.win.__AMP_SERVICES.documentInfo = null;
+          installDocumentInfoServiceForDoc(iframe.ampdoc);
+          resetScheduledElementForTesting(iframe.win, 'amp-analytics');
+          resetScheduledElementForTesting(iframe.win, 'amp-experiment');
+          resetScheduledElementForTesting(iframe.win, 'amp-share-tracking');
+          if (opt_options) {
+            if (opt_options.withCid) {
+              markElementScheduledForTesting(iframe.win, 'amp-analytics');
+              cidServiceForDocForTesting(iframe.ampdoc);
+              installCryptoService(iframe.win);
+            }
+            if (opt_options.withActivity) {
+              markElementScheduledForTesting(iframe.win, 'amp-analytics');
+              installActivityServiceForTesting(iframe.ampdoc);
+            }
+            if (opt_options.withVariant) {
+              markElementScheduledForTesting(iframe.win, 'amp-experiment');
+              registerServiceBuilder(iframe.win, 'variant', function() {
+                return {
+                  getVariants: () =>
+                    Promise.resolve({
+                      'x1': 'v1',
+                      'x2': null,
+                    }),
+                };
+              });
+            }
+            if (opt_options.withShareTracking) {
+              markElementScheduledForTesting(iframe.win, 'amp-share-tracking');
+              registerServiceBuilder(iframe.win, 'share-tracking', function() {
+                return Promise.resolve({
+                  incomingFragment: '12345',
+                  outgoingFragment: '54321',
+                });
+              });
+            }
+            if (opt_options.withStoryVariableService) {
+              markElementScheduledForTesting(iframe.win, 'amp-story');
+              registerServiceBuilder(iframe.win, 'story-variable', function() {
+                return Promise.resolve({
+                  pageIndex: 546,
+                  pageId: 'id-123',
+                });
+              });
+            }
+            if (opt_options.withViewerIntegrationVariableService) {
+              markElementScheduledForTesting(
+                iframe.win,
+                'amp-viewer-integration'
+              );
+              registerServiceBuilder(
+                iframe.win,
+                'viewer-integration-variable',
+                function() {
+                  return Promise.resolve(
+                    opt_options.withViewerIntegrationVariableService
+                  );
+                }
               );
             }
-          );
-        }
-        if (opt_options.withOriginalTitle) {
-          iframe.doc.originalTitle = 'Original Pixel Test';
-        }
-      }
-      viewerService = Services.viewerForDoc(iframe.ampdoc);
-      replacements = Services.urlReplacementsForDoc(iframe.doc.documentElement);
-      return replacements;
-    });
-  }
-
-  function expandUrlAsync(url, opt_bindings, opt_options) {
-    return getReplacements(opt_options).then(replacements =>
-      replacements.expandUrlAsync(url, opt_bindings)
-    );
-  }
-
-  function getFakeWindow() {
-    loadObservable = new Observable();
-    const win = {
-      addEventListener(type, callback) {
-        loadObservable.add(callback);
-      },
-      Object,
-      performance: {
-        timing: {
-          navigationStart: 100,
-          loadEventStart: 0,
-        },
-      },
-      removeEventListener(type, callback) {
-        loadObservable.remove(callback);
-      },
-      document: {
-        nodeType: /* document */ 9,
-        querySelector: selector => {
-          if (selector.startsWith('meta')) {
-            return {
-              getAttribute: () => {
-                return 'https://whitelisted.com https://greylisted.com http://example.com';
-              },
-              hasAttribute: () => {
-                return true;
-              },
-            };
-          } else {
-            return {href: canonical};
+            if (opt_options.withOriginalTitle) {
+              iframe.doc.originalTitle = 'Original Pixel Test';
+            }
           }
-        },
-        getElementById: () => {},
-        cookie: '',
-        documentElement: {
+          viewerService = Services.viewerForDoc(iframe.ampdoc);
+          replacements = Services.urlReplacementsForDoc(
+            iframe.doc.documentElement
+          );
+          return replacements;
+        });
+      }
+
+      function expandUrlAsync(url, opt_bindings, opt_options) {
+        return getReplacements(opt_options).then(replacements =>
+          replacements.expandUrlAsync(url, opt_bindings)
+        );
+      }
+
+      function getFakeWindow() {
+        loadObservable = new Observable();
+        const win = {
+          addEventListener(type, callback) {
+            loadObservable.add(callback);
+          },
+          Object,
+          performance: {
+            timing: {
+              navigationStart: 100,
+              loadEventStart: 0,
+            },
+          },
+          removeEventListener(type, callback) {
+            loadObservable.remove(callback);
+          },
+          document: {
+            nodeType: /* document */ 9,
+            querySelector: selector => {
+              if (selector.startsWith('meta')) {
+                return {
+                  getAttribute: () => {
+                    return 'https://whitelisted.com https://greylisted.com http://example.com';
+                  },
+                  hasAttribute: () => {
+                    return true;
+                  },
+                };
+              } else {
+                return {href: canonical};
+              }
+            },
+            getElementById: () => {},
+            cookie: '',
+            documentElement: {
+              nodeType: /* element */ 1,
+              getRootNode() {
+                return win.document;
+              },
+            },
+          },
+          Math: {
+            random: () => 0.1234,
+          },
+          crypto: {
+            getRandomValues: array => {
+              array[0] = 1;
+              array[1] = 2;
+              array[2] = 3;
+              array[15] = 15;
+            },
+          },
+          __AMP_SERVICES: {
+            'viewport': {obj: {}},
+            'cid': {
+              promise: Promise.resolve({
+                get: config =>
+                  Promise.resolve('test-cid(' + config.scope + ')'),
+              }),
+            },
+          },
+        };
+        win.document.defaultView = win;
+        win.document.documentElement.ownerDocument = win.document;
+        win.document.head = {
           nodeType: /* element */ 1,
+          // Fake query selectors needed to bypass <meta> tag checks.
+          querySelector: () => null,
+          querySelectorAll: () => [],
           getRootNode() {
             return win.document;
           },
-        },
-      },
-      Math: {
-        random: () => 0.1234,
-      },
-      crypto: {
-        getRandomValues: array => {
-          array[0] = 1;
-          array[1] = 2;
-          array[2] = 3;
-          array[15] = 15;
-        },
-      },
-      __AMP_SERVICES: {
-        'viewport': {obj: {}},
-        'cid': {
-          promise: Promise.resolve({
-            get: config => Promise.resolve('test-cid(' + config.scope + ')'),
-          }),
-        },
-      },
-    };
-    win.document.defaultView = win;
-    win.document.documentElement.ownerDocument = win.document;
-    win.document.head = {
-      nodeType: /* element */ 1,
-      // Fake query selectors needed to bypass <meta> tag checks.
-      querySelector: () => null,
-      querySelectorAll: () => [],
-      getRootNode() {
-        return win.document;
-      },
-    };
-    installDocService(win, /* isSingleDoc */ true);
-    const ampdoc = Services.ampdocServiceFor(win).getSingleDoc();
-    win.__AMP_SERVICES.documentInfo = null;
-    installDocumentInfoServiceForDoc(ampdoc);
-    win.ampdoc = ampdoc;
-    installUrlReplacementsServiceForDoc(ampdoc);
-    return win;
-  }
+        };
+        installDocService(win, /* isSingleDoc */ true);
+        const ampdoc = Services.ampdocServiceFor(win).getSingleDoc();
+        win.__AMP_SERVICES.documentInfo = null;
+        installDocumentInfoServiceForDoc(ampdoc);
+        win.ampdoc = ampdoc;
+        installUrlReplacementsServiceForDoc(ampdoc);
+        return win;
+      }
 
-  it('limit replacement params size', () => {
-    return getReplacements().then(replacements => {
-      replacements.getVariableSource().initialize();
-      const variables = Object.keys(
-        replacements.getVariableSource().replacements_
-      );
-      // Restrict the number of replacement params to globalVaraibleSource
-      // Please consider adding the logic to amp-analytics instead.
-      // Please contact @lannka or @zhouyx if the test fail.
-      expect(variables.length).to.equal(72);
-    });
-  });
-
-  it('should replace RANDOM', () => {
-    return expandUrlAsync('ord=RANDOM?').then(res => {
-      expect(res).to.match(/ord=(\d+(\.\d+)?)\?$/);
-    });
-  });
-
-  it('should replace COUNTER', () => {
-    return expandUrlAsync(
-      'COUNTER(foo),COUNTER(bar),COUNTER(foo),COUNTER(bar),COUNTER(bar)'
-    ).then(res => {
-      expect(res).to.equal('1,1,2,2,3');
-    });
-  });
-
-  it.configure()
-    .skipFirefox()
-    .run('should replace CANONICAL_URL', () => {
-      return expandUrlAsync('?href=CANONICAL_URL').then(res => {
-        expect(res).to.equal('?href=https%3A%2F%2Fpinterest.com%3A8080%2Fpin1');
+      it('limit replacement params size', () => {
+        return getReplacements().then(replacements => {
+          replacements.getVariableSource().initialize();
+          const variables = Object.keys(
+            replacements.getVariableSource().replacements_
+          );
+          // Restrict the number of replacement params to globalVaraibleSource
+          // Please consider adding the logic to amp-analytics instead.
+          // Please contact @lannka or @zhouyx if the test fail.
+          expect(variables.length).to.equal(72);
+        });
       });
-    });
 
-  it.configure()
-    .skipFirefox()
-    .run('should replace CANONICAL_HOST', () => {
-      return expandUrlAsync('?host=CANONICAL_HOST').then(res => {
-        expect(res).to.equal('?host=pinterest.com%3A8080');
+      it('should replace RANDOM', () => {
+        return expandUrlAsync('ord=RANDOM?').then(res => {
+          expect(res).to.match(/ord=(\d+(\.\d+)?)\?$/);
+        });
       });
-    });
 
-  it.configure()
-    .skipFirefox()
-    .run('should replace CANONICAL_HOSTNAME', () => {
-      return expandUrlAsync('?host=CANONICAL_HOSTNAME').then(res => {
-        expect(res).to.equal('?host=pinterest.com');
+      it('should replace COUNTER', () => {
+        return expandUrlAsync(
+          'COUNTER(foo),COUNTER(bar),COUNTER(foo),COUNTER(bar),COUNTER(bar)'
+        ).then(res => {
+          expect(res).to.equal('1,1,2,2,3');
+        });
       });
-    });
 
-  it.configure()
-    .skipFirefox()
-    .run('should replace CANONICAL_PATH', () => {
-      return expandUrlAsync('?path=CANONICAL_PATH').then(res => {
-        expect(res).to.equal('?path=%2Fpin1');
-      });
-    });
-
-  it('should replace DOCUMENT_REFERRER', async () => {
-    const replacements = await getReplacements();
-    env.sandbox
-      .stub(viewerService, 'getReferrerUrl')
-      .returns('http://fake.example/?foo=bar');
-    const res = await replacements.expandUrlAsync('?ref=DOCUMENT_REFERRER');
-    expect(res).to.equal('?ref=http%3A%2F%2Ffake.example%2F%3Ffoo%3Dbar');
-  });
-
-  it('should replace EXTERNAL_REFERRER', () => {
-    const windowInterface = mockWindowInterface(env.sandbox);
-    windowInterface.getHostname.returns('different.org');
-    return getReplacements()
-      .then(replacements => {
-        stubServiceForDoc(
-          env.sandbox,
-          ampdoc,
-          'viewer',
-          'getReferrerUrl'
-        ).returns(Promise.resolve('http://example.org/page.html'));
-        return replacements.expandUrlAsync('?ref=EXTERNAL_REFERRER');
-      })
-      .then(res => {
-        expect(res).to.equal('?ref=http%3A%2F%2Fexample.org%2Fpage.html');
-      });
-  });
-
-  it(
-    'should replace EXTERNAL_REFERRER to empty string ' +
-      'if referrer is of same domain',
-    () => {
-      const windowInterface = mockWindowInterface(env.sandbox);
-      windowInterface.getHostname.returns('example.org');
-      return getReplacements()
-        .then(replacements => {
-          stubServiceForDoc(
-            env.sandbox,
-            ampdoc,
-            'viewer',
-            'getReferrerUrl'
-          ).returns(Promise.resolve('http://example.org/page.html'));
-          return replacements.expandUrlAsync('?ref=EXTERNAL_REFERRER');
-        })
-        .then(res => {
-          expect(res).to.equal('?ref=');
-        });
-    }
-  );
-
-  it(
-    'should replace EXTERNAL_REFERRER to empty string ' +
-      'if referrer is CDN proxy of same domain',
-    () => {
-      const windowInterface = mockWindowInterface(env.sandbox);
-      windowInterface.getHostname.returns('example.org');
-      return getReplacements()
-        .then(replacements => {
-          stubServiceForDoc(
-            env.sandbox,
-            ampdoc,
-            'viewer',
-            'getReferrerUrl'
-          ).returns(
-            Promise.resolve(
-              'https://example-org.cdn.ampproject.org/v/example.org/page.html'
-            )
-          );
-          return replacements.expandUrlAsync('?ref=EXTERNAL_REFERRER');
-        })
-        .then(res => {
-          expect(res).to.equal('?ref=');
-        });
-    }
-  );
-
-  it(
-    'should replace EXTERNAL_REFERRER to empty string ' +
-      'if referrer is CDN proxy of same domain (before CURLS)',
-    () => {
-      const windowInterface = mockWindowInterface(env.sandbox);
-      windowInterface.getHostname.returns('example.org');
-      return getReplacements()
-        .then(replacements => {
-          stubServiceForDoc(
-            env.sandbox,
-            ampdoc,
-            'viewer',
-            'getReferrerUrl'
-          ).returns(
-            Promise.resolve(
-              'https://cdn.ampproject.org/v/example.org/page.html'
-            )
-          );
-          return replacements.expandUrlAsync('?ref=EXTERNAL_REFERRER');
-        })
-        .then(res => {
-          expect(res).to.equal('?ref=');
-        });
-    }
-  );
-
-  it('should replace TITLE', () => {
-    return expandUrlAsync('?title=TITLE').then(res => {
-      expect(res).to.equal('?title=Pixel%20Test');
-    });
-  });
-
-  it('should prefer original title for TITLE', () => {
-    return expandUrlAsync('?title=TITLE', /*opt_bindings*/ undefined, {
-      withOriginalTitle: true,
-    }).then(res => {
-      expect(res).to.equal('?title=Original%20Pixel%20Test');
-    });
-  });
-
-  describe('AMPDOC_URL', () => {
-    it('should replace AMPDOC_URL', () => {
-      return expandUrlAsync('?ref=AMPDOC_URL').then(res => {
-        expect(res).to.not.match(/AMPDOC_URL/);
-      });
-    });
-
-    it('should add extra params to AMPDOC_URL', () => {
-      const win = getFakeWindow();
-      win.location = parseUrlDeprecated(
-        'https://cdn.ampproject.org/a/o.com/foo/?amp_r=hello%3Dworld'
-      );
-      return Services.urlReplacementsForDoc(win.document.documentElement)
-        .expandUrlAsync('?url=AMPDOC_URL')
-        .then(res => {
-          expect(res).to.contain(
-            encodeURIComponent(
-              'https://cdn.ampproject.org/a/o.com/foo/?hello=world'
-            )
-          );
-        });
-    });
-
-    it('should merge extra params in AMPDOC_URL', () => {
-      const win = getFakeWindow();
-      win.location = parseUrlDeprecated(
-        'https://cdn.ampproject.org/a/o.com/foo/?test=case&amp_r=hello%3Dworld'
-      );
-      return Services.urlReplacementsForDoc(win.document.documentElement)
-        .expandUrlAsync('?url=AMPDOC_URL')
-        .then(res => {
-          expect(res).to.contain(
-            encodeURIComponent(
-              'https://cdn.ampproject.org/a/o.com/foo/?test=case&hello=world'
-            )
-          );
-        });
-    });
-
-    it('should allow an embedded amp_r parameter', () => {
-      const win = getFakeWindow();
-      win.location = parseUrlDeprecated(
-        'https://cdn.ampproject.org/a/o.com/foo/?amp_r=amp_r%3Dweird'
-      );
-      return Services.urlReplacementsForDoc(win.document.documentElement)
-        .expandUrlAsync('?url=AMPDOC_URL')
-        .then(res => {
-          expect(res).to.contain(
-            encodeURIComponent(
-              'https://cdn.ampproject.org/a/o.com/foo/?amp_r=weird'
-            )
-          );
-        });
-    });
-
-    it('should prefer original params in AMPDOC_URL', () => {
-      const win = getFakeWindow();
-      win.location = parseUrlDeprecated(
-        'https://cdn.ampproject.org/a/o.com/foo/?test=case&amp_r=test%3Devil'
-      );
-      return Services.urlReplacementsForDoc(win.document.documentElement)
-        .expandUrlAsync('?url=AMPDOC_URL')
-        .then(res => {
-          expect(res).to.contain(
-            encodeURIComponent(
-              'https://cdn.ampproject.org/a/o.com/foo/?test=case'
-            )
-          );
-        });
-    });
-
-    it('should merge multiple extra params safely in AMPDOC_URL', () => {
-      const win = getFakeWindow();
-      win.location = parseUrlDeprecated(
-        'https://cdn.ampproject.org/a/o.com/foo/?test=case&a&hello=you&amp_r=hello%3Dworld%26goodnight%3Dmoon'
-      );
-      return Services.urlReplacementsForDoc(win.document.documentElement)
-        .expandUrlAsync('?url=AMPDOC_URL')
-        .then(res => {
-          expect(res).to.contain(
-            encodeURIComponent(
-              'https://cdn.ampproject.org/a/o.com/foo/?test=case&a&hello=you&goodnight=moon'
-            )
-          );
-        });
-    });
-  });
-
-  it('should replace AMPDOC_HOST', () => {
-    return expandUrlAsync('?ref=AMPDOC_HOST').then(res => {
-      expect(res).to.not.match(/AMPDOC_HOST/);
-    });
-  });
-
-  it('should replace AMPDOC_HOSTNAME', () => {
-    return expandUrlAsync('?ref=AMPDOC_HOSTNAME').then(res => {
-      expect(res).to.not.match(/AMPDOC_HOSTNAME/);
-    });
-  });
-
-  describe('SOURCE_URL', () => {
-    it('should replace SOURCE_URL and SOURCE_HOST', () => {
-      const win = getFakeWindow();
-      win.location = parseUrlDeprecated('https://wrong.com');
-      env.sandbox
-        .stub(trackPromise, 'getTrackImpressionPromise')
-        .callsFake(() => {
-          return new Promise(resolve => {
-            win.location = parseUrlDeprecated('https://example.com/test');
-            resolve();
-          });
-        });
-      return Services.urlReplacementsForDoc(win.document.documentElement)
-        .expandUrlAsync('?url=SOURCE_URL&host=SOURCE_HOST')
-        .then(res => {
-          expect(res).to.equal(
-            '?url=https%3A%2F%2Fexample.com%2Ftest&host=example.com'
-          );
-        });
-    });
-
-    it('should replace SOURCE_URL and SOURCE_HOSTNAME', () => {
-      const win = getFakeWindow();
-      win.location = parseUrlDeprecated('https://wrong.com');
-      env.sandbox
-        .stub(trackPromise, 'getTrackImpressionPromise')
-        .callsFake(() => {
-          return new Promise(resolve => {
-            win.location = parseUrlDeprecated('https://example.com/test');
-            resolve();
-          });
-        });
-      return Services.urlReplacementsForDoc(win.document.documentElement)
-        .expandUrlAsync('?url=SOURCE_URL&hostname=SOURCE_HOSTNAME')
-        .then(res => {
-          expect(res).to.equal(
-            '?url=https%3A%2F%2Fexample.com%2Ftest&hostname=example.com'
-          );
-        });
-    });
-
-    it('should update SOURCE_URL after track impression', () => {
-      const win = getFakeWindow();
-      win.location = parseUrlDeprecated('https://wrong.com');
-      env.sandbox
-        .stub(trackPromise, 'getTrackImpressionPromise')
-        .callsFake(() => {
-          return new Promise(resolve => {
-            win.location = parseUrlDeprecated(
-              'https://example.com?gclid=123456'
+      it.configure()
+        .skipFirefox()
+        .run('should replace CANONICAL_URL', () => {
+          return expandUrlAsync('?href=CANONICAL_URL').then(res => {
+            expect(res).to.equal(
+              '?href=https%3A%2F%2Fpinterest.com%3A8080%2Fpin1'
             );
-            resolve();
           });
         });
-      return Services.urlReplacementsForDoc(win.document.documentElement)
-        .expandUrlAsync('?url=SOURCE_URL')
-        .then(res => {
-          expect(res).to.contain('example.com');
+
+      it.configure()
+        .skipFirefox()
+        .run('should replace CANONICAL_HOST', () => {
+          return expandUrlAsync('?host=CANONICAL_HOST').then(res => {
+            expect(res).to.equal('?host=pinterest.com%3A8080');
+          });
         });
-    });
 
-    it('should add extra params to SOURCE_URL', () => {
-      const win = getFakeWindow();
-      win.location = parseUrlDeprecated(
-        'https://cdn.ampproject.org/a/o.com/foo/?a&amp_r=hello%3Dworld'
-      );
-      env.sandbox
-        .stub(trackPromise, 'getTrackImpressionPromise')
-        .callsFake(() => {
-          return Promise.resolve();
+      it.configure()
+        .skipFirefox()
+        .run('should replace CANONICAL_HOSTNAME', () => {
+          return expandUrlAsync('?host=CANONICAL_HOSTNAME').then(res => {
+            expect(res).to.equal('?host=pinterest.com');
+          });
         });
-      return Services.urlReplacementsForDoc(win.document.documentElement)
-        .expandUrlAsync('?url=SOURCE_URL')
-        .then(res => {
-          expect(res).to.equal(
-            '?url=' + encodeURIComponent('http://o.com/foo/?a&hello=world')
-          );
+
+      it.configure()
+        .skipFirefox()
+        .run('should replace CANONICAL_PATH', () => {
+          return expandUrlAsync('?path=CANONICAL_PATH').then(res => {
+            expect(res).to.equal('?path=%2Fpin1');
+          });
         });
-    });
 
-    it('should ignore extra params that already exists in SOURCE_URL', () => {
-      const win = getFakeWindow();
-      win.location = parseUrlDeprecated(
-        'https://cdn.ampproject.org/a/o.com/foo/?a=1&safe=1&amp_r=hello%3Dworld%26safe=evil'
-      );
-      env.sandbox
-        .stub(trackPromise, 'getTrackImpressionPromise')
-        .callsFake(() => {
-          return Promise.resolve();
-        });
-      return Services.urlReplacementsForDoc(win.document.documentElement)
-        .expandUrlAsync('?url=SOURCE_URL')
-        .then(res => {
-          expect(res).to.equal(
-            '?url=' +
-              encodeURIComponent('http://o.com/foo/?a=1&safe=1&hello=world')
-          );
-        });
-    });
-
-    it('should not change SOURCE_URL if is not ad landing page', () => {
-      const win = getFakeWindow();
-      win.location = parseUrlDeprecated(
-        'https://cdn.ampproject.org/v/o.com/foo/?a&amp_r=hello%3Dworld'
-      );
-      env.sandbox
-        .stub(trackPromise, 'getTrackImpressionPromise')
-        .callsFake(() => {
-          return Promise.resolve();
-        });
-      return Services.urlReplacementsForDoc(win.document.documentElement)
-        .expandUrlAsync('?url=SOURCE_URL')
-        .then(res => {
-          expect(res).to.equal(
-            '?url=' + encodeURIComponent('http://o.com/foo/?a')
-          );
-        });
-    });
-  });
-
-  it('should replace SOURCE_PATH', () => {
-    return expandUrlAsync('?path=SOURCE_PATH').then(res => {
-      expect(res).to.not.match(/SOURCE_PATH/);
-    });
-  });
-
-  it('should replace PAGE_VIEW_ID', () => {
-    return expandUrlAsync('?pid=PAGE_VIEW_ID').then(res => {
-      expect(res).to.match(/pid=\d+/);
-    });
-  });
-
-  it('should replace PAGE_VIEW_ID_64', () => {
-    return expandUrlAsync('?pid=PAGE_VIEW_ID_64').then(res => {
-      expect(res).to.match(/pid=([a-zA-Z0-9_-]+){10,}/);
-    });
-  });
-
-  it('should replace CLIENT_ID', () => {
-    setCookie(window, 'url-abc', 'cid-for-abc');
-    // Make sure cookie does not exist
-    setCookie(window, 'url-xyz', '');
-    return expandUrlAsync(
-      '?a=CLIENT_ID(url-abc)&b=CLIENT_ID(url-xyz)',
-      /*opt_bindings*/ undefined,
-      {withCid: true}
-    ).then(res => {
-      expect(res).to.match(/^\?a=cid-for-abc\&b=amp-([a-zA-Z0-9_-]+){10,}/);
-    });
-  });
-
-  it('should allow empty CLIENT_ID', () => {
-    return getReplacements()
-      .then(replacements => {
-        stubServiceForDoc(env.sandbox, ampdoc, 'cid', 'get').returns(
-          Promise.resolve()
-        );
-        return replacements.expandUrlAsync('?a=CLIENT_ID(_ga)');
-      })
-      .then(res => {
-        expect(res).to.equal('?a=');
+      it('should replace DOCUMENT_REFERRER', async () => {
+        const replacements = await getReplacements();
+        env.sandbox
+          .stub(viewerService, 'getReferrerUrl')
+          .returns('http://fake.example/?foo=bar');
+        const res = await replacements.expandUrlAsync('?ref=DOCUMENT_REFERRER');
+        expect(res).to.equal('?ref=http%3A%2F%2Ffake.example%2F%3Ffoo%3Dbar');
       });
-  });
 
-  it('should replace CLIENT_ID with opt_cookieName', () => {
-    setCookie(window, 'url-abc', 'cid-for-abc');
-    // Make sure cookie does not exist
-    setCookie(window, 'url-xyz', '');
-    return expandUrlAsync(
-      '?a=CLIENT_ID(abc,,url-abc)&b=CLIENT_ID(xyz,,url-xyz)',
-      /*opt_bindings*/ undefined,
-      {withCid: true}
-    ).then(res => {
-      expect(res).to.match(/^\?a=cid-for-abc\&b=amp-([a-zA-Z0-9_-]+){10,}/);
-    });
-  });
-
-  it('should parse _ga cookie correctly', () => {
-    setCookie(window, '_ga', 'GA1.2.12345.54321');
-    return expandUrlAsync(
-      '?a=CLIENT_ID(AMP_ECID_GOOGLE,,_ga)&b=CLIENT_ID(_ga)',
-      /*opt_bindings*/ undefined,
-      {withCid: true}
-    ).then(res => {
-      expect(res).to.match(/^\?a=12345.54321&b=12345.54321/);
-    });
-  });
-
-  // TODO(alanorozco, #11827): Make this test work on Safari.
-  it.configure()
-    .skipSafari()
-    .run('should replace CLIENT_ID synchronously when available', () => {
-      return getReplacements({withCid: true}).then(urlReplacements => {
-        setCookie(window, 'url-abc', 'cid-for-abc');
-        setCookie(window, 'url-xyz', 'cid-for-xyz');
-        // Only requests cid-for-xyz in async path
-        return urlReplacements
-          .expandUrlAsync('b=CLIENT_ID(url-xyz)')
-          .then(res => {
-            expect(res).to.equal('b=cid-for-xyz');
+      it('should replace EXTERNAL_REFERRER', () => {
+        const windowInterface = mockWindowInterface(env.sandbox);
+        windowInterface.getHostname.returns('different.org');
+        return getReplacements()
+          .then(replacements => {
+            stubServiceForDoc(
+              env.sandbox,
+              ampdoc,
+              'viewer',
+              'getReferrerUrl'
+            ).returns(Promise.resolve('http://example.org/page.html'));
+            return replacements.expandUrlAsync('?ref=EXTERNAL_REFERRER');
           })
-          .then(() => {
-            const result = urlReplacements.expandUrlSync(
-              '?a=CLIENT_ID(url-abc)&b=CLIENT_ID(url-xyz)' +
-                '&c=CLIENT_ID(other)'
-            );
-            expect(result).to.equal('?a=&b=cid-for-xyz&c=');
+          .then(res => {
+            expect(res).to.equal('?ref=http%3A%2F%2Fexample.org%2Fpage.html');
           });
       });
-    });
 
-  it('should replace AMP_STATE(key)', () => {
-    const win = getFakeWindow();
-    env.sandbox.stub(Services, 'bindForDocOrNull').returns(
-      Promise.resolve({
-        getStateValue(key) {
-          expect(key).to.equal('foo.bar');
-          return Promise.resolve('baz');
-        },
-      })
-    );
-    return Services.urlReplacementsForDoc(win.document.documentElement)
-      .expandUrlAsync('?state=AMP_STATE(foo.bar)')
-      .then(res => {
-        expect(res).to.equal('?state=baz');
-      });
-  });
-
-  // TODO(#16916): Make this test work with synchronous throws.
-  it.skip('should replace VARIANT', () => {
-    return expect(
-      expandUrlAsync(
-        '?x1=VARIANT(x1)&x2=VARIANT(x2)&x3=VARIANT(x3)',
-        /*opt_bindings*/ undefined,
-        {withVariant: true}
-      )
-    ).to.eventually.equal('?x1=v1&x2=none&x3=');
-  });
-
-  // TODO(#16916): Make this test work with synchronous throws.
-  it.skip(
-    'should replace VARIANT with empty string if ' +
-      'amp-experiment is not configured ',
-    () => {
-      return expect(
-        expandUrlAsync('?x1=VARIANT(x1)&x2=VARIANT(x2)&x3=VARIANT(x3)')
-      ).to.eventually.equal('?x1=&x2=&x3=');
-    }
-  );
-
-  it('should replace VARIANTS', () => {
-    return expect(
-      expandUrlAsync('?VARIANTS', /*opt_bindings*/ undefined, {
-        withVariant: true,
-      })
-    ).to.eventually.equal('?x1.v1!x2.none');
-  });
-
-  // TODO(#16916): Make this test work with synchronous throws.
-  it.skip(
-    'should replace VARIANTS with empty string if ' +
-      'amp-experiment is not configured ',
-    () => {
-      return expect(expandUrlAsync('?VARIANTS')).to.eventually.equal('?');
-    }
-  );
-
-  it('should replace SHARE_TRACKING_INCOMING and SHARE_TRACKING_OUTGOING', () => {
-    return expect(
-      expandUrlAsync(
-        '?in=SHARE_TRACKING_INCOMING&out=SHARE_TRACKING_OUTGOING',
-        /*opt_bindings*/ undefined,
-        {withShareTracking: true}
-      )
-    ).to.eventually.equal('?in=12345&out=54321');
-  });
-
-  // TODO(#16916): Make this test work with synchronous throws.
-  it.skip(
-    'should replace SHARE_TRACKING_INCOMING and SHARE_TRACKING_OUTGOING' +
-      ' with empty string if amp-share-tracking is not configured',
-    () => {
-      return expect(
-        expandUrlAsync(
-          '?in=SHARE_TRACKING_INCOMING&out=SHARE_TRACKING_OUTGOING'
-        )
-      ).to.eventually.equal('?in=&out=');
-    }
-  );
-
-  it('should replace STORY_PAGE_INDEX and STORY_PAGE_ID', () => {
-    return expect(
-      expandUrlAsync(
-        '?index=STORY_PAGE_INDEX&id=STORY_PAGE_ID',
-        /*opt_bindings*/ undefined,
-        {withStoryVariableService: true}
-      )
-    ).to.eventually.equal('?index=546&id=id-123');
-  });
-
-  // TODO(#16916): Make this test work with synchronous throws.
-  it.skip(
-    'should replace STORY_PAGE_INDEX and STORY_PAGE_ID' +
-      ' with empty string if amp-story is not configured',
-    () => {
-      return expect(
-        expandUrlAsync('?index=STORY_PAGE_INDEX&id=STORY_PAGE_ID')
-      ).to.eventually.equal('?index=&id=');
-    }
-  );
-
-  it('should replace TIMESTAMP', () => {
-    return expandUrlAsync('?ts=TIMESTAMP').then(res => {
-      expect(res).to.match(/ts=\d+/);
-    });
-  });
-
-  it('should replace TIMESTAMP_ISO', () => {
-    return expandUrlAsync('?tsf=TIMESTAMP_ISO').then(res => {
-      expect(res).to.match(/tsf=\d+/);
-    });
-  });
-
-  it('should return correct ISO timestamp', () => {
-    const fakeTime = 1499979336612;
-    env.sandbox.useFakeTimers(fakeTime);
-    return expect(expandUrlAsync('?tsf=TIMESTAMP_ISO')).to.eventually.equal(
-      '?tsf=2017-07-13T20%3A55%3A36.612Z'
-    );
-  });
-
-  it('should replace TIMEZONE', () => {
-    return expandUrlAsync('?tz=TIMEZONE').then(res => {
-      expect(res).to.match(/tz=-?\d+/);
-    });
-  });
-
-  it('should replace TIMEZONE_CODE', () => {
-    return expandUrlAsync('?tz_code=TIMEZONE_CODE').then(res => {
-      expect(res).to.match(/tz_code=\w+|^$/);
-    });
-  });
-
-  it('should replace SCROLL_TOP', () => {
-    return expandUrlAsync('?scrollTop=SCROLL_TOP').then(res => {
-      expect(res).to.match(/scrollTop=\d+/);
-    });
-  });
-
-  it('should replace SCROLL_LEFT', () => {
-    return expandUrlAsync('?scrollLeft=SCROLL_LEFT').then(res => {
-      expect(res).to.match(/scrollLeft=\d+/);
-    });
-  });
-
-  it('should replace SCROLL_HEIGHT', () => {
-    return expandUrlAsync('?scrollHeight=SCROLL_HEIGHT').then(res => {
-      expect(res).to.match(/scrollHeight=\d+/);
-    });
-  });
-
-  it('should replace SCREEN_WIDTH', () => {
-    return expandUrlAsync('?sw=SCREEN_WIDTH').then(res => {
-      expect(res).to.match(/sw=\d+/);
-    });
-  });
-
-  it('should replace SCREEN_HEIGHT', () => {
-    return expandUrlAsync('?sh=SCREEN_HEIGHT').then(res => {
-      expect(res).to.match(/sh=\d+/);
-    });
-  });
-
-  it('should replace VIEWPORT_WIDTH', () => {
-    return expandUrlAsync('?vw=VIEWPORT_WIDTH').then(res => {
-      expect(res).to.match(/vw=\d+/);
-    });
-  });
-
-  it('should replace VIEWPORT_HEIGHT', () => {
-    return expandUrlAsync('?vh=VIEWPORT_HEIGHT').then(res => {
-      expect(res).to.match(/vh=\d+/);
-    });
-  });
-
-  it('should replace PAGE_LOAD_TIME', () => {
-    return expandUrlAsync('?sh=PAGE_LOAD_TIME').then(res => {
-      expect(res).to.match(/sh=\d+/);
-    });
-  });
-
-  it('should replace FIRST_CONTENTFUL_PAINT', () => {
-    const win = getFakeWindow();
-    env.sandbox.stub(Services, 'performanceFor').returns({
-      getFirstContentfulPaint() {
-        return 1;
-      },
-    });
-    return Services.urlReplacementsForDoc(win.document.documentElement)
-      .expandUrlAsync('FIRST_CONTENTFUL_PAINT')
-      .then(res => {
-        expect(res).to.match(/^\d+$/);
-      });
-  });
-
-  it('should replace FIRST_VIEWPORT_READY', () => {
-    const win = getFakeWindow();
-    env.sandbox.stub(Services, 'performanceFor').returns({
-      getFirstViewportReady() {
-        return 1;
-      },
-    });
-    return Services.urlReplacementsForDoc(win.document.documentElement)
-      .expandUrlAsync('FIRST_VIEWPORT_READY')
-      .then(res => {
-        expect(res).to.match(/^\d+$/);
-      });
-  });
-
-  it('should replace MAKE_BODY_VISIBLE', () => {
-    const win = getFakeWindow();
-    env.sandbox.stub(Services, 'performanceFor').returns({
-      getMakeBodyVisible() {
-        return 1;
-      },
-    });
-    return Services.urlReplacementsForDoc(win.document.documentElement)
-      .expandUrlAsync('MAKE_BODY_VISIBLE')
-      .then(res => {
-        expect(res).to.match(/^\d+$/);
-      });
-  });
-
-  it('should reject protocol changes', () => {
-    const win = getFakeWindow();
-    const {documentElement} = win.document;
-    const urlReplacements = Services.urlReplacementsForDoc(documentElement);
-    return urlReplacements
-      .expandUrlAsync('PROTOCOL://example.com/?r=RANDOM', {
-        'PROTOCOL': Promise.resolve('abc'),
-      })
-      .then(expanded => {
-        expect(expanded).to.equal('PROTOCOL://example.com/?r=RANDOM');
-      });
-  });
-
-  it('Should replace BACKGROUND_STATE with 0', () => {
-    const win = getFakeWindow();
-    const {ampdoc} = win;
-    env.sandbox.stub(ampdoc, 'isVisible').returns(true);
-    return Services.urlReplacementsForDoc(win.document.documentElement)
-      .expandUrlAsync('?sh=BACKGROUND_STATE')
-      .then(res => {
-        expect(res).to.equal('?sh=0');
-      });
-  });
-
-  it('Should replace BACKGROUND_STATE with 1', () => {
-    const win = getFakeWindow();
-    const {ampdoc} = win;
-    env.sandbox.stub(ampdoc, 'isVisible').returns(false);
-    return Services.urlReplacementsForDoc(win.document.documentElement)
-      .expandUrlAsync('?sh=BACKGROUND_STATE')
-      .then(res => {
-        expect(res).to.equal('?sh=1');
-      });
-  });
-
-  it('Should replace VIDEO_STATE(video,parameter) with video data', () => {
-    const win = getFakeWindow();
-    env.sandbox.stub(Services, 'videoManagerForDoc').returns({
-      getAnalyticsDetails() {
-        return Promise.resolve({currentTime: 1.5});
-      },
-    });
-    env.sandbox
-      .stub(win.document, 'getElementById')
-      .withArgs('video')
-      .returns(document.createElement('video'));
-
-    return Services.urlReplacementsForDoc(win.document.documentElement)
-      .expandUrlAsync('?sh=VIDEO_STATE(video,currentTime)')
-      .then(res => {
-        expect(res).to.equal('?sh=1.5');
-      });
-  });
-
-  describe('PAGE_LOAD_TIME', () => {
-    let win;
-    let eventListeners;
-    beforeEach(() => {
-      win = getFakeWindow();
-      eventListeners = {};
-      win.document.readyState = 'loading';
-      win.document.addEventListener = function(eventType, handler) {
-        eventListeners[eventType] = handler;
-      };
-      win.document.removeEventListener = function(eventType, handler) {
-        if (eventListeners[eventType] == handler) {
-          delete eventListeners[eventType];
+      it(
+        'should replace EXTERNAL_REFERRER to empty string ' +
+          'if referrer is of same domain',
+        () => {
+          const windowInterface = mockWindowInterface(env.sandbox);
+          windowInterface.getHostname.returns('example.org');
+          return getReplacements()
+            .then(replacements => {
+              stubServiceForDoc(
+                env.sandbox,
+                ampdoc,
+                'viewer',
+                'getReferrerUrl'
+              ).returns(Promise.resolve('http://example.org/page.html'));
+              return replacements.expandUrlAsync('?ref=EXTERNAL_REFERRER');
+            })
+            .then(res => {
+              expect(res).to.equal('?ref=');
+            });
         }
-      };
-    });
+      );
 
-    it('is replaced if timing info is not available', () => {
-      win.document.readyState = 'complete';
-      return Services.urlReplacementsForDoc(win.document.documentElement)
-        .expandUrlAsync('?sh=PAGE_LOAD_TIME&s')
-        .then(res => {
-          expect(res).to.match(/sh=&s/);
+      it(
+        'should replace EXTERNAL_REFERRER to empty string ' +
+          'if referrer is CDN proxy of same domain',
+        () => {
+          const windowInterface = mockWindowInterface(env.sandbox);
+          windowInterface.getHostname.returns('example.org');
+          return getReplacements()
+            .then(replacements => {
+              stubServiceForDoc(
+                env.sandbox,
+                ampdoc,
+                'viewer',
+                'getReferrerUrl'
+              ).returns(
+                Promise.resolve(
+                  'https://example-org.cdn.ampproject.org/v/example.org/page.html'
+                )
+              );
+              return replacements.expandUrlAsync('?ref=EXTERNAL_REFERRER');
+            })
+            .then(res => {
+              expect(res).to.equal('?ref=');
+            });
+        }
+      );
+
+      it(
+        'should replace EXTERNAL_REFERRER to empty string ' +
+          'if referrer is CDN proxy of same domain (before CURLS)',
+        () => {
+          const windowInterface = mockWindowInterface(env.sandbox);
+          windowInterface.getHostname.returns('example.org');
+          return getReplacements()
+            .then(replacements => {
+              stubServiceForDoc(
+                env.sandbox,
+                ampdoc,
+                'viewer',
+                'getReferrerUrl'
+              ).returns(
+                Promise.resolve(
+                  'https://cdn.ampproject.org/v/example.org/page.html'
+                )
+              );
+              return replacements.expandUrlAsync('?ref=EXTERNAL_REFERRER');
+            })
+            .then(res => {
+              expect(res).to.equal('?ref=');
+            });
+        }
+      );
+
+      it('should replace TITLE', () => {
+        return expandUrlAsync('?title=TITLE').then(res => {
+          expect(res).to.equal('?title=Pixel%20Test');
         });
-    });
-
-    it('is replaced if PAGE_LOAD_TIME is available within a delay', () => {
-      const {documentElement} = win.document;
-      const urlReplacements = Services.urlReplacementsForDoc(documentElement);
-      const validMetric = urlReplacements.expandUrlAsync(
-        '?sh=PAGE_LOAD_TIME&s'
-      );
-      urlReplacements.ampdoc.win.performance.timing.loadEventStart = 109;
-      win.document.readyState = 'complete';
-      loadObservable.fire({type: 'load'});
-      return validMetric.then(res => {
-        expect(res).to.match(/sh=9&s/);
       });
-    });
-  });
 
-  it('should replace NAV_REDIRECT_COUNT', () => {
-    return expandUrlAsync('?sh=NAV_REDIRECT_COUNT').then(res => {
-      expect(res).to.match(/sh=\d+/);
-    });
-  });
-
-  // TODO(cvializ, #12336): unskip
-  it.skip('should replace NAV_TIMING', () => {
-    return expandUrlAsync(
-      '?a=NAV_TIMING(navigationStart)' +
-        '&b=NAV_TIMING(navigationStart,responseStart)'
-    ).then(res => {
-      expect(res).to.match(/a=\d+&b=\d+/);
-    });
-  });
-
-  it('should replace NAV_TIMING when attribute names are invalid', () => {
-    return expandUrlAsync(
-      '?a=NAV_TIMING(invalid)' +
-        '&b=NAV_TIMING(invalid,invalid)' +
-        '&c=NAV_TIMING(navigationStart,invalid)' +
-        '&d=NAV_TIMING(invalid,responseStart)'
-    ).then(res => {
-      expect(res).to.match(/a=&b=&c=&d=/);
-    });
-  });
-
-  it('should replace NAV_TYPE', () => {
-    return expandUrlAsync('?sh=NAV_TYPE').then(res => {
-      expect(res).to.match(/sh=\d+/);
-    });
-  });
-
-  it('should replace DOMAIN_LOOKUP_TIME', () => {
-    return expandUrlAsync('?sh=DOMAIN_LOOKUP_TIME').then(res => {
-      expect(res).to.match(/sh=\d+/);
-    });
-  });
-
-  it('should replace TCP_CONNECT_TIME', () => {
-    return expandUrlAsync('?sh=TCP_CONNECT_TIME').then(res => {
-      expect(res).to.match(/sh=\d+/);
-    });
-  });
-
-  it('should replace SERVER_RESPONSE_TIME', () => {
-    return expandUrlAsync('?sh=SERVER_RESPONSE_TIME').then(res => {
-      expect(res).to.match(/sh=\d+/);
-    });
-  });
-
-  it('should replace PAGE_DOWNLOAD_TIME', () => {
-    return expandUrlAsync('?sh=PAGE_DOWNLOAD_TIME').then(res => {
-      expect(res).to.match(/sh=\d+/);
-    });
-  });
-
-  // TODO(cvializ, #12336): unskip
-  it.skip('should replace REDIRECT_TIME', () => {
-    return expandUrlAsync('?sh=REDIRECT_TIME').then(res => {
-      expect(res).to.match(/sh=\d+/);
-    });
-  });
-
-  it('should replace DOM_INTERACTIVE_TIME', () => {
-    return expandUrlAsync('?sh=DOM_INTERACTIVE_TIME').then(res => {
-      expect(res).to.match(/sh=\d+/);
-    });
-  });
-
-  it('should replace CONTENT_LOAD_TIME', () => {
-    return expandUrlAsync('?sh=CONTENT_LOAD_TIME').then(res => {
-      expect(res).to.match(/sh=\d+/);
-    });
-  });
-
-  it('should replace AVAILABLE_SCREEN_HEIGHT', () => {
-    return expandUrlAsync('?sh=AVAILABLE_SCREEN_HEIGHT').then(res => {
-      expect(res).to.match(/sh=\d+/);
-    });
-  });
-
-  it('should replace AVAILABLE_SCREEN_WIDTH', () => {
-    return expandUrlAsync('?sh=AVAILABLE_SCREEN_WIDTH').then(res => {
-      expect(res).to.match(/sh=\d+/);
-    });
-  });
-
-  it('should replace SCREEN_COLOR_DEPTH', () => {
-    return expandUrlAsync('?sh=SCREEN_COLOR_DEPTH').then(res => {
-      expect(res).to.match(/sh=\d+/);
-    });
-  });
-
-  it('should replace BROWSER_LANGUAGE', () => {
-    return expandUrlAsync('?sh=BROWSER_LANGUAGE').then(res => {
-      expect(res).to.match(/sh=\w+/);
-    });
-  });
-
-  it('should replace USER_AGENT', () => {
-    return expandUrlAsync('?sh=USER_AGENT').then(res => {
-      expect(res).to.match(/sh=\w+/);
-    });
-  });
-
-  it('should replace VIEWER with origin', () => {
-    return getReplacements().then(replacements => {
-      env.sandbox
-        .stub(viewerService, 'getViewerOrigin')
-        .returns(Promise.resolve('https://www.google.com'));
-      return replacements.expandUrlAsync('?sh=VIEWER').then(res => {
-        expect(res).to.equal('?sh=https%3A%2F%2Fwww.google.com');
+      it('should prefer original title for TITLE', () => {
+        return expandUrlAsync('?title=TITLE', /*opt_bindings*/ undefined, {
+          withOriginalTitle: true,
+        }).then(res => {
+          expect(res).to.equal('?title=Original%20Pixel%20Test');
+        });
       });
-    });
-  });
 
-  it('should replace VIEWER with empty string', () => {
-    return getReplacements().then(replacements => {
-      env.sandbox
-        .stub(viewerService, 'getViewerOrigin')
-        .returns(Promise.resolve(''));
-      return replacements.expandUrlAsync('?sh=VIEWER').then(res => {
-        expect(res).to.equal('?sh=');
-      });
-    });
-  });
+      describe('AMPDOC_URL', () => {
+        it('should replace AMPDOC_URL', () => {
+          return expandUrlAsync('?ref=AMPDOC_URL').then(res => {
+            expect(res).to.not.match(/AMPDOC_URL/);
+          });
+        });
 
-  it('should replace TOTAL_ENGAGED_TIME', () => {
-    return expandUrlAsync(
-      '?sh=TOTAL_ENGAGED_TIME',
-      /*opt_bindings*/ undefined,
-      {withActivity: true}
-    ).then(res => {
-      expect(res).to.match(/sh=\d+/);
-    });
-  });
-
-  it('should replace INCREMENTAL_ENGAGED_TIME', () => {
-    return expandUrlAsync(
-      '?sh=INCREMENTAL_ENGAGED_TIME',
-      /*opt_bindings*/ undefined,
-      {withActivity: true}
-    ).then(res => {
-      expect(res).to.match(/sh=\d+/);
-    });
-  });
-
-  it('should replace AMP_VERSION', () => {
-    return expandUrlAsync('?sh=AMP_VERSION').then(res => {
-      expect(res).to.equal('?sh=%24internalRuntimeVersion%24');
-    });
-  });
-
-  it('should replace ANCESTOR_ORIGIN', () => {
-    return expect(
-      expandUrlAsync('ANCESTOR_ORIGIN/recipes', /*opt_bindings*/ undefined, {
-        withViewerIntegrationVariableService: {
-          ancestorOrigin: () => {
-            return 'http://margarine-paradise.com';
-          },
-          fragmentParam: (param, defaultValue) => {
-            return param == 'ice_cream' ? '2' : defaultValue;
-          },
-        },
-      })
-    ).to.eventually.equal('http://margarine-paradise.com/recipes');
-  });
-
-  it('should replace FRAGMENT_PARAM with 2', () => {
-    const win = getFakeWindow();
-    win.location = {originalHash: '#margarine=1&ice=2&cream=3'};
-    return Services.urlReplacementsForDoc(win.document.documentElement)
-      .expandUrlAsync('?sh=FRAGMENT_PARAM(ice)&s')
-      .then(res => {
-        expect(res).to.equal('?sh=2&s');
-      });
-  });
-
-  it.configure()
-    .skipFirefox()
-    .run('should accept $expressions', () => {
-      return expandUrlAsync('?href=$CANONICAL_URL').then(res => {
-        expect(res).to.equal('?href=https%3A%2F%2Fpinterest.com%3A8080%2Fpin1');
-      });
-    });
-
-  it('should ignore unknown substitutions', () => {
-    return expandUrlAsync('?a=UNKNOWN').then(res => {
-      expect(res).to.equal('?a=UNKNOWN');
-    });
-  });
-
-  it.configure()
-    .skipFirefox()
-    .run('should replace several substitutions', () => {
-      return expandUrlAsync('?a=UNKNOWN&href=CANONICAL_URL&title=TITLE').then(
-        res => {
-          expect(res).to.equal(
-            '?a=UNKNOWN' +
-              '&href=https%3A%2F%2Fpinterest.com%3A8080%2Fpin1' +
-              '&title=Pixel%20Test'
+        it('should add extra params to AMPDOC_URL', () => {
+          const win = getFakeWindow();
+          win.location = parseUrlDeprecated(
+            'https://cdn.ampproject.org/a/o.com/foo/?amp_r=hello%3Dworld'
           );
+          return Services.urlReplacementsForDoc(win.document.documentElement)
+            .expandUrlAsync('?url=AMPDOC_URL')
+            .then(res => {
+              expect(res).to.contain(
+                encodeURIComponent(
+                  'https://cdn.ampproject.org/a/o.com/foo/?hello=world'
+                )
+              );
+            });
+        });
+
+        it('should merge extra params in AMPDOC_URL', () => {
+          const win = getFakeWindow();
+          win.location = parseUrlDeprecated(
+            'https://cdn.ampproject.org/a/o.com/foo/?test=case&amp_r=hello%3Dworld'
+          );
+          return Services.urlReplacementsForDoc(win.document.documentElement)
+            .expandUrlAsync('?url=AMPDOC_URL')
+            .then(res => {
+              expect(res).to.contain(
+                encodeURIComponent(
+                  'https://cdn.ampproject.org/a/o.com/foo/?test=case&hello=world'
+                )
+              );
+            });
+        });
+
+        it('should allow an embedded amp_r parameter', () => {
+          const win = getFakeWindow();
+          win.location = parseUrlDeprecated(
+            'https://cdn.ampproject.org/a/o.com/foo/?amp_r=amp_r%3Dweird'
+          );
+          return Services.urlReplacementsForDoc(win.document.documentElement)
+            .expandUrlAsync('?url=AMPDOC_URL')
+            .then(res => {
+              expect(res).to.contain(
+                encodeURIComponent(
+                  'https://cdn.ampproject.org/a/o.com/foo/?amp_r=weird'
+                )
+              );
+            });
+        });
+
+        it('should prefer original params in AMPDOC_URL', () => {
+          const win = getFakeWindow();
+          win.location = parseUrlDeprecated(
+            'https://cdn.ampproject.org/a/o.com/foo/?test=case&amp_r=test%3Devil'
+          );
+          return Services.urlReplacementsForDoc(win.document.documentElement)
+            .expandUrlAsync('?url=AMPDOC_URL')
+            .then(res => {
+              expect(res).to.contain(
+                encodeURIComponent(
+                  'https://cdn.ampproject.org/a/o.com/foo/?test=case'
+                )
+              );
+            });
+        });
+
+        it('should merge multiple extra params safely in AMPDOC_URL', () => {
+          const win = getFakeWindow();
+          win.location = parseUrlDeprecated(
+            'https://cdn.ampproject.org/a/o.com/foo/?test=case&a&hello=you&amp_r=hello%3Dworld%26goodnight%3Dmoon'
+          );
+          return Services.urlReplacementsForDoc(win.document.documentElement)
+            .expandUrlAsync('?url=AMPDOC_URL')
+            .then(res => {
+              expect(res).to.contain(
+                encodeURIComponent(
+                  'https://cdn.ampproject.org/a/o.com/foo/?test=case&a&hello=you&goodnight=moon'
+                )
+              );
+            });
+        });
+      });
+
+      it('should replace AMPDOC_HOST', () => {
+        return expandUrlAsync('?ref=AMPDOC_HOST').then(res => {
+          expect(res).to.not.match(/AMPDOC_HOST/);
+        });
+      });
+
+      it('should replace AMPDOC_HOSTNAME', () => {
+        return expandUrlAsync('?ref=AMPDOC_HOSTNAME').then(res => {
+          expect(res).to.not.match(/AMPDOC_HOSTNAME/);
+        });
+      });
+
+      describe('SOURCE_URL', () => {
+        it('should replace SOURCE_URL and SOURCE_HOST', () => {
+          const win = getFakeWindow();
+          win.location = parseUrlDeprecated('https://wrong.com');
+          env.sandbox
+            .stub(trackPromise, 'getTrackImpressionPromise')
+            .callsFake(() => {
+              return new Promise(resolve => {
+                win.location = parseUrlDeprecated('https://example.com/test');
+                resolve();
+              });
+            });
+          return Services.urlReplacementsForDoc(win.document.documentElement)
+            .expandUrlAsync('?url=SOURCE_URL&host=SOURCE_HOST')
+            .then(res => {
+              expect(res).to.equal(
+                '?url=https%3A%2F%2Fexample.com%2Ftest&host=example.com'
+              );
+            });
+        });
+
+        it('should replace SOURCE_URL and SOURCE_HOSTNAME', () => {
+          const win = getFakeWindow();
+          win.location = parseUrlDeprecated('https://wrong.com');
+          env.sandbox
+            .stub(trackPromise, 'getTrackImpressionPromise')
+            .callsFake(() => {
+              return new Promise(resolve => {
+                win.location = parseUrlDeprecated('https://example.com/test');
+                resolve();
+              });
+            });
+          return Services.urlReplacementsForDoc(win.document.documentElement)
+            .expandUrlAsync('?url=SOURCE_URL&hostname=SOURCE_HOSTNAME')
+            .then(res => {
+              expect(res).to.equal(
+                '?url=https%3A%2F%2Fexample.com%2Ftest&hostname=example.com'
+              );
+            });
+        });
+
+        it('should update SOURCE_URL after track impression', () => {
+          const win = getFakeWindow();
+          win.location = parseUrlDeprecated('https://wrong.com');
+          env.sandbox
+            .stub(trackPromise, 'getTrackImpressionPromise')
+            .callsFake(() => {
+              return new Promise(resolve => {
+                win.location = parseUrlDeprecated(
+                  'https://example.com?gclid=123456'
+                );
+                resolve();
+              });
+            });
+          return Services.urlReplacementsForDoc(win.document.documentElement)
+            .expandUrlAsync('?url=SOURCE_URL')
+            .then(res => {
+              expect(res).to.contain('example.com');
+            });
+        });
+
+        it('should add extra params to SOURCE_URL', () => {
+          const win = getFakeWindow();
+          win.location = parseUrlDeprecated(
+            'https://cdn.ampproject.org/a/o.com/foo/?a&amp_r=hello%3Dworld'
+          );
+          env.sandbox
+            .stub(trackPromise, 'getTrackImpressionPromise')
+            .callsFake(() => {
+              return Promise.resolve();
+            });
+          return Services.urlReplacementsForDoc(win.document.documentElement)
+            .expandUrlAsync('?url=SOURCE_URL')
+            .then(res => {
+              expect(res).to.equal(
+                '?url=' + encodeURIComponent('http://o.com/foo/?a&hello=world')
+              );
+            });
+        });
+
+        it('should ignore extra params that already exists in SOURCE_URL', () => {
+          const win = getFakeWindow();
+          win.location = parseUrlDeprecated(
+            'https://cdn.ampproject.org/a/o.com/foo/?a=1&safe=1&amp_r=hello%3Dworld%26safe=evil'
+          );
+          env.sandbox
+            .stub(trackPromise, 'getTrackImpressionPromise')
+            .callsFake(() => {
+              return Promise.resolve();
+            });
+          return Services.urlReplacementsForDoc(win.document.documentElement)
+            .expandUrlAsync('?url=SOURCE_URL')
+            .then(res => {
+              expect(res).to.equal(
+                '?url=' +
+                  encodeURIComponent('http://o.com/foo/?a=1&safe=1&hello=world')
+              );
+            });
+        });
+
+        it('should not change SOURCE_URL if is not ad landing page', () => {
+          const win = getFakeWindow();
+          win.location = parseUrlDeprecated(
+            'https://cdn.ampproject.org/v/o.com/foo/?a&amp_r=hello%3Dworld'
+          );
+          env.sandbox
+            .stub(trackPromise, 'getTrackImpressionPromise')
+            .callsFake(() => {
+              return Promise.resolve();
+            });
+          return Services.urlReplacementsForDoc(win.document.documentElement)
+            .expandUrlAsync('?url=SOURCE_URL')
+            .then(res => {
+              expect(res).to.equal(
+                '?url=' + encodeURIComponent('http://o.com/foo/?a')
+              );
+            });
+        });
+      });
+
+      it('should replace SOURCE_PATH', () => {
+        return expandUrlAsync('?path=SOURCE_PATH').then(res => {
+          expect(res).to.not.match(/SOURCE_PATH/);
+        });
+      });
+
+      it('should replace PAGE_VIEW_ID', () => {
+        return expandUrlAsync('?pid=PAGE_VIEW_ID').then(res => {
+          expect(res).to.match(/pid=\d+/);
+        });
+      });
+
+      it('should replace PAGE_VIEW_ID_64', () => {
+        return expandUrlAsync('?pid=PAGE_VIEW_ID_64').then(res => {
+          expect(res).to.match(/pid=([a-zA-Z0-9_-]+){10,}/);
+        });
+      });
+
+      it('should replace CLIENT_ID', () => {
+        setCookie(window, 'url-abc', 'cid-for-abc');
+        // Make sure cookie does not exist
+        setCookie(window, 'url-xyz', '');
+        return expandUrlAsync(
+          '?a=CLIENT_ID(url-abc)&b=CLIENT_ID(url-xyz)',
+          /*opt_bindings*/ undefined,
+          {withCid: true}
+        ).then(res => {
+          expect(res).to.match(/^\?a=cid-for-abc\&b=amp-([a-zA-Z0-9_-]+){10,}/);
+        });
+      });
+
+      it('should allow empty CLIENT_ID', () => {
+        return getReplacements()
+          .then(replacements => {
+            stubServiceForDoc(env.sandbox, ampdoc, 'cid', 'get').returns(
+              Promise.resolve()
+            );
+            return replacements.expandUrlAsync('?a=CLIENT_ID(_ga)');
+          })
+          .then(res => {
+            expect(res).to.equal('?a=');
+          });
+      });
+
+      it('should replace CLIENT_ID with opt_cookieName', () => {
+        setCookie(window, 'url-abc', 'cid-for-abc');
+        // Make sure cookie does not exist
+        setCookie(window, 'url-xyz', '');
+        return expandUrlAsync(
+          '?a=CLIENT_ID(abc,,url-abc)&b=CLIENT_ID(xyz,,url-xyz)',
+          /*opt_bindings*/ undefined,
+          {withCid: true}
+        ).then(res => {
+          expect(res).to.match(/^\?a=cid-for-abc\&b=amp-([a-zA-Z0-9_-]+){10,}/);
+        });
+      });
+
+      it('should parse _ga cookie correctly', () => {
+        setCookie(window, '_ga', 'GA1.2.12345.54321');
+        return expandUrlAsync(
+          '?a=CLIENT_ID(AMP_ECID_GOOGLE,,_ga)&b=CLIENT_ID(_ga)',
+          /*opt_bindings*/ undefined,
+          {withCid: true}
+        ).then(res => {
+          expect(res).to.match(/^\?a=12345.54321&b=12345.54321/);
+        });
+      });
+
+      // TODO(alanorozco, #11827): Make this test work on Safari.
+      it.configure()
+        .skipSafari()
+        .run('should replace CLIENT_ID synchronously when available', () => {
+          return getReplacements({withCid: true}).then(urlReplacements => {
+            setCookie(window, 'url-abc', 'cid-for-abc');
+            setCookie(window, 'url-xyz', 'cid-for-xyz');
+            // Only requests cid-for-xyz in async path
+            return urlReplacements
+              .expandUrlAsync('b=CLIENT_ID(url-xyz)')
+              .then(res => {
+                expect(res).to.equal('b=cid-for-xyz');
+              })
+              .then(() => {
+                const result = urlReplacements.expandUrlSync(
+                  '?a=CLIENT_ID(url-abc)&b=CLIENT_ID(url-xyz)' +
+                    '&c=CLIENT_ID(other)'
+                );
+                expect(result).to.equal('?a=&b=cid-for-xyz&c=');
+              });
+          });
+        });
+
+      it('should replace AMP_STATE(key)', () => {
+        const win = getFakeWindow();
+        env.sandbox.stub(Services, 'bindForDocOrNull').returns(
+          Promise.resolve({
+            getStateValue(key) {
+              expect(key).to.equal('foo.bar');
+              return Promise.resolve('baz');
+            },
+          })
+        );
+        return Services.urlReplacementsForDoc(win.document.documentElement)
+          .expandUrlAsync('?state=AMP_STATE(foo.bar)')
+          .then(res => {
+            expect(res).to.equal('?state=baz');
+          });
+      });
+
+      // TODO(#16916): Make this test work with synchronous throws.
+      it.skip('should replace VARIANT', () => {
+        return expect(
+          expandUrlAsync(
+            '?x1=VARIANT(x1)&x2=VARIANT(x2)&x3=VARIANT(x3)',
+            /*opt_bindings*/ undefined,
+            {withVariant: true}
+          )
+        ).to.eventually.equal('?x1=v1&x2=none&x3=');
+      });
+
+      // TODO(#16916): Make this test work with synchronous throws.
+      it.skip(
+        'should replace VARIANT with empty string if ' +
+          'amp-experiment is not configured ',
+        () => {
+          return expect(
+            expandUrlAsync('?x1=VARIANT(x1)&x2=VARIANT(x2)&x3=VARIANT(x3)')
+          ).to.eventually.equal('?x1=&x2=&x3=');
         }
       );
-    });
 
-  it('should replace new substitutions', () => {
-    return getReplacements().then(replacements => {
-      replacements.getVariableSource().set('ONE', () => 'a');
-      expect(replacements.expandUrlAsync('?a=ONE')).to.eventually.equal('?a=a');
-      replacements.getVariableSource().set('ONE', () => 'b');
-      replacements.getVariableSource().set('TWO', () => 'b');
-      return expect(
-        replacements.expandUrlAsync('?a=ONE&b=TWO')
-      ).to.eventually.equal('?a=b&b=b');
-    });
-  });
+      it('should replace VARIANTS', () => {
+        return expect(
+          expandUrlAsync('?VARIANTS', /*opt_bindings*/ undefined, {
+            withVariant: true,
+          })
+        ).to.eventually.equal('?x1.v1!x2.none');
+      });
 
-  // TODO(#16916): Make this test work with synchronous throws.
-  it.skip('should report errors & replace them with empty string (sync)', () => {
-    const clock = env.sandbox.useFakeTimers();
-    const {documentElement} = window.document;
-    const replacements = Services.urlReplacementsForDoc(documentElement);
-    replacements.getVariableSource().set('ONE', () => {
-      throw new Error('boom');
-    });
-    const p = expect(replacements.expandUrlAsync('?a=ONE')).to.eventually.equal(
-      '?a='
-    );
-    allowConsoleError(() => {
-      expect(() => {
-        clock.tick(1);
-      }).to.throw(/boom/);
-    });
-    return p;
-  });
+      // TODO(#16916): Make this test work with synchronous throws.
+      it.skip(
+        'should replace VARIANTS with empty string if ' +
+          'amp-experiment is not configured ',
+        () => {
+          return expect(expandUrlAsync('?VARIANTS')).to.eventually.equal('?');
+        }
+      );
 
-  // TODO(#16916): Make this test work with synchronous throws.
-  it.skip('should report errors & replace them with empty string (promise)', () => {
-    const clock = env.sandbox.useFakeTimers();
-    const {documentElement} = window.document;
-    const replacements = Services.urlReplacementsForDoc(documentElement);
-    replacements.getVariableSource().set('ONE', () => {
-      return Promise.reject(new Error('boom'));
-    });
-    return expect(replacements.expandUrlAsync('?a=ONE'))
-      .to.eventually.equal('?a=')
-      .then(() => {
+      it('should replace SHARE_TRACKING_INCOMING and SHARE_TRACKING_OUTGOING', () => {
+        return expect(
+          expandUrlAsync(
+            '?in=SHARE_TRACKING_INCOMING&out=SHARE_TRACKING_OUTGOING',
+            /*opt_bindings*/ undefined,
+            {withShareTracking: true}
+          )
+        ).to.eventually.equal('?in=12345&out=54321');
+      });
+
+      // TODO(#16916): Make this test work with synchronous throws.
+      it.skip(
+        'should replace SHARE_TRACKING_INCOMING and SHARE_TRACKING_OUTGOING' +
+          ' with empty string if amp-share-tracking is not configured',
+        () => {
+          return expect(
+            expandUrlAsync(
+              '?in=SHARE_TRACKING_INCOMING&out=SHARE_TRACKING_OUTGOING'
+            )
+          ).to.eventually.equal('?in=&out=');
+        }
+      );
+
+      it('should replace STORY_PAGE_INDEX and STORY_PAGE_ID', () => {
+        return expect(
+          expandUrlAsync(
+            '?index=STORY_PAGE_INDEX&id=STORY_PAGE_ID',
+            /*opt_bindings*/ undefined,
+            {withStoryVariableService: true}
+          )
+        ).to.eventually.equal('?index=546&id=id-123');
+      });
+
+      // TODO(#16916): Make this test work with synchronous throws.
+      it.skip(
+        'should replace STORY_PAGE_INDEX and STORY_PAGE_ID' +
+          ' with empty string if amp-story is not configured',
+        () => {
+          return expect(
+            expandUrlAsync('?index=STORY_PAGE_INDEX&id=STORY_PAGE_ID')
+          ).to.eventually.equal('?index=&id=');
+        }
+      );
+
+      it('should replace TIMESTAMP', () => {
+        return expandUrlAsync('?ts=TIMESTAMP').then(res => {
+          expect(res).to.match(/ts=\d+/);
+        });
+      });
+
+      it('should replace TIMESTAMP_ISO', () => {
+        return expandUrlAsync('?tsf=TIMESTAMP_ISO').then(res => {
+          expect(res).to.match(/tsf=\d+/);
+        });
+      });
+
+      it('should return correct ISO timestamp', () => {
+        const fakeTime = 1499979336612;
+        env.sandbox.useFakeTimers(fakeTime);
+        return expect(expandUrlAsync('?tsf=TIMESTAMP_ISO')).to.eventually.equal(
+          '?tsf=2017-07-13T20%3A55%3A36.612Z'
+        );
+      });
+
+      it('should replace TIMEZONE', () => {
+        return expandUrlAsync('?tz=TIMEZONE').then(res => {
+          expect(res).to.match(/tz=-?\d+/);
+        });
+      });
+
+      it('should replace TIMEZONE_CODE', () => {
+        return expandUrlAsync('?tz_code=TIMEZONE_CODE').then(res => {
+          expect(res).to.match(/tz_code=\w+|^$/);
+        });
+      });
+
+      it('should replace SCROLL_TOP', () => {
+        return expandUrlAsync('?scrollTop=SCROLL_TOP').then(res => {
+          expect(res).to.match(/scrollTop=\d+/);
+        });
+      });
+
+      it('should replace SCROLL_LEFT', () => {
+        return expandUrlAsync('?scrollLeft=SCROLL_LEFT').then(res => {
+          expect(res).to.match(/scrollLeft=\d+/);
+        });
+      });
+
+      it('should replace SCROLL_HEIGHT', () => {
+        return expandUrlAsync('?scrollHeight=SCROLL_HEIGHT').then(res => {
+          expect(res).to.match(/scrollHeight=\d+/);
+        });
+      });
+
+      it('should replace SCREEN_WIDTH', () => {
+        return expandUrlAsync('?sw=SCREEN_WIDTH').then(res => {
+          expect(res).to.match(/sw=\d+/);
+        });
+      });
+
+      it('should replace SCREEN_HEIGHT', () => {
+        return expandUrlAsync('?sh=SCREEN_HEIGHT').then(res => {
+          expect(res).to.match(/sh=\d+/);
+        });
+      });
+
+      it('should replace VIEWPORT_WIDTH', () => {
+        return expandUrlAsync('?vw=VIEWPORT_WIDTH').then(res => {
+          expect(res).to.match(/vw=\d+/);
+        });
+      });
+
+      it('should replace VIEWPORT_HEIGHT', () => {
+        return expandUrlAsync('?vh=VIEWPORT_HEIGHT').then(res => {
+          expect(res).to.match(/vh=\d+/);
+        });
+      });
+
+      it('should replace PAGE_LOAD_TIME', () => {
+        return expandUrlAsync('?sh=PAGE_LOAD_TIME').then(res => {
+          expect(res).to.match(/sh=\d+/);
+        });
+      });
+
+      it('should replace FIRST_CONTENTFUL_PAINT', () => {
+        const win = getFakeWindow();
+        env.sandbox.stub(Services, 'performanceFor').returns({
+          getFirstContentfulPaint() {
+            return 1;
+          },
+        });
+        return Services.urlReplacementsForDoc(win.document.documentElement)
+          .expandUrlAsync('FIRST_CONTENTFUL_PAINT')
+          .then(res => {
+            expect(res).to.match(/^\d+$/);
+          });
+      });
+
+      it('should replace FIRST_VIEWPORT_READY', () => {
+        const win = getFakeWindow();
+        env.sandbox.stub(Services, 'performanceFor').returns({
+          getFirstViewportReady() {
+            return 1;
+          },
+        });
+        return Services.urlReplacementsForDoc(win.document.documentElement)
+          .expandUrlAsync('FIRST_VIEWPORT_READY')
+          .then(res => {
+            expect(res).to.match(/^\d+$/);
+          });
+      });
+
+      it('should replace MAKE_BODY_VISIBLE', () => {
+        const win = getFakeWindow();
+        env.sandbox.stub(Services, 'performanceFor').returns({
+          getMakeBodyVisible() {
+            return 1;
+          },
+        });
+        return Services.urlReplacementsForDoc(win.document.documentElement)
+          .expandUrlAsync('MAKE_BODY_VISIBLE')
+          .then(res => {
+            expect(res).to.match(/^\d+$/);
+          });
+      });
+
+      it('should reject protocol changes', () => {
+        const win = getFakeWindow();
+        const {documentElement} = win.document;
+        const urlReplacements = Services.urlReplacementsForDoc(documentElement);
+        return urlReplacements
+          .expandUrlAsync('PROTOCOL://example.com/?r=RANDOM', {
+            'PROTOCOL': Promise.resolve('abc'),
+          })
+          .then(expanded => {
+            expect(expanded).to.equal('PROTOCOL://example.com/?r=RANDOM');
+          });
+      });
+
+      it('Should replace BACKGROUND_STATE with 0', () => {
+        const win = getFakeWindow();
+        const {ampdoc} = win;
+        env.sandbox.stub(ampdoc, 'isVisible').returns(true);
+        return Services.urlReplacementsForDoc(win.document.documentElement)
+          .expandUrlAsync('?sh=BACKGROUND_STATE')
+          .then(res => {
+            expect(res).to.equal('?sh=0');
+          });
+      });
+
+      it('Should replace BACKGROUND_STATE with 1', () => {
+        const win = getFakeWindow();
+        const {ampdoc} = win;
+        env.sandbox.stub(ampdoc, 'isVisible').returns(false);
+        return Services.urlReplacementsForDoc(win.document.documentElement)
+          .expandUrlAsync('?sh=BACKGROUND_STATE')
+          .then(res => {
+            expect(res).to.equal('?sh=1');
+          });
+      });
+
+      it('Should replace VIDEO_STATE(video,parameter) with video data', () => {
+        const win = getFakeWindow();
+        env.sandbox.stub(Services, 'videoManagerForDoc').returns({
+          getAnalyticsDetails() {
+            return Promise.resolve({currentTime: 1.5});
+          },
+        });
+        env.sandbox
+          .stub(win.document, 'getElementById')
+          .withArgs('video')
+          .returns(document.createElement('video'));
+
+        return Services.urlReplacementsForDoc(win.document.documentElement)
+          .expandUrlAsync('?sh=VIDEO_STATE(video,currentTime)')
+          .then(res => {
+            expect(res).to.equal('?sh=1.5');
+          });
+      });
+
+      describe('PAGE_LOAD_TIME', () => {
+        let win;
+        let eventListeners;
+        beforeEach(() => {
+          win = getFakeWindow();
+          eventListeners = {};
+          win.document.readyState = 'loading';
+          win.document.addEventListener = function(eventType, handler) {
+            eventListeners[eventType] = handler;
+          };
+          win.document.removeEventListener = function(eventType, handler) {
+            if (eventListeners[eventType] == handler) {
+              delete eventListeners[eventType];
+            }
+          };
+        });
+
+        it('is replaced if timing info is not available', () => {
+          win.document.readyState = 'complete';
+          return Services.urlReplacementsForDoc(win.document.documentElement)
+            .expandUrlAsync('?sh=PAGE_LOAD_TIME&s')
+            .then(res => {
+              expect(res).to.match(/sh=&s/);
+            });
+        });
+
+        it('is replaced if PAGE_LOAD_TIME is available within a delay', () => {
+          const {documentElement} = win.document;
+          const urlReplacements = Services.urlReplacementsForDoc(
+            documentElement
+          );
+          const validMetric = urlReplacements.expandUrlAsync(
+            '?sh=PAGE_LOAD_TIME&s'
+          );
+          urlReplacements.ampdoc.win.performance.timing.loadEventStart = 109;
+          win.document.readyState = 'complete';
+          loadObservable.fire({type: 'load'});
+          return validMetric.then(res => {
+            expect(res).to.match(/sh=9&s/);
+          });
+        });
+      });
+
+      it('should replace NAV_REDIRECT_COUNT', () => {
+        return expandUrlAsync('?sh=NAV_REDIRECT_COUNT').then(res => {
+          expect(res).to.match(/sh=\d+/);
+        });
+      });
+
+      // TODO(cvializ, #12336): unskip
+      it.skip('should replace NAV_TIMING', () => {
+        return expandUrlAsync(
+          '?a=NAV_TIMING(navigationStart)' +
+            '&b=NAV_TIMING(navigationStart,responseStart)'
+        ).then(res => {
+          expect(res).to.match(/a=\d+&b=\d+/);
+        });
+      });
+
+      it('should replace NAV_TIMING when attribute names are invalid', () => {
+        return expandUrlAsync(
+          '?a=NAV_TIMING(invalid)' +
+            '&b=NAV_TIMING(invalid,invalid)' +
+            '&c=NAV_TIMING(navigationStart,invalid)' +
+            '&d=NAV_TIMING(invalid,responseStart)'
+        ).then(res => {
+          expect(res).to.match(/a=&b=&c=&d=/);
+        });
+      });
+
+      it('should replace NAV_TYPE', () => {
+        return expandUrlAsync('?sh=NAV_TYPE').then(res => {
+          expect(res).to.match(/sh=\d+/);
+        });
+      });
+
+      it('should replace DOMAIN_LOOKUP_TIME', () => {
+        return expandUrlAsync('?sh=DOMAIN_LOOKUP_TIME').then(res => {
+          expect(res).to.match(/sh=\d+/);
+        });
+      });
+
+      it('should replace TCP_CONNECT_TIME', () => {
+        return expandUrlAsync('?sh=TCP_CONNECT_TIME').then(res => {
+          expect(res).to.match(/sh=\d+/);
+        });
+      });
+
+      it('should replace SERVER_RESPONSE_TIME', () => {
+        return expandUrlAsync('?sh=SERVER_RESPONSE_TIME').then(res => {
+          expect(res).to.match(/sh=\d+/);
+        });
+      });
+
+      it('should replace PAGE_DOWNLOAD_TIME', () => {
+        return expandUrlAsync('?sh=PAGE_DOWNLOAD_TIME').then(res => {
+          expect(res).to.match(/sh=\d+/);
+        });
+      });
+
+      // TODO(cvializ, #12336): unskip
+      it.skip('should replace REDIRECT_TIME', () => {
+        return expandUrlAsync('?sh=REDIRECT_TIME').then(res => {
+          expect(res).to.match(/sh=\d+/);
+        });
+      });
+
+      it('should replace DOM_INTERACTIVE_TIME', () => {
+        return expandUrlAsync('?sh=DOM_INTERACTIVE_TIME').then(res => {
+          expect(res).to.match(/sh=\d+/);
+        });
+      });
+
+      it('should replace CONTENT_LOAD_TIME', () => {
+        return expandUrlAsync('?sh=CONTENT_LOAD_TIME').then(res => {
+          expect(res).to.match(/sh=\d+/);
+        });
+      });
+
+      it('should replace AVAILABLE_SCREEN_HEIGHT', () => {
+        return expandUrlAsync('?sh=AVAILABLE_SCREEN_HEIGHT').then(res => {
+          expect(res).to.match(/sh=\d+/);
+        });
+      });
+
+      it('should replace AVAILABLE_SCREEN_WIDTH', () => {
+        return expandUrlAsync('?sh=AVAILABLE_SCREEN_WIDTH').then(res => {
+          expect(res).to.match(/sh=\d+/);
+        });
+      });
+
+      it('should replace SCREEN_COLOR_DEPTH', () => {
+        return expandUrlAsync('?sh=SCREEN_COLOR_DEPTH').then(res => {
+          expect(res).to.match(/sh=\d+/);
+        });
+      });
+
+      it('should replace BROWSER_LANGUAGE', () => {
+        return expandUrlAsync('?sh=BROWSER_LANGUAGE').then(res => {
+          expect(res).to.match(/sh=\w+/);
+        });
+      });
+
+      it('should replace USER_AGENT', () => {
+        return expandUrlAsync('?sh=USER_AGENT').then(res => {
+          expect(res).to.match(/sh=\w+/);
+        });
+      });
+
+      it('should replace VIEWER with origin', () => {
+        return getReplacements().then(replacements => {
+          env.sandbox
+            .stub(viewerService, 'getViewerOrigin')
+            .returns(Promise.resolve('https://www.google.com'));
+          return replacements.expandUrlAsync('?sh=VIEWER').then(res => {
+            expect(res).to.equal('?sh=https%3A%2F%2Fwww.google.com');
+          });
+        });
+      });
+
+      it('should replace VIEWER with empty string', () => {
+        return getReplacements().then(replacements => {
+          env.sandbox
+            .stub(viewerService, 'getViewerOrigin')
+            .returns(Promise.resolve(''));
+          return replacements.expandUrlAsync('?sh=VIEWER').then(res => {
+            expect(res).to.equal('?sh=');
+          });
+        });
+      });
+
+      it('should replace TOTAL_ENGAGED_TIME', () => {
+        return expandUrlAsync(
+          '?sh=TOTAL_ENGAGED_TIME',
+          /*opt_bindings*/ undefined,
+          {withActivity: true}
+        ).then(res => {
+          expect(res).to.match(/sh=\d+/);
+        });
+      });
+
+      it('should replace INCREMENTAL_ENGAGED_TIME', () => {
+        return expandUrlAsync(
+          '?sh=INCREMENTAL_ENGAGED_TIME',
+          /*opt_bindings*/ undefined,
+          {withActivity: true}
+        ).then(res => {
+          expect(res).to.match(/sh=\d+/);
+        });
+      });
+
+      it('should replace AMP_VERSION', () => {
+        return expandUrlAsync('?sh=AMP_VERSION').then(res => {
+          expect(res).to.equal('?sh=%24internalRuntimeVersion%24');
+        });
+      });
+
+      it('should replace ANCESTOR_ORIGIN', () => {
+        return expect(
+          expandUrlAsync(
+            'ANCESTOR_ORIGIN/recipes',
+            /*opt_bindings*/ undefined,
+            {
+              withViewerIntegrationVariableService: {
+                ancestorOrigin: () => {
+                  return 'http://margarine-paradise.com';
+                },
+                fragmentParam: (param, defaultValue) => {
+                  return param == 'ice_cream' ? '2' : defaultValue;
+                },
+              },
+            }
+          )
+        ).to.eventually.equal('http://margarine-paradise.com/recipes');
+      });
+
+      it('should replace FRAGMENT_PARAM with 2', () => {
+        const win = getFakeWindow();
+        win.location = {originalHash: '#margarine=1&ice=2&cream=3'};
+        return Services.urlReplacementsForDoc(win.document.documentElement)
+          .expandUrlAsync('?sh=FRAGMENT_PARAM(ice)&s')
+          .then(res => {
+            expect(res).to.equal('?sh=2&s');
+          });
+      });
+
+      it.configure()
+        .skipFirefox()
+        .run('should accept $expressions', () => {
+          return expandUrlAsync('?href=$CANONICAL_URL').then(res => {
+            expect(res).to.equal(
+              '?href=https%3A%2F%2Fpinterest.com%3A8080%2Fpin1'
+            );
+          });
+        });
+
+      it('should ignore unknown substitutions', () => {
+        return expandUrlAsync('?a=UNKNOWN').then(res => {
+          expect(res).to.equal('?a=UNKNOWN');
+        });
+      });
+
+      it.configure()
+        .skipFirefox()
+        .run('should replace several substitutions', () => {
+          return expandUrlAsync(
+            '?a=UNKNOWN&href=CANONICAL_URL&title=TITLE'
+          ).then(res => {
+            expect(res).to.equal(
+              '?a=UNKNOWN' +
+                '&href=https%3A%2F%2Fpinterest.com%3A8080%2Fpin1' +
+                '&title=Pixel%20Test'
+            );
+          });
+        });
+
+      it('should replace new substitutions', () => {
+        return getReplacements().then(replacements => {
+          replacements.getVariableSource().set('ONE', () => 'a');
+          expect(replacements.expandUrlAsync('?a=ONE')).to.eventually.equal(
+            '?a=a'
+          );
+          replacements.getVariableSource().set('ONE', () => 'b');
+          replacements.getVariableSource().set('TWO', () => 'b');
+          return expect(
+            replacements.expandUrlAsync('?a=ONE&b=TWO')
+          ).to.eventually.equal('?a=b&b=b');
+        });
+      });
+
+      // TODO(#16916): Make this test work with synchronous throws.
+      it.skip('should report errors & replace them with empty string (sync)', () => {
+        const clock = env.sandbox.useFakeTimers();
+        const {documentElement} = window.document;
+        const replacements = Services.urlReplacementsForDoc(documentElement);
+        replacements.getVariableSource().set('ONE', () => {
+          throw new Error('boom');
+        });
+        const p = expect(
+          replacements.expandUrlAsync('?a=ONE')
+        ).to.eventually.equal('?a=');
         allowConsoleError(() => {
           expect(() => {
             clock.tick(1);
           }).to.throw(/boom/);
         });
+        return p;
       });
-  });
 
-  it('should support positional arguments', () => {
-    return getReplacements().then(replacements => {
-      replacements.getVariableSource().set('FN', one => one);
-      return expect(
-        replacements.expandUrlAsync('?a=FN(xyz1)')
-      ).to.eventually.equal('?a=xyz1');
-    });
-  });
-
-  it('should support multiple positional arguments', () => {
-    return getReplacements().then(replacements => {
-      replacements.getVariableSource().set('FN', (one, two) => {
-        return one + '-' + two;
-      });
-      return expect(
-        replacements.expandUrlAsync('?a=FN(xyz,abc)')
-      ).to.eventually.equal('?a=xyz-abc');
-    });
-  });
-
-  it('should support multiple positional arguments with dots', () => {
-    return getReplacements().then(replacements => {
-      replacements.getVariableSource().set('FN', (one, two) => {
-        return one + '-' + two;
-      });
-      return expect(
-        replacements.expandUrlAsync('?a=FN(xy.z,ab.c)')
-      ).to.eventually.equal('?a=xy.z-ab.c');
-    });
-  });
-
-  it('should support promises as replacements', () => {
-    return getReplacements().then(replacements => {
-      replacements.getVariableSource().set('P1', () => Promise.resolve('abc '));
-      replacements.getVariableSource().set('P2', () => Promise.resolve('xyz'));
-      replacements.getVariableSource().set('P3', () => Promise.resolve('123'));
-      replacements.getVariableSource().set('OTHER', () => 'foo');
-      return expect(
-        replacements.expandUrlAsync('?a=P1&b=P2&c=P3&d=OTHER')
-      ).to.eventually.equal('?a=abc%20&b=xyz&c=123&d=foo');
-    });
-  });
-
-  it('should override an existing binding', () => {
-    return expandUrlAsync('ord=RANDOM?', {'RANDOM': 'abc'}).then(res => {
-      expect(res).to.match(/ord=abc\?$/);
-    });
-  });
-
-  it('should add an additional binding', () => {
-    return expandUrlAsync('rid=NONSTANDARD?', {'NONSTANDARD': 'abc'}).then(
-      res => {
-        expect(res).to.match(/rid=abc\?$/);
-      }
-    );
-  });
-
-  it('should NOT overwrite the cached expression with new bindings', () => {
-    return expandUrlAsync('rid=NONSTANDARD?', {'NONSTANDARD': 'abc'}).then(
-      res => {
-        expect(res).to.match(/rid=abc\?$/);
-        return expandUrlAsync('rid=NONSTANDARD?').then(res => {
-          expect(res).to.match(/rid=NONSTANDARD\?$/);
-        });
-      }
-    );
-  });
-
-  it('should expand bindings as functions', () => {
-    return expandUrlAsync('rid=FUNC(abc)?', {
-      'FUNC': value => 'func_' + value,
-    }).then(res => {
-      expect(res).to.match(/rid=func_abc\?$/);
-    });
-  });
-
-  it('should expand bindings as functions with promise', () => {
-    return expandUrlAsync('rid=FUNC(abc)?', {
-      'FUNC': value => Promise.resolve('func_' + value),
-    }).then(res => {
-      expect(res).to.match(/rid=func_abc\?$/);
-    });
-  });
-
-  it('should expand null as empty string', () => {
-    return expandUrlAsync('v=VALUE', {'VALUE': null}).then(res => {
-      expect(res).to.equal('v=');
-    });
-  });
-
-  it('should expand undefined as empty string', () => {
-    return expandUrlAsync('v=VALUE', {'VALUE': undefined}).then(res => {
-      expect(res).to.equal('v=');
-    });
-  });
-
-  it('should expand empty string as empty string', () => {
-    return expandUrlAsync('v=VALUE', {'VALUE': ''}).then(res => {
-      expect(res).to.equal('v=');
-    });
-  });
-
-  it('should expand zero as zero', () => {
-    return expandUrlAsync('v=VALUE', {'VALUE': 0}).then(res => {
-      expect(res).to.equal('v=0');
-    });
-  });
-
-  it('should expand false as false', () => {
-    return expandUrlAsync('v=VALUE', {'VALUE': false}).then(res => {
-      expect(res).to.equal('v=false');
-    });
-  });
-
-  it('should resolve sub-included bindings', () => {
-    // RANDOM is a standard property and we add RANDOM_OTHER.
-    return expandUrlAsync('r=RANDOM&ro=RANDOM_OTHER?', {
-      'RANDOM_OTHER': 'ABC',
-    }).then(res => {
-      expect(res).to.match(/r=(\d+(\.\d+)?)&ro=ABC\?$/);
-    });
-  });
-
-  it('should expand multiple vars', () => {
-    return expandUrlAsync('a=VALUEA&b=VALUEB?', {
-      'VALUEA': 'aaa',
-      'VALUEB': 'bbb',
-    }).then(res => {
-      expect(res).to.match(/a=aaa&b=bbb\?$/);
-    });
-  });
-
-  describe('QUERY_PARAM', () => {
-    it('should replace QUERY_PARAM with foo', () => {
-      const win = getFakeWindow();
-      win.location = parseUrlDeprecated(
-        'https://example.com?query_string_param1=wrong'
-      );
-      env.sandbox
-        .stub(trackPromise, 'getTrackImpressionPromise')
-        .callsFake(() => {
-          return new Promise(resolve => {
-            win.location = parseUrlDeprecated(
-              'https://example.com?query_string_param1=foo'
-            );
-            resolve();
-          });
-        });
-      return Services.urlReplacementsForDoc(win.document.documentElement)
-        .expandUrlAsync('?sh=QUERY_PARAM(query_string_param1)&s')
-        .then(res => {
-          expect(res).to.match(/sh=foo&s/);
-        });
-    });
-
-    it('should replace QUERY_PARAM with ""', () => {
-      const win = getFakeWindow();
-      win.location = parseUrlDeprecated('https://example.com');
-      env.sandbox
-        .stub(trackPromise, 'getTrackImpressionPromise')
-        .callsFake(() => {
-          return Promise.resolve();
-        });
-      return Services.urlReplacementsForDoc(win.document.documentElement)
-        .expandUrlAsync('?sh=QUERY_PARAM(query_string_param1)&s')
-        .then(res => {
-          expect(res).to.match(/sh=&s/);
-        });
-    });
-
-    it('should replace QUERY_PARAM with default_value', () => {
-      const win = getFakeWindow();
-      win.location = parseUrlDeprecated('https://example.com');
-      env.sandbox
-        .stub(trackPromise, 'getTrackImpressionPromise')
-        .callsFake(() => {
-          return Promise.resolve();
-        });
-      return Services.urlReplacementsForDoc(win.document.documentElement)
-        .expandUrlAsync('?sh=QUERY_PARAM(query_string_param1,default_value)&s')
-        .then(res => {
-          expect(res).to.match(/sh=default_value&s/);
-        });
-    });
-
-    it('should replace QUERY_PARAM with extra param', () => {
-      const win = getFakeWindow();
-      win.location = parseUrlDeprecated(
-        'https://cdn.ampproject.org/a/o.com/foo/?x=wrong'
-      );
-      env.sandbox
-        .stub(trackPromise, 'getTrackImpressionPromise')
-        .callsFake(() => {
-          return new Promise(resolve => {
-            win.location = parseUrlDeprecated(
-              'https://cdn.ampproject.org/a/o.com/foo/?amp_r=x%3Dfoo'
-            );
-            resolve();
-          });
-        });
-      return Services.urlReplacementsForDoc(win.document.documentElement)
-        .expandUrlAsync('?sh=QUERY_PARAM(x)&s')
-        .then(res => {
-          expect(res).to.match(/sh=foo&s/);
-        });
-    });
-
-    it('should replace QUERY_PARAM, preferring original over extra', () => {
-      const win = getFakeWindow();
-      win.location = parseUrlDeprecated(
-        'https://cdn.ampproject.org/a/o.com/foo/?x=wrong'
-      );
-      env.sandbox
-        .stub(trackPromise, 'getTrackImpressionPromise')
-        .callsFake(() => {
-          return new Promise(resolve => {
-            win.location = parseUrlDeprecated(
-              'https://cdn.ampproject.org/a/o.com/foo/?x=foo&amp_r=x%3Devil'
-            );
-            resolve();
-          });
-        });
-      return Services.urlReplacementsForDoc(win.document.documentElement)
-        .expandUrlAsync('?sh=QUERY_PARAM(x)&s')
-        .then(res => {
-          expect(res).to.match(/sh=foo&s/);
-        });
-    });
-  });
-
-  it('should collect vars', () => {
-    const win = getFakeWindow();
-    win.location = parseUrlDeprecated('https://example.com?p1=foo');
-    env.sandbox
-      .stub(trackPromise, 'getTrackImpressionPromise')
-      .callsFake(() => {
-        return Promise.resolve();
-      });
-    return Services.urlReplacementsForDoc(win.document.documentElement)
-      .collectVars('?SOURCE_HOST&QUERY_PARAM(p1)&SIMPLE&FUNC&PROMISE', {
-        'SIMPLE': 21,
-        'FUNC': () => 22,
-        'PROMISE': () => Promise.resolve(23),
-      })
-      .then(res => {
-        expect(res).to.deep.equal({
-          'SOURCE_HOST': 'example.com',
-          'QUERY_PARAM(p1)': 'foo',
-          'SIMPLE': 21,
-          'FUNC': 22,
-          'PROMISE': 23,
-        });
-      });
-  });
-
-  it('should collect unwhitelisted vars', () => {
-    const win = getFakeWindow();
-    win.location = parseUrlDeprecated(
-      'https://example.com/base?foo=bar&bar=abc&gclid=123'
-    );
-    const element = document.createElement('amp-foo');
-    element.setAttribute('src', '?SOURCE_HOST&QUERY_PARAM(p1)&COUNTER');
-    element.setAttribute('data-amp-replace', 'QUERY_PARAM');
-    const {documentElement} = win.document;
-    const urlReplacements = Services.urlReplacementsForDoc(documentElement);
-    const unwhitelisted = urlReplacements.collectUnwhitelistedVarsSync(element);
-    expect(unwhitelisted).to.deep.equal(['SOURCE_HOST', 'COUNTER']);
-  });
-
-  it('should reject javascript protocol', () => {
-    const win = getFakeWindow();
-    const {documentElement} = win.document;
-    const urlReplacements = Services.urlReplacementsForDoc(documentElement);
-    /*eslint no-script-url: 0*/
-    return urlReplacements
-      .expandUrlAsync('javascript://example.com/?r=RANDOM')
-      .then(
-        () => {
-          throw new Error('never here');
-        },
-        err => {
-          expect(err.message).to.match(/invalid protocol/);
-        }
-      );
-  });
-
-  describe('sync expansion', () => {
-    it('should expand w/ collect vars (skip async macro)', () => {
-      const win = getFakeWindow();
-      const {documentElement} = win.document;
-      const urlReplacements = Services.urlReplacementsForDoc(documentElement);
-      urlReplacements.ampdoc.win.performance.timing.loadEventStart = 109;
-      const collectVars = {};
-      const expanded = urlReplacements.expandUrlSync(
-        'r=RANDOM&c=CONST&f=FUNCT(hello,world)&a=b&d=PROM&e=PAGE_LOAD_TIME',
-        {
-          'CONST': 'ABC',
-          'FUNCT': function(a, b) {
-            return a + b;
-          },
-          // Will ignore promise based result and instead insert empty string.
-          'PROM': function() {
-            return Promise.resolve('boo');
-          },
-        },
-        collectVars
-      );
-      expect(expanded).to.match(/^r=\d(\.\d+)?&c=ABC&f=helloworld&a=b&d=&e=9$/);
-      expect(collectVars).to.deep.equal({
-        'RANDOM': parseFloat(/^r=(\d+(\.\d+)?)/.exec(expanded)[1]),
-        'CONST': 'ABC',
-        'FUNCT(hello,world)': 'helloworld',
-        'PAGE_LOAD_TIME': 9,
-      });
-    });
-
-    it('should reject protocol changes', () => {
-      const win = getFakeWindow();
-      const {documentElement} = win.document;
-      const urlReplacements = Services.urlReplacementsForDoc(documentElement);
-      let expanded = urlReplacements.expandUrlSync(
-        'PROTOCOL://example.com/?r=RANDOM',
-        {
-          'PROTOCOL': 'abc',
-        }
-      );
-      expect(expanded).to.equal('PROTOCOL://example.com/?r=RANDOM');
-      expanded = urlReplacements.expandUrlSync(
-        'FUNCT://example.com/?r=RANDOM',
-        {
-          'FUNCT': function() {
-            return 'abc';
-          },
-        }
-      );
-      expect(expanded).to.equal('FUNCT://example.com/?r=RANDOM');
-    });
-
-    it('should reject javascript protocol', () => {
-      const win = getFakeWindow();
-      const {documentElement} = win.document;
-      const urlReplacements = Services.urlReplacementsForDoc(documentElement);
-      allowConsoleError(() => {
-        expect(() => {
-          /*eslint no-script-url: 0*/
-          urlReplacements.expandUrlSync('javascript://example.com/?r=RANDOM');
-        }).to.throw('invalid protocol');
-      });
-    });
-  });
-
-  it('should expand sync and respect white list', () => {
-    const win = getFakeWindow();
-    const {documentElement} = win.document;
-    const urlReplacements = Services.urlReplacementsForDoc(documentElement);
-    const expanded = urlReplacements.expandUrlSync(
-      'r=RANDOM&c=CONST&f=FUNCT(hello,world)&a=b&d=PROM&e=PAGE_LOAD_TIME',
-      {
-        'CONST': 'ABC',
-        'FUNCT': () => {
-          throw Error('Should not be called');
-        },
-      },
-      undefined,
-      {
-        'CONST': true,
-      }
-    );
-    expect(expanded).to.equal(
-      'r=RANDOM&c=ABC&f=FUNCT(hello,world)&a=b&d=PROM&e=PAGE_LOAD_TIME'
-    );
-  });
-
-  describe('access values via amp-access', () => {
-    let accessService;
-    let accessServiceMock;
-
-    beforeEach(() => {
-      accessService = {
-        getAccessReaderId: () => {},
-        getAuthdataField: () => {},
-      };
-      accessServiceMock = env.sandbox.mock(accessService);
-      env.sandbox.stub(Services, 'accessServiceForDocOrNull').callsFake(() => {
-        return Promise.resolve(accessService);
-      });
-    });
-
-    afterEach(() => {
-      accessServiceMock.verify();
-    });
-
-    function expandUrlAsync(url, opt_disabled) {
-      if (opt_disabled) {
-        accessService = null;
-      }
-      return createIframePromise().then(iframe => {
-        iframe.doc.title = 'Pixel Test';
-        const link = iframe.doc.createElement('link');
-        link.setAttribute('href', 'https://pinterest.com/pin1');
-        link.setAttribute('rel', 'canonical');
-        iframe.doc.head.appendChild(link);
-        const {documentElement} = iframe.doc;
+      // TODO(#16916): Make this test work with synchronous throws.
+      it.skip('should report errors & replace them with empty string (promise)', () => {
+        const clock = env.sandbox.useFakeTimers();
+        const {documentElement} = window.document;
         const replacements = Services.urlReplacementsForDoc(documentElement);
-        return replacements.expandUrlAsync(url);
-      });
-    }
-
-    it('should replace ACCESS_READER_ID', () => {
-      accessServiceMock
-        .expects('getAccessReaderId')
-        .returns(Promise.resolve('reader1'))
-        .once();
-      return expandUrlAsync('?a=ACCESS_READER_ID').then(res => {
-        expect(res).to.match(/a=reader1/);
-        expect(userErrorStub).to.have.not.been.called;
-      });
-    });
-
-    it('should replace AUTHDATA', () => {
-      accessServiceMock
-        .expects('getAuthdataField')
-        .withExactArgs('field1')
-        .returns(Promise.resolve('value1'))
-        .once();
-      return expandUrlAsync('?a=AUTHDATA(field1)').then(res => {
-        expect(res).to.match(/a=value1/);
-        expect(userErrorStub).to.have.not.been.called;
-      });
-    });
-
-    it('should report error if not available', () => {
-      accessServiceMock.expects('getAccessReaderId').never();
-      return expandUrlAsync('?a=ACCESS_READER_ID;', /* disabled */ true).then(
-        res => {
-          expect(res).to.match(/a=;/);
-          expect(userErrorStub).to.be.calledOnce;
-        }
-      );
-    });
-  });
-
-  describe('access values via amp-subscriptions', () => {
-    let accessService;
-    let accessServiceMock;
-
-    beforeEach(() => {
-      accessService = {
-        getAccessReaderId: () => {},
-        getAuthdataField: () => {},
-      };
-      accessServiceMock = env.sandbox.mock(accessService);
-      env.sandbox
-        .stub(Services, 'subscriptionsServiceForDocOrNull')
-        .callsFake(() => {
-          return Promise.resolve(accessService);
+        replacements.getVariableSource().set('ONE', () => {
+          return Promise.reject(new Error('boom'));
         });
-    });
-
-    afterEach(() => {
-      accessServiceMock.verify();
-    });
-
-    function expandUrlAsync(url, opt_disabled) {
-      if (opt_disabled) {
-        accessService = null;
-      }
-      return createIframePromise().then(iframe => {
-        iframe.doc.title = 'Pixel Test';
-        const link = iframe.doc.createElement('link');
-        link.setAttribute('href', 'https://pinterest.com/pin1');
-        link.setAttribute('rel', 'canonical');
-        iframe.doc.head.appendChild(link);
-        const {documentElement} = iframe.doc;
-        const replacements = Services.urlReplacementsForDoc(documentElement);
-        return replacements.expandUrlAsync(url);
+        return expect(replacements.expandUrlAsync('?a=ONE'))
+          .to.eventually.equal('?a=')
+          .then(() => {
+            allowConsoleError(() => {
+              expect(() => {
+                clock.tick(1);
+              }).to.throw(/boom/);
+            });
+          });
       });
-    }
 
-    it('should replace ACCESS_READER_ID', () => {
-      accessServiceMock
-        .expects('getAccessReaderId')
-        .returns(Promise.resolve('reader1'))
-        .once();
-      return expandUrlAsync('?a=ACCESS_READER_ID').then(res => {
-        expect(res).to.match(/a=reader1/);
-        expect(userErrorStub).to.have.not.been.called;
+      it('should support positional arguments', () => {
+        return getReplacements().then(replacements => {
+          replacements.getVariableSource().set('FN', one => one);
+          return expect(
+            replacements.expandUrlAsync('?a=FN(xyz1)')
+          ).to.eventually.equal('?a=xyz1');
+        });
       });
-    });
 
-    it('should replace AUTHDATA', () => {
-      accessServiceMock
-        .expects('getAuthdataField')
-        .withExactArgs('field1')
-        .returns(Promise.resolve('value1'))
-        .once();
-      return expandUrlAsync('?a=AUTHDATA(field1)').then(res => {
-        expect(res).to.match(/a=value1/);
-        expect(userErrorStub).to.have.not.been.called;
+      it('should support multiple positional arguments', () => {
+        return getReplacements().then(replacements => {
+          replacements.getVariableSource().set('FN', (one, two) => {
+            return one + '-' + two;
+          });
+          return expect(
+            replacements.expandUrlAsync('?a=FN(xyz,abc)')
+          ).to.eventually.equal('?a=xyz-abc');
+        });
       });
-    });
 
-    it('should report error if not available', () => {
-      accessServiceMock.expects('getAccessReaderId').never();
-      return expandUrlAsync('?a=ACCESS_READER_ID;', /* disabled */ true).then(
-        res => {
-          expect(res).to.match(/a=;/);
-          expect(userErrorStub).to.be.calledOnce;
-        }
-      );
-    });
-  });
+      it('should support multiple positional arguments with dots', () => {
+        return getReplacements().then(replacements => {
+          replacements.getVariableSource().set('FN', (one, two) => {
+            return one + '-' + two;
+          });
+          return expect(
+            replacements.expandUrlAsync('?a=FN(xy.z,ab.c)')
+          ).to.eventually.equal('?a=xy.z-ab.c');
+        });
+      });
 
-  describe('link expansion', () => {
-    let urlReplacements;
-    let a;
-    let win;
+      it('should support promises as replacements', () => {
+        return getReplacements().then(replacements => {
+          replacements
+            .getVariableSource()
+            .set('P1', () => Promise.resolve('abc '));
+          replacements
+            .getVariableSource()
+            .set('P2', () => Promise.resolve('xyz'));
+          replacements
+            .getVariableSource()
+            .set('P3', () => Promise.resolve('123'));
+          replacements.getVariableSource().set('OTHER', () => 'foo');
+          return expect(
+            replacements.expandUrlAsync('?a=P1&b=P2&c=P3&d=OTHER')
+          ).to.eventually.equal('?a=abc%20&b=xyz&c=123&d=foo');
+        });
+      });
 
-    beforeEach(() => {
-      a = document.createElement('a');
-      win = getFakeWindow();
-      win.location = parseUrlDeprecated(
-        'https://example.com/base?foo=bar&bar=abc&gclid=123'
-      );
-      const {documentElement} = win.document;
-      urlReplacements = Services.urlReplacementsForDoc(documentElement);
-    });
+      it('should override an existing binding', () => {
+        return expandUrlAsync('ord=RANDOM?', {'RANDOM': 'abc'}).then(res => {
+          expect(res).to.match(/ord=abc\?$/);
+        });
+      });
 
-    it('should replace href', () => {
-      a.href = 'https://example.com/link?out=QUERY_PARAM(foo)';
-      a.setAttribute('data-amp-replace', 'QUERY_PARAM');
-      urlReplacements.maybeExpandLink(a, null);
-      expect(a.href).to.equal('https://example.com/link?out=bar');
-    });
-
-    it('should append default outgoing decoration', () => {
-      a.href = 'https://example.com/link?out=QUERY_PARAM(foo)';
-      a.setAttribute('data-amp-replace', 'QUERY_PARAM');
-      urlReplacements.maybeExpandLink(a, 'gclid=QUERY_PARAM(gclid)');
-      expect(a.href).to.equal('https://example.com/link?out=bar&gclid=123');
-    });
-
-    it('should replace href 2x', () => {
-      a.href = 'https://example.com/link?out=QUERY_PARAM(foo)';
-      a.setAttribute('data-amp-replace', 'QUERY_PARAM');
-      urlReplacements.maybeExpandLink(a, null);
-      expect(a.href).to.equal('https://example.com/link?out=bar');
-      urlReplacements.maybeExpandLink(a, null);
-      expect(a.href).to.equal('https://example.com/link?out=bar');
-    });
-
-    it('should replace href 2', () => {
-      a.href =
-        'https://example.com/link?out=QUERY_PARAM(foo)&' +
-        'out2=QUERY_PARAM(bar)';
-      a.setAttribute('data-amp-replace', 'QUERY_PARAM');
-      urlReplacements.maybeExpandLink(a, null);
-      expect(a.href).to.equal('https://example.com/link?out=bar&out2=abc');
-    });
-
-    it('has nothing to replace', () => {
-      a.href = 'https://example.com/link';
-      a.setAttribute('data-amp-replace', 'QUERY_PARAM');
-      urlReplacements.maybeExpandLink(a, null);
-      expect(a.href).to.equal('https://example.com/link');
-    });
-
-    it('should not replace without user whitelisting', () => {
-      a.href = 'https://example.com/link?out=QUERY_PARAM(foo)';
-      urlReplacements.maybeExpandLink(a, null);
-      expect(a.href).to.equal('https://example.com/link?out=QUERY_PARAM(foo)');
-    });
-
-    it('should not replace without user whitelisting 2', () => {
-      a.href = 'https://example.com/link?out=QUERY_PARAM(foo)';
-      a.setAttribute('data-amp-replace', 'ABC');
-      urlReplacements.maybeExpandLink(a, null);
-      expect(a.href).to.equal('https://example.com/link?out=QUERY_PARAM(foo)');
-    });
-
-    it('should replace default append params regardless of whitelist', () => {
-      a.href = 'https://example.com/link?out=QUERY_PARAM(foo)';
-      urlReplacements.maybeExpandLink(a, 'gclid=QUERY_PARAM(gclid)');
-      expect(a.href).to.equal(
-        'https://example.com/link?out=QUERY_PARAM(foo)&gclid=123'
-      );
-    });
-
-    it('should not replace unwhitelisted fields', () => {
-      a.href = 'https://example.com/link?out=RANDOM';
-      a.setAttribute('data-amp-replace', 'RANDOM');
-      urlReplacements.maybeExpandLink(a, null);
-      expect(a.href).to.equal('https://example.com/link?out=RANDOM');
-    });
-
-    it('should replace for http (non-secure) whitelisted origin', () => {
-      canonical = 'http://example.com/link';
-      a.href = 'http://example.com/link?out=QUERY_PARAM(foo)';
-      a.setAttribute('data-amp-replace', 'QUERY_PARAM');
-      urlReplacements.maybeExpandLink(a, null);
-      expect(a.href).to.equal('http://example.com/link?out=bar');
-    });
-
-    it('should replace with canonical origin', () => {
-      a.href = 'https://canonical.com/link?out=QUERY_PARAM(foo)';
-      a.setAttribute('data-amp-replace', 'QUERY_PARAM');
-      urlReplacements.maybeExpandLink(a, null);
-      expect(a.href).to.equal('https://canonical.com/link?out=bar');
-    });
-
-    it('should replace with whitelisted origin', () => {
-      a.href = 'https://whitelisted.com/link?out=QUERY_PARAM(foo)';
-      a.setAttribute('data-amp-replace', 'QUERY_PARAM');
-      urlReplacements.maybeExpandLink(a, null);
-      expect(a.href).to.equal('https://whitelisted.com/link?out=bar');
-    });
-
-    it('should not replace to different origin', () => {
-      a.href = 'https://example2.com/link?out=QUERY_PARAM(foo)';
-      a.setAttribute('data-amp-replace', 'QUERY_PARAM');
-      urlReplacements.maybeExpandLink(a, null);
-      expect(a.href).to.equal('https://example2.com/link?out=QUERY_PARAM(foo)');
-    });
-
-    it('should not append default param to different origin', () => {
-      a.href = 'https://example2.com/link?out=QUERY_PARAM(foo)';
-      a.setAttribute('data-amp-replace', 'QUERY_PARAM');
-      urlReplacements.maybeExpandLink(a, 'gclid=QUERY_PARAM(gclid)');
-      expect(a.href).to.equal('https://example2.com/link?out=QUERY_PARAM(foo)');
-    });
-
-    it('should replace whitelisted fields', () => {
-      a.href =
-        'https://canonical.com/link?' +
-        'out=QUERY_PARAM(foo)' +
-        '&c=PAGE_VIEW_IDCLIENT_ID(abc)NAV_TIMING(navigationStart)';
-      a.setAttribute(
-        'data-amp-replace',
-        'QUERY_PARAM CLIENT_ID PAGE_VIEW_ID NAV_TIMING'
-      );
-      // No replacement without previous async replacement
-      urlReplacements.maybeExpandLink(a, null);
-      expect(a.href).to.equal('https://canonical.com/link?out=bar&c=1234100');
-      // Get a cid, then proceed.
-      return urlReplacements.expandUrlAsync('CLIENT_ID(abc)').then(() => {
-        urlReplacements.maybeExpandLink(a, null);
-        expect(a.href).to.equal(
-          'https://canonical.com/link?out=bar&c=1234test-cid(abc)100'
+      it('should add an additional binding', () => {
+        return expandUrlAsync('rid=NONSTANDARD?', {'NONSTANDARD': 'abc'}).then(
+          res => {
+            expect(res).to.match(/rid=abc\?$/);
+          }
         );
       });
-    });
 
-    it('should add URL parameters for different origin', () => {
-      a.href = 'https://example2.com/link';
-      a.setAttribute('data-amp-addparams', 'guid=123');
-      urlReplacements.maybeExpandLink(a, null);
-      expect(a.href).to.equal('https://example2.com/link?guid=123');
-    });
-
-    it("should add URL parameters for http URL's(non-secure)", () => {
-      a.href = 'http://whitelisted.com/link?out=QUERY_PARAM(foo)';
-      a.setAttribute('data-amp-addparams', 'guid=123');
-      urlReplacements.maybeExpandLink(a, null);
-      expect(a.href).to.equal(
-        'http://whitelisted.com/link?out=QUERY_PARAM(foo)&guid=123'
-      );
-    });
-
-    it(
-      'should add URL parameters and repalce whitelisted' +
-        " values for http whitelisted URL's(non-secure)",
-      () => {
-        a.href = 'http://example.com/link?out=QUERY_PARAM(foo)';
-        a.setAttribute('data-amp-replace', 'CLIENT_ID');
-        a.setAttribute('data-amp-addparams', 'guid=123&c=CLIENT_ID(abc)');
-        // Get a cid, then proceed.
-        return urlReplacements.expandUrlAsync('CLIENT_ID(abc)').then(() => {
-          urlReplacements.maybeExpandLink(a, null);
-          expect(a.href).to.equal(
-            'http://example.com/link?out=QUERY_PARAM(foo)&guid=123&c=test-cid(abc)'
-          );
-        });
-      }
-    );
-
-    it(
-      'should add URL parameters and not repalce whitelisted' +
-        " values for non whitelisted http URL's(non-secure)",
-      () => {
-        a.href = 'http://example2.com/link?out=QUERY_PARAM(foo)';
-        a.setAttribute('data-amp-replace', 'CLIENT_ID');
-        a.setAttribute('data-amp-addparams', 'guid=123&c=CLIENT_ID(abc)');
-        // Get a cid, then proceed.
-        return urlReplacements.expandUrlAsync('CLIENT_ID(abc)').then(() => {
-          urlReplacements.maybeExpandLink(a, null);
-          expect(a.href).to.equal(
-            'http://example2.com/link?out=QUERY_PARAM(foo)&guid=123&c=CLIENT_ID(abc)'
-          );
-        });
-      }
-    );
-
-    it('should append query parameters and repalce whitelisted values', () => {
-      a.href = 'https://whitelisted.com/link?out=QUERY_PARAM(foo)';
-      a.setAttribute('data-amp-replace', 'QUERY_PARAM CLIENT_ID');
-      a.setAttribute('data-amp-addparams', 'guid=123&c=CLIENT_ID(abc)');
-      // Get a cid, then proceed.
-      return urlReplacements.expandUrlAsync('CLIENT_ID(abc)').then(() => {
-        urlReplacements.maybeExpandLink(a, null);
-        expect(a.href).to.equal(
-          'https://whitelisted.com/link?out=bar&guid=123&c=test-cid(abc)'
+      it('should NOT overwrite the cached expression with new bindings', () => {
+        return expandUrlAsync('rid=NONSTANDARD?', {'NONSTANDARD': 'abc'}).then(
+          res => {
+            expect(res).to.match(/rid=abc\?$/);
+            return expandUrlAsync('rid=NONSTANDARD?').then(res => {
+              expect(res).to.match(/rid=NONSTANDARD\?$/);
+            });
+          }
         );
       });
-    });
-  });
 
-  describe('Expanding String', () => {
-    it('should not reject protocol changes with expandStringSync', () => {
-      const win = getFakeWindow();
-      const {documentElement} = win.document;
-      const urlReplacements = Services.urlReplacementsForDoc(documentElement);
-      let expanded = urlReplacements.expandStringSync(
-        'PROTOCOL://example.com/?r=RANDOM',
-        {
-          'PROTOCOL': 'abc',
-        }
-      );
-      expect(expanded).to.match(/abc:\/\/example\.com\/\?r=(\d+(\.\d+)?)$/);
-      expanded = urlReplacements.expandStringSync(
-        'FUNCT://example.com/?r=RANDOM',
-        {
-          'FUNCT': function() {
-            return 'abc';
-          },
-        }
-      );
-      expect(expanded).to.match(/abc:\/\/example\.com\/\?r=(\d+(\.\d+)?)$/);
-    });
-
-    it('should not encode values returned by expandStringSync', () => {
-      const win = getFakeWindow();
-      const {documentElement} = win.document;
-      const urlReplacements = Services.urlReplacementsForDoc(documentElement);
-      const expanded = urlReplacements.expandStringSync('title=TITLE', {
-        'TITLE': 'test with spaces',
-      });
-      expect(expanded).to.equal('title=test with spaces');
-    });
-
-    it('should not check protocol changes with expandStringAsync', () => {
-      const win = getFakeWindow();
-      const {documentElement} = win.document;
-      const urlReplacements = Services.urlReplacementsForDoc(documentElement);
-      return urlReplacements
-        .expandStringAsync('RANDOM:X:Y', {
-          'RANDOM': Promise.resolve('abc'),
-        })
-        .then(expanded => {
-          expect(expanded).to.equal('abc:X:Y');
+      it('should expand bindings as functions', () => {
+        return expandUrlAsync('rid=FUNC(abc)?', {
+          'FUNC': value => 'func_' + value,
+        }).then(res => {
+          expect(res).to.match(/rid=func_abc\?$/);
         });
-    });
+      });
 
-    it('should not encode values returned by expandStringAsync', () => {
-      const win = getFakeWindow();
-      const {documentElement} = win.document;
-      const urlReplacements = Services.urlReplacementsForDoc(documentElement);
-      return urlReplacements
-        .expandStringAsync('title=TITLE', {
-          'TITLE': Promise.resolve('test with spaces'),
-        })
-        .then(expanded => {
+      it('should expand bindings as functions with promise', () => {
+        return expandUrlAsync('rid=FUNC(abc)?', {
+          'FUNC': value => Promise.resolve('func_' + value),
+        }).then(res => {
+          expect(res).to.match(/rid=func_abc\?$/);
+        });
+      });
+
+      it('should expand null as empty string', () => {
+        return expandUrlAsync('v=VALUE', {'VALUE': null}).then(res => {
+          expect(res).to.equal('v=');
+        });
+      });
+
+      it('should expand undefined as empty string', () => {
+        return expandUrlAsync('v=VALUE', {'VALUE': undefined}).then(res => {
+          expect(res).to.equal('v=');
+        });
+      });
+
+      it('should expand empty string as empty string', () => {
+        return expandUrlAsync('v=VALUE', {'VALUE': ''}).then(res => {
+          expect(res).to.equal('v=');
+        });
+      });
+
+      it('should expand zero as zero', () => {
+        return expandUrlAsync('v=VALUE', {'VALUE': 0}).then(res => {
+          expect(res).to.equal('v=0');
+        });
+      });
+
+      it('should expand false as false', () => {
+        return expandUrlAsync('v=VALUE', {'VALUE': false}).then(res => {
+          expect(res).to.equal('v=false');
+        });
+      });
+
+      it('should resolve sub-included bindings', () => {
+        // RANDOM is a standard property and we add RANDOM_OTHER.
+        return expandUrlAsync('r=RANDOM&ro=RANDOM_OTHER?', {
+          'RANDOM_OTHER': 'ABC',
+        }).then(res => {
+          expect(res).to.match(/r=(\d+(\.\d+)?)&ro=ABC\?$/);
+        });
+      });
+
+      it('should expand multiple vars', () => {
+        return expandUrlAsync('a=VALUEA&b=VALUEB?', {
+          'VALUEA': 'aaa',
+          'VALUEB': 'bbb',
+        }).then(res => {
+          expect(res).to.match(/a=aaa&b=bbb\?$/);
+        });
+      });
+
+      describe('QUERY_PARAM', () => {
+        it('should replace QUERY_PARAM with foo', () => {
+          const win = getFakeWindow();
+          win.location = parseUrlDeprecated(
+            'https://example.com?query_string_param1=wrong'
+          );
+          env.sandbox
+            .stub(trackPromise, 'getTrackImpressionPromise')
+            .callsFake(() => {
+              return new Promise(resolve => {
+                win.location = parseUrlDeprecated(
+                  'https://example.com?query_string_param1=foo'
+                );
+                resolve();
+              });
+            });
+          return Services.urlReplacementsForDoc(win.document.documentElement)
+            .expandUrlAsync('?sh=QUERY_PARAM(query_string_param1)&s')
+            .then(res => {
+              expect(res).to.match(/sh=foo&s/);
+            });
+        });
+
+        it('should replace QUERY_PARAM with ""', () => {
+          const win = getFakeWindow();
+          win.location = parseUrlDeprecated('https://example.com');
+          env.sandbox
+            .stub(trackPromise, 'getTrackImpressionPromise')
+            .callsFake(() => {
+              return Promise.resolve();
+            });
+          return Services.urlReplacementsForDoc(win.document.documentElement)
+            .expandUrlAsync('?sh=QUERY_PARAM(query_string_param1)&s')
+            .then(res => {
+              expect(res).to.match(/sh=&s/);
+            });
+        });
+
+        it('should replace QUERY_PARAM with default_value', () => {
+          const win = getFakeWindow();
+          win.location = parseUrlDeprecated('https://example.com');
+          env.sandbox
+            .stub(trackPromise, 'getTrackImpressionPromise')
+            .callsFake(() => {
+              return Promise.resolve();
+            });
+          return Services.urlReplacementsForDoc(win.document.documentElement)
+            .expandUrlAsync(
+              '?sh=QUERY_PARAM(query_string_param1,default_value)&s'
+            )
+            .then(res => {
+              expect(res).to.match(/sh=default_value&s/);
+            });
+        });
+
+        it('should replace QUERY_PARAM with extra param', () => {
+          const win = getFakeWindow();
+          win.location = parseUrlDeprecated(
+            'https://cdn.ampproject.org/a/o.com/foo/?x=wrong'
+          );
+          env.sandbox
+            .stub(trackPromise, 'getTrackImpressionPromise')
+            .callsFake(() => {
+              return new Promise(resolve => {
+                win.location = parseUrlDeprecated(
+                  'https://cdn.ampproject.org/a/o.com/foo/?amp_r=x%3Dfoo'
+                );
+                resolve();
+              });
+            });
+          return Services.urlReplacementsForDoc(win.document.documentElement)
+            .expandUrlAsync('?sh=QUERY_PARAM(x)&s')
+            .then(res => {
+              expect(res).to.match(/sh=foo&s/);
+            });
+        });
+
+        it('should replace QUERY_PARAM, preferring original over extra', () => {
+          const win = getFakeWindow();
+          win.location = parseUrlDeprecated(
+            'https://cdn.ampproject.org/a/o.com/foo/?x=wrong'
+          );
+          env.sandbox
+            .stub(trackPromise, 'getTrackImpressionPromise')
+            .callsFake(() => {
+              return new Promise(resolve => {
+                win.location = parseUrlDeprecated(
+                  'https://cdn.ampproject.org/a/o.com/foo/?x=foo&amp_r=x%3Devil'
+                );
+                resolve();
+              });
+            });
+          return Services.urlReplacementsForDoc(win.document.documentElement)
+            .expandUrlAsync('?sh=QUERY_PARAM(x)&s')
+            .then(res => {
+              expect(res).to.match(/sh=foo&s/);
+            });
+        });
+      });
+
+      it('should collect vars', () => {
+        const win = getFakeWindow();
+        win.location = parseUrlDeprecated('https://example.com?p1=foo');
+        env.sandbox
+          .stub(trackPromise, 'getTrackImpressionPromise')
+          .callsFake(() => {
+            return Promise.resolve();
+          });
+        return Services.urlReplacementsForDoc(win.document.documentElement)
+          .collectVars('?SOURCE_HOST&QUERY_PARAM(p1)&SIMPLE&FUNC&PROMISE', {
+            'SIMPLE': 21,
+            'FUNC': () => 22,
+            'PROMISE': () => Promise.resolve(23),
+          })
+          .then(res => {
+            expect(res).to.deep.equal({
+              'SOURCE_HOST': 'example.com',
+              'QUERY_PARAM(p1)': 'foo',
+              'SIMPLE': 21,
+              'FUNC': 22,
+              'PROMISE': 23,
+            });
+          });
+      });
+
+      it('should collect unwhitelisted vars', () => {
+        const win = getFakeWindow();
+        win.location = parseUrlDeprecated(
+          'https://example.com/base?foo=bar&bar=abc&gclid=123'
+        );
+        const element = document.createElement('amp-foo');
+        element.setAttribute('src', '?SOURCE_HOST&QUERY_PARAM(p1)&COUNTER');
+        element.setAttribute('data-amp-replace', 'QUERY_PARAM');
+        const {documentElement} = win.document;
+        const urlReplacements = Services.urlReplacementsForDoc(documentElement);
+        const unwhitelisted = urlReplacements.collectUnwhitelistedVarsSync(
+          element
+        );
+        expect(unwhitelisted).to.deep.equal(['SOURCE_HOST', 'COUNTER']);
+      });
+
+      it('should reject javascript protocol', () => {
+        const win = getFakeWindow();
+        const {documentElement} = win.document;
+        const urlReplacements = Services.urlReplacementsForDoc(documentElement);
+        /*eslint no-script-url: 0*/
+        return urlReplacements
+          .expandUrlAsync('javascript://example.com/?r=RANDOM')
+          .then(
+            () => {
+              throw new Error('never here');
+            },
+            err => {
+              expect(err.message).to.match(/invalid protocol/);
+            }
+          );
+      });
+
+      describe('sync expansion', () => {
+        it('should expand w/ collect vars (skip async macro)', () => {
+          const win = getFakeWindow();
+          const {documentElement} = win.document;
+          const urlReplacements = Services.urlReplacementsForDoc(
+            documentElement
+          );
+          urlReplacements.ampdoc.win.performance.timing.loadEventStart = 109;
+          const collectVars = {};
+          const expanded = urlReplacements.expandUrlSync(
+            'r=RANDOM&c=CONST&f=FUNCT(hello,world)&a=b&d=PROM&e=PAGE_LOAD_TIME',
+            {
+              'CONST': 'ABC',
+              'FUNCT': function(a, b) {
+                return a + b;
+              },
+              // Will ignore promise based result and instead insert empty string.
+              'PROM': function() {
+                return Promise.resolve('boo');
+              },
+            },
+            collectVars
+          );
+          expect(expanded).to.match(
+            /^r=\d(\.\d+)?&c=ABC&f=helloworld&a=b&d=&e=9$/
+          );
+          expect(collectVars).to.deep.equal({
+            'RANDOM': parseFloat(/^r=(\d+(\.\d+)?)/.exec(expanded)[1]),
+            'CONST': 'ABC',
+            'FUNCT(hello,world)': 'helloworld',
+            'PAGE_LOAD_TIME': 9,
+          });
+        });
+
+        it('should reject protocol changes', () => {
+          const win = getFakeWindow();
+          const {documentElement} = win.document;
+          const urlReplacements = Services.urlReplacementsForDoc(
+            documentElement
+          );
+          let expanded = urlReplacements.expandUrlSync(
+            'PROTOCOL://example.com/?r=RANDOM',
+            {
+              'PROTOCOL': 'abc',
+            }
+          );
+          expect(expanded).to.equal('PROTOCOL://example.com/?r=RANDOM');
+          expanded = urlReplacements.expandUrlSync(
+            'FUNCT://example.com/?r=RANDOM',
+            {
+              'FUNCT': function() {
+                return 'abc';
+              },
+            }
+          );
+          expect(expanded).to.equal('FUNCT://example.com/?r=RANDOM');
+        });
+
+        it('should reject javascript protocol', () => {
+          const win = getFakeWindow();
+          const {documentElement} = win.document;
+          const urlReplacements = Services.urlReplacementsForDoc(
+            documentElement
+          );
+          allowConsoleError(() => {
+            expect(() => {
+              /*eslint no-script-url: 0*/
+              urlReplacements.expandUrlSync(
+                'javascript://example.com/?r=RANDOM'
+              );
+            }).to.throw('invalid protocol');
+          });
+        });
+      });
+
+      it('should expand sync and respect white list', () => {
+        const win = getFakeWindow();
+        const {documentElement} = win.document;
+        const urlReplacements = Services.urlReplacementsForDoc(documentElement);
+        const expanded = urlReplacements.expandUrlSync(
+          'r=RANDOM&c=CONST&f=FUNCT(hello,world)&a=b&d=PROM&e=PAGE_LOAD_TIME',
+          {
+            'CONST': 'ABC',
+            'FUNCT': () => {
+              throw Error('Should not be called');
+            },
+          },
+          undefined,
+          {
+            'CONST': true,
+          }
+        );
+        expect(expanded).to.equal(
+          'r=RANDOM&c=ABC&f=FUNCT(hello,world)&a=b&d=PROM&e=PAGE_LOAD_TIME'
+        );
+      });
+
+      describe('access values via amp-access', () => {
+        let accessService;
+        let accessServiceMock;
+
+        beforeEach(() => {
+          accessService = {
+            getAccessReaderId: () => {},
+            getAuthdataField: () => {},
+          };
+          accessServiceMock = env.sandbox.mock(accessService);
+          env.sandbox
+            .stub(Services, 'accessServiceForDocOrNull')
+            .callsFake(() => {
+              return Promise.resolve(accessService);
+            });
+        });
+
+        afterEach(() => {
+          accessServiceMock.verify();
+        });
+
+        function expandUrlAsync(url, opt_disabled) {
+          if (opt_disabled) {
+            accessService = null;
+          }
+          return createIframePromise().then(iframe => {
+            iframe.doc.title = 'Pixel Test';
+            const link = iframe.doc.createElement('link');
+            link.setAttribute('href', 'https://pinterest.com/pin1');
+            link.setAttribute('rel', 'canonical');
+            iframe.doc.head.appendChild(link);
+            const {documentElement} = iframe.doc;
+            const replacements = Services.urlReplacementsForDoc(
+              documentElement
+            );
+            return replacements.expandUrlAsync(url);
+          });
+        }
+
+        it('should replace ACCESS_READER_ID', () => {
+          accessServiceMock
+            .expects('getAccessReaderId')
+            .returns(Promise.resolve('reader1'))
+            .once();
+          return expandUrlAsync('?a=ACCESS_READER_ID').then(res => {
+            expect(res).to.match(/a=reader1/);
+            expect(userErrorStub).to.have.not.been.called;
+          });
+        });
+
+        it('should replace AUTHDATA', () => {
+          accessServiceMock
+            .expects('getAuthdataField')
+            .withExactArgs('field1')
+            .returns(Promise.resolve('value1'))
+            .once();
+          return expandUrlAsync('?a=AUTHDATA(field1)').then(res => {
+            expect(res).to.match(/a=value1/);
+            expect(userErrorStub).to.have.not.been.called;
+          });
+        });
+
+        it('should report error if not available', () => {
+          accessServiceMock.expects('getAccessReaderId').never();
+          return expandUrlAsync(
+            '?a=ACCESS_READER_ID;',
+            /* disabled */ true
+          ).then(res => {
+            expect(res).to.match(/a=;/);
+            expect(userErrorStub).to.be.calledOnce;
+          });
+        });
+      });
+
+      describe('access values via amp-subscriptions', () => {
+        let accessService;
+        let accessServiceMock;
+
+        beforeEach(() => {
+          accessService = {
+            getAccessReaderId: () => {},
+            getAuthdataField: () => {},
+          };
+          accessServiceMock = env.sandbox.mock(accessService);
+          env.sandbox
+            .stub(Services, 'subscriptionsServiceForDocOrNull')
+            .callsFake(() => {
+              return Promise.resolve(accessService);
+            });
+        });
+
+        afterEach(() => {
+          accessServiceMock.verify();
+        });
+
+        function expandUrlAsync(url, opt_disabled) {
+          if (opt_disabled) {
+            accessService = null;
+          }
+          return createIframePromise().then(iframe => {
+            iframe.doc.title = 'Pixel Test';
+            const link = iframe.doc.createElement('link');
+            link.setAttribute('href', 'https://pinterest.com/pin1');
+            link.setAttribute('rel', 'canonical');
+            iframe.doc.head.appendChild(link);
+            const {documentElement} = iframe.doc;
+            const replacements = Services.urlReplacementsForDoc(
+              documentElement
+            );
+            return replacements.expandUrlAsync(url);
+          });
+        }
+
+        it('should replace ACCESS_READER_ID', () => {
+          accessServiceMock
+            .expects('getAccessReaderId')
+            .returns(Promise.resolve('reader1'))
+            .once();
+          return expandUrlAsync('?a=ACCESS_READER_ID').then(res => {
+            expect(res).to.match(/a=reader1/);
+            expect(userErrorStub).to.have.not.been.called;
+          });
+        });
+
+        it('should replace AUTHDATA', () => {
+          accessServiceMock
+            .expects('getAuthdataField')
+            .withExactArgs('field1')
+            .returns(Promise.resolve('value1'))
+            .once();
+          return expandUrlAsync('?a=AUTHDATA(field1)').then(res => {
+            expect(res).to.match(/a=value1/);
+            expect(userErrorStub).to.have.not.been.called;
+          });
+        });
+
+        it('should report error if not available', () => {
+          accessServiceMock.expects('getAccessReaderId').never();
+          return expandUrlAsync(
+            '?a=ACCESS_READER_ID;',
+            /* disabled */ true
+          ).then(res => {
+            expect(res).to.match(/a=;/);
+            expect(userErrorStub).to.be.calledOnce;
+          });
+        });
+      });
+
+      describe('link expansion', () => {
+        let urlReplacements;
+        let a;
+        let win;
+
+        beforeEach(() => {
+          a = document.createElement('a');
+          win = getFakeWindow();
+          win.location = parseUrlDeprecated(
+            'https://example.com/base?foo=bar&bar=abc&gclid=123'
+          );
+          const {documentElement} = win.document;
+          urlReplacements = Services.urlReplacementsForDoc(documentElement);
+        });
+
+        it('should replace href', () => {
+          a.href = 'https://example.com/link?out=QUERY_PARAM(foo)';
+          a.setAttribute('data-amp-replace', 'QUERY_PARAM');
+          urlReplacements.maybeExpandLink(a, null);
+          expect(a.href).to.equal('https://example.com/link?out=bar');
+        });
+
+        it('should append default outgoing decoration', () => {
+          a.href = 'https://example.com/link?out=QUERY_PARAM(foo)';
+          a.setAttribute('data-amp-replace', 'QUERY_PARAM');
+          urlReplacements.maybeExpandLink(a, 'gclid=QUERY_PARAM(gclid)');
+          expect(a.href).to.equal('https://example.com/link?out=bar&gclid=123');
+        });
+
+        it('should replace href 2x', () => {
+          a.href = 'https://example.com/link?out=QUERY_PARAM(foo)';
+          a.setAttribute('data-amp-replace', 'QUERY_PARAM');
+          urlReplacements.maybeExpandLink(a, null);
+          expect(a.href).to.equal('https://example.com/link?out=bar');
+          urlReplacements.maybeExpandLink(a, null);
+          expect(a.href).to.equal('https://example.com/link?out=bar');
+        });
+
+        it('should replace href 2', () => {
+          a.href =
+            'https://example.com/link?out=QUERY_PARAM(foo)&' +
+            'out2=QUERY_PARAM(bar)';
+          a.setAttribute('data-amp-replace', 'QUERY_PARAM');
+          urlReplacements.maybeExpandLink(a, null);
+          expect(a.href).to.equal('https://example.com/link?out=bar&out2=abc');
+        });
+
+        it('has nothing to replace', () => {
+          a.href = 'https://example.com/link';
+          a.setAttribute('data-amp-replace', 'QUERY_PARAM');
+          urlReplacements.maybeExpandLink(a, null);
+          expect(a.href).to.equal('https://example.com/link');
+        });
+
+        it('should not replace without user whitelisting', () => {
+          a.href = 'https://example.com/link?out=QUERY_PARAM(foo)';
+          urlReplacements.maybeExpandLink(a, null);
+          expect(a.href).to.equal(
+            'https://example.com/link?out=QUERY_PARAM(foo)'
+          );
+        });
+
+        it('should not replace without user whitelisting 2', () => {
+          a.href = 'https://example.com/link?out=QUERY_PARAM(foo)';
+          a.setAttribute('data-amp-replace', 'ABC');
+          urlReplacements.maybeExpandLink(a, null);
+          expect(a.href).to.equal(
+            'https://example.com/link?out=QUERY_PARAM(foo)'
+          );
+        });
+
+        it('should replace default append params regardless of whitelist', () => {
+          a.href = 'https://example.com/link?out=QUERY_PARAM(foo)';
+          urlReplacements.maybeExpandLink(a, 'gclid=QUERY_PARAM(gclid)');
+          expect(a.href).to.equal(
+            'https://example.com/link?out=QUERY_PARAM(foo)&gclid=123'
+          );
+        });
+
+        it('should not replace unwhitelisted fields', () => {
+          a.href = 'https://example.com/link?out=RANDOM';
+          a.setAttribute('data-amp-replace', 'RANDOM');
+          urlReplacements.maybeExpandLink(a, null);
+          expect(a.href).to.equal('https://example.com/link?out=RANDOM');
+        });
+
+        it('should replace for http (non-secure) whitelisted origin', () => {
+          canonical = 'http://example.com/link';
+          a.href = 'http://example.com/link?out=QUERY_PARAM(foo)';
+          a.setAttribute('data-amp-replace', 'QUERY_PARAM');
+          urlReplacements.maybeExpandLink(a, null);
+          expect(a.href).to.equal('http://example.com/link?out=bar');
+        });
+
+        it('should replace with canonical origin', () => {
+          a.href = 'https://canonical.com/link?out=QUERY_PARAM(foo)';
+          a.setAttribute('data-amp-replace', 'QUERY_PARAM');
+          urlReplacements.maybeExpandLink(a, null);
+          expect(a.href).to.equal('https://canonical.com/link?out=bar');
+        });
+
+        it('should replace with whitelisted origin', () => {
+          a.href = 'https://whitelisted.com/link?out=QUERY_PARAM(foo)';
+          a.setAttribute('data-amp-replace', 'QUERY_PARAM');
+          urlReplacements.maybeExpandLink(a, null);
+          expect(a.href).to.equal('https://whitelisted.com/link?out=bar');
+        });
+
+        it('should not replace to different origin', () => {
+          a.href = 'https://example2.com/link?out=QUERY_PARAM(foo)';
+          a.setAttribute('data-amp-replace', 'QUERY_PARAM');
+          urlReplacements.maybeExpandLink(a, null);
+          expect(a.href).to.equal(
+            'https://example2.com/link?out=QUERY_PARAM(foo)'
+          );
+        });
+
+        it('should not append default param to different origin', () => {
+          a.href = 'https://example2.com/link?out=QUERY_PARAM(foo)';
+          a.setAttribute('data-amp-replace', 'QUERY_PARAM');
+          urlReplacements.maybeExpandLink(a, 'gclid=QUERY_PARAM(gclid)');
+          expect(a.href).to.equal(
+            'https://example2.com/link?out=QUERY_PARAM(foo)'
+          );
+        });
+
+        it('should replace whitelisted fields', () => {
+          a.href =
+            'https://canonical.com/link?' +
+            'out=QUERY_PARAM(foo)' +
+            '&c=PAGE_VIEW_IDCLIENT_ID(abc)NAV_TIMING(navigationStart)';
+          a.setAttribute(
+            'data-amp-replace',
+            'QUERY_PARAM CLIENT_ID PAGE_VIEW_ID NAV_TIMING'
+          );
+          // No replacement without previous async replacement
+          urlReplacements.maybeExpandLink(a, null);
+          expect(a.href).to.equal(
+            'https://canonical.com/link?out=bar&c=1234100'
+          );
+          // Get a cid, then proceed.
+          return urlReplacements.expandUrlAsync('CLIENT_ID(abc)').then(() => {
+            urlReplacements.maybeExpandLink(a, null);
+            expect(a.href).to.equal(
+              'https://canonical.com/link?out=bar&c=1234test-cid(abc)100'
+            );
+          });
+        });
+
+        it('should add URL parameters for different origin', () => {
+          a.href = 'https://example2.com/link';
+          a.setAttribute('data-amp-addparams', 'guid=123');
+          urlReplacements.maybeExpandLink(a, null);
+          expect(a.href).to.equal('https://example2.com/link?guid=123');
+        });
+
+        it("should add URL parameters for http URL's(non-secure)", () => {
+          a.href = 'http://whitelisted.com/link?out=QUERY_PARAM(foo)';
+          a.setAttribute('data-amp-addparams', 'guid=123');
+          urlReplacements.maybeExpandLink(a, null);
+          expect(a.href).to.equal(
+            'http://whitelisted.com/link?out=QUERY_PARAM(foo)&guid=123'
+          );
+        });
+
+        it(
+          'should add URL parameters and repalce whitelisted' +
+            " values for http whitelisted URL's(non-secure)",
+          () => {
+            a.href = 'http://example.com/link?out=QUERY_PARAM(foo)';
+            a.setAttribute('data-amp-replace', 'CLIENT_ID');
+            a.setAttribute('data-amp-addparams', 'guid=123&c=CLIENT_ID(abc)');
+            // Get a cid, then proceed.
+            return urlReplacements.expandUrlAsync('CLIENT_ID(abc)').then(() => {
+              urlReplacements.maybeExpandLink(a, null);
+              expect(a.href).to.equal(
+                'http://example.com/link?out=QUERY_PARAM(foo)&guid=123&c=test-cid(abc)'
+              );
+            });
+          }
+        );
+
+        it(
+          'should add URL parameters and not repalce whitelisted' +
+            " values for non whitelisted http URL's(non-secure)",
+          () => {
+            a.href = 'http://example2.com/link?out=QUERY_PARAM(foo)';
+            a.setAttribute('data-amp-replace', 'CLIENT_ID');
+            a.setAttribute('data-amp-addparams', 'guid=123&c=CLIENT_ID(abc)');
+            // Get a cid, then proceed.
+            return urlReplacements.expandUrlAsync('CLIENT_ID(abc)').then(() => {
+              urlReplacements.maybeExpandLink(a, null);
+              expect(a.href).to.equal(
+                'http://example2.com/link?out=QUERY_PARAM(foo)&guid=123&c=CLIENT_ID(abc)'
+              );
+            });
+          }
+        );
+
+        it('should append query parameters and repalce whitelisted values', () => {
+          a.href = 'https://whitelisted.com/link?out=QUERY_PARAM(foo)';
+          a.setAttribute('data-amp-replace', 'QUERY_PARAM CLIENT_ID');
+          a.setAttribute('data-amp-addparams', 'guid=123&c=CLIENT_ID(abc)');
+          // Get a cid, then proceed.
+          return urlReplacements.expandUrlAsync('CLIENT_ID(abc)').then(() => {
+            urlReplacements.maybeExpandLink(a, null);
+            expect(a.href).to.equal(
+              'https://whitelisted.com/link?out=bar&guid=123&c=test-cid(abc)'
+            );
+          });
+        });
+      });
+
+      describe('Expanding String', () => {
+        it('should not reject protocol changes with expandStringSync', () => {
+          const win = getFakeWindow();
+          const {documentElement} = win.document;
+          const urlReplacements = Services.urlReplacementsForDoc(
+            documentElement
+          );
+          let expanded = urlReplacements.expandStringSync(
+            'PROTOCOL://example.com/?r=RANDOM',
+            {
+              'PROTOCOL': 'abc',
+            }
+          );
+          expect(expanded).to.match(/abc:\/\/example\.com\/\?r=(\d+(\.\d+)?)$/);
+          expanded = urlReplacements.expandStringSync(
+            'FUNCT://example.com/?r=RANDOM',
+            {
+              'FUNCT': function() {
+                return 'abc';
+              },
+            }
+          );
+          expect(expanded).to.match(/abc:\/\/example\.com\/\?r=(\d+(\.\d+)?)$/);
+        });
+
+        it('should not encode values returned by expandStringSync', () => {
+          const win = getFakeWindow();
+          const {documentElement} = win.document;
+          const urlReplacements = Services.urlReplacementsForDoc(
+            documentElement
+          );
+          const expanded = urlReplacements.expandStringSync('title=TITLE', {
+            'TITLE': 'test with spaces',
+          });
           expect(expanded).to.equal('title=test with spaces');
         });
-    });
-  });
 
-  describe('Expanding Input Value', () => {
-    it('should fail for non-inputs', () => {
-      const win = getFakeWindow();
-      const {documentElement} = win.document;
-      const urlReplacements = Services.urlReplacementsForDoc(documentElement);
-      const input = document.createElement('textarea');
-      input.value = 'RANDOM';
-      input.setAttribute('data-amp-replace', 'RANDOM');
-      allowConsoleError(() => {
-        expect(() => urlReplacements.expandInputValueSync(input)).to.throw(
-          /Input value expansion only works on hidden input fields/
-        );
-      });
-      expect(input.value).to.equal('RANDOM');
-    });
-
-    it('should fail for non-hidden inputs', () => {
-      const win = getFakeWindow();
-      const {documentElement} = win.document;
-      const urlReplacements = Services.urlReplacementsForDoc(documentElement);
-      const input = document.createElement('input');
-      input.value = 'RANDOM';
-      input.setAttribute('data-amp-replace', 'RANDOM');
-      allowConsoleError(() => {
-        expect(() => urlReplacements.expandInputValueSync(input)).to.throw(
-          /Input value expansion only works on hidden input fields/
-        );
-      });
-      expect(input.value).to.equal('RANDOM');
-    });
-
-    it('should not replace not whitelisted vars', () => {
-      const win = getFakeWindow();
-      const {documentElement} = win.document;
-      const urlReplacements = Services.urlReplacementsForDoc(documentElement);
-      const input = document.createElement('input');
-      input.value = 'RANDOM';
-      input.type = 'hidden';
-      input.setAttribute('data-amp-replace', 'CANONICAL_URL');
-      let expandedValue = urlReplacements.expandInputValueSync(input);
-      expect(expandedValue).to.equal('RANDOM');
-      input.setAttribute('data-amp-replace', 'CANONICAL_URL RANDOM');
-      expandedValue = urlReplacements.expandInputValueSync(input);
-      expect(expandedValue).to.match(/(\d+(\.\d+)?)/);
-      expect(input.value).to.match(/(\d+(\.\d+)?)/);
-      expect(input['amp-original-value']).to.equal('RANDOM');
-    });
-
-    it('should replace input value with var subs - sync', () => {
-      const win = getFakeWindow();
-      const {documentElement} = win.document;
-      const urlReplacements = Services.urlReplacementsForDoc(documentElement);
-      const input = document.createElement('input');
-      input.value = 'RANDOM';
-      input.type = 'hidden';
-      input.setAttribute('data-amp-replace', 'RANDOM');
-      let expandedValue = urlReplacements.expandInputValueSync(input);
-      expect(expandedValue).to.match(/(\d+(\.\d+)?)/);
-
-      input['amp-original-value'] = 'RANDOM://example.com/RANDOM';
-      expandedValue = urlReplacements.expandInputValueSync(input);
-      expect(expandedValue).to.match(
-        /(\d+(\.\d+)?):\/\/example\.com\/(\d+(\.\d+)?)$/
-      );
-      expect(input.value).to.match(
-        /(\d+(\.\d+)?):\/\/example\.com\/(\d+(\.\d+)?)$/
-      );
-      expect(input['amp-original-value']).to.equal(
-        'RANDOM://example.com/RANDOM'
-      );
-    });
-
-    it('should replace input value with var subs - sync', () => {
-      const win = getFakeWindow();
-      const {documentElement} = win.document;
-      const urlReplacements = Services.urlReplacementsForDoc(documentElement);
-      const input = document.createElement('input');
-      input.value = 'RANDOM';
-      input.type = 'hidden';
-      input.setAttribute('data-amp-replace', 'RANDOM');
-      return urlReplacements
-        .expandInputValueAsync(input)
-        .then(expandedValue => {
-          expect(input['amp-original-value']).to.equal('RANDOM');
-          expect(input.value).to.match(/(\d+(\.\d+)?)/);
-          expect(expandedValue).to.match(/(\d+(\.\d+)?)/);
+        it('should not check protocol changes with expandStringAsync', () => {
+          const win = getFakeWindow();
+          const {documentElement} = win.document;
+          const urlReplacements = Services.urlReplacementsForDoc(
+            documentElement
+          );
+          return urlReplacements
+            .expandStringAsync('RANDOM:X:Y', {
+              'RANDOM': Promise.resolve('abc'),
+            })
+            .then(expanded => {
+              expect(expanded).to.equal('abc:X:Y');
+            });
         });
-    });
-  });
 
-  describe('extractClientIdFromGaCookie', () => {
-    it('should extract correct Client ID', () => {
-      expect(
-        extractClientIdFromGaCookie('GA1.2.430749005.1489527047')
-      ).to.equal('430749005.1489527047');
-      expect(
-        extractClientIdFromGaCookie('GA1.12.430749005.1489527047')
-      ).to.equal('430749005.1489527047');
-      expect(
-        extractClientIdFromGaCookie('GA1.1-2.430749005.1489527047')
-      ).to.equal('430749005.1489527047');
-      expect(extractClientIdFromGaCookie('1.1.430749005.1489527047')).to.equal(
-        '430749005.1489527047'
-      );
-      expect(
-        extractClientIdFromGaCookie(
-          'GA1.3.amp-JTHCVn-4iMhzv5oEIZIspaXUSnEF0PwNVoxs' +
-            'NDrFP4BtPQJMyxE4jb9FDlp37OJL'
-        )
-      ).to.equal(
-        'amp-JTHCVn-4iMhzv5oEIZIspaXUSnEF0PwNVoxs' +
-          'NDrFP4BtPQJMyxE4jb9FDlp37OJL'
-      );
-      expect(
-        extractClientIdFromGaCookie(
-          '1.3.amp-JTHCVn-4iMhzv5oEIZIspaXUSnEF0PwNVoxs' +
-            'NDrFP4BtPQJMyxE4jb9FDlp37OJL'
-        )
-      ).to.equal(
-        'amp-JTHCVn-4iMhzv5oEIZIspaXUSnEF0PwNVoxs' +
-          'NDrFP4BtPQJMyxE4jb9FDlp37OJL'
-      );
-      expect(
-        extractClientIdFromGaCookie(
-          'amp-JTHCVn-4iMhzv5oEIZIspaXUSnEF0PwNVoxs' +
-            'NDrFP4BtPQJMyxE4jb9FDlp37OJL'
-        )
-      ).to.equal(
-        'amp-JTHCVn-4iMhzv5oEIZIspaXUSnEF0PwNVoxs' +
-          'NDrFP4BtPQJMyxE4jb9FDlp37OJL'
-      );
+        it('should not encode values returned by expandStringAsync', () => {
+          const win = getFakeWindow();
+          const {documentElement} = win.document;
+          const urlReplacements = Services.urlReplacementsForDoc(
+            documentElement
+          );
+          return urlReplacements
+            .expandStringAsync('title=TITLE', {
+              'TITLE': Promise.resolve('test with spaces'),
+            })
+            .then(expanded => {
+              expect(expanded).to.equal('title=test with spaces');
+            });
+        });
+      });
+
+      describe('Expanding Input Value', () => {
+        it('should fail for non-inputs', () => {
+          const win = getFakeWindow();
+          const {documentElement} = win.document;
+          const urlReplacements = Services.urlReplacementsForDoc(
+            documentElement
+          );
+          const input = document.createElement('textarea');
+          input.value = 'RANDOM';
+          input.setAttribute('data-amp-replace', 'RANDOM');
+          allowConsoleError(() => {
+            expect(() => urlReplacements.expandInputValueSync(input)).to.throw(
+              /Input value expansion only works on hidden input fields/
+            );
+          });
+          expect(input.value).to.equal('RANDOM');
+        });
+
+        it('should fail for non-hidden inputs', () => {
+          const win = getFakeWindow();
+          const {documentElement} = win.document;
+          const urlReplacements = Services.urlReplacementsForDoc(
+            documentElement
+          );
+          const input = document.createElement('input');
+          input.value = 'RANDOM';
+          input.setAttribute('data-amp-replace', 'RANDOM');
+          allowConsoleError(() => {
+            expect(() => urlReplacements.expandInputValueSync(input)).to.throw(
+              /Input value expansion only works on hidden input fields/
+            );
+          });
+          expect(input.value).to.equal('RANDOM');
+        });
+
+        it('should not replace not whitelisted vars', () => {
+          const win = getFakeWindow();
+          const {documentElement} = win.document;
+          const urlReplacements = Services.urlReplacementsForDoc(
+            documentElement
+          );
+          const input = document.createElement('input');
+          input.value = 'RANDOM';
+          input.type = 'hidden';
+          input.setAttribute('data-amp-replace', 'CANONICAL_URL');
+          let expandedValue = urlReplacements.expandInputValueSync(input);
+          expect(expandedValue).to.equal('RANDOM');
+          input.setAttribute('data-amp-replace', 'CANONICAL_URL RANDOM');
+          expandedValue = urlReplacements.expandInputValueSync(input);
+          expect(expandedValue).to.match(/(\d+(\.\d+)?)/);
+          expect(input.value).to.match(/(\d+(\.\d+)?)/);
+          expect(input['amp-original-value']).to.equal('RANDOM');
+        });
+
+        it('should replace input value with var subs - sync', () => {
+          const win = getFakeWindow();
+          const {documentElement} = win.document;
+          const urlReplacements = Services.urlReplacementsForDoc(
+            documentElement
+          );
+          const input = document.createElement('input');
+          input.value = 'RANDOM';
+          input.type = 'hidden';
+          input.setAttribute('data-amp-replace', 'RANDOM');
+          let expandedValue = urlReplacements.expandInputValueSync(input);
+          expect(expandedValue).to.match(/(\d+(\.\d+)?)/);
+
+          input['amp-original-value'] = 'RANDOM://example.com/RANDOM';
+          expandedValue = urlReplacements.expandInputValueSync(input);
+          expect(expandedValue).to.match(
+            /(\d+(\.\d+)?):\/\/example\.com\/(\d+(\.\d+)?)$/
+          );
+          expect(input.value).to.match(
+            /(\d+(\.\d+)?):\/\/example\.com\/(\d+(\.\d+)?)$/
+          );
+          expect(input['amp-original-value']).to.equal(
+            'RANDOM://example.com/RANDOM'
+          );
+        });
+
+        it('should replace input value with var subs - sync', () => {
+          const win = getFakeWindow();
+          const {documentElement} = win.document;
+          const urlReplacements = Services.urlReplacementsForDoc(
+            documentElement
+          );
+          const input = document.createElement('input');
+          input.value = 'RANDOM';
+          input.type = 'hidden';
+          input.setAttribute('data-amp-replace', 'RANDOM');
+          return urlReplacements
+            .expandInputValueAsync(input)
+            .then(expandedValue => {
+              expect(input['amp-original-value']).to.equal('RANDOM');
+              expect(input.value).to.match(/(\d+(\.\d+)?)/);
+              expect(expandedValue).to.match(/(\d+(\.\d+)?)/);
+            });
+        });
+      });
+
+      describe('extractClientIdFromGaCookie', () => {
+        it('should extract correct Client ID', () => {
+          expect(
+            extractClientIdFromGaCookie('GA1.2.430749005.1489527047')
+          ).to.equal('430749005.1489527047');
+          expect(
+            extractClientIdFromGaCookie('GA1.12.430749005.1489527047')
+          ).to.equal('430749005.1489527047');
+          expect(
+            extractClientIdFromGaCookie('GA1.1-2.430749005.1489527047')
+          ).to.equal('430749005.1489527047');
+          expect(
+            extractClientIdFromGaCookie('1.1.430749005.1489527047')
+          ).to.equal('430749005.1489527047');
+          expect(
+            extractClientIdFromGaCookie(
+              'GA1.3.amp-JTHCVn-4iMhzv5oEIZIspaXUSnEF0PwNVoxs' +
+                'NDrFP4BtPQJMyxE4jb9FDlp37OJL'
+            )
+          ).to.equal(
+            'amp-JTHCVn-4iMhzv5oEIZIspaXUSnEF0PwNVoxs' +
+              'NDrFP4BtPQJMyxE4jb9FDlp37OJL'
+          );
+          expect(
+            extractClientIdFromGaCookie(
+              '1.3.amp-JTHCVn-4iMhzv5oEIZIspaXUSnEF0PwNVoxs' +
+                'NDrFP4BtPQJMyxE4jb9FDlp37OJL'
+            )
+          ).to.equal(
+            'amp-JTHCVn-4iMhzv5oEIZIspaXUSnEF0PwNVoxs' +
+              'NDrFP4BtPQJMyxE4jb9FDlp37OJL'
+          );
+          expect(
+            extractClientIdFromGaCookie(
+              'amp-JTHCVn-4iMhzv5oEIZIspaXUSnEF0PwNVoxs' +
+                'NDrFP4BtPQJMyxE4jb9FDlp37OJL'
+            )
+          ).to.equal(
+            'amp-JTHCVn-4iMhzv5oEIZIspaXUSnEF0PwNVoxs' +
+              'NDrFP4BtPQJMyxE4jb9FDlp37OJL'
+          );
+        });
+      });
     });
-  });
 });

--- a/test/unit/test-validator-integration.js
+++ b/test/unit/test-validator-integration.js
@@ -28,8 +28,8 @@ describes.fakeWin('validator-integration', {}, env => {
   describe('maybeValidate', () => {
     beforeEach(() => {
       win = env.win;
-      loadScriptStub = sandbox.stub(eventHelper, 'loadPromise');
-      modeStub = sandbox.stub(mode, 'getMode');
+      loadScriptStub = env.sandbox.stub(eventHelper, 'loadPromise');
+      modeStub = env.sandbox.stub(mode, 'getMode');
     });
 
     it('should not load validator script if not in dev mode', () => {

--- a/test/unit/test-video-analytics-percentage-tracker.js
+++ b/test/unit/test-video-analytics-percentage-tracker.js
@@ -91,7 +91,7 @@ describes.fakeWin(
         },
       };
 
-      sandbox.stub(Services, 'timerFor').returns(mockTimer);
+      env.sandbox.stub(Services, 'timerFor').returns(mockTimer);
 
       tracker = new AnalyticsPercentageTracker(win, mockEntry);
     });

--- a/test/unit/test-video-iframe-integration.js
+++ b/test/unit/test-video-iframe-integration.js
@@ -23,27 +23,20 @@ import {
 const NOOP = () => {};
 
 describes.realWin('video-iframe-integration', {amp: false}, env => {
-  let sandbox;
-
-  beforeEach(() => {
-    sandbox = env.sandbox;
-  });
-
   function pushToGlobal(global, callback) {
     (global.AmpVideoIframe = global.AmpVideoIframe || []).push(callback);
   }
 
-  const matchAmpVideoIntegration = sinon.match({isAmpVideoIntegration_: true});
-
   function expectCalledWithAmpVideoIntegration(spy) {
-    expect(spy.withArgs(matchAmpVideoIntegration)).to.have.been.calledOnce;
+    expect(spy.withArgs(env.sandbox.match({isAmpVideoIntegration_: true}))).to
+      .have.been.calledOnce;
   }
 
   describe('adopt(win)', () => {
     describe('<script async> support', () => {
       it('should execute callbacks pushed before adoption', () => {
         const global = {};
-        const callback = sandbox.spy();
+        const callback = env.sandbox.spy();
         pushToGlobal(global, callback);
         adopt(global);
         expectCalledWithAmpVideoIntegration(callback);
@@ -52,7 +45,7 @@ describes.realWin('video-iframe-integration', {amp: false}, env => {
       it('should execute callbacks pushed after adoption', () => {
         const global = {};
         adopt(global);
-        const callback = sandbox.spy();
+        const callback = env.sandbox.spy();
         pushToGlobal(global, callback);
         expectCalledWithAmpVideoIntegration(callback);
       });
@@ -70,12 +63,12 @@ describes.realWin('video-iframe-integration', {amp: false}, env => {
         const win = {name: JSON.stringify(metadata)};
         const integration = new AmpVideoIntegration(win);
 
-        // Sinon does not support sinon.match on to.equal
-        const dummySpy = sandbox.spy();
+        // Sinon does not support env.sandbox.match on to.equal
+        const dummySpy = env.sandbox.spy();
 
         dummySpy(integration.getMetadata());
 
-        expect(dummySpy.withArgs(sinon.match(metadata))).to.have.been
+        expect(dummySpy.withArgs(env.sandbox.match(metadata))).to.have.been
           .calledOnce;
       });
     });
@@ -84,7 +77,7 @@ describes.realWin('video-iframe-integration', {amp: false}, env => {
       it('should execute on message', () => {
         const integration = new AmpVideoIntegration();
 
-        const listenToOnce = sandbox.stub(integration, 'listenToOnce_');
+        const listenToOnce = env.sandbox.stub(integration, 'listenToOnce_');
 
         const validMethods = [
           'pause',
@@ -98,7 +91,7 @@ describes.realWin('video-iframe-integration', {amp: false}, env => {
         ];
 
         validMethods.forEach(method => {
-          const spy = sandbox.spy();
+          const spy = env.sandbox.spy();
           integration.method(method, spy);
           integration.onMessage_({event: 'method', method});
           expect(spy).to.have.been.calledOnce;
@@ -110,12 +103,12 @@ describes.realWin('video-iframe-integration', {amp: false}, env => {
       it('should reject invalid methods', () => {
         const integration = new AmpVideoIntegration();
 
-        const listenToOnce = sandbox.stub(integration, 'listenToOnce_');
+        const listenToOnce = env.sandbox.stub(integration, 'listenToOnce_');
 
         const invalidMethods = 'tacos al pastor'.split(' ');
 
         invalidMethods.forEach(method => {
-          const spy = sandbox.spy();
+          const spy = env.sandbox.spy();
           expect(() => integration.method(method, spy)).to.throw(
             /Invalid method/
           );
@@ -138,7 +131,7 @@ describes.realWin('video-iframe-integration', {amp: false}, env => {
       it('should post valid events', () => {
         const integration = new AmpVideoIntegration();
 
-        const postToParent = sandbox.stub(integration, 'postToParent_');
+        const postToParent = env.sandbox.stub(integration, 'postToParent_');
 
         const validEvents = [
           'canplay',
@@ -153,7 +146,7 @@ describes.realWin('video-iframe-integration', {amp: false}, env => {
         for (let i = 0; i < validEvents.length; i++) {
           const event = validEvents[i];
           integration.postEvent(event);
-          expect(postToParent.withArgs(sinon.match({event}))).to.have.been
+          expect(postToParent.withArgs(env.sandbox.match({event}))).to.have.been
             .calledOnce;
         }
       });
@@ -162,14 +155,15 @@ describes.realWin('video-iframe-integration', {amp: false}, env => {
     describe('#getIntersection', () => {
       it('should request and receive intersection', () => {
         const integration = new AmpVideoIntegration();
-        const postToParent = sandbox.spy(integration, 'postToParent_');
+        const postToParent = env.sandbox.spy(integration, 'postToParent_');
 
-        const callback = sandbox.spy();
+        const callback = env.sandbox.spy();
 
         const id = integration.getIntersectionForTesting_(callback);
 
-        expect(postToParent.withArgs(sinon.match({method: 'getIntersection'})))
-          .to.have.been.calledOnce;
+        expect(
+          postToParent.withArgs(env.sandbox.match({method: 'getIntersection'}))
+        ).to.have.been.calledOnce;
 
         const mockedIntersection = {tacos: 'al pastor'};
 
@@ -183,12 +177,12 @@ describes.realWin('video-iframe-integration', {amp: false}, env => {
       describe('jwplayer', () => {
         it('registers all events and methods', () => {
           const player = {
-            on: sandbox.spy(),
-            play: sandbox.spy(),
-            pause: sandbox.spy(),
-            setMuted: sandbox.spy(),
-            setControls: sandbox.spy(),
-            setFullscreen: sandbox.spy(),
+            on: env.sandbox.spy(),
+            play: env.sandbox.spy(),
+            pause: env.sandbox.spy(),
+            setMuted: env.sandbox.spy(),
+            setControls: env.sandbox.spy(),
+            setFullscreen: env.sandbox.spy(),
           };
 
           const expectedEvents = [
@@ -216,19 +210,19 @@ describes.realWin('video-iframe-integration', {amp: false}, env => {
           ];
 
           const integration = new AmpVideoIntegration();
-          const listenToOnce = sandbox.stub(integration, 'listenToOnce_');
-          const methodSpy = sandbox.spy(integration, 'method');
+          const listenToOnce = env.sandbox.stub(integration, 'listenToOnce_');
+          const methodSpy = env.sandbox.spy(integration, 'method');
 
           integration.listenTo('jwplayer', player);
 
           expectedEvents.forEach(event => {
-            expect(player.on.withArgs(event, sinon.match.any)).to.have.been
-              .calledOnce;
+            expect(player.on.withArgs(event, env.sandbox.match.any)).to.have
+              .been.calledOnce;
           });
 
           expectedMethods.forEach(method => {
-            expect(methodSpy.withArgs(method, sinon.match.any)).to.have.been
-              .calledOnce;
+            expect(methodSpy.withArgs(method, env.sandbox.match.any)).to.have
+              .been.calledOnce;
           });
 
           expect(listenToOnce.callCount).to.equal(expectedMethods.length);
@@ -243,7 +237,7 @@ describes.realWin('video-iframe-integration', {amp: false}, env => {
           readyState() {
             return 0;
           },
-          on: sandbox.spy(),
+          on: env.sandbox.spy(),
         };
       }
 
@@ -264,8 +258,8 @@ describes.realWin('video-iframe-integration', {amp: false}, env => {
 
           const integration = new AmpVideoIntegration();
 
-          const listenToOnce = sandbox.stub(integration, 'listenToOnce_');
-          const methodSpy = sandbox.spy(integration, 'method');
+          const listenToOnce = env.sandbox.stub(integration, 'listenToOnce_');
+          const methodSpy = env.sandbox.spy(integration, 'method');
           const dummyElement = env.win.document.createElement('video');
 
           integration.listenTo(
@@ -275,8 +269,8 @@ describes.realWin('video-iframe-integration', {amp: false}, env => {
           );
 
           expectedMethods.forEach(method => {
-            expect(methodSpy.withArgs(method, sinon.match.any)).to.have.been
-              .calledOnce;
+            expect(methodSpy.withArgs(method, env.sandbox.match.any)).to.have
+              .been.calledOnce;
           });
 
           expect(listenToOnce.callCount).to.equal(expectedMethods.length);

--- a/test/unit/test-video-rotate-to-fullscreen.js
+++ b/test/unit/test-video-rotate-to-fullscreen.js
@@ -45,17 +45,17 @@ describes.fakeWin('Rotate-to-fullscreen', {amp: true}, env => {
   beforeEach(() => {
     ampdoc = env.ampdoc;
     autoFullscreenManager = new AutoFullscreenManager(ampdoc);
-    sandbox.stub(autoFullscreenManager, 'canFullscreen_').returns(true);
+    env.sandbox.stub(autoFullscreenManager, 'canFullscreen_').returns(true);
   });
 
   it('should enter fullscreen if a video is centered in portrait', () => {
     const video = createVideo();
     const entry = {video};
-    const enter = sandbox.stub(autoFullscreenManager, 'enter_');
+    const enter = env.sandbox.stub(autoFullscreenManager, 'enter_');
 
     mockCenteredVideo(video.element);
 
-    sandbox.stub(autoFullscreenManager, 'selectBestCenteredInPortrait_');
+    env.sandbox.stub(autoFullscreenManager, 'selectBestCenteredInPortrait_');
     autoFullscreenManager.register(entry);
     mockOrientation('landscape');
     autoFullscreenManager.onRotation_();
@@ -66,11 +66,11 @@ describes.fakeWin('Rotate-to-fullscreen', {amp: true}, env => {
   it('should not enter fullscreen if no video is centered in portrait', () => {
     const video = createVideo();
     const entry = {video};
-    const enter = sandbox.stub(autoFullscreenManager, 'enter_');
+    const enter = env.sandbox.stub(autoFullscreenManager, 'enter_');
 
     mockCenteredVideo(null);
 
-    sandbox.stub(autoFullscreenManager, 'selectBestCenteredInPortrait_');
+    env.sandbox.stub(autoFullscreenManager, 'selectBestCenteredInPortrait_');
     autoFullscreenManager.register(entry);
     mockOrientation('landscape');
     autoFullscreenManager.onRotation_();
@@ -81,9 +81,9 @@ describes.fakeWin('Rotate-to-fullscreen', {amp: true}, env => {
   it('should exit fullscreen on rotation', () => {
     const video = createVideo();
     const entry = {video};
-    const exit = sandbox.stub(autoFullscreenManager, 'exit_');
+    const exit = env.sandbox.stub(autoFullscreenManager, 'exit_');
 
-    sandbox.stub(autoFullscreenManager, 'selectBestCenteredInPortrait_');
+    env.sandbox.stub(autoFullscreenManager, 'selectBestCenteredInPortrait_');
     autoFullscreenManager.register(entry);
     autoFullscreenManager.currentlyInFullscreen_ = entry;
     mockOrientation('portrait');
@@ -95,9 +95,9 @@ describes.fakeWin('Rotate-to-fullscreen', {amp: true}, env => {
   it('should not exit on rotation if no video was in fullscreen', () => {
     const video = createVideo();
     const entry = {video};
-    const exit = sandbox.stub(autoFullscreenManager, 'exit_');
+    const exit = env.sandbox.stub(autoFullscreenManager, 'exit_');
 
-    sandbox.stub(autoFullscreenManager, 'selectBestCenteredInPortrait_');
+    env.sandbox.stub(autoFullscreenManager, 'selectBestCenteredInPortrait_');
     autoFullscreenManager.register(entry);
     autoFullscreenManager.currentlyInFullscreen_ = null;
     mockOrientation('portrait');
@@ -111,12 +111,12 @@ describes.fakeWin('Rotate-to-fullscreen', {amp: true}, env => {
     const video2 = createVideo();
     const video3 = createVideo();
 
-    sandbox.stub(Services.viewportForDoc(ampdoc), 'getSize').returns({
+    env.sandbox.stub(Services.viewportForDoc(ampdoc), 'getSize').returns({
       width: 1000,
       height: 1000,
     });
 
-    sandbox.stub(video1.element, 'getIntersectionChangeEntry').returns({
+    env.sandbox.stub(video1.element, 'getIntersectionChangeEntry').returns({
       // Visible:
       intersectionRatio: 1,
       boundingClientRect: {
@@ -126,7 +126,7 @@ describes.fakeWin('Rotate-to-fullscreen', {amp: true}, env => {
         height: 200,
       },
     });
-    sandbox.stub(video2.element, 'getIntersectionChangeEntry').returns({
+    env.sandbox.stub(video2.element, 'getIntersectionChangeEntry').returns({
       // Visible:
       intersectionRatio: 1,
       boundingClientRect: {
@@ -136,7 +136,7 @@ describes.fakeWin('Rotate-to-fullscreen', {amp: true}, env => {
         height: 200,
       },
     });
-    sandbox.stub(video3.element, 'getIntersectionChangeEntry').returns({
+    env.sandbox.stub(video3.element, 'getIntersectionChangeEntry').returns({
       // Visible:
       intersectionRatio: 1,
       boundingClientRect: {
@@ -147,7 +147,7 @@ describes.fakeWin('Rotate-to-fullscreen', {amp: true}, env => {
       },
     });
 
-    const getPlayingState = sandbox.stub(
+    const getPlayingState = env.sandbox.stub(
       autoFullscreenManager,
       'getPlayingState_'
     );
@@ -170,12 +170,12 @@ describes.fakeWin('Rotate-to-fullscreen', {amp: true}, env => {
     const video2 = createVideo();
     const video3 = createVideo();
 
-    sandbox.stub(Services.viewportForDoc(ampdoc), 'getSize').returns({
+    env.sandbox.stub(Services.viewportForDoc(ampdoc), 'getSize').returns({
       width: 1000,
       height: 600,
     });
 
-    sandbox.stub(video1.element, 'getIntersectionChangeEntry').returns({
+    env.sandbox.stub(video1.element, 'getIntersectionChangeEntry').returns({
       // Visible:
       intersectionRatio: 1,
       boundingClientRect: {
@@ -185,7 +185,7 @@ describes.fakeWin('Rotate-to-fullscreen', {amp: true}, env => {
         height: 200,
       },
     });
-    sandbox.stub(video2.element, 'getIntersectionChangeEntry').returns({
+    env.sandbox.stub(video2.element, 'getIntersectionChangeEntry').returns({
       // Visible:
       intersectionRatio: 1,
       boundingClientRect: {
@@ -195,7 +195,7 @@ describes.fakeWin('Rotate-to-fullscreen', {amp: true}, env => {
         height: 200,
       },
     });
-    sandbox.stub(video3.element, 'getIntersectionChangeEntry').returns({
+    env.sandbox.stub(video3.element, 'getIntersectionChangeEntry').returns({
       // Visible:
       intersectionRatio: 1,
       boundingClientRect: {
@@ -206,7 +206,7 @@ describes.fakeWin('Rotate-to-fullscreen', {amp: true}, env => {
       },
     });
 
-    const getPlayingState = sandbox.stub(
+    const getPlayingState = env.sandbox.stub(
       autoFullscreenManager,
       'getPlayingState_'
     );
@@ -228,12 +228,12 @@ describes.fakeWin('Rotate-to-fullscreen', {amp: true}, env => {
     const video1 = createVideo();
     const video2 = createVideo();
 
-    sandbox.stub(Services.viewportForDoc(ampdoc), 'getSize').returns({
+    env.sandbox.stub(Services.viewportForDoc(ampdoc), 'getSize').returns({
       width: 1000,
       height: 400,
     });
 
-    sandbox.stub(video1.element, 'getIntersectionChangeEntry').returns({
+    env.sandbox.stub(video1.element, 'getIntersectionChangeEntry').returns({
       // Visible:
       intersectionRatio: 1,
       boundingClientRect: {
@@ -243,7 +243,7 @@ describes.fakeWin('Rotate-to-fullscreen', {amp: true}, env => {
         height: 200,
       },
     });
-    sandbox.stub(video2.element, 'getIntersectionChangeEntry').returns({
+    env.sandbox.stub(video2.element, 'getIntersectionChangeEntry').returns({
       // Visible:
       intersectionRatio: 1,
       boundingClientRect: {
@@ -254,7 +254,7 @@ describes.fakeWin('Rotate-to-fullscreen', {amp: true}, env => {
       },
     });
 
-    const getPlayingState = sandbox.stub(
+    const getPlayingState = env.sandbox.stub(
       autoFullscreenManager,
       'getPlayingState_'
     );
@@ -274,12 +274,12 @@ describes.fakeWin('Rotate-to-fullscreen', {amp: true}, env => {
     const video1 = createVideo();
     const video2 = createVideo();
 
-    sandbox.stub(Services.viewportForDoc(ampdoc), 'getSize').returns({
+    env.sandbox.stub(Services.viewportForDoc(ampdoc), 'getSize').returns({
       width: 1000,
       height: 400,
     });
 
-    sandbox.stub(video1.element, 'getIntersectionChangeEntry').returns({
+    env.sandbox.stub(video1.element, 'getIntersectionChangeEntry').returns({
       intersectionRatio: 0.9,
       boundingClientRect: {
         top: -30,
@@ -288,7 +288,7 @@ describes.fakeWin('Rotate-to-fullscreen', {amp: true}, env => {
         height: 200,
       },
     });
-    sandbox.stub(video2.element, 'getIntersectionChangeEntry').returns({
+    env.sandbox.stub(video2.element, 'getIntersectionChangeEntry').returns({
       // Visible:
       intersectionRatio: 1,
       boundingClientRect: {
@@ -299,7 +299,7 @@ describes.fakeWin('Rotate-to-fullscreen', {amp: true}, env => {
       },
     });
 
-    const getPlayingState = sandbox.stub(
+    const getPlayingState = env.sandbox.stub(
       autoFullscreenManager,
       'getPlayingState_'
     );

--- a/test/unit/test-video-session-manager.js
+++ b/test/unit/test-video-session-manager.js
@@ -16,7 +16,7 @@
 
 import {VideoSessionManager} from '../../src/service/video-session-manager';
 
-describes.sandboxed('VideoSessionManager', {}, () => {
+describes.sandboxed('VideoSessionManager', {}, env => {
   let manager;
 
   beforeEach(() => {
@@ -24,7 +24,7 @@ describes.sandboxed('VideoSessionManager', {}, () => {
   });
 
   it('should trigger a listener when a session ends', () => {
-    const sessionSpy = sandbox.spy();
+    const sessionSpy = env.sandbox.spy();
     manager.onSessionEnd(sessionSpy);
 
     manager.beginSession();
@@ -33,7 +33,7 @@ describes.sandboxed('VideoSessionManager', {}, () => {
   });
 
   it('should only begin a session once even after repeated calls', () => {
-    const sessionSpy = sandbox.spy();
+    const sessionSpy = env.sandbox.spy();
     manager.onSessionEnd(sessionSpy);
 
     manager.beginSession();
@@ -44,7 +44,7 @@ describes.sandboxed('VideoSessionManager', {}, () => {
   });
 
   it('should only end a session once even after repeated calls', () => {
-    const sessionSpy = sandbox.spy();
+    const sessionSpy = env.sandbox.spy();
     manager.onSessionEnd(sessionSpy);
 
     manager.beginSession();

--- a/test/unit/test-viewer-cid-api.js
+++ b/test/unit/test-viewer-cid-api.js
@@ -21,13 +21,11 @@ import {mockServiceForDoc} from '../../testing/test-helper';
 describes.realWin('viewerCidApi', {amp: true}, env => {
   let ampdoc;
   let api;
-  let sandbox;
   let viewerMock;
 
   beforeEach(() => {
     ampdoc = env.ampdoc;
-    sandbox = env.sandbox;
-    viewerMock = mockServiceForDoc(sandbox, ampdoc, 'viewer', [
+    viewerMock = mockServiceForDoc(env.sandbox, ampdoc, 'viewer', [
       'sendMessageAwaitResponse',
       'hasCapability',
       'isTrustedViewer',

--- a/test/unit/test-viewer.js
+++ b/test/unit/test-viewer.js
@@ -27,7 +27,7 @@ import {
   removeFragment,
 } from '../../src/url';
 
-describes.sandboxed('Viewer', {}, () => {
+describes.sandboxed('Viewer', {}, env => {
   let windowMock;
   let viewer;
   let windowApi;
@@ -67,7 +67,7 @@ describes.sandboxed('Viewer', {}, () => {
   }
 
   beforeEach(() => {
-    clock = sandbox.useFakeTimers();
+    clock = env.sandbox.useFakeTimers();
     events = {};
     const WindowApi = function() {};
     windowApi = new WindowApi();
@@ -105,7 +105,7 @@ describes.sandboxed('Viewer', {}, () => {
     windowApi.history = {
       replaceState: () => {},
     };
-    sandbox
+    env.sandbox
       .stub(windowApi.history, 'replaceState')
       .callsFake((state, title, url) => {
         windowApi.location.href = url;
@@ -114,16 +114,16 @@ describes.sandboxed('Viewer', {}, () => {
     ampdoc = Services.ampdocServiceFor(windowApi).getSingleDoc();
 
     params = {'origin': 'g.com'};
-    sandbox
+    env.sandbox
       .stub(ampdoc, 'getParam')
       .callsFake(name => (name in params ? params[name] : null));
 
     installPlatformService(windowApi);
     installTimerService(windowApi);
     installDocumentInfoServiceForDoc(windowApi.document);
-    errorStub = sandbox.stub(dev(), 'error');
-    expectedErrorStub = sandbox.stub(dev(), 'expectedError');
-    windowMock = sandbox.mock(windowApi);
+    errorStub = env.sandbox.stub(dev(), 'error');
+    expectedErrorStub = env.sandbox.stub(dev(), 'expectedError');
+    windowMock = env.sandbox.mock(windowApi);
     viewer = new ViewerImpl(ampdoc);
   });
 
@@ -436,7 +436,7 @@ describes.sandboxed('Viewer', {}, () => {
       const fragment = '#replaceUrl=http://www.example.com/two&b=1';
       setUrl('http://www.example.com/one' + fragment);
       windowApi.history.replaceState.restore();
-      sandbox.stub(windowApi.history, 'replaceState').callsFake(() => {
+      env.sandbox.stub(windowApi.history, 'replaceState').callsFake(() => {
         throw new Error('intentional');
       });
       const viewer = new ViewerImpl(ampdoc);
@@ -476,7 +476,7 @@ describes.sandboxed('Viewer', {}, () => {
     it('should NOT replace URL in shadow doc', () => {
       const fragment = '#replaceUrl=http://www.example.com/two&b=1';
       setUrl('http://www.example.com/one' + fragment);
-      sandbox.stub(ampdoc, 'isSingleDoc').callsFake(() => false);
+      env.sandbox.stub(ampdoc, 'isSingleDoc').callsFake(() => false);
       const viewer = new ViewerImpl(ampdoc);
       viewer.replaceUrl(viewer.getParam('replaceUrl'));
       expect(windowApi.history.replaceState).to.not.be.called;
@@ -513,7 +513,7 @@ describes.sandboxed('Viewer', {}, () => {
     });
 
     it('should parse "hidden" as "prerender" before first visible', () => {
-      sandbox.stub(ampdoc, 'getLastVisibleTime').callsFake(() => null);
+      env.sandbox.stub(ampdoc, 'getLastVisibleTime').callsFake(() => null);
       viewer.receiveMessage('visibilitychange', {
         state: 'hidden',
       });
@@ -521,7 +521,7 @@ describes.sandboxed('Viewer', {}, () => {
     });
 
     it('should parse "hidden" as "inactive" after first visible', () => {
-      sandbox.stub(ampdoc, 'getLastVisibleTime').callsFake(() => 1);
+      env.sandbox.stub(ampdoc, 'getLastVisibleTime').callsFake(() => 1);
       viewer.receiveMessage('visibilitychange', {
         state: 'hidden',
       });
@@ -845,11 +845,11 @@ describes.sandboxed('Viewer', {}, () => {
           /* cancelUnsent */ true
         );
 
-        const delivererSpy = sandbox.stub();
+        const delivererSpy = env.sandbox.stub();
         delivererSpy.returns(Promise.resolve());
 
         viewer.setMessageDeliverer(delivererSpy, 'https://www.example.com');
-        sinon.assert.callOrder(
+        env.sandbox.assert.callOrder(
           delivererSpy.withArgs('event-b', {value: 2}, true),
           delivererSpy.withArgs('event-a', {value: 3}, true)
         );
@@ -875,7 +875,7 @@ describes.sandboxed('Viewer', {}, () => {
           /* cancelUnsent */ true
         );
 
-        const delivererSpy = sandbox.stub();
+        const delivererSpy = env.sandbox.stub();
         delivererSpy
           .withArgs('event-a', {value: 2}, true)
           .returns(Promise.resolve('result-2'));
@@ -1498,7 +1498,7 @@ describes.sandboxed('Viewer', {}, () => {
         expect(
           expectedErrorStub.calledWith(
             'Viewer',
-            sinon.match(arg => {
+            env.sandbox.match(arg => {
               return !!arg.match(/Untrusted viewer referrer override/);
             })
           )
@@ -1611,7 +1611,7 @@ describes.sandboxed('Viewer', {}, () => {
         expect(
           expectedErrorStub.calledWith(
             'Viewer',
-            sinon.match(arg => {
+            env.sandbox.match(arg => {
               return !!arg.match(/Untrusted viewer url override/);
             })
           )
@@ -1635,7 +1635,7 @@ describes.sandboxed('Viewer', {}, () => {
         expect(
           expectedErrorStub.calledWith(
             'Viewer',
-            sinon.match(arg => {
+            env.sandbox.match(arg => {
               return !!arg.match(/Untrusted viewer url override/);
             })
           )
@@ -1659,7 +1659,7 @@ describes.sandboxed('Viewer', {}, () => {
         expect(
           expectedErrorStub.calledWith(
             'Viewer',
-            sinon.match(arg => {
+            env.sandbox.match(arg => {
               return !!arg.match(/Untrusted viewer url override/);
             })
           )

--- a/test/unit/test-viewport-binding.js
+++ b/test/unit/test-viewport-binding.js
@@ -28,11 +28,8 @@ describes.realWin('ViewportBindingNatural', {ampCss: true}, env => {
   let win;
   let ampdoc;
   let child;
-  let sandbox;
 
   beforeEach(() => {
-    sandbox = env.sandbox;
-
     env.iframe.style.width = '100px';
     env.iframe.style.height = '200px';
     win = env.win;
@@ -142,8 +139,8 @@ describes.realWin('ViewportBindingNatural', {ampCss: true}, env => {
   });
 
   it('should account for child margin-top (WebKit)', () => {
-    sandbox.stub(win.document, 'scrollingElement').value(null);
-    sandbox.stub(binding.platform_, 'isWebKit').returns(true);
+    env.sandbox.stub(win.document, 'scrollingElement').value(null);
+    env.sandbox.stub(binding.platform_, 'isWebKit').returns(true);
 
     child.style.marginTop = '15px';
     expect(binding.getContentHeight()).to.equal(315);
@@ -224,11 +221,8 @@ describes.realWin('ViewportBindingNatural on iOS', {ampCss: true}, env => {
   let win;
   let ampdoc;
   let child;
-  let sandbox;
 
   beforeEach(() => {
-    sandbox = env.sandbox;
-
     env.iframe.style.width = '100px';
     env.iframe.style.height = '200px';
     win = env.win;
@@ -243,7 +237,7 @@ describes.realWin('ViewportBindingNatural on iOS', {ampCss: true}, env => {
     installVsyncService(win);
     installDocService(win, /* isSingleDoc */ true);
     ampdoc = Services.ampdocServiceFor(win).getSingleDoc();
-    sandbox.stub(Services.platformFor(win), 'isIos').returns(true);
+    env.sandbox.stub(Services.platformFor(win), 'isIos').returns(true);
     binding = new ViewportBindingNatural_(ampdoc);
     binding.connect();
   });
@@ -301,7 +295,7 @@ describes.realWin('ViewportBindingIosEmbedWrapper', {ampCss: true}, env => {
 
   // TODO(#22220): Remove when "ios-fixed-no-transfer" experiment is cleaned up.
   it('should require fixed layer transferring for later iOS w/o experiment', () => {
-    sandbox
+    env.sandbox
       .stub(Services.platformFor(win), 'getIosVersionString')
       .callsFake(() => '12.2');
     expect(binding.requiresFixedLayerTransfer()).to.be.true;
@@ -310,7 +304,7 @@ describes.realWin('ViewportBindingIosEmbedWrapper', {ampCss: true}, env => {
   it('should configure fixed layer transferring based on iOS version', () => {
     toggleExperiment(win, 'ios-fixed-no-transfer');
     let version;
-    sandbox
+    env.sandbox
       .stub(Services.platformFor(win), 'getIosVersionString')
       .callsFake(() => version);
 

--- a/test/unit/test-viewport.js
+++ b/test/unit/test-viewport.js
@@ -43,7 +43,6 @@ import {setParentWindow} from '../../src/service';
 const NOOP = () => {};
 
 describes.fakeWin('Viewport', {}, env => {
-  let sandbox;
   let clock;
   let viewport;
   let binding;
@@ -61,8 +60,7 @@ describes.fakeWin('Viewport', {}, env => {
   let onVisibilityHandlers;
 
   beforeEach(() => {
-    sandbox = env.sandbox;
-    clock = sandbox.useFakeTimers();
+    clock = env.sandbox.useFakeTimers();
 
     windowApi = env.win;
     windowApi.requestAnimationFrame = fn => window.setTimeout(fn, 16);
@@ -89,9 +87,9 @@ describes.fakeWin('Viewport', {}, env => {
           viewerDisableScrollHandler = handler;
         }
       },
-      sendMessage: sandbox.spy(),
+      sendMessage: env.sandbox.spy(),
     };
-    viewerMock = sandbox.mock(viewer);
+    viewerMock = env.sandbox.mock(viewer);
     installTimerService(windowApi);
     installVsyncService(windowApi);
     installPlatformService(windowApi);
@@ -99,12 +97,14 @@ describes.fakeWin('Viewport', {}, env => {
 
     ampdoc = Services.ampdocServiceFor(windowApi).getSingleDoc();
     installViewerServiceForDoc(ampdoc);
-    sandbox.stub(ampdoc, 'getVisibilityState').callsFake(() => visibilityState);
-    sandbox
+    env.sandbox
+      .stub(ampdoc, 'getVisibilityState')
+      .callsFake(() => visibilityState);
+    env.sandbox
       .stub(ampdoc, 'isVisible')
       .callsFake(() => visibilityState == 'visible');
     onVisibilityHandlers = [];
-    sandbox.stub(ampdoc, 'onVisibilityChanged').callsFake(handler => {
+    env.sandbox.stub(ampdoc, 'onVisibilityChanged').callsFake(handler => {
       onVisibilityHandlers.push(handler);
       return function() {
         const index = onVisibilityHandlers.indexOf(handler);
@@ -121,8 +121,8 @@ describes.fakeWin('Viewport', {}, env => {
     };
     binding.getScrollTop = () => 17;
     binding.getScrollLeft = () => 0;
-    binding.connect = sandbox.spy();
-    binding.disconnect = sandbox.spy();
+    binding.connect = env.sandbox.spy();
+    binding.disconnect = env.sandbox.spy();
     updatedPaddingTop = undefined;
     binding.updatePaddingTop = paddingTop => (updatedPaddingTop = paddingTop);
     viewport = new ViewportImpl(ampdoc, binding, viewer);
@@ -139,8 +139,8 @@ describes.fakeWin('Viewport', {}, env => {
     // Use window since Animation by default will use window.
     const vsync = Services.vsyncFor(window);
     vsyncTasks = [];
-    sandbox.stub(vsync, 'canAnimate').returns(true);
-    sandbox
+    env.sandbox.stub(vsync, 'canAnimate').returns(true);
+    env.sandbox
       .stub(vsync, 'createAnimTask')
       .callsFake((unusedContextNode, task) => {
         return () => {
@@ -172,7 +172,7 @@ describes.fakeWin('Viewport', {}, env => {
   }
 
   function stubVsyncMeasure() {
-    sandbox
+    env.sandbox
       .stub(viewport.vsync_, 'measurePromise')
       .callsFake(cb => Promise.resolve(cb()));
   }
@@ -191,7 +191,7 @@ describes.fakeWin('Viewport', {}, env => {
     });
 
     it('should not set singledoc class', () => {
-      sandbox.stub(ampdoc, 'isSingleDoc').callsFake(() => false);
+      env.sandbox.stub(ampdoc, 'isSingleDoc').callsFake(() => false);
       new ViewportImpl(ampdoc, binding, viewer);
       expect(root).to.not.have.class('i-amphtml-singledoc');
     });
@@ -203,7 +203,7 @@ describes.fakeWin('Viewport', {}, env => {
     });
 
     it('should set embedded class', () => {
-      sandbox.stub(viewer, 'isEmbedded').callsFake(() => true);
+      env.sandbox.stub(viewer, 'isEmbedded').callsFake(() => true);
       new ViewportImpl(ampdoc, binding, viewer);
       expect(root).to.have.class('i-amphtml-embedded');
       expect(root).to.not.have.class('i-amphtml-standalone');
@@ -226,7 +226,7 @@ describes.fakeWin('Viewport', {}, env => {
 
       beforeEach(() => {
         webviewParam = '1';
-        sandbox.stub(viewer, 'getParam').callsFake(param => {
+        env.sandbox.stub(viewer, 'getParam').callsFake(param => {
           if (param == 'webview') {
             return webviewParam;
           }
@@ -234,7 +234,7 @@ describes.fakeWin('Viewport', {}, env => {
         });
         const platform = Services.platformFor(ampdoc.win);
         isIos = true;
-        sandbox.stub(platform, 'isIos').callsFake(() => isIos);
+        env.sandbox.stub(platform, 'isIos').callsFake(() => isIos);
       });
 
       it('should set ios-webview class', () => {
@@ -262,9 +262,9 @@ describes.fakeWin('Viewport', {}, env => {
 
     beforeEach(() => {
       viewport.size_ = null;
-      errorStub = sandbox.stub(dev(), 'error');
+      errorStub = env.sandbox.stub(dev(), 'error');
       randomValue = 0.009;
-      sandbox.stub(Math, 'random').callsFake(() => randomValue);
+      env.sandbox.stub(Math, 'random').callsFake(() => randomValue);
     });
 
     it('should be ok with non-zero dimensions', () => {
@@ -370,8 +370,8 @@ describes.fakeWin('Viewport', {}, env => {
   it('should connect binding later when visibility changes', () => {
     onVisibilityHandlers.length = 0;
     changeVisibilityState('hidden');
-    binding.connect = sandbox.spy();
-    binding.disconnect = sandbox.spy();
+    binding.connect = env.sandbox.spy();
+    binding.disconnect = env.sandbox.spy();
     viewport = new ViewportImpl(ampdoc, binding, viewer);
 
     // Hasn't been called at first.
@@ -398,8 +398,8 @@ describes.fakeWin('Viewport', {}, env => {
   it('should resize only after size has been initialed', () => {
     onVisibilityHandlers.length = 0;
     changeVisibilityState('visible');
-    binding.connect = sandbox.spy();
-    binding.disconnect = sandbox.spy();
+    binding.connect = env.sandbox.spy();
+    binding.disconnect = env.sandbox.spy();
     viewport = new ViewportImpl(ampdoc, binding, viewer);
 
     // Size has not be initialized yet.
@@ -539,14 +539,14 @@ describes.fakeWin('Viewport', {}, env => {
   });
 
   it('should not do anything if padding is not changed', () => {
-    const bindingMock = sandbox.mock(binding);
+    const bindingMock = env.sandbox.mock(binding);
     viewerViewportHandler({paddingTop: 19});
     bindingMock.verify();
   });
 
   it('should update non-transient padding', () => {
-    const bindingMock = sandbox.mock(binding);
-    const fixedLayerMock = sandbox.mock(viewport.fixedLayer_);
+    const bindingMock = env.sandbox.mock(binding);
+    const fixedLayerMock = env.sandbox.mock(viewport.fixedLayer_);
     fixedLayerMock
       .expects('updatePaddingTop')
       .withExactArgs(/* paddingTop */ 0, /* transient */ undefined)
@@ -557,8 +557,8 @@ describes.fakeWin('Viewport', {}, env => {
   });
 
   it('should update padding when viewer wants to hide header', () => {
-    const bindingMock = sandbox.mock(binding);
-    const fixedLayerMock = sandbox.mock(viewport.fixedLayer_);
+    const bindingMock = env.sandbox.mock(binding);
+    const fixedLayerMock = env.sandbox.mock(viewport.fixedLayer_);
     fixedLayerMock
       .expects('updatePaddingTop')
       .withExactArgs(/* paddingTop */ 0, /* transient */ true)
@@ -582,7 +582,7 @@ describes.fakeWin('Viewport', {}, env => {
       'hide header',
     () => {
       viewport.fixedLayer_ = {updatePaddingTop: () => {}};
-      const fixedLayerMock = sandbox.mock(viewport.fixedLayer_);
+      const fixedLayerMock = env.sandbox.mock(viewport.fixedLayer_);
       fixedLayerMock
         .expects('updatePaddingTop')
         .withArgs(0)
@@ -601,10 +601,10 @@ describes.fakeWin('Viewport', {}, env => {
     const requestingEl = document.createElement('div');
 
     viewport.vsync_ = {mutate: callback => callback()};
-    sandbox.stub(viewport, 'enterOverlayMode');
-    sandbox.stub(viewport, 'maybeEnterFieLightboxMode').callsFake(NOOP);
-    sandbox.stub(viewport.fixedLayer_, 'enterLightbox');
-    const bindingMock = sandbox.mock(binding);
+    env.sandbox.stub(viewport, 'enterOverlayMode');
+    env.sandbox.stub(viewport, 'maybeEnterFieLightboxMode').callsFake(NOOP);
+    env.sandbox.stub(viewport.fixedLayer_, 'enterLightbox');
+    const bindingMock = env.sandbox.mock(binding);
     bindingMock
       .expects('updateLightboxMode')
       .withArgs(true)
@@ -629,10 +629,10 @@ describes.fakeWin('Viewport', {}, env => {
     const requestingEl = document.createElement('div');
 
     viewport.vsync_ = {mutate: callback => callback()};
-    sandbox.stub(viewport, 'leaveOverlayMode');
-    sandbox.stub(viewport, 'maybeLeaveFieLightboxMode').callsFake(NOOP);
-    sandbox.stub(viewport.fixedLayer_, 'leaveLightbox');
-    const bindingMock = sandbox.mock(binding);
+    env.sandbox.stub(viewport, 'leaveOverlayMode');
+    env.sandbox.stub(viewport, 'maybeLeaveFieLightboxMode').callsFake(NOOP);
+    env.sandbox.stub(viewport.fixedLayer_, 'leaveLightbox');
+    const bindingMock = env.sandbox.mock(binding);
     bindingMock
       .expects('updateLightboxMode')
       .withArgs(false)
@@ -656,12 +656,12 @@ describes.fakeWin('Viewport', {}, env => {
   it('should enter full overlay on FIE when entering lightbox mode', () => {
     const requestingElement = {};
     const fieMock = {
-      enterFullOverlayMode: sandbox.spy(),
+      enterFullOverlayMode: env.sandbox.spy(),
     };
 
-    sandbox.stub(viewport, 'isLightboxExperimentOn').callsFake(() => true);
+    env.sandbox.stub(viewport, 'isLightboxExperimentOn').callsFake(() => true);
 
-    sandbox.stub(viewport, 'getFriendlyIframeEmbed_').callsFake(el => {
+    env.sandbox.stub(viewport, 'getFriendlyIframeEmbed_').callsFake(el => {
       expect(el).to.equal(requestingElement);
       return fieMock;
     });
@@ -674,10 +674,10 @@ describes.fakeWin('Viewport', {}, env => {
   it('should leave full overlay on FIE when leaving lightbox mode', () => {
     const requestingElement = {};
     const fieMock = {
-      leaveFullOverlayMode: sandbox.spy(),
+      leaveFullOverlayMode: env.sandbox.spy(),
     };
 
-    sandbox.stub(viewport, 'getFriendlyIframeEmbed_').callsFake(el => {
+    env.sandbox.stub(viewport, 'getFriendlyIframeEmbed_').callsFake(el => {
       expect(el).to.equal(requestingElement);
       return fieMock;
     });
@@ -688,8 +688,8 @@ describes.fakeWin('Viewport', {}, env => {
   });
 
   it('should update viewport when entering overlay mode', () => {
-    const disableTouchZoomStub = sandbox.stub(viewport, 'disableTouchZoom');
-    const disableScrollStub = sandbox.stub(viewport, 'disableScroll');
+    const disableTouchZoomStub = env.sandbox.stub(viewport, 'disableTouchZoom');
+    const disableScrollStub = env.sandbox.stub(viewport, 'disableScroll');
 
     viewport.enterOverlayMode();
 
@@ -698,11 +698,11 @@ describes.fakeWin('Viewport', {}, env => {
   });
 
   it('should update viewport when leaving overlay mode', () => {
-    const restoreOriginalTouchZoomStub = sandbox.stub(
+    const restoreOriginalTouchZoomStub = env.sandbox.stub(
       viewport,
       'restoreOriginalTouchZoom'
     );
-    const resetScrollStub = sandbox.stub(viewport, 'resetScroll');
+    const resetScrollStub = env.sandbox.stub(viewport, 'resetScroll');
 
     viewport.leaveOverlayMode();
 
@@ -711,7 +711,7 @@ describes.fakeWin('Viewport', {}, env => {
   });
 
   it('should disable scrolling based on requests', () => {
-    const disableScrollStub = sandbox.stub(viewport, 'disableScroll');
+    const disableScrollStub = env.sandbox.stub(viewport, 'disableScroll');
 
     viewerDisableScrollHandler(true);
 
@@ -719,7 +719,7 @@ describes.fakeWin('Viewport', {}, env => {
   });
 
   it('should reset scrolling based on requests', () => {
-    const resetScrollStub = sandbox.stub(viewport, 'resetScroll');
+    const resetScrollStub = env.sandbox.stub(viewport, 'resetScroll');
 
     viewerDisableScrollHandler(false);
 
@@ -846,7 +846,7 @@ describes.fakeWin('Viewport', {}, env => {
   });
 
   it('should update scroll pos and reset cache', () => {
-    const bindingMock = sandbox.mock(binding);
+    const bindingMock = env.sandbox.mock(binding);
     bindingMock
       .expects('setScrollTop')
       .withArgs(117)
@@ -862,7 +862,7 @@ describes.fakeWin('Viewport', {}, env => {
     // be attached.
     document.body.appendChild(element);
 
-    const bindingMock = sandbox.mock(binding);
+    const bindingMock = env.sandbox.mock(binding);
 
     bindingMock
       .expects('getScrollingElement')
@@ -896,7 +896,7 @@ describes.fakeWin('Viewport', {}, env => {
     // be attached.
     document.body.appendChild(element);
 
-    const bindingMock = sandbox.mock(binding);
+    const bindingMock = env.sandbox.mock(binding);
 
     bindingMock
       .expects('getScrollingElement')
@@ -911,7 +911,7 @@ describes.fakeWin('Viewport', {}, env => {
       .returns({top})
       .once();
 
-    const interpolateScrollIntoView = sandbox.stub(
+    const interpolateScrollIntoView = env.sandbox.stub(
       viewport,
       'interpolateScrollIntoView_'
     );
@@ -932,25 +932,25 @@ describes.fakeWin('Viewport', {}, env => {
 
     expect(
       interpolateScrollIntoView.withArgs(
-        /* parent       */ sinon.match.any,
-        /* curScrollTop */ sinon.match.any,
+        /* parent       */ env.sandbox.match.any,
+        /* curScrollTop */ env.sandbox.match.any,
         /* newScrollTop */ top - /* padding */ 19,
-        /* duration     */ sinon.match.any,
-        /* curve        */ sinon.match.any
+        /* duration     */ env.sandbox.match.any,
+        /* curve        */ env.sandbox.match.any
       )
     ).to.be.calledOnce;
   });
 
   it('should not change scrollTop for animateScrollIntoView', () => {
     const element = document.createElement('div');
-    const bindingMock = sandbox.mock(binding);
+    const bindingMock = env.sandbox.mock(binding);
     bindingMock
       .expects('getLayoutRect')
       .withArgs(element)
       .returns({top: 111})
       .once();
     viewport.paddingTop_ = 0;
-    sandbox.stub(viewport, 'getScrollTop').returns(111);
+    env.sandbox.stub(viewport, 'getScrollTop').returns(111);
     bindingMock
       .expects('setScrollTop')
       .withArgs(111)
@@ -968,7 +968,7 @@ describes.fakeWin('Viewport', {}, env => {
 
   it('should send cached scroll pos to getLayoutRect', () => {
     const element = document.createElement('div');
-    const bindingMock = sandbox.mock(binding);
+    const bindingMock = env.sandbox.mock(binding);
     viewport.scrollTop_ = 111;
     viewport.scrollLeft_ = 222;
     bindingMock
@@ -980,7 +980,7 @@ describes.fakeWin('Viewport', {}, env => {
   });
 
   it('should calculate client rect w/o global client rect', () => {
-    const bindingMock = sandbox.mock(binding);
+    const bindingMock = env.sandbox.mock(binding);
     bindingMock
       .expects('getRootClientRectAsync')
       .returns(Promise.resolve(null));
@@ -993,7 +993,7 @@ describes.fakeWin('Viewport', {}, env => {
   });
 
   it('should calculate client rect w/ global client rect when ', () => {
-    const bindingMock = sandbox.mock(binding);
+    const bindingMock = env.sandbox.mock(binding);
     bindingMock
       .expects('getRootClientRectAsync')
       .returns(Promise.resolve(layoutRectLtwh(5, 5, 5, 5)))
@@ -1007,7 +1007,7 @@ describes.fakeWin('Viewport', {}, env => {
   });
 
   it('should deletegate scrollWidth', () => {
-    const bindingMock = sandbox.mock(binding);
+    const bindingMock = env.sandbox.mock(binding);
     bindingMock
       .expects('getScrollWidth')
       .withArgs()
@@ -1017,7 +1017,7 @@ describes.fakeWin('Viewport', {}, env => {
   });
 
   it('should deletegate scrollHeight', () => {
-    const bindingMock = sandbox.mock(binding);
+    const bindingMock = env.sandbox.mock(binding);
     bindingMock
       .expects('getScrollHeight')
       .withArgs()
@@ -1027,7 +1027,7 @@ describes.fakeWin('Viewport', {}, env => {
   });
 
   it('should delegate contentHeight', () => {
-    const bindingMock = sandbox.mock(binding);
+    const bindingMock = env.sandbox.mock(binding);
     bindingMock
       .expects('getContentHeight')
       .withArgs()
@@ -1038,14 +1038,14 @@ describes.fakeWin('Viewport', {}, env => {
   });
 
   it('should delegate contentHeightChanged', () => {
-    const bindingMock = sandbox.mock(binding);
+    const bindingMock = env.sandbox.mock(binding);
     bindingMock.expects('contentHeightChanged').once();
     viewport.contentHeightChanged();
     bindingMock.verify();
   });
 
   it('should scroll to target position when the viewer sets scrollTop', () => {
-    const bindingMock = sandbox.mock(binding);
+    const bindingMock = env.sandbox.mock(binding);
     bindingMock
       .expects('setScrollTop')
       .withArgs(117)
@@ -1094,7 +1094,7 @@ describes.fakeWin('Viewport', {}, env => {
     beforeEach(() => {
       ampdoc = new AmpDocSingle(window);
       viewport = new ViewportImpl(ampdoc, binding, viewer);
-      bindingMock = sandbox.mock(binding);
+      bindingMock = env.sandbox.mock(binding);
       iframe = document.createElement('iframe');
       const html = '<div id="one"></div>';
       let promise;
@@ -1182,18 +1182,20 @@ describes.fakeWin('Viewport', {}, env => {
     });
 
     it('should override scrollTo when requested', () => {
-      sandbox.stub(binding, 'overrideGlobalScrollTo').callsFake(() => true);
+      env.sandbox.stub(binding, 'overrideGlobalScrollTo').callsFake(() => true);
       viewport = new ViewportImpl(ampdoc, binding, viewer);
-      const setScrollTopStub = sandbox.stub(viewport, 'setScrollTop');
+      const setScrollTopStub = env.sandbox.stub(viewport, 'setScrollTop');
       expect(windowApi.scrollTo).to.not.equal(originalScrollTo);
       windowApi.scrollTo(0, 11);
       expect(setScrollTopStub).to.be.calledOnce.calledWith(11);
     });
 
     it('should override scrollY/pageYOffset when requested', () => {
-      sandbox.stub(binding, 'overrideGlobalScrollTo').callsFake(() => true);
+      env.sandbox.stub(binding, 'overrideGlobalScrollTo').callsFake(() => true);
       viewport = new ViewportImpl(ampdoc, binding, viewer);
-      const stub = sandbox.stub(viewport, 'getScrollTop').callsFake(() => 19);
+      const stub = env.sandbox
+        .stub(viewport, 'getScrollTop')
+        .callsFake(() => 19);
       expect(windowApi.scrollY).to.equal(19);
       expect(windowApi.pageYOffset).to.equal(19);
       expect(stub).to.be.calledTwice;
@@ -1205,7 +1207,7 @@ describes.fakeWin('Viewport', {}, env => {
         writable: false,
         configurable: false, // make it non-configurable to let it will throw
       });
-      sandbox.stub(binding, 'overrideGlobalScrollTo').callsFake(() => true);
+      env.sandbox.stub(binding, 'overrideGlobalScrollTo').callsFake(() => true);
       new ViewportImpl(ampdoc, binding, viewer);
       expect(windowApi.scrollTo).to.equal(originalScrollTo);
     });
@@ -1216,7 +1218,7 @@ describes.fakeWin('Viewport', {}, env => {
         writable: false,
         configurable: false, // make it non-configurable to let it will throw
       });
-      sandbox.stub(binding, 'overrideGlobalScrollTo').callsFake(() => true);
+      env.sandbox.stub(binding, 'overrideGlobalScrollTo').callsFake(() => true);
       new ViewportImpl(ampdoc, binding, viewer);
       expect(windowApi.scrollY).to.equal(21);
     });
@@ -1386,7 +1388,6 @@ describe('Viewport META', () => {
   });
 
   describe('TouchZoom', () => {
-    let sandbox;
     let clock;
     let viewport;
     let binding;
@@ -1398,8 +1399,7 @@ describe('Viewport META', () => {
     let viewportMetaSetter;
 
     beforeEach(() => {
-      sandbox = sinon.sandbox;
-      clock = sandbox.useFakeTimers();
+      clock = window.sandbox.useFakeTimers();
       viewer = {
         isEmbedded: () => false,
         getParam: param => {
@@ -1416,7 +1416,7 @@ describe('Viewport META', () => {
       originalViewportMetaString = 'width=device-width,minimum-scale=1';
       viewportMetaString = originalViewportMetaString;
       viewportMeta = Object.create(null);
-      viewportMetaSetter = sandbox.spy();
+      viewportMetaSetter = window.sandbox.spy();
       Object.defineProperty(viewportMeta, 'content', {
         get: () => viewportMetaString,
         set: value => {
@@ -1453,10 +1453,6 @@ describe('Viewport META', () => {
       installViewerServiceForDoc(ampdoc);
       binding = new ViewportBindingDef();
       viewport = new ViewportImpl(ampdoc, binding, viewer);
-    });
-
-    afterEach(() => {
-      sandbox.restore();
     });
 
     it('should initialize original viewport meta', () => {
@@ -1577,11 +1573,9 @@ describe('createViewport', () => {
       let win;
       let ampDoc;
       let viewer;
-      let sandbox;
 
       beforeEach(() => {
         win = env.win;
-        sandbox = env.sandbox;
         installPlatformService(win);
         installTimerService(win);
         installVsyncService(win);
@@ -1601,7 +1595,7 @@ describe('createViewport', () => {
 
       it('should bind to "iOS embed" when iframed', () => {
         win.parent = {};
-        sandbox.stub(viewer, 'isEmbedded').callsFake(() => true);
+        env.sandbox.stub(viewer, 'isEmbedded').callsFake(() => true);
         installViewportServiceForDoc(ampDoc);
         const viewport = Services.viewportForDoc(ampDoc);
         expect(viewport.binding_).to.be.instanceof(
@@ -1611,7 +1605,7 @@ describe('createViewport', () => {
 
       it('should NOT bind to "iOS embed" when iframed but not embedded', () => {
         win.parent = {};
-        sandbox.stub(viewer, 'isEmbedded').callsFake(() => false);
+        env.sandbox.stub(viewer, 'isEmbedded').callsFake(() => false);
         installViewportServiceForDoc(ampDoc);
         const viewport = Services.viewportForDoc(ampDoc);
         expect(viewport.binding_).to.be.instanceof(ViewportBindingNatural_);
@@ -1620,7 +1614,7 @@ describe('createViewport', () => {
       it('should bind to "iOS embed" when iframed but in test mode', () => {
         win.parent = {};
         getMode(win).test = true;
-        sandbox.stub(viewer, 'isEmbedded').callsFake(() => false);
+        env.sandbox.stub(viewer, 'isEmbedded').callsFake(() => false);
         installViewportServiceForDoc(ampDoc);
         const viewport = Services.viewportForDoc(ampDoc);
         expect(viewport.binding_).to.be.instanceof(
@@ -1630,8 +1624,8 @@ describe('createViewport', () => {
 
       it('should bind to "natural" when iframed, but iOS supports scrollable iframes', () => {
         win.parent = {};
-        sandbox.stub(viewer, 'isEmbedded').callsFake(() => true);
-        sandbox
+        env.sandbox.stub(viewer, 'isEmbedded').callsFake(() => true);
+        env.sandbox
           .stub(viewer, 'hasCapability')
           .withArgs('iframeScroll')
           .returns(true);

--- a/test/unit/test-vsync.js
+++ b/test/unit/test-vsync.js
@@ -27,7 +27,7 @@ describes.fakeWin('vsync', {}, env => {
   beforeEach(() => {
     win = env.win;
     doc = win.document;
-    clock = sandbox.useFakeTimers();
+    clock = env.sandbox.useFakeTimers();
 
     installTimerService(win);
 
@@ -45,8 +45,8 @@ describes.fakeWin('vsync', {}, env => {
     beforeEach(() => {
       installDocService(win, /* isSingleDoc */ true);
       ampdoc = Services.ampdocServiceFor(win).getSingleDoc();
-      isVisibleStub = sandbox.stub(ampdoc, 'isVisible').returns(true);
-      onVisibilityChangedStub = sandbox.stub(ampdoc, 'onVisibilityChanged');
+      isVisibleStub = env.sandbox.stub(ampdoc, 'isVisible').returns(true);
+      onVisibilityChangedStub = env.sandbox.stub(ampdoc, 'onVisibilityChanged');
       iniVisibilityEventCount = 0;
       iniVisibilityEventCount = getVisibilityEventCount();
       vsync = new Vsync(win);
@@ -209,8 +209,8 @@ describes.fakeWin('vsync', {}, env => {
 
     // TODO(choumx, #12476): Make this test work with sinon 4.0.
     it.skip('should return a promise from runPromise that executes "run"', () => {
-      const measureSpy = sandbox.spy();
-      const mutateSpy = sandbox.spy();
+      const measureSpy = env.sandbox.spy();
+      const mutateSpy = env.sandbox.spy();
       return vsync
         .runPromise({measure: measureSpy, mutate: mutateSpy})
         .then(() => {
@@ -233,7 +233,7 @@ describes.fakeWin('vsync', {}, env => {
 
     // TODO(choumx, #12476): Make this test work with sinon 4.0.
     it.skip('should return a promise from mutatePromisethat runs mutator', () => {
-      const mutator = sandbox.spy();
+      const mutator = env.sandbox.spy();
       return vsync.mutatePromise(mutator).then(() => {
         expect(mutator).to.be.calledOnce;
       });
@@ -482,7 +482,7 @@ describes.fakeWin('vsync', {}, env => {
 
     it('should reject mutate series when invisible', () => {
       isVisibleStub.returns(false);
-      const mutatorSpy = sandbox.spy();
+      const mutatorSpy = env.sandbox.spy();
 
       const promise = vsync.runAnimMutateSeries(contextNode, mutatorSpy);
       return promise
@@ -544,8 +544,8 @@ describes.fakeWin('vsync', {}, env => {
       root = doc.createElement('i-amphtml-shadow-root');
       doc.body.appendChild(root);
       ampdoc = new AmpDocShadow(win, 'https://acme.org/', root);
-      isVisibleStub = sandbox.stub(ampdoc, 'isVisible').returns(true);
-      onVisibilityChangedStub = sandbox.stub(ampdoc, 'onVisibilityChanged');
+      isVisibleStub = env.sandbox.stub(ampdoc, 'isVisible').returns(true);
+      onVisibilityChangedStub = env.sandbox.stub(ampdoc, 'onVisibilityChanged');
       contextNode.ampdoc_ = ampdoc;
       iniVisibilityEventCount = 0;
       iniVisibilityEventCount = getVisibilityEventCount();
@@ -762,7 +762,7 @@ describes.fakeWin('vsync', {}, env => {
 
     it('should reject mutate series when invisible', () => {
       doc.visibilityState = 'hidden';
-      const mutatorSpy = sandbox.spy();
+      const mutatorSpy = env.sandbox.spy();
 
       const promise = vsync.runAnimMutateSeries(contextNode, mutatorSpy);
       return promise

--- a/test/unit/test-xhr-document-fetcher.js
+++ b/test/unit/test-xhr-document-fetcher.js
@@ -16,19 +16,19 @@
 import {Services} from '../../src/services';
 import {fetchDocument} from '../../src/document-fetcher';
 
-describes.realWin('DocumentFetcher', {amp: true}, function() {
+describes.realWin('DocumentFetcher', {amp: true}, function(env) {
   let xhrCreated;
   let ampdocServiceForStub;
   let ampdocViewerStub;
   // Given XHR calls give tests more time.
   this.timeout(5000);
   function setupMockXhr() {
-    const mockXhr = sandbox.useFakeXMLHttpRequest();
+    const mockXhr = env.sandbox.useFakeXMLHttpRequest();
     xhrCreated = new Promise(resolve => (mockXhr.onCreate = resolve));
   }
   beforeEach(() => {
-    ampdocServiceForStub = sandbox.stub(Services, 'ampdocServiceFor');
-    ampdocViewerStub = sandbox.stub(Services, 'viewerForDoc');
+    ampdocServiceForStub = env.sandbox.stub(Services, 'ampdocServiceFor');
+    ampdocViewerStub = env.sandbox.stub(Services, 'viewerForDoc');
     ampdocViewerStub.returns({});
     ampdocServiceForStub.returns({
       isSingleDoc: () => false,
@@ -41,9 +41,6 @@ describes.realWin('DocumentFetcher', {amp: true}, function() {
     const win = {location: {href: 'https://acme.com/path'}};
     beforeEach(() => {
       setupMockXhr();
-    });
-    afterEach(() => {
-      sandbox.restore();
     });
 
     it('should be able to fetch a document', () => {
@@ -153,7 +150,7 @@ describes.realWin('DocumentFetcher', {amp: true}, function() {
         sendMessageAwaitResponse: getDefaultResponsePromise,
         whenFirstVisible: () => Promise.resolve(),
       };
-      sendMessageStub = sandbox.stub(viewer, 'sendMessageAwaitResponse');
+      sendMessageStub = window.sandbox.stub(viewer, 'sendMessageAwaitResponse');
       sendMessageStub.returns(getDefaultResponsePromise());
       ampdocViewerStub.returns(viewer);
       interceptionEnabledWin = {

--- a/test/unit/test-xhr-fetch-polyfill.js
+++ b/test/unit/test-xhr-fetch-polyfill.js
@@ -18,12 +18,12 @@ import {Response, fetchPolyfill} from '../../src/polyfills/fetch';
 import {Services} from '../../src/services';
 import {createFormDataWrapper} from '../../src/form-data-wrapper';
 
-describes.sandboxed('fetch', {}, () => {
+describes.sandboxed('fetch', {}, env => {
   describe('fetch method', () => {
     let xhrCreated;
 
     function setupMockXhr() {
-      const mockXhr = sandbox.useFakeXMLHttpRequest();
+      const mockXhr = env.sandbox.useFakeXMLHttpRequest();
       xhrCreated = new Promise(resolve => (mockXhr.onCreate = resolve));
     }
 
@@ -40,12 +40,7 @@ describes.sandboxed('fetch', {}, () => {
     }
 
     beforeEach(() => {
-      sandbox = sinon.sandbox;
       setupMockXhr();
-    });
-
-    afterEach(() => {
-      sandbox.restore();
     });
 
     it('should allow GET method', () => {
@@ -105,14 +100,14 @@ describes.sandboxed('fetch', {}, () => {
 
     it('should allow FormData as body', () => {
       const fakeWin = null;
-      sandbox.stub(Services, 'platformFor').returns({
+      env.sandbox.stub(Services, 'platformFor').returns({
         isIos() {
           return false;
         },
       });
 
       const formData = createFormDataWrapper(fakeWin);
-      sandbox.stub(JSON, 'stringify');
+      env.sandbox.stub(JSON, 'stringify');
       formData.append('name', 'John Miller');
       formData.append('age', 56);
       const post = fetchPolyfill.bind(this, '/post', {

--- a/test/unit/test-xhr.js
+++ b/test/unit/test-xhr.js
@@ -30,7 +30,6 @@ describe
   .configure()
   .skipSafari()
   .run('XHR', function() {
-    let sandbox;
     let ampdocServiceForStub;
     let ampdoc;
     let ampdocViewerStub;
@@ -63,7 +62,7 @@ describe
     ];
 
     function setupMockXhr() {
-      const mockXhr = sandbox.useFakeXMLHttpRequest();
+      const mockXhr = window.sandbox.useFakeXMLHttpRequest();
       xhrCreated = new Promise(resolve => (mockXhr.onCreate = resolve));
     }
 
@@ -77,8 +76,7 @@ describe
     }
 
     beforeEach(() => {
-      sandbox = sinon.sandbox;
-      ampdocServiceForStub = sandbox.stub(Services, 'ampdocServiceFor');
+      ampdocServiceForStub = window.sandbox.stub(Services, 'ampdocServiceFor');
       ampdoc = {
         getRootNode: () => null,
         whenFirstVisible: () => Promise.resolve(),
@@ -88,14 +86,10 @@ describe
         getAmpDoc: () => ampdoc,
         getSingleDoc: () => ampdoc,
       });
-      ampdocViewerStub = sandbox.stub(Services, 'viewerForDoc');
+      ampdocViewerStub = window.sandbox.stub(Services, 'viewerForDoc');
       ampdocViewerStub.returns({});
 
       location.href = 'https://acme.com/path';
-    });
-
-    afterEach(() => {
-      sandbox.restore();
     });
 
     scenarios.forEach(test => {
@@ -153,14 +147,14 @@ describe
 
           it('should allow FormData as body', () => {
             const fakeWin = null;
-            sandbox.stub(Services, 'platformFor').returns({
+            window.sandbox.stub(Services, 'platformFor').returns({
               isIos() {
                 return false;
               },
             });
 
             const formData = createFormDataWrapper(fakeWin);
-            sandbox.stub(JSON, 'stringify');
+            window.sandbox.stub(JSON, 'stringify');
             formData.append('name', 'John Miller');
             formData.append('age', 56);
             const post = xhr.fetchJson.bind(xhr, '/post', {
@@ -263,13 +257,13 @@ describe
               test.win.fetch.restore();
             });
             it('should not call fetch if view is not visible ', () => {
-              const fetchCall = sandbox.spy(test.win, 'fetch');
+              const fetchCall = window.sandbox.spy(test.win, 'fetch');
               ampdoc.whenFirstVisible = () => Promise.reject();
               xhr.fetchJson('/get', {ampCors: false});
               expect(fetchCall.notCalled).to.be.true;
             });
             it('should call fetch if view is visible ', () => {
-              const fetchCall = sandbox.spy(test.win, 'fetch');
+              const fetchCall = window.sandbox.spy(test.win, 'fetch');
               ampdoc.whenFirstVisible = () => Promise.resolve();
               const fetch = xhr.fetchJson('/get', {ampCors: false});
               fetch.then(() => {
@@ -375,7 +369,7 @@ describe
         });
 
         it.skip('should do simple JSON fetch', () => {
-          sandbox.stub(user(), 'assert');
+          window.sandbox.stub(user(), 'assert');
           return xhr
             .fetchJson(`${baseUrl}/get?k=v1`)
             .then(res => res.json())
@@ -488,7 +482,7 @@ describe
 
         beforeEach(() => {
           xhr = xhrServiceForTesting(test.win);
-          fetchStub = sandbox
+          fetchStub = window.sandbox
             .stub(xhr, 'fetchAmpCors_')
             .callsFake(() => Promise.resolve(new Response(TEST_TEXT)));
         });
@@ -679,7 +673,10 @@ describe
           sendMessageAwaitResponse: getDefaultResponsePromise,
           whenFirstVisible: () => Promise.resolve(),
         };
-        sendMessageStub = sandbox.stub(viewer, 'sendMessageAwaitResponse');
+        sendMessageStub = window.sandbox.stub(
+          viewer,
+          'sendMessageAwaitResponse'
+        );
         sendMessageStub.returns(getDefaultResponsePromise());
         ampdocViewerStub.returns(viewer);
         interceptionEnabledWin = {
@@ -738,7 +735,7 @@ describe
       });
 
       it('should not intercept if viewer is not capable', () => {
-        sandbox
+        window.sandbox
           .stub(viewer, 'hasCapability')
           .withArgs('xhrInterceptor')
           .returns(false);
@@ -750,7 +747,9 @@ describe
       });
 
       it('should not intercept if viewer untrusted and non-dev mode', () => {
-        sandbox.stub(viewer, 'isTrustedViewer').returns(Promise.resolve(false));
+        window.sandbox
+          .stub(viewer, 'isTrustedViewer')
+          .returns(Promise.resolve(false));
         interceptionEnabledWin.AMP_DEV_MODE = false;
 
         const xhr = xhrServiceForTesting(interceptionEnabledWin);
@@ -777,8 +776,10 @@ describe
       });
 
       it('should intercept if viewer untrusted but in local dev mode', () => {
-        sandbox.stub(viewer, 'isTrustedViewer').returns(Promise.resolve(false));
-        sandbox.stub(mode, 'getMode').returns({localDev: true});
+        window.sandbox
+          .stub(viewer, 'isTrustedViewer')
+          .returns(Promise.resolve(false));
+        window.sandbox.stub(mode, 'getMode').returns({localDev: true});
 
         const xhr = xhrServiceForTesting(interceptionEnabledWin);
 
@@ -788,9 +789,11 @@ describe
       });
 
       it('should intercept if untrusted-xhr-interception experiment enabled', () => {
-        sandbox.stub(viewer, 'isTrustedViewer').returns(Promise.resolve(false));
-        sandbox.stub(mode, 'getMode').returns({localDev: false});
-        sandbox
+        window.sandbox
+          .stub(viewer, 'isTrustedViewer')
+          .returns(Promise.resolve(false));
+        window.sandbox.stub(mode, 'getMode').returns({localDev: false});
+        window.sandbox
           .stub(viewer, 'hasCapability')
           .withArgs('xhrInterceptor')
           .returns(true);
@@ -808,7 +811,9 @@ describe
       });
 
       it('should intercept if non-dev mode but viewer trusted', () => {
-        sandbox.stub(viewer, 'isTrustedViewer').returns(Promise.resolve(true));
+        window.sandbox
+          .stub(viewer, 'isTrustedViewer')
+          .returns(Promise.resolve(true));
         interceptionEnabledWin.AMP_DEV_MODE = false;
 
         const xhr = xhrServiceForTesting(interceptionEnabledWin);
@@ -826,7 +831,7 @@ describe
           .then(() =>
             expect(sendMessageStub).to.have.been.calledWithMatch(
               'xhr',
-              sinon.match.any
+              window.sandbox.match.any
             )
           );
       });
@@ -836,7 +841,7 @@ describe
 
         return xhr.fetch('https://www.some-url.org/some-resource/').then(() =>
           expect(sendMessageStub).to.have.been.calledWithMatch(
-            sinon.match.any,
+            window.sandbox.match.any,
             {
               originalRequest: {
                 input:
@@ -863,7 +868,7 @@ describe
           })
           .then(() =>
             expect(sendMessageStub).to.have.been.calledWithMatch(
-              sinon.match.any,
+              window.sandbox.match.any,
               {
                 originalRequest: {
                   input:
@@ -886,7 +891,7 @@ describe
         const xhr = xhrServiceForTesting(interceptionEnabledWin);
 
         const fakeWin = null;
-        sandbox.stub(Services, 'platformFor').returns({
+        window.sandbox.stub(Services, 'platformFor').returns({
           isIos() {
             return false;
           },
@@ -904,7 +909,7 @@ describe
           })
           .then(() =>
             expect(sendMessageStub).to.have.been.calledWithMatch(
-              sinon.match.any,
+              window.sandbox.match.any,
               {
                 originalRequest: {
                   input:

--- a/test/unit/utils/test-base64.js
+++ b/test/unit/utils/test-base64.js
@@ -24,183 +24,202 @@ import {
 } from '../../../src/utils/base64';
 import {stringToBytes, utf8Decode, utf8Encode} from '../../../src/utils/bytes';
 
-describe('base64 <> utf-8 encode/decode', () => {
-  const testCases = [
-    'SimplyFoo',
-    'Unicode௵Z加䅌ਇ☎Èʘغޝ',
-    'Symbols/.,+-_()*&^%$#@!`~:="\'',
-  ];
-  const scenarios = ['NativeTextEncoding', 'PolyfillTextEncoding', 'Mixed'];
+// TODO(amphtml, #25621): Cannot find atob / btoa on Safari on Sauce Labs.
+describe
+  .configure()
+  .skipSafari()
+  .run('base64', () => {
+    describe('base64 <> utf-8 encode/decode', () => {
+      const testCases = [
+        'SimplyFoo',
+        'Unicode௵Z加䅌ਇ☎Èʘغޝ',
+        'Symbols/.,+-_()*&^%$#@!`~:="\'',
+      ];
+      const scenarios = ['NativeTextEncoding', 'PolyfillTextEncoding', 'Mixed'];
 
-  scenarios.forEach(scenario => {
-    describe(scenario, () => {
-      const {TextEncoder: oldTextEncoder, TextDecoder: oldTextDecoder} = window;
-      beforeEach(() => {
-        // Forces use of the TextEncoding polyfill
-        if (scenario == 'PolyfillTextEncoding') {
-          window.TextEncoder = undefined;
-          window.TextDecoder = undefined;
-        }
-        // Tests a mixture where encoding is done by the polyfill but decoding
-        // is done by the native TextDecoder
-        if (scenario == 'Mixed') {
-          window.TextEncoder = undefined;
-        }
-      });
-
-      afterEach(() => {
-        window.TextEncoder = oldTextEncoder;
-        window.TextDecoder = oldTextDecoder;
-      });
-
-      describe('base64Encode/base64Decode', () => {
-        testCases.forEach(testCase => {
-          it(testCase, () => {
-            const utf8Bytes = utf8Encode(testCase);
-            const encoded = base64EncodeFromBytes(utf8Bytes);
-            expect(encoded).not.to.equal(testCase);
-            const decodedUtf8Bytes = base64DecodeToBytes(encoded);
-            const decoded = utf8Decode(decodedUtf8Bytes);
-            expect(decoded).to.equal(testCase);
+      scenarios.forEach(scenario => {
+        describe(scenario, () => {
+          const {
+            TextEncoder: oldTextEncoder,
+            TextDecoder: oldTextDecoder,
+          } = window;
+          beforeEach(() => {
+            // Forces use of the TextEncoding polyfill
+            if (scenario == 'PolyfillTextEncoding') {
+              window.TextEncoder = undefined;
+              window.TextDecoder = undefined;
+            }
+            // Tests a mixture where encoding is done by the polyfill but decoding
+            // is done by the native TextDecoder
+            if (scenario == 'Mixed') {
+              window.TextEncoder = undefined;
+            }
           });
-        });
-      });
 
-      describe('base64UrlEncode/base64UrlDecode', () => {
-        testCases.forEach(testCase => {
-          it(testCase, () => {
-            const utf8Bytes = utf8Encode(testCase);
-            const encoded = base64UrlEncodeFromBytes(utf8Bytes);
-            expect(encoded).not.to.equal(testCase);
-            expect(encoded).not.to.match(/[+/=]/g);
-            const decodedUtf8Bytes = base64UrlDecodeToBytes(encoded);
-            const decoded = utf8Decode(decodedUtf8Bytes);
-            expect(decoded).to.equal(testCase);
+          afterEach(() => {
+            window.TextEncoder = oldTextEncoder;
+            window.TextDecoder = oldTextDecoder;
+          });
+
+          describe('base64Encode/base64Decode', () => {
+            testCases.forEach(testCase => {
+              it(testCase, () => {
+                const utf8Bytes = utf8Encode(testCase);
+                const encoded = base64EncodeFromBytes(utf8Bytes);
+                expect(encoded).not.to.equal(testCase);
+                const decodedUtf8Bytes = base64DecodeToBytes(encoded);
+                const decoded = utf8Decode(decodedUtf8Bytes);
+                expect(decoded).to.equal(testCase);
+              });
+            });
+          });
+
+          describe('base64UrlEncode/base64UrlDecode', () => {
+            testCases.forEach(testCase => {
+              it(testCase, () => {
+                const utf8Bytes = utf8Encode(testCase);
+                const encoded = base64UrlEncodeFromBytes(utf8Bytes);
+                expect(encoded).not.to.equal(testCase);
+                expect(encoded).not.to.match(/[+/=]/g);
+                const decodedUtf8Bytes = base64UrlDecodeToBytes(encoded);
+                const decoded = utf8Decode(decodedUtf8Bytes);
+                expect(decoded).to.equal(testCase);
+              });
+            });
           });
         });
       });
     });
-  });
-});
 
-describe('base64UrlDecodeToBytes', () => {
-  it('should map a sample string appropriately', () => {
-    expect(base64UrlDecodeToBytes('AQAB')).to.deep.equal(
-      new Uint8Array([1, 0, 1])
-    );
-    expect(base64UrlDecodeToBytes('_-..')).to.deep.equal(new Uint8Array([255]));
-  });
+    describe('base64UrlDecodeToBytes', () => {
+      it('should map a sample string appropriately', () => {
+        expect(base64UrlDecodeToBytes('AQAB')).to.deep.equal(
+          new Uint8Array([1, 0, 1])
+        );
+        expect(base64UrlDecodeToBytes('_-..')).to.deep.equal(
+          new Uint8Array([255])
+        );
+      });
 
-  it('should handle padded and unpadded input', () => {
-    expect(base64UrlDecodeToBytes('cw')).to.deep.equal(stringToBytes('s'));
-    expect(base64UrlDecodeToBytes('cw')).to.deep.equal(
-      base64UrlDecodeToBytes('cw..')
-    );
-    expect(base64UrlDecodeToBytes('c3U')).to.deep.equal(stringToBytes('su'));
-    expect(base64UrlDecodeToBytes('c3U')).to.deep.equal(
-      base64UrlDecodeToBytes('c3U.')
-    );
-    expect(base64UrlDecodeToBytes('c3Vy')).to.deep.equal(stringToBytes('sur'));
-  });
+      it('should handle padded and unpadded input', () => {
+        expect(base64UrlDecodeToBytes('cw')).to.deep.equal(stringToBytes('s'));
+        expect(base64UrlDecodeToBytes('cw')).to.deep.equal(
+          base64UrlDecodeToBytes('cw..')
+        );
+        expect(base64UrlDecodeToBytes('c3U')).to.deep.equal(
+          stringToBytes('su')
+        );
+        expect(base64UrlDecodeToBytes('c3U')).to.deep.equal(
+          base64UrlDecodeToBytes('c3U.')
+        );
+        expect(base64UrlDecodeToBytes('c3Vy')).to.deep.equal(
+          stringToBytes('sur')
+        );
+      });
 
-  it('should signal an error with bad input characters', () => {
-    expect(() => base64UrlDecodeToBytes('@#*#')).to.throw();
-  });
+      it('should signal an error with bad input characters', () => {
+        expect(() => base64UrlDecodeToBytes('@#*#')).to.throw();
+      });
 
-  it('should signal an error with bad padding', () => {
-    expect(() => base64UrlDecodeToBytes('c3Vy.')).to.throw();
-  });
-});
+      it('should signal an error with bad padding', () => {
+        expect(() => base64UrlDecodeToBytes('c3Vy.')).to.throw();
+      });
+    });
 
-describe('base64DecodeToBytes', () => {
-  it('should map a sample string appropriately', () => {
-    expect(base64DecodeToBytes('AQAB')).to.deep.equal(
-      new Uint8Array([1, 0, 1])
-    );
-    expect(base64DecodeToBytes('/+==')).to.deep.equal(new Uint8Array([255]));
-  });
+    describe('base64DecodeToBytes', () => {
+      it('should map a sample string appropriately', () => {
+        expect(base64DecodeToBytes('AQAB')).to.deep.equal(
+          new Uint8Array([1, 0, 1])
+        );
+        expect(base64DecodeToBytes('/+==')).to.deep.equal(
+          new Uint8Array([255])
+        );
+      });
 
-  it('should handle padded and unpadded input', () => {
-    expect(base64DecodeToBytes('cw')).to.deep.equal(stringToBytes('s'));
-    expect(base64DecodeToBytes('cw')).to.deep.equal(
-      base64DecodeToBytes('cw==')
-    );
-    expect(base64DecodeToBytes('c3U')).to.deep.equal(stringToBytes('su'));
-    expect(base64DecodeToBytes('c3U')).to.deep.equal(
-      base64DecodeToBytes('c3U=')
-    );
-    expect(base64DecodeToBytes('c3Vy')).to.deep.equal(stringToBytes('sur'));
-  });
+      it('should handle padded and unpadded input', () => {
+        expect(base64DecodeToBytes('cw')).to.deep.equal(stringToBytes('s'));
+        expect(base64DecodeToBytes('cw')).to.deep.equal(
+          base64DecodeToBytes('cw==')
+        );
+        expect(base64DecodeToBytes('c3U')).to.deep.equal(stringToBytes('su'));
+        expect(base64DecodeToBytes('c3U')).to.deep.equal(
+          base64DecodeToBytes('c3U=')
+        );
+        expect(base64DecodeToBytes('c3Vy')).to.deep.equal(stringToBytes('sur'));
+      });
 
-  it('should signal an error with bad input characters', () => {
-    expect(() => base64DecodeToBytes('@#*#')).to.throw();
-  });
+      it('should signal an error with bad input characters', () => {
+        expect(() => base64DecodeToBytes('@#*#')).to.throw();
+      });
 
-  it('should signal an error with bad padding', () => {
-    expect(() => base64DecodeToBytes('c3Vy=')).to.throw();
-  });
-});
+      it('should signal an error with bad padding', () => {
+        expect(() => base64DecodeToBytes('c3Vy=')).to.throw();
+      });
+    });
 
-describe('base64EncodeFromBytes', () => {
-  it('should encode a bytes array to base64url string correctly', () => {
-    expect(base64UrlEncodeFromBytes(new Uint8Array())).to.equal('');
-    expect(base64UrlEncodeFromBytes(stringToBytes('s'))).to.equal('cw..');
-    expect(base64UrlEncodeFromBytes(stringToBytes('su'))).to.equal('c3U.');
-    expect(base64UrlEncodeFromBytes(stringToBytes('sur'))).to.equal('c3Vy');
-    expect(base64UrlEncodeFromBytes(new Uint8Array([255, 239]))).to.equal(
-      '_-8.'
-    );
-  });
+    describe('base64EncodeFromBytes', () => {
+      it('should encode a bytes array to base64url string correctly', () => {
+        expect(base64UrlEncodeFromBytes(new Uint8Array())).to.equal('');
+        expect(base64UrlEncodeFromBytes(stringToBytes('s'))).to.equal('cw..');
+        expect(base64UrlEncodeFromBytes(stringToBytes('su'))).to.equal('c3U.');
+        expect(base64UrlEncodeFromBytes(stringToBytes('sur'))).to.equal('c3Vy');
+        expect(base64UrlEncodeFromBytes(new Uint8Array([255, 239]))).to.equal(
+          '_-8.'
+        );
+      });
 
-  it('should encode a bytes array to base64 string correctly', () => {
-    expect(base64EncodeFromBytes(new Uint8Array())).to.equal('');
-    expect(base64EncodeFromBytes(stringToBytes('s'))).to.equal('cw==');
-    expect(base64EncodeFromBytes(stringToBytes('su'))).to.equal('c3U=');
-    expect(base64EncodeFromBytes(stringToBytes('sur'))).to.equal('c3Vy');
-    expect(base64EncodeFromBytes(new Uint8Array([255, 239]))).to.equal('/+8=');
-  });
-});
+      it('should encode a bytes array to base64 string correctly', () => {
+        expect(base64EncodeFromBytes(new Uint8Array())).to.equal('');
+        expect(base64EncodeFromBytes(stringToBytes('s'))).to.equal('cw==');
+        expect(base64EncodeFromBytes(stringToBytes('su'))).to.equal('c3U=');
+        expect(base64EncodeFromBytes(stringToBytes('sur'))).to.equal('c3Vy');
+        expect(base64EncodeFromBytes(new Uint8Array([255, 239]))).to.equal(
+          '/+8='
+        );
+      });
+    });
 
-describe('base64(Encode/Decode)FromString', () => {
-  it('should handle unicode and non-unicode strings encoding', () => {
-    expect(base64UrlEncodeFromString('')).to.equal('');
-    expect(base64UrlEncodeFromString('      ')).to.equal('ICAgICAg');
-    expect(base64UrlEncodeFromString('helloworld')).to.equal(
-      'aGVsbG93b3JsZA..'
-    );
-    expect(base64UrlEncodeFromString('hello world')).to.equal(
-      'aGVsbG8gd29ybGQ.'
-    );
-    expect(base64UrlEncodeFromString(' hello world ')).to.equal(
-      'IGhlbGxvIHdvcmxkIA..'
-    );
-    expect(base64UrlEncodeFromString('✓ à la mode')).to.equal(
-      '4pyTIMOgIGxhIG1vZGU.'
-    );
-    expect(base64UrlEncodeFromString('\n')).to.equal('Cg..');
-    expect(base64UrlEncodeFromString('$#!@#$%^&*()')).to.equal(
-      'JCMhQCMkJV4mKigp'
-    );
-  });
+    describe('base64(Encode/Decode)FromString', () => {
+      it('should handle unicode and non-unicode strings encoding', () => {
+        expect(base64UrlEncodeFromString('')).to.equal('');
+        expect(base64UrlEncodeFromString('      ')).to.equal('ICAgICAg');
+        expect(base64UrlEncodeFromString('helloworld')).to.equal(
+          'aGVsbG93b3JsZA..'
+        );
+        expect(base64UrlEncodeFromString('hello world')).to.equal(
+          'aGVsbG8gd29ybGQ.'
+        );
+        expect(base64UrlEncodeFromString(' hello world ')).to.equal(
+          'IGhlbGxvIHdvcmxkIA..'
+        );
+        expect(base64UrlEncodeFromString('✓ à la mode')).to.equal(
+          '4pyTIMOgIGxhIG1vZGU.'
+        );
+        expect(base64UrlEncodeFromString('\n')).to.equal('Cg..');
+        expect(base64UrlEncodeFromString('$#!@#$%^&*()')).to.equal(
+          'JCMhQCMkJV4mKigp'
+        );
+      });
 
-  it('should handle unicode and non-unicode strings decoding', () => {
-    expect(base64UrlDecodeFromString('')).to.equal('');
-    expect(base64UrlDecodeFromString('ICAgICAg')).to.equal('      ');
-    expect(base64UrlDecodeFromString('aGVsbG93b3JsZA..')).to.equal(
-      'helloworld'
-    );
-    expect(base64UrlDecodeFromString('aGVsbG8gd29ybGQ.')).to.equal(
-      'hello world'
-    );
-    expect(base64UrlDecodeFromString('IGhlbGxvIHdvcmxkIA..')).to.equal(
-      ' hello world '
-    );
-    expect(base64UrlDecodeFromString('4pyTIMOgIGxhIG1vZGU.')).to.equal(
-      '✓ à la mode'
-    );
-    expect(base64UrlDecodeFromString('Cg..')).to.equal('\n');
-    expect(base64UrlDecodeFromString('JCMhQCMkJV4mKigp')).to.equal(
-      '$#!@#$%^&*()'
-    );
+      it('should handle unicode and non-unicode strings decoding', () => {
+        expect(base64UrlDecodeFromString('')).to.equal('');
+        expect(base64UrlDecodeFromString('ICAgICAg')).to.equal('      ');
+        expect(base64UrlDecodeFromString('aGVsbG93b3JsZA..')).to.equal(
+          'helloworld'
+        );
+        expect(base64UrlDecodeFromString('aGVsbG8gd29ybGQ.')).to.equal(
+          'hello world'
+        );
+        expect(base64UrlDecodeFromString('IGhlbGxvIHdvcmxkIA..')).to.equal(
+          ' hello world '
+        );
+        expect(base64UrlDecodeFromString('4pyTIMOgIGxhIG1vZGU.')).to.equal(
+          '✓ à la mode'
+        );
+        expect(base64UrlDecodeFromString('Cg..')).to.equal('\n');
+        expect(base64UrlDecodeFromString('JCMhQCMkJV4mKigp')).to.equal(
+          '$#!@#$%^&*()'
+        );
+      });
+    });
   });
-});

--- a/test/unit/utils/test-document-visibility.js
+++ b/test/unit/utils/test-document-visibility.js
@@ -26,8 +26,8 @@ describes.sandboxed('document-visibility', {}, env => {
 
   beforeEach(() => {
     doc = {
-      addEventListener: sandbox.spy(),
-      removeEventListener: sandbox.spy(),
+      addEventListener: env.sandbox.spy(),
+      removeEventListener: env.sandbox.spy(),
     };
   });
 

--- a/test/unit/utils/test-pem.js
+++ b/test/unit/utils/test-pem.js
@@ -16,74 +16,78 @@
 
 import {pemToBytes} from '../../../src/utils/pem';
 
-describe('pemToBytes', () => {
-  const PLAIN_TEXT =
-    'MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDdlatRjRjogo3WojgGHFHYLugd' +
-    'UWAY9iR3fy4arWNA1KoS8kVw33cJibXr8bvwUAUparCwlvdbH6dvEOfou0/gCFQs' +
-    'HUfQrSDv+MuSUMAe8jzKE4qW+jK+xQU9a03GUnKHkkle+Q0pX/g6jXZ7r1/xAK5D' +
-    'o2kQ+X5xK9cipRgEKwIDAQAB';
-  const PEM =
-    '-----BEGIN PUBLIC KEY-----\n' +
-    'MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDdlatRjRjogo3WojgGHFHYLugd\n' +
-    'UWAY9iR3fy4arWNA1KoS8kVw33cJibXr8bvwUAUparCwlvdbH6dvEOfou0/gCFQs\n' +
-    'HUfQrSDv+MuSUMAe8jzKE4qW+jK+xQU9a03GUnKHkkle+Q0pX/g6jXZ7r1/xAK5D\n' +
-    'o2kQ+X5xK9cipRgEKwIDAQAB\n' +
-    '-----END PUBLIC KEY-----';
+// TODO(amphtml, #25621): Cannot find atob / btoa on Safari on Sauce Labs.
+describe
+  .configure()
+  .skipSafari()
+  .run('pemToBytes', () => {
+    const PLAIN_TEXT =
+      'MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDdlatRjRjogo3WojgGHFHYLugd' +
+      'UWAY9iR3fy4arWNA1KoS8kVw33cJibXr8bvwUAUparCwlvdbH6dvEOfou0/gCFQs' +
+      'HUfQrSDv+MuSUMAe8jzKE4qW+jK+xQU9a03GUnKHkkle+Q0pX/g6jXZ7r1/xAK5D' +
+      'o2kQ+X5xK9cipRgEKwIDAQAB';
+    const PEM =
+      '-----BEGIN PUBLIC KEY-----\n' +
+      'MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDdlatRjRjogo3WojgGHFHYLugd\n' +
+      'UWAY9iR3fy4arWNA1KoS8kVw33cJibXr8bvwUAUparCwlvdbH6dvEOfou0/gCFQs\n' +
+      'HUfQrSDv+MuSUMAe8jzKE4qW+jK+xQU9a03GUnKHkkle+Q0pX/g6jXZ7r1/xAK5D\n' +
+      'o2kQ+X5xK9cipRgEKwIDAQAB\n' +
+      '-----END PUBLIC KEY-----';
 
-  it('should convert a valid key', () => {
-    const binary = pemToBytes(PEM);
-    const plain = atob(PLAIN_TEXT);
-    const len = plain.length;
-    expect(binary.byteLength).to.equal(len);
-    expect(binary[0]).to.equal(plain.charCodeAt(0));
-    expect(binary[1]).to.equal(plain.charCodeAt(1));
-    expect(binary[len - 1]).to.equal(plain.charCodeAt(len - 1));
-    expect(binary[len - 2]).to.equal(plain.charCodeAt(len - 2));
-  });
+    it('should convert a valid key', () => {
+      const binary = pemToBytes(PEM);
+      const plain = atob(PLAIN_TEXT);
+      const len = plain.length;
+      expect(binary.byteLength).to.equal(len);
+      expect(binary[0]).to.equal(plain.charCodeAt(0));
+      expect(binary[1]).to.equal(plain.charCodeAt(1));
+      expect(binary[len - 1]).to.equal(plain.charCodeAt(len - 1));
+      expect(binary[len - 2]).to.equal(plain.charCodeAt(len - 2));
+    });
 
-  it('should convert without headers, footers, line breaks', () => {
-    const binary = pemToBytes(PLAIN_TEXT);
-    const plain = atob(PLAIN_TEXT);
-    const len = plain.length;
-    expect(binary.byteLength).to.equal(len);
-    expect(binary[0]).to.equal(plain.charCodeAt(0));
-    expect(binary[1]).to.equal(plain.charCodeAt(1));
-    expect(binary[len - 1]).to.equal(plain.charCodeAt(len - 1));
-    expect(binary[len - 2]).to.equal(plain.charCodeAt(len - 2));
-  });
+    it('should convert without headers, footers, line breaks', () => {
+      const binary = pemToBytes(PLAIN_TEXT);
+      const plain = atob(PLAIN_TEXT);
+      const len = plain.length;
+      expect(binary.byteLength).to.equal(len);
+      expect(binary[0]).to.equal(plain.charCodeAt(0));
+      expect(binary[1]).to.equal(plain.charCodeAt(1));
+      expect(binary[len - 1]).to.equal(plain.charCodeAt(len - 1));
+      expect(binary[len - 2]).to.equal(plain.charCodeAt(len - 2));
+    });
 
-  it('should convert without line breaks', () => {
-    const binary = pemToBytes(
-      '-----BEGIN PUBLIC KEY-----' + PLAIN_TEXT + '-----END PUBLIC KEY-----'
-    );
-    const plain = atob(PLAIN_TEXT);
-    const len = plain.length;
-    expect(binary.byteLength).to.equal(len);
-    expect(binary[0]).to.equal(plain.charCodeAt(0));
-    expect(binary[1]).to.equal(plain.charCodeAt(1));
-    expect(binary[len - 1]).to.equal(plain.charCodeAt(len - 1));
-    expect(binary[len - 2]).to.equal(plain.charCodeAt(len - 2));
-  });
+    it('should convert without line breaks', () => {
+      const binary = pemToBytes(
+        '-----BEGIN PUBLIC KEY-----' + PLAIN_TEXT + '-----END PUBLIC KEY-----'
+      );
+      const plain = atob(PLAIN_TEXT);
+      const len = plain.length;
+      expect(binary.byteLength).to.equal(len);
+      expect(binary[0]).to.equal(plain.charCodeAt(0));
+      expect(binary[1]).to.equal(plain.charCodeAt(1));
+      expect(binary[len - 1]).to.equal(plain.charCodeAt(len - 1));
+      expect(binary[len - 2]).to.equal(plain.charCodeAt(len - 2));
+    });
 
-  it('should convert without header', () => {
-    const binary = pemToBytes(PLAIN_TEXT + '-----END PUBLIC KEY-----');
-    const plain = atob(PLAIN_TEXT);
-    const len = plain.length;
-    expect(binary.byteLength).to.equal(len);
-    expect(binary[0]).to.equal(plain.charCodeAt(0));
-    expect(binary[1]).to.equal(plain.charCodeAt(1));
-    expect(binary[len - 1]).to.equal(plain.charCodeAt(len - 1));
-    expect(binary[len - 2]).to.equal(plain.charCodeAt(len - 2));
-  });
+    it('should convert without header', () => {
+      const binary = pemToBytes(PLAIN_TEXT + '-----END PUBLIC KEY-----');
+      const plain = atob(PLAIN_TEXT);
+      const len = plain.length;
+      expect(binary.byteLength).to.equal(len);
+      expect(binary[0]).to.equal(plain.charCodeAt(0));
+      expect(binary[1]).to.equal(plain.charCodeAt(1));
+      expect(binary[len - 1]).to.equal(plain.charCodeAt(len - 1));
+      expect(binary[len - 2]).to.equal(plain.charCodeAt(len - 2));
+    });
 
-  it('should convert without footer', () => {
-    const binary = pemToBytes('-----BEGIN PUBLIC KEY-----' + PLAIN_TEXT);
-    const plain = atob(PLAIN_TEXT);
-    const len = plain.length;
-    expect(binary.byteLength).to.equal(len);
-    expect(binary[0]).to.equal(plain.charCodeAt(0));
-    expect(binary[1]).to.equal(plain.charCodeAt(1));
-    expect(binary[len - 1]).to.equal(plain.charCodeAt(len - 1));
-    expect(binary[len - 2]).to.equal(plain.charCodeAt(len - 2));
+    it('should convert without footer', () => {
+      const binary = pemToBytes('-----BEGIN PUBLIC KEY-----' + PLAIN_TEXT);
+      const plain = atob(PLAIN_TEXT);
+      const len = plain.length;
+      expect(binary.byteLength).to.equal(len);
+      expect(binary[0]).to.equal(plain.charCodeAt(0));
+      expect(binary[1]).to.equal(plain.charCodeAt(1));
+      expect(binary[len - 1]).to.equal(plain.charCodeAt(len - 1));
+      expect(binary[len - 2]).to.equal(plain.charCodeAt(len - 2));
+    });
   });
-});

--- a/test/unit/utils/test-priority-queue.js
+++ b/test/unit/utils/test-priority-queue.js
@@ -18,10 +18,8 @@ import PriorityQueue from '../../../src/utils/priority-queue';
 
 describe('PriorityQueue', function() {
   let pq;
-  let sandbox;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox;
     pq = new PriorityQueue();
   });
 
@@ -93,7 +91,7 @@ describe('PriorityQueue', function() {
   });
 
   it('should iterate through queue', () => {
-    const spy = sandbox.spy();
+    const spy = window.sandbox.spy();
     pq.enqueue('p', 1);
     pq.enqueue('m', 2);
     pq.enqueue('a', 3);

--- a/test/unit/utils/test-rate-limit.js
+++ b/test/unit/utils/test-rate-limit.js
@@ -18,20 +18,14 @@ import {debounce, throttle} from '../../../src/utils/rate-limit';
 
 describe('function utils', () => {
   describe('throttle', () => {
-    let sandbox;
     let clock;
 
     beforeEach(() => {
-      sandbox = sinon.sandbox;
-      clock = sandbox.useFakeTimers();
-    });
-
-    afterEach(() => {
-      sandbox.restore();
+      clock = window.sandbox.useFakeTimers();
     });
 
     it('should work', () => {
-      const callback = sandbox.spy();
+      const callback = window.sandbox.spy();
       const throttledCallback = throttle(window, callback, 100);
 
       throttledCallback(1);
@@ -89,20 +83,14 @@ describe('function utils', () => {
   });
 
   describe('debounce', () => {
-    let sandbox;
     let clock;
 
     beforeEach(() => {
-      sandbox = sinon.sandbox;
-      clock = sandbox.useFakeTimers();
-    });
-
-    afterEach(() => {
-      sandbox.restore();
+      clock = window.sandbox.useFakeTimers();
     });
 
     it('should wait before calling', () => {
-      const callback = sandbox.spy();
+      const callback = window.sandbox.spy();
       const debounced = debounce(window, callback, 100);
 
       debounced(1);

--- a/test/unit/utils/test-signals.js
+++ b/test/unit/utils/test-signals.js
@@ -16,12 +16,12 @@
 
 import {Signals} from '../../../src/utils/signals';
 
-describes.sandboxed('Signals', {}, () => {
+describes.sandboxed('Signals', {}, env => {
   let clock;
   let signals;
 
   beforeEach(() => {
-    clock = sandbox.useFakeTimers();
+    clock = env.sandbox.useFakeTimers();
     clock.tick(1);
     signals = new Signals();
   });
@@ -177,11 +177,11 @@ describes.sandboxed('Signals', {}, () => {
   });
 });
 
-describes.sandboxed('Signals with zero for tests', {}, () => {
+describes.sandboxed('Signals with zero for tests', {}, env => {
   let signals;
 
   beforeEach(() => {
-    sandbox.useFakeTimers();
+    env.sandbox.useFakeTimers();
     signals = new Signals();
   });
 

--- a/test/unit/utils/test-xhr-utils.js
+++ b/test/unit/utils/test-xhr-utils.js
@@ -25,12 +25,6 @@ import {
 } from '../../../src/utils/xhr-utils';
 
 describes.sandboxed('utils/xhr-utils', {}, env => {
-  let sandbox;
-
-  beforeEach(() => {
-    sandbox = env.sandbox;
-  });
-
   describe('setupAMPCors', () => {
     it('should set AMP-Same-Origin header', () => {
       // Given a same origin request.
@@ -103,7 +97,7 @@ describes.sandboxed('utils/xhr-utils', {}, env => {
         getRootNode() {
           return {documentElement: doc};
         },
-        whenFirstVisible: sandbox.stub().returns(Promise.resolve()),
+        whenFirstVisible: env.sandbox.stub().returns(Promise.resolve()),
       };
       doc = document.createElement('html');
       doc.setAttribute('allow-xhr-interception', 'true');
@@ -112,9 +106,11 @@ describes.sandboxed('utils/xhr-utils', {}, env => {
       viewer = {
         hasCapability: unusedParam => true,
         isTrustedViewer: () => Promise.resolve(true),
-        sendMessageAwaitResponse: sandbox.stub().returns(Promise.resolve({})),
+        sendMessageAwaitResponse: env.sandbox
+          .stub()
+          .returns(Promise.resolve({})),
       };
-      viewerForDoc = sandbox.stub(Services, 'viewerForDoc').returns(viewer);
+      viewerForDoc = env.sandbox.stub(Services, 'viewerForDoc').returns(viewer);
       win = {
         __AMP_MODE: {
           localDev: false,
@@ -236,7 +232,7 @@ describes.sandboxed('utils/xhr-utils', {}, env => {
     );
 
     it('should return an auth token if one is present', () => {
-      sandbox.stub(Services, 'viewerAssistanceForDocOrNull').returns(
+      env.sandbox.stub(Services, 'viewerAssistanceForDocOrNull').returns(
         Promise.resolve({
           getIdTokenPromise: () => Promise.resolve('idToken'),
         })
@@ -249,7 +245,7 @@ describes.sandboxed('utils/xhr-utils', {}, env => {
     });
 
     it('should return an empty auth token if there is not one present', () => {
-      sandbox.stub(Services, 'viewerAssistanceForDocOrNull').returns(
+      env.sandbox.stub(Services, 'viewerAssistanceForDocOrNull').returns(
         Promise.resolve({
           getIdTokenPromise: () => Promise.resolve(undefined),
         })
@@ -265,7 +261,7 @@ describes.sandboxed('utils/xhr-utils', {}, env => {
       'should return an empty auth token if there is an issue retrieving ' +
         'the identity token',
       () => {
-        sandbox.stub(Services, 'viewerAssistanceForDocOrNull').returns(
+        env.sandbox.stub(Services, 'viewerAssistanceForDocOrNull').returns(
           Promise.reject({
             getIdTokenPromise: () => Promise.reject(),
           })
@@ -279,7 +275,7 @@ describes.sandboxed('utils/xhr-utils', {}, env => {
     );
 
     it('should assert that amp-viewer-assistance extension is present', () => {
-      sandbox
+      window.sandbox
         .stub(Services, 'viewerAssistanceForDocOrNull')
         .returns(Promise.resolve());
       const el = document.createElement('html');

--- a/test/unit/web-worker/test-amp-worker.js
+++ b/test/unit/web-worker/test-amp-worker.js
@@ -24,7 +24,6 @@ import {getMode} from '../../../src/mode';
 import {installXhrService} from '../../../src/service/xhr-impl';
 
 describe('invokeWebWorker', () => {
-  let sandbox;
   let fakeWin;
 
   let ampWorker;
@@ -34,12 +33,11 @@ describe('invokeWebWorker', () => {
   let workerReadyPromise;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox;
-    sandbox.stub(Services, 'ampdocServiceFor').returns({
+    window.sandbox.stub(Services, 'ampdocServiceFor').returns({
       isSingleDoc: () => false,
     });
 
-    postMessageStub = sandbox.stub();
+    postMessageStub = window.sandbox.stub();
 
     fakeWorker = {};
     fakeWorker.postMessage = postMessageStub;
@@ -47,14 +45,14 @@ describe('invokeWebWorker', () => {
     // Fake Worker constructor just returns our `fakeWorker` instance.
     fakeWin = {
       Worker: () => fakeWorker,
-      Blob: sandbox.stub(),
-      URL: {createObjectURL: sandbox.stub()},
+      Blob: window.sandbox.stub(),
+      URL: {createObjectURL: window.sandbox.stub()},
       location: window.location,
     };
 
     // Stub xhr.fetchText() to return a resolved promise.
     installXhrService(fakeWin);
-    fetchTextCallStub = sandbox
+    fetchTextCallStub = window.sandbox
       .stub(Services.xhrFor(fakeWin), 'fetchText')
       .callsFake(() =>
         Promise.resolve({
@@ -66,10 +64,6 @@ describe('invokeWebWorker', () => {
 
     ampWorker = ampWorkerForTesting(fakeWin);
     workerReadyPromise = ampWorker.fetchPromiseForTesting();
-  });
-
-  afterEach(() => {
-    sandbox.restore();
   });
 
   it('should check if Worker is supported', () => {
@@ -87,7 +81,7 @@ describe('invokeWebWorker', () => {
     return workerReadyPromise.then(() => {
       expect(postMessageStub).to.have.been.calledWithMatch({
         method: 'foo',
-        args: sinon.match(['bar', 123]),
+        args: window.sandbox.match(['bar', 123]),
         id: 0,
       });
 
@@ -199,7 +193,7 @@ describe('invokeWebWorker', () => {
   });
 
   it('should log error when unexpected message is received', () => {
-    const errorStub = sandbox.stub(dev(), 'error');
+    const errorStub = window.sandbox.stub(dev(), 'error');
 
     invokeWebWorker(fakeWin, 'foo');
 

--- a/testing/describes.js
+++ b/testing/describes.js
@@ -417,7 +417,7 @@ class SandboxFixture {
 
   /** @override */
   setup(env) {
-    env.sandbox = sinon.createSandbox();
+    env.sandbox = sinon.createSandbox(); // eslint-disable-line no-undef
     env.sandbox.defineProperty = this.defineProperty_.bind(this);
     env.sandbox.deleteProperty = (obj, propertyKey) => {
       this.defineProperty_(obj, propertyKey, undefined);

--- a/testing/describes.js
+++ b/testing/describes.js
@@ -110,6 +110,7 @@ import {maybeTrackImpression} from '../src/impression';
 import {resetScheduledElementForTesting} from '../src/service/custom-element-registry';
 import {setStyles} from '../src/style';
 import fetchMock from 'fetch-mock';
+import sinon from 'sinon'; // eslint-disable-line local/no-import
 
 /** Should have something in the name, otherwise nothing is shown. */
 const SUB = ' ';
@@ -417,7 +418,7 @@ class SandboxFixture {
 
   /** @override */
   setup(env) {
-    env.sandbox = sinon.createSandbox(); // eslint-disable-line no-undef
+    env.sandbox = sinon.createSandbox();
     env.sandbox.defineProperty = this.defineProperty_.bind(this);
     env.sandbox.deleteProperty = (obj, propertyKey) => {
       this.defineProperty_(obj, propertyKey, undefined);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1557,7 +1557,7 @@
     "@sinonjs/commons" "^1"
     "@sinonjs/samsam" "^3.1.0"
 
-"@sinonjs/samsam@^3.1.0", "@sinonjs/samsam@^3.3.1":
+"@sinonjs/samsam@^3.1.0", "@sinonjs/samsam@^3.3.3":
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-3.3.3.tgz#46682efd9967b259b81136b9f120fd54585feb4a"
   integrity sha512-bKCMKZvWIjYD0BLGnNrxVuw4dkWCYsLqFOUWw8VgKF/+5Y+mE7LfHWPIYoDXowH+3a9LsWDMo0uAP8YDosPvHQ==
@@ -9268,7 +9268,7 @@ lolex@5.1.1:
   resolved "https://registry.yarnpkg.com/lolex/-/lolex-5.1.1.tgz#9587144854511d27940ee5e113dcb7de9b0fd666"
   integrity sha512-dEwHz1CJ8DsdgfpiimgQQEhEJYOEiJ69a0s4aJDNHajaTqOJuF34vBAWVa/sS0V8aQvt72p+KgQ3pRmEVJM+iA==
 
-lolex@^4.0.1, lolex@^4.1.0:
+lolex@^4.1.0, lolex@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lolex/-/lolex-4.2.0.tgz#ddbd7f6213ca1ea5826901ab1222b65d714b3cd7"
   integrity sha512-gKO5uExCXvSm6zbF562EvM+rd1kQDnB9AZBbiQVzf1ZmdDpxUSvpnAaVOP83N/31mRK8Ml8/VE8DMvsAZQ+7wg==
@@ -10000,7 +10000,7 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
-nise@^1.4.10:
+nise@^1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/nise/-/nise-1.5.2.tgz#b6d29af10e48b321b307e10e065199338eeb2652"
   integrity sha512-/6RhOUlicRCbE9s+94qCUsyE+pKlVJ5AhIv+jEE7ESKwnbXqulKZ1FYU+XAtHHWE9TinYvAxDUJAb912PwPoWA==
@@ -12737,17 +12737,17 @@ sinon-chai@3.3.0:
   resolved "https://registry.yarnpkg.com/sinon-chai/-/sinon-chai-3.3.0.tgz#8084ff99451064910fbe2c2cb8ab540c00b740ea"
   integrity sha512-r2JhDY7gbbmh5z3Q62pNbrjxZdOAjpsqW/8yxAZRSqLZqowmfGZPGUZPFf3UX36NLis0cv8VEM5IJh9HgkSOAA==
 
-sinon@7.3.2:
-  version "7.3.2"
-  resolved "https://registry.yarnpkg.com/sinon/-/sinon-7.3.2.tgz#82dba3a6d85f6d2181e1eca2c10d8657c2161f28"
-  integrity sha512-thErC1z64BeyGiPvF8aoSg0LEnptSaWE7YhdWWbWXgelOyThent7uKOnnEh9zBxDbKixtr5dEko+ws1sZMuFMA==
+sinon@7.5.0:
+  version "7.5.0"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-7.5.0.tgz#e9488ea466070ea908fd44a3d6478fd4923c67ec"
+  integrity sha512-AoD0oJWerp0/rY9czP/D6hDTTUYGpObhZjMpd7Cl/A6+j0xBE+ayL/ldfggkBXUs0IkvIiM1ljM8+WkOc5k78Q==
   dependencies:
     "@sinonjs/commons" "^1.4.0"
     "@sinonjs/formatio" "^3.2.1"
-    "@sinonjs/samsam" "^3.3.1"
+    "@sinonjs/samsam" "^3.3.3"
     diff "^3.5.0"
-    lolex "^4.0.1"
-    nise "^1.4.10"
+    lolex "^4.2.0"
+    nise "^1.5.2"
     supports-color "^5.5.0"
 
 sisteransi@^1.0.3:


### PR DESCRIPTION
The majority of AMP's tests reuse a single global sandbox instance provided by the `sinon` package. From looking at test code, there's a fair amount of inconsistency in how different tests create (sometimes), use, and clean up (not always) their sandbox.

This PR picks up where #23726 left off, and does the following:

- [Upgrades](https://github.com/ampproject/amphtml/pull/25587/commits/770859d444558898c81729d12df6739df4fd631c) `sinon` to v7.5.0
- [Makes](https://github.com/ampproject/amphtml/pull/25587/commits/3bfdb98a2063c451699c49e22a81c2d72d7648b6) it a lint error to use the globals `sinon` or `sandbox` in an AMP test
- [Fixes](https://github.com/ampproject/amphtml/pull/25587/commits/cfa41ea4ff17de7c8f978e4cccfb61b010421cad?w=1) O(thousand) tests that currently reuse the global sandbox.
    - For legacy `describe` tests:
        - Resets `window.sandbox` to a new instance in the top-level `beforeEach()`
        - Cleans up `window.sandbox` in the top-level `afterEach()`
    	- Modifies all tests to use `window.sandbox` instead of the global `sinon` object
    - For newer `describes` tests:
        - `env.sandbox` is already reset to a new instance in the `setup()` method of `SandboxFixture`
        - Modifies all tests to use `env.sandbox` instead of the global `sinon` object
- [Skips](https://github.com/ampproject/amphtml/pull/25587/commits/d5409557bada8f343eea0a66fbc6d6ca90101417?w=1) a few tests on Safari because `atob` and `btoa` cannot be found (#25621) 

Fixes #23842
Fixes #25371
Closes #23726
Closes #25588
Closes #25455
Related to #25621