### PR TITLE
Prevent horizontal shifts caused by conditional amp-social-share siblings

### DIFF
--- a/css/ampdoc.css
+++ b/css/ampdoc.css
@@ -353,7 +353,6 @@ amp-autocomplete > textarea,
  * would not cause a row to resize.
  */
 amp-social-share:not(.i-amphtml-built):not(body):not(head):not(html) {
-  display: none !important;
   width: 0 !important;
   margin-left: 0 !important;
   margin-right: 0 !important;

--- a/css/ampdoc.css
+++ b/css/ampdoc.css
@@ -352,7 +352,7 @@ amp-autocomplete > textarea,
  * This only overrides horizontal sizing, so sibling amp-social-share elements
  * would not cause a row to resize.
  */
-amp-social-share:not(.i-amphtml-built):not(body):not(head):not(html) {
+amp-social-share.i-amphtml-notbuilt:not(body):not(head):not(html) {
   width: 0 !important;
   margin-left: 0 !important;
   margin-right: 0 !important;

--- a/css/ampdoc.css
+++ b/css/ampdoc.css
@@ -345,3 +345,18 @@ amp-autocomplete > textarea,
 [amp-fx^="fly-in"] {
   visibility: hidden;
 }
+
+/*
+ * Using :not(body):not(head):not(html) to override inline sizing styles set
+ * by the runtime.
+ * This only overrides horizontal sizing, so sibling amp-social-share elements
+ * would not cause a row to resize.
+ */
+amp-social-share:not(.i-amphtml-built):not(body):not(head):not(html) {
+  display: none !important;
+  width: 0 !important;
+  margin-left: 0 !important;
+  margin-right: 0 !important;
+  padding-left: 0 !important;
+  padding-right: 0 !important;
+}

--- a/extensions/amp-social-share/0.1/amp-social-share.js
+++ b/extensions/amp-social-share/0.1/amp-social-share.js
@@ -147,7 +147,6 @@ class AmpSocialShare extends AMP.BaseElement {
     element.addEventListener('click', () => this.handleClick_());
     element.addEventListener('keydown', this.handleKeyPress_.bind(this));
     element.classList.add(`amp-social-share-${typeAttr}`);
-    element.classList.add('i-amphtml-built');
   }
 
   /**

--- a/extensions/amp-social-share/0.1/amp-social-share.js
+++ b/extensions/amp-social-share/0.1/amp-social-share.js
@@ -147,6 +147,7 @@ class AmpSocialShare extends AMP.BaseElement {
     element.addEventListener('click', () => this.handleClick_());
     element.addEventListener('keydown', this.handleKeyPress_.bind(this));
     element.classList.add(`amp-social-share-${typeAttr}`);
+    element.classList.add('i-amphtml-built');
   }
 
   /**


### PR DESCRIPTION
### Approach

This eliminates horizontal sizing from the element until system share support is resolved, at which point elements are toggled.

By effectively giving the elements an area of zero, they dont "knock" each other causing horizontal layout shift. By keeping their height we're preventing its outer container from shifting vertically.

### Shift regions changes

Buttons are always hue-tinted before, because they shift by their entire area.

||<div align="left">**By themselves.**</div>|
|-|-|
|before|![image](https://user-images.githubusercontent.com/254946/77100128-5e0a3f80-69d2-11ea-999e-f2f38bcec116.png)|
|after|![image](https://user-images.githubusercontent.com/254946/77104975-1daebf80-69da-11ea-9f1f-4cb4035b8b59.png)|
||**With author-defined tail element**.<br>This is variable based on tail's width. |
|before|![image](https://user-images.githubusercontent.com/254946/77104926-066fd200-69da-11ea-9bb2-6517fdbdbf4d.png)|
|after|![image](https://user-images.githubusercontent.com/254946/77104836-e17b5f00-69d9-11ea-9201-db7fea86f368.png)|

More testable examples on [amp-social-share-shift.glitch.me](https://amp-social-share-shift.glitch.me/).

### Markup

```html
<div>
  <!-- This button is displayed conditionally: -->
  <amp-social-share
    type="system"
    height="48px"
    width="48px"
    data-mode="replace"
  ></amp-social-share>
  <!-- The rest are exclusive to the previous button: -->
  <amp-social-share
    type="twitter"
    height="48px"
    width="48px"
  ></amp-social-share>
  <amp-social-share
    type="whatsapp"
    height="48px"
    width="48px"
  ></amp-social-share>
  <!-- Optional tail element: --->
  <span>tail</span>
</div>
```

### On columns

This reduces shift for horizontally-defined sets of `<amp-social-share>` elements. Columns are still problematic, so this assumes that they're usually laid out in rows.

To prevent vertical shift, the author needs to [somehow "lock" their container](https://amp-social-share-shift.glitch.me/):

```css
.vertical {
  width: 48px;
  height: calc(4 * 48px);
}
.vertical amp-social-share {
  display: block;
}
```