### PR TITLE
🐛 nit: fix logic for `deep-parsing` on `amp-next-page`

### DIFF
--- a/extensions/amp-next-page/1.0/service.js
+++ b/extensions/amp-next-page/1.0/service.js
@@ -218,10 +218,9 @@ export class NextPageService {
     insertAfterOrAtStart(this.host_, this.recBox_, null /** after */);
 
     this.nextSrc_ = this.getHost_().getAttribute('src');
-    this.hasDeepParsing_ =
-      (this.getHost_().hasAttribute('deep-parsing') &&
-        this.getHost_().getAttribute('deep-parsing') !== 'false') ||
-      !this.nextSrc_;
+    this.hasDeepParsing_ = this.getHost_().hasAttribute('deep-parsing')
+      ? this.getHost_().getAttribute('deep-parsing') !== 'false'
+      : !this.nextSrc_;
     this.maxPages_ = this.getHost_().hasAttribute('max-pages')
       ? parseInt(this.getHost_().getAttribute('max-pages'), 10)
       : Infinity;


### PR DESCRIPTION
Closes #27493 

### Changes
- Fixes logic issue that prevented `deep-parsing` from getting disabled if `amp-next-page` doesn't have an `src`