### PR TITLE
Fix single page story prerendering.

### DIFF
--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -981,7 +981,10 @@ export class AmpStory extends AMP.BaseElement {
     this.initializeSidebar_();
     this.setThemeColor_();
 
-    const storyLayoutPromise = this.initializePages_()
+    const storyLayoutPromise = Promise.all([
+      this.getAmpDoc().whenFirstVisible(), // Pauses execution during prerender.
+      this.initializePages_(),
+    ])
       .then(() => {
         this.handleConsentExtension_();
         this.initializeStoryAccess_();


### PR DESCRIPTION
During prerendering, we only build/layout the first story page. `this.initializePages_()` will stay pending until all pages are built, preventing a lot of code (access, branching, bookend, ...) from being executing until the story `visibilityState` gets to `visible`.

But when the story only has one page, this one being built, `this.initializePages_()` will resolve and run a lot of code consuming precious CPU cycles too soon, as well as messing up the UI (the only page is hidden).

This is a no-op in all stories but the single page ones.

Fixes https://github.com/ampproject/amphtml/issues/25872