### PR TITLE
Implement opening remote page attachments in new window

### DIFF
--- a/build-system/tasks/prepend-global/index.js
+++ b/build-system/tasks/prepend-global/index.js
@@ -42,13 +42,14 @@ function numConfigs(str) {
 /**
  * Checks that only 1 AMP_CONFIG should exist after append.
  *
+ * @param {string} filename
  * @param {string} str
  */
-function sanityCheck(str) {
+function sanityCheck(filename, str) {
   const numMatches = numConfigs(str);
   if (numMatches != 1) {
     throw new Error(
-      'Found ' + numMatches + ' AMP_CONFIG(s) before write. Aborting!'
+      `Found ${numMatches} AMP_CONFIG(s) in ${filename} before write. Aborting!`
     );
   }
 }
@@ -159,7 +160,7 @@ function applyConfig(
       return prependConfig(configString, targetString);
     })
     .then((fileString) => {
-      sanityCheck(fileString);
+      sanityCheck(target, fileString);
       return writeTarget(target, fileString, argv.dryrun);
     })
     .then(() => {

--- a/examples/amp-story/attachment.html
+++ b/examples/amp-story/attachment.html
@@ -7,7 +7,11 @@
     <script async custom-element="amp-social-share" src="https://cdn.ampproject.org/v0/amp-social-share-0.1.js"></script>
     <link href='https://fonts.googleapis.com/css?family=Georgia|Open+Sans|Roboto' rel='stylesheet' type='text/css'>
     <link href="https://fonts.googleapis.com/css?family=Roboto+Condensed" rel="stylesheet">
+<<<<<<< HEAD
     <title>Attachments</title>
+=======
+    <title>Landscape story</title>
+>>>>>>> [WIP] Implement opening content in new window
     <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
     <link rel="canonical" href="index.html">
     <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
@@ -69,7 +73,11 @@
             <span data-text-background-color="crimson">i can fit in that box but inspect anything brought into the house wack the mini furry mouse intently stare at the same spot. Flee in terror at cucumber discovered on floor shake treat bag</span>
           </p>
         </amp-story-grid-layer>
+<<<<<<< HEAD
         <amp-story-page-attachment data-title="Link Description" href="https://www.google.com" layout="nodisplay"></amp-story-page-attachment>
+=======
+        <amp-story-page-attachment data-title="Link" href="https://www.google.com" layout="nodisplay"></amp-story-page-attachment>
+>>>>>>> [WIP] Implement opening content in new window
       </amp-story-page>
 
       <amp-story-page id="page3">

--- a/examples/visual-tests/amp-story/amp-story-page-attachment.html
+++ b/examples/visual-tests/amp-story/amp-story-page-attachment.html
@@ -62,6 +62,11 @@
           </p>
         </amp-story-page-attachment>
       </amp-story-page>
+
+      <amp-story-page id="p2">
+        <amp-story-page-attachment layout="nodisplay" href="https://www.google.com">
+        </amp-story-page-attachment>
+      </amp-story-page>
     </amp-story>
   </body>
 </html>

--- a/extensions/amp-story/1.0/amp-story-draggable-drawer.js
+++ b/extensions/amp-story/1.0/amp-story-draggable-drawer.js
@@ -111,9 +111,6 @@ export class DraggableDrawer extends AMP.BaseElement {
 
     /** @private {!Array<function()>} */
     this.touchEventUnlisteners_ = [];
-
-    /** @private {number} Threshold in pixels above which the drawer opens itself. */
-    this.openThreshold_ = Infinity;
   }
 
   /** @override */
@@ -389,15 +386,6 @@ export class DraggableDrawer extends AMP.BaseElement {
       return;
     }
 
-    if (
-      this.state_ === DrawerState.DRAGGING_TO_OPEN &&
-      swipingUp &&
-      -deltaY > this.openThreshold_
-    ) {
-      this.open();
-      return;
-    }
-
     this.drag_(deltaY);
   }
 
@@ -417,15 +405,6 @@ export class DraggableDrawer extends AMP.BaseElement {
       },
       /* opt_stopAt */ this.element
     );
-  }
-
-  /**
-   * Sets a swipe threshold in pixels above which the drawer opens itself.
-   * @param {number} openThreshold
-   * @protected
-   */
-  setOpenThreshold_(openThreshold) {
-    this.openThreshold_ = openThreshold;
   }
 
   /**

--- a/extensions/amp-story/1.0/amp-story-page-attachment.js
+++ b/extensions/amp-story/1.0/amp-story-page-attachment.js
@@ -140,7 +140,6 @@ export class AmpStoryPageAttachment extends DraggableDrawer {
    */
   buildRemote_() {
     this.setDragCap_(48 /* pixels */);
-    this.setOpenThreshold_(150 /* pixels */);
 
     this.headerEl_.classList.add(
       'i-amphtml-story-draggable-drawer-header-attachment-remote'
@@ -217,11 +216,12 @@ export class AmpStoryPageAttachment extends DraggableDrawer {
 
     super.open(shouldAnimate);
 
-    this.storeService_.dispatch(Action.TOGGLE_SYSTEM_UI_IS_VISIBLE, false);
-
-    // Don't create a new history entry for remote attachment as user is
-    // navigating away.
     if (this.type_ !== AttachmentType.REMOTE) {
+      this.storeService_.dispatch(Action.TOGGLE_SYSTEM_UI_IS_VISIBLE, false);
+
+      // Don't create a new history entry for remote attachment as user is
+      // navigating away.
+
       const currentHistoryState = /** @type {!Object} */ (getState(
         this.win.history
       ));
@@ -255,6 +255,17 @@ export class AmpStoryPageAttachment extends DraggableDrawer {
     const storyEl = closest(this.element, (el) => el.tagName === 'AMP-STORY');
     this.storeService_.dispatch(Action.TOGGLE_SYSTEM_UI_IS_VISIBLE, false);
 
+    const navigationService = Services.navigationForDoc(this.getAmpDoc());
+    navigationService.openWindow(
+      this.win,
+      this.element.getAttribute('href'),
+      '_blank',
+      // We want an opener. Not because we want it, but be cause this allows
+      // detection of a blocked popup, which then leads to a navigation away
+      // from the page 😿
+      true
+    );
+
     this.mutateElement(() => {
       storyEl.appendChild(animationEl);
     }).then(() => {
@@ -262,12 +273,9 @@ export class AmpStoryPageAttachment extends DraggableDrawer {
       // amp-story-page-attachment.css). The navigation itself will take some
       // time, depending on the target and network conditions.
       this.win.setTimeout(() => {
-        const navigationService = Services.navigationForDoc(this.getAmpDoc());
-        navigationService.navigateTo(
-          this.win,
-          this.element.getAttribute('href')
-        );
-      }, 50);
+        removeElement(animationEl);
+        this.closeInternal_();
+      }, 300);
     });
   }
 


### PR DESCRIPTION
Changes behavior to require a `touchend` to terminate gesture. This allows opening popups in Chrome.

This change does not change behavior in Safari which [does not allow](https://twitter.com/cramforce/status/1249175564587540485) popups on touchend after a swipe gesture. [Demo glitch](http://touchpop.glitch.me/)

[Demo of feature (slide 2)](https://malte-amp.web.app/examples/amp-story/attachment.html)