### PR TITLE
♻️ Re-use service getter assertion in url-replacements

### DIFF
--- a/extensions/amp-experiment/0.1/test/test-amp-experiment.js
+++ b/extensions/amp-experiment/0.1/test/test-amp-experiment.js
@@ -124,7 +124,7 @@ describes.realWin(
           throw new Error('must have failed');
         },
         () => {
-          return Services.variantsForDocOrNull(ampdoc.getHeadNode())
+          return Services.variantsForDoc(ampdoc.getHeadNode())
             .then(service => service.getVariants())
             .then(variants => {
               expect(variants).to.deep.equal({});
@@ -147,7 +147,7 @@ describes.realWin(
         .returns(Promise.resolve(null));
 
       experiment.buildCallback();
-      return Services.variantsForDocOrNull(ampdoc.getHeadNode())
+      return Services.variantsForDoc(ampdoc.getHeadNode())
         .then(variantsService => variantsService.getVariants())
         .then(variants => {
           expect(variants).to.jsonEqual({

--- a/extensions/amp-experiment/1.0/test/test-amp-experiment.js
+++ b/extensions/amp-experiment/1.0/test/test-amp-experiment.js
@@ -162,7 +162,7 @@ describes.realWin(
           throw new Error('must have failed');
         },
         () => {
-          return Services.variantsForDocOrNull(ampdoc.getHeadNode())
+          return Services.variantsForDoc(ampdoc.getHeadNode())
             .then(service => service.getVariants())
             .then(variants => {
               expect(variants).to.deep.equal({});
@@ -180,7 +180,7 @@ describes.realWin(
         .returns(Promise.resolve());
 
       experiment.buildCallback();
-      return Services.variantsForDocOrNull(ampdoc.getHeadNode())
+      return Services.variantsForDoc(ampdoc.getHeadNode())
         .then(variantsService => variantsService.getVariants())
         .then(variants => {
           expect(applyStub).to.be.calledOnce;
@@ -206,7 +206,7 @@ describes.realWin(
         env.sandbox.stub(ampdoc, 'getParam').returns('true');
 
         experiment.buildCallback();
-        return Services.variantsForDocOrNull(ampdoc.getHeadNode())
+        return Services.variantsForDoc(ampdoc.getHeadNode())
           .then(variantsService => variantsService.getVariants())
           .then(variants => {
             expect(variants).to.jsonEqual({

--- a/src/service/url-replacements-impl.js
+++ b/src/service/url-replacements-impl.js
@@ -765,22 +765,15 @@ export class GlobalVariableSource extends VariableSource {
   /**
    * Resolves the value via amp-experiment's variants service.
    * @param {function(!Object<string, string>):(?string)} getter
-   * @param {string} expr
+   * @param {string} unusedExpr
    * @return {!Promise<?string>}
    * @template T
    * @private
    */
-  getVariantsValue_(getter, expr) {
-    return Services.variantsForDocOrNull(this.ampdoc.getHeadNode())
-      .then(variants => {
-        userAssert(
-          variants,
-          'To use variable %s, amp-experiment should be configured',
-          expr
-        );
-        return variants.getVariants();
-      })
-      .then(variantsMap => getter(variantsMap));
+  getVariantsValue_(getter, unusedExpr) {
+    return Services.variantsForDoc(this.ampdoc.getHeadNode())
+      .then(variants => variants.getVariants())
+      .then(getter);
   }
 
   /**

--- a/src/services.js
+++ b/src/services.js
@@ -744,10 +744,10 @@ export class Services {
    * Returns a promise for the experiment variants or a promise for null if it
    * is not available on the current page.
    * @param {!Element|!ShadowRoot} element
-   * @return {!Promise<?../extensions/amp-experiment/0.1/variant.Variants>}
+   * @return {!Promise<!../extensions/amp-experiment/0.1/variant.Variants>}
    */
-  static variantsForDocOrNull(element) {
-    return /** @type {!Promise<?../extensions/amp-experiment/0.1/variant.Variants>} */ (getElementServiceIfAvailableForDoc(
+  static variantsForDoc(element) {
+    return /** @type {!Promise<?../extensions/amp-experiment/0.1/variant.Variants>} */ (getElementServiceForDoc(
       element,
       'variant',
       'amp-experiment',


### PR DESCRIPTION
By making the `Variants` service getter assert, we can re-use the existing error message:

```js
function assertService(service, id, extension) {
  return userAssert(
    service,
    'Service %s was requested to be provided through %s, ' +
      'but %s is not loaded in the current page. To fix this ' +
      'problem load the JavaScript file for %s in this page.',
    ...
  );
}
```

And remove a very similar one in the replacements getter:

```js
userAssert(	
  variants,	
  'To use variable %s, amp-experiment should be configured',	
  expr	
);
```

This is the only usage of the service so we can make it non-optional.