### PR TITLE
ampdoc: Fix params unit test

### DIFF
--- a/test/unit/test-ampdoc.js
+++ b/test/unit/test-ampdoc.js
@@ -38,7 +38,7 @@ describes.sandboxed('AmpDocService', {}, () => {
     delete window.document['__AMPDOC'];
   });
 
-  describe('params', {}, () => {
+  describe('params', () => {
     let doc, win;
 
     beforeEach(() => {
@@ -73,7 +73,7 @@ describes.sandboxed('AmpDocService', {}, () => {
       }).getSingleDoc();
 
       // Fragment parameters take precedence.
-      expect(ampdoc.getParam('other')).to.equal('three');
+      expect(ampdoc.getParam('other')).to.equal('zero');
       expect(ampdoc.getParam('param1')).to.be.null;
       expect(ampdoc.getParam('paddingTop')).to.be.null;
     });


### PR DESCRIPTION
- Arguments to describe() were incorrect.
- Expected result to explicit params tests was incorrect.

Fixes #26830