### PR TITLE
Update validator version & fix tests

### DIFF
--- a/validator/gulpjs/package.json
+++ b/validator/gulpjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-amphtml-validator",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Gulp plugin for the official AMP HTML validator (www.ampproject.org)",
   "keywords": [
     "gulpplugin",
@@ -17,12 +17,12 @@
     "url": "https://github.com/ampproject/amphtml/tree/master/validator/gulpjs"
   },
   "dependencies": {
-    "amphtml-validator": "1.0.23",
-    "through2": "^2.0.1"
+    "amphtml-validator": "1.0.30",
+    "through2": "3.0.1"
   },
   "devDependencies": {
-    "gulp": "^3.9.1",
-    "mocha": "^3.2.0"
+    "gulp": "4.0.2",
+    "mocha": "7.0.1"
   },
   "scripts": {
     "test": " ./node_modules/mocha/bin/mocha",

--- a/validator/gulpjs/test/validate.js
+++ b/validator/gulpjs/test/validate.js
@@ -66,7 +66,7 @@ describe('gulp-amphtml-validator', function() {
       const validFile = createFile(VALID_FILE);
       validate.write(validFile);
       validate.once('data', function(file) {
-        assert.equal(file.ampValidationResult.status, 'N/A');
+        assert.equal(file.ampValidationResult.status, 'UNKNOWN');
         done();
       });
     });
@@ -92,8 +92,8 @@ describe('gulp-amphtml-validator', function() {
       format.write(pass);
       format.end();
       format.once('finish', function() {
-        assert.equal(logger.logged, 'AMP Validation results:\n\n' + VALID_FILE +
-          ': \u001b[32mPASS\u001b[39m');
+        assert.ok(logger.logged.includes('AMP Validation results:\n\n' + VALID_FILE +
+          ': \u001b[32mPASS\u001b[39m'));
         done();
       });
     });
@@ -118,9 +118,9 @@ describe('gulp-amphtml-validator', function() {
       format.write(fail);
       format.end();
       format.once('finish', function() {
-        assert.equal(logger.logged, 'AMP Validation results:\n\n' +
+        assert.ok(logger.logged.includes('AMP Validation results:\n\n' +
           INVALID_FILE + ': \u001b[31mFAIL\u001b[39m\n' + INVALID_FILE +
-          ':24:4 ' + '\u001b[31merrorMessage\u001b[39m (see specUrl)');
+          ':24:4 ' + '\u001b[31merrorMessage\u001b[39m (see specUrl)'));
         done();
       });
     });
@@ -175,7 +175,7 @@ describe('gulp-amphtml-validator', function() {
   function createFileWithValidatorFailure(name) {
     const file = createFileStub(name);
     file.ampValidationResult = {
-      status: 'N/A',
+      status: 'UNKNOWN',
     };
     return file;
   }


### PR DESCRIPTION
We should update the AMP validator dependency to 1.30.0 as well.