### PR TITLE
Add Map and Set support

### DIFF
--- a/build-system/test-configs/conformance-config.textproto
+++ b/build-system/test-configs/conformance-config.textproto
@@ -191,6 +191,74 @@ requirement: {
   value: 'Array.prototype.flatMap'
 }
 
+requirement: {
+  type: BANNED_PROPERTY_CALL
+  error_message: 'Array.prototype.keys is not allowed'
+  value: 'Array.prototype.keys'
+}
+
+requirement: {
+  type: BANNED_PROPERTY_CALL
+  error_message: 'Array.prototype.values is not allowed'
+  value: 'Array.prototype.values'
+}
+
+requirement: {
+  type: BANNED_PROPERTY_CALL
+  error_message: 'Array.prototype.entries is not allowed'
+  value: 'Array.prototype.entries'
+}
+
+# Map
+
+requirement: {
+  type: BANNED_CODE_PATTERN
+  error_message: 'Cannot construct Map with Iterable'
+  value: '/** @param {Array|Object} a */function template(a) {new Map(a)}'
+}
+
+requirement: {
+  type: BANNED_PROPERTY_CALL
+  error_message: 'Map.prototype.keys is not allowed'
+  value: 'Map.prototype.keys'
+}
+
+requirement: {
+  type: BANNED_PROPERTY_CALL
+  error_message: 'Map.prototype.values is not allowed'
+  value: 'Map.prototype.values'
+}
+requirement: {
+  type: BANNED_PROPERTY_CALL
+  error_message: 'Map.prototype.entries is not allowed'
+  value: 'Map.prototype.entries'
+}
+
+# Set
+
+requirement: {
+  type: BANNED_CODE_PATTERN
+  error_message: 'Cannot construct Set with Iterable'
+  value: '/** @param {Array|Object} a */function template(a) {new Set(a)}'
+}
+
+requirement: {
+  type: BANNED_PROPERTY_CALL
+  error_message: 'Set.prototype.keys is not allowed'
+  value: 'Set.prototype.keys'
+}
+
+requirement: {
+  type: BANNED_PROPERTY_CALL
+  error_message: 'Set.prototype.values is not allowed'
+  value: 'Set.prototype.values'
+}
+requirement: {
+  type: BANNED_PROPERTY_CALL
+  error_message: 'Set.prototype.entries is not allowed'
+  value: 'Set.prototype.entries'
+}
+
 # Math
 
 requirement: {
@@ -267,20 +335,8 @@ requirement: {
 
 requirement: {
   type: BANNED_NAME
-  error_message: 'Map is not allowed'
-  value: 'Map'
-}
-
-requirement: {
-  type: BANNED_NAME
   error_message: 'WeakMap is not allowed'
   value: 'WeakMap'
-}
-
-requirement: {
-  type: BANNED_NAME
-  error_message: 'Set is not allowed'
-  value: 'Set'
 }
 
 requirement: {

--- a/build-system/test-configs/dep-check-config.js
+++ b/build-system/test-configs/dep-check-config.js
@@ -419,6 +419,8 @@ exports.rules = [
       'src/polyfills.js->src/polyfills/array-includes.js',
       'src/polyfills.js->src/polyfills/custom-elements.js',
       'src/polyfills.js->src/polyfills/intersection-observer.js',
+      'src/polyfills.js->src/polyfills/map-set.js',
+      'src/polyfills.js->src/polyfills/set-add.js',
       'src/friendly-iframe-embed.js->src/polyfills/custom-elements.js',
       'src/friendly-iframe-embed.js->src/polyfills/document-contains.js',
       'src/friendly-iframe-embed.js->src/polyfills/domtokenlist.js',

--- a/src/polyfills.js
+++ b/src/polyfills.js
@@ -24,10 +24,12 @@ import {install as installDocContains} from './polyfills/document-contains';
 import {install as installFetch} from './polyfills/fetch';
 import {install as installGetBoundingClientRect} from './get-bounding-client-rect';
 import {install as installIntersectionObserver} from './polyfills/intersection-observer';
+import {install as installMapSet} from './polyfills/map-set';
 import {install as installMathSign} from './polyfills/math-sign';
 import {install as installObjectAssign} from './polyfills/object-assign';
 import {install as installObjectValues} from './polyfills/object-values';
 import {install as installPromise} from './polyfills/promise';
+import {install as installSetAdd} from './polyfills/set-add';
 
 if (!IS_ESM) {
   installFetch(self);
@@ -36,6 +38,8 @@ if (!IS_ESM) {
   installObjectValues(self);
   installPromise(self);
   installArrayIncludes(self);
+  installMapSet(self);
+  installSetAdd(self);
 }
 
 // Polyfills that depend on DOM availability

--- a/src/polyfills/array-includes.js
+++ b/src/polyfills/array-includes.js
@@ -43,7 +43,7 @@ function includes(value, opt_fromIndex) {
  */
 export function install(win) {
   if (!win.Array.prototype.includes) {
-    win.Object.defineProperty(Array.prototype, 'includes', {
+    win.Object.defineProperty(win.Array.prototype, 'includes', {
       enumerable: false,
       configurable: true,
       writable: true,

--- a/src/polyfills/map-set.js
+++ b/src/polyfills/map-set.js
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Forces the return value from Map.prototype.set to always be the map
+ * instance. IE11 returns undefined.
+ *
+ * @param {!Window} win
+ */
+export function install(win) {
+  const {Map} = win;
+  const m = new Map();
+  if (m.set(0, 0) !== m) {
+    const {set} = m;
+
+    win.Object.defineProperty(Map.prototype, 'set', {
+      enumerable: false,
+      configurable: true,
+      writable: true,
+      value: function () {
+        set.apply(this, arguments);
+        return this;
+      },
+    });
+  }
+}

--- a/src/polyfills/set-add.js
+++ b/src/polyfills/set-add.js
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Forces the return value from Set.prototype.add to always be the set
+ * instance. IE11 returns undefined.
+ *
+ * @param {!Window} win
+ */
+export function install(win) {
+  const {Set} = win;
+  const s = new Set();
+  if (s.add(0) !== s) {
+    const {add} = s;
+
+    win.Object.defineProperty(Set.prototype, 'add', {
+      enumerable: false,
+      configurable: true,
+      writable: true,
+      value: function () {
+        add.apply(this, arguments);
+        return this;
+      },
+    });
+  }
+}


### PR DESCRIPTION
Allows `Map` and `Set`, since they're well supported even in IE11.

We had previously banned these because we couldn't prevent the automatic import of the entire iteration polyfill. That doesn't seem to be a problem anymore.

/cc @caroqliu 