### PR TITLE
🏗 🐛 Enable `accessControls` checks for JS code (and fix errors)

### DIFF
--- a/ads/google/a4a/line-delimited-response-handler.js
+++ b/ads/google/a4a/line-delimited-response-handler.js
@@ -22,7 +22,7 @@ import {tryParseJson} from '../../../src/json';
  * @param {!Window} win
  * @param {!Response} response
  * @param {function(string, boolean)} lineCallback
- * @private
+ * @protected
  */
 export function lineDelimitedStreamer(win, response, lineCallback) {
   let line = '';
@@ -71,7 +71,7 @@ export function lineDelimitedStreamer(win, response, lineCallback) {
  * Given each line, groups such that the first is JSON parsed and second
  * html unescaped.
  * @param {function(string, !Object<string, *>, boolean)} callback
- * @private
+ * @protected
  * @return {function(string, boolean)}
  */
 export function metaJsonCreativeGrouper(callback) {

--- a/ads/google/a4a/line-delimited-response-handler.js
+++ b/ads/google/a4a/line-delimited-response-handler.js
@@ -22,7 +22,6 @@ import {tryParseJson} from '../../../src/json';
  * @param {!Window} win
  * @param {!Response} response
  * @param {function(string, boolean)} lineCallback
- * @protected
  */
 export function lineDelimitedStreamer(win, response, lineCallback) {
   let line = '';
@@ -71,7 +70,6 @@ export function lineDelimitedStreamer(win, response, lineCallback) {
  * Given each line, groups such that the first is JSON parsed and second
  * html unescaped.
  * @param {function(string, !Object<string, *>, boolean)} callback
- * @protected
  * @return {function(string, boolean)}
  */
 export function metaJsonCreativeGrouper(callback) {

--- a/build-system/compile/compile.js
+++ b/build-system/compile/compile.js
@@ -325,17 +325,14 @@ function compile(
       // it won't do strict type checking if its whitespace only.
       compilerOptions.define.push('TYPECHECK_ONLY=true');
       compilerOptions.jscomp_error.push(
+        'accessControls',
         'conformanceViolations',
         'checkTypes',
         'const',
         'constantProperty',
         'globalThis'
       );
-      compilerOptions.jscomp_off.push(
-        'accessControls',
-        'moduleLoad',
-        'unknownDefines'
-      );
+      compilerOptions.jscomp_off.push('moduleLoad', 'unknownDefines');
       compilerOptions.conformance_configs =
         'build-system/test-configs/conformance-config.textproto';
     } else {

--- a/extensions/amp-analytics/0.1/instrumentation.js
+++ b/extensions/amp-analytics/0.1/instrumentation.js
@@ -36,7 +36,7 @@ const PROP = '__AMP_AN_ROOT';
 
 /**
  * @implements {../../../src/service.Disposable}
- * @protected
+ * @package
  * @visibleForTesting
  */
 export class InstrumentationService {

--- a/extensions/amp-analytics/0.1/instrumentation.js
+++ b/extensions/amp-analytics/0.1/instrumentation.js
@@ -36,7 +36,7 @@ const PROP = '__AMP_AN_ROOT';
 
 /**
  * @implements {../../../src/service.Disposable}
- * @private
+ * @protected
  * @visibleForTesting
  */
 export class InstrumentationService {

--- a/extensions/amp-autocomplete/0.1/autocomplete-binding-inline.js
+++ b/extensions/amp-autocomplete/0.1/autocomplete-binding-inline.js
@@ -24,7 +24,7 @@ const TAG = 'amp-autocomplete';
  * Inline implementation of autocomplete. This supports autocompleting
  * multiple input values as part of a larger freeform input element.
  * @implements {./autocomplete-binding-def.AutocompleteBindingDef}
- * @private
+ * @protected
  */
 export class AutocompleteBindingInline {
   /**

--- a/extensions/amp-autocomplete/0.1/autocomplete-binding-inline.js
+++ b/extensions/amp-autocomplete/0.1/autocomplete-binding-inline.js
@@ -24,7 +24,7 @@ const TAG = 'amp-autocomplete';
  * Inline implementation of autocomplete. This supports autocompleting
  * multiple input values as part of a larger freeform input element.
  * @implements {./autocomplete-binding-def.AutocompleteBindingDef}
- * @protected
+ * @package
  */
 export class AutocompleteBindingInline {
   /**

--- a/extensions/amp-autocomplete/0.1/autocomplete-binding-single.js
+++ b/extensions/amp-autocomplete/0.1/autocomplete-binding-single.js
@@ -20,7 +20,7 @@ import {userAssert} from '../../../src/log';
  * Single implementation of autocomplete. This supports autocompleting
  * a single input value in its entirety.
  * @implements {./autocomplete-binding-def.AutocompleteBindingDef}
- * @protected
+ * @package
  */
 export class AutocompleteBindingSingle {
   /**

--- a/extensions/amp-autocomplete/0.1/autocomplete-binding-single.js
+++ b/extensions/amp-autocomplete/0.1/autocomplete-binding-single.js
@@ -20,7 +20,7 @@ import {userAssert} from '../../../src/log';
  * Single implementation of autocomplete. This supports autocompleting
  * a single input value in its entirety.
  * @implements {./autocomplete-binding-def.AutocompleteBindingDef}
- * @private
+ * @protected
  */
 export class AutocompleteBindingSingle {
   /**

--- a/extensions/amp-fx-collection/0.1/fx-type.js
+++ b/extensions/amp-fx-collection/0.1/fx-type.js
@@ -96,7 +96,8 @@ let FxBindingDef;
 
 /**
  * Include respective `FxType`s here.
- * @private @const {!Object<!FxType, !FxBindingDef>}
+ * @protected
+ * @const {!Object<!FxType, !FxBindingDef>}
  */
 export const FxBindings = {
   [FxType.FADE_IN]: {

--- a/extensions/amp-fx-collection/0.1/fx-type.js
+++ b/extensions/amp-fx-collection/0.1/fx-type.js
@@ -96,7 +96,7 @@ let FxBindingDef;
 
 /**
  * Include respective `FxType`s here.
- * @protected @const {!Object<!FxType, !FxBindingDef>}
+ * @package @const {!Object<!FxType, !FxBindingDef>}
  */
 export const FxBindings = {
   [FxType.FADE_IN]: {

--- a/extensions/amp-fx-collection/0.1/fx-type.js
+++ b/extensions/amp-fx-collection/0.1/fx-type.js
@@ -96,8 +96,7 @@ let FxBindingDef;
 
 /**
  * Include respective `FxType`s here.
- * @protected
- * @const {!Object<!FxType, !FxBindingDef>}
+ * @protected @const {!Object<!FxType, !FxBindingDef>}
  */
 export const FxBindings = {
   [FxType.FADE_IN]: {

--- a/extensions/amp-lightbox-gallery/0.1/utils.js
+++ b/extensions/amp-lightbox-gallery/0.1/utils.js
@@ -42,7 +42,7 @@ export function delayAfterDeferringToEventLoop(win, duration) {
  * Converts seconds to a timestamp formatted string.
  * @param {number} seconds
  * @return {string}
- * @protected
+ * @package
  */
 export function secondsToTimestampString(seconds) {
   const h = Math.floor(seconds / 3600);

--- a/extensions/amp-lightbox-gallery/0.1/utils.js
+++ b/extensions/amp-lightbox-gallery/0.1/utils.js
@@ -42,7 +42,7 @@ export function delayAfterDeferringToEventLoop(win, duration) {
  * Converts seconds to a timestamp formatted string.
  * @param {number} seconds
  * @return {string}
- * @private
+ * @protected
  */
 export function secondsToTimestampString(seconds) {
   const h = Math.floor(seconds / 3600);

--- a/extensions/amp-story/0.1/amp-story-share.js
+++ b/extensions/amp-story/0.1/amp-story-share.js
@@ -61,13 +61,13 @@ const MIN_BUTTON_PADDING = 10;
 
 /**
  * Key for share providers in bookend config.
- * @protected @const {string}
+ * @package @const {string}
  */
 export const SHARE_PROVIDERS_KEY = 'shareProviders';
 
 /**
  * Deprecated key for share providers in bookend config.
- * @protected @const {string}
+ * @package @const {string}
  */
 export const DEPRECATED_SHARE_PROVIDERS_KEY = 'share-providers';
 

--- a/extensions/amp-story/0.1/amp-story-share.js
+++ b/extensions/amp-story/0.1/amp-story-share.js
@@ -61,15 +61,13 @@ const MIN_BUTTON_PADDING = 10;
 
 /**
  * Key for share providers in bookend config.
- * @protected
- * @const {string}
+ * @protected @const {string}
  */
 export const SHARE_PROVIDERS_KEY = 'shareProviders';
 
 /**
  * Deprecated key for share providers in bookend config.
- * @protected
- * @const {string}
+ * @protected @const {string}
  */
 export const DEPRECATED_SHARE_PROVIDERS_KEY = 'share-providers';
 

--- a/extensions/amp-story/0.1/amp-story-share.js
+++ b/extensions/amp-story/0.1/amp-story-share.js
@@ -61,13 +61,15 @@ const MIN_BUTTON_PADDING = 10;
 
 /**
  * Key for share providers in bookend config.
- * @private @const {string}
+ * @protected
+ * @const {string}
  */
 export const SHARE_PROVIDERS_KEY = 'shareProviders';
 
 /**
  * Deprecated key for share providers in bookend config.
- * @private @const {string}
+ * @protected
+ * @const {string}
  */
 export const DEPRECATED_SHARE_PROVIDERS_KEY = 'share-providers';
 

--- a/extensions/amp-story/0.1/amp-story-store-service.js
+++ b/extensions/amp-story/0.1/amp-story-store-service.js
@@ -47,7 +47,6 @@ export let State;
 
 /**
  * @protected
- * @const
  * @enum {string}
  **/
 export const StateProperty = {
@@ -78,7 +77,6 @@ export const StateProperty = {
 
 /**
  * @protected
- * @const
  * @enum {string}
  **/
 export const Action = {

--- a/extensions/amp-story/0.1/amp-story-store-service.js
+++ b/extensions/amp-story/0.1/amp-story-store-service.js
@@ -45,10 +45,7 @@ const TAG = 'amp-story';
  */
 export let State;
 
-/**
- * @protected
- * @enum {string}
- **/
+/** @protected @enum {string} */
 export const StateProperty = {
   // Embed options.
   CAN_INSERT_AUTOMATIC_AD: 'caninsertautomaticad',
@@ -75,10 +72,7 @@ export const StateProperty = {
   CURRENT_PAGE_INDEX: 'currentpageindex',
 };
 
-/**
- * @protected
- * @enum {string}
- **/
+/** @protected @enum {string} */
 export const Action = {
   CHANGE_PAGE: 'changepage',
   SET_CONSENT_ID: 'setconsentid',

--- a/extensions/amp-story/0.1/amp-story-store-service.js
+++ b/extensions/amp-story/0.1/amp-story-store-service.js
@@ -45,7 +45,7 @@ const TAG = 'amp-story';
  */
 export let State;
 
-/** @protected @enum {string} */
+/** @protected @const @enum {string} */
 export const StateProperty = {
   // Embed options.
   CAN_INSERT_AUTOMATIC_AD: 'caninsertautomaticad',
@@ -72,7 +72,7 @@ export const StateProperty = {
   CURRENT_PAGE_INDEX: 'currentpageindex',
 };
 
-/** @protected @enum {string} */
+/** @protected @const @enum {string} */
 export const Action = {
   CHANGE_PAGE: 'changepage',
   SET_CONSENT_ID: 'setconsentid',

--- a/extensions/amp-story/0.1/amp-story-store-service.js
+++ b/extensions/amp-story/0.1/amp-story-store-service.js
@@ -45,7 +45,11 @@ const TAG = 'amp-story';
  */
 export let State;
 
-/** @private @const @enum {string} */
+/**
+ * @protected
+ * @const
+ * @enum {string}
+ **/
 export const StateProperty = {
   // Embed options.
   CAN_INSERT_AUTOMATIC_AD: 'caninsertautomaticad',
@@ -72,7 +76,11 @@ export const StateProperty = {
   CURRENT_PAGE_INDEX: 'currentpageindex',
 };
 
-/** @private @const @enum {string} */
+/**
+ * @protected
+ * @const
+ * @enum {string}
+ **/
 export const Action = {
   CHANGE_PAGE: 'changepage',
   SET_CONSENT_ID: 'setconsentid',

--- a/extensions/amp-story/0.1/amp-story-store-service.js
+++ b/extensions/amp-story/0.1/amp-story-store-service.js
@@ -45,7 +45,7 @@ const TAG = 'amp-story';
  */
 export let State;
 
-/** @protected @const @enum {string} */
+/** @package @const @enum {string} */
 export const StateProperty = {
   // Embed options.
   CAN_INSERT_AUTOMATIC_AD: 'caninsertautomaticad',
@@ -72,7 +72,7 @@ export const StateProperty = {
   CURRENT_PAGE_INDEX: 'currentpageindex',
 };
 
-/** @protected @const @enum {string} */
+/** @package @const @enum {string} */
 export const Action = {
   CHANGE_PAGE: 'changepage',
   SET_CONSENT_ID: 'setconsentid',

--- a/extensions/amp-story/0.1/embed-mode.js
+++ b/extensions/amp-story/0.1/embed-mode.js
@@ -61,7 +61,7 @@ export const EmbedModeParam = 'embedMode';
 /**
  * @param {string} str
  * @return {!EmbedMode}
- * @private
+ * @protected
  */
 export function parseEmbedMode(str) {
   const params = parseQueryString(str);

--- a/extensions/amp-story/0.1/embed-mode.js
+++ b/extensions/amp-story/0.1/embed-mode.js
@@ -61,7 +61,7 @@ export const EmbedModeParam = 'embedMode';
 /**
  * @param {string} str
  * @return {!EmbedMode}
- * @protected
+ * @package
  */
 export function parseEmbedMode(str) {
   const params = parseQueryString(str);

--- a/extensions/amp-story/1.0/amp-story-draggable-drawer.js
+++ b/extensions/amp-story/1.0/amp-story-draggable-drawer.js
@@ -79,13 +79,13 @@ export class DraggableDrawer extends AMP.BaseElement {
     /** @private {!Array<!Element>} AMP components within the drawer. */
     this.ampComponents_ = [];
 
-    /** @private {?Element} */
+    /** @protected {?Element} */
     this.containerEl_ = null;
 
     /** @protected {?Element} */
     this.contentEl_ = null;
 
-    /** @private {?Element} */
+    /** @protected {?Element} */
     this.headerEl_ = null;
 
     /** @protected {!DrawerState} */
@@ -482,7 +482,7 @@ export class DraggableDrawer extends AMP.BaseElement {
 
   /**
    * Fully closes the drawer from its current position.
-   * @private
+   * @protected
    */
   closeInternal_() {
     if (this.state_ === DrawerState.CLOSED) {

--- a/extensions/amp-story/1.0/amp-story-embedded-component.js
+++ b/extensions/amp-story/1.0/amp-story-embedded-component.js
@@ -67,7 +67,7 @@ const MAX_TWEET_WIDTH_PX = 500;
 /**
  * Components that can be expanded.
  * @const {!Object}
- * @private
+ * @protected
  */
 export const EXPANDABLE_COMPONENTS = {
   'amp-twitter': {

--- a/extensions/amp-story/1.0/amp-story-embedded-component.js
+++ b/extensions/amp-story/1.0/amp-story-embedded-component.js
@@ -67,7 +67,7 @@ const MAX_TWEET_WIDTH_PX = 500;
 /**
  * Components that can be expanded.
  * @const {!Object}
- * @protected
+ * @package
  */
 export const EXPANDABLE_COMPONENTS = {
   'amp-twitter': {

--- a/extensions/amp-story/1.0/amp-story-share.js
+++ b/extensions/amp-story/1.0/amp-story-share.js
@@ -63,13 +63,15 @@ const MIN_BUTTON_PADDING = 10;
 
 /**
  * Key for share providers in bookend config.
- * @private @const {string}
+ * @protected
+ * @const {string}
  */
 export const SHARE_PROVIDERS_KEY = 'shareProviders';
 
 /**
  * Deprecated key for share providers in bookend config.
- * @private @const {string}
+ * @protected
+ * @const {string}
  */
 export const DEPRECATED_SHARE_PROVIDERS_KEY = 'share-providers';
 

--- a/extensions/amp-story/1.0/amp-story-share.js
+++ b/extensions/amp-story/1.0/amp-story-share.js
@@ -63,15 +63,13 @@ const MIN_BUTTON_PADDING = 10;
 
 /**
  * Key for share providers in bookend config.
- * @protected
- * @const {string}
+ * @protected @const {string}
  */
 export const SHARE_PROVIDERS_KEY = 'shareProviders';
 
 /**
  * Deprecated key for share providers in bookend config.
- * @protected
- * @const {string}
+ * @protected @const {string}
  */
 export const DEPRECATED_SHARE_PROVIDERS_KEY = 'share-providers';
 

--- a/extensions/amp-story/1.0/amp-story-share.js
+++ b/extensions/amp-story/1.0/amp-story-share.js
@@ -63,13 +63,13 @@ const MIN_BUTTON_PADDING = 10;
 
 /**
  * Key for share providers in bookend config.
- * @protected @const {string}
+ * @const {string}
  */
 export const SHARE_PROVIDERS_KEY = 'shareProviders';
 
 /**
  * Deprecated key for share providers in bookend config.
- * @protected @const {string}
+ * @const {string}
  */
 export const DEPRECATED_SHARE_PROVIDERS_KEY = 'share-providers';
 

--- a/extensions/amp-story/1.0/amp-story-store-service.js
+++ b/extensions/amp-story/1.0/amp-story-store-service.js
@@ -111,7 +111,11 @@ export let InteractiveComponentDef;
  */
 export let State;
 
-/** @private @const @enum {string} */
+/**
+ * @protected
+ * @const
+ * @enum {string}
+ **/
 export const StateProperty = {
   // Embed options.
   CAN_INSERT_AUTOMATIC_AD: 'canInsertAutomaticAd',
@@ -156,7 +160,11 @@ export const StateProperty = {
   PAGE_IDS: 'pageIds',
 };
 
-/** @private @const @enum {string} */
+/**
+ * @protected
+ * @const
+ * @enum {string}
+ **/
 export const Action = {
   ADD_TO_ACTIONS_WHITELIST: 'addToActionsWhitelist',
   CHANGE_PAGE: 'setCurrentPageId',
@@ -531,7 +539,7 @@ export class AmpStoryStoreService {
   /**
    * Retrieves the embed mode config, that will override the default state.
    * @return {!Object<StateProperty, *>} Partial state
-   * @private
+   * @protected
    */
   getEmbedOverrides_() {
     const embedMode = parseEmbedMode(this.win_.location.hash);

--- a/extensions/amp-story/1.0/amp-story-store-service.js
+++ b/extensions/amp-story/1.0/amp-story-store-service.js
@@ -111,7 +111,7 @@ export let InteractiveComponentDef;
  */
 export let State;
 
-/** @protected @const @enum {string} */
+/** @const @enum {string} */
 export const StateProperty = {
   // Embed options.
   CAN_INSERT_AUTOMATIC_AD: 'canInsertAutomaticAd',
@@ -156,7 +156,7 @@ export const StateProperty = {
   PAGE_IDS: 'pageIds',
 };
 
-/** @protected @const @enum {string} */
+/** @const @enum {string} */
 export const Action = {
   ADD_TO_ACTIONS_WHITELIST: 'addToActionsWhitelist',
   CHANGE_PAGE: 'setCurrentPageId',

--- a/extensions/amp-story/1.0/amp-story-store-service.js
+++ b/extensions/amp-story/1.0/amp-story-store-service.js
@@ -111,11 +111,7 @@ export let InteractiveComponentDef;
  */
 export let State;
 
-/**
- * @protected
- * @const
- * @enum {string}
- **/
+/** @protected @const @enum {string} */
 export const StateProperty = {
   // Embed options.
   CAN_INSERT_AUTOMATIC_AD: 'canInsertAutomaticAd',
@@ -160,11 +156,7 @@ export const StateProperty = {
   PAGE_IDS: 'pageIds',
 };
 
-/**
- * @protected
- * @const
- * @enum {string}
- **/
+/** @protected @const @enum {string} */
 export const Action = {
   ADD_TO_ACTIONS_WHITELIST: 'addToActionsWhitelist',
   CHANGE_PAGE: 'setCurrentPageId',

--- a/extensions/amp-story/1.0/embed-mode.js
+++ b/extensions/amp-story/1.0/embed-mode.js
@@ -61,7 +61,7 @@ export const EmbedModeParam = 'embedMode';
 /**
  * @param {string} str
  * @return {!EmbedMode}
- * @private
+ * @protected
  */
 export function parseEmbedMode(str) {
   const params = parseQueryString(str);

--- a/extensions/amp-story/1.0/embed-mode.js
+++ b/extensions/amp-story/1.0/embed-mode.js
@@ -61,7 +61,7 @@ export const EmbedModeParam = 'embedMode';
 /**
  * @param {string} str
  * @return {!EmbedMode}
- * @protected
+ * @package
  */
 export function parseEmbedMode(str) {
   const params = parseQueryString(str);

--- a/extensions/amp-story/1.0/story-analytics.js
+++ b/extensions/amp-story/1.0/story-analytics.js
@@ -21,7 +21,10 @@ import {map} from '../../../src/utils/object';
 import {registerServiceBuilder} from '../../../src/service';
 import {triggerAnalyticsEvent} from '../../../src/analytics';
 
-/** @private @const {string} */
+/**
+ * @protected
+ * @const {string}
+ **/
 export const ANALYTICS_TAG_NAME = '__AMP_ANALYTICS_TAG_NAME__';
 
 /** @enum {string} */

--- a/extensions/amp-story/1.0/story-analytics.js
+++ b/extensions/amp-story/1.0/story-analytics.js
@@ -21,7 +21,7 @@ import {map} from '../../../src/utils/object';
 import {registerServiceBuilder} from '../../../src/service';
 import {triggerAnalyticsEvent} from '../../../src/analytics';
 
-/** @protected @const {string} */
+/** @package @const {string} */
 export const ANALYTICS_TAG_NAME = '__AMP_ANALYTICS_TAG_NAME__';
 
 /** @enum {string} */

--- a/extensions/amp-story/1.0/story-analytics.js
+++ b/extensions/amp-story/1.0/story-analytics.js
@@ -21,10 +21,7 @@ import {map} from '../../../src/utils/object';
 import {registerServiceBuilder} from '../../../src/service';
 import {triggerAnalyticsEvent} from '../../../src/analytics';
 
-/**
- * @protected
- * @const {string}
- **/
+/** @protected @const {string} */
 export const ANALYTICS_TAG_NAME = '__AMP_ANALYTICS_TAG_NAME__';
 
 /** @enum {string} */

--- a/extensions/amp-video-docking/0.1/events.js
+++ b/extensions/amp-video-docking/0.1/events.js
@@ -25,7 +25,7 @@ export const VideoDockingEvents = {
 /**
  * @param {!MouseEvent|!TouchEvent} e
  * @return {{x: number, y: number}}
- * @private
+ * @protected
  */
 export function pointerCoords(e) {
   const coords = e.touches ? e.touches[0] : e;

--- a/extensions/amp-video-docking/0.1/events.js
+++ b/extensions/amp-video-docking/0.1/events.js
@@ -25,7 +25,7 @@ export const VideoDockingEvents = {
 /**
  * @param {!MouseEvent|!TouchEvent} e
  * @return {{x: number, y: number}}
- * @protected
+ * @package
  */
 export function pointerCoords(e) {
   const coords = e.touches ? e.touches[0] : e;

--- a/src/iframe-helper.js
+++ b/src/iframe-helper.js
@@ -565,7 +565,6 @@ export function isAdLike(element) {
 /**
  * @param {!Element} iframe
  * @return {!Element}
- * @protected
  */
 export function disableScrollingOnIframe(iframe) {
   addAttributesToElement(iframe, dict({'scrolling': 'no'}));
@@ -583,7 +582,6 @@ export function disableScrollingOnIframe(iframe) {
  * from the perspective of the current window.
  * @param {!Window} win
  * @return {boolean}
- * @protected
  */
 export function canInspectWindow(win) {
   // TODO: this is not reliable.  The compiler assumes that property reads are

--- a/src/iframe-helper.js
+++ b/src/iframe-helper.js
@@ -565,7 +565,7 @@ export function isAdLike(element) {
 /**
  * @param {!Element} iframe
  * @return {!Element}
- * @private
+ * @protected
  */
 export function disableScrollingOnIframe(iframe) {
   addAttributesToElement(iframe, dict({'scrolling': 'no'}));
@@ -583,7 +583,7 @@ export function disableScrollingOnIframe(iframe) {
  * from the perspective of the current window.
  * @param {!Window} win
  * @return {boolean}
- * @private
+ * @protected
  */
 export function canInspectWindow(win) {
   // TODO: this is not reliable.  The compiler assumes that property reads are

--- a/src/log.js
+++ b/src/log.js
@@ -67,7 +67,6 @@ export function isUserErrorEmbed(message) {
 
 /**
  * @enum {number}
- * @protected
  */
 export const LogLevel = {
   OFF: 0,

--- a/src/log.js
+++ b/src/log.js
@@ -67,7 +67,7 @@ export function isUserErrorEmbed(message) {
 
 /**
  * @enum {number}
- * @private Visible for testing only.
+ * @protected
  */
 export const LogLevel = {
   OFF: 0,

--- a/src/service/origin-experiments-impl.js
+++ b/src/service/origin-experiments-impl.js
@@ -114,7 +114,7 @@ export class OriginExperiments {
 
 /**
  * Handles key generation and token signing/verifying.
- * @protected
+ * @package
  */
 export class TokenMaster {
   /**

--- a/src/service/owners-interface.js
+++ b/src/service/owners-interface.js
@@ -24,7 +24,6 @@ export class OwnersInterface {
    * within this element will be managed by the owner and not Resources manager.
    * @param {!Element} element
    * @param {!AmpElement} owner
-   * @public
    */
   setOwner(element, owner) {}
 

--- a/src/service/owners-interface.js
+++ b/src/service/owners-interface.js
@@ -24,7 +24,7 @@ export class OwnersInterface {
    * within this element will be managed by the owner and not Resources manager.
    * @param {!Element} element
    * @param {!AmpElement} owner
-   * @package
+   * @public
    */
   setOwner(element, owner) {}
 

--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -81,7 +81,7 @@ let ViewportRatioDef;
 
 /**
  * A Resource binding for an AmpElement.
- * @package
+ * @protected
  */
 export class Resource {
   /**
@@ -821,7 +821,7 @@ export class Resource {
    * once layout is complete. Only allowed to be called on a upgraded, built
    * and displayed element.
    * @return {!Promise}
-   * @package
+   * @public
    */
   startLayout() {
     if (this.layoutPromise_) {

--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -81,7 +81,6 @@ let ViewportRatioDef;
 
 /**
  * A Resource binding for an AmpElement.
- * @protected
  */
 export class Resource {
   /**
@@ -821,7 +820,6 @@ export class Resource {
    * once layout is complete. Only allowed to be called on a upgraded, built
    * and displayed element.
    * @return {!Promise}
-   * @public
    */
   startLayout() {
     if (this.layoutPromise_) {

--- a/src/service/variable-source.js
+++ b/src/service/variable-source.js
@@ -154,7 +154,7 @@ export function getTimingDataSync(win, startEvent, endEvent) {
  * @param {!Window} win
  * @param {string} attribute
  * @return {ResolverReturnDef}
- * @private
+ * @protected
  */
 export function getNavigationData(win, attribute) {
   const navigationInfo = win['performance'] && win['performance']['navigation'];

--- a/src/service/variable-source.js
+++ b/src/service/variable-source.js
@@ -154,7 +154,6 @@ export function getTimingDataSync(win, startEvent, endEvent) {
  * @param {!Window} win
  * @param {string} attribute
  * @return {ResolverReturnDef}
- * @protected
  */
 export function getNavigationData(win, attribute) {
   const navigationInfo = win['performance'] && win['performance']['navigation'];

--- a/src/url-rewrite.js
+++ b/src/url-rewrite.js
@@ -88,7 +88,6 @@ export function rewriteAttributesForElement(
  * @param {string} attrName Lowercase attribute name.
  * @param {string} attrValue
  * @return {string}
- * @protected
  * @visibleForTesting
  */
 export function rewriteAttributeValue(tagName, attrName, attrValue) {

--- a/src/url-rewrite.js
+++ b/src/url-rewrite.js
@@ -88,7 +88,7 @@ export function rewriteAttributesForElement(
  * @param {string} attrName Lowercase attribute name.
  * @param {string} attrValue
  * @return {string}
- * @private
+ * @protected
  * @visibleForTesting
  */
 export function rewriteAttributeValue(tagName, attrName, attrValue) {

--- a/src/utils/xhr-utils.js
+++ b/src/utils/xhr-utils.js
@@ -77,7 +77,6 @@ const allowedJsonBodyTypes_ = [isArray, isObject];
  *     cloneable.
  * @return {{input: string, init: !FetchInitDef}} The serialized structurally-
  *     cloneable request.
- * @protected
  */
 export function toStructuredCloneable(input, init) {
   const newInit = {...init};
@@ -193,7 +192,6 @@ export function fromStructuredCloneable(response, responseType) {
  * @return {!Promise<!Response|undefined>}
  *     A response returned by the interceptor if XHR is intercepted or
  *     `Promise<undefined>` otherwise.
- * @protected
  */
 export function getViewerInterceptResponse(win, ampdocSingle, input, init) {
   if (!ampdocSingle) {
@@ -373,7 +371,6 @@ function isRetriable(status) {
  * Returns the response if successful or otherwise throws an error.
  * @param {!Response} response
  * @return {!Promise<!Response>}
- * @protected
  */
 export function assertSuccess(response) {
   return new Promise(resolve => {

--- a/src/utils/xhr-utils.js
+++ b/src/utils/xhr-utils.js
@@ -77,7 +77,7 @@ const allowedJsonBodyTypes_ = [isArray, isObject];
  *     cloneable.
  * @return {{input: string, init: !FetchInitDef}} The serialized structurally-
  *     cloneable request.
- * @private
+ * @protected
  */
 export function toStructuredCloneable(input, init) {
   const newInit = {...init};
@@ -193,7 +193,7 @@ export function fromStructuredCloneable(response, responseType) {
  * @return {!Promise<!Response|undefined>}
  *     A response returned by the interceptor if XHR is intercepted or
  *     `Promise<undefined>` otherwise.
- * @private
+ * @protected
  */
 export function getViewerInterceptResponse(win, ampdocSingle, input, init) {
   if (!ampdocSingle) {
@@ -373,7 +373,7 @@ function isRetriable(status) {
  * Returns the response if successful or otherwise throws an error.
  * @param {!Response} response
  * @return {!Promise<!Response>}
- * @private Visible for testing
+ * @protected
  */
 export function assertSuccess(response) {
   return new Promise(resolve => {

--- a/third_party/react-externs/externs.js
+++ b/third_party/react-externs/externs.js
@@ -150,13 +150,13 @@ React.Component.prototype.context;
 
 /**
  * @type {Object}
- * @package
+ * @protected
  */
 React.Component.prototype.propTypes;
 
 /**
  * @type {Object}
- * @package
+ * @protected
  */
 React.Component.prototype.contextTypes;
 
@@ -226,19 +226,19 @@ React.Component.prototype.setState = function(nextState, callback) {};
 React.Component.prototype.replaceState = function(nextState, callback) {};
 
 /**
- * @package
+ * @protected
  */
 React.Component.prototype.componentWillMount = function() {};
 
 /**
  * @param {Element} element
- * @package
+ * @protected
  */
 React.Component.prototype.componentDidMount = function(element) {};
 
 /**
  * @param {Object} nextProps
- * @package
+ * @protected
  */
 React.Component.prototype.componentWillReceiveProps = function(
   nextProps) {};
@@ -247,7 +247,7 @@ React.Component.prototype.componentWillReceiveProps = function(
  * @param {Object} nextProps
  * @param {Object} nextState
  * @return {boolean}
- * @package
+ * @protected
  */
 React.Component.prototype.shouldComponentUpdate = function(
   nextProps, nextState) {};
@@ -255,7 +255,7 @@ React.Component.prototype.shouldComponentUpdate = function(
 /**
  * @param {Object} nextProps
  * @param {Object} nextState
- * @package
+ * @protected
  */
 React.Component.prototype.componentWillUpdate = function(
   nextProps, nextState) {};
@@ -264,19 +264,19 @@ React.Component.prototype.componentWillUpdate = function(
  * @param {Object} prevProps
  * @param {Object} prevState
  * @param {Element} rootNode
- * @package
+ * @protected
  */
 React.Component.prototype.componentDidUpdate = function(
   prevProps, prevState, rootNode) {};
 
 /**
- * @package
+ * @protected
  */
 React.Component.prototype.componentWillUnmount = function() {};
 
 /**
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.Component.prototype.render = function() {};
 
@@ -524,7 +524,7 @@ React.ChildrenArgument;
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.a = function(props, children) {};
 
@@ -532,7 +532,7 @@ React.DOM.a = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.abbr = function(props, children) {};
 
@@ -540,7 +540,7 @@ React.DOM.abbr = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.address = function(props, children) {};
 
@@ -548,7 +548,7 @@ React.DOM.address = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.area = function(props, children) {};
 
@@ -556,7 +556,7 @@ React.DOM.area = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.article = function(props, children) {};
 
@@ -564,7 +564,7 @@ React.DOM.article = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.aside = function(props, children) {};
 
@@ -572,7 +572,7 @@ React.DOM.aside = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.audio = function(props, children) {};
 
@@ -580,7 +580,7 @@ React.DOM.audio = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.b = function(props, children) {};
 
@@ -588,7 +588,7 @@ React.DOM.b = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.base = function(props, children) {};
 
@@ -596,7 +596,7 @@ React.DOM.base = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.bdi = function(props, children) {};
 
@@ -604,7 +604,7 @@ React.DOM.bdi = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.bdo = function(props, children) {};
 
@@ -612,7 +612,7 @@ React.DOM.bdo = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.big = function(props, children) {};
 
@@ -620,7 +620,7 @@ React.DOM.big = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.blockquote = function(props, children) {};
 
@@ -628,7 +628,7 @@ React.DOM.blockquote = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.body = function(props, children) {};
 
@@ -636,7 +636,7 @@ React.DOM.body = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.br = function(props, children) {};
 
@@ -644,7 +644,7 @@ React.DOM.br = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.button = function(props, children) {};
 
@@ -652,7 +652,7 @@ React.DOM.button = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.canvas = function(props, children) {};
 
@@ -660,7 +660,7 @@ React.DOM.canvas = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.caption = function(props, children) {};
 
@@ -668,7 +668,7 @@ React.DOM.caption = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.circle = function(props, children) {};
 
@@ -676,7 +676,7 @@ React.DOM.circle = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.cite = function(props, children) {};
 
@@ -684,7 +684,7 @@ React.DOM.cite = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.code = function(props, children) {};
 
@@ -692,7 +692,7 @@ React.DOM.code = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.col = function(props, children) {};
 
@@ -700,7 +700,7 @@ React.DOM.col = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.colgroup = function(props, children) {};
 
@@ -708,7 +708,7 @@ React.DOM.colgroup = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.data = function(props, children) {};
 
@@ -716,7 +716,7 @@ React.DOM.data = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.datalist = function(props, children) {};
 
@@ -724,7 +724,7 @@ React.DOM.datalist = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.dd = function(props, children) {};
 
@@ -732,7 +732,7 @@ React.DOM.dd = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.defs = function(props, children) {};
 
@@ -740,7 +740,7 @@ React.DOM.defs = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.del = function(props, children) {};
 
@@ -748,7 +748,7 @@ React.DOM.del = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.details = function(props, children) {};
 
@@ -756,7 +756,7 @@ React.DOM.details = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.dfn = function(props, children) {};
 
@@ -764,7 +764,7 @@ React.DOM.dfn = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.div = function(props, children) {};
 
@@ -772,7 +772,7 @@ React.DOM.div = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.dl = function(props, children) {};
 
@@ -780,7 +780,7 @@ React.DOM.dl = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.dt = function(props, children) {};
 
@@ -788,7 +788,7 @@ React.DOM.dt = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.ellipse = function(props, children) {};
 
@@ -796,7 +796,7 @@ React.DOM.ellipse = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.em = function(props, children) {};
 
@@ -804,7 +804,7 @@ React.DOM.em = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.embed = function(props, children) {};
 
@@ -812,7 +812,7 @@ React.DOM.embed = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.fieldset = function(props, children) {};
 
@@ -820,7 +820,7 @@ React.DOM.fieldset = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.figcaption = function(props, children) {};
 
@@ -828,7 +828,7 @@ React.DOM.figcaption = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.figure = function(props, children) {};
 
@@ -836,7 +836,7 @@ React.DOM.figure = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.footer = function(props, children) {};
 
@@ -844,7 +844,7 @@ React.DOM.footer = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.form = function(props, children) {};
 
@@ -852,7 +852,7 @@ React.DOM.form = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.g = function(props, children) {};
 
@@ -860,7 +860,7 @@ React.DOM.g = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.h1 = function(props, children) {};
 
@@ -868,7 +868,7 @@ React.DOM.h1 = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.h2 = function(props, children) {};
 
@@ -876,7 +876,7 @@ React.DOM.h2 = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.h3 = function(props, children) {};
 
@@ -884,7 +884,7 @@ React.DOM.h3 = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.h4 = function(props, children) {};
 
@@ -892,7 +892,7 @@ React.DOM.h4 = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.h5 = function(props, children) {};
 
@@ -900,7 +900,7 @@ React.DOM.h5 = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.h6 = function(props, children) {};
 
@@ -908,7 +908,7 @@ React.DOM.h6 = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.head = function(props, children) {};
 
@@ -916,7 +916,7 @@ React.DOM.head = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.header = function(props, children) {};
 
@@ -924,7 +924,7 @@ React.DOM.header = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.hr = function(props, children) {};
 
@@ -932,7 +932,7 @@ React.DOM.hr = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.html = function(props, children) {};
 
@@ -940,7 +940,7 @@ React.DOM.html = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.i = function(props, children) {};
 
@@ -948,7 +948,7 @@ React.DOM.i = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.iframe = function(props, children) {};
 
@@ -956,7 +956,7 @@ React.DOM.iframe = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.img = function(props, children) {};
 
@@ -964,7 +964,7 @@ React.DOM.img = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.input = function(props, children) {};
 
@@ -972,7 +972,7 @@ React.DOM.input = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.ins = function(props, children) {};
 
@@ -980,7 +980,7 @@ React.DOM.ins = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.kbd = function(props, children) {};
 
@@ -988,7 +988,7 @@ React.DOM.kbd = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.keygen = function(props, children) {};
 
@@ -996,7 +996,7 @@ React.DOM.keygen = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.label = function(props, children) {};
 
@@ -1004,7 +1004,7 @@ React.DOM.label = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.legend = function(props, children) {};
 
@@ -1012,7 +1012,7 @@ React.DOM.legend = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.li = function(props, children) {};
 
@@ -1020,7 +1020,7 @@ React.DOM.li = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.line = function(props, children) {};
 
@@ -1028,7 +1028,7 @@ React.DOM.line = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.linearGradient = function(props, children) {};
 
@@ -1036,7 +1036,7 @@ React.DOM.linearGradient = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.link = function(props, children) {};
 
@@ -1044,7 +1044,7 @@ React.DOM.link = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.main = function(props, children) {};
 
@@ -1052,7 +1052,7 @@ React.DOM.main = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.map = function(props, children) {};
 
@@ -1060,7 +1060,7 @@ React.DOM.map = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.mark = function(props, children) {};
 
@@ -1068,7 +1068,7 @@ React.DOM.mark = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.mask = function(props, children) {};
 
@@ -1076,7 +1076,7 @@ React.DOM.mask = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.menu = function(props, children) {};
 
@@ -1084,7 +1084,7 @@ React.DOM.menu = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.menuitem = function(props, children) {};
 
@@ -1092,7 +1092,7 @@ React.DOM.menuitem = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.meta = function(props, children) {};
 
@@ -1100,7 +1100,7 @@ React.DOM.meta = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.meter = function(props, children) {};
 
@@ -1108,7 +1108,7 @@ React.DOM.meter = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.nav = function(props, children) {};
 
@@ -1116,7 +1116,7 @@ React.DOM.nav = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.noscript = function(props, children) {};
 
@@ -1124,7 +1124,7 @@ React.DOM.noscript = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.object = function(props, children) {};
 
@@ -1132,7 +1132,7 @@ React.DOM.object = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.ol = function(props, children) {};
 
@@ -1140,7 +1140,7 @@ React.DOM.ol = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.optgroup = function(props, children) {};
 
@@ -1148,7 +1148,7 @@ React.DOM.optgroup = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.option = function(props, children) {};
 
@@ -1156,7 +1156,7 @@ React.DOM.option = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.output = function(props, children) {};
 
@@ -1164,7 +1164,7 @@ React.DOM.output = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.p = function(props, children) {};
 
@@ -1172,7 +1172,7 @@ React.DOM.p = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.param = function(props, children) {};
 
@@ -1180,7 +1180,7 @@ React.DOM.param = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.path = function(props, children) {};
 
@@ -1188,7 +1188,7 @@ React.DOM.path = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.pattern = function(props, children) {};
 
@@ -1196,7 +1196,7 @@ React.DOM.pattern = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.polygon = function(props, children) {};
 
@@ -1204,7 +1204,7 @@ React.DOM.polygon = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.polyline = function(props, children) {};
 
@@ -1212,7 +1212,7 @@ React.DOM.polyline = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.pre = function(props, children) {};
 
@@ -1220,7 +1220,7 @@ React.DOM.pre = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.progress = function(props, children) {};
 
@@ -1228,7 +1228,7 @@ React.DOM.progress = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.q = function(props, children) {};
 
@@ -1236,7 +1236,7 @@ React.DOM.q = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.radialGradient = function(props, children) {};
 
@@ -1244,7 +1244,7 @@ React.DOM.radialGradient = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.rect = function(props, children) {};
 
@@ -1252,7 +1252,7 @@ React.DOM.rect = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.rp = function(props, children) {};
 
@@ -1260,7 +1260,7 @@ React.DOM.rp = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.rt = function(props, children) {};
 
@@ -1268,7 +1268,7 @@ React.DOM.rt = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.ruby = function(props, children) {};
 
@@ -1276,7 +1276,7 @@ React.DOM.ruby = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.s = function(props, children) {};
 
@@ -1284,7 +1284,7 @@ React.DOM.s = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.samp = function(props, children) {};
 
@@ -1292,7 +1292,7 @@ React.DOM.samp = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.script = function(props, children) {};
 
@@ -1300,7 +1300,7 @@ React.DOM.script = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.section = function(props, children) {};
 
@@ -1308,7 +1308,7 @@ React.DOM.section = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.select = function(props, children) {};
 
@@ -1316,7 +1316,7 @@ React.DOM.select = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.small = function(props, children) {};
 
@@ -1324,7 +1324,7 @@ React.DOM.small = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.source = function(props, children) {};
 
@@ -1332,7 +1332,7 @@ React.DOM.source = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.span = function(props, children) {};
 
@@ -1340,7 +1340,7 @@ React.DOM.span = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.stop = function(props, children) {};
 
@@ -1348,7 +1348,7 @@ React.DOM.stop = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.strong = function(props, children) {};
 
@@ -1356,7 +1356,7 @@ React.DOM.strong = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.style = function(props, children) {};
 
@@ -1364,7 +1364,7 @@ React.DOM.style = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.sub = function(props, children) {};
 
@@ -1372,7 +1372,7 @@ React.DOM.sub = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.svg = function(props, children) {};
 
@@ -1380,7 +1380,7 @@ React.DOM.svg = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.table = function(props, children) {};
 
@@ -1388,7 +1388,7 @@ React.DOM.table = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.tbody = function(props, children) {};
 
@@ -1396,7 +1396,7 @@ React.DOM.tbody = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.td = function(props, children) {};
 
@@ -1404,7 +1404,7 @@ React.DOM.td = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.text = function(props, children) {};
 
@@ -1412,7 +1412,7 @@ React.DOM.text = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.textarea = function(props, children) {};
 
@@ -1420,7 +1420,7 @@ React.DOM.textarea = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.tfoot = function(props, children) {};
 
@@ -1428,7 +1428,7 @@ React.DOM.tfoot = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.th = function(props, children) {};
 
@@ -1436,7 +1436,7 @@ React.DOM.th = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.thead = function(props, children) {};
 
@@ -1444,7 +1444,7 @@ React.DOM.thead = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.time = function(props, children) {};
 
@@ -1452,7 +1452,7 @@ React.DOM.time = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.title = function(props, children) {};
 
@@ -1460,7 +1460,7 @@ React.DOM.title = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.tr = function(props, children) {};
 
@@ -1468,7 +1468,7 @@ React.DOM.tr = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.track = function(props, children) {};
 
@@ -1476,7 +1476,7 @@ React.DOM.track = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.tspan = function(props, children) {};
 
@@ -1484,7 +1484,7 @@ React.DOM.tspan = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.u = function(props, children) {};
 
@@ -1492,7 +1492,7 @@ React.DOM.u = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.ul = function(props, children) {};
 
@@ -1500,7 +1500,7 @@ React.DOM.ul = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.var = function(props, children) {};
 
@@ -1508,7 +1508,7 @@ React.DOM.var = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.video = function(props, children) {};
 
@@ -1516,7 +1516,7 @@ React.DOM.video = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @package
+ * @protected
  */
 React.DOM.wbr = function(props, children) {};
 

--- a/third_party/react-externs/externs.js
+++ b/third_party/react-externs/externs.js
@@ -150,13 +150,13 @@ React.Component.prototype.context;
 
 /**
  * @type {Object}
- * @protected
+ * @package
  */
 React.Component.prototype.propTypes;
 
 /**
  * @type {Object}
- * @protected
+ * @package
  */
 React.Component.prototype.contextTypes;
 
@@ -226,19 +226,19 @@ React.Component.prototype.setState = function(nextState, callback) {};
 React.Component.prototype.replaceState = function(nextState, callback) {};
 
 /**
- * @protected
+ * @package
  */
 React.Component.prototype.componentWillMount = function() {};
 
 /**
  * @param {Element} element
- * @protected
+ * @package
  */
 React.Component.prototype.componentDidMount = function(element) {};
 
 /**
  * @param {Object} nextProps
- * @protected
+ * @package
  */
 React.Component.prototype.componentWillReceiveProps = function(
   nextProps) {};
@@ -247,7 +247,7 @@ React.Component.prototype.componentWillReceiveProps = function(
  * @param {Object} nextProps
  * @param {Object} nextState
  * @return {boolean}
- * @protected
+ * @package
  */
 React.Component.prototype.shouldComponentUpdate = function(
   nextProps, nextState) {};
@@ -255,7 +255,7 @@ React.Component.prototype.shouldComponentUpdate = function(
 /**
  * @param {Object} nextProps
  * @param {Object} nextState
- * @protected
+ * @package
  */
 React.Component.prototype.componentWillUpdate = function(
   nextProps, nextState) {};
@@ -264,19 +264,19 @@ React.Component.prototype.componentWillUpdate = function(
  * @param {Object} prevProps
  * @param {Object} prevState
  * @param {Element} rootNode
- * @protected
+ * @package
  */
 React.Component.prototype.componentDidUpdate = function(
   prevProps, prevState, rootNode) {};
 
 /**
- * @protected
+ * @package
  */
 React.Component.prototype.componentWillUnmount = function() {};
 
 /**
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.Component.prototype.render = function() {};
 
@@ -524,7 +524,7 @@ React.ChildrenArgument;
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.a = function(props, children) {};
 
@@ -532,7 +532,7 @@ React.DOM.a = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.abbr = function(props, children) {};
 
@@ -540,7 +540,7 @@ React.DOM.abbr = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.address = function(props, children) {};
 
@@ -548,7 +548,7 @@ React.DOM.address = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.area = function(props, children) {};
 
@@ -556,7 +556,7 @@ React.DOM.area = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.article = function(props, children) {};
 
@@ -564,7 +564,7 @@ React.DOM.article = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.aside = function(props, children) {};
 
@@ -572,7 +572,7 @@ React.DOM.aside = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.audio = function(props, children) {};
 
@@ -580,7 +580,7 @@ React.DOM.audio = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.b = function(props, children) {};
 
@@ -588,7 +588,7 @@ React.DOM.b = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.base = function(props, children) {};
 
@@ -596,7 +596,7 @@ React.DOM.base = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.bdi = function(props, children) {};
 
@@ -604,7 +604,7 @@ React.DOM.bdi = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.bdo = function(props, children) {};
 
@@ -612,7 +612,7 @@ React.DOM.bdo = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.big = function(props, children) {};
 
@@ -620,7 +620,7 @@ React.DOM.big = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.blockquote = function(props, children) {};
 
@@ -628,7 +628,7 @@ React.DOM.blockquote = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.body = function(props, children) {};
 
@@ -636,7 +636,7 @@ React.DOM.body = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.br = function(props, children) {};
 
@@ -644,7 +644,7 @@ React.DOM.br = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.button = function(props, children) {};
 
@@ -652,7 +652,7 @@ React.DOM.button = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.canvas = function(props, children) {};
 
@@ -660,7 +660,7 @@ React.DOM.canvas = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.caption = function(props, children) {};
 
@@ -668,7 +668,7 @@ React.DOM.caption = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.circle = function(props, children) {};
 
@@ -676,7 +676,7 @@ React.DOM.circle = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.cite = function(props, children) {};
 
@@ -684,7 +684,7 @@ React.DOM.cite = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.code = function(props, children) {};
 
@@ -692,7 +692,7 @@ React.DOM.code = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.col = function(props, children) {};
 
@@ -700,7 +700,7 @@ React.DOM.col = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.colgroup = function(props, children) {};
 
@@ -708,7 +708,7 @@ React.DOM.colgroup = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.data = function(props, children) {};
 
@@ -716,7 +716,7 @@ React.DOM.data = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.datalist = function(props, children) {};
 
@@ -724,7 +724,7 @@ React.DOM.datalist = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.dd = function(props, children) {};
 
@@ -732,7 +732,7 @@ React.DOM.dd = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.defs = function(props, children) {};
 
@@ -740,7 +740,7 @@ React.DOM.defs = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.del = function(props, children) {};
 
@@ -748,7 +748,7 @@ React.DOM.del = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.details = function(props, children) {};
 
@@ -756,7 +756,7 @@ React.DOM.details = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.dfn = function(props, children) {};
 
@@ -764,7 +764,7 @@ React.DOM.dfn = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.div = function(props, children) {};
 
@@ -772,7 +772,7 @@ React.DOM.div = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.dl = function(props, children) {};
 
@@ -780,7 +780,7 @@ React.DOM.dl = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.dt = function(props, children) {};
 
@@ -788,7 +788,7 @@ React.DOM.dt = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.ellipse = function(props, children) {};
 
@@ -796,7 +796,7 @@ React.DOM.ellipse = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.em = function(props, children) {};
 
@@ -804,7 +804,7 @@ React.DOM.em = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.embed = function(props, children) {};
 
@@ -812,7 +812,7 @@ React.DOM.embed = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.fieldset = function(props, children) {};
 
@@ -820,7 +820,7 @@ React.DOM.fieldset = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.figcaption = function(props, children) {};
 
@@ -828,7 +828,7 @@ React.DOM.figcaption = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.figure = function(props, children) {};
 
@@ -836,7 +836,7 @@ React.DOM.figure = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.footer = function(props, children) {};
 
@@ -844,7 +844,7 @@ React.DOM.footer = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.form = function(props, children) {};
 
@@ -852,7 +852,7 @@ React.DOM.form = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.g = function(props, children) {};
 
@@ -860,7 +860,7 @@ React.DOM.g = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.h1 = function(props, children) {};
 
@@ -868,7 +868,7 @@ React.DOM.h1 = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.h2 = function(props, children) {};
 
@@ -876,7 +876,7 @@ React.DOM.h2 = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.h3 = function(props, children) {};
 
@@ -884,7 +884,7 @@ React.DOM.h3 = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.h4 = function(props, children) {};
 
@@ -892,7 +892,7 @@ React.DOM.h4 = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.h5 = function(props, children) {};
 
@@ -900,7 +900,7 @@ React.DOM.h5 = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.h6 = function(props, children) {};
 
@@ -908,7 +908,7 @@ React.DOM.h6 = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.head = function(props, children) {};
 
@@ -916,7 +916,7 @@ React.DOM.head = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.header = function(props, children) {};
 
@@ -924,7 +924,7 @@ React.DOM.header = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.hr = function(props, children) {};
 
@@ -932,7 +932,7 @@ React.DOM.hr = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.html = function(props, children) {};
 
@@ -940,7 +940,7 @@ React.DOM.html = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.i = function(props, children) {};
 
@@ -948,7 +948,7 @@ React.DOM.i = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.iframe = function(props, children) {};
 
@@ -956,7 +956,7 @@ React.DOM.iframe = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.img = function(props, children) {};
 
@@ -964,7 +964,7 @@ React.DOM.img = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.input = function(props, children) {};
 
@@ -972,7 +972,7 @@ React.DOM.input = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.ins = function(props, children) {};
 
@@ -980,7 +980,7 @@ React.DOM.ins = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.kbd = function(props, children) {};
 
@@ -988,7 +988,7 @@ React.DOM.kbd = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.keygen = function(props, children) {};
 
@@ -996,7 +996,7 @@ React.DOM.keygen = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.label = function(props, children) {};
 
@@ -1004,7 +1004,7 @@ React.DOM.label = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.legend = function(props, children) {};
 
@@ -1012,7 +1012,7 @@ React.DOM.legend = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.li = function(props, children) {};
 
@@ -1020,7 +1020,7 @@ React.DOM.li = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.line = function(props, children) {};
 
@@ -1028,7 +1028,7 @@ React.DOM.line = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.linearGradient = function(props, children) {};
 
@@ -1036,7 +1036,7 @@ React.DOM.linearGradient = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.link = function(props, children) {};
 
@@ -1044,7 +1044,7 @@ React.DOM.link = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.main = function(props, children) {};
 
@@ -1052,7 +1052,7 @@ React.DOM.main = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.map = function(props, children) {};
 
@@ -1060,7 +1060,7 @@ React.DOM.map = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.mark = function(props, children) {};
 
@@ -1068,7 +1068,7 @@ React.DOM.mark = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.mask = function(props, children) {};
 
@@ -1076,7 +1076,7 @@ React.DOM.mask = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.menu = function(props, children) {};
 
@@ -1084,7 +1084,7 @@ React.DOM.menu = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.menuitem = function(props, children) {};
 
@@ -1092,7 +1092,7 @@ React.DOM.menuitem = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.meta = function(props, children) {};
 
@@ -1100,7 +1100,7 @@ React.DOM.meta = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.meter = function(props, children) {};
 
@@ -1108,7 +1108,7 @@ React.DOM.meter = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.nav = function(props, children) {};
 
@@ -1116,7 +1116,7 @@ React.DOM.nav = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.noscript = function(props, children) {};
 
@@ -1124,7 +1124,7 @@ React.DOM.noscript = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.object = function(props, children) {};
 
@@ -1132,7 +1132,7 @@ React.DOM.object = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.ol = function(props, children) {};
 
@@ -1140,7 +1140,7 @@ React.DOM.ol = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.optgroup = function(props, children) {};
 
@@ -1148,7 +1148,7 @@ React.DOM.optgroup = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.option = function(props, children) {};
 
@@ -1156,7 +1156,7 @@ React.DOM.option = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.output = function(props, children) {};
 
@@ -1164,7 +1164,7 @@ React.DOM.output = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.p = function(props, children) {};
 
@@ -1172,7 +1172,7 @@ React.DOM.p = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.param = function(props, children) {};
 
@@ -1180,7 +1180,7 @@ React.DOM.param = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.path = function(props, children) {};
 
@@ -1188,7 +1188,7 @@ React.DOM.path = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.pattern = function(props, children) {};
 
@@ -1196,7 +1196,7 @@ React.DOM.pattern = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.polygon = function(props, children) {};
 
@@ -1204,7 +1204,7 @@ React.DOM.polygon = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.polyline = function(props, children) {};
 
@@ -1212,7 +1212,7 @@ React.DOM.polyline = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.pre = function(props, children) {};
 
@@ -1220,7 +1220,7 @@ React.DOM.pre = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.progress = function(props, children) {};
 
@@ -1228,7 +1228,7 @@ React.DOM.progress = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.q = function(props, children) {};
 
@@ -1236,7 +1236,7 @@ React.DOM.q = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.radialGradient = function(props, children) {};
 
@@ -1244,7 +1244,7 @@ React.DOM.radialGradient = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.rect = function(props, children) {};
 
@@ -1252,7 +1252,7 @@ React.DOM.rect = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.rp = function(props, children) {};
 
@@ -1260,7 +1260,7 @@ React.DOM.rp = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.rt = function(props, children) {};
 
@@ -1268,7 +1268,7 @@ React.DOM.rt = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.ruby = function(props, children) {};
 
@@ -1276,7 +1276,7 @@ React.DOM.ruby = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.s = function(props, children) {};
 
@@ -1284,7 +1284,7 @@ React.DOM.s = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.samp = function(props, children) {};
 
@@ -1292,7 +1292,7 @@ React.DOM.samp = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.script = function(props, children) {};
 
@@ -1300,7 +1300,7 @@ React.DOM.script = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.section = function(props, children) {};
 
@@ -1308,7 +1308,7 @@ React.DOM.section = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.select = function(props, children) {};
 
@@ -1316,7 +1316,7 @@ React.DOM.select = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.small = function(props, children) {};
 
@@ -1324,7 +1324,7 @@ React.DOM.small = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.source = function(props, children) {};
 
@@ -1332,7 +1332,7 @@ React.DOM.source = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.span = function(props, children) {};
 
@@ -1340,7 +1340,7 @@ React.DOM.span = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.stop = function(props, children) {};
 
@@ -1348,7 +1348,7 @@ React.DOM.stop = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.strong = function(props, children) {};
 
@@ -1356,7 +1356,7 @@ React.DOM.strong = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.style = function(props, children) {};
 
@@ -1364,7 +1364,7 @@ React.DOM.style = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.sub = function(props, children) {};
 
@@ -1372,7 +1372,7 @@ React.DOM.sub = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.svg = function(props, children) {};
 
@@ -1380,7 +1380,7 @@ React.DOM.svg = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.table = function(props, children) {};
 
@@ -1388,7 +1388,7 @@ React.DOM.table = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.tbody = function(props, children) {};
 
@@ -1396,7 +1396,7 @@ React.DOM.tbody = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.td = function(props, children) {};
 
@@ -1404,7 +1404,7 @@ React.DOM.td = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.text = function(props, children) {};
 
@@ -1412,7 +1412,7 @@ React.DOM.text = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.textarea = function(props, children) {};
 
@@ -1420,7 +1420,7 @@ React.DOM.textarea = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.tfoot = function(props, children) {};
 
@@ -1428,7 +1428,7 @@ React.DOM.tfoot = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.th = function(props, children) {};
 
@@ -1436,7 +1436,7 @@ React.DOM.th = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.thead = function(props, children) {};
 
@@ -1444,7 +1444,7 @@ React.DOM.thead = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.time = function(props, children) {};
 
@@ -1452,7 +1452,7 @@ React.DOM.time = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.title = function(props, children) {};
 
@@ -1460,7 +1460,7 @@ React.DOM.title = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.tr = function(props, children) {};
 
@@ -1468,7 +1468,7 @@ React.DOM.tr = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.track = function(props, children) {};
 
@@ -1476,7 +1476,7 @@ React.DOM.track = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.tspan = function(props, children) {};
 
@@ -1484,7 +1484,7 @@ React.DOM.tspan = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.u = function(props, children) {};
 
@@ -1492,7 +1492,7 @@ React.DOM.u = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.ul = function(props, children) {};
 
@@ -1500,7 +1500,7 @@ React.DOM.ul = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.var = function(props, children) {};
 
@@ -1508,7 +1508,7 @@ React.DOM.var = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.video = function(props, children) {};
 
@@ -1516,7 +1516,7 @@ React.DOM.video = function(props, children) {};
  * @param {Object=} props
  * @param {...React.ChildrenArgument} children
  * @return {React.Component}
- * @protected
+ * @package
  */
 React.DOM.wbr = function(props, children) {};
 


### PR DESCRIPTION
The `accessControls` closure compiler visibility check rule is currently ignored during `gulp check-types`. Turning on the rule results in about [350+ annotation errors](https://github.com/ampproject/amphtml/issues/26307#issuecomment-573214902).

This PR enables the rule and fixes all incorrect annotation errors. It took only ~25 annotation changes to fix all 350+ errors.

**Reference:** https://github.com/google/closure-compiler/wiki/Annotating-JavaScript-for-the-Closure-Compiler#visibility-checks

Fixes #26307