### PR TITLE
intersect-resources: Fix bad devAssert

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -26,6 +26,7 @@
   "fixed-elements-in-lightbox": 1,
   "flexAdSlots": 0.05,
   "hidden-mutation-observer": 1,
+  "intersect-resources": 1,
   "ios-fixed-no-transfer": 1,
   "layoutbox-invalidate-on-scroll": 1,
   "pump-early-frame": 1,

--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -26,7 +26,6 @@
   "fixed-elements-in-lightbox": 1,
   "flexAdSlots": 0.05,
   "hidden-mutation-observer": 1,
-  "intersect-resources": 1,
   "ios-fixed-no-transfer": 1,
   "layoutbox-invalidate-on-scroll": 1,
   "pump-early-frame": 1,

--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -678,7 +678,7 @@ export class Resource {
    * @return {boolean}
    */
   isDisplayed(usePremeasuredRect = false) {
-    devAssert(!usePremeasuredRect || !this.intersect_);
+    devAssert(!usePremeasuredRect || this.intersect_);
     const isFluid = this.element.getLayout() == Layout.FLUID;
     const box = usePremeasuredRect
       ? devAssert(this.premeasuredRect_)

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -1195,9 +1195,12 @@ export class ResourcesImpl {
         }
         // Difference: if we have a "premeasured" client rect, consume it
         // as the element's new measurements even if the element isn't built.
+        const requested = r.isMeasureRequested();
+        if (requested) {
+          dev().fine(TAG_, 'force remeasure:', r.debugid, premeasured);
+        }
         const premeasured = r.hasBeenPremeasured();
-        const needsMeasure =
-          premeasured || this.relayoutAll_ || r.isMeasureRequested();
+        const needsMeasure = premeasured || requested || this.relayoutAll_;
         if (needsMeasure) {
           const isDisplayed = this.measureResource_(
             r,

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -1197,7 +1197,7 @@ export class ResourcesImpl {
         // as the element's new measurements even if the element isn't built.
         const requested = r.isMeasureRequested();
         if (requested) {
-          dev().fine(TAG_, 'force remeasure:', r.debugid, premeasured);
+          dev().fine(TAG_, 'force remeasure:', r.debugid);
         }
         const premeasured = r.hasBeenPremeasured();
         const needsMeasure = premeasured || requested || this.relayoutAll_;


### PR DESCRIPTION
Related to #25428.

Also add a handy log for detecting forced remeasures e.g. due to `changeSize()`.