### PR TITLE
🏗 Add terminal newline to files.txt

### DIFF
--- a/build-system/tasks/dist.js
+++ b/build-system/tasks/dist.js
@@ -277,7 +277,7 @@ async function generateFileListing() {
   const filesOut = `${distDir}/files.txt`;
   fs.writeFileSync(filesOut, '');
   const files = (await walk(distDir)).map(f => f.replace(`${distDir}/`, ''));
-  fs.writeFileSync(filesOut, files.join('\n'));
+  fs.writeFileSync(filesOut, files.join('\n') + '\n');
   endBuildStep('Generated', filesOut, startTime);
 }
 


### PR DESCRIPTION
A (very) small part of #25989 . Currently, `files.txt` does not end in a newline. It should, which will allow the build script to append to it without having to worry about adding the newline itself.