### PR TITLE
📖 Update docs referencing bit.ly/amp-cherry-pick

### DIFF
--- a/.github/ISSUE_TEMPLATE/cherry_pick_template.md
+++ b/.github/ISSUE_TEMPLATE/cherry_pick_template.md
@@ -1,6 +1,6 @@
 ---
 name: Cherry-pick template
-about: Used to request a cherry-pick. See bit.ly/amp-cherry-pick
+about: Used to request a cherry-pick. See go.amp.dev/cherry-picks
 title: "\U0001F338 Cherry-pick request for #<ISSUE_NUMBER> into #<RELEASE_ISSUE> (Pending)"
 labels: 'Type: Release'
 ---

--- a/.github/ISSUE_TEMPLATE/release-tracking-issue.md
+++ b/.github/ISSUE_TEMPLATE/release-tracking-issue.md
@@ -49,4 +49,4 @@ If you perform cherry picks, add/update the checkboxes above as needed e.g.
 
 See the [release documentation](https://github.com/ampproject/amphtml/blob/master/contributing/release-schedule.md) for more information on the release process, including how to test changes in the Dev Channel.
 
-If you find a bug in this build, please file an [issue](https://github.com/ampproject/amphtml/issues/new). If you believe the bug should be fixed in this build, follow the instructions in the [cherry picks documentation](https://bit.ly/amp-cherry-pick).
+If you find a bug in this build, please file an [issue](https://github.com/ampproject/amphtml/issues/new). If you believe the bug should be fixed in this build, follow the instructions in the [cherry picks documentation](https://go.amp.dev/cherry-picks).

--- a/.github/ISSUE_TEMPLATE/release_issue_template.md
+++ b/.github/ISSUE_TEMPLATE/release_issue_template.md
@@ -34,4 +34,4 @@ If you perform cherry picks, add/update the checkboxes above as needed e.g.
 
 See the [release documentation](https://github.com/ampproject/amphtml/blob/master/contributing/release-schedule.md) for more information on the release process, including how to test changes in the Dev Channel.
 
-If you find a bug in this build, please file an [issue](https://github.com/ampproject/amphtml/issues/new). If you believe the bug should be fixed in this build, follow the instructions in the [cherry picks documentation](https://bit.ly/amp-cherry-pick).
+If you find a bug in this build, please file an [issue](https://github.com/ampproject/amphtml/issues/new). If you believe the bug should be fixed in this build, follow the instructions in the [cherry picks documentation](https://go.amp.dev/cherry-picks).


### PR DESCRIPTION
Currently, we link to bit.ly/amp-cherry-picks for the cherry-pick documentation. https://github.com/ampproject/amp.dev/pull/3351 creates an AMP.dev shortlink (and updates the destination, since the documentation location changed). This PR updates the places in AMP HTML docs that reference the old link.