### PR TITLE
Propagate vertical touch events in stories.

### DIFF
--- a/extensions/amp-story/1.0/amp-story-draggable-drawer.js
+++ b/extensions/amp-story/1.0/amp-story-draggable-drawer.js
@@ -266,14 +266,24 @@ export class DraggableDrawer extends AMP.BaseElement {
       return;
     }
 
-    event.stopPropagation();
-
     const coordinates = this.getClientTouchCoordinates_(event);
     if (!coordinates) {
       return;
     }
 
     const {x, y} = coordinates;
+
+    this.touchEventState_.swipingUp = y < this.touchEventState_.lastY;
+    this.touchEventState_.lastY = y;
+
+    if (
+      this.state_ === DrawerState.CLOSED &&
+      !this.touchEventState_.swipingUp
+    ) {
+      return;
+    }
+
+    event.stopPropagation();
 
     if (this.touchEventState_.isSwipeY === null) {
       this.touchEventState_.isSwipeY =
@@ -283,9 +293,6 @@ export class DraggableDrawer extends AMP.BaseElement {
         return;
       }
     }
-
-    this.touchEventState_.swipingUp = y < this.touchEventState_.lastY;
-    this.touchEventState_.lastY = y;
 
     this.onSwipeY_({
       event,

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -76,10 +76,7 @@ import {MediaPool, MediaType} from './media-pool';
 import {PaginationButtons} from './pagination-buttons';
 import {Services} from '../../../src/services';
 import {ShareMenu} from './amp-story-share-menu';
-import {
-  SwipeXYRecognizer,
-  SwipeYRecognizer,
-} from '../../../src/gesture-recognizers';
+import {SwipeXYRecognizer} from '../../../src/gesture-recognizers';
 import {SystemLayer} from './amp-story-system-layer';
 import {UnsupportedBrowserLayer} from './amp-story-unsupported-browser-layer';
 import {ViewportWarningLayer} from './amp-story-viewport-warning-layer';
@@ -837,18 +834,19 @@ export class AmpStory extends AMP.BaseElement {
 
   /** @private */
   installGestureRecognizers_() {
+    // If the story is within a viewer that enabled the swipe capability, this
+    // disables the navigation education overlay to enable:
+    //   - horizontal swipe events to the next story
+    //   - vertical swipe events to close the viewer, or open a page attachment
+    if (this.viewer_.hasCapability('swipe')) {
+      return;
+    }
+
     const {element} = this;
     const gestures = Gestures.get(element, /* shouldNotPreventDefault */ true);
 
-    // If the story is within a viewer that enabled the swipe capability, this
-    // disables the navigation education overlay on the X axis to enable the
-    // swipe to the next story feature.
-    const swipeRecognizer = this.viewer_.hasCapability('swipe')
-      ? SwipeYRecognizer
-      : SwipeXYRecognizer;
-
     // Shows "tap to navigate" hint when swiping.
-    gestures.onGesture(swipeRecognizer, gesture => {
+    gestures.onGesture(SwipeXYRecognizer, gesture => {
       const {deltaX, deltaY} = gesture.data;
       const embedComponent = /** @type {InteractiveComponentDef} */ (this.storeService_.get(
         StateProperty.INTERACTIVE_COMPONENT_STATE

--- a/extensions/amp-story/1.0/test/test-amp-story.js
+++ b/extensions/amp-story/1.0/test/test-amp-story.js
@@ -1503,11 +1503,19 @@ describes.realWin(
         };
 
         describe('without #cap=swipe', () => {
-          it('should handle touch events at the story level', async () => {
+          it('should handle h touch events at the story level', async () => {
             await createStoryWithPages(2);
             const touchmoveSpy = env.sandbox.spy();
             story.win.document.addEventListener('touchmove', touchmoveSpy);
             dispatchSwipeEvent(100, 0);
+            expect(touchmoveSpy).to.not.have.been.called;
+          });
+
+          it('should handle v touch events at the story level', async () => {
+            await createStoryWithPages(2);
+            const touchmoveSpy = env.sandbox.spy();
+            story.win.document.addEventListener('touchmove', touchmoveSpy);
+            dispatchSwipeEvent(0, 100);
             expect(touchmoveSpy).to.not.have.been.called;
           });
 
@@ -1527,11 +1535,19 @@ describes.realWin(
           before(() => (hasSwipeCapability = true));
           after(() => (hasSwipeCapability = false));
 
-          it('should let touch events bubble up to be forwarded', async () => {
+          it('should let h touch events bubble up to be forwarded', async () => {
             await createStoryWithPages(2);
             const touchmoveSpy = env.sandbox.spy();
             story.win.document.addEventListener('touchmove', touchmoveSpy);
             dispatchSwipeEvent(100, 0);
+            expect(touchmoveSpy).to.have.been.called;
+          });
+
+          it('should let v touch events bubble up to be forwarded', async () => {
+            await createStoryWithPages(2);
+            const touchmoveSpy = env.sandbox.spy();
+            story.win.document.addEventListener('touchmove', touchmoveSpy);
+            dispatchSwipeEvent(0, 100);
             expect(touchmoveSpy).to.have.been.called;
           });
 


### PR DESCRIPTION
When the viewer uses the `#cap=swipe` opt-in:
- Forwards vertical touch events, but still handling the page attachment case (there's no bookend in this mode, but they share the same code so it'd work properly too)
- Stops showing the navigation hint overlay UI as vertical events are for swiping to close / opening the page attachment, and horizontal events are for swiping between stories

More context and details #25697

Fixes #25697 