### PR TITLE
✅ Skip broken amp-story-affiliate link test

### DIFF
--- a/extensions/amp-story/1.0/test/integration/test-amp-story-affiliate-link.js
+++ b/extensions/amp-story/1.0/test/integration/test-amp-story-affiliate-link.js
@@ -31,11 +31,11 @@ t.run('amp-story-affiliate link', () => {
       body: `
       <amp-story standalone>
         <amp-story-page id="page-1">
-          <amp-story-grid-layer template="vertical">            
+          <amp-story-grid-layer template="vertical">
             <h1>Third Page</h1>
             <a id="blink-1" href="https://amp.dev" role="link" target="_blank" affiliate-link-icon="shopping-cart">
               amp.devamp.devamp.devamp.devamp.devamp.dev
-            </a>      
+            </a>
           </amp-story-grid-layer>
         </amp-story-page>
       </amp-story>
@@ -77,7 +77,7 @@ t.run('amp-story-affiliate link', () => {
         expect(RequestBank.withdraw()).to.throw;
       });
 
-      it('should send analytics event on external click', async () => {
+      it.skip('should send analytics event on external click', async () => {
         browser.click('#blink-1');
         browser.click('#blink-1');
         const req = await RequestBank.withdraw();


### PR DESCRIPTION
Seems to be broken (or at least very flaky):
- https://travis-ci.org/ampproject/amphtml/jobs/640678925
- https://travis-ci.org/ampproject/amphtml/jobs/640676380
- https://travis-ci.org/ampproject/amphtml/jobs/640623255

This was skipped in https://github.com/ampproject/amphtml/pull/26386. That skip was reverted in https://github.com/ampproject/amphtml/pull/26395. I'm now un-reverting it.