### PR TITLE
♻️ test-performance.js: differentiate between relative and absolute time.

### DIFF
--- a/test/unit/test-performance.js
+++ b/test/unit/test-performance.js
@@ -338,7 +338,7 @@ describes.realWin('performance', {amp: true}, env => {
 
         it('should calculate after visible', () => {
           perf.coreServicesAvailable();
-          firstVisibleTime = 105;
+          firstVisibleTime = timeOrigin + 5;
 
           clock.tick(10);
           perf.tickSinceVisible('test');
@@ -349,7 +349,7 @@ describes.realWin('performance', {amp: true}, env => {
 
         it('should be zero after visible but for earlier event', () => {
           perf.coreServicesAvailable();
-          firstVisibleTime = 105;
+          firstVisibleTime = timeOrigin + 5;
 
           // An earlier event, since event time (4) is less than visible time (5).
           clock.tick(4);

--- a/test/unit/test-performance.js
+++ b/test/unit/test-performance.js
@@ -28,7 +28,7 @@ describes.realWin('performance', {amp: true}, env => {
   let clock;
   let win;
   let ampdoc;
-  let timeOrigin = 100;
+  const timeOrigin = 100;
 
   beforeEach(() => {
     win = env.win;
@@ -108,18 +108,15 @@ describes.realWin('performance', {amp: true}, env => {
       expect(perf.events_.length).to.equal(50);
     });
 
-    it(
-      'should add default absolute start time on the ' + 'queued tick event',
-      () => {
-        clock.tick(150);
-        perf.tick('start0');
+    it('should add default absolute start time on the queued tick event', () => {
+      clock.tick(150);
+      perf.tick('start0');
 
-        expect(perf.events_[0]).to.be.jsonEqual({
-          label: 'start0',
-          value: timeOrigin + 150,
-        });
-      }
-    );
+      expect(perf.events_[0]).to.be.jsonEqual({
+        label: 'start0',
+        value: timeOrigin + 150,
+      });
+    });
 
     it('should drop events in the head of the queue', () => {
       const tickTime = 100;

--- a/test/unit/test-performance.js
+++ b/test/unit/test-performance.js
@@ -28,6 +28,7 @@ describes.realWin('performance', {amp: true}, env => {
   let clock;
   let win;
   let ampdoc;
+  let timeOrigin = 100;
 
   beforeEach(() => {
     win = env.win;
@@ -35,6 +36,8 @@ describes.realWin('performance', {amp: true}, env => {
     clock = lolex.install({
       target: win,
       toFake: ['Date', 'setTimeout', 'clearTimeout'],
+      // set initial Date.now to 100, so that we can differentiate between time relative to epoch and relative to process start (value vs. delta).
+      now: timeOrigin,
     });
     installPlatformService(env.win);
     installPerformanceService(env.win);
@@ -106,15 +109,14 @@ describes.realWin('performance', {amp: true}, env => {
     });
 
     it(
-      'should add default optional relative start time on the ' +
-        'queued tick event',
+      'should add default absolute start time on the ' + 'queued tick event',
       () => {
         clock.tick(150);
         perf.tick('start0');
 
         expect(perf.events_[0]).to.be.jsonEqual({
           label: 'start0',
-          value: 150,
+          value: timeOrigin + 150,
         });
       }
     );
@@ -132,7 +134,7 @@ describes.realWin('performance', {amp: true}, env => {
       expect(perf.events_.length).to.equal(50);
       expect(perf.events_[0]).to.be.jsonEqual({
         label: 'start0',
-        value: tickTime,
+        value: timeOrigin + tickTime,
       });
 
       clock.tick(1);
@@ -140,11 +142,11 @@ describes.realWin('performance', {amp: true}, env => {
 
       expect(perf.events_[0]).to.be.jsonEqual({
         label: 'start1',
-        value: tickTime,
+        value: timeOrigin + tickTime,
       });
       expect(perf.events_[49]).to.be.jsonEqual({
         label: 'start50',
-        value: tickTime + 1,
+        value: timeOrigin + tickTime + 1,
       });
     });
   });
@@ -339,7 +341,7 @@ describes.realWin('performance', {amp: true}, env => {
 
         it('should calculate after visible', () => {
           perf.coreServicesAvailable();
-          firstVisibleTime = 5;
+          firstVisibleTime = 105;
 
           clock.tick(10);
           perf.tickSinceVisible('test');
@@ -350,7 +352,7 @@ describes.realWin('performance', {amp: true}, env => {
 
         it('should be zero after visible but for earlier event', () => {
           perf.coreServicesAvailable();
-          firstVisibleTime = 5;
+          firstVisibleTime = 105;
 
           // An earlier event, since event time (4) is less than visible time (5).
           clock.tick(4);
@@ -439,13 +441,13 @@ describes.realWin('performance', {amp: true}, env => {
               viewerSendMessageStub.withArgs('tick').getCall(0).args[1]
             ).to.be.jsonEqual({
               label: 'start0',
-              value: 0,
+              value: timeOrigin,
             });
             expect(
               viewerSendMessageStub.withArgs('tick').getCall(1).args[1]
             ).to.be.jsonEqual({
               label: 'start1',
-              value: 1,
+              value: timeOrigin + 1,
             });
             expect(
               viewerSendMessageStub.withArgs('tick').getCall(4).args[1]
@@ -480,7 +482,7 @@ describes.realWin('performance', {amp: true}, env => {
               ).args[0][1]
             ).to.be.jsonEqual({
               label: 'start0',
-              value: 100,
+              value: timeOrigin + 100,
             });
             expect(
               viewerSendMessageStub.withArgs(


### PR DESCRIPTION
**summary**
- Configured `lolex` to simulate `Date.now()` to begin at 100 instead of at 0. When it was 0, it became impossible to test the difference between relative and absolute time (value vs. delta)
- Rewrite a test that was checking for relative time to actually check for absolute time. This was either a bug in the test or is currently a bug in our code. @erwinmombay, can you help me figure out the intention of the test named: "should add default optional relative start time on the"