### PR TITLE
🚀 amp-actions hide() can skipRemeasure

### DIFF
--- a/src/service/standard-actions-impl.js
+++ b/src/service/standard-actions-impl.js
@@ -319,13 +319,19 @@ export class StandardActions {
   handleHide_(invocation) {
     const target = dev().assertElement(invocation.node);
 
-    this.mutator_.mutateElement(target, () => {
-      if (target.classList.contains('i-amphtml-element')) {
-        target./*OK*/ collapse();
-      } else {
-        toggle(target, false);
-      }
-    });
+    this.mutator_.mutateElement(
+      target,
+      () => {
+        if (target.classList.contains('i-amphtml-element')) {
+          target./*OK*/ collapse();
+        } else {
+          toggle(target, false);
+        }
+      },
+      // It is safe to skip measuring, because  `mutator-impl.collapseElement`
+      // will trigger a remasure of everything below the collapsed element.
+      /* skipRemeasure */ true
+    );
 
     return null;
   }

--- a/src/service/standard-actions-impl.js
+++ b/src/service/standard-actions-impl.js
@@ -324,7 +324,7 @@ export class StandardActions {
         target,
         () => target./*OK*/collapse(),
         // It is safe to skip measuring, because `mutator-impl.collapseElement`
-        // will set the size of the element as well as trigger a remasure of
+        // will set the size of the element as well as trigger a remeasure of
         // everything below the collapsed element.
         /* skipRemeasure */ true
       );

--- a/src/service/standard-actions-impl.js
+++ b/src/service/standard-actions-impl.js
@@ -322,7 +322,7 @@ export class StandardActions {
     if (target.classList.contains('i-amphtml-element')) {
       this.mutator_.mutateElement(
         target,
-        () => target.collapse(),
+        () => target./*OK*/collapse(),
         // It is safe to skip measuring, because `mutator-impl.collapseElement`
         // will set the size of the element as well as trigger a remasure of
         // everything below the collapsed element.

--- a/src/service/standard-actions-impl.js
+++ b/src/service/standard-actions-impl.js
@@ -325,11 +325,13 @@ export class StandardActions {
         if (target.classList.contains('i-amphtml-element')) {
           target./*OK*/ collapse();
         } else {
+          // TODO: is skipping remeasre in the toggle(target, false) case okay?
           toggle(target, false);
         }
       },
       // It is safe to skip measuring, because  `mutator-impl.collapseElement`
-      // will trigger a remasure of everything below the collapsed element.
+      // will set the size of the element as well as trigger a remasure of everything 
+      // below the collapsed element.
       /* skipRemeasure */ true
     );
 

--- a/src/service/standard-actions-impl.js
+++ b/src/service/standard-actions-impl.js
@@ -319,21 +319,18 @@ export class StandardActions {
   handleHide_(invocation) {
     const target = dev().assertElement(invocation.node);
 
-    this.mutator_.mutateElement(
-      target,
-      () => {
-        if (target.classList.contains('i-amphtml-element')) {
-          target./*OK*/ collapse();
-        } else {
-          // TODO: is skipping remeasre in the toggle(target, false) case okay?
-          toggle(target, false);
-        }
-      },
-      // It is safe to skip measuring, because  `mutator-impl.collapseElement`
-      // will set the size of the element as well as trigger a remasure of everything 
-      // below the collapsed element.
-      /* skipRemeasure */ true
-    );
+    if (target.classList.contains('i-amphtml-element')) {
+      this.mutator_.mutateElement(
+        target,
+        () => target.collapse(),
+        // It is safe to skip measuring, because `mutator-impl.collapseElement`
+        // will set the size of the element as well as trigger a remasure of
+        // everything below the collapsed element.
+        /* skipRemeasure */ true
+      );
+    } else {
+      this.mutator_.mutateElement(target, () => toggle(target, false));
+    }
 
     return null;
   }

--- a/src/service/standard-actions-impl.js
+++ b/src/service/standard-actions-impl.js
@@ -322,7 +322,7 @@ export class StandardActions {
     if (target.classList.contains('i-amphtml-element')) {
       this.mutator_.mutateElement(
         target,
-        () => target./*OK*/collapse(),
+        () => target./*OK*/ collapse(),
         // It is safe to skip measuring, because `mutator-impl.collapseElement`
         // will set the size of the element as well as trigger a remeasure of
         // everything below the collapsed element.


### PR DESCRIPTION
**summary**
Recently, I've added support to `mutator-impl.mutateElement` to skip the remeasurement of an element in cases we know that it is unnecessary. I believe I've found another (albeit less significant) case.

The `hide()` action calls `mutateElement`, but I believe it then performs its own measurements within `collapseElement` (e.g. sets it all to 0, since `display:none`). It then sets relayoutTop and schedules a new pass.