### PR TITLE
amp-access: Support i-amphtml-access-state lookup in AmpDocShadow

### DIFF
--- a/extensions/amp-access/0.1/amp-access-server-jwt.js
+++ b/extensions/amp-access/0.1/amp-access-server-jwt.js
@@ -98,14 +98,8 @@ export class AccessServerJwtAdapter {
     /** @const @private {!../../../src/service/vsync-impl.Vsync} */
     this.vsync_ = Services.vsyncFor(ampdoc.win);
 
-    const stateElement = ampdoc
-      .getRootNode()
-      .querySelector('meta[name="i-amphtml-access-state"]');
-
     /** @private @const {?string} */
-    this.serverState_ = stateElement
-      ? stateElement.getAttribute('content')
-      : null;
+    this.serverState_ = ampdoc.getMetaByName('i-amphtml-access-state');
 
     const isInExperiment = isExperimentOn(ampdoc.win, 'amp-access-server-jwt');
 

--- a/extensions/amp-access/0.1/amp-access-server.js
+++ b/extensions/amp-access/0.1/amp-access-server.js
@@ -81,14 +81,8 @@ export class AccessServerAdapter {
     /** @const @private {!../../../src/service/vsync-impl.Vsync} */
     this.vsync_ = Services.vsyncFor(ampdoc.win);
 
-    const stateElement = ampdoc
-      .getRootNode()
-      .querySelector('meta[name="i-amphtml-access-state"]');
-
     /** @private @const {?string} */
-    this.serverState_ = stateElement
-      ? stateElement.getAttribute('content')
-      : null;
+    this.serverState_ = ampdoc.getMetaByName('i-amphtml-access-state');
 
     const isInExperiment = isExperimentOn(ampdoc.win, 'amp-access-server');
 


### PR DESCRIPTION
Read `meta[name="i-amphtml-access-state"]` using method supported by
`AmpDocShadow` as well as other `AmpDoc` subtypes.