### PR TITLE
Revert "♻️ Lint: include externs"

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -9,6 +9,7 @@ out/**
 test/coverage/**
 
 # Code directories
+**/*.extern.js
 build-system/tasks/visual-diff/snippets/*.js
 build-system/babel-plugins/**/fixtures/**/*.js
 build-system/server/app-index/test/*.js

--- a/.eslintrc
+++ b/.eslintrc
@@ -234,14 +234,7 @@
     {
       "files": ["**/*.extern.js"],
       "rules": {
-        "no-var": "off",
-        "no-undef": "off",
-        "no-unused-vars": "off",
-        "prefer-const": "off",
-        "require-jsdoc": "off",
-        "jsdoc/check-tag-names": "off",
-        "local/closure-type-primitives": "off",
-        "google-camelcase/google-camelcase": "off"
+        "prettier/prettier": 2
       }
     }
   ]

--- a/.eslintrc
+++ b/.eslintrc
@@ -234,14 +234,14 @@
     {
       "files": ["**/*.extern.js"],
       "rules": {
-        "no-var": 0,
-        "no-undef": 0,
-        "no-unused-vars": 0,
-        "prefer-const": 0,
-        "require-jsdoc": 0,
-        "jsdoc/check-tag-names": 0,
-        "local/closure-type-primitives": 0,
-        "google-camelcase/google-camelcase": 0
+        "no-var": "off",
+        "no-undef": "off",
+        "no-unused-vars": "off",
+        "prefer-const": "off",
+        "require-jsdoc": "off",
+        "jsdoc/check-tag-names": "off",
+        "local/closure-type-primitives": "off",
+        "google-camelcase/google-camelcase": "off"
       }
     }
   ]

--- a/.eslintrc
+++ b/.eslintrc
@@ -241,7 +241,6 @@
         "require-jsdoc": 0,
         "jsdoc/check-tag-names": 0,
         "local/closure-type-primitives": 0,
-        "local/no-duplicate-name-typedef": 0,
         "google-camelcase/google-camelcase": 0
       }
     }

--- a/.eslintrc
+++ b/.eslintrc
@@ -230,12 +230,6 @@
         "process": false,
         "require": false
       }
-    },
-    {
-      "files": ["**/*.extern.js"],
-      "rules": {
-        "prettier/prettier": 2
-      }
     }
   ]
 }

--- a/ads/ads.extern.js
+++ b/ads/ads.extern.js
@@ -19,15 +19,15 @@
 // HACK. Define application types used in default AMP externs
 // that are not in the 3p code.
 /** @constructor */
-function BaseElement$$module$src$base_element() {}
+function BaseElement$$module$src$base_element() {};
 /** @constructor */
-function AmpAdXOriginIframeHandler$$module$extensions$amp_ad$0_1$amp_ad_xorigin_iframe_handler() {}
+function AmpAdXOriginIframeHandler$$module$extensions$amp_ad$0_1$amp_ad_xorigin_iframe_handler() {};
 /** @constructor */
-function AmpAd3PImpl$$module$extensions$amp_ad$0_1$amp_ad_3p_impl() {}
+function AmpAd3PImpl$$module$extensions$amp_ad$0_1$amp_ad_3p_impl() {};
 /** @constructor */
-function AmpA4A$$module$extensions$amp_a4a$0_1$amp_a4a() {}
+function AmpA4A$$module$extensions$amp_a4a$0_1$amp_a4a() {};
 /** @constructor */
-function AmpAdUIHandler$$module$extensions$amp_ad$0_1$amp_ad_ui() {}
+function AmpAdUIHandler$$module$extensions$amp_ad$0_1$amp_ad_ui() {};
 
 // Long list of, uhm, stuff the ads code needs to compile.
 // All unquoted external properties need to be added here.
@@ -54,47 +54,45 @@ data.embedtype;
 data.src;
 
 //twitter.js
-data.tweetid;
+data.tweetid
 
 //mathml.js
-data.formula;
-var mathjax;
-mathjax.Hub;
-mathjax.Hub.Config;
-mathjax.Hub.Queue;
-window.MathJax;
+data.formula
+var mathjax
+mathjax.Hub
+mathjax.Hub.Config
+mathjax.Hub.Queue
+window.MathJax
 
 //3d-gltf/index.js
 var THREE;
 
-THREE.LoaderUtils;
-THREE.LoaderUtils.extractUrlBase;
+THREE.LoaderUtils
+THREE.LoaderUtils.extractUrlBase
 
 THREE.WebGLRenderer = class {
   /** @param {!JsonObject} opts */
   constructor(opts) {
-    /** @type {?Element} */ this.domElement = null;
-  }
-};
-THREE.WebGLRenderer.prototype.setSize;
-THREE.WebGLRenderer.prototype.setPixelRatio;
-THREE.WebGLRenderer.prototype.setClearColor;
-THREE.WebGLRenderer.prototype.render;
+    /** @type {?Element} */ this.domElement = null;}};
+THREE.WebGLRenderer.prototype.setSize
+THREE.WebGLRenderer.prototype.setPixelRatio
+THREE.WebGLRenderer.prototype.setClearColor
+THREE.WebGLRenderer.prototype.render
 /** @type {boolean} */
-THREE.WebGLRenderer.prototype.gammaOutput;
+THREE.WebGLRenderer.prototype.gammaOutput
 /** @type {number} */
-THREE.WebGLRenderer.prototype.gammaFactor;
+THREE.WebGLRenderer.prototype.gammaFactor
 
 THREE.Light = class extends THREE.Object3D {};
 THREE.DirectionalLight = class extends THREE.Light {};
 THREE.AmbientLight = class extends THREE.Light {};
 
 THREE.Box3 = class {};
-THREE.Box3.prototype.getSize;
-THREE.Box3.prototype.getCenter;
-THREE.Box3.prototype.setFromObject;
-THREE.Box3.prototype.min;
-THREE.Box3.prototype.max;
+THREE.Box3.prototype.getSize
+THREE.Box3.prototype.getCenter
+THREE.Box3.prototype.setFromObject
+THREE.Box3.prototype.min
+THREE.Box3.prototype.max
 
 THREE.Vector3 = class {
   /** @param {number=} opt_x
@@ -102,27 +100,25 @@ THREE.Vector3 = class {
    * @param {number=} opt_z */
   constructor(opt_x, opt_y, opt_z) {}
 };
-THREE.Vector3.prototype.lerpVectors;
-THREE.Vector3.prototype.copy;
-THREE.Vector3.prototype.clone;
-THREE.Vector3.prototype.subVectors;
-THREE.Vector3.prototype.multiplyScalar;
-THREE.Vector3.prototype.setFromMatrixColumn;
-THREE.Vector3.prototype.add;
-THREE.Vector3.prototype.set;
-THREE.Vector3.prototype.applyQuaternion;
-THREE.Vector3.prototype.setFromSpherical;
-THREE.Vector3.prototype.distanceToSquared;
-THREE.Vector3.prototype.length;
-THREE.Vector3.prototype.fromArray;
+THREE.Vector3.prototype.lerpVectors
+THREE.Vector3.prototype.copy
+THREE.Vector3.prototype.clone
+THREE.Vector3.prototype.subVectors
+THREE.Vector3.prototype.multiplyScalar
+THREE.Vector3.prototype.setFromMatrixColumn
+THREE.Vector3.prototype.add
+THREE.Vector3.prototype.set
+THREE.Vector3.prototype.applyQuaternion
+THREE.Vector3.prototype.setFromSpherical
+THREE.Vector3.prototype.distanceToSquared
+THREE.Vector3.prototype.length
+THREE.Vector3.prototype.fromArray
 
 THREE.Euler = class {
   constructor() {
     this.x = 0;
     this.y = 0;
-    this.z = 0;
-  }
-};
+    this.z = 0;}};
 
 THREE.Euler.prototype.set;
 
@@ -130,25 +126,21 @@ THREE.Object3D = class {
   constructor() {
     this.position = new THREE.Vector3();
     this.rotation = new THREE.Euler();
-    this.children = [];
-  }
-};
+    this.children = [];}};
 
-THREE.Object3D.prototype.applyMatrix;
-THREE.Object3D.prototype.add;
-THREE.Object3D.prototype.updateMatrixWorld;
-THREE.Object3D.prototype.lookAt;
-THREE.Object3D.prototype.clone;
+THREE.Object3D.prototype.applyMatrix
+THREE.Object3D.prototype.add
+THREE.Object3D.prototype.updateMatrixWorld
+THREE.Object3D.prototype.lookAt
+THREE.Object3D.prototype.clone
 
 THREE.OrbitControls = class {
   /** @param {THREE.Camera} camera
    * @param {Element} domElement */
   constructor(camera, domElement) {
-    this.target = new THREE.Vector3();
-  }
-};
-THREE.OrbitControls.prototype.update;
-THREE.OrbitControls.prototype.addEventListener;
+    this.target = new THREE.Vector3(); }};
+THREE.OrbitControls.prototype.update
+THREE.OrbitControls.prototype.addEventListener
 
 THREE.Scene = class extends THREE.Object3D {};
 THREE.Group = class extends THREE.Object3D {};
@@ -160,20 +152,16 @@ THREE.Camera = class extends THREE.Object3D {
     this.far = 0;
     this.near = 0;
     this.aspect = 0;
-    this.zoom = 0;
-  }
-};
-THREE.Camera.prototype.updateProjectionMatrix;
-THREE.Camera.prototype.setFromUnitVectors;
+    this.zoom = 0;}};
+THREE.Camera.prototype.updateProjectionMatrix
+THREE.Camera.prototype.setFromUnitVectors
 
 THREE.PerspectiveCamera = class extends THREE.Camera {};
 
 THREE.GLTFLoader = class {
   constructor() {
-    this.crossOrigin = false;
-  }
-};
-THREE.GLTFLoader.prototype.load;
+    this.crossOrigin = false;}};
+THREE.GLTFLoader.prototype.load
 
 // Under ads/google folder
 
@@ -210,7 +198,7 @@ data.overrideHeight;
 data.height;
 data.multiSizeValidation;
 data.categoryExclusions;
-data.categoryExclusions.length;
+data.categoryExclusions.length;;
 data.cookieOptions;
 data.tagForChildDirectedTreatment;
 data.targeting;
@@ -230,7 +218,7 @@ google.ima.AdsLoader;
 google.ima.AdsLoader.getSettings;
 google.ima.AdsLoader.requestAds;
 google.ima.AdsManagerLoadedEvent;
-google.ima.AdsManagerLoadedEvent.Type;
+google.ima.AdsManagerLoadedEvent.Type
 google.ima.AdsManagerLoadedEvent.Type.ADS_MANAGER_LOADED;
 google.ima.AdsManagerLoadedEvent.getAdsManager;
 google.ima.AdErrorEvent;
@@ -431,7 +419,7 @@ data.parameters;
 data.queue;
 
 // imedia.js
-data.positions;
+data.positions
 
 // imonomy.js
 data.pid;
@@ -520,7 +508,7 @@ Guoshi.queryAd.amp;
 Guoshi.queryAd.amp.setup;
 
 // openadstream.js
-data.adhost;
+data.adhost
 data.sitepage;
 data.pos;
 data.query;
@@ -624,8 +612,8 @@ data.z;
 data.tf;
 
 // swoop.js
-var Swoop;
-Swoop.announcePlace;
+var Swoop
+Swoop.announcePlace
 
 // taboola.js
 data.referrer;

--- a/build-system/externs/amp.extern.js
+++ b/build-system/externs/amp.extern.js
@@ -536,19 +536,9 @@ AccessService.prototype.getAccessReaderId = function() {};
 AccessService.prototype.getAuthdataField = function(field) {};
 // Same for amp-analytics
 
-/**
- * The "get CID" parameters.
- * - createCookieIfNotPresent: Whether CID is allowed to create a cookie when.
- *   Default value is `false`.
- * @typedef {{
- *   scope: string,
- *   createCookieIfNotPresent: (boolean|undefined),
- *   cookieName: (string|undefined),
- * }}
- */
 var GetCidDef;
 /**
- * @param {string|!GetCidDef} externalCidScope Name of the fallback cookie
+ * @param {string|!../../src/service/cid-impl.GetCidDef} externalCidScope Name of the fallback cookie
  *     for the case where this doc is not served by an AMP proxy. GetCidDef
  *     structure can also instruct CID to create a cookie if one doesn't yet
  *     exist in a non-proxy case.

--- a/build-system/externs/amp.extern.js
+++ b/build-system/externs/amp.extern.js
@@ -535,10 +535,18 @@ Activity.prototype.getIncrementalEngagedTime = function(name, reset) {};
 AccessService.prototype.getAccessReaderId = function() {};
 AccessService.prototype.getAuthdataField = function(field) {};
 // Same for amp-analytics
-
+/**
+ * The "get CID" parameters.
+ * - createCookieIfNotPresent: Whether CID is allowed to create a cookie when.
+ *   Default value is `false`.
+ * @typedef {{
+ *   scope: string,
+ *   createCookieIfNotPresent: (boolean|undefined),
+ * }}
+ */
 var GetCidDef;
 /**
- * @param {string|!../../src/service/cid-impl.GetCidDef} externalCidScope Name of the fallback cookie
+ * @param {string|!GetCidDef} externalCidScope Name of the fallback cookie
  *     for the case where this doc is not served by an AMP proxy. GetCidDef
  *     structure can also instruct CID to create a cookie if one doesn't yet
  *     exist in a non-proxy case.

--- a/build-system/externs/dompurify.extern.js
+++ b/build-system/externs/dompurify.extern.js
@@ -16,6 +16,7 @@
 
 /** @externs */
 
+
 /** @constructor */
 var DomPurifyConfig = function() {};
 

--- a/third_party/moment/moment.extern.js
+++ b/third_party/moment/moment.extern.js
@@ -100,10 +100,10 @@ moment.Locale = function() {};
  * @param {string} format
  * @return {string}
  */
-moment.Locale.longDateFormat = function(format) {};
+moment.Locale.longDateFormat = function (format) {};
 
 /** @return {moment.Locale} */
-moment.prototype.localeData = function() {};
+moment.prototype.localeData = function () {};
 
 /** @return {!moment} */
-moment.prototype.duration = function() {};
+moment.prototype.duration = function () {};


### PR DESCRIPTION
Reverts ampproject/amphtml#26228

Revert reasons (https://github.com/ampproject/amphtml/pull/26228#issuecomment-577418939):
1. Initial merge was done via 8 commits instead of a squashed 1
2. There have been changes to the externs files that make them out of sync with the introduced lint rules (making master red)