### PR TITLE
🐛Log warning when missing URL while attaching shadow doc

### DIFF
--- a/src/multidoc-manager.js
+++ b/src/multidoc-manager.js
@@ -227,6 +227,7 @@ export class MultidocManager {
    * @return {!./runtime.ShadowDoc}
    */
   attachShadowDoc(hostElement, doc, url, opt_initParams) {
+    user().assertString(url);
     dev().fine(TAG, 'Attach shadow doc:', doc);
     // TODO(dvoytenko, #9490): once stable, port full document case to emulated
     // stream.
@@ -269,6 +270,7 @@ export class MultidocManager {
    * @return {!Object}
    */
   attachShadowDocAsStream(hostElement, url, opt_initParams) {
+    user().assertString(url);
     dev().fine(TAG, 'Attach shadow doc as stream');
     return this.attachShadowDoc_(
       hostElement,


### PR DESCRIPTION
Closes #9871 by logging a warning when the URL arg to `attachShadowDoc` or `attachShadowDocAsStream` is not a string. 