### PR TITLE
🐛 Allow whitespace to precede intrinsic sizer SVG element in data: URL

### DIFF
--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -4880,7 +4880,7 @@ tags: {
   }
   attrs: {
     name: "src"
-    value_regex: "data:image\\/svg\\+xml;charset=utf-8,<svg height=\"\\d+(\\.\\d+)?\" width=\"\\d+(\\.\\d+)?\" xmlns=\"http:\\/\\/www\\.w3\\.org\\/2000\\/svg\" version=\"1\\.1\"\\/>|data:image\\/svg\\+xml;charset=utf-8,<svg height='\\d+(\\.\\d+)?\' width='\\d+(\\.\\d+)?\' xmlns='http:\\/\\/www\\.w3\\.org\\/2000\\/svg' version='1\\.1'\\/>"
+    value_regex: "data:image\\/svg\\+xml;charset=utf-8,\\s*<svg height=\"\\d+(\\.\\d+)?\" width=\"\\d+(\\.\\d+)?\" xmlns=\"http:\\/\\/www\\.w3\\.org\\/2000\\/svg\" version=\"1\\.1\"\\/>|data:image\\/svg\\+xml;charset=utf-8,\\s*<svg height='\\d+(\\.\\d+)?\' width='\\d+(\\.\\d+)?\' xmlns='http:\\/\\/www\\.w3\\.org\\/2000\\/svg' version='1\\.1'\\/>"
     mandatory: true
   }
 }


### PR DESCRIPTION
In reported in a [support topic](https://wordpress.org/support/topic/src-in-tag-img-i-amphtml-intrinsic-sizer-is-set-to-the-invalid/) for the the AMP plugin, validation errors were being reported for transformed `amp-img` that contained an intrinsic sizer image as follows:

```html
<img src="data:image/svg+xml;charset=utf-8, <svg height=&quot;257&quot; width=&quot;324&quot; xmlns=&quot;http://www.w3.org/2000/svg&quot; version=&quot;1.1&quot;/>" alt="" aria-hidden="true" class="i-amphtml-intrinsic-sizer" role="presentation">
```

Note the space appearing before the `<svg>` element in the `data:` URL. This space is getting added by a WordPress page caching plugin which is mutating the HTML to inject this space as part of its processing. This is very similar to another issue (https://github.com/ampproject/amp-wp/issues/4491) where caching plugins may try to optimize the HTML by removing the trailing slash of the `svg` element. Note that both of these issues would be avoided if the sizer SVG image was base64-encoded: https://github.com/ampproject/amphtml/pull/27518.

Compatibility with this WordPress caching plugin (LSCache for LightSpeed Server) can be fixed simply by allowing additional whitespace.

Also relates to a potential need to allow the attributes to be re-ordered and to allow an `</svg>` closing tag in addition to the self-closing `svg` tag:   https://github.com/ampproject/amphtml/pull/27544#discussion_r402520258.