### PR TITLE
🐛 Don't try to assign deferred before checking null

### DIFF
--- a/extensions/amp-video-iframe/0.1/amp-video-iframe.js
+++ b/extensions/amp-video-iframe/0.1/amp-video-iframe.js
@@ -406,7 +406,7 @@ class AmpVideoIframe extends AMP.BaseElement {
    * @private
    */
   postMessage_(message) {
-    const {promise} = this.readyDeferred_;
+    const promise = this.readyDeferred_ && this.readyDeferred_.promise;
     if (!promise) {
       return;
     }


### PR DESCRIPTION
This PR addresses the [sixth](https://pantheon.corp.google.com/errors/CJCcoczlpdyaQQ?time=P1D&project=amp-error-reporting) and [seventh](https://pantheon.corp.google.com/errors/CLbMwZ_dlL396gE?time=P1D&project=amp-error-reporting) most frequent unexpected errors logged to AMP Error Reporting.

At issue here is the fact there is a private `readyDeferred_` property in this component which is initialized to `null` at runtime. During `layoutCallback` it's initialized to a new `Deferred`, and the deferred's promise is returned from `layoutCallback` where I'm guessing it's resolved by the runtime or something like that.

Problem is, there is code in `postMessage_` which tries to destructure `readyDeferred` into an object:
```
    const {promise} = this.readyDeferred_;
    if (!promise) {
      return;
    }
```
This is why we get errors like "null is not an object" or "Cannot read property 'promise' of null" (error message depending on the JS engine), when some action on the video-player tries to trigger some method (such as, possibly autoplay) before the deferred is initialized..

This PR just makes sure `readyDeferred` is initialized before trying to access its promise. I expect this to eliminate approximately 600,000 error reports per week.

Closes #24246
Closes #24245