### PR TITLE
Small fixes for vertical rendering

### DIFF
--- a/examples/visual-tests/amp-story/amp-story-bot-rendering.html
+++ b/examples/visual-tests/amp-story/amp-story-bot-rendering.html
@@ -64,7 +64,7 @@
         </amp-story-page-attachment>
       </amp-story-page>
 
-      <amp-story-page id="page1">
+      <amp-story-page id="page-link">
         <amp-story-grid-layer template="fill">
           <amp-img layout="fill" src="./img/cat2.jpg"></amp-img>
         </amp-story-grid-layer>
@@ -74,6 +74,18 @@
           </p>
         </amp-story-grid-layer>
         <amp-story-page-attachment href="https://www.google.com" layout="nodisplay"></amp-story-page-attachment>
+      </amp-story-page>
+
+      <amp-story-page id="page-link-with-title">
+        <amp-story-grid-layer template="fill">
+          <amp-img layout="fill" src="./img/cat2.jpg"></amp-img>
+        </amp-story-grid-layer>
+        <amp-story-grid-layer template="center">
+          <p>
+            <span data-text-background-color="crimson">i can fit in that box but inspect anything brought into the house wack the mini furry mouse intently stare at the same spot. Flee in terror at cucumber discovered on floor shake treat bag</span>
+          </p>
+        </amp-story-grid-layer>
+        <amp-story-page-attachment data-title="Google" href="https://www.google.com" layout="nodisplay"></amp-story-page-attachment>
       </amp-story-page>
 
       <!--

--- a/extensions/amp-story/1.0/amp-story-page-attachment.css
+++ b/extensions/amp-story/1.0/amp-story-page-attachment.css
@@ -39,7 +39,7 @@
   line-height: 48px !important;
 }
 
-.i-amphtml-story-page-attachment-remote-domain {
+.i-amphtml-story-page-attachment-remote-title {
   max-width: calc(100% - 30px /* 24px icon + 6px margin */) !important;
   overflow: hidden !important;
   text-overflow: ellipsis !important;

--- a/extensions/amp-story/1.0/amp-story-page-attachment.js
+++ b/extensions/amp-story/1.0/amp-story-page-attachment.js
@@ -149,19 +149,19 @@ export class AmpStoryPageAttachment extends DraggableDrawer {
     // Use an anchor element to make this a real link in vertical rendering.
     const link = htmlFor(this.element)`
     <a class="i-amphtml-story-page-attachment-remote-content" target="_blank">
-      <span class="i-amphtml-story-page-attachment-remote-domain"></span>
+      <span class="i-amphtml-story-page-attachment-remote-title"></span>
       <span class="i-amphtml-story-page-attachment-remote-icon"></span>
     </a>`;
     link.setAttribute('href', this.element.getAttribute('href'));
     this.contentEl_.appendChild(link);
 
-    const urlService = Services.urlForDoc(this.element);
-    const domain = urlService.getSourceOrigin(
-      this.element.getAttribute('href')
-    );
     this.contentEl_.querySelector(
-      '.i-amphtml-story-page-attachment-remote-domain'
-    ).textContent = domain;
+      '.i-amphtml-story-page-attachment-remote-title'
+    ).textContent =
+      this.element.getAttribute('data-title') ||
+      Services.urlForDoc(this.element).getSourceOrigin(
+        this.element.getAttribute('href')
+      );
   }
 
   /**

--- a/extensions/amp-story/1.0/amp-story-vertical.css
+++ b/extensions/amp-story/1.0/amp-story-vertical.css
@@ -58,6 +58,10 @@ amp-story[i-amphtml-vertical].i-amphtml-element amp-story-page.i-amphtml-element
   transform: none !important;
 }
 
+[i-amphtml-vertical] .i-amphtml-story-page-attachment-remote-title {
+  overflow: visible !important;
+}
+
 [i-amphtml-vertical].i-amphtml-story-bookend-active amp-story-page[active]::after {
   content: none !important;
 }

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -1855,7 +1855,15 @@ export class AmpStory extends AMP.BaseElement {
           this.element.classList.remove('i-amphtml-story-desktop-fullbleed');
           this.element.classList.remove('i-amphtml-story-desktop-panels');
           for (let i = 0; i < pageAttachments.length; i++) {
-            this.element.appendChild(pageAttachments[i]);
+            this.element.insertBefore(
+              pageAttachments[i],
+              // Attachments that are just links are rendered in-line with their
+              // story page.
+              pageAttachments[i].getAttribute('href')
+                ? pageAttachments[i].parentElement.nextElementSibling
+                : // Other attachments are rendered at the end.
+                  null
+            );
           }
         });
 


### PR DESCRIPTION
  - Render remote attachments inline with their page to retain the correct ordering relationship.
  - Support a title for the remote attachment anchor
  - Don't overflow that title (render is completely)