### PR TITLE
xhr-fetch-polyfill: Minor test improvements

### DIFF
--- a/test/unit/test-xhr-fetch-polyfill.js
+++ b/test/unit/test-xhr-fetch-polyfill.js
@@ -20,6 +20,7 @@ import {createFormDataWrapper} from '../../src/form-data-wrapper';
 
 describes.sandboxed('fetch', {}, env => {
   describe('fetch method', () => {
+    const methodErrorRegex = /Only one of\s+GET, POST is currently allowed/;
     let xhrCreated;
 
     function setupMockXhr() {
@@ -63,6 +64,7 @@ describes.sandboxed('fetch', {}, env => {
     });
 
     it('should not allow PUT method', () => {
+      expectAsyncConsoleError(methodErrorRegex);
       mockOkResponse();
       return expect(
         fetchPolyfill('/post', {
@@ -71,10 +73,11 @@ describes.sandboxed('fetch', {}, env => {
             hello: 'world',
           },
         })
-      ).to.be.rejectedWith(/Only one of GET, POST is currently allowed./);
+      ).to.be.rejectedWith(methodErrorRegex);
     });
 
     it('should not allow PATCH method', () => {
+      expectAsyncConsoleError(methodErrorRegex);
       mockOkResponse();
       return expect(
         fetchPolyfill('/post', {
@@ -83,10 +86,11 @@ describes.sandboxed('fetch', {}, env => {
             hello: 'world',
           },
         })
-      ).to.be.rejectedWith(/Only one of GET, POST is currently allowed./);
+      ).to.be.rejectedWith(methodErrorRegex);
     });
 
     it('should not allow DELETE method', () => {
+      expectAsyncConsoleError(methodErrorRegex);
       mockOkResponse();
       return expect(
         fetchPolyfill('/post', {
@@ -95,7 +99,7 @@ describes.sandboxed('fetch', {}, env => {
             hello: 'world',
           },
         })
-      ).to.be.rejectedWith(/Only one of GET, POST is currently allowed./);
+      ).to.be.rejectedWith(methodErrorRegex);
     });
 
     it('should allow FormData as body', () => {
@@ -172,6 +176,7 @@ describes.sandboxed('fetch', {}, env => {
 
   describe('Response', () => {
     const TEST_TEXT = 'this is some test text';
+    const bodyUsedErrorRegex = /Body already used/;
 
     it('should keep default status as 200 OK', () => {
       const response = new Response(TEST_TEXT);
@@ -233,12 +238,13 @@ describes.sandboxed('fetch', {}, env => {
     });
 
     it('should provide text only once', () => {
+      expectAsyncConsoleError(bodyUsedErrorRegex);
       const response = new Response(TEST_TEXT);
       return response.text().then(result => {
         expect(result).to.equal(TEST_TEXT);
         expect(response.text.bind(response), 'should throw').to.throw(
           Error,
-          /Body already used/
+          bodyUsedErrorRegex
         );
       });
     });
@@ -264,11 +270,12 @@ describes.sandboxed('fetch', {}, env => {
     });
 
     it('should not be cloneable if body is already accessed', () => {
+      expectAsyncConsoleError(bodyUsedErrorRegex);
       const response = new Response(TEST_TEXT);
       return response.text().then(() => {
         expect(() => response.clone(), 'should throw').to.throw(
           Error,
-          /Body already used/
+          bodyUsedErrorRegex
         );
       });
     });


### PR DESCRIPTION
Resolve sinon warning:
```
ERROR: 'Only one of  GET, POST is currently allowed. Got PUT'
    The test "fetch   fetch method should not allow PUT method" resulted in a call to console.error. (See above line.)
    ⤷ If the error is not expected, fix the code that generated the error.
    ⤷ If the error is expected (and synchronous), use the following pattern to wrap the test code that generated the error:
        'allowConsoleError(() => { <code that generated the error> });'
    ⤷ If the error is expected (and asynchronous), use the following pattern at the top of the test:
        'expectAsyncConsoleError(<string or regex>[, <number of times the error message repeats>]);'
ERROR: 'Only one of  GET, POST is currently allowed. Got PATCH'
    The test "fetch   fetch method should not allow PATCH method" resulted in a call to console.error. (See above line.)
    ⤷ If the error is not expected, fix the code that generated the error.
    ⤷ If the error is expected (and synchronous), use the following pattern to wrap the test code that generated the error:
        'allowConsoleError(() => { <code that generated the error> });'
    ⤷ If the error is expected (and asynchronous), use the following pattern at the top of the test:
        'expectAsyncConsoleError(<string or regex>[, <number of times the error message repeats>]);'
ERROR: 'Only one of  GET, POST is currently allowed. Got DELETE'
    The test "fetch   fetch method should not allow DELETE method" resulted in a call to console.error. (See above line.)
    ⤷ If the error is not expected, fix the code that generated the error.
    ⤷ If the error is expected (and synchronous), use the following pattern to wrap the test code that generated the error:
        'allowConsoleError(() => { <code that generated the error> });'
    ⤷ If the error is expected (and asynchronous), use the following pattern at the top of the test:
        'expectAsyncConsoleError(<string or regex>[, <number of times the error message repeats>]);'
ERROR: 'Body already used'
    The test "fetch   Response should provide text only once" resulted in a call to console.error. (See above line.)
    ⤷ If the error is not expected, fix the code that generated the error.
    ⤷ If the error is expected (and synchronous), use the following pattern to wrap the test code that generated the error:
        'allowConsoleError(() => { <code that generated the error> });'
    ⤷ If the error is expected (and asynchronous), use the following pattern at the top of the test:
        'expectAsyncConsoleError(<string or regex>[, <number of times the error message repeats>]);'
ERROR: 'Body already used'
    The test "fetch   Response should not be cloneable if body is already accessed" resulted in a call to console.error. (See above line.)
    ⤷ If the error is not expected, fix the code that generated the error.
    ⤷ If the error is expected (and synchronous), use the following pattern to wrap the test code that generated the error:
        'allowConsoleError(() => { <code that generated the error> });'
    ⤷ If the error is expected (and asynchronous), use the following pattern at the top of the test:
        'expectAsyncConsoleError(<string or regex>[, <number of times the error message repeats>]);'
```
Full log: https://gist.github.com/mdmower/d2252c6dc06d096687c56a6368a30c41