### PR TITLE
service: Minor test improvement

### DIFF
--- a/test/unit/test-service.js
+++ b/test/unit/test-service.js
@@ -439,6 +439,7 @@ describe('service', () => {
     });
 
     it('should dispose disposable services', () => {
+      expectAsyncConsoleError(/intentional/);
       const disposableFactory = function() {
         return {
           dispose: window.sandbox.spy(),
@@ -478,7 +479,7 @@ describe('service', () => {
       // Window disposable is not touched.
       expect(windowDisposable.dispose).to.not.be.called;
 
-      // Deffered.
+      // Deferred.
       registerServiceBuilderForDoc(node, 'c', disposableFactory);
       const disposableDeferred = getServiceForDoc(node, 'c');
       expect(disposableDeferred.dispose).to.not.be.called;


### PR DESCRIPTION
Resolve sinon warning:
```
ERROR: '[SERVICE] failed to dispose service b intentional'
    The test "service ampdoc singletons should dispose disposable services" resulted in a call to console.error. (See above line.)
    ⤷ If the error is not expected, fix the code that generated the error.
    ⤷ If the error is expected (and synchronous), use the following pattern to wrap the test code that generated the error:
        'allowConsoleError(() => { <code that generated the error> });'
    ⤷ If the error is expected (and asynchronous), use the following pattern at the top of the test:
        'expectAsyncConsoleError(<string or regex>[, <number of times the error message repeats>]);'
```
Full log: https://gist.github.com/mdmower/d2252c6dc06d096687c56a6368a30c41