### PR TITLE
🐛Change validator to let amp-access and amp-subscriptions coexist

### DIFF
--- a/extensions/amp-access/validator-amp-access.protoascii
+++ b/extensions/amp-access/validator-amp-access.protoascii
@@ -32,8 +32,6 @@ tags: {  # amp-access (json)
   unique: true
   mandatory_parent: "HEAD"
   requires_extension: "amp-access"
-  satisfies: "amp-access extension .json script"
-  excludes: "amp-subscriptions extension .json script"
   attrs: {
     name: "id"
     mandatory: true

--- a/extensions/amp-subscriptions/0.1/test/validator-amp-subscriptions-errors.out
+++ b/extensions/amp-subscriptions/0.1/test/validator-amp-subscriptions-errors.out
@@ -1,4 +1,4 @@
-FAIL
+PASS
 |  <!--
 |    Copyright 2018 The AMP HTML Authors. All Rights Reserved.
 |
@@ -72,7 +72,3 @@ FAIL
 |    </template>
 |  </body>
 |  </html>
->>       ^~~~~~~~~
-amp-subscriptions/0.1/test/validator-amp-subscriptions-errors.html:73:6 The tag 'amp-access extension .json script' is present, but is excluded by the presence of 'amp-subscriptions extension .json script'. (see https://amp.dev/documentation/components/amp-access)
->>       ^~~~~~~~~
-amp-subscriptions/0.1/test/validator-amp-subscriptions-errors.html:73:6 The tag 'amp-subscriptions extension .json script' is present, but is excluded by the presence of 'amp-access extension .json script'. (see https://amp.dev/documentation/components/amp-subscriptions)

--- a/extensions/amp-subscriptions/validator-amp-subscriptions.protoascii
+++ b/extensions/amp-subscriptions/validator-amp-subscriptions.protoascii
@@ -31,9 +31,7 @@ tags: {  # amp-subscriptions (json)
   spec_name: "amp-subscriptions extension .json script"
   unique: true
   mandatory_parent: "HEAD"
-  requires_extension: "amp-subscriptions"
-  satisfies: "amp-subscriptions extension .json script"
-  excludes: "amp-access extension .json script"
+  requires_extension: "amp-subscriptions"  
   attrs: {
     name: "id"
     mandatory: true


### PR DESCRIPTION
Although the valdiator error is useful for pushing users to avoid errors, in practice amp-access and amp-subscriptions appear to coexist fine. This change is needed to allow publishers using amp-subscriptions to also use amp-access-scroll to let Scroll customers avoid ads.
