### PR TITLE
✨ [amp-list] Introduce "amp-state:" as a usable protocol for the src attribute.

### DIFF
--- a/examples/bind/basic.amp.html
+++ b/examples/bind/basic.amp.html
@@ -44,9 +44,9 @@
 
   <amp-state id="myState">
     <script type="application/json">
-      {
+      items: {
         "myStateKey1": "myStateValue1",
-        "animals": ["okapis", "bears", "pigs"]
+        "animals": {items: ["okapis", "bears", "pigs"]}
       }
     </script>
   </amp-state>

--- a/examples/bind/basic.amp.html
+++ b/examples/bind/basic.amp.html
@@ -33,10 +33,20 @@
     <button on="tap:AMP.setState({'foo': 'foo', 'isButtonDisabled': true, 'textClass': 'redBackground', 'imgSrc': 'https://amp.dev/static/samples/img/Shetland_Sheepdog.jpg', 'imgSize': 200, 'imgAlt': 'Sheepdog'})">Click me</button>
   </div>
 
+  <h3>"amp-state:" url example:</h3>
+  <amp-list src="amp-state:myState.animals" layout="fixed" height="200px">
+    Animals:
+    <template type="amp-mustache">
+      <li style="padding-left: 20px">{{.}}</li>
+    </template>
+  </amp-list>
+
+
   <amp-state id="myState">
     <script type="application/json">
       {
-        "myStateKey1": "myStateValue1"
+        "myStateKey1": "myStateValue1",
+        "animals": ["okapis", "bears", "pigs"]
       }
     </script>
   </amp-state>

--- a/examples/bind/basic.amp.html
+++ b/examples/bind/basic.amp.html
@@ -44,9 +44,9 @@
 
   <amp-state id="myState">
     <script type="application/json">
-      items: {
+      {
         "myStateKey1": "myStateValue1",
-        "animals": {items: ["okapis", "bears", "pigs"]}
+        "animals": { "items": ["okapis", "bears", "pigs"] }
       }
     </script>
   </amp-state>

--- a/examples/bind/basic.amp.html
+++ b/examples/bind/basic.amp.html
@@ -9,6 +9,8 @@
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <script async custom-element="amp-bind" src="https://cdn.ampproject.org/v0/amp-bind-0.1.js"></script>
+  <script async custom-element="amp-bind" src="https://cdn.ampproject.org/v0/amp-list-0.1.js"></script>
+  <script async custom-element="amp-bind" src="https://cdn.ampproject.org/v0/amp-mustache-0.2.js"></script>
 
   <style amp-custom>
     .redBackground {
@@ -34,8 +36,7 @@
   </div>
 
   <h3>"amp-state:" url example:</h3>
-  <amp-list src="amp-state:myState.animals" layout="fixed" height="200px">
-    Animals:
+  <amp-list src="amp-state:myState.animals" layout="fixed-height" height="300px">
     <template type="amp-mustache">
       <li style="padding-left: 20px">{{.}}</li>
     </template>

--- a/examples/bind/basic.amp.html
+++ b/examples/bind/basic.amp.html
@@ -9,6 +9,7 @@
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <script async custom-element="amp-bind" src="https://cdn.ampproject.org/v0/amp-bind-0.1.js"></script>
+  <script async custom-element="amp-list" src="https://cdn.ampproject.org/v0/amp-list-0.1.js"></script>
   <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.2.js" ></script>
   <style amp-custom>
     .redBackground {

--- a/examples/bind/basic.amp.html
+++ b/examples/bind/basic.amp.html
@@ -9,9 +9,7 @@
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <script async custom-element="amp-bind" src="https://cdn.ampproject.org/v0/amp-bind-0.1.js"></script>
-  <script async custom-element="amp-bind" src="https://cdn.ampproject.org/v0/amp-list-0.1.js"></script>
-  <script async custom-element="amp-bind" src="https://cdn.ampproject.org/v0/amp-mustache-0.2.js"></script>
-
+  <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.2.js" ></script>
   <style amp-custom>
     .redBackground {
       background-color: red;

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -591,9 +591,6 @@ export class AmpList extends AMP.BaseElement {
     if (!elementSrc) {
       return Promise.resolve();
     }
-    if (this.isAmpStateSrc_(elementSrc)) {
-      return this.renderLocalData_(elementSrc);
-    }
 
     let fetch;
     if (this.ssrTemplateHelper_.isEnabled()) {

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -16,6 +16,7 @@
 
 import {ActionTrust} from '../../../src/action-constants';
 import {AmpEvents} from '../../../src/amp-events';
+import {isExperimentOn} from '../../../src/experiments';
 import {CSS} from '../../../build/amp-list-0.1.css';
 import {
   DIFFABLE_AMP_ELEMENTS,
@@ -349,7 +350,8 @@ export class AmpList extends AMP.BaseElement {
    */
   isAmpStateSrc(src) {
     return (
-      // isExperimentOn('amp-list-init-from-state') &&
+      (isExperimentOn('amp-list-init-from-state') ||
+        /*TODO: remove the true / learn how experiments work. */ true) &&
       src.trim().startsWith('amp-state:')
     );
   }

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -352,7 +352,7 @@ export class AmpList extends AMP.BaseElement {
   isAmpStateSrc(src) {
     return (
       isExperimentOn(this.win, 'amp-list-init-from-state') &&
-      startsWith(src.trim(), 'amp-state:')
+      startsWith(src, 'amp-state:')
     );
   }
 
@@ -363,7 +363,7 @@ export class AmpList extends AMP.BaseElement {
   renderLocalData(src) {
     let dataPromise;
     if (typeof src === 'string') {
-      const ampStatePath = src.trim().substring('amp-state:'.length);
+      const ampStatePath = src.substring('amp-state:'.length);
       const ampStateId = ampStatePath.split('.')[0];
       const ampStateEl = this.win.document.querySelector(
         escapeCssSelectorIdent(`#${ampStateId}`)

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -370,7 +370,7 @@ export class AmpList extends AMP.BaseElement {
   getAmpStateJson_(src) {
     const ampStatePath = src.substring(AMP_STATE_URI_SCHEME.length);
     return Services.bindForDocOrNull(this.element).then(bind => {
-      user().assert(
+      userAssert(
         bind,
         '"amp-state:" URLs require amp-bind to be installed.',
         this.element

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -340,6 +340,21 @@ export class AmpList extends AMP.BaseElement {
     );
   }
 
+  /**
+   * @param {string} src
+   * @return {boolean}
+   */
+  shouldLocalRender(src, isMutation) {
+    if (isMutation) {
+      return typeof(src) ==='object';
+    }
+
+    return (
+      isExperimentOn('amp-list-init-from-state') &&
+      src.trim().startsWith('amp-script:')
+    );
+  }
+
   /** @override */
   mutatedAttributesCallback(mutations) {
     dev().info(TAG, 'mutate:', this.element, mutations);

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -405,6 +405,10 @@ export class AmpList extends AMP.BaseElement {
           promise = this.fetchList_();
         }
       } else if (typeof src === 'object') {
+        if (this.ssrTemplateHelper_.isEnabled()) {
+          user().error(TAG, '"[src]" may not be bound in SSR mode.');
+          return Promise.resolve();
+        }
         promise = renderLocalData(/** @type {!Object} */ (src));
       } else {
         this.user().error(TAG, 'Unexpected "src" type: ' + src);
@@ -588,6 +592,11 @@ export class AmpList extends AMP.BaseElement {
 
     let fetch;
     if (this.isAmpStateSrc_(elementSrc)) {
+      if (this.ssrTemplateHelper_.isEnabled()) {
+        user().error(TAG, '"amp-state" URIs cannot be used in SSR mode.');
+        return Promise.resolve();
+      }
+
       fetch = this.getAmpStateJson_(elementSrc).then(json => {
         if (typeof json === 'undefined') {
           user().warn(

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -354,7 +354,6 @@ export class AmpList extends AMP.BaseElement {
   isAmpStateSrc_(src) {
     return (
       isExperimentOn(this.win, 'amp-list-init-from-state') &&
-      typeof src === 'string' &&
       startsWith(src, AMP_STATE_URI_SCHEME)
     );
   }
@@ -368,7 +367,7 @@ export class AmpList extends AMP.BaseElement {
    * @private
    */
   getAmpStateJson_(src) {
-    const ampStatePath = src.substring(AMP_STATE_URI_SCHEME.length);
+    const ampStatePath = src.slice(AMP_STATE_URI_SCHEME.length);
     return Services.bindForDocOrNull(this.element).then(bind => {
       userAssert(
         bind,

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -372,10 +372,11 @@ export class AmpList extends AMP.BaseElement {
       const ampStatePath = src.substring('amp-state:'.length);
       const ampStateId = ampStatePath.split('.')[0];
       const ampStateEl = this.win.document.querySelector(
-        escapeCssSelectorIdent(`#${ampStateId}`)
+        `#${escapeCssSelectorIdent(ampStateId)}`
       );
       if (!ampStateEl) {
         const errorMsg = `An amp-state element with id: ${ampStateId} could not be found.`;
+        user().error(TAG, errorMsg);
         return Promise.reject(new Error(errorMsg));
       }
       if (
@@ -384,6 +385,7 @@ export class AmpList extends AMP.BaseElement {
         !isJsonScriptTag(ampStateEl.children[0])
       ) {
         const errorMsg = `In order to use amp-state with id ${ampStateId} as an initial source for amp-list, it must have a json script tag as its first child.`;
+        user().error(TAG, errorMsg);
         return Promise.reject(user().createError(errorMsg));
       }
 
@@ -416,8 +418,13 @@ export class AmpList extends AMP.BaseElement {
 
     const src = mutations['src'];
     if (src !== undefined) {
-      if (typeof src === 'object') {
+      if (typeof src === 'object' && src !== null) {
         promise = this.renderLocalData_(src);
+      } else if (typeof src === 'string' && this.isAmpStateSrc_(src)) {
+        this.user().error(
+          TAG,
+          'When using src as a bound attribute, you should use bind expressions instead of "amp-state:" syntax.'
+        );
       } else if (typeof src === 'string') {
         // Defer to fetch in layoutCallback() before first layout.
         if (this.layoutCompleted_) {

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -364,7 +364,7 @@ export class AmpList extends AMP.BaseElement {
   }
 
   /**
-   * Returns json pointed at by an amp-state protocol src. For example,
+   * Render an amp-list that has an "amp-state:" uri. For example,
    * src="amp-state:json.path".
    *
    * @param {string} src
@@ -372,30 +372,22 @@ export class AmpList extends AMP.BaseElement {
    * @private
    */
   renderAmpStateJson_(src) {
-    const ampStatePath = src.slice(AMP_STATE_URI_SCHEME.length);
     return Services.bindForDocOrNull(this.element)
       .then(bind => {
-        userAssert(
-          bind,
-          '"amp-state:" URLs require amp-bind to be installed.',
-          this.element
-        );
+        userAssert(bind, '"amp-state:" URLs require amp-bind to be installed.');
         userAssert(
           !this.ssrTemplateHelper_.isEnabled(),
-          "'amp-list': 'amp-state' URIs cannot be used in SSR mode."
+          '[amp-list]: "amp-state" URIs cannot be used in SSR mode.'
         );
 
+        const ampStatePath = src.slice(AMP_STATE_URI_SCHEME.length);
         return bind.getState(ampStatePath);
       })
       .then(json => {
-        if (typeof json === 'undefined') {
-          user().warn(
-            TAG,
-            `No data was found at provided uri: ${elementSrc}`,
-            this.element
-          );
-          return;
-        }
+        userAssert(
+          typeof json !== 'undefined',
+          `[amp-list] No data was found at provided uri: ${src}`
+        );
 
         const array = /** @type {!Array} */ (isArray(json) ? json : [json]);
         return this.scheduleRender_(array, /* append */ false);
@@ -421,8 +413,7 @@ export class AmpList extends AMP.BaseElement {
       this.element.setAttribute('src', '');
       userAssert(
         !this.ssrTemplateHelper_.isEnabled(),
-        TAG,
-        '"[src]" may not be bound in SSR mode.'
+        '[amp-list] "[src]" may not be bound in SSR mode.'
       );
 
       const array = /** @type {!Array} */ (isArray(data) ? data : [data]);

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -348,8 +348,9 @@ export class AmpList extends AMP.BaseElement {
    *
    * @param {string} src
    * @return {boolean}
+   * @private
    */
-  isAmpStateSrc(src) {
+  isAmpStateSrc_(src) {
     return (
       isExperimentOn(this.win, 'amp-list-init-from-state') &&
       startsWith(src, 'amp-state:')
@@ -359,8 +360,9 @@ export class AmpList extends AMP.BaseElement {
   /**
    * @param {!Array|!Object|string} src
    * @return {!Promise}
+   * @private
    */
-  renderLocalData(src) {
+  renderLocalData_(src) {
     let dataPromise;
     if (typeof src === 'string') {
       const ampStatePath = src.substring('amp-state:'.length);
@@ -410,8 +412,8 @@ export class AmpList extends AMP.BaseElement {
 
     const src = mutations['src'];
     if (src !== undefined) {
-      if (typeof src === 'object' || this.isAmpStateSrc(src)) {
-        promise = this.renderLocalData(/** @type {!Object} */ (src));
+      if (typeof src === 'object' || this.isAmpStateSrc_(src)) {
+        promise = this.renderLocalData_(/** @type {!Object} */ (src));
       } else if (typeof src === 'string') {
         // Defer to fetch in layoutCallback() before first layout.
         if (this.layoutCompleted_) {
@@ -596,8 +598,8 @@ export class AmpList extends AMP.BaseElement {
     const elementSrc = this.element.getAttribute('src');
     if (!elementSrc) {
       return Promise.resolve();
-    } else if (this.isAmpStateSrc(elementSrc)) {
-      return this.renderLocalData(elementSrc);
+    } else if (this.isAmpStateSrc_(elementSrc)) {
+      return this.renderLocalData_(elementSrc);
     }
 
     let fetch;

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -589,6 +589,14 @@ export class AmpList extends AMP.BaseElement {
     let fetch;
     if (this.isAmpStateSrc_(elementSrc)) {
       fetch = this.getAmpStateJson_(elementSrc).then(json => {
+        if (!json) {
+          user().warn(
+            TAG,
+            `No data was found at provided uri: ${elementSrc}`,
+            this.element
+          );
+          return;
+        }
         const array = /** @type {!Array} */ (isArray(json) ? json : [json]);
         return this.scheduleRender_(array, /* append */ false);
       });

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -364,7 +364,7 @@ export class AmpList extends AMP.BaseElement {
    * src="amp-state:json.path".
    *
    * @param {string} src
-   * @return {Promise<!Object>}
+   * @return {Promise<*>}
    * @private
    */
   getAmpStateJson_(src) {
@@ -589,7 +589,7 @@ export class AmpList extends AMP.BaseElement {
     let fetch;
     if (this.isAmpStateSrc_(elementSrc)) {
       fetch = this.getAmpStateJson_(elementSrc).then(json => {
-        if (!json) {
+        if (typeof json === 'undefined') {
           user().warn(
             TAG,
             `No data was found at provided uri: ${elementSrc}`,

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -263,6 +263,10 @@ export class AmpList extends AMP.BaseElement {
       this.initializeLoadMoreElements_();
     }
 
+    if (this.isAmpStateSrc_(this.element.getAttribute('src'))) {
+      return this.renderLocalData_(this.element.getAttribute('src'));
+    }
+
     return this.fetchList_();
   }
 
@@ -371,7 +375,7 @@ export class AmpList extends AMP.BaseElement {
         escapeCssSelectorIdent(`#${ampStateId}`)
       );
       if (!ampStateEl) {
-        const errorMsg = `amp-state could not be found for id: ${ampStateId}`;
+        const errorMsg = `An amp-state element with id: ${ampStateId} could not be found.`;
         return Promise.reject(new Error(errorMsg));
       }
       if (
@@ -412,8 +416,8 @@ export class AmpList extends AMP.BaseElement {
 
     const src = mutations['src'];
     if (src !== undefined) {
-      if (typeof src === 'object' || this.isAmpStateSrc_(src)) {
-        promise = this.renderLocalData_(/** @type {!Object} */ (src));
+      if (typeof src === 'object') {
+        promise = this.renderLocalData_(src);
       } else if (typeof src === 'string') {
         // Defer to fetch in layoutCallback() before first layout.
         if (this.layoutCompleted_) {
@@ -598,8 +602,6 @@ export class AmpList extends AMP.BaseElement {
     const elementSrc = this.element.getAttribute('src');
     if (!elementSrc) {
       return Promise.resolve();
-    } else if (this.isAmpStateSrc_(elementSrc)) {
-      return this.renderLocalData_(elementSrc);
     }
 
     let fetch;

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -376,7 +376,7 @@ export class AmpList extends AMP.BaseElement {
       if (!isJsonScriptTag(ampStateEl.children[0])) {
         user().error(
           TAG,
-          `amp-state with id: ${ampStateEl} must have a json script tag as its first child.`
+          `In order to use amp-state with id ${ampStateId} as an initial source for amp-list, it must have a json script tag as its first child.`
         );
         return;
       }
@@ -385,7 +385,7 @@ export class AmpList extends AMP.BaseElement {
         if (!bind) {
           user().error(
             TAG,
-            'In order to point an amp-list at amp-state, amp-bind must be loaded'
+            'You must include amp-bind in order to use amp-state as an initial source for amp-list.'
           );
           return;
         }
@@ -396,6 +396,7 @@ export class AmpList extends AMP.BaseElement {
       this.element.setAttribute('src', '');
       dataPromise = Promise.resolve(src);
     }
+
     dataPromise.then(data => {
       const array = /** @type {!Array} */ (isArray(data) ? data : [data]);
       this.resetIfNecessary_(/* isFetch */ false);

--- a/extensions/amp-list/0.1/test/test-amp-list.js
+++ b/extensions/amp-list/0.1/test/test-amp-list.js
@@ -1264,7 +1264,7 @@ describes.repeated(
 
             it('should render a list using local data', async () => {
               toggleExperiment(win, experimentName, true);
-              bind.getState = () => [1, 2, 3];
+              bind.getState = () => ({items: [1, 2, 3]});
 
               const ampStateEl = doc.createElement('amp-state');
               ampStateEl.setAttribute('id', 'okapis');
@@ -1275,8 +1275,10 @@ describes.repeated(
 
               listMock
                 .expects('scheduleRender_')
-                .withExactArgs([1, 2, 3], /*append*/ false)
+                .withExactArgs([1, 2, 3], /*append*/ false, {items: [1, 2, 3]})
+                .returns(Promise.resolve())
                 .once();
+
               await list.layoutCallback();
             });
           });

--- a/extensions/amp-list/0.1/test/test-amp-list.js
+++ b/extensions/amp-list/0.1/test/test-amp-list.js
@@ -546,6 +546,28 @@ describes.repeated(
             );
           });
 
+          describe('Initialized by amp-state', () => {
+            it('should throw an error if used without the experiment enabled', () => {
+              // TODO
+            });
+
+            it('should throw an error if amp-state does not exist in the HTML', () => {
+              // TODO
+            });
+
+            it('should throw if the amp-state does not have a json child', () => {
+              // TODO
+            });
+
+            it('should render a list using local data', () => {
+              // TODO
+            });
+
+            it('should support keying into a nested part of local data', () => {
+              // TODO
+            });
+          });
+
           describe('DOM diffing with [diffable]', () => {
             const newData = [{}];
 

--- a/extensions/amp-list/0.1/test/test-amp-list.js
+++ b/extensions/amp-list/0.1/test/test-amp-list.js
@@ -809,7 +809,7 @@ describes.repeated(
               );
             });
 
-            it('"amp-state:" uri should skip rendering and emit an error', async () => {
+            it('"amp-state:" uri should skip rendering and emit an error', () => {
               toggleExperiment(win, 'amp-list-init-from-state', true);
 
               const ampStateEl = doc.createElement('amp-state');
@@ -822,9 +822,9 @@ describes.repeated(
 
               listMock.expects('scheduleRender_').never();
 
-              allowConsoleError(async () => {
-                await list.layoutCallback();
-              });
+              const errorMsg = /cannot be used in SSR mode/;
+              expectAsyncConsoleError(errorMsg);
+              expect(list.layoutCallback()).eventually.rejectedWith(errorMsg);
             });
 
             it('Bound [src] should skip rendering and emit an error', async () => {
@@ -1241,11 +1241,9 @@ describes.repeated(
             });
 
             it('should throw an error if used without the experiment enabled', async () => {
-              const errorMsg = 'Invalid value: amp-state:okapis';
+              const errorMsg = /Invalid value: amp-state:okapis/;
               expectAsyncConsoleError(errorMsg);
-              expect(list.layoutCallback()).to.eventually.rejectedWith(
-                errorMsg
-              );
+              expect(list.layoutCallback()).to.eventually.throw(errorMsg);
             });
 
             it('should log an error if amp-bind was not included', async () => {
@@ -1258,9 +1256,10 @@ describes.repeated(
               ampStateJson.setAttribute('type', 'application/json');
               ampStateEl.appendChild(ampStateJson);
               doc.body.appendChild(ampStateEl);
-              expect(list.layoutCallback()).to.eventually.throw(
-                'require amp-bind to be installed'
-              );
+
+              const errorMsg = /bind to be installed/;
+              expectAsyncConsoleError(errorMsg);
+              expect(list.layoutCallback()).eventually.rejectedWith(errorMsg);
             });
 
             it('should render a list using local data', async () => {

--- a/extensions/amp-list/0.1/test/test-amp-list.js
+++ b/extensions/amp-list/0.1/test/test-amp-list.js
@@ -808,6 +808,31 @@ describes.repeated(
                 attrs
               );
             });
+
+            it('"amp-state:" uri should skip rendering and emit an error', async () => {
+              toggleExperiment(win, 'amp-list-init-from-state', true);
+
+              const ampStateEl = doc.createElement('amp-state');
+              ampStateEl.setAttribute('id', 'okapis');
+              const ampStateJson = doc.createElement('script');
+              ampStateJson.setAttribute('type', 'application/json');
+              ampStateEl.appendChild(ampStateJson);
+              doc.body.appendChild(ampStateEl);
+              list.element.setAttribute('src', 'amp-state:okapis');
+
+              listMock.expects('scheduleRender_').never();
+
+              allowConsoleError(async () => {
+                await list.layoutCallback();
+              });
+            });
+
+            it('Bound [src] should skip rendering and emit an error', async () => {
+              listMock.expects('scheduleRender_').never();
+              allowConsoleError(async () => {
+                await list.mutatedAttributesCallback({src: {}});
+              });
+            });
           });
 
           // TODO(aghassemi, #12476): Make this test work with sinon 4.0.

--- a/extensions/amp-list/0.1/test/test-amp-list.js
+++ b/extensions/amp-list/0.1/test/test-amp-list.js
@@ -1278,6 +1278,23 @@ describes.repeated(
                 .once();
               await list.layoutCallback();
             });
+
+            // Only valid for init.
+            it('should throw if setting [src] with "amp-state:" protocol.', async () => {
+              toggleExperiment(win, experimentName, true);
+              bind.getState = () => [1, 2, 3];
+
+              const ampStateEl = doc.createElement('amp-state');
+              ampStateEl.setAttribute('id', 'okapis');
+              const ampStateJson = doc.createElement('script');
+              ampStateJson.setAttribute('type', 'application/json');
+              ampStateEl.appendChild(ampStateJson);
+              doc.body.appendChild(ampStateEl);
+
+              expect(list.mutatedAttributesCallback({
+                'src': 'amp-state:okapis',
+              })).to.eventually.be.rejectedWith('Invalid value: amp-state:okapis');
+            });
           });
         }); // with amp-bind
       }

--- a/extensions/amp-list/0.1/test/test-amp-list.js
+++ b/extensions/amp-list/0.1/test/test-amp-list.js
@@ -1233,8 +1233,9 @@ describes.repeated(
               ampStateJson.setAttribute('type', 'application/json');
               ampStateEl.appendChild(ampStateJson);
               doc.body.appendChild(ampStateEl);
-              expectAsyncConsoleError('You must include amp-bind');
-              await list.layoutCallback();
+              expect(list.layoutCallback()).to.eventually.throw(
+                'require amp-bind to be installed'
+              );
             });
 
             it('should render a list using local data', async () => {

--- a/extensions/amp-list/0.1/test/test-amp-list.js
+++ b/extensions/amp-list/0.1/test/test-amp-list.js
@@ -892,11 +892,11 @@ describes.repeated(
 
           // Unlike [src] mutations with URLs, local data mutations should
           // always render immediately.
-          it('should render if [src] mutates with data (before layout)', () => {
+          it('should render if [src] mutates with data (before layout)', async () => {
             listMock.expects('scheduleRender_').once();
 
             element.setAttribute('src', 'https://new.com/list.json');
-            list.mutatedAttributesCallback({'src': [{title: 'Title1'}]});
+            await list.mutatedAttributesCallback({'src': [{title: 'Title1'}]});
             // `src` attribute should still be set to empty string.
             expect(element.getAttribute('src')).to.equal('');
           });
@@ -1204,7 +1204,7 @@ describes.repeated(
             });
           });
 
-          describe('Initialized by amp-state', () => {
+          describe.only('Initialized by amp-state', () => {
             const experimentName = 'amp-list-init-from-state';
 
             beforeEach(() => {
@@ -1225,7 +1225,7 @@ describes.repeated(
 
             it('should throw an error if amp-state does not exist in the HTML', async () => {
               toggleExperiment(win, experimentName, true);
-              const errorMsg = 'amp-state could not be found';
+              const errorMsg = 'An amp-state element with id';
               expectAsyncConsoleError(errorMsg);
               return expect(
                 list.layoutCallback()
@@ -1235,7 +1235,7 @@ describes.repeated(
             it('should throw if the amp-state does not have a json child', () => {
               toggleExperiment(win, experimentName, true);
 
-              const ampStateEl = doc.createElement('amp-script');
+              const ampStateEl = doc.createElement('amp-state');
               ampStateEl.setAttribute('id', 'okapis');
               doc.body.appendChild(ampStateEl);
 
@@ -1280,7 +1280,7 @@ describes.repeated(
             });
 
             // Only valid for init.
-            it('should throw if setting [src] with "amp-state:" protocol.', async () => {
+            it('should throw if setting [src] to an amp-state protocol.', async () => {
               toggleExperiment(win, experimentName, true);
               bind.getState = () => [1, 2, 3];
 
@@ -1291,9 +1291,14 @@ describes.repeated(
               ampStateEl.appendChild(ampStateJson);
               doc.body.appendChild(ampStateEl);
 
-              expect(list.mutatedAttributesCallback({
-                'src': 'amp-state:okapis',
-              })).to.eventually.be.rejectedWith('Invalid value: amp-state:okapis');
+              listMock.expects('scheduleRender_').returns(Promise.resolve());
+              expectAsyncConsoleError('When using src as a bound attribute');
+              await list.layoutCallback();
+              expect(
+                list.mutatedAttributesCallback({
+                  'src': 'amp-state:okapis',
+                })
+              ).to.be.undefined;
             });
           });
         }); // with amp-bind

--- a/extensions/amp-list/0.1/test/test-amp-list.js
+++ b/extensions/amp-list/0.1/test/test-amp-list.js
@@ -1204,7 +1204,7 @@ describes.repeated(
             });
           });
 
-          describe.only('Initialized by amp-state', () => {
+          describe('Using amp-state: protocol', () => {
             const experimentName = 'amp-list-init-from-state';
 
             beforeEach(() => {
@@ -1218,35 +1218,12 @@ describes.repeated(
             it('should throw an error if used without the experiment enabled', async () => {
               const errorMsg = 'Invalid value: amp-state:okapis';
               expectAsyncConsoleError(errorMsg);
-              return expect(
-                list.layoutCallback()
-              ).to.eventually.be.rejectedWith(errorMsg);
+              expect(list.layoutCallback()).to.eventually.rejectedWith(
+                errorMsg
+              );
             });
 
-            it('should throw an error if amp-state does not exist in the HTML', async () => {
-              toggleExperiment(win, experimentName, true);
-              const errorMsg = 'An amp-state element with id';
-              expectAsyncConsoleError(errorMsg);
-              return expect(
-                list.layoutCallback()
-              ).to.eventually.be.rejectedWith(errorMsg);
-            });
-
-            it('should throw if the amp-state does not have a json child', () => {
-              toggleExperiment(win, experimentName, true);
-
-              const ampStateEl = doc.createElement('amp-state');
-              ampStateEl.setAttribute('id', 'okapis');
-              doc.body.appendChild(ampStateEl);
-
-              const errorMsg = 'In order to use amp-state with id';
-              expectAsyncConsoleError(errorMsg);
-              return expect(
-                list.layoutCallback()
-              ).to.eventually.be.rejectedWith(errorMsg);
-            });
-
-            it('should throw if amp-bind was not included', async () => {
+            it('should log an error if amp-bind was not included', async () => {
               toggleExperiment(win, experimentName, true);
               Services.bindForDocOrNull.returns(Promise.resolve(null));
 
@@ -1256,9 +1233,8 @@ describes.repeated(
               ampStateJson.setAttribute('type', 'application/json');
               ampStateEl.appendChild(ampStateJson);
               doc.body.appendChild(ampStateEl);
-              expect(list.layoutCallback()).to.eventually.be.rejectedWith(
-                'You must include amp-bind'
-              );
+              expectAsyncConsoleError('You must include amp-bind');
+              await list.layoutCallback();
             });
 
             it('should render a list using local data', async () => {
@@ -1277,28 +1253,6 @@ describes.repeated(
                 .withExactArgs([1, 2, 3], /*append*/ false)
                 .once();
               await list.layoutCallback();
-            });
-
-            // Only valid for init.
-            it('should throw if setting [src] to an amp-state protocol.', async () => {
-              toggleExperiment(win, experimentName, true);
-              bind.getState = () => [1, 2, 3];
-
-              const ampStateEl = doc.createElement('amp-state');
-              ampStateEl.setAttribute('id', 'okapis');
-              const ampStateJson = doc.createElement('script');
-              ampStateJson.setAttribute('type', 'application/json');
-              ampStateEl.appendChild(ampStateJson);
-              doc.body.appendChild(ampStateEl);
-
-              listMock.expects('scheduleRender_').returns(Promise.resolve());
-              expectAsyncConsoleError('When using src as a bound attribute');
-              await list.layoutCallback();
-              expect(
-                list.mutatedAttributesCallback({
-                  'src': 'amp-state:okapis',
-                })
-              ).to.be.undefined;
             });
           });
         }); // with amp-bind

--- a/tools/experiments/experiments-config.js
+++ b/tools/experiments/experiments-config.js
@@ -115,6 +115,11 @@ export const EXPERIMENTS = [
     spec: 'https://github.com/ampproject/amphtml/issues/7743',
   },
   {
+    id: 'amp-list-init-from-state',
+    name: 'Allows amp-list to initialize off of amp-state',
+    spec: 'https://github.com/ampproject/amphtml/issues/26009',
+  },
+  {
     id: 'amp-playbuzz',
     name: 'AMP extension for playbuzz items (launched)',
     spec: 'https://github.com/ampproject/amphtml/issues/6106',


### PR DESCRIPTION
**Summary**
Implements https://github.com/ampproject/amphtml/issues/15647.

Allows an amp-list to initialize off of an SSRed amp-state. Initially I had been worried that this would delay the rendering of `amp-list` until `amp-bind` had finished initialization (ironically this could be slower than the client side fetch would have been). Turns out though, that `amp-state` parsing and `getState` are not blocked on amp-bind's `initializationPromise`, so all is well.

I've gated it on a feature flag, so nobody should be able to use it yet. In a followup PR I'll run performance measurements, create documentation and remove the flag.

cc @jridgewell / @choumx 