### PR TITLE
Fix amp-consent flakey e2e

### DIFF
--- a/extensions/amp-consent/0.1/test-e2e/test-amp-consent-server-side-expire-cache.js
+++ b/extensions/amp-consent/0.1/test-e2e/test-amp-consent-server-side-expire-cache.js
@@ -39,10 +39,16 @@ describes.endtoend(
       requestBank = env.requestBank;
     });
 
-    it.skip('should respect server side decision and clear on next visit', async () => {
+    it('should respect server side decision and clear on next visit', async () => {
       resetAllElements();
       const currentUrl = await controller.getCurrentUrl();
       const nextGeoUrl = currentUrl.replace('mx', 'ca');
+
+      // Check the analytics request consentState
+      const insufficientRequest = await requestBank.withdraw('tracking');
+      await expect(insufficientRequest.url).to.match(
+        /consentState=insufficient/
+      );
 
       // Block/unblock elements based off of 'reject' from response
       await findElements(controller);
@@ -84,8 +90,8 @@ describes.endtoend(
       });
 
       // Check the analytics request consentState
-      const req = await requestBank.withdraw('tracking');
-      await expect(req.url).to.match(/consentState=sufficient/);
+      const sufficentReqest = await requestBank.withdraw('tracking');
+      await expect(sufficentReqest.url).to.match(/consentState=sufficient/);
     });
   }
 );

--- a/extensions/amp-consent/0.1/test-e2e/test-amp-consent-server-side.js
+++ b/extensions/amp-consent/0.1/test-e2e/test-amp-consent-server-side.js
@@ -59,7 +59,6 @@ describes.endtoend(
         'ui2': true,
         'postPromptUi': false,
       });
-      // [true, true, false]);
 
       // Navigate away to random page
       await controller.navigateTo('http://localhost:8000/');


### PR DESCRIPTION
Closes #26214

Was making 2 analytics request (1 for each page visit), but only withdrawing 1 from the request bank, leading to sometimes checking the right request.

Now withdraw both requests in the correct order. 