### PR TITLE
🌐Add i18n for <amp-story-quiz> answer choice options

### DIFF
--- a/extensions/amp-story/1.0/_locales/en.js
+++ b/extensions/amp-story/1.0/_locales/en.js
@@ -140,22 +140,22 @@ const strings = {
   [LocalizedStringId.AMP_STORY_QUIZ_ANSWER_CHOICE_A]: {
     string: 'A',
     description:
-      'Text for the first answer choice from a multiple choice quiz (e.g. A in A/B/C/D)',
+      'Label for the first answer choice from a multiple choice quiz (e.g. A in A/B/C/D)',
   },
   [LocalizedStringId.AMP_STORY_QUIZ_ANSWER_CHOICE_B]: {
     string: 'B',
     description:
-      'Text for the second answer choice from a multiple choice quiz (e.g. B in A/B/C/D)',
+      'Label for the second answer choice from a multiple choice quiz (e.g. B in A/B/C/D)',
   },
   [LocalizedStringId.AMP_STORY_QUIZ_ANSWER_CHOICE_C]: {
     string: 'C',
     description:
-      'Text for the third answer choice from a multiple choice quiz (e.g. C in A/B/C/D)',
+      'Label for the third answer choice from a multiple choice quiz (e.g. C in A/B/C/D)',
   },
   [LocalizedStringId.AMP_STORY_QUIZ_ANSWER_CHOICE_D]: {
     string: 'D',
     description:
-      'Text for the fourth answer choice from a multiple choice quiz (e.g. D in A/B/C/D)',
+      'Label for the fourth answer choice from a multiple choice quiz (e.g. D in A/B/C/D)',
   },
   [LocalizedStringId.AMP_STORY_SHARE_BUTTON_LABEL]: {
     string: 'Share story',

--- a/extensions/amp-story/1.0/_locales/en.js
+++ b/extensions/amp-story/1.0/_locales/en.js
@@ -137,6 +137,26 @@ const strings = {
     string: 'Play video',
     description: 'Label for a button to play the video visible on the page.',
   },
+  [LocalizedStringId.AMP_STORY_QUIZ_ANSWER_CHOICE_A]: {
+    string: 'A',
+    description:
+      'Text for the first answer choice from a multiple choice quiz (e.g. A in A/B/C/D)',
+  },
+  [LocalizedStringId.AMP_STORY_QUIZ_ANSWER_CHOICE_B]: {
+    string: 'B',
+    description:
+      'Text for the second answer choice from a multiple choice quiz (e.g. B in A/B/C/D)',
+  },
+  [LocalizedStringId.AMP_STORY_QUIZ_ANSWER_CHOICE_C]: {
+    string: 'C',
+    description:
+      'Text for the third answer choice from a multiple choice quiz (e.g. C in A/B/C/D)',
+  },
+  [LocalizedStringId.AMP_STORY_QUIZ_ANSWER_CHOICE_D]: {
+    string: 'D',
+    description:
+      'Text for the fourth answer choice from a multiple choice quiz (e.g. D in A/B/C/D)',
+  },
   [LocalizedStringId.AMP_STORY_SHARE_BUTTON_LABEL]: {
     string: 'Share story',
     description:

--- a/extensions/amp-story/1.0/amp-story-quiz.js
+++ b/extensions/amp-story/1.0/amp-story-quiz.js
@@ -104,7 +104,7 @@ export class AmpStoryQuiz extends AMP.BaseElement {
     /** @private @const {!./story-analytics.StoryAnalyticsService} */
     this.analyticsService_ = getAnalyticsService(this.win, element);
 
-    /** @const {!Array<string>} */
+    /** @private {!Array<string>} */
     this.answerChoiceOptions_ = ['A', 'B', 'C', 'D'];
 
     /** @private {?Promise<!../../../src/service/cid-impl.CidDef>} */

--- a/extensions/amp-story/1.0/amp-story-quiz.js
+++ b/extensions/amp-story/1.0/amp-story-quiz.js
@@ -21,6 +21,7 @@ import {
 } from './story-analytics';
 import {AnalyticsVariable, getVariableService} from './variable-service';
 import {CSS} from '../../../build/amp-story-quiz-1.0.css';
+import {LocalizedStringId} from '../../../src/localized-strings';
 import {Services} from '../../../src/services';
 import {StateProperty, getStoreService} from './amp-story-store-service';
 import {addParamsToUrl, assertAbsoluteHttpOrHttpsUrl} from '../../../src/url';
@@ -31,9 +32,6 @@ import {dict} from '../../../src/utils/object';
 import {getRequestService} from './amp-story-request-service';
 import {htmlFor} from '../../../src/static-template';
 import {toArray} from '../../../src/types';
-
-/** @const {!Array<string>} */
-const answerChoiceOptions = ['A', 'B', 'C', 'D'];
 
 /** @const {string} */
 const TAG = 'amp-story-quiz';
@@ -106,6 +104,9 @@ export class AmpStoryQuiz extends AMP.BaseElement {
     /** @private @const {!./story-analytics.StoryAnalyticsService} */
     this.analyticsService_ = getAnalyticsService(this.win, element);
 
+    /** @const {!Array<string>} */
+    this.answerChoiceOptions_ = ['A', 'B', 'C', 'D'];
+
     /** @private {?Promise<!../../../src/service/cid-impl.CidDef>} */
     this.clientIdService_ = Services.cidForDoc(this.element);
 
@@ -114,6 +115,9 @@ export class AmpStoryQuiz extends AMP.BaseElement {
 
     /** @private {boolean} */
     this.hasUserSelection_ = false;
+
+    /** @private {!../../../src/service/localization.LocalizationService} */
+    this.localizationService_ = Services.localizationService(this.win);
 
     /** @private {?Element} */
     this.quizEl_ = null;
@@ -250,6 +254,12 @@ export class AmpStoryQuiz extends AMP.BaseElement {
       .querySelector('.i-amphtml-story-quiz-prompt-container')
       .appendChild(prompt);
 
+    // Localize the answer choice options
+    this.answerChoiceOptions_ = this.answerChoiceOptions_.map(choice => {
+      return this.localizationService_.getLocalizedString(
+        LocalizedStringId[`AMP_STORY_QUIZ_ANSWER_CHOICE_${choice}`]
+      );
+    });
     options.forEach((option, index) => this.configureOption_(option, index));
 
     if (this.element.children.length !== 0) {
@@ -272,7 +282,7 @@ export class AmpStoryQuiz extends AMP.BaseElement {
     // Fill in the answer choice and set the option ID
     convertedOption.querySelector(
       '.i-amphtml-story-quiz-answer-choice'
-    ).textContent = answerChoiceOptions[index];
+    ).textContent = this.answerChoiceOptions_[index];
     convertedOption.optionIndex_ = index;
 
     // Extract and structure the option information
@@ -682,8 +692,10 @@ export class AmpStoryQuiz extends AMP.BaseElement {
       dev().error(
         TAG,
         `Quiz #${this.element.getAttribute('id')} does not have option ${
-          answerChoiceOptions[selectedOptionKey]
-        }, but user selected option ${answerChoiceOptions[selectedOptionKey]}`
+          this.answerChoiceOptions_[selectedOptionKey]
+        }, but user selected option ${
+          this.answerChoiceOptions_[selectedOptionKey]
+        }`
       );
       return;
     }

--- a/extensions/amp-story/1.0/test/test-amp-story-quiz.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-quiz.js
@@ -17,6 +17,7 @@
 import {AmpStoryQuiz} from '../amp-story-quiz';
 import {AmpStoryStoreService} from '../amp-story-store-service';
 import {AnalyticsVariable, getVariableService} from '../variable-service';
+import {LocalizationService} from '../../../../src/service/localization';
 import {Services} from '../../../../src/services';
 import {getAnalyticsService} from '../story-analytics';
 import {getRequestService} from '../amp-story-request-service';
@@ -144,6 +145,9 @@ describes.realWin(
 
       const storeService = new AmpStoryStoreService(win);
       registerServiceBuilder(win, 'story-store', () => storeService);
+
+      const localizationService = new LocalizationService(win);
+      registerServiceBuilder(win, 'localization', () => localizationService);
 
       storyEl = win.document.createElement('amp-story');
       const storyPage = win.document.createElement('amp-story-page');

--- a/src/localized-strings.js
+++ b/src/localized-strings.js
@@ -24,7 +24,7 @@ import {parseJson} from './json';
  *   - NOT be reused; to deprecate an ID, comment it out and prefix its key with
  *     the string "DEPRECATED_"
  *
- * Next ID: 71
+ * Next ID: 75
  *
  * @const @enum {string}
  */
@@ -50,6 +50,10 @@ export const LocalizedStringId = {
   AMP_STORY_PAGE_ATTACHMENT_OPEN_LABEL: '35',
   AMP_STORY_PAGE_ERROR_VIDEO: '65',
   AMP_STORY_PAGE_PLAY_VIDEO: '34',
+  AMP_STORY_QUIZ_ANSWER_CHOICE_A: '71',
+  AMP_STORY_QUIZ_ANSWER_CHOICE_B: '72',
+  AMP_STORY_QUIZ_ANSWER_CHOICE_C: '73',
+  AMP_STORY_QUIZ_ANSWER_CHOICE_D: '74',
   AMP_STORY_SHARE_BUTTON_LABEL: '69',
   AMP_STORY_SHARING_CLIPBOARD_FAILURE_TEXT: '4',
   AMP_STORY_SHARING_CLIPBOARD_SUCCESS_TEXT: '5',


### PR DESCRIPTION
Adds i18n support for the answer choice options (e.g. A/B/C/D) in the <amp-story-quiz>.

Adds work related to tracking issue #25615