### PR TITLE
DO NOT SUBMIT 🏗🐛 Temporarily enable Percy Agent debug mode

### DIFF
--- a/build-system/pr-check/visual-diff-tests.js
+++ b/build-system/pr-check/visual-diff-tests.js
@@ -45,7 +45,7 @@ function main() {
     downloadDistOutput(FILENAME);
     timedExecOrDie('gulp update-packages');
     process.env['PERCY_TOKEN'] = atob(process.env.PERCY_TOKEN_ENCODED);
-    timedExecOrDie('gulp visual-diff --nobuild --master');
+    timedExecOrDie('gulp visual-diff --percy_agent_debug --nobuild --master');
   } else {
     printChangeSummary(FILENAME);
     const buildTargets = determineBuildTargets(FILENAME);
@@ -57,9 +57,9 @@ function main() {
     ) {
       downloadDistOutput(FILENAME);
       timedExecOrDie('gulp update-packages');
-      timedExecOrDie('gulp visual-diff --nobuild');
+      timedExecOrDie('gulp visual-diff --percy_agent_debug --nobuild');
     } else {
-      timedExecOrDie('gulp visual-diff --nobuild --empty');
+      timedExecOrDie('gulp visual-diff --percy_agent_debug --nobuild --empty');
       console.log(
         `${FILELOGPREFIX} Skipping`,
         colors.cyan('Visual Diff Tests'),


### PR DESCRIPTION
DO NOT SUBMIT looks like I managed to recreate the issue directly in this PR so I'll be investigating it for now...

To help debug flaky visual diff tests, as recommended by Percy support