### PR TITLE
Validator rollup

### DIFF
--- a/extensions/amp-minute-media-player/0.1/test/validator-amp-minute-media-player.html
+++ b/extensions/amp-minute-media-player/0.1/test/validator-amp-minute-media-player.html
@@ -30,7 +30,7 @@
   <script async src="https://cdn.ampproject.org/v0.js"></script>
 </head>
 <body>
-<!-- Valid tag with 'curated' data-content-type -->
+  <!-- Valid: tag with 'curated' data-content-type -->
   <amp-minute-media-player
     autoplay
     data-content-type="curated"
@@ -39,7 +39,7 @@
     width="160" height="96">
   </amp-minute-media-player>
 
-<!-- Valid tag with 'semantic' data-content-type -->
+  <!-- Valid: tag with 'semantic' data-content-type -->
   <amp-minute-media-player
     data-content-type="semantic"
     data-minimum-date-factor="10"
@@ -48,19 +48,19 @@
     layout="responsive" width="160" height="96">
   </amp-minute-media-player>
 
-<!-- Valid tag with 'semantic' data-content-type (no attributes) -->
+  <!-- Valid: tag with 'semantic' data-content-type (no attributes) -->
   <amp-minute-media-player
     data-content-type="semantic"
     layout="responsive" width="160" height="96">
   </amp-minute-media-player>
 
-<!-- Invalid tag: data-content-type is mandatory! -->
+  <!-- Invalid: data-content-type is mandatory! -->
   <amp-minute-media-player
     data-content-id="fSkmeWKF"
     layout="responsive" width="160" height="96">
   </amp-minute-media-player>
 
-<!-- Invalid tag: data-content-type value must be one of the following: 'semantic', 'curated' or 'specific'  -->
+  <!-- Invalid: data-content-type value must be one of the following: 'semantic', 'curated' or 'specific'  -->
   <amp-minute-media-player
     data-content-type="none"
     data-content-id="fSkmeWKF"
@@ -68,7 +68,7 @@
     width="160" height="96">
   </amp-minute-media-player>
 
-<!-- Invalid tag: 'dock' attribute without `amp-video-docking` extension -->
+  <!-- Invalid: 'dock' attribute without `amp-video-docking` extension -->
   <amp-minute-media-player
     dock
     data-content-type="semantic"
@@ -76,6 +76,5 @@
     data-scoped-keywords="football"
     layout="responsive" width="160" height="96">
   </amp-minute-media-player>
-
 </body>
 </html>

--- a/extensions/amp-minute-media-player/0.1/test/validator-amp-minute-media-player.out
+++ b/extensions/amp-minute-media-player/0.1/test/validator-amp-minute-media-player.out
@@ -31,7 +31,7 @@ FAIL
 |    <script async src="https://cdn.ampproject.org/v0.js"></script>
 |  </head>
 |  <body>
-|  <!-- Valid tag with 'curated' data-content-type -->
+|    <!-- Valid: tag with 'curated' data-content-type -->
 |    <amp-minute-media-player
 |      autoplay
 |      data-content-type="curated"
@@ -40,7 +40,7 @@ FAIL
 |      width="160" height="96">
 |    </amp-minute-media-player>
 |
-|  <!-- Valid tag with 'semantic' data-content-type -->
+|    <!-- Valid: tag with 'semantic' data-content-type -->
 |    <amp-minute-media-player
 |      data-content-type="semantic"
 |      data-minimum-date-factor="10"
@@ -49,13 +49,13 @@ FAIL
 |      layout="responsive" width="160" height="96">
 |    </amp-minute-media-player>
 |
-|  <!-- Valid tag with 'semantic' data-content-type (no attributes) -->
+|    <!-- Valid: tag with 'semantic' data-content-type (no attributes) -->
 |    <amp-minute-media-player
 |      data-content-type="semantic"
 |      layout="responsive" width="160" height="96">
 |    </amp-minute-media-player>
 |
-|  <!-- Invalid tag: data-content-type is mandatory! -->
+|    <!-- Invalid: data-content-type is mandatory! -->
 |    <amp-minute-media-player
 >>   ^~~~~~~~~
 amp-minute-media-player/0.1/test/validator-amp-minute-media-player.html:58:2 The mandatory attribute 'data-content-type' is missing in tag 'amp-minute-media-player'. (see https://amp.dev/documentation/components/amp-minute-media-player)
@@ -63,7 +63,7 @@ amp-minute-media-player/0.1/test/validator-amp-minute-media-player.html:58:2 The
 |      layout="responsive" width="160" height="96">
 |    </amp-minute-media-player>
 |
-|  <!-- Invalid tag: data-content-type value must be one of the following: 'semantic', 'curated' or 'specific'  -->
+|    <!-- Invalid: data-content-type value must be one of the following: 'semantic', 'curated' or 'specific'  -->
 |    <amp-minute-media-player
 >>   ^~~~~~~~~
 amp-minute-media-player/0.1/test/validator-amp-minute-media-player.html:64:2 The attribute 'data-content-type' in tag 'amp-minute-media-player' is set to the invalid value 'none'. (see https://amp.dev/documentation/components/amp-minute-media-player)
@@ -73,7 +73,7 @@ amp-minute-media-player/0.1/test/validator-amp-minute-media-player.html:64:2 The
 |      width="160" height="96">
 |    </amp-minute-media-player>
 |
-|  <!-- Invalid tag: 'dock' attribute without `amp-video-docking` extension -->
+|    <!-- Invalid: 'dock' attribute without `amp-video-docking` extension -->
 |    <amp-minute-media-player
 >>   ^~~~~~~~~
 amp-minute-media-player/0.1/test/validator-amp-minute-media-player.html:72:2 The attribute 'dock' requires including the 'amp-video-docking' extension JavaScript.
@@ -83,6 +83,5 @@ amp-minute-media-player/0.1/test/validator-amp-minute-media-player.html:72:2 The
 |      data-scoped-keywords="football"
 |      layout="responsive" width="160" height="96">
 |    </amp-minute-media-player>
-|
 |  </body>
 |  </html>

--- a/extensions/amp-minute-media-player/validator-amp-minute-media-player.protoascii
+++ b/extensions/amp-minute-media-player/validator-amp-minute-media-player.protoascii
@@ -29,18 +29,15 @@ tags: {  # <amp-minute-media-player>
   tag_name: "AMP-MINUTE-MEDIA-PLAYER"
   requires_extension: "amp-minute-media-player"
   attrs: { name: "autoplay" }
-  attrs: {
-    name: "dock"
-    requires_extension: "amp-video-docking"
-  }
+  attrs: { name: "data-content-id" }
   attrs: {
     name: "data-content-type"
     mandatory: true
     value: "curated"
-    value: "specific"
     value: "semantic"
+    value: "specific"
   }
-  attrs: { name: "data-content-id" }
+  attrs: { name: "data-minimum-date-factor" }
   attrs: { name: "data-scanned-element" }
   attrs: {
     name: "data-scanned-element-type"
@@ -48,17 +45,19 @@ tags: {  # <amp-minute-media-player>
     value: "id"
     value: "tag"
   }
-  attrs: { name: "data-tags" }
-  attrs: { name: "data-minimum-date-factor" }
   attrs: { name: "data-scoped-keywords" }
-
+  attrs: { name: "data-tags" }
+  attrs: {
+    name: "dock"
+    requires_extension: "amp-video-docking"
+  }
   attr_lists: "extended-amp-global"
   spec_url: "https://amp.dev/documentation/components/amp-minute-media-player"
   amp_layout: {
-    supported_layouts: RESPONSIVE
     supported_layouts: FILL
     supported_layouts: FIXED
     supported_layouts: FIXED_HEIGHT
     supported_layouts: FLEX_ITEM
+    supported_layouts: RESPONSIVE
   }
 }

--- a/validator/testdata/feature_tests/json-parsing.html
+++ b/validator/testdata/feature_tests/json-parsing.html
@@ -1,0 +1,38 @@
+<!--
+  Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS-IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the license.
+-->
+<!--
+  Test Description:
+  Test JSON parsing.
+-->
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <link rel="canonical" href="./regular-html-version.html">
+  <meta name="viewport" content="width=device-width">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async custom-element="amp-bind" src="https://cdn.ampproject.org/v0/amp-bind-0.1.js"></script>
+</head>
+<body>
+
+<!-- The JSON string contains a carriage return `\r` between `:` and `false` -->
+<amp-state id="td_amp_menu_state"><script type="application/json">
+{"visible":
+false}</script></amp-state>
+
+</body>
+</html>

--- a/validator/testdata/feature_tests/json-parsing.out
+++ b/validator/testdata/feature_tests/json-parsing.out
@@ -1,0 +1,39 @@
+PASS
+|  <!--
+|    Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+|
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|
+|        http://www.apache.org/licenses/LICENSE-2.0
+|
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Test JSON parsing.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    <script async custom-element="amp-bind" src="https://cdn.ampproject.org/v0/amp-bind-0.1.js"></script>
+|  </head>
+|  <body>
+|
+|  <!-- The JSON string contains a carriage return `\r` between `:` and `false` -->
+|  <amp-state id="td_amp_menu_state"><script type="application/json">
+|  {"visible":
+false}</script></amp-state>
+|
+|  </body>
+|  </html>

--- a/validator/testdata/feature_tests/json-parsing.out
+++ b/validator/testdata/feature_tests/json-parsing.out
@@ -33,7 +33,7 @@ PASS
 |  <!-- The JSON string contains a carriage return `\r` between `:` and `false` -->
 |  <amp-state id="td_amp_menu_state"><script type="application/json">
 |  {"visible":
-false}</script></amp-state>
+|  false}</script></amp-state>
 |
 |  </body>
 |  </html>

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -26,7 +26,7 @@ min_validator_revision_required: 375
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 1008
+spec_file_revision: 1009
 
 styles_spec_url: "https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages"
 script_spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags"

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -26,7 +26,7 @@ min_validator_revision_required: 375
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 1007
+spec_file_revision: 1008
 
 styles_spec_url: "https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages"
 script_spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags"
@@ -4422,7 +4422,10 @@ attr_lists: {
   attrs: { name: "accept" }
   attrs: { name: "accesskey" }
   attrs: { name: "autocomplete" }
-  attrs: { name: "autofocus" }
+  attrs: {
+    disabled_by: "amp4email"
+    name: "autofocus"
+  }
   attrs: { name: "checked" }
   attrs: { name: "disabled" }
   attrs: { name: "height" }

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -26,7 +26,7 @@ min_validator_revision_required: 375
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 1006
+spec_file_revision: 1007
 
 styles_spec_url: "https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages"
 script_spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags"


### PR DESCRIPTION
- cl/296998166 Revision bump for #26949
 - cl/296900817 Update test output.
 - cl/296492305 github commit msg missing or malformed
 - cl/296283601 Ban `autofocus` on <input> for email spec
 - cl/295821861 Changes to amp-minute-media-player tests.
