### PR TITLE
amp-sticky-ad: Fix unit test

### DIFF
--- a/extensions/amp-sticky-ad/1.0/test/test-amp-sticky-ad.js
+++ b/extensions/amp-sticky-ad/1.0/test/test-amp-sticky-ad.js
@@ -279,6 +279,7 @@ describes.realWin(
         ampStickyAd = win.document.createElement('amp-sticky-ad');
         ampStickyAd.setAttribute('layout', 'nodisplay');
         ampImg = win.document.createElement('amp-img');
+        ampImg.setAttribute('layout', 'nodisplay');
         ampAd1 = createElementWithAttributes(win.document, 'amp-ad', {
           'type': '_ping_',
           'height': 50,


### PR DESCRIPTION
Resolve the following unit test failure:
```
DESCRIBE => amp-sticky-ad 1.0 version
  DESCRIBE =>  
    DESCRIBE => with unvalid child 1.0
      IT => should not build when child is not ad
        ✗ Error: Uncaught Error: The element did not specify a layout attribute. Check https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/control_layout and the respective element documentation for details.​​​ (/home/travis/build/ampproject/amphtml/src/log.js:436:7 <- /tmp/e37c3a9eb37e0c201b3e74053a0d4391.browserify.js:75967)
            at Context.<anonymous> (home/travis/build/ampproject/amphtml/extensions/amp-sticky-ad/1.0/test/test-amp-sticky-ad.js:296:21)
```