### PR TITLE
amp-a4a: Identify deprecated uses of amp-3p-iframe-src in ShadowRoot

### DIFF
--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -456,9 +456,8 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
     if (hasUSDRD) {
       warnDeprecation(usdrd);
     }
-    const useRemoteHtml = !!this.win.document.querySelector(
-      'meta[name=amp-3p-iframe-src]'
-    );
+    const useRemoteHtml =
+      this.getAmpDoc().getMetaByName('amp-3p-iframe-src') !== null;
     if (useRemoteHtml) {
       warnDeprecation('remote.html');
     }

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -1778,6 +1778,7 @@ describes.realWin(
         env.sandbox.stub(AmpA4A.prototype, 'buildCallback').callsFake(() => {});
         env.sandbox.stub(impl, 'getAmpDoc').returns({
           whenFirstVisible: () => new Deferred().promise,
+          getMetaByName: () => null,
         });
       });
       afterEach(() => {


### PR DESCRIPTION
Query `meta[name="amp-3p-iframe-src"]` using method supported by
`AmpDocShadow` as well as other `AmpDoc` subtypes.