### PR TITLE
✨ Add 'feed' to allowed protocols for links

### DIFF
--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -1901,6 +1901,7 @@ tags: {
       protocol: "itms-services"
       protocol: "fb-me"
       protocol: "fb-messenger"
+      protocol: "feed"
       protocol: "intent"
       # Line messenger (https://media.line.me/howto/en/)
       protocol: "line"


### PR DESCRIPTION
I came across a WordPress theme that was using the [`feed` URI scheme](https://en.wikipedia.org/wiki/Feed_URI_scheme). The WordPress AMP plugin removed the link because this protocol is not allowed. However, I believe it should be. Clicking such `feed` links on Mac OS results in the Apple News app being opened:

![image](https://user-images.githubusercontent.com/134745/72475886-b9386f80-37a0-11ea-8fa9-5e030a17ece2.png)

Example:

```html
<a href="feed:https://weston.ruter.net/feed/">RSS</a>
```