### PR TITLE
fix single-pass to use `transferSrcsToTempDir`

### DIFF
--- a/build-system/compile/compile.js
+++ b/build-system/compile/compile.js
@@ -358,9 +358,7 @@ function compile(
       delete compilerOptions.define;
     }
 
-    if (!argv.single_pass) {
-      compilerOptions.js_module_root.push(SRC_TEMP_DIR);
-    }
+    compilerOptions.js_module_root.push(SRC_TEMP_DIR);
 
     const compilerOptionsArray = [];
     Object.keys(compilerOptions).forEach(function(option) {
@@ -378,12 +376,11 @@ function compile(
       }
     });
 
-    const gulpSrcs = !argv.single_pass ? convertPathsToTmpRoot(srcs) : srcs;
-    const gulpBase = !argv.single_pass ? SRC_TEMP_DIR : '.';
+    const gulpSrcs = convertPathsToTmpRoot(srcs);
 
     if (options.typeCheckOnly) {
       return gulp
-        .src(gulpSrcs, {base: gulpBase})
+        .src(gulpSrcs, {base: SRC_TEMP_DIR})
         .pipe(sourcemaps.init({loadMaps: true}))
         .pipe(gulpClosureCompile(compilerOptionsArray, checkTypesNailgunPort))
         .on('error', err => {
@@ -395,7 +392,7 @@ function compile(
     } else {
       timeInfo.startTime = Date.now();
       return gulp
-        .src(gulpSrcs, {base: gulpBase})
+        .src(gulpSrcs, {base: SRC_TEMP_DIR})
         .pipe(gulpIf(shouldShortenLicense, shortenLicense()))
         .pipe(sourcemaps.init({loadMaps: true}))
         .pipe(gulpClosureCompile(compilerOptionsArray, distNailgunPort))

--- a/build-system/compile/single-pass.js
+++ b/build-system/compile/single-pass.js
@@ -322,9 +322,11 @@ exports.getGraph = function(entryModules, config) {
     // directly and which we don't want to apply during deps finding.
     .transform(babelify, {
       compact: false,
-      overrides: [{
-        plugins: ['transform-es2015-modules-commonjs'],
-      }],
+      overrides: [
+        {
+          plugins: ['transform-es2015-modules-commonjs'],
+        },
+      ],
     });
   // This gets us the actual deps. We collect them in an array, so
   // we can sort them prior to building the dep tree. Otherwise the tree

--- a/build-system/compile/single-pass.js
+++ b/build-system/compile/single-pass.js
@@ -32,7 +32,6 @@ const pkgUp = require('pkg-up');
 const rename = require('gulp-rename');
 const resorcery = require('@jridgewell/resorcery');
 const sourcemaps = require('gulp-sourcemaps');
-const tempy = require('tempy');
 const terser = require('terser');
 const through = require('through2');
 const {
@@ -50,6 +49,7 @@ const {shortenLicense, shouldShortenLicense} = require('./shorten-license');
 const {TopologicalSort} = require('topological-sort');
 const TYPES_VALUES = Object.keys(TYPES).map(x => TYPES[x]);
 const wrappers = require('./compile-wrappers');
+const {SRC_TEMP_DIR} = require('../compile/sources');
 const {VERSION: internalRuntimeVersion} = require('./internal-version');
 
 const argv = minimist(process.argv.slice(2));
@@ -62,8 +62,6 @@ if (!singlePassDest.endsWith('/')) {
 
 const SPLIT_MARKER = `/** SPLIT_SINGLE_PASS */`;
 
-// Used to store transforms and compile v0.js
-const transformDir = tempy.directory();
 const srcs = [];
 
 const mainBundle = 'src/amp.js';
@@ -299,7 +297,7 @@ exports.getGraph = function(entryModules, config) {
       },
     },
     packages: {},
-    tmp: transformDir,
+    tmp: SRC_TEMP_DIR,
   };
 
   TYPES_VALUES.forEach(type => {
@@ -324,7 +322,9 @@ exports.getGraph = function(entryModules, config) {
     // directly and which we don't want to apply during deps finding.
     .transform(babelify, {
       compact: false,
-      plugins: ['transform-es2015-modules-commonjs'],
+      overrides: [{
+        plugins: ['transform-es2015-modules-commonjs'],
+      }],
     });
   // This gets us the actual deps. We collect them in an array, so
   // we can sort them prior to building the dep tree. Otherwise the tree
@@ -381,7 +381,6 @@ exports.getGraph = function(entryModules, config) {
       graph.sorted = Array.from(topo.sort().keys()).reverse();
 
       setupBundles(graph);
-      transformPathsToTempDir(graph, config);
       resolve(graph);
       fs.writeFileSync('deps.txt', JSON.stringify(graph, null, 2));
     })
@@ -460,43 +459,6 @@ function setupBundles(graph) {
     }
     graph.bundles[dest].modules.push(id);
   });
-}
-
-/**
- * Takes all of the nodes in the dependency graph and transfers them
- * to a temporary directory where we can run babel transformations.
- *
- * @param {!Object} graph
- * @param {!Object} config
- */
-function transformPathsToTempDir(graph, config) {
-  log(
-    'Performing single-pass',
-    colors.cyan('babel'),
-    'transforms in',
-    colors.cyan(graph.tmp) + '...'
-  );
-  // `sorted` will always have the files that we need.
-  graph.sorted.forEach(f => {
-    // For now, just copy node_module files instead of transforming them.
-    if (f.startsWith('node_modules/')) {
-      fs.copySync(f, `${graph.tmp}/${f}`);
-    } else {
-      const {code, map} = babel.transformFileSync(f, {
-        plugins: conf.plugins({
-          isEsmBuild: config.define.indexOf('ESM_BUILD=true') !== -1,
-          isForTesting: config.define.indexOf('FORTESTING=true') !== -1,
-          isSinglePass: true,
-        }),
-        retainLines: true,
-        sourceMaps: true,
-      });
-      fs.outputFileSync(`${graph.tmp}/${f}`, code);
-      fs.outputFileSync(`${graph.tmp}/${f}.map`, JSON.stringify(map));
-    }
-    process.stdout.write('.');
-  });
-  console.log('\n');
 }
 
 // Returns the extension bundle config for the given filename or null.
@@ -719,7 +681,7 @@ function compile(flagsArray) {
   // TODO(@cramforce): Run the post processing step
   return new Promise(function(resolve, reject) {
     gulp
-      .src(srcs, {base: transformDir})
+      .src(srcs, {base: SRC_TEMP_DIR})
       .pipe(gulpIf(shouldShortenLicense, shortenLicense()))
       .pipe(sourcemaps.init({loadMaps: true}))
       .pipe(gulpClosureCompile(flagsArray))

--- a/build-system/compile/single-pass.js
+++ b/build-system/compile/single-pass.js
@@ -321,9 +321,9 @@ exports.getGraph = function(entryModules, config) {
     // The second stage are transforms that closure compiler supports
     // directly and which we don't want to apply during deps finding.
     .transform(babelify, {
-      compact: false,
       overrides: [
         {
+          compact: false,
           plugins: ['transform-es2015-modules-commonjs'],
         },
       ],

--- a/build-system/tasks/dist.js
+++ b/build-system/tasks/dist.js
@@ -101,15 +101,11 @@ async function dist() {
   await compileCss();
   await compileJison();
 
-  // This is the temp directory processing for multi-pass (single-pass does its
-  // own processing). Executed after `compileCss` and `compileJison` so their
-  // results can be copied too.
-  if (!argv.single_pass) {
-    transferSrcsToTempDir({
-      isForTesting: argv.fortesting,
-      isEsmBuild: argv.esm,
-    });
-  }
+  transferSrcsToTempDir({
+    isForTesting: !!argv.fortesting,
+    isEsmBuild: !!argv.esm,
+    isSinglePass: !!argv.single_pass,
+  });
 
   await copyCss();
   await copyParsers();


### PR DESCRIPTION
single pass originally had its own `transformPathsToTempDir` which is very similar to `transferSrcsToTempDir` (pretty much a precursor). We need to unify usage so that the temp directory source is the same for single pass as well as the non single pass binaries ran during the single pass build