### PR TITLE
🏗 Remove the `engines` section from all `package.json` files in `amphtml`

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,10 +4,6 @@
   "version": "0.1.0",
   "description": "Fastish HTML",
   "main": "index.js",
-  "engines": {
-    "node": "^12.0.0",
-    "yarn": "^1.10.1"
-  },
   "author": "The AMP HTML Authors",
   "license": "Apache-2.0",
   "repository": {

--- a/validator/gulpjs/package.json
+++ b/validator/gulpjs/package.json
@@ -10,9 +10,6 @@
     "AMP HTML",
     "Accelerated Mobile Pages"
   ],
-  "engines": {
-    "node": ">=0.10.25"
-  },
   "author": "The AMP HTML Authors",
   "license": "Apache-2.0",
   "repository": {

--- a/validator/nodejs/package.json
+++ b/validator/nodejs/package.json
@@ -9,9 +9,6 @@
     "AMP HTML",
     "Accelerated Mobile Pages"
   ],
-  "engines": {
-    "node": "^8 || ^10 || ^12 || ^14"
-  },
   "author": "The AMP HTML Authors",
   "license": "Apache-2.0",
   "repository": {

--- a/validator/package.json
+++ b/validator/package.json
@@ -2,9 +2,6 @@
   "name": "amp-validator",
   "version": "0.1.0",
   "description": "Validator for AMP HTML (amp.dev)",
-  "engines": {
-    "node": "^12.0.0"
-  },
   "author": "The AMP HTML Authors",
   "license": "Apache-2.0",
   "repository": {

--- a/validator/webui/package.json
+++ b/validator/webui/package.json
@@ -2,9 +2,6 @@
   "name": "amp-validator-webui",
   "version": "0.1.0",
   "description": "Web UI for Validator for AMP HTML (www.ampproject.org)",
-  "engines": {
-    "node": "^12.0.0"
-  },
   "author": "The AMP HTML Authors",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
The `engines` section of `package.json` has traditionally been used to enforce a known good range of versions of `node` for local development. This has worked well so far for developers who work on the `amphtml` repo, where we require an active LTS version of `node` (and recommend the _latest_ active LTS version of `node`).

However, we've had multiple instances in the past of the `engines` section of `package.json` coming in the way of developer workflows for external contributors who use sub-packages published from within the `amphtml` repo. See earlier relevant discussions in #19050, #19218, #25161, #25189, #25209, and #26408.

In addition, it has caused failures on Travis CI when `node` pushes out a new version, causing our `package.json` files to be outdated until they are manually updated.

When I spoke to @MylesBorins at Open JS last month, he mentioned to me that the `engines` section is likely to be deprecated soon, and that a better way of enforcing `node` versions in a repo is to have tests / CI return an error for incompatible versions. We already do this for `amphtml` via [build-system/common/check-package-manager.js](https://github.com/ampproject/amphtml/blob/master/build-system/common/check-package-manager.js).

This PR deletes the `engines` section from all `package.json` files in `amphtml`.

Fixes #26408
Closes #25209
Related to #19050, #19218, #25161, #25189, #25209, and #26408.