### PR TITLE
🐛 SwG now uses AMP sendBeacon interface

### DIFF
--- a/extensions/amp-subscriptions-google/0.1/amp-subscriptions-google.js
+++ b/extensions/amp-subscriptions-google/0.1/amp-subscriptions-google.js
@@ -36,6 +36,7 @@ import {
 import {PageConfig} from '../../../third_party/subscriptions-project/config';
 import {Services} from '../../../src/services';
 import {SubscriptionsScoreFactor} from '../../amp-subscriptions/0.1/score-factors.js';
+import {WindowInterface} from '../../../src/window-interface';
 import {experimentToggles, isExperimentOn} from '../../../src/experiments';
 import {getData} from '../../../src/event-helper';
 import {installStylesForDoc} from '../../../src/style-installer';
@@ -626,11 +627,11 @@ class AmpFetcher {
     const body =
       'f.req=' +
       JSON.stringify(/** @type {JsonObject} */ (data.toArray(false)));
-    const {navigator} = this.win_;
+    const sendBeacon = WindowInterface.getSendBeacon(this.win_);
 
-    if (navigator.sendBeacon) {
+    if (sendBeacon) {
       const blob = new Blob([body], {type: contentType});
-      navigator.sendBeacon(url, blob);
+      sendBeacon(url, blob);
       return;
     }
 

--- a/extensions/amp-subscriptions-google/0.1/test/test-amp-subscriptions-google.js
+++ b/extensions/amp-subscriptions-google/0.1/test/test-amp-subscriptions-google.js
@@ -89,7 +89,7 @@ describes.realWin('AmpFetcher', {amp: true}, env => {
   });
 
   it('should support beacon when beacon not supported', async () => {
-    env.sandbox.stub(WindowInterface, 'getSendBeacon', () => null);
+    env.sandbox.stub(WindowInterface, 'getSendBeacon').callsFake(() => null);
     env.sandbox.stub(xhr, 'fetch').callsFake((url, init) => {
       expect(url).to.equal(sentUrl);
       expect(init).to.deep.equal({

--- a/extensions/amp-subscriptions-google/0.1/test/test-amp-subscriptions-google.js
+++ b/extensions/amp-subscriptions-google/0.1/test/test-amp-subscriptions-google.js
@@ -37,6 +37,7 @@ import {PageConfig} from '../../../../third_party/subscriptions-project/config';
 import {ServiceAdapter} from '../../../amp-subscriptions/0.1/service-adapter';
 import {Services} from '../../../../src/services';
 import {SubscriptionsScoreFactor} from '../../../amp-subscriptions/0.1/score-factors';
+import {WindowInterface} from '../../../../src/window-interface';
 import {toggleExperiment} from '../../../../src/experiments';
 
 const PLATFORM_ID = 'subscribe.google.com';
@@ -88,8 +89,7 @@ describes.realWin('AmpFetcher', {amp: true}, env => {
   });
 
   it('should support beacon when beacon not supported', async () => {
-    const tempFun = win.navigator.sendBeacon;
-    win.navigator.sendBeacon = null;
+    env.sandbox.stub(WindowInterface, 'getSendBeacon', () => null);
     env.sandbox.stub(xhr, 'fetch').callsFake((url, init) => {
       expect(url).to.equal(sentUrl);
       expect(init).to.deep.equal({
@@ -101,9 +101,6 @@ describes.realWin('AmpFetcher', {amp: true}, env => {
     });
 
     fetcher.sendBeacon(sentUrl, sentMessage);
-
-    // Restore the original function so we don't break Xhr tests throughout AMP.
-    win.navigator.sendBeacon = tempFun;
   });
 });
 

--- a/extensions/amp-subscriptions-google/0.1/test/test-amp-subscriptions-google.js
+++ b/extensions/amp-subscriptions-google/0.1/test/test-amp-subscriptions-google.js
@@ -44,8 +44,6 @@ const PLATFORM_ID = 'subscribe.google.com';
 const AMP_URL = 'myAMPurl.amp';
 
 describes.realWin('AmpFetcher', {amp: true}, env => {
-  let win;
-  let ampdoc;
   let fetcher;
   let xhr;
 
@@ -73,17 +71,18 @@ describes.realWin('AmpFetcher', {amp: true}, env => {
   const AmpFetcher = getAmpFetcherClassForTesting();
 
   beforeEach(() => {
-    win = env.win;
-    ampdoc = env.ampdoc;
-    fetcher = new AmpFetcher(ampdoc.win);
-    xhr = Services.xhrFor(env.win);
+    const {win} = env.ampdoc;
+    fetcher = new AmpFetcher(win);
+    xhr = Services.xhrFor(win);
   });
 
   it('should support beacon when beacon supported', async () => {
     const expectedBlob = new Blob([expectedBodyString], {type: contentType});
-    env.sandbox.stub(win.navigator, 'sendBeacon').callsFake((url, body) => {
-      expect(url).to.equal(sentUrl);
-      expect(body).to.deep.equal(expectedBlob);
+    env.sandbox.stub(WindowInterface, 'getSendBeacon').callsFake(() => {
+      return (url, body) => {
+        expect(url).to.equal(sentUrl);
+        expect(body).to.deep.equal(expectedBlob);
+      };
     });
     fetcher.sendBeacon(sentUrl, sentMessage);
   });


### PR DESCRIPTION
Redirects the new SwG "sendBeacon" command through AMP's native interface.