### PR TITLE
🚀 Disable ampCors for analytics vendors requests

### DIFF
--- a/extensions/amp-analytics/0.1/config.js
+++ b/extensions/amp-analytics/0.1/config.js
@@ -108,7 +108,7 @@ export class AnalyticsConfig {
     dev().fine(TAG, 'Fetching vendor config', vendorUrl);
 
     return Services.xhrFor(toWin(this.win_))
-      .fetchJson(vendorUrl)
+      .fetchJson(vendorUrl, {ampCors: false})
       .then(res => res.json())
       .then(
         jsonValue => {


### PR DESCRIPTION
This should improve cacheablity.