### PR TITLE
🐛Expander: better support of backticks

### DIFF
--- a/src/service/url-expander/expander.js
+++ b/src/service/url-expander/expander.js
@@ -146,10 +146,11 @@ export class Expander {
       const args = [];
 
       while (urlIndex < url.length && matchIndex <= matches.length) {
+        const trimmedBuilder = builder.trim();
         if (match && urlIndex === match.start) {
           // Collect any chars that may be prefixing the macro, if we are in
           // a nested context trim the args.
-          if (builder.trim().length) {
+          if (trimmedBuilder) {
             results.push(numOfPendingCalls ? trimStart(builder) : builder);
           }
 
@@ -198,8 +199,8 @@ export class Expander {
           if (!ignoringChars) {
             ignoringChars = true;
             // Collect any chars that may exist before backticks, eg FOO(a`b`)
-            if (builder.trim().length) {
-              results.push(builder.trim());
+            if (trimmedBuilder) {
+              results.push(trimmedBuilder);
             }
           } else {
             ignoringChars = false;
@@ -216,10 +217,10 @@ export class Expander {
           !ignoringChars
         ) {
           // Commas tell us to create a new argument when in nested context and
-          // We push any string built so far, create a new array for the next
+          // we push any string built so far, create a new array for the next
           // argument, and reset our string builder.
-          if (builder.length) {
-            results.push(builder.trim());
+          if (trimmedBuilder) {
+            results.push(trimmedBuilder);
           }
           args.push(results);
           results = [];
@@ -242,8 +243,8 @@ export class Expander {
           urlIndex++;
           numOfPendingCalls--;
           const binding = stack.pop();
-          if (builder.trim().length) {
-            results.push(builder.trim());
+          if (trimmedBuilder) {
+            results.push(trimmedBuilder);
           }
           args.push(results);
           const value = this.evaluateBinding_(binding, /* opt_args */ args);

--- a/src/service/url-expander/expander.js
+++ b/src/service/url-expander/expander.js
@@ -139,7 +139,6 @@ export class Expander {
     let match = matches[matchIndex];
     let numOfPendingCalls = 0;
     let ignoringChars = false;
-    let nextArgShouldBeRaw = false;
 
     const evaluateNextLevel = encode => {
       let builder = '';
@@ -243,12 +242,10 @@ export class Expander {
           urlIndex++;
           numOfPendingCalls--;
           const binding = stack.pop();
-          const nextArg = nextArgShouldBeRaw ? builder : builder.trim();
-          if (nextArg) {
-            results.push(nextArg);
+          if (builder.trim().length) {
+            results.push(builder.trim());
           }
           args.push(results);
-          nextArgShouldBeRaw = false;
           const value = this.evaluateBinding_(binding, /* opt_args */ args);
           return value;
         } else {

--- a/test/unit/url-expander/test-expander.js
+++ b/test/unit/url-expander/test-expander.js
@@ -255,6 +255,16 @@ describes.realWin(
           input: 'title=TRIM(TITLE)',
           output: 'title=hello%20world',
         },
+        {
+          description: 'should handle backticks inside args',
+          input: 'CONCAT(he`llo`, world)',
+          output: 'hello-world',
+        },
+        {
+          description: 'should handle backticks inside args w/ macros',
+          input: 'TRIM(CANONICAL_URL` `CANONICAL_URL)',
+          output: 'www.google.com%20www.google.com',
+        },
       ];
 
       describe('called asyncronously', () => {
@@ -276,15 +286,6 @@ describes.realWin(
             return expect(
               new Expander(variableSource, mockBindings).expand(url)
             ).to.eventually.equal(expected);
-          });
-
-          it('throws on bad input with back ticks', () => {
-            const url = 'CONCAT(bad`hello`, world)';
-            allowConsoleError(() => {
-              expect(() => {
-                new Expander(variableSource, mockBindings).expand(url);
-              }).to.throw(/bad/);
-            });
           });
 
           it('should handle tokens with parenthesis next to each other', () => {
@@ -322,20 +323,6 @@ describes.realWin(
         });
 
         describe('unique cases', () => {
-          it('throws on bad input with back ticks', () => {
-            const url = 'CONCAT(bad`hello`, world)';
-            allowConsoleError(() => {
-              expect(() => {
-                new Expander(
-                  variableSource,
-                  mockBindings,
-                  /* opt_collectVars */ undefined,
-                  /* opt_sync */ true
-                ).expand(url);
-              }).to.throw(/bad/);
-            });
-          });
-
           // Console errors allowed for these tests because anytime an async
           // function is called with the sync flag we user.error()
           it('should resolve promise to empty string', () => {


### PR DESCRIPTION
Previously the parser ignoring feature only worked when an argument was completely wrapped in backticks eg ``FOO(abc, ` - `)``

This allows backticks to be used anywhere inside of a macro to give raw input. 

Follow up to #26247.