### PR TITLE
Inject transport iframe to top window

### DIFF
--- a/extensions/amp-analytics/0.1/amp-analytics.js
+++ b/extensions/amp-analytics/0.1/amp-analytics.js
@@ -175,10 +175,7 @@ export class AmpAnalytics extends AMP.BaseElement {
   resumeCallback() {
     if (this.iniPromise_) {
       this.iniPromise_.then(() => {
-        this.transport_.maybeInitIframeTransport(
-          this.getAmpDoc().win,
-          this.element
-        );
+        this.transport_.maybeInitIframeTransport(this.element);
       });
     }
   }
@@ -294,16 +291,7 @@ export class AmpAnalytics extends AMP.BaseElement {
       this.element
     );
 
-    this.transport_.maybeInitIframeTransport(
-      // In the case of FIE rendering, we should be using the parent doc win.
-      // Currently, getAmpDoc returns the parent doc for FIE elements.
-      // This behavior will be changed by ampdoc-fie launch.
-      // TODO: this will be a blocker to launch ampdoc-fie.
-      // We should find a different way to get the parent win in case of FIE.
-      this.getAmpDoc().win,
-      this.element,
-      Services.preconnectFor(this.win)
-    );
+    this.transport_.maybeInitIframeTransport(this.element);
 
     const promises = [];
     // Trigger callback can be synchronous. Do the registration at the end.

--- a/extensions/amp-analytics/0.1/iframe-transport.js
+++ b/extensions/amp-analytics/0.1/iframe-transport.js
@@ -39,13 +39,26 @@ const LONG_TASK_REPORTING_THRESHOLD = 5;
 export let FrameData;
 
 /**
+ * @param {!Window} ampWin
+ * @param {boolean=} opt_forceProdUrl
+ * @return {string}
+ * @visibleForTesting
+ */
+export function getIframeTransportScriptUrlForTesting(
+  ampWin,
+  opt_forceProdUrl
+) {
+  return getIframeTransportScriptUrl(ampWin, opt_forceProdUrl);
+}
+
+/**
  * Get the URL of the client lib
  * @param {!Window} ampWin The window object of the AMP document
  * @param {boolean=} opt_forceProdUrl If true, prod URL will be returned even
  *     in local/test modes.
  * @return {string}
  */
-export function getIframeTransportScriptUrl(ampWin, opt_forceProdUrl) {
+function getIframeTransportScriptUrl(ampWin, opt_forceProdUrl) {
   if (
     (getMode().localDev || getMode().test) &&
     !opt_forceProdUrl &&

--- a/extensions/amp-analytics/0.1/test/test-iframe-transport.js
+++ b/extensions/amp-analytics/0.1/test/test-iframe-transport.js
@@ -192,7 +192,7 @@ describes.realWin(
   'amp-analytics.iframe-transport',
   {amp: true, allowExternalResources: true},
   env => {
-    it.only('logs poor performance of vendor iframe', () => {
+    it('logs poor performance of vendor iframe', () => {
       const body =
         '<html><head><script>' +
         'function busyWait(count, duration, cb) {\n' +

--- a/extensions/amp-analytics/0.1/test/test-iframe-transport.js
+++ b/extensions/amp-analytics/0.1/test/test-iframe-transport.js
@@ -16,7 +16,7 @@
 
 import {
   IframeTransport,
-  getIframeTransportScriptUrl,
+  getIframeTransportScriptUrlForTesting,
 } from '../iframe-transport';
 import {addParamsToUrl} from '../../../../src/url';
 import {expectPostMessage} from '../../../../testing/iframe.js';
@@ -172,13 +172,13 @@ describes.realWin('amp-analytics.iframe-transport', {amp: true}, env => {
   });
 
   it('gets correct client lib URL in local/test mode', () => {
-    const url = getIframeTransportScriptUrl(env.ampdoc.win);
+    const url = getIframeTransportScriptUrlForTesting(env.ampdoc.win);
     expect(url).to.contain(env.win.location.host);
     expect(url).to.contain('/dist/iframe-transport-client-lib.js');
   });
 
   it('gets correct client lib URL in prod mode', () => {
-    const url = getIframeTransportScriptUrl(env.ampdoc.win, true);
+    const url = getIframeTransportScriptUrlForTesting(env.ampdoc.win, true);
     expect(url).to.contain(urls.thirdParty);
     expect(url).to.contain('/iframe-transport-client-v0.js');
     expect(url).to.equal(
@@ -192,7 +192,7 @@ describes.realWin(
   'amp-analytics.iframe-transport',
   {amp: true, allowExternalResources: true},
   env => {
-    it('logs poor performance of vendor iframe', () => {
+    it.only('logs poor performance of vendor iframe', () => {
       const body =
         '<html><head><script>' +
         'function busyWait(count, duration, cb) {\n' +

--- a/extensions/amp-analytics/0.1/test/test-transport.js
+++ b/extensions/amp-analytics/0.1/test/test-transport.js
@@ -390,12 +390,8 @@ describes.realWin(
 
         const ampAnalyticsEl = null;
 
-        const preconnectSpy = env.sandbox.spy();
-        transport.maybeInitIframeTransport(win, ampAnalyticsEl, {
-          preload: preconnectSpy,
-        });
+        transport.maybeInitIframeTransport(ampAnalyticsEl);
         expect(transport.iframeTransport_).to.be.null;
-        expect(preconnectSpy).to.not.be.called;
       });
 
       it('initialize iframe transport when used', () => {
@@ -416,12 +412,8 @@ describes.realWin(
           'amp-analytics'
         );
 
-        const preconnectSpy = env.sandbox.spy();
-        transport.maybeInitIframeTransport(win, ampAnalyticsEl, {
-          preload: preconnectSpy,
-        });
+        transport.maybeInitIframeTransport(ampAnalyticsEl);
         expect(transport.iframeTransport_).to.be.ok;
-        expect(preconnectSpy).to.be.called;
 
         transport.deleteIframeTransport();
         expect(transport.iframeTransport_).to.be.null;
@@ -446,12 +438,8 @@ describes.realWin(
           'amp-analytics'
         );
 
-        const preconnectSpy = env.sandbox.spy();
-        transport.maybeInitIframeTransport(win, ampAnalyticsEl, {
-          preload: preconnectSpy,
-        });
+        transport.maybeInitIframeTransport(ampAnalyticsEl);
         expect(transport.iframeTransport_).to.be.ok;
-        expect(preconnectSpy).to.be.called;
 
         transport.deleteIframeTransport();
         expect(transport.iframeTransport_).to.be.null;

--- a/extensions/amp-analytics/0.1/transport.js
+++ b/extensions/amp-analytics/0.1/transport.js
@@ -21,7 +21,7 @@ import {
   TransportSerializers,
   defaultSerializer,
 } from './transport-serializer';
-import {IframeTransport, getIframeTransportScriptUrl} from './iframe-transport';
+import {IframeTransport} from './iframe-transport';
 import {Services} from '../../../src/services';
 import {WindowInterface} from '../../../src/window-interface';
 import {
@@ -146,34 +146,27 @@ export class Transport {
    * user navigates/swipes away from the page, and is recreated if the user
    * navigates back to the page.
    *
-   * @param {!Window} win
    * @param {!Element} element
-   * @param {(!../../../src/preconnect.PreconnectService)=} opt_preconnect
    */
-  maybeInitIframeTransport(win, element, opt_preconnect) {
+  maybeInitIframeTransport(element) {
     if (!this.options_['iframe'] || this.iframeTransport_) {
       return;
     }
-    if (opt_preconnect) {
-      opt_preconnect.preload(
-        Services.ampdoc(element),
-        getIframeTransportScriptUrl(win),
-        'script'
-      );
-    }
 
+    // In the case of FIE rendering, we should be using the parent doc win.
+    const topWin = getTopWindow(element.ownerDocument.defaultView);
     const type = element.getAttribute('type');
     // In inabox there is no amp-ad element.
     const ampAdResourceId = this.isInabox_
       ? '1'
       : user().assertString(
-          getAmpAdResourceId(element, getTopWindow(win)),
+          getAmpAdResourceId(element, topWin),
           'No friendly amp-ad ancestor element was found ' +
             'for amp-analytics tag with iframe transport.'
         );
 
     this.iframeTransport_ = new IframeTransport(
-      win,
+      topWin,
       type,
       this.options_,
       ampAdResourceId

--- a/extensions/amp-analytics/0.1/transport.js
+++ b/extensions/amp-analytics/0.1/transport.js
@@ -36,6 +36,7 @@ import {getMode} from '../../../src/mode';
 import {getTopWindow} from '../../../src/service';
 import {loadPromise} from '../../../src/event-helper';
 import {removeElement} from '../../../src/dom';
+import {toWin} from '../../../src/types';
 import {toggle} from '../../../src/style';
 
 /** @const {string} */
@@ -154,7 +155,7 @@ export class Transport {
     }
 
     // In the case of FIE rendering, we should be using the parent doc win.
-    const topWin = getTopWindow(element.ownerDocument.defaultView);
+    const topWin = getTopWindow(toWin(element.ownerDocument.defaultView));
     const type = element.getAttribute('type');
     // In inabox there is no amp-ad element.
     const ampAdResourceId = this.isInabox_


### PR DESCRIPTION
Removed unnecessary preconnect as we are loading the iframe immediately.

This is a follow up of https://github.com/ampproject/amphtml/pull/25917/files#r354994477