### PR TITLE
🐛 Propagate nonce to generated script tags.

### DIFF
--- a/src/service/extensions-impl.js
+++ b/src/service/extensions-impl.js
@@ -573,11 +573,9 @@ export class Extensions {
     scriptElement.setAttribute('i-amphtml-inserted', '');
 
     // Propagate nonce to all generated script tags.
-    if (this.win.document.currentScript.hasAttribute('nonce')) {
-      scriptElement.setAttribute(
-        'nonce',
-        this.win.document.currentScript.getAttribute('nonce')
-      );
+    const currentScript = this.win.document.querySelector('script[nonce]');
+    if (currentScript) {
+      scriptElement.setAttribute('nonce', currentScript.getAttribute('nonce'));
     }
 
     // Allow error information to be collected

--- a/src/service/extensions-impl.js
+++ b/src/service/extensions-impl.js
@@ -575,7 +575,7 @@ export class Extensions {
     // Propagate nonce to all generated script tags.
     const currentScript = this.win.document.querySelector('script[nonce]');
     if (currentScript) {
-      scriptElement.nonce = currentScript.nonce;
+      scriptElement.setAttribute('nonce', currentScript.getAttribute('nonce'));
     }
 
     // Allow error information to be collected

--- a/src/service/extensions-impl.js
+++ b/src/service/extensions-impl.js
@@ -572,6 +572,14 @@ export class Extensions {
     scriptElement.setAttribute('data-script', extensionId);
     scriptElement.setAttribute('i-amphtml-inserted', '');
 
+    // Propagate nonce to all generated script tags.
+    if (this.win.document.currentScript.hasAttribute('nonce')) {
+      scriptElement.setAttribute(
+        'nonce',
+        this.win.document.currentScript.getAttribute('nonce')
+      );
+    }
+
     // Allow error information to be collected
     // https://github.com/ampproject/amphtml/issues/7353
     scriptElement.setAttribute('crossorigin', 'anonymous');

--- a/src/service/extensions-impl.js
+++ b/src/service/extensions-impl.js
@@ -575,7 +575,7 @@ export class Extensions {
     // Propagate nonce to all generated script tags.
     const currentScript = this.win.document.querySelector('script[nonce]');
     if (currentScript) {
-      scriptElement.setAttribute('nonce', currentScript.getAttribute('nonce'));
+      scriptElement.nonce = currentScript.nonce;
     }
 
     // Allow error information to be collected

--- a/src/validator-integration.js
+++ b/src/validator-integration.js
@@ -58,14 +58,14 @@ export function maybeValidate(win) {
  * @param {string} url
  * @return {!Promise}
  */
-function loadScript(doc, url) {
+export function loadScript(doc, url) {
   const script = doc.createElement('script');
   script.src = url;
 
   // Propagate nonce to all generated script tags.
   const currentScript = doc.querySelector('script[nonce]');
   if (currentScript) {
-    script.setAttribute('nonce', currentScript.getAttribute('nonce'));
+    script.nonce = currentScript.nonce;
   }
 
   const promise = loadPromise(script).then(

--- a/src/validator-integration.js
+++ b/src/validator-integration.js
@@ -62,9 +62,10 @@ function loadScript(doc, url) {
   const script = doc.createElement('script');
   script.src = url;
 
-  // Propagate the nonce to generated script tags.
-  if (doc.currentScript.hasAttribute('nonce')) {
-    script.setAttribute('nonce', doc.currentScript.getAttribute('nonce'));
+  // Propagate nonce to all generated script tags.
+  const currentScript = doc.querySelector('script[nonce]');
+  if (currentScript) {
+    script.setAttribute('nonce', currentScript.getAttribute('nonce'));
   }
 
   const promise = loadPromise(script).then(

--- a/src/validator-integration.js
+++ b/src/validator-integration.js
@@ -61,6 +61,12 @@ export function maybeValidate(win) {
 function loadScript(doc, url) {
   const script = doc.createElement('script');
   script.src = url;
+
+  // Propagate the nonce to generated script tags.
+  if (doc.currentScript.hasAttribute('nonce')) {
+    script.setAttribute('nonce', doc.currentScript.getAttribute('nonce'));
+  }
+
   const promise = loadPromise(script).then(
     () => {
       doc.head.removeChild(script);

--- a/src/validator-integration.js
+++ b/src/validator-integration.js
@@ -65,7 +65,7 @@ export function loadScript(doc, url) {
   // Propagate nonce to all generated script tags.
   const currentScript = doc.querySelector('script[nonce]');
   if (currentScript) {
-    script.nonce = currentScript.nonce;
+    script.setAttribute('nonce', currentScript.getAttribute('nonce'));
   }
 
   const promise = loadPromise(script).then(

--- a/test/unit/test-validator-integration.js
+++ b/test/unit/test-validator-integration.js
@@ -19,7 +19,7 @@
 
 import * as eventHelper from '../../src/event-helper';
 import * as mode from '../../src/mode';
-import {maybeValidate, loadScript} from '../../src/validator-integration';
+import {loadScript, maybeValidate} from '../../src/validator-integration';
 
 describes.fakeWin('validator-integration', {}, env => {
   let loadScriptStub;

--- a/test/unit/test-validator-integration.js
+++ b/test/unit/test-validator-integration.js
@@ -51,12 +51,16 @@ describes.fakeWin('validator-integration', {}, env => {
       maybeValidate(win);
       expect(loadScriptStub).to.have.been.called;
     });
+  });
 
+  describe('loadScript', () => {
     it('should propagate pre-existing nonces', () => {
-      const scriptEl = win.document.createElement('script');
+      const scriptEl = env.win.document.createElement('script');
       scriptEl.setAttribute('nonce', '123');
       win.document.head.append(scriptEl);
-      loadScriptStub.returns(Promise.resolve());
+      loadScriptStub = env.sandbox
+        .stub(eventHelper, 'loadPromise')
+        .returns(Promise.resolve());
 
       loadScript(win.document, 'http://example.com');
 

--- a/test/unit/test-validator-integration.js
+++ b/test/unit/test-validator-integration.js
@@ -54,7 +54,7 @@ describes.fakeWin('validator-integration', {}, env => {
 
     it('should propagate pre-existing nonces', () => {
       const scriptEl = win.document.createElement('script');
-      scriptEl.nonce = '123';
+      scriptEl.setAttribute('nonce', '123');
       win.document.head.append(scriptEl);
       loadScriptStub.returns(Promise.resolve());
 

--- a/test/unit/test-validator-integration.js
+++ b/test/unit/test-validator-integration.js
@@ -19,7 +19,7 @@
 
 import * as eventHelper from '../../src/event-helper';
 import * as mode from '../../src/mode';
-import {maybeValidate} from '../../src/validator-integration';
+import {maybeValidate, loadScript} from '../../src/validator-integration';
 
 describes.fakeWin('validator-integration', {}, env => {
   let loadScriptStub;
@@ -50,6 +50,19 @@ describes.fakeWin('validator-integration', {}, env => {
       loadScriptStub.returns(Promise.resolve());
       maybeValidate(win);
       expect(loadScriptStub).to.have.been.called;
+    });
+
+    it('should propagate pre-existing nonces', () => {
+      const scriptEl = win.document.createElement('script');
+      scriptEl.nonce = '123';
+      win.document.head.append(scriptEl);
+      loadScriptStub.returns(Promise.resolve());
+
+      loadScript(win.document, 'http://example.com');
+
+      expect(loadScriptStub).calledWith(
+        env.sandbox.match(el => el.nonce === '123')
+      );
     });
   });
 });


### PR DESCRIPTION
**summary**
Any `nonce` attribute on script tags should be propagated to dynamically injected script tags.

Fixes https://github.com/ampproject/amphtml/issues/25701.