### PR TITLE
Always return cookie from origin if exist

### DIFF
--- a/src/service/cid-impl.js
+++ b/src/service/cid-impl.js
@@ -404,16 +404,16 @@ function getOrCreateCookie(cid, getCidStruct, persistenceConsent) {
     return /** @type {!Promise<?string>} */ (Promise.resolve(null));
   }
 
-  if (cid.externalCidCache_[scope]) {
-    return /** @type {!Promise<?string>} */ (cid.externalCidCache_[scope]);
-  }
-
   if (existingCookie) {
     // If we created the cookie, update it's expiration time.
     if (/^amp-/.test(existingCookie)) {
       setCidCookie(win, cookieName, existingCookie);
     }
     return /** @type {!Promise<?string>} */ (Promise.resolve(existingCookie));
+  }
+
+  if (cid.externalCidCache_[scope]) {
+    return /** @type {!Promise<?string>} */ (cid.externalCidCache_[scope]);
   }
 
   const newCookiePromise = getRandomString64(win)


### PR DESCRIPTION
Please see https://github.com/ampproject/amphtml/issues/25525#issuecomment-568125214 for context. 

Closes #25525 

@zikas Could you please confirm that this is the desired behavior. That the `CLIENT_ID(scope, opt_userNotificationId, opt_cookieName)` always return the value from `opt_cookieName` even if there's also value stored in `scope` (or if there's a new value generated for `scope`)? Thank you!