### PR TITLE
✨ Allow pubdate attribute on time element

### DIFF
--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -2110,6 +2110,10 @@ tags: {
   attrs: {
     name: "datetime"
   }
+  attrs: {
+    name: "pubdate"
+    value: ""
+  }
 }
 # 4.5.12 The code element
 tags: {


### PR DESCRIPTION
At one time, the HTML5 spec [included](https://www.w3.org/TR/2011/WD-html5-author-20110809/the-time-element.html) a `pubdate` attribute on the `time` element. While ultimately the attribute was [removed](http://html5doctor.com/time-and-data-element/) from the spec, it gained usage in the WordPress world. Specifically, on WordPress.com there are 72 themes that use this attribute. On the WordPress.org theme directory there are at least 139 themes using `time[pubdate]`.

Even though this semantic attribute is obsolete, it seems justifiable to allow it.