### PR TITLE
🏗 Debounce all `watch` operations in the AMP dev toolchain 

### DIFF
--- a/build-system/tasks/css.js
+++ b/build-system/tasks/css.js
@@ -14,12 +14,18 @@
  * limitations under the License.
  */
 
+const debounce = require('debounce');
 const file = require('gulp-file');
 const fs = require('fs-extra');
 const gulp = require('gulp');
 const gulpWatch = require('gulp-watch');
+const {
+  endBuildStep,
+  mkdirSync,
+  toPromise,
+  watchDebounceDelay,
+} = require('./helpers');
 const {buildExtensions, extensions} = require('./extension-helpers');
-const {endBuildStep, mkdirSync, toPromise} = require('./helpers');
 const {jsifyCssAsync} = require('./jsify-css');
 const {maybeUpdatePackages} = require('./update-packages');
 
@@ -75,9 +81,10 @@ const cssEntryPoints = [
  */
 function compileCss(watch) {
   if (watch) {
-    gulpWatch('css/**/*.css', function () {
+    const watchFunc = () => {
       compileCss();
-    });
+    };
+    gulpWatch('css/**/*.css', debounce(watchFunc, watchDebounceDelay));
   }
 
   /**

--- a/build-system/tasks/dist.js
+++ b/build-system/tasks/dist.js
@@ -25,7 +25,6 @@ const {
   compileCoreRuntime,
   compileJs,
   endBuildStep,
-  hostname,
   maybeToEsmName,
   mkdirSync,
   printConfigHelp,
@@ -55,12 +54,23 @@ const {VERSION} = require('../compile/internal-version');
 const {green, cyan} = colors;
 const argv = require('minimist')(process.argv.slice(2));
 
+/**
+ * Files that must be built for amp-web-push
+ */
 const WEB_PUSH_PUBLISHER_FILES = [
   'amp-web-push-helper-frame',
   'amp-web-push-permission-dialog',
 ];
 
+/**
+ * Versions that must be built for amp-web-push
+ */
 const WEB_PUSH_PUBLISHER_VERSIONS = ['0.1'];
+
+/**
+ * Used while building the experiments page.
+ */
+const hostname = argv.hostname || 'cdn.ampproject.org';
 
 /**
  * Prints a useful help message prior to the gulp dist task

--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -1143,6 +1143,7 @@ const forbiddenTermsSrcInclusive = {
       'build-system/server/shadow-viewer.js',
       'build-system/server/variable-substitution.js',
       'build-system/tasks/check-links.js',
+      'build-system/tasks/dist.js',
       'build-system/tasks/extension-generator/index.js',
       'build-system/tasks/helpers.js',
       'build-system/tasks/performance/helpers.js',

--- a/build-system/tasks/serve.js
+++ b/build-system/tasks/serve.js
@@ -16,6 +16,7 @@
 'use strict';
 
 const connect = require('gulp-connect');
+const debounce = require('debounce');
 const globby = require('globby');
 const header = require('connect-header');
 const log = require('fancy-log');
@@ -34,6 +35,7 @@ const {cyan, green, red} = require('ansi-colors');
 const {distNailgunPort, stopNailgunServer} = require('./nailgun');
 const {exec} = require('../common/exec');
 const {logServeMode, setServeMode} = require('../server/app-utils');
+const {watchDebounceDelay} = require('./helpers');
 
 const argv = minimist(process.argv.slice(2), {string: ['rtv']});
 
@@ -196,9 +198,10 @@ async function serve() {
  */
 async function doServe(lazyBuild = false) {
   createCtrlcHandler('serve');
-  watch(serverFiles, async () => {
+  const watchFunc = async () => {
     await restartServer();
-  });
+  };
+  watch(serverFiles, debounce(watchFunc, watchDebounceDelay));
   if (argv.new_server) {
     buildNewServer();
   }

--- a/build-system/tasks/vendor-configs.js
+++ b/build-system/tasks/vendor-configs.js
@@ -16,6 +16,7 @@
 
 const minimist = require('minimist');
 const argv = minimist(process.argv.slice(2));
+const debounce = require('debounce');
 const globby = require('globby');
 const gulp = require('gulp');
 const gulpif = require('gulp-if');
@@ -24,6 +25,7 @@ const jsonlint = require('gulp-jsonlint');
 const jsonminify = require('gulp-jsonminify');
 const rename = require('gulp-rename');
 const {endBuildStep, toPromise} = require('./helpers');
+const {watchDebounceDelay} = require('./helpers');
 
 /**
  * Entry point for 'gulp vendor-configs'
@@ -45,9 +47,10 @@ async function vendorConfigs(opt_options) {
   if (options.watch) {
     // Do not set watchers again when we get called by the watcher.
     const copyOptions = {...options, watch: false, calledByWatcher: true};
-    gulpWatch(srcPath, function () {
+    const watchFunc = () => {
       vendorConfigs(copyOptions);
-    });
+    };
+    gulpWatch(srcPath, debounce(watchFunc, watchDebounceDelay));
   }
 
   const startTime = Date.now();

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "commander": "5.0.0",
     "connect-header": "0.0.5",
     "cssnano": "4.1.10",
+    "debounce": "1.2.0",
     "del": "5.1.0",
     "derequire": "2.1.0",
     "dev-null": "0.1.1",

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "gulp-ava": "3.0.0",
     "gulp-babel": "8.0.0",
     "gulp-connect": "5.7.0",
+    "gulp-debounce": "1.0.2",
     "gulp-eslint": "6.0.0",
     "gulp-eslint-if-fixed": "1.0.0",
     "gulp-file": "0.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7993,6 +7993,13 @@ gulp-connect@5.7.0:
     serve-static "^1.13.2"
     tiny-lr "^1.1.1"
 
+gulp-debounce@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/gulp-debounce/-/gulp-debounce-1.0.2.tgz#0b943e812973e3003f980d88fc0d77e7996d9db9"
+  integrity sha1-C5Q+gSlz4wA/mA2I/A1355ltnbk=
+  dependencies:
+    through "^2.3.8"
+
 gulp-eslint-if-fixed@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/gulp-eslint-if-fixed/-/gulp-eslint-if-fixed-1.0.0.tgz#ebad1f2a92e2c6ed793b01daaf0081dcaaca0e26"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5482,6 +5482,11 @@ dateformat@^1.0.7-1.2.3:
     get-stdin "^4.0.1"
     meow "^3.3.0"
 
+debounce@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/debounce/-/debounce-1.2.0.tgz#44a540abc0ea9943018dc0eaa95cce87f65cd131"
+  integrity sha512-mYtLl1xfZLi1m4RtQYlZgJUNQjl4ZxVnHzIR8nLLgi4q1YT8o/WM+MK/f8yfcc9s5Ir5zRaPZyZU6xs1Syoocg==
+
 debug-fabulous@1.X:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/debug-fabulous/-/debug-fabulous-1.1.0.tgz#af8a08632465224ef4174a9f06308c3c2a1ebc8e"


### PR DESCRIPTION
**Background:**

Several tasks in AMP's `gulp` toolchain provide `watch` functionality to enable rebuild-on-edit behavior. However, if a file is saved more than once in a short interval (e.g. hitting Ctrl+S twice in succession), the watcher function is kicked off more than once, which can lead to [races in file writes](https://github.com/ampproject/amphtml/issues/27722#issue-599001542).

**PR highlights:**
- Uses [`debounce`](https://www.npmjs.com/package/debounce) for instances of `watchify` and `gulp-watch` that use a simple watcher function
- Uses [`gulp-debounce`](https://www.npmjs.com/package/gulp-debounce) for the one instance of `gulp-watch` that operates on the `gulp` stream
- Drive-by minor cleanup of `helpers.js`, `dist.js` and `lint.js`

**Tasks fixed by this PR:**
```sh
# Implicit watch
gulp
gulp serve

# Explicit watch
gulp build --watch
gulp dist --watch
gulp lint --watch
```


Fixes #27722
