### PR TITLE
Do not load amp-auto-lightbox on amp-story documents.

### DIFF
--- a/extensions/amp-auto-lightbox/0.1/test/test-amp-auto-lightbox.js
+++ b/extensions/amp-auto-lightbox/0.1/test/test-amp-auto-lightbox.js
@@ -137,14 +137,18 @@ describes.realWin(
           it(`${accepts ? 'accepts' : 'rejects'} ${accepts || rejects}`, () => {
             [
               html`
-                <amp-img src="asada.png"></amp-img>
-              `,
-              html`
-                <div><amp-img src="adobada.png"></amp-img></div>
+                <amp-img src="asada.png" layout="flex-item"></amp-img>
               `,
               html`
                 <div>
-                  <div><amp-img src="carnitas.png"></amp-img></div>
+                  <amp-img src="adobada.png" layout="flex-item"></amp-img>
+                </div>
+              `,
+              html`
+                <div>
+                  <div>
+                    <amp-img src="carnitas.png" layout="flex-item"></amp-img>
+                  </div>
                 </div>
               `,
             ].forEach(unwrapped => {
@@ -446,7 +450,7 @@ describes.realWin(
         mockCandidates([
           mockLoadedSignal(
             html`
-              <amp-img></amp-img>
+              <amp-img layout="flex-item"></amp-img>
             `,
             true
           ),
@@ -466,7 +470,7 @@ describes.realWin(
         mockCandidates([
           mockLoadedSignal(
             html`
-              <amp-img></amp-img>
+              <amp-img layout="flex-item"></amp-img>
             `,
             true
           ),
@@ -483,19 +487,19 @@ describes.realWin(
       it('sets attribute only for candidates that meet criteria', async () => {
         const a = mockLoadedSignal(
           html`
-            <amp-img src="a.png"></amp-img>
+            <amp-img src="a.png" layout="flex-item"></amp-img>
           `,
           true
         );
         const b = mockLoadedSignal(
           html`
-            <amp-img src="b.png"></amp-img>
+            <amp-img src="b.png" layout="flex-item"></amp-img>
           `,
           true
         );
         const c = mockLoadedSignal(
           html`
-            <amp-img src="c.png"></amp-img>
+            <amp-img src="c.png" layout="flex-item"></amp-img>
           `,
           true
         );
@@ -520,7 +524,7 @@ describes.realWin(
           [1, 2, 3].map(() =>
             mockLoadedSignal(
               html`
-                <amp-img src="a.png"></amp-img>
+                <amp-img src="a.png" layout="flex-item"></amp-img>
               `,
               true
             )
@@ -543,14 +547,14 @@ describes.realWin(
       it('filters out candidates that fail to load', async () => {
         const shouldNotLoad = mockLoadedSignal(
           html`
-            <amp-img src="bla.png"></amp-img>
+            <amp-img src="bla.png" layout="flex-item"></amp-img>
           `,
           false
         );
 
         const shouldLoad = mockLoadedSignal(
           html`
-            <amp-img src="bla.png"></amp-img>
+            <amp-img src="bla.png" layout="flex-item"></amp-img>
           `,
           true
         );
@@ -681,6 +685,7 @@ describes.realWin(
 
             const lightboxable = createElementWithAttributes(doc, 'amp-img', {
               [LIGHTBOXABLE_ATTR]: '',
+              layout: 'flex-item',
             });
 
             doc.head.appendChild(extensionScript);
@@ -715,6 +720,7 @@ describes.realWin(
 
             const lightboxable = createElementWithAttributes(doc, 'amp-img', {
               [LIGHTBOXABLE_ATTR]: '',
+              layout: 'flex-item',
             });
 
             doc.head.appendChild(extensionScript);
@@ -730,7 +736,7 @@ describes.realWin(
     describe('apply', () => {
       it('sets attribute', async () => {
         const element = html`
-          <amp-img src="chabuddy.g"></amp-img>
+          <amp-img src="chabuddy.g" layout="flex-item"></amp-img>
         `;
 
         await apply(env.ampdoc, element);
@@ -742,7 +748,7 @@ describes.realWin(
         const candidates = [1, 2, 3].map(
           () =>
             html`
-              <amp-img></amp-img>
+              <amp-img layout="flex-item"></amp-img>
             `
         );
 
@@ -757,7 +763,7 @@ describes.realWin(
 
       it('dispatches event', async () => {
         const element = html`
-          <amp-img src="chabuddy.g"></amp-img>
+          <amp-img src="chabuddy.g" layout="flex-item"></amp-img>
         `;
 
         element.dispatchCustomEvent = env.sandbox.spy();

--- a/src/auto-lightbox.js
+++ b/src/auto-lightbox.js
@@ -18,6 +18,7 @@ import {ChunkPriority, chunk} from './chunk';
 import {Services} from './services';
 import {dev} from './log';
 import {isAmphtml} from './format';
+import {isStoryDocument} from './utils/story';
 
 /** @const @enum {string} */
 export const AutoLightboxEvents = {
@@ -45,10 +46,16 @@ export function installAutoLightboxExtension(ampdoc) {
   chunk(
     ampdoc,
     () => {
-      Services.extensionsFor(win).installExtensionForDoc(
-        ampdoc,
-        'amp-auto-lightbox'
-      );
+      isStoryDocument(ampdoc).then(isStory => {
+        // Do not enable on amp-story documents.
+        if (isStory) {
+          return;
+        }
+        Services.extensionsFor(win).installExtensionForDoc(
+          ampdoc,
+          'amp-auto-lightbox'
+        );
+      });
     },
     ChunkPriority.LOW
   );


### PR DESCRIPTION
The `amp-auto-lightbox` script is loaded on all AMP Story documents, even in prerender mode.
This script is never used, removing it would save a bit over 3kb per story prerendered or loaded.

I added the `isStoryDocument` check in the `chunk()` statement as it uses some CPU cycles, but I'm open to alternative implementations. It delays the loading of the `amp-auto-lightbox` to after the `body` is fully parsed, which should be fine since AFAIK the lightbox can only be triggered by a user interaction.