### PR TITLE
🐛 Use quoted properties to prevent Closure's DCE

### DIFF
--- a/extensions/amp-date-display/0.2/amp-date-display.js
+++ b/extensions/amp-date-display/0.2/amp-date-display.js
@@ -79,13 +79,13 @@ class AmpDateDisplay extends PreactBaseElement {
 }
 
 /** @override */
-AmpDateDisplay.Component = DateDisplay;
+AmpDateDisplay['Component'] = DateDisplay;
 
 /** @override */
-AmpDateDisplay.passthrough = true;
+AmpDateDisplay['passthrough'] = true;
 
 /** @override */
-AmpDateDisplay.props = {
+AmpDateDisplay['props'] = {
   'displayIn': {attr: 'display-in'},
   'offsetSeconds': {attr: 'offset-seconds', type: 'number'},
   'locale': {attr: 'locale'},

--- a/extensions/amp-timeago/0.2/amp-timeago.js
+++ b/extensions/amp-timeago/0.2/amp-timeago.js
@@ -41,13 +41,13 @@ class AmpTimeago extends PreactBaseElement {
 }
 
 /** @override */
-AmpTimeago.Component = Timeago;
+AmpTimeago['Component'] = Timeago;
 
 /** @override */
-AmpTimeago.passthrough = true;
+AmpTimeago['passthrough'] = true;
 
 /** @override */
-AmpTimeago.props = {
+AmpTimeago['props'] = {
   'datetime': {attr: 'datetime'},
   'locale': {attr: 'locale'},
   'cutoff': {attr: 'cutoff', type: 'number'},

--- a/src/preact/base-element.js
+++ b/src/preact/base-element.js
@@ -157,7 +157,7 @@ export class PreactBaseElement extends AMP.BaseElement {
     const Ctor = this.constructor;
 
     if (!this.container_) {
-      if (Ctor.children || Ctor.passthrough) {
+      if (Ctor['children'] || Ctor['passthrough']) {
         this.container_ = this.element.attachShadow({mode: 'open'});
       } else {
         const container = this.win.document.createElement('i-amphtml-c');
@@ -174,7 +174,7 @@ export class PreactBaseElement extends AMP.BaseElement {
     // this element will be reused.
     const v = (
       <WithAmpContext {...this.context_}>
-        <Ctor.Component {...props} />
+        {Preact.createElement(Ctor['Component'], props)}
       </WithAmpContext>
     );
 
@@ -237,10 +237,10 @@ function collectProps(Ctor, element, defaultProps) {
   const props = /** @type {!JsonObject} */ ({...defaultProps});
 
   const {
-    className,
-    props: propDefs,
-    passthrough,
-    children: childrenDefs,
+    'className': className,
+    'props': propDefs,
+    'passthrough': passthrough,
+    'children': childrenDefs,
   } = Ctor;
 
   // Class.

--- a/src/preact/base-element.js
+++ b/src/preact/base-element.js
@@ -195,7 +195,7 @@ export class PreactBaseElement extends AMP.BaseElement {
  *
  * @protected {!PreactDef.FunctionalComponent}
  */
-PreactBaseElement.Component = function() {
+PreactBaseElement['Component'] = function() {
   devAssert(false, 'Must provide Component');
 };
 
@@ -204,7 +204,7 @@ PreactBaseElement.Component = function() {
  *
  * @protected {string}
  */
-PreactBaseElement.className = '';
+PreactBaseElement['className'] = '';
 
 /**
  * Enabling passthrough mode alters the children slotting to use a single
@@ -213,19 +213,19 @@ PreactBaseElement.className = '';
  *
  * @protected {boolean}
  */
-PreactBaseElement.passthrough = false;
+PreactBaseElement['passthrough'] = false;
 
 /**
  * Provides a mapping of Preact prop to AmpElement DOM attributes.
  *
  * @protected {!Object<string, !AmpElementPropDef>}
  */
-PreactBaseElement.props = {};
+PreactBaseElement['props'] = {};
 
 /**
  * @protected {!Object<string, !ChildDef>|null}
  */
-PreactBaseElement.children = null;
+PreactBaseElement['children'] = null;
 
 /**
  * @param {typeof PreactBaseElement} Ctor


### PR DESCRIPTION
Looks like the latest closure upgrade started DCE'ing our static prop assignments. This is the easiest fix to get them to persist.