### PR TITLE
🐛Add computed styles to fake win

### DIFF
--- a/test/unit/test-runtime.js
+++ b/test/unit/test-runtime.js
@@ -1625,7 +1625,7 @@ describes.realWin(
 
         it('should ignore unknown script', () => {
           expectAsyncConsoleError(
-            '[runtime] - unknown script:  [object HTMLScriptElement] ' +
+            '[multidoc-manager] - unknown script:  [object HTMLScriptElement] ' +
               'https://cdn.ampproject.org/other.js'
           );
 
@@ -1711,7 +1711,7 @@ describes.realWin(
 
         it('should ignore inline script if javascript', () => {
           expectAsyncConsoleError(
-            '[runtime] - unallowed inline javascript:  ' +
+            '[multidoc-manager] - unallowed inline javascript:  ' +
               '[object HTMLScriptElement]',
             2
           );

--- a/testing/fake-dom.js
+++ b/testing/fake-dom.js
@@ -253,6 +253,11 @@ export class FakeWindow {
      * @const
      */
     this.requestAnimationFrame = raf;
+
+    // Styles.
+    this.getComputedStyle = function() {
+      return window.getComputedStyle.apply(window, arguments);
+    };
   }
 
   /** polyfill addEventListener. */


### PR DESCRIPTION
While investigating test failures for #26447, I noticed that I would get a different number of tests each time when running `test-runtime` locally?!?

After investigation it appears many (all?) of the tests using `fakeWin` in this file would throw an error when the runtime eventually calls `getComputedStyle`. This PR adds this method to the fake win.

I think this was causing all sorts of weird behaviors, and likely that many tests were unintentionally being skipped due to the test runner borking. When I added the method it surfaced two obvious errors that must not have been run all this time :(

~~Also might be opening a can of worms here by exposing other uncaught errors in other test files that may be exposed after introduction of this method on `fakeWin`. Going to let travis run and see what happens.~~ Looks like tests passed.

