### PR TITLE
🐛amp-autocomplete: preserve existing query parameters. Fixes #26522

### DIFF
--- a/extensions/amp-autocomplete/0.1/amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/amp-autocomplete.js
@@ -28,6 +28,7 @@ import {
   batchFetchJsonFor,
   requestForBatchFetch,
 } from '../../../src/batched-json';
+import {addParamToUrl} from '../../../src/url';
 import {createCustomEvent} from '../../../src/event-helper';
 import {dev, user, userAssert} from '../../../src/log';
 import {dict, hasOwn, map, ownProperty} from '../../../src/utils/object';
@@ -439,9 +440,7 @@ export class AmpAutocomplete extends AMP.BaseElement {
    * @private
    */
   generateSrc_(opt_query = '') {
-    const encodedQueryKey = encodeURIComponent(this.queryKey_);
-    const encodedQuery = encodeURIComponent(opt_query);
-    return `${this.srcBase_}?${encodedQueryKey}=${encodedQuery}`;
+    return addParamToUrl(this.srcBase_, this.queryKey_, opt_query);
   }
 
   /**

--- a/extensions/amp-autocomplete/0.1/test/test-amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/test/test-amp-autocomplete.js
@@ -995,5 +995,18 @@ describes.realWin(
         );
       });
     });
+
+    it('should preserve existing query parameters when generating src values from "query" attribute', () => {
+      return impl.layoutCallback().then(() => {
+        impl.queryKey_ = 'q';
+        impl.srcBase_ = 'https://www.data.com/?param=1';
+        expect(impl.generateSrc_('')).to.equal(
+          'https://www.data.com/?param=1&q='
+        );
+        expect(impl.generateSrc_('abc')).to.equal(
+          'https://www.data.com/?param=1&q=abc'
+        );
+      });
+    });
   }
 );


### PR DESCRIPTION
Currently, if the `query` attribute is specified, existing query parameters in the
source url are replaced with the specified value.

For example, if the `src` is set to `https://example.com/?param=1` and the `query` attribute is set to `q`, then typing `abc` in the input field will attempt to load the suggestions from

```
https://example.com/?q=abc
```

instead of

```
https://example.com/?param=1&q=abc
```

This PR, if merged, will preserve any existing parameters and append the the query value instead of replacing it.

Fixes #26522
Ping: @caroqliu 
<!--
# Instructions:

- Pick a meaningful title for your pull request. (Use sentence case.)
  - Prefix the title with an emoji to identify what is being done. (Copy-paste the emoji from the list below.)
  - Do not overuse punctuation in the title (like `(chore):`).
  - If it is helpful, use a simple prefix (like `ProjectX: Implement some feature`).
- Enter a succinct description that says why the PR is necessary, and what it does.
  - Mention the GitHub issue that is being addressed by the pull request.
  - The keywords `Fixes`, `Closes`, or `Resolves` followed the issue number will automatically close the issue.

> NOTE: All non-trivial changes (like introducing new features or components) should have an associated issue or reference an I2I (intent-to-implement: go.amp.dev/i2i). Please read through the contribution process (go.amp.dev/contributing/code) for more information.

# Example of a good description:

- Implement aspect X
- Leave out feature Y because of A
- Improve performance by B
- Improve accessibility by C

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Reverting a previous change
♻️ Refactoring
🚮 Deleting code
-->
