### PR TITLE
Fix shadow test state pollution

### DIFF
--- a/test/unit/test-shadow-embed.js
+++ b/test/unit/test-shadow-embed.js
@@ -311,7 +311,6 @@ describes.sandboxed('shadow-embed', {}, () => {
     let isFirefox;
 
     beforeEach(() => {
-      setShadowDomStreamingSupportedForTesting(undefined);
       createHTMLDocumentSpy = window.sandbox.spy();
       isFirefox = false;
       const platform = {
@@ -336,6 +335,10 @@ describes.sandboxed('shadow-embed', {}, () => {
           'vsync': {obj: {}},
         },
       };
+    });
+
+    afterEach(() => {
+      setShadowDomStreamingSupportedForTesting(undefined);
     });
 
     it('should resolve to streamer', () => {


### PR DESCRIPTION
I was debugging test failures in #26447 and found that if I ran `test-runtime.js` directly it would work, but if I ran `test-shadow-embed.js` with it, it would always fail :(

Turns out in some of our tests, we manually set the streaming supported flag through `setShadowDomStreamingSupportedForTesting`. This value gets cached here https://github.com/ampproject/amphtml/blob/eccff2da8522b573c7c0e7e369d1ec7c03e8b085/src/shadow-embed.js#L328-L331

These tests would reset this flag in a beforeEach block, but this would not clean up this state for the last test in the section, causing hard to track test failures.

Moves the resetting of this state to an afterEach block instead, which seems to solve the problem.
