### PR TITLE
🐛 Mark initMessagingChannel timeout as expected error

### DIFF
--- a/src/service/viewer-impl.js
+++ b/src/service/viewer-impl.js
@@ -25,6 +25,7 @@ import {
   duplicateErrorIfNecessary,
   stripUserError,
 } from '../log';
+import {endsWith, startsWith} from '../string';
 import {findIndex} from '../utils/array';
 import {
   getSourceOrigin,
@@ -38,7 +39,6 @@ import {isIframed} from '../dom';
 import {map} from '../utils/object';
 import {registerServiceBuilderForDoc} from '../service';
 import {reportError} from '../error';
-import {endsWith, startsWith} from '../string';
 import {urls} from '../config';
 
 const TAG_ = 'Viewer';

--- a/src/service/viewer-impl.js
+++ b/src/service/viewer-impl.js
@@ -38,7 +38,7 @@ import {isIframed} from '../dom';
 import {map} from '../utils/object';
 import {registerServiceBuilderForDoc} from '../service';
 import {reportError} from '../error';
-import {startsWith} from '../string';
+import {endsWith, startsWith} from '../string';
 import {urls} from '../config';
 
 const TAG_ = 'Viewer';
@@ -320,7 +320,7 @@ export class ViewerImpl {
         let error = getChannelError(
           /** @type {!Error|string|undefined} */ (reason)
         );
-        if (error && error.message.endsWith(timeoutMessage)) {
+        if (error && endsWith(error.message, timeoutMessage)) {
           error = dev().createExpectedError(error);
         }
         reportError(error);

--- a/src/service/viewer-impl.js
+++ b/src/service/viewer-impl.js
@@ -320,7 +320,7 @@ export class ViewerImpl {
         let error = getChannelError(
           /** @type {!Error|string|undefined} */ (reason)
         );
-        if (error && reason === timeoutMessage) {
+        if (error && error.message.endsWith(timeoutMessage)) {
           error = dev().createExpectedError(error);
         }
         reportError(error);

--- a/src/service/viewer-impl.js
+++ b/src/service/viewer-impl.js
@@ -320,7 +320,7 @@ export class ViewerImpl {
         let error = getChannelError(
           /** @type {!Error|string|undefined} */ (reason)
         );
-        if (error && error.message === timeoutMessage) {
+        if (error && reason === timeoutMessage) {
           error = dev().createExpectedError(error);
         }
         reportError(error);


### PR DESCRIPTION
This PR is a follow-up to https://github.com/ampproject/amphtml/pull/27247

That PR attempted to mark the timeout error as expected by checking that the error message raised by `timeoutPromise` was the `opt_message` provided. What I missed at the time was that `getChannelError` prepends text to the error message, so the equality check failed and didn't actually mark the error as expected.

This PR updates the check to instead verify that the error reason matches the `opt_message` provided to `timeoutPromise`
