### PR TITLE
🐛 Fix unit tests broken by #26687

### DIFF
--- a/test/unit/test-url-replacements.js
+++ b/test/unit/test-url-replacements.js
@@ -193,16 +193,7 @@ describes.sandboxed('UrlReplacements', {}, env => {
         win.document.head = {
           nodeType: /* element */ 1,
           // Fake query selectors needed to bypass <meta> tag checks.
-          querySelector: selector => {
-            if (selector === 'meta[name="amp-link-variable-allowed-origin"]') {
-              return {
-                getAttribute: () => {
-                  return 'https://whitelisted.com https://greylisted.com http://example.com';
-                },
-              };
-            }
-            return null;
-          },
+          querySelector: () => null,
           querySelectorAll: () => [],
           getRootNode() {
             return win.document;
@@ -213,6 +204,10 @@ describes.sandboxed('UrlReplacements', {}, env => {
         win.__AMP_SERVICES.documentInfo = null;
         installDocumentInfoServiceForDoc(ampdoc);
         win.ampdoc = ampdoc;
+        env.sandbox.stub(win.ampdoc, 'getMeta').returns({
+          'amp-link-variable-allowed-origin':
+            'https://whitelisted.com https://greylisted.com http://example.com',
+        });
         installUrlReplacementsServiceForDoc(ampdoc);
         return win;
       }

--- a/test/unit/test-variable-source.js
+++ b/test/unit/test-variable-source.js
@@ -19,8 +19,6 @@ import {
   getTimingDataAsync,
 } from '../../src/service/variable-source';
 
-import {createElementWithAttributes} from '../../src/dom';
-
 describes.fakeWin(
   'VariableSource',
   {
@@ -130,12 +128,9 @@ describes.fakeWin(
       env => {
         let variableSource;
         beforeEach(() => {
-          env.win.document.head.appendChild(
-            createElementWithAttributes(env.win.document, 'meta', {
-              name: 'amp-allowed-url-macros',
-              content: 'ABC,ABCD,CANONICAL',
-            })
-          );
+          env.sandbox.stub(env.ampdoc, 'getMeta').returns({
+            'amp-allowed-url-macros': 'ABC,ABCD,CANONICAL',
+          });
           variableSource = new VariableSource(env.ampdoc);
         });
 
@@ -168,12 +163,9 @@ describes.fakeWin(
     );
 
     it('Should not work with empty variable whitelist', () => {
-      env.win.document.head.appendChild(
-        createElementWithAttributes(env.win.document, 'meta', {
-          name: 'amp-allowed-url-macros',
-          content: '',
-        })
-      );
+      env.sandbox.stub(env.ampdoc, 'getMeta').returns({
+        'amp-allowed-url-macros': '',
+      });
       const variableSource = new VariableSource(env.ampdoc);
 
       variableSource.setAsync('RANDOM', () => Promise.resolve('0.1234'));

--- a/test/unit/url-expander/test-expander.js
+++ b/test/unit/url-expander/test-expander.js
@@ -16,7 +16,6 @@
 
 import {Expander} from '../../../src/service/url-expander/expander';
 import {GlobalVariableSource} from '../../../src/service/url-replacements-impl';
-import {createElementWithAttributes} from '../../../src/dom';
 import {macroTask} from '../../../testing/yield';
 
 describes.realWin(
@@ -100,12 +99,9 @@ describes.realWin(
       };
 
       function createExpanderWithWhitelist(whitelist, mockBindings) {
-        env.win.document.head.appendChild(
-          createElementWithAttributes(env.win.document, 'meta', {
-            name: 'amp-allowed-url-macros',
-            content: whitelist,
-          })
-        );
+        env.sandbox.stub(env.ampdoc, 'getMeta').returns({
+          'amp-allowed-url-macros': whitelist,
+        });
 
         variableSource = new GlobalVariableSource(env.ampdoc);
         return new Expander(variableSource, mockBindings);


### PR DESCRIPTION
Cached meta tags feature requires stubbing `AmpDoc.getMeta` to ensure old
(or missing) meta tags are not reused in future tests.