### PR TITLE
🚀 Disable FixedLayer when page is served canonically

### DIFF
--- a/src/service/fixed-layer.js
+++ b/src/service/fixed-layer.js
@@ -180,7 +180,7 @@ export class FixedLayer {
       // Rare but may happen if the document is being concurrently disposed.
       if (!stylesheet) {
         dev().error(TAG, 'Aborting setup due to null stylesheet.');
-        return;
+        return true;
       }
       const {disabled, ownerNode} = stylesheet;
       if (

--- a/src/service/fixed-layer.js
+++ b/src/service/fixed-layer.js
@@ -97,9 +97,7 @@ export class FixedLayer {
     this.elements_ = [];
 
     /** @const @private {!Pass} */
-    this.updatePass_ = new Pass(ampdoc.win, () => {
-      this.update();
-    });
+    this.updatePass_ = new Pass(ampdoc.win, () => this.update());
 
     /** @private {?function()} */
     this.hiddenObserverUnlistener_ = null;
@@ -131,12 +129,12 @@ export class FixedLayer {
     }
 
     if (opt_lightbox && opt_onComplete) {
-      opt_onComplete.then(() => {
+      opt_onComplete.then(() =>
         this.scanNode_(
           dev().assertElement(opt_lightbox),
           /* lightboxMode */ true
-        );
-      });
+        )
+      );
     }
   }
 
@@ -160,6 +158,11 @@ export class FixedLayer {
    * Must be always called after DOMReady.
    */
   setup() {
+    const isEmbedded = !!this.ampdoc.getParent();
+    if (!isEmbedded) {
+      return;
+    }
+
     const root = this.ampdoc.getRootNode();
     const stylesheets = root.styleSheets;
     if (!stylesheets) {

--- a/src/service/fixed-layer.js
+++ b/src/service/fixed-layer.js
@@ -156,17 +156,19 @@ export class FixedLayer {
 
   /**
    * Must be always called after DOMReady.
+   * @return {boolean}
    */
   setup() {
-    const isEmbedded = !!this.ampdoc.getParent();
-    if (!isEmbedded) {
-      return;
+    const viewer = Services.viewerForDoc(this.ampdoc);
+    if (viewer && !viewer.isEmbedded()) {
+      // FixedLayer is not needed for standalone documents.
+      return false;
     }
 
     const root = this.ampdoc.getRootNode();
     const stylesheets = root.styleSheets;
     if (!stylesheets) {
-      return;
+      return true;
     }
 
     this.fixedSelectors_.length = 0;
@@ -210,6 +212,8 @@ export class FixedLayer {
           ' slightly different layout.'
       );
     }
+
+    return true;
   }
 
   /**

--- a/src/service/fixed-layer.js
+++ b/src/service/fixed-layer.js
@@ -30,6 +30,7 @@ import {
 import {closest, domOrderComparator, matches} from '../dom';
 import {dev, user} from '../log';
 import {endsWith} from '../string';
+import {getMode} from '../mode';
 import {isExperimentOn} from '../experiments';
 import {remove} from '../utils/array';
 
@@ -160,7 +161,7 @@ export class FixedLayer {
    */
   setup() {
     const viewer = Services.viewerForDoc(this.ampdoc);
-    if (viewer && !viewer.isEmbedded()) {
+    if (!getMode().localDev && !viewer.isEmbedded()) {
       // FixedLayer is not needed for standalone documents.
       return false;
     }

--- a/test/unit/test-fixed-layer.js
+++ b/test/unit/test-fixed-layer.js
@@ -22,13 +22,16 @@ import {endsWith} from '../../src/string';
 import {installHiddenObserverForDoc} from '../../src/service/hidden-observer-impl';
 import {installPlatformService} from '../../src/service/platform-impl';
 import {installTimerService} from '../../src/service/timer-impl';
+import {installViewerServiceForDoc} from '../../src/service/viewer-impl';
 import {toggle} from '../../src/style';
 import {toggleExperiment} from '../../src/experiments';
 import {user} from '../../src/log';
 
 describes.sandboxed('FixedLayer', {}, () => {
+  let parentApi;
   let documentApi;
   let ampdoc;
+  let viewer;
   let vsyncApi;
   let vsyncTasks;
   let docBody, docElem;
@@ -42,6 +45,7 @@ describes.sandboxed('FixedLayer', {}, () => {
   let timer;
 
   beforeEach(() => {
+    parentApi = {};
     documentApi = {};
     allRules = {};
 
@@ -165,6 +169,7 @@ describes.sandboxed('FixedLayer', {}, () => {
       },
       documentElement: docElem,
       body: docBody,
+      parent: parentApi,
     });
     documentApi.defaultView.document = documentApi;
     installDocService(documentApi.defaultView, /* isSingleDoc */ true);
@@ -172,7 +177,10 @@ describes.sandboxed('FixedLayer', {}, () => {
     installHiddenObserverForDoc(ampdoc);
     installPlatformService(documentApi.defaultView);
     installTimerService(documentApi.defaultView);
+    installViewerServiceForDoc(ampdoc);
     timer = Services.timerFor(documentApi.defaultView);
+    viewer = Services.viewerForDoc(ampdoc);
+    viewer.isEmbedded = () => true;
 
     vsyncTasks = [];
     vsyncApi = {
@@ -1255,6 +1263,10 @@ describes.sandboxed('FixedLayer', {}, () => {
     const transfer = true;
 
     beforeEach(() => {
+      installViewerServiceForDoc(ampdoc);
+      viewer = Services.viewerForDoc(ampdoc);
+      viewer.isEmbedded = () => true;
+
       fixedLayer = new FixedLayer(
         ampdoc,
         vsyncApi,
@@ -1270,6 +1282,9 @@ describes.sandboxed('FixedLayer', {}, () => {
       const ampdoc = new AmpDocSingle(win);
       installPlatformService(win);
       installTimerService(win);
+      installViewerServiceForDoc(ampdoc);
+      viewer = Services.viewerForDoc(ampdoc);
+      viewer.isEmbedded = () => true;
 
       const fixedLayer = new FixedLayer(
         ampdoc,
@@ -1691,9 +1706,64 @@ describes.sandboxed('FixedLayer', {}, () => {
   });
 });
 
+describes.sandboxed('FixedLayer Shortcut Setup', {}, () => {
+  let ampdoc;
+  let viewer;
+  let vsyncApi;
+
+  beforeEach(() => {
+    const win = new FakeWindow();
+    ampdoc = new AmpDocSingle(win);
+    installPlatformService(win);
+    installTimerService(win);
+    installViewerServiceForDoc(ampdoc);
+    viewer = Services.viewerForDoc(ampdoc);
+
+    const vsyncTasks = [];
+    vsyncApi = {
+      runPromise: task => {
+        vsyncTasks.push(task);
+        return Promise.resolve();
+      },
+      mutate: mutator => {
+        vsyncTasks.push({mutate: mutator});
+      },
+    };
+  });
+
+  it('should not perform setup when served canonically', () => {
+    viewer.isEmbedded = () => false;
+
+    const fixedLayer = new FixedLayer(
+      ampdoc,
+      vsyncApi,
+      /* borderTop */ 0,
+      /* paddingTop */ 11,
+      /* transfer */ false
+    );
+    const executed = fixedLayer.setup();
+    expect(executed).to.be.false;
+  });
+
+  it('should perform setup when served within a viewer', () => {
+    viewer.isEmbedded = () => true;
+
+    const fixedLayer = new FixedLayer(
+      ampdoc,
+      vsyncApi,
+      /* borderTop */ 0,
+      /* paddingTop */ 11,
+      /* transfer */ false
+    );
+    const executed = fixedLayer.setup();
+    expect(executed).to.be.true;
+  });
+});
+
 describes.realWin('FixedLayer', {}, env => {
   let win, doc;
   let ampdoc;
+  let viewer;
   let fixedLayer;
   let transferLayer;
   let root;
@@ -1723,6 +1793,9 @@ describes.realWin('FixedLayer', {}, env => {
         installPlatformService(win);
         installTimerService(win);
         ampdoc = new AmpDocSingle(win);
+        installViewerServiceForDoc(ampdoc);
+        viewer = Services.viewerForDoc(ampdoc);
+        viewer.isEmbedded = () => true;
         shadowRoot = win.document.body.attachShadow({mode: 'open'});
         fixedLayer = new FixedLayer(
           ampdoc,

--- a/test/unit/test-fixed-layer.js
+++ b/test/unit/test-fixed-layer.js
@@ -1721,7 +1721,7 @@ describes.sandboxed('FixedLayer Setup Execution Bailouts', {}, () => {
       test: false,
       version: '$internalRuntimeVersion$',
     };
-    
+
     const vsyncTasks = [];
     vsyncApi = {
       runPromise: task => {
@@ -1773,72 +1773,76 @@ describes.sandboxed('FixedLayer Setup Execution Bailouts', {}, () => {
   });
 });
 
-describes.sandboxed('FixedLayer Setup Execution Bailouts with Local Development', {}, () => {
-  let win;
-  let ampdoc;
-  let viewer;
-  let vsyncApi;
+describes.sandboxed(
+  'FixedLayer Setup Execution Bailouts with Local Development',
+  {},
+  () => {
+    let win;
+    let ampdoc;
+    let viewer;
+    let vsyncApi;
 
-  beforeEach(() => {
-    win = new FakeWindow();
-    window.__AMP_MODE = {
-      localDev: true,
-      development: false,
-      minified: false,
-      test: false,
-      version: '$internalRuntimeVersion$',
-    };
-    
-    const vsyncTasks = [];
-    vsyncApi = {
-      runPromise: task => {
-        vsyncTasks.push(task);
-        return Promise.resolve();
-      },
-      mutate: mutator => {
-        vsyncTasks.push({mutate: mutator});
-      },
-    };
-  });
+    beforeEach(() => {
+      win = new FakeWindow();
+      window.__AMP_MODE = {
+        localDev: true,
+        development: false,
+        minified: false,
+        test: false,
+        version: '$internalRuntimeVersion$',
+      };
 
-  it('should perform setup when served canonically', () => {
-    ampdoc = new AmpDocSingle(win);
-    installPlatformService(win);
-    installTimerService(win);
-    installViewerServiceForDoc(ampdoc);
-    viewer = Services.viewerForDoc(ampdoc);
-    viewer.isEmbedded = () => false;
+      const vsyncTasks = [];
+      vsyncApi = {
+        runPromise: task => {
+          vsyncTasks.push(task);
+          return Promise.resolve();
+        },
+        mutate: mutator => {
+          vsyncTasks.push({mutate: mutator});
+        },
+      };
+    });
 
-    const fixedLayer = new FixedLayer(
-      ampdoc,
-      vsyncApi,
-      /* borderTop */ 0,
-      /* paddingTop */ 11,
-      /* transfer */ false
-    );
-    const executed = fixedLayer.setup();
-    expect(executed).to.be.true;
-  });
+    it('should perform setup when served canonically', () => {
+      ampdoc = new AmpDocSingle(win);
+      installPlatformService(win);
+      installTimerService(win);
+      installViewerServiceForDoc(ampdoc);
+      viewer = Services.viewerForDoc(ampdoc);
+      viewer.isEmbedded = () => false;
 
-  it('should perform setup when served within a viewer', () => {
-    ampdoc = new AmpDocSingle(win);
-    installPlatformService(win);
-    installTimerService(win);
-    installViewerServiceForDoc(ampdoc);
-    viewer = Services.viewerForDoc(ampdoc);
-    viewer.isEmbedded = () => true;
+      const fixedLayer = new FixedLayer(
+        ampdoc,
+        vsyncApi,
+        /* borderTop */ 0,
+        /* paddingTop */ 11,
+        /* transfer */ false
+      );
+      const executed = fixedLayer.setup();
+      expect(executed).to.be.true;
+    });
 
-    const fixedLayer = new FixedLayer(
-      ampdoc,
-      vsyncApi,
-      /* borderTop */ 0,
-      /* paddingTop */ 11,
-      /* transfer */ false
-    );
-    const executed = fixedLayer.setup();
-    expect(executed).to.be.true;
-  });
-});
+    it('should perform setup when served within a viewer', () => {
+      ampdoc = new AmpDocSingle(win);
+      installPlatformService(win);
+      installTimerService(win);
+      installViewerServiceForDoc(ampdoc);
+      viewer = Services.viewerForDoc(ampdoc);
+      viewer.isEmbedded = () => true;
+
+      const fixedLayer = new FixedLayer(
+        ampdoc,
+        vsyncApi,
+        /* borderTop */ 0,
+        /* paddingTop */ 11,
+        /* transfer */ false
+      );
+      const executed = fixedLayer.setup();
+      expect(executed).to.be.true;
+    });
+  }
+);
 
 describes.realWin('FixedLayer', {}, env => {
   let win, doc;


### PR DESCRIPTION
When an AMP document is served canonically (like AMP.dev), the FixedLayer service is not needed.

This change disables the FixedLayer from performing its setup phase while we investigate a longer term fix. (#26397)