### PR TITLE
storage: Minor test improvements

### DIFF
--- a/test/unit/test-storage.js
+++ b/test/unit/test-storage.js
@@ -179,6 +179,7 @@ describes.sandboxed('Storage', {}, env => {
       });
 
       it('should recover from binding failure', () => {
+        expectAsyncConsoleError(/Failed to load store/);
         bindingMock
           .expects('loadBlob')
           .withExactArgs('https://acme.com')
@@ -193,6 +194,7 @@ describes.sandboxed('Storage', {}, env => {
       });
 
       it('should recover from binding error', () => {
+        expectAsyncConsoleError(/Failed to load store/);
         bindingMock
           .expects('loadBlob')
           .withExactArgs('https://acme.com')
@@ -499,7 +501,7 @@ describes.sandboxed('LocalStorageBinding', {}, env => {
     expect(errorSpy).to.have.not.been.called;
 
     delete windowApi.localStorage;
-    new LocalStorageBinding(windowApi);
+    allowConsoleError(() => new LocalStorageBinding(windowApi));
     expect(errorSpy).to.be.calledOnce;
     expect(errorSpy.args[0][1].message).to.match(/localStorage not supported/);
   });
@@ -564,6 +566,7 @@ describes.sandboxed('LocalStorageBinding', {}, env => {
   });
 
   it('should bypass loading from localStorage if getItem throws', () => {
+    expectAsyncConsoleError(/localStorage not supported/);
     localStorageMock
       .expects('getItem')
       .throws(new Error('unknown'))
@@ -626,6 +629,7 @@ describes.sandboxed('LocalStorageBinding', {}, env => {
   });
 
   it('should bypass saving to localStorage if getItem throws', () => {
+    expectAsyncConsoleError(/localStorage not supported/);
     const setItemSpy = env.sandbox.spy(windowApi.localStorage, 'setItem');
 
     localStorageMock


### PR DESCRIPTION
Resolve sinon warnings:
```
ERROR: '[Storage] Failed to load store:  intentional'
    The test "Storage   Storage should recover from binding failure" resulted in a call to console.error. (See above line.)
    ⤷ If the error is not expected, fix the code that generated the error.
    ⤷ If the error is expected (and synchronous), use the following pattern to wrap the test code that generated the error:
        'allowConsoleError(() => { <code that generated the error> });'
    ⤷ If the error is expected (and asynchronous), use the following pattern at the top of the test:
        'expectAsyncConsoleError(<string or regex>[, <number of times the error message repeats>]);'
ERROR: '[Storage] Failed to load store:  InvalidCharacterError: Failed to execute 'atob' on 'Window': The string to be decoded is not correctly encoded.'
    The test "Storage   Storage should recover from binding error" resulted in a call to console.error. (See above line.)
    ⤷ If the error is not expected, fix the code that generated the error.
    ⤷ If the error is expected (and synchronous), use the following pattern to wrap the test code that generated the error:
        'allowConsoleError(() => { <code that generated the error> });'
    ⤷ If the error is expected (and asynchronous), use the following pattern at the top of the test:
        'expectAsyncConsoleError(<string or regex>[, <number of times the error message repeats>]);'
ERROR: '[Storage] Error: localStorage not supported.'
    The test "LocalStorageBinding   should throw if localStorage is not supported" resulted in a call to console.error. (See above line.)
    ⤷ If the error is not expected, fix the code that generated the error.
    ⤷ If the error is expected (and synchronous), use the following pattern to wrap the test code that generated the error:
        'allowConsoleError(() => { <code that generated the error> });'
    ⤷ If the error is expected (and asynchronous), use the following pattern at the top of the test:
        'expectAsyncConsoleError(<string or regex>[, <number of times the error message repeats>]);'
ERROR: '[Storage] Error: localStorage not supported.'
    The test "LocalStorageBinding   should bypass loading from localStorage if getItem throws" resulted in a call to console.error. (See above line.)
    ⤷ If the error is not expected, fix the code that generated the error.
    ⤷ If the error is expected (and synchronous), use the following pattern to wrap the test code that generated the error:
        'allowConsoleError(() => { <code that generated the error> });'
    ⤷ If the error is expected (and asynchronous), use the following pattern at the top of the test:
        'expectAsyncConsoleError(<string or regex>[, <number of times the error message repeats>]);'
ERROR: '[Storage] Error: localStorage not supported.'
    The test "LocalStorageBinding   should bypass saving to localStorage if getItem throws" resulted in a call to console.error. (See above line.)
    ⤷ If the error is not expected, fix the code that generated the error.
    ⤷ If the error is expected (and synchronous), use the following pattern to wrap the test code that generated the error:
        'allowConsoleError(() => { <code that generated the error> });'
    ⤷ If the error is expected (and asynchronous), use the following pattern at the top of the test:
        'expectAsyncConsoleError(<string or regex>[, <number of times the error message repeats>]);'
```
Full log: https://gist.github.com/mdmower/d2252c6dc06d096687c56a6368a30c41