### PR TITLE
🏗 Update Selenium version for e2e tests

### DIFF
--- a/build-system/tasks/e2e/package.json
+++ b/build-system/tasks/e2e/package.json
@@ -9,6 +9,6 @@
     "chromedriver": "78.0.1",
     "puppeteer": "2.0.0",
     "geckodriver": "1.19.1",
-    "selenium-webdriver": "4.0.0-alpha.4"
+    "selenium-webdriver": "4.0.0-alpha.5"
   }
 }

--- a/build-system/tasks/e2e/yarn.lock
+++ b/build-system/tasks/e2e/yarn.lock
@@ -962,10 +962,10 @@ sax@>=0.6.0:
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
 
-selenium-webdriver@4.0.0-alpha.4:
-  version "4.0.0-alpha.4"
-  resolved "https://registry.yarnpkg.com/selenium-webdriver/-/selenium-webdriver-4.0.0-alpha.4.tgz#73694490e02c941d9d0bf7a36f7c49beb9372512"
-  integrity sha512-etJt20d8qInkxMAHIm5SEpPBSS+CdxVcybnxzSIB/GlWErb8pIWrArz/VA6VfUW0/6tIcokepXQ5ufvdzqqk1A==
+selenium-webdriver@4.0.0-alpha.5:
+  version "4.0.0-alpha.5"
+  resolved "https://registry.yarnpkg.com/selenium-webdriver/-/selenium-webdriver-4.0.0-alpha.5.tgz#e4683b3dbf827d70df09a7e43bf02ebad20fa7c1"
+  integrity sha512-hktl3DSrhzM59yLhWzDGHIX9o56DvA+cVK7Dw6FcJR6qQ4CGzkaHeXQPcdrslkWMTeq0Ci9AmCxq0EMOvm2Rkg==
   dependencies:
     jszip "^3.1.5"
     rimraf "^2.6.3"


### PR DESCRIPTION
Update to the latest Selenium version so that we can take advantage of their new performance logging feature for e2e tests.