### PR TITLE
✨amp-access-scroll: Update the activate bar to properly set up relay for resizing

### DIFF
--- a/extensions/amp-access-scroll/0.1/scroll-bar.js
+++ b/extensions/amp-access-scroll/0.1/scroll-bar.js
@@ -94,7 +94,8 @@ export class ScrollBar extends ScrollComponent {
           '&cid=CLIENT_ID(scroll1)' +
           '&c=CANONICAL_URL' +
           '&o=AMPDOC_URL' +
-          `&p=${PROTOCOL_VERSION}`,
+          `&p=${PROTOCOL_VERSION}` +
+          '&x=QUERY_PARAM(scrollx)',
         false
       )
       .then(scrollbarUrl => {

--- a/extensions/amp-access-scroll/0.1/scroll-bar.js
+++ b/extensions/amp-access-scroll/0.1/scroll-bar.js
@@ -22,9 +22,8 @@ import {dict} from '../../../src/utils/object';
  * UI for Scroll users.
  *
  * Presents a fixed bar at the bottom of the screen with Scroll content.
- * @abstract
  */
-class Bar extends ScrollComponent {
+export class ScrollBar extends ScrollComponent {
   /**
    * @param {!../../../src/service/ampdoc-impl.AmpDoc} doc
    * @param {!../../amp-access/0.1/amp-access-source.AccessSource} accessSource
@@ -84,28 +83,7 @@ class Bar extends ScrollComponent {
 
     this.toggleClass(this.HOLDBACK_CLASS, this.holdback_);
     this.mount();
-  }
 
-  /**
-   * @param {!JsonObject} action
-   */
-  update(action) {
-    const changed = this.updateHorizontalLayout(action);
-
-    if (changed) {
-      this.render_();
-    }
-  }
-}
-
-export class ScrollUserBar extends Bar {
-  /**
-   * Load the scrollbar URL in the iframe.
-   * @protected
-   * @override
-   * */
-  makeIframe_() {
-    Bar.prototype.makeIframe_.call(this);
     // Set iframe to scrollbar URL.
     this.accessSource_
       .buildUrl(
@@ -123,31 +101,15 @@ export class ScrollUserBar extends Bar {
         this.frame_.setAttribute('src', scrollbarUrl);
       });
   }
-}
-/**
- * Add link to the Scroll App connect page.
- */
-export class ActivateBar extends Bar {
-  /**
-   * @protected
-   * @override
-   * */
-  makeIframe_() {
-    Bar.prototype.makeIframe_.call(this);
 
-    this.accessSource_
-      .buildUrl(
-        `${this.baseUrl_}/html/amp/activate` +
-          '?rid=READER_ID' +
-          '&cid=CLIENT_ID(scroll1)' +
-          '&c=CANONICAL_URL' +
-          '&o=AMPDOC_URL' +
-          '&x=QUERY_PARAM(scrollx)' +
-          `&p=${PROTOCOL_VERSION}`,
-        false
-      )
-      .then(url => {
-        this.frame_.setAttribute('src', url);
-      });
+  /**
+   * @param {!JsonObject} action
+   */
+  update(action) {
+    const changed = this.updateHorizontalLayout(action);
+
+    if (changed) {
+      this.render_();
+    }
   }
 }

--- a/extensions/amp-access-scroll/0.1/scroll-impl.js
+++ b/extensions/amp-access-scroll/0.1/scroll-impl.js
@@ -15,11 +15,11 @@
  */
 
 import {AccessClientAdapter} from '../../amp-access/0.1/amp-access-client';
-import {ActivateBar, ScrollUserBar} from './scroll-bar';
 import {CSS} from '../../../build/amp-access-scroll-0.1.css';
 import {PROTOCOL_VERSION} from './scroll-protocol';
 import {ReadDepthTracker} from './read-depth-tracker.js';
 import {Relay} from './scroll-relay';
+import {ScrollBar} from './scroll-bar';
 import {Services} from '../../../src/services';
 import {Sheet} from './scroll-sheet';
 import {createElementWithAttributes} from '../../../src/dom';
@@ -160,7 +160,7 @@ export class ScrollAccessVendor extends AccessClientAdapter {
       if (response && response['scroll']) {
         if (!isStory) {
           // Display Scrollbar and set up features
-          const bar = new ScrollUserBar(
+          const bar = new ScrollBar(
             this.ampdoc,
             this.accessSource_,
             this.baseUrl_,
@@ -250,12 +250,21 @@ class ScrollContentBlocker {
           // TODO(dbow): Ideally we would automatically redirect to the page
           // here, but for now we are adding a button so we redirect on user
           // action.
-          new ActivateBar(
+          const baseUrl = connectHostname(
+            this.accessSource_.getAdapterConfig()
+          );
+          const bar = new ScrollBar(
             this.ampdoc_,
             this.accessSource_,
-            connectHostname(this.accessSource_.getAdapterConfig()),
+            baseUrl,
             holdback
           );
+          const relay = new Relay(baseUrl);
+          relay.register(bar.window, message => {
+            if (message['_scramp'] === 'st') {
+              bar.update(message);
+            }
+          });
         }
       });
   }


### PR DESCRIPTION
- Updates the "Activate" bar to use the same iframe URL as the normal Scroll user bar (we handle the difference on our end now)
- Sets up a Relay so the "Activate" bar can properly resize itself on demand
- Allows us to release the new Scroll UI begun [in 26810](https://github.com/ampproject/amphtml/pull/26810)