### PR TITLE
amp-inline-gallery docs and validation rules

### DIFF
--- a/extensions/amp-inline-gallery/0.1/amp-inline-gallery.js
+++ b/extensions/amp-inline-gallery/0.1/amp-inline-gallery.js
@@ -45,7 +45,7 @@ const THUMBNAILS_SELECTORS = 'amp-inline-gallery-thumbnails';
  * The selector for the main carousel (i.e. not the one for the thumbnails).
  */
 const CAROUSEL_SELECTOR =
-  ':not(amp-inline-gallery-thumbnails) > amp-base-carousel';
+  '> amp-base-carousel, :not(amp-inline-gallery-thumbnails) > amp-base-carousel';
 
 class AmpInlineGallery extends AMP.BaseElement {
   /** @param {!AmpElement} element */

--- a/extensions/amp-inline-gallery/0.1/test/validator-amp-inline-gallery-pagination.html
+++ b/extensions/amp-inline-gallery/0.1/test/validator-amp-inline-gallery-pagination.html
@@ -1,0 +1,57 @@
+<!--
+  Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS-IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the license.
+-->
+<!--
+  Test Description:
+  Tests for the amp-inline-gallery-pagination tag. See the inline comments.
+-->
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <link rel="canonical" href="./regular-html-version.html">
+  <meta name="viewport" content="width=device-width,minimum-scale=1">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async custom-element="amp-inline-gallery" src="https://cdn.ampproject.org/v0/amp-inline-gallery-0.1.js"></script>
+</head>
+<body>
+  <!-- Invalid: Not in a gallery -->
+  <amp-inline-gallery-pagination layout="fixed-height" height="24">
+  </amp-inline-gallery-pagination>
+  <!-- Invalid: Inset without nodisplay -->
+  <amp-inline-gallery layout="container">
+    <amp-inline-gallery-pagination layout="fixed-height" height="24" inset>
+    </amp-inline-gallery-pagination>
+  </amp-inline-gallery>
+  <!-- Valid: Inset with nodisplay -->
+  <amp-inline-gallery layout="container">
+    <amp-inline-gallery-pagination layout="nodisplay" inset>
+    </amp-inline-gallery-pagination>
+  </amp-inline-gallery>
+  <!-- Valid: Wrapped with a parent div -->
+  <amp-inline-gallery layout="container">
+    <div>
+      <amp-inline-gallery-pagination layout="nodisplay"inset>
+      </amp-inline-gallery-pagination>
+    </div>
+  </amp-inline-gallery>
+  <!-- Valid: Non-inset with fixed-height -->
+  <amp-inline-gallery layout="container">
+    <amp-inline-gallery-pagination layout="fixed-height" height="24">
+    </amp-inline-gallery-pagination>
+  </amp-inline-gallery>
+</body>
+</html>

--- a/extensions/amp-inline-gallery/0.1/test/validator-amp-inline-gallery-pagination.out
+++ b/extensions/amp-inline-gallery/0.1/test/validator-amp-inline-gallery-pagination.out
@@ -1,0 +1,62 @@
+FAIL
+|  <!--
+|    Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+|
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|
+|        http://www.apache.org/licenses/LICENSE-2.0
+|
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Tests for the amp-inline-gallery-pagination tag. See the inline comments.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    <script async custom-element="amp-inline-gallery" src="https://cdn.ampproject.org/v0/amp-inline-gallery-0.1.js"></script>
+|  </head>
+|  <body>
+|    <!-- Invalid: Not in a gallery -->
+|    <amp-inline-gallery-pagination layout="fixed-height" height="24">
+>>   ^~~~~~~~~
+amp-inline-gallery/0.1/test/validator-amp-inline-gallery-pagination.html:32:2 The tag 'amp-inline-gallery-pagination' may only appear as a descendant of tag 'amp-inline-gallery'. (see https://amp.dev/documentation/components/amp-inline-gallery)
+|    </amp-inline-gallery-pagination>
+|    <!-- Invalid: Inset without nodisplay -->
+|    <amp-inline-gallery layout="container">
+|      <amp-inline-gallery-pagination layout="fixed-height" height="24" inset>
+>>     ^~~~~~~~~
+amp-inline-gallery/0.1/test/validator-amp-inline-gallery-pagination.html:36:4 The specified layout 'FIXED_HEIGHT' is not supported by tag 'amp-inline-gallery-pagination [inset]'. (see https://amp.dev/documentation/components/amp-inline-gallery)
+|      </amp-inline-gallery-pagination>
+|    </amp-inline-gallery>
+|    <!-- Valid: Inset with nodisplay -->
+|    <amp-inline-gallery layout="container">
+|      <amp-inline-gallery-pagination layout="nodisplay" inset>
+|      </amp-inline-gallery-pagination>
+|    </amp-inline-gallery>
+|    <!-- Valid: Wrapped with a parent div -->
+|    <amp-inline-gallery layout="container">
+|      <div>
+|        <amp-inline-gallery-pagination layout="nodisplay"inset>
+|        </amp-inline-gallery-pagination>
+|      </div>
+|    </amp-inline-gallery>
+|    <!-- Valid: Non-inset with fixed-height -->
+|    <amp-inline-gallery layout="container">
+|      <amp-inline-gallery-pagination layout="fixed-height" height="24">
+|      </amp-inline-gallery-pagination>
+|    </amp-inline-gallery>
+|  </body>
+|  </html>

--- a/extensions/amp-inline-gallery/0.1/test/validator-amp-inline-gallery-thumbnails.html
+++ b/extensions/amp-inline-gallery/0.1/test/validator-amp-inline-gallery-thumbnails.html
@@ -1,0 +1,77 @@
+<!--
+  Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS-IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the license.
+-->
+<!--
+  Test Description:
+  Tests for the amp-inline-gallery-thumbnails tag. See the inline comments.
+-->
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <link rel="canonical" href="./regular-html-version.html">
+  <meta name="viewport" content="width=device-width,minimum-scale=1">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async custom-element="amp-inline-gallery" src="https://cdn.ampproject.org/v0/amp-inline-gallery-0.1.js"></script>
+</head>
+<body>
+  <!-- Invalid: Not in a gallery -->
+  <amp-inline-gallery-thumbnails layout="fixed-height" height="96">
+  </amp-inline-gallery-thumbnails>
+  <!-- Invalid: Aspect ratio height widthout width -->
+  <amp-inline-gallery layout="container">
+    <amp-inline-gallery-thumbnails layout="fixed-height" height="96" aspect-ratio-height="2">
+    </amp-inline-gallery-thumbnails>
+  </amp-inline-gallery>
+  <!-- Invalid: Non-number aspect ratio height-->
+  <amp-inline-gallery layout="container">
+    <amp-inline-gallery-thumbnails layout="fixed-height" height="96" aspect-ratio-height="two" aspect-ratio-width="3">
+    </amp-inline-gallery-thumbnails>
+  </amp-inline-gallery>
+  <!-- Invalid: Aspect ratio component of zero -->
+  <amp-inline-gallery layout="container">
+    <amp-inline-gallery-thumbnails layout="fixed-height" height="96" aspect-ratio-height="0" aspect-ratio-width="3">
+    </amp-inline-gallery-thumbnails>
+  </amp-inline-gallery>
+  <!-- Invalid: Aspect ratio component of zero (float) -->
+  <amp-inline-gallery layout="container">
+    <amp-inline-gallery-thumbnails layout="fixed-height" height="96" aspect-ratio-height="0.00" aspect-ratio-width="3">
+    </amp-inline-gallery-thumbnails>
+  </amp-inline-gallery>
+  <!-- Invalid: Loop attribute without value -->
+  <amp-inline-gallery layout="container">
+    <amp-inline-gallery-thumbnails layout="fixed-height" height="96" loop>
+    </amp-inline-gallery-thumbnails>
+  </amp-inline-gallery>
+  <!-- Valid: Wrapped with a parent div -->
+  <amp-inline-gallery layout="container">
+    <div>
+      <amp-inline-gallery-thumbnails layout="fixed-height" height="96">
+      </amp-inline-gallery-thumbnails>
+    </div>
+  </amp-inline-gallery>
+  <!-- Valid: Aspect ratio specified -->
+  <amp-inline-gallery layout="container">
+    <amp-inline-gallery-thumbnails layout="fixed-height" height="96" aspect-ratio-height="2.0" aspect-ratio-width="3">
+    </amp-inline-gallery-thumbnails>
+  </amp-inline-gallery>
+  <!-- Valid: Loop attribute specified -->
+  <amp-inline-gallery layout="container">
+    <amp-inline-gallery-thumbnails layout="fixed-height" height="96" loop="true">
+    </amp-inline-gallery-thumbnails>
+  </amp-inline-gallery>
+</body>
+</html>

--- a/extensions/amp-inline-gallery/0.1/test/validator-amp-inline-gallery-thumbnails.out
+++ b/extensions/amp-inline-gallery/0.1/test/validator-amp-inline-gallery-thumbnails.out
@@ -1,0 +1,90 @@
+FAIL
+|  <!--
+|    Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+|
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|
+|        http://www.apache.org/licenses/LICENSE-2.0
+|
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Tests for the amp-inline-gallery-thumbnails tag. See the inline comments.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    <script async custom-element="amp-inline-gallery" src="https://cdn.ampproject.org/v0/amp-inline-gallery-0.1.js"></script>
+|  </head>
+|  <body>
+|    <!-- Invalid: Not in a gallery -->
+|    <amp-inline-gallery-thumbnails layout="fixed-height" height="96">
+>>   ^~~~~~~~~
+amp-inline-gallery/0.1/test/validator-amp-inline-gallery-thumbnails.html:32:2 The tag 'amp-inline-gallery-thumbnails' may only appear as a descendant of tag 'amp-inline-gallery'. (see https://amp.dev/documentation/components/amp-inline-gallery)
+|    </amp-inline-gallery-thumbnails>
+|    <!-- Invalid: Aspect ratio height widthout width -->
+|    <amp-inline-gallery layout="container">
+|      <amp-inline-gallery-thumbnails layout="fixed-height" height="96" aspect-ratio-height="2">
+>>     ^~~~~~~~~
+amp-inline-gallery/0.1/test/validator-amp-inline-gallery-thumbnails.html:36:4 The attribute 'aspect-ratio-width' in tag 'amp-inline-gallery-thumbnails' is missing or incorrect, but required by attribute 'aspect-ratio-height'. (see https://amp.dev/documentation/components/amp-inline-gallery)
+|      </amp-inline-gallery-thumbnails>
+|    </amp-inline-gallery>
+|    <!-- Invalid: Non-number aspect ratio height-->
+|    <amp-inline-gallery layout="container">
+|      <amp-inline-gallery-thumbnails layout="fixed-height" height="96" aspect-ratio-height="two" aspect-ratio-width="3">
+>>     ^~~~~~~~~
+amp-inline-gallery/0.1/test/validator-amp-inline-gallery-thumbnails.html:41:4 The attribute 'aspect-ratio-height' in tag 'amp-inline-gallery-thumbnails' is set to the invalid value 'two'. (see https://amp.dev/documentation/components/amp-inline-gallery)
+|      </amp-inline-gallery-thumbnails>
+|    </amp-inline-gallery>
+|    <!-- Invalid: Aspect ratio component of zero -->
+|    <amp-inline-gallery layout="container">
+|      <amp-inline-gallery-thumbnails layout="fixed-height" height="96" aspect-ratio-height="0" aspect-ratio-width="3">
+>>     ^~~~~~~~~
+amp-inline-gallery/0.1/test/validator-amp-inline-gallery-thumbnails.html:46:4 The attribute 'aspect-ratio-height' in tag 'amp-inline-gallery-thumbnails' is set to the invalid value '0'. (see https://amp.dev/documentation/components/amp-inline-gallery)
+|      </amp-inline-gallery-thumbnails>
+|    </amp-inline-gallery>
+|    <!-- Invalid: Aspect ratio component of zero (float) -->
+|    <amp-inline-gallery layout="container">
+|      <amp-inline-gallery-thumbnails layout="fixed-height" height="96" aspect-ratio-height="0.00" aspect-ratio-width="3">
+>>     ^~~~~~~~~
+amp-inline-gallery/0.1/test/validator-amp-inline-gallery-thumbnails.html:51:4 The attribute 'aspect-ratio-height' in tag 'amp-inline-gallery-thumbnails' is set to the invalid value '0.00'. (see https://amp.dev/documentation/components/amp-inline-gallery)
+|      </amp-inline-gallery-thumbnails>
+|    </amp-inline-gallery>
+|    <!-- Invalid: Loop attribute without value -->
+|    <amp-inline-gallery layout="container">
+|      <amp-inline-gallery-thumbnails layout="fixed-height" height="96" loop>
+>>     ^~~~~~~~~
+amp-inline-gallery/0.1/test/validator-amp-inline-gallery-thumbnails.html:56:4 The attribute 'loop' in tag 'amp-inline-gallery-thumbnails' is set to the invalid value ''. (see https://amp.dev/documentation/components/amp-inline-gallery)
+|      </amp-inline-gallery-thumbnails>
+|    </amp-inline-gallery>
+|    <!-- Valid: Wrapped with a parent div -->
+|    <amp-inline-gallery layout="container">
+|      <div>
+|        <amp-inline-gallery-thumbnails layout="fixed-height" height="96">
+|        </amp-inline-gallery-thumbnails>
+|      </div>
+|    </amp-inline-gallery>
+|    <!-- Valid: Aspect ratio specified -->
+|    <amp-inline-gallery layout="container">
+|      <amp-inline-gallery-thumbnails layout="fixed-height" height="96" aspect-ratio-height="2.0" aspect-ratio-width="3">
+|      </amp-inline-gallery-thumbnails>
+|    </amp-inline-gallery>
+|    <!-- Valid: Loop attribute specified -->
+|    <amp-inline-gallery layout="container">
+|      <amp-inline-gallery-thumbnails layout="fixed-height" height="96" loop="true">
+|      </amp-inline-gallery-thumbnails>
+|    </amp-inline-gallery>
+|  </body>
+|  </html>

--- a/extensions/amp-inline-gallery/amp-inline-gallery.md
+++ b/extensions/amp-inline-gallery/amp-inline-gallery.md
@@ -1,0 +1,291 @@
+---
+$category@: layout
+formats:
+  - websites
+teaser:
+  text: Displays multiple similar pieces of content along a horizontal axis,
+  with optional pagination dots and thumbnails.
+---
+
+<!---
+Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS-IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# amp-inline-gallery
+
+A carousel for displaying content such as images along a horizontal axis along with optional pagination dots and preview thumbnails.
+
+<table>
+  <tr>
+    <td width="40%"><strong>Availability</strong></td>
+    <td><div><a href="https://amp.dev/documentation/guides-and-tutorials/learn/experimental">Experimental</a>; You must turn on the <code>amp-base-carousel</code> experiment to use this component.</div></td>
+  </tr>
+  <tr>
+    <td width="40%"><strong>Required Scripts</strong></td>
+    <td>
+      <div>
+        <code>&lt;script async custom-element="amp-inline-gallery" src="https://cdn.ampproject.org/v0/amp-inline-gallery.js">&lt;/script></code>
+      </div>
+      <div>
+        <code>&lt;script async custom-element="amp-base-carousel" src="https://cdn.ampproject.org/v0/amp-base-carousel.js">&lt;/script></code>
+      </div>
+    </td>
+  </tr>
+  <tr>
+    <td class="col-fourty"><strong><a href="https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/control_layout">Supported Layouts</a></strong></td>
+    <td>
+      container
+    </td>
+  </tr>
+</table>
+
+## Usage
+
+The `<amp-inline-gallery>` component uses an `<amp-base-carousel>` to display slides. The page must have the required scripts for both components in the document head. Typical usage might look like:
+
+[example preview="inline" playground="true" imports="amp-inline-gallery,amp-base-carousel"]
+
+```html
+<amp-inline-gallery layout="container">
+  <amp-base-carousel
+    class="gallery"
+    layout="responsive"
+    width="3.6"
+    height="2"
+    snap-align="center"
+    loop="true"
+    visible-count="1.2"
+    lightbox
+  >
+    <amp-img
+      src="{{server_for_email}}/static/inline-examples/images/image1.jpg"
+      layout="responsive"
+      width="450"
+      height="300"
+    ></amp-img>
+    <amp-img
+      src="{{server_for_email}}/static/inline-examples/images/image2.jpg"
+      layout="responsive"
+      width="450"
+      height="300"
+    ></amp-img>
+    <amp-img
+      src="{{server_for_email}}/static/inline-examples/images/image3.jpg"
+      layout="responsive"
+      width="450"
+      height="300"
+    ></amp-img>
+  </amp-base-carousel>
+  <amp-inline-gallery-pagination layout="nodisplay" inset>
+  </amp-inline-gallery-pagination>
+</amp-inline-gallery>
+```
+
+[/example]
+
+The above example shows slides using an aspect ratio of 3:2, with 10% of a slide peeking on either side. An aspect ratio of 3.6:2 is used on the `amp-base-carousel` to show 1.2 slides at a time.
+
+### Include pagination indicators
+
+The `<amp-inline-gallery-pagination>` component determines how a pagination idicator should be displayed. By default, no pagination indicator is displayed.
+
+The pagination indicator renders as dots when there are eight or fewer slides in the `amp-base-carousel`. For nine or more slides, the pagination indicator renders the current slide number and total number of slides, aligned to the right.
+
+The pagination indicator location defaults to underneath the carousel. Adding the inset attribute to the `<amp-inline-gallery-pagination>` tag will overlay the pagination indicator on the carousel. To use different styles for different screen sizes, use the media attribute:
+
+```html
+<amp-inline-gallery layout="container">
+  <amp-base-carousel>…</amp-base-carousel>
+  <amp-inline-gallery-pagination
+    media="(max-width: 599px)"
+    layout="nodisplay"
+    inset
+  >
+  </amp-inline-gallery-pagination>
+  <amp-inline-gallery-pagination
+    media="(min-width: 600px)"
+    layout="fixed-height"
+    height="24"
+  >
+  </amp-inline-gallery-pagination>
+</amp-inline-gallery>
+```
+
+#### `amp-inline-gallery-pagination` attributes
+
+##### `inset` (optional)
+
+Displays the pagination indicator as inset, overlaying the carousel itself. When using `inset`, you should give the `<amp-inline-gallery-pagination>` element `layout="nodisplay"`.
+
+##### common attributes
+
+The `<amp-inline-gallery-pagination>` element includes <a href="https://amp.dev/documentation/guides-and-tutorials/learn/common_attributes">common attributes</a> extended to AMP components.
+
+### Include thumbnails
+
+The `amp-inline-gallery` component can display thumbnail preview in addition to, or instead of, the pagination indicators. By default, not thumbnails are shown in the gallery. Keep in mind the following best practices when using thumbnails:
+
+- Avoid using both pagination indicators and thumbnails with less than eight slides. The indicator dots are redundant in smaller galleries.
+- When using both pagination indicators and thumbnails, inset the pagination indicators to overlap the slides. View the code sample below to see an example.
+- Use the `media` attribute to show pagination indicators on smaller mobile devices and thumbnails on larger screens.
+- Load lower resolution images at thumbnails by using `srcset`. You can omit the `sizes` on `<amp-img>`, it will be automatically generated based on the rendered width.
+
+The example below demonstrates a gallery with thumbnails visible at larger resolutions.
+
+[example preview="inline" playground="true" imports="amp-inline-gallery,amp-base-carousel"]
+
+```html
+<amp-inline-gallery layout="container">
+  <!--
+    The amp-layout with layout="container" is used to display the pagination on
+    top of the carousel instead of the thumbnails. You can also use a div with
+    `position: relative;`
+  -->
+  <amp-layout layout="container">
+    <amp-base-carousel
+      class="gallery"
+      layout="responsive"
+      width="3"
+      height="2"
+      snap-align="center"
+      loop="true"
+    >
+      <amp-img
+        class="slide"
+        layout="flex-item"
+        src="https://picsum.photos/id/779/600/400"
+        srcset="https://picsum.photos/id/779/150/100 150w,
+                https://picsum.photos/id/779/600/400 600w,
+                https://picsum.photos/id/779/1200/800 1200w"
+      >
+      </amp-img>
+      <amp-img
+        class="slide"
+        layout="flex-item"
+        src="https://picsum.photos/id/1048/600/400"
+        srcset="https://picsum.photos/id/1048/150/100 150w,
+                https://picsum.photos/id/1048/600/400 600w,
+                https://picsum.photos/id/1048/1200/800 1200w"
+      >
+      </amp-img>
+      <amp-img
+        class="slide"
+        layout="flex-item"
+        src="https://picsum.photos/id/108/600/400"
+        srcset="https://picsum.photos/id/108/150/100 150w,
+                https://picsum.photos/id/108/600/400 600w,
+                https://picsum.photos/id/108/1200/800 1200w"
+      >
+      </amp-img>
+      <amp-img
+        class="slide"
+        layout="flex-item"
+        src="https://picsum.photos/id/130/600/400"
+        srcset="https://picsum.photos/id/130/150/100 150w,
+                https://picsum.photos/id/130/600/400 600w,
+                https://picsum.photos/id/130/1200/800 1200w"
+      >
+      </amp-img>
+      <amp-img
+        class="slide"
+        layout="flex-item"
+        src="https://picsum.photos/id/14/600/400"
+        srcset="https://picsum.photos/id/14/150/100 150w,
+                https://picsum.photos/id/14/600/400 600w,
+                https://picsum.photos/id/14/1200/800 1200w"
+      >
+      </amp-img>
+      <amp-img
+        class="slide"
+        layout="flex-item"
+        src="https://picsum.photos/id/165/600/400"
+        srcset="https://picsum.photos/id/165/150/100 150w,
+                https://picsum.photos/id/165/600/400 600w,
+                https://picsum.photos/id/165/1200/800 1200w"
+      >
+      </amp-img>
+      <amp-img
+        class="slide"
+        layout="flex-item"
+        src="https://picsum.photos/id/179/600/400"
+        srcset="https://picsum.photos/id/179/150/100 150w,
+                https://picsum.photos/id/179/600/400 600w,
+                https://picsum.photos/id/179/1200/800 1200w"
+      >
+      </amp-img>
+      <amp-img
+        class="slide"
+        layout="flex-item"
+        src="https://picsum.photos/id/392/600/400"
+        srcset="https://picsum.photos/id/392/150/100 150w,
+                https://picsum.photos/id/392/600/400 600w,
+                https://picsum.photos/id/392/1200/800 1200w"
+      >
+      </amp-img>
+      <amp-img
+        class="slide"
+        layout="flex-item"
+        src="https://picsum.photos/id/468/600/400"
+        srcset="https://picsum.photos/id/468/150/100 150w,
+                https://picsum.photos/id/468/600/400 600w,
+                https://picsum.photos/id/468/1200/800 1200w"
+      >
+      </amp-img>
+    </amp-base-carousel>
+    <!--
+        If using fewer than 8 slides, consider adding something
+        like media="(max-width: 799px)".
+      -->
+    <amp-inline-gallery-pagination layout="nodisplay" inset>
+    </amp-inline-gallery-pagination>
+  </amp-layout>
+  <amp-inline-gallery-thumbnails
+    media="(min-width: 800px)"
+    layout="fixed-height"
+    height="96"
+  >
+  </amp-inline-gallery-thumbnails>
+</amp-inline-gallery>
+```
+
+[/example]
+
+#### `amp-inline-gallery-thumbnails` attributes
+
+##### `aspect-ratio-height` (optional)
+
+Specifies the aspect ratio when used with `aspect-ratio-width`. The aspect radio defaults to match the slides in `<amp-base-carousel>`.
+
+##### `aspect-ratio-width` (optional)
+
+Specifies the aspect ratio when used with `aspect-ratio-height`. The aspect radio defaults to match the slides in `<amp-base-carousel>`.
+
+##### `loop` (optional)
+
+Loops thumbnails. Takes a value of `"true"` or `"false"`. Defaults to `"true"`.
+
+##### common attributes
+
+The `<amp-inline-gallery-thumbnails>` element includes <a href="https://amp.dev/documentation/guides-and-tutorials/learn/common_attributes">common attributes</a> extended to AMP components.
+
+## Attributes
+
+### common attributes
+
+This element includes <a href="https://amp.dev/documentation/guides-and-tutorials/learn/common_attributes">common attributes</a> extended to AMP components.
+
+## Validation
+
+See [amp-inline-gallery rules](https://github.com/ampproject/amphtml/blob/master/extensions/amp-inline-gallery/validator-amp-inline-gallery.protoascii) in the AMP validator specification.

--- a/extensions/amp-inline-gallery/amp-inline-gallery.md
+++ b/extensions/amp-inline-gallery/amp-inline-gallery.md
@@ -8,7 +8,7 @@ teaser:
 ---
 
 <!---
-Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+Copyright 2020 The AMP HTML Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/extensions/amp-inline-gallery/validator-amp-inline-gallery.protoascii
+++ b/extensions/amp-inline-gallery/validator-amp-inline-gallery.protoascii
@@ -1,0 +1,110 @@
+#
+# Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the license.
+#
+
+tags: {  # amp-inline-gallery
+  html_format: AMP
+  tag_name: "SCRIPT"
+  extension_spec: {
+    name: "amp-inline-gallery"
+    version: "0.1"
+    version: "latest"
+  }
+  attr_lists: "common-extension-attrs"
+}
+tags: {  # <amp-inline-gallery>
+  html_format: AMP
+  tag_name: "AMP-INLINE-GALLERY"
+  requires_extension: "amp-inline-gallery"
+  attr_lists: "extended-amp-global"
+  spec_url: "https://amp.dev/documentation/components/amp-inline-gallery"
+  amp_layout: {
+    supported_layouts: CONTAINER
+  }
+}
+tags: {  # <amp-inline-gallery-pagination>
+  html_format: AMP
+  tag_name: "AMP-INLINE-GALLERY-PAGINATION"
+  spec_name: "amp-inline-gallery-pagination"
+  requires_extension: "amp-inline-gallery"
+  attr_lists: "extended-amp-global"
+  spec_url: "https://amp.dev/documentation/components/amp-inline-gallery"
+  mandatory_ancestor: "AMP-INLINE-GALLERY"
+  amp_layout: {
+    supported_layouts: FILL
+    supported_layouts: FIXED
+    supported_layouts: FIXED_HEIGHT
+    supported_layouts: FLEX_ITEM
+    supported_layouts: INTRINSIC
+    supported_layouts: NODISPLAY
+    supported_layouts: RESPONSIVE
+  }
+}
+tags: {  # <amp-inline-gallery-pagination inset>
+  html_format: AMP
+  tag_name: "AMP-INLINE-GALLERY-PAGINATION"
+  spec_name: "amp-inline-gallery-pagination [inset]"
+  requires_extension: "amp-inline-gallery"
+  attrs: {
+    name: "inset"
+    mandatory: true
+  }
+  attr_lists: "extended-amp-global"
+  spec_url: "https://amp.dev/documentation/components/amp-inline-gallery"
+  mandatory_ancestor: "AMP-INLINE-GALLERY"
+  amp_layout: {
+    supported_layouts: NODISPLAY
+  }
+}
+tags: {  # <amp-inline-gallery-thumbnails>
+  html_format: AMP
+  tag_name: "AMP-INLINE-GALLERY-THUMBNAILS"
+  requires_extension: "amp-inline-gallery"
+  attrs: {
+    name: "aspect-ratio-height"
+    # Non-zero number
+    value_regex: "\\d+(\\.\\d+)?"
+    blacklisted_value_regex: "^0+(\\.0+)?$"
+    trigger: {
+      also_requires_attr: "aspect-ratio-width"
+    }
+  }
+  attrs: {
+    name: "aspect-ratio-width"
+    # Non-zero number
+    value_regex: "\\d+(\\.\\d+)?"
+    blacklisted_value_regex: "^0+(\\.0+)?$"
+    trigger: {
+      also_requires_attr: "aspect-ratio-height"
+    }
+  }
+  attrs: {
+    name: "loop"
+    value: "true"
+    value: "false"
+  }
+  attr_lists: "extended-amp-global"
+  spec_url: "https://amp.dev/documentation/components/amp-inline-gallery"
+  mandatory_ancestor: "AMP-INLINE-GALLERY"
+  amp_layout: {
+    supported_layouts: FILL
+    supported_layouts: FIXED
+    supported_layouts: FIXED_HEIGHT
+    supported_layouts: FLEX_ITEM
+    supported_layouts: INTRINSIC
+    supported_layouts: NODISPLAY
+    supported_layouts: RESPONSIVE
+  }
+}

--- a/extensions/amp-inline-gallery/validator-amp-inline-gallery.protoascii
+++ b/extensions/amp-inline-gallery/validator-amp-inline-gallery.protoascii
@@ -1,5 +1,5 @@
 #
-# Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+# Copyright 2020 The AMP HTML Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
- Add docs for `amp-inline-gallery` elements and linking to `amp-base-carousel` for its usage.
- Add validation rules for `amp-inline-gallery` elements.
- Fix selector for finding the amp-base-carousel, when it is a direct child of the `amp-inline-gallery`.
