### PR TITLE
🐛 Add gulp dist flags

### DIFF
--- a/build-system/tasks/dist.js
+++ b/build-system/tasks/dist.js
@@ -453,4 +453,6 @@ dist.flags = {
   full_sourcemaps: '  Includes source code content in sourcemaps',
   disable_nailgun:
     "  Doesn't use nailgun to invoke closure compiler (much slower)",
+  type: '  Points sourcemap to fetch files from the correct GitHub tag',
+  esm: '  Does not transpile down to ES5',
 };


### PR DESCRIPTION
Adds missing flags, since release automation runs `gulp dist --type canary --noconfig --esm`.