### PR TITLE
🏗 Use in-process `gulp` server during `visual-diff` and `e2e`

### DIFF
--- a/build-system/server/app-utils.js
+++ b/build-system/server/app-utils.js
@@ -16,29 +16,40 @@
 
 const minimist = require('minimist');
 
+let serveMode = 'default';
+
 /**
- * Determines the server's mode based on command line arguments.
+ * Returns a string representation of the server's mode.
  * @return {string}
  */
 function getServeMode() {
-  const argv = minimist(process.argv.slice(2), {string: ['rtv']});
-  if (argv.compiled) {
-    return 'compiled';
+  return serveMode;
+}
+
+/**
+ * Sets the server's mode. Uses command line arguments by default, but can be
+ * overridden by passing in a modeOptions object.
+ * @param {?Object} modeOptions
+ */
+function setServeMode(modeOptions) {
+  if (!modeOptions) {
+    modeOptions = minimist(process.argv.slice(2), {string: ['rtv']});
   }
-  if (argv.cdn) {
-    return 'cdn';
-  }
-  if (argv.rtv != undefined) {
-    const {rtv} = argv;
+
+  if (modeOptions.compiled) {
+    serveMode = 'compiled';
+  } else if (modeOptions.cdn) {
+    serveMode = 'cdn';
+  } else if (modeOptions.rtv) {
+    const {rtv} = modeOptions;
     if (isRtvMode(rtv)) {
-      return 'rtv';
+      serveMode = rtv;
     } else {
       const err = new Error(`Invalid rtv: ${rtv}. (Must be 15 digits long.)`);
       err.showStack = false;
       throw err;
     }
   }
-  return 'default';
 }
 
 /**
@@ -148,4 +159,5 @@ module.exports = {
   isRtvMode,
   replaceUrls,
   getServeMode,
+  setServeMode,
 };

--- a/build-system/server/app-utils.js
+++ b/build-system/server/app-utils.js
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 
+const log = require('fancy-log');
 const minimist = require('minimist');
+const {cyan, green} = require('ansi-colors');
 
 let serveMode = 'default';
 
@@ -49,6 +51,22 @@ function setServeMode(modeOptions) {
       err.showStack = false;
       throw err;
     }
+  }
+}
+
+/**
+ * Logs the server's mode.
+ */
+function logServeMode() {
+  const serveMode = getServeMode();
+  if (serveMode == 'compiled') {
+    log(green('Serving'), cyan('minified'), green('JS'));
+  } else if (serveMode == 'cdn') {
+    log(green('Serving'), cyan('current prod'), green('JS'));
+  } else if (isRtvMode(serveMode)) {
+    log(green('Serving JS from RTV'), cyan(serveMode));
+  } else {
+    log(green('Serving'), cyan('unminified'), green('JS'));
   }
 }
 
@@ -156,8 +174,9 @@ const replaceUrls = (mode, file, hostName, inabox, storyV1) => {
 };
 
 module.exports = {
-  isRtvMode,
-  replaceUrls,
   getServeMode,
+  isRtvMode,
+  logServeMode,
+  replaceUrls,
   setServeMode,
 };

--- a/build-system/server/app-utils.js
+++ b/build-system/server/app-utils.js
@@ -31,10 +31,10 @@ function getServeMode() {
 /**
  * Sets the server's mode. Uses command line arguments by default, but can be
  * overridden by passing in a modeOptions object.
- * @param {?Object} modeOptions
+ * @param {!Object} modeOptions
  */
 function setServeMode(modeOptions) {
-  if (!modeOptions) {
+  if (Object.keys(modeOptions).length == 0) {
     modeOptions = minimist(process.argv.slice(2), {string: ['rtv']});
   }
 

--- a/build-system/tasks/build.js
+++ b/build-system/tasks/build.js
@@ -29,9 +29,9 @@ const {buildExtensions} = require('./extension-helpers');
 const {compileCss} = require('./css');
 const {compileJison} = require('./compile-jison');
 const {cyan, green} = require('ansi-colors');
+const {doServe} = require('./serve');
 const {maybeUpdatePackages} = require('./update-packages');
 const {parseExtensionFlags} = require('./extension-helpers');
-const {serve} = require('./serve');
 
 /**
  * Enables watching for file changes in css, extensions.
@@ -104,7 +104,7 @@ async function defaultTask() {
   printDefaultTaskHelp();
   parseExtensionFlags(/* preBuild */ true);
   await performPrerequisiteSteps(/* watch */ true);
-  await serve();
+  await doServe(/* lazyBuild */ true);
   log(green('JS and extensions will be lazily built when requested...'));
 }
 

--- a/build-system/tasks/e2e/index.js
+++ b/build-system/tasks/e2e/index.js
@@ -23,20 +23,17 @@ const glob = require('glob');
 const log = require('fancy-log');
 const Mocha = require('mocha');
 const path = require('path');
-const tryConnect = require('try-net-connect');
 const {cyan} = require('ansi-colors');
-const {execOrDie, execScriptAsync} = require('../../common/exec');
+const {execOrDie} = require('../../common/exec');
 const {isTravisBuild} = require('../../common/travis');
 const {reportTestStarted} = require('../report-test-status');
+const {startServer, stopServer} = require('../serve');
 const {watch} = require('gulp');
 
 const HOST = 'localhost';
 const PORT = 8000;
-const WEBSERVER_TIMEOUT_RETRIES = 10;
 const SLOW_TEST_THRESHOLD_MS = 2500;
 const TEST_RETRIES = isTravisBuild() ? 2 : 0;
-
-let webServerProcess_;
 
 function installPackages_() {
   log('Running', cyan('yarn'), 'to install packages...');
@@ -48,33 +45,12 @@ function buildRuntime_() {
   execOrDie(`gulp dist --fortesting --config ${argv.config}`);
 }
 
-function launchWebServer_() {
-  log('Launching webserver at', cyan(`http://${HOST}:${PORT}`) + '...');
-  webServerProcess_ = execScriptAsync(
-    `gulp serve --compiled --host ${HOST} --port ${PORT}`,
-    {stdio: 'ignore'}
-  );
-
-  let resolver;
-  const deferred = new Promise(resolverIn => {
-    resolver = resolverIn;
-  });
-
-  tryConnect({
-    host: HOST,
-    port: PORT,
-    retries: WEBSERVER_TIMEOUT_RETRIES, // retry timeout defaults to 1 sec
-  }).on('connected', () => {
-    return resolver(webServerProcess_);
-  });
-
-  return deferred;
+async function launchWebServer_() {
+  await startServer({host: HOST, port: PORT}, !!argv.debug, {compiled: true});
 }
 
-async function cleanUp_() {
-  if (webServerProcess_ && !webServerProcess_.killed) {
-    webServerProcess_.kill('SIGKILL');
-  }
+function cleanUp_() {
+  stopServer();
 }
 
 function createMocha_() {
@@ -139,7 +115,7 @@ async function e2e() {
     await reportTestStarted();
     mocha.run(async failures => {
       // end web server
-      await cleanUp_();
+      cleanUp_();
 
       // end task
       process.exitCode = failures ? 1 : 0;
@@ -182,4 +158,5 @@ e2e.flags = {
     '  The automation engine that orchestrates the browser. ' +
     'Options are `puppeteer` or `selenium`. Default: `selenium`',
   'headless': '  Runs the browser in headless mode',
+  'debug': '  Prints debugging information while running tests',
 };

--- a/build-system/tasks/e2e/index.js
+++ b/build-system/tasks/e2e/index.js
@@ -46,7 +46,11 @@ function buildRuntime_() {
 }
 
 async function launchWebServer_() {
-  await startServer({host: HOST, port: PORT}, !!argv.debug, {compiled: true});
+  await startServer(
+    {host: HOST, port: PORT},
+    {quiet: !argv.debug},
+    {compiled: true}
+  );
 }
 
 function cleanUp_() {

--- a/build-system/tasks/serve.js
+++ b/build-system/tasks/serve.js
@@ -30,7 +30,7 @@ const {
 } = require('../server/lazy-build');
 const {createCtrlcHandler} = require('../common/ctrlcHandler');
 const {cyan, green} = require('ansi-colors');
-const {isRtvMode, getServeMode, setServeMode} = require('../server/app-utils');
+const {logServeMode, setServeMode} = require('../server/app-utils');
 
 const argv = minimist(process.argv.slice(2), {string: ['rtv']});
 
@@ -39,22 +39,6 @@ let url = null;
 let {quiet} = argv;
 
 const serverFiles = globby.sync(['build-system/server/**']);
-
-/**
- * Logs the server's mode.
- */
-function logServeMode() {
-  const serveMode = getServeMode();
-  if (serveMode == 'compiled') {
-    log(green('Serving'), cyan('minified'), green('JS'));
-  } else if (serveMode == 'cdn') {
-    log(green('Serving'), cyan('current prod'), green('JS'));
-  } else if (isRtvMode(serveMode)) {
-    log(green('Serving JS from RTV'), cyan(serveMode));
-  } else {
-    log(green('Serving'), cyan('unminified'), green('JS'));
-  }
-}
 
 /**
  * Returns a list of middleware handler functions to use while serving

--- a/build-system/tasks/visual-diff/index.js
+++ b/build-system/tasks/visual-diff/index.js
@@ -21,7 +21,10 @@ const fs = require('fs');
 const JSON5 = require('json5');
 const path = require('path');
 const sleep = require('sleep-promise');
-const tryConnect = require('try-net-connect');
+const {
+  createCtrlcHandler,
+  exitCtrlcHandler,
+} = require('../../common/ctrlcHandler');
 const {
   escapeHtml,
   log,
@@ -37,6 +40,7 @@ const {
 } = require('../../common/git');
 const {execOrDie, execScriptAsync} = require('../../common/exec');
 const {isTravisBuild} = require('../../common/travis');
+const {startServer, stopServer} = require('../serve');
 
 // optional dependencies for local development (outside of visual diff tests)
 let puppeteer;
@@ -49,7 +53,6 @@ const VIEWPORT_WIDTH = 1400;
 const VIEWPORT_HEIGHT = 100000;
 const HOST = 'localhost';
 const PORT = 8000;
-const WEBSERVER_TIMEOUT_RETRIES = 10;
 const NAVIGATE_TIMEOUT_MS = 30000;
 const MAX_PARALLEL_TABS = 5;
 const WAIT_FOR_TABS_MS = 1000;
@@ -77,7 +80,6 @@ const SNAPSHOT_ERROR_SNIPPET = fs.readFileSync(
 );
 
 let browser_;
-let webServerProcess_;
 let percyAgentProcess_;
 
 /**
@@ -137,49 +139,10 @@ async function launchPercyAgent() {
 }
 
 /**
- * Launches a background AMP webserver for unminified js using gulp.
- *
- * Waits until the server is up and reachable, and ties its lifecycle to this
- * process's lifecycle.
- *
- * @return {!Promise} a Promise that resolves when the web server is launched
- *     and reachable.
+ * Launches an AMP webserver for unminified js.
  */
 async function launchWebServer() {
-  const stdio = argv.webserver_debug
-    ? ['ignore', process.stdout, process.stderr]
-    : 'ignore';
-  webServerProcess_ = execScriptAsync(
-    `gulp serve --compiled --host ${HOST} --port ${PORT}`,
-    {stdio}
-  );
-
-  webServerProcess_.on('close', code => {
-    code = code || 0;
-    if (code != 0) {
-      log(
-        'fatal',
-        colors.cyan("'serve'"),
-        `errored with code ${code}. Cannot continue with visual diff tests`
-      );
-    }
-  });
-
-  let resolver, rejecter;
-  const deferred = new Promise((resolverIn, rejecterIn) => {
-    resolver = resolverIn;
-    rejecter = rejecterIn;
-  });
-  tryConnect({
-    host: HOST,
-    port: PORT,
-    retries: WEBSERVER_TIMEOUT_RETRIES, // retry timeout defaults to 1 sec
-  })
-    .on('connected', () => {
-      return resolver(webServerProcess_);
-    })
-    .on('timeout', rejecter);
-  return deferred;
+  await startServer({host: HOST, port: PORT}, argv.webserver_debug);
 }
 
 /**
@@ -705,6 +668,7 @@ async function createEmptyBuild() {
  * @return {!Promise}
  */
 async function visualDiff() {
+  const handlerProcess = createCtrlcHandler('visual-diff');
   ensureOrBuildAmpRuntimeInTestMode_();
   installPercy_();
   setupCleanup_();
@@ -717,7 +681,8 @@ async function visualDiff() {
   }
 
   await performVisualTests();
-  return await cleanup_();
+  await cleanup_();
+  exitCtrlcHandler(handlerProcess);
 }
 
 /**
@@ -808,29 +773,28 @@ function setupCleanup_() {
   process.on('unhandledRejection', cleanup_);
 }
 
+async function exitPercyAgent_() {
+  let percyAgentExited_;
+  if (percyAgentProcess_ && !percyAgentProcess_.killed) {
+    let resolver;
+    percyAgentExited_ = new Promise(resolverIn => {
+      resolver = resolverIn;
+    });
+    percyAgentProcess_.on('exit', () => {
+      resolver();
+    });
+    // Explicitly exit the process by "Ctrl+C"-ing it.
+    await percyAgentProcess_.kill('SIGINT');
+    await percyAgentExited_;
+  }
+}
+
 async function cleanup_() {
   if (browser_) {
     await browser_.close();
   }
-
-  const processesExited = [];
-  for (const subprocess of [percyAgentProcess_, webServerProcess_]) {
-    if (subprocess && !subprocess.killed) {
-      let resolver;
-      processesExited.push(
-        new Promise(resolverIn => {
-          resolver = resolverIn;
-        })
-      );
-      subprocess.on('exit', () => {
-        resolver();
-      });
-
-      // Explicitly exit the processes by "Ctrl+C"-ing them.
-      await subprocess.kill('SIGINT');
-    }
-    await Promise.all(processesExited);
-  }
+  stopServer();
+  await exitPercyAgent_();
 }
 
 module.exports = {

--- a/build-system/tasks/visual-diff/index.js
+++ b/build-system/tasks/visual-diff/index.js
@@ -142,8 +142,11 @@ async function launchPercyAgent() {
  * Launches an AMP webserver for minified js.
  */
 async function launchWebServer() {
-  const logRequests = !!argv.webserver_debug;
-  await startServer({host: HOST, port: PORT}, logRequests, {compiled: true});
+  await startServer(
+    {host: HOST, port: PORT},
+    {quiet: !argv.webserver_debug},
+    {compiled: true}
+  );
 }
 
 /**
@@ -775,10 +778,9 @@ function setupCleanup_() {
 }
 
 async function exitPercyAgent_() {
-  let percyAgentExited_;
   if (percyAgentProcess_ && !percyAgentProcess_.killed) {
     let resolver;
-    percyAgentExited_ = new Promise(resolverIn => {
+    const percyAgentExited_ = new Promise(resolverIn => {
       resolver = resolverIn;
     });
     percyAgentProcess_.on('exit', () => {

--- a/build-system/tasks/visual-diff/index.js
+++ b/build-system/tasks/visual-diff/index.js
@@ -139,10 +139,11 @@ async function launchPercyAgent() {
 }
 
 /**
- * Launches an AMP webserver for unminified js.
+ * Launches an AMP webserver for minified js.
  */
 async function launchWebServer() {
-  await startServer({host: HOST, port: PORT}, argv.webserver_debug);
+  const logRequests = !!argv.webserver_debug;
+  await startServer({host: HOST, port: PORT}, logRequests, {compiled: true});
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -173,7 +173,6 @@
     "through2": "3.0.1",
     "topological-sort": "0.3.0",
     "traverse": "0.6.6",
-    "try-net-connect": "3.0.2",
     "tsickle": "0.37.1",
     "typescript": "3.7.2",
     "uglifyify": "5.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12296,11 +12296,6 @@ ret@~0.1.10:
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
   integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
 
-retry@^0.10.0:
-  version "0.10.1"
-  resolved "https://registry.yarnpkg.com/retry/-/retry-0.10.1.tgz#e76388d217992c252750241d3d3956fed98d8ff4"
-  integrity sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=
-
 reusify@^1.0.0:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
@@ -13803,13 +13798,6 @@ trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
   integrity sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=
-
-try-net-connect@3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/try-net-connect/-/try-net-connect-3.0.2.tgz#fbb081428fb347419573e14f3ebd72aff42ec65b"
-  integrity sha1-+7CBQo+zR0GVc+FPPr1yr/Quxls=
-  dependencies:
-    retry "^0.10.0"
 
 tsickle@0.37.1:
   version "0.37.1"


### PR DESCRIPTION
In order to support lazy-building, the `gulp serve` task was recently re-written to be an in-process server (instead of a `nodemon` child process). See #24325. This PR modifies the `visual-diff` and `e2e` tasks to use this new server startup mode.

**Highlights:**
- Rewrites `launchWebServer_()` in `visual-diff` and `e2e` to directly call `startServer()`
- Refactors `gulp serve` code to support non-default startup modes like `--compiled` or `--rtv <15 digits>`, and prevent lazy building during tests
- Fixes a bug in the `--rtv` case, where the mode was being set to `rtv` instead of the actual 15 digits

Fixes #25613