### PR TITLE
🐛Fix next/prev arrows being clickable with hidden controls for amp-base-carousel

### DIFF
--- a/extensions/amp-base-carousel/0.1/amp-base-carousel.css
+++ b/extensions/amp-base-carousel/0.1/amp-base-carousel.css
@@ -61,8 +61,8 @@ amp-base-carousel[dir="rtl"] .i-amphtml-base-carousel-arrow-next-slot {
 
 amp-base-carousel[loop="false"] .i-amphtml-base-carousel-arrow-prev-slot > [disabled],
 amp-base-carousel[loop="false"] .i-amphtml-base-carousel-arrow-next-slot > [disabled],
-amp-base-carousel[i-amphtml-base-carousel-hide-buttons] .i-amphtml-base-carousel-arrow-prev-slot,
-amp-base-carousel[i-amphtml-base-carousel-hide-buttons] .i-amphtml-base-carousel-arrow-next-slot {
+amp-base-carousel[i-amphtml-base-carousel-hide-buttons] .i-amphtml-base-carousel-arrow-prev-slot > *,
+amp-base-carousel[i-amphtml-base-carousel-hide-buttons] .i-amphtml-base-carousel-arrow-next-slot > * {
   opacity: 0;
   /** 
    * Note, screen readers can still activate the buttons when hide buttons is

--- a/extensions/amp-base-carousel/0.1/test-e2e/test-hidden-controls.js
+++ b/extensions/amp-base-carousel/0.1/test-e2e/test-hidden-controls.js
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {getNextArrow} from './helpers';
+
+describes.endtoend(
+  'AMP carousel arrows with hidden controls',
+  {
+    testUrl:
+      'http://localhost:8000/test/manual/amp-base-carousel/hidden-controls.amp.html',
+    experiments: ['amp-base-carousel'],
+    environments: ['single'],
+  },
+  async function(env) {
+    let controller;
+
+    beforeEach(async () => {
+      controller = env.controller;
+    });
+
+    it('should not go to the next slide', async () => {
+      const nextArrow = await getNextArrow(controller);
+
+      // The test driver should throw an error, since the element is not clickable.
+      await expect(() => controller.click(nextArrow)).to.throw;
+    });
+  }
+);

--- a/extensions/amp-base-carousel/0.1/test-e2e/test-hidden-controls.js
+++ b/extensions/amp-base-carousel/0.1/test-e2e/test-hidden-controls.js
@@ -25,6 +25,26 @@ describes.endtoend(
     environments: ['single'],
   },
   async function(env) {
+    /**
+     * A helper function for expecting an error from an async function since we
+     * don't have ChaiAsExpected and we cannot wait for errors from
+     * @param {function()} fn A function to run
+     * @param {!RegExp} regExp A regular expression to match the error message.
+     */
+    async function expectAysncError(fn, regExp) {
+      let error;
+
+      try {
+        await fn();
+      } catch (e) {
+        error = e;
+      } finally {
+        await expect(error, 'Expected an error to be thrown.').to.not.be
+          .undefined;
+        await expect(error.toString()).to.match(regExp);
+      }
+    }
+
     let controller;
 
     beforeEach(async () => {
@@ -34,8 +54,24 @@ describes.endtoend(
     it('should not go to the next slide', async () => {
       const nextArrow = await getNextArrow(controller);
 
-      // The test driver should throw an error, since the element is not clickable.
-      await expect(() => controller.click(nextArrow)).to.throw;
+      // The test driver should throw an error, since the element is not
+      // clickable.
+      // TODO(sparhami) Ideally we would do something like:
+      // `await expect(() => controller.click(nextArrow)).to.throw();`, but
+      // that  does not work for a few reasons, including:
+      // * Click does not return a ControllerPromise
+      // * ControllerPromise uses a Promise rejection to singal it is not done
+      //   yet. The wrapper logic would need to be modified to allow for an
+      //   expected error type or message to sort circuit the waiting, allowing
+      //   use of something like:
+      //   ```
+      //   await expect(() => controller.click(nextArrow))
+      //      .to.throw(/ElementClickInterceptedError/);
+      //   ```
+      expectAysncError(
+        () => controller.click(nextArrow),
+        /ElementClickInterceptedError/
+      );
     });
   }
 );

--- a/test/manual/amp-base-carousel/hidden-controls.amp.html
+++ b/test/manual/amp-base-carousel/hidden-controls.amp.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>Basic Carousel</title>
+  <link rel="canonical" href="amps.html" >
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <link href='https://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css'>
+  <script async custom-element="amp-base-carousel" src="https://cdn.ampproject.org/v0/amp-base-carousel-0.1.js"></script>
+  <script async custom-element="amp-lightbox-gallery" src="https://cdn.ampproject.org/v0/amp-lightbox-gallery-0.1.js"></script>
+  <style amp-custom>
+    amp-base-carousel img {
+      object-fit: cover;
+    }
+  </style>
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+</head>
+<body>
+  <h1>Hidden controls</h1>
+  <amp-base-carousel  width="300" height="200" layout="responsive" controls="never" loop="true">
+    <amp-img src="./img/redgradient.png" layout="flex-item"></amp-img>
+    <amp-img src="./img/greengradient.png" layout="flex-item"></amp-img>
+    <amp-img src="./img/bluegradient.png" layout="flex-item"></amp-img>
+    <amp-img src="./img/orangegradient.png" layout="flex-item"></amp-img>
+    <amp-img src="./img/tealgradient.png" layout="flex-item"></amp-img>
+    <amp-img src="./img/lemonyellowgradient.png" layout="flex-item"></amp-img>
+    <amp-img src="./img/lilacgradient.png" layout="flex-item"></amp-img>
+  </amp-base-carousel>
+</body>
+</html>


### PR DESCRIPTION
The selector was giving the `pointer-events: none` to the parent of the button, which was set to `pointer-events: all` a few rules above.

- Added a e2e test to make sure the button is not clickable.
- Tested on VoiceOver and Talkback to make sure the accessibility still works as expected.
