### PR TITLE
✨ amp-date-picker: allow to hide keyboard shortcuts panel #25608

### DIFF
--- a/examples/date-picker.amp.html
+++ b/examples/date-picker.amp.html
@@ -334,7 +334,11 @@
     min="2018-12-10" [min]="rangeMin" max="2018-12-20" [max]="rangeMax"
 ></amp-date-picker>
 
-
+<h3>hide keyboard shortcuts panel</h3>
+<amp-date-picker
+    mode="static" type="single" layout="fixed-height" height="360"
+    hide-keyboard-shortcuts-panel
+></amp-date-picker>
 <div class="spacer"></div>
 </body>
 </html>

--- a/extensions/amp-date-picker/0.1/amp-date-picker.js
+++ b/extensions/amp-date-picker/0.1/amp-date-picker.js
@@ -92,7 +92,7 @@ const attributesToForward = [
   'number-of-months',
   'minimum-nights',
   'maximum-nights',
-  'hide-keyboard-shortcuts-panel'
+  'hide-keyboard-shortcuts-panel',
 ];
 
 /** @enum {string} */

--- a/extensions/amp-date-picker/0.1/amp-date-picker.js
+++ b/extensions/amp-date-picker/0.1/amp-date-picker.js
@@ -360,6 +360,9 @@ export class AmpDatePicker extends AMP.BaseElement {
 
     /** @private @const */
     this.warnDaySizeOnce_ = once(this.warnDaySize_.bind(this));
+
+    /** @private */
+    this.hideKeyboardShortcutsPanel_ = false;
   }
 
   /** @override */
@@ -434,6 +437,8 @@ export class AmpDatePicker extends AMP.BaseElement {
     this.openAfterClear_ = this.element.hasAttribute('open-after-clear');
 
     this.openAfterSelect_ = this.element.hasAttribute('open-after-select');
+
+    this.hideKeyboardShortcutsPanel_ = this.element.hasAttribute("hide-keyboard-shortcuts-panel");
 
     this.elementTemplates_ = this.parseElementTemplates_(
       this.element.querySelectorAll('[date-template][dates]')
@@ -1388,7 +1393,8 @@ export class AmpDatePicker extends AMP.BaseElement {
       props.orientation = 'verticalScrollable';
       props.withFullScreenPortal = true;
     }
-
+    
+    props.hideKeyboardShortcutsPanel = this.hideKeyboardShortcutsPanel_;
     props.reopenPickerOnClearDate = this.openAfterClear_;
     props.keepOpenOnDateSelect = this.openAfterSelect_;
 

--- a/extensions/amp-date-picker/0.1/amp-date-picker.js
+++ b/extensions/amp-date-picker/0.1/amp-date-picker.js
@@ -92,6 +92,7 @@ const attributesToForward = [
   'number-of-months',
   'minimum-nights',
   'maximum-nights',
+  'hide-keyboard-shortcuts-panel'
 ];
 
 /** @enum {string} */
@@ -360,9 +361,6 @@ export class AmpDatePicker extends AMP.BaseElement {
 
     /** @private @const */
     this.warnDaySizeOnce_ = once(this.warnDaySize_.bind(this));
-
-    /** @private */
-    this.hideKeyboardShortcutsPanel_ = false;
   }
 
   /** @override */
@@ -437,8 +435,6 @@ export class AmpDatePicker extends AMP.BaseElement {
     this.openAfterClear_ = this.element.hasAttribute('open-after-clear');
 
     this.openAfterSelect_ = this.element.hasAttribute('open-after-select');
-
-    this.hideKeyboardShortcutsPanel_ = this.element.hasAttribute("hide-keyboard-shortcuts-panel");
 
     this.elementTemplates_ = this.parseElementTemplates_(
       this.element.querySelectorAll('[date-template][dates]')
@@ -1393,8 +1389,7 @@ export class AmpDatePicker extends AMP.BaseElement {
       props.orientation = 'verticalScrollable';
       props.withFullScreenPortal = true;
     }
-    
-    props.hideKeyboardShortcutsPanel = this.hideKeyboardShortcutsPanel_;
+
     props.reopenPickerOnClearDate = this.openAfterClear_;
     props.keepOpenOnDateSelect = this.openAfterSelect_;
 

--- a/extensions/amp-date-picker/0.1/test/validator-amp-date-picker.html
+++ b/extensions/amp-date-picker/0.1/test/validator-amp-date-picker.html
@@ -130,6 +130,9 @@
   <!-- Valid: amp-date-picker with allow-blocked-end-date -->
   <amp-date-picker allow-blocked-end-date layout="fixed-height" height="360">
   </amp-date-picker>
+  <!-- Valid: amp-date-picker with hide-keyboard-shortcuts-panel -->
+  <amp-date-picker layout="fixed-height" height="360" hide-keyboard-shortcuts-panel>
+  </amp-date-picker>
 
   <!-- Invalid: single amp-date-picker with start-input-selector -->
   <amp-date-picker type="single" mode="static" start-input-selector="#x3" layout="fixed-height" height="360">

--- a/extensions/amp-date-picker/0.1/test/validator-amp-date-picker.out
+++ b/extensions/amp-date-picker/0.1/test/validator-amp-date-picker.out
@@ -131,101 +131,104 @@ FAIL
 |    <!-- Valid: amp-date-picker with allow-blocked-end-date -->
 |    <amp-date-picker allow-blocked-end-date layout="fixed-height" height="360">
 |    </amp-date-picker>
+|    <!-- Valid: amp-date-picker with hide-keyboard-shortcuts-panel -->
+|    <amp-date-picker layout="fixed-height" height="360" hide-keyboard-shortcuts-panel>
+|    </amp-date-picker>
 |
 |    <!-- Invalid: single amp-date-picker with start-input-selector -->
 |    <amp-date-picker type="single" mode="static" start-input-selector="#x3" layout="fixed-height" height="360">
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:135:2 The attribute 'type' in tag 'amp-date-picker[type=range][mode=static]' is set to the invalid value 'single'. (see https://amp.dev/documentation/components/amp-date-picker)
+amp-date-picker/0.1/test/validator-amp-date-picker.html:138:2 The attribute 'type' in tag 'amp-date-picker[type=range][mode=static]' is set to the invalid value 'single'. (see https://amp.dev/documentation/components/amp-date-picker)
 |    </amp-date-picker>
 |    <!-- Invalid: range amp-date-picker with input-selector -->
 |    <amp-date-picker type="range" input-selector="#a4" layout="fixed-height" height="360">
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:138:2 The attribute 'type' in tag 'amp-date-picker[type=single][mode=static]' is set to the invalid value 'range'. (see https://amp.dev/documentation/components/amp-date-picker)
+amp-date-picker/0.1/test/validator-amp-date-picker.html:141:2 The attribute 'type' in tag 'amp-date-picker[type=single][mode=static]' is set to the invalid value 'range'. (see https://amp.dev/documentation/components/amp-date-picker)
 |      </amp-date-picker>
 |    <!-- Invalid: amp-date-picker with implicit mode="static" without layout -->
 |    <amp-date-picker></amp-date-picker>
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:141:2 Incomplete layout attributes specified for tag 'amp-date-picker[type=single][mode=static]'. For example, provide attributes 'width' and 'height'. (see https://amp.dev/documentation/components/amp-date-picker)
+amp-date-picker/0.1/test/validator-amp-date-picker.html:144:2 Incomplete layout attributes specified for tag 'amp-date-picker[type=single][mode=static]'. For example, provide attributes 'width' and 'height'. (see https://amp.dev/documentation/components/amp-date-picker)
 |    <!-- Invalid: amp-date-picker with explicit mode="static" without layout -->
 |    <amp-date-picker mode="static">
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:143:2 Incomplete layout attributes specified for tag 'amp-date-picker[type=single][mode=static]'. For example, provide attributes 'width' and 'height'. (see https://amp.dev/documentation/components/amp-date-picker)
+amp-date-picker/0.1/test/validator-amp-date-picker.html:146:2 Incomplete layout attributes specified for tag 'amp-date-picker[type=single][mode=static]'. For example, provide attributes 'width' and 'height'. (see https://amp.dev/documentation/components/amp-date-picker)
 |    </amp-date-picker>
 |    <!-- Invalid: overlay amp-date-picker with fullscreen attribute -->
 |    <amp-date-picker mode="overlay" fullscreen>
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:146:2 The attribute 'fullscreen' may not appear in tag 'amp-date-picker[type=single][mode=overlay]'. (see https://amp.dev/documentation/components/amp-date-picker)
+amp-date-picker/0.1/test/validator-amp-date-picker.html:149:2 The attribute 'fullscreen' may not appear in tag 'amp-date-picker[type=single][mode=overlay]'. (see https://amp.dev/documentation/components/amp-date-picker)
 |      <input type="text" name="date4">
 |    </amp-date-picker>
 |    <!-- Invalid: width is mistyped. -->
 |    <amp-date-picker height="360" wdith="360">
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:150:2 The attribute 'wdith' may not appear in tag 'amp-date-picker[type=single][mode=static]'. (see https://amp.dev/documentation/components/amp-date-picker)
+amp-date-picker/0.1/test/validator-amp-date-picker.html:153:2 The attribute 'wdith' may not appear in tag 'amp-date-picker[type=single][mode=static]'. (see https://amp.dev/documentation/components/amp-date-picker)
 |    </amp-date-picker>
 |    <!-- Invalid: amp-date-picker with bad day-size-->
 |    <amp-date-picker type="range" layout="fixed-height" height="360"
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:153:2 The attribute 'day-size' in tag 'amp-date-picker[type=range][mode=static]' is set to the invalid value 'five'. (see https://amp.dev/documentation/components/amp-date-picker)
+amp-date-picker/0.1/test/validator-amp-date-picker.html:156:2 The attribute 'day-size' in tag 'amp-date-picker[type=range][mode=static]' is set to the invalid value 'five'. (see https://amp.dev/documentation/components/amp-date-picker)
 |        day-size="five">
 |    </amp-date-picker>
 |    <!-- Invalid: amp-date-picker with bad number-of-months -->
 |    <amp-date-picker type="range" layout="fixed-height" height="360"
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:157:2 The attribute 'number-of-months' in tag 'amp-date-picker[type=range][mode=static]' is set to the invalid value 'twele'. (see https://amp.dev/documentation/components/amp-date-picker)
+amp-date-picker/0.1/test/validator-amp-date-picker.html:160:2 The attribute 'number-of-months' in tag 'amp-date-picker[type=range][mode=static]' is set to the invalid value 'twele'. (see https://amp.dev/documentation/components/amp-date-picker)
 |        number-of-months="twele">
 |    </amp-date-picker>
 |    <!-- Invalid: amp-date-picker with bad first-day-of-week -->
 |    <amp-date-picker type="range" layout="fixed-height" height="360"
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:161:2 The attribute 'first-day-of-week' in tag 'amp-date-picker[type=range][mode=static]' is set to the invalid value '7'. (see https://amp.dev/documentation/components/amp-date-picker)
+amp-date-picker/0.1/test/validator-amp-date-picker.html:164:2 The attribute 'first-day-of-week' in tag 'amp-date-picker[type=range][mode=static]' is set to the invalid value '7'. (see https://amp.dev/documentation/components/amp-date-picker)
 |        first-day-of-week="7">
 |    </amp-date-picker>
 |    <!-- Invalid: amp-date-picker templates outside amp-date-picker -->
 |    <template info-template type="amp-mustache"></template>
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:165:2 The parent tag of tag 'amp-date-picker > template [info-template]' is 'body', but it can only be 'amp-date-picker'. (see https://amp.dev/documentation/components/amp-mustache)
+amp-date-picker/0.1/test/validator-amp-date-picker.html:168:2 The parent tag of tag 'amp-date-picker > template [info-template]' is 'body', but it can only be 'amp-date-picker'. (see https://amp.dev/documentation/components/amp-mustache)
 |    <template date-template dates="2018-01-01" type="amp-mustache"></template>
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:166:2 The parent tag of tag 'amp-date-picker > template [date-template]' is 'body', but it can only be 'amp-date-picker'. (see https://amp.dev/documentation/components/amp-mustache)
+amp-date-picker/0.1/test/validator-amp-date-picker.html:169:2 The parent tag of tag 'amp-date-picker > template [date-template]' is 'body', but it can only be 'amp-date-picker'. (see https://amp.dev/documentation/components/amp-mustache)
 |    <!-- Invalid: amp-date-picker with bad maximum nights -->
 |    <amp-date-picker type="range" layout="fixed-height" height="360" maximum-nights="zero">
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:168:2 The attribute 'maximum-nights' in tag 'amp-date-picker[type=range][mode=static]' is set to the invalid value 'zero'. (see https://amp.dev/documentation/components/amp-date-picker)
+amp-date-picker/0.1/test/validator-amp-date-picker.html:171:2 The attribute 'maximum-nights' in tag 'amp-date-picker[type=range][mode=static]' is set to the invalid value 'zero'. (see https://amp.dev/documentation/components/amp-date-picker)
 |    </amp-date-picker>
 |    <!-- Invalid: amp-date-picker with bad minimum nights -->
 |    <amp-date-picker type="range" layout="fixed-height" height="360" minimum-nights="zero">
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:171:2 The attribute 'minimum-nights' in tag 'amp-date-picker[type=range][mode=static]' is set to the invalid value 'zero'. (see https://amp.dev/documentation/components/amp-date-picker)
+amp-date-picker/0.1/test/validator-amp-date-picker.html:174:2 The attribute 'minimum-nights' in tag 'amp-date-picker[type=range][mode=static]' is set to the invalid value 'zero'. (see https://amp.dev/documentation/components/amp-date-picker)
 |    </amp-date-picker>
 |    <!-- Invalid: single amp-date-picker with maximum nights -->
 |    <amp-date-picker layout="fixed-height" height="360" maximum-nights="0">
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:174:2 The mandatory attribute 'type' is missing in tag 'amp-date-picker[type=range][mode=static]'. (see https://amp.dev/documentation/components/amp-date-picker)
+amp-date-picker/0.1/test/validator-amp-date-picker.html:177:2 The mandatory attribute 'type' is missing in tag 'amp-date-picker[type=range][mode=static]'. (see https://amp.dev/documentation/components/amp-date-picker)
 |    </amp-date-picker>
 |    <!-- Invalid: single amp-date-picker with minimum nights -->
 |    <amp-date-picker layout="fixed-height" height="360" minimum-nights="0">
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:177:2 The mandatory attribute 'type' is missing in tag 'amp-date-picker[type=range][mode=static]'. (see https://amp.dev/documentation/components/amp-date-picker)
+amp-date-picker/0.1/test/validator-amp-date-picker.html:180:2 The mandatory attribute 'type' is missing in tag 'amp-date-picker[type=range][mode=static]'. (see https://amp.dev/documentation/components/amp-date-picker)
 |    </amp-date-picker>
 |    <!-- Invalid: single amp-date-picker with start-date attribute -->
 |    <amp-date-picker layout="fixed-height" height="360" start-date="2018-01-01">
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:180:2 The mandatory attribute 'type' is missing in tag 'amp-date-picker[type=range][mode=static]'. (see https://amp.dev/documentation/components/amp-date-picker)
+amp-date-picker/0.1/test/validator-amp-date-picker.html:183:2 The mandatory attribute 'type' is missing in tag 'amp-date-picker[type=range][mode=static]'. (see https://amp.dev/documentation/components/amp-date-picker)
 |    </amp-date-picker>
 |    <!-- Invalid: range amp-date-picker with date attribute -->
 |    <amp-date-picker type="range" layout="fixed-height" height="360" date="2018-01-01">
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:183:2 The attribute 'type' in tag 'amp-date-picker[type=single][mode=static]' is set to the invalid value 'range'. (see https://amp.dev/documentation/components/amp-date-picker)
+amp-date-picker/0.1/test/validator-amp-date-picker.html:186:2 The attribute 'type' in tag 'amp-date-picker[type=single][mode=static]' is set to the invalid value 'range'. (see https://amp.dev/documentation/components/amp-date-picker)
 |    </amp-date-picker>
 |    <!-- Invalid: static amp-date-picker with touch-keyboard-editable -->
 |    <amp-date-picker layout="fixed-height" height="360" touch-keyboard-editable>
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:186:2 The attribute 'touch-keyboard-editable' may not appear in tag 'amp-date-picker[type=single][mode=static]'. (see https://amp.dev/documentation/components/amp-date-picker)
+amp-date-picker/0.1/test/validator-amp-date-picker.html:189:2 The attribute 'touch-keyboard-editable' may not appear in tag 'amp-date-picker[type=single][mode=static]'. (see https://amp.dev/documentation/components/amp-date-picker)
 |    </amp-date-picker>
 |    <!-- Invalid: amp-date-picker with http src -->
 |    <amp-date-picker layout="fixed-height" height="360"
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:189:2 Invalid URL protocol 'http:' for attribute 'src' in tag 'amp-date-picker[type=single][mode=static]'. (see https://amp.dev/documentation/components/amp-date-picker)
+amp-date-picker/0.1/test/validator-amp-date-picker.html:192:2 Invalid URL protocol 'http:' for attribute 'src' in tag 'amp-date-picker[type=single][mode=static]'. (see https://amp.dev/documentation/components/amp-date-picker)
 |        src="http://data.com/dates.json?ref=CANONICAL_URL">
 |    </amp-date-picker>
 |  </body>

--- a/extensions/amp-date-picker/amp-date-picker.md
+++ b/extensions/amp-date-picker/amp-date-picker.md
@@ -560,6 +560,11 @@ If present, keeps the date picker overlay open after the user selects a date or 
 
 If present, keeps the date picker open after the user clears the date or dates. By default, this attribute is not present.
 
+
+##### hide-keyboard-shortcuts-panel
+
+If present, hides the keyboard shortcuts panel at the bottom of the picker. By default, this attribute is not present.
+
 ##### common attributes
 
 This element includes [common attributes](https://amp.dev/documentation/guides-and-tutorials/learn/common_attributes) extended to AMP components.

--- a/extensions/amp-date-picker/amp-date-picker.md
+++ b/extensions/amp-date-picker/amp-date-picker.md
@@ -560,7 +560,6 @@ If present, keeps the date picker overlay open after the user selects a date or 
 
 If present, keeps the date picker open after the user clears the date or dates. By default, this attribute is not present.
 
-
 ##### hide-keyboard-shortcuts-panel
 
 If present, hides the keyboard shortcuts panel at the bottom of the picker. By default, this attribute is not present.

--- a/extensions/amp-date-picker/validator-amp-date-picker.protoascii
+++ b/extensions/amp-date-picker/validator-amp-date-picker.protoascii
@@ -171,6 +171,10 @@ attr_lists: {
     value: ""
   }
   attrs: {
+    name: "hide-keyboard-shortcuts-panel"
+    value: ""
+  }
+  attrs: {
     name: "src"
     value_url: {
       protocol: "https"


### PR DESCRIPTION
Implements `hideKeyboardShortcutsPanel` on amp-date-picker. Fixes #25608

/cc @caroqliu 