### PR TITLE
✨ Add inactive event types to amp-analytics

### DIFF
--- a/extensions/amp-analytics/0.1/activity-impl.js
+++ b/extensions/amp-analytics/0.1/activity-impl.js
@@ -83,17 +83,16 @@ class ActivityHistory {
    * @param {ActivityEventDef} activityEvent
    */
   push(activityEvent) {
-    if (!this.prevActivityEvent_) {
-      this.prevActivityEvent_ = activityEvent;
-    }
-
-    if (this.prevActivityEvent_.time < activityEvent.time) {
+    if (
+      this.prevActivityEvent_ &&
+      this.prevActivityEvent_.time < activityEvent.time
+    ) {
       this.totalEngagedTime_ += findEngagedTimeBetween(
         this.prevActivityEvent_,
         activityEvent.time
       );
-      this.prevActivityEvent_ = activityEvent;
     }
+    this.prevActivityEvent_ = activityEvent;
   }
 
   /**
@@ -126,6 +125,13 @@ const ACTIVE_EVENT_TYPES = [
   'keydown',
   'keyup',
 ];
+/**
+ * Array of event types which will be listened for on the document to indicate
+ * leave from document. Other activities are also observed on the AmpDoc and Viewport
+ * objects. See {@link setUpActivityListeners_} for listener implementation.
+ * @private @const {Array<string>}
+ */
+const INACTIVE_EVENT_TYPES = ['mouseleave'];
 
 /**
  * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampDoc
@@ -163,6 +169,9 @@ export class Activity {
 
     /** @private @const {function()} */
     this.boundHandleActivity_ = this.handleActivity_.bind(this);
+
+    /** @private @const {function()} */
+    this.boundHandleInactive_ = this.handleInactive_.bind(this);
 
     /** @private @const {function()} */
     this.boundHandleVisibilityChange_ = this.handleVisibilityChange_.bind(this);
@@ -228,15 +237,17 @@ export class Activity {
 
   /** @private */
   setUpActivityListeners_() {
-    for (let i = 0; i < ACTIVE_EVENT_TYPES.length; i++) {
-      this.unlistenFuncs_.push(
-        listen(
-          this.ampdoc.getRootNode(),
-          ACTIVE_EVENT_TYPES[i],
-          this.boundHandleActivity_
-        )
-      );
-    }
+    this.setUpListenersFromArray_(
+      this.ampdoc.getRootNode(),
+      ACTIVE_EVENT_TYPES,
+      this.boundHandleActivity_
+    );
+
+    this.setUpListenersFromArray_(
+      this.ampdoc.getRootNode(),
+      INACTIVE_EVENT_TYPES,
+      this.boundHandleInactive_
+    );
 
     this.unlistenFuncs_.push(
       this.ampdoc.onVisibilityChanged(this.boundHandleVisibilityChange_)
@@ -246,6 +257,18 @@ export class Activity {
     // TODO(britice): If Viewport is updated to return an unlisten function,
     // update this to capture the unlisten function.
     this.viewport_.onScroll(this.boundHandleActivity_);
+  }
+
+  /**
+   *  @private
+   *  @param {!EventTarget} target
+   *  @param {Array<string>} events
+   *  @param {function()} listener
+   */
+  setUpListenersFromArray_(target, events, listener) {
+    for (let i = 0; i < events.length; i++) {
+      this.unlistenFuncs_.push(listen(target, events[i], listener));
+    }
   }
 
   /** @private */

--- a/test/unit/test-activity.js
+++ b/test/unit/test-activity.js
@@ -215,7 +215,7 @@ describe('Activity getTotalEngagedTime', () => {
 
   it(
     'should set event listeners on the document for' +
-    ' "mousedown", "mouseup", "mousemove", "keyup", "keydown", "mouseleave"',
+      ' "mousedown", "mouseup", "mousemove", "keyup", "keydown", "mouseleave"',
     () => {
       const addEventListenerSpy = window.sandbox.spy(
         fakeDoc,
@@ -368,7 +368,7 @@ describe('Activity getIncrementalEngagedTime', () => {
 
   it(
     'should have 5 seconds of incremental engaged time after doc ' +
-    'becomes visible',
+      'becomes visible',
     () => {
       whenFirstVisibleResolve();
       return ampdoc.whenFirstVisible().then(() => {

--- a/test/unit/test-activity.js
+++ b/test/unit/test-activity.js
@@ -35,6 +35,7 @@ describe('Activity getTotalEngagedTime', () => {
   let whenFirstVisibleResolve;
   let visibilityObservable;
   let mousedownObservable;
+  let mouseleaveObservable;
   let scrollObservable;
 
   beforeEach(() => {
@@ -45,6 +46,7 @@ describe('Activity getTotalEngagedTime', () => {
 
     visibilityObservable = new Observable();
     mousedownObservable = new Observable();
+    mouseleaveObservable = new Observable();
     scrollObservable = new Observable();
 
     fakeDoc = {
@@ -52,6 +54,8 @@ describe('Activity getTotalEngagedTime', () => {
       addEventListener(eventName, callback) {
         if (eventName === 'mousedown') {
           mousedownObservable.add(callback);
+        } else if (eventName === 'mouseleave') {
+          mouseleaveObservable.add(callback);
         }
       },
       documentElement: {
@@ -176,15 +180,23 @@ describe('Activity getTotalEngagedTime', () => {
       .stub(ampdoc, 'isVisible')
       .returns(true);
     whenFirstVisibleResolve();
-    return ampdoc.whenFirstVisible().then(() => {
-      clock.tick(3000);
-      mousedownObservable.fire();
-      clock.tick(1000);
-      isVisibleStub.returns(false);
-      visibilityObservable.fire();
-      clock.tick(10000);
-      return expect(activity.getTotalEngagedTime()).to.equal(4);
-    });
+    return ampdoc
+      .whenFirstVisible()
+      .then(() => {
+        clock.tick(3000);
+        mousedownObservable.fire();
+        clock.tick(1000);
+        isVisibleStub.returns(false);
+        visibilityObservable.fire();
+        clock.tick(10000);
+        return expect(activity.getTotalEngagedTime()).to.equal(4);
+      })
+      .then(() => {
+        mousedownObservable.fire();
+        mouseleaveObservable.fire();
+        clock.tick(2000);
+        return expect(activity.getTotalEngagedTime()).to.equal(4);
+      });
   });
 
   it('should accumulate engaged time over multiple activities', () => {
@@ -203,7 +215,7 @@ describe('Activity getTotalEngagedTime', () => {
 
   it(
     'should set event listeners on the document for' +
-      ' "mousedown", "mouseup", "mousemove", "keyup", "keydown"',
+    ' "mousedown", "mouseup", "mousemove", "keyup", "keydown", "mouseleave"',
     () => {
       const addEventListenerSpy = window.sandbox.spy(
         fakeDoc,
@@ -229,6 +241,10 @@ describe('Activity getTotalEngagedTime', () => {
         'keyup',
         activity.boundHandleActivity_
       );
+      expect(addEventListenerSpy).to.not.have.been.calledWith(
+        'mouseleave',
+        activity.boundHandleActivity_
+      );
       whenFirstVisibleResolve();
       return ampdoc.whenFirstVisible().then(() => {
         expect(addEventListenerSpy.getCall(0).args[0]).to.equal('mousedown');
@@ -236,6 +252,7 @@ describe('Activity getTotalEngagedTime', () => {
         expect(addEventListenerSpy.getCall(2).args[0]).to.equal('mousemove');
         expect(addEventListenerSpy.getCall(3).args[0]).to.equal('keydown');
         expect(addEventListenerSpy.getCall(4).args[0]).to.equal('keyup');
+        expect(addEventListenerSpy.getCall(5).args[0]).to.equal('mouseleave');
       });
     }
   );
@@ -351,7 +368,7 @@ describe('Activity getIncrementalEngagedTime', () => {
 
   it(
     'should have 5 seconds of incremental engaged time after doc ' +
-      'becomes visible',
+    'becomes visible',
     () => {
       whenFirstVisibleResolve();
       return ampdoc.whenFirstVisible().then(() => {


### PR DESCRIPTION
- Add inactive events.
It stops calculate "${totalEngagedTime}" when mouse leave document.