### PR TITLE
♻️ peformance-impl: simplify tick()

### DIFF
--- a/src/service/performance-impl.js
+++ b/src/service/performance-impl.js
@@ -719,7 +719,7 @@ export class Performance {
     let storedVal;
 
     // Absolute value case (not delta).
-    if (typeof opt_delta === 'undefined' || opt_delta === null) {
+    if (opt_delta == undefined) {
       // Marking only makes sense for non-deltas.
       this.mark(label);
       const now = this.win.Date.now();

--- a/src/service/performance-impl.js
+++ b/src/service/performance-impl.js
@@ -715,7 +715,7 @@ export class Performance {
    *     this directly.
    */
   tick(label, opt_delta) {
-    let data;
+    const data = dict({'label': label});
     let storedVal;
 
     // Absolute value case (not delta).
@@ -723,11 +723,10 @@ export class Performance {
       // Marking only makes sense for non-deltas.
       this.mark(label);
       const now = this.win.Date.now();
-      data = dict({'label': label, 'value': now});
+      data['value'] = now;
       storedVal = now - this.initTime_;
     } else {
-      data = dict({'label': label, 'delta': Math.max(opt_delta, 0)});
-      storedVal = Math.max(opt_delta, 0);
+      data['delta'] = storedVal = Math.max(opt_delta, 0);
     }
 
     if (this.isMessagingReady_ && this.isPerformanceTrackingOn_) {

--- a/src/service/performance-impl.js
+++ b/src/service/performance-impl.js
@@ -715,30 +715,27 @@ export class Performance {
    *     this directly.
    */
   tick(label, opt_delta) {
-    const value = opt_delta == undefined ? this.win.Date.now() : undefined;
+    let data;
+    let storedVal;
 
-    const data = dict({
-      'label': label,
-      'value': value,
-      // Delta can negative, but will always be changed to 0.
-      'delta': opt_delta != null ? Math.max(opt_delta, 0) : undefined,
-    });
+    // Absolute value case (not delta).
+    if (typeof opt_delta === 'undefined' || opt_delta === null) {
+      // Marking only makes sense for non-deltas.
+      this.mark(label);
+      const now = this.win.Date.now();
+      data = dict({'label': label, 'value': now});
+      storedVal = now - this.initTime_;
+    } else {
+      data = dict({'label': label, 'delta': Math.max(opt_delta, 0)});
+      storedVal = Math.max(opt_delta, 0);
+    }
+
     if (this.isMessagingReady_ && this.isPerformanceTrackingOn_) {
       this.viewer_.sendMessage('tick', data);
     } else {
       this.queueTick_(data);
     }
-    // Mark the event on the browser timeline, but only if there was
-    // no delta (in which case it would not make sense).
-    if (arguments.length == 1) {
-      this.mark(label);
-    }
 
-    // Store certain page visibility metrics to be exposed as analytics
-    // variables.
-    const storedVal = Math.round(
-      opt_delta != null ? Math.max(opt_delta, 0) : value - this.initTime_
-    );
     switch (label) {
       case 'fcp':
         this.fcpDeferred_.resolve(storedVal);


### PR DESCRIPTION
- places all of `tick()`'s branched logic in a single place near the top, instead of being spread throughout.
- only sends `value` or `delta`, instead of both.