### PR TITLE
♻️Change Stories tap handler from checking tag names to checking classes

### DIFF
--- a/extensions/amp-story/1.0/amp-story-page-attachment.js
+++ b/extensions/amp-story/1.0/amp-story-page-attachment.js
@@ -79,6 +79,9 @@ export class AmpStoryPageAttachment extends DraggableDrawer {
       this.element.classList.add(DARK_THEME_CLASS);
     }
 
+    // Add manual tap handler class to prevent advancement on tap
+    this.element.classList.add('i-amphtml-story-handle-tap-manually');
+
     const templateEl = this.element.querySelector(
       '.i-amphtml-story-draggable-drawer'
     );

--- a/extensions/amp-story/1.0/amp-story-quiz.js
+++ b/extensions/amp-story/1.0/amp-story-quiz.js
@@ -118,6 +118,9 @@ export class AmpStoryQuiz extends AMP.BaseElement {
    * @private
    */
   attachContent_() {
+    // Add manual tap handler class to prevent advancement on tap
+    this.element.classList.add('i-amphtml-story-handle-tap-manually');
+
     // TODO(jackbsteinberg): Optional prompt behavior must be implemented here
     const promptInput = this.element.children[0];
     // First child must be heading h1-h3

--- a/extensions/amp-story/1.0/page-advancement.js
+++ b/extensions/amp-story/1.0/page-advancement.js
@@ -430,10 +430,7 @@ class ManualAdvancement extends AdvancementConfig {
       dev().assertElement(event.target),
       el => {
         tagName = el.tagName.toLowerCase();
-        if (
-          tagName === 'amp-story-page-attachment' ||
-          tagName === 'amp-story-quiz'
-        ) {
+        if (el.classList.contains('i-amphtml-story-handle-tap-manually')) {
           shouldHandleEvent = false;
           return true;
         }


### PR DESCRIPTION
As per a comment by @newmuis on #25495, changed the tap handler for stories so page advancement is blocked when the `i-amphtml-story-handle-tap-manually` class is present, instead of checking for the tag names. This allows more versatility to make parts of a component interactive and others not, while simplifying the process to make future interactive methods.

Adds work related to tracking issue #25615