### PR TITLE
Unskip amp-consent e2e test

### DIFF
--- a/extensions/amp-base-carousel/0.1/test-e2e/test-carousel.js
+++ b/extensions/amp-base-carousel/0.1/test-e2e/test-carousel.js
@@ -113,7 +113,7 @@ describes.endtoend(
       await expect(prop(el, 'scrollLeft')).to.equal(scrollLeft);
     });
 
-    it.skip('should have the correct scroll position when resizing', async function () {
+    it('should have the correct scroll position when resizing', async function () {
       this.timeout(testTimeout);
       // Note: 513 seems to be the smallest settable width.
       await controller.setWindowRect({

--- a/extensions/amp-base-carousel/0.1/test-e2e/test-carousel.js
+++ b/extensions/amp-base-carousel/0.1/test-e2e/test-carousel.js
@@ -113,7 +113,7 @@ describes.endtoend(
       await expect(prop(el, 'scrollLeft')).to.equal(scrollLeft);
     });
 
-    it('should have the correct scroll position when resizing', async function () {
+    it.skip('should have the correct scroll position when resizing', async function () {
       this.timeout(testTimeout);
       // Note: 513 seems to be the smallest settable width.
       await controller.setWindowRect({

--- a/extensions/amp-consent/0.1/test-e2e/test-amp-consent-client-side.js
+++ b/extensions/amp-consent/0.1/test-e2e/test-amp-consent-client-side.js
@@ -97,7 +97,7 @@ describes.endtoend(
       });
 
       // Check the analytics request consentState
-      const p = new Promise(resolve => {
+      const p = new Promise((resolve) => {
         setTimeout(resolve, 1000);
       });
       await p;

--- a/extensions/amp-consent/0.1/test-e2e/test-amp-consent-client-side.js
+++ b/extensions/amp-consent/0.1/test-e2e/test-amp-consent-client-side.js
@@ -20,6 +20,7 @@ import {
   verifyElementsBuilt,
   verifyPromptsHidden,
 } from './common';
+import sleep from 'sleep-promise';
 
 describes.endtoend(
   'amp-consent',

--- a/extensions/amp-consent/0.1/test-e2e/test-amp-consent-client-side.js
+++ b/extensions/amp-consent/0.1/test-e2e/test-amp-consent-client-side.js
@@ -97,10 +97,10 @@ describes.endtoend(
       });
 
       // Check the analytics request consentState
-      const p = new Promise((resolve) => {
-        setTimeout(resolve, 1000);
-      });
-      await p;
+      // const p = new Promise((resolve) => {
+      //   setTimeout(resolve, 1000);
+      // });
+      // await p;
       await expect(
         'http://localhost:8000/amp4test/request-bank/e2e/deposit/tracking?consentState=sufficient'
       ).to.have.been.sent;

--- a/extensions/amp-consent/0.1/test-e2e/test-amp-consent-client-side.js
+++ b/extensions/amp-consent/0.1/test-e2e/test-amp-consent-client-side.js
@@ -97,9 +97,7 @@ describes.endtoend(
 
       // Check the analytics request consentState. Wait for 1 second for the
       // request to arrive to avoid flaky test.
-      await new Promise((resolve) => {
-        setTimeout(resolve, 1000);
-      });
+      await sleep(1000);
       await expect(
         'http://localhost:8000/amp4test/request-bank/e2e/deposit/tracking?consentState=sufficient'
       ).to.have.been.sent;

--- a/extensions/amp-consent/0.1/test-e2e/test-amp-consent-client-side.js
+++ b/extensions/amp-consent/0.1/test-e2e/test-amp-consent-client-side.js
@@ -39,7 +39,6 @@ describes.endtoend(
     it('should work with client side decision', async () => {
       resetAllElements();
       const currentUrl = await controller.getCurrentUrl();
-      //console.log('currentUrl is  ', currentUrl);
 
       // Verify no local storage decision
       await findElements(controller);
@@ -96,11 +95,11 @@ describes.endtoend(
         'postPromptUi': false,
       });
 
-      // Check the analytics request consentState
-      // const p = new Promise((resolve) => {
-      //   setTimeout(resolve, 1000);
-      // });
-      // await p;
+      // Check the analytics request consentState. Wait for 1 second for the
+      // request to arrive to avoid flaky test.
+      await new Promise((resolve) => {
+        setTimeout(resolve, 1000);
+      });
       await expect(
         'http://localhost:8000/amp4test/request-bank/e2e/deposit/tracking?consentState=sufficient'
       ).to.have.been.sent;

--- a/extensions/amp-consent/0.1/test-e2e/test-amp-consent-client-side.js
+++ b/extensions/amp-consent/0.1/test-e2e/test-amp-consent-client-side.js
@@ -98,7 +98,7 @@ describes.endtoend(
 
       // Check the analytics request consentState. Wait for 1 second for the
       // request to arrive to avoid flaky test.
-      await sleep(1000);
+      await sleep(3000);
       await expect(
         'http://localhost:8000/amp4test/request-bank/e2e/deposit/tracking?consentState=sufficient'
       ).to.have.been.sent;

--- a/extensions/amp-consent/0.1/test-e2e/test-amp-consent-client-side.js
+++ b/extensions/amp-consent/0.1/test-e2e/test-amp-consent-client-side.js
@@ -36,9 +36,10 @@ describes.endtoend(
       controller = env.controller;
     });
 
-    it.skip('should work with client side decision', async () => {
+    it('should work with client side decision', async () => {
       resetAllElements();
       const currentUrl = await controller.getCurrentUrl();
+      //console.log('currentUrl is  ', currentUrl);
 
       // Verify no local storage decision
       await findElements(controller);
@@ -96,6 +97,10 @@ describes.endtoend(
       });
 
       // Check the analytics request consentState
+      const p = new Promise(resolve => {
+        setTimeout(resolve, 1000);
+      });
+      await p;
       await expect(
         'http://localhost:8000/amp4test/request-bank/e2e/deposit/tracking?consentState=sufficient'
       ).to.have.been.sent;

--- a/extensions/amp-consent/0.1/test-e2e/test-amp-consent-server-side.js
+++ b/extensions/amp-consent/0.1/test-e2e/test-amp-consent-server-side.js
@@ -81,7 +81,7 @@ describes.endtoend(
 
       // Check the analytics request consentState. Wait for 1 second for the
       // request to arrive to avoid flaky test.
-      await sleep(1000);
+      await sleep(3000);
       await expect(
         'http://localhost:8000/amp4test/request-bank/e2e/deposit/tracking?consentState=insufficient'
       ).to.have.been.sent;

--- a/extensions/amp-consent/0.1/test-e2e/test-amp-consent-server-side.js
+++ b/extensions/amp-consent/0.1/test-e2e/test-amp-consent-server-side.js
@@ -37,7 +37,7 @@ describes.endtoend(
     });
 
     //TODO (micajuineho): Unskip flaky test
-    it.skip('should respect server side decision and persist it', async () => {
+    it('should respect server side decision and persist it', async () => {
       resetAllElements();
 
       const currentUrl = await controller.getCurrentUrl();

--- a/extensions/amp-consent/0.1/test-e2e/test-amp-consent-server-side.js
+++ b/extensions/amp-consent/0.1/test-e2e/test-amp-consent-server-side.js
@@ -20,6 +20,7 @@ import {
   verifyElementsBuilt,
   verifyPromptsHidden,
 } from './common';
+import sleep from 'sleep-promise';
 
 describes.endtoend(
   'amp-consent',

--- a/extensions/amp-consent/0.1/test-e2e/test-amp-consent-server-side.js
+++ b/extensions/amp-consent/0.1/test-e2e/test-amp-consent-server-side.js
@@ -80,9 +80,7 @@ describes.endtoend(
 
       // Check the analytics request consentState. Wait for 1 second for the
       // request to arrive to avoid flaky test.
-      await new Promise((resolve) => {
-        setTimeout(resolve, 1000);
-      });
+      await sleep(1000);
       await expect(
         'http://localhost:8000/amp4test/request-bank/e2e/deposit/tracking?consentState=insufficient'
       ).to.have.been.sent;

--- a/extensions/amp-consent/0.1/test-e2e/test-amp-consent-server-side.js
+++ b/extensions/amp-consent/0.1/test-e2e/test-amp-consent-server-side.js
@@ -36,7 +36,6 @@ describes.endtoend(
       controller = env.controller;
     });
 
-    //TODO (micajuineho): Unskip flaky test
     it('should respect server side decision and persist it', async () => {
       resetAllElements();
 
@@ -79,7 +78,11 @@ describes.endtoend(
         'postPromptUi': false,
       });
 
-      // Check the analytics request consentState
+      // Check the analytics request consentState. Wait for 1 second for the
+      // request to arrive to avoid flaky test.
+      await new Promise((resolve) => {
+        setTimeout(resolve, 1000);
+      });
       await expect(
         'http://localhost:8000/amp4test/request-bank/e2e/deposit/tracking?consentState=insufficient'
       ).to.have.been.sent;


### PR DESCRIPTION
I can't reproduce the test failure locally. Tried the fix a few times on travis, seemed to work. 
Confirmed with @estherkim `await expect(url).to.have.been.sent` only check the urls till the check is invoked. 
I added a timeout before verifying the outgoing request to minimize the flakiness.  An ideal fix would be to have something like `await expect(url).to.have.eventually.been.sent`. 

Closes #27634