### PR TITLE
xhr: Minor test improvements

### DIFF
--- a/test/unit/test-xhr.js
+++ b/test/unit/test-xhr.js
@@ -933,6 +933,7 @@ describe
       });
 
       it('should be rejected when response undefined', () => {
+        expectAsyncConsoleError(/Object expected/);
         sendMessageStub.returns(Promise.resolve());
         const xhr = xhrServiceForTesting(interceptionEnabledWin);
 
@@ -942,6 +943,7 @@ describe
       });
 
       it('should be rejected when response null', () => {
+        expectAsyncConsoleError(/Object expected/);
         sendMessageStub.returns(Promise.resolve(null));
         const xhr = xhrServiceForTesting(interceptionEnabledWin);
 
@@ -951,6 +953,7 @@ describe
       });
 
       it('should be rejected when response is string', () => {
+        expectAsyncConsoleError(/Object expected/);
         sendMessageStub.returns(Promise.resolve('response text'));
         const xhr = xhrServiceForTesting(interceptionEnabledWin);
 


### PR DESCRIPTION
Resolve sinon warnings:
```
ERROR: 'Object expected:  '
    The test "XHR interceptor should be rejected when response undefined" resulted in a call to console.error. (See above line.)
    ⤷ If the error is not expected, fix the code that generated the error.
    ⤷ If the error is expected (and synchronous), use the following pattern to wrap the test code that generated the error:
        'allowConsoleError(() => { <code that generated the error> });'
    ⤷ If the error is expected (and asynchronous), use the following pattern at the top of the test:
        'expectAsyncConsoleError(<string or regex>[, <number of times the error message repeats>]);'
ERROR: 'Object expected:  '
    The test "XHR interceptor should be rejected when response null" resulted in a call to console.error. (See above line.)
    ⤷ If the error is not expected, fix the code that generated the error.
    ⤷ If the error is expected (and synchronous), use the following pattern to wrap the test code that generated the error:
        'allowConsoleError(() => { <code that generated the error> });'
    ⤷ If the error is expected (and asynchronous), use the following pattern at the top of the test:
        'expectAsyncConsoleError(<string or regex>[, <number of times the error message repeats>]);'
ERROR: 'Object expected:  response text'
    The test "XHR interceptor should be rejected when response is string" resulted in a call to console.error. (See above line.)
    ⤷ If the error is not expected, fix the code that generated the error.
    ⤷ If the error is expected (and synchronous), use the following pattern to wrap the test code that generated the error:
        'allowConsoleError(() => { <code that generated the error> });'
    ⤷ If the error is expected (and asynchronous), use the following pattern at the top of the test:
        'expectAsyncConsoleError(<string or regex>[, <number of times the error message repeats>]);'
```
Full log: https://gist.github.com/mdmower/d2252c6dc06d096687c56a6368a30c41