### PR TITLE
🏗Don't run `VALIDATOR_JAVA` tests for `amphtml` package updates

### DIFF
--- a/build-system/pr-check/build-targets.js
+++ b/build-system/pr-check/build-targets.js
@@ -245,10 +245,12 @@ function determineBuildTargets(fileName = 'build-targets.js') {
   if (buildTargets.has('BABEL_PLUGIN') || buildTargets.has('SERVER')) {
     buildTargets.add('RUNTIME');
   }
-  // Test all targets on Travis during package upgrades.
+  // Test all targets except VALIDATOR_JAVA on Travis during package upgrades.
   if (isTravisBuild() && buildTargets.has('PACKAGE_UPGRADE')) {
     const allTargets = Object.keys(targetMatchers);
-    allTargets.forEach((target) => buildTargets.add(target));
+    allTargets
+      .filter((target) => target != 'VALIDATOR_JAVA')
+      .forEach((target) => buildTargets.add(target));
   }
   return buildTargets;
 }


### PR DESCRIPTION
Based on #27786, it isn't guaranteed that the validator java tests will always pass on `master`. Therefore, they shouldn't be run as blocking checks for any code other than the java validator code in and of itself.

This PR removes `VALIDATOR_JAVA` as a blocking check for `amphtml` package updates, which would earlier run _**all**_ test targets.

Follow up to #27788