### PR TITLE
dom: Minor test improvements

### DIFF
--- a/test/unit/test-dom.js
+++ b/test/unit/test-dom.js
@@ -951,13 +951,15 @@ describes.sandboxed('DOM', {}, env => {
         .withExactArgs('https://example.com/', '_top')
         .returns(dialog)
         .once();
-      const res = dom.openWindowDialog(
-        windowApi,
-        'https://example.com/',
-        '_blank',
-        'width=1'
-      );
-      expect(res).to.equal(dialog);
+      allowConsoleError(() => {
+        const res = dom.openWindowDialog(
+          windowApi,
+          'https://example.com/',
+          '_blank',
+          'width=1'
+        );
+        expect(res).to.equal(dialog);
+      });
     });
 
     it('should return the final result', () => {

--- a/test/unit/test-dom.js
+++ b/test/unit/test-dom.js
@@ -1261,6 +1261,7 @@ describes.realWin(
 
       it('should resolve if element has already upgrade', () => {
         const element = doc.createElement('amp-img');
+        element.setAttribute('layout', 'nodisplay');
         doc.body.appendChild(element);
         return dom.whenUpgradedToCustomElement(element).then(element => {
           expect(element.whenBuilt).to.exist;
@@ -1269,6 +1270,7 @@ describes.realWin(
 
       it('should resolve when element upgrade', () => {
         const element = doc.createElement('amp-test');
+        element.setAttribute('layout', 'nodisplay');
         doc.body.appendChild(element);
         env.win.setTimeout(() => {
           env.win.customElements.define(


### PR DESCRIPTION
Resolve sinon warning:
```
ERROR: '[DOM] Failed to open url on target:  _blank Error: intentional'
    The test "DOM   openWindowDialog should retry on first exception" resulted in a call to console.error. (See above line.)
    ⤷ If the error is not expected, fix the code that generated the error.
    ⤷ If the error is expected (and synchronous), use the following pattern to wrap the test code that generated the error:
        'allowConsoleError(() => { <code that generated the error> });'
    ⤷ If the error is expected (and asynchronous), use the following pattern at the top of the test:
        'expectAsyncConsoleError(<string or regex>[, <number of times the error message repeats>]);'
ERROR: 'The element did not specify a layout attribute. Check https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/control_layout and the respective element documentation for details.'
    The test "DOM   whenUpgradeToCustomElement function should resolve if element has already upgrade" resulted in a call to console.error. (See above line.)
    ⤷ If the error is not expected, fix the code that generated the error.
    ⤷ If the error is expected (and synchronous), use the following pattern to wrap the test code that generated the error:
        'allowConsoleError(() => { <code that generated the error> });'
    ⤷ If the error is expected (and asynchronous), use the following pattern at the top of the test:
        'expectAsyncConsoleError(<string or regex>[, <number of times the error message repeats>]);'
ERROR: 'The element did not specify a layout attribute. Check https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/control_layout and the respective element documentation for details.'
    The test "DOM   whenUpgradeToCustomElement function should resolve when element upgrade" resulted in a call to console.error. (See above line.)
    ⤷ If the error is not expected, fix the code that generated the error.
    ⤷ If the error is expected (and synchronous), use the following pattern to wrap the test code that generated the error:
        'allowConsoleError(() => { <code that generated the error> });'
    ⤷ If the error is expected (and asynchronous), use the following pattern at the top of the test:
        'expectAsyncConsoleError(<string or regex>[, <number of times the error message repeats>]);'
```
Full log: https://gist.github.com/mdmower/d2252c6dc06d096687c56a6368a30c41