### PR TITLE
🏗 Remove outliers when testing performance

### DIFF
--- a/build-system/tasks/performance/print-report.js
+++ b/build-system/tasks/performance/print-report.js
@@ -15,37 +15,12 @@
  */
 
 const fs = require('fs');
+const {averageNoOutliers, percent} = require('./stats');
 const {CONTROL, EXPERIMENT, RESULTS_PATH} = require('./helpers');
 
 const HEADER_COLUMN = 22;
 const BODY_COLUMN = 12;
 const FULL_TABLE = 68;
-
-/**
- * Computes an average for the specified key's values in the array of objects
- *
- * @param {Array<*>} arr
- * @param {string} key
- * @return {number} average
- */
-const average = (arr, key) =>
-  Math.round(arr.reduce((sum, result) => sum + result[key], 0) / arr.length);
-
-/**
- * Takes two numbers and generates a string representing the difference as
- * a percent for use in printing the results
- *
- * @param {number} a
- * @param {number} b
- * @return {string} String representing the change as a percent
- */
-function percent(a, b) {
-  if (a === 0) {
-    return b === 0 ? 'n/a' : `-${100 - Math.round((a / b) * 100)}`;
-  } else {
-    return `${100 - Math.round((b / a) * 100)}%`;
-  }
-}
 
 /**
  * Generates header lines to be printed to the console for url
@@ -73,8 +48,8 @@ const headerLines = url => [
  * @return {Array<string>} lines
  */
 function linesForMetric(metric, results) {
-  const control = average(results[CONTROL], metric);
-  const experiment = average(results[EXPERIMENT], metric);
+  const control = averageNoOutliers(results[CONTROL], metric);
+  const experiment = averageNoOutliers(results[EXPERIMENT], metric);
 
   return [
     [
@@ -123,14 +98,15 @@ class PageMetrics {
  * @return {Array<PageMetrics>} report
  */
 function getReport(urls) {
-  const results = JSON.parse(fs.readFileSync(RESULTS_PATH));
+  const raw = JSON.parse(fs.readFileSync(RESULTS_PATH));
   const report = [];
   urls.forEach(url => {
+    const results = raw[url];
     const pageMetrics = new PageMetrics(url);
-    const metrics = Object.keys(results[url][CONTROL][0]);
+    const metrics = Object.keys(results[CONTROL][0]);
     metrics.forEach(metric => {
-      const control = average(results[url][CONTROL], metric);
-      const experiment = average(results[url][EXPERIMENT], metric);
+      const control = averageNoOutliers(results[CONTROL], metric);
+      const experiment = averageNoOutliers(results[EXPERIMENT], metric);
       pageMetrics.set(metric, experiment, control);
     });
     report.push(pageMetrics);

--- a/build-system/tasks/performance/print-report.js
+++ b/build-system/tasks/performance/print-report.js
@@ -15,8 +15,8 @@
  */
 
 const fs = require('fs');
-const {averageNoOutliers, percent} = require('./stats');
 const {CONTROL, EXPERIMENT, RESULTS_PATH} = require('./helpers');
+const {percent, trimmedMean} = require('./stats');
 
 const HEADER_COLUMN = 22;
 const BODY_COLUMN = 12;
@@ -48,15 +48,16 @@ const headerLines = url => [
  * @return {Array<string>} lines
  */
 function linesForMetric(metric, results) {
-  const control = averageNoOutliers(results[CONTROL], metric);
-  const experiment = averageNoOutliers(results[EXPERIMENT], metric);
+  const control = trimmedMean(results[CONTROL], metric);
+  const experiment = trimmedMean(results[EXPERIMENT], metric);
+  const percentage = percent(control, experiment);
 
   return [
     [
       metric.padEnd(HEADER_COLUMN),
       experiment.toString().padEnd(BODY_COLUMN),
       control.toString().padEnd(BODY_COLUMN),
-      percent(control, experiment),
+      percentage == null ? 'n/a' : `${percentage}%`,
     ].join(' | '),
     `\n${''.padEnd(FULL_TABLE, '-')}\n`,
   ];
@@ -105,8 +106,8 @@ function getReport(urls) {
     const pageMetrics = new PageMetrics(url);
     const metrics = Object.keys(results[CONTROL][0]);
     metrics.forEach(metric => {
-      const control = averageNoOutliers(results[CONTROL], metric);
-      const experiment = averageNoOutliers(results[EXPERIMENT], metric);
+      const control = trimmedMean(results[CONTROL], metric);
+      const experiment = trimmedMean(results[EXPERIMENT], metric);
       pageMetrics.set(metric, experiment, control);
     });
     report.push(pageMetrics);

--- a/build-system/tasks/performance/stats.js
+++ b/build-system/tasks/performance/stats.js
@@ -14,6 +14,12 @@
  * limitations under the License.
  */
 
+/**
+ * Get the average of an array
+ *
+ * @param {Array<number>} array
+ * @return {number} average
+ */
 const average = array => {
   if (!array || array.length == 0) {
     return 0;
@@ -21,22 +27,39 @@ const average = array => {
   return array.reduce((a, b) => a + b) / array.length;
 };
 
+/**
+ * Sort an array from low to high
+ *
+ * @param {Array<number>} array
+ * @return {Array<number>} array
+ */
 const sort = array => {
-  return array.sort((a, b) => {
-    return a - b;
-  });
+  return array.sort((a, b) => a - b);
 };
 
+/**
+ * Get the median of a sorted array
+ *
+ * @param {Array<number>} array
+ * @return {number} median
+ */
 const median = array => {
   sort(array);
   const {length} = array;
+  const mid = Math.floor(length / 2);
   const isEven = length % 2 == 0;
   if (isEven) {
-    return average([array[length / 2], array[length / 2 + 1]]);
+    return average([array[mid], array[mid - 1]]);
   }
-  return array[length / 2];
+  return array[mid];
 };
 
+/**
+ * Get the median of the lower half of a sorted array
+ *
+ * @param {Array<number>} array
+ * @return {number} q1
+ */
 const q1 = array => {
   sort(array);
   const mid = Math.ceil(array.length / 2);
@@ -44,6 +67,12 @@ const q1 = array => {
   return median(half);
 };
 
+/**
+ * Get the median of the upper half of a sorted array
+ *
+ * @param {Array<number>} array
+ * @return {number} q3
+ */
 const q3 = array => {
   sort(array);
   const mid = Math.ceil(array.length / 2);
@@ -52,30 +81,31 @@ const q3 = array => {
 };
 
 /**
- * Takes two numbers and generates a string representing the difference as
- * a percent for use in printing the results
+ * Get the percentage change between two numbers,
+ * or returns null if invalid
  *
  * @param {number} a
  * @param {number} b
- * @return {string} String representing the change as a percent
+ * @return {number|null} percentage change or null
  */
 function percent(a, b) {
   if (a === 0) {
-    return b === 0 ? 'n/a' : `-${100 - Math.round((a / b) * 100)}`;
+    return b === 0 ? null : Math.round((a / b) * 100) - 100;
   } else {
-    return `${100 - Math.round((b / a) * 100)}%`;
+    return 100 - Math.round((b / a) * 100);
   }
 }
 
 /**
  * Given an array, identify outliers using the Tukey method,
- * and return the average after removing them.
+ * and return the average after removing them, which is
+ * also known as the interquartile mean.
  *
  * @param {Array<*>} results
  * @param {string} metric
  * @return {number}
  */
-function averageNoOutliers(results, metric) {
+function trimmedMean(results, metric) {
   const array = results.map(a => a[metric]);
   const stats = {
     q1: q1(array),
@@ -83,12 +113,12 @@ function averageNoOutliers(results, metric) {
   };
   const lowerFence = stats.q1 - 1.5 * (stats.q3 - stats.q1);
   const upperFence = stats.q3 + 1.5 * (stats.q3 - stats.q1);
-  const arrayNoOutliers = array.filter(a => a >= lowerFence && a <= upperFence);
+  const trimmedArray = array.filter(a => a >= lowerFence && a <= upperFence);
 
-  return Math.round(average(arrayNoOutliers));
+  return Math.round(average(trimmedArray));
 }
 
 module.exports = {
-  averageNoOutliers,
   percent,
+  trimmedMean,
 };

--- a/build-system/tasks/performance/stats.js
+++ b/build-system/tasks/performance/stats.js
@@ -1,0 +1,94 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const average = array => {
+  if (!array || array.length == 0) {
+    return 0;
+  }
+  return array.reduce((a, b) => a + b) / array.length;
+};
+
+const sort = array => {
+  return array.sort((a, b) => {
+    return a - b;
+  });
+};
+
+const median = array => {
+  sort(array);
+  const {length} = array;
+  const isEven = length % 2 == 0;
+  if (isEven) {
+    return average([array[length / 2], array[length / 2 + 1]]);
+  }
+  return array[length / 2];
+};
+
+const q1 = array => {
+  sort(array);
+  const mid = Math.ceil(array.length / 2);
+  const half = array.slice(0, mid);
+  return median(half);
+};
+
+const q3 = array => {
+  sort(array);
+  const mid = Math.ceil(array.length / 2);
+  const half = array.slice(mid);
+  return median(half);
+};
+
+/**
+ * Takes two numbers and generates a string representing the difference as
+ * a percent for use in printing the results
+ *
+ * @param {number} a
+ * @param {number} b
+ * @return {string} String representing the change as a percent
+ */
+function percent(a, b) {
+  if (a === 0) {
+    return b === 0 ? 'n/a' : `-${100 - Math.round((a / b) * 100)}`;
+  } else {
+    return `${100 - Math.round((b / a) * 100)}%`;
+  }
+}
+
+/**
+ * Given an array, identify outliers using the Tukey method,
+ * and return the average after removing them.
+ *
+ * @param {Array<*>} results
+ * @param {string} metric
+ * @return {number}
+ */
+function averageNoOutliers(results, metric) {
+  const array = results.map(a => a[metric]);
+  const stats = {
+    q1: q1(array),
+    q3: q3(array),
+  };
+  const lowerFence = stats.q1 - 1.5 * (stats.q3 - stats.q1);
+  const upperFence = stats.q3 + 1.5 * (stats.q3 - stats.q1);
+  const arrayNoOutliers = array.filter(a => a >= lowerFence && a <= upperFence);
+
+  return Math.round(average(arrayNoOutliers));
+}
+
+module.exports = {
+  averageNoOutliers,
+  percent,
+};


### PR DESCRIPTION
Taking performance measurements requires 100 runs at the moment, because the browser can act up in ways that bloat a performance metric. This PR fixes it by removing outliers before taking the average. It identifies outliers using the [Tukey method with inner and outer fences](https://en.wikipedia.org/wiki/Outlier#Tukey's_fences). 

For example, here's a sample run for the visible metric. 
![image](https://user-images.githubusercontent.com/44627152/77576595-d463e180-6eab-11ea-8c48-15eae508e70c.png)

So for control, we'll ignore everything outside the orange fence lines. Same fences are drawn for experiment. Out of bounds!

Hopefully we can use this lower the # of runs required to get reliable metrics, speeding up this task.

//related to https://github.com/ampproject/amphtml/issues/12128