### PR TITLE
🐛 Different method to bail out of native Animation on Safari

### DIFF
--- a/extensions/amp-animation/0.1/web-animations-polyfill.js
+++ b/extensions/amp-animation/0.1/web-animations-polyfill.js
@@ -48,8 +48,8 @@ function forceOnSafari(win) {
  * @param {!Window} win
  */
 export function installWebAnimationsIfNecessary(win) {
-  forceOnSafari(win);
   if (!win[POLYFILLED]) {
+    forceOnSafari(win);
     win[POLYFILLED] = true;
     installWebAnimations(win);
   }

--- a/extensions/amp-animation/0.1/web-animations-polyfill.js
+++ b/extensions/amp-animation/0.1/web-animations-polyfill.js
@@ -26,21 +26,8 @@ const POLYFILLED = '__AMP_WA';
  * @param {!Window} win
  */
 function forceOnSafari(win) {
-  if (win.Animation && Services.platformFor(win).isSafari()) {
-    const {prototype} = win.Animation;
-    const animationUnimplemented = {};
-    for (const k in prototype) {
-      try {
-        if (typeof prototype[k] === 'function') {
-          animationUnimplemented[k] = () => {};
-        }
-      } catch (unusedError) {
-        // Non-method member access (like .id) will fail.
-        // We don't care.
-      }
-    }
-    win.document.documentElement.animate = () =>
-      /** @type {!Animation} */ (animationUnimplemented);
+  if (Services.platformFor(win).isSafari()) {
+    win.Element.prototype.animate = null;
   }
 }
 

--- a/extensions/amp-animation/0.1/web-animations-polyfill.js
+++ b/extensions/amp-animation/0.1/web-animations-polyfill.js
@@ -26,8 +26,8 @@ const POLYFILLED = '__AMP_WA';
  * @param {!Window} win
  */
 function forceOnSafari(win) {
-  const {prototype} = win.Animation || {};
-  if (prototype && Services.platformFor(win).isSafari()) {
+  if (win.Animation && Services.platformFor(win).isSafari()) {
+    const {prototype} = win.Animation;
     const animationUnimplemented = {};
     for (const k in prototype) {
       try {

--- a/extensions/amp-animation/0.1/web-animations-polyfill.js
+++ b/extensions/amp-animation/0.1/web-animations-polyfill.js
@@ -26,8 +26,21 @@ const POLYFILLED = '__AMP_WA';
  * @param {!Window} win
  */
 function forceOnSafari(win) {
-  if (Services.platformFor(win).isSafari()) {
-    win.document.documentElement.animate = () => /** @type {!Animation} */ ({});
+  const {prototype} = win.Animation || {};
+  if (prototype && Services.platformFor(win).isSafari()) {
+    const animationUnimplemented = {};
+    for (const k in prototype) {
+      try {
+        if (typeof prototype[k] === 'function') {
+          animationUnimplemented[k] = () => {};
+        }
+      } catch (unusedError) {
+        // Non-method member access (like .id) will fail.
+        // We don't care.
+      }
+    }
+    win.document.documentElement.animate = () =>
+      /** @type {!Animation} */ (animationUnimplemented);
   }
 }
 

--- a/extensions/amp-animation/0.1/web-animations-polyfill.js
+++ b/extensions/amp-animation/0.1/web-animations-polyfill.js
@@ -27,7 +27,8 @@ const POLYFILLED = '__AMP_WA';
  */
 function forceOnSafari(win) {
   if (Services.platformFor(win).isSafari()) {
-    win.Element.prototype.animate = null;
+    // Using string access syntax to bypass typecheck.
+    win.Element.prototype['animate'] = null;
   }
 }
 


### PR DESCRIPTION
Fixes #27802