### PR TITLE
🌐 Allow overriding document language with viewer language

### DIFF
--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -358,7 +358,7 @@ export class AmpStory extends AMP.BaseElement {
     this.liveStoryManager_ = null;
 
     /** @private @const {!LocalizationService} */
-    this.localizationService_ = new LocalizationService(this.win);
+    this.localizationService_ = new LocalizationService(this.win, this.viewer_);
     const localizationService = this.localizationService_;
     this.localizationService_
       .registerLocalizedStringBundle('default', LocalizedStringsDefault)

--- a/src/service/localization.js
+++ b/src/service/localization.js
@@ -19,6 +19,7 @@
 // eslint-disable-next-line no-unused-vars
 import {LocalizedStringId} from '../localized-strings';
 import {closest} from '../dom';
+import {parseQueryString} from '../url';
 
 /**
  * Language code used if there is no language code specified by the document.
@@ -92,12 +93,20 @@ export class LocalizationService {
    * @param {!Window} win
    */
   constructor(win) {
-    const rootEl = win.document.documentElement;
+    /**
+     * @private @const {!Element}
+     */
+    this.rootEl_ = win.document.documentElement;
+
+    /**
+     * @private {?string}
+     */
+    this.viewerLanguageCode_ = parseQueryString(win.location.hash)['lang'];
 
     /**
      * @private @const {!Array<string>}
      */
-    this.rootLanguageCodes_ = this.getLanguageCodesForElement_(rootEl);
+    this.rootLanguageCodes_ = this.getLanguageCodesForElement_(this.rootEl_);
 
     /**
      * A mapping of language code to localized string bundle.
@@ -114,7 +123,13 @@ export class LocalizationService {
   getLanguageCodesForElement_(element) {
     const languageEl = closest(element, el => el.hasAttribute('lang'));
     const languageCode = languageEl ? languageEl.getAttribute('lang') : null;
-    return getLanguageCodesFromString(languageCode || '');
+    const languageCodesToUse = getLanguageCodesFromString(languageCode || '');
+
+    if (this.viewerLanguageCode_) {
+      languageCodesToUse.unshift(this.viewerLanguageCode_);
+    }
+
+    return languageCodesToUse;
   }
 
   /**

--- a/src/service/localization.js
+++ b/src/service/localization.js
@@ -91,14 +91,15 @@ export function getLanguageCodesFromString(languageCode) {
 export class LocalizationService {
   /**
    * @param {!Window} win
+   * @param {!./viewer-interface.ViewerInterface} viewer
    */
-  constructor(win) {
+  constructor(win, viewer = undefined) {
     const rootEl = win.document.documentElement;
 
     /**
      * @private {?string}
      */
-    this.viewerLanguageCode_ = parseQueryString(win.location.hash)['lang'];
+    this.viewerLanguageCode_ = viewer ? viewer.getParam('lang') : null;
 
     /**
      * @private @const {!Array<string>}

--- a/src/service/localization.js
+++ b/src/service/localization.js
@@ -93,10 +93,7 @@ export class LocalizationService {
    * @param {!Window} win
    */
   constructor(win) {
-    /**
-     * @private @const {!Element}
-     */
-    this.rootEl_ = win.document.documentElement;
+    const rootEl = win.document.documentElement;
 
     /**
      * @private {?string}
@@ -106,7 +103,7 @@ export class LocalizationService {
     /**
      * @private @const {!Array<string>}
      */
-    this.rootLanguageCodes_ = this.getLanguageCodesForElement_(this.rootEl_);
+    this.rootLanguageCodes_ = this.getLanguageCodesForElement_(rootEl);
 
     /**
      * A mapping of language code to localized string bundle.

--- a/test/unit/test-localization.js
+++ b/test/unit/test-localization.js
@@ -158,3 +158,64 @@ describes.fakeWin('localization', {}, env => {
     });
   });
 });
+
+describes.fakeWin(
+  'viewer localization',
+  {
+    win: {
+      location: 'https://example.com/story.html#lang=fr&otherParam=test',
+    },
+  },
+  env => {
+    describe('viewer language override', () => {
+      it('should take precedence over document language', () => {
+        const localizationService = new LocalizationService(env.win);
+        localizationService.registerLocalizedStringBundle('fr', {
+          'test_string_id': {
+            string: 'oui',
+          },
+        });
+        localizationService.registerLocalizedStringBundle('en', {
+          'test_string_id': {
+            string: 'yes',
+          },
+        });
+
+        expect(
+          localizationService.getLocalizedString('test_string_id')
+        ).to.equal('oui');
+      });
+
+      it('should fall back if string is not found', () => {
+        const localizationService = new LocalizationService(env.win);
+        localizationService.registerLocalizedStringBundle('fr', {
+          'incorrect_test_string_id': {
+            string: 'non',
+          },
+        });
+        localizationService.registerLocalizedStringBundle('en', {
+          'correct_test_string_id': {
+            string: 'yes',
+          },
+        });
+
+        expect(
+          localizationService.getLocalizedString('correct_test_string_id')
+        ).to.equal('yes');
+      });
+
+      it('should fall back if language code is not registered', () => {
+        const localizationService = new LocalizationService(env.win);
+        localizationService.registerLocalizedStringBundle('en', {
+          'test_string_id': {
+            string: 'yes',
+          },
+        });
+
+        expect(
+          localizationService.getLocalizedString('test_string_id')
+        ).to.equal('yes');
+      });
+    });
+  }
+);

--- a/test/unit/test-localization.js
+++ b/test/unit/test-localization.js
@@ -159,63 +159,68 @@ describes.fakeWin('localization', {}, env => {
   });
 });
 
-describes.fakeWin(
-  'viewer localization',
-  {
-    win: {
-      location: 'https://example.com/story.html#lang=fr&otherParam=test',
-    },
-  },
-  env => {
-    describe('viewer language override', () => {
-      it('should take precedence over document language', () => {
-        const localizationService = new LocalizationService(env.win);
-        localizationService.registerLocalizedStringBundle('fr', {
-          'test_string_id': {
-            string: 'oui',
-          },
-        });
-        localizationService.registerLocalizedStringBundle('en', {
-          'test_string_id': {
-            string: 'yes',
-          },
-        });
+describes.fakeWin('viewer localization', {}, env => {
+  describe('viewer language override', () => {
+    let viewer;
 
-        expect(
-          localizationService.getLocalizedString('test_string_id')
-        ).to.equal('oui');
-      });
-
-      it('should fall back if string is not found', () => {
-        const localizationService = new LocalizationService(env.win);
-        localizationService.registerLocalizedStringBundle('fr', {
-          'incorrect_test_string_id': {
-            string: 'non',
-          },
-        });
-        localizationService.registerLocalizedStringBundle('en', {
-          'correct_test_string_id': {
-            string: 'yes',
-          },
-        });
-
-        expect(
-          localizationService.getLocalizedString('correct_test_string_id')
-        ).to.equal('yes');
-      });
-
-      it('should fall back if language code is not registered', () => {
-        const localizationService = new LocalizationService(env.win);
-        localizationService.registerLocalizedStringBundle('en', {
-          'test_string_id': {
-            string: 'yes',
-          },
-        });
-
-        expect(
-          localizationService.getLocalizedString('test_string_id')
-        ).to.equal('yes');
-      });
+    beforeEach(() => {
+      viewer = {
+        getParam: param => {
+          if (param === 'lang') {
+            return 'fr';
+          }
+          return undefined;
+        },
+      };
     });
-  }
-);
+
+    it('should take precedence over document language', () => {
+      const localizationService = new LocalizationService(env.win, viewer);
+      localizationService.registerLocalizedStringBundle('fr', {
+        'test_string_id': {
+          string: 'oui',
+        },
+      });
+      localizationService.registerLocalizedStringBundle('en', {
+        'test_string_id': {
+          string: 'yes',
+        },
+      });
+
+      expect(localizationService.getLocalizedString('test_string_id')).to.equal(
+        'oui'
+      );
+    });
+
+    it('should fall back if string is not found', () => {
+      const localizationService = new LocalizationService(env.win, viewer);
+      localizationService.registerLocalizedStringBundle('fr', {
+        'incorrect_test_string_id': {
+          string: 'non',
+        },
+      });
+      localizationService.registerLocalizedStringBundle('en', {
+        'correct_test_string_id': {
+          string: 'yes',
+        },
+      });
+
+      expect(
+        localizationService.getLocalizedString('correct_test_string_id')
+      ).to.equal('yes');
+    });
+
+    it('should fall back if language code is not registered', () => {
+      const localizationService = new LocalizationService(env.win, viewer);
+      localizationService.registerLocalizedStringBundle('en', {
+        'test_string_id': {
+          string: 'yes',
+        },
+      });
+
+      expect(localizationService.getLocalizedString('test_string_id')).to.equal(
+        'yes'
+      );
+    });
+  });
+});


### PR DESCRIPTION
In platform contexts, it makes sense for document-rendered system-level user interfaces to be consistent across documents.  This PR allows an AMP viewer or story player to specify a fragment parameter to indicate the language to be used, falling back to the document's language if unspecified.

Fixes #27023 