### PR TITLE
🏗Allow wg-ads to approve new ad extensions

### DIFF
--- a/extensions/OWNERS
+++ b/extensions/OWNERS
@@ -10,6 +10,12 @@
       ],
     },
     {
+      pattern: 'amp-ad-network-*-impl/**/*',
+      owners: [
+        {name: 'ampproject/wg-ads-reviewers'},
+      ],
+    },
+    {
       pattern: '**/*-player.{js,md}',
       owners: [
         {name: 'alanorozco', notify: true},


### PR DESCRIPTION
We want to be able to approve new ad extension creation. Does this OWNER file work? @rcebulko if you can review.

