### PR TITLE
🏗 Added --port option to gulp's default task

### DIFF
--- a/build-system/tasks/default-task.js
+++ b/build-system/tasks/default-task.js
@@ -86,5 +86,6 @@ defaultTask.flags = {
     "  Doesn't use nailgun to invoke closure compiler (much slower)",
   version_override: '  Overrides the version written to AMP_CONFIG',
   custom_version_mark: '  Set final digit (0-9) on auto-generated version',
-  host: 'Host to serve the project on. localhost by default.',
+  host: '  Host to serve the project on. localhost by default.',
+  port: '  Port to serve the project on. 8000 by default.',
 };


### PR DESCRIPTION
The build system's default task [already supports](https://github.com/ampproject/amphtml/blob/3207eea93ff8acb30d5cdc3d5026c3bb0196ac95/build-system/tasks/serve.js#L104) specifying a port to serve on.

But this option is not part of the supported flags that were added in a recent refactor. This PR adds this flag back.