### PR TITLE
🐛performance-impl: timeOrigin should be a value instead of delta

### DIFF
--- a/src/service/performance-impl.js
+++ b/src/service/performance-impl.js
@@ -17,7 +17,7 @@
 import {Deferred} from '../utils/promise';
 import {Services} from '../services';
 import {VisibilityState} from '../visibility-state';
-import {dev} from '../log';
+import {dev, devAssert} from '../log';
 import {dict, map} from '../utils/object';
 import {getMode} from '../mode';
 import {getService, registerServiceBuilder} from '../service';
@@ -593,6 +593,11 @@ export class Performance {
    * @param {number=} opt_value The value to use. Overrides default calculation.
    */
   tick(label, opt_delta, opt_value) {
+    devAssert(
+      opt_delta == undefined || opt_value == undefined,
+      'You may not set both opt_delta and opt_value.'
+    );
+
     const data = dict({'label': label});
     let delta;
 

--- a/src/service/performance-impl.js
+++ b/src/service/performance-impl.js
@@ -244,7 +244,7 @@ export class Performance {
         this.tickDelta('msr', this.win.performance.now());
 
         // Tick timeOrigin so that epoch time can be calculated by consumers.
-        this.tickDelta('timeOrigin', this.timeOrigin_);
+        this.tick('timeOrigin', undefined, this.timeOrigin_);
 
         return this.maybeAddStoryExperimentId_();
       })
@@ -590,19 +590,21 @@ export class Performance {
    *     when adding a new metric.
    * @param {number=} opt_delta The delta. Call tickDelta instead of setting
    *     this directly.
+   * @param {number=} opt_value The value to use. Overrides default calculation.
    */
-  tick(label, opt_delta) {
+  tick(label, opt_delta, opt_value) {
     const data = dict({'label': label});
     let delta;
 
-    // Absolute value case (not delta).
-    if (opt_delta == undefined) {
-      // Marking only makes sense for non-deltas.
+    if (opt_delta != undefined) {
+      data['delta'] = delta = Math.max(opt_delta, 0);
+    } else if (opt_value != undefined) {
+      data['value'] = opt_value;
+    } else {
+      // Marking only makes sense for non-overridden values (and no deltas).
       this.mark(label);
       delta = this.win.performance.now();
       data['value'] = this.timeOrigin_ + delta;
-    } else {
-      data['delta'] = delta = Math.max(opt_delta, 0);
     }
 
     if (this.isMessagingReady_ && this.isPerformanceTrackingOn_) {

--- a/test/unit/test-performance.js
+++ b/test/unit/test-performance.js
@@ -252,7 +252,7 @@ describes.realWin('performance', {amp: true}, (env) => {
             expect(timeOriginCall).to.be.calledOnce;
             expect(timeOriginCall).calledWithMatch('tick', {
               label: 'timeOrigin',
-              delta: env.sandbox.match.number,
+              value: 100,
             });
 
             expect(flushSpy).to.have.callCount(5);


### PR DESCRIPTION
**summary**
- timeOrigin should be ticked as an absolute value as opposed to as a delta.
- resolves `b/137215986`
