### PR TITLE
amp-list[binding=refresh-evaluate]

### DIFF
--- a/build-system/externs/amp.extern.js
+++ b/build-system/externs/amp.extern.js
@@ -718,7 +718,7 @@ let BindEvaluateExpressionResultDef;
 
 /**
  * Options for Bind.rescan().
- * @typedef {{update: (boolean|undefined), fast: (boolean|undefined), timeout: (number|undefined)}}
+ * @typedef {{update: (boolean|undefined), fast: (boolean|undefined), evaluate: (boolean|undefined), timeout: (number|undefined)}}
  */
 let BindRescanOptionsDef;
 

--- a/build-system/externs/amp.extern.js
+++ b/build-system/externs/amp.extern.js
@@ -718,7 +718,7 @@ let BindEvaluateExpressionResultDef;
 
 /**
  * Options for Bind.rescan().
- * @typedef {{update: (boolean|undefined), fast: (boolean|undefined), evaluate: (boolean|undefined), timeout: (number|undefined)}}
+ * @typedef {{update: (boolean|string|undefined), fast: (boolean|undefined), timeout: (number|undefined)}}
  */
 let BindRescanOptionsDef;
 

--- a/examples/bind/list.amp.html
+++ b/examples/bind/list.amp.html
@@ -38,12 +38,12 @@
     </script>
   </amp-state>
 
-  <h3>Remote src (URL)</h3>
+  <h3>setState() for amp-list[src]: Remote (URL)</h3>
   <button on="tap:AMP.setState({src:'/list/fruit-data/get'})">Show Fruit</button>
   <button on="tap:AMP.setState({src:'/list/vegetable-data/get'})">Show Vegetables</button>
   <button on="tap:AMP.setState({src: otherFoods})">Show Other Foods</button>
 
-  <h3>Local src (JSON)</h3>
+  <h3>setState() for amp-list[src]: Local (JSON)</h3>
   <button on="tap:AMP.setState({
     src: [{
       name: 'pizza',
@@ -70,7 +70,7 @@
 
   <button on="tap:AMP.setState({src: (src || []).concat([{name: 'burger', quantity: 1, unitPrice: random()}])})">Add burger</button>
 
-  <h3>Other</h3>
+  <h3>setState() for children of amp-list</h3>
   <button on="tap:AMP.setState({foo: foo+1})">Increment foo</button>
 
   <hr>
@@ -84,22 +84,32 @@
   </template>
 
   <h3>amp-list:not([binding])</h3>
-  <amp-list layout="responsive" src="/list/fruit-data/get" [src]="src || '/list/fruit-data/get'" width="600" height="100" template="my-template">
+  <h4>Expected: The same behavior as [binding=always].</h4>
+  <amp-list src="/list/fruit-data/get" [src]="src || '/list/fruit-data/get'" width="360" height="60" template="my-template">
     <div placeholder>(Placeholder)</div>
   </amp-list>
 
   <h3>amp-list[binding=always]</h3>
-  <amp-list binding="always" layout="responsive" src="/list/fruit-data/get" [src]="src || '/list/fruit-data/get'" width="600" height="100" template="my-template">
+  <h4>Expected: The "1+1" and "foo" items should be "2" and "bar" on page load, respectively.</h4>
+  <amp-list binding="always" src="/list/fruit-data/get" [src]="src || '/list/fruit-data/get'" width="360" height="60" template="my-template">
     <div placeholder>(Placeholder)</div>
   </amp-list>
 
   <h3>amp-list[binding=refresh]</h3>
-  <amp-list binding="refresh" layout="responsive" src="/list/fruit-data/get" [src]="src || '/list/fruit-data/get'" width="600" height="100" template="my-template">
+  <h4>Expected: The "1+1" and "foo" items should be "?" on page load.</h4>
+  <amp-list binding="refresh" src="/list/fruit-data/get" [src]="src || '/list/fruit-data/get'" width="360" height="60" template="my-template">
+    <div placeholder>(Placeholder)</div>
+  </amp-list>
+
+  <h3>amp-list[binding=refresh-evaluate]</h3>
+  <h4>Expected: Tapping "Increment foo" should update "foo" items but _not_ the "1+1" items.</h4>
+  <amp-list binding="refresh-evaluate" src="/list/fruit-data/get" [src]="src || '/list/fruit-data/get'" width="360" height="60" template="my-template">
     <div placeholder>(Placeholder)</div>
   </amp-list>
 
   <h3>amp-list[binding=no]</h3>
-  <amp-list binding="no" layout="responsive" src="/list/fruit-data/get" [src]="src || '/list/fruit-data/get'" width="600" height="100" template="my-template">
+  <h4>Expected: Tapping "Increment foo" should have no effect.</h4>
+  <amp-list binding="no" src="/list/fruit-data/get" [src]="src || '/list/fruit-data/get'" width="360" height="60" template="my-template">
     <div placeholder>(Placeholder)</div>
   </amp-list>
 
@@ -112,7 +122,7 @@
   </ol>
   <p>Expected: The amp-list's children should update their "Foo:" values.</p>
   <h3>amp-list vs. amp-bind race condition test</h3>
-  <amp-list binding="refresh" layout="responsive" src="/list/fruit-data/get" width="600" height="100" template="my-template">
+  <amp-list binding="refresh" layout="responsive" src="/list/fruit-data/get" width="360" height="60" template="my-template">
     <div placeholder>(Placeholder)</div>
   </amp-list>
 </body>

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -443,9 +443,8 @@ export class Bind {
    * `addedElements`.
    *
    * If `options.update` is true, evaluates and applies changes to
-   * `addedElements` after adding new bindings.
-   *
-   * If `options.evaluate` is true, evaluates but does not apply changes.
+   * `addedElements` after adding new bindings. If "evaluate",
+   * it skips the actual DOM update but caches the expression results.
    *
    * If `options.fast` is true, uses a faster scan method that requires
    * (1) elements with bindings to have the attribute `i-amphtml-binding` and

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -490,11 +490,11 @@ export class Bind {
       : this.slowScan_(addedElements, removedElements);
 
     return rescanPromise.then(() => {
-      if (options.update || options.evaluate) {
+      if (options.update) {
         return this.evaluate_().then((results) =>
           this.apply_(results, {
             constrain: addedElements,
-            calculateOnly: options.evaluate,
+            evaluateOnly: options.update === 'evaluate',
           })
         );
       }
@@ -1234,7 +1234,7 @@ export class Bind {
    * @param {boolean=} opts.skipAmpState If true, skips <amp-state> elements.
    * @param {Array<!Element>=} opts.constrain If provided, restricts application
    *   to children of the provided elements.
-   * @param {boolean=} opts.calculateOnly If provided, caches the evaluated
+   * @param {boolean=} opts.evaluateOnly If provided, caches the evaluated
    *   result on each bound element and skips the actual DOM updates.
    * @return {!Promise}
    * @private
@@ -1260,8 +1260,8 @@ export class Bind {
 
       const {element, boundProperties} = boundElement;
       const updates = this.calculateUpdates_(boundProperties, results);
-      // If this is a "calculate only" application, skip the DOM mutations.
-      if (opts.calculateOnly) {
+      // If this is a "evaluate only" application, skip the DOM mutations.
+      if (opts.evaluateOnly) {
         return;
       }
       promises.push(this.applyUpdatesToElement_(element, updates));

--- a/extensions/amp-bind/0.1/test/integration/test-bind-impl.js
+++ b/extensions/amp-bind/0.1/test/integration/test-bind-impl.js
@@ -1363,6 +1363,32 @@ describe
             // The `toRemove` element's bindings should have been removed.
             expect(toRemove.textContent).to.not.equal('bar');
           });
+
+          it('{evaluate: true}', async () => {
+            toAdd = createElement(env, /* container */ null, '[text]="x"');
+
+            const options = {update: false, fast: false, evaluate: true};
+
+            // `toRemove` is updated normally before removal.
+            await onBindReadyAndSetState(env, bind, {foo: 'foo', x: '1'});
+            expect(toRemove.textContent).to.equal('foo');
+
+            // `toAdd` should be scanned but not updated. With {evaluate: true},
+            // its expression "x" is now cached on the element.
+            await onBindReadyAndRescan(env, bind, [toAdd], [toRemove], options);
+            expect(toAdd.textContent).to.equal('');
+
+            await onBindReadyAndSetState(env, bind, {foo: 'bar', x: '1'});
+            // `toAdd` should _not_ update since the value of its expression "x"
+            // hasn't changed (due to caching).
+            expect(toAdd.textContent).to.equal('');
+            // `toRemove`'s bindings have been removed and remains unchanged.
+            expect(toRemove.textContent).to.equal('foo');
+
+            await onBindReadyAndSetState(env, bind, {x: '2'});
+            // toAdd changes now that its expression "x"'s value has changed.
+            expect(toAdd.textContent).to.equal('2');
+          });
         });
 
         describe('AmpEvents.FORM_VALUE_CHANGE', () => {

--- a/extensions/amp-bind/0.1/test/integration/test-bind-impl.js
+++ b/extensions/amp-bind/0.1/test/integration/test-bind-impl.js
@@ -1372,7 +1372,7 @@ describe
             await onBindReadyAndSetState(env, bind, {foo: 'foo', x: '1'});
             expect(toRemove.textContent).to.equal('foo');
 
-            // `toAdd` should be scanned but not updated. With {evaluate: true},
+            // `toAdd` should be scanned but not updated. With {update: 'evaluate'},
             // its expression "x" is now cached on the element.
             await onBindReadyAndRescan(env, bind, [toAdd], [toRemove], options);
             expect(toAdd.textContent).to.equal('');

--- a/extensions/amp-bind/0.1/test/integration/test-bind-impl.js
+++ b/extensions/amp-bind/0.1/test/integration/test-bind-impl.js
@@ -1364,10 +1364,9 @@ describe
             expect(toRemove.textContent).to.not.equal('bar');
           });
 
-          it('{evaluate: true}', async () => {
+          it('{update: "evaluate"}', async () => {
             toAdd = createElement(env, /* container */ null, '[text]="x"');
-
-            const options = {update: false, fast: false, evaluate: true};
+            const options = {update: 'evaluate', fast: false};
 
             // `toRemove` is updated normally before removal.
             await onBindReadyAndSetState(env, bind, {foo: 'foo', x: '1'});

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -948,7 +948,7 @@ export class AmpList extends AMP.BaseElement {
     };
 
     // binding=refresh: Only do render-blocking update after initial render.
-    if (binding === 'refresh') {
+    if (binding && startsWith(binding, 'refresh')) {
       // Bind service must be available after first mutation, so don't
       // wait on the async service getter.
       if (this.bind_ && this.bind_.signals().get('FIRST_MUTATE')) {
@@ -957,7 +957,12 @@ export class AmpList extends AMP.BaseElement {
         // On initial render, do a non-blocking scan and don't update.
         Services.bindForDocOrNull(this.element).then((bind) => {
           if (bind) {
-            bind.rescan(elements, [], {'fast': true, 'update': false});
+            const evaluate = binding == 'refresh-evaluate';
+            bind.rescan(elements, [], {
+              'fast': true,
+              'update': false,
+              'evaluate': evaluate,
+            });
           }
         });
         return Promise.resolve(elements);

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -960,8 +960,7 @@ export class AmpList extends AMP.BaseElement {
             const evaluate = binding == 'refresh-evaluate';
             bind.rescan(elements, [], {
               'fast': true,
-              'update': false,
-              'evaluate': evaluate,
+              'update': evaluate ? 'evaluate' : false,
             });
           }
         });

--- a/extensions/amp-list/0.1/test/test-amp-list.js
+++ b/extensions/amp-list/0.1/test/test-amp-list.js
@@ -1158,7 +1158,7 @@ describes.repeated(
               element.setAttribute('binding', 'refresh-evaluate');
             });
 
-            it('should rescan() with {update: false, evaluate: true} before FIRST_MUTATE', async () => {
+            it('should rescan() with {update: "evaluate"} before FIRST_MUTATE', async () => {
               const child = doc.createElement('div');
               child.setAttribute('i-amphtml-binding', '');
               expectFetchAndRender(DEFAULT_FETCHED_DATA, [child]);

--- a/extensions/amp-list/0.1/test/test-amp-list.js
+++ b/extensions/amp-list/0.1/test/test-amp-list.js
@@ -1121,7 +1121,7 @@ describes.repeated(
               element.setAttribute('binding', 'refresh');
             });
 
-            it('should rescan() with {update: false, evaluate: false} before FIRST_MUTATE', async () => {
+            it('should rescan() with {update: false} before FIRST_MUTATE', async () => {
               const child = doc.createElement('div');
               child.setAttribute('i-amphtml-binding', '');
               expectFetchAndRender(DEFAULT_FETCHED_DATA, [child]);

--- a/extensions/amp-list/0.1/test/test-amp-list.js
+++ b/extensions/amp-list/0.1/test/test-amp-list.js
@@ -1121,7 +1121,7 @@ describes.repeated(
               element.setAttribute('binding', 'refresh');
             });
 
-            it('should rescan() with {update: false} before FIRST_MUTATE', async () => {
+            it('should rescan() with {update: false, evaluate: false} before FIRST_MUTATE', async () => {
               const child = doc.createElement('div');
               child.setAttribute('i-amphtml-binding', '');
               expectFetchAndRender(DEFAULT_FETCHED_DATA, [child]);
@@ -1130,6 +1130,45 @@ describes.repeated(
               expect(bind.rescan).calledWithExactly([child], [], {
                 update: false,
                 fast: true,
+                evaluate: false,
+              });
+            });
+
+            it('should rescan() with {update: true} after FIRST_MUTATE', async () => {
+              bind.signals = () => {
+                return {get: (name) => name === 'FIRST_MUTATE'};
+              };
+              const child = doc.createElement('div');
+              child.setAttribute('i-amphtml-binding', '');
+              expectFetchAndRender(DEFAULT_FETCHED_DATA, [child]);
+              await list.layoutCallback();
+              expect(bind.rescan).to.have.been.calledOnce;
+              expect(bind.rescan).calledWithExactly(
+                [child],
+                [list.container_],
+                {
+                  update: true,
+                  fast: true,
+                }
+              );
+            });
+          });
+
+          describe('binding="refresh-evaluate"', () => {
+            beforeEach(() => {
+              element.setAttribute('binding', 'refresh-evaluate');
+            });
+
+            it('should rescan() with {update: false, evaluate: true} before FIRST_MUTATE', async () => {
+              const child = doc.createElement('div');
+              child.setAttribute('i-amphtml-binding', '');
+              expectFetchAndRender(DEFAULT_FETCHED_DATA, [child]);
+              await list.layoutCallback();
+              expect(bind.rescan).to.have.been.calledOnce;
+              expect(bind.rescan).calledWithExactly([child], [], {
+                update: false,
+                fast: true,
+                evaluate: true,
               });
             });
 

--- a/extensions/amp-list/0.1/test/test-amp-list.js
+++ b/extensions/amp-list/0.1/test/test-amp-list.js
@@ -1130,7 +1130,6 @@ describes.repeated(
               expect(bind.rescan).calledWithExactly([child], [], {
                 update: false,
                 fast: true,
-                evaluate: false,
               });
             });
 
@@ -1166,9 +1165,8 @@ describes.repeated(
               await list.layoutCallback();
               expect(bind.rescan).to.have.been.calledOnce;
               expect(bind.rescan).calledWithExactly([child], [], {
-                update: false,
+                update: 'evaluate',
                 fast: true,
-                evaluate: true,
               });
             });
 

--- a/extensions/amp-list/validator-amp-list.protoascii
+++ b/extensions/amp-list/validator-amp-list.protoascii
@@ -213,6 +213,7 @@ tags: {  # <amp-list>
     value: "always"
     value: "no"
     value: "refresh"
+    value: "refresh-evaluate" # Experimental, email-only.
   }
   attrs: {
     name: "diffable"

--- a/extensions/amp-list/validator-amp-list.protoascii
+++ b/extensions/amp-list/validator-amp-list.protoascii
@@ -213,7 +213,7 @@ tags: {  # <amp-list>
     value: "always"
     value: "no"
     value: "refresh"
-    value: "refresh-evaluate" # Experimental, email-only.
+    value: "refresh-evaluate" # Experimental.
   }
   attrs: {
     name: "diffable"


### PR DESCRIPTION
Another amp-list/amp-bind interaction option that straddles `refresh` and `always`.

Like `refresh`, don't wait for children to have their bindings evaluated/applied on initial render. However, asynchronously evaluate the expressions in those bindings and cache their results. 

The outcome is that in subsequent `setState()` calls, elements whose expression values don't change will be skipped. This is similar to `always` (modulo mutating DOM on initial render), and is desirable for some use cases related to binding on form inputs.

Meta: I'm not in love with this API and I'm considering alternatives. E.g. support `this` keyword for getting the current value in `[text]` bindings. 

`b/140023700#comment8`