### PR TITLE
✅Change domains on tests for ads/analytics

### DIFF
--- a/ads/google/a4a/shared/test/test-url-builder.js
+++ b/ads/google/a4a/shared/test/test-url-builder.js
@@ -19,7 +19,7 @@ import {buildUrl} from '../url-builder';
 describe('buildUrl', () => {
   it('should build a simple URL', () => {
     expect(
-      buildUrl('https://example.com', {'key': 'value'}, Infinity)
-    ).to.equal('https://example.com?key=value');
+      buildUrl('https://example.test', {'key': 'value'}, Infinity)
+    ).to.equal('https://example.test?key=value');
   });
 });

--- a/extensions/amp-a4a/0.1/real-time-config-manager.js
+++ b/extensions/amp-a4a/0.1/real-time-config-manager.js
@@ -148,8 +148,8 @@ export class RealTimeConfigManager {
    * Converts a URL into its corresponding shortened callout string.
    * We also truncate to a maximum length of 50 characters.
    * For instance, if we are passed
-   * "https://example.com/example.php?foo=a&bar=b, then we return
-   * example.com/example.php
+   * "https://example.test/example.php?foo=a&bar=b, then we return
+   * example.test/example.php
    * @param {string} url
    * @return {string}
    */

--- a/extensions/amp-a4a/0.1/test/test-real-time-config-manager.js
+++ b/extensions/amp-a4a/0.1/test/test-real-time-config-manager.js
@@ -108,18 +108,18 @@ describes.realWin('real-time-config-manager', {amp: true}, env => {
 
   describe('#getCalloutParam_', () => {
     it('should convert url to callout param when parseable', () => {
-      const url = 'https://www.example.com/endpoint.php?unincluded';
+      const url = 'https://www.example.test/endpoint.php?unincluded';
       const ard = getCalloutParam_(url);
-      expect(ard).to.equal('www.example.com/endpoint.php');
+      expect(ard).to.equal('www.example.test/endpoint.php');
     });
 
     it('should convert & trunc url when parseable', () => {
       const url =
-        'https://www.example.com/thisIsTooMany' +
+        'https://www.example.test/thisIsTooMany' +
         'Characters1234567891011121314.php';
       const ard = getCalloutParam_(url);
       expect(ard).to.equal(
-        'www.example.com/thisIsTooManyCharacters12345678910'
+        'www.example.test/thisIsTooManyCharacters1234567891'
       );
     });
   });
@@ -976,7 +976,7 @@ describes.realWin('real-time-config-manager', {amp: true}, env => {
       imageStub = env.sandbox.stub(env.win, 'Image').returns(imageMock);
 
       errorType = RTC_ERROR_ENUM.TIMEOUT;
-      errorReportingUrl = 'https://www.example.com?e=ERROR_TYPE&h=HREF';
+      errorReportingUrl = 'https://www.example.test?e=ERROR_TYPE&h=HREF';
       const whitelist = {ERROR_TYPE: true, HREF: true};
       const macros = {
         ERROR_TYPE: errorType,

--- a/extensions/amp-ad/0.1/test/test-amp-ad-3p-impl.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-3p-impl.js
@@ -33,7 +33,7 @@ function createAmpAd(win, attachToAmpdoc = false, ampdoc) {
     type: '_ping_',
     width: 300,
     height: 250,
-    src: 'https://testsrc',
+    src: 'https://src.test',
     'data-valid': 'true',
     'data-width': '6666',
   });
@@ -54,7 +54,7 @@ describes.realWin(
   {
     amp: {
       runtimeOn: false,
-      canonicalUrl: 'https://canonical.url',
+      canonicalUrl: 'https://canonical.test',
     },
     allowExternalResources: true,
   },
@@ -101,10 +101,12 @@ describes.realWin(
           expect(url).to.match(/frame(.max)?.html/);
           const data = JSON.parse(iframe.name).attributes;
           expect(data).to.have.property('type', '_ping_');
-          expect(data).to.have.property('src', 'https://testsrc');
+          expect(data).to.have.property('src', 'https://src.test');
           expect(data).to.have.property('width', 300);
           expect(data).to.have.property('height', 250);
-          expect(data._context.canonicalUrl).to.equal('https://canonical.url/');
+          expect(data._context.canonicalUrl).to.equal(
+            'https://canonical.test/'
+          );
         });
       });
 
@@ -227,7 +229,7 @@ describes.realWin(
       });
 
       it('should use custom path', () => {
-        const remoteUrl = 'https://testsrc/boot/remote.html';
+        const remoteUrl = 'https://src.test/boot/remote.html';
         const meta = win.document.createElement('meta');
         meta.setAttribute('name', 'amp-3p-iframe-src');
         meta.setAttribute('content', remoteUrl);
@@ -245,7 +247,7 @@ describes.realWin(
       it('should use default path if custom disabled', () => {
         const meta = win.document.createElement('meta');
         meta.setAttribute('name', 'amp-3p-iframe-src');
-        meta.setAttribute('content', 'https://testsrc/boot/remote.html');
+        meta.setAttribute('content', 'https://src.test/boot/remote.html');
         win.document.head.appendChild(meta);
         ad3p.config.remoteHTMLDisabled = true;
         ad3p.onLayoutMeasure();
@@ -340,13 +342,13 @@ describes.realWin(
           );
           expect(preconnects[preconnects.length - 1]).to.have.property(
             'href',
-            'https://testsrc/'
+            'https://src.test/'
           );
         });
       });
 
       it('should use remote html path for preload', () => {
-        const remoteUrl = 'https://testsrc/boot/remote.html';
+        const remoteUrl = 'https://src.test/boot/remote.html';
         const meta = win.document.createElement('meta');
         meta.setAttribute('name', 'amp-3p-iframe-src');
         meta.setAttribute('content', remoteUrl);
@@ -365,7 +367,7 @@ describes.realWin(
       it('should not use remote html path for preload if disabled', () => {
         const meta = win.document.createElement('meta');
         meta.setAttribute('name', 'amp-3p-iframe-src');
-        meta.setAttribute('content', 'https://testsrc/boot/remote.html');
+        meta.setAttribute('content', 'https://src.test/boot/remote.html');
         win.document.head.appendChild(meta);
         ad3p.config.remoteHTMLDisabled = true;
         ad3p.buildCallback();

--- a/extensions/amp-ad/0.1/test/test-amp-ad-custom.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-custom.js
@@ -85,14 +85,14 @@ describes.realWin('Amp custom ad', {amp: true}, env => {
     }));
 
     // Single ad with no slot
-    const url1 = 'example.com/ad';
+    const url1 = 'example.test/ad';
     const element1 = getCustomAd(doc, url1);
     const ad1 = new AmpAdCustom(element1);
     ad1.buildCallback();
     ad1.layoutCallback();
 
     // Single ad with no slot
-    const url2 = 'example.com/ad';
+    const url2 = 'example.test/ad';
     const element2 = getCustomAd(doc, url2);
     const ad2 = new AmpAdCustom(element2);
     ad2.buildCallback();

--- a/extensions/amp-ad/0.1/test/test-amp-ad.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad.js
@@ -143,7 +143,7 @@ describes.realWin('Ad loader', {amp: true}, env => {
       it('falls back to Delayed Fetch if remote.html is used', () => {
         const meta = doc.createElement('meta');
         meta.setAttribute('name', 'amp-3p-iframe-src');
-        meta.setAttribute('content', 'https://example.com/remote.html');
+        meta.setAttribute('content', 'https://example.test/remote.html');
         doc.head.appendChild(meta);
         a4aRegistry['zort'] = (win, element, useRemoteHtml) => {
           return !useRemoteHtml;
@@ -182,7 +182,7 @@ describes.realWin('Ad loader', {amp: true}, env => {
       it('uses Fast Fetch if remote.html and RTC are used', () => {
         const meta = doc.createElement('meta');
         meta.setAttribute('name', 'amp-3p-iframe-src');
-        meta.setAttribute('content', 'https://example.com/remote.html');
+        meta.setAttribute('content', 'https://example.test/remote.html');
         doc.head.appendChild(meta);
         a4aRegistry['zort'] = function() {
           return true;
@@ -211,7 +211,7 @@ describes.realWin('Ad loader', {amp: true}, env => {
       it('uses Fast Fetch if remote.html is used but disabled', () => {
         const meta = doc.createElement('meta');
         meta.setAttribute('name', 'amp-3p-iframe-src');
-        meta.setAttribute('content', 'https://example.com/remote.html');
+        meta.setAttribute('content', 'https://example.test/remote.html');
         doc.head.appendChild(meta);
         adConfig['zort'] = {remoteHTMLDisabled: true};
         a4aRegistry['zort'] = function() {

--- a/extensions/amp-analytics/0.1/test/test-amp-analytics.js
+++ b/extensions/amp-analytics/0.1/test/test-amp-analytics.js
@@ -57,11 +57,11 @@ describes.realWin(
       '//invalidConfig': '{"transport": {"iframe": "fake.com"}}',
       '//config1': '{"vars": {"title": "remote"}}',
       'https://foo/My%20Test%20Title': '{"vars": {"title": "magic"}}',
-      '//config-rv2': '{"requests": {"foo": "https://example.com/remote"}}',
+      '//config-rv2': '{"requests": {"foo": "https://example.test/remote"}}',
       'https://rewriter.com': '{"vars": {"title": "rewritten"}}',
     };
     const trivialConfig = {
-      'requests': {'foo': 'https://example.com/bar'},
+      'requests': {'foo': 'https://example.test/bar'},
       'triggers': {'pageview': {'on': 'visible', 'request': 'foo'}},
     };
 
@@ -194,7 +194,7 @@ describes.realWin(
       it('sends a basic hit', function() {
         const analytics = getAnalyticsTag(trivialConfig);
         return waitForSendRequest(analytics).then(() => {
-          requestVerifier.verifyRequest('https://example.com/bar');
+          requestVerifier.verifyRequest('https://example.test/bar');
         });
       });
 
@@ -287,7 +287,7 @@ describes.realWin(
       it('does not send a hit when request is not provided', function() {
         expectAsyncConsoleError(onAndRequestAttributesError);
         const analytics = getAnalyticsTag({
-          'requests': {'foo': 'https://example.com/bar'},
+          'requests': {'foo': 'https://example.test/bar'},
           'triggers': [{'on': 'visible'}],
         });
 
@@ -307,33 +307,33 @@ describes.realWin(
       it('expands nested requests', function() {
         const analytics = getAnalyticsTag({
           'requests': {
-            'foo': 'https://example.com/bar&${foobar}&baz',
+            'foo': 'https://example.test/bar&${foobar}&baz',
             'foobar': 'f1',
           },
           'triggers': [{'on': 'visible', 'request': 'foo'}],
         });
         return waitForSendRequest(analytics).then(() => {
-          requestVerifier.verifyRequest('https://example.com/bar&f1&baz');
+          requestVerifier.verifyRequest('https://example.test/bar&f1&baz');
         });
       });
 
       it('expand nested requests with vendor provided value', () => {
         const analytics = getAnalyticsTag({
           'requests': {
-            'foo': 'https://example.com/bar&${clientId}&baz',
+            'foo': 'https://example.test/bar&${clientId}&baz',
             'clientId': 'c1',
           },
           'triggers': [{'on': 'visible', 'request': 'foo'}],
         });
         return waitForSendRequest(analytics).then(() => {
-          requestVerifier.verifyRequest('https://example.com/bar&c1&baz');
+          requestVerifier.verifyRequest('https://example.test/bar&c1&baz');
         });
       });
 
       it('expands nested requests (3 levels)', function() {
         const analytics = getAnalyticsTag({
           'requests': {
-            'foo': 'https://example.com/bar&${foobar}',
+            'foo': 'https://example.test/bar&${foobar}',
             'foobar': '${baz}',
             'baz': 'b1',
           },
@@ -341,14 +341,14 @@ describes.realWin(
         });
 
         return waitForSendRequest(analytics).then(() => {
-          requestVerifier.verifyRequest('https://example.com/bar&b1');
+          requestVerifier.verifyRequest('https://example.test/bar&b1');
         });
       });
 
       it('should tolerate invalid triggers', function() {
         expectAsyncConsoleError(/No request strings defined/);
         const analytics = getAnalyticsTag({
-          'request': {'foo': 'https://example.com'},
+          'request': {'foo': 'https://example.test'},
           'triggers': [],
         });
         return waitForNoSendRequest(analytics);
@@ -369,7 +369,7 @@ describes.realWin(
         expectAsyncConsoleError(/Request string not found/);
         const analytics = getAnalyticsTag({
           'requests': {
-            'foo': 'https://example.com/bar&${foobar}',
+            'foo': 'https://example.test/bar&${foobar}',
             'foobar': '${baz}',
             'baz': 'b1',
           },
@@ -377,7 +377,7 @@ describes.realWin(
         });
 
         return waitForSendRequest(analytics).then(() => {
-          requestVerifier.verifyRequest('https://example.com/bar&b1');
+          requestVerifier.verifyRequest('https://example.test/bar&b1');
           requestVerifier.verifyRequest('b1');
         });
       });
@@ -386,14 +386,14 @@ describes.realWin(
         const analytics = getAnalyticsTag({
           'requests': {
             'htmlAttrRequest':
-              'https://example.com/bar&ids=${htmlAttr(div,id)}',
+              'https://example.test/bar&ids=${htmlAttr(div,id)}',
           },
           'triggers': [{'on': 'visible', 'request': 'htmlAttrRequest'}],
         });
 
         return waitForSendRequest(analytics).then(() => {
           requestVerifier.verifyRequest(
-            'https://example.com/bar&ids=HTML_ATTR(div,id)'
+            'https://example.test/bar&ids=HTML_ATTR(div,id)'
           );
         });
       });
@@ -401,14 +401,14 @@ describes.realWin(
       it('fills cid', function() {
         const analytics = getAnalyticsTag({
           'requests': {
-            'foo': 'https://example.com/cid=${clientId(analytics-abc)}',
+            'foo': 'https://example.test/cid=${clientId(analytics-abc)}',
           },
           'triggers': [{'on': 'visible', 'request': 'foo'}],
         });
 
         return waitForSendRequest(analytics).then(() => {
           requestVerifier.verifyRequestMatch(
-            /^https:\/\/example.com\/cid=[a-zA-Z\-]+/
+            /^https:\/\/example.test\/cid=[a-zA-Z\-]+/
           );
         });
       });
@@ -440,7 +440,7 @@ describes.realWin(
 
       it('should create and destroy analytics group', () => {
         const analytics = getAnalyticsTag({
-          requests: {foo: 'https://example.com/bar'},
+          requests: {foo: 'https://example.test/bar'},
           triggers: [{on: 'click', selector: '${foo}', request: 'foo'}],
           vars: {foo: 'bar'},
         });
@@ -459,7 +459,7 @@ describes.realWin(
       it('expands urls in config request', () => {
         const analytics = getAnalyticsTag(
           {
-            'requests': {'foo': 'https://example.com/${title}'},
+            'requests': {'foo': 'https://example.test/${title}'},
             'triggers': [{'on': 'visible', 'request': 'foo'}],
           },
           {
@@ -467,13 +467,13 @@ describes.realWin(
           }
         );
         return waitForSendRequest(analytics).then(() => {
-          requestVerifier.verifyRequest('https://example.com/magic');
+          requestVerifier.verifyRequest('https://example.test/magic');
         });
       });
 
       it('updates requestCount on each request', () => {
         const analytics = getAnalyticsTag({
-          'host': 'example.com',
+          'host': 'example.test',
           'requests': {
             'pageview1': '/test1=${requestCount}',
             'pageview2': '/test2=${requestCount}',
@@ -494,7 +494,7 @@ describes.realWin(
       it('expands trigger vars', () => {
         const analytics = getAnalyticsTag({
           'requests': {
-            'pageview': 'https://example.com/test1=${var1}&test2=${var2}',
+            'pageview': 'https://example.test/test1=${var1}&test2=${var2}',
           },
           'triggers': [
             {
@@ -509,7 +509,7 @@ describes.realWin(
         });
         return waitForSendRequest(analytics).then(() => {
           requestVerifier.verifyRequest(
-            'https://example.com/test1=x&test2=test2'
+            'https://example.test/test1=x&test2=test2'
           );
         });
       });
@@ -521,13 +521,13 @@ describes.realWin(
             'var2': 'test2',
           },
           'requests': {
-            'pageview': 'https://example.com/test1=${var1}&test2=${var2}',
+            'pageview': 'https://example.test/test1=${var1}&test2=${var2}',
           },
           'triggers': [{'on': 'visible', 'request': 'pageview'}],
         });
         return waitForSendRequest(analytics).then(() => {
           requestVerifier.verifyRequest(
-            'https://example.com/test1=x&test2=test2'
+            'https://example.test/test1=x&test2=test2'
           );
         });
       });
@@ -539,25 +539,25 @@ describes.realWin(
         const analytics = getAnalyticsTag({
           'requests': {
             'pageview':
-              'https://example.com/title=${title}&ref=${documentReferrer}',
+              'https://example.test/title=${title}&ref=${documentReferrer}',
           },
           'triggers': [{'on': 'visible', 'request': 'pageview'}],
         });
         return waitForSendRequest(analytics).then(() => {
           requestVerifier.verifyRequestMatch(
-            /https:\/\/example.com\/title=My%20Test%20Title&ref=http%3A%2F%2Ffake.example%2F%3Ffoo%3Dbar/
+            /https:\/\/example.test\/title=My%20Test%20Title&ref=http%3A%2F%2Ffake.example%2F%3Ffoo%3Dbar/
           );
         });
       });
 
       it('expands url-replacements vars', function() {
         const analytics = getAnalyticsTag({
-          'requests': {'foo': 'https://example.com/TITLE'},
+          'requests': {'foo': 'https://example.test/TITLE'},
           'triggers': [{'on': 'visible', 'request': 'foo'}],
         });
         return waitForSendRequest(analytics).then(() => {
           requestVerifier.verifyRequest(
-            'https://example.com/My%20Test%20Title'
+            'https://example.test/My%20Test%20Title'
           );
         });
       });
@@ -569,7 +569,7 @@ describes.realWin(
             'var2': 'config2',
           },
           'requests': {
-            'pageview': 'https://example.com/test1=${var1}&test2=${var2}',
+            'pageview': 'https://example.test/test1=${var1}&test2=${var2}',
           },
           'triggers': [
             {
@@ -583,7 +583,7 @@ describes.realWin(
         });
         return waitForSendRequest(analytics).then(() => {
           requestVerifier.verifyRequest(
-            'https://example.com/test1=trigger1&test2=config2'
+            'https://example.test/test1=trigger1&test2=config2'
           );
         });
       });
@@ -619,13 +619,13 @@ describes.realWin(
         const analytics = getAnalyticsTag({
           'vars': {'random': 428},
           'requests': {
-            'pageview': 'https://example.com/test1=${title}&test2=${random}',
+            'pageview': 'https://example.test/test1=${title}&test2=${random}',
           },
           'triggers': [{'on': 'visible', 'request': 'pageview'}],
         });
         return waitForSendRequest(analytics).then(() => {
           requestVerifier.verifyRequest(
-            'https://example.com/test1=My%20Test%20Title&test2=428'
+            'https://example.test/test1=My%20Test%20Title&test2=428'
           );
         });
       });
@@ -637,7 +637,7 @@ describes.realWin(
             'c2': 'config&2',
           },
           'requests': {
-            'base': 'https://example.com/test?c1=${c1}&t1=${t1}',
+            'base': 'https://example.test/test?c1=${c1}&t1=${t1}',
             'pageview': '${base}&c2=${c2}&t2=${t2}',
           },
           'triggers': [
@@ -653,7 +653,7 @@ describes.realWin(
         });
         return waitForSendRequest(analytics).then(() => {
           requestVerifier.verifyRequest(
-            'https://example.com/test?c1=config%201&t1=trigger%3D1&c2=config%262&t2=trigger%3F2'
+            'https://example.test/test?c1=config%201&t1=trigger%3D1&c2=config%262&t2=trigger%3F2'
           );
         });
       });
@@ -665,7 +665,7 @@ describes.realWin(
             'c2': 'config&2',
           },
           'requests': {
-            'base': 'https://example.com/test?',
+            'base': 'https://example.test/test?',
             'pageview': '${base}c1=${c1}&c2=${c2}',
           },
           'triggers': [
@@ -677,7 +677,7 @@ describes.realWin(
         });
         return waitForSendRequest(analytics).then(() => {
           requestVerifier.verifyRequest(
-            'https://example.com/test?c1=Config%2C%20The%20Barbarian,config%201&c2=config%262'
+            'https://example.test/test?c1=Config%2C%20The%20Barbarian,config%201&c2=config%262'
           );
         });
       });
@@ -689,7 +689,7 @@ describes.realWin(
         const analytics = getAnalyticsTag({
           'requests': {
             'pageview':
-              'https://example.com/test1=${var1}&test2=${var2}&title=TITLE',
+              'https://example.test/test1=${var1}&test2=${var2}&title=TITLE',
           },
           'triggers': [
             {
@@ -704,7 +704,7 @@ describes.realWin(
         });
         return waitForSendRequest(analytics).then(() => {
           requestVerifier.verifyRequestMatch(
-            /https:\/\/example.com\/test1=x&test2=http%3A%2F%2Ffake.example%2F%3Ffoo%3Dbar&title=My%20Test%20Title/
+            /https:\/\/example.test\/test1=x&test2=http%3A%2F%2Ffake.example%2F%3Ffoo%3Dbar&title=My%20Test%20Title/
           );
         });
       });
@@ -712,7 +712,7 @@ describes.realWin(
       it('expands complex vars', () => {
         const analytics = getAnalyticsTag({
           'requests': {
-            'pageview': 'https://example.com/test1=${qp_foo}',
+            'pageview': 'https://example.test/test1=${qp_foo}',
           },
           'triggers': [
             {
@@ -739,7 +739,7 @@ describes.realWin(
 
         return waitForSendRequest(analytics).then(() => {
           requestVerifier.verifyRequest(
-            'https://example.com/test1=_query_param_foo_'
+            'https://example.test/test1=_query_param_foo_'
           );
         });
       });
@@ -750,7 +750,7 @@ describes.realWin(
         const tracker = ins.root_.getTracker('click', ClickEventTracker);
         const addStub = env.sandbox.stub(tracker, 'add');
         const analytics = getAnalyticsTag({
-          requests: {foo: 'https://example.com/bar'},
+          requests: {foo: 'https://example.test/bar'},
           triggers: [{on: 'click', selector: '${foo}', request: 'foo'}],
           vars: {foo: 'bar'},
         });
@@ -766,7 +766,7 @@ describes.realWin(
           const tracker = ins.root_.getTracker('click', ClickEventTracker);
           const addStub = env.sandbox.stub(tracker, 'add');
           const analytics = getAnalyticsTag({
-            requests: {foo: 'https://example.com/bar'},
+            requests: {foo: 'https://example.test/bar'},
             triggers: [
               {on: 'click', selector: '${foo}, ${bar}', request: 'foo'},
             ],
@@ -806,7 +806,7 @@ describes.realWin(
         const tracker = ins.root_.getTracker('click', ClickEventTracker);
         const addStub = env.sandbox.stub(tracker, 'add');
         const analytics = getAnalyticsTag({
-          requests: {foo: 'https://example.com/bar'},
+          requests: {foo: 'https://example.test/bar'},
           triggers: [{on: 'click', selector: '${title}', request: 'foo'}],
         });
         return waitForNoSendRequest(analytics).then(() => {
@@ -823,7 +823,7 @@ describes.realWin(
           Promise.resolve({
             'requests': {
               'foo': {
-                baseUrl: 'https://example.com/bar',
+                baseUrl: 'https://example.test/bar',
               },
             },
             'triggers': {
@@ -844,7 +844,7 @@ describes.realWin(
         win['foo'] = {'bar': () => false};
         const analytics = getAnalyticsTag(trivialConfig);
         return waitForSendRequest(analytics).then(() => {
-          requestVerifier.verifyRequest('https://example.com/bar');
+          requestVerifier.verifyRequest('https://example.test/bar');
         });
       });
 
@@ -865,7 +865,7 @@ describes.realWin(
           'type': 'testVendor',
         });
         return waitForSendRequest(analytics).then(() => {
-          requestVerifier.verifyRequest('https://example.com/bar');
+          requestVerifier.verifyRequest('https://example.test/bar');
         });
       });
     });
@@ -876,7 +876,7 @@ describes.realWin(
           Promise.resolve({
             'requests': {
               'foo': {
-                baseUrl: 'https://example.com/bar',
+                baseUrl: 'https://example.test/bar',
               },
             },
             'triggers': {
@@ -913,7 +913,7 @@ describes.realWin(
           'type': 'testVendor',
         });
         return waitForSendRequest(analytics).then(() => {
-          requestVerifier.verifyRequest('https://example.com/bar');
+          requestVerifier.verifyRequest('https://example.test/bar');
         });
       });
     });
@@ -922,7 +922,7 @@ describes.realWin(
       let config;
       beforeEach(() => {
         config = {
-          vars: {host: 'example.com', path: 'helloworld'},
+          vars: {host: 'example.test', path: 'helloworld'},
           extraUrlParams: {
             's.evar0': '0',
             's.evar1': '${path}',
@@ -937,7 +937,7 @@ describes.realWin(
         const analytics = getAnalyticsTag(config);
         return waitForSendRequest(analytics).then(() => {
           requestVerifier.verifyRequest(
-            'https://example.com/helloworld?a=b&s.evar0=0&s.evar1=helloworld&foofoo=baz'
+            'https://example.test/helloworld?a=b&s.evar0=0&s.evar1=helloworld&foofoo=baz'
           );
         });
       });
@@ -947,7 +947,7 @@ describes.realWin(
         const analytics = getAnalyticsTag(config);
         return waitForSendRequest(analytics).then(() => {
           requestVerifier.verifyRequest(
-            'https://example.com/helloworld?a=b&foofoo=baz&v0=0&v1=helloworld'
+            'https://example.test/helloworld?a=b&foofoo=baz&v0=0&v1=helloworld'
           );
         });
       });
@@ -958,7 +958,7 @@ describes.realWin(
         const analytics = getAnalyticsTag(config);
         return waitForSendRequest(analytics).then(() => {
           requestVerifier.verifyRequest(
-            'https://example.com/helloworld?a=b&foofoo=baz&v0=0&v1=helloworld&c=d&v=e'
+            'https://example.test/helloworld?a=b&foofoo=baz&v0=0&v1=helloworld&c=d&v=e'
           );
         });
       });
@@ -969,7 +969,7 @@ describes.realWin(
         const analytics = getAnalyticsTag(config);
         return waitForSendRequest(analytics).then(() => {
           requestVerifier.verifyRequest(
-            'https://example.com/helloworld?s.evar0=0&s.evar1=helloworld&foofoo=baz&a=b'
+            'https://example.test/helloworld?s.evar0=0&s.evar1=helloworld&foofoo=baz&a=b'
           );
         });
       });
@@ -979,7 +979,7 @@ describes.realWin(
         const analytics = getAnalyticsTag(config);
         return waitForSendRequest(analytics).then(() => {
           requestVerifier.verifyRequest(
-            'https://example.com/helloworld?a=b&foo=0'
+            'https://example.test/helloworld?a=b&foo=0'
           );
         });
       });
@@ -1409,7 +1409,7 @@ describes.realWin(
       it('should resume fetch when consent is given', () => {
         const analytics = getAnalyticsTag(
           {
-            'requests': {'foo': 'https://example.com/local'},
+            'requests': {'foo': 'https://example.test/local'},
             'triggers': [{'on': 'visible', 'request': 'foo'}],
           },
           {
@@ -1423,14 +1423,14 @@ describes.realWin(
         });
 
         return waitForSendRequest(analytics).then(() => {
-          requestVerifier.verifyRequest('https://example.com/local');
+          requestVerifier.verifyRequest('https://example.test/local');
         });
       });
 
       it('should not fetch when consent is not given', () => {
         const analytics = getAnalyticsTag(
           {
-            'requests': {'foo': 'https://example.com/local'},
+            'requests': {'foo': 'https://example.test/local'},
             'triggers': [{'on': 'visible', 'request': 'foo'}],
           },
           {
@@ -1458,7 +1458,7 @@ describes.realWin(
         () => {
           const analytics = getAnalyticsTag(
             {
-              'requests': {'foo': 'https://example.com/local'},
+              'requests': {'foo': 'https://example.test/local'},
               'triggers': [{'on': 'visible', 'request': 'foo'}],
             },
             {
@@ -1497,7 +1497,7 @@ describes.realWin(
         const addStub = env.sandbox.stub(tracker, 'add');
         const analytics = getAnalyticsTag(
           {
-            requests: {foo: 'https://example.com/bar'},
+            requests: {foo: 'https://example.test/bar'},
             triggers: [{on: 'click', request: 'foo'}],
           },
           {
@@ -1515,7 +1515,7 @@ describes.realWin(
         const addStub = env.sandbox.stub(tracker, 'add');
         const analytics = getAnalyticsTag(
           {
-            requests: {foo: 'https://example.com/bar'},
+            requests: {foo: 'https://example.test/bar'},
             triggers: [{on: 'visible', selector: 'amp-iframe', request: 'foo'}],
           },
           {
@@ -1538,7 +1538,7 @@ describes.realWin(
           {
             'requests': {
               'pageview':
-                'https://example.com/test1=${var1}&CLIENT_ID(analytics-abc)=${var2}',
+                'https://example.test/test1=${var1}&CLIENT_ID(analytics-abc)=${var2}',
             },
             'triggers': [
               {
@@ -1557,7 +1557,7 @@ describes.realWin(
         );
         return waitForSendRequest(analytics).then(() => {
           requestVerifier.verifyRequest(
-            'https://example.com/test1=CLIENT_ID(analytics-abc)&' +
+            'https://example.test/test1=CLIENT_ID(analytics-abc)&' +
               'CLIENT_ID(analytics-abc)=test2'
           );
         });
@@ -1567,7 +1567,7 @@ describes.realWin(
         const analytics = getAnalyticsTag(
           {
             'requests': {
-              'foo': 'https://example.com/cid=${clientId(analytics-abc)}',
+              'foo': 'https://example.test/cid=${clientId(analytics-abc)}',
             },
             'triggers': [{'on': 'visible', 'request': 'foo'}],
           },
@@ -1578,7 +1578,7 @@ describes.realWin(
 
         return waitForSendRequest(analytics).then(() => {
           requestVerifier.verifyRequest(
-            'https://example.com/cid=CLIENT_ID(analytics-abc)'
+            'https://example.test/cid=CLIENT_ID(analytics-abc)'
           );
         });
       });
@@ -1586,7 +1586,7 @@ describes.realWin(
       it('should replace whitelist variable', () => {
         const analytics = getAnalyticsTag(
           {
-            'requests': {'foo': 'https://example.com/random=${random}'},
+            'requests': {'foo': 'https://example.test/random=${random}'},
             'triggers': [{'on': 'visible', 'request': 'foo'}],
           },
           {
@@ -1597,7 +1597,7 @@ describes.realWin(
 
         return waitForSendRequest(analytics).then(() => {
           requestVerifier.verifyRequestMatch(
-            /^https:\/\/example.com\/random=0.[0-9]/
+            /^https:\/\/example.test\/random=0.[0-9]/
           );
         });
       });
@@ -1607,7 +1607,7 @@ describes.realWin(
           {
             'requests': {
               'foo':
-                'https://example.com/cid=${clientId(analytics-abc)}random=RANDOM',
+                'https://example.test/cid=${clientId(analytics-abc)}random=RANDOM',
             },
             'triggers': [{'on': 'visible', 'request': 'foo'}],
           },
@@ -1619,7 +1619,7 @@ describes.realWin(
 
         return waitForSendRequest(analytics).then(() => {
           requestVerifier.verifyRequestMatch(
-            /https:\/\/example\.com\/cid=CLIENT_ID\(analytics-abc\)random=0\.[0-9]+/
+            /https:\/\/example\.test\/cid=CLIENT_ID\(analytics-abc\)random=0\.[0-9]+/
           );
         });
       });
@@ -1629,7 +1629,7 @@ describes.realWin(
           {
             'requests': {
               'pageview':
-                'https://example.com/VIEWER&AMP_VERSION&' +
+                'https://example.test/VIEWER&AMP_VERSION&' +
                 'test1=${var1}&test2=${var2}&test3=${var3}&url=AMPDOC_URL',
             },
             'triggers': [
@@ -1651,7 +1651,7 @@ describes.realWin(
         );
         return waitForSendRequest(analytics).then(() => {
           requestVerifier.verifyRequest(
-            'https://example.com/VIEWER&%24internalRuntimeVersion%24' +
+            'https://example.test/VIEWER&%24internalRuntimeVersion%24' +
               '&test1=x&test2=about%3Asrcdoc&test3=CLIENT_ID' +
               '&url=about%3Asrcdoc'
           );
@@ -1796,7 +1796,7 @@ describes.realWin(
       it('does send a hit when parentPostMessage is provided inabox', function() {
         env.win.__AMP_MODE.runtime = 'inabox';
         const analytics = getAnalyticsTag({
-          'requests': {'foo': 'https://example.com/bar'},
+          'requests': {'foo': 'https://example.test/bar'},
           'triggers': [{'on': 'visible', 'parentPostMessage': 'foo'}],
         });
         postMessageSpy = env.sandbox.spy(analytics.win.parent, 'postMessage');
@@ -1818,7 +1818,7 @@ describes.realWin(
 
       it('does not send with parentPostMessage not inabox', function() {
         const analytics = getAnalyticsTag({
-          'requests': {'foo': 'https://example.com/bar'},
+          'requests': {'foo': 'https://example.test/bar'},
           'triggers': [
             {
               'on': 'visible',
@@ -1836,7 +1836,7 @@ describes.realWin(
         env.win.__AMP_MODE.runtime = 'inabox';
         expectAsyncConsoleError(onAndRequestAttributesInaboxError);
         const analytics = getAnalyticsTag({
-          'requests': {'foo': 'https://example.com/bar'},
+          'requests': {'foo': 'https://example.test/bar'},
           'triggers': [{'on': 'visible'}],
         });
         postMessageSpy = env.sandbox.spy(analytics.win.parent, 'postMessage');
@@ -1848,7 +1848,7 @@ describes.realWin(
       it('send when request and parentPostMessage are provided', function() {
         env.win.__AMP_MODE.runtime = 'inabox';
         const analytics = getAnalyticsTag({
-          'requests': {'foo': 'https://example.com/bar'},
+          'requests': {'foo': 'https://example.test/bar'},
           'triggers': [
             {
               'on': 'visible',

--- a/extensions/amp-analytics/0.1/test/test-config-new.js
+++ b/extensions/amp-analytics/0.1/test/test-config-new.js
@@ -56,7 +56,7 @@ describes.realWin('AnalyticsConfig', {amp: false}, env => {
   describe('handles top level fields correctly', () => {
     it('propogates requestOrigin into each request object', () => {
       fakeVendorJson = {
-        'requestOrigin': 'https://example.com',
+        'requestOrigin': 'https://example.test',
         'requests': {'test1': '/test1', 'test2': '/test1/test2'},
       };
 
@@ -65,11 +65,11 @@ describes.realWin('AnalyticsConfig', {amp: false}, env => {
       return new AnalyticsConfig(element).loadConfig().then(config => {
         expect(config['requests']).to.deep.equal({
           'test1': {
-            origin: 'https://example.com',
+            origin: 'https://example.test',
             baseUrl: '/test1',
           },
           'test2': {
-            origin: 'https://example.com',
+            origin: 'https://example.test',
             baseUrl: '/test1/test2',
           },
         });
@@ -152,7 +152,7 @@ describes.realWin('AnalyticsConfig', {amp: false}, env => {
 
       const element = getAnalyticsTag(
         {
-          'requests': {'foo': 'https://example.com/${bar}'},
+          'requests': {'foo': 'https://example.test/${bar}'},
           'triggers': [{'on': 'visible', 'request': 'foo'}],
         },
         {'type': vendorName}
@@ -161,7 +161,7 @@ describes.realWin('AnalyticsConfig', {amp: false}, env => {
       return new AnalyticsConfig(element).loadConfig().then(config => {
         expect(config['requests']).to.deep.equal({
           'foo': {
-            baseUrl: 'https://example.com/${bar}',
+            baseUrl: 'https://example.test/${bar}',
           },
           'bar': {
             baseUrl: 'foobar',
@@ -190,7 +190,7 @@ describes.realWin('AnalyticsConfig', {amp: false}, env => {
         {
           'requests': {
             'foo': {
-              'baseUrl': 'https://example.com/${bar}',
+              'baseUrl': 'https://example.test/${bar}',
               'batchInterval': 0,
             },
             'bar': 'bar-i',
@@ -203,7 +203,7 @@ describes.realWin('AnalyticsConfig', {amp: false}, env => {
       return new AnalyticsConfig(element).loadConfig().then(config => {
         expect(config['requests']).to.deep.equal({
           'foo': {
-            'baseUrl': 'https://example.com/${bar}',
+            'baseUrl': 'https://example.test/${bar}',
             'batchInterval': 0,
           },
           'bar': {
@@ -236,7 +236,7 @@ describes.realWin('AnalyticsConfig', {amp: false}, env => {
         {
           'requests': {
             'foo': {
-              'baseUrl': 'https://example.com/${bar}',
+              'baseUrl': 'https://example.test/${bar}',
               'batchInterval': 0,
             },
             'bar': {
@@ -251,7 +251,7 @@ describes.realWin('AnalyticsConfig', {amp: false}, env => {
       return new AnalyticsConfig(element).loadConfig().then(config => {
         expect(config['requests']).to.deep.equal({
           'foo': {
-            'baseUrl': 'https://example.com/${bar}',
+            'baseUrl': 'https://example.test/${bar}',
             'batchInterval': 0,
           },
           'bar': {
@@ -271,14 +271,14 @@ describes.realWin('AnalyticsConfig', {amp: false}, env => {
     it('inline and remote both string', () => {
       fakeRemoteJson = {
         requests: {
-          foo: 'https://example.com/remote',
+          foo: 'https://example.test/remote',
         },
       };
 
       const element = getAnalyticsTag(
         {
           'vars': {'title': 'local'},
-          'requests': {'foo': 'https://example.com/${title}'},
+          'requests': {'foo': 'https://example.test/${title}'},
           'triggers': [{'on': 'visible', 'request': 'foo'}],
         },
         {
@@ -289,7 +289,7 @@ describes.realWin('AnalyticsConfig', {amp: false}, env => {
       return new AnalyticsConfig(element).loadConfig().then(config => {
         expect(config['requests']).to.deep.equal({
           'foo': {
-            'baseUrl': 'https://example.com/remote',
+            'baseUrl': 'https://example.test/remote',
           },
         });
         expect(config['triggers']).to.deep.equal([
@@ -363,7 +363,7 @@ describes.realWin('AnalyticsConfig', {amp: false}, env => {
 
     it('fails for inline optout config', () => {
       const element = getAnalyticsTag({
-        'requests': {'foo': 'https://example.com/bar'},
+        'requests': {'foo': 'https://example.test/bar'},
         'triggers': [{'on': 'visible', 'request': 'foo'}],
         'optout': 'foo.bar',
       });
@@ -401,7 +401,7 @@ describes.realWin('AnalyticsConfig', {amp: false}, env => {
 
     it('fails for inlined iframePing config', () => {
       const element = getAnalyticsTag({
-        'element': {'foo': 'https://example.com/bar'},
+        'element': {'foo': 'https://example.test/bar'},
         'triggers': [{'on': 'visible', 'iframePing': true}],
       });
       return expect(
@@ -467,7 +467,7 @@ describes.realWin('AnalyticsConfig', {amp: false}, env => {
       };
       const element = getAnalyticsTag(
         {
-          'requests': {'foo': 'https://example.com/bar'},
+          'requests': {'foo': 'https://example.test/bar'},
           'triggers': [{'on': 'visible', 'request': 'foo'}],
           transport: {
             image: false,
@@ -498,7 +498,7 @@ describes.realWin('AnalyticsConfig', {amp: false}, env => {
       const element = getAnalyticsTag(
         {
           'vars': {'title': 'local'},
-          'requests': {'foo': 'https://example.com/${title}'},
+          'requests': {'foo': 'https://example.test/${title}'},
           'triggers': [{'on': 'visible', 'request': 'foo'}],
         },
         {
@@ -520,7 +520,7 @@ describes.realWin('AnalyticsConfig', {amp: false}, env => {
       const element = getAnalyticsTag(
         {
           'vars': {'title': 'local'},
-          'requests': {'foo': 'https://example.com/${title}'},
+          'requests': {'foo': 'https://example.test/${title}'},
           'triggers': [{'on': 'visible', 'request': 'foo'}],
         },
         {
@@ -542,7 +542,7 @@ describes.realWin('AnalyticsConfig', {amp: false}, env => {
       const element = getAnalyticsTag(
         {
           'vars': {'title': 'local'},
-          'requests': {'foo': 'https://example.com/${title}'},
+          'requests': {'foo': 'https://example.test/${title}'},
           'triggers': [{'on': 'visible', 'request': 'foo'}],
         },
         {

--- a/extensions/amp-analytics/0.1/test/test-config.js
+++ b/extensions/amp-analytics/0.1/test/test-config.js
@@ -39,7 +39,7 @@ describes.realWin.skip('AnalyticsConfig', {amp: false}, env => {
   describe('handles top level fields correctly', () => {
     it('propogates requestOrigin into each request object', () => {
       ANALYTICS_CONFIG['-test-venfor'] = {
-        'requestOrigin': 'https://example.com',
+        'requestOrigin': 'https://example.test',
         'requests': {'test1': '/test1', 'test2': '/test1/test2'},
       };
 
@@ -48,11 +48,11 @@ describes.realWin.skip('AnalyticsConfig', {amp: false}, env => {
       return new AnalyticsConfig(element).loadConfig().then(config => {
         expect(config['requests']).to.deep.equal({
           'test1': {
-            origin: 'https://example.com',
+            origin: 'https://example.test',
             baseUrl: '/test1',
           },
           'test2': {
-            origin: 'https://example.com',
+            origin: 'https://example.test',
             baseUrl: '/test1/test2',
           },
         });
@@ -135,7 +135,7 @@ describes.realWin.skip('AnalyticsConfig', {amp: false}, env => {
 
       const element = getAnalyticsTag(
         {
-          'requests': {'foo': 'https://example.com/${bar}'},
+          'requests': {'foo': 'https://example.test/${bar}'},
           'triggers': [{'on': 'visible', 'request': 'foo'}],
         },
         {'type': '-test-venfor'}
@@ -144,7 +144,7 @@ describes.realWin.skip('AnalyticsConfig', {amp: false}, env => {
       return new AnalyticsConfig(element).loadConfig().then(config => {
         expect(config['requests']).to.deep.equal({
           'foo': {
-            baseUrl: 'https://example.com/${bar}',
+            baseUrl: 'https://example.test/${bar}',
           },
           'bar': {
             baseUrl: 'foobar',
@@ -173,7 +173,7 @@ describes.realWin.skip('AnalyticsConfig', {amp: false}, env => {
         {
           'requests': {
             'foo': {
-              'baseUrl': 'https://example.com/${bar}',
+              'baseUrl': 'https://example.test/${bar}',
               'batchInterval': 0,
             },
             'bar': 'bar-i',
@@ -186,7 +186,7 @@ describes.realWin.skip('AnalyticsConfig', {amp: false}, env => {
       return new AnalyticsConfig(element).loadConfig().then(config => {
         expect(config['requests']).to.deep.equal({
           'foo': {
-            'baseUrl': 'https://example.com/${bar}',
+            'baseUrl': 'https://example.test/${bar}',
             'batchInterval': 0,
           },
           'bar': {
@@ -219,7 +219,7 @@ describes.realWin.skip('AnalyticsConfig', {amp: false}, env => {
         {
           'requests': {
             'foo': {
-              'baseUrl': 'https://example.com/${bar}',
+              'baseUrl': 'https://example.test/${bar}',
               'batchInterval': 0,
             },
             'bar': {
@@ -234,7 +234,7 @@ describes.realWin.skip('AnalyticsConfig', {amp: false}, env => {
       return new AnalyticsConfig(element).loadConfig().then(config => {
         expect(config['requests']).to.deep.equal({
           'foo': {
-            'baseUrl': 'https://example.com/${bar}',
+            'baseUrl': 'https://example.test/${bar}',
             'batchInterval': 0,
           },
           'bar': {
@@ -255,7 +255,7 @@ describes.realWin.skip('AnalyticsConfig', {amp: false}, env => {
       const element = getAnalyticsTag(
         {
           'vars': {'title': 'local'},
-          'requests': {'foo': 'https://example.com/${title}'},
+          'requests': {'foo': 'https://example.test/${title}'},
           'triggers': [{'on': 'visible', 'request': 'foo'}],
         },
         {
@@ -268,7 +268,7 @@ describes.realWin.skip('AnalyticsConfig', {amp: false}, env => {
           json() {
             return Promise.resolve({
               requests: {
-                foo: 'https://example.com/remote',
+                foo: 'https://example.test/remote',
               },
             });
           },
@@ -278,7 +278,7 @@ describes.realWin.skip('AnalyticsConfig', {amp: false}, env => {
       return new AnalyticsConfig(element).loadConfig().then(config => {
         expect(config['requests']).to.deep.equal({
           'foo': {
-            'baseUrl': 'https://example.com/remote',
+            'baseUrl': 'https://example.test/remote',
           },
         });
         expect(config['triggers']).to.deep.equal([
@@ -352,7 +352,7 @@ describes.realWin.skip('AnalyticsConfig', {amp: false}, env => {
 
     it('fails for inline optout config', () => {
       const element = getAnalyticsTag({
-        'requests': {'foo': 'https://example.com/bar'},
+        'requests': {'foo': 'https://example.test/bar'},
         'triggers': [{'on': 'visible', 'request': 'foo'}],
         'optout': 'foo.bar',
       });
@@ -390,7 +390,7 @@ describes.realWin.skip('AnalyticsConfig', {amp: false}, env => {
 
     it('fails for inlined iframePing config', () => {
       const element = getAnalyticsTag({
-        'element': {'foo': 'https://example.com/bar'},
+        'element': {'foo': 'https://example.test/bar'},
         'triggers': [{'on': 'visible', 'iframePing': true}],
       });
       return expect(
@@ -456,7 +456,7 @@ describes.realWin.skip('AnalyticsConfig', {amp: false}, env => {
       };
       const element = getAnalyticsTag(
         {
-          'requests': {'foo': 'https://example.com/bar'},
+          'requests': {'foo': 'https://example.test/bar'},
           'triggers': [{'on': 'visible', 'request': 'foo'}],
           transport: {
             image: false,
@@ -480,7 +480,7 @@ describes.realWin.skip('AnalyticsConfig', {amp: false}, env => {
       const element = getAnalyticsTag(
         {
           'vars': {'title': 'local'},
-          'requests': {'foo': 'https://example.com/${title}'},
+          'requests': {'foo': 'https://example.test/${title}'},
           'triggers': [{'on': 'visible', 'request': 'foo'}],
         },
         {
@@ -514,7 +514,7 @@ describes.realWin.skip('AnalyticsConfig', {amp: false}, env => {
       const element = getAnalyticsTag(
         {
           'vars': {'title': 'local'},
-          'requests': {'foo': 'https://example.com/${title}'},
+          'requests': {'foo': 'https://example.test/${title}'},
           'triggers': [{'on': 'visible', 'request': 'foo'}],
         },
         {
@@ -532,7 +532,7 @@ describes.realWin.skip('AnalyticsConfig', {amp: false}, env => {
       const element = getAnalyticsTag(
         {
           'vars': {'title': 'local'},
-          'requests': {'foo': 'https://example.com/${title}'},
+          'requests': {'foo': 'https://example.test/${title}'},
           'triggers': [{'on': 'visible', 'request': 'foo'}],
         },
         {

--- a/extensions/amp-analytics/0.1/test/test-cookie-writer.js
+++ b/extensions/amp-analytics/0.1/test/test-cookie-writer.js
@@ -235,7 +235,7 @@ describes.fakeWin('amp-analytics.cookie-writer value', {amp: true}, env => {
     ).callsFake((name, id) => {
       return `${name}-${id}`;
     });
-    win.location = 'https://example.com/?a=123&b=567';
+    win.location = 'https://example.test/?a=123&b=567';
     const cookieWriter = new CookieWriter(
       win,
       win.document.body,
@@ -270,7 +270,7 @@ describes.fakeWin('amp-analytics.cookie-writer value', {amp: true}, env => {
   });
 
   it('should write cookie under eTLD+1 domain with right exp.', () => {
-    win.location = 'https://www.example.com/?a=123&b=567';
+    win.location = 'https://www.example.test/?a=123&b=567';
     const cookieWriter = new CookieWriter(
       win,
       win.document.body,
@@ -284,14 +284,14 @@ describes.fakeWin('amp-analytics.cookie-writer value', {amp: true}, env => {
     );
     return cookieWriter.write().then(() => {
       expect(win.document.lastSetCookieRaw).to.equal(
-        'aCookie=123; path=/; domain=example.com; ' +
+        'aCookie=123; path=/; domain=example.test; ' +
           'expires=Tue, 01 Jan 2019 08:00:00 GMT'
       );
     });
   });
 
   it('should write cookie with custom expiration (number value)', () => {
-    win.location = 'https://www.example.com/';
+    win.location = 'https://www.example.test/';
     const cookieWriter = new CookieWriter(
       win,
       win.document.body,
@@ -306,14 +306,14 @@ describes.fakeWin('amp-analytics.cookie-writer value', {amp: true}, env => {
     );
     return cookieWriter.write().then(() => {
       expect(win.document.lastSetCookieRaw).to.equal(
-        'aCookie=testValue; path=/; domain=example.com; ' +
+        'aCookie=testValue; path=/; domain=example.test; ' +
           'expires=Mon, 08 Jan 2018 08:00:00 GMT'
       );
     });
   });
 
   it('should write cookie with custom expiration (string value)', () => {
-    win.location = 'https://www.example.com/';
+    win.location = 'https://www.example.test/';
     const cookieWriter = new CookieWriter(
       win,
       win.document.body,
@@ -328,14 +328,14 @@ describes.fakeWin('amp-analytics.cookie-writer value', {amp: true}, env => {
     );
     return cookieWriter.write().then(() => {
       expect(win.document.lastSetCookieRaw).to.equal(
-        'aCookie=testValue; path=/; domain=example.com; ' +
+        'aCookie=testValue; path=/; domain=example.test; ' +
           'expires=Mon, 08 Jan 2018 08:00:00 GMT'
       );
     });
   });
 
   it('should write cookie with custom expiration (decimal value)', () => {
-    win.location = 'https://www.example.com/';
+    win.location = 'https://www.example.test/';
     const cookieWriter = new CookieWriter(
       win,
       win.document.body,
@@ -351,14 +351,14 @@ describes.fakeWin('amp-analytics.cookie-writer value', {amp: true}, env => {
 
     return cookieWriter.write().then(() => {
       expect(win.document.lastSetCookieRaw).to.equal(
-        'aCookie=testValue; path=/; domain=example.com; ' +
+        'aCookie=testValue; path=/; domain=example.test; ' +
           'expires=Mon, 08 Jan 2018 08:00:00 GMT'
       );
     });
   });
 
   it('should write cookie with custom expiration (zero value)', () => {
-    win.location = 'https://www.example.com/';
+    win.location = 'https://www.example.test/';
     const cookieWriter = new CookieWriter(
       win,
       win.document.body,
@@ -373,14 +373,14 @@ describes.fakeWin('amp-analytics.cookie-writer value', {amp: true}, env => {
     );
     return cookieWriter.write().then(() => {
       expect(win.document.lastSetCookieRaw).to.equal(
-        'aCookie=testValue; path=/; domain=example.com; ' +
+        'aCookie=testValue; path=/; domain=example.test; ' +
           'expires=Mon, 01 Jan 2018 08:00:00 GMT'
       );
     });
   });
 
   it('should write cookie with custom expiration (negative value)', () => {
-    win.location = 'https://www.example.com/';
+    win.location = 'https://www.example.test/';
     const cookieWriter = new CookieWriter(
       win,
       win.document.body,
@@ -395,14 +395,14 @@ describes.fakeWin('amp-analytics.cookie-writer value', {amp: true}, env => {
     );
     return cookieWriter.write().then(() => {
       expect(win.document.lastSetCookieRaw).to.equal(
-        'aCookie=testValue; path=/; domain=example.com; ' +
+        'aCookie=testValue; path=/; domain=example.test; ' +
           'expires=Mon, 25 Dec 2017 08:00:00 GMT'
       );
     });
   });
 
   it('should write cookie with default expiration (invalid string value)', () => {
-    win.location = 'https://www.example.com/';
+    win.location = 'https://www.example.test/';
     const cookieWriter = new CookieWriter(
       win,
       win.document.body,
@@ -418,7 +418,7 @@ describes.fakeWin('amp-analytics.cookie-writer value', {amp: true}, env => {
     return allowConsoleError(() => {
       return cookieWriter.write().then(() => {
         expect(win.document.lastSetCookieRaw).to.equal(
-          'aCookie=testValue; path=/; domain=example.com; ' +
+          'aCookie=testValue; path=/; domain=example.test; ' +
             'expires=Tue, 01 Jan 2019 08:00:00 GMT'
         );
       });
@@ -426,7 +426,7 @@ describes.fakeWin('amp-analytics.cookie-writer value', {amp: true}, env => {
   });
 
   it('should not write empty cookie', () => {
-    win.location = 'https://www.example.com/?a=123&b=567';
+    win.location = 'https://www.example.test/?a=123&b=567';
     const cookieWriter = new CookieWriter(
       win,
       win.document.body,
@@ -445,7 +445,7 @@ describes.fakeWin('amp-analytics.cookie-writer value', {amp: true}, env => {
   });
 
   it('should not write cookie if macro is mal-formatted', () => {
-    win.location = 'https://www.example.com/?a=123&b=567';
+    win.location = 'https://www.example.test/?a=123&b=567';
     const cookieWriter = new CookieWriter(
       win,
       win.document.body,

--- a/extensions/amp-analytics/0.1/test/test-linker-manager.js
+++ b/extensions/amp-analytics/0.1/test/test-linker-manager.js
@@ -52,8 +52,8 @@ describes.realWin('Linker Manager', {amp: true}, env => {
     });
 
     env.sandbox.stub(Services, 'documentInfoForDoc').returns({
-      sourceUrl: 'https://amp.source.com/some/path?q=123',
-      canonicalUrl: 'https://www.canonical.com/some/path?q=123',
+      sourceUrl: 'https://amp.source.test/some/path?q=123',
+      canonicalUrl: 'https://www.canonical.test/some/path?q=123',
     });
 
     element = doc.createElement('div');
@@ -136,7 +136,7 @@ describes.realWin('Linker Manager', {amp: true}, env => {
 
   it('does not register anchor mutator if not on proxy', () => {
     windowInterface.getLocation.returns({
-      origin: 'https://amp.source.com',
+      origin: 'https://amp.source.test',
     });
     new LinkerManager(
       ampdoc,
@@ -158,7 +158,7 @@ describes.realWin('Linker Manager', {amp: true}, env => {
 
   it('registers anchor mutator if not on proxy but proxyOnly=false', () => {
     windowInterface.getLocation.returns({
-      origin: 'https://amp.source.com',
+      origin: 'https://amp.source.test',
     });
     new LinkerManager(
       ampdoc,
@@ -213,9 +213,9 @@ describes.realWin('Linker Manager', {amp: true}, env => {
     return lm.init().then(() => {
       expect(anchorClickHandlers).to.have.length(1);
       expect(navigateToHandlers).to.have.length(1);
-      const origUrl = 'https://www.source.com/dest?a=1';
+      const origUrl = 'https://www.source.test/dest?a=1';
       const finalUrl =
-        'https://www.source.com/dest' +
+        'https://www.source.test/dest' +
         '?a=1' +
         '&testLinker1=1*drctf3*_key*VGVzdCBUaXRsZQ..*gclid*MjM0' +
         '&testLinker2=1*1u4ugj3*foo*YmFy';
@@ -263,8 +263,8 @@ describes.realWin('Linker Manager', {amp: true}, env => {
     const lm = new LinkerManager(ampdoc, config, /* type */ null, element);
     return lm.init().then(() => {
       expect(anchorClickHandlers).to.have.length(1);
-      expect(clickAnchor('https://www.source.com/dest?a=1')).to.equal(
-        'https://www.source.com/dest?a=1'
+      expect(clickAnchor('https://www.source.test/dest?a=1')).to.equal(
+        'https://www.source.test/dest?a=1'
       );
     });
   });
@@ -286,7 +286,7 @@ describes.realWin('Linker Manager', {amp: true}, env => {
     const lm = new LinkerManager(ampdoc, config, /* type */ null, element);
     return lm.init().then(() => {
       clock.tick(1000 * 60 * 5); // 5 minutes.
-      const linkerUrl = clickAnchor('https://www.source.com/dest?a=1');
+      const linkerUrl = clickAnchor('https://www.source.test/dest?a=1');
 
       windowInterface.history = {replaceState: () => {}};
       windowInterface.location = {href: linkerUrl};
@@ -321,12 +321,12 @@ describes.realWin('Linker Manager', {amp: true}, env => {
         // testLinker1 should apply to both canonical and source
         // testLinker2 should not
         const canonicalDomainUrl = clickAnchor(
-          'https://www.canonical.com/path'
+          'https://www.canonical.test/path'
         );
         expect(canonicalDomainUrl).to.contain('testLinker1=');
         expect(canonicalDomainUrl).to.not.contain('testLinker2=');
 
-        const sourceDomainUrl = clickAnchor('https://www.source.com/path');
+        const sourceDomainUrl = clickAnchor('https://www.source.test/path');
         expect(sourceDomainUrl).to.contain('testLinker1=');
         expect(sourceDomainUrl).to.not.contain('testLinker2=');
 
@@ -453,11 +453,11 @@ describes.realWin('Linker Manager', {amp: true}, env => {
 
       const lm = new LinkerManager(ampdoc, config, /* type */ null, element);
       return lm.init().then(() => {
-        const url1 = clickAnchor('https://www.source.com/path');
+        const url1 = clickAnchor('https://www.source.test/path');
         const url2 = clickAnchor('https://foo.test.com');
         const url3 = clickAnchor('https://test.com');
-        const url4 = clickAnchor('https://canonical.com/path');
-        const url5 = clickAnchor('https://amp.www.canonical.com/path');
+        const url4 = clickAnchor('https://canonical.test/path');
+        const url5 = clickAnchor('https://amp.www.canonical.test/path');
         const url6 = clickAnchor('https://amp.google.com/path');
 
         expect(url1).to.not.contain('testLinker1=');
@@ -484,10 +484,10 @@ describes.realWin('Linker Manager', {amp: true}, env => {
 
       const lm = new LinkerManager(ampdoc, config, /* type */ null, element);
       return lm.init().then(() => {
-        const url1 = clickAnchor('https://www.source.com/path');
-        const url2 = clickAnchor('https://amp.www.source.com/path');
-        const url3 = clickAnchor('https://canonical.com/path');
-        const url4 = clickAnchor('https://amp.www.canonical.com/path');
+        const url1 = clickAnchor('https://www.source.test/path');
+        const url2 = clickAnchor('https://amp.www.source.test/path');
+        const url3 = clickAnchor('https://canonical.test/path');
+        const url4 = clickAnchor('https://amp.www.canonical.test/path');
         const url5 = clickAnchor('https://amp.google.com/path');
 
         expect(url1).to.contain('testLinker1=');
@@ -501,7 +501,7 @@ describes.realWin('Linker Manager', {amp: true}, env => {
 
   it('should respect proxyOnly config', () => {
     windowInterface.getLocation.returns({
-      origin: 'https://amp.source.com',
+      origin: 'https://amp.source.test',
     });
     const config = {
       linkers: {
@@ -523,7 +523,7 @@ describes.realWin('Linker Manager', {amp: true}, env => {
 
     const lm = new LinkerManager(ampdoc, config, /* type */ null, element);
     return lm.init().then(() => {
-      const a = clickAnchor('https://www.source.com/path');
+      const a = clickAnchor('https://www.source.test/path');
       expect(a).to.contain('testLinker1=');
       expect(a).to.not.contain('testLinker2=');
     });
@@ -531,7 +531,7 @@ describes.realWin('Linker Manager', {amp: true}, env => {
 
   it('proxyOnly should default to true', () => {
     windowInterface.getLocation.returns({
-      origin: 'https://amp.source.com',
+      origin: 'https://amp.source.test',
     });
     const config = {
       linkers: {
@@ -552,7 +552,7 @@ describes.realWin('Linker Manager', {amp: true}, env => {
 
     const lm = new LinkerManager(ampdoc, config, /* type */ null, element);
     return lm.init().then(() => {
-      const a = clickAnchor('https://www.source.com');
+      const a = clickAnchor('https://www.source.test');
       expect(a).to.not.contain('testLinker1=');
       expect(a).to.contain('testLinker2=');
     });
@@ -587,9 +587,9 @@ describes.realWin('Linker Manager', {amp: true}, env => {
 
     beforeEach(() => {
       windowInterface.getLocation.returns({
-        origin: 'https://amp.source.com',
+        origin: 'https://amp.source.test',
       });
-      windowInterface.getHostname.returns('amp.source.com');
+      windowInterface.getHostname.returns('amp.source.test');
       config = {
         linkers: {
           testLinker: {
@@ -606,7 +606,7 @@ describes.realWin('Linker Manager', {amp: true}, env => {
     it('should not add linker if same domain', () => {
       const lm = new LinkerManager(ampdoc, config, /* type */ null, element);
       return lm.init().then(() => {
-        const url = clickAnchor('https://amp.source.com/');
+        const url = clickAnchor('https://amp.source.test/');
         expect(url).to.not.contain('testLinker');
       });
     });
@@ -614,7 +614,7 @@ describes.realWin('Linker Manager', {amp: true}, env => {
     it('should add linker if subdomain is different but friendly', () => {
       const lm = new LinkerManager(ampdoc, config, /* type */ null, element);
       return lm.init().then(() => {
-        const url = clickAnchor('https://m.source.com/');
+        const url = clickAnchor('https://m.source.test/');
         expect(url).to.contain('testLinker');
       });
     });
@@ -628,13 +628,13 @@ describes.realWin('Linker Manager', {amp: true}, env => {
             ids: {
               foo: 'bar',
             },
-            destinationDomains: ['amp.source.com'],
+            destinationDomains: ['amp.source.test'],
           },
         },
       };
       const lm = new LinkerManager(ampdoc, config, /* type */ null, element);
       return lm.init().then(() => {
-        const url = clickAnchor('https://amp.source.com/');
+        const url = clickAnchor('https://amp.source.test/');
         expect(url).to.contain('testLinker');
       });
     });
@@ -644,7 +644,7 @@ describes.realWin('Linker Manager', {amp: true}, env => {
       return lm.init().then(() => {
         const a = {
           href: '#hello',
-          hostname: 'amp.source.com',
+          hostname: 'amp.source.test',
         };
         anchorClickHandlers.forEach(handler => handler(a, {type: 'click'}));
         expect(a.href).to.not.contain('testLinker');
@@ -656,7 +656,7 @@ describes.realWin('Linker Manager', {amp: true}, env => {
       return lm.init().then(() => {
         const a = {
           href: '/foo',
-          hostname: 'amp.source.com',
+          hostname: 'amp.source.test',
         };
         anchorClickHandlers.forEach(handler => handler(a, {type: 'click'}));
         expect(a.href).to.not.contain('testLinker');
@@ -683,7 +683,7 @@ describes.realWin('Linker Manager', {amp: true}, env => {
       };
       const lm = new LinkerManager(ampdoc, config, 'googleanalytics', element);
       return lm.init().then(() => {
-        const a = clickAnchor('https://www.source.com/path');
+        const a = clickAnchor('https://www.source.test/path');
         expect(a).to.contain('testLinker1=');
       });
     });
@@ -713,7 +713,7 @@ describes.realWin('Linker Manager', {amp: true}, env => {
         element
       ).init();
       return Promise.all([p1, p2]).then(() => {
-        const a = clickAnchor('https://www.source.com/path');
+        const a = clickAnchor('https://www.source.test/path');
         expect(a).to.not.match(/(testLinker1=.*){2}/);
       });
     });
@@ -969,7 +969,7 @@ describes.realWin('Linker Manager', {amp: true}, env => {
 
     it('should add multiple linker data to one form if not action-xhr', () => {
       windowInterface.getLocation.returns({
-        origin: 'https://www.ampbyexample.com',
+        origin: 'https://www.example.test',
       });
 
       const manager1 = new LinkerManager(
@@ -1011,7 +1011,7 @@ describes.realWin('Linker Manager', {amp: true}, env => {
 
       return Promise.all([p1, p2]).then(() => {
         const form = createForm();
-        form.setAttribute('action', 'https://www.source.com');
+        form.setAttribute('action', 'https://www.source.test');
         const setterSpy = env.sandbox.spy();
         manager1.handleFormSubmit_({form, actionXhrMutator: setterSpy});
         manager2.handleFormSubmit_({form, actionXhrMutator: setterSpy});
@@ -1045,13 +1045,15 @@ describes.realWin('Linker Manager', {amp: true}, env => {
 
 describe('areFriendlyDomains', () => {
   it('should work', () => {
-    expect(areFriendlyDomains('amp.source.com', 'www.source.com')).to.be.true;
-    expect(areFriendlyDomains('m.source.com', 'www.source.com')).to.be.true;
-    expect(areFriendlyDomains('amp.www.source.com', 'source.com')).to.be.true;
-    expect(areFriendlyDomains('amp.source.com', 'm.www.source.com')).to.be.true;
+    expect(areFriendlyDomains('amp.source.test', 'www.source.test')).to.be.true;
+    expect(areFriendlyDomains('m.source.test', 'www.source.test')).to.be.true;
+    expect(areFriendlyDomains('amp.www.source.test', 'source.test')).to.be.true;
+    expect(areFriendlyDomains('amp.source.test', 'm.www.source.test')).to.be
+      .true;
 
-    expect(areFriendlyDomains('amp.source.com', 'amp.google.com')).to.be.false;
-    expect(areFriendlyDomains('web.amp.source.com', 'web.m.source.com')).to.be
+    expect(areFriendlyDomains('amp.source.test', 'amp.google.test')).to.be
+      .false;
+    expect(areFriendlyDomains('web.amp.source.test', 'web.m.source.test')).to.be
       .false;
   });
 });

--- a/extensions/amp-analytics/0.1/test/test-requests.js
+++ b/extensions/amp-analytics/0.1/test/test-requests.js
@@ -65,33 +65,33 @@ describes.realWin('Requests', {amp: 1}, env => {
       });
 
       it('should prepend request origin', function*() {
-        const r = {'baseUrl': '/r1', 'origin': 'http://example.com'};
+        const r = {'baseUrl': '/r1', 'origin': 'http://example.test'};
         const handler = createRequestHandler(r, spy);
         const expansionOptions = new ExpansionOptions({});
 
         handler.send({}, {}, expansionOptions, {});
         yield macroTask();
-        expect(spy).to.be.calledWith('http://example.com/r1');
+        expect(spy).to.be.calledWith('http://example.test/r1');
       });
 
       it('handle trailing slash in request origin', function*() {
-        const r = {'baseUrl': '/r1', 'origin': 'http://example.com/'};
+        const r = {'baseUrl': '/r1', 'origin': 'http://example.test/'};
         const handler = createRequestHandler(r, spy);
         const expansionOptions = new ExpansionOptions({});
 
         handler.send({}, {}, expansionOptions, {});
         yield macroTask();
-        expect(spy).to.be.calledWith('http://example.com/r1');
+        expect(spy).to.be.calledWith('http://example.test/r1');
       });
 
       it('handle trailing path in request origin', function*() {
-        const r = {'baseUrl': '/r1', 'origin': 'http://example.com/test'};
+        const r = {'baseUrl': '/r1', 'origin': 'http://example.test/test'};
         const handler = createRequestHandler(r, spy);
         const expansionOptions = new ExpansionOptions({});
 
         handler.send({}, {}, expansionOptions, {});
         yield macroTask();
-        expect(spy).to.be.calledWith('http://example.com/r1');
+        expect(spy).to.be.calledWith('http://example.test/r1');
       });
 
       it('handle empty requestOrigin', function*() {
@@ -117,20 +117,20 @@ describes.realWin('Requests', {amp: 1}, env => {
       it('handle baseUrl with no leading slash', function*() {
         const r = {
           'baseUrl': 'r1',
-          'origin': 'https://requestorigin.com',
+          'origin': 'https://requestorigin.test',
         };
         const handler = createRequestHandler(r, spy);
         const expansionOptions = new ExpansionOptions({});
 
         handler.send({}, {}, expansionOptions, {});
         yield macroTask();
-        expect(spy).to.be.calledWith('https://requestorigin.comr1');
+        expect(spy).to.be.calledWith('https://requestorigin.testr1');
       });
 
       it('prepend request origin to absolute baseUrl', function*() {
         const r = {
-          'baseUrl': 'https://baseurl.com',
-          'origin': 'https://requestorigin.com',
+          'baseUrl': 'https://baseurl.test',
+          'origin': 'https://requestorigin.test',
         };
         const handler = createRequestHandler(r, spy);
         const expansionOptions = new ExpansionOptions({});
@@ -138,7 +138,7 @@ describes.realWin('Requests', {amp: 1}, env => {
         handler.send({}, {}, expansionOptions, {});
         yield macroTask();
         expect(spy).to.be.calledWith(
-          'https://requestorigin.comhttps://baseurl.com'
+          'https://requestorigin.testhttps://baseurl.test'
         );
       });
 
@@ -161,12 +161,12 @@ describes.realWin('Requests', {amp: 1}, env => {
         const r = {'baseUrl': '/r2', 'origin': '${documentReferrer}'};
         const handler = createRequestHandler(r, spy);
         const expansionOptions = new ExpansionOptions({
-          'documentReferrer': 'http://example.com',
+          'documentReferrer': 'http://example.test',
         });
 
         handler.send({}, {}, expansionOptions, {});
         yield macroTask();
-        expect(spy).to.be.calledWith('http://example.com/r2');
+        expect(spy).to.be.calledWith('http://example.test/r2');
       });
 
       it('should expand nested request origin', function*() {
@@ -174,12 +174,12 @@ describes.realWin('Requests', {amp: 1}, env => {
         const handler = createRequestHandler(r, spy);
         const expansionOptions = new ExpansionOptions({
           'a': '${b}',
-          'b': 'http://example.com',
+          'b': 'http://example.test',
         });
 
         handler.send({}, {}, expansionOptions, {});
         yield macroTask();
-        expect(spy).to.be.calledWith('http://example.com/r3');
+        expect(spy).to.be.calledWith('http://example.test/r3');
       });
     });
 


### PR DESCRIPTION
To avoid any inadvertently sending of a request to a real domain.

ICANN guarantees not to register `.test` domains so they can safely be used.