### PR TITLE
Avoid expanding selector

### DIFF
--- a/extensions/amp-analytics/0.1/amp-analytics.js
+++ b/extensions/amp-analytics/0.1/amp-analytics.js
@@ -35,7 +35,7 @@ import {Services} from '../../../src/services';
 import {Transport} from './transport';
 import {dev, devAssert, rethrowAsync, user} from '../../../src/log';
 import {dict, hasOwn} from '../../../src/utils/object';
-import {expandTemplate} from '../../../src/string';
+import {endsWith, expandTemplate, startsWith} from '../../../src/string';
 import {getMode} from '../../../src/mode';
 import {installLinkerReaderService} from './linker-reader';
 import {isArray, isEnumValue} from '../../../src/types';
@@ -358,7 +358,11 @@ export class AmpAnalytics extends AMP.BaseElement {
               trigger['selector'] = this.element.parentElement.tagName;
               trigger['selectionMethod'] = 'closest';
               this.addTrigger_(trigger);
-            } else if (trigger['selector']) {
+            } else if (
+              trigger['selector'] &&
+              startsWith(trigger['selector'], '${') &&
+              endsWith(trigger['selector'], '}')
+            ) {
               // Expand the selector using variable expansion.
               return this.variableService_
                 .expandTemplate(


### PR DESCRIPTION
Avoid expanding template for most selectors

before:
![image](https://user-images.githubusercontent.com/5419904/76912090-e2907d00-686f-11ea-94c0-13a15fc76e2e.png)

after: 
![image](https://user-images.githubusercontent.com/5419904/76912120-f4722000-686f-11ea-9cd9-f0fe450c958f.png)
