### PR TITLE
📖 (wip) Add a visualization explaining the release schedule

### DIFF
--- a/contributing/release-schedule-accessible.amp.html
+++ b/contributing/release-schedule-accessible.amp.html
@@ -1,0 +1,185 @@
+<!doctype html>
+<html lang="en" ⚡>
+  <head>
+    <meta charset="utf-8">
+    <script async src="https://cdn.ampproject.org/v0.js"></script>
+    <script async custom-element="amp-bind" src="https://cdn.ampproject.org/v0/amp-bind-0.1.js"></script>
+    <title>AMP release schedule explainer (accessible)</title>
+    <link rel="canonical" href="release-schedule-explainer.amp.html">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Fira+Mono|Noto+Sans|Poppins">
+    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+    <style amp-custom>
+      body {
+        color: #000000;
+        font-family: "Noto Sans", sans-serif;
+        padding: 1em;
+      }
+      .header {
+        color: #005af0;
+        font-family: "Poppins", sans-serif;
+        font-weight: bold;
+      }
+      code {
+        font-family: "Fira Mono", monospace;
+        font-weight: medium;
+      }
+    </style>
+  </head>
+  <body>
+    <p>For a detailed description of the various release channels, see <a href="https://github.com/ampproject/amphtml/blob/master/contributing/release-schedule.md">release-schedule.md</a>.</p>
+
+    <amp-state id="codeToChannels">
+      <script type="application/json">
+        {
+          "Sunday": {
+            "nightly": "the following day",
+            "opt-in": "Tuesday the following week",
+            "beta": "Wednesday the following week",
+            "stable": "Tuesday two weeks later",
+            "lts": "the 2nd Monday the following month"
+          },
+          "Monday": {
+            "nightly": "the following day",
+            "opt-in": "Tuesday the following week",
+            "beta": "Wednesday the following week",
+            "stable": "Tuesday two weeks later",
+            "lts": "the 2nd Monday the following month"
+          },
+          "Tuesday": {
+            "nightly": "the following day",
+            "opt-in": "Tuesday the following week",
+            "beta": "Wednesday the following week",
+            "stable": "Tuesday two weeks later",
+            "lts": "the 2nd Monday the following month"
+          },
+          "Wednesday": {
+            "nightly": "the following day",
+            "opt-in": "Tuesday the following week",
+            "beta": "Wednesday the following week",
+            "stable": "Tuesday two weeks later",
+            "lts": "the 2nd Monday the following month"
+          },
+          "Thursday": {
+            "nightly": "the following day",
+            "opt-in": "Tuesday the following week",
+            "beta": "Wednesday the following week",
+            "stable": "Tuesday two weeks later",
+            "lts": "the 2nd Monday the following month"
+          },
+          "Friday": {
+            "nightly": "Monday the following week",
+            "opt-in": "Tuesday two weeks later",
+            "beta": "Wednesday two weeks later",
+            "stable": "Tuesday three weeks later",
+            "lts": "the 2nd Monday the following month"
+          },
+          "Saturday": {
+            "nightly": "Monday the following week",
+            "opt-in": "Tuesday two weeks later",
+            "beta": "Wednesday two weeks later",
+            "stable": "Tuesday three weeks later",
+            "lts": "the 2nd Monday the following month"
+          }
+        }
+      </script>
+    </amp-state>
+    <amp-state id="channelToCode">
+      <script type="application/json">
+        {
+          "Sunday": {
+            "lts": "last Thursday of the previous month",
+            "stable": "Thursday three weeks prior",
+            "opt-in-beta": "Thursday two weeks prior",
+            "nightly": "Thursday the week before"
+          },
+          "Monday": {
+            "lts": "last Thursday of the previous month",
+            "stable": "Thursday three weeks prior",
+            "opt-in-beta": "Thursday two weeks prior",
+            "nightly": "the day before"
+          },
+          "Tuesday": {
+            "lts": "last Thursday of the previous month",
+            "stable": "Thursday three weeks prior",
+            "beta": "Thursday two weeks prior",
+            "opt-in": "Thursday the week before",
+            "nightly": "the day before"
+          },
+          "Wednesday": {
+            "lts": "last Thursday of the previous month",
+            "stable": "Thursday two weeks prior",
+            "opt-in-beta": "Thursday the week before",
+            "nightly": "the day before"
+          },
+          "Thursday": {
+            "lts": "last Thursday of the previous month",
+            "stable": "Thursday two weeks prior",
+            "opt-in-beta": "Thursday the week before",
+            "nightly": "the day before"
+          },
+          "Friday": {
+            "lts": "last Thursday of the previous month",
+            "stable": "Thursday two weeks prior",
+            "opt-in-beta": "Thursday the week before",
+            "nightly": "the day before"
+          },
+          "Saturday": {
+            "lts": "last Thursday of the previous month",
+            "stable": "Thursday two weeks prior",
+            "opt-in-beta": "Thursday the week before",
+            "nightly": "Thursday two days prior"
+          }
+        }
+      </script>
+    </amp-state>
+
+    <div>
+      <label for="codeToChannelsSelect">
+        Code merged on
+        <select id="codeToChannelsSelect" on="change:AMP.setState({code: event.value})">
+          <option value=""></option>
+          <option value="Sunday">Sunday</option>
+          <option value="Monday">Monday</option>
+          <option value="Tuesday">Tuesday</option>
+          <option value="Wednesday">Wednesday</option>
+          <option value="Thursday">Thursday</option>
+          <option value="Friday">Friday</option>
+          <option value="Saturday">Saturday</option>
+        </select>
+        will be available on:
+      </label>
+      <ul hidden [hidden]="!code">
+        <li>the <code>nightly</code> channel on <span [text]="codeToChannels[code]['nightly']"></span>,</li>
+        <li>the <code>opt-in</code> channel on <span [text]="codeToChannels[code]['opt-in']"></span>,</li>
+        <li>the <code>beta</code> and <code>experimental</code> channels on <span [text]="codeToChannels[code]['beta']"></span>,</li>
+        <li>the <code>stable</code> channel on <span [text]="codeToChannels[code]['stable']"></span>,</li>
+        <li>and the <code>lts</code> channel on <span [text]="codeToChannels[code]['lts']"></span>.</li>
+      </ul>
+    </div>
+
+    <div>
+      <label for="channelToCodeSelect">
+        Select a day to learn when the code was merged to have arrive on each channel
+        <select id="channelToCodeSelect" on="change:AMP.setState({channel: event.value})">
+          <option value=""></option>
+          <option value="Sunday">Sunday</option>
+          <option value="Monday">Monday</option>
+          <option value="Tuesday">Tuesday</option>
+          <option value="Wednesday">Wednesday</option>
+          <option value="Thursday">Thursday</option>
+          <option value="Friday">Friday</option>
+          <option value="Saturday">Saturday</option>
+        </select>
+      </label>
+      <ul hidden [hidden]="!channel">
+        <li>code for the <code>nightly</code> channel was merged on <span [text]="channelToCode[channel]['nightly']"></span>,</li>
+        <li [hidden]="!channelToCode[channel]['opt-in']">code for the <code>opt-in</code> channel was merged on <span [text]="channelToCode[channel]['opt-in']"></span>,</li>
+        <li [hidden]="!channelToCode[channel]['beta']">code for the <code>beta</code> and <code>experimental</code> channel was merged on <span [text]="channelToCode[channel]['beta']"></span>,</li>
+        <li [hidden]="!channelToCode[channel]['opt-in-beta']">code for the <code>opt-in</code>, <code>beta</code>, and <code>experimental</code> channels was merged on <span [text]="channelToCode[channel]['opt-in-beta']"></span>,</li>
+        <li>code for the <code>stable</code> channel was merged on <span [text]="channelToCode[channel]['stable']"></span>,</li>
+        <li>and code for the <code>lts</code> channel was merged on <span [text]="channelToCode[channel]['lts']"></span>.</li>
+      </ul>
+    </div>
+  </body>
+</html>

--- a/contributing/release-schedule-accessible.amp.html
+++ b/contributing/release-schedule-accessible.amp.html
@@ -27,7 +27,7 @@
     </style>
   </head>
   <body>
-    <p>For a detailed description of the various release channels, see <a href="https://github.com/ampproject/amphtml/blob/master/contributing/release-schedule.md">release-schedule.md</a>.</p>
+    <p>For a detailed description of the various release channels, see <a href="https://github.com/ampproject/amphtml/blob/master/contributing/release-schedule.md">release-schedule.md</a>. There is also a <a href="release-schedule-visual.amp.html">visual</a> (not screen-reader accessible) version of this page.</p>
 
     <amp-state id="codeToChannels">
       <script type="application/json">

--- a/contributing/release-schedule-visual.amp.html
+++ b/contributing/release-schedule-visual.amp.html
@@ -15,6 +15,15 @@
         font-family: "Noto Sans", sans-serif;
         padding: 1em;
       }
+      body .touch-only {
+        display: none;
+      }
+      body.amp-mode-touch .touch-only {
+        display: unset;
+      }
+      body.amp-mode-touch .no-touch-only {
+        display: none;
+      }
       #calendar {
         display: grid;
         gap: 10px;
@@ -165,8 +174,8 @@
         <div class="box header">Saturday</div>
         <div class="box header">Sunday</div>
 
-        <div class="box instructions week-1-instructions" data-week="1">Hover/tap on days above to see when the code merged on that day will be available on each release channel</div>
-        <div class="box instructions week-5-instructions" data-week="5">Hover/tap on days below to see when the latest code merge occurred so as to be included in each release channel</div>
+        <div class="box instructions week-1-instructions" data-week="1"><span class="touch-only">Tap</span><span class="no-touch-only">Hover</span> on days above to see when the code merged on that day will be available on each release channel</div>
+        <div class="box instructions week-5-instructions" data-week="5"><span class="touch-only">Tap</span><span class="no-touch-only">Hover</span> on days below to see when the latest code merge occurred so as to be included in each release channel</div>
 
         <div class="box sidebar week-1" data-week="1">
           <span class="top">N</span>

--- a/contributing/release-schedule-visual.amp.html
+++ b/contributing/release-schedule-visual.amp.html
@@ -128,7 +128,7 @@
           grid-template-rows: auto 100px auto auto 100px 100px 100px auto 100px;
         }
         .box {
-          font-size: small;
+          font-size: x-small;
           padding: 4px;
         }
       }
@@ -143,12 +143,14 @@
           grid-template-rows: auto 75px auto auto 75px 75px 75px auto 75px;
         }
         .box {
-          font-size: x-small;
+          font-size: xx-small;
         }
         .content span {
           font-size: 0;
-          word-break: break-word;
           hyphens: auto;
+          margin-top: 3px;
+          word-break: break-word;
+          writing-mode: vertical-rl;
         }
         .content span code {
           font-size: xx-small;

--- a/contributing/release-schedule-visual.amp.html
+++ b/contributing/release-schedule-visual.amp.html
@@ -310,7 +310,7 @@
             'lts': ['1', 'thursday'],
             'stable': ['2', 'thursday'],
             'opt-in-beta': ['3', 'thursday'],
-            'nightly': ['4', 'thursday'],
+            'nightly': ['4', 'sunday'],
           },
           'tuesday': {
             'lts': ['1', 'thursday'],

--- a/contributing/release-schedule-visual.amp.html
+++ b/contributing/release-schedule-visual.amp.html
@@ -213,7 +213,7 @@
 
         <div class="box sidebar week-1" data-week="1">
           <span class="top">N</span>
-          <span class="bottom">2<sup>nd</sup> Monday of the month, before <code>stable</code></span>
+          <span class="bottom">Last week of the previous month</span>
         </div>
         <div class="box sidebar week-2" data-week="2">
           <span class="top">N+1</span>
@@ -228,7 +228,7 @@
           <span class="bottom">N-1</span>
         </div>
         <div class="box sidebar week-5" data-week="5">
-          <span class="top">2<sup>nd</sup> Monday next month</span>
+          <span class="top">2<sup>nd</sup> week of the next month</span>
           <span class="bottom">N</span>
         </div>
 

--- a/contributing/release-schedule-visual.amp.html
+++ b/contributing/release-schedule-visual.amp.html
@@ -6,11 +6,13 @@
     <script async custom-element="amp-script" src="https://cdn.ampproject.org/v0/amp-script-0.1.js"></script>
     <title>AMP release schedule visualization</title>
     <link rel="canonical" href="release-schedule-visual.amp.html">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Fira+Mono|Noto+Sans|Poppins">
     <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
     <meta name="amp-script-src" content="sha384-CbfxNqnGzHYSDCrfBfpjwZu12Iy2L1YRXVmZLSVXpE4N4nS2YwMlGMMEglUiRC8f">
     <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
     <style amp-custom>
       body {
+        font-family: "Noto Sans", sans-serif;
         padding: 1em;
       }
       #calendar {
@@ -20,27 +22,28 @@
         grid-auto-flow: dense;
       }
       #calendar[data-direction="top"] {
-        grid-template-rows: 1fr 150px 1fr 150px 150px 150px 1fr 1fr 150px;
+        grid-template-rows: auto 150px auto 150px 150px 150px auto auto 150px;
       }
       #calendar[data-direction="bottom"] {
-        grid-template-rows: 1fr 150px 1fr 1fr 150px 150px 150px 1fr 150px;
+        grid-template-rows: auto 150px auto auto 150px 150px 150px auto 150px;
       }
       [data-direction="top"] .bottom,
       [data-direction="bottom"] .top {
         display: none;
       }
       .box {
+        border-radius: .25em;
         padding: 1em;
         text-align: center;
-        transition: all .15s ease-in-out;
       }
       .header {
-        font-weight: bold;
         grid-row: 1 / 2;
       }
       .instructions {
-        background-color: wheat;
+        background-image: linear-gradient(225deg, #f1f068 0%, #2db932 75%);
+        border-radius: .5em;
         grid-column: 1 / 9;
+        padding: .5em;
       }
       .week-1-instructions {
         grid-row: 3 / 4;
@@ -49,9 +52,11 @@
         grid-row: 8 / 9;
       }
       .sidebar {
-        font-weight: bold;
-        font-size: smaller;
+        font-size: x-small;
         grid-column: 1 / 2;
+      }
+      .ellipsis {
+        font-size: x-small;
       }
       [data-direction="top"] .ellipsis {
         grid-row: 7 / 8;
@@ -59,8 +64,17 @@
       [data-direction="bottom"] .ellipsis {
         grid-row: 4 / 5;
       }
+      .header,
+      .sidebar,
+      .ellipsis {
+        font-weight: bold;
+        color: #005af0;
+        font-family: "Poppins", sans-serif;
+      }
       .content {
         border: 1px dotted silver;
+        color: #ffffff;
+        font-size: small;
       }
       .content.week-1,
       .content.week-5 {
@@ -68,34 +82,31 @@
       }
       .content.week-1:hover,
       .content.week-5:hover {
+        background-image: linear-gradient(225deg, #fff300 0%, #ff8f00 75%);
+        color: #000000;
         cursor: pointer;
-        background-color: red;
       }
       .nightly {
-        background-color: orange;
+        background-image: linear-gradient(225deg, #00dcc0 0%, #34c2cb 75%);
       }
       .opt-in {
-        background-color: yellow;
+        background-image: linear-gradient(225deg, #34c2cb 0%, #3fa8d5 75%);
       }
       .beta {
-        background-color: green;
-        color: white;
+        background-image: linear-gradient(225deg, #3fa8d5 0%, #3d8edf 75%);
       }
       .opt-in-beta {
-        background-image: linear-gradient(135deg, yellow 25%, green 25%, green 50%, yellow 50%, yellow 75%, green 75%, green 100%);
-        background-size: 30px 30px;
-        color: white;
-      }
-      .opt-in-beta span {
-        background-color: #00000099;
+        background-image: linear-gradient(225deg, #34c2cb 0%, #3d8edf 75%);
       }
       .stable {
-        background-color: blue;
-        color: white;
+        background-image: linear-gradient(225deg, #3d8edf 0%, #3174e7 75%);
       }
       .lts {
-        background-color: purple;
-        color: white;
+        background-image: linear-gradient(225deg, #3174e7 0%, #005af0 75%);
+      }
+      code {
+        font-family: "Fira Mono", monospace;
+        font-weight: medium;
       }
       @media (max-width: 1023px) {
         #calendar {
@@ -103,16 +114,14 @@
           grid-template-columns: 4em repeat(7, 1fr);
         }
         #calendar[data-direction="top"] {
-          grid-template-rows: 1fr 100px 1fr 100px 100px 100px 1fr 1fr 100px;
+          grid-template-rows: auto 100px auto 100px 100px 100px auto auto 100px;
         }
         #calendar[data-direction="bottom"] {
-          grid-template-rows: 1fr 100px 1fr 1fr 100px 100px 100px 1fr 100px;
+          grid-template-rows: auto 100px auto auto 100px 100px 100px auto 100px;
         }
         .box {
-          padding: 4px;
-        }
-        .content {
           font-size: small;
+          padding: 4px;
         }
       }
       @media (max-width: 757px) {
@@ -120,10 +129,13 @@
           gap: 2px;
         }
         #calendar[data-direction="top"] {
-          grid-template-rows: 1fr 75px 1fr 75px 75px 75px 1fr 1fr 75px;
+          grid-template-rows: auto 75px auto 75px 75px 75px auto auto 75px;
         }
         #calendar[data-direction="bottom"] {
-          grid-template-rows: 1fr 75px 1fr 1fr 75px 75px 75px 1fr 75px;
+          grid-template-rows: auto 75px auto auto 75px 75px 75px auto 75px;
+        }
+        .box {
+          font-size: x-small;
         }
         .content span {
           font-size: 0;
@@ -131,13 +143,13 @@
           hyphens: auto;
         }
         .content span code {
-          font-size: x-small;
+          font-size: xx-small;
         }
         .header {
           font-size: 0;
         }
         .header::first-letter {
-          font-size: medium;
+          font-size: small;
         }
       }
     </style>

--- a/contributing/release-schedule-visual.amp.html
+++ b/contributing/release-schedule-visual.amp.html
@@ -29,12 +29,8 @@
         gap: 10px;
         grid-template-columns: 5em repeat(7, 7.5em);
         grid-auto-flow: dense;
-      }
-      #calendar[data-direction="top"] {
-        grid-template-rows: auto 150px auto 150px 150px 150px auto auto 150px;
-      }
-      #calendar[data-direction="bottom"] {
-        grid-template-rows: auto 150px auto auto 150px 150px 150px auto 150px;
+        grid-template-rows: auto 150px auto auto 150px 150px 150px auto auto 150px;
+        transition: all .2s ease-in-out;
       }
       [data-direction="top"] .bottom,
       [data-direction="bottom"] .top {
@@ -46,20 +42,41 @@
         padding: 1em;
         text-align: center;
       }
-      .header {
-        grid-row: 1 / 2;
-      }
       .instructions {
         background-image: linear-gradient(225deg, #00dcc0 0%, #1db395 75%);
         border-radius: .5em;
         grid-column: 1 / 9;
         padding: .5em;
       }
+      .header {
+        grid-row: 1 / 2;
+      }
+      .week-1 {
+        grid-row: 2 / 3;
+      }
       .week-1-instructions {
         grid-row: 3 / 4;
       }
-      .week-5-instructions {
+      .ellipsis-top {
+        grid-row: 4 / 5;
+      }
+      .week-2 {
+        grid-row: 5 / 6;
+      }
+      .week-3 {
+        grid-row: 6 / 7;
+      }
+      .week-4 {
+        grid-row: 7 / 8;
+      }
+      .ellipsis-bottom {
         grid-row: 8 / 9;
+      }
+      .week-5-instructions {
+        grid-row: 9 / 10;
+      }
+      .week-5 {
+        grid-row: 10 / 11;
       }
       .sidebar {
         font-size: small;
@@ -67,12 +84,15 @@
       }
       .ellipsis {
         font-size: x-small;
+        height: 1em;
+        overflow: hidden;
+        transition: all .4s ease-in-out;
       }
-      [data-direction="top"] .ellipsis {
-        grid-row: 7 / 8;
-      }
-      [data-direction="bottom"] .ellipsis {
-        grid-row: 4 / 5;
+      [data-direction="top"] .ellipsis-top,
+      [data-direction="bottom"] .ellipsis-bottom {
+        height: 0;
+        opacity: 0;
+        padding: 0;
       }
       .header,
       .sidebar,
@@ -120,12 +140,7 @@
         #calendar {
           gap: 5px;
           grid-template-columns: 4em repeat(7, 1fr);
-        }
-        #calendar[data-direction="top"] {
-          grid-template-rows: auto 100px auto 100px 100px 100px auto auto 100px;
-        }
-        #calendar[data-direction="bottom"] {
-          grid-template-rows: auto 100px auto auto 100px 100px 100px auto 100px;
+          grid-template-rows: auto 100px auto auto 100px 100px 100px auto auto 100px;
         }
         .box {
           font-size: x-small;
@@ -135,12 +150,7 @@
       @media (max-width: 757px) {
         #calendar {
           gap: 2px;
-        }
-        #calendar[data-direction="top"] {
-          grid-template-rows: auto 75px auto 75px 75px 75px auto auto 75px;
-        }
-        #calendar[data-direction="bottom"] {
-          grid-template-rows: auto 75px auto auto 75px 75px 75px auto 75px;
+          grid-template-rows: auto 75px auto auto 75px 75px 75px auto auto 75px;
         }
         .box {
           font-size: xx-small;
@@ -200,15 +210,25 @@
           <span class="bottom">N</span>
         </div>
 
-        <div class="box sidebar ellipsis">⋮</div>
+        <div class="box sidebar ellipsis ellipsis-top">⋮</div>
 
-        <div class="box ellipsis">⋮</div>
-        <div class="box ellipsis">⋮</div>
-        <div class="box ellipsis">⋮</div>
-        <div class="box ellipsis">⋮</div>
-        <div class="box ellipsis">⋮</div>
-        <div class="box ellipsis">⋮</div>
-        <div class="box ellipsis">⋮</div>
+        <div class="box ellipsis ellipsis-top">⋮</div>
+        <div class="box ellipsis ellipsis-top">⋮</div>
+        <div class="box ellipsis ellipsis-top">⋮</div>
+        <div class="box ellipsis ellipsis-top">⋮</div>
+        <div class="box ellipsis ellipsis-top">⋮</div>
+        <div class="box ellipsis ellipsis-top">⋮</div>
+        <div class="box ellipsis ellipsis-top">⋮</div>
+
+        <div class="box sidebar ellipsis ellipsis-bottom">⋮</div>
+
+        <div class="box ellipsis ellipsis-bottom">⋮</div>
+        <div class="box ellipsis ellipsis-bottom">⋮</div>
+        <div class="box ellipsis ellipsis-bottom">⋮</div>
+        <div class="box ellipsis ellipsis-bottom">⋮</div>
+        <div class="box ellipsis ellipsis-bottom">⋮</div>
+        <div class="box ellipsis ellipsis-bottom">⋮</div>
+        <div class="box ellipsis ellipsis-bottom">⋮</div>
 
         <div class="box content week-1 day-sunday" data-week="1" data-day="sunday"></div>
         <div class="box content week-1 day-monday" data-week="1" data-day="monday"></div>

--- a/contributing/release-schedule-visual.amp.html
+++ b/contributing/release-schedule-visual.amp.html
@@ -32,7 +32,7 @@
         grid-template-rows: auto 150px auto auto 150px 150px 150px auto auto 150px;
         transition: all .2s ease-in-out;
       }
-      @-webkit-keyframes background-flash {
+      @keyframes background-flash {
         0% {
           background-color: inherit;
         }

--- a/contributing/release-schedule-visual.amp.html
+++ b/contributing/release-schedule-visual.amp.html
@@ -195,6 +195,8 @@
     </style>
   </head>
   <body>
+    <p>For a detailed description of the various release channels, see <a href="https://github.com/ampproject/amphtml/blob/master/contributing/release-schedule.md">release-schedule.md</a>.</p>
+
     <amp-script layout="intrinsic" width="1050" height="0" script="calendar-script">
       <div id="calendar" data-direction="initialized">
         <div class="box header">Week</div>

--- a/contributing/release-schedule-visual.amp.html
+++ b/contributing/release-schedule-visual.amp.html
@@ -195,7 +195,7 @@
     </style>
   </head>
   <body>
-    <p>For a detailed description of the various release channels, see <a href="https://github.com/ampproject/amphtml/blob/master/contributing/release-schedule.md">release-schedule.md</a>.</p>
+    <p>For a detailed description of the various release channels, see <a href="https://github.com/ampproject/amphtml/blob/master/contributing/release-schedule.md">release-schedule.md</a>. There is also a <a href="release-schedule-accessible.amp.html">screen-reader accessible</a> version of this page.</p>
 
     <amp-script layout="intrinsic" width="1050" height="0" script="calendar-script">
       <div id="calendar" data-direction="initialized">

--- a/contributing/release-schedule-visual.amp.html
+++ b/contributing/release-schedule-visual.amp.html
@@ -8,7 +8,7 @@
     <link rel="canonical" href="release-schedule-visual.amp.html">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Fira+Mono|Noto+Sans|Poppins">
     <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
-    <meta name="amp-script-src" content="sha384-CbfxNqnGzHYSDCrfBfpjwZu12Iy2L1YRXVmZLSVXpE4N4nS2YwMlGMMEglUiRC8f">
+    <meta name="amp-script-src" content="sha384-nUTQObN6e9PL3jOH7VL1HiyQFnry3RPNDg4BEmJYCBuzkzz36tBPxin7e6iK_fJn">
     <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
     <style amp-custom>
       body {
@@ -429,11 +429,15 @@
           event.currentTarget.textContent = descriptions[selectedWeek].selected;
           for (let [channel, [channelWeek, channelDay]] of Object.entries(channels[selectedWeek][selectedDay])) {
             const channelElm = document.querySelectorAll('.content')
-            .filter(
-                elm => elm.getAttribute('data-week') === channelWeek
-                && elm.getAttribute('data-day') === channelDay
-            )[0];
-            
+              .filter(
+                  elm => elm.getAttribute('data-week') === channelWeek
+                  && elm.getAttribute('data-day') === channelDay
+              )[0];
+
+            while (channelElm.firstChild) {
+              channelElm.firstChild.remove();
+            }
+
             const {prefix, suffix} = descriptions[selectedWeek][channel];
             channelElm.appendChild(createSpan(prefix, channel, suffix));
             channelElm.classList.add(channel);
@@ -446,7 +450,7 @@
             document.querySelectorAll(`.${channel}`).forEach(elm => {
               elm.classList.remove(channel);
               while (elm.firstChild) {
-                elm.removeChild(elm.firstChild);
+                elm.firstChild.remove();
               }
             });
           }

--- a/contributing/release-schedule-visual.amp.html
+++ b/contributing/release-schedule-visual.amp.html
@@ -32,7 +32,26 @@
         grid-template-rows: auto 150px auto auto 150px 150px 150px auto auto 150px;
         transition: all .2s ease-in-out;
       }
+      @-webkit-keyframes background-flash {
+        0% {
+          background-color: inherit;
+        }
+        25% {
+          background-color: #ffff00;
+        }
+        75% {
+          background-color: #ffff00;
+        }
+        100% {
+          background-color: inherit;
+        }
+      }
+      [data-direction="top"] .top,
+      [data-direction="bottom"] .bottom {
+        animation: background-flash .5s linear;
+      }
       [data-direction="top"] .bottom,
+      [data-direction="initialized"] .bottom,
       [data-direction="bottom"] .top {
         display: none;
       }
@@ -88,6 +107,7 @@
         overflow: hidden;
         transition: all .4s ease-in-out;
       }
+      [data-direction="initialized"] .ellipsis-top,
       [data-direction="top"] .ellipsis-top,
       [data-direction="bottom"] .ellipsis-bottom {
         height: 0;
@@ -176,7 +196,7 @@
   </head>
   <body>
     <amp-script layout="intrinsic" width="1050" height="0" script="calendar-script">
-      <div id="calendar" data-direction="top">
+      <div id="calendar" data-direction="initialized">
         <div class="box header">Week</div>
         <div class="box header day-sunday">Sunday</div>
         <div class="box header day-monday">Monday</div>

--- a/contributing/release-schedule-visual.amp.html
+++ b/contributing/release-schedule-visual.amp.html
@@ -33,6 +33,7 @@
       }
       .box {
         border-radius: .25em;
+        color: #000000;
         padding: 1em;
         text-align: center;
       }
@@ -40,7 +41,7 @@
         grid-row: 1 / 2;
       }
       .instructions {
-        background-image: linear-gradient(225deg, #f1f068 0%, #2db932 75%);
+        background-image: linear-gradient(225deg, #00dcc0 0%, #1db395 75%);
         border-radius: .5em;
         grid-column: 1 / 9;
         padding: .5em;
@@ -72,8 +73,7 @@
         font-family: "Poppins", sans-serif;
       }
       .content {
-        border: 1px dotted silver;
-        color: #ffffff;
+        border: 1px dotted #cccccc;
         font-size: small;
       }
       .content.week-1,
@@ -82,27 +82,26 @@
       }
       .content.week-1:hover,
       .content.week-5:hover {
-        background-image: linear-gradient(225deg, #fff300 0%, #ff8f00 75%);
-        color: #000000;
+        background-image: linear-gradient(225deg, #ff52e1 0%, #eb49e1 75%);
         cursor: pointer;
       }
       .nightly {
-        background-image: linear-gradient(225deg, #00dcc0 0%, #34c2cb 75%);
+        background-image: linear-gradient(225deg, #21c1fa 0%, #25b4ed 75%);
       }
       .opt-in {
-        background-image: linear-gradient(225deg, #34c2cb 0%, #3fa8d5 75%);
+        background-image: linear-gradient(225deg, #25b4ed 0%, #27a6e0 75%);
       }
       .beta {
-        background-image: linear-gradient(225deg, #3fa8d5 0%, #3d8edf 75%);
+        background-image: linear-gradient(225deg, #27a6e0 0%, #2899d3 75%);
       }
       .opt-in-beta {
-        background-image: linear-gradient(225deg, #34c2cb 0%, #3d8edf 75%);
+        background-image: linear-gradient(225deg, #25b4ed 0%, #2899d3 75%);
       }
       .stable {
-        background-image: linear-gradient(225deg, #3d8edf 0%, #3174e7 75%);
+        background-image: linear-gradient(225deg, #2899d3 0%, #298dc6 75%);
       }
       .lts {
-        background-image: linear-gradient(225deg, #3174e7 0%, #005af0 75%);
+        background-image: linear-gradient(225deg, #298dc6 0%, #2980b9 75%);
       }
       code {
         font-family: "Fira Mono", monospace;

--- a/contributing/release-schedule-visual.amp.html
+++ b/contributing/release-schedule-visual.amp.html
@@ -62,7 +62,7 @@
         grid-row: 8 / 9;
       }
       .sidebar {
-        font-size: x-small;
+        font-size: small;
         grid-column: 1 / 2;
       }
       .ellipsis {

--- a/contributing/release-schedule-visual.amp.html
+++ b/contributing/release-schedule-visual.amp.html
@@ -1,0 +1,435 @@
+<!doctype html>
+<html lang="en" ⚡>
+  <head>
+    <meta charset="utf-8">
+    <script async src="https://cdn.ampproject.org/v0.js"></script>
+    <script async custom-element="amp-script" src="https://cdn.ampproject.org/v0/amp-script-0.1.js"></script>
+    <title>AMP release schedule visualization</title>
+    <link rel="canonical" href="release-schedule-visual.amp.html">
+    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+    <meta name="amp-script-src" content="sha384-CbfxNqnGzHYSDCrfBfpjwZu12Iy2L1YRXVmZLSVXpE4N4nS2YwMlGMMEglUiRC8f">
+    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+    <style amp-custom>
+      body {
+        padding: 1em;
+      }
+      #calendar {
+        display: grid;
+        gap: 10px;
+        grid-template-columns: 5em repeat(7, 7.5em);
+        grid-auto-flow: dense;
+      }
+      #calendar[data-direction="top"] {
+        grid-template-rows: 1fr 150px 1fr 150px 150px 150px 1fr 1fr 150px;
+      }
+      #calendar[data-direction="bottom"] {
+        grid-template-rows: 1fr 150px 1fr 1fr 150px 150px 150px 1fr 150px;
+      }
+      [data-direction="top"] .bottom,
+      [data-direction="bottom"] .top {
+        display: none;
+      }
+      .box {
+        padding: 1em;
+        text-align: center;
+        transition: all .15s ease-in-out;
+      }
+      .header {
+        font-weight: bold;
+        grid-row: 1 / 2;
+      }
+      .instructions {
+        background-color: wheat;
+        grid-column: 1 / 9;
+      }
+      .week-1-instructions {
+        grid-row: 3 / 4;
+      }
+      .week-5-instructions {
+        grid-row: 8 / 9;
+      }
+      .sidebar {
+        font-weight: bold;
+        font-size: smaller;
+        grid-column: 1 / 2;
+      }
+      [data-direction="top"] .ellipsis {
+        grid-row: 7 / 8;
+      }
+      [data-direction="bottom"] .ellipsis {
+        grid-row: 4 / 5;
+      }
+      .content {
+        border: 1px dotted silver;
+      }
+      .content.week-1,
+      .content.week-5 {
+        border-style: solid;
+      }
+      .content.week-1:hover,
+      .content.week-5:hover {
+        cursor: pointer;
+        background-color: red;
+      }
+      .nightly {
+        background-color: orange;
+      }
+      .opt-in {
+        background-color: yellow;
+      }
+      .beta {
+        background-color: green;
+        color: white;
+      }
+      .opt-in-beta {
+        background-image: linear-gradient(135deg, yellow 25%, green 25%, green 50%, yellow 50%, yellow 75%, green 75%, green 100%);
+        background-size: 30px 30px;
+        color: white;
+      }
+      .opt-in-beta span {
+        background-color: #00000099;
+      }
+      .stable {
+        background-color: blue;
+        color: white;
+      }
+      .lts {
+        background-color: purple;
+        color: white;
+      }
+      @media (max-width: 1023px) {
+        #calendar {
+          gap: 5px;
+          grid-template-columns: 4em repeat(7, 1fr);
+        }
+        #calendar[data-direction="top"] {
+          grid-template-rows: 1fr 100px 1fr 100px 100px 100px 1fr 1fr 100px;
+        }
+        #calendar[data-direction="bottom"] {
+          grid-template-rows: 1fr 100px 1fr 1fr 100px 100px 100px 1fr 100px;
+        }
+        .box {
+          padding: 4px;
+        }
+        .content {
+          font-size: small;
+        }
+      }
+      @media (max-width: 757px) {
+        #calendar {
+          gap: 2px;
+        }
+        #calendar[data-direction="top"] {
+          grid-template-rows: 1fr 75px 1fr 75px 75px 75px 1fr 1fr 75px;
+        }
+        #calendar[data-direction="bottom"] {
+          grid-template-rows: 1fr 75px 1fr 1fr 75px 75px 75px 1fr 75px;
+        }
+        .content span {
+          font-size: 0;
+          word-break: break-word;
+          hyphens: auto;
+        }
+        .content span code {
+          font-size: x-small;
+        }
+        .header {
+          font-size: 0;
+        }
+        .header::first-letter {
+          font-size: medium;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <amp-script layout="intrinsic" width="1050" height="0" script="calendar-script">    
+      <div id="calendar" data-direction="top">
+        <div class="box header">Week</div>
+        <div class="box header">Monday</div>
+        <div class="box header">Tuesday</div>
+        <div class="box header">Wednesday</div>
+        <div class="box header">Thursday</div>
+        <div class="box header">Friday</div>
+        <div class="box header">Saturday</div>
+        <div class="box header">Sunday</div>
+
+        <div class="box instructions week-1-instructions" data-week="1">Hover/tap on days in the first week to see how code flows into release channels…</div>
+        <div class="box instructions week-5-instructions" data-week="5">Hover/tap on days in the first week to see how code flows into release channels…</div>
+
+        <div class="box sidebar week-1" data-week="1">
+          <span class="top">N</span>
+          <span class="bottom">1<sup>st</sup> Monday of the month, before <code>stable</code></span>
+        </div>
+        <div class="box sidebar week-2" data-week="2">
+          <span class="top">N+1</span>
+          <span class="bottom">N-3</span>
+        </div>
+        <div class="box sidebar week-3" data-week="3">
+          <span class="top">N+2</span>
+          <span class="bottom">N-2</span>
+        </div>
+        <div class="box sidebar week-4" data-week="4">
+          <span class="top">N+3</span>
+          <span class="bottom">N-1</span>
+        </div>
+        <div class="box sidebar week-5" data-week="5">
+          <span class="top">1<sup>st</sup> Monday next month</span>
+          <span class="bottom">N</span>
+        </div>
+
+        <div class="box sidebar ellipsis">⋮</div>
+
+        <div class="box ellipsis">⋮</div>
+        <div class="box ellipsis">⋮</div>
+        <div class="box ellipsis">⋮</div>
+        <div class="box ellipsis">⋮</div>
+        <div class="box ellipsis">⋮</div>
+        <div class="box ellipsis">⋮</div>
+        <div class="box ellipsis">⋮</div>
+
+        <div class="box content week-1 day-monday" data-week="1" data-day="monday"></div>
+        <div class="box content week-1 day-tuesday" data-week="1" data-day="tuesday"></div>
+        <div class="box content week-1 day-wednesday" data-week="1" data-day="wednesday"></div>
+        <div class="box content week-1 day-thursday" data-week="1" data-day="thursday"></div>
+        <div class="box content week-1 day-friday" data-week="1" data-day="friday"></div>
+        <div class="box content week-1 day-saturday" data-week="1" data-day="saturday"></div>
+        <div class="box content week-1 day-sunday" data-week="1" data-day="sunday"></div>
+
+        <div class="box content week-2 day-monday" data-week="2" data-day="monday"></div>
+        <div class="box content week-2 day-tuesday" data-week="2" data-day="tuesday"></div>
+        <div class="box content week-2 day-wednesday" data-week="2" data-day="wednesday"></div>
+        <div class="box content week-2 day-thursday" data-week="2" data-day="thursday"></div>
+        <div class="box content week-2 day-friday" data-week="2" data-day="friday"></div>
+        <div class="box content week-2 day-saturday" data-week="2" data-day="saturday"></div>
+        <div class="box content week-2 day-sunday" data-week="2" data-day="sunday"></div>
+
+        <div class="box content week-3 day-monday" data-week="3" data-day="monday"></div>
+        <div class="box content week-3 day-tuesday" data-week="3" data-day="tuesday"></div>
+        <div class="box content week-3 day-wednesday" data-week="3" data-day="wednesday"></div>
+        <div class="box content week-3 day-thursday" data-week="3" data-day="thursday"></div>
+        <div class="box content week-3 day-friday" data-week="3" data-day="friday"></div>
+        <div class="box content week-3 day-saturday" data-week="3" data-day="saturday"></div>
+        <div class="box content week-3 day-sunday" data-week="3" data-day="sunday"></div>
+
+        <div class="box content week-4 day-monday" data-week="4" data-day="monday"></div>
+        <div class="box content week-4 day-tuesday" data-week="4" data-day="tuesday"></div>
+        <div class="box content week-4 day-wednesday" data-week="4" data-day="wednesday"></div>
+        <div class="box content week-4 day-thursday" data-week="4" data-day="thursday"></div>
+        <div class="box content week-4 day-friday" data-week="4" data-day="friday"></div>
+        <div class="box content week-4 day-saturday" data-week="4" data-day="saturday"></div>
+        <div class="box content week-4 day-sunday" data-week="4" data-day="sunday"></div>
+
+        <div class="box content week-5 day-monday" data-week="5" data-day="monday"></div>
+        <div class="box content week-5 day-tuesday" data-week="5" data-day="tuesday"></div>
+        <div class="box content week-5 day-wednesday" data-week="5" data-day="wednesday"></div>
+        <div class="box content week-5 day-thursday" data-week="5" data-day="thursday"></div>
+        <div class="box content week-5 day-friday" data-week="5" data-day="friday"></div>
+        <div class="box content week-5 day-saturday" data-week="5" data-day="saturday"></div>
+        <div class="box content week-5 day-sunday" data-week="5" data-day="sunday"></div>
+      </div>
+    </amp-script>
+
+    <script id="calendar-script" type="text/plain" target="amp-script">
+      const channels = {
+        '1': {
+          'monday': {
+            'nightly': ['1', 'tuesday'],
+            'opt-in': ['2', 'tuesday'],
+            'beta': ['2', 'wednesday'],
+            'stable': ['3', 'tuesday'],
+            'lts': ['5', 'monday'],
+          },
+          'tuesday': {
+            'nightly': ['1', 'wednesday'],
+            'opt-in': ['2', 'tuesday'],
+            'beta': ['2', 'wednesday'],
+            'stable': ['3', 'tuesday'],
+            'lts': ['5', 'monday'],
+          },
+          'wednesday': {
+            'nightly': ['1', 'thursday'],
+            'opt-in': ['2', 'tuesday'],
+            'beta': ['2', 'wednesday'],
+            'stable': ['3', 'tuesday'],
+            'lts': ['5', 'monday'],
+          },
+          'thursday': {
+            'nightly': ['1', 'friday'],
+            'opt-in': ['2', 'tuesday'],
+            'beta': ['2', 'wednesday'],
+            'stable': ['3', 'tuesday'],
+            'lts': ['5', 'monday'],
+          },
+          'friday': {
+            'nightly': ['2', 'monday'],
+            'opt-in': ['3', 'tuesday'],
+            'beta': ['3', 'wednesday'],
+            'stable': ['4', 'tuesday'],
+            'lts': ['5', 'monday'],
+          },
+          'saturday': {
+            'nightly': ['2', 'monday'],
+            'opt-in': ['3', 'tuesday'],
+            'beta': ['3', 'wednesday'],
+            'stable': ['4', 'tuesday'],
+            'lts': ['5', 'monday'],
+          },
+          'sunday': {
+            'nightly': ['2', 'monday'],
+            'opt-in': ['3', 'tuesday'],
+            'beta': ['3', 'wednesday'],
+            'stable': ['4', 'tuesday'],
+            'lts': ['5', 'monday'],
+          },
+        },
+        '5': {
+          'monday': {
+            'lts': ['1', 'thursday'],
+            'stable': ['2', 'thursday'],
+            'opt-in-beta': ['3', 'thursday'],
+            'nightly': ['4', 'thursday'],
+          },
+          'tuesday': {
+            'lts': ['1', 'thursday'],
+            'stable': ['2', 'thursday'],
+            'beta': ['3', 'thursday'],
+            'opt-in': ['4', 'thursday'],
+            'nightly': ['5', 'monday'],
+          },
+          'wednesday': {
+            'lts': ['1', 'thursday'],
+            'stable': ['3', 'thursday'],
+            'opt-in-beta': ['4', 'thursday'],
+            'nightly': ['5', 'tuesday'],
+          },
+          'thursday': {
+            'lts': ['1', 'thursday'],
+            'stable': ['3', 'thursday'],
+            'opt-in-beta': ['4', 'thursday'],
+            'nightly': ['5', 'wednesday'],
+          },
+          'friday': {
+            'lts': ['1', 'thursday'],
+            'stable': ['3', 'thursday'],
+            'opt-in-beta': ['4', 'thursday'],
+            'nightly': ['5', 'thursday'],
+          },
+          'saturday': {
+            'lts': ['1', 'thursday'],
+            'stable': ['3', 'thursday'],
+            'opt-in-beta': ['4', 'thursday'],
+            'nightly': ['5', 'thursday'],
+          },
+          'sunday': {
+            'lts': ['1', 'thursday'],
+            'stable': ['3', 'thursday'],
+            'opt-in-beta': ['4', 'thursday'],
+            'nightly': ['5', 'thursday'],
+          },
+        },
+      };
+
+      const descriptions = {
+        '1': {
+          'selected': 'Code merged on this day…',
+          'nightly': {
+            prefix: '…is available on the',
+            suffix: 'on this day,',
+          },
+          'opt-in': {
+            prefix: 'for',
+            suffix: 'to experimental / beta on this day,',
+          },
+          'beta': {
+            prefix: 'on 1% traffic experimental / ',
+            suffix: 'on this day,',
+          },
+          'stable': {
+            prefix: 'on',
+            suffix: 'on this day,',
+          },
+          'lts': {
+            prefix: 'and as',
+            suffix: 'on this day.',
+          },
+        },
+        '5': {
+          'selected': '…on the selected day',
+          'lts': {
+            prefix: 'code merged on this day is available as',
+            suffix: '…'
+          },
+          'stable': {
+            prefix: 'code merged on this day is available as',
+            suffix: '…'
+          },
+          'beta': {
+            prefix: 'code merged on this day is available as experimental /',
+            suffix: '…'
+          },
+          'opt-in-beta': {
+            prefix: 'code merged on this day is available for both',
+            suffix: '…'
+          },
+          'opt-in': {
+            prefix: 'code merged on this day is available as',
+            suffix: '…'
+          },
+          'nightly': {
+            prefix: 'code merged on this day is available as',
+            suffix: '…'
+          },
+        }
+      }
+
+      function createSpan(prefix, channel, suffix) {
+        const span = document.createElement('span');
+        const prefixElm = document.createTextNode(`${prefix} `);
+        const channelElm = document.createElement('code');
+        channelElm.textContent = channel;
+        const suffixElm = document.createTextNode(` ${suffix}`);
+        [prefixElm, channelElm, suffixElm].forEach(elm => {
+          span.appendChild(elm)
+        });
+        return span;
+      };
+
+      document.querySelectorAll('.content')
+      .filter(elm => elm.classList.contains('week-1') || elm.classList.contains('week-5'))
+      .forEach(elm => {
+        elm.addEventListener('mouseenter', event => {
+          const selectedWeek = elm.getAttribute('data-week');
+          const selectedDay = elm.getAttribute('data-day');
+          document.querySelector('#calendar')
+            .setAttribute('data-direction', selectedWeek == '1' ? 'top' : 'bottom');
+
+          event.currentTarget.textContent = descriptions[selectedWeek].selected;
+          for (let [channel, [channelWeek, channelDay]] of Object.entries(channels[selectedWeek][selectedDay])) {
+            const channelElm = document.querySelectorAll('.content')
+            .filter(
+                elm => elm.getAttribute('data-week') === channelWeek
+                && elm.getAttribute('data-day') === channelDay
+            )[0];
+            
+            const {prefix, suffix} = descriptions[selectedWeek][channel];
+            channelElm.appendChild(createSpan(prefix, channel, suffix));
+            channelElm.classList.add(channel);
+          }
+        });
+
+        elm.addEventListener('mouseleave', event => {
+          event.currentTarget.textContent = '';
+          for (const channel of ['nightly', 'opt-in', 'beta', 'opt-in-beta', 'stable', 'lts']) {
+            document.querySelectorAll(`.${channel}`).forEach(elm => {
+              elm.classList.remove(channel);
+              while (elm.firstChild) {
+                elm.removeChild(elm.firstChild);
+              }
+            });
+          }
+        });
+      });
+    </script>
+  </body>
+</html>

--- a/contributing/release-schedule-visual.amp.html
+++ b/contributing/release-schedule-visual.amp.html
@@ -167,7 +167,7 @@
         <div class="box header">Sunday</div>
 
         <div class="box instructions week-1-instructions" data-week="1">Hover/tap on days above to see when the code merged on that day will be available on each release channel</div>
-        <div class="box instructions week-5-instructions" data-week="5">Hover/tap on days below to see when was the latest code merge that is included in each release channel</div>
+        <div class="box instructions week-5-instructions" data-week="5">Hover/tap on days below to see when the latest code merge occurred so as to be included in each release channel</div>
 
         <div class="box sidebar week-1" data-week="1">
           <span class="top">N</span>

--- a/contributing/release-schedule-visual.amp.html
+++ b/contributing/release-schedule-visual.amp.html
@@ -166,8 +166,8 @@
         <div class="box header">Saturday</div>
         <div class="box header">Sunday</div>
 
-        <div class="box instructions week-1-instructions" data-week="1">Hover/tap on days in the first week to see how code flows into release channels…</div>
-        <div class="box instructions week-5-instructions" data-week="5">Hover/tap on days in the first week to see how code flows into release channels…</div>
+        <div class="box instructions week-1-instructions" data-week="1">Hover/tap on days above to see when the code merged on that day will be available on each release channel</div>
+        <div class="box instructions week-5-instructions" data-week="5">Hover/tap on days below to see when was the latest code merge that is included in each release channel</div>
 
         <div class="box sidebar week-1" data-week="1">
           <span class="top">N</span>

--- a/contributing/release-schedule-visual.amp.html
+++ b/contributing/release-schedule-visual.amp.html
@@ -8,7 +8,7 @@
     <link rel="canonical" href="release-schedule-visual.amp.html">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Fira+Mono|Noto+Sans|Poppins">
     <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
-    <meta name="amp-script-src" content="sha384-nUTQObN6e9PL3jOH7VL1HiyQFnry3RPNDg4BEmJYCBuzkzz36tBPxin7e6iK_fJn">
+    <meta name="amp-script-src" content="sha384-0ZxBLqhOncK0XJia6kZgtaPz6ZciY64IGaC6N174VoC6Jo6mew8Gkrgsb7rYrgW3">
     <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
     <style amp-custom>
       body {
@@ -165,16 +165,16 @@
     </style>
   </head>
   <body>
-    <amp-script layout="intrinsic" width="1050" height="0" script="calendar-script">    
+    <amp-script layout="intrinsic" width="1050" height="0" script="calendar-script">
       <div id="calendar" data-direction="top">
         <div class="box header">Week</div>
-        <div class="box header">Monday</div>
-        <div class="box header">Tuesday</div>
-        <div class="box header">Wednesday</div>
-        <div class="box header">Thursday</div>
-        <div class="box header">Friday</div>
-        <div class="box header">Saturday</div>
-        <div class="box header">Sunday</div>
+        <div class="box header day-sunday">Sunday</div>
+        <div class="box header day-monday">Monday</div>
+        <div class="box header day-tuesday">Tuesday</div>
+        <div class="box header day-wednesday">Wednesday</div>
+        <div class="box header day-thursday">Thursday</div>
+        <div class="box header day-friday">Friday</div>
+        <div class="box header day-saturday">Saturday</div>
 
         <div class="box instructions week-1-instructions" data-week="1"><span class="touch-only">Tap</span><span class="no-touch-only">Hover</span> on days above to see when the code merged on that day will be available on each release channel</div>
         <div class="box instructions week-5-instructions" data-week="5"><span class="touch-only">Tap</span><span class="no-touch-only">Hover</span> on days below to see when the latest code merge occurred so as to be included in each release channel</div>
@@ -210,51 +210,58 @@
         <div class="box ellipsis">⋮</div>
         <div class="box ellipsis">⋮</div>
 
+        <div class="box content week-1 day-sunday" data-week="1" data-day="sunday"></div>
         <div class="box content week-1 day-monday" data-week="1" data-day="monday"></div>
         <div class="box content week-1 day-tuesday" data-week="1" data-day="tuesday"></div>
         <div class="box content week-1 day-wednesday" data-week="1" data-day="wednesday"></div>
         <div class="box content week-1 day-thursday" data-week="1" data-day="thursday"></div>
         <div class="box content week-1 day-friday" data-week="1" data-day="friday"></div>
         <div class="box content week-1 day-saturday" data-week="1" data-day="saturday"></div>
-        <div class="box content week-1 day-sunday" data-week="1" data-day="sunday"></div>
 
+        <div class="box content week-2 day-sunday" data-week="2" data-day="sunday"></div>
         <div class="box content week-2 day-monday" data-week="2" data-day="monday"></div>
         <div class="box content week-2 day-tuesday" data-week="2" data-day="tuesday"></div>
         <div class="box content week-2 day-wednesday" data-week="2" data-day="wednesday"></div>
         <div class="box content week-2 day-thursday" data-week="2" data-day="thursday"></div>
         <div class="box content week-2 day-friday" data-week="2" data-day="friday"></div>
         <div class="box content week-2 day-saturday" data-week="2" data-day="saturday"></div>
-        <div class="box content week-2 day-sunday" data-week="2" data-day="sunday"></div>
 
+        <div class="box content week-3 day-sunday" data-week="3" data-day="sunday"></div>
         <div class="box content week-3 day-monday" data-week="3" data-day="monday"></div>
         <div class="box content week-3 day-tuesday" data-week="3" data-day="tuesday"></div>
         <div class="box content week-3 day-wednesday" data-week="3" data-day="wednesday"></div>
         <div class="box content week-3 day-thursday" data-week="3" data-day="thursday"></div>
         <div class="box content week-3 day-friday" data-week="3" data-day="friday"></div>
         <div class="box content week-3 day-saturday" data-week="3" data-day="saturday"></div>
-        <div class="box content week-3 day-sunday" data-week="3" data-day="sunday"></div>
 
+        <div class="box content week-4 day-sunday" data-week="4" data-day="sunday"></div>
         <div class="box content week-4 day-monday" data-week="4" data-day="monday"></div>
         <div class="box content week-4 day-tuesday" data-week="4" data-day="tuesday"></div>
         <div class="box content week-4 day-wednesday" data-week="4" data-day="wednesday"></div>
         <div class="box content week-4 day-thursday" data-week="4" data-day="thursday"></div>
         <div class="box content week-4 day-friday" data-week="4" data-day="friday"></div>
         <div class="box content week-4 day-saturday" data-week="4" data-day="saturday"></div>
-        <div class="box content week-4 day-sunday" data-week="4" data-day="sunday"></div>
 
+        <div class="box content week-5 day-sunday" data-week="5" data-day="sunday"></div>
         <div class="box content week-5 day-monday" data-week="5" data-day="monday"></div>
         <div class="box content week-5 day-tuesday" data-week="5" data-day="tuesday"></div>
         <div class="box content week-5 day-wednesday" data-week="5" data-day="wednesday"></div>
         <div class="box content week-5 day-thursday" data-week="5" data-day="thursday"></div>
         <div class="box content week-5 day-friday" data-week="5" data-day="friday"></div>
         <div class="box content week-5 day-saturday" data-week="5" data-day="saturday"></div>
-        <div class="box content week-5 day-sunday" data-week="5" data-day="sunday"></div>
       </div>
     </amp-script>
 
     <script id="calendar-script" type="text/plain" target="amp-script">
       const channels = {
         '1': {
+          'sunday': {
+            'nightly': ['1', 'monday'],
+            'opt-in': ['2', 'tuesday'],
+            'beta': ['2', 'wednesday'],
+            'stable': ['3', 'tuesday'],
+            'lts': ['5', 'monday'],
+          },
           'monday': {
             'nightly': ['1', 'tuesday'],
             'opt-in': ['2', 'tuesday'],
@@ -297,20 +304,19 @@
             'stable': ['4', 'tuesday'],
             'lts': ['5', 'monday'],
           },
-          'sunday': {
-            'nightly': ['2', 'monday'],
-            'opt-in': ['3', 'tuesday'],
-            'beta': ['3', 'wednesday'],
-            'stable': ['4', 'tuesday'],
-            'lts': ['5', 'monday'],
-          },
         },
         '5': {
+          'sunday': {
+            'lts': ['1', 'thursday'],
+            'stable': ['2', 'thursday'],
+            'opt-in-beta': ['3', 'thursday'],
+            'nightly': ['4', 'thursday'],
+          },
           'monday': {
             'lts': ['1', 'thursday'],
             'stable': ['2', 'thursday'],
             'opt-in-beta': ['3', 'thursday'],
-            'nightly': ['4', 'sunday'],
+            'nightly': ['5', 'sunday'],
           },
           'tuesday': {
             'lts': ['1', 'thursday'],
@@ -338,12 +344,6 @@
             'nightly': ['5', 'thursday'],
           },
           'saturday': {
-            'lts': ['1', 'thursday'],
-            'stable': ['3', 'thursday'],
-            'opt-in-beta': ['4', 'thursday'],
-            'nightly': ['5', 'thursday'],
-          },
-          'sunday': {
             'lts': ['1', 'thursday'],
             'stable': ['3', 'thursday'],
             'opt-in-beta': ['4', 'thursday'],

--- a/contributing/release-schedule-visual.amp.html
+++ b/contributing/release-schedule-visual.amp.html
@@ -179,7 +179,7 @@
 
         <div class="box sidebar week-1" data-week="1">
           <span class="top">N</span>
-          <span class="bottom">1<sup>st</sup> Monday of the month, before <code>stable</code></span>
+          <span class="bottom">2<sup>nd</sup> Monday of the month, before <code>stable</code></span>
         </div>
         <div class="box sidebar week-2" data-week="2">
           <span class="top">N+1</span>
@@ -194,7 +194,7 @@
           <span class="bottom">N-1</span>
         </div>
         <div class="box sidebar week-5" data-week="5">
-          <span class="top">1<sup>st</sup> Monday next month</span>
+          <span class="top">2<sup>nd</sup> Monday next month</span>
           <span class="bottom">N</span>
         </div>
 

--- a/contributing/release-schedule-visual.amp.html
+++ b/contributing/release-schedule-visual.amp.html
@@ -135,22 +135,22 @@
         cursor: pointer;
       }
       .nightly {
-        background-image: linear-gradient(225deg, #21c1fa 0%, #25b4ed 75%);
+        background-image: linear-gradient(225deg, #2980b9 0%, #298dc6 75%);
       }
       .opt-in {
-        background-image: linear-gradient(225deg, #25b4ed 0%, #27a6e0 75%);
+        background-image: linear-gradient(225deg, #298dc6 0%, #2899d3 75%);
       }
       .beta {
-        background-image: linear-gradient(225deg, #27a6e0 0%, #2899d3 75%);
+        background-image: linear-gradient(225deg, #2899d3 0%, #27a6e0 75%);
       }
       .opt-in-beta {
-        background-image: linear-gradient(225deg, #25b4ed 0%, #2899d3 75%);
+        background-image: linear-gradient(225deg, #298dc6 0%, #27a6e0 75%);
       }
       .stable {
-        background-image: linear-gradient(225deg, #2899d3 0%, #298dc6 75%);
+        background-image: linear-gradient(225deg, #27a6e0 0%, #25b4ed 75%);
       }
       .lts {
-        background-image: linear-gradient(225deg, #298dc6 0%, #2980b9 75%);
+        background-image: linear-gradient(225deg, #25b4ed 0%, #21c1fa 75%);
       }
       code {
         font-family: "Fira Mono", monospace;


### PR DESCRIPTION
This PR adds a page that visually shows, on a calendar (non-date-specific), how the release schedule works. For each release channel (e.g., beta, stable, lts) this page answers these two questions:

* By hovering your mouse / tapping on any day in the top row, it answers the question "if I merged a code on this day, when will it be available on <channel>?"
* By hovering your mouse / tapping on any day in the bottom row, it answers the slightly more confusing question: "on this day, when was the code for <channel> merged?"

This page is deployed here for now: https://output.jsbin.com/qovahib/quiet

Things that could use some work:
* ~~I hate the colour scheme (rainbows are fun but not exactly accessible or coherent for this type of visualization 🌈) (help, @ampproject/wg-ui-and-a11y)~~ (fixed)
* ~~Are the instructions clear?~~ (nobody said no so far)
* ~~Should I add more detailed explanations above the calendar?~~ (added a link to the detailed doc)
* ~~Is the hover text clear? (help, @ampproject/wg-outreach)~~ (nobody said no so far)
* Where can we deploy this so that we can link to it from `CONTRIBUTING.md`?
* ~~Improve screen-reader accessibility~~ (@caroqliu approved)
* ~~Verify that the data is correct~~ (doubled checked with @rcebulko and @rsimha)