### PR TITLE
amp-access: avoid spying on private func.

### DIFF
--- a/extensions/amp-access/0.1/access-expr.js
+++ b/extensions/amp-access/0.1/access-expr.js
@@ -75,21 +75,9 @@ export class AmpAccessEvaluator {
     }
 
     if (!hasOwn(this.cache, expr)) {
-      this.cache[expr] = this.eval_(expr, data);
+      this.cache[expr] = evaluateAccessExpr(expr, data);
     }
 
     return this.cache[expr];
-  }
-
-  /**
-   * Evaluates access expressions by proxying calls to evaluateAccessExpr.
-   * This function only exists to be spied on.
-   *
-   * @param {string} expr
-   * @param {!JsonObject} data
-   * @return {boolean}
-   */
-  eval_(expr, data) {
-    return evaluateAccessExpr(expr, data);
   }
 }

--- a/extensions/amp-access/0.1/test/test-access-expr.js
+++ b/extensions/amp-access/0.1/test/test-access-expr.js
@@ -347,27 +347,27 @@ describe('evaluate', () => {
   });
 
   describe('caching', () => {
-    class Data {
-      count = 0;
+    let count;
+    const data = {
       get field() {
         count++;
         return true;
-      }
-    }
+      },
+    };
+    beforeEach(() => {
+      count = 0;
+    });
 
     it('should use the cache on subsequent calls for the same expression and data', () => {
-      const data = new Data();
-      evaluator.evaluate('obj.field', data);
-      evaluator.evaluate('obj.field', data);
-      expect(data.count).equal(1);
+      evaluator.evaluate('field', data);
+      evaluator.evaluate('field', data);
+      expect(count).equal(1);
     });
 
     it('should not use the cache if the data is referentially unequal', () => {
-      const data1 = new Data();
-      const data2 = new Data();
-      evaluator.evaluate('obj.field', data1);
-      evaluator.evaluate('obj.field', data2);
-      expect(data.count).equal(2);
+      evaluator.evaluate('obj.field', {obj: data});
+      evaluator.evaluate('obj.field', {obj: data});
+      expect(count).equal(2);
     });
   });
 });

--- a/extensions/amp-access/0.1/test/test-access-expr.js
+++ b/extensions/amp-access/0.1/test/test-access-expr.js
@@ -347,26 +347,17 @@ describe('evaluate', () => {
   });
 
   describe('caching', () => {
-    beforeEach(() => {
-      window.sandbox.spy(evaluator, 'eval_');
-    });
-
-    it('first request should go through', () => {
-      evaluator.evaluate('access = true', {access: true});
-      expect(evaluator.eval_).calledOnce;
-    });
-
     it('should use the cache on subsequent calls for the same expression and data', () => {
       const data = {access: true};
-      evaluator.evaluate('access = true', data);
-      evaluator.evaluate('access = true', data);
-      expect(evaluator.eval_).calledOnce;
+      const result1 = evaluator.evaluate('access = true', data);
+      const result2 = evaluator.evaluate('access = true', data);
+      expect(result1).equal(result2);
     });
 
     it('should not use the cache if the data is referentially unequal', () => {
-      evaluator.evaluate('access = true', {access: true});
-      evaluator.evaluate('access = true', {access: true});
-      expect(evaluator.eval_).calledTwice;
+      const result1 = evaluator.evaluate('access = true', {access: true});
+      const result2 = evaluator.evaluate('access = true', {access: true});
+      expect(result1).not.equal(result2);
     });
   });
 });

--- a/extensions/amp-access/0.1/test/test-access-expr.js
+++ b/extensions/amp-access/0.1/test/test-access-expr.js
@@ -347,17 +347,27 @@ describe('evaluate', () => {
   });
 
   describe('caching', () => {
+    class Data {
+      count = 0;
+      get field() {
+        count++;
+        return true;
+      }
+    }
+
     it('should use the cache on subsequent calls for the same expression and data', () => {
-      const data = {access: true};
-      const result1 = evaluator.evaluate('access = true', data);
-      const result2 = evaluator.evaluate('access = true', data);
-      expect(result1).equal(result2);
+      const data = new Data();
+      evaluator.evaluate('obj.field', data);
+      evaluator.evaluate('obj.field', data);
+      expect(data.count).equal(1);
     });
 
     it('should not use the cache if the data is referentially unequal', () => {
-      const result1 = evaluator.evaluate('access = true', {access: true});
-      const result2 = evaluator.evaluate('access = true', {access: true});
-      expect(result1).not.equal(result2);
+      const data1 = new Data();
+      const data2 = new Data();
+      evaluator.evaluate('obj.field', data1);
+      evaluator.evaluate('obj.field', data2);
+      expect(data.count).equal(2);
     });
   });
 });


### PR DESCRIPTION
is it preferable to test for a proxy of an implementation detail, or to directly spy on the implementation detail?

cc @ampproject/wg-runtime 