### PR TITLE
Revert "Disable x-scrolling on iOS when iframed"

### DIFF
--- a/css/ampdoc.css
+++ b/css/ampdoc.css
@@ -77,17 +77,6 @@ html.i-amphtml-fie > body {
 }
 
 /**
- * iOS jitters when body overflows. See b/149328043. Notice that the min-height
- * essentially cancels `height: auto` from above.
- */
-html.i-amphtml-singledoc.i-amphtml-iframed:not(.i-amphtml-ios-embed):not([amp4ads]) > body {
-  overflow-x: hidden !important;
-  overflow-y: visible !important;
-  min-height: calc(100vh - var(--i-amphtml-padding-top, 0px));
-}
-
-
-/**
  * The `position: relative` is necessary to ensure that `paddingTop` can be
  * applied to a document to offset the header height, and it doesn't missplace
  * `position: absolute` elements.

--- a/extensions/amp-iframe/0.1/test/test-amp-iframe.js
+++ b/extensions/amp-iframe/0.1/test/test-amp-iframe.js
@@ -77,11 +77,6 @@ describes.realWin(
             content = message.data.replace('content-iframe:', '');
           }
         });
-        // TODO(dvoytenko): checked manually and it works, but for some
-        // reason the scrolling does not trigger on the scrollElement in
-        // the integration test. Thus disabling `i-amphtml-iframed` here
-        // for now.
-        doc.documentElement.classList.remove('i-amphtml-iframed');
         setTrackingIframeTimeoutForTesting(20);
       });
 

--- a/extensions/amp-sidebar/0.1/test/integration/test-amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/test/integration/test-amp-sidebar.js
@@ -91,11 +91,6 @@ describe
             const openerButton = win.document.getElementById('sidebarOpener');
             const sidebar = win.document.getElementById('sidebar1');
             const viewport = sidebar.implementation_.getViewport();
-            // TODO(dvoytenko): checked manually and it works, but for some
-            // reason the scrolling does not trigger on the scrollElement in
-            // the integration test. Thus disabling `i-amphtml-iframed` here
-            // for now.
-            win.document.documentElement.classList.remove('i-amphtml-iframed');
             const openedPromise = waitForSidebarOpen(win.document);
             openerButton.click();
             expect(viewport.getScrollTop()).to.equal(0);

--- a/extensions/amp-sidebar/0.2/test/integration/test-amp-sidebar.js
+++ b/extensions/amp-sidebar/0.2/test/integration/test-amp-sidebar.js
@@ -91,11 +91,6 @@ describe
             const openerButton = win.document.getElementById('sidebarOpener');
             const sidebar = win.document.getElementById('sidebar1');
             const viewport = sidebar.implementation_.getViewport();
-            // TODO(dvoytenko): checked manually and it works, but for some
-            // reason the scrolling does not trigger on the scrollElement in
-            // the integration test. Thus disabling `i-amphtml-iframed` here
-            // for now.
-            win.document.documentElement.classList.remove('i-amphtml-iframed');
             const openedPromise = waitForSidebarOpen(win.document);
             openerButton.click();
             expect(viewport.getScrollTop()).to.equal(0);

--- a/src/service/viewport/viewport-binding-natural.js
+++ b/src/service/viewport/viewport-binding-natural.js
@@ -138,7 +138,6 @@ export class ViewportBindingNatural_ {
   updatePaddingTop(paddingTop) {
     setImportantStyles(this.win.document.documentElement, {
       'padding-top': px(paddingTop),
-      '--i-amphtml-padding-top': px(paddingTop),
     });
   }
 

--- a/test/unit/test-viewport-binding.js
+++ b/test/unit/test-viewport-binding.js
@@ -73,16 +73,6 @@ describes.realWin('ViewportBindingNatural', {ampCss: true}, env => {
     expect(bodyStyles.overflowY).to.not.equal('hidden');
   });
 
-  it('should override body overflow for iframes', () => {
-    win.document.documentElement.classList.add('i-amphtml-iframed');
-    win.document.documentElement.classList.add('i-amphtml-singledoc');
-    binding = new ViewportBindingNatural_(ampdoc);
-    const bodyStyles = win.getComputedStyle(win.document.body);
-    expect(bodyStyles.position).to.equal('relative');
-    expect(bodyStyles.overflowX).to.equal('hidden');
-    expect(bodyStyles.overflowY).to.not.equal('hidden');
-  });
-
   it('should NOT require fixed layer transferring', () => {
     expect(binding.requiresFixedLayerTransfer()).to.be.false;
   });


### PR DESCRIPTION
Reverts ampproject/amphtml#27319

Reason for rollback: it breaks sticky CSS.