### PR TITLE
Modify restrictions for in-viewport expansion

### DIFF
--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -851,11 +851,12 @@ export class ResourcesImpl {
                 // cause some of them to be pushed down.
                 const parentWidth =
                   (parent.getLayoutWidth && parent.getLayoutWidth()) ||
-                  parent.getBoundingClientRect().width;
+                  parent./*OK*/ getBoundingClientRect().width;
                 let cumulativeWidth = widthDiff;
                 for (let i = 0; i < parent.childElementCount; i++) {
-                  cumulativeWidth += parent.children[i].getBoundingClientRect()
-                    .width;
+                  cumulativeWidth += parent.children[
+                    i
+                  ]./*OK*/ getBoundingClientRect().width;
                   if (cumulativeWidth > parentWidth) {
                     state.resize = false;
                     return;

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -852,12 +852,16 @@ export class ResourcesImpl {
                 const parentWidth =
                   (parent.getLayoutWidth && parent.getLayoutWidth()) ||
                   parent.getBoundingClientRect().width;
-                let cumulativeWidth = request.newWidth;
+                let cumulativeWidth = widthDiff;
                 for (let i = 0; i < parent.childElementCount; i++) {
                   cumulativeWidth += parent.children[i].getBoundingClientRect()
                     .width;
+                  if (cumulativeWidth > parentWidth) {
+                    state.resize = false;
+                    return;
+                  }
                 }
-                state.resize = cumulativeWidth <= parentWidth;
+                state.resize = true;
               },
               mutate: state => {
                 if (state.resize) {

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -841,9 +841,9 @@ export class ResourcesImpl {
           this.vsync_.run(
             {
               measure: state => {
+                state.resize = false;
                 const parent = resource.element.parentElement;
                 if (!parent) {
-                  state.resize = false;
                   return;
                 }
 
@@ -856,7 +856,6 @@ export class ResourcesImpl {
                 for (let i = 0; i < parent.childElementCount; i++) {
                   cumulativeWidth += parent.children[i]./*OK*/ offsetWidth;
                   if (cumulativeWidth > parentWidth) {
-                    state.resize = false;
                     return;
                   }
                 }
@@ -870,6 +869,12 @@ export class ResourcesImpl {
                     newMargins
                   );
                 }
+                request.resource.overflowCallback(
+                  /* overflown */ !state.resize,
+                  request.newHeight,
+                  request.newWidth,
+                  newMargins
+                );
               },
             },
             {}

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -851,12 +851,10 @@ export class ResourcesImpl {
                 // cause some of them to be pushed down.
                 const parentWidth =
                   (parent.getLayoutWidth && parent.getLayoutWidth()) ||
-                  parent./*OK*/ getBoundingClientRect().width;
+                  parent./*OK*/ offsetWidth;
                 let cumulativeWidth = widthDiff;
                 for (let i = 0; i < parent.childElementCount; i++) {
-                  cumulativeWidth += parent.children[
-                    i
-                  ]./*OK*/ getBoundingClientRect().width;
+                  cumulativeWidth += parent.children[i]./*OK*/ offsetWidth;
                   if (cumulativeWidth > parentWidth) {
                     state.resize = false;
                     return;

--- a/test/unit/test-mutator.js
+++ b/test/unit/test-mutator.js
@@ -1227,7 +1227,8 @@ describe('mutator changeSize', () => {
         task.mutate(state);
         expect(resource1.changeSize).to.be.calledOnce;
         expect(resource1.changeSize).to.be.calledWith(50, 222);
-    });
+      }
+    );
 
     it(
       'should NOT change size when resized margin in viewport and should ' +

--- a/test/unit/test-mutator.js
+++ b/test/unit/test-mutator.js
@@ -1138,10 +1138,13 @@ describe('mutator changeSize', () => {
         'reflow is not possible',
       () => {
         const parent = document.createElement('div');
+        parent.style.width = '222px';
         parent.getLayoutWidth = () => 222;
         const element = document.createElement('div');
-        element.overflowCallback = () => {};
+        element.overflowCallback = overflowCallbackSpy;
         parent.appendChild(element);
+        document.body.appendChild(parent);
+
         resource1.element = element;
         resource1.layoutBox_ = {
           top: 0,
@@ -1177,6 +1180,9 @@ describe('mutator changeSize', () => {
         task.mutate(state);
         expect(resource1.changeSize).to.be.calledOnce;
         expect(resource1.changeSize).to.be.calledWith(50, 222);
+        expect(overflowCallbackSpy).to.be.calledOnce;
+        expect(overflowCallbackSpy.firstCall.args[0]).to.equal(false);
+        document.body.removeChild(parent);
       }
     );
 
@@ -1185,13 +1191,17 @@ describe('mutator changeSize', () => {
         'reflow is possible',
       () => {
         const parent = document.createElement('div');
+        parent.style.width = '222px';
         parent.getLayoutWidth = () => 222;
         const element = document.createElement('div');
         const sibling = document.createElement('div');
         sibling.style.width = '1px';
-        element.overflowCallback = () => {};
+        sibling.id = 'sibling';
+        element.overflowCallback = overflowCallbackSpy;
         parent.appendChild(element);
         parent.appendChild(sibling);
+        document.body.appendChild(parent);
+
         resource1.element = element;
         resource1.layoutBox_ = {
           top: 0,
@@ -1225,8 +1235,10 @@ describe('mutator changeSize', () => {
         const state = {};
         task.measure(state);
         task.mutate(state);
-        expect(resource1.changeSize).to.be.calledOnce;
-        expect(resource1.changeSize).to.be.calledWith(50, 222);
+        expect(resource1.changeSize).to.not.be.called;
+        expect(overflowCallbackSpy).to.be.calledOnce;
+        expect(overflowCallbackSpy.firstCall.args[0]).to.equal(true);
+        document.body.removeChild(parent);
       }
     );
 


### PR DESCRIPTION
Flexible ad slot expansion was [launched](https://github.com/ampproject/amphtml/pull/23931) earlier this year in August. The new behavior enables large creatives to be rendered within smaller ad slots, necessarily requiring the runtime to expand the slot element at render-time. As preparation for the launch, we made a slight [change](https://github.com/ampproject/amphtml/pull/23031) to AMP’s no-reflow policy, to allow in-viewport expansion if the following criteria hold:

- Width-only expansion,
- Element has no siblings,
- Parent element is an AMP element,
- Parent element's width is >= the new element width

These conditions, however, are too restrictive to allow in-viewport expansion in many cases, resulting in cropped ad slots that load within the viewport. This PR will modify the criteria for in-viewport expansion to the following:

- Width-only expansion
- Cumulative width of all sibling elements and new width is < parent width

This should result in many fewer cropped ad slots, without introducing any risk of reflow.
