### PR TITLE
Auto advance from audio on story cover page.

### DIFF
--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -271,6 +271,9 @@ export class AmpStoryPage extends AMP.BaseElement {
     /** @private {!Array<!HTMLMediaElement>} */
     this.performanceTrackedVideos_ = [];
 
+    /** @private {boolean} */
+    this.mediaPoolHasRegisteredMedia_ = false;
+
     /** @private @const {!Promise<!MediaPool>} */
     this.mediaPoolPromise_ = deferred.promise;
 
@@ -495,10 +498,12 @@ export class AmpStoryPage extends AMP.BaseElement {
    * @private
    */
   resume_() {
-    this.registerAllMedia_();
+    const registerAllPromise = this.registerAllMedia_();
 
     if (this.isActive()) {
-      this.advancement_.start();
+      registerAllPromise.then(() => {
+        this.advancement_.start();
+      });
       this.prefersReducedMotion_()
         ? this.maybeFinishAnimations_()
         : this.maybeStartAnimations_();
@@ -1060,11 +1065,15 @@ export class AmpStoryPage extends AMP.BaseElement {
   }
 
   /**
-   * Registers all media on this page
+   * Registers all media on this page.
    * @return {!Promise} Promise that resolves after the callbacks are called.
    * @private
    */
   registerAllMedia_() {
+    if (this.mediaPoolHasRegisteredMedia_) {
+      return Promise.resolve();
+    }
+    this.mediaPoolHasRegisteredMedia_ = true;
     return this.whenAllMediaElements_((mediaPool, mediaEl) => {
       this.registerMedia_(mediaPool, mediaEl);
     });

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -271,8 +271,8 @@ export class AmpStoryPage extends AMP.BaseElement {
     /** @private {!Array<!HTMLMediaElement>} */
     this.performanceTrackedVideos_ = [];
 
-    /** @private {boolean} */
-    this.mediaPoolHasRegisteredMedia_ = false;
+    /** @private {?Promise} */
+    this.registerAllMediaPromise_ = null;
 
     /** @private @const {!Promise<!MediaPool>} */
     this.mediaPoolPromise_ = deferred.promise;
@@ -1070,13 +1070,12 @@ export class AmpStoryPage extends AMP.BaseElement {
    * @private
    */
   registerAllMedia_() {
-    if (this.mediaPoolHasRegisteredMedia_) {
-      return Promise.resolve();
-    }
-    this.mediaPoolHasRegisteredMedia_ = true;
-    return this.whenAllMediaElements_((mediaPool, mediaEl) => {
-      this.registerMedia_(mediaPool, mediaEl);
-    });
+    this.registerAllMediaPromise_ =
+      this.registerAllMediaPromise_ ||
+      this.whenAllMediaElements_((mediaPool, mediaEl) => {
+        this.registerMedia_(mediaPool, mediaEl);
+      });
+    return this.registerAllMediaPromise_;
   }
 
   /**

--- a/extensions/amp-story/1.0/test/test-amp-story-page.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-page.js
@@ -107,7 +107,7 @@ describes.realWin('amp-story-page', {amp: true}, env => {
   });
 
   it('should start the advancement when state becomes active', async () => {
-    page.mediaPoolHasRegisteredMedia_ = true;
+    page.registerAllMediaPromise_ = Promise.resolve();
     page.buildCallback();
     const advancementStartStub = env.sandbox.stub(page.advancement_, 'start');
     await page.layoutCallback();

--- a/extensions/amp-story/1.0/test/test-amp-story-page.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-page.js
@@ -107,10 +107,14 @@ describes.realWin('amp-story-page', {amp: true}, env => {
   });
 
   it('should start the advancement when state becomes active', async () => {
+    page.mediaPoolHasRegisteredMedia_ = true;
     page.buildCallback();
     const advancementStartStub = env.sandbox.stub(page.advancement_, 'start');
     await page.layoutCallback();
     page.setState(PageState.PLAYING);
+
+    // Microtask tick
+    await Promise.resolve();
 
     expect(advancementStartStub).to.have.been.calledOnce;
   });


### PR DESCRIPTION
Fixing auto advance from audio on story cover page.

The page advancement class was listening for progress/ended events on the original `audio` element, not the one replaced by the pool. Waiting until the elements are registered (and swapped) fixes the race condition.

Partial for #27291