### PR TITLE
🏗 Make `yarn.lock` change detection more resilient

### DIFF
--- a/build-system/common/git.js
+++ b/build-system/common/git.js
@@ -65,6 +65,17 @@ function shortSha(sha) {
 }
 
 /**
+ * Returns the list of files changed but not committed to the local branch, one
+ * on each line.
+ * @return {!Array<string>}
+ */
+function gitDiffNameOnly() {
+  return getStdout('git diff --name-only')
+    .trim()
+    .split('\n');
+}
+
+/**
  * Returns the list of files changed relative to the branch point off of master,
  * one on each line.
  * @return {!Array<string>}
@@ -211,6 +222,7 @@ module.exports = {
   gitDiffColor,
   gitDiffCommitLog,
   gitDiffFileMaster,
+  gitDiffNameOnly,
   gitDiffNameOnlyMaster,
   gitDiffPath,
   gitDiffStatMaster,

--- a/build-system/pr-check/yarn-checks.js
+++ b/build-system/pr-check/yarn-checks.js
@@ -23,7 +23,7 @@
 
 const colors = require('ansi-colors');
 const {getStderr} = require('../common/exec');
-const {gitDiffColor} = require('../common/git');
+const {gitDiffColor, gitDiffNameOnly} = require('../common/git');
 
 /**
  * Makes sure package.json and yarn.lock are in sync.
@@ -73,10 +73,10 @@ function isYarnLockFileInSync(fileName = 'yarn-checks.js') {
  * @return {boolean}
  */
 function isYarnLockFileProperlyUpdated(fileName = 'yarn-checks.js') {
-  const localChanges = gitDiffColor();
+  const filesChanged = gitDiffNameOnly();
   const fileLogPrefix = colors.bold(colors.yellow(`${fileName}:`));
 
-  if (localChanges.includes('yarn.lock')) {
+  if (filesChanged.includes('yarn.lock')) {
     console.error(
       fileLogPrefix,
       colors.red('ERROR:'),
@@ -92,7 +92,7 @@ function isYarnLockFileProperlyUpdated(fileName = 'yarn-checks.js') {
         ', and push a new commit containing the changes.'
     );
     console.error(fileLogPrefix, 'Expected changes:');
-    console.log(localChanges);
+    console.log(gitDiffColor());
     return false;
   }
   return true;


### PR DESCRIPTION
During Travis runs, we check if `yarn.lock` was properly updated. This is currently done in `isYarnLockFileProperlyUpdated()` by searching for the string `"yarn.lock"` in the `git diff` output. The check can cause `gulp pr-check` to return a false negative during local development if an in-flight change happens to contain the string `yarn.lock` (rare, but can happen).

This PR makes the detection more explicit by examining the list of files modified to see if there are unexpected changes to `yarn.lock`.