### PR TITLE
🚀 Remove 'use strict' directives in post compilation transform for modu…

### DIFF
--- a/build-system/babel-plugins/babel-plugin-transform-remove-directives/index.js
+++ b/build-system/babel-plugins/babel-plugin-transform-remove-directives/index.js
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module.exports = function () {
+  return {
+    name: 'remove-strict-directives',
+    visitor: {
+      Directive(path) {
+        const {node} = path;
+        if (node.value.value === 'use strict') {
+          path.remove();
+        }
+      },
+    },
+  };
+};

--- a/build-system/babel-plugins/babel-plugin-transform-remove-directives/test/fixtures/transform/directives/input.js
+++ b/build-system/babel-plugins/babel-plugin-transform-remove-directives/test/fixtures/transform/directives/input.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+function named() {
+  'use strict';
+}
+
+try {
+  (function () {
+    'use strict';
+  })();
+} catch (e) {}

--- a/build-system/babel-plugins/babel-plugin-transform-remove-directives/test/fixtures/transform/directives/input.js
+++ b/build-system/babel-plugins/babel-plugin-transform-remove-directives/test/fixtures/transform/directives/input.js
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+function without() {}
+
 'use strict';
 
 function named() {

--- a/build-system/babel-plugins/babel-plugin-transform-remove-directives/test/fixtures/transform/directives/options.json
+++ b/build-system/babel-plugins/babel-plugin-transform-remove-directives/test/fixtures/transform/directives/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["../../../../../babel-plugin-transform-remove-directives"]
+}

--- a/build-system/babel-plugins/babel-plugin-transform-remove-directives/test/fixtures/transform/directives/output.js
+++ b/build-system/babel-plugins/babel-plugin-transform-remove-directives/test/fixtures/transform/directives/output.js
@@ -1,3 +1,22 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+function without() {}
+
+'use strict';
+
 function named() {}
 
 try {

--- a/build-system/babel-plugins/babel-plugin-transform-remove-directives/test/fixtures/transform/directives/output.js
+++ b/build-system/babel-plugins/babel-plugin-transform-remove-directives/test/fixtures/transform/directives/output.js
@@ -1,0 +1,5 @@
+function named() {}
+
+try {
+  (function () {})();
+} catch (e) {}

--- a/build-system/babel-plugins/babel-plugin-transform-remove-directives/test/index.js
+++ b/build-system/babel-plugins/babel-plugin-transform-remove-directives/test/index.js
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const runner = require('@babel/helper-plugin-test-runner').default;
+
+runner(__dirname);

--- a/build-system/compile/build.conf.js
+++ b/build-system/compile/build.conf.js
@@ -45,6 +45,7 @@ const postCompilationPlugins = (isEsmBuild) =>
   isEsmBuild
     ? [
         localPlugin('transform-minified-comments'),
+        localPlugin('transform-remove-directives'),
         localPlugin('transform-function-declarations'),
         localPlugin('transform-stringish-literals'),
       ]


### PR DESCRIPTION
When loading the module runtime, documents indicate the module loader system should be used via a `type=module` attribute on corresponding `HTMLScriptElement`s.

This PR removes 'use strict' directives from the module output, since [modules use strict mode by default](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode#Strict_mode_for_modules).