### PR TITLE
🐛Make amp-carousel 0.1 focusable

### DIFF
--- a/extensions/amp-carousel/0.1/scrollable-carousel.js
+++ b/extensions/amp-carousel/0.1/scrollable-carousel.js
@@ -59,6 +59,8 @@ export class AmpScrollableCarousel extends BaseCarousel {
 
     this.container_ = this.element.ownerDocument.createElement('div');
     this.container_.classList.add('i-amphtml-scrollable-carousel-container');
+    // Focusable container makes it possible to fully consume Arrow key events.
+    this.container_.setAttribute('tabindex', '0');
     this.element.appendChild(this.container_);
 
     this.cells_.forEach(cell => {

--- a/extensions/amp-carousel/0.1/scrollable-carousel.js
+++ b/extensions/amp-carousel/0.1/scrollable-carousel.js
@@ -60,7 +60,7 @@ export class AmpScrollableCarousel extends BaseCarousel {
     this.container_ = this.element.ownerDocument.createElement('div');
     this.container_.classList.add('i-amphtml-scrollable-carousel-container');
     // Focusable container makes it possible to fully consume Arrow key events.
-    this.container_.setAttribute('tabindex', '0');
+    this.container_.setAttribute('tabindex', '-1');
     this.element.appendChild(this.container_);
 
     this.cells_.forEach(cell => {

--- a/extensions/amp-carousel/0.1/slidescroll.js
+++ b/extensions/amp-carousel/0.1/slidescroll.js
@@ -163,7 +163,7 @@ export class AmpSlideScroll extends BaseSlides {
 
     this.slidesContainer_ = this.win.document.createElement('div');
     // Focusable container makes it possible to fully consume Arrow key events.
-    this.slidesContainer_.setAttribute('tabindex', '0');
+    this.slidesContainer_.setAttribute('tabindex', '-1');
     this.slidesContainer_.classList.add('i-amphtml-slides-container');
     // Let screen reader know that this is a live area and changes
     // to it (such after pressing next) should be announced to the

--- a/extensions/amp-carousel/0.1/slidescroll.js
+++ b/extensions/amp-carousel/0.1/slidescroll.js
@@ -162,6 +162,8 @@ export class AmpSlideScroll extends BaseSlides {
     this.noOfSlides_ = this.slides_.length;
 
     this.slidesContainer_ = this.win.document.createElement('div');
+    // Focusable container makes it possible to fully consume Arrow key events.
+    this.slidesContainer_.setAttribute('tabindex', '0');
     this.slidesContainer_.classList.add('i-amphtml-slides-container');
     // Let screen reader know that this is a live area and changes
     // to it (such after pressing next) should be announced to the


### PR DESCRIPTION
Having a focusable carousel container makes it possible to escape Arrow keys. This is a follow up change to #25405. cc/ @zhangsu 