### PR TITLE
♻️ amp-list: remove support for deprecated state attribute

### DIFF
--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -358,7 +358,6 @@ export class AmpList extends AMP.BaseElement {
     };
 
     const src = mutations['src'];
-    const state = /** @type {!JsonObject} */ (mutations)['state'];
     if (src !== undefined) {
       if (typeof src === 'string') {
         // Defer to fetch in layoutCallback() before first layout.
@@ -371,9 +370,6 @@ export class AmpList extends AMP.BaseElement {
       } else {
         this.user().error(TAG, 'Unexpected "src" type: ' + src);
       }
-    } else if (state !== undefined) {
-      user().error(TAG, '[state] is deprecated, please use [src] instead.');
-      promise = renderLocalData(state);
     }
 
     const isLayoutContainer = mutations['is-layout-container'];

--- a/extensions/amp-list/0.1/test/validator-amp-list.out
+++ b/extensions/amp-list/0.1/test/validator-amp-list.out
@@ -48,7 +48,7 @@ FAIL
 |    <!-- Valid: amp-list with both src and [src] attributes -->
 |    <amp-list width=10 height=10
 >>   ^~~~~~~~~
-amp-list/0.1/test/validator-amp-list.html:48:2 The attribute '[state]' in tag 'amp-list' is deprecated - use '[src]' instead.
+amp-list/0.1/test/validator-amp-list.html:48:2 The attribute '[state]' may not appear in tag 'amp-list'. (see https://amp.dev/documentation/components/amp-list)
 |              src="https://data.com/articles.json?ref=CANONICAL_URL"
 |              [src]="foo.bar" [state]="baz.qux">
 |      <div></div>

--- a/extensions/amp-list/validator-amp-list.protoascii
+++ b/extensions/amp-list/validator-amp-list.protoascii
@@ -114,10 +114,6 @@ tags: {  # <amp-list> with mandatory src and/or [src] attr
     name: "[src]"
     mandatory_anyof: "['src','[src]','data-amp-bind-src']"
   }
-  attrs: {
-    name: "[state]"
-    deprecation: "[src]"
-  }
   attr_lists: "extended-amp-global"
   amp_layout: {
     supported_layouts: FILL


### PR DESCRIPTION
**summary**
Remove `[state]` attribute, which was deprecated back in Feb 2018 (https://github.com/ampproject/amphtml/pull/13237).

After checking our internal tool cookbook, this attr doesn't seem to be used in the wild.
