### PR TITLE
📖 [amp-social-share] Add basic bento storybook story for amp-social-share component

### DIFF
--- a/extensions/amp-social-share/0.2/social-share.js
+++ b/extensions/amp-social-share/0.2/social-share.js
@@ -83,6 +83,7 @@ export function SocialShare(props) {
       onClick={handleActivation}
       style={{...size, ...props['style']}}
       {...props}
+      aria-label={`amp-social-share component of type: ${type}`}
     >
       <SocialShareIcon
         style={{...backgroundStyle, ...baseStyle, ...size}}

--- a/extensions/amp-social-share/0.2/storybook/Basic.js
+++ b/extensions/amp-social-share/0.2/storybook/Basic.js
@@ -18,7 +18,7 @@ import * as Preact from '../../../../src/preact';
 import {SocialShare} from '../social-share';
 import {addParamsToUrl} from '../../../../src/url';
 import {getSocialConfig} from '../amp-social-share-config';
-import {select, withKnobs} from '@storybook/addon-knobs';
+import {select, text, withKnobs} from '@storybook/addon-knobs';
 import {withA11y} from '@storybook/addon-a11y';
 
 export default {
@@ -39,24 +39,25 @@ export const _default = () => {
     'line',
     'sms',
     'system',
+    'custom endpoint',
   ];
-  const type = select(
-    'Provider Type',
-    knobConfigurations,
-    knobConfigurations[0],
-    'type'
-  );
+  let type = select('Provider Type', knobConfigurations, knobConfigurations[0]);
+  let href = text('Custom Share Endpoint', 'Not Specified');
+
   const config = getSocialConfig(type);
+  if (type !== 'custom endpoint') {
+    href = addParamsToUrl(config.shareEndpoint, config.defaultParams);
+  } else {
+    type = 'system';
+  }
   return (
     <div>
       <p>
         Click the button below to share this page using the configured provider.
-        Update the provider using storybook knobs.
+        Update the provider using storybook knobs. Choose Provider Type: 'custom
+        endpoint' to specify your own share endpoint.
       </p>
-      <SocialShare
-        type={type}
-        href={addParamsToUrl(config.shareEndpoint, config.defaultParams)}
-      />
+      <SocialShare type={type} href={href} />
     </div>
   );
 };

--- a/extensions/amp-social-share/0.2/storybook/Basic.js
+++ b/extensions/amp-social-share/0.2/storybook/Basic.js
@@ -1,0 +1,62 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as Preact from '../../../../src/preact';
+import {SocialShare} from '../social-share';
+import {addParamsToUrl} from '../../../../src/url';
+import {getSocialConfig} from '../amp-social-share-config';
+import {select, withKnobs} from '@storybook/addon-knobs';
+import {withA11y} from '@storybook/addon-a11y';
+
+export default {
+  title: 'Social Share',
+  component: SocialShare,
+  decorators: [withA11y, withKnobs],
+};
+
+export const _default = () => {
+  const knobConfigurations = [
+    'email',
+    'facebook',
+    'linkedin',
+    'pinterest',
+    'tumblr',
+    'twitter',
+    'whatsapp',
+    'line',
+    'sms',
+    'system',
+  ];
+  const type = select(
+    'Provider Type',
+    knobConfigurations,
+    knobConfigurations[0],
+    'type'
+  );
+  const config = getSocialConfig(type);
+  return (
+    <div>
+      <p>
+        Click the button below to share this page using the configured provider.
+        Update the provider using storybook knobs.
+      </p>
+      <SocialShare
+        type={type}
+        href={addParamsToUrl(config.shareEndpoint, config.defaultParams)}
+      />
+    </div>
+  );
+};


### PR DESCRIPTION
Add basic storybook story for amp-social-share component

Includes a change to preact amp-social-share file to include aria-label attribute.  (This is used for accessibility, and without the label an accessibility error is triggered in storybook.)

aria-label is used for screenreaders

---

My understanding of bento is limited so please feel free to recommend changes