### PR TITLE
🏗🚮 Replace `bluebird` promises with node's native promises

### DIFF
--- a/build-system/compile/single-pass.js
+++ b/build-system/compile/single-pass.js
@@ -28,7 +28,6 @@ const log = require('fancy-log');
 const MagicString = require('magic-string');
 const minimist = require('minimist');
 const path = require('path');
-const Promise = require('bluebird');
 const relativePath = require('path').relative;
 const rename = require('gulp-rename');
 const resorcery = require('@jridgewell/resorcery');

--- a/build-system/server/app-index/index.js
+++ b/build-system/server/app-index/index.js
@@ -42,7 +42,7 @@ async function serveIndex({url}, res, next) {
     return next();
   }
 
-  const css = (await fs.promises.readFile(mainCssFile)).toString();
+  const css = fs.readFileSync(mainCssFile).toString();
 
   const renderedHtml = renderTemplate({
     fileSet,

--- a/build-system/server/app-index/index.js
+++ b/build-system/server/app-index/index.js
@@ -17,9 +17,8 @@
 
 const api = require('./api/api');
 const basepathMappings = require('./basepath-mappings');
-const BBPromise = require('bluebird');
-const fs = BBPromise.promisifyAll(require('fs'));
 const path = require('path');
+const promisifyAll = require('util-promisifyall');
 const {
   getListing,
   isMainPageFromUrl,
@@ -28,6 +27,8 @@ const {
 const {getServeMode} = require('../app-utils');
 const {join} = require('path');
 const {renderTemplate} = require('./template');
+
+const fs = promisifyAll(require('fs'));
 
 // Sitting on /build-system/server/app-index, so we go back thrice for the repo root.
 const root = path.join(__dirname, '../../../');

--- a/build-system/server/app-index/index.js
+++ b/build-system/server/app-index/index.js
@@ -17,8 +17,8 @@
 
 const api = require('./api/api');
 const basepathMappings = require('./basepath-mappings');
+const fs = require('fs');
 const path = require('path');
-const promisifyAll = require('util-promisifyall');
 const {
   getListing,
   isMainPageFromUrl,
@@ -27,8 +27,6 @@ const {
 const {getServeMode} = require('../app-utils');
 const {join} = require('path');
 const {renderTemplate} = require('./template');
-
-const fs = promisifyAll(require('fs'));
 
 // Sitting on /build-system/server/app-index, so we go back thrice for the repo root.
 const root = path.join(__dirname, '../../../');
@@ -44,7 +42,7 @@ async function serveIndex({url}, res, next) {
     return next();
   }
 
-  const css = (await fs.readFileAsync(mainCssFile)).toString();
+  const css = (await fs.promises.readFile(mainCssFile)).toString();
 
   const renderedHtml = renderTemplate({
     fileSet,

--- a/build-system/server/app-index/test/test-self.js
+++ b/build-system/server/app-index/test/test-self.js
@@ -111,7 +111,7 @@ describe('devdash', () => {
         const validDocPath = path.join(__dirname,
             '../../../../validator/testdata/feature_tests/minimum_valid_amp.html');
 
-        const validDoc = (await fs.promises.readFile(validDocPath)).toString();
+        const validDoc = fs.readFileSync(validDocPath).toString();
 
         expectValidAmphtml(await amphtmlValidator.getInstance(), validDoc);
       });

--- a/build-system/server/app-index/test/test-self.js
+++ b/build-system/server/app-index/test/test-self.js
@@ -15,16 +15,16 @@
  */
 
 const amphtmlValidator = require('amphtml-validator');
-const BBPromise = require('bluebird');
-const fs = BBPromise.promisifyAll(require('fs'));
+const promisifyAll = require('util-promisifyall');
 const path = require('path');
 const {expect} = require('chai');
-
 const {
   expectValidAmphtml,
   getBoundAttr,
   parseHtmlChunk,
 } = require('./helpers');
+
+const fs = promisifyAll(require('fs'));
 
 describe('devdash', () => {
 

--- a/build-system/server/app-index/test/test-self.js
+++ b/build-system/server/app-index/test/test-self.js
@@ -15,7 +15,7 @@
  */
 
 const amphtmlValidator = require('amphtml-validator');
-const promisifyAll = require('util-promisifyall');
+const fs = require('fs');
 const path = require('path');
 const {expect} = require('chai');
 const {
@@ -24,7 +24,6 @@ const {
   parseHtmlChunk,
 } = require('./helpers');
 
-const fs = promisifyAll(require('fs'));
 
 describe('devdash', () => {
 
@@ -112,7 +111,7 @@ describe('devdash', () => {
         const validDocPath = path.join(__dirname,
             '../../../../validator/testdata/feature_tests/minimum_valid_amp.html');
 
-        const validDoc = (await fs.readFileAsync(validDocPath)).toString();
+        const validDoc = (await fs.promises.readFile(validDocPath)).toString();
 
         expectValidAmphtml(await amphtmlValidator.getInstance(), validDoc);
       });

--- a/build-system/server/app-index/util/listing.js
+++ b/build-system/server/app-index/util/listing.js
@@ -15,10 +15,8 @@
  */
 'use strict';
 
-const promisifyAll = require('util-promisifyall');
+const fs = require('fs');
 const {join, normalize, sep} = require('path');
-
-const fs = promisifyAll(require('fs'));
 
 function isMaliciousPath(path, rootPath) {
   return (path + sep).substr(0, rootPath.length) !== rootPath;
@@ -36,8 +34,8 @@ async function getListing(rootPath, basepath) {
   }
 
   try {
-    if ((await fs.statAsync(path)).isDirectory()) {
-      return fs.readdirAsync(path);
+    if ((await fs.promises.stat(path)).isDirectory()) {
+      return fs.promises.readdir(path);
     }
   } catch (unusedE) {
     /* empty catch for fallbacks */

--- a/build-system/server/app-index/util/listing.js
+++ b/build-system/server/app-index/util/listing.js
@@ -15,9 +15,10 @@
  */
 'use strict';
 
-const BBPromise = require('bluebird');
-const fs = BBPromise.promisifyAll(require('fs'));
+const promisifyAll = require('util-promisifyall');
 const {join, normalize, sep} = require('path');
+
+const fs = promisifyAll(require('fs'));
 
 function isMaliciousPath(path, rootPath) {
   return (path + sep).substr(0, rootPath.length) !== rootPath;

--- a/build-system/server/app-index/util/listing.js
+++ b/build-system/server/app-index/util/listing.js
@@ -34,7 +34,7 @@ async function getListing(rootPath, basepath) {
   }
 
   try {
-    if ((await fs.promises.stat(path)).isDirectory()) {
+    if (fs.statSync(path).isDirectory()) {
       return fs.promises.readdir(path);
     }
   } catch (unusedE) {

--- a/build-system/server/app-video-testbench.js
+++ b/build-system/server/app-video-testbench.js
@@ -16,12 +16,11 @@
 /* eslint-disable */
 'use strict';
 
-const promisifyAll = require('util-promisifyall');
+const fs = require('fs');
 const {JSDOM} = require('jsdom');
 const {replaceUrls} = require('./app-utils');
 const {getServeMode} = require('./app-utils');
 
-const fs = promisifyAll(require('fs'));
 
 const sourceFile = 'test/manual/amp-video.amp.html';
 
@@ -368,7 +367,7 @@ function isValidExtension(extension) {
 
 
 function runVideoTestBench(req, res, next) {
-  fs.readFileAsync(sourceFile).then(contents => {
+  fs.promises.readFile(sourceFile).then(contents => {
     const dom = new JSDOM(contents);
     const {window} = dom;
     const doc = window.document;

--- a/build-system/server/app-video-testbench.js
+++ b/build-system/server/app-video-testbench.js
@@ -16,11 +16,12 @@
 /* eslint-disable */
 'use strict';
 
-const BBPromise = require('bluebird');
-const fs = BBPromise.promisifyAll(require('fs'));
+const promisifyAll = require('util-promisifyall');
 const {JSDOM} = require('jsdom');
 const {replaceUrls} = require('./app-utils');
 const {getServeMode} = require('./app-utils');
+
+const fs = promisifyAll(require('fs'));
 
 const sourceFile = 'test/manual/amp-video.amp.html';
 

--- a/build-system/server/app.js
+++ b/build-system/server/app.js
@@ -22,14 +22,13 @@
 const app = require('express')();
 const argv = require('minimist')(process.argv.slice(2));
 const bacon = require('baconipsum');
-const BBPromise = require('bluebird');
 const bodyParser = require('body-parser');
 const cors = require('./amp-cors');
 const devDashboard = require('./app-index/index');
 const formidable = require('formidable');
-const fs = BBPromise.promisifyAll(require('fs'));
 const jsdom = require('jsdom');
 const path = require('path');
+const promisifyAll = require('util-promisifyall');
 const request = require('request');
 const upload = require('multer')();
 const pc = process;
@@ -42,6 +41,8 @@ const {
 const {getServeMode} = require('./app-utils');
 const {renderShadowViewer} = require('./shadow-viewer');
 const {replaceUrls, isRtvMode} = require('./app-utils');
+
+const fs = promisifyAll(require('fs'));
 
 const TEST_SERVER_PORT = argv.port || 8000;
 let SERVE_MODE = getServeMode();

--- a/build-system/server/app.js
+++ b/build-system/server/app.js
@@ -26,9 +26,9 @@ const bodyParser = require('body-parser');
 const cors = require('./amp-cors');
 const devDashboard = require('./app-index/index');
 const formidable = require('formidable');
+const fs = require('fs');
 const jsdom = require('jsdom');
 const path = require('path');
-const promisifyAll = require('util-promisifyall');
 const request = require('request');
 const upload = require('multer')();
 const pc = process;
@@ -41,8 +41,6 @@ const {
 const {getServeMode} = require('./app-utils');
 const {renderShadowViewer} = require('./shadow-viewer');
 const {replaceUrls, isRtvMode} = require('./app-utils');
-
-const fs = promisifyAll(require('fs'));
 
 const TEST_SERVER_PORT = argv.port || 8000;
 let SERVE_MODE = getServeMode();
@@ -230,7 +228,7 @@ app.use('/pwa', (req, res) => {
   }
   res.statusCode = 200;
   res.setHeader('Content-Type', contentType);
-  fs.readFileAsync(pc.cwd() + file).then(file => {
+  fs.promises.readFile(pc.cwd() + file).then(file => {
     res.end(file);
   });
 });
@@ -811,7 +809,8 @@ app.get('/a4a_template/*', (req, res) => {
   const filePath =
     `${pc.cwd()}/extensions/amp-ad-network-${match[1]}-impl/` +
     `0.1/data/${match[2]}.template`;
-  fs.readFileAsync(filePath)
+  fs.promises
+    .readFile(filePath)
     .then(file => {
       res.setHeader('Content-Type', 'application/json');
       res.setHeader('AMP-template-amp-creative', 'amp-mustache');
@@ -886,7 +885,8 @@ app.get(
     const mode = SERVE_MODE;
     const inabox = req.query['inabox'];
     const stream = Number(req.query['stream']);
-    fs.readFileAsync(pc.cwd() + filePath, 'utf8')
+    fs.promises
+      .readFile(pc.cwd() + filePath, 'utf8')
       .then(file => {
         if (req.query['amp_js_v']) {
           file = addViewerIntegrationScript(req.query['amp_js_v'], file);
@@ -1091,7 +1091,8 @@ app.get('/adzerk/*', (req, res) => {
   }
   const filePath =
     pc.cwd() + '/extensions/amp-ad-network-adzerk-impl/0.1/data/' + match[1];
-  fs.readFileAsync(filePath)
+  fs.promises
+    .readFile(filePath)
     .then(file => {
       res.setHeader('Content-Type', 'application/json');
       res.setHeader('AMP-Ad-Template-Extension', 'amp-mustache');
@@ -1184,7 +1185,8 @@ app.get('/dist/amp-inabox-host.js', (req, res, next) => {
  */
 app.get('/dist/sw(.max)?.js', (req, res, next) => {
   const filePath = req.path;
-  fs.readFileAsync(pc.cwd() + filePath, 'utf8')
+  fs.promises
+    .readFile(pc.cwd() + filePath, 'utf8')
     .then(file => {
       let n = new Date();
       // Round down to the nearest 5 minutes.
@@ -1215,8 +1217,8 @@ app.get('/dist/rtv/9[89]*/*.js', (req, res, next) => {
     // Cause a delay, to show the "stale-while-revalidate"
     if (req.path.includes('v0.js')) {
       const path = req.path.replace(/rtv\/\d+/, '');
-      return fs
-        .readFileAsync(pc.cwd() + path, 'utf8')
+      return fs.promises
+        .readFile(pc.cwd() + path, 'utf8')
         .then(file => {
           res.end(file);
         })
@@ -1233,7 +1235,8 @@ app.get('/dist/rtv/9[89]*/*.js', (req, res, next) => {
 
 app.get(['/dist/cache-sw.html'], (req, res, next) => {
   const filePath = '/test/manual/cache-sw.html';
-  fs.readFileAsync(pc.cwd() + filePath, 'utf8')
+  fs.promises
+    .readFile(pc.cwd() + filePath, 'utf8')
     .then(file => {
       let n = new Date();
       // Round down to the nearest 5 minutes.
@@ -1278,7 +1281,7 @@ app.get('/dist/diversions', (req, res) => {
  * Web worker binary.
  */
 app.get('/dist/ww(.max)?.js', (req, res) => {
-  fs.readFileAsync(pc.cwd() + req.path).then(file => {
+  fs.promises.readFile(pc.cwd() + req.path).then(file => {
     res.setHeader('Content-Type', 'text/javascript');
     res.setHeader('Access-Control-Allow-Origin', '*');
     res.end(file);
@@ -1405,7 +1408,8 @@ app.use('(/dist)?/rtv/*/v0/analytics-vendors/:vendor.json', (req, res) => {
   const max = serveMode === 'default' ? '.max' : '';
   const localVendorConfigPath = `${pc.cwd()}/dist/v0/analytics-vendors/${vendor}${max}.json`;
 
-  fs.readFileAsync(localVendorConfigPath)
+  fs.promises
+    .readFile(localVendorConfigPath)
     .then(file => {
       res.setHeader('Content-Type', 'application/json');
       res.end(file);

--- a/build-system/server/recaptcha-router.js
+++ b/build-system/server/recaptcha-router.js
@@ -17,11 +17,11 @@
 const argv = require('minimist')(process.argv.slice(2));
 const cors = require('./amp-cors');
 const pc = process;
-const BBPromise = require('bluebird');
-const fs = BBPromise.promisifyAll(require('fs'));
 const multer = require('multer');
+const promisifyAll = require('util-promisifyall');
 const recaptchaRouter = require('express').Router();
 
+const fs = promisifyAll(require('fs'));
 const upload = multer();
 
 const recaptchaMock = `

--- a/build-system/server/recaptcha-router.js
+++ b/build-system/server/recaptcha-router.js
@@ -17,11 +17,10 @@
 const argv = require('minimist')(process.argv.slice(2));
 const cors = require('./amp-cors');
 const pc = process;
+const fs = require('fs');
 const multer = require('multer');
-const promisifyAll = require('util-promisifyall');
 const recaptchaRouter = require('express').Router();
 
-const fs = promisifyAll(require('fs'));
 const upload = multer();
 
 const recaptchaMock = `
@@ -33,7 +32,7 @@ window.grecaptcha = {
 
 const recaptchaFrameRequestHandler = (req, res, next) => {
   if (argv._.includes('unit') || argv._.includes('integration')) {
-    fs.readFileAsync(pc.cwd() + req.path, 'utf8').then(file => {
+    fs.promises.readFile(pc.cwd() + req.path, 'utf8').then(file => {
       file = file.replace(
         /initRecaptcha\(.*\)/g,
         'initRecaptcha("/recaptcha/mock.js?sitekey=")'

--- a/build-system/server/routes/a4a-envelopes.js
+++ b/build-system/server/routes/a4a-envelopes.js
@@ -15,13 +15,11 @@
  */
 
 const app = require('express').Router();
+const fs = require('fs');
 const log = require('fancy-log');
-const promisifyAll = require('util-promisifyall');
 const request = require('request');
 const {getServeMode, replaceUrls} = require('../app-utils');
 const {red} = require('ansi-colors');
-
-const fs = promisifyAll(require('fs'));
 
 // In-a-box envelope.
 // Examples:
@@ -30,7 +28,7 @@ const fs = promisifyAll(require('fs'));
 app.use('/inabox/', (req, res) => {
   const templatePath =
     process.cwd() + '/build-system/server/server-inabox-template.html';
-  fs.readFileAsync(templatePath, 'utf8').then(template => {
+  fs.promises.readFile(templatePath, 'utf8').then(template => {
     template = template.replace(/SOURCE/g, 'AD_URL');
     const url = getInaboxUrl(req);
     res.end(fillTemplate(template, url.href, req.query));
@@ -43,7 +41,8 @@ app.use('/inabox/', (req, res) => {
 // http://localhost:8000/inabox-friendly/proxy/s/www.washingtonpost.com/amphtml/news/post-politics/wp/2016/02/21/bernie-sanders-says-lower-turnout-contributed-to-his-nevada-loss-to-hillary-clinton/
 app.use('/inabox-(friendly|safeframe)', (req, res) => {
   const templatePath = '/build-system/server/server-inabox-template.html';
-  fs.readFileAsync(process.cwd() + templatePath, 'utf8')
+  fs.promises
+    .readFile(process.cwd() + templatePath, 'utf8')
     .then(template => {
       const url = getInaboxUrl(req);
       if (req.baseUrl == '/inabox-friendly') {
@@ -79,7 +78,7 @@ app.use('/a4a(|-3p)/', (req, res) => {
   const force3p = req.baseUrl.startsWith('/a4a-3p');
   const templatePath = '/build-system/server/server-a4a-template.html';
   const url = getInaboxUrl(req);
-  fs.readFileAsync(process.cwd() + templatePath, 'utf8').then(template => {
+  fs.promises.readFile(process.cwd() + templatePath, 'utf8').then(template => {
     const content = fillTemplate(template, url.href, req.query)
       .replace(/CHECKSIG/g, force3p || '')
       .replace(/DISABLE3PFALLBACK/g, !force3p);

--- a/build-system/server/routes/a4a-envelopes.js
+++ b/build-system/server/routes/a4a-envelopes.js
@@ -15,12 +15,13 @@
  */
 
 const app = require('express').Router();
-const BBPromise = require('bluebird');
-const fs = BBPromise.promisifyAll(require('fs'));
 const log = require('fancy-log');
+const promisifyAll = require('util-promisifyall');
 const request = require('request');
 const {getServeMode, replaceUrls} = require('../app-utils');
 const {red} = require('ansi-colors');
+
+const fs = promisifyAll(require('fs'));
 
 // In-a-box envelope.
 // Examples:

--- a/build-system/tasks/bundle-size/index.js
+++ b/build-system/tasks/bundle-size/index.js
@@ -16,14 +16,13 @@
 'use strict';
 
 const argv = require('minimist')(process.argv.slice(2));
-const BBPromise = require('bluebird');
 const brotliSize = require('brotli-size');
 const fs = require('fs');
 const globby = require('globby');
 const log = require('fancy-log');
 const path = require('path');
-const requestPost = BBPromise.promisify(require('request').post);
 const url = require('url');
+const util = require('util');
 const {
   gitCommitHash,
   gitTravisMasterBaseline,
@@ -39,6 +38,8 @@ const {
   VERSION: internalRuntimeVersion,
 } = require('../../compile/internal-version');
 const {cyan, green, red, yellow} = require('ansi-colors');
+
+const requestPost = util.promisify(require('request').post);
 
 const fileGlobs = ['dist/*.js', 'dist/v0/*-?.?.js'];
 const normalizedRtvNumber = '1234567890123';

--- a/build-system/tasks/changelog.js
+++ b/build-system/tasks/changelog.js
@@ -24,18 +24,19 @@
 
 const argv = require('minimist')(process.argv.slice(2));
 const assert = require('assert');
-const BBPromise = require('bluebird');
 const childProcess = require('child_process');
 const colors = require('ansi-colors');
 const config = require('../test-configs/config');
 const extend = require('util')._extend;
 const git = require('gulp-git');
 const log = require('fancy-log');
-const request = BBPromise.promisify(require('request'));
+const util = require('util');
 
 const {GITHUB_ACCESS_TOKEN} = process.env;
-const exec = BBPromise.promisify(childProcess.exec);
-const gitExec = BBPromise.promisify(git.exec);
+
+const exec = util.promisify(childProcess.exec);
+const gitExec = util.promisify(git.exec);
+const request = util.promisify(require('request'));
 
 const {branch: overrideBranch, dryrun: isDryrun} = argv;
 
@@ -397,7 +398,7 @@ function getGitLog(gitMetadata) {
 function getGithubPullRequestsMetadata(gitMetadata) {
   // (erwinm): Github seems to only return data for the first 3 pages
   // from my manual testing.
-  return BBPromise.all([
+  return Promise.all([
     getClosedPullRequests(1),
     getClosedPullRequests(2),
     getClosedPullRequests(3),
@@ -421,9 +422,9 @@ function getGithubPullRequestsMetadata(gitMetadata) {
           // through github merge).
           return getPullRequest(prOptions, log);
         }
-        return BBPromise.resolve();
+        return Promise.resolve();
       });
-      return BBPromise.all(githubPrRequest).then(() => {
+      return Promise.all(githubPrRequest).then(() => {
         return gitMetadata;
       });
     });
@@ -444,9 +445,9 @@ function getGithubFilesMetadata(gitMetadata) {
       fileOptions.url = `${log.pr.url}/files`;
       return getPullRequestFiles(fileOptions, log.pr);
     }
-    return BBPromise.resolve();
+    return Promise.resolve();
   });
-  return BBPromise.all(githubFileRequests).then(() => {
+  return Promise.all(githubFileRequests).then(() => {
     return gitMetadata;
   });
 }

--- a/build-system/tasks/check-owners.js
+++ b/build-system/tasks/check-owners.js
@@ -26,12 +26,12 @@ const fs = require('fs-extra');
 const JSON5 = require('json5');
 const log = require('fancy-log');
 const request = require('request');
-const utils = require('bluebird');
+const util = require('util');
 const {cyan, red, green} = require('ansi-colors');
 const {getFilesToCheck, usesFilesOrLocalChanges} = require('../common/utils');
 const {isTravisBuild} = require('../common/travis');
 
-const requestPost = utils.promisify(request.post);
+const requestPost = util.promisify(request.post);
 
 const OWNERS_SYNTAX_CHECK_URI =
   'http://ampproject-owners-bot.appspot.com/v0/syntax';

--- a/build-system/tasks/csvify-size/index.js
+++ b/build-system/tasks/csvify-size/index.js
@@ -15,12 +15,14 @@
  */
 'use strict';
 
-const BBPromise = require('bluebird');
 const childProcess = require('child_process');
-const exec = BBPromise.promisify(childProcess.exec);
 const colors = require('ansi-colors');
-const fs = BBPromise.promisifyAll(require('fs'));
 const log = require('fancy-log');
+const promisifyAll = require('util-promisifyall');
+const util = require('util');
+
+const fs = promisifyAll(require('fs'));
+const exec = util.promisify(childProcess.exec);
 
 const prettyBytesUnits = ['B', 'kB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
 

--- a/build-system/tasks/csvify-size/index.js
+++ b/build-system/tasks/csvify-size/index.js
@@ -17,11 +17,10 @@
 
 const childProcess = require('child_process');
 const colors = require('ansi-colors');
+const fs = require('fs');
 const log = require('fancy-log');
-const promisifyAll = require('util-promisifyall');
 const util = require('util');
 
-const fs = promisifyAll(require('fs'));
 const exec = util.promisify(childProcess.exec);
 
 const prettyBytesUnits = ['B', 'kB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
@@ -234,7 +233,7 @@ function serializeCheckout(logs) {
       // all the tables.
       return exec(`git checkout ${sha} ${filePath}`)
         .then(() => {
-          return fs.readFileAsync(`${filePath}`);
+          return fs.promises.readFile(`${filePath}`);
         })
         .then(file => {
           const quotedDateTime = `"${dateTime}"`;
@@ -268,7 +267,7 @@ async function csvifySize() {
     return serializeCheckout(logs.reverse()).then(rows => {
       rows.unshift.apply(rows, tableHeaders);
       const tbl = rows.map(row => row.join(',')).join('\n');
-      return fs.writeFileAsync('test/size.csv', `${tbl}\n`);
+      return fs.promises.writeFile('test/size.csv', `${tbl}\n`);
     });
   });
 }

--- a/build-system/tasks/dep-check.js
+++ b/build-system/tasks/dep-check.js
@@ -16,14 +16,13 @@
 'use strict';
 
 const babelify = require('babelify');
-const BBPromise = require('bluebird');
 const browserify = require('browserify');
 const depCheckConfig = require('../test-configs/dep-check-config');
-const fs = BBPromise.promisifyAll(require('fs-extra'));
 const gulp = require('gulp');
 const log = require('fancy-log');
 const minimatch = require('minimatch');
 const path = require('path');
+const promisifyAll = require('util-promisifyall');
 const source = require('vinyl-source-stream');
 const through = require('through2');
 const {
@@ -38,6 +37,7 @@ const {isTravisBuild} = require('../common/travis');
 
 const root = process.cwd();
 const absPathRegExp = new RegExp(`^${root}/`);
+const fs = promisifyAll(require('fs-extra'));
 
 /**
  * @typedef {{
@@ -199,7 +199,7 @@ function getSrcs() {
  */
 function getGraph(entryModule) {
   let resolve;
-  const promise = new BBPromise(r => {
+  const promise = new Promise(r => {
     resolve = r;
   });
   const module = Object.create(null);
@@ -312,7 +312,7 @@ async function depCheck() {
       // This check is for extension folders that actually dont have
       // an extension entry point module yet.
       entryPoints = entryPoints.filter(x => fs.existsSync(x));
-      return BBPromise.all(entryPoints.map(getGraph));
+      return Promise.all(entryPoints.map(getGraph));
     })
     .then(flattenGraph)
     .then(runRules)

--- a/build-system/tasks/dep-check.js
+++ b/build-system/tasks/dep-check.js
@@ -18,11 +18,11 @@
 const babelify = require('babelify');
 const browserify = require('browserify');
 const depCheckConfig = require('../test-configs/dep-check-config');
+const fs = require('fs-extra');
 const gulp = require('gulp');
 const log = require('fancy-log');
 const minimatch = require('minimatch');
 const path = require('path');
-const promisifyAll = require('util-promisifyall');
 const source = require('vinyl-source-stream');
 const through = require('through2');
 const {
@@ -37,7 +37,6 @@ const {isTravisBuild} = require('../common/travis');
 
 const root = process.cwd();
 const absPathRegExp = new RegExp(`^${root}/`);
-const fs = promisifyAll(require('fs-extra'));
 
 /**
  * @typedef {{
@@ -164,7 +163,7 @@ const rules = depCheckConfig.rules.map(config => new Rule(config));
  */
 function getSrcs() {
   return fs
-    .readdirAsync('extensions')
+    .readdir('extensions')
     .then(dirItems => {
       // Look for extension entry points
       return flatten(

--- a/build-system/tasks/e2e/puppeteer-controller.js
+++ b/build-system/tasks/e2e/puppeteer-controller.js
@@ -301,8 +301,11 @@ class PuppeteerController {
     this.isXpathInstalled_ = true;
 
     const scripts = await Promise.all([
-      fs.readFileAsync('third_party/wgxpath/wgxpath.js', 'utf8'),
-      fs.readFileAsync('build-system/tasks/e2e/driver/query-xpath.js', 'utf8'),
+      fs.promises.readFile('third_party/wgxpath/wgxpath.js', 'utf8'),
+      fs.promises.readFile(
+        'build-system/tasks/e2e/driver/query-xpath.js',
+        'utf8'
+      ),
     ]);
     const frame = await this.getCurrentFrame_();
     await frame.evaluate(scripts.join('\n\n'));

--- a/build-system/tasks/e2e/selenium-webdriver-controller.js
+++ b/build-system/tasks/e2e/selenium-webdriver-controller.js
@@ -231,8 +231,11 @@ class SeleniumWebDriverController {
     this.isXpathInstalled_ = true;
 
     const scripts = await Promise.all([
-      fs.readFileAsync('third_party/wgxpath/wgxpath.js', 'utf8'),
-      fs.readFileAsync('build-system/tasks/e2e/driver/query-xpath.js', 'utf8'),
+      fs.promises.readFile('third_party/wgxpath/wgxpath.js', 'utf8'),
+      fs.promises.readFile(
+        'build-system/tasks/e2e/driver/query-xpath.js',
+        'utf8'
+      ),
     ]);
     await this.driver.executeScript(scripts.join('\n\n'));
   }

--- a/build-system/tasks/prepend-global/index.js
+++ b/build-system/tasks/prepend-global/index.js
@@ -18,12 +18,11 @@
 const argv = require('minimist')(process.argv.slice(2));
 const childProcess = require('child_process');
 const colors = require('ansi-colors');
+const fs = require('fs');
 const log = require('fancy-log');
 const path = require('path');
-const promisifyAll = require('util-promisifyall');
 const util = require('util');
 
-const fs = promisifyAll(require('fs'));
 const exec = util.promisify(childProcess.exec);
 
 const {red, cyan} = colors;
@@ -100,7 +99,7 @@ function writeTarget(filename, fileString, opt_dryrun) {
     log(fileString);
     return Promise.resolve();
   }
-  return fs.writeFileAsync(filename, fileString);
+  return fs.promises.writeFile(filename, fileString);
 }
 
 /**
@@ -137,8 +136,8 @@ function applyConfig(
   return checkoutBranchConfigs(filename, opt_localBranch, opt_branch)
     .then(() => {
       return Promise.all([
-        fs.readFileAsync(filename),
-        fs.readFileAsync(target),
+        fs.promises.readFile(filename),
+        fs.promises.readFile(target),
       ]);
     })
     .then(files => {
@@ -211,7 +210,7 @@ function enableLocalDev(config, target, configJson) {
  * @return {!Promise}
  */
 function removeConfig(target) {
-  return fs.readFileAsync(target).then(file => {
+  return fs.promises.readFile(target).then(file => {
     let contents = file.toString();
     if (numConfigs(contents) == 0) {
       return Promise.resolve();

--- a/build-system/tasks/prepend-global/index.js
+++ b/build-system/tasks/prepend-global/index.js
@@ -16,13 +16,15 @@
 'use strict';
 
 const argv = require('minimist')(process.argv.slice(2));
-const BBPromise = require('bluebird');
 const childProcess = require('child_process');
-const exec = BBPromise.promisify(childProcess.exec);
 const colors = require('ansi-colors');
-const fs = BBPromise.promisifyAll(require('fs'));
 const log = require('fancy-log');
 const path = require('path');
+const promisifyAll = require('util-promisifyall');
+const util = require('util');
+
+const fs = promisifyAll(require('fs'));
+const exec = util.promisify(childProcess.exec);
 
 const {red, cyan} = colors;
 

--- a/build-system/tasks/process-3p-github-pr.js
+++ b/build-system/tasks/process-3p-github-pr.js
@@ -23,11 +23,12 @@
 'use strict';
 const argv = require('minimist')(process.argv.slice(2));
 const assert = require('assert');
-const BBPromise = require('bluebird');
 const colors = require('ansi-colors');
 const extend = require('util')._extend;
 const log = require('fancy-log');
-const request = BBPromise.promisify(require('request'));
+const util = require('util');
+
+const request = util.promisify(require('request'));
 
 const {GITHUB_ACCESS_TOKEN} = process.env;
 
@@ -140,7 +141,7 @@ function process3pGithubPr() {
   for (let batch = 1; batch < NUM_BATCHES; batch++) {
     arrayPromises.push(getIssues(batch));
   }
-  return BBPromise.all(arrayPromises)
+  return Promise.all(arrayPromises)
     .then(requests => [].concat.apply([], requests))
     .then(issues => {
       const allIssues = issues;

--- a/build-system/tasks/process-github-issues.js
+++ b/build-system/tasks/process-github-issues.js
@@ -16,11 +16,12 @@
 'use strict';
 const argv = require('minimist')(process.argv.slice(2));
 const assert = require('assert');
-const BBPromise = require('bluebird');
 const colors = require('ansi-colors');
 const extend = require('util')._extend;
 const log = require('fancy-log');
-const request = BBPromise.promisify(require('request'));
+const util = require('util');
+
+const request = util.promisify(require('request'));
 
 const {GITHUB_ACCESS_TOKEN} = process.env;
 
@@ -121,7 +122,7 @@ function updateGitHubIssues() {
   for (let batch = 1; batch < NUM_BATCHES; batch++) {
     arrayPromises.push(getIssues(batch));
   }
-  return BBPromise.all(arrayPromises)
+  return Promise.all(arrayPromises)
     .then(requests => [].concat.apply([], requests))
     .then(issues => {
       const allIssues = issues;

--- a/build-system/tasks/release-tagging.js
+++ b/build-system/tasks/release-tagging.js
@@ -16,15 +16,15 @@
 'use strict';
 
 const argv = require('minimist')(process.argv.slice(2));
-const BBPromise = require('bluebird');
 const colors = require('ansi-colors');
 const fs = require('fs-extra');
 const git = require('gulp-git');
 const log = require('fancy-log');
-const request = BBPromise.promisify(require('request'));
+const util = require('util');
 
 const {GITHUB_ACCESS_TOKEN} = process.env;
-const gitExec = BBPromise.promisify(git.exec);
+const gitExec = util.promisify(git.exec);
+const request = util.promisify(require('request'));
 
 const isDryrun = argv.dryrun;
 const verbose = argv.verbose || argv.v;

--- a/build-system/tasks/todos.js
+++ b/build-system/tasks/todos.js
@@ -15,13 +15,14 @@
  */
 'use strict';
 
-const BBPromise = require('bluebird');
 const colors = require('ansi-colors');
 const gulp = require('gulp');
 const log = require('fancy-log');
-const request = BBPromise.promisify(require('request'));
 const srcGlobs = require('../test-configs/config').presubmitGlobs;
 const through2 = require('through2');
+const util = require('util');
+
+const request = util.promisify(require('request'));
 
 const {GITHUB_ACCESS_TOKEN} = process.env;
 

--- a/package.json
+++ b/package.json
@@ -174,7 +174,6 @@
     "tsickle": "0.37.1",
     "typescript": "3.7.2",
     "uglifyify": "5.0.2",
-    "util-promisifyall": "1.0.6",
     "vinyl-buffer": "1.0.1",
     "vinyl-source-stream": "2.0.0",
     "watchify": "3.11.1"

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "babelify": "10.0.0",
     "baconipsum": "0.1.2",
     "base62": "2.0.1",
-    "bluebird": "3.7.1",
     "body-parser": "1.19.0",
     "brotli-size": "4.0.0",
     "browserify": "16.5.0",
@@ -175,6 +174,7 @@
     "tsickle": "0.37.1",
     "typescript": "3.7.2",
     "uglifyify": "5.0.2",
+    "util-promisifyall": "1.0.6",
     "vinyl-buffer": "1.0.1",
     "vinyl-source-stream": "2.0.0",
     "watchify": "3.11.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3039,11 +3039,6 @@ blob@0.0.5:
   resolved "https://registry.yarnpkg.com/blob/-/blob-0.0.5.tgz#d680eeef25f8cd91ad533f5b01eed48e64caf683"
   integrity sha512-gaqbzQPqOoamawKg0LGVd7SzLgXS+JH61oWprSLH+P+abTczqJbhTR8CmJ2u9/bUYNmHTGJx/UEmn6doAvvuig==
 
-bluebird@3.7.1:
-  version "3.7.1"
-  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.1.tgz#df70e302b471d7473489acf26a93d63b53f874de"
-  integrity sha512-DdmyoGCleJnkbp3nkbxTLJ18rjDsE4yCggEwKNXkeV123sPNfOCYeDoeuOY+F2FrSjO1YXcTU+dsy96KMy+gcg==
-
 bluebird@^3.3.0, bluebird@^3.5.0, bluebird@^3.5.5:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.0.tgz#56a6a886e03f6ae577cffedeb524f8f2450293cf"
@@ -14424,6 +14419,11 @@ util-deprecate@^1.0.1, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
+
+util-promisifyall@1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/util-promisifyall/-/util-promisifyall-1.0.6.tgz#03439a5a76461e1f71f76954d945cffc8bd6aad8"
+  integrity sha512-l+o62sbaqStC1xt7oEhlafC4jWBgkOjBXvlPwxkvOYmNqpY8dNXuKdOa+VHjkYz2Fw98e0HvJtNKUg0+6hfP2w==
 
 util.promisify@^1.0.0, util.promisify@~1.0.0:
   version "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -14420,11 +14420,6 @@ util-deprecate@^1.0.1, util-deprecate@~1.0.1:
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
 
-util-promisifyall@1.0.6:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/util-promisifyall/-/util-promisifyall-1.0.6.tgz#03439a5a76461e1f71f76954d945cffc8bd6aad8"
-  integrity sha512-l+o62sbaqStC1xt7oEhlafC4jWBgkOjBXvlPwxkvOYmNqpY8dNXuKdOa+VHjkYz2Fw98e0HvJtNKUg0+6hfP2w==
-
 util.promisify@^1.0.0, util.promisify@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/util.promisify/-/util.promisify-1.0.0.tgz#440f7165a459c9a16dc145eb8e72f35687097030"


### PR DESCRIPTION
Several of AMP's `gulp` tasks use the `bluebird` package for promise functionality because they were written at a time when `node` did not natively support promises.

**PR highlights:**

- Replaces `Promise` from `bluebird` with node's native `Promise`
- Replaces `Promise.all` from `bluebird` with node's native `Promise.all`
- Replaces `promisify` from `bluebird` with node's native [`util.promisify`](https://nodejs.org/dist/latest-v8.x/docs/api/util.html#util_util_promisify_original)
- Replaces `promisifyAll` from `bluebird` with native promise APIs of [`fs`](https://nodejs.org/api/fs.html#fs_fs_promises_api) and [`fs-extra`](https://www.npmjs.com/package/fs-extra#sync-vs-async-vs-asyncawait)
- Completely removes `bluebird` from `package.json`

**References:**
- `util.promisify` [docs](https://nodejs.org/dist/latest-v8.x/docs/api/util.html#util_util_promisify_original)
- `fs.promises` [docs](https://nodejs.org/api/fs.html#fs_fs_promises_api)
- `fs-extra` [docs](https://www.npmjs.com/package/fs-extra#sync-vs-async-vs-asyncawait)

Closes #25810
Resolves https://github.com/ampproject/amphtml/pull/25318#discussion_r340363737
