### PR TITLE
Remove per-element Preconnect wrapper class

### DIFF
--- a/builtins/amp-img.js
+++ b/builtins/amp-img.js
@@ -114,7 +114,7 @@ export class AmpImg extends BaseElement {
     // `src` url if it exists or the first srcset url.
     const src = this.element.getAttribute('src');
     if (src) {
-      this.preconnect.url(src, onLayout);
+      Services.preconnectFor(this.win).url(this.getAmpDoc(), src, onLayout);
     } else {
       const srcset = this.element.getAttribute('srcset');
       if (!srcset) {
@@ -124,7 +124,7 @@ export class AmpImg extends BaseElement {
       const srcseturl = /\S+/.exec(srcset);
       // Connect to the first url if it exists
       if (srcseturl) {
-        this.preconnect.url(srcseturl[0], onLayout);
+        Services.preconnectFor(this.win).url(this.getAmpDoc(), srcseturl[0], onLayout);
       }
     }
   }

--- a/builtins/amp-img.js
+++ b/builtins/amp-img.js
@@ -16,6 +16,7 @@
 
 import {BaseElement} from '../src/base-element';
 import {Layout, isLayoutSizeDefined} from '../src/layout';
+import {Services} from '../src/services';
 import {dev} from '../src/log';
 import {guaranteeSrcForSrcsetUnsupportedBrowsers} from '../src/utils/img';
 import {isExperimentOn} from '../src/experiments';
@@ -124,7 +125,11 @@ export class AmpImg extends BaseElement {
       const srcseturl = /\S+/.exec(srcset);
       // Connect to the first url if it exists
       if (srcseturl) {
-        Services.preconnectFor(this.win).url(this.getAmpDoc(), srcseturl[0], onLayout);
+        Services.preconnectFor(this.win).url(
+          this.getAmpDoc(),
+          srcseturl[0],
+          onLayout
+        );
       }
     }
   }

--- a/extensions/amp-3d-gltf/0.1/amp-3d-gltf.js
+++ b/extensions/amp-3d-gltf/0.1/amp-3d-gltf.js
@@ -59,16 +59,20 @@ export class Amp3dGltf extends AMP.BaseElement {
    * @override
    */
   preconnectCallback(opt_onLayout) {
-    preloadBootstrap(this.win, this.getAmpDoc(), this.preconnect);
-    Services.preconnectFor(this.win).url(this.getAmpDoc(),
+    const preconnect = Services.preconnectFor(this.win);
+    preloadBootstrap(this.win, this.getAmpDoc(), preconnect);
+    preconnect.url(
+      this.getAmpDoc(),
       'https://cdnjs.cloudflare.com/ajax/libs/three.js/91/three.js',
       opt_onLayout
     );
-    Services.preconnectFor(this.win).url(this.getAmpDoc(),
+    preconnect.url(
+      this.getAmpDoc(),
       'https://cdn.jsdelivr.net/npm/three@0.91/examples/js/loaders/GLTFLoader.js',
       opt_onLayout
     );
-    Services.preconnectFor(this.win).url(this.getAmpDoc(),
+    preconnect.url(
+      this.getAmpDoc(),
       'https://cdn.jsdelivr.net/npm/three@0.91/examples/js/controls/OrbitControls.js',
       opt_onLayout
     );

--- a/extensions/amp-3d-gltf/0.1/amp-3d-gltf.js
+++ b/extensions/amp-3d-gltf/0.1/amp-3d-gltf.js
@@ -59,15 +59,15 @@ export class Amp3dGltf extends AMP.BaseElement {
    */
   preconnectCallback(opt_onLayout) {
     preloadBootstrap(this.win, this.preconnect);
-    this.preconnect.url(
+    Services.preconnectFor(this.win).url(this.getAmpDoc(),
       'https://cdnjs.cloudflare.com/ajax/libs/three.js/91/three.js',
       opt_onLayout
     );
-    this.preconnect.url(
+    Services.preconnectFor(this.win).url(this.getAmpDoc(),
       'https://cdn.jsdelivr.net/npm/three@0.91/examples/js/loaders/GLTFLoader.js',
       opt_onLayout
     );
-    this.preconnect.url(
+    Services.preconnectFor(this.win).url(this.getAmpDoc(),
       'https://cdn.jsdelivr.net/npm/three@0.91/examples/js/controls/OrbitControls.js',
       opt_onLayout
     );

--- a/extensions/amp-3d-gltf/0.1/amp-3d-gltf.js
+++ b/extensions/amp-3d-gltf/0.1/amp-3d-gltf.js
@@ -15,6 +15,7 @@
  */
 import {ActionTrust} from '../../../src/action-constants';
 import {Deferred} from '../../../src/utils/promise';
+import {Services} from '../../../src/services';
 import {assertHttpsUrl, resolveRelativeUrl} from '../../../src/url';
 import {dev, devAssert} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
@@ -58,7 +59,7 @@ export class Amp3dGltf extends AMP.BaseElement {
    * @override
    */
   preconnectCallback(opt_onLayout) {
-    preloadBootstrap(this.win, this.preconnect);
+    preloadBootstrap(this.win, this.getAmpDoc(), this.preconnect);
     Services.preconnectFor(this.win).url(this.getAmpDoc(),
       'https://cdnjs.cloudflare.com/ajax/libs/three.js/91/three.js',
       opt_onLayout

--- a/extensions/amp-3q-player/0.1/amp-3q-player.js
+++ b/extensions/amp-3q-player/0.1/amp-3q-player.js
@@ -61,7 +61,7 @@ class Amp3QPlayer extends AMP.BaseElement {
    * @override
    */
   preconnectCallback(opt_onLayout) {
-    this.preconnect.url('https://playout.3qsdn.com', opt_onLayout);
+    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://playout.3qsdn.com', opt_onLayout);
   }
 
   /** @override */

--- a/extensions/amp-3q-player/0.1/amp-3q-player.js
+++ b/extensions/amp-3q-player/0.1/amp-3q-player.js
@@ -61,7 +61,11 @@ class Amp3QPlayer extends AMP.BaseElement {
    * @override
    */
   preconnectCallback(opt_onLayout) {
-    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://playout.3qsdn.com', opt_onLayout);
+    Services.preconnectFor(this.win).url(
+      this.getAmpDoc(),
+      'https://playout.3qsdn.com',
+      opt_onLayout
+    );
   }
 
   /** @override */

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -498,7 +498,7 @@ export class AmpA4A extends AMP.BaseElement {
     // matches amp-ad loader predicate such that A4A impl does not load.
     if (preconnect) {
       preconnect.forEach(p => {
-        this.preconnect.url(p, /*opt_preloadAs*/ true);
+        Services.preconnectFor(this.win).url(this.getAmpDoc(), p, /*opt_preloadAs*/ true);
       });
     }
   }

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -498,7 +498,11 @@ export class AmpA4A extends AMP.BaseElement {
     // matches amp-ad loader predicate such that A4A impl does not load.
     if (preconnect) {
       preconnect.forEach(p => {
-        Services.preconnectFor(this.win).url(this.getAmpDoc(), p, /*opt_preloadAs*/ true);
+        Services.preconnectFor(this.win).url(
+          this.getAmpDoc(),
+          p,
+          /*opt_preloadAs*/ true
+        );
       });
     }
   }
@@ -758,7 +762,8 @@ export class AmpA4A extends AMP.BaseElement {
         if (
           this.experimentalNonAmpCreativeRenderMethod_ == XORIGIN_MODE.NAMEFRAME
         ) {
-          Services.preconnectFor(this.win).preload(this.getAmpDoc(),
+          Services.preconnectFor(this.win).preload(
+            this.getAmpDoc(),
             getDefaultBootstrapBaseUrl(this.win, 'nameframe')
           );
         }
@@ -770,7 +775,10 @@ export class AmpA4A extends AMP.BaseElement {
           safeframeVersionHeader != DEFAULT_SAFEFRAME_VERSION
         ) {
           this.safeframeVersion = safeframeVersionHeader;
-          Services.preconnectFor(this.win).preload(this.getAmpDoc(), this.getSafeframePath());
+          Services.preconnectFor(this.win).preload(
+            this.getAmpDoc(),
+            this.getSafeframePath()
+          );
         }
         // Note: Resolving a .then inside a .then because we need to capture
         // two fields of fetchResponse, one of which is, itself, a promise,
@@ -862,7 +870,9 @@ export class AmpA4A extends AMP.BaseElement {
         const urls = Services.urlForDoc(this.element);
         // Preload any AMP images.
         (creativeMetaDataDef.images || []).forEach(
-          image => urls.isSecure(image) && Services.preconnectFor(this.win).preload(this.getAmpDoc(), image)
+          image =>
+            urls.isSecure(image) &&
+            Services.preconnectFor(this.win).preload(this.getAmpDoc(), image)
         );
         return creativeMetaDataDef;
       })

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -758,7 +758,7 @@ export class AmpA4A extends AMP.BaseElement {
         if (
           this.experimentalNonAmpCreativeRenderMethod_ == XORIGIN_MODE.NAMEFRAME
         ) {
-          this.preconnect.preload(
+          Services.preconnectFor(this.win).preload(this.getAmpDoc(),
             getDefaultBootstrapBaseUrl(this.win, 'nameframe')
           );
         }
@@ -770,7 +770,7 @@ export class AmpA4A extends AMP.BaseElement {
           safeframeVersionHeader != DEFAULT_SAFEFRAME_VERSION
         ) {
           this.safeframeVersion = safeframeVersionHeader;
-          this.preconnect.preload(this.getSafeframePath());
+          Services.preconnectFor(this.win).preload(this.getAmpDoc(), this.getSafeframePath());
         }
         // Note: Resolving a .then inside a .then because we need to capture
         // two fields of fetchResponse, one of which is, itself, a promise,
@@ -856,13 +856,13 @@ export class AmpA4A extends AMP.BaseElement {
         );
         // Preload any fonts.
         (creativeMetaDataDef.customStylesheets || []).forEach(font =>
-          this.preconnect.preload(font.href)
+          Services.preconnectFor(this.win).preload(this.getAmpDoc(), font.href)
         );
 
         const urls = Services.urlForDoc(this.element);
         // Preload any AMP images.
         (creativeMetaDataDef.images || []).forEach(
-          image => urls.isSecure(image) && this.preconnect.preload(image)
+          image => urls.isSecure(image) && Services.preconnectFor(this.win).preload(this.getAmpDoc(), image)
         );
         return creativeMetaDataDef;
       })

--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -537,7 +537,10 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
 
   /** @override */
   getPreconnectUrls() {
-    Services.preconnectFor(this.win).preload(this.getAmpDoc(), getDefaultBootstrapBaseUrl(this.win, 'nameframe'));
+    Services.preconnectFor(this.win).preload(
+      this.getAmpDoc(),
+      getDefaultBootstrapBaseUrl(this.win, 'nameframe')
+    );
     return ['https://googleads.g.doubleclick.net'];
   }
 

--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -537,7 +537,7 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
 
   /** @override */
   getPreconnectUrls() {
-    this.preconnect.preload(getDefaultBootstrapBaseUrl(this.win, 'nameframe'));
+    Services.preconnectFor(this.win).preload(this.getAmpDoc(), getDefaultBootstrapBaseUrl(this.win, 'nameframe'));
     return ['https://googleads.g.doubleclick.net'];
   }
 

--- a/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
@@ -1236,12 +1236,16 @@ describes.realWin(
 
     describe('#preconnect', () => {
       it('should preload nameframe', () => {
-        const preloadSpy = env.sandbox.spy(Preconnect.prototype, 'preload');
+        const preconnect = Services.preconnectFor(win);
+        env.sandbox.spy(preconnect, 'preload');
         expect(impl.getPreconnectUrls()).to.deep.equal([
           'https://googleads.g.doubleclick.net',
         ]);
-        expect(preloadSpy).to.be.calledOnce;
-        expect(preloadSpy.args[0]).to.match(/nameframe/);
+        expect(preconnect.preload).to.be.calledOnce;
+        expect(preconnect.preload).to.be.calledWithMatch(
+          env.sandbox.match.object,
+          /nameframe/
+        );
       });
     });
 

--- a/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
@@ -30,7 +30,6 @@ import {
   AmpAdXOriginIframeHandler, // eslint-disable-line no-unused-vars
 } from '../../../amp-ad/0.1/amp-ad-xorigin-iframe-handler';
 import {CONSENT_POLICY_STATE} from '../../../../src/consent-state';
-import {Preconnect} from '../../../../src/preconnect';
 import {Services} from '../../../../src/services';
 import {
   addAttributesToElement,

--- a/extensions/amp-ad/0.1/amp-ad-3p-impl.js
+++ b/extensions/amp-ad/0.1/amp-ad-3p-impl.js
@@ -28,6 +28,7 @@ import {
   LayoutPriority,
   isLayoutSizeDefined,
 } from '../../../src/layout';
+import {Services} from '../../../src/services';
 import {adConfig} from '../../../ads/_config';
 import {clamp} from '../../../src/utils/math';
 import {computedStyle, setStyle} from '../../../src/style';
@@ -233,20 +234,26 @@ export class AmpAd3PImpl extends AMP.BaseElement {
    * @override
    */
   preconnectCallback(opt_onLayout) {
+    const preconnect = Services.preconnectFor(this.win);
     // We always need the bootstrap.
-    preloadBootstrap(this.win, this.getAmpDoc(), this.preconnect, this.config.remoteHTMLDisabled);
+    preloadBootstrap(
+      this.win,
+      this.getAmpDoc(),
+      preconnect,
+      this.config.remoteHTMLDisabled
+    );
     if (typeof this.config.prefetch == 'string') {
-      Services.preconnectFor(this.win).preload(this.getAmpDoc(), this.config.prefetch, 'script');
+      preconnect.preload(this.getAmpDoc(), this.config.prefetch, 'script');
     } else if (this.config.prefetch) {
       this.config.prefetch.forEach(p => {
-        Services.preconnectFor(this.win).preload(this.getAmpDoc(), p, 'script');
+        preconnect.preload(this.getAmpDoc(), p, 'script');
       });
     }
     if (typeof this.config.preconnect == 'string') {
-      Services.preconnectFor(this.win).url(this.getAmpDoc(), this.config.preconnect, opt_onLayout);
+      preconnect.url(this.getAmpDoc(), this.config.preconnect, opt_onLayout);
     } else if (this.config.preconnect) {
       this.config.preconnect.forEach(p => {
-        Services.preconnectFor(this.win).url(this.getAmpDoc(), p, opt_onLayout);
+        preconnect.url(this.getAmpDoc(), p, opt_onLayout);
       });
     }
     // If fully qualified src for ad script is specified we preconnect to it.
@@ -254,7 +261,7 @@ export class AmpAd3PImpl extends AMP.BaseElement {
     if (src) {
       // We only preconnect to the src because we cannot know whether the URL
       // will have caching headers set.
-      Services.preconnectFor(this.win).url(this.getAmpDoc(), src);
+      preconnect.url(this.getAmpDoc(), src);
     }
   }
 

--- a/extensions/amp-ad/0.1/amp-ad-3p-impl.js
+++ b/extensions/amp-ad/0.1/amp-ad-3p-impl.js
@@ -243,10 +243,10 @@ export class AmpAd3PImpl extends AMP.BaseElement {
       });
     }
     if (typeof this.config.preconnect == 'string') {
-      this.preconnect.url(this.config.preconnect, opt_onLayout);
+      Services.preconnectFor(this.win).url(this.getAmpDoc(), this.config.preconnect, opt_onLayout);
     } else if (this.config.preconnect) {
       this.config.preconnect.forEach(p => {
-        this.preconnect.url(p, opt_onLayout);
+        Services.preconnectFor(this.win).url(this.getAmpDoc(), p, opt_onLayout);
       });
     }
     // If fully qualified src for ad script is specified we preconnect to it.
@@ -254,7 +254,7 @@ export class AmpAd3PImpl extends AMP.BaseElement {
     if (src) {
       // We only preconnect to the src because we cannot know whether the URL
       // will have caching headers set.
-      this.preconnect.url(src);
+      Services.preconnectFor(this.win).url(this.getAmpDoc(), src);
     }
   }
 

--- a/extensions/amp-ad/0.1/amp-ad-3p-impl.js
+++ b/extensions/amp-ad/0.1/amp-ad-3p-impl.js
@@ -234,7 +234,7 @@ export class AmpAd3PImpl extends AMP.BaseElement {
    */
   preconnectCallback(opt_onLayout) {
     // We always need the bootstrap.
-    preloadBootstrap(this.win, this.preconnect, this.config.remoteHTMLDisabled);
+    preloadBootstrap(this.win, this.getAmpDoc(), this.preconnect, this.config.remoteHTMLDisabled);
     if (typeof this.config.prefetch == 'string') {
       Services.preconnectFor(this.win).preload(this.getAmpDoc(), this.config.prefetch, 'script');
     } else if (this.config.prefetch) {

--- a/extensions/amp-ad/0.1/amp-ad-3p-impl.js
+++ b/extensions/amp-ad/0.1/amp-ad-3p-impl.js
@@ -236,10 +236,10 @@ export class AmpAd3PImpl extends AMP.BaseElement {
     // We always need the bootstrap.
     preloadBootstrap(this.win, this.preconnect, this.config.remoteHTMLDisabled);
     if (typeof this.config.prefetch == 'string') {
-      this.preconnect.preload(this.config.prefetch, 'script');
+      Services.preconnectFor(this.win).preload(this.getAmpDoc(), this.config.prefetch, 'script');
     } else if (this.config.prefetch) {
       this.config.prefetch.forEach(p => {
-        this.preconnect.preload(p, 'script');
+        Services.preconnectFor(this.win).preload(this.getAmpDoc(), p, 'script');
       });
     }
     if (typeof this.config.preconnect == 'string') {

--- a/extensions/amp-addthis/0.1/amp-addthis.js
+++ b/extensions/amp-addthis/0.1/amp-addthis.js
@@ -245,13 +245,37 @@ class AmpAddThis extends AMP.BaseElement {
    * @override
    */
   preconnectCallback(opt_onLayout) {
-    Services.preconnectFor(this.win).url(this.getAmpDoc(), ORIGIN, opt_onLayout);
-    Services.preconnectFor(this.win).url(this.getAmpDoc(), API_SERVER, opt_onLayout);
-    Services.preconnectFor(this.win).url(this.getAmpDoc(), COOKIELESS_API_SERVER, opt_onLayout);
-    Services.preconnectFor(this.win).url(this.getAmpDoc(), SHARECOUNTER_SERVER, opt_onLayout);
+    Services.preconnectFor(this.win).url(
+      this.getAmpDoc(),
+      ORIGIN,
+      opt_onLayout
+    );
+    Services.preconnectFor(this.win).url(
+      this.getAmpDoc(),
+      API_SERVER,
+      opt_onLayout
+    );
+    Services.preconnectFor(this.win).url(
+      this.getAmpDoc(),
+      COOKIELESS_API_SERVER,
+      opt_onLayout
+    );
+    Services.preconnectFor(this.win).url(
+      this.getAmpDoc(),
+      SHARECOUNTER_SERVER,
+      opt_onLayout
+    );
     // Images, etc.:
-    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://cache.addthiscdn.com', opt_onLayout);
-    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://su.addthis.com', opt_onLayout);
+    Services.preconnectFor(this.win).url(
+      this.getAmpDoc(),
+      'https://cache.addthiscdn.com',
+      opt_onLayout
+    );
+    Services.preconnectFor(this.win).url(
+      this.getAmpDoc(),
+      'https://su.addthis.com',
+      opt_onLayout
+    );
   }
 
   /** @override */

--- a/extensions/amp-addthis/0.1/amp-addthis.js
+++ b/extensions/amp-addthis/0.1/amp-addthis.js
@@ -245,13 +245,13 @@ class AmpAddThis extends AMP.BaseElement {
    * @override
    */
   preconnectCallback(opt_onLayout) {
-    this.preconnect.url(ORIGIN, opt_onLayout);
-    this.preconnect.url(API_SERVER, opt_onLayout);
-    this.preconnect.url(COOKIELESS_API_SERVER, opt_onLayout);
-    this.preconnect.url(SHARECOUNTER_SERVER, opt_onLayout);
+    Services.preconnectFor(this.win).url(this.getAmpDoc(), ORIGIN, opt_onLayout);
+    Services.preconnectFor(this.win).url(this.getAmpDoc(), API_SERVER, opt_onLayout);
+    Services.preconnectFor(this.win).url(this.getAmpDoc(), COOKIELESS_API_SERVER, opt_onLayout);
+    Services.preconnectFor(this.win).url(this.getAmpDoc(), SHARECOUNTER_SERVER, opt_onLayout);
     // Images, etc.:
-    this.preconnect.url('https://cache.addthiscdn.com', opt_onLayout);
-    this.preconnect.url('https://su.addthis.com', opt_onLayout);
+    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://cache.addthiscdn.com', opt_onLayout);
+    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://su.addthis.com', opt_onLayout);
   }
 
   /** @override */

--- a/extensions/amp-addthis/0.1/amp-addthis.js
+++ b/extensions/amp-addthis/0.1/amp-addthis.js
@@ -245,37 +245,15 @@ class AmpAddThis extends AMP.BaseElement {
    * @override
    */
   preconnectCallback(opt_onLayout) {
-    Services.preconnectFor(this.win).url(
-      this.getAmpDoc(),
-      ORIGIN,
-      opt_onLayout
-    );
-    Services.preconnectFor(this.win).url(
-      this.getAmpDoc(),
-      API_SERVER,
-      opt_onLayout
-    );
-    Services.preconnectFor(this.win).url(
-      this.getAmpDoc(),
-      COOKIELESS_API_SERVER,
-      opt_onLayout
-    );
-    Services.preconnectFor(this.win).url(
-      this.getAmpDoc(),
-      SHARECOUNTER_SERVER,
-      opt_onLayout
-    );
+    const preconnect = Services.preconnectFor(this.win);
+    const ampdoc = this.getAmpDoc();
+    preconnect.url(ampdoc, ORIGIN, opt_onLayout);
+    preconnect.url(ampdoc, API_SERVER, opt_onLayout);
+    preconnect.url(ampdoc, COOKIELESS_API_SERVER, opt_onLayout);
+    preconnect.url(ampdoc, SHARECOUNTER_SERVER, opt_onLayout);
     // Images, etc.:
-    Services.preconnectFor(this.win).url(
-      this.getAmpDoc(),
-      'https://cache.addthiscdn.com',
-      opt_onLayout
-    );
-    Services.preconnectFor(this.win).url(
-      this.getAmpDoc(),
-      'https://su.addthis.com',
-      opt_onLayout
-    );
+    preconnect.url(ampdoc, 'https://cache.addthiscdn.com', opt_onLayout);
+    preconnect.url(ampdoc, 'https://su.addthis.com', opt_onLayout);
   }
 
   /** @override */

--- a/extensions/amp-analytics/0.1/amp-analytics.js
+++ b/extensions/amp-analytics/0.1/amp-analytics.js
@@ -392,7 +392,11 @@ export class AmpAnalytics extends AMP.BaseElement {
    * @visibleForTesting
    */
   preload(url, opt_preloadAs) {
-    Services.preconnectFor(this.win).preload(this.getAmpDoc(), url, opt_preloadAs);
+    Services.preconnectFor(this.win).preload(
+      this.getAmpDoc(),
+      url,
+      opt_preloadAs
+    );
   }
 
   /**

--- a/extensions/amp-analytics/0.1/amp-analytics.js
+++ b/extensions/amp-analytics/0.1/amp-analytics.js
@@ -295,9 +295,9 @@ export class AmpAnalytics extends AMP.BaseElement {
     );
 
     this.transport_.maybeInitIframeTransport(
-      this.getAmpDoc().win,
+      this.win,
       this.element,
-      this.preconnect
+      Services.preconnectFor(this.win)
     );
 
     const promises = [];
@@ -544,7 +544,7 @@ export class AmpAnalytics extends AMP.BaseElement {
           requests[k] = new RequestHandler(
             this.element,
             request,
-            this.preconnect,
+            Services.preconnectFor(this.win),
             this.transport_,
             this.isSandbox_
           );

--- a/extensions/amp-analytics/0.1/amp-analytics.js
+++ b/extensions/amp-analytics/0.1/amp-analytics.js
@@ -392,7 +392,7 @@ export class AmpAnalytics extends AMP.BaseElement {
    * @visibleForTesting
    */
   preload(url, opt_preloadAs) {
-    this.preconnect.preload(url, opt_preloadAs);
+    Services.preconnectFor(this.win).preload(this.getAmpDoc(), url, opt_preloadAs);
   }
 
   /**

--- a/extensions/amp-analytics/0.1/requests.js
+++ b/extensions/amp-analytics/0.1/requests.js
@@ -30,7 +30,7 @@ export class RequestHandler {
   /**
    * @param {!Element} element
    * @param {!JsonObject} request
-   * @param {!../../../src/preconnect.Preconnect} preconnect
+   * @param {!../../../src/preconnect.PreconnectService} preconnect
    * @param {./transport.Transport} transport
    * @param {boolean} isSandbox
    */
@@ -80,7 +80,7 @@ export class RequestHandler {
     /** @private {!Array<!Promise<!BatchSegmentDef>>} */
     this.batchSegmentPromises_ = [];
 
-    /** @private {!../../../src/preconnect.Preconnect} */
+    /** @private {!../../../src/preconnect.PreconnectService} */
     this.preconnect_ = preconnect;
 
     /** @private {./transport.Transport} */
@@ -249,7 +249,7 @@ export class RequestHandler {
       : baseUrlTemplatePromise;
 
     preconnectPromise.then(preUrl => {
-      this.preconnect_.url(preUrl, true);
+      this.preconnect_.url(this.ampdoc_, preUrl, true);
     });
 
     Promise.all([

--- a/extensions/amp-analytics/0.1/test/test-requests.js
+++ b/extensions/amp-analytics/0.1/test/test-requests.js
@@ -216,6 +216,7 @@ describes.realWin('Requests', {amp: 1}, env => {
         handler.send({}, {}, expansionOptions, {});
         yield macroTask();
         expect(preconnectSpy).to.be.calledWith(
+          env.sandbox.match.object, // AmpDoc
           'r2?cid=CLIENT_ID(scope)&var=expanded'
         );
       });

--- a/extensions/amp-analytics/0.1/test/test-transport.js
+++ b/extensions/amp-analytics/0.1/test/test-transport.js
@@ -21,6 +21,7 @@ import {
 } from '../../../../testing/test-helper';
 import {Transport} from '../transport';
 import {getMode} from '../../../../src/mode';
+import {installDocService} from '../../../../src/service/ampdoc-impl';
 import {installTimerService} from '../../../../src/service/timer-impl';
 import {loadPromise} from '../../../../src/event-helper';
 
@@ -44,6 +45,9 @@ describes.realWin(
       openXhrStub = env.sandbox.stub();
       sendXhrStub = env.sandbox.stub();
       sendBeaconStub = env.sandbox.stub();
+
+      // Needed for PreconnectService.
+      installDocService(win, true);
     });
 
     it('prefers beacon over xhrpost and image', () => {

--- a/extensions/amp-analytics/0.1/transport.js
+++ b/extensions/amp-analytics/0.1/transport.js
@@ -148,14 +148,18 @@ export class Transport {
    *
    * @param {!Window} win
    * @param {!Element} element
-   * @param {(!../../../src/preconnect.Preconnect)=} opt_preconnect
+   * @param {(!../../../src/preconnect.PreconnectService)=} opt_preconnect
    */
   maybeInitIframeTransport(win, element, opt_preconnect) {
     if (!this.options_['iframe'] || this.iframeTransport_) {
       return;
     }
     if (opt_preconnect) {
-      opt_preconnect.preload(getIframeTransportScriptUrl(win), 'script');
+      opt_preconnect.preload(
+        Services.ampdoc(element),
+        getIframeTransportScriptUrl(win),
+        'script'
+      );
     }
 
     const type = element.getAttribute('type');

--- a/extensions/amp-apester-media/0.1/amp-apester-media.js
+++ b/extensions/amp-apester-media/0.1/amp-apester-media.js
@@ -103,9 +103,9 @@ class AmpApesterMedia extends AMP.BaseElement {
    * @override
    */
   preconnectCallback(onLayout) {
-    this.preconnect.url(this.displayBaseUrl_, onLayout);
-    this.preconnect.url(this.rendererBaseUrl_, onLayout);
-    this.preconnect.url(this.staticContent_, onLayout);
+    Services.preconnectFor(this.win).url(this.getAmpDoc(), this.displayBaseUrl_, onLayout);
+    Services.preconnectFor(this.win).url(this.getAmpDoc(), this.rendererBaseUrl_, onLayout);
+    Services.preconnectFor(this.win).url(this.getAmpDoc(), this.staticContent_, onLayout);
   }
 
   /** @override */

--- a/extensions/amp-apester-media/0.1/amp-apester-media.js
+++ b/extensions/amp-apester-media/0.1/amp-apester-media.js
@@ -103,21 +103,10 @@ class AmpApesterMedia extends AMP.BaseElement {
    * @override
    */
   preconnectCallback(onLayout) {
-    Services.preconnectFor(this.win).url(
-      this.getAmpDoc(),
-      this.displayBaseUrl_,
-      onLayout
-    );
-    Services.preconnectFor(this.win).url(
-      this.getAmpDoc(),
-      this.rendererBaseUrl_,
-      onLayout
-    );
-    Services.preconnectFor(this.win).url(
-      this.getAmpDoc(),
-      this.staticContent_,
-      onLayout
-    );
+    const preconnect = Services.preconnectFor(this.win);
+    preconnect.url(this.getAmpDoc(), this.displayBaseUrl_, onLayout);
+    preconnect.url(this.getAmpDoc(), this.rendererBaseUrl_, onLayout);
+    preconnect.url(this.getAmpDoc(), this.staticContent_, onLayout);
   }
 
   /** @override */

--- a/extensions/amp-apester-media/0.1/amp-apester-media.js
+++ b/extensions/amp-apester-media/0.1/amp-apester-media.js
@@ -103,9 +103,21 @@ class AmpApesterMedia extends AMP.BaseElement {
    * @override
    */
   preconnectCallback(onLayout) {
-    Services.preconnectFor(this.win).url(this.getAmpDoc(), this.displayBaseUrl_, onLayout);
-    Services.preconnectFor(this.win).url(this.getAmpDoc(), this.rendererBaseUrl_, onLayout);
-    Services.preconnectFor(this.win).url(this.getAmpDoc(), this.staticContent_, onLayout);
+    Services.preconnectFor(this.win).url(
+      this.getAmpDoc(),
+      this.displayBaseUrl_,
+      onLayout
+    );
+    Services.preconnectFor(this.win).url(
+      this.getAmpDoc(),
+      this.rendererBaseUrl_,
+      onLayout
+    );
+    Services.preconnectFor(this.win).url(
+      this.getAmpDoc(),
+      this.staticContent_,
+      onLayout
+    );
   }
 
   /** @override */

--- a/extensions/amp-app-banner/0.1/amp-app-banner.js
+++ b/extensions/amp-app-banner/0.1/amp-app-banner.js
@@ -369,7 +369,7 @@ export class AmpAndroidAppBanner extends AbstractAppBanner {
     }
     Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://play.google.com', opt_onLayout);
     if (this.manifestHref_) {
-      this.preconnect.preload(this.manifestHref_);
+      Services.preconnectFor(this.win).preload(this.getAmpDoc(), this.manifestHref_);
     }
   }
 

--- a/extensions/amp-app-banner/0.1/amp-app-banner.js
+++ b/extensions/amp-app-banner/0.1/amp-app-banner.js
@@ -225,7 +225,11 @@ export class AmpIosAppBanner extends AbstractAppBanner {
     if (!this.element.parentNode) {
       return;
     }
-    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://itunes.apple.com', opt_onLayout);
+    Services.preconnectFor(this.win).url(
+      this.getAmpDoc(),
+      'https://itunes.apple.com',
+      opt_onLayout
+    );
   }
 
   /** @override */
@@ -367,9 +371,16 @@ export class AmpAndroidAppBanner extends AbstractAppBanner {
     if (!this.element.parentNode) {
       return;
     }
-    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://play.google.com', opt_onLayout);
+    Services.preconnectFor(this.win).url(
+      this.getAmpDoc(),
+      'https://play.google.com',
+      opt_onLayout
+    );
     if (this.manifestHref_) {
-      Services.preconnectFor(this.win).preload(this.getAmpDoc(), this.manifestHref_);
+      Services.preconnectFor(this.win).preload(
+        this.getAmpDoc(),
+        this.manifestHref_
+      );
     }
   }
 

--- a/extensions/amp-app-banner/0.1/amp-app-banner.js
+++ b/extensions/amp-app-banner/0.1/amp-app-banner.js
@@ -225,7 +225,7 @@ export class AmpIosAppBanner extends AbstractAppBanner {
     if (!this.element.parentNode) {
       return;
     }
-    this.preconnect.url('https://itunes.apple.com', opt_onLayout);
+    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://itunes.apple.com', opt_onLayout);
   }
 
   /** @override */
@@ -367,7 +367,7 @@ export class AmpAndroidAppBanner extends AbstractAppBanner {
     if (!this.element.parentNode) {
       return;
     }
-    this.preconnect.url('https://play.google.com', opt_onLayout);
+    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://play.google.com', opt_onLayout);
     if (this.manifestHref_) {
       this.preconnect.preload(this.manifestHref_);
     }

--- a/extensions/amp-app-banner/0.1/test/test-amp-app-banner.js
+++ b/extensions/amp-app-banner/0.1/test/test-amp-app-banner.js
@@ -159,12 +159,14 @@ describes.realWin(
     function testSuiteIos() {
       it('should preconnect to app store', () => {
         return getAppBanner({iosMeta}).then(banner => {
+          const preconnect = Services.preconnectFor(win);
+          env.sandbox.stub(preconnect, 'url');
+
           const impl = banner.implementation_;
-          env.sandbox.stub(impl.preconnect, 'url');
           impl.preconnectCallback(true);
-          expect(impl.preconnect.url.called).to.be.true;
-          expect(impl.preconnect.url).to.be.calledOnce;
-          expect(impl.preconnect.url).to.have.been.calledWith(
+          expect(preconnect.url).to.be.calledOnce;
+          expect(preconnect.url).to.have.been.calledWith(
+            env.sandbox.match.object, // AmpDoc
             'https://itunes.apple.com'
           );
         });
@@ -242,18 +244,21 @@ describes.realWin(
     function testSuiteAndroid() {
       it('should preconnect to play store and preload manifest', () => {
         return getAppBanner({androidManifest}).then(banner => {
+          const preconnect = Services.preconnectFor(win);
+          env.sandbox.stub(preconnect, 'url');
+          env.sandbox.stub(preconnect, 'preload');
+
           const impl = banner.implementation_;
-          env.sandbox.stub(impl.preconnect, 'url');
-          env.sandbox.stub(impl.preconnect, 'preload');
           impl.preconnectCallback(true);
-          expect(impl.preconnect.url.called).to.be.true;
-          expect(impl.preconnect.url).to.have.been.calledOnce;
-          expect(impl.preconnect.url).to.have.been.calledWith(
+          expect(preconnect.url).to.have.been.calledOnce;
+          expect(preconnect.url).to.have.been.calledWith(
+            env.sandbox.match.object, // AmpDoc
             'https://play.google.com'
           );
-          expect(impl.preconnect.preload.called).to.be.true;
-          expect(impl.preconnect.preload).to.be.calledOnce;
-          expect(impl.preconnect.preload).to.have.been.calledWith(
+
+          expect(preconnect.preload).to.be.calledOnce;
+          expect(preconnect.preload).to.have.been.calledWith(
+            env.sandbox.match.object, // AmpDoc
             'https://example.com/manifest.json'
           );
         });
@@ -261,18 +266,20 @@ describes.realWin(
 
       it('should preconnect to play store and preload origin-manifest', () => {
         return getAppBanner({originManifest: androidManifest}).then(banner => {
+          const preconnect = Services.preconnectFor(win);
+          env.sandbox.stub(preconnect, 'url');
+          env.sandbox.stub(preconnect, 'preload');
+
           const impl = banner.implementation_;
-          env.sandbox.stub(impl.preconnect, 'url');
-          env.sandbox.stub(impl.preconnect, 'preload');
           impl.preconnectCallback(true);
-          expect(impl.preconnect.url.called).to.be.true;
-          expect(impl.preconnect.url).to.have.been.calledOnce;
-          expect(impl.preconnect.url).to.have.been.calledWith(
+          expect(preconnect.url).to.have.been.calledOnce;
+          expect(preconnect.url).to.have.been.calledWith(
+            env.sandbox.match.object, // AmpDoc
             'https://play.google.com'
           );
-          expect(impl.preconnect.preload.called).to.be.true;
-          expect(impl.preconnect.preload).to.be.calledOnce;
-          expect(impl.preconnect.preload).to.have.been.calledWith(
+          expect(preconnect.preload).to.be.calledOnce;
+          expect(preconnect.preload).to.have.been.calledWith(
+            env.sandbox.match.object, // AmpDoc
             'https://example.com/manifest.json'
           );
         });

--- a/extensions/amp-auto-lightbox/0.1/amp-auto-lightbox.js
+++ b/extensions/amp-auto-lightbox/0.1/amp-auto-lightbox.js
@@ -245,6 +245,8 @@ export class Scanner {
   static getCandidates(root) {
     const selector = candidateSelector('amp-img');
     const candidates = toArray(root.querySelectorAll(selector));
+    // TODO(alanorozco): DOM mutations should be wrapped in mutate contexts.
+    // Alternatively, use in-memory "visited" marker instead of attribute.
     candidates.forEach(markAsVisited);
     return candidates;
   }

--- a/extensions/amp-beopinion/0.1/amp-beopinion.js
+++ b/extensions/amp-beopinion/0.1/amp-beopinion.js
@@ -39,9 +39,9 @@ class AmpBeOpinion extends AMP.BaseElement {
     preloadBootstrap(this.win, this.preconnect);
     // Hosts the script that renders widgets.
     this.preconnect.preload('https://widget.beopinion.com/sdk.js', 'script');
-    this.preconnect.url('https://s.beopinion.com', opt_onLayout);
-    this.preconnect.url('https://t.beopinion.com', opt_onLayout);
-    this.preconnect.url('https://data.beopinion.com', opt_onLayout);
+    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://s.beopinion.com', opt_onLayout);
+    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://t.beopinion.com', opt_onLayout);
+    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://data.beopinion.com', opt_onLayout);
   }
 
   /** @override */

--- a/extensions/amp-beopinion/0.1/amp-beopinion.js
+++ b/extensions/amp-beopinion/0.1/amp-beopinion.js
@@ -38,7 +38,7 @@ class AmpBeOpinion extends AMP.BaseElement {
   preconnectCallback(opt_onLayout) {
     preloadBootstrap(this.win, this.preconnect);
     // Hosts the script that renders widgets.
-    this.preconnect.preload('https://widget.beopinion.com/sdk.js', 'script');
+    Services.preconnectFor(this.win).preload(this.getAmpDoc(), 'https://widget.beopinion.com/sdk.js', 'script');
     Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://s.beopinion.com', opt_onLayout);
     Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://t.beopinion.com', opt_onLayout);
     Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://data.beopinion.com', opt_onLayout);

--- a/extensions/amp-beopinion/0.1/amp-beopinion.js
+++ b/extensions/amp-beopinion/0.1/amp-beopinion.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {Services} from '../../../src/services';
 import {getIframe, preloadBootstrap} from '../../../src/3p-frame';
 import {isLayoutSizeDefined} from '../../../src/layout';
 import {listenFor} from '../../../src/iframe-helper';
@@ -36,12 +37,21 @@ class AmpBeOpinion extends AMP.BaseElement {
    * @override
    */
   preconnectCallback(opt_onLayout) {
-    preloadBootstrap(this.win, this.getAmpDoc(), this.preconnect);
+    const preconnect = Services.preconnectFor(this.win);
+    preloadBootstrap(this.win, this.getAmpDoc(), preconnect);
     // Hosts the script that renders widgets.
-    Services.preconnectFor(this.win).preload(this.getAmpDoc(), 'https://widget.beopinion.com/sdk.js', 'script');
-    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://s.beopinion.com', opt_onLayout);
-    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://t.beopinion.com', opt_onLayout);
-    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://data.beopinion.com', opt_onLayout);
+    preconnect.preload(
+      this.getAmpDoc(),
+      'https://widget.beopinion.com/sdk.js',
+      'script'
+    );
+    preconnect.url(this.getAmpDoc(), 'https://s.beopinion.com', opt_onLayout);
+    preconnect.url(this.getAmpDoc(), 'https://t.beopinion.com', opt_onLayout);
+    preconnect.url(
+      this.getAmpDoc(),
+      'https://data.beopinion.com',
+      opt_onLayout
+    );
   }
 
   /** @override */

--- a/extensions/amp-beopinion/0.1/amp-beopinion.js
+++ b/extensions/amp-beopinion/0.1/amp-beopinion.js
@@ -36,7 +36,7 @@ class AmpBeOpinion extends AMP.BaseElement {
    * @override
    */
   preconnectCallback(opt_onLayout) {
-    preloadBootstrap(this.win, this.preconnect);
+    preloadBootstrap(this.win, this.getAmpDoc(), this.preconnect);
     // Hosts the script that renders widgets.
     Services.preconnectFor(this.win).preload(this.getAmpDoc(), 'https://widget.beopinion.com/sdk.js', 'script');
     Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://s.beopinion.com', opt_onLayout);

--- a/extensions/amp-bodymovin-animation/0.1/amp-bodymovin-animation.js
+++ b/extensions/amp-bodymovin-animation/0.1/amp-bodymovin-animation.js
@@ -76,7 +76,7 @@ export class AmpBodymovinAnimation extends AMP.BaseElement {
       this.renderer_ === 'svg'
         ? 'https://cdnjs.cloudflare.com/ajax/libs/bodymovin/4.13.0/bodymovin_light.min.js'
         : 'https://cdnjs.cloudflare.com/ajax/libs/bodymovin/4.13.0/bodymovin.min.js';
-    preloadBootstrap(this.win, this.preconnect);
+    preloadBootstrap(this.win, this.getAmpDoc(), this.preconnect);
     Services.preconnectFor(this.win).url(this.getAmpDoc(), scriptToLoad, opt_onLayout);
   }
 

--- a/extensions/amp-bodymovin-animation/0.1/amp-bodymovin-animation.js
+++ b/extensions/amp-bodymovin-animation/0.1/amp-bodymovin-animation.js
@@ -77,7 +77,7 @@ export class AmpBodymovinAnimation extends AMP.BaseElement {
         ? 'https://cdnjs.cloudflare.com/ajax/libs/bodymovin/4.13.0/bodymovin_light.min.js'
         : 'https://cdnjs.cloudflare.com/ajax/libs/bodymovin/4.13.0/bodymovin.min.js';
     preloadBootstrap(this.win, this.preconnect);
-    this.preconnect.url(scriptToLoad, opt_onLayout);
+    Services.preconnectFor(this.win).url(this.getAmpDoc(), scriptToLoad, opt_onLayout);
   }
 
   /** @override */

--- a/extensions/amp-bodymovin-animation/0.1/amp-bodymovin-animation.js
+++ b/extensions/amp-bodymovin-animation/0.1/amp-bodymovin-animation.js
@@ -72,12 +72,13 @@ export class AmpBodymovinAnimation extends AMP.BaseElement {
    * @override
    */
   preconnectCallback(opt_onLayout) {
+    const preconnect = Services.preconnectFor(this.win);
     const scriptToLoad =
       this.renderer_ === 'svg'
         ? 'https://cdnjs.cloudflare.com/ajax/libs/bodymovin/4.13.0/bodymovin_light.min.js'
         : 'https://cdnjs.cloudflare.com/ajax/libs/bodymovin/4.13.0/bodymovin.min.js';
-    preloadBootstrap(this.win, this.getAmpDoc(), this.preconnect);
-    Services.preconnectFor(this.win).url(this.getAmpDoc(), scriptToLoad, opt_onLayout);
+    preloadBootstrap(this.win, this.getAmpDoc(), preconnect);
+    preconnect.url(this.getAmpDoc(), scriptToLoad, opt_onLayout);
   }
 
   /** @override */

--- a/extensions/amp-brid-player/0.1/amp-brid-player.js
+++ b/extensions/amp-brid-player/0.1/amp-brid-player.js
@@ -79,8 +79,8 @@ class AmpBridPlayer extends AMP.BaseElement {
    * @override
    */
   preconnectCallback(opt_onLayout) {
-    this.preconnect.url('https://services.brid.tv', opt_onLayout);
-    this.preconnect.url('https://cdn.brid.tv', opt_onLayout);
+    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://services.brid.tv', opt_onLayout);
+    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://cdn.brid.tv', opt_onLayout);
   }
 
   /** @override */

--- a/extensions/amp-brid-player/0.1/amp-brid-player.js
+++ b/extensions/amp-brid-player/0.1/amp-brid-player.js
@@ -79,8 +79,16 @@ class AmpBridPlayer extends AMP.BaseElement {
    * @override
    */
   preconnectCallback(opt_onLayout) {
-    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://services.brid.tv', opt_onLayout);
-    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://cdn.brid.tv', opt_onLayout);
+    Services.preconnectFor(this.win).url(
+      this.getAmpDoc(),
+      'https://services.brid.tv',
+      opt_onLayout
+    );
+    Services.preconnectFor(this.win).url(
+      this.getAmpDoc(),
+      'https://cdn.brid.tv',
+      opt_onLayout
+    );
   }
 
   /** @override */

--- a/extensions/amp-brightcove/0.1/amp-brightcove.js
+++ b/extensions/amp-brightcove/0.1/amp-brightcove.js
@@ -89,7 +89,10 @@ class AmpBrightcove extends AMP.BaseElement {
 
   /** @override */
   preconnectCallback() {
-    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://players.brightcove.net');
+    Services.preconnectFor(this.win).url(
+      this.getAmpDoc(),
+      'https://players.brightcove.net'
+    );
   }
 
   /** @override */

--- a/extensions/amp-brightcove/0.1/amp-brightcove.js
+++ b/extensions/amp-brightcove/0.1/amp-brightcove.js
@@ -89,7 +89,7 @@ class AmpBrightcove extends AMP.BaseElement {
 
   /** @override */
   preconnectCallback() {
-    this.preconnect.url('https://players.brightcove.net');
+    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://players.brightcove.net');
   }
 
   /** @override */

--- a/extensions/amp-byside-content/0.1/amp-byside-content.js
+++ b/extensions/amp-byside-content/0.1/amp-byside-content.js
@@ -129,7 +129,11 @@ export class AmpBysideContent extends AMP.BaseElement {
    */
   preconnectCallback(onLayout) {
     if (this.origin_) {
-      Services.preconnectFor(this.win).url(this.getAmpDoc(), this.origin_, onLayout);
+      Services.preconnectFor(this.win).url(
+        this.getAmpDoc(),
+        this.origin_,
+        onLayout
+      );
     }
   }
 

--- a/extensions/amp-byside-content/0.1/amp-byside-content.js
+++ b/extensions/amp-byside-content/0.1/amp-byside-content.js
@@ -129,7 +129,7 @@ export class AmpBysideContent extends AMP.BaseElement {
    */
   preconnectCallback(onLayout) {
     if (this.origin_) {
-      this.preconnect.url(this.origin_, onLayout);
+      Services.preconnectFor(this.win).url(this.getAmpDoc(), this.origin_, onLayout);
     }
   }
 

--- a/extensions/amp-connatix-player/0.1/amp-connatix-player.js
+++ b/extensions/amp-connatix-player/0.1/amp-connatix-player.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {Services} from '../../../src/services';
 import {addParamsToUrl} from '../../../src/url';
 import {dict} from '../../../src/utils/object';
 import {getData} from '../../../src/event-helper';
@@ -111,7 +112,11 @@ export class AmpConnatixPlayer extends AMP.BaseElement {
    */
   preconnectCallback(onLayout) {
     // Serves the player assets
-    Services.preconnectFor(this.win).url(this.getAmpDoc(), this.iframeDomain_, onLayout);
+    Services.preconnectFor(this.win).url(
+      this.getAmpDoc(),
+      this.iframeDomain_,
+      onLayout
+    );
   }
 
   /** @override */

--- a/extensions/amp-connatix-player/0.1/amp-connatix-player.js
+++ b/extensions/amp-connatix-player/0.1/amp-connatix-player.js
@@ -111,7 +111,7 @@ export class AmpConnatixPlayer extends AMP.BaseElement {
    */
   preconnectCallback(onLayout) {
     // Serves the player assets
-    this.preconnect.url(this.iframeDomain_, onLayout);
+    Services.preconnectFor(this.win).url(this.getAmpDoc(), this.iframeDomain_, onLayout);
   }
 
   /** @override */

--- a/extensions/amp-dailymotion/0.1/amp-dailymotion.js
+++ b/extensions/amp-dailymotion/0.1/amp-dailymotion.js
@@ -112,9 +112,9 @@ class AmpDailymotion extends AMP.BaseElement {
    * @override
    */
   preconnectCallback(opt_onLayout) {
-    this.preconnect.url('https://www.dailymotion.com', opt_onLayout);
+    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://www.dailymotion.com', opt_onLayout);
     // Host that Dailymotion uses to serve JS needed by player.
-    this.preconnect.url('https://static1.dmcdn.net', opt_onLayout);
+    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://static1.dmcdn.net', opt_onLayout);
   }
 
   /**

--- a/extensions/amp-dailymotion/0.1/amp-dailymotion.js
+++ b/extensions/amp-dailymotion/0.1/amp-dailymotion.js
@@ -112,9 +112,17 @@ class AmpDailymotion extends AMP.BaseElement {
    * @override
    */
   preconnectCallback(opt_onLayout) {
-    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://www.dailymotion.com', opt_onLayout);
+    Services.preconnectFor(this.win).url(
+      this.getAmpDoc(),
+      'https://www.dailymotion.com',
+      opt_onLayout
+    );
     // Host that Dailymotion uses to serve JS needed by player.
-    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://static1.dmcdn.net', opt_onLayout);
+    Services.preconnectFor(this.win).url(
+      this.getAmpDoc(),
+      'https://static1.dmcdn.net',
+      opt_onLayout
+    );
   }
 
   /**

--- a/extensions/amp-delight-player/0.1/amp-delight-player.js
+++ b/extensions/amp-delight-player/0.1/amp-delight-player.js
@@ -119,7 +119,11 @@ class AmpDelightPlayer extends AMP.BaseElement {
    * @override
    */
   preconnectCallback(onLayout) {
-    Services.preconnectFor(this.win).url(this.getAmpDoc(), this.baseURL_, onLayout);
+    Services.preconnectFor(this.win).url(
+      this.getAmpDoc(),
+      this.baseURL_,
+      onLayout
+    );
   }
 
   /** @override */

--- a/extensions/amp-delight-player/0.1/amp-delight-player.js
+++ b/extensions/amp-delight-player/0.1/amp-delight-player.js
@@ -119,7 +119,7 @@ class AmpDelightPlayer extends AMP.BaseElement {
    * @override
    */
   preconnectCallback(onLayout) {
-    this.preconnect.url(this.baseURL_, onLayout);
+    Services.preconnectFor(this.win).url(this.getAmpDoc(), this.baseURL_, onLayout);
   }
 
   /** @override */

--- a/extensions/amp-embedly-card/0.1/amp-embedly-card-impl.js
+++ b/extensions/amp-embedly-card/0.1/amp-embedly-card-impl.js
@@ -16,6 +16,7 @@
 
 import {TAG as KEY_TAG} from './amp-embedly-key';
 import {Layout} from '../../../src/layout';
+import {Services} from '../../../src/services';
 import {getIframe} from '../../../src/3p-frame';
 import {listenFor} from '../../../src/iframe-helper';
 import {removeElement} from '../../../src/dom';
@@ -115,6 +116,10 @@ export class AmpEmbedlyCard extends AMP.BaseElement {
    * @override
    */
   preconnectCallback(opt_onLayout) {
-    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://cdn.embedly.com', opt_onLayout);
+    Services.preconnectFor(this.win).url(
+      this.getAmpDoc(),
+      'https://cdn.embedly.com',
+      opt_onLayout
+    );
   }
 }

--- a/extensions/amp-embedly-card/0.1/amp-embedly-card-impl.js
+++ b/extensions/amp-embedly-card/0.1/amp-embedly-card-impl.js
@@ -115,6 +115,6 @@ export class AmpEmbedlyCard extends AMP.BaseElement {
    * @override
    */
   preconnectCallback(opt_onLayout) {
-    this.preconnect.url('https://cdn.embedly.com', opt_onLayout);
+    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://cdn.embedly.com', opt_onLayout);
   }
 }

--- a/extensions/amp-facebook-comments/0.1/amp-facebook-comments.js
+++ b/extensions/amp-facebook-comments/0.1/amp-facebook-comments.js
@@ -60,7 +60,7 @@ class AmpFacebookComments extends AMP.BaseElement {
       'https://connect.facebook.net/' + this.dataLocale_ + '/sdk.js',
       'script'
     );
-    preloadBootstrap(this.win, this.preconnect);
+    preloadBootstrap(this.win, this.getAmpDoc(), this.preconnect);
   }
 
   /** @override */

--- a/extensions/amp-facebook-comments/0.1/amp-facebook-comments.js
+++ b/extensions/amp-facebook-comments/0.1/amp-facebook-comments.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {Services} from '../../../src/services';
 import {createLoaderLogo} from '../../amp-facebook/0.1/facebook-loader';
 import {dashToUnderline} from '../../../src/string';
 import {getData, listen} from '../../../src/event-helper';
@@ -54,13 +55,15 @@ class AmpFacebookComments extends AMP.BaseElement {
    * @override
    */
   preconnectCallback(opt_onLayout) {
-    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://facebook.com', opt_onLayout);
+    const preconnect = Services.preconnectFor(this.win);
+    preconnect.url(this.getAmpDoc(), 'https://facebook.com', opt_onLayout);
     // Hosts the facebook SDK.
-    Services.preconnectFor(this.win).preload(this.getAmpDoc(),
+    preconnect.preload(
+      this.getAmpDoc(),
       'https://connect.facebook.net/' + this.dataLocale_ + '/sdk.js',
       'script'
     );
-    preloadBootstrap(this.win, this.getAmpDoc(), this.preconnect);
+    preloadBootstrap(this.win, this.getAmpDoc(), preconnect);
   }
 
   /** @override */

--- a/extensions/amp-facebook-comments/0.1/amp-facebook-comments.js
+++ b/extensions/amp-facebook-comments/0.1/amp-facebook-comments.js
@@ -54,7 +54,7 @@ class AmpFacebookComments extends AMP.BaseElement {
    * @override
    */
   preconnectCallback(opt_onLayout) {
-    this.preconnect.url('https://facebook.com', opt_onLayout);
+    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://facebook.com', opt_onLayout);
     // Hosts the facebook SDK.
     this.preconnect.preload(
       'https://connect.facebook.net/' + this.dataLocale_ + '/sdk.js',

--- a/extensions/amp-facebook-comments/0.1/amp-facebook-comments.js
+++ b/extensions/amp-facebook-comments/0.1/amp-facebook-comments.js
@@ -56,7 +56,7 @@ class AmpFacebookComments extends AMP.BaseElement {
   preconnectCallback(opt_onLayout) {
     Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://facebook.com', opt_onLayout);
     // Hosts the facebook SDK.
-    this.preconnect.preload(
+    Services.preconnectFor(this.win).preload(this.getAmpDoc(),
       'https://connect.facebook.net/' + this.dataLocale_ + '/sdk.js',
       'script'
     );

--- a/extensions/amp-facebook-like/0.1/amp-facebook-like.js
+++ b/extensions/amp-facebook-like/0.1/amp-facebook-like.js
@@ -53,7 +53,7 @@ class AmpFacebookLike extends AMP.BaseElement {
    * @override
    */
   preconnectCallback(opt_onLayout) {
-    this.preconnect.url('https://facebook.com', opt_onLayout);
+    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://facebook.com', opt_onLayout);
     // Hosts the facebook SDK.
     this.preconnect.preload(
       'https://connect.facebook.net/' + this.dataLocale_ + '/sdk.js',

--- a/extensions/amp-facebook-like/0.1/amp-facebook-like.js
+++ b/extensions/amp-facebook-like/0.1/amp-facebook-like.js
@@ -55,7 +55,7 @@ class AmpFacebookLike extends AMP.BaseElement {
   preconnectCallback(opt_onLayout) {
     Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://facebook.com', opt_onLayout);
     // Hosts the facebook SDK.
-    this.preconnect.preload(
+    Services.preconnectFor(this.win).preload(this.getAmpDoc(),
       'https://connect.facebook.net/' + this.dataLocale_ + '/sdk.js',
       'script'
     );

--- a/extensions/amp-facebook-like/0.1/amp-facebook-like.js
+++ b/extensions/amp-facebook-like/0.1/amp-facebook-like.js
@@ -55,11 +55,7 @@ class AmpFacebookLike extends AMP.BaseElement {
    */
   preconnectCallback(opt_onLayout) {
     const preconnect = Services.preconnectFor(this.win);
-    preconnect.url(
-      this.getAmpDoc(),
-      'https://facebook.com',
-      opt_onLayout
-    );
+    preconnect.url(this.getAmpDoc(), 'https://facebook.com', opt_onLayout);
     // Hosts the facebook SDK.
     preconnect.preload(
       this.getAmpDoc(),

--- a/extensions/amp-facebook-like/0.1/amp-facebook-like.js
+++ b/extensions/amp-facebook-like/0.1/amp-facebook-like.js
@@ -59,7 +59,7 @@ class AmpFacebookLike extends AMP.BaseElement {
       'https://connect.facebook.net/' + this.dataLocale_ + '/sdk.js',
       'script'
     );
-    preloadBootstrap(this.win, this.preconnect);
+    preloadBootstrap(this.win, this.getAmpDoc(), this.preconnect);
   }
 
   /** @override */

--- a/extensions/amp-facebook-like/0.1/amp-facebook-like.js
+++ b/extensions/amp-facebook-like/0.1/amp-facebook-like.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {Services} from '../../../src/services';
 import {dashToUnderline} from '../../../src/string';
 import {getData, listen} from '../../../src/event-helper';
 import {getIframe, preloadBootstrap} from '../../../src/3p-frame';
@@ -53,13 +54,19 @@ class AmpFacebookLike extends AMP.BaseElement {
    * @override
    */
   preconnectCallback(opt_onLayout) {
-    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://facebook.com', opt_onLayout);
+    const preconnect = Services.preconnectFor(this.win);
+    preconnect.url(
+      this.getAmpDoc(),
+      'https://facebook.com',
+      opt_onLayout
+    );
     // Hosts the facebook SDK.
-    Services.preconnectFor(this.win).preload(this.getAmpDoc(),
+    preconnect.preload(
+      this.getAmpDoc(),
       'https://connect.facebook.net/' + this.dataLocale_ + '/sdk.js',
       'script'
     );
-    preloadBootstrap(this.win, this.getAmpDoc(), this.preconnect);
+    preloadBootstrap(this.win, this.getAmpDoc(), preconnect);
   }
 
   /** @override */

--- a/extensions/amp-facebook-page/0.1/amp-facebook-page.js
+++ b/extensions/amp-facebook-page/0.1/amp-facebook-page.js
@@ -60,7 +60,7 @@ class AmpFacebookPage extends AMP.BaseElement {
       'https://connect.facebook.net/' + this.dataLocale_ + '/sdk.js',
       'script'
     );
-    preloadBootstrap(this.win, this.preconnect);
+    preloadBootstrap(this.win, this.getAmpDoc(), this.preconnect);
   }
 
   /** @override */

--- a/extensions/amp-facebook-page/0.1/amp-facebook-page.js
+++ b/extensions/amp-facebook-page/0.1/amp-facebook-page.js
@@ -54,7 +54,7 @@ class AmpFacebookPage extends AMP.BaseElement {
    * @override
    */
   preconnectCallback(opt_onLayout) {
-    this.preconnect.url('https://facebook.com', opt_onLayout);
+    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://facebook.com', opt_onLayout);
     // Hosts the facebook SDK.
     this.preconnect.preload(
       'https://connect.facebook.net/' + this.dataLocale_ + '/sdk.js',

--- a/extensions/amp-facebook-page/0.1/amp-facebook-page.js
+++ b/extensions/amp-facebook-page/0.1/amp-facebook-page.js
@@ -54,13 +54,15 @@ class AmpFacebookPage extends AMP.BaseElement {
    * @override
    */
   preconnectCallback(opt_onLayout) {
-    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://facebook.com', opt_onLayout);
+    const preconnect = Services.preconnectFor(this.win);
+    preconnect.url(this.getAmpDoc(), 'https://facebook.com', opt_onLayout);
     // Hosts the facebook SDK.
-    Services.preconnectFor(this.win).preload(this.getAmpDoc(),
+    preconnect.preload(
+      this.getAmpDoc(),
       'https://connect.facebook.net/' + this.dataLocale_ + '/sdk.js',
       'script'
     );
-    preloadBootstrap(this.win, this.getAmpDoc(), this.preconnect);
+    preloadBootstrap(this.win, this.getAmpDoc(), preconnect);
   }
 
   /** @override */

--- a/extensions/amp-facebook-page/0.1/amp-facebook-page.js
+++ b/extensions/amp-facebook-page/0.1/amp-facebook-page.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {Services} from '../../../src/services';
 import {createLoaderLogo} from '../../amp-facebook/0.1/facebook-loader';
 import {dashToUnderline} from '../../../src/string';
 import {getData, listen} from '../../../src/event-helper';

--- a/extensions/amp-facebook-page/0.1/amp-facebook-page.js
+++ b/extensions/amp-facebook-page/0.1/amp-facebook-page.js
@@ -56,7 +56,7 @@ class AmpFacebookPage extends AMP.BaseElement {
   preconnectCallback(opt_onLayout) {
     Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://facebook.com', opt_onLayout);
     // Hosts the facebook SDK.
-    this.preconnect.preload(
+    Services.preconnectFor(this.win).preload(this.getAmpDoc(),
       'https://connect.facebook.net/' + this.dataLocale_ + '/sdk.js',
       'script'
     );

--- a/extensions/amp-facebook/0.1/amp-facebook.js
+++ b/extensions/amp-facebook/0.1/amp-facebook.js
@@ -58,7 +58,7 @@ class AmpFacebook extends AMP.BaseElement {
    * @override
    */
   preconnectCallback(opt_onLayout) {
-    this.preconnect.url('https://facebook.com', opt_onLayout);
+    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://facebook.com', opt_onLayout);
     // Hosts the facebook SDK.
     this.preconnect.preload(
       'https://connect.facebook.net/' + this.dataLocale_ + '/sdk.js',

--- a/extensions/amp-facebook/0.1/amp-facebook.js
+++ b/extensions/amp-facebook/0.1/amp-facebook.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {Services} from '../../../src/services';
 import {createLoaderLogo} from './facebook-loader';
 import {dashToUnderline} from '../../../src/string';
 import {getData, listen} from '../../../src/event-helper';
@@ -58,13 +59,15 @@ class AmpFacebook extends AMP.BaseElement {
    * @override
    */
   preconnectCallback(opt_onLayout) {
-    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://facebook.com', opt_onLayout);
+    const preconnect = Services.preconnectFor(this.win);
+    preconnect.url(this.getAmpDoc(), 'https://facebook.com', opt_onLayout);
     // Hosts the facebook SDK.
-    Services.preconnectFor(this.win).preload(this.getAmpDoc(),
+    preconnect.preload(
+      this.getAmpDoc(),
       'https://connect.facebook.net/' + this.dataLocale_ + '/sdk.js',
       'script'
     );
-    preloadBootstrap(this.win, this.getAmpDoc(), this.preconnect);
+    preloadBootstrap(this.win, this.getAmpDoc(), preconnect);
   }
 
   /** @override */

--- a/extensions/amp-facebook/0.1/amp-facebook.js
+++ b/extensions/amp-facebook/0.1/amp-facebook.js
@@ -60,7 +60,7 @@ class AmpFacebook extends AMP.BaseElement {
   preconnectCallback(opt_onLayout) {
     Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://facebook.com', opt_onLayout);
     // Hosts the facebook SDK.
-    this.preconnect.preload(
+    Services.preconnectFor(this.win).preload(this.getAmpDoc(),
       'https://connect.facebook.net/' + this.dataLocale_ + '/sdk.js',
       'script'
     );

--- a/extensions/amp-facebook/0.1/amp-facebook.js
+++ b/extensions/amp-facebook/0.1/amp-facebook.js
@@ -64,7 +64,7 @@ class AmpFacebook extends AMP.BaseElement {
       'https://connect.facebook.net/' + this.dataLocale_ + '/sdk.js',
       'script'
     );
-    preloadBootstrap(this.win, this.preconnect);
+    preloadBootstrap(this.win, this.getAmpDoc(), this.preconnect);
   }
 
   /** @override */

--- a/extensions/amp-gfycat/0.1/amp-gfycat.js
+++ b/extensions/amp-gfycat/0.1/amp-gfycat.js
@@ -53,24 +53,14 @@ class AmpGfycat extends AMP.BaseElement {
    * @override
    */
   preconnectCallback(opt_onLayout) {
+    const preconnect = Services.preconnectFor(this.win);
+    const ampdoc = this.getAmpDoc();
     // Gfycat iframe
-    Services.preconnectFor(this.win).url(
-      this.getAmpDoc(),
-      'https://gfycat.com',
-      opt_onLayout
-    );
+    preconnect.url(ampdoc, 'https://gfycat.com', opt_onLayout);
 
     // Iframe video and poster urls
-    Services.preconnectFor(this.win).url(
-      this.getAmpDoc(),
-      'https://giant.gfycat.com',
-      opt_onLayout
-    );
-    Services.preconnectFor(this.win).url(
-      this.getAmpDoc(),
-      'https://thumbs.gfycat.com',
-      opt_onLayout
-    );
+    preconnect.url(ampdoc, 'https://giant.gfycat.com', opt_onLayout);
+    preconnect.url(ampdoc, 'https://thumbs.gfycat.com', opt_onLayout);
   }
 
   /** @override */

--- a/extensions/amp-gfycat/0.1/amp-gfycat.js
+++ b/extensions/amp-gfycat/0.1/amp-gfycat.js
@@ -54,11 +54,23 @@ class AmpGfycat extends AMP.BaseElement {
    */
   preconnectCallback(opt_onLayout) {
     // Gfycat iframe
-    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://gfycat.com', opt_onLayout);
+    Services.preconnectFor(this.win).url(
+      this.getAmpDoc(),
+      'https://gfycat.com',
+      opt_onLayout
+    );
 
     // Iframe video and poster urls
-    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://giant.gfycat.com', opt_onLayout);
-    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://thumbs.gfycat.com', opt_onLayout);
+    Services.preconnectFor(this.win).url(
+      this.getAmpDoc(),
+      'https://giant.gfycat.com',
+      opt_onLayout
+    );
+    Services.preconnectFor(this.win).url(
+      this.getAmpDoc(),
+      'https://thumbs.gfycat.com',
+      opt_onLayout
+    );
   }
 
   /** @override */

--- a/extensions/amp-gfycat/0.1/amp-gfycat.js
+++ b/extensions/amp-gfycat/0.1/amp-gfycat.js
@@ -54,11 +54,11 @@ class AmpGfycat extends AMP.BaseElement {
    */
   preconnectCallback(opt_onLayout) {
     // Gfycat iframe
-    this.preconnect.url('https://gfycat.com', opt_onLayout);
+    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://gfycat.com', opt_onLayout);
 
     // Iframe video and poster urls
-    this.preconnect.url('https://giant.gfycat.com', opt_onLayout);
-    this.preconnect.url('https://thumbs.gfycat.com', opt_onLayout);
+    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://giant.gfycat.com', opt_onLayout);
+    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://thumbs.gfycat.com', opt_onLayout);
   }
 
   /** @override */

--- a/extensions/amp-gist/0.1/amp-gist.js
+++ b/extensions/amp-gist/0.1/amp-gist.js
@@ -28,6 +28,7 @@
  */
 
 import {Layout} from '../../../src/layout';
+import {Services} from '../../../src/services';
 import {getIframe} from '../../../src/3p-frame';
 import {listenFor} from '../../../src/iframe-helper';
 import {removeElement} from '../../../src/dom';
@@ -46,7 +47,11 @@ export class AmpGist extends AMP.BaseElement {
    * @override
    */
   preconnectCallback(opt_onLayout) {
-    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://gist.github.com/', opt_onLayout);
+    Services.preconnectFor(this.win).url(
+      this.getAmpDoc(),
+      'https://gist.github.com/',
+      opt_onLayout
+    );
   }
 
   /** @override */

--- a/extensions/amp-gist/0.1/amp-gist.js
+++ b/extensions/amp-gist/0.1/amp-gist.js
@@ -46,7 +46,7 @@ export class AmpGist extends AMP.BaseElement {
    * @override
    */
   preconnectCallback(opt_onLayout) {
-    this.preconnect.url('https://gist.github.com/', opt_onLayout);
+    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://gist.github.com/', opt_onLayout);
   }
 
   /** @override */

--- a/extensions/amp-google-document-embed/0.1/amp-google-document-embed.js
+++ b/extensions/amp-google-document-embed/0.1/amp-google-document-embed.js
@@ -53,7 +53,7 @@ export class AmpDriveViewer extends AMP.BaseElement {
    * @override
    */
   preconnectCallback(opt_onLayout) {
-    this.preconnect.url('https://docs.google.com', opt_onLayout);
+    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://docs.google.com', opt_onLayout);
   }
 
   /** @override */

--- a/extensions/amp-google-document-embed/0.1/amp-google-document-embed.js
+++ b/extensions/amp-google-document-embed/0.1/amp-google-document-embed.js
@@ -27,6 +27,7 @@
  * </code>
  */
 
+import {Services} from '../../../src/services';
 import {addParamToUrl} from '../../../src/url';
 import {dev, userAssert} from '../../../src/log';
 import {isLayoutSizeDefined} from '../../../src/layout';
@@ -53,7 +54,11 @@ export class AmpDriveViewer extends AMP.BaseElement {
    * @override
    */
   preconnectCallback(opt_onLayout) {
-    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://docs.google.com', opt_onLayout);
+    Services.preconnectFor(this.win).url(
+      this.getAmpDoc(),
+      'https://docs.google.com',
+      opt_onLayout
+    );
   }
 
   /** @override */

--- a/extensions/amp-google-vrview-image/0.1/amp-google-vrview-image.js
+++ b/extensions/amp-google-vrview-image/0.1/amp-google-vrview-image.js
@@ -71,8 +71,8 @@ class AmpGoogleVrviewImage extends AMP.BaseElement {
   /** @override */
   preconnectCallback() {
     if (this.src_) {
-      this.preconnect.preload(this.src_);
-      this.preconnect.preload(this.imageSrc_);
+      Services.preconnectFor(this.win).preload(this.getAmpDoc(), this.src_);
+      Services.preconnectFor(this.win).preload(this.getAmpDoc(), this.imageSrc_);
     }
   }
 

--- a/extensions/amp-google-vrview-image/0.1/amp-google-vrview-image.js
+++ b/extensions/amp-google-vrview-image/0.1/amp-google-vrview-image.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {Services} from '../../../src/services';
 import {addParamToUrl, assertHttpsUrl} from '../../../src/url';
 import {isExperimentOn} from '../../../src/experiments';
 import {isLayoutSizeDefined} from '../../../src/layout';
@@ -72,7 +73,10 @@ class AmpGoogleVrviewImage extends AMP.BaseElement {
   preconnectCallback() {
     if (this.src_) {
       Services.preconnectFor(this.win).preload(this.getAmpDoc(), this.src_);
-      Services.preconnectFor(this.win).preload(this.getAmpDoc(), this.imageSrc_);
+      Services.preconnectFor(this.win).preload(
+        this.getAmpDoc(),
+        this.imageSrc_
+      );
     }
   }
 

--- a/extensions/amp-hulu/0.1/amp-hulu.js
+++ b/extensions/amp-hulu/0.1/amp-hulu.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {Services} from '../../../src/services';
 import {devAssert, userAssert} from '../../../src/log';
 import {isLayoutSizeDefined} from '../../../src/layout';
 import {removeElement} from '../../../src/dom';
@@ -32,7 +33,10 @@ class AmpHulu extends AMP.BaseElement {
 
   /** @override */
   preconnectCallback() {
-    Services.preconnectFor(this.win).preload(this.getAmpDoc(), this.getVideoIframeSrc_());
+    Services.preconnectFor(this.win).preload(
+      this.getAmpDoc(),
+      this.getVideoIframeSrc_()
+    );
   }
 
   /** @override */

--- a/extensions/amp-hulu/0.1/amp-hulu.js
+++ b/extensions/amp-hulu/0.1/amp-hulu.js
@@ -32,7 +32,7 @@ class AmpHulu extends AMP.BaseElement {
 
   /** @override */
   preconnectCallback() {
-    this.preconnect.preload(this.getVideoIframeSrc_());
+    Services.preconnectFor(this.win).preload(this.getAmpDoc(), this.getVideoIframeSrc_());
   }
 
   /** @override */

--- a/extensions/amp-iframe/0.1/amp-iframe.js
+++ b/extensions/amp-iframe/0.1/amp-iframe.js
@@ -276,7 +276,11 @@ export class AmpIframe extends AMP.BaseElement {
    */
   preconnectCallback(onLayout) {
     if (this.iframeSrc) {
-      Services.preconnectFor(this.win).url(this.getAmpDoc(), this.iframeSrc, onLayout);
+      Services.preconnectFor(this.win).url(
+        this.getAmpDoc(),
+        this.iframeSrc,
+        onLayout
+      );
     }
   }
 

--- a/extensions/amp-iframe/0.1/amp-iframe.js
+++ b/extensions/amp-iframe/0.1/amp-iframe.js
@@ -276,7 +276,7 @@ export class AmpIframe extends AMP.BaseElement {
    */
   preconnectCallback(onLayout) {
     if (this.iframeSrc) {
-      this.preconnect.url(this.iframeSrc, onLayout);
+      Services.preconnectFor(this.win).url(this.getAmpDoc(), this.iframeSrc, onLayout);
     }
   }
 

--- a/extensions/amp-ima-video/0.1/amp-ima-video.js
+++ b/extensions/amp-ima-video/0.1/amp-ima-video.js
@@ -149,7 +149,7 @@ class AmpImaVideo extends AMP.BaseElement {
       preconnect.url(this.preconnectTrack_);
     }
     preconnect.url(element.getAttribute('data-tag'));
-    preloadBootstrap(this.win, preconnect);
+    preloadBootstrap(this.win, this.getAmpDoc(), preconnect);
   }
 
   /** @override */

--- a/extensions/amp-ima-video/0.1/amp-ima-video.js
+++ b/extensions/amp-ima-video/0.1/amp-ima-video.js
@@ -136,20 +136,21 @@ class AmpImaVideo extends AMP.BaseElement {
     const {element} = this;
     const preconnect = Services.preconnectFor(this.win);
     preconnect.preload(
+      this.getAmpDoc(),
       'https://imasdk.googleapis.com/js/sdkloader/ima3.js',
       'script'
     );
     const source = element.getAttribute('data-src');
     if (source) {
-      preconnect.url(source);
+      preconnect.url(this.getAmpDoc(), source);
     }
     if (this.preconnectSource_) {
-      preconnect.url(this.preconnectSource_);
+      preconnect.url(this.getAmpDoc(), this.preconnectSource_);
     }
     if (this.preconnectTrack_) {
-      preconnect.url(this.preconnectTrack_);
+      preconnect.url(this.getAmpDoc(), this.preconnectTrack_);
     }
-    preconnect.url(element.getAttribute('data-tag'));
+    preconnect.url(this.getAmpDoc(), element.getAttribute('data-tag'));
     preloadBootstrap(this.win, this.getAmpDoc(), preconnect);
   }
 

--- a/extensions/amp-ima-video/0.1/amp-ima-video.js
+++ b/extensions/amp-ima-video/0.1/amp-ima-video.js
@@ -133,7 +133,8 @@ class AmpImaVideo extends AMP.BaseElement {
 
   /** @override */
   preconnectCallback() {
-    const {element, preconnect} = this;
+    const {element} = this;
+    const preconnect = Services.preconnectFor(this.win);
     preconnect.preload(
       'https://imasdk.googleapis.com/js/sdkloader/ima3.js',
       'script'

--- a/extensions/amp-instagram/0.1/amp-instagram.js
+++ b/extensions/amp-instagram/0.1/amp-instagram.js
@@ -75,10 +75,10 @@ class AmpInstagram extends AMP.BaseElement {
   preconnectCallback(opt_onLayout) {
     // See
     // https://instagram.com/developer/embedding/?hl=en
-    this.preconnect.url('https://www.instagram.com', opt_onLayout);
+    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://www.instagram.com', opt_onLayout);
     // Host instagram used for image serving. While the host name is
     // funky this appears to be stable in the post-domain sharding era.
-    this.preconnect.url(
+    Services.preconnectFor(this.win).url(this.getAmpDoc(),
       'https://instagram.fsnc1-1.fna.fbcdn.net',
       opt_onLayout
     );

--- a/extensions/amp-instagram/0.1/amp-instagram.js
+++ b/extensions/amp-instagram/0.1/amp-instagram.js
@@ -36,6 +36,7 @@
  */
 
 import {CSS} from '../../../build/amp-instagram-0.1.css';
+import {Services} from '../../../src/services';
 import {getData, listen} from '../../../src/event-helper';
 import {isLayoutSizeDefined} from '../../../src/layout';
 import {isObject} from '../../../src/types';
@@ -75,10 +76,15 @@ class AmpInstagram extends AMP.BaseElement {
   preconnectCallback(opt_onLayout) {
     // See
     // https://instagram.com/developer/embedding/?hl=en
-    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://www.instagram.com', opt_onLayout);
+    Services.preconnectFor(this.win).url(
+      this.getAmpDoc(),
+      'https://www.instagram.com',
+      opt_onLayout
+    );
     // Host instagram used for image serving. While the host name is
     // funky this appears to be stable in the post-domain sharding era.
-    Services.preconnectFor(this.win).url(this.getAmpDoc(),
+    Services.preconnectFor(this.win).url(
+      this.getAmpDoc(),
       'https://instagram.fsnc1-1.fna.fbcdn.net',
       opt_onLayout
     );

--- a/extensions/amp-izlesene/0.1/amp-izlesene.js
+++ b/extensions/amp-izlesene/0.1/amp-izlesene.js
@@ -40,9 +40,9 @@ class AmpIzlesene extends AMP.BaseElement {
    * @override
    */
   preconnectCallback(opt_onLayout) {
-    this.preconnect.url(this.getVideoIframeSrc_());
+    Services.preconnectFor(this.win).url(this.getAmpDoc(), this.getVideoIframeSrc_());
     // Host that Izlesene uses to serve poster frames needed by player.
-    this.preconnect.url('https://i1.imgiz.com', opt_onLayout);
+    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://i1.imgiz.com', opt_onLayout);
   }
 
   /** @override */

--- a/extensions/amp-izlesene/0.1/amp-izlesene.js
+++ b/extensions/amp-izlesene/0.1/amp-izlesene.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {Services} from '../../../src/services';
 import {addParamsToUrl} from '../../../src/url';
 import {devAssert, userAssert} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
@@ -40,9 +41,16 @@ class AmpIzlesene extends AMP.BaseElement {
    * @override
    */
   preconnectCallback(opt_onLayout) {
-    Services.preconnectFor(this.win).url(this.getAmpDoc(), this.getVideoIframeSrc_());
+    Services.preconnectFor(this.win).url(
+      this.getAmpDoc(),
+      this.getVideoIframeSrc_()
+    );
     // Host that Izlesene uses to serve poster frames needed by player.
-    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://i1.imgiz.com', opt_onLayout);
+    Services.preconnectFor(this.win).url(
+      this.getAmpDoc(),
+      'https://i1.imgiz.com',
+      opt_onLayout
+    );
   }
 
   /** @override */

--- a/extensions/amp-jwplayer/0.1/amp-jwplayer.js
+++ b/extensions/amp-jwplayer/0.1/amp-jwplayer.js
@@ -53,9 +53,9 @@ class AmpJWPlayer extends AMP.BaseElement {
    */
   preconnectCallback(onLayout) {
     // Host that serves player configuration and content redirects
-    this.preconnect.url('https://content.jwplatform.com', onLayout);
+    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://content.jwplatform.com', onLayout);
     // CDN which hosts jwplayer assets
-    this.preconnect.url('https://ssl.p.jwpcdn.com', onLayout);
+    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://ssl.p.jwpcdn.com', onLayout);
   }
 
   /** @override */

--- a/extensions/amp-jwplayer/0.1/amp-jwplayer.js
+++ b/extensions/amp-jwplayer/0.1/amp-jwplayer.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {Services} from '../../../src/services';
 import {addParamsToUrl} from '../../../src/url';
 import {dict} from '../../../src/utils/object';
 import {isLayoutSizeDefined} from '../../../src/layout';
@@ -53,9 +54,17 @@ class AmpJWPlayer extends AMP.BaseElement {
    */
   preconnectCallback(onLayout) {
     // Host that serves player configuration and content redirects
-    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://content.jwplatform.com', onLayout);
+    Services.preconnectFor(this.win).url(
+      this.getAmpDoc(),
+      'https://content.jwplatform.com',
+      onLayout
+    );
     // CDN which hosts jwplayer assets
-    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://ssl.p.jwpcdn.com', onLayout);
+    Services.preconnectFor(this.win).url(
+      this.getAmpDoc(),
+      'https://ssl.p.jwpcdn.com',
+      onLayout
+    );
   }
 
   /** @override */

--- a/extensions/amp-kaltura-player/0.1/amp-kaltura-player.js
+++ b/extensions/amp-kaltura-player/0.1/amp-kaltura-player.js
@@ -40,7 +40,7 @@ class AmpKaltura extends AMP.BaseElement {
    * @override
    */
   preconnectCallback(opt_onLayout) {
-    this.preconnect.url('https://cdnapisec.kaltura.com', opt_onLayout);
+    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://cdnapisec.kaltura.com', opt_onLayout);
   }
 
   /** @override */

--- a/extensions/amp-kaltura-player/0.1/amp-kaltura-player.js
+++ b/extensions/amp-kaltura-player/0.1/amp-kaltura-player.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {Services} from '../../../src/services';
 import {addParamsToUrl} from '../../../src/url';
 import {dict} from '../../../src/utils/object';
 import {getDataParamsFromAttributes} from '../../../src/dom';
@@ -40,7 +41,11 @@ class AmpKaltura extends AMP.BaseElement {
    * @override
    */
   preconnectCallback(opt_onLayout) {
-    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://cdnapisec.kaltura.com', opt_onLayout);
+    Services.preconnectFor(this.win).url(
+      this.getAmpDoc(),
+      'https://cdnapisec.kaltura.com',
+      opt_onLayout
+    );
   }
 
   /** @override */

--- a/extensions/amp-mathml/0.1/amp-mathml.js
+++ b/extensions/amp-mathml/0.1/amp-mathml.js
@@ -13,8 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import {CSS} from '../../../build/amp-mathml-0.1.css';
 import {Layout} from '../../../src/layout';
+import {Services} from '../../../src/services';
 import {getIframe} from '../../../src/3p-frame';
 import {listenFor} from '../../../src/iframe-helper';
 import {removeElement} from '../../../src/dom';
@@ -34,7 +36,10 @@ export class AmpMathml extends AMP.BaseElement {
    *
    */
   preconnectCallback() {
-    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://cdnjs.cloudflare.com');
+    Services.preconnectFor(this.win).url(
+      this.getAmpDoc(),
+      'https://cdnjs.cloudflare.com'
+    );
   }
 
   /**

--- a/extensions/amp-mathml/0.1/amp-mathml.js
+++ b/extensions/amp-mathml/0.1/amp-mathml.js
@@ -34,7 +34,7 @@ export class AmpMathml extends AMP.BaseElement {
    *
    */
   preconnectCallback() {
-    this.preconnect.url('https://cdnjs.cloudflare.com');
+    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://cdnjs.cloudflare.com');
   }
 
   /**

--- a/extensions/amp-megaphone/0.1/amp-megaphone.js
+++ b/extensions/amp-megaphone/0.1/amp-megaphone.js
@@ -62,7 +62,7 @@ class AmpMegaphone extends AMP.BaseElement {
    */
   preconnectCallback(opt_onLayout) {
     const preconnect = Services.preconnectFor(this.win);
-    const ampdoc = ampdoc;
+    const ampdoc = this.getAmpDoc();
     // Pre-connects to the iframe source itself
     preconnect.url(ampdoc, this.baseUrl_, opt_onLayout);
     // Pre-connects to the megaphone static documents server (serves CSS and JS)

--- a/extensions/amp-megaphone/0.1/amp-megaphone.js
+++ b/extensions/amp-megaphone/0.1/amp-megaphone.js
@@ -61,24 +61,14 @@ class AmpMegaphone extends AMP.BaseElement {
    * @override
    */
   preconnectCallback(opt_onLayout) {
+    const preconnect = Services.preconnectFor(this.win);
+    const ampdoc = ampdoc;
     // Pre-connects to the iframe source itself
-    Services.preconnectFor(this.win).url(
-      this.getAmpDoc(),
-      this.baseUrl_,
-      opt_onLayout
-    );
+    preconnect.url(ampdoc, this.baseUrl_, opt_onLayout);
     // Pre-connects to the megaphone static documents server (serves CSS and JS)
-    Services.preconnectFor(this.win).url(
-      this.getAmpDoc(),
-      'https://assets.megaphone.fm',
-      opt_onLayout
-    );
+    preconnect.url(ampdoc, 'https://assets.megaphone.fm', opt_onLayout);
     // Pre-connects to the image assets server (for UI elements and playlist cover art)
-    Services.preconnectFor(this.win).url(
-      this.getAmpDoc(),
-      'https://megaphone.imgix.net',
-      opt_onLayout
-    );
+    preconnect.url(ampdoc, 'https://megaphone.imgix.net', opt_onLayout);
   }
 
   /** @override */

--- a/extensions/amp-megaphone/0.1/amp-megaphone.js
+++ b/extensions/amp-megaphone/0.1/amp-megaphone.js
@@ -61,11 +61,11 @@ class AmpMegaphone extends AMP.BaseElement {
    */
   preconnectCallback(opt_onLayout) {
     // Pre-connects to the iframe source itself
-    this.preconnect.url(this.baseUrl_, opt_onLayout);
+    Services.preconnectFor(this.win).url(this.getAmpDoc(), this.baseUrl_, opt_onLayout);
     // Pre-connects to the megaphone static documents server (serves CSS and JS)
-    this.preconnect.url('https://assets.megaphone.fm', opt_onLayout);
+    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://assets.megaphone.fm', opt_onLayout);
     // Pre-connects to the image assets server (for UI elements and playlist cover art)
-    this.preconnect.url('https://megaphone.imgix.net', opt_onLayout);
+    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://megaphone.imgix.net', opt_onLayout);
   }
 
   /** @override */

--- a/extensions/amp-megaphone/0.1/amp-megaphone.js
+++ b/extensions/amp-megaphone/0.1/amp-megaphone.js
@@ -27,6 +27,7 @@
  * </amp-megaphone>
  */
 
+import {Services} from '../../../src/services';
 import {addParamsToUrl} from '../../../src/url';
 import {dict} from '../../../src/utils/object';
 import {getData, listen} from '../../../src/event-helper';
@@ -61,11 +62,23 @@ class AmpMegaphone extends AMP.BaseElement {
    */
   preconnectCallback(opt_onLayout) {
     // Pre-connects to the iframe source itself
-    Services.preconnectFor(this.win).url(this.getAmpDoc(), this.baseUrl_, opt_onLayout);
+    Services.preconnectFor(this.win).url(
+      this.getAmpDoc(),
+      this.baseUrl_,
+      opt_onLayout
+    );
     // Pre-connects to the megaphone static documents server (serves CSS and JS)
-    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://assets.megaphone.fm', opt_onLayout);
+    Services.preconnectFor(this.win).url(
+      this.getAmpDoc(),
+      'https://assets.megaphone.fm',
+      opt_onLayout
+    );
     // Pre-connects to the image assets server (for UI elements and playlist cover art)
-    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://megaphone.imgix.net', opt_onLayout);
+    Services.preconnectFor(this.win).url(
+      this.getAmpDoc(),
+      'https://megaphone.imgix.net',
+      opt_onLayout
+    );
   }
 
   /** @override */

--- a/extensions/amp-minute-media-player/0.1/amp-minute-media-player.js
+++ b/extensions/amp-minute-media-player/0.1/amp-minute-media-player.js
@@ -93,9 +93,9 @@ class AmpMinuteMediaPlayer extends AMP.BaseElement {
    * @override
    */
   preconnectCallback(onLayout) {
-    this.preconnect.url(this.iframeSource_());
+    Services.preconnectFor(this.win).url(this.getAmpDoc(), this.iframeSource_());
     // Host that serves player configuration and content redirects
-    this.preconnect.url('https://www.oo-syringe.com', onLayout);
+    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://www.oo-syringe.com', onLayout);
   }
 
   /** @override */

--- a/extensions/amp-minute-media-player/0.1/amp-minute-media-player.js
+++ b/extensions/amp-minute-media-player/0.1/amp-minute-media-player.js
@@ -93,9 +93,16 @@ class AmpMinuteMediaPlayer extends AMP.BaseElement {
    * @override
    */
   preconnectCallback(onLayout) {
-    Services.preconnectFor(this.win).url(this.getAmpDoc(), this.iframeSource_());
+    Services.preconnectFor(this.win).url(
+      this.getAmpDoc(),
+      this.iframeSource_()
+    );
     // Host that serves player configuration and content redirects
-    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://www.oo-syringe.com', onLayout);
+    Services.preconnectFor(this.win).url(
+      this.getAmpDoc(),
+      'https://www.oo-syringe.com',
+      onLayout
+    );
   }
 
   /** @override */

--- a/extensions/amp-mowplayer/0.1/amp-mowplayer.js
+++ b/extensions/amp-mowplayer/0.1/amp-mowplayer.js
@@ -83,10 +83,10 @@ class AmpMowplayer extends AMP.BaseElement {
    * @override
    */
   preconnectCallback(opt_onLayout) {
-    const {preconnect} = this;
-    preconnect.url(this.getVideoIframeSrc_());
+    const preconnect = Services.preconnectFor(this.win);
+    preconnect.url(this.getAmpDoc(), this.getVideoIframeSrc_());
     // Host that mowplayer uses to serve JS needed by player.
-    preconnect.url('https://mowplayer.com', opt_onLayout);
+    preconnect.url(this.getAmpDoc(), 'https://mowplayer.com', opt_onLayout);
   }
 
   /** @override */

--- a/extensions/amp-nexxtv-player/0.1/amp-nexxtv-player.js
+++ b/extensions/amp-nexxtv-player/0.1/amp-nexxtv-player.js
@@ -65,7 +65,7 @@ class AmpNexxtvPlayer extends AMP.BaseElement {
    * @override
    */
   preconnectCallback(opt_onLayout) {
-    this.preconnect.url(this.getVideoIframeSrc_(), opt_onLayout);
+    Services.preconnectFor(this.win).url(this.getAmpDoc(), this.getVideoIframeSrc_(), opt_onLayout);
   }
 
   /** @override */

--- a/extensions/amp-nexxtv-player/0.1/amp-nexxtv-player.js
+++ b/extensions/amp-nexxtv-player/0.1/amp-nexxtv-player.js
@@ -65,7 +65,11 @@ class AmpNexxtvPlayer extends AMP.BaseElement {
    * @override
    */
   preconnectCallback(opt_onLayout) {
-    Services.preconnectFor(this.win).url(this.getAmpDoc(), this.getVideoIframeSrc_(), opt_onLayout);
+    Services.preconnectFor(this.win).url(
+      this.getAmpDoc(),
+      this.getVideoIframeSrc_(),
+      opt_onLayout
+    );
   }
 
   /** @override */

--- a/extensions/amp-o2-player/0.1/amp-o2-player.js
+++ b/extensions/amp-o2-player/0.1/amp-o2-player.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {Services} from '../../../src/services';
 import {dict} from '../../../src/utils/object';
 import {isLayoutSizeDefined} from '../../../src/layout';
 import {userAssert} from '../../../src/log';
@@ -44,7 +45,11 @@ class AmpO2Player extends AMP.BaseElement {
    * @override
    */
   preconnectCallback(onLayout) {
-    Services.preconnectFor(this.win).url(this.getAmpDoc(), this.domain_, onLayout);
+    Services.preconnectFor(this.win).url(
+      this.getAmpDoc(),
+      this.domain_,
+      onLayout
+    );
   }
 
   /** @override */

--- a/extensions/amp-o2-player/0.1/amp-o2-player.js
+++ b/extensions/amp-o2-player/0.1/amp-o2-player.js
@@ -44,7 +44,7 @@ class AmpO2Player extends AMP.BaseElement {
    * @override
    */
   preconnectCallback(onLayout) {
-    this.preconnect.url(this.domain_, onLayout);
+    Services.preconnectFor(this.win).url(this.getAmpDoc(), this.domain_, onLayout);
   }
 
   /** @override */

--- a/extensions/amp-ooyala-player/0.1/amp-ooyala-player.js
+++ b/extensions/amp-ooyala-player/0.1/amp-ooyala-player.js
@@ -68,7 +68,11 @@ class AmpOoyalaPlayer extends AMP.BaseElement {
    * @override
    */
   preconnectCallback(opt_onLayout) {
-    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://player.ooyala.com', opt_onLayout);
+    Services.preconnectFor(this.win).url(
+      this.getAmpDoc(),
+      'https://player.ooyala.com',
+      opt_onLayout
+    );
   }
 
   /** @override */

--- a/extensions/amp-ooyala-player/0.1/amp-ooyala-player.js
+++ b/extensions/amp-ooyala-player/0.1/amp-ooyala-player.js
@@ -68,7 +68,7 @@ class AmpOoyalaPlayer extends AMP.BaseElement {
    * @override
    */
   preconnectCallback(opt_onLayout) {
-    this.preconnect.url('https://player.ooyala.com', opt_onLayout);
+    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://player.ooyala.com', opt_onLayout);
   }
 
   /** @override */

--- a/extensions/amp-pinterest/0.1/amp-pinterest.js
+++ b/extensions/amp-pinterest/0.1/amp-pinterest.js
@@ -63,7 +63,7 @@ class AmpPinterest extends AMP.BaseElement {
    */
   preconnectCallback(onLayout) {
     // preconnect to widget APIpinMedia
-    this.preconnect.url('https://widgets.pinterest.com', onLayout);
+    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://widgets.pinterest.com', onLayout);
   }
 
   /** @override */

--- a/extensions/amp-pinterest/0.1/amp-pinterest.js
+++ b/extensions/amp-pinterest/0.1/amp-pinterest.js
@@ -37,8 +37,8 @@
 import {CSS} from '../../../build/amp-pinterest-0.1.css';
 import {FollowButton} from './follow-button';
 import {SaveButton} from './save-button';
-
 import {PinWidget} from './pin-widget';
+import {Services} from '../../../src/services';
 import {htmlFor} from '../../../src/static-template';
 import {isLayoutSizeDefined} from '../../../src/layout';
 import {user, userAssert} from '../../../src/log';
@@ -63,7 +63,11 @@ class AmpPinterest extends AMP.BaseElement {
    */
   preconnectCallback(onLayout) {
     // preconnect to widget APIpinMedia
-    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://widgets.pinterest.com', onLayout);
+    Services.preconnectFor(this.win).url(
+      this.getAmpDoc(),
+      'https://widgets.pinterest.com',
+      onLayout
+    );
   }
 
   /** @override */

--- a/extensions/amp-pinterest/0.1/amp-pinterest.js
+++ b/extensions/amp-pinterest/0.1/amp-pinterest.js
@@ -36,8 +36,8 @@
 
 import {CSS} from '../../../build/amp-pinterest-0.1.css';
 import {FollowButton} from './follow-button';
-import {SaveButton} from './save-button';
 import {PinWidget} from './pin-widget';
+import {SaveButton} from './save-button';
 import {Services} from '../../../src/services';
 import {htmlFor} from '../../../src/static-template';
 import {isLayoutSizeDefined} from '../../../src/layout';

--- a/extensions/amp-playbuzz/0.1/amp-playbuzz.js
+++ b/extensions/amp-playbuzz/0.1/amp-playbuzz.js
@@ -89,7 +89,7 @@ class AmpPlaybuzz extends AMP.BaseElement {
    * @override
    */
   preconnectCallback() {
-    this.preconnect.url(this.iframeSrcUrl_);
+    Services.preconnectFor(this.win).url(this.getAmpDoc(), this.iframeSrcUrl_);
   }
 
   /** @override */

--- a/extensions/amp-powr-player/0.1/amp-powr-player.js
+++ b/extensions/amp-powr-player/0.1/amp-powr-player.js
@@ -87,7 +87,10 @@ class AmpPowrPlayer extends AMP.BaseElement {
 
   /** @override */
   preconnectCallback() {
-    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://player.powr.com');
+    Services.preconnectFor(this.win).url(
+      this.getAmpDoc(),
+      'https://player.powr.com'
+    );
   }
 
   /** @override */

--- a/extensions/amp-powr-player/0.1/amp-powr-player.js
+++ b/extensions/amp-powr-player/0.1/amp-powr-player.js
@@ -87,7 +87,7 @@ class AmpPowrPlayer extends AMP.BaseElement {
 
   /** @override */
   preconnectCallback() {
-    this.preconnect.url('https://player.powr.com');
+    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://player.powr.com');
   }
 
   /** @override */

--- a/extensions/amp-reach-player/0.1/amp-reach-player.js
+++ b/extensions/amp-reach-player/0.1/amp-reach-player.js
@@ -30,7 +30,7 @@ class AmpReachPlayer extends AMP.BaseElement {
    * @override
    */
   preconnectCallback(opt_onLayout) {
-    this.preconnect.url('https://player-cdn.beachfrontmedia.com', opt_onLayout);
+    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://player-cdn.beachfrontmedia.com', opt_onLayout);
   }
 
   /** @override */

--- a/extensions/amp-reach-player/0.1/amp-reach-player.js
+++ b/extensions/amp-reach-player/0.1/amp-reach-player.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {Services} from '../../../src/services';
 import {isLayoutSizeDefined} from '../../../src/layout';
 
 class AmpReachPlayer extends AMP.BaseElement {
@@ -30,7 +31,11 @@ class AmpReachPlayer extends AMP.BaseElement {
    * @override
    */
   preconnectCallback(opt_onLayout) {
-    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://player-cdn.beachfrontmedia.com', opt_onLayout);
+    Services.preconnectFor(this.win).url(
+      this.getAmpDoc(),
+      'https://player-cdn.beachfrontmedia.com',
+      opt_onLayout
+    );
   }
 
   /** @override */

--- a/extensions/amp-reddit/0.1/amp-reddit.js
+++ b/extensions/amp-reddit/0.1/amp-reddit.js
@@ -28,18 +28,18 @@ class AmpReddit extends AMP.BaseElement {
     // Required urls and scripts are different for comments and posts.
     if (this.element.getAttribute('data-embedtype') === 'comment') {
       // The domain for static comment permalinks.
-      this.preconnect.url('https://www.redditmedia.com', onLayout);
+      Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://www.redditmedia.com', onLayout);
       // The domain for JS and CSS used in rendering embeds.
-      this.preconnect.url('https://www.redditstatic.com', onLayout);
+      Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://www.redditstatic.com', onLayout);
       this.preconnect.preload(
         'https://www.redditstatic.com/comment-embed.js',
         'script'
       );
     } else {
       // Posts don't use the static domain.
-      this.preconnect.url('https://www.reddit.com', onLayout);
+      Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://www.reddit.com', onLayout);
       // Posts defer to the embedly API.
-      this.preconnect.url('https://cdn.embedly.com', onLayout);
+      Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://cdn.embedly.com', onLayout);
       this.preconnect.preload(
         'https://embed.redditmedia.com/widgets/platform.js',
         'script'

--- a/extensions/amp-reddit/0.1/amp-reddit.js
+++ b/extensions/amp-reddit/0.1/amp-reddit.js
@@ -31,7 +31,7 @@ class AmpReddit extends AMP.BaseElement {
       Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://www.redditmedia.com', onLayout);
       // The domain for JS and CSS used in rendering embeds.
       Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://www.redditstatic.com', onLayout);
-      this.preconnect.preload(
+      Services.preconnectFor(this.win).preload(this.getAmpDoc(),
         'https://www.redditstatic.com/comment-embed.js',
         'script'
       );
@@ -40,7 +40,7 @@ class AmpReddit extends AMP.BaseElement {
       Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://www.reddit.com', onLayout);
       // Posts defer to the embedly API.
       Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://cdn.embedly.com', onLayout);
-      this.preconnect.preload(
+      Services.preconnectFor(this.win).preload(this.getAmpDoc(),
         'https://embed.redditmedia.com/widgets/platform.js',
         'script'
       );

--- a/extensions/amp-reddit/0.1/amp-reddit.js
+++ b/extensions/amp-reddit/0.1/amp-reddit.js
@@ -46,7 +46,7 @@ class AmpReddit extends AMP.BaseElement {
       );
     }
 
-    preloadBootstrap(this.win, this.preconnect);
+    preloadBootstrap(this.win, this.getAmpDoc(), this.preconnect);
   }
 
   /** @override */

--- a/extensions/amp-reddit/0.1/amp-reddit.js
+++ b/extensions/amp-reddit/0.1/amp-reddit.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {Services} from '../../../src/services';
 import {getIframe, preloadBootstrap} from '../../../src/3p-frame';
 import {isLayoutSizeDefined} from '../../../src/layout';
 import {listenFor} from '../../../src/iframe-helper';
@@ -25,28 +26,35 @@ class AmpReddit extends AMP.BaseElement {
    * @override
    */
   preconnectCallback(onLayout) {
+    const preconnect = Services.preconnectFor(this.win);
     // Required urls and scripts are different for comments and posts.
     if (this.element.getAttribute('data-embedtype') === 'comment') {
       // The domain for static comment permalinks.
-      Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://www.redditmedia.com', onLayout);
+      preconnect.url(this.getAmpDoc(), 'https://www.redditmedia.com', onLayout);
       // The domain for JS and CSS used in rendering embeds.
-      Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://www.redditstatic.com', onLayout);
-      Services.preconnectFor(this.win).preload(this.getAmpDoc(),
+      preconnect.url(
+        this.getAmpDoc(),
+        'https://www.redditstatic.com',
+        onLayout
+      );
+      preconnect.preload(
+        this.getAmpDoc(),
         'https://www.redditstatic.com/comment-embed.js',
         'script'
       );
     } else {
       // Posts don't use the static domain.
-      Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://www.reddit.com', onLayout);
+      preconnect.url(this.getAmpDoc(), 'https://www.reddit.com', onLayout);
       // Posts defer to the embedly API.
-      Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://cdn.embedly.com', onLayout);
-      Services.preconnectFor(this.win).preload(this.getAmpDoc(),
+      preconnect.url(this.getAmpDoc(), 'https://cdn.embedly.com', onLayout);
+      preconnect.preload(
+        this.getAmpDoc(),
         'https://embed.redditmedia.com/widgets/platform.js',
         'script'
       );
     }
 
-    preloadBootstrap(this.win, this.getAmpDoc(), this.preconnect);
+    preloadBootstrap(this.win, this.getAmpDoc(), preconnect);
   }
 
   /** @override */

--- a/extensions/amp-reddit/0.1/amp-reddit.js
+++ b/extensions/amp-reddit/0.1/amp-reddit.js
@@ -27,34 +27,31 @@ class AmpReddit extends AMP.BaseElement {
    */
   preconnectCallback(onLayout) {
     const preconnect = Services.preconnectFor(this.win);
+    const ampdoc = this.getAmpDoc();
     // Required urls and scripts are different for comments and posts.
     if (this.element.getAttribute('data-embedtype') === 'comment') {
       // The domain for static comment permalinks.
-      preconnect.url(this.getAmpDoc(), 'https://www.redditmedia.com', onLayout);
+      preconnect.url(ampdoc, 'https://www.redditmedia.com', onLayout);
       // The domain for JS and CSS used in rendering embeds.
-      preconnect.url(
-        this.getAmpDoc(),
-        'https://www.redditstatic.com',
-        onLayout
-      );
+      preconnect.url(ampdoc, 'https://www.redditstatic.com', onLayout);
       preconnect.preload(
-        this.getAmpDoc(),
+        ampdoc,
         'https://www.redditstatic.com/comment-embed.js',
         'script'
       );
     } else {
       // Posts don't use the static domain.
-      preconnect.url(this.getAmpDoc(), 'https://www.reddit.com', onLayout);
+      preconnect.url(ampdoc, 'https://www.reddit.com', onLayout);
       // Posts defer to the embedly API.
-      preconnect.url(this.getAmpDoc(), 'https://cdn.embedly.com', onLayout);
+      preconnect.url(ampdoc, 'https://cdn.embedly.com', onLayout);
       preconnect.preload(
-        this.getAmpDoc(),
+        ampdoc,
         'https://embed.redditmedia.com/widgets/platform.js',
         'script'
       );
     }
 
-    preloadBootstrap(this.win, this.getAmpDoc(), preconnect);
+    preloadBootstrap(this.win, ampdoc, preconnect);
   }
 
   /** @override */

--- a/extensions/amp-soundcloud/0.1/amp-soundcloud.js
+++ b/extensions/amp-soundcloud/0.1/amp-soundcloud.js
@@ -45,7 +45,7 @@ class AmpSoundcloud extends AMP.BaseElement {
    * @override
    */
   preconnectCallback(opt_onLayout) {
-    this.preconnect.url('https://api.soundcloud.com/', opt_onLayout);
+    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://api.soundcloud.com/', opt_onLayout);
   }
 
   /** @override */

--- a/extensions/amp-soundcloud/0.1/amp-soundcloud.js
+++ b/extensions/amp-soundcloud/0.1/amp-soundcloud.js
@@ -27,6 +27,7 @@
  * </amp-soundcloud>
  */
 
+import {Services} from '../../../src/services';
 import {dict} from '../../../src/utils/object';
 import {isLayoutSizeDefined} from '../../../src/layout';
 import {userAssert} from '../../../src/log';
@@ -45,7 +46,11 @@ class AmpSoundcloud extends AMP.BaseElement {
    * @override
    */
   preconnectCallback(opt_onLayout) {
-    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://api.soundcloud.com/', opt_onLayout);
+    Services.preconnectFor(this.win).url(
+      this.getAmpDoc(),
+      'https://api.soundcloud.com/',
+      opt_onLayout
+    );
   }
 
   /** @override */

--- a/extensions/amp-springboard-player/0.1/amp-springboard-player.js
+++ b/extensions/amp-springboard-player/0.1/amp-springboard-player.js
@@ -46,8 +46,8 @@ class AmpSpringboardPlayer extends AMP.BaseElement {
    * @override
    */
   preconnectCallback(opt_onLayout) {
-    this.preconnect.url('https://cms.springboardplatform.com', opt_onLayout);
-    this.preconnect.url('https://www.springboardplatform.com', opt_onLayout);
+    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://cms.springboardplatform.com', opt_onLayout);
+    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://www.springboardplatform.com', opt_onLayout);
   }
 
   /** @override */

--- a/extensions/amp-springboard-player/0.1/amp-springboard-player.js
+++ b/extensions/amp-springboard-player/0.1/amp-springboard-player.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {Services} from '../../../src/services';
 import {isLayoutSizeDefined} from '../../../src/layout';
 import {userAssert} from '../../../src/log';
 
@@ -46,8 +47,16 @@ class AmpSpringboardPlayer extends AMP.BaseElement {
    * @override
    */
   preconnectCallback(opt_onLayout) {
-    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://cms.springboardplatform.com', opt_onLayout);
-    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://www.springboardplatform.com', opt_onLayout);
+    Services.preconnectFor(this.win).url(
+      this.getAmpDoc(),
+      'https://cms.springboardplatform.com',
+      opt_onLayout
+    );
+    Services.preconnectFor(this.win).url(
+      this.getAmpDoc(),
+      'https://www.springboardplatform.com',
+      opt_onLayout
+    );
   }
 
   /** @override */

--- a/extensions/amp-twitter/0.1/amp-twitter.js
+++ b/extensions/amp-twitter/0.1/amp-twitter.js
@@ -15,6 +15,7 @@
  */
 
 import {MessageType} from '../../../src/3p-frame-messaging';
+import {Services} from '../../../src/services';
 import {getIframe, preloadBootstrap} from '../../../src/3p-frame';
 import {htmlFor} from '../../../src/static-template';
 import {isLayoutSizeDefined} from '../../../src/layout';
@@ -45,17 +46,27 @@ class AmpTwitter extends AMP.BaseElement {
    * @override
    */
   preconnectCallback(opt_onLayout) {
-    preloadBootstrap(this.win, this.getAmpDoc(), this.preconnect);
+    const preconnect = Services.preconnectFor(this.win);
+    preloadBootstrap(this.win, this.getAmpDoc(), preconnect);
     // Hosts the script that renders tweets.
-    Services.preconnectFor(this.win).preload(this.getAmpDoc(),
+    preconnect.preload(
+      this.getAmpDoc(),
       'https://platform.twitter.com/widgets.js',
       'script'
     );
     // This domain serves the actual tweets as JSONP.
-    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://syndication.twitter.com', opt_onLayout);
+    preconnect.url(
+      this.getAmpDoc(),
+      'https://syndication.twitter.com',
+      opt_onLayout
+    );
     // All images
-    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://pbs.twimg.com', opt_onLayout);
-    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://cdn.syndication.twimg.com', opt_onLayout);
+    preconnect.url(this.getAmpDoc(), 'https://pbs.twimg.com', opt_onLayout);
+    preconnect.url(
+      this.getAmpDoc(),
+      'https://cdn.syndication.twimg.com',
+      opt_onLayout
+    );
   }
 
   /** @override */

--- a/extensions/amp-twitter/0.1/amp-twitter.js
+++ b/extensions/amp-twitter/0.1/amp-twitter.js
@@ -45,7 +45,7 @@ class AmpTwitter extends AMP.BaseElement {
    * @override
    */
   preconnectCallback(opt_onLayout) {
-    preloadBootstrap(this.win, this.preconnect);
+    preloadBootstrap(this.win, this.getAmpDoc(), this.preconnect);
     // Hosts the script that renders tweets.
     Services.preconnectFor(this.win).preload(this.getAmpDoc(),
       'https://platform.twitter.com/widgets.js',

--- a/extensions/amp-twitter/0.1/amp-twitter.js
+++ b/extensions/amp-twitter/0.1/amp-twitter.js
@@ -47,7 +47,7 @@ class AmpTwitter extends AMP.BaseElement {
   preconnectCallback(opt_onLayout) {
     preloadBootstrap(this.win, this.preconnect);
     // Hosts the script that renders tweets.
-    this.preconnect.preload(
+    Services.preconnectFor(this.win).preload(this.getAmpDoc(),
       'https://platform.twitter.com/widgets.js',
       'script'
     );

--- a/extensions/amp-twitter/0.1/amp-twitter.js
+++ b/extensions/amp-twitter/0.1/amp-twitter.js
@@ -47,26 +47,19 @@ class AmpTwitter extends AMP.BaseElement {
    */
   preconnectCallback(opt_onLayout) {
     const preconnect = Services.preconnectFor(this.win);
-    preloadBootstrap(this.win, this.getAmpDoc(), preconnect);
+    const ampdoc = this.getAmpDoc();
+    preloadBootstrap(this.win, ampdoc, preconnect);
     // Hosts the script that renders tweets.
     preconnect.preload(
-      this.getAmpDoc(),
+      ampdoc,
       'https://platform.twitter.com/widgets.js',
       'script'
     );
     // This domain serves the actual tweets as JSONP.
-    preconnect.url(
-      this.getAmpDoc(),
-      'https://syndication.twitter.com',
-      opt_onLayout
-    );
+    preconnect.url(ampdoc, 'https://syndication.twitter.com', opt_onLayout);
     // All images
-    preconnect.url(this.getAmpDoc(), 'https://pbs.twimg.com', opt_onLayout);
-    preconnect.url(
-      this.getAmpDoc(),
-      'https://cdn.syndication.twimg.com',
-      opt_onLayout
-    );
+    preconnect.url(ampdoc, 'https://pbs.twimg.com', opt_onLayout);
+    preconnect.url(ampdoc, 'https://cdn.syndication.twimg.com', opt_onLayout);
   }
 
   /** @override */

--- a/extensions/amp-twitter/0.1/amp-twitter.js
+++ b/extensions/amp-twitter/0.1/amp-twitter.js
@@ -52,10 +52,10 @@ class AmpTwitter extends AMP.BaseElement {
       'script'
     );
     // This domain serves the actual tweets as JSONP.
-    this.preconnect.url('https://syndication.twitter.com', opt_onLayout);
+    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://syndication.twitter.com', opt_onLayout);
     // All images
-    this.preconnect.url('https://pbs.twimg.com', opt_onLayout);
-    this.preconnect.url('https://cdn.syndication.twimg.com', opt_onLayout);
+    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://pbs.twimg.com', opt_onLayout);
+    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://cdn.syndication.twimg.com', opt_onLayout);
   }
 
   /** @override */

--- a/extensions/amp-video/0.1/amp-video.js
+++ b/extensions/amp-video/0.1/amp-video.js
@@ -107,7 +107,11 @@ class AmpVideo extends AMP.BaseElement {
     const videoSrc = this.getVideoSourceForPreconnect_();
     if (videoSrc) {
       this.getUrlService_().assertHttpsUrl(videoSrc, this.element);
-      Services.preconnectFor(this.win).url(this.getAmpDoc(), videoSrc, opt_onLayout);
+      Services.preconnectFor(this.win).url(
+        this.getAmpDoc(),
+        videoSrc,
+        opt_onLayout
+      );
     }
   }
 

--- a/extensions/amp-video/0.1/amp-video.js
+++ b/extensions/amp-video/0.1/amp-video.js
@@ -107,7 +107,7 @@ class AmpVideo extends AMP.BaseElement {
     const videoSrc = this.getVideoSourceForPreconnect_();
     if (videoSrc) {
       this.getUrlService_().assertHttpsUrl(videoSrc, this.element);
-      this.preconnect.url(videoSrc, opt_onLayout);
+      Services.preconnectFor(this.win).url(this.getAmpDoc(), videoSrc, opt_onLayout);
     }
   }
 

--- a/extensions/amp-video/0.1/test/test-amp-video.js
+++ b/extensions/amp-video/0.1/test/test-amp-video.js
@@ -72,15 +72,28 @@ describes.realWin(
       }
     }
 
+    it('should preconnect', async () => {
+      const v = await getVideo({
+        src: 'video.mp4',
+        width: 160,
+        height: 90,
+      });
+      const preconnect = Services.preconnectFor(win);
+      env.sandbox.spy(preconnect, 'url');
+      v.implementation_.preconnectCallback();
+      expect(preconnect.url).to.have.been.calledWithExactly(
+        env.sandbox.match.object, // AmpDoc
+        'video.mp4',
+        undefined
+      );
+    });
+
     it('should load a video', async () => {
       const v = await getVideo({
         src: 'video.mp4',
         width: 160,
         height: 90,
       });
-      const preloadSpy = env.sandbox.spy(v.implementation_.preconnect, 'url');
-      v.implementation_.preconnectCallback();
-      preloadSpy.should.have.been.calledWithExactly('video.mp4', undefined);
       const video = v.querySelector('video');
       expect(video.tagName).to.equal('VIDEO');
       expect(video.getAttribute('src')).to.equal('video.mp4');
@@ -98,9 +111,6 @@ describes.realWin(
         'crossorigin': '',
         'disableremoteplayback': '',
       });
-      const preloadSpy = env.sandbox.spy(v.implementation_.preconnect, 'url');
-      v.implementation_.preconnectCallback();
-      preloadSpy.should.have.been.calledWithExactly('video.mp4', undefined);
       const video = v.querySelector('video');
       expect(video.tagName).to.equal('VIDEO');
       expect(video.hasAttribute('controls')).to.be.true;
@@ -135,9 +145,6 @@ describes.realWin(
         },
         sources
       );
-      const preloadSpy = env.sandbox.spy(v.implementation_.preconnect, 'url');
-      v.implementation_.preconnectCallback();
-      preloadSpy.should.have.been.calledWithExactly('video.mp4', undefined);
       const video = v.querySelector('video');
       // check that the source tags were propogated
       expect(video.children.length).to.equal(mediatypes.length);
@@ -175,9 +182,6 @@ describes.realWin(
         },
         tracks
       );
-      const preloadSpy = env.sandbox.spy(v.implementation_.preconnect, 'url');
-      v.implementation_.preconnectCallback();
-      preloadSpy.should.have.been.calledWithExactly('video.mp4', undefined);
       const video = v.querySelector('video');
       // check that the source tags were propogated
       expect(video.children.length).to.equal(tracktypes.length);
@@ -823,16 +827,14 @@ describes.realWin(
       });
 
       describe('should preconnect to the first cached source', () => {
-        let fakePreconnect;
+        let preconnect;
 
         beforeEach(() => {
-          fakePreconnect = {url: () => {}};
-          registerServiceBuilder(win, 'preconnect', () => fakePreconnect);
+          preconnect = {url: env.sandbox.stub()};
+          env.sandbox.stub(Services, 'preconnectFor').returns(preconnect);
         });
 
         it('no cached source', async () => {
-          const preloadStub = window.sandbox.stub(fakePreconnect, 'url');
-
           await getVideo({
             src: 'https://example.com/video.mp4',
             poster: 'https://example.com/poster.jpg',
@@ -840,12 +842,10 @@ describes.realWin(
             height: 90,
           });
 
-          expect(preloadStub).to.not.have.been.called;
+          expect(preconnect.url).to.not.have.been.called;
         });
 
         it('cached source', async () => {
-          const preloadStub = window.sandbox.stub(fakePreconnect, 'url');
-
           const cachedSource = doc.createElement('source');
           cachedSource.setAttribute(
             'src',
@@ -865,15 +865,14 @@ describes.realWin(
             [cachedSource]
           );
 
-          expect(preloadStub).to.have.been.calledOnce;
-          expect(preloadStub.getCall(0).args[1]).to.equal(
+          expect(preconnect.url).to.have.been.calledOnce;
+          expect(preconnect.url.getCall(0)).to.have.been.calledWith(
+            env.sandbox.match.object, // AmpDoc
             'https://example-com.cdn.ampproject.org/m/s/video.mp4'
           );
         });
 
         it('mixed sources', async () => {
-          const preloadStub = window.sandbox.stub(fakePreconnect, 'url');
-
           const source = doc.createElement('source');
           source.setAttribute('src', 'video.mp4');
 
@@ -894,8 +893,9 @@ describes.realWin(
             },
             [source, cachedSource]
           );
-          expect(preloadStub).to.have.been.calledOnce;
-          expect(preloadStub.getCall(0).args[1]).to.equal(
+          expect(preconnect.url).to.have.been.calledOnce;
+          expect(preconnect.url.getCall(0)).to.have.been.calledWith(
+            env.sandbox.match.object, // AmpDoc
             'https://example-com.cdn.ampproject.org/m/s/video.mp4'
           );
         });

--- a/extensions/amp-video/0.1/test/test-amp-video.js
+++ b/extensions/amp-video/0.1/test/test-amp-video.js
@@ -19,7 +19,6 @@ import {Services} from '../../../../src/services';
 import {VideoEvents} from '../../../../src/video-interface';
 import {VisibilityState} from '../../../../src/visibility-state';
 import {listenOncePromise} from '../../../../src/event-helper';
-import {registerServiceBuilder} from '../../../../src/service';
 import {toggleExperiment} from '../../../../src/experiments';
 
 describes.realWin(

--- a/extensions/amp-vimeo/0.1/amp-vimeo.js
+++ b/extensions/amp-vimeo/0.1/amp-vimeo.js
@@ -99,12 +99,12 @@ class AmpVimeo extends AMP.BaseElement {
 
   /** @override */
   preconnectCallback(onLayout = false) {
-    const {preconnect} = this;
-    preconnect.url('https://player.vimeo.com', onLayout);
+    const preconnect = Services.preconnectFor(this.win);
+    preconnect.url(this.getAmpDoc(), 'https://player.vimeo.com', onLayout);
     // Host that Vimeo uses to serve poster frames needed by player.
-    preconnect.url('https://i.vimeocdn.com', onLayout);
+    preconnect.url(this.getAmpDoc(), 'https://i.vimeocdn.com', onLayout);
     // Host that Vimeo uses to serve JS, CSS and other assets needed.
-    preconnect.url('https://f.vimeocdn.com', onLayout);
+    preconnect.url(this.getAmpDoc(), 'https://f.vimeocdn.com', onLayout);
   }
 
   /** @override */

--- a/extensions/amp-vimeo/0.1/amp-vimeo.js
+++ b/extensions/amp-vimeo/0.1/amp-vimeo.js
@@ -115,7 +115,7 @@ class AmpVimeo extends AMP.BaseElement {
 
   /** @override */
   buildCallback() {
-    installVideoManagerForDoc(ampdoc);
+    installVideoManagerForDoc(this.getAmpDoc());
   }
 
   /** @override */

--- a/extensions/amp-vimeo/0.1/amp-vimeo.js
+++ b/extensions/amp-vimeo/0.1/amp-vimeo.js
@@ -100,11 +100,12 @@ class AmpVimeo extends AMP.BaseElement {
   /** @override */
   preconnectCallback(onLayout = false) {
     const preconnect = Services.preconnectFor(this.win);
-    preconnect.url(this.getAmpDoc(), 'https://player.vimeo.com', onLayout);
+    const ampdoc = this.getAmpDoc();
+    preconnect.url(ampdoc, 'https://player.vimeo.com', onLayout);
     // Host that Vimeo uses to serve poster frames needed by player.
-    preconnect.url(this.getAmpDoc(), 'https://i.vimeocdn.com', onLayout);
+    preconnect.url(ampdoc, 'https://i.vimeocdn.com', onLayout);
     // Host that Vimeo uses to serve JS, CSS and other assets needed.
-    preconnect.url(this.getAmpDoc(), 'https://f.vimeocdn.com', onLayout);
+    preconnect.url(ampdoc, 'https://f.vimeocdn.com', onLayout);
   }
 
   /** @override */
@@ -114,7 +115,7 @@ class AmpVimeo extends AMP.BaseElement {
 
   /** @override */
   buildCallback() {
-    installVideoManagerForDoc(this.getAmpDoc());
+    installVideoManagerForDoc(ampdoc);
   }
 
   /** @override */

--- a/extensions/amp-vine/0.1/amp-vine.js
+++ b/extensions/amp-vine/0.1/amp-vine.js
@@ -31,9 +31,9 @@ class AmpVine extends AMP.BaseElement {
    */
   preconnectCallback(onLayout) {
     // the Vine iframe
-    this.preconnect.url('https://vine.co', onLayout);
+    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://vine.co', onLayout);
     // Vine assets loaded in the iframe
-    this.preconnect.url('https://v.cdn.vine.co', onLayout);
+    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://v.cdn.vine.co', onLayout);
   }
 
   /** @override */

--- a/extensions/amp-vine/0.1/amp-vine.js
+++ b/extensions/amp-vine/0.1/amp-vine.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {Services} from '../../../src/services';
 import {isLayoutSizeDefined} from '../../../src/layout';
 import {userAssert} from '../../../src/log';
 
@@ -31,9 +32,17 @@ class AmpVine extends AMP.BaseElement {
    */
   preconnectCallback(onLayout) {
     // the Vine iframe
-    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://vine.co', onLayout);
+    Services.preconnectFor(this.win).url(
+      this.getAmpDoc(),
+      'https://vine.co',
+      onLayout
+    );
     // Vine assets loaded in the iframe
-    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://v.cdn.vine.co', onLayout);
+    Services.preconnectFor(this.win).url(
+      this.getAmpDoc(),
+      'https://v.cdn.vine.co',
+      onLayout
+    );
   }
 
   /** @override */

--- a/extensions/amp-viqeo-player/0.1/amp-viqeo-player.js
+++ b/extensions/amp-viqeo-player/0.1/amp-viqeo-player.js
@@ -71,8 +71,8 @@ class AmpViqeoPlayer extends AMP.BaseElement {
    * @override
    */
   preconnectCallback(opt_onLayout) {
-    this.preconnect.url('https://api.viqeo.tv', opt_onLayout);
-    this.preconnect.url('https://cdn.viqeo.tv', opt_onLayout);
+    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://api.viqeo.tv', opt_onLayout);
+    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://cdn.viqeo.tv', opt_onLayout);
   }
 
   /**

--- a/extensions/amp-viqeo-player/0.1/amp-viqeo-player.js
+++ b/extensions/amp-viqeo-player/0.1/amp-viqeo-player.js
@@ -71,8 +71,16 @@ class AmpViqeoPlayer extends AMP.BaseElement {
    * @override
    */
   preconnectCallback(opt_onLayout) {
-    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://api.viqeo.tv', opt_onLayout);
-    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://cdn.viqeo.tv', opt_onLayout);
+    Services.preconnectFor(this.win).url(
+      this.getAmpDoc(),
+      'https://api.viqeo.tv',
+      opt_onLayout
+    );
+    Services.preconnectFor(this.win).url(
+      this.getAmpDoc(),
+      'https://cdn.viqeo.tv',
+      opt_onLayout
+    );
   }
 
   /**

--- a/extensions/amp-vk/0.1/amp-vk.js
+++ b/extensions/amp-vk/0.1/amp-vk.js
@@ -68,7 +68,7 @@ export class AmpVk extends AMP.BaseElement {
    * @override
    */
   preconnectCallback(opt_onLayout) {
-    this.preconnect.url('https://vk.com', opt_onLayout);
+    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://vk.com', opt_onLayout);
   }
 
   /**

--- a/extensions/amp-vk/0.1/amp-vk.js
+++ b/extensions/amp-vk/0.1/amp-vk.js
@@ -68,7 +68,11 @@ export class AmpVk extends AMP.BaseElement {
    * @override
    */
   preconnectCallback(opt_onLayout) {
-    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://vk.com', opt_onLayout);
+    Services.preconnectFor(this.win).url(
+      this.getAmpDoc(),
+      'https://vk.com',
+      opt_onLayout
+    );
   }
 
   /**

--- a/extensions/amp-wistia-player/0.1/amp-wistia-player.js
+++ b/extensions/amp-wistia-player/0.1/amp-wistia-player.js
@@ -64,7 +64,11 @@ class AmpWistiaPlayer extends AMP.BaseElement {
    */
   preconnectCallback(onLayout) {
     // video player and video metadata
-    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://fast.wistia.net', onLayout);
+    Services.preconnectFor(this.win).url(
+      this.getAmpDoc(),
+      'https://fast.wistia.net',
+      onLayout
+    );
   }
 
   /** @override */

--- a/extensions/amp-wistia-player/0.1/amp-wistia-player.js
+++ b/extensions/amp-wistia-player/0.1/amp-wistia-player.js
@@ -64,7 +64,7 @@ class AmpWistiaPlayer extends AMP.BaseElement {
    */
   preconnectCallback(onLayout) {
     // video player and video metadata
-    this.preconnect.url('https://fast.wistia.net', onLayout);
+    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://fast.wistia.net', onLayout);
   }
 
   /** @override */

--- a/extensions/amp-yotpo/0.1/amp-yotpo.js
+++ b/extensions/amp-yotpo/0.1/amp-yotpo.js
@@ -37,7 +37,7 @@ export class AmpYotpo extends AMP.BaseElement {
    * @override
    */
   preconnectCallback(opt_onLayout) {
-    this.preconnect.url('https://staticw2.yotpo.com', opt_onLayout);
+    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://staticw2.yotpo.com', opt_onLayout);
   }
 
   /** @override */

--- a/extensions/amp-yotpo/0.1/amp-yotpo.js
+++ b/extensions/amp-yotpo/0.1/amp-yotpo.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {Services} from '../../../src/services';
 import {getIframe} from '../../../src/3p-frame';
 import {isLayoutSizeDefined} from '../../../src/layout';
 import {listenFor} from '../../../src/iframe-helper';
@@ -37,7 +38,11 @@ export class AmpYotpo extends AMP.BaseElement {
    * @override
    */
   preconnectCallback(opt_onLayout) {
-    Services.preconnectFor(this.win).url(this.getAmpDoc(), 'https://staticw2.yotpo.com', opt_onLayout);
+    Services.preconnectFor(this.win).url(
+      this.getAmpDoc(),
+      'https://staticw2.yotpo.com',
+      opt_onLayout
+    );
   }
 
   /** @override */

--- a/extensions/amp-youtube/0.1/amp-youtube.js
+++ b/extensions/amp-youtube/0.1/amp-youtube.js
@@ -119,11 +119,12 @@ class AmpYoutube extends AMP.BaseElement {
     // work, because we preload with a different type and in that case
     // responses are only picked up if they are cacheable.
     const preconnect = Services.preconnectFor(this.win);
-    preconnect.url(this.getAmpDoc(), this.getVideoIframeSrc_());
+    const ampdoc = this.getAmpDoc();
+    preconnect.url(ampdoc, this.getVideoIframeSrc_());
     // Host that YT uses to serve JS needed by player.
-    preconnect.url(this.getAmpDoc(), 'https://s.ytimg.com', opt_onLayout);
+    preconnect.url(ampdoc, 'https://s.ytimg.com', opt_onLayout);
     // Load high resolution placeholder images for videos in prerender mode.
-    preconnect.url(this.getAmpDoc(), 'https://i.ytimg.com', opt_onLayout);
+    preconnect.url(ampdoc, 'https://i.ytimg.com', opt_onLayout);
   }
 
   /** @override */

--- a/extensions/amp-youtube/0.1/amp-youtube.js
+++ b/extensions/amp-youtube/0.1/amp-youtube.js
@@ -118,12 +118,12 @@ class AmpYoutube extends AMP.BaseElement {
     // we can switch to preloading the full source. For now this doesn't
     // work, because we preload with a different type and in that case
     // responses are only picked up if they are cacheable.
-    const {preconnect} = this;
-    preconnect.url(this.getVideoIframeSrc_());
+    const preconnect = Services.preconnectFor(this.win);
+    preconnect.url(this.getAmpDoc(), this.getVideoIframeSrc_());
     // Host that YT uses to serve JS needed by player.
-    preconnect.url('https://s.ytimg.com', opt_onLayout);
+    preconnect.url(this.getAmpDoc(), 'https://s.ytimg.com', opt_onLayout);
     // Load high resolution placeholder images for videos in prerender mode.
-    preconnect.url('https://i.ytimg.com', opt_onLayout);
+    preconnect.url(this.getAmpDoc(), 'https://i.ytimg.com', opt_onLayout);
   }
 
   /** @override */

--- a/extensions/amp-youtube/0.1/test/test-amp-youtube.js
+++ b/extensions/amp-youtube/0.1/test/test-amp-youtube.js
@@ -155,7 +155,7 @@ describes.realWin(
         expect(iframe.src).to.contain('loop=1');
       });
 
-      it.only('should preload the final url', async () => {
+      it('should preload the final url', async () => {
         const yt = await getYt({
           'autoplay': '',
           'data-videoid': datasource,

--- a/extensions/amp-youtube/0.1/test/test-amp-youtube.js
+++ b/extensions/amp-youtube/0.1/test/test-amp-youtube.js
@@ -155,19 +155,21 @@ describes.realWin(
         expect(iframe.src).to.contain('loop=1');
       });
 
-      it('should preload the final url', async () => {
+      it.only('should preload the final url', async () => {
         const yt = await getYt({
           'autoplay': '',
           'data-videoid': datasource,
           'data-param-playsinline': '0',
         });
         const {src} = yt.querySelector('iframe');
-        const preloadSpy = env.sandbox.spy(
-          yt.implementation_.preconnect,
-          'url'
-        );
+
+        const preconnect = Services.preconnectFor(win);
+        env.sandbox.spy(preconnect, 'url');
         yt.implementation_.preconnectCallback();
-        preloadSpy.should.have.been.calledWithExactly(src);
+        expect(preconnect.url).to.have.been.calledWith(
+          env.sandbox.match.object, // AmpDoc
+          src
+        );
       });
 
       it('should forward certain events from youtube to the amp element', async () => {

--- a/src/3p-frame.js
+++ b/src/3p-frame.js
@@ -191,12 +191,13 @@ export function addDataAndJsonAttributes_(element, attributes) {
 /**
  * Preloads URLs related to the bootstrap iframe.
  * @param {!Window} win
- * @param {!./preconnect.Preconnect} preconnect
+ * @param {../service/ampdoc-impl.AmpDoc} ampdoc
+ * @param {!./preconnect.PreconnectService} preconnect
  * @param {boolean=} opt_disallowCustom whether 3p url should not use meta tag.
  */
-export function preloadBootstrap(win, preconnect, opt_disallowCustom) {
+export function preloadBootstrap(win, ampdoc, preconnect, opt_disallowCustom) {
   const url = getBootstrapBaseUrl(win, undefined, opt_disallowCustom);
-  preconnect.preload(url, 'document');
+  preconnect.preload(ampdoc, url, 'document');
 
   // While the URL may point to a custom domain, this URL will always be
   // fetched by it.

--- a/src/3p-frame.js
+++ b/src/3p-frame.js
@@ -191,7 +191,7 @@ export function addDataAndJsonAttributes_(element, attributes) {
 /**
  * Preloads URLs related to the bootstrap iframe.
  * @param {!Window} win
- * @param {../service/ampdoc-impl.AmpDoc} ampdoc
+ * @param {!./service/ampdoc-impl.AmpDoc} ampdoc
  * @param {!./preconnect.PreconnectService} preconnect
  * @param {boolean=} opt_disallowCustom whether 3p url should not use meta tag.
  */
@@ -204,7 +204,7 @@ export function preloadBootstrap(win, ampdoc, preconnect, opt_disallowCustom) {
   const scriptUrl = getMode().localDev
     ? getAdsLocalhost(win) + '/dist.3p/current/integration.js'
     : `${urls.thirdParty}/${internalRuntimeVersion()}/f.js`;
-  preconnect.preload(scriptUrl, 'script');
+  preconnect.preload(ampdoc, scriptUrl, 'script');
 }
 
 /**

--- a/src/base-element.js
+++ b/src/base-element.js
@@ -21,7 +21,6 @@ import {devAssert, user, userAssert} from './log';
 import {getData, listen, loadPromise} from './event-helper';
 import {getMode} from './mode';
 import {isArray, toWin} from './types';
-import {preconnectForElement} from './preconnect';
 
 /**
  * Base class for all custom element implementations. Instead of inheriting
@@ -157,9 +156,6 @@ export class BaseElement {
 
     /** @private {?string} */
     this.defaultActionAlias_ = null;
-
-    /** @public {!./preconnect.Preconnect} */
-    this.preconnect = preconnectForElement(this.element);
   }
 
   /**

--- a/src/preconnect.js
+++ b/src/preconnect.js
@@ -375,26 +375,6 @@ export class Preconnect {
 }
 
 /**
- * @param {!BaseElement} baseElement
- * @param {string} url
- * @param {boolean=} opt_alsoConnecting
- */
-export function preconnectUrl(baseElement, url, opt_alsoConnecting) {
-  const preconnect = Services.preconnectFor(baseElement.win);
-  preconnect.url(baseElement.getAmpDoc(), url, opt_alsoConnecting);
-}
-
-/**
- * @param {!BaseElement} baseElement
- * @param {string} url
- * @param {string=} opt_preloadAs
- */
-export function preconnectPreload(baseElement, url, opt_preloadAs) {
-  const preconnect = Services.preconnectFor(baseElement.win);
-  preconnect.preload(baseElement.getAmpDoc(), url, opt_preloadAs);
-}
-
-/**
  * @param {!Element} element
  * @return {!Preconnect}
  */

--- a/src/preconnect.js
+++ b/src/preconnect.js
@@ -71,7 +71,7 @@ export function setPreconnectFeaturesForTesting(features) {
   preconnectFeatures = features;
 }
 
-class PreconnectService {
+export class PreconnectService {
   /**
    * @param {!Window} win
    */
@@ -334,10 +334,13 @@ export function installPreconnectService(window) {
  */
 export function preconnectToOrigin(document) {
   return whenDocumentComplete(document).then(() => {
-    const element = document.documentElement;
-    const preconnect = Services.preconnectFor(document.defaultView);
-    const info = Services.documentInfoForDoc(element);
-    preconnect.url(info.sourceUrl);
-    preconnect.url(info.canonicalUrl);
+    const win = document.defaultView;
+    if (win) {
+      const preconnect = Services.preconnectFor(win);
+      const info = Services.documentInfoForDoc(document.documentElement);
+      const ampdoc = Services.ampdoc(document);
+      preconnect.url(ampdoc, info.sourceUrl);
+      preconnect.url(ampdoc, info.canonicalUrl);
+    }
   });
 }

--- a/src/preconnect.js
+++ b/src/preconnect.js
@@ -25,7 +25,6 @@ import {htmlFor} from './static-template';
 import {parseUrlDeprecated} from './url';
 import {registerServiceBuilder} from './service';
 import {startsWith} from './string';
-import {toWin} from './types';
 import {whenDocumentComplete} from './document-ready';
 
 const ACTIVE_CONNECTION_TIMEOUT_MS = 180 * 1000;
@@ -317,71 +316,6 @@ class PreconnectService {
 
     xhr.send();
   }
-}
-
-export class Preconnect {
-  /**
-   * @param {!PreconnectService} preconnectService
-   * @param {!Element} element
-   */
-  constructor(preconnectService, element) {
-    /** @const @private {!PreconnectService} */
-    this.preconnectService_ = preconnectService;
-
-    /** @const @private {!Element} */
-    this.element_ = element;
-
-    /** @private {?./service/ampdoc-impl.AmpDoc} */
-    this.ampdoc_ = null;
-  }
-
-  /**
-   * @return {!./service/ampdoc-impl.AmpDoc}
-   * @private
-   */
-  getAmpdoc_() {
-    if (!this.ampdoc_) {
-      this.ampdoc_ = Services.ampdoc(this.element_);
-    }
-    return this.ampdoc_;
-  }
-
-  /**
-   * Preconnects to a URL. Always also does a dns-prefetch because
-   * browser support for that is better.
-   * @param {string} url
-   * @param {boolean=} opt_alsoConnecting Set this flag if you also just
-   *    did or are about to connect to this host. This is for the case
-   *    where preconnect is issued immediate before or after actual connect
-   *    and preconnect is used to flatten a deep HTTP request chain.
-   *    E.g. when you preconnect to a host that an embed will connect to
-   *    when it is more fully rendered, you already know that the connection
-   *    will be used very soon.
-   */
-  url(url, opt_alsoConnecting) {
-    this.preconnectService_.url(this.getAmpdoc_(), url, opt_alsoConnecting);
-  }
-
-  /**
-   * Asks the browser to preload a URL. Always also does a preconnect
-   * because browser support for that is better.
-   *
-   * @param {string} url
-   * @param {string=} opt_preloadAs
-   */
-  preload(url, opt_preloadAs) {
-    this.preconnectService_.preload(this.getAmpdoc_(), url, opt_preloadAs);
-  }
-}
-
-/**
- * @param {!Element} element
- * @return {!Preconnect}
- */
-export function preconnectForElement(element) {
-  const window = toWin(element.ownerDocument.defaultView);
-  const preconnectService = Services.preconnectFor(window);
-  return new Preconnect(preconnectService, element);
 }
 
 /**

--- a/src/service/core-services.js
+++ b/src/service/core-services.js
@@ -30,6 +30,7 @@ import {installLayout} from '../../builtins/amp-layout';
 import {installOwnersServiceForDoc} from './owners-impl';
 import {installPixel} from '../../builtins/amp-pixel';
 import {installPlatformService} from './platform-impl';
+import {installPreconnectService} from '../preconnect';
 import {installResourcesServiceForDoc} from './resources-impl';
 import {installStandardActionsForDoc} from './standard-actions-impl';
 import {installStorageServiceForDoc} from './storage-impl';
@@ -67,6 +68,7 @@ export function installRuntimeServices(global) {
   installVsyncService(global);
   installXhrService(global);
   installInputService(global);
+  installPreconnectService(global);
 }
 
 /**

--- a/src/service/platform-impl.js
+++ b/src/service/platform-impl.js
@@ -230,8 +230,7 @@ export class Platform {
 
 /**
  * @param {!Window} window
- * @return {*} TODO(#23582): Specify return type
  */
 export function installPlatformService(window) {
-  return registerServiceBuilder(window, 'platform', Platform);
+  registerServiceBuilder(window, 'platform', Platform);
 }

--- a/src/services.js
+++ b/src/services.js
@@ -399,6 +399,14 @@ export class Services {
   }
 
   /**
+   * @param {!Window} window
+   * @return {!./preconnect.Preconnect}
+   */
+  static preconnectFor(window) {
+    return getService(window, 'preconnect');
+  }
+
+  /**
    * @param {!Element|!./service/ampdoc-impl.AmpDoc} elementOrAmpDoc
    * @return {!./service/resources-interface.ResourcesInterface}
    */

--- a/src/services.js
+++ b/src/services.js
@@ -400,7 +400,7 @@ export class Services {
 
   /**
    * @param {!Window} window
-   * @return {!./preconnect.Preconnect}
+   * @return {!./preconnect.PreconnectService}
    */
   static preconnectFor(window) {
     return getService(window, 'preconnect');

--- a/test/unit/3p/test-3p-frame.js
+++ b/test/unit/3p/test-3p-frame.js
@@ -32,7 +32,6 @@ import {
   serializeMessage,
 } from '../../../src/3p-frame-messaging';
 import {dev} from '../../../src/log';
-import {preconnectForElement} from '../../../src/preconnect';
 import {toggleExperiment} from '../../../src/experiments';
 
 describe
@@ -47,7 +46,7 @@ describe
       clock = window.sandbox.useFakeTimers();
       container = document.createElement('div');
       document.body.appendChild(container);
-      preconnect = preconnectForElement(container);
+      preconnect = Services.preconnectFor(window);
     });
 
     afterEach(() => {
@@ -413,20 +412,18 @@ describe
       const ampdoc = Services.ampdoc(window.document);
       preloadBootstrap(window, ampdoc, preconnect);
       // Wait for visible promise.
-      return ampdoc
-        .whenFirstVisible()
-        .then(() => {
-          const fetches = document.querySelectorAll('link[rel=preload]');
-          expect(fetches).to.have.length(2);
-          expect(fetches[0]).to.have.property(
-            'href',
-            'http://ads.localhost:9876/dist.3p/current/frame.max.html'
-          );
-          expect(fetches[1]).to.have.property(
-            'href',
-            'http://ads.localhost:9876/dist.3p/current/integration.js'
-          );
-        });
+      return ampdoc.whenFirstVisible().then(() => {
+        const fetches = document.querySelectorAll('link[rel=preload]');
+        expect(fetches).to.have.length(2);
+        expect(fetches[0]).to.have.property(
+          'href',
+          'http://ads.localhost:9876/dist.3p/current/frame.max.html'
+        );
+        expect(fetches[1]).to.have.property(
+          'href',
+          'http://ads.localhost:9876/dist.3p/current/integration.js'
+        );
+      });
     });
 
     it('should prefetch default bootstrap frame if custom disabled', () => {
@@ -435,16 +432,14 @@ describe
       const ampdoc = Services.ampdoc(window.document);
       preloadBootstrap(window, ampdoc, preconnect, true);
       // Wait for visible promise.
-      return ampdoc
-        .whenFirstVisible()
-        .then(() => {
-          expect(
-            document.querySelectorAll(
-              'link[rel=preload]' +
-                '[href="http://ads.localhost:9876/dist.3p/current/frame.max.html"]'
-            )
-          ).to.be.ok;
-        });
+      return ampdoc.whenFirstVisible().then(() => {
+        expect(
+          document.querySelectorAll(
+            'link[rel=preload]' +
+              '[href="http://ads.localhost:9876/dist.3p/current/frame.max.html"]'
+          )
+        ).to.be.ok;
+      });
     });
 
     it('should make sub domains (unique)', () => {

--- a/test/unit/3p/test-3p-frame.js
+++ b/test/unit/3p/test-3p-frame.js
@@ -410,9 +410,10 @@ describe
 
     it('should prefetch bootstrap frame and JS', () => {
       window.__AMP_MODE = {localDev: true};
-      preloadBootstrap(window, preconnect);
+      const ampdoc = Services.ampdoc(window.document);
+      preloadBootstrap(window, ampdoc, preconnect);
       // Wait for visible promise.
-      return Services.ampdoc(window.document)
+      return ampdoc
         .whenFirstVisible()
         .then(() => {
           const fetches = document.querySelectorAll('link[rel=preload]');
@@ -431,9 +432,10 @@ describe
     it('should prefetch default bootstrap frame if custom disabled', () => {
       window.__AMP_MODE = {localDev: true};
       addCustomBootstrap('http://localhost:9876/boot/remote.html');
-      preloadBootstrap(window, preconnect, true);
+      const ampdoc = Services.ampdoc(window.document);
+      preloadBootstrap(window, ampdoc, preconnect, true);
       // Wait for visible promise.
-      return Services.ampdoc(window.document)
+      return ampdoc
         .whenFirstVisible()
         .then(() => {
           expect(

--- a/test/unit/test-preconnect.js
+++ b/test/unit/test-preconnect.js
@@ -18,18 +18,20 @@ import * as lolex from 'lolex';
 import {Services} from '../../src/services';
 import {createIframePromise} from '../../testing/iframe';
 import {
-  preconnectForElement,
+  installPreconnectService,
   preconnectToOrigin,
   setPreconnectFeaturesForTesting,
 } from '../../src/preconnect';
 
-describe('preconnect', () => {
+describes.sandboxed('preconnect', {}, env => {
+  let ampdoc;
   let iframeClock;
   let clock;
   let preconnect;
   let preloadSupported;
   let preconnectSupported;
   let isSafari;
+  let sandbox;
   let visiblePromise;
 
   // Factored out to make our linter happy since we don't allow
@@ -52,25 +54,27 @@ describe('preconnect', () => {
         isSafari: () => !!isSafari,
       };
       iframe.win.__AMP_SERVICES['platform'] = {obj: platform};
+      sandbox.stub(Services, 'platformFor').returns(platform);
 
-      const element = document.createElement('div');
-      iframe.win.document.body.appendChild(element);
-      preconnect = preconnectForElement(element);
-      window.sandbox.stub(preconnect, 'getAmpdoc_').returns({
+      installPreconnectService(iframe.win);
+      preconnect = Services.preconnectFor(iframe.win);
+
+      ampdoc = {
         whenFirstVisible: () => visiblePromise,
-      });
+      };
       return iframe;
     });
   }
 
   beforeEach(() => {
+    sandbox = env.sandbox;
     visiblePromise = Promise.resolve();
     isSafari = undefined;
     // Default mock to not support preload/preconnect - override in cases
     // to test for preload/preconnect support.
     preloadSupported = false;
     preconnectSupported = false;
-    clock = window.sandbox.useFakeTimers();
+    clock = sandbox.useFakeTimers();
   });
 
   afterEach(() => {
@@ -81,10 +85,10 @@ describe('preconnect', () => {
   it('should preconnect', () => {
     isSafari = false;
     return getPreconnectIframe().then(iframe => {
-      const open = window.sandbox.spy(XMLHttpRequest.prototype, 'open');
-      preconnect.url('https://a.preconnect.com/foo/bar');
-      preconnect.url('https://a.preconnect.com/other');
-      preconnect.url(javascriptUrlPrefix + ':alert()');
+      const open = sandbox.spy(XMLHttpRequest.prototype, 'open');
+      preconnect.url(ampdoc, 'https://a.preconnect.com/foo/bar');
+      preconnect.url(ampdoc, 'https://a.preconnect.com/other');
+      preconnect.url(ampdoc, javascriptUrlPrefix + ':alert()');
       expect(
         iframe.doc.querySelectorAll('link[rel=dns-prefetch]')
       ).to.have.length(0);
@@ -117,7 +121,7 @@ describe('preconnect', () => {
   it('should preconnect to origins', async function() {
     isSafari = false;
     const iframe = await getPreconnectIframe();
-    window.sandbox.stub(Services, 'documentInfoForDoc').returns({
+    sandbox.stub(Services, 'documentInfoForDoc').returns({
       sourceUrl: 'https://sourceurl.com/',
       canonicalUrl: 'https://canonicalurl.com/',
     });
@@ -133,10 +137,10 @@ describe('preconnect', () => {
     isSafari = false;
     preconnectSupported = true;
     return getPreconnectIframe().then(iframe => {
-      const open = window.sandbox.spy(XMLHttpRequest.prototype, 'open');
-      preconnect.url('https://a.preconnect.com/foo/bar');
-      preconnect.url('https://a.preconnect.com/other');
-      preconnect.url(javascriptUrlPrefix + ':alert()');
+      const open = sandbox.spy(XMLHttpRequest.prototype, 'open');
+      preconnect.url(ampdoc, 'https://a.preconnect.com/foo/bar');
+      preconnect.url(ampdoc, 'https://a.preconnect.com/other');
+      preconnect.url(ampdoc, javascriptUrlPrefix + ':alert()');
       expect(
         iframe.doc.querySelectorAll('link[rel=preconnect]')
       ).to.have.length(0);
@@ -167,11 +171,11 @@ describe('preconnect', () => {
     isSafari = true;
     return getPreconnectIframe().then(iframe => {
       clock.tick(1485531293690);
-      const open = window.sandbox.spy(XMLHttpRequest.prototype, 'open');
-      const send = window.sandbox.spy(XMLHttpRequest.prototype, 'send');
-      preconnect.url('https://s.preconnect.com/foo/bar');
-      preconnect.url('https://s.preconnect.com/other');
-      preconnect.url(javascriptUrlPrefix + ':alert()');
+      const open = sandbox.spy(XMLHttpRequest.prototype, 'open');
+      const send = sandbox.spy(XMLHttpRequest.prototype, 'send');
+      preconnect.url(ampdoc, 'https://s.preconnect.com/foo/bar');
+      preconnect.url(ampdoc, 'https://s.preconnect.com/other');
+      preconnect.url(ampdoc, javascriptUrlPrefix + ':alert()');
       expect(
         iframe.doc.querySelectorAll('link[rel=dns-prefetch]')
       ).to.have.length(0);
@@ -204,7 +208,7 @@ describe('preconnect', () => {
 
   it('should cleanup', () => {
     return getPreconnectIframe().then(iframe => {
-      preconnect.url('https://c.preconnect.com/foo/bar');
+      preconnect.url(ampdoc, 'https://c.preconnect.com/foo/bar');
       return visiblePromise.then(() => {
         expect(
           iframe.doc.querySelectorAll('link[rel=dns-prefetch]')
@@ -232,9 +236,9 @@ describe('preconnect', () => {
 
   it('should preconnect to 2 different origins', () => {
     return getPreconnectIframe().then(iframe => {
-      preconnect.url('https://d.preconnect.com/foo/bar');
+      preconnect.url(ampdoc, 'https://d.preconnect.com/foo/bar');
       // Different origin
-      preconnect.url('https://e.preconnect.com/other');
+      preconnect.url(ampdoc, 'https://e.preconnect.com/other');
       return visiblePromise.then(() => {
         expect(
           iframe.doc.querySelectorAll('link[rel=dns-prefetch]')
@@ -254,13 +258,13 @@ describe('preconnect', () => {
 
   it('should timeout preconnects', () => {
     return getPreconnectIframe().then(iframe => {
-      preconnect.url('https://x.preconnect.com/foo/bar');
+      preconnect.url(ampdoc, 'https://x.preconnect.com/foo/bar');
       return visiblePromise.then(() => {
         expect(
           iframe.doc.querySelectorAll('link[rel=preconnect]')
         ).to.have.length(1);
         iframeClock.tick(9000);
-        preconnect.url('https://x.preconnect.com/foo/bar');
+        preconnect.url(ampdoc, 'https://x.preconnect.com/foo/bar');
         return visiblePromise.then(() => {
           expect(
             iframe.doc.querySelectorAll('link[rel=preconnect]')
@@ -271,7 +275,7 @@ describe('preconnect', () => {
           ).to.have.length(0);
           // After timeout preconnect creates a new tag.
           clock.tick(10000);
-          preconnect.url('https://x.preconnect.com/foo/bar');
+          preconnect.url(ampdoc, 'https://x.preconnect.com/foo/bar');
           return visiblePromise.then(() => {
             expect(
               iframe.doc.querySelectorAll('link[rel=preconnect]')
@@ -285,6 +289,7 @@ describe('preconnect', () => {
   it('should timeout preconnects longer with active connect', () => {
     return getPreconnectIframe().then(iframe => {
       preconnect.url(
+        ampdoc,
         'https://y.preconnect.com/foo/bar',
         /* opt_alsoConnecting */ true
       );
@@ -298,13 +303,13 @@ describe('preconnect', () => {
         ).to.have.length(0);
         clock.tick(10000);
         return visiblePromise.then(() => {
-          preconnect.url('https://y.preconnect.com/foo/bar');
+          preconnect.url(ampdoc, 'https://y.preconnect.com/foo/bar');
           expect(
             iframe.doc.querySelectorAll('link[rel=preconnect]')
           ).to.have.length(0);
           clock.tick(180 * 1000);
           return visiblePromise.then(() => {
-            preconnect.url('https://y.preconnect.com/foo/bar');
+            preconnect.url(ampdoc, 'https://y.preconnect.com/foo/bar');
             expect(
               iframe.doc.querySelectorAll('link[rel=preconnect]')
             ).to.have.length(1);
@@ -322,10 +327,10 @@ describe('preconnect', () => {
       // Don't stub preload support allow the test to run through the browser
       // default regardless of support or not.
       return getPreconnectIframe(/* detectFeatures */ true).then(iframe => {
-        preconnect.preload('https://a.prefetch.com/foo/bar', 'script');
-        preconnect.preload('https://a.prefetch.com/foo/bar');
-        preconnect.preload('https://a.prefetch.com/other', 'style');
-        preconnect.preload(javascriptUrlPrefix + ':alert()');
+        preconnect.preload(ampdoc, 'https://a.prefetch.com/foo/bar', 'script');
+        preconnect.preload(ampdoc, 'https://a.prefetch.com/foo/bar');
+        preconnect.preload(ampdoc, 'https://a.prefetch.com/other', 'style');
+        preconnect.preload(ampdoc, javascriptUrlPrefix + ':alert()');
         const fetches = iframe.doc.querySelectorAll('link[rel=preload]');
         expect(fetches).to.have.length(0);
         return visiblePromise.then(() => {
@@ -347,10 +352,10 @@ describe('preconnect', () => {
   it('should preload', () => {
     preloadSupported = true;
     return getPreconnectIframe().then(iframe => {
-      preconnect.preload('https://a.prefetch.com/foo/bar', 'script');
-      preconnect.preload('https://a.prefetch.com/foo/bar');
-      preconnect.preload('https://a.prefetch.com/other', 'style');
-      preconnect.preload(javascriptUrlPrefix + ':alert()');
+      preconnect.preload(ampdoc, 'https://a.prefetch.com/foo/bar', 'script');
+      preconnect.preload(ampdoc, 'https://a.prefetch.com/foo/bar');
+      preconnect.preload(ampdoc, 'https://a.prefetch.com/other', 'style');
+      preconnect.preload(ampdoc, javascriptUrlPrefix + ':alert()');
       return visiblePromise.then(() => {
         // Also preconnects.
         expect(


### PR DESCRIPTION
Fixes #17620 and fixes #25770 (I think).

- Removes the useless class `Preconnect` which wraps `PreconnectService`. 
- Avoids allocation of this object for each element on creation, which should also fix the "null window" that causes a runtime error.