### PR TITLE
✨ Add customization options to <amp-story-quiz>

### DIFF
--- a/examples/amp-story/quiz.html
+++ b/examples/amp-story/quiz.html
@@ -63,9 +63,16 @@
           layout="responsive">
       </amp-story-grid-layer>
       <amp-story-grid-layer>
+        <style>
+          #cat-question-appear {
+            --accent-color: cadetblue;
+          }
+        </style>
         <amp-story-quiz
           id='cat-question-appear'
-          endpoint="http://localhost:3000/reactions">
+          endpoint="http://localhost:3000/reactions"
+          chip-corner="sharp"
+          theme="dark">
           <h1>When did the domestic cat first appear on the scene?</h1>
           <option>7,000 years ago</option>
           <option correct>500,000 years ago</option>
@@ -82,7 +89,9 @@
         </amp-story-grid-layer>
         <amp-story-grid-layer>
           <amp-story-quiz
-            id='cat-question-handedness'>
+            id='cat-question-handedness'
+            theme="dark"
+            chip-style="shadow">
             <h2>True or False: Cats can be right-pawed or left-pawed.</h2>
             <option correct>True</option>
             <option>False</option>

--- a/examples/amp-story/quiz.html
+++ b/examples/amp-story/quiz.html
@@ -90,7 +90,6 @@
         <amp-story-grid-layer>
           <amp-story-quiz
             id='cat-question-handedness'
-            theme="dark"
             chip-style="shadow">
             <h2>True or False: Cats can be right-pawed or left-pawed.</h2>
             <option correct>True</option>

--- a/extensions/amp-story/1.0/amp-story-quiz.css
+++ b/extensions/amp-story/1.0/amp-story-quiz.css
@@ -206,7 +206,6 @@ h3.i-amphtml-story-quiz-prompt {
     border-radius: var(--chip-radius) !important;
     font-size: 16px !important;
     line-height: 20px !important;
-    filter: brightness(0.94) !important;
 }
 
 .i-amphtml-story-quiz-post-selection:not(.i-amphtml-story-quiz-has-data) .i-amphtml-story-quiz-option-selected[correct].i-amphtml-story-quiz-option::before {

--- a/extensions/amp-story/1.0/amp-story-quiz.css
+++ b/extensions/amp-story/1.0/amp-story-quiz.css
@@ -82,7 +82,7 @@ h3.i-amphtml-story-quiz-prompt {
     align-items: center !important;
     border-radius: var(--chip-radius) !important;
     padding: 8px 16px 8px 8px !important;
-    background-color: transparent !important;
+    background-color: var(--theme-background) !important;
     margin-bottom: 8px !important;
     color: var(--option-text-color) !important;
     border: solid 1px var(--theme-border) !important;

--- a/extensions/amp-story/1.0/amp-story-quiz.css
+++ b/extensions/amp-story/1.0/amp-story-quiz.css
@@ -193,6 +193,20 @@ h3.i-amphtml-story-quiz-prompt {
     font-size: 0 !important;
 }
 
+.i-amphtml-story-quiz-post-selection.i-amphtml-story-quiz-has-data .i-amphtml-story-quiz-option-selected:not([correct]) .i-amphtml-story-quiz-answer-choice {
+    background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24px' height='24px' viewBox='0 0 24 24' fill='%23FFFFFF'%3E%3Cpath d='M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z'/%3E%3Cpath d='M0 0h24v24H0z' fill='none'/%3E%3C/svg%3E") !important;
+    background-repeat: no-repeat !important;
+    background-position: center !important;
+    font-size: 0 !important;
+}
+
+.i-amphtml-story-quiz-post-selection.i-amphtml-story-quiz-has-data .i-amphtml-story-quiz-option-selected[correct] .i-amphtml-story-quiz-answer-choice {
+    background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24px' height='24px' viewBox='0 0 24 24' fill='%23FFFFFF'%3E%3Cpath fill='none' d='M0 0h24v24H0z'/%3E%3Cpath d='M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z'/%3E%3C/svg%3E") !important;
+    background-repeat: no-repeat !important;
+    background-position: center !important;
+    font-size: 0 !important;
+}
+
 .i-amphtml-story-quiz-option > * {
     position: relative !important;
 }

--- a/extensions/amp-story/1.0/amp-story-quiz.css
+++ b/extensions/amp-story/1.0/amp-story-quiz.css
@@ -21,7 +21,6 @@
     --correct-color-shaded: #2D8E42 !important;
     --incorrect-color: #F34E4E !important;
     --incorrect-color-shaded: #cc4141 !important;
-    --accent-color: #005AF0;
     --option-1-percentage: 0%;
     --option-2-percentage: 0%;
     --option-3-percentage: 0%;
@@ -31,11 +30,13 @@
     border-radius: 32px !important;
 }
 
+/* TODO: remove bg on no-prompt attribute here */
+
 .i-amphtml-story-quiz-prompt-container {
     display: flex !important;
     justify-items: center !important;
     padding: 20px !important;
-    color: white !important;
+    color: var(--prompt-text-color) !important;
 }
 
 .i-amphtml-story-quiz-prompt {
@@ -69,8 +70,8 @@ h3.i-amphtml-story-quiz-prompt {
 .i-amphtml-story-quiz-option-container {
     display: flex !important;
     flex-direction: column;
-    background-color: white !important;
-    border-radius: 30px !important;
+    background-color: var(--theme-background) !important;
+    border-radius: var(--chip-radius) !important;
     padding: 8px 8px 0px 8px !important;
 }
 
@@ -79,12 +80,15 @@ h3.i-amphtml-story-quiz-prompt {
     display: flex !important;
     justify-items: start !important;
     align-items: center !important;
-    border-radius: 30px !important;
+    border-radius: var(--chip-radius) !important;
     padding: 8px 16px 8px 8px !important;
     background-color: transparent !important;
     margin-bottom: 8px !important;
-    color: #5F6368 !important;
-    border: solid 1px #DADCE0 !important;
+    color: var(--option-text-color) !important;
+    border: solid 1px var(--theme-border) !important;
+    box-shadow: var(--chip-shadow) !important;
+    -webkit-box-shadow: var(--chip-shadow) !important;
+    -moz-box-shadow: var(--chip-shadow) !important;
     font-size: 16px !important;
     line-height: 20px !important;
     overflow: hidden !important;
@@ -167,12 +171,13 @@ h3.i-amphtml-story-quiz-prompt {
 .i-amphtml-story-quiz-post-selection .i-amphtml-story-quiz-option-selected > .i-amphtml-story-quiz-answer-choice {
     border: solid 2px white !important;
     animation: answer-choice-bounce forwards 600ms linear;
+    background-color: white !important;
 }
 
 /** TODO(jackbsteinberg): Use a more a11y-friendly approach than font-size: 0px; */
 
 .i-amphtml-story-quiz-post-selection [correct] > .i-amphtml-story-quiz-answer-choice {
-    background-color: white !important;
+    background-color: var(--theme-background);
     background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24px' height='24px' viewBox='0 0 24 24' fill='%235BBA74'%3E%3Cpath fill='none' d='M0 0h24v24H0z'/%3E%3Cpath d='M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z'/%3E%3C/svg%3E") !important;
     background-repeat: no-repeat !important;
     background-position: center !important;
@@ -180,7 +185,7 @@ h3.i-amphtml-story-quiz-prompt {
 }
 
 .i-amphtml-story-quiz-post-selection :not([correct]) > .i-amphtml-story-quiz-answer-choice {
-    background-color: white !important;
+    background-color: var(--theme-background);
     background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24px' height='24px' viewBox='0 0 24 24' fill='%23F34E4E'%3E%3Cpath d='M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z'/%3E%3Cpath d='M0 0h24v24H0z' fill='none'/%3E%3C/svg%3E") !important;
     background-repeat: no-repeat !important;
     background-position: center !important;
@@ -198,9 +203,10 @@ h3.i-amphtml-story-quiz-prompt {
     left: -1px !important;
     width: 100% !important;
     height: 100% !important;
-    border-radius: 32px !important;
+    border-radius: var(--chip-radius) !important;
     font-size: 16px !important;
     line-height: 20px !important;
+    filter: brightness(0.94) !important;
 }
 
 .i-amphtml-story-quiz-post-selection:not(.i-amphtml-story-quiz-has-data) .i-amphtml-story-quiz-option-selected[correct].i-amphtml-story-quiz-option::before {
@@ -251,8 +257,8 @@ h3.i-amphtml-story-quiz-prompt {
     width: 100% !important;
     height: 100% !important;
     border-radius: 0px !important;
-    background: #ECEDEF !important;
-    color: #ECEDEF !important;
+    background: var(--theme-shading) !important;
+    color: var(--theme-shading) !important;
     transition: transform 1s !important;
     border: solid 2px !important;
 }

--- a/extensions/amp-story/1.0/amp-story-quiz.css
+++ b/extensions/amp-story/1.0/amp-story-quiz.css
@@ -18,15 +18,15 @@
 
 .i-amphtml-story-quiz-container {
     --correct-color: #5BBA74 !important;
-    --correct-color-shaded: #2D8E42 !important;
+    --correct-color-shaded: #00600f !important;
     --incorrect-color: #F34E4E !important;
-    --incorrect-color-shaded: #cc4141 !important;
+    --incorrect-color-shaded: #B71C1C !important;
     --option-1-percentage: 0%;
     --option-2-percentage: 0%;
     --option-3-percentage: 0%;
     --option-4-percentage: 0%;
     font-family: 'Poppins-bold', sans-serif !important;
-    background: var(--accent-color) !important;
+    background: var(--reaction-accent-color) !important;
     border-radius: 32px !important;
 }
 
@@ -36,7 +36,7 @@
     display: flex !important;
     justify-items: center !important;
     padding: 20px !important;
-    color: var(--prompt-text-color) !important;
+    color: var(--reaction-prompt-text-color) !important;
 }
 
 .i-amphtml-story-quiz-prompt {
@@ -70,8 +70,8 @@ h3.i-amphtml-story-quiz-prompt {
 .i-amphtml-story-quiz-option-container {
     display: flex !important;
     flex-direction: column;
-    background-color: var(--theme-background) !important;
-    border-radius: var(--chip-radius) !important;
+    background-color: var(--reaction-theme-background) !important;
+    border-radius: var(--reaction-chip-radius) !important;
     padding: 8px 8px 0px 8px !important;
 }
 
@@ -80,15 +80,15 @@ h3.i-amphtml-story-quiz-prompt {
     display: flex !important;
     justify-items: start !important;
     align-items: center !important;
-    border-radius: var(--chip-radius) !important;
+    border-radius: var(--reaction-chip-radius) !important;
     padding: 8px 16px 8px 8px !important;
-    background-color: var(--theme-background) !important;
+    background-color: var(--reaction-theme-background) !important;
     margin-bottom: 8px !important;
-    color: var(--option-text-color) !important;
-    border: solid 1px var(--theme-border) !important;
-    box-shadow: var(--chip-shadow) !important;
-    -webkit-box-shadow: var(--chip-shadow) !important;
-    -moz-box-shadow: var(--chip-shadow) !important;
+    color: var(--reaction-option-text-color) !important;
+    border: solid 1px var(--reaction-theme-border) !important;
+    box-shadow: var(--reaction-chip-shadow) !important;
+    -webkit-box-shadow: var(--reaction-chip-shadow) !important;
+    -moz-box-shadow: var(--reaction-chip-shadow) !important;
     font-size: 16px !important;
     line-height: 20px !important;
     overflow: hidden !important;
@@ -126,7 +126,8 @@ h3.i-amphtml-story-quiz-prompt {
     border: solid 2px !important;
     padding: 5px !important;
     margin-right: 16px !important;
-    color: var(--accent-color) !important;
+    color: var(--reaction-accent-color) !important;
+    border-color: var(--reaction-answer-choice-border) !important;
     font-size: 16px !important;
     line-height: 16px !important;
     font-weight: bold !important;
@@ -162,22 +163,23 @@ h3.i-amphtml-story-quiz-prompt {
 
 .i-amphtml-story-quiz-post-selection :not([correct]) > .i-amphtml-story-quiz-answer-choice {
     color: var(--incorrect-color) !important;
+    border-color: var(--incorrect-color) !important;
 }
 
 .i-amphtml-story-quiz-post-selection [correct] > .i-amphtml-story-quiz-answer-choice {
     color: var(--correct-color) !important;
+    border-color: var(--correct-color) !important;
 }
 
 .i-amphtml-story-quiz-post-selection .i-amphtml-story-quiz-option-selected > .i-amphtml-story-quiz-answer-choice {
-    border: solid 2px white !important;
+    border: solid 2px var(--reaction-answer-choice-border) !important;
     animation: answer-choice-bounce forwards 600ms linear;
-    background-color: white !important;
+    background-color: var(--reaction-answer-choice-background) !important;
 }
 
 /** TODO(jackbsteinberg): Use a more a11y-friendly approach than font-size: 0px; */
 
 .i-amphtml-story-quiz-post-selection [correct] > .i-amphtml-story-quiz-answer-choice {
-    background-color: var(--theme-background);
     background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24px' height='24px' viewBox='0 0 24 24' fill='%235BBA74'%3E%3Cpath fill='none' d='M0 0h24v24H0z'/%3E%3Cpath d='M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z'/%3E%3C/svg%3E") !important;
     background-repeat: no-repeat !important;
     background-position: center !important;
@@ -185,7 +187,6 @@ h3.i-amphtml-story-quiz-prompt {
 }
 
 .i-amphtml-story-quiz-post-selection :not([correct]) > .i-amphtml-story-quiz-answer-choice {
-    background-color: var(--theme-background);
     background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24px' height='24px' viewBox='0 0 24 24' fill='%23F34E4E'%3E%3Cpath d='M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z'/%3E%3Cpath d='M0 0h24v24H0z' fill='none'/%3E%3C/svg%3E") !important;
     background-repeat: no-repeat !important;
     background-position: center !important;
@@ -203,7 +204,7 @@ h3.i-amphtml-story-quiz-prompt {
     left: -1px !important;
     width: 100% !important;
     height: 100% !important;
-    border-radius: var(--chip-radius) !important;
+    border-radius: var(--reaction-chip-radius) !important;
     font-size: 16px !important;
     line-height: 20px !important;
 }
@@ -256,8 +257,8 @@ h3.i-amphtml-story-quiz-prompt {
     width: 100% !important;
     height: 100% !important;
     border-radius: 0px !important;
-    background: var(--theme-shading) !important;
-    color: var(--theme-shading) !important;
+    background: var(--reaction-theme-shading) !important;
+    color: var(--reaction-theme-shading) !important;
     transition: transform 1s !important;
     border: solid 2px !important;
 }
@@ -268,23 +269,23 @@ h3.i-amphtml-story-quiz-prompt {
 
 .i-amphtml-story-quiz-post-selection.i-amphtml-story-quiz-has-data .i-amphtml-story-quiz-option-selected[correct].i-amphtml-story-quiz-option {
     background: var(--correct-color) !important;
-    border: none !important;
 }
 
 .i-amphtml-story-quiz-post-selection.i-amphtml-story-quiz-has-data .i-amphtml-story-quiz-option-selected:not([correct]).i-amphtml-story-quiz-option {
     background: var(--incorrect-color) !important;
-    border: none !important;
 }
 
-.i-amphtml-story-quiz-post-selection.i-amphtml-story-quiz-has-data .i-amphtml-story-quiz-option-selected.i-amphtml-story-quiz-option {
+.i-amphtml-story-quiz-post-selection .i-amphtml-story-quiz-option-selected.i-amphtml-story-quiz-option {
     /* Ups the padding by one to account for the border which must be removed
      * to allow the shading to reach the edge of the box */
      padding: 9px 17px 9px 9px !important;
+     border: none !important;
 }
 
-.i-amphtml-story-quiz-post-selection.i-amphtml-story-quiz-has-data[dir=rtl] .i-amphtml-story-quiz-option-selected.i-amphtml-story-quiz-option {
+.i-amphtml-story-quiz-post-selection[dir=rtl] .i-amphtml-story-quiz-option-selected.i-amphtml-story-quiz-option {
     /* Switches the extra padding to the left from the right, since the answer choice and the percentage switch */
     padding: 9px 9px 9px 17px !important;
+    border: none !important;
 }
 
 .i-amphtml-story-quiz-post-selection.i-amphtml-story-quiz-has-data .i-amphtml-story-quiz-option-selected[correct].i-amphtml-story-quiz-option::before {
@@ -308,7 +309,7 @@ h3.i-amphtml-story-quiz-prompt {
 @keyframes answer-choice-bounce {
     0% {
         visibility: hidden;
-        border: solid 2px transparent;
+        border: solid 2px var(--reaction-answer-choice-background);
         transform: scale(0);
     }
     20% {
@@ -399,7 +400,7 @@ h3.i-amphtml-story-quiz-prompt {
     98% { transform: scale(0.9992426461382049); }
     99% { transform: scale(0.9988663284742909); }
     100% { 
-        border: solid 2px white;
+        border: solid 2px var(--reaction-answer-choice-background);
         transform: scale(1); 
     }
 }

--- a/extensions/amp-story/1.0/amp-story-quiz.js
+++ b/extensions/amp-story/1.0/amp-story-quiz.js
@@ -242,7 +242,7 @@ export class AmpStoryQuiz extends AMP.BaseElement {
         TAG,
         'The first child must be a heading element <h1>, <h2>, or <h3>'
       );
-      promptContainer.remove();
+      this.quizEl_.removeChild(promptContainer);
     } else {
       const prompt = document.createElement(promptInput.tagName);
 

--- a/extensions/amp-story/1.0/amp-story-quiz.js
+++ b/extensions/amp-story/1.0/amp-story-quiz.js
@@ -232,18 +232,26 @@ export class AmpStoryQuiz extends AMP.BaseElement {
   attachContent_() {
     // TODO(jackbsteinberg): Optional prompt behavior must be implemented here
     const promptInput = this.element.children[0];
+    const promptContainer = this.quizEl_.querySelector(
+      '.i-amphtml-story-quiz-prompt-container'
+    );
+
     // First child must be heading h1-h3
     if (!['h1', 'h2', 'h3'].includes(promptInput.tagName.toLowerCase())) {
       dev().error(
         TAG,
         'The first child must be a heading element <h1>, <h2>, or <h3>'
       );
-    }
+      promptContainer.remove();
+    } else {
+      const prompt = document.createElement(promptInput.tagName);
 
-    const prompt = document.createElement(promptInput.tagName);
-    prompt.textContent = promptInput.textContent;
-    prompt.classList.add('i-amphtml-story-quiz-prompt');
-    this.element.removeChild(promptInput);
+      prompt.textContent = promptInput.textContent;
+      prompt.classList.add('i-amphtml-story-quiz-prompt');
+
+      this.element.removeChild(promptInput);
+      promptContainer.appendChild(prompt);
+    }
 
     const options = toArray(this.element.querySelectorAll('option'));
     if (options.length < 2 || options.length > 4) {

--- a/extensions/amp-story/1.0/amp-story-quiz.js
+++ b/extensions/amp-story/1.0/amp-story-quiz.js
@@ -258,10 +258,6 @@ export class AmpStoryQuiz extends AMP.BaseElement {
       dev().error(TAG, 'Improper number of options');
     }
 
-    this.quizEl_
-      .querySelector('.i-amphtml-story-quiz-prompt-container')
-      .appendChild(prompt);
-
     // Localize the answer choice options
     this.answerChoiceOptions_ = this.answerChoiceOptions_.map(choice => {
       return this.localizationService_.getLocalizedString(

--- a/extensions/amp-story/1.0/amp-story.css
+++ b/extensions/amp-story/1.0/amp-story.css
@@ -1009,4 +1009,29 @@ amp-story-quiz {
   /* 224px = the width of a narrow phone (320px) - tap-safe margins (48px * 2) */
   min-width: 224px !important;
   max-width: 400px !important;
+  --accent-color: #005AF0;
+  --prompt-text-color: white;
+  --option-text-color: #5F6368;
+  --theme-background: white !important;
+  --theme-border: #DADCE0 !important;
+  --theme-shading: #ECEDEF !important;
+  --chip-radius: 32px !important;
+  --chip-shadow: none !important
+}
+
+amp-story-quiz[theme="dark"] {
+  --option-text-color: white;
+  --theme-background: #202124 !important;
+  --theme-border: #3C4043 !important;
+  --theme-shading: rgb(42, 96, 150) !important;
+  /* TODO: need fill color for non-selected percentages */
+}
+
+amp-story-quiz[chip-corner="sharp"] {
+  --chip-radius: 8px !important;
+}
+
+amp-story-quiz[chip-style="shadow"] {
+  --chip-shadow: 0px 2px 8px 0px rgba(0, 0, 0, 0.3) !important;
+  --theme-border: rgba(0, 0, 0, 0) !important;
 }

--- a/extensions/amp-story/1.0/amp-story.css
+++ b/extensions/amp-story/1.0/amp-story.css
@@ -1023,8 +1023,7 @@ amp-story-quiz[theme="dark"] {
   --option-text-color: white;
   --theme-background: #202124 !important;
   --theme-border: #3C4043 !important;
-  --theme-shading: rgb(42, 96, 150) !important;
-  /* TODO: need fill color for non-selected percentages */
+  --theme-shading: #3C4043 !important;
 }
 
 amp-story-quiz[chip-corner="sharp"] {

--- a/extensions/amp-story/1.0/amp-story.css
+++ b/extensions/amp-story/1.0/amp-story.css
@@ -1009,28 +1009,36 @@ amp-story-quiz {
   /* 224px = the width of a narrow phone (320px) - tap-safe margins (48px * 2) */
   min-width: 224px !important;
   max-width: 400px !important;
-  --accent-color: #005AF0;
-  --prompt-text-color: white;
-  --option-text-color: #5F6368;
-  --theme-background: white !important;
-  --theme-border: #DADCE0 !important;
-  --theme-shading: #ECEDEF !important;
-  --chip-radius: 32px !important;
-  --chip-shadow: none !important
+  --reaction-accent-color: #005AF0;
+  --reaction-prompt-text-color: white;
+  --reaction-option-text-color: #5F6368;
+  --reaction-theme-background: white !important;
+  --reaction-theme-border: #DADCE0 !important;
+  --reaction-theme-shading: #ECEDEF !important;
+  --reaction-chip-radius: 32px !important;
+  --reaction-chip-shadow: none !important;
+  --reaction-answer-choice-border: var(--reaction-accent-color) !important;
+  --reaction-answer-choice-background: white !important;
 }
 
 amp-story-quiz[theme="dark"] {
-  --option-text-color: white;
-  --theme-background: #202124 !important;
-  --theme-border: #3C4043 !important;
-  --theme-shading: #3C4043 !important;
+  --reaction-option-text-color: white;
+  --reaction-theme-background: #202124 !important;
+  --reaction-theme-border: #3C4043 !important;
+  --reaction-theme-shading: #3C4043 !important;
 }
 
 amp-story-quiz[chip-corner="sharp"] {
-  --chip-radius: 8px !important;
+  --reaction-chip-radius: 8px !important;
+  --reaction-answer-choice-border: transparent !important;
+  --reaction-answer-choice-background: transparent !important;
 }
 
 amp-story-quiz[chip-style="shadow"] {
-  --chip-shadow: 0px 2px 8px 0px rgba(0, 0, 0, 0.3) !important;
-  --theme-border: rgba(0, 0, 0, 0) !important;
+  --reaction-chip-shadow: 0px 2px 8px rgba(60, 60, 60, 0.12) !important;
+  --reaction-theme-border: rgba(0, 0, 0, 0) !important;
+}
+
+amp-story-quiz[chip-style="shadow"][theme="dark"] {
+  --reaction-chip-shadow: 0px 2px 8px 0px rgba(0, 0, 0, 0.3) !important;
 }


### PR DESCRIPTION
Adds methods to customize the <amp-story-quiz> element via CSS custom properties for color customizations, or HTML attributes on the element for other customizations. 

Additionally adds support for leaving off the prompt of a quiz, in the case where a publisher wants to present only the quiz options.

### Attributes
* `theme`: controls the theme of the quiz - **`light`**, `dark`
* `chip-corner`: controls the sharpness of the corners on the option chip - **`round`**, `sharp`
* `chip-style`: controls the UI style of the option chips - **`outline`**, `shadow`

### Custom Properties:
 * `--accent-color`: controls the accent color of the quiz - default `#005AF0`
* `--prompt-text-color`: controls the color of the prompt text - default `#FFFFFF`
* `--option-text-color`: controls the color of the option text - default `#5F6368`

Adds work related to tracking issue #25615