### PR TITLE
amp-autocomplete: Revise order of selection events

### DIFF
--- a/examples/amp-autocomplete-bind.html
+++ b/examples/amp-autocomplete-bind.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
-<html amp data-ampdevmode>
+<html amp>
   <head>
     <meta charset="utf-8">
-    <title>autocomplete testing</title>
+    <title>autocomplete and bind testing</title>
     <link rel="canonical" href="autocomplete-testing.html" >
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
@@ -10,8 +10,6 @@
     <script async custom-element="amp-bind" src="https://cdn.ampproject.org/v0/amp-bind-0.1.js"></script>
     <script async custom-element="amp-form" src="https://cdn.ampproject.org/v0/amp-form-0.1.js"></script>
     <script async custom-element="amp-autocomplete" src="https://cdn.ampproject.org/v0/amp-autocomplete-0.1.js"></script>
-    <script async custom-element="amp-script" src="https://cdn.ampproject.org/v0/amp-script-0.1.js"></script>
-    <!-- <meta name="amp-script-src" content="sha384-DYxIFXpU4kmJjfzvb4W5twGuG3Rn__B7WPoTFqdXBrJHylbvFKQJEv-tBUq7lSiC"></head> -->
     <style amp-custom>
       body {
         margin: 0;
@@ -41,13 +39,11 @@
     </style>
   </head>
   <body>
-    <h3>amp-autocomplete + amp-bind + amp-script testing</h3>
+    <h3>amp-autocomplete + amp-bind testing</h3>
     <amp-autocomplete filter="substring">
-      <amp-script script="search-script" sandbox="allow-forms" data-ampdevmode>
-        <div>
-          <span>Search <input type="text" name="search" id="search" on="input-debounced:AMP.setState({search: event.value});change:AMP.setState({search: event.value})"></span> <span>Value set by amp-script: <output id="asout"></output></span>
-        </div>
-      </amp-script>
+      <div>
+        <span>Search <input type="text" name="search" id="search" on="input-debounced:AMP.setState({search: event.value});change:AMP.setState({search: event.value})"></span>
+      </div>
       <script type="application/json">
         {
           "items": ["apple", "orange", "banana"]
@@ -55,30 +51,5 @@
       </script>
     </amp-autocomplete>
     <p>Value set by amp-bind: <input readonly type="text" value="" [value]="search"></p>
-
-    <script id="search-script" type="text/plain" target="amp-script">
-      const searchOutput = document.getElementById('asout');
-      const searchInput = document.getElementById('search');
-
-      searchInput.addEventListener('input', function (e) {
-        try {
-          console.log('input event; value: ' + searchInput.value);
-          searchOutput.setAttribute('data-value', searchInput.value);
-          searchOutput.textContent = searchInput.value;
-        } catch (ex) {
-          console.error('Unable to execute "input" event callback\n', ex);
-        }
-      });
-
-      searchInput.addEventListener('change', function (e) {
-        try {
-          console.log('change event; value: ' + searchInput.value);
-          searchOutput.setAttribute('data-value', searchInput.value);
-          searchOutput.textContent = searchInput.value;
-        } catch (ex) {
-          console.error('Unable to execute "change" event callback\n', ex);
-        }
-      });
-    </script>
   </body>
 </html>

--- a/examples/amp-autocomplete-testing.html
+++ b/examples/amp-autocomplete-testing.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html amp data-ampdevmode>
+  <head>
+    <meta charset="utf-8">
+    <title>autocomplete testing</title>
+    <link rel="canonical" href="autocomplete-testing.html" >
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+    <script async src="https://cdn.ampproject.org/v0.js"></script>
+    <script async custom-element="amp-bind" src="https://cdn.ampproject.org/v0/amp-bind-0.1.js"></script>
+    <script async custom-element="amp-form" src="https://cdn.ampproject.org/v0/amp-form-0.1.js"></script>
+    <script async custom-element="amp-autocomplete" src="https://cdn.ampproject.org/v0/amp-autocomplete-0.1.js"></script>
+    <script async custom-element="amp-script" src="https://cdn.ampproject.org/v0/amp-script-0.1.js"></script>
+    <!-- <meta name="amp-script-src" content="sha384-DYxIFXpU4kmJjfzvb4W5twGuG3Rn__B7WPoTFqdXBrJHylbvFKQJEv-tBUq7lSiC"></head> -->
+    <style amp-custom>
+      body {
+        margin: 0;
+        padding: 0.5em;
+        font-family: sans-serif;
+      }
+    </style>
+  </head>
+  <body>
+    <h3>amp-autocomplete + amp-bind + amp-script testing</h3>
+    <amp-autocomplete filter="substring">
+      <amp-script script="search-script" data-ampdevmode>
+        <div>
+          <input type="text" name="search" id="search" on="input-debounced:AMP.setState({search: event.value});change:AMP.setState({search: event.value})"> <a id="asAnchor" href="">This anchor is updated by amp-script</a>
+        </div>
+      </amp-script>
+      <script type="application/json">
+        {
+          "items": ["apple", "orange", "banana"]
+        }
+      </script>
+    </amp-autocomplete>
+    <p>
+        <a id="abAnchor" href="" [href]="search ? '?q=' + search : ''">This anchor is updated by amp-bind</a>
+    </p>
+
+    <script id="search-script" type="text/plain" target="amp-script">
+      const asAnchor = document.getElementById('asAnchor');
+      const searchInput = document.getElementById('search');
+
+      searchInput.addEventListener('input', function (e) {
+        try {
+          console.log('input event; value: ' + searchInput.value);
+          asAnchor.setAttribute('href', '?q=' + searchInput.value);
+        } catch (ex) {
+          console.error('Unable to execute "input" event callback\n', ex);
+        }
+      });
+
+      searchInput.addEventListener('change', function (e) {
+        try {
+          console.log('change event; value: ' + searchInput.value);
+          asAnchor.setAttribute('href', '?q=' + searchInput.value);
+        } catch (ex) {
+          console.error('Unable to execute "change" event callback\n', ex);
+        }
+      });
+    </script>
+  </body>
+</html>

--- a/examples/amp-autocomplete-testing.html
+++ b/examples/amp-autocomplete-testing.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html amp data-ampdevmode>
+<html amp>
   <head>
     <meta charset="utf-8">
     <title>autocomplete testing</title>
@@ -11,7 +11,7 @@
     <script async custom-element="amp-form" src="https://cdn.ampproject.org/v0/amp-form-0.1.js"></script>
     <script async custom-element="amp-autocomplete" src="https://cdn.ampproject.org/v0/amp-autocomplete-0.1.js"></script>
     <script async custom-element="amp-script" src="https://cdn.ampproject.org/v0/amp-script-0.1.js"></script>
-    <!-- <meta name="amp-script-src" content="sha384-DYxIFXpU4kmJjfzvb4W5twGuG3Rn__B7WPoTFqdXBrJHylbvFKQJEv-tBUq7lSiC"></head> -->
+    <meta name="amp-script-src" content="sha384-lkZe5hu5T1z7PF2HQkxeneF_vgDxtjTso8jfxHdHe6obPTTZoYiBhm9tjU9Qsre1"></head>
     <style amp-custom>
       body {
         margin: 0;
@@ -43,7 +43,7 @@
   <body>
     <h3>amp-autocomplete + amp-bind + amp-script testing</h3>
     <amp-autocomplete filter="substring">
-      <amp-script script="search-script" sandbox="allow-forms" data-ampdevmode>
+      <amp-script script="search-script" sandbox="allow-forms">
         <div>
           <span>Search <input type="text" name="search" id="search" on="input-debounced:AMP.setState({search: event.value});change:AMP.setState({search: event.value})"></span> <span>Value set by amp-script: <output id="asout"></output></span>
         </div>

--- a/extensions/amp-autocomplete/0.1/amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/amp-autocomplete.js
@@ -1083,7 +1083,7 @@ export class AmpAutocomplete extends AMP.BaseElement {
       ActionTrust.HIGH
     );
 
-    // Ensure native change listeners in user amp-scripts are triggered
+    // Ensure native change listeners are triggered
     const nativeChangeEvent = createCustomEvent(
       this.win,
       'change',

--- a/extensions/amp-autocomplete/0.1/amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/amp-autocomplete.js
@@ -628,9 +628,10 @@ export class AmpAutocomplete extends AMP.BaseElement {
    * @private
    */
   selectHandler_(event) {
+    const element = dev().assertElement(event.target);
+    const selectedValue = this.setInputValue_(this.getItemElement_(element));
     return this.mutateElement(() => {
-      const element = dev().assertElement(event.target);
-      this.selectItem_(this.getItemElement_(element));
+      this.selectItem_(selectedValue);
     });
   }
 
@@ -1010,18 +1011,15 @@ export class AmpAutocomplete extends AMP.BaseElement {
   /**
    * Writes the selected value into the input field.
    * @param {?Element} element
+   * @return {?string}
    * @private
    */
-  selectItem_(element) {
+  setInputValue_(element) {
     if (element === null || element.hasAttribute('data-disabled')) {
-      return;
+      return null;
     }
     const selectedValue =
       element.getAttribute('data-value') || element.textContent;
-
-    this.fireSelectEvent_(selectedValue);
-    this.clearAllItems_();
-    this.toggleResults_(false);
 
     this.inputElement_.value = this.binding_.getUserInputForUpdateWithSelection(
       selectedValue,
@@ -1029,6 +1027,19 @@ export class AmpAutocomplete extends AMP.BaseElement {
       this.userInput_
     );
     this.userInput_ = this.binding_.getUserInputForUpdate(this.inputElement_);
+
+    return selectedValue;
+  }
+
+  /**
+   * Finish item selection with the selected value.
+   * @param {string} value
+   * @private
+   */
+  selectItem_(value) {
+    this.fireSelectEvent_(value);
+    this.clearAllItems_();
+    this.toggleResults_(false);
   }
 
   /**
@@ -1044,6 +1055,15 @@ export class AmpAutocomplete extends AMP.BaseElement {
       /** @type {!JsonObject} */ ({value})
     );
     this.action_.trigger(this.element, name, selectEvent, ActionTrust.HIGH);
+  }
+
+  /**
+   * Triggers a native 'change' event on the input.
+   * @private
+   */
+  fireNativeChangeEvent_() {
+    const changeEvent = createCustomEvent(this.win, 'change', null);
+    this.inputElement_.dispatchEvent(changeEvent);
   }
 
   /**
@@ -1209,12 +1229,15 @@ export class AmpAutocomplete extends AMP.BaseElement {
           event.preventDefault();
         }
         this.binding_.removeSelectionHighlighting(this.inputElement_);
-        return this.mutateElement(() => {
-          if (this.areResultsDisplayed_() && !!this.activeElement_) {
-            this.selectItem_(this.activeElement_);
+        if (this.areResultsDisplayed_() && this.activeElement_) {
+          const selectedValue = this.setInputValue_(this.activeElement_);
+          return this.mutateElement(() => {
+            this.selectItem_(selectedValue);
+            this.fireNativeChangeEvent_();
             this.resetActiveElement_();
-            return Promise.resolve();
-          }
+          });
+        }
+        return this.mutateElement(() => {
           this.toggleResults_(false);
         });
       case Keys.ESCAPE:
@@ -1229,9 +1252,15 @@ export class AmpAutocomplete extends AMP.BaseElement {
       case Keys.TAB:
         if (this.areResultsDisplayed_() && this.activeElement_) {
           event.preventDefault();
-          this.selectItem_(this.activeElement_);
+          const selectedValue = this.setInputValue_(this.activeElement_);
+          return this.mutateElement(() => {
+            this.selectItem_(selectedValue);
+            this.fireNativeChangeEvent_();
+          });
         }
-        return Promise.resolve();
+        return this.mutateElement(() => {
+          this.toggleResults_(false);
+        });
       case Keys.BACKSPACE:
         this.detectBackspace_ = this.shouldSuggestFirst_;
         return Promise.resolve();

--- a/extensions/amp-autocomplete/0.1/amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/amp-autocomplete.js
@@ -1033,10 +1033,13 @@ export class AmpAutocomplete extends AMP.BaseElement {
 
   /**
    * Finish item selection with the selected value.
-   * @param {string} value
+   * @param {?string} value
    * @private
    */
   selectItem_(value) {
+    if (value === null) {
+      return;
+    }
     this.fireSelectEvent_(value);
     this.clearAllItems_();
     this.toggleResults_(false);

--- a/extensions/amp-autocomplete/0.1/test/test-amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/test/test-amp-autocomplete.js
@@ -722,7 +722,7 @@ describes.realWin(
       impl.activeElement_ = doc.createElement('div');
       expect(impl.userInput_).not.to.equal(impl.inputElement_.value);
       env.sandbox.stub(impl, 'areResultsDisplayed_').returns(true);
-      const fireEventSpy = env.sandbox.spy(impl, 'fireSelectEvent_');
+      const fireEventSpy = env.sandbox.spy(impl, 'fireSelectAndChangeEvents_');
       return impl
         .layoutCallback()
         .then(() => {
@@ -825,7 +825,7 @@ describes.realWin(
     });
 
     it('should fire events from selectItem_', () => {
-      const fireEventSpy = env.sandbox.spy(impl, 'fireSelectEvent_');
+      const fireEventSpy = env.sandbox.spy(impl, 'fireSelectAndChangeEvents_');
       const triggerSpy = env.sandbox.spy(impl.action_, 'trigger');
       const dispatchSpy = env.sandbox.spy(impl.inputElement_, 'dispatchEvent');
       return impl.layoutCallback().then(() => {
@@ -833,7 +833,11 @@ describes.realWin(
         impl.selectItem_('test');
         expect(fireEventSpy).to.have.been.calledOnce;
         expect(fireEventSpy).to.have.been.calledWith('test');
-        expect(triggerSpy).to.have.been.calledTwice;
+        expect(triggerSpy).to.have.been.calledWith(impl.element, 'select');
+        expect(triggerSpy).to.have.been.calledWith(
+          impl.inputElement_,
+          'change'
+        );
         expect(dispatchSpy).to.have.been.calledOnce;
       });
     });

--- a/extensions/amp-autocomplete/0.1/test/test-amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/test/test-amp-autocomplete.js
@@ -824,15 +824,17 @@ describes.realWin(
         });
     });
 
-    it('should fire select event from selectItem_', () => {
+    it('should fire events from selectItem_', () => {
       const fireEventSpy = env.sandbox.spy(impl, 'fireSelectEvent_');
       const triggerSpy = env.sandbox.spy(impl.action_, 'trigger');
+      const dispatchSpy = env.sandbox.spy(impl.inputElement_, 'dispatchEvent');
       return impl.layoutCallback().then(() => {
         impl.toggleResults_(true);
         impl.selectItem_('test');
         expect(fireEventSpy).to.have.been.calledOnce;
         expect(fireEventSpy).to.have.been.calledWith('test');
-        expect(triggerSpy).to.have.been.calledOnce;
+        expect(triggerSpy).to.have.been.calledTwice;
+        expect(dispatchSpy).to.have.been.calledOnce;
       });
     });
 

--- a/extensions/amp-autocomplete/0.1/test/test-amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/test/test-amp-autocomplete.js
@@ -812,14 +812,14 @@ describes.realWin(
         })
         .then(() => {
           expect(getItemSpy).to.have.been.calledTwice;
-          expect(selectItemSpy).to.have.been.called;
+          expect(selectItemSpy).to.have.been.calledWith(null);
           expect(impl.inputElement_.value).to.equal('');
           mockEl = impl.createElementFromItem_('abc');
           return impl.selectHandler_({target: mockEl});
         })
         .then(() => {
           expect(getItemSpy).to.have.been.calledWith(mockEl);
-          expect(selectItemSpy).to.have.been.calledWith(mockEl);
+          expect(selectItemSpy).to.have.been.calledWith('abc');
           expect(impl.inputElement_.value).to.equal('abc');
         });
     });
@@ -827,11 +827,9 @@ describes.realWin(
     it('should fire select event from selectItem_', () => {
       const fireEventSpy = env.sandbox.spy(impl, 'fireSelectEvent_');
       const triggerSpy = env.sandbox.spy(impl.action_, 'trigger');
-      const mockEl = doc.createElement('div');
       return impl.layoutCallback().then(() => {
         impl.toggleResults_(true);
-        mockEl.setAttribute('data-value', 'test');
-        impl.selectItem_(mockEl);
+        impl.selectItem_('test');
         expect(fireEventSpy).to.have.been.calledOnce;
         expect(fireEventSpy).to.have.been.calledWith('test');
         expect(triggerSpy).to.have.been.calledOnce;


### PR DESCRIPTION
- When selecting an autocomplete item, if `mutateElement()` is called
  before the input element's value is changed, then input and change
  events are fired in amp-script with the old input element's value.
  Split up `selectItem_()` into two functions, one which sets input values
  early and the other which fires events specific to amp-autocomplete at
  the end.
- On item selection, fire amp-specific and native change events on the
  the input to ensure the change is detected by `amp-bind` and user
  scripts in `amp-script`.

Fixes #26273