### PR TITLE
🐛 Check for null on bad video message JSON parses

### DIFF
--- a/extensions/amp-3q-player/0.1/amp-3q-player.js
+++ b/extensions/amp-3q-player/0.1/amp-3q-player.js
@@ -154,8 +154,8 @@ class Amp3QPlayer extends AMP.BaseElement {
     }
 
     const data = objOrParseJson(getData(event));
-    if (data === undefined) {
-      return;
+    if (data == null) {
+      return; // we only process valid json
     }
 
     const eventType = data['data'];

--- a/extensions/amp-3q-player/0.1/test/test-amp-3q-player.js
+++ b/extensions/amp-3q-player/0.1/test/test-amp-3q-player.js
@@ -17,6 +17,7 @@
 import '../amp-3q-player';
 import {Services} from '../../../../src/services';
 import {VideoEvents} from '../../../../src/video-interface';
+import {createElementWithAttributes} from '../../../../src/dom';
 import {listenOncePromise} from '../../../../src/event-helper';
 
 describes.realWin(
@@ -38,7 +39,10 @@ describes.realWin(
     });
 
     async function get3QElement(playoutId) {
-      const player = doc.createElement('amp-3q-player');
+      const player = createElementWithAttributes(doc, 'amp-3q-player', {
+        width: 300,
+        height: 200,
+      });
       if (playoutId) {
         player.setAttribute('data-id', playoutId);
       }

--- a/extensions/amp-brightcove/0.1/amp-brightcove.js
+++ b/extensions/amp-brightcove/0.1/amp-brightcove.js
@@ -185,7 +185,7 @@ class AmpBrightcove extends AMP.BaseElement {
     }
 
     const data = objOrParseJson(eventData);
-    if (data === undefined) {
+    if (data == null) {
       return; // We only process valid JSON.
     }
 

--- a/extensions/amp-delight-player/0.1/amp-delight-player.js
+++ b/extensions/amp-delight-player/0.1/amp-delight-player.js
@@ -245,7 +245,7 @@ class AmpDelightPlayer extends AMP.BaseElement {
     }
 
     const data = objOrParseJson(getData(event));
-    if (data === undefined || data['type'] === undefined) {
+    if (data == null || !data['type']) {
       return; // We only process valid JSON.
     }
 

--- a/extensions/amp-minute-media-player/0.1/amp-minute-media-player.js
+++ b/extensions/amp-minute-media-player/0.1/amp-minute-media-player.js
@@ -172,7 +172,7 @@ class AmpMinuteMediaPlayer extends AMP.BaseElement {
       return;
     }
     const data = objOrParseJson(eventData);
-    if (data === undefined) {
+    if (data == null) {
       return; // We only process valid JSON.
     }
 

--- a/extensions/amp-nexxtv-player/0.1/amp-nexxtv-player.js
+++ b/extensions/amp-nexxtv-player/0.1/amp-nexxtv-player.js
@@ -217,7 +217,7 @@ class AmpNexxtvPlayer extends AMP.BaseElement {
     }
 
     const data = objOrParseJson(eventData);
-    if (!data) {
+    if (data == null) {
       return;
     }
 

--- a/extensions/amp-powr-player/0.1/amp-powr-player.js
+++ b/extensions/amp-powr-player/0.1/amp-powr-player.js
@@ -168,7 +168,7 @@ class AmpPowrPlayer extends AMP.BaseElement {
     }
 
     const data = objOrParseJson(eventData);
-    if (data === undefined) {
+    if (data == null) {
       return; // We only process valid JSON.
     }
 

--- a/extensions/amp-redbull-player/0.1/amp-redbull-player.js
+++ b/extensions/amp-redbull-player/0.1/amp-redbull-player.js
@@ -184,6 +184,10 @@ class AmpRedBullPlayer extends AMP.BaseElement {
 
     const data = objOrParseJson(eventData);
 
+    if (data == null) {
+      return; // we only process valid json
+    }
+
     if (data['id'] === `redbull-amp-video-tracking-${this.tagId_}`) {
       const type = ANALYTICS_EVENT_TYPE_PREFIX + data['type'];
       this.dispatchCustomAnalyticsEvent_(type, data);

--- a/extensions/amp-video-iframe/0.1/amp-video-iframe.js
+++ b/extensions/amp-video-iframe/0.1/amp-video-iframe.js
@@ -298,6 +298,10 @@ class AmpVideoIframe extends AMP.BaseElement {
 
     const data = objOrParseJson(eventData);
 
+    if (data == null) {
+      return; // we only process valid json
+    }
+
     const messageId = data['id'];
     const methodReceived = data['method'];
 

--- a/extensions/amp-vimeo/0.1/amp-vimeo.js
+++ b/extensions/amp-vimeo/0.1/amp-vimeo.js
@@ -222,6 +222,10 @@ class AmpVimeo extends AMP.BaseElement {
 
     const data = objOrParseJson(eventData);
 
+    if (data == null) {
+      return; // we only process valid json
+    }
+
     if (data['event'] == 'ready' || data['method'] == 'ping') {
       this.onReadyOnce_();
       return;

--- a/extensions/amp-wistia-player/0.1/amp-wistia-player.js
+++ b/extensions/amp-wistia-player/0.1/amp-wistia-player.js
@@ -170,7 +170,7 @@ class AmpWistiaPlayer extends AMP.BaseElement {
     }
 
     const data = objOrParseJson(eventData);
-    if (data === undefined) {
+    if (data == null) {
       return; // We only process valid JSON.
     }
 


### PR DESCRIPTION
`tryParseJson` was [modified to return `null`](https://github.com/ampproject/amphtml/blame/master/src/json.js#L131), this updates checks for all video players.

Fixes #26895