### PR TITLE
Fix unsupported browser font sizing, and reenable tests.

### DIFF
--- a/extensions/amp-story/1.0/amp-story.css
+++ b/extensions/amp-story/1.0/amp-story.css
@@ -235,10 +235,6 @@ amp-story-page[active] {
   animation-name: i-amphtml-sidebar-slide-out-right;
 }
 
-.i-amphtml-story-fallback amp-story-page {
-  display: none !important;
-}
-
 /* Setting `translateY` distances as a trick so that the runtime schedules
  * layout for the next N pages. The default value (1000%) means that pages are
  * not be automatically laid out. Max distance is set to 2 (next 2 pages) since

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -2066,17 +2066,21 @@ export class AmpStory extends AMP.BaseElement {
             'publisher provided fallback.'
         );
       } else {
-        this.layoutStory_().then(() =>
+        this.layoutStory_().then(() => {
+          this.storeService_.dispatch(
+            Action.TOGGLE_PAUSED,
+            this.pausedStateToRestore_
+          );
           this.mutateElement(() => {
             this.unsupportedBrowserLayer_.removeLayer();
-            this.element.classList.remove('i-amphtml-story-fallback');
-          })
-        );
+          });
+        });
       }
     } else {
-      this.mutateElement(() => {
-        this.element.classList.add('i-amphtml-story-fallback');
-      });
+      this.pausedStateToRestore_ = !!this.storeService_.get(
+        StateProperty.PAUSED_STATE
+      );
+      this.storeService_.dispatch(Action.TOGGLE_PAUSED, true);
       // Displays the publisher provided fallback or fallbacks to the default
       // unsupported browser layer.
       if (fallbackEl) {

--- a/test/visual-diff/visual-tests
+++ b/test/visual-diff/visual-tests
@@ -361,7 +361,6 @@
       "name": "amp-story: unsupported browser",
       "viewport": {"width": 320, "height": 480},
       "loading_complete_selectors": [
-        ".i-amphtml-story-fallback",
         ".i-amphtml-story-unsupported-browser-overlay"
       ]
     },
@@ -466,7 +465,6 @@
       "name": "amp-story: unsupported browser (desktop)",
       "viewport": {"width": 1440, "height": 900},
       "loading_complete_selectors": [
-        ".i-amphtml-story-fallback",
         ".i-amphtml-story-unsupported-browser-overlay"
       ]
     },

--- a/test/visual-diff/visual-tests
+++ b/test/visual-diff/visual-tests
@@ -329,8 +329,6 @@
       ]
     },
     {
-      // TODO(#27185, @ampproject/wg-stories): font size is unstable, e.g., https://percy.io/ampproject/amphtml/builds/4680570
-      "flaky": true,
       "url": "examples/visual-tests/amp-story/info-dialog.html",
       "name": "amp-story: info dialog",
       "viewport": {"width": 320, "height": 480},
@@ -464,8 +462,6 @@
       "interactive_tests": "examples/visual-tests/amp-story/amp-story-consent.js"
     },
     {
-      // TODO(#27185, @ampproject/wg-stories): font size is unstable, e.g., https://percy.io/ampproject/amphtml/builds/4680570
-      "flaky": true,
       "url": "examples/visual-tests/amp-story/amp-story-unsupported-browser-layer.html",
       "name": "amp-story: unsupported browser (desktop)",
       "viewport": {"width": 1440, "height": 900},


### PR DESCRIPTION
Fix unsupported browser dynamic font sizing, and reenable tests.

Sorry, I know this is super low priority, but I wanted to look into it as I was worried about a bug in the dynamic font sizing code. Fortunately, this was very specific to the unsupported browser page, that set a `display: none;` on all story pages.

This PR pauses the story, instead of hiding the pages. That makes more sense, as we can expect most people to click the "continue anyway" button.

Fixes #27185