### PR TITLE
Position n+1 story desktop page before positioning attributes are set.

### DIFF
--- a/extensions/amp-story/1.0/amp-story-desktop-panels.css
+++ b/extensions/amp-story/1.0/amp-story-desktop-panels.css
@@ -66,6 +66,7 @@ amp-story[standalone].i-amphtml-story-desktop-panels {
 
 .i-amphtml-story-desktop-panels amp-story-page[i-amphtml-desktop-position="-1"],
 .i-amphtml-story-desktop-panels .prev-container > .i-amphtml-story-page-sentinel,
+[dir=rtl] .i-amphtml-story-desktop-panels amp-story-page[active] + amp-story-page:not([i-amphtml-desktop-position]):not([distance]), /** Position n+1 page on load, before attributes are set. */
 [dir=rtl] .i-amphtml-story-desktop-panels amp-story-page[i-amphtml-desktop-position="1"],
 [dir=rtl] .i-amphtml-story-desktop-panels .next-container > .i-amphtml-story-page-sentinel {
   transform: scale(0.9) translateX(calc(-3 * var(--i-amphtml-story-page-50vw, 50%) - 64px)) translateY(0%) !important;
@@ -79,6 +80,7 @@ amp-story[standalone].i-amphtml-story-desktop-panels {
   opacity: 1 !important;
 }
 
+.i-amphtml-story-desktop-panels amp-story-page[active] + amp-story-page:not([i-amphtml-desktop-position]):not([distance]), /** Position n+1 page on load, before attributes are set. */
 .i-amphtml-story-desktop-panels amp-story-page[i-amphtml-desktop-position="1"],
 .i-amphtml-story-desktop-panels .next-container > .i-amphtml-story-page-sentinel,
 [dir=rtl] .i-amphtml-story-desktop-panels amp-story-page[i-amphtml-desktop-position="-1"],


### PR DESCRIPTION
When loading a desktop panels story, the n+1 page isn't positioned until pretty late in the code execution, when we set positioning attributes. That n+1 page flies in the viewport once the position is set.

This PR positions the n+1 page until the final position attributes are set.

[Repro the animation issue](https://stamp-gmajoulet.firebaseapp.com/examples/s20/body-painting/index.html)