### PR TITLE
WebUI app.yaml update to runtime

### DIFF
--- a/validator/webui/app.yaml
+++ b/validator/webui/app.yaml
@@ -1,4 +1,4 @@
-runtime: go
+runtime: googlelegacy
 api_version: go1
 
 handlers:


### PR DESCRIPTION
Go1.9 is deprecated on AppEngine, for the mean time use `runtime: googlelegacy`.