### PR TITLE
🐛Avoid fractional scroll position impacting current index.

### DIFF
--- a/extensions/amp-carousel/0.2/amp-carousel.js
+++ b/extensions/amp-carousel/0.2/amp-carousel.js
@@ -479,6 +479,11 @@ class AmpCarousel extends AMP.BaseElement {
     const isSlides = type == CarouselType.SLIDES;
 
     this.type_ = isSlides ? CarouselType.SLIDES : CarouselType.CAROUSEL;
+    // Use center alignment for slides to make sure fractional widths
+    // do not cause the wrong slide to be considered as active. For example,
+    // a slide is positioned at 100.5px, but the updated scroll position is
+    // truncated to 100px.
+    this.carousel_.updateAlignment(isSlides ? 'center' : 'start');
     this.carousel_.updateHideScrollbar(isSlides);
     this.carousel_.updateMixedLength(!isSlides);
     this.carousel_.updateSnap(isSlides);


### PR DESCRIPTION
- Use center alignment for slides in carousel 0.2, avoiding an issue
with fractional scroll positions not being tracked. While fractional
scroll is being fixed in Chrome, it may take longer to land in Safari.

Fixes #25775
