### PR TITLE
Allow multi-size expansion if appropriate attribute is set. (WIP)

### DIFF
--- a/ads/google/utils.js
+++ b/ads/google/utils.js
@@ -58,6 +58,7 @@ export function getMultiSizeDimensions(
   primaryWidth,
   primaryHeight,
   multiSizeValidation,
+  allowExpansion,
   isFluidPrimary = false
 ) {
   const dimensions = [];
@@ -104,6 +105,7 @@ export function getMultiSizeDimensions(
     // Check that secondary size is not larger than primary size.
     if (
       !isFluidPrimary &&
+      !allowExpansion &&
       !validateDimensions(
         width,
         height,

--- a/ads/yieldbot.js
+++ b/ads/yieldbot.js
@@ -40,7 +40,8 @@ export function yieldbot(global, data) {
             multiSizeDataStr,
             primaryWidth,
             primaryHeight,
-            false
+            false /* multiSizeValidation */,
+            false /* allowExpansion */
           );
           dimensions.unshift([primaryWidth, primaryHeight]);
         } else {

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -932,6 +932,8 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
     if (multiSizeDataStr) {
       const multiSizeValidation =
         this.element.getAttribute('data-multi-size-validation') || 'true';
+      const allowExpansion =
+        this.element.getAttribute('data-multi-size-allow-expansion') == 'true';
       // The following call will check all specified multi-size dimensions,
       // verify that they meet all requirements, and then return all the valid
       // dimensions in an array.
@@ -940,6 +942,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
         this.initialSize_.width,
         this.initialSize_.height,
         multiSizeValidation == 'true',
+        allowExpansion,
         this.isFluidPrimaryRequest_
       );
       if (dimensions.length) {

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -1345,6 +1345,43 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
       });
     });
 
+    it('should default to not allowing expansion', () => {
+      stubForAmpCreative();
+      env.sandbox
+        .stub(impl, 'sendXhrRequest')
+        .callsFake(() => mockSendXhrRequest(undefined, true));
+      impl.element.setAttribute('data-multi-size', '300x50');
+      // Stub ini load otherwise FIE could delay test
+      env.sandbox
+        ./*OK*/ stub(FriendlyIframeEmbed.prototype, 'whenIniLoaded')
+        .returns(Promise.resolve());
+      impl.buildCallback();
+      impl.onLayoutMeasure();
+      return impl.layoutCallback().then(() => {
+        expect(impl.adUrl_).to.be.ok;
+        expect(impl.adUrl_).to.not.match(/300x50/);
+      });
+    });
+
+    it('should allow expansion if attribute set', () => {
+      stubForAmpCreative();
+      env.sandbox
+        .stub(impl, 'sendXhrRequest')
+        .callsFake(() => mockSendXhrRequest(undefined, true));
+      impl.element.setAttribute('data-multi-size', '300x50');
+      impl.element.setAttribute('data-multi-size-allow-expansion', 'true');
+      // Stub ini load otherwise FIE could delay test
+      env.sandbox
+        ./*OK*/ stub(FriendlyIframeEmbed.prototype, 'whenIniLoaded')
+        .returns(Promise.resolve());
+      impl.buildCallback();
+      impl.onLayoutMeasure();
+      return impl.layoutCallback().then(() => {
+        expect(impl.adUrl_).to.be.ok;
+        expect(impl.adUrl_).to.match(/300x50/);
+      });
+    });
+
     it('should attempt resize for fluid request + fixed response case', () => {
       impl.isFluidRequest_ = true;
       impl.handleResize_(150, 50);


### PR DESCRIPTION
Currently, multi-size slots cannot expand, but can only shrink. In fact, all sizes listed in the multi-size attribute that have a larger dimension than the primary size are filtered out and never requested.

This is somewhat more complicated, because if the primary size is fluid, then ANY size is allowed in the multi-size attribute, thus providing a hacky way around this constraint. Some publishers have been using fluid for this purpose, but this has negative effects on viewability when the slot is loaded within the viewport. To remove this detriment, this PR provides a way to allow multi-size to expand as well as contract. 