### PR TITLE
🐛 Avoid [overflow] layout shift after buildCallback

### DIFF
--- a/css/ampshared.css
+++ b/css/ampshared.css
@@ -231,6 +231,7 @@ i-amphtml-sizer {
   color: transparent !important;
 }
 
+/* Hide all children of non-container elements. */
 .i-amphtml-notbuilt:not(.i-amphtml-layout-container) > * ,
 [layout]:not([layout=container]):not(.i-amphtml-element) > *
 {
@@ -350,6 +351,10 @@ i-amphtml-scroll-container.amp-active, i-amp-scroll-container.amp-active {
   position: relative;
   z-index: 2;
   visibility: hidden;
+  /* display:initial overrides display:none from the "hide all children of
+     non-container elements" rule. This avoids a minor content jump after
+     element build since overflows increase the height of their parents. */
+  display: initial;
 }
 
 .i-amphtml-element > [overflow].amp-visible {

--- a/test/fixtures/overflow.html
+++ b/test/fixtures/overflow.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>amp-iframe</title>
+  <link rel="canonical" href="amps.html" >
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <script async src="/dist/amp.js"></script>
+  <script async custom-element="amp-iframe" src="intentionally_wrong"></script>
+  <style amp-custom>
+    div[overflow] {
+      height: 33px;
+    }
+  </style>
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+</head>
+<body>
+  <amp-iframe width=100 height=100 layout=responsive>
+      <div overflow>The height of the overflow should be reflected in my responsive parent's height!</div>
+      <amp-img layout="fill" src="https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w400-h300-no-n" placeholder></amp-img>
+  </amp-iframe>
+</body>
+</html>

--- a/test/integration/test-css.js
+++ b/test/integration/test-css.js
@@ -39,8 +39,8 @@ describe
       expect(overflowRect.height).to.be.greaterThan(0);
       // The amp-iframe has a 1:1 aspect ratio, and its height should be
       // incremented by the overflow's height.
-      expect(iframeRect.height).to.equal(
-        iframeRect.width + overflowRect.height
-      );
+      expect(
+        Math.abs(iframeRect.width + overflowRect.height) - iframeRect.height
+      ).to.lessThan(2);
     });
   });

--- a/test/integration/test-css.js
+++ b/test/integration/test-css.js
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {AmpEvents} from '../../src/amp-events.js';
+import {createFixtureIframe} from '../../testing/iframe.js';
+
+describe
+  .configure()
+  .retryOnSaucelabs()
+  .run('CSS', () => {
+    it('should include height of [overflow] child in size before build', async () => {
+      const fixture = await createFixtureIframe(
+        'test/fixtures/overflow.html',
+        500
+      );
+      // Wait until layout.js CSS is applied.
+      await fixture.awaitEvent(AmpEvents.ATTACHED, 1);
+      const {doc} = fixture;
+
+      const iframe = doc.querySelector('amp-iframe');
+      const iframeRect = iframe.getBoundingClientRect();
+
+      const overflow = doc.querySelector('[overflow]');
+      const overflowRect = overflow.getBoundingClientRect();
+
+      expect(iframeRect.width).to.equal(
+        iframeRect.height + overflowRect.height
+      );
+    });
+  });

--- a/test/integration/test-css.js
+++ b/test/integration/test-css.js
@@ -36,6 +36,7 @@ describe
       const overflow = doc.querySelector('[overflow]');
       const overflowRect = overflow.getBoundingClientRect();
 
+      expect(overflowRect.height).to.be.greaterThan(0);
       expect(iframeRect.width).to.equal(
         iframeRect.height + overflowRect.height
       );

--- a/test/integration/test-css.js
+++ b/test/integration/test-css.js
@@ -37,8 +37,10 @@ describe
       const overflowRect = overflow.getBoundingClientRect();
 
       expect(overflowRect.height).to.be.greaterThan(0);
-      expect(iframeRect.width).to.equal(
-        iframeRect.height + overflowRect.height
+      // The amp-iframe has a 1:1 aspect ratio, and its height should be
+      // incremented by the overflow's height.
+      expect(iframeRect.height).to.equal(
+        iframeRect.width + overflowRect.height
       );
     });
   });


### PR DESCRIPTION
Related to #25428.
 
`[overflow]` elements currently increase size of parents that use sizers (responsive/intrinsic) after `buildCallback`. For example:

```html
<!-- 
  This element will have a height of 100+20=120px after build, modulo scaling.
  However, it'll have a height of 100px before build because the overflow is hidden.
  This means building the amp-iframe results in a size change of 20px.
-->
<amp-iframe layout=responsive width=100 height=100>
  <div overflow style="height: 20px>Overflow</div>
</amp-iframe>
```

This is due to the following CSS rule:
https://github.com/ampproject/amphtml/blob/876ef78fbbb2ccc281a3766b911b8e8c645ad633/css/ampshared.css#L234-L238

This PR makes the pre-build sizing behavior consistent by overriding `display: none` with `display: initial`. The overflow is not displayed already due to `visibility: hidden`.

Re: `intersect-resources` experiment, this bug can result in incorrect cached layout boxes for affected elements. More generally, any unsanctioned change in size (not through the `changeSize()` API or similar) causes this issue.

Side note: I noticed that status quo behavior of increasing parent height isn't ideal in some cases e.g. it'll distort the aspect ratio of an `amp-img[placeholder]`. But it's unclear how we'd fix that without breaking pages.