### PR TITLE
🏗 Increase max duration for Sauce Labs testing to 15 mins

### DIFF
--- a/build-system/tasks/karma.conf.js
+++ b/build-system/tasks/karma.conf.js
@@ -28,12 +28,12 @@ const COMMON_CHROME_FLAGS = [
   '--autoplay-policy=no-user-gesture-required',
 ];
 
-// Reduces the odds of Sauce labs timing out during tests. See #16135 and #24286.
+// Reduces the odds of Sauce labs timing out during tests. See #16135, #24286, and #25780.
 // Reference: https://wiki.saucelabs.com/display/DOCS/Test+Configuration+Options#TestConfigurationOptions-Timeouts
 const SAUCE_TIMEOUT_CONFIG = {
-  maxDuration: 10 * 60,
-  commandTimeout: 10 * 60,
-  idleTimeout: 10 * 60,
+  maxDuration: 15 * 60,
+  commandTimeout: 15 * 60,
+  idleTimeout: 15 * 60,
 };
 
 const BABELIFY_CONFIG = Object.assign(


### PR DESCRIPTION
We're seeing an unusual number of disconnection errors on Sauce Labs. It turns out that they're due to the max duration setting of 10 minutes.

We originally chose 10 mins to prevent tests from failing and sitting around for a long time, but now that we're running more tests, it makes sense to increase this timeout to 15 mins. This PR mitigates disconnections of this sort:

<img width="867" alt="Screen Shot 2019-11-26 at 12 12 27 PM" src="https://user-images.githubusercontent.com/26553114/69661264-b0040f80-1047-11ea-8299-99f04c9fafc7.png">
