### PR TITLE
Rename changeSize APIs to be grep-able (noop)

### DIFF
--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -954,7 +954,6 @@ const forbiddenTermsSrcInclusive = {
   '\\.scrollingElement(?!_)': bannedTermsHelpString,
   '\\.computeCTM(?!_)': bannedTermsHelpString,
   // Functions
-  '\\.changeHeight\\(': bannedTermsHelpString,
   '\\.applySize\\(': bannedTermsHelpString,
   '\\.attemptChangeHeight\\(0\\)': 'please consider using `attemptCollapse()`',
   '\\.collapse\\(': bannedTermsHelpString,

--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -955,7 +955,7 @@ const forbiddenTermsSrcInclusive = {
   '\\.computeCTM(?!_)': bannedTermsHelpString,
   // Functions
   '\\.changeHeight\\(': bannedTermsHelpString,
-  '\\.changeSize\\(': bannedTermsHelpString,
+  '\\.applySize\\(': bannedTermsHelpString,
   '\\.attemptChangeHeight\\(0\\)': 'please consider using `attemptCollapse()`',
   '\\.collapse\\(': bannedTermsHelpString,
   '\\.expand\\(': bannedTermsHelpString,

--- a/contributing/building-an-amp-extension.md
+++ b/contributing/building-an-amp-extension.md
@@ -570,7 +570,7 @@ probably wants to return true in order to signal to AMP the need to call
 `layoutCallback` again once the document is active. Otherwise your
 element will never be re-laid out.
 
-### vsync, mutateElement, and attemptChangeSize
+### vsync, mutateElement, and requestChangeSize
 
 AMP provides multiple utilities to optimize many mutations and measuring
 for better performance. These include vsync service with a mutate and

--- a/contributing/building-an-amp-extension.md
+++ b/contributing/building-an-amp-extension.md
@@ -570,7 +570,7 @@ probably wants to return true in order to signal to AMP the need to call
 `layoutCallback` again once the document is active. Otherwise your
 element will never be re-laid out.
 
-### vsync, mutateElement, and changeSize
+### vsync, mutateElement, and attemptChangeSize
 
 AMP provides multiple utilities to optimize many mutations and measuring
 for better performance. These include vsync service with a mutate and

--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -191,7 +191,7 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
         this.responsiveState_ = state;
       }
       if (this.responsiveState_ != null) {
-        return this.responsiveState_.attemptChangeSize();
+        return this.responsiveState_.attemptToMatchResponsiveHeight();
       }
       // This should happen last, as some diversion criteria rely on some of the
       // preceding logic (specifically responsive logic).

--- a/extensions/amp-ad-network-adsense-impl/0.1/responsive-state.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/responsive-state.js
@@ -358,7 +358,7 @@ export class ResponsiveState {
    * @return {!Promise} a promise that resolves when we have attempted to change size
    * (whether successfully or not).
    */
-  attemptChangeSize() {
+  attemptToMatchResponsiveHeight() {
     const viewportSize = Services.viewportForDoc(
       this.element_.getAmpDoc()
     ).getSize();

--- a/extensions/amp-ad-network-adsense-impl/0.1/test/test-responsive-state.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/test/test-responsive-state.js
@@ -183,7 +183,7 @@ describes.realWin(
       });
     });
 
-    describe('attemptChangeSize', () => {
+    describe('attemptToMatchResponsiveHeight', () => {
       it(`should attempt to set the right size for data-auto-format="${ADSENSE_RSPV_TAG}" without height fix experiment`, async () => {
         const state = createState({
           'data-auto-format': [ADSENSE_RSPV_TAG],
@@ -192,7 +192,7 @@ describes.realWin(
           'width': '100vw',
         });
 
-        await state.attemptChangeSize();
+        await state.attemptToMatchResponsiveHeight();
 
         expect(lastSizeChangeAttempt).to.be.deep.equal({
           height: 300,
@@ -214,7 +214,7 @@ describes.realWin(
           'width': '100vw',
         });
 
-        await state.attemptChangeSize();
+        await state.attemptToMatchResponsiveHeight();
 
         expect(lastSizeChangeAttempt).to.be.deep.equal({
           height: 313,
@@ -230,7 +230,7 @@ describes.realWin(
           'width': '100vw',
         });
 
-        await state.attemptChangeSize();
+        await state.attemptToMatchResponsiveHeight();
 
         expect(lastSizeChangeAttempt).to.be.deep.equal({
           height: 1386,

--- a/extensions/amp-apester-media/0.1/amp-apester-media.js
+++ b/extensions/amp-apester-media/0.1/amp-apester-media.js
@@ -349,9 +349,9 @@ class AmpApesterMedia extends AMP.BaseElement {
                 if (height != this.height_) {
                   this.height_ = height;
                   if (this.random_) {
-                    this./*OK*/ attemptChangeHeight(height);
+                    this.attemptChangeHeight(height);
                   } else {
-                    this./*OK*/ changeHeight(height);
+                    this.forceChangeHeight(height);
                   }
                 }
               });

--- a/extensions/amp-apester-media/0.1/monetization/companion/display.js
+++ b/extensions/amp-apester-media/0.1/monetization/companion/display.js
@@ -85,7 +85,7 @@ function constructCompanionDisplayAd(slot, bannerSizes, apesterElement) {
   );
   ampAd.classList.add('amp-apester-companion');
   apesterElement.parentNode.insertBefore(ampAd, apesterElement.nextSibling);
-  Services.mutatorForDoc(apesterElement).attemptChangeSize(
+  Services.mutatorForDoc(apesterElement).requestChangeSize(
     ampAd,
     maxHeight,
     /* newWidth */ undefined

--- a/extensions/amp-apester-media/0.1/monetization/companion/video.js
+++ b/extensions/amp-apester-media/0.1/monetization/companion/video.js
@@ -112,7 +112,7 @@ function addCompanionSrElement(videoTag, position, macros, apesterElement) {
     position === 'below' ? apesterElement.nextSibling : apesterElement;
   apesterElement.parentNode.insertBefore(ampBladeAd, relativeElement);
 
-  Services.mutatorForDoc(apesterElement).attemptChangeSize(
+  Services.mutatorForDoc(apesterElement).requestChangeSize(
     ampBladeAd,
     size.height,
     /* newWidth */ undefined

--- a/extensions/amp-apester-media/0.1/test/test-amp-apester-media.js
+++ b/extensions/amp-apester-media/0.1/test/test-amp-apester-media.js
@@ -81,7 +81,10 @@ describes.realWin(
           ? playlistResponse
           : regularResponse;
 
-      changeSizeSpy = env.sandbox.spy(media.implementation_, 'changeHeight');
+      changeSizeSpy = env.sandbox.spy(
+        media.implementation_,
+        'forceChangeHeight'
+      );
       attemptChangeSizeSpy = env.sandbox.spy(
         media.implementation_,
         'attemptChangeHeight'

--- a/extensions/amp-apester-media/0.1/test/test-amp-apester-monetization.js
+++ b/extensions/amp-apester-media/0.1/test/test-amp-apester-monetization.js
@@ -37,7 +37,7 @@ describes.realWin('amp-apester-media-monetization', {}, env => {
     baseElement = doc.createElement('amp-apester-media');
 
     const mutator = {
-      attemptChangeSize: () => env.sandbox.stub(),
+      requestChangeSize: () => env.sandbox.stub(),
     };
     env.sandbox.stub(Services, 'mutatorForDoc').returns(mutator);
 

--- a/extensions/amp-auto-ads/0.1/placement.js
+++ b/extensions/amp-auto-ads/0.1/placement.js
@@ -245,7 +245,7 @@ export class Placement {
           return whenUpgradedToCustomElement(this.getAdElement())
             .then(() => this.getAdElement().whenBuilt())
             .then(() => {
-              return this.mutator_.attemptChangeSize(
+              return this.mutator_.requestChangeSize(
                 this.getAdElement(),
                 placement.height,
                 placement.width,

--- a/extensions/amp-auto-ads/0.1/test/test-placement.js
+++ b/extensions/amp-auto-ads/0.1/test/test-placement.js
@@ -463,7 +463,7 @@ describes.realWin(
         });
 
         const mutator = Services.mutatorForDoc(anchor);
-        env.sandbox.stub(mutator, 'attemptChangeSize').callsFake(() => {
+        env.sandbox.stub(mutator, 'requestChangeSize').callsFake(() => {
           return Promise.reject();
         });
 
@@ -666,7 +666,7 @@ describes.realWin(
         container.appendChild(anchor);
 
         const mutator = Services.mutatorForDoc(anchor);
-        env.sandbox.stub(mutator, 'attemptChangeSize').callsFake(() => {
+        env.sandbox.stub(mutator, 'requestChangeSize').callsFake(() => {
           return Promise.resolve();
         });
         env.sandbox.stub(mutator.viewport_, 'getWidth').callsFake(() => 2000);
@@ -719,7 +719,7 @@ describes.realWin(
         container.appendChild(anchor);
 
         const mutator = Services.mutatorForDoc(anchor);
-        env.sandbox.stub(mutator, 'attemptChangeSize').callsFake(() => {
+        env.sandbox.stub(mutator, 'requestChangeSize').callsFake(() => {
           return Promise.resolve();
         });
 
@@ -750,7 +750,7 @@ describes.realWin(
         return placements[0]
           .placeAd(attributes, sizing, adTracker)
           .then(placementState => {
-            expect(mutator.attemptChangeSize).to.have.been.calledWith(
+            expect(mutator.requestChangeSize).to.have.been.calledWith(
               anchor.firstChild,
               250,
               undefined
@@ -765,7 +765,7 @@ describes.realWin(
         container.appendChild(anchor);
 
         const mutator = Services.mutatorForDoc(anchor);
-        env.sandbox.stub(mutator, 'attemptChangeSize').callsFake(() => {
+        env.sandbox.stub(mutator, 'requestChangeSize').callsFake(() => {
           return Promise.reject(new Error('Resize failed'));
         });
 
@@ -796,7 +796,7 @@ describes.realWin(
         return placements[0]
           .placeAd(attributes, sizing, adTracker)
           .then(placementState => {
-            expect(mutator.attemptChangeSize).to.have.been.calledWith(
+            expect(mutator.requestChangeSize).to.have.been.calledWith(
               anchor.firstChild,
               250,
               undefined

--- a/extensions/amp-beopinion/0.1/amp-beopinion.js
+++ b/extensions/amp-beopinion/0.1/amp-beopinion.js
@@ -81,7 +81,7 @@ class AmpBeOpinion extends AMP.BaseElement {
         // We only get the message if and when there is a tweet to display,
         // so hide the placeholder
         this.togglePlaceholder(false);
-        this./*OK*/ changeHeight(data['height']);
+        this.forceChangeHeight(data['height']);
       },
       /* opt_is3P */ true
     );

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -1290,7 +1290,7 @@ export class Bind {
       if (width !== undefined || height !== undefined) {
         // request without scheduling vsync pass since `mutateElement()`
         // will schedule a pass after a short delay anyways.
-        this.mutator_./*OK*/ changeSize(element, height, width);
+        this.mutator_.forceChangeSize(element, height, width);
       }
 
       if (typeof element.mutatedAttributesCallback === 'function') {

--- a/extensions/amp-date-picker/0.1/amp-date-picker.js
+++ b/extensions/amp-date-picker/0.1/amp-date-picker.js
@@ -572,7 +572,7 @@ export class AmpDatePicker extends AMP.BaseElement {
             const height = this.element./*OK*/ offsetHeight;
             if (scrollHeight > height) {
               // Add 1px to allow the bottom border to show
-              this./*OK*/ changeHeight(scrollHeight + 1);
+              this.forceChangeHeight(scrollHeight + 1);
             }
           });
         }
@@ -1996,7 +1996,7 @@ export class AmpDatePicker extends AMP.BaseElement {
           const height = this.element./*OK*/ offsetHeight;
           if (scrollHeight > height) {
             // Add 1px to allow the bottom border to show
-            this./*OK*/ changeHeight(scrollHeight + 1);
+            this.forceChangeHeight(scrollHeight + 1);
           }
         }
       });

--- a/extensions/amp-embedly-card/0.1/amp-embedly-card-impl.js
+++ b/extensions/amp-embedly-card/0.1/amp-embedly-card-impl.js
@@ -81,7 +81,7 @@ export class AmpEmbedlyCard extends AMP.BaseElement {
       iframe,
       'embed-size',
       data => {
-        this./*OK*/ changeHeight(data['height']);
+        this.forceChangeHeight(data['height']);
       },
       opt_is3P
     );

--- a/extensions/amp-facebook-comments/0.1/amp-facebook-comments.js
+++ b/extensions/amp-facebook-comments/0.1/amp-facebook-comments.js
@@ -80,7 +80,7 @@ class AmpFacebookComments extends AMP.BaseElement {
       iframe,
       'embed-size',
       data => {
-        this./*OK*/ changeHeight(data['height']);
+        this.forceChangeHeight(data['height']);
       },
       /* opt_is3P */ true
     );

--- a/extensions/amp-facebook/0.1/amp-facebook.js
+++ b/extensions/amp-facebook/0.1/amp-facebook.js
@@ -84,7 +84,7 @@ class AmpFacebook extends AMP.BaseElement {
       iframe,
       'embed-size',
       data => {
-        this./*OK*/ changeHeight(data['height']);
+        this.forceChangeHeight(data['height']);
       },
       /* opt_is3P */ true
     );

--- a/extensions/amp-facebook/0.1/test/test-amp-facebook.js
+++ b/extensions/amp-facebook/0.1/test/test-amp-facebook.js
@@ -263,7 +263,7 @@ describes.realWin(
           const ampFB = await getAmpFacebook(fbPostHref);
           return new Promise((resolve, unusedReject) => {
             const {firstChild: iframe, implementation_: impl} = ampFB;
-            impl.changeHeight = newHeight => {
+            impl.forceChangeHeight = newHeight => {
               expect(newHeight).to.equal(666);
               resolve(ampFB);
             };

--- a/extensions/amp-gist/0.1/amp-gist.js
+++ b/extensions/amp-gist/0.1/amp-gist.js
@@ -69,7 +69,7 @@ export class AmpGist extends AMP.BaseElement {
       iframe,
       'embed-size',
       data => {
-        this./*OK*/ changeHeight(data['height']);
+        this.forceChangeHeight(data['height']);
       },
       /* opt_is3P */ true
     );

--- a/extensions/amp-instagram/0.1/amp-instagram.js
+++ b/extensions/amp-instagram/0.1/amp-instagram.js
@@ -223,7 +223,7 @@ class AmpInstagram extends AMP.BaseElement {
       const height = data['details']['height'];
       this.getVsync().measure(() => {
         if (this.iframe_ && this.iframe_./*OK*/ offsetHeight !== height) {
-          this./*OK*/ changeHeight(height);
+          this.forceChangeHeight(height);
         }
       });
     }

--- a/extensions/amp-instagram/0.1/test/test-amp-instagram.js
+++ b/extensions/amp-instagram/0.1/test/test-amp-instagram.js
@@ -196,15 +196,15 @@ describes.realWin(
       const ins = await getIns('fBwFP', true);
       const impl = ins.implementation_;
       const iframe = ins.querySelector('iframe');
-      const changeHeight = env.sandbox.spy(impl, 'changeHeight');
+      const forceChangeHeight = env.sandbox.spy(impl, 'forceChangeHeight');
       const newHeight = 977;
       expect(iframe).to.not.be.null;
       sendFakeMessage(ins, iframe, 'MEASURE', {
         height: newHeight,
       });
-      expect(changeHeight).to.be.calledOnce;
+      expect(forceChangeHeight).to.be.calledOnce;
       // Height minus padding
-      expect(changeHeight.firstCall.args[0]).to.equal(newHeight);
+      expect(forceChangeHeight.firstCall.args[0]).to.equal(newHeight);
     });
 
     function sendFakeMessage(ins, iframe, type, details) {

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -1067,8 +1067,7 @@ export class AmpList extends AMP.BaseElement {
     if (shouldReplace) {
       before.parentElement.replaceChild(after, before);
     } else {
-      // TODO(#23470): Support more attributes to manually diff by calling
-      // mutatedAttributesCallback() and changeSize().
+      // TODO(#23470): Support more attributes to manually diff.
 
       // Add new classes.
       for (let i = 0; i < after.classList.length; i++) {

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -339,7 +339,8 @@ export class AmpList extends AMP.BaseElement {
         setStyles(dev().assertElement(this.container_), {
           'max-height': `calc(100% - ${px(buttonHeight)})`,
         });
-        this.element./*OK*/ changeSize(listHeight + buttonHeight);
+        // TODO(wg-ui-and-a11y): Use Mutator.attemptChangeSize.
+        this.element./*OK*/ applySize(listHeight + buttonHeight);
       }
     );
   }
@@ -1185,8 +1186,9 @@ export class AmpList extends AMP.BaseElement {
       setStyles(this.element, {height: ''});
     }
 
-    // The changeSize() call removes the sizer element.
-    this.element./*OK*/ changeSize();
+    // TODO(wg-ui-and-a11y): Use a new, unprivileged API.
+    // The applySize() call removes the sizer element.
+    this.element./*OK*/ applySize();
   }
 
   /**

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -339,7 +339,7 @@ export class AmpList extends AMP.BaseElement {
         setStyles(dev().assertElement(this.container_), {
           'max-height': `calc(100% - ${px(buttonHeight)})`,
         });
-        // TODO(wg-ui-and-a11y): Use Mutator.attemptChangeSize.
+        // TODO(wg-ui-and-a11y): Use Mutator.requestChangeSize.
         this.element./*OK*/ applySize(listHeight + buttonHeight);
       }
     );

--- a/extensions/amp-list/0.1/test/test-amp-list-container.js
+++ b/extensions/amp-list/0.1/test/test-amp-list-container.js
@@ -70,7 +70,7 @@ describes.realWin(
 
       env.sandbox.stub(list, 'getOverflowElement').returns(null);
       env.sandbox.stub(list, 'fetchList_').returns(Promise.resolve());
-      list.element.changeSize = () => {};
+      list.element.applySize = () => {};
       list.buildCallback();
     });
 

--- a/extensions/amp-list/0.1/test/test-amp-list-load-more.js
+++ b/extensions/amp-list/0.1/test/test-amp-list-load-more.js
@@ -82,7 +82,7 @@ describes.realWin(
 
         env.sandbox.stub(list, 'getOverflowElement').returns(null);
         env.sandbox.stub(list, 'fetchList_').returns(Promise.resolve());
-        list.element.changeSize = () => {};
+        list.element.applySize = () => {};
         list.buildCallback();
       });
 
@@ -171,7 +171,7 @@ describes.realWin(
         env.sandbox
           .stub(list, 'prepareAndSendFetch_')
           .returns(Promise.resolve(HAS_MORE_ITEMS_PAYLOAD));
-        list.element.changeSize = () => {};
+        list.element.applySize = () => {};
         list.buildCallback();
       });
 

--- a/extensions/amp-mathml/0.1/amp-mathml.js
+++ b/extensions/amp-mathml/0.1/amp-mathml.js
@@ -77,7 +77,7 @@ export class AmpMathml extends AMP.BaseElement {
           // Don't change the width if not inlined.
           data['width'] = undefined;
         }
-        Services.mutatorForDoc(this.getAmpDoc())./*OK*/ changeSize(
+        Services.mutatorForDoc(this.getAmpDoc()).forceChangeSize(
           this.element,
           data['height'],
           data['width']

--- a/extensions/amp-reddit/0.1/amp-reddit.js
+++ b/extensions/amp-reddit/0.1/amp-reddit.js
@@ -80,7 +80,7 @@ class AmpReddit extends AMP.BaseElement {
       iframe,
       'embed-size',
       data => {
-        this./*OK*/ changeHeight(data['height']);
+        this.forceChangeHeight(data['height']);
       },
       /* opt_is3P */ true
     );

--- a/extensions/amp-twitter/0.1/amp-twitter.js
+++ b/extensions/amp-twitter/0.1/amp-twitter.js
@@ -112,7 +112,7 @@ class AmpTwitter extends AMP.BaseElement {
       },
       () => {
         // Set an explicit height so we can animate it.
-        this./*OK*/ changeHeight(height);
+        this.forceChangeHeight(height);
       }
     );
   }
@@ -128,7 +128,7 @@ class AmpTwitter extends AMP.BaseElement {
       if (this.userPlaceholder_) {
         this.togglePlaceholder(false);
       }
-      this./*OK*/ changeHeight(height);
+      this.forceChangeHeight(height);
     });
   }
 
@@ -149,7 +149,7 @@ class AmpTwitter extends AMP.BaseElement {
       }
 
       if (content) {
-        this./*OK*/ changeHeight(content./*OK*/ offsetHeight);
+        this.forceChangeHeight(content./*OK*/ offsetHeight);
       }
     });
   }

--- a/extensions/amp-vk/0.1/amp-vk.js
+++ b/extensions/amp-vk/0.1/amp-vk.js
@@ -247,7 +247,7 @@ export class AmpVk extends AMP.BaseElement {
         const newHeight = parseInt(matches[1], 10);
         if (this.widgetHeight_ !== newHeight) {
           this.widgetHeight_ = newHeight;
-          this./*OK*/ changeHeight(newHeight);
+          this.forceChangeHeight(newHeight);
         }
       }
     }

--- a/extensions/amp-vk/0.1/test/test-amp-vk.js
+++ b/extensions/amp-vk/0.1/test/test-amp-vk.js
@@ -205,12 +205,12 @@ describes.realWin(
       const vkPoll = await createAmpVkElement(POLL_PARAMS);
       const impl = vkPoll.implementation_;
       const iframe = vkPoll.querySelector('iframe');
-      const changeHeight = env.sandbox.spy(impl, 'changeHeight');
+      const forceChangeHeight = env.sandbox.spy(impl, 'forceChangeHeight');
       const fakeHeight = 555;
       expect(iframe).to.not.be.null;
       generatePostMessage(vkPoll, iframe, fakeHeight);
-      expect(changeHeight).to.be.calledOnce;
-      expect(changeHeight.firstCall.args[0]).to.equal(fakeHeight);
+      expect(forceChangeHeight).to.be.calledOnce;
+      expect(forceChangeHeight.firstCall.args[0]).to.equal(fakeHeight);
     });
 
     function generatePostMessage(ins, iframe, height) {

--- a/src/base-element.js
+++ b/src/base-element.js
@@ -865,7 +865,7 @@ export class BaseElement {
    * @public
    */
   attemptChangeHeight(newHeight) {
-    return Services.mutatorForDoc(this.getAmpDoc()).attemptChangeSize(
+    return Services.mutatorForDoc(this.getAmpDoc()).requestChangeSize(
       this.element,
       newHeight,
       /* newWidth */ undefined
@@ -889,7 +889,7 @@ export class BaseElement {
    * @public
    */
   attemptChangeSize(newHeight, newWidth, opt_event) {
-    return Services.mutatorForDoc(this.getAmpDoc()).attemptChangeSize(
+    return Services.mutatorForDoc(this.getAmpDoc()).requestChangeSize(
       this.element,
       newHeight,
       newWidth,

--- a/src/base-element.js
+++ b/src/base-element.js
@@ -824,7 +824,7 @@ export class BaseElement {
    * @public
    */
   changeHeight(newHeight) {
-    Services.mutatorForDoc(this.getAmpDoc())./*OK*/ changeSize(
+    Services.mutatorForDoc(this.getAmpDoc()).forceChangeSize(
       this.element,
       newHeight,
       /* newWidth */ undefined

--- a/src/base-element.js
+++ b/src/base-element.js
@@ -817,21 +817,6 @@ export class BaseElement {
   }
 
   /**
-   * Requests the runtime to update the height of this element to the specified
-   * value. The runtime will schedule this request and attempt to process it
-   * as soon as possible.
-   * @param {number} newHeight
-   * @public
-   */
-  changeHeight(newHeight) {
-    Services.mutatorForDoc(this.getAmpDoc()).forceChangeSize(
-      this.element,
-      newHeight,
-      /* newWidth */ undefined
-    );
-  }
-
-  /**
    * Collapses the element, setting it to `display: none`, and notifies its
    * owner (if there is one) through {@link collapsedCallback} that the element
    * is no longer visible.
@@ -851,10 +836,25 @@ export class BaseElement {
   }
 
   /**
+   * Requests the runtime to update the height of this element to the specified
+   * value. The runtime will schedule this request and attempt to process it
+   * as soon as possible.
+   * @param {number} newHeight
+   * @public
+   */
+  forceChangeHeight(newHeight) {
+    Services.mutatorForDoc(this.getAmpDoc()).forceChangeSize(
+      this.element,
+      newHeight,
+      /* newWidth */ undefined
+    );
+  }
+
+  /**
    * Return a promise that requests the runtime to update
    * the height of this element to the specified value.
    * The runtime will schedule this request and attempt to process it
-   * as soon as possible. However, unlike in {@link changeHeight}, the runtime
+   * as soon as possible. However, unlike in {@link forceChangeHeight}, the runtime
    * may refuse to make a change in which case it will show the element's
    * overflow element if provided, which is supposed to provide the reader with
    * the necessary user action. (The overflow element is shown only if the

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -729,7 +729,7 @@ function createBaseCustomElementClass(win) {
     }
 
     /**
-     * Changes the size of the element.
+     * Applies a size change to the element.
      *
      * This method is called by Resources and shouldn't be called by anyone
      * else. This method must always be called in the mutation context.
@@ -740,7 +740,7 @@ function createBaseCustomElementClass(win) {
      * @final
      * @package
      */
-    changeSize(newHeight, newWidth, opt_newMargins) {
+    applySize(newHeight, newWidth, opt_newMargins) {
       const sizer = this.getSizer_();
       if (sizer) {
         // From the moment height is changed the element becomes fully

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -1836,7 +1836,7 @@ function createBaseCustomElementClass(win) {
         if (overflown) {
           this.overflowElement_.onclick = () => {
             const mutator = Services.mutatorForDoc(this.getAmpDoc());
-            mutator./*OK*/ changeSize(this, requestedHeight, requestedWidth);
+            mutator.forceChangeSize(this, requestedHeight, requestedWidth);
             mutator./*OK*/ mutateElement(this, () => {
               this.overflowCallback(
                 /* overflown */ false,

--- a/src/inabox/inabox-mutator.js
+++ b/src/inabox/inabox-mutator.js
@@ -48,7 +48,7 @@ export class InaboxMutator {
     return this.mutateElement(element, () => {
       this.resources_
         .getResourceForElement(element)
-        ./*OK*/ changeSize(newHeight, newWidth, opt_newMargins);
+        .changeSize(newHeight, newWidth, opt_newMargins);
     });
   }
 

--- a/src/inabox/inabox-mutator.js
+++ b/src/inabox/inabox-mutator.js
@@ -34,7 +34,7 @@ export class InaboxMutator {
 
   /** @override */
   forceChangeSize(element, newHeight, newWidth, opt_callback, opt_newMargins) {
-    this.attemptChangeSize(element, newHeight, newWidth, opt_newMargins).then(
+    this.requestChangeSize(element, newHeight, newWidth, opt_newMargins).then(
       () => {
         if (opt_callback) {
           opt_callback();
@@ -44,7 +44,7 @@ export class InaboxMutator {
   }
 
   /** @override */
-  attemptChangeSize(element, newHeight, newWidth, opt_newMargins) {
+  requestChangeSize(element, newHeight, newWidth, opt_newMargins) {
     return this.mutateElement(element, () => {
       this.resources_
         .getResourceForElement(element)

--- a/src/inabox/inabox-mutator.js
+++ b/src/inabox/inabox-mutator.js
@@ -33,7 +33,7 @@ export class InaboxMutator {
   }
 
   /** @override */
-  changeSize(element, newHeight, newWidth, opt_callback, opt_newMargins) {
+  forceChangeSize(element, newHeight, newWidth, opt_callback, opt_newMargins) {
     this.attemptChangeSize(element, newHeight, newWidth, opt_newMargins).then(
       () => {
         if (opt_callback) {

--- a/src/service/mutator-impl.js
+++ b/src/service/mutator-impl.js
@@ -77,7 +77,7 @@ export class MutatorImpl {
   }
 
   /** @override */
-  attemptChangeSize(element, newHeight, newWidth, opt_newMargins, opt_event) {
+  requestChangeSize(element, newHeight, newWidth, opt_newMargins, opt_event) {
     return new Promise((resolve, reject) => {
       this.scheduleChangeSize_(
         Resource.forElement(element),

--- a/src/service/mutator-impl.js
+++ b/src/service/mutator-impl.js
@@ -64,7 +64,7 @@ export class MutatorImpl {
   }
 
   /** @override */
-  changeSize(element, newHeight, newWidth, opt_callback, opt_newMargins) {
+  forceChangeSize(element, newHeight, newWidth, opt_callback, opt_newMargins) {
     this.scheduleChangeSize_(
       Resource.forElement(element),
       newHeight,

--- a/src/service/mutator-interface.js
+++ b/src/service/mutator-interface.js
@@ -28,13 +28,13 @@ export class MutatorInterface {
    * @param {function()=} opt_callback A callback function.
    * @param {!../layout-rect.LayoutMarginsChangeDef=} opt_newMargins
    */
-  changeSize(element, newHeight, newWidth, opt_callback, opt_newMargins) {}
+  forceChangeSize(element, newHeight, newWidth, opt_callback, opt_newMargins) {}
 
   /**
    * Return a promise that requests the runtime to update the size of
    * this element to the specified value.
    * The runtime will schedule this request and attempt to process it
-   * as soon as possible. However, unlike in {@link changeSize}, the runtime
+   * as soon as possible. However, unlike in {@link forceChangeSize}, the runtime
    * may refuse to make a change in which case it will reject promise, call the
    * `overflowCallback` method on the target resource with the height value.
    * Overflow callback is expected to provide the reader with the user action

--- a/src/service/mutator-interface.js
+++ b/src/service/mutator-interface.js
@@ -49,7 +49,7 @@ export class MutatorInterface {
    * @return {!Promise}
    * @param {?Event=} opt_event
    */
-  attemptChangeSize(element, newHeight, newWidth, opt_newMargins, opt_event) {}
+  requestChangeSize(element, newHeight, newWidth, opt_newMargins, opt_event) {}
 
   /**
    * Expands the element.

--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -358,7 +358,7 @@ export class Resource {
    * @param {!../layout-rect.LayoutMarginsChangeDef=} opt_newMargins
    */
   changeSize(newHeight, newWidth, opt_newMargins) {
-    this.element./*OK*/ changeSize(newHeight, newWidth, opt_newMargins);
+    this.element./*OK*/ applySize(newHeight, newWidth, opt_newMargins);
 
     // Schedule for re-measure and possible re-layout.
     this.requestMeasure();

--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -356,6 +356,7 @@ export class Resource {
    * @param {number|undefined} newHeight
    * @param {number|undefined} newWidth
    * @param {!../layout-rect.LayoutMarginsChangeDef=} opt_newMargins
+   * @package
    */
   changeSize(newHeight, newWidth, opt_newMargins) {
     this.element./*OK*/ applySize(newHeight, newWidth, opt_newMargins);

--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -356,7 +356,6 @@ export class Resource {
    * @param {number|undefined} newHeight
    * @param {number|undefined} newWidth
    * @param {!../layout-rect.LayoutMarginsChangeDef=} opt_newMargins
-   * @package
    */
   changeSize(newHeight, newWidth, opt_newMargins) {
     this.element./*OK*/ applySize(newHeight, newWidth, opt_newMargins);

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -1055,7 +1055,7 @@ export class ResourcesImpl {
               },
               mutate: state => {
                 if (state.resize) {
-                  request.resource./*OK*/ changeSize(
+                  request.resource.changeSize(
                     request.newHeight,
                     request.newWidth,
                     newMargins
@@ -1086,7 +1086,7 @@ export class ResourcesImpl {
           if (box.top >= 0) {
             minTop = minTop == -1 ? box.top : Math.min(minTop, box.top);
           }
-          request.resource./*OK*/ changeSize(
+          request.resource.changeSize(
             request.newHeight,
             request.newWidth,
             newMargins
@@ -1122,7 +1122,7 @@ export class ResourcesImpl {
               scrollAdjSet.forEach(request => {
                 const box = request.resource.getLayoutBox();
                 minTop = minTop == -1 ? box.top : Math.min(minTop, box.top);
-                request.resource./*OK*/ changeSize(
+                request.resource.changeSize(
                   request.newHeight,
                   request.newWidth,
                   request.marginChange

--- a/test/unit/inabox/test-inabox-mutator.js
+++ b/test/unit/inabox/test-inabox-mutator.js
@@ -62,8 +62,8 @@ describes.realWin('inabox-mutator', {amp: true}, env => {
     expect(schedulePassStub).to.be.calledOnce;
   });
 
-  it('attemptChangeSize', async () => {
-    const resultPromise = mutator.attemptChangeSize(element, 12, 34, {
+  it('requestChangeSize', async () => {
+    const resultPromise = mutator.requestChangeSize(element, 12, 34, {
       top: 4,
       right: 5,
       bottom: 6,

--- a/test/unit/inabox/test-inabox-mutator.js
+++ b/test/unit/inabox/test-inabox-mutator.js
@@ -42,9 +42,9 @@ describes.realWin('inabox-mutator', {amp: true}, env => {
     };
   });
 
-  it('changeSize', async () => {
+  it('forceChangeSize', async () => {
     const callback = env.sandbox.spy();
-    mutator.changeSize(element, 12, 34, callback, {
+    mutator.forceChangeSize(element, 12, 34, callback, {
       top: 4,
       right: 5,
       bottom: 6,

--- a/test/unit/test-custom-element.js
+++ b/test/unit/test-custom-element.js
@@ -1247,7 +1247,7 @@ describes.realWin('CustomElement', {amp: true}, env => {
 
       it('should change size without sizer', () => {
         const element = new ElementClass();
-        element.changeSize(111, 222, {top: 1, right: 2, bottom: 3, left: 4});
+        element.applySize(111, 222, {top: 1, right: 2, bottom: 3, left: 4});
         expect(element.style.height).to.equal('111px');
         expect(element.style.width).to.equal('222px');
         expect(element.style.marginTop).to.equal('1px');
@@ -1258,19 +1258,19 @@ describes.realWin('CustomElement', {amp: true}, env => {
 
       it('should change size - height only without sizer', () => {
         const element = new ElementClass();
-        element.changeSize(111);
+        element.applySize(111);
         expect(element.style.height).to.equal('111px');
       });
 
       it('should change size - width only without sizer', () => {
         const element = new ElementClass();
-        element.changeSize(undefined, 111);
+        element.applySize(undefined, 111);
         expect(element.style.width).to.equal('111px');
       });
 
       it('should change size - margins only without sizer', () => {
         const element = new ElementClass();
-        element.changeSize(undefined, undefined, {
+        element.applySize(undefined, undefined, {
           top: 1,
           right: 2,
           bottom: 3,
@@ -1285,7 +1285,7 @@ describes.realWin('CustomElement', {amp: true}, env => {
       it('should change size - some margins only without sizer', () => {
         const element = new ElementClass();
         element.style.margin = '1px 2px 3px 4px';
-        element.changeSize(undefined, undefined, {top: 5, left: 6});
+        element.applySize(undefined, undefined, {top: 5, left: 6});
         expect(element.style.marginTop).to.equal('5px');
         expect(element.style.marginRight).to.equal('2px');
         expect(element.style.marginBottom).to.equal('3px');
@@ -1295,7 +1295,7 @@ describes.realWin('CustomElement', {amp: true}, env => {
       it('should change size - some margins only without sizer', () => {
         const element = new ElementClass();
         element.style.margin = '1px 2px 3px 4px';
-        element.changeSize(undefined, undefined, {top: 5, left: 6});
+        element.applySize(undefined, undefined, {top: 5, left: 6});
         expect(element.style.marginTop).to.equal('5px');
         expect(element.style.marginRight).to.equal('2px');
         expect(element.style.marginBottom).to.equal('3px');
@@ -1306,7 +1306,7 @@ describes.realWin('CustomElement', {amp: true}, env => {
         const element = new ElementClass();
         const sizer = doc.createElement('div');
         element.sizerElement = sizer;
-        element.changeSize(111, 222, {top: 1, right: 2, bottom: 3, left: 4});
+        element.applySize(111, 222, {top: 1, right: 2, bottom: 3, left: 4});
         expect(element.style.height).to.equal('111px');
         expect(element.style.width).to.equal('222px');
         expect(element.style.marginTop).to.equal('1px');
@@ -1320,7 +1320,7 @@ describes.realWin('CustomElement', {amp: true}, env => {
         element.layout_ = Layout.RESPONSIVE;
         const sizer = doc.createElement('div');
         element.sizerElement = sizer;
-        element.changeSize(111, 222, {top: 1, right: 2, bottom: 3, left: 4});
+        element.applySize(111, 222, {top: 1, right: 2, bottom: 3, left: 4});
         expect(sizer.style.paddingTop).to.equal('0px');
         expect(element.sizerElement).to.be.null;
       });
@@ -1337,7 +1337,7 @@ describes.realWin('CustomElement', {amp: true}, env => {
         );
         sizer.appendChild(intrinsicSizer);
         element.appendChild(sizer);
-        element.changeSize(111);
+        element.applySize(111);
         expect(intrinsicSizer.getAttribute('src')).to.equal('');
       });
 
@@ -1354,14 +1354,14 @@ describes.realWin('CustomElement', {amp: true}, env => {
 
       it('should change size to zero', () => {
         const element = new ElementClass();
-        element.changeSize(0, 0);
+        element.applySize(0, 0);
         expect(element.style.height).to.equal('0px');
         expect(element.style.width).to.equal('0px');
       });
 
       it('should change width to zero', () => {
         const element = new ElementClass();
-        element.changeSize(undefined, 0);
+        element.applySize(undefined, 0);
         expect(element.style.width).to.equal('0px');
       });
 
@@ -1374,7 +1374,7 @@ describes.realWin('CustomElement', {amp: true}, env => {
           element.classList.add('i-amphtml-layout-awaiting-size');
 
           expect(element).to.have.class('i-amphtml-layout-awaiting-size');
-          element.changeSize(100, 100);
+          element.applySize(100, 100);
           expect(element).not.to.have.class('i-amphtml-layout-awaiting-size');
         }
       );
@@ -1386,7 +1386,7 @@ describes.realWin('CustomElement', {amp: true}, env => {
           'dispatchCustomEvent'
         );
 
-        element.changeSize();
+        element.applySize();
 
         expect(spyDispatchEvent).to.be.calledWith(AmpEvents.SIZE_CHANGED);
       });
@@ -2288,7 +2288,7 @@ describes.realWin('CustomElement Overflow Element', {amp: true}, env => {
     element.overflowCallback(true, 117, 113);
     expect(overflowElement).to.have.class('amp-visible');
     mutatorMock
-      .expects('changeSize')
+      .expects('applySize')
       .withExactArgs(element, 117, 113)
       .once();
 

--- a/test/unit/test-custom-element.js
+++ b/test/unit/test-custom-element.js
@@ -2288,7 +2288,7 @@ describes.realWin('CustomElement Overflow Element', {amp: true}, env => {
     element.overflowCallback(true, 117, 113);
     expect(overflowElement).to.have.class('amp-visible');
     mutatorMock
-      .expects('applySize')
+      .expects('forceChangeSize')
       .withExactArgs(element, 117, 113)
       .once();
 

--- a/test/unit/test-mutator.js
+++ b/test/unit/test-mutator.js
@@ -317,7 +317,7 @@ describe('mutator changeSize', () => {
     expect(resources.requestsChangeSize_[1].resource).to.equal(resource1);
   });
 
-  describe('attemptChangeSize rules wrt viewport', () => {
+  describe('requestChangeSize rules wrt viewport', () => {
     let overflowCallbackSpy;
     let vsyncSpy;
     let viewportRect;
@@ -1415,7 +1415,7 @@ describe('mutator changeSize', () => {
     });
   });
 
-  describe('attemptChangeSize rules for element wrt document', () => {
+  describe('requestChangeSize rules for element wrt document', () => {
     beforeEach(() => {
       viewportMock
         .expects('getRect')
@@ -1652,11 +1652,11 @@ describes.realWin('mutator mutateElement and collapse', {amp: true}, env => {
     });
   });
 
-  it('attemptCollapse should not call attemptChangeSize', () => {
+  it('attemptCollapse should not call requestChangeSize', () => {
     // This test ensure that #attemptCollapse won't do any optimization or
-    // refactor by calling attemptChangeSize.
+    // refactor by calling requestChangeSize.
     // This to support collapsing element above viewport
-    // When attemptChangeSize succeed, resources manager will measure the new
+    // When requestChangeSize succeed, resources manager will measure the new
     // scrollHeight, and we need to make sure the newScrollHeight is measured
     // after setting element display:none
     env.sandbox.stub(resources.viewport_, 'getRect').callsFake(() => {

--- a/test/unit/test-resource.js
+++ b/test/unit/test-resource.js
@@ -801,7 +801,7 @@ describes.realWin('Resource', {amp: true}, env => {
     expect(resource.isMeasureRequested()).to.be.false;
     resource.state_ = ResourceState.READY_FOR_LAYOUT;
     elementMock
-      .expects('changeSize')
+      .expects('applySize')
       .withExactArgs(111, 222, {top: 1, right: 2, bottom: 3, left: 4})
       .once();
     resource.changeSize(111, 222, {top: 1, right: 2, bottom: 3, left: 4});
@@ -811,7 +811,7 @@ describes.realWin('Resource', {amp: true}, env => {
   it('should change size but not state', () => {
     resource.state_ = ResourceState.NOT_BUILT;
     elementMock
-      .expects('changeSize')
+      .expects('applySize')
       .withExactArgs(111, 222, {top: 1, right: 2, bottom: 3, left: 4})
       .once();
     resource.changeSize(111, 222, {top: 1, right: 2, bottom: 3, left: 4});
@@ -1166,7 +1166,7 @@ describe('Resource idleRenderOutsideViewport', () => {
       updateLayoutBox: () => {},
       isRelayoutNeeded: () => false,
       layoutCallback: () => {},
-      changeSize: () => {},
+      applySize: () => {},
       unlayoutOnPause: () => false,
       unlayoutCallback: () => true,
       pauseCallback: () => false,


### PR DESCRIPTION
- AmpElement.changeSize -> applySize
- Mutator.changeSize -> forceChangeSize
- Mutator.attemptChangeSize -> requestChangeSize (vs. BaseElement.attemptChangeSize)
- ResponsiveState.attemptChangeSize -> attemptToMatchResponsiveHeight
- BaseElement.changeHeight -> forceChangeHeight (consistency)

@ampproject/wg-infra Should we discourage reuse of the same function names? I think we can theoretically do this with ESLint.