### PR TITLE
🐛 Force bust cached document for amp-addthis

### DIFF
--- a/extensions/amp-addthis/0.1/amp-addthis.js
+++ b/extensions/amp-addthis/0.1/amp-addthis.js
@@ -53,6 +53,7 @@ import {PostMessageDispatcher} from './post-message-dispatcher';
 import {ScrollMonitor} from './addthis-utils/monitors/scroll-monitor';
 import {Services} from '../../../src/services';
 
+import {addParamToUrl, parseUrlDeprecated} from '../../../src/url';
 import {callEng} from './addthis-utils/eng';
 import {callLojson} from './addthis-utils/lojson';
 import {callPjson} from './addthis-utils/pjson';
@@ -66,9 +67,9 @@ import {
 } from './addthis-utils/mode';
 import {getOgImage} from './addthis-utils/meta';
 import {getWidgetOverload} from './addthis-utils/get-widget-id-overloaded-with-json-for-anonymous-mode';
+import {internalRuntimeVersion} from '../../../src/internal-version';
 import {isLayoutSizeDefined} from '../../../src/layout';
 import {listen} from '../../../src/event-helper';
-import {parseUrlDeprecated} from '../../../src/url';
 import {setStyle} from '../../../src/style';
 import {userAssert} from '../../../src/log';
 
@@ -299,7 +300,14 @@ class AmpAddThis extends AMP.BaseElement {
       dict({
         'frameborder': 0,
         'title': ALT_TEXT,
-        'src': `${ORIGIN}/dc/amp-addthis.html`,
+        // Document has overly long cache age: go.amp.dev/issue/24848
+        // Adding AMP runtime version as a meaningless query param to force bust
+        // cached versions.
+        'src': addParamToUrl(
+          `${ORIGIN}/dc/amp-addthis.html`,
+          '_amp_',
+          internalRuntimeVersion()
+        ),
         'id': this.widgetId_,
         'pco': this.productCode_,
         'containerClassName': this.containerClassName_,

--- a/extensions/amp-addthis/0.1/amp-addthis.js
+++ b/extensions/amp-addthis/0.1/amp-addthis.js
@@ -303,11 +303,7 @@ class AmpAddThis extends AMP.BaseElement {
         // Document has overly long cache age: go.amp.dev/issue/24848
         // Adding AMP runtime version as a meaningless query param to force bust
         // cached versions.
-        'src': addParamToUrl(
-          `${ORIGIN}/dc/amp-addthis.html`,
-          '_amp_',
-          internalRuntimeVersion()
-        ),
+        'src': `${ORIGIN}/dc/amp-addthis.html?_amp_=${internalRuntimeVersion()}`,
         'id': this.widgetId_,
         'pco': this.productCode_,
         'containerClassName': this.containerClassName_,

--- a/extensions/amp-addthis/0.1/amp-addthis.js
+++ b/extensions/amp-addthis/0.1/amp-addthis.js
@@ -52,8 +52,6 @@ import {DwellMonitor} from './addthis-utils/monitors/dwell-monitor';
 import {PostMessageDispatcher} from './post-message-dispatcher';
 import {ScrollMonitor} from './addthis-utils/monitors/scroll-monitor';
 import {Services} from '../../../src/services';
-
-import {addParamToUrl, parseUrlDeprecated} from '../../../src/url';
 import {callEng} from './addthis-utils/eng';
 import {callLojson} from './addthis-utils/lojson';
 import {callPjson} from './addthis-utils/pjson';
@@ -70,6 +68,7 @@ import {getWidgetOverload} from './addthis-utils/get-widget-id-overloaded-with-j
 import {internalRuntimeVersion} from '../../../src/internal-version';
 import {isLayoutSizeDefined} from '../../../src/layout';
 import {listen} from '../../../src/event-helper';
+import {parseUrlDeprecated} from '../../../src/url';
 import {setStyle} from '../../../src/style';
 import {userAssert} from '../../../src/log';
 

--- a/extensions/amp-addthis/0.1/test/test-amp-addthis.js
+++ b/extensions/amp-addthis/0.1/test/test-amp-addthis.js
@@ -102,7 +102,7 @@ describes.realWin(
     function testIframe(iframe) {
       expect(iframe).to.not.equal(null);
       expect(iframe.getAttribute('src')).to.match(
-        new RegExp(`^${ORIGIN.replace('.', '\\.')}/dc/amp-addthis.html\\?`)
+        new RegExp(`^${ORIGIN}/dc/amp-addthis.html?`.replace(/[.?]/g, '\\\\$&'))
       );
       expect(iframe.getAttribute('title')).to.equal(ALT_TEXT);
     }

--- a/extensions/amp-addthis/0.1/test/test-amp-addthis.js
+++ b/extensions/amp-addthis/0.1/test/test-amp-addthis.js
@@ -101,8 +101,8 @@ describes.realWin(
 
     function testIframe(iframe) {
       expect(iframe).to.not.equal(null);
-      expect(iframe.getAttribute('src')).to.equal(
-        `${ORIGIN}/dc/amp-addthis.html`
+      expect(iframe.getAttribute('src')).to.match(
+        new RegExp(`^${ORIGIN}/dc/amp-addthis.html?`)
       );
       expect(iframe.getAttribute('title')).to.equal(ALT_TEXT);
     }

--- a/extensions/amp-addthis/0.1/test/test-amp-addthis.js
+++ b/extensions/amp-addthis/0.1/test/test-amp-addthis.js
@@ -102,7 +102,7 @@ describes.realWin(
     function testIframe(iframe) {
       expect(iframe).to.not.equal(null);
       expect(iframe.getAttribute('src')).to.match(
-        new RegExp(`^${ORIGIN}/dc/amp-addthis.html\\?`)
+        new RegExp(`^${ORIGIN.replace('.', '\\.')}/dc/amp-addthis.html\\?`)
       );
       expect(iframe.getAttribute('title')).to.equal(ALT_TEXT);
     }

--- a/extensions/amp-addthis/0.1/test/test-amp-addthis.js
+++ b/extensions/amp-addthis/0.1/test/test-amp-addthis.js
@@ -31,6 +31,7 @@ import {getDetailsForMeta, getMetaElements} from './../addthis-utils/meta';
 import {getKeywordsString} from './../addthis-utils/classify';
 import {getSessionId} from '../addthis-utils/session';
 import {getWidgetOverload} from '../addthis-utils/get-widget-id-overloaded-with-json-for-anonymous-mode';
+import {startsWith} from '../../../../src/string';
 import {toArray} from '../../../../src/types';
 
 describes.realWin(
@@ -101,9 +102,11 @@ describes.realWin(
 
     function testIframe(iframe) {
       expect(iframe).to.not.equal(null);
-      expect(iframe.getAttribute('src')).to.match(
-        new RegExp(`^${ORIGIN}/dc/amp-addthis.html?`.replace(/[.?]/g, '\\\\$&'))
-      );
+      const srcPrefix = `${ORIGIN}/dc/amp-addthis.html?`;
+      expect(
+        startsWith(iframe.getAttribute('src'), srcPrefix),
+        `iframe src starts with ${srcPrefix}`
+      ).to.be.true;
       expect(iframe.getAttribute('title')).to.equal(ALT_TEXT);
     }
 

--- a/extensions/amp-addthis/0.1/test/test-amp-addthis.js
+++ b/extensions/amp-addthis/0.1/test/test-amp-addthis.js
@@ -102,7 +102,7 @@ describes.realWin(
     function testIframe(iframe) {
       expect(iframe).to.not.equal(null);
       expect(iframe.getAttribute('src')).to.match(
-        new RegExp(`^${ORIGIN}/dc/amp-addthis.html\?`)
+        new RegExp(`^${ORIGIN}/dc/amp-addthis.html\\?`)
       );
       expect(iframe.getAttribute('title')).to.equal(ALT_TEXT);
     }

--- a/extensions/amp-addthis/0.1/test/test-amp-addthis.js
+++ b/extensions/amp-addthis/0.1/test/test-amp-addthis.js
@@ -102,7 +102,7 @@ describes.realWin(
     function testIframe(iframe) {
       expect(iframe).to.not.equal(null);
       expect(iframe.getAttribute('src')).to.match(
-        new RegExp(`^${ORIGIN}/dc/amp-addthis.html?`)
+        new RegExp(`^${ORIGIN}/dc/amp-addthis.html\?`)
       );
       expect(iframe.getAttribute('title')).to.equal(ALT_TEXT);
     }


### PR DESCRIPTION
Adds `?_amp_=VERSION` query param to force-bust old, broken versions of document when cached (origin has overly long cache age of 999 days, workaround for #24848)

@taojing10
@dmvjs
@pjcunnin
@matthinegardner

max-age should be changed on server :)