### PR TITLE
🐛 Values returned by setInterval must be greater than 0.

### DIFF
--- a/3p/environment.js
+++ b/3p/environment.js
@@ -32,7 +32,7 @@ export function setInViewportForTesting(inV) {
 // Active intervals. Must be global, because people clear intervals
 // with clearInterval from a different window.
 const intervals = {};
-let intervalId = 0;
+let intervalId = 1;
 
 /**
  * Add instrumentation to a window and all child iframes.


### PR DESCRIPTION
https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#dom-setinterval
https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#timer-initialisation-steps

Per the spec, timers must return a value greater than 0.  Currently, the first setInterval call will return 0 as the interval ID.  This can cause some code to inadvertently fail, since 0 is falsey.