### PR TITLE
amp-analytics: Support amp-google-client-id-api lookup in AmpDocShadow

### DIFF
--- a/extensions/amp-analytics/0.1/linker-manager.js
+++ b/extensions/amp-analytics/0.1/linker-manager.js
@@ -216,24 +216,36 @@ export class LinkerManager {
   }
 
   /**
-   * If the document has existing cid meta tag they do not need to explicity
+   * If the document has existing cid meta tag they do not need to explicitly
    * opt-in to use linker.
    * @return {boolean}
    * @private
    */
   isLegacyOptIn_() {
-    const optInMeta = this.ampdoc_.win.document.head./*OK*/ querySelector(
-      'meta[name="amp-google-client-id-api"][content="googleanalytics"]'
-    );
+    if (this.type_ !== 'googleanalytics') {
+      return false;
+    }
+
     if (
-      !optInMeta ||
-      optInMeta.hasAttribute(LINKER_CREATED) ||
-      this.type_ !== 'googleanalytics'
+      this.ampdoc_.getMetaByName('amp-google-client-id-api') !==
+      'googleanalytics'
     ) {
       return false;
     }
 
-    optInMeta.setAttribute(LINKER_CREATED, '');
+    const headNode = this.ampdoc_.getHeadNode();
+    const linkerCreatedEl =
+      headNode instanceof ShadowRoot
+        ? this.ampdoc_.getBody()
+        : headNode.querySelector(
+            'meta[name="amp-google-client-id-api"][content="googleanalytics"]'
+          );
+
+    if (linkerCreatedEl.hasAttribute(LINKER_CREATED)) {
+      return false;
+    }
+
+    linkerCreatedEl.setAttribute(LINKER_CREATED, '');
     return true;
   }
 

--- a/src/service/cid-impl.js
+++ b/src/service/cid-impl.js
@@ -303,12 +303,9 @@ class Cid {
    */
   getOptedInScopes_() {
     const apiKeyMap = {};
-    const optInMeta = this.ampdoc.win.document.head./*OK*/ querySelector(
-      `meta[name=${GOOGLE_CID_API_META_NAME}]`
-    );
-    if (optInMeta && optInMeta.hasAttribute('content')) {
-      const list = optInMeta.getAttribute('content').split(',');
-      list.forEach(item => {
+    const optInMeta = this.ampdoc.getMetaByName(GOOGLE_CID_API_META_NAME);
+    if (optInMeta) {
+      optInMeta.split(',').forEach(item => {
         item = item.trim();
         if (item.indexOf('=') > 0) {
           const pair = item.split('=');
@@ -323,7 +320,7 @@ class Cid {
             user().warn(
               TAG_,
               `Unsupported client for Google CID API: ${clientName}.` +
-                `Please remove or correct ${optInMeta./*OK*/ outerHTML}`
+                `Please remove or correct meta[name="${GOOGLE_CID_API_META_NAME}"]`
             );
           }
         }


### PR DESCRIPTION
- Read `meta[name="amp-google-client-id-api"]` using method supported by
  `AmpDocShadow` as well as other `AmpDoc` subtypes.
- Tag `<body>` with `i-amphtml-linker-created` in `AmpDocShadow` since `<meta>`
  element does not exist.