### PR TITLE
🐛 Change method of sending data to Propensity

### DIFF
--- a/examples/amp-subscriptions.amp.html
+++ b/examples/amp-subscriptions.amp.html
@@ -192,7 +192,7 @@
          aware.  An example is shown in the onAd trigger below, you will need
          to adjust it so the CSS selector works for your page.
 -->
-
+<!--
 <amp-analytics type="subscriptions-propensity"
   data-credentials="include"
   credentials="include">
@@ -232,7 +232,7 @@
   }
   </script>
 </amp-analytics>
-
+-->
 <amp-analytics type="googleanalytics" id="analytics2">
 <script type="application/json">
 {

--- a/examples/amp-subscriptions.amp.html
+++ b/examples/amp-subscriptions.amp.html
@@ -192,7 +192,7 @@
          aware.  An example is shown in the onAd trigger below, you will need
          to adjust it so the CSS selector works for your page.
 -->
-<!--
+
 <amp-analytics type="subscriptions-propensity"
   data-credentials="include"
   credentials="include">
@@ -208,7 +208,7 @@
         "request": "sendEvent",
         "vars": {
           "event": "subscriptions_landing_page",
-          "data": "{'source': 'email marketing campaign 2019', 'active': false}"
+          "data": "{\"source\": \"email marketing campaign 2019\", \"is_active\": false}"
         }
       },
       "onPastSubscriber": {
@@ -216,7 +216,7 @@
         "request": "sendSubscriptionState",
         "vars": {
           "state": "past_subscriber",
-          "productId": "myPreviousProductId"
+          "products": "'product1', 'product2'"
         }
       },
       "onAd": {
@@ -225,14 +225,14 @@
         "request": "sendEvent",
         "vars": {
           "event": "ad_shown",
-          "data": "{'ad_name': 'fall_ad or custom name'}"
+          "data": "{\"ad_name\": \"fall_ad or custom name\"}"
         }
       }
     }
   }
   </script>
 </amp-analytics>
--->
+
 <amp-analytics type="googleanalytics" id="analytics2">
 <script type="application/json">
 {

--- a/extensions/amp-analytics/0.1/test/vendor-requests.json
+++ b/extensions/amp-analytics/0.1/test/vendor-requests.json
@@ -360,13 +360,10 @@
     "conversion": "https://adserver.pressboard.ca/track/attention-amp?&amp=1&url=_canonical_url_&referrer=_document_referrer_&ts=_timestamp_&ua=_user_agent_&rand=_random_&uid=_client_id_&mid=!mediaId&cid=!campaignId&sid=!storyRequestId&geoid=!geoNameId&cn=!country&rg=!region&ct=!city&dbi=!dbInstance&tz=!timeZoneOffset&hbt=1&pvid=_page_view_id_&asurl=_source_url_&ash=_scroll_height_&asnh=_screen_height_&aasnh=_available_screen_height_&avh=_viewport_height_&ast=_scroll_top_&atet=_total_engaged_time_"
   },
   "subscriptions-propensity": {
-    "sendEvent": "https://pubads.g.doubleclick.net/subopt/data?u_tz=240&v=1&cookie=_client_id_&cdm=!sourceHostName&_amp_source_origin=_source_host_&events=!publicationId%3A!event%3A!data",
-    "sendSubscriptionState": "https://pubads.g.doubleclick.net/subopt/data?u_tz=240&v=1&cookie=_client_id_&cdm=!sourceHostName&_amp_source_origin=_source_host_&states=!publicationId%3A!state%3A!productId",
-    "eventParams": "events=!publicationId%3A!event%3A!data",
-    "stateParams": "states=!publicationId%3A!state%3A!productId",
-    "sendBase": "https://pubads.g.doubleclick.net/subopt/data?u_tz=240&v=1&cookie=_client_id_&cdm=!sourceHostName&_amp_source_origin=_source_host_",
-    "baseParams": "u_tz=240&v=1&cookie=_client_id_&cdm=!sourceHostName&_amp_source_origin=_source_host_",
-    "baseUrl": "https://pubads.g.doubleclick.net/subopt"
+    "baseParams": "u_tz=240&v=1&cookie=_client_id_&cdm=!sourceHostName&_amp_source_origin=_source_host_&extrainfo=",
+    "sendBase": "https://pubads.g.doubleclick.net/subopt/data?u_tz=240&v=1&cookie=_client_id_&cdm=!sourceHostName&_amp_source_origin=_source_host_&extrainfo=",
+    "sendEvent": "https://pubads.g.doubleclick.net/subopt/data?u_tz=240&v=1&cookie=_client_id_&cdm=!sourceHostName&_amp_source_origin=_source_host_&extrainfo=!data&events=!publicationId%3A!event",
+    "sendSubscriptionState": "https://pubads.g.doubleclick.net/subopt/data?u_tz=240&v=1&cookie=_client_id_&cdm=!sourceHostName&_amp_source_origin=_source_host_&extrainfo=!productObjstates=!publicationId%3A!state"
   },
   "quantcast": {
     "host": "https://pixel.quantserve.com/pixel",

--- a/extensions/amp-analytics/0.1/test/vendor-requests.json
+++ b/extensions/amp-analytics/0.1/test/vendor-requests.json
@@ -363,7 +363,7 @@
     "baseParams": "u_tz=240&v=1&cookie=_client_id_&cdm=!sourceHostName&_amp_source_origin=_source_host_&extrainfo=",
     "sendBase": "https://pubads.g.doubleclick.net/subopt/data?u_tz=240&v=1&cookie=_client_id_&cdm=!sourceHostName&_amp_source_origin=_source_host_&extrainfo=",
     "sendEvent": "https://pubads.g.doubleclick.net/subopt/data?u_tz=240&v=1&cookie=_client_id_&cdm=!sourceHostName&_amp_source_origin=_source_host_&extrainfo=!data&events=!publicationId%3A!event",
-    "sendSubscriptionState": "https://pubads.g.doubleclick.net/subopt/data?u_tz=240&v=1&cookie=_client_id_&cdm=!sourceHostName&_amp_source_origin=_source_host_&extrainfo=!productObjstates=!publicationId%3A!state"
+    "sendSubscriptionState": "https://pubads.g.doubleclick.net/subopt/data?u_tz=240&v=1&cookie=_client_id_&cdm=!sourceHostName&_amp_source_origin=_source_host_&extrainfo=%7B%22product%22%3A%20%5B!products%5D%7D&states=!publicationId%3A!state"
   },
   "quantcast": {
     "host": "https://pixel.quantserve.com/pixel",

--- a/extensions/amp-analytics/0.1/vendors/subscriptions-propensity.js
+++ b/extensions/amp-analytics/0.1/vendors/subscriptions-propensity.js
@@ -19,19 +19,17 @@ import {jsonLiteral} from '../../../../src/json';
 const SUBSCRIPTIONS_PROPENSITY_CONFIG = jsonLiteral({
   'vars': {
     'clientId': 'CLIENT_ID(__gads)',
-    'data':
-      '{"skus": "${skus}","source": "${source}","active": "${active}","product": "${product}"}',
+    'productObj': '{"product": [${products}]}',
+    'stateParams': '${publicationId}:${state}',
+    'eventParams': '${publicationId}:${event}',
   },
   'requests': {
     'baseUrl': 'https://pubads.g.doubleclick.net/subopt',
     'baseParams':
-      'u_tz=240&v=1&cookie=${clientId}&cdm=${sourceHostName}&' +
-      '_amp_source_origin=${sourceHost}',
+      'u_tz=240&v=1&cookie=${clientId}&cdm=${sourceHostName}&_amp_source_origin=${sourceHost}&extrainfo=',
     'sendBase': '${baseUrl}/data?${baseParams}',
-    'stateParams': 'states=${publicationId}%3A${state}%3A${productId}',
-    'eventParams': 'events=${publicationId}%3A${event}%3A${data}',
-    'sendSubscriptionState': '${sendBase}&${stateParams}',
-    'sendEvent': '${sendBase}&${eventParams}',
+    'sendSubscriptionState': '${sendBase}${productObj}&states=${stateParams}',
+    'sendEvent': '${sendBase}${data}&events=${eventParams}',
   },
   'triggers': {
     'onSubscribed': {
@@ -39,6 +37,7 @@ const SUBSCRIPTIONS_PROPENSITY_CONFIG = jsonLiteral({
       'request': 'sendSubscriptionState',
       'vars': {
         'state': 'subscriber',
+        'products': '"${productId}"',
       },
     },
     'onNotSubscribed': {
@@ -46,6 +45,7 @@ const SUBSCRIPTIONS_PROPENSITY_CONFIG = jsonLiteral({
       'request': 'sendSubscriptionState',
       'vars': {
         'state': 'non_subscriber',
+        'products': '"${productId}"',
       },
     },
     'onShowOffers': {
@@ -53,6 +53,7 @@ const SUBSCRIPTIONS_PROPENSITY_CONFIG = jsonLiteral({
       'request': 'sendEvent',
       'vars': {
         'event': 'offers_shown',
+        'data': '{"skus": "${skus}","source": "${source}"}',
       },
     },
     'onPaywall': {
@@ -60,7 +61,7 @@ const SUBSCRIPTIONS_PROPENSITY_CONFIG = jsonLiteral({
       'request': 'sendEvent',
       'vars': {
         'event': 'paywall',
-        'active': 'false',
+        'data': '{"is_active": false, "source": "${source}"}',
       },
     },
     'onSelectOffer': {
@@ -68,7 +69,7 @@ const SUBSCRIPTIONS_PROPENSITY_CONFIG = jsonLiteral({
       'request': 'sendEvent',
       'vars': {
         'event': 'offer_selected',
-        'active': 'true',
+        'data': '{"is_active": true,"product": "${product}"}',
       },
     },
     'onStartBuyflow': {
@@ -76,7 +77,7 @@ const SUBSCRIPTIONS_PROPENSITY_CONFIG = jsonLiteral({
       'request': 'sendEvent',
       'vars': {
         'event': 'payment_flow_start',
-        'active': 'true',
+        'data': '{"is_active": true,"product": "${product}"}',
       },
     },
     'onPaymentComplete': {
@@ -84,7 +85,7 @@ const SUBSCRIPTIONS_PROPENSITY_CONFIG = jsonLiteral({
       'request': 'sendEvent',
       'vars': {
         'event': 'payment_complete',
-        'active': 'true',
+        'data': '{"is_active": true,"product": "${product}"}',
       },
     },
   },

--- a/extensions/amp-analytics/0.1/vendors/subscriptions-propensity.json
+++ b/extensions/amp-analytics/0.1/vendors/subscriptions-propensity.json
@@ -1,29 +1,31 @@
 {
   "vars": {
-    "clientId": "CLIENT_ID(__gads)"
+    "clientId": "CLIENT_ID(__gads)",
+    "productObj": "{\"product\": [${products}]}",
+    "stateParams": "${publicationId}:${state}",
+    "eventParams": "${publicationId}:${event}"
   },
   "requests": {
-    "baseUrl": "https://pubads.g.doubleclick.net/subopt",
-    "baseParams": "u_tz=240&v=1&cookie=${clientId}&cdm=${sourceHostName}&_amp_source_origin=${sourceHost}",
-    "sendBase": "${baseUrl}/data?${baseParams}",
-    "stateParams": "states=${publicationId}%3A${state}%3A${productId}",
-    "eventParams": "events=${publicationId}%3A${event}%3A${data}",
-    "sendSubscriptionState": "${sendBase}&${stateParams}",
-    "sendEvent": "${sendBase}&${eventParams}"
+    "baseParams": "u_tz=240&v=1&cookie=${clientId}&cdm=${sourceHostName}&_amp_source_origin=${sourceHost}&extrainfo=",
+    "sendBase": "https://pubads.g.doubleclick.net/subopt/data?${baseParams}",
+    "sendSubscriptionState": "${sendBase}${productObj}&states=${stateParams}",
+    "sendEvent": "${sendBase}${data}&events=${eventParams}"
   },
   "triggers": {
     "onSubscribed": {
       "on": "subscriptions-access-granted",
       "request": "sendSubscriptionState",
       "vars": {
-        "state": "subscriber"
+        "state": "subscriber",
+        "products": "\"${productId}\""
       }
     },
     "onNotSubscribed": {
       "on": "subscriptions-access-denied",
       "request": "sendSubscriptionState",
       "vars": {
-        "state": "non_subscriber"
+        "state": "non_subscriber",
+        "products": "\"${productId}\""
       }
     },
     "onShowOffers": {
@@ -31,7 +33,7 @@
       "request": "sendEvent",
       "vars": {
         "event": "offers_shown",
-        "data": "{\"skus\": \"${skus}\",\"source\": \"${source}\",\"active\": \"${active}\"}"
+        "data": "{\"skus\": \"${skus}\",\"source\": \"${source}\"}"
       }
     },
     "onPaywall": {
@@ -39,7 +41,7 @@
       "request": "sendEvent",
       "vars": {
         "event": "paywall",
-        "data": "{\"source\": \"${source}\",\"active\": \"false\"}"
+        "data": "{\"is_active\": false, \"source\": \"${source}\"}"
       }
     },
     "onSelectOffer": {
@@ -47,7 +49,7 @@
       "request": "sendEvent",
       "vars": {
         "event": "offer_selected",
-        "data": "{\"active\": \"true\",\"product\": \"${product}\"}"
+        "data": "{\"is_active\": true,\"product\": \"${product}\"}"
       }
     },
     "onStartBuyflow": {
@@ -55,7 +57,7 @@
       "request": "sendEvent",
       "vars": {
         "event": "payment_flow_start",
-        "data": "{\"active\": \"true\",\"product\": \"${product}\"}"
+        "data": "{\"is_active\": true,\"product\": \"${product}\"}"
       }
     },
     "onPaymentComplete": {
@@ -63,7 +65,7 @@
       "request": "sendEvent",
       "vars": {
         "event": "payment_complete",
-        "data": "{\"active\": \"true\",\"product\": \"${product}\"}"
+        "data": "{\"is_active\": true,\"product\": \"${product}\"}"
       }
     }
   },

--- a/extensions/amp-subscriptions/0.1/amp-subscriptions.js
+++ b/extensions/amp-subscriptions/0.1/amp-subscriptions.js
@@ -281,6 +281,7 @@ export class SubscriptionService {
   getEntitlements_(platform) {
     return platform.getEntitlements().then(entitlements => {
       if (
+        entitlements &&
         entitlements.granted &&
         this.cryptoHandler_.isDocumentEncrypted() &&
         !entitlements.decryptedDocumentKey


### PR DESCRIPTION
Propensity has agreed to move the JSON object out of the shared parameter and into its own parameter.  This resolves an issue with double encoding.