### PR TITLE
Allow clip-path for animations

### DIFF
--- a/extensions/amp-animation/0.1/test/test-web-animations.js
+++ b/extensions/amp-animation/0.1/test/test-web-animations.js
@@ -664,6 +664,60 @@ describes.realWin('MeasureScanner', {amp: 1}, env => {
     expect(keyframes).to.deep.equal([{opacity: '0'}, {opacity: '1'}]);
   });
 
+  it('should parse object keyframe with vendor prefixes', () => {
+    const {keyframes} = scan({
+      target: target1,
+      keyframes: {
+        'clip-path': ['A', 'B'],
+      },
+    })[0];
+    expect(isObject(keyframes)).to.be.true;
+    expect(isArray(keyframes['clip-path'])).to.be.true;
+    expect(keyframes['clip-path']).to.deep.equal(['A', 'B']);
+    // WebKit version as well.
+    expect(isArray(keyframes['-webkit-clip-path'])).to.be.true;
+    expect(keyframes['-webkit-clip-path']).to.deep.equal(['A', 'B']);
+  });
+
+  it('should parse object keyframe with vendor prefixes in camel-case', () => {
+    const {keyframes} = scan({
+      target: target1,
+      keyframes: {
+        'clipPath': ['A', 'B'],
+      },
+    })[0];
+    expect(isObject(keyframes)).to.be.true;
+    expect(isArray(keyframes['clipPath'])).to.be.true;
+    expect(keyframes['clipPath']).to.deep.equal(['A', 'B']);
+    // WebKit version as well.
+    expect(isArray(keyframes['-webkit-clip-path'])).to.be.true;
+    expect(keyframes['-webkit-clip-path']).to.deep.equal(['A', 'B']);
+  });
+
+  it('should parse array keyframe with vendor prefixes', () => {
+    const {keyframes} = scan({
+      target: target1,
+      keyframes: [{'clip-path': 'A'}, {'clip-path': 'B'}],
+    })[0];
+    expect(isArray(keyframes)).to.be.true;
+    expect(keyframes).to.deep.equal([
+      {'clip-path': 'A', '-webkit-clip-path': 'A'},
+      {'clip-path': 'B', '-webkit-clip-path': 'B'},
+    ]);
+  });
+
+  it('should parse array keyframe with vendor prefixes in camel-case', () => {
+    const {keyframes} = scan({
+      target: target1,
+      keyframes: [{'clipPath': 'A'}, {'clipPath': 'B'}],
+    })[0];
+    expect(isArray(keyframes)).to.be.true;
+    expect(keyframes).to.deep.equal([
+      {'clipPath': 'A', '-webkit-clip-path': 'A'},
+      {'clipPath': 'B', '-webkit-clip-path': 'B'},
+    ]);
+  });
+
   it('should parse width/height functions', () => {
     target2.style.width = '11px';
     target2.style.height = '22px';

--- a/extensions/amp-animation/0.1/web-animation-types.js
+++ b/extensions/amp-animation/0.1/web-animation-types.js
@@ -192,6 +192,8 @@ const WHITELISTED_RPOPS = {
   'visibility': true,
   'offset-distance': true,
   'offsetDistance': true,
+  'clip-path': true,
+  'clipPath': true,
 };
 
 /**

--- a/extensions/amp-animation/0.1/web-animations.js
+++ b/extensions/amp-animation/0.1/web-animations.js
@@ -534,7 +534,7 @@ export class MeasureScanner extends Scanner {
         }
         keyframes.push(this.css_.resolveCssMap(frame));
       }
-      for (let  i = 0; i < keyframes.length; i++) {
+      for (let i = 0; i < keyframes.length; i++) {
         const frame = keyframes[i];
         for (const k in ADD_PROPS) {
           if (k in frame) {

--- a/extensions/amp-animation/0.1/web-animations.js
+++ b/extensions/amp-animation/0.1/web-animations.js
@@ -65,6 +65,16 @@ const SERVICE_PROPS = {
 };
 
 /**
+ * Clip-path is an only CSS property we allow for animation that may require
+ * vendor prefix. And it's always "-webkit". Use a simple map to avoid
+ * expensive lookup for all other properties.
+ */
+const ADD_PROPS = {
+  'clip-path': '-webkit-clip-path',
+  'clipPath': '-webkit-clip-path',
+};
+
+/**
  * The scanner for the `WebAnimationDef` format. It calls the appropriate
  * callbacks based on the discovered animation types.
  * @abstract
@@ -487,6 +497,9 @@ export class MeasureScanner extends Scanner {
           preparedValue = value.map(v => this.css_.resolveCss(v));
         }
         keyframes[prop] = preparedValue;
+        if (prop in ADD_PROPS) {
+          keyframes[ADD_PROPS[prop]] = preparedValue;
+        }
       }
       return keyframes;
     }
@@ -520,6 +533,14 @@ export class MeasureScanner extends Scanner {
           }
         }
         keyframes.push(this.css_.resolveCssMap(frame));
+      }
+      for (let  i = 0; i < keyframes.length; i++) {
+        const frame = keyframes[i];
+        for (const k in ADD_PROPS) {
+          if (k in frame) {
+            frame[ADD_PROPS[k]] = frame[k];
+          }
+        }
       }
       return keyframes;
     }


### PR DESCRIPTION
Clip path can be animated safely and with good performance. Some masked shapes that will be used in stories use clip-path a lot. Another good example are local "reveal" animations.