### PR TITLE
🐛 Fix simple-object-destructure transform for check-types

### DIFF
--- a/build-system/babel-plugins/babel-plugin-transform-simple-object-destructure/index.js
+++ b/build-system/babel-plugins/babel-plugin-transform-simple-object-destructure/index.js
@@ -37,7 +37,11 @@ module.exports = function(babel) {
     const properties = path.get('properties');
     for (const prop of properties) {
       const {key, value, computed} = prop.node;
-      const member = t.memberExpression(t.cloneWithoutLoc(from), key, computed);
+      const member = t.memberExpression(
+        t.cloneWithoutLoc(from),
+        key,
+        computed || !t.isIdentifier(key)
+      );
       let expression = member;
       let newValue = value;
       if (t.isAssignmentPattern(value)) {

--- a/build-system/babel-plugins/babel-plugin-transform-simple-object-destructure/test/fixtures/transform/computed-keys/input.js
+++ b/build-system/babel-plugins/babel-plugin-transform-simple-object-destructure/test/fixtures/transform/computed-keys/input.js
@@ -1,0 +1,23 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+function func() {
+  const {
+    [axisName]: value,
+    [axisName + 'Min']: min = 0,
+    [axisName + 'Max']: max = Math.PI * 2,
+  } = args;
+}

--- a/build-system/babel-plugins/babel-plugin-transform-simple-object-destructure/test/fixtures/transform/computed-keys/options.json
+++ b/build-system/babel-plugins/babel-plugin-transform-simple-object-destructure/test/fixtures/transform/computed-keys/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["../../../../../babel-plugin-transform-simple-object-destructure"]
+}

--- a/build-system/babel-plugins/babel-plugin-transform-simple-object-destructure/test/fixtures/transform/computed-keys/output.js
+++ b/build-system/babel-plugins/babel-plugin-transform-simple-object-destructure/test/fixtures/transform/computed-keys/output.js
@@ -1,0 +1,23 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+function func() {
+  const _args = args,
+  value = _args[axisName],min = _args[
+  axisName + 'Min'] === void 0 ? 0 : _args[axisName + 'Min'],max = _args[
+  axisName + 'Max'] === void 0 ? Math.PI * 2 : _args[axisName + 'Max'],_foo = void 0;
+
+}

--- a/build-system/babel-plugins/babel-plugin-transform-simple-object-destructure/test/fixtures/transform/non-identifier-keys/input.js
+++ b/build-system/babel-plugins/babel-plugin-transform-simple-object-destructure/test/fixtures/transform/non-identifier-keys/input.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+function string() {
+  const obj = {};
+  let {'foo': bar} = obj;
+  let {'foo': baz} = get();
+}
+
+function number() {
+  const obj = {};
+  let {0: bar} = obj;
+  let {0: baz} = get();
+}

--- a/build-system/babel-plugins/babel-plugin-transform-simple-object-destructure/test/fixtures/transform/non-identifier-keys/options.json
+++ b/build-system/babel-plugins/babel-plugin-transform-simple-object-destructure/test/fixtures/transform/non-identifier-keys/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["../../../../../babel-plugin-transform-simple-object-destructure"]
+}

--- a/build-system/babel-plugins/babel-plugin-transform-simple-object-destructure/test/fixtures/transform/non-identifier-keys/output.js
+++ b/build-system/babel-plugins/babel-plugin-transform-simple-object-destructure/test/fixtures/transform/non-identifier-keys/output.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+function string() {
+  const obj = {};
+  let bar = obj['foo'],_foo = void 0;
+  let _get = get(),baz = _get['foo'],_foo2 = void 0;
+}
+
+function number() {
+  const obj = {};
+  let bar = obj[0],_foo3 = void 0;
+  let _get2 = get(),baz = _get2[0],_foo4 = void 0;
+}

--- a/test/unit/test-validator-integration.js
+++ b/test/unit/test-validator-integration.js
@@ -65,7 +65,7 @@ describes.fakeWin('validator-integration', {}, env => {
       loadScript(win.document, 'http://example.com');
 
       expect(loadScriptStub).calledWith(
-        env.sandbox.match(el => el.nonce === '123')
+        env.sandbox.match(el => el.getAttribute('nonce') === '123')
       );
     });
   });


### PR DESCRIPTION
We need to use computed keys when the key is a quoted key or a numeric key. Also adds tests for computed keys.

Necessary for #25969.