### PR TITLE
🐛Swap columns on performance report

### DIFF
--- a/build-system/tasks/performance/print-report.js
+++ b/build-system/tasks/performance/print-report.js
@@ -79,8 +79,8 @@ function linesForMetric(metric, results) {
   return [
     [
       metric.padEnd(HEADER_COLUMN),
-      control.toString().padEnd(BODY_COLUMN),
       experiment.toString().padEnd(BODY_COLUMN),
+      control.toString().padEnd(BODY_COLUMN),
       percent(control, experiment),
     ].join(' | '),
     `\n${''.padEnd(FULL_TABLE, '-')}\n`,


### PR DESCRIPTION
Fix bug where experiment numbers were under PRODUCTION and control numbers were under BRANCH.