### PR TITLE
🚀 Move from custom logic to babel evaluate

### DIFF
--- a/build-system/babel-plugins/babel-plugin-transform-stringish-literals/test/fixtures/transform/binary-expression/output.js
+++ b/build-system/babel-plugins/babel-plugin-transform-stringish-literals/test/fixtures/transform/binary-expression/output.js
@@ -13,17 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-let add = `/rtv/bar`;
-let multipleAdd = `/rtv/bar/`;
-let subtract = `/rtv` - `r`;
-let multiply = `/rtv` * `r`;
-let divide = `/rtv` / `r`;
-let numberStart = `1/foo`;
-let stringStart = `1/foo`;
-let numberEnd = `foo/1`;
-let stringEnd = `foo/1`;
-let illegalCharacter = `Invalid share providers configuration for in bookend. Value must be \`true\` or a params object.`;
+let add = "/rtv/bar";
+let multipleAdd = "/rtv/bar/";
+let subtract = 0 / 0;
+let multiply = 0 / 0;
+let divide = 0 / 0;
+let numberStart = "1/foo";
+let stringStart = "1/foo";
+let numberEnd = "foo/1";
+let stringEnd = "foo/1";
+let illegalCharacter = "Invalid share providers configuration for in bookend. Value must be `true` or a params object.";
 let stringLiterals = "12";
-let numberLiterals = 1 + 2;
-let booleanLiterals = false + true;
-let identifiers = `${foo}${bar}`;
+let numberLiterals = 3;
+let booleanLiterals = 1;
+let identifiers = `${foo}` + `${bar}`;

--- a/build-system/babel-plugins/babel-plugin-transform-stringish-literals/test/fixtures/transform/literals/output.js
+++ b/build-system/babel-plugins/babel-plugin-transform-stringish-literals/test/fixtures/transform/literals/output.js
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-let none = `/rtv/100/log-messages.simple.json`;
-let start = `123/foo`;
-let middle = `/rtv/012003312116250/log-messages.simple.json`;
-let end = `rtv/123`;
-let number = `123/foo`;
-let boolean = `true/foo`;
+let none = "/rtv/100/log-messages.simple.json";
+let start = "123/foo";
+let middle = "/rtv/012003312116250/log-messages.simple.json";
+let end = "rtv/123";
+let number = "123/foo";
+let boolean = "true/foo";


### PR DESCRIPTION
A followup to #27516. This PR removes much of the one-off logic and instead uses Babel's evaluate functionality.