### PR TITLE
🐛Fixed quiz icon not showing on sharp chip

### DIFF
--- a/extensions/amp-story/1.0/amp-story.css
+++ b/extensions/amp-story/1.0/amp-story.css
@@ -887,8 +887,6 @@ amp-story-quiz[theme="dark"] {
 
 amp-story-quiz[chip-corner="sharp"] {
   --reaction-chip-radius: 8px !important;
-  --reaction-answer-choice-border: transparent !important;
-  --reaction-answer-choice-background: transparent !important;
 }
 
 amp-story-quiz[chip-style="shadow"] {


### PR DESCRIPTION
The white icon would not show on the selected answer if the quiz had chip-corner="sharp" since it was overriding the color to transparent.

Before:
![image](https://user-images.githubusercontent.com/22420856/78720488-cd00f700-78f3-11ea-94ef-9a6b75977f5f.png)

After:
![image](https://user-images.githubusercontent.com/22420856/78720073-084ef600-78f3-11ea-9291-12e815ca21db.png)
