### PR TITLE
Reduce severity of shadow close timeout log

### DIFF
--- a/src/runtime.js
+++ b/src/runtime.js
@@ -902,7 +902,7 @@ export class MultidocManager {
         'Timeout reached waiting for visibility state change callback'
       )
       .catch(error => {
-        user().warn(TAG, error);
+        user().info(TAG, error);
       });
   }
 


### PR DESCRIPTION
closeShadowRoot_ was recently updated to return a promise that resolves
on a race between visibility state change completion or 15ms timeout.
The timeout is pretty easy to hit. Remove the sense that a regression
occurred when this feature was introduced due to the new console
warning. Matters have only improved for those taking advantage of the
shadow closure promise. Log at the info level instead of warn.