### PR TITLE
Revert user-agent check in performance-impl

### DIFF
--- a/extensions/amp-access/0.1/test/test-amp-access-source.js
+++ b/extensions/amp-access/0.1/test/test-amp-access-source.js
@@ -23,7 +23,6 @@ import {AccessSource} from '../amp-access-source';
 import {AccessVendorAdapter} from '../amp-access-vendor';
 import {cidServiceForDocForTesting} from '../../../../src/service/cid-impl';
 import {installPerformanceService} from '../../../../src/service/performance-impl';
-import {installPlatformService} from '../../../../src/service/platform-impl';
 import {toggleExperiment} from '../../../../src/experiments';
 
 describes.fakeWin(
@@ -46,7 +45,6 @@ describes.fakeWin(
       document = win.document;
 
       cidServiceForDocForTesting(ampdoc);
-      installPlatformService(win);
       installPerformanceService(win);
 
       element = document.createElement('script');
@@ -268,7 +266,6 @@ describes.fakeWin(
       clock.tick(0);
 
       cidServiceForDocForTesting(ampdoc);
-      installPlatformService(win);
       installPerformanceService(win);
 
       const config = {
@@ -388,7 +385,6 @@ describes.fakeWin(
       clock.tick(0);
 
       cidServiceForDocForTesting(ampdoc);
-      installPlatformService(win);
       installPerformanceService(win);
 
       const config = {

--- a/extensions/amp-access/0.1/test/test-amp-access.js
+++ b/extensions/amp-access/0.1/test/test-amp-access.js
@@ -21,7 +21,6 @@ import {Observable} from '../../../../src/observable';
 import {Services} from '../../../../src/services';
 import {cidServiceForDocForTesting} from '../../../../src/service/cid-impl';
 import {installPerformanceService} from '../../../../src/service/performance-impl';
-import {installPlatformService} from '../../../../src/service/platform-impl';
 import {toggleExperiment} from '../../../../src/experiments';
 
 describes.fakeWin(
@@ -41,7 +40,6 @@ describes.fakeWin(
       document = win.document;
 
       cidServiceForDocForTesting(ampdoc);
-      installPlatformService(win);
       installPerformanceService(win);
 
       element = document.createElement('script');
@@ -277,7 +275,6 @@ describes.fakeWin(
       clock.tick(0);
 
       cidServiceForDocForTesting(ampdoc);
-      installPlatformService(win);
       installPerformanceService(win);
 
       configElement = document.createElement('script');
@@ -567,7 +564,6 @@ describes.fakeWin(
       document = win.document;
 
       cidServiceForDocForTesting(ampdoc);
-      installPlatformService(win);
       installPerformanceService(win);
 
       configElement = document.createElement('script');
@@ -728,7 +724,6 @@ describes.fakeWin(
       clock = env.sandbox.useFakeTimers();
 
       cidServiceForDocForTesting(ampdoc);
-      installPlatformService(win);
       installPerformanceService(win);
 
       configElement = document.createElement('script');
@@ -1129,7 +1124,6 @@ describes.fakeWin(
       document = win.document;
 
       cidServiceForDocForTesting(ampdoc);
-      installPlatformService(win);
       installPerformanceService(win);
 
       configElement = document.createElement('script');
@@ -1214,7 +1208,6 @@ describes.fakeWin(
       clock = env.sandbox.useFakeTimers();
 
       cidServiceForDocForTesting(ampdoc);
-      installPlatformService(win);
       installPerformanceService(win);
 
       configElement = document.createElement('script');
@@ -1627,7 +1620,6 @@ describes.fakeWin(
       document = win.document;
 
       cidServiceForDocForTesting(ampdoc);
-      installPlatformService(win);
       installPerformanceService(win);
 
       configElement = document.createElement('script');
@@ -1757,7 +1749,6 @@ describes.fakeWin(
       clock.tick(0);
 
       cidServiceForDocForTesting(ampdoc);
-      installPlatformService(win);
       installPerformanceService(win);
 
       configElement = document.createElement('script');

--- a/src/inabox/amp-inabox.js
+++ b/src/inabox/amp-inabox.js
@@ -36,7 +36,6 @@ import {
 import {installDocService} from '../service/ampdoc-impl';
 import {installErrorReporting} from '../error';
 import {installPerformanceService} from '../service/performance-impl';
-import {installPlatformService} from '../service/platform-impl';
 import {
   installStylesForDoc,
   makeBodyVisible,
@@ -73,7 +72,6 @@ allowLongTasksInChunking();
 startupChunk(self.document, function initial() {
   /** @const {!../service/ampdoc-impl.AmpDoc} */
   const ampdoc = ampdocService.getAmpDoc(self.document);
-  installPlatformService(self);
   installPerformanceService(self);
   /** @const {!../service/performance-impl.Performance} */
   const perf = Services.performanceFor(self);

--- a/src/service/performance-impl.js
+++ b/src/service/performance-impl.js
@@ -91,16 +91,6 @@ export class Performance {
     this.fvrDeferred_ = new Deferred();
     this.mbvDeferred_ = new Deferred();
 
-    // Platform service must be installed before performance serivce is
-    this.platform_ = Services.platformFor(this.win);
-
-    // TODO (micajuineho) change this once all platforms
-    // support PerformancePaintTiming
-    // https://developer.mozilla.org/en-US/docs/Web/API/PerformancePaintTiming
-    if (!this.platform_.isChrome() && !this.platform_.isOpera()) {
-      this.fcpDeferred_.resolve(null);
-    }
-
     /**
      * How many times a layout jank metric has been ticked.
      *
@@ -387,6 +377,10 @@ export class Performance {
       // https://bugs.chromium.org/p/chromium/issues/detail?id=725567
       this.win.performance.getEntriesByType('paint').forEach(processEntry);
       entryTypesToObserve.push('paint');
+    } else {
+      // PerformancePaintTiming is not currently supported by all user-agents
+      // https://developer.mozilla.org/en-US/docs/Web/API/PerformancePaintTiming
+      this.fcpDeferred_.resolve(null);
     }
 
     if (this.supportsEventTimingAPIv76_) {

--- a/test/unit/test-layout-delay-meter.js
+++ b/test/unit/test-layout-delay-meter.js
@@ -18,7 +18,6 @@ import * as lolex from 'lolex';
 import {LayoutDelayMeter} from '../../src/layout-delay-meter';
 import {Services} from '../../src/services';
 import {installPerformanceService} from '../../src/service/performance-impl';
-import {installPlatformService} from '../../src/service/platform-impl';
 
 describes.realWin(
   'layout-delay-meter',
@@ -35,7 +34,6 @@ describes.realWin(
 
     beforeEach(() => {
       win = env.win;
-      installPlatformService(win);
       installPerformanceService(win);
       const perf = Services.performanceFor(win);
       env.sandbox.stub(perf, 'isPerformanceTrackingOn').callsFake(() => true);

--- a/test/unit/test-performance.js
+++ b/test/unit/test-performance.js
@@ -20,7 +20,6 @@ import {Services} from '../../src/services';
 import {VisibilityState} from '../../src/visibility-state';
 import {getMode} from '../../src/mode';
 import {installPerformanceService} from '../../src/service/performance-impl';
-import {installPlatformService} from '../../src/service/platform-impl';
 import {installRuntimeServices} from '../../src/service/core-services';
 
 describes.realWin('performance', {amp: true}, env => {
@@ -39,7 +38,6 @@ describes.realWin('performance', {amp: true}, env => {
       // set initial Date.now to 100, so that we can differentiate between time relative to epoch and relative to process start (value vs. delta).
       now: timeOrigin,
     });
-    installPlatformService(env.win);
     installPerformanceService(env.win);
     perf = Services.performanceFor(env.win);
   });
@@ -760,7 +758,6 @@ describes.realWin('performance with experiment', {amp: true}, env => {
       .withArgs('csi')
       .returns('1');
     env.sandbox.stub(viewer, 'isEmbedded').returns(true);
-    installPlatformService(win);
     installPerformanceService(win);
     perf = Services.performanceFor(win);
   });

--- a/test/unit/test-style-installer.js
+++ b/test/unit/test-style-installer.js
@@ -21,7 +21,6 @@ import {Services} from '../../src/services';
 import {createShadowRoot} from '../../src/shadow-embed';
 import {getStyle} from '../../src/style';
 import {installPerformanceService} from '../../src/service/performance-impl';
-import {installPlatformService} from '../../src/service/platform-impl';
 import {isAnimationNone} from '../../testing/test-helper';
 import {setShadowDomSupportedVersionForTesting} from '../../src/web-components';
 
@@ -37,7 +36,6 @@ describe('Styles', () => {
       win = env.win;
       doc = win.document;
       ampdoc = env.ampdoc;
-      installPlatformService(win);
       installPerformanceService(win);
       const perf = Services.performanceFor(win);
       tickSpy = env.sandbox.spy(perf, 'tick');


### PR DESCRIPTION
Check [window.PerformancePaintTiming](https://developer.mozilla.org/en-US/docs/Web/API/PerformancePaintTiming) instead of user-agent to see if `first-contentful-paint` and` first-paint` are supported.

[Reverts the installation of platform service](https://github.com/ampproject/amphtml/pull/25259) in some places.
