### PR TITLE
🐛Fix CTA not showing in Firefox

### DIFF
--- a/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.css
+++ b/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.css
@@ -47,7 +47,8 @@
   letter-spacing: 0.2px !important;
   line-height: 36px !important;
   overflow: hidden !important;
-  opacity: 0 !important;
+  /* no important on opacity b/c ff does not allow keyframes to override. */
+  opacity: 0;
   padding: 0 10px !important;
   position: absolute !important;
   text-align: center !important;


### PR DESCRIPTION
Closes #26334 

In most browsers a css property set in keyframes will override a !important style. This does not happen in Firefox 😕.