### PR TITLE
🏗Don't throw an error when an unrecognized `babel` caller is encountered

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -59,16 +59,16 @@ const babelTransforms = new Map([
  * @return {!Object}
  */
 module.exports = function (api) {
-  const caller = api.caller((caller) => {
-    return caller ? caller.name : '<unnamed>';
+  const callerName = api.caller((callerObj) => {
+    return callerObj ? callerObj.name : '<unnamed>';
   });
-  if (caller && babelTransforms.has(caller)) {
-    return babelTransforms.get(caller);
+  if (callerName && babelTransforms.has(callerName)) {
+    return babelTransforms.get(callerName);
   } else {
     log(
       yellow('WARNING:'),
       'Unrecognized Babel caller',
-      cyan(caller),
+      cyan(callerName),
       '(see babel.config.js).'
     );
     return {};

--- a/babel.config.js
+++ b/babel.config.js
@@ -15,7 +15,7 @@
  */
 
 /**
- * @fileoverview Global configuration file for the babelify transform.
+ * @fileoverview Global configuration file for various babel transforms.
  *
  * Notes: From https://babeljs.io/docs/en/plugins#plugin-ordering:
  * 1. Plugins run before Presets.
@@ -25,6 +25,7 @@
 
 'use strict';
 
+const log = require('fancy-log');
 const {
   getDepCheckConfig,
   getPostClosureConfig,
@@ -34,6 +35,7 @@ const {
   getTestConfig,
   getUnminifiedConfig,
 } = require('./build-system/babel-config');
+const {cyan, yellow} = require('ansi-colors');
 
 /**
  * Mapping of babel transform callers to their corresponding babel configs.
@@ -50,18 +52,25 @@ const babelTransforms = new Map([
 ]);
 
 /**
- * Main entry point. Returns babel config corresponding to the caller.
+ * Main entry point. Returns babel config corresponding to the caller, or a
+ * blank config if the caller is unrecognized.
  *
  * @param {!Object} api
  * @return {!Object}
  */
 module.exports = function (api) {
-  const caller = api.caller((caller) => caller.name);
-  if (babelTransforms.has(caller)) {
+  const caller = api.caller((caller) => {
+    return caller ? caller.name : '<unnamed>';
+  });
+  if (caller && babelTransforms.has(caller)) {
     return babelTransforms.get(caller);
   } else {
-    const err = new Error('Unrecognized Babel caller (see babel.config.js).');
-    err.showStack = false;
-    throw err;
+    log(
+      yellow('WARNING:'),
+      'Unrecognized Babel caller',
+      cyan(caller),
+      '(see babel.config.js).'
+    );
+    return {};
   }
 };


### PR DESCRIPTION
#27576 added a check to make sure none of AMP's `gulp` commands would inadvertently use the wrong babel config. However, this works badly with dev dependencies that use babel under the covers. For example, see the comment thread starting at https://github.com/ampproject/amphtml/issues/27718#issuecomment-613611374

This PR does two things:
- Makes caller extraction resilient to the case where there's no caller at all
- Prints a warning instead of throwing an error when an unrecognized / empty caller is encountered

Partially fixes #27718