### PR TITLE
✨ SwG - Add sendBeacon method to AmpFetcher

### DIFF
--- a/extensions/amp-subscriptions-google/0.1/amp-subscriptions-google.js
+++ b/extensions/amp-subscriptions-google/0.1/amp-subscriptions-google.js
@@ -683,7 +683,7 @@ export function getFetcherClassForTesting() {
 }
 
 /**
- * TODO(dvoytenko): remove once compiler type checking is fixed for third_party.
+ * TODO(mborof): remove once not required by test-amp-subscriptions-google.js
  * @package
  * @visibleForTesting
  * @return {*}

--- a/extensions/amp-subscriptions-google/0.1/amp-subscriptions-google.js
+++ b/extensions/amp-subscriptions-google/0.1/amp-subscriptions-google.js
@@ -617,9 +617,9 @@ class AmpFetcher {
   }
 
   /**
-   *
+   * POST data to a URL endpoint, do not wait for a response.
    * @param {string} url
-   * @param {*} data
+   * @param {string|!Object} data
    */
   sendBeacon(url, data) {
     const contentType = 'application/x-www-form-urlencoded;charset=UTF-8';
@@ -680,6 +680,16 @@ AMP.extension(TAG, '0.1', function(AMP) {
  */
 export function getFetcherClassForTesting() {
   return Fetcher;
+}
+
+/**
+ * TODO(dvoytenko): remove once compiler type checking is fixed for third_party.
+ * @package
+ * @visibleForTesting
+ * @return {*}
+ */
+export function getAmpFetcherClassForTesting() {
+  return AmpFetcher;
 }
 
 /**

--- a/extensions/amp-subscriptions-google/0.1/test/test-amp-subscriptions-google.js
+++ b/extensions/amp-subscriptions-google/0.1/test/test-amp-subscriptions-google.js
@@ -20,11 +20,6 @@ import {
   SubscriptionAnalytics,
 } from '../../../amp-subscriptions/0.1/analytics';
 import {
-  AmpFetcher,
-  GoogleSubscriptionsPlatform,
-} from '../amp-subscriptions-google';
-import {
-  AnalyticsContext,
   ConfiguredRuntime,
   Entitlements,
   SubscribeResponse,
@@ -34,6 +29,10 @@ import {
   Entitlement,
   GrantReason,
 } from '../../../amp-subscriptions/0.1/entitlement';
+import {
+  GoogleSubscriptionsPlatform,
+  getAmpFetcherClassForTesting,
+} from '../amp-subscriptions-google';
 import {PageConfig} from '../../../../third_party/subscriptions-project/config';
 import {ServiceAdapter} from '../../../amp-subscriptions/0.1/service-adapter';
 import {Services} from '../../../../src/services';
@@ -44,14 +43,17 @@ const PLATFORM_ID = 'subscribe.google.com';
 const AMP_URL = 'myAMPurl.amp';
 
 describes.realWin('AmpFetcher', {amp: true}, env => {
+  // Please note that AmpFetcher is only called by swg-js.
+  // Also note that sendBeach accepts a message object which is private to
+  // swg-js.
+
   let win;
   let ampdoc;
   let fetcher;
   let xhr;
 
   const sentUrl = 'url';
-  const sentContent = new AnalyticsContext([
-    'AnalyticsContext',
+  const sentArray = [
     'embed',
     'tx',
     'refer',
@@ -63,10 +65,15 @@ describes.realWin('AmpFetcher', {amp: true}, env => {
     ['exp1', 'exp2'],
     'version',
     'baseUrl',
-  ]);
+  ];
+  const sentMessage = {
+    toArray: function() {
+      return sentArray;
+    },
+  };
   const contentType = 'application/x-www-form-urlencoded;charset=UTF-8';
-  const expectedBodyString =
-    'f.req=' + JSON.stringify(sentContent.toArray(false));
+  const expectedBodyString = 'f.req=' + JSON.stringify(sentArray);
+  const AmpFetcher = getAmpFetcherClassForTesting();
 
   beforeEach(() => {
     win = env.win;
@@ -81,7 +88,7 @@ describes.realWin('AmpFetcher', {amp: true}, env => {
       expect(url).to.equal(sentUrl);
       expect(body).to.deep.equal(expectedBlob);
     });
-    fetcher.sendBeacon(sentUrl, sentContent);
+    fetcher.sendBeacon(sentUrl, sentMessage);
   });
 
   it('should support beacon when beacon not supported', async () => {
@@ -96,7 +103,7 @@ describes.realWin('AmpFetcher', {amp: true}, env => {
       });
     });
 
-    fetcher.sendBeacon(sentUrl, sentContent);
+    fetcher.sendBeacon(sentUrl, sentMessage);
   });
 });
 

--- a/extensions/amp-subscriptions-google/0.1/test/test-amp-subscriptions-google.js
+++ b/extensions/amp-subscriptions-google/0.1/test/test-amp-subscriptions-google.js
@@ -43,10 +43,6 @@ const PLATFORM_ID = 'subscribe.google.com';
 const AMP_URL = 'myAMPurl.amp';
 
 describes.realWin('AmpFetcher', {amp: true}, env => {
-  // Please note that AmpFetcher is only called by swg-js.
-  // Also note that sendBeach accepts a message object which is private to
-  // swg-js.
-
   let win;
   let ampdoc;
   let fetcher;

--- a/extensions/amp-subscriptions-google/0.1/test/test-amp-subscriptions-google.js
+++ b/extensions/amp-subscriptions-google/0.1/test/test-amp-subscriptions-google.js
@@ -20,6 +20,11 @@ import {
   SubscriptionAnalytics,
 } from '../../../amp-subscriptions/0.1/analytics';
 import {
+  AmpFetcher,
+  GoogleSubscriptionsPlatform,
+} from '../amp-subscriptions-google';
+import {
+  AnalyticsContext,
   ConfiguredRuntime,
   Entitlements,
   SubscribeResponse,
@@ -29,7 +34,6 @@ import {
   Entitlement,
   GrantReason,
 } from '../../../amp-subscriptions/0.1/entitlement';
-import {GoogleSubscriptionsPlatform} from '../amp-subscriptions-google';
 import {PageConfig} from '../../../../third_party/subscriptions-project/config';
 import {ServiceAdapter} from '../../../amp-subscriptions/0.1/service-adapter';
 import {Services} from '../../../../src/services';
@@ -38,6 +42,63 @@ import {toggleExperiment} from '../../../../src/experiments';
 
 const PLATFORM_ID = 'subscribe.google.com';
 const AMP_URL = 'myAMPurl.amp';
+
+describes.realWin('AmpFetcher', {amp: true}, env => {
+  let win;
+  let ampdoc;
+  let fetcher;
+  let xhr;
+
+  const sentUrl = 'url';
+  const sentContent = new AnalyticsContext([
+    'AnalyticsContext',
+    'embed',
+    'tx',
+    'refer',
+    'utmS',
+    'utmC',
+    'utmM',
+    'sku',
+    true,
+    ['exp1', 'exp2'],
+    'version',
+    'baseUrl',
+  ]);
+  const contentType = 'application/x-www-form-urlencoded;charset=UTF-8';
+  const expectedBodyString =
+    'f.req=' + JSON.stringify(sentContent.toArray(false));
+
+  beforeEach(() => {
+    win = env.win;
+    ampdoc = env.ampdoc;
+    fetcher = new AmpFetcher(ampdoc.win);
+    xhr = Services.xhrFor(env.win);
+  });
+
+  it('should support beacon when beacon supported', async () => {
+    const expectedBlob = new Blob([expectedBodyString], {type: contentType});
+    env.sandbox.stub(win.navigator, 'sendBeacon').callsFake((url, body) => {
+      expect(url).to.equal(sentUrl);
+      expect(body).to.deep.equal(expectedBlob);
+    });
+    fetcher.sendBeacon(sentUrl, sentContent);
+  });
+
+  it('should support beacon when beacon not supported', async () => {
+    win.navigator.sendBeacon = null;
+    env.sandbox.stub(xhr, 'fetch').callsFake((url, init) => {
+      expect(url).to.equal(sentUrl);
+      expect(init).to.deep.equal({
+        method: 'POST',
+        headers: {'Content-Type': contentType},
+        credentials: 'include',
+        body: expectedBodyString,
+      });
+    });
+
+    fetcher.sendBeacon(sentUrl, sentContent);
+  });
+});
 
 describes.realWin('amp-subscriptions-google', {amp: true}, env => {
   let ampdoc;

--- a/extensions/amp-subscriptions-google/0.1/test/test-amp-subscriptions-google.js
+++ b/extensions/amp-subscriptions-google/0.1/test/test-amp-subscriptions-google.js
@@ -88,6 +88,7 @@ describes.realWin('AmpFetcher', {amp: true}, env => {
   });
 
   it('should support beacon when beacon not supported', async () => {
+    const tempFun = win.navigator.sendBeacon;
     win.navigator.sendBeacon = null;
     env.sandbox.stub(xhr, 'fetch').callsFake((url, init) => {
       expect(url).to.equal(sentUrl);
@@ -100,6 +101,9 @@ describes.realWin('AmpFetcher', {amp: true}, env => {
     });
 
     fetcher.sendBeacon(sentUrl, sentMessage);
+
+    // Restore the original function so we don't break Xhr tests throughout AMP.
+    win.navigator.sendBeacon = tempFun;
   });
 });
 


### PR DESCRIPTION
Adds the sendBeacon method to AmpFetcher.  

This method is currently being used by an experiment (internal only).  The signature is required for the next SwG release.  There may be future adjustments to this code.