### PR TITLE
✨🐛 Scroll return button on docked video ad

### DIFF
--- a/extensions/amp-video-docking/0.1/amp-video-docking.css
+++ b/extensions/amp-video-docking/0.1/amp-video-docking.css
@@ -32,17 +32,21 @@
   margin: -20px 0 0 -60px;
 }
 
+.amp-large > .amp-video-docked-main-button-group {
+  margin-left: -70px;
+}
+
+.amp-large > .amp-video-docked-main-button-group >
+    .amp-video-docked-button-group {
+  margin-right: 10px;
+}
+
 /* large/small breakpoints shouldn't affect this set, so we specify for both. */
 .amp-large > .amp-video-docked-set-scroll-back,
 .amp-small > .amp-video-docked-set-scroll-back {
   /* Container is dynamically centered at corner. Offset by -50% in horizontal
   axis to properly center (holds a single 64px wide button). */
   margin-left: -32px;
-}
-
-.amp-large > .amp-video-docked-set-scroll-back >
-    .amp-video-docked-button-group {
-  margin-right: 10px;
 }
 
 .amp-large > .amp-video-docked-set-scroll-back >

--- a/extensions/amp-video-docking/0.1/amp-video-docking.css
+++ b/extensions/amp-video-docking/0.1/amp-video-docking.css
@@ -42,14 +42,14 @@
 }
 
 /* large/small breakpoints shouldn't affect this set, so we specify for both. */
-.amp-large > .amp-video-docked-set-scroll-back,
-.amp-small > .amp-video-docked-set-scroll-back {
+.amp-large > .amp-video-docked-control-set-scroll-back,
+.amp-small > .amp-video-docked-control-set-scroll-back {
   /* Container is dynamically centered at corner. Offset by -50% in horizontal
   axis to properly center (holds a single 64px wide button). */
   margin-left: -32px;
 }
 
-.amp-large > .amp-video-docked-set-scroll-back >
+.amp-large > .amp-video-docked-control-set-scroll-back >
     .amp-video-docked-button-group {
   /* Reset margin since this set only holds one button. */
   margin-right: 0;
@@ -153,8 +153,8 @@
   background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg width='40' height='40' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cpath d='M-4-4h48v48H-4z'/%3E%3Cpath d='M36 0c2.2 0 4 1.8 4 4v24c0 2.2-1.8 4-4 4H12c-2.2 0-4-1.8-4-4V4c0-2.2 1.8-4 4-4h24zM16 11.868l12.618 12.618 2.829-2.828L18.789 9H27V5H12v15h4v-8.132zM4 8H0v28c0 2.2 1.8 4 4 4h28v-4H4V8z' fill='%23000' fill-rule='nonzero'/%3E%3C/g%3E%3C/svg%3E");
 }
 
-.amp-video-docked-set-scroll-back > .amp-video-docked-button-group,
-.amp-video-docked-set-scroll-back > .amp-video-docked-button-group > div[role=button] {
+.amp-video-docked-control-set-scroll-back > .amp-video-docked-button-group,
+.amp-video-docked-control-set-scroll-back > .amp-video-docked-button-group > div[role=button] {
   min-width: 64px;
   height: 64px;
 }

--- a/extensions/amp-video-docking/0.1/amp-video-docking.css
+++ b/extensions/amp-video-docking/0.1/amp-video-docking.css
@@ -32,13 +32,23 @@
   margin: -20px 0 0 -60px;
 }
 
-.amp-large > .amp-video-docked-main-button-group {
-  margin-left: -70px;
+/* large/small breakpoints shouldn't affect this set, so we specify for both. */
+.amp-large > .amp-video-docked-set-scroll-back,
+.amp-small > .amp-video-docked-set-scroll-back {
+  /* Container is dynamically centered at corner. Offset by -50% in horizontal
+  axis to properly center (holds a single 64px wide button). */
+  margin-left: -32px;
 }
 
-.amp-large > .amp-video-docked-main-button-group >
+.amp-large > .amp-video-docked-set-scroll-back >
     .amp-video-docked-button-group {
   margin-right: 10px;
+}
+
+.amp-large > .amp-video-docked-set-scroll-back >
+    .amp-video-docked-button-group {
+  /* Reset margin since this set only holds one button. */
+  margin-right: 0;
 }
 
 .amp-large > .amp-video-docked-button-dismiss-group {
@@ -59,7 +69,6 @@
      margin to compensate. */
   margin-left: 8px;
 }
-
 
 .amp-video-docked-controls-shown {
   opacity: 1;
@@ -128,6 +137,22 @@
 
 .amp-video-docked-dismiss {
   background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24'%3E%3Cpath d='M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z'/%3E%3Cpath d='M0 0h24v24H0z' fill='none'/%3E%3C/svg%3E");
+}
+
+.amp-video-docked-scroll-back {
+  background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg width='40' height='40' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cpath d='M-4-4h48v48H-4z'/%3E%3Cpath d='M36 0c2.2 0 4 1.8 4 4v24c0 2.2-1.8 4-4 4H12c-2.2 0-4-1.8-4-4V4c0-2.2 1.8-4 4-4h24zM16 11.868l12.618 12.618 2.829-2.828L18.789 9H27V5H12v15h4v-8.132zM4 8H0v28c0 2.2 1.8 4 4 4h28v-4H4V8z' fill='%23000' fill-rule='nonzero'/%3E%3C/g%3E%3C/svg%3E");
+  background-size: 50%; /* 🤷🏻‍♂️ */
+}
+
+.amp-rtl .amp-video-docked-scroll-back {
+  /* opposite direction of icon arrow */
+  background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg width='40' height='40' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cpath d='M-4-4h48v48H-4z'/%3E%3Cpath d='M36 0c2.2 0 4 1.8 4 4v24c0 2.2-1.8 4-4 4H12c-2.2 0-4-1.8-4-4V4c0-2.2 1.8-4 4-4h24zM16 11.868l12.618 12.618 2.829-2.828L18.789 9H27V5H12v15h4v-8.132zM4 8H0v28c0 2.2 1.8 4 4 4h28v-4H4V8z' fill='%23000' fill-rule='nonzero'/%3E%3C/g%3E%3C/svg%3E");
+}
+
+.amp-video-docked-set-scroll-back > .amp-video-docked-button-group,
+.amp-video-docked-set-scroll-back > .amp-video-docked-button-group > div[role=button] {
+  min-width: 64px;
+  height: 64px;
 }
 
 .amp-video-docked-shadow,

--- a/extensions/amp-video-docking/0.1/amp-video-docking.css
+++ b/extensions/amp-video-docking/0.1/amp-video-docking.css
@@ -150,6 +150,9 @@
 
 .amp-rtl .amp-video-docked-scroll-back {
   /* opposite direction of icon arrow */
+  /* TODO(alanorozco): Might not be worth it to keep a horizontally asymmetrical 
+     icon for a simple drop shadow, consider removing drop shadow and use a
+     horizontal flip CSS transform instead of another SVG definition here. */
   background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg width='40' height='40' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cpath d='M-4-4h48v48H-4z'/%3E%3Cpath d='M36 0c2.2 0 4 1.8 4 4v24c0 2.2-1.8 4-4 4H12c-2.2 0-4-1.8-4-4V4c0-2.2 1.8-4 4-4h24zM16 11.868l12.618 12.618 2.829-2.828L18.789 9H27V5H12v15h4v-8.132zM4 8H0v28c0 2.2 1.8 4 4 4h28v-4H4V8z' fill='%23000' fill-rule='nonzero'/%3E%3C/g%3E%3C/svg%3E");
 }
 

--- a/extensions/amp-video-docking/0.1/amp-video-docking.js
+++ b/extensions/amp-video-docking/0.1/amp-video-docking.js
@@ -1104,8 +1104,6 @@ export class VideoDocking {
 
     const {element} = video;
 
-    const controls = this.getControls_();
-
     const internalElement = getInternalVideoElementFor(element);
     const shadowLayer = this.getShadowLayer_();
     const {overlay} = this.getControls_();
@@ -1122,7 +1120,7 @@ export class VideoDocking {
       );
 
       placeholderIcon.classList.toggle('amp-rtl', isPlacementRtl);
-      controls.container.classList.toggle('amp-rtl', isPlacementRtl);
+      this.getControls_().container.classList.toggle('amp-rtl', isPlacementRtl);
     }
 
     // Setting explicit dimensions is needed to match the video's aspect

--- a/extensions/amp-video-docking/0.1/amp-video-docking.js
+++ b/extensions/amp-video-docking/0.1/amp-video-docking.js
@@ -536,6 +536,10 @@ export class VideoDocking {
       this.dismissOnTap_();
     });
 
+    listen(container, VideoDockingEvents.SCROLL_BACK, () => {
+      this.scrollBack_();
+    });
+
     this.addDragListeners_(container);
     this.addDragListeners_(overlay);
 
@@ -1100,6 +1104,8 @@ export class VideoDocking {
 
     const {element} = video;
 
+    const controls = this.getControls_();
+
     const internalElement = getInternalVideoElementFor(element);
     const shadowLayer = this.getShadowLayer_();
     const {overlay} = this.getControls_();
@@ -1116,6 +1122,7 @@ export class VideoDocking {
       );
 
       placeholderIcon.classList.toggle('amp-rtl', isPlacementRtl);
+      controls.container.classList.toggle('amp-rtl', isPlacementRtl);
     }
 
     // Setting explicit dimensions is needed to match the video's aspect
@@ -1953,6 +1960,22 @@ export class VideoDocking {
       return;
     }
     removeElement(el);
+  }
+
+  /**
+   * Scrolls the document back to the video's inline position.
+   * @private
+   */
+  scrollBack_() {
+    if (!this.currentlyDocked_) {
+      return;
+    }
+    // Don't set curve or duration, rely on Viewport service to determine best
+    // transition time depending on scroll Δ.
+    this.viewport_.animateScrollIntoView(
+      this.getDockedVideo_().element,
+      'center'
+    );
   }
 }
 

--- a/extensions/amp-video-docking/0.1/amp-video-docking.js
+++ b/extensions/amp-video-docking/0.1/amp-video-docking.js
@@ -1965,8 +1965,8 @@ export class VideoDocking {
     if (!this.currentlyDocked_) {
       return;
     }
-    // Don't set curve or duration, rely on Viewport service to determine best
-    // transition time depending on scroll Δ.
+    // Don't set duration or curve.
+    // Rely on Viewport service to determine timing based on scroll Δ.
     this.viewport_.animateScrollIntoView(
       this.getDockedVideo_().element,
       'center'

--- a/extensions/amp-video-docking/0.1/amp-video-docking.js
+++ b/extensions/amp-video-docking/0.1/amp-video-docking.js
@@ -1962,10 +1962,7 @@ export class VideoDocking {
     removeElement(el);
   }
 
-  /**
-   * Scrolls the document back to the video's inline position.
-   * @private
-   */
+  /** @private */
   scrollBack_() {
     if (!this.currentlyDocked_) {
       return;

--- a/extensions/amp-video-docking/0.1/controls.js
+++ b/extensions/amp-video-docking/0.1/controls.js
@@ -44,7 +44,7 @@ import {
  * e.g. `PLAYBACK: 'playback'` gets `amp-video-docked-set-playback`
  * @enum {string}
  */
-const ControlsSet = {
+const ControlSet = {
   // Playback buttons like play/pause, mute and fullscreen.
   PLAYBACK: 'playback',
 
@@ -201,7 +201,7 @@ export class Controls {
     this.dismissContainer_ = assertRef('dismissContainer');
 
     /** @private @const {!NodeList} */
-    this.controlsSets_ = this.container.querySelectorAll(
+    this.controlSets_ = this.container.querySelectorAll(
       '.amp-video-docked-main-button-group'
     );
 
@@ -263,14 +263,14 @@ export class Controls {
 
   /**
    * Sets displayed controls set.
-   * @param {ControlsSet} setName
+   * @param {ControlSet} setName
    * @private
    */
-  useControlsSet_(setName) {
+  useControlSet_(setName) {
     const activeClassname = `amp-video-docked-set-${setName}`;
 
-    iterateCursor(this.controlsSets_, controlsSet => {
-      toggle(controlsSet, controlsSet.classList.contains(activeClassname));
+    iterateCursor(this.controlSets_, controlSet => {
+      toggle(controlSet, controlSet.classList.contains(activeClassname));
     });
   }
 
@@ -324,11 +324,11 @@ export class Controls {
       listen(element, VideoEvents.UNMUTED, () => this.onUnmute_()),
 
       listen(element, VideoEvents.AD_START, () =>
-        this.useControlsSet_(ControlsSet.SCROLL_BACK)
+        this.useControlSet_(ControlSet.SCROLL_BACK)
       ),
 
       listen(element, VideoEvents.AD_END, () =>
-        this.useControlsSet_(ControlsSet.PLAYBACK)
+        this.useControlSet_(ControlSet.PLAYBACK)
       )
     );
   }
@@ -506,9 +506,9 @@ export class Controls {
    * @public
    */
   hide(opt_respectSticky, opt_immediately) {
-    const ampVideoDockedControlsShown = 'amp-video-docked-controls-shown';
+    const ampVideoDockedControlShown = 'amp-video-docked-controls-shown';
     const {container, overlay} = this;
-    if (!container.classList.contains(ampVideoDockedControlsShown)) {
+    if (!container.classList.contains(ampVideoDockedControlShown)) {
       return;
     }
     if (opt_respectSticky && this.isSticky_) {
@@ -519,7 +519,7 @@ export class Controls {
       toggle(overlay, false);
     }
     overlay.classList.remove('amp-video-docked-controls-bg');
-    container.classList.remove(ampVideoDockedControlsShown);
+    container.classList.remove(ampVideoDockedControlShown);
   }
 
   /** @private */

--- a/extensions/amp-video-docking/0.1/controls.js
+++ b/extensions/amp-video-docking/0.1/controls.js
@@ -140,7 +140,7 @@ const renderControls = html =>
         <div class="amp-video-docked-button-group">
           <div
             role="button"
-            ref="scrollReturnButton"
+            ref="scrollBackButton"
             class="amp-video-docked-scroll-back"
           ></div>
         </div>
@@ -195,7 +195,7 @@ export class Controls {
     this.fullscreenButton_ = assertRef('fullscreenButton');
 
     /** @private @const {!Element} */
-    this.scrollReturnButton_ = assertRef('scrollReturnButton');
+    this.scrollBackButton_ = assertRef('scrollBackButton');
 
     /** @private @const {!Element} */
     this.dismissContainer_ = assertRef('dismissContainer');
@@ -310,7 +310,7 @@ export class Controls {
         video.fullscreenEnter();
       }),
 
-      this.listenWhenEnabled_(this.scrollReturnButton_, click, () => {
+      this.listenWhenEnabled_(this.scrollBackButton_, click, () => {
         this.dispatch_(VideoDockingEvents.SCROLL_BACK);
       }),
 

--- a/extensions/amp-video-docking/0.1/controls.js
+++ b/extensions/amp-video-docking/0.1/controls.js
@@ -456,7 +456,7 @@ export class Controls {
    * @param {number} height
    */
   positionOnVsync(scale, x, y, width, height) {
-    this.area_ = layoutRectLtwh(x, y, width, height);
+    this.area_ = layoutRectLtwh(x, y, width * scale, height * scale);
 
     const {container} = this;
     const halfScale = scale / 2;

--- a/extensions/amp-video-docking/0.1/controls.js
+++ b/extensions/amp-video-docking/0.1/controls.js
@@ -506,9 +506,9 @@ export class Controls {
    * @public
    */
   hide(opt_respectSticky, opt_immediately) {
-    const ampVideoDockedControlShown = 'amp-video-docked-controls-shown';
+    const ampVideoDockedControlsShown = 'amp-video-docked-controls-shown';
     const {container, overlay} = this;
-    if (!container.classList.contains(ampVideoDockedControlShown)) {
+    if (!container.classList.contains(ampVideoDockedControlsShown)) {
       return;
     }
     if (opt_respectSticky && this.isSticky_) {
@@ -519,7 +519,7 @@ export class Controls {
       toggle(overlay, false);
     }
     overlay.classList.remove('amp-video-docked-controls-bg');
-    container.classList.remove(ampVideoDockedControlShown);
+    container.classList.remove(ampVideoDockedControlsShown);
   }
 
   /** @private */

--- a/extensions/amp-video-docking/0.1/controls.js
+++ b/extensions/amp-video-docking/0.1/controls.js
@@ -40,8 +40,8 @@ import {
  * A single controls set can be displayed at a time on the controls layer.
  *
  * These map to their displayable classname portion in the format
- * `amp-video-docked-set-${NAME}`
- * e.g. `PLAYBACK: 'playback'` gets `amp-video-docked-set-playback`
+ * `amp-video-docked-control-set-${NAME}`
+ * e.g. `PLAYBACK: 'playback'` gets `amp-video-docked-control-set-playback`
  * @enum {string}
  */
 const ControlSet = {
@@ -98,7 +98,7 @@ const renderControls = html =>
     <div class="amp-video-docked-controls" hidden>
       <div
         class="amp-video-docked-main-button-group
-               amp-video-docked-set-playback"
+               amp-video-docked-control-set-playback"
       >
         <div class="amp-video-docked-button-group">
           <div
@@ -134,7 +134,7 @@ const renderControls = html =>
       </div>
       <div
         class="amp-video-docked-main-button-group
-               amp-video-docked-set-scroll-back"
+               amp-video-docked-control-set-scroll-back"
         hidden
       >
         <div class="amp-video-docked-button-group">
@@ -267,7 +267,7 @@ export class Controls {
    * @private
    */
   useControlSet_(setName) {
-    const activeClassname = `amp-video-docked-set-${setName}`;
+    const activeClassname = `amp-video-docked-control-set-${setName}`;
 
     iterateCursor(this.controlSets_, controlSet => {
       toggle(controlSet, controlSet.classList.contains(activeClassname));

--- a/extensions/amp-video-docking/0.1/controls.js
+++ b/extensions/amp-video-docking/0.1/controls.js
@@ -98,8 +98,7 @@ const renderControls = html =>
     <div class="amp-video-docked-controls" hidden>
       <div
         class="amp-video-docked-main-button-group
-               amp-video-docked-set-playback
-               i-amphtml-video-docked-set"
+               amp-video-docked-set-playback"
       >
         <div class="amp-video-docked-button-group">
           <div
@@ -135,8 +134,7 @@ const renderControls = html =>
       </div>
       <div
         class="amp-video-docked-main-button-group
-               amp-video-docked-set-scroll-back
-               i-amphtml-video-docked-set"
+               amp-video-docked-set-scroll-back"
         hidden
       >
         <div class="amp-video-docked-button-group">
@@ -204,7 +202,7 @@ export class Controls {
 
     /** @private @const {!NodeList} */
     this.controlsSets_ = this.container.querySelectorAll(
-      '.i-amphtml-video-docked-set'
+      '.amp-video-docked-main-button-group'
     );
 
     /** @private {boolean} */

--- a/extensions/amp-video-docking/0.1/controls.js
+++ b/extensions/amp-video-docking/0.1/controls.js
@@ -20,10 +20,14 @@ import {Services} from '../../../src/services';
 import {Timeout} from './timeout';
 import {VideoDockingEvents, pointerCoords} from './events';
 import {applyBreakpointClassname} from './breakpoints';
-import {closestAncestorElementBySelector} from '../../../src/dom';
+import {
+  closestAncestorElementBySelector,
+  iterateCursor,
+} from '../../../src/dom';
 import {createCustomEvent, listen} from '../../../src/event-helper';
 import {dev, devAssert} from '../../../src/log';
 import {htmlFor, htmlRefs} from '../../../src/static-template';
+import {layoutRectLtwh} from '../../../src/layout-rect';
 import {once} from '../../../src/utils/function';
 import {
   resetStyles,
@@ -32,7 +36,22 @@ import {
   translate,
 } from '../../../src/style';
 
-const TAG = 'amp-video-docking-controls';
+/**
+ * A single controls set can be displayed at a time on the controls layer.
+ *
+ * These map to their displayable classname portion in the format
+ * `amp-video-docked-set-${NAME}`
+ * e.g. `PLAYBACK: 'playback'` gets `amp-video-docked-set-playback`
+ * @enum {string}
+ */
+const ControlsSet = {
+  // Playback buttons like play/pause, mute and fullscreen.
+  PLAYBACK: 'playback',
+
+  // Single button to scroll back to inline position of the component. Displayed
+  // during ad playback for CTA interaction.
+  SCROLL_BACK: 'scroll-back',
+};
 
 /** @private @const {!Array<!./breakpoints.SyntheticBreakpointDef>} */
 const BREAKPOINTS = [
@@ -77,7 +96,11 @@ const renderDockedOverlay = html =>
 const renderControls = html =>
   html`
     <div class="amp-video-docked-controls" hidden>
-      <div class="amp-video-docked-main-button-group">
+      <div
+        class="amp-video-docked-main-button-group
+               amp-video-docked-set-playback
+               i-amphtml-video-docked-set"
+      >
         <div class="amp-video-docked-button-group">
           <div
             role="button"
@@ -107,6 +130,20 @@ const renderControls = html =>
             role="button"
             ref="fullscreenButton"
             class="amp-video-docked-fullscreen"
+          ></div>
+        </div>
+      </div>
+      <div
+        class="amp-video-docked-main-button-group
+               amp-video-docked-set-scroll-back
+               i-amphtml-video-docked-set"
+        hidden
+      >
+        <div class="amp-video-docked-button-group">
+          <div
+            role="button"
+            ref="scrollReturnButton"
+            class="amp-video-docked-scroll-back"
           ></div>
         </div>
       </div>
@@ -160,7 +197,15 @@ export class Controls {
     this.fullscreenButton_ = assertRef('fullscreenButton');
 
     /** @private @const {!Element} */
-    this.dismissContainer_ = assertRef('dismissContainer'); // eslint-disable-line
+    this.scrollReturnButton_ = assertRef('scrollReturnButton');
+
+    /** @private @const {!Element} */
+    this.dismissContainer_ = assertRef('dismissContainer');
+
+    /** @private @const {!NodeList} */
+    this.controlsSets_ = this.container.querySelectorAll(
+      '.i-amphtml-video-docked-set'
+    );
 
     /** @private {boolean} */
     this.isDisabled_ = false;
@@ -197,13 +242,11 @@ export class Controls {
 
   /** @public */
   disable() {
-    dev().info(TAG, 'disable');
     this.isDisabled_ = true;
   }
 
   /** @public */
   enable() {
-    dev().info(TAG, 'enable');
     this.isDisabled_ = false;
   }
 
@@ -221,6 +264,19 @@ export class Controls {
   }
 
   /**
+   * Sets displayed controls set.
+   * @param {ControlsSet} setName
+   * @private
+   */
+  useControlsSet_(setName) {
+    const activeClassname = `amp-video-docked-set-${setName}`;
+
+    iterateCursor(this.controlsSets_, controlsSet => {
+      toggle(controlsSet, controlsSet.classList.contains(activeClassname));
+    });
+  }
+
+  /**
    * @param {!../../../src/video-interface.VideoOrBaseElementDef} video
    * @private
    */
@@ -233,13 +289,7 @@ export class Controls {
 
     this.videoUnlisteners_.push(
       this.listenWhenEnabled_(this.dismissButton_, click, () => {
-        this.container.dispatchEvent(
-          createCustomEvent(
-            this.ampdoc_.win,
-            VideoDockingEvents.DISMISS_ON_TAP,
-            /* detail */ undefined
-          )
-        );
+        this.dispatch_(VideoDockingEvents.DISMISS_ON_TAP);
       }),
 
       this.listenWhenEnabled_(this.playButton_, click, () => {
@@ -262,6 +312,10 @@ export class Controls {
         video.fullscreenEnter();
       }),
 
+      this.listenWhenEnabled_(this.scrollReturnButton_, click, () => {
+        this.dispatch_(VideoDockingEvents.SCROLL_BACK);
+      }),
+
       listen(this.container, 'mouseup', () =>
         this.hideOnTimeout(TIMEOUT_AFTER_INTERACTION)
       ),
@@ -269,7 +323,25 @@ export class Controls {
       listen(element, VideoEvents.PLAYING, () => this.onPlay_()),
       listen(element, VideoEvents.PAUSE, () => this.onPause_()),
       listen(element, VideoEvents.MUTED, () => this.onMute_()),
-      listen(element, VideoEvents.UNMUTED, () => this.onUnmute_())
+      listen(element, VideoEvents.UNMUTED, () => this.onUnmute_()),
+
+      listen(element, VideoEvents.AD_START, () =>
+        this.useControlsSet_(ControlsSet.SCROLL_BACK)
+      ),
+
+      listen(element, VideoEvents.AD_END, () =>
+        this.useControlsSet_(ControlsSet.PLAYBACK)
+      )
+    );
+  }
+
+  /**
+   * @param {VideoDockingEvents} event
+   * @private
+   */
+  dispatch_(event) {
+    this.container.dispatchEvent(
+      createCustomEvent(this.ampdoc_.win, event, /* detail */ undefined)
     );
   }
 
@@ -357,33 +429,24 @@ export class Controls {
 
   /** @private */
   showOnNextAnimationFrame_() {
-    const {
-      container,
-      overlay,
-      playButton_: playButton,
-      pauseButton_: pauseButton,
-      muteButton_: muteButton,
-      unmuteButton_: unmuteButton,
-    } = this;
+    const {container, overlay} = this;
 
     toggle(container, true);
+
     container.classList.add('amp-video-docked-controls-shown');
     overlay.classList.add('amp-video-docked-controls-bg');
 
+    const isPlaying = this.isPlaying_();
+
+    toggle(this.playButton_, !isPlaying);
+    toggle(this.pauseButton_, isPlaying);
+
+    const isMuted = this.manager_().isMuted(this.video_);
+
+    toggle(this.muteButton_, !isMuted);
+    toggle(this.unmuteButton_, isMuted);
+
     this.listenToMouseMove_();
-
-    if (this.isPlaying_()) {
-      swap(playButton, pauseButton);
-    } else {
-      swap(pauseButton, playButton);
-    }
-
-    if (this.manager_().isMuted(this.video_)) {
-      swap(muteButton, unmuteButton);
-    } else {
-      swap(unmuteButton, muteButton);
-    }
-
     this.hideOnTimeout();
   }
 
@@ -395,7 +458,9 @@ export class Controls {
    * @param {number} height
    */
   positionOnVsync(scale, x, y, width, height) {
-    const {container, dismissContainer_: dismissContainer} = this;
+    this.area_ = layoutRectLtwh(x, y, width, height);
+
+    const {container} = this;
     const halfScale = scale / 2;
     const centerX = x + width * halfScale;
     const centerY = y + height * halfScale;
@@ -410,7 +475,7 @@ export class Controls {
     const dismissWidth = 40;
     const dismissX = width * halfScale - dismissMargin - dismissWidth;
     const dismissY = -(height * halfScale - dismissMargin - dismissWidth);
-    setImportantStyles(dismissContainer, {
+    setImportantStyles(this.dismissContainer_, {
       'transform': translate(dismissX, dismissY),
     });
   }

--- a/extensions/amp-video-docking/0.1/events.js
+++ b/extensions/amp-video-docking/0.1/events.js
@@ -19,6 +19,7 @@ import {dev} from '../../../src/log';
 /** @enum {string} */
 export const VideoDockingEvents = {
   DISMISS_ON_TAP: 'dock-dismiss-on-tap',
+  SCROLL_BACK: 'dock-scroll-back',
 };
 
 /**

--- a/extensions/amp-video-docking/0.1/test/test-amp-video-docking.js
+++ b/extensions/amp-video-docking/0.1/test/test-amp-video-docking.js
@@ -533,25 +533,18 @@ describes.realWin('↗ 🔲', {amp: true}, env => {
       const setsOrUnsets = hasAmpRtl ? 'sets' : 'unsets';
 
       it(
-        `${setsOrUnsets} amp-rtl classname on icon and controls layer when ` +
-          `docking from ${directionTextual}`,
+        `${setsOrUnsets} amp-rtl classname on icon when docking from ` +
+          directionTextual,
         async () => {
-          const controls = stubControls();
+          stubControls();
           enableComputedStyle(video.element);
 
-          const x = 30;
-          const y = 60;
-          const scale = 0.5;
-          const step = 1;
-          const transitionDurationMs = 0;
-
           await docking.placeAt_(
-            video,
-            x,
-            y,
-            scale,
-            step,
-            transitionDurationMs,
+            /* x, irrelevant */ 30,
+            /* y, irrelevant */ 60,
+            /* scale, irrelevant */ 0.5,
+            /* step, irrelevant */ 1,
+            /* transitionDurationMs, irrelevant */ 0,
             relativeX
           );
 
@@ -560,6 +553,24 @@ describes.realWin('↗ 🔲', {amp: true}, env => {
               '.amp-video-docked-placeholder-icon'
             ).classList.contains('amp-rtl')
           ).to.equal(hasAmpRtl);
+        }
+      );
+
+      it(
+        `${setsOrUnsets} amp-rtl classname on controls layer when docking ` +
+          `from ${directionTextual}`,
+        async () => {
+          const controls = stubControls();
+          enableComputedStyle(video.element);
+
+          await docking.placeAt_(
+            /* x, irrelevant */ 30,
+            /* y, irrelevant */ 60,
+            /* scale, irrelevant */ 0.5,
+            /* step, irrelevant */ 1,
+            /* transitionDurationMs, irrelevant */ 0,
+            relativeX
+          );
 
           expect(controls.container.classList.contains('amp-rtl')).to.equal(
             hasAmpRtl

--- a/extensions/amp-video-docking/0.1/test/test-amp-video-docking.js
+++ b/extensions/amp-video-docking/0.1/test/test-amp-video-docking.js
@@ -527,20 +527,20 @@ describes.realWin('↗ 🔲', {amp: true}, env => {
     [
       {
         relativeX: RelativeX.RIGHT,
-        relativeXTextual: 'right',
+        directionTextual: 'left to right',
         placeholderIconHasAmpRtl: false,
       },
       {
         relativeX: RelativeX.LEFT,
-        relativeXTextual: 'left',
+        directionTextual: 'right to left',
         placeholderIconHasAmpRtl: true,
       },
-    ].forEach(({relativeX, relativeXTextual, placeholderIconHasAmpRtl}) => {
+    ].forEach(({relativeX, directionTextual, placeholderIconHasAmpRtl}) => {
       const setsOrUnsets = placeholderIconHasAmpRtl ? 'sets' : 'unsets';
 
       it(
-        `${setsOrUnsets} RTL classname on icon transitioning to ` +
-          relativeXTextual,
+        `${setsOrUnsets} amp-rtl classname on icon and controls layer when ` +
+          `docking from ${directionTextual}`,
         async () => {
           const controls = stubControls();
           enableComputedStyle(video.element);

--- a/extensions/amp-video-docking/0.1/test/test-amp-video-docking.js
+++ b/extensions/amp-video-docking/0.1/test/test-amp-video-docking.js
@@ -482,45 +482,39 @@ describes.realWin('↗ 🔲', {amp: true}, env => {
           expectedIconX: -width + iconWidth + iconMargin * 2,
         },
       ].forEach(({relativeX, relativeXTextual, expectedIconX}) => {
-        it(
-          'translates placeholder icon horizontally for ' +
-            `posX=${relativeXTextual} in threshold for .${className}`,
-          async () => {
-            stubControls();
-            enableComputedStyle(video.element);
+        it(`translates placeholder icon horizontally for posX=${relativeXTextual} in threshold for .${className}`, async () => {
+          stubControls();
+          enableComputedStyle(video.element);
 
-            const expectedTransformMatrix = transformMatrix(
-              expectedIconX,
-              /* y */ 0,
-              /* scale */ 1
-            );
+          const expectedTransformMatrix = transformMatrix(
+            expectedIconX,
+            /* y */ 0,
+            /* scale */ 1
+          );
 
-            const x = 30;
-            const y = 60;
-            const scale = 0.5;
-            const transitionDurationMs = 0;
+          const x = 30;
+          const y = 60;
+          const scale = 0.5;
+          const transitionDurationMs = 0;
 
-            placeElementLtwh(video, 0, 0, width, 200);
+          placeElementLtwh(video, 0, 0, width, 200);
 
-            await docking.placeAt_(
-              video,
-              x,
-              y,
-              scale,
-              step,
-              transitionDurationMs,
-              relativeX
-            );
+          await docking.placeAt_(
+            video,
+            x,
+            y,
+            scale,
+            step,
+            transitionDurationMs,
+            relativeX
+          );
 
-            const computedStyle = getComputedStyle(
-              videoLayerElement('.amp-video-docked-placeholder-icon')
-            );
+          const computedStyle = getComputedStyle(
+            videoLayerElement('.amp-video-docked-placeholder-icon')
+          );
 
-            expect(computedStyle['transform']).to.equal(
-              expectedTransformMatrix
-            );
-          }
-        );
+          expect(computedStyle['transform']).to.equal(expectedTransformMatrix);
+        });
       });
     });
 

--- a/extensions/amp-video-docking/0.1/test/test-amp-video-docking.js
+++ b/extensions/amp-video-docking/0.1/test/test-amp-video-docking.js
@@ -41,7 +41,7 @@ const noop = () => {};
 
 const slotId = 'my-slot-element';
 
-describes.realWin('↗ 🔲', {amp: true}, env => {
+describes.realWin('video docking', {amp: true}, env => {
   let ampdoc;
   let manager;
   let viewport;
@@ -540,6 +540,7 @@ describes.realWin('↗ 🔲', {amp: true}, env => {
           enableComputedStyle(video.element);
 
           await docking.placeAt_(
+            video,
             /* x, irrelevant */ 30,
             /* y, irrelevant */ 60,
             /* scale, irrelevant */ 0.5,
@@ -564,6 +565,7 @@ describes.realWin('↗ 🔲', {amp: true}, env => {
           enableComputedStyle(video.element);
 
           await docking.placeAt_(
+            video,
             /* x, irrelevant */ 30,
             /* y, irrelevant */ 60,
             /* scale, irrelevant */ 0.5,

--- a/extensions/amp-video-docking/0.1/test/test-amp-video-docking.js
+++ b/extensions/amp-video-docking/0.1/test/test-amp-video-docking.js
@@ -142,16 +142,14 @@ describes.realWin('↗ 🔲', {amp: true}, env => {
   }
 
   function stubControls() {
-    const html = htmlFor(env.win.document);
     const controls = {
       positionOnVsync: env.sandbox.spy(),
       enable: env.sandbox.spy(),
       disable: env.sandbox.spy(),
       hide: env.sandbox.spy(),
       setVideo: env.sandbox.spy(),
-      overlay: html`
-        <div></div>
-      `,
+      overlay: env.win.document.createElement('div'),
+      container: env.win.document.createElement('div'),
     };
 
     env.sandbox.stub(docking, 'getControls_').returns(controls);
@@ -182,6 +180,7 @@ describes.realWin('↗ 🔲', {amp: true}, env => {
     viewport = {
       getScrollTop: () => 0,
       getSize: () => viewportSize,
+      animateScrollIntoView: env.sandbox.spy(),
     };
 
     env.sandbox.stub(Services, 'viewportForDoc').returns(viewport);
@@ -233,7 +232,7 @@ describes.realWin('↗ 🔲', {amp: true}, env => {
       videoLayerElement = s => elementExists(video.element, s);
     });
 
-    it('delegates controls positioning', function*() {
+    it('delegates controls positioning', async () => {
       const {positionOnVsync} = stubControls();
 
       const x = 0;
@@ -242,12 +241,12 @@ describes.realWin('↗ 🔲', {amp: true}, env => {
       const step = 1;
       const transitionDurationMs = 0;
 
-      yield docking.placeAt_(video, x, y, scale, step, transitionDurationMs);
+      await docking.placeAt_(video, x, y, scale, step, transitionDurationMs);
 
       expect(positionOnVsync).to.have.been.calledOnce;
     });
 
-    it('reparents placeholder', function*() {
+    it('reparents placeholder', async () => {
       stubControls();
 
       const x = 30;
@@ -256,13 +255,13 @@ describes.realWin('↗ 🔲', {amp: true}, env => {
       const step = 1;
       const transitionDurationMs = 0;
 
-      yield docking.placeAt_(video, x, y, scale, step, transitionDurationMs);
+      await docking.placeAt_(video, x, y, scale, step, transitionDurationMs);
 
       expect(videoLayerElement('.amp-video-docked-placeholder-background')).to
         .be.ok;
     });
 
-    it('fills component area with placeholder elemenets', function*() {
+    it('fills component area with placeholder elemenets', async () => {
       stubControls();
 
       const x = 30;
@@ -271,7 +270,7 @@ describes.realWin('↗ 🔲', {amp: true}, env => {
       const step = 1;
       const transitionDurationMs = 0;
 
-      yield docking.placeAt_(video, x, y, scale, step, transitionDurationMs);
+      await docking.placeAt_(video, x, y, scale, step, transitionDurationMs);
 
       expect(
         video.applyFillContent.withArgs(
@@ -286,7 +285,7 @@ describes.realWin('↗ 🔲', {amp: true}, env => {
       ).to.have.been.calledOnce;
     });
 
-    it('styles and transforms elements into docked area', function*() {
+    it('styles and transforms elements into docked area', async () => {
       const {overlay} = stubControls();
 
       enableComputedStyle(video.element);
@@ -303,7 +302,7 @@ describes.realWin('↗ 🔲', {amp: true}, env => {
 
       placeElementLtwh(video, 0, 0, width, height);
 
-      yield docking.placeAt_(video, x, y, scale, step, transitionDurationMs);
+      await docking.placeAt_(video, x, y, scale, step, transitionDurationMs);
 
       const shadow = bodyLayerElement('.amp-video-docked-shadow');
 
@@ -319,7 +318,7 @@ describes.realWin('↗ 🔲', {amp: true}, env => {
       });
     });
 
-    it('sets poster image', function*() {
+    it('sets poster image', async () => {
       const posterSrc = 'https://whatever.com/image.png';
 
       stubControls();
@@ -333,7 +332,7 @@ describes.realWin('↗ 🔲', {amp: true}, env => {
       const step = 1;
       const transitionDurationMs = 0;
 
-      yield docking.placeAt_(video, x, y, scale, step, transitionDurationMs);
+      await docking.placeAt_(video, x, y, scale, step, transitionDurationMs);
 
       const poster = videoLayerElement(
         '.amp-video-docked-placeholder-background-poster'
@@ -345,7 +344,7 @@ describes.realWin('↗ 🔲', {amp: true}, env => {
     });
 
     for (let step = 0; step <= 1; step = Number((step + 0.1).toFixed(1))) {
-      it(`sets opacity = step @ step = ${step}`, function*() {
+      it(`sets opacity = step @ step = ${step}`, async () => {
         stubControls();
         enableComputedStyle(video.element);
 
@@ -354,7 +353,7 @@ describes.realWin('↗ 🔲', {amp: true}, env => {
         const scale = 0.5;
         const transitionDurationMs = 0;
 
-        yield docking.placeAt_(video, x, y, scale, step, transitionDurationMs);
+        await docking.placeAt_(video, x, y, scale, step, transitionDurationMs);
 
         const shadow = bodyLayerElement('.amp-video-docked-shadow');
         const placeholder = videoLayerElement(
@@ -366,7 +365,7 @@ describes.realWin('↗ 🔲', {amp: true}, env => {
       });
     }
 
-    it('overrides overflow to render outside of component area', function*() {
+    it('overrides overflow to render outside of component area', async () => {
       stubControls();
       enableComputedStyle(video.element);
 
@@ -376,12 +375,12 @@ describes.realWin('↗ 🔲', {amp: true}, env => {
       const step = 1;
       const transitionDurationMs = 0;
 
-      yield docking.placeAt_(video, x, y, scale, step, transitionDurationMs);
+      await docking.placeAt_(video, x, y, scale, step, transitionDurationMs);
 
       expect(getComputedStyle(video.element)['overflow']).to.equal('visible');
     });
 
-    it('applies classname on internal element', function*() {
+    it('applies classname on internal element', async () => {
       stubControls();
 
       const x = 30;
@@ -390,7 +389,7 @@ describes.realWin('↗ 🔲', {amp: true}, env => {
       const step = 1;
       const transitionDurationMs = 0;
 
-      yield docking.placeAt_(video, x, y, scale, step, transitionDurationMs);
+      await docking.placeAt_(video, x, y, scale, step, transitionDurationMs);
 
       expect(internalElement).to.have.class(BASE_CLASS_NAME);
     });
@@ -399,7 +398,7 @@ describes.realWin('↗ 🔲', {amp: true}, env => {
       {step: 0, fn: 'ease-in'},
       {step: 1, fn: 'ease-out'},
     ].forEach(({step, fn}) => {
-      it(`sets transition timing on elements for step = ${step}`, function*() {
+      it(`sets transition timing on elements for step = ${step}`, async () => {
         const {overlay} = stubControls();
 
         enableComputedStyle(video.element);
@@ -412,7 +411,7 @@ describes.realWin('↗ 🔲', {amp: true}, env => {
         const durationMs = 260;
         const durationSecondsStr = '0.26s';
 
-        yield docking.placeAt_(video, x, y, scale, step, durationMs);
+        await docking.placeAt_(video, x, y, scale, step, durationMs);
 
         [
           internalElement,
@@ -444,7 +443,7 @@ describes.realWin('↗ 🔲', {amp: true}, env => {
 
       const step = 1;
 
-      it(`sets ${className} on icon @ ${width}px wide`, function*() {
+      it(`sets ${className} on icon @ ${width}px wide`, async () => {
         stubControls();
 
         const x = 30;
@@ -454,7 +453,7 @@ describes.realWin('↗ 🔲', {amp: true}, env => {
 
         placeElementLtwh(video, 0, 0, width, 200);
 
-        yield docking.placeAt_(
+        await docking.placeAt_(
           video,
           x,
           y,
@@ -483,39 +482,45 @@ describes.realWin('↗ 🔲', {amp: true}, env => {
           expectedIconX: -width + iconWidth + iconMargin * 2,
         },
       ].forEach(({relativeX, relativeXTextual, expectedIconX}) => {
-        it(`translates placeholder icon horizontally for posX=${relativeXTextual} in threshold for .${className}`, function*() {
-          stubControls();
-          enableComputedStyle(video.element);
+        it(
+          'translates placeholder icon horizontally for ' +
+            `posX=${relativeXTextual} in threshold for .${className}`,
+          async () => {
+            stubControls();
+            enableComputedStyle(video.element);
 
-          const expectedTransformMatrix = transformMatrix(
-            expectedIconX,
-            /* y */ 0,
-            /* scale */ 1
-          );
+            const expectedTransformMatrix = transformMatrix(
+              expectedIconX,
+              /* y */ 0,
+              /* scale */ 1
+            );
 
-          const x = 30;
-          const y = 60;
-          const scale = 0.5;
-          const transitionDurationMs = 0;
+            const x = 30;
+            const y = 60;
+            const scale = 0.5;
+            const transitionDurationMs = 0;
 
-          placeElementLtwh(video, 0, 0, width, 200);
+            placeElementLtwh(video, 0, 0, width, 200);
 
-          yield docking.placeAt_(
-            video,
-            x,
-            y,
-            scale,
-            step,
-            transitionDurationMs,
-            relativeX
-          );
+            await docking.placeAt_(
+              video,
+              x,
+              y,
+              scale,
+              step,
+              transitionDurationMs,
+              relativeX
+            );
 
-          const computedStyle = getComputedStyle(
-            videoLayerElement('.amp-video-docked-placeholder-icon')
-          );
+            const computedStyle = getComputedStyle(
+              videoLayerElement('.amp-video-docked-placeholder-icon')
+            );
 
-          expect(computedStyle['transform']).to.equal(expectedTransformMatrix);
-        });
+            expect(computedStyle['transform']).to.equal(
+              expectedTransformMatrix
+            );
+          }
+        );
       });
     });
 
@@ -533,32 +538,40 @@ describes.realWin('↗ 🔲', {amp: true}, env => {
     ].forEach(({relativeX, relativeXTextual, placeholderIconHasAmpRtl}) => {
       const setsOrUnsets = placeholderIconHasAmpRtl ? 'sets' : 'unsets';
 
-      it(`${setsOrUnsets} RTL classname on icon transitioning to ${relativeXTextual}`, function*() {
-        stubControls();
-        enableComputedStyle(video.element);
+      it(
+        `${setsOrUnsets} RTL classname on icon transitioning to ` +
+          relativeXTextual,
+        async () => {
+          const controls = stubControls();
+          enableComputedStyle(video.element);
 
-        const x = 30;
-        const y = 60;
-        const scale = 0.5;
-        const step = 1;
-        const transitionDurationMs = 0;
+          const x = 30;
+          const y = 60;
+          const scale = 0.5;
+          const step = 1;
+          const transitionDurationMs = 0;
 
-        yield docking.placeAt_(
-          video,
-          x,
-          y,
-          scale,
-          step,
-          transitionDurationMs,
-          relativeX
-        );
+          await docking.placeAt_(
+            video,
+            x,
+            y,
+            scale,
+            step,
+            transitionDurationMs,
+            relativeX
+          );
 
-        expect(
-          videoLayerElement(
-            '.amp-video-docked-placeholder-icon'
-          ).classList.contains('amp-rtl')
-        ).to.equal(placeholderIconHasAmpRtl);
-      });
+          expect(
+            videoLayerElement(
+              '.amp-video-docked-placeholder-icon'
+            ).classList.contains('amp-rtl')
+          ).to.equal(placeholderIconHasAmpRtl);
+
+          expect(controls.container.classList.contains('amp-rtl')).to.equal(
+            placeholderIconHasAmpRtl
+          );
+        }
+      );
     });
   });
 
@@ -618,7 +631,7 @@ describes.realWin('↗ 🔲', {amp: true}, env => {
   describe('dockInTransferLayerStep_', () => {
     // Something weird causing this to flake in certain leftover states.
     // TODO(alanorozco): Unskip.
-    it.skip('should not overflow', function*() {
+    it.skip('should not overflow', async () => {
       const video = {};
       const target = {};
 
@@ -626,7 +639,7 @@ describes.realWin('↗ 🔲', {amp: true}, env => {
         .stub(docking, 'dock_')
         .returns(Promise.resolve());
 
-      yield docking.dockInTransferLayerStep_(video, target);
+      await docking.dockInTransferLayerStep_(video, target);
 
       expect(dock).to.have.been.called;
     });
@@ -953,19 +966,23 @@ describes.realWin('↗ 🔲', {amp: true}, env => {
         targetX: 0,
       },
     ].forEach(({expectedRelativeX, placementTextual, videoX, targetX}) => {
-      it(`returns relativeX=${placementTextual.toUpperCase()} when target placed ${placementTextual} of component`, () => {
-        const step = 1;
+      it(
+        `returns relativeX=${placementTextual.toUpperCase()} when target ` +
+          `placed ${placementTextual} of component`,
+        () => {
+          const step = 1;
 
-        placeElementLtwh(video, videoX, videoY, videoWidth, videoHeight);
+          placeElementLtwh(video, videoX, videoY, videoWidth, videoHeight);
 
-        targetAreaStub.returns(
-          layoutRectLtwh(targetX, targetY, targetWidth, targetHeight)
-        );
+          targetAreaStub.returns(
+            layoutRectLtwh(targetX, targetY, targetWidth, targetHeight)
+          );
 
-        expect(docking.getDims_(video, target, step).relativeX).to.equal(
-          expectedRelativeX
-        );
-      });
+          expect(docking.getDims_(video, target, step).relativeX).to.equal(
+            expectedRelativeX
+          );
+        }
+      );
     });
   });
 
@@ -991,19 +1008,19 @@ describes.realWin('↗ 🔲', {amp: true}, env => {
       env.sandbox.stub(docking, 'getDims_').returns(targetDims);
     });
 
-    it('sets currently docked', function*() {
+    it('sets currently docked', async () => {
       stubControls();
 
-      yield docking.dock_(video, target, step);
+      await docking.dock_(video, target, step);
 
       expect(setCurrentlyDocked.withArgs(video, target, step)).to.have.been
         .calledOnce;
     });
 
-    it('places element at the result of getDims_', function*() {
+    it('places element at the result of getDims_', async () => {
       stubControls();
 
-      yield docking.dock_(video, target, step);
+      await docking.dock_(video, target, step);
 
       const {x, y, scale, relativeX} = targetDims;
 
@@ -1020,24 +1037,24 @@ describes.realWin('↗ 🔲', {amp: true}, env => {
       ).to.have.been.calledOnce;
     });
 
-    it('hides component controls', function*() {
-      yield docking.dock_(video, target, step);
+    it('hides component controls', async () => {
+      await docking.dock_(video, target, step);
 
       expect(video.hideControls).to.have.been.calledOnce;
     });
 
-    it('enables docked controls', function*() {
+    it('enables docked controls', async () => {
       const {enable} = stubControls();
 
-      yield docking.dock_(video, target, step);
+      await docking.dock_(video, target, step);
 
       expect(enable).to.have.been.calledOnce;
     });
 
-    it('does not enable docked controls if transferring layer', function*() {
+    it('does not enable docked controls if transferring layer', async () => {
       const {enable} = stubControls();
 
-      yield docking.dock_(video, target, step, /* isTransferLayerStep */ true);
+      await docking.dock_(video, target, step, /* isTransferLayerStep */ true);
 
       expect(enable).to.not.have.been.called;
     });
@@ -1143,15 +1160,15 @@ describes.realWin('↗ 🔲', {amp: true}, env => {
         .returns(targetDims);
     });
 
-    it('triggers action', function*() {
+    it('triggers action', async () => {
       stubControls();
 
-      yield docking.undock_(video);
+      await docking.undock_(video);
 
       expect(trigger.withArgs(Actions.UNDOCK)).to.have.been.calledOnce;
     });
 
-    it('updates stale Y after undock', function*() {
+    it('updates stale Y after undock', async () => {
       const {promise, resolve} = new Deferred();
 
       placeAt.returns(promise);
@@ -1163,13 +1180,13 @@ describes.realWin('↗ 🔲', {amp: true}, env => {
 
       resolve();
 
-      yield done;
+      await done;
 
       expect(maybeUpdateStaleYAfterScroll.withArgs(video)).to.have.been
         .calledOnce;
     });
 
-    it('resets after undock', function*() {
+    it('resets after undock', async () => {
       const {promise, resolve} = new Deferred();
 
       placeAt.returns(promise);
@@ -1180,24 +1197,24 @@ describes.realWin('↗ 🔲', {amp: true}, env => {
 
       resolve();
 
-      yield done;
+      await done;
 
       expect(resetOnUndock.withArgs(video)).to.have.been.calledOnce;
     });
 
-    it('hides and disables docked controls', function*() {
+    it('hides and disables docked controls', async () => {
       const {hide, disable} = stubControls();
 
-      yield docking.undock_(video);
+      await docking.undock_(video);
 
       expect(hide).to.have.been.calledOnce;
       expect(disable).to.have.been.calledOnce;
     });
 
-    it('places element at the result of getDims_', function*() {
+    it('places element at the result of getDims_', async () => {
       stubControls();
 
-      yield docking.undock_(video);
+      await docking.undock_(video);
 
       const {x, y, scale, relativeX} = targetDims;
 
@@ -1216,18 +1233,18 @@ describes.realWin('↗ 🔲', {amp: true}, env => {
 
     const inlinePercVis = `${REVERT_TO_INLINE_RATIO * 100}% visible`;
 
-    it(`pauses video when < ${inlinePercVis}`, function*() {
+    it(`pauses video when < ${inlinePercVis}`, async () => {
       placeElementLtwh(video, 0, 0, 400, 400, REVERT_TO_INLINE_RATIO - 0.1);
 
-      yield docking.undock_(video);
+      await docking.undock_(video);
 
       expect(video.pause).to.have.been.calledOnce;
     });
 
-    it(`doesn't pause video when >= ${inlinePercVis}`, function*() {
+    it(`doesn't pause video when >= ${inlinePercVis}`, async () => {
       placeElementLtwh(video, 0, 0, 400, 400, REVERT_TO_INLINE_RATIO);
 
-      yield docking.undock_(video);
+      await docking.undock_(video);
 
       expect(video.pause).to.not.have.been.called;
     });
@@ -1267,12 +1284,12 @@ describes.realWin('↗ 🔲', {amp: true}, env => {
         });
       });
 
-      it(`does not animate transition when < ${inlinePercVis}`, function*() {
+      it(`does not animate transition when < ${inlinePercVis}`, async () => {
         const expectedTransitionDurationMs = 0;
 
         placeElementLtwh(video, 0, 0, 400, 400, REVERT_TO_INLINE_RATIO - 0.1);
 
-        yield docking.undock_(video);
+        await docking.undock_(video);
 
         expect(
           placeAt.withArgs(
@@ -1286,7 +1303,7 @@ describes.realWin('↗ 🔲', {amp: true}, env => {
         ).to.have.been.calledOnce;
       });
 
-      it(`animates transition when >= ${inlinePercVis}`, function*() {
+      it(`animates transition when >= ${inlinePercVis}`, async () => {
         const expectedTransitionDurationMs = 555;
 
         env.sandbox
@@ -1295,7 +1312,7 @@ describes.realWin('↗ 🔲', {amp: true}, env => {
 
         placeElementLtwh(video, 0, 0, 400, 400, REVERT_TO_INLINE_RATIO);
 
-        yield docking.undock_(video);
+        await docking.undock_(video);
 
         expect(
           placeAt.withArgs(
@@ -1308,6 +1325,35 @@ describes.realWin('↗ 🔲', {amp: true}, env => {
           )
         ).to.have.been.calledOnce;
       });
+    });
+  });
+
+  describe('scrollBack_', () => {
+    beforeEach(() => {
+      // Requests ampdoc when calling `setCurrentlyDocked_`. Node is detached
+      // and we don't care about callee's side effects.
+      env.sandbox.stub(docking, 'trigger_');
+    });
+
+    it('does not scroll when undocked', () => {
+      docking.scrollBack_();
+
+      expect(viewport.animateScrollIntoView).to.not.have.been.called;
+    });
+
+    it("scrolls back to video component's inline box when docked", () => {
+      const video = createVideo();
+
+      docking.setCurrentlyDocked_(
+        video,
+        /* target, irrelevant */ {},
+        /* step, irrelevant */ 1
+      );
+
+      docking.scrollBack_();
+
+      expect(viewport.animateScrollIntoView.withArgs(video.element, 'center'))
+        .to.have.been.calledOnce;
     });
   });
 

--- a/extensions/amp-video-docking/0.1/test/test-amp-video-docking.js
+++ b/extensions/amp-video-docking/0.1/test/test-amp-video-docking.js
@@ -528,15 +528,15 @@ describes.realWin('↗ 🔲', {amp: true}, env => {
       {
         relativeX: RelativeX.RIGHT,
         directionTextual: 'left to right',
-        placeholderIconHasAmpRtl: false,
+        hasAmpRtl: false,
       },
       {
         relativeX: RelativeX.LEFT,
         directionTextual: 'right to left',
-        placeholderIconHasAmpRtl: true,
+        hasAmpRtl: true,
       },
-    ].forEach(({relativeX, directionTextual, placeholderIconHasAmpRtl}) => {
-      const setsOrUnsets = placeholderIconHasAmpRtl ? 'sets' : 'unsets';
+    ].forEach(({relativeX, directionTextual, hasAmpRtl}) => {
+      const setsOrUnsets = hasAmpRtl ? 'sets' : 'unsets';
 
       it(
         `${setsOrUnsets} amp-rtl classname on icon and controls layer when ` +
@@ -565,10 +565,10 @@ describes.realWin('↗ 🔲', {amp: true}, env => {
             videoLayerElement(
               '.amp-video-docked-placeholder-icon'
             ).classList.contains('amp-rtl')
-          ).to.equal(placeholderIconHasAmpRtl);
+          ).to.equal(hasAmpRtl);
 
           expect(controls.container.classList.contains('amp-rtl')).to.equal(
-            placeholderIconHasAmpRtl
+            hasAmpRtl
           );
         }
       );

--- a/extensions/amp-video-docking/amp-video-docking.md
+++ b/extensions/amp-video-docking/amp-video-docking.md
@@ -217,10 +217,10 @@ measuring 64 by 64 pixels. Other control buttons are sized at
 
 The icon for this button (set through the `background-image` CSS property)
 changes depending on the relative direction of the docked area. When the video
-docks from left-to-right, the `.amp-docked-video-controls` gets no additional
-classnames, but it will get the `amp-rtl` classname when the video docks in the
-opposite direction. This allows this button to be drawn with an arrow pointing
-in the right direction.
+docks from left-to-right, the `.amp-docked-video-controls` container gets no
+additional classnames, but it will get the `amp-rtl` classname when the video
+docks in the opposite direction. This allows the button to be drawn with an
+arrow pointing in the correct direction.
 
 #### `.amp-video-docked-placeholder-background`
 

--- a/extensions/amp-video-docking/amp-video-docking.md
+++ b/extensions/amp-video-docking/amp-video-docking.md
@@ -166,7 +166,7 @@ displayed at a time depending on the state of the video:
 - The **playback** set is displayed on most scenarios and contains play/pause,
   mute/unmute and fullscreen buttons.
 
-- The **scroll return** set only contains a button to scroll the document back
+- The **scroll back** set only contains a button to scroll the document back
   to the video's inline position. This is displayed during ad playback in order
   to allow user interaction.
 
@@ -204,14 +204,16 @@ Represents the `unmute` button.
 
 Represents the `fullscreen` button.
 
-#### `.amp-docked-video-scroll-return`
+#### `.amp-docked-video-scroll-back`
 
-Represents a button to go back to scroll the document back to the video's inline
-position during ad playback.
+Represents a button to scroll the document back to the video's inline position
+during ad playback to allow user interaction.
 
-This button is different from the others in that the `amp-small`/`amp-large`
-classnames on the `.amp-docked-video-controls` container do not affect its
-dimensions.
+This button is different from the other control buttons in that the
+`amp-small`/`amp-large` classnames on the `.amp-docked-video-controls` container
+do not affect it. Because it's the only button in its set it's also larger,
+measuring 64 by 64 pixels. Other control buttons are sized at
+40 by 40 pixels.
 
 #### `.amp-video-docked-placeholder-background`
 

--- a/extensions/amp-video-docking/amp-video-docking.md
+++ b/extensions/amp-video-docking/amp-video-docking.md
@@ -211,9 +211,9 @@ during ad playback to allow user interaction.
 
 This button is different from the other control buttons in that the
 `amp-small`/`amp-large` classnames on the `.amp-docked-video-controls` container
-do not affect it. Because it's the only button in its set it's also larger,
-measuring 64 by 64 pixels. Other control buttons are sized at
-40 by 40 pixels.
+do not affect it. Because it's the only button in its set, it's also larger than
+the others, at 64 by 64 pixels. Other control buttons are sized at 40 by 40
+pixels.
 
 The icon for this button (set through the `background-image` CSS property)
 changes depending on the relative direction of the docked area. When the video

--- a/extensions/amp-video-docking/amp-video-docking.md
+++ b/extensions/amp-video-docking/amp-video-docking.md
@@ -215,6 +215,13 @@ do not affect it. Because it's the only button in its set it's also larger,
 measuring 64 by 64 pixels. Other control buttons are sized at
 40 by 40 pixels.
 
+The icon for this button (set through the `background-image` CSS property)
+changes depending on the relative direction of the docked area. When the video
+docks from left-to-right, the `.amp-docked-video-controls` gets no additional
+classnames, but it will get the `amp-rtl` classname when the video docks in the
+opposite direction. This allows this button to be drawn with an arrow pointing
+in the right direction.
+
 #### `.amp-video-docked-placeholder-background`
 
 Represents a container for placeholder elements placed on the empty component area.

--- a/extensions/amp-video-docking/amp-video-docking.md
+++ b/extensions/amp-video-docking/amp-video-docking.md
@@ -158,6 +158,20 @@ References a layer that draws an overlay background over the video and under
 the controls. It's displayed only when the controls are displayed. Its
 background can be overridden or removed.
 
+#### `.amp-video-docked-main-button-group`
+
+A controls group that contains a set of buttons. Only one of these elements are
+displayed at a time depending on the state of the video:
+
+- The **playback** set is displayed on most scenarios and contains play/pause,
+  mute/unmute and fullscreen buttons.
+
+- The **scroll return** set only contains a button to scroll the document back
+  to the video's inline position. This is displayed during ad playback in order
+  to allow user interaction.
+
+The dismiss button is **not** part of a controls set and is always displayed.
+
 #### `.amp-docked-video-button-group`
 
 A button "group" that usually contains two buttons, with only one displayed at
@@ -189,6 +203,15 @@ Represents the `unmute` button.
 #### `.amp-docked-video-fullscreen`
 
 Represents the `fullscreen` button.
+
+#### `.amp-docked-video-scroll-return`
+
+Represents a button to go back to scroll the document back to the video's inline
+position during ad playback.
+
+This button is different from the others in that the `amp-small`/`amp-large`
+classnames on the `.amp-docked-video-controls` container do not affect its
+dimensions.
 
 #### `.amp-video-docked-placeholder-background`
 


### PR DESCRIPTION
Fixes #21783

Changes docked video's controls set to a single button to scroll back to the video's inline box while an ad is playing (area would otherwise be too small to interact with the ad).

Additionally:

- fixes #24408, a controls flickering bug when docked area changes
- updates tests from non-standard generator syntax to `async/await`