### PR TITLE
Allow one tracking iframe in each amp doc

### DIFF
--- a/examples/amp-next-page.amp.html
+++ b/examples/amp-next-page.amp.html
@@ -21,6 +21,7 @@
   <link rel="canonical" href="https://medium.com/p/cb7f223fad86" >
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <script async src="https://cdn.ampproject.org/v0.js"></script>
+
   <style amp-custom>
     body {
       margin: 0;
@@ -260,7 +261,6 @@
   <script async custom-element="amp-next-page" src="https://cdn.ampproject.org/v0/amp-next-page-1.0.js" data-amp-report-test="amp-app-banner.js"></script>
   <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.2.js"></script>
   <script async custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
-  <script async custom-element="amp-iframe" src="https://cdn.ampproject.org/v0/amp-iframe-0.1.js"></script>
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
   <meta name="apple-itunes-app" content="app-id=828256236, app-argument=medium://p/cb7f223fad86">
   <link rel="manifest" href="medium-manifest.json">
@@ -378,6 +378,7 @@
             Maecenas sollicitudin felis aliquam tortor vulputate,
             ac posuere velit semper.
           </p>
+          
           <p>
             Sed pharetra semper fringilla. Nulla fringilla, neque eget
             varius suscipit, mi turpis congue odio, quis dignissim nisi
@@ -468,13 +469,6 @@
             Ut elementum velit fermentum felis volutpat sodales in non libero.
             Aliquam erat volutpat.
           </p>
-          amp-iframe
-          <amp-iframe width=1 height=1
-            sandbox="allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox"
-            layout="fixed"
-            frameborder="0"
-            src="https://www.w3.org/TR/page-visibility/">
-          </amp-iframe>
         </div>
       </div>
     </article>

--- a/examples/amp-next-page.amp.html
+++ b/examples/amp-next-page.amp.html
@@ -21,7 +21,6 @@
   <link rel="canonical" href="https://medium.com/p/cb7f223fad86" >
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <script async src="https://cdn.ampproject.org/v0.js"></script>
-
   <style amp-custom>
     body {
       margin: 0;
@@ -261,6 +260,7 @@
   <script async custom-element="amp-next-page" src="https://cdn.ampproject.org/v0/amp-next-page-1.0.js" data-amp-report-test="amp-app-banner.js"></script>
   <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.2.js"></script>
   <script async custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
+  <script async custom-element="amp-iframe" src="https://cdn.ampproject.org/v0/amp-iframe-0.1.js"></script>
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
   <meta name="apple-itunes-app" content="app-id=828256236, app-argument=medium://p/cb7f223fad86">
   <link rel="manifest" href="medium-manifest.json">
@@ -378,7 +378,6 @@
             Maecenas sollicitudin felis aliquam tortor vulputate,
             ac posuere velit semper.
           </p>
-          
           <p>
             Sed pharetra semper fringilla. Nulla fringilla, neque eget
             varius suscipit, mi turpis congue odio, quis dignissim nisi
@@ -469,6 +468,13 @@
             Ut elementum velit fermentum felis volutpat sodales in non libero.
             Aliquam erat volutpat.
           </p>
+          amp-iframe
+          <amp-iframe width=1 height=1
+            sandbox="allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox"
+            layout="fixed"
+            frameborder="0"
+            src="https://www.w3.org/TR/page-visibility/">
+          </amp-iframe>
         </div>
       </div>
     </article>

--- a/extensions/amp-iframe/0.1/amp-iframe.js
+++ b/extensions/amp-iframe/0.1/amp-iframe.js
@@ -61,9 +61,6 @@ const ATTRIBUTES_TO_PROPAGATE = [
 let count = 0;
 
 /** @type {number}  */
-let trackingIframeCount = 0;
-
-/** @type {number}  */
 let trackingIframeTimeout = 5000;
 
 export class AmpIframe extends AMP.BaseElement {
@@ -398,8 +395,7 @@ export class AmpIframe extends AMP.BaseElement {
     }
 
     if (this.isTrackingFrame_) {
-      trackingIframeCount++;
-      if (trackingIframeCount > 1) {
+      if (!this.getAmpDoc().registerTrackingIframe()) {
         console /*OK*/
           .error(
             'Only 1 analytics/tracking iframe allowed per ' +

--- a/src/service/ampdoc-impl.js
+++ b/src/service/ampdoc-impl.js
@@ -308,6 +308,9 @@ export class AmpDoc {
     /** @public @const {!Window} */
     this.win = win;
 
+    /** @private */
+    this.hasTrackingIframe_ = false;
+
     /** @public @const {?AmpDoc} */
     this.parent_ = parent;
 
@@ -748,6 +751,19 @@ export class AmpDoc {
    */
   onVisibilityChanged(handler) {
     return this.visibilityStateHandlers_.add(handler);
+  }
+
+  /**
+   * Allow one tracking iframe for each amp doc. Caller need to handle user
+   * error when registeration returns false
+   * @return {boolean}
+   */
+  registerTrackingIframe() {
+    if (this.hasTrackingIframe_) {
+      return false;
+    }
+    this.hasTrackingIframe_ = true;
+    return true;
   }
 }
 

--- a/test/manual/amp-next-page/1.0/articles/article-short.html
+++ b/test/manual/amp-next-page/1.0/articles/article-short.html
@@ -8,6 +8,7 @@
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <script async custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
+  <script async custom-element="amp-iframe" src="https://cdn.ampproject.org/v0/amp-iframe-0.1.js"></script>
   <style amp-custom>
     header {
       position: relative;
@@ -36,6 +37,12 @@
   </style>
 </head>
 <body>
+    <amp-iframe width=5 height=5
+      sandbox="allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox"
+      layout="fixed"
+      frameborder="0"
+      src="https://www.w3.org/TR/page-visibility/">
+    </amp-iframe>
   <amp-analytics>
     <script type="application/json">
     {
@@ -66,11 +73,11 @@
             "eventCategory": "${canonicalUrl}",
             "eventAction": "view"
           }
-        }      
+        }
       }
     }
     </script>
-  </amp-analytics> 
+  </amp-analytics>
   <main>
     <h2>Short Article</h2>
 

--- a/test/manual/amp-next-page/1.0/articles/article-with-fixed.html
+++ b/test/manual/amp-next-page/1.0/articles/article-with-fixed.html
@@ -8,6 +8,7 @@
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <script async custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
+  <script async custom-element="amp-iframe" src="https://cdn.ampproject.org/v0/amp-iframe-0.1.js"></script>
   <style amp-custom>
     .spacer {
       margin-top: 10px;
@@ -99,6 +100,12 @@
   </style>
 </head>
 <body>
+    <amp-iframe width=1 height=1
+      sandbox="allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox"
+      layout="fixed"
+      frameborder="0"
+      src="https://www.w3.org/TR/page-visibility/">
+    </amp-iframe>
   <amp-analytics>
     <script type="application/json">
       {
@@ -129,7 +136,7 @@
               "eventCategory": "${canonicalUrl}",
               "eventAction": "view"
             }
-          }      
+          }
         }
       }
     </script>

--- a/test/manual/amp-next-page/1.0/articles/article-with-fixed.html
+++ b/test/manual/amp-next-page/1.0/articles/article-with-fixed.html
@@ -8,7 +8,6 @@
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <script async custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
-  <script async custom-element="amp-iframe" src="https://cdn.ampproject.org/v0/amp-iframe-0.1.js"></script>
   <style amp-custom>
     .spacer {
       margin-top: 10px;
@@ -100,12 +99,6 @@
   </style>
 </head>
 <body>
-    <amp-iframe width=1 height=1
-      sandbox="allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox"
-      layout="fixed"
-      frameborder="0"
-      src="https://www.w3.org/TR/page-visibility/">
-    </amp-iframe>
   <amp-analytics>
     <script type="application/json">
       {


### PR DESCRIPTION
AMP enforces restriction to the tracking iframe (with width/height less than 10px) count. It's more reasonable to allow one tracking iframe for each ampdoc instead of each window.  