### PR TITLE
Viewer must be trusted for ssr templates to be supported

### DIFF
--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -435,6 +435,7 @@ const forbiddenTerms = {
       'src/inabox/inabox-viewer.js',
       'src/service/cid-impl.js',
       'src/impression.js',
+      'src/ssr-template-helper.js',
       'extensions/amp-viewer-assistance/0.1/amp-viewer-assistance.js',
     ],
   },

--- a/extensions/amp-form/0.1/test/test-amp-form.js
+++ b/extensions/amp-form/0.1/test/test-amp-form.js
@@ -247,6 +247,9 @@ describes.repeated(
               env.sandbox
                 .stub(ampForm.ssrTemplateHelper_, 'isSupported')
                 .returns(true);
+              env.sandbox
+                .stub(ampForm.viewer_, 'isTrustedViewer')
+                .returns(Promise.resolve(true));
 
               return ampForm;
             });

--- a/src/ssr-template-helper.js
+++ b/src/ssr-template-helper.js
@@ -96,7 +96,7 @@ export class SsrTemplateHelper {
    * If SSR is supported, data is assumed to be from ssr() above.
    * @param {!Element} element
    * @param {(?JsonObject|string|undefined|!Array)} data
-   * @return {!Promise}
+   * @return {!Promise<!Element>}
    */
   applySsrOrCsrTemplate(element, data) {
     let renderTemplatePromise;
@@ -107,7 +107,7 @@ export class SsrTemplateHelper {
       );
       renderTemplatePromise = this.viewer_.isTrustedViewer().then(trusted => {
         userAssert(trusted, 'May only ssr from trusted viewers');
-        this.templates_.findAndSetHtmlForTemplate(
+        return this.templates_.findAndSetHtmlForTemplate(
           element,
           /** @type {string} */ (data['html'])
         );

--- a/src/ssr-template-helper.js
+++ b/src/ssr-template-helper.js
@@ -96,7 +96,7 @@ export class SsrTemplateHelper {
     if (!opt_templates) {
       mustacheTemplate = this.templates_.maybeFindTemplate(element);
     }
-    return this.assertTrustedViewer().then(() => {
+    return this.assertTrustedViewer(element).then(() => {
       return this.viewer_.sendMessageAwaitResponse(
         'viewerRenderTemplate',
         this.buildPayload_(

--- a/src/ssr-template-helper.js
+++ b/src/ssr-template-helper.js
@@ -65,6 +65,15 @@ export class SsrTemplateHelper {
   }
 
   /**
+   * Whether the viewer is allowed to ssr templates. Based on whether or not
+   * it is from a trusted domain.
+   * @return {Promise<boolean>}
+   */
+  isAllowed() {
+    return this.viewer_.isTrustedViewer();
+  }
+
+  /**
    * Proxies xhr and template rendering to the viewer.
    * Returns the renderable response, for use with applySsrOrCsrTemplate.
    * @param {!Element} element
@@ -105,10 +114,13 @@ export class SsrTemplateHelper {
         typeof data['html'] === 'string',
         'Server side html response must be defined'
       );
-      renderTemplatePromise = this.templates_.findAndSetHtmlForTemplate(
-        element,
-        /** @type {string} */ (data['html'])
-      );
+      renderTemplatePromise = this.isAllowed().then(allowed => {
+        userAssert(allowed, 'May only ssr from trusted viewers');
+        this.templates_.findAndSetHtmlForTemplate(
+          element,
+          /** @type {string} */ (data['html'])
+        );
+      });
     } else if (isArray(data)) {
       renderTemplatePromise = this.templates_.findAndRenderTemplateArray(
         element,

--- a/src/ssr-template-helper.js
+++ b/src/ssr-template-helper.js
@@ -65,15 +65,6 @@ export class SsrTemplateHelper {
   }
 
   /**
-   * Whether the viewer is allowed to ssr templates. Based on whether or not
-   * it is from a trusted domain.
-   * @return {Promise<boolean>}
-   */
-  isAllowed() {
-    return this.viewer_.isTrustedViewer();
-  }
-
-  /**
    * Proxies xhr and template rendering to the viewer.
    * Returns the renderable response, for use with applySsrOrCsrTemplate.
    * @param {!Element} element
@@ -114,8 +105,8 @@ export class SsrTemplateHelper {
         typeof data['html'] === 'string',
         'Server side html response must be defined'
       );
-      renderTemplatePromise = this.isAllowed().then(allowed => {
-        userAssert(allowed, 'May only ssr from trusted viewers');
+      renderTemplatePromise = this.isTrustedViewer().then(trusted => {
+        userAssert(trusted, 'May only ssr from trusted viewers');
         this.templates_.findAndSetHtmlForTemplate(
           element,
           /** @type {string} */ (data['html'])

--- a/src/ssr-template-helper.js
+++ b/src/ssr-template-helper.js
@@ -85,7 +85,7 @@ export class SsrTemplateHelper {
       .then(trusted => {
         userAssert(
           trusted,
-          'Refused to apply SSR in untrusted viewer: ',
+          'Refused to attempt SSR in untrusted viewer: ',
           element
         );
       })

--- a/src/ssr-template-helper.js
+++ b/src/ssr-template-helper.js
@@ -105,7 +105,7 @@ export class SsrTemplateHelper {
         typeof data['html'] === 'string',
         'Server side html response must be defined'
       );
-      renderTemplatePromise = this.isTrustedViewer().then(trusted => {
+      renderTemplatePromise = this.viewer_.isTrustedViewer().then(trusted => {
         userAssert(trusted, 'May only ssr from trusted viewers');
         this.templates_.findAndSetHtmlForTemplate(
           element,

--- a/test/unit/test-ssr-template-helper.js
+++ b/test/unit/test-ssr-template-helper.js
@@ -197,7 +197,7 @@ describes.fakeWin(
 
         it('should throw if trying to ssr from an untrusted viewer', () => {
           viewer.isTrustedViewer = () => Promise.resolve(false);
-          const errorMsg = /Refused to apply SSR in untrusted viewer/;
+          const errorMsg = /Refused to attempt SSR in untrusted viewer: /;
           expectAsyncConsoleError(errorMsg);
 
           ssrTemplateHelper

--- a/test/unit/test-ssr-template-helper.js
+++ b/test/unit/test-ssr-template-helper.js
@@ -83,7 +83,7 @@ describes.fakeWin(
     });
 
     describe('ssr', () => {
-      it('should build payload', () => {
+      it('should build payload', async () => {
         const request = {
           'xhrUrl': 'https://www.abracadabra.org/some-json',
           'fetchOpt': {
@@ -94,15 +94,16 @@ describes.fakeWin(
             'ampCors': true,
           },
         };
-        const sendMessage = env.sandbox.spy(viewer, 'sendMessageAwaitResponse');
+        const sendMessage = env.sandbox
+          .stub(viewer, 'sendMessageAwaitResponse')
+          .returns(Promise.resolve({}));
         maybeFindTemplateStub.returns(null);
         const templates = {
           successTemplate: {'innerHTML': '<div>much success</div>'},
           errorTemplate: {'innerHTML': '<div>try again</div>'},
         };
-        ssrTemplateHelper.ssr({}, request, templates, {
-          attr: 'test',
-        });
+        await ssrTemplateHelper.ssr({}, request, templates, {attr: 'test'});
+
         expect(sendMessage).calledWith('viewerRenderTemplate', {
           'ampComponent': {
             'type': 'amp-list',
@@ -183,7 +184,7 @@ describes.fakeWin(
 
         it('should throw if trying to ssr from an untrusted viewer', () => {
           viewer.isTrustedViewer = () => Promise.resolve(false);
-          const errorMsg = /May only ssr from trusted viewers/;
+          const errorMsg = /Refused to apply SSR in untrusted viewer/;
           expectAsyncConsoleError(errorMsg);
 
           ssrTemplateHelper

--- a/test/unit/test-ssr-template-helper.js
+++ b/test/unit/test-ssr-template-helper.js
@@ -83,6 +83,20 @@ describes.fakeWin(
     });
 
     describe('ssr', () => {
+      it('Should refuse to SSR with an untrusted viewer', async () => {
+        viewer.isTrustedViewer = () => Promise.resolve(false);
+        const errorMsg = /Refused to attempt SSR in untrusted viewer: /;
+        expectAsyncConsoleError(errorMsg);
+
+        return ssrTemplateHelper.ssr({}, {}, {})
+        .then(
+          () => Promise.reject(),
+          err => {
+            expect(err).match(errorMsg);
+          }
+        );
+      });
+
       it('should build payload', async () => {
         const request = {
           'xhrUrl': 'https://www.abracadabra.org/some-json',

--- a/test/unit/test-ssr-template-helper.js
+++ b/test/unit/test-ssr-template-helper.js
@@ -88,8 +88,7 @@ describes.fakeWin(
         const errorMsg = /Refused to attempt SSR in untrusted viewer: /;
         expectAsyncConsoleError(errorMsg);
 
-        return ssrTemplateHelper.ssr({}, {}, {})
-        .then(
+        return ssrTemplateHelper.ssr({}, {}, {}).then(
           () => Promise.reject(),
           err => {
             expect(err).match(errorMsg);

--- a/test/unit/test-ssr-template-helper.js
+++ b/test/unit/test-ssr-template-helper.js
@@ -156,13 +156,20 @@ describes.fakeWin(
 
       describe('applySsrOrCsrTemplate', () => {
         it('should set html template', () => {
+          // Not a real document element. This variable is used to ensure the
+          // value returned by findAndSetHtmlForTemplate is returned by
+          // applySsrOrCsrTemplate.
+          const element = {};
+          findAndSetHtmlForTemplate.returns(element);
+
           return ssrTemplateHelper
             .applySsrOrCsrTemplate({}, {html: '<div>some template</div>'})
-            .then(() => {
+            .then(renderedHTML => {
               expect(findAndSetHtmlForTemplate).to.have.been.calledWith(
                 {},
                 '<div>some template</div>'
               );
+              expect(renderedHTML).to.equal(element);
             });
         });
 


### PR DESCRIPTION
**summary**
Viewers should be trusted if attempting to use SSR. This is a take two at https://github.com/ampproject/amphtml/pull/25520, but with a much simpler approach. Instead of turning ssr service's `isSupported` function to return a promise, we can defer the trusted viewer check to render time and throw if untrusted (rather than falling back to csr).

This behavior is okay because the developer has already explicitly opted in to ssr via an ampdoc attribute.

/to @choumx, @jridgewell 