### PR TITLE
🐛 Possible fix for resizing amp-ad beop

### DIFF
--- a/3p/beopinion.js
+++ b/3p/beopinion.js
@@ -87,10 +87,10 @@ function createContainer(global, data) {
  */
 function getBeOpinionAsyncInit(global, accountId) {
   const {context} = global;
-  context.onResizeDenied(function(requestedHeight, requestedWidth) {
-    context.requestResize(requestedWidth, requestedHeight);
-  });
   return function() {
+    context.onResizeDenied(function(requestedHeight, requestedWidth) {
+      context.requestResize(requestedWidth, requestedHeight);
+    });
     global.BeOpinionSDK.init({
       account: accountId,
       onContentReceive: function(hasContent) {

--- a/3p/beopinion.js
+++ b/3p/beopinion.js
@@ -87,6 +87,9 @@ function createContainer(global, data) {
  */
 function getBeOpinionAsyncInit(global, accountId) {
   const {context} = global;
+  context.onResizeDenied(function(requestedHeight, requestedWidth) {
+    context.requestResize(requestedWidth, requestedHeight);
+  });
   return function() {
     global.BeOpinionSDK.init({
       account: accountId,
@@ -100,7 +103,6 @@ function getBeOpinionAsyncInit(global, accountId) {
       onHeightChange: function(newHeight) {
         const c = global.document.getElementById('c');
         const boundingClientRect = c./*REVIEW*/ getBoundingClientRect();
-        context.onResizeDenied(context.requestResize.bind(context));
         context.requestResize(boundingClientRect.width, newHeight);
       },
     });


### PR DESCRIPTION
It would appear that the confusion would come from the inverted
parameters:

- `requestResize` has (width, height)
- `onResizeDenied` callback has (height, width)

Attaching requestResize to onResizeDenied would invert the height &
width, and given it reads the width from the #c container, mistaking
them results in the resized container to be `InitialHeight x RequestedHeight`.

Took the occasion to only register `onResizeDenied` once instead of
multiple times.

Closes #25687

<!--
# Instructions:

- Pick a meaningful title for your pull request. (Use sentence case.)
  - Prefix the title with an emoji to identify what is being done. (Copy-paste the emoji from the list below.)
  - Do not overuse punctuation in the title (like `(chore):`).
  - If it is helpful, use a simple prefix (like `ProjectX: Implement some feature`).
- Enter a succinct description that says why the PR is necessary, and what it does.
  - Mention the GitHub issue that is being addressed by the pull request.
  - The keywords `Fixes`, `Closes`, or `Resolves` followed the issue number will automatically close the issue.

# Example of a good description:

- Implement aspect X
- Leave out feature Y because of A
- Improve performance by B
- Improve accessibility by C

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Reverting a previous change
♻️ Refactoring
🚮 Deleting code
-->
