### PR TITLE
✨ amp-list: allow for static rendering by the server

### DIFF
--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -243,6 +243,8 @@ export class AmpList extends AMP.BaseElement {
 
   /** @override */
   layoutCallback() {
+    const isFirstLayout = !this.layoutCompleted_;
+    this.layoutCompleted_ = true;
     // If a placeholder exists and it's taller than amp-list, attempt a resize.
     const placeholder = this.getPlaceholder();
     if (placeholder) {
@@ -261,11 +263,9 @@ export class AmpList extends AMP.BaseElement {
 
     // We want to skip fetch/render iff the amp-list was SSRed with content, but only on the first layout.
     // TODO(amphtml): are we also willing to use the SSRed html on subsequent layouts?
-    if (this.hasInitialContent_ && !this.layoutCompleted_) {
-      this.layoutCompleted_ = true;
+    if (this.hasInitialContent_ && isFirstLayout) {
       return Promise.resolve();
     }
-    this.layoutCompleted_ = true;
     return this.fetchList_();
   }
 


### PR DESCRIPTION
**summary**
Partial for https://github.com/ampproject/amphtml/issues/20752.

This PR allows publishers to SSR an `amp-list` element with all of its contents already filled out. The `amp-list` does not need to have a `src` attribute (although `[src]` may still be useful). This optimizes for UX by having all the content available in HTML, no JS necessary.

Developers can opt in to this mode by following two rules:
- The list must be contained within a `<div role="list"></div>` 
- Each list element should be contained in a `<div role="listitem"></div>`

**future work**
- Since `amp-list` can [initialize from server rendered json](https://amp.dev/documentation/components/amp-list/?format=websites#initialization-from-amp-state), we can create utilities to perform a perfect conversion between the two automatically (either in the AMP Optimizer or just for AMP Cache). This leads to a win/win where developers can write what is more ergonomic and we can automatically transform it to something more performant.

cc @alankent  / @alanorozco who both seemed interested