### PR TITLE
Updates Homebrew Cask install command.

### DIFF
--- a/validator/README.md
+++ b/validator/README.md
@@ -88,7 +88,7 @@ Dependencies:
 
   - openjdk-7-jre
     ```sh
-    brew tap caskroom/cask
+    brew tap homebrew/cask
     brew install Caskroom/cask/java
     ```
 


### PR DESCRIPTION
Tapping `caskroom/cask` returns an error. 
This updates the command for installing Homebrew Cask.