### PR TITLE
🖍 Increase CSS byte limit from 50000 bytes to 75000 bytes

### DIFF
--- a/spec/amp-html-format.md
+++ b/spec/amp-html-format.md
@@ -363,7 +363,7 @@ In the following examples `<property>` needs to be in the white list above.
 
 #### Maximum size
 
-It is a validation error if the author stylesheet or inline styles together are larger than 50,000 bytes.
+It is a validation error if the author stylesheet or inline styles together are larger than 75,000 bytes.
 
 ### Keyframes stylesheet
 

--- a/validator/engine/validator_test.js
+++ b/validator/engine/validator_test.js
@@ -473,10 +473,10 @@ describe('ValidatorCssLength', () => {
   const validInlineStyleBlob = 'width:1px;';
   assertStrictEqual(10, validInlineStyleBlob.length);
 
-  it('accepts 50000 bytes in author stylesheet and 0 bytes in inline style',
+  it('accepts 75000 bytes in author stylesheet and 0 bytes in inline style',
       () => {
-        const stylesheet = Array(5001).join(validStyleBlob);
-        assertStrictEqual(50000, stylesheet.length);
+        const stylesheet = Array(7501).join(validStyleBlob);
+        assertStrictEqual(75000, stylesheet.length);
         const test = new ValidatorTestCase('feature_tests/css_length.html');
         test.inlineOutput = false;
         test.ampHtmlFileContents = test.ampHtmlFileContents
@@ -486,11 +486,11 @@ describe('ValidatorCssLength', () => {
         test.run();
       });
 
-  it('will not accept 50001 bytes in author stylesheet and 0 bytes in ' +
+  it('will not accept 75001 bytes in author stylesheet and 0 bytes in ' +
      'inline style',
   () => {
-    const stylesheet = Array(5001).join(validStyleBlob) + ' ';
-    assertStrictEqual(50001, stylesheet.length);
+    const stylesheet = Array(7501).join(validStyleBlob) + ' ';
+    assertStrictEqual(75001, stylesheet.length);
     const test = new ValidatorTestCase('feature_tests/css_length.html');
     test.inlineOutput = false;
     test.ampHtmlFileContents =
@@ -501,17 +501,17 @@ describe('ValidatorCssLength', () => {
     test.expectedOutput = 'FAIL\n' +
         'feature_tests/css_length.html:28:2 The author stylesheet ' +
         'specified in tag \'style amp-custom\' is too long - document ' +
-        'contains 50001 bytes whereas the limit is 50000 bytes. ' +
+        'contains 75001 bytes whereas the limit is 75000 bytes. ' +
         '(see https://amp.dev/documentation/guides-and-tutorials/' +
         'learn/spec/amphtml#maximum-size)';
     test.run();
   });
 
-  it('knows utf8 and rejects file with 50002 bytes but 49999 characters ' +
+  it('knows utf8 and rejects file with 75002 bytes but 74999 characters ' +
      'and 0 bytes in inline style',
   () => {
-    const stylesheet = Array(5000).join(validStyleBlob) + 'h {a: 😺}';
-    assertStrictEqual(49999, stylesheet.length); // character length
+    const stylesheet = Array(7500).join(validStyleBlob) + 'h {a: 😺}';
+    assertStrictEqual(74999, stylesheet.length); // character length
     const test = new ValidatorTestCase('feature_tests/css_length.html');
     test.inlineOutput = false;
     test.ampHtmlFileContents =
@@ -522,16 +522,16 @@ describe('ValidatorCssLength', () => {
     test.expectedOutput = 'FAIL\n' +
         'feature_tests/css_length.html:28:2 The author stylesheet ' +
         'specified in tag \'style amp-custom\' is too long - document ' +
-        'contains 50002 bytes whereas the limit is 50000 bytes. ' +
+        'contains 75002 bytes whereas the limit is 75000 bytes. ' +
         '(see https://amp.dev/documentation/guides-and-tutorials/' +
         'learn/spec/amphtml#maximum-size)';
     test.run();
   });
 
-  it('fails on 0 bytes in author stylesheet and 50000 bytes in inline style',
+  it('fails on 0 bytes in author stylesheet and 75000 bytes in inline style',
      () => {
-       const inlineStyle = Array(5001).join(validInlineStyleBlob);
-       assertStrictEqual(50000, inlineStyle.length);
+       const inlineStyle = Array(7501).join(validInlineStyleBlob);
+       assertStrictEqual(75000, inlineStyle.length);
        const test = new ValidatorTestCase('feature_tests/css_length.html');
        test.inlineOutput = false;
        test.ampHtmlFileContents =
@@ -539,17 +539,17 @@ describe('ValidatorCssLength', () => {
                .replace('replace_inline_style', inlineStyle);
        test.expectedOutput = 'FAIL\n' +
            'feature_tests/css_length.html:34:2 The inline style specified in ' +
-           'tag \'div\' is too long - it contains 50000 bytes whereas the ' +
+           'tag \'div\' is too long - it contains 75000 bytes whereas the ' +
            'limit is 1000 bytes. (see https://amp.dev/documentation/guides' +
            '-and-tutorials/learn/spec/amphtml#maximum-size)';
        test.run();
      });
 
-  it('will not accept 0 bytes in author stylesheet and 50001 bytes in ' +
+  it('will not accept 0 bytes in author stylesheet and 75001 bytes in ' +
      'inline style',
   () => {
-    const inlineStyle = Array(5001).join(validInlineStyleBlob) + ' ';
-    assertStrictEqual(50001, inlineStyle.length);
+    const inlineStyle = Array(7501).join(validInlineStyleBlob) + ' ';
+    assertStrictEqual(75001, inlineStyle.length);
     const test = new ValidatorTestCase('feature_tests/css_length.html');
     test.inlineOutput = false;
     test.ampHtmlFileContents =
@@ -558,23 +558,23 @@ describe('ValidatorCssLength', () => {
     test.expectedOutputFile = null;
     test.expectedOutput = 'FAIL\n' +
         'feature_tests/css_length.html:34:2 The inline style specified in ' +
-        'tag \'div\' is too long - it contains 50001 bytes whereas the ' +
+        'tag \'div\' is too long - it contains 75001 bytes whereas the ' +
         'limit is 1000 bytes. (see https://amp.dev/documentation/guides' +
         '-and-tutorials/learn/spec/amphtml#maximum-size)\n' +
         'feature_tests/css_length.html:36:6 The author stylesheet ' +
         'specified in tag \'style amp-custom\' and the combined inline ' +
-        'styles is too large - document contains 50001 bytes whereas the ' +
-        'limit is 50000 bytes. ' +
+        'styles is too large - document contains 75001 bytes whereas the ' +
+        'limit is 75000 bytes. ' +
         '(see https://amp.dev/documentation/guides-and-tutorials/' +
         'learn/spec/amphtml#maximum-size)';
     test.run();
   });
 
-  it('will not accept 50000 bytes in author stylesheet and 14 bytes in ' +
+  it('will not accept 75000 bytes in author stylesheet and 14 bytes in ' +
      'inline style',
   () => {
-    const stylesheet = Array(5001).join(validStyleBlob);
-    assertStrictEqual(50000, stylesheet.length);
+    const stylesheet = Array(7501).join(validStyleBlob);
+    assertStrictEqual(75000, stylesheet.length);
     const test = new ValidatorTestCase('feature_tests/css_length.html');
     test.inlineOutput = false;
     test.ampHtmlFileContents =
@@ -582,10 +582,10 @@ describe('ValidatorCssLength', () => {
            .replace('.replace_amp_custom {}', stylesheet)
            .replace('replace_inline_style', 'display:block;');
     test.expectedOutput = 'FAIL\n' +
-        'feature_tests/css_length.html:5036:6 The author stylesheet ' +
+        'feature_tests/css_length.html:7536:6 The author stylesheet ' +
         'specified in tag \'style amp-custom\' and the combined inline ' +
-        'styles is too large - document contains 50014 bytes whereas the ' +
-        'limit is 50000 bytes. ' +
+        'styles is too large - document contains 75014 bytes whereas the ' +
+        'limit is 75000 bytes. ' +
         '(see https://amp.dev/documentation/guides-and-tutorials/' +
         'learn/spec/amphtml#maximum-size)';
     test.run();
@@ -606,16 +606,16 @@ describe('ValidatorCssLengthWithUrls', () => {
   const validStyleBlob = 'h1 {a: b}\n';
   assertStrictEqual(10, validStyleBlob.length);
 
-  it('will accept 50010 bytes in author stylesheet that includes an URL ' +
+  it('will accept 75010 bytes in author stylesheet that includes an URL ' +
          'of 19 bytes',
   () => {
     const url = 'http://example.com/';
     assertStrictEqual(19, url.length);
     const cssWithUrl = 'a{b:url(\'' + url + '\')';
     assertStrictEqual(30, cssWithUrl.length);
-    const stylesheet = Array(4999).join(validStyleBlob) + cssWithUrl;
+    const stylesheet = Array(7499).join(validStyleBlob) + cssWithUrl;
     // 10 bytes over limit, 19 of which are the URL.
-    assertStrictEqual(50010, stylesheet.length);
+    assertStrictEqual(75010, stylesheet.length);
     const test = new ValidatorTestCase('feature_tests/css_length.html');
     test.inlineOutput = false;
     test.ampHtmlFileContents =
@@ -626,22 +626,22 @@ describe('ValidatorCssLengthWithUrls', () => {
     test.expectedOutput = 'FAIL\n' +
         'feature_tests/css_length.html:28:2 The author stylesheet ' +
         'specified in tag \'style amp-custom\' is too long - document ' +
-        'contains 50010 bytes whereas the limit is 50000 bytes. ' +
+        'contains 75010 bytes whereas the limit is 75000 bytes. ' +
         '(see https://amp.dev/documentation/guides-and-tutorials/' +
         'learn/spec/amphtml#maximum-size)';
     test.run();
   });
 
-  it('will accept 50010 bytes in stylesheet that includes a relative URL ' +
+  it('will accept 75010 bytes in stylesheet that includes a relative URL ' +
          'of 19 bytes',
   () => {
     const url = 'a-relative-url.html';
     assertStrictEqual(19, url.length);
     const cssWithUrl = 'a{b:url(\'' + url + '\')';
     assertStrictEqual(30, cssWithUrl.length);
-    const stylesheet = Array(4999).join(validStyleBlob) + cssWithUrl;
+    const stylesheet = Array(7499).join(validStyleBlob) + cssWithUrl;
     // 10 bytes over limit, 19 of which are the URL.
-    assertStrictEqual(50010, stylesheet.length);
+    assertStrictEqual(75010, stylesheet.length);
     const test = new ValidatorTestCase('feature_tests/css_length.html');
     test.inlineOutput = false;
     test.ampHtmlFileContents =
@@ -652,22 +652,22 @@ describe('ValidatorCssLengthWithUrls', () => {
     test.expectedOutput = 'FAIL\n' +
         'feature_tests/css_length.html:28:2 The author stylesheet ' +
         'specified in tag \'style amp-custom\' is too long - document ' +
-        'contains 50010 bytes whereas the limit is 50000 bytes. ' +
+        'contains 75010 bytes whereas the limit is 75000 bytes. ' +
         '(see https://amp.dev/documentation/guides-and-tutorials/' +
         'learn/spec/amphtml#maximum-size)';
     test.run();
   });
 
-  it('will accept 50010 bytes in stylesheet that includes a data URL ' +
+  it('will accept 75010 bytes in stylesheet that includes a data URL ' +
          'of 19 bytes',
   () => {
     const url = 'data:nineteen-bytes';
     assertStrictEqual(19, url.length);
     const cssWithUrl = 'a{b:url(\'' + url + '\')';
     assertStrictEqual(30, cssWithUrl.length);
-    const stylesheet = Array(4999).join(validStyleBlob) + cssWithUrl;
+    const stylesheet = Array(7499).join(validStyleBlob) + cssWithUrl;
     // 10 bytes over limit, 19 of which are the URL.
-    assertStrictEqual(50010, stylesheet.length);
+    assertStrictEqual(75010, stylesheet.length);
     const test = new ValidatorTestCase('feature_tests/css_length.html');
     test.inlineOutput = false;
     test.ampHtmlFileContents =
@@ -678,7 +678,7 @@ describe('ValidatorCssLengthWithUrls', () => {
     test.expectedOutput = 'FAIL\n' +
         'feature_tests/css_length.html:28:2 The author stylesheet ' +
         'specified in tag \'style amp-custom\' is too long - document ' +
-        'contains 50010 bytes whereas the limit is 50000 bytes. ' +
+        'contains 75010 bytes whereas the limit is 75000 bytes. ' +
         '(see https://amp.dev/documentation/guides-and-tutorials/' +
         'learn/spec/amphtml#maximum-size)';
     test.run();
@@ -700,16 +700,16 @@ describe('ValidatorTransformedAmpCssLengthWithUrls', () => {
   const validStyleBlob = 'h1 {a: b}\n';
   assertStrictEqual(10, validStyleBlob.length);
 
-  it('will accept 50010 bytes in author stylesheet that includes an URL ' +
+  it('will accept 75010 bytes in author stylesheet that includes an URL ' +
          'of 19 bytes',
   () => {
     const url = 'http://example.com/';
     assertStrictEqual(19, url.length);
     const cssWithUrl = 'a{b:url(\'' + url + '\')';
     assertStrictEqual(30, cssWithUrl.length);
-    const stylesheet = Array(4999).join(validStyleBlob) + cssWithUrl;
+    const stylesheet = Array(7499).join(validStyleBlob) + cssWithUrl;
     // 10 bytes over limit, 19 of which are the URL.
-    assertStrictEqual(50010, stylesheet.length);
+    assertStrictEqual(75010, stylesheet.length);
     const test =
         new ValidatorTestCase('transformed_feature_tests/css_length.html');
     test.inlineOutput = false;
@@ -722,16 +722,16 @@ describe('ValidatorTransformedAmpCssLengthWithUrls', () => {
     test.run();
   });
 
-  it('will accept 50010 bytes in stylesheet that includes a relative URL ' +
+  it('will accept 75010 bytes in stylesheet that includes a relative URL ' +
          'of 19 bytes',
   () => {
     const url = 'a-relative-url.html';
     assertStrictEqual(19, url.length);
     const cssWithUrl = 'a{b:url(\'' + url + '\')';
     assertStrictEqual(30, cssWithUrl.length);
-    const stylesheet = Array(4999).join(validStyleBlob) + cssWithUrl;
+    const stylesheet = Array(7499).join(validStyleBlob) + cssWithUrl;
     // 10 bytes over limit, 19 of which are the URL.
-    assertStrictEqual(50010, stylesheet.length);
+    assertStrictEqual(75010, stylesheet.length);
     const test =
         new ValidatorTestCase('transformed_feature_tests/css_length.html');
     test.inlineOutput = false;
@@ -744,16 +744,16 @@ describe('ValidatorTransformedAmpCssLengthWithUrls', () => {
     test.run();
   });
 
-  it('will accept 50010 bytes in stylesheet that includes a data URL ' +
+  it('will accept 75010 bytes in stylesheet that includes a data URL ' +
          'of 19 bytes',
   () => {
     const url = 'data:nineteen-bytes';
     assertStrictEqual(19, url.length);
     const cssWithUrl = 'a{b:url(\'' + url + '\')';
     assertStrictEqual(30, cssWithUrl.length);
-    const stylesheet = Array(4999).join(validStyleBlob) + cssWithUrl;
+    const stylesheet = Array(7499).join(validStyleBlob) + cssWithUrl;
     // 10 bytes over limit, 19 of which are the URL.
-    assertStrictEqual(50010, stylesheet.length);
+    assertStrictEqual(75010, stylesheet.length);
     const test =
         new ValidatorTestCase('transformed_feature_tests/css_length.html');
     test.inlineOutput = false;
@@ -765,8 +765,8 @@ describe('ValidatorTransformedAmpCssLengthWithUrls', () => {
     test.expectedOutput = 'FAIL\n' +
         'transformed_feature_tests/css_length.html:29:2 The author ' +
         'stylesheet specified in tag \'style amp-custom (transformed)\' ' +
-        'is too long - document contains 50010 bytes whereas the limit ' +
-        'is 50000 bytes. ' +
+        'is too long - document contains 75010 bytes whereas the limit ' +
+        'is 75000 bytes. ' +
         '(see https://amp.dev/documentation/guides-and-tutorials/' +
         'learn/spec/amphtml#maximum-size)';
     test.run();

--- a/validator/java/src/main/proto/validator.proto
+++ b/validator/java/src/main/proto/validator.proto
@@ -270,7 +270,7 @@ message CdataSpec {
   optional int32 max_bytes = 1 [default = -2];
   // If false, bytes inside URLs are not included in the byte calculation for
   // max_bytes. This is used for handling signed exchange transformations which
-  // can potentially take the number of bytes over the 50,000 byte limit due
+  // can potentially take the number of bytes over the 75,000 byte limit due
   // to rewriting URLs to point at an AMP Cache.
   optional bool url_bytes_included = 9 [default = true];
   // If provided, a URL which linking to a section / sentence in the

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -1257,7 +1257,7 @@ tags: {  # Special custom 'author' spreadsheet for AMP4ADS
     value_casei: "text/css"
   }
   cdata: {
-    max_bytes: 20000  # Smaller than AMP, which is 50,000.
+    max_bytes: 20000  # Smaller than AMP, which is 75,000.
     max_bytes_spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/a4a_spec#css"
     css_spec: {
       at_rule_spec: {
@@ -1346,7 +1346,7 @@ tags: {  # Special custom 'author' spreadsheet for AMP
   }
   # TODO(b/68756045): Whitelist CSS properties allowed in Dynamic Mail.
   cdata: {
-    max_bytes: 75000
+    max_bytes: 50000
     max_bytes_spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#maximum-size"
     css_spec: {
       at_rule_spec: {

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -33,7 +33,7 @@ script_spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/
 
 css_length_spec: {
   html_format: AMP
-  max_bytes: 50000
+  max_bytes: 75000
   max_bytes_per_inline_style: 1000
   spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#maximum-size"
 }
@@ -1058,7 +1058,7 @@ tags: {  # Special custom 'author' spreadsheet for AMP
     value_casei: "text/css"
   }
   cdata: {
-    max_bytes: 50000
+    max_bytes: 75000
     max_bytes_spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#maximum-size"
     css_spec: {
       at_rule_spec: {
@@ -1176,7 +1176,7 @@ tags: {  # Special custom 'author' spreadsheet for transformed AMP
     value_casei: "text/css"
   }
   cdata: {
-    max_bytes: 50000
+    max_bytes: 75000
     url_bytes_included: false
     max_bytes_spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#maximum-size"
     css_spec: {
@@ -1346,7 +1346,7 @@ tags: {  # Special custom 'author' spreadsheet for AMP
   }
   # TODO(b/68756045): Whitelist CSS properties allowed in Dynamic Mail.
   cdata: {
-    max_bytes: 50000
+    max_bytes: 75000
     max_bytes_spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#maximum-size"
     css_spec: {
       at_rule_spec: {

--- a/validator/validator.pb.go
+++ b/validator/validator.pb.go
@@ -1886,7 +1886,7 @@ type CdataSpec struct {
 	MaxBytes *int32 `protobuf:"varint,1,opt,name=max_bytes,json=maxBytes,def=-2" json:"max_bytes,omitempty"`
 	// If false, bytes inside URLs are not included in the byte calculation for
 	// max_bytes. This is used for handling signed exchange transformations which
-	// can potentially take the number of bytes over the 50,000 byte limit due
+	// can potentially take the number of bytes over the 75,000 byte limit due
 	// to rewriting URLs to point at an AMP Cache.
 	UrlBytesIncluded *bool `protobuf:"varint,9,opt,name=url_bytes_included,json=urlBytesIncluded,def=1" json:"url_bytes_included,omitempty"`
 	// If provided, a URL which linking to a section / sentence in the

--- a/validator/validator.proto
+++ b/validator/validator.proto
@@ -267,7 +267,7 @@ message CdataSpec {
   optional int32 max_bytes = 1 [default = -2];
   // If false, bytes inside URLs are not included in the byte calculation for
   // max_bytes. This is used for handling signed exchange transformations which
-  // can potentially take the number of bytes over the 50,000 byte limit due
+  // can potentially take the number of bytes over the 75,000 byte limit due
   // to rewriting URLs to point at an AMP Cache.
   optional bool url_bytes_included = 9 [default = true];
   // If provided, a URL which linking to a section / sentence in the


### PR DESCRIPTION
Increase allowed css byte_limit in validation. This PR implements #26466

Please note: Haven't made changes in this section of the codebase before, a more thorough review is appreciated.

**Edit**: Incorrect # reference for implementation.