### PR TITLE
🏗 Debug Compilation Lifecycles via gulp dist --debug

### DIFF
--- a/build-system/compile/debug-compilation-lifecycle.js
+++ b/build-system/compile/debug-compilation-lifecycle.js
@@ -1,0 +1,68 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+const argv = require('minimist')(process.argv.slice(2));
+const colors = require('ansi-colors');
+const fs = require('fs');
+const log = require('fancy-log');
+const path = require('path');
+const tempy = require('tempy');
+
+const logFile = path.resolve(process.cwd(), 'dist', 'debug-compilation.log');
+
+const pad = (value, length) =>
+  (value.length > length ? value.slice(value.length - length) : value).padEnd(
+    length
+  );
+
+const LIFECYCLES = {
+  'pre-babel': 'pre-babel',
+  'pre-closure': 'pre-closure',
+  'closured-pre-babel': 'closured-pre-babel',
+  'closured-pre-terser': 'closured-pre-terser',
+  'complete': 'complete',
+};
+
+/**
+ * Output debugging information when developing changes in this functionality.
+ *
+ * @param {string} lifecycle
+ * @param {string} fullpath
+ * @param {string} content
+ */
+function debug(lifecycle, fullpath, content) {
+  if (argv.debug && Object.keys(LIFECYCLES).includes(lifecycle)) {
+    fs.appendFileSync(
+      logFile,
+      `${pad(lifecycle, 20)}: ${pad(
+        path.basename(fullpath),
+        30
+      )} ${tempy.writeSync(content)}\n`
+    );
+  }
+}
+
+function displayLifecycleDebugging() {
+  if (argv.debug) {
+    log(colors.white('Debug Lifecycles: ') + colors.red(logFile));
+  }
+}
+
+module.exports = {
+  displayLifecycleDebugging,
+  debug,
+  CompilationLifecycles: LIFECYCLES,
+};

--- a/build-system/compile/pre-closure-babel.js
+++ b/build-system/compile/pre-closure-babel.js
@@ -21,6 +21,7 @@ const gulpBabel = require('gulp-babel');
 const log = require('fancy-log');
 const through = require('through2');
 const {BABEL_SRC_GLOBS, THIRD_PARTY_TRANSFORM_GLOBS} = require('./sources');
+const {debug, CompilationLifecycles} = require('./debug-compilation-lifecycle');
 const {EventEmitter} = require('events');
 const {red, cyan} = require('ansi-colors');
 
@@ -84,6 +85,7 @@ function preClosureBabel() {
     }
 
     let data, err;
+    debug(CompilationLifecycles['pre-babel'], file.path, file.contents);
     function onData(d) {
       babel.off('error', onError);
       data = d;
@@ -99,6 +101,11 @@ function preClosureBabel() {
         return next(err);
       }
 
+      debug(
+        CompilationLifecycles['pre-closure'],
+        file.path,
+        data.contents.toString('utf8')
+      );
       cache[path] = {
         file: data,
         hash,

--- a/build-system/tasks/dist.js
+++ b/build-system/tasks/dist.js
@@ -40,6 +40,9 @@ const {
   createModuleCompatibleES5Bundle,
 } = require('./create-module-compatible-es5-bundle');
 const {
+  displayLifecycleDebugging,
+} = require('../compile/debug-compilation-lifecycle');
+const {
   distNailgunPort,
   startNailgunServer,
   stopNailgunServer,
@@ -100,6 +103,7 @@ async function runPreDistSteps(watch) {
   await copyParsers();
   await bootstrapThirdPartyFrames(watch, /* minify */ true);
   await startNailgunServer(distNailgunPort, /* detached */ false);
+  displayLifecycleDebugging();
 }
 
 /**
@@ -462,4 +466,5 @@ dist.flags = {
   custom_version_mark: '  Set final digit (0-9) on auto-generated version',
   watch: '  Watches for changes in files, re-compiles when detected',
   closure_concurrency: '  Sets the number of concurrent invocations of closure',
+  debug: '  Outputs the file contents during compilation lifecycles',
 };


### PR DESCRIPTION
Introduces a new debugger for `gulp dist` with our evolving compilation pipeline.

![Screen Shot 2020-04-10 at 9 14 23 AM](https://user-images.githubusercontent.com/61764/79005436-b208cf80-7b0b-11ea-954d-bdb2f09cf2f1.png)

This file is updated with each compilation lifecycle event.

![Screen Shot 2020-04-10 at 9 15 29 AM](https://user-images.githubusercontent.com/61764/79005512-db296000-7b0b-11ea-96ba-84ce7a434da1.png)

As a result, when debugging the pipeline you can see per event the operation, filename, and current status of the contents (written to temp).

This allows you to disect problems with the pipeline by looking at individual operations.