### PR TITLE
🏗🐛 Fix babel plugin tests and run them for babel config changes

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -39,6 +39,7 @@ const {
  * Mapping of babel transform callers to their corresponding babel configs.
  */
 const babelTransforms = new Map([
+  ['babel-jest', {}],
   ['dep-check', getDepCheckConfig()],
   ['post-closure', getPostClosureConfig()],
   ['pre-closure', getPreClosureConfig()],

--- a/build-system/pr-check/build-targets.js
+++ b/build-system/pr-check/build-targets.js
@@ -61,7 +61,9 @@ const targetMatchers = {
       file == 'build-system/compile/internal-version.js' ||
       file == 'build-system/compile/log-messages.js' ||
       file == 'build-system/tasks/babel-plugin-tests.js' ||
-      file.startsWith('build-system/babel-plugins/')
+      file == 'babel.config.js' ||
+      file.startsWith('build-system/babel-plugins/') ||
+      file.startsWith('build-system/babel-config/')
     );
   },
   'CACHES_JSON': (file) => {


### PR DESCRIPTION
#27576 refactored all babel configs into one place, but neglected to account for the babel plugin tests.

This PR adds a new empty config type called `babel-jest` for `gulp babel-plugin-tests` and makes sure the plugin tests are run when babel configs are changed.

Follow up to #27576