### PR TITLE
cl/290808403 Allow span[tooShort] in validation.

### DIFF
--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -26,7 +26,7 @@ min_validator_revision_required: 375
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 996
+spec_file_revision: 997
 
 styles_spec_url: "https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages"
 script_spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags"
@@ -6728,6 +6728,7 @@ attr_lists: {
     value: "rangeUnderflow"
     value: "stepMismatch"
     value: "tooLong"
+    value: "tooShort"
     value: "typeMismatch"
     value: "valueMissing"
     trigger: {


### PR DESCRIPTION
Fixes #26412