### PR TITLE
🐛Require src attribute in amp-ad-custom

### DIFF
--- a/extensions/amp-ad-custom/validator-amp-ad-custom.protoascii
+++ b/extensions/amp-ad-custom/validator-amp-ad-custom.protoascii
@@ -33,6 +33,7 @@ tags: {  # <amp-ad-custom>
   disallowed_ancestor: "AMP-APP-BANNER"
   attrs: {
     name: "src"
+    mandatory: true
     value_url: {
       protocol: "https"
       allow_relative: false


### PR DESCRIPTION
https://github.com/ampproject/amphtml/issues/27614

This requirement should be mandatory but is missing from validator spec. We do not expect to see a large audience encounting problems with it since it would never work.