### PR TITLE
🐛Allow zero vals for in validateData

### DIFF
--- a/3p/3p.js
+++ b/3p/3p.js
@@ -232,7 +232,8 @@ export function validateData(data, mandatoryFields, opt_optionalFields) {
       allowedFields = allowedFields.concat(field);
     } else {
       userAssert(
-        data[field],
+        // Allow zero values for height, width etc.
+        data[field] != null,
         'Missing attribute for %s: %s.',
         data.type,
         field

--- a/test/unit/test-3p.js
+++ b/test/unit/test-3p.js
@@ -126,6 +126,17 @@ describe('3p', () => {
       });
     });
 
+    it('should allow mandatory fields to have 0 as a value', () => {
+      validateData(
+        {
+          width: 0,
+          height: 0,
+          type: 'cats',
+        },
+        ['height', 'width']
+      );
+    });
+
     it('should check mandatory fields with alternative options', () => {
       validateData(
         {


### PR DESCRIPTION
Ads use `validateData` to ensure required attributes exist. In #24850 we recommended creating an ad with `0` height and requesting resize. This did not work as expected. While debugging I discovered `validateData` will reject attributes with zero values even though they should be valid.

This is because it calls `userAssert` which checks for falsey values here https://github.com/ampproject/amphtml/blob/5f7a03d369d3cc76c5c0efb6647e94269b6225d1/src/log.js#L404

This changes the check to  `val != null`.