### PR TITLE
build-system: Support alternate sourcemap URLs

### DIFF
--- a/build-system/compile/compile.js
+++ b/build-system/compile/compile.js
@@ -120,7 +120,7 @@ function compile(
     if (isProdBuild) {
       return `https://raw.githubusercontent.com/ampproject/amphtml/${internalRuntimeVersion}/`;
     } else if (argv.sourcemap_url) {
-      // Custom sourcemap URLs have placeholder $version$ that should be
+      // Custom sourcemap URLs have placeholder {version} that should be
       // replaced with the actual version. Also, ensure trailing slash exists.
       return String(argv.sourcemap_url)
         .replace(/\{version\}/g, internalRuntimeVersion)

--- a/build-system/compile/compile.js
+++ b/build-system/compile/compile.js
@@ -38,6 +38,7 @@ const {preClosureBabel, handlePreClosureError} = require('./pre-closure-babel');
 const {singlePassCompile} = require('./single-pass');
 const {VERSION: internalRuntimeVersion} = require('./internal-version');
 
+const isProdBuild = !!argv.type;
 const queue = [];
 let inProgress = 0;
 
@@ -116,14 +117,14 @@ function compile(
   }
 
   function getSourceMapBase() {
-    if (!!argv.type) {
-      // Production build, point sourcemap to fetch files from correct GitHub tag.
+    if (isProdBuild) {
       return `https://raw.githubusercontent.com/ampproject/amphtml/${internalRuntimeVersion}/`;
     } else if (argv.sourcemap_url) {
-      return String(argv.sourcemap_url).replace(
-        '{version}',
-        internalRuntimeVersion
-      );
+      // Custom sourcemap URLs have placeholder $version$ that should be
+      // replaced with the actual version. Also, ensure trailing slash exists.
+      return String(argv.sourcemap_url)
+        .replace(/\{version\}/g, internalRuntimeVersion)
+        .replace(/([^/])$/, '$1/');
     }
     return 'http://localhost:8000/';
   }

--- a/build-system/tasks/dist.js
+++ b/build-system/tasks/dist.js
@@ -456,8 +456,8 @@ dist.flags = {
   full_sourcemaps: '  Includes source code content in sourcemaps',
   disable_nailgun:
     "  Doesn't use nailgun to invoke closure compiler (much slower)",
-  sourcemap_url: '  Points sourcemap URLs to a custom destination',
-  type: '  Points sourcemap URLs to the correct AMP Project GitHub tag',
+  sourcemap_url: '  Sets a custom sourcemap URL with placeholder $version$',
+  type: '  Points sourcemap to fetch files from the correct GitHub tag',
   esm: '  Does not transpile down to ES5',
   version_override: '  Override the version written to AMP_CONFIG',
   custom_version_mark: '  Set final digit (0-9) on auto-generated version',

--- a/build-system/tasks/dist.js
+++ b/build-system/tasks/dist.js
@@ -456,7 +456,7 @@ dist.flags = {
   full_sourcemaps: '  Includes source code content in sourcemaps',
   disable_nailgun:
     "  Doesn't use nailgun to invoke closure compiler (much slower)",
-  sourcemap_url: '  Sets a custom sourcemap URL with placeholder $version$',
+  sourcemap_url: '  Sets a custom sourcemap URL with placeholder {version}',
   type: '  Points sourcemap to fetch files from the correct GitHub tag',
   esm: '  Does not transpile down to ES5',
   version_override: '  Override the version written to AMP_CONFIG',

--- a/build-system/tasks/dist.js
+++ b/build-system/tasks/dist.js
@@ -456,7 +456,8 @@ dist.flags = {
   full_sourcemaps: '  Includes source code content in sourcemaps',
   disable_nailgun:
     "  Doesn't use nailgun to invoke closure compiler (much slower)",
-  type: '  Points sourcemap to fetch files from the correct GitHub tag',
+  sourcemap_url: '  Points sourcemap URLs to a custom destination',
+  type: '  Points sourcemap URLs to the correct AMP Project GitHub tag',
   esm: '  Does not transpile down to ES5',
   version_override: '  Override the version written to AMP_CONFIG',
   custom_version_mark: '  Set final digit (0-9) on auto-generated version',


### PR DESCRIPTION
Support `--sourcemap_url` flag in `gulp dist` to customize the base URL
used in sourcemap links. The value passed to this flag should include a
placeholder `{version}` that will be replaced with the actual version.

For example:
```
gulp dist --sourcemap_url "https://example.com/{version}/root/" --version_override "12345"
```
would set the `amp.js` sourcemap URL to
```
https://example.com/12345/root/src/amp.js
```
This feature improves support for self-hosting the AMP runtime. It will be documented in the "Hosting the AMP framework" guide.