### PR TITLE
performance: emit timeOrigin w/ polyfill

### DIFF
--- a/src/service/performance-impl.js
+++ b/src/service/performance-impl.js
@@ -241,6 +241,11 @@ export class Performance {
     whenDocumentComplete(win.document).then(() => this.onload_());
     this.registerPerformanceObserver_();
     this.registerFirstInputDelayPolyfillListener_();
+
+    this.tick(
+      'timeOrigin',
+      win.performance.timeOrigin || win.performance.timing.navigationStart
+    );
   }
 
   /**

--- a/src/service/performance-impl.js
+++ b/src/service/performance-impl.js
@@ -241,11 +241,6 @@ export class Performance {
     whenDocumentComplete(win.document).then(() => this.onload_());
     this.registerPerformanceObserver_();
     this.registerFirstInputDelayPolyfillListener_();
-
-    this.tick(
-      'timeOrigin',
-      win.performance.timeOrigin || win.performance.timing.navigationStart
-    );
   }
 
   /**
@@ -306,6 +301,13 @@ export class Performance {
       .then(() => {
         // Tick the "messaging ready" signal.
         this.tickDelta('msr', this.win.Date.now() - this.initTime_);
+
+        // Tick timeOrigin so that epoch time can be calculated by consumers.
+        this.tickDelta(
+          'timeOrigin',
+          this.win.performance.timeOrigin ||
+            this.win.performance.timing.navigationStart
+        );
 
         return this.maybeAddStoryExperimentId_();
       })

--- a/test/unit/test-performance.js
+++ b/test/unit/test-performance.js
@@ -251,13 +251,24 @@ describes.realWin('performance', {amp: true}, env => {
             expect(perf.isMessagingReady_).to.be.true;
             const msrCalls = viewerSendMessageStub.withArgs(
               'tick',
-              env.sandbox.match(arg => arg.label == 'msr')
+              env.sandbox.match(arg => arg.label === 'msr')
             );
             expect(msrCalls).to.be.calledOnce;
             expect(msrCalls.args[0][1]).to.be.jsonEqual({
               label: 'msr',
               delta: 1,
             });
+
+            const timeOriginCall = viewerSendMessageStub.withArgs(
+              'tick',
+              env.sandbox.match(arg => arg.label === 'timeOrigin')
+            );
+            expect(timeOriginCall).to.be.calledOnce;
+            expect(timeOriginCall).calledWithMatch('tick', {
+              label: 'timeOrigin',
+              delta: env.sandbox.match.number,
+            });
+
             expect(flushSpy).to.have.callCount(5);
             expect(perf.events_.length).to.equal(0);
           });
@@ -650,16 +661,16 @@ describes.realWin('performance', {amp: true}, env => {
         () => {
           clock.tick(100);
           whenFirstVisibleResolve();
-          expect(tickSpy).to.have.callCount(3);
+          expect(tickSpy).to.have.callCount(4);
           return ampdoc.whenFirstVisible().then(() => {
             clock.tick(400);
-            expect(tickSpy).to.have.callCount(4);
+            expect(tickSpy).to.have.callCount(5);
             whenViewportLayoutCompleteResolve();
             return perf.whenViewportLayoutComplete_().then(() => {
-              expect(tickSpy).to.have.callCount(4);
+              expect(tickSpy).to.have.callCount(5);
               expect(tickSpy.withArgs('ofv')).to.be.calledOnce;
               return whenFirstVisiblePromise.then(() => {
-                expect(tickSpy).to.have.callCount(5);
+                expect(tickSpy).to.have.callCount(6);
                 expect(tickSpy.withArgs('pc')).to.be.calledOnce;
                 expect(Number(tickSpy.withArgs('pc').args[0][1])).to.equal(400);
               });


### PR DESCRIPTION
**summary**
Fixes: `b/137215986` by emitting `performance.timeOrigin` tick event when the messaging channel is ready.  Technically I could also have added this tick to the contructor since it would be queued until msr, but that would have required updating 23 tests.