### PR TITLE
Change progress bar resize delay.

### DIFF
--- a/extensions/amp-story/1.0/progress-bar.js
+++ b/extensions/amp-story/1.0/progress-bar.js
@@ -197,7 +197,7 @@ export class ProgressBar {
     );
 
     Services.viewportForDoc(this.ampdoc_).onResize(
-      debounce(this.win_, () => this.onResize_(), 30)
+      debounce(this.win_, () => this.onResize_(), 300)
     );
 
     this.segmentsAddedPromise_.then(() => {


### PR DESCRIPTION
Not a big deal since people can't resize their phone, but when developers enable the responsive mode from the devtools the sidebar doesn't update correctly.

A better fix would be for the progress bar to be an AMP component, so we could listen for `onMeasureChanged` callbacks.