### PR TITLE
🏗️ enable 2-at-a-time batching for all sauce labs tests 

### DIFF
--- a/build-system/pr-check/remote-tests.js
+++ b/build-system/pr-check/remote-tests.js
@@ -47,10 +47,7 @@ async function main() {
 
     await startSauceConnect(FILENAME);
     timedExecOrDie('gulp unit --nobuild --saucelabs');
-    timedExecOrDie(
-      'gulp integration --nobuild --compiled --saucelabs --stable'
-    );
-    timedExecOrDie('gulp integration --nobuild --compiled --saucelabs --beta');
+    timedExecOrDie('gulp integration --nobuild --compiled --saucelabs');
 
     stopSauceConnect(FILENAME);
   } else {
@@ -84,12 +81,7 @@ async function main() {
       buildTargets.has('FLAG_CONFIG') ||
       buildTargets.has('INTEGRATION_TEST')
     ) {
-      timedExecOrDie(
-        'gulp integration --nobuild --compiled --saucelabs --stable'
-      );
-      timedExecOrDie(
-        'gulp integration --nobuild --compiled --saucelabs --beta'
-      );
+      timedExecOrDie('gulp integration --nobuild --compiled --saucelabs');
     }
     stopSauceConnect(FILENAME);
   }

--- a/build-system/tasks/runtime-test/helpers.js
+++ b/build-system/tasks/runtime-test/helpers.js
@@ -29,7 +29,7 @@ const {green, yellow, cyan, red} = require('ansi-colors');
 const {isTravisBuild} = require('../../common/travis');
 const {Server} = require('karma');
 
-const BATCHSIZE = 4; // Number of Sauce Lab browsers
+const BATCHSIZE = 2; // Number of Sauce Lab browsers
 const CHROMEBASE = argv.chrome_canary ? 'ChromeCanary' : 'Chrome';
 const chromeFlags = [];
 


### PR DESCRIPTION
### What's going on

We have 15 concurrency slots in our Sauce Labs plan. This is not the number of open tunnels; it's the number of browser test sessions we have running at any one time. When we issue test requests in excess of the limit, Sauce Labs will try to queue them for a short time; according to [Sauce](https://support.saucelabs.com/hc/en-us/articles/225243308-Why-am-I-not-getting-the-parallelism-concurrency-I-expected-):

> Queuing is intended to deal with small mistakes in concurrency management. Sauce Labs does not recommend queuing tests intentionally.
>
> Tests that are queued for too long will time out with an error. Tests may also time out if too many tests are already queued.  Sauce Labs reserves the right to alter queue size, time and availability at will.

When we run `gulp integration --saucelabs --stable`, it triggers \~6 browser runs simultaneously. Some complete quickly (like IE11, which runs only one test) while others are much slower (ie. Chrome latest and canary, which run all tests). This full parallelism means that a single PR consumes a peak of 5\~6 concurrency sessions. During peak contribution hours (\~5pm EST == \~2pm PST), the high PR  volume means a high number of (both pull and push) Travis jobs running tests on Sauce.

As the queue gets long--our peak concurrency in the last month is usually around 25--some browser sessions never run, reporting timeout errors in Travis and failing the tests. This in turn causes the developer to re-start the Travis job, re-queue the Sauce sessions, and in turn delay/break other Travis jobs.

### What this does

This re-enables batching functionality for Sauce. We use it already for unit tests, but it was disabled for integration tests a while back because we didn't think it was needed. Instead of running 5~6 browsers at a time, it batches requests into at most 2 at a time. This will limit any given Travis job to creating 2 sessions, and should drastically reduce our peak session load.

By looking at 10 previous (successful) Sauce Labs jobs on Travis, I determined the mean runtime to be 1842s with a standard deviation of 137s. This yields a 95% confidence-interval of [1568s, 2117]. Test runs of these changes resulted in a runtime of 2038s, indicating there was not a statistically significant increase in the runtime due to the restricted concurrency.

### Why 2 at a time instead of 3 or 4

Why not? Increasing concurrency (or leaving it as unlimited) clearly didn't significantly reduce runtime, even when all tests run successfully. Reducing it to 2 is sufficient to maintain good performance, and has the potential to drastically reduce Sauce test flakiness by addressing the concurrency limit issue.

Could we increase the batch size to 3? Probably, for now. But a) it wouldn't actually reduce runtime (as evidence shows) b) it would increase the likelihood of Sauce flaking during high-activity periods and c) it will have to be adjusted further if/when the developer team grows in such a way as to increase our PR rate (or during events like Fixits where there is a surge).