### PR TITLE
♻️ Refactor template helper: Rename isSupported() to isEnabled()

### DIFF
--- a/extensions/amp-autocomplete/0.1/amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/amp-autocomplete.js
@@ -269,7 +269,7 @@ export class AmpAutocomplete extends AMP.BaseElement {
     }
 
     // When SSR is supported, it is required.
-    this.isSsr_ = this.getSsrTemplateHelper().isSupported();
+    this.isSsr_ = this.getSsrTemplateHelper().isEnabled();
     this.hasTemplate_ = this.templates_.hasTemplate(
       this.element,
       'template, script[template]'

--- a/extensions/amp-autocomplete/0.1/test/test-amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/test/test-amp-autocomplete.js
@@ -66,7 +66,7 @@ describes.realWin(
 
       const ampAutocomplete = new AmpAutocomplete(element);
       const ssrTemplateHelper = ampAutocomplete.getSsrTemplateHelper();
-      env.sandbox.stub(ssrTemplateHelper, 'isSupported').returns(wantSsr);
+      env.sandbox.stub(ssrTemplateHelper, 'isEnabled').returns(wantSsr);
 
       return ampAutocomplete.buildCallback().then(() => {
         return ampAutocomplete;

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -392,7 +392,7 @@ export class AmpForm {
     );
 
     //  Form verification is not supported when SSRing templates is enabled.
-    if (!this.ssrTemplateHelper_.isSupported()) {
+    if (!this.ssrTemplateHelper_.isEnabled()) {
       this.form_.addEventListener('change', e => {
         this.verifier_.onCommit().then(updatedErrors => {
           const {updatedElements, errors} = updatedErrors;
@@ -688,7 +688,7 @@ export class AmpForm {
    */
   handleXhrSubmit_(trust) {
     let p;
-    if (this.ssrTemplateHelper_.isSupported()) {
+    if (this.ssrTemplateHelper_.isEnabled()) {
       p = this.handleSsrTemplate_(trust);
     } else {
       this.submittingWithTrust_(trust);
@@ -1070,7 +1070,7 @@ export class AmpForm {
    * @private
    */
   assertSsrTemplate_(value, msg) {
-    const supported = this.ssrTemplateHelper_.isSupported();
+    const supported = this.ssrTemplateHelper_.isEnabled();
     userAssert(
       supported === value,
       '[amp-form]: viewerRenderTemplate | %s',

--- a/extensions/amp-form/0.1/test/test-amp-form.js
+++ b/extensions/amp-form/0.1/test/test-amp-form.js
@@ -96,7 +96,7 @@ describes.repeated(
           env.ampdoc.getBody().appendChild(form);
           const ampForm = new AmpForm(form, 'amp-form-test-id');
           env.sandbox
-            .stub(ampForm.ssrTemplateHelper_, 'isSupported')
+            .stub(ampForm.ssrTemplateHelper_, 'isEnabled')
             .returns(false);
           return Promise.resolve(ampForm);
         }
@@ -243,9 +243,9 @@ describes.repeated(
               env.sandbox.stub(form, 'submit');
               env.sandbox.stub(form, 'checkValidity').returns(true);
               env.sandbox.stub(ampForm, 'analyticsEvent_');
-              ampForm.ssrTemplateHelper_.isSupported.restore();
+              ampForm.ssrTemplateHelper_.isEnabled.restore();
               env.sandbox
-                .stub(ampForm.ssrTemplateHelper_, 'isSupported')
+                .stub(ampForm.ssrTemplateHelper_, 'isEnabled')
                 .returns(true);
               env.sandbox
                 .stub(ampForm.viewer_, 'isTrustedViewer')
@@ -2396,7 +2396,7 @@ describes.repeated(
                 .stub(Services, 'navigationForDoc')
                 .returns({navigateTo});
               env.sandbox
-                .stub(ampForm.ssrTemplateHelper_, 'isSupported')
+                .stub(ampForm.ssrTemplateHelper_, 'isEnabled')
                 .returns(false);
             });
 

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -549,7 +549,7 @@ export class AmpList extends AMP.BaseElement {
       return Promise.resolve();
     }
     let fetch;
-    if (this.ssrTemplateHelper_.isSupported()) {
+    if (this.ssrTemplateHelper_.isEnabled()) {
       fetch = this.ssrTemplate_(opt_refresh);
     } else {
       fetch = this.prepareAndSendFetch_(opt_refresh).then(data => {
@@ -740,7 +740,7 @@ export class AmpList extends AMP.BaseElement {
       scheduleNextPass();
       current.rejecter();
     };
-    const isSSR = this.ssrTemplateHelper_.isSupported();
+    const isSSR = this.ssrTemplateHelper_.isEnabled();
     let renderPromise = this.ssrTemplateHelper_
       .applySsrOrCsrTemplate(this.element, current.data)
       .then(result => this.updateBindings_(result, current.append))

--- a/extensions/amp-list/0.1/test/test-amp-list.js
+++ b/extensions/amp-list/0.1/test/test-amp-list.js
@@ -89,7 +89,7 @@ describes.repeated(
           setBindService = resolve;
 
           ssrTemplateHelper = {
-            isSupported: () => false,
+            isEnabled: () => false,
             ssr: () => Promise.resolve(),
             applySsrOrCsrTemplate: env.sandbox.stub(),
           };
@@ -692,7 +692,7 @@ describes.repeated(
 
           describe('SSR templates', () => {
             beforeEach(() => {
-              env.sandbox.stub(ssrTemplateHelper, 'isSupported').returns(true);
+              env.sandbox.stub(ssrTemplateHelper, 'isEnabled').returns(true);
             });
 
             it('should error if proxied fetch fails', () => {

--- a/src/ssr-template-helper.js
+++ b/src/ssr-template-helper.js
@@ -48,12 +48,12 @@ export class SsrTemplateHelper {
   }
 
   /**
-   * Whether the viewer can render templates. A doc-level opt in as
+   * Whether the viewer should render templates. A doc-level opt in as
    * trusted viewers must set this capability explicitly, as a security
    * measure for potential abuse of feature.
    * @return {boolean}
    */
-  isSupported() {
+  isEnabled() {
     const ampdoc = this.viewer_.getAmpDoc();
     if (ampdoc.isSingleDoc()) {
       const htmlElement = ampdoc.getRootNode().documentElement;
@@ -118,7 +118,7 @@ export class SsrTemplateHelper {
    */
   applySsrOrCsrTemplate(element, data) {
     let renderTemplatePromise;
-    if (this.isSupported()) {
+    if (this.isEnabled()) {
       userAssert(
         typeof data['html'] === 'string',
         'Server side html response must be defined'

--- a/test/unit/test-ssr-template-helper.js
+++ b/test/unit/test-ssr-template-helper.js
@@ -60,12 +60,12 @@ describes.fakeWin(
           true
         );
         hasCapabilityStub.withArgs('viewerRenderTemplate').returns(true);
-        expect(ssrTemplateHelper.isSupported()).to.be.true;
+        expect(ssrTemplateHelper.isEnabled()).to.be.true;
       });
 
       it('should return false if not doc level opt-in', () => {
         hasCapabilityStub.withArgs('viewerRenderTemplate').returns(true);
-        expect(ssrTemplateHelper.isSupported()).to.be.false;
+        expect(ssrTemplateHelper.isEnabled()).to.be.false;
       });
 
       it(
@@ -77,7 +77,7 @@ describes.fakeWin(
             true
           );
           hasCapabilityStub.withArgs('viewerRenderTemplate').returns(false);
-          expect(ssrTemplateHelper.isSupported()).to.be.false;
+          expect(ssrTemplateHelper.isEnabled()).to.be.false;
         }
       );
     });

--- a/test/unit/test-ssr-template-helper.js
+++ b/test/unit/test-ssr-template-helper.js
@@ -53,7 +53,7 @@ describes.fakeWin(
       );
     });
 
-    describe('isSupported', () => {
+    describe('isEnabled', () => {
       it('should return true if doc level opt-in', () => {
         win.document.documentElement.setAttribute(
           'allow-viewer-render-template',


### PR DESCRIPTION
This change is to better signal the intent of the variable. It is meant to signify that SSR should be used as opposed to just that it is "supported" (possible to use).