### PR TITLE
🐛Use `env.sandbox` in `test-amp-story-embedded-component.js`

### DIFF
--- a/extensions/amp-story/1.0/test/test-amp-story-embedded-component.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-embedded-component.js
@@ -79,7 +79,10 @@ describes.realWin('amp-story-embedded-component', {amp: true}, env => {
       clientY: 50,
     };
 
-    analyticsTriggerStub = sandbox.stub(analyticsApi, 'triggerAnalyticsEvent');
+    analyticsTriggerStub = env.sandbox.stub(
+      analyticsApi,
+      'triggerAnalyticsEvent'
+    );
     storeService = getStoreService(win);
     registerServiceBuilder(win, 'story-store', () => storeService);
   });


### PR DESCRIPTION
Fixes a merge conflict between #25649 and #25587.