### PR TITLE
🐛 Append url parameters correct in viewer-demo 

### DIFF
--- a/build-system/tasks/e2e/amp-driver.js
+++ b/build-system/tasks/e2e/amp-driver.js
@@ -57,6 +57,8 @@ const EnvironmentBehaviorMap = {
         'swipe',
         'iframeScroll',
       ];
+      // Correctly append extra params in original url
+      url = url.replace('#', '&');
       // TODO(estherkim): somehow allow non-8000 port and domain
       return (
         `http://localhost:8000/examples/viewer.html#href=${url}` +


### PR DESCRIPTION
Use case is for testing urls with amp-geo signifier (#amp-geo=de)
