### PR TITLE
Swap ads requestResize argument order to align

### DIFF
--- a/3p/ampcontext-integration.js
+++ b/3p/ampcontext-integration.js
@@ -101,7 +101,7 @@ export class IntegrationAmpContext extends AbstractAmpContext {
    */
   updateDimensions(width, height) {
     userAssert(this.updateDimensionsEnabled_(), 'Not available.');
-    this.requestResize(width, height);
+    this.requestResize(height, width);
   }
 
   /**

--- a/3p/ampcontext.js
+++ b/3p/ampcontext.js
@@ -207,11 +207,11 @@ export class AbstractAmpContext {
   /**
    *  Send message to runtime requesting to resize ad to height and width.
    *    This is not guaranteed to succeed. All this does is make the request.
-   *  @param {number} width The new width for the ad we are requesting.
    *  @param {number} height The new height for the ad we are requesting.
+   *  @param {number} width The new width for the ad we are requesting.
    *  @param {boolean=} hasOverflow Whether the ad handles its own overflow ele
    */
-  requestResize(width, height, hasOverflow) {
+  requestResize(height, width, hasOverflow) {
     this.client_.sendMessage(
       MessageType.EMBED_SIZE,
       dict({

--- a/3p/beopinion.js
+++ b/3p/beopinion.js
@@ -89,7 +89,7 @@ function getBeOpinionAsyncInit(global, accountId) {
   const {context} = global;
   return function() {
     context.onResizeDenied(function(requestedHeight, requestedWidth) {
-      context.requestResize(requestedWidth, requestedHeight);
+      context.requestResize(requestedHeight, requestedWidth);
     });
     global.BeOpinionSDK.init({
       account: accountId,
@@ -103,7 +103,7 @@ function getBeOpinionAsyncInit(global, accountId) {
       onHeightChange: function(newHeight) {
         const c = global.document.getElementById('c');
         const boundingClientRect = c./*REVIEW*/ getBoundingClientRect();
-        context.requestResize(boundingClientRect.width, newHeight);
+        context.requestResize(newHeight, boundingClientRect.width);
       },
     });
     global.BeOpinionSDK['watch'](); // global.BeOpinionSDK.watch() fails 'gulp check-types' validation

--- a/3p/embedly.js
+++ b/3p/embedly.js
@@ -108,8 +108,8 @@ export function embedly(global, data) {
     // Use embedly SDK to listen to resize event from loaded card
     global.window['embedly']('on', RESIZE_EVENT_NAME, function(iframe) {
       context.requestResize(
-        iframe./*OK*/ width,
-        parseInt(iframe./*OK*/ height, 10) + /* margin */ 5
+        parseInt(iframe./*OK*/ height, 10) + /* margin */ 5,
+        iframe./*OK*/ width
       );
     });
   });

--- a/3p/mathml.js
+++ b/3p/mathml.js
@@ -73,8 +73,8 @@ export function mathml(global, data) {
         }
         display[0].setAttribute('style', 'margin-top:0;margin-bottom:0');
         context.requestResize(
-          rendered./*OK*/ offsetWidth,
-          rendered./*OK*/ offsetHeight
+          rendered./*OK*/ offsetHeight,
+          rendered./*OK*/ offsetWidth
         );
         setStyle(div, 'visibility', 'visible');
       });

--- a/ads/README.md
+++ b/ads/README.md
@@ -156,7 +156,7 @@ Additionally, one can observe the `amp:visibilitychange` on the `window` object 
 ### Ad resizing
 
 Ads can call the special API
-`window.context.requestResize(width, height, opt_hasOverflow)` to send a resize request.
+`window.context.requestResize(height, width, opt_hasOverflow)` to send a resize request.
 
 Once the request is processed the AMP runtime will try to accommodate this request as soon as
 possible, but it will take into account where the reader is currently reading, whether the scrolling
@@ -223,7 +223,7 @@ _Example:_
 window.context.renderStart({width: 200, height: 100});
 ```
 
-Note that if the creative needs to resize on user interaction, the creative can continue to do that by calling the `window.context.requestResize(width, height, opt_hasOverflow)` API. Details in [Ad Resizing](#ad-resizing).
+Note that if the creative needs to resize on user interaction, the creative can continue to do that by calling the `window.context.requestResize(height, width, opt_hasOverflow)` API. Details in [Ad Resizing](#ad-resizing).
 
 ### amp-consent integration
 

--- a/ads/google/csa.js
+++ b/ads/google/csa.js
@@ -141,10 +141,10 @@ function orientationChangeHandler(global, containerDiv) {
       const overflow = global.document.getElementById('overflow');
       if (overflow) {
         overflow.onclick = () =>
-          global.context.requestResize(undefined, newHeight);
+          global.context.requestResize(newHeight, undefined);
       }
       // Resize the container to the correct height.
-      global.context.requestResize(undefined, newHeight);
+      global.context.requestResize(newHeight, undefined);
     }
   }, 250); /* 250 is time in ms to wait before executing orientation */
 }
@@ -296,7 +296,7 @@ export function resizeIframe(global, containerName) {
     createOverflow(global, container, height);
   }
   // Attempt to resize to actual CSA container height
-  global.context.requestResize(undefined, height);
+  global.context.requestResize(height, undefined);
 }
 
 /**
@@ -309,7 +309,7 @@ export function resizeIframe(global, containerName) {
 function createOverflow(global, container, height) {
   const overflow = getOverflowElement(global);
   // When overflow is clicked, resize to full height
-  overflow.onclick = () => global.context.requestResize(undefined, height);
+  overflow.onclick = () => global.context.requestResize(height, undefined);
   global.document.getElementById('c').appendChild(overflow);
   // Resize the CSA container to not conflict with overflow
   resizeCsa(container, currentAmpHeight - overflowHeight);

--- a/ads/nativeroll.js
+++ b/ads/nativeroll.js
@@ -46,7 +46,7 @@ function initPlayer(global, data) {
     onLoad: () => {
       const height = global.document.getElementsByClassName('nr-player')[0]
         ./* OK */ offsetHeight;
-      global.context.requestResize(undefined, height);
+      global.context.requestResize(height, undefined);
     },
     onDestroy: () => {
       global.context.noContentAvailable();

--- a/ads/netletix.js
+++ b/ads/netletix.js
@@ -82,7 +82,7 @@ export function netletix(global, data) {
             event.data.height &&
             (event.data.width != nxw || event.data.height != nxh)
           ) {
-            global.context.requestResize(event.data.width, event.data.height);
+            global.context.requestResize(event.data.height, event.data.width);
           }
           break;
         case 'nx-empty':

--- a/examples/ampcontext-creative-json.html
+++ b/examples/ampcontext-creative-json.html
@@ -10,6 +10,6 @@
   <script src='https://localhost:8000/examples/ac-creative.js'></script>
 </head>
 
-<body> Test Ad using ampcontext.js to create window.context <button onclick='toggleObserveIntersection()'>Toggle Observe Intersections</button>  <button onclick='toggleObserveVisibility()'>Toggle Observe visibility</button> <button onclick='window.context.requestResize(500,600)'>resize ad</button>  <button onclick='console.log(window.context)'>console.log(window.context)</button> </body>
+<body> Test Ad using ampcontext.js to create window.context <button onclick='toggleObserveIntersection()'>Toggle Observe Intersections</button>  <button onclick='toggleObserveVisibility()'>Toggle Observe visibility</button> <button onclick='window.context.requestResize(600,500)'>resize ad</button>  <button onclick='console.log(window.context)'>console.log(window.context)</button> </body>
 
 </html>

--- a/examples/ampcontext-creative.html
+++ b/examples/ampcontext-creative.html
@@ -98,7 +98,7 @@
     Test Ad using ampcontext.js to create window.context
     <button onclick='toggleObserveIntersection()'>Toggle Observe Intersections</button>
     <button onclick='toggleObserveVisibility()'>Toggle Observe visibility</button>
-    <button onclick='window.context.requestResize(500,600)'>resize ad</button>
+    <button onclick='window.context.requestResize(600,500)'>resize ad</button>
     <button onclick='console.log(window.context)'>console.log(window.context)</button>
   </body>
 </html>

--- a/test/integration/test-amp-ad-3p.js
+++ b/test/integration/test-amp-ad-3p.js
@@ -163,7 +163,7 @@ describe.configure().run('amp-ad 3P', () => {
         expect(iframe.offsetHeight).to.equal(250);
         expect(iframe.offsetWidth).to.equal(300);
         expect(iframe.contentWindow.ping.resizeSuccess).to.be.undefined;
-        iframe.contentWindow.context.requestResize(200, 50);
+        iframe.contentWindow.context.requestResize(50, 200);
         return poll('wait for embed-size to be received', () => {
           return !!fixture.messages.getFirstMessageEventOfType('embed-size');
         });

--- a/test/unit/ads/test-csa.js
+++ b/test/unit/ads/test-csa.js
@@ -174,7 +174,7 @@ describes.fakeWin('amp-ad-csa-impl', {}, env => {
 
       const overflow = win.document.getElementById('overflow');
       const container = win.document.getElementById('csacontainer');
-      const requestedHeight = requestResizeSpy.args[0][1];
+      const requestedHeight = requestResizeSpy.args[0][0];
 
       // Resize requests above the fold will be denied
       resizeDeniedHandler(win, container, requestedHeight);
@@ -200,7 +200,7 @@ describes.fakeWin('amp-ad-csa-impl', {}, env => {
 
       const overflow = win.document.getElementById('overflow');
       const container = win.document.getElementById('csacontainer');
-      const requestedHeight = requestResizeSpy.args[0][1];
+      const requestedHeight = requestResizeSpy.args[0][0];
 
       // Resize requests above the fold will be denied
       resizeDeniedHandler(win, container, requestedHeight);
@@ -223,7 +223,7 @@ describes.fakeWin('amp-ad-csa-impl', {}, env => {
       // Try to resize when ads are loaded
       resizeIframe(win, 'csacontainer');
       // Resize requests below the fold succeeed
-      const requestedHeight = requestResizeSpy.args[0][1];
+      const requestedHeight = requestResizeSpy.args[0][0];
 
       const overflow = win.document.getElementById('overflow');
       const container = win.document.getElementById('csacontainer');
@@ -248,7 +248,7 @@ describes.fakeWin('amp-ad-csa-impl', {}, env => {
       // Try to resize when ads are loaded
       resizeIframe(win, 'csacontainer');
       // Resize requests below the fold succeed
-      const requestedHeight = requestResizeSpy.args[0][1];
+      const requestedHeight = requestResizeSpy.args[0][0];
       resizeSuccessHandler(win, container, requestedHeight);
 
       const overflow = win.document.getElementById('overflow');

--- a/test/unit/test-amp-context.js
+++ b/test/unit/test-amp-context.js
@@ -272,7 +272,7 @@ describe('3p ampcontext.js', () => {
     expect(windowPostMessageSpy).to.be.calledOnce;
     expect(windowPostMessageSpy).to.be.calledWith(
       'amp-$internalRuntimeVersion$' +
-        '{"width":100,"height":200,"type":"embed-size","sentinel":"1-291921"}',
+        '{"width":200,"height":100,"type":"embed-size","sentinel":"1-291921"}',
       '*'
     );
 
@@ -319,7 +319,7 @@ describe('3p ampcontext.js', () => {
     expect(windowPostMessageSpy).to.be.calledOnce;
     expect(windowPostMessageSpy).to.be.calledWith(
       'amp-$internalRuntimeVersion$' +
-        '{"width":100,"height":200,"type":"embed-size","sentinel":"1-291921"}',
+        '{"width":200,"height":100,"type":"embed-size","sentinel":"1-291921"}',
       '*'
     );
 


### PR DESCRIPTION
https://github.com/ampproject/amphtml/issues/25895

Swap the two arguments so that it aligns with onResizeDenied. It has caused some confusions to 3p, and even some unit test code got the two inverted (see test-amp-context.js)
