### PR TITLE
🐛 Fix `gulp changelog`

### DIFF
--- a/build-system/tasks/changelog.js
+++ b/build-system/tasks/changelog.js
@@ -164,7 +164,7 @@ function getLastGitTag(gitMetadata) {
   const command = 'git describe --tags --abbrev=0';
 
   return exec(command).then(lastTag => {
-    gitMetadata.baseTag = lastTag.trim();
+    gitMetadata.baseTag = lastTag.stdout.trim();
     return gitMetadata;
   });
 }
@@ -183,7 +183,7 @@ function getCurrentBranchName(gitMetadata) {
   const command = 'git rev-parse --abbrev-ref HEAD';
 
   return exec(command).then(branchName => {
-    gitMetadata.branch = branchName.trim();
+    gitMetadata.branch = branchName.stdout.trim();
     return gitMetadata;
   });
 }


### PR DESCRIPTION
This PR fixes the following error in `gulp changelog`.

```
lastTag.trim is not a function
```

The error appears because `exec` returns an object containing two fields: `stdout` and `stderr`. The error can be traced back to the migration from `bluebird` promises to `util.promisify` done in #25822.