### PR TITLE
🐛Remove Google Safeframe origin check

### DIFF
--- a/extensions/amp-ad-network-doubleclick-impl/0.1/safeframe-host.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/safeframe-host.js
@@ -202,10 +202,10 @@ export class SafeframeHostApi {
   /**
    * Returns true if the given window matches the Safeframe's content window.
    * @return {Boolean}
-   */  
+   */
    equalsSafeframeContentWindow(otherWindow) {
-    devAssert(this.iframe_, "SafeframeAPI doesn't have an iframe to compare against.");
-    return otherWindow === this.iframe_.contentWindow;
+    devAssert(this.baseInstance_.iframe, "SafeframeAPI doesn't have an iframe to compare against.");
+    return otherWindow === this.baseInstance_.iframe.contentWindow
    }
 
   /**

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/safeframe-host.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/safeframe-host.js
@@ -204,7 +204,6 @@ export class SafeframeHostApi {
    * @return {Boolean}
    */
    equalsSafeframeContentWindow(otherWindow) {
-    devAssert(this.baseInstance_.iframe, "SafeframeAPI doesn't have an iframe to compare against.");
     return otherWindow === this.baseInstance_.iframe.contentWindow
    }
 

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/safeframe-host.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/safeframe-host.js
@@ -204,9 +204,7 @@ export class SafeframeHostApi {
    * @return {Boolean}
    */  
    equalsSafeframeContentWindow(otherWindow) {
-    if (!this.iframe_) {
-      throw new Error("SafeframeAPI doesn't have an iframe to compare against???");
-    }
+    devAssert(this.iframe_, "SafeframeAPI doesn't have an iframe to compare against.");
     return otherWindow === this.iframe_.contentWindow;
    }
 

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/safeframe-host.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/safeframe-host.js
@@ -207,7 +207,9 @@ export class SafeframeHostApi {
    * @return {boolean}
    */
   equalsSafeframeContentWindow(otherWindow) {
-    return otherWindow && otherWindow === this.baseInstance_.iframe.contentWindow;
+    return (
+      otherWindow && otherWindow === this.baseInstance_.iframe.contentWindow
+    );
   }
 
   /**

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/safeframe-host.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/safeframe-host.js
@@ -204,6 +204,9 @@ export class SafeframeHostApi {
    * @return {Boolean}
    */  
    equalsSafeframeContentWindow(otherWindow) {
+    if (!this.iframe_) {
+      throw new Error("SafeframeAPI doesn't have an iframe to compare against???");
+    }
     return otherWindow === this.iframe_.contentWindow;
    }
 

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/safeframe-host.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/safeframe-host.js
@@ -61,9 +61,6 @@ export const SERVICE = {
 /** @private {string} */
 const TAG = 'AMP-DOUBLECLICK-SAFEFRAME';
 
-/** @const {string} */
-export const SAFEFRAME_ORIGIN = 'https://tpc.googlesyndication.com';
-
 /**
  * Event listener callback for message events. If message is a Safeframe
  * message, handles the message. This listener is registered within
@@ -73,7 +70,7 @@ export const SAFEFRAME_ORIGIN = 'https://tpc.googlesyndication.com';
 export function safeframeListener(event) {
   const data = tryParseJson(getData(event));
   /** Only process messages that are valid Safeframe messages */
-  if (event.origin != SAFEFRAME_ORIGIN || !data) {
+  if (!event.origin.endsWith('googlesyndication.com') || !data) {
     return;
   }
   const payload = tryParseJson(data[MESSAGE_FIELDS.PAYLOAD]) || {};
@@ -465,7 +462,7 @@ export class SafeframeHostApi {
     message[MESSAGE_FIELDS.ENDPOINT_IDENTITY] = this.endpointIdentity_;
     this.iframe_.contentWindow./*OK*/ postMessage(
       JSON.stringify(message),
-      SAFEFRAME_ORIGIN
+      "*"
     );
   }
 
@@ -769,7 +766,7 @@ export class SafeframeHostApi {
     this.baseInstance_.fireFluidDelayedImpression();
     this.iframe_.contentWindow./*OK*/ postMessage(
       JSON.stringify(dict({'message': 'resize-complete', 'c': this.channel})),
-      SAFEFRAME_ORIGIN
+      "*"
     );
   }
 

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/safeframe-host.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/safeframe-host.js
@@ -461,7 +461,7 @@ export class SafeframeHostApi {
     message[MESSAGE_FIELDS.ENDPOINT_IDENTITY] = this.endpointIdentity_;
     this.iframe_.contentWindow./*OK*/ postMessage(
       JSON.stringify(message),
-      "*"
+      '*'
     );
   }
 
@@ -765,7 +765,7 @@ export class SafeframeHostApi {
     this.baseInstance_.fireFluidDelayedImpression();
     this.iframe_.contentWindow./*OK*/ postMessage(
       JSON.stringify(dict({'message': 'resize-complete', 'c': this.channel})),
-      "*"
+      '*'
     );
   }
 

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/safeframe-host.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/safeframe-host.js
@@ -83,6 +83,10 @@ export function safeframeListener(event) {
     dev().warn(TAG, `Safeframe Host for sentinel: ${sentinel} not found.`);
     return;
   }
+  if (!safeframeHost.equalsSafeframeContentWindow(event.source)) {
+    dev().warn(TAG, `Safeframe source did not match event.source.`);
+    return;
+  }
   if (!safeframeHost.channel) {
     safeframeHost.connectMessagingChannel(data[MESSAGE_FIELDS.CHANNEL]);
   } else if (payload) {
@@ -194,6 +198,14 @@ export class SafeframeHostApi {
 
     this.registerSafeframeHost();
   }
+
+  /**
+   * Returns true if the given window matches the Safeframe's content window.
+   * @return {Boolean}
+   */  
+   equalsSafeframeContentWindow(otherWindow) {
+    return otherWindow === this.iframe_.contentWindow;
+   }
 
   /**
    * Returns the Safeframe specific name attributes that are needed for the

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/safeframe-host.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/safeframe-host.js
@@ -201,11 +201,13 @@ export class SafeframeHostApi {
 
   /**
    * Returns true if the given window matches the Safeframe's content window.
-   * @return {Boolean}
+   *
+   * @param {!Window} otherWindow
+   * @return {boolean}
    */
-   equalsSafeframeContentWindow(otherWindow) {
-    return otherWindow === this.baseInstance_.iframe.contentWindow
-   }
+  equalsSafeframeContentWindow(otherWindow) {
+    return otherWindow === this.baseInstance_.iframe.contentWindow;
+  }
 
   /**
    * Returns the Safeframe specific name attributes that are needed for the
@@ -471,10 +473,7 @@ export class SafeframeHostApi {
     message[MESSAGE_FIELDS.SERVICE] = serviceName;
     message[MESSAGE_FIELDS.SENTINEL] = this.sentinel_;
     message[MESSAGE_FIELDS.ENDPOINT_IDENTITY] = this.endpointIdentity_;
-    this.iframe_.contentWindow./*OK*/ postMessage(
-      JSON.stringify(message),
-      '*'
-    );
+    this.iframe_.contentWindow./*OK*/ postMessage(JSON.stringify(message), '*');
   }
 
   /**

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/safeframe-host.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/safeframe-host.js
@@ -69,8 +69,7 @@ const TAG = 'AMP-DOUBLECLICK-SAFEFRAME';
  */
 export function safeframeListener(event) {
   const data = tryParseJson(getData(event));
-  /** Only process messages that are valid Safeframe messages */
-  if (!event.origin.endsWith('googlesyndication.com') || !data) {
+  if (!data) {
     return;
   }
   const payload = tryParseJson(data[MESSAGE_FIELDS.PAYLOAD]) || {};

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/safeframe-host.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/safeframe-host.js
@@ -201,12 +201,13 @@ export class SafeframeHostApi {
 
   /**
    * Returns true if the given window matches the Safeframe's content window.
+   * Comparing to a null window will always return false.
    *
-   * @param {!Window} otherWindow
+   * @param {Window|null} otherWindow
    * @return {boolean}
    */
   equalsSafeframeContentWindow(otherWindow) {
-    return otherWindow === this.baseInstance_.iframe.contentWindow;
+    return otherWindow && otherWindow === this.baseInstance_.iframe.contentWindow;
   }
 
   /**

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/safeframe-host.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/safeframe-host.js
@@ -208,7 +208,7 @@ export class SafeframeHostApi {
    */
   equalsSafeframeContentWindow(otherWindow) {
     return (
-      otherWindow && otherWindow === this.baseInstance_.iframe.contentWindow
+      !!otherWindow && otherWindow === this.baseInstance_.iframe.contentWindow
     );
   }
 

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-fluid.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-fluid.js
@@ -63,7 +63,6 @@ const mockPromise = {
   },
 };
 
-window.originalConsoleLog = window.console.log.bind(console.log)
 
 /**
  * Sets up the necessary mocks and stubs to render a fake fluid creative in unit
@@ -244,19 +243,19 @@ describes.realWin('DoubleClick Fast Fetch Fluid', realWinConfig, env => {
       'onFluidResize_'
     );
 
-    originalConsoleLog('safeframeAPI iframe', impl.safeframeApi_.iframe_)
-    originalConsoleLog('IMPL iframe', impl.iframe)
+    console.log('safeframeAPI iframe', impl.safeframeApi_.iframe_)
+    console.log('IMPL iframe', impl.iframe)
 
     // impl.safeframeApi_.iframe_ = impl.iframe; 
 
     return impl.adPromise_.then(() => {
 
-      originalConsoleLog('safeframeAPI iframe', impl.safeframeApi_.iframe_)
-      originalConsoleLog('IMPL iframe', impl.iframe)
+      console.log('safeframeAPI iframe', impl.safeframeApi_.iframe_)
+      console.log('IMPL iframe', impl.iframe)
       return impl.layoutCallback().then(() => {
 
-        originalConsoleLog('safeframeAPI iframe', impl.safeframeApi_.iframe_)
-        originalConsoleLog('IMPL iframe', impl.iframe)
+        console.log('safeframeAPI iframe', impl.safeframeApi_.iframe_)
+        console.log('IMPL iframe', impl.iframe)
         expect(connectMessagingChannelSpy).to.be.calledOnce;
         expect(onFluidResizeSpy).to.be.calledOnce;
       });

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-fluid.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-fluid.js
@@ -41,6 +41,7 @@ const realWinConfig = {
 
 const rawCreative = `
   <script>
+  debugger;
   parent./*OK*/postMessage(
       JSON.stringify(/** @type {!JsonObject} */ ({
         e: 'sentinel',
@@ -61,6 +62,8 @@ const mockPromise = {
     };
   },
 };
+
+window.originalConsoleLog = window.console.log.bind(console.log)
 
 /**
  * Sets up the necessary mocks and stubs to render a fake fluid creative in unit
@@ -240,8 +243,20 @@ describes.realWin('DoubleClick Fast Fetch Fluid', realWinConfig, env => {
       impl.safeframeApi_,
       'onFluidResize_'
     );
+
+    originalConsoleLog('safeframeAPI iframe', impl.safeframeApi_.iframe_)
+    originalConsoleLog('IMPL iframe', impl.iframe)
+
+    // impl.safeframeApi_.iframe_ = impl.iframe; 
+
     return impl.adPromise_.then(() => {
+
+      originalConsoleLog('safeframeAPI iframe', impl.safeframeApi_.iframe_)
+      originalConsoleLog('IMPL iframe', impl.iframe)
       return impl.layoutCallback().then(() => {
+
+        originalConsoleLog('safeframeAPI iframe', impl.safeframeApi_.iframe_)
+        originalConsoleLog('IMPL iframe', impl.iframe)
         expect(connectMessagingChannelSpy).to.be.calledOnce;
         expect(onFluidResizeSpy).to.be.calledOnce;
       });

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-fluid.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-fluid.js
@@ -41,7 +41,6 @@ const realWinConfig = {
 
 const rawCreative = `
   <script>
-  debugger;
   parent./*OK*/postMessage(
       JSON.stringify(/** @type {!JsonObject} */ ({
         e: 'sentinel',
@@ -62,7 +61,6 @@ const mockPromise = {
     };
   },
 };
-
 
 /**
  * Sets up the necessary mocks and stubs to render a fake fluid creative in unit
@@ -242,20 +240,8 @@ describes.realWin('DoubleClick Fast Fetch Fluid', realWinConfig, env => {
       impl.safeframeApi_,
       'onFluidResize_'
     );
-
-    console.log('safeframeAPI iframe', impl.safeframeApi_.iframe_)
-    console.log('IMPL iframe', impl.iframe)
-
-    // impl.safeframeApi_.iframe_ = impl.iframe; 
-
     return impl.adPromise_.then(() => {
-
-      console.log('safeframeAPI iframe', impl.safeframeApi_.iframe_)
-      console.log('IMPL iframe', impl.iframe)
       return impl.layoutCallback().then(() => {
-
-        console.log('safeframeAPI iframe', impl.safeframeApi_.iframe_)
-        console.log('IMPL iframe', impl.iframe)
         expect(connectMessagingChannelSpy).to.be.calledOnce;
         expect(onFluidResizeSpy).to.be.calledOnce;
       });

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-safeframe.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-safeframe.js
@@ -109,7 +109,7 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
   function receiveMessage(messageData, source) {
     const messageEvent = {
       data: JSON.stringify(messageData),
-      source: source,
+      source,
     };
     safeframeListener(messageEvent);
   }

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-safeframe.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-safeframe.js
@@ -22,7 +22,6 @@ import '../../../amp-ad/0.1/amp-ad';
 import {AmpAdNetworkDoubleclickImpl} from '../amp-ad-network-doubleclick-impl';
 import {
   MESSAGE_FIELDS,
-  SAFEFRAME_ORIGIN,
   SERVICE,
   SafeframeHostApi,
   removeSafeframeListener,
@@ -110,7 +109,6 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
   function receiveMessage(messageData) {
     const messageEvent = {
       data: JSON.stringify(messageData),
-      origin: SAFEFRAME_ORIGIN,
     };
     safeframeListener(messageEvent);
   }

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-safeframe.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-safeframe.js
@@ -128,9 +128,6 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
         'postMessage'
       );
 
-      doubleclickImpl.iframe = safeframeMock;
-      safeframeHost.iframe_ = safeframeMock;
-
       sendSetupMessage();
 
       // Verify that the channel was set up
@@ -538,7 +535,6 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
       const safeframeMock = createElementWithAttributes(doc, 'iframe', {});
       ampAd.appendChild(safeframeMock);
       doubleclickImpl.iframe = safeframeMock;
-      safeframeHost.iframe_ = safeframeMock;
 
       const onScrollStub = env.sandbox./*OK*/ stub(
         safeframeHost.viewport_,
@@ -711,7 +707,6 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
       });
       ampAd.appendChild(safeframeMock);
       doubleclickImpl.iframe = safeframeMock;
-      safeframeHost.iframe_ = safeframeMock;
       resizeSafeframeSpy = env.sandbox./*OK*/ spy(
         safeframeHost,
         'resizeSafeframe'

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-safeframe.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-safeframe.js
@@ -127,7 +127,6 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
         safeframeMock.contentWindow,
         'postMessage'
       );
-
       sendSetupMessage();
 
       // Verify that the channel was set up

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-safeframe.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-safeframe.js
@@ -102,7 +102,7 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
       initialWidth: '100',
       sentinel: safeframeHost.sentinel_,
     });
-    receiveMessage(message, safeframeHost.contentWindow);
+    receiveMessage(message, safeframeHost.iframe_.contentWindow);
   }
 
   // Simulates receiving a post message from the safeframe.

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-safeframe.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-safeframe.js
@@ -89,7 +89,7 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
     const messageData = {};
     messageData[MESSAGE_FIELDS.SENTINEL] = doubleclickImpl.sentinel;
     messageData[MESSAGE_FIELDS.CHANNEL] = safeframeChannel;
-    receiveMessage(messageData);
+    receiveMessage(messageData, doubleclickImpl.iframe.contentWindow);
   }
 
   function sendRegisterDoneMessage() {
@@ -102,13 +102,14 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
       initialWidth: '100',
       sentinel: safeframeHost.sentinel_,
     });
-    receiveMessage(message);
+    receiveMessage(message, safeframeHost.contentWindow);
   }
 
   // Simulates receiving a post message from the safeframe.
-  function receiveMessage(messageData) {
+  function receiveMessage(messageData, source) {
     const messageEvent = {
       data: JSON.stringify(messageData),
+      source: source,
     };
     safeframeListener(messageEvent);
   }
@@ -126,6 +127,10 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
         safeframeMock.contentWindow,
         'postMessage'
       );
+
+      doubleclickImpl.iframe = safeframeMock;
+      safeframeHost.iframe_ = safeframeMock;
+
       sendSetupMessage();
 
       // Verify that the channel was set up
@@ -533,6 +538,7 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
       const safeframeMock = createElementWithAttributes(doc, 'iframe', {});
       ampAd.appendChild(safeframeMock);
       doubleclickImpl.iframe = safeframeMock;
+      safeframeHost.iframe_ = safeframeMock;
 
       const onScrollStub = env.sandbox./*OK*/ stub(
         safeframeHost.viewport_,
@@ -705,6 +711,7 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
       });
       ampAd.appendChild(safeframeMock);
       doubleclickImpl.iframe = safeframeMock;
+      safeframeHost.iframe_ = safeframeMock;
       resizeSafeframeSpy = env.sandbox./*OK*/ spy(
         safeframeHost,
         'resizeSafeframe'
@@ -751,7 +758,7 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
         'push': true,
         'sentinel': safeframeHost.sentinel_,
       });
-      receiveMessage(expandMessage);
+      receiveMessage(expandMessage, safeframeHost.iframe_.contentWindow);
     }
 
     /**
@@ -908,7 +915,7 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
         'sentinel': safeframeHost.sentinel_,
       });
       allowConsoleError(() => {
-        receiveMessage(expandMessage);
+        receiveMessage(expandMessage, safeframeHost.iframe_.contentWindow);
       });
       return Services.timerFor(env.win)
         .promise(100)
@@ -958,7 +965,7 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
         'push': false,
         'sentinel': safeframeHost.sentinel_,
       });
-      receiveMessage(collapseMessage);
+      receiveMessage(collapseMessage, safeframeHost.iframe_.contentWindow);
     }
 
     it('should collapse safeframe on amp-ad resize failure', () => {
@@ -1064,7 +1071,7 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
         'resize_l': left,
         'sentinel': safeframeHost.sentinel_,
       });
-      receiveMessage(resizeMessage);
+      receiveMessage(resizeMessage, safeframeHost.iframe_.contentWindow);
     }
 
     it('should resize safeframe on amp-ad resize success', () => {


### PR DESCRIPTION
Remove Google SafeFrame origin check. Google is experimenting with loading SafeFrame from different domains, which would cause this check to fail. SafeFrame is designed to run arbitrary code so this check isn't helpful from a security perspective. 

