### PR TITLE
🐛Fix amp-carousel 0.2 bound slide change to slide zero.

### DIFF
--- a/extensions/amp-carousel/0.2/amp-carousel.js
+++ b/extensions/amp-carousel/0.2/amp-carousel.js
@@ -222,7 +222,7 @@ class AmpCarousel extends AMP.BaseElement {
 
   /** @override */
   mutatedAttributesCallback(mutations) {
-    if (mutations['slide']) {
+    if (mutations['slide'] !== undefined) {
       this.carousel_.goToSlide(Number(mutations['slide']));
     }
   }


### PR DESCRIPTION
Check if the value is not `undefined` like carousel 0.1, so that `0` works. 

Fixes #25723