### PR TITLE
amp-list: initialize from json instead of amp-state.

### DIFF
--- a/examples/amp-list.ssr.html
+++ b/examples/amp-list.ssr.html
@@ -26,7 +26,6 @@
     </amp-list>
 
     <!--amp-list with initial json-->
-
     <amp-list id="amp-list" width="auto" height="100" layout="fixed-height"
               max-items="5" src="https://lively-and-awesome.appspot.com/ssr_amp_list/">
         <script type="application/json">{ "items": [{"name": "product1"}, {"name": "product2"}, {"name": "product3"}]} </script>

--- a/examples/amp-list.ssr.html
+++ b/examples/amp-list.ssr.html
@@ -25,5 +25,15 @@
         </template>
     </amp-list>
 
+    <!--amp-list with initial json-->
+
+    <amp-list id="amp-list" width="auto" height="100" layout="fixed-height"
+              max-items="5" src="https://lively-and-awesome.appspot.com/ssr_amp_list/">
+        <script type="application/json">{ "items": [{"name": "product1"}, {"name": "product2"}, {"name": "product3"}]} </script>
+        <template type="amp-mustache">
+            <div class="product">{{name}}</div>
+        </template>
+    </amp-list>
+
 </body>
 </html>

--- a/examples/bind/basic.amp.html
+++ b/examples/bind/basic.amp.html
@@ -34,19 +34,10 @@
     <button on="tap:AMP.setState({'foo': 'foo', 'isButtonDisabled': true, 'textClass': 'redBackground', 'imgSrc': 'https://amp.dev/static/samples/img/Shetland_Sheepdog.jpg', 'imgSize': 200, 'imgAlt': 'Sheepdog'})">Click me</button>
   </div>
 
-  <h3>"amp-state:" url example:</h3>
-  <amp-list src="amp-state:myState.animals" layout="fixed-height" height="300px">
-    <template type="amp-mustache">
-      <li style="padding-left: 20px">{{.}}</li>
-    </template>
-  </amp-list>
-
-
   <amp-state id="myState">
     <script type="application/json">
       {
         "myStateKey1": "myStateValue1",
-        "animals": { "items": ["okapis", "bears", "pigs"] }
       }
     </script>
   </amp-state>

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -50,13 +50,13 @@ import {
 import {createCustomEvent, listen} from '../../../src/event-helper';
 import {dev, devAssert, user, userAssert} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
-import {getMode} from '../../../src/mode';
-import {getSourceOrigin} from '../../../src/url';
 import {
+  getChildJsonConfig,
   getValueForExpr,
   hasChildJsonConfig,
-  getChildJsonConfig,
 } from '../../../src/json';
+import {getMode} from '../../../src/mode';
+import {getSourceOrigin} from '../../../src/url';
 import {
   getViewerAuthTokenIfAvailable,
   setupAMPCors,
@@ -135,7 +135,7 @@ export class AmpList extends AMP.BaseElement {
      * Has the initialization json been used yet?
      * @private {boolean}
      */
-    this.initialJsonUsed = false;
+    this.initialJsonUsed_ = false;
 
     /**
      * The `src` attribute's initial value.
@@ -357,14 +357,14 @@ export class AmpList extends AMP.BaseElement {
    * @return {null|Promise<?JsonObject>}
    * @private
    */
-  getInitialJson() {
+  getInitialJson_() {
     if (!isExperimentOn(this.win, 'amp-list-init-from-state')) {
       return null;
     }
-    if (this.initialJsonUsed || !hasChildJsonConfig(this.element)) {
+    if (this.initialJsonUsed_ || !hasChildJsonConfig(this.element)) {
       return null;
     }
-    this.initialJsonUsed = true;
+    this.initialJsonUsed_ = true;
     return Promise.resolve(getChildJsonConfig(this.element));
   }
 
@@ -584,7 +584,7 @@ export class AmpList extends AMP.BaseElement {
     if (this.ssrTemplateHelper_.isEnabled()) {
       fetch = this.ssrTemplate_(opt_refresh);
     } else {
-      fetch = this.getInitialJson() || this.prepareAndSendFetch_(opt_refresh);
+      fetch = this.getInitialJson_() || this.prepareAndSendFetch_(opt_refresh);
       fetch = fetch.then(data => {
         // Bail if the src has changed while resolving the xhr request.
         if (elementSrc !== this.element.getAttribute('src')) {

--- a/extensions/amp-list/0.1/test/test-amp-list.js
+++ b/extensions/amp-list/0.1/test/test-amp-list.js
@@ -809,24 +809,6 @@ describes.repeated(
               );
             });
 
-            it('"amp-state:" uri should skip rendering and emit an error', () => {
-              toggleExperiment(win, 'amp-list-init-from-state', true);
-
-              const ampStateEl = doc.createElement('amp-state');
-              ampStateEl.setAttribute('id', 'okapis');
-              const ampStateJson = doc.createElement('script');
-              ampStateJson.setAttribute('type', 'application/json');
-              ampStateEl.appendChild(ampStateJson);
-              doc.body.appendChild(ampStateEl);
-              list.element.setAttribute('src', 'amp-state:okapis');
-
-              listMock.expects('scheduleRender_').never();
-
-              const errorMsg = /cannot be used in SSR mode/;
-              expectAsyncConsoleError(errorMsg);
-              expect(list.layoutCallback()).eventually.rejectedWith(errorMsg);
-            });
-
             it('Bound [src] should skip rendering and emit an error', async () => {
               listMock.expects('scheduleRender_').never();
               allowConsoleError(async () => {
@@ -884,6 +866,51 @@ describes.repeated(
                 .withExactArgs(true)
                 .once();
               return list.layoutCallback().catch(() => {});
+            });
+          });
+
+          describe('Using json for initial render', () => {
+            const experimentName = 'amp-list-init-from-state';
+
+            beforeEach(() => {
+              resetExperimentTogglesForTesting(win);
+              element = createAmpListElement();
+              element.setAttribute('src', 'https://example.com');
+              element.toggleLoading = () => {};
+              list = createAmpList(element);
+            });
+
+            it('should ignore the json if the experiment is not enabled', async () => {
+              listMock
+                .expects('prepareAndSendFetch_')
+                .returns(Promise.resolve({items: [1, 2, 3]}))
+                .once();
+              listMock
+                .expects('scheduleRender_')
+                .withExactArgs([1, 2, 3], /*append*/ false, {items: [1, 2, 3]})
+                .returns(Promise.resolve())
+                .once();
+
+              await list.layoutCallback();
+            });
+
+            it('should render a list using local data', async () => {
+              toggleExperiment(win, experimentName, true);
+
+              const childJson = win.document.createElement('script');
+              childJson.type = 'application/json';
+              childJson.innerText = '{"items": [1,2,3]}';
+              element.appendChild(childJson);
+              doc.body.appendChild(element);
+
+              listMock.expects('prepareAndSendFetch_').never();
+              listMock
+                .expects('scheduleRender_')
+                .withExactArgs([1, 2, 3], /*append*/ false, {items: [1, 2, 3]})
+                .returns(Promise.resolve())
+                .once();
+
+              await list.layoutCallback();
             });
           });
         }); // without amp-bind
@@ -1226,60 +1253,6 @@ describes.repeated(
               expectFetchAndRender(DEFAULT_FETCHED_DATA, output);
               await list.layoutCallback();
               expect(bind.rescan).to.not.have.been.called;
-            });
-          });
-
-          describe('Using amp-state: protocol', () => {
-            const experimentName = 'amp-list-init-from-state';
-
-            beforeEach(() => {
-              resetExperimentTogglesForTesting(win);
-              element = createAmpListElement();
-              element.setAttribute('src', 'amp-state:okapis');
-              element.toggleLoading = () => {};
-              list = createAmpList(element);
-            });
-
-            it('should throw an error if used without the experiment enabled', async () => {
-              const errorMsg = /Invalid value: amp-state:okapis/;
-              expectAsyncConsoleError(errorMsg);
-              expect(list.layoutCallback()).to.eventually.throw(errorMsg);
-            });
-
-            it('should log an error if amp-bind was not included', async () => {
-              toggleExperiment(win, experimentName, true);
-              Services.bindForDocOrNull.returns(Promise.resolve(null));
-
-              const ampStateEl = doc.createElement('amp-state');
-              ampStateEl.setAttribute('id', 'okapis');
-              const ampStateJson = doc.createElement('script');
-              ampStateJson.setAttribute('type', 'application/json');
-              ampStateEl.appendChild(ampStateJson);
-              doc.body.appendChild(ampStateEl);
-
-              const errorMsg = /bind to be installed/;
-              expectAsyncConsoleError(errorMsg);
-              expect(list.layoutCallback()).eventually.rejectedWith(errorMsg);
-            });
-
-            it('should render a list using local data', async () => {
-              toggleExperiment(win, experimentName, true);
-              bind.getState = () => ({items: [1, 2, 3]});
-
-              const ampStateEl = doc.createElement('amp-state');
-              ampStateEl.setAttribute('id', 'okapis');
-              const ampStateJson = doc.createElement('script');
-              ampStateJson.setAttribute('type', 'application/json');
-              ampStateEl.appendChild(ampStateJson);
-              doc.body.appendChild(ampStateEl);
-
-              listMock
-                .expects('scheduleRender_')
-                .withExactArgs([1, 2, 3], /*append*/ false, {items: [1, 2, 3]})
-                .returns(Promise.resolve())
-                .once();
-
-              await list.layoutCallback();
             });
           });
         }); // with amp-bind

--- a/extensions/amp-list/0.1/test/test-amp-list.js
+++ b/extensions/amp-list/0.1/test/test-amp-list.js
@@ -912,6 +912,34 @@ describes.repeated(
 
               await list.layoutCallback();
             });
+
+            it('should perform a real fetch for the second render', async () => {
+              toggleExperiment(win, experimentName, true);
+
+              const childJson = win.document.createElement('script');
+              childJson.type = 'application/json';
+              childJson.innerText = '{"items": [1,2,3]}';
+              element.appendChild(childJson);
+              doc.body.appendChild(element);
+
+              listMock
+                .expects('fetch_')
+                .returns(Promise.resolve({items: [4, 5, 6]}))
+                .once();
+              listMock
+                .expects('scheduleRender_')
+                .withExactArgs([1, 2, 3], /*append*/ false, {items: [1, 2, 3]})
+                .returns(Promise.resolve())
+                .once();
+              listMock
+                .expects('scheduleRender_')
+                .withExactArgs([4, 5, 6], /*append*/ false, {items: [4, 5, 6]})
+                .returns(Promise.resolve())
+                .once();
+
+              await list.layoutCallback();
+              await list.layoutCallback();
+            });
           });
         }); // without amp-bind
 

--- a/src/json.js
+++ b/src/json.js
@@ -133,6 +133,16 @@ export function tryParseJson(json, opt_onFailed) {
 }
 
 /**
+ * Helper method that returns whether the element has one child json <script> tag.
+ * @param {!Element} element
+ * @return {boolean}
+ */
+export function hasChildJsonConfig(element) {
+  const scripts = childElementsByTag(element, 'script');
+  return scripts.length === 1 && isJsonScriptTag(scripts[0]);
+}
+
+/**
  * Helper method to get the json config from an element <script> tag
  * @param {!Element} element
  * @return {?JsonObject}


### PR DESCRIPTION
**summary**
addressed the updates to https://github.com/ampproject/amphtml/issues/26473#issuecomment-581637039. specifically, removes support for amp-state in favor of child json.

Old code
```html
<amp-state><script type="application/json">{ ... }</script></amp-state>
<amp-list src="amp-state:path">...</amp-list>
```

New code:
```html
<amp-list>
  <script type="application/json">{ ... }</script>
  ...
</amp-list>
```

**caveats**
There are two cases that the new version is less efficient than the old one:
1. When multiple `amp-list` components reference the same data in the same page.
2. When we actually wanted the data to live within `amp-state` so that components could then modify it.

Even given the two caveats I believe this change is still worthwhile. Mainly because this solution doesn't preclude us from a small future PR implementing the `amp-state:` uri.