### PR TITLE
[amp-story-player] 🐛 Fixes firefox bug

### DIFF
--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -358,7 +358,7 @@ const forbiddenTerms = {
       'dist.3p/current/integration.js',
       'extensions/amp-access/0.1/amp-login-done.js',
       'extensions/amp-viewer-integration/0.1/examples/amp-viewer-host.js',
-      'src/amp-story-player-impl.js',
+      'src/amp-story-player-manager.js',
       'src/runtime.js',
       'src/log.js',
       'src/web-worker/web-worker.js',

--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -358,6 +358,7 @@ const forbiddenTerms = {
       'dist.3p/current/integration.js',
       'extensions/amp-access/0.1/amp-login-done.js',
       'extensions/amp-viewer-integration/0.1/examples/amp-viewer-host.js',
+      'src/amp-story-player-impl.js',
       'src/runtime.js',
       'src/log.js',
       'src/web-worker/web-worker.js',

--- a/src/amp-story-player-impl.js
+++ b/src/amp-story-player-impl.js
@@ -134,8 +134,7 @@ export class AmpStoryPlayer {
 
   /** @public */
   buildCallback() {
-    initLogConstructor();
-    this.stories_ = toArray(this.querySelectorAll('a'));
+    this.stories_ = toArray(this.element_.querySelectorAll('a'));
 
     this.initializeShadowRoot_();
     this.initializeIframes_();

--- a/src/amp-story-player-impl.js
+++ b/src/amp-story-player-impl.js
@@ -14,26 +14,18 @@
  * limitations under the License.
  */
 
-<<<<<<< HEAD
-=======
-import {AmpStoryPlayerManager} from './amp-story-player-manager';
 import {IframePool} from './amp-story-player-iframe-pool';
->>>>>>> a808afbee... fixes firefox bug
 import {Messaging} from '@ampproject/viewer-messaging';
+import {VisibilityState} from './visibility-state';
 import {
   addParamsToUrl,
   getFragment,
   parseUrlWithA,
   removeFragment,
 } from './url';
+import {applySandbox} from './3p-frame';
 import {dict, map} from './utils/object';
 // Source for this constant is css/amp-story-player-iframe.css
-<<<<<<< HEAD
-import {IframePool} from './amp-story-player-iframe-pool';
-import {VisibilityState} from './visibility-state';
-import {applySandbox} from './3p-frame';
-=======
->>>>>>> a808afbee... fixes firefox bug
 import {cssText} from '../build/amp-story-player-iframe.css';
 import {initLogConstructor} from './log';
 import {resetStyles, setStyle, setStyles} from './style';
@@ -140,8 +132,8 @@ export class AmpStoryPlayer {
     return this.element_;
   }
 
-  /** @private */
-  buildCallback_() {
+  /** @public */
+  buildCallback() {
     initLogConstructor();
     this.stories_ = toArray(this.querySelectorAll('a'));
 

--- a/src/amp-story-player-impl.js
+++ b/src/amp-story-player-impl.js
@@ -27,7 +27,6 @@ import {applySandbox} from './3p-frame';
 import {dict, map} from './utils/object';
 // Source for this constant is css/amp-story-player-iframe.css
 import {cssText} from '../build/amp-story-player-iframe.css';
-import {initLogConstructor} from './log';
 import {resetStyles, setStyle, setStyles} from './style';
 import {toArray} from './types';
 

--- a/src/amp-story-player-impl.js
+++ b/src/amp-story-player-impl.js
@@ -14,6 +14,11 @@
  * limitations under the License.
  */
 
+<<<<<<< HEAD
+=======
+import {AmpStoryPlayerManager} from './amp-story-player-manager';
+import {IframePool} from './amp-story-player-iframe-pool';
+>>>>>>> a808afbee... fixes firefox bug
 import {Messaging} from '@ampproject/viewer-messaging';
 import {
   addParamsToUrl,
@@ -23,10 +28,14 @@ import {
 } from './url';
 import {dict, map} from './utils/object';
 // Source for this constant is css/amp-story-player-iframe.css
+<<<<<<< HEAD
 import {IframePool} from './amp-story-player-iframe-pool';
 import {VisibilityState} from './visibility-state';
 import {applySandbox} from './3p-frame';
+=======
+>>>>>>> a808afbee... fixes firefox bug
 import {cssText} from '../build/amp-story-player-iframe.css';
+import {initLogConstructor} from './log';
 import {resetStyles, setStyle, setStyles} from './style';
 import {toArray} from './types';
 
@@ -131,9 +140,10 @@ export class AmpStoryPlayer {
     return this.element_;
   }
 
-  /** @public */
-  buildCallback() {
-    this.stories_ = toArray(this.element_.querySelectorAll('a'));
+  /** @private */
+  buildCallback_() {
+    initLogConstructor();
+    this.stories_ = toArray(this.querySelectorAll('a'));
 
     this.initializeShadowRoot_();
     this.initializeIframes_();

--- a/src/amp-story-player-manager.js
+++ b/src/amp-story-player-manager.js
@@ -15,6 +15,7 @@
  */
 
 import {AmpStoryPlayer} from './amp-story-player-impl';
+import {initLogConstructor} from './log';
 import {throttle} from './utils/rate-limit';
 
 /** @const {string} */
@@ -98,6 +99,7 @@ export class AmpStoryPlayerManager {
   loadPlayers() {
     const doc = this.win_.document;
     const players = doc.getElementsByTagName('amp-story-player');
+    initLogConstructor();
     for (let i = 0; i < players.length; i++) {
       const playerEl = players[i];
       const player = new AmpStoryPlayer(this.win_, playerEl);


### PR DESCRIPTION
Fixes  #27538

When calling `applySandbox()`, `devAssert()` was being called since one of the flags in the sandbox of the iframe isn't allowed in firefox. And since `devAssert()` hasn't been initialized, it was throwing an error. Calling `initLogConstructor()` initializes it.


<!--
# Instructions:

- Pick a meaningful title for your pull request. (Use sentence case.)
  - Prefix the title with an emoji to identify what is being done. (Copy-paste the emoji from the list below.)
  - Do not overuse punctuation in the title (like `(chore):`).
  - If it is helpful, use a simple prefix (like `ProjectX: Implement some feature`).
- Enter a succinct description that says why the PR is necessary, and what it does.
  - Mention the GitHub issue that is being addressed by the pull request.
  - The keywords `Fixes`, `Closes`, or `Resolves` followed the issue number will automatically close the issue.

> NOTE: All non-trivial changes (like introducing new features or components) should have an associated issue or reference an I2I (intent-to-implement: go.amp.dev/i2i). Please read through the contribution process (go.amp.dev/contributing/code) for more information.

# Example of a good description:

- Implement aspect X
- Leave out feature Y because of A
- Improve performance by B
- Improve accessibility by C

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Reverting a previous change
♻️ Refactoring
🚮 Deleting code
-->
