### PR TITLE
url-replacements: Minor test improvement

### DIFF
--- a/test/unit/test-url-replacements.js
+++ b/test/unit/test-url-replacements.js
@@ -1493,6 +1493,8 @@ describes.sandboxed('UrlReplacements', {}, env => {
       });
 
       it('should reject javascript protocol', () => {
+        const protocolErrorRegex = /invalid protocol/;
+        expectAsyncConsoleError(protocolErrorRegex);
         const win = getFakeWindow();
         const {documentElement} = win.document;
         const urlReplacements = Services.urlReplacementsForDoc(documentElement);
@@ -1504,7 +1506,7 @@ describes.sandboxed('UrlReplacements', {}, env => {
               throw new Error('never here');
             },
             err => {
-              expect(err.message).to.match(/invalid protocol/);
+              expect(err.message).to.match(protocolErrorRegex);
             }
           );
       });


### PR DESCRIPTION
Resolve sinon warning:
```
ERROR: 'The replacement url has invalid protocol:  javascript://example.com/?r=0.17944693054878424'
    The test "UrlReplacements   UrlReplacements should reject javascript protocol" resulted in a call to console.error. (See above line.)
    ⤷ If the error is not expected, fix the code that generated the error.
    ⤷ If the error is expected (and synchronous), use the following pattern to wrap the test code that generated the error:
        'allowConsoleError(() => { <code that generated the error> });'
    ⤷ If the error is expected (and asynchronous), use the following pattern at the top of the test:
        'expectAsyncConsoleError(<string or regex>[, <number of times the error message repeats>]);'
```
Full log: https://gist.github.com/mdmower/d2252c6dc06d096687c56a6368a30c41