### PR TITLE
🐛 Fix binary type map in a4a

### DIFF
--- a/ads/google/a4a/test/test-utils.js
+++ b/ads/google/a4a/test/test-utils.js
@@ -257,10 +257,10 @@ describe('Google A4A utils', () => {
   });
 
   describe('#getAmpRuntimeTypeParameter', () => {
-    it('should specify that this is canary', () => {
+    it('should specify that this is experimental', () => {
       expect(
         getAmpRuntimeTypeParameter({
-          AMP_CONFIG: {type: 'canary'},
+          AMP_CONFIG: {type: 'experimental'},
           location: {origin: 'https://www-example-com.cdn.ampproject.org'},
         })
       ).to.equal('2');
@@ -299,7 +299,7 @@ describe('Google A4A utils', () => {
     it('should not have `art` parameter when canonical', () => {
       expect(
         getAmpRuntimeTypeParameter({
-          AMP_CONFIG: {type: 'canary'},
+          AMP_CONFIG: {type: 'experimental'},
           location: {origin: 'https://www.example.com'},
         })
       ).to.be.null;

--- a/ads/google/a4a/utils.js
+++ b/ads/google/a4a/utils.js
@@ -830,7 +830,7 @@ export function getBinaryTypeNumericalCode(type) {
     {
       'production': '0',
       'control': '1',
-      'canary': '2',
+      'experimental': '2',
       'rc': '3',
       'experimentA': '10',
       'experimentB': '11',

--- a/test/unit/test-error.js
+++ b/test/unit/test-error.js
@@ -460,7 +460,7 @@ describe('getErrorReportData', () => {
 
   it('reportError marks binary type', () => {
     window.AMP_CONFIG = {
-      type: 'canary',
+      type: 'experimental',
     };
     const e = new Error('XYZ');
     const data = getErrorReportData(
@@ -471,7 +471,7 @@ describe('getErrorReportData', () => {
       e
     );
     expect(data.m).to.equal('XYZ');
-    expect(data['bt']).to.equal('canary');
+    expect(data['bt']).to.equal('experimental');
 
     window.AMP_CONFIG = {
       type: 'control',

--- a/test/unit/test-experiments.js
+++ b/test/unit/test-experiments.js
@@ -548,8 +548,8 @@ describe('getBinaryType', () => {
       },
     };
     expect(getBinaryType(win)).to.equal('production');
-    win.AMP_CONFIG.type = 'canary';
-    expect(getBinaryType(win)).to.equal('canary');
+    win.AMP_CONFIG.type = 'experimental';
+    expect(getBinaryType(win)).to.equal('experimental');
     win.AMP_CONFIG.type = 'control';
     expect(getBinaryType(win)).to.equal('control');
     win.AMP_CONFIG.type = 'rc';


### PR DESCRIPTION
Recent updates in release scripts as a part of https://github.com/ampproject/amphtml/issues/25560 changed the release name in `AMP_CONFIG.type` from `canary` to `experimental`. There is one location in `amphtml` which uses this release name to determine the binary type RTV prefix code, which was not updated.

This PR updates two tests which referenced `canary` (one of which, `utils-test.js`, failed with this update). It then updates the `utils.js` code in A4A which references the old release name.