### PR TITLE
Fix border around desktop amp-story-pages.

### DIFF
--- a/extensions/amp-story/1.0/amp-story-desktop-panels.css
+++ b/extensions/amp-story/1.0/amp-story-desktop-panels.css
@@ -61,21 +61,21 @@ amp-story[standalone].i-amphtml-story-desktop-panels {
 
 .i-amphtml-story-desktop-panels amp-story-page[i-amphtml-desktop-position="-2"],
 [dir=rtl] .i-amphtml-story-desktop-panels amp-story-page[i-amphtml-desktop-position="2"] {
-  transform: scale(0.9) translateX(calc(-5 * var(--i-amphthml-story-page-50vw, 50%) - 128px)) translateY(0%) !important;
+  transform: scale(0.9) translateX(calc(-5 * var(--i-amphtml-story-page-50vw, 50%) - 128px)) translateY(0%) !important;
 }
 
 .i-amphtml-story-desktop-panels amp-story-page[i-amphtml-desktop-position="-1"],
 .i-amphtml-story-desktop-panels .prev-container > .i-amphtml-story-page-sentinel,
 [dir=rtl] .i-amphtml-story-desktop-panels amp-story-page[i-amphtml-desktop-position="1"],
 [dir=rtl] .i-amphtml-story-desktop-panels .next-container > .i-amphtml-story-page-sentinel {
-  transform: scale(0.9) translateX(calc(-3 * var(--i-amphthml-story-page-50vw, 50%) - 64px)) translateY(0%) !important;
+  transform: scale(0.9) translateX(calc(-3 * var(--i-amphtml-story-page-50vw, 50%) - 64px)) translateY(0%) !important;
 }
 
 .i-amphtml-story-desktop-panels amp-story-page[active],
 [dir=rtl] .i-amphtml-story-desktop-panels amp-story-page[active],
 .i-amphtml-story-desktop-panels amp-story-page[i-amphtml-desktop-position="0"],
 [dir=rtl] .i-amphtml-story-desktop-panels amp-story-page[i-amphtml-desktop-position="0"] {
-  transform: scale(1.0) translateX(calc(-1 * var(--i-amphthml-story-page-50vw, 50%))) translateY(0%) !important;
+  transform: scale(1.0) translateX(calc(-1 * var(--i-amphtml-story-page-50vw, 50%))) translateY(0%) !important;
   opacity: 1 !important;
 }
 
@@ -83,12 +83,12 @@ amp-story[standalone].i-amphtml-story-desktop-panels {
 .i-amphtml-story-desktop-panels .next-container > .i-amphtml-story-page-sentinel,
 [dir=rtl] .i-amphtml-story-desktop-panels amp-story-page[i-amphtml-desktop-position="-1"],
 [dir=rtl] .i-amphtml-story-desktop-panels .prev-container > .i-amphtml-story-page-sentinel {
-  transform: scale(0.9) translate(calc(var(--i-amphthml-story-page-50vw, 50%) + 64px), 0%) !important;
+  transform: scale(0.9) translate(calc(var(--i-amphtml-story-page-50vw, 50%) + 64px), 0%) !important;
 }
 
 .i-amphtml-story-desktop-panels amp-story-page[i-amphtml-desktop-position="2"],
 [dir=rtl] .i-amphtml-story-desktop-panels amp-story-page[i-amphtml-desktop-position="-2"] {
-  transform: scale(0.9) translate(calc(3 * var(--i-amphthml-story-page-50vw, 50%) + 128px), 0%) !important;
+  transform: scale(0.9) translate(calc(3 * var(--i-amphtml-story-page-50vw, 50%) + 128px), 0%) !important;
 }
 
 .i-amphtml-story-prev-hover > amp-story-page[i-amphtml-desktop-position="-1"] {

--- a/extensions/amp-story/1.0/amp-story-desktop-panels.css
+++ b/extensions/amp-story/1.0/amp-story-desktop-panels.css
@@ -61,21 +61,21 @@ amp-story[standalone].i-amphtml-story-desktop-panels {
 
 .i-amphtml-story-desktop-panels amp-story-page[i-amphtml-desktop-position="-2"],
 [dir=rtl] .i-amphtml-story-desktop-panels amp-story-page[i-amphtml-desktop-position="2"] {
-  transform: perspective(1px) scale(0.9) translateX(calc(-250% - 128px)) translateY(0%) !important;
+  transform: scale(0.9) translateX(calc(-5 * var(--story-page-50vw, 50%) - 128px)) translateY(0%) !important;
 }
 
 .i-amphtml-story-desktop-panels amp-story-page[i-amphtml-desktop-position="-1"],
 .i-amphtml-story-desktop-panels .prev-container > .i-amphtml-story-page-sentinel,
 [dir=rtl] .i-amphtml-story-desktop-panels amp-story-page[i-amphtml-desktop-position="1"],
 [dir=rtl] .i-amphtml-story-desktop-panels .next-container > .i-amphtml-story-page-sentinel {
-  transform: perspective(1px) scale(0.9) translateX(calc(-150% - 64px)) translateY(0%) !important;
+  transform: scale(0.9) translateX(calc(-3 * var(--story-page-50vw, 50%) - 64px)) translateY(0%) !important;
 }
 
 .i-amphtml-story-desktop-panels amp-story-page[active],
 [dir=rtl] .i-amphtml-story-desktop-panels amp-story-page[active],
 .i-amphtml-story-desktop-panels amp-story-page[i-amphtml-desktop-position="0"],
 [dir=rtl] .i-amphtml-story-desktop-panels amp-story-page[i-amphtml-desktop-position="0"] {
-  transform: perspective(1px) scale(1.0) translateX(-50%) translateY(0%) !important;
+  transform: scale(1.0) translateX(calc(-1 * var(--story-page-50vw, 50%))) translateY(0%) !important;
   opacity: 1 !important;
 }
 
@@ -83,12 +83,12 @@ amp-story[standalone].i-amphtml-story-desktop-panels {
 .i-amphtml-story-desktop-panels .next-container > .i-amphtml-story-page-sentinel,
 [dir=rtl] .i-amphtml-story-desktop-panels amp-story-page[i-amphtml-desktop-position="-1"],
 [dir=rtl] .i-amphtml-story-desktop-panels .prev-container > .i-amphtml-story-page-sentinel {
-  transform: perspective(1px) scale(0.9) translate(calc(50% + 64px), 0%) !important;
+  transform: scale(0.9) translate(calc(var(--story-page-50vw, 50%) + 64px), 0%) !important;
 }
 
 .i-amphtml-story-desktop-panels amp-story-page[i-amphtml-desktop-position="2"],
 [dir=rtl] .i-amphtml-story-desktop-panels amp-story-page[i-amphtml-desktop-position="-2"] {
-  transform: perspective(1px) scale(0.9) translate(calc(150% + 128px), 0%) !important;
+  transform: scale(0.9) translate(calc(3 * var(--story-page-50vw, 50%) + 128px), 0%) !important;
 }
 
 .i-amphtml-story-prev-hover > amp-story-page[i-amphtml-desktop-position="-1"] {

--- a/extensions/amp-story/1.0/amp-story-desktop-panels.css
+++ b/extensions/amp-story/1.0/amp-story-desktop-panels.css
@@ -61,21 +61,21 @@ amp-story[standalone].i-amphtml-story-desktop-panels {
 
 .i-amphtml-story-desktop-panels amp-story-page[i-amphtml-desktop-position="-2"],
 [dir=rtl] .i-amphtml-story-desktop-panels amp-story-page[i-amphtml-desktop-position="2"] {
-  transform: scale(0.9) translateX(calc(-5 * var(--story-page-50vw, 50%) - 128px)) translateY(0%) !important;
+  transform: scale(0.9) translateX(calc(-5 * var(--i-amphthml-story-page-50vw, 50%) - 128px)) translateY(0%) !important;
 }
 
 .i-amphtml-story-desktop-panels amp-story-page[i-amphtml-desktop-position="-1"],
 .i-amphtml-story-desktop-panels .prev-container > .i-amphtml-story-page-sentinel,
 [dir=rtl] .i-amphtml-story-desktop-panels amp-story-page[i-amphtml-desktop-position="1"],
 [dir=rtl] .i-amphtml-story-desktop-panels .next-container > .i-amphtml-story-page-sentinel {
-  transform: scale(0.9) translateX(calc(-3 * var(--story-page-50vw, 50%) - 64px)) translateY(0%) !important;
+  transform: scale(0.9) translateX(calc(-3 * var(--i-amphthml-story-page-50vw, 50%) - 64px)) translateY(0%) !important;
 }
 
 .i-amphtml-story-desktop-panels amp-story-page[active],
 [dir=rtl] .i-amphtml-story-desktop-panels amp-story-page[active],
 .i-amphtml-story-desktop-panels amp-story-page[i-amphtml-desktop-position="0"],
 [dir=rtl] .i-amphtml-story-desktop-panels amp-story-page[i-amphtml-desktop-position="0"] {
-  transform: scale(1.0) translateX(calc(-1 * var(--story-page-50vw, 50%))) translateY(0%) !important;
+  transform: scale(1.0) translateX(calc(-1 * var(--i-amphthml-story-page-50vw, 50%))) translateY(0%) !important;
   opacity: 1 !important;
 }
 
@@ -83,12 +83,12 @@ amp-story[standalone].i-amphtml-story-desktop-panels {
 .i-amphtml-story-desktop-panels .next-container > .i-amphtml-story-page-sentinel,
 [dir=rtl] .i-amphtml-story-desktop-panels amp-story-page[i-amphtml-desktop-position="-1"],
 [dir=rtl] .i-amphtml-story-desktop-panels .prev-container > .i-amphtml-story-page-sentinel {
-  transform: scale(0.9) translate(calc(var(--story-page-50vw, 50%) + 64px), 0%) !important;
+  transform: scale(0.9) translate(calc(var(--i-amphthml-story-page-50vw, 50%) + 64px), 0%) !important;
 }
 
 .i-amphtml-story-desktop-panels amp-story-page[i-amphtml-desktop-position="2"],
 [dir=rtl] .i-amphtml-story-desktop-panels amp-story-page[i-amphtml-desktop-position="-2"] {
-  transform: scale(0.9) translate(calc(3 * var(--story-page-50vw, 50%) + 128px), 0%) !important;
+  transform: scale(0.9) translate(calc(3 * var(--i-amphthml-story-page-50vw, 50%) + 128px), 0%) !important;
 }
 
 .i-amphtml-story-prev-hover > amp-story-page[i-amphtml-desktop-position="-1"] {

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -524,9 +524,9 @@ export class AmpStoryPage extends AMP.BaseElement {
             'style',
             `--story-page-vh: ${px(state.vh)};` +
               `--story-page-vw: ${px(state.vw)};` +
-              `--story-page-50vw: ${px(state.fiftyVw)};` +
               `--story-page-vmin: ${px(state.vmin)};` +
-              `--story-page-vmax: ${px(state.vmax)};`
+              `--story-page-vmax: ${px(state.vmax)};` +
+              `--i-amphtml-story-page-50vw: ${px(state.fiftyVw)};`
           );
         },
       },

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -496,6 +496,8 @@ export class AmpStoryPage extends AMP.BaseElement {
 
   /** @override */
   onMeasureChanged() {
+    // Only measures from the first story page, that always gets built because
+    // of the prerendering optimizations in place.
     if (!this.isFirstPage_) {
       return;
     }

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -522,6 +522,9 @@ export class AmpStoryPage extends AMP.BaseElement {
           state.vmax = Math.max(state.vh, state.vw);
         },
         mutate: state => {
+          if (state.vh === 0 && state.vw === 0) {
+            return;
+          }
           this.win.document.documentElement.setAttribute(
             'style',
             `--story-page-vh: ${px(state.vh)};` +

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -75,7 +75,7 @@ import {getMode} from '../../../src/mode';
 import {htmlFor} from '../../../src/static-template';
 import {isExperimentOn} from '../../../src/experiments';
 import {isMediaDisplayed, setTextBackgroundColor} from './utils';
-import {toggle} from '../../../src/style';
+import {px, toggle} from '../../../src/style';
 import {upgradeBackgroundAudio} from './audio';
 
 /**
@@ -233,6 +233,9 @@ export class AmpStoryPage extends AMP.BaseElement {
       100
     );
 
+    /** @private {boolean}  */
+    this.isFirstPage_ = false;
+
     /** @private {?LoadingSpinner} */
     this.loadingSpinner_ = null;
 
@@ -269,9 +272,6 @@ export class AmpStoryPage extends AMP.BaseElement {
 
     /** @private @const {!function(*)} */
     this.mediaPoolRejectFn_ = deferred.reject;
-
-    /** @private {boolean}  */
-    this.prerenderAllowed_ = false;
 
     /** @private {!PageState} */
     this.state_ = PageState.NOT_ACTIVE;
@@ -317,10 +317,7 @@ export class AmpStoryPage extends AMP.BaseElement {
   /** @override */
   firstAttachedCallback() {
     // Only prerender the first story page.
-    this.prerenderAllowed_ = matches(
-      this.element,
-      'amp-story-page:first-of-type'
-    );
+    this.isFirstPage_ = matches(this.element, 'amp-story-page:first-of-type');
   }
 
   /** @override */
@@ -497,6 +494,46 @@ export class AmpStoryPage extends AMP.BaseElement {
     ]);
   }
 
+  /** @override */
+  onMeasureChanged() {
+    if (!this.isFirstPage_) {
+      return;
+    }
+
+    return this.getVsync().runPromise(
+      {
+        measure: state => {
+          const uiState = this.storeService_.get(StateProperty.UI_STATE);
+          // The desktop panels UI uses CSS scale. Retrieving clientHeight/Width
+          // ensures we are getting the raw size, ignoring the scale.
+          const {width, height} =
+            uiState === UIType.DESKTOP_PANELS
+              ? {
+                  height: this.element./*OK*/ clientHeight,
+                  width: this.element./*OK*/ clientWidth,
+                }
+              : this.getLayoutBox();
+          state.vh = height / 100;
+          state.vw = width / 100;
+          state.fiftyVw = Math.round(width / 2);
+          state.vmin = Math.min(state.vh, state.vw);
+          state.vmax = Math.max(state.vh, state.vw);
+        },
+        mutate: state => {
+          this.win.document.documentElement.setAttribute(
+            'style',
+            `--story-page-vh: ${px(state.vh)};` +
+              `--story-page-vw: ${px(state.vw)};` +
+              `--story-page-50vw: ${px(state.fiftyVw)};` +
+              `--story-page-vmin: ${px(state.vmin)};` +
+              `--story-page-vmax: ${px(state.vmax)};`
+          );
+        },
+      },
+      {}
+    );
+  }
+
   /**
    * @private
    */
@@ -651,7 +688,7 @@ export class AmpStoryPage extends AMP.BaseElement {
 
   /** @override */
   prerenderAllowed() {
-    return this.prerenderAllowed_;
+    return this.isFirstPage_;
   }
 
   /**

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -94,7 +94,6 @@ import {
 } from '../../../src/dom';
 import {
   computedStyle,
-  px,
   resetStyles,
   setImportantStyles,
   toggle,
@@ -610,40 +609,6 @@ export class AmpStory extends AMP.BaseElement {
   }
 
   /**
-   * @private
-   */
-  updateViewportSizeStyles_() {
-    const pageEl =
-      (this.activePage_ && this.activePage_.element) ||
-      this.element.querySelector('amp-story-page');
-
-    if (!pageEl || !this.isStandalone_()) {
-      return;
-    }
-
-    return this.vsync_.runPromise(
-      {
-        measure: state => {
-          state.vh = pageEl./*OK*/ clientHeight / 100;
-          state.vw = pageEl./*OK*/ clientWidth / 100;
-          state.vmin = Math.min(state.vh, state.vw);
-          state.vmax = Math.max(state.vh, state.vw);
-        },
-        mutate: state => {
-          this.win.document.documentElement.setAttribute(
-            'style',
-            `--story-page-vh: ${px(state.vh)};` +
-              `--story-page-vw: ${px(state.vw)};` +
-              `--story-page-vmin: ${px(state.vmin)};` +
-              `--story-page-vmax: ${px(state.vmax)};`
-          );
-        },
-      },
-      {}
-    );
-  }
-
-  /**
    * Builds the system layer DOM.
    * @param {string} initialPageId
    * @private
@@ -1023,7 +988,6 @@ export class AmpStory extends AMP.BaseElement {
         }
       })
       .then(() => this.switchTo_(initialPageId, NavigationDirection.NEXT))
-      .then(() => this.updateViewportSizeStyles_())
       .then(() => {
         const shouldReOpenAttachmentForPageId = getHistoryState(
           this.win,
@@ -1059,10 +1023,7 @@ export class AmpStory extends AMP.BaseElement {
     // visible.
     if (!this.getAmpDoc().hasBeenVisible()) {
       return whenUpgradedToCustomElement(firstPageEl).then(() => {
-        return Promise.all([
-          firstPageEl.whenBuilt(),
-          this.updateViewportSizeStyles_(),
-        ]);
+        return firstPageEl.whenBuilt();
       });
     }
 
@@ -1740,8 +1701,6 @@ export class AmpStory extends AMP.BaseElement {
    * @visibleForTesting
    */
   onResize() {
-    this.updateViewportSizeStyles_();
-
     const uiState = this.getUIType_();
     this.storeService_.dispatch(Action.TOGGLE_UI, uiState);
 


### PR DESCRIPTION
- Moves the code that sets the `--story-page--*` CSS variables to `amp-story-page`
- Leverages the `onMeasureChanged()` runtime method to know when the `amp-story-page` actually gets resized
- Only measures from the first story page, that always gets built because of the prerendering optimizations we have (even with branching)
- `onMeasureChanged()` is called after `buildCallback` but before `layoutCallback`, so the story can't be marked as rendered before the CSS variables are set, as it waits for the first page to be fully loaded. Also works perfectly with prerendering (no jump)
- Fixes a bug where the previous code would sometimes measure the page on viewport resize before the page is actually resized
- Provides a rounded value to use for the `translate` and remove the unwanted border around `amp-story-page` elements on desktop

[Demo](https://stamp-gmajoulet.firebaseapp.com/examples/s20/body-painting/index.html)

Fixes #16626