### PR TITLE
Fix sharing layout when the label is two lines long.

### DIFF
--- a/extensions/amp-story/1.0/amp-story-share-menu.css
+++ b/extensions/amp-story/1.0/amp-story-share-menu.css
@@ -72,6 +72,10 @@
   display: none !important;
 }
 
+.i-amphtml-story-share-menu .i-amphtml-story-share-item {
+  height: 72px !important;
+}
+
 [desktop].i-amphtml-story-share-menu {
   display: flex !important;
   align-items: center !important;
@@ -108,7 +112,8 @@
   text-align: center !important;
 }
 
-[desktop] .i-amphtml-story-share-item {
+[desktop].i-amphtml-story-share-menu .i-amphtml-story-share-item {
   padding: 0 !important;
+  height: 66px !important;
   margin: 12px !important;
 }

--- a/extensions/amp-story/1.0/amp-story-share.css
+++ b/extensions/amp-story/1.0/amp-story-share.css
@@ -155,15 +155,15 @@
 
 .i-amphtml-story-share-icon .i-amphtml-story-share-label {
   position: absolute !important;
-  bottom: -18px !important;
+  top: 48px !important;
   left: 0 !important;
   width: 100% !important;
   color: rgba(0, 0, 0, 0.87) !important;
-  padding-top: 7px !important; /* Making sure the whole icon is clickable. */
+  padding-top: 5px !important; /* Making sure the whole icon is clickable. */
   text-transform: capitalize !important;
   font-family: 'Roboto', sans-serif !important;
   font-weight: 400 !important;
-  line-height: 11px !important;
+  line-height: 13px !important;
   font-size: 11px !important;
   text-align: center !important;
 }


### PR DESCRIPTION
Fixing the sharing layout to display labels that are up to 2 lines on mobile, desktop, and within the bookend.

Fixes #26602