### PR TITLE
✨ Update Pubmine amp-ad to support amp-consent states

### DIFF
--- a/ads/pubmine.js
+++ b/ads/pubmine.js
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
+import {CONSENT_POLICY_STATE} from '../src/consent-state';
 import {loadScript, validateData} from '../3p/3p';
 
-const pubmineOptional = ['section', 'pt', 'ht'],
+const pubmineOptional = ['section', 'pt', 'ht', 'npaOnUnknownConsent'],
   pubmineRequired = ['siteid'],
   pubmineURL = 'https://s.pubmine.com/head.js';
 
@@ -25,11 +26,26 @@ const pubmineOptional = ['section', 'pt', 'ht'],
  * @param {!Window} global
  */
 function initMasterFrame(data, global) {
+  /*
+   * INSUFFICIENT and UNKNOWN should be treated as INSUFFICIENT
+   * unless state is UNKNOWN and `data-npa-on-unknown-consent=false`
+   */
+  const paUnknown =
+    data['npaOnUnknownConsent'] !== undefined &&
+    'false' == data['npaOnUnknownConsent'];
+  const ctxt = global.context;
+  const consent =
+    ctxt.initialConsentState === null ||
+    ctxt.initialConsentState === CONSENT_POLICY_STATE.SUFFICIENT ||
+    ctxt.initialConsentState === CONSENT_POLICY_STATE.UNKNOWN_NOT_REQUIRED ||
+    (ctxt.initialConsentState === CONSENT_POLICY_STATE.UNKNOWN && paUnknown);
+
   global['__ATA_PP'] = {
     pt: data['pt'] || 1,
     ht: data['ht'] || 1,
     tn: 'amp',
     amp: true,
+    consent: consent ? 1 : 0,
   };
   global['__ATA'] = global['__ATA'] || {};
   global['__ATA']['cmd'] = global['__ATA']['cmd'] || [];

--- a/ads/pubmine.md
+++ b/ads/pubmine.md
@@ -55,3 +55,15 @@ Please note that the height parameter should be 15 greater than your ad size to 
 - `data-section`: Pubmine slot identifier
 - `data-pt`: Enum value for page type
 - `data-ht`: Enum value for hosting type
+- `data-npa-on-unknown-consent`: Flag for allowing/prohibiting non-personalized-ads on unknown consent.
+
+## Consent Support
+
+Pubmine's amp-ad adheres to a user's consent in the following ways:
+
+- No `data-block-on-consent` attribute: Pubmine amp-ad will display a personalized ad to the user.
+- `CONSENT_POLICY_STATE.SUFFICIENT`: Pubmine amp-ad will display a personalized ad to the user.
+- `CONSENT_POLICY_STATE.INSUFFICIENT`: Pubmine amp-ad will display a non-personalized ad to the user.
+- `CONSENT_POLICY_STATE.UNKNOWN_NOT_REQUIRED`: Pubmine amp-ad will display a personalized ad to the user.
+- `CONSENT_POLICY_STATE.UNKNOWN`: Pubmine amp-ad will display a non-personalized ad to the user.
+- `CONSENT_POLICY_STATE.UNKNOWN` and `data-npa-on-unknown-consent=false`: Pubmine amp-ad will display a personalized ad to the user.

--- a/test/unit/ads/test-pubmine.js
+++ b/test/unit/ads/test-pubmine.js
@@ -49,6 +49,7 @@ describes.fakeWin('pubmine', {}, env => {
       ht: 2,
       tn: 'amp',
       amp: true,
+      consent: 0,
     };
     pubmine(win, mockData);
     expect(win.__ATA_PP).to.deep.equal(expectedConfig);


### PR DESCRIPTION
Updating our amp-ad implementation back-end to appropriately consume consent states passed by amp-consent. Not using `data-block-on-consent` assumes consent, but otherwise only `CONSENT_POLICY_STATE.SUFFICIENT` and `CONSENT_POLICY_STATE.UNKNOWN_NOT_REQUIRED` will pass consent.