### PR TITLE
pass in esm flag when transfering src to temp dir

### DIFF
--- a/build-system/tasks/dist.js
+++ b/build-system/tasks/dist.js
@@ -104,7 +104,10 @@ async function dist() {
   // own processing). Executed after `compileCss` and `compileJison` so their
   // results can be copied too.
   if (!argv.single_pass) {
-    transferSrcsToTempDir({isForTesting: argv.fortesting});
+    transferSrcsToTempDir({
+      isForTesting: argv.fortesting,
+      isEsmBuild: argv.esm,
+    });
   }
 
   await copyCss();


### PR DESCRIPTION
seems we removed the flag recently. i'll follow this up by running integration tests against `--esm` in a follow up PR