### PR TITLE
🐛 Mark initMessagingChannel timeout as an expected error

### DIFF
--- a/src/service/viewer-impl.js
+++ b/src/service/viewer-impl.js
@@ -20,6 +20,7 @@ import {Services} from '../services';
 import {ViewerInterface} from './viewer-interface';
 import {VisibilityState} from '../visibility-state';
 import {
+  createExpectedError,
   dev,
   devAssert,
   duplicateErrorIfNecessary,
@@ -306,11 +307,11 @@ export class ViewerImpl {
     return Services.timerFor(this.win)
       .timeoutPromise(20000, messagingPromise, timeoutMessage)
       .catch(reason => {
-        const error = getChannelError(
+        let error = getChannelError(
           /** @type {!Error|string|undefined} */ (reason)
         );
         if (error && error.message === timeoutMessage) {
-          error.expected = true;
+          error = createExpectedError(error);
         }
         reportError(error);
         throw error;

--- a/src/service/viewer-impl.js
+++ b/src/service/viewer-impl.js
@@ -20,7 +20,6 @@ import {Services} from '../services';
 import {ViewerInterface} from './viewer-interface';
 import {VisibilityState} from '../visibility-state';
 import {
-  createExpectedError,
   dev,
   devAssert,
   duplicateErrorIfNecessary,
@@ -311,7 +310,7 @@ export class ViewerImpl {
           /** @type {!Error|string|undefined} */ (reason)
         );
         if (error && error.message === timeoutMessage) {
-          error = createExpectedError(error);
+          error = dev().createExpectedError(error);
         }
         reportError(error);
         throw error;

--- a/src/service/viewer-impl.js
+++ b/src/service/viewer-impl.js
@@ -302,12 +302,16 @@ export class ViewerImpl {
     if (!isEmbedded) {
       return null;
     }
+    const timeoutMessage = 'initMessagingChannel timeout';
     return Services.timerFor(this.win)
-      .timeoutPromise(20000, messagingPromise, 'initMessagingChannel')
+      .timeoutPromise(20000, messagingPromise, timeoutMessage)
       .catch(reason => {
         const error = getChannelError(
           /** @type {!Error|string|undefined} */ (reason)
         );
+        if (error && error.message === timeoutMessage) {
+          error.expected = true;
+        }
         reportError(error);
         throw error;
       });


### PR DESCRIPTION
Initializing the messaging channel to the viewer can time out for a handful of reasons. #23874 addressed one of those in `cid-impl.js`, marking the reported error as an expected/known failure case. This PR marks a similar viewer timeout error as expected, to improve classification in error reporting.  

Closes https://github.com/ampproject/amphtml/issues/20120