### PR TITLE
Allow chrome protocol to A href

### DIFF
--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -1895,6 +1895,7 @@ tags: {
       # Blackberry messenger
       # (http://devblog.blackberry.com/2015/02/cross-platform-sharing-with-bbm/)
       protocol: "bbmi"
+      protocol: "chrome"
       # IOS over-the-air app installation
       # (https://github.com/nifcblm/AHPP-iOS-App/wiki/How-to-distribute-enterprise-iOS-App)
       protocol: "itms-services"


### PR DESCRIPTION
Fixes #26061

Allows `chrome://` protocol in `<a href>`.