### PR TITLE
♻️ Refactor dist --fortesting into commons/utils

### DIFF
--- a/build-system/common/utils.js
+++ b/build-system/common/utils.js
@@ -27,6 +27,15 @@ const {isTravisBuild} = require('./travis');
 const ROOT_DIR = path.resolve(__dirname, '../../');
 
 /**
+ * Cleans and builds binaries with --fortesting flag and
+ * overriden config.
+ */
+function buildMinifiedRuntime() {
+  execOrDie('gulp clean');
+  execOrDie(`gulp dist --fortesting --config ${argv.config}`);
+}
+
+/**
  * Logs a message on the same line to indicate progress
  *
  * @param {string} message
@@ -137,6 +146,7 @@ function installPackages(dir) {
 }
 
 module.exports = {
+  buildMinifiedRuntime,
   getFilesChanged,
   getFilesToCheck,
   installPackages,

--- a/build-system/tasks/e2e/index.js
+++ b/build-system/tasks/e2e/index.js
@@ -23,9 +23,8 @@ const glob = require('glob');
 const log = require('fancy-log');
 const Mocha = require('mocha');
 const path = require('path');
+const {buildMinifiedRuntime, installPackages} = require('../../common/utils');
 const {cyan} = require('ansi-colors');
-const {execOrDie} = require('../../common/exec');
-const {installPackages} = require('../../common/utils');
 const {isTravisBuild} = require('../../common/travis');
 const {reportTestStarted} = require('../report-test-status');
 const {startServer, stopServer} = require('../serve');
@@ -35,11 +34,6 @@ const HOST = 'localhost';
 const PORT = 8000;
 const SLOW_TEST_THRESHOLD_MS = 2500;
 const TEST_RETRIES = isTravisBuild() ? 2 : 0;
-
-function buildRuntime_() {
-  execOrDie('gulp clean');
-  execOrDie(`gulp dist --fortesting --config ${argv.config}`);
-}
 
 async function launchWebServer_() {
   await startServer(
@@ -86,7 +80,7 @@ async function e2e() {
 
   // build runtime
   if (!argv.nobuild) {
-    buildRuntime_();
+    buildMinifiedRuntime();
   }
 
   // start up web server

--- a/build-system/tasks/visual-diff/index.js
+++ b/build-system/tasks/visual-diff/index.js
@@ -38,8 +38,8 @@ const {
   gitTravisMasterBaseline,
   shortSha,
 } = require('../../common/git');
-const {execOrDie, execScriptAsync} = require('../../common/exec');
-const {installPackages} = require('../../common/utils');
+const {buildMinifiedRuntime, installPackages} = require('../../common/utils');
+const {execScriptAsync} = require('../../common/exec');
 const {isTravisBuild} = require('../../common/travis');
 const {startServer, stopServer} = require('../serve');
 const {waitUntilUsed} = require('tcp-port-used');
@@ -767,8 +767,7 @@ async function ensureOrBuildAmpRuntimeInTestMode_() {
       );
     }
   } else {
-    execOrDie('gulp clean');
-    execOrDie(`gulp dist --fortesting --config ${argv.config}`);
+    buildMinifiedRuntime();
   }
 }
 


### PR DESCRIPTION
Added `buildRuntime()` to `build-system/commons/utils`, which cleans and build the runtime using `--fortesting` flag and overwritten config. 
- Replaced in e2e and visual-diff
