### PR TITLE
Trim page attachment cta text.

### DIFF
--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -1635,14 +1635,15 @@ export class AmpStoryPage extends AMP.BaseElement {
         '.i-amphtml-story-page-open-attachment-label'
       );
 
-      const openAttachmentLabel =
-        attachmentEl.getAttribute('data-cta-text') ||
+      const openLabelAttr = attachmentEl.getAttribute('data-cta-text');
+      const openLabel =
+        (openLabelAttr && openLabelAttr.trim()) ||
         Services.localizationService(this.win).getLocalizedString(
           LocalizedStringId.AMP_STORY_PAGE_ATTACHMENT_OPEN_LABEL
         );
 
       this.mutateElement(() => {
-        textEl.textContent = openAttachmentLabel;
+        textEl.textContent = openLabel;
         this.element.appendChild(this.openAttachmentEl_);
       });
     }


### PR DESCRIPTION
Some publishers configure the page attachment with a single space character as the `data-cta-text`, eg: `data-cta-text=" "` which renders a completely empty "Swipe up" label.
See: https://aollco.com/collection/1708734

`trim()` removes all the empty characters (spaces) listed here http://emptycharacter.com/, very likely there are other ways to do it but this fixes the most obvious ones.