### PR TITLE
🐛 .show() for iOS and autofocus must always remeasure

### DIFF
--- a/src/service/standard-actions-impl.js
+++ b/src/service/standard-actions-impl.js
@@ -375,6 +375,7 @@ export class StandardActions {
     // iOS only honors focus in sync operations.
     if (autofocusElOrNull && Services.platformFor(ownerWindow).isIos()) {
       this.handleShowSync_(target, autofocusElOrNull);
+      this.mutator_.mutateElement(target, () => {}); // force a remeasure
     } else {
       this.mutator_.mutateElement(target, () => {
         this.handleShowSync_(target, autofocusElOrNull);

--- a/test/unit/test-standard-actions.js
+++ b/test/unit/test-standard-actions.js
@@ -67,7 +67,7 @@ describes.sandboxed('StandardActions', {}, (env) => {
     if (sync) {
       expect(mutateElementStub).calledWithMatch(
         element,
-        env.sandbox.match.func
+        env.sandbox.match((fn) => fn.toString() === (() => {}).toString())
       );
     } else {
       expectElementMutatedAsync(element);
@@ -258,7 +258,7 @@ describes.sandboxed('StandardActions', {}, (env) => {
 
           standardActions.handleShow_(trustedInvocation({node}));
 
-          expect(mutateElementStub).to.not.have.been.called;
+          expectElementToHaveBeenShown(node, /* sync */ true);
           expect(node.focus).to.have.been.calledOnce;
         });
 
@@ -270,7 +270,7 @@ describes.sandboxed('StandardActions', {}, (env) => {
           wrapper.firstElementChild.appendChild(node);
           standardActions.handleShow_(trustedInvocation({node: wrapper}));
 
-          expect(mutateElementStub).to.not.have.been.called;
+          expectElementToHaveBeenShown(wrapper, /* sync */ true);
           expect(node.focus).to.have.been.calledOnce;
         });
 

--- a/test/unit/test-standard-actions.js
+++ b/test/unit/test-standard-actions.js
@@ -65,13 +65,7 @@ describes.sandboxed('StandardActions', {}, (env) => {
 
   function expectElementToHaveBeenShown(element, sync = false) {
     if (sync) {
-      expect(mutateElementStub).calledWithMatch(
-        element,
-        env.sandbox.match((fn) => {
-          console./*OK*/ error('DEBUG ME', fn);
-          return fn.toString() === (() => {}).toString();
-        })
-      );
+      expect(mutateElementStub).calledWithMatch(element, env.sandbox.match.any);
     } else {
       expectElementMutatedAsync(element);
     }

--- a/test/unit/test-standard-actions.js
+++ b/test/unit/test-standard-actions.js
@@ -47,10 +47,16 @@ describes.sandboxed('StandardActions', {}, (env) => {
     return element;
   }
 
-  function stubMutate(methodName) {
+  function stubMutate() {
     return env.sandbox
-      .stub(standardActions.mutator_, methodName)
+      .stub(standardActions.mutator_, 'mutateElement')
       .callsFake((unusedElement, mutator) => mutator());
+  }
+  function stubMutateNoop() {
+    standardActions.mutator_.mutateElement.restore();
+    return env.sandbox
+      .stub(standardActions.mutator_, 'mutateElement')
+      .callsFake(() => {});
   }
 
   function expectElementMutatedAsync(element) {
@@ -63,12 +69,8 @@ describes.sandboxed('StandardActions', {}, (env) => {
     expect(element).to.have.attribute('hidden');
   }
 
-  function expectElementToHaveBeenShown(element, sync = false) {
-    if (sync) {
-      expect(mutateElementStub).calledWithMatch(element, env.sandbox.match.any);
-    } else {
-      expectElementMutatedAsync(element);
-    }
+  function expectElementToHaveBeenShown(element) {
+    expectElementMutatedAsync(element);
     expect(element).to.not.have.attribute('hidden');
     expect(element.hasAttribute('hidden')).to.be.false;
   }
@@ -114,7 +116,7 @@ describes.sandboxed('StandardActions', {}, (env) => {
     ampdoc = new AmpDocSingle(window);
     env.sandbox.stub(AmpDocService.prototype, 'getAmpDoc').returns(ampdoc);
     standardActions = new StandardActions(ampdoc);
-    mutateElementStub = stubMutate('mutateElement');
+    mutateElementStub = stubMutate();
     scrollStub = env.sandbox.stub(
       standardActions.viewport_,
       'animateScrollIntoView'
@@ -212,29 +214,31 @@ describes.sandboxed('StandardActions', {}, (env) => {
           </div>
         `;
         standardActions.handleShow_(trustedInvocation({node}));
-        expectElementToHaveBeenShown(node, /* sync */ false);
+        expectElementToHaveBeenShown(node);
       });
 
       it('executes asynchronously when no autofocus (direct)', () => {
         const node = html` <input /> `;
         standardActions.handleShow_(trustedInvocation({node}));
-        expectElementToHaveBeenShown(node, /* sync */ false);
+        expectElementToHaveBeenShown(node);
       });
 
       it('executes synchronously when autofocus (wrapped)', () => {
+        mutateElementStub = stubMutateNoop();
         const node = html`
           <div>
             <div><input autofocus /></div>
           </div>
         `;
         standardActions.handleShow_(trustedInvocation({node}));
-        expectElementToHaveBeenShown(node, /* sync */ true);
+        expectElementToHaveBeenShown(node);
       });
 
       it('executes synchronously when autofocus (direct)', () => {
+        mutateElementStub = stubMutateNoop();
         const node = html` <input autofocus /> `;
         standardActions.handleShow_(trustedInvocation({node}));
-        expectElementToHaveBeenShown(node, /* sync */ true);
+        expectElementToHaveBeenShown(node);
       });
     });
 
@@ -250,16 +254,18 @@ describes.sandboxed('StandardActions', {}, (env) => {
         });
 
         it('focuses [autofocus] element synchronously (direct)', () => {
+          mutateElementStub = stubMutateNoop();
           const node = html` <input autofocus /> `;
           node.focus = env.sandbox.spy();
 
           standardActions.handleShow_(trustedInvocation({node}));
 
-          expectElementToHaveBeenShown(node, /* sync */ true);
+          expectElementToHaveBeenShown(node);
           expect(node.focus).to.have.been.calledOnce;
         });
 
         it('focuses [autofocus] element synchronously (wrapped)', () => {
+          mutateElementStub = stubMutateNoop();
           const wrapper = html` <div><div></div></div> `;
           const node = html` <input autofocus /> `;
           node.focus = env.sandbox.spy();
@@ -267,7 +273,7 @@ describes.sandboxed('StandardActions', {}, (env) => {
           wrapper.firstElementChild.appendChild(node);
           standardActions.handleShow_(trustedInvocation({node: wrapper}));
 
-          expectElementToHaveBeenShown(wrapper, /* sync */ true);
+          expectElementToHaveBeenShown(wrapper);
           expect(node.focus).to.have.been.calledOnce;
         });
 

--- a/test/unit/test-standard-actions.js
+++ b/test/unit/test-standard-actions.js
@@ -65,7 +65,10 @@ describes.sandboxed('StandardActions', {}, (env) => {
 
   function expectElementToHaveBeenShown(element, sync = false) {
     if (sync) {
-      expect(mutateElementStub).to.not.have.been.called;
+      expect(mutateElementStub).calledWithMatch(
+        element,
+        env.sandbox.match.func
+      );
     } else {
       expectElementMutatedAsync(element);
     }

--- a/test/unit/test-standard-actions.js
+++ b/test/unit/test-standard-actions.js
@@ -67,7 +67,10 @@ describes.sandboxed('StandardActions', {}, (env) => {
     if (sync) {
       expect(mutateElementStub).calledWithMatch(
         element,
-        env.sandbox.match((fn) => fn.toString() === (() => {}).toString())
+        env.sandbox.match((fn) => {
+          console./*OK*/ error('DEBUG ME', fn);
+          return fn.toString() === (() => {}).toString();
+        })
       );
     } else {
       expectElementMutatedAsync(element);


### PR DESCRIPTION
**summary**
When showing a hidden element, we must remeasure that element as well as everything below it (via `relayoutTop`). I just found an edge case where we miss the remeasurement, which would cause all the elements below the shown one to have stale (and incorrect) measurements.

The bug only strikes if all three conditions are met:
- On an iOS device
- Calling `.show()` with a target that is not an amp element (e.g. a div)
- Element we are showing requires `autofocus`