### PR TITLE
navigation: Minor test improvements

### DIFF
--- a/test/unit/test-navigation.js
+++ b/test/unit/test-navigation.js
@@ -179,18 +179,16 @@ describes.sandboxed('Navigation', {}, () => {
       });
 
       describe('anchor mutators', () => {
-        it('should throw error if priority is already in use', () => {
+        it('should not throw error if priority is already in use', () => {
           const priority = 10;
           handler.registerAnchorMutator(element => {
             element.href += '?am=1';
           }, priority);
-          allowConsoleError(() => {
-            expect(() =>
-              handler.registerAnchorMutator(element => {
-                element.href += '?am=2';
-              }, priority)
-            ).to.not.throw();
-          });
+          expect(() =>
+            handler.registerAnchorMutator(element => {
+              element.href += '?am=2';
+            }, priority)
+          ).to.not.throw();
         });
 
         it('should execute in order', () => {
@@ -648,10 +646,7 @@ describes.sandboxed('Navigation', {}, () => {
             return 'https://www.pub.com/dir/abc.html';
           });
 
-          allowConsoleError(() => {
-            handler.navigateTo(win, 'abc.html');
-          });
-
+          handler.navigateTo(win, 'abc.html');
           expect(win.location.href).to.equal(
             'https://www.pub.com/dir/abc.html'
           );


### PR DESCRIPTION
Errors are no longer thrown for:

- Multiple anchor mutators with equal priority
- Navigation to relative URLs

Resolve sinon warnings:
```
ERROR: 'The test "Navigation   non-embed   anchor mutators should throw error if priority is already in use" contains an "allowConsoleError" block that didn't result in a call to console.error.'
ERROR: 'The test "Navigation   non-embed   navigateTo should navigate relative to source url" contains an "allowConsoleError" block that didn't result in a call to console.error.'
```
Full log: https://gist.github.com/mdmower/d2252c6dc06d096687c56a6368a30c41