### PR TITLE
♻️ Alias video.fullscreen action for symmetry with interface names

### DIFF
--- a/spec/amp-actions-and-events.md
+++ b/spec/amp-actions-and-events.md
@@ -604,7 +604,7 @@ The actions below are supported in the following AMP video elements: `amp-video`
     <td>Unmutes the video.</td>
   </tr>
   <tr>
-    <td><code>fullscreen</code></td>
+    <td><code>fullscreenenter</code></td>
     <td>Takes the video to fullscreen.</td>
   </tr>
 </table>

--- a/src/service/video-manager-impl.js
+++ b/src/service/video-manager-impl.js
@@ -226,7 +226,7 @@ export class VideoManager {
 
     // fullscreen/fullscreenenter are a special case.
     // - fullscreenenter is kept as a standard name for symmetry with internal
-    // internal interfaceswhile
+    //   internal interfaces
     // - fullscreen is an undocumented alias for backwards compatibility.
     const fullscreenEnter = video.fullscreenEnter.bind(video);
     registerAction('fullscreen', fullscreenEnter);

--- a/src/service/video-manager-impl.js
+++ b/src/service/video-manager-impl.js
@@ -288,42 +288,40 @@ export class VideoManager {
   }
 
   /**
-   * Returns the entry in the video manager corresponding to the video or
-   * element provided
-   * @param {!../video-interface.VideoOrBaseElementDef|!Element} videoOrElement
+   * Returns the entry in the video manager corresponding to the video
+   * provided
+   *
+   * @param {!../video-interface.VideoInterface} video
    * @return {VideoEntry} entry
+   * @private
    */
-  getEntry_(videoOrElement) {
-    if (isEntryFor(this.lastFoundEntry_, videoOrElement)) {
-      return this.lastFoundEntry_;
-    }
-
+  getEntryForVideo_(video) {
     for (let i = 0; i < this.entries_.length; i++) {
-      const entry = this.entries_[i];
-      if (isEntryFor(entry, videoOrElement)) {
-        this.lastFoundEntry_ = entry;
-        return entry;
+      if (this.entries_[i].video === video) {
+        return this.entries_[i];
       }
     }
-
-    return devAssert(
-      null,
-      '%s not registered to VideoManager',
-      videoOrElement.element || videoOrElement
-    );
-  }
-
-  /** @param {!VideoEntry} entry */
-  registerForAutoFullscreen(entry) {
-    this.getAutoFullscreenManager_().register(entry);
+    dev().error(TAG, 'video is not registered to this video manager');
+    return null;
   }
 
   /**
-   * @return {!AutoFullscreenManager}
-   * @visibleForTesting
+   * Returns the entry in the video manager corresponding to the element
+   * provided
+   *
+   * @param {!AmpElement} element
+   * @return {VideoEntry} entry
+   * @private
    */
-  getAutoFullscreenManagerForTesting_() {
-    return this.getAutoFullscreenManager_();
+  getEntryForElement_(element) {
+    for (let i = 0; i < this.entries_.length; i++) {
+      const entry = this.entries_[i];
+      if (entry.video.element === element) {
+        return entry;
+      }
+    }
+    dev().error(TAG, 'video is not registered to this video manager');
+    return null;
   }
 
   /**

--- a/src/service/video-manager-impl.js
+++ b/src/service/video-manager-impl.js
@@ -225,9 +225,9 @@ export class VideoManager {
     registerAction('unmute', () => video.unmute());
 
     // fullscreen/fullscreenenter are a special case.
-    // fullscreenenter is kept as a standard name for symmetry
-    // with internal interfaces, while fullscreen is an undocumented alias
-    // for backwards compatibility.
+    // - fullscreenenter is kept as a standard name for symmetry with internal
+    // internal interfaceswhile
+    // - fullscreen is an undocumented alias for backwards compatibility.
     const fullscreenEnter = video.fullscreenEnter.bind(video);
     registerAction('fullscreen', fullscreenEnter);
     registerAction('fullscreenenter', fullscreenEnter);
@@ -288,40 +288,42 @@ export class VideoManager {
   }
 
   /**
-   * Returns the entry in the video manager corresponding to the video
-   * provided
-   *
-   * @param {!../video-interface.VideoInterface} video
+   * Returns the entry in the video manager corresponding to the video or
+   * element provided
+   * @param {!../video-interface.VideoOrBaseElementDef|!Element} videoOrElement
    * @return {VideoEntry} entry
-   * @private
    */
-  getEntryForVideo_(video) {
-    for (let i = 0; i < this.entries_.length; i++) {
-      if (this.entries_[i].video === video) {
-        return this.entries_[i];
-      }
+  getEntry_(videoOrElement) {
+    if (isEntryFor(this.lastFoundEntry_, videoOrElement)) {
+      return this.lastFoundEntry_;
     }
-    dev().error(TAG, 'video is not registered to this video manager');
-    return null;
-  }
 
-  /**
-   * Returns the entry in the video manager corresponding to the element
-   * provided
-   *
-   * @param {!AmpElement} element
-   * @return {VideoEntry} entry
-   * @private
-   */
-  getEntryForElement_(element) {
     for (let i = 0; i < this.entries_.length; i++) {
       const entry = this.entries_[i];
-      if (entry.video.element === element) {
+      if (isEntryFor(entry, videoOrElement)) {
+        this.lastFoundEntry_ = entry;
         return entry;
       }
     }
-    dev().error(TAG, 'video is not registered to this video manager');
-    return null;
+
+    return devAssert(
+      null,
+      '%s not registered to VideoManager',
+      videoOrElement.element || videoOrElement
+    );
+  }
+
+  /** @param {!VideoEntry} entry */
+  registerForAutoFullscreen(entry) {
+    this.getAutoFullscreenManager_().register(entry);
+  }
+
+  /**
+   * @return {!AutoFullscreenManager}
+   * @visibleForTesting
+   */
+  getAutoFullscreenManagerForTesting_() {
+    return this.getAutoFullscreenManager_();
   }
 
   /**

--- a/src/service/video-manager-impl.js
+++ b/src/service/video-manager-impl.js
@@ -223,7 +223,14 @@ export class VideoManager {
     registerAction('pause', () => video.pause());
     registerAction('mute', () => video.mute());
     registerAction('unmute', () => video.unmute());
-    registerAction('fullscreen', () => video.fullscreenEnter());
+
+    // fullscreen/fullscreenenter are a special case.
+    // fullscreenenter is kept as a standard name for symmetry
+    // with internal interfaces, while fullscreen is an undocumented alias
+    // for backwards compatibility.
+    const fullscreenEnter = video.fullscreenEnter.bind(video);
+    registerAction('fullscreen', fullscreenEnter);
+    registerAction('fullscreenenter', fullscreenEnter);
 
     /**
      * @param {string} action

--- a/src/service/video-manager-impl.js
+++ b/src/service/video-manager-impl.js
@@ -228,9 +228,9 @@ export class VideoManager {
     // - fullscreenenter is kept as a standard name for symmetry with internal
     //   internal interfaces
     // - fullscreen is an undocumented alias for backwards compatibility.
-    const fullscreenEnter = video.fullscreenEnter.bind(video);
-    registerAction('fullscreen', fullscreenEnter);
+    const fullscreenEnter = () => video.fullscreenEnter();
     registerAction('fullscreenenter', fullscreenEnter);
+    registerAction('fullscreen', fullscreenEnter);
 
     /**
      * @param {string} action


### PR DESCRIPTION
Maintains external sanity, e.g. we can say "to implement any playback actions on `amp-video-iframe` implement the method with its corresponding name". 