### PR TITLE
🏗Java Validator testing changes

### DIFF
--- a/build-system/pr-check/build-targets.js
+++ b/build-system/pr-check/build-targets.js
@@ -189,8 +189,7 @@ const targetMatchers = {
     }
     return (
       file.startsWith('validator/java/') ||
-      file === 'build-system/tasks/validator.js' ||
-      isValidatorFile(file)
+      file === 'build-system/tasks/validator.js'
     );
   },
   'VALIDATOR_WEBUI': (file) => {

--- a/build-system/pr-check/build.js
+++ b/build-system/pr-check/build.js
@@ -36,8 +36,7 @@ const {runYarnChecks} = require('./yarn-checks');
 
 const FILENAME = 'build.js';
 const FILELOGPREFIX = colors.bold(colors.yellow(`${FILENAME}:`));
-const timedExecOrDie = (cmd, unusedFileName) =>
-  timedExecOrDieBase(cmd, FILENAME);
+const timedExecOrDie = (cmd) => timedExecOrDieBase(cmd, FILENAME);
 
 function main() {
   const startTime = startTimer(FILENAME, FILENAME);

--- a/build-system/pr-check/checks.js
+++ b/build-system/pr-check/checks.js
@@ -35,8 +35,7 @@ const {reportAllExpectedTests} = require('../tasks/report-test-status');
 const {runYarnChecks} = require('./yarn-checks');
 
 const FILENAME = 'checks.js';
-const timedExecOrDie = (cmd, unusedFileName) =>
-  timedExecOrDieBase(cmd, FILENAME);
+const timedExecOrDie = (cmd) => timedExecOrDieBase(cmd, FILENAME);
 
 async function main() {
   const startTime = startTimer(FILENAME, FILENAME);

--- a/build-system/pr-check/dist-bundle-size.js
+++ b/build-system/pr-check/dist-bundle-size.js
@@ -39,8 +39,7 @@ const {signalDistUpload} = require('../tasks/pr-deploy-bot-utils');
 
 const FILENAME = 'dist-bundle-size.js';
 const FILELOGPREFIX = colors.bold(colors.yellow(`${FILENAME}:`));
-const timedExecOrDie = (cmd, unusedFileName) =>
-  timedExecOrDieBase(cmd, FILENAME);
+const timedExecOrDie = (cmd) => timedExecOrDieBase(cmd, FILENAME);
 
 async function main() {
   const startTime = startTimer(FILENAME, FILENAME);

--- a/build-system/pr-check/e2e-tests.js
+++ b/build-system/pr-check/e2e-tests.js
@@ -34,8 +34,7 @@ const {isTravisPullRequestBuild} = require('../common/travis');
 
 const FILENAME = 'e2e-tests.js';
 const FILELOGPREFIX = colors.bold(colors.yellow(`${FILENAME}:`));
-const timedExecOrDie = (cmd, unusedFileName) =>
-  timedExecOrDieBase(cmd, FILENAME);
+const timedExecOrDie = (cmd) => timedExecOrDieBase(cmd, FILENAME);
 
 async function main() {
   const startTime = startTimer(FILENAME, FILENAME);

--- a/build-system/pr-check/experiment-tests.js
+++ b/build-system/pr-check/experiment-tests.js
@@ -31,8 +31,7 @@ const {
 const {experiment} = require('minimist')(process.argv.slice(2));
 const FILENAME = `${experiment}-tests.js`;
 const FILELOGPREFIX = colors.bold(colors.yellow(`${FILENAME}:`));
-const timedExecOrDie = (cmd, unusedFileName) =>
-  timedExecOrDieBase(cmd, FILENAME);
+const timedExecOrDie = (cmd) => timedExecOrDieBase(cmd, FILENAME);
 
 function getConfig_() {
   const config = experimentsConfig[experiment];

--- a/build-system/pr-check/local-tests.js
+++ b/build-system/pr-check/local-tests.js
@@ -34,8 +34,7 @@ const {isTravisPullRequestBuild} = require('../common/travis');
 
 const FILENAME = 'local-tests.js';
 const FILELOGPREFIX = colors.bold(colors.yellow(`${FILENAME}:`));
-const timedExecOrDie = (cmd, unusedFileName) =>
-  timedExecOrDieBase(cmd, FILENAME);
+const timedExecOrDie = (cmd) => timedExecOrDieBase(cmd, FILENAME);
 
 function main() {
   const startTime = startTimer(FILENAME, FILENAME);

--- a/build-system/pr-check/module-dist-bundle-size.js
+++ b/build-system/pr-check/module-dist-bundle-size.js
@@ -36,8 +36,7 @@ const {runYarnChecks} = require('./yarn-checks');
 
 const FILENAME = 'module-dist-bundle-size.js';
 const FILELOGPREFIX = colors.bold(colors.yellow(`${FILENAME}:`));
-const timedExecOrDie = (cmd, unusedFileName) =>
-  timedExecOrDieBase(cmd, FILENAME);
+const timedExecOrDie = (cmd) => timedExecOrDieBase(cmd, FILENAME);
 
 function main() {
   const startTime = startTimer(FILENAME, FILENAME);

--- a/build-system/pr-check/single-pass-tests.js
+++ b/build-system/pr-check/single-pass-tests.js
@@ -33,8 +33,7 @@ const {isTravisPullRequestBuild} = require('../common/travis');
 
 const FILENAME = 'single-pass-tests.js';
 const FILELOGPREFIX = colors.bold(colors.yellow(`${FILENAME}:`));
-const timedExecOrDie = (cmd, unusedFileName) =>
-  timedExecOrDieBase(cmd, FILENAME);
+const timedExecOrDie = (cmd) => timedExecOrDieBase(cmd, FILENAME);
 
 function main() {
   const startTime = startTimer(FILENAME, FILENAME);

--- a/build-system/pr-check/validator-tests.js
+++ b/build-system/pr-check/validator-tests.js
@@ -36,9 +36,8 @@ const {runYarnChecks} = require('./yarn-checks');
 
 const FILENAME = 'validator-tests.js';
 const FILELOGPREFIX = colors.bold(colors.yellow(`${FILENAME}:`));
-const timedExecOrDie = (cmd, unusedFileName) =>
-  timedExecOrDieBase(cmd, FILENAME);
-const timedExec = (cmd, unusedFileName) => timedExecBase(cmd, FILENAME);
+const timedExecOrDie = (cmd) => timedExecOrDieBase(cmd, FILENAME);
+const timedExec = (cmd) => timedExecBase(cmd, FILENAME);
 
 function main() {
   const startTime = startTimer(FILENAME, FILENAME);

--- a/build-system/pr-check/validator-tests.js
+++ b/build-system/pr-check/validator-tests.js
@@ -27,6 +27,7 @@ const {
   startTimer,
   stopTimer,
   stopTimedJob,
+  timedExec: timedExecBase,
   timedExecOrDie: timedExecOrDieBase,
 } = require('./utils');
 const {determineBuildTargets} = require('./build-targets');
@@ -37,6 +38,7 @@ const FILENAME = 'validator-tests.js';
 const FILELOGPREFIX = colors.bold(colors.yellow(`${FILENAME}:`));
 const timedExecOrDie = (cmd, unusedFileName) =>
   timedExecOrDieBase(cmd, FILENAME);
+const timedExec = (cmd, unusedFileName) => timedExecBase(cmd, FILENAME);
 
 function main() {
   const startTime = startTimer(FILENAME, FILENAME);
@@ -47,7 +49,8 @@ function main() {
 
   if (!isTravisPullRequestBuild()) {
     timedExecOrDie('gulp validator');
-    timedExecOrDie('gulp validator-java');
+    // #27786: Java validator is not guaranteed to be in sync with AMP code.
+    timedExec('gulp validator-java');
     timedExecOrDie('gulp validator-webui');
   } else {
     printChangeSummary(FILENAME);
@@ -72,8 +75,10 @@ function main() {
       timedExecOrDie('gulp validator');
     }
 
-    if (buildTargets.has('RUNTIME') || buildTargets.has('VALIDATOR_JAVA')) {
+    if (buildTargets.has('VALIDATOR_JAVA')) {
       timedExecOrDie('gulp validator-java');
+    } else if (buildTargets.has('RUNTIME')) {
+      timedExec('gulp validator-java');
     }
 
     if (buildTargets.has('VALIDATOR_WEBUI')) {

--- a/build-system/pr-check/visual-diff-tests.js
+++ b/build-system/pr-check/visual-diff-tests.js
@@ -35,8 +35,7 @@ const {isTravisPullRequestBuild} = require('../common/travis');
 
 const FILENAME = 'visual-diff-tests.js';
 const FILELOGPREFIX = colors.bold(colors.yellow(`${FILENAME}:`));
-const timedExecOrDie = (cmd, unusedFileName) =>
-  timedExecOrDieBase(cmd, FILENAME);
+const timedExecOrDie = (cmd) => timedExecOrDieBase(cmd, FILENAME);
 
 function main() {
   const startTime = startTimer(FILENAME, FILENAME);

--- a/build-system/tasks/pr-check.js
+++ b/build-system/tasks/pr-check.js
@@ -114,6 +114,10 @@ async function prCheck(cb) {
     runCheck('gulp validator');
   }
 
+  if (buildTargets.has('VALIDATOR_JAVA')) {
+    runCheck('gulp validator-java');
+  }
+
   if (buildTargets.has('VALIDATOR_WEBUI')) {
     runCheck('gulp validator-webui');
   }


### PR DESCRIPTION
From #27786, it turns out that there is no guarantee that the Java validator is always in sync with amphtml code. Therefore, we cannot run these tests in blocking mode all the time.

**PR changes:**
- Exclude validator-related runtime changes from the `VALIDATOR_JAVA` build target
- For PR builds, run `gulp validator-java` in blocking mode for the `VALIDATOR_JAVA` target
- For PR builds, run `gulp validator-java` in non-blocking mode for the `RUNTIME` target (in the absence of the `VALIDATOR_JAVA` target)
- For Push builds, run `gulp validator-java` in non-blocking mode
- For local PR checks, run `gulp validator-java` in blocking mode for the `VALIDATOR_JAVA` target

Partial fix for #27786