### PR TITLE
🖍 [amp-story-player] Adds css for pre-fetch experience

### DIFF
--- a/build-system/tasks/css.js
+++ b/build-system/tasks/css.js
@@ -57,7 +57,7 @@ const cssEntryPoints = [
   {
     path: 'amp-story-player.css',
     outJs: 'amp-story-player.css.js',
-    outCss: 'amp-story-player-out.css',
+    outCss: 'amp-story-player-styles.css',
   },
 ];
 

--- a/build-system/tasks/css.js
+++ b/build-system/tasks/css.js
@@ -57,7 +57,7 @@ const cssEntryPoints = [
   {
     path: 'amp-story-player.css',
     outJs: 'amp-story-player.css.js',
-    outCss: 'amp-story-player-styles.css',
+    outCss: 'amp-story-player-v0.css',
   },
 ];
 

--- a/build-system/tasks/css.js
+++ b/build-system/tasks/css.js
@@ -54,6 +54,11 @@ const cssEntryPoints = [
     // than the JS file to avoid loading CSS as JS
     outCss: 'video-autoplay-out.css',
   },
+  {
+    path: 'amp-story-player.css',
+    outJs: 'amp-story-player.css.js',
+    outCss: 'amp-story-player-out.css',
+  },
 ];
 
 /**

--- a/css/amp-story-player.css
+++ b/css/amp-story-player.css
@@ -1,31 +1,27 @@
 amp-story-player {
   background: var(--story-player-poster, lightgrey);
-  width: 405px;
-  height: 720px;
+  width: 320px;
+  height: 480px;
 }
 
 amp-story-player::after {
   content: " ";
   position: absolute;
-  top: calc(50% - 38px);
-  left: calc(50% - 38px);
+  top: calc(50% - 35px);
+  left: calc(50% - 35px);
   width: 64px;
   height: 64px;
   border-radius: 50%;
   border: 6px solid #fff;
   border-color: #fff transparent #fff transparent;
   filter: drop-shadow(0px 1px 3px rgba(0, 0, 0, 0.25));
-  animation-name: story-player-spinner;
+  animation-name: i-amphtml-story-player-spinner;
   animation-duration: 4400ms;
   animation-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
   animation-iteration-count: infinite;
 }
 
-.i-amphtml-story-player-loaded::after {
-  visibility: hidden;
-}
-
-@keyframes story-player-spinner {
+@keyframes i-amphtml-story-player-spinner {
   12.5% { transform: rotate(135deg) }
   25%   { transform: rotate(270deg) }
   37.5% { transform: rotate(405deg) }
@@ -34,4 +30,8 @@ amp-story-player::after {
   75%   { transform: rotate(810deg) }
   87.5% { transform: rotate(945deg) }
   to    { transform: rotate(1080deg) }
+}
+
+.i-amphtml-story-player-loaded::after {
+  visibility: hidden;
 }

--- a/css/amp-story-player.css
+++ b/css/amp-story-player.css
@@ -1,14 +1,24 @@
 amp-story-player {
+  width: 360px;
+  height: 600px;
+  position: relative;
+  display: block;
+}
+
+amp-story-player a:first-of-type {
+  width: 100%;
+  height: 100%;
   background: var(--story-player-poster, lightgrey);
-  width: 320px;
-  height: 480px;
+  background-size: 100% 100%;
+  display: block;
 }
 
 amp-story-player::after {
   content: " ";
   position: absolute;
-  top: calc(50% - 35px);
-  left: calc(50% - 35px);
+  box-sizing: border-box;
+  top: calc(50% - 32px);
+  left: calc(50% - 32px);
   width: 64px;
   height: 64px;
   border-radius: 50%;

--- a/css/amp-story-player.css
+++ b/css/amp-story-player.css
@@ -1,0 +1,37 @@
+amp-story-player {
+  background: var(--story-player-poster, lightgrey);
+  width: 405px;
+  height: 720px;
+}
+
+amp-story-player::after {
+  content: " ";
+  position: absolute;
+  top: calc(50% - 38px);
+  left: calc(50% - 38px);
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  border: 6px solid #fff;
+  border-color: #fff transparent #fff transparent;
+  filter: drop-shadow(0px 1px 3px rgba(0, 0, 0, 0.25));
+  animation-name: story-player-spinner;
+  animation-duration: 4400ms;
+  animation-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  animation-iteration-count: infinite;
+}
+
+.i-amphtml-story-player-loaded::after {
+  visibility: hidden;
+}
+
+@keyframes story-player-spinner {
+  12.5% { transform: rotate(135deg) }
+  25%   { transform: rotate(270deg) }
+  37.5% { transform: rotate(405deg) }
+  50%   { transform: rotate(540deg) }
+  62.5% { transform: rotate(675deg) }
+  75%   { transform: rotate(810deg) }
+  87.5% { transform: rotate(945deg) }
+  to    { transform: rotate(1080deg) }
+}

--- a/css/amp-story-player.css
+++ b/css/amp-story-player.css
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 amp-story-player {
   width: 360px;
   height: 600px;

--- a/examples/amp-story/player.html
+++ b/examples/amp-story/player.html
@@ -2,22 +2,13 @@
   <head>
     <title>Story Player (Non-AMP)</title>
     <script async src="../../dist/amp-story-player.js"></script>
-    <link href="../../build/css/amp-story-player-styles.css" rel='stylesheet' type='text/css'>
+    <link href="../../build/css/amp-story-player-v0.css" rel='stylesheet' type='text/css'>
     <style page>
       body {
         font-family: sans-serif;
       }
-      amp-story-player {
-        position: absolute;
-        top: 3000px;
-      }
     </style>
     <style injected>
-      .amp-story-player {
-        width: 320px;
-        height: 480px;
-      }
-
       .story-player-iframe {
         background-size: cover;
         display: block;
@@ -44,9 +35,11 @@
   </head>
   <body>
     <h1>This is a NON-AMP page that embeds a story below:</h1>
-    <amp-story-player style="width: 320px; height: 480px; --story-player-poster: url('https://www-washingtonpost-com.cdn.ampproject.org/i/s/www.washingtonpost.com/graphics/2019/lifestyle/travel/amp-stories/a-locals-guide-to-what-to-eat-and-do-in-new-york-city/img/promo3x4.jpg');">
-        <a href="https://www-washingtonpost-com.cdn.ampproject.org/v/s/www.washingtonpost.com/graphics/2019/lifestyle/travel/amp-stories/a-locals-guide-to-what-to-eat-and-do-in-new-york-city/"
-            data-poster-portrait-src="https://www-washingtonpost-com.cdn.ampproject.org/v/s/www.washingtonpost.com/graphics/2019/lifestyle/travel/amp-stories/a-locals-guide-to-what-to-eat-and-do-in-new-york-city/img/promo3x4.jpg"
+    <div>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras viverra neque ex, sit amet varius sem maximus sed. Suspendisse potenti. Donec erat purus, sagittis sit amet tincidunt ut, maximus sit amet massa. Maecenas venenatis fringilla dui vitae vestibulum. Fusce imperdiet euismod lobortis. Nullam sagittis nunc at tristique mattis. In sodales consectetur mollis. Maecenas sollicitudin, ex vel tempor rutrum, turpis eros interdum enim, sit amet volutpat tortor dolor at ipsum. Nam posuere velit vel urna vulputate interdum. Aenean eu vulputate lorem. Praesent nec nunc sodales, egestas orci sed, hendrerit mauris. Ut blandit turpis non erat sagittis, quis fermentum odio feugiat.</div>
+    <amp-story-player style="width: 360px; height: 600px;">
+        <a
+        href="https://www-washingtonpost-com.cdn.ampproject.org/v/s/www.washingtonpost.com/graphics/2019/lifestyle/travel/amp-stories/a-locals-guide-to-what-to-eat-and-do-in-new-york-city/"
+            style="--story-player-poster: url('https://www-washingtonpost-com.cdn.ampproject.org/i/s/www.washingtonpost.com/graphics/2019/lifestyle/travel/amp-stories/a-locals-guide-to-what-to-eat-and-do-in-new-york-city/img/promo3x4.jpg');"
             class="story">
           <span class="title">A local’s guide to what to eat and do in New York City</span>
         </a>
@@ -66,5 +59,6 @@
           <span class="title">A local’s guide to what to eat and do in Rome</span>
         </a>
     </amp-story-player>
+    <div>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras viverra neque ex, sit amet varius sem maximus sed. Suspendisse potenti. Donec erat purus, sagittis sit amet tincidunt ut, maximus sit amet massa. Maecenas venenatis fringilla dui vitae vestibulum. Fusce imperdiet euismod lobortis. Nullam sagittis nunc at tristique mattis. In sodales consectetur mollis. Maecenas sollicitudin, ex vel tempor rutrum, turpis eros interdum enim, sit amet volutpat tortor dolor at ipsum. Nam posuere velit vel urna vulputate interdum. Aenean eu vulputate lorem. Praesent nec nunc sodales, egestas orci sed, hendrerit mauris. Ut blandit turpis non erat sagittis, quis fermentum odio feugiat.</div>
   </body>
 </html>

--- a/examples/amp-story/player.html
+++ b/examples/amp-story/player.html
@@ -2,7 +2,7 @@
   <head>
     <title>Story Player (Non-AMP)</title>
     <script async src="../../dist/amp-story-player.js"></script>
-    <link href="../../build/css/amp-story-player-out.css" rel='stylesheet' type='text/css'>
+    <link href="../../build/css/amp-story-player-styles.css" rel='stylesheet' type='text/css'>
     <style page>
       body {
         font-family: sans-serif;
@@ -14,8 +14,8 @@
     </style>
     <style injected>
       .amp-story-player {
-        width: 405px;
-        height: 720px;
+        width: 320px;
+        height: 480px;
       }
 
       .story-player-iframe {
@@ -44,7 +44,7 @@
   </head>
   <body>
     <h1>This is a NON-AMP page that embeds a story below:</h1>
-    <amp-story-player style="width: 405px; height: 720px; --story-player-poster: url('https://www-washingtonpost-com.cdn.ampproject.org/i/s/www.washingtonpost.com/graphics/2019/lifestyle/travel/amp-stories/a-locals-guide-to-what-to-eat-and-do-in-new-york-city/img/promo3x4.jpg');">
+    <amp-story-player style="width: 320px; height: 480px; --story-player-poster: url('https://www-washingtonpost-com.cdn.ampproject.org/i/s/www.washingtonpost.com/graphics/2019/lifestyle/travel/amp-stories/a-locals-guide-to-what-to-eat-and-do-in-new-york-city/img/promo3x4.jpg');">
         <a href="https://www-washingtonpost-com.cdn.ampproject.org/v/s/www.washingtonpost.com/graphics/2019/lifestyle/travel/amp-stories/a-locals-guide-to-what-to-eat-and-do-in-new-york-city/"
             data-poster-portrait-src="https://www-washingtonpost-com.cdn.ampproject.org/v/s/www.washingtonpost.com/graphics/2019/lifestyle/travel/amp-stories/a-locals-guide-to-what-to-eat-and-do-in-new-york-city/img/promo3x4.jpg"
             class="story">

--- a/examples/amp-story/player.html
+++ b/examples/amp-story/player.html
@@ -2,6 +2,7 @@
   <head>
     <title>Story Player (Non-AMP)</title>
     <script async src="../../dist/amp-story-player.js"></script>
+    <link href="../../build/css/amp-story-player-out.css" rel='stylesheet' type='text/css'>
     <style page>
       body {
         font-family: sans-serif;
@@ -43,7 +44,7 @@
   </head>
   <body>
     <h1>This is a NON-AMP page that embeds a story below:</h1>
-    <amp-story-player>
+    <amp-story-player style="width: 405px; height: 720px; --story-player-poster: url('https://www-washingtonpost-com.cdn.ampproject.org/i/s/www.washingtonpost.com/graphics/2019/lifestyle/travel/amp-stories/a-locals-guide-to-what-to-eat-and-do-in-new-york-city/img/promo3x4.jpg');">
         <a href="https://www-washingtonpost-com.cdn.ampproject.org/v/s/www.washingtonpost.com/graphics/2019/lifestyle/travel/amp-stories/a-locals-guide-to-what-to-eat-and-do-in-new-york-city/"
             data-poster-portrait-src="https://www-washingtonpost-com.cdn.ampproject.org/v/s/www.washingtonpost.com/graphics/2019/lifestyle/travel/amp-stories/a-locals-guide-to-what-to-eat-and-do-in-new-york-city/img/promo3x4.jpg"
             class="story">

--- a/src/amp-story-player.js
+++ b/src/amp-story-player.js
@@ -36,7 +36,7 @@ const LoadStateClass = {
 
 /** @const {string} */
 const CSS = `
-  :host { all: initial; display: block; border-radius: 0 !important; width: 405px; height: 720px; overflow: auto; }
+  :host { all: initial; display: block; border-radius: 0 !important; width: 320px; height: 480px; overflow: auto; }
   .story-player-iframe { height: 100%; width: 100%; flex: 0 0 100%; border: 0; opacity: 0; transition: opacity 500ms ease; }
   main { display: flex; flex-direction: row; height: 100%; }
   .i-amphtml-story-player-loaded iframe { opacity: 1; }`;

--- a/src/amp-story-player.js
+++ b/src/amp-story-player.js
@@ -36,7 +36,7 @@ const LoadStateClass = {
 
 /** @const {string} */
 const CSS = `
-  :host { all: initial; display: block; border-radius: 0 !important; width: 320px; height: 480px; overflow: auto; }
+  :host { all: initial; display: block; border-radius: 0 !important; width: 360px; height: 600px; overflow: auto; }
   .story-player-iframe { height: 100%; width: 100%; flex: 0 0 100%; border: 0; opacity: 0; transition: opacity 500ms ease; }
   main { display: flex; flex-direction: row; height: 100%; }
   .i-amphtml-story-player-loaded iframe { opacity: 1; }`;


### PR DESCRIPTION
* Sets up basic css for the `amp-story-player` which will set a placeholder specified by the publisher (`--story-player-poster`).
* In the case no poster is specified, falls back to a spinner.
* Finally hides the above styles when the story is loaded.


Partial for #24539 #26308
