### PR TITLE
🏗 Added --host option to gulp's default task

### DIFF
--- a/build-system/tasks/default-task.js
+++ b/build-system/tasks/default-task.js
@@ -86,4 +86,5 @@ defaultTask.flags = {
     "  Doesn't use nailgun to invoke closure compiler (much slower)",
   version_override: '  Overrides the version written to AMP_CONFIG',
   custom_version_mark: '  Set final digit (0-9) on auto-generated version',
+  host: 'Host to serve the project on. localhost by default.',
 };


### PR DESCRIPTION
The build system's default task [already supports](https://github.com/ampproject/amphtml/blob/bddcddb6169abfb16abca483823a8fd26c52ee34/build-system/tasks/serve.js#L103) specifying a host to serve on.

But this option is not part of the supported flags that were added in a recent refactor. This PR adds this flag back.