### PR TITLE
🚀 Defer viewport getSize in performance-impl

### DIFF
--- a/src/service/performance-impl.js
+++ b/src/service/performance-impl.js
@@ -544,10 +544,10 @@ export class Performance {
    * @private
    */
   whenViewportLayoutComplete_() {
-    const {documentElement} = this.win.document;
-    const size = Services.viewportForDoc(documentElement).getSize();
-    const rect = layoutRectLtwh(0, 0, size.width, size.height);
     return this.resources_.whenFirstPass().then(() => {
+      const {documentElement} = this.win.document;
+      const size = Services.viewportForDoc(documentElement).getSize();
+      const rect = layoutRectLtwh(0, 0, size.width, size.height);
       return whenContentIniLoad(
         documentElement,
         this.win,


### PR DESCRIPTION
The calls to `getSize` show up in testing, taking up as much as 60ms:

<img width="1440" alt="Screen Shot 2020-04-06 at 10 51 01 PM" src="https://user-images.githubusercontent.com/112982/78625802-0174a480-785b-11ea-96c5-182530a12d2b.png">

Note that this doesn't eliminate the recalc, since it will still be done at least once. It just doesn't need to happen so soon (before Resources has even loaded).