### PR TITLE
Fix edge case in isStoryDocument()

### DIFF
--- a/src/utils/story.js
+++ b/src/utils/story.js
@@ -44,7 +44,7 @@ export function isStoryDocument(ampdoc, timeout = 2000) {
       body,
       () => !!body.firstElementChild
     );
-    // Timeout to avoid never resolving e.g. when the body has no children.
+    // Timeout to avoid never resolving e.g. the body has no element children.
     return Services.timerFor(ampdoc.win)
       .timeoutPromise(timeout, childPromise)
       .then(

--- a/src/utils/story.js
+++ b/src/utils/story.js
@@ -34,7 +34,7 @@ export function descendsFromStory(element) {
  * Times out after `timeout` ms (default is 2000).
  *
  * @param {!../service/ampdoc-impl.AmpDoc} ampdoc
- * @param timeout
+ * @param {number=} timeout
  * @return {!Promise<boolean>}
  */
 export function isStoryDocument(ampdoc, timeout = 2000) {

--- a/src/utils/story.js
+++ b/src/utils/story.js
@@ -34,19 +34,18 @@ export function descendsFromStory(element) {
  * Times out after `timeout` ms (default is 2000).
  *
  * @param {!../service/ampdoc-impl.AmpDoc} ampdoc
- * @param {number=} timeout
  * @return {!Promise<boolean>}
  */
-export function isStoryDocument(ampdoc, timeout = 2000) {
+export function isStoryDocument(ampdoc) {
   return ampdoc.waitForBodyOpen().then(() => {
     const body = ampdoc.getBody();
     const childPromise = waitForChildPromise(
       body,
       () => !!body.firstElementChild
     );
-    // Timeout to avoid never resolving e.g. the body has no element children.
+    // 2s timeout for edge case where body has no element children.
     return Services.timerFor(ampdoc.win)
-      .timeoutPromise(timeout, childPromise)
+      .timeoutPromise(2000, childPromise)
       .then(
         () => body.firstElementChild.tagName === 'AMP-STORY',
         () => false


### PR DESCRIPTION
Fixes bug that causes some documents to never send performance ticks e.g. the AMP4Email "Hello World" sample doc.

`b/147509020`