### PR TITLE
Remove 'canary' perf experiment

### DIFF
--- a/src/service/performance-impl.js
+++ b/src/service/performance-impl.js
@@ -231,9 +231,7 @@ export class Performance {
 
     // Add RTV version as experiment ID, so we can slice the data by version.
     this.addEnabledExperiment('rtv-' + getMode(this.win).rtvVersion);
-    if (isCanary(this.win)) {
-      this.addEnabledExperiment('canary');
-    }
+
     // Tick document ready event.
     whenDocumentReady(win.document).then(() => {
       this.tick('dr');

--- a/src/service/performance-impl.js
+++ b/src/service/performance-impl.js
@@ -21,7 +21,6 @@ import {dev} from '../log';
 import {dict, map} from '../utils/object';
 import {getMode} from '../mode';
 import {getService, registerServiceBuilder} from '../service';
-import {isCanary} from '../experiments';
 import {isStoryDocument} from '../utils/story';
 import {layoutRectLtwh} from '../layout-rect';
 import {throttle} from '../utils/rate-limit';


### PR DESCRIPTION
Reverts #8142. 

Is this still useful? I find it confusing since "is canary" is already baked into our RTV scheme. Removing this would also simplify our latency dashboards.

/to @lannka @dvoytenko 