### PR TITLE
intersect-resources: Always schedule pass after build

### DIFF
--- a/src/service/mutator-impl.js
+++ b/src/service/mutator-impl.js
@@ -231,12 +231,12 @@ export class MutatorImpl {
       },
       mutate: () => {
         mutator();
+
+        // `skipRemeasure` is set by callers when we know that `mutator`
+        // cannot cause a change in size/position e.g. toggleLoading().
         if (skipRemeasure) {
           return;
         }
-
-        // TODO(willchou): toggleLoading() mutate causes a lot of unnecessary
-        // remeasures. Add affordance to mutateElement() to disable remeasures.
 
         if (element.classList.contains('i-amphtml-element')) {
           const r = Resource.forElement(element);

--- a/src/service/viewport/viewport-binding-natural.js
+++ b/src/service/viewport/viewport-binding-natural.js
@@ -239,30 +239,9 @@ export class ViewportBindingNatural_ {
     // Nothing to do here.
   }
 
-  rectToString(b) {
-    return `[w: ${b.width}. h: ${b.height}]`;
-  }
-
   /** @override */
   getLayoutRect(el, opt_scrollLeft, opt_scrollTop, opt_premeasuredRect) {
     const b = opt_premeasuredRect || el./*OK*/ getBoundingClientRect();
-
-    if (opt_premeasuredRect) {
-      const c = el./*OK*/ getBoundingClientRect();
-      if (
-        Math.abs(b.width - c.width) > 1 ||
-        Math.abs(b.height - c.height) > 1
-      ) {
-        console.assert(
-          false,
-          'Mismatched size:',
-          el,
-          this.rectToString(c),
-          this.rectToString(b)
-        );
-      }
-    }
-
     const scrollTop =
       opt_scrollTop != undefined ? opt_scrollTop : this.getScrollTop();
     const scrollLeft =

--- a/src/service/viewport/viewport-binding-natural.js
+++ b/src/service/viewport/viewport-binding-natural.js
@@ -239,9 +239,30 @@ export class ViewportBindingNatural_ {
     // Nothing to do here.
   }
 
+  rectToString(b) {
+    return `[w: ${b.width}. h: ${b.height}]`;
+  }
+
   /** @override */
   getLayoutRect(el, opt_scrollLeft, opt_scrollTop, opt_premeasuredRect) {
     const b = opt_premeasuredRect || el./*OK*/ getBoundingClientRect();
+
+    if (opt_premeasuredRect) {
+      const c = el./*OK*/ getBoundingClientRect();
+      if (
+        Math.abs(b.width - c.width) > 1 ||
+        Math.abs(b.height - c.height) > 1
+      ) {
+        console.assert(
+          false,
+          'Mismatched size:',
+          el,
+          this.rectToString(c),
+          this.rectToString(b)
+        );
+      }
+    }
+
     const scrollTop =
       opt_scrollTop != undefined ? opt_scrollTop : this.getScrollTop();
     const scrollLeft =

--- a/test/unit/test-resources.js
+++ b/test/unit/test-resources.js
@@ -366,7 +366,12 @@ describe('Resources', () => {
         getTaskId: () => 'resource#L',
         applySizesAndMediaQuery: () => {},
       };
-      resources.scheduleLayoutOrPreload(resource, true, 0, /* force */ true);
+      resources.scheduleLayoutOrPreload(
+        resource,
+        true,
+        0,
+        /* ignoreQuota */ true
+      );
       expect(resources.queue_.getSize()).to.equal(1);
       expect(resources.queue_.tasks_[0].forceOutsideViewport).to.be.true;
     }
@@ -931,7 +936,12 @@ describes.realWin('Resources discoverWork', {amp: true}, (env) => {
   });
 
   it('should force schedule resource execution outside viewport', () => {
-    resources.scheduleLayoutOrPreload(resource1, true, 0, /* force */ true);
+    resources.scheduleLayoutOrPreload(
+      resource1,
+      true,
+      0,
+      /* ignoreQuota */ true
+    );
     expect(resources.queue_.getSize()).to.equal(1);
     expect(resources.queue_.tasks_[0].resource).to.equal(resource1);
 
@@ -1046,8 +1056,7 @@ describes.realWin('Resources discoverWork', {amp: true}, (env) => {
     expect(resource1.build).to.be.calledOnce;
     expect(buildResourceSpy).calledWithExactly(
       resource1,
-      /* schedulePass */ true,
-      /* force */ false
+      /* ignoreQuota */ false
     );
   });
 
@@ -1069,10 +1078,7 @@ describes.realWin('Resources discoverWork', {amp: true}, (env) => {
     resources.discoverWork_();
 
     expect(resource1.build).to.be.calledOnce;
-    expect(buildResourceSpy).calledWithExactly(
-      resource1,
-      /* schedulePass */ true
-    );
+    expect(buildResourceSpy).calledWithExactly(resource1);
   });
 
   it('should NOT build non-prerenderable resources in prerender', () => {
@@ -1159,14 +1165,12 @@ describes.realWin('Resources discoverWork', {amp: true}, (env) => {
     // discoverWork_ phase 1 build.
     expect(buildResourceSpy).calledWithExactly(
       resource1,
-      /* schedulePass */ true,
-      /* force */ false
+      /* ignoreQuota */ false
     );
     // discoverWork_ phase 4 layout grants build.
     expect(buildResourceSpy).calledWithExactly(
       resource1,
-      /* schedulePass */ true,
-      /* force */ true
+      /* ignoreQuota */ true
     );
   });
 


### PR DESCRIPTION
Related to #25428.

Minor bug fix: we always need to schedule a pass after building a resource because it won't be laid out in the same pass (`Resource.build` is async). Surveyed the remaining "skip pass in intersection mode" cases and they look good.

Also realized we're no longer using `scheduleWhenBuilt` parameter at all, so removed it. For some context on "why do we even have that button", the I think the last usage was removed in #12311.