### PR TITLE
Reduce sauce labs batch size

### DIFF
--- a/build-system/tasks/runtime-test/helpers.js
+++ b/build-system/tasks/runtime-test/helpers.js
@@ -29,7 +29,7 @@ const {green, yellow, cyan, red} = require('ansi-colors');
 const {isTravisBuild} = require('../../common/travis');
 const {Server} = require('karma');
 
-const BATCHSIZE = 4; // Number of Sauce Lab browsers
+const BATCHSIZE = 3; // Number of Sauce Lab browsers
 const CHROMEBASE = argv.chrome_canary ? 'ChromeCanary' : 'Chrome';
 const chromeFlags = [];
 


### PR DESCRIPTION
Now that Sauce Labs is no longer timing out, it's hitting concurrency limits because jobs are surviving long enough to start overlapping. We currently run 4 browsers at a time on Sauce from Travis. This PR reduces that to 3 as a stopgap to reduce concurrency limit errors and to observe impact on Travis build time.