### PR TITLE
Fix error, remove BaseElement.layoutWidth_

### DIFF
--- a/build-system/externs/amp.multipass.extern.js
+++ b/build-system/externs/amp.multipass.extern.js
@@ -21,9 +21,6 @@
 var SomeBaseElementLikeClass;
 SomeBaseElementLikeClass.prototype.layout_;
 
-/** @type {number} */
-SomeBaseElementLikeClass.prototype.layoutWidth_;
-
 /** @type {boolean} */
 SomeBaseElementLikeClass.prototype.inViewport_;
 

--- a/builtins/amp-img.js
+++ b/builtins/amp-img.js
@@ -214,7 +214,7 @@ export class AmpImg extends BaseElement {
       return;
     }
 
-    const width = this.getLayoutWidth();
+    const width = this.element.getLayoutWidth();
     if (!this.shouldSetSizes_(width)) {
       return;
     }
@@ -269,7 +269,7 @@ export class AmpImg extends BaseElement {
     const img = dev().assertElement(this.img_);
     this.unlistenLoad_ = listen(img, 'load', () => this.hideFallbackImg_());
     this.unlistenError_ = listen(img, 'error', () => this.onImgLoadingError_());
-    if (this.getLayoutWidth() <= 0) {
+    if (this.element.getLayoutWidth() <= 0) {
       return Promise.resolve();
     }
     return this.loadPromise(img);

--- a/extensions/amp-carousel/0.1/scrollable-carousel.js
+++ b/extensions/amp-carousel/0.1/scrollable-carousel.js
@@ -298,7 +298,7 @@ export class AmpScrollableCarousel extends BaseCarousel {
    * @private
    */
   withinWindow_(pos, callback) {
-    const containerWidth = this.getLayoutWidth();
+    const containerWidth = this.element.getLayoutWidth();
     for (let i = 0; i < this.cells_.length; i++) {
       const cell = this.cells_[i];
       if (
@@ -367,8 +367,7 @@ export class AmpScrollableCarousel extends BaseCarousel {
 
   /** @override */
   hasNext() {
-    // TODO(jridgewell): this could be using cached values from Layers.
-    const containerWidth = this.getLayoutWidth();
+    const containerWidth = this.element.getLayoutWidth();
     const scrollWidth = this.container_./*OK*/ scrollWidth;
     const maxPos = Math.max(scrollWidth - containerWidth, 0);
     return this.pos_ != maxPos;

--- a/extensions/amp-carousel/0.1/slidescroll.js
+++ b/extensions/amp-carousel/0.1/slidescroll.js
@@ -302,7 +302,7 @@ export class AmpSlideScroll extends BaseSlides {
 
   /** @override */
   onLayoutMeasure() {
-    this.slideWidth_ = this.getLayoutWidth();
+    this.slideWidth_ = this.element.getLayoutWidth();
   }
 
   /** @override */

--- a/extensions/amp-carousel/0.1/test/test-slidescroll.js
+++ b/extensions/amp-carousel/0.1/test/test-slidescroll.js
@@ -639,8 +639,11 @@ describes.realWin(
 
     it('should handle layout measures (orientation changes)', async () => {
       const ampSlideScroll = await getAmpSlideScroll();
+      const getLayoutWidthStub = env.sandbox.stub(
+        ampSlideScroll,
+        'getLayoutWidth'
+      );
       const impl = ampSlideScroll.implementation_;
-      const getLayoutWidthStub = env.sandbox.stub(impl, 'getLayoutWidth');
 
       getLayoutWidthStub.returns(200);
       impl.onLayoutMeasure();

--- a/extensions/amp-fx-flying-carpet/0.1/amp-fx-flying-carpet.js
+++ b/extensions/amp-fx-flying-carpet/0.1/amp-fx-flying-carpet.js
@@ -157,7 +157,7 @@ export class AmpFlyingCarpet extends AMP.BaseElement {
       this.initialPositionChecked_ = true;
     }
 
-    const width = this.getLayoutWidth();
+    const width = this.element.getLayoutWidth();
     setStyle(this.container_, 'width', width, 'px');
     Services.ownersForDoc(this.element).scheduleLayout(
       this.element,

--- a/extensions/amp-fx-flying-carpet/0.1/test/test-amp-fx-flying-carpet.js
+++ b/extensions/amp-fx-flying-carpet/0.1/test/test-amp-fx-flying-carpet.js
@@ -146,7 +146,7 @@ describes.realWin(
         impl.mutateElement = function(callback) {
           callback();
         };
-        impl.getLayoutWidth = () => width;
+        flyingCarpet.getLayoutWidth = () => width;
 
         impl.layoutCallback();
         expect(container.style.width).to.equal(width + 'px');

--- a/extensions/amp-vk/0.1/test/test-amp-vk.js
+++ b/extensions/amp-vk/0.1/test/test-amp-vk.js
@@ -144,7 +144,7 @@ describes.realWin(
         vkPost.ownerDocument.location.href.replace(/#.*$/, '')
       );
       impl.onLayoutMeasure();
-      const startWidth = impl.getLayoutWidth();
+      const startWidth = vkPost.getLayoutWidth();
       const correctIFrameSrc = `https://vk.com/widget_post.php?app=0&width=100%25&_ver=1&owner_id=1&post_id=45616&hash=Yc8_Z9pnpg8aKMZbVcD-jK45eAk&amp=1&startWidth=${startWidth}&url=${url}&referrer=${referrer}&title=AMP%20Post`;
       expect(iframe).to.not.be.null;
       const timeArgPosition = iframe.src.lastIndexOf('&');

--- a/src/base-element.js
+++ b/src/base-element.js
@@ -136,9 +136,6 @@ export class BaseElement {
     /** @package {!Layout} */
     this.layout_ = Layout.NODISPLAY;
 
-    /** @package {number} */
-    this.layoutWidth_ = -1;
-
     /** @package {boolean} */
     this.inViewport_ = false;
 
@@ -253,17 +250,6 @@ export class BaseElement {
    */
   getVsync() {
     return Services.vsyncFor(this.win);
-  }
-
-  /**
-   * Returns the layout width for this element. A `-1` value indicates that the
-   * layout is not yet known. A `0` value indicates that the element is not
-   * visible.
-   * @return {number}
-   * @public
-   */
-  getLayoutWidth() {
-    return this.layoutWidth_;
   }
 
   /**

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -413,8 +413,8 @@ function createBaseCustomElementClass(win) {
       this.classList.remove('i-amphtml-unresolved');
       this.implementation_.createdCallback();
       this.assertLayout_();
+      // TODO(wg-runtime): Don't set BaseElement ivars externally.
       this.implementation_.layout_ = this.layout_;
-      this.implementation_.layoutWidth_ = this.layoutWidth_;
       this.implementation_.firstAttachedCallback();
       this.dispatchCustomEventForTesting(AmpEvents.ATTACHED);
       this.getResources().upgraded(this);
@@ -464,6 +464,15 @@ function createBaseCustomElementClass(win) {
     getLayoutPriority() {
       devAssert(this.isUpgraded(), 'Cannot get priority of unupgraded element');
       return this.implementation_.getLayoutPriority();
+    }
+
+    /**
+     * TODO(wg-runtime, #25824): Make Resource.getLayoutBox() the source of truth.
+     * @return {number}
+     * @deprecated
+     */
+    getLayoutWidth() {
+      return this.layoutWidth_;
     }
 
     /**
@@ -588,16 +597,12 @@ function createBaseCustomElementClass(win) {
 
     /**
      * Updates the layout box of the element.
-     * See {@link BaseElement.getLayoutWidth} for details.
      * @param {!./layout-rect.LayoutRectDef} layoutBox
      * @param {boolean=} opt_measurementsChanged
      */
     updateLayoutBox(layoutBox, opt_measurementsChanged) {
       this.layoutWidth_ = layoutBox.width;
       this.layoutHeight_ = layoutBox.height;
-      if (this.isUpgraded()) {
-        this.implementation_.layoutWidth_ = this.layoutWidth_;
-      }
       if (this.isBuilt()) {
         try {
           this.implementation_.onLayoutMeasure();

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -1116,7 +1116,7 @@ export class ResourcesImpl {
       return false;
     }
     const parentWidth =
-      (parent.getImpl && parent.getImpl().getLayoutWidth()) || -1;
+      (parent.getLayoutWidth && parent.getLayoutWidth()) || -1;
     // Reflow will not happen if the parent element is at least as wide as the
     // new width.
     return parentWidth >= width;

--- a/test/unit/test-amp-img.js
+++ b/test/unit/test-amp-img.js
@@ -208,9 +208,9 @@ describes.sandboxed('amp-img', {}, env => {
       el.setAttribute('height', 100);
       el.getResources = () => Services.resourcesForDoc(document);
       el.getPlaceholder = sandbox.stub();
+      el.getLayoutWidth = () => 100;
       impl = new AmpImg(el);
       impl.createdCallback();
-      sandbox.stub(impl, 'getLayoutWidth').returns(100);
       el.toggleFallback = function() {};
       el.togglePlaceholder = function() {};
       toggleFallbackSpy = sandbox.spy(el, 'toggleFallback');
@@ -364,6 +364,7 @@ describes.sandboxed('amp-img', {}, env => {
     el.setAttribute('aria-label', 'Hello');
     el.setAttribute('aria-labelledby', 'id2');
     el.setAttribute('aria-describedby', 'id3');
+    el.getLayoutWidth = () => -1;
 
     el.getPlaceholder = sandbox.stub();
     const impl = new AmpImg(el);
@@ -464,10 +465,10 @@ describes.sandboxed('amp-img', {}, env => {
       if (addBlurClass) {
         img.classList.add('i-amphtml-blurry-placeholder');
       }
+      el.getLayoutWidth = () => 200;
       el.appendChild(img);
       el.getResources = () => Services.resourcesForDoc(document);
       const impl = new AmpImg(el);
-      sandbox.stub(impl, 'getLayoutWidth').returns(200);
       impl.togglePlaceholder = sandbox.stub();
       return impl;
     }
@@ -518,9 +519,9 @@ describes.sandboxed('amp-img', {}, env => {
       }
       el.getResources = () => Services.resourcesForDoc(document);
       el.getPlaceholder = sandbox.stub();
+      el.getLayoutWidth = () => layoutWidth;
       const impl = new AmpImg(el);
       impl.createdCallback();
-      sandbox.stub(impl, 'getLayoutWidth').returns(layoutWidth);
       sandbox.stub(impl, 'getLayout').returns(attributes['layout']);
       el.toggleFallback = function() {};
       el.togglePlaceholder = function() {};

--- a/test/unit/test-custom-element.js
+++ b/test/unit/test-custom-element.js
@@ -329,12 +329,10 @@ describes.realWin('CustomElement', {amp: true}, env => {
       it('Element - updateLayoutBox', () => {
         const element = new ElementClass();
         container.appendChild(element);
-        expect(element.layoutWidth_).to.equal(-1);
-        expect(element.implementation_.layoutWidth_).to.equal(-1);
+        expect(element.getLayoutWidth()).to.equal(-1);
 
         element.updateLayoutBox({top: 0, left: 0, width: 111, height: 51});
-        expect(element.layoutWidth_).to.equal(111);
-        expect(element.implementation_.layoutWidth_).to.equal(111);
+        expect(element.getLayoutWidth()).to.equal(111);
       });
 
       it('should tolerate errors in onLayoutMeasure', () => {
@@ -352,8 +350,7 @@ describes.realWin('CustomElement', {amp: true}, env => {
         return element.buildingPromise_.then(() => {
           allowConsoleError(() => {
             element.updateLayoutBox({top: 0, left: 0, width: 111, height: 51});
-            expect(element.layoutWidth_).to.equal(111);
-            expect(element.implementation_.layoutWidth_).to.equal(111);
+            expect(element.getLayoutWidth()).to.equal(111);
             expect(errorStub).to.be.calledWith(AmpEvents.ERROR, 'intentional');
           });
         });
@@ -374,8 +371,7 @@ describes.realWin('CustomElement', {amp: true}, env => {
               {top: 0, left: 0, width: 111, height: 51},
               /* opt_hasMeasurementsChanged */ false
             );
-            expect(element.layoutWidth_).to.equal(111);
-            expect(element.implementation_.layoutWidth_).to.equal(111);
+            expect(element.getLayoutWidth()).to.equal(111);
             expect(onMeasureChangeStub).to.have.not.been.called;
           });
         }
@@ -396,8 +392,7 @@ describes.realWin('CustomElement', {amp: true}, env => {
               {top: 0, left: 0, width: 111, height: 51},
               /* opt_hasMeasurementsChanged */ true
             );
-            expect(element.layoutWidth_).to.equal(111);
-            expect(element.implementation_.layoutWidth_).to.equal(111);
+            expect(element.getLayoutWidth()).to.equal(111);
             expect(onMeasureChangeStub).to.have.been.called;
           });
         }
@@ -421,7 +416,6 @@ describes.realWin('CustomElement', {amp: true}, env => {
         expect(element.isUpgraded()).to.equal(true);
         expect(element.implementation_).to.be.instanceOf(TestElement);
         expect(element.implementation_.layout_).to.equal(Layout.FILL);
-        expect(element.implementation_.layoutWidth_).to.equal(111);
         expect(testElementCreatedCallback).to.be.calledOnce;
         expect(testElementFirstAttachedCallback).to.be.calledOnce;
         expect(element.isBuilt()).to.equal(false);

--- a/test/unit/test-resources.js
+++ b/test/unit/test-resources.js
@@ -2458,7 +2458,7 @@ describe('Resources changeSize', () => {
         'reflow is impossible',
       () => {
         const parent = document.createElement('div');
-        parent.getImpl = () => ({getLayoutWidth: () => 222});
+        parent.getLayoutWidth = () => 222;
         const element = document.createElement('div');
         element.overflowCallback = () => {};
         parent.appendChild(element);


### PR DESCRIPTION
Fixes #24249. 
- Original error from: https://github.com/ampproject/amphtml/pull/23031#discussion_r352895947.

Partial for #25824. 
- custom-element.js already has a `layoutWidth_` with apparently the same semantics.