### PR TITLE
📖 Fix validation errors in amp-web-push example

### DIFF
--- a/extensions/amp-web-push/amp-web-push.md
+++ b/extensions/amp-web-push/amp-web-push.md
@@ -90,6 +90,8 @@ The `amp-web-push` component requires extra integration on your site. You will n
 
 ```html
 <amp-web-push
+  id="amp-web-push"
+  layout="nodisplay"
   helper-iframe-url="https://example.com/helper-iframe.html"
   permission-dialog-url="https://example.com/permission-dialog.html"
   service-worker-url="https://example.com/service-worker.js"

--- a/extensions/amp-web-push/amp-web-push.md
+++ b/extensions/amp-web-push/amp-web-push.md
@@ -90,7 +90,6 @@ The `amp-web-push` component requires extra integration on your site. You will n
 
 ```html
 <amp-web-push
-  id="amp-web-push"
   layout="nodisplay"
   helper-iframe-url="https://example.com/helper-iframe.html"
   permission-dialog-url="https://example.com/permission-dialog.html"


### PR DESCRIPTION
The `amp-web-push` validator spec component requires the layout of `nodisplay`:

https://github.com/ampproject/amphtml/blob/8dadf0336300daadf91304946d7959635635390e/extensions/amp-web-push/validator-amp-web-push.protoascii#L68-L70

The current example does not validate against this constraint:

![image](https://user-images.githubusercontent.com/134745/75502070-dca03c80-5a25-11ea-804a-255d08d03ee3.png)

This PR fixes the problem.