### PR TITLE
Display fallbacks in `amp-lightbox-gallery` if original `amp-img` is unsupported

### DIFF
--- a/examples/lightbox-gallery.amp.html
+++ b/examples/lightbox-gallery.amp.html
@@ -1,0 +1,146 @@
+<!DOCTYPE html>
+<html ⚡>
+  <head>
+    <meta charset="utf-8">
+    <link rel="canonical" href="https://amp.dev/documentation/examples/components/amp-lightbox-gallery/index.html">
+    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+    <script async src="https://cdn.ampproject.org/v0.js"></script>
+    <title>amp-lightbox-gallery</title>
+    <script async custom-element="amp-lightbox-gallery" src="https://cdn.ampproject.org/v0/amp-lightbox-gallery-0.1.js"></script>
+    <script async custom-element="amp-carousel" src="https://cdn.ampproject.org/v0/amp-carousel-0.1.js"></script>
+    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+    <style amp-custom>
+      amp-carousel{
+        max-width: 400px;
+        margin-bottom: 100px;
+      }
+    </style>
+  </head>
+  <body>
+    <h2>AMP lightbox gallery with just regualar old jpgs.</h2>
+    <amp-img
+      lightbox
+      src="https://picsum.photos/id/494/400/400.jpg"
+      layout="fixed"
+      width="400"
+      height="400"
+    >
+    </amp-img>
+    <amp-img
+      lightbox
+      src="https://picsum.photos/id/525/400/400.jpg"
+      layout="fixed"
+      width="400"
+      height="400"
+    >
+    </amp-img>
+    <amp-img
+      lightbox
+      src="https://picsum.photos/id/78/400/400.jpg"
+      layout="fixed"
+      width="400"
+      height="400"
+    >
+    </amp-img>
+
+    <h2>AMP lightbox gallery with webp and jpeg fallback.</h2>
+    <p>This doesnt work in browsers that doesnt support webp</p>
+    <amp-img
+      lightbox
+      src="https://picsum.photos/id/494/400/400sdfsdf.webp"
+      layout="fixed"
+      width="400"
+      height="400"
+    >
+      <amp-img
+        fallback
+        src="https://picsum.photos/id/494/400/400.jpg"
+        layout="fill"
+      ></amp-img>
+    </amp-img>
+    <amp-img
+      lightbox
+      src="https://picsum.photos/id/525/400/400.webp"
+      layout="fixed"
+      width="400"
+      height="400"
+    >
+      <amp-img
+        fallback
+        src="https://picsum.photos/id/525/400/400.jpg"
+        layout="fill"
+      ></amp-img>
+    </amp-img>
+    <amp-img
+      lightbox
+      src="https://picsum.photos/id/78/400/400.webp"
+      layout="fixed"
+      width="400"
+      height="400"
+    >
+      <amp-img
+        fallback
+        src="https://picsum.photos/id/78/400/400.jpg"
+        layout="fill"
+      ></amp-img>
+    </amp-img>
+
+    <h2>AMP Carousel with just regualar old jpgs.</h2>
+    <amp-carousel
+      class="storslider"
+      width="400"
+      height="400"
+      layout="fixed"
+      type="slides"
+      lightbox
+      loop
+    >
+      <amp-img
+        src="https://picsum.photos/id/494/400/400.jpg"
+        layout="fill"
+      ></amp-img>
+      <amp-img
+        src="https://picsum.photos/id/525/400/400.jpg"
+        layout="fill"
+      ></amp-img>
+      <amp-img
+        src="https://picsum.photos/id/78/400/400.jpg"
+        layout="fill"
+      ></amp-img>
+    </amp-carousel>
+
+    <h2>AMP Carousel with webp and jpeg fallback.</h2>
+    <p>This doesnt work in browsers that doesnt support webp</p>
+    <amp-carousel
+      class="storslider"
+      width="400"
+      height="400"
+      layout="fixed"
+      type="slides"
+      lightbox
+      loop
+    >
+      <amp-img src="https://picsum.photos/id/494/400/400.webp" layout="fill">
+        <amp-img
+          fallback
+          src="https://picsum.photos/id/494/400/400.jpg"
+          layout="fill"
+        ></amp-img>
+      </amp-img>
+      <amp-img src="https://picsum.photos/id/525/400/400.webp" layout="fill">
+        <amp-img
+          fallback
+          src="https://picsum.photos/id/525/400/400.jpg"
+          layout="fill"
+        ></amp-img>
+      </amp-img>
+      <amp-img src="https://picsum.photos/id/78/400/400.webp" layout="fill">
+        <amp-img
+          fallback
+          src="https://picsum.photos/id/78/400/400.jpg"
+          layout="fill"
+        ></amp-img>
+      </amp-img>
+    </amp-carousel>
+  </body>
+</html>

--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
@@ -273,15 +273,22 @@ export class AmpLightboxGallery extends AMP.BaseElement {
    * Return a cleaned clone of the given element for building
    * carousel slides with.
    * @param {!Element} element
-   * @return {*} TODO(#23582): Specify return type
+   * @return {!Element}
    * @private
    */
   cloneLightboxableElement_(element) {
+    const fallback = element.getFallback();
+    const shouldCloneFallback =
+      element.classList.contains('amp-notsupported') && !!fallback;
+    if (shouldCloneFallback) {
+      element = fallback;
+    }
     const deepClone = !element.classList.contains('i-amphtml-element');
     const clonedNode = element.cloneNode(deepClone);
     clonedNode.removeAttribute('on');
     clonedNode.removeAttribute('id');
     clonedNode.removeAttribute('i-amphtml-layout');
+    clonedNode.removeAttribute('fallback');
     return clonedNode;
   }
   /**


### PR DESCRIPTION
Fixes #25804 

Currently an `amp-img` is cloned to its lightbox view without its associated fallback. For cases i.e. webp sourced images and non-webp fallbacks, the lightbox gallery will display nothing in browsers that do not support webp. This change modifies the `amp-lightbox-gallery` to detect if its target image has resorted to its fallback, and if so, to lightbox the fallback element instead.