### PR TITLE
✨ [amp-form] Allow user to specify enctype=application/x-www-form-urlencoded for form submission

### DIFF
--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -37,6 +37,7 @@ import {
   addParamsToUrl,
   isProxyOrigin,
   parseQueryString,
+  serializeQueryString,
 } from '../../../src/url';
 import {Services} from '../../../src/services';
 import {SsrTemplateHelper} from '../../../src/ssr-template-helper';
@@ -70,7 +71,6 @@ import {installFormProxy} from './form-proxy';
 import {installStylesForDoc} from '../../../src/style-installer';
 import {isAmp4Email} from '../../../src/format';
 import {isArray, toArray, toWin} from '../../../src/types';
-import {serializeQueryString} from '../../../src/url.js';
 import {triggerAnalyticsEvent} from '../../../src/analytics';
 import {tryParseJson} from '../../../src/json';
 

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -182,6 +182,9 @@ export class AmpForm {
     /** @const @private {?string} */
     this.xhrVerify_ = this.getXhrUrl_('verify-xhr');
 
+    /** @const @private {?string} */
+    this.encType_ = this.getEncType_('enctype');
+
     /** @const @private {boolean} */
     this.shouldValidate_ = !this.form_.hasAttribute('novalidate');
     // Need to disable browser validation in order to allow us to take full
@@ -259,6 +262,20 @@ export class AmpForm {
   }
 
   /**
+   * Gets and validates an attribute for form request encoding type.
+   * @param {string} attribute
+   * @return {?string}
+   * @private
+   */
+  getEncType_(attribute) {
+    const encType = this.form_.getAttribute(attribute);
+    if (encType === 'application/x-www-form-urlencoded') {
+      return encType;
+    }
+    return 'multipart/form-data';
+  }
+
+  /**
    * @return {string|undefined} the value of the form's xssi-prefix attribute.
    */
   getXssiPrefix() {
@@ -291,7 +308,12 @@ export class AmpForm {
       xhrUrl = addParamsToUrl(url, values);
     } else {
       xhrUrl = url;
-      body = createFormDataWrapper(this.win_, this.form_);
+      if (this.encType_ === 'application/x-www-form-urlencoded') {
+        body = new URLSearchParams(this.getFormAsObject_());
+      } else {
+        // default case: encType_ is 'multipart/form-data'
+        body = createFormDataWrapper(this.win_, this.form_);
+      }
       if (opt_fieldBlacklist) {
         opt_fieldBlacklist.forEach((name) => {
           body.delete(name);

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -275,8 +275,7 @@ export class AmpForm {
       encType === 'multipart/form-data'
     ) {
       return encType;
-    }
-    if (encType !== null) {
+    } else if (encType !== null) {
       user().warn(
         TAG,
         `Unexpected enctype: ${encType}. Defaulting to 'multipart/form-data'.`
@@ -327,6 +326,7 @@ export class AmpForm {
         });
       } else {
         // default case: encType_ is 'multipart/form-data'
+        devAssert(this.encType_ === 'multipart/form-data');
         body = createFormDataWrapper(this.win_, this.form_);
       }
       if (opt_fieldBlacklist) {

--- a/extensions/amp-form/0.1/test/test-amp-form.js
+++ b/extensions/amp-form/0.1/test/test-amp-form.js
@@ -37,6 +37,7 @@ import {
   isFormDataWrapper,
 } from '../../../../src/form-data-wrapper';
 import {fromIterator} from '../../../../src/utils/array';
+import {parseQueryString} from '../../../../src/url.js';
 import {
   setCheckValiditySupportedForTesting,
   setReportValiditySupportedForTesting,
@@ -1271,7 +1272,7 @@ describes.repeated(
           });
         });
 
-        it('should call fetch with URLSearchParams when enctype is "application/x-www-form-urlencoded"', () => {
+        it('should call fetch with a url encoded string when enctype is "application/x-www-form-urlencoded"', () => {
           const form = getForm();
           form.setAttribute('enctype', 'application/x-www-form-urlencoded');
           return getAmpForm(form).then((ampForm) => {
@@ -1295,14 +1296,17 @@ describes.repeated(
 
               const xhrCall = ampForm.xhr_.fetch.getCall(0);
               const config = xhrCall.args[1];
-              expect(config.body instanceof URLSearchParams).to.be.true;
+              expect(config.body).to.be.a('string');
+              expect(config.headers['Content-Type']).to.equal(
+                'application/x-www-form-urlencoded'
+              );
 
               const entriesInForm = fromIterator(
                 createFormDataWrapper(env.win, getForm()).entries()
               );
-              expect(fromIterator(config.body.entries())).to.have.deep.members(
-                entriesInForm
-              );
+              expect(
+                Object.entries(parseQueryString(config.body))
+              ).to.have.deep.members(entriesInForm);
               expect(config.method).to.equal('POST');
               expect(config.credentials).to.equal('include');
 

--- a/extensions/amp-form/0.1/test/test-amp-form.js
+++ b/extensions/amp-form/0.1/test/test-amp-form.js
@@ -1308,7 +1308,6 @@ describes.repeated(
                 Object.entries(parseQueryString(config.body))
               ).to.have.deep.members(entriesInForm);
               expect(config.method).to.equal('POST');
-              expect(config.credentials).to.equal('include');
 
               return submitEventPromise;
             });
@@ -1348,7 +1347,6 @@ describes.repeated(
                 entriesInForm
               );
               expect(config.method).to.equal('POST');
-              expect(config.credentials).to.equal('include');
 
               return submitEventPromise;
             });

--- a/extensions/amp-form/amp-form.md
+++ b/extensions/amp-form/amp-form.md
@@ -112,6 +112,16 @@ The value for `action-xhr` can be the same or a different endpoint than `action`
 
 To learn about redirecting the user after successfully submitting the form, see the [Redirecting after a submission](#redirecting-after-a-submission) section below.
 
+##### enctype (optional)
+
+The enctype attribute specifies how form-data should be encoded before sending it to the server via the `method=POST` submission. The default encoding is set to `multipart/form-data`. This and `application/x-www-form-urlencoded` encoding types are currently supported.
+
+Summary of enctype values:
+
+- `application/x-www-form-urlencoded` - Sets the encoding type to `application/x-www-form-urlencoded`.
+- `multipart/form-data` - Sets the encoding type to `multipart/form-data`.
+- `any value` or unspecified - Setting the `enctype` attribute to a value not specified above or not setting the attribute at all will result in the default encoding type of `multipart/form-data`.
+
 ##### data-initialize-from-url (optional)
 
 Initializes form fields from the window URL's search string, where the query parameter name matches the field's name. When this attribute is present, `<input>`, `<select>`, and `<textarea>` fields can optionally be initialized.


### PR DESCRIPTION
Fixes: https://github.com/ampproject/amphtml/issues/7607

- Added support for the enctype attribute on amp-form
- enctype will now support `application/x-www-form-urlencoded` in addition to the previously supported `multipart/form-data`
- Documentation and unit tests updates included