### PR TITLE
custom-element: Minor test improvements

### DIFF
--- a/test/unit/test-custom-element.js
+++ b/test/unit/test-custom-element.js
@@ -336,6 +336,7 @@ describes.realWin('CustomElement', {amp: true}, env => {
       });
 
       it('should tolerate errors in onLayoutMeasure', () => {
+        expectAsyncConsoleError(/intentional/, 1);
         const element = new ElementClass();
         env.sandbox
           .stub(element.implementation_, 'onLayoutMeasure')
@@ -519,7 +520,7 @@ describes.realWin('CustomElement', {amp: true}, env => {
       });
 
       it('Element - re-upgrade with a failed promised', () => {
-        expectAsyncConsoleError('upgrade failed', 1);
+        expectAsyncConsoleError(/upgrade failed/, 1);
         const element = new ElementClass();
         expect(element.isUpgraded()).to.equal(false);
         const oldImpl = element.implementation_;
@@ -684,6 +685,7 @@ describes.realWin('CustomElement', {amp: true}, env => {
       });
 
       it('should anticipate build errors', () => {
+        expectAsyncConsoleError(/intentional/, 2);
         const element = new ElementClass();
         env.sandbox
           .stub(element.implementation_, 'buildCallback')
@@ -2085,6 +2087,8 @@ describes.realWin('CustomElement', {amp: true}, env => {
       it('should toggle loading off after layout complete', () => {
         stubInA4A(false);
         const toggle = env.sandbox.spy(element, 'toggleLoading');
+        element.setAttribute('height', '10');
+        element.setAttribute('width', '10');
         container.appendChild(element);
         return element.buildingPromise_
           .then(() => {
@@ -2105,6 +2109,8 @@ describes.realWin('CustomElement', {amp: true}, env => {
           .callsFake(() => {
             return Promise.reject();
           });
+        element.setAttribute('height', '10');
+        element.setAttribute('width', '10');
         container.appendChild(element);
         return element.buildingPromise_
           .then(() => {
@@ -2130,6 +2136,8 @@ describes.realWin('CustomElement', {amp: true}, env => {
           .callsFake(() => {
             return Promise.reject();
           });
+        element.setAttribute('height', '10');
+        element.setAttribute('width', '10');
         container.appendChild(element);
         return element.buildingPromise_
           .then(() => {


### PR DESCRIPTION
Resolve sinon warnings:
```
ERROR: 'Error: upgrade failed'
    The test "CustomElement   CustomElement Element - re-upgrade with a failed promised" resulted in a call to console.error. (See above line.)
    ⤷ If the error is not expected, fix the code that generated the error.
    ⤷ If the error is expected (and synchronous), use the following pattern to wrap the test code that generated the error:
        'allowConsoleError(() => { <code that generated the error> });'
    ⤷ If the error is expected (and asynchronous), use the following pattern at the top of the test:
        'expectAsyncConsoleError(<string or regex>[, <number of times the error message repeats>]);'
ERROR: 'intentional [object HTMLElement]'
    The test "CustomElement   CustomElement should anticipate build errors" resulted in a call to console.error. (See above line.)
    ⤷ If the error is not expected, fix the code that generated the error.
    ⤷ If the error is expected (and synchronous), use the following pattern to wrap the test code that generated the error:
        'allowConsoleError(() => { <code that generated the error> });'
    ⤷ If the error is expected (and asynchronous), use the following pattern at the top of the test:
        'expectAsyncConsoleError(<string or regex>[, <number of times the error message repeats>]);'
ERROR: '[Resource] failed to build: amp-test#1 Error: intentional'
    The test "CustomElement   CustomElement should anticipate build errors" resulted in a call to console.error. (See above line.)
    ⤷ If the error is not expected, fix the code that generated the error.
    ⤷ If the error is expected (and synchronous), use the following pattern to wrap the test code that generated the error:
        'allowConsoleError(() => { <code that generated the error> });'
    ⤷ If the error is expected (and asynchronous), use the following pattern at the top of the test:
        'expectAsyncConsoleError(<string or regex>[, <number of times the error message repeats>]);'
ERROR: 'The "height" attribute is missing:  [object HTMLElement]'
    The test "CustomElement   Loading Indicator should toggle loading off after layout complete" resulted in a call to console.error. (See above line.)
    ⤷ If the error is not expected, fix the code that generated the error.
    ⤷ If the error is expected (and synchronous), use the following pattern to wrap the test code that generated the error:
        'allowConsoleError(() => { <code that generated the error> });'
    ⤷ If the error is expected (and asynchronous), use the following pattern at the top of the test:
        'expectAsyncConsoleError(<string or regex>[, <number of times the error message repeats>]);'
ERROR: 'The "height" attribute is missing:  [object HTMLElement]'
    The test "CustomElement   Loading Indicator should toggle loading off after layout failed" resulted in a call to console.error. (See above line.)
    ⤷ If the error is not expected, fix the code that generated the error.
    ⤷ If the error is expected (and synchronous), use the following pattern to wrap the test code that generated the error:
        'allowConsoleError(() => { <code that generated the error> });'
    ⤷ If the error is expected (and asynchronous), use the following pattern at the top of the test:
        'expectAsyncConsoleError(<string or regex>[, <number of times the error message repeats>]);'
ERROR: 'The "height" attribute is missing:  [object HTMLElement]'
    The test "CustomElement   Loading Indicator should disable toggle loading on after layout failed" resulted in a call to console.error. (See above line.)
    ⤷ If the error is not expected, fix the code that generated the error.
    ⤷ If the error is expected (and synchronous), use the following pattern to wrap the test code that generated the error:
        'allowConsoleError(() => { <code that generated the error> });'
    ⤷ If the error is expected (and asynchronous), use the following pattern at the top of the test:
        'expectAsyncConsoleError(<string or regex>[, <number of times the error message repeats>]);'
```
Full log: https://gist.github.com/mdmower/d2252c6dc06d096687c56a6368a30c41