### PR TITLE
amp-bind: getStateValue: Return nullable string

### DIFF
--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -557,11 +557,13 @@ export class Bind {
    * Returns the stringified value of the global state for a given field-based
    * expression, e.g. "foo.bar.baz".
    * @param {string} expr
-   * @return {string}
+   * @return {?string}
    */
   getStateValue(expr) {
     const value = getValueForExpr(this.state_, expr);
-    if (isObject(value) || isArray(value)) {
+    if (value === undefined || value === null) {
+      return null;
+    } else if (isObject(value) || isArray(value)) {
       return JSON.stringify(/** @type {JsonObject} */ (value));
     } else {
       return String(value);

--- a/src/service/url-replacements-impl.js
+++ b/src/service/url-replacements-impl.js
@@ -641,7 +641,7 @@ export class GlobalVariableSource extends VariableSource {
         if (!bind) {
           return '';
         }
-        return bind.getStateValue(/** @type {string} */ (key));
+        return bind.getStateValue(/** @type {string} */ (key)) || '';
       });
     });
   }


### PR DESCRIPTION
- Allow returning null from `Bind.getStateValue()` so that values `null`
  and `undefined` are not cast to strings "null" and "undefined"
- Set `AMP_STATE URL` replacement to substitute an empty string if
  `Bind.getStateValue()` returns `null`

Fixes #26853