### PR TITLE
🐛 Fix Custom Element instance creation in IE11, redo

### DIFF
--- a/src/polyfills/custom-elements.js
+++ b/src/polyfills/custom-elements.js
@@ -804,6 +804,8 @@ function polyfill(win) {
   // And because `HTMLElementPolyfill` extends from `HTMLElement`, it doesn't
   // have a `.call`! So we need to manually install it.
   if (!HTMLElementPolyfill.call) {
+    HTMLElementPolyfill.apply = win.Function.apply;
+    HTMLElementPolyfill.bind = win.Function.bind;
     HTMLElementPolyfill.call = win.Function.call;
   }
 }


### PR DESCRIPTION
This is a continuation of #25245. All of our Custom Elements extend from a common `CustomAmpElement` class, which itself extends from `HTMLElementPolyfill`. In #27470, I removed the `constructor` from `CustomAmpElement` class. But, because it's a subclass and must have a `constructor` that calls `super()`, Closure replaced it with a `constructor() { superClass.apply(this, arguments); }` when transpiling.

But, due to the same faulty inheritance chain described in #25245, `HTMLElementPolyfill` doesn't inherit an `apply` method! So doing `superClass.apply()` throws an error. 😭

This PR installs all important Function methods onto our polyfill, to be resilient to any future changes in the instance creation.

Fixes #27660
Fixes #27775