### PR TITLE
[amp-list]: make layout=container and load-more mutually exclusive

### DIFF
--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -1016,7 +1016,7 @@ export class AmpList extends AMP.BaseElement {
       return this.maybeResizeListToFitItems_();
     };
 
-    if (this.isLayoutContainer_) {
+    if (!this.loadMoreEnabled_ & this.isLayoutContainer_) {
       return this.lockHeightAndMutate_(() =>
         renderAndResize().then((resized) =>
           resized ? this.unlockHeightInsideMutate_() : null

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -1016,7 +1016,7 @@ export class AmpList extends AMP.BaseElement {
       return this.maybeResizeListToFitItems_();
     };
 
-    if (!this.loadMoreEnabled_ & this.isLayoutContainer_) {
+    if (!this.loadMoreEnabled_ && this.isLayoutContainer_) {
       return this.lockHeightAndMutate_(() =>
         renderAndResize().then((resized) =>
           resized ? this.unlockHeightInsideMutate_() : null

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -1122,12 +1122,16 @@ export class AmpList extends AMP.BaseElement {
 
   /**
    * Measure and lock height before performing given mutate fn.
-   * Applicable for layout=container.
+   * Applicable for layout=container without infinite scrolling.
    * @private
    * @param {!Function} mutate
    * @return {!Promise}
    */
   lockHeightAndMutate_(mutate) {
+    devAssert(
+      !this.loadMoreEnabled_,
+      'amp-list[layout=container] does not support infinite scrolling with [load-more].'
+    );
     let currentHeight;
     return this.measureMutateElement(
       () => {

--- a/extensions/amp-list/0.1/test/test-amp-list-load-more.js
+++ b/extensions/amp-list/0.1/test/test-amp-list-load-more.js
@@ -42,6 +42,7 @@ describes.realWin(
     let ampdoc;
     let element, list;
     let templates;
+    let lockHeightSpy;
 
     beforeEach(() => {
       win = env.win;
@@ -55,13 +56,18 @@ describes.realWin(
       };
       env.sandbox.stub(Services, 'templatesFor').returns(templates);
       env.sandbox.stub(AmpDocService.prototype, 'getAmpDoc').returns(ampdoc);
+
+      element = doc.createElement('amp-list');
+      list = new AmpList(element);
+      lockHeightSpy = env.sandbox.spy(list, 'lockHeightAndMutate_');
+    });
+
+    afterEach(() => {
+      expect(lockHeightSpy.notCalled).to.be.true;
     });
 
     describe('manual', () => {
       beforeEach(() => {
-        element = doc.createElement('amp-list');
-        list = new AmpList(element);
-
         env.sandbox.stub(list, 'getAmpDoc').returns(ampdoc);
         env.sandbox.stub(list, 'getFallback').returns(null);
 
@@ -147,9 +153,6 @@ describes.realWin(
 
     describe('loading states', () => {
       beforeEach(() => {
-        element = doc.createElement('amp-list');
-        list = new AmpList(element);
-
         env.sandbox.stub(list, 'getAmpDoc').returns(ampdoc);
         env.sandbox.stub(list, 'getFallback').returns(null);
 


### PR DESCRIPTION
amp-list[load-more] already did not support layout=container. This change explicitly guards the layout=container feature from going down the infinite list code path.

/cc @rcebulko 