### PR TITLE
♻️ amp-story-quiz: fix small gcc type warning

### DIFF
--- a/extensions/amp-story/1.0/amp-story-quiz.js
+++ b/extensions/amp-story/1.0/amp-story-quiz.js
@@ -119,11 +119,7 @@ export class AmpStoryQuiz extends AMP.BaseElement {
    */
   adjustGridLayer_() {
     const gridLayer = closest(dev().assertElement(this.element), el => {
-      const tagName = el.tagName.toLowerCase();
-
-      if (tagName === 'amp-story-grid-layer') {
-        return true;
-      }
+      return el.tagName.toLowerCase() === 'amp-story-grid-layer';
     });
 
     gridLayer.classList.add('i-amphtml-story-has-quiz');


### PR DESCRIPTION
Fixes small gcc type error:
```
extensions/amp-story/1.0/amp-story-quiz.js:121: WARNING - [JSC_MISSING_RETURN_STATEMENT] Missing return statement. Function expected to return boolean.
    const gridLayer = closest(dev().assertElement(this.element), el => {
```
