### PR TITLE
access-expr: cache evaluations

### DIFF
--- a/extensions/amp-access/0.1/access-expr.js
+++ b/extensions/amp-access/0.1/access-expr.js
@@ -45,16 +45,35 @@ export function evaluateAccessExpr(expr, data) {
   }
 }
 
+import stringify from 'json-stable-stringify';
+
+// TODO(samouri): this is bad for bundle size and performance.
+function createKey(obj) {
+  return stringify(obj);
+}
+
 export class AmpAccessEvaluator {
   constructor() {
     /** @const */
     this.cache = map();
   }
 
+  /**
+   * Evaluate access expressions, but turn to a cache first.
+   *
+   * @param {string} expr
+   * @param {!JsonObject} data
+   * @return {boolean}
+   */
   eval(expr, data) {
-    if (!this.cache[expr]) {
-      this.cache[expr] = evaluateAccessExpr(expr, data);
+    const key = createKey(data);
+    if (!this.cache[data]) {
+      this.cache[data] = map();
+      if (!this.cache[key][expr]) {
+        this.cache[key][expr] = evaluateAccessExpr(expr, data);
+      }
     }
-    return this.cache[expr];
+
+    return this.cache[key][expr];
   }
 }

--- a/extensions/amp-access/0.1/access-expr.js
+++ b/extensions/amp-access/0.1/access-expr.js
@@ -68,7 +68,7 @@ export class AmpAccessEvaluator {
    * @param {!JsonObject} data
    * @return {boolean}
    */
-  eval(expr, data) {
+  evaluate(expr, data) {
     if (this.lastData !== data) {
       this.lastData = data;
       this.cache = map();

--- a/extensions/amp-access/0.1/access-expr.js
+++ b/extensions/amp-access/0.1/access-expr.js
@@ -15,6 +15,7 @@
  */
 
 import {accessParser as parser} from '../../../build/parsers/access-expr-impl';
+import {map} from '../../../src/utils/object';
 
 /**
  * Evaluates access expression.
@@ -58,6 +59,10 @@ export class AmpAccessEvaluator {
     this.cache = map();
   }
 
+  eval_(expr, data) {
+    return evaluateAccessExpr(expr, data);
+  }
+
   /**
    * Evaluate access expressions, but turn to a cache first.
    *
@@ -67,10 +72,10 @@ export class AmpAccessEvaluator {
    */
   eval(expr, data) {
     const key = createKey(data);
-    if (!this.cache[data]) {
-      this.cache[data] = map();
+    if (!this.cache[key]) {
+      this.cache[key] = map();
       if (!this.cache[key][expr]) {
-        this.cache[key][expr] = evaluateAccessExpr(expr, data);
+        this.cache[key][expr] = this.eval_(expr, data);
       }
     }
 

--- a/extensions/amp-access/0.1/access-expr.js
+++ b/extensions/amp-access/0.1/access-expr.js
@@ -44,3 +44,17 @@ export function evaluateAccessExpr(expr, data) {
     parser.yy = null;
   }
 }
+
+export class AmpAccessEvaluator {
+  constructor() {
+    /** @const */
+    this.cache = map();
+  }
+
+  eval(expr, data) {
+    if (!this.cache[expr]) {
+      this.cache[expr] = evaluateAccessExpr(expr, data);
+    }
+    return this.cache[expr];
+  }
+}

--- a/extensions/amp-access/0.1/access-expr.js
+++ b/extensions/amp-access/0.1/access-expr.js
@@ -56,8 +56,8 @@ export class AmpAccessEvaluator {
     /** @type {Object<string, boolean>} */
     this.cache = null;
 
-    /** @type {JsonObject} */
-    this.lastData = null;
+    /** @private @type {JsonObject} */
+    this.lastData_ = null;
   }
 
   /**
@@ -69,8 +69,8 @@ export class AmpAccessEvaluator {
    * @return {boolean}
    */
   evaluate(expr, data) {
-    if (this.lastData !== data) {
-      this.lastData = data;
+    if (this.lastData_ !== data) {
+      this.lastData_ = data;
       this.cache = map();
     }
 

--- a/extensions/amp-access/0.1/access-expr.js
+++ b/extensions/amp-access/0.1/access-expr.js
@@ -18,7 +18,7 @@ import {hasOwn, map} from '../../../src/utils/object';
 import {accessParser as parser} from '../../../build/parsers/access-expr-impl';
 
 /**
- * Evaluates access expression.
+ * Evaluates access expressions.
  *
  * The grammar is defined in the `access-expr-impl.jison` and compiled using
  * (Jison)[https://zaach.github.io/jison/] parser. The compilation steps are
@@ -47,28 +47,17 @@ export function evaluateAccessExpr(expr, data) {
 }
 
 /**
- * AmpAccessEvaluator evaluate amp-access expressions.
+ * AmpAccessEvaluator evaluates amp-access expressions.
+ * It uses a cache to speed up repeated evals for the same expression.
  */
 export class AmpAccessEvaluator {
   /** */
   constructor() {
-    /** @const */
+    /** @type {Object<string, boolean>} */
     this.cache = null;
 
-    /** @const */
+    /** @type {JsonObject} */
     this.lastData = null;
-  }
-
-  /**
-   * Proxies the call to evaluateAccessExpr.
-   * This function exists so that the test can spy on it.
-   *
-   * @param {string} expr
-   * @param {!JsonObject} data
-   * @return {boolean}
-   */
-  eval_(expr, data) {
-    return evaluateAccessExpr(expr, data);
   }
 
   /**
@@ -90,5 +79,17 @@ export class AmpAccessEvaluator {
     }
 
     return this.cache[expr];
+  }
+
+  /**
+   * Evaluates access expressions by proxying calls to evaluateAccessExpr.
+   * This function only exists to be spied on.
+   *
+   * @param {string} expr
+   * @param {!JsonObject} data
+   * @return {boolean}
+   */
+  eval_(expr, data) {
+    return evaluateAccessExpr(expr, data);
   }
 }

--- a/extensions/amp-access/0.1/access-expr.js
+++ b/extensions/amp-access/0.1/access-expr.js
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
+import {hasOwn, map} from '../../../src/utils/object';
 import {accessParser as parser} from '../../../build/parsers/access-expr-impl';
-import {map, hasOwn} from '../../../src/utils/object';
 
 /**
  * Evaluates access expression.
@@ -46,13 +46,27 @@ export function evaluateAccessExpr(expr, data) {
   }
 }
 
+/**
+ * AmpAccessEvaluator evaluate amp-access expressions.
+ */
 export class AmpAccessEvaluator {
+  /** */
   constructor() {
     /** @const */
     this.cache = null;
+
+    /** @const */
     this.lastData = null;
   }
 
+  /**
+   * Proxies the call to evaluateAccessExpr.
+   * This function exists so that the test can spy on it.
+   *
+   * @param {string} expr
+   * @param {!JsonObject} data
+   * @return {boolean}
+   */
   eval_(expr, data) {
     return evaluateAccessExpr(expr, data);
   }

--- a/extensions/amp-access/0.1/amp-access.js
+++ b/extensions/amp-access/0.1/amp-access.js
@@ -455,7 +455,7 @@ export class AccessService {
    */
   applyAuthorizationToElement_(element, response) {
     const expr = element.getAttribute('amp-access');
-    const on = this.evaluator_.eval(expr, response);
+    const on = this.evaluator_.evaluate(expr, response);
     let renderPromise = null;
     if (on) {
       renderPromise = this.renderTemplates_(element, response);

--- a/extensions/amp-access/0.1/amp-access.js
+++ b/extensions/amp-access/0.1/amp-access.js
@@ -17,6 +17,7 @@
 import {AccessSource, AccessType} from './amp-access-source';
 import {AccessVars} from './access-vars';
 import {ActionTrust} from '../../../src/action-constants';
+import {AmpAccessEvaluator} from './access-expr';
 import {AmpEvents} from '../../../src/amp-events';
 import {CSS} from '../../../build/amp-access-0.1.css';
 import {Observable} from '../../../src/observable';
@@ -24,7 +25,6 @@ import {Services} from '../../../src/services';
 import {cancellation} from '../../../src/error';
 import {dev, user, userAssert} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
-import {AmpAccessEvaluator} from './access-expr';
 import {getSourceOrigin} from '../../../src/url';
 import {getValueForExpr, tryParseJson} from '../../../src/json';
 import {installStylesForDoc} from '../../../src/style-installer';

--- a/extensions/amp-access/0.1/amp-access.js
+++ b/extensions/amp-access/0.1/amp-access.js
@@ -24,7 +24,7 @@ import {Services} from '../../../src/services';
 import {cancellation} from '../../../src/error';
 import {dev, user, userAssert} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
-import {evaluateAccessExpr} from './access-expr';
+import {AmpAccessEvaluator} from './access-expr';
 import {getSourceOrigin} from '../../../src/url';
 import {getValueForExpr, tryParseJson} from '../../../src/json';
 import {installStylesForDoc} from '../../../src/style-installer';
@@ -100,6 +100,9 @@ export class AccessService {
 
     /** @private {?Promise<string>} */
     this.readerIdPromise_ = null;
+
+    /** @private {!./access-expr.AmpAccessEvaluator} */
+    this.evaluator_ = new AmpAccessEvaluator();
 
     /** @const */
     this.sources_ = this.parseConfig_();
@@ -452,7 +455,7 @@ export class AccessService {
    */
   applyAuthorizationToElement_(element, response) {
     const expr = element.getAttribute('amp-access');
-    const on = evaluateAccessExpr(expr, response);
+    const on = this.evaluator_.eval(expr, response);
     let renderPromise = null;
     if (on) {
       renderPromise = this.renderTemplates_(element, response);

--- a/extensions/amp-access/0.1/test/test-access-expr.js
+++ b/extensions/amp-access/0.1/test/test-access-expr.js
@@ -343,7 +343,7 @@ describe('evaluateAccessExpr', () => {
     }).to.throw();
   });
 
-  describe('AmpAccessEvaluator', () => {
+  describe.only('AmpAccessEvaluator', () => {
     let evaluator;
     beforeEach(() => {
       window.sandbox.stub(accessExpr, 'evaluateAccessExpr');

--- a/extensions/amp-access/0.1/test/test-access-expr.js
+++ b/extensions/amp-access/0.1/test/test-access-expr.js
@@ -14,190 +14,192 @@
  * limitations under the License.
  */
 
-import {AmpAccessEvaluator, evaluateAccessExpr} from '../access-expr';
+import {AmpAccessEvaluator} from '../access-expr';
 
-describe('evaluateAccessExpr', () => {
+describe('evaluate', () => {
+  let evaluator;
+  beforeEach(() => {
+    evaluator = new AmpAccessEvaluator();
+  });
+
   it('should NOT allow double equal', () => {
     expect(() => {
-      evaluateAccessExpr('access == true', {});
+      evaluator.eval('access == true', {});
     }).to.throw(/\"\=\=\" is not allowed, use \"\=\"/);
   });
 
   it('should evaluate simple boolean expressions', () => {
-    expect(evaluateAccessExpr('access = true', {access: true})).to.be.true;
-    expect(evaluateAccessExpr('access = TRUE', {access: true})).to.be.true;
-    expect(evaluateAccessExpr('access = false', {access: true})).to.be.false;
-    expect(evaluateAccessExpr('access = FALSE', {access: true})).to.be.false;
-    expect(evaluateAccessExpr('access != false', {access: true})).to.be.true;
+    expect(evaluator.eval('access = true', {access: true})).to.be.true;
+    expect(evaluator.eval('access = TRUE', {access: true})).to.be.true;
+    expect(evaluator.eval('access = false', {access: true})).to.be.false;
+    expect(evaluator.eval('access = FALSE', {access: true})).to.be.false;
+    expect(evaluator.eval('access != false', {access: true})).to.be.true;
 
-    expect(evaluateAccessExpr('access = FALSE', {access: false})).to.be.true;
-    expect(evaluateAccessExpr('access != TRUE', {access: false})).to.be.true;
-    expect(evaluateAccessExpr('access = TRUE', {access: false})).to.be.false;
+    expect(evaluator.eval('access = FALSE', {access: false})).to.be.true;
+    expect(evaluator.eval('access != TRUE', {access: false})).to.be.true;
+    expect(evaluator.eval('access = TRUE', {access: false})).to.be.false;
   });
 
   it('should evaluate boolean expressions over undefined', () => {
-    expect(evaluateAccessExpr('access = true', {})).to.be.false;
-    expect(evaluateAccessExpr('access != true', {})).to.be.true;
+    expect(evaluator.eval('access = true', {})).to.be.false;
+    expect(evaluator.eval('access != true', {})).to.be.true;
 
-    expect(evaluateAccessExpr('access = false', {})).to.be.false;
-    expect(evaluateAccessExpr('access != false', {})).to.be.true;
+    expect(evaluator.eval('access = false', {})).to.be.false;
+    expect(evaluator.eval('access != false', {})).to.be.true;
   });
 
   it('should evaluate simple numeric expressions', () => {
-    expect(evaluateAccessExpr('num = 1', {num: 1})).to.be.true;
-    expect(evaluateAccessExpr('num > 1', {num: 1})).to.be.false;
-    expect(evaluateAccessExpr('num < 1', {num: 1})).to.be.false;
-    expect(evaluateAccessExpr('num >= 1', {num: 1})).to.be.true;
-    expect(evaluateAccessExpr('num <= 1', {num: 1})).to.be.true;
+    expect(evaluator.eval('num = 1', {num: 1})).to.be.true;
+    expect(evaluator.eval('num > 1', {num: 1})).to.be.false;
+    expect(evaluator.eval('num < 1', {num: 1})).to.be.false;
+    expect(evaluator.eval('num >= 1', {num: 1})).to.be.true;
+    expect(evaluator.eval('num <= 1', {num: 1})).to.be.true;
   });
 
   it('should evaluate negative numerics', () => {
-    expect(evaluateAccessExpr('num = -1', {num: -1})).to.be.true;
-    expect(evaluateAccessExpr('num = -1', {num: 0})).to.be.false;
-    expect(evaluateAccessExpr('num < -1', {num: -1})).to.be.false;
-    expect(evaluateAccessExpr('num < -1', {num: -2})).to.be.true;
-    expect(evaluateAccessExpr('num > -1', {num: 0})).to.be.true;
+    expect(evaluator.eval('num = -1', {num: -1})).to.be.true;
+    expect(evaluator.eval('num = -1', {num: 0})).to.be.false;
+    expect(evaluator.eval('num < -1', {num: -1})).to.be.false;
+    expect(evaluator.eval('num < -1', {num: -2})).to.be.true;
+    expect(evaluator.eval('num > -1', {num: 0})).to.be.true;
   });
 
   it('should evaluate numeric expressions over mistamtching type', () => {
-    expect(evaluateAccessExpr('num = 1', {})).to.be.false;
-    expect(evaluateAccessExpr('num > 1', {})).to.be.false;
-    expect(evaluateAccessExpr('num < 1', {})).to.be.false;
-    expect(evaluateAccessExpr('num >= 1', {})).to.be.false;
-    expect(evaluateAccessExpr('num <= 1', {})).to.be.false;
-    expect(evaluateAccessExpr('num != 1', {})).to.be.true;
+    expect(evaluator.eval('num = 1', {})).to.be.false;
+    expect(evaluator.eval('num > 1', {})).to.be.false;
+    expect(evaluator.eval('num < 1', {})).to.be.false;
+    expect(evaluator.eval('num >= 1', {})).to.be.false;
+    expect(evaluator.eval('num <= 1', {})).to.be.false;
+    expect(evaluator.eval('num != 1', {})).to.be.true;
 
-    expect(evaluateAccessExpr('num = 0', {num: 0})).to.be.true;
-    expect(evaluateAccessExpr('num > 0', {num: 0})).to.be.false;
-    expect(evaluateAccessExpr('num < 0', {num: 0})).to.be.false;
-    expect(evaluateAccessExpr('num >= 0', {num: 0})).to.be.true;
-    expect(evaluateAccessExpr('num <= 0', {num: 0})).to.be.true;
-    expect(evaluateAccessExpr('num != 0', {num: 0})).to.be.false;
+    expect(evaluator.eval('num = 0', {num: 0})).to.be.true;
+    expect(evaluator.eval('num > 0', {num: 0})).to.be.false;
+    expect(evaluator.eval('num < 0', {num: 0})).to.be.false;
+    expect(evaluator.eval('num >= 0', {num: 0})).to.be.true;
+    expect(evaluator.eval('num <= 0', {num: 0})).to.be.true;
+    expect(evaluator.eval('num != 0', {num: 0})).to.be.false;
 
-    expect(evaluateAccessExpr('num = 0', {})).to.be.false;
-    expect(evaluateAccessExpr('num > 0', {})).to.be.false;
-    expect(evaluateAccessExpr('num < 0', {})).to.be.false;
-    expect(evaluateAccessExpr('num >= 0', {})).to.be.false;
-    expect(evaluateAccessExpr('num <= 0', {})).to.be.false;
-    expect(evaluateAccessExpr('num != 0', {})).to.be.true;
+    expect(evaluator.eval('num = 0', {})).to.be.false;
+    expect(evaluator.eval('num > 0', {})).to.be.false;
+    expect(evaluator.eval('num < 0', {})).to.be.false;
+    expect(evaluator.eval('num >= 0', {})).to.be.false;
+    expect(evaluator.eval('num <= 0', {})).to.be.false;
+    expect(evaluator.eval('num != 0', {})).to.be.true;
 
-    expect(evaluateAccessExpr('num = 0', {num: false})).to.be.false;
-    expect(evaluateAccessExpr('num > 0', {num: false})).to.be.false;
-    expect(evaluateAccessExpr('num < 0', {num: false})).to.be.false;
-    expect(evaluateAccessExpr('num >= 0', {num: false})).to.be.false;
-    expect(evaluateAccessExpr('num <= 0', {num: false})).to.be.false;
-    expect(evaluateAccessExpr('num != 0', {num: false})).to.be.true;
+    expect(evaluator.eval('num = 0', {num: false})).to.be.false;
+    expect(evaluator.eval('num > 0', {num: false})).to.be.false;
+    expect(evaluator.eval('num < 0', {num: false})).to.be.false;
+    expect(evaluator.eval('num >= 0', {num: false})).to.be.false;
+    expect(evaluator.eval('num <= 0', {num: false})).to.be.false;
+    expect(evaluator.eval('num != 0', {num: false})).to.be.true;
 
-    expect(evaluateAccessExpr('num = 0', {num: ''})).to.be.false;
-    expect(evaluateAccessExpr('num > 0', {num: ''})).to.be.false;
-    expect(evaluateAccessExpr('num < 0', {num: ''})).to.be.false;
-    expect(evaluateAccessExpr('num >= 0', {num: ''})).to.be.false;
-    expect(evaluateAccessExpr('num <= 0', {num: ''})).to.be.false;
-    expect(evaluateAccessExpr('num != 0', {num: ''})).to.be.true;
+    expect(evaluator.eval('num = 0', {num: ''})).to.be.false;
+    expect(evaluator.eval('num > 0', {num: ''})).to.be.false;
+    expect(evaluator.eval('num < 0', {num: ''})).to.be.false;
+    expect(evaluator.eval('num >= 0', {num: ''})).to.be.false;
+    expect(evaluator.eval('num <= 0', {num: ''})).to.be.false;
+    expect(evaluator.eval('num != 0', {num: ''})).to.be.true;
 
-    expect(evaluateAccessExpr('num = 0', {num: '0'})).to.be.false;
-    expect(evaluateAccessExpr('num > 0', {num: '0'})).to.be.false;
-    expect(evaluateAccessExpr('num < 0', {num: '0'})).to.be.false;
-    expect(evaluateAccessExpr('num >= 0', {num: '0'})).to.be.false;
-    expect(evaluateAccessExpr('num <= 0', {num: '0'})).to.be.false;
-    expect(evaluateAccessExpr('num != 0', {num: '0'})).to.be.true;
+    expect(evaluator.eval('num = 0', {num: '0'})).to.be.false;
+    expect(evaluator.eval('num > 0', {num: '0'})).to.be.false;
+    expect(evaluator.eval('num < 0', {num: '0'})).to.be.false;
+    expect(evaluator.eval('num >= 0', {num: '0'})).to.be.false;
+    expect(evaluator.eval('num <= 0', {num: '0'})).to.be.false;
+    expect(evaluator.eval('num != 0', {num: '0'})).to.be.true;
   });
 
   it('should evaluate simple string expressions', () => {
-    expect(evaluateAccessExpr('str = "A"', {str: 'A'})).to.be.true;
-    expect(evaluateAccessExpr("str = 'A'", {str: 'A'})).to.be.true;
-    expect(evaluateAccessExpr('str != "A"', {str: 'A'})).to.be.false;
+    expect(evaluator.eval('str = "A"', {str: 'A'})).to.be.true;
+    expect(evaluator.eval("str = 'A'", {str: 'A'})).to.be.true;
+    expect(evaluator.eval('str != "A"', {str: 'A'})).to.be.false;
   });
 
   it('should evaluate string expressions with wrong type', () => {
-    expect(evaluateAccessExpr('str = "A"', {})).to.be.false;
-    expect(evaluateAccessExpr("str = 'A'", {})).to.be.false;
-    expect(evaluateAccessExpr('str != "A"', {})).to.be.true;
+    expect(evaluator.eval('str = "A"', {})).to.be.false;
+    expect(evaluator.eval("str = 'A'", {})).to.be.false;
+    expect(evaluator.eval('str != "A"', {})).to.be.true;
 
-    expect(evaluateAccessExpr('str = "A"', {str: 1})).to.be.false;
-    expect(evaluateAccessExpr("str = 'A'", {str: 1})).to.be.false;
-    expect(evaluateAccessExpr('str != "A"', {str: 1})).to.be.true;
+    expect(evaluator.eval('str = "A"', {str: 1})).to.be.false;
+    expect(evaluator.eval("str = 'A'", {str: 1})).to.be.false;
+    expect(evaluator.eval('str != "A"', {str: 1})).to.be.true;
 
-    expect(evaluateAccessExpr('str = ""', {str: false})).to.be.false;
-    expect(evaluateAccessExpr("str = ''", {str: false})).to.be.false;
-    expect(evaluateAccessExpr('str != ""', {str: false})).to.be.true;
+    expect(evaluator.eval('str = ""', {str: false})).to.be.false;
+    expect(evaluator.eval("str = ''", {str: false})).to.be.false;
+    expect(evaluator.eval('str != ""', {str: false})).to.be.true;
 
-    expect(evaluateAccessExpr('str = "A"', {str: true})).to.be.false;
-    expect(evaluateAccessExpr("str = 'A'", {str: true})).to.be.false;
-    expect(evaluateAccessExpr('str != "A"', {str: true})).to.be.true;
+    expect(evaluator.eval('str = "A"', {str: true})).to.be.false;
+    expect(evaluator.eval("str = 'A'", {str: true})).to.be.false;
+    expect(evaluator.eval('str != "A"', {str: true})).to.be.true;
   });
 
   it('should evaluate simple NULL expressions', () => {
-    expect(evaluateAccessExpr('access = NULL', {})).to.be.true;
-    expect(evaluateAccessExpr('access != NULL', {})).to.be.false;
+    expect(evaluator.eval('access = NULL', {})).to.be.true;
+    expect(evaluator.eval('access != NULL', {})).to.be.false;
 
-    expect(evaluateAccessExpr('access = NULL', {access: null})).to.be.true;
-    expect(evaluateAccessExpr('access != NULL', {access: null})).to.be.false;
+    expect(evaluator.eval('access = NULL', {access: null})).to.be.true;
+    expect(evaluator.eval('access != NULL', {access: null})).to.be.false;
   });
 
   it('should evaluate NULL expressions with wrong type', () => {
-    expect(evaluateAccessExpr('n = NULL', {n: ''})).to.be.false;
-    expect(evaluateAccessExpr('n != NULL', {n: ''})).to.be.true;
+    expect(evaluator.eval('n = NULL', {n: ''})).to.be.false;
+    expect(evaluator.eval('n != NULL', {n: ''})).to.be.true;
 
-    expect(evaluateAccessExpr('n = NULL', {n: 0})).to.be.false;
-    expect(evaluateAccessExpr('n != NULL', {n: 0})).to.be.true;
+    expect(evaluator.eval('n = NULL', {n: 0})).to.be.false;
+    expect(evaluator.eval('n != NULL', {n: 0})).to.be.true;
 
-    expect(evaluateAccessExpr('n = NULL', {n: false})).to.be.false;
-    expect(evaluateAccessExpr('n != NULL', {n: false})).to.be.true;
+    expect(evaluator.eval('n = NULL', {n: false})).to.be.false;
+    expect(evaluator.eval('n != NULL', {n: false})).to.be.true;
   });
 
   it('should evaluate truthy expressions', () => {
-    expect(evaluateAccessExpr('t', {})).to.be.false;
-    expect(evaluateAccessExpr('NOT t', {})).to.be.true;
-    expect(evaluateAccessExpr('t', {t: null})).to.be.false;
-    expect(evaluateAccessExpr('NOT t', {t: null})).to.be.true;
+    expect(evaluator.eval('t', {})).to.be.false;
+    expect(evaluator.eval('NOT t', {})).to.be.true;
+    expect(evaluator.eval('t', {t: null})).to.be.false;
+    expect(evaluator.eval('NOT t', {t: null})).to.be.true;
 
-    expect(evaluateAccessExpr('t', {t: true})).to.be.true;
-    expect(evaluateAccessExpr('NOT t', {t: true})).to.be.false;
-    expect(evaluateAccessExpr('t', {t: false})).to.be.false;
-    expect(evaluateAccessExpr('NOT t', {t: false})).to.be.true;
+    expect(evaluator.eval('t', {t: true})).to.be.true;
+    expect(evaluator.eval('NOT t', {t: true})).to.be.false;
+    expect(evaluator.eval('t', {t: false})).to.be.false;
+    expect(evaluator.eval('NOT t', {t: false})).to.be.true;
 
-    expect(evaluateAccessExpr('t', {t: 1})).to.be.true;
-    expect(evaluateAccessExpr('NOT t', {t: 1})).to.be.false;
-    expect(evaluateAccessExpr('t', {t: 0})).to.be.false;
-    expect(evaluateAccessExpr('NOT t', {t: 0})).to.be.true;
+    expect(evaluator.eval('t', {t: 1})).to.be.true;
+    expect(evaluator.eval('NOT t', {t: 1})).to.be.false;
+    expect(evaluator.eval('t', {t: 0})).to.be.false;
+    expect(evaluator.eval('NOT t', {t: 0})).to.be.true;
 
-    expect(evaluateAccessExpr('t', {t: '1'})).to.be.true;
-    expect(evaluateAccessExpr('NOT t', {t: '1'})).to.be.false;
-    expect(evaluateAccessExpr('t', {t: ''})).to.be.false;
-    expect(evaluateAccessExpr('NOT t', {t: ''})).to.be.true;
+    expect(evaluator.eval('t', {t: '1'})).to.be.true;
+    expect(evaluator.eval('NOT t', {t: '1'})).to.be.false;
+    expect(evaluator.eval('t', {t: ''})).to.be.false;
+    expect(evaluator.eval('NOT t', {t: ''})).to.be.true;
   });
 
   it('should evaluate NOT expressions', () => {
-    expect(evaluateAccessExpr('NOT (access = true)', {})).to.be.true;
+    expect(evaluator.eval('NOT (access = true)', {})).to.be.true;
 
-    expect(evaluateAccessExpr('NOT (access = true)', {access: true})).to.be
-      .false;
-    expect(evaluateAccessExpr('NOT (access = true)', {access: false})).to.be
-      .true;
+    expect(evaluator.eval('NOT (access = true)', {access: true})).to.be.false;
+    expect(evaluator.eval('NOT (access = true)', {access: false})).to.be.true;
 
-    expect(evaluateAccessExpr('NOT (access = 1)', {access: 1})).to.be.false;
-    expect(evaluateAccessExpr('NOT (access = 1)', {access: 0})).to.be.true;
-    expect(evaluateAccessExpr('NOT (access > 1)', {access: 1})).to.be.true;
-    expect(evaluateAccessExpr('NOT (access > 0)', {access: 1})).to.be.false;
+    expect(evaluator.eval('NOT (access = 1)', {access: 1})).to.be.false;
+    expect(evaluator.eval('NOT (access = 1)', {access: 0})).to.be.true;
+    expect(evaluator.eval('NOT (access > 1)', {access: 1})).to.be.true;
+    expect(evaluator.eval('NOT (access > 0)', {access: 1})).to.be.false;
 
-    expect(evaluateAccessExpr('NOT (access = "a")', {access: 'a'})).to.be.false;
-    expect(evaluateAccessExpr('NOT (access = "b")', {access: 'a'})).to.be.true;
+    expect(evaluator.eval('NOT (access = "a")', {access: 'a'})).to.be.false;
+    expect(evaluator.eval('NOT (access = "b")', {access: 'a'})).to.be.true;
   });
 
   it('should evaluate AND/OR expressions', () => {
-    expect(evaluateAccessExpr('a = 1 AND b = 2', {a: 1, b: 2})).to.be.true;
-    expect(evaluateAccessExpr('a = 1 AND b != 2', {a: 1, b: 2})).to.be.false;
+    expect(evaluator.eval('a = 1 AND b = 2', {a: 1, b: 2})).to.be.true;
+    expect(evaluator.eval('a = 1 AND b != 2', {a: 1, b: 2})).to.be.false;
 
-    expect(evaluateAccessExpr('a = 1 OR b = 2', {a: 1, b: 2})).to.be.true;
-    expect(evaluateAccessExpr('a = 1 OR b != 2', {a: 1, b: 2})).to.be.true;
+    expect(evaluator.eval('a = 1 OR b = 2', {a: 1, b: 2})).to.be.true;
+    expect(evaluator.eval('a = 1 OR b != 2', {a: 1, b: 2})).to.be.true;
 
-    expect(evaluateAccessExpr('NOT (a = 1 OR b != 2)', {a: 1, b: 2})).to.be
-      .false;
+    expect(evaluator.eval('NOT (a = 1 OR b != 2)', {a: 1, b: 2})).to.be.false;
 
-    expect(evaluateAccessExpr('a AND b = 2', {a: 1, b: 2})).to.be.true;
-    expect(evaluateAccessExpr('a AND b', {a: 1, b: 2})).to.be.true;
-    expect(evaluateAccessExpr('a AND c', {a: 1, b: 2})).to.be.false;
+    expect(evaluator.eval('a AND b = 2', {a: 1, b: 2})).to.be.true;
+    expect(evaluator.eval('a AND b', {a: 1, b: 2})).to.be.true;
+    expect(evaluator.eval('a AND c', {a: 1, b: 2})).to.be.false;
   });
 
   it('should evaluate nested expressions', () => {
@@ -209,22 +211,22 @@ describe('evaluateAccessExpr', () => {
       },
     };
 
-    expect(evaluateAccessExpr('obj.bool = true', resp)).to.be.true;
-    expect(evaluateAccessExpr('obj.num = 11', resp)).to.be.true;
-    expect(evaluateAccessExpr('obj.str = "A"', resp)).to.be.true;
+    expect(evaluator.eval('obj.bool = true', resp)).to.be.true;
+    expect(evaluator.eval('obj.num = 11', resp)).to.be.true;
+    expect(evaluator.eval('obj.str = "A"', resp)).to.be.true;
 
-    expect(evaluateAccessExpr('obj.other = NULL', resp)).to.be.true;
-    expect(evaluateAccessExpr('obj.str = NULL', resp)).to.be.false;
+    expect(evaluator.eval('obj.other = NULL', resp)).to.be.true;
+    expect(evaluator.eval('obj.str = NULL', resp)).to.be.false;
 
-    expect(evaluateAccessExpr('obj.bool', resp)).to.be.true;
-    expect(evaluateAccessExpr('obj.str', resp)).to.be.true;
-    expect(evaluateAccessExpr('obj.num', resp)).to.be.true;
-    expect(evaluateAccessExpr('obj.other', resp)).to.be.false;
+    expect(evaluator.eval('obj.bool', resp)).to.be.true;
+    expect(evaluator.eval('obj.str', resp)).to.be.true;
+    expect(evaluator.eval('obj.num', resp)).to.be.true;
+    expect(evaluator.eval('obj.other', resp)).to.be.false;
 
-    expect(evaluateAccessExpr('NOT obj.bool', resp)).to.be.false;
-    expect(evaluateAccessExpr('NOT obj.str', resp)).to.be.false;
-    expect(evaluateAccessExpr('NOT obj.num', resp)).to.be.false;
-    expect(evaluateAccessExpr('NOT obj.other', resp)).to.be.true;
+    expect(evaluator.eval('NOT obj.bool', resp)).to.be.false;
+    expect(evaluator.eval('NOT obj.str', resp)).to.be.false;
+    expect(evaluator.eval('NOT obj.num', resp)).to.be.false;
+    expect(evaluator.eval('NOT obj.other', resp)).to.be.true;
   });
 
   it('should shortcircuit nested expressions with missing parent', () => {
@@ -237,13 +239,13 @@ describe('evaluateAccessExpr', () => {
       },
     };
 
-    expect(evaluateAccessExpr('obj.str = "A"', resp)).to.be.true;
-    expect(evaluateAccessExpr('obj.child.str = "B"', resp)).to.be.true;
-    expect(evaluateAccessExpr('obj.child.other = NULL', resp)).to.be.true;
-    expect(evaluateAccessExpr('obj.child2 = NULL', resp)).to.be.true;
-    expect(evaluateAccessExpr('obj.child2.other = NULL', resp)).to.be.true;
-    expect(evaluateAccessExpr('obj.child2.other.x = NULL', resp)).to.be.true;
-    expect(evaluateAccessExpr('obj2.child2.other.x = NULL', resp)).to.be.true;
+    expect(evaluator.eval('obj.str = "A"', resp)).to.be.true;
+    expect(evaluator.eval('obj.child.str = "B"', resp)).to.be.true;
+    expect(evaluator.eval('obj.child.other = NULL', resp)).to.be.true;
+    expect(evaluator.eval('obj.child2 = NULL', resp)).to.be.true;
+    expect(evaluator.eval('obj.child2.other = NULL', resp)).to.be.true;
+    expect(evaluator.eval('obj.child2.other.x = NULL', resp)).to.be.true;
+    expect(evaluator.eval('obj2.child2.other.x = NULL', resp)).to.be.true;
   });
 
   it('should evaluate nested expressions with brackets', () => {
@@ -258,93 +260,91 @@ describe('evaluateAccessExpr', () => {
       },
     };
 
-    expect(evaluateAccessExpr('obj["bool"] = true', resp)).to.be.true;
-    expect(evaluateAccessExpr('obj["a bool"] = true', resp)).to.be.true;
-    expect(evaluateAccessExpr('obj["num"] = 11', resp)).to.be.true;
-    expect(evaluateAccessExpr('obj["a num"] = 11', resp)).to.be.true;
-    expect(evaluateAccessExpr('obj["str"] = "A"', resp)).to.be.true;
-    expect(evaluateAccessExpr('obj["a str"] = "A"', resp)).to.be.true;
+    expect(evaluator.eval('obj["bool"] = true', resp)).to.be.true;
+    expect(evaluator.eval('obj["a bool"] = true', resp)).to.be.true;
+    expect(evaluator.eval('obj["num"] = 11', resp)).to.be.true;
+    expect(evaluator.eval('obj["a num"] = 11', resp)).to.be.true;
+    expect(evaluator.eval('obj["str"] = "A"', resp)).to.be.true;
+    expect(evaluator.eval('obj["a str"] = "A"', resp)).to.be.true;
 
-    expect(evaluateAccessExpr("obj['bool'] = true", resp)).to.be.true;
-    expect(evaluateAccessExpr("obj['a bool'] = true", resp)).to.be.true;
-    expect(evaluateAccessExpr("obj['num'] = 11", resp)).to.be.true;
-    expect(evaluateAccessExpr("obj['a num'] = 11", resp)).to.be.true;
-    expect(evaluateAccessExpr("obj['str'] = 'A'", resp)).to.be.true;
-    expect(evaluateAccessExpr("obj['a str'] = 'A'", resp)).to.be.true;
+    expect(evaluator.eval("obj['bool'] = true", resp)).to.be.true;
+    expect(evaluator.eval("obj['a bool'] = true", resp)).to.be.true;
+    expect(evaluator.eval("obj['num'] = 11", resp)).to.be.true;
+    expect(evaluator.eval("obj['a num'] = 11", resp)).to.be.true;
+    expect(evaluator.eval("obj['str'] = 'A'", resp)).to.be.true;
+    expect(evaluator.eval("obj['a str'] = 'A'", resp)).to.be.true;
 
-    expect(evaluateAccessExpr('obj["other"] = NULL', resp)).to.be.true;
-    expect(evaluateAccessExpr('obj["a other"] = NULL', resp)).to.be.true;
-    expect(evaluateAccessExpr('obj["str"] = NULL', resp)).to.be.false;
-    expect(evaluateAccessExpr('obj["a str"] = NULL', resp)).to.be.false;
+    expect(evaluator.eval('obj["other"] = NULL', resp)).to.be.true;
+    expect(evaluator.eval('obj["a other"] = NULL', resp)).to.be.true;
+    expect(evaluator.eval('obj["str"] = NULL', resp)).to.be.false;
+    expect(evaluator.eval('obj["a str"] = NULL', resp)).to.be.false;
 
-    expect(evaluateAccessExpr('obj["bool"]', resp)).to.be.true;
-    expect(evaluateAccessExpr('obj["a bool"]', resp)).to.be.true;
-    expect(evaluateAccessExpr('obj["str"]', resp)).to.be.true;
-    expect(evaluateAccessExpr('obj["a str"]', resp)).to.be.true;
-    expect(evaluateAccessExpr('obj["num"]', resp)).to.be.true;
-    expect(evaluateAccessExpr('obj["a num"]', resp)).to.be.true;
-    expect(evaluateAccessExpr('obj["other"]', resp)).to.be.false;
-    expect(evaluateAccessExpr('obj["a other"]', resp)).to.be.false;
+    expect(evaluator.eval('obj["bool"]', resp)).to.be.true;
+    expect(evaluator.eval('obj["a bool"]', resp)).to.be.true;
+    expect(evaluator.eval('obj["str"]', resp)).to.be.true;
+    expect(evaluator.eval('obj["a str"]', resp)).to.be.true;
+    expect(evaluator.eval('obj["num"]', resp)).to.be.true;
+    expect(evaluator.eval('obj["a num"]', resp)).to.be.true;
+    expect(evaluator.eval('obj["other"]', resp)).to.be.false;
+    expect(evaluator.eval('obj["a other"]', resp)).to.be.false;
 
-    expect(evaluateAccessExpr('NOT obj["bool"]', resp)).to.be.false;
-    expect(evaluateAccessExpr('NOT obj["a bool"]', resp)).to.be.false;
-    expect(evaluateAccessExpr('NOT obj["str"]', resp)).to.be.false;
-    expect(evaluateAccessExpr('NOT obj["a str"]', resp)).to.be.false;
-    expect(evaluateAccessExpr('NOT obj["num"]', resp)).to.be.false;
-    expect(evaluateAccessExpr('NOT obj["a num"]', resp)).to.be.false;
-    expect(evaluateAccessExpr('NOT obj["other"]', resp)).to.be.true;
-    expect(evaluateAccessExpr('NOT obj["a other"]', resp)).to.be.true;
+    expect(evaluator.eval('NOT obj["bool"]', resp)).to.be.false;
+    expect(evaluator.eval('NOT obj["a bool"]', resp)).to.be.false;
+    expect(evaluator.eval('NOT obj["str"]', resp)).to.be.false;
+    expect(evaluator.eval('NOT obj["a str"]', resp)).to.be.false;
+    expect(evaluator.eval('NOT obj["num"]', resp)).to.be.false;
+    expect(evaluator.eval('NOT obj["a num"]', resp)).to.be.false;
+    expect(evaluator.eval('NOT obj["other"]', resp)).to.be.true;
+    expect(evaluator.eval('NOT obj["a other"]', resp)).to.be.true;
 
-    expect(evaluateAccessExpr('obj2["bool"] = NULL', resp)).to.be.true;
+    expect(evaluator.eval('obj2["bool"] = NULL', resp)).to.be.true;
   });
 
   it('should NOT evaluate nested expressions with wrong type', function() {
-    expect(evaluateAccessExpr('obj.bool = true', {obj: true})).to.be.false;
-    expect(evaluateAccessExpr('obj.num = 11', {obj: 11})).to.be.false;
-    expect(evaluateAccessExpr('obj.str = "A"', {obj: 'A'})).to.be.false;
-    expect(evaluateAccessExpr('obj.str = "A"', {})).to.be.false;
+    expect(evaluator.eval('obj.bool = true', {obj: true})).to.be.false;
+    expect(evaluator.eval('obj.num = 11', {obj: 11})).to.be.false;
+    expect(evaluator.eval('obj.str = "A"', {obj: 'A'})).to.be.false;
+    expect(evaluator.eval('obj.str = "A"', {})).to.be.false;
 
-    expect(evaluateAccessExpr('obj.other = NULL', {obj: 11})).to.be.true;
+    expect(evaluator.eval('obj.other = NULL', {obj: 11})).to.be.true;
 
     expect(() => {
-      evaluateAccessExpr('obj.NULL', {});
+      evaluator.eval('obj.NULL', {});
     }).to.throw();
     expect(() => {
-      evaluateAccessExpr('NULL.obj', {});
+      evaluator.eval('NULL.obj', {});
     }).to.throw();
     expect(() => {
-      evaluateAccessExpr('1.obj', {});
+      evaluator.eval('1.obj', {});
     }).to.throw();
     expect(() => {
-      evaluateAccessExpr('TRUE.obj', {});
+      evaluator.eval('TRUE.obj', {});
     }).to.throw();
   });
 
   it('should evaluate nested expressions securely', () => {
-    expect(evaluateAccessExpr('obj.__bool__ = NULL', {obj: {}})).to.be.true;
+    expect(evaluator.eval('obj.__bool__ = NULL', {obj: {}})).to.be.true;
   });
 
   it('should accept name grammar', () => {
-    expect(evaluateAccessExpr('num = 10', {num: 10})).to.be.true;
-    expect(evaluateAccessExpr('num1 = 10', {num1: 10})).to.be.true;
-    expect(evaluateAccessExpr('num_ = 10', {num_: 10})).to.be.true;
-    expect(evaluateAccessExpr('_num = 10', {_num: 10})).to.be.true;
+    expect(evaluator.eval('num = 10', {num: 10})).to.be.true;
+    expect(evaluator.eval('num1 = 10', {num1: 10})).to.be.true;
+    expect(evaluator.eval('num_ = 10', {num_: 10})).to.be.true;
+    expect(evaluator.eval('_num = 10', {_num: 10})).to.be.true;
 
     expect(() => {
-      evaluateAccessExpr('1num = 10', {'1num': 10});
+      evaluator.eval('1num = 10', {'1num': 10});
     }).to.throw();
     expect(() => {
-      evaluateAccessExpr('num-a = 10', {'num-a': 10});
+      evaluator.eval('num-a = 10', {'num-a': 10});
     }).to.throw();
     expect(() => {
-      evaluateAccessExpr('num-1 = 10', {'num-1': 10});
+      evaluator.eval('num-1 = 10', {'num-1': 10});
     }).to.throw();
   });
 
-  describe('AmpAccessEvaluator', () => {
-    let evaluator;
+  describe('caching', () => {
     beforeEach(() => {
-      evaluator = new AmpAccessEvaluator();
       window.sandbox.spy(evaluator, 'eval_');
     });
 

--- a/extensions/amp-access/0.1/test/test-access-expr.js
+++ b/extensions/amp-access/0.1/test/test-access-expr.js
@@ -176,8 +176,10 @@ describe('evaluate', () => {
   it('should evaluate NOT expressions', () => {
     expect(evaluator.evaluate('NOT (access = true)', {})).to.be.true;
 
-    expect(evaluator.evaluate('NOT (access = true)', {access: true})).to.be.false;
-    expect(evaluator.evaluate('NOT (access = true)', {access: false})).to.be.true;
+    expect(evaluator.evaluate('NOT (access = true)', {access: true})).to.be
+      .false;
+    expect(evaluator.evaluate('NOT (access = true)', {access: false})).to.be
+      .true;
 
     expect(evaluator.evaluate('NOT (access = 1)', {access: 1})).to.be.false;
     expect(evaluator.evaluate('NOT (access = 1)', {access: 0})).to.be.true;
@@ -195,7 +197,8 @@ describe('evaluate', () => {
     expect(evaluator.evaluate('a = 1 OR b = 2', {a: 1, b: 2})).to.be.true;
     expect(evaluator.evaluate('a = 1 OR b != 2', {a: 1, b: 2})).to.be.true;
 
-    expect(evaluator.evaluate('NOT (a = 1 OR b != 2)', {a: 1, b: 2})).to.be.false;
+    expect(evaluator.evaluate('NOT (a = 1 OR b != 2)', {a: 1, b: 2})).to.be
+      .false;
 
     expect(evaluator.evaluate('a AND b = 2', {a: 1, b: 2})).to.be.true;
     expect(evaluator.evaluate('a AND b', {a: 1, b: 2})).to.be.true;

--- a/extensions/amp-access/0.1/test/test-access-expr.js
+++ b/extensions/amp-access/0.1/test/test-access-expr.js
@@ -14,9 +14,11 @@
  * limitations under the License.
  */
 
-import {evaluateAccessExpr} from '../access-expr';
+import * as accessExpr from '../access-expr';
 
 describe('evaluateAccessExpr', () => {
+  let evaluateAccessExpr = accessExpr.evaluateAccessExpr;
+
   it('should NOT allow double equal', () => {
     expect(() => {
       evaluateAccessExpr('access == true', {});
@@ -339,5 +341,29 @@ describe('evaluateAccessExpr', () => {
     expect(() => {
       evaluateAccessExpr('num-1 = 10', {'num-1': 10});
     }).to.throw();
+  });
+
+  describe('AmpAccessEvaluator', () => {
+    let evaluator;
+    beforeEach(() => {
+      window.sandbox.stub(accessExpr, 'evaluateAccessExpr');
+      evaluator = new accessExpr.AmpAccessEvaluator();
+    });
+
+    it('first request should go through', () => {
+      expect(evaluator.eval('access = true', {access: true})).to.be.true;
+    });
+
+    it('should use the cache on subsequent calls for the same expression', () => {
+      evaluator.eval('access = true', {access: true});
+      evaluator.eval('access = true', {access: true});
+      expect(accessExpr.evaluateAccessExpr.calls.length).to.be(1);
+    });
+
+    it('should not use the cache on subsequent calls for the same expression if the data has changed', () => {
+      evaluator.eval('access = true', {access: true});
+      evaluator.eval('access = true', {access: false});
+      expect(accessExpr.evaluateAccessExpr.calls.length).to.be(2);
+    });
   });
 });

--- a/extensions/amp-access/0.1/test/test-access-expr.js
+++ b/extensions/amp-access/0.1/test/test-access-expr.js
@@ -14,11 +14,9 @@
  * limitations under the License.
  */
 
-import * as accessExpr from '../access-expr';
+import {AmpAccessEvaluator, evaluateAccessExpr} from '../access-expr';
 
-describe('evaluateAccessExpr', () => {
-  let evaluateAccessExpr = accessExpr.evaluateAccessExpr;
-
+describe('evaluateAccessExpr', () => { 
   it('should NOT allow double equal', () => {
     expect(() => {
       evaluateAccessExpr('access == true', {});
@@ -346,24 +344,25 @@ describe('evaluateAccessExpr', () => {
   describe.only('AmpAccessEvaluator', () => {
     let evaluator;
     beforeEach(() => {
-      window.sandbox.stub(accessExpr, 'evaluateAccessExpr');
-      evaluator = new accessExpr.AmpAccessEvaluator();
+      evaluator = new AmpAccessEvaluator();
+      window.sandbox.spy(evaluator, 'eval_');
     });
 
     it('first request should go through', () => {
       expect(evaluator.eval('access = true', {access: true})).to.be.true;
+      expect(evaluator.eval_.callCount).to.equal(1);
     });
 
     it('should use the cache on subsequent calls for the same expression', () => {
       evaluator.eval('access = true', {access: true});
       evaluator.eval('access = true', {access: true});
-      expect(accessExpr.evaluateAccessExpr.calls.length).to.be(1);
+      expect(evaluator.eval_.callCount).to.equal(1);
     });
 
     it('should not use the cache on subsequent calls for the same expression if the data has changed', () => {
       evaluator.eval('access = true', {access: true});
       evaluator.eval('access = true', {access: false});
-      expect(accessExpr.evaluateAccessExpr.calls.length).to.be(2);
+      expect(evaluator.eval_.callCount).to.equal(2);
     });
   });
 });

--- a/extensions/amp-access/0.1/test/test-access-expr.js
+++ b/extensions/amp-access/0.1/test/test-access-expr.js
@@ -24,182 +24,182 @@ describe('evaluate', () => {
 
   it('should NOT allow double equal', () => {
     expect(() => {
-      evaluator.eval('access == true', {});
+      evaluator.evaluate('access == true', {});
     }).to.throw(/\"\=\=\" is not allowed, use \"\=\"/);
   });
 
   it('should evaluate simple boolean expressions', () => {
-    expect(evaluator.eval('access = true', {access: true})).to.be.true;
-    expect(evaluator.eval('access = TRUE', {access: true})).to.be.true;
-    expect(evaluator.eval('access = false', {access: true})).to.be.false;
-    expect(evaluator.eval('access = FALSE', {access: true})).to.be.false;
-    expect(evaluator.eval('access != false', {access: true})).to.be.true;
+    expect(evaluator.evaluate('access = true', {access: true})).to.be.true;
+    expect(evaluator.evaluate('access = TRUE', {access: true})).to.be.true;
+    expect(evaluator.evaluate('access = false', {access: true})).to.be.false;
+    expect(evaluator.evaluate('access = FALSE', {access: true})).to.be.false;
+    expect(evaluator.evaluate('access != false', {access: true})).to.be.true;
 
-    expect(evaluator.eval('access = FALSE', {access: false})).to.be.true;
-    expect(evaluator.eval('access != TRUE', {access: false})).to.be.true;
-    expect(evaluator.eval('access = TRUE', {access: false})).to.be.false;
+    expect(evaluator.evaluate('access = FALSE', {access: false})).to.be.true;
+    expect(evaluator.evaluate('access != TRUE', {access: false})).to.be.true;
+    expect(evaluator.evaluate('access = TRUE', {access: false})).to.be.false;
   });
 
   it('should evaluate boolean expressions over undefined', () => {
-    expect(evaluator.eval('access = true', {})).to.be.false;
-    expect(evaluator.eval('access != true', {})).to.be.true;
+    expect(evaluator.evaluate('access = true', {})).to.be.false;
+    expect(evaluator.evaluate('access != true', {})).to.be.true;
 
-    expect(evaluator.eval('access = false', {})).to.be.false;
-    expect(evaluator.eval('access != false', {})).to.be.true;
+    expect(evaluator.evaluate('access = false', {})).to.be.false;
+    expect(evaluator.evaluate('access != false', {})).to.be.true;
   });
 
   it('should evaluate simple numeric expressions', () => {
-    expect(evaluator.eval('num = 1', {num: 1})).to.be.true;
-    expect(evaluator.eval('num > 1', {num: 1})).to.be.false;
-    expect(evaluator.eval('num < 1', {num: 1})).to.be.false;
-    expect(evaluator.eval('num >= 1', {num: 1})).to.be.true;
-    expect(evaluator.eval('num <= 1', {num: 1})).to.be.true;
+    expect(evaluator.evaluate('num = 1', {num: 1})).to.be.true;
+    expect(evaluator.evaluate('num > 1', {num: 1})).to.be.false;
+    expect(evaluator.evaluate('num < 1', {num: 1})).to.be.false;
+    expect(evaluator.evaluate('num >= 1', {num: 1})).to.be.true;
+    expect(evaluator.evaluate('num <= 1', {num: 1})).to.be.true;
   });
 
   it('should evaluate negative numerics', () => {
-    expect(evaluator.eval('num = -1', {num: -1})).to.be.true;
-    expect(evaluator.eval('num = -1', {num: 0})).to.be.false;
-    expect(evaluator.eval('num < -1', {num: -1})).to.be.false;
-    expect(evaluator.eval('num < -1', {num: -2})).to.be.true;
-    expect(evaluator.eval('num > -1', {num: 0})).to.be.true;
+    expect(evaluator.evaluate('num = -1', {num: -1})).to.be.true;
+    expect(evaluator.evaluate('num = -1', {num: 0})).to.be.false;
+    expect(evaluator.evaluate('num < -1', {num: -1})).to.be.false;
+    expect(evaluator.evaluate('num < -1', {num: -2})).to.be.true;
+    expect(evaluator.evaluate('num > -1', {num: 0})).to.be.true;
   });
 
   it('should evaluate numeric expressions over mistamtching type', () => {
-    expect(evaluator.eval('num = 1', {})).to.be.false;
-    expect(evaluator.eval('num > 1', {})).to.be.false;
-    expect(evaluator.eval('num < 1', {})).to.be.false;
-    expect(evaluator.eval('num >= 1', {})).to.be.false;
-    expect(evaluator.eval('num <= 1', {})).to.be.false;
-    expect(evaluator.eval('num != 1', {})).to.be.true;
+    expect(evaluator.evaluate('num = 1', {})).to.be.false;
+    expect(evaluator.evaluate('num > 1', {})).to.be.false;
+    expect(evaluator.evaluate('num < 1', {})).to.be.false;
+    expect(evaluator.evaluate('num >= 1', {})).to.be.false;
+    expect(evaluator.evaluate('num <= 1', {})).to.be.false;
+    expect(evaluator.evaluate('num != 1', {})).to.be.true;
 
-    expect(evaluator.eval('num = 0', {num: 0})).to.be.true;
-    expect(evaluator.eval('num > 0', {num: 0})).to.be.false;
-    expect(evaluator.eval('num < 0', {num: 0})).to.be.false;
-    expect(evaluator.eval('num >= 0', {num: 0})).to.be.true;
-    expect(evaluator.eval('num <= 0', {num: 0})).to.be.true;
-    expect(evaluator.eval('num != 0', {num: 0})).to.be.false;
+    expect(evaluator.evaluate('num = 0', {num: 0})).to.be.true;
+    expect(evaluator.evaluate('num > 0', {num: 0})).to.be.false;
+    expect(evaluator.evaluate('num < 0', {num: 0})).to.be.false;
+    expect(evaluator.evaluate('num >= 0', {num: 0})).to.be.true;
+    expect(evaluator.evaluate('num <= 0', {num: 0})).to.be.true;
+    expect(evaluator.evaluate('num != 0', {num: 0})).to.be.false;
 
-    expect(evaluator.eval('num = 0', {})).to.be.false;
-    expect(evaluator.eval('num > 0', {})).to.be.false;
-    expect(evaluator.eval('num < 0', {})).to.be.false;
-    expect(evaluator.eval('num >= 0', {})).to.be.false;
-    expect(evaluator.eval('num <= 0', {})).to.be.false;
-    expect(evaluator.eval('num != 0', {})).to.be.true;
+    expect(evaluator.evaluate('num = 0', {})).to.be.false;
+    expect(evaluator.evaluate('num > 0', {})).to.be.false;
+    expect(evaluator.evaluate('num < 0', {})).to.be.false;
+    expect(evaluator.evaluate('num >= 0', {})).to.be.false;
+    expect(evaluator.evaluate('num <= 0', {})).to.be.false;
+    expect(evaluator.evaluate('num != 0', {})).to.be.true;
 
-    expect(evaluator.eval('num = 0', {num: false})).to.be.false;
-    expect(evaluator.eval('num > 0', {num: false})).to.be.false;
-    expect(evaluator.eval('num < 0', {num: false})).to.be.false;
-    expect(evaluator.eval('num >= 0', {num: false})).to.be.false;
-    expect(evaluator.eval('num <= 0', {num: false})).to.be.false;
-    expect(evaluator.eval('num != 0', {num: false})).to.be.true;
+    expect(evaluator.evaluate('num = 0', {num: false})).to.be.false;
+    expect(evaluator.evaluate('num > 0', {num: false})).to.be.false;
+    expect(evaluator.evaluate('num < 0', {num: false})).to.be.false;
+    expect(evaluator.evaluate('num >= 0', {num: false})).to.be.false;
+    expect(evaluator.evaluate('num <= 0', {num: false})).to.be.false;
+    expect(evaluator.evaluate('num != 0', {num: false})).to.be.true;
 
-    expect(evaluator.eval('num = 0', {num: ''})).to.be.false;
-    expect(evaluator.eval('num > 0', {num: ''})).to.be.false;
-    expect(evaluator.eval('num < 0', {num: ''})).to.be.false;
-    expect(evaluator.eval('num >= 0', {num: ''})).to.be.false;
-    expect(evaluator.eval('num <= 0', {num: ''})).to.be.false;
-    expect(evaluator.eval('num != 0', {num: ''})).to.be.true;
+    expect(evaluator.evaluate('num = 0', {num: ''})).to.be.false;
+    expect(evaluator.evaluate('num > 0', {num: ''})).to.be.false;
+    expect(evaluator.evaluate('num < 0', {num: ''})).to.be.false;
+    expect(evaluator.evaluate('num >= 0', {num: ''})).to.be.false;
+    expect(evaluator.evaluate('num <= 0', {num: ''})).to.be.false;
+    expect(evaluator.evaluate('num != 0', {num: ''})).to.be.true;
 
-    expect(evaluator.eval('num = 0', {num: '0'})).to.be.false;
-    expect(evaluator.eval('num > 0', {num: '0'})).to.be.false;
-    expect(evaluator.eval('num < 0', {num: '0'})).to.be.false;
-    expect(evaluator.eval('num >= 0', {num: '0'})).to.be.false;
-    expect(evaluator.eval('num <= 0', {num: '0'})).to.be.false;
-    expect(evaluator.eval('num != 0', {num: '0'})).to.be.true;
+    expect(evaluator.evaluate('num = 0', {num: '0'})).to.be.false;
+    expect(evaluator.evaluate('num > 0', {num: '0'})).to.be.false;
+    expect(evaluator.evaluate('num < 0', {num: '0'})).to.be.false;
+    expect(evaluator.evaluate('num >= 0', {num: '0'})).to.be.false;
+    expect(evaluator.evaluate('num <= 0', {num: '0'})).to.be.false;
+    expect(evaluator.evaluate('num != 0', {num: '0'})).to.be.true;
   });
 
   it('should evaluate simple string expressions', () => {
-    expect(evaluator.eval('str = "A"', {str: 'A'})).to.be.true;
-    expect(evaluator.eval("str = 'A'", {str: 'A'})).to.be.true;
-    expect(evaluator.eval('str != "A"', {str: 'A'})).to.be.false;
+    expect(evaluator.evaluate('str = "A"', {str: 'A'})).to.be.true;
+    expect(evaluator.evaluate("str = 'A'", {str: 'A'})).to.be.true;
+    expect(evaluator.evaluate('str != "A"', {str: 'A'})).to.be.false;
   });
 
   it('should evaluate string expressions with wrong type', () => {
-    expect(evaluator.eval('str = "A"', {})).to.be.false;
-    expect(evaluator.eval("str = 'A'", {})).to.be.false;
-    expect(evaluator.eval('str != "A"', {})).to.be.true;
+    expect(evaluator.evaluate('str = "A"', {})).to.be.false;
+    expect(evaluator.evaluate("str = 'A'", {})).to.be.false;
+    expect(evaluator.evaluate('str != "A"', {})).to.be.true;
 
-    expect(evaluator.eval('str = "A"', {str: 1})).to.be.false;
-    expect(evaluator.eval("str = 'A'", {str: 1})).to.be.false;
-    expect(evaluator.eval('str != "A"', {str: 1})).to.be.true;
+    expect(evaluator.evaluate('str = "A"', {str: 1})).to.be.false;
+    expect(evaluator.evaluate("str = 'A'", {str: 1})).to.be.false;
+    expect(evaluator.evaluate('str != "A"', {str: 1})).to.be.true;
 
-    expect(evaluator.eval('str = ""', {str: false})).to.be.false;
-    expect(evaluator.eval("str = ''", {str: false})).to.be.false;
-    expect(evaluator.eval('str != ""', {str: false})).to.be.true;
+    expect(evaluator.evaluate('str = ""', {str: false})).to.be.false;
+    expect(evaluator.evaluate("str = ''", {str: false})).to.be.false;
+    expect(evaluator.evaluate('str != ""', {str: false})).to.be.true;
 
-    expect(evaluator.eval('str = "A"', {str: true})).to.be.false;
-    expect(evaluator.eval("str = 'A'", {str: true})).to.be.false;
-    expect(evaluator.eval('str != "A"', {str: true})).to.be.true;
+    expect(evaluator.evaluate('str = "A"', {str: true})).to.be.false;
+    expect(evaluator.evaluate("str = 'A'", {str: true})).to.be.false;
+    expect(evaluator.evaluate('str != "A"', {str: true})).to.be.true;
   });
 
   it('should evaluate simple NULL expressions', () => {
-    expect(evaluator.eval('access = NULL', {})).to.be.true;
-    expect(evaluator.eval('access != NULL', {})).to.be.false;
+    expect(evaluator.evaluate('access = NULL', {})).to.be.true;
+    expect(evaluator.evaluate('access != NULL', {})).to.be.false;
 
-    expect(evaluator.eval('access = NULL', {access: null})).to.be.true;
-    expect(evaluator.eval('access != NULL', {access: null})).to.be.false;
+    expect(evaluator.evaluate('access = NULL', {access: null})).to.be.true;
+    expect(evaluator.evaluate('access != NULL', {access: null})).to.be.false;
   });
 
   it('should evaluate NULL expressions with wrong type', () => {
-    expect(evaluator.eval('n = NULL', {n: ''})).to.be.false;
-    expect(evaluator.eval('n != NULL', {n: ''})).to.be.true;
+    expect(evaluator.evaluate('n = NULL', {n: ''})).to.be.false;
+    expect(evaluator.evaluate('n != NULL', {n: ''})).to.be.true;
 
-    expect(evaluator.eval('n = NULL', {n: 0})).to.be.false;
-    expect(evaluator.eval('n != NULL', {n: 0})).to.be.true;
+    expect(evaluator.evaluate('n = NULL', {n: 0})).to.be.false;
+    expect(evaluator.evaluate('n != NULL', {n: 0})).to.be.true;
 
-    expect(evaluator.eval('n = NULL', {n: false})).to.be.false;
-    expect(evaluator.eval('n != NULL', {n: false})).to.be.true;
+    expect(evaluator.evaluate('n = NULL', {n: false})).to.be.false;
+    expect(evaluator.evaluate('n != NULL', {n: false})).to.be.true;
   });
 
   it('should evaluate truthy expressions', () => {
-    expect(evaluator.eval('t', {})).to.be.false;
-    expect(evaluator.eval('NOT t', {})).to.be.true;
-    expect(evaluator.eval('t', {t: null})).to.be.false;
-    expect(evaluator.eval('NOT t', {t: null})).to.be.true;
+    expect(evaluator.evaluate('t', {})).to.be.false;
+    expect(evaluator.evaluate('NOT t', {})).to.be.true;
+    expect(evaluator.evaluate('t', {t: null})).to.be.false;
+    expect(evaluator.evaluate('NOT t', {t: null})).to.be.true;
 
-    expect(evaluator.eval('t', {t: true})).to.be.true;
-    expect(evaluator.eval('NOT t', {t: true})).to.be.false;
-    expect(evaluator.eval('t', {t: false})).to.be.false;
-    expect(evaluator.eval('NOT t', {t: false})).to.be.true;
+    expect(evaluator.evaluate('t', {t: true})).to.be.true;
+    expect(evaluator.evaluate('NOT t', {t: true})).to.be.false;
+    expect(evaluator.evaluate('t', {t: false})).to.be.false;
+    expect(evaluator.evaluate('NOT t', {t: false})).to.be.true;
 
-    expect(evaluator.eval('t', {t: 1})).to.be.true;
-    expect(evaluator.eval('NOT t', {t: 1})).to.be.false;
-    expect(evaluator.eval('t', {t: 0})).to.be.false;
-    expect(evaluator.eval('NOT t', {t: 0})).to.be.true;
+    expect(evaluator.evaluate('t', {t: 1})).to.be.true;
+    expect(evaluator.evaluate('NOT t', {t: 1})).to.be.false;
+    expect(evaluator.evaluate('t', {t: 0})).to.be.false;
+    expect(evaluator.evaluate('NOT t', {t: 0})).to.be.true;
 
-    expect(evaluator.eval('t', {t: '1'})).to.be.true;
-    expect(evaluator.eval('NOT t', {t: '1'})).to.be.false;
-    expect(evaluator.eval('t', {t: ''})).to.be.false;
-    expect(evaluator.eval('NOT t', {t: ''})).to.be.true;
+    expect(evaluator.evaluate('t', {t: '1'})).to.be.true;
+    expect(evaluator.evaluate('NOT t', {t: '1'})).to.be.false;
+    expect(evaluator.evaluate('t', {t: ''})).to.be.false;
+    expect(evaluator.evaluate('NOT t', {t: ''})).to.be.true;
   });
 
   it('should evaluate NOT expressions', () => {
-    expect(evaluator.eval('NOT (access = true)', {})).to.be.true;
+    expect(evaluator.evaluate('NOT (access = true)', {})).to.be.true;
 
-    expect(evaluator.eval('NOT (access = true)', {access: true})).to.be.false;
-    expect(evaluator.eval('NOT (access = true)', {access: false})).to.be.true;
+    expect(evaluator.evaluate('NOT (access = true)', {access: true})).to.be.false;
+    expect(evaluator.evaluate('NOT (access = true)', {access: false})).to.be.true;
 
-    expect(evaluator.eval('NOT (access = 1)', {access: 1})).to.be.false;
-    expect(evaluator.eval('NOT (access = 1)', {access: 0})).to.be.true;
-    expect(evaluator.eval('NOT (access > 1)', {access: 1})).to.be.true;
-    expect(evaluator.eval('NOT (access > 0)', {access: 1})).to.be.false;
+    expect(evaluator.evaluate('NOT (access = 1)', {access: 1})).to.be.false;
+    expect(evaluator.evaluate('NOT (access = 1)', {access: 0})).to.be.true;
+    expect(evaluator.evaluate('NOT (access > 1)', {access: 1})).to.be.true;
+    expect(evaluator.evaluate('NOT (access > 0)', {access: 1})).to.be.false;
 
-    expect(evaluator.eval('NOT (access = "a")', {access: 'a'})).to.be.false;
-    expect(evaluator.eval('NOT (access = "b")', {access: 'a'})).to.be.true;
+    expect(evaluator.evaluate('NOT (access = "a")', {access: 'a'})).to.be.false;
+    expect(evaluator.evaluate('NOT (access = "b")', {access: 'a'})).to.be.true;
   });
 
   it('should evaluate AND/OR expressions', () => {
-    expect(evaluator.eval('a = 1 AND b = 2', {a: 1, b: 2})).to.be.true;
-    expect(evaluator.eval('a = 1 AND b != 2', {a: 1, b: 2})).to.be.false;
+    expect(evaluator.evaluate('a = 1 AND b = 2', {a: 1, b: 2})).to.be.true;
+    expect(evaluator.evaluate('a = 1 AND b != 2', {a: 1, b: 2})).to.be.false;
 
-    expect(evaluator.eval('a = 1 OR b = 2', {a: 1, b: 2})).to.be.true;
-    expect(evaluator.eval('a = 1 OR b != 2', {a: 1, b: 2})).to.be.true;
+    expect(evaluator.evaluate('a = 1 OR b = 2', {a: 1, b: 2})).to.be.true;
+    expect(evaluator.evaluate('a = 1 OR b != 2', {a: 1, b: 2})).to.be.true;
 
-    expect(evaluator.eval('NOT (a = 1 OR b != 2)', {a: 1, b: 2})).to.be.false;
+    expect(evaluator.evaluate('NOT (a = 1 OR b != 2)', {a: 1, b: 2})).to.be.false;
 
-    expect(evaluator.eval('a AND b = 2', {a: 1, b: 2})).to.be.true;
-    expect(evaluator.eval('a AND b', {a: 1, b: 2})).to.be.true;
-    expect(evaluator.eval('a AND c', {a: 1, b: 2})).to.be.false;
+    expect(evaluator.evaluate('a AND b = 2', {a: 1, b: 2})).to.be.true;
+    expect(evaluator.evaluate('a AND b', {a: 1, b: 2})).to.be.true;
+    expect(evaluator.evaluate('a AND c', {a: 1, b: 2})).to.be.false;
   });
 
   it('should evaluate nested expressions', () => {
@@ -211,22 +211,22 @@ describe('evaluate', () => {
       },
     };
 
-    expect(evaluator.eval('obj.bool = true', resp)).to.be.true;
-    expect(evaluator.eval('obj.num = 11', resp)).to.be.true;
-    expect(evaluator.eval('obj.str = "A"', resp)).to.be.true;
+    expect(evaluator.evaluate('obj.bool = true', resp)).to.be.true;
+    expect(evaluator.evaluate('obj.num = 11', resp)).to.be.true;
+    expect(evaluator.evaluate('obj.str = "A"', resp)).to.be.true;
 
-    expect(evaluator.eval('obj.other = NULL', resp)).to.be.true;
-    expect(evaluator.eval('obj.str = NULL', resp)).to.be.false;
+    expect(evaluator.evaluate('obj.other = NULL', resp)).to.be.true;
+    expect(evaluator.evaluate('obj.str = NULL', resp)).to.be.false;
 
-    expect(evaluator.eval('obj.bool', resp)).to.be.true;
-    expect(evaluator.eval('obj.str', resp)).to.be.true;
-    expect(evaluator.eval('obj.num', resp)).to.be.true;
-    expect(evaluator.eval('obj.other', resp)).to.be.false;
+    expect(evaluator.evaluate('obj.bool', resp)).to.be.true;
+    expect(evaluator.evaluate('obj.str', resp)).to.be.true;
+    expect(evaluator.evaluate('obj.num', resp)).to.be.true;
+    expect(evaluator.evaluate('obj.other', resp)).to.be.false;
 
-    expect(evaluator.eval('NOT obj.bool', resp)).to.be.false;
-    expect(evaluator.eval('NOT obj.str', resp)).to.be.false;
-    expect(evaluator.eval('NOT obj.num', resp)).to.be.false;
-    expect(evaluator.eval('NOT obj.other', resp)).to.be.true;
+    expect(evaluator.evaluate('NOT obj.bool', resp)).to.be.false;
+    expect(evaluator.evaluate('NOT obj.str', resp)).to.be.false;
+    expect(evaluator.evaluate('NOT obj.num', resp)).to.be.false;
+    expect(evaluator.evaluate('NOT obj.other', resp)).to.be.true;
   });
 
   it('should shortcircuit nested expressions with missing parent', () => {
@@ -239,13 +239,13 @@ describe('evaluate', () => {
       },
     };
 
-    expect(evaluator.eval('obj.str = "A"', resp)).to.be.true;
-    expect(evaluator.eval('obj.child.str = "B"', resp)).to.be.true;
-    expect(evaluator.eval('obj.child.other = NULL', resp)).to.be.true;
-    expect(evaluator.eval('obj.child2 = NULL', resp)).to.be.true;
-    expect(evaluator.eval('obj.child2.other = NULL', resp)).to.be.true;
-    expect(evaluator.eval('obj.child2.other.x = NULL', resp)).to.be.true;
-    expect(evaluator.eval('obj2.child2.other.x = NULL', resp)).to.be.true;
+    expect(evaluator.evaluate('obj.str = "A"', resp)).to.be.true;
+    expect(evaluator.evaluate('obj.child.str = "B"', resp)).to.be.true;
+    expect(evaluator.evaluate('obj.child.other = NULL', resp)).to.be.true;
+    expect(evaluator.evaluate('obj.child2 = NULL', resp)).to.be.true;
+    expect(evaluator.evaluate('obj.child2.other = NULL', resp)).to.be.true;
+    expect(evaluator.evaluate('obj.child2.other.x = NULL', resp)).to.be.true;
+    expect(evaluator.evaluate('obj2.child2.other.x = NULL', resp)).to.be.true;
   });
 
   it('should evaluate nested expressions with brackets', () => {
@@ -260,86 +260,86 @@ describe('evaluate', () => {
       },
     };
 
-    expect(evaluator.eval('obj["bool"] = true', resp)).to.be.true;
-    expect(evaluator.eval('obj["a bool"] = true', resp)).to.be.true;
-    expect(evaluator.eval('obj["num"] = 11', resp)).to.be.true;
-    expect(evaluator.eval('obj["a num"] = 11', resp)).to.be.true;
-    expect(evaluator.eval('obj["str"] = "A"', resp)).to.be.true;
-    expect(evaluator.eval('obj["a str"] = "A"', resp)).to.be.true;
+    expect(evaluator.evaluate('obj["bool"] = true', resp)).to.be.true;
+    expect(evaluator.evaluate('obj["a bool"] = true', resp)).to.be.true;
+    expect(evaluator.evaluate('obj["num"] = 11', resp)).to.be.true;
+    expect(evaluator.evaluate('obj["a num"] = 11', resp)).to.be.true;
+    expect(evaluator.evaluate('obj["str"] = "A"', resp)).to.be.true;
+    expect(evaluator.evaluate('obj["a str"] = "A"', resp)).to.be.true;
 
-    expect(evaluator.eval("obj['bool'] = true", resp)).to.be.true;
-    expect(evaluator.eval("obj['a bool'] = true", resp)).to.be.true;
-    expect(evaluator.eval("obj['num'] = 11", resp)).to.be.true;
-    expect(evaluator.eval("obj['a num'] = 11", resp)).to.be.true;
-    expect(evaluator.eval("obj['str'] = 'A'", resp)).to.be.true;
-    expect(evaluator.eval("obj['a str'] = 'A'", resp)).to.be.true;
+    expect(evaluator.evaluate("obj['bool'] = true", resp)).to.be.true;
+    expect(evaluator.evaluate("obj['a bool'] = true", resp)).to.be.true;
+    expect(evaluator.evaluate("obj['num'] = 11", resp)).to.be.true;
+    expect(evaluator.evaluate("obj['a num'] = 11", resp)).to.be.true;
+    expect(evaluator.evaluate("obj['str'] = 'A'", resp)).to.be.true;
+    expect(evaluator.evaluate("obj['a str'] = 'A'", resp)).to.be.true;
 
-    expect(evaluator.eval('obj["other"] = NULL', resp)).to.be.true;
-    expect(evaluator.eval('obj["a other"] = NULL', resp)).to.be.true;
-    expect(evaluator.eval('obj["str"] = NULL', resp)).to.be.false;
-    expect(evaluator.eval('obj["a str"] = NULL', resp)).to.be.false;
+    expect(evaluator.evaluate('obj["other"] = NULL', resp)).to.be.true;
+    expect(evaluator.evaluate('obj["a other"] = NULL', resp)).to.be.true;
+    expect(evaluator.evaluate('obj["str"] = NULL', resp)).to.be.false;
+    expect(evaluator.evaluate('obj["a str"] = NULL', resp)).to.be.false;
 
-    expect(evaluator.eval('obj["bool"]', resp)).to.be.true;
-    expect(evaluator.eval('obj["a bool"]', resp)).to.be.true;
-    expect(evaluator.eval('obj["str"]', resp)).to.be.true;
-    expect(evaluator.eval('obj["a str"]', resp)).to.be.true;
-    expect(evaluator.eval('obj["num"]', resp)).to.be.true;
-    expect(evaluator.eval('obj["a num"]', resp)).to.be.true;
-    expect(evaluator.eval('obj["other"]', resp)).to.be.false;
-    expect(evaluator.eval('obj["a other"]', resp)).to.be.false;
+    expect(evaluator.evaluate('obj["bool"]', resp)).to.be.true;
+    expect(evaluator.evaluate('obj["a bool"]', resp)).to.be.true;
+    expect(evaluator.evaluate('obj["str"]', resp)).to.be.true;
+    expect(evaluator.evaluate('obj["a str"]', resp)).to.be.true;
+    expect(evaluator.evaluate('obj["num"]', resp)).to.be.true;
+    expect(evaluator.evaluate('obj["a num"]', resp)).to.be.true;
+    expect(evaluator.evaluate('obj["other"]', resp)).to.be.false;
+    expect(evaluator.evaluate('obj["a other"]', resp)).to.be.false;
 
-    expect(evaluator.eval('NOT obj["bool"]', resp)).to.be.false;
-    expect(evaluator.eval('NOT obj["a bool"]', resp)).to.be.false;
-    expect(evaluator.eval('NOT obj["str"]', resp)).to.be.false;
-    expect(evaluator.eval('NOT obj["a str"]', resp)).to.be.false;
-    expect(evaluator.eval('NOT obj["num"]', resp)).to.be.false;
-    expect(evaluator.eval('NOT obj["a num"]', resp)).to.be.false;
-    expect(evaluator.eval('NOT obj["other"]', resp)).to.be.true;
-    expect(evaluator.eval('NOT obj["a other"]', resp)).to.be.true;
+    expect(evaluator.evaluate('NOT obj["bool"]', resp)).to.be.false;
+    expect(evaluator.evaluate('NOT obj["a bool"]', resp)).to.be.false;
+    expect(evaluator.evaluate('NOT obj["str"]', resp)).to.be.false;
+    expect(evaluator.evaluate('NOT obj["a str"]', resp)).to.be.false;
+    expect(evaluator.evaluate('NOT obj["num"]', resp)).to.be.false;
+    expect(evaluator.evaluate('NOT obj["a num"]', resp)).to.be.false;
+    expect(evaluator.evaluate('NOT obj["other"]', resp)).to.be.true;
+    expect(evaluator.evaluate('NOT obj["a other"]', resp)).to.be.true;
 
-    expect(evaluator.eval('obj2["bool"] = NULL', resp)).to.be.true;
+    expect(evaluator.evaluate('obj2["bool"] = NULL', resp)).to.be.true;
   });
 
   it('should NOT evaluate nested expressions with wrong type', function() {
-    expect(evaluator.eval('obj.bool = true', {obj: true})).to.be.false;
-    expect(evaluator.eval('obj.num = 11', {obj: 11})).to.be.false;
-    expect(evaluator.eval('obj.str = "A"', {obj: 'A'})).to.be.false;
-    expect(evaluator.eval('obj.str = "A"', {})).to.be.false;
+    expect(evaluator.evaluate('obj.bool = true', {obj: true})).to.be.false;
+    expect(evaluator.evaluate('obj.num = 11', {obj: 11})).to.be.false;
+    expect(evaluator.evaluate('obj.str = "A"', {obj: 'A'})).to.be.false;
+    expect(evaluator.evaluate('obj.str = "A"', {})).to.be.false;
 
-    expect(evaluator.eval('obj.other = NULL', {obj: 11})).to.be.true;
+    expect(evaluator.evaluate('obj.other = NULL', {obj: 11})).to.be.true;
 
     expect(() => {
-      evaluator.eval('obj.NULL', {});
+      evaluator.evaluate('obj.NULL', {});
     }).to.throw();
     expect(() => {
-      evaluator.eval('NULL.obj', {});
+      evaluator.evaluate('NULL.obj', {});
     }).to.throw();
     expect(() => {
-      evaluator.eval('1.obj', {});
+      evaluator.evaluate('1.obj', {});
     }).to.throw();
     expect(() => {
-      evaluator.eval('TRUE.obj', {});
+      evaluator.evaluate('TRUE.obj', {});
     }).to.throw();
   });
 
   it('should evaluate nested expressions securely', () => {
-    expect(evaluator.eval('obj.__bool__ = NULL', {obj: {}})).to.be.true;
+    expect(evaluator.evaluate('obj.__bool__ = NULL', {obj: {}})).to.be.true;
   });
 
   it('should accept name grammar', () => {
-    expect(evaluator.eval('num = 10', {num: 10})).to.be.true;
-    expect(evaluator.eval('num1 = 10', {num1: 10})).to.be.true;
-    expect(evaluator.eval('num_ = 10', {num_: 10})).to.be.true;
-    expect(evaluator.eval('_num = 10', {_num: 10})).to.be.true;
+    expect(evaluator.evaluate('num = 10', {num: 10})).to.be.true;
+    expect(evaluator.evaluate('num1 = 10', {num1: 10})).to.be.true;
+    expect(evaluator.evaluate('num_ = 10', {num_: 10})).to.be.true;
+    expect(evaluator.evaluate('_num = 10', {_num: 10})).to.be.true;
 
     expect(() => {
-      evaluator.eval('1num = 10', {'1num': 10});
+      evaluator.evaluate('1num = 10', {'1num': 10});
     }).to.throw();
     expect(() => {
-      evaluator.eval('num-a = 10', {'num-a': 10});
+      evaluator.evaluate('num-a = 10', {'num-a': 10});
     }).to.throw();
     expect(() => {
-      evaluator.eval('num-1 = 10', {'num-1': 10});
+      evaluator.evaluate('num-1 = 10', {'num-1': 10});
     }).to.throw();
   });
 
@@ -349,20 +349,20 @@ describe('evaluate', () => {
     });
 
     it('first request should go through', () => {
-      evaluator.eval('access = true', {access: true});
+      evaluator.evaluate('access = true', {access: true});
       expect(evaluator.eval_.callCount).to.equal(1);
     });
 
     it('should use the cache on subsequent calls for the same expression and data', () => {
       const data = {access: true};
-      evaluator.eval('access = true', data);
-      evaluator.eval('access = true', data);
+      evaluator.evaluate('access = true', data);
+      evaluator.evaluate('access = true', data);
       expect(evaluator.eval_.callCount).to.equal(1);
     });
 
     it('should not use the cache if the data is referentially unequal', () => {
-      evaluator.eval('access = true', {access: true});
-      evaluator.eval('access = true', {access: true});
+      evaluator.evaluate('access = true', {access: true});
+      evaluator.evaluate('access = true', {access: true});
       expect(evaluator.eval_.callCount).to.equal(2);
     });
   });

--- a/extensions/amp-access/0.1/test/test-access-expr.js
+++ b/extensions/amp-access/0.1/test/test-access-expr.js
@@ -353,20 +353,20 @@ describe('evaluate', () => {
 
     it('first request should go through', () => {
       evaluator.evaluate('access = true', {access: true});
-      expect(evaluator.eval_.callCount).to.equal(1);
+      expect(evaluator.eval_).calledOnce;
     });
 
     it('should use the cache on subsequent calls for the same expression and data', () => {
       const data = {access: true};
       evaluator.evaluate('access = true', data);
       evaluator.evaluate('access = true', data);
-      expect(evaluator.eval_.callCount).to.equal(1);
+      expect(evaluator.eval_).calledOnce;
     });
 
     it('should not use the cache if the data is referentially unequal', () => {
       evaluator.evaluate('access = true', {access: true});
       evaluator.evaluate('access = true', {access: true});
-      expect(evaluator.eval_.callCount).to.equal(2);
+      expect(evaluator.eval_).calledTwice;
     });
   });
 });

--- a/extensions/amp-access/0.1/test/test-access-expr.js
+++ b/extensions/amp-access/0.1/test/test-access-expr.js
@@ -16,7 +16,7 @@
 
 import {AmpAccessEvaluator, evaluateAccessExpr} from '../access-expr';
 
-describe('evaluateAccessExpr', () => { 
+describe('evaluateAccessExpr', () => {
   it('should NOT allow double equal', () => {
     expect(() => {
       evaluateAccessExpr('access == true', {});
@@ -341,7 +341,7 @@ describe('evaluateAccessExpr', () => {
     }).to.throw();
   });
 
-  describe.only('AmpAccessEvaluator', () => {
+  describe('AmpAccessEvaluator', () => {
     let evaluator;
     beforeEach(() => {
       evaluator = new AmpAccessEvaluator();
@@ -349,19 +349,20 @@ describe('evaluateAccessExpr', () => {
     });
 
     it('first request should go through', () => {
-      expect(evaluator.eval('access = true', {access: true})).to.be.true;
-      expect(evaluator.eval_.callCount).to.equal(1);
-    });
-
-    it('should use the cache on subsequent calls for the same expression', () => {
-      evaluator.eval('access = true', {access: true});
       evaluator.eval('access = true', {access: true});
       expect(evaluator.eval_.callCount).to.equal(1);
     });
 
-    it('should not use the cache on subsequent calls for the same expression if the data has changed', () => {
+    it('should use the cache on subsequent calls for the same expression and data', () => {
+      const data = {access: true};
+      evaluator.eval('access = true', data);
+      evaluator.eval('access = true', data);
+      expect(evaluator.eval_.callCount).to.equal(1);
+    });
+
+    it('should not use the cache if the data is referentially unequal', () => {
       evaluator.eval('access = true', {access: true});
-      evaluator.eval('access = true', {access: false});
+      evaluator.eval('access = true', {access: true});
       expect(evaluator.eval_.callCount).to.equal(2);
     });
   });


### PR DESCRIPTION
**summary**
This PR modifies `amp-access` so that it caches the result of expression evaluation. For sites with the same expression repeated many times on the page, this yields a significant improvement.

Access expressions are evaluated with two parameters, the expression and auxiliary data. The expression is used as the cache key, and the whole cache is invalidated any time the data is referentially changed (should only happen on reauth flows)

All testing was done on a Nokia 2.3. The `applyAuthorizationToRoot_` function went from taking 260ms to 42ms.  The remaining big chunk of work within this long task is actually `DOMPurify` instantiations, which is being optimized in https://github.com/ampproject/amphtml/pull/27260

**before**
![before-cache](https://user-images.githubusercontent.com/4656974/77356242-502f2400-6d1c-11ea-8115-9868e303b3c9.png)

**after** 
![after-cache](https://user-images.githubusercontent.com/4656974/77356262-57563200-6d1c-11ea-8d90-305c97a06662.png)