### PR TITLE
Support `disable-inline-width` attribute when applying layout sizes

### DIFF
--- a/spec/amp-html-layout.md
+++ b/spec/amp-html-layout.md
@@ -162,7 +162,7 @@ In the following example, if the viewport is wider than `320px`, the image will 
 
 ### `disable-inline-width`
 
-All AMP elements that support the `responsive` layout, also support the `disable-inline-width` attribute. The presence of this attribute describes how the `sizes` attribute is used. When pairing `disable-inline-width` with `sizes`, the AMP element will propagate the value of `sizes` to the element's underlying tag, as with the `img` nested inside an `amp-img`, **without** getting the sizing behavior of `sizes` in AMP (which adds a width based on which media query matches).
+The `sizes` attribute on its own will set an inline `width` style on the element. When pairing `disable-inline-width` with `sizes`, the AMP element will propagate the value of `sizes` to the element's underlying tag, as with the `img` nested inside an `amp-img`, **without** setting the inline `width` as `sizes` typically does on its own in AMP.
 
 **Example**: Using the `disable-inline-width` attribute
 

--- a/spec/amp-html-layout.md
+++ b/spec/amp-html-layout.md
@@ -160,6 +160,26 @@ In the following example, if the viewport is wider than `320px`, the image will 
 </amp-img>
 ```
 
+### `disable-inline-width`
+
+All AMP elements that support the `responsive` layout, also support the `disable-inline-width` attribute. The presence of this attribute describes how the `sizes` attribute is used. When pairing `disable-inline-width` with `sizes`, the AMP element will propagate the value of `sizes` to the element's underlying tag, as with the `img` nested inside an `amp-img`, **without** getting the sizing behavior of `sizes` in AMP (which adds a width based on which media query matches).
+
+**Example**: Using the `disable-inline-width` attribute
+
+In the following example, the width of the `<amp-img>` element is unaffected, and `sizes` is only used to select one of the sources from the `srcset`.
+
+```html
+<amp-img
+  src="https://acme.org/image1.png"
+  width="400"
+  height="300"
+  layout="responsive"
+  sizes="(min-width: 320px) 320px, 100vw"
+  disable-inline-width
+>
+</amp-img>
+```
+
 ### `heights`
 
 All AMP elements that support the `responsive` layout, also support the `heights` attribute.

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -694,6 +694,10 @@ function createBaseCustomElementClass(win) {
         );
       }
 
+      if (this.hasAttribute('disable-inline-width')) {
+        return;
+      }
+
       // Sizes.
       if (this.sizeList_ === undefined) {
         const sizesAttr = this.getAttribute('sizes');

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -694,14 +694,12 @@ function createBaseCustomElementClass(win) {
         );
       }
 
-      if (this.hasAttribute('disable-inline-width')) {
-        return;
-      }
-
       // Sizes.
       if (this.sizeList_ === undefined) {
         const sizesAttr = this.getAttribute('sizes');
-        this.sizeList_ = sizesAttr ? parseSizeList(sizesAttr) : null;
+        const isDisabled = this.hasAttribute('disable-inline-width');
+        this.sizeList_ =
+          !isDisabled && sizesAttr ? parseSizeList(sizesAttr) : null;
       }
       if (this.sizeList_) {
         setStyle(

--- a/test/unit/test-amp-img.js
+++ b/test/unit/test-amp-img.js
@@ -205,6 +205,22 @@ describes.sandboxed('amp-img', {}, env => {
     });
   });
 
+  it('should propagate srcset and sizes with disable-inline-width', async () => {
+    const ampImg = await getImg({
+      src: '/examples/img/sample.jpg',
+      srcset: SRCSET_STRING,
+      sizes: '(max-width: 320px) 640px, 100vw',
+      width: 320,
+      height: 240,
+      'disable-inline-width': null,
+    });
+    const img = ampImg.querySelector('img');
+    expect(img.getAttribute('srcset')).to.equal(SRCSET_STRING);
+    expect(img.getAttribute('sizes')).to.equal(
+      '(max-width: 320px) 640px, 100vw'
+    );
+  });
+
   describe('#fallback on initial load', () => {
     let el;
     let impl;

--- a/test/unit/test-custom-element.js
+++ b/test/unit/test-custom-element.js
@@ -1164,6 +1164,13 @@ describes.realWin('CustomElement', {amp: true}, env => {
           element2.ampdoc_ = env.ampdoc;
         });
 
+        it('should not apply sizes when "disable-inline-width" is present', () => {
+          element1.setAttribute('disable-inline-width', null);
+          element1.setAttribute('sizes', '(min-width: 1px) 200px, 50vw');
+          element1.applySizesAndMediaQuery();
+          expect(element1.style.width).not.to.equal('200px');
+        });
+
         it('should apply media condition', () => {
           element1.setAttribute('media', '(min-width: 1px)');
           element1.applySizesAndMediaQuery();

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -5436,6 +5436,7 @@ tags: {
 # their values.
 attr_lists: {
   name: "$AMP_LAYOUT_ATTRS"
+  attrs: { name: "disable-inline-width" }
   attrs: { name: "height" }
   attrs: { name: "heights" }
   attrs: { name: "layout" }


### PR DESCRIPTION
This allows specifying the `sizes` on elements without getting the sizing behavior of sizes in AMP (which adds a width based on which media query matches). Addresses #21736

See [discussion doc](https://docs.google.com/document/d/1qRF38BwZPfgIdNfZ8W1sf1lHyWYd2Y5ZFM4nPSMFt3Y/edit#) for more