### PR TITLE
⏩Skip broken shadow tests

### DIFF
--- a/test/unit/test-ampdoc.js
+++ b/test/unit/test-ampdoc.js
@@ -284,35 +284,30 @@ describes.sandboxed('AmpDocService', {}, () => {
     });
 
     // TODO(dvoytenko, #11827): Make this test work on Safari.
-    it.configure()
-      .skipSafari()
-      .skipFirefox()
-      .run('should navigate via host', () => {
-        if (!shadowRoot) {
-          return;
-        }
+    // TODO(kevinkimball): reenable this test after removing createShadowRoot.
+    it.skip('should navigate via host', () => {
+      if (!shadowRoot) {
+        return;
+      }
 
-        const newAmpDoc = service.installShadowDoc(
-          'https://a.org/',
-          shadowRoot
-        );
-        const ampDoc = service.getAmpDoc(content);
-        expect(ampDoc).to.equal(newAmpDoc);
+      const newAmpDoc = service.installShadowDoc('https://a.org/', shadowRoot);
+      const ampDoc = service.getAmpDoc(content);
+      expect(ampDoc).to.equal(newAmpDoc);
 
-        const content2 = document.createElement('span');
-        const host2 = document.createElement('div');
-        const shadowRoot2 = host2.createShadowRoot();
-        shadowRoot2.appendChild(content2);
-        shadowRoot.appendChild(host2);
-        expect(content2.parentNode).to.equal(shadowRoot2);
-        expect(shadowRoot2.host).to.equal(host2);
-        expect(host2.shadowRoot).to.equal(shadowRoot2);
-        expect(host2.parentNode).to.equal(shadowRoot);
+      const content2 = document.createElement('span');
+      const host2 = document.createElement('div');
+      const shadowRoot2 = host2.createShadowRoot();
+      shadowRoot2.appendChild(content2);
+      shadowRoot.appendChild(host2);
+      expect(content2.parentNode).to.equal(shadowRoot2);
+      expect(shadowRoot2.host).to.equal(host2);
+      expect(host2.shadowRoot).to.equal(shadowRoot2);
+      expect(host2.parentNode).to.equal(shadowRoot);
 
-        expect(service.getAmpDoc(host2)).to.equal(ampDoc);
-        expect(service.getAmpDoc(content2)).to.equal(ampDoc);
-        expect(service.getAmpDoc(shadowRoot2)).to.equal(ampDoc);
-      });
+      expect(service.getAmpDoc(host2)).to.equal(ampDoc);
+      expect(service.getAmpDoc(content2)).to.equal(ampDoc);
+      expect(service.getAmpDoc(shadowRoot2)).to.equal(ampDoc);
+    });
   });
 
   describe('fie-doc mode', () => {
@@ -410,35 +405,30 @@ describes.sandboxed('AmpDocService', {}, () => {
     });
 
     // TODO(dvoytenko, #11827): Make this test work on Safari.
-    it.configure()
-      .skipSafari()
-      .skipFirefox()
-      .run('should navigate via host', () => {
-        if (!shadowRoot) {
-          return;
-        }
+    // TODO(kevinkimball): reenable this test after removing createShadowRoot.
+    it.skip('should navigate via host', () => {
+      if (!shadowRoot) {
+        return;
+      }
 
-        const newAmpDoc = service.installShadowDoc(
-          'https://a.org/',
-          shadowRoot
-        );
-        const ampDoc = service.getAmpDoc(content);
-        expect(ampDoc).to.equal(newAmpDoc);
+      const newAmpDoc = service.installShadowDoc('https://a.org/', shadowRoot);
+      const ampDoc = service.getAmpDoc(content);
+      expect(ampDoc).to.equal(newAmpDoc);
 
-        const content2 = document.createElement('span');
-        const host2 = document.createElement('div');
-        const shadowRoot2 = host2.createShadowRoot();
-        shadowRoot2.appendChild(content2);
-        shadowRoot.appendChild(host2);
-        expect(content2.parentNode).to.equal(shadowRoot2);
-        expect(shadowRoot2.host).to.equal(host2);
-        expect(host2.shadowRoot).to.equal(shadowRoot2);
-        expect(host2.parentNode).to.equal(shadowRoot);
+      const content2 = document.createElement('span');
+      const host2 = document.createElement('div');
+      const shadowRoot2 = host2.createShadowRoot();
+      shadowRoot2.appendChild(content2);
+      shadowRoot.appendChild(host2);
+      expect(content2.parentNode).to.equal(shadowRoot2);
+      expect(shadowRoot2.host).to.equal(host2);
+      expect(host2.shadowRoot).to.equal(shadowRoot2);
+      expect(host2.parentNode).to.equal(shadowRoot);
 
-        expect(service.getAmpDoc(host2)).to.equal(ampDoc);
-        expect(service.getAmpDoc(content2)).to.equal(ampDoc);
-        expect(service.getAmpDoc(shadowRoot2)).to.equal(ampDoc);
-      });
+      expect(service.getAmpDoc(host2)).to.equal(ampDoc);
+      expect(service.getAmpDoc(content2)).to.equal(ampDoc);
+      expect(service.getAmpDoc(shadowRoot2)).to.equal(ampDoc);
+    });
 
     describes.realWin('fie-doc', {}, env => {
       let childWin;


### PR DESCRIPTION
To fix master. Chrome 80 seems to have removed `createShadowRoot` API.