### PR TITLE
mutator: skip an extra measure

### DIFF
--- a/src/service/mutator-impl.js
+++ b/src/service/mutator-impl.js
@@ -225,7 +225,7 @@ export class MutatorImpl {
         }
         // With IntersectionObserver, "relayout top" is no longer needed since
         // relative positional changes won't affect correctness.
-        if (!this.intersect_) {
+        if (!this.intersect_ && !skipRemeasure) {
           relayoutTop = calcRelayoutTop();
         }
       },


### PR DESCRIPTION
**summary**
No point in calling `calcRelayoutTop` if we aren't going to remeasure anyway.