### PR TITLE
🐛 Update owners file to correct syntax

### DIFF
--- a/css/OWNERS
+++ b/css/OWNERS
@@ -11,7 +11,7 @@
       ],
     },
     {
-      pattern: '{amp-story-*}.css',
+      pattern: 'amp-story-*.css',
       owners: [{name: 'newmuis'}, {name: 'gmajoulet'}, {name: 'enriqe'}],
     },
   ],

--- a/src/OWNERS
+++ b/src/OWNERS
@@ -15,7 +15,7 @@
       owners: [{name: 'ampproject/wg-analytics'}],
     },
     {
-      pattern: '{amp-story-*}.js',
+      pattern: 'amp-story-*.js',
       owners: [{name: 'newmuis'}, {name: 'gmajoulet'}, {name: 'enriqe'}],
     },
     {


### PR DESCRIPTION
Including the curly braces for a single file pattern (not multiple options separated by a comma) was resulting in an incorrect expansion