### PR TITLE
✨ Allow a[type=application/rss+xml] in validator spec

### DIFF
--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -1968,6 +1968,7 @@ tags: {
   attrs: {
     name: "type"
     value_casei: "text/html"
+    value_casei: "application/rss+xml"
   }
   attr_lists: "name-attr"
   # <amp-bind>


### PR DESCRIPTION
When analyzing WordPress themes for compatibility, I came across links to RSS comments feed like:

```html
<a
    href="https://example.com/foo/feed/" 
    title="Comments RSS" 
    rel="alternate"
    type="application/rss+xml"
>Comments Feed</a>
```

This seems like it should be allowed.

Related: https://github.com/ampproject/amphtml/pull/26362