### PR TITLE
amp-script: remove all console errors from tests

### DIFF
--- a/extensions/amp-script/0.1/test/unit/test-amp-script.js
+++ b/extensions/amp-script/0.1/test/unit/test-amp-script.js
@@ -23,6 +23,10 @@ import {
 } from '../../amp-script';
 import {FakeWindow} from '../../../../../testing/fake-dom';
 import {Services} from '../../../../../src/services';
+import {
+  registerServiceBuilderForDoc,
+  resetServiceForTesting,
+} from '../../../../../src/service';
 import {user} from '../../../../../src/log';
 
 describes.fakeWin('AmpScript', {amp: {runtimeOn: false}}, env => {
@@ -76,6 +80,7 @@ describes.fakeWin('AmpScript', {amp: {runtimeOn: false}}, env => {
       'alert(1)'
     );
 
+    expectAsyncConsoleError(/Same-origin "src" requires/);
     return script.layoutCallback().should.be.rejected;
   });
 
@@ -89,6 +94,7 @@ describes.fakeWin('AmpScript', {amp: {runtimeOn: false}}, env => {
       'alert(1)'
     );
 
+    expectAsyncConsoleError(/should require JS content-type/);
     return script.layoutCallback().should.be.fulfilled;
   });
 
@@ -197,6 +203,17 @@ describes.fakeWin('AmpScript', {amp: {runtimeOn: false}}, env => {
   });
 
   describe('development mode', () => {
+    beforeEach(() => {
+      registerServiceBuilderForDoc(
+        env.win.document,
+        'amp-script',
+        AmpScriptService
+      );
+    });
+    afterEach(() => {
+      resetServiceForTesting(env.win, 'amp-script');
+    });
+
     it('should not be in dev mode by default', () => {
       script.buildCallback();
       expect(script.development_).false;
@@ -266,6 +283,7 @@ describes.repeated(
           });
 
           it('should reject if hash does not exist in meta tag', () => {
+            expectAsyncConsoleError(/Script hash not found/);
             createMetaHash('amp-script-src', 'sha384-another_fake_hash');
 
             service = new AmpScriptService(env.ampdoc);
@@ -541,6 +559,7 @@ describe('SanitizerImpl', () => {
     });
 
     it('AMP.setState(not_json)', async () => {
+      expectAsyncConsoleError(/Invalid AMP.setState/);
       await s.setStorage(
         StorageLocation.AMP_STATE,
         /* key */ null,


### PR DESCRIPTION
small cleanup. most of the changes were standard (adding `expectAsyncConsoleError`), but fixing the development tests had a surprise. They were throwing warnings based a service that `buildCallback` needs missing. So for those I installed the service.