### PR TITLE
🐛 amp-consent getRemoteConsent null

### DIFF
--- a/extensions/amp-consent/0.1/amp-consent.js
+++ b/extensions/amp-consent/0.1/amp-consent.js
@@ -456,6 +456,9 @@ export class AmpConsent extends AMP.BaseElement {
           return Promise.resolve(consentRequired);
         }
         return this.getConsentRemote_().then(consentResponse => {
+          if (!consentResponse) {
+            return false;
+          }
           // `promptIfUnknown` is a legacy field
           return consentResponse['consentRequired'] !== undefined
             ? !!consentResponse['consentRequired']


### PR DESCRIPTION
`this.getConsentRemote_()` can return null, and we're assuming that it always is an object.

Defaults `getConsentRequiredPromise_` to false if this is the case. 