### PR TITLE
📖 VDO.AI: updated <amp-ad> example in .md file

### DIFF
--- a/ads/vdoai.md
+++ b/ads/vdoai.md
@@ -22,7 +22,7 @@ limitations under the License.
 <amp-ad
   width="300"
   height="1"
-  type="vdo"
+  type="vdoai"
   data-unitid="_vdo_ads_player_ai_"
   data-tagname="publisher"
   layout="responsive"


### PR DESCRIPTION
The `<amp-ad>` example for vdo.ai is wrong, it uses `type="vdo"` instead of `type="vdoai"`, which seems to be the proper value.