### PR TITLE
🐛Support amp-lightbox-gallery with amp-base-carousel

### DIFF
--- a/extensions/amp-image-viewer/0.1/amp-image-viewer.css
+++ b/extensions/amp-image-viewer/0.1/amp-image-viewer.css
@@ -36,3 +36,16 @@
   overflow: hidden;
   transform: translate3d(0, 0, 0);
 }
+
+/**
+ * Make sure the amp-img inside the image viewer has some size in case it does
+ * not define a size itself. Otherwise, the `layoutCallback` Promise will never
+ * resolve and the image will never be given a proper size.
+ *
+ * Note: Not using .i-amphtml-image-viewer-image here, since the class is added
+ * later.
+ */
+.i-amphtml-image-viewer > amp-img {
+  min-width: 1px;
+  min-height: 1px;
+}

--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
@@ -60,7 +60,7 @@ import {triggerAnalyticsEvent} from '../../../src/analytics';
 const TAG = 'amp-lightbox-gallery';
 const DEFAULT_GALLERY_ID = 'amp-lightbox-gallery';
 const SLIDE_ITEM_SELECTOR =
-  '.i-amphtml-slide-item, .i-amphtml-carousel-slide-item';
+  '.i-amphtml-slide-item, .i-amphtml-carousel-slotted';
 
 /**
  * Set of namespaces that indicate the lightbox controls mode.

--- a/extensions/amp-lightbox-gallery/0.1/service/lightbox-manager-impl.js
+++ b/extensions/amp-lightbox-gallery/0.1/service/lightbox-manager-impl.js
@@ -52,9 +52,9 @@ export const VIDEO_TAGS = {
 };
 
 const GALLERY_TAG = 'amp-lightbox-gallery';
-const CAROUSEL_TAG = 'AMP-CAROUSEL';
+const CAROUSEL_TAGS = 'AMP-CAROUSEL, AMP-BASE-CAROUSEL';
 const FIGURE_TAG = 'FIGURE';
-const SLIDE_SELECTOR = '.amp-carousel-slide';
+const SLIDE_SELECTOR = '.amp-carousel-slide, .i-amphtml-carousel-slotted';
 
 /**
  * @param {!Element} slide
@@ -221,7 +221,7 @@ export class LightboxManager {
       return;
     }
     this.seen_.push(element);
-    if (element.tagName == CAROUSEL_TAG) {
+    if (CAROUSEL_TAGS.includes(element.tagName)) {
       this.processLightboxCarousel_(element);
     } else {
       const lightboxGroupId = element.getAttribute('lightbox') || 'default';

--- a/extensions/amp-lightbox-gallery/0.1/service/lightbox-manager-impl.js
+++ b/extensions/amp-lightbox-gallery/0.1/service/lightbox-manager-impl.js
@@ -52,7 +52,7 @@ export const VIDEO_TAGS = {
 };
 
 const GALLERY_TAG = 'amp-lightbox-gallery';
-const CAROUSEL_TAGS = 'AMP-CAROUSEL, AMP-BASE-CAROUSEL';
+const CAROUSEL_TAGS = ['AMP-CAROUSEL', 'AMP-BASE-CAROUSEL'];
 const FIGURE_TAG = 'FIGURE';
 const SLIDE_SELECTOR = '.amp-carousel-slide, .i-amphtml-carousel-slotted';
 

--- a/test/manual/amp-base-carousel/basic.amp.html
+++ b/test/manual/amp-base-carousel/basic.amp.html
@@ -7,6 +7,7 @@
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <link href='https://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css'>
   <script async custom-element="amp-base-carousel" src="https://cdn.ampproject.org/v0/amp-base-carousel-0.1.js"></script>
+  <script async custom-element="amp-lightbox-gallery" src="https://cdn.ampproject.org/v0/amp-lightbox-gallery-0.1.js"></script>
   <style amp-custom>
     amp-base-carousel img {
       object-fit: cover;
@@ -17,7 +18,7 @@
 </head>
 <body>
   <h1>A Basic carousel, with looping</h1>
-  <amp-base-carousel id="carousel-1" width="300" height="200" layout="responsive" loop="true">
+  <amp-base-carousel width="300" height="200" layout="responsive" loop="true" lightbox>
     <amp-img src="./img/redgradient.png" layout="flex-item"></amp-img>
     <amp-img src="./img/greengradient.png" layout="flex-item"></amp-img>
     <amp-img src="./img/bluegradient.png" layout="flex-item"></amp-img>

--- a/test/manual/amp-base-carousel/basic.amp.html
+++ b/test/manual/amp-base-carousel/basic.amp.html
@@ -18,7 +18,7 @@
 </head>
 <body>
   <h1>A Basic carousel, with looping</h1>
-  <amp-base-carousel width="300" height="200" layout="responsive" loop="true" lightbox>
+  <amp-base-carousel  id="carousel-1" width="300" height="200" layout="responsive" loop="true" lightbox>
     <amp-img src="./img/redgradient.png" layout="flex-item"></amp-img>
     <amp-img src="./img/greengradient.png" layout="flex-item"></amp-img>
     <amp-img src="./img/bluegradient.png" layout="flex-item"></amp-img>

--- a/test/manual/amp-base-carousel/fixed-children.amp.html
+++ b/test/manual/amp-base-carousel/fixed-children.amp.html
@@ -7,6 +7,7 @@
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <link href='https://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css'>
   <script async custom-element="amp-base-carousel" src="https://cdn.ampproject.org/v0/amp-base-carousel-0.1.js"></script>
+  <script async custom-element="amp-lightbox-gallery" src="https://cdn.ampproject.org/v0/amp-lightbox-gallery-0.1.js"></script>
   <style amp-custom>
     body {
       max-width: 527px;
@@ -28,7 +29,7 @@
 </head>
 <body>
   <h1>Fixed size children, centered using wrapping divs</h1>
-  <amp-base-carousel id="carousel-1" width="300" height="200" layout="responsive" loop="true" snap-align="center">
+  <amp-base-carousel id="carousel-1" width="300" height="200" layout="responsive" loop="true" snap-align="center" lightbox>
     <div class="slide">
       <amp-img src="./img/redgradient.png" width=150 height=100 layout="fixed"></amp-img>
     </div> 

--- a/test/manual/amp-base-carousel/mixed-lengths-no-snap.amp.html
+++ b/test/manual/amp-base-carousel/mixed-lengths-no-snap.amp.html
@@ -7,6 +7,7 @@
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <link href='https://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css'>
   <script async custom-element="amp-base-carousel" src="https://cdn.ampproject.org/v0/amp-base-carousel-0.1.js"></script>
+<script async custom-element="amp-lightbox-gallery" src="https://cdn.ampproject.org/v0/amp-lightbox-gallery-0.1.js"></script>
   <style amp-custom>
     body {
       font-family: 'Questrial', Arial;
@@ -33,7 +34,7 @@
 </head>
 <body>
   <h1>Mixed lengths carousel, looping</h1>
-  <amp-base-carousel id="carousel-1" width="300" height="200" layout="responsive" loop="true" mixed-length="true" snap="false">
+  <amp-base-carousel id="carousel-1" width="300" height="200" layout="responsive" loop="true" mixed-length="true" snap="false" lightbox>
     <amp-img class="slide wide" src="./img/redgradient.png" height="200" layout="fixed-height"></amp-img>
     <amp-img class="slide narrow" src="./img/bluegradient.png" height="200" layout="fixed-height"></amp-img>
     <amp-img class="slide wide" src="./img/orangegradient.png" height="200" layout="fixed-height"></amp-img>

--- a/test/manual/amp-base-carousel/mixed-lengths.amp.html
+++ b/test/manual/amp-base-carousel/mixed-lengths.amp.html
@@ -7,6 +7,7 @@
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <link href='https://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css'>
   <script async custom-element="amp-base-carousel" src="https://cdn.ampproject.org/v0/amp-base-carousel-0.1.js"></script>
+  <script async custom-element="amp-lightbox-gallery" src="https://cdn.ampproject.org/v0/amp-lightbox-gallery-0.1.js"></script>
   <style amp-custom>
     body {
       font-family: 'Questrial', Arial;
@@ -33,7 +34,7 @@
 </head>
 <body>
   <h1>Mixed lengths carousel, looping</h1>
-  <amp-base-carousel id="carousel-1" width="300" height="200" layout="responsive" loop="true" mixed-length="true" snap-align="center">
+  <amp-base-carousel id="carousel-1" width="300" height="200" layout="responsive" loop="true" mixed-length="true" snap-align="center" lightbox>
     <amp-img class="slide wide" src="./img/redgradient.png" height="200" layout="fixed-height"></amp-img>
     <amp-img class="slide narrow" src="./img/bluegradient.png" height="200" layout="fixed-height"></amp-img>
     <amp-img class="slide wide" src="./img/orangegradient.png" height="200" layout="fixed-height"></amp-img>

--- a/test/manual/amp-base-carousel/vertical.amp.html
+++ b/test/manual/amp-base-carousel/vertical.amp.html
@@ -7,6 +7,7 @@
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <link href='https://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css'>
   <script async custom-element="amp-base-carousel" src="https://cdn.ampproject.org/v0/amp-base-carousel-0.1.js"></script>
+  <script async custom-element="amp-lightbox-gallery" src="https://cdn.ampproject.org/v0/amp-lightbox-gallery-0.1.js"></script>
   <style amp-custom>
     amp-base-carousel img {
       object-fit: cover;
@@ -17,7 +18,7 @@
 </head>
 <body>
   <h1>A vertical carousel</h1>
-  <amp-base-carousel id="carousel-1" width="300" height="200" layout="responsive" loop="true" horizontal="false">
+  <amp-base-carousel id="carousel-1" width="300" height="200" layout="responsive" loop="true" horizontal="false" lightbox>
     <amp-img src="./img/redgradient.png" layout="flex-item"></amp-img>
     <amp-img src="./img/greengradient.png" layout="flex-item"></amp-img>
     <amp-img src="./img/bluegradient.png" layout="flex-item"></amp-img>


### PR DESCRIPTION
- Fix amp-image-viewer never loading if the amp-image is a `layout="flex-item"` or
otherwise does not define a size. This is more important for `amp-base-carousel`, where you can give the slides `layout="flex-item"`, but could occur in other cases as well.
- Add lightbox attribute to a few of base carousel's manual tests.

