### PR TITLE
🐛Fix the documentation link to the experiment list

### DIFF
--- a/tools/experiments/README.md
+++ b/tools/experiments/README.md
@@ -67,7 +67,7 @@ To prevent race conditions caused from loading the runtime and an inline script 
 
 To add a new experiment:
 
-1. Add the new experiment to this [list](https://github.com/ampproject/amphtml/blob/master/tools/experiments/experiments.js).
+1. Add the new experiment to this [list](https://github.com/ampproject/amphtml/blob/master/tools/experiments/experiments-config.js).
 1. (This is rare, most new experiments can skip this step) Decide if the experiment should allow document level opt-in. One top consideration is that switching the experiment on/off should not break any document. For example, experimental custom elements should never be white listed, as any documents start using it will get broken if the we switch it off. Add it to `allow-doc-opt-in` in `prod-config.json` and `canary-config.json` if so.
 1. Use it like this:
 


### PR DESCRIPTION
Fix the experiment documentation to link to the correct file. 