### PR TITLE
Fix memory leak in inabox-viewport-friendly introduced by inabox-lite.

### DIFF
--- a/src/inabox/inabox-viewport.js
+++ b/src/inabox/inabox-viewport.js
@@ -143,6 +143,7 @@ class InaboxViewportImpl {
 
     // Workaround for Safari not firing visibilityChange when the page is
     // unloaded (https://bugs.webkit.org/show_bug.cgi?id=151234).
+    // TODO(zombifier): Remove this when ampdoc can handle this event.
     /** @private @const {function()} */
     this.boundDispose_ = this.dispose.bind(this);
     win.addEventListener('pagehide', this.boundDispose_);

--- a/src/inabox/inabox-viewport.js
+++ b/src/inabox/inabox-viewport.js
@@ -523,7 +523,7 @@ export class ViewportBindingInabox {
     return Services.resourcesPromiseForDoc(
       this.win.document.documentElement
     ).then(() => {
-      this.unobserveFunction_ = this.unobserveFunction ||
+      this.unobserveFunction_ = this.unobserveFunction_ ||
       this.topWindowPositionObserver_.observe(
         // If the window is the top window (not sitting in an iframe) then
         // frameElement doesn't exist. In that case we observe the scrolling

--- a/src/inabox/inabox-viewport.js
+++ b/src/inabox/inabox-viewport.js
@@ -143,10 +143,9 @@ class InaboxViewportImpl {
 
     // Workaround for Safari not firing visibilityChange when the page is
     // unloaded (https://bugs.webkit.org/show_bug.cgi?id=151234).
-    const unloadListener = win.addEventListener('pagehide', () => {
-      this.binding_.disconnect();
-      win.removeEventListener('pagehide', unloadListener);
-    });
+    /** @private @const {function()} */
+    this.boundDispose_ = this.dispose.bind(this);
+    win.addEventListener('pagehide', this.boundDispose_);
 
     // Top-level mode classes.
     const docElement = win.document.documentElement;
@@ -160,6 +159,7 @@ class InaboxViewportImpl {
   /** @override */
   dispose() {
     this.binding_.disconnect();
+    this.ampdoc.win.removeEventListener('pagehide', this.boundDispose_);
   }
 
   /** @override */
@@ -407,11 +407,9 @@ class InaboxViewportImpl {
       this.visible_ = visible;
       if (visible) {
         this.binding_.connect();
-        if (this.size_) {
-          // If the size has already been intialized, check it again in case
-          // the size has changed between `disconnect` and `connect`.
-          this.resize_();
-        }
+        // Check the size again in case it has changed between `disconnect` and
+        // `connect`.
+        this.resize_();
       } else {
         this.binding_.disconnect();
       }

--- a/src/inabox/inabox-viewport.js
+++ b/src/inabox/inabox-viewport.js
@@ -467,6 +467,13 @@ export class ViewportBindingInabox {
     /** @private {?UnlistenDef} */
     this.unobserveFunction_ = null;
 
+    const unloadListener = this.win.addEventListener('unload', () => {
+      if (this.unobserveFunction_) {
+        this.unobserveFunction_();
+        this.unobserveFunction_ = null;
+        this.win.removeEventListener('unload', unloadListener);
+      }
+    });
     dev().fine(TAG, 'initialized inabox viewport');
   }
 


### PR DESCRIPTION
The leak is caused by InaboxViewportImpl not disconnecting the binding on visibilityChange=hidden, so when the inabox iframe is cleared the reference to it remains in the top window. Readd code for handling the event, with a workaround for Safari not firing it on unload.