### PR TITLE
amp-action: Support whitelist lookup in AmpDocShadow

### DIFF
--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -807,10 +807,6 @@ export class ActionService {
    * @private
    */
   queryWhitelist_() {
-    const root = this.ampdoc.getRootNode();
-    if (!root.head && !(root instanceof ShadowRoot)) {
-      return null;
-    }
     const actionWhitelist = this.ampdoc.getMetaByName('amp-action-whitelist');
     if (actionWhitelist === null) {
       return null;

--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -807,17 +807,16 @@ export class ActionService {
    * @private
    */
   queryWhitelist_() {
-    const {head} = this.ampdoc.getRootNode();
-    if (!head) {
+    const root = this.ampdoc.getRootNode();
+    if (!root.head && !(root instanceof ShadowRoot)) {
       return null;
     }
-    const meta = head.querySelector('meta[name="amp-action-whitelist"]');
-    if (!meta) {
+    const actionWhitelist = this.ampdoc.getMetaByName('amp-action-whitelist');
+    if (actionWhitelist === null) {
       return null;
     }
     return (
-      meta
-        .getAttribute('content')
+      actionWhitelist
         .split(',')
         // Turn an empty string whitelist into an empty array, otherwise the
         // parse error in the mapper below would trigger.

--- a/test/unit/test-action.js
+++ b/test/unit/test-action.js
@@ -39,7 +39,14 @@ import {whenCalled} from '../../testing/test-helper.js';
  */
 function actionService() {
   const win = {
-    document: {body: {}},
+    document: {
+      body: {},
+      head: {
+        nodeType: /* ELEMENT */ 1,
+        querySelector: () => null,
+        querySelectorAll: () => [],
+      },
+    },
     __AMP_SERVICES: {
       vsync: {obj: {}},
     },


### PR DESCRIPTION
New `getMetaByName` method supports retrieving meta content values in
shadow docs as well.