### PR TITLE
Make image responsive

### DIFF
--- a/extensions/amp-story/amp-story.md
+++ b/extensions/amp-story/amp-story.md
@@ -74,7 +74,7 @@ As of 2018-07-16, version 0.1 is considered deprecated, and will be deleted on 2
 
 An [AMP story](#story:-amp-story) is a complete AMP HTML document that is comprised of [pages](#pages:-amp-story-page), within the pages are [layers](#layers:-amp-story-grid-layer), within the layers are AMP & HTML elements, like media, analytics, text, and so on.
 
-<amp-img alt="AMP story tag hierarchy" layout="fixed" src="https://github.com/ampproject/docs/raw/master/assets/img/docs/amp-story-tag-hierarchy.png" width="591" height="358">
+<amp-img alt="AMP story tag hierarchy" layout="responsive" src="https://github.com/ampproject/docs/raw/master/assets/img/docs/amp-story-tag-hierarchy.png" width="591" height="358">
   <noscript>
     <img alt="AMP story tag hierarchy" src="https://github.com/ampproject/docs/raw/master/assets/img/docs/amp-story-tag-hierarchy.png" />
   </noscript>


### PR DESCRIPTION
Fixes #26783

The page https://amp.dev/documentation/components/amp-story/#amp-story-format causes an overflow on mobile devices, since the image https://github.com/ampproject/docs/raw/master/assets/img/docs/amp-story-tag-hierarchy.png is set to have a `fixed` layout, but is too wide for common mobile form factors.
# Emojis for categorizing pull requests (copy-paste emoji into description):


🐛 Bug fix
📖 Documentation
