### PR TITLE
🏗 Build ESM output on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,6 +55,10 @@ jobs:
       script:
         - unbuffer node build-system/pr-check/build.js
     - stage: build
+      name: 'Module Build'
+      script:
+        - unbuffer node build-system/pr-check/module-build.js
+    - stage: build
       name: 'Checks'
       script:
         - unbuffer node build-system/pr-check/checks.js
@@ -70,10 +74,6 @@ jobs:
       name: 'Single Pass Tests'
       script:
         - unbuffer node build-system/pr-check/single-pass-tests.js
-    - stage: test
-      name: 'Module Build Tests'
-      script:
-        - unbuffer node build-system/pr-check/module-build-tests.js
     - stage: test
       name: 'Visual Diff Tests'
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,6 +71,10 @@ jobs:
       script:
         - unbuffer node build-system/pr-check/single-pass-tests.js
     - stage: test
+      name: 'Module Build Tests'
+      script:
+        - unbuffer node build-system/pr-check/module-build-tests.js
+    - stage: test
       name: 'Visual Diff Tests'
       script:
         - unbuffer node build-system/pr-check/visual-diff-tests.js

--- a/build-system/pr-check/module-build-tests.js
+++ b/build-system/pr-check/module-build-tests.js
@@ -1,0 +1,68 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+/**
+ * @fileoverview
+ * This script builds the AMP runtime in ESM(module) mode.
+ * This is run during the CI stage = test; job = module mode tests.
+ */
+
+const colors = require('ansi-colors');
+const {
+  printChangeSummary,
+  startTimer,
+  stopTimer,
+  timedExecOrDie: timedExecOrDieBase,
+} = require('./utils');
+const {determineBuildTargets} = require('./build-targets');
+const {isTravisPullRequestBuild} = require('../common/travis');
+
+const FILENAME = 'module-build-tests.js';
+const FILELOGPREFIX = colors.bold(colors.yellow(`${FILENAME}:`));
+const timedExecOrDie = (cmd, unusedFileName) =>
+  timedExecOrDieBase(cmd, FILENAME);
+
+function main() {
+  const startTime = startTimer(FILENAME, FILENAME);
+
+  if (!isTravisPullRequestBuild()) {
+    timedExecOrDie('gulp update-packages');
+    timedExecOrDie('gulp dist --esm');
+  } else {
+    printChangeSummary(FILENAME);
+    const buildTargets = determineBuildTargets(FILENAME);
+    if (
+      buildTargets.has('RUNTIME') ||
+      buildTargets.has('FLAG_CONFIG') ||
+      buildTargets.has('INTEGRATION_TEST')
+    ) {
+      timedExecOrDie('gulp update-packages');
+      timedExecOrDie('gulp dist --esm');
+    } else {
+      console.log(
+        `${FILELOGPREFIX} Skipping`,
+        colors.cyan('Module Build Tests'),
+        'because this commit does not affect the runtime, flag configs,',
+        'or integration tests.'
+      );
+    }
+  }
+
+  stopTimer(FILENAME, FILENAME, startTime);
+}
+
+main();

--- a/build-system/pr-check/module-build.js
+++ b/build-system/pr-check/module-build.js
@@ -31,7 +31,7 @@ const {
 const {determineBuildTargets} = require('./build-targets');
 const {isTravisPullRequestBuild} = require('../common/travis');
 
-const FILENAME = 'module-build-tests.js';
+const FILENAME = 'module-build.js';
 const FILELOGPREFIX = colors.bold(colors.yellow(`${FILENAME}:`));
 const timedExecOrDie = (cmd, unusedFileName) =>
   timedExecOrDieBase(cmd, FILENAME);
@@ -55,7 +55,7 @@ function main() {
     } else {
       console.log(
         `${FILELOGPREFIX} Skipping`,
-        colors.cyan('Module Build Tests'),
+        colors.cyan('Module Build'),
         'because this commit does not affect the runtime, flag configs,',
         'or integration tests.'
       );

--- a/build-system/pr-check/module-build.js
+++ b/build-system/pr-check/module-build.js
@@ -18,7 +18,7 @@
 /**
  * @fileoverview
  * This script builds the AMP runtime in ESM(module) mode.
- * This is run during the CI stage = test; job = module mode tests.
+ * This is run during the CI stage = build; job = module build.
  */
 
 const colors = require('ansi-colors');
@@ -45,20 +45,17 @@ function main() {
   } else {
     printChangeSummary(FILENAME);
     const buildTargets = determineBuildTargets(FILENAME);
-    if (
-      buildTargets.has('RUNTIME') ||
-      buildTargets.has('FLAG_CONFIG') ||
-      buildTargets.has('INTEGRATION_TEST')
-    ) {
+    if (buildTargets.has('RUNTIME') || buildTargets.has('FLAG_CONFIG')) {
       timedExecOrDie('gulp update-packages');
       timedExecOrDie('gulp dist --esm');
     } else {
-      console.log(
-        `${FILELOGPREFIX} Skipping`,
-        colors.cyan('Module Build'),
-        'because this commit does not affect the runtime, flag configs,',
-        'or integration tests.'
-      );
+      console /*OK*/
+        .log(
+          `${FILELOGPREFIX} Skipping`,
+          colors.cyan('Module Build'),
+          'because this commit does not affect the runtime, flag configs,',
+          'or integration tests.'
+        );
     }
   }
 


### PR DESCRIPTION
Ensure ESM builds run successfully like other runtimes.