### PR TITLE
✅ Implements unit test for `amp-next-page` v2

### DIFF
--- a/extensions/amp-next-page/0.2/service.js
+++ b/extensions/amp-next-page/0.2/service.js
@@ -168,11 +168,12 @@ export class NextPageService {
 
   /**
    * @param {boolean=} force
+   * @return {!Promise}
    */
   maybeFetchNext(force = false) {
     // If a page is already queued to be fetched, wait for it
     if (this.pages_.some(page => page.isFetching())) {
-      return;
+      return Promise.resolve();
     }
 
     if (force || this.getViewportsAway_() <= PRERENDER_VIEWPORT_COUNT) {
@@ -180,7 +181,7 @@ export class NextPageService {
         this.getPageIndex_(this.lastFetchedPage_) + 1
       ];
       if (nextPage) {
-        nextPage.fetch();
+        return nextPage.fetch();
       }
     }
   }

--- a/extensions/amp-next-page/0.2/test/test-amp-next-page.js
+++ b/extensions/amp-next-page/0.2/test/test-amp-next-page.js
@@ -1,0 +1,299 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import '../amp-next-page';
+import {PageState} from '../page';
+import {Services} from '../../../../src/services';
+import {VisibilityState} from '../../../../src/visibility-state';
+import {setStyle} from '../../../../src/style';
+import {toggleExperiment} from '../../../../src/experiments';
+
+const MOCK_NEXT_PAGE = `<header>Header</header>
+    <div style="height:1000px"></div>
+    <footer>Footer</footer>`;
+const VALID_CONFIG = [
+  {
+    'image': '/examples/img/hero@1x.jpg',
+    'title': 'Title 1',
+    'url': '/document1',
+  },
+  {
+    'image': '/examples/img/hero@1x.jpg',
+    'title': 'Title 2',
+    'url': '/document2',
+  },
+];
+
+describes.realWin(
+  'amp-next-page component',
+  {
+    amp: {
+      extensions: ['amp-next-page:0.2'],
+    },
+  },
+  env => {
+    let win, doc, ampdoc;
+
+    beforeEach(() => {
+      win = env.win;
+      doc = win.document;
+      ampdoc = env.ampdoc;
+
+      toggleExperiment(win, 'amp-next-page-v2', true);
+
+      // Mocks
+      ampdoc.getUrl = () => document.location.href;
+      win.document.title = 'Host page';
+    });
+
+    async function getAMPNextPage(options) {
+      options = options || {};
+
+      const element = doc.createElement('amp-next-page');
+
+      // Ensure element is off screen when it renders.
+      setStyle(element, 'marginTop', '10000px');
+
+      // Add inline config if specified
+      if (options.inlineConfig) {
+        const configElement = document.createElement('script');
+        configElement.setAttribute('id', 'next-page');
+        configElement.setAttribute('type', 'application/json');
+        configElement.textContent = JSON.stringify(options.inlineConfig);
+        element.appendChild(configElement);
+      }
+
+      if (options.src) {
+        element.setAttribute('src', options.src);
+      }
+
+      doc.body.appendChild(element);
+
+      return element;
+    }
+
+    afterEach(() => {
+      toggleExperiment(win, 'amp-next-page-v2', false);
+    });
+
+    describe('inline config', () => {
+      it('builds with valid inline config', async () => {
+        const element = await getAMPNextPage({
+          inlineConfig: VALID_CONFIG,
+        });
+
+        await element.build();
+        await element.layoutCallback();
+      });
+
+      it('errors on invalid inline config (object instead of array)', async () => {
+        const element = await getAMPNextPage({
+          inlineConfig: {
+            pages: [
+              {
+                'image': '/examples/img/hero@1x.jpg',
+                'title': 'Title 1',
+                'ampUrl': '/document1',
+              },
+              {
+                'image': '/examples/img/hero@1x.jpg',
+                'title': 'Title 2',
+                'ampUrl': '/document2',
+              },
+            ],
+          },
+        });
+
+        await allowConsoleError(() =>
+          element.build().catch(err => {
+            expect(err.message).to.include(
+              'amp-next-page page list should be an array'
+            );
+          })
+        );
+      });
+
+      it('errors on invalid inline config (ampUrl instead of url)', async () => {
+        const element = await getAMPNextPage({
+          inlineConfig: [
+            {
+              'image': '/examples/img/hero@1x.jpg',
+              'title': 'Title 1',
+              'ampUrl': '/document1',
+            },
+            {
+              'image': '/examples/img/hero@1x.jpg',
+              'title': 'Title 2',
+              'ampUrl': '/document2',
+            },
+          ],
+        });
+
+        await allowConsoleError(() =>
+          element.build().catch(err => {
+            expect(err.message).to.include('page url must be a string');
+          })
+        );
+      });
+
+      it('builds with valid inline config', async () => {
+        const element = await getAMPNextPage({
+          inlineConfig: VALID_CONFIG,
+        });
+
+        await element.build();
+        await element.layoutCallback();
+      });
+    });
+
+    describe('basic functionality', () => {
+      let element;
+      let service;
+
+      beforeEach(async () => {
+        element = await getAMPNextPage({
+          inlineConfig: VALID_CONFIG,
+        });
+
+        await element.build();
+        await element.layoutCallback();
+
+        service = Services.nextPageServiceForDoc(doc);
+      });
+
+      afterEach(async () => {
+        element.parentNode.removeChild(element);
+      });
+
+      it('should register pages from the given config', async () => {
+        // Page 1
+        expect(service.pages_[1].title).to.equal('Title 1');
+        expect(service.pages_[1].url).to.include('/document1');
+        expect(service.pages_[1].image).to.equal('/examples/img/hero@1x.jpg');
+        // Page 2
+        expect(service.pages_[2].title).to.equal('Title 2');
+        expect(service.pages_[2].url).to.include('/document2');
+        expect(service.pages_[2].image).to.equal('/examples/img/hero@1x.jpg');
+      });
+
+      it('should internally register the host page', async () => {
+        expect(service.pages_[0].title).to.equal('Host page');
+        expect(service.pages_[0].url).to.include('about:srcdoc');
+        expect(service.pages_[0].state_).to.equal(PageState.INSERTED);
+        expect(service.pages_[0].visibilityState_).to.equal(
+          VisibilityState.VISIBLE
+        );
+      });
+
+      it('should not fetch the next document before scrolling', async () => {
+        [1, 2].forEach(i => {
+          expect(service.pages_[i].state_).to.equal(PageState.QUEUED);
+          expect(service.pages_[i].visibilityState_).to.equal(
+            VisibilityState.PRERENDER
+          );
+        });
+      });
+
+      it('fetches the next document on scroll', async () => {
+        env.sandbox.stub(service, 'getViewportsAway_').returns(2);
+        const firstPageFetchSpy = env.sandbox.spy(service.pages_[1], 'fetch');
+        const secondPageFetchSpy = env.sandbox.spy(service.pages_[2], 'fetch');
+
+        env.fetchMock.get(/\/document1/, MOCK_NEXT_PAGE);
+        await service.maybeFetchNext();
+
+        expect(firstPageFetchSpy).to.be.calledOnce;
+        expect(service.pages_[1].state_).to.equal(PageState.INSERTED);
+        expect(service.pages_[1].visibilityState_).to.equal(
+          VisibilityState.PRERENDER
+        );
+
+        expect(secondPageFetchSpy).to.not.be.called;
+        expect(service.pages_[2].state_).to.equal(PageState.QUEUED);
+        expect(service.pages_[2].visibilityState_).to.equal(
+          VisibilityState.PRERENDER
+        );
+      });
+
+      it('fetches the second document on scroll', async () => {
+        env.sandbox.stub(service, 'getViewportsAway_').returns(2);
+        const firstPageFetchSpy = env.sandbox.spy(service.pages_[1], 'fetch');
+        const secondPageFetchSpy = env.sandbox.spy(service.pages_[2], 'fetch');
+
+        env.fetchMock.get(/\/document1/, MOCK_NEXT_PAGE);
+        env.fetchMock.get(/\/document2/, MOCK_NEXT_PAGE);
+        await service.maybeFetchNext();
+        await service.maybeFetchNext();
+
+        expect(firstPageFetchSpy).to.be.calledOnce;
+        expect(service.pages_[1].state_).to.equal(PageState.INSERTED);
+        expect(service.pages_[1].visibilityState_).to.equal(
+          VisibilityState.PRERENDER
+        );
+
+        expect(secondPageFetchSpy).to.be.calledOnce;
+        expect(service.pages_[2].state_).to.equal(PageState.INSERTED);
+        expect(service.pages_[2].visibilityState_).to.equal(
+          VisibilityState.PRERENDER
+        );
+      });
+
+      it('blocks documents which resolve to a different origin when fetched ', async () => {
+        expectAsyncConsoleError(
+          /Invalid page URL supplied to amp-next-page, pages must be from the same origin as the current document/,
+          2
+        );
+
+        env.fetchMock.get(/\/document1/, {
+          redirectUrl: 'https://othersite.com/article',
+          body: MOCK_NEXT_PAGE,
+        });
+        env.sandbox.stub(service, 'getViewportsAway_').returns(2);
+
+        await service.maybeFetchNext();
+
+        expect(service.pages_[1].state_).to.equal(PageState.FAILED);
+        expect(service.pages_[1].visibilityState_).to.equal(
+          VisibilityState.PRERENDER
+        );
+      });
+
+      it('adds the hidden class to elements that should be hidden', () => {
+        // TODO(wassgha): Implement once #26235 is merged
+      });
+
+      it('removes amp-analytics tags from child documents', async () => {
+        env.sandbox.stub(service, 'getViewportsAway_').returns(2);
+
+        env.fetchMock.get(
+          /\/document1/,
+          `${MOCK_NEXT_PAGE} <amp-analytics id="analytics1"></amp-analytics>`
+        );
+        await service.maybeFetchNext();
+
+        // TODO(wassgha): Replace `.shadowDoc_.ampdoc.getRootNode()` with `.document` once #26235 is merged
+        expect(
+          service.pages_[1].shadowDoc_.ampdoc
+            .getRootNode()
+            .getElementById('analytics1')
+        ).to.be.null;
+      });
+    });
+
+    describe('remote config', () => {
+      // TODO (wassgha): Implement once remote config is implemented
+    });
+  }
+);

--- a/extensions/amp-next-page/0.2/test/test-config.js
+++ b/extensions/amp-next-page/0.2/test/test-config.js
@@ -1,0 +1,189 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {Page} from '../page';
+import {validatePage} from '../utils';
+
+describe('amp-next-page config', () => {
+  describes.sandboxed('assertConfig', {}, () => {
+    const documentUrl = 'https://example.com/parent';
+    const documentUrlCdn =
+      'https://example-com.cdn.ampproject.org/c/s/example.com/parent';
+
+    it('rewrites relative URLs to absolute', () => {
+      const page = new Page(null, {
+        url: '/article1',
+        image: '/image.png',
+        title: 'Article 1',
+      });
+      expect(() => validatePage(page, documentUrl)).to.not.throw();
+      expect(page.url).to.equal('https://example.com/article1');
+    });
+
+    it('rewrites relative URLs when served from the cache', () => {
+      const page = new Page(null, {
+        url: '/article1',
+        image: '/image.png',
+        title: 'Article 1',
+      });
+      expect(() => validatePage(page, documentUrlCdn)).to.not.throw();
+      expect(page.url).to.equal(
+        'https://example-com.cdn.ampproject.org/c/s/example.com/article1'
+      );
+    });
+
+    it('rewrites canonical URLs when served from the cache', () => {
+      const page = new Page(null, {
+        url: 'https://example.com/art2?x=1',
+        image: '/image.png',
+        title: 'Article 1',
+      });
+      expect(() => validatePage(page, documentUrlCdn)).to.not.throw();
+      expect(page.url).to.equal(
+        'https://example-com.cdn.ampproject.org/c/s/example.com/art2?x=1'
+      );
+
+      const pageWithCdn = new Page(null, {
+        url: 'https://example-com.cdn.ampproject.org/c/s/example.com/art1',
+        image: '/image.png',
+        title: 'Article 1',
+      });
+      expect(() => validatePage(pageWithCdn, documentUrlCdn)).to.not.throw();
+      expect(pageWithCdn.url).to.equal(
+        'https://example-com.cdn.ampproject.org/c/s/example.com/art1'
+      );
+    });
+
+    it('rewrites non-HTTPS canonical URLs when served from the cache', () => {
+      const url = documentUrlCdn.replace('/s/', '/');
+
+      const page = new Page(null, {
+        url: 'http://example.com/art2?x=1',
+        image: '/image.png',
+        title: 'Article 1',
+      });
+      expect(() => validatePage(page, url)).to.not.throw();
+      expect(page.url).to.equal(
+        'https://example-com.cdn.ampproject.org/c/example.com/art2?x=1'
+      );
+    });
+
+    it("doesn't rewrite URLs if sourceOrigin and origin match", () => {
+      const page = new Page(null, {
+        url: 'https://example.com/article',
+        image: '/image.png',
+        title: 'Article 1',
+      });
+      expect(() => validatePage(page, documentUrl)).to.not.throw();
+      expect(page.url).to.equal('https://example.com/article');
+    });
+
+    it('throws on config with missing page title', () => {
+      const page = new Page(null, {
+        url: 'https://example.com/article',
+        image: '/image.png',
+      });
+
+      allowConsoleError(() => {
+        expect(() => validatePage(page, documentUrl)).to.throw(
+          'title must be a string'
+        );
+      });
+    });
+
+    it('throws on config with non-string page title', () => {
+      const page = new Page(null, {
+        url: 'https://example.com/article',
+        image: '/image.png',
+        title: {},
+      });
+
+      allowConsoleError(() => {
+        expect(() => validatePage(page, documentUrl)).to.throw(
+          'title must be a string'
+        );
+      });
+    });
+
+    it('throws on config with missing page image', () => {
+      const page = new Page(null, {
+        url: 'https://example.com/article',
+        title: 'Article 1',
+      });
+
+      allowConsoleError(() => {
+        expect(() => validatePage(page, documentUrl)).to.throw(
+          'image must be a string'
+        );
+      });
+    });
+
+    it('throws on config with non-string recommendation image', () => {
+      const page = new Page(null, {
+        url: 'https://example.com/article',
+        image: {},
+        title: 'Article 1',
+      });
+
+      allowConsoleError(() => {
+        expect(() => validatePage(page, documentUrl)).to.throw(
+          'image must be a string'
+        );
+      });
+    });
+
+    it('throws on config with pages from different domains', () => {
+      const page = new Page(null, {
+        url: 'https://othersite.com/article1',
+        image: 'https://othersite.com/image.png',
+        title: 'Article 1',
+      });
+
+      allowConsoleError(() => {
+        expect(() => validatePage(page, documentUrl)).to.throw(
+          'pages must be from the same origin as the current document'
+        );
+      });
+    });
+
+    it('throws on config with pages from different subdomains', () => {
+      const page = new Page(null, {
+        url: 'https://www.example.com/article1',
+        image: 'https://example.com/image.png',
+        title: 'Article 1',
+      });
+
+      allowConsoleError(() => {
+        expect(() => validatePage(page, documentUrl)).to.throw(
+          'pages must be from the same origin as the current document'
+        );
+      });
+    });
+
+    it('throws on config with pages on different ports', () => {
+      const page = new Page(null, {
+        url: 'https://example.com:8080/article1',
+        image: 'https://example.com/image.png',
+        title: 'Article 1',
+      });
+
+      allowConsoleError(() => {
+        expect(() => validatePage(page, documentUrl)).to.throw(
+          'pages must be from the same origin as the current document'
+        );
+      });
+    });
+  });
+});

--- a/extensions/amp-next-page/0.2/test/test-config.js
+++ b/extensions/amp-next-page/0.2/test/test-config.js
@@ -16,174 +16,172 @@
 import {Page} from '../page';
 import {validatePage} from '../utils';
 
-describe('amp-next-page config', () => {
-  describes.sandboxed('assertConfig', {}, () => {
-    const documentUrl = 'https://example.com/parent';
-    const documentUrlCdn =
-      'https://example-com.cdn.ampproject.org/c/s/example.com/parent';
+describes.sandboxed('amp-next-page config', {}, () => {
+  const documentUrl = 'https://example.com/parent';
+  const documentUrlCdn =
+    'https://example-com.cdn.ampproject.org/c/s/example.com/parent';
 
-    it('rewrites relative URLs to absolute', () => {
-      const page = new Page(null, {
-        url: '/article1',
-        image: '/image.png',
-        title: 'Article 1',
-      });
-      expect(() => validatePage(page, documentUrl)).to.not.throw();
-      expect(page.url).to.equal('https://example.com/article1');
+  it('rewrites relative URLs to absolute', () => {
+    const page = new Page(null, {
+      url: '/article1',
+      image: '/image.png',
+      title: 'Article 1',
+    });
+    expect(() => validatePage(page, documentUrl)).to.not.throw();
+    expect(page.url).to.equal('https://example.com/article1');
+  });
+
+  it('rewrites relative URLs when served from the cache', () => {
+    const page = new Page(null, {
+      url: '/article1',
+      image: '/image.png',
+      title: 'Article 1',
+    });
+    expect(() => validatePage(page, documentUrlCdn)).to.not.throw();
+    expect(page.url).to.equal(
+      'https://example-com.cdn.ampproject.org/c/s/example.com/article1'
+    );
+  });
+
+  it('rewrites canonical URLs when served from the cache', () => {
+    const page = new Page(null, {
+      url: 'https://example.com/art2?x=1',
+      image: '/image.png',
+      title: 'Article 1',
+    });
+    expect(() => validatePage(page, documentUrlCdn)).to.not.throw();
+    expect(page.url).to.equal(
+      'https://example-com.cdn.ampproject.org/c/s/example.com/art2?x=1'
+    );
+
+    const pageWithCdn = new Page(null, {
+      url: 'https://example-com.cdn.ampproject.org/c/s/example.com/art1',
+      image: '/image.png',
+      title: 'Article 1',
+    });
+    expect(() => validatePage(pageWithCdn, documentUrlCdn)).to.not.throw();
+    expect(pageWithCdn.url).to.equal(
+      'https://example-com.cdn.ampproject.org/c/s/example.com/art1'
+    );
+  });
+
+  it('rewrites non-HTTPS canonical URLs when served from the cache', () => {
+    const url = documentUrlCdn.replace('/s/', '/');
+
+    const page = new Page(null, {
+      url: 'http://example.com/art2?x=1',
+      image: '/image.png',
+      title: 'Article 1',
+    });
+    expect(() => validatePage(page, url)).to.not.throw();
+    expect(page.url).to.equal(
+      'https://example-com.cdn.ampproject.org/c/example.com/art2?x=1'
+    );
+  });
+
+  it("doesn't rewrite URLs if sourceOrigin and origin match", () => {
+    const page = new Page(null, {
+      url: 'https://example.com/article',
+      image: '/image.png',
+      title: 'Article 1',
+    });
+    expect(() => validatePage(page, documentUrl)).to.not.throw();
+    expect(page.url).to.equal('https://example.com/article');
+  });
+
+  it('throws on config with missing page title', () => {
+    const page = new Page(null, {
+      url: 'https://example.com/article',
+      image: '/image.png',
     });
 
-    it('rewrites relative URLs when served from the cache', () => {
-      const page = new Page(null, {
-        url: '/article1',
-        image: '/image.png',
-        title: 'Article 1',
-      });
-      expect(() => validatePage(page, documentUrlCdn)).to.not.throw();
-      expect(page.url).to.equal(
-        'https://example-com.cdn.ampproject.org/c/s/example.com/article1'
+    allowConsoleError(() => {
+      expect(() => validatePage(page, documentUrl)).to.throw(
+        'title must be a string'
       );
     });
+  });
 
-    it('rewrites canonical URLs when served from the cache', () => {
-      const page = new Page(null, {
-        url: 'https://example.com/art2?x=1',
-        image: '/image.png',
-        title: 'Article 1',
-      });
-      expect(() => validatePage(page, documentUrlCdn)).to.not.throw();
-      expect(page.url).to.equal(
-        'https://example-com.cdn.ampproject.org/c/s/example.com/art2?x=1'
-      );
+  it('throws on config with non-string page title', () => {
+    const page = new Page(null, {
+      url: 'https://example.com/article',
+      image: '/image.png',
+      title: {},
+    });
 
-      const pageWithCdn = new Page(null, {
-        url: 'https://example-com.cdn.ampproject.org/c/s/example.com/art1',
-        image: '/image.png',
-        title: 'Article 1',
-      });
-      expect(() => validatePage(pageWithCdn, documentUrlCdn)).to.not.throw();
-      expect(pageWithCdn.url).to.equal(
-        'https://example-com.cdn.ampproject.org/c/s/example.com/art1'
+    allowConsoleError(() => {
+      expect(() => validatePage(page, documentUrl)).to.throw(
+        'title must be a string'
       );
     });
+  });
 
-    it('rewrites non-HTTPS canonical URLs when served from the cache', () => {
-      const url = documentUrlCdn.replace('/s/', '/');
+  it('throws on config with missing page image', () => {
+    const page = new Page(null, {
+      url: 'https://example.com/article',
+      title: 'Article 1',
+    });
 
-      const page = new Page(null, {
-        url: 'http://example.com/art2?x=1',
-        image: '/image.png',
-        title: 'Article 1',
-      });
-      expect(() => validatePage(page, url)).to.not.throw();
-      expect(page.url).to.equal(
-        'https://example-com.cdn.ampproject.org/c/example.com/art2?x=1'
+    allowConsoleError(() => {
+      expect(() => validatePage(page, documentUrl)).to.throw(
+        'image must be a string'
       );
     });
+  });
 
-    it("doesn't rewrite URLs if sourceOrigin and origin match", () => {
-      const page = new Page(null, {
-        url: 'https://example.com/article',
-        image: '/image.png',
-        title: 'Article 1',
-      });
-      expect(() => validatePage(page, documentUrl)).to.not.throw();
-      expect(page.url).to.equal('https://example.com/article');
+  it('throws on config with non-string recommendation image', () => {
+    const page = new Page(null, {
+      url: 'https://example.com/article',
+      image: {},
+      title: 'Article 1',
     });
 
-    it('throws on config with missing page title', () => {
-      const page = new Page(null, {
-        url: 'https://example.com/article',
-        image: '/image.png',
-      });
+    allowConsoleError(() => {
+      expect(() => validatePage(page, documentUrl)).to.throw(
+        'image must be a string'
+      );
+    });
+  });
 
-      allowConsoleError(() => {
-        expect(() => validatePage(page, documentUrl)).to.throw(
-          'title must be a string'
-        );
-      });
+  it('throws on config with pages from different domains', () => {
+    const page = new Page(null, {
+      url: 'https://othersite.com/article1',
+      image: 'https://othersite.com/image.png',
+      title: 'Article 1',
     });
 
-    it('throws on config with non-string page title', () => {
-      const page = new Page(null, {
-        url: 'https://example.com/article',
-        image: '/image.png',
-        title: {},
-      });
+    allowConsoleError(() => {
+      expect(() => validatePage(page, documentUrl)).to.throw(
+        'pages must be from the same origin as the current document'
+      );
+    });
+  });
 
-      allowConsoleError(() => {
-        expect(() => validatePage(page, documentUrl)).to.throw(
-          'title must be a string'
-        );
-      });
+  it('throws on config with pages from different subdomains', () => {
+    const page = new Page(null, {
+      url: 'https://www.example.com/article1',
+      image: 'https://example.com/image.png',
+      title: 'Article 1',
     });
 
-    it('throws on config with missing page image', () => {
-      const page = new Page(null, {
-        url: 'https://example.com/article',
-        title: 'Article 1',
-      });
+    allowConsoleError(() => {
+      expect(() => validatePage(page, documentUrl)).to.throw(
+        'pages must be from the same origin as the current document'
+      );
+    });
+  });
 
-      allowConsoleError(() => {
-        expect(() => validatePage(page, documentUrl)).to.throw(
-          'image must be a string'
-        );
-      });
+  it('throws on config with pages on different ports', () => {
+    const page = new Page(null, {
+      url: 'https://example.com:8080/article1',
+      image: 'https://example.com/image.png',
+      title: 'Article 1',
     });
 
-    it('throws on config with non-string recommendation image', () => {
-      const page = new Page(null, {
-        url: 'https://example.com/article',
-        image: {},
-        title: 'Article 1',
-      });
-
-      allowConsoleError(() => {
-        expect(() => validatePage(page, documentUrl)).to.throw(
-          'image must be a string'
-        );
-      });
-    });
-
-    it('throws on config with pages from different domains', () => {
-      const page = new Page(null, {
-        url: 'https://othersite.com/article1',
-        image: 'https://othersite.com/image.png',
-        title: 'Article 1',
-      });
-
-      allowConsoleError(() => {
-        expect(() => validatePage(page, documentUrl)).to.throw(
-          'pages must be from the same origin as the current document'
-        );
-      });
-    });
-
-    it('throws on config with pages from different subdomains', () => {
-      const page = new Page(null, {
-        url: 'https://www.example.com/article1',
-        image: 'https://example.com/image.png',
-        title: 'Article 1',
-      });
-
-      allowConsoleError(() => {
-        expect(() => validatePage(page, documentUrl)).to.throw(
-          'pages must be from the same origin as the current document'
-        );
-      });
-    });
-
-    it('throws on config with pages on different ports', () => {
-      const page = new Page(null, {
-        url: 'https://example.com:8080/article1',
-        image: 'https://example.com/image.png',
-        title: 'Article 1',
-      });
-
-      allowConsoleError(() => {
-        expect(() => validatePage(page, documentUrl)).to.throw(
-          'pages must be from the same origin as the current document'
-        );
-      });
+    allowConsoleError(() => {
+      expect(() => validatePage(page, documentUrl)).to.throw(
+        'pages must be from the same origin as the current document'
+      );
     });
   });
 });

--- a/extensions/amp-next-page/0.2/utils.js
+++ b/extensions/amp-next-page/0.2/utils.js
@@ -50,6 +50,7 @@ export function validatePage(page, hostUrl) {
   user().assertString(page.url, 'page url must be a string');
 
   const base = getSourceUrl(hostUrl);
+  const {origin} = parseUrlDeprecated(hostUrl);
   page.url = resolveRelativeUrl(page.url, base);
 
   const url = validateUrl(page.url, hostUrl);


### PR DESCRIPTION
### Changes
- Ports unit tests from `amp-next-page` v1 to v2 with a cleaner API
- Adds new unit tests, with more to come in following PRs
- Fixes bug in url rewriting