### PR TITLE
Change OWNER wg-ads to wg-ads-reviewers

### DIFF
--- a/3p/OWNERS
+++ b/3p/OWNERS
@@ -5,7 +5,7 @@
   rules: [
     {
       owners: [
-        {name: 'ampproject/wg-ads'},
+        {name: 'ampproject/wg-ads-reviewers'},
         {name: 'ampproject/wg-ui-and-a11y'},
       ],
     },

--- a/ads/OWNERS
+++ b/ads/OWNERS
@@ -4,9 +4,7 @@
 {
   rules: [
     {
-      owners: [
-        {name: 'ampproject/wg-ads-reviewers'},
-      ],
+      owners: [{name: 'ampproject/wg-ads-reviewers'}],
     },
   ],
 }

--- a/ads/OWNERS
+++ b/ads/OWNERS
@@ -5,7 +5,7 @@
   rules: [
     {
       owners: [
-        {name: 'ampproject/wg-ads'},
+        {name: 'ampproject/wg-ads-reviewers'},
         {name: 'jeffkaufman', requestReviews: false},
       ],
     },

--- a/ads/OWNERS
+++ b/ads/OWNERS
@@ -6,7 +6,6 @@
     {
       owners: [
         {name: 'ampproject/wg-ads-reviewers'},
-        {name: 'jeffkaufman', requestReviews: false},
       ],
     },
   ],

--- a/ads/google/OWNERS
+++ b/ads/google/OWNERS
@@ -4,7 +4,7 @@
 {
   rules: [
     {
-      owners: [{name: 'ampproject/wg-ads'}],
+      owners: [{name: 'ampproject/wg-ads-reviewers'}],
     },
   ],
 }

--- a/extensions/amp-a4a/OWNERS
+++ b/extensions/amp-a4a/OWNERS
@@ -4,7 +4,7 @@
 {
   rules: [
     {
-      owners: [{name: 'ampproject/wg-ads'}],
+      owners: [{name: 'ampproject/wg-ads-reviewers'}],
     },
   ],
 }

--- a/extensions/amp-ad-custom/OWNERS
+++ b/extensions/amp-ad-custom/OWNERS
@@ -4,7 +4,7 @@
 {
   rules: [
     {
-      owners: [{name: 'ampproject/wg-ads'}],
+      owners: [{name: 'ampproject/wg-ads-reviewers'}],
     },
   ],
 }

--- a/extensions/amp-ad-exit/OWNERS
+++ b/extensions/amp-ad-exit/OWNERS
@@ -4,7 +4,7 @@
 {
   rules: [
     {
-      owners: [{name: 'ampproject/wg-ads'}],
+      owners: [{name: 'ampproject/wg-ads-reviewers'}],
     },
   ],
 }

--- a/extensions/amp-ad-network-adsense-impl/OWNERS
+++ b/extensions/amp-ad-network-adsense-impl/OWNERS
@@ -4,7 +4,7 @@
 {
   rules: [
     {
-      owners: [{name: 'ampproject/wg-ads'}],
+      owners: [{name: 'ampproject/wg-ads-reviewers'}],
     },
   ],
 }

--- a/extensions/amp-ad-network-adzerk-impl/OWNERS
+++ b/extensions/amp-ad-network-adzerk-impl/OWNERS
@@ -4,7 +4,7 @@
 {
   rules: [
     {
-      owners: [{name: 'ampproject/wg-ads'}],
+      owners: [{name: 'ampproject/wg-ads-reviewers'}],
     },
   ],
 }

--- a/extensions/amp-ad-network-doubleclick-impl/OWNERS
+++ b/extensions/amp-ad-network-doubleclick-impl/OWNERS
@@ -4,7 +4,7 @@
 {
   rules: [
     {
-      owners: [{name: 'ampproject/wg-ads'}],
+      owners: [{name: 'ampproject/wg-ads-reviewers'}],
     },
   ],
 }

--- a/extensions/amp-ad-network-fake-impl/OWNERS
+++ b/extensions/amp-ad-network-fake-impl/OWNERS
@@ -4,7 +4,7 @@
 {
   rules: [
     {
-      owners: [{name: 'ampproject/wg-ads'}],
+      owners: [{name: 'ampproject/wg-ads-reviewers'}],
     },
   ],
 }

--- a/extensions/amp-ad/OWNERS
+++ b/extensions/amp-ad/OWNERS
@@ -4,7 +4,7 @@
 {
   rules: [
     {
-      owners: [{name: 'ampproject/wg-ads'}],
+      owners: [{name: 'ampproject/wg-ads-reviewers'}],
     },
   ],
 }

--- a/extensions/amp-beopinion/OWNERS
+++ b/extensions/amp-beopinion/OWNERS
@@ -4,7 +4,7 @@
 {
   rules: [
     {
-      owners: [{name: 'lannka'}],
+      owners: [{name: 'ampproject/wg-ads-reviewers'}],
     },
   ],
 }

--- a/extensions/amp-consent/OWNERS
+++ b/extensions/amp-consent/OWNERS
@@ -4,7 +4,7 @@
 {
   rules: [
     {
-      owners: [{name: 'ampproject/wg-ads'}, {name: 'ampproject/wg-analytics'}],
+      owners: [{name: 'ampproject/wg-ads-reviewers'}, {name: 'ampproject/wg-analytics'}],
     },
   ],
 }

--- a/extensions/amp-consent/OWNERS
+++ b/extensions/amp-consent/OWNERS
@@ -4,7 +4,10 @@
 {
   rules: [
     {
-      owners: [{name: 'ampproject/wg-ads-reviewers'}, {name: 'ampproject/wg-analytics'}],
+      owners: [
+        {name: 'ampproject/wg-ads-reviewers'},
+        {name: 'ampproject/wg-analytics'},
+      ],
     },
   ],
 }

--- a/extensions/amp-mraid/OWNERS
+++ b/extensions/amp-mraid/OWNERS
@@ -4,7 +4,7 @@
 {
   rules: [
     {
-      owners: [{name: 'lannka'}, {name: 'jeffkaufman'}],
+      owners: [{name: 'ampproject/wg-ads-reviewers'}],
     },
   ],
 }

--- a/src/OWNERS
+++ b/src/OWNERS
@@ -20,7 +20,7 @@
     },
     {
       pattern: 'friendly-iframe-embed.js',
-      owners: [{name: 'ampproject/wg-ads'}],
+      owners: [{name: 'ampproject/wg-ads-reviewers'}],
     },
   ],
 }

--- a/src/inabox/OWNERS
+++ b/src/inabox/OWNERS
@@ -4,7 +4,7 @@
 {
   rules: [
     {
-      owners: [{name: 'ampproject/wg-ads'}],
+      owners: [{name: 'ampproject/wg-ads-reviewers'}],
     },
   ],
 }


### PR DESCRIPTION
Creating a separate  "GH team" for wg-ads PR reviews, that we can freely change according to members availability.