### PR TITLE
♻️AMP Analytics: Linker and cookie configs added for WebEngage vendor

### DIFF
--- a/extensions/amp-analytics/0.1/vendors/webengage.js
+++ b/extensions/amp-analytics/0.1/vendors/webengage.js
@@ -38,7 +38,6 @@ const WEBENGAGE_CONFIG = jsonLiteral({
   },
   'linkers': {
     '_we_linker': {
-      'destinationDomains': ['*'],
       'enabled': true,
       'ids': {
         'we_luid': '${clientId}',

--- a/extensions/amp-analytics/0.1/vendors/webengage.js
+++ b/extensions/amp-analytics/0.1/vendors/webengage.js
@@ -17,9 +17,12 @@
 import {jsonLiteral} from '../../../../src/json';
 
 const WEBENGAGE_CONFIG = jsonLiteral({
+  'vars': {
+    'clientId': 'CLIENT_ID(we_luid)',
+  },
   'requests': {
     'base':
-      'https://c.${region}.webengage.com/amp?licenseCode=${licenseCode}&luid=${clientId(we_luid)}&pageUrl=${canonicalUrl}&pageTitle=${title}&referrer=${documentReferrer}&vh=${viewportHeight}&vw=${viewportWidth}&category=application',
+      'https://c.${region}.webengage.com/amp?licenseCode=${licenseCode}&luid=${clientId}&pageUrl=${canonicalUrl}&pageTitle=${title}&referrer=${documentReferrer}&vh=${viewportHeight}&vw=${viewportWidth}&category=application',
     'wePageview': {
       'baseUrl': '${base}&eventName=Page Viewed',
     },
@@ -31,6 +34,22 @@ const WEBENGAGE_CONFIG = jsonLiteral({
     'wePageviewTrigger': {
       'on': 'visible',
       'request': 'wePageview',
+    },
+  },
+  'linkers': {
+    '_we_linker': {
+      'destinationDomains': ['*'],
+      'enabled': true,
+      'ids': {
+        'we_luid': '${clientId}',
+      },
+      'proxyOnly': false,
+    },
+  },
+  'cookies': {
+    'we_luid': {
+      'value':
+        '$IF(LINKER_PARAM(_we_linker, we_luid),LINKER_PARAM(_we_linker, we_luid))',
     },
   },
 });

--- a/extensions/amp-analytics/0.1/vendors/webengage.json
+++ b/extensions/amp-analytics/0.1/vendors/webengage.json
@@ -16,7 +16,6 @@
   },
   "linkers": {
     "_we_linker": {
-      "destinationDomains": ["*"],
       "enabled": true,
       "ids": {
         "we_luid": "${clientId(we_luid)}"

--- a/extensions/amp-analytics/0.1/vendors/webengage.json
+++ b/extensions/amp-analytics/0.1/vendors/webengage.json
@@ -1,9 +1,6 @@
 {
-  "vars": {
-    "clientId": "CLIENT_ID(we_luid)"
-  },
   "requests": {
-    "base": "https://c.${region}.webengage.com/amp?licenseCode=${licenseCode}&luid=${clientId}&pageUrl=${canonicalUrl}&pageTitle=${title}&referrer=${documentReferrer}&vh=${viewportHeight}&vw=${viewportWidth}&category=application",
+    "base": "https://c.${region}.webengage.com/amp?licenseCode=${licenseCode}&luid=${clientId(we_luid)}&pageUrl=${canonicalUrl}&pageTitle=${title}&referrer=${documentReferrer}&vh=${viewportHeight}&vw=${viewportWidth}&category=application",
     "wePageview": {
       "baseUrl": "${base}&eventName=Page Viewed"
     }
@@ -22,14 +19,14 @@
       "destinationDomains": ["*"],
       "enabled": true,
       "ids": {
-        "we_luid": "${clientId}"
+        "we_luid": "${clientId(we_luid)}"
       },
       "proxyOnly": false
     }
   },
   "cookies": {
     "we_luid": {
-      "value": "$IF(LINKER_PARAM(_we_linker, we_luid),LINKER_PARAM(_we_linker, we_luid),)"
+      "value": "$IF(LINKER_PARAM(_we_linker, we_luid),LINKER_PARAM(_we_linker, we_luid))"
     }
   }
 }

--- a/extensions/amp-analytics/0.1/vendors/webengage.json
+++ b/extensions/amp-analytics/0.1/vendors/webengage.json
@@ -1,6 +1,9 @@
 {
+  "vars": {
+    "clientId": "CLIENT_ID(we_luid)"
+  },
   "requests": {
-    "base": "https://c.${region}.webengage.com/amp?licenseCode=${licenseCode}&luid=${clientId(we_luid)}&pageUrl=${canonicalUrl}&pageTitle=${title}&referrer=${documentReferrer}&vh=${viewportHeight}&vw=${viewportWidth}&category=application",
+    "base": "https://c.${region}.webengage.com/amp?licenseCode=${licenseCode}&luid=${clientId}&pageUrl=${canonicalUrl}&pageTitle=${title}&referrer=${documentReferrer}&vh=${viewportHeight}&vw=${viewportWidth}&category=application",
     "wePageview": {
       "baseUrl": "${base}&eventName=Page Viewed"
     }
@@ -12,6 +15,21 @@
     "wePageviewTrigger": {
       "on": "visible",
       "request": "wePageview"
+    }
+  },
+  "linkers": {
+    "_we_linker": {
+      "destinationDomains": ["*"],
+      "enabled": true,
+      "ids": {
+        "we_luid": "${clientId}"
+      },
+      "proxyOnly": false
+    }
+  },
+  "cookies": {
+    "we_luid": {
+      "value": "$IF(LINKER_PARAM(_we_linker, we_luid),LINKER_PARAM(_we_linker, we_luid),)"
     }
   }
 }


### PR DESCRIPTION
For vendor WebEngage Linker and Cookie configs have been added in order to make sure that the user journey across differently served AMP pages and Non-AMP is synced.