### PR TITLE
ad-cid: Minor test improvement

### DIFF
--- a/test/unit/test-ad-cid.js
+++ b/test/unit/test-ad-cid.js
@@ -106,6 +106,7 @@ describes.realWin('ad-cid', {amp: true}, env => {
   });
 
   it('should return undefined on failed CID', () => {
+    expectAsyncConsoleError(/nope/);
     config.clientIdScope = cidScope;
     env.sandbox.stub(cidService, 'get').callsFake(() => {
       return Promise.reject(new Error('nope'));


### PR DESCRIPTION
Resolve sinon warning:
```
ERROR: '[AD-CID] Error: nope'
    The test "ad-cid   should return undefined on failed CID" resulted in a call to console.error. (See above line.)
    ⤷ If the error is not expected, fix the code that generated the error.
    ⤷ If the error is expected (and synchronous), use the following pattern to wrap the test code that generated the error:
        'allowConsoleError(() => { <code that generated the error> });'
    ⤷ If the error is expected (and asynchronous), use the following pattern at the top of the test:
        'expectAsyncConsoleError(<string or regex>[, <number of times the error message repeats>]);'
```
Full log: https://gist.github.com/mdmower/d2252c6dc06d096687c56a6368a30c41