### PR TITLE
Revert "Update I2I & I2S to reflect new Open Source process (#25530)"

### DIFF
--- a/.github/ISSUE_TEMPLATE/intent-to-implement--i2i-.md
+++ b/.github/ISSUE_TEMPLATE/intent-to-implement--i2i-.md
@@ -15,13 +15,6 @@ See https://github.com/ampproject/amphtml/blob/master/contributing/contributing-
 If you haven't already done so, sign the Contributor License Agreement (CLA) as soon as possible to avoid delays merging your code. A signed CLA is not necessary to submit this I2I or to send a pull request, but it will be needed before your code can be merged. See https://github.com/ampproject/amphtml/blob/master/contributing/contributing-code.md#contributor-license-agreement for more information on CLAs.
 -->
 
-## Status
-- [ ] Draft
-- [ ] Ready for review
-<!--
-Issues that aren't marked "Ready for review" are considered drafts. Draft I2Is are encouraged for complex proposals and/or those expected to impact many stakeholders or parts of the project in order to promote promote broader community awareness and get earlier feedback.
--->
-
 ## Summary
 
 <!--
@@ -55,20 +48,8 @@ The launch tracker is meant to be an easy way of sharing a project's status with
 You should add a link to the launch tracker for this work here if applicable. One ideal template and instructions can be found here: bit.ly/amp-launch-tracker
 -->
 
-## Consideration checklist
-### Software Design
-- [ ] Design shows understanding of problem statement/priority
-- [ ] Acceptance/success criteria for problem being solved is clear
-- [ ] Brought to design review
 <!--
-Mark as done once this design has been presented at a [Design Review](https://github.com/ampproject/amphtml/blob/master/contributing/design-reviews.md).
--->
-
-<!--
-Please cc those that you want to notify about this I2I, including a reviewer once you have found one. 
-For a list of potential WGs to cc please see https://github.com/ampproject/meta/tree/master/working-groups.
-Please note that the Approvers WG is cced below by default.
-See https://github.com/ampproject/amphtml/blob/master/contributing/contributing-code.md for help in finding a reviewer.
+Add anyone to this cc line that you want to notify about this I2I, including a reviewer once you have found one. See https://github.com/ampproject/amphtml/blob/master/contributing/contributing-code.md for help in finding a reviewer.
 -->
 
 /cc @ampproject/wg-approvers

--- a/.github/ISSUE_TEMPLATE/intent-to-ship--i2s-.md
+++ b/.github/ISSUE_TEMPLATE/intent-to-ship--i2s-.md
@@ -51,66 +51,8 @@ Provide instructions for how to demo your feature such as a link to a demo page.
 Add any other information that may be relevant in determining if your feature can ship.
 -->
 
-## Build checklist
-
-This section describes considerations the implementor should keep in mind while building this technical solution.
-
-- [ ] Tests written
 <!--
-Have unit tests been written? Integration tests? Validator tests?
-Details on unit and integration tests:https://github.com/ampproject/amphtml/blob/master/contributing/getting-started-e2e.md#testing-your-changes
-Details on validator tests: https://github.com/ampproject/amphtml/blob/master/contributing/component-validator-rules.md
--->
-- [ ] Documentation present
-<!--
-Has reference documentation been added? Have examples been added? Has an example been made available on amp.dev?
--->
-- [ ] Cross platform testing
-<!--
-Have you tested all browsers and versions that AMP supports? https://amp.dev/support/faq/supported-browsers/
-Have you tested across mobile and desktop devices? 
--->
-
-### Considerations checklist
-
-This section describes different cross cutting considerations that the implementor should keep in mind while building this technical solution.
-
-<!--
-Retain all the considerations below that are applicable to your issue. If a consideration doesn't apply to you please remove that section.
--->
-
-- #### Accessibility Considerations
-<!--
-Reach out to the UI and Accessibility WG for assistance. https://github.com/ampproject/wg-ui-and-a11y
--->
-- #### Performance Considerations
-<!--
-Reach out to the Performance WG for assistance. https://github.com/ampproject/wg-performance
--->
-- #### Privacy Considerations
-<!--
-Reach out to the Security and Privacy WG for assistance. https://github.com/ampproject/wg-security-privacy
--->
-- #### Security Considerations
-<!--
-Reach out to the Security and Privacy WG for assistance. https://github.com/ampproject/wg-security-privacy
--->
-- #### Analytics Considerations
-<!--
-Reach out to the Analytics WG for assistance. https://github.com/ampproject/wg-analytics
--->
-
-### Launch checklist
-
-This section describes the final approvals needed before this feature can launch.
-
-- [ ] TSC/Approvers WG approved
-
-<!--
-Please cc those that you want to notify about this I2I, including a reviewer once you have found one. 
-For a list of potential WGs to cc please see https://github.com/ampproject/meta/tree/master/working-groups.
-Please note that the Approvers WG is cced below by default.
-See https://github.com/ampproject/amphtml/blob/master/contributing/contributing-code.md for help in finding a reviewer.
+Add anyone to this cc line that you want to notify about this I2S, including the reviewer who you worked with on the I2I.
 -->
 
 /cc @ampproject/wg-approvers


### PR DESCRIPTION
This reverts commit d46416bb1c520bae1c9d09521d1e2e93cef51405.
Reverting because the original PR doesn't address the comment here: https://github.com/ampproject/amphtml/pull/25530#discussion_r366546137
