### PR TITLE
🏗 Update Cherry-pick template with new release names

### DIFF
--- a/.github/ISSUE_TEMPLATE/cherry_pick_template.md
+++ b/.github/ISSUE_TEMPLATE/cherry_pick_template.md
@@ -5,7 +5,6 @@ title: "\U0001F338 Cherry-pick request for #<ISSUE_NUMBER> into #<RELEASE_ISSUE>
 labels: 'Cherry Pick: Beta, Cherry Pick: Experimental, Cherry Pick: Stable, Type:
   Release'
 assignees: ''
-
 ---
 
 <!--

--- a/.github/ISSUE_TEMPLATE/cherry_pick_template.md
+++ b/.github/ISSUE_TEMPLATE/cherry_pick_template.md
@@ -8,13 +8,6 @@ assignees: ''
 
 ---
 
----
-name: Cherry-pick template
-about: Used to request a cherry-pick. See go.amp.dev/cherry-picks
-title: "\U0001F338 Cherry-pick request for #<ISSUE_NUMBER> into #<RELEASE_ISSUE> (Pending)"
-labels: 'Type: Release'
----
-
 <!--
 MUST: Replace *everything* in angle brackets in the title AND body of this issue.
 MUST: Update issue labels to indicate which channels the cherry-pick is going into.

--- a/.github/ISSUE_TEMPLATE/cherry_pick_template.md
+++ b/.github/ISSUE_TEMPLATE/cherry_pick_template.md
@@ -1,5 +1,5 @@
 ---
-name: Cherry-pick template
+name: Cherry-pick request
 about: Used to request a cherry-pick. See go.amp.dev/cherry-picks
 title: "\U0001F338 Cherry-pick request for #<ISSUE_NUMBER> into #<RELEASE_ISSUE> (Pending)"
 labels:

--- a/.github/ISSUE_TEMPLATE/cherry_pick_template.md
+++ b/.github/ISSUE_TEMPLATE/cherry_pick_template.md
@@ -3,7 +3,7 @@ name: Cherry-pick request
 about: Used to request a cherry-pick. See go.amp.dev/cherry-picks
 title: "\U0001F338 Cherry-pick request for #<ISSUE_NUMBER> into #<RELEASE_ISSUE> (Pending)"
 labels:
-  'Cherry Pick: Beta, Cherry Pick: Experimental, Cherry Pick: LTS, Cherry Pick: Stable, Type:
+  'Cherry-pick: Beta, Cherry-pick: Experimental, Cherry-pick: LTS, Cherry-pick: Stable, Type:
   Release'
 assignees: ''
 ---

--- a/.github/ISSUE_TEMPLATE/cherry_pick_template.md
+++ b/.github/ISSUE_TEMPLATE/cherry_pick_template.md
@@ -2,7 +2,8 @@
 name: Cherry-pick template
 about: Used to request a cherry-pick. See go.amp.dev/cherry-picks
 title: "\U0001F338 Cherry-pick request for #<ISSUE_NUMBER> into #<RELEASE_ISSUE> (Pending)"
-labels: 'Cherry Pick: Beta, Cherry Pick: Experimental, Cherry Pick: Stable, Type:
+labels:
+  'Cherry Pick: Beta, Cherry Pick: Experimental, Cherry Pick: LTS, Cherry Pick: Stable, Type:
   Release'
 assignees: ''
 ---
@@ -20,9 +21,9 @@ If you have any questions see the [cherry-pick documentation](https://github.com
 TIP: Cherry-picks into Stable most likely require a cherry-pick into Beta / Experimental too. Otherwise, your fix will be lost when Beta is promoted.
 -->
 
-|       Issue       |       PR       |   Stable?    | Beta / Experimental? | [Release issue](https://github.com/ampproject/amphtml/labels/Type%3A%20Release) |
-| :---------------: | :------------: | :----------: | :------------------: | :-----------------------------------------------------------------------------: |
-| #<_ISSUE_NUMBER_> | #<_PR_NUMBER_> | **<YES/NO>** |     **<YES/NO>**     |                               #<_RELEASE_ISSUE_>                                |
+|       Issue       |       PR       | Beta / Experimental? |   Stable?    |     LTS?     | [Release issue](https://github.com/ampproject/amphtml/labels/Type%3A%20Release) |
+| :---------------: | :------------: | :------------------: | :----------: | :----------: | ------------------------------------------------------------------------------- |
+| #<_ISSUE_NUMBER_> | #<_PR_NUMBER_> |     **<YES/NO>**     | **<YES/NO>** | **<YES/NO>** | #<_RELEASE_ISSUE_>                                                              |
 
 ## Why does this issue meet the [cherry-pick criteria](https://github.com/ampproject/amphtml/blob/master/contributing/release-schedule.md#cherry-pick-criteria)?
 
@@ -37,6 +38,14 @@ CONDITION: Cherry-picking into Stable but _not_ Beta / Experimental. Otherwise, 
 -->
 
 ## Why is a Beta / Experimental cherry-pick not needed?
+
+<_YOUR_REASONS_>
+
+<!--
+CONDITION: Cherry-picking into LTS. Otherwise, delete.
+-->
+
+## Why is an LTS cherry-pick needed?
 
 <_YOUR_REASONS_>
 

--- a/.github/ISSUE_TEMPLATE/cherry_pick_template.md
+++ b/.github/ISSUE_TEMPLATE/cherry_pick_template.md
@@ -12,7 +12,7 @@ assignees: ''
 MUST: Replace *everything* in angle brackets in the title AND body of this issue.
 MUST: Update issue labels to indicate which channels the cherry-pick is going into.
 
-If you have any questions see the [cherry-pick documentation](https://github.com/ampproject/amphtml/blob/master/contributing/release-schedule.md#cherry-picks).
+If you have any questions see the [cherry-pick documentation](https://github.com/ampproject/amphtml/blob/master/contributing/contributing-code.md#Cherry-picks).
 -->
 
 # Cherry-pick request

--- a/.github/ISSUE_TEMPLATE/cherry_pick_template.md
+++ b/.github/ISSUE_TEMPLATE/cherry_pick_template.md
@@ -2,11 +2,22 @@
 name: Cherry-pick template
 about: Used to request a cherry-pick. See go.amp.dev/cherry-picks
 title: "\U0001F338 Cherry-pick request for #<ISSUE_NUMBER> into #<RELEASE_ISSUE> (Pending)"
+labels: 'Cherry Pick: Beta, Cherry Pick: Experimental, Cherry Pick: Stable, Type:
+  Release'
+assignees: ''
+
+---
+
+---
+name: Cherry-pick template
+about: Used to request a cherry-pick. See go.amp.dev/cherry-picks
+title: "\U0001F338 Cherry-pick request for #<ISSUE_NUMBER> into #<RELEASE_ISSUE> (Pending)"
 labels: 'Type: Release'
 ---
 
 <!--
 MUST: Replace *everything* in angle brackets in the title AND body of this issue.
+MUST: Update issue labels to indicate which channels the cherry-pick is going into.
 
 If you have any questions see the [cherry-pick documentation](https://github.com/ampproject/amphtml/blob/master/contributing/release-schedule.md#cherry-picks).
 -->
@@ -14,12 +25,12 @@ If you have any questions see the [cherry-pick documentation](https://github.com
 # Cherry-pick request
 
 <!--
-TIP: Cherry-picks into production most likely require a cherry-pick into RC too. Otherwise, your fix will be lost when the RC is promoted.
+TIP: Cherry-picks into Stable most likely require a cherry-pick into Beta / Experimental too. Otherwise, your fix will be lost when Beta is promoted.
 -->
 
-|       Issue       |       PR       | Production?  |     RC?      | [Release issue](https://github.com/ampproject/amphtml/labels/Type%3A%20Release) |
-| :---------------: | :------------: | :----------: | :----------: | :-----------------------------------------------------------------------------: |
-| #<_ISSUE_NUMBER_> | #<_PR_NUMBER_> | **<YES/NO>** | **<YES/NO>** |                               #<_RELEASE_ISSUE_>                                |
+|       Issue       |       PR       |   Stable?    | Beta / Experimental? | [Release issue](https://github.com/ampproject/amphtml/labels/Type%3A%20Release) |
+| :---------------: | :------------: | :----------: | :------------------: | :-----------------------------------------------------------------------------: |
+| #<_ISSUE_NUMBER_> | #<_PR_NUMBER_> | **<YES/NO>** |     **<YES/NO>**     |                               #<_RELEASE_ISSUE_>                                |
 
 ## Why does this issue meet the [cherry-pick criteria](https://github.com/ampproject/amphtml/blob/master/contributing/release-schedule.md#cherry-pick-criteria)?
 
@@ -30,15 +41,15 @@ TIP: Be specific.
 <_YOUR_REASONS_>
 
 <!--
-CONDITION: Cherry-picking into production but _not_ RC. Otherwise, delete.
+CONDITION: Cherry-picking into Stable but _not_ Beta / Experimental. Otherwise, delete.
 -->
 
-## Why is a RC cherry-pick not needed?
+## Why is a Beta / Experimental cherry-pick not needed?
 
 <_YOUR_REASONS_>
 
 <!--
-MUST: Filling out the mini-PM template is required _after_ the deployment of a production cherry-pick. If this cherry-pick does not include production, the mini-PM section can be deleted.
+MUST: Filling out the mini-PM template is required _after_ the deployment of a stable cherry-pick. If this cherry-pick does not include stable, the mini-PM section can be deleted.
 
 MUST: This issue cannot be closed until the mini-PM is written and its action items are completed.
 -->


### PR DESCRIPTION
This PR updates the template. Labels have already been updated.

![image](https://user-images.githubusercontent.com/26553114/73396704-f11ad900-42af-11ea-93f5-b6118dee016a.png)



Partial fix for #25560