### PR TITLE
🏗 Standardize on-demand package installation for `gulp` tasks

### DIFF
--- a/build-system/common/utils.js
+++ b/build-system/common/utils.js
@@ -18,9 +18,13 @@ const argv = require('minimist')(process.argv.slice(2));
 const fs = require('fs-extra');
 const globby = require('globby');
 const log = require('fancy-log');
-const {gitDiffNameOnlyMaster} = require('../common/git');
+const path = require('path');
+const {execOrDie} = require('./exec');
+const {gitDiffNameOnlyMaster} = require('./git');
 const {green, cyan, yellow} = require('ansi-colors');
-const {isTravisBuild} = require('../common/travis');
+const {isTravisBuild} = require('./travis');
+
+const ROOT_DIR = path.resolve(__dirname, '../../');
 
 /**
  * Logs a message on the same line to indicate progress
@@ -117,9 +121,25 @@ function usesFilesOrLocalChanges(taskName) {
   return validUsage;
 }
 
+/**
+ * Runs 'yarn' to install packages in a given directory.
+ *
+ * @param {string} dir
+ */
+function installPackages(dir) {
+  log(
+    'Running',
+    cyan('yarn'),
+    'to install packages in',
+    cyan(path.relative(ROOT_DIR, dir)) + '...'
+  );
+  execOrDie(`npx yarn --cwd ${dir}`, {'stdio': 'ignore'});
+}
+
 module.exports = {
   getFilesChanged,
   getFilesToCheck,
+  installPackages,
   logOnSameLine,
   usesFilesOrLocalChanges,
 };

--- a/build-system/tasks/e2e/index.js
+++ b/build-system/tasks/e2e/index.js
@@ -25,6 +25,7 @@ const Mocha = require('mocha');
 const path = require('path');
 const {cyan} = require('ansi-colors');
 const {execOrDie} = require('../../common/exec');
+const {installPackages} = require('../../common/utils');
 const {isTravisBuild} = require('../../common/travis');
 const {reportTestStarted} = require('../report-test-status');
 const {startServer, stopServer} = require('../serve');
@@ -34,11 +35,6 @@ const HOST = 'localhost';
 const PORT = 8000;
 const SLOW_TEST_THRESHOLD_MS = 2500;
 const TEST_RETRIES = isTravisBuild() ? 2 : 0;
-
-function installPackages_() {
-  log('Running', cyan('yarn'), 'to install packages...');
-  execOrDie('npx yarn --cwd build-system/tasks/e2e', {'stdio': 'ignore'});
-}
 
 function buildRuntime_() {
   execOrDie('gulp clean');
@@ -72,7 +68,7 @@ function createMocha_() {
 
 async function e2e() {
   // install e2e-specific modules
-  installPackages_();
+  installPackages(__dirname);
 
   // set up promise to return to gulp.task()
   let resolver;

--- a/build-system/tasks/performance/index.js
+++ b/build-system/tasks/performance/index.js
@@ -18,24 +18,15 @@ const cacheDocuments = require('./cache-documents');
 const compileScripts = require('./compile-scripts');
 const getMetrics = require('./measure-documents');
 const loadConfig = require('./load-config');
-const log = require('fancy-log');
 const printReport = require('./print-report');
 const rewriteScriptTags = require('./rewrite-script-tags');
-const {cyan} = require('ansi-colors');
-const {execOrDie} = require('../../common/exec');
-
-function installPackages_() {
-  log('Running', cyan('yarn'), 'to install packages...');
-  execOrDie('npx yarn --cwd build-system/tasks/performance', {
-    'stdio': 'ignore',
-  });
-}
+const {installPackages} = require('../../common/utils');
 
 /**
  * @return {!Promise}
  */
 async function performance() {
-  installPackages_();
+  installPackages(__dirname);
   const {headless, runs, urls} = new loadConfig();
   await cacheDocuments(urls);
   await compileScripts(urls);

--- a/build-system/tasks/visual-diff/index.js
+++ b/build-system/tasks/visual-diff/index.js
@@ -39,6 +39,7 @@ const {
   shortSha,
 } = require('../../common/git');
 const {execOrDie, execScriptAsync} = require('../../common/exec');
+const {installPackages} = require('../../common/utils');
 const {isTravisBuild} = require('../../common/travis');
 const {startServer, stopServer} = require('../serve');
 const {waitUntilUsed} = require('tcp-port-used');
@@ -773,10 +774,7 @@ async function ensureOrBuildAmpRuntimeInTestMode_() {
 
 function installPercy_() {
   if (!argv.noyarn) {
-    log('info', 'Running', colors.cyan('yarn'), 'to install Percy...');
-    execOrDie('npx yarn --cwd build-system/tasks/visual-diff', {
-      'stdio': 'ignore',
-    });
+    installPackages(__dirname);
   }
 
   puppeteer = require('puppeteer');


### PR DESCRIPTION
There are now three copies of the code that installs packages on-demand within a `gulp` task subdirectory. This PR consolidates them into a single util function to be used by `gulp e2e|performance|visual-diff`.

**I swear, I tested all three:**

![image](https://user-images.githubusercontent.com/26553114/76127892-ef3fe600-5fd0-11ea-8e4d-3c86777ba14c.png)
![image](https://user-images.githubusercontent.com/26553114/76128026-375f0880-5fd1-11ea-9b9a-c3c004bae941.png)
![image](https://user-images.githubusercontent.com/26553114/76127910-febf2f00-5fd0-11ea-8560-97d9599c1175.png)
