### PR TITLE
🚀Use { passive: true } on gesture.js to improve touch event performance

### DIFF
--- a/src/event-helper-listen.js
+++ b/src/event-helper-listen.js
@@ -22,6 +22,12 @@
 let optsSupported;
 
 /**
+ * Whether addEventListener supports options or only takes passive as a boolean
+ * @type {boolean|undefined}
+ */
+let passiveSupported;
+
+/**
  * Listens for the specified event on the element.
  *
  * Do not use this directly. This method is implemented as a shared
@@ -114,4 +120,41 @@ export function detectEvtListenerOptsSupport() {
  */
 export function resetEvtListenerOptsSupportForTesting() {
   optsSupported = undefined;
+}
+
+/**
+ * Return boolean. if listener option is supported, return `true`.
+ * if not supported, return `false`
+ * @param {!Window} win
+ * @return {boolean}
+ */
+export function supportsPassiveEventListener(win) {
+  if (passiveSupported !== undefined) {
+    return passiveSupported;
+  }
+
+  passiveSupported = false;
+  try {
+    const options = {
+      get passive() {
+        // This function will be called when the browser
+        // attempts to access the passive property.
+        passiveSupported = true;
+        return false;
+      },
+    };
+
+    win.addEventListener('test-options', null, options);
+    win.removeEventListener('test-options', null, options);
+  } catch (err) {
+    // EventListenerOptions are not supported
+  }
+  return passiveSupported;
+}
+
+/**
+ * Resets the test for whether addEventListener supports passive options or not.
+ */
+export function resetPassiveSupportedForTesting() {
+  passiveSupported = undefined;
 }

--- a/src/gesture.js
+++ b/src/gesture.js
@@ -18,6 +18,7 @@ import {Observable} from './observable';
 import {Pass} from './pass';
 import {devAssert} from './log';
 import {findIndex} from './utils/array';
+import {supportsPassiveEventListener} from './event-helper-listen';
 import {toWin} from './types';
 
 const PROP_ = '__AMP_Gestures';
@@ -144,9 +145,19 @@ export class Gestures {
     /** @private @const {function(!Event)} */
     this.boundOnTouchCancel_ = this.onTouchCancel_.bind(this);
 
-    this.element_.addEventListener('touchstart', this.boundOnTouchStart_);
+    const win = element.ownerDocument.defaultView;
+    const passiveSupported = supportsPassiveEventListener(toWin(win));
+    this.element_.addEventListener(
+      'touchstart',
+      this.boundOnTouchStart_,
+      passiveSupported ? {passive: true} : false
+    );
     this.element_.addEventListener('touchend', this.boundOnTouchEnd_);
-    this.element_.addEventListener('touchmove', this.boundOnTouchMove_);
+    this.element_.addEventListener(
+      'touchmove',
+      this.boundOnTouchMove_,
+      passiveSupported ? {passive: true} : false
+    );
     this.element_.addEventListener('touchcancel', this.boundOnTouchCancel_);
 
     /** @private {boolean} */


### PR DESCRIPTION
This PR improves performance for touchstart / touchmove .
I would like to use passive option to improve scroll / touch event.

see passive listener details: https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#Improving_scrolling_performance_with_passive_listeners

if this pr is applied, we could achieve 💯 on Best Practice pane in Lighthouse.

before: 
![image](https://user-images.githubusercontent.com/555645/74906662-012c6100-53f5-11ea-8f10-347cee1a4031.png)

after:
![image](https://user-images.githubusercontent.com/555645/74906676-0c7f8c80-53f5-11ea-8f5a-9b4aedf88bce.png)

solved: https://github.com/ampproject/amphtml/issues/25865


<!--
# Instructions:

- Pick a meaningful title for your pull request. (Use sentence case.)
  - Prefix the title with an emoji to identify what is being done. (Copy-paste the emoji from the list below.)
  - Do not overuse punctuation in the title (like `(chore):`).
  - If it is helpful, use a simple prefix (like `ProjectX: Implement some feature`).
- Enter a succinct description that says why the PR is necessary, and what it does.
  - Mention the GitHub issue that is being addressed by the pull request.
  - The keywords `Fixes`, `Closes`, or `Resolves` followed the issue number will automatically close the issue.

> NOTE: All non-trivial changes (like introducing new features or components) should have an associated issue or reference an I2I (intent-to-implement: go.amp.dev/i2i). Please read through the contribution process (go.amp.dev/contributing/code) for more information.

# Example of a good description:

- Implement aspect X
- Leave out feature Y because of A
- Improve performance by B
- Improve accessibility by C

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Reverting a previous change
♻️ Refactoring
🚮 Deleting code
-->
