### PR TITLE
🐛 Wait for document body to exist before testing rtl/ltr

### DIFF
--- a/extensions/amp-video-docking/0.1/amp-video-docking.js
+++ b/extensions/amp-video-docking/0.1/amp-video-docking.js
@@ -56,7 +56,7 @@ import {escapeCssSelectorIdent} from '../../../src/css';
 import {getInternalVideoElementFor} from '../../../src/utils/video';
 import {htmlFor, htmlRefs} from '../../../src/static-template';
 import {installStylesForDoc} from '../../../src/style-installer';
-import {isRTL, removeElement, scopedQuerySelector, waitForBodyOpen} from '../../../src/dom';
+import {isRTL, removeElement, scopedQuerySelector} from '../../../src/dom';
 import {once} from '../../../src/utils/function';
 import {
   px,
@@ -271,14 +271,9 @@ export class VideoDocking {
      * Overriden when user drags the video to a different corner.
      * @private {!DirectionX}
      */
-    this.cornerDirectionX_ = DirectionX.RIGHT;
-    // Initialize to right side, then update based on whether the doc is RTL as
-    // soon as it's available.
-    waitForBodyOpen(this.getDoc_(), () => {
-      this.cornerDirectionX_ = isRTL(this.getDoc_())
-        ? DirectionX.LEFT
-        : DirectionX.RIGHT;
-    });
+    this.cornerDirectionX_ = !!this.getDoc_().body && isRTL(this.getDoc_())
+      ? DirectionX.LEFT
+      : DirectionX.RIGHT;
 
     const html = htmlFor(this.getDoc_());
 

--- a/extensions/amp-video-docking/0.1/amp-video-docking.js
+++ b/extensions/amp-video-docking/0.1/amp-video-docking.js
@@ -56,7 +56,7 @@ import {escapeCssSelectorIdent} from '../../../src/css';
 import {getInternalVideoElementFor} from '../../../src/utils/video';
 import {htmlFor, htmlRefs} from '../../../src/static-template';
 import {installStylesForDoc} from '../../../src/style-installer';
-import {isRTL, removeElement, scopedQuerySelector} from '../../../src/dom';
+import {isRTL, removeElement, scopedQuerySelector, waitForBodyOpen} from '../../../src/dom';
 import {once} from '../../../src/utils/function';
 import {
   px,
@@ -271,9 +271,14 @@ export class VideoDocking {
      * Overriden when user drags the video to a different corner.
      * @private {!DirectionX}
      */
-    this.cornerDirectionX_ = isRTL(this.getDoc_())
-      ? DirectionX.LEFT
-      : DirectionX.RIGHT;
+    this.cornerDirectionX_ = DirectionX.RIGHT;
+    // Initialize to right side, then update based on whether the doc is RTL as
+    // soon as it's available.
+    waitForBodyOpen(this.getDoc_(), () => {
+      this.cornerDirectionX_ = isRTL(this.getDoc_())
+        ? DirectionX.LEFT
+        : DirectionX.RIGHT;
+    });
 
     const html = htmlFor(this.getDoc_());
 

--- a/extensions/amp-video-docking/0.1/amp-video-docking.js
+++ b/extensions/amp-video-docking/0.1/amp-video-docking.js
@@ -269,11 +269,9 @@ export class VideoDocking {
 
     /**
      * Overriden when user drags the video to a different corner.
-     * @private {!DirectionX}
+     * @private {?DirectionX}
      */
-    this.cornerDirectionX_ = !!this.getDoc_().body && isRTL(this.getDoc_())
-      ? DirectionX.LEFT
-      : DirectionX.RIGHT;
+    this.cornerDirectionX_ = null;
 
     const html = htmlFor(this.getDoc_());
 
@@ -1682,6 +1680,12 @@ export class VideoDocking {
         type: DockTargetType.SLOT,
         rect: letterboxRect(inlineRect, slot.getPageLayoutBox()),
       };
+    }
+
+    if (this.cornerDirectionX_ === null) {
+      this.cornerDirectionX_ = isRTL(this.getDoc_())
+        ? DirectionX.LEFT
+        : DirectionX.RIGHT;
     }
 
     return {


### PR DESCRIPTION
Addresses the [eigth](https://pantheon.corp.google.com/errors/CM2H9OvX1deHPQ?time=P7D&project=amp-error-reporting) most frequent unexpected error reported to AMP Error Reporting.

When the amp-video-docking component initializes, it tries to dock to either the left or right side of the screen, defaulting to right but using left if the `dir="rtl"` attribute is set on the document or body. The issue is that sometimes the component is initialized before the document is fully created, and so there is no documentElement and the call to `isRTL` fails. This PR gates the call to `isRTL` with an assertion that `document.body` exists, and if it doesn't defaults to docking to the right.Note that the initial docking is overridden when the user drags the dock.

I anticipate this PR will eliminate ~160k errors per week.

Closes https://github.com/ampproject/amphtml/issues/24252