### PR TITLE
🏗 Add APPROVERS.json to enable blocking bundle-size checks for extensions

### DIFF
--- a/build-system/tasks/bundle-size/APPROVERS.json
+++ b/build-system/tasks/bundle-size/APPROVERS.json
@@ -1,0 +1,18 @@
+{
+  "dist/v0.js": {
+    "approvers": ["ampproject/wg-performance", "ampproject/wg-runtime"],
+    "threshold": 0.1
+  },
+  "dist/amp4ads-v0.js": {
+    "approvers": ["ampproject/wg-ads"],
+    "threshold": 0.1
+  },
+  "dist/v0/amp-story-0.1.js": {
+    "approvers": ["ampproject/wg-stories"],
+    "threshold": 0.5
+  },
+  "dist/v0/amp-story-1.0.js": {
+    "approvers": ["ampproject/wg-stories"],
+    "threshold": 0.5
+  }
+}

--- a/build-system/tasks/bundle-size/README.md
+++ b/build-system/tasks/bundle-size/README.md
@@ -3,9 +3,9 @@
 The `APPROVERS.json` file is a listing of compiled AMP runtime and extensions
 files. Each rule has two parts:
 
-- `approvers`: list of GitHub project teams, members of which are allowed to
-  approve pull requests that fail the check
-- `threshold`: number of KBs that the file bundle size (Brotli-compressed size)
+- `approvers`: list of GitHub teams whose members may approve pull requests that
+  fail the check
+- `threshold`: number of kilobytes by which the brotli-compressed bundle size
   can increase before failing the check
 
 Approval from any single member of any of the file's approval-teams is enough to
@@ -13,11 +13,9 @@ satisfy the check.
 
 This file is dynamically fetched by the [Bundle-Size GitHub App](https://github.com/ampproject/amp-github-apps/tree/master/bundle-size)
 
-Note that pull requests that increase the bundle size of multiple files that
-each require approval by a different set of teams (e.g., a PR that increases the
-bundle-size of three files, requiring approvals by `{team1}`, `{team1, team2}`,
-and `{team2}`) will fall back to the set of default approvers, currently set to
-@ampproject/wg-runtime and @ampproject/wg-performance. Members of
-@ampproject/wg-infra can also approve all all bundle size increases or app
-failures, but this should only be done when the cause for the failure is an
-infrastructure issue.
+If a pull request requires a bundle-size approval from more than one _set_ of
+approvers, it will fall back to the default set of approvers
+(@ampproject/wg-runtime and @ampproject/wg-performance). Members of
+@ampproject/wg-infra can also approve all bundle size increases or app failures,
+but this should only be done when the cause for the failure is an infrastructure
+issue.

--- a/build-system/tasks/bundle-size/README.md
+++ b/build-system/tasks/bundle-size/README.md
@@ -15,7 +15,7 @@ This file is dynamically fetched by the [Bundle-Size GitHub App](https://github.
 
 If a pull request requires a bundle-size approval from more than one _set_ of
 approvers, it will fall back to the default set of approvers
-(@ampproject/wg-runtime and @ampproject/wg-performance). Members of
-@ampproject/wg-infra can also approve all bundle size increases or app failures,
-but this should only be done when the cause for the failure is an infrastructure
-issue.
+(`@ampproject/wg-runtime` and `@ampproject/wg-performance`). Members of
+`@ampproject/wg-infra` can also approve all bundle size increases or app
+failures, but this should only be done when the cause for the failure is an
+infrastructure issue.

--- a/build-system/tasks/bundle-size/README.md
+++ b/build-system/tasks/bundle-size/README.md
@@ -2,6 +2,7 @@
 
 The `APPROVERS.json` file is a listing of compiled AMP runtime and extensions
 files. Each rule has two parts:
+
 - `approvers`: list of GitHub project teams, members of which are allowed to
   approve pull requests that increase the file's bundle size (Brotli-compressed
   size)

--- a/build-system/tasks/bundle-size/README.md
+++ b/build-system/tasks/bundle-size/README.md
@@ -1,9 +1,12 @@
 # Bundle Size checks
 
 The `APPROVERS.json` file is a listing of compiled AMP runtime and extensions
-files, and for each file what teams are allowed to approve pull requests that
-increase to that file's bundle size (Brotli-compressed size) and what is the
-threshold of an increase that requires special approval, in KBs.
+files. Each rule has two parts:
+- `approvers`: list of GitHub project teams, members of which are allowed to
+  approve pull requests that increase the file's bundle size (Brotli-compressed
+  size)
+- `threshold`: number of KBs that the file can increase before requiring an
+  approval from the above team members.
 
 Approval from any single member of any of the file's approval-teams is enough to
 satisfy the check.
@@ -16,4 +19,5 @@ bundle-size of three files, requiring approvals by `{team1}`, `{team1, team2}`,
 and `{team2}`) will fall back to the set of default approvers, currently set to
 @ampproject/wg-runtime and @ampproject/wg-performance. Members of
 @ampproject/wg-infra can also approve all all bundle size increases or app
-failures, but this should only be done when the cause for infrastructure issues.
+failures, but this should only be done when the cause for the failure is an
+infrastructure issue.

--- a/build-system/tasks/bundle-size/README.md
+++ b/build-system/tasks/bundle-size/README.md
@@ -1,0 +1,19 @@
+# Bundle Size checks
+
+The `APPROVERS.json` file is a listing of compiled AMP runtime and extensions
+files, and for each file what teams are allowed to approve pull requests that
+increase to that file's bundle size (Brotli-compressed size) and what is the
+threshold of an increase that requires special approval, in KBs.
+
+Approval from any single member of any of the file's approval-teams is enough to
+satisfy the check.
+
+This file is dynamically fetched by the [Bundle-Size GitHub App](https://github.com/ampproject/amp-github-apps/tree/master/bundle-size)
+
+Note that pull requests that increase the bundle size of multiple files that
+each require approval by a different set of teams (e.g., a PR that increases the
+bundle-size of three files, requiring approvals by `{team1}`, `{team1, team2}`,
+and `{team2}`) will fall back to the set of default approvers, currently set to
+@ampproject/wg-runtime and @ampproject/wg-performance. Members of
+@ampproject/wg-infra can also approve all all bundle size increases or app
+failures, but this should only be done when the cause for infrastructure issues.

--- a/build-system/tasks/bundle-size/README.md
+++ b/build-system/tasks/bundle-size/README.md
@@ -4,10 +4,9 @@ The `APPROVERS.json` file is a listing of compiled AMP runtime and extensions
 files. Each rule has two parts:
 
 - `approvers`: list of GitHub project teams, members of which are allowed to
-  approve pull requests that increase the file's bundle size (Brotli-compressed
-  size)
-- `threshold`: number of KBs that the file can increase before requiring an
-  approval from the above team members.
+  approve pull requests that fail the check
+- `threshold`: number of KBs that the file bundle size (Brotli-compressed size)
+  can increase before failing the check
 
 Approval from any single member of any of the file's approval-teams is enough to
 satisfy the check.

--- a/build-system/tasks/bundle-size/index.js
+++ b/build-system/tasks/bundle-size/index.js
@@ -28,16 +28,16 @@ const {
   gitCommitHash,
   gitTravisMasterBaseline,
   shortSha,
-} = require('../common/git');
+} = require('../../common/git');
 const {
   isTravisPullRequestBuild,
   isTravisPushBuild,
   travisPushBranch,
   travisRepoSlug,
-} = require('../common/travis');
+} = require('../../common/travis');
 const {
   VERSION: internalRuntimeVersion,
-} = require('../compile/internal-version');
+} = require('../../compile/internal-version');
 const {cyan, green, red, yellow} = require('ansi-colors');
 
 const fileGlobs = ['dist/*.js', 'dist/v0/*-?.?.js'];


### PR DESCRIPTION
wip - not yet being used because the bundle-size app needs to be updated to use it