### PR TITLE
Register story page level background-audio.

### DIFF
--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -92,7 +92,7 @@ const PAGE_LOADED_CLASS_NAME = 'i-amphtml-story-page-loaded';
  * contained in amp-story-page-attachment.
  * @enum {string}
  */
-const Selectors = {
+export const Selectors = {
   // which media to wait for on page layout.
   ALL_AMP_MEDIA:
     'amp-story-grid-layer amp-audio, ' +
@@ -521,7 +521,12 @@ export class AmpStoryPage extends AMP.BaseElement {
 
   /** @override */
   layoutCallback() {
-    upgradeBackgroundAudio(this.element);
+    const audioEl = upgradeBackgroundAudio(this.element);
+    if (audioEl) {
+      this.mediaPoolPromise_.then((mediaPool) => {
+        this.registerMedia_(mediaPool, dev().assertElement(audioEl));
+      });
+    }
     this.muteAllMedia();
     this.getViewport().onResize(
       debounce(this.win, () => this.onResize_(), RESIZE_TIMEOUT_MS)


### PR DESCRIPTION
https://github.com/ampproject/amphtml/pull/27366 has an optimization to run the `registerAllMedia_()` only once. But the `background-audio` is built and added to the DOM on `layoutCallback`, which happens after the first call to `registerAllMedia_()` for pages with distance > 2.

Fixes https://github.com/ampproject/amphtml/issues/27573, https://github.com/ampproject/amphtml/issues/27779