### PR TITLE
♻️Introduce split in a4a request flow.

### DIFF
--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -724,10 +724,9 @@ export class AmpA4A extends AMP.BaseElement {
         }
         return adUrl && this.sendXhrRequest(adUrl);
       })
-      // The following block returns either the response (as a
-      // {bytes, headers} object), or null if no response is available /
-      // response is empty.
-      /** @return {?Promise<?{bytes: !ArrayBuffer, headers: !Headers}>} */
+      // The following block returns either the response or throws if no
+      // response is available / response is empty.
+      /** @return {!Promise<!Response>} */
       .then(fetchResponse => {
         checkStillCurrent();
         this.maybeTriggerAnalyticsEvent_('adRequestEnd');
@@ -803,7 +802,7 @@ export class AmpA4A extends AMP.BaseElement {
       });
 
     const validationPromise = this.shouldNotVerifySigning_
-      ? fetchPromise.then(res => this.handleWithoutSigning_(res))
+      ? fetchPromise.then(unusedRes => this.handleWithoutSigning_())
       : fetchPromise.then(res =>
           this.handleSignedResponse_(res, checkStillCurrent)
         );


### PR DESCRIPTION
In prep for removing signing experiment. Tries to encapsulate the signing related work into its own method that will not be called in unsigned flow.

May still need to move some shared logic (eg extension preloading) at the end of the promise chain. Will clean it up when new rendering engine is introduced in follow up PR.