### PR TITLE
amp-consent allow full screen after promptTrigger: action

### DIFF
--- a/extensions/amp-consent/0.1/amp-consent.js
+++ b/extensions/amp-consent/0.1/amp-consent.js
@@ -239,7 +239,6 @@ export class AmpConsent extends AMP.BaseElement {
     });
 
     this.registerAction('prompt', () => {
-      console.log('register action prompt');
       this.scheduleDisplay_(true);
     });
 

--- a/extensions/amp-consent/0.1/amp-consent.js
+++ b/extensions/amp-consent/0.1/amp-consent.js
@@ -239,6 +239,7 @@ export class AmpConsent extends AMP.BaseElement {
     });
 
     this.registerAction('prompt', () => {
+      console.log('register action prompt');
       this.scheduleDisplay_(true);
     });
 

--- a/extensions/amp-consent/0.1/consent-ui.js
+++ b/extensions/amp-consent/0.1/consent-ui.js
@@ -163,6 +163,9 @@ export class ConsentUI {
     /** @private {boolean} */
     this.enableBorder_ = DEFAULT_ENABLE_BORDER;
 
+    /** @private {boolean} */
+    this.isActionPromptTrigger_ = false;
+
     /** @private @const {!Function} */
     this.boundHandleIframeMessages_ = this.handleIframeMessages_.bind(this);
 
@@ -225,7 +228,9 @@ export class ConsentUI {
     // Add to fixed layer
     this.baseInstance_.getViewport().addToFixedLayer(this.parent_);
     if (this.isCreatedIframe_) {
-      this.loadIframe_(isActionPromptTrigger).then(() => {
+      // Set this for every iframe request to show, no need to reset.
+      this.isActionPromptTrigger_ = isActionPromptTrigger;
+      this.loadIframe_().then(() => {
         // It is safe to assume that the loadIframe_ promise will resolve
         // before resetIframe_. Because the iframe needs to be shown first
         // being hidden. CMP iframe is responsible to call consent-iframe-ready
@@ -465,10 +470,9 @@ export class ConsentUI {
 
   /**
    * Get the client information that needs to be passed to cmp iframe
-   * @param {boolean} isActionPromptTrigger
    * @return {!Promise<JsonObject>}
    */
-  getClientInfoPromise_(isActionPromptTrigger) {
+  getClientInfoPromise_() {
     const consentStatePromise = getServicePromiseForDoc(
       this.ampdoc_,
       CONSENT_STATE_MANAGER
@@ -485,7 +489,7 @@ export class ConsentUI {
               consentInfo['consentState']
             ),
             'consentString': consentInfo['consentString'],
-            'promptTrigger': isActionPromptTrigger ? 'action' : 'load',
+            'promptTrigger': this.isActionPromptTrigger_ ? 'action' : 'load',
             'isDirty': !!consentInfo['isDirty'],
           });
         });
@@ -495,10 +499,9 @@ export class ConsentUI {
   /**
    * Apply placeholder
    * Set up event listener to handle UI related messages.
-   * @param {boolean} isActionPromptTrigger
    * @return {!Promise}
    */
-  loadIframe_(isActionPromptTrigger) {
+  loadIframe_() {
     this.iframeReady_ = new Deferred();
     const {classList} = this.parent_;
     if (!elementByTag(this.parent_, 'placeholder')) {
@@ -511,9 +514,7 @@ export class ConsentUI {
     classList.add(consentUiClasses.loading);
     toggle(dev().assertElement(this.ui_), false);
 
-    const iframePromise = this.getClientInfoPromise_(
-      isActionPromptTrigger
-    ).then((clientInfo) => {
+    const iframePromise = this.getClientInfoPromise_().then((clientInfo) => {
       this.ui_.setAttribute('name', JSON.stringify(clientInfo));
       this.win_.addEventListener('message', this.boundHandleIframeMessages_);
       insertAfterOrAtStart(this.parent_, dev().assertElement(this.ui_), null);
@@ -769,11 +770,14 @@ export class ConsentUI {
     }
 
     if (requestAction === 'enter-fullscreen') {
-      // Do nothing if iframe not visible or it's not the active element.
+      // Do nothing iff:
+      // - iframe not visible or
+      // - iframe not active element && not called via actionPromptTrigger
       if (
         !this.isIframeVisible_ ||
         (this.restrictFullscreenOn_ &&
-          this.document_.activeElement !== this.ui_)
+          this.document_.activeElement !== this.ui_ &&
+          !this.isActionPromptTrigger_)
       ) {
         user().warn(TAG, FULLSCREEN_ERROR);
         this.sendEnterFullscreenResponse_(requestType, requestAction, true);

--- a/extensions/amp-consent/0.1/consent-ui.js
+++ b/extensions/amp-consent/0.1/consent-ui.js
@@ -228,7 +228,8 @@ export class ConsentUI {
     // Add to fixed layer
     this.baseInstance_.getViewport().addToFixedLayer(this.parent_);
     if (this.isCreatedIframe_) {
-      // Set this for every iframe request to show, no need to reset.
+      // show() can be called multiple times, but notificationsUiManager
+      // ensures that only 1 is shown at a time, so no race condition here
       this.isActionPromptTrigger_ = isActionPromptTrigger;
       this.loadIframe_().then(() => {
         // It is safe to assume that the loadIframe_ promise will resolve

--- a/extensions/amp-consent/0.1/test/test-consent-ui.js
+++ b/extensions/amp-consent/0.1/test/test-consent-ui.js
@@ -475,13 +475,14 @@ describes.realWin(
           ).to.be.true;
         });
 
-        it('should show error and send messages back to iframe', async () => {
+        it('should show error and send messages back to iframe if not user interaction', async () => {
           const errorSpy = env.sandbox.spy(user(), 'warn');
 
           consentUI = new ConsentUI(mockInstance, {
             'promptUISrc': 'https//promptUISrc',
           });
 
+          // No user interation through actionPromptTrigger
           consentUI.show(false);
           consentUI.iframeReady_.resolve();
           await macroTask();
@@ -524,6 +525,79 @@ describes.realWin(
             'requestAction': 'enter-fullscreen',
             'state': 'success',
             'info': 'Entering fullscreen.',
+          });
+        });
+
+        describe('actionPromptTrigger', () => {
+          it('should not expand when actionPromptTrigger is false', async () => {
+            consentUI = new ConsentUI(mockInstance, {
+              'promptUISrc': 'https//promptUISrc',
+            });
+
+            consentUI.show(false);
+            consentUI.iframeReady_.resolve();
+            await macroTask();
+
+            // Send expand
+            sendMessageConsentUi(consentUI, 'enter-fullscreen');
+
+            // not currently fullscreen
+            expect(consentUI.isFullscreen_).to.be.false;
+            expect(consentUI.isActionPromptTrigger_).to.be.false;
+            expect(
+              consentUI.parent_.classList.contains(
+                consentUiClasses.iframeFullscreen
+              )
+            ).to.be.false;
+          });
+
+          it('should expand when actionPromptTrigger is true', async () => {
+            consentUI = new ConsentUI(mockInstance, {
+              'promptUISrc': 'https//promptUISrc',
+            });
+
+            consentUI.show(true);
+            consentUI.iframeReady_.resolve();
+            await macroTask();
+
+            // Send expand
+            sendMessageConsentUi(consentUI, 'enter-fullscreen');
+
+            expect(consentUI.isFullscreen_).to.be.true;
+            expect(consentUI.isActionPromptTrigger_).to.be.true;
+            expect(
+              consentUI.parent_.classList.contains(
+                consentUiClasses.iframeFullscreen
+              )
+            ).to.be.true;
+          });
+
+          it('should expand after hidden', async () => {
+            consentUI = new ConsentUI(mockInstance, {
+              'promptUISrc': 'https//promptUISrc',
+            });
+
+            consentUI.show(false);
+            consentUI.iframeReady_.resolve();
+            await macroTask();
+
+            consentUI.hide();
+            await macroTask();
+
+            consentUI.show(true);
+            consentUI.iframeReady_.resolve();
+            await macroTask();
+
+            // Send expand
+            sendMessageConsentUi(consentUI, 'enter-fullscreen');
+
+            expect(consentUI.isFullscreen_).to.be.true;
+            expect(consentUI.isActionPromptTrigger_).to.be.true;
+            expect(
+              consentUI.parent_.classList.contains(
+                consentUiClasses.iframeFullscreen
+              )
+            ).to.be.true;
           });
         });
       });

--- a/extensions/amp-consent/0.1/test/test-consent-ui.js
+++ b/extensions/amp-consent/0.1/test/test-consent-ui.js
@@ -529,60 +529,10 @@ describes.realWin(
         });
 
         describe('actionPromptTrigger', () => {
-          it('should not expand when actionPromptTrigger is false', async () => {
-            consentUI = new ConsentUI(mockInstance, {
-              'promptUISrc': 'https//promptUISrc',
-            });
-
-            consentUI.show(false);
-            consentUI.iframeReady_.resolve();
-            await macroTask();
-
-            // Send expand
-            sendMessageConsentUi(consentUI, 'enter-fullscreen');
-
-            // not currently fullscreen
-            expect(consentUI.isFullscreen_).to.be.false;
-            expect(consentUI.isActionPromptTrigger_).to.be.false;
-            expect(
-              consentUI.parent_.classList.contains(
-                consentUiClasses.iframeFullscreen
-              )
-            ).to.be.false;
-          });
-
           it('should expand when actionPromptTrigger is true', async () => {
             consentUI = new ConsentUI(mockInstance, {
               'promptUISrc': 'https//promptUISrc',
             });
-
-            consentUI.show(true);
-            consentUI.iframeReady_.resolve();
-            await macroTask();
-
-            // Send expand
-            sendMessageConsentUi(consentUI, 'enter-fullscreen');
-
-            expect(consentUI.isFullscreen_).to.be.true;
-            expect(consentUI.isActionPromptTrigger_).to.be.true;
-            expect(
-              consentUI.parent_.classList.contains(
-                consentUiClasses.iframeFullscreen
-              )
-            ).to.be.true;
-          });
-
-          it('should expand after hidden', async () => {
-            consentUI = new ConsentUI(mockInstance, {
-              'promptUISrc': 'https//promptUISrc',
-            });
-
-            consentUI.show(false);
-            consentUI.iframeReady_.resolve();
-            await macroTask();
-
-            consentUI.hide();
-            await macroTask();
 
             consentUI.show(true);
             consentUI.iframeReady_.resolve();


### PR DESCRIPTION
Keep track of `isActionPromptTrigger` when showing consentUI. 

`isActionPromptTrigger` was only used as part of clientInfo to be sent to iframe. 

Now it's also used to relax the restriction on `enter-fullscreen` signal sent from iframe. 

Closes #27819