### PR TITLE
✨ Copy data attrs from amp-img to inner img (fixes #24787)

### DIFF
--- a/builtins/amp-img.js
+++ b/builtins/amp-img.js
@@ -98,6 +98,7 @@ export class AmpImg extends BaseElement {
         this.img_,
         /* opt_removeMissingAttrs */ true
       );
+      this.propagateDataset(this.img_);
       guaranteeSrcForSrcsetUnsupportedBrowsers(this.img_);
     }
   }
@@ -179,6 +180,7 @@ export class AmpImg extends BaseElement {
     // It is important to call this before setting `srcset` attribute.
     this.maybeGenerateSizes_(/* sync setAttribute */ true);
     this.propagateAttributes(ATTRIBUTES_TO_PROPAGATE, this.img_);
+    this.propagateDataset(this.img_);
     guaranteeSrcForSrcsetUnsupportedBrowsers(this.img_);
     this.applyFillContent(this.img_, true);
     propagateObjectFitStyles(this.element, this.img_);

--- a/builtins/amp-img.md
+++ b/builtins/amp-img.md
@@ -160,6 +160,10 @@ An explicit size of the image, which is used by the AMP runtime to determine the
 
 This element includes [common attributes](https://amp.dev/documentation/guides-and-tutorials/learn/common_attributes) extended to AMP components.
 
+**data attributes**
+
+Data attributes are copied from the `amp-img` element to the internal `img` element created by the component.
+
 ## Styling
 
 `amp-img` can be styled directly via CSS properties. Setting a grey background

--- a/src/base-element.js
+++ b/src/base-element.js
@@ -664,6 +664,27 @@ export class BaseElement {
   }
 
   /**
+   * Utility method to propagate all data attributes from this element
+   * to the target element. (For use with arbitrary data attributes.)
+   * Removes any data attributes that are missing on this element from
+   * the target element.
+   * @param {!Element} targetElement
+   */
+  propagateDataset(targetElement) {
+    for (const key in targetElement.dataset) {
+      if (!(key in this.element.dataset)) {
+        delete targetElement.dataset[key];
+      }
+    }
+
+    for (const key in this.element.dataset) {
+      if (targetElement.dataset[key] !== this.element.dataset[key]) {
+        targetElement.dataset[key] = this.element.dataset[key];
+      }
+    }
+  }
+
+  /**
    * Utility method that forwards the given list of non-bubbling events
    * from the given element to this element as custom events with the same name.
    * @param  {string|!Array<string>} events

--- a/test/unit/test-amp-img.js
+++ b/test/unit/test-amp-img.js
@@ -183,6 +183,18 @@ describe('amp-img', () => {
     });
   });
 
+  it('should propagate data attributes', () => {
+    return getImg({
+      src: '/examples/img/sample.jpg',
+      width: 320,
+      height: 240,
+      'data-foo': 'abc',
+    }).then(ampImg => {
+      const img = ampImg.querySelector('img');
+      expect(img.getAttribute('data-foo')).to.equal('abc');
+    });
+  });
+
   describe('#fallback on initial load', () => {
     let el;
     let impl;

--- a/test/unit/test-base-element.js
+++ b/test/unit/test-base-element.js
@@ -81,6 +81,18 @@ describes.realWin('BaseElement', {amp: true}, env => {
     expect(target.getAttribute('data-test3')).to.equal('123');
   });
 
+  it('propagateDataset', () => {
+    const target = doc.createElement('div');
+    target.dataset.foo = 'abc';
+
+    element.propagateDataset(target);
+    expect(target.hasAttribute('data-foo')).to.be.false;
+
+    customElement.dataset.bar = '123';
+    element.propagateDataset(target);
+    expect(target.hasAttribute('data-bar', '123')).to.be.true;
+  });
+
   it('should register action', () => {
     const handler = () => {};
     element.registerAction('method1', handler);


### PR DESCRIPTION
- Copy data attrs from amp-img to inner img (fixes #24787)
- Minor performance optimization to related `propagateAttributes` method (don't call .length on every loop iteration)
