### PR TITLE
Change the LCP/CLS trade-off in font timeouts

### DIFF
--- a/src/font-stylesheet-timeout.js
+++ b/src/font-stylesheet-timeout.js
@@ -41,15 +41,19 @@ export function fontStylesheetTimeout(win) {
  * @param {!Window} win
  */
 function maybeTimeoutFonts(win) {
-  let timeSinceResponseStart = 0;
-  // If available, we start counting from the time the HTTP response
+  // Educated guess 😅, but we're calculating the correct value further down
+  // if available.
+  let timeSinceNavigationStart = 1500;
+  // If available, we start counting from the time the HTTP request
   // for the page started. The preload scanner should then quickly
   // start the CSS download.
   const perf = win.performance;
-  if (perf && perf.timing && perf.timing.responseStart) {
-    timeSinceResponseStart = Date.now() - perf.timing.responseStart;
+  if (perf && perf.timing && perf.timing.navigationStart) {
+    timeSinceNavigationStart = Date.now() - perf.timing.navigationStart;
   }
-  const timeout = Math.max(1, 250 - timeSinceResponseStart);
+  // Set timeout such that we have some time to paint fonts in time for
+  // the desired goal of a 2500ms for LCP.
+  const timeout = Math.max(1, 2000 - timeSinceNavigationStart);
 
   // Avoid timer dependency since this runs very early in execution.
   win.setTimeout(() => {

--- a/src/font-stylesheet-timeout.js
+++ b/src/font-stylesheet-timeout.js
@@ -53,7 +53,10 @@ function maybeTimeoutFonts(win) {
   }
   // Set timeout such that we have some time to paint fonts in time for
   // the desired goal of a 2500ms for LCP.
-  const timeout = Math.max(1, 2000 - timeSinceNavigationStart);
+  const timeout = Math.max(
+    1,
+    2500 - 400 /* Estimated max time to paint */ - timeSinceNavigationStart
+  );
 
   // Avoid timer dependency since this runs very early in execution.
   win.setTimeout(() => {

--- a/test/unit/test-font-stylesheet-timeout.js
+++ b/test/unit/test-font-stylesheet-timeout.js
@@ -29,23 +29,33 @@ describes.realWin(
         let clock;
         let win;
         let readyState;
-        let responseStart;
+        let navigationStart;
+
+        const defaultTimeout =
+          /* target */ 2500 -
+          /* max paint time */ 400 -
+          /* default nav start*/ 1500;
+
         beforeEach(() => {
           clock = env.sandbox.useFakeTimers();
           win = env.win;
           win.setTimeout = self.setTimeout;
           readyState = 'interactive';
-          responseStart = 0;
+          navigationStart = undefined;
           env.sandbox.defineProperty(win.document, 'readyState', {
             get() {
               return readyState;
             },
           });
-          env.sandbox.defineProperty(win.performance.timing, 'responseStart', {
-            get() {
-              return responseStart;
-            },
-          });
+          env.sandbox.defineProperty(
+            win.performance.timing,
+            'navigationStart',
+            {
+              get() {
+                return navigationStart;
+              },
+            }
+          );
         });
 
         function addLink(opt_content, opt_href) {
@@ -86,7 +96,7 @@ describes.realWin(
         it('should time out if style sheets do not load', () => {
           const link = addLink(undefined, '/does-not-exist.css');
           fontStylesheetTimeout(win);
-          clock.tick(249);
+          clock.tick(defaultTimeout - 1);
           expect(
             win.document.querySelectorAll(
               'link[rel="stylesheet"][i-amphtml-timeout]'
@@ -113,11 +123,13 @@ describes.realWin(
         });
 
         it('should time out from response start', () => {
-          responseStart = 200;
+          const startTime = 100000;
+          clock.tick(startTime);
+          navigationStart = startTime;
           clock.tick(250);
           const link = addLink(undefined, '/does-not-exist.css');
           fontStylesheetTimeout(win);
-          clock.tick(199);
+          clock.tick(2500 - 400 - 250 - 1);
           expect(
             win.document.querySelectorAll(
               'link[rel="stylesheet"][i-amphtml-timeout]'
@@ -138,7 +150,7 @@ describes.realWin(
         });
 
         it('should time out multiple style sheets and ignore CDN URLs', () => {
-          responseStart = 500;
+          navigationStart = 500;
           clock.tick(10000);
           const link0 = addLink(undefined, '/does-not-exist.css');
           const link1 = addLink(undefined, '/does-not-exist.css');
@@ -221,14 +233,14 @@ describes.realWin(
             fontStylesheetTimeout(win);
             expect(fonts[1].display).to.equal('auto');
             expect(fonts[2].display).to.equal('auto');
-            clock.tick(250);
+            clock.tick(defaultTimeout);
             expect(fonts[1].display).to.equal('swap');
             expect(fonts[2].display).to.equal('swap');
           });
 
           it('should not override non-default values', () => {
             fontStylesheetTimeout(win);
-            clock.tick(250);
+            clock.tick(defaultTimeout);
             expect(fonts[3].display).to.equal('optional');
           });
         });


### PR DESCRIPTION
Make it so that the timeout

- Is as late as possible (reduces swaps)
- But still in time to enable a good LCP time (2500ms)

Related to #27776