### PR TITLE
♻️ Refactor fetchJson() to return Promise<JsonObject>

### DIFF
--- a/ads/google/a4a/utils.js
+++ b/ads/google/a4a/utils.js
@@ -894,13 +894,15 @@ function executeIdentityTokenFetch(
 ) {
   const url = getIdentityTokenRequestUrl(win, ampDoc, domain);
   return Services.xhrFor(win)
-    .fetchJson(url, {
-      mode: 'cors',
-      method: 'GET',
-      ampCors: false,
-      credentials: 'include',
-    })
-    .then(res => res.json())
+    .fetch(
+      url,
+      Services.xhrFor(win).setupJsonFetchInit({
+        mode: 'cors',
+        method: 'GET',
+        ampCors: false,
+        credentials: 'include',
+      })
+    )
     .then(obj => {
       const token = obj['newToken'];
       const jar = obj['1p_jar'] || '';

--- a/extensions/amp-a4a/0.1/real-time-config-manager.js
+++ b/extensions/amp-a4a/0.1/real-time-config-manager.js
@@ -469,12 +469,14 @@ export class RealTimeConfigManager {
       .timeoutPromise(
         timeoutMillis,
         Services.xhrFor(this.win_)
-          .fetchJson(
+          .fetch(
             // NOTE(bradfrizzell): we could include ampCors:false allowing
             // the request to be cached across sites but for now assume that
             // is not a required feature.
             url,
-            {credentials: 'include'}
+            Services.xhrFor(this.win).setupJsonFetchInit({
+              credentials: 'include',
+            })
           )
           .then(res => {
             checkStillCurrent();

--- a/extensions/amp-a4a/0.1/signature-verifier.js
+++ b/extensions/amp-a4a/0.1/signature-verifier.js
@@ -310,14 +310,17 @@ export class SignatureVerifier {
     }
     // TODO(@taymonbeal, #11088): consider a timeout on this fetch
     return Services.xhrFor(this.win_)
-      .fetchJson(url, {
-        mode: 'cors',
-        method: 'GET',
-        // This should be cached across publisher domains, so don't append
-        // __amp_source_origin to the URL.
-        ampCors: false,
-        credentials: 'omit',
-      })
+      .fetch(
+        url,
+        Services.xhrFor(this.win_).setupJsonFetchInit({
+          mode: 'cors',
+          method: 'GET',
+          // This should be cached across publisher domains, so don't append
+          // __amp_source_origin to the URL.
+          ampCors: false,
+          credentials: 'omit',
+        })
+      )
       .then(
         response => {
           // These are assertions on signing service behavior required by

--- a/extensions/amp-access-laterpay/0.1/laterpay-impl.js
+++ b/extensions/amp-access-laterpay/0.1/laterpay-impl.js
@@ -253,7 +253,6 @@ export class LaterpayVendor {
               credentials: 'include',
             })
           )
-          .then(res => res.json());
       });
   }
 

--- a/extensions/amp-access-laterpay/0.2/laterpay-impl.js
+++ b/extensions/amp-access-laterpay/0.2/laterpay-impl.js
@@ -289,7 +289,6 @@ export class LaterpayVendor {
               credentials: 'include',
             })
           )
-          .then(res => res.json());
       });
   }
 

--- a/extensions/amp-access-poool/0.1/poool-impl.js
+++ b/extensions/amp-access-poool/0.1/poool-impl.js
@@ -168,9 +168,10 @@ export class PooolVendor {
       })
       .then(url => {
         dev().info(TAG, 'Authorization URL: ', url);
-        return this.timer_
-          .timeoutPromise(AUTHORIZATION_TIMEOUT, this.xhr_.fetchJson(url))
-          .then(res => res.json());
+        return this.timer_.timeoutPromise(
+          AUTHORIZATION_TIMEOUT,
+          this.xhr_.fetchJson(url)
+        );
       });
   }
 

--- a/extensions/amp-access/0.1/amp-access-client.js
+++ b/extensions/amp-access/0.1/amp-access-client.js
@@ -134,7 +134,6 @@ export class AccessClientAdapter {
             credentials: 'include',
           })
         )
-        .then(res => res.json());
     });
   }
 

--- a/extensions/amp-ad/0.1/amp-ad-custom.js
+++ b/extensions/amp-ad/0.1/amp-ad-custom.js
@@ -96,9 +96,7 @@ export class AmpAdCustom extends AMP.BaseElement {
     // if we have cached the response, find it, otherwise fetch
     const responsePromise =
       ampCustomadXhrPromises[fullUrl] ||
-      Services.xhrFor(this.win)
-        .fetchJson(fullUrl)
-        .then(res => res.json());
+      Services.xhrFor(this.win).fetchJson(fullUrl);
     if (this.slot_ !== null) {
       // Cache this response if using `data-slot` feature so only one request
       // is made per url

--- a/extensions/amp-addthis/0.1/addthis-utils/pixel.js
+++ b/extensions/amp-addthis/0.1/addthis-utils/pixel.js
@@ -197,7 +197,6 @@ export const callPixelEndpoint = event => {
       ampCors: false,
       credentials: 'include',
     })
-    .then(res => res.json())
     .then(
       json => {
         const {pixels = []} = json;

--- a/extensions/amp-analytics/0.1/config.js
+++ b/extensions/amp-analytics/0.1/config.js
@@ -114,7 +114,6 @@ export class AnalyticsConfig {
 
     return Services.xhrFor(toWin(this.win_))
       .fetchJson(vendorUrl)
-      .then(res => res.json())
       .then(
         jsonValue => {
           this.predefinedConfig_[type] = jsonValue;
@@ -182,7 +181,6 @@ export class AnalyticsConfig {
           fetchConfig
         );
       })
-      .then(res => res.json())
       .then(
         jsonValue => {
           this.remoteConfig_ = jsonValue;
@@ -252,7 +250,6 @@ export class AnalyticsConfig {
             fetchConfig
           );
         })
-        .then(res => res.json())
         .then(
           jsonValue => {
             this.config_ = this.mergeConfigs_(jsonValue);

--- a/extensions/amp-apester-media/0.1/amp-apester-media.js
+++ b/extensions/amp-apester-media/0.1/amp-apester-media.js
@@ -215,14 +215,7 @@ class AmpApesterMedia extends AMP.BaseElement {
    **/
   queryMedia_() {
     const url = this.buildUrl_();
-    return Services.xhrFor(this.win)
-      .fetchJson(url, {})
-      .then(res => {
-        if (res.status === 200) {
-          return res.json();
-        }
-        return res;
-      });
+    return Services.xhrFor(this.win).fetchJson(url, {});
   }
 
   /** @param {string} id

--- a/extensions/amp-app-banner/0.1/amp-app-banner.js
+++ b/extensions/amp-app-banner/0.1/amp-app-banner.js
@@ -444,7 +444,6 @@ export class AmpAndroidAppBanner extends AbstractAppBanner {
 
     return Services.xhrFor(this.win)
       .fetchJson(this.manifestHref_, {})
-      .then(res => res.json())
       .then(json => this.parseManifest_(json))
       .catch(error => {
         this.hide_();

--- a/extensions/amp-auto-ads/0.1/amp-auto-ads.js
+++ b/extensions/amp-auto-ads/0.1/amp-auto-ads.js
@@ -134,7 +134,6 @@ export class AmpAutoAds extends AMP.BaseElement {
     };
     return Services.xhrFor(this.win)
       .fetchJson(configUrl, xhrInit)
-      .then(res => res.json())
       .catch(reason => {
         this.user().error(TAG, 'amp-auto-ads config xhr failed: ' + reason);
         return null;

--- a/extensions/amp-call-tracking/0.1/amp-call-tracking.js
+++ b/extensions/amp-call-tracking/0.1/amp-call-tracking.js
@@ -35,9 +35,9 @@ let cachedResponsePromises_ = {};
  */
 function fetch_(win, url) {
   if (!(url in cachedResponsePromises_)) {
-    cachedResponsePromises_[url] = Services.xhrFor(win)
-      .fetchJson(url, {credentials: 'include'})
-      .then(res => res.json());
+    cachedResponsePromises_[url] = Services.xhrFor(win).fetchJson(url, {
+      credentials: 'include',
+    });
   }
   return cachedResponsePromises_[url];
 }

--- a/extensions/amp-consent/0.1/amp-consent.js
+++ b/extensions/amp-consent/0.1/amp-consent.js
@@ -630,9 +630,7 @@ export class AmpConsent extends AMP.BaseElement {
         const sourceBase = getSourceUrl(ampdoc.getUrl());
         const resolvedHref = resolveRelativeUrl(href, sourceBase);
         return ampdoc.whenFirstVisible().then(() => {
-          return Services.xhrFor(this.win)
-            .fetchJson(resolvedHref, init)
-            .then(res => res.json());
+          return Services.xhrFor(this.win).fetchJson(resolvedHref, init);
         });
       });
     }

--- a/extensions/amp-pinterest/0.1/pin-widget.js
+++ b/extensions/amp-pinterest/0.1/pin-widget.js
@@ -84,16 +84,13 @@ export class PinWidget {
   fetchPin() {
     const baseUrl = 'https://widgets.pinterest.com/v3/pidgets/pins/info/?';
     const query = `pin_ids=${this.pinId}&sub=www&base_scheme=https`;
-    return this.xhr
-      .fetchJson(baseUrl + query, {})
-      .then(res => res.json())
-      .then(json => {
-        try {
-          return /** @type {JsonObject} */ (json)['data'][0];
-        } catch (e) {
-          return null;
-        }
-      });
+    return this.xhr.fetchJson(baseUrl + query, {}).then(json => {
+      try {
+        return /** @type {JsonObject} */ (json)['data'][0];
+      } catch (e) {
+        return null;
+      }
+    });
   }
 
   /**

--- a/extensions/amp-pinterest/0.1/save-button.js
+++ b/extensions/amp-pinterest/0.1/save-button.js
@@ -91,7 +91,7 @@ export class SaveButton {
    */
   fetchCount() {
     const url = `https://widgets.pinterest.com/v1/urls/count.json?return_jsonp=false&url=${this.url}`;
-    return this.xhr.fetchJson(url, {}).then(res => res.json());
+    return this.xhr.fetchJson(url, {});
   }
 
   /**

--- a/extensions/amp-share-tracking/0.1/amp-share-tracking.js
+++ b/extensions/amp-share-tracking/0.1/amp-share-tracking.js
@@ -149,7 +149,6 @@ export class AmpShareTracking extends AMP.BaseElement {
     };
     return Services.xhrFor(this.win)
       .fetchJson(vendorUrl, postReq)
-      .then(res => res.json())
       .then(
         json => {
           if (json.fragment) {

--- a/extensions/amp-skimlinks/0.1/affiliate-link-resolver.js
+++ b/extensions/amp-skimlinks/0.1/affiliate-link-resolver.js
@@ -105,7 +105,7 @@ export class AffiliateLinkResolver {
       credentials: 'include',
     };
 
-    return this.xhr_.fetchJson(beaconUrl, fetchOptions).then(res => res.json());
+    return this.xhr_.fetchJson(beaconUrl, fetchOptions);
   }
 
   /**

--- a/extensions/amp-smartlinks/0.1/amp-smartlinks.js
+++ b/extensions/amp-smartlinks/0.1/amp-smartlinks.js
@@ -133,7 +133,6 @@ export class AmpSmartlinks extends AMP.BaseElement {
           method: 'GET',
           ampCors: false,
         })
-        .then(res => res.json())
         .then(res => {
           return getData(res)[0]['amp_config'];
         });

--- a/extensions/amp-smartlinks/0.1/linkmate.js
+++ b/extensions/amp-smartlinks/0.1/linkmate.js
@@ -115,7 +115,7 @@ export class Linkmate {
       body: payload,
     };
 
-    return this.xhr_.fetchJson(fetchUrl, postOptions).then(res => res.json());
+    return this.xhr_.fetchJson(fetchUrl, postOptions);
   }
 
   /**

--- a/extensions/amp-story/0.1/amp-story-request-service.js
+++ b/extensions/amp-story/0.1/amp-story-request-service.js
@@ -66,10 +66,6 @@ export class AmpStoryRequestService {
 
     return Services.urlReplacementsForDoc(this.storyElement_)
       .expandUrlAsync(user().assertString(rawUrl))
-      .then(url => this.xhr_.fetchJson(url, opts))
-      .then(response => {
-        userAssert(response.ok, 'Invalid HTTP response');
-        return response.json();
-      });
+      .then(url => this.xhr_.fetchJson(url, opts));
   }
 }

--- a/extensions/amp-story/1.0/amp-story-request-service.js
+++ b/extensions/amp-story/1.0/amp-story-request-service.js
@@ -103,11 +103,7 @@ export class AmpStoryRequestService {
 
     return Services.urlReplacementsForDoc(this.storyElement_)
       .expandUrlAsync(user().assertString(rawUrl))
-      .then(url => this.xhr_.fetchJson(url, opts))
-      .then(response => {
-        userAssert(response.ok, 'Invalid HTTP response');
-        return response.json();
-      });
+      .then(url => this.xhr_.fetchJson(url, opts));
   }
 }
 

--- a/extensions/amp-subscriptions-google/0.1/amp-subscriptions-google.js
+++ b/extensions/amp-subscriptions-google/0.1/amp-subscriptions-google.js
@@ -568,12 +568,10 @@ class AmpFetcher {
 
   /** @override */
   fetchCredentialedJson(url) {
-    return this.xhr_
-      .fetchJson(url, {
-        credentials: 'include',
-        prerenderSafe: true,
-      })
-      .then(response => response.json());
+    return this.xhr_.fetchJson(url, {
+      credentials: 'include',
+      prerenderSafe: true,
+    });
   }
 
   /** @override */

--- a/extensions/amp-subscriptions/0.1/local-subscription-platform-remote.js
+++ b/extensions/amp-subscriptions/0.1/local-subscription-platform-remote.js
@@ -69,7 +69,6 @@ export class LocalSubscriptionRemotePlatform extends LocalSubscriptionBasePlatfo
         }
         return this.xhr_
           .fetchJson(fetchUrl, {credentials: 'include'})
-          .then(res => res.json())
           .then(resJson => {
             return Entitlement.parseFromJson(resJson);
           });

--- a/extensions/amp-user-notification/0.1/amp-user-notification.js
+++ b/extensions/amp-user-notification/0.1/amp-user-notification.js
@@ -260,7 +260,6 @@ export class AmpUserNotification extends AMP.BaseElement {
       };
       return Services.xhrFor(this.win)
         .fetchJson(href, getReq)
-        .then(res => res.json());
     });
   }
 

--- a/extensions/amp-viz-vega/0.1/amp-viz-vega.js
+++ b/extensions/amp-viz-vega/0.1/amp-viz-vega.js
@@ -169,7 +169,6 @@ export class AmpVizVega extends AMP.BaseElement {
 
       return Services.xhrFor(this.win)
         .fetchJson(dev().assertString(this.src_), {})
-        .then(res => res.json())
         .then(data => {
           this.data_ = data;
         });

--- a/src/batched-json.js
+++ b/src/batched-json.js
@@ -73,6 +73,7 @@ export function batchFetchJsonFor(
       }
       return xhr.fetchJson(data.xhrUrl, data.fetchOpt);
     })
+    // TODO(samour): convert to fetch() for now until xssiJson is combined with fetchJson.
     .then(res => Services.xhrFor(ampdoc.win).xssiJson(res, xssiPrefix))
     .then(data => {
       if (data == null) {

--- a/src/impression.js
+++ b/src/impression.js
@@ -235,17 +235,22 @@ function invoke(win, clickUrl) {
   if (getMode().localDev && !getMode().test) {
     clickUrl = 'http://localhost:8000/impression-proxy?url=' + clickUrl;
   }
-  return Services.xhrFor(win)
-    .fetchJson(clickUrl, {
-      credentials: 'include',
-    })
-    .then(res => {
-      // Treat 204 no content response specially
-      if (res.status == 204) {
-        return null;
-      }
-      return res.json();
-    });
+  return (
+    Services.xhrFor(win)
+      .fetch(
+        clickUrl,
+        Services.xhrFor(win).setupJsonFetchInit({
+          credentials: 'include',
+        })
+      )
+      .then(res => {
+        // Treat 204 no content response specially
+        if (res.status == 204) {
+          return null;
+        }
+        return res.json();
+      })
+  );
 }
 
 /**

--- a/src/service/cache-cid-api.js
+++ b/src/service/cache-cid-api.js
@@ -115,20 +115,18 @@ export class CacheCidApi {
         }),
         timeoutMessage
       )
-      .then(res => {
-        return res.json().then(response => {
-          if (response['optOut']) {
-            return null;
-          }
-          const cid = response['publisherClientId'];
-          if (!cid && useAlternate && response['alternateUrl']) {
-            // If an alternate url is provided, try again with the alternate url
-            // The client is still responsible for appending API keys to the URL.
-            const alt = `${response['alternateUrl']}?key=${SERVICE_KEY_}`;
-            return this.fetchCid_(dev().assertString(alt), false);
-          }
-          return cid;
-        });
+      .then(response => {
+        if (response['optOut']) {
+          return null;
+        }
+        const cid = response['publisherClientId'];
+        if (!cid && useAlternate && response['alternateUrl']) {
+          // If an alternate url is provided, try again with the alternate url
+          // The client is still responsible for appending API keys to the URL.
+          const alt = `${response['alternateUrl']}?key=${SERVICE_KEY_}`;
+          return this.fetchCid_(dev().assertString(alt), false);
+        }
+        return cid;
       })
       .catch(e => {
         if (e && e.response) {

--- a/src/service/cid-api.js
+++ b/src/service/cid-api.js
@@ -150,15 +150,13 @@ export class GoogleCidApi {
     }
     return this.timer_.timeoutPromise(
       TIMEOUT,
-      Services.xhrFor(this.win_)
-        .fetchJson(url, {
-          method: 'POST',
-          ampCors: false,
-          credentials: 'include',
-          mode: 'cors',
-          body: payload,
-        })
-        .then(res => res.json())
+      Services.xhrFor(this.win_).fetchJson(url, {
+        method: 'POST',
+        ampCors: false,
+        credentials: 'include',
+        mode: 'cors',
+        body: payload,
+      })
     );
   }
 

--- a/src/service/xhr-impl.js
+++ b/src/service/xhr-impl.js
@@ -127,10 +127,12 @@ export class Xhr {
    *
    * @param {string} input
    * @param {?FetchInitDef=} opt_init
-   * @return {!Promise<!Response>}
+   * @return {!Promise<!JsonObject>}
    */
   fetchJson(input, opt_init) {
-    return this.fetch(input, setupJsonFetchInit(opt_init));
+    return this.fetch(input, setupJsonFetchInit(opt_init)).then(res =>
+      res.json()
+    );
   }
 
   /**

--- a/test/unit/test-xhr.js
+++ b/test/unit/test-xhr.js
@@ -372,7 +372,6 @@ describe
           window.sandbox.stub(user(), 'assert');
           return xhr
             .fetchJson(`${baseUrl}/get?k=v1`)
-            .then(res => res.json())
             .then(res => {
               expect(res).to.exist;
               expect(res['args']['k']).to.equal('v1');
@@ -385,7 +384,6 @@ describe
             encodeURIComponent(`${baseUrl}/get?k=v2`);
           return xhr
             .fetchJson(url, {ampCors: false})
-            .then(res => res.json())
             .then(res => {
               expect(res).to.exist;
               expect(res['args']['k']).to.equal('v2');
@@ -584,7 +582,6 @@ describe
                 'Content-Type': 'application/json;charset=utf-8',
               },
             })
-            .then(res => res.json())
             .then(res => {
               expect(res.json).to.jsonEqual({
                 hello: 'world',
@@ -1166,7 +1163,7 @@ describe
       it('should not strip characters if the prefix is not present', () => {
         xhrCreated.then(mock => mock.respond(200, [], '{"a": 1}'));
         return xhr
-          .fetchJson('/abc')
+          .fetch('/abc')
           .then(res => xhr.xssiJson(res, 'while(1)'))
           .then(json => {
             expect(json).to.be.deep.equal({a: 1});
@@ -1176,7 +1173,7 @@ describe
       it('should strip prefix from the response text if prefix is present', () => {
         xhrCreated.then(mock => mock.respond(200, [], 'while(1){"a": 1}'));
         return xhr
-          .fetchJson('/abc')
+          .fetch('/abc')
           .then(res => xhr.xssiJson(res, 'while(1)'))
           .then(json => {
             expect(json).to.be.deep.equal({a: 1});


### PR DESCRIPTION
**DO NOT MERGE**
This is just an exploration into what it would mean to make `fetchJson` in the xhr service actually return `JsonObject` instead of `Response`. The thinking being that the vast majority of cases immediately call `.json()`, so why not make the few cases that require the `Response` call `.fetch(url, xhr.setupJsonOptions(...))` instead of burdening every callsite.

Will probably close this, it seems like more effort than it is worth (if even desirable).

cc @lannka.