### PR TITLE
✨Add percentage display to <amp-story-quiz>

### DIFF
--- a/examples/amp-story/quiz.html
+++ b/examples/amp-story/quiz.html
@@ -70,7 +70,7 @@
           <option>7,000 years ago</option>
           <option correct>500,000 years ago</option>
           <option>2 million years ago</option>
-          <!-- <option>34 million years ago</option> -->
+          <option>34 million years ago</option>
         </amp-story-quiz>
       </amp-story-grid-layer>
     </amp-story-page>

--- a/examples/amp-story/quiz.html
+++ b/examples/amp-story/quiz.html
@@ -70,7 +70,7 @@
           <option>7,000 years ago</option>
           <option correct>500,000 years ago</option>
           <option>2 million years ago</option>
-          <option>34 million years ago</option>
+          <!-- <option>34 million years ago</option> -->
         </amp-story-quiz>
       </amp-story-grid-layer>
     </amp-story-page>

--- a/extensions/amp-story/1.0/amp-story-quiz.css
+++ b/extensions/amp-story/1.0/amp-story-quiz.css
@@ -22,6 +22,10 @@
     --incorrect-color: #F34E4E !important;
     --incorrect-color-shaded: #cc4141 !important;
     --accent-color: #005AF0;
+    --option-1-percentage: 100%;
+    --option-2-percentage: 50%;
+    --option-3-percentage: 25%;
+    --option-4-percentage: 12%;
     font-family: 'Poppins-bold', sans-serif !important;
     background: var(--accent-color) !important;
     border-radius: 32px !important;
@@ -83,6 +87,7 @@ h3.i-amphtml-story-quiz-prompt {
     border: solid 1px #DADCE0 !important;
     font-size: 16px !important;
     line-height: 20px !important;
+    overflow: hidden !important;
 }
 
 /* Truncate option text and add an ellipsis after 2 lines. */
@@ -121,6 +126,22 @@ h3.i-amphtml-story-quiz-prompt {
 [dir=rtl ] .i-amphtml-story-quiz-answer-choice {
     margin-left: 16px !important;
     margin-right: 0px !important;
+}
+
+.i-amphtml-story-quiz-percentage-text {
+    display: flex !important;
+    padding-left: 10px !important;
+    margin-left: auto !important;
+    color: #AAAAAA !important;
+    visibility: hidden !important;
+}
+
+.i-amphtml-story-quiz-post-selection .i-amphtml-story-quiz-percentage-text {
+    visibility: visible !important;
+}
+
+.i-amphtml-story-quiz-post-selection .i-amphtml-story-quiz-option-selected > .i-amphtml-story-quiz-percentage-text {
+    color: white !important;
 }
 
 .i-amphtml-story-quiz-post-selection :not([correct]) > .i-amphtml-story-quiz-answer-choice {
@@ -165,19 +186,72 @@ h3.i-amphtml-story-quiz-prompt {
     left: -1px !important;
     width: 100% !important;
     height: 100% !important;
+    border: 1px solid !important;
     border-radius: 32px !important;
     font-size: 16px !important;
     line-height: 20px !important;
 }
 
-.i-amphtml-story-quiz-post-selection .i-amphtml-story-quiz-option-selected[correct].i-amphtml-story-quiz-option::before {
+.i-amphtml-story-quiz-post-selection.i-amphtml-story-quiz-no-data .i-amphtml-story-quiz-option-selected[correct].i-amphtml-story-quiz-option::before {
     animation: option-select-correct forwards 150ms cubic-bezier(0.0, 0.0, 0.2, 1) !important;
     border: solid 1px !important;
 }
 
-.i-amphtml-story-quiz-post-selection .i-amphtml-story-quiz-option-selected:not([correct]).i-amphtml-story-quiz-option::before {
+.i-amphtml-story-quiz-post-selection.i-amphtml-story-quiz-no-data .i-amphtml-story-quiz-option-selected:not([correct]).i-amphtml-story-quiz-option::before {
     animation: option-select-incorrect forwards 150ms cubic-bezier(0.0, 0.0, 0.2, 1) !important;
     border: solid 1px !important;
+}
+
+.i-amphtml-story-quiz-post-selection:not(.i-amphtml-story-quiz-no-data) .i-amphtml-story-quiz-option:nth-of-type(1)::before {
+    transform: translateX(var(--option-1-percentage));
+}
+
+.i-amphtml-story-quiz-post-selection:not(.i-amphtml-story-quiz-no-data) .i-amphtml-story-quiz-option:nth-of-type(2)::before {
+    transform: translateX(var(--option-2-percentage));
+}
+
+.i-amphtml-story-quiz-post-selection:not(.i-amphtml-story-quiz-no-data) .i-amphtml-story-quiz-option:nth-of-type(3)::before {
+    transform: translateX(var(--option-3-percentage));
+}
+
+.i-amphtml-story-quiz-post-selection:not(.i-amphtml-story-quiz-no-data) .i-amphtml-story-quiz-option:nth-of-type(4)::before {
+    transform: translateX(var(--option-4-percentage));
+}
+
+.i-amphtml-story-quiz-post-selection:not(.i-amphtml-story-quiz-no-data) .i-amphtml-story-quiz-option::before {
+    left: -100% !important;
+    width: 100% !important;
+    height: 100% !important;
+    border-radius: 0px !important;
+    background: #ECEDEF !important;
+    color: #ECEDEF !important;
+    transition: transform 1s;
+}
+
+.i-amphtml-story-quiz-post-selection:not(.i-amphtml-story-quiz-no-data) .i-amphtml-story-quiz-option-selected[correct].i-amphtml-story-quiz-option {
+    background: var(--correct-color) !important;
+    border: none !important;
+    /* Ups the padding by one to account for the border which must be removed
+     * to allow the shading to reach the edge of the box */
+    padding: 9px 17px 9px 9px !important;
+}
+
+.i-amphtml-story-quiz-post-selection:not(.i-amphtml-story-quiz-no-data) .i-amphtml-story-quiz-option-selected:not([correct]).i-amphtml-story-quiz-option {
+    background: var(--incorrect-color) !important;
+    border: none !important;
+    /* Ups the padding by one to account for the border which must be removed
+     * to allow the shading to reach the edge of the box */
+    padding: 9px 17px 9px 9px !important;
+}
+
+.i-amphtml-story-quiz-post-selection:not(.i-amphtml-story-quiz-no-data) .i-amphtml-story-quiz-option-selected[correct].i-amphtml-story-quiz-option::before {
+    background: var(--correct-color-shaded) !important;
+    color: var(--correct-color-shaded) !important;
+}
+
+.i-amphtml-story-quiz-post-selection:not(.i-amphtml-story-quiz-no-data) .i-amphtml-story-quiz-option-selected:not([correct]).i-amphtml-story-quiz-option::before {
+    background: var(--incorrect-color-shaded) !important;
+    color: var(--incorrect-color-shaded) !important;
 }
 
 /**

--- a/extensions/amp-story/1.0/amp-story-quiz.css
+++ b/extensions/amp-story/1.0/amp-story-quiz.css
@@ -22,10 +22,10 @@
     --incorrect-color: #F34E4E !important;
     --incorrect-color-shaded: #cc4141 !important;
     --accent-color: #005AF0;
-    --option-1-percentage: 100%;
-    --option-2-percentage: 50%;
-    --option-3-percentage: 25%;
-    --option-4-percentage: 12%;
+    --option-1-percentage: 0%;
+    --option-2-percentage: 0%;
+    --option-3-percentage: 0%;
+    --option-4-percentage: 0%;
     font-family: 'Poppins-bold', sans-serif !important;
     background: var(--accent-color) !important;
     border-radius: 32px !important;
@@ -136,7 +136,7 @@ h3.i-amphtml-story-quiz-prompt {
     visibility: hidden !important;
 }
 
-.i-amphtml-story-quiz-post-selection .i-amphtml-story-quiz-percentage-text {
+.i-amphtml-story-quiz-post-selection.i-amphtml-story-quiz-has-data .i-amphtml-story-quiz-percentage-text {
     visibility: visible !important;
 }
 
@@ -192,33 +192,33 @@ h3.i-amphtml-story-quiz-prompt {
     line-height: 20px !important;
 }
 
-.i-amphtml-story-quiz-post-selection.i-amphtml-story-quiz-no-data .i-amphtml-story-quiz-option-selected[correct].i-amphtml-story-quiz-option::before {
+.i-amphtml-story-quiz-post-selection:not(.i-amphtml-story-quiz-has-data) .i-amphtml-story-quiz-option-selected[correct].i-amphtml-story-quiz-option::before {
     animation: option-select-correct forwards 150ms cubic-bezier(0.0, 0.0, 0.2, 1) !important;
     border: solid 1px !important;
 }
 
-.i-amphtml-story-quiz-post-selection.i-amphtml-story-quiz-no-data .i-amphtml-story-quiz-option-selected:not([correct]).i-amphtml-story-quiz-option::before {
+.i-amphtml-story-quiz-post-selection:not(.i-amphtml-story-quiz-has-data) .i-amphtml-story-quiz-option-selected:not([correct]).i-amphtml-story-quiz-option::before {
     animation: option-select-incorrect forwards 150ms cubic-bezier(0.0, 0.0, 0.2, 1) !important;
     border: solid 1px !important;
 }
 
-.i-amphtml-story-quiz-post-selection:not(.i-amphtml-story-quiz-no-data) .i-amphtml-story-quiz-option:nth-of-type(1)::before {
+.i-amphtml-story-quiz-post-selection.i-amphtml-story-quiz-has-data .i-amphtml-story-quiz-option:nth-of-type(1)::before {
     transform: translateX(var(--option-1-percentage));
 }
 
-.i-amphtml-story-quiz-post-selection:not(.i-amphtml-story-quiz-no-data) .i-amphtml-story-quiz-option:nth-of-type(2)::before {
+.i-amphtml-story-quiz-post-selection.i-amphtml-story-quiz-has-data .i-amphtml-story-quiz-option:nth-of-type(2)::before {
     transform: translateX(var(--option-2-percentage));
 }
 
-.i-amphtml-story-quiz-post-selection:not(.i-amphtml-story-quiz-no-data) .i-amphtml-story-quiz-option:nth-of-type(3)::before {
+.i-amphtml-story-quiz-post-selection.i-amphtml-story-quiz-has-data .i-amphtml-story-quiz-option:nth-of-type(3)::before {
     transform: translateX(var(--option-3-percentage));
 }
 
-.i-amphtml-story-quiz-post-selection:not(.i-amphtml-story-quiz-no-data) .i-amphtml-story-quiz-option:nth-of-type(4)::before {
+.i-amphtml-story-quiz-post-selection.i-amphtml-story-quiz-has-data .i-amphtml-story-quiz-option:nth-of-type(4)::before {
     transform: translateX(var(--option-4-percentage));
 }
 
-.i-amphtml-story-quiz-post-selection:not(.i-amphtml-story-quiz-no-data) .i-amphtml-story-quiz-option::before {
+.i-amphtml-story-quiz-post-selection.i-amphtml-story-quiz-has-data .i-amphtml-story-quiz-option::before {
     left: -100% !important;
     width: 100% !important;
     height: 100% !important;
@@ -228,7 +228,7 @@ h3.i-amphtml-story-quiz-prompt {
     transition: transform 1s;
 }
 
-.i-amphtml-story-quiz-post-selection:not(.i-amphtml-story-quiz-no-data) .i-amphtml-story-quiz-option-selected[correct].i-amphtml-story-quiz-option {
+.i-amphtml-story-quiz-post-selection.i-amphtml-story-quiz-has-data .i-amphtml-story-quiz-option-selected[correct].i-amphtml-story-quiz-option {
     background: var(--correct-color) !important;
     border: none !important;
     /* Ups the padding by one to account for the border which must be removed
@@ -236,7 +236,7 @@ h3.i-amphtml-story-quiz-prompt {
     padding: 9px 17px 9px 9px !important;
 }
 
-.i-amphtml-story-quiz-post-selection:not(.i-amphtml-story-quiz-no-data) .i-amphtml-story-quiz-option-selected:not([correct]).i-amphtml-story-quiz-option {
+.i-amphtml-story-quiz-post-selection.i-amphtml-story-quiz-has-data .i-amphtml-story-quiz-option-selected:not([correct]).i-amphtml-story-quiz-option {
     background: var(--incorrect-color) !important;
     border: none !important;
     /* Ups the padding by one to account for the border which must be removed
@@ -244,12 +244,12 @@ h3.i-amphtml-story-quiz-prompt {
     padding: 9px 17px 9px 9px !important;
 }
 
-.i-amphtml-story-quiz-post-selection:not(.i-amphtml-story-quiz-no-data) .i-amphtml-story-quiz-option-selected[correct].i-amphtml-story-quiz-option::before {
+.i-amphtml-story-quiz-post-selection.i-amphtml-story-quiz-has-data .i-amphtml-story-quiz-option-selected[correct].i-amphtml-story-quiz-option::before {
     background: var(--correct-color-shaded) !important;
     color: var(--correct-color-shaded) !important;
 }
 
-.i-amphtml-story-quiz-post-selection:not(.i-amphtml-story-quiz-no-data) .i-amphtml-story-quiz-option-selected:not([correct]).i-amphtml-story-quiz-option::before {
+.i-amphtml-story-quiz-post-selection.i-amphtml-story-quiz-has-data .i-amphtml-story-quiz-option-selected:not([correct]).i-amphtml-story-quiz-option::before {
     background: var(--incorrect-color-shaded) !important;
     color: var(--incorrect-color-shaded) !important;
 }

--- a/extensions/amp-story/1.0/amp-story-quiz.css
+++ b/extensions/amp-story/1.0/amp-story-quiz.css
@@ -218,13 +218,14 @@ h3.i-amphtml-story-quiz-prompt {
 }
 
 .i-amphtml-story-quiz-post-selection.i-amphtml-story-quiz-has-data .i-amphtml-story-quiz-option::before {
-    left: -100% !important;
+    left: -101% !important;
     width: 100% !important;
     height: 100% !important;
     border-radius: 0px !important;
     background: #ECEDEF !important;
     color: #ECEDEF !important;
     transition: transform 1s !important;
+    border: solid 2px !important;
 }
 
 .i-amphtml-story-quiz-post-selection.i-amphtml-story-quiz-has-data .i-amphtml-story-quiz-option-selected[correct].i-amphtml-story-quiz-option {

--- a/extensions/amp-story/1.0/amp-story-quiz.css
+++ b/extensions/amp-story/1.0/amp-story-quiz.css
@@ -203,19 +203,19 @@ h3.i-amphtml-story-quiz-prompt {
 }
 
 .i-amphtml-story-quiz-post-selection.i-amphtml-story-quiz-has-data .i-amphtml-story-quiz-option:nth-of-type(1)::before {
-    transform: translateX(var(--option-1-percentage));
+    transform: translateX(var(--option-1-percentage)) !important;
 }
 
 .i-amphtml-story-quiz-post-selection.i-amphtml-story-quiz-has-data .i-amphtml-story-quiz-option:nth-of-type(2)::before {
-    transform: translateX(var(--option-2-percentage));
+    transform: translateX(var(--option-2-percentage)) !important;
 }
 
 .i-amphtml-story-quiz-post-selection.i-amphtml-story-quiz-has-data .i-amphtml-story-quiz-option:nth-of-type(3)::before {
-    transform: translateX(var(--option-3-percentage));
+    transform: translateX(var(--option-3-percentage)) !important;
 }
 
 .i-amphtml-story-quiz-post-selection.i-amphtml-story-quiz-has-data .i-amphtml-story-quiz-option:nth-of-type(4)::before {
-    transform: translateX(var(--option-4-percentage));
+    transform: translateX(var(--option-4-percentage)) !important;
 }
 
 .i-amphtml-story-quiz-post-selection.i-amphtml-story-quiz-has-data .i-amphtml-story-quiz-option::before {
@@ -225,7 +225,7 @@ h3.i-amphtml-story-quiz-prompt {
     border-radius: 0px !important;
     background: #ECEDEF !important;
     color: #ECEDEF !important;
-    transition: transform 1s;
+    transition: transform 1s !important;
 }
 
 .i-amphtml-story-quiz-post-selection.i-amphtml-story-quiz-has-data .i-amphtml-story-quiz-option-selected[correct].i-amphtml-story-quiz-option {

--- a/extensions/amp-story/1.0/amp-story-quiz.css
+++ b/extensions/amp-story/1.0/amp-story-quiz.css
@@ -77,6 +77,8 @@ h3.i-amphtml-story-quiz-prompt {
 .i-amphtml-story-quiz-option {
     position: relative !important;
     display: flex !important;
+    box-sizing: border-box;
+    height: 58px !important;
     justify-items: start !important;
     align-items: center !important;
     border-radius: 30px !important;
@@ -89,6 +91,10 @@ h3.i-amphtml-story-quiz-prompt {
     line-height: 20px !important;
     overflow: hidden !important;
     z-index: 0 !important;
+}
+
+[dir=rtl] .i-amphtml-story-quiz-option {
+    padding: 8px 8px 8px 16px !important;
 }
 
 /* Truncate option text and add an ellipsis after 2 lines. */
@@ -135,6 +141,13 @@ h3.i-amphtml-story-quiz-prompt {
     margin-left: auto !important;
     color: #AAAAAA !important;
     visibility: hidden !important;
+}
+
+[dir=rtl ] .i-amphtml-story-quiz-percentage-text {
+    padding-left: 0px !important;
+    padding-right: 10px !important;
+    margin-right: auto !important;
+    margin-left: 0px !important;
 }
 
 .i-amphtml-story-quiz-post-selection.i-amphtml-story-quiz-has-data .i-amphtml-story-quiz-percentage-text {
@@ -218,6 +231,23 @@ h3.i-amphtml-story-quiz-prompt {
     transform: translateX(var(--option-4-percentage)) !important;
 }
 
+
+.i-amphtml-story-quiz-post-selection.i-amphtml-story-quiz-has-data[dir=rtl] .i-amphtml-story-quiz-option:nth-of-type(1)::before {
+    transform: translateX(calc(-1 * var(--option-1-percentage))) !important;
+}
+
+.i-amphtml-story-quiz-post-selection.i-amphtml-story-quiz-has-data[dir=rtl] .i-amphtml-story-quiz-option:nth-of-type(2)::before {
+    transform: translateX(calc(-1 * var(--option-2-percentage))) !important;
+}
+
+.i-amphtml-story-quiz-post-selection.i-amphtml-story-quiz-has-data[dir=rtl] .i-amphtml-story-quiz-option:nth-of-type(3)::before {
+    transform: translateX(calc(-1 * var(--option-3-percentage))) !important;
+}
+
+.i-amphtml-story-quiz-post-selection.i-amphtml-story-quiz-has-data[dir=rtl] .i-amphtml-story-quiz-option:nth-of-type(4)::before {
+    transform: translateX(calc(-1 * var(--option-4-percentage))) !important;
+}
+
 .i-amphtml-story-quiz-post-selection.i-amphtml-story-quiz-has-data .i-amphtml-story-quiz-option::before {
     left: -101% !important;
     width: 100% !important;
@@ -229,20 +259,29 @@ h3.i-amphtml-story-quiz-prompt {
     border: solid 2px !important;
 }
 
+.i-amphtml-story-quiz-post-selection.i-amphtml-story-quiz-has-data[dir=rtl] .i-amphtml-story-quiz-option::before {
+    left: 101% !important;
+}
+
 .i-amphtml-story-quiz-post-selection.i-amphtml-story-quiz-has-data .i-amphtml-story-quiz-option-selected[correct].i-amphtml-story-quiz-option {
     background: var(--correct-color) !important;
     border: none !important;
-    /* Ups the padding by one to account for the border which must be removed
-     * to allow the shading to reach the edge of the box */
-    padding: 9px 17px 9px 9px !important;
 }
 
 .i-amphtml-story-quiz-post-selection.i-amphtml-story-quiz-has-data .i-amphtml-story-quiz-option-selected:not([correct]).i-amphtml-story-quiz-option {
     background: var(--incorrect-color) !important;
     border: none !important;
+}
+
+.i-amphtml-story-quiz-post-selection.i-amphtml-story-quiz-has-data .i-amphtml-story-quiz-option-selected.i-amphtml-story-quiz-option {
     /* Ups the padding by one to account for the border which must be removed
      * to allow the shading to reach the edge of the box */
-    padding: 9px 17px 9px 9px !important;
+     padding: 9px 17px 9px 9px !important;
+}
+
+.i-amphtml-story-quiz-post-selection.i-amphtml-story-quiz-has-data[dir=rtl] .i-amphtml-story-quiz-option-selected.i-amphtml-story-quiz-option {
+    /* Switches the extra padding to the left from the right, since the answer choice and the percentage switch */
+    padding: 9px 9px 9px 17px !important;
 }
 
 .i-amphtml-story-quiz-post-selection.i-amphtml-story-quiz-has-data .i-amphtml-story-quiz-option-selected[correct].i-amphtml-story-quiz-option::before {

--- a/extensions/amp-story/1.0/amp-story-quiz.css
+++ b/extensions/amp-story/1.0/amp-story-quiz.css
@@ -77,8 +77,6 @@ h3.i-amphtml-story-quiz-prompt {
 .i-amphtml-story-quiz-option {
     position: relative !important;
     display: flex !important;
-    box-sizing: border-box;
-    height: 58px !important;
     justify-items: start !important;
     align-items: center !important;
     border-radius: 30px !important;

--- a/extensions/amp-story/1.0/amp-story-quiz.css
+++ b/extensions/amp-story/1.0/amp-story-quiz.css
@@ -186,7 +186,6 @@ h3.i-amphtml-story-quiz-prompt {
     left: -1px !important;
     width: 100% !important;
     height: 100% !important;
-    border: 1px solid !important;
     border-radius: 32px !important;
     font-size: 16px !important;
     line-height: 20px !important;

--- a/extensions/amp-story/1.0/amp-story-quiz.css
+++ b/extensions/amp-story/1.0/amp-story-quiz.css
@@ -88,6 +88,7 @@ h3.i-amphtml-story-quiz-prompt {
     font-size: 16px !important;
     line-height: 20px !important;
     overflow: hidden !important;
+    z-index: 0 !important;
 }
 
 /* Truncate option text and add an ellipsis after 2 lines. */

--- a/extensions/amp-story/1.0/amp-story-quiz.js
+++ b/extensions/amp-story/1.0/amp-story-quiz.js
@@ -435,12 +435,13 @@ export class AmpStoryQuiz extends AMP.BaseElement {
       0
     );
 
-    // Special case: ties with remainder 0.5 cause total to rise above 100.
+    // Special case: divide remainders by three if they break 100,
+    // 3 is the maximum above 100 the remainders can add.
     if (total > 100) {
       percentages = percentages.map(percentage =>
-        (percentage - Math.floor(percentage)).toFixed(2) === '0.50'
-          ? (Math.floor(percentage) + 0.49).toFixed(2)
-          : percentage
+        (percentage - (2 * (percentage - Math.floor(percentage))) / 3).toFixed(
+          2
+        )
       );
 
       total = percentages.reduce(
@@ -523,7 +524,7 @@ export class AmpStoryQuiz extends AMP.BaseElement {
       if (this.responseData_) {
         this.responseData_['totalResponseCount']++;
         this.responseData_['responses'].forEach(response => {
-          if (response['reactionValue'] === optionEl.optionIndex_) {
+          if (Number(response['reactionValue']) === optionEl.optionIndex_) {
             response['totalCount']++;
           }
         });

--- a/extensions/amp-story/1.0/amp-story-quiz.js
+++ b/extensions/amp-story/1.0/amp-story-quiz.js
@@ -30,6 +30,7 @@ import {dev} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
 import {getRequestService} from './amp-story-request-service';
 import {htmlFor} from '../../../src/static-template';
+import {setStyles} from '../../../src/style';
 import {toArray} from '../../../src/types';
 
 /** @const {!Array<string>} */
@@ -375,8 +376,8 @@ export class AmpStoryQuiz extends AMP.BaseElement {
     this.quizEl_.classList.add('i-amphtml-story-quiz-post-selection');
     selectedOption.classList.add('i-amphtml-story-quiz-option-selected');
 
-    if (!this.responseData_) {
-      this.quizEl_.classList.add('i-amphtml-story-quiz-no-data');
+    if (this.responseData_) {
+      this.quizEl_.classList.add('i-amphtml-story-quiz-has-data');
     }
   }
 
@@ -392,10 +393,9 @@ export class AmpStoryQuiz extends AMP.BaseElement {
       this.quizEl_.querySelectorAll('.i-amphtml-story-quiz-option')
     );
 
-    // TODO: PREPROCCESS PERCENTAGES
     const percentages = this.preprocessPercentages_(options.length);
 
-    // update percentage text
+    // Update percentage text boxes.
     this.responseData_['responses'].forEach(response => {
       options[response['reactionValue']].querySelector(
         '.i-amphtml-story-quiz-percentage-text'
@@ -403,6 +403,16 @@ export class AmpStoryQuiz extends AMP.BaseElement {
     });
 
     // update percentage CSS vars
+    // TODO: USE SET ATTRIBUTE!
+    this.quizEl_.setAttribute(
+      'style',
+      `
+      --option-1-percentage: ${percentages[0]}%;
+      --option-2-percentage: ${percentages[1]}%;
+      --option-3-percentage: ${percentages[2]}%;
+      --option-4-percentage: ${percentages[3]}%;
+    `
+    );
   }
 
   /**
@@ -433,7 +443,7 @@ export class AmpStoryQuiz extends AMP.BaseElement {
     if (total > 100) {
       percentages = percentages.map(percentage =>
         (percentage - Math.trunc(percentage)).toFixed(2) === '0.50'
-          ? Math.trunc(percentage).toFixed(2)
+          ? (Math.trunc(percentage) + 0.49).toFixed(2)
           : percentage
       );
       total = percentages.reduce(

--- a/extensions/amp-story/1.0/amp-story-quiz.js
+++ b/extensions/amp-story/1.0/amp-story-quiz.js
@@ -388,7 +388,7 @@ export class AmpStoryQuiz extends AMP.BaseElement {
       return;
     }
 
-    const options = Array.from(
+    const options = toArray(
       this.quizEl_.querySelectorAll('.i-amphtml-story-quiz-option')
     );
 
@@ -438,8 +438,8 @@ export class AmpStoryQuiz extends AMP.BaseElement {
     // Special case: ties with remainder 0.5 cause total to rise above 100.
     if (total > 100) {
       percentages = percentages.map(percentage =>
-        (percentage - Math.trunc(percentage)).toFixed(2) === '0.50'
-          ? (Math.trunc(percentage) + 0.49).toFixed(2)
+        (percentage - Math.floor(percentage)).toFixed(2) === '0.50'
+          ? (Math.floor(percentage) + 0.49).toFixed(2)
           : percentage
       );
 
@@ -461,7 +461,7 @@ export class AmpStoryQuiz extends AMP.BaseElement {
         return {
           originalIndex: index,
           value: percentage,
-          remainder: (percentage - Math.trunc(percentage)).toFixed(2),
+          remainder: (percentage - Math.floor(percentage)).toFixed(2),
         };
       });
       preserveOriginal.sort(
@@ -486,7 +486,7 @@ export class AmpStoryQuiz extends AMP.BaseElement {
 
         ties.forEach(percentageObj => {
           finalPercentages[percentageObj.originalIndex] =
-            Math.trunc(percentageObj.value) + (toRoundUp ? 1 : 0);
+            Math.floor(percentageObj.value) + (toRoundUp ? 1 : 0);
         });
 
         // Update the remainder given additions to the percentages.
@@ -494,7 +494,7 @@ export class AmpStoryQuiz extends AMP.BaseElement {
       }
 
       preserveOriginal.forEach(percentageObj => {
-        finalPercentages[percentageObj.originalIndex] = Math.trunc(
+        finalPercentages[percentageObj.originalIndex] = Math.floor(
           percentageObj.value
         );
       });

--- a/extensions/amp-story/1.0/amp-story-quiz.js
+++ b/extensions/amp-story/1.0/amp-story-quiz.js
@@ -423,14 +423,13 @@ export class AmpStoryQuiz extends AMP.BaseElement {
       ).toFixed(2);
     }
 
-    // now perform truncations, preserving order, ties, and adding to 100
     let total = percentages.reduce(
       (currentTotal, currentValue) =>
         (currentTotal += Math.round(currentValue)),
       0
     );
 
-    // Special case: ties with remainder 0.5 cause total to rise above 100
+    // Special case: ties with remainder 0.5 cause total to rise above 100.
     if (total > 100) {
       percentages = percentages.map(percentage =>
         (percentage - Math.trunc(percentage)).toFixed(2) === '0.50'
@@ -447,7 +446,8 @@ export class AmpStoryQuiz extends AMP.BaseElement {
     if (total === 100) {
       return percentages.map(percentage => Math.round(percentage));
     } else {
-      // trunc, preserve ties, order, & 100 sum
+      // Truncate all and round up those with the highest remainders,
+      // preserving order and ties and adding to 100 (if possible given ties and ordering).
       let remainder = 100 - total;
 
       let preserveOriginal = percentages.map((percentage, index) => {
@@ -465,7 +465,6 @@ export class AmpStoryQuiz extends AMP.BaseElement {
       const finalPercentages = [];
 
       while (remainder > 0 && preserveOriginal.length !== 0) {
-        // grab highest remainder
         const highestRemainderObj = preserveOriginal[0];
 
         const ties = preserveOriginal.filter(
@@ -478,11 +477,17 @@ export class AmpStoryQuiz extends AMP.BaseElement {
         ties.forEach(percentageObj => {
           finalPercentages[percentageObj.originalIndex] =
             Math.trunc(percentageObj.value) +
-            (ties.length <= remainder ? 1 : 0);
+            (ties.length <= remainder &&
+            highestRemainderObj.remainder !== '0.00'
+              ? 1
+              : 0);
         });
 
-        // update remainder
-        remainder -= ties.length;
+        // Update the remainder given additions to the percentages.
+        remainder -=
+          ties.length <= remainder && highestRemainderObj.remainder !== '0.00'
+            ? ties.length
+            : 0;
       }
 
       preserveOriginal.forEach(percentageObj => {

--- a/extensions/amp-story/1.0/amp-story-quiz.js
+++ b/extensions/amp-story/1.0/amp-story-quiz.js
@@ -392,10 +392,7 @@ export class AmpStoryQuiz extends AMP.BaseElement {
       this.quizEl_.querySelectorAll('.i-amphtml-story-quiz-option')
     );
 
-    const percentages = this.preprocessPercentages_(
-      this.responseData_,
-      options.length
-    );
+    const percentages = this.preprocessPercentages_(this.responseData_);
 
     this.responseData_['responses'].forEach(response => {
       options[response['reactionValue']].querySelector(
@@ -418,12 +415,11 @@ export class AmpStoryQuiz extends AMP.BaseElement {
    * Preprocess the percentages for display.
    *
    * @param {ReactionResponseType} responseData
-   * @param {number} numOptions
    * @return {Array<number>}
    * @private
    */
-  preprocessPercentages_(responseData, numOptions) {
-    let percentages = new Array(numOptions).fill(0);
+  preprocessPercentages_(responseData) {
+    let percentages = [];
 
     for (let i = 0; i < responseData['responses'].length; i++) {
       percentages[i] = (

--- a/extensions/amp-story/1.0/amp-story-quiz.js
+++ b/extensions/amp-story/1.0/amp-story-quiz.js
@@ -30,7 +30,6 @@ import {dev} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
 import {getRequestService} from './amp-story-request-service';
 import {htmlFor} from '../../../src/static-template';
-import {setStyles} from '../../../src/style';
 import {toArray} from '../../../src/types';
 
 /** @const {!Array<string>} */
@@ -393,17 +392,17 @@ export class AmpStoryQuiz extends AMP.BaseElement {
       this.quizEl_.querySelectorAll('.i-amphtml-story-quiz-option')
     );
 
-    const percentages = this.preprocessPercentages_(options.length);
+    const percentages = this.preprocessPercentages_(
+      this.responseData_,
+      options.length
+    );
 
-    // Update percentage text boxes.
     this.responseData_['responses'].forEach(response => {
       options[response['reactionValue']].querySelector(
         '.i-amphtml-story-quiz-percentage-text'
       ).textContent = `${percentages[response['reactionValue']]}%`;
     });
 
-    // update percentage CSS vars
-    // TODO: USE SET ATTRIBUTE!
     this.quizEl_.setAttribute(
       'style',
       `
@@ -416,20 +415,21 @@ export class AmpStoryQuiz extends AMP.BaseElement {
   }
 
   /**
-   * Preprocess the percentages for display
+   * Preprocess the percentages for display.
    *
+   * @param {ReactionResponseType} responseData
    * @param {number} numOptions
    * @return {Array<number>}
    * @private
    */
-  preprocessPercentages_(numOptions) {
-    const totalResponseCount = this.responseData_['totalResponseCount'];
+  preprocessPercentages_(responseData, numOptions) {
+    const totalResponseCount = responseData['totalResponseCount'];
     let percentages = new Array(numOptions).fill(0);
 
-    for (let i = 0; i < this.responseData_['responses'].length; i++) {
+    for (let i = 0; i < responseData['responses'].length; i++) {
       percentages[i] = (
         100 *
-        (this.responseData_['responses'][i]['totalCount'] / totalResponseCount)
+        (responseData['responses'][i]['totalCount'] / totalResponseCount)
       ).toFixed(2);
     }
 
@@ -469,7 +469,7 @@ export class AmpStoryQuiz extends AMP.BaseElement {
       });
       preserveOriginal.sort(
         (left, right) =>
-          // Break remainder ties using the higher value
+          // Break remainder ties using the higher value.
           right.remainder - left.remainder || right.value - left.value
       );
       const finalPercentages = [];

--- a/extensions/amp-story/1.0/amp-story-quiz.js
+++ b/extensions/amp-story/1.0/amp-story-quiz.js
@@ -423,13 +423,13 @@ export class AmpStoryQuiz extends AMP.BaseElement {
    * @private
    */
   preprocessPercentages_(responseData, numOptions) {
-    const totalResponseCount = responseData['totalResponseCount'];
     let percentages = new Array(numOptions).fill(0);
 
     for (let i = 0; i < responseData['responses'].length; i++) {
       percentages[i] = (
         100 *
-        (responseData['responses'][i]['totalCount'] / totalResponseCount)
+        (responseData['responses'][i]['totalCount'] /
+          responseData['totalResponseCount'])
       ).toFixed(2);
     }
 
@@ -446,6 +446,7 @@ export class AmpStoryQuiz extends AMP.BaseElement {
           ? (Math.trunc(percentage) + 0.49).toFixed(2)
           : percentage
       );
+
       total = percentages.reduce(
         (currentTotal, currentValue) =>
           (currentTotal += Math.round(currentValue)),
@@ -472,8 +473,8 @@ export class AmpStoryQuiz extends AMP.BaseElement {
           // Break remainder ties using the higher value.
           right.remainder - left.remainder || right.value - left.value
       );
-      const finalPercentages = [];
 
+      const finalPercentages = [];
       while (remainder > 0 && preserveOriginal.length !== 0) {
         const highestRemainderObj = preserveOriginal[0];
 
@@ -484,20 +485,16 @@ export class AmpStoryQuiz extends AMP.BaseElement {
           percentageObj => percentageObj.value !== highestRemainderObj.value
         );
 
+        const toRoundUp =
+          ties.length <= remainder && highestRemainderObj.remainder !== '0.00';
+
         ties.forEach(percentageObj => {
           finalPercentages[percentageObj.originalIndex] =
-            Math.trunc(percentageObj.value) +
-            (ties.length <= remainder &&
-            highestRemainderObj.remainder !== '0.00'
-              ? 1
-              : 0);
+            Math.trunc(percentageObj.value) + (toRoundUp ? 1 : 0);
         });
 
         // Update the remainder given additions to the percentages.
-        remainder -=
-          ties.length <= remainder && highestRemainderObj.remainder !== '0.00'
-            ? ties.length
-            : 0;
+        remainder -= toRoundUp ? ties.length : 0;
       }
 
       preserveOriginal.forEach(percentageObj => {

--- a/extensions/amp-story/1.0/test/test-amp-story-quiz.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-quiz.js
@@ -303,34 +303,22 @@ describes.realWin(
     it('should preprocess percentages preserving ties, order, and adding to 100 (in most cases)', () => {
       const responseData1 = getMockReactionData()['data'];
 
-      const percentages1 = ampStoryQuiz.preprocessPercentages_(
-        responseData1,
-        4
-      );
+      const percentages1 = ampStoryQuiz.preprocessPercentages_(responseData1);
 
       expect(percentages1).to.deep.equal([30, 30, 30, 10]);
 
       const responseData2 = generateResponseDataFor([3, 3, 3]);
-      const percentages2 = ampStoryQuiz.preprocessPercentages_(
-        responseData2,
-        3
-      );
+      const percentages2 = ampStoryQuiz.preprocessPercentages_(responseData2);
 
       expect(percentages2).to.deep.equal([33, 33, 33]);
 
       const responseData3 = generateResponseDataFor([255, 255, 245, 245]);
-      const percentages3 = ampStoryQuiz.preprocessPercentages_(
-        responseData3,
-        4
-      );
+      const percentages3 = ampStoryQuiz.preprocessPercentages_(responseData3);
 
       expect(percentages3).to.deep.equal([26, 26, 24, 24]);
 
       const responseData4 = generateResponseDataFor([335, 335, 330]);
-      const percentages4 = ampStoryQuiz.preprocessPercentages_(
-        responseData4,
-        3
-      );
+      const percentages4 = ampStoryQuiz.preprocessPercentages_(responseData4);
 
       expect(percentages4).to.deep.equal([33, 33, 33]);
     });

--- a/extensions/amp-story/1.0/test/test-amp-story-quiz.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-quiz.js
@@ -23,7 +23,7 @@ import {getRequestService} from '../amp-story-request-service';
 import {registerServiceBuilder} from '../../../../src/service';
 
 /**
- * Populates the quiz with some number of prompts and some number of options
+ * Populates the quiz with some number of prompts and some number of options.
  *
  * @param {Window} win
  * @param {AmpStoryQuiz} quiz
@@ -47,7 +47,7 @@ const populateQuiz = (win, quizElement, numPrompts = 1, numOptions = 4) => {
 };
 
 /**
- * Populates the quiz with a prompt and three options
+ * Populates the quiz with a prompt and three options.
  *
  * @param {Window} win
  * @param {AmpStoryQuiz} quiz
@@ -57,10 +57,9 @@ const populateStandardQuizContent = (win, quizElement) => {
 };
 
 /**
- * Returns mock reaction data
+ * Returns mock reaction data.
  *
  * @return {Object}
- * @private
  */
 const getMockReactionData = () => {
   return {
@@ -91,6 +90,29 @@ const getMockReactionData = () => {
       ],
     },
   };
+};
+
+/**
+ * Generates a response give a number of counts
+ *
+ * @param {Array<number>} responseCounts
+ */
+const generateResponseDataFor = responseCounts => {
+  const response = {
+    totalResponseCount: responseCounts.reduce((a, b) => a + b, 0),
+    hasUserResponded: false,
+    responses: [],
+  };
+
+  responseCounts.forEach((count, index) => {
+    response.responses.push({
+      reactionValue: index,
+      totalCount: count,
+      selectedByUser: false,
+    });
+  });
+
+  return response;
 };
 
 describes.realWin(
@@ -154,13 +176,13 @@ describes.realWin(
         'i-amphtml-story-quiz-option-container'
       );
 
-      // check prompt container structure
+      // Check prompt container structure.
       expect(quizContent[0].children.length).to.equal(1);
       expect(
         quizContent[0].querySelectorAll('.i-amphtml-story-quiz-prompt')
       ).to.have.length(1);
 
-      // check option container structure
+      // Check option container structure.
       expect(quizContent[1].childNodes.length).to.equal(4);
       expect(
         quizContent[1].querySelectorAll('.i-amphtml-story-quiz-option')
@@ -256,7 +278,7 @@ describes.realWin(
     });
 
     it('should update the quiz when the user has already reacted', async () => {
-      // Fill the response to the requestService with mock reaction data
+      // Fill the response to the requestService with mock reaction data.
       env.sandbox
         .stub(requestService, 'executeRequest')
         .resolves(getMockReactionData());
@@ -276,6 +298,41 @@ describes.realWin(
       expect(quizOptions[0]).to.have.class(
         'i-amphtml-story-quiz-option-selected'
       );
+    });
+
+    it('should preprocess percentages preserving ties, order, and adding to 100', () => {
+      const responseData1 = getMockReactionData()['data'];
+
+      const percentages1 = ampStoryQuiz.preprocessPercentages_(
+        responseData1,
+        4
+      );
+
+      expect(percentages1).to.deep.equal([30, 30, 30, 10]);
+
+      const responseData2 = generateResponseDataFor([3, 3, 3]);
+      const percentages2 = ampStoryQuiz.preprocessPercentages_(
+        responseData2,
+        3
+      );
+
+      expect(percentages2).to.deep.equal([33, 33, 33]);
+
+      const responseData3 = generateResponseDataFor([255, 255, 245, 245]);
+      const percentages3 = ampStoryQuiz.preprocessPercentages_(
+        responseData3,
+        4
+      );
+
+      expect(percentages3).to.deep.equal([26, 26, 24, 24]);
+
+      const responseData4 = generateResponseDataFor([335, 335, 330]);
+      const percentages4 = ampStoryQuiz.preprocessPercentages_(
+        responseData4,
+        3
+      );
+
+      expect(percentages4).to.deep.equal([33, 33, 33]);
     });
   }
 );

--- a/extensions/amp-story/1.0/test/test-amp-story-quiz.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-quiz.js
@@ -300,23 +300,58 @@ describes.realWin(
       );
     });
 
-    it('should preprocess percentages preserving ties, order, and adding to 100 (in most cases)', () => {
+    it('should handle the percentage pipeline', async () => {
+      env.sandbox
+        .stub(requestService, 'executeRequest')
+        .resolves(getMockReactionData());
+
+      ampStoryQuiz.element.setAttribute('endpoint', 'http://localhost:8000');
+
+      populateStandardQuizContent(win, ampStoryQuiz.element);
+      ampStoryQuiz.buildCallback();
+      await ampStoryQuiz.layoutCallback();
+
+      const quizElement = ampStoryQuiz.getQuizElement();
+      const quizOptions = quizElement.querySelectorAll(
+        '.i-amphtml-story-quiz-option'
+      );
+
+      const percentageOption0 = quizOptions[0].querySelector(
+        '.i-amphtml-story-quiz-percentage-text'
+      );
+
+      expect(percentageOption0.textContent).to.equal('30%');
+
+      const percentageOption3 = quizOptions[3].querySelector(
+        '.i-amphtml-story-quiz-percentage-text'
+      );
+
+      expect(percentageOption3.textContent).to.equal('10%');
+    });
+
+    it('should preprocess percentages properly', () => {
       const responseData1 = getMockReactionData()['data'];
 
       const percentages1 = ampStoryQuiz.preprocessPercentages_(responseData1);
 
       expect(percentages1).to.deep.equal([30, 30, 30, 10]);
+    });
 
+    it('should preprocess percentages preserving ties', () => {
       const responseData2 = generateResponseDataFor([3, 3, 3]);
       const percentages2 = ampStoryQuiz.preprocessPercentages_(responseData2);
 
       expect(percentages2).to.deep.equal([33, 33, 33]);
+    });
 
+    it('should preprocess percentages preserving order', () => {
       const responseData3 = generateResponseDataFor([255, 255, 245, 245]);
       const percentages3 = ampStoryQuiz.preprocessPercentages_(responseData3);
 
       expect(percentages3).to.deep.equal([26, 26, 24, 24]);
+    });
 
+    it('should preprocess percentages handling rounding edge cases', () => {
       const responseData4 = generateResponseDataFor([335, 335, 330]);
       const percentages4 = ampStoryQuiz.preprocessPercentages_(responseData4);
 

--- a/extensions/amp-story/1.0/test/test-amp-story-quiz.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-quiz.js
@@ -93,7 +93,7 @@ const getMockReactionData = () => {
 };
 
 /**
- * Generates a response give a number of counts
+ * Generates a response given an array of counts.
  *
  * @param {Array<number>} responseCounts
  */
@@ -300,7 +300,7 @@ describes.realWin(
       );
     });
 
-    it('should preprocess percentages preserving ties, order, and adding to 100', () => {
+    it('should preprocess percentages preserving ties, order, and adding to 100 (in most cases)', () => {
       const responseData1 = getMockReactionData()['data'];
 
       const percentages1 = ampStoryQuiz.preprocessPercentages_(


### PR DESCRIPTION
Adds percentage display to <amp-story-quiz> component if data is available. These percentages are rounded to the nearest integer while preserving ties, general ordering, and summation to 100 (if possible).

Demo for percentage calculation can be found [here](https://codepen.io/jackbsteinberg/pen/YzPBzao)
Demo for percentage display can be found [here](https://codepen.io/jackbsteinberg/pen/vYEaoNj)

Adds work related to tracking issue #25615