### PR TITLE
resources-impl: remove check

### DIFF
--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -1301,7 +1301,6 @@ export class ResourcesImpl {
         if (
           !r.isBuilt() &&
           !r.hasOwner() &&
-          r.hasBeenMeasured() &&
           r.isDisplayed() &&
           r.overlaps(loadRect)
         ) {


### PR DESCRIPTION
If `isDisplayed` returns true, doesn't that imply it was already measured. Therefore we can skip the `r.hasBeenMeasured()` check.