### PR TITLE
Use a real anchor for remote page attachments

### DIFF
--- a/examples/visual-tests/amp-story/amp-story-bot-rendering.html
+++ b/examples/visual-tests/amp-story/amp-story-bot-rendering.html
@@ -73,6 +73,7 @@
             <span data-text-background-color="crimson">i can fit in that box but inspect anything brought into the house wack the mini furry mouse intently stare at the same spot. Flee in terror at cucumber discovered on floor shake treat bag</span>
           </p>
         </amp-story-grid-layer>
+        <amp-story-page-attachment href="https://www.google.com" layout="nodisplay"></amp-story-page-attachment>
       </amp-story-page>
 
       <!--

--- a/extensions/amp-story/1.0/amp-story-page-attachment.js
+++ b/extensions/amp-story/1.0/amp-story-page-attachment.js
@@ -146,13 +146,14 @@ export class AmpStoryPageAttachment extends DraggableDrawer {
       'i-amphtml-story-draggable-drawer-header-attachment-remote'
     );
     this.element.classList.add('i-amphtml-story-page-attachment-remote');
-    this.contentEl_.appendChild(
-      htmlFor(this.element)`
-          <div class="i-amphtml-story-page-attachment-remote-content">
-            <span class="i-amphtml-story-page-attachment-remote-domain"></span>
-            <span class="i-amphtml-story-page-attachment-remote-icon"></span>
-          </div>`
-    );
+    // Use an anchor element to make this a real link in vertical rendering.
+    const link = htmlFor(this.element)`
+    <a class="i-amphtml-story-page-attachment-remote-content" target="_blank">
+      <span class="i-amphtml-story-page-attachment-remote-domain"></span>
+      <span class="i-amphtml-story-page-attachment-remote-icon"></span>
+    </a>`;
+    link.setAttribute('href', this.element.getAttribute('href'));
+    this.contentEl_.appendChild(link);
 
     const urlService = Services.urlForDoc(this.element);
     const domain = urlService.getSourceOrigin(

--- a/extensions/amp-story/1.0/amp-story-page-attachment.js
+++ b/extensions/amp-story/1.0/amp-story-page-attachment.js
@@ -148,11 +148,12 @@ export class AmpStoryPageAttachment extends DraggableDrawer {
     this.element.classList.add('i-amphtml-story-page-attachment-remote');
     // Use an anchor element to make this a real link in vertical rendering.
     const link = htmlFor(this.element)`
-    <a class="i-amphtml-story-page-attachment-remote-content" target="_blank">
+    <a href=${this.element.getAttribute(
+      'href'
+    )} target="_blank" class="i-amphtml-story-page-attachment-remote-content">
       <span class="i-amphtml-story-page-attachment-remote-domain"></span>
       <span class="i-amphtml-story-page-attachment-remote-icon"></span>
     </a>`;
-    link.setAttribute('href', this.element.getAttribute('href'));
     this.contentEl_.appendChild(link);
 
     const urlService = Services.urlForDoc(this.element);

--- a/extensions/amp-story/1.0/amp-story-page-attachment.js
+++ b/extensions/amp-story/1.0/amp-story-page-attachment.js
@@ -148,12 +148,11 @@ export class AmpStoryPageAttachment extends DraggableDrawer {
     this.element.classList.add('i-amphtml-story-page-attachment-remote');
     // Use an anchor element to make this a real link in vertical rendering.
     const link = htmlFor(this.element)`
-    <a href=${this.element.getAttribute(
-      'href'
-    )} target="_blank" class="i-amphtml-story-page-attachment-remote-content">
+    <a class="i-amphtml-story-page-attachment-remote-content" target="_blank">
       <span class="i-amphtml-story-page-attachment-remote-domain"></span>
       <span class="i-amphtml-story-page-attachment-remote-icon"></span>
     </a>`;
+    link.setAttribute('href', this.element.getAttribute('href'));
     this.contentEl_.appendChild(link);
 
     const urlService = Services.urlForDoc(this.element);

--- a/extensions/amp-story/1.0/amp-story-share-menu.css
+++ b/extensions/amp-story/1.0/amp-story-share-menu.css
@@ -26,11 +26,13 @@
   z-index: 100003 !important; /** Above pagination-buttons. */
   transform: translate3d(0, 100vh, 0) !important;
   transition-delay: 0.15s !important;
+  pointer-events: none;
 }
 
 .i-amphtml-story-share-menu-visible {
   transform: translate3d(0, 0, 0) !important;
   transition-delay: 0s !important;
+  pointer-events: auto;
 }
 
 /** Black opacity overlay. */

--- a/extensions/amp-story/1.0/amp-story-share-menu.css
+++ b/extensions/amp-story/1.0/amp-story-share-menu.css
@@ -32,7 +32,7 @@
 .i-amphtml-story-share-menu-visible {
   transform: translate3d(0, 0, 0) !important;
   transition-delay: 0s !important;
-  pointer-events: auto;
+  pointer-events: auto !important;
 }
 
 /** Black opacity overlay. */

--- a/extensions/amp-story/1.0/amp-story-share-menu.css
+++ b/extensions/amp-story/1.0/amp-story-share-menu.css
@@ -26,7 +26,7 @@
   z-index: 100003 !important; /** Above pagination-buttons. */
   transform: translate3d(0, 100vh, 0) !important;
   transition-delay: 0.15s !important;
-  pointer-events: none;
+  pointer-events: none !important;
 }
 
 .i-amphtml-story-share-menu-visible {

--- a/extensions/amp-story/1.0/amp-story-vertical.css
+++ b/extensions/amp-story/1.0/amp-story-vertical.css
@@ -55,7 +55,6 @@ amp-story[i-amphtml-vertical].i-amphtml-element amp-story-page.i-amphtml-element
 [i-amphtml-vertical] amp-story-page-attachment {
   display: block !important;
   position: relative !important;
-  height: 178vw !important;
   transform: none !important;
 }
 

--- a/test/visual-diff/visual-tests
+++ b/test/visual-diff/visual-tests
@@ -657,8 +657,6 @@
       "interactive_tests": "examples/visual-tests/amp-story/amp-story-live-story.js"
     },
     {
-      // TODO(#27452, @ampproject/wg-stories): font size is unstable, e.g., https://percy.io/ampproject/amphtml/builds/4680570
-      "flaky": true,
       "url": "examples/visual-tests/amp-story/amp-story-bot-rendering.html",
       "name": "amp-story: bot rendering",
       "viewport": {"width": 360, "height": 4500},


### PR DESCRIPTION
...which are really just links.

Also:

- Changes vertical rendering to not specify a height for attachments such that they simply flow as high as their content.
- Fixes menu overlaying all vertically rendered content making it non-interactive.