### PR TITLE
Remove z-index on flex ad slots by default.

### DIFF
--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -307,7 +307,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
      * If true, will add a z-index to flex ad slots upon expansion.
      * @private {boolean}
      */
-    this.inZIndexHoldback_ = false;
+    this.inZIndexHoldBack_ = false;
   }
 
   /**
@@ -417,10 +417,8 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
     Object.keys(setExps).forEach(
       expName => setExps[expName] && this.experimentIds.push(setExps[expName])
     );
-    if (
-      setExps[ZINDEX_EXP] == ZINDEX_EXP_BRANCHES.HOLDBACK
-    ) {
-      this.inZIndexHoldback_ = true;
+    if (setExps[ZINDEX_EXP] == ZINDEX_EXP_BRANCHES.HOLDBACK) {
+      this.inZIndexHoldBack_ = true;
     }
   }
 

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -132,13 +132,13 @@ const DOUBLECLICK_SRA_EXP_BRANCHES = {
 };
 
 /** @const {string} */
-const FLEXIBLE_AD_SLOTS_EXP = 'flexAdSlots';
+const ZINDEX_EXP = 'zIndexExp';
 
-/** @const @enum{string} */
-const FLEXIBLE_AD_SLOTS_BRANCHES = {
-  CONTROL: '21063173',
-  EXPERIMENT: '21063174',
-};
+/**@const @enum{string} */
+const ZINDEX_EXP_BRANCHES = {
+  NO_ZINDEX: '21065356',
+  HOLDBACK: '21065357',
+}
 
 /**
  * Required size to be sent with fluid requests.
@@ -297,14 +297,17 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
      */
     this.shouldSandbox_ = false;
 
-    /** @private {boolean} */
-    this.sendFlexibleAdSlotParams_ = true;
-
     /**
      * Set after the ad request is built.
      * @private {?FlexibleAdSlotDataTypeDef}
      */
     this.flexibleAdSlotData_ = null;
+    
+    /**
+     * If true, will add a z-index to flex ad slots upon expansion.
+     * @private {boolean}
+     */
+    this.inZIndexHoldback_ = false;
   }
 
   /**
@@ -397,16 +400,16 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
           key => DOUBLECLICK_SRA_EXP_BRANCHES[key]
         ),
       },
-      [FLEXIBLE_AD_SLOTS_EXP]: {
-        isTrafficEligible: () => true,
-        branches: Object.values(FLEXIBLE_AD_SLOTS_BRANCHES),
-      },
       [[FIE_CSS_CLEANUP_EXP.branch]]: {
         isTrafficEligible: () => true,
         branches: [
           [FIE_CSS_CLEANUP_EXP.control],
           [FIE_CSS_CLEANUP_EXP.experiment],
         ],
+      },
+      [ZINDEX_EXP]: {
+        isTrafficEligible: () => true,
+        branches: Object.values(ZINDEX_EXP_BRANCHES),
       },
       ...AMPDOC_FIE_EXPERIMENT_INFO_MAP,
     });
@@ -415,9 +418,9 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
       expName => setExps[expName] && this.experimentIds.push(setExps[expName])
     );
     if (
-      setExps[FLEXIBLE_AD_SLOTS_EXP] == FLEXIBLE_AD_SLOTS_BRANCHES.EXPERIMENT
+      setExps[ZINDEX_EXP] == ZINDEX_EXP_BRANCHES.HOLDBACK
     ) {
-      this.sendFlexibleAdSlotParams_ = false;
+      this.inZIndexHoldback_ = true;
     }
   }
 
@@ -540,18 +543,16 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
     let msz = null;
     let psz = null;
     let fws = null;
-    if (this.sendFlexibleAdSlotParams_) {
-      this.flexibleAdSlotData_ = getFlexibleAdSlotData(
-        this.win,
-        this.element.parentElement
-      );
-      const {fwSignal, slotWidth, parentWidth} = this.flexibleAdSlotData_;
-      // If slotWidth is -1, that means its width must be determined by its
-      // parent container, and so should have the same value as parentWidth.
-      msz = `${slotWidth == -1 ? parentWidth : slotWidth}x-1`;
-      psz = `${parentWidth}x-1`;
-      fws = fwSignal ? fwSignal : '0';
-    }
+    this.flexibleAdSlotData_ = getFlexibleAdSlotData(
+      this.win,
+      this.element.parentElement
+    );
+    const {fwSignal, slotWidth, parentWidth} = this.flexibleAdSlotData_;
+    // If slotWidth is -1, that means its width must be determined by its
+    // parent container, and so should have the same value as parentWidth.
+    msz = `${slotWidth == -1 ? parentWidth : slotWidth}x-1`;
+    psz = `${parentWidth}x-1`;
+    fws = fwSignal ? fwSignal : '0';
     return {
       'iu': this.element.getAttribute('data-slot'),
       'co':
@@ -1283,7 +1284,9 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
     const {parentWidth, parentStyle} = this.flexibleAdSlotData_;
     const isRtl = isRTL(this.win.document);
     const dirStr = isRtl ? 'Right' : 'Left';
-    const /** !Object<string, string> */ style = {'z-index': '11'};
+    const /** !Object<string, string> */ style = this.inZIndexHoldBack_
+        ? {'z-index': '11'}
+        : {};
     // Compute offset margins if the slot is not centered by default.
     if (parentStyle.textAlign != 'center') {
       const getMarginStr = marginNum => `${Math.round(marginNum)}px`;

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -138,7 +138,7 @@ const ZINDEX_EXP = 'zIndexExp';
 const ZINDEX_EXP_BRANCHES = {
   NO_ZINDEX: '21065356',
   HOLDBACK: '21065357',
-}
+};
 
 /**
  * Required size to be sent with fluid requests.
@@ -302,7 +302,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
      * @private {?FlexibleAdSlotDataTypeDef}
      */
     this.flexibleAdSlotData_ = null;
-    
+
     /**
      * If true, will add a z-index to flex ad slots upon expansion.
      * @private {boolean}

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -376,6 +376,13 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
         margin: '',
         isAlreadyCentered: true,
       },
+      {
+        direction: 'ltr',
+        parentWidth: 300,
+        newWidth: 250,
+        margin: '-25px',
+        inZIndexHoldBack: true,
+      },
     ].forEach((testCase, testNum) => {
       it(`should adjust slot CSS after expanding width #${testNum}`, () => {
         if (testCase.isMultiSizeResponse) {
@@ -408,7 +415,7 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
           },
         };
         impl.win.document.body.dir = testCase.direction;
-        impl.inZIndexHoldback_ = testCase.inZIndexHoldback;
+        impl.inZIndexHoldBack_ = testCase.inZIndexHoldBack;
         impl.extractSize({
           get(name) {
             switch (name) {
@@ -421,7 +428,7 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
           },
         });
         expect(impl.element.style[`margin${dirStr}`]).to.equal(testCase.margin);
-        if (!testCase.isMultiSizeResponse && testCase.inZIndexHoldback) {
+        if (!testCase.isMultiSizeResponse && testCase.inZIndexHoldBack) {
           // We use a fixed '11' value for z-index.
           expect(impl.element.style.zIndex).to.equal('11');
         }

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -408,6 +408,7 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
           },
         };
         impl.win.document.body.dir = testCase.direction;
+        impl.inZIndexHoldback_ = testCase.inZIndexHoldback;
         impl.extractSize({
           get(name) {
             switch (name) {
@@ -420,7 +421,7 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
           },
         });
         expect(impl.element.style[`margin${dirStr}`]).to.equal(testCase.margin);
-        if (!testCase.isMultiSizeResponse) {
+        if (!testCase.isMultiSizeResponse && testCase.inZIndexHoldback) {
           // We use a fixed '11' value for z-index.
           expect(impl.element.style.zIndex).to.equal('11');
         }
@@ -1006,19 +1007,6 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
         expect(url).to.match(/(\?|&)psz=[0-9]+x-1(&|$)/);
         expect(url).to.match(/(\?|&)fws=[0-9]+(&|$)/);
         expect(url).to.match(/(=|%2C)21063173(%2C|&|$)/);
-      });
-    });
-
-    it('should not include msz/psz if not in holdback experiment', () => {
-      env.sandbox
-        .stub(impl, 'randomlySelectUnsetExperiments_')
-        .returns({flexAdSlots: '21063174'});
-      impl.setPageLevelExperiments();
-      return impl.getAdUrl().then(url => {
-        expect(url).to.not.match(/(\?|&)msz=/);
-        expect(url).to.not.match(/(\?|&)psz=/);
-        expect(url).to.not.match(/(\?|&)fws=/);
-        expect(url).to.match(/(=|%2C)21063174(%2C|&|$)/);
       });
     });
 


### PR DESCRIPTION
Fixes #24653.

We currently set a fixed z-index on flex ad slots upon expansion which is causing ads to hover over publisher content (usually navigation components which also use a z-index, but often a lower value), with no obvious added benefit. After this PR is merged, we will default to not setting a z-index for flex ad slots, but will maintain a temporary holdback experiment to ensure no other breakages occur and to allow for the easy reversal of this change.

This also removes an old holdback experiment for enabling flex ad slots, which is no longer of use.