### PR TITLE
intersect-resources: Fix incorrect pre-layout assumption

### DIFF
--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -677,7 +677,7 @@ export class Resource {
    *     available, use it. Otherwise, use the cached layout box.
    * @return {boolean}
    */
-  isDisplayed(usePremeasuredRect) {
+  isDisplayed(usePremeasuredRect = false) {
     devAssert(!usePremeasuredRect || !this.intersect_);
     const isFluid = this.element.getLayout() == Layout.FLUID;
     const box = usePremeasuredRect

--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -673,13 +673,16 @@ export class Resource {
   /**
    * Whether the resource is displayed, i.e. if it has non-zero width and
    * height.
-   * @param {!ClientRect=} opt_premeasuredRect If provided, use this
-   *    premeasured ClientRect instead of using the cached layout box.
+   * @param {boolean} usePremeasuredRect If true and a premeasured rect is
+   *     available, use it. Otherwise, use the cached layout box.
    * @return {boolean}
    */
-  isDisplayed(opt_premeasuredRect) {
+  isDisplayed(usePremeasuredRect) {
+    devAssert(!usePremeasuredRect || !this.intersect_);
     const isFluid = this.element.getLayout() == Layout.FLUID;
-    const box = opt_premeasuredRect || this.getLayoutBox();
+    const box = usePremeasuredRect
+      ? devAssert(this.premeasuredRect_)
+      : this.getLayoutBox();
     const hasNonZeroSize = box.height > 0 && box.width > 0;
     return (
       (isFluid || hasNonZeroSize) &&

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -1420,14 +1420,28 @@ export class ResourcesImpl {
         const reschedule = this.reschedule_.bind(this, task);
         executing.promise.then(reschedule, reschedule);
       } else {
-        // With IntersectionObserver, the element's client rect measurement
-        // is recent so immediate remeasuring shouldn't be necessary.
-        if (!this.intersectionObserver_) {
-          task.resource.measure();
+        const {resource} = task;
+
+        let stillDisplayed = true;
+        if (this.intersectionObserver_) {
+          // With IntersectionObserver, peek at the premeasured rect to see
+          // if the resource is still displayed (has a non-zero size).
+          // The premeasured rect is most analogous to an immediate measure.
+          if (resource.hasBeenPremeasured()) {
+            stillDisplayed = resource.isDisplayed(
+              /* usePremeasuredRect */ true
+            );
+          }
+        } else {
+          // Remeasure can only update isDisplayed(), not in-viewport state.
+          resource.measure();
         }
         // Check if the element has exited the viewport or the page has changed
         // visibility since the layout was scheduled.
-        if (this.isLayoutAllowed_(task.resource, task.forceOutsideViewport)) {
+        if (
+          stillDisplayed &&
+          this.isLayoutAllowed_(resource, task.forceOutsideViewport)
+        ) {
           task.promise = task.callback();
           task.startTime = now;
           dev().fine(TAG_, 'exec:', task.id, 'at', task.startTime);
@@ -1439,9 +1453,8 @@ export class ResourcesImpl {
             )
             .catch(/** @type {function (*)} */ (reportError));
         } else {
-          devAssert(!this.intersectionObserver_);
           dev().fine(TAG_, 'cancelled', task.id);
-          task.resource.layoutCanceled();
+          resource.layoutCanceled();
         }
       }
 

--- a/test/unit/test-resources.js
+++ b/test/unit/test-resources.js
@@ -23,7 +23,6 @@ import {Signals} from '../../src/utils/signals';
 import {VisibilityState} from '../../src/visibility-state';
 import {layoutRectLtwh} from '../../src/layout-rect';
 import {loadPromise} from '../../src/event-helper';
-import {toggleExperiment} from '../../src/experiments';
 
 /*eslint "google-camelcase/google-camelcase": 0*/
 describe('Resources', () => {

--- a/test/unit/test-resources.js
+++ b/test/unit/test-resources.js
@@ -1229,19 +1229,18 @@ describes.realWin(
     let win;
     let resources;
     let viewerSendMessageStub, viewportContentHeightChangedStub;
+    let sandbox;
 
     beforeEach(() => {
       win = env.win;
+      sandbox = env.sandbox;
       resources = win.__AMP_SERVICES.resources.obj;
-      viewerSendMessageStub = env.sandbox.stub(
-        resources.viewer_,
-        'sendMessage'
-      );
-      viewportContentHeightChangedStub = env.sandbox.stub(
+      viewerSendMessageStub = sandbox.stub(resources.viewer_, 'sendMessage');
+      viewportContentHeightChangedStub = sandbox.stub(
         resources.viewport_,
         'contentHeightChanged'
       );
-      env.sandbox.stub(resources.vsync_, 'run').callsFake((task) => {
+      sandbox.stub(resources.vsync_, 'run').callsFake((task) => {
         task.measure({});
       });
     });
@@ -1254,7 +1253,7 @@ describes.realWin(
     });
 
     it('should send contentHeight to viewer if height was changed', () => {
-      env.sandbox.stub(resources.viewport_, 'getContentHeight').returns(200);
+      sandbox.stub(resources.viewport_, 'getContentHeight').returns(200);
       resources.maybeChangeHeight_ = true;
 
       resources.doPass();
@@ -1281,7 +1280,7 @@ describes.realWin(
     });
 
     it('should send contentHeight to viewer if viewport resizes', () => {
-      env.sandbox.stub(resources.viewport_, 'getContentHeight').returns(200);
+      sandbox.stub(resources.viewport_, 'getContentHeight').returns(200);
       resources.viewport_.changed_(/* relayoutAll */ true, /* velocity */ 0);
       resources.doPass();
 
@@ -1338,7 +1337,7 @@ describes.fakeWin('Resources.add/upgrade/remove', {amp: true}, (env) => {
         return signals;
       },
     };
-    element.build = env.sandbox.stub().returns(Promise.resolve());
+    element.build = sandbox.stub().returns(Promise.resolve());
     return element;
   }
 
@@ -1352,7 +1351,7 @@ describes.fakeWin('Resources.add/upgrade/remove', {amp: true}, (env) => {
 
   function stubBuild(resource) {
     const origBuild = resource.build;
-    env.sandbox.stub(resource, 'build').callsFake(() => {
+    sandbox.stub(resource, 'build').callsFake(() => {
       resource.buildPromise = origBuild.call(resource);
       return resource.buildPromise;
     });

--- a/test/unit/test-resources.js
+++ b/test/unit/test-resources.js
@@ -932,12 +932,13 @@ describes.realWin('Resources discoverWork', {amp: true}, (env) => {
     });
 
     it('should check premeasured rect before layout', () => {
+      sandbox.stub(resource1, 'hasBeenMeasured').returns(true);
       sandbox.stub(resource1, 'hasBeenPremeasured').returns(true);
       sandbox.stub(resource1, 'isDisplayed').returns(true);
       resource1.isDisplayed
         .withArgs(/* usePremeasuredRect */ true)
         .returns(false);
-      sandbox.stub(resource1, 'layoutCanceled');
+      sandbox.spy(resource1, 'layoutCanceled');
 
       resources.scheduleLayoutOrPreload(resource1, /* layout */ true);
       resources.work_();
@@ -947,7 +948,7 @@ describes.realWin('Resources discoverWork', {amp: true}, (env) => {
         /* usePremeasuredRect */ true
       );
       expect(resource1.layoutCanceled).to.be.calledOnce;
-      expect(resource1.getState()).to.equal(ResourceState.LAYOUT_SCHEDULED);
+      expect(resource1.getState()).to.equal(ResourceState.READY_FOR_LAYOUT);
     });
   });
 

--- a/test/unit/test-resources.js
+++ b/test/unit/test-resources.js
@@ -655,7 +655,6 @@ describes.realWin('Resources discoverWork', {amp: true}, (env) => {
   beforeEach(() => {
     sandbox = env.sandbox;
 
-    toggleExperiment(window, 'amp-force-prerender-visible-elements', true);
     const viewer = Services.viewerForDoc(env.ampdoc);
     sandbox.stub(viewer, 'isRuntimeOn').returns(true);
     resources = new ResourcesImpl(env.ampdoc);
@@ -679,7 +678,6 @@ describes.realWin('Resources discoverWork', {amp: true}, (env) => {
   });
 
   afterEach(() => {
-    toggleExperiment(window, 'amp-force-prerender-visible-elements', false);
     viewportMock.verify();
   });
 


### PR DESCRIPTION
Related to #25428.

More closely mimic the classical behavior of "explicit measure before layout" by checking if there's an unprocessed, "premeasured rect" from a more recent intersection callback. 

Noticed this potential issue in examples/everything.amp.html in an `amp-ad > amp-analytics` element that starts with size 1x1 and then gets hidden.