### PR TITLE
🐛 Fix race condition between amp-list and amp-state.

### DIFF
--- a/build-system/externs/amp.extern.js
+++ b/build-system/externs/amp.extern.js
@@ -717,7 +717,12 @@ let BindEvaluateExpressionResultDef;
 
 /**
  * Options for Bind.rescan().
- * @typedef {{update: (boolean|undefined), fast: (boolean|undefined), timeout: (number|undefined)}}
+ * @typedef {{
+ *    update: (boolean|undefined),
+ *    fast: (boolean|undefined),
+ *    timeout: (number|undefined),
+ *    wait: (boolean|undefined)
+ * }}
  */
 let BindRescanOptionsDef;
 

--- a/extensions/amp-bind/0.1/amp-state.js
+++ b/extensions/amp-bind/0.1/amp-state.js
@@ -45,8 +45,8 @@ export class AmpState extends AMP.BaseElement {
      */
     this.localData_ = undefined;
 
-    /** @private {Promise=} */
-    this.fetchAndUpdatePromise_ = undefined;
+    /** @private {Promise} */
+    this.fetchAndUpdatePromise_ = null;
   }
 
   /** @override */
@@ -215,19 +215,22 @@ export class AmpState extends AMP.BaseElement {
    */
   fetchAndUpdate_(isInit, opt_refresh) {
     // Don't fetch in prerender mode.
-    this.fetchAndUpdatePromise_ = this.getAmpDoc()
+    const fetchAndUpdatePromise = this.getAmpDoc()
       .whenFirstVisible()
       .then(() => this.prepareAndSendFetch_(isInit, opt_refresh))
       .then(json => this.updateState_(json, isInit));
 
-    Services.bindForDocOrNull(this.element).then(bind => {
-      devAssert(bind);
-      bind.registerAsyncAmpState(
-        this.element.getAttribute('id'),
-        this.fetchAndUpdatePromise_
-      );
-    });
-    return /**@type {!Promise} */ this.fetchAndUpdatePromise_;
+    if (isInit) {
+      Services.bindForDocOrNull(this.element).then(bind => {
+        devAssert(bind);
+        bind.registerAsyncAmpState(
+          this.element.getAttribute('id'),
+          fetchAndUpdatePromise
+        );
+      });
+    }
+
+    return /** @type {!Promise} */ (this.fetchAndUpdatePromise_ = fetchAndUpdatePromise);
   }
 
   /**

--- a/extensions/amp-bind/0.1/amp-state.js
+++ b/extensions/amp-bind/0.1/amp-state.js
@@ -74,7 +74,6 @@ export class AmpState extends AMP.BaseElement {
         bind.addOverridableKey(element.getAttribute('id'));
       });
     }
-
     // Parse child <script> tag and/or fetch JSON from `src` attribute.
     // The latter is allowed to overwrite the former.
     this.parseAndUpdate();

--- a/extensions/amp-bind/0.1/amp-state.js
+++ b/extensions/amp-bind/0.1/amp-state.js
@@ -220,24 +220,25 @@ export class AmpState extends AMP.BaseElement {
       .then(() => this.prepareAndSendFetch_(isInit, opt_refresh))
       .then(json => this.updateState_(json, isInit));
 
-    if (isInit) {
-      Services.bindForDocOrNull(this.element).then(bind => {
-        devAssert(bind);
-        bind.registerAsyncAmpState(
-          this.element.getAttribute('id'),
-          fetchAndUpdatePromise
-        );
+    if (/* TODO: should we gate this on isInit?  */ true) {
+      this.fetchAndUpdatePromise_ = fetchAndUpdatePromise;
+
+      // Cleanup when complete
+      fetchAndUpdatePromise.then(() => {
+        if (this.fetchAndUpdatePromise_ === fetchAndUpdatePromise) {
+          this.fetchAndUpdatePromise_ = null;
+        }
       });
     }
 
-    return /** @type {!Promise} */ (this.fetchAndUpdatePromise_ = fetchAndUpdatePromise);
+    return fetchAndUpdatePromise;
   }
 
   /**
+   * Returns a promise that resolves after the fetch and update completes.
    * @return {Promise}
-   * @visibleForTesting
    */
-  getFetchAndUpdatePromiseForTesting() {
+  getFetchAndUpdatePromise() {
     return this.fetchAndUpdatePromise_;
   }
 

--- a/extensions/amp-bind/0.1/amp-state.js
+++ b/extensions/amp-bind/0.1/amp-state.js
@@ -191,9 +191,8 @@ export class AmpState extends AMP.BaseElement {
         ? UrlReplacementPolicy.OPT_IN
         : UrlReplacementPolicy.ALL;
 
-    return getViewerAuthTokenIfAvailable(element)
-      .then(token => this.fetch_(ampdoc, policy, opt_refresh, token))
-      .catch(error => {
+    return getViewerAuthTokenIfAvailable(element).then(token =>
+      this.fetch_(ampdoc, policy, opt_refresh, token).catch(error => {
         const event = error
           ? createCustomEvent(
               this.win,
@@ -204,7 +203,8 @@ export class AmpState extends AMP.BaseElement {
         // Trigger "fetch-error" event on fetch failure.
         const actions = Services.actionServiceForDoc(element);
         actions.trigger(element, 'fetch-error', event, ActionTrust.LOW);
-      });
+      })
+    );
   }
 
   /**

--- a/extensions/amp-bind/0.1/amp-state.js
+++ b/extensions/amp-bind/0.1/amp-state.js
@@ -44,6 +44,9 @@ export class AmpState extends AMP.BaseElement {
      * @private {?JsonObject|undefined}
      */
     this.localData_ = undefined;
+
+    /** @private {Promise} */
+    this.fetchAndUpdatePromise_ = undefined;
   }
 
   /** @override */
@@ -212,7 +215,7 @@ export class AmpState extends AMP.BaseElement {
    */
   fetchAndUpdate_(isInit, opt_refresh) {
     // Don't fetch in prerender mode.
-    const fetchAndUpdatePromise = this.getAmpDoc()
+    this.fetchAndUpdatePromise_ = this.getAmpDoc()
       .whenFirstVisible()
       .then(() => this.prepareAndSendFetch_(isInit, opt_refresh))
       .then(json => this.updateState_(json, isInit));
@@ -221,10 +224,18 @@ export class AmpState extends AMP.BaseElement {
       devAssert(bind);
       bind.registerAsyncAmpState(
         this.element.getAttribute('id'),
-        fetchAndUpdatePromise
+        this.fetchAndUpdatePromise_
       );
     });
-    return fetchAndUpdatePromise;
+    return this.fetchAndUpdatePromise_;
+  }
+
+  /**
+   * @return {Promise}
+   * @visibleForTesting
+   */
+  getFetchAndUpdatePromiseForTesting() {
+    return this.fetchAndUpdatePromise_;
   }
 
   /**

--- a/extensions/amp-bind/0.1/amp-state.js
+++ b/extensions/amp-bind/0.1/amp-state.js
@@ -45,7 +45,7 @@ export class AmpState extends AMP.BaseElement {
      */
     this.localData_ = undefined;
 
-    /** @private {Promise} */
+    /** @private {Promise=} */
     this.fetchAndUpdatePromise_ = undefined;
   }
 
@@ -210,7 +210,7 @@ export class AmpState extends AMP.BaseElement {
   /**
    * @param {boolean} isInit
    * @param {boolean=} opt_refresh
-   * @return {!Promise<undefined>}
+   * @return {!Promise}
    * @private
    */
   fetchAndUpdate_(isInit, opt_refresh) {
@@ -227,7 +227,7 @@ export class AmpState extends AMP.BaseElement {
         this.fetchAndUpdatePromise_
       );
     });
-    return this.fetchAndUpdatePromise_;
+    return /**@type {!Promise} */ this.fetchAndUpdatePromise_;
   }
 
   /**

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -1100,16 +1100,12 @@ export class Bind {
    * @private
    */
   evaluate_(opt_wait) {
-    const state = opt_wait
+    const statePromise = opt_wait
       ? this.getStateWithWait('.')
       : Promise.resolve(this.state_);
-    const evaluatePromise = state.then(s =>
-      this.ww_('bind.evaluateBindings', [s])
+    const evaluatePromise = statePromise.then(state =>
+      this.ww_('bind.evaluateBindings', [state])
     );
-
-    // return evaluatePromise.then(() => {
-    //   return state;
-    // });
 
     return evaluatePromise.then(returnValue => {
       const {results, errors} = returnValue;
@@ -1840,8 +1836,6 @@ export class Bind {
   registerAsyncAmpState(id, promise) {
     this.asyncLoadingAmpStates_[id] = promise;
 
-    promise
-      .then(() => delete this.asyncLoadingAmpStates_[id])
-      .catch(() => delete this.asyncLoadingAmpStates_[id]);
+    promise.catch(() => {}).then(() => delete this.asyncLoadingAmpStates_[id]);
   }
 }

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -491,7 +491,7 @@ export class Bind {
 
     return rescanPromise.then(() => {
       if (options.update) {
-        return this.evaluate_().then(results =>
+        return this.evaluate_(options.wait).then(results =>
           this.apply_(results, {constrain: addedElements})
         );
       }
@@ -1088,11 +1088,16 @@ export class Bind {
 
   /**
    * Reevaluates all expressions and returns a map of expressions to results.
+   * @param {boolean=} opt_wait - whether to wait for an amp-state to complete its fetch/parse.
    * @return {!Promise<!Object<string, BindExpressionResultDef>>}
    * @private
    */
-  evaluate_() {
-    const evaluatePromise = this.ww_('bind.evaluateBindings', [this.state_]);
+  evaluate_(opt_wait) {
+    const state = opt_wait ? this.getStateWithWait() : this.state_;
+    const evaluatePromise = state.then(s =>
+      this.ww_('bind.evaluateBindings', [s])
+    );
+
     return evaluatePromise.then(returnValue => {
       const {results, errors} = returnValue;
       // Report evaluation errors.

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -1821,5 +1821,9 @@ export class Bind {
    */
   registerAsyncAmpState(id, promise) {
     this.asyncLoadingAmpStates_[id] = promise;
+
+    promise
+      .then(() => delete this.asyncLoadingAmpStates_[id])
+      .catch(() => delete this.asyncLoadingAmpStates_[id]);
   }
 }

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -564,17 +564,17 @@ export class Bind {
    */
   getStateWithWait(expr) {
     const asyncLoadingAmpStates = {};
-    const ampStatesEls = root.querySelectorAll('AMP-STATE');
+    const ampStateEls = this.ampdoc.getRootNode().querySelectorAll('AMP-STATE');
     let hasLoadingAmpState = false;
     const gatherAsyncAmpStates = Promise.all(
-      toArray(ampStatesEls).map(el => {
+      toArray(ampStateEls).map(el => {
         return whenUpgradedToCustomElement(el)
           .then(() => el.getImpl(/* waitForBuild */ false))
           .then(impl => {
             const id = impl.element.getAttribute('id');
             const loadingPromise = impl.getFetchAndUpdatePromise();
             if (loadingPromise) {
-              asyncLoadingAmpStates[id] = loadedPromise;
+              asyncLoadingAmpStates[id] = loadingPromise;
               hasLoadingAmpState = true;
             }
           });
@@ -592,7 +592,7 @@ export class Bind {
         wait = Promise.all(Object.values(asyncLoadingAmpStates));
       } else {
         const stateKey = expr.split('.')[0];
-        wait = asyncLoadingAmpStates[stateKey];
+        wait = Promise.resolve(asyncLoadingAmpStates[stateKey]);
       }
 
       return wait.catch(() => {}).then(() => this.getState(expr));

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -1093,7 +1093,7 @@ export class Bind {
    * @private
    */
   evaluate_(opt_wait) {
-    const state = opt_wait ? this.getStateWithWait() : this.state_;
+    const state = opt_wait ? this.getStateWithWait() : Promise.resolve(this.state_);
     const evaluatePromise = state.then(s =>
       this.ww_('bind.evaluateBindings', [s])
     );

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -577,9 +577,8 @@ export class Bind {
       // If getting everything, then wait for all async amp states.
       wait = Promise.all(Object.values(this.asyncLoadingAmpStates_));
     } else {
-      wait = Promise.resolve().then(
-        () => this.asyncLoadingAmpStates_[expr.split('.')[0]]
-      );
+      const stateKey = expr.split('.')[0];
+      wait = Promise.resolve(this.asyncLoadingAmpStates_[stateKey]);
     }
 
     return wait.then(

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -563,7 +563,7 @@ export class Bind {
    *
    * e.g. "foo.bar".
    * @param {string} expr
-   * @return {*}
+   * @return {!Promise<*>}
    */
   getStateWithWait(expr) {
     const value = this.getState(expr);
@@ -574,7 +574,7 @@ export class Bind {
         return wait.then(() => this.getState(expr));
       }
     }
-    return undefined;
+    return Promise.resolve(value);
   }
 
   /**

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -581,10 +581,7 @@ export class Bind {
       wait = Promise.resolve(this.asyncLoadingAmpStates_[stateKey]);
     }
 
-    return wait.then(
-      () => this.getState(expr),
-      () => this.getState(expr)
-    );
+    return wait.catch(() => {}).then(() => this.getState(expr));
   }
 
   /**

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -563,7 +563,7 @@ export class Bind {
    *
    * e.g. "foo.bar".
    * @param {string} expr
-   * @return {!Promise<*>}
+   * @return {!Promise}
    */
   getStateWithWait(expr) {
     const value = this.getState(expr);
@@ -1817,7 +1817,7 @@ export class Bind {
   /**
    *
    * @param {string} id
-   * @param {!Promise<*>} promise
+   * @param {!Promise} promise
    */
   registerAsyncAmpState(id, promise) {
     this.asyncLoadingAmpStates_[id] = promise;

--- a/extensions/amp-bind/0.1/test/integration/test-bind-impl.js
+++ b/extensions/amp-bind/0.1/test/integration/test-bind-impl.js
@@ -955,7 +955,7 @@ describe
           });
         });
 
-        describe.only('getStateWithWait', () => {
+        describe('getStateWithWait', () => {
           function addAmpState(id, valuePromise) {
             const ampState = document.createElement('amp-state', id);
             ampState.createdCallback = () => {};

--- a/extensions/amp-bind/0.1/test/integration/test-bind-impl.js
+++ b/extensions/amp-bind/0.1/test/integration/test-bind-impl.js
@@ -956,6 +956,7 @@ describe
         });
 
         describe('getStateWithWait', () => {
+          // TODO: fix all these tests if impl looks okay.
           it('should return the same result as getState if already present', async () => {
             await bind.initializePromiseForTesting();
             await bind.setState({mystate: {mykey: 'myval'}});

--- a/extensions/amp-bind/0.1/test/integration/test-bind-impl.js
+++ b/extensions/amp-bind/0.1/test/integration/test-bind-impl.js
@@ -957,7 +957,7 @@ describe
 
         describe.only('getStateWithWait', () => {
           function addAmpState(id, valuePromise) {
-            let ampState = document.createElement('amp-state', id);
+            const ampState = document.createElement('amp-state', id);
             ampState.createdCallback = () => {};
             ampState.getImpl = () =>
               Promise.resolve({

--- a/extensions/amp-bind/0.1/test/integration/test-bind-impl.js
+++ b/extensions/amp-bind/0.1/test/integration/test-bind-impl.js
@@ -1221,6 +1221,24 @@ describe
             toAdd = createElement(env, /* container */ null, '[text]="1+1"');
           });
 
+          it('{update: true, fast: true, wait: true}', async () => {
+            const options = {update: true, fast: true, wait: true};
+
+            await onBindReadyAndSetState(env, bind, {foo: 'foo'});
+            expect(toRemove.textContent).to.equal('foo');
+
+            // [i-amphtml-binding] necessary in {fast: true}.
+            toAdd.setAttribute('i-amphtml-binding', '');
+
+            // `toAdd` should be scanned and updated.
+            await onBindReadyAndRescan(env, bind, [toAdd], [toRemove], options);
+            expect(toAdd.textContent).to.equal('2');
+
+            await onBindReadyAndSetState(env, bind, {foo: 'bar'});
+            // The `toRemove` element's bindings should have been removed.
+            expect(toRemove.textContent).to.not.equal('bar');
+          });
+
           it('{update: true, fast: true}', async () => {
             const options = {update: true, fast: true};
 

--- a/extensions/amp-bind/0.1/test/integration/test-bind-impl.js
+++ b/extensions/amp-bind/0.1/test/integration/test-bind-impl.js
@@ -23,12 +23,12 @@ import * as lolex from 'lolex';
 import {AmpEvents} from '../../../../../src/amp-events';
 import {Bind} from '../../bind-impl';
 import {BindEvents} from '../../bind-events';
+import {Deferred} from '../../../../../src/utils/promise';
 import {RAW_OBJECT_ARGS_KEY} from '../../../../../src/action-constants';
 import {Services} from '../../../../../src/services';
 import {chunkInstanceForTesting} from '../../../../../src/chunk';
 import {dev, user} from '../../../../../src/log';
 import {toArray} from '../../../../../src/types';
-import {Deferred} from '../../../../../src/utils/promise';
 
 /**
  * @param {!Object} env
@@ -1003,10 +1003,12 @@ describe
 
             await bind.initializePromiseForTesting();
             const statePromise = bind.getStateWithWait('.');
-            r1(); 
+            r1();
 
             await bind.setState({mystate: {mykey: 'myval'}}).then(r2);
-            expect(await statePromise).to.deep.equal({mystate: {mykey: 'myval'}});
+            expect(await statePromise).to.deep.equal({
+              mystate: {mykey: 'myval'},
+            });
           });
         });
 

--- a/extensions/amp-bind/0.1/test/integration/test-bind-impl.js
+++ b/extensions/amp-bind/0.1/test/integration/test-bind-impl.js
@@ -988,7 +988,13 @@ describe
           it('should not wait if the still-loading state is irrelevant', async () => {
             await bind.initializePromiseForTesting();
             await bind.setState({mystate: {mykey: 'myval'}});
-            addAmpState(env, container, 'otherkey', {}, new Promise(unused => {})); // never going to resolve
+            addAmpState(
+              env,
+              container,
+              'otherkey',
+              {},
+              new Promise(unused => {})
+            ); // never going to resolve
 
             const state = await bind.getStateWithWait('mystate.mykey');
             expect(state).to.equal('myval');
@@ -1306,7 +1312,12 @@ describe
 
             await bind.initializePromiseForTesting();
             let resolveFetch;
-            addAmpState(env, container, 'foo', new Promise(r => (resolveFetch = r)));
+            addAmpState(
+              env,
+              container,
+              'foo',
+              new Promise(r => (resolveFetch = r))
+            );
             const rescanPromise = bind.rescan([toAdd], [], options);
             expect(toAdd.textContent).to.equal('');
 

--- a/extensions/amp-bind/0.1/test/test-amp-state.js
+++ b/extensions/amp-bind/0.1/test/test-amp-state.js
@@ -75,7 +75,6 @@ describes.realWin(
 
       bind = {
         setState: env.sandbox.stub(),
-        registerAsyncAmpState: env.sandbox.stub(),
       };
       env.sandbox.stub(Services, 'bindForDocOrNull').resolves(bind);
     });
@@ -113,34 +112,6 @@ describes.realWin(
         {myAmpState: {remote: 'data'}},
         {skipEval: true, skipAmpState: false}
       );
-    });
-
-    it('should register itself with bind if performing a fetch', async () => {
-      element.setAttribute('src', 'https://foo.com/bar?baz=1');
-      element.build();
-
-      whenFirstVisiblePromiseResolve();
-      await whenFirstVisiblePromise;
-
-      // await one macro-task to let viewer/fetch promise chains resolve.
-      await new Promise(resolve => setTimeout(resolve, 0));
-
-      expect(bind.registerAsyncAmpState).to.have.been.calledWith(
-        'myAmpState',
-        ampState.getFetchAndUpdatePromiseForTesting()
-      );
-    });
-
-    it('should not register itself if not init', async () => {
-      element.mutatedAttributesCallback({src: 'https://foo.com/bar?baz=1'});
-
-      whenFirstVisiblePromiseResolve();
-      await whenFirstVisiblePromise;
-
-      // await one macro-task to let viewer/fetch promise chains resolve.
-      await new Promise(resolve => setTimeout(resolve, 0));
-
-      expect(bind.registerAsyncAmpState).to.not.have.been.called;
     });
 
     it('should trigger "fetch-error" if fetch fails', async () => {

--- a/extensions/amp-bind/0.1/test/test-amp-state.js
+++ b/extensions/amp-bind/0.1/test/test-amp-state.js
@@ -115,7 +115,7 @@ describes.realWin(
       );
     });
 
-    it.only('should register itself with bind if performing a fetch', async () => {
+    it('should register itself with bind if performing a fetch', async () => {
       element.setAttribute('src', 'https://foo.com/bar?baz=1');
       element.build();
 
@@ -130,6 +130,18 @@ describes.realWin(
         ampState.getFetchAndUpdatePromiseForTesting()
       );
     });
+
+    it('should not register itself if not init', async () => {
+      element.mutatedAttributesCallback({src: 'https://foo.com/bar?baz=1'});
+
+      whenFirstVisiblePromiseResolve();
+      await whenFirstVisiblePromise;
+
+      // await one macro-task to let viewer/fetch promise chains resolve.
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      expect(bind.registerAsyncAmpState).to.not.have.been.called;
+    })
 
     it('should trigger "fetch-error" if fetch fails', async () => {
       ampState.fetch_.returns(Promise.reject());

--- a/extensions/amp-bind/0.1/test/test-amp-state.js
+++ b/extensions/amp-bind/0.1/test/test-amp-state.js
@@ -141,7 +141,7 @@ describes.realWin(
       await new Promise(resolve => setTimeout(resolve, 0));
 
       expect(bind.registerAsyncAmpState).to.not.have.been.called;
-    })
+    });
 
     it('should trigger "fetch-error" if fetch fails', async () => {
       ampState.fetch_.returns(Promise.reject());

--- a/extensions/amp-bind/0.1/test/test-amp-state.js
+++ b/extensions/amp-bind/0.1/test/test-amp-state.js
@@ -73,7 +73,10 @@ describes.realWin(
         .stub(ampState, 'fetch_')
         .returns(Promise.resolve({remote: 'data'}));
 
-      bind = {setState: env.sandbox.stub()};
+      bind = {
+        setState: env.sandbox.stub(),
+        registerAsyncAmpState: env.sandbox.stub(),
+      };
       env.sandbox.stub(Services, 'bindForDocOrNull').resolves(bind);
     });
 
@@ -109,6 +112,22 @@ describes.realWin(
       expect(bind.setState).calledWithMatch(
         {myAmpState: {remote: 'data'}},
         {skipEval: true, skipAmpState: false}
+      );
+    });
+
+    it.only('should register itself with bind if performing a fetch', async () => {
+      element.setAttribute('src', 'https://foo.com/bar?baz=1');
+      element.build();
+
+      whenFirstVisiblePromiseResolve();
+      await whenFirstVisiblePromise;
+
+      // await one macro-task to let viewer/fetch promise chains resolve.
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      expect(bind.registerAsyncAmpState).to.have.been.calledWith(
+        'myAmpState',
+        ampState.getFetchAndUpdatePromiseForTesting()
       );
     });
 

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -376,7 +376,7 @@ export class AmpList extends AMP.BaseElement {
         );
 
         const ampStatePath = src.slice(AMP_STATE_URI_SCHEME.length);
-        return bind.getState(ampStatePath);
+        return bind.getStateWithWait(ampStatePath);
       })
       .then(json => {
         userAssert(

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -912,7 +912,7 @@ export class AmpList extends AMP.BaseElement {
       const removedElements = append ? [] : [this.container_];
       // Forward elements to chained promise on success or failure.
       return bind
-        .rescan(elements, removedElements, {'fast': true, 'update': true})
+        .rescan(elements, removedElements, {'fast': true, 'update': true, 'wait': true})
         .then(
           () => elements,
           () => elements

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -912,7 +912,11 @@ export class AmpList extends AMP.BaseElement {
       const removedElements = append ? [] : [this.container_];
       // Forward elements to chained promise on success or failure.
       return bind
-        .rescan(elements, removedElements, {'fast': true, 'update': true, 'wait': true})
+        .rescan(elements, removedElements, {
+          'fast': true,
+          'update': true,
+          'wait': true,
+        })
         .then(
           () => elements,
           () => elements

--- a/extensions/amp-list/0.1/test/test-amp-list.js
+++ b/extensions/amp-list/0.1/test/test-amp-list.js
@@ -1148,7 +1148,7 @@ describes.repeated(
               expect(bind.rescan).calledWithExactly(
                 [child],
                 [list.container_],
-                {update: true, fast: true}
+                {update: true, fast: true, wait: true}
               );
             });
 
@@ -1174,7 +1174,7 @@ describes.repeated(
               expect(bind.rescan).calledWithExactly(
                 [child],
                 [list.container_],
-                {update: true, fast: true}
+                {update: true, fast: true, wait: true}
               );
             });
           });
@@ -1211,6 +1211,7 @@ describes.repeated(
                 {
                   update: true,
                   fast: true,
+                  wait: true,
                 }
               );
             });

--- a/extensions/amp-list/0.1/test/test-amp-list.js
+++ b/extensions/amp-list/0.1/test/test-amp-list.js
@@ -1264,7 +1264,7 @@ describes.repeated(
 
             it('should render a list using local data', async () => {
               toggleExperiment(win, experimentName, true);
-              bind.getState = () => ({items: [1, 2, 3]});
+              bind.getStateWithWait = () => Promise.resolve({items: [1, 2, 3]});
 
               const ampStateEl = doc.createElement('amp-state');
               ampStateEl.setAttribute('id', 'okapis');


### PR DESCRIPTION
**summary**
Fixes https://github.com/ampproject/amphtml/issues/11998.

Creates a new function in bind named `getStateWithWait`. It is identical to `getState` in most cases, except that if a piece of state is currently being loaded by an `amp-state`, it will wait for it to complete first.

This lets `amp-list` solve the race condition that exists when `binding=always`:
```html
<amp-state id="state" src="/slow.json"></amp-state>
<amp-list src="/fast.json">
  <template type="amp-mustache">
     <p [text]="state.text"></p>
  </template>
</amp-list>
```
 
**technical changes**
- New function in bind-impl, `getStateWithWait`, which scans the dom for `amp-state` components and then waits for all the ones evaluating fetches (that match the current state query).

**open questions**
- Is the new `wait` option necessary? Can make it always true.

TODO:
 - [x] `amp-list` unit tests 
 - [x] `bind-impl` unit tests