### PR TITLE
amp-ad-network-doubleclick: Respect meta['referrer'] in AmpDocShadow

### DIFF
--- a/extensions/amp-ad-network-doubleclick-impl/0.1/safeframe-host.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/safeframe-host.js
@@ -248,16 +248,13 @@ export class SafeframeHostApi {
     // Don't allow for referrer policy same-origin,
     // as Safeframe will always be a different origin.
     // Don't allow for no-referrer.
-    const {canonicalUrl} = Services.documentInfoForDoc(
-      this.baseInstance_.getAmpDoc()
-    );
-    const metaReferrer = this.win_.document.querySelector(
-      "meta[name='referrer']"
-    );
+    const ampdoc = this.baseInstance_.getAmpDoc();
+    const {canonicalUrl} = Services.documentInfoForDoc(ampdoc);
+    const metaReferrer = ampdoc.getMetaByName('referrer');
     if (!metaReferrer) {
       return canonicalUrl;
     }
-    switch (metaReferrer.getAttribute('content')) {
+    switch (metaReferrer) {
       case 'same-origin':
         return;
       case 'no-referrer':


### PR DESCRIPTION
Read `meta[name="referrer"]` using method supported by `AmpDocShadow` as well as other `AmpDoc` subtypes.