### PR TITLE
📖 Development, Nightly, and Release schedule documentation updates

### DIFF
--- a/contributing/DEVELOPING.md
+++ b/contributing/DEVELOPING.md
@@ -98,7 +98,7 @@ We also recommend scanning the [spec](../spec/). The non-element part should hel
 
 Developers and users of AMP can have their browser request AMP JS files from the pre-release channels (**beta**, **experimental**, and **nightly**) for all requests, using an opt-in mechanism.
 
-To opt your browser into the a pre-release channel, go to [the AMP experiments page](https://cdn.ampproject.org/experiments.html) and activate the experiment channel of your choice (see [Beta and Experimental channels](release-schedule.md#beta-and-experimental-channels) and [Nightly](release-schedule.md##nightly) in the [release process](release-schedule.md) document for description of these channels). Please subscribe to our [low-volume announcements](https://groups.google.com/forum/#!forum/amphtml-announce) mailing list to get notified about important/breaking changes about AMP.
+To opt your browser into the a pre-release channel, go to [the AMP experiments page](https://cdn.ampproject.org/experiments.html) and activate the experiment channel of your choice (see [Beta/Experimental](release-schedule.md#beta-and-experimental-channels) and [Nightly](release-schedule.md##nightly) channels in the [release process](release-schedule.md) document for description of these channels). Please subscribe to our [low-volume announcements](https://groups.google.com/forum/#!forum/amphtml-announce) mailing list to get notified about important/breaking changes about AMP.
 
 **Notes:**
 

--- a/contributing/DEVELOPING.md
+++ b/contributing/DEVELOPING.md
@@ -94,4 +94,25 @@ We also recommend scanning the [spec](../spec/). The non-element part should hel
 - The [AMP buildcop](buildcop.md) helps ensure that AMP's builds remain green (i.e. everything builds and all of the tests pass). If you run into issues with builds that seem unrelated to your changes see if the issue is present on [Travis](https://travis-ci.org/ampproject/amphtml/builds) and send a message to the [#contributing](https://amphtml.slack.com/messages/C9HRJ1GPN) channel on Slack ([sign up for Slack](https://bit.ly/amp-slack-signup)).
 - Understanding the [AMP release process](release-schedule.md) is useful for understanding when a change in AMP will make it into production and what to do if things go wrong during the rollout of a change.
 
+### Opting in to pre-release channels
+
+Developers and users of AMP can have their browser request AMP JS files from the pre-release channels (**beta**, **experimental**, and **nightly**) for all requests, using an opt-in mechanism.
+
+To opt your browser into the a pre-release channel, go to [the AMP experiments page](https://cdn.ampproject.org/experiments.html) and activate the experiment channel of your choice (see [Beta and Experimental channels](release-schedule.md#beta-and-experimental-channels) and [Nightly](release-schedule.md##nightly) in the [release process](release-schedule.md) document for description of these channels). Please subscribe to our [low-volume announcements](https://groups.google.com/forum/#!forum/amphtml-announce) mailing list to get notified about important/breaking changes about AMP.
+
+**Notes:**
+
+- When you opt into a pre-release channel via the cookie mechanism, you are only affecting the AMP JS libraries in your browser.
+- An alternative to using cookies to opt a page into these pre-release channels is adding `?optin=experimental`/`?optin=beta` to the URL of the AMP runtime (e.g., `https://cdn.ampproject.org/v0.js?optin=beta`).
+  - URL-based opt-in should only be used for development purposes.
+  - Doing so will cause the AMP validator to flag your page as invalid, and prevent it from being included in AMP caches.
+  - There is no valid-AMP way to force visitors to your site to use the _AMP Experimental/Beta Channel_ version of AMP.
+
+**If you find an issue that appears to only occur in the _Experimental/Beta Channel_ version of AMP**:
+
+- please [file an issue](https://github.com/ampproject/amphtml/issues/new) with a description of the problem
+  - include a note that the problem is new to the _Experimental/Beta Channel_ build so that it can be properly prioritized
+  - include a URL to a page that reproduces the problem
+- ping the [AMP Slack #release channel](https://amphtml.slack.com/messages/C4NVAR0H3/) ([sign up for Slack](https://bit.ly/amp-slack-signup)) with the issue you filed so we can delay the push of the _Experimental/Beta Channel_ version to production if needed
+
 ## [Code of conduct](../CODE_OF_CONDUCT.md)

--- a/contributing/contributing-code.md
+++ b/contributing/contributing-code.md
@@ -180,6 +180,8 @@ These guidelines are specific to the amphtml repository. Other ampproject repos 
 
 We have a well-defined process for handling requests for changes to the **experimental**/**beta**, **stable**, or **lts** release builds. These changes are known as "cherry-picks".
 
+> Note: We do not support cherry-picks into the **nightly** release channel; in the event of security or privacy issues, a rollback is performed instead.
+
 **The bar for getting a cherry-pick into a live release is very high** because our goal is to produce high quality launches on a predictable schedule.
 
 **Keep in mind that performing a cherry-pick requires a significant amount of work from you and the on-duty engineer** and they can take a long time to process.

--- a/contributing/release-schedule.md
+++ b/contributing/release-schedule.md
@@ -1,6 +1,7 @@
 # Release Schedule
 
 - [Release Channels](#release-channels)
+  - [Nightly](#nightly)
   - [Weekly](#weekly)
   - [Long-Term Stable (lts)](#long-term-stable-lts)
   - [AMP Experimental and Beta Channels](#amp-experimental-and-beta-channels)
@@ -16,6 +17,14 @@ A new release of AMP is pushed to all AMP pages every week on Tuesday. **Once a 
 The AMP runtime and extensions are provided through a variety of different _release channels_. Each channel serves a purpose for developers and for the AMP HTML Project itself. See the [release cadence section](#release-cadence) for a more detailed breakdown of how and when code from the [`ampproject/amphtml`](https://github.com/ampproject/amphtml) repository makes it into release builds.
 
 To determine if a PR has been included in any of the following release channels, look for the GitHub labels _PR Use: In Canary_, _PR Use: In Production_, or _PR Use: In LTS_ (see the section on [determining if your change is in a release](#Determining-if-your-change-is-in-a-release) for more details).
+
+### Nightly
+
+The **nightly** release channel is updated (as its name indicates) every weeknight. This process is automated, and there is no guarantee that any given nightly release is free of bugs or other issues. Each night after midnight (Pacific Time), the last "green" commit from the day is selected to be the release cutoff point. A green build indicates that all automated tests have passed on that bulid.
+
+The nightly release provides a mechanism to detect and resolve issues quickly and before they reach the more traffic-heavy _weekly_ release channels. It also serves to reduce the number of users affected by newly introduced issues
+
+The **nightly** release build is served to 0.05% of AMP traffic. It is possible to opt into the **nightly** channel via the `AMP_CANARY` cookie; see the [Opt-In Cookie section](#opt-in-cookie) for details.
 
 ### Weekly
 

--- a/contributing/release-schedule.md
+++ b/contributing/release-schedule.md
@@ -36,7 +36,7 @@ The **stable** release channel is built with the _production_ configuration and 
 
 #### Beta and Experimental channels
 
-The _Beta_ and _Experimental Channels_ are pre-release candidates for the next Stable release of AMP. Every Tuesday (except for releases-freeze weeks), last week's **nightly** is promoted to the developer opt-in channels for **beta** and **experimental**. Following a 1-day period where we verify that no feature or performance regressions were introduced in these channels, we promote this release on Wednesday to a small portion of traffic. This same release is then promoted to the **stable** channel on Tuesday the following week.
+The _Beta_ and _Experimental Channels_ are pre-release candidates for the next Stable release of AMP. Every Tuesday (except for weeks where there is a [release freeze](#release-freezes)), last week's **nightly** is promoted to the developer opt-in channels for **beta** and **experimental**. Following a 1-day period where we verify that no feature or performance regressions were introduced in these channels, we promote this release on Wednesday to a small portion of traffic. This same release is then promoted to the **stable** channel on Tuesday the following week.
 
 It is possible to opt into these channels. See the [opt-in section](DEVELOPING.md#opting-in-to-pre-release-channels) in [DEVELOPING.md] for details.
 
@@ -56,7 +56,7 @@ The _Experimental Channel_ **may be less stable** and it may contain features no
 
 The **lts** release channel provides a previous **stable** build for one-month intervals. On the second Monday of each month, the current **stable** release is promoted to **lts**. This channel is not recommended for all AMP publishers. It is provided so that publishers who wish to perform a QA cycle on their website less frequently may do so by opting specific web pages into the **lts** channel (see the [**lts** readme](https://github.com/ampproject/amphtml/blob/master/contributing/lts-release.md)).
 
-In the event that the second Monday of the month falls on a holiday, the promotion will be performed after the end of the release freeze.
+In the event that the second Monday of the month falls on a holiday, the promotion will be performed after the end of the [release freeze](#release-freezes).
 
 Important: Publishers using the **lts** release channel should not use newly introduced features. Because of the longer cycle, the **lts** release may be as much as seven weeks behind the `HEAD` of [`ampproject/amphtml`](https://github.com/ampproject/amphtml). See the section on [determining if your change is in a release](#Determining-if-your-change-is-in-a-release) to validate if a change will be ready with your chosen release cycle.
 

--- a/contributing/release-schedule.md
+++ b/contributing/release-schedule.md
@@ -22,7 +22,7 @@ To determine if a PR has been included in any of the following release channels,
 
 The **nightly** release channel is updated (as its name indicates) every weeknight. This process is automated, and there is no guarantee that any given nightly release is free of bugs or other issues. Each night after midnight (Pacific Time), the last "green" commit from the day is selected to be the release cutoff point. A green build indicates that all automated tests have passed on that build.
 
-The nightly release provides a mechanism to detect and resolve issues quickly and before they reach the more traffic-heavy _weekly_ release channels. It also serves to reduce the number of users affected by newly introduced issues
+The nightly release provides a mechanism to detect and resolve issues quickly and before they reach the more traffic-heavy _weekly_ release channels. It also serves to reduce the number of users affected by newly introduced issues.
 
 The **nightly** release build is served to 0.05% of AMP traffic. It is possible to opt into the **nightly** channel, to test pull requests that were merged in the past few days. See the [opt-in section](DEVELOPING.md#opting-in-to-pre-release-channels) in [DEVELOPING.md] for details.
 
@@ -36,7 +36,7 @@ The **stable** release channel is built with the _production_ configuration and 
 
 #### Beta and Experimental channels
 
-The _Beta_ and _Experimental Channels_ are pre-release candidates for the next Stable release of AMP. Every Tuesday (except for releases-freeze weeks), last week's **nightly** is promoted to the developer opt-in channels for **beta** and **experimental**. Following a 1-day period where we verify that no feature or erformance regressions were introduced in these channels, we promote this release on Wednesday to a small portion of traffic. This same release is then promoted to the **stable** channel on Tuesday the following week.
+The _Beta_ and _Experimental Channels_ are pre-release candidates for the next Stable release of AMP. Every Tuesday (except for releases-freeze weeks), last week's **nightly** is promoted to the developer opt-in channels for **beta** and **experimental**. Following a 1-day period where we verify that no feature or performance regressions were introduced in these channels, we promote this release on Wednesday to a small portion of traffic. This same release is then promoted to the **stable** channel on Tuesday the following week.
 
 It is possible to opt into these channels. See the [opt-in section](DEVELOPING.md#opting-in-to-pre-release-channels) in [DEVELOPING.md] for details.
 

--- a/contributing/release-schedule.md
+++ b/contributing/release-schedule.md
@@ -3,8 +3,8 @@
 - [Release Channels](#release-channels)
   - [Nightly](#nightly)
   - [Weekly](#weekly)
+    - [Experimental and Beta channels](#experimental-and-beta-channels)
   - [Long-Term Stable (lts)](#long-term-stable-lts)
-  - [AMP Experimental and Beta Channels](#amp-experimental-and-beta-channels)
 - [Determining if your change is in a release](#determining-if-your-change-is-in-a-release)
 - [Release Cadence](#release-cadence)
   - [Detailed schedule](#detailed-schedule)
@@ -24,7 +24,7 @@ The **nightly** release channel is updated (as its name indicates) every weeknig
 
 The nightly release provides a mechanism to detect and resolve issues quickly and before they reach the more traffic-heavy _weekly_ release channels. It also serves to reduce the number of users affected by newly introduced issues
 
-The **nightly** release build is served to 0.05% of AMP traffic. It is possible to opt into the **nightly** channel via the `AMP_CANARY` cookie; see the [Opt-In Cookie section](#opt-in-cookie) for details.
+The **nightly** release build is served to 0.05% of AMP traffic. It is possible to opt into the **nightly** channel, to test pull requests that were merged in the past few days. See the [opt-in section](DEVELOPING.md#opting-in-to-pre-release-channels) in [DEVELOPING.md] for details.
 
 ### Weekly
 
@@ -33,6 +33,24 @@ The _weekly_ release channels are considered to be the primary "evergreen" relea
 There are two sets of build configurations used in creating release builds: the _canary_ configuration and the _production_ configuration. The **experimental** and **beta** release channels are built off of the same commit. However, the **experimental** channel uses the _canary_ configuration while the **beta** channel uses the _production_ configuration. The _canary_ configuration enables experimental components and features that may be turned off in _production_. It is possible to opt into the **experimental** or **beta** channels via the [experiments page](https://cdn.ampproject.org/experiments.html).
 
 The **stable** release channel is built with the _production_ configuration and served to most AMP traffic. Since the **beta** release channel is also built from the _production_ configuration, it represents the exact build which will become **stable** the following week (modulo the possibility of cherry-picks; see [Contributing Code](https://github.com/ampproject/amphtml/blob/master/contributing/contributing-code.md#Cherry-picks)).
+
+#### Beta and Experimental channels
+
+The _Beta_ and _Experimental Channels_ are pre-release candidates for the next Stable release of AMP. Every Tuesday (except for releases-freeze weeks), last week's **nightly** is promoted to the developer opt-in channels for **beta** and **experimental**. Following a 1-day period where we verify that no feature or erformance regressions were introduced in these channels, we promote this release on Wednesday to a small portion of traffic. This same release is then promoted to the **stable** channel on Tuesday the following week.
+
+It is possible to opt into these channels. See the [opt-in section](DEVELOPING.md#opting-in-to-pre-release-channels) in [DEVELOPING.md] for details.
+
+Opting into the _Beta Channel_ is intended for:
+
+- testing and playing with the version of the AMP runtime that will be released soon
+- using in Quality Assurance (QA) to ensure that your site is compatible with the next version of AMP
+
+The _Experimental Channel_ is intended for:
+
+- testing and playing with new features not yet available to all users
+- using in Quality Assurance (QA) to ensure that your site is compatible with upcoming features of AMP that are still under development
+
+The _Experimental Channel_ **may be less stable** and it may contain features not yet available to all users.
 
 ### Long-Term Stable (lts)
 
@@ -49,44 +67,7 @@ Important: Publishers using the **lts** release channel should not use newly int
 You can determine what changes are in a given build using one of the following:
 
 - The [_Type: Release_ GitHub issues](https://github.com/ampproject/amphtml/labels/Type%3A%20Release) for each release build will include a link to the specific [release page](https://github.com/ampproject/amphtml/releases) listing the changes contained in that release.
-- The [_PR Use: In Canary_](https://github.com/ampproject/amphtml/issues?utf8=%E2%9C%93&q=label%3A%22PR%20use%3A%20In%20Canary%22), [_PR Use: In Production_](https://github.com/ampproject/amphtml/issues?utf8=%E2%9C%93&q=label%3A%22PR%20use%3A%20In%20Production%22), and [_PR Use: In LTS_](https://github.com/ampproject/amphtml/issues?utf8=%E2%9C%93&q=label%3A%22PR%20use%3A%20In%20LTS%22) labels are added to PRs when they've made it into a _weekly_ or **lts** build. There may be a delay between when the build is created and when the label is added.
-
-> Note: These labels still use legacy release names. They will be renamed soon to reflect the new release channel names (**beta** and **stable**).
-
-### AMP Experimental and Beta Channels
-
-The _AMP Experimental Channel_ is a way to opt a browser into using the **experimental** release build of the AMP JS libraries. The _Experimental Channel_ **may be less stable** and it may contain features not yet available to all users.
-
-Opting into the _Experimental Channel_ is intended for:
-
-- testing and playing with new features not yet available to all users
-- using in Quality Assurance (QA) to ensure that your site is compatible with upcoming features of AMP that are still under development
-
-To opt your browser into the _AMP Experimental Channel_, go to [the AMP experiments page](https://cdn.ampproject.org/experiments.html) and activate the "AMP Experimental Channel" experiment. Please subscribe to our [low-volume announcements](https://groups.google.com/forum/#!forum/amphtml-announce) mailing list to get notified about important/breaking changes about AMP.
-
-The _AMP Beta Channel_ is a way to opt a browser into using the **beta** release build of the AMP JS libraries that will be promoted to **stable** during the subsequent release cycle (typically, a week later). It is similar to the _Experimental Channel_ described above, but it will not contain the experimental features that are still under development.
-
-Opting into the _Beta Channel_ is intended for:
-
-- testing and playing with the version of the AMP runtime that will be released soon
-- using in Quality Assurance (QA) to ensure that your site is compatible with the next version of AMP
-
-**Notes:**
-
-- When you opt into the _Experimental_ or _Beta_ channel via the cookie mechanism, you are only affecting the AMP JS libraries in your browser.
-- An alternative to using cookies to opt a page into these pre-release channels is adding `?optin=experimental`/`?optin=beta` to the URL of the AMP runtime (e.g., `https://cdn.ampproject.org/v0.js?optin=beta`).
-  - URL-based opt-in should only be used for development purposes.
-  - Doing so will cause the AMP validator to flag your page as invalid, and prevent it from being included in AMP caches.
-  - There is no valid-AMP way to force visitors to your site to use the _AMP Experimental/Beta Channel_ version of AMP.
-
-To opt your browser into one of these channels, go to [the AMP experiments page](https://cdn.ampproject.org/experiments.html) and activate the "AMP Experimental Channel" or "AMP Beta Channel" experiment. Please subscribe to our [low-volume announcements](https://groups.google.com/forum/#!forum/amphtml-announce) mailing list to get notified about important/breaking changes about AMP.
-
-**If you find an issue that appears to only occur in the _Experimental/Beta Channel_ version of AMP**:
-
-- please [file an issue](https://github.com/ampproject/amphtml/issues/new) with a description of the problem
-  - include a note that the problem is new to the _Experimental/Beta Channel_ build so that it can be properly prioritized
-  - include a URL to a page that reproduces the problem
-- ping the [AMP Slack #release channel](https://amphtml.slack.com/messages/C4NVAR0H3/) ([sign up for Slack](https://bit.ly/amp-slack-signup)) with the issue you filed so we can delay the push of the _Experimental/Beta Channel_ version to production if needed
+- The [_PR Use: In Beta / Experimental_](https://github.com/ampproject/amphtml/issues?q=label%3A%22PR+use%3A+In+Beta+%2F+Experimental%22), [_PR Use: In Stable_](https://github.com/ampproject/amphtml/issues?utf8=%E2%9C%93&q=label%3A%22PR%20use%3A%20In%20Production%22), and [_PR Use: In LTS_](https://github.com/ampproject/amphtml/issues?utf8=%E2%9C%93&q=label%3A%22PR%20use%3A%20In%20LTS%22) labels are added to PRs when they've made it into a _weekly_ or **lts** build. There may be a delay between when the build is created and when the label is added.
 
 ## Release Cadence
 

--- a/contributing/release-schedule.md
+++ b/contributing/release-schedule.md
@@ -24,7 +24,7 @@ The **nightly** release channel is updated (as its name indicates) every weeknig
 
 The nightly release provides a mechanism to detect and resolve issues quickly and before they reach the more traffic-heavy _weekly_ release channels. It also serves to reduce the number of users affected by newly introduced issues.
 
-The **nightly** release build is served to 0.05% of AMP traffic. It is possible to opt into the **nightly** channel, to test pull requests that were merged in the past few days. See the [opt-in section](DEVELOPING.md#opting-in-to-pre-release-channels) in [DEVELOPING.md] for details.
+It is possible to opt into the **nightly** channel, to test pull requests that were merged in the past few days. See the [opt-in section](DEVELOPING.md#opting-in-to-pre-release-channels) in [DEVELOPING.md] for details.
 
 ### Weekly
 

--- a/contributing/release-schedule.md
+++ b/contributing/release-schedule.md
@@ -20,7 +20,7 @@ To determine if a PR has been included in any of the following release channels,
 
 ### Nightly
 
-The **nightly** release channel is updated (as its name indicates) every weeknight. This process is automated, and there is no guarantee that any given nightly release is free of bugs or other issues. Each night after midnight (Pacific Time), the last "green" commit from the day is selected to be the release cutoff point. A green build indicates that all automated tests have passed on that bulid.
+The **nightly** release channel is updated (as its name indicates) every weeknight. This process is automated, and there is no guarantee that any given nightly release is free of bugs or other issues. Each night after midnight (Pacific Time), the last "green" commit from the day is selected to be the release cutoff point. A green build indicates that all automated tests have passed on that build.
 
 The nightly release provides a mechanism to detect and resolve issues quickly and before they reach the more traffic-heavy _weekly_ release channels. It also serves to reduce the number of users affected by newly introduced issues
 


### PR DESCRIPTION
* Move opt-in instructions from release-schedule.md to DEVELOPING.md
* Add details about the nightly release channel to release-schedule.md
* Move description of beta/experimental channels into the weekly section of release-schedule.md and remove the opt-in instructions (links to DEVELOPING.md instead)
* Minor fixes (e.g., fixing broken links to PR labels)