### PR TITLE
Add notify:true for amphtml/validator/...

### DIFF
--- a/validator/OWNERS
+++ b/validator/OWNERS
@@ -4,7 +4,7 @@
 {
   rules: [
     {
-      owners: [{name: 'ampproject/wg-caching'}],
+      owners: [{name: 'ampproject/wg-caching', notify: true}],
     },
   ],
 }


### PR DESCRIPTION
This will cause `ampproject/wg-caching` to be notified when PRs make changes to files within `amphtml/validator/`.

This currently happens for all `.protoascii`, '.html', and '.out' files in `amphtml/extensions/` via this OWNERS file: https://github.com/ampproject/amphtml/blob/master/OWNERS#L16

