### PR TITLE
♻️Move new methods in resources service to package visibility

### DIFF
--- a/src/service/resources-interface.js
+++ b/src/service/resources-interface.js
@@ -131,11 +131,13 @@ export class ResourcesInterface {
    * Enqueue, or update if already exists, a mutation task for a resource.
    * @param {./resource.Resource} resource
    * @param {ChangeSizeRequestDef} newRequest
+   * @package
    */
   updateOrEnqueueMutateTask(resource, newRequest) {}
 
   /**
    * Schedules the work pass at the latest with the specified delay.
+   * @package
    */
   schedulePassVsync() {}
 
@@ -158,11 +160,13 @@ export class ResourcesInterface {
 
   /**
    * @param {number} relayoutTop
+   * @package
    */
   setRelayoutTop(relayoutTop) {}
 
   /**
    * Flag that the height could have been changed.
+   * @package
    */
   maybeHeightChanged() {}
 


### PR DESCRIPTION
These new methods are only supposed to be used in the framework (vs extension), so it makes sense to make them visible only in package. 