### PR TITLE
Whitelist amp-list's [is-layout-container] in AMP for Email

### DIFF
--- a/extensions/amp-list/validator-amp-list.protoascii
+++ b/extensions/amp-list/validator-amp-list.protoascii
@@ -238,6 +238,10 @@ tags: {  # <amp-list>
     name: "template"
     value_oneof_set: TEMPLATE_IDS
   }
+  # <amp-bind>
+  attrs: {
+    name: "[is-layout-container]"
+  }
   attr_lists: "extended-amp-global"
   amp_layout: {
     supported_layouts: FILL


### PR DESCRIPTION
This can already be achieved via the `changeToLayoutContainer` action, so it makes sense to whitelist the binding too.