### PR TITLE
🐛♻️ Docking: pageLayoutBox and position RTL controls

### DIFF
--- a/extensions/amp-video-docking/0.1/amp-video-docking.css
+++ b/extensions/amp-video-docking/0.1/amp-video-docking.css
@@ -15,6 +15,9 @@
  */
 
 .amp-video-docked-controls {
+  /* Override in case of RTL so that buttons match their DOM order visually. */
+  direction: ltr !important;
+
   opacity: 0;
   pointer-events: none !important;
   transition: 0.3s opacity ease;

--- a/extensions/amp-video-docking/0.1/amp-video-docking.js
+++ b/extensions/amp-video-docking/0.1/amp-video-docking.js
@@ -633,7 +633,9 @@ export class VideoDocking {
    * @private
    */
   getFixedSlotLayoutBox_() {
-    return this.getFixedLayoutBox_(dev().assertElement(this.getSlot_()));
+    return dev()
+      .assertElement(this.getSlot_())
+      .getPageLayoutBox();
   }
 
   /**

--- a/extensions/amp-video-docking/0.1/test/test-amp-video-docking.js
+++ b/extensions/amp-video-docking/0.1/test/test-amp-video-docking.js
@@ -93,7 +93,9 @@ describes.realWin('video docking', {amp: true}, env => {
 
   function stubLayoutBox(impl, rect, ratio = 0) {
     impl.getLayoutBox = () => rect;
+    impl.getPageLayoutBox = impl.getLayoutBox;
     impl.element.getLayoutBox = impl.getLayoutBox;
+    impl.element.getPageLayoutBox = impl.getLayoutBox;
     impl.element.getIntersectionChangeEntry = () => ({
       intersectionRatio: ratio,
       intersectionRect: rect,


### PR DESCRIPTION
- RTL controls are incorrectly aligned and ordered.

![ezgif-1-cfe12b1bc881](https://user-images.githubusercontent.com/254946/70470269-7d163e80-1a7f-11ea-8f22-779e72905d8f.gif)

- Cheaper and simpler to use `getPageLayoutBox` for slot element.