### PR TITLE
🏗 Validator Java test updates

### DIFF
--- a/build-system/pr-check/build-targets.js
+++ b/build-system/pr-check/build-targets.js
@@ -38,20 +38,12 @@ function isOwnersFile(file) {
 }
 
 /**
- * Checks if the given file is a validator protoascii file.
+ * Checks if the given file is of the form validator-.*\.(html|out|protoascii)
  *
  * @param {string} file
  * @return {boolean}
  */
-function isValidatorProtoasciiFile(file) {
-  if (!file.startsWith('extensions/')) {
-    return false; // All protoascii files live in extensions/
-  }
-  const pathArray = path.dirname(file).split(path.sep);
-  if (pathArray.length < 2) {
-    return false; // Protoascii files live at least 2 levels in
-  }
-  // Protoascii files are of the form validator-.*\.(html|out|protoascii)
+function isValidatorFile(file) {
   const name = path.basename(file);
   return (
     name.startsWith('validator-') &&
@@ -188,7 +180,7 @@ const targetMatchers = {
     return (
       file.startsWith('validator/') ||
       file === 'build-system/tasks/validator.js' ||
-      isValidatorProtoasciiFile(file)
+      isValidatorFile(file)
     );
   },
   'VALIDATOR_JAVA': (file) => {
@@ -198,7 +190,7 @@ const targetMatchers = {
     return (
       file.startsWith('validator/java/') ||
       file === 'build-system/tasks/validator.js' ||
-      isValidatorProtoasciiFile(file)
+      isValidatorFile(file)
     );
   },
   'VALIDATOR_WEBUI': (file) => {

--- a/build-system/pr-check/validator-tests.js
+++ b/build-system/pr-check/validator-tests.js
@@ -47,8 +47,8 @@ function main() {
 
   if (!isTravisPullRequestBuild()) {
     timedExecOrDie('gulp validator');
-    timedExecOrDie('gulp validator-webui');
     timedExecOrDie('gulp validator-java');
+    timedExecOrDie('gulp validator-webui');
   } else {
     printChangeSummary(FILENAME);
     const buildTargets = determineBuildTargets(FILENAME);
@@ -72,12 +72,12 @@ function main() {
       timedExecOrDie('gulp validator');
     }
 
-    if (buildTargets.has('VALIDATOR_WEBUI')) {
-      timedExecOrDie('gulp validator-webui');
+    if (buildTargets.has('RUNTIME') || buildTargets.has('VALIDATOR_JAVA')) {
+      timedExecOrDie('gulp validator-java');
     }
 
-    if (buildTargets.has('VALIDATOR_JAVA')) {
-      timedExecOrDie('gulp validator-java');
+    if (buildTargets.has('VALIDATOR_WEBUI')) {
+      timedExecOrDie('gulp validator-webui');
     }
   }
 

--- a/validator/java/.bazelrc
+++ b/validator/java/.bazelrc
@@ -1,1 +1,1 @@
-common --show_result 0 --noshow_progress
+common --show_result 0 --noshow_progress --experimental_ui_limit_console_output 1

--- a/validator/java/.bazelrc
+++ b/validator/java/.bazelrc
@@ -1,0 +1,1 @@
+common --show_result 0 --noshow_progress

--- a/validator/java/BUILD
+++ b/validator/java/BUILD
@@ -71,5 +71,5 @@ java_test(
     ],
     use_testrunner=False,
     main_class='org.testng.TestNG',
-    args=['-testjar','libamphtml_validator_test_lib.jar','-verbose','2'],
+    args=['-testjar','libamphtml_validator_test_lib.jar','-verbose','1'],
 )

--- a/validator/java/build.sh
+++ b/validator/java/build.sh
@@ -16,6 +16,8 @@
 #
 # This script builds the Java AMP Validator.
 
+set -e # Exit on error
+
 bazel clean
 bazel run //:fetchAMPResources
 bazel build //:amphtml_validator_java_proto_lib

--- a/validator/java/build_and_test.sh
+++ b/validator/java/build_and_test.sh
@@ -16,7 +16,7 @@
 #
 # This script builds the Java AMP Validator and runs a full test suite.
 
-echo travis_fold:start:java_validator_build
+set -e # Exit on error
+
 ./build.sh
-echo travis_fold:end:java_validator_build
 bazel run //:amphtml_validator_test

--- a/validator/java/install_bazel.sh
+++ b/validator/java/install_bazel.sh
@@ -64,8 +64,8 @@ echo "$LOG_PREFIX Verifying sha256 integrity of $(CYAN "$BAZEL_BIN_PATH")..."
 
 echo "$LOG_PREFIX Installing $(CYAN "bazel") from $(CYAN "$BAZEL_BIN_PATH")..."
 if [[ "$OSTYPE" == "linux-gnu" ]]; then
-  sudo dpkg -i $BAZEL_BIN_PATH  >/dev/null
+  sudo dpkg -i $BAZEL_BIN_PATH  >/dev/null 2>&1
 elif [[ "$OSTYPE" == "darwin"* ]]; then
   chmod +x $BAZEL_BIN_PATH
-  sudo ./$BAZEL_BIN_PATH --user >/dev/null
+  sudo ./$BAZEL_BIN_PATH --user >/dev/null 2>&1
 fi

--- a/validator/java/install_bazel.sh
+++ b/validator/java/install_bazel.sh
@@ -16,20 +16,23 @@
 #
 # This script installs Bazel, either by downloading it or by installing from the
 # Travis cache if available.
+
+set -e # Exit on error
+
 CYAN() { echo -e "\033[0;36m$1\033[0m"; }
 YELLOW() { echo -e "\033[1;33m$1\033[0m"; }
 GREEN() { echo -e "\033[0;32m$1\033[0m"; }
 RED() { echo -e "\033[0;31m$1\033[0m"; }
 
 LOG_PREFIX=$(YELLOW "install_bazel.sh")
-BAZEL_VERSION="2.2.0"
-BAZEL_BIN_SHA="b1b8dba9b625b10e47a6dcc027abfdaf213b454709d32473c81c146ba8ccb8e3"
+BAZEL_VERSION="3.0.0"
 INSTALLER_DIR="bazel-installer"
 
-# TODO(rsima): Add support for installs on Darwin.
+
 if [[ "$OSTYPE" == "linux-gnu" ]]; then
-  PLATFORM="linux"
-  BAZEL_INSTALLER="bazel_$BAZEL_VERSION-$PLATFORM-x86_64.deb"
+  BAZEL_INSTALLER="bazel_$BAZEL_VERSION-linux-x86_64.deb"
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+  BAZEL_INSTALLER="bazel-$BAZEL_VERSION-installer-darwin-x86_64.sh"
 else
   echo "$LOG_PREFIX Installing Bazel on $(CYAN "$OSTYPE") is not yet supported; aborting"
   exit 1
@@ -37,6 +40,10 @@ fi
 
 BAZEL_BIN_URL="https://github.com/bazelbuild/bazel/releases/download/$BAZEL_VERSION/$BAZEL_INSTALLER"
 BAZEL_BIN_PATH="$INSTALLER_DIR/$BAZEL_INSTALLER"
+
+BAZEL_BIN_SHA_URL="$BAZEL_BIN_URL.sha256"
+BAZEL_BIN_SHA_PATH="$BAZEL_BIN_PATH.sha256"
+BAZEL_INSTALLER_SHA="$BAZEL_INSTALLER.sha256"
 
 if type bazel &>/dev/null ; then
   echo "$LOG_PREFIX Bazel binary detected at $(CYAN "$BAZEL_BIN_PATH"); skipping installation"
@@ -48,9 +55,17 @@ if [[ -f $BAZEL_BIN_PATH ]]; then
 else
   echo "$LOG_PREFIX Downloading $(CYAN "$BAZEL_BIN_URL")..."
   mkdir -p $INSTALLER_DIR
-  wget -q -O $BAZEL_BIN_PATH $BAZEL_BIN_URL
-  echo "SHA256 ($BAZEL_BIN_PATH) = $BAZEL_BIN_SHA" | sha256sum -c -
+  curl -s --create-dirs -o "$BAZEL_BIN_PATH" -L "$BAZEL_BIN_URL"
+  curl -s --create-dirs -o "$BAZEL_BIN_SHA_PATH" -L "$BAZEL_BIN_SHA_URL"
 fi
 
+echo "$LOG_PREFIX Verifying sha256 integrity of $(CYAN "$BAZEL_BIN_PATH")..."
+(cd "$INSTALLER_DIR" && shasum -c "$BAZEL_INSTALLER_SHA" >/dev/null)
+
 echo "$LOG_PREFIX Installing $(CYAN "bazel") from $(CYAN "$BAZEL_BIN_PATH")..."
-sudo dpkg -i $BAZEL_BIN_PATH
+if [[ "$OSTYPE" == "linux-gnu" ]]; then
+  sudo dpkg -i $BAZEL_BIN_PATH  >/dev/null
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+  chmod +x $BAZEL_BIN_PATH
+  sudo ./$BAZEL_BIN_PATH --user >/dev/null
+fi

--- a/validator/java/src/main/bin/copyValidatorJavaSource.sh
+++ b/validator/java/src/main/bin/copyValidatorJavaSource.sh
@@ -8,14 +8,16 @@
 BASE_DIR=$1
 if [ -z "$BASE_DIR" ]
 then
-      BASE_DIR=$BUILD_WORKING_DIRECTORY
+  BASE_DIR=$BUILD_WORKING_DIRECTORY
 fi
 
 BAZEL_BIN_DIR=$BASE_DIR/bazel-bin
 AMP_VALIDATOR_GENERATED_DIR=$BASE_DIR/"src/main/java/dev/amp/validator"
 
 cd $BAZEL_BIN_DIR
-jar xvf amphtml_validator_proto_lib-speed-src.jar
+jar xvf amphtml_validator_proto_lib-speed-src.jar >/dev/null
 
-echo "Copying Validator.java from ${BAZEL_BIN_DIR}/amp/validator"
+if [[ -z "$TRAVIS" ]]; then
+  echo "Copying Validator.java from ${BAZEL_BIN_DIR}/amp/validator"
+fi
 cp $BAZEL_BIN_DIR/dev/amp/validator/ValidatorProtos.java $AMP_VALIDATOR_GENERATED_DIR/.

--- a/validator/java/src/main/bin/fetchAMPResources.sh
+++ b/validator/java/src/main/bin/fetchAMPResources.sh
@@ -11,7 +11,7 @@
 BASE_DIR=$1
 if [ -z "$BASE_DIR" ]
 then
-      BASE_DIR=$BUILD_WORKING_DIRECTORY
+    BASE_DIR=$BUILD_WORKING_DIRECTORY
 fi
 
 AMP_VALIDATOR_PROTOASCII="validator-all.protoascii"
@@ -21,7 +21,9 @@ AMP_RESOURCES_DIR=$BASE_DIR/"src/main/resources"
 AMP_VALIDATOR_GENERATED_DIR=$BASE_DIR/"src/main/java/amp/validator"
 
 if [[ -f "$AMP_VALIDATOR_PROTO_DIR/$AMP_VALIDATOR_PROTO" && -f "$AMP_RESOURCES_DIR/$AMP_VALIDATOR_PROTOASCII" ]]; then
-    echo "Both $AMP_VALIDATOR_PROTO && $AMP_VALIDATOR_PROTOASCII exists";
+    if [[ -z "$TRAVIS" ]]; then
+        echo "Both $AMP_VALIDATOR_PROTO and $AMP_VALIDATOR_PROTOASCII exist";
+    fi
 else
     # Creating proto & resources directories.
     mkdir -p ${AMP_VALIDATOR_GENERATED_DIR}
@@ -30,15 +32,23 @@ else
 
     pushd $BASE_DIR
 
-    echo "Append validator main proto asci files"
+    if [[ -z "$TRAVIS" ]]; then
+        echo "Appending validator main protoascii files..."
+    fi
     cat ../validator-main.protoascii >> ${AMP_RESOURCES_DIR}/${AMP_VALIDATOR_PROTOASCII};
 
-    echo "Append validator css proto ascii files"
+    if [[ -z "$TRAVIS" ]]; then
+        echo "Appending validator css protoascii files..."
+    fi
     cat ../validator-css.protoascii >> ${AMP_RESOURCES_DIR}/${AMP_VALIDATOR_PROTOASCII};
 
-    echo "Concatenate all extension proto asci files"
+    if [[ -z "$TRAVIS" ]]; then
+        echo "Concatenating all extension protoascii files..."
+    fi
     for i in `find ../../extensions -name "*.protoascii"`; do
-        echo $i;
+        if [[ -z "$TRAVIS" ]]; then
+            echo $i;
+        fi
         cat $i >> ${AMP_RESOURCES_DIR}/${AMP_VALIDATOR_PROTOASCII};
     done
 


### PR DESCRIPTION
#27271 added tests for the Java validator to our Travis CI workflow. A few follow up items remain.

**PR highlights:**
- Add MacOS support to `validator/java/install_bazel.sh`
- Instead of a hard-coded SHA, download the correct `.sha256` for the installer
- Download with `curl -L`, which supports URL redirects (Linux and MacOS)
- Use latest version [3.0.0](https://github.com/bazelbuild/bazel/releases/tag/3.0.0) of `bazel`
- Perform a SHA check before installation on Linux and MacOS
- Substantially reduce logging verbosity on Travis in the passing case
- Make scripts return a failing exit status soon as a command fails
- Add a `.bazelrc` file for more streamlined output
- Refactor build target detection for `VALIDATOR` and `VALIDATOR_JAVA`
- Run `VALIDATOR_JAVA` tests when a `.protoascii` file is changed (just like `VALIDATOR`)
- Run `VALIDATOR_JAVA` tests for all runtime changes (just like `VALIDATOR`)

With this, we eliminate ~2500 lines of unnecessary logging. Test progress is still visible, and the final pass / fail count is still printed on the console. See [this](https://travis-ci.org/github/ampproject/amphtml/jobs/673651380#L406) sample run.

/cc @ampproject/wg-caching @GeorgeLuo @nhant01 

Follow up to #27271