### PR TITLE
add flux as RTC callout vendors

### DIFF
--- a/extensions/amp-a4a/0.1/callout-vendors.js
+++ b/extensions/amp-a4a/0.1/callout-vendors.js
@@ -155,6 +155,12 @@ const RTC_VENDORS = jsonConfiguration({
     macros: ['TAG_ID'],
     disableKeyAppend: true,
   },
+  prebidflux: {
+    url:
+      'https://prebid-server.flux-adserver.com/openrtb2/amp?tag_id=TAG_ID',
+    macros: ['TAG_ID'],
+    disableKeyAppend: true,
+  },
 });
 
 // DO NOT MODIFY: Setup for tests

--- a/extensions/amp-a4a/0.1/callout-vendors.js
+++ b/extensions/amp-a4a/0.1/callout-vendors.js
@@ -156,8 +156,7 @@ const RTC_VENDORS = jsonConfiguration({
     disableKeyAppend: true,
   },
   prebidflux: {
-    url:
-      'https://prebid-server.flux-adserver.com/openrtb2/amp?tag_id=TAG_ID',
+    url: 'https://prebid-server.flux-adserver.com/openrtb2/amp?tag_id=TAG_ID',
     macros: ['TAG_ID'],
     disableKeyAppend: true,
   },

--- a/extensions/amp-a4a/rtc-documentation.md
+++ b/extensions/amp-a4a/rtc-documentation.md
@@ -127,6 +127,7 @@ The `errorReportingUrl` property is optional. The only available macros are ERRO
 - APS
 - Automatad
 - Criteo
+- FLUX
 - IndexExchange
 - Lotame
 - Media.net

--- a/extensions/amp-a4a/rtc-publisher-implementation-guide.md
+++ b/extensions/amp-a4a/rtc-publisher-implementation-guide.md
@@ -23,6 +23,7 @@ To use RTC, you must meet the following requirements:
 - APS
 - Automatad
 - Criteo
+- FLUX
 - IndexExchange
 - Lotame
 - Media.net


### PR DESCRIPTION
This pull request adds flux adserver as a RTC callout vendors.