### PR TITLE
Trigger user rather than dev errors for amp-story-consent misconfiguration.

### DIFF
--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -1183,7 +1183,7 @@ export class AmpStory extends AMP.BaseElement {
    */
   validateConsent_(consentEl) {
     if (!childElementByTag(consentEl, 'amp-story-consent')) {
-      dev().error(TAG, 'amp-consent must have an amp-story-consent child');
+      user().error(TAG, 'amp-consent must have an amp-story-consent child');
     }
 
     const allowedTags = ['SCRIPT', 'AMP-STORY-CONSENT'];
@@ -1195,7 +1195,7 @@ export class AmpStory extends AMP.BaseElement {
     if (toRemoveChildren.length === 0) {
       return;
     }
-    dev().error(TAG, 'amp-consent only allows tags: %s', allowedTags);
+    user().error(TAG, 'amp-consent only allows tags: %s', allowedTags);
     toRemoveChildren.forEach((el) => consentEl.removeChild(el));
   }
 


### PR DESCRIPTION
Validation would fail if the `amp-story-consent` doesn't have the right parent, but it cannot catch the case where `amp-consent` does not have an `amp-story-consent` child.

It fails nicely, but the error triggered should be `user()` instead of `dev()`.

Fixes https://github.com/ampproject/amphtml/issues/27669