### PR TITLE
gulp performance: emit status updates

### DIFF
--- a/build-system/tasks/performance/measure-documents.js
+++ b/build-system/tasks/performance/measure-documents.js
@@ -15,6 +15,7 @@
  */
 
 const fs = require('fs');
+const log = require('fancy-log');
 const {
   CONTROL,
   EXPERIMENT,
@@ -201,9 +202,19 @@ async function measureDocuments(urls, {headless, runs}) {
     ])
   );
 
+  const startTime = Date.now();
+  function timeLeft() {
+    const elapsed = (Date.now() - startTime) / 1000;
+    const secondsPerTask = elapsed / i;
+    return Math.floor(secondsPerTask * (tasks.length - i));
+  }
+
   // Excecute the tasks serially
-  const [first, ...rest] = tasks;
-  await rest.reduce((prev, task) => prev.then(task), first());
+  let i = 0;
+  for (const task of tasks) {
+    log(`Progress: ${i++}/${tasks.length}. ${timeLeft()} seconds left.`);
+    await task();
+  }
 }
 
 module.exports = measureDocuments;


### PR DESCRIPTION
**summary**
I recently started taking advantage of the new `gulp performance` task. During its execution, it always emits a message about calling `yarn install`, but then appears to hang until all the measurements are complete. For a single link with 100 runs, this meant 12m without a status update.

This PR adds progress notification to the task. Here is an example of the output:
<img width="672" alt="Screen Shot 2020-02-28 at 6 19 16 PM" src="https://user-images.githubusercontent.com/4656974/75594468-dbd3ce80-5a56-11ea-96d3-57e039497013.png">
