### PR TITLE
Correct type for position observer `relativePos`

### DIFF
--- a/src/service/position-observer/position-observer-worker.js
+++ b/src/service/position-observer/position-observer-worker.js
@@ -40,7 +40,7 @@ const LOW_FIDELITY_FRAME_COUNT = 4;
  * @typedef {{
  *  positionRect: ?../../layout-rect.LayoutRectDef,
  *  viewportRect: !../../layout-rect.LayoutRectDef,
- *  relativePos: string,
+ *  relativePos: ?../../layout-rect.RelativePositions,
  * }}
  */
 export let PositionInViewportEntryDef;
@@ -146,7 +146,7 @@ export class PositionObserverWorker {
         /** @type {./position-observer-worker.PositionInViewportEntryDef}*/ ({
           positionRect: elementBox,
           viewportRect: viewportBox,
-          relativePos: '',
+          relativePos: null,
         })
       );
     });


### PR DESCRIPTION
### Changes
- Tightens type checking on the `relativePos` field of the position observer's `PositionInViewport` type