### PR TITLE
Exclude /validator/htmlparser

### DIFF
--- a/build-system/test-configs/config.js
+++ b/build-system/test-configs/config.js
@@ -114,7 +114,9 @@ const presubmitGlobs = [
   '!dist.3p/current/**/iframe-transport-client-lib.js',
   '!out/**/*.*',
   '!validator/validator.pb.go',
+  '!validator/chromeextension/*.*',
   '!validator/dist/**/*.*',
+  '!validator/htmlparser/**/*.*',
   '!validator/node_modules/**/*.*',
   '!validator/nodejs/node_modules/**/*.*',
   '!validator/webui/dist/**/*.*',
@@ -127,7 +129,6 @@ const presubmitGlobs = [
   '!build/polyfills.js',
   '!build/polyfills/*.js',
   '!third_party/**/*.*',
-  '!validator/chromeextension/*.*',
   '!src/purifier/node_modules/**/*.*',
   // Files in this testdata dir are machine-generated and are not part
   // of the AMP runtime, so shouldn't be checked.


### PR DESCRIPTION
The HTML parser is written in C++ and many of these checks shouldn't apply to it.
