### PR TITLE
🏗📦 Switch renovate updates for `amphtml` from opt-in to opt-out

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -8,12 +8,5 @@
   "dependencies": {
     "enabled": false
   },
-  "includePaths": [
-    "package.json",
-    "build-system/tasks/e2e/package.json",
-    "build-system/tasks/visual-diff/package.json",
-    "build-system/tasks/storybook/package.json",
-    "src/purifier/package.json",
-    "validator/package.json"
-  ]
+  "ignorePaths": []
 }


### PR DESCRIPTION
When renovate was originally installed to keep `amphtml` dependencies up to date, only the root `package.json` was opted in.

Since then, various developers have added a bunch of new `package.json` / `pom.xml` files without opting them in to automatic updates. This frequently results in security vulnerabilities due to outdated dependencies.

<img width="768" alt="Screen Shot 2020-04-10 at 2 33 40 AM" src="https://user-images.githubusercontent.com/26553114/78969001-e95b8a00-7ad3-11ea-830d-c741777a79ea.png">

This PR removes the `includePaths` section of `.renovaterc.json` and enables automatic updates for the following files:

- [x] `package.json`
- [x] `extensions/amp-viewer-integration/0.1/messaging/package.json`
- [x] `extensions/amp-access/0.1/iframe-api/package.json`
- [x] `validator/package.json`
- [x] `validator/gulpjs/package.json`
- [x] `validator/java/pom.xml`
- [x] `validator/nodejs/package.json`
- [x] `validator/webui/package.json`
- [x] `third_party/amp-toolbox-cache-url/package.json`
- [x] `build-system/tasks/storybook/package.json`
- [x] `build-system/tasks/visual-diff/package.json`
- [x] `build-system/tasks/performance/package.json`
- [x] `build-system/tasks/e2e/package.json`
- [x] `src/purifier/package.json`

I'll merge this after checking with the respective owners on whether automatic updates are desirable, and if not, we can add specific files to `ignorePaths`.

With this, security vulnerability reports for AMP should become less frequent.