### PR TITLE
🚀 Reuse analytics macros regexp

### DIFF
--- a/extensions/amp-analytics/0.1/amp-analytics.js
+++ b/extensions/amp-analytics/0.1/amp-analytics.js
@@ -45,6 +45,9 @@ import {toggle} from '../../../src/style';
 
 const TAG = 'amp-analytics';
 
+/** @const {RegExp} */
+const ANALYTICS_MACROS_REGEXP = /\${([^}]*)}/g;
+
 const MAX_REPLACES = 16; // The maximum number of entries in a extraUrlParamsReplaceMap
 
 const WHITELIST_EVENT_IN_SANDBOX = [
@@ -530,6 +533,7 @@ export class AmpAnalytics extends AMP.BaseElement {
             const request = this.config_['requests'][key];
             return (request && request['baseUrl']) || '${' + key + '}';
           },
+          ANALYTICS_MACROS_REGEXP,
           5
         );
       }

--- a/src/string.js
+++ b/src/string.js
@@ -108,17 +108,18 @@ export function includes(string, substring, start) {
  * @param {string} template The template string to expand.
  * @param {function(string):*} getter Function used to retrieve a value for a
  *   placeholder. Returns values will be coerced into strings.
+ * @param {RegExp} regexp
  * @param {number=} opt_maxIterations Number of times to expand the template.
  *   Defaults to 1, but should be set to a larger value your placeholder tokens
  *   can be expanded to other placeholder tokens. Take caution with large values
  *   as recursively expanding a string can be exponentially expensive.
  * @return {string}
  */
-export function expandTemplate(template, getter, opt_maxIterations) {
+export function expandTemplate(template, getter, regexp, opt_maxIterations) {
   const maxIterations = opt_maxIterations || 1;
   for (let i = 0; i < maxIterations; i++) {
     let matches = 0;
-    template = template.replace(/\${([^}]*)}/g, (_a, b) => {
+    template = template.replace(regexp, (_a, b) => {
       matches++;
       return getter(b);
     });

--- a/test/unit/test-string.js
+++ b/test/unit/test-string.js
@@ -69,6 +69,7 @@ describe('includes', () => {
 });
 
 describe('expandTemplate', () => {
+  const regex = /\${([^}]*)}/g;
   const data = {
     'x': 'Test 1',
     'y': 'Test 2',
@@ -88,43 +89,57 @@ describe('expandTemplate', () => {
   }
 
   it('should replace place holders with values.', () => {
-    expect(expandTemplate('${x}', testGetter)).to.equal('Test 1');
-    expect(expandTemplate('${y}', testGetter)).to.equal('Test 2');
-    expect(expandTemplate('${x} ${y}', testGetter)).to.equal('Test 1 Test 2');
-    expect(expandTemplate('a${x}', testGetter)).to.equal('aTest 1');
-    expect(expandTemplate('${x}a', testGetter)).to.equal('Test 1a');
-    expect(expandTemplate('a${x}a', testGetter)).to.equal('aTest 1a');
-    expect(expandTemplate('${unknown}', testGetter)).to.equal('not found');
+    expect(expandTemplate('${x}', testGetter, regex)).to.equal('Test 1');
+    expect(expandTemplate('${y}', testGetter, regex)).to.equal('Test 2');
+    expect(expandTemplate('${x} ${y}', testGetter, regex)).to.equal(
+      'Test 1 Test 2'
+    );
+    expect(expandTemplate('a${x}', testGetter, regex)).to.equal('aTest 1');
+    expect(expandTemplate('${x}a', testGetter, regex)).to.equal('Test 1a');
+    expect(expandTemplate('a${x}a', testGetter, regex)).to.equal('aTest 1a');
+    expect(expandTemplate('${unknown}', testGetter, regex)).to.equal(
+      'not found'
+    );
   });
 
   it('should handle malformed place holders.', () => {
-    expect(expandTemplate('${x', testGetter)).to.equal('${x');
-    expect(expandTemplate('${', testGetter)).to.equal('${');
-    expect(expandTemplate('$x}', testGetter)).to.equal('$x}');
-    expect(expandTemplate('$x', testGetter)).to.equal('$x');
-    expect(expandTemplate('{x}', testGetter)).to.equal('{x}');
-    expect(expandTemplate('${{x}', testGetter)).to.equal('not found');
+    expect(expandTemplate('${x', testGetter, regex)).to.equal('${x');
+    expect(expandTemplate('${', testGetter, regex)).to.equal('${');
+    expect(expandTemplate('$x}', testGetter, regex)).to.equal('$x}');
+    expect(expandTemplate('$x', testGetter, regex)).to.equal('$x');
+    expect(expandTemplate('{x}', testGetter, regex)).to.equal('{x}');
+    expect(expandTemplate('${{x}', testGetter, regex)).to.equal('not found');
   });
 
   it('should default to one iteration.', () => {
-    expect(expandTemplate('${tox}', testGetter)).to.equal('${x}');
-    expect(expandTemplate('${toxy}', testGetter)).to.equal('${x}${y}');
+    expect(expandTemplate('${tox}', testGetter, regex)).to.equal('${x}');
+    expect(expandTemplate('${toxy}', testGetter, regex)).to.equal('${x}${y}');
   });
 
   it('should handle multiple iterations when asked to.', () => {
-    expect(expandTemplate('${tox}', testGetter, 2)).to.equal('Test 1');
-    expect(expandTemplate('${toxy}', testGetter, 2)).to.equal('Test 1Test 2');
-    expect(expandTemplate('${totoxy}', testGetter, 2)).to.equal('${x}${y}');
-    expect(expandTemplate('${totoxy}', testGetter, 3)).to.equal('Test 1Test 2');
-    expect(expandTemplate('${totoxy}', testGetter, 10)).to.equal(
+    expect(expandTemplate('${tox}', testGetter, regex, 2)).to.equal('Test 1');
+    expect(expandTemplate('${toxy}', testGetter, regex, 2)).to.equal(
+      'Test 1Test 2'
+    );
+    expect(expandTemplate('${totoxy}', testGetter, regex, 2)).to.equal(
+      '${x}${y}'
+    );
+    expect(expandTemplate('${totoxy}', testGetter, regex, 3)).to.equal(
+      'Test 1Test 2'
+    );
+    expect(expandTemplate('${totoxy}', testGetter, regex, 10)).to.equal(
       'Test 1Test 2'
     );
   });
 
   it('should handle circular expansions without hanging', () => {
-    expect(expandTemplate('${loop}', testGetter)).to.equal('${loop}');
-    expect(expandTemplate('${loop}', testGetter), 10).to.equal('${loop}');
-    expect(expandTemplate('${loop1}', testGetter), 10).to.equal('${loop2}');
+    expect(expandTemplate('${loop}', testGetter, regex)).to.equal('${loop}');
+    expect(expandTemplate('${loop}', testGetter, regex), 10).to.equal(
+      '${loop}'
+    );
+    expect(expandTemplate('${loop1}', testGetter, regex), 10).to.equal(
+      '${loop2}'
+    );
   });
 });
 


### PR DESCRIPTION
B/c `expandTemplate` is used extremely frequently, storing the regexp literal will result in a performance increase since the regexp literal will not be compiled with each  invocation of `expandTemplate`