### PR TITLE
🏗Lay groundwork for testing ESM code during CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,10 +55,6 @@ jobs:
       script:
         - unbuffer node build-system/pr-check/build.js
     - stage: build
-      name: 'Module Build'
-      script:
-        - unbuffer node build-system/pr-check/module-build.js
-    - stage: build
       name: 'Checks'
       script:
         - unbuffer node build-system/pr-check/checks.js
@@ -70,6 +66,10 @@ jobs:
       name: 'Dist, Bundle Size'
       script:
         - unbuffer node build-system/pr-check/dist-bundle-size.js
+    - stage: build
+      name: 'Module Dist, Bundle Size'
+      script:
+        - unbuffer node build-system/pr-check/module-dist-bundle-size.js
     - stage: test
       name: 'Single Pass Tests'
       script:

--- a/build-system/pr-check/dist-bundle-size.js
+++ b/build-system/pr-check/dist-bundle-size.js
@@ -17,9 +17,8 @@
 
 /**
  * @fileoverview
- * This script builds the AMP runtime for production and runs the bundle size
- * check.
- * This is run during the CI stage = build; job = dist.
+ * This script builds the minified AMP runtime and runs the bundle size check.
+ * This is run during the CI stage = build; job = dist, bundle size.
  */
 
 const colors = require('ansi-colors');

--- a/build-system/pr-check/utils.js
+++ b/build-system/pr-check/utils.js
@@ -40,6 +40,9 @@ const BUILD_OUTPUT_FILE = isTravisBuild()
 const DIST_OUTPUT_FILE = isTravisBuild()
   ? `amp_dist_${travisBuildNumber()}.zip`
   : '';
+const ESM_DIST_OUTPUT_FILE = isTravisBuild()
+  ? `amp_esm_dist_${travisBuildNumber()}.zip`
+  : '';
 
 const BUILD_OUTPUT_DIRS = 'build/ dist/ dist.3p/ EXTENSIONS_CSS_MAP';
 const APP_SERVING_DIRS = 'dist.tools/ examples/ test/manual/';
@@ -333,6 +336,14 @@ function downloadDistOutput(functionName) {
 }
 
 /**
+ * Downloads and unzips esm dist output from storage
+ * @param {string} functionName
+ */
+function downloadEsmDistOutput(functionName) {
+  downloadOutput_(functionName, ESM_DIST_OUTPUT_FILE, BUILD_OUTPUT_DIRS);
+}
+
+/**
  * Zips and uploads the build output to a remote storage location
  * @param {string} functionName
  */
@@ -347,6 +358,15 @@ function uploadBuildOutput(functionName) {
 function uploadDistOutput(functionName) {
   const distOutputDirs = `${BUILD_OUTPUT_DIRS} ${APP_SERVING_DIRS}`;
   uploadOutput_(functionName, DIST_OUTPUT_FILE, distOutputDirs);
+}
+
+/**
+ * Zips and uploads the esm dist output to a remote storage location
+ * @param {string} functionName
+ */
+function uploadEsmDistOutput(functionName) {
+  const esmDistOutputDirs = `${BUILD_OUTPUT_DIRS} ${APP_SERVING_DIRS}`;
+  uploadOutput_(functionName, ESM_DIST_OUTPUT_FILE, esmDistOutputDirs);
 }
 
 /**
@@ -378,6 +398,7 @@ function decryptTravisKey_() {
 module.exports = {
   downloadBuildOutput,
   downloadDistOutput,
+  downloadEsmDistOutput,
   printChangeSummary,
   processAndUploadDistOutput,
   startTimer,
@@ -390,4 +411,5 @@ module.exports = {
   timedExecWithError,
   uploadBuildOutput,
   uploadDistOutput,
+  uploadEsmDistOutput,
 };

--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -114,6 +114,7 @@ const forbiddenTerms = {
       'build-system/pr-check/build-targets.js',
       'build-system/pr-check/checks.js',
       'build-system/pr-check/dist-bundle-size.js',
+      'build-system/pr-check/module-dist-bundle-size.js',
       'build-system/pr-check/experiment-tests.js',
       'build-system/pr-check/e2e-tests.js',
       'build-system/pr-check/local-tests.js',


### PR DESCRIPTION
#27685 made it so that ESM code was compiled during Travis CI. Given that the intent is to run a whole host of tests against ESM code, we want to stick with the model followed by multi-pass `gulp dist` (compile code in the `build` stage, upload to GCP, download and run tests in the `test` stage).

**PR highlights:**
- Migrates the module job to `'Module Dist, Bundle Size'`, which is based on the current `'Dist, Bundle Size'` job
- Adds`yarn` checks before esm compilation (to prevent conflicts due to Travis merge commits)
- Adds a step to upload esm artifacts to GCP
- Adds placeholders for bundle size checks
- Adds the `--fortesting` flag so that integration tests can be run using a `localhost` server

**Successful upload:**

![image](https://user-images.githubusercontent.com/26553114/79025806-d63cce80-7b54-11ea-82f0-d9f02ce382b1.png)

**Build time comparisons:**

`gulp dist --fortesting`: [5m 19s](https://travis-ci.org/github/ampproject/amphtml/jobs/673604611#L560)
`gulp dist --esm --fortesting`: [7m 25s](https://travis-ci.org/github/ampproject/amphtml/jobs/673604612#L560)

**Future work:**
- Bundle-size checks for parallel esm and non-esm `gulp dist` jobs (#27703)
- PR-deploy for ESM (is this worth doing?)