### PR TITLE
🚀 Delay constructing BaseElement until connectedCallback

### DIFF
--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -344,7 +344,7 @@ function createBaseCustomElementClass(win) {
         return;
       }
 
-      // If the implmementation fails to construct, we'll leave it as a
+      // If the implementation fails to construct, we'll leave it as a
       // ElementStub. The runtime will ignore the element from now on.
       try {
         this.implementation_ = new newImplClass(this);
@@ -354,13 +354,8 @@ function createBaseCustomElementClass(win) {
         dev().error(TAG, 'Failed to construct BaseElement', e);
         return;
       }
-      if (this.everAttached) {
-        // Usually, we do an implementation upgrade when the element is
-        // attached to the DOM. But, if it hadn't yet upgraded from
-        // ElementStub, we couldn't. Now that it's upgraded from a stub, go
-        // ahead and do the full upgrade.
-        this.tryUpgrade_();
-      }
+
+      this.tryUpgrade_();
     }
 
     /**
@@ -785,8 +780,7 @@ function createBaseCustomElementClass(win) {
         // Ampdoc can now be initialized.
         const win = toWin(this.ownerDocument.defaultView);
         const ampdocService = Services.ampdocServiceFor(win);
-        const ampdoc = ampdocService.getAmpDoc(this);
-        this.ampdoc_ = ampdoc;
+        this.ampdoc_ = ampdocService.getAmpDoc(this);
       }
       if (!this.resources_) {
         // Resources can now be initialized since the ampdoc is now available.

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -773,9 +773,6 @@ function createBaseCustomElementClass(win) {
       }
       this.isConnected_ = true;
 
-      const wasEverAttached = this.everAttached;
-      this.everAttached = true;
-
       if (!this.ampdoc_) {
         // Ampdoc can now be initialized.
         const win = toWin(this.ownerDocument.defaultView);
@@ -786,6 +783,9 @@ function createBaseCustomElementClass(win) {
         // Resources can now be initialized since the ampdoc is now available.
         this.resources_ = Services.resourcesForDoc(this.ampdoc_);
       }
+
+      const wasEverAttached = this.everAttached;
+      this.everAttached = true;
       this.getResources().add(this);
 
       if (wasEverAttached) {

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -837,6 +837,9 @@ function createBaseCustomElementClass(win) {
           } else {
             this.upgrade(Ctor);
           }
+        } else if (getMode().test) {
+          // Test mode can sync upgrade, because our tests expected this behavior.
+          this.tryUpgrade_();
         }
         // Classically, sizes/media queries are applied just before
         // Resource.measure. With IntersectionObserver, observe() is the

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -265,9 +265,8 @@ function createBaseCustomElementClass(win) {
       /** @private @const */
       this.signals_ = new Signals();
 
-      const perf = Services.performanceForOrNull(win);
       /** @private {boolean} */
-      this.perfOn_ = perf && perf.isPerformanceTrackingOn();
+      this.perfOn_ = false;
 
       /** @private {?./layout-delay-meter.LayoutDelayMeter} */
       this.layoutDelayMeter_ = null;
@@ -473,6 +472,9 @@ function createBaseCustomElementClass(win) {
         return this.buildingPromise_;
       }
       return (this.buildingPromise_ = new Promise((resolve, reject) => {
+        const perf = Services.performanceForOrNull(win);
+        this.perfOn_ = perf && perf.isPerformanceTrackingOn();
+
         const policyId = this.getConsentPolicy_();
         if (!policyId) {
           resolve(this.implementation_.buildCallback());

--- a/src/element-stub.js
+++ b/src/element-stub.js
@@ -17,14 +17,10 @@
 import {BaseElement} from './base-element';
 import {devAssert} from './log';
 
-/** @type {!Array} */
-export const stubbedElements = [];
-
 export class ElementStub extends BaseElement {
   /** @param {!AmpElement} element */
   constructor(element) {
     super(element);
-    stubbedElements.push(this);
   }
 
   /** @override */

--- a/src/service/custom-element-registry.js
+++ b/src/service/custom-element-registry.js
@@ -93,7 +93,7 @@ export function upgradeOrRegisterElement(win, name, toClass) {
   // document.createElement-and-connected after registering the CE name (eg,
   // amp-img registered as ElementStub), but before the actual BaseElement
   // implementation was registered. We need to go through and "upgrade" the BE
-  // implmementation on these elements.
+  // implementation on these elements.
   for (let i = 0; i < stubbedElements.length; i++) {
     const element = stubbedElements[i];
     if (

--- a/src/service/custom-element-registry.js
+++ b/src/service/custom-element-registry.js
@@ -14,11 +14,15 @@
  * limitations under the License.
  */
 
-import {ElementStub, stubbedElements} from '../element-stub';
+import {ElementStub} from '../element-stub';
 import {createCustomElementClass} from '../custom-element';
+import {devAssert, userAssert} from '../log';
 import {extensionScriptsInNode} from '../element-service';
+import {getMode} from '../mode';
 import {reportError} from '../error';
-import {userAssert} from '../log';
+
+/** @type {!Array<!Element>} */
+const stubbedElements = [];
 
 /**
  * @param {!Window} win
@@ -29,6 +33,33 @@ function getExtendedElements(win) {
     win.__AMP_EXTENDED_ELEMENTS = {};
   }
   return win.__AMP_EXTENDED_ELEMENTS;
+}
+
+/**
+ * Returns the BaseElement implementation that the element should upgrade to.
+ * @param {!Window} win
+ * @param {!Element} el
+ * @return {function(new:../base-element.BaseElement, !Element)}
+ */
+export function getImplementationClass(win, el) {
+  // Closure compiler appears to mark HTMLElement as @struct which
+  // disables bracket access. Force this with a type coercion.
+  const nonStructEl = /** @type {!Object} */ (el);
+
+  let Ctor = getExtendedElements(win)[el.localName];
+  if (getMode().test && nonStructEl['implementationClassForTesting']) {
+    Ctor = nonStructEl['implementationClassForTesting'];
+  }
+  return devAssert(Ctor);
+}
+
+/**
+ * Schedules the element to have its BaseElement implementation upgraded when
+ * it becomes registered.
+ * @param {!Element} el
+ */
+export function upgradeWhenRegistered(el) {
+  stubbedElements.push(el);
 }
 
 /**
@@ -54,27 +85,27 @@ export function upgradeOrRegisterElement(win, name, toClass) {
     name,
     name
   );
+
   knownElements[name] = toClass;
+  let pointer = 0;
+
+  // The only elements in stubbedElements are the ones that were parsed or
+  // document.createElement-and-connected after registering the CE name (eg,
+  // amp-img registered as ElementStub), but before the actual BaseElement
+  // implementation was registered. We need to go through and "upgrade" the BE
+  // implmementation on these elements.
   for (let i = 0; i < stubbedElements.length; i++) {
-    const stub = stubbedElements[i];
-    // There are 3 possible states here:
-    // 1. We never made the stub because the extended impl. loaded first.
-    //    In that case the element won't be in the array.
-    // 2. We made a stub but the browser didn't attach it yet. In
-    //    that case we don't need to upgrade but simply switch to the new
-    //    implementation.
-    // 3. A stub was attached. We upgrade which means we replay the
-    //    implementation.
-    const {element} = stub;
+    const element = stubbedElements[i];
     if (
       element.tagName.toLowerCase() == name &&
       element.ownerDocument.defaultView == win
     ) {
       tryUpgradeElement_(element, toClass);
-      // Remove element from array.
-      stubbedElements.splice(i--, 1);
+    } else {
+      stubbedElements[pointer++] = element;
     }
   }
+  stubbedElements.length = pointer;
 }
 
 /**


### PR DESCRIPTION
This delays the only expensive action inside `createdCallback` until at least `connectedCallback` (and possibly longer if the extension is not downloaded yet). Unfortunately, `customElements.define` can still call `connectedCallback`, so we still haven't fixed everything.

This also avoids a whole host of problems that can happen innocently inside the implementation's constructor. Eg, trying to get access to the ampdoc or a doc-level service.

Prior attempt: #25491