### PR TITLE
Don't include extraUrlParams when image fallback is used

### DIFF
--- a/extensions/amp-analytics/0.1/transport.js
+++ b/extensions/amp-analytics/0.1/transport.js
@@ -103,6 +103,8 @@ export class Transport {
     }
 
     const getRequest = cacheFuncResult(generateRequest);
+    const beacon = this.options_['beacon'];
+    const xhrpost = this.options_['xhrpost'];
 
     if (this.options_['iframe']) {
       if (!this.iframeTransport_) {
@@ -114,13 +116,13 @@ export class Transport {
     }
 
     if (
-      this.options_['beacon'] &&
+      beacon &&
       Transport.sendRequestUsingBeacon(this.win_, getRequest(this.useBody_))
     ) {
       return;
     }
     if (
-      this.options_['xhrpost'] &&
+      xhrpost &&
       Transport.sendRequestUsingXhr(this.win_, getRequest(this.useBody_))
     ) {
       return;
@@ -131,7 +133,10 @@ export class Transport {
         typeof image == 'object' && image['suppressWarnings'];
       Transport.sendRequestUsingImage(
         this.win_,
-        getRequest(false),
+        // If xhrpost or beacon failed, don't append extraUrlParams to url
+        xhrpost || beacon
+          ? {'url': getRequest(this.useBody_).url}
+          : getRequest(false),
         suppressWarnings,
         /** @type {string|undefined} */ (this.referrerPolicy_)
       );


### PR DESCRIPTION
From our [docs](https://github.com/ampproject/amphtml/blob/master/extensions/amp-analytics/amp-analytics.md#use-body-for-extra-url-params):
> if the request falls back to other transport options that don't support useBody (e.g. image), then those nested objects will be stringified into the URL as [object Object].

While this is the expected behavior, we might want to rethink this for our tests: 
`test-vendors-new.js` always falls back to `image` request, causing `extraUrlParams` that would be sent in the body to be stringified in the request URL. 

Solutions:
- Not include the payload in the url if image request was a fall back (seen in this PR) 
- Force vendors' requests (in `vendor-requests.json`) to include the `[Object object]` in their urls (if applicable). This is already being done by some vendors, but none of them include `[Object object]` in their requests because all of their `extraUrlParams` are all strings.
- Use the first solution only during local dev based upon the amp config

/cc @zhouyx What do you think?

Prereq for #27222