### PR TITLE
Support Ctrl + Enter to submit a form within a <textarea>

### DIFF
--- a/examples/forms.amp.html
+++ b/examples/forms.amp.html
@@ -155,7 +155,7 @@
     </style>
 </head>
 <body>
-
+  
 <amp-analytics>
     <script type="application/json">
         {
@@ -181,6 +181,17 @@
         }
     </script>
 </amp-analytics>
+
+<h4>Form with textarea</h4>
+<form method="post" action-xhr="/form/echo-json/post" target="_blank">
+  <textarea name="textarea-ctrl-submit">Press Ctrl+Enter to submit this text</textarea><br>
+  <input name="submit-button" type="submit" value="Submit" />
+  <div submit-success>
+    <template type="amp-mustache">
+      Success! {{textarea-ctrl-submit}}
+    </template>
+  </div>
+</form>
 
 <h4>Search (GET non-xhr same origin)</h4>
 <form method="get" action="/form/search-html/get" target="_blank">

--- a/examples/forms.amp.html
+++ b/examples/forms.amp.html
@@ -155,7 +155,7 @@
     </style>
 </head>
 <body>
-  
+
 <amp-analytics>
     <script type="application/json">
         {

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -1631,6 +1631,7 @@ export class AmpFormService {
   installFormSubmissionShortcutForTextarea_(doc) {
     doc.addEventListener('keydown', e => {
       if (
+        e.defaultPrevented ||
         e.key != Keys.ENTER ||
         !(e.ctrlKey || e.metaKey) ||
         e.target.tagName !== 'TEXTAREA'
@@ -1643,6 +1644,7 @@ export class AmpFormService {
         return;
       }
       ampForm.handleSubmitEvent_(e);
+      e.preventDefault();
     });
   }
 }

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -1589,7 +1589,7 @@ export class AmpFormService {
 
       this.installSubmissionHandlers_(root.querySelectorAll('form'));
       AmpFormTextarea.install(ampdoc);
-      this.installGlobalEventListener_(root);
+      this.installDomUpdateEventListener_(root);
       this.installFormSubmissionShortcutForTextarea_(root);
     });
   }
@@ -1618,7 +1618,7 @@ export class AmpFormService {
    * @param {!Document|!ShadowRoot} doc
    * @private
    */
-  installGlobalEventListener_(doc) {
+  installDomUpdateEventListener_(doc) {
     doc.addEventListener(AmpEvents.DOM_UPDATE, () => {
       this.installSubmissionHandlers_(doc.querySelectorAll('form'));
     });

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -1627,7 +1627,7 @@ export class AmpFormService {
   /**
    * Listen for Ctrl/Cmd + Enter in textarea elements
    * to trigger form submission when relevant.
-   * @param {!Document} doc
+   * @param {!Document|!ShadowRoot} doc
    */
   installFormSubmissionShortcutForTextarea_(doc) {
     doc.addEventListener('keydown', e => {
@@ -1641,7 +1641,10 @@ export class AmpFormService {
       const formId = e.target.getAttribute('form');
       const form = formId
         ? doc.getElementById(formId)
-        : closestAncestorElementBySelector(e.target, 'form');
+        : closestAncestorElementBySelector(
+            dev().assertElement(e.target),
+            'form'
+          );
       const ampForm = form ? formOrNullForElement(form) : null;
       if (!ampForm) {
         return;

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -31,6 +31,7 @@ import {
 import {FormDirtiness} from './form-dirtiness';
 import {FormEvents} from './form-events';
 import {FormSubmitService} from './form-submit-service';
+import {Keys} from '../../../src/utils/key-codes';
 import {
   SOURCE_ORIGIN_PARAM,
   addParamsToUrl,
@@ -431,6 +432,15 @@ export class AmpForm {
       checkUserValidityAfterInteraction_(dev().assertElement(e.target));
       this.validator_.onInput(e);
     });
+
+    // Ctrl/Cmd + Enter on textarea or contenteditable triggers form submission.
+    this.form_.querySelectorAll('textarea,[contenteditable]').forEach(el =>
+      el.addEventListener('keydown', e => {
+        if (e.key == Keys.ENTER && (e.ctrlKey || e.metaKey)) {
+          this.handleSubmitEvent_(e);
+        }
+      })
+    );
   }
 
   /** @private */

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -43,7 +43,6 @@ import {SsrTemplateHelper} from '../../../src/ssr-template-helper';
 import {
   ancestorElementsByTag,
   childElementByAttr,
-  closestAncestorElementBySelector,
   createElementWithAttributes,
   iterateCursor,
   removeElement,
@@ -1638,13 +1637,7 @@ export class AmpFormService {
       ) {
         return;
       }
-      const formId = e.target.getAttribute('form');
-      const form = formId
-        ? doc.getElementById(formId)
-        : closestAncestorElementBySelector(
-            dev().assertElement(e.target),
-            'form'
-          );
+      const {form} = e.target;
       const ampForm = form ? formOrNullForElement(form) : null;
       if (!ampForm) {
         return;


### PR DESCRIPTION
Resolves #26004.

This change supports form submission via `Ctrl`/`Cmd` + `Enter` from within any nested `textarea`  element. 