### PR TITLE
🐛 Validate presence of contentWindow after promise resolves

### DIFF
--- a/extensions/amp-ima-video/0.1/amp-ima-video.js
+++ b/extensions/amp-ima-video/0.1/amp-ima-video.js
@@ -244,6 +244,10 @@ class AmpImaVideo extends AMP.BaseElement {
    * @private
    */
   sendCommand_(command, opt_args) {
+    if (!this.playerReadyPromise_) {
+      return;
+    }
+
     this.playerReadyPromise_.then(() => {
       if (this.iframe_ && this.iframe_.contentWindow) {
         this.iframe_.contentWindow./*OK*/ postMessage(

--- a/extensions/amp-ima-video/0.1/amp-ima-video.js
+++ b/extensions/amp-ima-video/0.1/amp-ima-video.js
@@ -244,24 +244,22 @@ class AmpImaVideo extends AMP.BaseElement {
    * @private
    */
   sendCommand_(command, opt_args) {
-    if (!this.playerReadyPromise_) {
-      return;
+    if (this.playerReadyPromise_) {
+      this.playerReadyPromise_.then(() => {
+        if (this.iframe_ && this.iframe_.contentWindow) {
+          this.iframe_.contentWindow./*OK*/ postMessage(
+            JSON.stringify(
+              dict({
+                'event': 'command',
+                'func': command,
+                'args': opt_args || '',
+              })
+            ),
+            '*'
+          );
+        }
+      });
     }
-
-    this.playerReadyPromise_.then(() => {
-      if (this.iframe_ && this.iframe_.contentWindow) {
-        this.iframe_.contentWindow./*OK*/ postMessage(
-          JSON.stringify(
-            dict({
-              'event': 'command',
-              'func': command,
-              'args': opt_args || '',
-            })
-          ),
-          '*'
-        );
-      }
-    });
     // If we have an unlistener for this command, call it.
     if (this.unlisteners_[command]) {
       this.unlisteners_[command]();

--- a/extensions/amp-ima-video/0.1/amp-ima-video.js
+++ b/extensions/amp-ima-video/0.1/amp-ima-video.js
@@ -244,8 +244,8 @@ class AmpImaVideo extends AMP.BaseElement {
    * @private
    */
   sendCommand_(command, opt_args) {
-    if (this.iframe_ && this.iframe_.contentWindow) {
-      this.playerReadyPromise_.then(() => {
+    this.playerReadyPromise_.then(() => {
+      if (this.iframe_ && this.iframe_.contentWindow) {
         this.iframe_.contentWindow./*OK*/ postMessage(
           JSON.stringify(
             dict({
@@ -256,8 +256,8 @@ class AmpImaVideo extends AMP.BaseElement {
           ),
           '*'
         );
-      });
-    }
+      }
+    });
     // If we have an unlistener for this command, call it.
     if (this.unlisteners_[command]) {
       this.unlisteners_[command]();


### PR DESCRIPTION
Addresses the [third](https://pantheon.corp.google.com/errors/CNu81pXjoeLfVQ?time=P7D&project=amp-error-reporting) most frequently logged error in AMP Error Reporting.

Currently, when the amp-ima-video extension tries to send a command it:
1) Checks that the iframe's `contentWindow` is available
2) Waits for a promise to resolve indicating the player is ready
3) Tries to post a message to the iframe's `contentWindow`

If `unlayoutCallback` is called before the promise resolves, `contentWindow` won't be available, and we get this error. The solution is to instead validate the iframe is available after the promise resolves, right before trying to post a message to it.

I anticipate this will eliminate approximately 900k errors per week.

Closes https://github.com/ampproject/amphtml/issues/12063