### PR TITLE
Fix nasty race condition in AMP video

### DIFF
--- a/extensions/amp-video/0.1/amp-video.js
+++ b/extensions/amp-video/0.1/amp-video.js
@@ -321,6 +321,10 @@ class AmpVideo extends AMP.BaseElement {
 
     this.propagateCachedSources_();
 
+    const videoLoaded = () => {
+      this.element.dispatchCustomEvent(VideoEvents.LOAD);
+    };
+
     // If we are in prerender mode, only propagate cached sources and then
     // when document becomes visible propagate origin sources and other children
     // If not in prerender mode, propagate everything.
@@ -338,7 +342,8 @@ class AmpVideo extends AMP.BaseElement {
           // load.
           return Services.timerFor(this.win)
             .promise(1)
-            .then(() => this.loadPromise(this.video_));
+            .then(() => this.loadPromise(this.video_))
+            .then(videoLoaded);
         });
     } else {
       this.propagateLayoutChildren_();
@@ -346,9 +351,7 @@ class AmpVideo extends AMP.BaseElement {
 
     // loadPromise for media elements listens to `loadedmetadata`.
     const promise = this.loadPromise(this.video_).then(
-      () => {
-        this.element.dispatchCustomEvent(VideoEvents.LOAD);
-      },
+      videoLoaded,
       (reason) => {
         if (pendingOriginPromise) {
           return pendingOriginPromise;

--- a/extensions/amp-video/0.1/amp-video.js
+++ b/extensions/amp-video/0.1/amp-video.js
@@ -165,7 +165,7 @@ class AmpVideo extends AMP.BaseElement {
 
   /**
    * @private
-   * @return {?string}
+   * @return {!Array<string>}
    */
   getVideoSourcesForPreconnect_() {
     const videoSrc = this.element.getAttribute('src');
@@ -178,6 +178,7 @@ class AmpVideo extends AMP.BaseElement {
       if (src) {
         srcs.push(src);
       }
+      // We also want to preconnect to the origin src to make fallback faster.
       const origSrc = source.getAttribute('amp-orig-src');
       if (origSrc) {
         srcs.push(origSrc);

--- a/extensions/amp-video/0.1/amp-video.js
+++ b/extensions/amp-video/0.1/amp-video.js
@@ -15,6 +15,10 @@
  */
 
 import {EMPTY_METADATA} from '../../../src/mediasession-helper';
+import {
+  MEDIA_LOAD_FAILURE_SRC_PROPERTY,
+  listen,
+} from '../../../src/event-helper';
 import {Services} from '../../../src/services';
 import {VideoEvents} from '../../../src/video-interface';
 import {VisibilityState} from '../../../src/visibility-state';
@@ -35,10 +39,6 @@ import {htmlFor} from '../../../src/static-template';
 import {installVideoManagerForDoc} from '../../../src/service/video-manager-impl';
 import {isExperimentOn} from '../../../src/experiments';
 import {isLayoutSizeDefined} from '../../../src/layout';
-import {
-  listen,
-  MEDIA_LOAD_FAILURE_SRC_PROPERTY,
-} from '../../../src/event-helper';
 import {mutedOrUnmutedEvent} from '../../../src/iframe-video';
 import {
   propagateObjectFitStyles,

--- a/extensions/amp-video/0.1/amp-video.js
+++ b/extensions/amp-video/0.1/amp-video.js
@@ -172,9 +172,18 @@ class AmpVideo extends AMP.BaseElement {
     if (videoSrc) {
       return [videoSrc];
     }
-    return toArray(childElementsByTag(this.element, 'source')).map((source) =>
-      source.getAttribute('src')
-    );
+    const srcs = [];
+    childElementsByTag(this.element, 'source').forEach((source) => {
+      const src = source.getAttribute('src');
+      if (src) {
+        srcs.push(src);
+      }
+      const origSrc = source.getAttribute('amp-orig-src');
+      if (origSrc) {
+        srcs.push(origSrc);
+      }
+    });
+    return srcs;
   }
 
   /** @override */

--- a/extensions/amp-video/0.1/amp-video.js
+++ b/extensions/amp-video/0.1/amp-video.js
@@ -321,10 +321,6 @@ class AmpVideo extends AMP.BaseElement {
 
     this.propagateCachedSources_();
 
-    const videoLoaded = () => {
-      this.element.dispatchCustomEvent(VideoEvents.LOAD);
-    };
-
     // If we are in prerender mode, only propagate cached sources and then
     // when document becomes visible propagate origin sources and other children
     // If not in prerender mode, propagate everything.
@@ -342,23 +338,23 @@ class AmpVideo extends AMP.BaseElement {
           // load.
           return Services.timerFor(this.win)
             .promise(1)
-            .then(() => this.loadPromise(this.video_))
-            .then(videoLoaded);
+            .then(() => this.loadPromise(this.video_));
         });
     } else {
       this.propagateLayoutChildren_();
     }
 
     // loadPromise for media elements listens to `loadedmetadata`.
-    const promise = this.loadPromise(this.video_).then(
-      videoLoaded,
-      (reason) => {
+    const promise = this.loadPromise(this.video_)
+      .then(null, (reason) => {
         if (pendingOriginPromise) {
           return pendingOriginPromise;
         }
         throw reason;
-      }
-    );
+      })
+      .then(() => {
+        this.element.dispatchCustomEvent(VideoEvents.LOAD);
+      });
 
     // Resolve layoutCallback right away if the video won't preload.
     if (this.element.getAttribute('preload') === 'none') {

--- a/extensions/amp-video/0.1/test/test-amp-video.js
+++ b/extensions/amp-video/0.1/test/test-amp-video.js
@@ -42,7 +42,12 @@ describes.realWin(
       return '//someHost/foo.' + filetype.slice(filetype.indexOf('/') + 1); // assumes no optional params
     }
 
-    async function getVideo(attributes, children, opt_beforeLayoutCallback) {
+    async function getVideo(
+      attributes,
+      children,
+      opt_beforeLayoutCallback,
+      opt_noLayout
+    ) {
       const v = doc.createElement('amp-video');
       for (const key in attributes) {
         v.setAttribute(key, attributes[key]);
@@ -55,6 +60,9 @@ describes.realWin(
       doc.body.appendChild(v);
       await v.build();
 
+      if (opt_noLayout) {
+        return;
+      }
       if (opt_beforeLayoutCallback) {
         opt_beforeLayoutCallback(v);
       }
@@ -834,14 +842,23 @@ describes.realWin(
         });
 
         it('no cached source', async () => {
-          await getVideo({
-            src: 'https://example.com/video.mp4',
-            poster: 'https://example.com/poster.jpg',
-            width: 160,
-            height: 90,
-          });
+          await getVideo(
+            {
+              src: 'https://example.com/video.mp4',
+              poster: 'https://example.com/poster.jpg',
+              width: 160,
+              height: 90,
+            },
+            null,
+            null,
+            /* opt_noLayout */ true
+          );
 
-          expect(preconnect.url).to.not.have.been.called;
+          expect(preconnect.url).to.have.been.calledOnce;
+          expect(preconnect.url.getCall(0)).to.have.been.calledWith(
+            env.sandbox.match.object, // AmpDoc
+            'https://example.com/video.mp4'
+          );
         });
 
         it('cached source', async () => {
@@ -861,7 +878,9 @@ describes.realWin(
               width: 160,
               height: 90,
             },
-            [cachedSource]
+            [cachedSource],
+            null,
+            /* opt_noLayout */ true
           );
 
           expect(preconnect.url).to.have.been.calledOnce;
@@ -873,7 +892,7 @@ describes.realWin(
 
         it('mixed sources', async () => {
           const source = doc.createElement('source');
-          source.setAttribute('src', 'video.mp4');
+          source.setAttribute('src', 'https://example.com/video.mp4');
 
           const cachedSource = doc.createElement('source');
           cachedSource.setAttribute(
@@ -890,10 +909,16 @@ describes.realWin(
               width: 160,
               height: 90,
             },
-            [source, cachedSource]
+            [source, cachedSource],
+            null,
+            /* opt_noLayout */ true
           );
-          expect(preconnect.url).to.have.been.calledOnce;
+          expect(preconnect.url).to.have.been.calledTwice;
           expect(preconnect.url.getCall(0)).to.have.been.calledWith(
+            env.sandbox.match.object, // AmpDoc
+            'https://example.com/video.mp4'
+          );
+          expect(preconnect.url.getCall(1)).to.have.been.calledWith(
             env.sandbox.match.object, // AmpDoc
             'https://example-com.cdn.ampproject.org/m/s/video.mp4'
           );

--- a/extensions/amp-video/0.1/test/test-amp-video.js
+++ b/extensions/amp-video/0.1/test/test-amp-video.js
@@ -833,7 +833,7 @@ describes.realWin(
         });
       });
 
-      describe('should preconnect to the first cached source', () => {
+      describe('should preconnect to all sources', () => {
         let preconnect;
 
         beforeEach(() => {
@@ -883,10 +883,14 @@ describes.realWin(
             /* opt_noLayout */ true
           );
 
-          expect(preconnect.url).to.have.been.calledOnce;
+          expect(preconnect.url).to.have.been.calledTwice;
           expect(preconnect.url.getCall(0)).to.have.been.calledWith(
             env.sandbox.match.object, // AmpDoc
             'https://example-com.cdn.ampproject.org/m/s/video.mp4'
+          );
+          expect(preconnect.url.getCall(1)).to.have.been.calledWith(
+            env.sandbox.match.object, // AmpDoc
+            'https://example.com/video.mp4'
           );
         });
 
@@ -913,7 +917,7 @@ describes.realWin(
             null,
             /* opt_noLayout */ true
           );
-          expect(preconnect.url).to.have.been.calledTwice;
+          expect(preconnect.url).to.have.been.calledThrice;
           expect(preconnect.url.getCall(0)).to.have.been.calledWith(
             env.sandbox.match.object, // AmpDoc
             'https://example.com/video.mp4'
@@ -921,6 +925,10 @@ describes.realWin(
           expect(preconnect.url.getCall(1)).to.have.been.calledWith(
             env.sandbox.match.object, // AmpDoc
             'https://example-com.cdn.ampproject.org/m/s/video.mp4'
+          );
+          expect(preconnect.url.getCall(2)).to.have.been.calledWith(
+            env.sandbox.match.object, // AmpDoc
+            'https://example.com/video.mp4'
           );
         });
       });

--- a/src/preconnect.js
+++ b/src/preconnect.js
@@ -112,6 +112,13 @@ export class PreconnectService {
   /**
    * Preconnects to a URL. Always also does a dns-prefetch because
    * browser support for that is better.
+   *
+   * It is safe to call this method during prerender with any value,
+   * because no action will be performed until the doc is visible.
+   *
+   * It is safe to call this method with non-HTTP(s) URLs as other URLs
+   * are skipped.
+   *
    * @param {!./service/ampdoc-impl.AmpDoc} ampdoc
    * @param {string} url
    * @param {boolean=} opt_alsoConnecting Set this flag if you also just
@@ -192,6 +199,12 @@ export class PreconnectService {
   /**
    * Asks the browser to preload a URL. Always also does a preconnect
    * because browser support for that is better.
+   *
+   * It is safe to call this method during prerender with any value,
+   * because no action will be performed until the doc is visible.
+   *
+   * It is safe to call this method with non-HTTP(s) URLs as other URLs
+   * are skipped.
    *
    * @param {!./service/ampdoc-impl.AmpDoc} ampdoc
    * @param {string} url


### PR DESCRIPTION
Under this scenario a video might not fall back to the origin on pre-render.
Possible fix for #27109

Reproduces by navigating (locally) to [page with a video on page one in prerender mode](http://localhost:8000/proxy/s/stories.nonblocking.io/waffles/?usqp=mq331AQFKAGwASA%3D&amp_js_v=0.1#referrer=https%3A%2F%2Fwww.google.com&visibilityState=prerender&cap=swipe&ampshare=https%3A%2F%2Funumbox.com%2Fwebsite-development-trends-2020-amp-story%2F),
waiting for the prerender load to fail, and then executing `AMP.viewer.receiveMessage('visibilitychange', {'state': 'visible'})` in the console.

If this if not a fix for #27109, then it might be the same race, but elsewhere. The problem is that you cannot wait for `loadPromise` on a video element that has failed a source and has just had a new source provided, because `currentSrc` hasn't been updated yet.

There might be a more elegant fix. Lots of fixes that I thought should have worked, didn't :)

## Other changes

- Preconnects to all sources of a video to improve performance.
- Documents that that is safe.