### PR TITLE
♻️  amp-state: tiny promise cleanup

### DIFF
--- a/extensions/amp-bind/0.1/amp-state.js
+++ b/extensions/amp-bind/0.1/amp-state.js
@@ -188,8 +188,9 @@ export class AmpState extends AMP.BaseElement {
         ? UrlReplacementPolicy.OPT_IN
         : UrlReplacementPolicy.ALL;
 
-    return getViewerAuthTokenIfAvailable(element).then(token =>
-      this.fetch_(ampdoc, policy, opt_refresh, token).catch(error => {
+    return getViewerAuthTokenIfAvailable(element)
+      .then(token => this.fetch_(ampdoc, policy, opt_refresh, token))
+      .catch(error => {
         const event = error
           ? createCustomEvent(
               this.win,
@@ -200,8 +201,7 @@ export class AmpState extends AMP.BaseElement {
         // Trigger "fetch-error" event on fetch failure.
         const actions = Services.actionServiceForDoc(element);
         actions.trigger(element, 'fetch-error', event, ActionTrust.LOW);
-      })
-    );
+      });
   }
 
   /**


### PR DESCRIPTION
**summary**
Fix awkward promise chaining.

before:
```js
promise
  .then(() => fetch().catch(() => ...))
```

after:
```js
promise
  .then(() => fetch)
  .catch(() =>...)
```