### PR TITLE
🏗♻️ More fixes for `gulp --compiled`

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -30,7 +30,9 @@ const {isTravisBuild} = require('./build-system/common/travis');
 const argv = minimist(process.argv.slice(2));
 
 const isClosureCompiler =
-  argv._.includes('dist') || argv._.includes('check-types');
+  argv._.includes('dist') ||
+  argv._.includes('check-types') ||
+  (argv._.length == 0 && argv.compiled);
 const {esm} = argv;
 
 const targets = (esm) => {

--- a/build-system/tasks/build.js
+++ b/build-system/tasks/build.js
@@ -59,6 +59,18 @@ async function watch() {
 }
 
 /**
+ * Perform the prerequisite steps before starting the unminified build.
+ * Used by `gulp` and `gulp build`.
+ *
+ * @param {boolean} watch
+ */
+async function runPreBuildSteps(watch) {
+  await compileCss(watch);
+  await compileJison();
+  await bootstrapThirdPartyFrames(watch);
+}
+
+/**
  * Unminified build. Entry point for `gulp build`.
  */
 async function build() {
@@ -68,9 +80,7 @@ async function build() {
   printNobuildHelp();
   printConfigHelp('gulp build');
   parseExtensionFlags();
-  await compileCss(argv.watch);
-  await compileJison();
-  await bootstrapThirdPartyFrames(argv.watch);
+  await runPreBuildSteps(argv.watch);
   if (argv.core_runtime_only) {
     await compileCoreRuntime(argv.watch, /* minify */ false);
   } else {
@@ -84,6 +94,7 @@ async function build() {
 
 module.exports = {
   build,
+  runPreBuildSteps,
   watch,
 };
 

--- a/build-system/tasks/default-task.js
+++ b/build-system/tasks/default-task.js
@@ -18,7 +18,7 @@ const log = require('fancy-log');
 const {bootstrapThirdPartyFrames, printConfigHelp} = require('./helpers');
 const {compileCss} = require('./css');
 const {compileJison} = require('./compile-jison');
-const {copyCss, copyParsers} = require('./dist');
+const {copyCss, copyParsers, prebuild} = require('./dist');
 const {createCtrlcHandler} = require('../common/ctrlcHandler');
 const {cyan, green} = require('ansi-colors');
 const {doServe} = require('./serve');
@@ -51,6 +51,9 @@ async function defaultTask() {
   printConfigHelp('gulp');
   printDefaultTaskHelp();
   parseExtensionFlags(/* preBuild */ true);
+  if (argv.compiled) {
+    await prebuild();
+  }
   await compileCss(/* watch */ true);
   await compileJison();
   if (argv.compiled) {

--- a/build-system/tasks/default-task.js
+++ b/build-system/tasks/default-task.js
@@ -57,7 +57,7 @@ async function defaultTask() {
     await copyCss();
     await copyParsers();
   }
-  await bootstrapThirdPartyFrames(/* watch */ true);
+  await bootstrapThirdPartyFrames(/* watch */ true, argv.compiled);
   await doServe(/* lazyBuild */ true);
   log(green('JS and extensions will be lazily built when requested...'));
 }

--- a/build-system/tasks/default-task.js
+++ b/build-system/tasks/default-task.js
@@ -68,11 +68,22 @@ defaultTask.description =
   'Starts the dev server, lazily builds JS and extensions when requested, and watches them for changes';
 defaultTask.flags = {
   compiled: '  Compiles and serves minified binaries',
+  pseudo_names:
+    '  Compiles with readable names. ' +
+    'Great for profiling and debugging production code.',
+  pretty_print:
+    '  Outputs compiled code with whitespace. ' +
+    'Great for debugging production code.',
+  fortesting: '  Compiles production binaries for local testing',
+  noconfig: '  Compiles production binaries without applying AMP_CONFIG',
   config: '  Sets the runtime\'s AMP_CONFIG to one of "prod" or "canary"',
   closure_concurrency: '  Sets the number of concurrent invocations of closure',
   extensions: '  Pre-builds the given extensions, lazily builds the rest.',
   extensions_from:
     '  Pre-builds the extensions used by the provided example page.',
+  full_sourcemaps: '  Includes source code content in sourcemaps',
+  disable_nailgun:
+    "  Doesn't use nailgun to invoke closure compiler (much slower)",
   version_override: '  Overrides the version written to AMP_CONFIG',
   custom_version_mark: '  Set final digit (0-9) on auto-generated version',
 };

--- a/build-system/tasks/default-task.js
+++ b/build-system/tasks/default-task.js
@@ -14,18 +14,16 @@
  * limitations under the License.
  */
 
+const argv = require('minimist')(process.argv.slice(2));
 const log = require('fancy-log');
-const {bootstrapThirdPartyFrames, printConfigHelp} = require('./helpers');
-const {compileCss} = require('./css');
-const {compileJison} = require('./compile-jison');
-const {copyCss, copyParsers, prebuild} = require('./dist');
 const {createCtrlcHandler} = require('../common/ctrlcHandler');
 const {cyan, green} = require('ansi-colors');
 const {doServe} = require('./serve');
 const {maybeUpdatePackages} = require('./update-packages');
 const {parseExtensionFlags} = require('./extension-helpers');
-
-const argv = require('minimist')(process.argv.slice(2));
+const {printConfigHelp} = require('./helpers');
+const {runPreBuildSteps} = require('./build');
+const {runPreDistSteps} = require('./dist');
 
 /**
  * Prints a useful help message prior to the default gulp task
@@ -52,15 +50,10 @@ async function defaultTask() {
   printDefaultTaskHelp();
   parseExtensionFlags(/* preBuild */ true);
   if (argv.compiled) {
-    await prebuild();
+    await runPreDistSteps(/* watch */ true);
+  } else {
+    await runPreBuildSteps(/* watch */ true);
   }
-  await compileCss(/* watch */ true);
-  await compileJison();
-  if (argv.compiled) {
-    await copyCss();
-    await copyParsers();
-  }
-  await bootstrapThirdPartyFrames(/* watch */ true, argv.compiled);
   await doServe(/* lazyBuild */ true);
   log(green('JS and extensions will be lazily built when requested...'));
 }

--- a/build-system/tasks/dist.js
+++ b/build-system/tasks/dist.js
@@ -86,6 +86,23 @@ function printDistHelp() {
 }
 
 /**
+ * Perform the prerequisite steps before starting the minified build.
+ * Used by `gulp` and `gulp dist`.
+ *
+ * @param {boolean} watch
+ */
+async function runPreDistSteps(watch) {
+  cleanupBuildDir();
+  await prebuild();
+  await compileCss(watch);
+  await compileJison();
+  await copyCss();
+  await copyParsers();
+  await bootstrapThirdPartyFrames(watch, /* minify */ true);
+  await startNailgunServer(distNailgunPort, /* detached */ false);
+}
+
+/**
  * Dist Build
  * @return {!Promise}
  */
@@ -96,17 +113,9 @@ async function dist() {
   printNobuildHelp();
   printDistHelp();
 
-  cleanupBuildDir();
-  await prebuild();
-  await compileCss();
-  await compileJison();
-
-  await copyCss();
-  await copyParsers();
-  await bootstrapThirdPartyFrames(argv.watch, /* minify */ true);
+  await runPreDistSteps(argv.watch);
 
   // Steps that use closure compiler. Small ones before large (parallel) ones.
-  await startNailgunServer(distNailgunPort, /* detached */ false);
   if (argv.core_runtime_only) {
     await compileCoreRuntime(argv.watch, /* minify */ true);
   } else {
@@ -419,9 +428,7 @@ function preBuildLoginDoneVersion(version) {
 
 module.exports = {
   dist,
-  copyCss,
-  copyParsers,
-  prebuild,
+  runPreDistSteps,
 };
 
 /* eslint "google-camelcase/google-camelcase": 0 */

--- a/build-system/tasks/dist.js
+++ b/build-system/tasks/dist.js
@@ -421,6 +421,7 @@ module.exports = {
   dist,
   copyCss,
   copyParsers,
+  prebuild,
 };
 
 /* eslint "google-camelcase/google-camelcase": 0 */

--- a/build-system/tasks/serve.js
+++ b/build-system/tasks/serve.js
@@ -24,19 +24,14 @@ const morgan = require('morgan');
 const path = require('path');
 const watch = require('gulp-watch');
 const {
-  distNailgunPort,
-  startNailgunServer,
-  stopNailgunServer,
-} = require('./nailgun');
-const {
   lazyBuildExtensions,
   lazyBuildJs,
   preBuildRuntimeFiles,
   preBuildExtensions,
 } = require('../server/lazy-build');
-const {cleanupBuildDir} = require('../compile/compile');
 const {createCtrlcHandler} = require('../common/ctrlcHandler');
 const {cyan, green, red} = require('ansi-colors');
+const {distNailgunPort, stopNailgunServer} = require('./nailgun');
 const {exec} = require('../common/exec');
 const {logServeMode, setServeMode} = require('../server/app-utils');
 
@@ -118,11 +113,6 @@ async function startServer(
   url = `http${options.https ? 's' : ''}://${options.host}:${options.port}`;
   log(green('Started'), cyan(options.name), green('at'), cyan(url));
   logServeMode();
-
-  if (lazyBuild && argv.compiled) {
-    cleanupBuildDir();
-    await startNailgunServer(distNailgunPort, /* detached */ false);
-  }
 }
 
 /**

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -88,7 +88,8 @@ function createTask(name, taskFunc) {
  * @param {function} taskFunc
  */
 function checkFlags(name, taskFunc) {
-  if (!argv._.includes(name)) {
+  const isDefaultTask = name == 'default' && argv._.length == 0;
+  if (!argv._.includes(name) && !isDefaultTask) {
     return; // This isn't the task being run.
   }
   const validFlags = taskFunc.flags ? Object.keys(taskFunc.flags) : [];


### PR DESCRIPTION
**PR highlights:**
- Refactors prerequisite steps for `gulp build` into `runPreBuildSteps()`
- Refactors prerequisite steps for `gulp dist` into `runPreDistSteps()`
- Reuses both functions during unminified / minified lazy build
- Removes all unnecessary copy-pasted steps
- Documents flags for default `gulp` task
- Fixes 3p frame compilation flags during lazy build
- Fixes config returned by `babel.config.js` during minified lazy build

With this PR, the two commands listed below generated identical `v0.js` files:

```sh
gulp dist --core_runtime_only
gulp --compiled
```

Follow up to #27471 and #27515