### PR TITLE
🏗🚀 Speed up pre-closure `babel` transforms

### DIFF
--- a/build-system/compile/compile.js
+++ b/build-system/compile/compile.js
@@ -31,9 +31,10 @@ const {
 } = require('./closure-compile');
 const {checkForUnknownDeps} = require('./check-for-unknown-deps');
 const {checkTypesNailgunPort, distNailgunPort} = require('../tasks/nailgun');
-const {CLOSURE_SRC_GLOBS, SRC_TEMP_DIR} = require('./sources');
+const {CLOSURE_SRC_GLOBS} = require('./sources');
 const {isTravisBuild} = require('../common/travis');
 const {postClosureBabel} = require('./post-closure-babel');
+const {preClosureBabel} = require('./pre-closure-babel');
 const {singlePassCompile} = require('./single-pass');
 const {VERSION: internalRuntimeVersion} = require('./internal-version');
 
@@ -45,17 +46,6 @@ let inProgress = 0;
 // during various local development scenarios.
 // See https://github.com/google/closure-compiler-npm/issues/9
 const MAX_PARALLEL_CLOSURE_INVOCATIONS = isTravisBuild() ? 4 : 1;
-
-/**
- * Prefixes the tmp directory if we need to shadow files that have been
- * preprocessed by babel in the `dist` task.
- *
- * @param {!Array<string>} paths
- * @return {!Array<string>}
- */
-function convertPathsToTmpRoot(paths) {
-  return paths.map(path => path.replace(/^(!?)(.*)$/, `$1${SRC_TEMP_DIR}/$2`));
-}
 
 // Compiles AMP with the closure compiler. This is intended only for
 // production use. During development we intend to continue using
@@ -358,8 +348,6 @@ function compile(
       delete compilerOptions.define;
     }
 
-    compilerOptions.js_module_root.push(SRC_TEMP_DIR);
-
     const compilerOptionsArray = [];
     Object.keys(compilerOptions).forEach(function(option) {
       const value = compilerOptions[option];
@@ -376,11 +364,10 @@ function compile(
       }
     });
 
-    const gulpSrcs = convertPathsToTmpRoot(srcs);
-
     if (options.typeCheckOnly) {
       return gulp
-        .src(gulpSrcs, {base: SRC_TEMP_DIR})
+        .src(srcs, {base: '.'})
+        .pipe(preClosureBabel())
         .pipe(sourcemaps.init({loadMaps: true}))
         .pipe(gulpClosureCompile(compilerOptionsArray, checkTypesNailgunPort))
         .on('error', err => {
@@ -392,7 +379,8 @@ function compile(
     } else {
       timeInfo.startTime = Date.now();
       return gulp
-        .src(gulpSrcs, {base: SRC_TEMP_DIR})
+        .src(srcs, {base: '.'})
+        .pipe(preClosureBabel())
         .pipe(sourcemaps.init({loadMaps: true}))
         .pipe(gulpClosureCompile(compilerOptionsArray, distNailgunPort))
         .on('error', err => {

--- a/build-system/compile/pre-closure-babel.js
+++ b/build-system/compile/pre-closure-babel.js
@@ -1,0 +1,88 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+const argv = require('minimist')(process.argv.slice(2));
+const babel = require('@babel/core');
+const conf = require('./build.conf');
+const globby = require('globby');
+const path = require('path');
+const through = require('through2');
+const {BABEL_SRC_GLOBS, THIRD_PARTY_TRANSFORM_GLOBS} = require('./sources');
+
+const ROOT_DIR = path.resolve(__dirname, '../../');
+
+/**
+ * Files on which to run pre-closure babel transforms.
+ *
+ * @private @const {!Array<string>}
+ */
+const filesToTransform = getFilesToTransform();
+
+/**
+ * Used to cache babel transforms.
+ *
+ * @private @const {!Object<string, string>}
+ */
+const cachedTransforms = {};
+
+/**
+ * Computes the set of files on which to run pre-closure babel transforms.
+ *
+ * @return {!Array<string>}
+ */
+function getFilesToTransform() {
+  return globby
+    .sync([...BABEL_SRC_GLOBS, '!node_modules/', '!third_party/'])
+    .concat(globby.sync(THIRD_PARTY_TRANSFORM_GLOBS));
+}
+
+/**
+ * Apply babel transforms prior to closure compiler pass.
+ *
+ * When a source file is transformed for the first time, it is written to an
+ * in-memory cache from where it is retrieved every subsequent time without
+ * invoking babel.
+ *
+ * @return {!Promise}
+ */
+function preClosureBabel() {
+  return through.obj((file, enc, next) => {
+    const cachedTransform = cachedTransforms[file.path];
+    if (cachedTransform) {
+      file.contents = Buffer.from(cachedTransform);
+    } else if (filesToTransform.includes(path.relative(ROOT_DIR, file.path))) {
+      const babelPlugins = conf.plugins({
+        isForTesting: !!argv.fortesting,
+        isEsmBuild: !!argv.esm,
+        isSinglePass: !!argv.single_pass,
+        isChecktypes: argv._.includes('check-types'),
+      });
+      const {code} = babel.transformFileSync(file.path, {
+        plugins: babelPlugins,
+        retainLines: true,
+        compact: false,
+      });
+      cachedTransforms[file.path] = code;
+      file.contents = Buffer.from(code);
+    }
+    return next(null, file);
+  });
+}
+
+module.exports = {
+  preClosureBabel,
+};

--- a/build-system/compile/sources.js
+++ b/build-system/compile/sources.js
@@ -20,10 +20,6 @@
  * for both the babel and closure sources to be as close as possible.
  */
 
-const tempy = require('tempy');
-
-const SRC_TEMP_DIR = tempy.directory();
-
 const COMMON_GLOBS = [
   'third_party/amp-toolbox-cache-url/**/*.js',
   'third_party/caja/html-sanitizer.js',
@@ -154,6 +150,5 @@ const THIRD_PARTY_TRANSFORM_GLOBS = [
 module.exports = {
   BABEL_SRC_GLOBS,
   CLOSURE_SRC_GLOBS,
-  SRC_TEMP_DIR,
   THIRD_PARTY_TRANSFORM_GLOBS,
 };

--- a/build-system/tasks/check-types.js
+++ b/build-system/tasks/check-types.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-const argv = require('minimist')(process.argv.slice(2));
 const log = require('fancy-log');
 const {
   checkTypesNailgunPort,
@@ -29,7 +28,6 @@ const {cleanupBuildDir, closureCompile} = require('../compile/compile');
 const {compileCss} = require('./css');
 const {extensions, maybeInitializeExtensions} = require('./extension-helpers');
 const {maybeUpdatePackages} = require('./update-packages');
-const {transferSrcsToTempDir} = require('./helpers');
 
 /**
  * Dedicated type check path.
@@ -41,7 +39,6 @@ async function checkTypes() {
   process.env.NODE_ENV = 'production';
   cleanupBuildDir();
   maybeInitializeExtensions();
-  transferSrcsToTempDir({isChecktypes: true, isEsmBuild: argv.esm || false});
   const compileSrcs = [
     './src/amp.js',
     './src/amp-shadow.js',

--- a/build-system/tasks/dist.js
+++ b/build-system/tasks/dist.js
@@ -31,7 +31,6 @@ const {
   printConfigHelp,
   printNobuildHelp,
   toPromise,
-  transferSrcsToTempDir,
 } = require('./helpers');
 const {
   createCtrlcHandler,
@@ -101,12 +100,6 @@ async function dist() {
   await prebuild();
   await compileCss();
   await compileJison();
-
-  transferSrcsToTempDir({
-    isForTesting: !!argv.fortesting,
-    isEsmBuild: !!argv.esm,
-    isSinglePass: !!argv.single_pass,
-  });
 
   await copyCss();
   await copyParsers();

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-const babel = require('@babel/core');
 const babelify = require('babelify');
 const browserify = require('browserify');
 const buffer = require('vinyl-buffer');
@@ -23,13 +22,11 @@ const conf = require('../compile/build.conf');
 const del = require('del');
 const file = require('gulp-file');
 const fs = require('fs-extra');
-const globby = require('globby');
 const gulp = require('gulp');
 const gulpIf = require('gulp-if');
 const gulpWatch = require('gulp-watch');
 const istanbul = require('gulp-istanbul');
 const log = require('fancy-log');
-const micromatch = require('micromatch');
 const path = require('path');
 const regexpSourcemaps = require('gulp-regexp-sourcemaps');
 const rename = require('gulp-rename');
@@ -37,11 +34,6 @@ const source = require('vinyl-source-stream');
 const sourcemaps = require('gulp-sourcemaps');
 const watchify = require('watchify');
 const wrappers = require('../compile/compile-wrappers');
-const {
-  BABEL_SRC_GLOBS,
-  SRC_TEMP_DIR,
-  THIRD_PARTY_TRANSFORM_GLOBS,
-} = require('../compile/sources');
 const {
   VERSION: internalRuntimeVersion,
 } = require('../compile/internal-version');
@@ -698,46 +690,6 @@ function toPromise(readable) {
   });
 }
 
-/**
- * @param {{isEsmBuild: boolean|undefined, isCheckTypes: boolean|undefined, isFortesting: boolean|undefined, isSinglePass: boolean|undefined}=} options
- */
-function transferSrcsToTempDir(options = {}) {
-  log(
-    'Performing pre-closure',
-    colors.cyan('babel'),
-    'transforms in',
-    colors.cyan(SRC_TEMP_DIR)
-  );
-  const files = globby.sync(BABEL_SRC_GLOBS);
-  const babelPlugins = conf.plugins({
-    isEsmBuild: options.isEsmBuild,
-    isSinglePass: options.isSinglePass,
-    isForTesting: options.isForTesting,
-    isChecktypes: options.isChecktypes,
-    isPostCompile: false,
-  });
-
-  files.forEach(file => {
-    if (
-      (file.startsWith('node_modules/') || file.startsWith('third_party/')) &&
-      !micromatch.isMatch(file, THIRD_PARTY_TRANSFORM_GLOBS)
-    ) {
-      fs.copySync(file, `${SRC_TEMP_DIR}/${file}`);
-      return;
-    }
-
-    const {code} = babel.transformFileSync(file, {
-      plugins: babelPlugins,
-      retainLines: true,
-      compact: false,
-    });
-    const name = `${SRC_TEMP_DIR}/${file}`;
-    fs.outputFileSync(name, code);
-    process.stdout.write('.');
-  });
-  console.log('\n');
-}
-
 module.exports = {
   applyAmpConfig,
   BABELIFY_GLOBAL_TRANSFORM,
@@ -757,5 +709,4 @@ module.exports = {
   printConfigHelp,
   printNobuildHelp,
   toPromise,
-  transferSrcsToTempDir,
 };


### PR DESCRIPTION
**Background:**

- AMP's minified build (`gulp dist`) and type checker (`gulp check-types`) run a set of `babel` transforms on source files before invoking closure compiler. 
- Today, transforms are run on **_all_** source files at once, after which the results are written to disk in a temp directory. Following this, closure compiler is invoked on the temp directory.
- This is particularly inefficient for flags like `--core_runtime_only` and `--noextensions`, which only compile a small subset of source files.

<img width="976" alt="Screen Shot 2020-03-26 at 12 28 24 AM" src="https://user-images.githubusercontent.com/26553114/77610359-e0c25b80-6ef8-11ea-95ac-367b392be724.png">

**This PR does the following:**
- Refactors pre-closure babel transforms to run directly on the `gulp.src` stream
- Moves all transform code to `build-system/compile/pre-closure-babel.js`
- Implements a caching mechanism so every source file is transformed at most once
- Deletes `transferSrcsToTempDir()` and all associated code
- Ensures that only those source files that are compiled are first transformed

**Performance improvements (Macbook Pro):**

Command | Before | After
--- | --- | ---
`gulp dist --core_runtime_only` | ~50s | ~30s
`gulp check-types` | ~1m 40s | ~1m 10s
`gulp dist --extensions_from examples/article.amp.html` | ~2m | ~1m 40s
`gulp dist` | ~7m | ~6m 30s
`gulp dist --single_pass` | ~5m | ~5m

**Coming up:**

- [ ] Enable a minified version of `gulp` with instant startup and lazy building


Addresses https://github.com/ampproject/amphtml/pull/26779#discussion_r397248222