### PR TITLE
🐛Remove `postEvent` allowlist from video iframe integration

### DIFF
--- a/src/video-iframe-integration.js
+++ b/src/video-iframe-integration.js
@@ -72,16 +72,6 @@ const validMethods = [
   'hidecontrols',
 ];
 
-const validEvents = [
-  'canplay',
-  'load',
-  'playing',
-  'pause',
-  'ended',
-  'muted',
-  'unmuted',
-];
-
 /**
  * @param {function()} win
  * @param {*} opt_initializer
@@ -346,11 +336,6 @@ export class AmpVideoIntegration {
    * @param {string} event
    */
   postEvent(event) {
-    userAssert(
-      validEvents.indexOf(event) > -1,
-      `%s Invalid event [${event}]`,
-      TAG
-    );
     this.postToParent_(dict({'event': event}));
   }
 

--- a/test/unit/test-video-iframe-integration.js
+++ b/test/unit/test-video-iframe-integration.js
@@ -119,21 +119,12 @@ describes.realWin('video-iframe-integration', {amp: false}, env => {
     });
 
     describe('#postEvent', () => {
-      it('should reject invalid events', () => {
-        const integration = new AmpVideoIntegration();
-        const invalidEvents = 'tacos al pastor'.split(' ');
-        for (let i = 0; i < invalidEvents.length; i++) {
-          const event = invalidEvents[i];
-          expect(() => integration.postEvent(event)).to.throw(/Invalid event/);
-        }
-      });
-
-      it('should post valid events', () => {
+      it('should post any event', () => {
         const integration = new AmpVideoIntegration();
 
         const postToParent = env.sandbox.stub(integration, 'postToParent_');
 
-        const validEvents = [
+        const events = [
           'canplay',
           'load',
           'playing',
@@ -141,10 +132,12 @@ describes.realWin('video-iframe-integration', {amp: false}, env => {
           'ended',
           'muted',
           'unmuted',
+          'tacos',
+          'al',
+          'pastor',
         ];
 
-        for (let i = 0; i < validEvents.length; i++) {
-          const event = validEvents[i];
+        for (const event of events) {
           integration.postEvent(event);
           expect(postToParent.withArgs(env.sandbox.match({event}))).to.have.been
             .calledOnce;

--- a/test/unit/test-video-iframe-integration.js
+++ b/test/unit/test-video-iframe-integration.js
@@ -137,7 +137,8 @@ describes.realWin('video-iframe-integration', {amp: false}, env => {
           'pastor',
         ];
 
-        for (const event of events) {
+        for (let i = 0; i < events.length; i++) {
+          const event = events[i];
           integration.postEvent(event);
           expect(postToParent.withArgs(env.sandbox.match({event}))).to.have.been
             .calledOnce;


### PR DESCRIPTION
Fixes #25774.

Host-level component already sets an allow-list:

https://github.com/ampproject/amphtml/blob/083122d905d8b3a8ed53e88ca1ecdac2f5531ed7/extensions/amp-video-iframe/0.1/amp-video-iframe.js#L61-L69

https://github.com/ampproject/amphtml/blob/083122d905d8b3a8ed53e88ca1ecdac2f5531ed7/extensions/amp-video-iframe/0.1/amp-video-iframe.js#L318-L321

Frame-level integration allow-list is redundant (and currently inconsistent, causing #25774)