### PR TITLE
🏗 Add an override for closure compiler concurrency

### DIFF
--- a/build-system/compile/compile.js
+++ b/build-system/compile/compile.js
@@ -45,7 +45,9 @@ let inProgress = 0;
 // There's a race in the gulp plugin of closure compiler that gets exposed
 // during various local development scenarios.
 // See https://github.com/google/closure-compiler-npm/issues/9
-const MAX_PARALLEL_CLOSURE_INVOCATIONS = isTravisBuild() ? 4 : 1;
+const MAX_PARALLEL_CLOSURE_INVOCATIONS = isTravisBuild()
+  ? 4
+  : parseInt(argv.closure_concurrency, 10) || 1;
 
 // Compiles AMP with the closure compiler. This is intended only for
 // production use. During development we intend to continue using

--- a/build-system/tasks/build.js
+++ b/build-system/tasks/build.js
@@ -151,6 +151,7 @@ defaultTask.description =
 defaultTask.flags = {
   compiled: '  Compiles and serves minified binaries',
   config: '  Sets the runtime\'s AMP_CONFIG to one of "prod" or "canary"',
+  closure_concurrency: '  Sets the number of concurrent invocations of closure',
   extensions: '  Pre-builds the given extensions, lazily builds the rest.',
   extensions_from:
     '  Pre-builds the extensions used by the provided example page.',

--- a/build-system/tasks/check-types.js
+++ b/build-system/tasks/check-types.js
@@ -134,6 +134,7 @@ module.exports = {
 
 checkTypes.description = 'Check source code for JS type errors';
 checkTypes.flags = {
+  closure_concurrency: '  Sets the number of concurrent invocations of closure',
   disable_nailgun:
     "  Doesn't use nailgun to invoke closure compiler (much slower)",
 };

--- a/build-system/tasks/dist.js
+++ b/build-system/tasks/dist.js
@@ -451,4 +451,5 @@ dist.flags = {
   version_override: '  Override the version written to AMP_CONFIG',
   custom_version_mark: '  Set final digit (0-9) on auto-generated version',
   watch: '  Watches for changes in files, re-compiles when detected',
+  closure_concurrency: '  Sets the number of concurrent invocations of closure',
 };


### PR DESCRIPTION
Due to #23238 and https://github.com/google/closure-compiler-npm/issues/9, we lowered the concurrency of closure compiler to 1 for local development.

This PR adds a flag called `--closure_concurrency` to `gulp`, `gulp check-types`, and `gulp dist` that lets you override the concurrency during local development.

Related to #23238

