### PR TITLE
🏗 Do not write sourcesContent in sourcemaps unless requested

### DIFF
--- a/build-system/compile/debug-compilation-lifecycle.js
+++ b/build-system/compile/debug-compilation-lifecycle.js
@@ -41,16 +41,24 @@ const LIFECYCLES = {
  *
  * @param {string} lifecycle
  * @param {string} fullpath
- * @param {string} content
+ * @param {Buffer} content
+ * @param {Object} sourcemap
  */
-function debug(lifecycle, fullpath, content) {
+function debug(lifecycle, fullpath, content, sourcemap) {
   if (argv.debug && Object.keys(LIFECYCLES).includes(lifecycle)) {
+    const contentsPath = tempy.writeSync(content);
+    if (sourcemap) {
+      fs.writeFileSync(
+        `${contentsPath}.map`,
+        JSON.stringify(sourcemap, null, 4)
+      );
+    }
     fs.appendFileSync(
       logFile,
       `${pad(lifecycle, 20)}: ${pad(
         path.basename(fullpath),
         30
-      )} ${tempy.writeSync(content)}\n`
+      )} ${contentsPath}\n`
     );
   }
 }

--- a/build-system/compile/helpers.js
+++ b/build-system/compile/helpers.js
@@ -38,6 +38,7 @@ function getSourceMapBase() {
 function writeSourcemaps() {
   return sourcemaps.write('.', {
     sourceRoot: getSourceMapBase(),
+    includeContent: !!argv.full_sourcemaps,
   });
 }
 

--- a/build-system/compile/pre-closure-babel.js
+++ b/build-system/compile/pre-closure-babel.js
@@ -85,7 +85,12 @@ function preClosureBabel() {
     }
 
     let data, err;
-    debug(CompilationLifecycles['pre-babel'], file.path, file.contents);
+    debug(
+      CompilationLifecycles['pre-babel'],
+      file.path,
+      file.contents,
+      file.sourceMap
+    );
     function onData(d) {
       babel.off('error', onError);
       data = d;
@@ -104,7 +109,8 @@ function preClosureBabel() {
       debug(
         CompilationLifecycles['pre-closure'],
         file.path,
-        data.contents.toString('utf8')
+        data.contents,
+        data.sourceMap
       );
       cache[path] = {
         file: data,


### PR DESCRIPTION
Also adds sourcemaps debugging at each stage in the compilation process.