### PR TITLE
✨ Add support for tracking sub ids for revcontent amp ads

### DIFF
--- a/ads/revcontent.js
+++ b/ads/revcontent.js
@@ -36,6 +36,7 @@ export function revcontent(global, data) {
 
   const required = ['id', 'height'];
   const optional = [
+    'subIds',
     'revcontent',
     'env',
     'loadscript',

--- a/ads/revcontent.md
+++ b/ads/revcontent.md
@@ -58,6 +58,7 @@ Supported parameters:
 - `data-ssl`
 - `data-testing`
 - `data-loadscript`
+- `data-sub-ids`
 
 ## Auto-sizing of Ads
 


### PR DESCRIPTION
Revcontent has support for some verbose stats tracking called sub ids, but they were never implemented into our amp ad code as a supported attribute. This PR adds a parameter for them so that users can pass these along to our ad code and have them track as intended. While it's possible to pass these anyways, this parameter ensures that there are no console errors due to unknown attributes.