### PR TITLE
amp-script: decouple dev modes

### DIFF
--- a/extensions/amp-script/0.1/amp-script.js
+++ b/extensions/amp-script/0.1/amp-script.js
@@ -104,10 +104,11 @@ export class AmpScript extends AMP.BaseElement {
 
   /** @override */
   buildCallback() {
-    const htmlEl = this.element.ownerDocument.documentElement;
     this.development_ =
       this.element.hasAttribute('data-ampdevmode') ||
-      htmlEl.hasAttribute('data-ampdevmode');
+      this.element.ownerDocument.documentElement.hasAttribute(
+        'data-ampdevmode'
+      );
 
     if (this.development_) {
       user().warn(

--- a/extensions/amp-script/0.1/amp-script.js
+++ b/extensions/amp-script/0.1/amp-script.js
@@ -22,7 +22,6 @@ import {Services} from '../../../src/services';
 import {UserActivationTracker} from './user-activation-tracker';
 import {calculateExtensionScriptUrl} from '../../../src/service/extension-location';
 import {cancellation} from '../../../src/error';
-import {closestAncestorElementBySelector} from '../../../src/dom';
 import {dev, user, userAssert} from '../../../src/log';
 import {dict, map} from '../../../src/utils/object';
 import {getElementServiceForDoc} from '../../../src/element-service';
@@ -105,7 +104,7 @@ export class AmpScript extends AMP.BaseElement {
 
   /** @override */
   buildCallback() {
-    this.development_ = htmlEl.hasAttribute('data-ampdevmode');
+    this.development_ = this.element.hasAttribute('data-ampdevmode');
 
     if (this.development_) {
       user().warn(

--- a/extensions/amp-script/0.1/amp-script.js
+++ b/extensions/amp-script/0.1/amp-script.js
@@ -91,7 +91,7 @@ export class AmpScript extends AMP.BaseElement {
      * If true, most production constraints are disabled including script size,
      * script hash sum for local scripts, etc. Default is false.
      *
-     * Enabled by the "development" attribute which is intentionally invalid.
+     * Enabled by the "data-ampdevmode" attribute which is intentionally invalid.
      *
      * @private {boolean}
      */
@@ -105,16 +105,7 @@ export class AmpScript extends AMP.BaseElement {
 
   /** @override */
   buildCallback() {
-    /*
-     * Development mode is enabled by satisfying two constraints:
-     *   1. Root html element has 'data-ampdevmode'
-     *   2. The amp-script tag or any of its parents must also have 'data-ampdevmode'.
-     */
-    const htmlEl = this.element.ownerDocument.documentElement;
-    this.development_ =
-      htmlEl.hasAttribute('data-ampdevmode') &&
-      closestAncestorElementBySelector(this.element, '[data-ampdevmode]') !=
-        htmlEl;
+    this.development_ = htmlEl.hasAttribute('data-ampdevmode');
 
     if (this.development_) {
       user().warn(
@@ -122,13 +113,6 @@ export class AmpScript extends AMP.BaseElement {
         'JavaScript size and script hash requirements are disabled in development mode.',
         this.element
       );
-      if (this.element.hasAttribute('development')) {
-        user().warn(
-          TAG,
-          "The 'development' flag is deprecated. Please use 'data-ampdevmode' on the root html element instead",
-          this.element
-        );
-      }
     }
 
     return getElementServiceForDoc(this.element, TAG, TAG).then(service => {

--- a/extensions/amp-script/0.1/amp-script.js
+++ b/extensions/amp-script/0.1/amp-script.js
@@ -104,7 +104,7 @@ export class AmpScript extends AMP.BaseElement {
 
   /** @override */
   buildCallback() {
-    this.development_ = this.element.hasAttribute('data-ampdevmode');
+    this.development_ = this.element.getAttribute('data-ampdevmode') === 'true';
 
     if (this.development_) {
       user().warn(

--- a/extensions/amp-script/0.1/amp-script.js
+++ b/extensions/amp-script/0.1/amp-script.js
@@ -104,7 +104,10 @@ export class AmpScript extends AMP.BaseElement {
 
   /** @override */
   buildCallback() {
-    this.development_ = this.element.hasAttribute('data-ampdevmode');
+    const htmlEl = this.element.ownerDocument.documentElement;
+    this.development_ =
+      this.element.hasAttribute('data-ampdevmode') ||
+      htmlEl.hasAttribute('data-ampdevmode');
 
     if (this.development_) {
       user().warn(

--- a/extensions/amp-script/0.1/amp-script.js
+++ b/extensions/amp-script/0.1/amp-script.js
@@ -104,10 +104,7 @@ export class AmpScript extends AMP.BaseElement {
 
   /** @override */
   buildCallback() {
-    const htmlEl = this.element.ownerDocument.documentElement;
-    this.development_ =
-      this.element.hasAttribute('data-ampdevmode') ||
-      htmlEl.hasAttribute('data-ampdevmode');
+    this.development_ = this.element.hasAttribute('data-ampdevmode');
 
     if (this.development_) {
       user().warn(

--- a/extensions/amp-script/0.1/amp-script.js
+++ b/extensions/amp-script/0.1/amp-script.js
@@ -104,7 +104,10 @@ export class AmpScript extends AMP.BaseElement {
 
   /** @override */
   buildCallback() {
-    this.development_ = this.element.getAttribute('data-ampdevmode') === 'true';
+    const htmlEl = this.element.ownerDocument.documentElement;
+    this.development_ =
+      this.element.hasAttribute('data-ampdevmode') ||
+      htmlEl.hasAttribute('data-ampdevmode');
 
     if (this.development_) {
       user().warn(

--- a/extensions/amp-script/0.1/test/unit/test-amp-script.js
+++ b/extensions/amp-script/0.1/test/unit/test-amp-script.js
@@ -203,20 +203,17 @@ describes.fakeWin('AmpScript', {amp: {runtimeOn: false}}, env => {
     });
 
     it('data-ampdevmode on just the element should enable dev mode', () => {
-      element.setAttribute('data-ampdevmode', true);
+      element.setAttribute('data-ampdevmode', '');
       script = new AmpScript(element);
       script.buildCallback();
       expect(script.development_).true;
     });
 
-    it('data-ampdevmode on just the root html element should not enable dev mode', () => {
-      element.ownerDocument.documentElement.setAttribute(
-        'data-ampdevmode',
-        true
-      );
+    it('data-ampdevmode on just the root html element should enable dev mode', () => {
+      element.ownerDocument.documentElement.setAttribute('data-ampdevmode', '');
       script = new AmpScript(element);
       script.buildCallback();
-      expect(script.development_).false;
+      expect(script.development_).true;
     });
   });
 });

--- a/extensions/amp-script/0.1/test/unit/test-amp-script.js
+++ b/extensions/amp-script/0.1/test/unit/test-amp-script.js
@@ -202,11 +202,11 @@ describes.fakeWin('AmpScript', {amp: {runtimeOn: false}}, env => {
       expect(script.development_).false;
     });
 
-    it('data-ampdevmode on just the element should not enable dev mode', () => {
+    it('data-ampdevmode on just the element should enable dev mode', () => {
       element.setAttribute('data-ampdevmode', true);
       script = new AmpScript(element);
       script.buildCallback();
-      expect(script.development_).false;
+      expect(script.development_).true;
     });
 
     it('data-ampdevmode on just the root html element should not enable dev mode', () => {
@@ -217,28 +217,6 @@ describes.fakeWin('AmpScript', {amp: {runtimeOn: false}}, env => {
       script = new AmpScript(element);
       script.buildCallback();
       expect(script.development_).false;
-    });
-
-    it('data-ampdevmode on both the element and root html element should enable dev mode', () => {
-      element.setAttribute('data-ampdevmode', true);
-      element.ownerDocument.documentElement.setAttribute(
-        'data-ampdevmode',
-        true
-      );
-      script = new AmpScript(element);
-      script.buildCallback();
-      expect(script.development_).true;
-    });
-
-    it('data-ampdevmode on both the element and a parent element should enable dev mode', () => {
-      element.ownerDocument.documentElement.setAttribute(
-        'data-ampdevmode',
-        true
-      );
-      element.ownerDocument.body.setAttribute('data-ampdevmode', true);
-      script = new AmpScript(element);
-      script.buildCallback();
-      expect(script.development_).true;
     });
   });
 });

--- a/extensions/amp-script/0.1/test/unit/test-amp-script.js
+++ b/extensions/amp-script/0.1/test/unit/test-amp-script.js
@@ -207,14 +207,7 @@ describes.fakeWin('AmpScript', {amp: {runtimeOn: false}}, env => {
       script = new AmpScript(element);
       script.buildCallback();
       expect(script.development_).true;
-    });
-
-    it('data-ampdevmode on just the root html element should enable dev mode', () => {
-      element.ownerDocument.documentElement.setAttribute('data-ampdevmode', '');
-      script = new AmpScript(element);
-      script.buildCallback();
-      expect(script.development_).true;
-    });
+    }); 
   });
 });
 

--- a/extensions/amp-script/0.1/test/unit/test-amp-script.js
+++ b/extensions/amp-script/0.1/test/unit/test-amp-script.js
@@ -207,7 +207,14 @@ describes.fakeWin('AmpScript', {amp: {runtimeOn: false}}, env => {
       script = new AmpScript(element);
       script.buildCallback();
       expect(script.development_).true;
-    }); 
+    });
+
+    it('data-ampdevmode on just the root html element should enable dev mode', () => {
+      element.ownerDocument.documentElement.setAttribute('data-ampdevmode', '');
+      script = new AmpScript(element);
+      script.buildCallback();
+      expect(script.development_).true;
+    });
   });
 });
 

--- a/extensions/amp-script/0.1/test/validator-amp-script.html
+++ b/extensions/amp-script/0.1/test/validator-amp-script.html
@@ -99,7 +99,7 @@
   <script type=text/amp-script target=amp-script id=hello>
     document.body.textContent = "Hello World!";
   </script>
-  
+
   <!-- Invalid: Local script with invalid 'target'. -->
   <script type=text/plain target=amp-js id=hello>
     document.body.textContent = "Hello World!";

--- a/extensions/amp-script/0.1/test/validator-amp-script.html
+++ b/extensions/amp-script/0.1/test/validator-amp-script.html
@@ -90,6 +90,9 @@
   <!-- Invalid: 'data-ampdevmode' attribute. -->
   <amp-script layout=container src="https://example.com/foo.js" data-ampdevmode></amp-script>
 
+  <!-- Invalid: 'data-ampdevmode' attribute. -->
+  <amp-script layout=container src="https://example.com/foo.js" data-ampdevmode="false"></amp-script>
+
   <!-- Invalid: Local script without 'target' or 'id' attributes. -->
   <script type=text/plain>
     document.body.textContent = "Hello World!";

--- a/extensions/amp-script/0.1/test/validator-amp-script.html
+++ b/extensions/amp-script/0.1/test/validator-amp-script.html
@@ -87,6 +87,9 @@
   <!-- Invalid: 'development' attribute. -->
   <amp-script layout=container src="https://example.com/foo.js" development></amp-script>
 
+  <!-- Invalid: 'data-ampdevmode' attribute. -->
+  <amp-script layout=container src="https://example.com/foo.js" data-ampdevmode></amp-script>
+
   <!-- Invalid: Local script without 'target' or 'id' attributes. -->
   <script type=text/plain>
     document.body.textContent = "Hello World!";
@@ -96,7 +99,7 @@
   <script type=text/amp-script target=amp-script id=hello>
     document.body.textContent = "Hello World!";
   </script>
-
+  
   <!-- Invalid: Local script with invalid 'target'. -->
   <script type=text/plain target=amp-js id=hello>
     document.body.textContent = "Hello World!";

--- a/extensions/amp-script/0.1/test/validator-amp-script.out
+++ b/extensions/amp-script/0.1/test/validator-amp-script.out
@@ -124,7 +124,7 @@ amp-script/0.1/test/validator-amp-script.html:94:2 Custom JavaScript is not allo
 amp-script/0.1/test/validator-amp-script.html:99:2 The attribute 'type' in tag 'amp-script extension local script' is set to the invalid value 'text/amp-script'. (see https://amp.dev/documentation/components/amp-script)
 |      document.body.textContent = "Hello World!";
 |    </script>
-|    
+|
 |    <!-- Invalid: Local script with invalid 'target'. -->
 |    <script type=text/plain target=amp-js id=hello>
 >>   ^~~~~~~~~

--- a/extensions/amp-script/0.1/test/validator-amp-script.out
+++ b/extensions/amp-script/0.1/test/validator-amp-script.out
@@ -108,38 +108,41 @@ amp-script/0.1/test/validator-amp-script.html:85:2 Invalid URL protocol 'http:' 
 >>   ^~~~~~~~~
 amp-script/0.1/test/validator-amp-script.html:88:2 The attribute 'development' may not appear in tag 'amp-script'. (see https://amp.dev/documentation/components/amp-script)
 |
+|    <!-- Invalid: 'data-ampdevmode' attribute. -->
+|    <amp-script layout=container src="https://example.com/foo.js" data-ampdevmode></amp-script>
+|
 |    <!-- Invalid: Local script without 'target' or 'id' attributes. -->
 |    <script type=text/plain>
 >>   ^~~~~~~~~
-amp-script/0.1/test/validator-amp-script.html:91:2 Custom JavaScript is not allowed. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags)
+amp-script/0.1/test/validator-amp-script.html:94:2 Custom JavaScript is not allowed. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags)
 |      document.body.textContent = "Hello World!";
 |    </script>
 |
 |    <!-- Invalid: Local script with invalid 'type'. -->
 |    <script type=text/amp-script target=amp-script id=hello>
 >>   ^~~~~~~~~
-amp-script/0.1/test/validator-amp-script.html:96:2 The attribute 'type' in tag 'amp-script extension local script' is set to the invalid value 'text/amp-script'. (see https://amp.dev/documentation/components/amp-script)
+amp-script/0.1/test/validator-amp-script.html:99:2 The attribute 'type' in tag 'amp-script extension local script' is set to the invalid value 'text/amp-script'. (see https://amp.dev/documentation/components/amp-script)
 |      document.body.textContent = "Hello World!";
 |    </script>
-|
+|    
 |    <!-- Invalid: Local script with invalid 'target'. -->
 |    <script type=text/plain target=amp-js id=hello>
 >>   ^~~~~~~~~
-amp-script/0.1/test/validator-amp-script.html:101:2 Custom JavaScript is not allowed. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags)
+amp-script/0.1/test/validator-amp-script.html:104:2 Custom JavaScript is not allowed. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags)
 |      document.body.textContent = "Hello World!";
 |    </script>
 |
 |    <!-- Invalid: Local script without 'target' attribute. -->
 |    <script type=text/plain id=hello>
 >>   ^~~~~~~~~
-amp-script/0.1/test/validator-amp-script.html:106:2 Custom JavaScript is not allowed. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags)
+amp-script/0.1/test/validator-amp-script.html:109:2 Custom JavaScript is not allowed. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags)
 |      document.body.textContent = "Hello World!";
 |    </script>
 |
 |    <!-- Invalid: Local script without 'id' attribute. -->
 |    <script type=text/plain target=amp-script>
 >>   ^~~~~~~~~
-amp-script/0.1/test/validator-amp-script.html:111:2 The mandatory attribute 'id' is missing in tag 'amp-script extension local script'. (see https://amp.dev/documentation/components/amp-script)
+amp-script/0.1/test/validator-amp-script.html:114:2 The mandatory attribute 'id' is missing in tag 'amp-script extension local script'. (see https://amp.dev/documentation/components/amp-script)
 |      document.body.textContent = "Hello World!";
 |    </script>
 |  </body>

--- a/extensions/amp-script/0.1/test/validator-amp-script.out
+++ b/extensions/amp-script/0.1/test/validator-amp-script.out
@@ -113,38 +113,43 @@ amp-script/0.1/test/validator-amp-script.html:88:2 The attribute 'development' m
 >>   ^~~~~~~~~
 amp-script/0.1/test/validator-amp-script.html:91:2 The attribute 'data-ampdevmode' in tag 'amp-script' is set to the invalid value ''. (see https://amp.dev/documentation/components/amp-script)
 |
+|    <!-- Invalid: 'data-ampdevmode' attribute. -->
+|    <amp-script layout=container src="https://example.com/foo.js" data-ampdevmode="false"></amp-script>
+>>   ^~~~~~~~~
+amp-script/0.1/test/validator-amp-script.html:94:2 The attribute 'data-ampdevmode' in tag 'amp-script' is set to the invalid value 'false'. (see https://amp.dev/documentation/components/amp-script)
+|
 |    <!-- Invalid: Local script without 'target' or 'id' attributes. -->
 |    <script type=text/plain>
 >>   ^~~~~~~~~
-amp-script/0.1/test/validator-amp-script.html:94:2 Custom JavaScript is not allowed. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags)
+amp-script/0.1/test/validator-amp-script.html:97:2 Custom JavaScript is not allowed. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags)
 |      document.body.textContent = "Hello World!";
 |    </script>
 |
 |    <!-- Invalid: Local script with invalid 'type'. -->
 |    <script type=text/amp-script target=amp-script id=hello>
 >>   ^~~~~~~~~
-amp-script/0.1/test/validator-amp-script.html:99:2 The attribute 'type' in tag 'amp-script extension local script' is set to the invalid value 'text/amp-script'. (see https://amp.dev/documentation/components/amp-script)
+amp-script/0.1/test/validator-amp-script.html:102:2 The attribute 'type' in tag 'amp-script extension local script' is set to the invalid value 'text/amp-script'. (see https://amp.dev/documentation/components/amp-script)
 |      document.body.textContent = "Hello World!";
 |    </script>
 |
 |    <!-- Invalid: Local script with invalid 'target'. -->
 |    <script type=text/plain target=amp-js id=hello>
 >>   ^~~~~~~~~
-amp-script/0.1/test/validator-amp-script.html:104:2 Custom JavaScript is not allowed. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags)
+amp-script/0.1/test/validator-amp-script.html:107:2 Custom JavaScript is not allowed. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags)
 |      document.body.textContent = "Hello World!";
 |    </script>
 |
 |    <!-- Invalid: Local script without 'target' attribute. -->
 |    <script type=text/plain id=hello>
 >>   ^~~~~~~~~
-amp-script/0.1/test/validator-amp-script.html:109:2 Custom JavaScript is not allowed. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags)
+amp-script/0.1/test/validator-amp-script.html:112:2 Custom JavaScript is not allowed. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags)
 |      document.body.textContent = "Hello World!";
 |    </script>
 |
 |    <!-- Invalid: Local script without 'id' attribute. -->
 |    <script type=text/plain target=amp-script>
 >>   ^~~~~~~~~
-amp-script/0.1/test/validator-amp-script.html:114:2 The mandatory attribute 'id' is missing in tag 'amp-script extension local script'. (see https://amp.dev/documentation/components/amp-script)
+amp-script/0.1/test/validator-amp-script.html:117:2 The mandatory attribute 'id' is missing in tag 'amp-script extension local script'. (see https://amp.dev/documentation/components/amp-script)
 |      document.body.textContent = "Hello World!";
 |    </script>
 |  </body>

--- a/extensions/amp-script/0.1/test/validator-amp-script.out
+++ b/extensions/amp-script/0.1/test/validator-amp-script.out
@@ -110,6 +110,8 @@ amp-script/0.1/test/validator-amp-script.html:88:2 The attribute 'development' m
 |
 |    <!-- Invalid: 'data-ampdevmode' attribute. -->
 |    <amp-script layout=container src="https://example.com/foo.js" data-ampdevmode></amp-script>
+>>   ^~~~~~~~~
+amp-script/0.1/test/validator-amp-script.html:91:2 The attribute 'data-ampdevmode' in tag 'amp-script' is set to the invalid value ''. (see https://amp.dev/documentation/components/amp-script)
 |
 |    <!-- Invalid: Local script without 'target' or 'id' attributes. -->
 |    <script type=text/plain>

--- a/extensions/amp-script/amp-script.md
+++ b/extensions/amp-script/amp-script.md
@@ -222,7 +222,7 @@ Example of script hashes:
 ```
 
 [tip type="default"]
-The JavaScript size and script hash requirements can be disabled during development by adding a `data-ampdevmode` attribute to the `amp-script` element.
+The JavaScript size and script hash requirements can be disabled during development by adding a `data-ampdevmode` attribute to either the `amp-script` element or the root html node.
 [/tip]
 
 ## Attributes

--- a/extensions/amp-script/amp-script.md
+++ b/extensions/amp-script/amp-script.md
@@ -222,7 +222,7 @@ Example of script hashes:
 ```
 
 [tip type="default"]
-The JavaScript size and script hash requirements can be disabled during development by adding a `data-ampdevmode` attribute to both the top-level `html` element and the `amp-script` element (or any of its parent nodes).
+The JavaScript size and script hash requirements can be disabled during development by adding a `data-ampdevmode` attribute to the `amp-script` element.
 [/tip]
 
 ## Attributes

--- a/extensions/amp-script/amp-script.md
+++ b/extensions/amp-script/amp-script.md
@@ -222,7 +222,7 @@ Example of script hashes:
 ```
 
 [tip type="default"]
-The JavaScript size and script hash requirements can be disabled during development by adding a `data-ampdevmode` attribute to either the `amp-script` element or the root html node.
+The JavaScript size and script hash requirements can be disabled during development by adding a `data-ampdevmode` attribute to the `amp-script` element.
 [/tip]
 
 ## Attributes

--- a/extensions/amp-script/validator-amp-script.protoascii
+++ b/extensions/amp-script/validator-amp-script.protoascii
@@ -193,8 +193,10 @@ tags: {  # <amp-script>
     }
   }
   attrs: {
+    # This attribute should always be invalid.
     name: "data-ampdevmode"
     value: "false"
+    blacklisted_value_regex: "false"
   }
   attrs: { name: "sandbox" }
   attrs: {

--- a/extensions/amp-script/validator-amp-script.protoascii
+++ b/extensions/amp-script/validator-amp-script.protoascii
@@ -193,7 +193,7 @@ tags: {  # <amp-script>
     }
   }
   attrs: {
-    # This attribute should always be invalid. See https://github.com/ampproject/amphtml/pull/2707
+    # This attribute should always be invalid. See https://github.com/ampproject/amphtml/pull/27076
     name: "data-ampdevmode"
     value: "false"
     blacklisted_value_regex: "false"

--- a/extensions/amp-script/validator-amp-script.protoascii
+++ b/extensions/amp-script/validator-amp-script.protoascii
@@ -167,6 +167,10 @@ tags: {  # <amp-script> (local script)
     mandatory: true
     value_casei: "text/plain"
   }
+  attrs: {
+    name: "data-ampdevmode"
+    value: "false"
+  }
   attr_lists: "mandatory-id-attr"
   attr_lists: "nonce-attr"
   cdata: {

--- a/extensions/amp-script/validator-amp-script.protoascii
+++ b/extensions/amp-script/validator-amp-script.protoascii
@@ -167,10 +167,6 @@ tags: {  # <amp-script> (local script)
     mandatory: true
     value_casei: "text/plain"
   }
-  attrs: {
-    name: "data-ampdevmode"
-    value: "false"
-  }
   attr_lists: "mandatory-id-attr"
   attr_lists: "nonce-attr"
   cdata: {
@@ -195,6 +191,10 @@ tags: {  # <amp-script>
       # max-age only applies to inline scripts.
       also_requires_attr: "script"
     }
+  }
+  attrs: {
+    name: "data-ampdevmode"
+    value: "false"
   }
   attrs: { name: "sandbox" }
   attrs: {

--- a/extensions/amp-script/validator-amp-script.protoascii
+++ b/extensions/amp-script/validator-amp-script.protoascii
@@ -193,7 +193,7 @@ tags: {  # <amp-script>
     }
   }
   attrs: {
-    # This attribute should always be invalid.
+    # This attribute should always be invalid. See https://github.com/ampproject/amphtml/pull/2707
     name: "data-ampdevmode"
     value: "false"
     blacklisted_value_regex: "false"


### PR DESCRIPTION
- Relaxes requirement that `data-ampdevmode` must be on both root and the amp-script. Now, placing a `data-ampdevmode` on either will do.
- Removes a warning that `development` is outdated and `data-ampdevmode` should be used.

See https://github.com/ampproject/amphtml/issues/26341#issuecomment-594205335

Todo:
- [x] `data-ampdevmode` on an `amp-script` tag needs to fail validation.