### PR TITLE
🐛Delete setting of incorrect field "iframe_"

### DIFF
--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-safeframe.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-safeframe.js
@@ -354,7 +354,6 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
         'display:block!important;}';
       doc.head.appendChild(css);
       ampAd.appendChild(safeframeMock);
-      doubleclickImpl.iframe_ = safeframeMock;
       safeframeHost.iframe_ = safeframeMock;
 
       const sendMessageStub = env.sandbox./*OK*/ stub(
@@ -406,7 +405,6 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
         'display:block!important;}';
       doc.head.appendChild(css);
       ampAd.appendChild(safeframeMock);
-      doubleclickImpl.iframe_ = safeframeMock;
       safeframeHost.iframe_ = safeframeMock;
 
       const sendMessageStub = env.sandbox./*OK*/ stub(
@@ -459,7 +457,6 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
         'display:block!important;}';
       doc.head.appendChild(css);
       ampAd.appendChild(safeframeMock);
-      doubleclickImpl.iframe_ = safeframeMock;
       safeframeHost.iframe_ = safeframeMock;
       const sendMessageStub = env.sandbox./*OK*/ stub(
         safeframeHost,
@@ -497,7 +494,6 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
         'display:block!important;}';
       doc.head.appendChild(css);
       ampAd.appendChild(safeframeMock);
-      doubleclickImpl.iframe_ = safeframeMock;
       safeframeHost.iframe_ = safeframeMock;
 
       // Scroll 100 px


### PR DESCRIPTION
`doubleclickImpl.iframe` is the field where the reference to the iframe is stored. There are four lines that set the incorrect field `doubleclickImpl.iframe_` (with an underscore). Removing these lines doesn't break the tests, so it seems like they aren't needed. 