### PR TITLE
Fixes the extension test file boilerplate file.

### DIFF
--- a/build-system/tasks/extension-generator/index.js
+++ b/build-system/tasks/extension-generator/index.js
@@ -98,27 +98,33 @@ function getJsTestExtensionFile(name) {
  */
 
 import '../${name}';
+import {createElementWithAttributes} from '../../../../src/dom';
 
-describes.realWin('${name}', {
-  amp: {
-    extensions: ['${name}'],
+describes.realWin(
+  '${name}',
+  {
+    amp: {
+      extensions: ['${name}'],
+    },
   },
-}, env => {
+  (env) => {
+    let win;
+    let element;
 
-  let win;
-  let element;
+    beforeEach(() => {
+      win = env.win;
+      element = createElementWithAttributes(win.document, '${name}', {
+        layout: 'responsive',
+      });
+      win.document.body.appendChild(element);
+    });
 
-  beforeEach(() => {
-    win = env.win;
-    element = win.document.createElement('${name}');
-    win.document.body.appendChild(element);
-  });
-
-  it('should have hello world when built', () => {
-    element.build();
-    expect(element.querySelector('div').textContent).to.equal('hello world');
-  });
-});
+    it('should have hello world when built', () => {
+      element.build();
+      expect(element.querySelector('div').textContent).to.equal('hello world');
+    });
+  }
+);
 `;
 }
 


### PR DESCRIPTION
The extension test was breaking.
It now also matches the [Creating your first component](https://codelabs.developers.google.com/codelabs/creating-your-first-amp-component/#3) codelab.