### PR TITLE
🏗 Upgrade `com.puppycrawl.tools:checkstyle` to 8.18

### DIFF
--- a/validator/java/pom.xml
+++ b/validator/java/pom.xml
@@ -251,7 +251,7 @@
                     <dependency>
                         <groupId>com.puppycrawl.tools</groupId>
                         <artifactId>checkstyle</artifactId>
-                        <version>8.5</version>
+                        <version>8.18</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/validator/java/pom.xml
+++ b/validator/java/pom.xml
@@ -517,7 +517,7 @@
         <dependency>
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
-            <version>8.14</version>
+            <version>8.18</version>
         </dependency>
         <dependency>
             <groupId>org.testng</groupId>


### PR DESCRIPTION
This PR fixes the security warning introduced by #25579.

![](https://user-images.githubusercontent.com/26553114/70263273-ed614f00-1763-11ea-9948-860b968f1096.png)

Resolves https://github.com/ampproject/amphtml/pull/25579#discussion_r354478921

/cc @GeorgeLuo