### PR TITLE
intersect-resources: Support prerender mode, patch for stale rects

### DIFF
--- a/src/service/owners-impl.js
+++ b/src/service/owners-impl.js
@@ -200,14 +200,14 @@ export class OwnersImpl {
         resource.whenBuilt().then(() => {
           this.measureAndTryScheduleLayout_(
             resource,
-            !layout,
+            /* isPreload */ !layout,
             parentResource.getLayoutPriority()
           );
         });
       } else {
         this.measureAndTryScheduleLayout_(
           resource,
-          !layout,
+          /* isPreload */ !layout,
           parentResource.getLayoutPriority()
         );
       }
@@ -228,7 +228,7 @@ export class OwnersImpl {
     ) {
       this.resources_.scheduleLayoutOrPreload(
         resource,
-        !isPreload,
+        /* layout */ !isPreload,
         opt_parentPriority
       );
     }

--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -210,6 +210,12 @@ export class Resource {
 
     /** @private {?Function} */
     this.loadPromiseResolve_ = deferred.resolve;
+
+    /**
+     * The most recent value of IntersectionObserverEntry.isIntersecting.
+     * @package @type {boolean|undefined}
+     */
+    this.isIntersecting = undefined;
   }
 
   /**

--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -212,10 +212,11 @@ export class Resource {
     this.loadPromiseResolve_ = deferred.resolve;
 
     /**
-     * The most recent value of IntersectionObserverEntry.isIntersecting.
-     * @package @type {boolean|undefined}
+     * intersected[i] is true if this resource received a callback from
+     * IntersectionObserver with id `i`.
+     * @const {!Array<boolean|undefined>}
      */
-    this.isIntersecting = undefined;
+    this.intersected = [];
   }
 
   /**

--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -210,13 +210,6 @@ export class Resource {
 
     /** @private {?Function} */
     this.loadPromiseResolve_ = deferred.resolve;
-
-    /**
-     * intersected[i] is true if this resource received a callback from
-     * IntersectionObserver with id `i`.
-     * @const {!Array<boolean|undefined>}
-     */
-    this.intersected = [];
   }
 
   /**

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -295,6 +295,7 @@ export class ResourcesImpl {
    * @private
    */
   intersects_(entries) {
+    devAssert(this.intersectionObserver_);
     // TODO(willchou): Remove assert once #27167 is fixed.
     devAssert(this.prerenderSize_ == 1);
     dev().fine(TAG_, 'intersect', entries);
@@ -795,7 +796,8 @@ export class ResourcesImpl {
     }
 
     // Process queued intersections (outside of 1vp) once we're visible.
-    if (!wasVisible && this.visible_) {
+    const becameVisible = !wasVisible && this.visible_;
+    if (this.intersectionObserver_ && becameVisible) {
       dev().fine(TAG_, 'Handling queued intersections...');
       this.intersects_(this.queuedIntersectionEntries_);
       this.queuedIntersectionEntries_.length = 0;

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -1305,7 +1305,6 @@ export class ResourcesImpl {
           // TODO(willchou): May need to add another ResourceState to avoid
           // multiple invocations (relayoutAll requires reinvocation).
           r.applySizesAndMediaQuery();
-          // dev().fine(TAG_, 'apply sizes/media query:', r.debugid);
         }
       }
 
@@ -1364,7 +1363,6 @@ export class ResourcesImpl {
         r.getState() == ResourceState.NOT_LAID_OUT
       ) {
         r.applySizesAndMediaQuery();
-        dev().fine(TAG_, 'apply sizes/media query:', r.debugid);
         relayoutCount++;
       }
       if (r.isMeasureRequested()) {

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -300,7 +300,8 @@ export class ResourcesImpl {
 
     // Store the 1vp rect for later.
     if (!this.oneViewportRect_) {
-      this.oneViewportRect_ = entries[0].rootBounds;
+      this.oneViewportRect_ =
+        /** @type {!ClientRect} */ (entries[0].rootBounds);
     }
 
     const whenBuilt = this.intersects_(entries, /* viewports */ 1);
@@ -334,7 +335,11 @@ export class ResourcesImpl {
 
     // Always ignore intersections in 1vp to avoid dupe handling.
     const outsideOneViewport = entries.filter(
-      e => !rectsOverlap(this.oneViewportRect_, e.intersectionRect)
+      e =>
+        !rectsOverlap(
+          devAssert(this.oneViewportRect_),
+          /** @type {!ClientRect} */ (e.intersectionRect)
+        )
     );
 
     const whenBuilt = this.intersects_(outsideOneViewport, /* viewports */ 3);

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -199,6 +199,9 @@ export class ResourcesImpl {
      */
     this.oneViewportObserver_ = null;
 
+    /** @private {ClientRect?} */
+    this.oneViewportRect_ = null;
+
     /**
      * Observes elements within current viewport +/- one viewport length (3vp).
      * @private {?IntersectionObserver}

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -549,16 +549,14 @@ export class ResourcesImpl {
 
     if (this.oneViewportObserver_) {
       // applyStaticLayout() actually happens after this function (sync),
-      // so give the browser a chance to layout first via rAF.
+      // so give the browser a chance to layout first by waiting for upgrade.
       // This results in fresher client rects in the intersection entry.
-      // this.win.requestAnimationFrame(() => {
       element.whenUpgraded().then(() => {
         this.oneViewportObserver_.observe(element);
         if (this.threeViewportsObserver_) {
           this.threeViewportsObserver_.observe(element);
         }
       });
-      // });
     } else {
       this.remeasurePass_.schedule(1000);
     }

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -325,11 +325,6 @@ export class ResourcesImpl {
         isPrerender &&
         !rectsOverlap(clientRect, devAssert(this.viewportRect_))
       ) {
-        dev().fine(
-          TAG_,
-          'Handling queued intersections:',
-          this.queuedIntersectionEntries_
-        );
         this.queuedIntersectionEntries_.push(entry);
         return;
       }
@@ -367,7 +362,7 @@ export class ResourcesImpl {
           return;
         }
 
-        if (rectsOverlap(clientRect, this.visibleRect_)) {
+        if (rectsOverlap(clientRect, devAssert(this.visibleRect_))) {
           r.setInViewport(isIntersecting);
         }
 
@@ -801,6 +796,7 @@ export class ResourcesImpl {
 
     // Process queued intersections (outside of 1vp) once we're visible.
     if (!wasVisible && this.visible_) {
+      dev().fine(TAG_, 'Handling queued intersections...');
       this.intersects_(this.queuedIntersectionEntries_);
       this.queuedIntersectionEntries_.length = 0;
     }

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -292,12 +292,7 @@ export class ResourcesImpl {
    * @private
    */
   intersectsOneViewport_(entries) {
-    if (this.prerenderSize_ == 0) {
-      // TODO(willchou): Store entries and process when visible,
-      // or unobserve/reobserver all resources when visible.
-      devAssert(false, 'Not implemented');
-      return;
-    }
+    // TODO(willchou): Remove assert once #27167 is fixed.
     devAssert(this.prerenderSize_ == 1);
 
     const whenBuilt = this.intersects_(entries, /* viewports */ 1);


### PR DESCRIPTION
Partial for #25428.

- Keep using a single observer at 3vp and compute intersection with 1vp. In prerender mode, queue intersections outside of 1vp.
- Addresses the stale layout box issue by reverting to continue to use the current system i.e. requesting measure on mutations, scheduling passes after element size changes, etc.
- Removes some of the edge case handling for simplicity. I'll restore them if needed later.

Will add tests next.

/to @dvoytenko @jridgewell /cc @ampproject/wg-runtime 