### PR TITLE
🐛 Make amp-carousel.css use .i-amphtml-carousel-has-controls instead of [controls]

### DIFF
--- a/extensions/amp-carousel/0.1/amp-carousel.css
+++ b/extensions/amp-carousel/0.1/amp-carousel.css
@@ -48,6 +48,7 @@ amp-carousel {
 }
 
 amp-carousel[controls] .amp-carousel-button,
+amp-carousel.i-amphtml-carousel-has-controls .amp-carousel-button,
 .amp-mode-mouse .amp-carousel-button {
   opacity: 1;
   visibility: visible;
@@ -93,7 +94,7 @@ amp-carousel .amp-carousel-button.amp-disabled {
 amp-carousel[i-amphtml-carousel-hide-buttons] .amp-carousel-button-prev,
 amp-carousel[i-amphtml-carousel-hide-buttons] .amp-carousel-button-next {
   opacity: 0;
-  /** 
+  /**
    * Note, screen readers can still activate the buttons when hide buttons is
    * specified, even though we have `pointer-events: none`.
    */

--- a/test/integration/test-amp-carousel.js
+++ b/test/integration/test-amp-carousel.js
@@ -64,6 +64,7 @@ t.run('amp-carousel', function() {
         () => {
           document.body.classList.remove('amp-mode-mouse');
           const amp = document.querySelector('#carousel-1');
+          amp.classList.remove('i-amphtml-carousel-has-controls');
           const prevBtn = amp.querySelector('.amp-carousel-button-prev');
           const nextBtn = amp.querySelector('.amp-carousel-button-next');
           expect(document.body).to.not.have.class('amp-mode-mouse');
@@ -123,6 +124,7 @@ t.run('amp-carousel', function() {
         () => {
           document.body.classList.remove('amp-mode-mouse');
           const amp = document.querySelector('#carousel-1');
+          amp.classList.remove('i-amphtml-carousel-has-controls');
           const prevBtn = amp.querySelector('.amp-carousel-button-prev');
           const nextBtn = amp.querySelector('.amp-carousel-button-next');
           expect(document.body).to.not.have.class('amp-mode-mouse');
@@ -228,6 +230,7 @@ t.run('amp-carousel', function() {
         () => {
           document.body.classList.remove('amp-mode-mouse');
           const amp = document.querySelector('#carousel-1');
+          amp.classList.remove('i-amphtml-carousel-has-controls');
           const prevBtn = amp.querySelector('.amp-carousel-button-prev');
           const nextBtn = amp.querySelector('.amp-carousel-button-next');
           expect(document.body).to.not.have.class('amp-mode-mouse');
@@ -287,6 +290,7 @@ t.run('amp-carousel', function() {
         () => {
           document.body.classList.remove('amp-mode-mouse');
           const amp = document.querySelector('#carousel-1');
+          amp.classList.remove('i-amphtml-carousel-has-controls');
           const prevBtn = amp.querySelector('.amp-carousel-button-prev');
           const nextBtn = amp.querySelector('.amp-carousel-button-next');
           expect(document.body).to.not.have.class('amp-mode-mouse');


### PR DESCRIPTION
Fixes bug introduced by #25714: because AMP email overrides the behavior of the `controls` attribute without the attribute being present, neither CSS selector that shows carousel buttons actually catches it.