### PR TITLE
♻️ amp-script: inline amp-script-worker.js

### DIFF
--- a/build-system/compile/sources.js
+++ b/build-system/compile/sources.js
@@ -85,6 +85,8 @@ const CLOSURE_SRC_GLOBS = [
   'build/patched-module/**/*.js',
   'build/experiments/**/*.js',
   'build/parsers/**/*.js',
+  'build/amp-script-worker.js',
+  'build/amp-script-worker.max.js',
   // A4A has these cross extension deps.
   'extensions/amp-ad-network*/**/*-config.js',
   'extensions/amp-ad/**/*.js',

--- a/build-system/tasks/build.js
+++ b/build-system/tasks/build.js
@@ -27,6 +27,7 @@ const {
   exitCtrlcHandler,
 } = require('../common/ctrlcHandler');
 const {buildExtensions} = require('./extension-helpers');
+const {compileAmpScriptWorker} = require('./extension-helpers.js');
 const {compileCss} = require('./css');
 const {compileJison} = require('./compile-jison');
 const {cyan, green} = require('ansi-colors');
@@ -77,6 +78,7 @@ function printDefaultTaskHelp() {
 async function performPrerequisiteSteps(watch) {
   await compileCss(watch);
   await compileJison();
+  await compileAmpScriptWorker();
   await bootstrapThirdPartyFrames(watch);
 }
 

--- a/build-system/tasks/dep-check.js
+++ b/build-system/tasks/dep-check.js
@@ -30,6 +30,7 @@ const {
   exitCtrlcHandler,
 } = require('../common/ctrlcHandler');
 const {BABELIFY_GLOBAL_TRANSFORM} = require('./helpers');
+const {compileAmpScriptWorker} = require('./extension-helpers.js');
 const {compileJison} = require('./compile-jison');
 const {css} = require('./css');
 const {cyan, red, yellow} = require('ansi-colors');
@@ -298,8 +299,8 @@ function runRules(modules) {
 
 async function depCheck() {
   const handlerProcess = createCtrlcHandler('dep-check');
-  await css();
-  await compileJison();
+  await Promise.all([css(), compileJison(), compileAmpScriptWorker()]);
+
   if (!isTravisBuild()) {
     log('Checking dependencies...');
   }

--- a/build-system/tasks/dist.js
+++ b/build-system/tasks/dist.js
@@ -33,6 +33,11 @@ const {
   transferSrcsToTempDir,
 } = require('./helpers');
 const {
+  buildExtensions,
+  parseExtensionFlags,
+  compileAmpScriptWorker,
+} = require('./extension-helpers');
+const {
   createCtrlcHandler,
   exitCtrlcHandler,
 } = require('../common/ctrlcHandler');
@@ -44,7 +49,6 @@ const {
   startNailgunServer,
   stopNailgunServer,
 } = require('./nailgun');
-const {buildExtensions, parseExtensionFlags} = require('./extension-helpers');
 const {cleanupBuildDir} = require('../compile/compile');
 const {compileCss, cssEntryPoints} = require('./css');
 const {compileJison} = require('./compile-jison');
@@ -97,8 +101,7 @@ async function dist() {
 
   cleanupBuildDir();
   await prebuild();
-  await compileCss();
-  await compileJison();
+  await Promise.all([compileCss(), compileJison(), compileAmpScriptWorker()]);
 
   // This is the temp directory processing for multi-pass (single-pass does its
   // own processing). Executed after `compileCss` and `compileJison` so their

--- a/build-system/tasks/unit.js
+++ b/build-system/tasks/unit.js
@@ -24,6 +24,7 @@ const {
   RuntimeTestRunner,
   RuntimeTestConfig,
 } = require('./runtime-test/runtime-test-base');
+const {compileAmpScriptWorker} = require('./extension-helpers.js');
 const {compileJison} = require('./compile-jison');
 const {css} = require('./css');
 const {getUnitTestsToRun} = require('./runtime-test/helpers-unit');
@@ -39,8 +40,7 @@ class Runner extends RuntimeTestRunner {
       return;
     }
 
-    await css();
-    await compileJison();
+    await Promise.all([css(), compileJison(), compileAmpScriptWorker()]);
   }
 }
 

--- a/extensions/amp-script/0.1/test/unit/test-amp-script.js
+++ b/extensions/amp-script/0.1/test/unit/test-amp-script.js
@@ -47,9 +47,6 @@ describes.fakeWin('AmpScript', {amp: {runtimeOn: false}}, env => {
     xhr = {
       fetchText: env.sandbox.stub(),
     };
-    xhr.fetchText
-      .withArgs(env.sandbox.match(/amp-script-worker-0.1.js/))
-      .resolves({text: () => Promise.resolve('/* noop */')});
     env.sandbox.stub(Services, 'xhrFor').returns(xhr);
 
     // Make @ampproject/worker-dom dependency a no-op for these unit tests.


### PR DESCRIPTION
**summary**
Inlines the `amp-script-worker.js` file into a string constant. This should improve the init time of any page that uses amp-script by removing the need for a roundtrip. Beyond the roundtrip, this also allows the worker text to be downloaded with the initial set of script tags instead of waiting for amp-script to boot up.


Note:
- no longer any "version" associated with the worker file since it is not distributed standalone. 