### PR TITLE
Session stitching creating multiple CIDs 

### DIFF
--- a/src/service/cid-impl.js
+++ b/src/service/cid-impl.js
@@ -404,16 +404,16 @@ function getOrCreateCookie(cid, getCidStruct, persistenceConsent) {
     return /** @type {!Promise<?string>} */ (Promise.resolve(null));
   }
 
-  if (cid.externalCidCache_[scope]) {
-    return /** @type {!Promise<?string>} */ (cid.externalCidCache_[scope]);
-  }
-
   if (existingCookie) {
     // If we created the cookie, update it's expiration time.
     if (/^amp-/.test(existingCookie)) {
       setCidCookie(win, cookieName, existingCookie);
     }
     return /** @type {!Promise<?string>} */ (Promise.resolve(existingCookie));
+  }
+
+  if (cid.externalCidCache_[scope]) {
+    return /** @type {!Promise<?string>} */ (cid.externalCidCache_[scope]);
   }
 
   const newCookiePromise = getRandomString64(win)

--- a/test/manual/test-manual-cid.html
+++ b/test/manual/test-manual-cid.html
@@ -1,0 +1,214 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>AMP CID Analytics Test</title>
+  <link rel="canonical" href="amps.html" >
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <link href='https://fonts.googleapis.com/css?family=Georgia|Open+Sans|Roboto' rel='stylesheet' type='text/css'>
+
+  <style amp-custom>
+    body {
+      margin: 0;
+      font-family: 'Georgia', Serif;
+    }
+
+    .brand-logo {
+      font-family: 'Open Sans';
+    }
+
+    .ad-container {
+      display: flex;
+      justify-content: center;
+    }
+
+    .content-container p {
+      line-height: 24px;
+    }
+
+    header,
+    .article-body {
+      padding: 15px;
+    }
+
+    .full-bleed {
+      margin: 0 -15px;
+    }
+
+    figure {
+      margin: 0;
+    }
+
+    figcaption {
+      color: #6f757a;
+      padding: 15px 0;
+      font-size: .9em;
+    }
+
+    .author {
+      display: flex;
+      align-items: center;
+
+      background: #f4f4f4;
+      padding: 0 15px;
+
+      font-size: .8em;
+
+      border: solid #dcdcdc;
+      border-width: 1px 0;
+    }
+
+    .header-time {
+      color: #a8a3ae;
+      font-family: 'Roboto';
+      font-size: 12px;
+    }
+
+    .author p {
+      margin: 5px;
+    }
+
+    .byline {
+      font-family: 'Roboto';
+      display: inline-block;
+    }
+
+    .byline p {
+      line-height: normal;
+    }
+
+    .byline .brand {
+      color: #6f757a;
+    }
+
+    .standfirst {
+      color: #6f757a;
+    }
+
+    .mailto {
+      text-decoration: none;
+    }
+
+    #author-avatar {
+      margin: 10px;
+      border: 5px solid #fff;
+      width: 50px;
+      height: 50px;
+      border-radius: 50%;
+    }
+
+    h1 {
+      margin: 5px 0;
+      font-weight: normal;
+    }
+
+    footer {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      height: 226px;
+      background: #f4f4f4;
+    }
+
+    amp-consent {
+      min-height: 30px;
+      font-family: 'Roboto';
+      font-weight: 500;
+      line-height: 30px;
+      padding: 8px;
+      background: #46b6ac;
+    }
+
+    amp-consent button {
+      border: none;
+      border-radius: 2px;
+
+      color: #fafafa;
+      height: 26px;
+      min-width: 32px;
+      padding: 0 16px;
+      margin: 0 16px;
+      text-transform: uppercase;
+      letter-spacing: 0;
+      cursor: pointer;
+      vertical-align: middle;
+      line-height: 26px;
+      text-align: center;
+      background: #3f51b5;
+    }
+
+    hr {
+      margin: 0;
+    }
+  </style>
+  <script async custom-element="amp-geo" src="https://cdn.ampproject.org/v0/amp-geo-0.1.js"></script>
+  <script async custom-element="amp-ad" src="https://cdn.ampproject.org/v0/amp-ad-0.1.js"></script>
+  <script async custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+</head>
+<script>
+    console.log('Inside script: ')
+    document.cookie.split(";").forEach(function(c) { document.cookie = c.replace(/^ +/, "").replace(/=.*/, "=;expires=" + new Date().toUTCString() + ";path=/"); });
+    console.log("   " + document.cookie);
+    document.cookie='_ga=GA1.2.12345.54321';
+    console.log("   " + document.cookie);
+</script>
+
+<body>
+  <p>This AMP page has <code>amp-analytics</code> tags in the following order:</p>
+  <ol>
+    <li><code>&lt;amp-analytics id="example_collect"&gt;</code></li>
+    <li><code>&lt;amp-analytics type="googleanalytics" id="ga_collect"&gt;</code></li>
+  </ol>
+
+  <!-- Create a _ga cookie  ga('create', 'UA-XXXXX-Y', 'blog.example.co.uk');  -->
+  
+  <amp-analytics id="example_collect">
+      <script type="application/json">
+        {
+          "transport": {
+            "beacon": false,
+            "xhrpost": false,
+            "image": true
+          },
+          "requests": {
+            "pageview": "https://example.com/i.gif?"
+          },
+          "triggers": {
+            "defaultPageview": {
+              "on": "visible",
+              "request": "pageview",
+              "extraUrlParams": {
+                "vid": "CLIENT_ID(AMP_ECID_GOOGLE)"
+              }
+            }
+          }
+        }
+      </script>
+    </amp-analytics>
+  
+    <amp-analytics type="googleanalytics" id="ga_collect">
+      <script type="application/json">
+        {
+          "vars": {
+            "account": "UA-000000-1"
+          },
+          "linkers": {
+              "enabled": true,
+              "proxyOnly": false,
+              "destinationDomains": [
+                  "example.com"
+              ]
+          },
+          "triggers": {
+              "trackPageview": {
+                "on": "visible",
+                "request": "pageview"
+              }
+          }
+        }
+      </script>
+    </amp-analytics>
+</body>
+</html>


### PR DESCRIPTION
Scenario: 
GA created _ga browser cookie, and the googleanalytics analytics config is expected to pick it up in the CID (which is configured like this `CLIENT_ID(AMP_ECID_GOOGLE,,_ga)`. 

However, if there is a analytics trigger before it that has `CLIENT_ID(AMP_ECID_GOOGLE)`, this will create a new cookie for AMP_ECID_GOOGLE and then this new cookie will be picked up by googleanalytics.

Fix would be default to the _ga cookie before AMP_ECID_GOOGLE cookie.

