### PR TITLE
🐛 Mark viewer storage failure as an expected error

### DIFF
--- a/src/service/storage-impl.js
+++ b/src/service/storage-impl.js
@@ -403,7 +403,9 @@ export class ViewerStorageBinding {
     return /** @type {!Promise} */ (this.viewer_.sendMessageAwaitResponse(
       'saveStore',
       dict({'origin': origin, 'blob': blob})
-    ));
+    )).catch(reason => {
+      dev().expectedError(TAG, 'Failed to save store: ', reason);
+    });
   }
 }
 

--- a/src/service/storage-impl.js
+++ b/src/service/storage-impl.js
@@ -400,14 +400,14 @@ export class ViewerStorageBinding {
 
   /** @override */
   saveBlob(origin, blob) {
-    return /** @type {!Promise} */ this.viewer_
+    return /** @type {!Promise} */ (this.viewer_
       .sendMessageAwaitResponse(
         'saveStore',
         dict({'origin': origin, 'blob': blob})
       )
       .catch(reason => {
         dev().expectedError(TAG, 'Failed to save store: ', reason);
-      });
+      }));
   }
 }
 

--- a/src/service/storage-impl.js
+++ b/src/service/storage-impl.js
@@ -406,7 +406,7 @@ export class ViewerStorageBinding {
         dict({'origin': origin, 'blob': blob})
       )
       .catch(reason => {
-        dev().expectedError(TAG, 'Failed to save store: ', reason);
+        throw dev().createExpectedError(TAG, 'Failed to save store: ', reason);
       }));
   }
 }

--- a/src/service/storage-impl.js
+++ b/src/service/storage-impl.js
@@ -400,12 +400,14 @@ export class ViewerStorageBinding {
 
   /** @override */
   saveBlob(origin, blob) {
-    return /** @type {!Promise} */ (this.viewer_.sendMessageAwaitResponse(
-      'saveStore',
-      dict({'origin': origin, 'blob': blob})
-    )).catch(reason => {
-      dev().expectedError(TAG, 'Failed to save store: ', reason);
-    });
+    return /** @type {!Promise} */ this.viewer_
+      .sendMessageAwaitResponse(
+        'saveStore',
+        dict({'origin': origin, 'blob': blob})
+      )
+      .catch(reason => {
+        dev().expectedError(TAG, 'Failed to save store: ', reason);
+      });
   }
 }
 


### PR DESCRIPTION
When users disable storage, the Google AMP Viewer can throw an error when it receives a `saveStore` message. This PR catches that error and reports it as an expected error. This should silence ~185k errors/week from the unexpected error buckets.

Closes https://github.com/ampproject/amphtml/issues/25643