### PR TITLE
Fix: amp-sticky-ad made visible for AdSense no fill case

### DIFF
--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -563,7 +563,7 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
           event['source'] == this.iframe.contentWindow
         ) {
           this.renderStarted();
-          this.iframe.setAttribute('visible', '');
+          setStyles(this.iframe, {'visibility': ''});
           this.win.removeEventListener('message', stickyMsgListener);
         }
       };

--- a/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
@@ -1368,7 +1368,6 @@ describes.realWin(
         impl.renderStarted = () => {
           promiseResolver();
         };
-        let key, val;
         impl.iframe = {
           contentWindow: window,
           style: {'visibility': 'hidden'},

--- a/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
@@ -1371,15 +1371,11 @@ describes.realWin(
         let key, val;
         impl.iframe = {
           contentWindow: window,
-          setAttribute: (k, v) => {
-            key = k;
-            val = v;
-          },
+          style: {'visibility': 'hidden'},
         };
         win.postMessage('fill_sticky', '*');
         return renderPromise.then(() => {
-          expect(key).to.equal('visible');
-          expect(val).to.equal('');
+          expect(impl.iframe.style['visibility']).to.equal('');
         });
       });
 

--- a/extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js
+++ b/extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js
@@ -285,11 +285,18 @@ export class AmpAdXOriginIframeHandler {
       setStyle(this.iframe, 'visibility', 'hidden');
     }
 
-    Promise.race([
-      renderStartPromise,
-      iframeLoadPromise,
-      timer.promise(VISIBILITY_TIMEOUT),
-    ]).then(() => {
+    // If A4A where creative is responsible for triggering render start (e.g
+    // no fill for sticky ad case), only trigger if renderStart listener promise
+    // explicitly fired (though we do not expect this to occur for A4A).
+    const triggerRenderStartPromise =
+      opt_isA4A && opt_letCreativeTriggerRenderStart
+        ? renderStartPromise
+        : Promise.race([
+            renderStartPromise,
+            iframeLoadPromise,
+            timer.promise(VISIBILITY_TIMEOUT),
+          ]);
+    triggerRenderStartPromise.then(() => {
       // Common signal RENDER_START invoked at toggle visibility time
       // Note: 'render-start' msg and common signal RENDER_START are different
       // 'render-start' msg is a way for implemented Ad to display ad earlier

--- a/extensions/amp-ad/0.1/test/test-amp-ad-xorigin-iframe-handler.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-xorigin-iframe-handler.js
@@ -40,6 +40,8 @@ describe('amp-ad-xorigin-iframe-handler', () => {
     ampdoc = ampdocService.getSingleDoc();
     const adElement = document.createElement('container-element');
     adElement.getAmpDoc = () => ampdoc;
+    adElement.togglePlaceholder = () => {};
+    adElement.toggleFallback = () => {};
     adElement.isBuilt = () => {
       return true;
     };

--- a/extensions/amp-auto-ads/0.1/adsense-network-config.js
+++ b/extensions/amp-auto-ads/0.1/adsense-network-config.js
@@ -18,6 +18,7 @@ import {Services} from '../../../src/services';
 import {buildUrl} from '../../../ads/google/a4a/shared/url-builder';
 import {dict} from '../../../src/utils/object';
 import {parseUrlDeprecated} from '../../../src/url';
+import {toWin} from '../../../src/types';
 
 /**
  * @implements {./ad-network-config.AdNetworkConfigDef}
@@ -46,6 +47,7 @@ export class AdSenseNetworkConfig {
   getConfigUrl() {
     const docInfo = Services.documentInfoForDoc(this.autoAmpAdsElement_);
     const canonicalHostname = parseUrlDeprecated(docInfo.canonicalUrl).hostname;
+    const win = toWin(this.autoAmpAdsElement_.ownerDocument.defaultView);
     return buildUrl(
       '//pagead2.googlesyndication.com/getconfig/ama',
       {
@@ -53,6 +55,8 @@ export class AdSenseNetworkConfig {
         'plah': canonicalHostname,
         'ama_t': 'amp',
         'url': docInfo.canonicalUrl,
+        'debug_experiment_id':
+          (/(?:#|,)deid=([\d,]+)/i.exec(win.location.hash) || [])[1] || null,
       },
       4096
     );


### PR DESCRIPTION
🐛 Bug fix currently if amp-ad type=adsense element within amp-ad-sticky results in no fill on canonical AMP page, sticky element is improperly made visible.

Issue due to x-origin handler improperly calling renderStart based on load or timeout when expectation is the underlying adsense impl class is expected to trigger based on receiving fill postMessage.
