### PR TITLE
[amp-sidebar] Replace base visual test with interactive test

### DIFF
--- a/examples/visual-tests/amp-sidebar/amp-sidebar-toolbar.js
+++ b/examples/visual-tests/amp-sidebar/amp-sidebar-toolbar.js
@@ -20,11 +20,20 @@
 
 const {
   verifySelectorsVisible,
+  verifySelectorsInvisible,
 } = require('../../../build-system/tasks/visual-diff/helpers');
 
 module.exports = {
+  'renders closed': async (page, name) => {
+    await verifySelectorsInvisible(page, name, [
+      'amp-sidebar.i-amphtml-element',
+    ]);
+  },
+
   'open sidebar toolbar': async (page, name) => {
-    await page.tap('[on="tap:sidebar.toggle"]');
+    const toggleButtonSelector = '[on="tap:sidebar.toggle"]';
+    await verifySelectorsVisible(page, name, [toggleButtonSelector]);
+    await page.tap(toggleButtonSelector);
     await verifySelectorsVisible(page, name, ['amp-sidebar[open]']);
     await verifySelectorsVisible(page, name, ['nav[toolbar]']);
   },

--- a/examples/visual-tests/amp-sidebar/amp-sidebar.js
+++ b/examples/visual-tests/amp-sidebar/amp-sidebar.js
@@ -17,11 +17,20 @@
 
 const {
   verifySelectorsVisible,
+  verifySelectorsInvisible,
 } = require('../../../build-system/tasks/visual-diff/helpers');
 
 module.exports = {
+  'renders closed': async (page, name) => {
+    await verifySelectorsInvisible(page, name, [
+      'amp-sidebar.i-amphtml-element',
+    ]);
+  },
+
   'open sidebar': async (page, name) => {
-    await page.tap('[on="tap:sidebar1.toggle"]');
+    const toggleButtonSelector = '[on="tap:sidebar1.toggle"]';
+    await verifySelectorsVisible(page, name, [toggleButtonSelector]);
+    await page.tap(toggleButtonSelector);
     await verifySelectorsVisible(page, name, ['amp-sidebar[open]']);
   },
 };

--- a/test/visual-diff/visual-tests
+++ b/test/visual-diff/visual-tests
@@ -214,21 +214,21 @@
       "name": "amp-sidebar",
       "viewport": {"width": 400, "height": 800},
       "interactive_tests": "examples/visual-tests/amp-sidebar/amp-sidebar.js",
-      "loading_incomplete_selectors": ["amp-sidebar.i-amphtml-element"]
+      "no_base_test": true
     },
     {
       "url": "examples/visual-tests/amp-sidebar/amp-sidebar-toolbar-ol.amp.html",
       "name": "amp-sidebar toolbar > ol",
       "viewport": {"width": 400, "height": 800},
       "interactive_tests": "examples/visual-tests/amp-sidebar/amp-sidebar-toolbar.js",
-      "loading_incomplete_selectors": ["amp-sidebar.i-amphtml-element"]
+      "no_base_test": true
     },
     {
       "url": "examples/visual-tests/amp-sidebar/amp-sidebar-toolbar-ul.amp.html",
       "name": "amp-sidebar toolbar > ul",
       "viewport": {"width": 400, "height": 800},
       "interactive_tests": "examples/visual-tests/amp-sidebar/amp-sidebar-toolbar.js",
-      "loading_incomplete_selectors": ["amp-sidebar.i-amphtml-element"]
+      "no_base_test": true
     },
     {
       // TODO(#27455, @ampproject/wg-ads): see https://percy.io/ampproject/amphtml/builds/4672752


### PR DESCRIPTION
`amp-sidebar` visual tests occasionally flakes [[1](https://percy.io/ampproject/amphtml/builds/4753560), [2](https://percy.io/ampproject/amphtml/builds/4752459)] if the screenshot is taken before the element completely builds. The pre-build visual state of the component is for the navigational menu to be visible. A selector that indicates the build has completed is `amp-sidebar.i-amphtml-element`, at which point the sidebar is invisible and its nested navigational menu subsequently becomes hidden as well. 

The base test specifies that the aforementioned selector should be hidden with `loading_incomplete_selectors`, however that property is satisfied upon the given selector(s) being _either_ present and invisible _or_ absent. When sidebar is fully loaded, the selector has the former state. When the test flakes, the selector has the latter state. 

This PR removes the base test and replaces it with an interactive test that more precisely waits for the selector to be invisible, not just absent.

Related to #27456