### PR TITLE
Story education viewer messaging.

### DIFF
--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -400,6 +400,7 @@ const forbiddenTerms = {
     whitelist: [
       'extensions/amp-access/0.1/login-dialog.js',
       'extensions/amp-access/0.1/signin.js',
+      'extensions/amp-story-education/0.1/amp-story-education.js',
       'extensions/amp-subscriptions/0.1/viewer-subscription-platform.js',
       'src/impression.js',
       'src/service/cid-impl.js',

--- a/extensions/amp-story-education/0.1/amp-story-education.js
+++ b/extensions/amp-story-education/0.1/amp-story-education.js
@@ -263,6 +263,7 @@ export class AmpStoryEducation extends AMP.BaseElement {
 
   /**
    * Asks the viewer whether the navigation screen should be shown.
+   * Viewer responses should be treated right away, and not cached.
    * @param {!Screen} screen Screen to show
    * @param {!State} state State to set
    * @private

--- a/extensions/amp-story-education/0.1/amp-story-education.js
+++ b/extensions/amp-story-education/0.1/amp-story-education.js
@@ -24,6 +24,7 @@ import {LocalizedStringId} from '../../../src/localized-strings';
 import {Services} from '../../../src/services';
 import {createShadowRootWithStyle} from '../../amp-story/1.0/utils';
 import {dev} from '../../../src/log';
+import {dict} from '../../../src/utils/object';
 import {htmlFor} from '../../../src/static-template';
 import {removeChildren} from '../../../src/dom';
 import {toggle} from '../../../src/style';
@@ -49,6 +50,11 @@ const buildNavigationEl = element => {
       <button class="i-amphtml-story-education-navigation-button"></button>
     </div>
   `;
+};
+
+/** @enum {string} */
+const Screen = {
+  ONBOARDING_NAVIGATION: 'on',
 };
 
 /** @enum */
@@ -79,6 +85,9 @@ export class AmpStoryEducation extends AMP.BaseElement {
     this.storeService_ = /** @type {!../../amp-story/1.0/amp-story-store-service.AmpStoryStoreService} */ (Services.storyStoreService(
       this.win
     ));
+
+    /** @private {?../../../src/service/viewer-interface.ViewerInterface} */
+    this.viewer_ = null;
   }
 
   /** @override */
@@ -87,6 +96,11 @@ export class AmpStoryEducation extends AMP.BaseElement {
     toggle(this.containerEl_, false);
     this.startListening_();
     createShadowRootWithStyle(this.element, this.containerEl_, CSS);
+
+    this.viewer_ = Services.viewerForDoc(this.element);
+    if (this.viewer_.isEmbedded()) {
+      this.maybeShowScreen_(Screen.ONBOARDING_NAVIGATION, State.NAVIGATION_TAP);
+    }
   }
 
   /** @override */
@@ -101,6 +115,23 @@ export class AmpStoryEducation extends AMP.BaseElement {
     this.containerEl_.addEventListener(
       'click',
       () => this.onClick_(),
+      true /** useCapture */
+    );
+
+    // Prevent touchevents from being forwarded through viewer messaging.
+    this.containerEl_.addEventListener(
+      'touchstart',
+      event => event.stopPropagation(),
+      true /** useCapture */
+    );
+    this.containerEl_.addEventListener(
+      'touchmove',
+      event => event.stopPropagation(),
+      true /** useCapture */
+    );
+    this.containerEl_.addEventListener(
+      'touchend',
+      event => event.stopPropagation(),
       true /** useCapture */
     );
 
@@ -150,6 +181,7 @@ export class AmpStoryEducation extends AMP.BaseElement {
 
     switch (state) {
       case State.HIDDEN:
+        this.storeService_.dispatch(Action.TOGGLE_EDUCATION, false);
         this.mutateElement(() => {
           removeChildren(this.containerEl_);
           toggle(this.containerEl_, false);
@@ -217,12 +249,45 @@ export class AmpStoryEducation extends AMP.BaseElement {
     }
 
     this.storeService_.dispatch(Action.TOGGLE_PAUSED, true);
+    this.storeService_.dispatch(Action.TOGGLE_EDUCATION, true);
 
     this.mutateElement(() => {
       removeChildren(this.containerEl_);
       toggle(this.containerEl_, true);
       this.containerEl_.appendChild(template);
     });
+  }
+
+  /**
+   * Asks the viewer whether the navigation screen should be shown.
+   * @param {!Screen} screen Screen to show
+   * @param {!State} state State to set
+   * @private
+   */
+  maybeShowScreen_(screen, state) {
+    // Only show education screens when the ampdoc is visible.
+    this.getAmpDoc()
+      .whenFirstVisible()
+      .then(() => {
+        // TODO(gmajoulet): update this method to support showing multiple
+        // screens, if/when needed.
+        this.viewer_
+          .sendMessageAwaitResponse(
+            'canShowScreens',
+            dict({'screens': [{'screen': screen}]})
+          )
+          .then(response => {
+            const shouldShow = !!(
+              response &&
+              response['screens'] &&
+              response['screens'][0] &&
+              response['screens'][0]['show']
+            );
+            if (shouldShow) {
+              this.setState_(state);
+            }
+          });
+      });
   }
 }
 

--- a/extensions/amp-story-education/0.1/amp-story-education.js
+++ b/extensions/amp-story-education/0.1/amp-story-education.js
@@ -54,7 +54,7 @@ const buildNavigationEl = element => {
 
 /** @enum {string} */
 const Screen = {
-  ONBOARDING_NAVIGATION: 'on',
+  ONBOARDING_NAVIGATION_TAP_AND_SWIPE: 'ontas',
 };
 
 /** @enum */
@@ -99,7 +99,10 @@ export class AmpStoryEducation extends AMP.BaseElement {
 
     this.viewer_ = Services.viewerForDoc(this.element);
     if (this.viewer_.isEmbedded()) {
-      this.maybeShowScreen_(Screen.ONBOARDING_NAVIGATION, State.NAVIGATION_TAP);
+      this.maybeShowScreen_(
+        Screen.ONBOARDING_NAVIGATION_TAP_AND_SWIPE,
+        State.NAVIGATION_TAP
+      );
     }
   }
 

--- a/extensions/amp-story-education/0.1/test/test-amp-story-education.js
+++ b/extensions/amp-story-education/0.1/test/test-amp-story-education.js
@@ -207,13 +207,13 @@ describes.realWin('amp-story-education', {amp: true}, env => {
       await Promise.resolve(); // Microtask tick.
 
       expect(sendStub).to.have.been.calledOnceWith('canShowScreens', {
-        screens: [{screen: 'on'}],
+        screens: [{screen: 'ontas'}],
       });
     });
 
     it('should show navigation screen on viewer response', async () => {
       env.sandbox.stub(viewer, 'sendMessageAwaitResponse').resolves({
-        screens: [{screen: 'on', show: true}],
+        screens: [{screen: 'ontas', show: true}],
       });
       env.sandbox
         .stub(storyEducation.getAmpDoc(), 'whenFirstVisible')
@@ -231,7 +231,7 @@ describes.realWin('amp-story-education', {amp: true}, env => {
 
     it('should not show navigation screen on viewer response', async () => {
       env.sandbox.stub(viewer, 'sendMessageAwaitResponse').resolves({
-        screens: [{screen: 'on', show: false}],
+        screens: [{screen: 'ontas', show: false}],
       });
       env.sandbox
         .stub(storyEducation.getAmpDoc(), 'whenFirstVisible')

--- a/extensions/amp-story-education/0.1/test/test-amp-story-education.js
+++ b/extensions/amp-story-education/0.1/test/test-amp-story-education.js
@@ -238,7 +238,7 @@ describes.realWin('amp-story-education', {amp: true}, env => {
         .resolves();
 
       storyEducation.buildCallback();
-      await Promise.resolve(); // whenFirstVisible icrotask tick.
+      await Promise.resolve(); // whenFirstVisible microtask tick.
       await Promise.resolve(); // sendMessageAwaitResponse microtask tick.
 
       const navigationTapEl = storyEducation.containerEl_.querySelector(

--- a/extensions/amp-story-education/0.1/test/test-amp-story-education.js
+++ b/extensions/amp-story-education/0.1/test/test-amp-story-education.js
@@ -19,13 +19,17 @@ import {
   AmpStoryStoreService,
   StateProperty,
 } from '../../../amp-story/1.0/amp-story-store-service';
+import {AmpDocSingle} from '../../../../src/service/ampdoc-impl';
 import {AmpStoryEducation, State} from '../amp-story-education';
 import {LocalizationService} from '../../../../src/service/localization';
+import {Services} from '../../../../src/services';
 import {registerServiceBuilder} from '../../../../src/service';
 
 describes.realWin('amp-story-education', {amp: true}, env => {
+  let ampdoc;
   let storeService;
   let storyEducation;
+  let viewer;
   let win;
 
   beforeEach(() => {
@@ -42,9 +46,13 @@ describes.realWin('amp-story-education', {amp: true}, env => {
     });
 
     const element = win.document.createElement('amp-story-education');
+    ampdoc = new AmpDocSingle(win);
+    element.getAmpDoc = () => ampdoc;
     win.document.body.appendChild(element);
     storyEducation = new AmpStoryEducation(element);
 
+    viewer = Services.viewerForDoc(storyEducation.element);
+    env.sandbox.stub(viewer, 'isEmbedded').returns(true);
     env.sandbox.stub(storyEducation, 'mutateElement').callsFake(fn => fn());
   });
 
@@ -172,6 +180,71 @@ describes.realWin('amp-story-education', {amp: true}, env => {
       storyEducation.containerEl_.dispatchEvent(clickEvent);
 
       expect(storyEducation.containerEl_).to.have.attribute('hidden');
+    });
+  });
+
+  describe('amp-story-education viewer messaging', () => {
+    it('should not send viewer message if not visible', async () => {
+      const sendStub = env.sandbox.stub(viewer, 'sendMessageAwaitResponse');
+      // Viewer is not visible.
+      env.sandbox
+        .stub(storyEducation.getAmpDoc(), 'whenFirstVisible')
+        .rejects();
+
+      storyEducation.buildCallback();
+      await Promise.resolve();
+
+      expect(sendStub).to.not.have.been.called;
+    });
+
+    it('should send canShowScreens for navigation on build', async () => {
+      const sendStub = env.sandbox.stub(viewer, 'sendMessageAwaitResponse');
+      env.sandbox
+        .stub(storyEducation.getAmpDoc(), 'whenFirstVisible')
+        .resolves();
+
+      storyEducation.buildCallback();
+      await Promise.resolve(); // Microtask tick.
+
+      expect(sendStub).to.have.been.calledOnceWith('canShowScreens', {
+        screens: [{screen: 'on'}],
+      });
+    });
+
+    it('should show navigation screen on viewer response', async () => {
+      env.sandbox.stub(viewer, 'sendMessageAwaitResponse').resolves({
+        screens: [{screen: 'on', show: true}],
+      });
+      env.sandbox
+        .stub(storyEducation.getAmpDoc(), 'whenFirstVisible')
+        .resolves();
+
+      storyEducation.buildCallback();
+      await Promise.resolve(); // whenFirstVisible icrotask tick.
+      await Promise.resolve(); // sendMessageAwaitResponse microtask tick.
+
+      const navigationTapEl = storyEducation.containerEl_.querySelector(
+        '[step="tap"]'
+      );
+      expect(navigationTapEl).to.exist;
+    });
+
+    it('should not show navigation screen on viewer response', async () => {
+      env.sandbox.stub(viewer, 'sendMessageAwaitResponse').resolves({
+        screens: [{screen: 'on', show: false}],
+      });
+      env.sandbox
+        .stub(storyEducation.getAmpDoc(), 'whenFirstVisible')
+        .resolves();
+
+      storyEducation.buildCallback();
+      await Promise.resolve(); // whenFirstVisible icrotask tick.
+      await Promise.resolve(); // sendMessageAwaitResponse microtask tick.
+
+      const navigationTapEl = storyEducation.containerEl_.querySelector(
+        '[step="tap"]'
+      );
+      expect(navigationTapEl).to.not.exist;
     });
   });
 });

--- a/extensions/amp-story/1.0/amp-story-store-service.js
+++ b/extensions/amp-story/1.0/amp-story-store-service.js
@@ -88,6 +88,7 @@ export let InteractiveComponentDef;
  *    affiliateLinkState: !Element,
  *    bookendState: boolean,
  *    desktopState: boolean,
+ *    educationState: boolean,
  *    hasSidebarState: boolean,
  *    infoDialogState: boolean,
  *    interactiveEmbeddedComponentState: !InteractiveComponentDef,
@@ -130,6 +131,7 @@ export const StateProperty = {
   BOOKEND_STATE: 'bookendState',
   AFFILIATE_LINK_STATE: 'affiliateLinkState',
   DESKTOP_STATE: 'desktopState',
+  EDUCATION_STATE: 'educationState',
   HAS_SIDEBAR_STATE: 'hasSidebarState',
   INFO_DIALOG_STATE: 'infoDialogState',
   INTERACTIVE_COMPONENT_STATE: 'interactiveEmbeddedComponentState',
@@ -173,6 +175,7 @@ export const Action = {
   TOGGLE_AFFILIATE_LINK: 'toggleAffiliateLink',
   TOGGLE_BOOKEND: 'toggleBookend',
   TOGGLE_CAN_SHOW_BOOKEND: 'toggleCanShowBookend',
+  TOGGLE_EDUCATION: 'toggleEducation',
   TOGGLE_HAS_SIDEBAR: 'toggleHasSidebar',
   TOGGLE_INFO_DIALOG: 'toggleInfoDialog',
   TOGGLE_INTERACTIVE_COMPONENT: 'toggleInteractiveComponent',
@@ -270,6 +273,11 @@ const actions = (state, action, data) => {
       return /** @type {!State} */ ({
         ...state,
         [StateProperty.CAN_SHOW_BOOKEND]: !!data,
+      });
+    case Action.TOGGLE_EDUCATION:
+      return /** @type {!State} */ ({
+        ...state,
+        [StateProperty.EDUCATION_STATE]: !!data,
       });
     case Action.TOGGLE_INTERACTIVE_COMPONENT:
       data = /** @type {InteractiveComponentDef} */ (data);
@@ -507,6 +515,7 @@ export class AmpStoryStoreService {
       [StateProperty.AFFILIATE_LINK_STATE]: null,
       [StateProperty.BOOKEND_STATE]: false,
       [StateProperty.DESKTOP_STATE]: false,
+      [StateProperty.EDUCATION_STATE]: false,
       [StateProperty.HAS_SIDEBAR_STATE]: false,
       [StateProperty.INFO_DIALOG_STATE]: false,
       [StateProperty.INTERACTIVE_COMPONENT_STATE]: {

--- a/extensions/amp-story/1.0/amp-story-viewer-messaging-handler.js
+++ b/extensions/amp-story/1.0/amp-story-viewer-messaging-handler.js
@@ -48,6 +48,10 @@ const GET_STATE_CONFIGURATIONS = {
     dataSource: DataSources.STORE_SERVICE,
     property: StateProperty.CURRENT_PAGE_ID,
   },
+  'EDUCATION_STATE': {
+    dataSource: DataSources.STORE_SERVICE,
+    property: StateProperty.EDUCATION_STATE,
+  },
   'MUTED_STATE': {
     dataSource: DataSources.STORE_SERVICE,
     property: StateProperty.MUTED_STATE,

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -2275,6 +2275,12 @@ export class AmpStory extends AMP.BaseElement {
       return;
     }
 
+    this.mutateElement(() => {
+      this.element.appendChild(
+        this.win.document.createElement('amp-story-education')
+      );
+    });
+
     Services.extensionsFor(this.win).installExtensionForDoc(
       this.getAmpDoc(),
       'amp-story-education'


### PR DESCRIPTION
Story education viewer messaging:

- Sends a message on build to display the tap + swipe navigation screen
- Only sends messages when the doc gets visible, to avoid receiving messages from multiple prerendered docs
- Stops propagation on touch events so they're not forwarded to the viewer, disabling the "swipe to next" feature (and the navigation hint overlay)
- Adds an `EDUCATION_STATE` in the store service and expose it to viewers, so they can block swiping interactions while it's on if they're using native gestures

#27097