### PR TITLE
Clean up 'remove-viewer-query-params-on-navigate' experiment

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -39,7 +39,6 @@
   "layoutbox-invalidate-on-scroll": 0.05,
   "macro-after-long-task": 1,
   "pump-early-frame": 1,
-  "remove-viewer-query-params-on-navigate": 1,
   "use-responsive-ads-for-responsive-sizing-in-auto-ads": 0.05,
   "version-locking": 1
 }

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -36,7 +36,6 @@
   "layoutbox-invalidate-on-scroll": 0.05,
   "macro-after-long-task": 0,
   "pump-early-frame": 1,
-  "remove-viewer-query-params-on-navigate": 1,
   "swg-gpay-api": 0.1,
   "swg-gpay-native": 1,
   "use-responsive-ads-for-responsive-sizing-in-auto-ads": 0.05,

--- a/tools/experiments/experiments-config.js
+++ b/tools/experiments/experiments-config.js
@@ -311,12 +311,6 @@ export const EXPERIMENTS = [
     cleanupIssue: 'https://github.com/ampproject/amphtml/issues/24169',
   },
   {
-    id: 'remove-viewer-query-params-on-navigate',
-    name: 'Removes query params from viewer iframe on navigation.',
-    spec: 'https://github.com/ampproject/amphtml/issues/25179',
-    cleanupIssue: 'https://github.com/ampproject/amphtml/issues/24169',
-  },
-  {
     id: 'layoutbox-invalidate-on-scroll',
     name:
       'Invalidate the cached layoutboxes of elements nested in a scroller ' +


### PR DESCRIPTION
Fixes #25180. Context: #25179.

View diff with whitespace ignored for easier reading.