### PR TITLE
cache-cid-api: Minor test improvement

### DIFF
--- a/test/unit/test-cache-cid-api.js
+++ b/test/unit/test-cache-cid-api.js
@@ -165,6 +165,7 @@ describes.realWin('cacheCidApi', {amp: true}, env => {
       });
 
       it('should fail if the request times out', () => {
+        expectAsyncConsoleError(/fetchCidTimeout​​​/);
         fetchJsonStub.callsFake(() => {
           return new Promise((resolve, unused) => {
             clock.setTimeout(resolve, 35000, {


### PR DESCRIPTION
Resolve sinon warning:
```
ERROR: '[CacheCidApi] Error: fetchCidTimeout​​​'
    The test "cacheCidApi   getScopedCid should fail if the request times out" resulted in a call to console.error. (See above line.)
    ⤷ If the error is not expected, fix the code that generated the error.
    ⤷ If the error is expected (and synchronous), use the following pattern to wrap the test code that generated the error:
        'allowConsoleError(() => { <code that generated the error> });'
    ⤷ If the error is expected (and asynchronous), use the following pattern at the top of the test:
        'expectAsyncConsoleError(<string or regex>[, <number of times the error message repeats>]);'
```
Full log: https://gist.github.com/mdmower/d2252c6dc06d096687c56a6368a30c41