### PR TITLE
✅ Skip flaky shadow integration test on Safari

### DIFF
--- a/test/integration/test-shadow-amp.js
+++ b/test/integration/test-shadow-amp.js
@@ -55,7 +55,8 @@ describes.integration(
       shadowDoc = env.win.document.getElementById('host').shadowRoot;
     });
 
-    it('should attach shadow AMP document', () => {
+    // TODO(kevinkimball, #26863): Flaky on Safari.
+    it.configure().skipSafari('should attach shadow AMP document', () => {
       return expect(shadowDoc.body.innerText).to.include('Shadow AMP document');
     });
 


### PR DESCRIPTION
This is the most common failure cause on `master` today.

```
DESCRIBE => AMP shadow v0
  IT => "before each" hook for "should attach shadow AMP document"
    ✗ Timeout of 10000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves.
  IT => "before each" hook for "should attach shadow AMP document"
    ✗ Timeout of 10000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves.

Safari 11.1.2 (Mac OS X 10.13.6): Executed 91 of 462 (1 FAILED) (skipped 371) (4 mins 10.788 secs / 1 min 37.474 secs)
Safari 12.1.1 (Mac OS X 10.13.6): Executed 91 of 462 (1 FAILED) (skipped 371) (4 mins 11.602 secs / 1 min 37.873 secs)
```

Related to #26863
