### PR TITLE
performance-impl: use performance.now() over Date.now()

### DIFF
--- a/extensions/amp-access/0.1/test/test-amp-access.js
+++ b/extensions/amp-access/0.1/test/test-amp-access.js
@@ -37,6 +37,7 @@ describes.fakeWin(
 
     beforeEach(() => {
       win = env.win;
+      win.performance = {timeOrigin: 1};
       ampdoc = env.ampdoc;
       document = win.document;
 
@@ -271,6 +272,7 @@ describes.fakeWin(
 
     beforeEach(() => {
       win = env.win;
+      win.performance = {timeOrigin: 1};
       ampdoc = env.ampdoc;
       document = win.document;
       clock = env.sandbox.useFakeTimers();
@@ -563,6 +565,7 @@ describes.fakeWin(
 
     beforeEach(() => {
       win = env.win;
+      win.performance = {timeOrigin: 1};
       ampdoc = env.ampdoc;
       document = win.document;
 
@@ -723,6 +726,7 @@ describes.fakeWin(
 
     beforeEach(() => {
       win = env.win;
+      win.performance = {timeOrigin: 1};
       ampdoc = env.ampdoc;
       document = win.document;
       clock = env.sandbox.useFakeTimers();
@@ -1125,6 +1129,7 @@ describes.fakeWin(
 
     beforeEach(() => {
       win = env.win;
+      win.performance = {timeOrigin: 1};
       ampdoc = env.ampdoc;
       document = win.document;
 
@@ -1209,6 +1214,7 @@ describes.fakeWin(
 
     beforeEach(() => {
       win = env.win;
+      win.performance = {timeOrigin: 1};
       ampdoc = env.ampdoc;
       document = win.document;
       clock = env.sandbox.useFakeTimers();
@@ -1623,6 +1629,7 @@ describes.fakeWin(
 
     beforeEach(() => {
       win = env.win;
+      win.performance = {timeOrigin: 1};
       ampdoc = env.ampdoc;
       document = win.document;
 
@@ -1751,6 +1758,7 @@ describes.fakeWin(
 
     beforeEach(() => {
       win = env.win;
+      win.performance = {timeOrigin: 1};
       ampdoc = env.ampdoc;
       document = win.document;
       clock = env.sandbox.useFakeTimers();

--- a/src/service/performance-impl.js
+++ b/src/service/performance-impl.js
@@ -514,7 +514,7 @@ export class Performance {
     this.whenViewportLayoutComplete_().then(() => {
       if (didStartInPrerender) {
         const userPerceivedVisualCompletenesssTime =
-          docVisibleTime >= 0
+          docVisibleTime > -1
             ? this.win.performance.now() - docVisibleTime
             : //  Prerender was complete before visibility.
               0;

--- a/src/service/performance-impl.js
+++ b/src/service/performance-impl.js
@@ -531,7 +531,6 @@ export class Performance {
         // and we just need to tick `pc`. (it will give us the relative
         // time since the viewer initialized the timer)
         this.tick('pc');
-        // TODO before merge: what should be the actual value here? performance.now() or performance.now() - docVisibleTime?
         this.prerenderComplete_(this.win.performance.now() - docVisibleTime);
       }
       this.flush();

--- a/src/service/performance-impl.js
+++ b/src/service/performance-impl.js
@@ -533,10 +533,8 @@ export class Performance {
         // and we just need to tick `pc`. (it will give us the relative
         // time since the viewer initialized the timer)
         this.tick('pc');
-        // We don't have the actual csi timer's clock start time,
-        // so we just have to use `docVisibleTime`.
         // TODO before merge: what should be the actual value here? performance.now() or performance.now() - docVisibleTime?
-        this.prerenderComplete_(this.win.performance.now());
+        this.prerenderComplete_(this.win.performance.now() - docVisibleTime);
       }
       this.flush();
     });

--- a/src/service/performance-impl.js
+++ b/src/service/performance-impl.js
@@ -502,8 +502,6 @@ export class Performance {
   measureUserPerceivedVisualCompletenessTime_() {
     const didStartInPrerender = !this.ampdoc_.hasBeenVisible();
 
-    // This will only be relevant if the ampdoc is in prerender mode.
-    // (hasn't been visible yet, ever at this point)
     let docVisibleTime = -1;
     this.ampdoc_.whenFirstVisible().then(() => {
       docVisibleTime = this.win.performance.now();

--- a/test/unit/test-performance.js
+++ b/test/unit/test-performance.js
@@ -729,7 +729,7 @@ describes.realWin('performance', {amp: true}, env => {
             viewerSendMessageStub.withArgs('prerenderComplete').firstCall
               .args[1].value
           ).to.equal(300);
-          expect(getPerformanceMarks()).to.deep.equal([
+          expect(getPerformanceMarks()).to.have.members([
             'dr',
             'ol',
             'visible',

--- a/test/unit/test-performance.js
+++ b/test/unit/test-performance.js
@@ -39,6 +39,7 @@ describes.realWin('performance', {amp: true}, env => {
       // set initial Date.now to 100, so that we can differentiate between time relative to epoch and relative to process start (value vs. delta).
       now: timeOrigin,
     });
+    Object.defineProperty(win.performance, 'timeOrigin', {value: timeOrigin}); // timeOrigin is read-only.
     win.performance.now = clock.performance.now;
     installPlatformService(env.win);
     installPerformanceService(env.win);
@@ -856,6 +857,7 @@ describes.realWin('PeformanceObserver metrics', {amp: true}, env => {
       performance: {
         getEntriesByType: env.sandbox.stub(),
         now: () => Date.now(),
+        timeOrigin: 100,
       },
     };
 

--- a/test/unit/test-performance.js
+++ b/test/unit/test-performance.js
@@ -866,7 +866,7 @@ describes.realWin('PeformanceObserver metrics', {amp: true}, env => {
       navigator: env.win.navigator,
       performance: {
         getEntriesByType: env.sandbox.stub(),
-        now: () => Date.now(),
+        now: () => 100,
         timeOrigin: 100,
       },
     };

--- a/test/unit/test-performance.js
+++ b/test/unit/test-performance.js
@@ -718,14 +718,17 @@ describes.realWin('performance', {amp: true}, env => {
           .withArgs('csi')
           .returns('1');
         env.sandbox.stub(viewer, 'isEmbedded').returns(true);
-        clock.tick(300);
+        whenFirstVisibleResolve();
+        whenFirstVisiblePromise.then(() => {
+          clock.tick(300);
+        });
         whenViewportLayoutCompleteResolve();
         return perf.whenViewportLayoutComplete_().then(() => {
           expect(
             viewerSendMessageStub.withArgs('prerenderComplete').firstCall
               .args[1].value
           ).to.equal(300);
-          expect(getPerformanceMarks()).to.deep.equal(['dr', 'ol', 'pc']);
+          expect(getPerformanceMarks()).to.deep.equal(['dr', 'ol', 'visible', 'ofv', 'pc',]);
         });
       });
 

--- a/test/unit/test-performance.js
+++ b/test/unit/test-performance.js
@@ -712,14 +712,15 @@ describes.realWin('performance', {amp: true}, env => {
         perf.coreServicesAvailable();
       });
 
-      it('should call prerenderComplete on viewer', () => {
+      it('should call prerenderComplete on viewer', async () => {
         env.sandbox
           .stub(viewer, 'getParam')
           .withArgs('csi')
           .returns('1');
         env.sandbox.stub(viewer, 'isEmbedded').returns(true);
+        clock.tick(100);
         whenFirstVisibleResolve();
-        whenFirstVisiblePromise.then(() => {
+        await whenFirstVisiblePromise.then(() => {
           clock.tick(300);
         });
         whenViewportLayoutCompleteResolve();

--- a/test/unit/test-performance.js
+++ b/test/unit/test-performance.js
@@ -39,6 +39,7 @@ describes.realWin('performance', {amp: true}, env => {
       // set initial Date.now to 100, so that we can differentiate between time relative to epoch and relative to process start (value vs. delta).
       now: timeOrigin,
     });
+    win.performance.now = clock.performance.now;
     installPlatformService(env.win);
     installPerformanceService(env.win);
     perf = Services.performanceFor(env.win);
@@ -854,6 +855,7 @@ describes.realWin('PeformanceObserver metrics', {amp: true}, env => {
       navigator: env.win.navigator,
       performance: {
         getEntriesByType: env.sandbox.stub(),
+        now: () => Date.now(),
       },
     };
 

--- a/test/unit/test-performance.js
+++ b/test/unit/test-performance.js
@@ -728,7 +728,13 @@ describes.realWin('performance', {amp: true}, env => {
             viewerSendMessageStub.withArgs('prerenderComplete').firstCall
               .args[1].value
           ).to.equal(300);
-          expect(getPerformanceMarks()).to.deep.equal(['dr', 'ol', 'visible', 'ofv', 'pc',]);
+          expect(getPerformanceMarks()).to.deep.equal([
+            'dr',
+            'ol',
+            'visible',
+            'ofv',
+            'pc',
+          ]);
         });
       });
 


### PR DESCRIPTION
Fixes https://github.com/ampproject/amphtml/issues/16042

TODO: figure out why it was reverted last time (https://github.com/ampproject/amphtml/pull/16227).
Answer: `performance.now()` is relative to `timeOrigin` whereas `Date.now()` is relative to epoch.