### PR TITLE
🚀Remove IE bug fix from ESM build

### DIFF
--- a/build-system/compile/build.conf.js
+++ b/build-system/compile/build.conf.js
@@ -61,6 +61,7 @@ const esmRemovedImports = {
   './polyfills/promise': ['installPromise'],
   './polyfills/array-includes': ['installArrayIncludes'],
   '../third_party/css-escape/css-escape': ['cssEscape'],
+  './ie-media-bug': ['ieMediaCheckAndFix'],
 };
 
 // Removable imports that are not needed for valid transformed documents.


### PR DESCRIPTION
Remove unnecessary IE bug fix (does not support ESM) from ESM build. Reduction in ESM build minified from 63.24 kb to 63.01kb 
