### PR TITLE
🐛 amp-access: Keeps trying to close window for a minute

### DIFF
--- a/extensions/amp-access/0.1/amp-login-done-dialog.js
+++ b/extensions/amp-access/0.1/amp-login-done-dialog.js
@@ -203,9 +203,23 @@ export class LoginDoneDialog {
       // Ignore.
     }
 
+    // Keep trying to close the window.
+    // Sometimes `window.close()` is ignored by the browser for a stretch of time.
+    // For instance, iOS ignores the method when there is a
+    // "Save Password" or "Update Password" prompt open.
+    // https://github.com/ampproject/amphtml/issues/11369
+    const windowCloseInterval = this.win.setInterval(() => {
+      try {
+        this.win.close();
+      } catch (e) {
+        // Ignore.
+      }
+    }, 100);
+
     // Give the opener a chance to close the dialog, if not, show the
     // close button.
     this.win.setTimeout(() => {
+      clearInterval(windowCloseInterval);
       this.postbackError_(new Error('Failed to close the dialog'));
     }, 3000);
   }

--- a/extensions/amp-access/0.1/amp-login-done-dialog.js
+++ b/extensions/amp-access/0.1/amp-login-done-dialog.js
@@ -203,23 +203,28 @@ export class LoginDoneDialog {
       // Ignore.
     }
 
-    // Keep trying to close the window.
+    // Keep trying to close the window for a minute.
     // Sometimes `window.close()` is ignored by the browser for a stretch of time.
     // For instance, iOS ignores the method when there is a
     // "Save Password" or "Update Password" prompt open.
     // https://github.com/ampproject/amphtml/issues/11369
+    const windowCloseIntervalDeadline = Date.now() + 60 * 1000;
     const windowCloseInterval = this.win.setInterval(() => {
+      if (this.win.closed || Date.now() > windowCloseIntervalDeadline) {
+        clearInterval(windowCloseInterval);
+        return;
+      }
+
       try {
         this.win.close();
       } catch (e) {
         // Ignore.
       }
-    }, 100);
+    }, 500);
 
     // Give the opener a chance to close the dialog, if not, show the
     // close button.
     this.win.setTimeout(() => {
-      clearInterval(windowCloseInterval);
       this.postbackError_(new Error('Failed to close the dialog'));
     }, 3000);
   }

--- a/extensions/amp-access/0.1/test/test-amp-login-done-dialog.js
+++ b/extensions/amp-access/0.1/test/test-amp-login-done-dialog.js
@@ -19,7 +19,6 @@ import {LoginDoneDialog, buildLangSelector} from '../amp-login-done-dialog';
 describe('LoginDoneDialog', () => {
   let clock;
   let windowApi;
-  let windowMock;
   let dialog;
   let messageListener;
   let openerMock;
@@ -74,7 +73,6 @@ describe('LoginDoneDialog', () => {
         },
       },
     };
-    windowMock = window.sandbox.mock(windowApi);
     openerMock = window.sandbox.mock(windowApi.opener);
 
     dialog = new LoginDoneDialog(windowApi);

--- a/extensions/amp-access/0.1/test/test-amp-login-done-dialog.js
+++ b/extensions/amp-access/0.1/test/test-amp-login-done-dialog.js
@@ -336,14 +336,25 @@ describe('LoginDoneDialog', () => {
         });
     });
 
-    it('should keep trying to close window for 3 seconds', () => {
+    it('should keep trying to close window for a minute', () => {
       dialog.postbackSuccess_();
       expect(windowApi.close).to.have.callCount(1);
-      clock.tick(3000);
-      expect(windowApi.close).to.have.callCount(31);
+      clock.tick(60000);
+      expect(windowApi.close).to.have.callCount(121);
       windowApi.close.resetHistory();
-      // After 3 seconds it'll stop trying.
-      clock.tick(3000);
+      // After 60 seconds it'll stop trying.
+      clock.tick(60000);
+      expect(windowApi.close).to.not.be.called;
+    });
+
+    it('should stop trying to close window after it is closed', () => {
+      dialog.postbackSuccess_();
+      clock.tick(30000);
+      expect(windowApi.close).to.have.callCount(61);
+      windowApi.close.resetHistory();
+      windowApi.closed = true;
+      // After the window is closed it'll stop trying.
+      clock.tick(30000);
       expect(windowApi.close).to.not.be.called;
     });
 


### PR DESCRIPTION
This PR updates `amp-access`'s login done dialog to keep trying to close its window for a minute.

Sometimes `window.close()` is ignored by the browser for a stretch of time. For instance, iOS ignores the method when there is a "Save Password" or "Update Password" prompt open. (https://github.com/ampproject/amphtml/issues/11369)
