### PR TITLE
📖 Document `amp-nested-menu` usage in `amp-sidebar`

### DIFF
--- a/extensions/amp-nested-menu/amp-nested-menu.md
+++ b/extensions/amp-nested-menu/amp-nested-menu.md
@@ -4,7 +4,6 @@ formats:
   - websites
 teaser:
   text: Displays a drilldown menu with arbitrary levels of nested submenus.
-experimental: true
 ---
 
 <!--
@@ -72,7 +71,7 @@ Only `<div>` tags may receive the `amp-nested-submenu` attribute. The submenu op
 The following example demonstrates an `<amp-nested-menu>` with two levels of nested submenus.
 
 [tip type="note"]
-We recommend wrapping every menu item in a `li` element to improve accessibility and keyboard support.
+Wrap every menu item in a `li` element to improve accessibility and keyboard support.
 [/tip]
 
 [example playground="true" preview="top-frame" imports="amp-sidebar"]

--- a/extensions/amp-nested-menu/amp-nested-menu.md
+++ b/extensions/amp-nested-menu/amp-nested-menu.md
@@ -70,10 +70,6 @@ Only `<div>` tags may receive the `amp-nested-submenu` attribute. The submenu op
 
 The following example demonstrates an `<amp-nested-menu>` with two levels of nested submenus.
 
-[tip type="note"]
-Wrap every menu item in a `li` element to improve accessibility and keyboard support.
-[/tip]
-
 [example playground="true" preview="top-frame" imports="amp-sidebar"]
 
 ```html
@@ -202,6 +198,10 @@ The `<amp-nested-menu>` component can be styled with standard CSS.
 ## Accessibility
 
 `<amp-nested-menu>` assigns `role=button` and `tabindex=0` on each submenu open/close element. When a submenu opens, focus shifts to the submenu close element inside it. When the submenu closes, focus shifts back to the submenu open element that opened it.
+
+[tip type="note"]
+Wrap every menu item in a `li` element to improve accessibility and keyboard support.
+[/tip]
 
 The component supports arrow key navigation as follows:
 

--- a/extensions/amp-sidebar/0.1/amp-sidebar.md
+++ b/extensions/amp-sidebar/0.1/amp-sidebar.md
@@ -328,7 +328,7 @@ Please see [this example file](https://github.com/ampproject/amphtml/blob/master
 
 ## Building Nested Menus
 
-`<amp-sidebar>` can supports drilldown (nested) menus through the [`<amp-nested-menu>`](https://amp.dev/documentation/components/amp-nested-menu/) component which must be placed as a child of `<amp-sidebar>`. `<amp-nested-menu>` supports nesting one or more layers of submenus as demonstrated by the following example:
+`<amp-sidebar>` can supports drilldown (nested) menus through a child component named [`<amp-nested-menu>`](https://amp.dev/documentation/components/amp-nested-menu/). With `<amp-nested-menu>`, `<amp-sidebar>` can support nesting one or more layers of submenus (and transition between them) as demonstrated by the following example:
 
 [tip type="note"]
 We recommend wrapping every menu item in a `li` element to improve accessibility and keyboard support.

--- a/extensions/amp-sidebar/0.1/amp-sidebar.md
+++ b/extensions/amp-sidebar/0.1/amp-sidebar.md
@@ -328,10 +328,10 @@ Please see [this example file](https://github.com/ampproject/amphtml/blob/master
 
 ## Building Nested Menus
 
-`<amp-sidebar>` can supports drilldown (nested) menus through a child component named [`<amp-nested-menu>`](https://amp.dev/documentation/components/amp-nested-menu/). With `<amp-nested-menu>`, `<amp-sidebar>` can support nesting one or more layers of submenus (and transition between them) as demonstrated by the following example:
+`<amp-sidebar>` supports drilldown (nested) menus through a child component named [`<amp-nested-menu>`](../../amp-nested-menu/amp-nested-menu.md). With `<amp-nested-menu>`, `<amp-sidebar>` can support nesting one or more layers of submenus (and transition between them) as demonstrated by the following example:
 
 [tip type="note"]
-We recommend wrapping every menu item in a `li` element to improve accessibility and keyboard support.
+Wrap every menu item in a `li` element to improve accessibility and keyboard support.
 [/tip]
 
 [example playground="true" preview="top-frame" imports="amp-sidebar"]
@@ -367,7 +367,7 @@ We recommend wrapping every menu item in a `li` element to improve accessibility
 
 [/example]
 
-See [`<amp-nested-menu>`](https://amp.dev/documentation/components/amp-nested-menu/) for the full documentation on nested menus along with advanced feature such as dynamic content loading.
+See [`<amp-nested-menu>`](../../amp-nested-menu/amp-nested-menu.md) for the full documentation on nested menus along with advanced feature such as dynamic content loading.
 
 ## UX considerations
 

--- a/extensions/amp-sidebar/0.1/amp-sidebar.md
+++ b/extensions/amp-sidebar/0.1/amp-sidebar.md
@@ -331,7 +331,7 @@ Please see [this example file](https://github.com/ampproject/amphtml/blob/master
 `<amp-sidebar>` supports drilldown (nested) menus through a child component named [`<amp-nested-menu>`](../../amp-nested-menu/amp-nested-menu.md). With `<amp-nested-menu>`, `<amp-sidebar>` can support nesting one or more layers of submenus (and transition between them) as demonstrated by the following example:
 
 [tip type="note"]
-Wrap every menu item in a `li` element to improve accessibility and keyboard support.
+When using `amp-nested-menu`, wrap every menu item in a `li` element to improve accessibility and keyboard support.
 [/tip]
 
 [example playground="true" preview="top-frame" imports="amp-sidebar"]

--- a/extensions/amp-sidebar/0.1/amp-sidebar.md
+++ b/extensions/amp-sidebar/0.1/amp-sidebar.md
@@ -326,6 +326,49 @@ When using `toolbar` feature, `autoscroll` only works if the `<nav toolbar>` ele
 
 Please see [this example file](https://github.com/ampproject/amphtml/blob/master/examples/amp-sidebar-autoscroll.amp.html) for a working example code.
 
+## Building Nested Menus
+
+`<amp-sidebar>` can supports drilldown (nested) menus through the [`<amp-nested-menu>`](https://amp.dev/documentation/components/amp-nested-menu/) component which must be placed as a child of `<amp-sidebar>`. `<amp-nested-menu>` supports nesting one or more layers of submenus as demonstrated by the following example:
+
+[tip type="note"]
+We recommend wrapping every menu item in a `li` element to improve accessibility and keyboard support.
+[/tip]
+
+[example playground="true" preview="top-frame" imports="amp-sidebar"]
+
+```html
+<button on="tap:sidebar1">Open Sidebar</button>
+<amp-sidebar id="sidebar1" layout="nodisplay" style="width:300px">
+  <amp-nested-menu layout="fill">
+    <ul>
+      <li>
+        <h4 amp-nested-submenu-open>Open Sub-Menu</h4>
+        <div amp-nested-submenu>
+          <ul>
+            <li>
+              <h4 amp-nested-submenu-close>Go back</h4>
+            </li>
+            <li>
+              <h4 amp-nested-submenu-open>Open Another Sub-Menu</h4>
+              <div amp-nested-submenu>
+                <h4 amp-nested-submenu-close>Go back</h4>
+              </div>
+            </li>
+          </ul>
+        </div>
+      </li>
+      <li>
+        <a href="https://amp.dev/">Link</a>
+      </li>
+    </ul>
+  </amp-nested-menu>
+</amp-sidebar>
+```
+
+[/example]
+
+See [`<amp-nested-menu>`](https://amp.dev/documentation/components/amp-nested-menu/) for the full documentation on nested menus along with advanced feature such as dynamic content loading.
+
 ## UX considerations
 
 When using `<amp-sidebar>`, keep in mind that your users will often view your page on mobile in an AMP viewer, which may display a fixed-position header. In addition, browsers often display their own fixed header at the top of the page. Adding another fixed-position element at the top of the screen would take up a large amount of mobile screen space with content that gives the user no new information.


### PR DESCRIPTION
Closes #26175, Partial for #26176 

### Changes
- Adds an excerpt of the `amp-nested-menu` documentation to `amp-sidebar` 0.1