### PR TITLE
Add geo-based consent to doclevel opt-in

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -1,5 +1,8 @@
 {
-  "allow-doc-opt-in": ["amp-next-page"],
+  "allow-doc-opt-in": [
+    "amp-consent-geo-override",
+    "amp-next-page"
+  ],
   "allow-url-opt-in": [
     "pump-early-frame",
     "twitter-default-placeholder",

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -1,5 +1,8 @@
 {
-  "allow-doc-opt-in": ["amp-next-page"],
+  "allow-doc-opt-in": [
+    "amp-consent-geo-override",
+    "amp-next-page"
+  ],
   "allow-url-opt-in": [
     "pump-early-frame",
     "twitter-default-placeholder",
@@ -38,5 +41,6 @@
   "swg-gpay-api": 0.1,
   "swg-gpay-native": 1,
   "use-responsive-ads-for-responsive-sizing-in-auto-ads": 0.05,
-  "version-locking": 1
+  "version-locking": 1,
+  "amp-consent-geo-override": 1
 }


### PR DESCRIPTION
Since amp-story-consent will be broken by the new workflow, we should add this to doc-level opt-in so it does not break them.