### PR TITLE
🏗 Clean up error reporting Beta diversions & divert all Nightly

### DIFF
--- a/build-system/externs/amp.extern.js
+++ b/build-system/externs/amp.extern.js
@@ -241,11 +241,15 @@ AmpConfigType.prototype.thirdPartyFrameRegex;
 /* @public {string} */
 AmpConfigType.prototype.errorReporting;
 /* @public {string} */
+AmpConfigType.prototype.betaErrorReporting;
+/* @public {string} */
 AmpConfigType.prototype.cdn;
 /* @public {string} */
 AmpConfigType.prototype.cdnUrl;
 /* @public {string} */
 AmpConfigType.prototype.errorReportingUrl;
+/* @public {string} */
+AmpConfigType.prototype.betaErrorReportingUrl;
 /* @public {string} */
 AmpConfigType.prototype.localDev;
 /* @public {string} */

--- a/src/config.js
+++ b/src/config.js
@@ -75,6 +75,9 @@ export const urls = {
   localhostRegex: /^https?:\/\/localhost(:\d+)?$/,
   errorReporting:
     env['errorReportingUrl'] || 'https://amp-error-reporting.appspot.com/r',
+  betaErrorReporting:
+    env['betaErrorReportingUrl'] ||
+    'https://us-central1-amp-error-reporting.cloudfunctions.net/r',
   localDev: env['localDev'] || false,
   /**
    * These domains are trusted with more sensitive viewer operations such as

--- a/src/error.js
+++ b/src/error.js
@@ -67,7 +67,7 @@ const USER_ERROR_THROTTLE_THRESHOLD = 0.1;
  * Chance to post to the new error reporting endpoint.
  * @const {number}
  */
-const NEW_ERROR_REPORT_URL_FREQ = 0.2;
+const BETA_ERROR_REPORT_URL_FREQ = 0.2;
 
 /**
  * Collects error messages, so they can be included in subsequent reports.
@@ -356,6 +356,16 @@ function onError(message, filename, line, col, error) {
 }
 
 /**
+ * Determines if the Beta error reporting endpoint should be used.
+ *
+ * @param {!JsonObject} errData Data from `getErrorReportData`.
+ * @return {boolean}
+ */
+function useBetaReportingUrl_(errData) {
+  return errData['esm'] === '1' || Math.random() < BETA_ERROR_REPORT_URL_FREQ;
+}
+
+/**
  * Passes the given error data to either server or viewer.
  * @param {!Window} win
  * @param {!JsonObject} data Data from `getErrorReportData`.
@@ -368,11 +378,11 @@ export function reportErrorToServerOrViewer(win, data) {
   return maybeReportErrorToViewer(win, data).then((reportedErrorToViewer) => {
     if (!reportedErrorToViewer) {
       const xhr = new XMLHttpRequest();
-      // Override the errorReportingUrl to test the new error reporting endpoint.
       const newErrorReportingUrl =
         'https://us-central1-amp-error-reporting.cloudfunctions.net/r';
+      // Divert to the Beta error reporting endpoint.
       const url =
-        IS_ESM || Math.random() < NEW_ERROR_REPORT_URL_FREQ
+        useBetaReportingUrl_(data)
           ? newErrorReportingUrl
           : urls.errorReporting;
       xhr.open('POST', url, true);

--- a/src/error.js
+++ b/src/error.js
@@ -363,7 +363,13 @@ function onError(message, filename, line, col, error) {
  */
 function chooseReportingUrl_(errData) {
   const useBeta =
-    errData['esm'] === '1' || Math.random() < BETA_ERROR_REPORT_URL_FREQ;
+    // Legacy reporting drops non-.js stacktraces.
+    errData['esm'] === '1' ||
+    // Legacy reporting throttles non-canary binary types by a factor of 20.
+    errData['bt'] === 'nightly' ||
+    // Randomly divert remaining error reporting traffic.
+    Math.random() < BETA_ERROR_REPORT_URL_FREQ;
+
   return useBeta ? urls.betaErrorReporting : urls.errorReporting;
 }
 


### PR DESCRIPTION
This PR:
- moves the new error reporting endpoint to a `betaErrorReporting` config field
- moves logic for picking reporting endpoint URL to a helper function
- diverts all nightly traffic to the new endpoint (otherwise traffic % times the 0.05 throttling factor on legacy error reporting will suppress almost all errors from Nightly)

In coming weeks, the new endpoint will become the standard `errorReporting` URL, while the `betaErrorReporting` will eventually become `https://us-central1-amp-error-reporting.cloudfunctions.net/r-beta`. When this happens, all traffic will be going through the migrated error reporting, and the exceptions for ESM and Nightly can be removed.

Part of https://github.com/ampproject/error-tracker/issues/112