### PR TITLE
a4a: RefreshManager: Support amp-ad-enable-refresh lookup in AmpDocShadow

### DIFF
--- a/extensions/amp-a4a/0.1/refresh-manager.js
+++ b/extensions/amp-a4a/0.1/refresh-manager.js
@@ -43,21 +43,17 @@ const TAG = 'AMP-AD';
  * Retrieves the publisher-specified refresh interval, if one were set. This
  * function first checks for appropriate slot attributes and then for
  * metadata tags, preferring whichever it finds first.
- * @param {!Element} element
- * @param {!Window} win
+ * @param {!AmpElement} element
+ * @param {!Window} unusedWin
  * @return {?number}
  * @visibleForTesting
  */
-export function getPublisherSpecifiedRefreshInterval(element, win) {
+export function getPublisherSpecifiedRefreshInterval(element, unusedWin) {
   const refreshInterval = element.getAttribute(DATA_ATTR_NAME);
   if (refreshInterval) {
     return checkAndSanitizeRefreshInterval(refreshInterval);
   }
-  let metaTag;
-  const metaTagContent =
-    (metaTag = win.document.getElementsByName(METATAG_NAME)) &&
-    metaTag[0] &&
-    metaTag[0].getAttribute('content');
+  const metaTagContent = element.getAmpDoc().getMetaByName(METATAG_NAME);
   if (!metaTagContent) {
     return null;
   }

--- a/extensions/amp-a4a/0.1/test/test-refresh.js
+++ b/extensions/amp-a4a/0.1/test/test-refresh.js
@@ -38,6 +38,16 @@ describe('refresh', () => {
     div.setAttribute('type', 'doubleclick');
     div.setAttribute(DATA_ATTR_NAME, '35');
     window.sandbox.replaceGetter(div, 'isConnected', () => true);
+    div.getAmpDoc = () => {
+      return {
+        getMetaByName: name => {
+          const metaTag = window.document.head.querySelector(
+            `[name="${name}"]`
+          );
+          return metaTag ? metaTag.getAttribute('content') : null;
+        },
+      };
+    };
     return div;
   }
 


### PR DESCRIPTION
Read `meta[name="amp-ad-enable-refresh"]` using method supported by
`AmpDocShadow` as well as other `AmpDoc` subtypes.