### PR TITLE
🐛 Improvements for embedded tweets

### DIFF
--- a/extensions/amp-story/1.0/amp-story-embedded-component.js
+++ b/extensions/amp-story/1.0/amp-story-embedded-component.js
@@ -1015,7 +1015,7 @@ export class AmpStoryEmbeddedComponent {
     // When a window resize happens, we must reset the styles and prepare the
     // animation again.
     if (element.hasAttribute(EMBED_ID_ATTRIBUTE_NAME)) {
-      elId = element.getAttribute(EMBED_ID_ATTRIBUTE_NAME);
+      elId = parseInt(element.getAttribute(EMBED_ID_ATTRIBUTE_NAME), 10);
       const embedStyleEl = dev().assertElement(
         embedStyleEls[elId],
         `Failed to look up embed style element with ID ${elId}`

--- a/extensions/amp-story/1.0/amp-story-embedded-component.js
+++ b/extensions/amp-story/1.0/amp-story-embedded-component.js
@@ -53,7 +53,14 @@ const ActionIcon = {
 /** @private @const {number} */
 const TOOLTIP_CLOSE_ANIMATION_MS = 100;
 
-/** @private @const {number} */
+/**
+ * Since we don't know the actual width of the content inside the iframe
+ * and in responsive environments the iframe takes the whole width, we
+ * hardcode a limit based on what we know of how the embed behaves (only true
+ * for Twitter embeds). See #22334.
+ * @const {number}
+ * @private
+ */
 const MAX_EMBED_WIDTH_PX = 500;
 
 /**
@@ -209,8 +216,7 @@ function updateEmbedStyleEl(embedStyleEl, embedData) {
   embedStyleEl.textContent = `[${EMBED_ID_ATTRIBUTE_NAME}="${embedId}"] {
       width: ${px(embedData.width)} !important;
       transform: ${embedData.transform} !important;
-      margin-left: ${embedData.horizontalMargin}px !important;
-      margin-right: ${embedData.horizontalMargin}px !important;
+      margin: 0 ${embedData.horizontalMargin}px !important;
       }`;
 }
 
@@ -788,7 +794,7 @@ export class AmpStoryEmbeddedComponent {
         // TODO(#20832): Store DOMRect for the page in the store to avoid
         // having to call getBoundingClientRect().
         const pageRect = this.componentPage_./*OK*/ getBoundingClientRect();
-        const realHeight = target.scrollHeight;
+        const realHeight = target./*OK*/ offsetHeight;
         const maxHeight = pageRect.height - VERTICAL_PADDING;
         state.scaleFactor = 1;
         if (realHeight > maxHeight) {
@@ -860,13 +866,9 @@ export class AmpStoryEmbeddedComponent {
 
         // If screen is very wide and story has supports-landscape attribute,
         // we don't want it to take the whole width. We take the maximum width
-        // that the embed can actually take instead.
+        // that the embed can actually use instead.
         state.newWidth = Math.min(pageRect.width, MAX_EMBED_WIDTH_PX);
 
-        // Since we don't know the actual width of the content inside the iframe
-        // and in responsive environments the iframe takes the whole width. We
-        // hardcode a limit based on how we know the content behaves. See
-        // #22334.
         state.scaleFactor =
           Math.min(elRect.width, MAX_EMBED_WIDTH_PX) / state.newWidth;
 

--- a/extensions/amp-story/1.0/amp-story-embedded-component.js
+++ b/extensions/amp-story/1.0/amp-story-embedded-component.js
@@ -234,7 +234,8 @@ function buildStringStyleFromEl(target, embedData) {
 }
 
 /**
- * Builds string used in the <style> element for tweets.
+ * Builds string used in the <style> element for tweets. We ignore the height
+ * as its non-deterministic.
  * @param {!EmbedDataDef} embedData
  * @return {string}
  */

--- a/extensions/amp-story/1.0/amp-story-embedded-component.js
+++ b/extensions/amp-story/1.0/amp-story-embedded-component.js
@@ -61,7 +61,7 @@ const TOOLTIP_CLOSE_ANIMATION_MS = 100;
  * @const {number}
  * @private
  */
-const MAX_EMBED_WIDTH_PX = 500;
+const MAX_TWEET_WIDTH_PX = 500;
 
 /**
  * Components that can be expanded.
@@ -207,17 +207,180 @@ const buildExpandedViewOverlay = element => htmlFor(element)`
 
 /**
  * Updates embed's corresponding <style> element with embedData.
+ * @param {!Element} target
  * @param {!Element} embedStyleEl
  * @param {!EmbedDataDef} embedData
  */
-function updateEmbedStyleEl(embedStyleEl, embedData) {
+function updateEmbedStyleEl(target, embedStyleEl, embedData) {
   const embedId = embedData.id;
+  embedStyleEl.textContent = `[${EMBED_ID_ATTRIBUTE_NAME}="${embedId}"]
+  ${buildStringStyleFromEl(target, embedData)}`;
+}
 
-  embedStyleEl.textContent = `[${EMBED_ID_ATTRIBUTE_NAME}="${embedId}"] {
-      width: ${px(embedData.width)} !important;
-      transform: ${embedData.transform} !important;
-      margin: 0 ${embedData.horizontalMargin}px !important;
-      }`;
+/**
+ * Builds a string containing the corresponding style depending on the
+ * element.
+ * @param {!Element} target
+ * @param {!EmbedDataDef} embedData
+ * @return {string}
+ */
+function buildStringStyleFromEl(target, embedData) {
+  switch (target.tagName.toLowerCase()) {
+    case EXPANDABLE_COMPONENTS['amp-twitter'].selector:
+      return buildStringStyleForTweet(embedData);
+    default:
+      return buildDefaultStringStyle(embedData);
+  }
+}
+
+/**
+ * Builds string used in the <style> element for tweets.
+ * @param {!EmbedDataDef} embedData
+ * @return {string}
+ */
+function buildStringStyleForTweet(embedData) {
+  return `{
+    width: ${px(embedData.width)} !important;
+    transform: ${embedData.transform} !important;
+    margin: 0 ${embedData.horizontalMargin}px !important;
+    }`;
+}
+
+/**
+ * Builds string used in the <style> element for default embeds.
+ * @param {!EmbedDataDef} embedData
+ * @return {string}
+ */
+function buildDefaultStringStyle(embedData) {
+  return `{
+    width: ${px(embedData.width)} !important;
+    height: ${px(embedData.height)} !important;
+    transform: ${embedData.transform} !important;
+    margin: ${embedData.verticalMargin}px ${
+    embedData.horizontalMargin
+  }px !important;
+    }`;
+}
+
+/**
+ * Measures syles for a given element in preparation for its expanded animation.
+ * @param {!Element} element
+ * @param {!Object} state
+ * @param {!DOMRect} pageRect
+ * @param {!DOMRect} elRect
+ * @return {!Object}
+ */
+function measureStyleForEl(element, state, pageRect, elRect) {
+  switch (element.tagName.toLowerCase()) {
+    case EXPANDABLE_COMPONENTS['amp-twitter'].selector:
+      return measureStylesForTwitter(state, pageRect, elRect);
+    default:
+      return measureDefaultStyles(state, pageRect, elRect);
+  }
+}
+
+/**
+ * Since amp-twitter handles its own resize events for its height, we don't
+ * resize based on its height, but rather just based on its width.
+ * @param {!Object} state
+ * @param {!DOMRect} pageRect
+ * @param {!DOMRect} elRect
+ * @return {!Object}
+ */
+function measureStylesForTwitter(state, pageRect, elRect) {
+  // If screen is very wide and story has supports-landscape attribute,
+  // we don't want it to take the whole width. We take the maximum width
+  // that the tweet can actually use instead.
+  state.newWidth = Math.min(pageRect.width, MAX_TWEET_WIDTH_PX);
+
+  state.scaleFactor =
+    Math.min(elRect.width, MAX_TWEET_WIDTH_PX) / state.newWidth;
+
+  state.horizontalMargin = -1 * ((state.newWidth - elRect.width) / 2);
+
+  return state;
+}
+
+/**
+ * Measures styles for a given element in preparation for its expanded
+ * animation.
+ * @param {!Object} state
+ * @param {!DOMRect} pageRect
+ * @param {!DOMRect} elRect
+ * @return {!Object}
+ */
+function measureDefaultStyles(state, pageRect, elRect) {
+  if (elRect.width >= elRect.height) {
+    state.newWidth = pageRect.width;
+    state.scaleFactor = elRect.width / state.newWidth;
+    state.newHeight = (elRect.height / elRect.width) * state.newWidth;
+  } else {
+    const maxHeight = pageRect.height - VERTICAL_PADDING;
+    state.newWidth = Math.min(
+      (elRect.width / elRect.height) * maxHeight,
+      pageRect.width
+    );
+    state.newHeight = (elRect.height / elRect.width) * state.newWidth;
+    state.scaleFactor = elRect.height / state.newHeight;
+  }
+
+  state.verticalMargin = -1 * ((state.newHeight - elRect.height) / 2);
+  state.horizontalMargin = -1 * ((state.newWidth - elRect.width) / 2);
+
+  return state;
+}
+
+/**
+ * Gets updated style object for a given element.
+ * @param {!Element} element
+ * @param {number} elId
+ * @param {!Object} state
+ * @return {!Object}
+ */
+function updateStyleForEl(element, elId, state) {
+  switch (element.tagName.toLowerCase()) {
+    case EXPANDABLE_COMPONENTS['amp-twitter'].selector:
+      return updateStylesForTwitter(elId, state);
+    default:
+      return updateDefaultStyles(elId, state);
+  }
+}
+
+/**
+ * Gets style object for an embedded component, setting negative margins
+ * to make up for the expanded size in preparation of the expanded animation.
+ * @param {number} elId
+ * @param {!Object} state
+ * @return {!Object}
+ */
+function updateDefaultStyles(elId, state) {
+  return {
+    id: elId,
+    width: state.newWidth,
+    height: state.newHeight,
+    scaleFactor: state.scaleFactor,
+    transform: `scale(${state.scaleFactor})`,
+    verticalMargin: state.verticalMargin,
+    horizontalMargin: state.horizontalMargin,
+  };
+}
+
+/**
+ * Gets style object for twitter. Notice there is no height or vertical margin
+ * since we don't know the final height of tweets even after layout, so we just
+ * let the embed handle its own height.
+ * @param {number} elId
+ * @param {!Object} state
+ * @return {!Object}
+ */
+function updateStylesForTwitter(elId, state) {
+  return {
+    id: elId,
+    width: state.newWidth,
+    scaleFactor: state.scaleFactor,
+    transform: `scale(${state.scaleFactor})`,
+    horizontalMargin: state.horizontalMargin,
+  };
 }
 
 /**
@@ -768,7 +931,11 @@ export class AmpStoryEmbeddedComponent {
     embedStyleEl[
       AMP_EMBED_DATA
     ].transform = `scale(${embedStyleEl[AMP_EMBED_DATA].scaleFactor})`;
-    updateEmbedStyleEl(embedStyleEl, embedStyleEl[AMP_EMBED_DATA]);
+    updateEmbedStyleEl(
+      this.triggeringTarget_,
+      embedStyleEl,
+      embedStyleEl[AMP_EMBED_DATA]
+    );
   }
 
   /**
@@ -827,7 +994,7 @@ export class AmpStoryEmbeddedComponent {
         embedData.transform = `translate3d(${state.translateX}px,
             ${state.translateY}px, 0) scale(${state.scaleFactor})`;
 
-        updateEmbedStyleEl(embedStyleEl, embedData);
+        updateEmbedStyleEl(target, embedStyleEl, embedData);
       }
     );
   }
@@ -856,23 +1023,14 @@ export class AmpStoryEmbeddedComponent {
       embedStyleEl[AMP_EMBED_DATA] = {};
     }
 
-    const state = {};
+    let state = {};
     resources.measureMutateElement(
       element,
       /** measure */
       () => {
         const pageRect = pageEl./*OK*/ getBoundingClientRect();
         const elRect = element./*OK*/ getBoundingClientRect();
-
-        // If screen is very wide and story has supports-landscape attribute,
-        // we don't want it to take the whole width. We take the maximum width
-        // that the embed can actually use instead.
-        state.newWidth = Math.min(pageRect.width, MAX_EMBED_WIDTH_PX);
-
-        state.scaleFactor =
-          Math.min(elRect.width, MAX_EMBED_WIDTH_PX) / state.newWidth;
-
-        state.horizontalMargin = -1 * ((state.newWidth - elRect.width) / 2);
+        state = measureStyleForEl(element, state, pageRect, elRect);
       },
       /** mutate */
       () => {
@@ -891,20 +1049,14 @@ export class AmpStoryEmbeddedComponent {
 
         embedStyleEls[elId][AMP_EMBED_DATA] = Object.assign(
           {},
-          {
-            id: elId,
-            width: state.newWidth,
-            scaleFactor: state.scaleFactor,
-            transform: `scale(${state.scaleFactor})`,
-            horizontalMargin: state.horizontalMargin,
-          }
+          updateStyleForEl(element, elId, state)
         );
 
         const embedStyleEl = dev().assertElement(
           embedStyleEls[elId],
           `Failed to look up embed style element with ID ${elId}`
         );
-        updateEmbedStyleEl(embedStyleEl, embedStyleEl[AMP_EMBED_DATA]);
+        updateEmbedStyleEl(element, embedStyleEl, embedStyleEl[AMP_EMBED_DATA]);
       }
     );
   }

--- a/extensions/amp-story/1.0/amp-story.css
+++ b/extensions/amp-story/1.0/amp-story.css
@@ -364,16 +364,6 @@ amp-story-grid-layer {
   left: 0 !important;
 }
 
-/**
- * Adds a width limit to make sure amp-twitter element only takes required
- * space, otherwise it takes whole width and causes a tooltip trigger in blank
- * space.
- * See #22334
- */
-amp-story-grid-layer amp-twitter {
-  max-width: 500px !important;
-}
-
 amp-story-grid-layer > * {
   pointer-events: auto !important;
 }


### PR DESCRIPTION
Closes #24298
Closes #21724

Since the final height of the tweet is unknown when loading it initially, we should only resize the element's width in preparation for the "expanded" animation. Then, when animating into the "expanded" view, we read the actual height of the element in order to scale it appropriately.

### Before 
(notice cut-off tweets)
![tweet-before-gif](https://user-images.githubusercontent.com/5449100/69179458-90b23300-0ad9-11ea-90b4-cdf42f64b18c.gif)


### After 
![tweet-after-1](https://user-images.githubusercontent.com/5449100/69179495-a0ca1280-0ad9-11ea-9729-a0e7bd48fbb5.gif)

### Landscape 
(notice I'm able to click sides of tweet without blocking navigation)
![landscape-tweet-after](https://user-images.githubusercontent.com/5449100/69179717-f4d4f700-0ad9-11ea-97e1-d67ddbcbd3ec.gif)



