### PR TITLE
♻️ Refactor docking to use rects for targets

### DIFF
--- a/extensions/amp-video-docking/0.1/amp-video-docking.js
+++ b/extensions/amp-video-docking/0.1/amp-video-docking.js
@@ -269,7 +269,7 @@ export class VideoDocking {
 
     /**
      * Overriden when user drags the video to a different corner.
-     * @private {!RelativeX}
+     * @private {!DirectionX}
      */
     this.cornerDirectionX_ = isRTL(this.getDoc_())
       ? DirectionX.LEFT
@@ -305,7 +305,7 @@ export class VideoDocking {
     /** @private {?{width: number, height: number}} */
     this.sizedAt_ = null;
 
-    /** @private {?RelativeY} */
+    /** @private {?DirectionY} */
     this.scrollDirection_ = null;
 
     /** @private {number} */
@@ -1269,7 +1269,9 @@ export class VideoDocking {
    * @private
    */
   isDockedToType_(type) {
-    return this.currentlyDocked_ && this.currentlyDocked_.target.type == type;
+    return (
+      !!this.currentlyDocked_ && this.currentlyDocked_.target.type === type
+    );
   }
 
   /**

--- a/extensions/amp-video-docking/0.1/amp-video-docking.js
+++ b/extensions/amp-video-docking/0.1/amp-video-docking.js
@@ -38,7 +38,6 @@ import {
 import {PositionObserverFidelity} from '../../../src/service/position-observer/position-observer-worker';
 import {Services} from '../../../src/services';
 import {VideoDockingEvents, pointerCoords} from './events';
-import {ViewportInterface} from '../../../src/service/viewport/viewport-interface';
 import {applyBreakpointClassname} from './breakpoints';
 import {
   calculateLeftJustifiedX,
@@ -259,7 +258,7 @@ export class VideoDocking {
     /** @private @const */
     this.manager_ = once(() => Services.videoManagerForDoc(ampdoc));
 
-    /** @private @const {!ViewportInterface} */
+    /** @private @const {!../../../src/service/viewport/viewport-interface.ViewportInterface} */
     this.viewport_ = Services.viewportForDoc(ampdoc);
 
     /** @private @const {!LayoutRectDef} */

--- a/extensions/amp-video-docking/0.1/amp-video-docking.js
+++ b/extensions/amp-video-docking/0.1/amp-video-docking.js
@@ -309,9 +309,6 @@ export class VideoDocking {
     /** @private {?VideoOrBaseElementDef} */
     this.lastDismissed_ = null;
 
-    /** @private {?RelativeY} */
-    this.lastDismissedPosY_ = null;
-
     /**
      * Memoizes x, y and scale to prevent useless mutations.
      * @private {?{x: number, y: number, scale: number}}
@@ -731,19 +728,6 @@ export class VideoDocking {
   }
 
   /**
-   * @param {!RelativeY} posY
-   * @return {boolean}
-   * @private
-   */
-  positionMatchesScroll_(posY) {
-    const direction = this.scrollDirection_;
-    return (
-      (posY == RelativeY.TOP && direction == RelativeY.TOP) ||
-      (posY == RelativeY.BOTTOM && direction == RelativeY.BOTTOM)
-    );
-  }
-
-  /**
    * @param {!VideoOrBaseElementDef} video
    * @param {!TargetDef} target
    * @private
@@ -870,12 +854,6 @@ export class VideoDocking {
     if (this.lastDismissed_ != video) {
       return false;
     }
-    if (
-      this.lastDismissedPosY_ !== null &&
-      !this.positionMatchesScroll_(this.lastDismissedPosY_)
-    ) {
-      return false;
-    }
     if (this.isVisible_(video.element, FLOAT_TOLERANCE)) {
       this.resetDismissed_();
     }
@@ -885,7 +863,6 @@ export class VideoDocking {
   /** @private */
   resetDismissed_() {
     this.lastDismissed_ = null;
-    this.lastDismissedPosY_ = null;
   }
 
   /**

--- a/extensions/amp-video-docking/0.1/amp-video-docking.js
+++ b/extensions/amp-video-docking/0.1/amp-video-docking.js
@@ -848,7 +848,7 @@ export class VideoDocking {
    */
   trigger_(action) {
     const element = dev().assertElement(
-      this.isDockedToSlot_() ? this.getSlot_() : this.getDockedVideo_().element
+      this.getUsableSlot_() || this.getDockedVideo_().element
     );
 
     const trust = ActionTrust.LOW;
@@ -1261,7 +1261,7 @@ export class VideoDocking {
       return;
     }
 
-    if (this.isDockedToSlot_()) {
+    if (this.isDockedToType_(TargetType.SLOT)) {
       return;
     }
 
@@ -1300,14 +1300,12 @@ export class VideoDocking {
   }
 
   /**
+   * @param {!TargetType} type
    * @return {boolean}
    * @private
    */
-  isDockedToSlot_() {
-    if (!this.currentlyDocked_) {
-      return false;
-    }
-    return this.currentlyDocked_.target.type == TargetType.SLOT;
+  isDockedToType_(type) {
+    return this.currentlyDocked_ && this.currentlyDocked_.target.type == type;
   }
 
   /**

--- a/extensions/amp-video-docking/0.1/amp-video-docking.js
+++ b/extensions/amp-video-docking/0.1/amp-video-docking.js
@@ -16,7 +16,7 @@
 import {ActionTrust} from '../../../src/action-constants';
 import {CSS} from '../../../build/amp-video-docking-0.1.css';
 import {Controls} from './controls';
-import {FLOAT_TOLERANCE, DirectionX, DirectionY} from './def.js';
+import {DirectionX, DirectionY, FLOAT_TOLERANCE} from './def.js';
 import {HtmlLiteralTagDef} from './html';
 import {
   LayoutRectDef,
@@ -57,7 +57,6 @@ import {escapeCssSelectorIdent} from '../../../src/css';
 import {getInternalVideoElementFor} from '../../../src/utils/video';
 import {htmlFor, htmlRefs} from '../../../src/static-template';
 import {installStylesForDoc} from '../../../src/style-installer';
-import {isFiniteNumber} from '../../../src/types';
 import {isRTL, removeElement, scopedQuerySelector} from '../../../src/dom';
 import {once} from '../../../src/utils/function';
 import {

--- a/extensions/amp-video-docking/0.1/amp-video-docking.js
+++ b/extensions/amp-video-docking/0.1/amp-video-docking.js
@@ -122,7 +122,7 @@ export const BASE_CLASS_NAME = 'i-amphtml-video-docked';
 export const Actions = {DOCK: 'dock', UNDOCK: 'undock'};
 
 /** @enum {string} */
-export const TargetType = {
+export const DockTargetType = {
   // Dynamically calculated corner based on viewport percentage. Draggable.
   CORNER: 'corner',
   // Targets author-defined element's box. Not draggable.
@@ -132,7 +132,7 @@ export const TargetType = {
 /**
  * @struct @typedef {{
  *   video: !VideoOrBaseElementDef,
- *   target: !TargetDef,
+ *   target: !DockTargetDef,
  *   step: number,
  * }}
  */
@@ -140,11 +140,11 @@ let DockedDef;
 
 /**
  * @struct @typedef {{
- *   type: TargetType,
+ *   type: DockTargetType,
  *   rect: !LayoutRectDef,
  * }}
  */
-let TargetDef;
+let DockTargetDef;
 
 // Function should ideally be in `dom.js`, but moving it causes a bunch of ads
 // tests to fail, for some reason.
@@ -596,7 +596,7 @@ export class VideoDocking {
   /**
    * Returns the area's target when a video should be docked.
    * @param {!VideoOrBaseElementDef} video
-   * @return {?TargetDef}
+   * @return {?DockTargetDef}
    * @private
    */
   getTargetFor_(video) {
@@ -729,7 +729,7 @@ export class VideoDocking {
 
   /**
    * @param {!VideoOrBaseElementDef} video
-   * @param {!TargetDef} target
+   * @param {!DockTargetDef} target
    * @private
    */
   dockOnPositionChange_(video, target) {
@@ -756,7 +756,7 @@ export class VideoDocking {
 
   /**
    * @param {!VideoOrBaseElementDef} video
-   * @param {!TargetDef} target
+   * @param {!DockTargetDef} target
    * @param {number=} opt_step
    * @return {!Promise}
    * @private
@@ -785,7 +785,7 @@ export class VideoDocking {
 
   /**
    * @param {!VideoOrBaseElementDef} video
-   * @param {!TargetDef} target
+   * @param {!DockTargetDef} target
    * @param {number} step
    * @param {boolean=} opt_isTransferLayerStep
    * @return {!Promise}
@@ -1173,7 +1173,7 @@ export class VideoDocking {
 
   /**
    * @param {!VideoOrBaseElementDef} video
-   * @param {!TargetDef} target
+   * @param {!DockTargetDef} target
    * @param {number} step
    */
   setCurrentlyDocked_(video, target, step) {
@@ -1238,7 +1238,7 @@ export class VideoDocking {
       return;
     }
 
-    if (this.isDockedToType_(TargetType.SLOT)) {
+    if (this.isDockedToType_(DockTargetType.SLOT)) {
       return;
     }
 
@@ -1277,7 +1277,7 @@ export class VideoDocking {
   }
 
   /**
-   * @param {!TargetType} type
+   * @param {!DockTargetType} type
    * @return {boolean}
    * @private
    */
@@ -1532,7 +1532,7 @@ export class VideoDocking {
 
   /**
    * @param {!VideoOrBaseElementDef} video
-   * @param {!TargetDef} target
+   * @param {!DockTargetDef} target
    * @param {number} step in [0..1]
    * @return {{x: number, y: number, scale: number, relativeX: !DirectionX}}
    */
@@ -1681,7 +1681,7 @@ export class VideoDocking {
    * Otherwise returns a rectangle calculated relative to viewport and sticking
    * to the horizontal `directionX`.
    * @param {!AmpElement|!VideoOrBaseElementDef} video
-   * @return {!TargetDef}
+   * @return {!DockTargetDef}
    * @private
    */
   getUsableTarget_(video) {
@@ -1690,13 +1690,13 @@ export class VideoDocking {
 
     if (slot) {
       return {
-        type: TargetType.SLOT,
+        type: DockTargetType.SLOT,
         rect: letterboxRect(inlineRect, slot.getPageLayoutBox()),
       };
     }
 
     return {
-      type: TargetType.CORNER,
+      type: DockTargetType.CORNER,
       rect: topCornerRect(
         inlineRect,
         this.viewportRect_,

--- a/extensions/amp-video-docking/0.1/amp-video-docking.js
+++ b/extensions/amp-video-docking/0.1/amp-video-docking.js
@@ -16,11 +16,19 @@
 import {ActionTrust} from '../../../src/action-constants';
 import {CSS} from '../../../build/amp-video-docking-0.1.css';
 import {Controls} from './controls';
+import {FLOAT_TOLERANCE, RelativeX, RelativeY} from './def.js';
 import {HtmlLiteralTagDef} from './html';
+import {
+  LayoutRectDef,
+  layoutRectEquals,
+  moveLayoutRect,
+} from '../../../src/layout-rect';
 import {
   PlayingStates,
   VideoAttributes,
   VideoEvents,
+  VideoInterface,
+  VideoOrBaseElementDef,
   isDockable,
 } from '../../../src/video-interface';
 import {
@@ -30,9 +38,19 @@ import {
 import {PositionObserverFidelity} from '../../../src/service/position-observer/position-observer-worker';
 import {Services} from '../../../src/services';
 import {VideoDockingEvents, pointerCoords} from './events';
+import {ViewportInterface} from '../../../src/service/viewport/viewport-interface';
 import {applyBreakpointClassname} from './breakpoints';
-import {calculateLeftJustifiedX, calculateRightJustifiedX} from './math';
+import {
+  calculateLeftJustifiedX,
+  calculateRightJustifiedX,
+  interpolatedBoxesTransform,
+  isSizedRect,
+  isVisibleBySize,
+  letterboxRect,
+  topCornerRect,
+} from './math';
 import {createCustomEvent, listen, listenOnce} from '../../../src/event-helper';
+import {createViewportRect} from './viewport-rect';
 import {dev, devAssert, user, userAssert} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
 import {escapeCssSelectorIdent} from '../../../src/css';
@@ -41,8 +59,6 @@ import {htmlFor, htmlRefs} from '../../../src/static-template';
 import {installStylesForDoc} from '../../../src/style-installer';
 import {isFiniteNumber} from '../../../src/types';
 import {isRTL, removeElement, scopedQuerySelector} from '../../../src/dom';
-import {layoutRectLtwh, moveLayoutRect} from '../../../src/layout-rect';
-import {magnitude, mapRange} from '../../../src/utils/math';
 import {once} from '../../../src/utils/function';
 import {
   px,
@@ -54,53 +70,90 @@ import {
 
 const TAG = 'amp-video-docking';
 
-/** @visibleForTesting @const {number} */
-export const MARGIN_MAX = 30;
+/** Ratio to viewport width to use when docked to corner. */
+export const CORNER_WIDTH_RATIO = 0.3;
 
-/** @visibleForTesting @const {number} */
-export const MARGIN_AREA_WIDTH_PERC = 0.04;
+/** Min width in pixels for corner area. */
+export const CORNER_WIDTH_MIN = 180;
 
-/** @visibleForTesting @const {number} */
-export const MIN_WIDTH = 180;
+/** Max amount of pixels to use for margins (it's relative to viewport.) */
+export const CORNER_MARGIN_MAX = 30;
 
-/** @private @const {number} */
-const MIN_VIEWPORT_WIDTH = 320;
+/** Max % of viewport width to use form margins. */
+export const CORNER_MARGIN_RATIO = 0.04;
 
-/** @private @const {number} */
-const FLOAT_TOLERANCE = 0.02;
+/** Min viewport width for dock to appear at all. */
+export const MIN_VIEWPORT_WIDTH = 320;
+
+/** Min visible intersection ratio of inline box to undock when scrolling. */
+export const REVERT_TO_INLINE_RATIO = 0.85;
+
+/**
+ * Width/height of placeholder icon when the inline box is large.
+ * @visibleForTesting
+ */
+export const PLACEHOLDER_ICON_LARGE_WIDTH = 48;
+
+/** Margin applied to placeholder icon when the inline box is large. */
+export const PLACEHOLDER_ICON_LARGE_MARGIN = 40;
+
+/** Width/height of placeholder icon when the inline box is small. */
+export const PLACEHOLDER_ICON_SMALL_WIDTH = 32;
+
+/** Margin applied to placeholder icon when the inline box is large. */
+export const PLACEHOLDER_ICON_SMALL_MARGIN = 20;
+
+/** @const {!Array<!./breakpoints.SyntheticBreakpointDef>} */
+export const PLACEHOLDER_ICON_BREAKPOINTS = [
+  {
+    className: 'amp-small',
+    minWidth: 0,
+  },
+  {
+    className: 'amp-large',
+    minWidth: 420,
+  },
+];
 
 /** @visibleForTesting @const {string} */
 export const BASE_CLASS_NAME = 'i-amphtml-video-docked';
 
-/** @visibleForTesting @const {number} */
-export const REVERT_TO_INLINE_RATIO = 0.7;
-
-/** @enum */
-export const RelativeX = {LEFT: 0, RIGHT: 1};
-
-/** @enum */
-export const RelativeY = {TOP: 0, BOTTOM: 1};
-
-/** @enum */
-export const Direction = {UP: 1, DOWN: -1};
-
 /** @enum {string} */
 export const Actions = {DOCK: 'dock', UNDOCK: 'undock'};
 
-/** @visibleForTesting */
-export const DOCKED_TO_CORNER_SIZING_RATIO = 0.3;
+/** @enum {string} */
+const TargetType = {
+  // Dynamically calculated corner based on viewport percentage. Draggable.
+  CORNER: 'corner',
+  // Targets author-defined element's box. Not draggable.
+  SLOT: 'slot',
+};
 
 /**
  * @struct @typedef {{
- *   video: !../../../src/video-interface.VideoOrBaseElementDef,
- *   target: !DockTargetDef,
+ *   video: !VideoOrBaseElementDef,
+ *   target: !TargetDef,
  *   step: number,
  * }}
  */
 let DockedDef;
 
-/** @typedef {{posX: !RelativeX, posY: !RelativeY}|!Element} */
-let DockTargetDef;
+/**
+ * @struct @typedef {{
+ *   type: TargetType,
+ *   rect: !LayoutRectDef,
+ * }}
+ */
+let TargetDef;
+
+// Function should ideally be in `dom.js`, but moving it causes a bunch of ads
+// tests to fail, for some reason.
+// TODO(alanorozco): Move.
+/**
+ * @param {!Object} obj
+ * @return {boolean}
+ */
+export const isElement = obj => obj.nodeType == /* ELEMENT */ 1;
 
 /**
  * @param {number} x
@@ -130,17 +183,6 @@ function throttleByAnimationFrame(win, fn) {
 }
 
 /**
- * Maps an interpolation step in [0..1] to its position in a range.
- * @param {number} step
- * @param {number} min
- * @param {number} max
- * @return {number}
- */
-function mapStep(step, min, max) {
-  return mapRange(step, 0, 1, min, max);
-}
-
-/**
  * @param {!Element} element
  * @restricted
  */
@@ -154,18 +196,39 @@ function complainAboutPortrait(element) {
   );
 }
 
-// Function should ideally be in `dom.js`, but moving it causes a bunch of ads
-// tests to fail, for some reason.
-// TODO(alanorozco): Move.
 /**
- * @param {!Object} obj
- * @return {boolean}
+ * Gets a poster src URL from a video players element.
+ * API across components is unfortunately inconsistent, so this queries for all
+ * known `poster` attribute patterns. Instances may also not use the `poster`
+ * API at all, in which case we fallback to `placeholder` images.
+ * @param {!Element} element
+ * @return {string|undefined}
+ * @private
  */
-export function isElement(obj) {
-  return obj.nodeType == /* ELEMENT */ 1;
+export function getPosterImageSrc(element) {
+  const attr = ['poster', 'data-poster'].reduce(
+    (existing, attr) => existing || element.getAttribute(attr),
+    null
+  );
+  if (attr) {
+    return attr;
+  }
+  const imgEl = scopedQuerySelector(
+    element,
+    'amp-img[placeholder],img[placeholder],[placeholder] amp-img'
+  );
+  if (imgEl) {
+    return imgEl.getAttribute('src');
+  }
 }
 
 /**
+ * Returns an element representing a shadow under the docked video.
+ * Alternatively, we could use box-shadow on the video element, but in
+ * order to animate it without jank we have to use an opacity transition.
+ * A separate layer also has the added benefit that authors can override its
+ * box-shadow value or any other styling without handling the transition
+ * themselves.
  * @param {!HtmlLiteralTagDef} html
  * @return {!Element}
  * @private
@@ -191,61 +254,9 @@ const PlaceholderBackground = html =>
     </div>
   `;
 
-/** @visibleForTesting @const {!Array<!./breakpoints.SyntheticBreakpointDef>} */
-export const PLACEHOLDER_ICON_BREAKPOINTS = [
-  {
-    className: 'amp-small',
-    minWidth: 0,
-  },
-  {
-    className: 'amp-large',
-    minWidth: 420,
-  },
-];
-
-/** @visibleForTesting */
-export const PLACEHOLDER_ICON_LARGE_WIDTH = 48;
-/** @visibleForTesting */
-export const PLACEHOLDER_ICON_LARGE_MARGIN = 40;
-
-/** @visibleForTesting */
-export const PLACEHOLDER_ICON_SMALL_WIDTH = 32;
-/** @visibleForTesting */
-export const PLACEHOLDER_ICON_SMALL_MARGIN = 20;
-
-/**
- * @param {!Element} element
- * @return {!../../../src/layout-rect.LayoutRectDef}
- */
-function getIntersectionRect(element) {
-  return /** @type {!../../../src/layout-rect.LayoutRectDef} */ (element.getIntersectionChangeEntry()
-    .intersectionRect);
-}
-
-/**
- * @param {!../../../src/layout-rect.LayoutRectDef} rect
- * @return {boolean}
- */
-function isSizedLayoutRect(rect) {
-  const {width, height} = rect;
-  return width > 0 && height > 0;
-}
-
-/**
- * @param {!DockTargetDef} a
- * @param {!DockTargetDef} b
- * @return {boolean}
- */
-function targetsEqual(a, b) {
-  if (isElement(a)) {
-    return a == b;
-  }
-  return a.posX == b.posX;
-}
-
 /**
  * Manages docking (a.k.a. minimize to corner) for videos that satisfy the
- * {@see ../../../src/video-interface.VideoInterface}.
+ * {@see VideoInterface}.
  * @visibleForTesting
  */
 export class VideoDocking {
@@ -260,35 +271,26 @@ export class VideoDocking {
     /** @private @const */
     this.manager_ = once(() => Services.videoManagerForDoc(ampdoc));
 
-    /**
-     * @private
-     * @const {!../../../src/service/viewport/viewport-interface.ViewportInterface}
-     */
+    /** @private @const {!ViewportInterface} */
     this.viewport_ = Services.viewportForDoc(ampdoc);
+
+    /** @private @const {!LayoutRectDef} */
+    this.viewportRect_ = createViewportRect(this.viewport_);
 
     /** @private {?DockedDef} */
     this.currentlyDocked_ = null;
 
     /**
-     * Overriden when user drags the video to a corner.
-     * Y-corner is determined based on scroll direction.
+     * Overriden when user drags the video to a different corner.
      * @private {!RelativeX}
      */
-    this.preferredCornerX_ = isRTL(this.getDoc_())
+    this.cornerDirectionX_ = isRTL(this.getDoc_())
       ? RelativeX.LEFT
       : RelativeX.RIGHT;
 
     const html = htmlFor(this.getDoc_());
 
-    /**
-     * Returns an element representing a shadow under the docked video.
-     * Alternatively, we could use box-shadow on the video element, but in
-     * order to animate it without jank we have to use an opacity transition.
-     * A separate layer also has the added benefit that authors can override its
-     * box-shadow value or any other styling without handling the transition
-     * themselves.
-     * @private @const {function():!Element}
-     */
+    /** @private @const {function():!Element} */
     this.getShadowLayer_ = once(() => this.append_(ShadowLayer(html)));
 
     /** @private @const {function():!Controls} */
@@ -304,7 +306,7 @@ export class VideoDocking {
       htmlRefs(this.getPlaceholderBackground_())
     );
 
-    /** @private {?../../../src/video-interface.VideoOrBaseElementDef} */
+    /** @private {?VideoOrBaseElementDef} */
     this.lastDismissed_ = null;
 
     /** @private {?RelativeY} */
@@ -319,7 +321,7 @@ export class VideoDocking {
     /** @private {?{width: number, height: number}} */
     this.sizedAt_ = null;
 
-    /** @private {?Direction} */
+    /** @private {?RelativeY} */
     this.scrollDirection_ = null;
 
     /** @private {number} */
@@ -329,12 +331,15 @@ export class VideoDocking {
     this.isDragging_ = false;
 
     /** @private {number} */
+    this.dragOffsetX_ = 0;
+
+    /** @private {number} */
     this.previousDragOffsetX_ = 0;
 
     /** @private {number} */
     this.dragVelocityX_ = 0;
 
-    /** @private {!Array<!../../../src/video-interface.VideoOrBaseElementDef>} */
+    /** @private {!Array<!VideoOrBaseElementDef>} */
     this.observed_ = [];
 
     /**
@@ -348,7 +353,7 @@ export class VideoDocking {
         throttleByAnimationFrame(ampdoc.win, () => this.updateScroll_())
       );
 
-      this.viewport_.onResize(() => this.updateAllOnResize_());
+      this.viewport_.onResize(() => this.onViewportResize_());
 
       installStylesForDoc(
         ampdoc,
@@ -453,11 +458,24 @@ export class VideoDocking {
   }
 
   /** @private */
-  updateAllOnResize_() {
+  onViewportResize_() {
     this.observed_.forEach(video => this.updateOnResize_(video));
   }
 
-  /** @param {!../../../src/video-interface.VideoOrBaseElementDef} video */
+  /**
+   * @return {number}
+   * @private
+   */
+  getTopBoundary_() {
+    const slot = this.getUsableSlot_();
+    if (slot) {
+      // Match slot's top edge to tie transition to element.
+      return slot.getPageLayoutBox().top;
+    }
+    return 0;
+  }
+
+  /** @param {!VideoOrBaseElementDef} video */
   register(video) {
     this.install_();
 
@@ -487,7 +505,7 @@ export class VideoDocking {
     }
 
     const scrollDirection =
-      scrollTop > this.lastScrollTop_ ? Direction.UP : Direction.DOWN;
+      scrollTop > this.lastScrollTop_ ? RelativeY.TOP : RelativeY.BOTTOM;
 
     this.scrollDirection_ = scrollDirection;
     this.lastScrollTop_ = scrollTop;
@@ -557,7 +575,7 @@ export class VideoDocking {
   }
 
   /**
-   * @return {!../../../src/video-interface.VideoOrBaseElementDef}
+   * @return {!VideoOrBaseElementDef}
    * @private
    */
   getDockedVideo_() {
@@ -579,10 +597,9 @@ export class VideoDocking {
   }
 
   /**
-   * Reconciles the state of a docked or potentially dockable video when
-   * the viewport/position changes.
-   * @param {!../../../src/video-interface.VideoOrBaseElementDef} video
-   * @return {?DockTargetDef}
+   * Returns the area's target when a video should be docked.
+   * @param {!VideoOrBaseElementDef} video
+   * @return {?TargetDef}
    * @private
    */
   getTargetFor_(video) {
@@ -594,75 +611,30 @@ export class VideoDocking {
     ) {
       return null;
     }
-    if (this.canUpdateFromSlot_(video)) {
-      return this.getSlot_();
-    }
-    const posY = this.maybeGetRelativeY_(video);
-    if (posY === null) {
-      return posY;
-    }
-    return {posY, posX: this.getRelativeX_()};
-  }
 
-  /**
-   * @param {!../../../src/video-interface.VideoOrBaseElementDef} video
-   * @return {boolean}
-   * @private
-   */
-  canUpdateFromSlot_(video) {
-    if (!this.slotHasDimensions_()) {
-      return false;
-    }
-    const relativeY = this.getSlotRelativeY_();
     const {element} = video;
-    const intersectionRect = getIntersectionRect(element);
-    if (!isSizedLayoutRect(intersectionRect)) {
-      return false;
+    const {intersectionRect} = element.getIntersectionChangeEntry();
+    if (!isSizedRect(intersectionRect)) {
+      return null;
     }
-    const {top, bottom} = intersectionRect;
-    const {top: slotTop, height: slotHeight} = this.getFixedSlotLayoutBox_();
-    const slotBottom = this.viewport_.getSize().height - slotHeight - slotTop;
-    if (relativeY == RelativeY.TOP) {
-      return top <= slotTop;
+    if (intersectionRect.top > this.getTopBoundary_()) {
+      return null;
     }
-    return bottom >= slotBottom;
+    return this.getUsableTarget_(video);
   }
 
   /**
-   * @return {!../../../src/layout-rect.LayoutRectDef}
+   * @param {!AmpElement|!VideoOrBaseElementDef} element
+   * @return {!LayoutRectDef}
    * @private
    */
-  getFixedSlotLayoutBox_() {
-    return dev()
-      .assertElement(this.getSlot_())
-      .getPageLayoutBox();
-  }
-
-  /**
-   * @param {!Element} element
-   * @return {!../../../src/layout-rect.LayoutRectDef}
-   * @private
-   */
-  getFixedLayoutBox_(element) {
+  getScrollAdjustedRect_(element) {
     const dy = -this.viewport_.getScrollTop();
     return moveLayoutRect(element.getLayoutBox(), /* dx */ 0, dy);
   }
 
   /**
-   * @return {boolean}
-   * @private
-   */
-  slotHasDimensions_() {
-    const el = this.getSlot_();
-    if (!el) {
-      return false;
-    }
-    const {width, height} = this.getFixedSlotLayoutBox_();
-    return width > 0 && height > 0;
-  }
-
-  /**
-   * @param {!../../../src/video-interface.VideoOrBaseElementDef} video
+   * @param {!VideoOrBaseElementDef} video
    * @private
    */
   updateOnResize_(video) {
@@ -689,31 +661,31 @@ export class VideoDocking {
   }
 
   /**
-   * @param {!../../../src/video-interface.VideoOrBaseElementDef} video
+   * @param {!VideoOrBaseElementDef} video
    * @private
    */
   updateOnPositionChange_(video) {
     if (this.isTransitioning_) {
       return;
     }
-    if (this.scrollDirection_ == Direction.UP) {
+    if (this.scrollDirection_ == RelativeY.TOP) {
       const target = this.getTargetFor_(video);
       if (target) {
         this.dockOnPositionChange_(video, target);
       }
-    } else if (this.scrollDirection_ == Direction.DOWN) {
+    } else if (this.scrollDirection_ == RelativeY.BOTTOM) {
       if (!this.currentlyDocked_) {
         return;
       }
       const video = this.getDockedVideo_();
-      if (this.isVisible_(video.element, REVERT_TO_INLINE_RATIO)) {
+      if (this.isVisible_(video, REVERT_TO_INLINE_RATIO)) {
         this.undock_(video);
       }
     }
   }
 
   /**
-   * @param  {!../../../src/video-interface.VideoOrBaseElementDef} video
+   * @param  {!VideoOrBaseElementDef} video
    * @return {boolean}
    */
   ignoreDueToNotPlayingManually_(video) {
@@ -721,7 +693,7 @@ export class VideoDocking {
   }
 
   /**
-   * @param  {!../../../src/video-interface.VideoOrBaseElementDef} video
+   * @param  {!VideoOrBaseElementDef} video
    * @return {boolean}
    */
   ignoreBecauseAnotherDocked_(video) {
@@ -729,7 +701,7 @@ export class VideoDocking {
   }
 
   /**
-   * @param  {!../../../src/video-interface.VideoOrBaseElementDef} video
+   * @param  {!VideoOrBaseElementDef} video
    * @return {boolean}
    * @private
    */
@@ -740,130 +712,22 @@ export class VideoDocking {
       return false;
     }
     return (
-      this.getAreaWidth_() >= MIN_VIEWPORT_WIDTH &&
-      this.getAreaHeight_() >= height * REVERT_TO_INLINE_RATIO
+      this.viewportRect_.width >= MIN_VIEWPORT_WIDTH &&
+      this.viewportRect_.height >= height * REVERT_TO_INLINE_RATIO
     );
   }
 
   /**
-   * @return {number}
-   * @private
-   */
-  getTopEdge_() {
-    return 0;
-  }
-
-  /**
-   * @return {number}
-   * @private
-   */
-  getBottomEdge_() {
-    return this.viewport_.getSize().height;
-  }
-
-  /**
-   * @return {number}
-   * @private
-   */
-  getLeftEdge_() {
-    return 0;
-  }
-
-  /**
-   * @return {number}
-   * @private
-   */
-  getRightEdge_() {
-    return this.viewport_.getSize().width;
-  }
-
-  /**
-   * @return {!RelativeX}
-   * @private
-   */
-  getRelativeX_() {
-    return this.preferredCornerX_;
-  }
-
-  /**
-   * @param {!../../../src/video-interface.VideoOrBaseElementDef} video
-   * @return {?RelativeY}
-   * @private
-   */
-  maybeGetRelativeY_(video) {
-    if (this.slotHasDimensions_()) {
-      return null;
-    }
-
-    if (
-      this.isCurrentlyDocked_(video) &&
-      !isElement(this.currentlyDocked_.target)
-    ) {
-      const {posY} = devAssert(this.currentlyDocked_).target;
-      return /** @type {!RelativeY} */ (dev().assertNumber(posY));
-    }
-
-    const {element} = video;
-    const intersectionRect = getIntersectionRect(element);
-
-    if (
-      !isSizedLayoutRect(intersectionRect) ||
-      intersectionRect.top > this.getTopEdge_()
-    ) {
-      return null;
-    }
-
-    dev().info(TAG, 'should dock at Y = TOP', {video, intersectionRect});
-    return RelativeY.TOP;
-  }
-
-  /**
-   * @return {number}
-   * @private
-   */
-  getMargin_() {
-    return Math.min(MARGIN_MAX, MARGIN_AREA_WIDTH_PERC * this.getAreaWidth_());
-  }
-
-  /**
-   * @return {number}
-   * @private
-   */
-  getAreaWidth_() {
-    return this.getRightEdge_() - this.getLeftEdge_();
-  }
-
-  /**
-   * @return {number}
-   * @private
-   */
-  getAreaHeight_() {
-    return this.getBottomEdge_() - this.getTopEdge_();
-  }
-
-  /**
-   * @param {?../../../src/video-interface.VideoOrBaseElementDef} optVideo
+   * @param {?VideoOrBaseElementDef} optVideo
    * @return {boolean}
    * @private
    */
   isPlaying_(optVideo = null) {
     const video =
-      /** @type {!../../../src/video-interface.VideoInterface} */ (optVideo ||
-      this.getDockedVideo_());
+      /** @type {!VideoInterface} */ (optVideo || this.getDockedVideo_());
     return (
       this.manager_().getPlayingState(video) == PlayingStates.PLAYING_MANUAL
     );
-  }
-
-  /**
-   * @return {!RelativeY}
-   * @private
-   */
-  getSlotRelativeY_() {
-    const {top, height} = this.getFixedSlotLayoutBox_();
-    const vh = this.viewport_.getSize().height;
-    const bottom = vh - height - top;
-    return bottom > top ? RelativeY.TOP : RelativeY.BOTTOM;
   }
 
   /**
@@ -874,14 +738,14 @@ export class VideoDocking {
   positionMatchesScroll_(posY) {
     const direction = this.scrollDirection_;
     return (
-      (posY == RelativeY.TOP && direction == Direction.UP) ||
-      (posY == RelativeY.BOTTOM && direction == Direction.DOWN)
+      (posY == RelativeY.TOP && direction == RelativeY.TOP) ||
+      (posY == RelativeY.BOTTOM && direction == RelativeY.BOTTOM)
     );
   }
 
   /**
-   * @param {!../../../src/video-interface.VideoOrBaseElementDef} video
-   * @param {!DockTargetDef} target
+   * @param {!VideoOrBaseElementDef} video
+   * @param {!TargetDef} target
    * @private
    */
   dockOnPositionChange_(video, target) {
@@ -897,8 +761,8 @@ export class VideoDocking {
 
     if (
       currentlyDocked &&
-      targetsEqual(target, currentlyDocked.target) &&
-      currentlyDocked.step >= 0
+      currentlyDocked.step >= 0 &&
+      layoutRectEquals(currentlyDocked.target.rect, target.rect)
     ) {
       return;
     }
@@ -907,10 +771,10 @@ export class VideoDocking {
   }
 
   /**
-   * @param {!../../../src/video-interface.VideoOrBaseElementDef} video
-   * @param {!DockTargetDef} target
+   * @param {!VideoOrBaseElementDef} video
+   * @param {!TargetDef} target
    * @param {number=} opt_step
-   * @return {*} TODO(#23582): Specify return type
+   * @return {!Promise}
    * @private
    */
   dockInTransferLayerStep_(video, target, opt_step) {
@@ -936,16 +800,14 @@ export class VideoDocking {
   }
 
   /**
-   * @param {!../../../src/video-interface.VideoOrBaseElementDef} video
-   * @param {!DockTargetDef} target
+   * @param {!VideoOrBaseElementDef} video
+   * @param {!TargetDef} target
    * @param {number} step
    * @param {boolean=} opt_isTransferLayerStep
    * @return {!Promise}
    * @private
    */
   dock_(video, target, step, opt_isTransferLayerStep) {
-    dev().info(TAG, 'dock', {video, target, step});
-
     const {element} = video;
 
     // Component background is now visible, so hide the poster for the Android
@@ -955,6 +817,7 @@ export class VideoDocking {
     this.removePosterForAndroidBug_(element);
 
     const {x, y, scale, relativeX} = this.getDims_(video, target, step);
+
     video.hideControls();
 
     const transitionDurationMs = this.calculateTransitionDuration_(step);
@@ -999,7 +862,7 @@ export class VideoDocking {
   }
 
   /**
-   * @param  {!../../../src/video-interface.VideoOrBaseElementDef} video
+   * @param  {!VideoOrBaseElementDef} video
    * @return {boolean}
    * @private
    */
@@ -1026,29 +889,24 @@ export class VideoDocking {
   }
 
   /**
-   * @param {!AmpElement} element
-   * @param {?DockTargetDef=} target
+   * @param {!AmpElement|!VideoOrBaseElementDef} element
    * @return {number}
    * @private
    */
-  calculateIntersectionRatio_(element, target = null) {
-    if (target == null || !isElement(target)) {
-      return element.getIntersectionChangeEntry().intersectionRatio;
-    }
+  calculateIntersectionRatio_(element) {
+    const inlineRect = this.getScrollAdjustedRect_(element);
 
-    const layoutBox = element.getLayoutBox();
-    const {top, bottom, height} = layoutBox;
-    const {top: slotTop, bottom: slotBottom} = this.getSlot_().getLayoutBox();
-
-    if (!isSizedLayoutRect(layoutBox)) {
+    // If the component's box is way out of view, the runtime might have
+    // discarded its size values.
+    if (!isSizedRect(inlineRect)) {
       return 0;
     }
 
-    if (this.getSlotRelativeY_() == RelativeY.TOP) {
-      return (bottom - Math.max(top, slotTop)) / height;
-    } else {
-      return (slotBottom - top) / height;
-    }
+    const intersectionHeight =
+      Math.min(inlineRect.bottom, this.viewportRect_.bottom) -
+      Math.max(inlineRect.top, this.viewportRect_.top);
+
+    return Math.max(0, intersectionHeight / inlineRect.height);
   }
 
   /**
@@ -1082,7 +940,7 @@ export class VideoDocking {
   }
 
   /**
-   * @param {!../../../src/video-interface.VideoOrBaseElementDef} video
+   * @param {!VideoOrBaseElementDef} video
    * @param {number} x
    * @param {number} y
    * @param {number} scale
@@ -1245,7 +1103,7 @@ export class VideoDocking {
   }
 
   /**
-   * @param {!../../../src/video-interface.VideoOrBaseElementDef} video
+   * @param {!VideoOrBaseElementDef} video
    * @return {!Promise|undefined}
    * @private
    */
@@ -1255,7 +1113,7 @@ export class VideoDocking {
     }
 
     const {x, y, scale} = this.placedAt_;
-    const {top: fixedScrollTop} = this.getFixedLayoutBox_(video.element);
+    const {top: fixedScrollTop} = this.getScrollAdjustedRect_(video);
 
     if (y == fixedScrollTop) {
       return;
@@ -1280,7 +1138,7 @@ export class VideoDocking {
   }
 
   /**
-   * @param {!../../../src/video-interface.VideoOrBaseElementDef} video
+   * @param {!VideoOrBaseElementDef} video
    * @return {!Array<!Element>}
    * @private
    */
@@ -1293,12 +1151,12 @@ export class VideoDocking {
   }
 
   /**
-   * @param {!../../../src/video-interface.VideoOrBaseElementDef} video
+   * @param {!VideoOrBaseElementDef} video
    * @private
    */
   setPosterImage_(video) {
     const placeholderPoster = this.getPlaceholderRefs_()['poster'];
-    const posterSrc = this.getPosterImageSrc_(video.element);
+    const posterSrc = getPosterImageSrc(video.element);
 
     if (!posterSrc) {
       toggle(placeholderPoster, false);
@@ -1309,28 +1167,6 @@ export class VideoDocking {
     setStyles(placeholderPoster, {
       'background-image': `url(${posterSrc})`,
     });
-  }
-
-  /**
-   * @param {!Element} element
-   * @return {string|undefined}
-   * @private
-   */
-  getPosterImageSrc_(element) {
-    const attrs = ['poster', 'data-poster'];
-    for (let i = 0; i < attrs.length; i++) {
-      const attr = attrs[i];
-      if (element.hasAttribute(attr)) {
-        return element.getAttribute(attr);
-      }
-    }
-    const imgEl = scopedQuerySelector(
-      element,
-      'amp-img[placeholder],img[placeholder],[placeholder] amp-img'
-    );
-    if (imgEl) {
-      return imgEl.getAttribute('src');
-    }
   }
 
   /**
@@ -1351,7 +1187,7 @@ export class VideoDocking {
   }
 
   /**
-   * @param {!../../../src/video-interface.VideoOrBaseElementDef} video
+   * @param {!VideoOrBaseElementDef} video
    * @return {boolean}
    */
   isCurrentlyDocked_(video) {
@@ -1359,8 +1195,8 @@ export class VideoDocking {
   }
 
   /**
-   * @param {!../../../src/video-interface.VideoOrBaseElementDef} video
-   * @param {!DockTargetDef} target
+   * @param {!VideoOrBaseElementDef} video
+   * @param {!TargetDef} target
    * @param {number} step
    */
   setCurrentlyDocked_(video, target, step) {
@@ -1368,21 +1204,20 @@ export class VideoDocking {
     this.currentlyDocked_ = {video, target, step};
     if (
       previouslyDocked &&
-      targetsEqual(target, previouslyDocked.target) &&
-      previouslyDocked.video == video
+      previouslyDocked.video == video &&
+      layoutRectEquals(target.rect, previouslyDocked.target.rect)
     ) {
       return;
     }
-    this.getControls_().setVideo(video, this.getTargetArea_(video, target));
+    this.getControls_().setVideo(video, target.rect);
     this.trigger_(Actions.DOCK);
   }
 
   /**
    * @param {number} offsetX
-   * @param {number} offsetY
    * @private
    */
-  offset_(offsetX, offsetY) {
+  offsetX_(offsetX) {
     const video = this.getDockedVideo_();
     const {target} = this.currentlyDocked_;
 
@@ -1390,8 +1225,8 @@ export class VideoDocking {
     const transitionDurationMs = 0;
 
     const {x, y, scale} = this.getDims_(video, target, step);
-    const {centerX} = this.getCenter_(offsetX, offsetY);
-    const offsetRelativeX = this.calculateRelativeX_(centerX);
+    const centerX = this.getCenterX_(offsetX);
+    const directionX = this.calculateDirectionX_(centerX);
 
     this.dragVelocityX_ = offsetX - this.previousDragOffsetX_;
     this.previousDragOffsetX_ = offsetX;
@@ -1399,22 +1234,21 @@ export class VideoDocking {
     this.placeAt_(
       video,
       x + offsetX,
-      y + offsetY,
+      y,
       scale,
       step,
       transitionDurationMs,
-      offsetRelativeX
+      directionX
     );
   }
 
   /**
-   * @param {!AmpElement} element
+   * @param {!AmpElement|!VideoOrBaseElementDef} element
    * @param {number=} minRatio
    * @return {boolean}
    */
   isVisible_(element, minRatio = 1) {
-    const target = this.slotHasDimensions_() ? this.getSlot_() : null;
-    const intersectionRatio = this.calculateIntersectionRatio_(element, target);
+    const intersectionRatio = this.calculateIntersectionRatio_(element);
     return intersectionRatio > minRatio - FLOAT_TOLERANCE;
   }
 
@@ -1438,23 +1272,20 @@ export class VideoDocking {
       return;
     }
 
-    const {x: initialX, y: initialY} = pointerCoords(e);
+    this.dragOffsetX_ = 0;
 
-    const offset = {x: 0, y: 0};
-    const {posX: currentPosX, posY: currentPosY} = this.currentlyDocked_.target;
+    const {x} = pointerCoords(e);
+    const {directionX} = this.currentlyDocked_.target;
 
     const onDragMove = throttleByAnimationFrame(this.ampdoc_.win, e =>
       this.onDragMove_(
         /** @type {!TouchEvent|!MouseEvent} */ (e),
-        currentPosX,
-        currentPosY,
-        initialX,
-        initialY,
-        offset
+        directionX,
+        x
       )
     );
 
-    const onDragEnd = () => this.onDragEnd_(unlisteners, offset);
+    const onDragEnd = () => this.onDragEnd_(unlisteners);
 
     const root = this.ampdoc_.getRootNode();
     const unlisteners = [
@@ -1476,7 +1307,7 @@ export class VideoDocking {
     if (!this.currentlyDocked_) {
       return false;
     }
-    return isElement(this.currentlyDocked_.target);
+    return this.currentlyDocked_.target.type == TargetType.SLOT;
   }
 
   /**
@@ -1501,26 +1332,22 @@ export class VideoDocking {
 
   /**
    * @param {!MouseEvent|!TouchEvent} e
-   * @param {!RelativeX} startPosX
-   * @param {!RelativeY} startPosY
+   * @param {!RelativeX} directionX
    * @param {number} startX
-   * @param {number} startY
-   * @param {{x: number, y: number}} offset
    * @private
    */
-  onDragMove_(e, startPosX, startPosY, startX, startY, offset) {
-    const {posX, posY} = this.currentlyDocked_.target;
-    if (posX !== startPosX || posY !== startPosY) {
+  onDragMove_(e, directionX, startX) {
+    if (this.currentlyDocked_.target.directionX !== directionX) {
       // stale event
       return;
     }
 
-    offset.x = pointerCoords(e).x - startX;
-    offset.y = 0;
+    const offsetX = pointerCoords(e).x - startX;
+
+    this.dragOffsetX_ = offsetX;
 
     // Prevents dragging misfires.
-    const offsetDist = magnitude(offset.x, offset.y);
-    if (offsetDist <= 10) {
+    if (offsetX <= 10) {
       return;
     }
 
@@ -1530,7 +1357,7 @@ export class VideoDocking {
     this.getControls_().hide(/* respectSticky */ false, /* immediately */ true);
     this.isDragging_ = true;
     this.getControls_().disable();
-    this.offset_(offset.x, offset.y);
+    this.offsetX_(offsetX);
   }
 
   /**
@@ -1552,10 +1379,9 @@ export class VideoDocking {
 
   /**
    * @param {!Array<!UnlistenDef>} unlisteners
-   * @param {{x: number, y: number}} offset
    * @private
    */
-  onDragEnd_(unlisteners, offset) {
+  onDragEnd_(unlisteners) {
     unlisteners.forEach(unlisten => unlisten.call());
 
     this.isDragging_ = false;
@@ -1563,7 +1389,7 @@ export class VideoDocking {
     this.getControls_().enable();
 
     if (Math.abs(this.dragVelocityX_) < 40) {
-      this.snap_(offset.x, offset.y);
+      this.snap_(this.dragOffsetX_);
     } else {
       this.flickToDismiss_(
         this.previousDragOffsetX_,
@@ -1573,6 +1399,7 @@ export class VideoDocking {
 
     this.dragVelocityX_ = 0;
     this.previousDragOffsetX_ = 0;
+    this.dragOffsetX_ = 0;
   }
 
   /**
@@ -1587,20 +1414,21 @@ export class VideoDocking {
 
     video.pause();
 
-    if (this.isVisible_(video.element, 0.2)) {
+    if (this.isVisible_(video, 0.2)) {
       this.bounceToDismiss_(video, offsetX, direction);
       return;
     }
 
     const step = 1;
     const {target} = devAssert(this.currentlyDocked_);
-
-    const {x, y, width} = this.getTargetArea_(video, target);
+    const {x, y, width} = target.rect;
     const {scale} = this.getDims_(video, target, step);
 
     const currentX = x + offsetX;
     const nextX =
-      direction == 1 ? this.getRightEdge_() : this.getLeftEdge_() - width;
+      direction == 1
+        ? this.viewportRect_.right
+        : this.viewportRect_.left - width;
 
     const transitionDurationMs = this.calculateDismissalTransitionDurationMs_(
       nextX - currentX
@@ -1624,7 +1452,7 @@ export class VideoDocking {
   }
 
   /**
-   * @param {!../../../src/video-interface.VideoOrBaseElementDef} video
+   * @param {!VideoOrBaseElementDef} video
    * @param {number} offsetX
    * @param {number} direction -1 or 1
    * @private
@@ -1635,16 +1463,16 @@ export class VideoDocking {
     const step = 1;
     const {target} = devAssert(this.currentlyDocked_);
 
-    const {x, y, width} = this.getTargetArea_(video, target);
+    const {x, y, width} = target.rect;
     const {scale} = this.getDims_(video, target, step);
 
-    const areaWidth = this.getAreaWidth_();
+    const outerWidth = this.viewportRect_.width;
 
     const currentX = x + offsetX;
     const nextX =
       direction == 1
-        ? calculateRightJustifiedX(areaWidth, width, /* margin */ 0, step)
-        : calculateLeftJustifiedX(areaWidth, width, /* margin */ 0, step);
+        ? calculateRightJustifiedX(outerWidth, width, /* margin */ 0, step)
+        : calculateLeftJustifiedX(outerWidth, width, /* margin */ 0, step);
 
     const transitionDurationMs = this.calculateDismissalTransitionDurationMs_(
       nextX - currentX
@@ -1675,45 +1503,33 @@ export class VideoDocking {
   }
 
   /**
-   * Gets the center of the currently docked video, offset by (x, y).
+   * Gets the horizontal center of the currently docked video, offset by x.
    * @param {number} offsetX
-   * @param {number} offsetY
-   * @return {{centerX: number, centerY: number}}
+   * @return {number}
    * @private
    */
-  getCenter_(offsetX, offsetY) {
+  getCenterX_(offsetX) {
     const {target, step} = this.currentlyDocked_;
     const video = this.getDockedVideo_();
-    const {width, height} = video.getLayoutBox();
-    const {x, y, scale} = this.getDims_(video, target, step);
-
-    const centerX = x + offsetX + (width * scale) / 2;
-    const centerY = y + offsetY + (height * scale) / 2;
-
-    return {centerX, centerY};
+    const {width} = video.getLayoutBox();
+    const {x, scale} = this.getDims_(video, target, step);
+    return x + offsetX + (width * scale) / 2;
   }
 
   /**
    * @param {number} offsetX
-   * @param {number} offsetY
    * @private
    */
-  snap_(offsetX, offsetY) {
+  snap_(offsetX) {
     const video = this.getDockedVideo_();
     const {step} = this.currentlyDocked_;
 
-    const {centerX} = this.getCenter_(offsetX, offsetY);
-    const offsetRelativeX = this.calculateRelativeX_(centerX);
+    const directionX = this.calculateDirectionX_(offsetX);
+    this.cornerDirectionX_ = directionX;
 
-    const target = {
-      posX: offsetRelativeX,
-      // TODO(alanorozco): Reconsider if we have a need to bookkeep RelativeY.
-      posY: RelativeY.TOP,
-    };
+    const target = this.getUsableTarget_(video);
 
     this.currentlyDocked_.target = target;
-
-    this.preferredCornerX_ = offsetRelativeX;
 
     const {x, y, scale} = this.getDims_(video, target, step);
 
@@ -1724,134 +1540,43 @@ export class VideoDocking {
       scale,
       step,
       /* transitionDurationMs */ 200,
-      offsetRelativeX
+      directionX
     );
   }
 
   /**
-   * @param {number} centerX
+   * @param {number} offsetX
    * @return {!RelativeX}
    * @private
    */
-  calculateRelativeX_(centerX) {
-    return centerX >= this.getAreaWidth_() / 2
+  calculateDirectionX_(offsetX) {
+    return this.getCenterX_(offsetX) >= this.viewportRect_.width / 2
       ? RelativeX.RIGHT
       : RelativeX.LEFT;
   }
 
   /**
-   * @param {!../../../src/video-interface.VideoOrBaseElementDef} video
-   * @param {!DockTargetDef} target
-   * @return {!../../../src/layout-rect.LayoutRectDef}
-   * @private
-   */
-  getTargetArea_(video, target) {
-    return isElement(target)
-      ? this.getTargetAreaFromSlot_(video, dev().assertElement(target))
-      : this.getTargetAreaFromPos_(video, target.posX, target.posY);
-  }
-
-  /**
-   * @param {!../../../src/video-interface.VideoOrBaseElementDef} video
-   * @param {!RelativeX} posX
-   * @param {!RelativeY} posY
-   * @return {!../../../src/layout-rect.LayoutRectDef}
-   * @private
-   */
-  getTargetAreaFromPos_(video, posX, posY) {
-    const {width, height} = video.getLayoutBox();
-    const margin = this.getMargin_();
-    const aspectRatio = width / height;
-    const targetWidth = Math.max(
-      MIN_WIDTH,
-      this.getAreaWidth_() * DOCKED_TO_CORNER_SIZING_RATIO
-    );
-    const targetHeight = targetWidth / aspectRatio;
-
-    const x =
-      posX == RelativeX.RIGHT
-        ? this.getRightEdge_() - margin - targetWidth
-        : this.getLeftEdge_() + margin;
-
-    // TODO(alanorozco): Reconsider if y-axis logic for both sides is needed
-    // at all.
-    const y =
-      posY == RelativeY.TOP
-        ? this.getTopEdge_() + margin
-        : this.getBottomEdge_() - margin - targetHeight;
-
-    return layoutRectLtwh(x, y, targetWidth, targetHeight);
-  }
-
-  /**
-   * @param {!../../../src/video-interface.VideoOrBaseElementDef} video
-   * @param {!AmpElement} slot
-   * @return {!../../../src/layout-rect.LayoutRectDef}
-   * @private
-   */
-  getTargetAreaFromSlot_(video, slot) {
-    const {width: naturalWidth, height: naturalHeight} = video.getLayoutBox();
-
-    const {
-      width: slotWidth,
-      height: slotHeight,
-      top,
-      left,
-    } = this.getFixedLayoutBox_(slot);
-
-    const slotAspect = slotWidth / slotHeight;
-    const naturalAspect = naturalWidth / naturalHeight;
-
-    let x, y, scale;
-
-    if (naturalAspect > slotAspect) {
-      scale = slotWidth / naturalWidth;
-      y = top + slotHeight / 2 - (naturalHeight * scale) / 2;
-      x = left;
-    } else {
-      scale = slotHeight / naturalHeight;
-      x = left + slotWidth / 2 - (naturalWidth * scale) / 2;
-      y = top;
-    }
-
-    const targetWidth = naturalWidth * scale;
-    const targetHeight = naturalHeight * scale;
-
-    return layoutRectLtwh(x, y, targetWidth, targetHeight);
-  }
-
-  /**
-   * @param {!../../../src/video-interface.VideoOrBaseElementDef} video
-   * @param {!DockTargetDef} target
+   * @param {!VideoOrBaseElementDef} video
+   * @param {!TargetDef} target
    * @param {number} step in [0..1]
    * @return {{x: number, y: number, scale: number, relativeX: !RelativeX}}
    */
   getDims_(video, target, step) {
-    const {left, top, width} = this.getFixedLayoutBox_(video.element);
-    const {x, y, width: targetWidth} = this.getTargetArea_(video, target);
-    const relativeX = x < left ? RelativeX.LEFT : RelativeX.RIGHT;
-    const currentX = mapStep(step, left, x);
-    const currentWidth = mapStep(step, width, targetWidth);
-    const currentY = mapStep(step, top, y);
-    const scale = currentWidth / width;
-    const dims = {x: currentX, y: currentY, scale, relativeX};
-
-    dev().info(TAG, 'translated to dims', dims, ' @ step=', step);
-
-    return dims;
+    return interpolatedBoxesTransform(
+      this.getScrollAdjustedRect_(video),
+      target.rect,
+      step
+    );
   }
 
   /**
-   * @param {!../../../src/video-interface.VideoOrBaseElementDef} video
+   * @param {!VideoOrBaseElementDef} video
    * @param {boolean=} opt_reconciled
    * @return {!Promise}
    * @private
    */
   undock_(video, opt_reconciled) {
-    dev().info(TAG, 'undock', {video});
-
-    const {element} = video;
-    const isMostlyInView = this.isVisible_(element, REVERT_TO_INLINE_RATIO);
+    const isMostlyInView = this.isVisible_(video, REVERT_TO_INLINE_RATIO);
 
     if (!isMostlyInView) {
       video.pause();
@@ -1907,15 +1632,13 @@ export class VideoDocking {
   }
 
   /**
-   * @param {!../../../src/video-interface.VideoOrBaseElementDef} video
+   * @param {!VideoOrBaseElementDef} video
    * @return {!Promise}
    * @private
    */
   resetOnUndock_(video) {
     const {element} = video;
     const internalElement = getInternalVideoElementFor(element);
-
-    dev().info(TAG, 'resetOnUndock', {video});
 
     return video.mutateElement(() => {
       internalElement.classList.remove(BASE_CLASS_NAME);
@@ -1974,6 +1697,60 @@ export class VideoDocking {
       this.getDockedVideo_().element,
       'center'
     );
+  }
+
+  /**
+   * Returns usable target. If it can dock to a `slot` element that's larger
+   * than zero width/height, it calculates a letterboxed rectangle that matches
+   * the aspect ratio of the `video` but is contained within the slot's box.
+   * Otherwise returns a rectangle calculated relative to viewport and sticking
+   * to the horizontal `directionX`.
+   * @param {!AmpElement|!VideoOrBaseElementDef} video
+   * @return {!TargetDef}
+   * @private
+   */
+  getUsableTarget_(video) {
+    const slot = this.getUsableSlot_();
+    const inlineRect = video.getLayoutBox();
+
+    if (slot) {
+      return {
+        type: TargetType.SLOT,
+        rect: letterboxRect(inlineRect, slot.getPageLayoutBox()),
+      };
+    }
+
+    return {
+      type: TargetType.CORNER,
+      rect: topCornerRect(
+        inlineRect,
+        this.viewportRect_,
+        this.cornerDirectionX_,
+        CORNER_WIDTH_RATIO,
+        CORNER_WIDTH_MIN,
+        CORNER_MARGIN_RATIO,
+        CORNER_MARGIN_MAX
+      ),
+      // Bookkeep horizontal edge for drag-and-snap.
+      directionX: this.cornerDirectionX_,
+    };
+  }
+
+  /**
+   * @return {?Element}
+   * @private
+   */
+  getUsableSlot_() {
+    const slot = this.getSlot_();
+
+    // Slots are optional by configuration but also by visibility.
+    // If the slot element is hidden via media queries (`isVisibleBySize`),
+    // fallback to corner.
+    if (slot && isElement(slot) && isVisibleBySize(slot)) {
+      return slot;
+    }
+
+    return null;
   }
 }
 

--- a/extensions/amp-video-docking/0.1/amp-video-docking.js
+++ b/extensions/amp-video-docking/0.1/amp-video-docking.js
@@ -196,10 +196,8 @@ function complainAboutPortrait(element) {
  * @private
  */
 export function getPosterImageSrc(element) {
-  const attr = ['poster', 'data-poster'].reduce(
-    (existing, attr) => existing || element.getAttribute(attr),
-    null
-  );
+  const attr =
+    element.getAttribute('poster') || element.getAttribute('data-poster');
   if (attr) {
     return attr;
   }

--- a/extensions/amp-video-docking/0.1/amp-video-docking.js
+++ b/extensions/amp-video-docking/0.1/amp-video-docking.js
@@ -145,15 +145,6 @@ let DockedDef;
  */
 let DockTargetDef;
 
-// Function should ideally be in `dom.js`, but moving it causes a bunch of ads
-// tests to fail, for some reason.
-// TODO(alanorozco): Move.
-/**
- * @param {!Object} obj
- * @return {boolean}
- */
-export const isElement = obj => obj.nodeType == /* ELEMENT */ 1;
-
 /**
  * @param {number} x
  * @param {number} y
@@ -1720,7 +1711,7 @@ export class VideoDocking {
     // Slots are optional by configuration but also by visibility.
     // If the slot element is hidden via media queries (`isVisibleBySize`),
     // fallback to corner.
-    if (slot && isElement(slot) && isVisibleBySize(slot)) {
+    if (slot && isVisibleBySize(slot)) {
       return slot;
     }
 

--- a/extensions/amp-video-docking/0.1/def.js
+++ b/extensions/amp-video-docking/0.1/def.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/extensions/amp-video-docking/0.1/def.js
+++ b/extensions/amp-video-docking/0.1/def.js
@@ -15,10 +15,10 @@
  */
 
 /** @enum {string} */
-export const RelativeX = {LEFT: 'left', RIGHT: 'right'};
+export const DirectionX = {LEFT: 'left', RIGHT: 'right'};
 
 /** @enum {string} */
-export const RelativeY = {TOP: 'top', BOTTOM: 'bottom'};
+export const DirectionY = {TOP: 'top', BOTTOM: 'bottom'};
 
 /** A loose small decimal amount to compensate for rough float calculations. */
 export const FLOAT_TOLERANCE = 0.02;

--- a/extensions/amp-video-docking/0.1/def.js
+++ b/extensions/amp-video-docking/0.1/def.js
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** @enum {string} */
+export const RelativeX = {LEFT: 'left', RIGHT: 'right'};
+
+/** @enum {string} */
+export const RelativeY = {TOP: 'top', BOTTOM: 'bottom'};
+
+/** A loose small decimal amount to compensate for rough float calculations. */
+export const FLOAT_TOLERANCE = 0.02;

--- a/extensions/amp-video-docking/0.1/math.js
+++ b/extensions/amp-video-docking/0.1/math.js
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import {LayoutRectDef, layoutRectLtwh} from '../../../src/layout-rect';
+import {RelativeX} from './def';
+import {mapRange} from '../../../src/utils/math.js';
 
 /**
  * @param {number} containerWidth
@@ -61,3 +64,109 @@ export function calculateLeftJustifiedX(
 ) {
   return calculateJustified(containerWidth, itemWidth, itemMargin, -step);
 }
+
+/**
+ * Maps an interpolation step in [0..1] to its position in a range.
+ * @param {number} step
+ * @param {number} min
+ * @param {number} max
+ * @return {number}
+ */
+const mapStep = (step, min, max) => mapRange(step, 0, 1, min, max);
+
+/**
+ * Provides offset coords to interpolate `from` rect `to` rect.
+ * @param {!LayoutRectDef} from
+ * @param {!LayoutRectDef} to
+ * @param {number=} step  in [0..1]
+ * @return {{x: number, y: number, scale: number, relativeX: !RelativeX}}
+ *  - x is offset from the original box in pixels.
+ *  - y is offset from the original box in pixels.
+ *  - scale is the
+ */
+export function interpolatedBoxesTransform(from, to, step = 1) {
+  const relativeX = to.x < from.x ? RelativeX.LEFT : RelativeX.RIGHT;
+  const x = mapStep(step, from.x, to.x);
+  const y = mapStep(step, from.y, to.y);
+  const width = mapStep(step, from.width, to.width);
+  const scale = width / from.width;
+  return {x, y, scale, relativeX};
+}
+
+/**
+ * Scales, fits and centers `original` into `container`.
+ * @param {!LayoutRectDef} original
+ * @param {!LayoutRectDef} container
+ * @return {!LayoutRectDef}
+ */
+export function letterboxRect(original, container) {
+  const {width, height} = original;
+  const {top, left, width: maxWidth, height: maxHeight} = container;
+
+  const containerAspect = maxWidth / maxHeight;
+  const originalAspect = width / height;
+
+  let x, y, scale;
+
+  if (originalAspect > containerAspect) {
+    scale = maxWidth / width;
+    y = top + maxHeight / 2 - (height * scale) / 2;
+    x = left;
+  } else {
+    scale = maxHeight / height;
+    x = left + maxWidth / 2 - (width * scale) / 2;
+    y = top;
+  }
+
+  return layoutRectLtwh(x, y, width * scale, height * scale);
+}
+
+/**
+ * @param {!LayoutRectDef} original
+ * @param {!LayoutRectDef} container
+ * @param {RelativeX} horizontalEdge
+ * @param {number} widthRatio
+ * @param {number} widthMin
+ * @param {number} marginRatio
+ * @param {number} marginMax
+ * @return {!LayoutRectDef}
+ */
+export function topCornerRect(
+  original,
+  container,
+  horizontalEdge,
+  widthRatio,
+  widthMin,
+  marginRatio,
+  marginMax
+) {
+  const widthUnit = container.width;
+
+  const margin = Math.min(marginMax, marginRatio * widthUnit);
+  const aspect = original.width / original.height;
+
+  const width = Math.max(widthMin, widthUnit * widthRatio);
+  const height = width / aspect;
+
+  const x =
+    horizontalEdge == RelativeX.RIGHT
+      ? container.right - margin - width
+      : container.left + margin;
+
+  const y = margin;
+
+  return layoutRectLtwh(x, y, width, height);
+}
+
+/**
+ * @param {!AmpElement} element
+ * @return {boolean}
+ */
+export const isVisibleBySize = element =>
+  isSizedRect(element.getPageLayoutBox());
+
+/**
+ * @param {!LayoutRectDef|!ClientRect|!DOMRect} rect
+ * @return {boolean}
+ */
+export const isSizedRect = rect => rect.width > 0 && rect.height > 0;

--- a/extensions/amp-video-docking/0.1/math.js
+++ b/extensions/amp-video-docking/0.1/math.js
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import {DirectionX} from './def';
 import {LayoutRectDef, layoutRectLtwh} from '../../../src/layout-rect';
-import {RelativeX} from './def';
 import {mapRange} from '../../../src/utils/math.js';
 
 /**
@@ -79,13 +79,13 @@ const mapStep = (step, min, max) => mapRange(step, 0, 1, min, max);
  * @param {!LayoutRectDef} from
  * @param {!LayoutRectDef} to
  * @param {number=} step  in [0..1]
- * @return {{x: number, y: number, scale: number, relativeX: !RelativeX}}
+ * @return {{x: number, y: number, scale: number, relativeX: !DirectionX}}
  *  - x is offset from the original box in pixels.
  *  - y is offset from the original box in pixels.
  *  - scale is the
  */
 export function interpolatedBoxesTransform(from, to, step = 1) {
-  const relativeX = to.x < from.x ? RelativeX.LEFT : RelativeX.RIGHT;
+  const relativeX = to.x < from.x ? DirectionX.LEFT : DirectionX.RIGHT;
   const x = mapStep(step, from.x, to.x);
   const y = mapStep(step, from.y, to.y);
   const width = mapStep(step, from.width, to.width);
@@ -124,7 +124,7 @@ export function letterboxRect(original, container) {
 /**
  * @param {!LayoutRectDef} original
  * @param {!LayoutRectDef} container
- * @param {RelativeX} horizontalEdge
+ * @param {DirectionX} horizontalEdge
  * @param {number} widthRatio
  * @param {number} widthMin
  * @param {number} marginRatio
@@ -149,7 +149,7 @@ export function topCornerRect(
   const height = width / aspect;
 
   const x =
-    horizontalEdge == RelativeX.RIGHT
+    horizontalEdge == DirectionX.RIGHT
       ? container.right - margin - width
       : container.left + margin;
 

--- a/extensions/amp-video-docking/0.1/test/test-amp-video-docking.js
+++ b/extensions/amp-video-docking/0.1/test/test-amp-video-docking.js
@@ -17,7 +17,6 @@ import {
   Actions,
   BASE_CLASS_NAME,
   DOCKED_TO_CORNER_SIZING_RATIO,
-  Direction,
   MARGIN_AREA_WIDTH_PERC,
   MARGIN_MAX,
   MIN_WIDTH,
@@ -27,13 +26,15 @@ import {
   PLACEHOLDER_ICON_SMALL_MARGIN,
   PLACEHOLDER_ICON_SMALL_WIDTH,
   REVERT_TO_INLINE_RATIO,
-  RelativeX,
-  RelativeY,
+  TargetType,
   VideoDocking,
+  getPosterImageSrc,
 } from '../amp-video-docking';
 import {Deferred, tryResolve} from '../../../../src/utils/promise';
+import {DirectionX, DirectionY} from '../def.js';
 import {PlayingStates} from '../../../../src/video-interface';
 import {Services} from '../../../../src/services';
+import {createElementWithAttributes} from '../../../../src/dom';
 import {htmlFor} from '../../../../src/static-template';
 import {layoutRectLtwh} from '../../../../src/layout-rect';
 
@@ -52,8 +53,8 @@ describes.realWin('video docking', {amp: true}, env => {
 
   const viewportSize = {width: 0, height: 0};
 
-  function createAmpElementMock(tag = 'div') {
-    const element = env.win.document.createElement(tag);
+  function createAmpElementMock(tag = 'div', attrs = {}) {
+    const element = createElementWithAttributes(env.win.document, tag, attrs);
     const defaultLayoutRect = layoutRectLtwh(0, 0, 0, 0);
     Object.assign(element, {
       getIntersectionChangeEntry: noop,
@@ -91,13 +92,12 @@ describes.realWin('video docking', {amp: true}, env => {
     return video;
   }
 
-  function stubLayoutBox(impl, rect, ratio = 0) {
+  function stubLayoutBox(impl, rect) {
     impl.getLayoutBox = () => rect;
     impl.getPageLayoutBox = impl.getLayoutBox;
     impl.element.getLayoutBox = impl.getLayoutBox;
     impl.element.getPageLayoutBox = impl.getLayoutBox;
     impl.element.getIntersectionChangeEntry = () => ({
-      intersectionRatio: ratio,
       intersectionRect: rect,
     });
   }
@@ -113,7 +113,6 @@ describes.realWin('video docking', {amp: true}, env => {
 
   function mockAreaWidth(width) {
     viewportSize.width = width;
-    env.sandbox.stub(docking, 'getRightEdge_').returns(width);
     return width;
   }
 
@@ -123,12 +122,17 @@ describes.realWin('video docking', {amp: true}, env => {
 
   function mockAreaHeight(height) {
     viewportSize.height = height;
-    env.sandbox.stub(docking, 'getBottomEdge_').returns(height);
     return height;
   }
 
-  function placeElementLtwh(ampEl, left, top, width, height, ratio = 0) {
-    stubLayoutBox(ampEl, layoutRectLtwh(left, top, width, height), ratio);
+  function placeElementLtwh(ampEl, left, top, width, height) {
+    stubLayoutBox(ampEl, layoutRectLtwh(left, top, width, height));
+  }
+
+  function placeRatio(ampEl, width, height, ratio) {
+    const visibleHeight = ratio * height;
+    placeElementLtwh(ampEl, 0, visibleHeight - height, width, height);
+    mockAreaHeight(height);
   }
 
   function setScrollDirection(direction) {
@@ -311,12 +315,13 @@ describes.realWin('video docking', {amp: true}, env => {
       const expectedTransform = transformMatrix(x, y, scale);
 
       [internalElement, overlay, shadow].forEach(el => {
-        const computedStyle = getComputedStyle(el);
-        expect(computedStyle['transform']).to.equal(expectedTransform);
-        expect(computedStyle['width']).to.equal(width + 'px');
-        expect(computedStyle['min-width']).to.equal(width + 'px');
-        expect(computedStyle['height']).to.equal(height + 'px');
-        expect(computedStyle['min-height']).to.equal(height + 'px');
+        expect(getComputedStyle(el)).to.include({
+          'transform': expectedTransform,
+          'width': width + 'px',
+          'min-width': width + 'px',
+          'height': height + 'px',
+          'min-height': height + 'px',
+        });
       });
     });
 
@@ -326,7 +331,7 @@ describes.realWin('video docking', {amp: true}, env => {
       stubControls();
       enableComputedStyle(video.element);
 
-      env.sandbox.stub(docking, 'getPosterImageSrc_').returns(posterSrc);
+      video.element.setAttribute('poster', posterSrc);
 
       const x = 30;
       const y = 60;
@@ -464,7 +469,7 @@ describes.realWin('video docking', {amp: true}, env => {
           transitionDurationMs,
           // Expecting relative placement to apply icon styling but direction
           // is irrelevant in this case.
-          RelativeX.RIGHT
+          DirectionX.RIGHT
         );
 
         expect(
@@ -474,12 +479,12 @@ describes.realWin('video docking', {amp: true}, env => {
 
       [
         {
-          relativeX: RelativeX.RIGHT,
+          relativeX: DirectionX.RIGHT,
           relativeXTextual: 'right',
           expectedIconX: width - iconWidth - iconMargin * 2,
         },
         {
-          relativeX: RelativeX.LEFT,
+          relativeX: DirectionX.LEFT,
           relativeXTextual: 'left',
           expectedIconX: -width + iconWidth + iconMargin * 2,
         },
@@ -522,12 +527,12 @@ describes.realWin('video docking', {amp: true}, env => {
 
     [
       {
-        relativeX: RelativeX.RIGHT,
+        relativeX: DirectionX.RIGHT,
         directionTextual: 'left to right',
         hasAmpRtl: false,
       },
       {
-        relativeX: RelativeX.LEFT,
+        relativeX: DirectionX.LEFT,
         directionTextual: 'right to left',
         hasAmpRtl: true,
       },
@@ -584,7 +589,7 @@ describes.realWin('video docking', {amp: true}, env => {
     });
   });
 
-  describe('getPosterImageSrc_', () => {
+  describe('getPosterImageSrc', () => {
     let html;
     beforeEach(() => {
       html = htmlFor(env.win.document);
@@ -594,14 +599,14 @@ describes.realWin('video docking', {amp: true}, env => {
       const el = html`
         <amp-video poster="foo.png"></amp-video>
       `;
-      expect(docking.getPosterImageSrc_(el)).to.equal('foo.png');
+      expect(getPosterImageSrc(el)).to.equal('foo.png');
     });
 
     it('uses `data-poster` attr', () => {
       const el = html`
         <amp-video data-poster="foo.png"></amp-video>
       `;
-      expect(docking.getPosterImageSrc_(el)).to.equal('foo.png');
+      expect(getPosterImageSrc(el)).to.equal('foo.png');
     });
 
     it('uses `placeholder` amp-img', () => {
@@ -611,7 +616,7 @@ describes.realWin('video docking', {amp: true}, env => {
         </amp-video>
       `;
 
-      expect(docking.getPosterImageSrc_(el)).to.equal('foo.png');
+      expect(getPosterImageSrc(el)).to.equal('foo.png');
     });
 
     it('uses amp-img in a `placeholder`', () => {
@@ -623,7 +628,7 @@ describes.realWin('video docking', {amp: true}, env => {
         </amp-video>
       `;
 
-      expect(docking.getPosterImageSrc_(el)).to.equal('foo.png');
+      expect(getPosterImageSrc(el)).to.equal('foo.png');
     });
 
     it('uses `placeholder` img', () => {
@@ -633,7 +638,7 @@ describes.realWin('video docking', {amp: true}, env => {
         </amp-video>
       `;
 
-      expect(docking.getPosterImageSrc_(el)).to.equal('foo.png');
+      expect(getPosterImageSrc(el)).to.equal('foo.png');
     });
   });
 
@@ -654,56 +659,15 @@ describes.realWin('video docking', {amp: true}, env => {
     });
   });
 
-  describe('getTargetArea_', () => {
-    it('delegates for slot', () => {
-      const fromPos = env.sandbox
-        .stub(docking, 'getTargetAreaFromPos_')
-        .returns('foo');
-
-      const fromSlot = env.sandbox
-        .stub(docking, 'getTargetAreaFromSlot_')
-        .returns('bar');
-
-      const video = {};
-      const target = {nodeType: /* ELEMENT */ 1};
-
-      expect(docking.getTargetArea_(video, target)).to.equal('bar');
-
-      expect(fromPos).to.not.have.been.called;
-      expect(fromSlot.withArgs(video, target)).to.have.been.calledOnce;
-    });
-
-    it('delegates for corner', () => {
-      const fromPos = env.sandbox
-        .stub(docking, 'getTargetAreaFromPos_')
-        .returns('foo');
-
-      const fromSlot = env.sandbox
-        .stub(docking, 'getTargetAreaFromSlot_')
-        .returns('bar');
-
-      const posX = RelativeX.LEFT;
-      const posY = RelativeY.BOTTOM;
-
-      const video = {};
-      const target = {posX, posY};
-
-      expect(docking.getTargetArea_(video, target)).to.equal('foo');
-
-      expect(fromPos.withArgs(video, posX, posY)).to.have.been.calledOnce;
-      expect(fromSlot).to.not.have.been.called;
-    });
-  });
-
-  describe('getTargetAreaFromPos_', () => {
+  describe.skip('getTargetAreaFromPos_', () => {
     [
       {
-        posX: RelativeX.RIGHT,
+        posX: DirectionX.RIGHT,
         posXTextual: 'right',
         expectedXFn: (vw, margin, width) => vw - margin - width,
       },
       {
-        posX: RelativeX.LEFT,
+        posX: DirectionX.LEFT,
         posXTextual: 'left',
         expectedXFn: (unusedVw, margin, unusedWidth) => margin,
       },
@@ -733,7 +697,7 @@ describes.realWin('video docking', {amp: true}, env => {
         const {width, height} = docking.getTargetAreaFromPos_(
           video,
           posX,
-          RelativeY.TOP
+          DirectionY.TOP
         );
 
         expect(width, 'width').to.equal(expectedWidth);
@@ -755,7 +719,7 @@ describes.realWin('video docking', {amp: true}, env => {
 
         const expectedX = expectedXFn(vw, expectedMargin, expectedWidth);
 
-        const pos = docking.getTargetAreaFromPos_(video, posX, RelativeY.TOP);
+        const pos = docking.getTargetAreaFromPos_(video, posX, DirectionY.TOP);
 
         expect(pos.x, 'x').to.equal(expectedX);
         expect(pos.y, 'y').to.equal(expectedY);
@@ -776,7 +740,7 @@ describes.realWin('video docking', {amp: true}, env => {
 
         const expectedX = expectedXFn(vw, expectedMargin, expectedWidth);
 
-        const pos = docking.getTargetAreaFromPos_(video, posX, RelativeY.TOP);
+        const pos = docking.getTargetAreaFromPos_(video, posX, DirectionY.TOP);
 
         expect(pos.x, 'x').to.equal(expectedX);
         expect(pos.y, 'y').to.equal(expectedY);
@@ -784,7 +748,7 @@ describes.realWin('video docking', {amp: true}, env => {
     });
   });
 
-  describe('getTargetAreaFromSlot_', () => {
+  describe.skip('getTargetAreaFromSlot_', () => {
     it('returns valid dimensions for same aspect ratio as component', () => {
       const video = createVideo();
       const slot = createAmpElementMock('amp-layout');
@@ -926,19 +890,13 @@ describes.realWin('video docking', {amp: true}, env => {
     const targetWidth = 440;
     const targetHeight = 264;
 
-    const target = {};
-
-    let targetAreaStub;
+    const target = {
+      rect: layoutRectLtwh(targetX, targetY, targetWidth, targetHeight),
+    };
 
     beforeEach(() => {
       video = createVideo();
       placeElementLtwh(video, videoX, videoY, videoWidth, videoHeight);
-
-      targetAreaStub = env.sandbox.stub(docking, 'getTargetArea_');
-
-      targetAreaStub.returns(
-        layoutRectLtwh(targetX, targetY, targetWidth, targetHeight)
-      );
 
       env.sandbox.stub(docking.viewport_, 'getScrollTop').returns(scrollTop);
     });
@@ -963,13 +921,13 @@ describes.realWin('video docking', {amp: true}, env => {
 
     [
       {
-        expectedRelativeX: RelativeX.RIGHT,
+        expectedRelativeX: DirectionX.RIGHT,
         placementTextual: 'right',
         videoX: 0,
         targetX: 10,
       },
       {
-        expectedRelativeX: RelativeX.LEFT,
+        expectedRelativeX: DirectionX.LEFT,
         placementTextual: 'left',
         videoX: 10,
         targetX: 0,
@@ -983,8 +941,11 @@ describes.realWin('video docking', {amp: true}, env => {
 
           placeElementLtwh(video, videoX, videoY, videoWidth, videoHeight);
 
-          targetAreaStub.returns(
-            layoutRectLtwh(targetX, targetY, targetWidth, targetHeight)
+          target.rect = layoutRectLtwh(
+            targetX,
+            targetY,
+            targetWidth,
+            targetHeight
           );
 
           expect(docking.getDims_(video, target, step).relativeX).to.equal(
@@ -1002,12 +963,12 @@ describes.realWin('video docking', {amp: true}, env => {
 
     const target = {};
     const step = 1;
-    const targetDims = {x: 20, y: 10, scale: 0.5, relativeX: RelativeX.RIGHT};
+    const targetDims = {x: 20, y: 10, scale: 0.5, relativeX: DirectionX.RIGHT};
 
     beforeEach(() => {
       video = createVideo();
 
-      placeElementLtwh(video, 0, 0, 400, 300, /* ratio */ 1);
+      placeElementLtwh(video, 0, 0, 400, 300);
 
       setCurrentlyDocked = env.sandbox.stub(docking, 'setCurrentlyDocked_');
       placeAt = env.sandbox
@@ -1071,9 +1032,7 @@ describes.realWin('video docking', {amp: true}, env => {
 
   describe('setCurrentlyDocked_', () => {
     const video = {foo: 'bar'};
-    const target = {tacos: 'sí'};
-
-    const targetArea = layoutRectLtwh(0, 0, 50, 50);
+    const target = {rect: layoutRectLtwh(0, 0, 50, 50)};
 
     const step = 1;
 
@@ -1081,11 +1040,6 @@ describes.realWin('video docking', {amp: true}, env => {
 
     beforeEach(() => {
       trigger = env.sandbox.stub(docking, 'trigger_');
-
-      env.sandbox
-        .stub(docking, 'getTargetArea_')
-        .withArgs(video, target)
-        .returns(targetArea);
     });
 
     it('triggers action', () => {
@@ -1116,14 +1070,19 @@ describes.realWin('video docking', {amp: true}, env => {
       expect(trigger.withArgs(Actions.DOCK)).to.have.been.calledThrice;
     });
 
-    it('retriggers action when targets change', () => {
+    it('retriggers action when target rects change', () => {
       stubControls();
 
-      docking.setCurrentlyDocked_(video, target, step);
-      docking.setCurrentlyDocked_(video, {posX: 'a'}, step);
-      docking.setCurrentlyDocked_(video, {nodeType: /* ELEMENT */ 1}, step);
-      docking.setCurrentlyDocked_(video, {posX: 'b'}, step);
-      docking.setCurrentlyDocked_(video, {posX: 'b'}, step);
+      const a = {rect: layoutRectLtwh(1, 0, 0, 0)};
+      const b = {rect: layoutRectLtwh(2, 0, 0, 0)};
+      const c = {rect: layoutRectLtwh(3, 0, 0, 0)};
+      const d = {rect: layoutRectLtwh(4, 0, 0, 0)};
+
+      docking.setCurrentlyDocked_(video, a, step);
+      docking.setCurrentlyDocked_(video, b, step);
+      docking.setCurrentlyDocked_(video, c, step);
+      docking.setCurrentlyDocked_(video, d, step);
+      docking.setCurrentlyDocked_(video, d, step);
 
       expect(trigger.withArgs(Actions.DOCK).callCount).to.equal(4);
     });
@@ -1133,7 +1092,7 @@ describes.realWin('video docking', {amp: true}, env => {
 
       docking.setCurrentlyDocked_(video, target, step);
 
-      expect(setVideo.withArgs(video, targetArea)).to.have.been.calledOnce;
+      expect(setVideo.withArgs(video, target.rect)).to.have.been.calledOnce;
     });
   });
 
@@ -1144,12 +1103,12 @@ describes.realWin('video docking', {amp: true}, env => {
     let placeAt;
     let maybeUpdateStaleYAfterScroll;
 
-    const targetDims = {x: 20, y: 10, scale: 0.5, relativeX: RelativeX.RIGHT};
+    const targetDims = {x: 20, y: 10, scale: 0.5, relativeX: DirectionX.RIGHT};
 
     beforeEach(() => {
       video = createVideo();
 
-      placeElementLtwh(video, 0, 0, 400, 300, /* ratio */ 1);
+      placeElementLtwh(video, 0, 0, 400, 300);
 
       trigger = env.sandbox.stub(docking, 'trigger_');
       resetOnUndock = env.sandbox.stub(docking, 'resetOnUndock_');
@@ -1243,7 +1202,7 @@ describes.realWin('video docking', {amp: true}, env => {
     const inlinePercVis = `${REVERT_TO_INLINE_RATIO * 100}% visible`;
 
     it(`pauses video when < ${inlinePercVis}`, async () => {
-      placeElementLtwh(video, 0, 0, 400, 400, REVERT_TO_INLINE_RATIO - 0.1);
+      placeRatio(video, 400, 400, REVERT_TO_INLINE_RATIO - 0.1);
 
       await docking.undock_(video);
 
@@ -1251,7 +1210,7 @@ describes.realWin('video docking', {amp: true}, env => {
     });
 
     it(`doesn't pause video when >= ${inlinePercVis}`, async () => {
-      placeElementLtwh(video, 0, 0, 400, 400, REVERT_TO_INLINE_RATIO);
+      placeRatio(video, 400, 400, REVERT_TO_INLINE_RATIO);
 
       await docking.undock_(video);
 
@@ -1261,8 +1220,7 @@ describes.realWin('video docking', {amp: true}, env => {
     describe('Chrome freeze when out-of-view workaround', () => {
       it(`shows component controls early when < ${inlinePercVis}`, () => {
         const {promise, resolve} = new Deferred();
-
-        placeElementLtwh(video, 0, 0, 400, 400, REVERT_TO_INLINE_RATIO - 0.1);
+        placeRatio(video, 400, 400, REVERT_TO_INLINE_RATIO - 0.1);
 
         placeAt.returns(promise);
 
@@ -1276,7 +1234,7 @@ describes.realWin('video docking', {amp: true}, env => {
       });
 
       it(`shows component controls late when >= ${inlinePercVis}`, () => {
-        placeElementLtwh(video, 0, 0, 400, 400, REVERT_TO_INLINE_RATIO);
+        placeRatio(video, 400, 400, REVERT_TO_INLINE_RATIO);
 
         const {promise, resolve} = new Deferred();
 
@@ -1319,7 +1277,7 @@ describes.realWin('video docking', {amp: true}, env => {
           .stub(docking, 'calculateTransitionDuration_')
           .returns(expectedTransitionDurationMs);
 
-        placeElementLtwh(video, 0, 0, 400, 400, REVERT_TO_INLINE_RATIO);
+        placeRatio(video, 400, 400, REVERT_TO_INLINE_RATIO);
 
         await docking.undock_(video);
 
@@ -1381,14 +1339,15 @@ describes.realWin('video docking', {amp: true}, env => {
     (name, {useSlot, topBoundary}) => {
       const targetType = useSlot ? 'slot element' : 'corner';
 
-      function maybeCreateSlotElementLtwh(left, top, width, height, ratio = 0) {
+      function maybeCreateSlotElementLtwh(left, top, width, height) {
         if (!useSlot) {
           return;
         }
-        const impl = createAmpElementMock('amp-layout');
-        impl.element.id = slotId;
-        impl.element.setAttribute('layout', 'fill');
-        stubLayoutBox(impl, layoutRectLtwh(left, top, width, height), ratio);
+        const impl = createAmpElementMock('amp-layout', {
+          id: slotId,
+          layout: 'fill',
+        });
+        stubLayoutBox(impl, layoutRectLtwh(left, top, width, height));
         env.win.document.body.appendChild(impl.element);
 
         querySelectorStub.withArgs('#' + slotId).returns(impl.element);
@@ -1403,8 +1362,8 @@ describes.realWin('video docking', {amp: true}, env => {
       });
 
       describe('getTargetFor_', () => {
-        it(`should use a ${targetType} as target`, () => {
-          maybeCreateSlotElementLtwh(190, topBoundary, 200, 100);
+        it(`should use ${targetType} as target type`, () => {
+          maybeCreateSlotElementLtwh(190, topBoundary, 200, 150);
 
           const video = createVideo();
 
@@ -1413,7 +1372,7 @@ describes.realWin('video docking', {amp: true}, env => {
 
           placeElementLtwh(video, 0, -200, videoWidth, videoHeight);
 
-          setScrollDirection(Direction.UP);
+          setScrollDirection(DirectionY.TOP);
 
           setValidAreaWidth();
           setValidAreaHeight(videoHeight);
@@ -1421,15 +1380,13 @@ describes.realWin('video docking', {amp: true}, env => {
           const target = docking.getTargetFor_(video);
 
           expect(target).to.not.be.null;
+          expect(target.rect).to.not.be.null;
 
           if (useSlot) {
-            expect(target.nodeType).to.equal(/* ELEMENT */ 1);
-            expect(target.posX).to.be.undefined;
-            expect(target.posY).to.be.undefined;
+            expect(target.type).to.equal(TargetType.SLOT);
           } else {
-            expect(target.nodeType).to.be.undefined;
-            expect(target.posX).to.not.be.undefined;
-            expect(target.posY).to.not.be.undefined;
+            expect(target.type).to.equal(TargetType.CORNER);
+            expect(target.directionX).to.not.be.undefined;
           }
         });
       });
@@ -1446,7 +1403,7 @@ describes.realWin('video docking', {amp: true}, env => {
 
           placeElementLtwh(video, 0, -200, videoWidth, videoHeight);
 
-          setScrollDirection(Direction.UP);
+          setScrollDirection(DirectionY.TOP);
 
           mockInvalidAreaWidth();
           setValidAreaHeight(videoHeight);
@@ -1465,7 +1422,7 @@ describes.realWin('video docking', {amp: true}, env => {
           const videoWidth = 300;
           const videoHeight = 400;
 
-          setScrollDirection(Direction.UP);
+          setScrollDirection(DirectionY.TOP);
 
           setValidAreaWidth();
           setValidAreaHeight(videoHeight);
@@ -1488,7 +1445,7 @@ describes.realWin('video docking', {amp: true}, env => {
 
           placeElementLtwh(video, 0, -100, 0, 0);
 
-          setScrollDirection(Direction.UP);
+          setScrollDirection(DirectionY.TOP);
 
           setValidAreaWidth();
           setValidAreaHeight();
@@ -1510,7 +1467,7 @@ describes.realWin('video docking', {amp: true}, env => {
 
           docking.currentlyDocked_ = {video: createVideo()};
 
-          setScrollDirection(Direction.UP);
+          setScrollDirection(DirectionY.TOP);
 
           docking.updateOnPositionChange_(video);
 
@@ -1523,7 +1480,7 @@ describes.realWin('video docking', {amp: true}, env => {
           const dock = stubDockInTransferLayerStep();
           const video = createVideo();
 
-          setScrollDirection(Direction.UP);
+          setScrollDirection(DirectionY.TOP);
 
           const videoWidth = 400;
           const videoHeight = 300;
@@ -1531,16 +1488,7 @@ describes.realWin('video docking', {amp: true}, env => {
           setValidAreaWidth();
           setValidAreaHeight(videoHeight * 2);
 
-          placeElementLtwh(
-            video,
-            0,
-            -250,
-            videoWidth,
-            videoHeight,
-            /* ratio */ 1 / 3
-          );
-
-          env.sandbox.stub(docking, 'getTopEdge_').returns(topBoundary);
+          placeElementLtwh(video, 0, -250, videoWidth, videoHeight);
 
           docking.updateOnPositionChange_(video);
 
@@ -1558,7 +1506,7 @@ describes.realWin('video docking', {amp: true}, env => {
 
           setValidAreaWidth();
           setValidAreaHeight(videoHeight);
-          setScrollDirection(Direction.UP);
+          setScrollDirection(DirectionY.TOP);
           placeElementLtwh(video, 0, topBoundary + 1, videoWidth, videoHeight);
 
           docking.updateOnPositionChange_(video);
@@ -1574,11 +1522,15 @@ describes.realWin('video docking', {amp: true}, env => {
           const actions = {trigger: env.sandbox.spy()};
           env.sandbox.stub(Services, 'actionServiceForDoc').returns(actions);
 
-          const slot = maybeCreateSlotElementLtwh(0, 0, 0, 0);
+          const slot = maybeCreateSlotElementLtwh(23, 17, 100, 100);
           const video = createVideo();
           const action = '🌮';
 
-          docking.currentlyDocked_ = {video, target: slot || {}};
+          docking.currentlyDocked_ = {
+            video,
+            target: {type: useSlot ? TargetType.SLOT : TargetType.CORNER},
+          };
+
           docking.trigger_(action);
 
           expect(

--- a/extensions/amp-video-docking/0.1/test/test-amp-video-docking.js
+++ b/extensions/amp-video-docking/0.1/test/test-amp-video-docking.js
@@ -17,6 +17,7 @@ import {
   Actions,
   BASE_CLASS_NAME,
   DOCKED_TO_CORNER_SIZING_RATIO,
+  DockTargetType,
   MARGIN_AREA_WIDTH_PERC,
   MARGIN_MAX,
   MIN_WIDTH,
@@ -26,7 +27,6 @@ import {
   PLACEHOLDER_ICON_SMALL_MARGIN,
   PLACEHOLDER_ICON_SMALL_WIDTH,
   REVERT_TO_INLINE_RATIO,
-  TargetType,
   VideoDocking,
   getPosterImageSrc,
 } from '../amp-video-docking';
@@ -1337,7 +1337,7 @@ describes.realWin('video docking', {amp: true}, env => {
       },
     },
     (name, {useSlot, topBoundary}) => {
-      const targetType = useSlot ? 'slot element' : 'corner';
+      const DocktargetType = useSlot ? 'slot element' : 'corner';
 
       function maybeCreateSlotElementLtwh(left, top, width, height) {
         if (!useSlot) {
@@ -1362,7 +1362,7 @@ describes.realWin('video docking', {amp: true}, env => {
       });
 
       describe('getTargetFor_', () => {
-        it(`should use ${targetType} as target type`, () => {
+        it(`should use ${DocktargetType} as target type`, () => {
           maybeCreateSlotElementLtwh(190, topBoundary, 200, 150);
 
           const video = createVideo();
@@ -1383,9 +1383,9 @@ describes.realWin('video docking', {amp: true}, env => {
           expect(target.rect).to.not.be.null;
 
           if (useSlot) {
-            expect(target.type).to.equal(TargetType.SLOT);
+            expect(target.type).to.equal(DockTargetType.SLOT);
           } else {
-            expect(target.type).to.equal(TargetType.CORNER);
+            expect(target.type).to.equal(DockTargetType.CORNER);
             expect(target.directionX).to.not.be.undefined;
           }
         });
@@ -1528,7 +1528,9 @@ describes.realWin('video docking', {amp: true}, env => {
 
           docking.currentlyDocked_ = {
             video,
-            target: {type: useSlot ? TargetType.SLOT : TargetType.CORNER},
+            target: {
+              type: useSlot ? DockTargetType.SLOT : DockTargetType.CORNER,
+            },
           };
 
           docking.trigger_(action);

--- a/extensions/amp-video-docking/0.1/viewport-rect.js
+++ b/extensions/amp-video-docking/0.1/viewport-rect.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/extensions/amp-video-docking/0.1/viewport-rect.js
+++ b/extensions/amp-video-docking/0.1/viewport-rect.js
@@ -29,7 +29,7 @@ const readonlyGetterProp = get => ({
 /**
  * Returns a `LayoutRectDef`-like object whose values match the viewport's area
  * accoding to service.
- * @param {!../../../src/service/viewport/viewport-interface/ViewportInterface} viewport
+ * @param {!../../../src/service/viewport/viewport-interface.ViewportInterface} viewport
  * @return {!LayoutRectDef} with dynamic getters
  */
 export function createViewportRect(viewport) {

--- a/extensions/amp-video-docking/0.1/viewport-rect.js
+++ b/extensions/amp-video-docking/0.1/viewport-rect.js
@@ -36,10 +36,13 @@ export function createViewportRect(viewport) {
   const width = readonlyGetterProp(() => viewport.getSize().width);
   const height = readonlyGetterProp(() => viewport.getSize().height);
 
-  return Object.defineProperties(layoutRectLtwh(0, 0, 0, 0), {
-    width,
-    height,
-    right: width,
-    bottom: height,
-  });
+  return /** @type {!LayoutRectDef} */ (Object.defineProperties(
+    layoutRectLtwh(0, 0, 0, 0),
+    {
+      width,
+      height,
+      right: width,
+      bottom: height,
+    }
+  ));
 }

--- a/extensions/amp-video-docking/0.1/viewport-rect.js
+++ b/extensions/amp-video-docking/0.1/viewport-rect.js
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {LayoutRectDef, layoutRectLtwh} from '../../../src/layout-rect';
+import {ViewportInterface} from '../../../src/service/viewport/viewport-interface';
+
+/**
+ * @param {function():T} get
+ * @return {{get: function():T, configurable: boolean, enumerable: boolean}}
+ * @template T
+ */
+const readonlyGetterProp = get => ({
+  get,
+  configurable: false,
+  enumerable: true,
+});
+
+/**
+ * Returns a `LayoutRectDef`-like object whose values match the viewport's area
+ * accoding to service.
+ * @param {!ViewportInterface} viewport
+ * @return {!LayoutRectDef} with dynamic getters
+ */
+export function createViewportRect(viewport) {
+  const rect = layoutRectLtwh(0, 0, 0, 0);
+
+  Object.defineProperties(rect, {
+    right: readonlyGetterProp(() => rect.width),
+    bottom: readonlyGetterProp(() => rect.height),
+    width: readonlyGetterProp(() => viewport.getSize().width),
+    height: readonlyGetterProp(() => viewport.getSize().height),
+  });
+
+  return rect;
+}

--- a/extensions/amp-video-docking/0.1/viewport-rect.js
+++ b/extensions/amp-video-docking/0.1/viewport-rect.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 import {LayoutRectDef, layoutRectLtwh} from '../../../src/layout-rect';
-import {ViewportInterface} from '../../../src/service/viewport/viewport-interface';
 
 /**
  * @param {function():T} get
@@ -30,7 +29,7 @@ const readonlyGetterProp = get => ({
 /**
  * Returns a `LayoutRectDef`-like object whose values match the viewport's area
  * accoding to service.
- * @param {!ViewportInterface} viewport
+ * @param {!../../../src/service/viewport/viewport-interface/ViewportInterface} viewport
  * @return {!LayoutRectDef} with dynamic getters
  */
 export function createViewportRect(viewport) {

--- a/extensions/amp-video-docking/0.1/viewport-rect.js
+++ b/extensions/amp-video-docking/0.1/viewport-rect.js
@@ -33,14 +33,13 @@ const readonlyGetterProp = get => ({
  * @return {!LayoutRectDef} with dynamic getters
  */
 export function createViewportRect(viewport) {
-  const rect = layoutRectLtwh(0, 0, 0, 0);
+  const width = readonlyGetterProp(() => viewport.getSize().width);
+  const height = readonlyGetterProp(() => viewport.getSize().height);
 
-  Object.defineProperties(rect, {
-    right: readonlyGetterProp(() => rect.width),
-    bottom: readonlyGetterProp(() => rect.height),
-    width: readonlyGetterProp(() => viewport.getSize().width),
-    height: readonlyGetterProp(() => viewport.getSize().height),
+  return Object.defineProperties(layoutRectLtwh(0, 0, 0, 0), {
+    width,
+    height,
+    right: width,
+    bottom: height,
   });
-
-  return rect;
 }


### PR DESCRIPTION
- Simplifies types/style.
- Removes vertical axis edge logic (it was incomplete and not exposed to user.)
- Extracts utilities for conciseness (particularly in `math.js`).
- Consolidates element slot vs. dynamic corner behavior with a standard rectangle concept.