### PR TITLE
Reconstruct safeframe API upon refreshing.

### DIFF
--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -1604,13 +1604,24 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
     }
     const creativeSize = this.getCreativeSize();
     devAssert(creativeSize, 'this.getCreativeSize returned null');
-    this.safeframeApi_ =
-      this.safeframeApi_ ||
-      new SafeframeHostApi(
+    if (this.isRefreshing) {
+      if (this.safeframeApi_) {
+        this.safeframeApi_.destroy();
+      }
+      this.safeframeApi_ = new SafeframeHostApi(
         this,
         this.isFluidRequest_,
         /** @type {{height, width}} */ (creativeSize)
       );
+    } else {
+      this.safeframeApi_ =
+        this.safeframeApi_ ||
+        new SafeframeHostApi(
+          this,
+          this.isFluidRequest_,
+          /** @type {{height, width}} */ (creativeSize)
+        );
+    }
 
     return this.safeframeApi_.getSafeframeNameAttr();
   }


### PR DESCRIPTION
Fixes #27125 

SafeFrame APIs are currently not rebuilt after refresh events, causing them to hold on to stale data (such as iframe and promise ID verification functions). In turn, this means calls to the API by post-initial creatives are effectively dropped.