### PR TITLE
Set the last three digit of the AMP version to be the number of cherry-picks in the branch

### DIFF
--- a/build-system/common/git.js
+++ b/build-system/common/git.js
@@ -169,12 +169,30 @@ function gitCommitterEmail() {
 }
 
 /**
- * Returns the timestamp of the latest commit on the local branch.
+ * Returns list of commit SHAs and their cherry-pick status from master.
+ *
+ * @return {!Array<{sha: string, isCherryPick: boolean}>}
+ */
+function gitCherryMaster() {
+  return getStdout('git cherry master')
+    .trim()
+    .split('\n')
+    .map((line) => ({
+      isCherryPick: line.substring(0, 2) == '- ',
+      sha: line.substring(2),
+    }));
+}
+
+/**
+ * Returns the timestamp of a commit on the local branch.
+ *
+ * @param {string} ref a Git reference (commit SHA, branch name, etc.) for the
+ *   commit to get the time of. Leave out or set to empty string for HEAD.
  * @return {number}
  */
-function gitCommitFormattedTime() {
+function gitCommitFormattedTime(ref = '') {
   return getStdout(
-    'TZ=UTC git log -1 --pretty="%cd" --date=format-local:%y%m%d%H%M%S'
+    `TZ=UTC git log ${ref} -1 --pretty="%cd" --date=format-local:%y%m%d%H%M%S`
   ).trim();
 }
 
@@ -211,6 +229,7 @@ function gitDiffPath(path, commit) {
 module.exports = {
   gitBranchCreationPoint,
   gitBranchName,
+  gitCherryMaster,
   gitCommitFormattedTime,
   gitCommitHash,
   gitCommitterEmail,

--- a/build-system/common/git.js
+++ b/build-system/common/git.js
@@ -171,6 +171,12 @@ function gitCommitterEmail() {
 /**
  * Returns list of commit SHAs and their cherry-pick status from master.
  *
+ * `git cherry <branch>` returns a list of commit SHAs. While the exact
+ * mechanism is too complicated for this comment (run `git help cherry` for a
+ * full explanation), the gist of it is that commits that were cherry-picked
+ * from <branch> are prefixed with '- ', and those that were not are prefixed
+ * with '+ '.
+ *
  * @return {!Array<{sha: string, isCherryPick: boolean}>}
  */
 function gitCherryMaster() {
@@ -184,13 +190,13 @@ function gitCherryMaster() {
 }
 
 /**
- * Returns the timestamp of a commit on the local branch.
+ * Returns (UTC) time of a commit on the local branch, in %y%m%d%H%M%S format.
  *
  * @param {string} ref a Git reference (commit SHA, branch name, etc.) for the
- *   commit to get the time of. Leave out or set to empty string for HEAD.
- * @return {number}
+ *   commit to get the time of.
+ * @return {string}
  */
-function gitCommitFormattedTime(ref = '') {
+function gitCommitFormattedTime(ref = 'HEAD') {
   return getStdout(
     `TZ=UTC git log ${ref} -1 --pretty="%cd" --date=format-local:%y%m%d%H%M%S`
   ).trim();

--- a/build-system/compile/internal-version.js
+++ b/build-system/compile/internal-version.js
@@ -32,12 +32,11 @@ function getVersion() {
     return version;
   }
   // Version numbers are determined using the following algorithm:
-  // - Count the number (<X>) of cherry-picked releases on this branch that came
+  // - Count the number (<X>) of cherry-picked commits on this branch that came
   //   from the `master` branch, until reaching `master` or the first commit
   //   that was added directly on this branch (if the current commit is on
   //   `master`'s commit history, or only contains new commits that are not
   //   cherry-picked from `master`, then <X> is 0).
-  //   - If <X> > 9 then cap it at 9 (or throw an error for `--strict_build`s).
   // - Find the commit (<C>) before the last cherry-picked commit from the
   //   `master` branch (if the current branch is `master`, or otherwise in
   //   `master`'s commit history, then the current commit is <C>).
@@ -46,35 +45,37 @@ function getVersion() {
   //   was merged into `master`, or a commit was cherry-picked onto the brabnch;
   //   author time is when the original author of the commit ran the
   //   "git commit" command.
-  // - The version number is <C>.time.format("YYmmDDHHMMSS", "UTC") + <X> (the
-  //   pseudo-code assumes standard `.strftime` formatting).
+  // - The version number is <C>.time.format("YYmmDDHHMM", "UTC") + <X> (the
+  //   pseudo-code assumes standard `.strftime` formatting, and <X> gets
+  //   zero-padded until it is three digits long).
+  //   - The maximum number of cherry-picks in a single branch is 999. More than
+  //     that will fail to build. This should never happen.
   //
   // Examples:
   // 1. The version number of a release built from the HEAD commit on `master`,
-  //    where that HEAD commit was committed on April 25, 2020 2:31:11 PM EDT
-  //    would be `2004251831110`.
+  //    where that HEAD commit was committed on April 25, 2020 2:31 PM EDT would
+  //    be `2004251831000`.
   //    - EDT is UTC-4, so the hour value changes from EDT's 14 to UTC's 18.
-  //    - The last digit is 0 as this commit is on `master`.
+  //    - The last three digits are 000 as this commit is on `master`.
   //
   // 2. The version number of a release built from a local working branch (e.g.,
   //    on a developer's workstation) that was split off from a `master` commit
-  //    from May 6, 2021 10:40:59 AM PDT and has multiple commits that exist
-  //    only on local working branch would be `2105061840590`.
-  //    - PDT is UTC-7, so the hour value changes from PST's 10 to UTC's 17.
-  //    - The last digit is 0 as this commit is on a branch that was split
-  //      from but does not have any commits since the split that were
-  //      cherry-picked from `master`.
+  //    from May 6, 2021 10:40 AM PDT and has multiple commits that exist only
+  //    on local working branch would be `2105061840000`.
+  //    - PDT is UTC-7, so the hour value changes from PDT's 10 to UTC's 17.
+  //    - The last three digits are 000 as this commit is on a branch that was
+  //      split from `master`, and does not have any cherry-picked commits.
   //
   // 3. For a release built from a local working branch that was split off from
-  //    a `master` commit from November 9, 2021 11:48:11 PM PST, and then:
+  //    a `master` commit from November 9, 2021 11:48 PM PST, and then:
   //    - had one commit that was cherry-picked from `master`,
   //    - followed by two commits that were created directly on the branch, the
-  //      last of which was commited on November 10, 2021 5:01:12 PM PST,
-  //    - followed by four commits that were cherry-picked from `master`,
-  //    then its version number would be `202111110101124`.
-  //    - The latest four commits are cherry-picks from `master`, and the one
-  //      before them is not, so our last digit is set to 4.
-  //    - PST is UTC-8, so the hour value changes from PST's 17 to UTC's 1, and
+  //      last of which was commited on November 23, 2021 6:38 PM PST,
+  //    - followed by twelve commits that were cherry-picked from `master`,
+  //    then its version number would be `2111240238014`.
+  //    - The latest twelve commits are cherry-picks from `master`, and the one
+  //      before them is not, so our last three digits are set to 014.
+  //    - PST is UTC-8, so the hour value changes from PST's 18 to UTC's 2, and
   //      one day is added.
   let numberOfCherryPicks = 0;
   const commitCherriesInfo = gitCherryMaster().reverse();
@@ -84,17 +85,18 @@ function getVersion() {
     }
     numberOfCherryPicks++;
   }
-  const lastCommitFormattedTime = gitCommitFormattedTime(
-    `HEAD~${numberOfCherryPicks}`
-  );
-
-  if (argv.strict_build && numberOfCherryPicks > 9) {
+  if (numberOfCherryPicks > 999) {
     throw new Error(
-      `This branch has ${numberOfCherryPicks} cherry-picks. --strict_build caps the number of cherry-picks at 10. To build this branch use --version_override.`
+      `This branch has ${numberOfCherryPicks} cherry-picks, which is more than 999, the maximum allowed number of cherry-picks!`
     );
   }
-  const lastDigit = Math.min(numberOfCherryPicks, 9);
-  return `${lastCommitFormattedTime}${lastDigit}`;
+
+  const lastCommitFormattedTime = gitCommitFormattedTime(
+    `HEAD~${numberOfCherryPicks}`
+  ).slice(0, -2);
+
+  numberOfCherryPicks = String(numberOfCherryPicks).padStart(3, '0');
+  return `${lastCommitFormattedTime}${numberOfCherryPicks}`;
 }
 
 // Used to e.g. references the ads binary from the runtime to get version lock.

--- a/build-system/compile/internal-version.js
+++ b/build-system/compile/internal-version.js
@@ -42,7 +42,7 @@ function getVersion() {
   //   `master`'s commit history, then the current commit is <C>).
   // - Find the commit time of <C> (<C>.time). Note that commit time might be
   //   different from author time! e.g., commit time might be the time that a PR
-  //   was merged into `master`, or a commit was cherry-picked onto the brabnch;
+  //   was merged into `master`, or a commit was cherry-picked onto the branch;
   //   author time is when the original author of the commit ran the
   //   "git commit" command.
   // - The version number is <C>.time.format("YYmmDDHHMM", "UTC") + <X> (the
@@ -72,9 +72,9 @@ function getVersion() {
   //    - followed by two commits that were created directly on the branch, the
   //      last of which was commited on November 23, 2021 6:38 PM PST,
   //    - followed by twelve commits that were cherry-picked from `master`,
-  //    then its version number would be `2111240238014`.
+  //    then its version number would be `2111240238012`.
   //    - The latest twelve commits are cherry-picks from `master`, and the one
-  //      before them is not, so our last three digits are set to 014.
+  //      before them is not, so our last three digits are set to 012.
   //    - PST is UTC-8, so the hour value changes from PST's 18 to UTC's 2, and
   //      one day is added.
   let numberOfCherryPicks = 0;

--- a/build-system/compile/internal-version.js
+++ b/build-system/compile/internal-version.js
@@ -78,8 +78,8 @@ function getVersion() {
   //      one day is added.
   let numberOfCherryPicks = 0;
   const commitCherriesInfo = gitCherryMaster().reverse();
-  for (const commitCherryInfo of commitCherriesInfo) {
-    if (!commitCherryInfo.isCherryPick) {
+  for (const {isCherryPick} of commitCherriesInfo) {
+    if (!isCherryPick) {
       break;
     }
     numberOfCherryPicks++;

--- a/build-system/compile/internal-version.js
+++ b/build-system/compile/internal-version.js
@@ -26,7 +26,6 @@ const argv = minimist(process.argv.slice(2), {
 function getVersion() {
   if (argv.version_override) {
     const version = String(argv.version_override);
-    // #27579: What are allowed version strings...?
     if (!/^\d{13}$/.test(version)) {
       throw new Error('--version_override only accepts a 13-digit version');
     }

--- a/build-system/compile/internal-version.js
+++ b/build-system/compile/internal-version.js
@@ -23,6 +23,61 @@ const argv = minimist(process.argv.slice(2), {
   string: ['version_override'],
 });
 
+/**
+ * Generates the AMP version number.
+ *
+ * Version numbers are determined using the following algorithm:
+ * - Count the number (<X>) of cherry-picked commits on this branch that came
+ *   from the `master` branch, until reaching `master` or the first commit that
+ *   was added directly on this branch (if the current commit is on `master`'s
+ *   commit history, or only contains new commits that are not cherry-picked
+ *   from `master`, then <X> is 0).
+ * - Find the commit (<C>) before the last cherry-picked commit from the
+ *   `master` branch (if the current branch is `master`, or otherwise in
+ *   `master`'s commit history, then the current commit is <C>).
+ * - Find the commit time of <C> (<C>.time). Note that commit time might be
+ *   different from author time! e.g., commit time might be the time that a PR
+ *   was merged into `master`, or a commit was cherry-picked onto the branch;
+ *   author time is when the original author of the commit ran the "git commit"
+ *   command.
+ * - The version number is <C>.time.format("YYmmDDHHMM", "UTC") + <X> (the
+ *   pseudo-code assumes standard `.strftime` formatting, and <X> gets
+ *   zero-padded until it is three digits long).
+ *   - The maximum number of cherry-picks in a single branch is 999. More than
+ *     that will fail to build. This should never happen.
+ *
+ * Examples:
+ * 1. The version number of a release built from the HEAD commit on `master`,
+ *    where that HEAD commit was committed on April 25, 2020 2:31 PM EDT would
+ *    be `2004251831000`.
+ *    - EDT is UTC-4, so the hour value changes from EDT's 14 to UTC's 18.
+ *    - The last three digits are 000 as this commit is on `master`.
+ *
+ * 2. The version number of a release built from a local working branch (e.g.,
+ *    on a developer's workstation) that was split off from a `master` commit
+ *    from May 6, 2021 10:40 AM PDT and has multiple commits that exist only on
+ *    local working branch would be `2105061840000`.
+ *    - PDT is UTC-7, so the hour value changes from PDT's 10 to UTC's 17.
+ *    - The last three digits are 000 as this commit is on a branch that was
+ *      split from `master`, and does not have any cherry-picked commits.
+ *
+ * 3. For a release built from a local working branch that was split off from a
+ *    `master` commit from November 9, 2021 11:48 PM PST, and then:
+ *    - had one commit that was cherry-picked from `master`,
+ *    - followed by two commits that were created directly on the branch, the
+ *      last of which was commited on November 23, 2021 6:38 PM PST,
+ *    - followed by twelve commits that were cherry-picked from `master`, then
+ *      its version number would be `2111240238012`.
+ *    - The latest twelve commits are cherry-picks from `master`, and the one
+ *      before them is not, so our last three digits are set to 012.
+ *    - PST is UTC-8, so the hour value changes from PST's 18 to UTC's 2, and
+ *      one day is added.
+ *
+ * The version number can be manually overridden by passing --version_override
+ * to the `gulp build`/`gulp dist` command.
+ *
+ * @return {string} AMP version number (always 13 digits long)
+ */
 function getVersion() {
   if (argv.version_override) {
     const version = String(argv.version_override);
@@ -31,52 +86,7 @@ function getVersion() {
     }
     return version;
   }
-  // Version numbers are determined using the following algorithm:
-  // - Count the number (<X>) of cherry-picked commits on this branch that came
-  //   from the `master` branch, until reaching `master` or the first commit
-  //   that was added directly on this branch (if the current commit is on
-  //   `master`'s commit history, or only contains new commits that are not
-  //   cherry-picked from `master`, then <X> is 0).
-  // - Find the commit (<C>) before the last cherry-picked commit from the
-  //   `master` branch (if the current branch is `master`, or otherwise in
-  //   `master`'s commit history, then the current commit is <C>).
-  // - Find the commit time of <C> (<C>.time). Note that commit time might be
-  //   different from author time! e.g., commit time might be the time that a PR
-  //   was merged into `master`, or a commit was cherry-picked onto the branch;
-  //   author time is when the original author of the commit ran the
-  //   "git commit" command.
-  // - The version number is <C>.time.format("YYmmDDHHMM", "UTC") + <X> (the
-  //   pseudo-code assumes standard `.strftime` formatting, and <X> gets
-  //   zero-padded until it is three digits long).
-  //   - The maximum number of cherry-picks in a single branch is 999. More than
-  //     that will fail to build. This should never happen.
-  //
-  // Examples:
-  // 1. The version number of a release built from the HEAD commit on `master`,
-  //    where that HEAD commit was committed on April 25, 2020 2:31 PM EDT would
-  //    be `2004251831000`.
-  //    - EDT is UTC-4, so the hour value changes from EDT's 14 to UTC's 18.
-  //    - The last three digits are 000 as this commit is on `master`.
-  //
-  // 2. The version number of a release built from a local working branch (e.g.,
-  //    on a developer's workstation) that was split off from a `master` commit
-  //    from May 6, 2021 10:40 AM PDT and has multiple commits that exist only
-  //    on local working branch would be `2105061840000`.
-  //    - PDT is UTC-7, so the hour value changes from PDT's 10 to UTC's 17.
-  //    - The last three digits are 000 as this commit is on a branch that was
-  //      split from `master`, and does not have any cherry-picked commits.
-  //
-  // 3. For a release built from a local working branch that was split off from
-  //    a `master` commit from November 9, 2021 11:48 PM PST, and then:
-  //    - had one commit that was cherry-picked from `master`,
-  //    - followed by two commits that were created directly on the branch, the
-  //      last of which was commited on November 23, 2021 6:38 PM PST,
-  //    - followed by twelve commits that were cherry-picked from `master`,
-  //    then its version number would be `2111240238012`.
-  //    - The latest twelve commits are cherry-picks from `master`, and the one
-  //      before them is not, so our last three digits are set to 012.
-  //    - PST is UTC-8, so the hour value changes from PST's 18 to UTC's 2, and
-  //      one day is added.
+
   let numberOfCherryPicks = 0;
   const commitCherriesInfo = gitCherryMaster().reverse();
   for (const {isCherryPick} of commitCherriesInfo) {

--- a/build-system/tasks/build.js
+++ b/build-system/tasks/build.js
@@ -110,7 +110,6 @@ build.flags = {
   core_runtime_only: '  Builds only the core runtime.',
   coverage: '  Adds code coverage instrumentation to JS files using istanbul.',
   version_override: '  Overrides the version written to AMP_CONFIG',
-  custom_version_mark: '  Set final digit (0-9) on auto-generated version',
   watch: '  Watches for changes in files, re-builds when detected',
   define_experiment_constant:
     '  Builds runtime with the EXPERIMENT constant set to true',

--- a/build-system/tasks/default-task.js
+++ b/build-system/tasks/default-task.js
@@ -85,7 +85,6 @@ defaultTask.flags = {
   disable_nailgun:
     "  Doesn't use nailgun to invoke closure compiler (much slower)",
   version_override: '  Overrides the version written to AMP_CONFIG',
-  custom_version_mark: '  Set final digit (0-9) on auto-generated version',
   host: '  Host to serve the project on. localhost by default.',
   port: '  Port to serve the project on. 8000 by default.',
   define_experiment_constant:

--- a/build-system/tasks/dist.js
+++ b/build-system/tasks/dist.js
@@ -463,7 +463,6 @@ dist.flags = {
   type: '  Points sourcemap to fetch files from the correct GitHub tag',
   esm: '  Does not transpile down to ES5',
   version_override: '  Override the version written to AMP_CONFIG',
-  custom_version_mark: '  Set final digit (0-9) on auto-generated version',
   watch: '  Watches for changes in files, re-compiles when detected',
   closure_concurrency: '  Sets the number of concurrent invocations of closure',
   debug: '  Outputs the file contents during compilation lifecycles',


### PR DESCRIPTION
Implements and closes #27793