### PR TITLE
🐛 Maintain ad-rolling state, use to init dock controls

### DIFF
--- a/extensions/amp-video-docking/0.1/controls.js
+++ b/extensions/amp-video-docking/0.1/controls.js
@@ -344,7 +344,7 @@ export class Controls {
   /**
    * @return {{
    *   isMuted: boolean,
-   *   isInAdPlayback: boolean,
+   *   isRollingAd: boolean,
    *   isPlaying: boolean,
    * }} state
    * @private
@@ -432,7 +432,7 @@ export class Controls {
 
   /** @private */
   showOnNextAnimationFrame_() {
-    const {isInAdPlayback, isMuted, isPlaying} = this.videoState_;
+    const {isRollingAd, isMuted, isPlaying} = this.videoState_;
     const {container, overlay} = this;
 
     toggle(container, true);
@@ -441,7 +441,7 @@ export class Controls {
     overlay.classList.add('amp-video-docked-controls-bg');
 
     this.useControlSet_(
-      isInAdPlayback ? ControlSet.SCROLL_BACK : ControlSet.PLAYBACK
+      isRollingAd ? ControlSet.SCROLL_BACK : ControlSet.PLAYBACK
     );
 
     toggle(this.playButton_, !isPlaying);

--- a/extensions/amp-video-docking/0.1/controls.js
+++ b/extensions/amp-video-docking/0.1/controls.js
@@ -252,7 +252,6 @@ export class Controls {
   setVideo(video, area) {
     this.area_ = area;
 
-    // TODO(alanorozco): We could keep a plain Element instead.
     if (this.video_ !== video) {
       this.video_ = video;
       this.listen_(video);

--- a/extensions/amp-video-docking/0.1/controls.js
+++ b/extensions/amp-video-docking/0.1/controls.js
@@ -348,8 +348,7 @@ export class Controls {
    *   isPlaying: boolean,
    * }} state
    * @private
-   * TODO(alanorozco): Bookkeep entry before showing on next frame as a small
-   * optimization. If using a VideoEntry then we can destructure that instead.
+   * TODO(go.amp.dev/issue/27010): Bookkeep VideoEntry instead.
    */
   get videoState_() {
     const video = dev().assert(this.video_);

--- a/extensions/amp-video-docking/0.1/controls.js
+++ b/extensions/amp-video-docking/0.1/controls.js
@@ -421,7 +421,7 @@ export class Controls {
 
     const isRollingAd = manager.isRollingAd(video);
     const isMuted = manager.isMuted(video);
-    const isPlaying = manager.isPlaying(video);
+    const isPlaying = manager.getPlayingState(video) !== PlayingStates.PAUSED;
 
     const {container, overlay} = this;
 

--- a/extensions/amp-video-docking/0.1/controls.js
+++ b/extensions/amp-video-docking/0.1/controls.js
@@ -341,21 +341,6 @@ export class Controls {
     );
   }
 
-  /**
-   * @return {{
-   *   isMuted: boolean,
-   *   isRollingAd: boolean,
-   *   isPlaying: boolean,
-   * }} state
-   * @private
-   * TODO(go.amp.dev/issue/27010): Bookkeep VideoEntry instead.
-   */
-  get videoState_() {
-    const video = dev().assert(this.video_);
-    const manager = Services.videoManagerForDoc(this.ampdoc_);
-    return manager.getState(video);
-  }
-
   /** @private */
   onPlay_() {
     const {playButton_, pauseButton_} = this;
@@ -431,7 +416,13 @@ export class Controls {
 
   /** @private */
   showOnNextAnimationFrame_() {
-    const {isRollingAd, isMuted, isPlaying} = this.videoState_;
+    const manager = Services.videoManagerForDoc(this.ampdoc_);
+    const video = devAssert(this.video_);
+
+    const isRollingAd = manager.isRollingAd(video);
+    const isMuted = manager.isMuted(video);
+    const isPlaying = manager.isPlaying(video);
+
     const {container, overlay} = this;
 
     toggle(container, true);

--- a/extensions/amp-viqeo-player/0.1/test/test-amp-viqeo-player.js
+++ b/extensions/amp-viqeo-player/0.1/test/test-amp-viqeo-player.js
@@ -207,7 +207,7 @@ describes.realWin(
         .then(() => viqeoElement.layoutCallback())
         .then(() => {
           const videoManager = Services.videoManagerForDoc(doc);
-          const entry = videoManager.getEntryForElement_(viqeoElement);
+          const entry = videoManager.getEntry_(viqeoElement);
           return Promise.resolve({
             viqeoElement,
             videoManager,

--- a/src/service/video-manager-impl.js
+++ b/src/service/video-manager-impl.js
@@ -387,16 +387,6 @@ export class VideoManager {
   isRollingAd(videoOrElement) {
     return this.getEntry_(videoOrElement).isRollingAd();
   }
-
-  /**
-   * @param {!../video-interface.VideoOrBaseElementDef|!Element} videoOrElement
-   * @return {boolean}
-   */
-  isPlaying(videoOrElement) {
-    return (
-      this.getEntry_(videoOrElement).getPlayingState() !== PlayingStates.PAUSED
-    );
-  }
 }
 
 /**

--- a/src/service/video-manager-impl.js
+++ b/src/service/video-manager-impl.js
@@ -511,12 +511,6 @@ class VideoEntry {
       this.logCustomAnalytics_(eventType, data['vars']);
     });
 
-    // TODO(alanorozco): Listeners below could be symmetrical (ie. just one)
-    // if consolidating VideoEvents with VideoAnalyticsEvents,
-    // e.g. `video-` prefix. This also applies to most other handlers that
-    // trigger an analyticsEvent.
-    // (Ensure symmetry between types via unit test.)
-
     listen(video.element, VideoEvents.ENDED, () => {
       this.isRollingAd_ = false;
       analyticsEvent(this, VideoAnalyticsEvents.ENDED);

--- a/src/service/video-manager-impl.js
+++ b/src/service/video-manager-impl.js
@@ -372,7 +372,7 @@ export class VideoManager {
 
   /** @param {*} unusedVideo */
   isRollingAd(unusedVideo) {
-    dev().assert(false, "Don't implement. Use getEntryState().");
+    devAssert(false, "Don't implement. Use getEntryState().");
   }
 
   /**
@@ -387,7 +387,7 @@ export class VideoManager {
    * but we need to restructure public methods first.
    */
   getState(videoOrElement) {
-    const entry = dev().assert(this.getEntry_(videoOrElement));
+    const entry = devAssert(this.getEntry_(videoOrElement));
     return {
       isPlaying: entry.getPlayingState() !== PlayingStates.PAUSED,
       isRollingAd: entry.isRollingAd(),

--- a/src/service/video-manager-impl.js
+++ b/src/service/video-manager-impl.js
@@ -372,7 +372,7 @@ export class VideoManager {
 
   /** @param {*} unusedVideo */
   isRollingAd(unusedVideo) {
-    devAssert(false, "Don't implement. Use getEntryState().");
+    devAssert(false, "Don't implement. Use .getState()");
   }
 
   /**

--- a/src/service/video-manager-impl.js
+++ b/src/service/video-manager-impl.js
@@ -394,7 +394,7 @@ export class VideoManager {
  * @return {boolean}
  */
 const isEntryFor = (entry, videoOrElement) =>
-  entry &&
+  !!entry &&
   (entry.video === videoOrElement || entry.video.element === videoOrElement);
 
 /**

--- a/src/service/video-manager-impl.js
+++ b/src/service/video-manager-impl.js
@@ -298,6 +298,7 @@ export class VideoManager {
     if (lastFoundEntry && isEntryFor(lastFoundEntry, videoOrElement)) {
       return lastFoundEntry;
     }
+
     for (let i = 0; i < this.entries_.length; i++) {
       const entry = this.entries_[i];
       if (isEntryFor(entry, videoOrElement)) {
@@ -398,6 +399,11 @@ export class VideoManager {
   }
 }
 
+/**
+ * @param {!VideoEntry} entry
+ * @param {!../video-interface.VideoOrBaseElementDef|!Element} videoOrElement
+ * @return {boolean}
+ */
 const isEntryFor = (entry, videoOrElement) =>
   entry.video === videoOrElement || entry.video.element === videoOrElement;
 

--- a/src/service/video-manager-impl.js
+++ b/src/service/video-manager-impl.js
@@ -317,11 +317,11 @@ export class VideoManager {
     return this.getAutoFullscreenManager_();
   }
 
-  // TODO(alanorozco): For getters below, let's expose VideoEntry instead and
-  // use directly. This is better for size and sanity. Users can also then
-  // keep the entry reference for their own use.
+  // TODO(go.amp.dev/issue/27010): For getters below, let's expose VideoEntry
+  // instead and use directly. This is better for size and sanity. Users can
+  // also then keep the entry reference for their own use.
   // (Can't expose yet due to package-level methods to be restructured, e.g
-  // videoLoaded())
+  // videoLoaded(). See issue)
 
   /**
    * Gets the current analytics details property for the given video.
@@ -383,8 +383,7 @@ export class VideoManager {
    *   isPlaying: boolean,
    *   userInteracted: boolean,
    * }}
-   * TODO(alanorozco): These should be part of an exposed VideoEntry instead,
-   * but we need to restructure public methods first.
+   * TODO(go.amp.dev/issue/27010): These should be part of an exposed VideoEntry
    */
   getState(videoOrElement) {
     const entry = devAssert(this.getEntry_(videoOrElement));

--- a/src/service/video-manager-impl.js
+++ b/src/service/video-manager-impl.js
@@ -294,9 +294,8 @@ export class VideoManager {
    * @return {VideoEntry} entry
    */
   getEntry_(videoOrElement) {
-    const lastFoundEntry = this.lastFoundEntry_;
-    if (lastFoundEntry && isEntryFor(lastFoundEntry, videoOrElement)) {
-      return lastFoundEntry;
+    if (isEntryFor(this.lastFoundEntry_, videoOrElement)) {
+      return this.lastFoundEntry_;
     }
 
     for (let i = 0; i < this.entries_.length; i++) {
@@ -390,12 +389,13 @@ export class VideoManager {
 }
 
 /**
- * @param {!VideoEntry} entry
- * @param {!../video-interface.VideoOrBaseElementDef|!Element} videoOrElement
+ * @param {?VideoEntry=} entry
+ * @param {?../video-interface.VideoOrBaseElementDef|!Element=} videoOrElement
  * @return {boolean}
  */
 const isEntryFor = (entry, videoOrElement) =>
-  entry.video === videoOrElement || entry.video.element === videoOrElement;
+  entry &&
+  (entry.video === videoOrElement || entry.video.element === videoOrElement);
 
 /**
  * VideoEntry represents an entry in the VideoManager's list.

--- a/src/video-interface.js
+++ b/src/video-interface.js
@@ -528,7 +528,7 @@ export const videoAnalyticsCustomEventTypeKey = '__amp:eventType';
  * Helper union type to be used internally, so that the compiler treats
  * `VideoInterface` objects as `BaseElement`s, which they should be anyway.
  *
- * WARNING: Don't use this at the service level. Its `register` method should
+ * WARNING: Don't use to `register` at the Service level. Registering should
  * only allow `VideoInterface` as a guarding measure.
  *
  * @typedef {!VideoInterface|!./base-element.BaseElement}

--- a/test/integration/test-video-manager.js
+++ b/test/integration/test-video-manager.js
@@ -79,7 +79,7 @@ describe
 
         it('should be paused if autoplay is not set', () => {
           videoManager.register(impl);
-          const entry = videoManager.getEntryForVideo_(impl);
+          const entry = videoManager.getEntry_(impl);
           entry.isVisible_ = false;
 
           const curState = videoManager.getPlayingState(impl);
@@ -91,7 +91,7 @@ describe
 
           videoManager.register(impl);
 
-          const entry = videoManager.getEntryForVideo_(impl);
+          const entry = videoManager.getEntry_(impl);
           env.sandbox.stub(entry, 'userInteracted').returns(true);
           entry.isVisible_ = true;
           entry.loaded_ = true;
@@ -110,7 +110,7 @@ describe
           const visibilityStub = env.sandbox.stub(env.ampdoc, 'isVisible');
           visibilityStub.onFirstCall().returns(true);
 
-          const entry = videoManager.getEntryForVideo_(impl);
+          const entry = videoManager.getEntry_(impl);
           entry.isVisible_ = true;
           entry.loaded_ = true;
           entry.videoVisibilityChanged_();
@@ -132,7 +132,7 @@ describe
             const visibilityStub = env.sandbox.stub(env.ampdoc, 'isVisible');
             visibilityStub.onFirstCall().returns(true);
 
-            const entry = videoManager.getEntryForVideo_(impl);
+            const entry = videoManager.getEntry_(impl);
 
             const supportsAutoplayStub = env.sandbox.stub(
               entry,
@@ -166,7 +166,7 @@ describe
 
           impl.play();
 
-          const entry = videoManager.getEntryForVideo_(impl);
+          const entry = videoManager.getEntry_(impl);
           env.sandbox.stub(entry, 'userInteracted').returns(true);
           entry.isVisible_ = false;
 
@@ -181,7 +181,7 @@ describe
           video.setAttribute('autoplay', '');
 
           videoManager.register(impl);
-          const entry = videoManager.getEntryForVideo_(impl);
+          const entry = videoManager.getEntry_(impl);
           entry.isVisible_ = false;
 
           expect(videoManager.userInteracted(impl)).to.be.false;
@@ -191,7 +191,7 @@ describe
           video.setAttribute('autoplay', '');
 
           videoManager.register(impl);
-          const entry = videoManager.getEntryForVideo_(impl);
+          const entry = videoManager.getEntry_(impl);
           entry.isVisible_ = true;
           entry.loaded_ = true;
           entry.videoVisibilityChanged_();
@@ -216,7 +216,7 @@ describe
           const visibilityStub = env.sandbox.stub(env.ampdoc, 'isVisible');
           visibilityStub.onFirstCall().returns(true);
 
-          const entry = videoManager.getEntryForVideo_(impl);
+          const entry = videoManager.getEntry_(impl);
           entry.isVisible_ = true;
           entry.loaded_ = true;
           entry.videoVisibilityChanged_();
@@ -229,7 +229,7 @@ describe
 
         it('no autoplay - should pause if user presses pause after playing', () => {
           videoManager.register(impl);
-          const entry = videoManager.getEntryForVideo_(impl);
+          const entry = videoManager.getEntry_(impl);
           entry.isVisible_ = false;
 
           impl.play();
@@ -244,7 +244,7 @@ describe
 
         it('no autoplay - should be playing manual whenever playing', () => {
           videoManager.register(impl);
-          const entry = videoManager.getEntryForVideo_(impl);
+          const entry = videoManager.getEntry_(impl);
           entry.isVisible_ = false;
 
           impl.play();


### PR DESCRIPTION
Fixes #26980.

- Keeps `isRollingAd` state.
- Consolidates `getEntry(ForVideo|ForElement)_`.
- Rather than keep the manager as an intermediary for `VideoEntry` state, this exposes all state at once and proposes restructuring/moving public methods instead. Exposing all state at once prevents running a linear search thrice when showing controls.