### PR TITLE
🐛 Add check for isIE before accessing self.crypto

### DIFF
--- a/third_party/subscriptions-project/aes_gcm.js
+++ b/third_party/subscriptions-project/aes_gcm.js
@@ -24,7 +24,7 @@
 export function decryptAesGcm(key, text) {
   const keybytes = base64Decode(key);
   const isIE = !!self.msCrypto;
-  const subtle = (self.crypto || self.msCrypto).subtle;
+  const subtle = isIE ? self.msCrypto.subtle : self.crypto.subtle;
   return wrapCryptoOp(subtle.importKey('raw', keybytes.buffer,
     'AES-GCM',
     true, ['decrypt'])).


### PR DESCRIPTION
Checks if browser is IE before accessing self.crypto as this is causing an issue with "crypto not found" on IE.
