### PR TITLE
🐛 Rewrite relative urls in the bookend

### DIFF
--- a/extensions/amp-story/1.0/bookend/amp-story-bookend.js
+++ b/extensions/amp-story/1.0/bookend/amp-story-bookend.js
@@ -635,7 +635,7 @@ export class AmpStoryBookend extends DraggableDrawer {
       .then(localizationService => {
         const bookendEls = BookendComponent.buildElements(
           components,
-          this.win.document,
+          this.win,
           localizationService
         );
         const container = dev().assertElement(

--- a/extensions/amp-story/1.0/bookend/bookend-component.js
+++ b/extensions/amp-story/1.0/bookend/bookend-component.js
@@ -152,12 +152,12 @@ export class BookendComponent {
    * Builds the bookend components elements by choosing the appropriate builder
    * class and appending the elements to the container.
    * @param {!Array<BookendComponentDef>} components
-   * @param {!Document} doc
+   * @param {!Window} win
    * @param {?../../../../src/service/localization.LocalizationService} localizationService
    * @return {!DocumentFragment}
    */
-  static buildElements(components, doc, localizationService) {
-    const fragment = doc.createDocumentFragment();
+  static buildElements(components, win, localizationService) {
+    const fragment = win.document.createDocumentFragment();
 
     components = prependTitle(components, localizationService);
     components.forEach((component, index) => {
@@ -165,7 +165,7 @@ export class BookendComponent {
       if (type && componentBuilderInstanceFor(type)) {
         const el = componentBuilderInstanceFor(type).buildElement(
           component,
-          doc,
+          win,
           {position: index}
         );
         fragment.appendChild(el);

--- a/extensions/amp-story/1.0/bookend/components/article.js
+++ b/extensions/amp-story/1.0/bookend/components/article.js
@@ -22,10 +22,12 @@ import {
 import {addAttributesToElement} from '../../../../../src/dom';
 import {dict} from '../../../../../src/utils/object';
 import {
+  getDocLocation,
   getSourceOriginForElement,
   resolveImgSrc,
   userAssertValidProtocol,
 } from '../../utils';
+import {getSourceUrl, resolveRelativeUrl} from '../../../../../src/url';
 import {htmlFor, htmlRefs} from '../../../../../src/static-template';
 import {userAssert} from '../../../../../src/log';
 
@@ -107,7 +109,14 @@ export class ArticleComponent {
         </div>
       </a>
     `;
-    addAttributesToElement(el, dict({'href': articleData.url}));
+    const loc = getDocLocation(doc);
+    addAttributesToElement(
+      el,
+      dict({
+        'href': resolveRelativeUrl(articleData.url, getSourceUrl(loc)),
+      })
+    );
+
     el[AMP_STORY_BOOKEND_COMPONENT_DATA] = {
       position: data.position,
       type: BOOKEND_COMPONENT_TYPES.SMALL,

--- a/extensions/amp-story/1.0/bookend/components/article.js
+++ b/extensions/amp-story/1.0/bookend/components/article.js
@@ -22,7 +22,6 @@ import {
 import {addAttributesToElement} from '../../../../../src/dom';
 import {dict} from '../../../../../src/utils/object';
 import {
-  getDocLocation,
   getSourceOriginForElement,
   resolveImgSrc,
   userAssertValidProtocol,
@@ -92,8 +91,8 @@ export class ArticleComponent {
   }
 
   /** @override */
-  buildElement(articleData, doc, data) {
-    const html = htmlFor(doc);
+  buildElement(articleData, win, data) {
+    const html = htmlFor(win.document);
     //TODO(#14657, #14658): Binaries resulting from htmlFor are bloated.
     const el = html`
       <a
@@ -109,11 +108,11 @@ export class ArticleComponent {
         </div>
       </a>
     `;
-    const loc = getDocLocation(doc);
+
     addAttributesToElement(
       el,
       dict({
-        'href': resolveRelativeUrl(articleData.url, getSourceUrl(loc)),
+        'href': resolveRelativeUrl(articleData.url, getSourceUrl(win.location)),
       })
     );
 
@@ -137,7 +136,7 @@ export class ArticleComponent {
 
       addAttributesToElement(
         image,
-        dict({'src': resolveImgSrc(doc, articleData.image)})
+        dict({'src': resolveImgSrc(win, articleData.image)})
       );
 
       el.appendChild(imgEl);

--- a/extensions/amp-story/1.0/bookend/components/bookend-component-interface.js
+++ b/extensions/amp-story/1.0/bookend/components/bookend-component-interface.js
@@ -54,9 +54,9 @@ export class BookendComponentInterface {
   /**
    * Builds the DOM element for the component.
    * @param {../bookend-component.BookendComponentDef} unusedComponentJson
-   * @param {!Document} unusedDoc
+   * @param {!Window} unusedWin
    * @param {!Object} unusedData
    * @return {!Element}
    */
-  buildElement(unusedComponentJson, unusedDoc, unusedData) {}
+  buildElement(unusedComponentJson, unusedWin, unusedData) {}
 }

--- a/extensions/amp-story/1.0/bookend/components/cta-link.js
+++ b/extensions/amp-story/1.0/bookend/components/cta-link.js
@@ -21,11 +21,11 @@ import {
 } from './bookend-component-interface';
 import {addAttributesToElement} from '../../../../../src/dom';
 import {dict} from '../../../../../src/utils/object';
-import {getDocLocation, userAssertValidProtocol} from '../../utils';
 import {getSourceUrl, resolveRelativeUrl} from '../../../../../src/url';
 import {htmlFor, htmlRefs} from '../../../../../src/static-template';
 import {isArray} from '../../../../../src/types';
 import {userAssert} from '../../../../../src/log';
+import {userAssertValidProtocol} from '../../utils';
 
 /**
  * @typedef {{
@@ -86,8 +86,8 @@ export class CtaLinkComponent {
   }
 
   /** @override */
-  buildElement(ctaLinksData, doc, data) {
-    const html = htmlFor(doc);
+  buildElement(ctaLinksData, win, data) {
+    const html = htmlFor(win.document);
     const container = html`
       <div
         class="i-amphtml-story-bookend-cta-link-wrapper
@@ -102,11 +102,13 @@ export class CtaLinkComponent {
     `;
     ctaLinksData['links'].forEach(currentLink => {
       const el = linkSeed.cloneNode(/* deep */ true);
-      const loc = getDocLocation(doc);
       addAttributesToElement(
         el,
         dict({
-          'href': resolveRelativeUrl(currentLink['url'], getSourceUrl(loc)),
+          'href': resolveRelativeUrl(
+            currentLink['url'],
+            getSourceUrl(win.location)
+          ),
         })
       );
 

--- a/extensions/amp-story/1.0/bookend/components/cta-link.js
+++ b/extensions/amp-story/1.0/bookend/components/cta-link.js
@@ -21,10 +21,11 @@ import {
 } from './bookend-component-interface';
 import {addAttributesToElement} from '../../../../../src/dom';
 import {dict} from '../../../../../src/utils/object';
+import {getDocLocation, userAssertValidProtocol} from '../../utils';
+import {getSourceUrl, resolveRelativeUrl} from '../../../../../src/url';
 import {htmlFor, htmlRefs} from '../../../../../src/static-template';
 import {isArray} from '../../../../../src/types';
 import {userAssert} from '../../../../../src/log';
-import {userAssertValidProtocol} from '../../utils';
 
 /**
  * @typedef {{
@@ -101,7 +102,13 @@ export class CtaLinkComponent {
     `;
     ctaLinksData['links'].forEach(currentLink => {
       const el = linkSeed.cloneNode(/* deep */ true);
-      addAttributesToElement(el, dict({'href': currentLink['url']}));
+      const loc = getDocLocation(doc);
+      addAttributesToElement(
+        el,
+        dict({
+          'href': resolveRelativeUrl(currentLink['url'], getSourceUrl(loc)),
+        })
+      );
 
       if (currentLink['amphtml'] === true) {
         addAttributesToElement(el, dict({'rel': 'amphtml'}));

--- a/extensions/amp-story/1.0/bookend/components/heading.js
+++ b/extensions/amp-story/1.0/bookend/components/heading.js
@@ -60,8 +60,8 @@ export class HeadingComponent {
   }
 
   /** @override */
-  buildElement(headingData, doc, data) {
-    const html = htmlFor(doc);
+  buildElement(headingData, win, data) {
+    const html = htmlFor(win.document);
     const template = html`
       <h3
         class="i-amphtml-story-bookend-component

--- a/extensions/amp-story/1.0/bookend/components/landscape.js
+++ b/extensions/amp-story/1.0/bookend/components/landscape.js
@@ -22,10 +22,12 @@ import {
 import {addAttributesToElement} from '../../../../../src/dom';
 import {dict} from '../../../../../src/utils/object';
 import {
+  getDocLocation,
   getSourceOriginForElement,
   resolveImgSrc,
   userAssertValidProtocol,
 } from '../../utils';
+import {getSourceUrl, resolveRelativeUrl} from '../../../../../src/url';
 import {htmlFor, htmlRefs} from '../../../../../src/static-template';
 import {userAssert} from '../../../../../src/log';
 
@@ -112,7 +114,14 @@ export class LandscapeComponent {
           <div class="i-amphtml-story-bookend-component-meta"
             ref="meta"></div>
         </a>`;
-    addAttributesToElement(el, dict({'href': landscapeData.url}));
+    const loc = getDocLocation(doc);
+    addAttributesToElement(
+      el,
+      dict({
+        'href': resolveRelativeUrl(landscapeData.url, getSourceUrl(loc)),
+      })
+    );
+
     el[AMP_STORY_BOOKEND_COMPONENT_DATA] = {
       position: data.position,
       type: BOOKEND_COMPONENT_TYPES.LANDSCAPE,

--- a/extensions/amp-story/1.0/bookend/components/landscape.js
+++ b/extensions/amp-story/1.0/bookend/components/landscape.js
@@ -22,7 +22,6 @@ import {
 import {addAttributesToElement} from '../../../../../src/dom';
 import {dict} from '../../../../../src/utils/object';
 import {
-  getDocLocation,
   getSourceOriginForElement,
   resolveImgSrc,
   userAssertValidProtocol,
@@ -98,9 +97,9 @@ export class LandscapeComponent {
   }
 
   /** @override */
-  buildElement(landscapeData, doc, data) {
+  buildElement(landscapeData, win, data) {
     landscapeData = /** @type {LandscapeComponentDef} */ (landscapeData);
-    const html = htmlFor(doc);
+    const html = htmlFor(win.document);
     const el = html`
         <a class="i-amphtml-story-bookend-landscape
             i-amphtml-story-bookend-component" target="_top">
@@ -114,11 +113,13 @@ export class LandscapeComponent {
           <div class="i-amphtml-story-bookend-component-meta"
             ref="meta"></div>
         </a>`;
-    const loc = getDocLocation(doc);
     addAttributesToElement(
       el,
       dict({
-        'href': resolveRelativeUrl(landscapeData.url, getSourceUrl(loc)),
+        'href': resolveRelativeUrl(
+          landscapeData.url,
+          getSourceUrl(win.location)
+        ),
       })
     );
 
@@ -144,7 +145,7 @@ export class LandscapeComponent {
 
     addAttributesToElement(
       image,
-      dict({'src': resolveImgSrc(doc, landscapeData.image)})
+      dict({'src': resolveImgSrc(win, landscapeData.image)})
     );
 
     meta.textContent = landscapeData.domainName;

--- a/extensions/amp-story/1.0/bookend/components/portrait.js
+++ b/extensions/amp-story/1.0/bookend/components/portrait.js
@@ -22,7 +22,6 @@ import {
 import {addAttributesToElement} from '../../../../../src/dom';
 import {dict} from '../../../../../src/utils/object';
 import {
-  getDocLocation,
   getSourceOriginForElement,
   resolveImgSrc,
   userAssertValidProtocol,
@@ -98,9 +97,9 @@ export class PortraitComponent {
   }
 
   /** @override */
-  buildElement(portraitData, doc, data) {
+  buildElement(portraitData, win, data) {
     portraitData = /** @type {PortraitComponentDef} */ (portraitData);
-    const html = htmlFor(doc);
+    const html = htmlFor(win.document);
     const el = html`
         <a class="i-amphtml-story-bookend-portrait i-amphtml-story-bookend-component" target="_top">
           <h2 class="i-amphtml-story-bookend-component-category"
@@ -113,11 +112,13 @@ export class PortraitComponent {
           <div class="i-amphtml-story-bookend-component-meta"
             ref="meta"></div>
         </a>`;
-    const loc = getDocLocation(doc);
     addAttributesToElement(
       el,
       dict({
-        'href': resolveRelativeUrl(portraitData.url, getSourceUrl(loc)),
+        'href': resolveRelativeUrl(
+          portraitData.url,
+          getSourceUrl(win.location)
+        ),
       })
     );
 
@@ -142,7 +143,7 @@ export class PortraitComponent {
 
     addAttributesToElement(
       image,
-      dict({'src': resolveImgSrc(doc, portraitData.image)})
+      dict({'src': resolveImgSrc(win, portraitData.image)})
     );
 
     meta.textContent = portraitData.domainName;

--- a/extensions/amp-story/1.0/bookend/components/portrait.js
+++ b/extensions/amp-story/1.0/bookend/components/portrait.js
@@ -22,10 +22,12 @@ import {
 import {addAttributesToElement} from '../../../../../src/dom';
 import {dict} from '../../../../../src/utils/object';
 import {
+  getDocLocation,
   getSourceOriginForElement,
   resolveImgSrc,
   userAssertValidProtocol,
 } from '../../utils';
+import {getSourceUrl, resolveRelativeUrl} from '../../../../../src/url';
 import {htmlFor, htmlRefs} from '../../../../../src/static-template';
 import {userAssert} from '../../../../../src/log';
 
@@ -111,7 +113,14 @@ export class PortraitComponent {
           <div class="i-amphtml-story-bookend-component-meta"
             ref="meta"></div>
         </a>`;
-    addAttributesToElement(el, dict({'href': portraitData.url}));
+    const loc = getDocLocation(doc);
+    addAttributesToElement(
+      el,
+      dict({
+        'href': resolveRelativeUrl(portraitData.url, getSourceUrl(loc)),
+      })
+    );
+
     el[AMP_STORY_BOOKEND_COMPONENT_DATA] = {
       position: data.position,
       type: BOOKEND_COMPONENT_TYPES.PORTRAIT,

--- a/extensions/amp-story/1.0/bookend/components/text-box.js
+++ b/extensions/amp-story/1.0/bookend/components/text-box.js
@@ -62,8 +62,8 @@ export class TextBoxComponent {
   }
 
   /** @override */
-  buildElement(textboxData, doc, data) {
-    const html = htmlFor(doc);
+  buildElement(textboxData, win, data) {
+    const html = htmlFor(win.document);
     const container = html`
       <div
         class="i-amphtml-story-bookend-textbox

--- a/extensions/amp-story/1.0/test/test-amp-story-bookend.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-bookend.js
@@ -30,318 +30,276 @@ import {createElementWithAttributes} from '../../../../src/dom';
 import {registerServiceBuilder} from '../../../../src/service';
 import {user} from '../../../../src/log';
 
-describes.fakeWin(
-  'amp-story-bookend',
-  {
-    win: {
-      location:
-        'https://www.testorigin.com/amp-stories/example/path/google.com',
+const location =
+  'https://www.testorigin.com/amp-stories/example/path/google.com';
+
+describes.fakeWin('amp-story-bookend', {win: {location}, amp: true}, env => {
+  let win;
+  let doc;
+  let storyElem;
+  let bookend;
+  let bookendElem;
+  let requestService;
+  let analytics;
+  let analyticsVariables;
+
+  const expectedComponents = [
+    {
+      'type': 'heading',
+      'text': 'My Heading Title!',
     },
-    amp: true,
-  },
-  env => {
-    let win;
-    let doc;
-    let storyElem;
-    let bookend;
-    let bookendElem;
-    let requestService;
-    let analytics;
-    let analyticsVariables;
-
-    const expectedComponents = [
-      {
-        'type': 'heading',
-        'text': 'My Heading Title!',
-      },
-      {
-        'type': 'small',
-        'title': 'This is an example article',
-        'domainName': 'example.com',
-        'url': 'http://example.com/article.html',
-        'image': 'http://placehold.it/256x128',
-      },
-      {
-        'type': 'portrait',
-        'title': 'This is an example article',
-        'category': 'This is an example article',
-        'domainName': 'example.com',
-        'url': 'http://example.com/article.html',
-        'image': 'http://placehold.it/256x128',
-      },
-      {
-        'type': 'cta-link',
-        'links': [
-          {
-            'text': 'buttonA',
-            'url': 'google.com',
-          },
-          {
-            'text': 'buttonB',
-            'url': 'google.com',
-          },
-          {
-            'text': 'longtext longtext longtext longtext longtext',
-            'url': 'google.com',
-          },
-        ],
-      },
-      {
-        'type': 'landscape',
-        'title': 'TRAPPIST-1 Planets May Still Be Wet Enough for Life',
-        'domainName': 'example.com',
-        'url': 'http://example.com/article.html',
-        'category': 'astronomy',
-        'image': 'http://placehold.it/256x128',
-      },
-      {
-        'type': 'textbox',
-        'text': [
-          'Food by Enrique McPizza',
-          'Choreography by Gabriel Filly',
-          'Script by Alan Ecma S.',
-          'Direction by Jon Tarantino',
-        ],
-      },
-    ];
-
-    const metadata = {
-      '@context': 'http://schema.org',
-      '@type': 'NewsArticle',
-      'mainEntityOfPage': {
-        '@type': 'WebPage',
-        '@id': './bookend.html',
-      },
-      'headline': 'My Story',
-      'image': ['http://placehold.it/420x740'],
-      'datePublished': '2018-01-01T00:00:00+00:00',
-      'dateModified': '2018-01-01T00:00:00+00:00',
-      'author': {
-        '@type': 'Organization',
-        'name': 'AMP Project',
-      },
-      'publisher': {
-        '@type': 'Organization',
-        'name': 'AMP Project',
-        'logo': {
-          '@type': 'ImageObject',
-          'url': 'http://placehold.it/128x128',
+    {
+      'type': 'small',
+      'title': 'This is an example article',
+      'domainName': 'example.com',
+      'url': 'http://example.com/article.html',
+      'image': 'http://placehold.it/256x128',
+    },
+    {
+      'type': 'portrait',
+      'title': 'This is an example article',
+      'category': 'This is an example article',
+      'domainName': 'example.com',
+      'url': 'http://example.com/article.html',
+      'image': 'http://placehold.it/256x128',
+    },
+    {
+      'type': 'cta-link',
+      'links': [
+        {
+          'text': 'buttonA',
+          'url': 'google.com',
         },
+        {
+          'text': 'buttonB',
+          'url': 'google.com',
+        },
+        {
+          'text': 'longtext longtext longtext longtext longtext',
+          'url': 'google.com',
+        },
+      ],
+    },
+    {
+      'type': 'landscape',
+      'title': 'TRAPPIST-1 Planets May Still Be Wet Enough for Life',
+      'domainName': 'example.com',
+      'url': 'http://example.com/article.html',
+      'category': 'astronomy',
+      'image': 'http://placehold.it/256x128',
+    },
+    {
+      'type': 'textbox',
+      'text': [
+        'Food by Enrique McPizza',
+        'Choreography by Gabriel Filly',
+        'Script by Alan Ecma S.',
+        'Direction by Jon Tarantino',
+      ],
+    },
+  ];
+
+  const metadata = {
+    '@context': 'http://schema.org',
+    '@type': 'NewsArticle',
+    'mainEntityOfPage': {
+      '@type': 'WebPage',
+      '@id': './bookend.html',
+    },
+    'headline': 'My Story',
+    'image': ['http://placehold.it/420x740'],
+    'datePublished': '2018-01-01T00:00:00+00:00',
+    'dateModified': '2018-01-01T00:00:00+00:00',
+    'author': {
+      '@type': 'Organization',
+      'name': 'AMP Project',
+    },
+    'publisher': {
+      '@type': 'Organization',
+      'name': 'AMP Project',
+      'logo': {
+        '@type': 'ImageObject',
+        'url': 'http://placehold.it/128x128',
       },
-      'description': 'My Story',
+    },
+    'description': 'My Story',
+  };
+
+  beforeEach(() => {
+    win = env.win;
+    doc = win.document;
+    storyElem = doc.createElement('amp-story');
+    storyElem.appendChild(doc.createElement('amp-story-page'));
+    doc.body.appendChild(storyElem);
+    bookendElem = createElementWithAttributes(doc, 'amp-story-bookend', {
+      'layout': 'nodisplay',
+    });
+    storyElem.appendChild(bookendElem);
+
+    requestService = new AmpStoryRequestService(win, storyElem);
+    env.sandbox.stub(Services, 'storyRequestService').returns(requestService);
+
+    const localizationService = new LocalizationService(win);
+    registerServiceBuilder(win, 'localization', () => localizationService);
+
+    bookend = new AmpStoryBookend(bookendElem);
+    bookend.buildCallback();
+
+    analytics = getAnalyticsService(win);
+    analyticsVariables = getVariableService(win);
+
+    // Force sync mutateElement.
+    env.sandbox.stub(bookend, 'mutateElement').callsArg(0);
+    env.sandbox.stub(bookend, 'getStoryMetadata_').returns(metadata);
+  });
+
+  it('should build the users json', async () => {
+    const userJson = {
+      'bookendVersion': 'v1.0',
+      'shareProviders': [
+        'email',
+        {'provider': 'facebook', 'app_id': '254325784911610'},
+        'whatsapp',
+      ],
+      'components': [
+        {
+          'type': 'heading',
+          'text': 'My Heading Title!',
+        },
+        {
+          'type': 'small',
+          'title': 'This is an example article',
+          'url': 'http://example.com/article.html',
+          'image': 'http://placehold.it/256x128',
+        },
+        {
+          'type': 'portrait',
+          'title': 'This is an example article',
+          'category': 'This is an example article',
+          'url': 'http://example.com/article.html',
+          'image': 'http://placehold.it/256x128',
+        },
+        {
+          'type': 'cta-link',
+          'links': [
+            {
+              'text': 'buttonA',
+              'url': 'google.com',
+            },
+            {
+              'text': 'buttonB',
+              'url': 'google.com',
+            },
+            {
+              'text': 'longtext longtext longtext longtext longtext',
+              'url': 'google.com',
+            },
+          ],
+        },
+        {
+          'type': 'landscape',
+          'title': 'TRAPPIST-1 Planets May Still Be Wet Enough for Life',
+          'url': 'http://example.com/article.html',
+          'category': 'astronomy',
+          'image': 'http://placehold.it/256x128',
+        },
+        {
+          'type': 'textbox',
+          'text': [
+            'Food by Enrique McPizza',
+            'Choreography by Gabriel Filly',
+            'Script by Alan Ecma S.',
+            'Direction by Jon Tarantino',
+          ],
+        },
+      ],
     };
 
-    beforeEach(() => {
-      win = env.win;
-      doc = win.document;
-      storyElem = doc.createElement('amp-story');
-      storyElem.appendChild(doc.createElement('amp-story-page'));
-      doc.body.appendChild(storyElem);
-      bookendElem = createElementWithAttributes(doc, 'amp-story-bookend', {
-        'layout': 'nodisplay',
-      });
-      storyElem.appendChild(bookendElem);
+    env.sandbox.stub(requestService, 'loadBookendConfig').resolves(userJson);
 
-      requestService = new AmpStoryRequestService(win, storyElem);
-      env.sandbox.stub(Services, 'storyRequestService').returns(requestService);
-
-      const localizationService = new LocalizationService(win);
-      registerServiceBuilder(win, 'localization', () => localizationService);
-
-      bookend = new AmpStoryBookend(bookendElem);
-      bookend.buildCallback();
-
-      analytics = getAnalyticsService(win);
-      analyticsVariables = getVariableService(win);
-
-      // Force sync mutateElement.
-      env.sandbox.stub(bookend, 'mutateElement').callsArg(0);
-      env.sandbox.stub(bookend, 'getStoryMetadata_').returns(metadata);
+    bookend.build();
+    const config = await bookend.loadConfigAndMaybeRenderBookend();
+    config.components.forEach((currentComponent, index) => {
+      expect(currentComponent).to.deep.equal(expectedComponents[index]);
     });
+  });
 
-    it('should build the users json', async () => {
-      const userJson = {
-        'bookendVersion': 'v1.0',
-        'shareProviders': [
-          'email',
-          {'provider': 'facebook', 'app_id': '254325784911610'},
-          'whatsapp',
-        ],
-        'components': [
-          {
-            'type': 'heading',
-            'text': 'My Heading Title!',
-          },
-          {
-            'type': 'small',
-            'title': 'This is an example article',
-            'url': 'http://example.com/article.html',
-            'image': 'http://placehold.it/256x128',
-          },
-          {
-            'type': 'portrait',
-            'title': 'This is an example article',
-            'category': 'This is an example article',
-            'url': 'http://example.com/article.html',
-            'image': 'http://placehold.it/256x128',
-          },
-          {
-            'type': 'cta-link',
-            'links': [
-              {
-                'text': 'buttonA',
-                'url': 'google.com',
-              },
-              {
-                'text': 'buttonB',
-                'url': 'google.com',
-              },
-              {
-                'text': 'longtext longtext longtext longtext longtext',
-                'url': 'google.com',
-              },
-            ],
-          },
-          {
-            'type': 'landscape',
-            'title': 'TRAPPIST-1 Planets May Still Be Wet Enough for Life',
-            'url': 'http://example.com/article.html',
-            'category': 'astronomy',
-            'image': 'http://placehold.it/256x128',
-          },
-          {
-            'type': 'textbox',
-            'text': [
-              'Food by Enrique McPizza',
-              'Choreography by Gabriel Filly',
-              'Script by Alan Ecma S.',
-              'Direction by Jon Tarantino',
-            ],
-          },
-        ],
-      };
-
-      env.sandbox.stub(requestService, 'loadBookendConfig').resolves(userJson);
-
-      bookend.build();
-      const config = await bookend.loadConfigAndMaybeRenderBookend();
-      config.components.forEach((currentComponent, index) => {
-        expect(currentComponent).to.deep.equal(expectedComponents[index]);
-      });
-    });
-
-    it('should build the users json with share providers alternative', async () => {
-      const userJson = {
-        'bookendVersion': 'v1.0',
-        'shareProviders': [
-          'email',
-          {'provider': 'facebook', 'app_id': '254325784911610'},
-          {'provider': 'whatsapp'},
-        ],
-        'components': [
-          {
-            'type': 'heading',
-            'text': 'My Heading Title!',
-          },
-          {
-            'type': 'small',
-            'title': 'This is an example article',
-            'url': 'http://example.com/article.html',
-            'image': 'http://placehold.it/256x128',
-          },
-          {
-            'type': 'portrait',
-            'title': 'This is an example article',
-            'category': 'This is an example article',
-            'domainName': 'example.com',
-            'url': 'http://example.com/article.html',
-            'image': 'http://placehold.it/256x128',
-          },
-          {
-            'type': 'cta-link',
-            'links': [
-              {
-                'text': 'buttonA',
-                'url': 'google.com',
-              },
-              {
-                'text': 'buttonB',
-                'url': 'google.com',
-              },
-              {
-                'text': 'longtext longtext longtext longtext longtext',
-                'url': 'google.com',
-              },
-            ],
-          },
-          {
-            'type': 'landscape',
-            'title': 'TRAPPIST-1 Planets May Still Be Wet Enough for Life',
-            'url': 'http://example.com/article.html',
-            'category': 'astronomy',
-            'image': 'http://placehold.it/256x128',
-          },
-          {
-            'type': 'textbox',
-            'text': [
-              'Food by Enrique McPizza',
-              'Choreography by Gabriel Filly',
-              'Script by Alan Ecma S.',
-              'Direction by Jon Tarantino',
-            ],
-          },
-        ],
-      };
-
-      env.sandbox.stub(requestService, 'loadBookendConfig').resolves(userJson);
-
-      bookend.build();
-      const config = await bookend.loadConfigAndMaybeRenderBookend();
-      config.components.forEach((currentComponent, index) => {
-        expect(currentComponent).to.deep.equal(expectedComponents[index]);
-      });
-    });
-
-    it(
-      'should add amp-to-amp linking to individual cta links when ' +
-        'specified in the JSON config',
-      async () => {
-        const userJson = {
-          'bookendVersion': 'v1.0',
-          'shareProviders': [
-            'email',
-            {'provider': 'facebook', 'app_id': '254325784911610'},
-            'whatsapp',
-          ],
-          'components': [
+  it('should build the users json with share providers alternative', async () => {
+    const userJson = {
+      'bookendVersion': 'v1.0',
+      'shareProviders': [
+        'email',
+        {'provider': 'facebook', 'app_id': '254325784911610'},
+        {'provider': 'whatsapp'},
+      ],
+      'components': [
+        {
+          'type': 'heading',
+          'text': 'My Heading Title!',
+        },
+        {
+          'type': 'small',
+          'title': 'This is an example article',
+          'url': 'http://example.com/article.html',
+          'image': 'http://placehold.it/256x128',
+        },
+        {
+          'type': 'portrait',
+          'title': 'This is an example article',
+          'category': 'This is an example article',
+          'domainName': 'example.com',
+          'url': 'http://example.com/article.html',
+          'image': 'http://placehold.it/256x128',
+        },
+        {
+          'type': 'cta-link',
+          'links': [
             {
-              'type': 'cta-link',
-              'links': [
-                {
-                  'text': 'buttonA',
-                  'url': 'google.com',
-                  'amphtml': true,
-                },
-              ],
+              'text': 'buttonA',
+              'url': 'google.com',
+            },
+            {
+              'text': 'buttonB',
+              'url': 'google.com',
+            },
+            {
+              'text': 'longtext longtext longtext longtext longtext',
+              'url': 'google.com',
             },
           ],
-        };
+        },
+        {
+          'type': 'landscape',
+          'title': 'TRAPPIST-1 Planets May Still Be Wet Enough for Life',
+          'url': 'http://example.com/article.html',
+          'category': 'astronomy',
+          'image': 'http://placehold.it/256x128',
+        },
+        {
+          'type': 'textbox',
+          'text': [
+            'Food by Enrique McPizza',
+            'Choreography by Gabriel Filly',
+            'Script by Alan Ecma S.',
+            'Direction by Jon Tarantino',
+          ],
+        },
+      ],
+    };
 
-        env.sandbox
-          .stub(requestService, 'loadBookendConfig')
-          .resolves(userJson);
+    env.sandbox.stub(requestService, 'loadBookendConfig').resolves(userJson);
 
-        bookend.build();
-        await bookend.loadConfigAndMaybeRenderBookend();
-        const ctaLinks = bookend.bookendEl_.querySelector(
-          '.i-amphtml-story-bookend-cta-link-wrapper'
-        );
-        expect(ctaLinks.children[0]).to.have.attribute('rel');
-        expect(ctaLinks.children[0].getAttribute('rel')).to.equal('amphtml');
-      }
-    );
+    bookend.build();
+    const config = await bookend.loadConfigAndMaybeRenderBookend();
+    config.components.forEach((currentComponent, index) => {
+      expect(currentComponent).to.deep.equal(expectedComponents[index]);
+    });
+  });
 
-    it('should forward the correct target when clicking on an element', async () => {
+  it(
+    'should add amp-to-amp linking to individual cta links when ' +
+      'specified in the JSON config',
+    async () => {
       const userJson = {
         'bookendVersion': 'v1.0',
         'shareProviders': [
@@ -364,25 +322,148 @@ describes.fakeWin(
       };
 
       env.sandbox.stub(requestService, 'loadBookendConfig').resolves(userJson);
-      const clickSpy = env.sandbox.spy();
-      doc.addEventListener('click', clickSpy);
 
       bookend.build();
       await bookend.loadConfigAndMaybeRenderBookend();
       const ctaLinks = bookend.bookendEl_.querySelector(
         '.i-amphtml-story-bookend-cta-link-wrapper'
       );
-      ctaLinks.children[0].onclick = function(e) {
-        e.preventDefault(); // Make the test not actually navigate.
-      };
-      ctaLinks.children[0].click();
+      expect(ctaLinks.children[0]).to.have.attribute('rel');
+      expect(ctaLinks.children[0].getAttribute('rel')).to.equal('amphtml');
+    }
+  );
 
-      expect(clickSpy.getCall(0).args[0]).to.contain({
-        '__AMP_CUSTOM_LINKER_TARGET__': ctaLinks.children[0],
-      });
+  it('should forward the correct target when clicking on an element', async () => {
+    const userJson = {
+      'bookendVersion': 'v1.0',
+      'shareProviders': [
+        'email',
+        {'provider': 'facebook', 'app_id': '254325784911610'},
+        'whatsapp',
+      ],
+      'components': [
+        {
+          'type': 'cta-link',
+          'links': [
+            {
+              'text': 'buttonA',
+              'url': 'google.com',
+              'amphtml': true,
+            },
+          ],
+        },
+      ],
+    };
+
+    env.sandbox.stub(requestService, 'loadBookendConfig').resolves(userJson);
+    const clickSpy = env.sandbox.spy();
+    doc.addEventListener('click', clickSpy);
+
+    bookend.build();
+    await bookend.loadConfigAndMaybeRenderBookend();
+    const ctaLinks = bookend.bookendEl_.querySelector(
+      '.i-amphtml-story-bookend-cta-link-wrapper'
+    );
+    ctaLinks.children[0].onclick = function(e) {
+      e.preventDefault(); // Make the test not actually navigate.
+    };
+    ctaLinks.children[0].click();
+
+    expect(clickSpy.getCall(0).args[0]).to.contain({
+      '__AMP_CUSTOM_LINKER_TARGET__': ctaLinks.children[0],
     });
+  });
 
-    it('should fire analytics event when clicking on a link', async () => {
+  it('should fire analytics event when clicking on a link', async () => {
+    const userJson = {
+      'bookendVersion': 'v1.0',
+      'shareProviders': [
+        'email',
+        {'provider': 'facebook', 'app_id': '254325784911610'},
+        'whatsapp',
+      ],
+      'components': [
+        {
+          'type': 'cta-link',
+          'links': [
+            {
+              'text': 'buttonA',
+              'url': 'google.com',
+              'amphtml': true,
+            },
+          ],
+        },
+      ],
+    };
+
+    env.sandbox.stub(requestService, 'loadBookendConfig').resolves(userJson);
+    const analyticsSpy = env.sandbox.spy(analytics, 'triggerEvent');
+
+    bookend.build();
+    await bookend.loadConfigAndMaybeRenderBookend();
+    const ctaLinks = bookend.bookendEl_.querySelector(
+      '.i-amphtml-story-bookend-cta-link-wrapper'
+    );
+    ctaLinks.children[0].onclick = function(e) {
+      e.preventDefault(); // Make the test not actually navigate.
+    };
+    ctaLinks.children[0].click();
+
+    expect(analyticsSpy).to.have.been.calledWith(
+      StoryAnalyticsEvent.BOOKEND_CLICK
+    );
+    expect(
+      analyticsVariables.get()[AnalyticsVariable.BOOKEND_TARGET_HREF]
+    ).to.equal(
+      'https://www.testorigin.com/amp-stories/example/path/google.com'
+    );
+    expect(
+      analyticsVariables.get()[AnalyticsVariable.BOOKEND_COMPONENT_TYPE]
+    ).to.equal('cta-link');
+    expect(
+      analyticsVariables.get()[AnalyticsVariable.BOOKEND_COMPONENT_POSITION]
+    ).to.equal(1);
+  });
+
+  it('should not fire analytics event when clicking non-clickable components', async () => {
+    const userJson = {
+      'bookendVersion': 'v1.0',
+      'shareProviders': [
+        'email',
+        {'provider': 'facebook', 'app_id': '254325784911610'},
+        'whatsapp',
+      ],
+      'components': [
+        {
+          'type': 'textbox',
+          'text': [
+            'Food by Enrique McPizza',
+            'Choreography by Gabriel Filly',
+            'Script by Alan Ecma S.',
+            'Direction by Jon Tarantino',
+          ],
+        },
+      ],
+    };
+
+    env.sandbox.stub(requestService, 'loadBookendConfig').resolves(userJson);
+    const analyticsSpy = env.sandbox.spy(analytics, 'triggerEvent');
+
+    bookend.build();
+    await bookend.loadConfigAndMaybeRenderBookend();
+    const textEl = bookend.bookendEl_.querySelector(
+      '.i-amphtml-story-bookend-text'
+    );
+
+    textEl.click();
+
+    expect(analyticsSpy).to.not.have.been.called;
+  });
+
+  it(
+    'should not add amp-to-amp linking to cta links when not ' +
+      'specified in the JSON config',
+    async () => {
       const userJson = {
         'bookendVersion': 'v1.0',
         'shareProviders': [
@@ -395,9 +476,14 @@ describes.fakeWin(
             'type': 'cta-link',
             'links': [
               {
-                'text': 'buttonA',
+                'text': 'buttonB',
                 'url': 'google.com',
-                'amphtml': true,
+                'amphtml': '',
+              },
+              {
+                'text': 'longtext longtext longtext longtext longtext',
+                'url': 'google.com',
+                'amphtml': false,
               },
             ],
           },
@@ -405,35 +491,21 @@ describes.fakeWin(
       };
 
       env.sandbox.stub(requestService, 'loadBookendConfig').resolves(userJson);
-      const analyticsSpy = env.sandbox.spy(analytics, 'triggerEvent');
 
       bookend.build();
       await bookend.loadConfigAndMaybeRenderBookend();
       const ctaLinks = bookend.bookendEl_.querySelector(
         '.i-amphtml-story-bookend-cta-link-wrapper'
       );
-      ctaLinks.children[0].onclick = function(e) {
-        e.preventDefault(); // Make the test not actually navigate.
-      };
-      ctaLinks.children[0].click();
+      expect(ctaLinks.children[0]).to.not.have.attribute('rel');
+      expect(ctaLinks.children[1]).to.not.have.attribute('rel');
+    }
+  );
 
-      expect(analyticsSpy).to.have.been.calledWith(
-        StoryAnalyticsEvent.BOOKEND_CLICK
-      );
-      expect(
-        analyticsVariables.get()[AnalyticsVariable.BOOKEND_TARGET_HREF]
-      ).to.equal(
-        'https://www.testorigin.com/amp-stories/example/path/google.com'
-      );
-      expect(
-        analyticsVariables.get()[AnalyticsVariable.BOOKEND_COMPONENT_TYPE]
-      ).to.equal('cta-link');
-      expect(
-        analyticsVariables.get()[AnalyticsVariable.BOOKEND_COMPONENT_POSITION]
-      ).to.equal(1);
-    });
-
-    it('should not fire analytics event when clicking non-clickable components', async () => {
+  it(
+    'should add amp-to-amp linking to small articles when specified ' +
+      'in the JSON config',
+    async () => {
       const userJson = {
         'bookendVersion': 'v1.0',
         'shareProviders': [
@@ -443,855 +515,758 @@ describes.fakeWin(
         ],
         'components': [
           {
-            'type': 'textbox',
-            'text': [
-              'Food by Enrique McPizza',
-              'Choreography by Gabriel Filly',
-              'Script by Alan Ecma S.',
-              'Direction by Jon Tarantino',
-            ],
+            'type': 'small',
+            'title': 'This is an example article!',
+            'url': 'http://example.com/article.html',
+            'image': 'http://placehold.it/256x128',
+            'amphtml': true,
           },
         ],
       };
 
       env.sandbox.stub(requestService, 'loadBookendConfig').resolves(userJson);
-      const analyticsSpy = env.sandbox.spy(analytics, 'triggerEvent');
 
       bookend.build();
       await bookend.loadConfigAndMaybeRenderBookend();
-      const textEl = bookend.bookendEl_.querySelector(
-        '.i-amphtml-story-bookend-text'
+      const articles = bookend.bookendEl_.querySelectorAll(
+        '.i-amphtml-story-bookend-article'
       );
+      expect(articles[0]).to.have.attribute('rel');
+      expect(articles[0].getAttribute('rel')).to.equal('amphtml');
+    }
+  );
 
-      textEl.click();
-
-      expect(analyticsSpy).to.not.have.been.called;
-    });
-
-    it(
-      'should not add amp-to-amp linking to cta links when not ' +
-        'specified in the JSON config',
-      async () => {
-        const userJson = {
-          'bookendVersion': 'v1.0',
-          'shareProviders': [
-            'email',
-            {'provider': 'facebook', 'app_id': '254325784911610'},
-            'whatsapp',
-          ],
-          'components': [
-            {
-              'type': 'cta-link',
-              'links': [
-                {
-                  'text': 'buttonB',
-                  'url': 'google.com',
-                  'amphtml': '',
-                },
-                {
-                  'text': 'longtext longtext longtext longtext longtext',
-                  'url': 'google.com',
-                  'amphtml': false,
-                },
-              ],
-            },
-          ],
-        };
-
-        env.sandbox
-          .stub(requestService, 'loadBookendConfig')
-          .resolves(userJson);
-
-        bookend.build();
-        await bookend.loadConfigAndMaybeRenderBookend();
-        const ctaLinks = bookend.bookendEl_.querySelector(
-          '.i-amphtml-story-bookend-cta-link-wrapper'
-        );
-        expect(ctaLinks.children[0]).to.not.have.attribute('rel');
-        expect(ctaLinks.children[1]).to.not.have.attribute('rel');
-      }
-    );
-
-    it(
-      'should add amp-to-amp linking to small articles when specified ' +
-        'in the JSON config',
-      async () => {
-        const userJson = {
-          'bookendVersion': 'v1.0',
-          'shareProviders': [
-            'email',
-            {'provider': 'facebook', 'app_id': '254325784911610'},
-            'whatsapp',
-          ],
-          'components': [
-            {
-              'type': 'small',
-              'title': 'This is an example article!',
-              'url': 'http://example.com/article.html',
-              'image': 'http://placehold.it/256x128',
-              'amphtml': true,
-            },
-          ],
-        };
-
-        env.sandbox
-          .stub(requestService, 'loadBookendConfig')
-          .resolves(userJson);
-
-        bookend.build();
-        await bookend.loadConfigAndMaybeRenderBookend();
-        const articles = bookend.bookendEl_.querySelectorAll(
-          '.i-amphtml-story-bookend-article'
-        );
-        expect(articles[0]).to.have.attribute('rel');
-        expect(articles[0].getAttribute('rel')).to.equal('amphtml');
-      }
-    );
-
-    it(
-      'should not add amp-to-amp linking to small articles when not ' +
-        'specified in the JSON config',
-      async () => {
-        const userJson = {
-          'bookendVersion': 'v1.0',
-          'shareProviders': [
-            'email',
-            {'provider': 'facebook', 'app_id': '254325784911610'},
-            'whatsapp',
-          ],
-          'components': [
-            {
-              'type': 'small',
-              'title': 'This is an example article!',
-              'url': 'http://example.com/article.html',
-              'image': 'http://placehold.it/256x128',
-            },
-            {
-              'type': 'small',
-              'title': 'This is an example article!',
-              'url': 'http://example.com/article.html',
-              'image': 'http://placehold.it/256x128',
-              'amphtml': 'true',
-            },
-          ],
-        };
-
-        env.sandbox
-          .stub(requestService, 'loadBookendConfig')
-          .resolves(userJson);
-
-        bookend.build();
-        await bookend.loadConfigAndMaybeRenderBookend();
-        const articles = bookend.bookendEl_.querySelectorAll(
-          '.i-amphtml-story-bookend-article'
-        );
-        expect(articles[0]).to.not.have.attribute('rel');
-        expect(articles[1]).to.not.have.attribute('rel');
-      }
-    );
-
-    it(
-      'should add amp-to-amp linking to portrait articles when specified ' +
-        'in the JSON config',
-      async () => {
-        const userJson = {
-          'bookendVersion': 'v1.0',
-          'shareProviders': [
-            'email',
-            {'provider': 'facebook', 'app_id': '254325784911610'},
-            'whatsapp',
-          ],
-          'components': [
-            {
-              'type': 'portrait',
-              'title': 'example title',
-              'category': 'example category',
-              'url': 'http://example.com/article.html',
-              'image': 'http://placehold.it/256x128',
-              'amphtml': true,
-            },
-          ],
-        };
-
-        env.sandbox
-          .stub(requestService, 'loadBookendConfig')
-          .resolves(userJson);
-
-        bookend.build();
-        await bookend.loadConfigAndMaybeRenderBookend();
-        const articles = bookend.bookendEl_.querySelectorAll(
-          '.i-amphtml-story-bookend-portrait'
-        );
-        expect(articles[0]).to.have.attribute('rel');
-        expect(articles[0].getAttribute('rel')).to.equal('amphtml');
-      }
-    );
-
-    it(
-      'should not add amp-to-amp linking to portrait articles when not ' +
-        'specified in the JSON config',
-      async () => {
-        const userJson = {
-          'bookendVersion': 'v1.0',
-          'shareProviders': [
-            'email',
-            {'provider': 'facebook', 'app_id': '254325784911610'},
-            'whatsapp',
-          ],
-          'components': [
-            {
-              'type': 'portrait',
-              'title': 'example title',
-              'category': 'example category',
-              'url': 'http://example.com/article.html',
-              'image': 'http://placehold.it/256x128',
-            },
-            {
-              'type': 'portrait',
-              'title': 'example title',
-              'category': 'example category',
-              'url': 'http://example.com/article.html',
-              'image': 'http://placehold.it/256x128',
-              'amphtml': 'true',
-            },
-          ],
-        };
-
-        env.sandbox
-          .stub(requestService, 'loadBookendConfig')
-          .resolves(userJson);
-
-        bookend.build();
-        await bookend.loadConfigAndMaybeRenderBookend();
-        const articles = bookend.bookendEl_.querySelectorAll(
-          '.i-amphtml-story-bookend-portrait'
-        );
-        expect(articles[0]).to.not.have.attribute('rel');
-        expect(articles[1]).to.not.have.attribute('rel');
-      }
-    );
-
-    it(
-      'should add amp-to-amp linking to landscape articles when ' +
-        'specified in the JSON config',
-      async () => {
-        const userJson = {
-          'bookendVersion': 'v1.0',
-          'shareProviders': [
-            'email',
-            {'provider': 'facebook', 'app_id': '254325784911610'},
-            'whatsapp',
-          ],
-          'components': [
-            {
-              'type': 'landscape',
-              'category': 'example category',
-              'title': 'example title',
-              'url': 'http://example.com/article.html',
-              'image': 'http://placehold.it/256x128',
-              'amphtml': true,
-            },
-          ],
-        };
-
-        env.sandbox
-          .stub(requestService, 'loadBookendConfig')
-          .resolves(userJson);
-
-        bookend.build();
-        await bookend.loadConfigAndMaybeRenderBookend();
-        const articles = bookend.bookendEl_.querySelectorAll(
-          '.i-amphtml-story-bookend-landscape'
-        );
-        expect(articles[0]).to.have.attribute('rel');
-        expect(articles[0].getAttribute('rel')).to.equal('amphtml');
-      }
-    );
-
-    it(
-      'should not add amp-to-amp linking to landscape articles when not' +
-        ' specified in the JSON config',
-      async () => {
-        const userJson = {
-          'bookendVersion': 'v1.0',
-          'shareProviders': [
-            'email',
-            {'provider': 'facebook', 'app_id': '254325784911610'},
-            'whatsapp',
-          ],
-          'components': [
-            {
-              'type': 'landscape',
-              'category': 'example category',
-              'title': 'example title',
-              'url': 'http://example.com/article.html',
-              'image': 'http://placehold.it/256x128',
-            },
-            {
-              'type': 'landscape',
-              'category': 'example category',
-              'title': 'example title',
-              'url': 'http://example.com/article.html',
-              'image': 'http://placehold.it/256x128',
-              'amphtml': 'true',
-            },
-          ],
-        };
-
-        env.sandbox
-          .stub(requestService, 'loadBookendConfig')
-          .resolves(userJson);
-
-        bookend.build();
-        await bookend.loadConfigAndMaybeRenderBookend();
-        const articles = bookend.bookendEl_.querySelectorAll(
-          '.i-amphtml-story-bookend-landscape'
-        );
-        expect(articles[0]).to.not.have.attribute('rel');
-        expect(articles[1]).to.not.have.attribute('rel');
-      }
-    );
-
-    it('should build the users share providers', async () => {
+  it(
+    'should not add amp-to-amp linking to small articles when not ' +
+      'specified in the JSON config',
+    async () => {
       const userJson = {
         'bookendVersion': 'v1.0',
         'shareProviders': [
           'email',
           {'provider': 'facebook', 'app_id': '254325784911610'},
-          {
-            'provider': 'twitter',
-            'text':
-              'This is custom share text that I' +
-              ' would like for the Twitter platform',
-          },
           'whatsapp',
         ],
         'components': [
           {
-            'type': 'heading',
-            'text': 'My Heading Title!',
+            'type': 'small',
+            'title': 'This is an example article!',
+            'url': 'http://example.com/article.html',
+            'image': 'http://placehold.it/256x128',
           },
           {
             'type': 'small',
-            'title': 'This is an example article',
+            'title': 'This is an example article!',
             'url': 'http://example.com/article.html',
             'image': 'http://placehold.it/256x128',
+            'amphtml': 'true',
           },
         ],
       };
 
-      const expectedShareProviders = [
+      env.sandbox.stub(requestService, 'loadBookendConfig').resolves(userJson);
+
+      bookend.build();
+      await bookend.loadConfigAndMaybeRenderBookend();
+      const articles = bookend.bookendEl_.querySelectorAll(
+        '.i-amphtml-story-bookend-article'
+      );
+      expect(articles[0]).to.not.have.attribute('rel');
+      expect(articles[1]).to.not.have.attribute('rel');
+    }
+  );
+
+  it(
+    'should add amp-to-amp linking to portrait articles when specified ' +
+      'in the JSON config',
+    async () => {
+      const userJson = {
+        'bookendVersion': 'v1.0',
+        'shareProviders': [
+          'email',
+          {'provider': 'facebook', 'app_id': '254325784911610'},
+          'whatsapp',
+        ],
+        'components': [
+          {
+            'type': 'portrait',
+            'title': 'example title',
+            'category': 'example category',
+            'url': 'http://example.com/article.html',
+            'image': 'http://placehold.it/256x128',
+            'amphtml': true,
+          },
+        ],
+      };
+
+      env.sandbox.stub(requestService, 'loadBookendConfig').resolves(userJson);
+
+      bookend.build();
+      await bookend.loadConfigAndMaybeRenderBookend();
+      const articles = bookend.bookendEl_.querySelectorAll(
+        '.i-amphtml-story-bookend-portrait'
+      );
+      expect(articles[0]).to.have.attribute('rel');
+      expect(articles[0].getAttribute('rel')).to.equal('amphtml');
+    }
+  );
+
+  it(
+    'should not add amp-to-amp linking to portrait articles when not ' +
+      'specified in the JSON config',
+    async () => {
+      const userJson = {
+        'bookendVersion': 'v1.0',
+        'shareProviders': [
+          'email',
+          {'provider': 'facebook', 'app_id': '254325784911610'},
+          'whatsapp',
+        ],
+        'components': [
+          {
+            'type': 'portrait',
+            'title': 'example title',
+            'category': 'example category',
+            'url': 'http://example.com/article.html',
+            'image': 'http://placehold.it/256x128',
+          },
+          {
+            'type': 'portrait',
+            'title': 'example title',
+            'category': 'example category',
+            'url': 'http://example.com/article.html',
+            'image': 'http://placehold.it/256x128',
+            'amphtml': 'true',
+          },
+        ],
+      };
+
+      env.sandbox.stub(requestService, 'loadBookendConfig').resolves(userJson);
+
+      bookend.build();
+      await bookend.loadConfigAndMaybeRenderBookend();
+      const articles = bookend.bookendEl_.querySelectorAll(
+        '.i-amphtml-story-bookend-portrait'
+      );
+      expect(articles[0]).to.not.have.attribute('rel');
+      expect(articles[1]).to.not.have.attribute('rel');
+    }
+  );
+
+  it(
+    'should add amp-to-amp linking to landscape articles when ' +
+      'specified in the JSON config',
+    async () => {
+      const userJson = {
+        'bookendVersion': 'v1.0',
+        'shareProviders': [
+          'email',
+          {'provider': 'facebook', 'app_id': '254325784911610'},
+          'whatsapp',
+        ],
+        'components': [
+          {
+            'type': 'landscape',
+            'category': 'example category',
+            'title': 'example title',
+            'url': 'http://example.com/article.html',
+            'image': 'http://placehold.it/256x128',
+            'amphtml': true,
+          },
+        ],
+      };
+
+      env.sandbox.stub(requestService, 'loadBookendConfig').resolves(userJson);
+
+      bookend.build();
+      await bookend.loadConfigAndMaybeRenderBookend();
+      const articles = bookend.bookendEl_.querySelectorAll(
+        '.i-amphtml-story-bookend-landscape'
+      );
+      expect(articles[0]).to.have.attribute('rel');
+      expect(articles[0].getAttribute('rel')).to.equal('amphtml');
+    }
+  );
+
+  it(
+    'should not add amp-to-amp linking to landscape articles when not' +
+      ' specified in the JSON config',
+    async () => {
+      const userJson = {
+        'bookendVersion': 'v1.0',
+        'shareProviders': [
+          'email',
+          {'provider': 'facebook', 'app_id': '254325784911610'},
+          'whatsapp',
+        ],
+        'components': [
+          {
+            'type': 'landscape',
+            'category': 'example category',
+            'title': 'example title',
+            'url': 'http://example.com/article.html',
+            'image': 'http://placehold.it/256x128',
+          },
+          {
+            'type': 'landscape',
+            'category': 'example category',
+            'title': 'example title',
+            'url': 'http://example.com/article.html',
+            'image': 'http://placehold.it/256x128',
+            'amphtml': 'true',
+          },
+        ],
+      };
+
+      env.sandbox.stub(requestService, 'loadBookendConfig').resolves(userJson);
+
+      bookend.build();
+      await bookend.loadConfigAndMaybeRenderBookend();
+      const articles = bookend.bookendEl_.querySelectorAll(
+        '.i-amphtml-story-bookend-landscape'
+      );
+      expect(articles[0]).to.not.have.attribute('rel');
+      expect(articles[1]).to.not.have.attribute('rel');
+    }
+  );
+
+  it('should build the users share providers', async () => {
+    const userJson = {
+      'bookendVersion': 'v1.0',
+      'shareProviders': [
         'email',
         {'provider': 'facebook', 'app_id': '254325784911610'},
         {
           'provider': 'twitter',
           'text':
-            'This is custom share text that I ' +
-            'would like for the Twitter platform',
+            'This is custom share text that I' +
+            ' would like for the Twitter platform',
         },
         'whatsapp',
-      ];
+      ],
+      'components': [
+        {
+          'type': 'heading',
+          'text': 'My Heading Title!',
+        },
+        {
+          'type': 'small',
+          'title': 'This is an example article',
+          'url': 'http://example.com/article.html',
+          'image': 'http://placehold.it/256x128',
+        },
+      ],
+    };
 
-      env.sandbox.stub(requestService, 'loadBookendConfig').resolves(userJson);
+    const expectedShareProviders = [
+      'email',
+      {'provider': 'facebook', 'app_id': '254325784911610'},
+      {
+        'provider': 'twitter',
+        'text':
+          'This is custom share text that I ' +
+          'would like for the Twitter platform',
+      },
+      'whatsapp',
+    ];
 
-      bookend.build();
-      const config = await bookend.loadConfigAndMaybeRenderBookend();
-      config['shareProviders'].forEach((currProvider, index) => {
-        expect(currProvider).to.deep.equal(expectedShareProviders[index]);
-      });
+    env.sandbox.stub(requestService, 'loadBookendConfig').resolves(userJson);
+
+    bookend.build();
+    const config = await bookend.loadConfigAndMaybeRenderBookend();
+    config['shareProviders'].forEach((currProvider, index) => {
+      expect(currProvider).to.deep.equal(expectedShareProviders[index]);
     });
+  });
 
-    it('should ignore empty share providers', async () => {
-      const userJson = {
-        'bookendVersion': 'v1.0',
-        'shareProviders': [],
-        'components': [
-          {
-            'type': 'heading',
-            'text': 'My Heading Title!',
-          },
-          {
-            'type': 'small',
-            'title': 'This is an example article',
-            'url': 'http://example.com/article.html',
-            'image': 'http://placehold.it/256x128',
-          },
-        ],
-      };
+  it('should ignore empty share providers', async () => {
+    const userJson = {
+      'bookendVersion': 'v1.0',
+      'shareProviders': [],
+      'components': [
+        {
+          'type': 'heading',
+          'text': 'My Heading Title!',
+        },
+        {
+          'type': 'small',
+          'title': 'This is an example article',
+          'url': 'http://example.com/article.html',
+          'image': 'http://placehold.it/256x128',
+        },
+      ],
+    };
 
-      env.sandbox.stub(requestService, 'loadBookendConfig').resolves(userJson);
+    env.sandbox.stub(requestService, 'loadBookendConfig').resolves(userJson);
 
-      bookend.build();
-      const config = await bookend.loadConfigAndMaybeRenderBookend();
-      expect(config['shareProviders']).to.deep.equal([]);
-    });
+    bookend.build();
+    const config = await bookend.loadConfigAndMaybeRenderBookend();
+    expect(config['shareProviders']).to.deep.equal([]);
+  });
 
-    it('should warn when trying to use system sharing', async () => {
-      const userJson = {
-        'bookendVersion': 'v1.0',
-        'shareProviders': ['system'],
-        'components': [
-          {
-            'type': 'heading',
-            'text': 'My Heading Title!',
-          },
-          {
-            'type': 'small',
-            'title': 'This is an example article',
-            'url': 'http://example.com/article.html',
-            'image': 'http://placehold.it/256x128',
-          },
-        ],
-      };
+  it('should warn when trying to use system sharing', async () => {
+    const userJson = {
+      'bookendVersion': 'v1.0',
+      'shareProviders': ['system'],
+      'components': [
+        {
+          'type': 'heading',
+          'text': 'My Heading Title!',
+        },
+        {
+          'type': 'small',
+          'title': 'This is an example article',
+          'url': 'http://example.com/article.html',
+          'image': 'http://placehold.it/256x128',
+        },
+      ],
+    };
 
-      const userWarnStub = env.sandbox.stub(user(), 'warn');
+    const userWarnStub = env.sandbox.stub(user(), 'warn');
 
-      env.sandbox.stub(requestService, 'loadBookendConfig').resolves(userJson);
+    env.sandbox.stub(requestService, 'loadBookendConfig').resolves(userJson);
 
-      bookend.build();
-      await bookend.loadConfigAndMaybeRenderBookend();
-      expect(userWarnStub).to.be.calledOnce;
-      expect(userWarnStub.args[0][1]).to.be.equal(
-        '`system` is not a valid ' +
-          'share provider type. Native sharing is ' +
-          'enabled by default and cannot be turned off.'
+    bookend.build();
+    await bookend.loadConfigAndMaybeRenderBookend();
+    expect(userWarnStub).to.be.calledOnce;
+    expect(userWarnStub.args[0][1]).to.be.equal(
+      '`system` is not a valid ' +
+        'share provider type. Native sharing is ' +
+        'enabled by default and cannot be turned off.'
+    );
+  });
+
+  it('should reject invalid user json for article', () => {
+    const articleComponent = new ArticleComponent();
+    const userJson = {
+      'bookendVersion': 'v1.0',
+      'shareProviders': [
+        'email',
+        {'provider': 'facebook', 'app_id': '254325784911610'},
+        'whatsapp',
+      ],
+      'components': [
+        {
+          'type': 'heading',
+          'title': 'test',
+        },
+        {
+          'type': 'small',
+          'url': 'http://example.com/article.html',
+          'image': 'http://placehold.it/256x128',
+        },
+      ],
+    };
+
+    allowConsoleError(() => {
+      expect(() => articleComponent.assertValidity(userJson)).to.throw(
+        'Small article component must contain `title`, `url` fields, ' +
+          'skipping invalid.​​​'
       );
     });
+  });
 
-    it('should reject invalid user json for article', () => {
-      const articleComponent = new ArticleComponent();
-      const userJson = {
-        'bookendVersion': 'v1.0',
-        'shareProviders': [
-          'email',
-          {'provider': 'facebook', 'app_id': '254325784911610'},
-          'whatsapp',
-        ],
-        'components': [
-          {
-            'type': 'heading',
-            'title': 'test',
-          },
-          {
-            'type': 'small',
-            'url': 'http://example.com/article.html',
-            'image': 'http://placehold.it/256x128',
-          },
-        ],
-      };
+  it('should reject invalid user json for portrait article', () => {
+    const portraitComponant = new PortraitComponent();
+    const userJson = {
+      'bookendVersion': 'v1.0',
+      'shareProviders': [
+        'email',
+        {'provider': 'facebook', 'app_id': '254325784911610'},
+        'whatsapp',
+      ],
+      'components': [
+        {
+          'type': 'portrait',
+          'category': 'sample',
+          'url': 'http://example.com/article.html',
+          'image': 'http://placehold.it/256x128',
+        },
+      ],
+    };
 
-      allowConsoleError(() => {
-        expect(() => articleComponent.assertValidity(userJson)).to.throw(
-          'Small article component must contain `title`, `url` fields, ' +
-            'skipping invalid.​​​'
-        );
-      });
-    });
-
-    it('should reject invalid user json for portrait article', () => {
-      const portraitComponant = new PortraitComponent();
-      const userJson = {
-        'bookendVersion': 'v1.0',
-        'shareProviders': [
-          'email',
-          {'provider': 'facebook', 'app_id': '254325784911610'},
-          'whatsapp',
-        ],
-        'components': [
-          {
-            'type': 'portrait',
-            'category': 'sample',
-            'url': 'http://example.com/article.html',
-            'image': 'http://placehold.it/256x128',
-          },
-        ],
-      };
-
-      allowConsoleError(() => {
-        expect(() => portraitComponant.assertValidity(userJson)).to.throw(
-          'Portrait component must contain `title`, `image`, ' +
-            '`url` fields, skipping invalid.'
-        );
-      });
-    });
-
-    it('should reject invalid user json for the cta links component', () => {
-      const ctaLinkComponent = new CtaLinkComponent();
-      const userJson = {
-        'bookendVersion': 'v1.0',
-        'shareProviders': [
-          'email',
-          {'provider': 'facebook', 'app_id': '254325784911610'},
-          'whatsapp',
-        ],
-        'components': [
-          {
-            'type': 'heading',
-            'title': 'test',
-          },
-          {
-            'type': 'small',
-            'url': 'http://example.com/article.html',
-            'image': 'http://placehold.it/256x128',
-          },
-          {
-            'type': 'cta-link',
-            'links': [],
-          },
-        ],
-      };
-
-      allowConsoleError(() => {
-        expect(() => ctaLinkComponent.assertValidity(userJson)).to.throw(
-          'CTA link component must be an array ' +
-            'and contain at least one link inside it.'
-        );
-      });
-    });
-
-    it('should reject invalid user json for a landscape component', () => {
-      const landscapeComponent = new LandscapeComponent();
-      const userJson = {
-        'bookendVersion': 'v1.0',
-        'shareProviders': [
-          'email',
-          {'provider': 'facebook', 'app_id': '254325784911610'},
-          'whatsapp',
-        ],
-        'components': [
-          {
-            'type': 'heading',
-            'title': 'test',
-          },
-          {
-            'type': 'small',
-            'url': 'http://example.com/article.html',
-            'image': 'http://placehold.it/256x128',
-          },
-          {
-            'type': 'landscape',
-            'url': 'http://example.com/article.html',
-            'category': 'astronomy',
-            'image': 'http://placehold.it/256x128',
-          },
-        ],
-      };
-
-      allowConsoleError(() => {
-        expect(() => landscapeComponent.assertValidity(userJson)).to.throw(
-          'Landscape component must contain `title`, `image`, ' +
-            '`url` fields, skipping invalid.'
-        );
-      });
-    });
-
-    it('should reject invalid user json for a textbox component', () => {
-      const textBoxComponent = new TextBoxComponent();
-      const userJson = {
-        'bookendVersion': 'v1.0',
-        'shareProviders': [
-          'email',
-          {'provider': 'facebook', 'app-id': '254325784911610'},
-          'whatsapp',
-        ],
-        'components': [
-          {
-            'type': 'heading',
-            'title': 'test',
-          },
-          {
-            'type': 'small',
-            'url': 'http://example.com/article.html',
-            'image': 'http://placehold.it/256x128',
-          },
-          {
-            'type': 'textbox',
-            'text': 'http://example.com/article.html',
-          },
-        ],
-      };
-
-      allowConsoleError(() => {
-        expect(() => textBoxComponent.assertValidity(userJson)).to.throw(
-          'Textbox component must contain ' +
-            '`text` array and at least one element inside it, ' +
-            'skipping invalid.'
-        );
-      });
-    });
-
-    it('should have a button to re-prompt the consent if story has one', () => {
-      const consentId = 'CONSENT_ID';
-      bookend.storeService_.dispatch(Action.SET_CONSENT_ID, consentId);
-
-      bookend.build();
-
-      const promptButtonEl = bookend
-        .getShadowRoot()
-        .querySelector(`[on="tap:${consentId}.prompt"]`);
-
-      expect(promptButtonEl).to.exist;
-    });
-
-    it('should not have a button to re-prompt the consent by default', () => {
-      bookend.build();
-
-      // No element with an "on" attribute ending with ".prompt".
-      const promptButtonEl = bookend
-        .getShadowRoot()
-        .querySelector('[on$=".prompt"]');
-
-      expect(promptButtonEl).to.be.null;
-    });
-
-    it('should skip invalid component name and continue building', async () => {
-      const userJson = {
-        'bookendVersion': 'v1.0',
-        'shareProviders': [
-          'email',
-          {'provider': 'facebook', 'app-id': '254325784911610'},
-          'whatsapp',
-        ],
-        'components': [
-          {
-            'type': 'invalid-type',
-            'title': 'test',
-          },
-          {
-            'type': 'small',
-            'title': 'This is an example article',
-            'domainName': 'example.com',
-            'url': 'http://example.com/article.html',
-            'image': 'http://placehold.it/256x128',
-          },
-        ],
-      };
-
-      env.sandbox.stub(requestService, 'loadBookendConfig').resolves(userJson);
-
-      bookend.build();
-      expectAsyncConsoleError(
-        /[Component `invalid-type` is not supported. Skipping invalid]/
-      );
-
-      const config = await bookend.loadConfigAndMaybeRenderBookend();
-      // Still builds rest of valid components.
-
-      // We use config.components[1] because config.components[0] is a heading
-      // that we prepend when there is no heading present in the user config.
-      expect(config.components[1]).to.deep.equal(userJson.components[1]);
-    });
-
-    it('should not add a heading component when there are no components', async () => {
-      const userJson = {
-        'bookendVersion': 'v1.0',
-        'shareProviders': [
-          'email',
-          {'provider': 'facebook', 'app_id': '254325784911610'},
-          'whatsapp',
-        ],
-        'components': [],
-      };
-
-      env.sandbox.stub(requestService, 'loadBookendConfig').resolves(userJson);
-
-      bookend.build();
-      const config = await bookend.loadConfigAndMaybeRenderBookend();
-      expect(config.components.length).to.equal(0);
-    });
-
-    it('should resolve article relative url for origin url when served from the cache', async () => {
-      const component = {
-        url: './other-article.html',
-        domainName: 'example.com',
-        type: 'small',
-        title: 'This is an example article',
-        image: '../../assets/01-iconic-american-destinations.jpg',
-      };
-
-      win.location.resetHref(
-        'https://www-nationalgeographic-com.cdn.ampproject.org/c/s/www.nationalgeographic.com/amp-stories/travel/10-iconic-places-to-photograph/'
-      );
-
-      const article = new ArticleComponent();
-      const el = article.buildElement(component, win, {position: 0});
-      expect(el.href).to.equal(
-        'https://www.nationalgeographic.com/amp-stories/travel/10-iconic-places-to-photograph/other-article.html'
+    allowConsoleError(() => {
+      expect(() => portraitComponant.assertValidity(userJson)).to.throw(
+        'Portrait component must contain `title`, `image`, ' +
+          '`url` fields, skipping invalid.'
       );
     });
+  });
 
-    it('should respect specified absolute URL', async () => {
-      const component = {
-        url: 'https://www.anothersite.com/article.html',
-        domainName: 'example.com',
-        type: 'small',
-        title: 'This is an example article',
-        image: '../../assets/01-iconic-american-destinations.jpg',
-      };
+  it('should reject invalid user json for the cta links component', () => {
+    const ctaLinkComponent = new CtaLinkComponent();
+    const userJson = {
+      'bookendVersion': 'v1.0',
+      'shareProviders': [
+        'email',
+        {'provider': 'facebook', 'app_id': '254325784911610'},
+        'whatsapp',
+      ],
+      'components': [
+        {
+          'type': 'heading',
+          'title': 'test',
+        },
+        {
+          'type': 'small',
+          'url': 'http://example.com/article.html',
+          'image': 'http://placehold.it/256x128',
+        },
+        {
+          'type': 'cta-link',
+          'links': [],
+        },
+      ],
+    };
 
-      win.location.resetHref(
-        'https://www-nationalgeographic-com.cdn.ampproject.org/c/s/www.nationalgeographic.com/amp-stories/travel/10-iconic-places-to-photograph/'
-      );
-
-      const article = new ArticleComponent();
-      const el = article.buildElement(component, win, {position: 0});
-      expect(el.href).to.equal('https://www.anothersite.com/article.html');
-    });
-
-    it('should rewrite article thumbnail image url for cached version', async () => {
-      const component = {
-        url: 'http://example.com/article.html',
-        domainName: 'example.com',
-        type: 'small',
-        title: 'This is an example article',
-        image: '../../assets/01-iconic-american-destinations.jpg',
-      };
-
-      win.location.resetHref(
-        'https://www-nationalgeographic-com.cdn.ampproject.org/c/s/www.nationalgeographic.com/amp-stories/travel/10-iconic-places-to-photograph/'
-      );
-
-      const article = new ArticleComponent();
-      const el = article.buildElement(component, win, {position: 0});
-      expect(el.querySelector('img').src).to.equal(
-        'https://www-nationalgeographic-com.cdn.ampproject.org/i/s/www.nationalgeographic.com/amp-stories/assets/01-iconic-american-destinations.jpg'
+    allowConsoleError(() => {
+      expect(() => ctaLinkComponent.assertValidity(userJson)).to.throw(
+        'CTA link component must be an array ' +
+          'and contain at least one link inside it.'
       );
     });
+  });
 
-    it('should rewrite landscape thumbnail image url for cached version', async () => {
-      const component = {
-        url: 'http://example.com/landscape.html',
-        domainName: 'example.com',
-        type: 'landscape',
-        title: 'This is an example landscape',
-        image: './assets/01-iconic-american-destinations.jpg',
-      };
+  it('should reject invalid user json for a landscape component', () => {
+    const landscapeComponent = new LandscapeComponent();
+    const userJson = {
+      'bookendVersion': 'v1.0',
+      'shareProviders': [
+        'email',
+        {'provider': 'facebook', 'app_id': '254325784911610'},
+        'whatsapp',
+      ],
+      'components': [
+        {
+          'type': 'heading',
+          'title': 'test',
+        },
+        {
+          'type': 'small',
+          'url': 'http://example.com/article.html',
+          'image': 'http://placehold.it/256x128',
+        },
+        {
+          'type': 'landscape',
+          'url': 'http://example.com/article.html',
+          'category': 'astronomy',
+          'image': 'http://placehold.it/256x128',
+        },
+      ],
+    };
 
-      win.location.resetHref(
-        'https://www-nationalgeographic-com.cdn.ampproject.org/c/s/www.nationalgeographic.com/amp-stories/travel/10-iconic-places-to-photograph/'
-      );
-
-      const landscape = new LandscapeComponent();
-      const el = landscape.buildElement(component, win, {position: 0});
-      expect(el.querySelector('img').src).to.equal(
-        'https://www-nationalgeographic-com.cdn.ampproject.org/i/s/www.nationalgeographic.com/amp-stories/travel/10-iconic-places-to-photograph/assets/01-iconic-american-destinations.jpg'
-      );
-    });
-
-    it('should resolve absolute url correctly', async () => {
-      const component = {
-        url: '//othersite.com/other-article.html',
-        domainName: 'example.com',
-        type: 'small',
-        title: 'This is an example landscape article',
-        image: '../../assets/01-iconic-american-destinations.jpg',
-      };
-
-      win.location.resetHref(
-        'https://www.nationalgeographic.com/amp-stories/travel/10-iconic-places-to-photograph/'
-      );
-      const landscape = new LandscapeComponent();
-
-      const el = landscape.buildElement(component, win, {position: 0});
-      expect(el.href).to.equal('https://othersite.com/other-article.html');
-    });
-
-    it('should resolve relative url for landscape component', async () => {
-      const component = {
-        url: './other-article.html',
-        domainName: 'example.com',
-        type: 'small',
-        title: 'This is an example landscape article',
-        image: '../../assets/01-iconic-american-destinations.jpg',
-      };
-
-      win.location.resetHref(
-        'https://www.nationalgeographic.com/amp-stories/travel/10-iconic-places-to-photograph/'
-      );
-
-      const landscape = new LandscapeComponent();
-
-      const el = landscape.buildElement(component, win, {position: 0});
-      expect(el.href).to.equal(
-        'https://www.nationalgeographic.com/amp-stories/travel/10-iconic-places-to-photograph/other-article.html'
+    allowConsoleError(() => {
+      expect(() => landscapeComponent.assertValidity(userJson)).to.throw(
+        'Landscape component must contain `title`, `image`, ' +
+          '`url` fields, skipping invalid.'
       );
     });
+  });
 
-    it('should resolve relative url for landscape component in cache', async () => {
-      const component = {
-        url: './other-article.html',
-        domainName: 'example.com',
-        type: 'small',
-        title: 'This is an example landscape article',
-        image: '../../assets/01-iconic-american-destinations.jpg',
-      };
+  it('should reject invalid user json for a textbox component', () => {
+    const textBoxComponent = new TextBoxComponent();
+    const userJson = {
+      'bookendVersion': 'v1.0',
+      'shareProviders': [
+        'email',
+        {'provider': 'facebook', 'app-id': '254325784911610'},
+        'whatsapp',
+      ],
+      'components': [
+        {
+          'type': 'heading',
+          'title': 'test',
+        },
+        {
+          'type': 'small',
+          'url': 'http://example.com/article.html',
+          'image': 'http://placehold.it/256x128',
+        },
+        {
+          'type': 'textbox',
+          'text': 'http://example.com/article.html',
+        },
+      ],
+    };
 
-      win.location.resetHref(
-        'https://www-nationalgeographic-com.cdn.ampproject.org/c/s/www.nationalgeographic.com/amp-stories/travel/10-iconic-places-to-photograph/'
-      );
-      const landscape = new LandscapeComponent();
-
-      const el = landscape.buildElement(component, win, {position: 0});
-      expect(el.href).to.equal(
-        'https://www.nationalgeographic.com/amp-stories/travel/10-iconic-places-to-photograph/other-article.html'
-      );
-    });
-
-    it('should rewrite portrait thumbnail image url for cached version', async () => {
-      const component = {
-        url: 'http://example.com/portrait.html',
-        domainName: 'example.com',
-        type: 'small',
-        title: 'This is an example portrait',
-        image: 'assets/01-iconic-american-destinations.jpg',
-      };
-
-      win.location.resetHref(
-        'https://www-nationalgeographic-com.cdn.ampproject.org/c/s/www.nationalgeographic.com/amp-stories/travel/10-iconic-places-to-photograph/'
-      );
-      const portrait = new PortraitComponent();
-      const el = portrait.buildElement(component, win, {position: 0});
-      expect(el.querySelector('img').src).to.equal(
-        'https://www-nationalgeographic-com.cdn.ampproject.org/i/s/www.nationalgeographic.com/amp-stories/travel/10-iconic-places-to-photograph/assets/01-iconic-american-destinations.jpg'
+    allowConsoleError(() => {
+      expect(() => textBoxComponent.assertValidity(userJson)).to.throw(
+        'Textbox component must contain ' +
+          '`text` array and at least one element inside it, ' +
+          'skipping invalid.'
       );
     });
+  });
 
-    it('should not rewrite thumbnail image url when using absolute url', async () => {
-      const component = {
-        url: 'http://example.com/portrait.html',
-        domainName: 'example.com',
-        type: 'small',
-        title: 'This is an example portrait',
-        image: 'http://placehold.it/256x128',
-      };
+  it('should have a button to re-prompt the consent if story has one', () => {
+    const consentId = 'CONSENT_ID';
+    bookend.storeService_.dispatch(Action.SET_CONSENT_ID, consentId);
 
-      win.location.resetHref(
-        'https://www-nationalgeographic-com.cdn.ampproject.org/c/s/www.nationalgeographic.com/amp-stories/travel/10-iconic-places-to-photograph/'
-      );
-      const portrait = new PortraitComponent();
-      const el = portrait.buildElement(component, win, {position: 0});
-      expect(el.querySelector('img').src).to.equal(
-        'http://placehold.it/256x128'
-      );
-    });
+    bookend.build();
 
-    it('should not rewrite thumbnail image for origin documents', async () => {
-      const component = {
-        url: 'http://example.com/portrait.html',
-        domainName: 'example.com',
-        type: 'small',
-        title: 'This is an example portrait',
-        image: '../../assets/01-iconic-american-destinations.jpg',
-      };
+    const promptButtonEl = bookend
+      .getShadowRoot()
+      .querySelector(`[on="tap:${consentId}.prompt"]`);
 
-      win.location.resetHref(
-        'https://www.nationalgeographic.com/amp-stories/travel/10-iconic-places-to-photograph/'
-      );
-      const portrait = new PortraitComponent();
-      const el = portrait.buildElement(component, win, {position: 0});
-      expect(el.querySelector('img').src).to.equal(
-        'https://www.nationalgeographic.com/amp-stories/assets/01-iconic-american-destinations.jpg'
-      );
-    });
-  }
-);
+    expect(promptButtonEl).to.exist;
+  });
+
+  it('should not have a button to re-prompt the consent by default', () => {
+    bookend.build();
+
+    // No element with an "on" attribute ending with ".prompt".
+    const promptButtonEl = bookend
+      .getShadowRoot()
+      .querySelector('[on$=".prompt"]');
+
+    expect(promptButtonEl).to.be.null;
+  });
+
+  it('should skip invalid component name and continue building', async () => {
+    const userJson = {
+      'bookendVersion': 'v1.0',
+      'shareProviders': [
+        'email',
+        {'provider': 'facebook', 'app-id': '254325784911610'},
+        'whatsapp',
+      ],
+      'components': [
+        {
+          'type': 'invalid-type',
+          'title': 'test',
+        },
+        {
+          'type': 'small',
+          'title': 'This is an example article',
+          'domainName': 'example.com',
+          'url': 'http://example.com/article.html',
+          'image': 'http://placehold.it/256x128',
+        },
+      ],
+    };
+
+    env.sandbox.stub(requestService, 'loadBookendConfig').resolves(userJson);
+
+    bookend.build();
+    expectAsyncConsoleError(
+      /[Component `invalid-type` is not supported. Skipping invalid]/
+    );
+
+    const config = await bookend.loadConfigAndMaybeRenderBookend();
+    // Still builds rest of valid components.
+
+    // We use config.components[1] because config.components[0] is a heading
+    // that we prepend when there is no heading present in the user config.
+    expect(config.components[1]).to.deep.equal(userJson.components[1]);
+  });
+
+  it('should not add a heading component when there are no components', async () => {
+    const userJson = {
+      'bookendVersion': 'v1.0',
+      'shareProviders': [
+        'email',
+        {'provider': 'facebook', 'app_id': '254325784911610'},
+        'whatsapp',
+      ],
+      'components': [],
+    };
+
+    env.sandbox.stub(requestService, 'loadBookendConfig').resolves(userJson);
+
+    bookend.build();
+    const config = await bookend.loadConfigAndMaybeRenderBookend();
+    expect(config.components.length).to.equal(0);
+  });
+
+  it('should resolve article relative url for origin url when served from the cache', async () => {
+    const component = {
+      url: './other-article.html',
+      domainName: 'example.com',
+      type: 'small',
+      title: 'This is an example article',
+      image: '../../assets/01-iconic-american-destinations.jpg',
+    };
+
+    win.location.resetHref(
+      'https://www-nationalgeographic-com.cdn.ampproject.org/c/s/www.nationalgeographic.com/amp-stories/travel/10-iconic-places-to-photograph/'
+    );
+
+    const article = new ArticleComponent();
+    const el = article.buildElement(component, win, {position: 0});
+    expect(el.href).to.equal(
+      'https://www.nationalgeographic.com/amp-stories/travel/10-iconic-places-to-photograph/other-article.html'
+    );
+  });
+
+  it('should respect specified absolute URL', async () => {
+    const component = {
+      url: 'https://www.anothersite.com/article.html',
+      domainName: 'example.com',
+      type: 'small',
+      title: 'This is an example article',
+      image: '../../assets/01-iconic-american-destinations.jpg',
+    };
+
+    win.location.resetHref(
+      'https://www-nationalgeographic-com.cdn.ampproject.org/c/s/www.nationalgeographic.com/amp-stories/travel/10-iconic-places-to-photograph/'
+    );
+
+    const article = new ArticleComponent();
+    const el = article.buildElement(component, win, {position: 0});
+    expect(el.href).to.equal('https://www.anothersite.com/article.html');
+  });
+
+  it('should rewrite article thumbnail image url for cached version', async () => {
+    const component = {
+      url: 'http://example.com/article.html',
+      domainName: 'example.com',
+      type: 'small',
+      title: 'This is an example article',
+      image: '../../assets/01-iconic-american-destinations.jpg',
+    };
+
+    win.location.resetHref(
+      'https://www-nationalgeographic-com.cdn.ampproject.org/c/s/www.nationalgeographic.com/amp-stories/travel/10-iconic-places-to-photograph/'
+    );
+
+    const article = new ArticleComponent();
+    const el = article.buildElement(component, win, {position: 0});
+    expect(el.querySelector('img').src).to.equal(
+      'https://www-nationalgeographic-com.cdn.ampproject.org/i/s/www.nationalgeographic.com/amp-stories/assets/01-iconic-american-destinations.jpg'
+    );
+  });
+
+  it('should rewrite landscape thumbnail image url for cached version', async () => {
+    const component = {
+      url: 'http://example.com/landscape.html',
+      domainName: 'example.com',
+      type: 'landscape',
+      title: 'This is an example landscape',
+      image: './assets/01-iconic-american-destinations.jpg',
+    };
+
+    win.location.resetHref(
+      'https://www-nationalgeographic-com.cdn.ampproject.org/c/s/www.nationalgeographic.com/amp-stories/travel/10-iconic-places-to-photograph/'
+    );
+
+    const landscape = new LandscapeComponent();
+    const el = landscape.buildElement(component, win, {position: 0});
+    expect(el.querySelector('img').src).to.equal(
+      'https://www-nationalgeographic-com.cdn.ampproject.org/i/s/www.nationalgeographic.com/amp-stories/travel/10-iconic-places-to-photograph/assets/01-iconic-american-destinations.jpg'
+    );
+  });
+
+  it('should resolve absolute url correctly', async () => {
+    const component = {
+      url: '//othersite.com/other-article.html',
+      domainName: 'example.com',
+      type: 'small',
+      title: 'This is an example landscape article',
+      image: '../../assets/01-iconic-american-destinations.jpg',
+    };
+
+    win.location.resetHref(
+      'https://www.nationalgeographic.com/amp-stories/travel/10-iconic-places-to-photograph/'
+    );
+    const landscape = new LandscapeComponent();
+
+    const el = landscape.buildElement(component, win, {position: 0});
+    expect(el.href).to.equal('https://othersite.com/other-article.html');
+  });
+
+  it('should resolve relative url for landscape component', async () => {
+    const component = {
+      url: './other-article.html',
+      domainName: 'example.com',
+      type: 'small',
+      title: 'This is an example landscape article',
+      image: '../../assets/01-iconic-american-destinations.jpg',
+    };
+
+    win.location.resetHref(
+      'https://www.nationalgeographic.com/amp-stories/travel/10-iconic-places-to-photograph/'
+    );
+
+    const landscape = new LandscapeComponent();
+
+    const el = landscape.buildElement(component, win, {position: 0});
+    expect(el.href).to.equal(
+      'https://www.nationalgeographic.com/amp-stories/travel/10-iconic-places-to-photograph/other-article.html'
+    );
+  });
+
+  it('should resolve relative url for landscape component in cache', async () => {
+    const component = {
+      url: './other-article.html',
+      domainName: 'example.com',
+      type: 'small',
+      title: 'This is an example landscape article',
+      image: '../../assets/01-iconic-american-destinations.jpg',
+    };
+
+    win.location.resetHref(
+      'https://www-nationalgeographic-com.cdn.ampproject.org/c/s/www.nationalgeographic.com/amp-stories/travel/10-iconic-places-to-photograph/'
+    );
+    const landscape = new LandscapeComponent();
+
+    const el = landscape.buildElement(component, win, {position: 0});
+    expect(el.href).to.equal(
+      'https://www.nationalgeographic.com/amp-stories/travel/10-iconic-places-to-photograph/other-article.html'
+    );
+  });
+
+  it('should rewrite portrait thumbnail image url for cached version', async () => {
+    const component = {
+      url: 'http://example.com/portrait.html',
+      domainName: 'example.com',
+      type: 'small',
+      title: 'This is an example portrait',
+      image: 'assets/01-iconic-american-destinations.jpg',
+    };
+
+    win.location.resetHref(
+      'https://www-nationalgeographic-com.cdn.ampproject.org/c/s/www.nationalgeographic.com/amp-stories/travel/10-iconic-places-to-photograph/'
+    );
+    const portrait = new PortraitComponent();
+    const el = portrait.buildElement(component, win, {position: 0});
+    expect(el.querySelector('img').src).to.equal(
+      'https://www-nationalgeographic-com.cdn.ampproject.org/i/s/www.nationalgeographic.com/amp-stories/travel/10-iconic-places-to-photograph/assets/01-iconic-american-destinations.jpg'
+    );
+  });
+
+  it('should not rewrite thumbnail image url when using absolute url', async () => {
+    const component = {
+      url: 'http://example.com/portrait.html',
+      domainName: 'example.com',
+      type: 'small',
+      title: 'This is an example portrait',
+      image: 'http://placehold.it/256x128',
+    };
+
+    win.location.resetHref(
+      'https://www-nationalgeographic-com.cdn.ampproject.org/c/s/www.nationalgeographic.com/amp-stories/travel/10-iconic-places-to-photograph/'
+    );
+    const portrait = new PortraitComponent();
+    const el = portrait.buildElement(component, win, {position: 0});
+    expect(el.querySelector('img').src).to.equal('http://placehold.it/256x128');
+  });
+
+  it('should not rewrite thumbnail image for origin documents', async () => {
+    const component = {
+      url: 'http://example.com/portrait.html',
+      domainName: 'example.com',
+      type: 'small',
+      title: 'This is an example portrait',
+      image: '../../assets/01-iconic-american-destinations.jpg',
+    };
+
+    win.location.resetHref(
+      'https://www.nationalgeographic.com/amp-stories/travel/10-iconic-places-to-photograph/'
+    );
+    const portrait = new PortraitComponent();
+    const el = portrait.buildElement(component, win, {position: 0});
+    expect(el.querySelector('img').src).to.equal(
+      'https://www.nationalgeographic.com/amp-stories/assets/01-iconic-american-destinations.jpg'
+    );
+  });
+});

--- a/extensions/amp-story/1.0/test/test-amp-story-bookend.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-bookend.js
@@ -296,440 +296,6 @@ describes.fakeWin('amp-story-bookend', {win: {location}, amp: true}, env => {
     });
   });
 
-  it(
-    'should add amp-to-amp linking to individual cta links when ' +
-      'specified in the JSON config',
-    async () => {
-      const userJson = {
-        'bookendVersion': 'v1.0',
-        'shareProviders': [
-          'email',
-          {'provider': 'facebook', 'app_id': '254325784911610'},
-          'whatsapp',
-        ],
-        'components': [
-          {
-            'type': 'cta-link',
-            'links': [
-              {
-                'text': 'buttonA',
-                'url': 'google.com',
-                'amphtml': true,
-              },
-            ],
-          },
-        ],
-      };
-
-      env.sandbox.stub(requestService, 'loadBookendConfig').resolves(userJson);
-
-      bookend.build();
-      await bookend.loadConfigAndMaybeRenderBookend();
-      const ctaLinks = bookend.bookendEl_.querySelector(
-        '.i-amphtml-story-bookend-cta-link-wrapper'
-      );
-      expect(ctaLinks.children[0]).to.have.attribute('rel');
-      expect(ctaLinks.children[0].getAttribute('rel')).to.equal('amphtml');
-    }
-  );
-
-  it('should forward the correct target when clicking on an element', async () => {
-    const userJson = {
-      'bookendVersion': 'v1.0',
-      'shareProviders': [
-        'email',
-        {'provider': 'facebook', 'app_id': '254325784911610'},
-        'whatsapp',
-      ],
-      'components': [
-        {
-          'type': 'cta-link',
-          'links': [
-            {
-              'text': 'buttonA',
-              'url': 'google.com',
-              'amphtml': true,
-            },
-          ],
-        },
-      ],
-    };
-
-    env.sandbox.stub(requestService, 'loadBookendConfig').resolves(userJson);
-    const clickSpy = env.sandbox.spy();
-    doc.addEventListener('click', clickSpy);
-
-    bookend.build();
-    await bookend.loadConfigAndMaybeRenderBookend();
-    const ctaLinks = bookend.bookendEl_.querySelector(
-      '.i-amphtml-story-bookend-cta-link-wrapper'
-    );
-    ctaLinks.children[0].onclick = function(e) {
-      e.preventDefault(); // Make the test not actually navigate.
-    };
-    ctaLinks.children[0].click();
-
-    expect(clickSpy.getCall(0).args[0]).to.contain({
-      '__AMP_CUSTOM_LINKER_TARGET__': ctaLinks.children[0],
-    });
-  });
-
-  it('should fire analytics event when clicking on a link', async () => {
-    const userJson = {
-      'bookendVersion': 'v1.0',
-      'shareProviders': [
-        'email',
-        {'provider': 'facebook', 'app_id': '254325784911610'},
-        'whatsapp',
-      ],
-      'components': [
-        {
-          'type': 'cta-link',
-          'links': [
-            {
-              'text': 'buttonA',
-              'url': 'google.com',
-              'amphtml': true,
-            },
-          ],
-        },
-      ],
-    };
-
-    env.sandbox.stub(requestService, 'loadBookendConfig').resolves(userJson);
-    const analyticsSpy = env.sandbox.spy(analytics, 'triggerEvent');
-
-    bookend.build();
-    await bookend.loadConfigAndMaybeRenderBookend();
-    const ctaLinks = bookend.bookendEl_.querySelector(
-      '.i-amphtml-story-bookend-cta-link-wrapper'
-    );
-    ctaLinks.children[0].onclick = function(e) {
-      e.preventDefault(); // Make the test not actually navigate.
-    };
-    ctaLinks.children[0].click();
-
-    expect(analyticsSpy).to.have.been.calledWith(
-      StoryAnalyticsEvent.BOOKEND_CLICK
-    );
-    expect(
-      analyticsVariables.get()[AnalyticsVariable.BOOKEND_TARGET_HREF]
-    ).to.equal(
-      'https://www.testorigin.com/amp-stories/example/path/google.com'
-    );
-    expect(
-      analyticsVariables.get()[AnalyticsVariable.BOOKEND_COMPONENT_TYPE]
-    ).to.equal('cta-link');
-    expect(
-      analyticsVariables.get()[AnalyticsVariable.BOOKEND_COMPONENT_POSITION]
-    ).to.equal(1);
-  });
-
-  it('should not fire analytics event when clicking non-clickable components', async () => {
-    const userJson = {
-      'bookendVersion': 'v1.0',
-      'shareProviders': [
-        'email',
-        {'provider': 'facebook', 'app_id': '254325784911610'},
-        'whatsapp',
-      ],
-      'components': [
-        {
-          'type': 'textbox',
-          'text': [
-            'Food by Enrique McPizza',
-            'Choreography by Gabriel Filly',
-            'Script by Alan Ecma S.',
-            'Direction by Jon Tarantino',
-          ],
-        },
-      ],
-    };
-
-    env.sandbox.stub(requestService, 'loadBookendConfig').resolves(userJson);
-    const analyticsSpy = env.sandbox.spy(analytics, 'triggerEvent');
-
-    bookend.build();
-    await bookend.loadConfigAndMaybeRenderBookend();
-    const textEl = bookend.bookendEl_.querySelector(
-      '.i-amphtml-story-bookend-text'
-    );
-
-    textEl.click();
-
-    expect(analyticsSpy).to.not.have.been.called;
-  });
-
-  it(
-    'should not add amp-to-amp linking to cta links when not ' +
-      'specified in the JSON config',
-    async () => {
-      const userJson = {
-        'bookendVersion': 'v1.0',
-        'shareProviders': [
-          'email',
-          {'provider': 'facebook', 'app_id': '254325784911610'},
-          'whatsapp',
-        ],
-        'components': [
-          {
-            'type': 'cta-link',
-            'links': [
-              {
-                'text': 'buttonB',
-                'url': 'google.com',
-                'amphtml': '',
-              },
-              {
-                'text': 'longtext longtext longtext longtext longtext',
-                'url': 'google.com',
-                'amphtml': false,
-              },
-            ],
-          },
-        ],
-      };
-
-      env.sandbox.stub(requestService, 'loadBookendConfig').resolves(userJson);
-
-      bookend.build();
-      await bookend.loadConfigAndMaybeRenderBookend();
-      const ctaLinks = bookend.bookendEl_.querySelector(
-        '.i-amphtml-story-bookend-cta-link-wrapper'
-      );
-      expect(ctaLinks.children[0]).to.not.have.attribute('rel');
-      expect(ctaLinks.children[1]).to.not.have.attribute('rel');
-    }
-  );
-
-  it(
-    'should add amp-to-amp linking to small articles when specified ' +
-      'in the JSON config',
-    async () => {
-      const userJson = {
-        'bookendVersion': 'v1.0',
-        'shareProviders': [
-          'email',
-          {'provider': 'facebook', 'app_id': '254325784911610'},
-          'whatsapp',
-        ],
-        'components': [
-          {
-            'type': 'small',
-            'title': 'This is an example article!',
-            'url': 'http://example.com/article.html',
-            'image': 'http://placehold.it/256x128',
-            'amphtml': true,
-          },
-        ],
-      };
-
-      env.sandbox.stub(requestService, 'loadBookendConfig').resolves(userJson);
-
-      bookend.build();
-      await bookend.loadConfigAndMaybeRenderBookend();
-      const articles = bookend.bookendEl_.querySelectorAll(
-        '.i-amphtml-story-bookend-article'
-      );
-      expect(articles[0]).to.have.attribute('rel');
-      expect(articles[0].getAttribute('rel')).to.equal('amphtml');
-    }
-  );
-
-  it(
-    'should not add amp-to-amp linking to small articles when not ' +
-      'specified in the JSON config',
-    async () => {
-      const userJson = {
-        'bookendVersion': 'v1.0',
-        'shareProviders': [
-          'email',
-          {'provider': 'facebook', 'app_id': '254325784911610'},
-          'whatsapp',
-        ],
-        'components': [
-          {
-            'type': 'small',
-            'title': 'This is an example article!',
-            'url': 'http://example.com/article.html',
-            'image': 'http://placehold.it/256x128',
-          },
-          {
-            'type': 'small',
-            'title': 'This is an example article!',
-            'url': 'http://example.com/article.html',
-            'image': 'http://placehold.it/256x128',
-            'amphtml': 'true',
-          },
-        ],
-      };
-
-      env.sandbox.stub(requestService, 'loadBookendConfig').resolves(userJson);
-
-      bookend.build();
-      await bookend.loadConfigAndMaybeRenderBookend();
-      const articles = bookend.bookendEl_.querySelectorAll(
-        '.i-amphtml-story-bookend-article'
-      );
-      expect(articles[0]).to.not.have.attribute('rel');
-      expect(articles[1]).to.not.have.attribute('rel');
-    }
-  );
-
-  it(
-    'should add amp-to-amp linking to portrait articles when specified ' +
-      'in the JSON config',
-    async () => {
-      const userJson = {
-        'bookendVersion': 'v1.0',
-        'shareProviders': [
-          'email',
-          {'provider': 'facebook', 'app_id': '254325784911610'},
-          'whatsapp',
-        ],
-        'components': [
-          {
-            'type': 'portrait',
-            'title': 'example title',
-            'category': 'example category',
-            'url': 'http://example.com/article.html',
-            'image': 'http://placehold.it/256x128',
-            'amphtml': true,
-          },
-        ],
-      };
-
-      env.sandbox.stub(requestService, 'loadBookendConfig').resolves(userJson);
-
-      bookend.build();
-      await bookend.loadConfigAndMaybeRenderBookend();
-      const articles = bookend.bookendEl_.querySelectorAll(
-        '.i-amphtml-story-bookend-portrait'
-      );
-      expect(articles[0]).to.have.attribute('rel');
-      expect(articles[0].getAttribute('rel')).to.equal('amphtml');
-    }
-  );
-
-  it(
-    'should not add amp-to-amp linking to portrait articles when not ' +
-      'specified in the JSON config',
-    async () => {
-      const userJson = {
-        'bookendVersion': 'v1.0',
-        'shareProviders': [
-          'email',
-          {'provider': 'facebook', 'app_id': '254325784911610'},
-          'whatsapp',
-        ],
-        'components': [
-          {
-            'type': 'portrait',
-            'title': 'example title',
-            'category': 'example category',
-            'url': 'http://example.com/article.html',
-            'image': 'http://placehold.it/256x128',
-          },
-          {
-            'type': 'portrait',
-            'title': 'example title',
-            'category': 'example category',
-            'url': 'http://example.com/article.html',
-            'image': 'http://placehold.it/256x128',
-            'amphtml': 'true',
-          },
-        ],
-      };
-
-      env.sandbox.stub(requestService, 'loadBookendConfig').resolves(userJson);
-
-      bookend.build();
-      await bookend.loadConfigAndMaybeRenderBookend();
-      const articles = bookend.bookendEl_.querySelectorAll(
-        '.i-amphtml-story-bookend-portrait'
-      );
-      expect(articles[0]).to.not.have.attribute('rel');
-      expect(articles[1]).to.not.have.attribute('rel');
-    }
-  );
-
-  it(
-    'should add amp-to-amp linking to landscape articles when ' +
-      'specified in the JSON config',
-    async () => {
-      const userJson = {
-        'bookendVersion': 'v1.0',
-        'shareProviders': [
-          'email',
-          {'provider': 'facebook', 'app_id': '254325784911610'},
-          'whatsapp',
-        ],
-        'components': [
-          {
-            'type': 'landscape',
-            'category': 'example category',
-            'title': 'example title',
-            'url': 'http://example.com/article.html',
-            'image': 'http://placehold.it/256x128',
-            'amphtml': true,
-          },
-        ],
-      };
-
-      env.sandbox.stub(requestService, 'loadBookendConfig').resolves(userJson);
-
-      bookend.build();
-      await bookend.loadConfigAndMaybeRenderBookend();
-      const articles = bookend.bookendEl_.querySelectorAll(
-        '.i-amphtml-story-bookend-landscape'
-      );
-      expect(articles[0]).to.have.attribute('rel');
-      expect(articles[0].getAttribute('rel')).to.equal('amphtml');
-    }
-  );
-
-  it(
-    'should not add amp-to-amp linking to landscape articles when not' +
-      ' specified in the JSON config',
-    async () => {
-      const userJson = {
-        'bookendVersion': 'v1.0',
-        'shareProviders': [
-          'email',
-          {'provider': 'facebook', 'app_id': '254325784911610'},
-          'whatsapp',
-        ],
-        'components': [
-          {
-            'type': 'landscape',
-            'category': 'example category',
-            'title': 'example title',
-            'url': 'http://example.com/article.html',
-            'image': 'http://placehold.it/256x128',
-          },
-          {
-            'type': 'landscape',
-            'category': 'example category',
-            'title': 'example title',
-            'url': 'http://example.com/article.html',
-            'image': 'http://placehold.it/256x128',
-            'amphtml': 'true',
-          },
-        ],
-      };
-
-      env.sandbox.stub(requestService, 'loadBookendConfig').resolves(userJson);
-
-      bookend.build();
-      await bookend.loadConfigAndMaybeRenderBookend();
-      const articles = bookend.bookendEl_.querySelectorAll(
-        '.i-amphtml-story-bookend-landscape'
-      );
-      expect(articles[0]).to.not.have.attribute('rel');
-      expect(articles[1]).to.not.have.attribute('rel');
-    }
-  );
-
   it('should build the users share providers', async () => {
     const userJson = {
       'bookendVersion': 'v1.0',
@@ -834,133 +400,6 @@ describes.fakeWin('amp-story-bookend', {win: {location}, amp: true}, env => {
         'share provider type. Native sharing is ' +
         'enabled by default and cannot be turned off.'
     );
-  });
-
-  it('should reject invalid user json for article', () => {
-    const articleComponent = new ArticleComponent();
-    const userJson = {
-      'bookendVersion': 'v1.0',
-      'shareProviders': [
-        'email',
-        {'provider': 'facebook', 'app_id': '254325784911610'},
-        'whatsapp',
-      ],
-      'components': [
-        {
-          'type': 'heading',
-          'title': 'test',
-        },
-        {
-          'type': 'small',
-          'url': 'http://example.com/article.html',
-          'image': 'http://placehold.it/256x128',
-        },
-      ],
-    };
-
-    allowConsoleError(() => {
-      expect(() => articleComponent.assertValidity(userJson)).to.throw(
-        'Small article component must contain `title`, `url` fields, ' +
-          'skipping invalid.​​​'
-      );
-    });
-  });
-
-  it('should reject invalid user json for portrait article', () => {
-    const portraitComponant = new PortraitComponent();
-    const userJson = {
-      'bookendVersion': 'v1.0',
-      'shareProviders': [
-        'email',
-        {'provider': 'facebook', 'app_id': '254325784911610'},
-        'whatsapp',
-      ],
-      'components': [
-        {
-          'type': 'portrait',
-          'category': 'sample',
-          'url': 'http://example.com/article.html',
-          'image': 'http://placehold.it/256x128',
-        },
-      ],
-    };
-
-    allowConsoleError(() => {
-      expect(() => portraitComponant.assertValidity(userJson)).to.throw(
-        'Portrait component must contain `title`, `image`, ' +
-          '`url` fields, skipping invalid.'
-      );
-    });
-  });
-
-  it('should reject invalid user json for the cta links component', () => {
-    const ctaLinkComponent = new CtaLinkComponent();
-    const userJson = {
-      'bookendVersion': 'v1.0',
-      'shareProviders': [
-        'email',
-        {'provider': 'facebook', 'app_id': '254325784911610'},
-        'whatsapp',
-      ],
-      'components': [
-        {
-          'type': 'heading',
-          'title': 'test',
-        },
-        {
-          'type': 'small',
-          'url': 'http://example.com/article.html',
-          'image': 'http://placehold.it/256x128',
-        },
-        {
-          'type': 'cta-link',
-          'links': [],
-        },
-      ],
-    };
-
-    allowConsoleError(() => {
-      expect(() => ctaLinkComponent.assertValidity(userJson)).to.throw(
-        'CTA link component must be an array ' +
-          'and contain at least one link inside it.'
-      );
-    });
-  });
-
-  it('should reject invalid user json for a landscape component', () => {
-    const landscapeComponent = new LandscapeComponent();
-    const userJson = {
-      'bookendVersion': 'v1.0',
-      'shareProviders': [
-        'email',
-        {'provider': 'facebook', 'app_id': '254325784911610'},
-        'whatsapp',
-      ],
-      'components': [
-        {
-          'type': 'heading',
-          'title': 'test',
-        },
-        {
-          'type': 'small',
-          'url': 'http://example.com/article.html',
-          'image': 'http://placehold.it/256x128',
-        },
-        {
-          'type': 'landscape',
-          'url': 'http://example.com/article.html',
-          'category': 'astronomy',
-          'image': 'http://placehold.it/256x128',
-        },
-      ],
-    };
-
-    allowConsoleError(() => {
-      expect(() => landscapeComponent.assertValidity(userJson)).to.throw(
-        'Landscape component must contain `title`, `image`, ' +
-          '`url` fields, skipping invalid.'
-      );
-    });
   });
 
   it('should reject invalid user json for a textbox component', () => {
@@ -1078,195 +517,841 @@ describes.fakeWin('amp-story-bookend', {win: {location}, amp: true}, env => {
     expect(config.components.length).to.equal(0);
   });
 
-  it('should resolve article relative url for origin url when served from the cache', async () => {
-    const component = {
-      url: './other-article.html',
-      domainName: 'example.com',
-      type: 'small',
-      title: 'This is an example article',
-      image: '../../assets/01-iconic-american-destinations.jpg',
-    };
+  describe('analytics', () => {
+    it('should fire analytics event when clicking on a link', async () => {
+      const userJson = {
+        'bookendVersion': 'v1.0',
+        'shareProviders': [
+          'email',
+          {'provider': 'facebook', 'app_id': '254325784911610'},
+          'whatsapp',
+        ],
+        'components': [
+          {
+            'type': 'cta-link',
+            'links': [
+              {
+                'text': 'buttonA',
+                'url': 'google.com',
+                'amphtml': true,
+              },
+            ],
+          },
+        ],
+      };
 
-    win.location.resetHref(
-      'https://www-nationalgeographic-com.cdn.ampproject.org/c/s/www.nationalgeographic.com/amp-stories/travel/10-iconic-places-to-photograph/'
+      env.sandbox.stub(requestService, 'loadBookendConfig').resolves(userJson);
+      const analyticsSpy = env.sandbox.spy(analytics, 'triggerEvent');
+
+      bookend.build();
+      await bookend.loadConfigAndMaybeRenderBookend();
+      const ctaLinks = bookend.bookendEl_.querySelector(
+        '.i-amphtml-story-bookend-cta-link-wrapper'
+      );
+      ctaLinks.children[0].onclick = function(e) {
+        e.preventDefault(); // Make the test not actually navigate.
+      };
+      ctaLinks.children[0].click();
+
+      expect(analyticsSpy).to.have.been.calledWith(
+        StoryAnalyticsEvent.BOOKEND_CLICK
+      );
+      expect(
+        analyticsVariables.get()[AnalyticsVariable.BOOKEND_TARGET_HREF]
+      ).to.equal(
+        'https://www.testorigin.com/amp-stories/example/path/google.com'
+      );
+      expect(
+        analyticsVariables.get()[AnalyticsVariable.BOOKEND_COMPONENT_TYPE]
+      ).to.equal('cta-link');
+      expect(
+        analyticsVariables.get()[AnalyticsVariable.BOOKEND_COMPONENT_POSITION]
+      ).to.equal(1);
+    });
+
+    it('should not fire analytics event when clicking non-clickable components', async () => {
+      const userJson = {
+        'bookendVersion': 'v1.0',
+        'shareProviders': [
+          'email',
+          {'provider': 'facebook', 'app_id': '254325784911610'},
+          'whatsapp',
+        ],
+        'components': [
+          {
+            'type': 'textbox',
+            'text': [
+              'Food by Enrique McPizza',
+              'Choreography by Gabriel Filly',
+              'Script by Alan Ecma S.',
+              'Direction by Jon Tarantino',
+            ],
+          },
+        ],
+      };
+
+      env.sandbox.stub(requestService, 'loadBookendConfig').resolves(userJson);
+      const analyticsSpy = env.sandbox.spy(analytics, 'triggerEvent');
+
+      bookend.build();
+      await bookend.loadConfigAndMaybeRenderBookend();
+      const textEl = bookend.bookendEl_.querySelector(
+        '.i-amphtml-story-bookend-text'
+      );
+
+      textEl.click();
+
+      expect(analyticsSpy).to.not.have.been.called;
+    });
+
+    it('should forward the correct target when clicking on an element', async () => {
+      const userJson = {
+        'bookendVersion': 'v1.0',
+        'shareProviders': [
+          'email',
+          {'provider': 'facebook', 'app_id': '254325784911610'},
+          'whatsapp',
+        ],
+        'components': [
+          {
+            'type': 'cta-link',
+            'links': [
+              {
+                'text': 'buttonA',
+                'url': 'google.com',
+                'amphtml': true,
+              },
+            ],
+          },
+        ],
+      };
+
+      env.sandbox.stub(requestService, 'loadBookendConfig').resolves(userJson);
+      const clickSpy = env.sandbox.spy();
+      doc.addEventListener('click', clickSpy);
+
+      bookend.build();
+      await bookend.loadConfigAndMaybeRenderBookend();
+      const ctaLinks = bookend.bookendEl_.querySelector(
+        '.i-amphtml-story-bookend-cta-link-wrapper'
+      );
+      ctaLinks.children[0].onclick = function(e) {
+        e.preventDefault(); // Make the test not actually navigate.
+      };
+      ctaLinks.children[0].click();
+
+      expect(clickSpy.getCall(0).args[0]).to.contain({
+        '__AMP_CUSTOM_LINKER_TARGET__': ctaLinks.children[0],
+      });
+    });
+  });
+
+  describe('cta links component', () => {
+    it('should reject invalid user json', () => {
+      const ctaLinkComponent = new CtaLinkComponent();
+      const userJson = {
+        'bookendVersion': 'v1.0',
+        'shareProviders': [
+          'email',
+          {'provider': 'facebook', 'app_id': '254325784911610'},
+          'whatsapp',
+        ],
+        'components': [
+          {
+            'type': 'heading',
+            'title': 'test',
+          },
+          {
+            'type': 'small',
+            'url': 'http://example.com/article.html',
+            'image': 'http://placehold.it/256x128',
+          },
+          {
+            'type': 'cta-link',
+            'links': [],
+          },
+        ],
+      };
+
+      allowConsoleError(() => {
+        expect(() => ctaLinkComponent.assertValidity(userJson)).to.throw(
+          'CTA link component must be an array ' +
+            'and contain at least one link inside it.'
+        );
+      });
+    });
+
+    it(
+      'should add amp-to-amp linking to individual cta links when ' +
+        'specified in the JSON config',
+      async () => {
+        const userJson = {
+          'bookendVersion': 'v1.0',
+          'shareProviders': [
+            'email',
+            {'provider': 'facebook', 'app_id': '254325784911610'},
+            'whatsapp',
+          ],
+          'components': [
+            {
+              'type': 'cta-link',
+              'links': [
+                {
+                  'text': 'buttonA',
+                  'url': 'google.com',
+                  'amphtml': true,
+                },
+              ],
+            },
+          ],
+        };
+
+        env.sandbox
+          .stub(requestService, 'loadBookendConfig')
+          .resolves(userJson);
+
+        bookend.build();
+        await bookend.loadConfigAndMaybeRenderBookend();
+        const ctaLinks = bookend.bookendEl_.querySelector(
+          '.i-amphtml-story-bookend-cta-link-wrapper'
+        );
+        expect(ctaLinks.children[0]).to.have.attribute('rel');
+        expect(ctaLinks.children[0].getAttribute('rel')).to.equal('amphtml');
+      }
     );
 
-    const article = new ArticleComponent();
-    const el = article.buildElement(component, win, {position: 0});
-    expect(el.href).to.equal(
-      'https://www.nationalgeographic.com/amp-stories/travel/10-iconic-places-to-photograph/other-article.html'
+    it(
+      'should not add amp-to-amp linking to cta links when not ' +
+        'specified in the JSON config',
+      async () => {
+        const userJson = {
+          'bookendVersion': 'v1.0',
+          'shareProviders': [
+            'email',
+            {'provider': 'facebook', 'app_id': '254325784911610'},
+            'whatsapp',
+          ],
+          'components': [
+            {
+              'type': 'cta-link',
+              'links': [
+                {
+                  'text': 'buttonB',
+                  'url': 'google.com',
+                  'amphtml': '',
+                },
+                {
+                  'text': 'longtext longtext longtext longtext longtext',
+                  'url': 'google.com',
+                  'amphtml': false,
+                },
+              ],
+            },
+          ],
+        };
+
+        env.sandbox
+          .stub(requestService, 'loadBookendConfig')
+          .resolves(userJson);
+
+        bookend.build();
+        await bookend.loadConfigAndMaybeRenderBookend();
+        const ctaLinks = bookend.bookendEl_.querySelector(
+          '.i-amphtml-story-bookend-cta-link-wrapper'
+        );
+        expect(ctaLinks.children[0]).to.not.have.attribute('rel');
+        expect(ctaLinks.children[1]).to.not.have.attribute('rel');
+      }
     );
   });
 
-  it('should respect specified absolute URL', async () => {
-    const component = {
-      url: 'https://www.anothersite.com/article.html',
-      domainName: 'example.com',
-      type: 'small',
-      title: 'This is an example article',
-      image: '../../assets/01-iconic-american-destinations.jpg',
-    };
+  describe('small article component', () => {
+    it('should reject invalid user json', () => {
+      const articleComponent = new ArticleComponent();
+      const userJson = {
+        'bookendVersion': 'v1.0',
+        'shareProviders': [
+          'email',
+          {'provider': 'facebook', 'app_id': '254325784911610'},
+          'whatsapp',
+        ],
+        'components': [
+          {
+            'type': 'heading',
+            'title': 'test',
+          },
+          {
+            'type': 'small',
+            'url': 'http://example.com/article.html',
+            'image': 'http://placehold.it/256x128',
+          },
+        ],
+      };
 
-    win.location.resetHref(
-      'https://www-nationalgeographic-com.cdn.ampproject.org/c/s/www.nationalgeographic.com/amp-stories/travel/10-iconic-places-to-photograph/'
-    );
+      allowConsoleError(() => {
+        expect(() => articleComponent.assertValidity(userJson)).to.throw(
+          'Small article component must contain `title`, `url` fields, ' +
+            'skipping invalid.​​​'
+        );
+      });
+    });
 
-    const article = new ArticleComponent();
-    const el = article.buildElement(component, win, {position: 0});
-    expect(el.href).to.equal('https://www.anothersite.com/article.html');
+    it('should add amp-to-amp linking when specified in the JSON config', async () => {
+      const userJson = {
+        'bookendVersion': 'v1.0',
+        'shareProviders': [
+          'email',
+          {'provider': 'facebook', 'app_id': '254325784911610'},
+          'whatsapp',
+        ],
+        'components': [
+          {
+            'type': 'small',
+            'title': 'This is an example article!',
+            'url': 'http://example.com/article.html',
+            'image': 'http://placehold.it/256x128',
+            'amphtml': true,
+          },
+        ],
+      };
+
+      env.sandbox.stub(requestService, 'loadBookendConfig').resolves(userJson);
+
+      bookend.build();
+      await bookend.loadConfigAndMaybeRenderBookend();
+      const articles = bookend.bookendEl_.querySelectorAll(
+        '.i-amphtml-story-bookend-article'
+      );
+      expect(articles[0]).to.have.attribute('rel');
+      expect(articles[0].getAttribute('rel')).to.equal('amphtml');
+    });
+
+    it('should not add amp-to-amp linking when not specified in the JSON config', async () => {
+      const userJson = {
+        'bookendVersion': 'v1.0',
+        'shareProviders': [
+          'email',
+          {'provider': 'facebook', 'app_id': '254325784911610'},
+          'whatsapp',
+        ],
+        'components': [
+          {
+            'type': 'small',
+            'title': 'This is an example article!',
+            'url': 'http://example.com/article.html',
+            'image': 'http://placehold.it/256x128',
+          },
+          {
+            'type': 'small',
+            'title': 'This is an example article!',
+            'url': 'http://example.com/article.html',
+            'image': 'http://placehold.it/256x128',
+            'amphtml': 'true',
+          },
+        ],
+      };
+
+      env.sandbox.stub(requestService, 'loadBookendConfig').resolves(userJson);
+
+      bookend.build();
+      await bookend.loadConfigAndMaybeRenderBookend();
+      const articles = bookend.bookendEl_.querySelectorAll(
+        '.i-amphtml-story-bookend-article'
+      );
+      expect(articles[0]).to.not.have.attribute('rel');
+      expect(articles[1]).to.not.have.attribute('rel');
+    });
+
+    it('should resolve relative url for origin url when served from the cache', () => {
+      const component = {
+        url: './other-article.html',
+        domainName: 'example.com',
+        type: 'small',
+        title: 'This is an example article',
+        image: '../../assets/01-iconic-american-destinations.jpg',
+      };
+
+      win.location.resetHref(
+        'https://www-nationalgeographic-com.cdn.ampproject.org/c/s/www.nationalgeographic.com/amp-stories/travel/10-iconic-places-to-photograph/'
+      );
+
+      const article = new ArticleComponent();
+      const el = article.buildElement(component, win, {position: 0});
+      expect(el.href).to.equal(
+        'https://www.nationalgeographic.com/amp-stories/travel/10-iconic-places-to-photograph/other-article.html'
+      );
+    });
+
+    it('should respect specified absolute URL', () => {
+      const component = {
+        url: 'https://www.anothersite.com/article.html',
+        domainName: 'example.com',
+        type: 'small',
+        title: 'This is an example article',
+        image: '../../assets/01-iconic-american-destinations.jpg',
+      };
+
+      win.location.resetHref(
+        'https://www-nationalgeographic-com.cdn.ampproject.org/c/s/www.nationalgeographic.com/amp-stories/travel/10-iconic-places-to-photograph/'
+      );
+
+      const article = new ArticleComponent();
+      const el = article.buildElement(component, win, {position: 0});
+      expect(el.href).to.equal('https://www.anothersite.com/article.html');
+    });
+
+    it('should rewrite thumbnail image url for cached version', () => {
+      const component = {
+        url: 'http://example.com/article.html',
+        domainName: 'example.com',
+        type: 'small',
+        title: 'This is an example article',
+        image: '../../assets/01-iconic-american-destinations.jpg',
+      };
+
+      win.location.resetHref(
+        'https://www-nationalgeographic-com.cdn.ampproject.org/c/s/www.nationalgeographic.com/amp-stories/travel/10-iconic-places-to-photograph/'
+      );
+
+      const article = new ArticleComponent();
+      const el = article.buildElement(component, win, {position: 0});
+      expect(el.querySelector('img').src).to.equal(
+        'https://www-nationalgeographic-com.cdn.ampproject.org/i/s/www.nationalgeographic.com/amp-stories/assets/01-iconic-american-destinations.jpg'
+      );
+    });
+
+    it('should not rewrite thumbnail image url when using absolute url', () => {
+      const component = {
+        url: 'http://example.com/small.html',
+        domainName: 'example.com',
+        type: 'small',
+        title: 'This is an example small',
+        image: 'http://placehold.it/256x128',
+      };
+
+      win.location.resetHref(
+        'https://www-nationalgeographic-com.cdn.ampproject.org/c/s/www.nationalgeographic.com/amp-stories/travel/10-iconic-places-to-photograph/'
+      );
+      const small = new ArticleComponent();
+      const el = small.buildElement(component, win, {position: 0});
+      expect(el.querySelector('img').src).to.equal(
+        'http://placehold.it/256x128'
+      );
+    });
+
+    it('should not rewrite thumbnail image for origin documents', () => {
+      const component = {
+        url: 'http://example.com/small.html',
+        domainName: 'example.com',
+        type: 'small',
+        title: 'This is an example small',
+        image: '../../assets/01-iconic-american-destinations.jpg',
+      };
+
+      win.location.resetHref(
+        'https://www.nationalgeographic.com/amp-stories/travel/10-iconic-places-to-photograph/'
+      );
+      const small = new ArticleComponent();
+      const el = small.buildElement(component, win, {position: 0});
+      expect(el.querySelector('img').src).to.equal(
+        'https://www.nationalgeographic.com/amp-stories/assets/01-iconic-american-destinations.jpg'
+      );
+    });
   });
 
-  it('should rewrite article thumbnail image url for cached version', async () => {
-    const component = {
-      url: 'http://example.com/article.html',
-      domainName: 'example.com',
-      type: 'small',
-      title: 'This is an example article',
-      image: '../../assets/01-iconic-american-destinations.jpg',
-    };
+  describe('landscape component', () => {
+    it('should reject invalid user json', () => {
+      const landscapeComponent = new LandscapeComponent();
+      const userJson = {
+        'bookendVersion': 'v1.0',
+        'shareProviders': [
+          'email',
+          {'provider': 'facebook', 'app_id': '254325784911610'},
+          'whatsapp',
+        ],
+        'components': [
+          {
+            'type': 'heading',
+            'title': 'test',
+          },
+          {
+            'type': 'small',
+            'url': 'http://example.com/article.html',
+            'image': 'http://placehold.it/256x128',
+          },
+          {
+            'type': 'landscape',
+            'url': 'http://example.com/article.html',
+            'category': 'astronomy',
+            'image': 'http://placehold.it/256x128',
+          },
+        ],
+      };
 
-    win.location.resetHref(
-      'https://www-nationalgeographic-com.cdn.ampproject.org/c/s/www.nationalgeographic.com/amp-stories/travel/10-iconic-places-to-photograph/'
-    );
+      allowConsoleError(() => {
+        expect(() => landscapeComponent.assertValidity(userJson)).to.throw(
+          'Landscape component must contain `title`, `image`, ' +
+            '`url` fields, skipping invalid.'
+        );
+      });
+    });
 
-    const article = new ArticleComponent();
-    const el = article.buildElement(component, win, {position: 0});
-    expect(el.querySelector('img').src).to.equal(
-      'https://www-nationalgeographic-com.cdn.ampproject.org/i/s/www.nationalgeographic.com/amp-stories/assets/01-iconic-american-destinations.jpg'
-    );
+    it('should add amp-to-amp linking when specified in the JSON config', async () => {
+      const userJson = {
+        'bookendVersion': 'v1.0',
+        'shareProviders': [
+          'email',
+          {'provider': 'facebook', 'app_id': '254325784911610'},
+          'whatsapp',
+        ],
+        'components': [
+          {
+            'type': 'landscape',
+            'category': 'example category',
+            'title': 'example title',
+            'url': 'http://example.com/article.html',
+            'image': 'http://placehold.it/256x128',
+            'amphtml': true,
+          },
+        ],
+      };
+
+      env.sandbox.stub(requestService, 'loadBookendConfig').resolves(userJson);
+
+      bookend.build();
+      await bookend.loadConfigAndMaybeRenderBookend();
+      const articles = bookend.bookendEl_.querySelectorAll(
+        '.i-amphtml-story-bookend-landscape'
+      );
+      expect(articles[0]).to.have.attribute('rel');
+      expect(articles[0].getAttribute('rel')).to.equal('amphtml');
+    });
+
+    it('should not add amp-to-amp linking when not specified in the JSON config', async () => {
+      const userJson = {
+        'bookendVersion': 'v1.0',
+        'shareProviders': [
+          'email',
+          {'provider': 'facebook', 'app_id': '254325784911610'},
+          'whatsapp',
+        ],
+        'components': [
+          {
+            'type': 'landscape',
+            'category': 'example category',
+            'title': 'example title',
+            'url': 'http://example.com/article.html',
+            'image': 'http://placehold.it/256x128',
+          },
+          {
+            'type': 'landscape',
+            'category': 'example category',
+            'title': 'example title',
+            'url': 'http://example.com/article.html',
+            'image': 'http://placehold.it/256x128',
+            'amphtml': 'true',
+          },
+        ],
+      };
+
+      env.sandbox.stub(requestService, 'loadBookendConfig').resolves(userJson);
+
+      bookend.build();
+      await bookend.loadConfigAndMaybeRenderBookend();
+      const articles = bookend.bookendEl_.querySelectorAll(
+        '.i-amphtml-story-bookend-landscape'
+      );
+      expect(articles[0]).to.not.have.attribute('rel');
+      expect(articles[1]).to.not.have.attribute('rel');
+    });
+
+    it('should resolve relative url for origin url when served from the cache', () => {
+      const component = {
+        url: './other-article.html',
+        domainName: 'example.com',
+        type: 'landscape',
+        title: 'This is an example landscape article',
+        image: '../../assets/01-iconic-american-destinations.jpg',
+      };
+
+      win.location.resetHref(
+        'https://www.nationalgeographic.com/amp-stories/travel/10-iconic-places-to-photograph/'
+      );
+
+      const landscape = new LandscapeComponent();
+
+      const el = landscape.buildElement(component, win, {position: 0});
+      expect(el.href).to.equal(
+        'https://www.nationalgeographic.com/amp-stories/travel/10-iconic-places-to-photograph/other-article.html'
+      );
+    });
+
+    it('should respect specified absolute URL', () => {
+      const component = {
+        url: 'https://www.anothersite.com/article.html',
+        domainName: 'example.com',
+        type: 'landscape',
+        title: 'This is an example landscape article',
+        image: '../../assets/01-iconic-american-destinations.jpg',
+      };
+
+      win.location.resetHref(
+        'https://www-nationalgeographic-com.cdn.ampproject.org/c/s/www.nationalgeographic.com/amp-stories/travel/10-iconic-places-to-photograph/'
+      );
+      const landscape = new LandscapeComponent();
+      const el = landscape.buildElement(component, win, {position: 0});
+      expect(el.href).to.equal('https://www.anothersite.com/article.html');
+    });
+
+    it('should rewrite landscape thumbnail image url for cached version', () => {
+      const component = {
+        url: 'http://example.com/landscape.html',
+        domainName: 'example.com',
+        type: 'landscape',
+        title: 'This is an example landscape',
+        image: './assets/01-iconic-american-destinations.jpg',
+      };
+
+      win.location.resetHref(
+        'https://www-nationalgeographic-com.cdn.ampproject.org/c/s/www.nationalgeographic.com/amp-stories/travel/10-iconic-places-to-photograph/'
+      );
+
+      const landscape = new LandscapeComponent();
+      const el = landscape.buildElement(component, win, {position: 0});
+      expect(el.querySelector('img').src).to.equal(
+        'https://www-nationalgeographic-com.cdn.ampproject.org/i/s/www.nationalgeographic.com/amp-stories/travel/10-iconic-places-to-photograph/assets/01-iconic-american-destinations.jpg'
+      );
+    });
+
+    it('should not rewrite thumbnail image url when using absolute url', () => {
+      const component = {
+        url: 'http://example.com/landscape.html',
+        domainName: 'example.com',
+        type: 'landscape',
+        title: 'This is an example landscape',
+        image: 'http://placehold.it/256x128',
+      };
+
+      win.location.resetHref(
+        'https://www-nationalgeographic-com.cdn.ampproject.org/c/s/www.nationalgeographic.com/amp-stories/travel/10-iconic-places-to-photograph/'
+      );
+      const landscape = new LandscapeComponent();
+      const el = landscape.buildElement(component, win, {position: 0});
+      expect(el.querySelector('img').src).to.equal(
+        'http://placehold.it/256x128'
+      );
+    });
+
+    it('should not rewrite thumbnail image for origin documents', () => {
+      const component = {
+        url: 'http://example.com/landscape.html',
+        domainName: 'example.com',
+        type: 'small',
+        title: 'This is an example landscape',
+        image: '../../assets/01-iconic-american-destinations.jpg',
+      };
+
+      win.location.resetHref(
+        'https://www.nationalgeographic.com/amp-stories/travel/10-iconic-places-to-photograph/'
+      );
+      const landscape = new LandscapeComponent();
+      const el = landscape.buildElement(component, win, {position: 0});
+      expect(el.querySelector('img').src).to.equal(
+        'https://www.nationalgeographic.com/amp-stories/assets/01-iconic-american-destinations.jpg'
+      );
+    });
   });
 
-  it('should rewrite landscape thumbnail image url for cached version', async () => {
-    const component = {
-      url: 'http://example.com/landscape.html',
-      domainName: 'example.com',
-      type: 'landscape',
-      title: 'This is an example landscape',
-      image: './assets/01-iconic-american-destinations.jpg',
-    };
+  describe('portrait component', () => {
+    it('should reject invalid user json', () => {
+      const portraitComponant = new PortraitComponent();
+      const userJson = {
+        'bookendVersion': 'v1.0',
+        'shareProviders': [
+          'email',
+          {'provider': 'facebook', 'app_id': '254325784911610'},
+          'whatsapp',
+        ],
+        'components': [
+          {
+            'type': 'portrait',
+            'category': 'sample',
+            'url': 'http://example.com/article.html',
+            'image': 'http://placehold.it/256x128',
+          },
+        ],
+      };
 
-    win.location.resetHref(
-      'https://www-nationalgeographic-com.cdn.ampproject.org/c/s/www.nationalgeographic.com/amp-stories/travel/10-iconic-places-to-photograph/'
-    );
+      allowConsoleError(() => {
+        expect(() => portraitComponant.assertValidity(userJson)).to.throw(
+          'Portrait component must contain `title`, `image`, ' +
+            '`url` fields, skipping invalid.'
+        );
+      });
+    });
 
-    const landscape = new LandscapeComponent();
-    const el = landscape.buildElement(component, win, {position: 0});
-    expect(el.querySelector('img').src).to.equal(
-      'https://www-nationalgeographic-com.cdn.ampproject.org/i/s/www.nationalgeographic.com/amp-stories/travel/10-iconic-places-to-photograph/assets/01-iconic-american-destinations.jpg'
-    );
-  });
+    it('should add amp-to-amp linking when specified in the JSON config', async () => {
+      const userJson = {
+        'bookendVersion': 'v1.0',
+        'shareProviders': [
+          'email',
+          {'provider': 'facebook', 'app_id': '254325784911610'},
+          'whatsapp',
+        ],
+        'components': [
+          {
+            'type': 'portrait',
+            'title': 'example title',
+            'category': 'example category',
+            'url': 'http://example.com/article.html',
+            'image': 'http://placehold.it/256x128',
+            'amphtml': true,
+          },
+        ],
+      };
 
-  it('should resolve absolute url correctly', async () => {
-    const component = {
-      url: '//othersite.com/other-article.html',
-      domainName: 'example.com',
-      type: 'small',
-      title: 'This is an example landscape article',
-      image: '../../assets/01-iconic-american-destinations.jpg',
-    };
+      env.sandbox.stub(requestService, 'loadBookendConfig').resolves(userJson);
 
-    win.location.resetHref(
-      'https://www.nationalgeographic.com/amp-stories/travel/10-iconic-places-to-photograph/'
-    );
-    const landscape = new LandscapeComponent();
+      bookend.build();
+      await bookend.loadConfigAndMaybeRenderBookend();
+      const articles = bookend.bookendEl_.querySelectorAll(
+        '.i-amphtml-story-bookend-portrait'
+      );
+      expect(articles[0]).to.have.attribute('rel');
+      expect(articles[0].getAttribute('rel')).to.equal('amphtml');
+    });
 
-    const el = landscape.buildElement(component, win, {position: 0});
-    expect(el.href).to.equal('https://othersite.com/other-article.html');
-  });
+    it('should not add amp-to-amp linking when not specified in the JSON config', async () => {
+      const userJson = {
+        'bookendVersion': 'v1.0',
+        'shareProviders': [
+          'email',
+          {'provider': 'facebook', 'app_id': '254325784911610'},
+          'whatsapp',
+        ],
+        'components': [
+          {
+            'type': 'portrait',
+            'title': 'example title',
+            'category': 'example category',
+            'url': 'http://example.com/article.html',
+            'image': 'http://placehold.it/256x128',
+          },
+          {
+            'type': 'portrait',
+            'title': 'example title',
+            'category': 'example category',
+            'url': 'http://example.com/article.html',
+            'image': 'http://placehold.it/256x128',
+            'amphtml': 'true',
+          },
+        ],
+      };
 
-  it('should resolve relative url for landscape component', async () => {
-    const component = {
-      url: './other-article.html',
-      domainName: 'example.com',
-      type: 'small',
-      title: 'This is an example landscape article',
-      image: '../../assets/01-iconic-american-destinations.jpg',
-    };
+      env.sandbox.stub(requestService, 'loadBookendConfig').resolves(userJson);
 
-    win.location.resetHref(
-      'https://www.nationalgeographic.com/amp-stories/travel/10-iconic-places-to-photograph/'
-    );
+      bookend.build();
+      await bookend.loadConfigAndMaybeRenderBookend();
+      const articles = bookend.bookendEl_.querySelectorAll(
+        '.i-amphtml-story-bookend-portrait'
+      );
+      expect(articles[0]).to.not.have.attribute('rel');
+      expect(articles[1]).to.not.have.attribute('rel');
+    });
 
-    const landscape = new LandscapeComponent();
+    it('should resolve relative url for origin url when served from the cache', () => {
+      const component = {
+        url: './other-article.html',
+        domainName: 'example.com',
+        type: 'portrait',
+        title: 'This is an example portrait article',
+        image: '../../assets/01-iconic-american-destinations.jpg',
+      };
 
-    const el = landscape.buildElement(component, win, {position: 0});
-    expect(el.href).to.equal(
-      'https://www.nationalgeographic.com/amp-stories/travel/10-iconic-places-to-photograph/other-article.html'
-    );
-  });
+      win.location.resetHref(
+        'https://www-nationalgeographic-com.cdn.ampproject.org/c/s/www.nationalgeographic.com/amp-stories/travel/10-iconic-places-to-photograph/'
+      );
 
-  it('should resolve relative url for landscape component in cache', async () => {
-    const component = {
-      url: './other-article.html',
-      domainName: 'example.com',
-      type: 'small',
-      title: 'This is an example landscape article',
-      image: '../../assets/01-iconic-american-destinations.jpg',
-    };
+      const portrait = new PortraitComponent();
+      const el = portrait.buildElement(component, win, {position: 0});
+      expect(el.href).to.equal(
+        'https://www.nationalgeographic.com/amp-stories/travel/10-iconic-places-to-photograph/other-article.html'
+      );
+    });
 
-    win.location.resetHref(
-      'https://www-nationalgeographic-com.cdn.ampproject.org/c/s/www.nationalgeographic.com/amp-stories/travel/10-iconic-places-to-photograph/'
-    );
-    const landscape = new LandscapeComponent();
+    it('should respect specified absolute URL', () => {
+      const component = {
+        url: 'https://www.anothersite.com/article.html',
+        domainName: 'example.com',
+        type: 'portrait',
+        title: 'This is an example portrait article',
+        image: '../../assets/01-iconic-american-destinations.jpg',
+      };
 
-    const el = landscape.buildElement(component, win, {position: 0});
-    expect(el.href).to.equal(
-      'https://www.nationalgeographic.com/amp-stories/travel/10-iconic-places-to-photograph/other-article.html'
-    );
-  });
+      win.location.resetHref(
+        'https://www-nationalgeographic-com.cdn.ampproject.org/c/s/www.nationalgeographic.com/amp-stories/travel/10-iconic-places-to-photograph/'
+      );
 
-  it('should rewrite portrait thumbnail image url for cached version', async () => {
-    const component = {
-      url: 'http://example.com/portrait.html',
-      domainName: 'example.com',
-      type: 'small',
-      title: 'This is an example portrait',
-      image: 'assets/01-iconic-american-destinations.jpg',
-    };
+      const portrait = new PortraitComponent();
+      const el = portrait.buildElement(component, win, {position: 0});
+      expect(el.href).to.equal('https://www.anothersite.com/article.html');
+    });
 
-    win.location.resetHref(
-      'https://www-nationalgeographic-com.cdn.ampproject.org/c/s/www.nationalgeographic.com/amp-stories/travel/10-iconic-places-to-photograph/'
-    );
-    const portrait = new PortraitComponent();
-    const el = portrait.buildElement(component, win, {position: 0});
-    expect(el.querySelector('img').src).to.equal(
-      'https://www-nationalgeographic-com.cdn.ampproject.org/i/s/www.nationalgeographic.com/amp-stories/travel/10-iconic-places-to-photograph/assets/01-iconic-american-destinations.jpg'
-    );
-  });
+    it('should rewrite thumbnail image url for cached version', () => {
+      const component = {
+        url: 'http://example.com/portrait.html',
+        domainName: 'example.com',
+        type: 'portrait',
+        title: 'This is an example portrait',
+        image: 'assets/01-iconic-american-destinations.jpg',
+      };
 
-  it('should not rewrite thumbnail image url when using absolute url', async () => {
-    const component = {
-      url: 'http://example.com/portrait.html',
-      domainName: 'example.com',
-      type: 'small',
-      title: 'This is an example portrait',
-      image: 'http://placehold.it/256x128',
-    };
+      win.location.resetHref(
+        'https://www-nationalgeographic-com.cdn.ampproject.org/c/s/www.nationalgeographic.com/amp-stories/travel/10-iconic-places-to-photograph/'
+      );
+      const portrait = new PortraitComponent();
+      const el = portrait.buildElement(component, win, {position: 0});
+      expect(el.querySelector('img').src).to.equal(
+        'https://www-nationalgeographic-com.cdn.ampproject.org/i/s/www.nationalgeographic.com/amp-stories/travel/10-iconic-places-to-photograph/assets/01-iconic-american-destinations.jpg'
+      );
+    });
 
-    win.location.resetHref(
-      'https://www-nationalgeographic-com.cdn.ampproject.org/c/s/www.nationalgeographic.com/amp-stories/travel/10-iconic-places-to-photograph/'
-    );
-    const portrait = new PortraitComponent();
-    const el = portrait.buildElement(component, win, {position: 0});
-    expect(el.querySelector('img').src).to.equal('http://placehold.it/256x128');
-  });
+    it('should not rewrite thumbnail image url when using absolute url', () => {
+      const component = {
+        url: 'http://example.com/portrait.html',
+        domainName: 'example.com',
+        type: 'portrait',
+        title: 'This is an example portrait',
+        image: 'http://placehold.it/256x128',
+      };
 
-  it('should not rewrite thumbnail image for origin documents', async () => {
-    const component = {
-      url: 'http://example.com/portrait.html',
-      domainName: 'example.com',
-      type: 'small',
-      title: 'This is an example portrait',
-      image: '../../assets/01-iconic-american-destinations.jpg',
-    };
+      win.location.resetHref(
+        'https://www-nationalgeographic-com.cdn.ampproject.org/c/s/www.nationalgeographic.com/amp-stories/travel/10-iconic-places-to-photograph/'
+      );
+      const portrait = new PortraitComponent();
+      const el = portrait.buildElement(component, win, {position: 0});
+      expect(el.querySelector('img').src).to.equal(
+        'http://placehold.it/256x128'
+      );
+    });
 
-    win.location.resetHref(
-      'https://www.nationalgeographic.com/amp-stories/travel/10-iconic-places-to-photograph/'
-    );
-    const portrait = new PortraitComponent();
-    const el = portrait.buildElement(component, win, {position: 0});
-    expect(el.querySelector('img').src).to.equal(
-      'https://www.nationalgeographic.com/amp-stories/assets/01-iconic-american-destinations.jpg'
-    );
+    it('should not rewrite thumbnail image for origin documents', () => {
+      const component = {
+        url: 'http://example.com/portrait.html',
+        domainName: 'example.com',
+        type: 'small',
+        title: 'This is an example portrait',
+        image: '../../assets/01-iconic-american-destinations.jpg',
+      };
+
+      win.location.resetHref(
+        'https://www.nationalgeographic.com/amp-stories/travel/10-iconic-places-to-photograph/'
+      );
+      const portrait = new PortraitComponent();
+      const el = portrait.buildElement(component, win, {position: 0});
+      expect(el.querySelector('img').src).to.equal(
+        'https://www.nationalgeographic.com/amp-stories/assets/01-iconic-american-destinations.jpg'
+      );
+    });
   });
 });

--- a/extensions/amp-story/1.0/utils.js
+++ b/extensions/amp-story/1.0/utils.js
@@ -252,6 +252,15 @@ export function resolveImgSrc(doc, url) {
   return urlSrc;
 }
 
+/**
+ * Wrapper for testing purposes.
+ * @param {!Document} doc
+ * @return {!Location}
+ */
+export function getDocLocation(doc) {
+  return doc.location;
+}
+
 /** @enum {string} */
 export const HistoryState = {
   ATTACHMENT_PAGE_ID: 'ampStoryAttachmentPageId',

--- a/extensions/amp-story/1.0/utils.js
+++ b/extensions/amp-story/1.0/utils.js
@@ -238,27 +238,18 @@ export function getSourceOriginForElement(element, url) {
 
 /**
  * Resolves an image url and optimizes it if served from the cache.
- * @param {!Document} doc
+ * @param {!Window} win
  * @param {string} url
  * @return {string}
  */
-export function resolveImgSrc(doc, url) {
-  let urlSrc = resolveRelativeUrl(url, doc.location);
-  if (isProxyOrigin(doc.location.href)) {
+export function resolveImgSrc(win, url) {
+  let urlSrc = resolveRelativeUrl(url, win.location);
+  if (isProxyOrigin(win.location.href)) {
     // TODO(Enriqe): add extra params for resized image, for example:
     // (/ii/w${width}/s)
     urlSrc = urlSrc.replace('/c/s/', '/i/s/');
   }
   return urlSrc;
-}
-
-/**
- * Wrapper for testing purposes.
- * @param {!Document} doc
- * @return {!Location}
- */
-export function getDocLocation(doc) {
-  return doc.location;
 }
 
 /** @enum {string} */


### PR DESCRIPTION
Closes #26316

Resolves relative URLs specified in the bookend configuration. See linked issue for more details.

* Note: I know we don't like to write code that is only used in tests but this was the best I could do given that Sinon doesn't like stubbing `document.location / window.location` and I've seen other tests do similar things.