### PR TITLE
SwG release 0.1.22.84

### DIFF
--- a/third_party/subscriptions-project/config.js
+++ b/third_party/subscriptions-project/config.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/** Version: 0.1.22.83 */
+/** Version: 0.1.22.84 */
 /**
  * Copyright 2018 The Subscribe with Google Authors. All Rights Reserved.
  *


### PR DESCRIPTION
## Version: 0.1.22.84

## Previous release: [0.1.22.83](https://github.com/subscriptions-project/swg-js/releases/tag/0.1.22.83)

  - Update dependency rollup to v1.27.2 (#799)
  - ✅ Moves two `expect` calls outside callbacks (#794)
  - Update babelify and get rid of custom-babel-helpers (#795)
  - Always log page load event (#796)
  - Allow adding defaultArguments to ActivityPort calls (#790)
  - Add e2e tests to travis and set travis jobs in sequential stages. (#792)
  - Updates a few tests to use async/await (#791)
  - Handle passed null promise (#767)
  - Update dependency rollup to v1.27.0 (#788)
  - Add a helper.js and some other cleanups. (#787)
  - Move gulp build task to gulpfile and clean up gulp test task. (#786)