### PR TITLE
variable substitutions: Support whitelist lookup in AmpDocShadow

### DIFF
--- a/src/service/url-replacements-impl.js
+++ b/src/service/url-replacements-impl.js
@@ -1037,15 +1037,9 @@ export class UrlReplacements {
       return true;
     }
 
-    const meta = this.ampdoc
-      .getRootNode()
-      .querySelector('meta[name=amp-link-variable-allowed-origin]');
-
-    if (meta && meta.hasAttribute('content')) {
-      const whitelist = meta
-        .getAttribute('content')
-        .trim()
-        .split(/\s+/);
+    const meta = this.ampdoc.getMetaByName('amp-link-variable-allowed-origin');
+    if (meta) {
+      const whitelist = meta.trim().split(/\s+/);
       for (let i = 0; i < whitelist.length; i++) {
         if (url.origin == parseUrlDeprecated(whitelist[i]).origin) {
           return true;

--- a/src/service/variable-source.js
+++ b/src/service/variable-source.js
@@ -339,15 +339,10 @@ export class VariableSource {
       return this.variableWhitelist_;
     }
 
-    const {head} = this.ampdoc.getRootNode();
-    if (!head) {
-      return null;
-    }
-
     // A meta[name="amp-allowed-url-macros"] tag, if present,
     // contains, in its content attribute, a whitelist of variable substitution.
-    const meta = head.querySelector('meta[name="amp-allowed-url-macros"]');
-    if (!meta) {
+    const meta = this.ampdoc.getMetaByName('amp-allowed-url-macros');
+    if (meta === null) {
       return null;
     }
 
@@ -355,10 +350,7 @@ export class VariableSource {
      * The whitelist of variables allowed for variable substitution.
      * @private {?Array<string>}
      */
-    this.variableWhitelist_ = meta
-      .getAttribute('content')
-      .split(',')
-      .map(variable => variable.trim());
+    this.variableWhitelist_ = meta.split(',').map(variable => variable.trim());
     return this.variableWhitelist_;
   }
 }

--- a/test/unit/test-url-replacements.js
+++ b/test/unit/test-url-replacements.js
@@ -155,19 +155,8 @@ describes.sandboxed('UrlReplacements', {}, env => {
           },
           document: {
             nodeType: /* document */ 9,
-            querySelector: selector => {
-              if (selector.startsWith('meta')) {
-                return {
-                  getAttribute: () => {
-                    return 'https://whitelisted.com https://greylisted.com http://example.com';
-                  },
-                  hasAttribute: () => {
-                    return true;
-                  },
-                };
-              } else {
-                return {href: canonical};
-              }
+            querySelector: () => {
+              return {href: canonical};
             },
             getElementById: () => {},
             cookie: '',
@@ -204,7 +193,16 @@ describes.sandboxed('UrlReplacements', {}, env => {
         win.document.head = {
           nodeType: /* element */ 1,
           // Fake query selectors needed to bypass <meta> tag checks.
-          querySelector: () => null,
+          querySelector: selector => {
+            if (selector === 'meta[name="amp-link-variable-allowed-origin"]') {
+              return {
+                getAttribute: () => {
+                  return 'https://whitelisted.com https://greylisted.com http://example.com';
+                },
+              };
+            }
+            return null;
+          },
           querySelectorAll: () => [],
           getRootNode() {
             return win.document;


### PR DESCRIPTION
- url: Read `meta[name="amp-link-variable-allowed-origin"]` using method
  supported by `AmpDocShadow` as well as other `AmpDoc` subtypes.
- vars: Read `meta[name="amp-allowed-url-macros"]` using method
  supported by `AmpDocShadow` as well as other `AmpDoc` subtypes.