### PR TITLE
integration: Improve amp-img test reliability

### DIFF
--- a/src/amp-events.js
+++ b/src/amp-events.js
@@ -27,8 +27,9 @@ export const AmpEvents = {
   // TODO(choumx): Move these to a separate enum so they can be DCE'd.
   ATTACHED: 'amp:attached',
   STUBBED: 'amp:stubbed',
-  LOAD_START: 'amp:load:start',
-  LOAD_END: 'amp:load:end',
+  LOAD_START: 'amp:load-start',
+  LOAD_END: 'amp:load-end',
   ERROR: 'amp:error',
   SIZE_CHANGED: 'amp:size-changed',
+  UNLOAD: 'amp:unload',
 };

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -1351,6 +1351,7 @@ function createBaseCustomElementClass(win) {
       if (isReLayoutNeeded) {
         this.reset_();
       }
+      this.dispatchCustomEventForTesting(AmpEvents.UNLOAD);
       return isReLayoutNeeded;
     }
 

--- a/test/integration/test-amp-img.js
+++ b/test/integration/test-amp-img.js
@@ -87,16 +87,19 @@ describe
           expect(largeScreen.offsetHeight).to.equal(0);
           fixture.iframe.width = 600;
           fixture.win.dispatchEvent(new fixture.win.Event('resize'));
-          return fixture.awaitEvent(AmpEvents.LOAD_START, 4).then(function() {
-            expect(smallScreen.className).to.match(
-              /i-amphtml-hidden-by-media-query/
-            );
-            expect(largeScreen.className).to.not.match(
-              /i-amphtml-hidden-by-media-query/
-            );
-            expect(smallScreen.offsetHeight).to.equal(0);
-            expect(largeScreen.offsetHeight).to.not.equal(0);
-          });
+          return fixture
+            .awaitEvent(AmpEvents.LOAD_START, 4)
+            .then(() => fixture.awaitEvent(AmpEvents.UNLOAD, 1))
+            .then(function() {
+              expect(smallScreen.className).to.match(
+                /i-amphtml-hidden-by-media-query/
+              );
+              expect(largeScreen.className).to.not.match(
+                /i-amphtml-hidden-by-media-query/
+              );
+              expect(smallScreen.offsetHeight).to.equal(0);
+              expect(largeScreen.offsetHeight).to.not.equal(0);
+            });
         });
     });
 

--- a/test/integration/test-amp-img.js
+++ b/test/integration/test-amp-img.js
@@ -87,7 +87,7 @@ describe
           expect(largeScreen.offsetHeight).to.equal(0);
           fixture.iframe.width = 600;
           fixture.win.dispatchEvent(new fixture.win.Event('resize'));
-          return fixture.awaitEvent(AmpEvents.LOAD_START, 5).then(function() {
+          return fixture.awaitEvent(AmpEvents.LOAD_START, 4).then(function() {
             expect(smallScreen.className).to.match(
               /i-amphtml-hidden-by-media-query/
             );

--- a/test/integration/test-amp-img.js
+++ b/test/integration/test-amp-img.js
@@ -87,7 +87,7 @@ describe
           expect(largeScreen.offsetHeight).to.equal(0);
           fixture.iframe.width = 600;
           fixture.win.dispatchEvent(new fixture.win.Event('resize'));
-          return fixture.awaitEvent(AmpEvents.LOAD_START, 4).then(function() {
+          return fixture.awaitEvent(AmpEvents.LOAD_START, 5).then(function() {
             expect(smallScreen.className).to.match(
               /i-amphtml-hidden-by-media-query/
             );

--- a/testing/iframe.js
+++ b/testing/iframe.js
@@ -74,6 +74,7 @@ export function createFixtureIframe(
       [AmpEvents.LOAD_END]: 0,
       [AmpEvents.LOAD_START]: 0,
       [AmpEvents.STUBBED]: 0,
+      [AmpEvents.UNLOAD]: 0,
       [BindEvents.INITIALIZE]: 0,
       [BindEvents.SET_STATE]: 0,
       [BindEvents.RESCAN_TEMPLATE]: 0,


### PR DESCRIPTION
The 'should respect media queries' amp-img integration test fails
intermittently due to a race between setting/getting class
`i-amphtml-hidden-by-media-query` when the window resizes. The race
results because `expect()` is performed immediately after an amp-img
`LOAD_START` event fires without waiting for the other amp-img to fire
its `UNLOAD` event. Remedy this by waiting for both amp-img layout changes
to fire before checking their final classes.

- Add `UNLOAD` event to custom-element test event dispatches
- Fix names of test events `LOAD_START`, `LOAD_END` so that they match the
  corresponding signal names