### PR TITLE
✨ [amp-story-embed] Adds messaging, implements build/layoutcallbacks

### DIFF
--- a/build-system/compile/sources.js
+++ b/build-system/compile/sources.js
@@ -49,6 +49,8 @@ const COMMON_GLOBS = [
   'node_modules/web-activities/activity-ports.js',
   'node_modules/@ampproject/animations/package.json',
   'node_modules/@ampproject/animations/dist/animations.mjs',
+  'node_modules/@ampproject/viewer-messaging/package.json',
+  'node_modules/@ampproject/viewer-messaging/messaging.js',
   'node_modules/@ampproject/worker-dom/package.json',
   'node_modules/@ampproject/worker-dom/dist/amp/main.mjs',
   'node_modules/preact/package.json',

--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -366,6 +366,7 @@ const forbiddenTerms = {
       'src/service/navigation.js',
       'src/service/url-impl.js',
       'dist.3p/current/integration.js',
+      'src/amp-story-embed.js',
     ],
   },
   '\\.sendMessage\\(': {

--- a/examples/amp-story/embed.html
+++ b/examples/amp-story/embed.html
@@ -8,7 +8,7 @@
       }
       amp-story-embed {
         position: absolute;
-        top: 1500px;
+        top: 3000px;
       }
     </style>
     <style injected>
@@ -44,14 +44,26 @@
   <body>
     <h1>This is a NON-AMP page that embeds a story below:</h1>
     <amp-story-embed>
-      <a href="https://stamp-demo.firebaseapp.com/examples/amp-story/artezan/kitchen-stories/index.html"
-          class="story">
-        <span class="title">Kitchen</span>
-      </a>
-      <a href="./body-painting/index.html"
-          class="story">
-        <span class="title">Body Painting</span>
-      </a>
+        <a href="https://www-washingtonpost-com.cdn.ampproject.org/v/s/www.washingtonpost.com/graphics/2019/lifestyle/travel/amp-stories/a-locals-guide-to-what-to-eat-and-do-in-new-york-city/"
+            data-poster-portrait-src="https://www-washingtonpost-com.cdn.ampproject.org/v/s/www.washingtonpost.com/graphics/2019/lifestyle/travel/amp-stories/a-locals-guide-to-what-to-eat-and-do-in-new-york-city/img/promo3x4.jpg"
+            class="story">
+          <span class="title">A local’s guide to what to eat and do in New York City</span>
+        </a>
+        <a href="https://www-washingtonpost-com.cdn.ampproject.org/v/s/www.washingtonpost.com/graphics/2019/lifestyle/travel/amp-stories/a-locals-guide-to-what-to-eat-and-do-in-miami/"
+            data-poster-portrait-src="https://www-washingtonpost-com.cdn.ampproject.org/v/s/www.washingtonpost.com/graphics/2019/lifestyle/travel/amp-stories/a-locals-guide-to-what-to-eat-and-do-in-miami/img/promo3x4.jpg"
+            class="story">
+          <span class="title">A local’s guide to what to eat and do in Miami</span>
+        </a>
+        <a href="https://www-washingtonpost-com.cdn.ampproject.org/v/s/www.washingtonpost.com/graphics/2019/lifestyle/travel/amp-stories/a-locals-guide-to-what-to-eat-and-do-in-mexico-city/"
+            data-poster-portrait-src="https://www-washingtonpost-com.cdn.ampproject.org/v/s/www.washingtonpost.com/graphics/2019/lifestyle/travel/amp-stories/a-locals-guide-to-what-to-eat-and-do-in-mexico-city/img/promo3x4.jpg"
+            class="story">
+          <span class="title">A local’s guide to what to eat and do in Mexico City</span>
+        </a>
+        <a href="https://www-washingtonpost-com.cdn.ampproject.org/v/s/www.washingtonpost.com/graphics/2019/lifestyle/travel/amp-stories/a-locals-guide-to-what-to-eat-and-do-in-rome/"
+            data-poster-portrait-src="https://www-washingtonpost-com.cdn.ampproject.org/v/s/washingtonpost.com/graphics/2019/lifestyle/travel/amp-stories/a-locals-guide-to-what-to-do-and-eat-in-rome/img/promo3x4.jpg"
+            class="story">
+          <span class="title">A local’s guide to what to eat and do in Rome</span>
+        </a>
     </amp-story-embed>
   </body>
 </html>

--- a/examples/amp-story/embed.html
+++ b/examples/amp-story/embed.html
@@ -6,6 +6,10 @@
       body {
         font-family: sans-serif;
       }
+      amp-story-embed {
+        position: absolute;
+        top: 1500px;
+      }
     </style>
     <style injected>
       .amp-story-embed {
@@ -40,25 +44,13 @@
   <body>
     <h1>This is a NON-AMP page that embeds a story below:</h1>
     <amp-story-embed>
-      <a href="https://www.washingtonpost.com/graphics/2019/lifestyle/travel/amp-stories/a-locals-guide-to-what-to-eat-and-do-in-new-york-city/"
-          data-poster-portrait-src="https://www.washingtonpost.com/graphics/2019/lifestyle/travel/amp-stories/a-locals-guide-to-what-to-eat-and-do-in-new-york-city/img/promo3x4.jpg"
+      <a href="https://stamp-demo.firebaseapp.com/examples/amp-story/artezan/kitchen-stories/index.html"
           class="story">
-        <span class="title">A local’s guide to what to eat and do in New York City</span>
+        <span class="title">Kitchen</span>
       </a>
-      <a href="https://www.washingtonpost.com/graphics/2019/lifestyle/travel/amp-stories/a-locals-guide-to-what-to-eat-and-do-in-miami/"
-          data-poster-portrait-src="https://www.washingtonpost.com/graphics/2019/lifestyle/travel/amp-stories/a-locals-guide-to-what-to-eat-and-do-in-miami/img/promo3x4.jpg"
+      <a href="./body-painting/index.html"
           class="story">
-        <span class="title">A local’s guide to what to eat and do in Miami</span>
-      </a>
-      <a href="https://www.washingtonpost.com/graphics/2019/lifestyle/travel/amp-stories/a-locals-guide-to-what-to-eat-and-do-in-mexico-city/"
-          data-poster-portrait-src="https://www.washingtonpost.com/graphics/2019/lifestyle/travel/amp-stories/a-locals-guide-to-what-to-eat-and-do-in-mexico-city/img/promo3x4.jpg"
-          class="story">
-        <span class="title">A local’s guide to what to eat and do in Mexico City</span>
-      </a>
-      <a href="https://www.washingtonpost.com/graphics/2019/lifestyle/travel/amp-stories/a-locals-guide-to-what-to-eat-and-do-in-rome/"
-          data-poster-portrait-src="https://washingtonpost.com/graphics/2019/lifestyle/travel/amp-stories/a-locals-guide-to-what-to-do-and-eat-in-rome/img/promo3x4.jpg"
-          class="story">
-        <span class="title">A local’s guide to what to eat and do in Rome</span>
+        <span class="title">Body Painting</span>
       </a>
     </amp-story-embed>
   </body>

--- a/examples/amp-story/embed.html
+++ b/examples/amp-story/embed.html
@@ -17,7 +17,7 @@
         height: 720px;
       }
 
-      .story {
+      .story-embed-iframe {
         background-size: cover;
         display: block;
         position: relative;

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@ampproject/animations": "0.2.0",
     "@ampproject/worker-dom": "0.23.2",
+    "@ampproject/viewer-messaging": "1.1.0",
     "dompurify": "2.0.7",
     "moment": "2.24.0",
     "preact": "10.2.1",

--- a/src/OWNERS
+++ b/src/OWNERS
@@ -15,7 +15,7 @@
       owners: [{name: 'ampproject/wg-analytics'}],
     },
     {
-      pattern: 'amp-story-embed.js',
+      pattern: '{amp-story-embed,amp-story-embed-manager}.js',
       owners: [{name: 'newmuis'}, {name: 'gmajoulet'}, {name: 'enriqe'}],
     },
   ],

--- a/src/amp-story-embed-manager.js
+++ b/src/amp-story-embed-manager.js
@@ -35,7 +35,7 @@ export class AmpStoryEmbedManager {
    * @private
    */
   layoutEmbed_(embedImpl) {
-    if (!IntersectionObserver || this.win_ !== this.win_.parent) {
+    if (!this.win_.IntersectionObserver || this.win_ !== this.win_.parent) {
       this.layoutFallback_(embedImpl);
       return;
     }

--- a/src/amp-story-embed-manager.js
+++ b/src/amp-story-embed-manager.js
@@ -15,6 +15,7 @@
  */
 
 import {AmpStoryEmbed} from './amp-story-embed';
+import {throttle} from './utils/rate-limit';
 
 /** @const {string} */
 const SCROLL_THROTTLE_MS = 500;
@@ -62,22 +63,15 @@ export class AmpStoryEmbedManager {
    * @private
    */
   layoutFallback_(embedImpl) {
-    let tick = true;
-
     // TODO(Enriqe): pause embeds when scrolling away from viewport.
-    this.win_.addEventListener('scroll', () => {
-      if (!tick) {
-        return;
-      }
-
-      setTimeout(() => {
-        tick = true;
-
-        this.layoutIfVisible_(embedImpl);
-      }, SCROLL_THROTTLE_MS);
-
-      tick = false;
-    });
+    this.win_.addEventListener(
+      'scroll',
+      throttle(
+        this.win_,
+        this.layoutIfVisible_.bind(this, embedImpl),
+        SCROLL_THROTTLE_MS
+      )
+    );
 
     // Calls it once it in case scroll event never fires.
     this.layoutIfVisible_(embedImpl);

--- a/src/amp-story-embed-manager.js
+++ b/src/amp-story-embed-manager.js
@@ -1,0 +1,99 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {AmpStoryEmbed} from './amp-story-embed';
+
+/** @const {string} */
+const SCROLL_THROTTLE_MS = 500;
+
+export class AmpStoryEmbedManager {
+  /**
+   * Fallback for when IntersectionObserver is not supported. Calls layoutCallback
+   * on the embed when it is close to the viewport.
+   * @param {!AmpStoryEmbed} embedImpl
+   */
+  layoutFallback_(embedImpl) {
+    let tick = true;
+
+    self.addEventListener('scroll', () => {
+      if (!tick) {
+        return;
+      }
+
+      setTimeout(() => {
+        tick = true;
+
+        this.layoutIfVisible_(embedImpl);
+      }, SCROLL_THROTTLE_MS);
+
+      tick = false;
+    });
+
+    // Calls it once it in case scroll event never fires.
+    this.layoutIfVisible_(embedImpl);
+  }
+
+  /**
+   * Checks if embed is close to the viewport and calls layoutCallback when it is.
+   * @param {!AmpStoryEmbed} embedImpl
+   */
+  layoutIfVisible_(embedImpl) {
+    const embedTop = embedImpl.getElement()./*OK*/ getBoundingClientRect().top;
+    if (self./*OK*/ innerHeight * 2 > embedTop) {
+      embedImpl.layoutCallback();
+    }
+  }
+
+  /**
+   * Calls layoutCallback on the embed when it is close to the viewport.
+   * @param {!AmpStoryEmbed} embedImpl
+   * @visibleForTesting
+   */
+  layoutEmbed(embedImpl) {
+    if (IntersectionObserver && self === self.parent) {
+      const intersectingCallback = entries => {
+        entries.forEach(entry => {
+          if (!entry.isIntersecting) {
+            return;
+          }
+          embedImpl.layoutCallback();
+        });
+      };
+
+      const observer = new IntersectionObserver(intersectingCallback, {
+        rootMargin: '100%',
+      });
+      observer.observe(embedImpl.getElement());
+      return;
+    }
+
+    this.layoutFallback_(embedImpl);
+  }
+
+  /**
+   * Builds and layouts the embeds when appropiate.
+   */
+  loadEmbeds() {
+    const doc = self.document;
+    const embeds = doc.getElementsByTagName('amp-story-embed');
+    for (let i = 0; i < embeds.length; i++) {
+      const embedEl = embeds[i];
+      const embedImpl = new AmpStoryEmbed(self, embedEl);
+      embedImpl.buildCallback();
+      this.layoutEmbed(embedImpl);
+    }
+  }
+}

--- a/src/amp-story-embed.js
+++ b/src/amp-story-embed.js
@@ -93,14 +93,6 @@ export class AmpStoryEmbed {
     return this.element_;
   }
 
-  /**
-   * @visibleForTesting
-   * @return {!Element}
-   */
-  getRoot() {
-    return this.rootEl_;
-  }
-
   /** @public */
   buildCallback() {
     this.stories_ = toArray(this.element_.querySelectorAll('a'));

--- a/src/amp-story-embed.js
+++ b/src/amp-story-embed.js
@@ -92,6 +92,14 @@ export class AmpStoryEmbed {
     return this.element_;
   }
 
+  /**
+   * @visibleForTesting
+   * @return {!Element}
+   */
+  getRoot() {
+    return this.rootEl_;
+  }
+
   /** @public */
   buildCallback() {
     this.stories_ = toArray(this.element_.querySelectorAll('a'));
@@ -264,22 +272,33 @@ function layoutFallback(embedImpl) {
     setTimeout(() => {
       tick = true;
 
-      const embedTop = embedImpl.getElement()./*OK*/ getBoundingClientRect()
-        .top;
-      if (self./*OK*/ innerHeight * 2 > embedTop) {
-        embedImpl.layoutCallback();
-      }
+      layoutIfVisible(embedImpl);
     }, SCROLL_THROTTLE_MS);
 
     tick = false;
   });
+
+  // Calls it once it in case scroll event never fires.
+  layoutIfVisible(embedImpl);
+}
+
+/**
+ * Checks if embed is close to the viewport and calls layoutCallback when it is.
+ * @param {!AmpStoryEmbed} embedImpl
+ */
+function layoutIfVisible(embedImpl) {
+  const embedTop = embedImpl.getElement()./*OK*/ getBoundingClientRect().top;
+  if (self./*OK*/ innerHeight * 2 > embedTop) {
+    embedImpl.layoutCallback();
+  }
 }
 
 /**
  * Calls layoutCallback on the embed when it is close to the viewport.
  * @param {!AmpStoryEmbed} embedImpl
+ * @visibleForTesting
  */
-function layoutEmbed(embedImpl) {
+export function layoutEmbed(embedImpl) {
   if (IntersectionObserver && self === self.parent) {
     const intersectingCallback = entries => {
       entries.forEach(entry => {

--- a/test/unit/test-amp-story-embed.js
+++ b/test/unit/test-amp-story-embed.js
@@ -1,0 +1,70 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {AmpStoryEmbed, layoutEmbed} from '../../src/amp-story-embed';
+
+describe('amp-story-embed', () => {
+  describes.realWin('AmpStoryEmbed', {amp: false}, env => {
+    let win;
+    let storyEmbed;
+    let embedEl;
+    let url;
+
+    function buildStoryEmbed() {
+      embedEl = win.document.createElement('amp-story-embed');
+      const storyAnchor = win.document.createElement('a');
+      url =
+        'https://www-washingtonpost-com.cdn.ampproject.org/v/s/www.washingtonpost.com/graphics/2019/lifestyle/travel/amp-stories/a-locals-guide-to-what-to-eat-and-do-in-new-york-city/?testParam=true';
+      storyAnchor.setAttribute('href', url);
+      embedEl.appendChild(storyAnchor);
+      storyEmbed = new AmpStoryEmbed(win, embedEl);
+      win.document.body.appendChild(embedEl);
+    }
+
+    beforeEach(() => {
+      win = env.win;
+      buildStoryEmbed();
+    });
+
+    it('should build an iframe for each story', () => {
+      storyEmbed.buildCallback();
+      layoutEmbed(storyEmbed);
+
+      const shadowRoot = storyEmbed.getRoot();
+      expect(shadowRoot.children.length).to.equal(1);
+    });
+
+    it('should correctly append params at the end of the story url', () => {
+      storyEmbed.buildCallback();
+      layoutEmbed(storyEmbed);
+
+      const shadowRoot = storyEmbed.getRoot();
+      expect(shadowRoot.firstElementChild.getAttribute('src')).to.equals(
+        url + '?amp_js_v=0.1#&visibilityState=inactive&origin=about%3Asrcdoc'
+      );
+    });
+
+    it('should correctly append params at the end of a story url with existing params', () => {
+      storyEmbed.buildCallback();
+      layoutEmbed(storyEmbed);
+
+      const shadowRoot = storyEmbed.getRoot();
+      expect(shadowRoot.firstElementChild.getAttribute('src')).to.equals(
+        url + '&amp_js_v=0.1#&visibilityState=inactive&origin=about%3Asrcdoc'
+      );
+    });
+  });
+});

--- a/test/unit/test-amp-story-embed.js
+++ b/test/unit/test-amp-story-embed.js
@@ -40,18 +40,15 @@ describes.realWin('AmpStoryEmbed', {amp: false}, env => {
 
   it('should build an iframe for each story', () => {
     manager.loadEmbeds();
-    const storyEmbed = manager.getEmbed();
-    const shadowRoot = storyEmbed.getRoot();
 
-    expect(shadowRoot.children.length).to.equal(1);
+    expect(embedEl.shadowRoot.querySelector('iframe')).to.exist;
   });
 
   it('should correctly append params at the end of the story url', () => {
     manager.loadEmbeds();
-    const storyEmbed = manager.getEmbed();
-    const shadowRoot = storyEmbed.getRoot();
+    const storyIframe = embedEl.shadowRoot.querySelector('iframe');
 
-    expect(shadowRoot.firstElementChild.getAttribute('src')).to.equals(
+    expect(storyIframe.getAttribute('src')).to.equals(
       url + '?amp_js_v=0.1#visibilityState=inactive&origin=about%3Asrcdoc'
     );
   });
@@ -61,10 +58,9 @@ describes.realWin('AmpStoryEmbed', {amp: false}, env => {
     embedEl.firstElementChild.setAttribute('href', url);
 
     manager.loadEmbeds();
-    const storyEmbed = manager.getEmbed();
-    const shadowRoot = storyEmbed.getRoot();
+    const storyIframe = embedEl.shadowRoot.querySelector('iframe');
 
-    expect(shadowRoot.firstElementChild.getAttribute('src')).to.equals(
+    expect(storyIframe.getAttribute('src')).to.equals(
       url + '&amp_js_v=0.1#visibilityState=inactive&origin=about%3Asrcdoc'
     );
   });

--- a/test/unit/test-amp-story-embed.js
+++ b/test/unit/test-amp-story-embed.js
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-import {AmpStoryEmbed, layoutEmbed} from '../../src/amp-story-embed';
+import {AmpStoryEmbedManager} from '../../src/amp-story-embed-manager';
 
 describes.realWin('AmpStoryEmbed', {amp: false}, env => {
   let win;
-  let storyEmbed;
   let embedEl;
   let url;
+  let manager;
 
   function buildStoryEmbed() {
     embedEl = win.document.createElement('amp-story-embed');
@@ -29,8 +29,8 @@ describes.realWin('AmpStoryEmbed', {amp: false}, env => {
       'https://www-washingtonpost-com.cdn.ampproject.org/v/s/www.washingtonpost.com/graphics/2019/lifestyle/travel/amp-stories/a-locals-guide-to-what-to-eat-and-do-in-new-york-city/';
     storyAnchor.setAttribute('href', url);
     embedEl.appendChild(storyAnchor);
-    storyEmbed = new AmpStoryEmbed(win, embedEl);
     win.document.body.appendChild(embedEl);
+    manager = new AmpStoryEmbedManager(win);
   }
 
   beforeEach(() => {
@@ -39,33 +39,33 @@ describes.realWin('AmpStoryEmbed', {amp: false}, env => {
   });
 
   it('should build an iframe for each story', () => {
-    storyEmbed.buildCallback();
-    layoutEmbed(storyEmbed);
-
+    manager.loadEmbeds();
+    const storyEmbed = manager.getEmbed();
     const shadowRoot = storyEmbed.getRoot();
+
     expect(shadowRoot.children.length).to.equal(1);
   });
 
   it('should correctly append params at the end of the story url', () => {
-    storyEmbed.buildCallback();
-    layoutEmbed(storyEmbed);
-
+    manager.loadEmbeds();
+    const storyEmbed = manager.getEmbed();
     const shadowRoot = storyEmbed.getRoot();
+
     expect(shadowRoot.firstElementChild.getAttribute('src')).to.equals(
-      url + '?amp_js_v=0.1#&visibilityState=inactive&origin=about%3Asrcdoc'
+      url + '?amp_js_v=0.1#visibilityState=inactive&origin=about%3Asrcdoc'
     );
   });
 
   it('should correctly append params at the end of a story url with existing params', () => {
-    url += '?testParam=true';
+    url += '?testParam=true#myhash=hashValue';
     embedEl.firstElementChild.setAttribute('href', url);
 
-    storyEmbed.buildCallback();
-    layoutEmbed(storyEmbed);
-
+    manager.loadEmbeds();
+    const storyEmbed = manager.getEmbed();
     const shadowRoot = storyEmbed.getRoot();
+
     expect(shadowRoot.firstElementChild.getAttribute('src')).to.equals(
-      url + '&amp_js_v=0.1#&visibilityState=inactive&origin=about%3Asrcdoc'
+      url + '&amp_js_v=0.1#visibilityState=inactive&origin=about%3Asrcdoc'
     );
   });
 });

--- a/test/unit/test-amp-story-embed.js
+++ b/test/unit/test-amp-story-embed.js
@@ -16,55 +16,56 @@
 
 import {AmpStoryEmbed, layoutEmbed} from '../../src/amp-story-embed';
 
-describe('amp-story-embed', () => {
-  describes.realWin('AmpStoryEmbed', {amp: false}, env => {
-    let win;
-    let storyEmbed;
-    let embedEl;
-    let url;
+describes.realWin('AmpStoryEmbed', {amp: false}, env => {
+  let win;
+  let storyEmbed;
+  let embedEl;
+  let url;
 
-    function buildStoryEmbed() {
-      embedEl = win.document.createElement('amp-story-embed');
-      const storyAnchor = win.document.createElement('a');
-      url =
-        'https://www-washingtonpost-com.cdn.ampproject.org/v/s/www.washingtonpost.com/graphics/2019/lifestyle/travel/amp-stories/a-locals-guide-to-what-to-eat-and-do-in-new-york-city/?testParam=true';
-      storyAnchor.setAttribute('href', url);
-      embedEl.appendChild(storyAnchor);
-      storyEmbed = new AmpStoryEmbed(win, embedEl);
-      win.document.body.appendChild(embedEl);
-    }
+  function buildStoryEmbed() {
+    embedEl = win.document.createElement('amp-story-embed');
+    const storyAnchor = win.document.createElement('a');
+    url =
+      'https://www-washingtonpost-com.cdn.ampproject.org/v/s/www.washingtonpost.com/graphics/2019/lifestyle/travel/amp-stories/a-locals-guide-to-what-to-eat-and-do-in-new-york-city/';
+    storyAnchor.setAttribute('href', url);
+    embedEl.appendChild(storyAnchor);
+    storyEmbed = new AmpStoryEmbed(win, embedEl);
+    win.document.body.appendChild(embedEl);
+  }
 
-    beforeEach(() => {
-      win = env.win;
-      buildStoryEmbed();
-    });
+  beforeEach(() => {
+    win = env.win;
+    buildStoryEmbed();
+  });
 
-    it('should build an iframe for each story', () => {
-      storyEmbed.buildCallback();
-      layoutEmbed(storyEmbed);
+  it('should build an iframe for each story', () => {
+    storyEmbed.buildCallback();
+    layoutEmbed(storyEmbed);
 
-      const shadowRoot = storyEmbed.getRoot();
-      expect(shadowRoot.children.length).to.equal(1);
-    });
+    const shadowRoot = storyEmbed.getRoot();
+    expect(shadowRoot.children.length).to.equal(1);
+  });
 
-    it('should correctly append params at the end of the story url', () => {
-      storyEmbed.buildCallback();
-      layoutEmbed(storyEmbed);
+  it('should correctly append params at the end of the story url', () => {
+    storyEmbed.buildCallback();
+    layoutEmbed(storyEmbed);
 
-      const shadowRoot = storyEmbed.getRoot();
-      expect(shadowRoot.firstElementChild.getAttribute('src')).to.equals(
-        url + '?amp_js_v=0.1#&visibilityState=inactive&origin=about%3Asrcdoc'
-      );
-    });
+    const shadowRoot = storyEmbed.getRoot();
+    expect(shadowRoot.firstElementChild.getAttribute('src')).to.equals(
+      url + '?amp_js_v=0.1#&visibilityState=inactive&origin=about%3Asrcdoc'
+    );
+  });
 
-    it('should correctly append params at the end of a story url with existing params', () => {
-      storyEmbed.buildCallback();
-      layoutEmbed(storyEmbed);
+  it('should correctly append params at the end of a story url with existing params', () => {
+    url += '?testParam=true';
+    embedEl.firstElementChild.setAttribute('href', url);
 
-      const shadowRoot = storyEmbed.getRoot();
-      expect(shadowRoot.firstElementChild.getAttribute('src')).to.equals(
-        url + '&amp_js_v=0.1#&visibilityState=inactive&origin=about%3Asrcdoc'
-      );
-    });
+    storyEmbed.buildCallback();
+    layoutEmbed(storyEmbed);
+
+    const shadowRoot = storyEmbed.getRoot();
+    expect(shadowRoot.firstElementChild.getAttribute('src')).to.equals(
+      url + '&amp_js_v=0.1#&visibilityState=inactive&origin=about%3Asrcdoc'
+    );
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,6 +12,11 @@
   resolved "https://registry.yarnpkg.com/@ampproject/worker-dom/-/worker-dom-0.23.2.tgz#9b27a6b96125ddca58ebef302d7d05dc6080d689"
   integrity sha512-+L2MCofSaFqTyGlp5FxqoH2JuiuHJkxVuLyim2RpMsnj9CVcfNlCdNwn2KqROw9kFnJp8gnZ7c8voqwD6yDwEg==
 
+"@ampproject/viewer-messaging@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@ampproject/viewer-messaging/-/viewer-messaging-1.1.0.tgz#404f92c5754bac61014ed2272dd5e87174b9af84"
+  integrity sha512-SoR1dGl2Pl8eJlyGCU/9Gz/orOggmW/13wUh7NnuGvDYqLdlhnRBzvEGqEAlq/fQKel9ZM6RNtu85Jw8WC3K2Q==
+
 "@ava/babel-plugin-throws-helper@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@ava/babel-plugin-throws-helper/-/babel-plugin-throws-helper-4.0.0.tgz#8f5b45b7a0a79c6f4032de2101e0c221847efb62"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,15 +7,15 @@
   resolved "https://registry.yarnpkg.com/@ampproject/animations/-/animations-0.2.0.tgz#82b6b68b6fe0eacbcc95d3f0a82ddf19a0e2b316"
   integrity sha512-CiMdKK9eMa6eqhqZc9bq86nPdgbALY+E8rKgUPR7wf2wGUNTm/jtFZQ7fn4sj/oggn0wvadBokabErtl1m1KSw==
 
+"@ampproject/viewer-messaging@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@ampproject/viewer-messaging/-/viewer-messaging-1.1.0.tgz#404f92c5754bac61014ed2272dd5e87174b9af84"
+  integrity sha512-SoR1dGl2Pl8eJlyGCU/9Gz/orOggmW/13wUh7NnuGvDYqLdlhnRBzvEGqEAlq/fQKel9ZM6RNtu85Jw8WC3K2Q==
+
 "@ampproject/worker-dom@0.23.2":
   version "0.23.2"
   resolved "https://registry.yarnpkg.com/@ampproject/worker-dom/-/worker-dom-0.23.2.tgz#9b27a6b96125ddca58ebef302d7d05dc6080d689"
   integrity sha512-+L2MCofSaFqTyGlp5FxqoH2JuiuHJkxVuLyim2RpMsnj9CVcfNlCdNwn2KqROw9kFnJp8gnZ7c8voqwD6yDwEg==
-
-"@ampproject/viewer-messaging@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@ampproject/viewer-messaging/-/viewer-messaging-1.1.0.tgz#404f92c5754bac61014ed2272dd5e87174b9af84"
-  integrity sha512-SoR1dGl2Pl8eJlyGCU/9Gz/orOggmW/13wUh7NnuGvDYqLdlhnRBzvEGqEAlq/fQKel9ZM6RNtu85Jw8WC3K2Q==
 
 "@ava/babel-plugin-throws-helper@^4.0.0":
   version "4.0.0"


### PR DESCRIPTION
Partial for #24539 

This PR adds:
* Messaging that is needed for communication between the viewer and the STAMPs.
<!-- * Builds and lays all iframes inside the `<amp-story-embed>`. -->
* Adds an intersection observer that calls `layoutCallback()` with a fallback that uses a scroll listener.

Things I'm not sure about:
* Since I'm installing a new package (`@ampproject/viewer-messaging`), yarn.lock has been updated, but I don't know if that should be in my local gitignore or if it should actually be checked in.
<!-- * I set up some logging to make sure the document/viewer communication was working and I left it for easy debugging, but I can remove it if needed. -->

Issue tracker #26308