### PR TITLE
🐛 Subscriptions: Stops stopping propagation of click events

### DIFF
--- a/extensions/amp-subscriptions/0.1/local-subscription-platform-base.js
+++ b/extensions/amp-subscriptions/0.1/local-subscription-platform-base.js
@@ -109,8 +109,11 @@ export class LocalSubscriptionBasePlatform {
    * @protected
    */
   initializeListeners_() {
-    const handleClickAndStopEventPropagation = e => {
-      e.stopPropagation();
+    const handleClickOncePerEvent = e => {
+      if (e.ampSubscriptionsClickHasBeenHandled) {
+        return;
+      }
+      e.ampSubscriptionsClickHasBeenHandled = true;
 
       const element = closestAncestorElementBySelector(
         dev().assertElement(e.target),
@@ -118,18 +121,12 @@ export class LocalSubscriptionBasePlatform {
       );
       this.handleClick_(element);
     };
-    this.rootNode_.addEventListener(
-      'click',
-      handleClickAndStopEventPropagation
-    );
+    this.rootNode_.addEventListener('click', handleClickOncePerEvent);
 
     // If the root node has a `body` property, listen to events on that too,
     // to fix an iOS shadow DOM bug (https://github.com/ampproject/amphtml/issues/25754).
     if (this.rootNode_.body) {
-      this.rootNode_.body.addEventListener(
-        'click',
-        handleClickAndStopEventPropagation
-      );
+      this.rootNode_.body.addEventListener('click', handleClickOncePerEvent);
     }
   }
 

--- a/extensions/amp-subscriptions/0.1/local-subscription-platform-base.js
+++ b/extensions/amp-subscriptions/0.1/local-subscription-platform-base.js
@@ -22,6 +22,12 @@ import {closestAncestorElementBySelector} from '../../../src/dom';
 import {dev, userAssert} from '../../../src/log';
 
 /**
+ * Surrogate property added to click events marking them as handled by the
+ * amp-subscriptions extension.
+ */
+const CLICK_HANDLED_EVENT_PROPERTY = '_AMP_SUBSCRIPTIONS_CLICK_HANDLED';
+
+/**
  * This implements the methods to interact with various subscription platforms.
  *
  * @implements {./subscription-platform.SubscriptionPlatform}
@@ -110,10 +116,10 @@ export class LocalSubscriptionBasePlatform {
    */
   initializeListeners_() {
     const handleClickOncePerEvent = e => {
-      if (e.ampSubscriptionsClickHasBeenHandled) {
+      if (e[CLICK_HANDLED_EVENT_PROPERTY]) {
         return;
       }
-      e.ampSubscriptionsClickHasBeenHandled = true;
+      e[CLICK_HANDLED_EVENT_PROPERTY] = true;
 
       const element = closestAncestorElementBySelector(
         dev().assertElement(e.target),

--- a/extensions/amp-subscriptions/0.1/test/test-local-subscriptions.js
+++ b/extensions/amp-subscriptions/0.1/test/test-local-subscriptions.js
@@ -116,6 +116,17 @@ describes.fakeWin('LocalSubscriptionsPlatform', {amp: true}, env => {
     expect(domStub.getCall(0).args[0]).to.be.equals('click');
   });
 
+  it('initializeListeners_ should handle clicks once per event', () => {
+    const handleClickStub = env.sandbox.stub(
+      localSubscriptionPlatform,
+      'handleClick_'
+    );
+
+    localSubscriptionPlatform.initializeListeners_();
+    localSubscriptionPlatform.rootNode_.body.click();
+    expect(handleClickStub).calledOnce;
+  });
+
   it('should return baseScore', () => {
     expect(localSubscriptionPlatform.getBaseScore()).to.be.equal(99);
   });


### PR DESCRIPTION
Stopping the propagation of `click` events broke the `amp-bind` extension. This PR uses a new method to ensure `click` events are only handled once by the `amp-subscriptions` extension. Basically, an additional property, specific to `amp-subscriptions`, is added to the event when it is first handled, and the handler bails if it is present on a subsequent call.

I plan to test this PR across a variety of devices/browsers using the PR deploy tool described here:
https://github.com/ampproject/amp-github-apps/blob/master/pr-deploy/README.md