### PR TITLE
cid-api: Minor test improvement

### DIFF
--- a/test/unit/test-cid-api.js
+++ b/test/unit/test-cid-api.js
@@ -166,7 +166,8 @@ describes.realWin('test-cid-api', {amp: true}, env => {
   });
 
   it('should return null if API rejects', () => {
-    fetchJsonStub.returns(Promise.reject());
+    expectAsyncConsoleError(/fetch failed/);
+    fetchJsonStub.rejects('fetch failed');
     return api
       .getScopedCid('api-key', 'scope-a')
       .then(cid => {


### PR DESCRIPTION
Resolve sinon warning:
```
ERROR: '[GoogleCidApi] '
    The test "test-cid-api   should return null if API rejects" resulted in a call to console.error. (See above line.)
    ⤷ If the error is not expected, fix the code that generated the error.
    ⤷ If the error is expected (and synchronous), use the following pattern to wrap the test code that generated the error:
        'allowConsoleError(() => { <code that generated the error> });'
    ⤷ If the error is expected (and asynchronous), use the following pattern at the top of the test:
        'expectAsyncConsoleError(<string or regex>[, <number of times the error message repeats>]);'
```
Full log: https://gist.github.com/mdmower/d2252c6dc06d096687c56a6368a30c41