### PR TITLE
🏗 Provide validation for LTS runtime and extensions

### DIFF
--- a/validator/testdata/amp4email_feature_tests/nonce_disallowed.out
+++ b/validator/testdata/amp4email_feature_tests/nonce_disallowed.out
@@ -26,7 +26,7 @@ FAIL
 |    <style amp4email-boilerplate>body{visibility:hidden}</style>
 |    <script async src="https://cdn.ampproject.org/v0.js" nonce="disallowed"></script>
 >>   ^~~~~~~~~
-amp4email_feature_tests/nonce_disallowed.html:26:2 The attribute 'nonce' may not appear in tag 'amphtml engine v0.js script'. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#required-markup)
+amp4email_feature_tests/nonce_disallowed.html:26:2 The attribute 'nonce' may not appear in tag 'amphtml engine v0.js script [AMP4EMAIL,ACTIONS]'. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#required-markup)
 |  </head>
 |  <body>
 |  Hello, world.

--- a/validator/testdata/feature_tests/empty.out
+++ b/validator/testdata/feature_tests/empty.out
@@ -19,6 +19,6 @@ feature_tests/empty.html:1:0 The mandatory tag 'noscript > style[amp-boilerplate
 >> ^~~~~~~~~
 feature_tests/empty.html:1:0 The mandatory tag 'body' is missing or incorrect. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#required-markup)
 >> ^~~~~~~~~
-feature_tests/empty.html:1:0 The mandatory tag 'amphtml engine v0.js script' is missing or incorrect. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#required-markup)
->> ^~~~~~~~~
 feature_tests/empty.html:1:0 The mandatory tag 'noscript enclosure for boilerplate' is missing or incorrect. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amp-boilerplate?format=websites)
+>> ^~~~~~~~~
+feature_tests/empty.html:1:0 The mandatory tag 'amphtml engine v0.js script' is missing or incorrect. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#required-markup)

--- a/validator/testdata/feature_tests/lts_extension_without_lts_runtime.html
+++ b/validator/testdata/feature_tests/lts_extension_without_lts_runtime.html
@@ -1,0 +1,49 @@
+<!--
+  Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS-IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the license.
+-->
+<!--
+  Test Description:
+
+  This test demonstrates an error message selected via dispatch_key rules.
+
+  The <script> tag in the body is invalid only in it's location in the document.
+  Other forms of <script> tags are allowed in the body, but not the runtime tag.
+  We want to verify that the error message generated suggests a different
+  parent, not different attribute values.
+-->
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <link rel="canonical" href="./regular-html-version.html">
+  <meta name="viewport" content="width=device-width,minimum-scale=1">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <!-- LTS extension is included. Produces error. -->
+  <script async custom-element='amp-ad'
+     src='https://cdn.ampproject.org/lts/v0/amp-ad-0.1.js'></script>
+  <!-- Non-LTS extension is included and used. No error or warning. -->
+  <script async custom-element='amp-font'
+     src='https://cdn.ampproject.org/v0/amp-font-0.1.js'></script>
+</head>
+<body>
+  <amp-font
+    layout="nodisplay"
+    font-family="Comic Amp"
+    timeout="3000">
+  </amp-font>
+</body>
+</html>

--- a/validator/testdata/feature_tests/lts_extension_without_lts_runtime.out
+++ b/validator/testdata/feature_tests/lts_extension_without_lts_runtime.out
@@ -1,0 +1,52 @@
+FAIL
+|  <!--
+|    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+|
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|
+|        http://www.apache.org/licenses/LICENSE-2.0
+|
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|
+|    This test demonstrates an error message selected via dispatch_key rules.
+|
+|    The <script> tag in the body is invalid only in it's location in the document.
+|    Other forms of <script> tags are allowed in the body, but not the runtime tag.
+|    We want to verify that the error message generated suggests a different
+|    parent, not different attribute values.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    <!-- LTS extension is included. Produces error. -->
+|    <script async custom-element='amp-ad'
+>>   ^~~~~~~~~
+feature_tests/lts_extension_without_lts_runtime.html:36:2 Extension 'amp-ad' may not use LTS with non-LTS runtime. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#required-markup)
+|       src='https://cdn.ampproject.org/lts/v0/amp-ad-0.1.js'></script>
+|    <!-- Non-LTS extension is included and used. No error or warning. -->
+|    <script async custom-element='amp-font'
+|       src='https://cdn.ampproject.org/v0/amp-font-0.1.js'></script>
+|  </head>
+|  <body>
+|    <amp-font
+|      layout="nodisplay"
+|      font-family="Comic Amp"
+|      timeout="3000">
+|    </amp-font>
+|  </body>
+|  </html>

--- a/validator/testdata/feature_tests/lts_runtime_and_extensions.html
+++ b/validator/testdata/feature_tests/lts_runtime_and_extensions.html
@@ -1,0 +1,49 @@
+<!--
+  Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS-IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the license.
+-->
+<!--
+  Test Description:
+
+  This test demonstrates an error message selected via dispatch_key rules.
+
+  The <script> tag in the body is invalid only in it's location in the document.
+  Other forms of <script> tags are allowed in the body, but not the runtime tag.
+  We want to verify that the error message generated suggests a different
+  parent, not different attribute values.
+-->
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <link rel="canonical" href="./regular-html-version.html">
+  <meta name="viewport" content="width=device-width,minimum-scale=1">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+
+  <script async src="https://cdn.ampproject.org/lts/v0.js"></script>
+  <!-- Non-LTS extension is included. Produces error. -->
+  <script async custom-element='amp-ad'
+     src='https://cdn.ampproject.org/v0/amp-ad-0.1.js'></script>
+  <!-- LTS extension is included and used. No error or warning. -->
+  <script async custom-element='amp-font'
+     src='https://cdn.ampproject.org/lts/v0/amp-font-0.1.js'></script>
+</head>
+<body>
+  <amp-font
+    layout="nodisplay"
+    font-family="Comic Amp"
+    timeout="3000">
+  </amp-font>
+</body>
+</html>

--- a/validator/testdata/feature_tests/lts_runtime_and_extensions.out
+++ b/validator/testdata/feature_tests/lts_runtime_and_extensions.out
@@ -1,0 +1,52 @@
+FAIL
+|  <!--
+|    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+|
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|
+|        http://www.apache.org/licenses/LICENSE-2.0
+|
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|
+|    This test demonstrates an error message selected via dispatch_key rules.
+|
+|    The <script> tag in the body is invalid only in it's location in the document.
+|    Other forms of <script> tags are allowed in the body, but not the runtime tag.
+|    We want to verify that the error message generated suggests a different
+|    parent, not different attribute values.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|
+|    <script async src="https://cdn.ampproject.org/lts/v0.js"></script>
+|    <!-- Non-LTS extension is included. Produces error. -->
+|    <script async custom-element='amp-ad'
+>>   ^~~~~~~~~
+feature_tests/lts_runtime_and_extensions.html:36:2 Extension 'amp-ad' must use LTS to match LTS runtime. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#required-markup)
+|       src='https://cdn.ampproject.org/v0/amp-ad-0.1.js'></script>
+|    <!-- LTS extension is included and used. No error or warning. -->
+|    <script async custom-element='amp-font'
+|       src='https://cdn.ampproject.org/lts/v0/amp-font-0.1.js'></script>
+|  </head>
+|  <body>
+|    <amp-font
+|      layout="nodisplay"
+|      font-family="Comic Amp"
+|      timeout="3000">
+|    </amp-font>
+|  </body>
+|  </html>

--- a/validator/testdata/feature_tests/multiple_body_tags_3.out
+++ b/validator/testdata/feature_tests/multiple_body_tags_3.out
@@ -42,7 +42,7 @@ feature_tests/multiple_body_tags_3.html:33:2 The parent tag of tag 'style amp-cu
 feature_tests/multiple_body_tags_3.html:33:641 The tag 'noscript > style[amp-boilerplate]' may only appear as a descendant of tag 'head'. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amp-boilerplate?format=websites)
 |    <script async src="https://cdn.ampproject.org/v0.js"></script>
 >>   ^~~~~~~~~
-feature_tests/multiple_body_tags_3.html:34:2 The parent tag of tag 'amphtml engine v0.js script' is 'body', but it can only be 'head'. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#required-markup)
+feature_tests/multiple_body_tags_3.html:34:2 The parent tag of tag 'amphtml engine v0.js script [AMP]' is 'body', but it can only be 'head'. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#required-markup)
 |  </head>
 |  <body class="foo">
 |    <!-- You might think there's only one body in this doc, but this is

--- a/validator/testdata/feature_tests/not_amp.out
+++ b/validator/testdata/feature_tests/not_amp.out
@@ -38,6 +38,6 @@ feature_tests/not_amp.html:28:6 The mandatory tag 'head > style[amp-boilerplate]
 >>       ^~~~~~~~~
 feature_tests/not_amp.html:28:6 The mandatory tag 'noscript > style[amp-boilerplate]' is missing or incorrect. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amp-boilerplate?format=websites)
 >>       ^~~~~~~~~
-feature_tests/not_amp.html:28:6 The mandatory tag 'amphtml engine v0.js script' is missing or incorrect. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#required-markup)
->>       ^~~~~~~~~
 feature_tests/not_amp.html:28:6 The mandatory tag 'noscript enclosure for boilerplate' is missing or incorrect. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amp-boilerplate?format=websites)
+>>       ^~~~~~~~~
+feature_tests/not_amp.html:28:6 The mandatory tag 'amphtml engine v0.js script' is missing or incorrect. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#required-markup)

--- a/validator/testdata/feature_tests/runtime_in_body.out
+++ b/validator/testdata/feature_tests/runtime_in_body.out
@@ -40,7 +40,7 @@ FAIL
 |
 |    <script async src="https://cdn.ampproject.org/v0.js"></script>
 >>   ^~~~~~~~~
-feature_tests/runtime_in_body.html:40:2 The parent tag of tag 'amphtml engine v0.js script' is 'body', but it can only be 'head'. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#required-markup)
+feature_tests/runtime_in_body.html:40:2 The parent tag of tag 'amphtml engine v0.js script [AMP]' is 'body', but it can only be 'head'. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#required-markup)
 |
 |  </body>
 |  </html>

--- a/validator/testdata/feature_tests/several_errors.out
+++ b/validator/testdata/feature_tests/several_errors.out
@@ -57,6 +57,6 @@ feature_tests/several_errors.html:40:2 The attribute 'height' in tag 'amp-ad' is
 >>       ^~~~~~~~~
 feature_tests/several_errors.html:43:6 The mandatory tag 'meta name=viewport' is missing or incorrect. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#required-markup)
 >>       ^~~~~~~~~
-feature_tests/several_errors.html:43:6 The mandatory tag 'amphtml engine v0.js script' is missing or incorrect. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#required-markup)
->>       ^~~~~~~~~
 feature_tests/several_errors.html:43:6 The tag 'amp-ad extension .js script' is missing or incorrect, but required by 'amp-ad'. This will soon be an error. (see https://amp.dev/documentation/components/amp-ad)
+>>       ^~~~~~~~~
+feature_tests/several_errors.html:43:6 The mandatory tag 'amphtml engine v0.js script' is missing or incorrect. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#required-markup)

--- a/validator/testdata/feature_tests/unprintable_chars.out
+++ b/validator/testdata/feature_tests/unprintable_chars.out
@@ -54,7 +54,7 @@ feature_tests/unprintable_chars.html:35:2 The parent tag of tag 'style amp-custo
 feature_tests/unprintable_chars.html:35:641 The tag 'noscript > style[amp-boilerplate]' may only appear as a descendant of tag 'head'. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amp-boilerplate?format=websites)
 |    <script async src="https://cdn.ampproject.org/v0.js"></script>
 >>   ^~~~~~~~~
-feature_tests/unprintable_chars.html:36:2 The parent tag of tag 'amphtml engine v0.js script' is 'body', but it can only be 'head'. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#required-markup)
+feature_tests/unprintable_chars.html:36:2 The parent tag of tag 'amphtml engine v0.js script [AMP]' is 'body', but it can only be 'head'. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#required-markup)
 |  </head>
 |  <body data-foo>
 |  Hello, world.

--- a/validator/testdata/transformed_feature_tests/nonce_attribute_error.out
+++ b/validator/testdata/transformed_feature_tests/nonce_attribute_error.out
@@ -26,7 +26,7 @@ FAIL
 |    <meta name="viewport" content="width=device-width">
 |    <script async nonce src="https://cdn.ampproject.org/v0.js"></script>
 >>   ^~~~~~~~~
-transformed_feature_tests/nonce_attribute_error.html:26:2 The attribute 'nonce' may not appear in tag 'amphtml engine v0.js script'. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#required-markup)
+transformed_feature_tests/nonce_attribute_error.html:26:2 The attribute 'nonce' may not appear in tag 'amphtml engine v0.js script [AMP]'. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#required-markup)
 |    <script async custom-element="amp-bind" nonce src="https://cdn.ampproject.org/v0/amp-bind-0.1.js"></script>
 >>   ^~~~~~~~~
 transformed_feature_tests/nonce_attribute_error.html:27:2 The attribute 'nonce' may not appear in tag 'amp-bind extension .js script'. (see https://amp.dev/documentation/components/amp-bind)

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -4924,6 +4924,41 @@ tags: {
   spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#required-markup"
 }
 tags: {
+  html_format: AMP
+  tag_name: "SCRIPT"
+  spec_name: "amphtml engine v0.js script [AMP LTS]"
+  mandatory_alternatives: "amphtml engine v0.js script"
+  unique: true
+  mandatory_parent: "HEAD"
+  attr_lists: "nonce-attr"
+  attrs: {
+    name: "async"
+    mandatory: true
+    value: ""
+  }
+  attrs: {
+    name: "crossorigin"
+    value: "anonymous"
+  }
+  attrs: {
+    name: "src"
+    mandatory: true
+    value: "https://cdn.ampproject.org/lts/v0.js"
+    dispatch_key: NAME_VALUE_DISPATCH
+  }
+  attrs: {
+    name: "type"
+    value_casei: "text/javascript"
+  }
+  cdata: {
+    blacklisted_cdata_regex: {
+      regex: "."
+      error_message: "contents"
+    }
+  }
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#required-markup"
+}
+tags: {
   html_format: AMP4ADS
   tag_name: "SCRIPT"
   spec_name: "amp4ads engine amp4ads-v0.js script"

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -4853,12 +4853,46 @@ tags: {
 # Note that the type TEXT/PLAIN description is define in
 # validator-amp-mustache.protoascii.
 tags: {
-  html_format: AMP
   html_format: AMP4EMAIL
   html_format: ACTIONS
   tag_name: "SCRIPT"
-  spec_name: "amphtml engine v0.js script"
-  mandatory: true
+  spec_name: "amphtml engine v0.js script [AMP4EMAIL,ACTIONS]"
+  mandatory_alternatives: "amphtml engine v0.js script"
+  unique: true
+  mandatory_parent: "HEAD"
+  attr_lists: "nonce-attr"
+  attrs: {
+    name: "async"
+    mandatory: true
+    value: ""
+  }
+  attrs: {
+    name: "crossorigin"
+    value: "anonymous"
+  }
+  attrs: {
+    name: "src"
+    mandatory: true
+    value: "https://cdn.ampproject.org/v0.js"
+    dispatch_key: NAME_VALUE_DISPATCH
+  }
+  attrs: {
+    name: "type"
+    value_casei: "text/javascript"
+  }
+  cdata: {
+    blacklisted_cdata_regex: {
+      regex: "."
+      error_message: "contents"
+    }
+  }
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#required-markup"
+}
+tags: {
+  html_format: AMP
+  tag_name: "SCRIPT"
+  spec_name: "amphtml engine v0.js script [AMP]"
+  mandatory_alternatives: "amphtml engine v0.js script"
   unique: true
   mandatory_parent: "HEAD"
   attr_lists: "nonce-attr"

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -6937,62 +6937,64 @@ error_specificity {
   code: BASE_TAG_MUST_PRECEED_ALL_URLS
   specificity: 83
 }
-error_specificity { code: DISALLOWED_SCRIPT_TAG specificity: 100 }
-error_specificity { code: GENERAL_DISALLOWED_TAG specificity: 101 }
-error_specificity { code: DEPRECATED_ATTR specificity: 102 }
-error_specificity { code: DEPRECATED_TAG specificity: 103 }
-error_specificity { code: DISALLOWED_MANUFACTURED_BODY specificity: 104 }
-error_specificity { code: DOCUMENT_TOO_COMPLEX specificity: 105 }
-error_specificity { code: INCORRECT_MIN_NUM_CHILD_TAGS specificity: 106 }
-error_specificity { code: TAG_NOT_ALLOWED_TO_HAVE_SIBLINGS specificity: 107 }
-error_specificity { code: MANDATORY_LAST_CHILD_TAG specificity: 108 }
+error_specificity { code: LTS_EXTENSION_ONLY specificity: 100 }
+error_specificity { code: LTS_RUNTIME_ONLY specificity: 101 }
+error_specificity { code: DISALLOWED_SCRIPT_TAG specificity: 102 }
+error_specificity { code: GENERAL_DISALLOWED_TAG specificity: 103 }
+error_specificity { code: DEPRECATED_ATTR specificity: 104 }
+error_specificity { code: DEPRECATED_TAG specificity: 105 }
+error_specificity { code: DISALLOWED_MANUFACTURED_BODY specificity: 106 }
+error_specificity { code: DOCUMENT_TOO_COMPLEX specificity: 107 }
+error_specificity { code: INCORRECT_MIN_NUM_CHILD_TAGS specificity: 108 }
+error_specificity { code: TAG_NOT_ALLOWED_TO_HAVE_SIBLINGS specificity: 109 }
+error_specificity { code: MANDATORY_LAST_CHILD_TAG specificity: 110 }
 error_specificity {
   code: CSS_SYNTAX_INVALID_PROPERTY
-  specificity: 109
-}
-error_specificity {
-  code: CSS_SYNTAX_INVALID_PROPERTY_NOLIST
-  specificity: 110
-}
-error_specificity {
-  code: CSS_SYNTAX_QUALIFIED_RULE_HAS_NO_DECLARATIONS
   specificity: 111
 }
 error_specificity {
-  code: CSS_SYNTAX_DISALLOWED_QUALIFIED_RULE_MUST_BE_INSIDE_KEYFRAME
+  code: CSS_SYNTAX_INVALID_PROPERTY_NOLIST
   specificity: 112
 }
 error_specificity {
-  code: CSS_SYNTAX_DISALLOWED_KEYFRAME_INSIDE_KEYFRAME
+  code: CSS_SYNTAX_QUALIFIED_RULE_HAS_NO_DECLARATIONS
   specificity: 113
 }
 error_specificity {
-  code: CSS_SYNTAX_MALFORMED_MEDIA_QUERY
+  code: CSS_SYNTAX_DISALLOWED_QUALIFIED_RULE_MUST_BE_INSIDE_KEYFRAME
+  specificity: 114
+}
+error_specificity {
+  code: CSS_SYNTAX_DISALLOWED_KEYFRAME_INSIDE_KEYFRAME
   specificity: 115
 }
 error_specificity {
-  code: CSS_SYNTAX_DISALLOWED_MEDIA_TYPE
-  specificity: 116
-}
-error_specificity {
-  code: CSS_SYNTAX_DISALLOWED_MEDIA_FEATURE
+  code: CSS_SYNTAX_MALFORMED_MEDIA_QUERY
   specificity: 117
 }
 error_specificity {
-  code: INVALID_UTF8
+  code: CSS_SYNTAX_DISALLOWED_MEDIA_TYPE
   specificity: 118
 }
 error_specificity {
-  code: CSS_EXCESSIVELY_NESTED
+  code: CSS_SYNTAX_DISALLOWED_MEDIA_FEATURE
   specificity: 119
 }
 error_specificity {
-  code: DOCUMENT_SIZE_LIMIT_EXCEEDED
+  code: INVALID_UTF8
   specificity: 120
 }
 error_specificity {
-  code: VALUE_SET_MISMATCH
+  code: CSS_EXCESSIVELY_NESTED
   specificity: 121
+}
+error_specificity {
+  code: DOCUMENT_SIZE_LIMIT_EXCEEDED
+  specificity: 122
+}
+error_specificity {
+  code: VALUE_SET_MISMATCH
+  specificity: 123
 }
 error_specificity {
   code: DEV_MODE_ONLY
@@ -7053,6 +7055,14 @@ error_formats {
 error_formats {
   code: GENERAL_DISALLOWED_TAG
   format: "The tag '%1' is disallowed except in specific forms."
+}
+error_formats {
+  code: LTS_RUNTIME_ONLY
+  format: "Extension '%1' must use LTS to match LTS runtime."
+}
+error_formats {
+  code: LTS_EXTENSION_ONLY
+  format: "Extension '%1' may not use LTS with non-LTS runtime."
 }
 error_formats {
   code: DISALLOWED_SCRIPT_TAG

--- a/validator/validator.proto
+++ b/validator/validator.proto
@@ -712,7 +712,7 @@ message ValidationError {
     // DO NOT REASSIGN the previously used values 2, 3.
   }
   optional Severity severity = 6 [default = ERROR];
-  // NEXT AVAILABLE TAG: 111
+  // NEXT AVAILABLE TAG: 113
   enum Code {
     UNKNOWN_CODE = 0;
     MANDATORY_TAG_MISSING = 1;
@@ -729,6 +729,8 @@ message ValidationError {
     DISALLOWED_ATTR = 3;
     DISALLOWED_STYLE_ATTR = 81;
     INVALID_ATTR_VALUE = 4;
+    LTS_RUNTIME_ONLY = 111;
+    LTS_EXTENSION_ONLY = 112;
     DUPLICATE_ATTRIBUTE = 94;
     ATTR_VALUE_REQUIRED_BY_LAYOUT = 27;
     MISSING_LAYOUT_ATTRIBUTES = 105;


### PR DESCRIPTION
This PR updates the validator to handle `script` tags referencing the runtime or extensions using the [LTS release](https://github.com/ampproject/amphtml/issues/25578). With this change, `AMP` pages (not `AMP4EMAIL` or `ACTIONS`) are allowed to use `/lts/v0.js` for the runtime and `/lts/v0/amp-*.js` for extensions. If an extension uses LTS but the runtime does not (or the reverse), the validator will report an error indicating the mismatch. Accompanying tests include both of those cases.

This may be easiest to review commit-by-commit rather than all file changes together.