### PR TITLE
🐛Fix ad request logic in stories

### DIFF
--- a/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js
+++ b/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js
@@ -577,6 +577,7 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
 
   /**
    * Reset the counter that tracks when to place ads.
+   * @private
    */
   resetPageCount_() {
     this.uniquePagesCount_ = 0;

--- a/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js
+++ b/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js
@@ -460,19 +460,24 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
     if (this.adPageIds_[pageId]) {
       // We are switching to an ad.
       const adIndex = this.adPageIds_[pageId];
+      const adPage = this.adPages_[adIndex - 1];
+
+      if (!adPage.hasBeenViewed()) {
+        this.pendingAdView_ = false;
+        this.resetPageCount_();
+        if (this.enoughPagesLeftInStory_(pageIndex)) {
+          this.startNextAdPage_();
+        }
+      }
+
       // Tell the iframe that it is visible.
-      this.setVisibleAttribute_(this.adPages_[adIndex - 1]);
+      this.setVisibleAttribute_(adPage);
+
       // Fire the view event on the corresponding Ad.
       this.analyticsEvent_(AnalyticsEvents.AD_VIEWED, {
         [AnalyticsVars.AD_VIEWED]: Date.now(),
         [AnalyticsVars.AD_INDEX]: adIndex,
       });
-
-      // Previously inserted ad has been viewed.
-      this.pendingAdView_ = false;
-
-      // Start loading next ad.
-      this.startNextAdPage_();
 
       // Keeping track of this here so that we can contain the logic for when
       // we exit the ad within this extension.
@@ -502,7 +507,7 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
           this.analyticsEventWithCurrentAd_(AnalyticsEvents.AD_DISCARDED, {
             [AnalyticsVars.AD_DISCARDED]: Date.now(),
           });
-          this.startNextAdPage_(/* failure */ true);
+          this.startNextAdPage_();
         }
       });
     }
@@ -562,19 +567,19 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
   /**
    * Start the process over.
    * @private
-   * @param {boolean=} opt_failure If we are calling this due to failed ad.
    */
-  startNextAdPage_(opt_failure) {
+  startNextAdPage_() {
     if (!this.firstAdViewed_) {
       this.firstAdViewed_ = true;
     }
-
-    if (!opt_failure) {
-      // Don't reset the count on a failed ad.
-      this.uniquePagesCount_ = 0;
-    }
-
     this.schedulePage_();
+  }
+
+  /**
+   * Reset the counter that tracks when to place ads.
+   */
+  resetPageCount_() {
+    this.uniquePagesCount_ = 0;
   }
 
   /**

--- a/extensions/amp-story-auto-ads/0.1/story-ad-page.js
+++ b/extensions/amp-story-auto-ads/0.1/story-ad-page.js
@@ -124,6 +124,9 @@ export class StoryAdPage {
 
     /** @private @const {./story-ad-button-text-fitter.ButtonTextFitter} */
     this.buttonFitter_ = buttonFitter;
+
+    /** @private {boolean} */
+    this.viewed_ = false;
   }
 
   /** @return {?Document} ad document within FIE */
@@ -148,6 +151,11 @@ export class StoryAdPage {
     return this.loaded_;
   }
 
+  /** @return {boolean} */
+  hasBeenViewed() {
+    return this.viewed_;
+  }
+
   /** @return {?Element} */
   getPageElement() {
     return this.pageElement_;
@@ -166,6 +174,7 @@ export class StoryAdPage {
    * respond accordingly.
    */
   toggleVisibility() {
+    this.viewed_ = true;
     // TODO(calebcordry): Properly handle visible attribute for custom ads.
     if (this.adDoc_) {
       toggleAttribute(


### PR DESCRIPTION
Fixes 2 bugs:

1. Should not request a new ad when visiting a previously seen ad (only when user sees a new ad)
2. Should not request an ad when there are not enough pages left in a story for it to be placed.

Closes #22001 