### PR TITLE
Swg release 0.1.22.85

### DIFF
--- a/third_party/subscriptions-project/config.js
+++ b/third_party/subscriptions-project/config.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/** Version: 0.1.22.84 */
+/** Version: 0.1.22.85 */
 /**
  * Copyright 2018 The Subscribe with Google Authors. All Rights Reserved.
  *


### PR DESCRIPTION
## Version: 0.1.22.85

## Previous release: [0.1.22.84](https://github.com/subscriptions-project/swg-js/releases/tag/0.1.22.84)

  - ♻ Registers `src/proto/api_messages_test.js` as a test (#866)
  - ✅ Improves test coverage (#865)
  - Update dependency rollup to v1.27.9 (#863)
  - Add subscribe button to amp article page (#861)
  - Remove fancy-log and traivs requires in preinstall script. (#859)
  - 🚮 Removes extra files (#860)
  - Further work to propogate one-time status with sku (#855)
  - Update dependency postcss to v7.0.24 (#858)
  - Update babel monorepo to v7.7.5 (#857)
  - Add sorting imports to "gulp lint" (#856)
  - Run e2e tests against local server (#850)
  - ✨ Updates API messages (#854)
  - Remove experiment flag for Contributions (#852)
  - Update dependency gulp-rename to v2 (#851)
  - Update dependency gulp-git to v2.10.0 (#849)
  - Update dependency rollup to v1.27.8 (#848)
  - Update dependency rollup to v1.27.7 (#847)
  - Update dependency eslint to v6.7.2 (#845)
  - Update dependency rollup to v1.27.6 (#846)
  - Update dependency autoprefixer to v9.7.3 (#844)
  - Update dependency bluebird to v3.7.2 (#843)
  - One time contributions (#840)
  - Turn codecov comment off (#842)
  - Disable codecov checks on patch for now (#841)
  - Update target and threshold for codecov (#839)
  - Add .codecov.yml (#838)
  - Refactor to prep for future changes (#837)
  - Refactor ButtonApi (#819)
  - Pin dependency codecov to 3.6.1 (#834)
  - Upload code coverage to Travis (#833)
  - 🔒 Parse decrypted document key (#827)
  - 🔑 Adds AES GCM decryption fn (#830)
  - Update dependency eslint to v6.7.1 (#831)
  - Update dependency rollup to v1.27.5 (#832)
  - Update dependency karma-coverage-istanbul-reporter to v2.1.1 (#829)
  - Enable coverage mode for unit tests. (#828)
  - Update babel monorepo to v7.7.4 (#826)
  - Update dependency eslint to v6.7.0 (#825)
  - Update instructions for logging publisher events (#793)
  - Add additional logging for save subscriptions (#817)
  - Update dependency nodemon to v2.0.1 (#824)
  - Update dependency rollup to v1.27.4 (#823)
  - Add two e2e test cases to check payment window. (#822)
  - ✅ Finishes moving `expect` calls to top level in tests (#820)
  - ✅ Moves `expect` calls to top level in several tests (part 2) (#818)
  - ✅ Moves `expect` calls to top level in several tests (#814)
  - Update dependency rollup to v1.27.3 (#816)
  - Update dependency nodemon to v2 (#815)
  - Some code refactor (#812)
  - ✅ Moves `expect` calls to top level in `dialog-test.js` (#811)
  - ✅ Moves `expect` calls to top level in `analytics-service-test.js` (#810)
  - ✅ Moves `expect` calls to top level in `page-config-resolver-test.js` (#809)
  - Use oldsku (#798)
  - Run unit tests in random order by default and clean up some config exports and help messages. (#808)
  - Update dependency postcss to v7.0.23 (#807)
  - ✅ Moves `expect` calls to top level in `dialog-manager-test.js` (#801)
  - ✅ Moves `expect` calls to top level in `graypane-test.js` (#804)
  - ✅ Moves `expect` calls to top level in `doc-test.js` (#805)
  - ♻ Migrates to arrow functions where possible in `dialog-test.js` (#802)
  - Update dependency autoprefixer to v9.7.2 (#806)
  - Log client version (#803)
  - ✅ Moves `expect` calls to the top-level in `activities-test.js` (#797)
  - Add version to proto (#800)
