### PR TITLE
🐛 Fix amp-list race condition

### DIFF
--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -547,7 +547,7 @@ export class AmpList extends AMP.BaseElement {
   fetchList_(opt_refresh = false) {
     const elementSrc = this.element.getAttribute('src');
     if (!elementSrc) {
-      return;
+      return Promise.resolve();
     }
     let fetch;
     if (this.ssrTemplateHelper_.isSupported()) {
@@ -556,13 +556,14 @@ export class AmpList extends AMP.BaseElement {
       fetch = this.prepareAndSendFetch_(opt_refresh).then(data => {
         // Bail if the src has changed while resolving the xhr request.
         if (elementSrc !== this.element.getAttribute('src')) {
-          return;
+          return Promise.resolve();
         }
 
         const items = this.computeListItems_(data);
         if (this.loadMoreEnabled_) {
           this.updateLoadMoreSrc_(/** @type {!JsonObject} */ (data));
         }
+
         return this.scheduleRender_(
           items,
           /*opt_append*/ false,

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -545,7 +545,8 @@ export class AmpList extends AMP.BaseElement {
    * @private
    */
   fetchList_(opt_refresh = false) {
-    if (!this.element.getAttribute('src')) {
+    const elementSrc = this.element.getAttribute('src');
+    if (!elementSrc) {
       return Promise.resolve();
     }
     let fetch;
@@ -553,6 +554,11 @@ export class AmpList extends AMP.BaseElement {
       fetch = this.ssrTemplate_(opt_refresh);
     } else {
       fetch = this.prepareAndSendFetch_(opt_refresh).then(data => {
+        // Bail if the src has changed while resolving the xhr request.
+        if (elementSrc !== this.element.getAttribute('src')) {
+          return Promise.resolve();
+        }
+
         const items = this.computeListItems_(data);
         if (this.loadMoreEnabled_) {
           this.updateLoadMoreSrc_(/** @type {!JsonObject} */ (data));
@@ -620,6 +626,7 @@ export class AmpList extends AMP.BaseElement {
    * @return {!Promise}
    */
   ssrTemplate_(refresh) {
+    const elementSrc = this.element.getAttribute('src');
     let request;
     // Construct the fetch init data that would be called by the viewer
     // passed in as the 'originalRequest'.
@@ -678,7 +685,13 @@ export class AmpList extends AMP.BaseElement {
           throw user().createError('Error proxying amp-list templates', error);
         }
       )
-      .then(data => this.scheduleRender_(data, /* append */ false));
+      .then(data => {
+        // Bail if the src has changed while resolving the xhr request.
+        if (elementSrc !== this.element.getAttribute('src')) {
+          return Promise.resolve();
+        }
+        this.scheduleRender_(data, /* append */ false);
+      });
   }
 
   /**

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -556,7 +556,7 @@ export class AmpList extends AMP.BaseElement {
       fetch = this.prepareAndSendFetch_(opt_refresh).then(data => {
         // Bail if the src has changed while resolving the xhr request.
         if (elementSrc !== this.element.getAttribute('src')) {
-          return Promise.resolve();
+          return;
         }
 
         const items = this.computeListItems_(data);
@@ -689,7 +689,7 @@ export class AmpList extends AMP.BaseElement {
       .then(data => {
         // Bail if the src has changed while resolving the xhr request.
         if (elementSrc !== this.element.getAttribute('src')) {
-          return Promise.resolve();
+          return;
         }
         this.scheduleRender_(data, /* append */ false);
       });

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -547,7 +547,7 @@ export class AmpList extends AMP.BaseElement {
   fetchList_(opt_refresh = false) {
     const elementSrc = this.element.getAttribute('src');
     if (!elementSrc) {
-      return Promise.resolve();
+      return;
     }
     let fetch;
     if (this.ssrTemplateHelper_.isSupported()) {
@@ -556,7 +556,7 @@ export class AmpList extends AMP.BaseElement {
       fetch = this.prepareAndSendFetch_(opt_refresh).then(data => {
         // Bail if the src has changed while resolving the xhr request.
         if (elementSrc !== this.element.getAttribute('src')) {
-          return Promise.resolve();
+          return;
         }
 
         const items = this.computeListItems_(data);

--- a/extensions/amp-list/0.1/test/test-amp-list.js
+++ b/extensions/amp-list/0.1/test/test-amp-list.js
@@ -895,6 +895,10 @@ describes.repeated(
             expect(element.getAttribute('src')).to.equal('');
           });
 
+          it('should not render if [src] has changed since the fetch was initiated', () => {
+            // TODO(samouri)
+          });
+
           it('should render if [src] mutates with data', () => {
             const foo = doc.createElement('div');
             expectFetchAndRender(DEFAULT_FETCHED_DATA, [foo]);

--- a/extensions/amp-list/0.1/test/test-amp-list.js
+++ b/extensions/amp-list/0.1/test/test-amp-list.js
@@ -895,12 +895,12 @@ describes.repeated(
             expect(element.getAttribute('src')).to.equal('');
           });
 
-          it('should not render if [src] has changed since the fetch was initiated', async () => {
-            const foo = {items: [doc.createElement('div')]};
-            const bar = {items: [doc.createElement('div')]};
+          it.only('should not render if [src] has changed since the fetch was initiated', async () => {
+            const foo = doc.createElement('div');
+            const bar = doc.createElement('div');
 
-            const firstPromise = Promise.resolve(foo);
-            const secondPromise = firstPromise.then(() => bar);
+            const firstPromise = Promise.resolve({items: [foo]});
+            const secondPromise = firstPromise.then(() => ({items: [bar]}));
 
             listMock
               .expects('fetch_')
@@ -909,8 +909,10 @@ describes.repeated(
               .twice();
             listMock
               .expects('scheduleRender_')
+              .withArgs([bar])
               .returns(Promise.resolve())
               .once();
+            listMock.expects('showFallback_').never();
 
             element.setAttribute('src', 'https://foo.com/list.json');
             list.layoutCallback();

--- a/extensions/amp-list/0.1/test/test-amp-list.js
+++ b/extensions/amp-list/0.1/test/test-amp-list.js
@@ -926,9 +926,9 @@ describes.repeated(
             const layout1Promise = list.layoutCallback();
 
             element.setAttribute('src', 'https://bar.com/list.json');
-            const layout2Promise = list.layoutCallback();
-
+            const layout2Promise = list.layoutCallback(); 
             layout2Promise.then(() => resolveFirstPromise());
+
             await Promise.all([layout1Promise, layout2Promise]);
           });
 

--- a/extensions/amp-list/0.1/test/test-amp-list.js
+++ b/extensions/amp-list/0.1/test/test-amp-list.js
@@ -895,8 +895,28 @@ describes.repeated(
             expect(element.getAttribute('src')).to.equal('');
           });
 
-          it('should not render if [src] has changed since the fetch was initiated', () => {
-            // TODO(samouri)
+          it('should not render if [src] has changed since the fetch was initiated', async () => {
+            const foo = {items: [doc.createElement('div')]};
+            const bar = {items: [doc.createElement('div')]};
+
+            const firstPromise = Promise.resolve(foo);
+            const secondPromise = firstPromise.then(() => bar);
+
+            listMock
+              .expects('fetch_')
+              .returns(firstPromise)
+              .returns(secondPromise)
+              .twice();
+            listMock
+              .expects('scheduleRender_')
+              .returns(Promise.resolve())
+              .once();
+
+            element.setAttribute('src', 'https://foo.com/list.json');
+            list.layoutCallback();
+
+            element.setAttribute('src', 'https://bar.com/list.json');
+            await list.layoutCallback();
           });
 
           it('should render if [src] mutates with data', () => {

--- a/extensions/amp-list/0.1/test/test-amp-list.js
+++ b/extensions/amp-list/0.1/test/test-amp-list.js
@@ -895,7 +895,7 @@ describes.repeated(
             expect(element.getAttribute('src')).to.equal('');
           });
 
-          it.only('should not render if [src] has changed since the fetch was initiated', async () => {
+          it('should not render if [src] has changed since the fetch was initiated', async () => {
             const foo = doc.createElement('div');
             const bar = doc.createElement('div');
 

--- a/extensions/amp-list/0.1/test/test-amp-list.js
+++ b/extensions/amp-list/0.1/test/test-amp-list.js
@@ -926,7 +926,7 @@ describes.repeated(
             const layout1Promise = list.layoutCallback();
 
             element.setAttribute('src', 'https://bar.com/list.json');
-            const layout2Promise = list.layoutCallback(); 
+            const layout2Promise = list.layoutCallback();
             layout2Promise.then(() => resolveFirstPromise());
 
             await Promise.all([layout1Promise, layout2Promise]);


### PR DESCRIPTION
**summary**
Addresses https://github.com/ampproject/amphtml/issues/25961

Adds a check that the `src` has not changed while the xhr was inflight. If the `src` has changed, then bail instead of scheduling a render.  I've added a test that previously would have resulted in two renders and now instead only has one.

cc @jridgewell  / @choumx 