### PR TITLE
use symbol replacement IS_ESM instead of relying on AMP_CONFIG.esm

### DIFF
--- a/src/mode-object.js
+++ b/src/mode-object.js
@@ -26,7 +26,7 @@ export function getModeObject(opt_win) {
   return {
     localDev: getMode(opt_win).localDev,
     development: getMode(opt_win).development,
-    esm: getMode(opt_win).esm,
+    esm: IS_ESM,
     filter: getMode(opt_win).filter,
     minified: getMode(opt_win).minified,
     lite: getMode(opt_win).lite,

--- a/src/mode.js
+++ b/src/mode.js
@@ -80,7 +80,7 @@ function getMode_(win) {
     // from the URL.
     win.location.originalHash || win.location.hash
   );
-  const {spt: singlePassType, esm} = AMP_CONFIG;
+  const {spt: singlePassType} = AMP_CONFIG;
 
   const searchQuery = parseQueryString_(win.location.search);
 
@@ -104,7 +104,7 @@ function getMode_(win) {
       ) >= 0 || win.AMP_DEV_MODE
     ),
     examiner: hashQuery['development'] == '2',
-    esm,
+    esm: IS_ESM,
     // amp-geo override
     geoOverride: hashQuery['amp-geo'],
     minified: IS_MINIFIED,

--- a/test/unit/3p/test-3p-frame.js
+++ b/test/unit/3p/test-3p-frame.js
@@ -202,6 +202,7 @@ describe
             'minified': false,
             'test': false,
             'version': '$internalRuntimeVersion$',
+            'esm': false,
           },
           'canary': true,
           'hidden': false,


### PR DESCRIPTION
This makes it so we don't rely on the internal build system for the esm identification mechanism and solely rely on the external symbol replacement