### PR TITLE
🚀 Optimize toggleLoading by letting the mutator skip measuring in specific cases.

### DIFF
--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -1761,7 +1761,7 @@ function createBaseCustomElementClass(win) {
           }
         },
         undefined,
-        /* skipMeasure */ true
+        /* skipRemeasure */ true
       );
     }
 
@@ -1842,14 +1842,14 @@ function createBaseCustomElementClass(win) {
      *
      * @param {function()} mutator
      * @param {?Element=} opt_element
-     * @param {boolean=} opt_skipMeasure
+     * @param {boolean=} opt_skipRemeasure
      */
-    mutateOrInvoke_(mutator, opt_element, opt_skipMeasure = false) {
+    mutateOrInvoke_(mutator, opt_element, opt_skipRemeasure = false) {
       if (this.ampdoc_) {
         Services.mutatorForDoc(this.getAmpDoc()).mutateElement(
           opt_element || this,
           mutator,
-          opt_skipMeasure
+          opt_skipRemeasure
         );
       } else {
         mutator();

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -1751,9 +1751,13 @@ function createBaseCustomElementClass(win) {
             const loadingContainer = this.loadingContainer_;
             this.loadingContainer_ = null;
             this.loadingElement_ = null;
-            this.mutateOrInvoke_(() => {
-              dom.removeElement(loadingContainer);
-            });
+            this.mutateOrInvoke_(
+              () => {
+                dom.removeElement(loadingContainer);
+              },
+              undefined,
+              true
+            );
           }
         },
         undefined,

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -1815,7 +1815,7 @@ function createBaseCustomElementClass(win) {
           this.overflowElement_.onclick = () => {
             const mutator = Services.mutatorForDoc(this.getAmpDoc());
             mutator.forceChangeSize(this, requestedHeight, requestedWidth);
-            mutator./*OK*/ mutateElement(this, () => {
+            mutator.mutateElement(this, () => {
               this.overflowCallback(
                 /* overflown */ false,
                 requestedHeight,

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -1729,32 +1729,36 @@ function createBaseCustomElementClass(win) {
         return;
       }
 
-      this.mutateOrInvoke_(() => {
-        let state = this.loadingState_;
-        // Repeat "loading enabled" check because it could have changed while
-        // waiting for vsync.
-        if (state && !force && !this.isLoadingEnabled_()) {
-          state = false;
-        }
-        if (state) {
-          this.prepareLoading_();
-        }
-        if (!this.loadingContainer_) {
-          return;
-        }
+      this.mutateOrInvoke_(
+        () => {
+          let state = this.loadingState_;
+          // Repeat "loading enabled" check because it could have changed while
+          // waiting for vsync.
+          if (state && !force && !this.isLoadingEnabled_()) {
+            state = false;
+          }
+          if (state) {
+            this.prepareLoading_();
+          }
+          if (!this.loadingContainer_) {
+            return;
+          }
 
-        this.loadingContainer_.classList.toggle('amp-hidden', !state);
-        this.loadingElement_.classList.toggle('amp-active', state);
+          this.loadingContainer_.classList.toggle('amp-hidden', !state);
+          this.loadingElement_.classList.toggle('amp-active', state);
 
-        if (!state && cleanup && !this.implementation_.isLoadingReused()) {
-          const loadingContainer = this.loadingContainer_;
-          this.loadingContainer_ = null;
-          this.loadingElement_ = null;
-          this.mutateOrInvoke_(() => {
-            dom.removeElement(loadingContainer);
-          });
-        }
-      });
+          if (!state && cleanup && !this.implementation_.isLoadingReused()) {
+            const loadingContainer = this.loadingContainer_;
+            this.loadingContainer_ = null;
+            this.loadingElement_ = null;
+            this.mutateOrInvoke_(() => {
+              dom.removeElement(loadingContainer);
+            });
+          }
+        },
+        undefined,
+        /* skipMeasure */ true
+      );
     }
 
     /**
@@ -1834,12 +1838,14 @@ function createBaseCustomElementClass(win) {
      *
      * @param {function()} mutator
      * @param {?Element=} opt_element
+     * @param {boolean=} opt_skipMeasure
      */
-    mutateOrInvoke_(mutator, opt_element) {
+    mutateOrInvoke_(mutator, opt_element, opt_skipMeasure = false) {
       if (this.ampdoc_) {
         Services.mutatorForDoc(this.getAmpDoc()).mutateElement(
           opt_element || this,
-          mutator
+          mutator,
+          opt_skipMeasure
         );
       } else {
         mutator();

--- a/src/layout.js
+++ b/src/layout.js
@@ -295,7 +295,7 @@ export function getNaturalDimensions(element) {
 }
 
 /**
- * Whether the loading can be shown for the specified elemeent. This set has
+ * Whether the loading can be shown for the specified element. This set has
  * to be externalized since the element's implementation may not be
  * downloaded yet.
  * @param {!Element} element

--- a/src/service/mutator-impl.js
+++ b/src/service/mutator-impl.js
@@ -164,8 +164,13 @@ export class MutatorImpl {
   }
 
   /** @override */
-  mutateElement(element, mutator) {
-    return this.measureMutateElement(element, null, mutator);
+  mutateElement(element, mutator, skipMeasure) {
+    return this.measureMutateElementResources_(
+      element,
+      null,
+      mutator,
+      skipMeasure
+    );
   }
 
   /** @override */
@@ -195,9 +200,15 @@ export class MutatorImpl {
    * @param {!Element} element
    * @param {?function()} measurer
    * @param {function()} mutator
+   * @param {boolean} skipMeasure
    * @return {!Promise}
    */
-  measureMutateElementResources_(element, measurer, mutator) {
+  measureMutateElementResources_(
+    element,
+    measurer,
+    mutator,
+    skipMeasure = false
+  ) {
     const calcRelayoutTop = () => {
       const box = this.viewport_.getLayoutRect(element);
       if (box.width != 0 && box.height != 0) {
@@ -220,6 +231,9 @@ export class MutatorImpl {
       },
       mutate: () => {
         mutator();
+        if (skipMeasure) {
+          return;
+        }
 
         // TODO(willchou): IntersectionObserver won't catch size changes,
         // which means layout boxes may be stale. However, always requesting

--- a/src/service/mutator-impl.js
+++ b/src/service/mutator-impl.js
@@ -164,12 +164,12 @@ export class MutatorImpl {
   }
 
   /** @override */
-  mutateElement(element, mutator, skipMeasure) {
+  mutateElement(element, mutator, skipRemeasure) {
     return this.measureMutateElementResources_(
       element,
       null,
       mutator,
-      skipMeasure
+      skipRemeasure
     );
   }
 
@@ -200,14 +200,14 @@ export class MutatorImpl {
    * @param {!Element} element
    * @param {?function()} measurer
    * @param {function()} mutator
-   * @param {boolean} skipMeasure
+   * @param {boolean} skipRemeasure
    * @return {!Promise}
    */
   measureMutateElementResources_(
     element,
     measurer,
     mutator,
-    skipMeasure = false
+    skipRemeasure = false
   ) {
     const calcRelayoutTop = () => {
       const box = this.viewport_.getLayoutRect(element);
@@ -231,7 +231,7 @@ export class MutatorImpl {
       },
       mutate: () => {
         mutator();
-        if (skipMeasure) {
+        if (skipRemeasure) {
           return;
         }
 

--- a/src/service/mutator-interface.js
+++ b/src/service/mutator-interface.js
@@ -93,11 +93,15 @@ export class MutatorInterface {
    * first argument to this method and all the mutation work should be done
    * in the mutator callback which is called in the "mutation" vsync phase.
    *
+   * By default, all mutations force a remeasure. If you know that a mutation
+   * cannot cause a change to the layout, you may use the skipMeasure arg.
+   *
    * @param {!Element} element
    * @param {function()} mutator
+   * @param {boolean=} skipMeasure
    * @return {!Promise}
    */
-  mutateElement(element, mutator) {}
+  mutateElement(element, mutator, skipMeasure) {}
 
   /**
    * Runs the specified mutation on the element and ensures that remeasures and

--- a/src/service/mutator-interface.js
+++ b/src/service/mutator-interface.js
@@ -94,14 +94,14 @@ export class MutatorInterface {
    * in the mutator callback which is called in the "mutation" vsync phase.
    *
    * By default, all mutations force a remeasure. If you know that a mutation
-   * cannot cause a change to the layout, you may use the skipMeasure arg.
+   * cannot cause a change to the layout, you may use the skipRemeasure arg.
    *
    * @param {!Element} element
    * @param {function()} mutator
-   * @param {boolean=} skipMeasure
+   * @param {boolean=} skipRemeasure
    * @return {!Promise}
    */
-  mutateElement(element, mutator, skipMeasure) {}
+  mutateElement(element, mutator, skipRemeasure) {}
 
   /**
    * Runs the specified mutation on the element and ensures that remeasures and


### PR DESCRIPTION
**summary**
Before this PR, every single call to `mutator.mutateElement` would automatically result in a remeasure. The `toggleLoading` flow calls mutate twice, and therefore may result in two extra measurements. It turns out, that our loading indicator will never affect the bounding box of its parent (it has `position: absolute`), therefore measurement is completely unnecessary.

This PR adds an `opt_skipMeasure` parameter to `mutateElement` and takes advantage of it for the loading toggler as well as its cleanup.

**performance delta**
Unlike my prior two PRs where the numbers were relatively stable, I've found that measuring the measurement system (ha!) is difficult. Results are highly variable between refreshes. Our resources system is fairly nondeterministic and highly dependent on uncontrollable factors like network etc.

Instead of showing a before/after flamechart, I've run the profiler 10x and calculated averages for time spent measuring as well as the total number of times measuring occurred. Testing was done with a Nokia 2.3

|                | before | after | delta |
|----------------|--------|-------|-----|
| avg measures   |   1021.9     |  860.6 |  -15.7% |
| avg total time |    1633.8    |   1413.2    | -13.5%|

**appendix**

"Total time" (ms) spent measuring:
- master:             [1730, 1558, 1831, 1556, 1729, 1583, 1749, 1556, 1507, 1539]
- toggleloading: [1416, 1410,  1459, 1460, 1422, 1343, 1392, 1418, 1411, 1401]

Measure counts:
- master:            [1060, 1037, 1059, 1037, 1039, 930, 1059, 930, 1031, 1037]
- toggleloading: [844 ,848, 951 ,741, 709, 951, 709, 951, 951, 951]