### PR TITLE
✨ Start logging AMP URL on SwG Pages

### DIFF
--- a/extensions/amp-subscriptions-google/0.1/amp-subscriptions-google.js
+++ b/extensions/amp-subscriptions-google/0.1/amp-subscriptions-google.js
@@ -144,6 +144,7 @@ export class GoogleSubscriptionsPlatform {
       isFromUserAction: false,
       additionalParameters: null,
     });
+    this.runtime_.analytics().setUrl(ampdoc.getUrl());
     resolver();
 
     this.runtime_.setOnLoginRequest(request => {

--- a/extensions/amp-subscriptions-google/0.1/test/test-amp-subscriptions-google.js
+++ b/extensions/amp-subscriptions-google/0.1/test/test-amp-subscriptions-google.js
@@ -37,6 +37,7 @@ import {SubscriptionsScoreFactor} from '../../../amp-subscriptions/0.1/score-fac
 import {toggleExperiment} from '../../../../src/experiments';
 
 const PLATFORM_ID = 'subscribe.google.com';
+const AMP_URL = 'myAMPurl.amp';
 
 describes.realWin('amp-subscriptions-google', {amp: true}, env => {
   let ampdoc;
@@ -61,6 +62,7 @@ describes.realWin('amp-subscriptions-google', {amp: true}, env => {
     element = env.win.document.createElement('script');
     element.id = 'amp-subscriptions';
     env.win.document.head.appendChild(element);
+    env.sandbox.stub(ampdoc, 'getUrl').callsFake(() => AMP_URL);
     pageConfig = new PageConfig('example.org:basic', true);
     xhr = Services.xhrFor(env.win);
     viewer = Services.viewerForDoc(ampdoc);
@@ -140,7 +142,7 @@ describes.realWin('amp-subscriptions-google', {amp: true}, env => {
 
   it('should set the current URL in analytics', () => {
     const swgAnalytics = platform.runtime_.analytics();
-    expect(swgAnalytics.getContext().getUrl()).to.equal('about:srcdoc');
+    expect(swgAnalytics.getContext().getUrl()).to.equal(AMP_URL);
   });
 
   it('should reset runtime on platform reset', () => {

--- a/extensions/amp-subscriptions-google/0.1/test/test-amp-subscriptions-google.js
+++ b/extensions/amp-subscriptions-google/0.1/test/test-amp-subscriptions-google.js
@@ -138,6 +138,11 @@ describes.realWin('amp-subscriptions-google', {amp: true}, env => {
     return stub.args[0][0];
   }
 
+  it('should set the current URL in analytics', () => {
+    const swgAnalytics = platform.runtime_.analytics();
+    expect(swgAnalytics.getContext().getUrl()).to.equal('about:srcdoc');
+  });
+
   it('should reset runtime on platform reset', () => {
     expect(methods.reset).to.not.be.called;
     platform.reset();


### PR DESCRIPTION
* Start sending the current AMP URL to SwG's analytics logs.  This replaces the canonical URL swg-js now automatically sets in the analytics logs.