### PR TITLE
caches: Fix bing cache hosts

### DIFF
--- a/build-system/global-configs/caches.json
+++ b/build-system/global-configs/caches.json
@@ -12,9 +12,9 @@
       "id": "bing",
       "name": "Bing AMP Cache",
       "docs": "https://www.bing.com/webmaster/help/bing-amp-cache-bc1c884c",
-      "cacheDomain": "bing-amp.com",
-      "updateCacheApiDomainSuffix": "bing-amp.com",
-      "thirdPartyFrameDomainSuffix": "bing-amp.net"
+      "cacheDomain": "www.bing-amp.com",
+      "updateCacheApiDomainSuffix": "www.bing-amp.com",
+      "thirdPartyFrameDomainSuffix": "www.bing-amp.net"
     }
   ]
 }


### PR DESCRIPTION
Bing AMP cache hosts are only reachable with `www` prepended.