### PR TITLE
Revert "🏗 Increase karma browser activity timeout to 5min"

### DIFF
--- a/build-system/tasks/karma.conf.js
+++ b/build-system/tasks/karma.conf.js
@@ -281,10 +281,9 @@ module.exports = {
   // on Travis before stalling out after 10 minutes.
   browserDisconnectTimeout: 2 * 60 * 1000,
 
-  // If there's no message from the browser, make Karma wait 5 minutes
-  // until it disconnects. This number will need to gradually grow as the
-  // duration of a full integration test run increases.
-  browserNoActivityTimeout: 5 * 60 * 1000,
+  // If there's no message from the browser, make Karma wait 2 minutes
+  // until it disconnects.
+  browserNoActivityTimeout: 2 * 60 * 1000,
 
   // IF YOU CHANGE THIS, DEBUGGING WILL RANDOMLY KILL THE BROWSER
   browserDisconnectTolerance: isTravisBuild() ? 2 : 0,


### PR DESCRIPTION
Reverts ampproject/amphtml#26887

There's a bigger bug to be fixed; beta browser runs are not being batched. Rolling back until the underlying bug is found