### PR TITLE
Treat amp-script AMP.setState as high trust

### DIFF
--- a/extensions/amp-script/0.1/amp-script.js
+++ b/extensions/amp-script/0.1/amp-script.js
@@ -649,7 +649,14 @@ export class SanitizerImpl {
             dev().error(TAG, 'Invalid AMP.setState() argument: %s', value);
           });
           if (state) {
+            // Only evaluate updates in case of recent user interaction.
             const skipEval = !this.userActivationTracker_.isActive();
+            if (skipEval) {
+              user().warn(
+                TAG,
+                'AMP.setState only updated page state and did not reevaluate bindings due to lack of recent user interaction.'
+              );
+            }
             bind.setState(state, skipEval, /* skipAmpState */ false);
           }
         }

--- a/extensions/amp-script/0.1/amp-script.js
+++ b/extensions/amp-script/0.1/amp-script.js
@@ -202,7 +202,12 @@ export class AmpScript extends AMP.BaseElement {
         this.userActivation_.expandLongTask(promise);
         // TODO(dvoytenko): consider additional "progress" UI.
       },
-      sanitizer: new SanitizerImpl(this.win, this.element, sandboxTokens),
+      sanitizer: new SanitizerImpl(
+        this.win,
+        this.element,
+        sandboxTokens,
+        this.userActivation_
+      ),
       // Callbacks.
       onCreateWorker: data => {
         dev().info(TAG, 'Create worker:', data);
@@ -479,8 +484,9 @@ export class SanitizerImpl {
    * @param {!Window} win
    * @param {!Element} element
    * @param {!Array<string>} sandboxTokens
+   * @param {!UserActivationTracker} userActivationTracker
    */
-  constructor(win, element, sandboxTokens) {
+  constructor(win, element, sandboxTokens, userActivationTracker) {
     /** @private @const {!Window} */
     this.win_ = win;
 
@@ -492,6 +498,9 @@ export class SanitizerImpl {
 
     /** @private @const {!Object<string, boolean>} */
     this.allowedTags_ = getAllowedTags();
+
+    /** @private @const {!UserActivationTracker} */
+    this.userActivationTracker_ = userActivationTracker;
 
     // TODO(choumx): Support opt-in for variable substitutions.
     // For now, only allow built-in AMP components except amp-pixel.
@@ -640,7 +649,8 @@ export class SanitizerImpl {
             dev().error(TAG, 'Invalid AMP.setState() argument: %s', value);
           });
           if (state) {
-            bind.setState(state, /* skipEval */ true, /* skipAmpState */ false);
+            const skipEval = !this.userActivationTracker_.isActive();
+            bind.setState(state, skipEval, /* skipAmpState */ false);
           }
         }
       });

--- a/extensions/amp-script/0.1/test/unit/test-amp-script.js
+++ b/extensions/amp-script/0.1/test/unit/test-amp-script.js
@@ -253,7 +253,7 @@ describe('SanitizerImpl', () => {
 
   beforeEach(() => {
     win = new FakeWindow();
-    s = new SanitizerImpl(win, /* element */ null, []);
+    s = new SanitizerImpl(win, /* element */ null, [], {});
     el = win.document.createElement('div');
   });
 
@@ -436,8 +436,9 @@ describe('SanitizerImpl', () => {
       window.sandbox.stub(Services, 'bindForDocOrNull').resolves(bind);
     });
 
-    it('AMP.setState(json)', async () => {
+    it('AMP.setState(json), without user interaction', async () => {
       window.sandbox.spy(bind, 'setState');
+      s.userActivationTracker_.isActive = () => false;
 
       await s.setStorage(
         StorageLocation.AMP_STATE,
@@ -447,6 +448,20 @@ describe('SanitizerImpl', () => {
 
       expect(bind.setState).to.be.calledOnce;
       expect(bind.setState).to.be.calledWithExactly({foo: 'bar'}, true, false);
+    });
+
+    it('AMP.setState(json), with user interaction', async () => {
+      window.sandbox.spy(bind, 'setState');
+      s.userActivationTracker_.isActive = () => true;
+
+      await s.setStorage(
+        StorageLocation.AMP_STATE,
+        /* key */ null,
+        '{"foo":"bar"}'
+      );
+
+      expect(bind.setState).to.be.calledOnce;
+      expect(bind.setState).to.be.calledWithExactly({foo: 'bar'}, false, false);
     });
 
     it('AMP.setState(not_json)', async () => {

--- a/extensions/amp-script/amp-script.md
+++ b/extensions/amp-script/amp-script.md
@@ -141,7 +141,7 @@ Under the hood, `amp-script` uses [@ampproject/worker-dom](https://github.com/am
 
 `amp-script` supports getting and setting [`amp-state`](https://amp.dev/documentation/components/amp-bind/#initializing-state-with-amp-state) JSON via JavaScript.
 
-This enables advanced interactions between `amp-script` and other AMP elements on the page via `amp-bind` [bindings](https://amp.dev/documentation/components/amp-bind/#bindings). Currently, invoking `AMP.setState()` from `amp-script` will only implicitly update state without mutating the DOM (similar to [`amp-state` initialization](https://amp.dev/documentation/examples/components/amp-bind/?referrer=ampbyexample.com#initializing-state)) &mdash; work is planned to allow mutations from `AMP.setState()` triggered by user gesture ([#24862](https://github.com/ampproject/amphtml/issues/24862)).
+This enables advanced interactions between `amp-script` and other AMP elements on the page via `amp-bind` [bindings](https://amp.dev/documentation/components/amp-bind/#bindings). Invoking `AMP.setState()` from `amp-script` may cause mutations to the DOM as long as it was triggered by user gesture, otherwise it will only implicitly set state (similar to [`amp-state` initialization](https://amp.dev/documentation/examples/components/amp-bind/?referrer=ampbyexample.com#initializing-state)).
 
 [tip type="default"]
 `AMP.setState()` requires the [`amp-bind`](https://amp.dev/documentation/components/amp-bind) extension script to be included in the document head.

--- a/test/unit/test-validator-integration.js
+++ b/test/unit/test-validator-integration.js
@@ -65,7 +65,7 @@ describes.fakeWin('validator-integration', {}, env => {
       loadScript(win.document, 'http://example.com');
 
       expect(loadScriptStub).calledWith(
-        env.sandbox.match(el => el.nonce === '123')
+        env.sandbox.match(el => el.getAttribute('nonce') === '123')
       );
     });
   });


### PR DESCRIPTION
**summary**
Addresses https://github.com/ampproject/amphtml/issues/24862

With this change, we allow all `AMP.setState` calls triggered within an amp-script to cause bind reevaluations as long as there was a recent (5s) user interaction.

**open question**
1. Is 5 seconds too long of a user interaction window? If so, how short should it be?

cc @choumx / @jridgewell 