### PR TITLE
Aspect ratio format for amp-story-grid-layer

### DIFF
--- a/examples/amp-story/helloworld.html
+++ b/examples/amp-story/helloworld.html
@@ -56,7 +56,7 @@
           <h1>Hello World</h1>
           <p>This is the cover page of this story.</p>
         </amp-story-grid-layer>
-        <amp-story-grid-layer class="box" format="9:16">
+        <amp-story-grid-layer class="box" aspect-ratio="9:16">
           <div class="top"></div>
           <div class="bottom"></div>
           <div class="text">9:16</div>

--- a/examples/amp-story/helloworld.html
+++ b/examples/amp-story/helloworld.html
@@ -23,6 +23,28 @@
         line-height: 1.174;
         text-transform: uppercase;
       }
+      .box {
+        background: rgba(255, 0, 0, 0.3);
+      }
+      .top {
+        position: absolute;
+        left: 0;
+        top: 0;
+        width: 20px;
+        height: 20px;
+        background: green;
+      }
+      .bottom {
+        position: absolute;
+        right: 0;
+        bottom: 0;
+        width: 20px;
+        height: 20px;
+        background: blue;
+      }
+      .text {
+        font-size: 1em;
+      }
     </style>
   </head>
 
@@ -33,6 +55,11 @@
         <amp-story-grid-layer template="vertical">
           <h1>Hello World</h1>
           <p>This is the cover page of this story.</p>
+        </amp-story-grid-layer>
+        <amp-story-grid-layer class="box" format="9:16">
+          <div class="top"></div>
+          <div class="bottom"></div>
+          <div class="text">9:16</div>
         </amp-story-grid-layer>
       </amp-story-page>
 

--- a/extensions/amp-story/1.0/amp-story-grid-layer.js
+++ b/extensions/amp-story/1.0/amp-story-grid-layer.js
@@ -114,14 +114,14 @@ export class AmpStoryGridLayer extends AmpStoryBaseLayer {
   onLayoutMeasure() {
     super.onLayoutMeasure();
 
-    const format = this.element.getAttribute('format');
-    if (!format) {
+    const aspectRatio = this.element.getAttribute('aspect-ratio');
+    if (!aspectRatio) {
       return;
     }
 
-    const formatSplits = format.split(':');
-    const horiz = parseInt(formatSplits[0], 10);
-    const vert = parseInt(formatSplits[1], 10);
+    const aspectRatioSplits = aspectRatio.split(':');
+    const horiz = parseInt(aspectRatioSplits[0], 10);
+    const vert = parseInt(aspectRatioSplits[1], 10);
 
     return this.getVsync().runPromise(
       {

--- a/extensions/amp-story/1.0/amp-story-grid-layer.js
+++ b/extensions/amp-story/1.0/amp-story-grid-layer.js
@@ -133,7 +133,7 @@ export class AmpStoryGridLayer extends AmpStoryBaseLayer {
   }
 
   /**
-   * @param {{width: number, height: number}} pageSize
+   * @param {?{width: number, height: number}} pageSize
    * @private
    */
   updatePageSize_(pageSize) {

--- a/extensions/amp-story/1.0/amp-story-grid-layer.js
+++ b/extensions/amp-story/1.0/amp-story-grid-layer.js
@@ -26,6 +26,7 @@
  * </code>
  */
 
+import {StateProperty, getStoreService} from './amp-story-store-service';
 import {AmpStoryBaseLayer} from './amp-story-base-layer';
 import {assertDoesNotContainDisplay, px, setStyles} from '../../../src/style';
 import {matches, scopedQuerySelectorAll} from '../../../src/dom';
@@ -84,6 +85,9 @@ export class AmpStoryGridLayer extends AmpStoryBaseLayer {
 
     /** @private {boolean} */
     this.prerenderAllowed_ = false;
+
+    /** @private {?{horiz: number, vert: number}} */
+    this.aspectRatio_ = null;
   }
 
   /** @override */
@@ -101,6 +105,7 @@ export class AmpStoryGridLayer extends AmpStoryBaseLayer {
     this.applyTemplateClassName_();
     this.setOwnCssGridStyles_();
     this.setDescendentCssGridStyles_();
+    this.initializeListeners_();
   }
 
   /** @override */
@@ -108,41 +113,50 @@ export class AmpStoryGridLayer extends AmpStoryBaseLayer {
     return this.prerenderAllowed_;
   }
 
-  // TODO(26866): switch back to onMeasuredChange and remove the layoutBox
-  // equality checks.
-  /** @override */
-  onLayoutMeasure() {
-    super.onLayoutMeasure();
-
+  /** @private */
+  initializeListeners_() {
     const aspectRatio = this.element.getAttribute('aspect-ratio');
-    if (!aspectRatio) {
+    if (aspectRatio) {
+      const aspectRatioSplits = aspectRatio.split(':');
+      const horiz = parseInt(aspectRatioSplits[0], 10);
+      const vert = parseInt(aspectRatioSplits[1], 10);
+      if (horiz > 0 && vert > 0) {
+        this.aspectRatio_ = {horiz, vert};
+        const storeService = getStoreService(this.win);
+        storeService.subscribe(
+          StateProperty.PAGE_SIZE,
+          this.updatePageSize_.bind(this),
+          true /* callToInitialize */
+        );
+      }
+    }
+  }
+
+  /**
+   * @param {{width: number, height: number}} pageSize
+   * @private
+   */
+  updatePageSize_(pageSize) {
+    if (!pageSize) {
       return;
     }
-
-    const aspectRatioSplits = aspectRatio.split(':');
-    const horiz = parseInt(aspectRatioSplits[0], 10);
-    const vert = parseInt(aspectRatioSplits[1], 10);
-
-    return this.getVsync().runPromise(
-      {
-        measure: state => {
-          const parent = this.element.parentElement;
-          const vw = parent./*OK*/ clientWidth;
-          const vh = parent./*OK*/ clientHeight;
-          state.width = Math.min(vw, vh * horiz / vert);
-          state.height = Math.min(vh, vw * vert / horiz);
-        },
-        mutate: ({width, height}) => {
-          if (width === 0 && height === 0) {
-            return;
-          }
-          this.element.classList.add('i-amphtml-story-grid-template-aspect');
-          this.element.style.setProperty('--i-amphtml-story-layer-width', px(width));
-          this.element.style.setProperty('--i-amphtml-story-layer-height', px(height));
-        },
-      },
-      {}
-    );
+    const {width: vw, height: vh} = pageSize;
+    const {horiz, vert} = this.aspectRatio_;
+    const width = Math.min(vw, (vh * horiz) / vert);
+    const height = Math.min(vh, (vw * vert) / horiz);
+    if (width > 0 && height > 0) {
+      this.getVsync().mutate(() => {
+        this.element.classList.add('i-amphtml-story-grid-template-aspect');
+        this.element.style.setProperty(
+          '--i-amphtml-story-layer-width',
+          px(width)
+        );
+        this.element.style.setProperty(
+          '--i-amphtml-story-layer-height',
+          px(height)
+        );
+      });
+    }
   }
 
   /**

--- a/extensions/amp-story/1.0/amp-story-grid-layer.js
+++ b/extensions/amp-story/1.0/amp-story-grid-layer.js
@@ -26,8 +26,8 @@
  * </code>
  */
 
-import {StateProperty, getStoreService} from './amp-story-store-service';
 import {AmpStoryBaseLayer} from './amp-story-base-layer';
+import {StateProperty, getStoreService} from './amp-story-store-service';
 import {assertDoesNotContainDisplay, px, setStyles} from '../../../src/style';
 import {matches, scopedQuerySelectorAll} from '../../../src/dom';
 
@@ -147,14 +147,10 @@ export class AmpStoryGridLayer extends AmpStoryBaseLayer {
     if (width > 0 && height > 0) {
       this.getVsync().mutate(() => {
         this.element.classList.add('i-amphtml-story-grid-template-aspect');
-        this.element.style.setProperty(
-          '--i-amphtml-story-layer-width',
-          px(width)
-        );
-        this.element.style.setProperty(
-          '--i-amphtml-story-layer-height',
-          px(height)
-        );
+        setStyles(this.element, {
+          '--i-amphtml-story-layer-width': px(width),
+          '--i-amphtml-story-layer-height': px(height),
+        });
       });
     }
   }

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -544,7 +544,7 @@ export class AmpStoryPage extends AMP.BaseElement {
           if (state.vh === 0 && state.vw === 0) {
             return;
           }
-          this.storeService_.dispatch(Action.UPDATE_PAGE_SIZE, {height, width});
+          this.storeService_.dispatch(Action.SET_PAGE_SIZE, {height, width});
           if (!this.cssVariablesStyleEl_) {
             const doc = this.win.document;
             this.cssVariablesStyleEl_ = doc.createElement('style');

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -531,6 +531,8 @@ export class AmpStoryPage extends AMP.BaseElement {
                   width: this.element./*OK*/ clientWidth,
                 }
               : layoutBox;
+          state.height = height;
+          state.width = width;
           state.vh = height / 100;
           state.vw = width / 100;
           state.fiftyVw = Math.round(width / 2);
@@ -538,9 +540,11 @@ export class AmpStoryPage extends AMP.BaseElement {
           state.vmax = Math.max(state.vh, state.vw);
         },
         mutate: state => {
+          const {height, width} = state;
           if (state.vh === 0 && state.vw === 0) {
             return;
           }
+          this.storeService_.dispatch(Action.UPDATE_PAGE_SIZE, {height, width});
           if (!this.cssVariablesStyleEl_) {
             const doc = this.win.document;
             this.cssVariablesStyleEl_ = doc.createElement('style');

--- a/extensions/amp-story/1.0/amp-story-store-service.js
+++ b/extensions/amp-story/1.0/amp-story-store-service.js
@@ -189,7 +189,7 @@ export const Action = {
   TOGGLE_UI: 'toggleUi',
   TOGGLE_VIEWPORT_WARNING: 'toggleViewportWarning',
   ADD_NEW_PAGE_ID: 'addNewPageId',
-  UPDATE_PAGE_SIZE: 'updatePageSize',
+  SET_PAGE_SIZE: 'updatePageSize',
 };
 
 /**
@@ -397,7 +397,7 @@ const actions = (state, action, data) => {
         ...state,
         [StateProperty.PAGE_IDS]: data,
       });
-    case Action.UPDATE_PAGE_SIZE:
+    case Action.SET_PAGE_SIZE:
       return /** @type {!State} */ ({
         ...state,
         [StateProperty.PAGE_SIZE]: data,

--- a/extensions/amp-story/1.0/amp-story-store-service.js
+++ b/extensions/amp-story/1.0/amp-story-store-service.js
@@ -109,6 +109,7 @@ export let InteractiveComponentDef;
  *    currentPageIndex: number,
  *    pageIds: !Array<string>,
  *    newPageAvailableId: string,
+ *    pageSize: {width: number, height: number},
  * }}
  */
 export let State;
@@ -156,6 +157,7 @@ export const StateProperty = {
   NAVIGATION_PATH: 'navigationPath',
   NEW_PAGE_AVAILABLE_ID: 'newPageAvailableId',
   PAGE_IDS: 'pageIds',
+  PAGE_SIZE: 'pageSize',
 };
 
 /** @const @enum {string} */
@@ -187,6 +189,7 @@ export const Action = {
   TOGGLE_UI: 'toggleUi',
   TOGGLE_VIEWPORT_WARNING: 'toggleViewportWarning',
   ADD_NEW_PAGE_ID: 'addNewPageId',
+  UPDATE_PAGE_SIZE: 'updatePageSize',
 };
 
 /**
@@ -394,6 +397,11 @@ const actions = (state, action, data) => {
         ...state,
         [StateProperty.PAGE_IDS]: data,
       });
+    case Action.UPDATE_PAGE_SIZE:
+      return /** @type {!State} */ ({
+        ...state,
+        [StateProperty.PAGE_SIZE]: data,
+      });
     default:
       dev().error(TAG, 'Unknown action %s.', action);
       return state;
@@ -526,6 +534,7 @@ export class AmpStoryStoreService {
       [StateProperty.NEW_PAGE_AVAILABLE_ID]: '',
       [StateProperty.NAVIGATION_PATH]: [],
       [StateProperty.PAGE_IDS]: [],
+      [StateProperty.PAGE_SIZE]: null,
     });
   }
 

--- a/extensions/amp-story/1.0/amp-story.css
+++ b/extensions/amp-story/1.0/amp-story.css
@@ -450,6 +450,13 @@ amp-story-grid-layer .i-amphtml-embedded-component::after {
                        "lower-third" !important;
 }
 
+.i-amphtml-story-grid-template-aspect {
+  margin: auto;
+  width: var(--i-amphtml-story-layer-width, 100%);
+  height: var(--i-amphtml-story-layer-height, 100%);
+  font-size: calc(var(--i-amphtml-story-layer-height, 100vh) / 10);
+}
+
 /**
  * Development mode
  */

--- a/extensions/amp-story/1.0/test/test-amp-story-grid-layer.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-grid-layer.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/extensions/amp-story/1.0/test/test-amp-story-grid-layer.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-grid-layer.js
@@ -1,0 +1,133 @@
+/**
+ * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Action, AmpStoryStoreService} from '../amp-story-store-service';
+import {AmpDocSingle} from '../../../../src/service/ampdoc-impl';
+import {AmpStoryGridLayer} from '../amp-story-grid-layer';
+import {AmpStoryPage} from '../amp-story-page';
+import {LocalizationService} from '../../../../src/service/localization';
+import {MediaType} from '../media-pool';
+import {Services} from '../../../../src/services';
+import {registerServiceBuilder} from '../../../../src/service';
+
+describes.realWin('amp-story-grid-layer', {amp: true}, env => {
+  let win;
+  let element;
+  let gridLayerEl;
+  let page;
+  let grid;
+  let storeService;
+
+  beforeEach(() => {
+    win = env.win;
+
+    env.sandbox
+      .stub(Services, 'vsyncFor')
+      .callsFake(() => ({mutate: task => task()}));
+
+    const mediaPoolRoot = {
+      getElement: () => win.document.createElement('div'),
+      getMaxMediaElementCounts: () => ({
+        [MediaType.VIDEO]: 8,
+        [MediaType.AUDIO]: 8,
+      }),
+    };
+
+    storeService = new AmpStoryStoreService(win);
+    registerServiceBuilder(win, 'story-store', function() {
+      return storeService;
+    });
+
+    const localizationService = new LocalizationService(win);
+    registerServiceBuilder(win, 'localization', function() {
+      return localizationService;
+    });
+
+    registerServiceBuilder(win, 'performance', function() {
+      return {
+        isPerformanceTrackingOn: () => false,
+      };
+    });
+
+    const story = win.document.createElement('amp-story');
+    story.getImpl = () => Promise.resolve(mediaPoolRoot);
+
+    element = win.document.createElement('amp-story-page');
+    gridLayerEl = win.document.createElement('amp-story-grid-layer');
+    element.getAmpDoc = () => new AmpDocSingle(win);
+    element.appendChild(gridLayerEl);
+    story.appendChild(element);
+    win.document.body.appendChild(story);
+
+    page = new AmpStoryPage(element);
+    env.sandbox.stub(page, 'mutateElement').callsFake(fn => fn());
+
+    grid = new AmpStoryGridLayer(gridLayerEl);
+  });
+
+  afterEach(() => {
+    element.remove();
+  });
+
+  async function buildGridLayer() {
+    page.buildCallback();
+    await page.layoutCallback();
+    grid.buildCallback();
+    await grid.layoutCallback();
+  }
+
+  it('should set the vertical aspect-ratio', async () => {
+    gridLayerEl.setAttribute('aspect-ratio', '9:16');
+    await buildGridLayer();
+
+    storeService.dispatch(Action.SET_PAGE_SIZE, {width: 1000, height: 1000});
+
+    expect(gridLayerEl).to.have.class('i-amphtml-story-grid-template-aspect');
+    expect(
+      parseInt(
+        gridLayerEl.style.getPropertyValue('--i-amphtml-story-layer-width'),
+        10
+      )
+    ).to.equal(562);
+    expect(
+      parseInt(
+        gridLayerEl.style.getPropertyValue('--i-amphtml-story-layer-height'),
+        10
+      )
+    ).to.equal(1000);
+  });
+
+  it('should set the horizontal aspect-ratio', async () => {
+    gridLayerEl.setAttribute('aspect-ratio', '16:9');
+    await buildGridLayer();
+
+    storeService.dispatch(Action.SET_PAGE_SIZE, {width: 1000, height: 1000});
+
+    expect(gridLayerEl).to.have.class('i-amphtml-story-grid-template-aspect');
+    expect(
+      parseInt(
+        gridLayerEl.style.getPropertyValue('--i-amphtml-story-layer-width'),
+        10
+      )
+    ).to.equal(1000);
+    expect(
+      parseInt(
+        gridLayerEl.style.getPropertyValue('--i-amphtml-story-layer-height'),
+        10
+      )
+    ).to.equal(562);
+  });
+});

--- a/extensions/amp-story/1.0/test/validator-amp-story-grid-layer-error.html
+++ b/extensions/amp-story/1.0/test/validator-amp-story-grid-layer-error.html
@@ -29,8 +29,8 @@
   </head>
 
   <body>
-    <amp-story standalone>
-      <amp-story-page>
+    <amp-story standalone title="My Story" publisher="Me" publisher-logo-src="http://me.com/logo.png" poster-portrait-src="http://me.com/poster.jpg">
+      <amp-story-page id="cover">
         <amp-story-grid-layer aspect-ratio="a:b" template="vertical">
         </amp-story-grid-layer>
       </amp-story-page>

--- a/extensions/amp-story/1.0/test/validator-amp-story-grid-layer-error.html
+++ b/extensions/amp-story/1.0/test/validator-amp-story-grid-layer-error.html
@@ -1,0 +1,40 @@
+<!--
+  Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS-IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the license.
+-->
+<!--
+  Test Description:
+  Tests for the live story functionality inside amp-story.
+-->
+<!doctype html>
+<html amp lang="en">
+  <head>
+    <meta charset="utf-8">
+    <script async src="https://cdn.ampproject.org/v0.js"></script>
+    <script async custom-element="amp-story"
+        src="https://cdn.ampproject.org/v0/amp-story-1.0.js"></script>
+    <title>amp-story-grid-layer</title>
+    <meta name="viewport"
+          content="width=device-width,minimum-scale=1,initial-scale=1">
+    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+    <link rel="canonical" href="index.html">
+  </head>
+
+  <body>
+    <amp-story standalone>
+      <amp-story-page>
+        <amp-story-grid-layer aspect-ratio="a:b" template="vertical">
+        </amp-story-grid-layer>
+      </amp-story-page>
+    </amp-story>
+  </body>
+
+</html>

--- a/extensions/amp-story/1.0/test/validator-amp-story-grid-layer-error.html
+++ b/extensions/amp-story/1.0/test/validator-amp-story-grid-layer-error.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+  Copyright 2020 The AMP HTML Authors. All Rights Reserved.
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
@@ -31,6 +31,7 @@
   <body>
     <amp-story standalone title="My Story" publisher="Me" publisher-logo-src="http://me.com/logo.png" poster-portrait-src="http://me.com/poster.jpg">
       <amp-story-page id="cover">
+        <!-- Invalid: aspect-ratio does not contain a numeric value -->
         <amp-story-grid-layer aspect-ratio="a:b" template="vertical">
         </amp-story-grid-layer>
       </amp-story-page>

--- a/extensions/amp-story/1.0/test/validator-amp-story-grid-layer-error.out
+++ b/extensions/amp-story/1.0/test/validator-amp-story-grid-layer-error.out
@@ -1,6 +1,6 @@
 FAIL
 |  <!--
-|    Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+|    Copyright 2020 The AMP HTML Authors. All Rights Reserved.
 |    Licensed under the Apache License, Version 2.0 (the "License");
 |    you may not use this file except in compliance with the License.
 |    You may obtain a copy of the License at
@@ -32,9 +32,10 @@ FAIL
 |    <body>
 |      <amp-story standalone title="My Story" publisher="Me" publisher-logo-src="http://me.com/logo.png" poster-portrait-src="http://me.com/poster.jpg">
 |        <amp-story-page id="cover">
+|          <!-- Invalid: aspect-ratio does not contain a numeric value -->
 |          <amp-story-grid-layer aspect-ratio="a:b" template="vertical">
 >>         ^~~~~~~~~
-amp-story/1.0/test/validator-amp-story-grid-layer-error.html:34:8 The attribute 'aspect-ratio' in tag 'amp-story-grid-layer' is set to the invalid value 'a:b'.
+amp-story/1.0/test/validator-amp-story-grid-layer-error.html:35:8 The attribute 'aspect-ratio' in tag 'amp-story-grid-layer' is set to the invalid value 'a:b'.
 |          </amp-story-grid-layer>
 |        </amp-story-page>
 |      </amp-story>

--- a/extensions/amp-story/1.0/test/validator-amp-story-grid-layer-error.out
+++ b/extensions/amp-story/1.0/test/validator-amp-story-grid-layer-error.out
@@ -30,11 +30,11 @@ FAIL
 |    </head>
 |
 |    <body>
-|      <amp-story standalone>
-|        <amp-story-page>
+|      <amp-story standalone title="My Story" publisher="Me" publisher-logo-src="http://me.com/logo.png" poster-portrait-src="http://me.com/poster.jpg">
+|        <amp-story-page id="cover">
 |          <amp-story-grid-layer aspect-ratio="a:b" template="vertical">
->>     ^~~~~~~~~
-amp-story/1.0/test/validator-amp-story-grid-layer-error.html:35:6 The attribute 'aspec-ratio' in tag 'amp-story-grid-layer' is set to the invalid value 'a:b'. (see https://amp.dev/documentation/components/amp-story)
+>>         ^~~~~~~~~
+amp-story/1.0/test/validator-amp-story-grid-layer-error.html:34:8 The attribute 'aspect-ratio' in tag 'amp-story-grid-layer' is set to the invalid value 'a:b'.
 |          </amp-story-grid-layer>
 |        </amp-story-page>
 |      </amp-story>

--- a/extensions/amp-story/1.0/test/validator-amp-story-grid-layer-error.out
+++ b/extensions/amp-story/1.0/test/validator-amp-story-grid-layer-error.out
@@ -1,0 +1,43 @@
+FAIL
+|  <!--
+|    Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|        http://www.apache.org/licenses/LICENSE-2.0
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Tests for the live story functionality inside amp-story.
+|  -->
+|  <!doctype html>
+|  <html amp lang="en">
+|    <head>
+|      <meta charset="utf-8">
+|      <script async src="https://cdn.ampproject.org/v0.js"></script>
+|      <script async custom-element="amp-story"
+|          src="https://cdn.ampproject.org/v0/amp-story-1.0.js"></script>
+|      <title>amp-story-grid-layer</title>
+|      <meta name="viewport"
+|            content="width=device-width,minimum-scale=1,initial-scale=1">
+|      <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|      <link rel="canonical" href="index.html">
+|    </head>
+|
+|    <body>
+|      <amp-story standalone>
+|        <amp-story-page>
+|          <amp-story-grid-layer aspect-ratio="a:b" template="vertical">
+>>     ^~~~~~~~~
+amp-story/1.0/test/validator-amp-story-grid-layer-error.html:35:6 The attribute 'aspec-ratio' in tag 'amp-story-grid-layer' is set to the invalid value 'a:b'. (see https://amp.dev/documentation/components/amp-story)
+|          </amp-story-grid-layer>
+|        </amp-story-page>
+|      </amp-story>
+|    </body>
+|
+|  </html>

--- a/extensions/amp-story/1.0/test/validator-amp-story-grid-layer.html
+++ b/extensions/amp-story/1.0/test/validator-amp-story-grid-layer.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+  Copyright 2020 The AMP HTML Authors. All Rights Reserved.
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at

--- a/extensions/amp-story/1.0/test/validator-amp-story-grid-layer.html
+++ b/extensions/amp-story/1.0/test/validator-amp-story-grid-layer.html
@@ -1,0 +1,40 @@
+<!--
+  Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS-IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the license.
+-->
+<!--
+  Test Description:
+  Tests for the live story functionality inside amp-story.
+-->
+<!doctype html>
+<html amp lang="en">
+  <head>
+    <meta charset="utf-8">
+    <script async src="https://cdn.ampproject.org/v0.js"></script>
+    <script async custom-element="amp-story"
+        src="https://cdn.ampproject.org/v0/amp-story-1.0.js"></script>
+    <title>amp-story-grid-layer</title>
+    <meta name="viewport"
+          content="width=device-width,minimum-scale=1,initial-scale=1">
+    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+    <link rel="canonical" href="index.html">
+  </head>
+
+  <body>
+    <amp-story standalone>
+      <amp-story-page>
+        <amp-story-grid-layer aspect-ratio="9:16" template="vertical">
+        </amp-story-grid-layer>
+      </amp-story-page>
+    </amp-story>
+  </body>
+
+</html>

--- a/extensions/amp-story/1.0/test/validator-amp-story-grid-layer.html
+++ b/extensions/amp-story/1.0/test/validator-amp-story-grid-layer.html
@@ -29,8 +29,8 @@
   </head>
 
   <body>
-    <amp-story standalone>
-      <amp-story-page>
+    <amp-story standalone title="My Story" publisher="Me" publisher-logo-src="http://me.com/logo.png" poster-portrait-src="http://me.com/poster.jpg">
+      <amp-story-page id="cover">
         <amp-story-grid-layer aspect-ratio="9:16" template="vertical">
         </amp-story-grid-layer>
       </amp-story-page>

--- a/extensions/amp-story/1.0/test/validator-amp-story-grid-layer.out
+++ b/extensions/amp-story/1.0/test/validator-amp-story-grid-layer.out
@@ -1,6 +1,6 @@
 PASS
 |  <!--
-|    Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+|    Copyright 2020 The AMP HTML Authors. All Rights Reserved.
 |    Licensed under the Apache License, Version 2.0 (the "License");
 |    you may not use this file except in compliance with the License.
 |    You may obtain a copy of the License at

--- a/extensions/amp-story/1.0/test/validator-amp-story-grid-layer.out
+++ b/extensions/amp-story/1.0/test/validator-amp-story-grid-layer.out
@@ -30,8 +30,8 @@ PASS
 |    </head>
 |
 |    <body>
-|      <amp-story standalone>
-|        <amp-story-page>
+|      <amp-story standalone title="My Story" publisher="Me" publisher-logo-src="http://me.com/logo.png" poster-portrait-src="http://me.com/poster.jpg">
+|        <amp-story-page id="cover">
 |          <amp-story-grid-layer aspect-ratio="9:16" template="vertical">
 |          </amp-story-grid-layer>
 |        </amp-story-page>

--- a/extensions/amp-story/1.0/test/validator-amp-story-grid-layer.out
+++ b/extensions/amp-story/1.0/test/validator-amp-story-grid-layer.out
@@ -1,0 +1,41 @@
+PASS
+|  <!--
+|    Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|        http://www.apache.org/licenses/LICENSE-2.0
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Tests for the live story functionality inside amp-story.
+|  -->
+|  <!doctype html>
+|  <html amp lang="en">
+|    <head>
+|      <meta charset="utf-8">
+|      <script async src="https://cdn.ampproject.org/v0.js"></script>
+|      <script async custom-element="amp-story"
+|          src="https://cdn.ampproject.org/v0/amp-story-1.0.js"></script>
+|      <title>amp-story-grid-layer</title>
+|      <meta name="viewport"
+|            content="width=device-width,minimum-scale=1,initial-scale=1">
+|      <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|      <link rel="canonical" href="index.html">
+|    </head>
+|
+|    <body>
+|      <amp-story standalone>
+|        <amp-story-page>
+|          <amp-story-grid-layer aspect-ratio="9:16" template="vertical">
+|          </amp-story-grid-layer>
+|        </amp-story-page>
+|      </amp-story>
+|    </body>
+|
+|  </html>

--- a/extensions/amp-story/amp-story-grid-layer.md
+++ b/extensions/amp-story/amp-story-grid-layer.md
@@ -69,8 +69,8 @@ Example:
 ```html
 <amp-story-grid-layer aspect-ratio="9:16" template="vertical">
   <div style="width: 10%; height: 10%; font-size: 2em;">
-    This block will be in 9:16 aspect ratio and font size will be set at the
-    20% of the layer's height.
+    This block will be in 9:16 aspect ratio and font size will be set at the 20%
+    of the layer's height.
   </div>
 </amp-story-grid-layer>
 ```

--- a/extensions/amp-story/amp-story-grid-layer.md
+++ b/extensions/amp-story/amp-story-grid-layer.md
@@ -60,6 +60,21 @@ Example:
 </amp-story-grid-layer>
 ```
 
+### aspect-ratio [optional]
+
+The value specifies an aspect ratio in the "horizontal:vertical" format, where both "horizontal" and "vertical" are integer numbers. If this attribute is specified, the layout of the grid layer is set to conform to the specified proportions. The font size, in this case, is automatically set to the 1/10th of the resulting height to enable proportional content scaling.
+
+Example:
+
+```html
+<amp-story-grid-layer aspect-ratio="9:16" template="vertical">
+  <div style="width: 10%; height: 10%; font-size: 2em;">
+    This block will be in 9:16 aspect ratio and font size will be set at the
+    20% of the layer's height.
+  </div>
+</amp-story-grid-layer>
+```
+
 ## Templates
 
 The following are available templates to specify for the layout of the grid layer.

--- a/extensions/amp-story/validator-amp-story.protoascii
+++ b/extensions/amp-story/validator-amp-story.protoascii
@@ -151,6 +151,10 @@ tags: {  # <amp-story-grid-layer>
     value: "landscape-half-left"
     value: "landscape-half-right"
   }
+  attrs: {
+    name: "aspect-ratio"
+    value_regex: "\\d+:\\d+"
+  }
   descendant_tag_list: "amp-story-grid-layer-allowed-descendants"
   reference_points: {
     tag_spec_name: "AMP-STORY-GRID-LAYER default"

--- a/src/style.js
+++ b/src/style.js
@@ -150,7 +150,7 @@ export function getStyle(element, property, opt_bypassCache) {
     return undefined;
   }
   if (isVar(propertyName)) {
-    return element.getProperty(propertyName);
+    return element.style.getPropertyValue(propertyName);
   }
   return element.style[propertyName];
 }

--- a/src/style.js
+++ b/src/style.js
@@ -64,7 +64,7 @@ function getVendorJsPropertyName_(style, titleCase) {
  * @return {string}
  */
 export function getVendorJsPropertyName(style, camelCase, opt_bypassCache) {
-  if (startsWith(camelCase, '--')) {
+  if (isVar(camelCase)) {
     // CSS vars are returned as is.
     return camelCase;
   }
@@ -120,10 +120,16 @@ export function setStyle(element, property, value, opt_units, opt_bypassCache) {
     property,
     opt_bypassCache
   );
-  if (propertyName) {
-    element.style[propertyName] = /** @type {string} */ (opt_units
-      ? value + opt_units
-      : value);
+  if (!propertyName) {
+    return;
+  }
+  const styleValue = /** @type {string} */ (opt_units
+    ? value + opt_units
+    : value);
+  if (isVar(propertyName)) {
+    element.style.setProperty(propertyName, styleValue);
+  } else {
+    element.style[propertyName] = styleValue;
   }
 }
 
@@ -142,6 +148,9 @@ export function getStyle(element, property, opt_bypassCache) {
   );
   if (!propertyName) {
     return undefined;
+  }
+  if (isVar(propertyName)) {
+    return element.getProperty(propertyName);
   }
   return element.style[propertyName];
 }
@@ -359,4 +368,12 @@ export function propagateObjectFitStyles(fromEl, toEl) {
   if (fromEl.hasAttribute('object-position')) {
     setStyle(toEl, 'object-position', fromEl.getAttribute('object-position'));
   }
+}
+
+/**
+ * @param {string} property
+ * @return {boolean}
+ */
+function isVar(property) {
+  return startsWith(property, '--');
 }

--- a/test/unit/test-style.js
+++ b/test/unit/test-style.js
@@ -45,6 +45,13 @@ describe('Style', () => {
     expect(element.style.WebkitTransitionDuration).to.equal('1s');
   });
 
+  it('setStyle with custom var', () => {
+    const element = document.createElement('div');
+    st.setStyle(element, '--x', '1px');
+    expect(element.style.getPropertyValue('--x')).to.equal('1px');
+    expect(st.getStyle(element, '--x')).to.equal('1px');
+  });
+
   it('setStyles', () => {
     const element = document.createElement('div');
     st.setStyles(element, {


### PR DESCRIPTION
Fixes #27049

Blocked by: #27145

Let's discuss and if this works I will add the tests, validator rules, and documentation.

The most critical aspect here is `font-size`. Everything else could in theory be calculated via CSS, but font-size is the only outlier. The `font-size` has to be referenceable from the height, or in other words `font-size = X% of height`. So the only real choice here is `X`. I started with `100%`, but then I actually tried `10%` and I liked that a lot better. It's quite natural to use `em` units with that, as well as `%` values. Let me know what you think.

Another nuance: I used two private CSS vars and moved the actual CSS assignments to the private `i-amphtml-story-grid-template-aspect` class. I did this so that it's easy to override any of these values in the user stylesheet.

TODO:

- [x] Tests
- [x] Validation rules
- [x] Documentation
