### PR TITLE
🏗 Fix ESM Output with new Babel Configuration

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -40,13 +40,13 @@ const {
  */
 const babelTransforms = new Map([
   ['babel-jest', {}],
-  ['dep-check', getDepCheckConfig()],
-  ['post-closure', getPostClosureConfig()],
-  ['pre-closure', getPreClosureConfig()],
-  ['single-pass-deps', getSinglePassDepsConfig()],
-  ['single-pass-post', getSinglePassPostConfig()],
-  ['test', getTestConfig()],
-  ['unminified', getUnminifiedConfig()],
+  ['dep-check', getDepCheckConfig],
+  ['post-closure', getPostClosureConfig],
+  ['pre-closure', getPreClosureConfig],
+  ['single-pass-deps', getSinglePassDepsConfig],
+  ['single-pass-post', getSinglePassPostConfig],
+  ['test', getTestConfig],
+  ['unminified', getUnminifiedConfig],
 ]);
 
 /**
@@ -58,7 +58,7 @@ const babelTransforms = new Map([
 module.exports = function (api) {
   const caller = api.caller((caller) => caller.name);
   if (babelTransforms.has(caller)) {
-    return babelTransforms.get(caller);
+    return babelTransforms.get(caller)();
   } else {
     const err = new Error('Unrecognized Babel caller (see babel.config.js).');
     err.showStack = false;

--- a/babel.config.js
+++ b/babel.config.js
@@ -40,13 +40,13 @@ const {
  */
 const babelTransforms = new Map([
   ['babel-jest', {}],
-  ['dep-check', getDepCheckConfig],
-  ['post-closure', getPostClosureConfig],
-  ['pre-closure', getPreClosureConfig],
-  ['single-pass-deps', getSinglePassDepsConfig],
-  ['single-pass-post', getSinglePassPostConfig],
-  ['test', getTestConfig],
-  ['unminified', getUnminifiedConfig],
+  ['dep-check', getDepCheckConfig()],
+  ['post-closure', getPostClosureConfig()],
+  ['pre-closure', getPreClosureConfig()],
+  ['single-pass-deps', getSinglePassDepsConfig()],
+  ['single-pass-post', getSinglePassPostConfig()],
+  ['test', getTestConfig()],
+  ['unminified', getUnminifiedConfig()],
 ]);
 
 /**
@@ -58,7 +58,7 @@ const babelTransforms = new Map([
 module.exports = function (api) {
   const caller = api.caller((caller) => caller.name);
   if (babelTransforms.has(caller)) {
-    return babelTransforms.get(caller)();
+    return babelTransforms.get(caller);
   } else {
     const err = new Error('Unrecognized Babel caller (see babel.config.js).');
     err.showStack = false;

--- a/build-system/babel-config/post-closure-config.js
+++ b/build-system/babel-config/post-closure-config.js
@@ -33,7 +33,6 @@ function getPostClosureConfig() {
     './build-system/babel-plugins/babel-plugin-transform-remove-directives',
     './build-system/babel-plugins/babel-plugin-transform-function-declarations',
     './build-system/babel-plugins/babel-plugin-transform-stringish-literals',
-    './build-system/babel-plugins/babel-plugin-transform-fix-leading-comments',
   ];
   return {
     inputSourceMap: false,

--- a/build-system/babel-config/post-closure-config.js
+++ b/build-system/babel-config/post-closure-config.js
@@ -27,14 +27,6 @@ function getPostClosureConfig() {
     return {};
   }
 
-  const reactJsxPlugin = [
-    '@babel/plugin-transform-react-jsx',
-    {
-      pragma: 'Preact.createElement',
-      pragmaFrag: 'Preact.Fragment',
-      useSpread: true,
-    },
-  ];
   const postClosurePlugins = [
     './build-system/babel-plugins/babel-plugin-transform-minified-comments',
     './build-system/babel-plugins/babel-plugin-const-transformer',
@@ -42,23 +34,10 @@ function getPostClosureConfig() {
     './build-system/babel-plugins/babel-plugin-transform-function-declarations',
     './build-system/babel-plugins/babel-plugin-transform-stringish-literals',
     './build-system/babel-plugins/babel-plugin-transform-fix-leading-comments',
-    '@babel/plugin-transform-react-constant-elements',
-    reactJsxPlugin,
   ];
-  const presetEnv = [
-    '@babel/preset-env',
-    {
-      bugfixes: true,
-      modules: false,
-      targets: {'esmodules': true},
-    },
-  ];
-  const postClosurePresets = [presetEnv];
   return {
-    compact: false,
     inputSourceMap: false,
     plugins: postClosurePlugins,
-    presets: postClosurePresets,
     retainLines: false,
     sourceMaps: true,
   };

--- a/build-system/babel-config/pre-closure-config.js
+++ b/build-system/babel-config/pre-closure-config.js
@@ -71,9 +71,6 @@ const preClosurePlugins = [
     ? './build-system/babel-plugins/babel-plugin-transform-amp-asserts'
     : null,
   argv.esm ? filterImportsPlugin : null,
-  // argv.esm
-  //   ? './build-system/babel-plugins/babel-plugin-transform-function-declarations'
-  //   : null,
   isCheckTypes
     ? './build-system/babel-plugins/babel-plugin-transform-simple-object-destructure'
     : './build-system/babel-plugins/babel-plugin-transform-json-configuration',

--- a/build-system/babel-config/pre-closure-config.js
+++ b/build-system/babel-config/pre-closure-config.js
@@ -18,30 +18,30 @@
 const argv = require('minimist')(process.argv.slice(2));
 const {getDevDependencies} = require('./dev-dependencies');
 const {getReplacePlugin} = require('./replace-plugin');
-// const {isTravisBuild} = require('../common/travis');
+const {isTravisBuild} = require('../common/travis');
 
 const isCheckTypes = argv._.includes('check-types');
-// const filterImportsPlugin = [
-//   'filter-imports',
-//   {
-//     imports: {
-//       // Imports removed for all ESM builds.
-//       './polyfills/document-contains': ['installDocContains'],
-//       './polyfills/domtokenlist': ['installDOMTokenList'],
-//       './polyfills/fetch': ['installFetch'],
-//       './polyfills/math-sign': ['installMathSign'],
-//       './polyfills/object-assign': ['installObjectAssign'],
-//       './polyfills/object-values': ['installObjectValues'],
-//       './polyfills/promise': ['installPromise'],
-//       './polyfills/array-includes': ['installArrayIncludes'],
-//       './ie-media-bug': ['ieMediaCheckAndFix'],
-//       '../third_party/css-escape/css-escape': ['cssEscape'],
-//       // Imports that are not needed for valid transformed documents.
-//       '../build/ampshared.css': ['cssText', 'ampSharedCss'],
-//       '../build/ampdoc.css': ['cssText', 'ampDocCss'],
-//     },
-//   },
-// ];
+const filterImportsPlugin = [
+  'filter-imports',
+  {
+    imports: {
+      // Imports removed for all ESM builds.
+      './polyfills/document-contains': ['installDocContains'],
+      './polyfills/domtokenlist': ['installDOMTokenList'],
+      './polyfills/fetch': ['installFetch'],
+      './polyfills/math-sign': ['installMathSign'],
+      './polyfills/object-assign': ['installObjectAssign'],
+      './polyfills/object-values': ['installObjectValues'],
+      './polyfills/promise': ['installPromise'],
+      './polyfills/array-includes': ['installArrayIncludes'],
+      './ie-media-bug': ['ieMediaCheckAndFix'],
+      '../third_party/css-escape/css-escape': ['cssEscape'],
+      // Imports that are not needed for valid transformed documents.
+      '../build/ampshared.css': ['cssText', 'ampSharedCss'],
+      '../build/ampdoc.css': ['cssText', 'ampDocCss'],
+    },
+  },
+];
 const preClosurePlugins = [
   './build-system/babel-plugins/babel-plugin-transform-fix-leading-comments',
   '@babel/plugin-transform-react-constant-elements',
@@ -53,8 +53,7 @@ const preClosurePlugins = [
       useSpread: true,
     },
   ],
-  // argv.esm ? null : ['@babel/plugin-transform-classes', {loose: false}],
-  ['@babel/plugin-transform-classes', {loose: false}],
+  argv.esm ? null : ['@babel/plugin-transform-classes', {loose: false}],
   './build-system/babel-plugins/babel-plugin-transform-inline-configure-component',
   // TODO(alanorozco): Remove `replaceCallArguments` once serving infra is up.
   [
@@ -71,16 +70,16 @@ const preClosurePlugins = [
   argv.single_pass
     ? './build-system/babel-plugins/babel-plugin-transform-amp-asserts'
     : null,
-  // argv.esm ? filterImportsPlugin : null,
+  argv.esm ? filterImportsPlugin : null,
   isCheckTypes
     ? './build-system/babel-plugins/babel-plugin-transform-simple-object-destructure'
     : './build-system/babel-plugins/babel-plugin-transform-json-configuration',
-  // argv.esm
-  //   ? [
-  //       './build-system/babel-plugins/babel-plugin-amp-mode-transformer',
-  //       {isEsmBuild: !!argv.esm},
-  //     ]
-  //   : null,
+  argv.esm
+    ? [
+        './build-system/babel-plugins/babel-plugin-amp-mode-transformer',
+        {isEsmBuild: !!argv.esm},
+      ]
+    : null,
   !(argv.fortesting || isCheckTypes)
     ? './build-system/babel-plugins/babel-plugin-is_dev-constant-transformer'
     : null,
@@ -92,24 +91,21 @@ const preClosurePlugins = [
  * @return {!Object}
  */
 function getPreClosurePresets() {
-  const targets = /*
-    argv.esm
+  const targets = argv.esm
     ? {'esmodules': true}
     : isTravisBuild()
     ? {'browsers': ['Last 2 versions', 'safari >= 9']}
-    :*/ {
-    'browsers': ['Last 2 versions'],
-  };
+    : {'browsers': ['Last 2 versions']};
 
   const options = {
     'modules': false,
     'targets': targets,
   };
-  // if (argv.esm) {
-  //   options['bugfixes'] = true;
-  // } else {
-  options['loose'] = true;
-  // }
+  if (argv.esm) {
+    options['bugfixes'] = true;
+  } else {
+    options['loose'] = true;
+  }
 
   return [['@babel/preset-env', options]];
 }

--- a/build-system/babel-config/pre-closure-config.js
+++ b/build-system/babel-config/pre-closure-config.js
@@ -71,9 +71,9 @@ const preClosurePlugins = [
     ? './build-system/babel-plugins/babel-plugin-transform-amp-asserts'
     : null,
   argv.esm ? filterImportsPlugin : null,
-  argv.esm
-    ? './build-system/babel-plugins/babel-plugin-transform-function-declarations'
-    : null,
+  // argv.esm
+  //   ? './build-system/babel-plugins/babel-plugin-transform-function-declarations'
+  //   : null,
   isCheckTypes
     ? './build-system/babel-plugins/babel-plugin-transform-simple-object-destructure'
     : './build-system/babel-plugins/babel-plugin-transform-json-configuration',
@@ -101,17 +101,27 @@ function getPreClosurePresets() {
     ? {'browsers': ['Last 2 versions', 'safari >= 9']}
     : {'browsers': ['Last 2 versions']};
 
-  const options = {
-    'modules': false,
-    'targets': targets,
-  };
-  if (argv.esm) {
-    options['bugfixes'] = true;
-  } else {
-    options['loose'] = true;
-  }
+  // const options = {
+  //   'modules': false,
+  //   'targets': targets,
+  // };
+  // if (argv.esm) {
+  //   options['bugfixes'] = true;
+  // } else {
+  //   options['loose'] = true;
+  // }
 
-  return [['@babel/preset-env', options]];
+  return [
+    [
+      '@babel/preset-env',
+      {
+        'modules': false,
+        'targets': targets,
+        'bugfixes': true,
+        'loose': true,
+      },
+    ],
+  ];
 }
 
 /**

--- a/build-system/babel-config/pre-closure-config.js
+++ b/build-system/babel-config/pre-closure-config.js
@@ -20,8 +20,81 @@ const {getDevDependencies} = require('./dev-dependencies');
 const {getReplacePlugin} = require('./replace-plugin');
 const {isTravisBuild} = require('../common/travis');
 
+const isCheckTypes = argv._.includes('check-types');
+const filterImportsPlugin = [
+  'filter-imports',
+  {
+    imports: {
+      // Imports removed for all ESM builds.
+      './polyfills/document-contains': ['installDocContains'],
+      './polyfills/domtokenlist': ['installDOMTokenList'],
+      './polyfills/fetch': ['installFetch'],
+      './polyfills/math-sign': ['installMathSign'],
+      './polyfills/object-assign': ['installObjectAssign'],
+      './polyfills/object-values': ['installObjectValues'],
+      './polyfills/promise': ['installPromise'],
+      './polyfills/array-includes': ['installArrayIncludes'],
+      './ie-media-bug': ['ieMediaCheckAndFix'],
+      '../third_party/css-escape/css-escape': ['cssEscape'],
+      // Imports that are not needed for valid transformed documents.
+      '../build/ampshared.css': ['cssText', 'ampSharedCss'],
+      '../build/ampdoc.css': ['cssText', 'ampDocCss'],
+    },
+  },
+];
+const preClosurePlugins = [
+  './build-system/babel-plugins/babel-plugin-transform-fix-leading-comments',
+  '@babel/plugin-transform-react-constant-elements',
+  [
+    '@babel/plugin-transform-react-jsx',
+    {
+      pragma: 'Preact.createElement',
+      pragmaFrag: 'Preact.Fragment',
+      useSpread: true,
+    },
+  ],
+  argv.esm ? null : ['@babel/plugin-transform-classes', {loose: false}],
+  './build-system/babel-plugins/babel-plugin-transform-inline-configure-component',
+  // TODO(alanorozco): Remove `replaceCallArguments` once serving infra is up.
+  [
+    './build-system/babel-plugins/babel-plugin-transform-log-methods',
+    {replaceCallArguments: false},
+  ],
+  './build-system/babel-plugins/babel-plugin-transform-parenthesize-expression',
+  './build-system/babel-plugins/babel-plugin-is_minified-constant-transformer',
+  './build-system/babel-plugins/babel-plugin-transform-amp-extension-call',
+  './build-system/babel-plugins/babel-plugin-transform-html-template',
+  './build-system/babel-plugins/babel-plugin-transform-version-call',
+  './build-system/babel-plugins/babel-plugin-transform-simple-array-destructure',
+  getReplacePlugin(),
+  argv.single_pass
+    ? './build-system/babel-plugins/babel-plugin-transform-amp-asserts'
+    : null,
+  argv.esm ? filterImportsPlugin : null,
+  argv.esm
+    ? './build-system/babel-plugins/babel-plugin-transform-function-declarations'
+    : null,
+  isCheckTypes
+    ? './build-system/babel-plugins/babel-plugin-transform-simple-object-destructure'
+    : './build-system/babel-plugins/babel-plugin-transform-json-configuration',
+  argv.esm
+    ? [
+        './build-system/babel-plugins/babel-plugin-amp-mode-transformer',
+        {isEsmBuild: !!argv.esm},
+      ]
+    : null,
+  !(argv.fortesting || isCheckTypes)
+    ? './build-system/babel-plugins/babel-plugin-is_dev-constant-transformer'
+    : null,
+  'transform-es2015-modules-commonjs',
+].filter(Boolean);
+
+/**
+ * Gets the preset configuration for Babel before Closure Compiler executes.
+ *
+ * @return {!Object}
+ */
 function getPreClosurePresets() {
-  const modules = argv.esm ? false : 'commonjs';
   const targets = argv.esm
     ? {'esmodules': true}
     : isTravisBuild()
@@ -29,11 +102,12 @@ function getPreClosurePresets() {
     : {'browsers': ['Last 2 versions']};
 
   const options = {
-    'modules': modules,
+    'modules': false,
     'targets': targets,
-    'bugfixes': true,
   };
   if (argv.esm) {
+    options['bugfixes'] = true;
+  } else {
     options['loose'] = true;
   }
 
@@ -46,75 +120,6 @@ function getPreClosurePresets() {
  * @return {!Object}
  */
 function getPreClosureConfig() {
-  const isCheckTypes = argv._.includes('check-types');
-  const filterImportsPlugin = [
-    'filter-imports',
-    {
-      imports: {
-        // Imports removed for all ESM builds.
-        './polyfills/document-contains': ['installDocContains'],
-        './polyfills/domtokenlist': ['installDOMTokenList'],
-        './polyfills/fetch': ['installFetch'],
-        './polyfills/math-sign': ['installMathSign'],
-        './polyfills/object-assign': ['installObjectAssign'],
-        './polyfills/object-values': ['installObjectValues'],
-        './polyfills/promise': ['installPromise'],
-        './polyfills/array-includes': ['installArrayIncludes'],
-        './ie-media-bug': ['ieMediaCheckAndFix'],
-        '../third_party/css-escape/css-escape': ['cssEscape'],
-        // Imports that are not needed for valid transformed documents.
-        '../build/ampshared.css': ['cssText', 'ampSharedCss'],
-        '../build/ampdoc.css': ['cssText', 'ampDocCss'],
-      },
-    },
-  ];
-  const reactJsxPlugin = [
-    '@babel/plugin-transform-react-jsx',
-    {
-      pragma: 'Preact.createElement',
-      pragmaFrag: 'Preact.Fragment',
-      useSpread: true,
-    },
-  ];
-  const replacePlugin = getReplacePlugin();
-  const preClosurePlugins = [
-    './build-system/babel-plugins/babel-plugin-transform-fix-leading-comments',
-    '@babel/plugin-transform-react-constant-elements',
-    reactJsxPlugin,
-    argv.esm ? null : ['@babel/plugin-transform-classes', {loose: false}],
-    './build-system/babel-plugins/babel-plugin-transform-inline-configure-component',
-    // TODO(alanorozco): Remove `replaceCallArguments` once serving infra is up.
-    [
-      './build-system/babel-plugins/babel-plugin-transform-log-methods',
-      {replaceCallArguments: false},
-    ],
-    './build-system/babel-plugins/babel-plugin-transform-parenthesize-expression',
-    './build-system/babel-plugins/babel-plugin-is_minified-constant-transformer',
-    './build-system/babel-plugins/babel-plugin-transform-amp-extension-call',
-    './build-system/babel-plugins/babel-plugin-transform-html-template',
-    './build-system/babel-plugins/babel-plugin-transform-version-call',
-    './build-system/babel-plugins/babel-plugin-transform-simple-array-destructure',
-    replacePlugin,
-    argv.single_pass
-      ? './build-system/babel-plugins/babel-plugin-transform-amp-asserts'
-      : null,
-    argv.esm ? filterImportsPlugin : null,
-    argv.esm
-      ? './build-system/babel-plugins/babel-plugin-transform-function-declarations'
-      : null,
-    isCheckTypes
-      ? './build-system/babel-plugins/babel-plugin-transform-simple-object-destructure'
-      : './build-system/babel-plugins/babel-plugin-transform-json-configuration',
-    argv.esm
-      ? [
-          './build-system/babel-plugins/babel-plugin-amp-mode-transformer',
-          {isEsmBuild: !!argv.esm},
-        ]
-      : null,
-    !(argv.fortesting || isCheckTypes)
-      ? './build-system/babel-plugins/babel-plugin-is_dev-constant-transformer'
-      : null,
-  ].filter(Boolean);
   const devDependencies = getDevDependencies();
   const preClosureConfig = {
     compact: false,

--- a/build-system/babel-config/pre-closure-config.js
+++ b/build-system/babel-config/pre-closure-config.js
@@ -18,30 +18,30 @@
 const argv = require('minimist')(process.argv.slice(2));
 const {getDevDependencies} = require('./dev-dependencies');
 const {getReplacePlugin} = require('./replace-plugin');
-const {isTravisBuild} = require('../common/travis');
+// const {isTravisBuild} = require('../common/travis');
 
 const isCheckTypes = argv._.includes('check-types');
-const filterImportsPlugin = [
-  'filter-imports',
-  {
-    imports: {
-      // Imports removed for all ESM builds.
-      './polyfills/document-contains': ['installDocContains'],
-      './polyfills/domtokenlist': ['installDOMTokenList'],
-      './polyfills/fetch': ['installFetch'],
-      './polyfills/math-sign': ['installMathSign'],
-      './polyfills/object-assign': ['installObjectAssign'],
-      './polyfills/object-values': ['installObjectValues'],
-      './polyfills/promise': ['installPromise'],
-      './polyfills/array-includes': ['installArrayIncludes'],
-      './ie-media-bug': ['ieMediaCheckAndFix'],
-      '../third_party/css-escape/css-escape': ['cssEscape'],
-      // Imports that are not needed for valid transformed documents.
-      '../build/ampshared.css': ['cssText', 'ampSharedCss'],
-      '../build/ampdoc.css': ['cssText', 'ampDocCss'],
-    },
-  },
-];
+// const filterImportsPlugin = [
+//   'filter-imports',
+//   {
+//     imports: {
+//       // Imports removed for all ESM builds.
+//       './polyfills/document-contains': ['installDocContains'],
+//       './polyfills/domtokenlist': ['installDOMTokenList'],
+//       './polyfills/fetch': ['installFetch'],
+//       './polyfills/math-sign': ['installMathSign'],
+//       './polyfills/object-assign': ['installObjectAssign'],
+//       './polyfills/object-values': ['installObjectValues'],
+//       './polyfills/promise': ['installPromise'],
+//       './polyfills/array-includes': ['installArrayIncludes'],
+//       './ie-media-bug': ['ieMediaCheckAndFix'],
+//       '../third_party/css-escape/css-escape': ['cssEscape'],
+//       // Imports that are not needed for valid transformed documents.
+//       '../build/ampshared.css': ['cssText', 'ampSharedCss'],
+//       '../build/ampdoc.css': ['cssText', 'ampDocCss'],
+//     },
+//   },
+// ];
 const preClosurePlugins = [
   './build-system/babel-plugins/babel-plugin-transform-fix-leading-comments',
   '@babel/plugin-transform-react-constant-elements',
@@ -53,7 +53,8 @@ const preClosurePlugins = [
       useSpread: true,
     },
   ],
-  argv.esm ? null : ['@babel/plugin-transform-classes', {loose: false}],
+  // argv.esm ? null : ['@babel/plugin-transform-classes', {loose: false}],
+  ['@babel/plugin-transform-classes', {loose: false}],
   './build-system/babel-plugins/babel-plugin-transform-inline-configure-component',
   // TODO(alanorozco): Remove `replaceCallArguments` once serving infra is up.
   [
@@ -70,16 +71,16 @@ const preClosurePlugins = [
   argv.single_pass
     ? './build-system/babel-plugins/babel-plugin-transform-amp-asserts'
     : null,
-  argv.esm ? filterImportsPlugin : null,
+  // argv.esm ? filterImportsPlugin : null,
   isCheckTypes
     ? './build-system/babel-plugins/babel-plugin-transform-simple-object-destructure'
     : './build-system/babel-plugins/babel-plugin-transform-json-configuration',
-  argv.esm
-    ? [
-        './build-system/babel-plugins/babel-plugin-amp-mode-transformer',
-        {isEsmBuild: !!argv.esm},
-      ]
-    : null,
+  // argv.esm
+  //   ? [
+  //       './build-system/babel-plugins/babel-plugin-amp-mode-transformer',
+  //       {isEsmBuild: !!argv.esm},
+  //     ]
+  //   : null,
   !(argv.fortesting || isCheckTypes)
     ? './build-system/babel-plugins/babel-plugin-is_dev-constant-transformer'
     : null,
@@ -91,21 +92,24 @@ const preClosurePlugins = [
  * @return {!Object}
  */
 function getPreClosurePresets() {
-  const targets = argv.esm
+  const targets = /*
+    argv.esm
     ? {'esmodules': true}
     : isTravisBuild()
     ? {'browsers': ['Last 2 versions', 'safari >= 9']}
-    : {'browsers': ['Last 2 versions']};
+    :*/ {
+    'browsers': ['Last 2 versions'],
+  };
 
   const options = {
     'modules': false,
     'targets': targets,
   };
-  if (argv.esm) {
-    options['bugfixes'] = true;
-  } else {
-    options['loose'] = true;
-  }
+  // if (argv.esm) {
+  //   options['bugfixes'] = true;
+  // } else {
+  options['loose'] = true;
+  // }
 
   return [['@babel/preset-env', options]];
 }

--- a/build-system/babel-config/pre-closure-config.js
+++ b/build-system/babel-config/pre-closure-config.js
@@ -86,7 +86,6 @@ const preClosurePlugins = [
   !(argv.fortesting || isCheckTypes)
     ? './build-system/babel-plugins/babel-plugin-is_dev-constant-transformer'
     : null,
-  'transform-es2015-modules-commonjs',
 ].filter(Boolean);
 
 /**
@@ -101,27 +100,17 @@ function getPreClosurePresets() {
     ? {'browsers': ['Last 2 versions', 'safari >= 9']}
     : {'browsers': ['Last 2 versions']};
 
-  // const options = {
-  //   'modules': false,
-  //   'targets': targets,
-  // };
-  // if (argv.esm) {
-  //   options['bugfixes'] = true;
-  // } else {
-  //   options['loose'] = true;
-  // }
+  const options = {
+    'modules': false,
+    'targets': targets,
+  };
+  if (argv.esm) {
+    options['bugfixes'] = true;
+  } else {
+    options['loose'] = true;
+  }
 
-  return [
-    [
-      '@babel/preset-env',
-      {
-        'modules': false,
-        'targets': targets,
-        'bugfixes': true,
-        'loose': true,
-      },
-    ],
-  ];
+  return [['@babel/preset-env', options]];
 }
 
 /**

--- a/build-system/babel-config/pre-closure-config.js
+++ b/build-system/babel-config/pre-closure-config.js
@@ -20,29 +20,24 @@ const {getDevDependencies} = require('./dev-dependencies');
 const {getReplacePlugin} = require('./replace-plugin');
 const {isTravisBuild} = require('../common/travis');
 
-const isClosureCompiler =
-  argv._.includes('dist') ||
-  argv._.includes('check-types') ||
-  (argv._.length == 0 && argv.compiled);
-
 function getPreClosurePresets() {
+  const modules = argv.esm ? false : 'commonjs';
   const targets = argv.esm
     ? {'esmodules': true}
     : isTravisBuild()
     ? {'browsers': ['Last 2 versions', 'safari >= 9']}
     : {'browsers': ['Last 2 versions']};
 
-  return [
-    [
-      '@babel/preset-env',
-      {
-        'modules': argv.esm || isClosureCompiler ? false : 'commonjs',
-        'loose': true,
-        'targets': targets,
-        'bugfixes': true,
-      },
-    ],
-  ];
+  const options = {
+    'modules': modules,
+    'targets': targets,
+    'bugfixes': true,
+  };
+  if (argv.esm) {
+    options['loose'] = true;
+  }
+
+  return [['@babel/preset-env', options]];
 }
 
 /**
@@ -86,6 +81,7 @@ function getPreClosureConfig() {
     './build-system/babel-plugins/babel-plugin-transform-fix-leading-comments',
     '@babel/plugin-transform-react-constant-elements',
     reactJsxPlugin,
+    argv.esm ? null : ['@babel/plugin-transform-classes', {loose: false}],
     './build-system/babel-plugins/babel-plugin-transform-inline-configure-component',
     // TODO(alanorozco): Remove `replaceCallArguments` once serving infra is up.
     [

--- a/build-system/babel-config/single-pass-config.js
+++ b/build-system/babel-config/single-pass-config.js
@@ -42,9 +42,11 @@ function getSinglePassPostConfig() {
  * @return {!Object}
  */
 function getSinglePassDepsConfig() {
-  const singlePassDepsConfig = getPreClosureConfig();
-  singlePassDepsConfig.plugins.push('transform-es2015-modules-commonjs');
-  return singlePassDepsConfig;
+  const clonedPreClosureConfig = JSON.parse(
+    JSON.stringify(getPreClosureConfig())
+  );
+  clonedPreClosureConfig.plugins.push('transform-es2015-modules-commonjs');
+  return clonedPreClosureConfig;
 }
 
 module.exports = {

--- a/build-system/compile/bundles.config.js
+++ b/build-system/compile/bundles.config.js
@@ -130,7 +130,7 @@ exports.jsBundles = {
       minifiedName: 'amp-viewer-host.js',
       incudePolyfills: true,
       extraGlobs: ['extensions/amp-viewer-integration/**/*.js'],
-      compilationLevel: 'WHITESPACE_ONLY',
+      // compilationLevel: 'WHITESPACE_ONLY',
       skipUnknownDepsCheck: true,
     },
   },

--- a/build-system/compile/bundles.config.js
+++ b/build-system/compile/bundles.config.js
@@ -130,7 +130,6 @@ exports.jsBundles = {
       minifiedName: 'amp-viewer-host.js',
       incudePolyfills: true,
       extraGlobs: ['extensions/amp-viewer-integration/**/*.js'],
-      // compilationLevel: 'WHITESPACE_ONLY',
       skipUnknownDepsCheck: true,
     },
   },

--- a/build-system/compile/debug-compilaton-lifecyle.js
+++ b/build-system/compile/debug-compilaton-lifecyle.js
@@ -1,0 +1,68 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+const argv = require('minimist')(process.argv.slice(2));
+const colors = require('ansi-colors');
+const fs = require('fs');
+const log = require('fancy-log');
+const path = require('path');
+const tempy = require('tempy');
+
+const logFile = tempy.writeSync('Debug Lifecycles\n', {name: 'log'});
+
+const pad = (value, length) =>
+  (value.length > length ? value.slice(value.length - length) : value).padEnd(
+    length
+  );
+
+const LIFECYCLES = {
+  'pre-babel': 'pre-babel',
+  'pre-closure': 'pre-closure',
+  'closured-pre-babel': 'closured-pre-babel',
+  'closured-pre-terser': 'closured-pre-terser',
+  'complete': 'complete',
+};
+
+/**
+ * Output debugging information when developing changes in this functionality.
+ *
+ * @param {string} lifecycle
+ * @param {string} fullpath
+ * @param {string} content
+ */
+function debug(lifecycle, fullpath, content) {
+  if (argv.debug && Object.keys(LIFECYCLES).includes(lifecycle)) {
+    fs.appendFileSync(
+      logFile,
+      `${pad(lifecycle, 25)}: ${pad(
+        path.basename(fullpath),
+        25
+      )} ${tempy.writeSync(content)}\n`
+    );
+  }
+}
+
+function message() {
+  if (argv.debug) {
+    log(colors.white('Debug Lifecycles: ') + colors.red(logFile));
+  }
+}
+
+module.exports = {
+  message,
+  debug,
+  CompilationLifecycles: LIFECYCLES,
+};

--- a/build-system/compile/debug-compilaton-lifecyle.js
+++ b/build-system/compile/debug-compilaton-lifecyle.js
@@ -21,7 +21,7 @@ const log = require('fancy-log');
 const path = require('path');
 const tempy = require('tempy');
 
-const logFile = tempy.writeSync('Debug Lifecycles\n', {name: 'log'});
+const logFile = path.resolve(process.cwd(), 'dist', 'debug-compilation.log');
 
 const pad = (value, length) =>
   (value.length > length ? value.slice(value.length - length) : value).padEnd(

--- a/build-system/compile/post-closure-babel.js
+++ b/build-system/compile/post-closure-babel.js
@@ -21,6 +21,7 @@ const path = require('path');
 const remapping = require('@ampproject/remapping');
 const terser = require('terser');
 const through = require('through2');
+const {debug, CompilationLifecycles} = require('./debug-compilaton-lifecyle');
 
 /**
  * Given a filepath, return the sourcemap.
@@ -91,10 +92,20 @@ exports.postClosureBabel = function (directory) {
       return next(null, file);
     }
 
+    debug(
+      CompilationLifecycles['closured-pre-babel'],
+      file.path,
+      file.contents
+    );
     const map = loadSourceMap(file.path);
     const {code, map: babelMap} = babel.transformSync(file.contents, {
       caller: {name: 'post-closure'},
     });
+    debug(
+      CompilationLifecycles['closured-pre-terser'],
+      file.path,
+      file.contents
+    );
     let remapped = remapping(
       babelMap,
       returnMapFirst(map),
@@ -103,6 +114,7 @@ exports.postClosureBabel = function (directory) {
 
     const {compressed, terserMap} = terserMinify(code);
     file.contents = Buffer.from(compressed, 'utf-8');
+    debug(CompilationLifecycles['complete'], file.path, compressed);
 
     // TODO: Remapping should support a chain, instead of multiple invocations.
     remapped = remapping(

--- a/build-system/compile/pre-closure-babel.js
+++ b/build-system/compile/pre-closure-babel.js
@@ -21,6 +21,7 @@ const gulpBabel = require('gulp-babel');
 const log = require('fancy-log');
 const through = require('through2');
 const {BABEL_SRC_GLOBS, THIRD_PARTY_TRANSFORM_GLOBS} = require('./sources');
+const {debug, CompilationLifecycles} = require('./debug-compilaton-lifecyle');
 const {EventEmitter} = require('events');
 const {red, cyan} = require('ansi-colors');
 
@@ -83,6 +84,7 @@ function preClosureBabel() {
       return next(null, cached.file.clone());
     }
 
+    debug(CompilationLifecycles['pre-babel'], file.path, file.contents);
     let data, err;
     function onData(d) {
       babel.off('error', onError);
@@ -99,6 +101,11 @@ function preClosureBabel() {
         return next(err);
       }
 
+      debug(
+        CompilationLifecycles['pre-closure'],
+        file.path,
+        data.contents.toString('utf8')
+      );
       cache[path] = {
         file: data,
         hash,

--- a/build-system/tasks/dist.js
+++ b/build-system/tasks/dist.js
@@ -50,6 +50,7 @@ const {compileCss, cssEntryPoints} = require('./css');
 const {compileJison} = require('./compile-jison');
 const {formatExtractedMessages} = require('../compile/log-messages');
 const {maybeUpdatePackages} = require('./update-packages');
+const {message} = require('../compile/debug-compilaton-lifecyle');
 const {VERSION} = require('../compile/internal-version');
 
 const {green, cyan} = colors;
@@ -100,6 +101,7 @@ async function runPreDistSteps(watch) {
   await copyParsers();
   await bootstrapThirdPartyFrames(watch, /* minify */ true);
   await startNailgunServer(distNailgunPort, /* detached */ false);
+  message();
 }
 
 /**
@@ -462,4 +464,5 @@ dist.flags = {
   custom_version_mark: '  Set final digit (0-9) on auto-generated version',
   watch: '  Watches for changes in files, re-compiles when detected',
   closure_concurrency: '  Sets the number of concurrent invocations of closure',
+  debug: '  Outputs the file contents during compilation lifecycles',
 };

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "fs-extra": "9.0.0",
     "fuse.js": "5.1.0",
     "globby": "11.0.0",
-    "google-closure-compiler": "20200224.0.0",
+    "google-closure-compiler": "20200406.0.0",
     "gulp": "4.0.2",
     "gulp-append-prepend": "1.0.8",
     "gulp-ava": "3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7827,46 +7827,46 @@ glogg@^1.0.0:
   dependencies:
     sparkles "^1.0.0"
 
-google-closure-compiler-java@^20200224.0.0:
-  version "20200224.0.0"
-  resolved "https://registry.yarnpkg.com/google-closure-compiler-java/-/google-closure-compiler-java-20200224.0.0.tgz#03d71aefd0a07010fd8a7057d09c76f6729767bc"
-  integrity sha512-palFcDoScauZjWIsGDzMK6h+IctcRb55I3wJX8Ko/DTSz72xwadRdKm0lGt8OoYL7SKEO+IjgD7s8XrAGpLnlQ==
+google-closure-compiler-java@^20200406.0.0:
+  version "20200406.0.0"
+  resolved "https://registry.yarnpkg.com/google-closure-compiler-java/-/google-closure-compiler-java-20200406.0.0.tgz#89c640b89a91e9a693ab8119e3839d3e79b158ab"
+  integrity sha512-07WM/06CgQ0T2ZtSitfl+jmpeXW+c+spZgEgekJxEauzZztruYSkkBAHK8bZQ0N0+ZGfIUyQFNhLu//vxb5EJg==
 
-google-closure-compiler-js@^20200224.0.0:
-  version "20200224.0.0"
-  resolved "https://registry.yarnpkg.com/google-closure-compiler-js/-/google-closure-compiler-js-20200224.0.0.tgz#cf4b598abf7be686c683e530529756805b8af500"
-  integrity sha512-70VKN0kbnTRtu2dqxDjWZQGfEQIHj7b7oUUCsYPO5oEXCDfgxNc13oYUJXvrTONLRWlHCNl/I8FNrVOwZ3gY/g==
+google-closure-compiler-js@^20200406.0.0:
+  version "20200406.0.0"
+  resolved "https://registry.yarnpkg.com/google-closure-compiler-js/-/google-closure-compiler-js-20200406.0.0.tgz#e73f498b1ab56a0580c0f945463252f7562f6f98"
+  integrity sha512-4qsr9VwjpSfoGt84bRAwDAcUlyYodZ9iywVMQwWzCu+SziCNXLFhUWkfLqTXbOYRSwO94UadwERSBdoPZY/GrA==
 
-google-closure-compiler-linux@^20200224.0.0:
-  version "20200224.0.0"
-  resolved "https://registry.yarnpkg.com/google-closure-compiler-linux/-/google-closure-compiler-linux-20200224.0.0.tgz#d9608b224b4d8f38d4d34e99a24da54bca6b1902"
-  integrity sha512-/BaE889EPrXWOKJVolA9++e99xBDMzeFBf7zF7nBB8PUmU5DlvtsoLL82xnT6nbZC1ktHaETlVx+vYGju8zKBQ==
+google-closure-compiler-linux@^20200406.0.0:
+  version "20200406.0.0"
+  resolved "https://registry.yarnpkg.com/google-closure-compiler-linux/-/google-closure-compiler-linux-20200406.0.0.tgz#af2d5e6041a8a8ac4a5f0ec5015d328e18b66121"
+  integrity sha512-5NiU/jAjeMVJ7xm1KBDttE863lF7ItEqxg5Z1Vg/QMabTZz6Rr5S0Qy4hP+wjMfBnmqcL10BjXKJP5/m+doSbA==
 
-google-closure-compiler-osx@^20200224.0.0:
-  version "20200224.0.0"
-  resolved "https://registry.yarnpkg.com/google-closure-compiler-osx/-/google-closure-compiler-osx-20200224.0.0.tgz#aee62d8b878a662fc73b92419603168c0c3a35ed"
-  integrity sha512-WXVNW9nPUqjvCe38mUIlBGEPVPCTKLtdaXC+q+kQdonkJFHNrpdyYWa746Y8cNP/byQyDNpPsqcKseZTLh17sQ==
+google-closure-compiler-osx@^20200406.0.0:
+  version "20200406.0.0"
+  resolved "https://registry.yarnpkg.com/google-closure-compiler-osx/-/google-closure-compiler-osx-20200406.0.0.tgz#bcab837e654dd74828030eafb95acadc49d974c6"
+  integrity sha512-XSF1l7GANVHnp2w8AGhhGDL3gw+XV3RaJvA7GsOJUmplPHguwlNvcLMEnSit7AEDa0JYdaQ50dfATwIKm6k8BQ==
 
-google-closure-compiler-windows@^20200224.0.0:
-  version "20200224.0.0"
-  resolved "https://registry.yarnpkg.com/google-closure-compiler-windows/-/google-closure-compiler-windows-20200224.0.0.tgz#cae323b898625ca57b0e87aaddde021a414dda58"
-  integrity sha512-l6w2D8r9+GC9CQTAYEMAuNI996Zb6YV5qG7+FR0gCoL6h6S3Mc7mi87bafgwaicsVcmmHE/9kCBuW4ZyTMs5Fg==
+google-closure-compiler-windows@^20200406.0.0:
+  version "20200406.0.0"
+  resolved "https://registry.yarnpkg.com/google-closure-compiler-windows/-/google-closure-compiler-windows-20200406.0.0.tgz#ddb785df271026dd3a97da37710771480b6d2341"
+  integrity sha512-F7mSN06PrjWYrD9cTkCcNwJXyoYmcwAMrJGgFvmm04Nb7TDQRK6yVqXwrEkncGMuiymD+B1vsoCzUJ/GlQVf0Q==
 
-google-closure-compiler@20200224.0.0:
-  version "20200224.0.0"
-  resolved "https://registry.yarnpkg.com/google-closure-compiler/-/google-closure-compiler-20200224.0.0.tgz#ec0e708d9716a48e12fff43fe37fa5cec732a283"
-  integrity sha512-V81dRYygdHbZtOtU16VX26xAdJBB1UZyfSg3OTzdNl3l/xEIx1D/L7TYUqjeTXsxcy+JruJ/UfUlIJAOaMRTog==
+google-closure-compiler@20200406.0.0:
+  version "20200406.0.0"
+  resolved "https://registry.yarnpkg.com/google-closure-compiler/-/google-closure-compiler-20200406.0.0.tgz#ae77582160fb286e161249f7e1c3806396beb251"
+  integrity sha512-CBfXKVeZASKrgWRDJoYKxbZ546Pphld1SP6mN/KXVW4LbtV1wvXauM9wq1X/Y0Cez4Qh8MlU8VHCtLtNZfq17A==
   dependencies:
     chalk "2.x"
-    google-closure-compiler-java "^20200224.0.0"
-    google-closure-compiler-js "^20200224.0.0"
+    google-closure-compiler-java "^20200406.0.0"
+    google-closure-compiler-js "^20200406.0.0"
     minimist "1.x"
     vinyl "2.x"
     vinyl-sourcemaps-apply "^0.2.0"
   optionalDependencies:
-    google-closure-compiler-linux "^20200224.0.0"
-    google-closure-compiler-osx "^20200224.0.0"
-    google-closure-compiler-windows "^20200224.0.0"
+    google-closure-compiler-linux "^20200406.0.0"
+    google-closure-compiler-osx "^20200406.0.0"
+    google-closure-compiler-windows "^20200406.0.0"
 
 got@^9.6.0:
   version "9.6.0"


### PR DESCRIPTION
This PR Draft contains several fixes that @rsimha is going to pull apart and apply.

1. Fix ESM output with our new `babel.config.js` configuration by removing `WHITESPACE_ONLY` compile passes.
2. Upgrade to the latest Closure Compiler.
3. Apply Babel `preset-env` during `pre-closure` compilation, and remove it from `post-closure` compilation.
4. Introduce a new debugger for our more complex compilation pipeline allowing AMP Developers to remedy issues with different plugin interactions.
5. Deep clone configuration before modifying for `single pass`, to avoid mutating the existing `multi pass` configuration unintentionally.