### PR TITLE
✨ Add support for data-ad-host-channel to AdSense ads

### DIFF
--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -323,6 +323,7 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
       'bc': global.SVGElement && global.document.createElementNS ? '1' : null,
       'ctypes': this.getCtypes_(),
       'host': this.element.getAttribute('data-ad-host'),
+      'h_ch': this.element.getAttribute('data-ad-host-channel'),
       'hl': this.element.getAttribute('data-language'),
       'to': this.element.getAttribute('data-tag-origin'),
       'pv': sharedStateParams.pv,

--- a/extensions/amp-auto-ads/0.1/adsense-network-config.js
+++ b/extensions/amp-auto-ads/0.1/adsense-network-config.js
@@ -65,8 +65,14 @@ export class AdSenseNetworkConfig {
       'data-ad-client': this.autoAmpAdsElement_.getAttribute('data-ad-client'),
     });
     const dataAdHost = this.autoAmpAdsElement_.getAttribute('data-ad-host');
+    const dataAdHostChannel = this.autoAmpAdsElement_.getAttribute(
+      'data-ad-host-channel'
+    );
     if (dataAdHost) {
       attributesObj['data-ad-host'] = dataAdHost;
+      if (dataAdHostChannel) {
+        attributesObj['data-ad-host-channel'] = dataAdHostChannel;
+      }
     }
     return attributesObj;
   }

--- a/extensions/amp-auto-ads/0.1/test/test-adsense-network-config.js
+++ b/extensions/amp-auto-ads/0.1/test/test-adsense-network-config.js
@@ -43,6 +43,7 @@ describes.realWin(
     describe('AdSense', () => {
       const AD_CLIENT = 'ca-pub-1234';
       const AD_HOST = 'ca-pub-5678';
+      const AD_HOST_CHANNEL = '987654';
 
       beforeEach(() => {
         ampAutoAdsElem.setAttribute('data-ad-client', AD_CLIENT);
@@ -96,6 +97,26 @@ describes.realWin(
           'data-ad-host': AD_HOST,
         });
         ampAutoAdsElem.removeAttribute('data-ad-host');
+      });
+
+      it('should add data-ad-host-channel to attributes if set on ampAutoAdsElem', () => {
+        ampAutoAdsElem.setAttribute('data-ad-host', AD_HOST);
+        ampAutoAdsElem.setAttribute('data-ad-host-channel', AD_HOST_CHANNEL);
+        const adNetwork = getAdNetworkConfig('adsense', ampAutoAdsElem);
+        expect(adNetwork.getAttributes()).to.deep.equal({
+          'type': 'adsense',
+          'data-ad-client': AD_CLIENT,
+          'data-ad-host': AD_HOST,
+          'data-ad-host-channel': AD_HOST_CHANNEL,
+        });
+      });
+
+      it('should add data-ad-host-channel to attributes only if also data-ad-host is present', () => {
+        ampAutoAdsElem.setAttribute('data-ad-host-channel', AD_HOST_CHANNEL);
+        const adNetwork = getAdNetworkConfig('adsense', ampAutoAdsElem);
+        expect(adNetwork.getAttributes()).to.not.have.property(
+          'data-ad-host-channel'
+        );
       });
 
       it('should get the default ad constraints', () => {


### PR DESCRIPTION
AdSense custom channels allow to track the performance of specific adunits and generate reports for each channel.

AMP currently only supports the data-ad-channel attribute, which allows to specify one or more custom channels for a specific amp-ad element.

Host channels are also available to AdSense Host account, these can be used to track the performance of ads across publishers.

https://developers.google.com/adsense/host/adunits#custom-channels
https://developers.google.com/adsense/host/faq/hostchannels

Currently AMP doesn't allow to specify an Host channel to `amp-ad` elements, this pull request adds support for the `data-ad-host-channel` attribute to both `amp-ad` and `amp-auto-ads` elements.