### PR TITLE
📖 [amp-bind] Fix documentation on binding data- attributes

### DIFF
--- a/extensions/amp-bind/amp-bind.md
+++ b/extensions/amp-bind/amp-bind.md
@@ -991,7 +991,7 @@ Change the `width` and `height` using the `[width]` and `[height]` attributes.
 
 **Accessibility states and properties**
 
-Use to dynamically update information available to assistive technologies, such as screen readers. [All `[aria-*]`](https://www.w3.org/WAI/PF/aria-1.1/states_and_properties) and only [specific `[data-*]`](#amp-component-specific-attributes) attributes are bindable.
+Use to dynamically update information available to assistive technologies, such as screen readers. [All `[aria-*]` attributes](https://www.w3.org/WAI/PF/aria-1.1/states_and_properties) are bindable.
 
 **AMP Component specific and HTML attributes**
 

--- a/extensions/amp-bind/amp-bind.md
+++ b/extensions/amp-bind/amp-bind.md
@@ -991,7 +991,7 @@ Change the `width` and `height` using the `[width]` and `[height]` attributes.
 
 **Accessibility states and properties**
 
-Use to dynamically update information available to assistive technologies, such as screen readers. All `[aria-*]` and `[data-*]` are bindable. See the [full list here](https://www.w3.org/WAI/PF/aria-1.1/states_and_properties).
+Use to dynamically update information available to assistive technologies, such as screen readers. [All `[aria-*]`](https://www.w3.org/WAI/PF/aria-1.1/states_and_properties) and only [specific `[data-*]`](#amp-component-specific-attributes) attributes are bindable.
 
 **AMP Component specific and HTML attributes**
 


### PR DESCRIPTION
As of https://github.com/ampproject/amphtml/issues/21633#issuecomment-478464327 `data-vars-` attributes are currently not bindable. This is why I adjusted the `amp-bind` documentation.

Edit: As @samouri pointed out, only a few `data-` attributes are bindable. I changed the purpose of this PR to reflect that.