### PR TITLE
🏗 add .percy.yaml config file for visual diff tests

### DIFF
--- a/build-system/tasks/visual-diff/.percy.yaml
+++ b/build-system/tasks/visual-diff/.percy.yaml
@@ -1,6 +1,12 @@
+# Percy Agent config.
+# https://docs.percy.io/docs/sdk-configuration
+
 version: 1
 snapshot:
-  widths: [375, 411, 1400]
+  widths:
+    - 375 # e.g., iPhone
+    - 411 # e.g., iPhone X, Pixel
+    - 1400 # e.g., common desktop width
 agent:
   asset-discovery:
     network-idle-timeout: 150 # ms

--- a/build-system/tasks/visual-diff/.percy.yaml
+++ b/build-system/tasks/visual-diff/.percy.yaml
@@ -1,0 +1,6 @@
+version: 1
+snapshot:
+  widths: [375, 411, 1400]
+agent:
+  asset-discovery:
+    network-idle-timeout: 150 # ms

--- a/build-system/tasks/visual-diff/index.js
+++ b/build-system/tasks/visual-diff/index.js
@@ -48,8 +48,6 @@ const {waitUntilUsed} = require('tcp-port-used');
 let puppeteer;
 let percySnapshot;
 
-// CSS widths: iPhone: 375, Pixel: 411, Desktop: 1400.
-const DEFAULT_SNAPSHOT_OPTIONS = {widths: [375, 411, 1400]};
 const SNAPSHOT_SINGLE_BUILD_OPTIONS = {widths: [375]};
 const VIEWPORT_WIDTH = 1400;
 const VIEWPORT_HEIGHT = 100000;
@@ -578,7 +576,7 @@ async function snapshotWebpages(browser, webpages) {
 
           // Create a default set of snapshot options for Percy and modify
           // them based on the test's configuration.
-          const snapshotOptions = {...DEFAULT_SNAPSHOT_OPTIONS};
+          const snapshotOptions = {};
           if (webpage.enable_percy_javascript) {
             snapshotOptions.enableJavaScript = true;
           }

--- a/build-system/tasks/visual-diff/index.js
+++ b/build-system/tasks/visual-diff/index.js
@@ -316,12 +316,10 @@ function logTestError(testError) {
 /**
  * Runs the visual tests.
  *
- * @param {!Array<string>} assetGlobs an array of glob strings to load assets
- *     from.
  * @param {!Array<JsonObject>} webpages an array of JSON objects containing
  *     details about the pages to snapshot.
  */
-async function runVisualTests(assetGlobs, webpages) {
+async function runVisualTests(webpages) {
   // Create a Percy client and start a build.
   if (process.env['PERCY_TARGET_COMMIT']) {
     log(
@@ -738,10 +736,7 @@ async function performVisualTests() {
         'utf8'
       )
     );
-    await runVisualTests(
-      visualTestsConfig.asset_globs,
-      visualTestsConfig.webpages
-    );
+    await runVisualTests(visualTestsConfig.webpages);
   }
 }
 

--- a/test/visual-diff/visual-tests
+++ b/test/visual-diff/visual-tests
@@ -19,24 +19,6 @@
  */
  {
   /**
-  * An array of glob strings to use to load assets to Percy, relative to
-  * the base amphtml/ directory. All assets accessed by the test must be
-  * relative to the server path (i.e., use relative paths such as
-  * <amp-img src="/examples/visual-tests/..."> - never external domains such as
-  * <amp-img src="https://ampbyexample.com/...">)
-  *
-  * Note that if you add a new test from a sub-directory that is not matched
-  * by any glob string in this list, it will be missing its resources!
-  *
-  * See: glob primer https://github.com/isaacs/node-glob#glob-primer
-  */
-  "asset_globs": [
-    "examples/visual-tests/**",
-    "examples/amphtml-ads/ads-tag-integration.js",
-    "test/fixtures/e2e/amphtml-ads/**"
-  ],
-
-  /**
    * List of webpages used in tests.
    */
   "webpages": [


### PR DESCRIPTION
This PR:
* Adds a .percy.yaml file with default settings
* Sets the asset discovery timeout to 150 ms instead of the default 50 ms (recommended by Percy support in an attempt to resolve flakiness with missing images)
* [*Tag-along change*] removes the unused `asset_globs` field from the `visual_tests` file

Related to #27181