### PR TITLE
SwG Release 0.1.22.86

### DIFF
--- a/third_party/subscriptions-project/config.js
+++ b/third_party/subscriptions-project/config.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/** Version: 0.1.22.85 */
+/** Version: 0.1.22.86 */
 /**
  * Copyright 2018 The Subscribe with Google Authors. All Rights Reserved.
  *

--- a/third_party/subscriptions-project/swg.js
+++ b/third_party/subscriptions-project/swg.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/** Version: 0.1.22.85 */
+/** Version: 0.1.22.86 */
 /**
  * Copyright 2018 The Subscribe with Google Authors. All Rights Reserved.
  *
@@ -4251,6 +4251,18 @@ function tryParseJson(json, onFailed) {
 }
 
 /**
+ * Converts the passed string into a JSON object (if possible) and returns the
+ * value of the propertyName on that object.
+ * @param {string} jsonString
+ * @param {string} propertyName
+ * @return {*}
+ */
+function getPropertyFromJsonString(jsonString, propertyName) {
+  const json = tryParseJson(jsonString);
+  return (json && json[propertyName]) || null;
+}
+
+/**
  * Copyright 2018 The Subscribe with Google Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -4577,6 +4589,19 @@ class Entitlement {
       ? /** @type {!Array<Object>} */ (json)
       : [json];
     return jsonList.map(json => Entitlement.parseFromJson(json));
+  }
+
+  /**
+   * Returns the SKU associated with this entitlement.
+   * @return {?string}
+   */
+  getSku() {
+    return (
+      /** @type {?string} */ (getPropertyFromJsonString(
+        this.subscriptionToken,
+        'productId'
+      ) || null)
+    );
   }
 }
 
@@ -5398,7 +5423,7 @@ function feCached(url) {
  */
 function feArgs(args) {
   return Object.assign(args, {
-    '_client': 'SwG 0.1.22.85',
+    '_client': 'SwG 0.1.22.86',
   });
 }
 
@@ -5442,6 +5467,7 @@ function cacheParam(cacheKey) {
  *
  * In other words, Flow = Payments + Account Creation.
  */
+
 /**
  * String values input by the publisher are mapped to the number values.
  * @type {!Object<string, number>}
@@ -5522,6 +5548,7 @@ class PayStartFlow {
     this.recurrenceEnum = 0;
     if (this.subscriptionRequest_.oneTime) {
       this.recurrenceEnum = RecurrenceMapping['ONE_TIME'];
+      delete this.subscriptionRequest_.oneTime;
     }
   }
 
@@ -5541,7 +5568,7 @@ class PayStartFlow {
     }
 
     if (this.recurrenceEnum) {
-      swgPaymentRequest.oneTime = this.recurrenceEnum;
+      swgPaymentRequest.paymentRecurrence = this.recurrenceEnum;
     }
 
     // Start/cancel events.
@@ -5812,8 +5839,9 @@ function validatePayResponse(deps, payPromise, completeHandler) {
 function parseSubscriptionResponse(deps, data, completeHandler) {
   let swgData = null;
   let raw = null;
-  let productType = null;
+  let productType = ProductType.SUBSCRIPTION;
   let oldSku = null;
+
   if (data) {
     if (typeof data == 'string') {
       raw = /** @type {string} */ (data);
@@ -5821,21 +5849,18 @@ function parseSubscriptionResponse(deps, data, completeHandler) {
       // Assume it's a json object in the format:
       // `{integratorClientCallbackData: "..."}` or `{swgCallbackData: "..."}`.
       const json = /** @type {!Object} */ (data);
-      if ('productType' in data) {
-        productType = data['productType'];
-      }
       if ('swgCallbackData' in json) {
         swgData = /** @type {!Object} */ (json['swgCallbackData']);
       } else if ('integratorClientCallbackData' in json) {
         raw = json['integratorClientCallbackData'];
       }
-      if ('swgRequest' in data) {
-        oldSku = data['swgRequest']['oldSku'] || null;
+      if ('paymentRequest' in data) {
+        oldSku = (data['paymentRequest']['swg'] || {})['oldSku'];
+        productType =
+          (data['paymentRequest']['i'] || {})['productType'] ||
+          ProductType.SUBSCRIPTION;
       }
     }
-  }
-  if (!productType) {
-    productType = ProductType.SUBSCRIPTION;
   }
   if (raw && !swgData) {
     raw = atob(raw);
@@ -5901,8 +5926,12 @@ function parseEntitlements(deps, swgData) {
  * @return {?string}
  */
 function parseSkuFromPurchaseDataSafe(purchaseData) {
-  const json = tryParseJson(purchaseData.raw);
-  return (json && json['productId']) || null;
+  return (
+    /** @type {?string} */ (getPropertyFromJsonString(
+      purchaseData.raw,
+      'productId'
+    ) || null)
+  );
 }
 
 /**
@@ -6019,8 +6048,8 @@ class OffersFlow {
       }
     }
 
-    /** @private @const {!string} */
-    this.skus_ = (feArgsObj['skus'] || []).join(',') || ALL_SKUS;
+    /** @private  @const {!Array<!string>} */
+    this.skus_ = feArgsObj['skus'] || [ALL_SKUS];
 
     /** @private @const {!ActivityIframeView} */
     this.activityIframeView_ = new ActivityIframeView(
@@ -6094,7 +6123,11 @@ class OffersFlow {
     if (this.activityIframeView_) {
       // So no error if skipped to payment screen.
       // Start/cancel events.
-      this.deps_.callbacks().triggerFlowStarted(SubscriptionFlows.SHOW_OFFERS);
+      // The second parameter is required by Propensity in AMP.
+      this.deps_.callbacks().triggerFlowStarted(SubscriptionFlows.SHOW_OFFERS, {
+        skus: this.skus_,
+        source: 'SwG',
+      });
       this.activityIframeView_.onCancel(() => {
         this.deps_
           .callbacks()
@@ -6116,7 +6149,7 @@ class OffersFlow {
       this.eventManager_.logSwgEvent(
         AnalyticsEvent.IMPRESSION_OFFERS,
         null,
-        getEventParams$1(this.skus_)
+        getEventParams$1(this.skus_.join(','))
       );
 
       return this.dialogManager_.openView(this.activityIframeView_);
@@ -6510,7 +6543,7 @@ class ActivityPorts$1 {
         'analyticsContext': context.toArray(),
         'publicationId': pageConfig.getPublicationId(),
         'productId': pageConfig.getProductId(),
-        '_client': 'SwG 0.1.22.85',
+        '_client': 'SwG 0.1.22.86',
       },
       args || {}
     );
@@ -7243,7 +7276,7 @@ class AnalyticsService {
     if (source) {
       this.context_.setUtmSource(source);
     }
-    this.context_.setClientVersion('SwG 0.1.22.85');
+    this.context_.setClientVersion('SwG 0.1.22.86');
     this.addLabels(getOnExperiments(this.doc_.getWin()));
   }
 
@@ -10116,12 +10149,6 @@ const ExperimentFlags = {
    * Cleanup issue: #406.
    */
   GPAY_API: 'gpay-api',
-
-  /**
-   * Enables GPay native support.
-   * Cleanup issue: #441.
-   */
-  GPAY_NATIVE: 'gpay-native',
 
   /**
    * Enables the feature that allows you to replace one subscription
@@ -14490,7 +14517,7 @@ function isNativeDisabledInRequest(request) {
 
 const PAY_REQUEST_ID = 'swg-pay';
 const GPAY_ACTIVITY_REQUEST$1 = 'GPAY';
-
+const REDIRECT_DELAY = 500;
 const REDIRECT_STORAGE_KEY = 'subscribe.google.com:rk';
 
 /**
@@ -14611,6 +14638,25 @@ class PayClientBindingSwg {
 
   /** @override */
   start(paymentRequest, options) {
+    if (options.forceRedirect) {
+      // This resolves an issue with logging where the page redirects before
+      // logs get sent to the server.  Ultimately we need a logging promise to
+      // resolve prior to redirecting but that is not possible right now.
+      const start = this.start_.bind(this);
+      this.win_.setTimeout(
+        () => start(paymentRequest, options),
+        REDIRECT_DELAY
+      );
+    } else {
+      this.start_(paymentRequest, options);
+    }
+  }
+
+  /**
+   * @param {!Object} paymentRequest
+   * @param {!PayOptionsDef} options
+   */
+  start_(paymentRequest, options) {
     const opener = this.activityPorts_.open(
       GPAY_ACTIVITY_REQUEST$1,
       payUrl(),
@@ -14692,6 +14738,9 @@ class PayClientBindingPayjs {
     /** @private {?function(!Promise<!Object>)} */
     this.responseCallback_ = null;
 
+    /** @private {?Object} */
+    this.request_ = null;
+
     /** @private {?Promise<!Object>} */
     this.response_ = null;
 
@@ -14740,6 +14789,8 @@ class PayClientBindingPayjs {
 
   /** @override */
   start(paymentRequest, options) {
+    this.request_ = paymentRequest;
+
     if (options.forceRedirect) {
       paymentRequest = Object.assign(paymentRequest, {
         'forceRedirect': options.forceRedirect || false,
@@ -14750,16 +14801,22 @@ class PayClientBindingPayjs {
       'disableNative',
       // The page cannot be iframed at this time. May be relaxed later
       // for AMP and similar contexts.
-      this.win_ != this.top_() ||
-        // Experiment must be enabled.
-        !isExperimentOn(this.win_, ExperimentFlags.GPAY_NATIVE)
+      this.win_ != this.top_()
     );
     // Notice that the callback for verifier may execute asynchronously.
     this.redirectVerifierHelper_.useVerifier(verifier => {
       if (verifier) {
         setInternalParam(paymentRequest, 'redirectVerifier', verifier);
       }
-      this.client_.loadPaymentData(paymentRequest);
+      if (options.forceRedirect) {
+        const client = this.client_;
+        this.win_.setTimeout(
+          () => client.loadPaymentData(paymentRequest),
+          REDIRECT_DELAY
+        );
+      } else {
+        this.client_.loadPaymentData(paymentRequest);
+      }
     });
   }
 
@@ -14770,7 +14827,7 @@ class PayClientBindingPayjs {
     if (response) {
       Promise.resolve().then(() => {
         if (response) {
-          callback(this.convertResponse_(response));
+          callback(this.convertResponse_(response, this.request_));
         }
       });
     }
@@ -14783,22 +14840,37 @@ class PayClientBindingPayjs {
   handleResponse_(responsePromise) {
     this.response_ = responsePromise;
     if (this.responseCallback_) {
-      this.responseCallback_(this.convertResponse_(this.response_));
+      this.responseCallback_(
+        this.convertResponse_(this.response_, this.request_)
+      );
     }
   }
 
   /**
    * @param {!Promise<!Object>} response
+   * @param {?Object} request
    * @return {!Promise<!Object>}
    * @private
    */
-  convertResponse_(response) {
-    return response.catch(reason => {
-      if (typeof reason == 'object' && reason['statusCode'] == 'CANCELED') {
-        return Promise.reject(createCancelError(this.win_));
-      }
-      return Promise.reject(reason);
-    });
+  convertResponse_(response, request) {
+    return response
+      .then(
+        // Temporary client side solution to remember the
+        // input params. TODO: Remove this once server-side
+        // input preservation is done and is part of the response.
+        res => {
+          if (request) {
+            res['paymentRequest'] = request;
+          }
+          return res;
+        }
+      )
+      .catch(reason => {
+        if (typeof reason == 'object' && reason['statusCode'] == 'CANCELED') {
+          return Promise.reject(createCancelError(this.win_));
+        }
+        return Promise.reject(reason);
+      });
   }
 
   /**
@@ -15873,7 +15945,20 @@ class ConfiguredRuntime {
   getEntitlements(encryptedDocumentKey) {
     return this.entitlementsManager_
       .getEntitlements(encryptedDocumentKey)
-      .then(entitlements => entitlements.clone());
+      .then(entitlements => {
+        // Auto update internal things tracking the user's current SKU.
+        if (entitlements) {
+          try {
+            const skus = entitlements.entitlements.map(
+              entitlement => entitlement.getSku() || 'unknown subscriptionToken'
+            );
+            if (skus.length > 0) {
+              this.analyticsService_.setSku(skus.join(','));
+            }
+          } catch (ex) {}
+        }
+        return entitlements.clone();
+      });
   }
 
   /** @override */


### PR DESCRIPTION
  - Delay Redirect so Logging Can Finish (#891)
  - Update dependency rollup to v1.27.13 (#889)
  - Update dependency eslint-plugin-prettier to v3.1.2 (#890)
  - Update travis image to the default dist Xenial because Trusty is EOL … (#888)
  - Clean up gpay_native experiment. (#886)
  - Pause after switching iframe and window. (#887)
  - Update dependency rollup to v1.27.12 (#885)
  - Revert the revert for paymentRequest. (#884)
  - Make unit and e2e tests jobs run parallel in Travis (#883)
  - Revert "Preserve paymentRequest locally." (#882)
  - Preserve paymentRequest locally. (#878)
  - Add wait before switching iframe. This will stabilize the e2e tests. (#881)
  - Add waitForElementPresent statements before interacting with DOM (#880)
  - Send offers to flow (#876)
  - Make it easier to get an SKU from entitlements (#853)
  - Update dependency rollup to v1.27.11 (#879)
  - Add a e2e for scenic amp page. More assertions will be added in follo… (#873)
  - Update dependency rollup to v1.27.10 (#874)
  - Update dependency nodemon to v2.0.2 (#875)
  - lint build-system/ (#871)
  - Change so Contribution's one-time feature is understandable by Pay (#870)
  - Update dependency gulp-nightwatch to v1.2.0 (#869)
  - ♻️ Refactors runtime.js a bit for readability + fixes a few tests (#862)
  - 🏗 Fixes `gulp changelog` (#868)
  - ✅ Standardizes a test name (#867)
