### PR TITLE
Respects prefers-reduced-motion for content animations.

### DIFF
--- a/extensions/amp-story/1.0/amp-story.css
+++ b/extensions/amp-story/1.0/amp-story.css
@@ -40,6 +40,15 @@ amp-consent {
   z-index: initial !important;
 }
 
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0s !important;
+    transition-duration: 0s !important;
+  }
+}
+
 /**
  * amp-hidden uses visiblity: hidden that does not propagate to shadow trees
  * because of amp-story-shadow-reset.css. Use display: none instead.


### PR DESCRIPTION
Respects `prefers-reduced-motion` for AMP story content animations.
This does not affect system components for now, but only animations provided by `animate-in` attributes, or custom publisher animations.

#24821