### PR TITLE
Create amp-list 0.2

### DIFF
--- a/build-system/compile/bundles.config.js
+++ b/build-system/compile/bundles.config.js
@@ -705,6 +705,13 @@ exports.extensionBundles = [
     type: TYPES.MISC,
   },
   {
+    name: 'amp-list',
+    version: '0.2',
+    latestVersion: '0.1',
+    options: {hasCss: true},
+    type: TYPES.MISC,
+  },
+  {
     name: 'amp-live-list',
     version: '0.1',
     latestVersion: '0.1',

--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -315,8 +315,6 @@ const forbiddenTerms = {
     whitelist: [
       // Please keep list alphabetically sorted.
       'extensions/amp-fx-collection/0.1/providers/fx-provider.js',
-      'extensions/amp-list/0.1/amp-list.js',
-      'extensions/amp-list/0.2/amp-list.js',
       'extensions/amp-next-page/0.1/next-page-service.js',
       'extensions/amp-next-page/1.0/visibility-observer.js',
       'extensions/amp-position-observer/0.1/amp-position-observer.js',

--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -316,6 +316,7 @@ const forbiddenTerms = {
       // Please keep list alphabetically sorted.
       'extensions/amp-fx-collection/0.1/providers/fx-provider.js',
       'extensions/amp-list/0.1/amp-list.js',
+      'extensions/amp-list/0.2/amp-list.js',
       'extensions/amp-next-page/0.1/next-page-service.js',
       'extensions/amp-next-page/1.0/visibility-observer.js',
       'extensions/amp-position-observer/0.1/amp-position-observer.js',
@@ -798,6 +799,7 @@ const forbiddenTerms = {
       'extensions/amp-fx-collection/0.1/test/integration/test-amp-fx-fly-in.js',
       'extensions/amp-lightbox-gallery/0.1/test/integration/test-amp-lightbox-gallery.js',
       'extensions/amp-list/0.1/test/integration/test-amp-list.js',
+      'extensions/amp-list/0.2/test/integration/test-amp-list.js',
       'extensions/amp-live-list/0.1/test/test-poller.js',
       'extensions/amp-next-page/0.1/test/test-config.js',
       'extensions/amp-script/0.1/test/unit/test-amp-script.js',

--- a/build-system/test-configs/dep-check-config.js
+++ b/build-system/test-configs/dep-check-config.js
@@ -356,7 +356,11 @@ exports.rules = [
         'src/service/position-observer/position-observer-worker.js',
       'extensions/amp-list/0.1/amp-list.js->' +
         'src/service/position-observer/position-observer-impl.js',
+      'extensions/amp-list/0.2/amp-list.js->' +
+        'src/service/position-observer/position-observer-impl.js',
       'extensions/amp-list/0.1/amp-list.js->' +
+        'src/service/position-observer/position-observer-worker.js',
+      'extensions/amp-list/0.2/amp-list.js->' +
         'src/service/position-observer/position-observer-worker.js',
       'extensions/amp-video-docking/0.1/amp-video-docking.js->' +
         'src/service/position-observer/position-observer-impl.js',
@@ -400,13 +404,14 @@ exports.rules = [
         'src/service/navigation.js',
       'extensions/amp-skimlinks/0.1/link-rewriter/link-rewriter-manager.js->' +
         'src/service/navigation.js',
-      'extensions/amp-list/0.1/amp-list.js->src/service/xhr-impl.js',
       'extensions/amp-form/0.1/amp-form.js->src/service/xhr-impl.js',
       // Accessing extension-location.calculateExtensionScriptUrl().
       'extensions/amp-script/0.1/amp-script.js->' +
         'src/service/extension-location.js',
       // Origin experiments.
       'extensions/amp-list/0.1/amp-list.js->' +
+        'src/service/origin-experiments-impl.js',
+      'extensions/amp-list/0.2/amp-list.js->' +
         'src/service/origin-experiments-impl.js',
       'extensions/amp-recaptcha-input/0.1/amp-recaptcha-input.js->' +
         'src/service/origin-experiments-impl.js',

--- a/build-system/test-configs/dep-check-config.js
+++ b/build-system/test-configs/dep-check-config.js
@@ -354,14 +354,6 @@ exports.rules = [
         'src/service/position-observer/position-observer-impl.js',
       'extensions/amp-fx-collection/0.1/providers/fx-provider.js->' +
         'src/service/position-observer/position-observer-worker.js',
-      'extensions/amp-list/0.1/amp-list.js->' +
-        'src/service/position-observer/position-observer-impl.js',
-      'extensions/amp-list/0.2/amp-list.js->' +
-        'src/service/position-observer/position-observer-impl.js',
-      'extensions/amp-list/0.1/amp-list.js->' +
-        'src/service/position-observer/position-observer-worker.js',
-      'extensions/amp-list/0.2/amp-list.js->' +
-        'src/service/position-observer/position-observer-worker.js',
       'extensions/amp-video-docking/0.1/amp-video-docking.js->' +
         'src/service/position-observer/position-observer-impl.js',
       'extensions/amp-video-docking/0.1/amp-video-docking.js->' +
@@ -409,10 +401,6 @@ exports.rules = [
       'extensions/amp-script/0.1/amp-script.js->' +
         'src/service/extension-location.js',
       // Origin experiments.
-      'extensions/amp-list/0.1/amp-list.js->' +
-        'src/service/origin-experiments-impl.js',
-      'extensions/amp-list/0.2/amp-list.js->' +
-        'src/service/origin-experiments-impl.js',
       'extensions/amp-recaptcha-input/0.1/amp-recaptcha-input.js->' +
         'src/service/origin-experiments-impl.js',
       'extensions/amp-experiment/1.0/amp-experiment.js->' +

--- a/extensions/amp-list/0.2/amp-list.css
+++ b/extensions/amp-list/0.2/amp-list.css
@@ -1,0 +1,119 @@
+/**
+ * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Show the error messaging container on fetch error.
+ */
+amp-list.i-amphtml-list-fetch-error [fetch-error] {
+  display: block;
+}
+
+amp-list[load-more] [load-more-loading].amp-visible,
+amp-list[load-more] [load-more-failed].amp-visible,
+amp-list[load-more] [load-more-button].amp-visible,
+amp-list[load-more] [load-more-end].amp-visible {
+  display: block;
+}
+
+amp-list[load-more] [load-more-loading].i-amphtml-default-ui,
+amp-list[load-more] [load-more-failed].i-amphtml-default-ui,
+amp-list[load-more] [load-more-button].i-amphtml-default-ui {
+  height: 80px;
+  padding: 12px 0px;
+  box-sizing: border-box;
+}
+
+/* TODO (#19798): Standardize the system font string we use across the code base,
+         possibly by factoring it out into its own class. */
+amp-list[load-more] [load-more-loading].i-amphtml-default-ui,
+amp-list[load-more] [load-more-failed].i-amphtml-default-ui,
+amp-list[load-more] [load-more-button].i-amphtml-default-ui,
+.i-amphtml-list-load-more-button {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+  font-weight: bold;
+  font-size: 14px;
+  text-transform: uppercase;
+  letter-spacing: .1em;
+  color: rgb(51,51,51);
+  text-align: center;
+}
+
+amp-list[load-more] [load-more-loading].i-amphtml-default-ui .i-amphtml-list-load-more-spinner {
+  display: inline-block;
+  width: 40px;
+  height: 40px;
+  margin: 8px 0px;
+
+  background-image: url("data:image/svg+xml;charset=utf-8,<svg viewBox='0 0 40 40' xmlns='http://www.w3.org/2000/svg'><defs><linearGradient id='grad'><stop stop-color='rgb(51,51,51)' stop-opacity='.75'></stop><stop offset='100%' stop-color='rgb(51,51,51)' stop-opacity='0'></stop></linearGradient></defs><path d='M11,4.4 A18,18, 0,1,0, 38,20' fill='none' stroke='url(#grad)' stroke-width='1.725'></path></svg>");
+  animation: 1000ms amp-list-load-more-spinner linear infinite;
+}
+
+@keyframes amp-list-load-more-spinner {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}
+
+.i-amphtml-list-load-more-button {
+  border: none; margin: 0; padding: 0; /* poor man's reset */
+
+  display: inline-block;
+  background-color: rgba(51,51,51,.75);
+  color: white;
+  margin: 4px 0px;
+  padding: 0px 32px;
+  box-sizing: border-box;
+
+  height: 48px;
+  border-radius: 24px;
+}
+
+[load-more] div[role="list"] {
+  overflow-y: hidden;
+}
+
+.i-amphtml-list-load-more-button,
+.i-amphtml-list-load-more-button label,
+.i-amphtml-list-load-more-icon {
+  cursor: pointer;
+}
+
+.i-amphtml-list-load-more-button:hover {
+  background-color: rgba(51,51,51,1);
+}
+
+.i-amphtml-list-load-more-button.i-amphtml-list-load-more-button-small {
+  margin: 0px;
+  padding: 4px 16px;
+  height: 32px;
+}
+
+.i-amphtml-list-load-more-button label {
+  display: inline-block;
+  vertical-align: middle;
+  line-height: 24px;
+}
+
+amp-list[load-more] [load-more-failed].i-amphtml-default-ui .i-amphtml-list-load-more-message {
+  line-height: 24px;
+}
+
+amp-list[load-more] [load-more-failed].i-amphtml-default-ui .i-amphtml-list-load-more-icon {
+  height: 24px;
+  width: 24px;
+  display: inline-block;
+  vertical-align: middle;
+  background-image: url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24'><path fill='#ffffff' d='M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z'/></svg>");
+}

--- a/extensions/amp-list/0.2/amp-list.js
+++ b/extensions/amp-list/0.2/amp-list.js
@@ -1,0 +1,1459 @@
+/**
+ * Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {ActionTrust} from '../../../src/action-constants';
+import {AmpEvents} from '../../../src/amp-events';
+import {CSS} from '../../../build/amp-list-0.1.css';
+import {
+  DIFFABLE_AMP_ELEMENTS,
+  DIFF_IGNORE,
+  DIFF_KEY,
+  markElementForDiffing,
+} from '../../../src/purifier/sanitation';
+import {Deferred} from '../../../src/utils/promise';
+import {
+  Layout,
+  getLayoutClass,
+  isLayoutSizeDefined,
+  parseLayout,
+} from '../../../src/layout';
+import {LoadMoreService} from './service/load-more-service';
+import {Pass} from '../../../src/pass';
+import {Services} from '../../../src/services';
+import {SsrTemplateHelper} from '../../../src/ssr-template-helper';
+import {
+  UrlReplacementPolicy,
+  batchFetchJsonFor,
+  requestForBatchFetch,
+} from '../../../src/batched-json';
+import {
+  childElementByAttr,
+  matches,
+  removeChildren,
+  scopedQuerySelector,
+  scopedQuerySelectorAll,
+  tryFocus,
+} from '../../../src/dom';
+import {createCustomEvent, listen} from '../../../src/event-helper';
+import {dev, devAssert, user, userAssert} from '../../../src/log';
+import {dict} from '../../../src/utils/object';
+import {getMode} from '../../../src/mode';
+import {getSourceOrigin} from '../../../src/url';
+import {getValueForExpr} from '../../../src/json';
+import {
+  getViewerAuthTokenIfAvailable,
+  setupAMPCors,
+  setupInput,
+  setupJsonFetchInit,
+} from '../../../src/utils/xhr-utils';
+import {isArray, toArray} from '../../../src/types';
+import {isExperimentOn} from '../../../src/experiments';
+import {px, setStyles, toggle} from '../../../src/style';
+import {setDOM} from '../../../third_party/set-dom/set-dom';
+import {startsWith} from '../../../src/string';
+
+/** @const {string} */
+const TAG = 'amp-list';
+
+/** @const {string} */
+const TABBABLE_ELEMENTS_QUERY =
+  'button, a[href], input, select, textarea, [tabindex]:not([tabindex="-1"]), audio[controls], video[controls], [contenteditable]:not([contenteditable="false"])';
+
+// Technically the ':' is not considered part of the scheme, but it is useful to include.
+const AMP_STATE_URI_SCHEME = 'amp-state:';
+
+/**
+ * @typedef {{
+ *   data:(?JsonObject|string|undefined|!Array),
+ *   resolver:!Function,
+ *   rejecter:!Function,
+ *   append:boolean,
+ *   payload: (?JsonObject|Array<JsonObject>)
+ * }}
+ */
+export let RenderItems;
+
+/**
+ * The implementation of `amp-list` component. See {@link ../amp-list.md} for
+ * the spec.
+ */
+export class AmpList extends AMP.BaseElement {
+  /** @param {!AmpElement} element */
+  constructor(element) {
+    super(element);
+
+    /** @private {?Element} */
+    this.container_ = null;
+
+    /** @private {?../../../src/service/viewport/viewport-interface.ViewportInterface} */
+    this.viewport_ = null;
+
+    /** @private {boolean} */
+    this.fallbackDisplayed_ = false;
+
+    /**
+     * Maintains invariant that only one fetch result may be processed for
+     * render at a time.
+     * @const @private {!../../../src/pass.Pass}
+     */
+    this.renderPass_ = new Pass(this.win, () => this.doRenderPass_());
+
+    /**
+     * Latest fetched items to render and the promise resolver and rejecter
+     * to be invoked on render success or fail, respectively.
+     * @private {?RenderItems}
+     */
+    this.renderItems_ = null;
+
+    /** @private {?Array} */
+    this.renderedItems_ = null;
+
+    /** @const {!../../../src/service/template-impl.Templates} */
+    this.templates_ = Services.templatesFor(this.win);
+
+    /**
+     * Has layoutCallback() been called yet?
+     * @private {boolean}
+     */
+    this.layoutCompleted_ = false;
+
+    /**
+     * The `src` attribute's initial value.
+     * @private {?string}
+     */
+    this.initialSrc_ = null;
+
+    /**
+     * Does the amp-list have initial content that's not a placeholder?
+     * @private {boolean}
+     */
+    this.hasInitialContent_ = false;
+
+    /** @private {?../../../extensions/amp-bind/0.1/bind-impl.Bind} */
+    this.bind_ = null;
+
+    /** @private {boolean} */
+    this.loadMoreEnabled_ = false;
+
+    /** @private {?./service/load-more-service.LoadMoreService} */
+    this.loadMoreService_ = null;
+
+    /** @private {?string} */
+    this.loadMoreSrc_ = null;
+
+    /**@private {boolean} */
+    this.resizeFailed_ = false;
+
+    /**@private {?UnlistenDef} */
+    this.unlistenAutoLoadMore_ = null;
+
+    this.registerAction('refresh', () => {
+      if (this.layoutCompleted_) {
+        this.resetIfNecessary_();
+        return this.fetchList_(/* opt_refresh */ true);
+      }
+    });
+
+    this.registerAction('changeToLayoutContainer', () =>
+      this.changeToLayoutContainer_()
+    );
+
+    /** @private {?../../../src/ssr-template-helper.SsrTemplateHelper} */
+    this.ssrTemplateHelper_ = null;
+  }
+
+  /** @override */
+  isLayoutSupported(layout) {
+    return isLayoutSizeDefined(layout);
+  }
+
+  /** @override */
+  buildCallback() {
+    this.viewport_ = this.getViewport();
+    const viewer = Services.viewerForDoc(this.getAmpDoc());
+    this.ssrTemplateHelper_ = new SsrTemplateHelper(
+      TAG,
+      viewer,
+      this.templates_
+    );
+
+    this.loadMoreEnabled_ = this.element.hasAttribute('load-more');
+
+    // Store this in buildCallback() because `this.element` sometimes
+    // is missing attributes in the constructor.
+    this.initialSrc_ = this.element.getAttribute('src');
+
+    // TODO(amphtml): Decouple "initial content" from diffing in new version.
+    if (this.element.hasAttribute('diffable')) {
+      // Set container to the initial content, if it exists. This allows
+      // us to DOM diff with the rendered result.
+      const initialContent = scopedQuerySelector(
+        this.element,
+        '> div[role=list]:not([placeholder]):not([fallback]):not([fetch-error])'
+      );
+      if (initialContent) {
+        this.container_ = initialContent;
+        this.hasInitialContent_ = true;
+      }
+    }
+    if (!this.container_) {
+      this.container_ = this.createContainer_();
+      this.element.appendChild(this.container_);
+    }
+
+    if (!this.element.hasAttribute('aria-live')) {
+      this.element.setAttribute('aria-live', 'polite');
+    }
+
+    // auto-resize is deprecated and will be removed per deprecation schedule
+    // It will relaunched under a new attribute (resizable-children) soon.
+    // please see https://github.com/ampproject/amphtml/issues/18849
+    if (this.element.hasAttribute('auto-resize')) {
+      user().warn(
+        TAG,
+        'auto-resize attribute is deprecated and its behavior' +
+          ' is disabled. This feature will be relaunched under a new name' +
+          ' soon. Please see https://github.com/ampproject/amphtml/issues/18849'
+      );
+    }
+
+    // Override default attributes used for setDOM customization.
+    setDOM['KEY'] = DIFF_KEY;
+    setDOM['IGNORE'] = DIFF_IGNORE;
+
+    Services.bindForDocOrNull(this.element).then(bind => {
+      this.bind_ = bind;
+    });
+  }
+
+  /** @override */
+  reconstructWhenReparented() {
+    return false;
+  }
+
+  /** @override */
+  layoutCallback() {
+    this.layoutCompleted_ = true;
+
+    // If a placeholder exists and it's taller than amp-list, attempt a resize.
+    const placeholder = this.getPlaceholder();
+    if (placeholder) {
+      this.attemptToFit_(placeholder);
+    } else if (this.hasInitialContent_) {
+      this.attemptToFit_(dev().assertElement(this.container_));
+    }
+
+    this.viewport_.onResize(() => {
+      this.maybeResizeListToFitItems_();
+    });
+
+    if (this.loadMoreEnabled_) {
+      this.initializeLoadMoreElements_();
+    }
+
+    return this.fetchList_();
+  }
+
+  /**
+   * @return {!Promise}
+   * @private
+   */
+  initializeLoadMoreElements_() {
+    return this.mutateElement(() => {
+      this.getLoadMoreService_().initializeLoadMore();
+      const overflowElement = this.getOverflowElement();
+      if (overflowElement) {
+        toggle(overflowElement, false);
+      }
+      this.element.warnOnMissingOverflow = false;
+    }).then(() => {
+      this.adjustContainerForLoadMoreButton_();
+      listen(
+        this.getLoadMoreService_().getLoadMoreFailedClickable(),
+        'click',
+        () =>
+          this.loadMoreCallback_(/*opt_reload*/ true, /*opt_fromClick*/ true)
+      );
+      listen(
+        this.getLoadMoreService_().getLoadMoreButtonClickable(),
+        'click',
+        () =>
+          this.loadMoreCallback_(/*opt_reload*/ false, /*opt_fromClick*/ true)
+      );
+    });
+  }
+
+  /**
+   * @private
+   */
+  maybeResizeListToFitItems_() {
+    if (this.loadMoreEnabled_) {
+      this.attemptToFitLoadMore_(dev().assertElement(this.container_));
+    } else {
+      this.attemptToFit_(dev().assertElement(this.container_));
+    }
+  }
+
+  /**
+   * @return {!LoadMoreService}
+   * @private
+   */
+  getLoadMoreService_() {
+    if (!this.loadMoreService_) {
+      this.loadMoreService_ = new LoadMoreService(this.element);
+    }
+    return this.loadMoreService_;
+  }
+
+  /**
+   * This function is called at layout time if the amp-list has the
+   * load-more attribute. This increases the height of the amp-list by
+   * the height of the load-more button and forces the contents to allow
+   * space for the button.
+   * @private
+   * @return {!Promise}
+   */
+  adjustContainerForLoadMoreButton_() {
+    let buttonHeight;
+    let listHeight;
+    return this.measureMutateElement(
+      /* measurer */ () => {
+        buttonHeight = this.getLoadMoreService_().getLoadMoreButton()
+          ./*OK*/ offsetHeight;
+        listHeight = this.element./*OK*/ offsetHeight;
+      },
+      /* mutator */ () => {
+        setStyles(dev().assertElement(this.container_), {
+          'max-height': `calc(100% - ${px(buttonHeight)})`,
+        });
+        this.element./*OK*/ changeSize(listHeight + buttonHeight);
+      }
+    );
+  }
+
+  /**
+   * Returns true if element's src points to amp-state.
+   *
+   * @param {string} src
+   * @return {boolean}
+   * @private
+   */
+  isAmpStateSrc_(src) {
+    return (
+      isExperimentOn(this.win, 'amp-list-init-from-state') &&
+      startsWith(src, AMP_STATE_URI_SCHEME)
+    );
+  }
+
+  /**
+   * Gets the json an amp-list that has an "amp-state:" uri. For example,
+   * src="amp-state:json.path".
+   *
+   * @param {string} src
+   * @return {Promise<!JsonObject>}
+   * @private
+   */
+  getAmpStateJson_(src) {
+    return Services.bindForDocOrNull(this.element)
+      .then(bind => {
+        userAssert(bind, '"amp-state:" URLs require amp-bind to be installed.');
+        userAssert(
+          !this.ssrTemplateHelper_.isEnabled(),
+          '[amp-list]: "amp-state" URIs cannot be used in SSR mode.'
+        );
+
+        const ampStatePath = src.slice(AMP_STATE_URI_SCHEME.length);
+        return bind.getState(ampStatePath);
+      })
+      .then(json => {
+        userAssert(
+          typeof json !== 'undefined',
+          `[amp-list] No data was found at provided uri: ${src}`
+        );
+        return json;
+      });
+  }
+
+  /** @override */
+  mutatedAttributesCallback(mutations) {
+    dev().info(TAG, 'mutate:', this.element, mutations);
+    let promise;
+
+    /**
+     * @param {!Array|!Object} data
+     * @return {!Promise}
+     */
+    const renderLocalData = data => {
+      // Remove the 'src' now that local data is used to render the list.
+      this.element.setAttribute('src', '');
+      userAssert(
+        !this.ssrTemplateHelper_.isEnabled(),
+        '[amp-list] "[src]" may not be bound in SSR mode.'
+      );
+
+      const array = /** @type {!Array} */ (isArray(data) ? data : [data]);
+      this.resetIfNecessary_(/* isFetch */ false);
+      return this.scheduleRender_(array, /* append */ false);
+    };
+
+    const src = mutations['src'];
+    if (src !== undefined) {
+      if (typeof src === 'string') {
+        // Defer to fetch in layoutCallback() before first layout.
+        if (this.layoutCompleted_) {
+          this.resetIfNecessary_();
+          promise = this.fetchList_();
+        }
+      } else if (typeof src === 'object') {
+        promise = renderLocalData(/** @type {!Object} */ (src));
+      } else {
+        this.user().error(TAG, 'Unexpected "src" type: ' + src);
+      }
+    }
+
+    const isLayoutContainer = mutations['is-layout-container'];
+    if (isLayoutContainer) {
+      this.changeToLayoutContainer_();
+    }
+
+    // Only return the promise for easier testing.
+    if (getMode().test) {
+      return promise;
+    }
+  }
+
+  /**
+   * amp-list reuses the loading indicator when the list is fetched again via
+   * bind mutation or refresh action
+   * @override
+   */
+  isLoadingReused() {
+    return this.element.hasAttribute('reset-on-refresh');
+  }
+
+  /**
+   * Creates and returns <div> that contains the template-rendered children.
+   * @return {!Element}
+   * @private
+   */
+  createContainer_() {
+    const container = this.win.document.createElement('div');
+    container.setAttribute('role', 'list');
+    // In the load-more case, we allow the container to be height auto
+    // in order to reasonably make space for the load-more button and
+    // load-more related UI elements underneath.
+    if (!this.loadMoreEnabled_) {
+      this.applyFillContent(container, true);
+    }
+    return container;
+  }
+
+  /**
+   * Adds template-rendered `elements` as children to `container`.
+   * @param {!Array<!Node>} elements
+   * @param {!Element} container
+   * @private
+   */
+  addElementsToContainer_(elements, container) {
+    elements.forEach(element => {
+      if (!element.hasAttribute('role')) {
+        element.setAttribute('role', 'listitem');
+      }
+      if (
+        !element.hasAttribute('tabindex') &&
+        !this.isTabbable_(dev().assertElement(element))
+      ) {
+        element.setAttribute('tabindex', '0');
+      }
+      container.appendChild(element);
+    });
+  }
+
+  /**
+   * Wraps `toggleFallback()`. Must be called in a mutate context.
+   * @param {boolean} show
+   * @private
+   */
+  toggleFallback_(show) {
+    // Early-out if toggling would be a no-op.
+    if (!show && !this.fallbackDisplayed_) {
+      return;
+    }
+    this.toggleFallback(show);
+    this.fallbackDisplayed_ = show;
+  }
+
+  /**
+   * Removes any previously rendered children and displays placeholder, loading
+   * indicator, etc. depending on the value of `reset-on-refresh` attribute.
+   *
+   *     <amp-list reset-on-refresh="fetch|always">
+   *
+   * - "fetch": Reset only on network requests.
+   * - "always": Reset on network request OR rendering with local data.
+   *
+   * Default is "fetch" if no value is specified (boolean attribute).
+   *
+   * @param {boolean=} isFetch
+   */
+  resetIfNecessary_(isFetch = true) {
+    if (
+      (isFetch && this.element.hasAttribute('reset-on-refresh')) ||
+      this.element.getAttribute('reset-on-refresh') === 'always'
+    ) {
+      // Placeholder and loading don't need a mutate context.
+      this.togglePlaceholder(true);
+      this.toggleLoading(true, /* opt_force */ true);
+      this.mutateElement(() => {
+        this.toggleFallback_(false);
+        // Clean up bindings in children before removing them from DOM.
+        if (this.bind_) {
+          const removed = toArray(this.container_.children);
+          this.bind_.rescan(/* added */ [], removed, {
+            'fast': true,
+            'update': false,
+          });
+        }
+        removeChildren(dev().assertElement(this.container_));
+        if (this.loadMoreEnabled_) {
+          this.getLoadMoreService_().hideAllLoadMoreElements();
+        }
+      });
+    }
+  }
+
+  /**
+   * Given JSON payload data fetched from the server, modifies the
+   * data according to developer-defined parameters. Extracts the correct
+   * list items according to the 'items' attribute, asserts that this
+   * contains an array or object, put object in an array if the single-item
+   * attribute is set, and truncates the list-items to a length defined
+   * by max-items.
+   * @param {!JsonObject|!Array<JsonObject>} data
+   * @throws {!Error} If response is undefined
+   * @return {!Array}
+   */
+  computeListItems_(data) {
+    const itemsExpr = this.element.getAttribute('items') || 'items';
+    let items = data;
+    if (itemsExpr != '.') {
+      items = getValueForExpr(/**@type {!JsonObject}*/ (data), itemsExpr);
+    }
+    userAssert(
+      typeof items !== 'undefined',
+      'Response must contain an array or object at "%s". %s',
+      itemsExpr,
+      this.element
+    );
+    if (this.element.hasAttribute('single-item') && !isArray(items)) {
+      items = [items];
+    }
+    items = user().assertArray(items);
+    if (this.element.hasAttribute('max-items')) {
+      items = this.truncateToMaxLen_(items);
+    }
+    return items;
+  }
+
+  /**
+   * Trigger a fetch-error event
+   * @param {*} error
+   */
+  triggerFetchErrorEvent_(error) {
+    const event = error
+      ? createCustomEvent(
+          this.win,
+          `${TAG}.error`,
+          dict({'response': error.response})
+        )
+      : null;
+    const actions = Services.actionServiceForDoc(this.element);
+    actions.trigger(this.element, 'fetch-error', event, ActionTrust.LOW);
+  }
+
+  /**
+   * Request list data from `src` and return a promise that resolves when
+   * the list has been populated with rendered list items. If the viewer is
+   * capable of rendering the templates, then the fetching of the list and
+   * transformation of the template is handled by the viewer.
+   * @param {boolean=} opt_refresh
+   * @return {!Promise}
+   * @private
+   */
+  fetchList_(opt_refresh = false) {
+    const elementSrc = this.element.getAttribute('src');
+    if (!elementSrc) {
+      return Promise.resolve();
+    }
+
+    let fetch;
+    if (this.ssrTemplateHelper_.isEnabled()) {
+      fetch = this.ssrTemplate_(opt_refresh);
+    } else {
+      fetch = this.isAmpStateSrc_(elementSrc)
+        ? this.getAmpStateJson_(elementSrc)
+        : this.prepareAndSendFetch_(opt_refresh);
+      fetch = fetch.then(data => {
+        // Bail if the src has changed while resolving the xhr request.
+        if (elementSrc !== this.element.getAttribute('src')) {
+          return;
+        }
+
+        const items = this.computeListItems_(data);
+        if (this.loadMoreEnabled_) {
+          this.updateLoadMoreSrc_(/** @type {!JsonObject} */ (data));
+        }
+
+        return this.scheduleRender_(
+          items,
+          /*opt_append*/ false,
+          data
+        ).then(() => this.maybeSetLoadMore_());
+      });
+    }
+
+    return fetch.catch(error => {
+      this.triggerFetchErrorEvent_(error);
+      this.showFallback_();
+      throw error;
+    });
+  }
+
+  /**
+   * Fetch and render items intended to be appended to the current list
+   * @return {!Promise}
+   */
+  fetchListAndAppend_() {
+    if (!this.element.getAttribute('src')) {
+      return Promise.resolve();
+    }
+    return this.prepareAndSendFetch_().then(data => {
+      const items = this.computeListItems_(data);
+      this.updateLoadMoreSrc_(/** @type {!JsonObject} */ (data));
+      return this.scheduleRender_(
+        items,
+        /*opt_append*/ true,
+        /*opt_payload*/ data
+      );
+    });
+  }
+
+  /**
+   * @param {!Array<?JsonObject>} items
+   * @return {!Array<?JsonObject>}
+   * @private
+   */
+  truncateToMaxLen_(items) {
+    const maxLen = parseInt(this.element.getAttribute('max-items'), 10);
+    if (maxLen < items.length) {
+      items = items.slice(0, maxLen);
+    }
+    return items;
+  }
+
+  /**
+   * @param {!JsonObject} data
+   * @private
+   */
+  updateLoadMoreSrc_(data) {
+    const nextExpr =
+      this.element.getAttribute('load-more-bookmark') || 'load-more-src';
+    this.loadMoreSrc_ = /** @type {string} */ (getValueForExpr(data, nextExpr));
+  }
+
+  /**
+   * Proxies the template rendering to the viewer.
+   * @param {boolean} refresh
+   * @return {!Promise}
+   */
+  ssrTemplate_(refresh) {
+    const elementSrc = this.element.getAttribute('src');
+    let request;
+    // Construct the fetch init data that would be called by the viewer
+    // passed in as the 'originalRequest'.
+    return requestForBatchFetch(this.element, this.getPolicy_(), refresh)
+      .then(r => {
+        request = r;
+
+        request.xhrUrl = setupInput(this.win, request.xhrUrl, request.fetchOpt);
+        request.fetchOpt = setupAMPCors(
+          this.win,
+          request.xhrUrl,
+          request.fetchOpt
+        );
+        setupJsonFetchInit(r.fetchOpt);
+
+        const attributes = dict({
+          'ampListAttributes': {
+            'items': this.element.getAttribute('items') || 'items',
+            'singleItem': this.element.hasAttribute('single-item'),
+            'maxItems': this.element.getAttribute('max-items'),
+          },
+        });
+        return this.ssrTemplateHelper_.ssr(
+          this.element,
+          request,
+          /* opt_templates */ null,
+          attributes
+        );
+      })
+      .then(
+        response => {
+          userAssert(
+            response,
+            'Error proxying amp-list templates, received no response.'
+          );
+          const init = response['init'];
+          if (init) {
+            const status = init['status'];
+            if (status >= 300) {
+              /** HTTP status codes of 300+ mean redirects and errors. */
+              throw user().createError(
+                'Error proxying amp-list templates with status: ',
+                status
+              );
+            }
+          }
+          userAssert(
+            typeof response['html'] === 'string',
+            'Expected response with format {html: <string>}. Received: ',
+            response
+          );
+          request.fetchOpt.responseType = 'application/json';
+          return response;
+        },
+        error => {
+          throw user().createError('Error proxying amp-list templates', error);
+        }
+      )
+      .then(data => {
+        // Bail if the src has changed while resolving the xhr request.
+        if (elementSrc !== this.element.getAttribute('src')) {
+          return;
+        }
+        this.scheduleRender_(data, /* append */ false);
+      });
+  }
+
+  /**
+   * Schedules a fetch result to be rendered in the near future.
+   * @param {!Array|!JsonObject|undefined} data
+   * @param {boolean=} opt_append
+   * @param {JsonObject|Array<JsonObject>=} opt_payload
+   * @return {!Promise}
+   * @private
+   */
+  scheduleRender_(data, opt_append, opt_payload) {
+    const deferred = new Deferred();
+    const {promise, resolve: resolver, reject: rejecter} = deferred;
+
+    // If there's nothing currently being rendered, schedule a render pass.
+    if (!this.renderItems_) {
+      this.renderPass_.schedule();
+    }
+
+    this.renderItems_ = /** @type {?RenderItems} */ ({
+      data,
+      resolver,
+      rejecter,
+      append: opt_append,
+      payload: opt_payload,
+    });
+
+    if (this.renderedItems_ && opt_append) {
+      this.renderItems_.payload =
+        /** @type {(?JsonObject|Array<JsonObject>)} */ (opt_payload || {});
+    }
+
+    return promise;
+  }
+
+  /**
+   * Renders the items stored in `this.renderItems_`. If its value changes
+   * by the time render completes, schedules another render pass.
+   * @private
+   */
+  doRenderPass_() {
+    const current = this.renderItems_;
+
+    devAssert(current && current.data, 'Nothing to render.');
+    const scheduleNextPass = () => {
+      // If there's a new `renderItems_`, schedule it for render.
+      if (this.renderItems_ !== current) {
+        this.renderPass_.schedule(1); // Allow paint frame before next render.
+      } else {
+        this.renderedItems_ = /** @type {?Array} */ (this.renderItems_.data);
+        this.renderItems_ = null;
+      }
+    };
+    const onFulfilledCallback = () => {
+      scheduleNextPass();
+      current.resolver();
+    };
+    const onRejectedCallback = () => {
+      scheduleNextPass();
+      current.rejecter();
+    };
+    const isSSR = this.ssrTemplateHelper_.isEnabled();
+    let renderPromise = this.ssrTemplateHelper_
+      .applySsrOrCsrTemplate(this.element, current.data)
+      .then(result => this.updateBindings_(result, current.append))
+      .then(elements => this.render_(elements, current.append));
+    if (!isSSR) {
+      const payload = /** @type {!JsonObject} */ (current.payload);
+      renderPromise = renderPromise.then(() =>
+        this.maybeRenderLoadMoreTemplates_(payload)
+      );
+    }
+    renderPromise.then(onFulfilledCallback, onRejectedCallback);
+  }
+
+  /**
+   * @param {!JsonObject} data
+   * @return {!Promise}
+   * @private
+   */
+  maybeRenderLoadMoreTemplates_(data) {
+    if (this.loadMoreEnabled_) {
+      const promises = [];
+      promises.push(
+        this.maybeRenderLoadMoreElement_(
+          this.getLoadMoreService_().getLoadMoreButton(),
+          data
+        )
+      );
+      promises.push(
+        this.maybeRenderLoadMoreElement_(
+          this.getLoadMoreService_().getLoadMoreEndElement(),
+          data
+        )
+      );
+      return Promise.all(promises);
+    } else {
+      return Promise.resolve();
+    }
+  }
+
+  /**
+   * @param {?Element} elem
+   * @param {!JsonObject} data
+   * @return {!Promise}
+   * @private
+   */
+  maybeRenderLoadMoreElement_(elem, data) {
+    if (elem && this.templates_.hasTemplate(elem)) {
+      return this.templates_
+        .findAndRenderTemplate(elem, data)
+        .then(newContents => {
+          return this.mutateElement(() => {
+            removeChildren(dev().assertElement(elem));
+            elem.appendChild(newContents);
+          });
+        });
+    }
+    return Promise.resolve();
+  }
+
+  /**
+   * Scans for, evaluates and applies any bindings in the given elements.
+   * Ensures that rendered content is up-to-date with the latest bindable state.
+   * Can be skipped by setting binding="no" or binding="refresh" attribute.
+   * @param {!Array<!Element>|!Element} elementOrElements
+   * @param {boolean} append
+   * @return {!Promise<!Array<!Element>>}
+   * @private
+   */
+  updateBindings_(elementOrElements, append) {
+    const elements = /** @type {!Array<!Element>} */ (isArray(elementOrElements)
+      ? elementOrElements
+      : [elementOrElements]);
+
+    // binding=no: Always skip render-blocking update.
+    const binding = this.element.getAttribute('binding');
+    if (binding === 'no') {
+      return Promise.resolve(elements);
+    }
+
+    // Early out if elements contain no bindings.
+    const hasBindings = elements.some(
+      el =>
+        el.hasAttribute('i-amphtml-binding') ||
+        !!el.querySelector('[i-amphtml-binding]')
+    );
+    if (!hasBindings) {
+      return Promise.resolve(elements);
+    }
+
+    if (!binding) {
+      user().warn(
+        TAG,
+        'Missing "binding" attribute. Using binding="refresh" is recommended for performance.'
+      );
+    }
+
+    /**
+     * @param {!../../../extensions/amp-bind/0.1/bind-impl.Bind} bind
+     * @return {!Promise<!Array<!Element>>}
+     */
+    const updateWith = bind => {
+      const removedElements = append ? [] : [this.container_];
+      // Forward elements to chained promise on success or failure.
+      return bind
+        .rescan(elements, removedElements, {'fast': true, 'update': true})
+        .then(
+          () => elements,
+          () => elements
+        );
+    };
+
+    // binding=refresh: Only do render-blocking update after initial render.
+    if (binding === 'refresh') {
+      // Bind service must be available after first mutation, so don't
+      // wait on the async service getter.
+      if (this.bind_ && this.bind_.signals().get('FIRST_MUTATE')) {
+        return updateWith(this.bind_);
+      } else {
+        // On initial render, do a non-blocking scan and don't update.
+        Services.bindForDocOrNull(this.element).then(bind => {
+          if (bind) {
+            bind.rescan(elements, [], {'fast': true, 'update': false});
+          }
+        });
+        return Promise.resolve(elements);
+      }
+    }
+    // binding=always (default): Wait for amp-bind to download and always
+    // do render-blocking update.
+    return Services.bindForDocOrNull(this.element).then(bind => {
+      if (bind) {
+        return updateWith(bind);
+      } else {
+        return Promise.resolve(elements);
+      }
+    });
+  }
+
+  /**
+   * @param {!Array<!Element>} elements
+   * @param {boolean=} opt_append
+   * @return {!Promise}
+   * @private
+   */
+  render_(elements, opt_append = false) {
+    dev().info(TAG, 'render:', this.element, elements);
+    const container = dev().assertElement(this.container_);
+
+    return this.mutateElement(() => {
+      this.hideFallbackAndPlaceholder_();
+
+      if (this.element.hasAttribute('diffable') && container.hasChildNodes()) {
+        this.diff_(container, elements);
+      } else {
+        if (!opt_append) {
+          removeChildren(container);
+        }
+        this.addElementsToContainer_(elements, container);
+      }
+
+      const event = createCustomEvent(
+        this.win,
+        AmpEvents.DOM_UPDATE,
+        /* detail */ null,
+        {bubbles: true}
+      );
+      this.container_.dispatchEvent(event);
+
+      // Now that new contents have been rendered, clear pending size requests
+      // from previous calls to attemptToFit_(). Rejected size requests are
+      // saved as "pending" and are fulfilled later on 'focus' event.
+      // See resources-impl.checkPendingChangeSize_().
+      const r = this.element.getResources().getResourceForElement(this.element);
+      r.resetPendingChangeSize();
+
+      this.maybeResizeListToFitItems_();
+    });
+  }
+
+  /**
+   * Updates `this.container_` by DOM diffing its children against `elements`.
+   *
+   * TODO(amphtml): The diffing feature is dark-launched and highly complex.
+   * See markElementForDiffing() and markContainerForDiffing_() for examples.
+   * Validate whether or not this complexity is warranted before fully launching
+   * (e.g. in a new version) and pushing documentation.
+   *
+   * @param {!Element} container
+   * @param {!Array<!Element>} elements
+   * @private
+   */
+  diff_(container, elements) {
+    const newContainer = this.createContainer_();
+    this.addElementsToContainer_(elements, newContainer);
+
+    // Typically, diff-marking elements happens during template sanitization.
+    // This obviously doesn't apply to initial content, so we mark them manually
+    // here to enable diffing in the first render.
+    if (this.hasInitialContent_) {
+      this.markContainerForDiffing_(container);
+    }
+
+    // setDOM does in-place DOM diffing for all non-AMP elements.
+    const ignored = setDOM(container, newContainer);
+
+    // Manually process ignored (AMP) elements.
+    for (let i = 0; i < ignored.length; i += 2) {
+      const before = dev().assertElement(ignored[i]);
+      const after = dev().assertElement(ignored[i + 1]);
+      this.manuallyDiffElement_(before, after);
+    }
+  }
+
+  /**
+   * @param {!Element} container
+   * @private
+   */
+  markContainerForDiffing_(container) {
+    // amp-mustache starts at 1 and increments, so start at -1 and decrement
+    // to guarantee uniqueness.
+    let key = -1;
+    // (1) AMP elements and (2) elements with bindings need diff marking.
+    // But, we only need to do (1) here because bindings in initial content
+    // are inert by design (as are bindings in placeholder content).
+    const elements = container.querySelectorAll('.i-amphtml-element');
+    elements.forEach(element => {
+      markElementForDiffing(element, () => String(key--));
+    });
+  }
+
+  /**
+   * @param {!Element} before
+   * @param {!Element} after
+   * @private
+   */
+  manuallyDiffElement_(before, after) {
+    devAssert(before.nodeName == after.nodeName, 'Mismatched nodeName.');
+    const replacementAttrs = DIFFABLE_AMP_ELEMENTS[before.nodeName];
+    if (!replacementAttrs) {
+      return;
+    }
+    const shouldReplace = replacementAttrs.some(
+      attr => before.getAttribute(attr) !== after.getAttribute(attr)
+    );
+    // Use the new element if there's a mismatched attribute value.
+    if (shouldReplace) {
+      before.parentElement.replaceChild(after, before);
+    } else {
+      // TODO(#23470): Support more attributes to manually diff by calling
+      // mutatedAttributesCallback() and changeSize().
+
+      // Add new classes.
+      for (let i = 0; i < after.classList.length; i++) {
+        before.classList.add(after.classList[i]);
+      }
+      // Remove missing, non-internal classes.
+      for (let i = 0; i < before.classList.length; i++) {
+        const c = before.classList[i];
+        if (!startsWith(c, 'i-amphtml-') && !after.classList.contains(c)) {
+          before.classList.remove(c);
+        }
+      }
+      // Concatenate instead of overwrite [style] since width/height are set
+      // by AMP's layout engine.
+      if (after.hasAttribute('style')) {
+        const afterStyle = after.getAttribute('style');
+        before.setAttribute(
+          'style',
+          `${before.getAttribute('style') || ''};${afterStyle}`
+        );
+      }
+    }
+  }
+
+  /**
+   * Attempts to change the height of the amp-list to fit a target child.
+   *
+   * If the target's height is greater than the amp-list's height, attempt
+   * to change the amp-list's height to fit the target.
+   *
+   * @param {!Element} target
+   * @private
+   */
+  attemptToFit_(target) {
+    if (this.element.getAttribute('layout') == Layout.CONTAINER) {
+      return;
+    }
+    this.measureElement(() => {
+      const targetHeight = target./*OK*/ scrollHeight;
+      const height = this.element./*OK*/ offsetHeight;
+      if (targetHeight > height) {
+        this.attemptChangeHeight(targetHeight).catch(() => {});
+      }
+    });
+  }
+
+  /**
+   *
+   * @param {!Element} target
+   * @private
+   */
+  attemptToFitLoadMore_(target) {
+    const element = !!this.loadMoreSrc_
+      ? this.getLoadMoreService_().getLoadMoreButton()
+      : this.getLoadMoreService_().getLoadMoreEndElement();
+    this.attemptToFitLoadMoreElement_(element, target);
+  }
+
+  /**
+   * @param {?Element} element
+   * @param {!Element} target
+   * @private
+   */
+  attemptToFitLoadMoreElement_(element, target) {
+    if (this.element.getAttribute('layout') == Layout.CONTAINER) {
+      return;
+    }
+    this.measureElement(() => {
+      const targetHeight = target./*OK*/ scrollHeight;
+      const height = this.element./*OK*/ offsetHeight;
+      const loadMoreHeight = element ? element./*OK*/ offsetHeight : 0;
+      if (targetHeight + loadMoreHeight > height) {
+        this.attemptChangeHeight(targetHeight + loadMoreHeight)
+          .then(() => {
+            this.resizeFailed_ = false;
+            // If there were not enough items to fill the list, consider
+            // automatically loading more if load-more="auto" is enabled
+            if (this.element.getAttribute('load-more') === 'auto') {
+              this.maybeLoadMoreItems_();
+            }
+            setStyles(dev().assertElement(this.container_), {
+              'max-height': '',
+            });
+          })
+          .catch(() => {
+            this.resizeFailed_ = true;
+            this.adjustContainerForLoadMoreButton_();
+          });
+      }
+    });
+  }
+
+  /**
+   * Undoes previous size-defined layout, must be called in mutation context.
+   * @param {string} layoutString
+   * @see src/layout.js
+   */
+  undoLayout_(layoutString) {
+    const layout = parseLayout(layoutString);
+    const layoutClass = getLayoutClass(devAssert(layout));
+    this.element.classList.remove(layoutClass, 'i-amphtml-layout-size-defined');
+
+    // TODO(amphtml): Remove [width] and [height] attributes too?
+    if (
+      [
+        Layout.FIXED,
+        Layout.FLEX_ITEM,
+        Layout.FLUID,
+        Layout.INTRINSIC,
+        Layout.RESPONSIVE,
+      ].includes(layout)
+    ) {
+      setStyles(this.element, {width: '', height: ''});
+    } else if (layout == Layout.FIXED_HEIGHT) {
+      setStyles(this.element, {height: ''});
+    }
+
+    // The changeSize() call removes the sizer element.
+    this.element./*OK*/ changeSize();
+  }
+
+  /**
+   * Converts the amp-list to de facto layout container. Called in mutate
+   * context.
+   * @return {!Promise}
+   * @private
+   */
+  changeToLayoutContainer_() {
+    const previousLayout = this.element.getAttribute('i-amphtml-layout');
+    // If we have already changed to layout container, no need to run again.
+    if (previousLayout == Layout.CONTAINER) {
+      return Promise.resolve();
+    }
+    return this.mutateElement(() => {
+      this.undoLayout_(previousLayout);
+      this.container_.classList.remove(
+        'i-amphtml-fill-content',
+        'i-amphtml-replaced-content'
+      );
+      // The overflow element is generally hidden with visibility hidden,
+      // but after changing to layout container, this causes an undesirable
+      // empty white space so we hide it with "display: none" instead.
+      const overflowElement = this.getOverflowElement();
+      if (overflowElement) {
+        toggle(overflowElement, false);
+      }
+      this.element.setAttribute('layout', 'container');
+      this.element.setAttribute('i-amphtml-layout', 'container');
+      this.element.classList.add('i-amphtml-layout-container');
+    });
+  }
+
+  /**
+   * @return {!Promise}
+   * @private
+   */
+  maybeSetLoadMore_() {
+    if (this.loadMoreEnabled_) {
+      return this.setLoadMore_();
+    }
+    return Promise.resolve();
+  }
+
+  /**
+   * Sets up auto-load-more if automatic load-more is on. Otherwise, sets up
+   * manual load-more. In manual, shows the load-more button if there are more
+   * elements to load and the load-more-end element if otherwise. Called on
+   * the first fetch if load-more is on. Only called once.
+   * @return {!Promise}
+   * @private
+   */
+  setLoadMore_() {
+    if (this.loadMoreSrc_) {
+      const autoLoad = this.element.getAttribute('load-more') === 'auto';
+      if (autoLoad) {
+        this.setupLoadMoreAuto_();
+      }
+      return this.mutateElement(() => {
+        this.getLoadMoreService_().toggleLoadMoreLoading(false);
+        // Set back to visible because there are actually more elements
+        // to load. See comment in initializeLoadMoreButton_ for context.
+        setStyles(this.getLoadMoreService_().getLoadMoreButton(), {
+          visibility: '',
+        });
+      });
+    } else {
+      return this.mutateElement(() =>
+        this.getLoadMoreService_().setLoadMoreEnded()
+      );
+    }
+  }
+
+  /**
+   * Called when 3 viewports above bottom of automatic load-more list, or
+   * manually on clicking the load-more-button element. Sets the amp-list
+   * src to the bookmarked src and fetches data from it.
+   * @param {boolean=} opt_reload
+   * @param {boolean=} opt_fromClick
+   * @return {!Promise}
+   * @private
+   */
+  loadMoreCallback_(opt_reload = false, opt_fromClick = false) {
+    if (!!this.loadMoreSrc_) {
+      this.element.setAttribute('src', this.loadMoreSrc_);
+      // Clear url to avoid repeated fetches from same url
+      this.loadMoreSrc_ = null;
+    } else if (!opt_reload) {
+      // Nothing more to load or previous fetch still inflight
+      return Promise.resolve();
+    }
+    const container = dev().assertElement(this.container_);
+    const lastTabbableChild = this.lastTabbableChild_(container);
+    this.mutateElement(() => {
+      this.getLoadMoreService_().toggleLoadMoreLoading(true);
+    });
+    return this.fetchListAndAppend_()
+      .then(() => {
+        return this.mutateElement(() => {
+          if (this.loadMoreSrc_) {
+            this.getLoadMoreService_().toggleLoadMoreLoading(false);
+            if (lastTabbableChild && opt_fromClick) {
+              tryFocus(lastTabbableChild);
+            }
+          } else {
+            this.getLoadMoreService_().setLoadMoreEnded();
+          }
+        });
+      })
+      .then(() => {
+        // Necessary since load-more elements are toggled in the above block
+        this.attemptToFitLoadMore_(dev().assertElement(this.container_));
+      })
+      .catch(error => {
+        this.triggerFetchErrorEvent_(error);
+        this.handleLoadMoreFailed_();
+      });
+  }
+
+  /**
+   * @private
+   */
+  handleLoadMoreFailed_() {
+    this.mutateElement(() =>
+      this.getLoadMoreService_().setLoadMoreFailed()
+    ).then(() => {
+      this.attemptToFitLoadMoreElement_(
+        this.getLoadMoreService_().getLoadMoreFailedElement(),
+        dev().assertElement(this.container_)
+      );
+    });
+  }
+
+  /**
+   * @param {boolean=} refresh
+   * @param {string=} token
+   * @return {!Promise<!JsonObject|!Array<JsonObject>>}
+   * @private
+   */
+  fetch_(refresh = false, token = undefined) {
+    return batchFetchJsonFor(this.getAmpDoc(), this.element, {
+      expr: '.',
+      urlReplacement: this.getPolicy_(),
+      refresh,
+      token,
+      xssiPrefix: this.element.getAttribute('xssi-prefix') || undefined,
+    });
+  }
+
+  /**
+   * Sets up a listener on viewport change to load more items
+   * @private
+   */
+  setupLoadMoreAuto_() {
+    if (!this.unlistenAutoLoadMore_) {
+      this.unlistenAutoLoadMore_ = this.viewport_.onChanged(() =>
+        this.maybeLoadMoreItems_()
+      );
+    }
+  }
+
+  /**
+   * If the bottom of the list is within three viewports of the current
+   * viewport, then load more items.
+   * @private
+   */
+  maybeLoadMoreItems_() {
+    if (this.resizeFailed_) {
+      return;
+    }
+    const endoOfListMarker = this.container_.lastChild || this.container_;
+
+    this.viewport_
+      .getClientRectAsync(dev().assertElement(endoOfListMarker))
+      .then(positionRect => {
+        const viewportHeight = this.viewport_.getHeight();
+        if (3 * viewportHeight > positionRect.bottom) {
+          return this.loadMoreCallback_();
+        }
+      });
+  }
+
+  /**
+   * @param {boolean=} opt_refresh
+   * @return {!Promise<!JsonObject|!Array<JsonObject>>}
+   * @private
+   */
+  prepareAndSendFetch_(opt_refresh = false) {
+    return getViewerAuthTokenIfAvailable(this.element).then(token =>
+      this.fetch_(opt_refresh, token)
+    );
+  }
+
+  /**
+   * @return {!UrlReplacementPolicy}
+   */
+  getPolicy_() {
+    const src = this.element.getAttribute('src');
+    // Require opt-in for URL variable replacements on CORS fetches triggered
+    // by [src] mutation. @see spec/amp-var-substitutions.md
+    let policy = UrlReplacementPolicy.OPT_IN;
+    if (
+      src == this.initialSrc_ ||
+      getSourceOrigin(src) == getSourceOrigin(this.getAmpDoc().win.location)
+    ) {
+      policy = UrlReplacementPolicy.ALL;
+    }
+    return policy;
+  }
+
+  /**
+   * Must be called in mutate context.
+   * @private
+   */
+  hideFallbackAndPlaceholder_() {
+    this.element.classList.remove('i-amphtml-list-fetch-error');
+    this.toggleLoading(false);
+    if (this.getFallback()) {
+      this.toggleFallback_(false);
+    }
+    this.togglePlaceholder(false);
+  }
+
+  /**
+   * @private
+   */
+  showFallback_() {
+    this.element.classList.add('i-amphtml-list-fetch-error');
+    // Displaying [fetch-error] may offset initial content, so resize to fit.
+    if (childElementByAttr(this.element, 'fetch-error')) {
+      // Note that we're measuring against the element instead of the container.
+      this.attemptToFit_(this.element);
+    }
+    this.toggleLoading(false);
+    if (this.getFallback()) {
+      this.toggleFallback_(true);
+      this.togglePlaceholder(false);
+    }
+  }
+
+  /**
+   * @param {!Element} element
+   * @return {?Element}
+   * @private
+   */
+  lastTabbableChild_(element) {
+    const allTabbableChildren = scopedQuerySelectorAll(
+      element,
+      TABBABLE_ELEMENTS_QUERY
+    );
+    return allTabbableChildren
+      ? allTabbableChildren[allTabbableChildren.length - 1]
+      : null;
+  }
+
+  /**
+   * @param {!Element} element
+   * @return {?Element}
+   * @private
+   */
+  firstTabbableChild_(element) {
+    return scopedQuerySelector(element, TABBABLE_ELEMENTS_QUERY);
+  }
+
+  /**
+   * @param {!Element} element
+   * @return {boolean}
+   * @private
+   */
+  isTabbable_(element) {
+    return (
+      matches(element, TABBABLE_ELEMENTS_QUERY) ||
+      !!this.firstTabbableChild_(element)
+    );
+  }
+}
+
+AMP.extension(TAG, '0.1', AMP => {
+  AMP.registerElement(TAG, AmpList, CSS);
+});

--- a/extensions/amp-list/0.2/amp-list.js
+++ b/extensions/amp-list/0.2/amp-list.js
@@ -16,7 +16,7 @@
 
 import {ActionTrust} from '../../../src/action-constants';
 import {AmpEvents} from '../../../src/amp-events';
-import {CSS} from '../../../build/amp-list-0.1.css';
+import {CSS} from '../../../build/amp-list-0.2.css';
 import {
   DIFFABLE_AMP_ELEMENTS,
   DIFF_IGNORE,
@@ -1454,6 +1454,6 @@ export class AmpList extends AMP.BaseElement {
   }
 }
 
-AMP.extension(TAG, '0.1', AMP => {
+AMP.extension(TAG, '0.2', AMP => {
   AMP.registerElement(TAG, AmpList, CSS);
 });

--- a/extensions/amp-list/0.2/service/load-more-service.js
+++ b/extensions/amp-list/0.2/service/load-more-service.js
@@ -1,0 +1,269 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {childElementByAttr} from '../../../../src/dom';
+import {dev} from '../../../../src/log';
+import {htmlFor} from '../../../../src/static-template';
+import {setStyles} from '../../../../src/style';
+
+export class LoadMoreService {
+  /**
+   * @param {!Element} element
+   */
+  constructor(element) {
+    /** @private {!Element} */
+    this.ampListElement_ = element;
+    /** @private {?Element} */
+    this.loadMoreButton_ = null;
+    /** @private {?Element} */
+    this.loadMoreButtonClickable_ = null;
+    /** @private {?Element} */
+    this.loadMoreLoadingElement_ = null;
+    /** @private {?Element} */
+    this.loadMoreFailedElement_ = null;
+    /** @private {?Element} */
+    this.loadMoreFailedClickable_ = null;
+    /** @private {?Element} */
+    this.loadMoreEndElement_ = null;
+  }
+
+  /**
+   */
+  initializeLoadMore() {
+    this.initializeLoadMoreButton_();
+    this.initializeLoadMoreLoadingElement_();
+    this.initializeLoadMoreFailedElement_();
+    this.initializeLoadMoreEndElement_();
+  }
+
+  /**
+   * @private
+   */
+  initializeLoadMoreButton_() {
+    this.loadMoreButton_ = childElementByAttr(
+      this.ampListElement_,
+      'load-more-button'
+    );
+
+    if (this.loadMoreButton_) {
+      this.loadMoreButton_.classList.add('amp-visible');
+    } else {
+      this.loadMoreButton_ = htmlFor(this.ampListElement_)`
+        <amp-list-load-more load-more-button
+          class="amp-visible i-amphtml-default-ui">
+          <button load-more-clickable class="i-amphtml-list-load-more-button">
+            <label>See More</label>
+          </button>
+        </amp-list-load-more>
+      `;
+    }
+    // Even if it was provided by the user, we would still like to move it
+    // to the end of amp-list after the container element.
+    this.ampListElement_.appendChild(this.loadMoreButton_);
+    // Hide this so that we can measure its height but not see it.
+    setStyles(this.loadMoreButton_, {
+      visibility: 'hidden',
+    });
+  }
+
+  /**
+   * @private
+   */
+  initializeLoadMoreLoadingElement_() {
+    this.loadMoreLoadingElement_ = childElementByAttr(
+      this.ampListElement_,
+      'load-more-loading'
+    );
+
+    if (!this.loadMoreLoadingElement_) {
+      this.loadMoreLoadingElement_ = htmlFor(this.ampListElement_)`
+        <amp-list-load-more load-more-loading class="i-amphtml-default-ui">
+          <div class="i-amphtml-list-load-more-spinner"></div>
+        </amp-list-load-more>
+      `;
+    }
+    // Even if it was provided by the user, we would still like to move it
+    // to the end of amp-list after the container element.
+    this.ampListElement_.appendChild(this.loadMoreLoadingElement_);
+  }
+
+  /**
+   * @return {!Element}
+   */
+  getLoadMoreButton() {
+    if (!this.loadMoreButton_) {
+      this.initializeLoadMoreButton_();
+    }
+    return dev().assertElement(this.loadMoreButton_);
+  }
+
+  /**
+   * @return {?Element}
+   */
+  getLoadMoreLoadingElement() {
+    if (!this.loadMoreLoadingElement_) {
+      this.initializeLoadMoreLoadingElement_();
+    }
+    return this.loadMoreLoadingElement_;
+  }
+
+  /**
+   * @return {!Element}
+   */
+  getLoadMoreButtonClickable() {
+    if (!this.loadMoreButtonClickable_) {
+      const loadMoreButton = this.getLoadMoreButton();
+      this.loadMoreButtonClickable_ =
+        childElementByAttr(loadMoreButton, 'load-more-clickable') ||
+        loadMoreButton;
+    }
+    return this.loadMoreButtonClickable_;
+  }
+
+  /**
+   * @private
+   */
+  initializeLoadMoreFailedElement_() {
+    this.loadMoreFailedElement_ = childElementByAttr(
+      this.ampListElement_,
+      'load-more-failed'
+    );
+
+    if (!this.loadMoreFailedElement_) {
+      this.loadMoreFailedElement_ = htmlFor(this.ampListElement_)`
+        <amp-list-load-more load-more-failed class="i-amphtml-default-ui">
+          <div class="i-amphtml-list-load-more-message">
+            Unable to Load More
+          </div>
+          <button load-more-clickable
+            class="i-amphtml-list-load-more-button
+                  i-amphtml-list-load-more-button-has-icon
+                  i-amphtml-list-load-more-button-small"
+          >
+            <div class="i-amphtml-list-load-more-icon"></div>
+            <label>Retry</label>
+          </button>
+        </amp-list-load-more>
+      `;
+    }
+
+    this.ampListElement_.appendChild(this.loadMoreFailedElement_);
+  }
+
+  /**
+   * @return {!Element}
+   */
+  getLoadMoreFailedElement() {
+    if (!this.loadMoreFailedElement_) {
+      this.initializeLoadMoreFailedElement_();
+    }
+    return dev().assertElement(this.loadMoreFailedElement_);
+  }
+
+  /**
+   * @return {!Element}
+   */
+  getLoadMoreFailedClickable() {
+    if (!this.loadMoreFailedClickable_) {
+      const loadFailedElement = this.getLoadMoreFailedElement();
+      this.loadMoreFailedClickable_ =
+        childElementByAttr(loadFailedElement, 'load-more-clickable') ||
+        loadFailedElement;
+    }
+    return this.loadMoreFailedClickable_;
+  }
+
+  /**
+   * @private
+   */
+  initializeLoadMoreEndElement_() {
+    if (!this.loadMoreEndElement_) {
+      this.loadMoreEndElement_ = childElementByAttr(
+        this.ampListElement_,
+        'load-more-end'
+      );
+      if (this.loadMoreEndElement_) {
+        this.ampListElement_.appendChild(this.loadMoreEndElement_);
+      }
+    }
+  }
+
+  /**
+   * Not guaranteed to return an element because load-more-end elements
+   * are not mandatory.
+   * @return {?Element}
+   */
+  getLoadMoreEndElement() {
+    return this.loadMoreEndElement_;
+  }
+
+  /**
+   * Must be called in mutate context
+   */
+  setLoadMoreEnded() {
+    this.getLoadMoreFailedElement().classList.toggle('amp-visible', false);
+    this.getLoadMoreButton().classList.toggle('amp-visible', false);
+    this.getLoadMoreLoadingElement().classList.toggle('amp-visible', false);
+    const loadMoreEndElement = this.getLoadMoreEndElement();
+    if (loadMoreEndElement) {
+      loadMoreEndElement.classList.toggle('amp-visible', true);
+    }
+  }
+  /**
+   * Toggles the visibility of the load-more-loading element. Must be called
+   * in mutate context.
+   * @param {boolean} state
+   */
+  toggleLoadMoreLoading(state) {
+    // If it's loading, then it's no longer failed or ended
+    if (state) {
+      this.getLoadMoreFailedElement().classList.toggle('amp-visible', false);
+    }
+    const loadMoreEndElement = this.getLoadMoreEndElement();
+    if (loadMoreEndElement) {
+      loadMoreEndElement.classList.toggle('amp-visible', false);
+    }
+    this.getLoadMoreButton().classList.toggle('amp-visible', !state);
+    this.getLoadMoreLoadingElement().classList.toggle('amp-visible', state);
+  }
+
+  /**
+   * Shows the load-more-failed element and hides the load-more-button
+   * element.
+   */
+  setLoadMoreFailed() {
+    const loadMoreFailedElement = this.getLoadMoreFailedElement();
+    const loadMoreButton = this.getLoadMoreButton();
+    if (!loadMoreFailedElement && !loadMoreButton) {
+      return;
+    }
+    loadMoreFailedElement.classList.toggle('amp-visible', true);
+    loadMoreButton.classList.toggle('amp-visible', false);
+    this.getLoadMoreLoadingElement().classList.toggle('amp-visible', false);
+  }
+
+  /**
+   * Hide all load-more elements during reset.
+   */
+  hideAllLoadMoreElements() {
+    this.getLoadMoreButton().classList.toggle('amp-visible', false);
+    this.getLoadMoreLoadingElement().classList.toggle('amp-visible', false);
+    this.getLoadMoreFailedElement().classList.toggle('amp-visible', false);
+    if (this.getLoadMoreEndElement()) {
+      this.getLoadMoreEndElement().classList.toggle('amp-visible', false);
+    }
+  }
+}

--- a/extensions/amp-list/0.2/test-e2e/test-load-more-auto.js
+++ b/extensions/amp-list/0.2/test-e2e/test-load-more-auto.js
@@ -1,0 +1,82 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const pageWidth = 800;
+const pageHeight = 420; // unusually small to force a scrollbar
+
+describes.endtoend(
+  'AMP list load-more=auto',
+  {
+    testUrl:
+      'http://localhost:8000/test/manual/amp-list/load-more-auto.amp.html',
+    initialRect: {width: pageWidth, height: pageHeight},
+    // TODO(cathyxz, cvializ): figure out why 'viewer' only shows 'FALLBACK'
+    // TODO(cathyxz): figure out why shadow-demo doesn't work
+    environments: ['single'],
+  },
+  env => {
+    let controller;
+
+    beforeEach(async () => {
+      controller = env.controller;
+    });
+
+    // TODO(cathyxz): flaky in single env
+    it.skip('should render correctly', async () => {
+      const listItems = await controller.findElements('.item');
+      await expect(listItems).to.have.length(2);
+
+      const loader = await controller.findElement('[load-more-loading]');
+      await expect(loader).to.be.ok;
+      await expect(controller.getElementCssValue(loader, 'display')).to.equal(
+        'none'
+      );
+
+      const failedIndicator = await controller.findElement(
+        '[load-more-failed]'
+      );
+      await expect(failedIndicator).to.be.ok;
+      await expect(
+        controller.getElementCssValue(failedIndicator, 'display')
+      ).to.equal('none');
+
+      const seeMore = await controller.findElement('[load-more-button]');
+      await expect(seeMore).to.be.ok;
+      await expect(
+        controller.getElementCssValue(seeMore, 'visibility')
+      ).to.equal('visible');
+      await expect(controller.getElementCssValue(seeMore, 'display')).to.equal(
+        'block'
+      );
+    });
+
+    it.skip('should load more items on scroll', async () => {
+      let listItems = await controller.findElements('.item');
+      await expect(listItems).to.have.length(2);
+
+      // wait for load more to be ready?
+      await controller.findElement('[load-more-button]');
+
+      const article = await controller.getDocumentElement();
+      await controller.scrollBy(article, {top: 100});
+
+      const fourthItem = await controller.findElement('div.item:nth-child(4)');
+      await expect(fourthItem).to.be.ok;
+      listItems = await controller.findElements('.item');
+      await expect(listItems).to.have.length(4);
+    });
+  }
+);

--- a/extensions/amp-list/0.2/test-e2e/test-load-more-manual.js
+++ b/extensions/amp-list/0.2/test-e2e/test-load-more-manual.js
@@ -1,0 +1,100 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const pageWidth = 600;
+const pageHeight = 600;
+
+describes.endtoend(
+  'AMP list load-more=manual',
+  {
+    testUrl:
+      'http://localhost:8000/test/manual/amp-list/' +
+      'load-more-manual.amp.html',
+    initialRect: {width: pageWidth, height: pageHeight},
+    // TODO(cathyxz, cvializ): figure out why 'viewer-demo' only shows 'FALLBACK'
+    environments: ['single'],
+  },
+  async env => {
+    let controller;
+
+    beforeEach(async () => {
+      controller = env.controller;
+    });
+
+    it('should render correctly', async () => {
+      const listItems = await controller.findElements('.item');
+      await expect(listItems).to.have.length(2);
+      const seeMore = await controller.findElement('[load-more-button]');
+
+      // Can we assert its CSS be visible and display block?
+      await expect(seeMore).to.be.ok;
+
+      await expect(
+        controller.getElementCssValue(seeMore, 'visibility')
+      ).to.equal('visible');
+      await expect(controller.getElementCssValue(seeMore, 'display')).to.equal(
+        'block'
+      );
+
+      const loader = await controller.findElement('[load-more-loading]');
+      await expect(loader).to.be.ok;
+
+      await expect(controller.getElementCssValue(loader, 'display')).to.equal(
+        'none'
+      );
+
+      const failedIndicator = await controller.findElement(
+        '[load-more-failed]'
+      );
+      await expect(failedIndicator).to.be.ok;
+      await expect(
+        controller.getElementCssValue(failedIndicator, 'display')
+      ).to.equal('none');
+    });
+
+    it('should load more items on click', async () => {
+      let listItems = await controller.findElements('.item');
+      await expect(listItems).to.have.length(2);
+      const seeMore = await controller.findElement('[load-more-button]');
+
+      await controller.click(seeMore);
+
+      const fourthItem = await controller.findElement('div.item:nth-child(4)');
+      await expect(fourthItem).to.be.ok;
+      listItems = await controller.findElements('.item');
+      await expect(listItems).to.have.length(4);
+    });
+
+    it('should show load-more-end when done', async () => {
+      const seeMore = await controller.findElement('[load-more-button]');
+      await controller.click(seeMore);
+      await controller.findElement('div.item:nth-child(4)');
+
+      const loadMoreEnd = await controller.findElement('[load-more-end]');
+      await expect(
+        controller.getElementCssValue(loadMoreEnd, 'display')
+      ).to.equal('block');
+
+      await expect(controller.getElementCssValue(seeMore, 'display')).to.equal(
+        'none'
+      );
+      const loader = await controller.findElement('[load-more-loading]');
+      await expect(controller.getElementCssValue(loader, 'display')).to.equal(
+        'none'
+      );
+    });
+  }
+);

--- a/extensions/amp-list/0.2/test-e2e/test-ssr.js
+++ b/extensions/amp-list/0.2/test-e2e/test-ssr.js
@@ -1,0 +1,85 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+describes.endtoend(
+  'amp-list SSR templates',
+  {
+    testUrl: 'http://localhost:8000/test/fixtures/e2e/amp-list/amp-list.html',
+    environments: ['viewer-demo'],
+  },
+  async env => {
+    let controller;
+
+    beforeEach(async () => {
+      controller = env.controller;
+    });
+
+    // TODO(estherkim): fails in viewer
+    it.configure()
+      .skipViewerDemo()
+      .run('should render ssr rendered list', async function() {
+        const container = await getListContainer(controller);
+        await verifyContainer(controller, container);
+
+        // Verify that all items rendered.
+        const listItems = await getListItems(controller);
+        await expect(listItems).to.have.length(6);
+
+        // Verify that bindings work.
+        await expect(controller.getElementText(listItems[0])).to.equal(
+          'Pineapple'
+        );
+      });
+  }
+);
+
+describes.endtoend(
+  'amp-list',
+  {
+    testUrl: 'http://localhost:8000/test/fixtures/e2e/amp-list/amp-list.html',
+    environments: ['single'],
+  },
+  async env => {
+    let controller;
+
+    beforeEach(async () => {
+      controller = env.controller;
+    });
+
+    it('should render list', async function() {
+      const container = await getListContainer(controller);
+      await verifyContainer(controller, container);
+
+      // Verify that all items rendered.
+      const listItems = await getListItems(controller);
+      await expect(listItems).to.have.length(5);
+    });
+  }
+);
+
+function getListContainer(controller) {
+  return controller.findElement('div[role=list]');
+}
+
+function getListItems(controller) {
+  return controller.findElements('div[role=listitem]');
+}
+
+async function verifyContainer(controller, container) {
+  await expect(controller.getElementAttribute(container, 'class')).to.equal(
+    'i-amphtml-fill-content i-amphtml-replaced-content'
+  );
+}

--- a/extensions/amp-list/0.2/test/integration/test-amp-list.js
+++ b/extensions/amp-list/0.2/test/integration/test-amp-list.js
@@ -1,0 +1,105 @@
+/**
+ * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {BrowserController} from '../../../../../testing/test-helper';
+
+const TIMEOUT = 15000;
+
+describe('amp-list (integration)', function() {
+  this.timeout(TIMEOUT);
+
+  const basicBody = `<amp-list width=300 height=100 src="http://localhost:9876/list/fruit-data/get?cors=0">
+      <template type="amp-mustache">
+        {{name}} : {{quantity}} @ {{unitPrice}}
+      </template>
+    '</amp-list>`;
+
+  const scriptTemplateBody = `<amp-list width=300 height=100 src="http://localhost:9876/list/fruit-data/get?cors=0">
+    <script type="text/plain" template="amp-mustache">
+      {{name}} : {{quantity}} @ {{unitPrice}}
+    </script>
+  '</amp-list>`;
+
+  const basicTests = env => {
+    let browser;
+    let doc;
+    let win;
+
+    beforeEach(() => {
+      win = env.win;
+      browser = new BrowserController(win);
+      doc = win.document;
+    });
+
+    it('should build', function*() {
+      const list = doc.querySelector('amp-list');
+      expect(list).to.exist;
+      yield browser.waitForElementBuild('amp-list', TIMEOUT);
+      const container = list.querySelector('div[role="list"]');
+      expect(container).to.exist;
+    });
+
+    // TODO(choumx): Frequent 10s timeout on Chrome 72.0.3626 (Linux 0.0.0).
+    it.skip('should render items', function*() {
+      const list = doc.querySelector('amp-list');
+      expect(list).to.exist;
+
+      yield browser.waitForElementLayout('amp-list', TIMEOUT);
+
+      const children = list.querySelectorAll('div[role=list] > div');
+      expect(children.length).to.equal(3);
+      expect(children[0].textContent.trim()).to.equal('apple : 47 @ 0.33');
+      expect(children[1].textContent.trim()).to.equal('pear : 538 @ 0.54');
+      expect(children[2].textContent.trim()).to.equal('tomato : 0 @ 0.23');
+    });
+  };
+
+  describes.integration(
+    'basic (mustache-0.1)',
+    {
+      body: basicBody,
+      extensions: ['amp-list', 'amp-mustache:0.1'],
+    },
+    basicTests
+  );
+
+  describes.integration(
+    'basic (mustache-0.2)',
+    {
+      body: basicBody,
+      extensions: ['amp-list', 'amp-mustache:0.2'],
+    },
+    basicTests
+  );
+
+  describes.integration(
+    'basic (mustache-0.1) script template',
+    {
+      body: scriptTemplateBody,
+      extensions: ['amp-list', 'amp-mustache:0.1'],
+    },
+    basicTests
+  );
+
+  describes.integration(
+    'basic (mustache-0.2) script template',
+    {
+      body: scriptTemplateBody,
+      extensions: ['amp-list', 'amp-mustache:0.2'],
+    },
+    basicTests
+  );
+});

--- a/extensions/amp-list/0.2/test/test-amp-list-container.js
+++ b/extensions/amp-list/0.2/test/test-amp-list-container.js
@@ -1,0 +1,97 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {AmpDocService} from '../../../../src/service/ampdoc-impl';
+import {AmpList} from '../amp-list';
+import {Services} from '../../../../src/services';
+import {
+  measureElementStub,
+  measureMutateElementStub,
+  mutateElementStub,
+} from '../../../../testing/test-helper';
+
+describes.realWin(
+  'amp-list layout container',
+  {
+    amp: {
+      ampdoc: 'single',
+      extensions: ['amp-list'],
+    },
+  },
+  env => {
+    let win;
+    let doc;
+    let ampdoc;
+    let element, list;
+    let templates;
+
+    beforeEach(() => {
+      win = env.win;
+      doc = win.document;
+      ampdoc = env.ampdoc;
+
+      templates = {
+        findAndSetHtmlForTemplate: env.sandbox.stub(),
+        findAndRenderTemplate: env.sandbox.stub(),
+        findAndRenderTemplateArray: env.sandbox.stub(),
+      };
+      env.sandbox.stub(Services, 'templatesFor').returns(templates);
+      env.sandbox.stub(AmpDocService.prototype, 'getAmpDoc').returns(ampdoc);
+
+      element = doc.createElement('amp-list');
+      list = new AmpList(element);
+
+      env.sandbox.stub(list, 'getAmpDoc').returns(ampdoc);
+      env.sandbox.stub(list, 'getFallback').returns(null);
+
+      env.sandbox.stub(list, 'mutateElement').callsFake(mutateElementStub);
+      env.sandbox.stub(list, 'measureElement').callsFake(measureElementStub);
+      env.sandbox
+        .stub(list, 'measureMutateElement')
+        .callsFake(measureMutateElementStub);
+      element.setAttribute('src', '/list');
+      element.setAttribute('layout', 'fixed');
+      element.setAttribute('width', '50');
+      element.setAttribute('height', '10');
+      doc.body.appendChild(element);
+
+      env.sandbox.stub(list, 'getOverflowElement').returns(null);
+      env.sandbox.stub(list, 'fetchList_').returns(Promise.resolve());
+      list.element.changeSize = () => {};
+      list.buildCallback();
+    });
+
+    it('should change to layout container', async () => {
+      await list.layoutCallback();
+      await list.changeToLayoutContainer_();
+      expect(element.style.height).to.equal('');
+      expect(element.getAttribute('layout')).to.equal('container');
+      expect(element.classList.contains('i-amphtml-layout-container')).to.be
+        .true;
+      const containerClasses = list.container_.classList;
+      expect(containerClasses.contains('i-amphtml-fill-content')).to.be.false;
+      expect(containerClasses.contains('i-amphtml-replaced-content')).to.be
+        .false;
+    });
+
+    it('should trigger on bind', async () => {
+      const changeSpy = env.sandbox.spy(list, 'changeToLayoutContainer_');
+      await list.layoutCallback();
+      await list.mutatedAttributesCallback({'is-layout-container': true});
+      expect(changeSpy).to.be.calledOnce;
+    });
+  }
+);

--- a/extensions/amp-list/0.2/test/test-amp-list-load-more.js
+++ b/extensions/amp-list/0.2/test/test-amp-list-load-more.js
@@ -1,0 +1,259 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {AmpDocService} from '../../../../src/service/ampdoc-impl';
+import {AmpList} from '../amp-list';
+import {Services} from '../../../../src/services';
+import {
+  measureElementStub,
+  measureMutateElementStub,
+  mutateElementStub,
+} from '../../../../testing/test-helper';
+
+const HAS_MORE_ITEMS_PAYLOAD = {
+  'items': ['1', '2'],
+  'load-more-src': '/list/infinite-scroll?items=2&left=0',
+};
+
+describes.realWin(
+  'amp-list with load-more',
+  {
+    amp: {
+      ampdoc: 'single',
+      extensions: ['amp-list'],
+    },
+  },
+  env => {
+    let win;
+    let doc;
+    let ampdoc;
+    let element, list;
+    let templates;
+
+    beforeEach(() => {
+      win = env.win;
+      doc = win.document;
+      ampdoc = env.ampdoc;
+
+      templates = {
+        findAndSetHtmlForTemplate: env.sandbox.stub(),
+        findAndRenderTemplate: env.sandbox.stub(),
+        findAndRenderTemplateArray: env.sandbox.stub(),
+      };
+      env.sandbox.stub(Services, 'templatesFor').returns(templates);
+      env.sandbox.stub(AmpDocService.prototype, 'getAmpDoc').returns(ampdoc);
+    });
+
+    describe('manual', () => {
+      beforeEach(() => {
+        element = doc.createElement('amp-list');
+        list = new AmpList(element);
+
+        env.sandbox.stub(list, 'getAmpDoc').returns(ampdoc);
+        env.sandbox.stub(list, 'getFallback').returns(null);
+
+        env.sandbox.stub(list, 'mutateElement').callsFake(mutateElementStub);
+        env.sandbox.stub(list, 'measureElement').callsFake(measureElementStub);
+        env.sandbox
+          .stub(list, 'measureMutateElement')
+          .callsFake(measureMutateElementStub);
+
+        element.setAttribute('src', '/list/infinite-scroll?items=2&left=1');
+        element.setAttribute('load-more', 'manual');
+        element.setAttribute('layout', 'fixed');
+        element.setAttribute('width', '50');
+        element.setAttribute('height', '10');
+
+        element.style.height = '10px';
+        doc.body.appendChild(element);
+
+        env.sandbox.stub(list, 'getOverflowElement').returns(null);
+        env.sandbox.stub(list, 'fetchList_').returns(Promise.resolve());
+        list.element.changeSize = () => {};
+        list.buildCallback();
+      });
+
+      it('should create load-more elements after init', async () => {
+        env.sandbox.stub(list, 'getPlaceholder').returns(null);
+        await list.initializeLoadMoreElements_();
+
+        expect(
+          list.element.querySelectorAll('[load-more-button]')
+        ).to.have.lengthOf(1);
+        expect(
+          list.element.querySelectorAll('[load-more-failed]')
+        ).to.have.lengthOf(1);
+        expect(list.element.querySelector('[load-more-end]')).to.be.null;
+      });
+
+      it('should hide load-more-button after init', async () => {
+        env.sandbox.stub(list, 'getPlaceholder').returns(null);
+        await list.initializeLoadMoreElements_();
+
+        const button = list.element.querySelector('[load-more-button]');
+        const buttonStyles = win.getComputedStyle(button);
+        expect(buttonStyles).include({
+          'display': 'block',
+          'visibility': 'hidden',
+        });
+      });
+
+      it('should hide load-more-failed element after init', async () => {
+        env.sandbox.stub(list, 'getPlaceholder').returns(null);
+        await list.initializeLoadMoreElements_();
+
+        const failedElement = list.element.querySelector('[load-more-failed]');
+        const failedStyles = win.getComputedStyle(failedElement);
+        expect(failedStyles.display).to.equal('none');
+      });
+
+      it('should hide load-more-loading element after init', async () => {
+        env.sandbox.stub(list, 'getPlaceholder').returns(null);
+        await list.initializeLoadMoreElements_();
+
+        const loader = list.element.querySelector('[load-more-loading]');
+        const loaderStyles = win.getComputedStyle(loader);
+        expect(loaderStyles.display).to.equal('none');
+      });
+
+      it('should resize the list to fit a placeholder', async () => {
+        const attemptChangeHeightSpy = env.sandbox.spy(
+          list,
+          'attemptChangeHeight'
+        );
+        const placeholder = doc.createElement('div');
+        placeholder.setAttribute('placeholder', '');
+        placeholder.style.height = '50px';
+        placeholder.style.width = '50px';
+        list.element.appendChild(placeholder);
+        env.sandbox.stub(list, 'getPlaceholder').returns(placeholder);
+        await list.layoutCallback();
+        expect(attemptChangeHeightSpy).to.be.calledOnceWith(50);
+      });
+    });
+
+    describe('loading states', () => {
+      beforeEach(() => {
+        element = doc.createElement('amp-list');
+        list = new AmpList(element);
+
+        env.sandbox.stub(list, 'getAmpDoc').returns(ampdoc);
+        env.sandbox.stub(list, 'getFallback').returns(null);
+
+        env.sandbox.stub(list, 'mutateElement').callsFake(mutateElementStub);
+        env.sandbox.stub(list, 'measureElement').callsFake(measureElementStub);
+        env.sandbox
+          .stub(list, 'measureMutateElement')
+          .callsFake(measureMutateElementStub);
+
+        element.setAttribute('src', '/list/infinite-scroll?items=2&left=1');
+        element.setAttribute('load-more', 'manual');
+        element.setAttribute('layout', 'fixed');
+        element.setAttribute('width', '50');
+        element.setAttribute('height', '10');
+        element.style.height = '10px';
+        doc.body.appendChild(element);
+
+        env.sandbox.stub(list, 'getOverflowElement').returns(null);
+        env.sandbox
+          .stub(list, 'prepareAndSendFetch_')
+          .returns(Promise.resolve(HAS_MORE_ITEMS_PAYLOAD));
+        list.element.changeSize = () => {};
+        list.buildCallback();
+      });
+
+      it('should update the next loading src', async () => {
+        env.sandbox.stub(list, 'scheduleRender_').returns(Promise.resolve());
+        await list.layoutCallback();
+        expect(element.getAttribute('src')).to.equal(
+          '/list/infinite-scroll?items=2&left=1'
+        );
+        await list.loadMoreCallback_();
+        expect(element.getAttribute('src')).to.equal(
+          '/list/infinite-scroll?items=2&left=0'
+        );
+      });
+
+      it('should append items to the existing list', async () => {
+        const div1 = doc.createElement('div');
+        div1.textContent = '1';
+
+        const div2 = doc.createElement('div');
+        div2.textContent = '2';
+        env.sandbox
+          .stub(list.ssrTemplateHelper_, 'applySsrOrCsrTemplate')
+          .returns(Promise.resolve([]));
+        const updateBindingsStub = env.sandbox.stub(list, 'updateBindings_');
+        env.sandbox
+          .stub(list, 'maybeRenderLoadMoreTemplates_')
+          .returns(Promise.resolve([]));
+        updateBindingsStub.onCall(0).returns(Promise.resolve([div1, div2]));
+
+        const div3 = doc.createElement('div');
+        div3.textContent = '3';
+        const div4 = doc.createElement('div');
+        div4.textContent = '4';
+        updateBindingsStub.onCall(1).returns(Promise.resolve([div3, div4]));
+
+        const renderSpy = env.sandbox.spy(list, 'render_');
+        await list.layoutCallback();
+        expect(renderSpy).to.be.calledOnce;
+        expect(renderSpy).to.be.calledWith([div1, div2], false);
+        expect(list.container_.children).to.have.lengthOf(2);
+
+        await list.loadMoreCallback_();
+        expect(renderSpy).to.be.calledTwice;
+        expect(renderSpy).to.be.calledWith([div3, div4], true);
+
+        list.container_;
+        expect(list.container_.children).to.have.lengthOf(4);
+      });
+
+      // TODO(cathyxz) Create a mirror test for automatic amp-list loading once the automatic tests are unskipped
+      it('should call focus on the last element after load more is clicked', async () => {
+        env.sandbox
+          .stub(list.ssrTemplateHelper_, 'applySsrOrCsrTemplate')
+          .returns(Promise.resolve([]));
+        const updateBindingsStub = env.sandbox.stub(list, 'updateBindings_');
+        env.sandbox
+          .stub(list, 'maybeRenderLoadMoreTemplates_')
+          .returns(Promise.resolve([]));
+
+        const div1 = doc.createElement('div');
+        div1.textContent = '1';
+        const div2 = doc.createElement('div');
+        div2.textContent = '2';
+        updateBindingsStub.onCall(0).returns(Promise.resolve([div1, div2]));
+        const focusSpy = env.sandbox.spy(div2, 'focus');
+
+        await list.layoutCallback();
+
+        const div3 = doc.createElement('div');
+        div3.textContent = '3';
+        const div4 = doc.createElement('div');
+        div4.textContent = '4';
+        updateBindingsStub.onCall(1).returns(Promise.resolve([div3, div4]));
+
+        await list.loadMoreCallback_(
+          /* opt_reload */ false,
+          /* opt_fromClick */ true
+        );
+
+        await expect(focusSpy).to.have.been.called;
+      });
+    });
+  }
+);

--- a/extensions/amp-list/0.2/test/test-amp-list.js
+++ b/extensions/amp-list/0.2/test/test-amp-list.js
@@ -1,0 +1,1289 @@
+/**
+ * Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {ActionTrust} from '../../../../src/action-constants';
+import {AmpDocService} from '../../../../src/service/ampdoc-impl';
+import {AmpEvents} from '../../../../src/amp-events';
+import {AmpList} from '../amp-list';
+import {Deferred} from '../../../../src/utils/promise';
+import {Services} from '../../../../src/services';
+import {
+  resetExperimentTogglesForTesting,
+  toggleExperiment,
+} from '../../../../src/experiments';
+
+describes.repeated(
+  'amp-list',
+  {
+    'with script[type=text/plain][template=amp-mustache]': {
+      templateType: 'script',
+    },
+    'with template[type=amp-mustache]': {templateType: 'template'},
+  },
+  (name, variant) => {
+    describes.realWin(
+      '<amp-list>',
+      {
+        amp: {
+          ampdoc: 'single',
+          extensions: ['amp-list'],
+        },
+        runtimeOn: false,
+      },
+      env => {
+        let win, doc, ampdoc;
+        let element, list, listMock;
+        let resource, resources;
+        let setBindService;
+        let ssrTemplateHelper;
+        let templates;
+
+        beforeEach(() => {
+          win = env.win;
+          doc = win.document;
+          ampdoc = env.ampdoc;
+
+          templates = {
+            findAndSetHtmlForTemplate: env.sandbox.stub(),
+            findAndRenderTemplate: env.sandbox.stub(),
+            findAndRenderTemplateArray: env.sandbox.stub(),
+          };
+          env.sandbox.stub(Services, 'templatesFor').returns(templates);
+          env.sandbox
+            .stub(AmpDocService.prototype, 'getAmpDoc')
+            .returns(ampdoc);
+
+          resource = {
+            resetPendingChangeSize: env.sandbox.stub(),
+          };
+          resources = {
+            getResourceForElement: e => (e === element ? resource : null),
+          };
+
+          element = createAmpListElement();
+
+          const {templateType} = variant;
+          const template = doc.createElement(templateType);
+
+          if (templateType == 'template') {
+            template.content.appendChild(doc.createTextNode('{{template}}'));
+          } else {
+            template.setAttribute('type', 'text/plain');
+            template.setAttribute('template', 'amp-mustache');
+            template.innerText = '{{template}}';
+          }
+
+          element.appendChild(template);
+
+          const {promise, resolve} = new Deferred();
+          env.sandbox.stub(Services, 'bindForDocOrNull').returns(promise);
+          setBindService = resolve;
+
+          ssrTemplateHelper = {
+            isEnabled: () => false,
+            ssr: () => Promise.resolve(),
+            applySsrOrCsrTemplate: env.sandbox.stub(),
+          };
+
+          list = createAmpList(element);
+
+          element.style.height = '10px';
+          doc.body.appendChild(element);
+        });
+
+        afterEach(() => {
+          // There should only be one mock to verify.
+          listMock.verify();
+        });
+
+        function createAmpListElement() {
+          const element = doc.createElement('div');
+          element.setAttribute('src', 'https://data.com/list.json');
+          element.getAmpDoc = () => ampdoc;
+          element.getFallback = () => null;
+          element.getPlaceholder = () => null;
+          element.getResources = () => resources;
+          return element;
+        }
+
+        function createAmpList(element) {
+          const list = new AmpList(element);
+          list.buildCallback();
+          list.ssrTemplateHelper_ = ssrTemplateHelper;
+          listMock = env.sandbox.mock(list);
+          return list;
+        }
+
+        const DEFAULT_LIST_OPTS = {
+          expr: 'items',
+          maxItems: 0,
+          singleItem: false,
+          refresh: false,
+          resetOnRefresh: false,
+        };
+        const DEFAULT_ITEMS = [{title: 'Title1'}];
+        const DEFAULT_FETCHED_DATA = {
+          items: DEFAULT_ITEMS,
+        };
+
+        /**
+         * @param {!Array|!Object} fetched
+         * @param {!Array<!Element>} rendered
+         * @param {Object=} opts
+         * @return {!Promise}
+         */
+        function expectFetchAndRender(
+          fetched,
+          rendered,
+          opts = DEFAULT_LIST_OPTS
+        ) {
+          // Mock the actual network request.
+          listMock
+            .expects('fetch_')
+            .withExactArgs(!!opts.refresh, /* token */ undefined)
+            .returns(Promise.resolve(fetched))
+            .atLeast(1);
+
+          // If "reset-on-refresh" is set, show loading/placeholder before fetch.
+          if (opts.resetOnRefresh) {
+            listMock
+              .expects('togglePlaceholder')
+              .withExactArgs(true)
+              .once();
+            listMock
+              .expects('toggleLoading')
+              .withExactArgs(true, true)
+              .once();
+          }
+
+          // Stub the rendering of the template.
+          let itemsToRender = fetched[opts.expr];
+          if (opts.singleItem) {
+            expect(itemsToRender).to.be.a('object');
+            itemsToRender = [fetched[opts.expr]];
+          } else if (opts.maxItems > 0) {
+            itemsToRender = fetched[opts.expr].slice(0, opts.maxItems);
+          }
+          ssrTemplateHelper.applySsrOrCsrTemplate
+            .withArgs(element, itemsToRender)
+            .returns(Promise.resolve(rendered));
+
+          expectRender();
+        }
+
+        function expectRender() {
+          // Call mutate/measure during render.
+          listMock
+            .expects('mutateElement')
+            .callsFake(m => m())
+            .atLeast(1);
+          listMock
+            .expects('measureElement')
+            .callsFake(m => m())
+            .atLeast(1);
+
+          // Hide loading/placeholder during render.
+          listMock
+            .expects('toggleLoading')
+            .withExactArgs(false)
+            .atLeast(1);
+          listMock
+            .expects('togglePlaceholder')
+            .withExactArgs(false)
+            .atLeast(1);
+        }
+
+        describe('without amp-bind', () => {
+          beforeEach(() => {
+            setBindService(null);
+          });
+
+          it('should fetch and render', () => {
+            const itemElem = doc.createElement('div');
+            const rendered = expectFetchAndRender(DEFAULT_FETCHED_DATA, [
+              itemElem,
+            ]);
+            return list
+              .layoutCallback()
+              .then(() => rendered)
+              .then(() => {
+                expect(list.container_.contains(itemElem)).to.be.true;
+              });
+          });
+
+          it('should reset pending change-size request after render', function*() {
+            const itemElement = doc.createElement('div');
+            const rendered = expectFetchAndRender(DEFAULT_FETCHED_DATA, [
+              itemElement,
+            ]);
+            yield list.layoutCallback();
+            yield rendered;
+            expect(resource.resetPendingChangeSize).calledOnce;
+          });
+
+          it('should attemptChangeHeight placeholder, if present', () => {
+            const itemElement = doc.createElement('div');
+            const placeholder = doc.createElement('div');
+            placeholder.style.height = '1337px';
+            element.appendChild(placeholder);
+            element.getPlaceholder = () => placeholder;
+
+            expectFetchAndRender(DEFAULT_FETCHED_DATA, [itemElement]);
+
+            listMock
+              .expects('attemptChangeHeight')
+              .withExactArgs(1337)
+              .returns(Promise.resolve());
+
+            return list.layoutCallback();
+          });
+
+          it('should attemptChangeHeight rendered contents', () => {
+            const itemElement = doc.createElement('div');
+            itemElement.style.height = '1337px';
+
+            expectFetchAndRender(DEFAULT_FETCHED_DATA, [itemElement]);
+
+            listMock
+              .expects('attemptChangeHeight')
+              .withExactArgs(1337)
+              .returns(Promise.resolve());
+
+            return list.layoutCallback().then(() => {
+              expect(list.container_.contains(itemElement)).to.be.true;
+            });
+          });
+
+          it('should fetch and render non-array if single-item is set', () => {
+            const fetched = {'items': {title: 'Title1'}};
+            const itemElement = doc.createElement('div');
+            element.setAttribute('single-item', 'true');
+
+            const rendered = expectFetchAndRender(fetched, [itemElement], {
+              expr: 'items',
+              singleItem: true,
+            });
+
+            return list
+              .layoutCallback()
+              .then(() => rendered)
+              .then(() => {
+                expect(list.container_.contains(itemElement)).to.be.true;
+              });
+          });
+
+          it('should trim the results to max-items', () => {
+            const fetched = {
+              items: [{title: 'Title1'}, {title: 'Title2'}, {title: 'Title3'}],
+            };
+            const itemElement = doc.createElement('div');
+            element.setAttribute('max-items', '2');
+
+            expectFetchAndRender(fetched, [itemElement], {
+              expr: 'items',
+              maxItems: 2,
+            });
+
+            return list.layoutCallback().then(() => {
+              expect(list.container_.contains(itemElement)).to.be.true;
+            });
+          });
+
+          it('should dispatch DOM_UPDATE event after render', () => {
+            const spy = env.sandbox.spy(list.container_, 'dispatchEvent');
+
+            const itemElement = doc.createElement('div');
+            expectFetchAndRender(DEFAULT_FETCHED_DATA, [itemElement]);
+
+            return list.layoutCallback().then(() => {
+              expect(spy).to.have.been.calledOnce;
+              expect(spy).calledWithMatch({
+                type: AmpEvents.DOM_UPDATE,
+                bubbles: true,
+              });
+            });
+          });
+
+          it('should resize with viewport', () => {
+            const resize = env.sandbox.spy(list, 'attemptToFit_');
+            list.layoutCallback().then(() => {
+              list.viewport_.resize_();
+              expect(resize).to.have.been.called;
+            });
+          });
+
+          // TODO(choumx, #14772): Flaky.
+          it.skip('should only process one result at a time for rendering', () => {
+            const doRenderPassSpy = env.sandbox.spy(list, 'doRenderPass_');
+            const scheduleRenderSpy = env.sandbox.spy(
+              list.renderPass_,
+              'schedule'
+            );
+
+            const items = [{title: 'foo'}];
+            const foo = doc.createElement('div');
+            expectFetchAndRender(items, [foo]);
+            const layout = list.layoutCallback();
+
+            // Execute another fetch-triggering action immediately (actually on
+            // the next tick to avoid losing the layoutCallback() promise resolver).
+            Promise.resolve().then(() => {
+              element.setAttribute('src', 'https://new.com/list.json');
+              list.mutatedAttributesCallback({
+                'src': 'https://new.com/list.json',
+              });
+            });
+            // TODO(#14772): this expectation is sometimes not met.
+            listMock
+              .expects('toggleLoading')
+              .withExactArgs(false)
+              .once();
+            listMock
+              .expects('togglePlaceholder')
+              .withExactArgs(false)
+              .once();
+
+            return layout.then(() => {
+              expect(list.container_.contains(foo)).to.be.true;
+
+              // Only one render pass should be invoked at a time.
+              expect(doRenderPassSpy).to.be.calledOnce;
+              // But the next render pass should be scheduled.
+              expect(scheduleRenderSpy).to.be.calledTwice;
+              expect(scheduleRenderSpy).to.be.calledWith(1);
+            });
+          });
+
+          it('should refetch if refresh action is called', () => {
+            const foo = doc.createElement('div');
+            expectFetchAndRender(DEFAULT_FETCHED_DATA, [foo]);
+
+            return list.layoutCallback().then(() => {
+              expect(list.container_.contains(foo)).to.be.true;
+
+              expectFetchAndRender(DEFAULT_FETCHED_DATA, [foo], {
+                refresh: true,
+                expr: 'items',
+              });
+
+              return list.executeAction({
+                method: 'refresh',
+                satisfiesTrust: () => true,
+              });
+            });
+          });
+
+          it('should reset on refresh if `reset-on-refresh` is set', () => {
+            element.setAttribute('reset-on-refresh', '');
+            const foo = doc.createElement('div');
+            expectFetchAndRender(DEFAULT_FETCHED_DATA, [foo]);
+
+            return list.layoutCallback().then(() => {
+              expect(list.container_.contains(foo)).to.be.true;
+
+              const opts = {refresh: true, resetOnRefresh: true, expr: 'items'};
+              expectFetchAndRender(DEFAULT_FETCHED_DATA, [foo], opts);
+
+              return list.executeAction({
+                method: 'refresh',
+                satisfiesTrust: () => true,
+              });
+            });
+          });
+
+          it('fetch should resolve if `src` is empty', () => {
+            const spy = env.sandbox.spy(list, 'fetchList_');
+            element.setAttribute('src', '');
+            return list.layoutCallback().then(() => {
+              expect(spy).to.be.called;
+            });
+          });
+
+          it('should fail to load b/c data array is absent', () => {
+            expectAsyncConsoleError(/Response must contain an array/, 1);
+            listMock
+              .expects('fetch_')
+              .returns(Promise.resolve({}))
+              .once();
+            listMock
+              .expects('toggleLoading')
+              .withExactArgs(false)
+              .once();
+            return expect(list.layoutCallback()).to.eventually.be.rejectedWith(
+              /Response must contain an array/
+            );
+          });
+
+          it('should fail to load b/c data single-item object is absent', () => {
+            expectAsyncConsoleError(
+              /Response must contain an array or object/,
+              1
+            );
+            element.setAttribute('single-item', 'true');
+            listMock
+              .expects('fetch_')
+              .returns(Promise.resolve())
+              .once();
+            listMock
+              .expects('toggleLoading')
+              .withExactArgs(false)
+              .once();
+            return expect(list.layoutCallback()).to.eventually.be.rejectedWith(
+              /Response must contain an array or object/
+            );
+          });
+
+          it('should load and render with a different root', () => {
+            const items = {different: [{title: 'Title1'}]};
+            const itemElement = doc.createElement('div');
+            element.setAttribute('items', 'different');
+            expectFetchAndRender(items, [itemElement], {expr: 'different'});
+
+            return list.layoutCallback().then(() => {
+              expect(list.container_.contains(itemElement)).to.be.true;
+            });
+          });
+
+          it('should set accessibility roles', () => {
+            const itemElement = doc.createElement('div');
+            expectFetchAndRender(DEFAULT_FETCHED_DATA, [itemElement]);
+
+            return list.layoutCallback().then(() => {
+              expect(list.container_.getAttribute('role')).to.equal('list');
+              expect(itemElement.getAttribute('role')).to.equal('listitem');
+            });
+          });
+
+          it('should preserve accessibility roles', () => {
+            element.setAttribute('role', 'list1');
+            const itemElement = doc.createElement('div');
+            itemElement.setAttribute('role', 'listitem1');
+            expectFetchAndRender(DEFAULT_FETCHED_DATA, [itemElement]);
+
+            return list.layoutCallback().then(() => {
+              expect(list.element.getAttribute('role')).to.equal('list1');
+              expect(itemElement.getAttribute('role')).to.equal('listitem1');
+            });
+          });
+
+          it('should set tabbindex only if the list item is not tabbable', () => {
+            // A list item with a no tabindex value or tabbable child
+            const nonTabbableItemElement = doc.createElement('div');
+
+            // A list item with a pre-set tabindex value
+            const tabbableItemElement = doc.createElement('div');
+            tabbableItemElement.setAttribute('tabindex', '4');
+
+            // A list item with a tabbable element (<a href>)
+            const childTabbableItemElement = doc.createElement('div');
+            const childTabbableItemChild = doc.createElement('a');
+            childTabbableItemChild.setAttribute('href', 'https://google.com/');
+            childTabbableItemElement.appendChild(childTabbableItemChild);
+
+            expectFetchAndRender(DEFAULT_FETCHED_DATA, [
+              nonTabbableItemElement,
+              tabbableItemElement,
+              childTabbableItemElement,
+            ]);
+
+            return list.layoutCallback().then(() => {
+              expect(nonTabbableItemElement.getAttribute('tabindex')).to.equal(
+                '0'
+              );
+              expect(tabbableItemElement.getAttribute('tabindex')).to.equal(
+                '4'
+              );
+              expect(childTabbableItemElement.getAttribute('tabindex')).to.be
+                .null;
+            });
+          });
+
+          it('should not show placeholder on fetch failure', function*() {
+            // Stub fetch_() to fail.
+            listMock
+              .expects('fetch_')
+              .returns(Promise.reject())
+              .once();
+            listMock
+              .expects('toggleLoading')
+              .withExactArgs(false)
+              .once();
+            listMock.expects('togglePlaceholder').never();
+
+            return list.layoutCallback();
+          });
+
+          it('should trigger "fetch-error" event on fetch failure', function*() {
+            const actions = {trigger: env.sandbox.spy()};
+            env.sandbox.stub(Services, 'actionServiceForDoc').returns(actions);
+
+            // Stub fetch_() to fail.
+            listMock
+              .expects('fetch_')
+              .returns(Promise.reject())
+              .once();
+            listMock
+              .expects('toggleLoading')
+              .withExactArgs(false)
+              .once();
+
+            yield list.layoutCallback();
+
+            expect(actions.trigger).to.be.calledWithExactly(
+              list.element,
+              'fetch-error',
+              env.sandbox.match.any,
+              ActionTrust.LOW
+            );
+          });
+
+          describe('DOM diffing with [diffable]', () => {
+            const newData = [{}];
+
+            function createAmpImg(src) {
+              const img = doc.createElement('amp-img');
+              img.setAttribute('src', src);
+              // The ignore attribute is normally set by amp-mustache.
+              img.setAttribute('i-amphtml-ignore', '');
+              img.setAttribute('layout', 'fixed');
+              return img;
+            }
+
+            async function renderTwice(first, second) {
+              const rendered = expectFetchAndRender(DEFAULT_FETCHED_DATA, [
+                first,
+              ]);
+              await list.layoutCallback().then(() => rendered);
+
+              ssrTemplateHelper.applySsrOrCsrTemplate
+                .withArgs(element, newData)
+                .returns(Promise.resolve([second]));
+              await list.mutatedAttributesCallback({src: newData});
+            }
+
+            beforeEach(() => {
+              element.setAttribute('diffable', '');
+            });
+
+            it('should keep unchanged elements', async () => {
+              const div = doc.createElement('div');
+              const newDiv = doc.createElement('div');
+              newDiv.setAttribute('class', 'foo');
+
+              await renderTwice(div, newDiv);
+
+              expect(list.container_.contains(div)).to.be.true;
+              expect(list.container_.contains(newDiv)).to.be.false;
+              // Diff algorithm should copy [class] to original div.
+              expect(div.getAttribute('class')).to.equal('foo');
+            });
+
+            it('should use i-amphtml-key as a replacement key', async () => {
+              const div = doc.createElement('div');
+              div.setAttribute('i-amphtml-key', '1');
+
+              const newDiv = doc.createElement('div');
+              newDiv.setAttribute('i-amphtml-key', '2');
+              newDiv.setAttribute('class', 'foo');
+
+              await renderTwice(div, newDiv);
+
+              expect(list.container_.contains(div)).to.be.false;
+              expect(list.container_.contains(newDiv)).to.be.true;
+              expect(div.hasAttribute('class')).to.be.false;
+            });
+
+            it('should keep amp-img if [src] is the same', async () => {
+              const img = createAmpImg('foo.jpg');
+              img.setAttribute('style', 'width:10px');
+              const newImg = createAmpImg('foo.jpg');
+              newImg.setAttribute('class', 'foo');
+              newImg.setAttribute('style', 'color:red');
+              newImg.setAttribute('should-not', 'be-copied');
+
+              await renderTwice(img, newImg);
+
+              expect(list.container_.contains(img)).to.be.true;
+              expect(list.container_.contains(newImg)).to.be.false;
+              // Only [class] and [style] should be manually diffed.
+              expect(img.classList.contains('foo')).to.be.true;
+              expect(img.getAttribute('style')).to.equal(
+                'width:10px;color:red'
+              );
+              // Other attributes will be lost.
+              expect(img.hasAttribute('should-not')).to.be.false;
+            });
+
+            it('should replace amp-img if [src] changes', async () => {
+              const img = createAmpImg('foo.jpg');
+              const newImg = createAmpImg('bar.png');
+
+              await renderTwice(img, newImg);
+
+              expect(list.container_.contains(img)).to.be.false;
+              expect(list.container_.contains(newImg)).to.be.true;
+            });
+
+            it('should attemptChangeHeight initial content', async () => {
+              const initialContent = doc.createElement('div');
+              initialContent.setAttribute('role', 'list');
+              initialContent.style.height = '1337px';
+
+              // Initial content must be set before buildCallback(), so use
+              // a new test AmpList instance.
+              element = createAmpListElement();
+              element.setAttribute('diffable', '');
+              element.style.height = '10px';
+              element.appendChild(initialContent);
+              doc.body.appendChild(element);
+
+              list = createAmpList(element);
+              // Expect attemptChangeHeight() twice: once to resize to initial
+              // content, once to resize to rendered contents.
+              listMock
+                .expects('attemptChangeHeight')
+                .withExactArgs(1337)
+                .returns(Promise.resolve())
+                .twice();
+
+              const itemElement = doc.createElement('div');
+              expectFetchAndRender(DEFAULT_FETCHED_DATA, [itemElement]);
+              await list.layoutCallback();
+            });
+
+            it('should diff against initial content', async () => {
+              const img = createAmpImg('foo.jpg');
+              img.setAttribute('class', 'i-amphtml-element');
+              const newImg = createAmpImg('foo.jpg'); // Same src.
+              newImg.setAttribute('class', 'bar');
+
+              const initialContent = doc.createElement('div');
+              initialContent.setAttribute('role', 'list');
+              initialContent.appendChild(img);
+
+              // Initial content must be set before buildCallback(), so use
+              // a new test AmpList instance.
+              element = createAmpListElement();
+              element.setAttribute('diffable', '');
+              element.appendChild(initialContent);
+              list = createAmpList(element);
+
+              const rendered = expectFetchAndRender(DEFAULT_FETCHED_DATA, [
+                newImg,
+              ]);
+              await list.layoutCallback().then(() => rendered);
+
+              expect(list.container_.contains(img)).to.be.true;
+              expect(list.container_.contains(newImg)).to.be.false;
+              // Internal class names should be preserved.
+              expect(img.getAttribute('class')).to.equal(
+                'i-amphtml-element bar'
+              );
+            });
+          });
+
+          describe('SSR templates', () => {
+            beforeEach(() => {
+              env.sandbox.stub(ssrTemplateHelper, 'isEnabled').returns(true);
+            });
+
+            it('should error if proxied fetch fails', () => {
+              env.sandbox
+                .stub(ssrTemplateHelper, 'ssr')
+                .returns(Promise.reject());
+
+              listMock
+                .expects('toggleLoading')
+                .withExactArgs(false)
+                .once();
+
+              return expect(
+                list.layoutCallback()
+              ).to.eventually.be.rejectedWith(
+                /Error proxying amp-list templates/
+              );
+            });
+
+            it('should error if proxied fetch returns invalid data', () => {
+              expectAsyncConsoleError(/received no response/, 1);
+              env.sandbox
+                .stub(ssrTemplateHelper, 'ssr')
+                .returns(Promise.resolve(undefined));
+              listMock
+                .expects('toggleLoading')
+                .withExactArgs(false)
+                .once();
+              return expect(
+                list.layoutCallback()
+              ).to.eventually.be.rejectedWith(/received no response/);
+            });
+
+            it('should error if proxied fetch returns non-2xx status (error) in the response', () => {
+              expectAsyncConsoleError(/received no response/, 1);
+              env.sandbox
+                .stub(ssrTemplateHelper, 'ssr')
+                .returns(Promise.resolve({init: {status: 400}}));
+              listMock
+                .expects('toggleLoading')
+                .withExactArgs(false)
+                .once();
+              return expect(
+                list.layoutCallback()
+              ).to.eventually.be.rejectedWith(
+                /Error proxying amp-list templates with status/
+              );
+            });
+
+            it('should delegate template rendering to viewer', function*() {
+              const rendered = doc.createElement('p');
+              const html =
+                '<div role="list" class="i-amphtml-fill-content ' +
+                'i-amphtml-replaced-content">' +
+                '<div role="item">foo</div>' +
+                '</div>';
+              const listContainer = document.createElement('div');
+              listContainer.setAttribute('role', 'list');
+              listContainer.setAttribute(
+                'class',
+                'i-amphtml-fill-content i-amphtml-replace-content'
+              );
+              const listItem = document.createElement('div');
+              listItem.setAttribute('role', 'item');
+              listContainer.appendChild(listItem);
+              env.sandbox
+                .stub(ssrTemplateHelper, 'ssr')
+                .returns(Promise.resolve({html}));
+              ssrTemplateHelper.applySsrOrCsrTemplate.returns(
+                Promise.resolve(listContainer)
+              );
+              listMock
+                .expects('updateBindings_')
+                .returns(Promise.resolve(listContainer))
+                .once();
+              listMock
+                .expects('render_')
+                .withExactArgs(listContainer, false)
+                .returns(Promise.resolve());
+
+              ssrTemplateHelper.applySsrOrCsrTemplate
+                .withArgs(element, html)
+                .returns(Promise.resolve(rendered));
+
+              yield list.layoutCallback();
+
+              const request = env.sandbox.match({
+                xhrUrl:
+                  'https://data.com/list.json?__amp_source_origin=about%3Asrcdoc',
+                fetchOpt: env.sandbox.match({
+                  headers: {Accept: 'application/json'},
+                  method: 'GET',
+                  responseType: 'application/json',
+                }),
+              });
+              const attrs = env.sandbox.match({
+                ampListAttributes: env.sandbox.match({
+                  items: 'items',
+                  maxItems: null,
+                  singleItem: false,
+                }),
+              });
+              expect(ssrTemplateHelper.ssr).to.be.calledOnce;
+              expect(ssrTemplateHelper.ssr).to.be.calledWithExactly(
+                element,
+                request,
+                null,
+                attrs
+              );
+            });
+
+            it('"amp-state:" uri should skip rendering and emit an error', () => {
+              toggleExperiment(win, 'amp-list-init-from-state', true);
+
+              const ampStateEl = doc.createElement('amp-state');
+              ampStateEl.setAttribute('id', 'okapis');
+              const ampStateJson = doc.createElement('script');
+              ampStateJson.setAttribute('type', 'application/json');
+              ampStateEl.appendChild(ampStateJson);
+              doc.body.appendChild(ampStateEl);
+              list.element.setAttribute('src', 'amp-state:okapis');
+
+              listMock.expects('scheduleRender_').never();
+
+              const errorMsg = /cannot be used in SSR mode/;
+              expectAsyncConsoleError(errorMsg);
+              expect(list.layoutCallback()).eventually.rejectedWith(errorMsg);
+            });
+
+            it('Bound [src] should skip rendering and emit an error', async () => {
+              listMock.expects('scheduleRender_').never();
+              allowConsoleError(async () => {
+                await list.mutatedAttributesCallback({src: {}});
+              });
+            });
+          });
+
+          // TODO(aghassemi, #12476): Make this test work with sinon 4.0.
+          describe.skip('with fallback', () => {
+            beforeEach(() => {
+              // Stub getFallback() with fake truthy value.
+              listMock.expects('getFallback').returns(true);
+              // Stub getVsync().mutate() to execute immediately.
+              listMock
+                .expects('getVsync')
+                .returns({
+                  measure: () => {},
+                  mutate: block => block(),
+                })
+                .atLeast(1);
+            });
+
+            it('should hide fallback element on fetch success', () => {
+              // Stub fetch and render to succeed.
+              listMock
+                .expects('fetch_')
+                .returns(Promise.resolve([]))
+                .once();
+              templates.findAndRenderTemplate.returns(Promise.resolve([]));
+              // Act as if a fallback is already displayed.
+              env.sandbox.stub(list, 'fallbackDisplayed_').callsFake(true);
+
+              listMock.expects('togglePlaceholder').never();
+              listMock
+                .expects('toggleFallback')
+                .withExactArgs(false)
+                .once();
+              return list.layoutCallback().catch(() => {});
+            });
+
+            it('should hide placeholder and show fallback on fetch failure', () => {
+              // Stub fetch_() to fail.
+              listMock
+                .expects('fetch_')
+                .returns(Promise.reject())
+                .once();
+
+              listMock
+                .expects('togglePlaceholder')
+                .withExactArgs(false)
+                .once();
+              listMock
+                .expects('toggleFallback')
+                .withExactArgs(true)
+                .once();
+              return list.layoutCallback().catch(() => {});
+            });
+          });
+        }); // without amp-bind
+
+        describe('with amp-bind', () => {
+          let bind;
+
+          beforeEach(() => {
+            bind = {
+              rescan: env.sandbox.stub().returns(Promise.resolve()),
+              signals: () => {
+                return {get: unusedName => false};
+              },
+              getState: () => ({}),
+            };
+            setBindService(bind);
+          });
+
+          it('should not fetch if [src] mutates with URL (before layout)', () => {
+            // Not allowed before layout.
+            listMock.expects('fetchList_').never();
+
+            element.setAttribute('src', 'https://new.com/list.json');
+            list.mutatedAttributesCallback({
+              'src': 'https://new.com/list.json',
+            });
+            expect(element.getAttribute('src')).to.equal(
+              'https://new.com/list.json'
+            );
+          });
+
+          // Unlike [src] mutations with URLs, local data mutations should
+          // always render immediately.
+          it('should render if [src] mutates with data (before layout)', async () => {
+            listMock.expects('scheduleRender_').once();
+
+            element.setAttribute('src', 'https://new.com/list.json');
+            await list.mutatedAttributesCallback({'src': [{title: 'Title1'}]});
+            // `src` attribute should still be set to empty string.
+            expect(element.getAttribute('src')).to.equal('');
+          });
+
+          it('should not render if [src] has changed since the fetch was initiated', async () => {
+            const foo = doc.createElement('div');
+            const bar = doc.createElement('div');
+
+            // firstPromise won't resolve until the render triggered by secondPromise completes.
+            let resolveFirstPromise;
+            const firstPromise = new Promise(resolve => {
+              resolveFirstPromise = () => resolve({items: [foo]});
+            });
+            const secondPromise = Promise.resolve({items: [bar]});
+
+            listMock
+              .expects('fetch_')
+              .onFirstCall()
+              .returns(firstPromise)
+              .onSecondCall()
+              .returns(secondPromise)
+              .twice();
+
+            // Even though there are two fetches, the render associated with
+            // the first one should be cancelled due to an outdated src.
+            listMock
+              .expects('scheduleRender_')
+              .withArgs([bar])
+              .returns(Promise.resolve())
+              .once();
+
+            element.setAttribute('src', 'https://foo.com/list.json');
+            const layout1Promise = list.layoutCallback();
+
+            element.setAttribute('src', 'https://bar.com/list.json');
+            const layout2Promise = list.layoutCallback();
+            layout2Promise.then(() => resolveFirstPromise());
+
+            await Promise.all([layout1Promise, layout2Promise]);
+          });
+
+          it('should render if [src] mutates with data', () => {
+            const foo = doc.createElement('div');
+            expectFetchAndRender(DEFAULT_FETCHED_DATA, [foo]);
+
+            return list.layoutCallback().then(() => {
+              expect(list.container_.contains(foo)).to.be.true;
+
+              listMock.expects('fetchList_').never();
+              // Expect hiding of placeholder/loading after render.
+              listMock
+                .expects('togglePlaceholder')
+                .withExactArgs(false)
+                .once();
+              listMock
+                .expects('toggleLoading')
+                .withExactArgs(false)
+                .once();
+
+              element.setAttribute('src', 'https://new.com/list.json');
+              list.mutatedAttributesCallback({'src': [{title: 'Title1'}]});
+              expect(element.getAttribute('src')).to.equal('');
+            });
+          });
+
+          it(
+            "should fetch with viewer auth token if 'crossorigin=" +
+              "amp-viewer-auth-token-via-post' attribute is present",
+            () => {
+              env.sandbox
+                .stub(Services, 'viewerAssistanceForDocOrNull')
+                .returns(
+                  Promise.resolve({
+                    getIdTokenPromise: () => Promise.resolve('idToken'),
+                  })
+                );
+              element.setAttribute(
+                'crossorigin',
+                'amp-viewer-auth-token-via-post'
+              );
+              const fetched = {items: DEFAULT_ITEMS};
+              const foo = doc.createElement('div');
+              const rendered = [foo];
+              const opts = DEFAULT_LIST_OPTS;
+
+              listMock
+                .expects('fetch_')
+                .withExactArgs(!!opts.refresh, 'idToken')
+                .returns(Promise.resolve(fetched))
+                .atLeast(1);
+
+              // Stub the rendering of the template.
+              const itemsToRender = fetched[opts.expr];
+              ssrTemplateHelper.applySsrOrCsrTemplate
+                .withArgs(element, itemsToRender)
+                .returns(Promise.resolve(rendered));
+
+              expectRender();
+
+              return list.layoutCallback().then(() => Promise.resolve());
+            }
+          );
+
+          it('should reset if `reset-on-refresh` is set (new URL)', () => {
+            element.setAttribute('reset-on-refresh', '');
+            const foo = doc.createElement('div');
+            expectFetchAndRender(DEFAULT_FETCHED_DATA, [foo]);
+
+            return list.layoutCallback().then(() => {
+              expect(list.container_.contains(foo)).to.be.true;
+
+              expectFetchAndRender(DEFAULT_FETCHED_DATA, [foo], {
+                resetOnRefresh: true,
+              });
+              element.setAttribute('src', 'https://new.com/list.json');
+              list.mutatedAttributesCallback({
+                'src': 'https://new.com/list.json',
+              });
+            });
+          });
+
+          it('should clear old bindings when resetting', () => {
+            element.setAttribute('reset-on-refresh', '');
+            const foo = doc.createElement('div');
+            expectFetchAndRender(DEFAULT_FETCHED_DATA, [foo]);
+
+            return list.layoutCallback().then(() => {
+              expect(list.container_.contains(foo)).to.be.true;
+
+              expectFetchAndRender(DEFAULT_FETCHED_DATA, [foo], {
+                resetOnRefresh: true,
+              });
+              element.setAttribute('src', 'https://new.com/list.json');
+              list.mutatedAttributesCallback({
+                'src': 'https://new.com/list.json',
+              });
+
+              expect(bind.rescan).to.be.calledOnce;
+              expect(bind.rescan).to.be.calledWith([], env.sandbox.match.array);
+            });
+          });
+
+          it('should not reset if `reset-on-refresh=""` (new data)', () => {
+            element.setAttribute('reset-on-refresh', '');
+            const foo = doc.createElement('div');
+            expectFetchAndRender(DEFAULT_FETCHED_DATA, [foo]);
+
+            return list.layoutCallback().then(() => {
+              expect(list.container_.contains(foo)).to.be.true;
+
+              listMock.expects('fetchList_').never();
+              // Expect hiding of placeholder/loading after render.
+              listMock
+                .expects('togglePlaceholder')
+                .withExactArgs(false)
+                .once();
+              listMock
+                .expects('toggleLoading')
+                .withExactArgs(false)
+                .once();
+
+              element.setAttribute('src', 'https://new.com/list.json');
+              list.mutatedAttributesCallback({'src': DEFAULT_ITEMS});
+            });
+          });
+
+          it('should reset if `reset-on-refresh="always"` (new data)', () => {
+            element.setAttribute('reset-on-refresh', 'always');
+            const foo = doc.createElement('div');
+            expectFetchAndRender(DEFAULT_FETCHED_DATA, [foo]);
+
+            return list.layoutCallback().then(() => {
+              expect(list.container_.contains(foo)).to.be.true;
+
+              listMock.expects('fetchList_').never();
+              // Expect display of placeholder/loading before render.
+              listMock
+                .expects('togglePlaceholder')
+                .withExactArgs(true)
+                .once();
+              listMock
+                .expects('toggleLoading')
+                .withExactArgs(true, true)
+                .once();
+              // Expect hiding of placeholder/loading after render.
+              listMock
+                .expects('togglePlaceholder')
+                .withExactArgs(false)
+                .once();
+              listMock
+                .expects('toggleLoading')
+                .withExactArgs(false)
+                .once();
+
+              element.setAttribute('src', 'https://new.com/list.json');
+              list.mutatedAttributesCallback({'src': DEFAULT_ITEMS});
+            });
+          });
+
+          it('should refetch if [src] attribute changes (after layout)', () => {
+            const foo = doc.createElement('div');
+            expectFetchAndRender(DEFAULT_FETCHED_DATA, [foo]);
+
+            return list.layoutCallback().then(() => {
+              expect(list.container_.contains(foo)).to.be.true;
+
+              // Allowed post-layout.
+              listMock.expects('fetchList_').once();
+
+              element.setAttribute('src', 'https://new.com/list.json');
+              list.mutatedAttributesCallback({
+                'src': 'https://new.com/list.json',
+              });
+            });
+          });
+
+          describe('no `binding` attribute', () => {
+            it('should rescan()', async () => {
+              const child = doc.createElement('div');
+              child.setAttribute('i-amphtml-binding', '');
+              expectFetchAndRender(DEFAULT_FETCHED_DATA, [child]);
+              await list.layoutCallback();
+              expect(bind.rescan).to.have.been.calledOnce;
+              expect(bind.rescan).calledWithExactly(
+                [child],
+                [list.container_],
+                {update: true, fast: true}
+              );
+            });
+
+            it('should not rescan() if new children have no bindings', async () => {
+              const child = doc.createElement('div');
+              expectFetchAndRender(DEFAULT_FETCHED_DATA, [child]);
+              await list.layoutCallback();
+              expect(bind.rescan).to.not.be.called;
+            });
+          });
+
+          describe('binding="always"', () => {
+            beforeEach(() => {
+              element.setAttribute('binding', 'always');
+            });
+
+            it('should rescan()', async () => {
+              const child = doc.createElement('div');
+              child.setAttribute('i-amphtml-binding', '');
+              expectFetchAndRender(DEFAULT_FETCHED_DATA, [child]);
+              await list.layoutCallback();
+              expect(bind.rescan).to.have.been.calledOnce;
+              expect(bind.rescan).calledWithExactly(
+                [child],
+                [list.container_],
+                {update: true, fast: true}
+              );
+            });
+          });
+
+          describe('binding="refresh"', () => {
+            beforeEach(() => {
+              element.setAttribute('binding', 'refresh');
+            });
+
+            it('should rescan() with {update: false} before FIRST_MUTATE', async () => {
+              const child = doc.createElement('div');
+              child.setAttribute('i-amphtml-binding', '');
+              expectFetchAndRender(DEFAULT_FETCHED_DATA, [child]);
+              await list.layoutCallback();
+              expect(bind.rescan).to.have.been.calledOnce;
+              expect(bind.rescan).calledWithExactly([child], [], {
+                update: false,
+                fast: true,
+              });
+            });
+
+            it('should rescan() with {update: true} after FIRST_MUTATE', async () => {
+              bind.signals = () => {
+                return {get: name => name === 'FIRST_MUTATE'};
+              };
+              const child = doc.createElement('div');
+              child.setAttribute('i-amphtml-binding', '');
+              expectFetchAndRender(DEFAULT_FETCHED_DATA, [child]);
+              await list.layoutCallback();
+              expect(bind.rescan).to.have.been.calledOnce;
+              expect(bind.rescan).calledWithExactly(
+                [child],
+                [list.container_],
+                {
+                  update: true,
+                  fast: true,
+                }
+              );
+            });
+          });
+
+          describe('binding="no"', () => {
+            beforeEach(() => {
+              element.setAttribute('binding', 'no');
+            });
+
+            it('should not rescan()', async () => {
+              const output = [doc.createElement('div')];
+              expectFetchAndRender(DEFAULT_FETCHED_DATA, output);
+              await list.layoutCallback();
+              expect(bind.rescan).to.not.have.been.called;
+            });
+          });
+
+          describe('Using amp-state: protocol', () => {
+            const experimentName = 'amp-list-init-from-state';
+
+            beforeEach(() => {
+              resetExperimentTogglesForTesting(win);
+              element = createAmpListElement();
+              element.setAttribute('src', 'amp-state:okapis');
+              element.toggleLoading = () => {};
+              list = createAmpList(element);
+            });
+
+            it('should throw an error if used without the experiment enabled', async () => {
+              const errorMsg = /Invalid value: amp-state:okapis/;
+              expectAsyncConsoleError(errorMsg);
+              expect(list.layoutCallback()).to.eventually.throw(errorMsg);
+            });
+
+            it('should log an error if amp-bind was not included', async () => {
+              toggleExperiment(win, experimentName, true);
+              Services.bindForDocOrNull.returns(Promise.resolve(null));
+
+              const ampStateEl = doc.createElement('amp-state');
+              ampStateEl.setAttribute('id', 'okapis');
+              const ampStateJson = doc.createElement('script');
+              ampStateJson.setAttribute('type', 'application/json');
+              ampStateEl.appendChild(ampStateJson);
+              doc.body.appendChild(ampStateEl);
+
+              const errorMsg = /bind to be installed/;
+              expectAsyncConsoleError(errorMsg);
+              expect(list.layoutCallback()).eventually.rejectedWith(errorMsg);
+            });
+
+            it('should render a list using local data', async () => {
+              toggleExperiment(win, experimentName, true);
+              bind.getState = () => ({items: [1, 2, 3]});
+
+              const ampStateEl = doc.createElement('amp-state');
+              ampStateEl.setAttribute('id', 'okapis');
+              const ampStateJson = doc.createElement('script');
+              ampStateJson.setAttribute('type', 'application/json');
+              ampStateEl.appendChild(ampStateJson);
+              doc.body.appendChild(ampStateEl);
+
+              listMock
+                .expects('scheduleRender_')
+                .withExactArgs([1, 2, 3], /*append*/ false, {items: [1, 2, 3]})
+                .returns(Promise.resolve())
+                .once();
+
+              await list.layoutCallback();
+            });
+          });
+        }); // with amp-bind
+      }
+    );
+  }
+);

--- a/extensions/amp-list/0.2/test/validator-amp-list.html
+++ b/extensions/amp-list/0.2/test/validator-amp-list.html
@@ -1,0 +1,207 @@
+<!--
+  Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS-IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the license.
+-->
+<!--
+  Test Description:
+  Tests for the amp-list tag.
+-->
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <link rel="canonical" href="./regular-html-version.html">
+  <meta name="viewport" content="width=device-width,minimum-scale=1">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async custom-element="amp-list"
+    src="https://cdn.ampproject.org/v0/amp-list-0.1.js"></script>
+</head>
+<body>
+  <!-- Valid: amp-list with only src attribute -->
+  <amp-list width=10 height=10
+            src="https://data.com/articles.json?ref=CANONICAL_URL">
+    <div></div>
+  </amp-list>
+  <!-- Valid: amp-list with only [src] attribute -->
+  <amp-list width=10 height=10
+            [src]="foo.bar">
+    <div></div>
+  </amp-list>
+  <!-- Valid: amp-list with only data-amp-bind-src attribute -->
+  <amp-list width=10 height=10
+            data-amp-bind-src="foo.bar">
+    <div></div>
+  </amp-list>
+  <!-- Valid: amp-list with both src and [src] attributes -->
+  <amp-list width=10 height=10
+            src="https://data.com/articles.json?ref=CANONICAL_URL"
+            [src]="foo.bar" [state]="baz.qux">
+    <div></div>
+  </amp-list>
+  <!-- Valid: amp-list with src and reset-on-refresh attributes -->
+  <amp-list width=10 height=10
+            src="https://data.com/articles.json?ref=CANONICAL_URL"
+            reset-on-refresh>
+    <div></div>
+  </amp-list>
+  <!-- Valid: amp-list with src and reset-on-refresh="fetch" attributes -->
+  <amp-list width=10 height=10
+            src="https://data.com/articles.json?ref=CANONICAL_URL"
+            reset-on-refresh="fetch">
+    <div></div>
+  </amp-list>
+  <!-- Valid: amp-list with src and reset-on-refresh="always" attributes -->
+  <amp-list width=10 height=10
+            src="https://data.com/articles.json?ref=CANONICAL_URL"
+            reset-on-refresh="always">
+    <div></div>
+  </amp-list>
+  <!-- Valid: amp-list with [src] and reset-on-refresh attributes -->
+  <amp-list width=10 height=10
+            [src]="foo.bar"
+            reset-on-refresh>
+    <div></div>
+  </amp-list>
+  <!-- Valid amp-list with binding="refresh" attribute -->
+  <amp-list width=10 height=10
+            src="https://data.com/articles.json?ref=CANONICAL_URL"
+            binding="refresh">
+    <div></div>
+  </amp-list>
+  <!-- Valid amp-list with binding="no" attribute -->
+  <amp-list width=10 height=10
+            src="https://data.com/articles.json?ref=CANONICAL_URL"
+            binding="no">
+    <div></div>
+  </amp-list>
+  <!-- Valid amp-list with deprecated auto-resize attribute -->
+  <amp-list width=10 height=10
+    src="https://data.com/articles.json?ref=CANONICAL_URL"
+    auto-resize>
+  <div></div>
+  <!-- Valid amp-list with load-more="auto" attribute -->
+  <amp-list width=10 height=10
+    src="https://data.com/articles.json?ref=CANONICAL_URL"
+    load-more="auto"></amp-list>
+  </amp-list>
+  <!-- Valid amp-list with load-more="manual" attribute -->
+  <amp-list width=10 height=10
+    src="https://data.com/articles.json?ref=CANONICAL_URL"
+    load-more="manual"></amp-list>
+  </amp-list>
+  <!-- Valid amp-list with load-more and optional load-more-bookmark attribute -->
+  <amp-list width=10 height=10
+    src="https://data.com/articles.json?ref=CANONICAL_URL"
+    load-more="manual"
+    load-more-bookmark="next"></amp-list>
+  </amp-list>
+  <!-- Valid amp-list with custom children -->
+  <amp-list width=10 height=10
+    src="https://data.com/articles.json?ref=CANONICAL_URL"
+    load-more="manual"
+    load-more-bookmark="next">
+    <amp-list-load-more load-more-button></amp-list-load-more>
+    <amp-list-load-more load-more-loading></amp-list-load-more>
+    <amp-list-load-more load-more-failed></amp-list-load-more>
+    <amp-list-load-more load-more-end></amp-list-load-more>
+  </amp-list>
+  <!-- Valid amp-list load-more-failed with allowed child -->
+  <amp-list width=10 height=10
+    src="https://data.com/articles.json?ref=CANONICAL_URL"
+    load-more="manual"
+    load-more-bookmark="next">
+    <amp-list-load-more load-more-failed>
+      <button load-more-clickable>Click me to reload!</button>
+    </amp-list-load-more>
+  </amp-list>
+  <!-- Valid amp-list with is-layout-container attribute -->
+  <amp-list width=10 height=10
+    src="https://data.com/articles.json?ref=CANONICAL_URL"
+    [is-layout-container]="containerState"></amp-list>
+  </amp-list>
+  <!-- Valid amp-list with diffable attribute -->
+  <amp-list width=10 height=10
+    src="https://data.com/articles.json?ref=CANONICAL_URL"
+    diffable></amp-list>
+  </amp-list>
+  <!-- Invalid: unsupported "binding" attribute value -->
+  <amp-list width=10 height=10
+            src="https://data.com/articles.json?ref=CANONICAL_URL"
+            binding="this-is-an-error">
+    <div></div>
+  </amp-list>
+  <!-- Invalid: width is mistyped. -->
+  <amp-list src="https://data.com/articles.json?ref=CANONICAL_URL"
+            wdith=10 height=10>
+    <div></div>
+  </amp-list>
+  <!-- Invalid: missing at least src, [src] or data-amp-bind-src. -->
+  <amp-list width=10 height=10>
+    <div></div>
+  </amp-list>
+  <!-- Invalid: width/height missing, so it's container layout
+       which isn't supported. -->
+  <amp-list src="https://data.com/articles.json?ref=CANONICAL_URL">
+    <div></div>
+  </amp-list>
+  <!-- Invalid amp-list with load-more attribute -->
+  <amp-list width=10 height=10
+    src="https://data.com/articles.json?ref=CANONICAL_URL"
+    load-more></amp-list>
+  </amp-list>
+  <!-- Invalid amp-list with bad load-more attribute -->
+  <amp-list width=10 height=10
+    src="https://data.com/articles.json?ref=CANONICAL_URL"
+    load-more="gibberish"
+    load-more-bookmark="next"></amp-list>
+  </amp-list>
+  <!-- Invalid load-more attributes -->
+  <div load-more-button></div>
+  <div load-more-loading></div>
+  <div load-more-failed></div>
+  <div load-more-end></div>
+  <amp-list-load-more></amp-list-load-more>
+  <amp-list width=10 height=10
+    src="https://data.com/articles.json?ref=CANONICAL_URL"
+    load-more="manual"
+    load-more-bookmark="next">
+    <button load-more-clickable></button>
+  </amp-list>
+  <amp-list width=10 height=10
+    src="https://data.com/articles.json?ref=CANONICAL_URL"
+    load-more="manual"
+    load-more-bookmark="next">
+    <button></button>
+  </amp-list>
+  <!-- References to template elements -->
+  <amp-list width=10 height=10
+    src="https://data.com/articles.json?ref=CANONICAL_URL"
+    template="missing">
+    <div></div>
+  </amp-list>
+  <amp-list width=10 height=10
+    src="https://data.com/articles.json?ref=CANONICAL_URL"
+    template="found">
+    <div></div>
+  </amp-list>
+  <template id="found"></template>
+  <!-- Valid: amp-list with src and xssi-prefix attribute -->
+  <amp-list width=10 height=10
+            src="https://data.com/articles.json?ref=CANONICAL_URL"
+            xssi-prefix="while(1)">
+    <div></div>
+  </amp-list>
+</body>
+</html>

--- a/extensions/amp-list/0.2/test/validator-amp-list.html
+++ b/extensions/amp-list/0.2/test/validator-amp-list.html
@@ -26,7 +26,7 @@
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <script async custom-element="amp-list"
-    src="https://cdn.ampproject.org/v0/amp-list-0.1.js"></script>
+    src="https://cdn.ampproject.org/v0/amp-list-0.2.js"></script>
 </head>
 <body>
   <!-- Valid: amp-list with only src attribute -->

--- a/extensions/amp-list/0.2/test/validator-amp-list.out
+++ b/extensions/amp-list/0.2/test/validator-amp-list.out
@@ -1,0 +1,242 @@
+FAIL
+|  <!--
+|    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+|
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|
+|        http://www.apache.org/licenses/LICENSE-2.0
+|
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Tests for the amp-list tag.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    <script async custom-element="amp-list"
+|      src="https://cdn.ampproject.org/v0/amp-list-0.1.js"></script>
+|  </head>
+|  <body>
+|    <!-- Valid: amp-list with only src attribute -->
+|    <amp-list width=10 height=10
+|              src="https://data.com/articles.json?ref=CANONICAL_URL">
+|      <div></div>
+|    </amp-list>
+|    <!-- Valid: amp-list with only [src] attribute -->
+|    <amp-list width=10 height=10
+|              [src]="foo.bar">
+|      <div></div>
+|    </amp-list>
+|    <!-- Valid: amp-list with only data-amp-bind-src attribute -->
+|    <amp-list width=10 height=10
+|              data-amp-bind-src="foo.bar">
+|      <div></div>
+|    </amp-list>
+|    <!-- Valid: amp-list with both src and [src] attributes -->
+|    <amp-list width=10 height=10
+>>   ^~~~~~~~~
+amp-list/0.1/test/validator-amp-list.html:48:2 The attribute '[state]' may not appear in tag 'amp-list'. (see https://amp.dev/documentation/components/amp-list)
+|              src="https://data.com/articles.json?ref=CANONICAL_URL"
+|              [src]="foo.bar" [state]="baz.qux">
+|      <div></div>
+|    </amp-list>
+|    <!-- Valid: amp-list with src and reset-on-refresh attributes -->
+|    <amp-list width=10 height=10
+|              src="https://data.com/articles.json?ref=CANONICAL_URL"
+|              reset-on-refresh>
+|      <div></div>
+|    </amp-list>
+|    <!-- Valid: amp-list with src and reset-on-refresh="fetch" attributes -->
+|    <amp-list width=10 height=10
+|              src="https://data.com/articles.json?ref=CANONICAL_URL"
+|              reset-on-refresh="fetch">
+|      <div></div>
+|    </amp-list>
+|    <!-- Valid: amp-list with src and reset-on-refresh="always" attributes -->
+|    <amp-list width=10 height=10
+|              src="https://data.com/articles.json?ref=CANONICAL_URL"
+|              reset-on-refresh="always">
+|      <div></div>
+|    </amp-list>
+|    <!-- Valid: amp-list with [src] and reset-on-refresh attributes -->
+|    <amp-list width=10 height=10
+|              [src]="foo.bar"
+|              reset-on-refresh>
+|      <div></div>
+|    </amp-list>
+|    <!-- Valid amp-list with binding="refresh" attribute -->
+|    <amp-list width=10 height=10
+|              src="https://data.com/articles.json?ref=CANONICAL_URL"
+|              binding="refresh">
+|      <div></div>
+|    </amp-list>
+|    <!-- Valid amp-list with binding="no" attribute -->
+|    <amp-list width=10 height=10
+|              src="https://data.com/articles.json?ref=CANONICAL_URL"
+|              binding="no">
+|      <div></div>
+|    </amp-list>
+|    <!-- Valid amp-list with deprecated auto-resize attribute -->
+|    <amp-list width=10 height=10
+>>   ^~~~~~~~~
+amp-list/0.1/test/validator-amp-list.html:90:2 The attribute 'auto-resize' in tag 'amp-list' is deprecated - use 'replacement-to-be-determined-at-a-later-date' instead. (see https://github.com/ampproject/amphtml/issues/18849)
+|      src="https://data.com/articles.json?ref=CANONICAL_URL"
+|      auto-resize>
+|    <div></div>
+|    <!-- Valid amp-list with load-more="auto" attribute -->
+|    <amp-list width=10 height=10
+|      src="https://data.com/articles.json?ref=CANONICAL_URL"
+|      load-more="auto"></amp-list>
+|    </amp-list>
+|    <!-- Valid amp-list with load-more="manual" attribute -->
+|    <amp-list width=10 height=10
+|      src="https://data.com/articles.json?ref=CANONICAL_URL"
+|      load-more="manual"></amp-list>
+|    </amp-list>
+|    <!-- Valid amp-list with load-more and optional load-more-bookmark attribute -->
+|    <amp-list width=10 height=10
+|      src="https://data.com/articles.json?ref=CANONICAL_URL"
+|      load-more="manual"
+|      load-more-bookmark="next"></amp-list>
+|    </amp-list>
+|    <!-- Valid amp-list with custom children -->
+|    <amp-list width=10 height=10
+|      src="https://data.com/articles.json?ref=CANONICAL_URL"
+|      load-more="manual"
+|      load-more-bookmark="next">
+|      <amp-list-load-more load-more-button></amp-list-load-more>
+|      <amp-list-load-more load-more-loading></amp-list-load-more>
+|      <amp-list-load-more load-more-failed></amp-list-load-more>
+|      <amp-list-load-more load-more-end></amp-list-load-more>
+|    </amp-list>
+|    <!-- Valid amp-list load-more-failed with allowed child -->
+|    <amp-list width=10 height=10
+|      src="https://data.com/articles.json?ref=CANONICAL_URL"
+|      load-more="manual"
+|      load-more-bookmark="next">
+|      <amp-list-load-more load-more-failed>
+|        <button load-more-clickable>Click me to reload!</button>
+|      </amp-list-load-more>
+|    </amp-list>
+|    <!-- Valid amp-list with is-layout-container attribute -->
+|    <amp-list width=10 height=10
+|      src="https://data.com/articles.json?ref=CANONICAL_URL"
+|      [is-layout-container]="containerState"></amp-list>
+|    </amp-list>
+|    <!-- Valid amp-list with diffable attribute -->
+|    <amp-list width=10 height=10
+|      src="https://data.com/articles.json?ref=CANONICAL_URL"
+|      diffable></amp-list>
+|    </amp-list>
+|    <!-- Invalid: unsupported "binding" attribute value -->
+|    <amp-list width=10 height=10
+>>   ^~~~~~~~~
+amp-list/0.1/test/validator-amp-list.html:140:2 The attribute 'binding' in tag 'amp-list' is set to the invalid value 'this-is-an-error'. (see https://amp.dev/documentation/components/amp-list)
+|              src="https://data.com/articles.json?ref=CANONICAL_URL"
+|              binding="this-is-an-error">
+|      <div></div>
+|    </amp-list>
+|    <!-- Invalid: width is mistyped. -->
+|    <amp-list src="https://data.com/articles.json?ref=CANONICAL_URL"
+>>   ^~~~~~~~~
+amp-list/0.1/test/validator-amp-list.html:146:2 The attribute 'wdith' may not appear in tag 'amp-list'. (see https://amp.dev/documentation/components/amp-list)
+|              wdith=10 height=10>
+|      <div></div>
+|    </amp-list>
+|    <!-- Invalid: missing at least src, [src] or data-amp-bind-src. -->
+|    <amp-list width=10 height=10>
+>>   ^~~~~~~~~
+amp-list/0.1/test/validator-amp-list.html:151:2 The tag 'amp-list' is missing a mandatory attribute - pick at least one of ['src','[src]','data-amp-bind-src']. (see https://amp.dev/documentation/components/amp-list)
+|      <div></div>
+|    </amp-list>
+|    <!-- Invalid: width/height missing, so it's container layout
+|         which isn't supported. -->
+|    <amp-list src="https://data.com/articles.json?ref=CANONICAL_URL">
+>>   ^~~~~~~~~
+amp-list/0.1/test/validator-amp-list.html:156:2 Incomplete layout attributes specified for tag 'amp-list'. For example, provide attributes 'width' and 'height'. (see https://amp.dev/documentation/components/amp-list)
+|      <div></div>
+|    </amp-list>
+|    <!-- Invalid amp-list with load-more attribute -->
+|    <amp-list width=10 height=10
+>>   ^~~~~~~~~
+amp-list/0.1/test/validator-amp-list.html:160:2 The attribute 'load-more' in tag 'amp-list' is set to the invalid value ''. (see https://amp.dev/documentation/components/amp-list)
+|      src="https://data.com/articles.json?ref=CANONICAL_URL"
+|      load-more></amp-list>
+|    </amp-list>
+|    <!-- Invalid amp-list with bad load-more attribute -->
+|    <amp-list width=10 height=10
+>>   ^~~~~~~~~
+amp-list/0.1/test/validator-amp-list.html:165:2 The attribute 'load-more' in tag 'amp-list' is set to the invalid value 'gibberish'. (see https://amp.dev/documentation/components/amp-list)
+|      src="https://data.com/articles.json?ref=CANONICAL_URL"
+|      load-more="gibberish"
+|      load-more-bookmark="next"></amp-list>
+|    </amp-list>
+|    <!-- Invalid load-more attributes -->
+|    <div load-more-button></div>
+>>   ^~~~~~~~~
+amp-list/0.1/test/validator-amp-list.html:171:2 The attribute 'load-more-button' may not appear in tag 'div'.
+|    <div load-more-loading></div>
+>>   ^~~~~~~~~
+amp-list/0.1/test/validator-amp-list.html:172:2 The attribute 'load-more-loading' may not appear in tag 'div'.
+|    <div load-more-failed></div>
+>>   ^~~~~~~~~
+amp-list/0.1/test/validator-amp-list.html:173:2 The attribute 'load-more-failed' may not appear in tag 'div'.
+|    <div load-more-end></div>
+>>   ^~~~~~~~~
+amp-list/0.1/test/validator-amp-list.html:174:2 The attribute 'load-more-end' may not appear in tag 'div'.
+|    <amp-list-load-more></amp-list-load-more>
+>>   ^~~~~~~~~
+amp-list/0.1/test/validator-amp-list.html:175:2 The parent tag of tag 'amp-list-load-more' is 'body', but it can only be 'amp-list'. (see https://amp.dev/documentation/components/amp-list)
+|    <amp-list width=10 height=10
+|      src="https://data.com/articles.json?ref=CANONICAL_URL"
+|      load-more="manual"
+|      load-more-bookmark="next">
+|      <button load-more-clickable></button>
+>>     ^~~~~~~~~
+amp-list/0.1/test/validator-amp-list.html:180:4 The parent tag of tag 'amp-list-load-more button[load-more-clickable]' is 'amp-list', but it can only be 'amp-list-load-more'. (see https://amp.dev/documentation/components/amp-list)
+|    </amp-list>
+|    <amp-list width=10 height=10
+|      src="https://data.com/articles.json?ref=CANONICAL_URL"
+|      load-more="manual"
+|      load-more-bookmark="next">
+|      <button></button>
+|    </amp-list>
+|    <!-- References to template elements -->
+|    <amp-list width=10 height=10
+>>   ^~~~~~~~~
+amp-list/0.1/test/validator-amp-list.html:189:2 Attribute 'template' in tag 'amp-list' contains a value that does not match any other tags on the page. (see https://amp.dev/documentation/components/amp-list)
+|      src="https://data.com/articles.json?ref=CANONICAL_URL"
+|      template="missing">
+|      <div></div>
+|    </amp-list>
+|    <amp-list width=10 height=10
+|      src="https://data.com/articles.json?ref=CANONICAL_URL"
+|      template="found">
+|      <div></div>
+|    </amp-list>
+|    <template id="found"></template>
+>>   ^~~~~~~~~
+amp-list/0.1/test/validator-amp-list.html:199:2 The mandatory attribute 'type' is missing in tag 'template'. (see https://amp.dev/documentation/components/amp-mustache)
+>>   ^~~~~~~~~
+amp-list/0.1/test/validator-amp-list.html:199:2 The tag 'template' requires including the 'amp-mustache' extension JavaScript. (see https://amp.dev/documentation/components/amp-mustache)
+|    <!-- Valid: amp-list with src and xssi-prefix attribute -->
+|    <amp-list width=10 height=10
+|              src="https://data.com/articles.json?ref=CANONICAL_URL"
+|              xssi-prefix="while(1)">
+|      <div></div>
+|    </amp-list>
+|  </body>
+|  </html>

--- a/extensions/amp-list/0.2/test/validator-amp-list.out
+++ b/extensions/amp-list/0.2/test/validator-amp-list.out
@@ -27,7 +27,7 @@ FAIL
 |    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
 |    <script async src="https://cdn.ampproject.org/v0.js"></script>
 |    <script async custom-element="amp-list"
-|      src="https://cdn.ampproject.org/v0/amp-list-0.1.js"></script>
+|      src="https://cdn.ampproject.org/v0/amp-list-0.2.js"></script>
 |  </head>
 |  <body>
 |    <!-- Valid: amp-list with only src attribute -->
@@ -48,7 +48,7 @@ FAIL
 |    <!-- Valid: amp-list with both src and [src] attributes -->
 |    <amp-list width=10 height=10
 >>   ^~~~~~~~~
-amp-list/0.1/test/validator-amp-list.html:48:2 The attribute '[state]' may not appear in tag 'amp-list'. (see https://amp.dev/documentation/components/amp-list)
+amp-list/0.2/test/validator-amp-list.html:48:2 The attribute '[state]' may not appear in tag 'amp-list'. (see https://amp.dev/documentation/components/amp-list)
 |              src="https://data.com/articles.json?ref=CANONICAL_URL"
 |              [src]="foo.bar" [state]="baz.qux">
 |      <div></div>
@@ -92,7 +92,7 @@ amp-list/0.1/test/validator-amp-list.html:48:2 The attribute '[state]' may not a
 |    <!-- Valid amp-list with deprecated auto-resize attribute -->
 |    <amp-list width=10 height=10
 >>   ^~~~~~~~~
-amp-list/0.1/test/validator-amp-list.html:90:2 The attribute 'auto-resize' in tag 'amp-list' is deprecated - use 'replacement-to-be-determined-at-a-later-date' instead. (see https://github.com/ampproject/amphtml/issues/18849)
+amp-list/0.2/test/validator-amp-list.html:90:2 The attribute 'auto-resize' in tag 'amp-list' is deprecated - use 'replacement-to-be-determined-at-a-later-date' instead. (see https://github.com/ampproject/amphtml/issues/18849)
 |      src="https://data.com/articles.json?ref=CANONICAL_URL"
 |      auto-resize>
 |    <div></div>
@@ -144,7 +144,7 @@ amp-list/0.1/test/validator-amp-list.html:90:2 The attribute 'auto-resize' in ta
 |    <!-- Invalid: unsupported "binding" attribute value -->
 |    <amp-list width=10 height=10
 >>   ^~~~~~~~~
-amp-list/0.1/test/validator-amp-list.html:140:2 The attribute 'binding' in tag 'amp-list' is set to the invalid value 'this-is-an-error'. (see https://amp.dev/documentation/components/amp-list)
+amp-list/0.2/test/validator-amp-list.html:140:2 The attribute 'binding' in tag 'amp-list' is set to the invalid value 'this-is-an-error'. (see https://amp.dev/documentation/components/amp-list)
 |              src="https://data.com/articles.json?ref=CANONICAL_URL"
 |              binding="this-is-an-error">
 |      <div></div>
@@ -152,34 +152,34 @@ amp-list/0.1/test/validator-amp-list.html:140:2 The attribute 'binding' in tag '
 |    <!-- Invalid: width is mistyped. -->
 |    <amp-list src="https://data.com/articles.json?ref=CANONICAL_URL"
 >>   ^~~~~~~~~
-amp-list/0.1/test/validator-amp-list.html:146:2 The attribute 'wdith' may not appear in tag 'amp-list'. (see https://amp.dev/documentation/components/amp-list)
+amp-list/0.2/test/validator-amp-list.html:146:2 The attribute 'wdith' may not appear in tag 'amp-list'. (see https://amp.dev/documentation/components/amp-list)
 |              wdith=10 height=10>
 |      <div></div>
 |    </amp-list>
 |    <!-- Invalid: missing at least src, [src] or data-amp-bind-src. -->
 |    <amp-list width=10 height=10>
 >>   ^~~~~~~~~
-amp-list/0.1/test/validator-amp-list.html:151:2 The tag 'amp-list' is missing a mandatory attribute - pick at least one of ['src','[src]','data-amp-bind-src']. (see https://amp.dev/documentation/components/amp-list)
+amp-list/0.2/test/validator-amp-list.html:151:2 The tag 'amp-list' is missing a mandatory attribute - pick at least one of ['src','[src]','data-amp-bind-src']. (see https://amp.dev/documentation/components/amp-list)
 |      <div></div>
 |    </amp-list>
 |    <!-- Invalid: width/height missing, so it's container layout
 |         which isn't supported. -->
 |    <amp-list src="https://data.com/articles.json?ref=CANONICAL_URL">
 >>   ^~~~~~~~~
-amp-list/0.1/test/validator-amp-list.html:156:2 Incomplete layout attributes specified for tag 'amp-list'. For example, provide attributes 'width' and 'height'. (see https://amp.dev/documentation/components/amp-list)
+amp-list/0.2/test/validator-amp-list.html:156:2 Incomplete layout attributes specified for tag 'amp-list'. For example, provide attributes 'width' and 'height'. (see https://amp.dev/documentation/components/amp-list)
 |      <div></div>
 |    </amp-list>
 |    <!-- Invalid amp-list with load-more attribute -->
 |    <amp-list width=10 height=10
 >>   ^~~~~~~~~
-amp-list/0.1/test/validator-amp-list.html:160:2 The attribute 'load-more' in tag 'amp-list' is set to the invalid value ''. (see https://amp.dev/documentation/components/amp-list)
+amp-list/0.2/test/validator-amp-list.html:160:2 The attribute 'load-more' in tag 'amp-list' is set to the invalid value ''. (see https://amp.dev/documentation/components/amp-list)
 |      src="https://data.com/articles.json?ref=CANONICAL_URL"
 |      load-more></amp-list>
 |    </amp-list>
 |    <!-- Invalid amp-list with bad load-more attribute -->
 |    <amp-list width=10 height=10
 >>   ^~~~~~~~~
-amp-list/0.1/test/validator-amp-list.html:165:2 The attribute 'load-more' in tag 'amp-list' is set to the invalid value 'gibberish'. (see https://amp.dev/documentation/components/amp-list)
+amp-list/0.2/test/validator-amp-list.html:165:2 The attribute 'load-more' in tag 'amp-list' is set to the invalid value 'gibberish'. (see https://amp.dev/documentation/components/amp-list)
 |      src="https://data.com/articles.json?ref=CANONICAL_URL"
 |      load-more="gibberish"
 |      load-more-bookmark="next"></amp-list>
@@ -187,26 +187,26 @@ amp-list/0.1/test/validator-amp-list.html:165:2 The attribute 'load-more' in tag
 |    <!-- Invalid load-more attributes -->
 |    <div load-more-button></div>
 >>   ^~~~~~~~~
-amp-list/0.1/test/validator-amp-list.html:171:2 The attribute 'load-more-button' may not appear in tag 'div'.
+amp-list/0.2/test/validator-amp-list.html:171:2 The attribute 'load-more-button' may not appear in tag 'div'.
 |    <div load-more-loading></div>
 >>   ^~~~~~~~~
-amp-list/0.1/test/validator-amp-list.html:172:2 The attribute 'load-more-loading' may not appear in tag 'div'.
+amp-list/0.2/test/validator-amp-list.html:172:2 The attribute 'load-more-loading' may not appear in tag 'div'.
 |    <div load-more-failed></div>
 >>   ^~~~~~~~~
-amp-list/0.1/test/validator-amp-list.html:173:2 The attribute 'load-more-failed' may not appear in tag 'div'.
+amp-list/0.2/test/validator-amp-list.html:173:2 The attribute 'load-more-failed' may not appear in tag 'div'.
 |    <div load-more-end></div>
 >>   ^~~~~~~~~
-amp-list/0.1/test/validator-amp-list.html:174:2 The attribute 'load-more-end' may not appear in tag 'div'.
+amp-list/0.2/test/validator-amp-list.html:174:2 The attribute 'load-more-end' may not appear in tag 'div'.
 |    <amp-list-load-more></amp-list-load-more>
 >>   ^~~~~~~~~
-amp-list/0.1/test/validator-amp-list.html:175:2 The parent tag of tag 'amp-list-load-more' is 'body', but it can only be 'amp-list'. (see https://amp.dev/documentation/components/amp-list)
+amp-list/0.2/test/validator-amp-list.html:175:2 The parent tag of tag 'amp-list-load-more' is 'body', but it can only be 'amp-list'. (see https://amp.dev/documentation/components/amp-list)
 |    <amp-list width=10 height=10
 |      src="https://data.com/articles.json?ref=CANONICAL_URL"
 |      load-more="manual"
 |      load-more-bookmark="next">
 |      <button load-more-clickable></button>
 >>     ^~~~~~~~~
-amp-list/0.1/test/validator-amp-list.html:180:4 The parent tag of tag 'amp-list-load-more button[load-more-clickable]' is 'amp-list', but it can only be 'amp-list-load-more'. (see https://amp.dev/documentation/components/amp-list)
+amp-list/0.2/test/validator-amp-list.html:180:4 The parent tag of tag 'amp-list-load-more button[load-more-clickable]' is 'amp-list', but it can only be 'amp-list-load-more'. (see https://amp.dev/documentation/components/amp-list)
 |    </amp-list>
 |    <amp-list width=10 height=10
 |      src="https://data.com/articles.json?ref=CANONICAL_URL"
@@ -217,7 +217,7 @@ amp-list/0.1/test/validator-amp-list.html:180:4 The parent tag of tag 'amp-list-
 |    <!-- References to template elements -->
 |    <amp-list width=10 height=10
 >>   ^~~~~~~~~
-amp-list/0.1/test/validator-amp-list.html:189:2 Attribute 'template' in tag 'amp-list' contains a value that does not match any other tags on the page. (see https://amp.dev/documentation/components/amp-list)
+amp-list/0.2/test/validator-amp-list.html:189:2 Attribute 'template' in tag 'amp-list' contains a value that does not match any other tags on the page. (see https://amp.dev/documentation/components/amp-list)
 |      src="https://data.com/articles.json?ref=CANONICAL_URL"
 |      template="missing">
 |      <div></div>
@@ -229,9 +229,9 @@ amp-list/0.1/test/validator-amp-list.html:189:2 Attribute 'template' in tag 'amp
 |    </amp-list>
 |    <template id="found"></template>
 >>   ^~~~~~~~~
-amp-list/0.1/test/validator-amp-list.html:199:2 The mandatory attribute 'type' is missing in tag 'template'. (see https://amp.dev/documentation/components/amp-mustache)
+amp-list/0.2/test/validator-amp-list.html:199:2 The mandatory attribute 'type' is missing in tag 'template'. (see https://amp.dev/documentation/components/amp-mustache)
 >>   ^~~~~~~~~
-amp-list/0.1/test/validator-amp-list.html:199:2 The tag 'template' requires including the 'amp-mustache' extension JavaScript. (see https://amp.dev/documentation/components/amp-mustache)
+amp-list/0.2/test/validator-amp-list.html:199:2 The tag 'template' requires including the 'amp-mustache' extension JavaScript. (see https://amp.dev/documentation/components/amp-mustache)
 |    <!-- Valid: amp-list with src and xssi-prefix attribute -->
 |    <amp-list width=10 height=10
 |              src="https://data.com/articles.json?ref=CANONICAL_URL"


### PR DESCRIPTION
**summary**
As requested in https://github.com/ampproject/amphtml/pull/26530#issuecomment-591062618

I intend on fixing a race condition between amp-list and amp-state that could break sites which rely on it.  Therefore I'm creating a 0.2, and will fix the bug there.

The bugfix is specifically regarding the race condition in this case:
```html
<amp-state id="state" src="some.json"></amp-state>
<amp-list>
  <template type="amp-mustache">
     <p [text]="state.text"></p>
  </template>
</amp-list>
```

**how to review**
I recommend reviewing this PR commit by commit. The first is simply a copy of the 0.1 directory, whereas the rest are the minor changes to change the ver number and add the bundle to the build.