### PR TITLE
amp-pixel: Minor test improvements

### DIFF
--- a/test/unit/test-amp-pixel.js
+++ b/test/unit/test-amp-pixel.js
@@ -18,6 +18,8 @@ import {VariableSource} from '../../src/service/variable-source';
 import {installUrlReplacementsForEmbed} from '../../src/service/url-replacements-impl';
 
 describes.realWin('amp-pixel', {amp: true}, env => {
+  const urlErrorRegex = /src attribute must start with/;
+
   let win;
   let whenFirstVisiblePromise, whenFirstVisibleResolver;
   let pixel;
@@ -99,27 +101,21 @@ describes.realWin('amp-pixel', {amp: true}, env => {
   });
 
   it('should disallow http URLs', () => {
-    expectAsyncConsoleError(/src attribute must start with/);
+    expectAsyncConsoleError(urlErrorRegex);
     const url = 'http://pubads.g.doubleclick.net/activity;dc_iu=1/abc;ord=2';
-    return expect(trigger(url)).to.eventually.be.rejectedWith(
-      /src attribute must start with/
-    );
+    return expect(trigger(url)).to.eventually.be.rejectedWith(urlErrorRegex);
   });
 
   it('should disallow relative URLs', () => {
-    expectAsyncConsoleError(/src attribute must start with/);
+    expectAsyncConsoleError(urlErrorRegex);
     const url = '/activity;dc_iu=1/abc;ord=2';
-    return expect(trigger(url)).to.eventually.be.rejectedWith(
-      /src attribute must start with/
-    );
+    return expect(trigger(url)).to.eventually.be.rejectedWith(urlErrorRegex);
   });
 
   it('should disallow fake-protocol URLs', () => {
-    expectAsyncConsoleError(/src attribute must start with/);
+    expectAsyncConsoleError(urlErrorRegex);
     const url = 'https/activity;dc_iu=1/abc;ord=2';
-    return expect(trigger(url)).to.eventually.be.rejectedWith(
-      /src attribute must start with/
-    );
+    return expect(trigger(url)).to.eventually.be.rejectedWith(urlErrorRegex);
   });
 
   it('should replace URL parameters', () => {

--- a/test/unit/test-amp-pixel.js
+++ b/test/unit/test-amp-pixel.js
@@ -99,6 +99,7 @@ describes.realWin('amp-pixel', {amp: true}, env => {
   });
 
   it('should disallow http URLs', () => {
+    expectAsyncConsoleError(/src attribute must start with/);
     const url = 'http://pubads.g.doubleclick.net/activity;dc_iu=1/abc;ord=2';
     return expect(trigger(url)).to.eventually.be.rejectedWith(
       /src attribute must start with/
@@ -106,6 +107,7 @@ describes.realWin('amp-pixel', {amp: true}, env => {
   });
 
   it('should disallow relative URLs', () => {
+    expectAsyncConsoleError(/src attribute must start with/);
     const url = '/activity;dc_iu=1/abc;ord=2';
     return expect(trigger(url)).to.eventually.be.rejectedWith(
       /src attribute must start with/
@@ -113,6 +115,7 @@ describes.realWin('amp-pixel', {amp: true}, env => {
   });
 
   it('should disallow fake-protocol URLs', () => {
+    expectAsyncConsoleError(/src attribute must start with/);
     const url = 'https/activity;dc_iu=1/abc;ord=2';
     return expect(trigger(url)).to.eventually.be.rejectedWith(
       /src attribute must start with/


### PR DESCRIPTION
Resolve sinon warnings:
```
ERROR: 'The <amp-pixel> src attribute must start with "https://" or "//". Invalid value: http://pubads.g.doubleclick.net/activity;dc_iu=1/abc;ord=2'
    The test "amp-pixel   should disallow http URLs" resulted in a call to console.error. (See above line.)
    ⤷ If the error is not expected, fix the code that generated the error.
    ⤷ If the error is expected (and synchronous), use the following pattern to wrap the test code that generated the error:
        'allowConsoleError(() => { <code that generated the error> });'
    ⤷ If the error is expected (and asynchronous), use the following pattern at the top of the test:
        'expectAsyncConsoleError(<string or regex>[, <number of times the error message repeats>]);'
ERROR: 'The <amp-pixel> src attribute must start with "https://" or "//". Invalid value: /activity;dc_iu=1/abc;ord=2'
    The test "amp-pixel   should disallow relative URLs" resulted in a call to console.error. (See above line.)
    ⤷ If the error is not expected, fix the code that generated the error.
    ⤷ If the error is expected (and synchronous), use the following pattern to wrap the test code that generated the error:
        'allowConsoleError(() => { <code that generated the error> });'
    ⤷ If the error is expected (and asynchronous), use the following pattern at the top of the test:
        'expectAsyncConsoleError(<string or regex>[, <number of times the error message repeats>]);'
ERROR: 'The <amp-pixel> src attribute must start with "https://" or "//". Invalid value: https/activity;dc_iu=1/abc;ord=2'
    The test "amp-pixel   should disallow fake-protocol URLs" resulted in a call to console.error. (See above line.)
    ⤷ If the error is not expected, fix the code that generated the error.
    ⤷ If the error is expected (and synchronous), use the following pattern to wrap the test code that generated the error:
        'allowConsoleError(() => { <code that generated the error> });'
    ⤷ If the error is expected (and asynchronous), use the following pattern at the top of the test:
        'expectAsyncConsoleError(<string or regex>[, <number of times the error message repeats>]);'
```
Full log: https://gist.github.com/mdmower/d2252c6dc06d096687c56a6368a30c41