### PR TITLE
🏗 Run all PR checks during package upgrades

### DIFF
--- a/build-system/pr-check/build-targets.js
+++ b/build-system/pr-check/build-targets.js
@@ -25,6 +25,7 @@ const config = require('../test-configs/config');
 const minimatch = require('minimatch');
 const path = require('path');
 const {gitDiffNameOnlyMaster} = require('../common/git');
+const {isTravisBuild} = require('../common/travis');
 
 /**
  * List of all build targets.
@@ -280,7 +281,7 @@ function determineBuildTargets(fileName = 'build-targets.js') {
         .join(', ')
     )
   );
-  if (buildTargets.has('PACKAGE_UPGRADE')) {
+  if (isTravisBuild() && buildTargets.has('PACKAGE_UPGRADE')) {
     console.log(
       `${fileLogPrefix} Since this PR contains package upgrade(s), running all checks...`
     );

--- a/build-system/pr-check/build-targets.js
+++ b/build-system/pr-check/build-targets.js
@@ -27,6 +27,27 @@ const path = require('path');
 const {gitDiffNameOnlyMaster} = require('../common/git');
 
 /**
+ * List of all build targets.
+ */
+const ALL_TARGETS = [
+  'AVA',
+  'BABEL_PLUGIN',
+  'CACHES_JSON',
+  'DEV_DASHBOARD',
+  'DOCS',
+  'E2E_TEST',
+  'FLAG_CONFIG',
+  'INTEGRATION_TEST',
+  'OWNERS',
+  'PACKAGE_UPGRADE',
+  'RUNTIME',
+  'UNIT_TEST',
+  'VALIDATOR',
+  'VALIDATOR_WEBUI',
+  'VISUAL_DIFF',
+];
+
+/**
  * Checks if the given file is an OWNERS file
  * @param {string} file
  * @return {boolean}
@@ -37,6 +58,7 @@ function isOwnersFile(file) {
 
 /**
  * A mapping of functions that match a given file to one or more build targets.
+ * Note: Remember to update ALL_TARGETS above when you add a new target type.
  */
 const targetMatchers = [
   {
@@ -152,6 +174,12 @@ const targetMatchers = [
     },
   },
   {
+    targets: ['PACKAGE_UPGRADE'],
+    func: file => {
+      return file == 'package.json' || file == 'yarn.lock';
+    },
+  },
+  {
     targets: ['UNIT_TEST'],
     func: file => {
       if (isOwnersFile(file)) {
@@ -252,6 +280,12 @@ function determineBuildTargets(fileName = 'build-targets.js') {
         .join(', ')
     )
   );
+  if (buildTargets.has('PACKAGE_UPGRADE')) {
+    console.log(
+      `${fileLogPrefix} Since this PR contains package upgrade(s), running all checks...`
+    );
+    ALL_TARGETS.forEach(target => buildTargets.add(target));
+  }
   return buildTargets;
 }
 

--- a/build-system/pr-check/build-targets.js
+++ b/build-system/pr-check/build-targets.js
@@ -224,9 +224,6 @@ function determineBuildTargets(fileName = 'build-targets.js') {
   }
   // Test all targets on Travis during package upgrades.
   if (isTravisBuild() && buildTargets.has('PACKAGE_UPGRADE')) {
-    console.log(
-      `${fileLogPrefix} Since this PR contains package upgrade(s), running all checks...`
-    );
     const allTargets = Object.keys(targetMatchers);
     allTargets.forEach(target => buildTargets.add(target));
   }

--- a/build-system/pr-check/build-targets.js
+++ b/build-system/pr-check/build-targets.js
@@ -28,27 +28,6 @@ const {gitDiffNameOnlyMaster} = require('../common/git');
 const {isTravisBuild} = require('../common/travis');
 
 /**
- * List of all build targets.
- */
-const ALL_TARGETS = [
-  'AVA',
-  'BABEL_PLUGIN',
-  'CACHES_JSON',
-  'DEV_DASHBOARD',
-  'DOCS',
-  'E2E_TEST',
-  'FLAG_CONFIG',
-  'INTEGRATION_TEST',
-  'OWNERS',
-  'PACKAGE_UPGRADE',
-  'RUNTIME',
-  'UNIT_TEST',
-  'VALIDATOR',
-  'VALIDATOR_WEBUI',
-  'VISUAL_DIFF',
-];
-
-/**
  * Checks if the given file is an OWNERS file
  * @param {string} file
  * @return {boolean}
@@ -58,197 +37,154 @@ function isOwnersFile(file) {
 }
 
 /**
- * A mapping of functions that match a given file to one or more build targets.
- * Note: Remember to update ALL_TARGETS above when you add a new target type.
+ * A dictionary of functions that match a given file to a given build target.
  */
-const targetMatchers = [
-  {
-    targets: ['AVA'],
-    func: file => {
-      if (isOwnersFile(file)) {
-        return false;
-      }
-      return (
-        file == 'build-system/tasks/ava.js' ||
-        file.startsWith('build-system/tasks/csvify-size/') ||
-        file.startsWith('build-system/tasks/get-zindex/') ||
-        file.startsWith('build-system/tasks/prepend-global/')
-      );
-    },
+const targetMatchers = {
+  'AVA': file => {
+    if (isOwnersFile(file)) {
+      return false;
+    }
+    return (
+      file == 'build-system/tasks/ava.js' ||
+      file.startsWith('build-system/tasks/csvify-size/') ||
+      file.startsWith('build-system/tasks/get-zindex/') ||
+      file.startsWith('build-system/tasks/prepend-global/')
+    );
   },
-  {
-    targets: ['BABEL_PLUGIN', 'RUNTIME'], // Test the runtime for babel plugin changes.
-    func: file => {
-      if (isOwnersFile(file)) {
-        return false;
-      }
-      return (
-        file == 'build-system/babel-plugins/log-module-metadata.js' ||
-        file == 'build-system/babel-plugins/static-template-metadata.js' ||
-        file == 'build-system/compile/internal-version.js' ||
-        file == 'build-system/compile/log-messages.js' ||
-        file == 'build-system/tasks/babel-plugin-tests.js' ||
-        file.startsWith('build-system/babel-plugins/')
-      );
-    },
+  'BABEL_PLUGIN': file => {
+    if (isOwnersFile(file)) {
+      return false;
+    }
+    return (
+      file == 'build-system/babel-plugins/log-module-metadata.js' ||
+      file == 'build-system/babel-plugins/static-template-metadata.js' ||
+      file == 'build-system/compile/internal-version.js' ||
+      file == 'build-system/compile/log-messages.js' ||
+      file == 'build-system/tasks/babel-plugin-tests.js' ||
+      file.startsWith('build-system/babel-plugins/')
+    );
   },
-  {
-    targets: ['CACHES_JSON'],
-    func: file => {
-      if (isOwnersFile(file)) {
-        return false;
-      }
-      return (
-        file == 'build-system/tasks/caches-json.js' ||
-        file == 'build-system/global-configs/caches.json'
-      );
-    },
+  'CACHES_JSON': file => {
+    if (isOwnersFile(file)) {
+      return false;
+    }
+    return (
+      file == 'build-system/tasks/caches-json.js' ||
+      file == 'build-system/global-configs/caches.json'
+    );
   },
-  {
-    targets: ['DEV_DASHBOARD'],
-    func: file => {
-      if (isOwnersFile(file)) {
-        return false;
-      }
-      return (
-        file == 'build-system/tasks/dev-dashboard-tests.js' ||
-        file == 'build-system/server/app.js' ||
-        file.startsWith('build-system/server/app-index/')
-      );
-    },
+  'DEV_DASHBOARD': file => {
+    if (isOwnersFile(file)) {
+      return false;
+    }
+    return (
+      file == 'build-system/tasks/dev-dashboard-tests.js' ||
+      file == 'build-system/server/app.js' ||
+      file.startsWith('build-system/server/app-index/')
+    );
   },
-  {
-    targets: ['DOCS'],
-    func: file => {
-      if (isOwnersFile(file)) {
-        return false;
-      }
-      return (
-        file == 'build-system/tasks/check-links.js' ||
-        (path.extname(file) == '.md' && !file.startsWith('examples/'))
-      );
-    },
+  'DOCS': file => {
+    if (isOwnersFile(file)) {
+      return false;
+    }
+    return (
+      file == 'build-system/tasks/check-links.js' ||
+      (path.extname(file) == '.md' && !file.startsWith('examples/'))
+    );
   },
-  {
-    targets: ['E2E_TEST'],
-    func: file => {
-      if (isOwnersFile(file)) {
-        return false;
-      }
-      return (
-        file.startsWith('build-system/tasks/e2e/') ||
-        config.e2eTestPaths.some(pattern => {
-          return minimatch(file, pattern);
-        })
-      );
-    },
+  'E2E_TEST': file => {
+    if (isOwnersFile(file)) {
+      return false;
+    }
+    return (
+      file.startsWith('build-system/tasks/e2e/') ||
+      config.e2eTestPaths.some(pattern => {
+        return minimatch(file, pattern);
+      })
+    );
   },
-  {
-    targets: ['FLAG_CONFIG'],
-    func: file => {
-      if (isOwnersFile(file)) {
-        return false;
-      }
-      return file.startsWith('build-system/global-configs/');
-    },
+  'FLAG_CONFIG': file => {
+    if (isOwnersFile(file)) {
+      return false;
+    }
+    return file.startsWith('build-system/global-configs/');
   },
-  {
-    targets: ['INTEGRATION_TEST'],
-    func: file => {
-      if (isOwnersFile(file)) {
-        return false;
-      }
-      return (
-        file == 'build-system/tasks/integration.js' ||
-        (file.startsWith('build-system/tasks/runtime-test/') &&
-          !file.endsWith('unit.js')) ||
-        config.integrationTestPaths.some(pattern => {
-          return minimatch(file, pattern);
-        })
-      );
-    },
+  'INTEGRATION_TEST': file => {
+    if (isOwnersFile(file)) {
+      return false;
+    }
+    return (
+      file == 'build-system/tasks/integration.js' ||
+      (file.startsWith('build-system/tasks/runtime-test/') &&
+        !file.endsWith('unit.js')) ||
+      config.integrationTestPaths.some(pattern => {
+        return minimatch(file, pattern);
+      })
+    );
   },
-  {
-    targets: ['OWNERS'],
-    func: file => {
-      return isOwnersFile(file) || file == 'build-system/tasks/check-owners.js';
-    },
+  'OWNERS': file => {
+    return isOwnersFile(file) || file == 'build-system/tasks/check-owners.js';
   },
-  {
-    targets: ['PACKAGE_UPGRADE'],
-    func: file => {
-      return file == 'package.json' || file == 'yarn.lock';
-    },
+  'PACKAGE_UPGRADE': file => {
+    return file == 'package.json' || file == 'yarn.lock';
   },
-  {
-    targets: ['UNIT_TEST'],
-    func: file => {
-      if (isOwnersFile(file)) {
-        return false;
-      }
-      return (
-        file == 'build-system/tasks/unit.js' ||
-        file.startsWith('build-system/tasks/runtime-test/') ||
-        config.unitTestPaths.some(pattern => {
-          return minimatch(file, pattern);
-        })
-      );
-    },
+  'UNIT_TEST': file => {
+    if (isOwnersFile(file)) {
+      return false;
+    }
+    return (
+      file == 'build-system/tasks/unit.js' ||
+      file.startsWith('build-system/tasks/runtime-test/') ||
+      config.unitTestPaths.some(pattern => {
+        return minimatch(file, pattern);
+      })
+    );
   },
-  {
-    targets: ['VALIDATOR'],
-    func: file => {
-      if (isOwnersFile(file)) {
-        return false;
-      }
-      if (file.startsWith('validator/webui/')) {
-        return false;
-      }
-      if (file.startsWith('validator/')) {
-        return true;
-      }
-      // validator files for each extension
-      if (!file.startsWith('extensions/')) {
-        return false;
-      }
-      const pathArray = path.dirname(file).split(path.sep);
-      if (pathArray.length < 2) {
-        // At least 2 with ['extensions', '{$name}']
-        return false;
-      }
-      // Validator files take the form of validator-.*\.(html|out|protoascii)
-      const name = path.basename(file);
-      return (
-        name.startsWith('validator-') &&
-        (name.endsWith('.out') ||
-          name.endsWith('.html') ||
-          name.endsWith('.protoascii'))
-      );
-    },
+  'VALIDATOR': file => {
+    if (isOwnersFile(file)) {
+      return false;
+    }
+    if (file.startsWith('validator/webui/')) {
+      return false;
+    }
+    if (file.startsWith('validator/')) {
+      return true;
+    }
+    // validator files for each extension
+    if (!file.startsWith('extensions/')) {
+      return false;
+    }
+    const pathArray = path.dirname(file).split(path.sep);
+    if (pathArray.length < 2) {
+      // At least 2 with ['extensions', '{$name}']
+      return false;
+    }
+    // Validator files take the form of validator-.*\.(html|out|protoascii)
+    const name = path.basename(file);
+    return (
+      name.startsWith('validator-') &&
+      (name.endsWith('.out') ||
+        name.endsWith('.html') ||
+        name.endsWith('.protoascii'))
+    );
   },
-  {
-    targets: ['VALIDATOR_WEBUI'],
-    func: file => {
-      if (isOwnersFile(file)) {
-        return false;
-      }
-      return file.startsWith('validator/webui/');
-    },
+  'VALIDATOR_WEBUI': file => {
+    if (isOwnersFile(file)) {
+      return false;
+    }
+    return file.startsWith('validator/webui/');
   },
-  {
-    targets: ['VISUAL_DIFF'],
-    func: file => {
-      if (isOwnersFile(file)) {
-        return false;
-      }
-      return (
-        file.startsWith('build-system/tasks/visual-diff/') ||
-        file.startsWith('examples/visual-tests/') ||
-        file == 'test/visual-diff/visual-tests'
-      );
-    },
+  'VISUAL_DIFF': file => {
+    if (isOwnersFile(file)) {
+      return false;
+    }
+    return (
+      file.startsWith('build-system/tasks/visual-diff/') ||
+      file.startsWith('examples/visual-tests/') ||
+      file == 'test/visual-diff/visual-tests'
+    );
   },
-];
+};
 
 /**
  * Populates buildTargets with a set of build targets contained in a PR after
@@ -262,9 +198,10 @@ function determineBuildTargets(fileName = 'build-targets.js') {
   const buildTargets = new Set();
   for (const file of filesChanged) {
     let matched = false;
-    targetMatchers.forEach(matcher => {
-      if (matcher.func(file)) {
-        matcher.targets.forEach(target => buildTargets.add(target));
+    Object.keys(targetMatchers).forEach(target => {
+      const matcher = targetMatchers[target];
+      if (matcher(file)) {
+        buildTargets.add(target);
         matched = true;
       }
     });
@@ -281,11 +218,17 @@ function determineBuildTargets(fileName = 'build-targets.js') {
         .join(', ')
     )
   );
+  // Test the runtime for babel plugin changes.
+  if (buildTargets.has('BABEL_PLUGIN')) {
+    buildTargets.add('RUNTIME');
+  }
+  // Test all targets on Travis during package upgrades.
   if (isTravisBuild() && buildTargets.has('PACKAGE_UPGRADE')) {
     console.log(
       `${fileLogPrefix} Since this PR contains package upgrade(s), running all checks...`
     );
-    ALL_TARGETS.forEach(target => buildTargets.add(target));
+    const allTargets = Object.keys(targetMatchers);
+    allTargets.forEach(target => buildTargets.add(target));
   }
   return buildTargets;
 }


### PR DESCRIPTION
In order to optimize the use of Travis CPU time, AMP's PR checks use a [build target system](https://github.com/ampproject/amphtml/blob/master/build-system/pr-check/build-targets.js) to determine which tests to run. When packages are upgraded, the system currently neglects to run tests that may be affected, causing them to potentially [break on `master`](https://travis-ci.org/github/ampproject/amphtml/jobs/663242651#L367).

This PR makes it so that when a package upgrade is detected (e.g. a renovate PR), tests corresponding to all build targets are executed on Travis. Local `gulp pr-check` is left as is, because it's meant to be a quick verification and not a comprehensive run of all tests.

Fixes #27263