### PR TITLE
🐛Fix attribution icon being centered incorrectly

### DIFF
--- a/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads-attribution.css
+++ b/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads-attribution.css
@@ -17,6 +17,7 @@
 .i-amphtml-story-ad-attribution {
   position: absolute;
   bottom: 0 !important;
+  left: 0 !important;
   max-height: 15px !important;
   /* 1 greater than cta layer. */
   z-index: 4 !important;

--- a/test/fixtures/e2e/amp-story-auto-ads/basic.html
+++ b/test/fixtures/e2e/amp-story-auto-ads/basic.html
@@ -9,6 +9,11 @@
     <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
     <link rel="canonical" href="helloworld.html">
     <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+    <style>
+      amp-story {
+        text-align: center;
+      }
+    </style>
   </head>
 
   <body>


### PR DESCRIPTION
If a publisher writes a CSS rule like `amp-story { text-align: center }` this rule will affect the placement of the attribution icon, even though the icon element is in shadow DOM :(

![localhost_8000_examples_amp-story_fake-ad html(Pixel 2 XL)](https://user-images.githubusercontent.com/16087874/69096707-ca1b6d80-0a09-11ea-954b-b8b266761062.png)

This fix explicitly sets the `left` position so that pubs can't break the positioning in this way.