### PR TITLE
amp-consent remove cmp iframe focus

### DIFF
--- a/extensions/amp-consent/0.1/consent-ui.js
+++ b/extensions/amp-consent/0.1/consent-ui.js
@@ -85,6 +85,12 @@ export class ConsentUI {
       config['uiConfig']['overlay'] === true;
 
     /** @private {boolean} */
+    this.restrictFullscreenOn_ = isExperimentOn(
+      baseInstance.win,
+      'amp-consent-restrict-fullscreen'
+    );
+
+    /** @private {boolean} */
     this.scrollEnabled_ = true;
 
     /** @private {?Element} */
@@ -202,7 +208,7 @@ export class ConsentUI {
 
           this.showIframe_();
 
-          if (!this.isPostPrompt_) {
+          if (!this.isPostPrompt_ && !this.restrictFullscreenOn_) {
             this.ui_./*OK*/ focus();
           }
         });

--- a/extensions/amp-consent/0.1/test/test-consent-ui.js
+++ b/extensions/amp-consent/0.1/test/test-consent-ui.js
@@ -294,6 +294,31 @@ describes.realWin(
           })
         );
       });
+
+      describe('fullscreen user interaction experiment', () => {
+        beforeEach(() => {
+          toggleExperiment(win, 'amp-consent-restrict-fullscreen', true);
+        });
+
+        afterEach(() => {
+          toggleExperiment(win, 'amp-consent-restrict-fullscreen', false);
+        });
+
+        it('should not change document.activeElement', () => {
+          const {activeElement} = doc;
+          consentUI = new ConsentUI(mockInstance, {
+            'promptUISrc': 'https//promptUISrc',
+          });
+          const showIframeSpy = env.sandbox.spy(consentUI, 'showIframe_');
+
+          consentUI.show(false);
+          consentUI.iframeReady_.resolve();
+
+          return whenCalled(showIframeSpy).then(() =>
+            expect(activeElement).to.equal(doc.activeElement)
+          );
+        });
+      });
     });
 
     describe('overlay', () => {

--- a/tools/experiments/experiments-config.js
+++ b/tools/experiments/experiments-config.js
@@ -62,6 +62,12 @@ export const EXPERIMENTS = [
     cleanupIssue: 'https://github.com/ampproject/amphtml/issues/3996',
   },
   {
+    id: 'amp-consent-restrict-fullscreen',
+    name: 'AMP consent restrict fullscreen API before user interaction',
+    spec: 'https://github.com/ampproject/amphtml/issues/26432',
+    cleanupIssue: 'https://github.com/ampproject/amphtml/issues/26432',
+  },
+  {
     id: 'amp-consent-geo-override',
     name: 'AMP consent modified to support CCPA',
     spec:


### PR DESCRIPTION
Task 2 for #26432

If flag is on, don't focus on the CMP iframe when it loads, so that document.activeElement will not change. 

