### PR TITLE
✨Add support for AMP Story Quiz Reaction API calls

### DIFF
--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -427,6 +427,7 @@ const forbiddenTerms = {
       'extensions/amp-experiment/1.0/variant.js',
       'extensions/amp-user-notification/0.1/amp-user-notification.js',
       'extensions/amp-consent/0.1/consent-state-manager.js',
+      'extensions/amp-story/1.0/amp-story-quiz.js',
     ],
   },
   'getBaseCid': {

--- a/examples/amp-story/quiz.html
+++ b/examples/amp-story/quiz.html
@@ -65,7 +65,7 @@
       <amp-story-grid-layer>
         <amp-story-quiz
           id='cat-question-appear'
-          endpoint="http://localhost:8000">
+          endpoint="http://localhost:3000/reactions">
           <h1>When did the domestic cat first appear on the scene?</h1>
           <option>7,000 years ago</option>
           <option correct>500,000 years ago</option>

--- a/examples/amp-story/quiz.html
+++ b/examples/amp-story/quiz.html
@@ -65,7 +65,7 @@
       <amp-story-grid-layer>
         <amp-story-quiz
           id='cat-question-appear'
-          endpoint="https://google.com">
+          endpoint="http://localhost:8000">
           <h1>When did the domestic cat first appear on the scene?</h1>
           <option>7,000 years ago</option>
           <option correct>500,000 years ago</option>

--- a/examples/amp-story/quiz.html
+++ b/examples/amp-story/quiz.html
@@ -64,7 +64,8 @@
       </amp-story-grid-layer>
       <amp-story-grid-layer>
         <amp-story-quiz
-          id='cat-question-appear'>
+          id='cat-question-appear'
+          endpoint="https://google.com">
           <h1>When did the domestic cat first appear on the scene?</h1>
           <option>7,000 years ago</option>
           <option correct>500,000 years ago</option>

--- a/extensions/amp-story/1.0/amp-story-quiz.js
+++ b/extensions/amp-story/1.0/amp-story-quiz.js
@@ -48,11 +48,11 @@ const ENDPOINT_INVALID_ERROR =
   'The publisher has specified an invalid datastore endpoint';
 
 /**
- * @typedef {
+ * @typedef {{
  *    totalResponseCount: number,
  *    hasUserResponded: boolean,
  *    responses: !Object,
- * }
+ * }}
  */
 export let ReactionResponseType;
 

--- a/extensions/amp-story/1.0/amp-story-quiz.js
+++ b/extensions/amp-story/1.0/amp-story-quiz.js
@@ -431,7 +431,7 @@ export class AmpStoryQuiz extends AMP.BaseElement {
     }).getAttribute('id');
 
     if (this.reactionId_ === null) {
-      this.reactionId_ = `CANONICAL_URL?page=${quizPageId}`;
+      this.reactionId_ = `CANONICAL_URL#page=${quizPageId}`;
     }
 
     const requestVars = dict({

--- a/extensions/amp-story/1.0/amp-story-quiz.js
+++ b/extensions/amp-story/1.0/amp-story-quiz.js
@@ -126,8 +126,12 @@ export class AmpStoryQuiz extends AMP.BaseElement {
     this.adjustGridLayer_();
     this.attachContent_();
     this.initializeListeners_();
-    this.retrieveReactionData_();
     createShadowRootWithStyle(this.element, this.quizEl_, CSS);
+  }
+
+  /** @override */
+  layoutCallback() {
+    this.retrieveReactionData_();
   }
 
   /**
@@ -421,7 +425,6 @@ export class AmpStoryQuiz extends AMP.BaseElement {
 
     return this.getClientId_().then(clientId => {
       requestVars.userId = clientId;
-      console.log(clientId);
       return this.requestService_.executeRequest(URL, null, requestOptions);
     });
   }

--- a/extensions/amp-story/1.0/amp-story-quiz.js
+++ b/extensions/amp-story/1.0/amp-story-quiz.js
@@ -43,7 +43,7 @@ const STORY_REACTION_TYPE_QUIZ = 0;
 
 /** @const {string} */
 const ENDPOINT_UNAVAILABLE_ERROR =
-  'The publisher has not specified an endpoint';
+  'The publisher has not specified a datastore endpoint';
 
 /**
  * @typedef {{
@@ -131,6 +131,8 @@ export class AmpStoryQuiz extends AMP.BaseElement {
   }
 
   /**
+   * Gets a Promise to return the unique AMP clientId
+   *
    * @private
    * @return {Promise<string>}
    */
@@ -356,6 +358,8 @@ export class AmpStoryQuiz extends AMP.BaseElement {
   }
 
   /**
+   * Get the Reaction data from the datastore
+   *
    * @private
    */
   retrieveReactionData_() {
@@ -370,6 +374,8 @@ export class AmpStoryQuiz extends AMP.BaseElement {
   }
 
   /**
+   * Update the Reaction data in the datastore
+   *
    * @private
    * @param {number} reactionResponse
    */
@@ -383,6 +389,8 @@ export class AmpStoryQuiz extends AMP.BaseElement {
   }
 
   /**
+   * Executes a Reactions API call
+   *
    * @param {number} reactionResponse
    * @return {Promise<JsonObject>}
    * @private

--- a/extensions/amp-story/1.0/amp-story-quiz.js
+++ b/extensions/amp-story/1.0/amp-story-quiz.js
@@ -383,11 +383,10 @@ export class AmpStoryQuiz extends AMP.BaseElement {
       }
 
       this.triggerAnalytics_(optionEl);
+      this.hasUserSelection_ = true;
 
       this.mutateElement(() => {
         this.updateQuizToPostSelectionState_(optionEl);
-
-        this.hasUserSelection_ = true;
       });
 
       if (this.element.hasAttribute('endpoint')) {

--- a/extensions/amp-story/1.0/amp-story-request-service.js
+++ b/extensions/amp-story/1.0/amp-story-request-service.js
@@ -71,7 +71,7 @@ export class AmpStoryRequestService {
       const credentials = bookendEl.getAttribute(
         BOOKEND_CREDENTIALS_ATTRIBUTE_NAME
       );
-      return this.loadJsonFromAttribute_(rawUrl, credentials);
+      return this.executeRequest(rawUrl, {credentials});
     }
 
     // Fallback. Check for an inline json config.
@@ -85,20 +85,13 @@ export class AmpStoryRequestService {
 
   /**
    * @param {string} rawUrl
-   * @param {string|null} credentials
+   * @param {Object} opts
    * @return {(!Promise<!JsonObject>|!Promise<null>)}
-   * @private
    */
-  loadJsonFromAttribute_(rawUrl, credentials) {
-    const opts = {};
-
+  executeRequest(rawUrl, opts = {}) {
     if (!isProtocolValid(rawUrl)) {
       user().error(TAG, 'Invalid config url.');
       return Promise.resolve(null);
-    }
-
-    if (credentials) {
-      opts.credentials = credentials;
     }
 
     return Services.urlReplacementsForDoc(this.storyElement_)

--- a/extensions/amp-story/1.0/amp-story-request-service.js
+++ b/extensions/amp-story/1.0/amp-story-request-service.js
@@ -71,7 +71,7 @@ export class AmpStoryRequestService {
       const credentials = bookendEl.getAttribute(
         BOOKEND_CREDENTIALS_ATTRIBUTE_NAME
       );
-      return this.executeRequest(rawUrl, {credentials});
+      return this.executeRequest(rawUrl, credentials ? {credentials} : {});
     }
 
     // Fallback. Check for an inline json config.

--- a/extensions/amp-story/1.0/amp-story-request-service.js
+++ b/extensions/amp-story/1.0/amp-story-request-service.js
@@ -85,7 +85,7 @@ export class AmpStoryRequestService {
 
   /**
    * @param {string} rawUrl
-   * @param {Object} opts
+   * @param {Object=} opts
    * @return {(!Promise<!JsonObject>|!Promise<null>)}
    */
   executeRequest(rawUrl, opts = {}) {

--- a/extensions/amp-story/1.0/test/test-amp-story-quiz.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-quiz.js
@@ -219,7 +219,7 @@ describes.realWin(
       quizOptions[0].click();
       quizOptions[1].click();
 
-      // Microtask ticks
+      // Microtask tick
       await Promise.resolve();
 
       expect(quizOptions[0]).to.have.class(

--- a/extensions/amp-story/1.0/test/test-amp-story-quiz.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-quiz.js
@@ -64,24 +64,24 @@ const populateStandardQuizContent = (win, quizElement) => {
 const getMockReactionData = () => {
   return {
     data: {
-      total_response_count: 10,
-      has_user_responded: true,
+      totalResponseCount: 10,
+      hasUserResponded: true,
       responses: {
         0: {
-          total_count: 3,
-          selected_by_user: true,
+          totalCount: 3,
+          selectedByUser: true,
         },
         1: {
-          total_count: 3,
-          selected_by_user: false,
+          totalCount: 3,
+          selectedByUser: false,
         },
         2: {
-          total_count: 3,
-          selected_by_user: false,
+          totalCount: 3,
+          selectedByUser: false,
         },
         3: {
-          total_count: 1,
-          selected_by_user: false,
+          totalCount: 1,
+          selectedByUser: false,
         },
       },
     },

--- a/extensions/amp-story/1.0/test/test-amp-story-quiz.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-quiz.js
@@ -17,6 +17,7 @@
 import {AmpStoryQuiz} from '../amp-story-quiz';
 import {AmpStoryStoreService} from '../amp-story-store-service';
 import {AnalyticsVariable, getVariableService} from '../variable-service';
+import {Services} from '../../../../src/services';
 import {getAnalyticsService} from '../story-analytics';
 import {getRequestService} from '../amp-story-request-service';
 import {registerServiceBuilder} from '../../../../src/service';
@@ -66,24 +67,28 @@ const getMockReactionData = () => {
     data: {
       totalResponseCount: 10,
       hasUserResponded: true,
-      responses: {
-        0: {
+      responses: [
+        {
+          reactionValue: 0,
           totalCount: 3,
           selectedByUser: true,
         },
-        1: {
+        {
+          reactionValue: 1,
           totalCount: 3,
           selectedByUser: false,
         },
-        2: {
+        {
+          reactionValue: 2,
           totalCount: 3,
           selectedByUser: false,
         },
-        3: {
+        {
+          reactionValue: 3,
           totalCount: 1,
           selectedByUser: false,
         },
-      },
+      ],
     },
   };
 };
@@ -103,6 +108,11 @@ describes.realWin(
 
     beforeEach(() => {
       win = env.win;
+
+      env.sandbox
+        .stub(Services, 'cidForDoc')
+        .resolves({get: () => Promise.resolve('cid')});
+
       const ampStoryQuizEl = win.document.createElement('amp-story-quiz');
       ampStoryQuizEl.getResources = () => win.__AMP_SERVICES.resources.obj;
 
@@ -189,6 +199,9 @@ describes.realWin(
 
       quizOption.click();
 
+      // Microtask tick
+      await Promise.resolve();
+
       expect(quizElement).to.have.class('i-amphtml-story-quiz-post-selection');
       expect(quizOption).to.have.class('i-amphtml-story-quiz-option-selected');
     });
@@ -205,6 +218,9 @@ describes.realWin(
 
       quizOptions[0].click();
       quizOptions[1].click();
+
+      // Microtask ticks
+      await Promise.resolve();
 
       expect(quizOptions[0]).to.have.class(
         'i-amphtml-story-quiz-option-selected'
@@ -225,6 +241,9 @@ describes.realWin(
         .querySelector('.i-amphtml-story-quiz-option');
 
       option.click();
+
+      // Microtask tick
+      await Promise.resolve();
 
       expect(trigger).to.have.been.calledWith('story-reaction');
 

--- a/extensions/amp-story/1.0/test/test-amp-story-quiz.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-quiz.js
@@ -18,6 +18,7 @@ import {AmpStoryQuiz} from '../amp-story-quiz';
 import {AmpStoryStoreService} from '../amp-story-store-service';
 import {AnalyticsVariable, getVariableService} from '../variable-service';
 import {getAnalyticsService} from '../story-analytics';
+import {getRequestService} from '../amp-story-request-service';
 import {registerServiceBuilder} from '../../../../src/service';
 
 /**
@@ -98,6 +99,7 @@ describes.realWin(
     let storyEl;
     let analytics;
     let analyticsVars;
+    let requestService;
 
     beforeEach(() => {
       win = env.win;
@@ -106,6 +108,7 @@ describes.realWin(
 
       analyticsVars = getVariableService(win);
       analytics = getAnalyticsService(win, win.document.body);
+      requestService = getRequestService(win, ampStoryQuizEl);
 
       const storeService = new AmpStoryStoreService(win);
       registerServiceBuilder(win, 'story-store', () => storeService);
@@ -123,17 +126,15 @@ describes.realWin(
       env.sandbox.stub(ampStoryQuiz, 'mutateElement').callsFake(fn => fn());
     });
 
-    it('should take the html and reformat it', async () => {
+    it('should take the html and reformat it', () => {
       populateStandardQuizContent(win, ampStoryQuiz.element);
       ampStoryQuiz.buildCallback();
-      await ampStoryQuiz.layoutCallback();
       expect(ampStoryQuiz.getQuizElement().children.length).to.equal(2);
     });
 
-    it('should structure the content in the quiz element', async () => {
+    it('should structure the content in the quiz element', () => {
       populateStandardQuizContent(win, ampStoryQuiz.element);
       ampStoryQuiz.buildCallback();
-      await ampStoryQuiz.layoutCallback();
 
       const quizContent = ampStoryQuiz.getQuizElement().children;
       expect(quizContent[0]).to.have.class(
@@ -180,6 +181,7 @@ describes.realWin(
       populateStandardQuizContent(win, ampStoryQuiz.element);
       ampStoryQuiz.buildCallback();
       await ampStoryQuiz.layoutCallback();
+
       const quizElement = ampStoryQuiz.getQuizElement();
       const quizOption = quizElement.querySelector(
         '.i-amphtml-story-quiz-option'
@@ -195,6 +197,7 @@ describes.realWin(
       populateStandardQuizContent(win, ampStoryQuiz.element);
       ampStoryQuiz.buildCallback();
       await ampStoryQuiz.layoutCallback();
+
       const quizElement = ampStoryQuiz.getQuizElement();
       const quizOptions = quizElement.querySelectorAll(
         '.i-amphtml-story-quiz-option'
@@ -234,6 +237,13 @@ describes.realWin(
     });
 
     it('should update the quiz when the user has already reacted', async () => {
+      // Fill the response to the requestService with mock reaction data
+      env.sandbox
+        .stub(requestService, 'executeRequest')
+        .resolves(getMockReactionData());
+
+      ampStoryQuiz.element.setAttribute('endpoint', 'http://localhost:8000');
+
       populateStandardQuizContent(win, ampStoryQuiz.element);
       ampStoryQuiz.buildCallback();
       await ampStoryQuiz.layoutCallback();
@@ -242,9 +252,6 @@ describes.realWin(
       const quizOptions = quizElement.querySelectorAll(
         '.i-amphtml-story-quiz-option'
       );
-
-      // Mock a successful data retrieval.
-      ampStoryQuiz.handleSuccessfulDataRetrieval_(getMockReactionData());
 
       expect(quizElement).to.have.class('i-amphtml-story-quiz-post-selection');
       expect(quizOptions[0]).to.have.class(

--- a/extensions/amp-story/1.0/test/test-amp-story-quiz.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-quiz.js
@@ -1,4 +1,3 @@
-/* eslint-disable google-camelcase/google-camelcase */
 /**
  * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
  *
@@ -244,7 +243,7 @@ describes.realWin(
         '.i-amphtml-story-quiz-option'
       );
 
-      // mock a successful data retrieval
+      // Mock a successful data retrieval.
       ampStoryQuiz.handleSuccessfulDataRetrieval_(getMockReactionData());
 
       expect(quizElement).to.have.class('i-amphtml-story-quiz-post-selection');

--- a/extensions/amp-story/1.0/test/test-amp-story-quiz.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-quiz.js
@@ -1,3 +1,4 @@
+/* eslint-disable google-camelcase/google-camelcase */
 /**
  * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
  *
@@ -52,6 +53,39 @@ const populateQuiz = (win, quizElement, numPrompts = 1, numOptions = 4) => {
  */
 const populateStandardQuizContent = (win, quizElement) => {
   populateQuiz(win, quizElement);
+};
+
+/**
+ * Returns mock reaction data
+ *
+ * @return {Object}
+ * @private
+ */
+const getMockReactionData = () => {
+  return {
+    data: {
+      total_response_count: 10,
+      has_user_responded: true,
+      responses: {
+        0: {
+          total_count: 3,
+          selected_by_user: true,
+        },
+        1: {
+          total_count: 3,
+          selected_by_user: false,
+        },
+        2: {
+          total_count: 3,
+          selected_by_user: false,
+        },
+        3: {
+          total_count: 1,
+          selected_by_user: false,
+        },
+      },
+    },
+  };
 };
 
 describes.realWin(
@@ -198,6 +232,25 @@ describes.realWin(
       );
       expect(variables[AnalyticsVariable.STORY_REACTION_RESPONSE]).to.equal(0);
       expect(variables[AnalyticsVariable.STORY_REACTION_TYPE]).to.equal(0);
+    });
+
+    it('should update the quiz when the user has already reacted', async () => {
+      populateStandardQuizContent(win, ampStoryQuiz.element);
+      ampStoryQuiz.buildCallback();
+      await ampStoryQuiz.layoutCallback();
+
+      const quizElement = ampStoryQuiz.getQuizElement();
+      const quizOptions = quizElement.querySelectorAll(
+        '.i-amphtml-story-quiz-option'
+      );
+
+      // mock a successful data retrieval
+      ampStoryQuiz.handleSuccessfulDataRetrieval_(getMockReactionData());
+
+      expect(quizElement).to.have.class('i-amphtml-story-quiz-post-selection');
+      expect(quizOptions[0]).to.have.class(
+        'i-amphtml-story-quiz-option-selected'
+      );
     });
   }
 );


### PR DESCRIPTION
Adds support for API calls in AMP Story Quizzes, to both retrieve and update the Reactions data. Currently the API calls must be supplied an endpoint, support for a default endpoint will come in a future PR.