### PR TITLE
♻️✅ amp-story animations: test, refactor presets

### DIFF
--- a/extensions/amp-story/1.0/animation-presets.js
+++ b/extensions/amp-story/1.0/animation-presets.js
@@ -35,6 +35,23 @@ const SCALE_HIGH_DEFAULT = 3;
 /** @const {number} */
 const SCALE_LOW_DEFAULT = 1;
 
+/** @const {string} */
+const SCALE_START_ATTRIBUTE_NAME = 'scale-start';
+/** @const {string} */
+const SCALE_END_ATTRIBUTE_NAME = 'scale-end';
+/** @const {string} */
+const TRANSLATE_X_ATTRIBUTE_NAME = 'translate-x';
+/** @const {string} */
+const TRANSLATE_Y_ATTRIBUTE_NAME = 'translate-y';
+
+/** @const {!Array<string} */
+export const PRESET_OPTION_ATTRIBUTES = [
+  SCALE_START_ATTRIBUTE_NAME,
+  SCALE_END_ATTRIBUTE_NAME,
+  TRANSLATE_X_ATTRIBUTE_NAME,
+  TRANSLATE_Y_ATTRIBUTE_NAME,
+];
+
 /**
  * A list of animations that are full bleed.
  * @private @const {!Array<string>}
@@ -243,7 +260,7 @@ export const presets = {
     duration: 1000,
     easing: 'linear',
     keyframes(dimensions, options) {
-      const {translateX} = options;
+      const translateX = options[TRANSLATE_X_ATTRIBUTE_NAME];
       const scalingFactor = calculateTargetScalingFactor(dimensions);
       dimensions.targetWidth *= scalingFactor;
       dimensions.targetHeight *= scalingFactor;
@@ -264,7 +281,7 @@ export const presets = {
     duration: 1000,
     easing: 'linear',
     keyframes(dimensions, options) {
-      const {translateX} = options;
+      const translateX = options[TRANSLATE_X_ATTRIBUTE_NAME];
 
       const scalingFactor = calculateTargetScalingFactor(dimensions);
       dimensions.targetWidth *= scalingFactor;
@@ -286,7 +303,7 @@ export const presets = {
     duration: 1000,
     easing: 'linear',
     keyframes(dimensions, options) {
-      const {translateY} = options;
+      const translateY = options[TRANSLATE_Y_ATTRIBUTE_NAME];
       const scalingFactor = calculateTargetScalingFactor(dimensions);
       dimensions.targetWidth *= scalingFactor;
       dimensions.targetHeight *= scalingFactor;
@@ -307,7 +324,7 @@ export const presets = {
     duration: 1000,
     easing: 'linear',
     keyframes(dimensions, options) {
-      const {translateY} = options;
+      const translateY = options[TRANSLATE_Y_ATTRIBUTE_NAME];
       const scalingFactor = calculateTargetScalingFactor(dimensions);
       dimensions.targetWidth *= scalingFactor;
       dimensions.targetHeight *= scalingFactor;
@@ -328,7 +345,8 @@ export const presets = {
     duration: 1000,
     easing: 'linear',
     keyframes(unusedDimensions, options) {
-      const {scaleStart, scaleEnd} = options;
+      const scaleStart = options[SCALE_START_ATTRIBUTE_NAME];
+      const scaleEnd = options[SCALE_END_ATTRIBUTE_NAME];
 
       if (scaleStart) {
         userAssert(
@@ -348,7 +366,8 @@ export const presets = {
     duration: 1000,
     easing: 'linear',
     keyframes(unusedDimensions, options) {
-      const {scaleStart, scaleEnd} = options;
+      const scaleStart = options[SCALE_START_ATTRIBUTE_NAME];
+      const scaleEnd = options[SCALE_END_ATTRIBUTE_NAME];
 
       if (scaleStart) {
         userAssert(

--- a/extensions/amp-story/1.0/animation-presets.js
+++ b/extensions/amp-story/1.0/animation-presets.js
@@ -44,7 +44,7 @@ const TRANSLATE_X_ATTRIBUTE_NAME = 'translate-x';
 /** @const {string} */
 const TRANSLATE_Y_ATTRIBUTE_NAME = 'translate-y';
 
-/** @const {!Array<string} */
+/** @const {!Array<string>} */
 export const PRESET_OPTION_ATTRIBUTES = [
   SCALE_START_ATTRIBUTE_NAME,
   SCALE_END_ATTRIBUTE_NAME,

--- a/extensions/amp-story/1.0/animation-presets.js
+++ b/extensions/amp-story/1.0/animation-presets.js
@@ -80,274 +80,255 @@ export function setStyleForPreset(el, presetName) {
 }
 
 /**
- * @param {string} name
- * @param {!Object} options
- * @return {?StoryAnimationPresetDef}
+ * First keyframe will always be considered offset: 0 and will be applied to the
+ * element as the first frame before animation starts.
+ * @type {!Object<string, !StoryAnimationPresetDef>}
  */
-// First keyframe will always be considered offset: 0 and will be applied to the
-// element as the first frame before animation starts.
-export const getPresetDef = (name, options) => {
-  switch (name) {
-    case 'pulse':
-      return {
-        duration: 400,
-        easing: 'cubic-bezier(0.4, 0.0, 0.2, 1)',
-        keyframes: [
-          {
-            offset: 0,
-            transform: 'scale(1)',
-          },
-          {
-            offset: 0.25,
-            transform: 'scale(0.95)',
-          },
-          {
-            offset: 0.75,
-            transform: 'scale(1.05)',
-          },
-          {
-            offset: 1,
-            transform: 'scale(1)',
-          },
-        ],
-      };
-    case 'fly-in-left':
-      return {
-        duration: 400,
-        easing: 'cubic-bezier(0.0, 0.0, 0.2, 1)',
-        keyframes(dimensions) {
-          const offsetX = -(dimensions.targetX + dimensions.targetWidth);
-          return translate2d(offsetX, 0, 0, 0);
-        },
-      };
-    case 'fly-in-right':
-      return {
-        duration: 400,
-        easing: 'cubic-bezier(0.0, 0.0, 0.2, 1)',
-        keyframes(dimensions) {
-          const offsetX = dimensions.pageWidth - dimensions.targetX;
-          return translate2d(offsetX, 0, 0, 0);
-        },
-      };
-    case 'fly-in-top':
-      return {
-        duration: 400,
-        easing: 'cubic-bezier(0.0, 0.0, 0.2, 1)',
-        keyframes(dimensions) {
-          const offsetY = -(dimensions.targetY + dimensions.targetHeight);
-          return translate2d(0, offsetY, 0, 0);
-        },
-      };
-    case 'fly-in-bottom':
-      return {
-        duration: 400,
-        easing: 'cubic-bezier(0.0, 0.0, 0.2, 1)',
-        keyframes(dimensions) {
-          const offsetY = dimensions.pageHeight - dimensions.targetY;
-          return translate2d(0, offsetY, 0, 0);
-        },
-      };
-    case 'rotate-in-left':
-      return {
-        duration: 600,
-        easing: 'cubic-bezier(0.0, 0.0, 0.2, 1)',
-        keyframes(dimensions) {
-          const offsetX = -(dimensions.targetX + dimensions.targetWidth);
-          return rotateAndTranslate(offsetX, 0, 0, 0, -1);
-        },
-      };
-    case 'rotate-in-right':
-      return {
-        duration: 600,
-        easing: 'cubic-bezier(0.0, 0.0, 0.2, 1)',
-        keyframes(dimensions) {
-          const offsetX = dimensions.pageWidth - dimensions.targetX;
-          return rotateAndTranslate(offsetX, 0, 0, 0, 1);
-        },
-      };
-    case 'fade-in':
-      return {
-        duration: 400,
-        easing: 'cubic-bezier(0.0, 0.0, 0.2, 1)',
-        keyframes: [
-          {
-            opacity: 0,
-          },
-          {
-            opacity: 1,
-          },
-        ],
-      };
-    case 'drop':
-      return {
-        duration: 1600,
-        keyframes(dimensions) {
-          const maxBounceHeight = Math.max(
-            160,
-            dimensions.targetY + dimensions.targetHeight
-          );
+export const presets = {
+  'pulse': {
+    duration: 400,
+    easing: 'cubic-bezier(0.4, 0.0, 0.2, 1)',
+    keyframes: [
+      {
+        offset: 0,
+        transform: 'scale(1)',
+      },
+      {
+        offset: 0.25,
+        transform: 'scale(0.95)',
+      },
+      {
+        offset: 0.75,
+        transform: 'scale(1.05)',
+      },
+      {
+        offset: 1,
+        transform: 'scale(1)',
+      },
+    ],
+  },
+  'fly-in-left': {
+    duration: 400,
+    easing: 'cubic-bezier(0.0, 0.0, 0.2, 1)',
+    keyframes(dimensions) {
+      const offsetX = -(dimensions.targetX + dimensions.targetWidth);
+      return translate2d(offsetX, 0, 0, 0);
+    },
+  },
+  'fly-in-right': {
+    duration: 400,
+    easing: 'cubic-bezier(0.0, 0.0, 0.2, 1)',
+    keyframes(dimensions) {
+      const offsetX = dimensions.pageWidth - dimensions.targetX;
+      return translate2d(offsetX, 0, 0, 0);
+    },
+  },
+  'fly-in-top': {
+    duration: 400,
+    easing: 'cubic-bezier(0.0, 0.0, 0.2, 1)',
+    keyframes(dimensions) {
+      const offsetY = -(dimensions.targetY + dimensions.targetHeight);
+      return translate2d(0, offsetY, 0, 0);
+    },
+  },
+  'fly-in-bottom': {
+    duration: 400,
+    easing: 'cubic-bezier(0.0, 0.0, 0.2, 1)',
+    keyframes(dimensions) {
+      const offsetY = dimensions.pageHeight - dimensions.targetY;
+      return translate2d(0, offsetY, 0, 0);
+    },
+  },
+  'rotate-in-left': {
+    duration: 600,
+    easing: 'cubic-bezier(0.0, 0.0, 0.2, 1)',
+    keyframes(dimensions) {
+      const offsetX = -(dimensions.targetX + dimensions.targetWidth);
+      return rotateAndTranslate(offsetX, 0, 0, 0, -1);
+    },
+  },
+  'rotate-in-right': {
+    duration: 600,
+    easing: 'cubic-bezier(0.0, 0.0, 0.2, 1)',
+    keyframes(dimensions) {
+      const offsetX = dimensions.pageWidth - dimensions.targetX;
+      return rotateAndTranslate(offsetX, 0, 0, 0, 1);
+    },
+  },
+  'fade-in': {
+    duration: 400,
+    easing: 'cubic-bezier(0.0, 0.0, 0.2, 1)',
+    keyframes: [
+      {
+        opacity: 0,
+      },
+      {
+        opacity: 1,
+      },
+    ],
+  },
+  'drop': {
+    duration: 1600,
+    keyframes(dimensions) {
+      const maxBounceHeight = Math.max(
+        160,
+        dimensions.targetY + dimensions.targetHeight
+      );
 
-          return [
-            {
-              offset: 0,
-              transform: `translateY(${px(-maxBounceHeight)})`,
-              easing: 'cubic-bezier(.75,.05,.86,.08)',
-            },
-            {
-              offset: 0.3,
-              transform: 'translateY(0)',
-              easing: 'cubic-bezier(.22,.61,.35,1)',
-            },
-            {
-              offset: 0.52,
-              transform: `translateY(${px(-0.6 * maxBounceHeight)})`,
-              easing: 'cubic-bezier(.75,.05,.86,.08)',
-            },
-            {
-              offset: 0.74,
-              transform: 'translateY(0)',
-              easing: 'cubic-bezier(.22,.61,.35,1)',
-            },
-            {
-              offset: 0.83,
-              transform: `translateY(${px(-0.3 * maxBounceHeight)})`,
-              easing: 'cubic-bezier(.75,.05,.86,.08)',
-            },
-            {
-              offset: 1,
-              transform: 'translateY(0)',
-              easing: 'cubic-bezier(.22,.61,.35,1)',
-            },
-          ];
+      return [
+        {
+          offset: 0,
+          transform: `translateY(${px(-maxBounceHeight)})`,
+          easing: 'cubic-bezier(.75,.05,.86,.08)',
         },
-      };
-    case 'twirl-in':
-      return {
-        duration: 1000,
-        easing: 'cubic-bezier(.2,.75,.4,1)',
-        keyframes: [
-          {
-            transform: 'rotate(-540deg) scale(0.1)',
-            opacity: 0,
-          },
-          {
-            transform: 'none',
-            opacity: 1,
-          },
-        ],
-      };
-    case 'whoosh-in-left':
-      return {
-        duration: 400,
-        easing: 'cubic-bezier(0.0, 0.0, 0.2, 1)',
-        keyframes(dimensions) {
-          const offsetX = -(dimensions.targetX + dimensions.targetWidth);
-          return whooshIn(offsetX, 0, 0, 0);
+        {
+          offset: 0.3,
+          transform: 'translateY(0)',
+          easing: 'cubic-bezier(.22,.61,.35,1)',
         },
-      };
-    case 'whoosh-in-right':
-      return {
-        duration: 400,
-        easing: 'cubic-bezier(0.0, 0.0, 0.2, 1)',
-        keyframes(dimensions) {
-          const offsetX = dimensions.pageWidth - dimensions.targetX;
-          return whooshIn(offsetX, 0, 0, 0);
+        {
+          offset: 0.52,
+          transform: `translateY(${px(-0.6 * maxBounceHeight)})`,
+          easing: 'cubic-bezier(.75,.05,.86,.08)',
         },
-      };
-    case 'pan-left':
-      let {translateX} = options;
-
-      return {
-        duration: 1000,
-        easing: 'linear',
-        keyframes(dimensions) {
-          const scalingFactor = calculateTargetScalingFactor(dimensions);
-          dimensions.targetWidth *= scalingFactor;
-          dimensions.targetHeight *= scalingFactor;
-
-          const offsetX = dimensions.pageWidth - dimensions.targetWidth;
-          const offsetY = (dimensions.pageHeight - dimensions.targetHeight) / 2;
-
-          return scaleAndTranslate(
-            offsetX,
-            offsetY,
-            translateX ? offsetX + translateX : 0,
-            offsetY,
-            scalingFactor
-          );
+        {
+          offset: 0.74,
+          transform: 'translateY(0)',
+          easing: 'cubic-bezier(.22,.61,.35,1)',
         },
-      };
-    case 'pan-right':
-      translateX = options.translateX;
-
-      return {
-        duration: 1000,
-        easing: 'linear',
-        keyframes(dimensions) {
-          const scalingFactor = calculateTargetScalingFactor(dimensions);
-          dimensions.targetWidth *= scalingFactor;
-          dimensions.targetHeight *= scalingFactor;
-
-          const offsetX = dimensions.pageWidth - dimensions.targetWidth;
-          const offsetY = (dimensions.pageHeight - dimensions.targetHeight) / 2;
-
-          return scaleAndTranslate(
-            0,
-            offsetY,
-            -translateX || offsetX,
-            offsetY,
-            scalingFactor
-          );
+        {
+          offset: 0.83,
+          transform: `translateY(${px(-0.3 * maxBounceHeight)})`,
+          easing: 'cubic-bezier(.75,.05,.86,.08)',
         },
-      };
-    case 'pan-down':
-      let {translateY} = options;
-
-      return {
-        duration: 1000,
-        easing: 'linear',
-        keyframes(dimensions) {
-          const scalingFactor = calculateTargetScalingFactor(dimensions);
-          dimensions.targetWidth *= scalingFactor;
-          dimensions.targetHeight *= scalingFactor;
-
-          const offsetX = -dimensions.targetWidth / 2;
-          const offsetY = dimensions.pageHeight - dimensions.targetHeight;
-
-          return scaleAndTranslate(
-            offsetX,
-            0,
-            offsetX,
-            -translateY || offsetY,
-            scalingFactor
-          );
+        {
+          offset: 1,
+          transform: 'translateY(0)',
+          easing: 'cubic-bezier(.22,.61,.35,1)',
         },
-      };
-    case 'pan-up':
-      translateY = options.translateY;
+      ];
+    },
+  },
+  'twirl-in': {
+    duration: 1000,
+    easing: 'cubic-bezier(.2,.75,.4,1)',
+    keyframes: [
+      {
+        transform: 'rotate(-540deg) scale(0.1)',
+        opacity: 0,
+      },
+      {
+        transform: 'none',
+        opacity: 1,
+      },
+    ],
+  },
+  'whoosh-in-left': {
+    duration: 400,
+    easing: 'cubic-bezier(0.0, 0.0, 0.2, 1)',
+    keyframes(dimensions) {
+      const offsetX = -(dimensions.targetX + dimensions.targetWidth);
+      return whooshIn(offsetX, 0, 0, 0);
+    },
+  },
+  'whoosh-in-right': {
+    duration: 400,
+    easing: 'cubic-bezier(0.0, 0.0, 0.2, 1)',
+    keyframes(dimensions) {
+      const offsetX = dimensions.pageWidth - dimensions.targetX;
+      return whooshIn(offsetX, 0, 0, 0);
+    },
+  },
+  'pan-left': {
+    duration: 1000,
+    easing: 'linear',
+    keyframes(dimensions, options) {
+      const {translateX} = options;
+      const scalingFactor = calculateTargetScalingFactor(dimensions);
+      dimensions.targetWidth *= scalingFactor;
+      dimensions.targetHeight *= scalingFactor;
 
-      return {
-        duration: 1000,
-        easing: 'linear',
-        keyframes(dimensions) {
-          const scalingFactor = calculateTargetScalingFactor(dimensions);
-          dimensions.targetWidth *= scalingFactor;
-          dimensions.targetHeight *= scalingFactor;
+      const offsetX = dimensions.pageWidth - dimensions.targetWidth;
+      const offsetY = (dimensions.pageHeight - dimensions.targetHeight) / 2;
 
-          const offsetX = -dimensions.targetWidth / 2;
-          const offsetY = dimensions.pageHeight - dimensions.targetHeight;
+      return scaleAndTranslate(
+        offsetX,
+        offsetY,
+        translateX ? offsetX + translateX : 0,
+        offsetY,
+        scalingFactor
+      );
+    },
+  },
+  'pan-right': {
+    duration: 1000,
+    easing: 'linear',
+    keyframes(dimensions, options) {
+      const {translateX} = options;
 
-          return scaleAndTranslate(
-            offsetX,
-            offsetY,
-            offsetX,
-            translateY ? offsetY + translateY : 0,
-            scalingFactor
-          );
-        },
-      };
-    case 'zoom-in':
-      let {scaleStart, scaleEnd} = options;
+      const scalingFactor = calculateTargetScalingFactor(dimensions);
+      dimensions.targetWidth *= scalingFactor;
+      dimensions.targetHeight *= scalingFactor;
+
+      const offsetX = dimensions.pageWidth - dimensions.targetWidth;
+      const offsetY = (dimensions.pageHeight - dimensions.targetHeight) / 2;
+
+      return scaleAndTranslate(
+        0,
+        offsetY,
+        -translateX || offsetX,
+        offsetY,
+        scalingFactor
+      );
+    },
+  },
+  'pan-down': {
+    duration: 1000,
+    easing: 'linear',
+    keyframes(dimensions, options) {
+      const {translateY} = options;
+      const scalingFactor = calculateTargetScalingFactor(dimensions);
+      dimensions.targetWidth *= scalingFactor;
+      dimensions.targetHeight *= scalingFactor;
+
+      const offsetX = -dimensions.targetWidth / 2;
+      const offsetY = dimensions.pageHeight - dimensions.targetHeight;
+
+      return scaleAndTranslate(
+        offsetX,
+        0,
+        offsetX,
+        -translateY || offsetY,
+        scalingFactor
+      );
+    },
+  },
+  'pan-up': {
+    duration: 1000,
+    easing: 'linear',
+    keyframes(dimensions, options) {
+      const {translateY} = options;
+      const scalingFactor = calculateTargetScalingFactor(dimensions);
+      dimensions.targetWidth *= scalingFactor;
+      dimensions.targetHeight *= scalingFactor;
+
+      const offsetX = -dimensions.targetWidth / 2;
+      const offsetY = dimensions.pageHeight - dimensions.targetHeight;
+
+      return scaleAndTranslate(
+        offsetX,
+        offsetY,
+        offsetX,
+        translateY ? offsetY + translateY : 0,
+        scalingFactor
+      );
+    },
+  },
+  'zoom-in': {
+    duration: 1000,
+    easing: 'linear',
+    keyframes(unusedDimensions, options) {
+      const {scaleStart, scaleEnd} = options;
 
       if (scaleStart) {
         userAssert(
@@ -357,17 +338,17 @@ export const getPresetDef = (name, options) => {
         );
       }
 
-      return {
-        duration: 1000,
-        easing: 'linear',
-        keyframes: [
-          {transform: `scale(${scaleStart || SCALE_LOW_DEFAULT})`},
-          {transform: `scale(${scaleEnd || SCALE_HIGH_DEFAULT})`},
-        ],
-      };
-    case 'zoom-out':
-      scaleStart = options.scaleStart;
-      scaleEnd = options.scaleEnd;
+      return [
+        {transform: `scale(${scaleStart || SCALE_LOW_DEFAULT})`},
+        {transform: `scale(${scaleEnd || SCALE_HIGH_DEFAULT})`},
+      ];
+    },
+  },
+  'zoom-out': {
+    duration: 1000,
+    easing: 'linear',
+    keyframes(unusedDimensions, options) {
+      const {scaleStart, scaleEnd} = options;
 
       if (scaleStart) {
         userAssert(
@@ -377,14 +358,10 @@ export const getPresetDef = (name, options) => {
         );
       }
 
-      return {
-        duration: 1000,
-        easing: 'linear',
-        keyframes: [
-          {transform: `scale(${scaleStart || SCALE_HIGH_DEFAULT})`},
-          {transform: `scale(${scaleEnd || SCALE_LOW_DEFAULT})`},
-        ],
-      };
-  }
-  return null;
+      return [
+        {transform: `scale(${scaleStart || SCALE_HIGH_DEFAULT})`},
+        {transform: `scale(${scaleEnd || SCALE_LOW_DEFAULT})`},
+      ];
+    },
+  },
 };

--- a/extensions/amp-story/1.0/animation-types.js
+++ b/extensions/amp-story/1.0/animation-types.js
@@ -17,7 +17,10 @@
 /** @typedef {!Array<!Object<string, *>>} */
 export let KeyframesDef;
 
-/** @typedef {(function(StoryAnimationDimsDef):!KeyframesDef)|!KeyframesDef} */
+/** @typedef {function(StoryAnimationDimsDef, Object<string, *>):!KeyframesDef} */
+export let KeyframesFilterFnDef;
+
+/** @typedef {!KeyframesDef|!KeyframesFilterFnDef} */
 export let KeyframesOrFilterFnDef;
 
 /**

--- a/extensions/amp-story/1.0/animation.js
+++ b/extensions/amp-story/1.0/animation.js
@@ -23,37 +23,34 @@ import {
   StoryAnimationDimsDef,
   StoryAnimationPresetDef,
 } from './animation-types';
+import {
+  PRESET_OPTION_ATTRIBUTES,
+  presets,
+  setStyleForPreset,
+} from './animation-presets';
 import {Services} from '../../../src/services';
 import {WebAnimationPlayState} from '../../amp-animation/0.1/web-animation-types';
 import {assertDoesNotContainDisplay, setStyles} from '../../../src/style';
 import {dev, devAssert, user, userAssert} from '../../../src/log';
 import {escapeCssSelectorIdent} from '../../../src/css';
 import {map, omit} from '../../../src/utils/object';
-import {presets, setStyleForPreset} from './animation-presets';
 import {scopedQuerySelector, scopedQuerySelectorAll} from '../../../src/dom';
 import {timeStrToMillis, unscaledClientRect} from './utils';
 
-/** const {string} */
+/** @const {string} */
 export const ANIMATE_IN_ATTRIBUTE_NAME = 'animate-in';
-/** const {string} */
+/** @const {string} */
 const ANIMATE_IN_DURATION_ATTRIBUTE_NAME = 'animate-in-duration';
-/** const {string} */
+/** @const {string} */
 const ANIMATE_IN_DELAY_ATTRIBUTE_NAME = 'animate-in-delay';
-/** const {string} */
+/** @const {string} */
 const ANIMATE_IN_AFTER_ATTRIBUTE_NAME = 'animate-in-after';
-/** const {string} */
+/** @const {string} */
 const ANIMATE_IN_TIMING_FUNCTION_ATTRIBUTE_NAME = 'animate-in-timing-function';
-/** const {string} */
+/** @const {string} */
 const ANIMATABLE_ELEMENTS_SELECTOR = `[${ANIMATE_IN_ATTRIBUTE_NAME}]`;
-/** const {string} */
-const SCALE_START_ATTRIBUTE_NAME = 'scale-start';
-/** const {string} */
-const SCALE_END_ATTRIBUTE_NAME = 'scale-end';
-/** const {string} */
-const TRANSLATE_X_ATTRIBUTE_NAME = 'translate-x';
-/** const {string} */
-const TRANSLATE_Y_ATTRIBUTE_NAME = 'translate-y';
-/** const {string} */
+
+/** @const {string} */
 const DEFAULT_EASING = 'cubic-bezier(0.4, 0.0, 0.2, 1)';
 
 /**
@@ -569,6 +566,9 @@ export class AnimationManager {
     const keyframeOptions = this.getKeyframeOptions_(el);
     const animationDef = this.createAnimationDef(el, preset);
 
+    // TODO(alanorozco): This should be part of a mutate cycle.
+    setStyleForPreset(el, name);
+
     return AnimationRunner.create(
       this.root_,
       animationDef,
@@ -658,61 +658,23 @@ export class AnimationManager {
    */
   getKeyframeOptions_(el) {
     const options = {};
-    setStyleForPreset(el, name);
 
-    if (el.hasAttribute(SCALE_START_ATTRIBUTE_NAME)) {
-      options.scaleStart = parseFloat(
-        el.getAttribute(SCALE_START_ATTRIBUTE_NAME)
-      );
-
-      userAssert(
-        options.scaleStart > 0,
-        '"%s" attribute must be a ' +
-          'positive number. Found negative or zero in element %s',
-        SCALE_START_ATTRIBUTE_NAME,
-        el
-      );
-    }
-
-    if (el.hasAttribute(SCALE_END_ATTRIBUTE_NAME)) {
-      options.scaleEnd = parseFloat(el.getAttribute(SCALE_END_ATTRIBUTE_NAME));
+    PRESET_OPTION_ATTRIBUTES.forEach((name) => {
+      if (!el.hasAttribute(name)) {
+        return;
+      }
+      const value = parseFloat(el.getAttribute(name));
 
       userAssert(
-        options.scaleEnd > 0,
+        value > 0,
         '"%s" attribute must be a ' +
           'positive number. Found negative or zero in element %s',
-        SCALE_END_ATTRIBUTE_NAME,
+        name,
         el
       );
-    }
 
-    if (el.hasAttribute(TRANSLATE_X_ATTRIBUTE_NAME)) {
-      options.translateX = parseFloat(
-        el.getAttribute(TRANSLATE_X_ATTRIBUTE_NAME)
-      );
-
-      userAssert(
-        options.translateX > 0,
-        '"%s" attribute must be a ' +
-          'positive number. Found negative or zero in element %s',
-        TRANSLATE_X_ATTRIBUTE_NAME,
-        el
-      );
-    }
-
-    if (el.hasAttribute(TRANSLATE_Y_ATTRIBUTE_NAME)) {
-      options.translateY = parseFloat(
-        el.getAttribute(TRANSLATE_Y_ATTRIBUTE_NAME)
-      );
-
-      userAssert(
-        options.translateY > 0,
-        '"%s" attribute must be a ' +
-          'positive number. Found negative or zero in element %s',
-        TRANSLATE_Y_ATTRIBUTE_NAME,
-        el
-      );
-    }
+      options[name] = value;
+    });
 
     return options;
   }

--- a/extensions/amp-story/1.0/animation.js
+++ b/extensions/amp-story/1.0/animation.js
@@ -566,9 +566,6 @@ export class AnimationManager {
     const keyframeOptions = this.getKeyframeOptions_(el);
     const animationDef = this.createAnimationDef(el, preset);
 
-    // TODO(alanorozco): This should be part of a mutate cycle.
-    setStyleForPreset(el, name);
-
     return AnimationRunner.create(
       this.root_,
       animationDef,
@@ -641,6 +638,9 @@ export class AnimationManager {
    */
   getPreset_(el) {
     const name = el.getAttribute(ANIMATE_IN_ATTRIBUTE_NAME);
+
+    // TODO(alanorozco): This should be part of a mutate cycle.
+    setStyleForPreset(el, name);
 
     return /** @type {StoryAnimationPresetDef} */ (userAssert(
       presets[name],

--- a/extensions/amp-story/1.0/test/test-animation.js
+++ b/extensions/amp-story/1.0/test/test-animation.js
@@ -437,25 +437,25 @@ describes.realWin('amp-story animations', {}, (env) => {
       const targetsWithOptions = [
         {
           target: html`<div animate-in="pan-left" translate-x="100"></div>`,
-          expectedOptions: {translateX: 100},
+          expectedOptions: {'translate-x': 100},
         },
         {
           target: html`<div animate-in="pan-up" translate-y="200"></div>`,
-          expectedOptions: {translateY: 200},
+          expectedOptions: {'translate-y': 200},
         },
         {
           target: html`<div animate-in="zoom-out" scale-start="0.9"></div>`,
-          expectedOptions: {scaleStart: 0.9},
+          expectedOptions: {'scale-start': 0.9},
         },
         {
           target: html`<div animate-in="zoom-out" scale-end="0.2"></div>`,
-          expectedOptions: {scaleEnd: 0.2},
+          expectedOptions: {'scale-end': 0.2},
         },
         {
           target: html`
             <div animate-in="zoom-in" scale-end="0.1" scale-start="0.5"></div>
           `,
-          expectedOptions: {scaleEnd: 0.1, scaleStart: 0.5},
+          expectedOptions: {'scale-end': 0.1, 'scale-start': 0.5},
         },
       ];
 

--- a/extensions/amp-story/1.0/test/test-animation.js
+++ b/extensions/amp-story/1.0/test/test-animation.js
@@ -392,7 +392,7 @@ describes.realWin('amp-story animations', {}, (env) => {
         .returns(runner);
     });
 
-    it(`creates internal runners when applying first frame`, async () => {
+    it('creates internal runners when applying first frame', async () => {
       const page = html`
         <div>
           <div animate-in="fly-in-left"></div>
@@ -431,7 +431,7 @@ describes.realWin('amp-story animations', {}, (env) => {
       expect(async () => await animationManager.applyFirstFrame()).to.throw;
     });
 
-    it(`passes keyframeOptions to runner`, async () => {
+    it('passes keyframeOptions to runner', async () => {
       const page = html`<div></div>`;
 
       const targetsWithOptions = [
@@ -480,7 +480,7 @@ describes.realWin('amp-story animations', {}, (env) => {
       });
     });
 
-    it(`applies first frame`, async () => {
+    it('applies first frame', async () => {
       const page = html`
         <div>
           <div animate-in="fly-in-left"></div>

--- a/extensions/amp-story/1.0/test/test-animation.js
+++ b/extensions/amp-story/1.0/test/test-animation.js
@@ -26,11 +26,11 @@ import {WebAnimationPlayState} from '../../../amp-animation/0.1/web-animation-ty
 import {htmlFor, htmlRefs} from '../../../../src/static-template';
 import {layoutRectLtwh} from '../../../../src/layout-rect';
 import {presets} from '../animation-presets';
+import {scopedQuerySelectorAll} from '../../../../src/dom';
+import {toArray} from '../../../../src/types';
 
-function htmlRefsFlat(element) {
-  const refs = htmlRefs(element);
-  return Object.keys(refs).map((k) => refs[k]);
-}
+const querySelectorAllAnimateIn = (element) =>
+  toArray(scopedQuerySelectorAll(element, '[animate-in]'));
 
 describes.realWin('amp-story animations', {}, (env) => {
   let html;
@@ -395,16 +395,16 @@ describes.realWin('amp-story animations', {}, (env) => {
     it(`creates internal runners when applying first frame`, async () => {
       const page = html`
         <div>
-          <div animate-in="fly-in-left" ref="0"></div>
-          <div animate-in="fade-in" ref="1"></div>
-          <div animate-in="drop" ref="2"></div>
+          <div animate-in="fly-in-left"></div>
+          <div animate-in="fade-in"></div>
+          <div animate-in="drop"></div>
         </div>
       `;
 
       const animationManager = new AnimationManager(page, ampdoc);
       await animationManager.applyFirstFrame();
 
-      htmlRefsFlat(page).forEach((target) => {
+      querySelectorAllAnimateIn(page).forEach((target) => {
         const preset = presets[target.getAttribute('animate-in')];
         expect(
           createAnimationRunner.withArgs(
@@ -483,15 +483,15 @@ describes.realWin('amp-story animations', {}, (env) => {
     it(`applies first frame`, async () => {
       const page = html`
         <div>
-          <div animate-in="fly-in-left" ref="0"></div>
-          <div animate-in="fade-in" ref="1"></div>
-          <div animate-in="drop" ref="2"></div>
+          <div animate-in="fly-in-left"></div>
+          <div animate-in="fade-in"></div>
+          <div animate-in="drop"></div>
         </div>
       `;
       const animationManager = new AnimationManager(page, ampdoc);
       await animationManager.applyFirstFrame();
       expect(runner.applyFirstFrame).to.have.callCount(
-        htmlRefsFlat(page).length
+        querySelectorAllAnimateIn(page).length
       );
     });
 
@@ -584,9 +584,9 @@ describes.realWin('amp-story animations', {}, (env) => {
       it(`calls ${runnerMethod}() on all runners calling ${managerMethod}()`, async () => {
         const page = html`
           <div>
-            <div animate-in="fly-in-left" ref="0"></div>
-            <div animate-in="fade-in" ref="1"></div>
-            <div animate-in="drop" ref="2"></div>
+            <div animate-in="fly-in-left"></div>
+            <div animate-in="fade-in"></div>
+            <div animate-in="drop"></div>
           </div>
         `;
 
@@ -595,7 +595,7 @@ describes.realWin('amp-story animations', {}, (env) => {
         await animationManager.applyFirstFrame();
         animationManager[managerMethod]();
         expect(runner[runnerMethod]).to.have.callCount(
-          htmlRefsFlat(page).length
+          querySelectorAllAnimateIn(page).length
         );
       });
     });

--- a/extensions/amp-story/1.0/test/test-animation.js
+++ b/extensions/amp-story/1.0/test/test-animation.js
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import {AmpDocSingle} from '../../../../src/service/ampdoc-impl';
 import {
   AnimationManager,
   AnimationRunner,
@@ -39,7 +40,7 @@ describes.realWin('amp-story animations', {}, (env) => {
 
   beforeEach(() => {
     html = htmlFor(env.win.document);
-    ampdoc = {win: env.win};
+    ampdoc = new AmpDocSingle(env.win);
   });
 
   describe('AnimationRunner', () => {

--- a/extensions/amp-story/1.0/test/test-animation.js
+++ b/extensions/amp-story/1.0/test/test-animation.js
@@ -1,0 +1,650 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {match} from 'sinon'; // eslint-disable-line local/no-import
+
+import {
+  AnimationManager,
+  AnimationRunner,
+  AnimationSequence,
+} from '../animation';
+import {Deferred} from '../../../../src/utils/promise';
+import {Services} from '../../../../src/services';
+import {WebAnimationPlayState} from '../../../amp-animation/0.1/web-animation-types';
+import {htmlFor, htmlRefs} from '../../../../src/static-template';
+import {layoutRectLtwh} from '../../../../src/layout-rect';
+import {presets} from '../animation-presets';
+
+function htmlRefsFlat(element) {
+  const refs = htmlRefs(element);
+  return Object.keys(refs).map((k) => refs[k]);
+}
+
+describes.realWin('amp-story animations', {}, (env) => {
+  let html;
+  let ampdoc;
+
+  const nextTick = () =>
+    new Promise((resolve) => env.win.setTimeout(resolve, 0));
+
+  beforeEach(() => {
+    html = htmlFor(env.win.document);
+    ampdoc = {win: env.win};
+  });
+
+  describe('AnimationRunner', () => {
+    const vsync = {
+      measurePromise: (cb) => Promise.resolve(cb()),
+      mutatePromise: (cb) => Promise.resolve(cb()),
+    };
+
+    let webAnimationBuilder;
+    let webAnimationBuilderPromise;
+    let sequence;
+
+    beforeEach(() => {
+      webAnimationBuilder = {
+        createRunner: () => {},
+        onPlayStateChanged: () => {},
+      };
+
+      webAnimationBuilderPromise = Promise.resolve(webAnimationBuilder);
+
+      sequence = {
+        notifyFinish: () => {},
+        waitFor: () => Promise.resolve(),
+      };
+    });
+
+    it('passes keyframeOptions to preset keyframes function', async () => {
+      const page = html`<div></div>`;
+      const target = html`<div></div>`;
+
+      const keyframeOptions = {foo: 'bar'};
+
+      const animationDef = {
+        target,
+        preset: {
+          keyframes: env.sandbox.spy(() => [{}]),
+        },
+      };
+
+      const runner = new AnimationRunner(
+        page,
+        animationDef,
+        webAnimationBuilderPromise,
+        vsync,
+        sequence,
+        keyframeOptions
+      );
+
+      await runner.applyFirstFrame();
+
+      expect(
+        animationDef.preset.keyframes.withArgs(
+          match.any,
+          match(keyframeOptions)
+        )
+      ).to.have.been.calledOnce;
+    });
+
+    it('passes dimensions to preset keyframes function', async () => {
+      const page = html`<div></div>`;
+      const target = html`<div></div>`;
+
+      const pageDimensions = layoutRectLtwh(10, 20, 300, 500);
+      Object.defineProperties(page, {
+        'offsetWidth': {value: pageDimensions.width},
+        'offsetHeight': {value: pageDimensions.height},
+      });
+
+      const targetDimensions = layoutRectLtwh(40, 80, 100, 200);
+      Object.defineProperties(target, {
+        'offsetWidth': {value: targetDimensions.width},
+        'offsetHeight': {value: targetDimensions.height},
+      });
+
+      env.sandbox.stub(page, 'getBoundingClientRect').returns(pageDimensions);
+      env.sandbox
+        .stub(target, 'getBoundingClientRect')
+        .returns(targetDimensions);
+
+      const animationDef = {
+        target,
+        preset: {
+          keyframes: env.sandbox.spy(() => [{}]),
+        },
+      };
+
+      const runner = new AnimationRunner(
+        page,
+        animationDef,
+        webAnimationBuilderPromise,
+        vsync,
+        sequence
+      );
+
+      await runner.applyFirstFrame();
+
+      expect(
+        animationDef.preset.keyframes.withArgs(
+          match({
+            pageWidth: pageDimensions.width,
+            pageHeight: pageDimensions.height,
+            targetWidth: targetDimensions.width,
+            targetHeight: targetDimensions.height,
+            targetX: targetDimensions.x - pageDimensions.x,
+            targetY: targetDimensions.y - pageDimensions.y,
+          }),
+          match.any
+        )
+      ).to.have.been.calledOnce;
+    });
+
+    const keyframes = [{opacity: 0}, {opacity: 1}];
+    const keyframeDefTypes = {
+      'function': () => keyframes,
+      'array': keyframes,
+    };
+    Object.keys(keyframeDefTypes).forEach((keyframeDefType) => {
+      it(`applies first frame (with ${keyframeDefType})`, async () => {
+        const page = html`<div></div>`;
+        const target = html`<div></div>`;
+
+        const animationDef = {
+          target,
+          preset: {
+            keyframes: keyframeDefTypes[keyframeDefType],
+          },
+        };
+
+        const runner = new AnimationRunner(
+          page,
+          animationDef,
+          webAnimationBuilderPromise,
+          vsync,
+          sequence
+        );
+
+        await runner.applyFirstFrame();
+
+        expect(target.style.opacity).to.equal('0');
+      });
+    });
+
+    it('creates WebAnimationRunner with definition', async () => {
+      const page = html`<div></div>`;
+      const target = html`<div></div>`;
+
+      const webAnimationRunner = {
+        getPlayState: () => WebAnimationPlayState.IDLE,
+        onPlayStateChanged: () => {},
+      };
+
+      webAnimationBuilder.createRunner = env.sandbox.spy(
+        () => webAnimationRunner
+      );
+
+      const keyframes = [{}];
+
+      const easing = 'test-easing';
+      const duration = 123;
+      const delay = 456;
+
+      const animationDef = {
+        target,
+        easing,
+        duration,
+        delay,
+        preset: {
+          keyframes: () => keyframes,
+        },
+      };
+
+      new AnimationRunner(
+        page,
+        animationDef,
+        webAnimationBuilderPromise,
+        vsync,
+        sequence
+      );
+
+      await nextTick();
+
+      expect(
+        webAnimationBuilder.createRunner.withArgs(
+          match({
+            target,
+            easing,
+            duration,
+            delay,
+            keyframes,
+          })
+        )
+      ).to.have.been.calledOnce;
+    });
+
+    it('starts', async () => {
+      const page = html`<div></div>`;
+      const target = html`<div></div>`;
+
+      const webAnimationRunner = {
+        start: env.sandbox.spy(),
+        getPlayState: () => WebAnimationPlayState.IDLE,
+        onPlayStateChanged: () => {},
+      };
+
+      webAnimationBuilder.createRunner = () => webAnimationRunner;
+
+      const animationDef = {
+        target,
+        preset: {
+          keyframes: [{}],
+        },
+      };
+
+      const runner = new AnimationRunner(
+        page,
+        animationDef,
+        webAnimationBuilderPromise,
+        vsync,
+        sequence
+      );
+
+      runner.start();
+
+      await nextTick();
+      expect(webAnimationRunner.start).to.have.been.calledOnce;
+    });
+
+    it('starts after sequence id', async () => {
+      const page = html`<div></div>`;
+      const target = html`<div></div>`;
+
+      const startAfterId = 'my-test-id';
+
+      const webAnimationRunner = {
+        start: env.sandbox.spy(),
+        getPlayState: () => WebAnimationPlayState.IDLE,
+        onPlayStateChanged: () => {},
+      };
+
+      webAnimationBuilder.createRunner = () => webAnimationRunner;
+
+      const {resolve: resolveWaitFor, promise} = new Deferred();
+      sequence.waitFor = env.sandbox.spy(() => promise);
+
+      const animationDef = {
+        target,
+        startAfterId,
+        preset: {
+          keyframes: [{}],
+        },
+      };
+
+      const runner = new AnimationRunner(
+        page,
+        animationDef,
+        webAnimationBuilderPromise,
+        vsync,
+        sequence
+      );
+
+      runner.start();
+
+      await nextTick();
+
+      expect(sequence.waitFor.withArgs(startAfterId)).to.have.been.calledOnce;
+      expect(webAnimationRunner.start).to.not.have.been.called;
+
+      resolveWaitFor();
+
+      await nextTick();
+
+      expect(webAnimationRunner.start).to.have.been.calledOnce;
+    });
+
+    it('notifies sequence when finished', async () => {
+      const page = html`<div></div>`;
+      const target = html`<div id="my-test-id"></div>`;
+
+      const targetId = 'my-test-id';
+
+      let onPlayStateChangedCallback;
+      const webAnimationRunner = {
+        getPlayState: () => WebAnimationPlayState.IDLE,
+        onPlayStateChanged: (callback) => {
+          onPlayStateChangedCallback = callback;
+        },
+      };
+
+      webAnimationBuilder.createRunner = () => webAnimationRunner;
+
+      sequence.notifyFinish = env.sandbox.spy();
+
+      const animationDef = {
+        target,
+        preset: {
+          keyframes: [{}],
+        },
+      };
+
+      new AnimationRunner(
+        page,
+        animationDef,
+        webAnimationBuilderPromise,
+        vsync,
+        sequence
+      );
+
+      await nextTick();
+
+      expect(sequence.notifyFinish).to.not.have.been.called;
+
+      onPlayStateChangedCallback(WebAnimationPlayState.FINISHED);
+
+      expect(sequence.notifyFinish.withArgs(targetId)).to.have.been.calledOnce;
+    });
+  });
+
+  describe('AnimationManager', () => {
+    let extensionsService;
+    let webAnimationService;
+    let webAnimationBuilderPromise;
+    let createAnimationRunner;
+    let runner;
+
+    beforeEach(() => {
+      webAnimationBuilderPromise = Promise.resolve();
+
+      extensionsService = {
+        installExtensionForDoc: env.sandbox.spy(() => Promise.resolve()),
+      };
+
+      webAnimationService = {
+        createBuilder: env.sandbox.spy(() => webAnimationBuilderPromise),
+      };
+
+      env.sandbox.stub(Services, 'extensionsFor').returns(extensionsService);
+      env.sandbox.stub(Services, 'vsyncFor').returns({});
+      env.sandbox
+        .stub(Services, 'webAnimationServiceFor')
+        .returns(Promise.resolve(webAnimationService));
+
+      runner = {
+        applyFirstFrame: env.sandbox.spy(() => Promise.resolve()),
+      };
+
+      createAnimationRunner = env.sandbox
+        .stub(AnimationRunner, 'create')
+        .returns(runner);
+    });
+
+    it(`creates internal runners when applying first frame`, async () => {
+      const page = html`
+        <div>
+          <div animate-in="fly-in-left" ref="0"></div>
+          <div animate-in="fade-in" ref="1"></div>
+          <div animate-in="drop" ref="2"></div>
+        </div>
+      `;
+
+      const animationManager = new AnimationManager(page, ampdoc);
+      await animationManager.applyFirstFrame();
+
+      htmlRefsFlat(page).forEach((target) => {
+        const preset = presets[target.getAttribute('animate-in')];
+        expect(
+          createAnimationRunner.withArgs(
+            page,
+            match({target, preset}),
+            webAnimationBuilderPromise,
+            match.any,
+            match.any,
+            match.any
+          )
+        ).to.have.been.calledOnce;
+      });
+    });
+
+    it('fails when using unknown presets', () => {
+      const animationManager = new AnimationManager(
+        html`
+          <div>
+            <div animate-in="unknown-preset"></div>
+          </div>
+        `,
+        ampdoc
+      );
+      expect(async () => await animationManager.applyFirstFrame()).to.throw;
+    });
+
+    it(`passes keyframeOptions to runner`, async () => {
+      const page = html`<div></div>`;
+
+      const targetsWithOptions = [
+        {
+          target: html`<div animate-in="pan-left" translate-x="100"></div>`,
+          expectedOptions: {translateX: 100},
+        },
+        {
+          target: html`<div animate-in="pan-up" translate-y="200"></div>`,
+          expectedOptions: {translateY: 200},
+        },
+        {
+          target: html`<div animate-in="zoom-out" scale-start="0.9"></div>`,
+          expectedOptions: {scaleStart: 0.9},
+        },
+        {
+          target: html`<div animate-in="zoom-out" scale-end="0.2"></div>`,
+          expectedOptions: {scaleEnd: 0.2},
+        },
+        {
+          target: html`
+            <div animate-in="zoom-in" scale-end="0.1" scale-start="0.5"></div>
+          `,
+          expectedOptions: {scaleEnd: 0.1, scaleStart: 0.5},
+        },
+      ];
+
+      targetsWithOptions.forEach(({target}) => {
+        page.appendChild(target);
+      });
+
+      const animationManager = new AnimationManager(page, ampdoc);
+      await animationManager.applyFirstFrame();
+
+      targetsWithOptions.forEach(({target, expectedOptions}) => {
+        expect(
+          createAnimationRunner.withArgs(
+            page,
+            match({target}),
+            match.any,
+            match.any,
+            match.any,
+            match(expectedOptions)
+          )
+        ).to.have.been.calledOnce;
+      });
+    });
+
+    it(`applies first frame`, async () => {
+      const page = html`
+        <div>
+          <div animate-in="fly-in-left" ref="0"></div>
+          <div animate-in="fade-in" ref="1"></div>
+          <div animate-in="drop" ref="2"></div>
+        </div>
+      `;
+      const animationManager = new AnimationManager(page, ampdoc);
+      await animationManager.applyFirstFrame();
+      expect(runner.applyFirstFrame).to.have.callCount(
+        htmlRefsFlat(page).length
+      );
+    });
+
+    it('fails when animate-in-after element does not exist', async () => {
+      const page = html`
+        <div>
+          <div animate-in="fly-in-left" animate-in-after="does-not-exist"></div>
+        </div>
+      `;
+      env.win.document.body.appendChild(page);
+      const animationManager = new AnimationManager(page, ampdoc);
+      expect(() => animationManager.applyFirstFrame()).to.throw;
+    });
+
+    it('passes animate-in-after id in definition', async () => {
+      const page = html`
+        <div>
+          <div
+            id="animated-first"
+            ref="animatedFirst"
+            animate-in="fly-in-left"
+          ></div>
+          <div
+            id="animated-second"
+            ref="animatedSecond"
+            animate-in-after="animated-first"
+            animate-in="fly-in-top"
+          ></div>
+          <div
+            id="animated-third"
+            ref="animatedThird"
+            animate-in-after="animated-second"
+            animate-in="fly-in-right"
+          ></div>
+        </div>
+      `;
+      const {animatedFirst, animatedSecond, animatedThird} = htmlRefs(page);
+
+      env.win.document.body.appendChild(page);
+
+      const animationManager = new AnimationManager(page, ampdoc);
+      await animationManager.applyFirstFrame();
+
+      expect(
+        createAnimationRunner.withArgs(
+          match.any,
+          match({target: animatedFirst, startAfterId: undefined}),
+          match.any,
+          match.any,
+          match.any,
+          match.any
+        )
+      ).to.have.been.calledOnce;
+
+      expect(
+        createAnimationRunner.withArgs(
+          match.any,
+          match({target: animatedSecond, startAfterId: 'animated-first'}),
+          match.any,
+          match.any,
+          match.any,
+          match.any
+        )
+      ).to.have.been.calledOnce;
+
+      expect(
+        createAnimationRunner.withArgs(
+          match.any,
+          match({target: animatedThird, startAfterId: 'animated-second'}),
+          match.any,
+          match.any,
+          match.any,
+          match.any
+        )
+      ).to.have.been.calledOnce;
+    });
+
+    const oneToManyPassthrus = {
+      animateIn: 'start',
+      finishAll: 'finish',
+      cancelAll: 'cancel',
+      pauseAll: 'pause',
+      resumeAll: 'resume',
+      hasAnimationStarted: 'hasStarted',
+    };
+
+    Object.keys(oneToManyPassthrus).forEach((managerMethod) => {
+      const runnerMethod = oneToManyPassthrus[managerMethod];
+
+      it(`calls ${runnerMethod}() on all runners calling ${managerMethod}()`, async () => {
+        const page = html`
+          <div>
+            <div animate-in="fly-in-left" ref="0"></div>
+            <div animate-in="fade-in" ref="1"></div>
+            <div animate-in="drop" ref="2"></div>
+          </div>
+        `;
+
+        runner[runnerMethod] = env.sandbox.spy();
+        const animationManager = new AnimationManager(page, ampdoc);
+        await animationManager.applyFirstFrame();
+        animationManager[managerMethod]();
+        expect(runner[runnerMethod]).to.have.callCount(
+          htmlRefsFlat(page).length
+        );
+      });
+    });
+  });
+
+  describe('AnimationSequence', () => {
+    it('waits until notified', async () => {
+      const sequence = new AnimationSequence();
+      const notified = env.sandbox.spy();
+
+      sequence.waitFor('test-notify-id').then(notified);
+      await nextTick();
+      expect(notified).to.not.have.been.called;
+
+      sequence.notifyFinish('test-notify-id');
+      await nextTick();
+      expect(notified).to.have.been.calledOnce;
+    });
+
+    it('notifies only once per wait', async () => {
+      const sequence = new AnimationSequence();
+      const notified = env.sandbox.spy();
+
+      sequence.waitFor('test-notify-id').then(notified);
+      await nextTick();
+
+      sequence.notifyFinish('test-notify-id');
+      await nextTick();
+
+      sequence.notifyFinish('test-notify-id');
+      await nextTick();
+
+      sequence.notifyFinish('test-notify-id');
+      await nextTick();
+
+      expect(notified).to.have.been.calledOnce;
+    });
+
+    it("doesn't notify incorrect ids", async () => {
+      const sequence = new AnimationSequence();
+      const notified = env.sandbox.spy();
+
+      sequence.waitFor('test-notify-id').then(notified);
+      await nextTick();
+      expect(notified).to.not.have.been.called;
+
+      sequence.notifyFinish('a-different-test-notify-id');
+      await nextTick();
+      expect(notified).to.not.have.been.called;
+    });
+  });
+});

--- a/extensions/amp-story/1.0/test/test-animation.js
+++ b/extensions/amp-story/1.0/test/test-animation.js
@@ -13,8 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {match} from 'sinon'; // eslint-disable-line local/no-import
-
 import {
   AnimationManager,
   AnimationRunner,
@@ -94,8 +92,8 @@ describes.realWin('amp-story animations', {}, (env) => {
 
       expect(
         animationDef.preset.keyframes.withArgs(
-          match.any,
-          match(keyframeOptions)
+          env.sandbox.match.any,
+          env.sandbox.match(keyframeOptions)
         )
       ).to.have.been.calledOnce;
     });
@@ -140,7 +138,7 @@ describes.realWin('amp-story animations', {}, (env) => {
 
       expect(
         animationDef.preset.keyframes.withArgs(
-          match({
+          env.sandbox.match({
             pageWidth: pageDimensions.width,
             pageHeight: pageDimensions.height,
             targetWidth: targetDimensions.width,
@@ -148,7 +146,7 @@ describes.realWin('amp-story animations', {}, (env) => {
             targetX: targetDimensions.x - pageDimensions.x,
             targetY: targetDimensions.y - pageDimensions.y,
           }),
-          match.any
+          env.sandbox.match.any
         )
       ).to.have.been.calledOnce;
     });
@@ -225,7 +223,7 @@ describes.realWin('amp-story animations', {}, (env) => {
 
       expect(
         webAnimationBuilder.createRunner.withArgs(
-          match({
+          env.sandbox.match({
             target,
             easing,
             duration,
@@ -409,11 +407,11 @@ describes.realWin('amp-story animations', {}, (env) => {
         expect(
           createAnimationRunner.withArgs(
             page,
-            match({target, preset}),
+            env.sandbox.match({target, preset}),
             webAnimationBuilderPromise,
-            match.any,
-            match.any,
-            match.any
+            env.sandbox.match.any,
+            env.sandbox.match.any,
+            env.sandbox.match.any
           )
         ).to.have.been.calledOnce;
       });
@@ -470,11 +468,11 @@ describes.realWin('amp-story animations', {}, (env) => {
         expect(
           createAnimationRunner.withArgs(
             page,
-            match({target}),
-            match.any,
-            match.any,
-            match.any,
-            match(expectedOptions)
+            env.sandbox.match({target}),
+            env.sandbox.match.any,
+            env.sandbox.match.any,
+            env.sandbox.match.any,
+            env.sandbox.match(expectedOptions)
           )
         ).to.have.been.calledOnce;
       });
@@ -537,34 +535,40 @@ describes.realWin('amp-story animations', {}, (env) => {
 
       expect(
         createAnimationRunner.withArgs(
-          match.any,
-          match({target: animatedFirst, startAfterId: undefined}),
-          match.any,
-          match.any,
-          match.any,
-          match.any
+          env.sandbox.match.any,
+          env.sandbox.match({target: animatedFirst, startAfterId: undefined}),
+          env.sandbox.match.any,
+          env.sandbox.match.any,
+          env.sandbox.match.any,
+          env.sandbox.match.any
         )
       ).to.have.been.calledOnce;
 
       expect(
         createAnimationRunner.withArgs(
-          match.any,
-          match({target: animatedSecond, startAfterId: 'animated-first'}),
-          match.any,
-          match.any,
-          match.any,
-          match.any
+          env.sandbox.match.any,
+          env.sandbox.match({
+            target: animatedSecond,
+            startAfterId: 'animated-first',
+          }),
+          env.sandbox.match.any,
+          env.sandbox.match.any,
+          env.sandbox.match.any,
+          env.sandbox.match.any
         )
       ).to.have.been.calledOnce;
 
       expect(
         createAnimationRunner.withArgs(
-          match.any,
-          match({target: animatedThird, startAfterId: 'animated-second'}),
-          match.any,
-          match.any,
-          match.any,
-          match.any
+          env.sandbox.match.any,
+          env.sandbox.match({
+            target: animatedThird,
+            startAfterId: 'animated-second',
+          }),
+          env.sandbox.match.any,
+          env.sandbox.match.any,
+          env.sandbox.match.any,
+          env.sandbox.match.any
         )
       ).to.have.been.calledOnce;
     });

--- a/extensions/amp-story/1.0/test/test-full-bleed-animations.js
+++ b/extensions/amp-story/1.0/test/test-full-bleed-animations.js
@@ -26,7 +26,7 @@ import {
   calculateTargetScalingFactor,
   targetFitsWithinPage,
 } from '../animation-presets-utils';
-import {getPresetDef} from '../animation-presets';
+import {presets} from '../animation-presets';
 import {registerServiceBuilder} from '../../../../src/service';
 
 describes.realWin(
@@ -242,8 +242,11 @@ describes.realWin(
       const factor = factorThatWillMakeTargetFitPage * 1.25;
       expect(calculateTargetScalingFactor(dimensions)).to.equal(factor);
 
-      const calculatedKeyframes = getPresetDef('pan-up', {});
-      calculatedKeyframes.keyframes = calculatedKeyframes.keyframes(dimensions);
+      const calculatedKeyframes = presets['pan-up'];
+      calculatedKeyframes.keyframes = calculatedKeyframes.keyframes(
+        dimensions,
+        /* options */ {}
+      );
 
       const offsetX = -dimensions.targetWidth / 2;
       const offsetY = dimensions.pageHeight - dimensions.targetHeight;


### PR DESCRIPTION
1. Presets are now a `{name: preset}` map, rather than a constructor function. Their `keyframes()` functions now take the element-defined options, rather than having a top-level constructor function. 

2. Test everything.