### PR TITLE
🏗 Ensure valid flag usage for `gulp` tasks

### DIFF
--- a/build-system/tasks/build.js
+++ b/build-system/tasks/build.js
@@ -126,6 +126,7 @@ module.exports = {
 build.description = 'Builds the AMP library';
 build.flags = {
   config: '  Sets the runtime\'s AMP_CONFIG to one of "prod" or "canary"',
+  fortesting: '  Builds the AMP library for local testing',
   extensions: '  Builds only the listed extensions.',
   extensions_from: '  Builds only the extensions from the listed AMP(s).',
   noextensions: '  Builds with no extensions.',

--- a/build-system/tasks/integration.js
+++ b/build-system/tasks/integration.js
@@ -70,6 +70,7 @@ integration.flags = {
   'chrome_flags': '  Uses the given flags to launch Chrome',
   'compiled':
     '  Changes integration tests to use production JS binaries for execution',
+  'single_pass': '  Run tests in Single Pass mode',
   'config':
     '  Sets the runtime\'s AMP_CONFIG to one of "prod" (default) or "canary"',
   'coverage': '  Run tests in code coverage mode',
@@ -81,7 +82,9 @@ integration.flags = {
   'nobuild': '  Skips build step',
   'nohelp': '  Silence help messages that are printed prior to test run',
   'safari': '  Runs tests on Safari',
-  'saucelabs': '  Runs tests on saucelabs (requires setup)',
+  'saucelabs': '  Runs tests on Sauce Labs (requires setup)',
+  'stable': '  Runs Sauce Labs tests on stable browsers',
+  'beta': '  Runs Sauce Labs tests on beta browsers',
   'testnames': '  Lists the name of each test being run',
   'verbose': '  With logging enabled',
   'watch': '  Watches for changes in files, runs corresponding test(s)',

--- a/build-system/tasks/process-3p-github-pr.js
+++ b/build-system/tasks/process-3p-github-pr.js
@@ -341,6 +341,10 @@ function assignIssue(issue, assignees) {
   return request(options);
 }
 
+module.exports = {
+  process3pGithubPr,
+};
+
 process3pGithubPr.description = 'Automatically triage 3P integration PRs';
 process3pGithubPr.flags = {
   dryrun: "  Generate process but don't push it out",

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -111,7 +111,7 @@ function checkFlags(name, taskFunc) {
     if (validFlags.length > 0) {
       log('Valid flags for', cyan(`gulp ${name}`) + ':');
       validFlags.forEach(key => {
-        console.log(cyan(`\t--${key}`) + `: ${taskFunc.flags[key]}`);
+        log(cyan(`\t--${key}`) + `: ${taskFunc.flags[key]}`);
       });
     }
     process.exit(1);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -14,9 +14,13 @@
  * limitations under the License.
  */
 
-/* global require */
+/* global require, process */
 
+const argv = require('minimist')(process.argv.slice(2));
 const gulp = require('gulp-help')(require('gulp'));
+const log = require('fancy-log');
+const {cyan, red} = require('ansi-colors');
+
 const {
   checkExactVersions,
 } = require('./build-system/tasks/check-exact-versions');
@@ -68,50 +72,98 @@ const {validator, validatorWebui} = require('./build-system/tasks/validator');
 const {vendorConfigs} = require('./build-system/tasks/vendor-configs');
 const {visualDiff} = require('./build-system/tasks/visual-diff');
 
-// Keep this list alphabetized.
-gulp.task('a4a', a4a);
-gulp.task('ava', ava);
-gulp.task('babel-plugin-tests', babelPluginTests);
-gulp.task('build', build);
-gulp.task('bundle-size', bundleSize);
-gulp.task('caches-json', cachesJson);
-gulp.task('check-exact-versions', checkExactVersions);
-gulp.task('check-links', checkLinks);
-gulp.task('check-owners', checkOwners);
-gulp.task('check-types', checkTypes);
-gulp.task('clean', clean);
-gulp.task('codecov-upload', codecovUpload);
-gulp.task('compile-jison', compileJison);
-gulp.task('create-golden-css', createGoldenCss);
-gulp.task('css', css);
-gulp.task('csvify-size', csvifySize);
-gulp.task('default', defaultTask);
-gulp.task('dep-check', depCheck);
-gulp.task('dev-dashboard-tests', devDashboardTests);
-gulp.task('dist', dist);
-gulp.task('e2e', e2e);
-gulp.task('firebase', firebase);
-gulp.task('generate-vendor-jsons', generateVendorJsons);
-gulp.task('get-zindex', getZindex);
-gulp.task('integration', integration);
-gulp.task('lint', lint);
-gulp.task('make-extension', makeExtension);
-gulp.task('nailgun-start', nailgunStart);
-gulp.task('nailgun-stop', nailgunStop);
-gulp.task('performance', performance);
-gulp.task('pr-check', prCheck);
-gulp.task('prepend-global', prependGlobal);
-gulp.task('presubmit', presubmit);
-gulp.task('prettify', prettify);
-gulp.task('process-3p-github-pr', process3pGithubPr);
-gulp.task('process-github-issues', processGithubIssues);
-gulp.task('serve', serve);
-gulp.task('size', size);
-gulp.task('todos:find-closed', todosFindClosed);
-gulp.task('unit', unit);
-gulp.task('update-packages', updatePackages);
-gulp.task('validator', validator);
-gulp.task('validator-webui', validatorWebui);
-gulp.task('vendor-configs', vendorConfigs);
-gulp.task('visual-diff', visualDiff);
-gulp.task('watch', watch);
+/**
+ * Creates a gulp task using the given name and task function.
+ *
+ * @param {string} name
+ * @param {function} taskFunc
+ */
+function createTask(name, taskFunc) {
+  checkFlags(name, taskFunc);
+  gulp.task(name, taskFunc);
+}
+
+/**
+ * Checks if the flags passed in to a task are valid.
+ * @param {string} name
+ * @param {function} taskFunc
+ */
+function checkFlags(name, taskFunc) {
+  if (!argv._.includes(name)) {
+    return; // This isn't the task being run.
+  }
+  const validFlags = taskFunc.flags ? Object.keys(taskFunc.flags) : [];
+  const usedFlags = Object.keys(argv).slice(1); // Skip the '_' argument
+  const invalidFlags = [];
+  usedFlags.forEach(flag => {
+    if (!validFlags.includes(flag)) {
+      invalidFlags.push(`--${flag}`);
+    }
+  });
+  if (invalidFlags.length > 0) {
+    log(
+      red('ERROR:'),
+      'Found invalid flags for',
+      cyan(`gulp ${name}`) + ':',
+      cyan(invalidFlags.join(', '))
+    );
+    log('For detailed usage information, run', cyan('gulp help') + '.');
+    if (validFlags.length > 0) {
+      log('Valid flags for', cyan(`gulp ${name}`) + ':');
+      validFlags.forEach(key => {
+        console.log(cyan(`\t--${key}`) + `: ${taskFunc.flags[key]}`);
+      });
+    }
+    process.exit(1);
+  }
+}
+
+/**
+ * All the gulp tasks. Keep this list alphabetized.
+ */
+createTask('a4a', a4a);
+createTask('ava', ava);
+createTask('babel-plugin-tests', babelPluginTests);
+createTask('build', build);
+createTask('bundle-size', bundleSize);
+createTask('caches-json', cachesJson);
+createTask('check-exact-versions', checkExactVersions);
+createTask('check-links', checkLinks);
+createTask('check-owners', checkOwners);
+createTask('check-types', checkTypes);
+createTask('clean', clean);
+createTask('codecov-upload', codecovUpload);
+createTask('compile-jison', compileJison);
+createTask('create-golden-css', createGoldenCss);
+createTask('css', css);
+createTask('csvify-size', csvifySize);
+createTask('default', defaultTask);
+createTask('dep-check', depCheck);
+createTask('dev-dashboard-tests', devDashboardTests);
+createTask('dist', dist);
+createTask('e2e', e2e);
+createTask('firebase', firebase);
+createTask('generate-vendor-jsons', generateVendorJsons);
+createTask('get-zindex', getZindex);
+createTask('integration', integration);
+createTask('lint', lint);
+createTask('make-extension', makeExtension);
+createTask('nailgun-start', nailgunStart);
+createTask('nailgun-stop', nailgunStop);
+createTask('performance', performance);
+createTask('pr-check', prCheck);
+createTask('prepend-global', prependGlobal);
+createTask('presubmit', presubmit);
+createTask('prettify', prettify);
+createTask('process-3p-github-pr', process3pGithubPr);
+createTask('process-github-issues', processGithubIssues);
+createTask('serve', serve);
+createTask('size', size);
+createTask('todos:find-closed', todosFindClosed);
+createTask('unit', unit);
+createTask('update-packages', updatePackages);
+createTask('validator', validator);
+createTask('validator-webui', validatorWebui);
+createTask('vendor-configs', vendorConfigs);
+createTask('visual-diff', visualDiff);
+createTask('watch', watch);


### PR DESCRIPTION
Developers have frequently run into problems due to incorrect flag usage, where the recommended usage is not always obvious.

This PR checks for valid flag usage during the invocation of each `gulp` task, and prints a list of valid flags when invalid usage is detected.

<img width="1274" alt="Screen Shot 2020-02-14 at 9 41 41 PM" src="https://user-images.githubusercontent.com/26553114/74582596-197f2480-4f8c-11ea-96aa-0518e840d4b9.png">
