### PR TITLE
🏗🐛 Assorted fixes for `gulp --compiled`

### DIFF
--- a/build-system/server/lazy-build.js
+++ b/build-system/server/lazy-build.js
@@ -21,7 +21,7 @@ const {
   maybeInitializeExtensions,
   getExtensionsToBuild,
 } = require('../tasks/extension-helpers');
-const {doBuildJs} = require('../tasks/helpers');
+const {doBuildJs, compileCoreRuntime} = require('../tasks/helpers');
 const {jsBundles} = require('../compile/bundles.config');
 
 const extensionBundles = {};
@@ -128,7 +128,7 @@ async function lazyBuildJs(req, res, next) {
  * Pre-builds the core runtime and the JS files that it loads.
  */
 async function preBuildRuntimeFiles() {
-  await build(jsBundles, 'amp.js', doBuildJs);
+  await compileCoreRuntime(/* watch */ true, argv.compiled);
   await build(jsBundles, 'ww.max.js', doBuildJs);
 }
 

--- a/build-system/tasks/default-task.js
+++ b/build-system/tasks/default-task.js
@@ -1,0 +1,82 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const log = require('fancy-log');
+const {bootstrapThirdPartyFrames, printConfigHelp} = require('./helpers');
+const {compileCss} = require('./css');
+const {compileJison} = require('./compile-jison');
+const {copyCss, copyParsers} = require('./dist');
+const {createCtrlcHandler} = require('../common/ctrlcHandler');
+const {cyan, green} = require('ansi-colors');
+const {doServe} = require('./serve');
+const {maybeUpdatePackages} = require('./update-packages');
+const {parseExtensionFlags} = require('./extension-helpers');
+
+const argv = require('minimist')(process.argv.slice(2));
+
+/**
+ * Prints a useful help message prior to the default gulp task
+ */
+function printDefaultTaskHelp() {
+  log(green('Running the default ') + cyan('gulp ') + green('task.'));
+  log(
+    green(
+      '⤷ JS and extensions will be lazily built when requested from the server.'
+    )
+  );
+}
+
+/**
+ * The default task run when `gulp` is executed
+ *
+ * @return {!Promise}
+ */
+async function defaultTask() {
+  maybeUpdatePackages();
+  createCtrlcHandler('gulp');
+  process.env.NODE_ENV = 'development';
+  printConfigHelp('gulp');
+  printDefaultTaskHelp();
+  parseExtensionFlags(/* preBuild */ true);
+  await compileCss(/* watch */ true);
+  await compileJison();
+  if (argv.compiled) {
+    await copyCss();
+    await copyParsers();
+  }
+  await bootstrapThirdPartyFrames(/* watch */ true);
+  await doServe(/* lazyBuild */ true);
+  log(green('JS and extensions will be lazily built when requested...'));
+}
+
+module.exports = {
+  defaultTask,
+};
+
+/* eslint "google-camelcase/google-camelcase": 0 */
+
+defaultTask.description =
+  'Starts the dev server, lazily builds JS and extensions when requested, and watches them for changes';
+defaultTask.flags = {
+  compiled: '  Compiles and serves minified binaries',
+  config: '  Sets the runtime\'s AMP_CONFIG to one of "prod" or "canary"',
+  closure_concurrency: '  Sets the number of concurrent invocations of closure',
+  extensions: '  Pre-builds the given extensions, lazily builds the rest.',
+  extensions_from:
+    '  Pre-builds the extensions used by the provided example page.',
+  version_override: '  Overrides the version written to AMP_CONFIG',
+  custom_version_mark: '  Set final digit (0-9) on auto-generated version',
+};

--- a/build-system/tasks/dist.js
+++ b/build-system/tasks/dist.js
@@ -419,6 +419,8 @@ function preBuildLoginDoneVersion(version) {
 
 module.exports = {
   dist,
+  copyCss,
+  copyParsers,
 };
 
 /* eslint "google-camelcase/google-camelcase": 0 */

--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -656,6 +656,7 @@ const forbiddenTerms = {
       'build-system/tasks/prepend-global/test.js',
       'build-system/tasks/visual-diff/index.js',
       'build-system/tasks/build.js',
+      'build-system/tasks/default-task.js',
       'build-system/tasks/dist.js',
       'build-system/tasks/helpers.js',
       'dist.3p/current/integration.js',

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -33,7 +33,7 @@ const {
 const {a4a} = require('./build-system/tasks/a4a');
 const {ava} = require('./build-system/tasks/ava');
 const {babelPluginTests} = require('./build-system/tasks/babel-plugin-tests');
-const {build, defaultTask, watch} = require('./build-system/tasks/build');
+const {build, watch} = require('./build-system/tasks/build');
 const {bundleSize} = require('./build-system/tasks/bundle-size');
 const {cachesJson} = require('./build-system/tasks/caches-json');
 const {checkLinks} = require('./build-system/tasks/check-links');
@@ -45,6 +45,7 @@ const {compileJison} = require('./build-system/tasks/compile-jison');
 const {createGoldenCss} = require('./build-system/tasks/create-golden-css');
 const {css} = require('./build-system/tasks/css');
 const {csvifySize} = require('./build-system/tasks/csvify-size');
+const {defaultTask} = require('./build-system/tasks/default-task');
 const {depCheck} = require('./build-system/tasks/dep-check');
 const {devDashboardTests} = require('./build-system/tasks/dev-dashboard-tests');
 const {dist} = require('./build-system/tasks/dist');


### PR DESCRIPTION
**Background:**
- During `gulp dist`, we copy CSS and parsers from `build/` to `dist/`
- During `gulp dist`, we build the core runtime by calling this function:

https://github.com/ampproject/amphtml/blob/c71405018130c691f8be3528e4248dff589cfae3/build-system/tasks/helpers.js#L173-L188

**PR highlights:**

- Make `gulp --compiled` use the same compilation options as `gulp dist` for the core runtime
- Refactor default `gulp` task into `build-system/tasks/default-task.js` and add missing steps for `gulp --compiled`

**Comparison:**

- **`gulp dist --core_runtime_only`:**

![image](https://user-images.githubusercontent.com/26553114/78085422-ec929f80-7388-11ea-9ee7-920d38b11ed6.png)


- **`gulp --compiled`:**

![image](https://user-images.githubusercontent.com/26553114/78085501-28c60000-7389-11ea-91e6-78cb599c2daf.png)

Follow up to #27471