### PR TITLE
🐛 [amp-story-player] Install viewer integration script on buildCallback

### DIFF
--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -418,6 +418,7 @@ export class AmpStory extends AMP.BaseElement {
     this.initializeListeners_();
     this.initializeListenersForDev_();
     this.initializePageIds_();
+    this.initializeStoryPlayer_();
 
     this.storeService_.dispatch(Action.TOGGLE_UI, this.getUIType_());
 
@@ -1011,7 +1012,6 @@ export class AmpStory extends AMP.BaseElement {
       .then(() => {
         this.markStoryAsLoaded_();
         this.initializeLiveStory_();
-        this.initializeStoryPlayer_();
       });
 
     this.maybeLoadStoryEducation_();


### PR DESCRIPTION
In the player, stories following the first one that were loaded from origin and that did not explicitly imported the `viewer-integration.js` script were unplayable.

This was caused because we were installing the `viewer-integration.js` script in the `layoutCallback` of `AmpStory`. Since `layoutCallback` is not ran in `prerender` mode, these stories weren't installing the `viewer-integration.js` script. And by the time `layoutCallback` runs when displaying the next story, it is too late because the player's handshake has already timed out.

I didn't catch this before because I was testing with stories loaded from the cache, and since we inject the `viewer-integration.js` script in the cache, it seemed to work fine...

Fix following #26719