### PR TITLE
🏗 Migrate deprecated VSCode setting `eslint.autoFixOnSave` to `editor.codeActionsOnSave`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,6 +9,8 @@
     ".eslintrc": "json",
     ".prettierrc": "json",
     ".renovaterc.json": "json",
+
+    // Enable YAML auto-formatting for these files.
     ".codecov.yml": "yaml",
     ".lando.yml": "yaml",
     ".lgtm.yml": "yaml",
@@ -17,7 +19,7 @@
 
   // Auto-fix JS files with ESLint using amphtml's custom settings. Needs
   // https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint
-  "eslint.autoFixOnSave": true,
+  "editor.codeActionsOnSave": {"source.fixAll.eslint": true},
   "[js]": {"editor.formatOnSave": false},
 
   // Auto-fix non-JS files with Prettier using amphtml's custom settings. Needs


### PR DESCRIPTION
**Highlights:** Addresses this warning from VS Code's `eslint` plugin by migrating the deprecated setting to the new one.

![Screenshot from 2020-01-22 11-58-02](https://user-images.githubusercontent.com/26553114/72915641-a0830900-3d0e-11ea-905e-f9da2f2f675d.png)

**Reference:** `vscode-eslint` [release notes](https://github.com/microsoft/vscode-eslint/tree/release/2.0.4#release-notes).