### PR TITLE
custom-element.updateLayoutBox: remove automatic toggleLoading

### DIFF
--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -1211,7 +1211,7 @@ function createBaseCustomElementClass(win) {
         } else {
           // Set a minimum delay in case the element loads very fast or if it
           // leaves the viewport.
-          const loadingStartTime = Date.now();
+          const loadingStartTime = win.Date.now();
           Services.timerFor(toWin(this.ownerDocument.defaultView)).delay(() => {
             // TODO(dvoytenko, #9177): cleanup `this.ownerDocument.defaultView`
             // once investigation is complete. It appears that we get a lot of

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -591,19 +591,9 @@ function createBaseCustomElementClass(win) {
         }
       }
 
-      if (this.isLoadingEnabled_()) {
-        if (this.isInViewport_) {
-          // Already in viewport - start showing loading.
-          this.toggleLoading(true);
-        } else if (
-          layoutBox.top < PREPARE_LOADING_THRESHOLD &&
-          layoutBox.top >= 0 &&
-          !this.loadingContainer_
-        ) {
-          // Few top elements will also be pre-initialized with a loading
-          // element.
-          this.mutateOrInvoke_(() => this.prepareLoading_());
-        }
+      // Few top elements will also be pre-initialized with a loading element.
+      if (layoutBox.top < PREPARE_LOADING_THRESHOLD && layoutBox.top >= 0) {
+        this.mutateOrInvoke_(() => this.prepareLoading_());
       }
     }
 

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -1692,7 +1692,7 @@ function createBaseCustomElementClass(win) {
     /**
      * Turns the loading indicator on or off.
      * @param {boolean} state
-     * @param {{cleanup:(boolean|undefined), force:(boolean|undefined)}=, startTime:(number=)} opt_options
+     * @param {{cleanup:(boolean|undefined), force:(boolean|undefined)}=, startTime:(number=)}} opt_options
      * @public @final
      */
     toggleLoading(state, opt_options) {
@@ -1731,7 +1731,7 @@ function createBaseCustomElementClass(win) {
             state = false;
           }
           if (state) {
-            this.prepareLoading_();
+            this.prepareLoading_(startTime);
           }
           if (!this.loadingContainer_) {
             return;

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -1692,12 +1692,13 @@ function createBaseCustomElementClass(win) {
     /**
      * Turns the loading indicator on or off.
      * @param {boolean} state
-     * @param {{cleanup:(boolean|undefined), force:(boolean|undefined)}=, startTime:(number=)}} opt_options
+     * @param {{cleanup:(boolean|undefined), force:(boolean|undefined), startTime:(number|undefined)}=} opt_options
      * @public @final
      */
     toggleLoading(state, opt_options) {
       const cleanup = opt_options && opt_options.cleanup;
       const force = opt_options && opt_options.force;
+      const startTime = opt_options && opt_options.startTime;
       assertNotTemplate(this);
       if (
         state &&

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -1224,6 +1224,7 @@ function createBaseCustomElementClass(win) {
         } else {
           // Set a minimum delay in case the element loads very fast or if it
           // leaves the viewport.
+          const beforeDelay = Date.now();
           Services.timerFor(toWin(this.ownerDocument.defaultView)).delay(() => {
             // TODO(dvoytenko, #9177): cleanup `this.ownerDocument.defaultView`
             // once investigation is complete. It appears that we get a lot of
@@ -1233,7 +1234,7 @@ function createBaseCustomElementClass(win) {
               this.ownerDocument &&
               this.ownerDocument.defaultView
             ) {
-              this.toggleLoading(true);
+              this.toggleLoading(true, {startTime: beforeDelay});
             }
           }, 100);
         }
@@ -1659,8 +1660,9 @@ function createBaseCustomElementClass(win) {
      * actually be shown. This method must also be called in the mutate
      * context.
      * @private
+     * @param {number=} startTime
      */
-    prepareLoading_() {
+    prepareLoading_(startTime) {
       if (!this.isLoadingEnabled_()) {
         return;
       }
@@ -1675,7 +1677,8 @@ function createBaseCustomElementClass(win) {
           this.getAmpDoc(),
           this,
           this.layoutWidth_,
-          this.layoutHeight_
+          this.layoutHeight_,
+          startTime
         );
 
         container.appendChild(loadingElement);
@@ -1689,7 +1692,7 @@ function createBaseCustomElementClass(win) {
     /**
      * Turns the loading indicator on or off.
      * @param {boolean} state
-     * @param {{cleanup:(boolean|undefined), force:(boolean|undefined)}=} opt_options
+     * @param {{cleanup:(boolean|undefined), force:(boolean|undefined)}=, startTime:(number=)} opt_options
      * @public @final
      */
     toggleLoading(state, opt_options) {

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -45,14 +45,6 @@ import {tryResolve} from '../src/utils/promise';
 const TAG = 'CustomElement';
 
 /**
- * The elements positioned ahead of this threshold may have their loading
- * indicator initialized faster. This is benefitial to avoid relayout during
- * render phase or scrolling.
- * @private @const {number}
- */
-const PREPARE_LOADING_THRESHOLD = 1000;
-
-/**
  * @enum {number}
  */
 const UpgradeState = {
@@ -589,11 +581,6 @@ function createBaseCustomElementClass(win) {
         } catch (e) {
           reportError(e, this);
         }
-      }
-
-      // Few top elements will also be pre-initialized with a loading element.
-      if (layoutBox.top < PREPARE_LOADING_THRESHOLD && layoutBox.top >= 0) {
-        this.mutateOrInvoke_(() => this.prepareLoading_());
       }
     }
 
@@ -1224,7 +1211,7 @@ function createBaseCustomElementClass(win) {
         } else {
           // Set a minimum delay in case the element loads very fast or if it
           // leaves the viewport.
-          const beforeDelay = Date.now();
+          const loadingStartTime = Date.now();
           Services.timerFor(toWin(this.ownerDocument.defaultView)).delay(() => {
             // TODO(dvoytenko, #9177): cleanup `this.ownerDocument.defaultView`
             // once investigation is complete. It appears that we get a lot of
@@ -1234,7 +1221,7 @@ function createBaseCustomElementClass(win) {
               this.ownerDocument &&
               this.ownerDocument.defaultView
             ) {
-              this.toggleLoading(true, {startTime: beforeDelay});
+              this.toggleLoading(true, {startTime: loadingStartTime});
             }
           }, 100);
         }

--- a/src/loader.js
+++ b/src/loader.js
@@ -38,15 +38,16 @@ function getLoaderServicePromise(ampDoc, element) {
  * @param {!AmpElement} element
  * @param {number} elementWidth
  * @param {number} elementHeight
+ * @param {number=} startTime
  * @return {!Element} The loader root element.
  */
 export function createLoaderElement(
   ampDoc,
   element,
   elementWidth,
-  elementHeight
+  elementHeight,
+  startTime = Date.now()
 ) {
-  const startTime = Date.now();
   // We create the loader root element up front, since it is needed
   // synchronously. We create the actual element with animations when the
   // service is ready.

--- a/test/unit/test-custom-element.js
+++ b/test/unit/test-custom-element.js
@@ -1767,7 +1767,7 @@ describes.realWin('CustomElement', {amp: true}, (env) => {
       beforeEach(() => {
         win = env.win;
         doc = win.document;
-        clock = lolex.install({target: win});
+        clock = lolex.install({target: win, now: 42});
         ElementClass = createAmpElementForTesting(win, TestElement);
         win.customElements.define('amp-test-loader', ElementClass);
         win.__AMP_EXTENDED_ELEMENTS['amp-test-loader'] = TestElement;
@@ -1980,18 +1980,16 @@ describes.realWin('CustomElement', {amp: true}, (env) => {
         expect(toggle).to.have.not.been.called;
       });
 
-      it('should turn on when enters viewport', () => {
+      it('should turn on when enters viewport, after a 100ms delay', () => {
         stubInA4A(false);
         const toggle = env.sandbox.spy(element, 'toggleLoading');
         element.setAttribute('layout', 'fill');
         container.appendChild(element);
         element.viewportCallback(true);
-        clock.tick(101);
-        expect(toggle).to.be.calledOnce;
-        expect(toggle.firstCall.args).to.deep.equal([
-          true,
-          {startTime: env.sandbox.match.number},
-        ]);
+        clock.tick(99);
+        expect(toggle).not.called;
+        clock.tick(100);
+        expect(toggle).calledOnceWith(true, {startTime: 42});
       });
 
       it('should NOT turn on when enters viewport but already laid out', () => {

--- a/test/unit/test-custom-element.js
+++ b/test/unit/test-custom-element.js
@@ -1986,9 +1986,9 @@ describes.realWin('CustomElement', {amp: true}, (env) => {
         element.setAttribute('layout', 'fill');
         container.appendChild(element);
         element.viewportCallback(true);
-        clock.tick(1000);
+        clock.tick(101);
         expect(toggle).to.be.calledOnce;
-        expect(toggle.firstCall.args[0]).to.equal(true);
+        expect(toggle.firstCall.args).to.deep.equal([true, {startTime: 0}]);
       });
 
       it('should NOT turn on when enters viewport but already laid out', () => {
@@ -2000,7 +2000,17 @@ describes.realWin('CustomElement', {amp: true}, (env) => {
         expect(toggle).to.have.not.been.called;
       });
 
-      it('should create loading when measured if in the top window', () => {
+      it('should not start loading when measured if already in viewport', () => {
+        stubInA4A(false);
+        const toggle = env.sandbox.spy(element, 'toggleLoading');
+        element.isInViewport_ = true;
+        element.setAttribute('layout', 'fill');
+        container.appendChild(element);
+        element.updateLayoutBox({top: 0, width: 300});
+        expect(toggle).to.not.be.called;
+      });
+
+      it('should prepare loading when measured if in the top window', () => {
         stubInA4A(false);
         const toggle = env.sandbox.spy(element, 'toggleLoading');
         element.setAttribute('layout', 'fill');

--- a/test/unit/test-custom-element.js
+++ b/test/unit/test-custom-element.js
@@ -1988,7 +1988,10 @@ describes.realWin('CustomElement', {amp: true}, (env) => {
         element.viewportCallback(true);
         clock.tick(101);
         expect(toggle).to.be.calledOnce;
-        expect(toggle.firstCall.args).to.deep.equal([true, {startTime: 0}]);
+        expect(toggle.firstCall.args).to.deep.equal([
+          true,
+          {startTime: env.sandbox.match.number},
+        ]);
       });
 
       it('should NOT turn on when enters viewport but already laid out', () => {

--- a/test/unit/test-custom-element.js
+++ b/test/unit/test-custom-element.js
@@ -2013,17 +2013,6 @@ describes.realWin('CustomElement', {amp: true}, (env) => {
         expect(toggle).to.not.be.called;
       });
 
-      it('should prepare loading when measured if in the top window', () => {
-        stubInA4A(false);
-        const toggle = env.sandbox.spy(element, 'toggleLoading');
-        element.setAttribute('layout', 'fill');
-        container.appendChild(element);
-        element.updateLayoutBox({top: 0, width: 300});
-        expect(toggle).to.have.not.been.called;
-        expect(element.loadingContainer_).to.not.be.null;
-        expect(element.loadingContainer_).to.have.class('amp-hidden');
-      });
-
       it('should toggle loading off after layout complete', () => {
         stubInA4A(false);
         const toggle = env.sandbox.spy(element, 'toggleLoading');

--- a/test/unit/test-custom-element.js
+++ b/test/unit/test-custom-element.js
@@ -2000,18 +2000,6 @@ describes.realWin('CustomElement', {amp: true}, (env) => {
         expect(toggle).to.have.not.been.called;
       });
 
-      // WHY when measured?
-      // it('should start loading when measured if already in viewport', () => {
-      //   stubInA4A(false);
-      //   const toggle = env.sandbox.spy(element, 'toggleLoading');
-      //   element.isInViewport_ = true;
-      //   element.setAttribute('layout', 'fill');
-      //   container.appendChild(element);
-      //   element.updateLayoutBox({top: 0, width: 300});
-      //   expect(toggle).to.be.calledOnce;
-      //   expect(toggle.firstCall.args[0]).to.equal(true);
-      // });
-
       it('should create loading when measured if in the top window', () => {
         stubInA4A(false);
         const toggle = env.sandbox.spy(element, 'toggleLoading');

--- a/test/unit/test-custom-element.js
+++ b/test/unit/test-custom-element.js
@@ -2000,16 +2000,17 @@ describes.realWin('CustomElement', {amp: true}, (env) => {
         expect(toggle).to.have.not.been.called;
       });
 
-      it('should start loading when measured if already in viewport', () => {
-        stubInA4A(false);
-        const toggle = env.sandbox.spy(element, 'toggleLoading');
-        element.isInViewport_ = true;
-        element.setAttribute('layout', 'fill');
-        container.appendChild(element);
-        element.updateLayoutBox({top: 0, width: 300});
-        expect(toggle).to.be.calledOnce;
-        expect(toggle.firstCall.args[0]).to.equal(true);
-      });
+      // WHY when measured?
+      // it('should start loading when measured if already in viewport', () => {
+      //   stubInA4A(false);
+      //   const toggle = env.sandbox.spy(element, 'toggleLoading');
+      //   element.isInViewport_ = true;
+      //   element.setAttribute('layout', 'fill');
+      //   container.appendChild(element);
+      //   element.updateLayoutBox({top: 0, width: 300});
+      //   expect(toggle).to.be.calledOnce;
+      //   expect(toggle.firstCall.args[0]).to.equal(true);
+      // });
 
       it('should create loading when measured if in the top window', () => {
         stubInA4A(false);


### PR DESCRIPTION
**summary**
The `custom-elements.getLayoutBox` function always triggers a toggleLoading for in-viewport elements. Why do we do this? Can it be removed? We already call `this.toggleLoading(true)` within viewportCallback.

We can also simplify some of the conditions considering that `prepareLoading` will also noop if either `this.loadingContainer_` exists or if `this.isLoadingEnabled` returns false.

/to @ampproject/wg-runtime 