### PR TITLE
🏗️ Update no-import lint rule to forbid sub-paths

### DIFF
--- a/build-system/eslint-rules/no-import.js
+++ b/build-system/eslint-rules/no-import.js
@@ -41,14 +41,13 @@ module.exports = function(context) {
       const name = node.source.value;
 
       for (const forbidden of imports) {
-        if (name !== forbidden.import) {
-          continue;
+        const importSource = forbidden.import;
+        if (name === importSource || name.startsWith(`${importSource}/`)) {
+          context.report({
+            node,
+            message: forbidden.message,
+          });
         }
-
-        context.report({
-          node,
-          message: forbidden.message,
-        });
       }
     },
   };


### PR DESCRIPTION
Caroline accidentally imported `from 'preact/src'`, and took a bit to figure out what was going wrong. This fix now forbids importing from the `preact/src` sub-paths.