### PR TITLE
🐛 Fix navigation bug

### DIFF
--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -1431,15 +1431,6 @@ export class AmpStory extends AMP.BaseElement {
       // First step contains the minimum amount of code to display and play the
       // target page as fast as possible.
       () => {
-        oldPage && oldPage.element.removeAttribute('active');
-
-        if (
-          this.storeService_.get(StateProperty.UI_STATE) ===
-          UIType.DESKTOP_PANELS
-        ) {
-          this.setDesktopPositionAttributes_(targetPage);
-        }
-
         // Starts playing the page, if the story is not paused.
         // Note: navigation is prevented when the story is paused, this test
         // covers the case where the story is rendered paused (eg: consent).
@@ -1449,6 +1440,15 @@ export class AmpStory extends AMP.BaseElement {
           // Even if the page won't be playing, setting the active attribute
           // ensures it gets visible.
           targetPage.element.setAttribute('active', '');
+        }
+
+        oldPage && oldPage.element.removeAttribute('active');
+
+        if (
+          this.storeService_.get(StateProperty.UI_STATE) ===
+          UIType.DESKTOP_PANELS
+        ) {
+          this.setDesktopPositionAttributes_(targetPage);
         }
 
         this.forceRepaintForSafari_();


### PR DESCRIPTION
When navigating backwards in a story, the next page will be shown for a split second before showing the correct target page. This is caused by the removal of the `z-index: 1` of the `active` page BEFORE setting `z-index: 1` to the target page.

This would only be noticeable when navigating backwards because of the positioning of the elements in the DOM, since the next page will always be on top of the previous when they have equal stack indices.

This PR sets the `active` attribute on the target page before removing it from the old page.

/cc @calebcordry 