### PR TITLE
🐛Turn SwG gpay 100% in canary and 10% in prod.

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -33,6 +33,7 @@
   "fixed-elements-in-lightbox": 1,
   "flexAdSlots": 0.05,
   "swg-gpay-api": 1,
+  "swg-gpay-native": 1,
   "hidden-mutation-observer": 1,
   "ios-fixed-no-transfer": 1,
   "layoutbox-invalidate-on-scroll": 1,

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -31,6 +31,7 @@
   "fix-inconsistent-responsive-height-selection": 0,
   "fixed-elements-in-lightbox": 1,
   "flexAdSlots": 0.05,
+  "swg-gpay-api": 0.1,
   "swg-gpay-native": 1,
   "hidden-mutation-observer": 1,
   "ios-fixed-no-transfer": 0,


### PR DESCRIPTION
In both instances, we want 100% native buy flow.
