### PR TITLE
viewport: Minor test improvement

### DIFF
--- a/test/unit/test-viewport.js
+++ b/test/unit/test-viewport.js
@@ -191,6 +191,7 @@ describes.fakeWin('Viewport', {}, env => {
     });
 
     it('should not set singledoc class', () => {
+      expectAsyncConsoleError(/Expected service/);
       env.sandbox.stub(ampdoc, 'isSingleDoc').callsFake(() => false);
       new ViewportImpl(ampdoc, binding, viewer);
       expect(root).to.not.have.class('i-amphtml-singledoc');


### PR DESCRIPTION
Resolve sinon warning:
```
ERROR: 'Expected service viewer to be registered'
    The test "Viewport   top-level classes should not set singledoc class" resulted in a call to console.error. (See above line.)
    ⤷ If the error is not expected, fix the code that generated the error.
    ⤷ If the error is expected (and synchronous), use the following pattern to wrap the test code that generated the error:
        'allowConsoleError(() => { <code that generated the error> });'
    ⤷ If the error is expected (and asynchronous), use the following pattern at the top of the test:
        'expectAsyncConsoleError(<string or regex>[, <number of times the error message repeats>]);'
```
Full log: https://gist.github.com/mdmower/d2252c6dc06d096687c56a6368a30c41