### PR TITLE
amp-consent geoOverride: should NOT override instanceId

### DIFF
--- a/extensions/amp-consent/0.1/consent-config.js
+++ b/extensions/amp-consent/0.1/consent-config.js
@@ -18,7 +18,7 @@ import {CMP_CONFIG} from './cmps';
 import {CONSENT_POLICY_STATE} from '../../../src/consent-state';
 import {GEO_IN_GROUP} from '../../amp-geo/0.1/amp-geo-in-group';
 import {Services} from '../../../src/services';
-import {deepMerge, map} from '../../../src/utils/object';
+import {deepMerge, hasOwn, map} from '../../../src/utils/object';
 import {devAssert, user, userAssert} from '../../../src/log';
 import {getChildJsonConfig} from '../../../src/json';
 import {isExperimentOn} from '../../../src/experiments';
@@ -206,7 +206,16 @@ export class ConsentConfig {
       // Stop at the first group that the geoService says we're in and then merge configs.
       for (let i = 0; i < geoGroups.length; i++) {
         if (geoService.isInCountryGroup(geoGroups[i]) === GEO_IN_GROUP.IN) {
-          deepMerge(mergedConfig, config['geoOverride'][geoGroups[i]], 1);
+          const geoConfig = config['geoOverride'][geoGroups[i]];
+          if (hasOwn(geoConfig, 'consentInstanceId')) {
+            user().error(
+              TAG,
+              'consentInstanceId cannot be overriden in geoGroup:',
+              geoGroups[i]
+            );
+            delete geoConfig['consentInstanceId'];
+          }
+          deepMerge(mergedConfig, geoConfig, 1);
           this.matchedGeoGroup_ = geoGroups[i];
           break;
         }

--- a/extensions/amp-consent/0.1/test/test-consent-config.js
+++ b/extensions/amp-consent/0.1/test/test-consent-config.js
@@ -244,6 +244,10 @@ describes.realWin('ConsentConfig', {amp: 1}, env => {
               'checkConsentHref': 'https://example.com/check-consent',
               'consentRequired': true,
             },
+            'invalid': {
+              'consentInstanceId': 'error',
+              'checkConsentHref': 'https://example.com/check-consent',
+            },
           },
         };
       });
@@ -375,6 +379,27 @@ describes.realWin('ConsentConfig', {amp: 1}, env => {
           'consentInstanceId': 'abc',
           'consentRequired': true,
           'promptIfUnknownForGeoGroup': 'na',
+        });
+      });
+
+      it('should not override consentInstanceId', async () => {
+        expectAsyncConsoleError(/consentInstanceId/, 1);
+        appendConfigScriptElement(doc, element, geoConfig);
+        env.sandbox.stub(Services, 'geoForDocOrNull').returns(
+          Promise.resolve({
+            isInCountryGroup(geoGroup) {
+              if (geoGroup === 'invalid') {
+                return GEO_IN_GROUP.IN;
+              }
+              return GEO_IN_GROUP.NOT_IN;
+            },
+          })
+        );
+        const consentConfig = new ConsentConfig(element);
+        expect(await consentConfig.getConsentConfigPromise()).to.deep.equal({
+          'consentInstanceId': 'abc',
+          'consentRequired': false,
+          'checkConsentHref': 'https://example.com/check-consent',
         });
       });
     });


### PR DESCRIPTION
One single instanceId to store consent info is allowed. Fix the issue the value NOT be overridden based on geo location. I'll make a change to the doc in a following PR. 