### PR TITLE
ampdoc: Add get/setMetaByName methods

### DIFF
--- a/src/multidoc-manager.js
+++ b/src/multidoc-manager.js
@@ -358,6 +358,9 @@ export class MultidocManager {
               // Ignore.
             } else if (name == 'viewport') {
               // Ignore.
+            } else if (name) {
+              // Store meta name/content pairs.
+              ampdoc.setMetaByName(name, n.getAttribute('content') || '');
             } else {
               // TODO(dvoytenko): copy other meta tags.
               dev().warn(TAG, 'meta ignored: ', n);

--- a/src/service/ampdoc-impl.js
+++ b/src/service/ampdoc-impl.js
@@ -941,11 +941,7 @@ export class AmpDocShadow extends AmpDoc {
     return this.meta_[name] !== undefined ? this.meta_[name] : null;
   }
 
-  /**
-   * Stores the value of an ampdoc's meta tag content for a given name.
-   * @param {string} name
-   * @param {string} content
-   */
+  /** @override */
   setMetaByName(name, content) {
     if (!name) {
       throw new Error('Attempted to store invalid meta name/content pair');

--- a/src/service/ampdoc-impl.js
+++ b/src/service/ampdoc-impl.js
@@ -24,6 +24,7 @@ import {
   removeDocumentVisibilityChangeListener,
 } from '../utils/document-visibility';
 import {dev, devAssert} from '../log';
+import {findIndex} from '../utils/array';
 import {getParentWindowFrameElement, registerServiceBuilder} from '../service';
 import {getShadowRootNode} from '../shadow-embed';
 import {isDocumentReady, whenDocumentReady} from '../document-ready';
@@ -31,6 +32,7 @@ import {isInAmpdocFieExperiment} from '../ampdoc-fie';
 import {map} from '../utils/object';
 import {parseQueryString} from '../url';
 import {rootNodeFor, waitForBodyOpenPromise} from '../dom';
+import {toArray} from '../types';
 
 /** @const {string} */
 const AMPDOC_PROP = '__AMPDOC';
@@ -317,6 +319,9 @@ export class AmpDoc {
     /** @private {!Object<string, string>} */
     this.params_ = (opt_options && opt_options.params) || map();
 
+    /** @protected {!Object<string, string>} */
+    this.meta_ = (opt_options && opt_options.meta) || map();
+
     /** @private @const {!Array<string>} */
     this.declaredExtensions_ = [];
 
@@ -412,6 +417,25 @@ export class AmpDoc {
   getParam(name) {
     const v = this.params_[name];
     return v == null ? null : v;
+  }
+
+  /**
+   * Returns the value of an ampdoc's meta tag content for a given name, or
+   * `null` if the meta tag does not exist. To be implemented by subclasses.
+   * @param {string} unusedName
+   * @return {?string}
+   */
+  getMetaByName(unusedName) {
+    return /** @type {?} */ (devAssert(null, 'not implemented'));
+  }
+
+  /**
+   * Stores the value of an ampdoc's meta tag content for a given name.
+   * @param {string} unusedName
+   * @param {string} unusedContent
+   */
+  setMetaByName(unusedName, unusedContent) {
+    devAssert(null, 'not implemented');
   }
 
   /**
@@ -756,6 +780,49 @@ export class AmpDocSingle extends AmpDoc {
   whenReady() {
     return this.readyPromise_;
   }
+
+  /** @override */
+  getMetaByName(name) {
+    if (!name) {
+      return null;
+    }
+
+    // 4.2.5.1 Standard metadata names
+    //   Names are case-insensitive, and must be compared in an ASCII case-
+    //   insensitive manner.
+    // https://html.spec.whatwg.org/multipage/semantics.html#standard-metadata-names
+    //
+    // Rules about case sensitivity and multiple meta tags with the same name
+    // are not as strict for non-standard metadata names. Adopt the conventions
+    // used by PHP get_meta_tags():
+    //   1. Special characters in the value of the name property are substituted
+    //      with '_', the rest is converted to lower case.
+    //   2. If two meta tags have the same name, only the last one is returned.
+    // https://www.php.net/manual/en/function.get-meta-tags.php
+    //
+    // Proper unicode support if browser can handle it
+    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/unicode
+    const lowerName = name.toLowerCase();
+    const metaEls = toArray(
+      dev()
+        .assertElement(this.win.document.head)
+        .querySelectorAll(`meta[name]`)
+    );
+    const metaElIndex = findIndex(metaEls, el => {
+      const mName = el.getAttribute('name');
+      let sanitizedName;
+      try {
+        sanitizedName = mName.replace(/[^\x00-\x7F]/gu, '_').toLowerCase();
+      } catch (ex) {
+        sanitizedName = mName.replace(/[^\x00-\x7F]/g, '_').toLowerCase();
+      }
+      return sanitizedName === lowerName;
+    });
+
+    return metaElIndex >= 0
+      ? metaEls[metaElIndex].getAttribute('content') || ''
+      : null;
+  }
 }
 
 /**
@@ -866,6 +933,47 @@ export class AmpDocShadow extends AmpDoc {
   /** @override */
   whenReady() {
     return this.readyPromise_;
+  }
+
+  /** @override */
+  getMetaByName(name) {
+    name = name.toLowerCase();
+    return this.meta_[name] !== undefined ? this.meta_[name] : null;
+  }
+
+  /**
+   * Stores the value of an ampdoc's meta tag content for a given name.
+   * @param {string} name
+   * @param {string} content
+   */
+  setMetaByName(name, content) {
+    if (!name) {
+      throw new Error('Attempted to store invalid meta name/content pair');
+    }
+
+    // 4.2.5.1 Standard metadata names
+    //   Names are case-insensitive, and must be compared in an ASCII case-
+    //   insensitive manner.
+    // https://html.spec.whatwg.org/multipage/semantics.html#standard-metadata-names
+    //
+    // Rules about case sensitivity and multiple meta tags with the same name
+    // are not as strict for non-standard metadata names. Adopt the conventions
+    // used by PHP get_meta_tags():
+    //   1. Special characters in the value of the name property are substituted
+    //      with '_', the rest is converted to lower case.
+    //   2. If two meta tags have the same name, only the last one is returned.
+    // https://www.php.net/manual/en/function.get-meta-tags.php
+    //
+    // Proper unicode support if browser can handle it
+    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/unicode
+    let sanitizedName;
+    try {
+      sanitizedName = name.replace(/[^\x00-\x7F]/gu, '_').toLowerCase();
+    } catch (ex) {
+      sanitizedName = name.replace(/[^\x00-\x7F]/g, '_').toLowerCase();
+    }
+
+    this.meta_[sanitizedName] = content;
   }
 }
 

--- a/test/unit/test-ampdoc.js
+++ b/test/unit/test-ampdoc.js
@@ -121,6 +121,14 @@ describes.sandboxed('AmpDocService', {}, () => {
       expect(service.getAmpDoc(div)).to.equal(service.getSingleDoc());
     });
 
+    it('should return meta content values', () => {
+      const meta = document.createElement('meta');
+      meta.setAttribute('name', 'abc');
+      meta.setAttribute('content', '123');
+      document.head.appendChild(meta);
+      expect(service.getAmpDoc(meta).getMetaByName('abc')).to.equal('123');
+    });
+
     // For example, <amp-next-page> creates shadow documents in single-doc
     // mode.
     describe('shadow documents', () => {

--- a/test/unit/test-runtime.js
+++ b/test/unit/test-runtime.js
@@ -1351,7 +1351,6 @@ describes.realWin(
         metaEl.setAttribute('content', '123');
         importDoc.head.appendChild(metaEl);
         const amp = win.AMP.attachShadowDoc(hostElement, importDoc, docUrl);
-        
         expect(amp.ampdoc.getMetaByName('abc')).to.equal('123');
       });
 

--- a/test/unit/test-runtime.js
+++ b/test/unit/test-runtime.js
@@ -1346,14 +1346,12 @@ describes.realWin(
       });
 
       it('should import meta content', () => {
-        const name = 'abc';
-        const content = '123';
         const metaEl = win.document.createElement('meta');
-        metaEl.setAttribute('name', name);
-        metaEl.setAttribute('content', content);
+        metaEl.setAttribute('name', 'abc');
+        metaEl.setAttribute('content', '123');
         importDoc.head.appendChild(metaEl);
         const amp = win.AMP.attachShadowDoc(hostElement, importDoc, docUrl);
-        expect(amp.ampdoc.getMetaByName(name)).to.equal(content);
+        expect(amp.ampdoc.getMetaByName('abc')).to.equal('123');
       });
 
       it('should start as visible by default', () => {

--- a/test/unit/test-runtime.js
+++ b/test/unit/test-runtime.js
@@ -1345,6 +1345,17 @@ describes.realWin(
         ).to.not.exist;
       });
 
+      it('should import meta content', () => {
+        const name = 'abc';
+        const content = '123';
+        const metaEl = win.document.createElement('meta');
+        metaEl.setAttribute('name', name);
+        metaEl.setAttribute('content', content);
+        importDoc.head.appendChild(metaEl);
+        const amp = win.AMP.attachShadowDoc(hostElement, importDoc, docUrl);
+        expect(amp.ampdoc.getMetaByName(name)).to.equal(content);
+      });
+
       it('should start as visible by default', () => {
         win.AMP.attachShadowDoc(hostElement, importDoc, docUrl);
         expect(ampdoc.getVisibilityState()).to.equal('visible');

--- a/test/unit/test-runtime.js
+++ b/test/unit/test-runtime.js
@@ -1351,6 +1351,7 @@ describes.realWin(
         metaEl.setAttribute('content', '123');
         importDoc.head.appendChild(metaEl);
         const amp = win.AMP.attachShadowDoc(hostElement, importDoc, docUrl);
+        
         expect(amp.ampdoc.getMetaByName('abc')).to.equal('123');
       });
 


### PR DESCRIPTION
- Add `getMetaByName` to `AmpDoc` to get the `content` value from a `<meta name=... content=...>` element. Override in `AmpShadowDoc` to perform the lookup in a name/content pair dictionary.
- Add `setMetaByName` to `AmpDoc` (only implemented in `AmpDocShadow`) to store meta name/content values in a variable. This enables retention of information stored in `<meta name=... content=...>` tags since it would be invalid HTML to copy them into the `ShadowRoot` where there is no `<head>` under which they could reside.