### PR TITLE
🏗 Temporarily disable function transform due to Services implementation

### DIFF
--- a/build-system/babel-config/post-closure-config.js
+++ b/build-system/babel-config/post-closure-config.js
@@ -31,7 +31,6 @@ function getPostClosureConfig() {
     './build-system/babel-plugins/babel-plugin-transform-minified-comments',
     './build-system/babel-plugins/babel-plugin-const-transformer',
     './build-system/babel-plugins/babel-plugin-transform-remove-directives',
-    './build-system/babel-plugins/babel-plugin-transform-function-declarations',
     './build-system/babel-plugins/babel-plugin-transform-stringish-literals',
   ];
   return {


### PR DESCRIPTION
Services break module patterns, and the current transform is not designed to handle this issue when running post closure compilation.