### PR TITLE
🐛Remask amp-inputmask elements on amp-state change

### DIFF
--- a/examples/masking.amp.html
+++ b/examples/masking.amp.html
@@ -16,6 +16,50 @@
 </head>
 <body>
   <h1>Input Masking</h1>
+  <h2>Mask with amp-state</h2>
+  <form
+    method="post"
+    action-xhr="/form/echo-json/post"
+    target="_blank"
+    >
+      <label
+        >Masked input:
+        <input
+          [value]="maskedValue"
+          on="change:AMP.setState({maskedValue: event.value})"
+          name="statemask"
+          mask="000-000-000"
+          mask-output="alphanumeric" 
+          placeholder="Type some numbers..."
+      /></label>
+      <input type="submit">
+      <div submit-success>
+        <template type="amp-mustache">
+          {{statemask}}, 
+          {{statemask-unmasked}}
+        </template>
+      </div>
+    </form>
+    <div>
+      <div class="pt-15">
+        <button on="tap:AMP.setState({maskedValue:''})">
+          Reset value with AMP.setState
+        </button>
+      </div>
+      <div class="pt-15">
+        <label
+          ><button on="tap:AMP.setState({maskedValue:maskedValueProxy || ''})">
+            Apply value with AMP.setState
+          </button>
+          <input
+            [value]="maskedValueProxy"
+            on="change:AMP.setState({maskedValueProxy: event.value})"
+            name="maskedValueProxy"
+            mask="000-000-000"
+            placeholder="Type value to be applied..."
+        /></label>
+      </div>
+    </div>
 
   <h2>Named Masks</h2>
   <form method="post"

--- a/extensions/amp-inputmask/0.1/mask-impl.js
+++ b/extensions/amp-inputmask/0.1/mask-impl.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {AmpEvents} from '../../../src/amp-events';
 import {MASK_SEPARATOR_CHAR, MaskChars, NamedMasks} from './constants';
 import {MaskInterface} from './mask-interface';
 import {dict} from '../../../src/utils/object';
@@ -95,6 +96,10 @@ export class Mask {
     }
 
     this.controller_ = this.Inputmask_(config);
+
+    this.element_.addEventListener(AmpEvents.FORM_VALUE_CHANGE, () => {
+      this.mask();
+    });
   }
 
   /**

--- a/extensions/amp-inputmask/0.1/test/test-mask-impl.js
+++ b/extensions/amp-inputmask/0.1/test/test-mask-impl.js
@@ -17,9 +17,7 @@
 import {Mask} from '../mask-impl';
 
 describes.sandboxed('amp-inputmask mask-impl', {}, env => {
-  class FakeElement {
-    addEventListener() {}
-  }
+  class FakeElement {}
 
   describe('config', () => {
     let constructorStub;
@@ -31,6 +29,7 @@ describes.sandboxed('amp-inputmask mask-impl', {}, env => {
       env.sandbox.stub(Mask, 'getInputmask_').returns(constructorStub);
 
       FakeElement.prototype.getAttribute = env.sandbox.stub();
+      FakeElement.prototype.addEventListener = env.sandbox.stub();
     });
 
     it(

--- a/extensions/amp-inputmask/0.1/test/test-mask-impl.js
+++ b/extensions/amp-inputmask/0.1/test/test-mask-impl.js
@@ -17,7 +17,9 @@
 import {Mask} from '../mask-impl';
 
 describes.sandboxed('amp-inputmask mask-impl', {}, env => {
-  class FakeElement {}
+  class FakeElement {
+    addEventListener() {}
+  }
 
   describe('config', () => {
     let constructorStub;


### PR DESCRIPTION
Fixes #24493

Calls `mask` on an `amp-inputmask` input when its value gets altered by `amp-state`. 