### PR TITLE
🖍 Remove placeholder on amp-access-scroll

### DIFF
--- a/extensions/amp-access-scroll/0.1/amp-access-scroll.css
+++ b/extensions/amp-access-scroll/0.1/amp-access-scroll.css
@@ -36,8 +36,6 @@
   height: 100px;
   left: 0;
   width: 100%;
-  border-top: 1px solid transparent;
-  border-bottom: 1px solid transparent;
 }
 @media (min-width: 600px) {
   .amp-access-scroll-audio {
@@ -46,6 +44,5 @@
     left: auto;
     right: 16px;
     width: 475px;
-    border: 1px solid transparent;
   }
 }

--- a/extensions/amp-access-scroll/0.1/amp-access-scroll.css
+++ b/extensions/amp-access-scroll/0.1/amp-access-scroll.css
@@ -36,7 +36,7 @@
   height: 100px;
   left: 0;
   width: 100%;
-  border-top: 1px solid transparent; /* gray2 */
+  border-top: 1px solid transparent;
   border-bottom: 1px solid transparent;
 }
 @media (min-width: 600px) {
@@ -46,6 +46,6 @@
     left: auto;
     right: 16px;
     width: 475px;
-    border: 1px solid transparent; /* gray2 */
+    border: 1px solid transparent;
   }
 }

--- a/extensions/amp-access-scroll/0.1/amp-access-scroll.css
+++ b/extensions/amp-access-scroll/0.1/amp-access-scroll.css
@@ -24,15 +24,6 @@
   bottom: 0;
 }
 
-.amp-access-scroll-placeholder {
-  padding-top: 5px;
-  padding-left: 16px;
-  background-color: #fff;
-  border-top: 1px solid #eee;
-  border-bottom: 1px solid #eee;
-  box-sizing: border-box;
-}
-
 .amp-access-scroll-audio {
   position: fixed;
   background-color: #fff;

--- a/extensions/amp-access-scroll/0.1/amp-access-scroll.css
+++ b/extensions/amp-access-scroll/0.1/amp-access-scroll.css
@@ -26,7 +26,7 @@
 
 .amp-access-scroll-audio {
   position: fixed;
-  background-color: #fff;
+  background-color: transparent;
   position: fixed;
   z-index: 2147483647;
   display: block;
@@ -36,7 +36,7 @@
   height: 100px;
   left: 0;
   width: 100%;
-  border-top: 1px solid #e1e6e5; /* gray2 */
+  border-top: 1px solid transparent; /* gray2 */
   border-bottom: 1px solid transparent;
 }
 @media (min-width: 600px) {
@@ -46,6 +46,6 @@
     left: auto;
     right: 16px;
     width: 475px;
-    border: 1px solid #e1e6e5; /* gray2 */
+    border: 1px solid transparent; /* gray2 */
   }
 }

--- a/extensions/amp-access-scroll/0.1/scroll-bar.js
+++ b/extensions/amp-access-scroll/0.1/scroll-bar.js
@@ -88,34 +88,12 @@ class Bar extends ScrollComponent {
 
 export class ScrollUserBar extends Bar {
   /**
-   * Add a scrollbar placeholder and then load the scrollbar URL in the iframe.
+   * Load the scrollbar URL in the iframe.
    *
    * @override
    * */
   makeIframe_() {
     const frame = Bar.prototype.makeIframe_.call(this);
-    // Add a placeholder element to display while scrollbar iframe loads.
-    const placeholder = this.el(
-      'div',
-      dict({
-        'class': 'amp-access-scroll-bar amp-access-scroll-placeholder',
-      }),
-      [
-        this.el(
-          'img',
-          dict({
-            'src':
-              'https://static.scroll.com/assets/icn-scroll-logo32-9f4ceef399905139bbd26b87bfe94542.svg',
-            'layout': 'fixed',
-            'width': 32,
-            'height': 32,
-          })
-        ),
-      ]
-    );
-
-    this.doc_.getBody().appendChild(placeholder);
-
     // Set iframe to scrollbar URL.
     this.accessSource_
       .buildUrl(
@@ -127,10 +105,6 @@ export class ScrollUserBar extends Bar {
         false
       )
       .then(scrollbarUrl => {
-        frame.onload = () => {
-          // On iframe load, remove placeholder element.
-          this.doc_.getBody().removeChild(placeholder);
-        };
         frame.setAttribute('src', scrollbarUrl);
       });
     return frame;


### PR DESCRIPTION
Because of upcoming design enhancements to the bottom bar shown in the iframe with amp-access-scroll, it is necessary to remove the placeholder so that it does not conflict with the content that gets loaded subsequently in the iframe.

This PR removes the html and css associated with rendering the placeholder.

cc @kushal @dbow