### PR TITLE
🖍Add animation to story quiz option selection

### DIFF
--- a/extensions/amp-story/1.0/amp-story-quiz.css
+++ b/extensions/amp-story/1.0/amp-story-quiz.css
@@ -146,7 +146,7 @@ h3.i-amphtml-story-quiz-prompt {
 
 .i-amphtml-story-quiz-post-selection [correct] > .i-amphtml-story-quiz-answer-choice {
     background-color: white !important;
-    background-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" viewBox="0 0 24 24" fill="#5BBA74"><path fill="none" d="M0 0h24v24H0z"/><path d="M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z"/></svg>') !important;
+    background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24px' height='24px' viewBox='0 0 24 24' fill='%235BBA74'%3E%3Cpath fill='none' d='M0 0h24v24H0z'/%3E%3Cpath d='M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z'/%3E%3C/svg%3E") !important;
     background-repeat: no-repeat !important;
     background-position: center !important;
     font-size: 0 !important;
@@ -154,7 +154,7 @@ h3.i-amphtml-story-quiz-prompt {
 
 .i-amphtml-story-quiz-post-selection :not([correct]) > .i-amphtml-story-quiz-answer-choice {
     background-color: white !important;
-    background-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" viewBox="0 0 24 24" fill="#F34E4E"><path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"/><path d="M0 0h24v24H0z" fill="none"/></svg>') !important;
+    background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24px' height='24px' viewBox='0 0 24 24' fill='%23F34E4E'%3E%3Cpath d='M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z'/%3E%3Cpath d='M0 0h24v24H0z' fill='none'/%3E%3C/svg%3E") !important;
     background-repeat: no-repeat !important;
     background-position: center !important;
     font-size: 0 !important;

--- a/extensions/amp-story/1.0/amp-story-quiz.css
+++ b/extensions/amp-story/1.0/amp-story-quiz.css
@@ -278,12 +278,7 @@ h3.i-amphtml-story-quiz-prompt {
     }
     50% {
         opacity: 1;
-    }
-    70% {
         color: var(--correct-color);
-    }
-    71% {
-        color: white;
     }
     100% {
         border-color: var(--correct-color);
@@ -303,12 +298,7 @@ h3.i-amphtml-story-quiz-prompt {
     }
     50% {
         opacity: 1;
-    }
-    70% {
         color: var(--incorrect-color);
-    }
-    71% {
-        color: white;
     }
     100% {
         border-color: var(--incorrect-color);

--- a/extensions/amp-story/1.0/amp-story-quiz.css
+++ b/extensions/amp-story/1.0/amp-story-quiz.css
@@ -180,6 +180,14 @@ h3.i-amphtml-story-quiz-prompt {
     border: solid 1px !important;
 }
 
+/**
+ * Proper bounce animation scale values calculated in a CodePen
+ * using methodology from Medium post "Spring Animation in CSS"
+ * by Thai Pangsakulyanont.
+ *
+ * https://codepen.io/jackbsteinberg/pen/ExaZpjZ
+ * https://medium.com/@dtinth/spring-animation-in-css-2039de6e1a03
+ */
 @keyframes answer-choice-bounce {
     0% {
         visibility: hidden;

--- a/extensions/amp-story/1.0/amp-story-quiz.css
+++ b/extensions/amp-story/1.0/amp-story-quiz.css
@@ -140,7 +140,7 @@ h3.i-amphtml-story-quiz-prompt {
 }
 
 .i-amphtml-story-quiz-post-selection .i-amphtml-story-quiz-option-selected > .i-amphtml-story-quiz-answer-choice {
-    border: solid 2px transparent !important;
+    animation: answer-choice-bounce forwards 350ms cubic-bezier(0.0, 0.0, 0.2, 1);
 }
 
 /** TODO(jackbsteinberg): Use a more a11y-friendly approach than font-size: 0px; */
@@ -161,28 +161,74 @@ h3.i-amphtml-story-quiz-prompt {
     font-size: 0 !important;
 }
 
-.i-amphtml-story-quiz-option-animation {
-    position: absolute;
-    width: 100%;
-    height: 100%;
-    border-radius: 32px;
-    border: solid 1px transparent;
-    /*
-    padding: 8px 16px 8px 8px;
-    margin-bottom: 8px; */
+.i-amphtml-story-quiz-post-selection .i-amphtml-story-quiz-option-selected[correct] {
+    animation: option-select-correct forwards 150ms cubic-bezier(0.0, 0.0, 0.2, 1);
 }
 
-.i-amphtml-story-quiz-post-selection .i-amphtml-story-quiz-option-selected .i-amphtml-story-quiz-option-animation {
-    animation: scales forwards 1s ease;
+.i-amphtml-story-quiz-post-selection .i-amphtml-story-quiz-option-selected:not([correct]) {
+    animation: option-select-incorrect forwards 150ms cubic-bezier(0.0, 0.0, 0.2, 1);
 }
 
-@keyframes scales {
+.i-amphtml-story-quiz-post-selection .i-amphtml-story-quiz-option-selected .i-amphtml-story-quiz-option-text {
+    animation: keep-text-stable forwards 150ms cubic-bezier(0.0, 0.0, 0.2, 1);
+}
+
+@keyframes keep-text-stable {
     0% {
-      background: rgba(255, 0, 0, 1);
-      transform: scale(0.1);
+        color: white !important;
+        visibility: hidden;
+    }
+    80% {
+        visibility: hidden;
+    }
+    90% {
+        visibility: visible;
+    }
+}
+
+@keyframes answer-choice-bounce {
+    0% {
+        visibility: hidden;
+        border: solid 2px transparent !important;
+    }
+    40% {
+        visibility: hidden;
+    }
+    41% {
+        transform: scale(0.1);
+        visibility: visible;
+    }
+    90% {
+        transform: scale(1.1);
     }
     100% {
-      background: rgba(255, 0, 0, 1);
-      transform: scale(1);
+        border: solid 2px transparent !important;
+        transform: scale(1);
+    }
+}
+
+@keyframes option-select-correct {
+    0% {
+        border-color: var(--correct-color);
+        background: var(--correct-color);
+        transform: scale(0.1);
+    }
+    100% {
+        border-color: var(--correct-color);
+        background: var(--correct-color);
+        transform: scale(1);
+    }
+}
+
+@keyframes option-select-incorrect {
+    0% {
+        border-color: var(--incorrect-color);
+        background: var(--incorrect-color);
+        transform: scale(0.1);
+    }
+    100% {
+        border-color: var(--incorrect-color);
+        background: var(--incorrect-color);
+        transform: scale(1);
     }
 }

--- a/extensions/amp-story/1.0/amp-story-quiz.css
+++ b/extensions/amp-story/1.0/amp-story-quiz.css
@@ -169,23 +169,6 @@ h3.i-amphtml-story-quiz-prompt {
     animation: option-select-incorrect forwards 150ms cubic-bezier(0.0, 0.0, 0.2, 1);
 }
 
-.i-amphtml-story-quiz-post-selection .i-amphtml-story-quiz-option-selected .i-amphtml-story-quiz-option-text {
-    animation: keep-text-stable forwards 150ms cubic-bezier(0.0, 0.0, 0.2, 1);
-}
-
-@keyframes keep-text-stable {
-    0% {
-        color: white !important;
-        visibility: hidden;
-    }
-    50% {
-        visibility: hidden;
-    }
-    60% {
-        visibility: visible;
-    }
-}
-
 @keyframes answer-choice-bounce {
     0% {
         visibility: hidden;
@@ -213,14 +196,22 @@ h3.i-amphtml-story-quiz-prompt {
         background: var(--correct-color);
         opacity: 0.2;
         transform: scale(0.1);
+        color: var(--incorrect-color);
     }
     50% {
         opacity: 1;
+    }
+    70% {
+        color: var(--correct-color);
+    }
+    71% {
+        color: white;
     }
     100% {
         border-color: var(--correct-color);
         background: var(--correct-color);
         transform: scale(1);
+        color: white;
     }
 }
 
@@ -230,13 +221,21 @@ h3.i-amphtml-story-quiz-prompt {
         background: var(--incorrect-color);
         opacity: 0.2;
         transform: scale(0.1);
+        color: var(--incorrect-color);
     }
     50% {
         opacity: 1;
+    }
+    70% {
+        color: var(--incorrect-color);
+    }
+    71% {
+        color: white;
     }
     100% {
         border-color: var(--incorrect-color);
         background: var(--incorrect-color);
         transform: scale(1);
+        color: white;
     }
 }

--- a/extensions/amp-story/1.0/amp-story-quiz.css
+++ b/extensions/amp-story/1.0/amp-story-quiz.css
@@ -155,36 +155,35 @@ h3.i-amphtml-story-quiz-prompt {
 }
 
 .i-amphtml-story-quiz-option > * {
-    z-index: 2 !important;
+    position: relative !important;
 }
 
 .i-amphtml-story-quiz-option::before {
-    content: "";
+    content: "" !important;
     position: absolute !important;
-    top: -1 !important;
-    left: 0 !important;
+    top: -1px !important;
+    left: -1px !important;
     width: 100% !important;
     height: 100% !important;
     border-radius: 32px !important;
     font-size: 16px !important;
     line-height: 20px !important;
-    z-index: 1 !important;
 }
 
 .i-amphtml-story-quiz-post-selection .i-amphtml-story-quiz-option-selected[correct].i-amphtml-story-quiz-option::before {
-    animation: option-select-correct forwards 150ms cubic-bezier(0.0, 0.0, 0.2, 1);
+    animation: option-select-correct forwards 150ms cubic-bezier(0.0, 0.0, 0.2, 1) !important;
     border: solid 1px !important;
 }
 
 .i-amphtml-story-quiz-post-selection .i-amphtml-story-quiz-option-selected:not([correct]).i-amphtml-story-quiz-option::before {
-    animation: option-select-incorrect forwards 150ms cubic-bezier(0.0, 0.0, 0.2, 1);
+    animation: option-select-incorrect forwards 150ms cubic-bezier(0.0, 0.0, 0.2, 1) !important;
     border: solid 1px !important;
 }
 
 @keyframes answer-choice-bounce {
     0% {
         visibility: hidden;
-        border: solid 2px transparent !important;
+        border: solid 2px transparent;
         transform: scale(0);
     }
     20% {
@@ -275,7 +274,7 @@ h3.i-amphtml-story-quiz-prompt {
     98% { transform: scale(0.9992426461382049); }
     99% { transform: scale(0.9988663284742909); }
     100% { 
-        border: solid 2px white !important;
+        border: solid 2px white;
         transform: scale(1); 
     }
 }

--- a/extensions/amp-story/1.0/amp-story-quiz.css
+++ b/extensions/amp-story/1.0/amp-story-quiz.css
@@ -140,7 +140,7 @@ h3.i-amphtml-story-quiz-prompt {
 }
 
 .i-amphtml-story-quiz-post-selection .i-amphtml-story-quiz-option-selected > .i-amphtml-story-quiz-answer-choice {
-    animation: answer-choice-bounce forwards 350ms cubic-bezier(0.0, 0.0, 0.2, 1);
+    animation: answer-choice-bounce forwards 300ms cubic-bezier(0.0, 0.0, 0.2, 1);
 }
 
 /** TODO(jackbsteinberg): Use a more a11y-friendly approach than font-size: 0px; */
@@ -178,10 +178,10 @@ h3.i-amphtml-story-quiz-prompt {
         color: white !important;
         visibility: hidden;
     }
-    80% {
+    50% {
         visibility: hidden;
     }
-    90% {
+    60% {
         visibility: visible;
     }
 }
@@ -191,10 +191,10 @@ h3.i-amphtml-story-quiz-prompt {
         visibility: hidden;
         border: solid 2px transparent !important;
     }
-    40% {
+    45% {
         visibility: hidden;
     }
-    41% {
+    46% {
         transform: scale(0.1);
         visibility: visible;
     }
@@ -211,7 +211,11 @@ h3.i-amphtml-story-quiz-prompt {
     0% {
         border-color: var(--correct-color);
         background: var(--correct-color);
+        opacity: 0.2;
         transform: scale(0.1);
+    }
+    50% {
+        opacity: 1;
     }
     100% {
         border-color: var(--correct-color);
@@ -224,7 +228,11 @@ h3.i-amphtml-story-quiz-prompt {
     0% {
         border-color: var(--incorrect-color);
         background: var(--incorrect-color);
+        opacity: 0.2;
         transform: scale(0.1);
+    }
+    50% {
+        opacity: 1;
     }
     100% {
         border-color: var(--incorrect-color);

--- a/extensions/amp-story/1.0/amp-story-quiz.css
+++ b/extensions/amp-story/1.0/amp-story-quiz.css
@@ -71,12 +71,13 @@ h3.i-amphtml-story-quiz-prompt {
 }
 
 .i-amphtml-story-quiz-option {
+    position: relative !important;
     display: flex !important;
     justify-items: start !important;
     align-items: center !important;
     border-radius: 30px !important;
     padding: 8px 16px 8px 8px !important;
-    background-color: inherit !important;
+    background-color: transparent !important;
     margin-bottom: 8px !important;
     color: #5F6368 !important;
     border: solid 1px #DADCE0 !important;
@@ -130,14 +131,6 @@ h3.i-amphtml-story-quiz-prompt {
     color: var(--correct-color) !important;
 }
 
-.i-amphtml-story-quiz-post-selection .i-amphtml-story-quiz-option-selected:not([correct]) {
-    background-color: var(--incorrect-color) !important;
-}
-
-.i-amphtml-story-quiz-post-selection .i-amphtml-story-quiz-option-selected[correct] {
-    background-color: var(--correct-color) !important;
-}
-
 .i-amphtml-story-quiz-post-selection .i-amphtml-story-quiz-option-selected > .i-amphtml-story-quiz-answer-choice {
     border: solid 2px white !important;
     animation: answer-choice-bounce forwards 600ms linear;
@@ -161,12 +154,31 @@ h3.i-amphtml-story-quiz-prompt {
     font-size: 0 !important;
 }
 
-.i-amphtml-story-quiz-post-selection .i-amphtml-story-quiz-option-selected[correct] {
-    animation: option-select-correct forwards 150ms cubic-bezier(0.0, 0.0, 0.2, 1);
+.i-amphtml-story-quiz-option > * {
+    z-index: 2 !important;
 }
 
-.i-amphtml-story-quiz-post-selection .i-amphtml-story-quiz-option-selected:not([correct]) {
+.i-amphtml-story-quiz-option::before {
+    content: "";
+    position: absolute !important;
+    top: -1 !important;
+    left: 0 !important;
+    width: 100% !important;
+    height: 100% !important;
+    border-radius: 32px !important;
+    font-size: 16px !important;
+    line-height: 20px !important;
+    z-index: 1 !important;
+}
+
+.i-amphtml-story-quiz-post-selection .i-amphtml-story-quiz-option-selected[correct].i-amphtml-story-quiz-option::before {
+    animation: option-select-correct forwards 150ms cubic-bezier(0.0, 0.0, 0.2, 1);
+    border: solid 1px !important;
+}
+
+.i-amphtml-story-quiz-post-selection .i-amphtml-story-quiz-option-selected:not([correct]).i-amphtml-story-quiz-option::before {
     animation: option-select-incorrect forwards 150ms cubic-bezier(0.0, 0.0, 0.2, 1);
+    border: solid 1px !important;
 }
 
 @keyframes answer-choice-bounce {

--- a/extensions/amp-story/1.0/amp-story-quiz.css
+++ b/extensions/amp-story/1.0/amp-story-quiz.css
@@ -82,7 +82,6 @@ h3.i-amphtml-story-quiz-prompt {
     border: solid 1px #DADCE0 !important;
     font-size: 16px !important;
     line-height: 20px !important;
-    position: relative;
 }
 
 /* Truncate option text and add an ellipsis after 2 lines. */

--- a/extensions/amp-story/1.0/amp-story-quiz.css
+++ b/extensions/amp-story/1.0/amp-story-quiz.css
@@ -139,7 +139,8 @@ h3.i-amphtml-story-quiz-prompt {
 }
 
 .i-amphtml-story-quiz-post-selection .i-amphtml-story-quiz-option-selected > .i-amphtml-story-quiz-answer-choice {
-    animation: answer-choice-bounce forwards 300ms cubic-bezier(0.0, 0.0, 0.2, 1);
+    border: solid 2px white !important;
+    animation: answer-choice-bounce forwards 600ms linear;
 }
 
 /** TODO(jackbsteinberg): Use a more a11y-friendly approach than font-size: 0px; */
@@ -172,20 +173,98 @@ h3.i-amphtml-story-quiz-prompt {
     0% {
         visibility: hidden;
         border: solid 2px transparent !important;
+        transform: scale(0);
     }
-    45% {
+    20% {
         visibility: hidden;
     }
-    46% {
-        transform: scale(0.1);
-        visibility: visible;
+    21% { 
+      visibility: visible;
+      transform: scale(0.01); 
     }
-    90% {
-        transform: scale(1.1);
+    22% { 
+    transform: scale(0.013684856124433913); 
     }
-    100% {
-        border: solid 2px transparent !important;
-        transform: scale(1);
+    23% { transform: scale(0.051769509391971655); }
+    24% { transform: scale(0.10979880954474115); }
+    25% { transform: scale(0.18341305176970135); }
+    26% { transform: scale(0.2684509024266566); }
+    27% { transform: scale(0.3610325247585034); }
+    28% { transform: scale(0.45762347596723524); }
+    29% { transform: scale(0.5550803797992331); }
+    30% { transform: scale(0.6506797237526039); }
+    31% { transform: scale(0.7421313903611753); }
+    32% { transform: scale(0.8275787127008348); }
+    33% { transform: scale(0.9055869517056766); }
+    34% { transform: scale(0.9751221345284993); }
+    35% { transform: scale(1.0355221771929732); }
+    36% { transform: scale(1.0864621497121156); }
+    37% { transform: scale(1.1279154363439434); }
+    38% { transform: scale(1.1601124062343622); }
+    39% { transform: scale(1.1834980485255882); }
+    40% { transform: scale(1.1986898487351407); }
+    41% { transform: scale(1.206436996836743); }
+    42% { transform: scale(1.207581828257875); }
+    43% { transform: scale(1.2030242124007107); }
+    44% { transform: scale(1.1936894239073792); }
+    45% { transform: scale(1.1804998634975756); }
+    46% { transform: scale(1.164350840752402); }
+    47% { transform: scale(1.1460904928615012); }
+    48% { transform: scale(1.1265037925158579); }
+    49% { transform: scale(1.1063004955722653); }
+    50% { transform: scale(1.0861067949991137); }
+    51% { transform: scale(1.0664603815836224); }
+    52% { transform: scale(1.0478085631515224); }
+    53% { transform: scale(1.030509061484278); }
+    54% { transform: scale(1.0148330883076693); }
+    55% { transform: scale(1.0009702970651233); }
+    56% { transform: scale(0.9890352139507006); }
+    57% { transform: scale(0.9790747680699967); }
+    58% { transform: scale(0.9710765648274233); }
+    59% { transform: scale(0.9649775769542337); }
+    60% { transform: scale(0.960672962326338); }
+    61% { transform: scale(0.9580247553245481); }
+    62% { transform: scale(0.95687021755429); }
+    63% { transform: scale(0.9570296730184168); }
+    64% { transform: scale(0.9583136912471878); }
+    65% { transform: scale(0.9605295185305057); }
+    66% { transform: scale(0.9634866915404066); }
+    67% { transform: scale(0.9670017987172033); }
+    68% { transform: scale(0.9709023824217144); }
+    69% { transform: scale(0.9750299987781944); }
+    70% { transform: scale(0.9792424722317997); }
+    71% { transform: scale(0.9834153981228285); }
+    72% { transform: scale(0.987442959141541); }
+    73% { transform: scale(0.9912381305605557); }
+    74% { transform: scale(0.9947323549027182); }
+    75% { transform: scale(0.9978747694983578); }
+    76% { transform: scale(1.0006310705601353); }
+    77% { transform: scale(1.0029820953210673); }
+    78% { transform: scale(1.004922199815467); }
+    79% { transform: scale(1.0064575044046478); }
+    80% { transform: scale(1.0076040725187143); }
+    81% { transform: scale(1.008386080641916); }
+    82% { transform: scale(1.0088340296253053); }
+    83% { transform: scale(1.0089830392492103); }
+    84% { transform: scale(1.0088712598278986); }
+    85% { transform: scale(1.008538426762332); }
+    86% { transform: scale(1.0080245764803404); }
+    87% { transform: scale(1.007368935296965); }
+    88% { transform: scale(1.0066089864866092); }
+    89% { transform: scale(1.0057797153557928); }
+    90% { transform: scale(1.0049130273835836); }
+    91% { transform: scale(1.004037330572153); }
+    92% { transform: scale(1.0031772700147796); }
+    93% { transform: scale(1.0023536003154552); }
+    94% { transform: scale(1.0015831798389911); }
+    95% { transform: scale(1.0008790697761887); }
+    96% { transform: scale(1.0002507206086413); }
+    97% { transform: scale(0.9997042286789821); }
+    98% { transform: scale(0.9992426461382049); }
+    99% { transform: scale(0.9988663284742909); }
+    100% { 
+        border: solid 2px white !important;
+        transform: scale(1); 
     }
 }
 
@@ -195,7 +274,7 @@ h3.i-amphtml-story-quiz-prompt {
         background: var(--correct-color);
         opacity: 0.2;
         transform: scale(0.1);
-        color: var(--incorrect-color);
+        color: var(--correct-color);
     }
     50% {
         opacity: 1;

--- a/extensions/amp-story/1.0/amp-story-quiz.css
+++ b/extensions/amp-story/1.0/amp-story-quiz.css
@@ -82,6 +82,7 @@ h3.i-amphtml-story-quiz-prompt {
     border: solid 1px #DADCE0 !important;
     font-size: 16px !important;
     line-height: 20px !important;
+    position: relative;
 }
 
 /* Truncate option text and add an ellipsis after 2 lines. */
@@ -158,4 +159,30 @@ h3.i-amphtml-story-quiz-prompt {
     background-repeat: no-repeat !important;
     background-position: center !important;
     font-size: 0 !important;
+}
+
+.i-amphtml-story-quiz-option-animation {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    border-radius: 32px;
+    border: solid 1px transparent;
+    /*
+    padding: 8px 16px 8px 8px;
+    margin-bottom: 8px; */
+}
+
+.i-amphtml-story-quiz-post-selection .i-amphtml-story-quiz-option-selected .i-amphtml-story-quiz-option-animation {
+    animation: scales forwards 1s ease;
+}
+
+@keyframes scales {
+    0% {
+      background: rgba(255, 0, 0, 1);
+      transform: scale(0.1);
+    }
+    100% {
+      background: rgba(255, 0, 0, 1);
+      transform: scale(1);
+    }
 }

--- a/extensions/amp-story/1.0/amp-story-quiz.js
+++ b/extensions/amp-story/1.0/amp-story-quiz.js
@@ -210,7 +210,6 @@ export class AmpStoryQuiz extends AMP.BaseElement {
     const optionText = document.createElement('span');
     optionText.classList.add('i-amphtml-story-quiz-option-text');
     optionText.textContent = option.textContent;
-
     convertedOption.appendChild(optionText);
 
     if (option.hasAttribute('correct')) {

--- a/extensions/amp-story/1.0/amp-story-quiz.js
+++ b/extensions/amp-story/1.0/amp-story-quiz.js
@@ -211,11 +211,6 @@ export class AmpStoryQuiz extends AMP.BaseElement {
     optionText.classList.add('i-amphtml-story-quiz-option-text');
     optionText.textContent = option.textContent;
 
-    // Add the animation container
-    const animationContainer = document.createElement('div');
-    animationContainer.classList.add('i-amphtml-story-quiz-option-animation');
-    convertedOption.appendChild(animationContainer);
-
     convertedOption.appendChild(optionText);
 
     if (option.hasAttribute('correct')) {

--- a/extensions/amp-story/1.0/amp-story-quiz.js
+++ b/extensions/amp-story/1.0/amp-story-quiz.js
@@ -210,6 +210,12 @@ export class AmpStoryQuiz extends AMP.BaseElement {
     const optionText = document.createElement('span');
     optionText.classList.add('i-amphtml-story-quiz-option-text');
     optionText.textContent = option.textContent;
+
+    // Add the animation container
+    const animationContainer = document.createElement('div');
+    animationContainer.classList.add('i-amphtml-story-quiz-option-animation');
+    convertedOption.appendChild(animationContainer);
+
     convertedOption.appendChild(optionText);
 
     if (option.hasAttribute('correct')) {


### PR DESCRIPTION
Adds animation to selecting an option from an `<amp-story-quiz>` element. The animation is available to view [here](https://codepen.io/jackbsteinberg/pen/BayKzrm).

Adds work related to #25615 