### PR TITLE
🐛Fix test failure

### DIFF
--- a/test/unit/test-performance.js
+++ b/test/unit/test-performance.js
@@ -1233,12 +1233,10 @@ describes.realWin('PeformanceObserver metrics', {amp: true}, env => {
       expect(fakeWin.document.visibilityState).to.equal('visible');
 
       // Fake layoutJank that occured before the Performance service is started.
-      fakeWin.performance.getEntriesByType
-        .withArgs('layoutJank')
-        .returns([
-          {entryType: 'layoutJank', fraction: 0.25},
-          {entryType: 'layoutJank', fraction: 0.3},
-        ]);
+      fakeWin.performance.getEntriesByType.withArgs('layoutJank').returns([
+        {entryType: 'layoutJank', fraction: 0.25},
+        {entryType: 'layoutJank', fraction: 0.3},
+      ]);
 
       const perf = getPerformance();
       // visibilitychange/beforeunload listeners are now added.
@@ -1290,12 +1288,10 @@ describes.realWin('PeformanceObserver metrics', {amp: true}, env => {
         .returns(false);
 
       // Fake layoutJank that occured before the Performance service is started.
-      fakeWin.performance.getEntriesByType
-        .withArgs('layoutJank')
-        .returns([
-          {entryType: 'layoutJank', fraction: 0.25},
-          {entryType: 'layoutJank', fraction: 0.3},
-        ]);
+      fakeWin.performance.getEntriesByType.withArgs('layoutJank').returns([
+        {entryType: 'layoutJank', fraction: 0.25},
+        {entryType: 'layoutJank', fraction: 0.3},
+      ]);
       const perf = getPerformance();
       perf.coreServicesAvailable();
       viewerVisibilityState = VisibilityState.INACTIVE;
@@ -1347,12 +1343,10 @@ describes.realWin('PeformanceObserver metrics', {amp: true}, env => {
       expect(fakeWin.document.visibilityState).to.equal('visible');
 
       // Fake layoutShift that occured before the Performance service is started.
-      fakeWin.performance.getEntriesByType
-        .withArgs('layoutShift')
-        .returns([
-          {entryType: 'layoutShift', value: 0.25},
-          {entryType: 'layoutShift', value: 0.3},
-        ]);
+      fakeWin.performance.getEntriesByType.withArgs('layoutShift').returns([
+        {entryType: 'layoutShift', value: 0.25},
+        {entryType: 'layoutShift', value: 0.3},
+      ]);
 
       const perf = getPerformance();
       // visibilitychange/beforeunload listeners are now added.

--- a/test/unit/test-performance.js
+++ b/test/unit/test-performance.js
@@ -841,6 +841,7 @@ describes.realWin('PeformanceObserver metrics', {amp: true}, env => {
         visibilityState: 'visible',
       },
       location: env.win.location,
+      navigator: env.win.navigator,
       performance: {
         getEntriesByType: env.sandbox.stub(),
       },
@@ -1232,10 +1233,12 @@ describes.realWin('PeformanceObserver metrics', {amp: true}, env => {
       expect(fakeWin.document.visibilityState).to.equal('visible');
 
       // Fake layoutJank that occured before the Performance service is started.
-      fakeWin.performance.getEntriesByType.withArgs('layoutJank').returns([
-        {entryType: 'layoutJank', fraction: 0.25},
-        {entryType: 'layoutJank', fraction: 0.3},
-      ]);
+      fakeWin.performance.getEntriesByType
+        .withArgs('layoutJank')
+        .returns([
+          {entryType: 'layoutJank', fraction: 0.25},
+          {entryType: 'layoutJank', fraction: 0.3},
+        ]);
 
       const perf = getPerformance();
       // visibilitychange/beforeunload listeners are now added.
@@ -1287,10 +1290,12 @@ describes.realWin('PeformanceObserver metrics', {amp: true}, env => {
         .returns(false);
 
       // Fake layoutJank that occured before the Performance service is started.
-      fakeWin.performance.getEntriesByType.withArgs('layoutJank').returns([
-        {entryType: 'layoutJank', fraction: 0.25},
-        {entryType: 'layoutJank', fraction: 0.3},
-      ]);
+      fakeWin.performance.getEntriesByType
+        .withArgs('layoutJank')
+        .returns([
+          {entryType: 'layoutJank', fraction: 0.25},
+          {entryType: 'layoutJank', fraction: 0.3},
+        ]);
       const perf = getPerformance();
       perf.coreServicesAvailable();
       viewerVisibilityState = VisibilityState.INACTIVE;
@@ -1342,10 +1347,12 @@ describes.realWin('PeformanceObserver metrics', {amp: true}, env => {
       expect(fakeWin.document.visibilityState).to.equal('visible');
 
       // Fake layoutShift that occured before the Performance service is started.
-      fakeWin.performance.getEntriesByType.withArgs('layoutShift').returns([
-        {entryType: 'layoutShift', value: 0.25},
-        {entryType: 'layoutShift', value: 0.3},
-      ]);
+      fakeWin.performance.getEntriesByType
+        .withArgs('layoutShift')
+        .returns([
+          {entryType: 'layoutShift', value: 0.25},
+          {entryType: 'layoutShift', value: 0.3},
+        ]);
 
       const perf = getPerformance();
       // visibilitychange/beforeunload listeners are now added.


### PR DESCRIPTION
- Provide a navigator on the fakeWin object which is needed when
creating the Performance service.
