### PR TITLE
Adds new touch capability to viewer integration

### DIFF
--- a/extensions/amp-viewer-integration/0.1/amp-viewer-integration.js
+++ b/extensions/amp-viewer-integration/0.1/amp-viewer-integration.js
@@ -223,7 +223,7 @@ export class AmpViewerIntegration {
       this.handleUnload_.bind(this, messaging)
     );
 
-    if (viewer.hasCapability('swipe')) {
+    if (viewer.hasCapability('swipe') || viewer.hasCapability('touch')) {
       this.initTouchHandler_(messaging);
     }
     if (viewer.hasCapability('keyboard')) {


### PR DESCRIPTION
By enabling the `touch` capability, viewers/players will be able to receive touch events from the AMP document even when they don't necessarily support `swiping`.