### PR TITLE
🐛 amp-subscriptions: Fixes click event delegation for iOS 12 and lower

### DIFF
--- a/extensions/amp-subscriptions/0.1/local-subscription-platform-base.js
+++ b/extensions/amp-subscriptions/0.1/local-subscription-platform-base.js
@@ -126,7 +126,7 @@ export class LocalSubscriptionBasePlatform {
     // If the root node has a `body` property, listen to events on that too,
     // to fix an iOS shadow DOM bug (https://github.com/ampproject/amphtml/issues/25754).
     if (this.rootNode_.body) {
-      this.rootNode_.addEventListener(
+      this.rootNode_.body.addEventListener(
         'click',
         handleClickAndStopEventPropagation
       );

--- a/extensions/amp-subscriptions/0.1/local-subscription-platform-base.js
+++ b/extensions/amp-subscriptions/0.1/local-subscription-platform-base.js
@@ -109,17 +109,28 @@ export class LocalSubscriptionBasePlatform {
    * @protected
    */
   initializeListeners_() {
-    // Listen for `click` events bubbling up to the root node.
-    // If the root node has a `body` property, listen to events on that instead,
-    // to fix an iOS shadow DOM bug (https://github.com/ampproject/amphtml/issues/25754).
-    const el = this.rootNode_.body || this.rootNode_;
-    el.addEventListener('click', e => {
+    const handleClickAndStopEventPropagation = e => {
+      e.stopPropagation();
+
       const element = closestAncestorElementBySelector(
         dev().assertElement(e.target),
         '[subscriptions-action]'
       );
       this.handleClick_(element);
-    });
+    };
+    this.rootNode_.addEventListener(
+      'click',
+      handleClickAndStopEventPropagation
+    );
+
+    // If the root node has a `body` property, listen to events on that too,
+    // to fix an iOS shadow DOM bug (https://github.com/ampproject/amphtml/issues/25754).
+    if (this.rootNode_.body) {
+      this.rootNode_.addEventListener(
+        'click',
+        handleClickAndStopEventPropagation
+      );
+    }
   }
 
   /**

--- a/extensions/amp-subscriptions/0.1/test/test-local-subscriptions.js
+++ b/extensions/amp-subscriptions/0.1/test/test-local-subscriptions.js
@@ -96,6 +96,17 @@ describes.fakeWin('LocalSubscriptionsPlatform', {amp: true}, env => {
 
   it('initializeListeners_ should listen to clicks on rootNode', () => {
     const domStub = env.sandbox.stub(
+      localSubscriptionPlatform.rootNode_,
+      'addEventListener'
+    );
+
+    localSubscriptionPlatform.initializeListeners_();
+    expect(domStub).calledOnce;
+    expect(domStub.getCall(0).args[0]).to.be.equals('click');
+  });
+
+  it('initializeListeners_ should listen to clicks on rootNode body', () => {
+    const domStub = env.sandbox.stub(
       localSubscriptionPlatform.rootNode_.body,
       'addEventListener'
     );


### PR DESCRIPTION
To fix an issue with click handling in iOS 12 and lower (#25754), listen to both the root node and, if it's defined, its body property as well.