### PR TITLE
inabox-resources: Minor test improvement

### DIFF
--- a/test/unit/inabox/test-inabox-resources.js
+++ b/test/unit/inabox/test-inabox-resources.js
@@ -40,9 +40,11 @@ describes.realWin('inabox-resources', {amp: true}, env => {
     const resource2 = resources.getResourceForElement(element2);
     expect(resource1.getId()).to.not.equal(resource2.getId());
 
-    expect(() => {
-      resources.getResourceForElement(element3);
-    }).to.throw(/Missing resource prop on/);
+    allowConsoleError(() => {
+      expect(() => {
+        resources.getResourceForElement(element3);
+      }).to.throw(/Missing resource prop on/);
+    });
 
     resources.remove(element1);
     expect(resources.get()).to.have.length(1);


### PR DESCRIPTION
Resolve sinon warning:
```
ERROR: 'Missing resource prop on  [object HTMLDivElement]'
    The test "inabox-resources   add & remove" resulted in a call to console.error. (See above line.)
    ⤷ If the error is not expected, fix the code that generated the error.
    ⤷ If the error is expected (and synchronous), use the following pattern to wrap the test code that generated the error:
        'allowConsoleError(() => { <code that generated the error> });'
    ⤷ If the error is expected (and asynchronous), use the following pattern at the top of the test:
        'expectAsyncConsoleError(<string or regex>[, <number of times the error message repeats>]);'
```
Full log: https://gist.github.com/mdmower/d2252c6dc06d096687c56a6368a30c41