### PR TITLE
🏗Update code coverage status configuration for `amphtml`

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,13 +1,38 @@
-comment: off
+# Overall settings for PR integration via codecov.io
+# See https://docs.codecov.io/docs/codecovyml-reference
+codecov:
+  bot: 'amphtml-codecov-bot'
+  ci:
+    - 'travis.org'
+  max_report_age: 24
+  require_ci_to_pass: yes
+  notify:
+    wait_for_ci: yes
+
+# Pull request comments disabled because they were too noisy
+# See https://docs.codecov.io/docs/pull-request-comments
+comment: false
+
+# Separate PR statuses for project-level and patch-level coverage
+# See https://docs.codecov.io/docs/commit-status
 coverage:
+  precision: 2
+  round: down
+  range: '80...100'
   status:
     project:
       default:
         base: auto
-        target: auto
-        threshold: 100
+        if_not_found: success
+        informational: true # TODO(rsimha): Remove this line after testing
+        only_pulls: true
+        target: 80%
+        threshold: 10%
     patch:
       default:
         base: auto
-        target: 100
-        threshold: 100
+        informational: true # TODO(rsimha): Remove this line after testing
+        if_not_found: success
+        only_pulls: true
+        target: 80%
+        threshold: 10%

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,7 +1,7 @@
 # Overall settings for PR integration via codecov.io
 # See https://docs.codecov.io/docs/codecovyml-reference
 codecov:
-  bot: 'amphtml-codecov-bot'
+  bot: 'amp-coverage-bot'
   ci:
     - 'travis.org'
   max_report_age: 24


### PR DESCRIPTION
We've had code coverage reports for `amphtml` for a while via https://codecov.io/gh/ampproject/amphtml. However, our [config file](https://github.com/ampproject/amphtml/commits/master/.codecov.yml) has bit-rotted, and GitHub PR integration with codecov.io appears to have been shut off a while ago.

This PR updates the config in `.codecov.yml` based on the latest documentation here:
- https://docs.codecov.io/docs/codecovyml-reference
- https://docs.codecov.io/docs/pull-request-comments
- https://docs.codecov.io/docs/commit-status

**Next steps:**

- [ ] Make sure the [`codecov`](https://github.com/apps/codecov) Github app is installed and enabled for `ampproject/amphtml`
- [ ] Merge this PR and observe incoming statuses (in informational mode, so non-blocking)
- [ ] Fine tune config until we have the right coverage thresholds
- [ ] Remove informational mode and start blocking PRs that lack patch-level coverage
- [ ] Drive up unit test coverage for all AMP features