### PR TITLE
Report dev error at viewer channel timeout

### DIFF
--- a/src/log.js
+++ b/src/log.js
@@ -51,6 +51,14 @@ export function isUserErrorMessage(message) {
 
 /**
  * @param {string} message
+ * @return {string} The new message without USER_ERROR_SENTINEL
+ */
+export function stripUserError(message) {
+  return message.replace(USER_ERROR_SENTINEL, '');
+}
+
+/**
+ * @param {string} message
  * @return {boolean} Whether this message was a a user error from an iframe embed.
  */
 export function isUserErrorEmbed(message) {

--- a/src/service/viewer-impl.js
+++ b/src/service/viewer-impl.js
@@ -17,9 +17,14 @@
 import {Deferred, tryResolve} from '../utils/promise';
 import {Observable} from '../observable';
 import {Services} from '../services';
+import {
+  USER_ERROR_SENTINEL,
+  dev,
+  devAssert,
+  duplicateErrorIfNecessary,
+} from '../log';
 import {ViewerInterface} from './viewer-interface';
 import {VisibilityState} from '../visibility-state';
-import {dev, devAssert, duplicateErrorIfNecessary} from '../log';
 import {findIndex} from '../utils/array';
 import {
   getSourceOrigin,
@@ -856,17 +861,22 @@ export class ViewerImpl {
 }
 
 /**
- * Creates an error for the case where a channel cannot be established.
+ * Creates a dev error for the case where a channel cannot be established.
  * @param {*=} opt_reason
  * @return {!Error}
  */
 function getChannelError(opt_reason) {
+  let channelError;
   if (opt_reason instanceof Error) {
     opt_reason = duplicateErrorIfNecessary(opt_reason);
     opt_reason.message = 'No messaging channel: ' + opt_reason.message;
-    return opt_reason;
+    channelError = opt_reason;
+  } else {
+    channelError = new Error('No messaging channel: ' + opt_reason);
   }
-  return new Error('No messaging channel: ' + opt_reason);
+  // Force convert user error to dev error
+  channelError.message = channelError.message.replace(USER_ERROR_SENTINEL, '');
+  return channelError;
 }
 
 /**

--- a/src/service/viewer-impl.js
+++ b/src/service/viewer-impl.js
@@ -17,14 +17,14 @@
 import {Deferred, tryResolve} from '../utils/promise';
 import {Observable} from '../observable';
 import {Services} from '../services';
+import {ViewerInterface} from './viewer-interface';
+import {VisibilityState} from '../visibility-state';
 import {
-  USER_ERROR_SENTINEL,
   dev,
   devAssert,
   duplicateErrorIfNecessary,
+  stripUserError,
 } from '../log';
-import {ViewerInterface} from './viewer-interface';
-import {VisibilityState} from '../visibility-state';
 import {findIndex} from '../utils/array';
 import {
   getSourceOrigin,
@@ -875,7 +875,7 @@ function getChannelError(opt_reason) {
     channelError = new Error('No messaging channel: ' + opt_reason);
   }
   // Force convert user error to dev error
-  channelError.message = channelError.message.replace(USER_ERROR_SENTINEL, '');
+  channelError.message = stripUserError(channelError.message);
   return channelError;
 }
 


### PR DESCRIPTION
Fixes #25923 

Another approach I've been thinking of is to introduce an `opt_errorType` param to the `#reportError()` method. But that doesn't apply to the uncaught error that we ret hrow. 

The code looks like
```
    return Services.timerFor(this.win)
      .timeoutPromise(20000, messagingPromise, 'initMessagingChannel')
      .catch(reason => {
        const error = getChannelError(
          /** @type {!Error|string|undefined} */ (reason)
        );
        reportError(error);
        throw error;
      });
```

Do you know why we want to re-throw the error after calling `reportError()` (From my test, either one should get the error sent to endpoint)

