### PR TITLE
added application/octet-stream as valid script type

### DIFF
--- a/spec/amp-html-format.md
+++ b/spec/amp-html-format.md
@@ -195,7 +195,7 @@ HTML tags can be used unchanged in AMP HTML. Certain tags have equivalent custom
   </tr>
   <tr>
     <td width="30%">script</td>
-    <td>Prohibited unless the type is <code>application/ld+json</code>, <code>application/json</code>, or <code>text/plain</code>. (Other non-executable values may be added as needed.) Exception is the mandatory script tag to load the AMP runtime and the script tags to load extended components.</td>
+    <td>Prohibited unless the type is <code>application/ld+json</code>, <code>application/json</code>, <code>text/plain</code>, or <code>application/octet-stream</code>. (Other non-executable values may be added as needed.) Exception is the mandatory script tag to load the AMP runtime and the script tags to load extended components.</td>
   </tr>
   <tr>
     <td width="30%">noscript</td>


### PR DESCRIPTION
Looks like theres another valid type for `<script>`
https://github.com/ampproject/amphtml/blob/e1fd0e15b85e6f80f5d6382600b0765875d37b23/extensions/amp-subscriptions/validator-amp-subscriptions.protoascii#L112

https://github.com/ampproject/amphtml/blob/489204f5d9c47cb13a98928e4e7963bf57c157ff/validator/engine/validator_test.js#L1598