### PR TITLE
🖍 Use auto instead of 100% as width of story description.

### DIFF
--- a/extensions/amp-story/1.0/amp-story-vertical.css
+++ b/extensions/amp-story/1.0/amp-story-vertical.css
@@ -69,6 +69,6 @@ amp-story[i-amphtml-vertical].i-amphtml-element amp-story-page.i-amphtml-element
   display: block !important;
   font-size: 0.8rem !important;
   padding: 32px !important;
-  width: 100% !important;
+  width: auto !important;
   z-index: 9999999 !important;
 }


### PR DESCRIPTION
Otherwise the padding leads to the text going over the edge of the right side of the screen.

Fixes #26528
