### PR TITLE
✨ Add support for wrapper attribute

### DIFF
--- a/ads/revcontent.js
+++ b/ads/revcontent.js
@@ -36,6 +36,7 @@ export function revcontent(global, data) {
 
   const required = ['id', 'height'];
   const optional = [
+    'wrapper',
     'subIds',
     'revcontent',
     'env',


### PR DESCRIPTION
Some of Revcontents older AMP ad implementations reference a wrapper attribute, but this attribute is not listed as an required or optional attribute for a Revcontent ad tag. This results in an "unknown attribute for revcontent: wrapper" error in the console:

![image](https://user-images.githubusercontent.com/56326230/77464646-e414f480-6ddd-11ea-802d-42512c49fac4.png)

This PR adds this attribute to the list of optional attributes we support and resolves this console error.