### PR TITLE
Remove linker initialization promise

### DIFF
--- a/extensions/amp-analytics/0.1/amp-analytics.js
+++ b/extensions/amp-analytics/0.1/amp-analytics.js
@@ -557,6 +557,7 @@ export class AmpAnalytics extends AMP.BaseElement {
 
   /**
    * Create the linker-manager that will append linker params as necessary.
+   * The initialization is asynchronous and non blocking
    * @private
    */
   initializeLinker_() {

--- a/extensions/amp-analytics/0.1/linker-manager.js
+++ b/extensions/amp-analytics/0.1/linker-manager.js
@@ -55,9 +55,6 @@ export class LinkerManager {
     /** @const @private {!Element} */
     this.element_ = element;
 
-    /** @private {!Array<Promise>} */
-    this.allLinkerPromises_ = [];
-
     /** @const @private {!JsonObject} */
     this.resolvedIds_ = dict();
 
@@ -82,7 +79,6 @@ export class LinkerManager {
    * and register the callback with the navigation service. Since macro
    * resolution is asynchronous the callback may be looking for these values
    * before they are ready.
-   * @return {*} TODO(#23582): Specify return type
    */
   init() {
     if (!isObject(this.config_)) {
@@ -95,7 +91,7 @@ export class LinkerManager {
       /** @type {!JsonObject} */ (this.config_)
     );
     // Each linker config has it's own set of macros to resolve.
-    this.allLinkerPromises_ = Object.keys(this.config_).map((name) => {
+    const allLinkerPromises = Object.keys(this.config_).map((name) => {
       const ids = this.config_[name]['ids'];
       // Keys for linker data.
       const keys = Object.keys(ids);
@@ -123,7 +119,7 @@ export class LinkerManager {
       });
     });
 
-    if (this.allLinkerPromises_.length) {
+    if (allLinkerPromises.length) {
       const navigation = Services.navigationForDoc(this.ampdoc_);
       navigation.registerAnchorMutator((element, event) => {
         if (!element.href || event.type !== 'click') {
@@ -138,8 +134,6 @@ export class LinkerManager {
     }
 
     this.enableFormSupport_();
-
-    return Promise.all(this.allLinkerPromises_);
   }
 
   /**

--- a/extensions/amp-analytics/0.1/linker-manager.js
+++ b/extensions/amp-analytics/0.1/linker-manager.js
@@ -79,10 +79,13 @@ export class LinkerManager {
    * and register the callback with the navigation service. Since macro
    * resolution is asynchronous the callback may be looking for these values
    * before they are ready.
+   * init() is asynchronouse and non blocking.
+   * Return a promise for testing only.
+   * @return {!Promise}
    */
   init() {
     if (!isObject(this.config_)) {
-      return;
+      return Promise.resolve();
     }
 
     this.highestAvailableDomain_ = getHighestAvailableDomain(this.ampdoc_.win);
@@ -134,6 +137,8 @@ export class LinkerManager {
     }
 
     this.enableFormSupport_();
+
+    return Promise.all(allLinkerPromises);
   }
 
   /**


### PR DESCRIPTION
I don't see any need to return a promise for the LinkerManager.init()
The initialization is asynchronous but not blocking any service. 