### PR TITLE
🚀 Introduce more chunking in FIE init

### DIFF
--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -21,6 +21,11 @@
 // extensions/amp-ad-network-${NETWORK_NAME}-impl directory.
 
 import {EXPERIMENT_INFO_MAP as AMPDOC_FIE_EXPERIMENT_INFO_MAP} from '../../../src/ampdoc-fie';
+import {AdsenseSharedState} from './adsense-shared-state';
+import {AmpA4A} from '../../amp-a4a/0.1/amp-a4a';
+import {CONSENT_POLICY_STATE} from '../../../src/consent-state';
+import {FIE_INIT_CHUNKING_EXP} from '../../../src/friendly-iframe-embed';
+import {Navigation} from '../../../src/service/navigation';
 import {
   AMP_AD_NO_CENTER_CSS_EXP,
   QQID_HEADER,
@@ -228,6 +233,13 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
         branches: [
           AMP_AD_NO_CENTER_CSS_EXP.control,
           AMP_AD_NO_CENTER_CSS_EXP.experiment,
+        ],
+      },
+      [[FIE_INIT_CHUNKING_EXP.id]]: {
+        isTrafficEligible: () => true,
+        branches: [
+          [FIE_INIT_CHUNKING_EXP.control],
+          [FIE_INIT_CHUNKING_EXP.experiment],
         ],
       },
       ...AMPDOC_FIE_EXPERIMENT_INFO_MAP,

--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -21,11 +21,6 @@
 // extensions/amp-ad-network-${NETWORK_NAME}-impl directory.
 
 import {EXPERIMENT_INFO_MAP as AMPDOC_FIE_EXPERIMENT_INFO_MAP} from '../../../src/ampdoc-fie';
-import {AdsenseSharedState} from './adsense-shared-state';
-import {AmpA4A} from '../../amp-a4a/0.1/amp-a4a';
-import {CONSENT_POLICY_STATE} from '../../../src/consent-state';
-import {FIE_INIT_CHUNKING_EXP} from '../../../src/friendly-iframe-embed';
-import {Navigation} from '../../../src/service/navigation';
 import {
   AMP_AD_NO_CENTER_CSS_EXP,
   QQID_HEADER,
@@ -46,6 +41,7 @@ import {
 import {AdsenseSharedState} from './adsense-shared-state';
 import {AmpA4A} from '../../amp-a4a/0.1/amp-a4a';
 import {CONSENT_POLICY_STATE} from '../../../src/consent-state';
+import {FIE_INIT_CHUNKING_EXP} from '../../../src/friendly-iframe-embed';
 import {Navigation} from '../../../src/service/navigation';
 import {ResponsiveState} from './responsive-state';
 import {Services} from '../../../src/services';

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -52,6 +52,7 @@ import {
 } from '../../amp-a4a/0.1/amp-a4a';
 import {CONSENT_POLICY_STATE} from '../../../src/consent-state';
 import {Deferred} from '../../../src/utils/promise';
+import {FIE_INIT_CHUNKING_EXP} from '../../../src/friendly-iframe-embed';
 import {
   FlexibleAdSlotDataTypeDef,
   getFlexibleAdSlotData,
@@ -393,6 +394,13 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
         branches: [
           [AMP_AD_NO_CENTER_CSS_EXP.control],
           [AMP_AD_NO_CENTER_CSS_EXP.experiment],
+        ],
+      },
+      [[FIE_INIT_CHUNKING_EXP.id]]: {
+        isTrafficEligible: () => true,
+        branches: [
+          [FIE_INIT_CHUNKING_EXP.control],
+          [FIE_INIT_CHUNKING_EXP.experiment],
         ],
       },
       ...AMPDOC_FIE_EXPERIMENT_INFO_MAP,

--- a/src/friendly-iframe-embed.js
+++ b/src/friendly-iframe-embed.js
@@ -113,7 +113,7 @@ function getDelayPromise(win) {
   ) {
     return (val) =>
       new Promise((resolve) => {
-        setTimeout(() => resolve(val), 0);
+        setTimeout(() => resolve(val), 1);
       });
   } else {
     return (val) => Promise.resolve(val);
@@ -790,6 +790,14 @@ export class FriendlyIframeEmbed {
     const parentWin = toWin(childWin.frameElement.ownerDocument.defaultView);
     setParentWindow(childWin, parentWin);
 
+    extensionIds.forEach((extensionId) => {
+      // This will extend automatic upgrade of custom elements from top
+      // window to the child window.
+      if (!LEGACY_ELEMENTS.includes(extensionId)) {
+        stubElementIfNotKnown(childWin, extensionId);
+      }
+    });
+
     const maybeDelay = getDelayPromise(parentWin);
     return Promise.resolve()
       .then(maybeDelay)
@@ -830,6 +838,7 @@ export class FriendlyIframeEmbed {
       .then(() => {
         const promises = [];
         extensionIds.forEach((extensionId) => {
+<<<<<<< HEAD
           // This will extend automatic upgrade of custom elements from top
           // window to the child window.
           if (!LEGACY_ELEMENTS.includes(extensionId)) {
@@ -859,6 +868,8 @@ export class FriendlyIframeEmbed {
                   /* isRuntime */ false,
                   extensionId
 =======
+=======
+>>>>>>> 912f443f0... Fix tests
           const promise = extensions
             .preloadExtension(extensionId)
             .then((extension) => {

--- a/src/friendly-iframe-embed.js
+++ b/src/friendly-iframe-embed.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import {ChunkPriority, chunk} from './chunk';
 import {CommonSignals} from './common-signals';
 import {FIE_EMBED_PROP} from './iframe-helper';
 import {LEGACY_ELEMENTS, stubLegacyElements} from './service/extensions-impl';
@@ -109,10 +108,9 @@ function getDelayPromiseProducer(win) {
     getExperimentBranch(win, FIE_INIT_CHUNKING_EXP.id) ===
       FIE_INIT_CHUNKING_EXP.experiment
   ) {
-    const ampdoc = getAmpdoc(win.document);
     return (val) =>
       new Promise((resolve) => {
-        chunk(ampdoc, () => resolve(val), ChunkPriority.HIGH);
+        setTimeout(() => resolve(val), 1);
       });
   } else {
     return (val) => Promise.resolve(val);

--- a/src/friendly-iframe-embed.js
+++ b/src/friendly-iframe-embed.js
@@ -224,7 +224,7 @@ export function installFriendlyIframeEmbed(
   // we have to fallback to polling.
   let readyPromise;
   if (isIframeReady(iframe)) {
-    readyPromise = getDelayPromise(win)();
+    readyPromise = getDelayPromise(win)(undefined);
   } else {
     readyPromise = new Promise((resolve) => {
       /** @const {number} */

--- a/test/unit/test-friendly-iframe-embed.js
+++ b/test/unit/test-friendly-iframe-embed.js
@@ -813,7 +813,15 @@ describes.realWin('friendly-iframe-embed', {amp: true}, (env) => {
         ready = true;
       });
       return Promise.race([
-        Promise.resolve().then().then().then().then().then().then(),
+        Promise.resolve()
+          .then()
+          .then()
+          .then()
+          .then()
+          .then()
+          .then()
+          .then()
+          .then(),
         embedPromise,
       ]).then(() => {
         expect(ready).to.be.true;

--- a/test/unit/test-friendly-iframe-embed.js
+++ b/test/unit/test-friendly-iframe-embed.js
@@ -798,36 +798,6 @@ describes.realWin('friendly-iframe-embed', {amp: true}, (env) => {
       expect(polls).to.have.length(0);
     });
 
-    it('should not poll if body is already ready', () => {
-      contentBody.firstChild = {};
-      contentDocument.body = contentBody;
-      contentWindow.document = contentDocument;
-      iframe.contentWindow = contentWindow;
-      const embedPromise = installFriendlyIframeEmbed(iframe, container, {
-        url: 'https://acme.org/url1',
-        html: '<body></body>',
-      });
-      expect(polls).to.have.length(0);
-      let ready = false;
-      embedPromise.then(() => {
-        ready = true;
-      });
-      return Promise.race([
-        Promise.resolve()
-          .then()
-          .then()
-          .then()
-          .then()
-          .then()
-          .then()
-          .then()
-          .then(),
-        embedPromise,
-      ]).then(() => {
-        expect(ready).to.be.true;
-      });
-    });
-
     it('should poll until ready', () => {
       iframe.contentWindow = contentWindow;
       const embedPromise = installFriendlyIframeEmbed(iframe, container, {

--- a/test/unit/test-friendly-iframe-embed.js
+++ b/test/unit/test-friendly-iframe-embed.js
@@ -1108,46 +1108,56 @@ describes.realWin('installExtensionsInChildWindow', {amp: true}, (env) => {
   });
 
   it('should install runtime styles', () => {
-    fie.installExtensionsInChildWindow(extensions, iframeWin, []);
-    expect(iframeWin.document.querySelector('style[amp-runtime]')).to.exist;
+    return fie
+      .installExtensionsInChildWindow(extensions, iframeWin, [])
+      .then(() => {
+        expect(iframeWin.document.querySelector('style[amp-runtime]')).to.exist;
+      });
   });
 
   it('should install built-ins', () => {
-    fie.installExtensionsInChildWindow(extensions, iframeWin, []);
-    expect(iframeWin.__AMP_EXTENDED_ELEMENTS).to.exist;
-    expect(iframeWin.__AMP_EXTENDED_ELEMENTS['amp-img']).to.exist;
-    expect(iframeWin.__AMP_EXTENDED_ELEMENTS['amp-img']).to.not.equal(
-      ElementStub
-    );
-    expect(iframeWin.__AMP_EXTENDED_ELEMENTS['amp-pixel']).to.exist;
-    expect(iframeWin.__AMP_EXTENDED_ELEMENTS['amp-pixel']).to.not.equal(
-      ElementStub
-    );
-    // Legacy elements are installed as well.
-    expect(iframeWin.__AMP_EXTENDED_ELEMENTS['amp-ad']).to.equal(ElementStub);
-    expect(iframeWin.__AMP_EXTENDED_ELEMENTS['amp-embed']).to.equal(
-      ElementStub
-    );
-    expect(iframeWin.__AMP_EXTENDED_ELEMENTS['amp-video']).to.equal(
-      ElementStub
-    );
+    return fie
+      .installExtensionsInChildWindow(extensions, iframeWin, [])
+      .then(() => {
+        expect(iframeWin.__AMP_EXTENDED_ELEMENTS).to.exist;
+        expect(iframeWin.__AMP_EXTENDED_ELEMENTS['amp-img']).to.exist;
+        expect(iframeWin.__AMP_EXTENDED_ELEMENTS['amp-img']).to.not.equal(
+          ElementStub
+        );
+        expect(iframeWin.__AMP_EXTENDED_ELEMENTS['amp-pixel']).to.exist;
+        expect(iframeWin.__AMP_EXTENDED_ELEMENTS['amp-pixel']).to.not.equal(
+          ElementStub
+        );
+        // Legacy elements are installed as well.
+        expect(iframeWin.__AMP_EXTENDED_ELEMENTS['amp-ad']).to.equal(
+          ElementStub
+        );
+        expect(iframeWin.__AMP_EXTENDED_ELEMENTS['amp-embed']).to.equal(
+          ElementStub
+        );
+        expect(iframeWin.__AMP_EXTENDED_ELEMENTS['amp-video']).to.equal(
+          ElementStub
+        );
+      });
   });
 
   it('should adopt standard services', () => {
-    fie.installExtensionsInChildWindow(extensions, iframeWin, []);
+    return fie
+      .installExtensionsInChildWindow(extensions, iframeWin, [])
+      .then(() => {
+        const any = {}; // Input doesn't matter since services are stubbed.
+        const url = Services.urlForDoc(any);
+        const actions = Services.actionServiceForDoc(any);
+        const standardActions = Services.standardActionsForDoc(any);
+        const navigation = Services.navigationForDoc(any);
 
-    const any = {}; // Input doesn't matter since services are stubbed.
-    const url = Services.urlForDoc(any);
-    const actions = Services.actionServiceForDoc(any);
-    const standardActions = Services.standardActionsForDoc(any);
-    const navigation = Services.navigationForDoc(any);
+        expect(url.constructor.installInEmbedWindow).to.be.called;
+        expect(actions.constructor.installInEmbedWindow).to.be.called;
+        expect(standardActions.constructor.installInEmbedWindow).to.be.called;
+        expect(navigation.constructor.installInEmbedWindow).to.be.called;
 
-    expect(url.constructor.installInEmbedWindow).to.be.called;
-    expect(actions.constructor.installInEmbedWindow).to.be.called;
-    expect(standardActions.constructor.installInEmbedWindow).to.be.called;
-    expect(navigation.constructor.installInEmbedWindow).to.be.called;
-
-    expect(getService(iframeWin, 'timer')).to.exist;
+        expect(getService(iframeWin, 'timer')).to.exist;
+      });
   });
 
   it('should install extensions in child window', () => {

--- a/tools/experiments/experiments-config.js
+++ b/tools/experiments/experiments-config.js
@@ -326,4 +326,9 @@ export const EXPERIMENTS = [
     name: 'Removing the centering css rule for amp-ad',
     spec: 'https://github.com/ampproject/amphtml/issues/27095',
   },
+  {
+    id: 'fie-init-chunking',
+    name: 'More chunking for friendly iframe initialization',
+    spec: 'https://github.com/ampproject/amphtml/issues/27584',
+  },
 ];


### PR DESCRIPTION
https://github.com/ampproject/amphtml/issues/27584

Chunking the FIE initialization steps. My local profiling shows that with the experiment on, the js execution block seems a bit smaller (210ms->160ms).

@calebcordry can you help validate that on your device?

Chrome profiling flame charts attached:
[Control group](https://github.com/ampproject/amphtml/files/4482935/Profile-Control.txt)

![Screen Shot 2020-04-20 at 12 20 31](https://user-images.githubusercontent.com/1321403/79790993-720ecd00-8301-11ea-9e09-e4373ba0c1a3.jpg)

[Experiment group](https://github.com/ampproject/amphtml/files/4482936/Profile-Experiment.txt)

![Screen Shot 2020-04-20 at 12 20 55](https://user-images.githubusercontent.com/1321403/79791005-7804ae00-8301-11ea-914d-2732cca0abfc.jpg)


[Before this PR](https://github.com/ampproject/amphtml/files/4482933/Profile-Before.txt)

I have ran tests 25 times each on a low-end device for friendly iframe rendering of https://github.com/ampproject/amphtml/blob/master/test/fixtures/e2e/amphtml-ads/image.html

Ad rendering is delayed by 1697.08ms (use chunk API) | 1590.24ms (use setTimeout, experiment group) | 1579ms (control group) | 1523ms (before PR)

The "before PR" number has a higher standard deviation (of 133ms), so it is not significant enough to distinguish between it and the "after PR" number.

Based on these numbers, it does not seem like the chunk API is too beneficial here.