### PR TITLE
🐛 Force Web Animations polyfill on Safari

### DIFF
--- a/extensions/amp-animation/0.1/web-animations-polyfill.js
+++ b/extensions/amp-animation/0.1/web-animations-polyfill.js
@@ -19,16 +19,23 @@ import {installWebAnimations} from 'web-animations-js/web-animations.install';
 const POLYFILLED = '__AMP_WA';
 
 /**
+ * Force Web Animations polyfill on Safari.
+ * Native Web Animations on WebKit do not respect easing for individual
+ * keyframes and break overall timing. See https://go.amp.dev/issue/27762 and
+ * https://bugs.webkit.org/show_bug.cgi?id=210526
+ * @param {!Window} win
+ */
+function forceOnSafari(win) {
+  if (Services.platformFor(win).isSafari()) {
+    win.document.documentElement.animate = () => /** @type {!Animation} */ ({});
+  }
+}
+
+/**
  * @param {!Window} win
  */
 export function installWebAnimationsIfNecessary(win) {
-  // Force polyfill in Safari. Native Web Animations on WebKit do not respect
-  // easing for individual keyframes and break overall timing. See:
-  // https://go.amp.dev/issue/27762
-  // https://bugs.webkit.org/show_bug.cgi?id=210526
-  if (Services.platformFor(win).isSafari()) {
-    win.document.documentElement.animate = () => {};
-  }
+  forceOnSafari(win);
   if (!win[POLYFILLED]) {
     win[POLYFILLED] = true;
     installWebAnimations(win);

--- a/extensions/amp-animation/0.1/web-animations-polyfill.js
+++ b/extensions/amp-animation/0.1/web-animations-polyfill.js
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import {Services} from '../../../src/services';
 import {installWebAnimations} from 'web-animations-js/web-animations.install';
 
 const POLYFILLED = '__AMP_WA';
@@ -21,6 +22,13 @@ const POLYFILLED = '__AMP_WA';
  * @param {!Window} win
  */
 export function installWebAnimationsIfNecessary(win) {
+  // Force polyfill in Safari. Native Web Animations on WebKit do not respect
+  // easing for individual keyframes and break overall timing. See:
+  // https://go.amp.dev/issue/27762
+  // https://bugs.webkit.org/show_bug.cgi?id=210526
+  if (Services.platformFor(win).isSafari()) {
+    win.document.documentElement.animate = () => {};
+  }
   if (!win[POLYFILLED]) {
     win[POLYFILLED] = true;
     installWebAnimations(win);


### PR DESCRIPTION
Native Web Animations on WebKit do not respect easing for individual keyframes and break overall timing.

Fixes #27762 as a workaround for https://bugs.webkit.org/show_bug.cgi?id=210526

This was the only technique I could find that forces the polyfill across multiple checks. Alternatives tried:

1. Setting a global boolean to short-circuit a particular condition.
2. `delete win.Element.prototype.animate`
3. `delete win.document.documentElement.animate`