### PR TITLE
Split 'on tap' and 'on tap and swipe' education messages.

### DIFF
--- a/extensions/amp-story-education/0.1/amp-story-education.js
+++ b/extensions/amp-story-education/0.1/amp-story-education.js
@@ -55,7 +55,8 @@ const buildNavigationEl = (element) => {
 
 /** @enum {string} */
 const Screen = {
-  ONBOARDING_NAVIGATION_TAP_AND_SWIPE: 'ontas',
+  ONBOARDING_NAVIGATION_TAP: 'ont', // Sent on page load if no "swipe" capability.
+  ONBOARDING_NAVIGATION_TAP_AND_SWIPE: 'ontas', // Sent on page load if "swipe" capability.
 };
 
 /** @enum */
@@ -106,10 +107,10 @@ export class AmpStoryEducation extends AMP.BaseElement {
     const isMobileUI =
       this.storeService_.get(StateProperty.UI_STATE) === UIType.MOBILE;
     if (this.viewer_.isEmbedded() && isMobileUI) {
-      this.maybeShowScreen_(
-        Screen.ONBOARDING_NAVIGATION_TAP_AND_SWIPE,
-        State.NAVIGATION_TAP
-      );
+      const screen = this.viewer_.hasCapability('swipe')
+        ? Screen.ONBOARDING_NAVIGATION_TAP_AND_SWIPE
+        : Screen.ONBOARDING_NAVIGATION_TAP;
+      this.maybeShowScreen_(screen, State.NAVIGATION_TAP);
     }
   }
 

--- a/extensions/amp-story-education/0.1/test/test-amp-story-education.js
+++ b/extensions/amp-story-education/0.1/test/test-amp-story-education.js
@@ -216,7 +216,22 @@ describes.realWin('amp-story-education', {amp: true}, (env) => {
       expect(sendStub).to.not.have.been.called;
     });
 
-    it('should send canShowScreens for navigation on build', async () => {
+    it('should send canShowScreens ont for navigation on build', async () => {
+      const sendStub = env.sandbox.stub(viewer, 'sendMessageAwaitResponse');
+      env.sandbox
+        .stub(storyEducation.getAmpDoc(), 'whenFirstVisible')
+        .resolves();
+
+      storyEducation.buildCallback();
+      await Promise.resolve(); // Microtask tick.
+
+      expect(sendStub).to.have.been.calledOnceWith('canShowScreens', {
+        screens: [{screen: 'ont'}],
+      });
+    });
+
+    it('should send canShowScreens ontas for navigation on build', async () => {
+      hasSwipeCap = true;
       const sendStub = env.sandbox.stub(viewer, 'sendMessageAwaitResponse');
       env.sandbox
         .stub(storyEducation.getAmpDoc(), 'whenFirstVisible')


### PR DESCRIPTION
Story education API update:
- If `cap=swipe` is NOT present, send a "on tap" message to only show the tap education screen
- If `cap=swipe` is present, send a "on tap and swipe" message to display both tap and swipe education screens

#27097