### PR TITLE
Enable stale bot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -3,6 +3,6 @@ daysUntilClose: 7
 staleLabel: Stale
 markComment: >
   This issue has been automatically marked as stale because it has not had
-  recent activity. It will be closed if no further activity occurs. Thank you
+  recent activity. It will be closed in 7 days if no further activity occurs. Thank you
   for your contributions.
 closeComment: false

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,8 @@
+daysUntilStale: 540 # 1.5Y - 7d
+daysUntilClose: 7
+staleLabel: Stale
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+closeComment: false


### PR DESCRIPTION
Closes #27138.

- Starting at 1.5Y stale threshold with 7 day grace period. Will reduce to 1Y eventually.
- Adds "Stale" label with no opt-out label (yet).

/to @rsimha 