### PR TITLE
🐛Fix weird border on some story ads

### DIFF
--- a/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.css
+++ b/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.css
@@ -75,3 +75,10 @@ amp-story-page[active] .i-amphtml-story-ad-link {
   width: 100% !important;
   z-index: 1 !important;
 }
+
+amp-ad[data-a4a-upgrade-type="amp-ad-network-doubleclick-impl"] > iframe,
+amp-ad[type="adsense"] > iframe {
+  top: 0 !important;
+  left: 0 !important;
+  transform: translate(0) !important;
+}

--- a/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.css
+++ b/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.css
@@ -76,6 +76,7 @@ amp-story-page[active] .i-amphtml-story-ad-link {
   z-index: 1 !important;
 }
 
+/* TODO(ccordry): refactor centering logic in amp-ad.css and remove this hack.  */
 amp-ad[data-a4a-upgrade-type="amp-ad-network-doubleclick-impl"] > iframe,
 amp-ad[type="adsense"] > iframe {
   top: 0 !important;


### PR DESCRIPTION
Based on viewport size etc sometimes ads will serve with a fractional border visible around the top and left side of the iframe holding a creative.
![www cnn com_ampstories_health_candy-corn-what-you-dont-know-about-the-halloween-treat(Pixel 2) (1)](https://user-images.githubusercontent.com/16087874/69099997-056d6a80-0a11-11ea-8f65-1d80b77e2d68.png)

This is caused by the iframe not taking the full viewport and the background of the story itself peeking through. For normal ads we have some logic that tries to center the creative  in `amp-ad.css`
https://github.com/ampproject/amphtml/blob/3c20f74235c3d175316e6b98c588d9a79b725245/extensions/amp-ad/0.1/amp-ad.css#L53-L58

This logic sometimes causes the result to be fractional pixels which manifests the bug. This change overwrites this logic for story ads and always moves them to the top left.

Side note: I couldn't figure out how to write a test for this, as something like `getBoundingClientRect()` will actually report `top: 0, left: 0` even though in rendering you can see that it is not the case. Open to suggestions here.

