### PR TITLE
🐛 Set content-type header for error-reporting

### DIFF
--- a/src/error.js
+++ b/src/error.js
@@ -376,6 +376,7 @@ export function reportErrorToServerOrViewer(win, data) {
           ? newErrorReportingUrl
           : urls.errorReporting;
       xhr.open('POST', url, true);
+      xhr.setRequestHeader('Content-Type', 'application/json');
       xhr.send(JSON.stringify(data));
     }
   });


### PR DESCRIPTION
Currently, the AMP Runtime doesn't set the content-type header when reporting errors. On the legacy error-reporting, we were able to ignore the header and try to parse the request body anyway. Within Cloud Functions, the framework parses the request body based on this header, and consuming functions have access to the parsed body.

This PR adds the missing request header.