### PR TITLE
🏗 Increase karma browser activity timeout to 5min

### DIFF
--- a/build-system/tasks/karma.conf.js
+++ b/build-system/tasks/karma.conf.js
@@ -281,9 +281,10 @@ module.exports = {
   // on Travis before stalling out after 10 minutes.
   browserDisconnectTimeout: 2 * 60 * 1000,
 
-  // If there's no message from the browser, make Karma wait 2 minutes
-  // until it disconnects.
-  browserNoActivityTimeout: 2 * 60 * 1000,
+  // If there's no message from the browser, make Karma wait 5 minutes
+  // until it disconnects. This number will need to gradually grow as the
+  // duration of a full integration test run increases.
+  browserNoActivityTimeout: 5 * 60 * 1000,
 
   // IF YOU CHANGE THIS, DEBUGGING WILL RANDOMLY KILL THE BROWSER
   browserDisconnectTolerance: isTravisBuild() ? 2 : 0,


### PR DESCRIPTION
When Karma runs our integration tests in a browser, it can take a while for results to be reported. This is increasingly relevant on slow browsers as the number of integration tests in our suite grows. Right now, the suite (including setup and teardown) does not always finish during this window, especially when there is a high Sauce load from many parallel Travis builds.

It impacts Chrome the most, since we execute many of our tests on Chrome (versus IE 11, which includes only a single integration test). 

This PR ups the activity timeout from 2 minutes to 5 minutes, which should resolve the majority of tests that currently fail due to message timeout errors.