### PR TITLE
✅ Skip another flaky shadow integration test on Safari

### DIFF
--- a/test/integration/test-shadow-amp.js
+++ b/test/integration/test-shadow-amp.js
@@ -60,12 +60,16 @@ describes.integration(
       return expect(shadowDoc.body.innerText).to.include('Shadow AMP document');
     });
 
-    it('should layout amp-img component in shadow AMP document', async () => {
-      const shadowDocController = new BrowserController(env.win, shadowDoc);
-      await shadowDocController.waitForElementLayout('amp-img');
-      return expect(
-        shadowDoc.querySelectorAll('amp-img img[src]')
-      ).to.have.length(1);
-    });
+    // TODO(kevinkimball, #26863): Flaky on Safari.
+    it.configure().skipSafari(
+      'should layout amp-img component in shadow AMP document',
+      async () => {
+        const shadowDocController = new BrowserController(env.win, shadowDoc);
+        await shadowDocController.waitForElementLayout('amp-img');
+        return expect(
+          shadowDoc.querySelectorAll('amp-img img[src]')
+        ).to.have.length(1);
+      }
+    );
   }
 );


### PR DESCRIPTION
This is the most common failure cause on `master` today.

```
DESCRIBE => AMP shadow v0
  IT => "before each" hook for "should layout amp-img component in shadow AMP document"
    ✗ Timeout of 10000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves.

Safari 11.1.2 (Mac OS X 10.13.6): Executed 91 of 462 (1 FAILED) (skipped 371) (3 mins 52.475 secs / 1 min 30.952 secs)
```

Related to #26863
