### PR TITLE
♻️Introduce waiting for body into DomWriter

### DIFF
--- a/src/multidoc-manager.js
+++ b/src/multidoc-manager.js
@@ -295,7 +295,7 @@ export class MultidocManager {
           );
           body.classList.add('amp-shadow');
           ampdoc.setBody(body);
-          return body;
+          return Promise.resolve(body);
         });
         writer.onBodyChunk(() => {
           // TODO(dvoytenko): find a better and more stable way to make

--- a/src/utils/dom-writer.js
+++ b/src/utils/dom-writer.js
@@ -331,6 +331,9 @@ export class DomWriterBulk {
         // EOF.
         this.onEnd_();
       });
+    } else {
+      // EOF.
+      this.onEnd_();
     }
   }
 }

--- a/src/utils/dom-writer.js
+++ b/src/utils/dom-writer.js
@@ -205,6 +205,8 @@ export class DomWriterStreamer {
           this.onEnd_();
         }
       });
+    } else if (this.eof_) {
+      this.onEnd_();
     }
   }
 }

--- a/test/unit/test-runtime.js
+++ b/test/unit/test-runtime.js
@@ -31,6 +31,7 @@ import {
 import {installAmpdocServices} from '../../src/service/core-services';
 import {installPlatformService} from '../../src/service/platform-impl';
 import {installTimerService} from '../../src/service/timer-impl';
+import {macroTask} from '../../testing/yield';
 import {setShadowDomSupportedVersionForTesting} from '../../src/web-components';
 import {toggleExperiment} from '../../src/experiments';
 import {vsyncForTesting} from '../../src/service/vsync-impl';
@@ -1508,7 +1509,7 @@ describes.realWin(
           shadowDoc = win.AMP.attachShadowDocAsStream(hostElement, docUrl);
           writer = shadowDoc.writer;
           writer.write('<body><child>');
-          return ampdoc.waitForBodyOpen().then(() => {
+          return ampdoc.waitForBodyOpen().then(async () => {
             const shadowRoot = getShadowRoot(hostElement);
             const body =
               shadowRoot.querySelector('body') ||
@@ -1517,6 +1518,7 @@ describes.realWin(
             expect(body).to.have.class('amp-shadow');
             expect(body.style.position).to.equal('relative');
             env.flushVsync();
+            await macroTask();
             expect(body.querySelector('child')).to.exist;
             expect(ampdoc.getBody()).to.exist;
           });


### PR DESCRIPTION
Working on using DomWriter in a4a, however ads need to fetch ASAP (layoutMeasure) but delay any rendering until layoutCallback.

This change makes DomWriter wait for a promise of a body to write to, before doing any transferring of elements. Open to other ideas of how to make this work.

