### PR TITLE
add esm AMP_CONFIG field and esm performance identifier

### DIFF
--- a/build-system/externs/amp.extern.js
+++ b/build-system/externs/amp.extern.js
@@ -254,6 +254,8 @@ AmpConfigType.prototype.runtime;
 AmpConfigType.prototype.test;
 /* @public {string|undefined} */
 AmpConfigType.prototype.spt;
+/* @public {boolean|undefined} */
+AmpConfigType.prototype.esm;
 
 /** @type {!AmpConfigType}  */
 window.AMP_CONFIG;

--- a/src/amp.js
+++ b/src/amp.js
@@ -26,6 +26,7 @@ import {adoptWithMultidocDeps} from './runtime';
 import {cssText as ampDocCss} from '../build/ampdoc.css';
 import {cssText as ampSharedCss} from '../build/ampshared.css';
 import {fontStylesheetTimeout} from './font-stylesheet-timeout';
+import {getModeObject} from './mode-object';
 import {
   installAmpdocServices,
   installBuiltinElements,
@@ -99,6 +100,9 @@ if (shouldMainBootstrapRun) {
       self.document.documentElement.hasAttribute('i-amphtml-no-boilerplate')
     ) {
       perf.addEnabledExperiment('no-boilerplate');
+    }
+    if (getModeObject().esm) {
+      perf.addEnabledExperiment('esm');
     }
     fontStylesheetTimeout(self);
     perf.tick('is');

--- a/src/amp.js
+++ b/src/amp.js
@@ -26,7 +26,7 @@ import {adoptWithMultidocDeps} from './runtime';
 import {cssText as ampDocCss} from '../build/ampdoc.css';
 import {cssText as ampSharedCss} from '../build/ampshared.css';
 import {fontStylesheetTimeout} from './font-stylesheet-timeout';
-import {getModeObject} from './mode-object';
+import {getMode} from './mode';
 import {
   installAmpdocServices,
   installBuiltinElements,
@@ -101,7 +101,7 @@ if (shouldMainBootstrapRun) {
     ) {
       perf.addEnabledExperiment('no-boilerplate');
     }
-    if (getModeObject().esm) {
+    if (getMode().esm) {
       perf.addEnabledExperiment('esm');
     }
     fontStylesheetTimeout(self);

--- a/src/mode-object.js
+++ b/src/mode-object.js
@@ -26,6 +26,7 @@ export function getModeObject(opt_win) {
   return {
     localDev: getMode(opt_win).localDev,
     development: getMode(opt_win).development,
+    esm: getMode(opt_win).esm,
     filter: getMode(opt_win).filter,
     minified: getMode(opt_win).minified,
     lite: getMode(opt_win).lite,

--- a/src/mode.js
+++ b/src/mode.js
@@ -29,7 +29,8 @@ import {parseQueryString_} from './url-parse-query-string';
  *   rtvVersion: string,
  *   runtime: (null|string|undefined),
  *   a4aId: (null|string|undefined),
- *   singlePassType: (string|undefined)
+ *   singlePassType: (string|undefined),
+ *   esm: (boolean|undefined)
  * }}
  */
 export let ModeDef;
@@ -79,7 +80,7 @@ function getMode_(win) {
     // from the URL.
     win.location.originalHash || win.location.hash
   );
-  const singlePassType = AMP_CONFIG.spt;
+  const {spt: singlePassType, esm} = AMP_CONFIG;
 
   const searchQuery = parseQueryString_(win.location.search);
 
@@ -103,6 +104,7 @@ function getMode_(win) {
       ) >= 0 || win.AMP_DEV_MODE
     ),
     examiner: hashQuery['development'] == '2',
+    esm,
     // amp-geo override
     geoOverride: hashQuery['amp-geo'],
     minified: IS_MINIFIED,


### PR DESCRIPTION
this will allow for us to identify if an AMP page has loaded the module or no module build.
module builds will be marked as `rtv-${version}-esm` while no module builds will be the usual `rtv-${version}`