### PR TITLE
🏗 Add new issue template for error reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/error-report.md
+++ b/.github/ISSUE_TEMPLATE/error-report.md
@@ -19,7 +19,7 @@ Details
 Remove the backticks around the link below and replace Error_ID with the ID from
 the Cloud Error Reporting URL.
 -->
-**Error report:** [link](`go/ampe/<Error_ID>`)
+**Error report:** `[link](go/ampe/<Error_ID>)`
 **First seen:** <First seen date> <!--
 Select "1 day" on the error details page for the error and record the
 occurrences.

--- a/.github/ISSUE_TEMPLATE/error-report.md
+++ b/.github/ISSUE_TEMPLATE/error-report.md
@@ -1,0 +1,36 @@
+---
+name: Error report
+about: Used to report production errors seen in AMP Error Reporting.
+title: "\U0001F6A8 Error: [error message]"
+labels: 'Type: Error Report'
+assignees: ''
+
+---
+
+<!-- Please only file error reports from AMP Error Reporting here. -->
+Details
+---
+
+**First seen:** <First seen date>
+<!--
+Select "1 day" on the error details page for the error and record the
+occurrences.
+-->
+**Frequency:** ~ <Daily occurrences>/day
+
+
+Stacktrace
+---
+```
+<!-- Stacktrace here -->
+```
+
+<!--
+If there are other interesting trends to note (ex. all user-agent strings are
+from iPhones, sudden jump in volume with recent release, etc.),
+uncomment and include them in the section below.
+
+Notes
+---
+<Additional notes>
+-->

--- a/.github/ISSUE_TEMPLATE/error-report.md
+++ b/.github/ISSUE_TEMPLATE/error-report.md
@@ -11,6 +11,7 @@ assignees: ''
 Details
 ---
 
+**Error report:** go/ampe/<Error ID>
 **First seen:** <First seen date>
 <!--
 Select "1 day" on the error details page for the error and record the

--- a/.github/ISSUE_TEMPLATE/error-report.md
+++ b/.github/ISSUE_TEMPLATE/error-report.md
@@ -15,7 +15,11 @@ Replace/remove all of the text in brackets, including this text.
 Details
 ---
 
-**Error report:** [link](go/ampe/<Error_ID>)
+<!--
+Remove the backticks around the link below and replace Error_ID with the ID from
+the Cloud Error Reporting URL.
+-->
+**Error report:** [link](`go/ampe/<Error_ID>`)
 **First seen:** <First seen date> <!--
 Select "1 day" on the error details page for the error and record the
 occurrences.

--- a/.github/ISSUE_TEMPLATE/error-report.md
+++ b/.github/ISSUE_TEMPLATE/error-report.md
@@ -7,13 +7,16 @@ assignees: ''
 
 ---
 
-<!-- Please only file error reports from AMP Error Reporting here. -->
+<!--
+Please only file error reports from AMP Error Reporting here.
+Replace/remove all of the text in brackets, including this text.
+-->
+
 Details
 ---
 
-**Error report:** go/ampe/<Error ID>
-**First seen:** <First seen date>
-<!--
+**Error report:** [link](go/ampe/<Error_ID>)
+**First seen:** <First seen date> <!--
 Select "1 day" on the error details page for the error and record the
 occurrences.
 -->
@@ -30,7 +33,9 @@ Stacktrace
 If there are other interesting trends to note (ex. all user-agent strings are
 from iPhones, sudden jump in volume with recent release, etc.),
 uncomment and include them in the section below.
+-->
 
+<!--
 Notes
 ---
 <Additional notes>


### PR DESCRIPTION
The AMP release on-duty monitors AMP Error Reporting and files issues for errors that appear. Usually, the on-duty copy-pastes the message/stacktrace and maybe some extra info. This PR introduces a template for error reports, with clear fields for the on-duty to populate. It also adds the **Type: Error Report** label.

An example issue built from this template can be seen [here](https://github.com/rcebulko/amphtml/issues/6)