### PR TITLE
✨Render captions in the vertical render mode of stories

### DIFF
--- a/examples/amp-story/ampconf.html
+++ b/examples/amp-story/ampconf.html
@@ -132,7 +132,7 @@
         </template>
       </amp-story-auto-ads>
 
-      <amp-story-page id="page-1" title="Lorem ipsum dolor sit amet">
+      <!-- <amp-story-page id="page-1" title="Lorem ipsum dolor sit amet">
         <amp-story-grid-layer template="fill">
           <amp-video autoplay loop
             width="400"
@@ -190,7 +190,7 @@
             format for delivering news and information as visual, tap-through
             stories on the open web.</p>
         </amp-story-grid-layer>
-      </amp-story-page>
+      </amp-story-page> -->
 
       <amp-story-page id="page-5" auto-advance-after="stamp-vid">
         <amp-story-grid-layer template="fill">

--- a/examples/amp-story/ampconf.html
+++ b/examples/amp-story/ampconf.html
@@ -132,7 +132,7 @@
         </template>
       </amp-story-auto-ads>
 
-      <!-- <amp-story-page id="page-1" title="Lorem ipsum dolor sit amet">
+      <amp-story-page id="page-1" title="Lorem ipsum dolor sit amet">
         <amp-story-grid-layer template="fill">
           <amp-video autoplay loop
             width="400"
@@ -190,7 +190,7 @@
             format for delivering news and information as visual, tap-through
             stories on the open web.</p>
         </amp-story-grid-layer>
-      </amp-story-page> -->
+      </amp-story-page>
 
       <amp-story-page id="page-5" auto-advance-after="stamp-vid">
         <amp-story-grid-layer template="fill">

--- a/examples/visual-tests/amp-story/amp-story-bot-rendering.html
+++ b/examples/visual-tests/amp-story/amp-story-bot-rendering.html
@@ -75,6 +75,22 @@
         </amp-story-grid-layer>
       </amp-story-page>
 
+      <amp-story-page id="page2" title="This is a page title">
+        <amp-story-grid-layer template="fill">
+          <amp-video autoplay
+            id="stamp-vid"
+            width="400"
+            height="750"
+            poster="../../amp-story/img/poster2.jpg"
+            alt="This is a video alt text"
+            title="This is a video title"
+            layout="fill">
+            <source src="../../amp-story/video/stamp.mp4" type="video/mp4">
+            <track default src="../../amp-story/video/stamp.vtt" srclang="en">
+          </amp-video>
+        </amp-story-grid-layer>
+      </amp-story-page>
+
       <amp-story-page id="page3">
         <amp-story-grid-layer template="fill">
           <amp-img layout="fill" src="./img/cat1.jpg"></amp-img>

--- a/examples/visual-tests/amp-story/amp-story-bot-rendering.html
+++ b/examples/visual-tests/amp-story/amp-story-bot-rendering.html
@@ -75,6 +75,8 @@
         </amp-story-grid-layer>
       </amp-story-page>
 
+      <!--
+      TODO(#26390) Remove comment when https://github.com/ampproject/amphtml/issues/26390 is fixed.
       <amp-story-page id="page2" title="This is a page title">
         <amp-story-grid-layer template="fill">
           <amp-video autoplay
@@ -90,6 +92,7 @@
           </amp-video>
         </amp-story-grid-layer>
       </amp-story-page>
+      -->
 
       <amp-story-page id="page3">
         <amp-story-grid-layer template="fill">

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -75,8 +75,8 @@ import {htmlFor} from '../../../src/static-template';
 import {isExperimentOn} from '../../../src/experiments';
 import {isMediaDisplayed, setTextBackgroundColor} from './utils';
 import {px, toggle} from '../../../src/style';
-import {upgradeBackgroundAudio} from './audio';
 import {renderPageDescription} from './semantic-render';
+import {upgradeBackgroundAudio} from './audio';
 
 /**
  * CSS class for an amp-story-page that indicates the entire page is loaded.

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -75,8 +75,8 @@ import {htmlFor} from '../../../src/static-template';
 import {isExperimentOn} from '../../../src/experiments';
 import {isMediaDisplayed, setTextBackgroundColor} from './utils';
 import {px, toggle} from '../../../src/style';
-import {renderPageDescription} from './semantic-render';
 import {upgradeBackgroundAudio} from './audio';
+import {renderPageDescription} from './semantic-render';
 
 /**
  * CSS class for an amp-story-page that indicates the entire page is loaded.

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -56,7 +56,6 @@ import {VideoUtils} from '../../../src/utils/video';
 import {
   childElement,
   closestAncestorElementBySelector,
-  createElementWithAttributes,
   isAmpElement,
   iterateCursor,
   matches,
@@ -76,6 +75,7 @@ import {htmlFor} from '../../../src/static-template';
 import {isExperimentOn} from '../../../src/experiments';
 import {isMediaDisplayed, setTextBackgroundColor} from './utils';
 import {px, toggle} from '../../../src/style';
+import {renderPageDescription} from './semantic-render';
 import {upgradeBackgroundAudio} from './audio';
 
 /**
@@ -1689,7 +1689,10 @@ export class AmpStoryPage extends AMP.BaseElement {
    */
   setPageDescription_() {
     if (this.isBotUserAgent_) {
-      this.renderPageDescription_();
+      renderPageDescription(
+        this,
+        this.getMediaBySelector_(Selectors.ALL_AMP_VIDEO, true)
+      );
     }
 
     if (!this.isBotUserAgent_ && this.element.hasAttribute('title')) {
@@ -1703,53 +1706,6 @@ export class AmpStoryPage extends AMP.BaseElement {
       }
       this.element.removeAttribute('title');
     }
-  }
-
-  /**
-   * Renders the page description, and videos title/alt attributes in the page.
-   * @private
-   */
-  renderPageDescription_() {
-    const descriptionElId = `i-amphtml-story-${this.element.id}-description`;
-    const descriptionEl = createElementWithAttributes(
-      this.win.document,
-      'div',
-      dict({
-        'class': 'i-amphtml-story-page-description',
-        'id': descriptionElId,
-      })
-    );
-
-    const addTagToDescriptionEl = (tagName, text) => {
-      if (!text) {
-        return;
-      }
-      const el = this.win.document.createElement(tagName);
-      el./* OK */ textContent = text;
-      descriptionEl.appendChild(el);
-    };
-
-    addTagToDescriptionEl('h2', this.element.getAttribute('title'));
-
-    this.getMediaBySelector_(Selectors.ALL_AMP_VIDEO, true).forEach(videoEl => {
-      addTagToDescriptionEl('p', videoEl.getAttribute('alt'));
-      addTagToDescriptionEl('p', videoEl.getAttribute('title'));
-    });
-
-    if (descriptionEl.childElementCount === 0) {
-      return;
-    }
-
-    this.mutateElement(() => {
-      this.element.parentElement.insertBefore(
-        descriptionEl,
-        this.element.nextElementSibling
-      );
-
-      if (!this.element.getAttribute('aria-labelledby')) {
-        this.element.setAttribute('aria-labelledby', descriptionElId);
-      }
-    });
   }
 
   /**

--- a/extensions/amp-story/1.0/amp-story-vertical.css
+++ b/extensions/amp-story/1.0/amp-story-vertical.css
@@ -65,10 +65,14 @@ amp-story[i-amphtml-vertical].i-amphtml-element amp-story-page.i-amphtml-element
 
 [i-amphtml-vertical] .i-amphtml-story-page-description {
   background: white !important;
-  color: black !important;
   display: block !important;
-  font-size: 0.8rem !important;
   padding: 32px !important;
   width: auto !important;
   z-index: 9999999 !important;
+}
+
+[i-amphtml-vertical] .i-amphtml-story-page-description > * {
+  background: white !important;
+  color: black !important;
+  font-size: 0.8rem !important;
 }

--- a/extensions/amp-story/1.0/amp-story-vertical.css
+++ b/extensions/amp-story/1.0/amp-story-vertical.css
@@ -74,5 +74,10 @@ amp-story[i-amphtml-vertical].i-amphtml-element amp-story-page.i-amphtml-element
 [i-amphtml-vertical] .i-amphtml-story-page-description > * {
   background: white !important;
   color: black !important;
-  font-size: 0.8rem !important;
+  font-size: 1rem !important;
+}
+
+
+[i-amphtml-vertical] .i-amphtml-story-page-description > h2 {
+  font-size: 1.5rem !important;
 }

--- a/extensions/amp-story/1.0/semantic-render.js
+++ b/extensions/amp-story/1.0/semantic-render.js
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 
-import {Services} from '../../../src/services';
 import {createElementWithAttributes} from '../../../src/dom';
 import {dict} from '../../../src/utils/object';
-import {includes, startsWith} from '../../../src/string';
+import {Services} from '../../../src/services';
+import {startsWith, includes} from '../../../src/string';
+import {dev} from '../../../src/log';
 
 /**
  * Renders the page description, and videos title/alt attributes in the page.
@@ -135,7 +136,7 @@ function extractTextContentTtml(text) {
       .textContent.replace(/[\s\n\r]+/g, ' ')
       .trim();
   } catch (e) {
-    console.error(e.message);
+    dev().error(e.message);
   }
   return '';
 }
@@ -172,6 +173,6 @@ function extractTextContentWebVtt(text) {
   // Super loose HTML parsing to get HTML entity parsing and removal
   // of WebVTT elements.
   const div = document.createElement('div');
-  div.innerHTML = text;
+  div./* element is never added to DOM */ innerHTML = text;
   return div.textContent;
 }

--- a/extensions/amp-story/1.0/semantic-render.js
+++ b/extensions/amp-story/1.0/semantic-render.js
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-import {createElementWithAttributes} from '../../../src/dom';
-import {dict} from '../../../src/utils/object';
 import {Services} from '../../../src/services';
-import {startsWith, includes} from '../../../src/string';
+import {createElementWithAttributes} from '../../../src/dom';
 import {dev} from '../../../src/log';
+import {dict} from '../../../src/utils/object';
+import {includes, startsWith} from '../../../src/string';
 
 /**
  * Renders the page description, and videos title/alt attributes in the page.

--- a/extensions/amp-story/1.0/semantic-render.js
+++ b/extensions/amp-story/1.0/semantic-render.js
@@ -1,0 +1,177 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {createElementWithAttributes} from '../../../src/dom';
+import {dict} from '../../../src/utils/object';
+import {Services} from '../../../src/services';
+import {startsWith, includes} from '../../../src/string';
+
+/**
+ * Renders the page description, and videos title/alt attributes in the page.
+ * @param {!./amp-story-page.AmpStoryPage} page
+ * @param {!Array<?Element>} videos
+ */
+export function renderPageDescription(page, videos) {
+  const descriptionElId = `i-amphtml-story-${page.element.id}-description`;
+  const descriptionEl = createElementWithAttributes(
+    page.win.document,
+    'div',
+    dict({
+      'class': 'i-amphtml-story-page-description',
+      'id': descriptionElId,
+    })
+  );
+
+  const addTagToDescriptionEl = (tagName, text) => {
+    if (!text) {
+      return;
+    }
+    const el = page.win.document.createElement(tagName);
+    el./* OK */ textContent = text;
+    descriptionEl.appendChild(el);
+  };
+
+  addTagToDescriptionEl('h2', page.element.getAttribute('title'));
+
+  const fetches = [];
+
+  videos.forEach(videoEl => {
+    addTagToDescriptionEl('p', videoEl.getAttribute('alt'));
+    addTagToDescriptionEl('p', videoEl.getAttribute('title'));
+    fetches.push(
+      fetchCaptions(page, videoEl).then(text => {
+        addTagToDescriptionEl('p', text);
+      })
+    );
+  });
+
+  Promise.all(fetches).then(() => {
+    if (descriptionEl.childElementCount === 0) {
+      return;
+    }
+
+    page.mutateElement(() => {
+      page.element.parentElement.insertBefore(
+        descriptionEl,
+        page.element.nextElementSibling
+      );
+
+      if (!page.element.getAttribute('aria-labelledby')) {
+        page.element.setAttribute('aria-labelledby', descriptionElId);
+      }
+    });
+  });
+}
+
+/**
+ * Fetches captions for a video if available and returns them as plain
+ * text.
+ * @param {!./amp-story-page.AmpStoryPage} page
+ * @param {!Element} videoEl
+ * @return {!Promise<string|undefined>}
+ */
+function fetchCaptions(page, videoEl) {
+  // Prefer the default track, otherwise pick the first.
+  // Could be extended to prefer the language of the doc.
+  const track =
+    videoEl.querySelector('track[default]') || videoEl.querySelector('track');
+  if (!track || !track.src) {
+    return Promise.resolve();
+  }
+  return Services.xhrFor(page.win)
+    .fetchText(track.src, {
+      mode: 'cors',
+    })
+    .then(response => {
+      if (!response.ok) {
+        return;
+      }
+      return response.text().then(extractTextContent);
+    });
+}
+
+/**
+ * Extract the text content from a captions file.
+ * @param {string} text
+ * @return {string}
+ * @visibleForTesting
+ */
+export function extractTextContent(text) {
+  text = text.trim();
+  if (startsWith(text, 'WEBVTT')) {
+    return extractTextContentWebVtt(text);
+  }
+  if (includes(text, 'http://www.w3.org/ns/ttml')) {
+    return extractTextContentTtml(text);
+  }
+
+  return '';
+}
+
+/**
+ * Extract the text content from a TTML file.
+ * https://www.w3.org/TR/2018/REC-ttml2-20181108/
+ * @param {string} text
+ * @return {string}
+ */
+function extractTextContentTtml(text) {
+  try {
+    const doc = new DOMParser().parseFromString(text, 'text/xml');
+    return doc
+      .querySelector('body')
+      .textContent.replace(/[\s\n\r]+/g, ' ')
+      .trim();
+  } catch (e) {
+    console.error(e.message);
+  }
+  return '';
+}
+
+/**
+ * Extract the text content from a WebVTT file.
+ * https://www.w3.org/TR/webvtt1/
+ * @param {string} text
+ * @return {string}
+ */
+function extractTextContentWebVtt(text) {
+  const queue = /^\d\d\:\d\d/;
+  let seenQueue = false;
+  text = text
+    .split(/[\n\r]+/)
+    .filter(line => {
+      const isQueue = queue.test(line);
+      seenQueue = seenQueue || isQueue;
+      // Filter queues and everything before.
+      if (!seenQueue || isQueue) {
+        return false;
+      }
+      // Filter comments.
+      return !/^NOTE\s+/.test(line);
+    })
+    .map(line => {
+      return (
+        line
+          // Strip multiline indicators.
+          .replace(/^- /, '')
+      );
+    })
+    .join(' ');
+  // Super loose HTML parsing to get HTML entity parsing and removal
+  // of WebVTT elements.
+  const div = document.createElement('div');
+  div.innerHTML = text;
+  return div.textContent;
+}

--- a/extensions/amp-story/1.0/semantic-render.js
+++ b/extensions/amp-story/1.0/semantic-render.js
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
+import {Services} from '../../../src/services';
 import {createElementWithAttributes} from '../../../src/dom';
 import {dict} from '../../../src/utils/object';
-import {Services} from '../../../src/services';
-import {startsWith, includes} from '../../../src/string';
+import {includes, startsWith} from '../../../src/string';
 
 /**
  * Renders the page description, and videos title/alt attributes in the page.

--- a/extensions/amp-story/1.0/semantic-render.js
+++ b/extensions/amp-story/1.0/semantic-render.js
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-import {Services} from '../../../src/services';
 import {createElementWithAttributes} from '../../../src/dom';
-import {dev} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
-import {includes, startsWith} from '../../../src/string';
+import {Services} from '../../../src/services';
+import {startsWith, includes} from '../../../src/string';
+import {dev} from '../../../src/log';
 
 /**
  * Renders the page description, and videos title/alt attributes in the page.
@@ -136,7 +136,7 @@ function extractTextContentTtml(text) {
       .textContent.replace(/[\s\n\r]+/g, ' ')
       .trim();
   } catch (e) {
-    dev().error(e.message);
+    dev().error('TTML', e.message);
   }
   return '';
 }

--- a/extensions/amp-story/1.0/test/test-semantic-render.js
+++ b/extensions/amp-story/1.0/test/test-semantic-render.js
@@ -1,0 +1,144 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {extractTextContent} from '../semantic-render';
+
+describes.fakeWin('amp-story semantic-render', {}, () => {
+  describe('text extraction WebVTT', () => {
+    it('should turn WebVTT into plain text example 1', () => {
+      expect(
+        extractTextContent(`WEBVTT
+
+00:00.000 --> 00:02.000
+<v Jon Newmuis>(Jon Newmuis) &auml;
+<v Jon Newmuis>So today, we're excited to announce the developer
+
+00:02.000 --> 00:06.000
+<v Jon Newmuis>preview of AMP stories, an open format for visual storytelling
+
+00:06.000 --> 00:09.000
+<v Jon Newmuis>on mobile.
+
+00:09.000 --> 00:12.500
+<v Jon Newmuis>To demonstrate, here's a story by CNN using the format.
+
+00:12.500 --> 00:16.500
+<v Jon Newmuis>As you can see, it's very visual with these full bleed images.
+
+00:16.500 --> 00:19.000
+<v Jon Newmuis>And you can also include video assets as well.
+
+00:19.000 --> 00:22.000
+<v Jon Newmuis>The short-form bite-sized text is more easily
+
+00:22.000 --> 00:24.000
+<v Jon Newmuis>consumable on mobile.`)
+      ).to.equal(
+        `(Jon Newmuis) ä So today, we're excited to announce the developer preview of AMP stories, an open format for visual storytelling on mobile. To demonstrate, here's a story by CNN using the format. As you can see, it's very visual with these full bleed images. And you can also include video assets as well. The short-form bite-sized text is more easily consumable on mobile.`
+      );
+    });
+
+    it('should turn WebVTT into plain text example with lots of features', () => {
+      expect(
+        extractTextContent(`WEBVTT
+
+STYLE
+::cue {
+  background-image: linear-gradient(to bottom, dimgray, lightgray);
+  color: papayawhip;
+}
+/* Style blocks cannot use blank lines nor "dash dash greater than" */
+
+NOTE comment blocks can be used between style blocks.
+
+STYLE
+::cue(b) {
+  color: peachpuff;
+}
+
+hello
+00:00:00.000 --> 00:00:10.000
+Hello <b>world</b>.
+
+NOTE style blocks cannot appear after the first cue.`)
+      ).to.equal(`Hello world.`);
+    });
+  });
+
+  describe('text extraction TTML', () => {
+    it('should turn TTML into plain text example 1', () => {
+      expect(
+        extractTextContent(`<?xml version="1.0" encoding="UTF-8"?>
+        <tt xmlns="http://www.w3.org/ns/ttml">
+          <head>
+            <metadata xmlns:ttm="http://www.w3.org/ns/ttml#metadata">
+              <ttm:title>Timed Text TTML Example</ttm:title>
+              <ttm:copyright>The Authors (c) 2006</ttm:copyright>
+            </metadata>
+            <styling xmlns:tts="http://www.w3.org/ns/ttml#styling">
+              <!-- s1 specifies default color, font, and text alignment -->
+              <style xml:id="s1"
+                tts:color="white"
+                tts:fontFamily="proportionalSansSerif"
+                tts:fontSize="22px"
+                tts:textAlign="center"
+              />
+              <!-- alternative using yellow text but otherwise the same as style s1 -->
+              <style xml:id="s2" style="s1" tts:color="yellow"/>
+              <!-- a style based on s1 but justified to the right -->
+              <style xml:id="s1Right" style="s1" tts:textAlign="end" />     
+              <!-- a style based on s2 but justified to the left -->
+              <style xml:id="s2Left" style="s2" tts:textAlign="start" />
+            </styling>
+            <layout xmlns:tts="http://www.w3.org/ns/ttml#styling">
+              <region xml:id="subtitleArea"
+                style="s1"
+                tts:extent="560px 62px"
+                tts:padding="5px 3px"
+                tts:backgroundColor="black"
+                tts:displayAlign="after"
+              />
+            </layout> 
+          </head>
+          <body region="subtitleArea">
+            <div>
+              <p xml:id="subtitle1" begin="0.76s" end="3.45s">
+                It seems a paradox, does it not,
+              </p>
+              <p xml:id="subtitle2" begin="5.0s" end="10.0s">
+                that the image formed on<br/>
+                the Retina should be inverted?
+              </p>
+              <p xml:id="subtitle3" begin="10.0s" end="16.0s" style="s2">
+                It is puzzling, why is it<br/>
+                we do not see things upside-down?
+              </p>
+              <p xml:id="subtitle4" begin="17.2s" end="23.0s">
+                You have never heard the Theory,<br/>
+                then, that the Brain also is inverted?
+              </p>
+              <p xml:id="subtitle5" begin="23.0s" end="27.0s" style="s2">
+                No indeed! What a beautiful fact!
+              </p>
+            </div>
+          </body>
+        </tt>`)
+      ).to.equal(
+        `It seems a paradox, does it not, that the image formed on the Retina should be inverted? It is puzzling, why is it we do not see things upside-down? You have never heard the Theory, then, that the Brain also is inverted? No indeed! What a beautiful fact!`
+      );
+    });
+  });
+});


### PR DESCRIPTION
- Introduces a new file for "semantic rendering" to factor out the
related code into its own place.
- Render WebVTT and TTML based captions as paragraphs into the vertical document.
- Fixes a bug where text could still be white on white due to CSS inheritance.
- Updated visual tests with example for captions and video alt/title attribute.
