### PR TITLE
🐛 Update validator regex to support Google Fonts CSS API v2

### DIFF
--- a/validator/testdata/feature_tests/regexps.html
+++ b/validator/testdata/feature_tests/regexps.html
@@ -47,11 +47,13 @@
         href="https://cdn.materialdesignicons.com/2.0.46/css/.../materialdesignicons.min.css">
 
   <!--
-  href value_regex: "https://fonts\\.googleapis\\.com/css\\?.*|https://fast\\.fonts\\.net/.*"
-  The first two examples are valid, the third example is invalid.
+  href value_regex: "https://fonts\\.googleapis\\.com/css2?\\?.*|https://fast\\.fonts\\.net/.*"
+  The first three examples are valid, the third example is invalid.
   -->
   <link rel="stylesheet" type="text/css"
         href="https://fonts.googleapis.com/css?foobar">
+  <link rel="stylesheet" type="text/css"
+        href="https://fonts.googleapis.com/css2?foobar">
   <link rel="stylesheet" type="text/css"
         href="https://cloud.typography.com/6256354/724768/css/fonts.css">
   <link rel="stylesheet" type="text/css"

--- a/validator/testdata/feature_tests/regexps.out
+++ b/validator/testdata/feature_tests/regexps.out
@@ -58,16 +58,18 @@ feature_tests/regexps.html:46:2 The attribute 'href' in tag 'link rel=stylesheet
 |          href="https://cdn.materialdesignicons.com/2.0.46/css/.../materialdesignicons.min.css">
 |
 |    <!--
-|    href value_regex: "https://fonts\\.googleapis\\.com/css\\?.*|https://fast\\.fonts\\.net/.*"
-|    The first two examples are valid, the third example is invalid.
+|    href value_regex: "https://fonts\\.googleapis\\.com/css2?\\?.*|https://fast\\.fonts\\.net/.*"
+|    The first three examples are valid, the third example is invalid.
 |    -->
 |    <link rel="stylesheet" type="text/css"
 |          href="https://fonts.googleapis.com/css?foobar">
 |    <link rel="stylesheet" type="text/css"
+|          href="https://fonts.googleapis.com/css2?foobar">
+|    <link rel="stylesheet" type="text/css"
 |          href="https://cloud.typography.com/6256354/724768/css/fonts.css">
 |    <link rel="stylesheet" type="text/css"
 >>   ^~~~~~~~~
-feature_tests/regexps.html:57:2 The attribute 'href' in tag 'link rel=stylesheet for fonts' is set to the invalid value 'http://xss.com/https://fonts.googleapis.com/css?foobar'. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#custom-fonts)
+feature_tests/regexps.html:59:2 The attribute 'href' in tag 'link rel=stylesheet for fonts' is set to the invalid value 'http://xss.com/https://fonts.googleapis.com/css?foobar'. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#custom-fonts)
 |          href="http://xss.com/https://fonts.googleapis.com/css?foobar">
 |
 |    <!--
@@ -79,7 +81,7 @@ feature_tests/regexps.html:57:2 The attribute 'href' in tag 'link rel=stylesheet
 |          href="https://use.typekit.net/oeg4hgb.css">
 |    <link rel="stylesheet" type="text/css"
 >>   ^~~~~~~~~
-feature_tests/regexps.html:67:2 The attribute 'href' in tag 'link rel=stylesheet for fonts' is set to the invalid value 'https://use.typekit.net/css/oeg4hgb.css'. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#custom-fonts)
+feature_tests/regexps.html:69:2 The attribute 'href' in tag 'link rel=stylesheet for fonts' is set to the invalid value 'https://use.typekit.net/css/oeg4hgb.css'. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#custom-fonts)
 |          href="https://use.typekit.net/css/oeg4hgb.css">
 |
 |    <!--
@@ -90,7 +92,7 @@ feature_tests/regexps.html:67:2 The attribute 'href' in tag 'link rel=stylesheet
 |          href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
 |    <link rel="stylesheet" type="text/css"
 >>   ^~~~~~~~~
-feature_tests/regexps.html:76:2 The attribute 'href' in tag 'link rel=stylesheet for fonts' is set to the invalid value 'https://maxcdn.bootstrapcdn.com/font-awesome/../bootstrap/3.3.7/css/bootstrap.min.class'. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#custom-fonts)
+feature_tests/regexps.html:78:2 The attribute 'href' in tag 'link rel=stylesheet for fonts' is set to the invalid value 'https://maxcdn.bootstrapcdn.com/font-awesome/../bootstrap/3.3.7/css/bootstrap.min.class'. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#custom-fonts)
 |          href="https://maxcdn.bootstrapcdn.com/font-awesome/../bootstrap/3.3.7/css/bootstrap.min.class">
 |    <!--
 |      New Font Awesome url format the first four are valid the last two are not.
@@ -102,10 +104,10 @@ feature_tests/regexps.html:76:2 The attribute 'href' in tag 'link rel=stylesheet
 |    <!-- invalid -->
 |    <link href="https://use.fontawesome.com/releases/v5.0.8/css/other.css" rel="stylesheet">
 >>   ^~~~~~~~~
-feature_tests/regexps.html:86:2 The attribute 'href' in tag 'link rel=stylesheet for fonts' is set to the invalid value 'https://use.fontawesome.com/releases/v5.0.8/css/other.css'. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#custom-fonts)
+feature_tests/regexps.html:88:2 The attribute 'href' in tag 'link rel=stylesheet for fonts' is set to the invalid value 'https://use.fontawesome.com/releases/v5.0.8/css/other.css'. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#custom-fonts)
 |    <link href="https://use.fontawesome.com/releases/v5.0.8/../css/solid.css" rel="stylesheet">
 >>   ^~~~~~~~~
-feature_tests/regexps.html:87:2 The attribute 'href' in tag 'link rel=stylesheet for fonts' is set to the invalid value 'https://use.fontawesome.com/releases/v5.0.8/../css/solid.css'. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#custom-fonts)
+feature_tests/regexps.html:89:2 The attribute 'href' in tag 'link rel=stylesheet for fonts' is set to the invalid value 'https://use.fontawesome.com/releases/v5.0.8/../css/solid.css'. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#custom-fonts)
 |    <!--
 |      Old Font Awesome url format. Valid.
 |    -->
@@ -120,13 +122,13 @@ feature_tests/regexps.html:87:2 The attribute 'href' in tag 'link rel=stylesheet
 |    <link rel="accessibility alternate archives">
 |    <link rel="import">
 >>   ^~~~~~~~~
-feature_tests/regexps.html:100:2 The attribute 'rel' in tag 'link rel=' is set to the invalid value 'import'. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags)
+feature_tests/regexps.html:102:2 The attribute 'rel' in tag 'link rel=' is set to the invalid value 'import'. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags)
 |    <link rel="accessibility subresource">
 >>   ^~~~~~~~~
-feature_tests/regexps.html:101:2 The attribute 'rel' in tag 'link rel=' is set to the invalid value 'accessibility subresource'. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags)
+feature_tests/regexps.html:103:2 The attribute 'rel' in tag 'link rel=' is set to the invalid value 'accessibility subresource'. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags)
 |    <link rel="manifest accessibility">
 >>   ^~~~~~~~~
-feature_tests/regexps.html:102:2 The attribute 'rel' in tag 'link rel=' is set to the invalid value 'manifest accessibility'. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags)
+feature_tests/regexps.html:104:2 The attribute 'rel' in tag 'link rel=' is set to the invalid value 'manifest accessibility'. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags)
 |
 |    <!--
 |    name blacklisted_value_regex: "(^|\\s)(viewport|content-disposition|revisit-after)($|\\s)"
@@ -136,10 +138,10 @@ feature_tests/regexps.html:102:2 The attribute 'rel' in tag 'link rel=' is set t
 |    <meta name="validcontent-disposition" content="">
 |    <meta name="content-disposition" content="">
 >>   ^~~~~~~~~
-feature_tests/regexps.html:110:2 The attribute 'name' in tag 'meta name= and content=' is set to the invalid value 'content-disposition'.
+feature_tests/regexps.html:112:2 The attribute 'name' in tag 'meta name= and content=' is set to the invalid value 'content-disposition'.
 |    <meta name="invalid content-disposition" content="">
 >>   ^~~~~~~~~
-feature_tests/regexps.html:111:2 The attribute 'name' in tag 'meta name= and content=' is set to the invalid value 'invalid content-disposition'.
+feature_tests/regexps.html:113:2 The attribute 'name' in tag 'meta name= and content=' is set to the invalid value 'invalid content-disposition'.
 |
 |    <!--
 |    css selector blacklisted_value_regex: "(^|\\W)i-amphtml-"
@@ -147,7 +149,7 @@ feature_tests/regexps.html:111:2 The attribute 'name' in tag 'meta name= and con
 |    -->
 |    <style amp-custom>
 >>   ^~~~~~~~~
-feature_tests/regexps.html:117:2 The text inside tag 'style amp-custom' contains 'CSS i-amphtml- name prefix', which is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#stylesheets)
+feature_tests/regexps.html:119:2 The text inside tag 'style amp-custom' contains 'CSS i-amphtml- name prefix', which is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#stylesheets)
 |      .comic-amp-font-loaded .comic-amp {
 |        font-family: 'Comic AMP', serif, sans-serif;
 |      }
@@ -167,10 +169,10 @@ feature_tests/regexps.html:117:2 The text inside tag 'style amp-custom' contains
 |    <div class="example-amp-font"></div>
 |    <div class="example-amp-font i-amphtml-hidden"></div>
 >>   ^~~~~~~~~
-feature_tests/regexps.html:135:2 The attribute 'class' in tag 'div' is set to the invalid value 'example-amp-font i-amphtml-hidden'.
+feature_tests/regexps.html:137:2 The attribute 'class' in tag 'div' is set to the invalid value 'example-amp-font i-amphtml-hidden'.
 |    <div class="i-amphtml-hidden example-amp-font"></div>
 >>   ^~~~~~~~~
-feature_tests/regexps.html:136:2 The attribute 'class' in tag 'div' is set to the invalid value 'i-amphtml-hidden example-amp-font'.
+feature_tests/regexps.html:138:2 The attribute 'class' in tag 'div' is set to the invalid value 'i-amphtml-hidden example-amp-font'.
 |
 |    <!--
 |    id blacklisted_value_regex: lengthy, see protoascii
@@ -179,10 +181,10 @@ feature_tests/regexps.html:136:2 The attribute 'class' in tag 'div' is set to th
 |    <div id="exampe-amp-font"></div>
 |    <div id="i-amphtml-abc"></div>
 >>   ^~~~~~~~~
-feature_tests/regexps.html:143:2 The attribute 'id' in tag 'div' is set to the invalid value 'i-amphtml-abc'.
+feature_tests/regexps.html:145:2 The attribute 'id' in tag 'div' is set to the invalid value 'i-amphtml-abc'.
 |    <div id="AMP"></div>
 >>   ^~~~~~~~~
-feature_tests/regexps.html:144:2 The attribute 'id' in tag 'div' is set to the invalid value 'AMP'.
+feature_tests/regexps.html:146:2 The attribute 'id' in tag 'div' is set to the invalid value 'AMP'.
 |
 |    <!--
 |    name blacklisted_value_regex: lengthy, see protoascii
@@ -192,17 +194,17 @@ feature_tests/regexps.html:144:2 The attribute 'id' in tag 'div' is set to the i
 |    <input name="email" />
 |    <input name="innerHTML" />
 >>   ^~~~~~~~~
-feature_tests/regexps.html:152:2 The attribute 'name' in tag 'input' is set to the invalid value 'innerHTML'. (see https://amp.dev/documentation/components/amp-form)
+feature_tests/regexps.html:154:2 The attribute 'name' in tag 'input' is set to the invalid value 'innerHTML'. (see https://amp.dev/documentation/components/amp-form)
 |    <input name="__amp_source_origin" />
 >>   ^~~~~~~~~
-feature_tests/regexps.html:153:2 The attribute 'name' in tag 'input' is set to the invalid value '__amp_source_origin'. (see https://amp.dev/documentation/components/amp-form)
+feature_tests/regexps.html:155:2 The attribute 'name' in tag 'input' is set to the invalid value '__amp_source_origin'. (see https://amp.dev/documentation/components/amp-form)
 |    <input name="webkitRequestFullscreen" />
 >>   ^~~~~~~~~
-feature_tests/regexps.html:154:2 The attribute 'name' in tag 'input' is set to the invalid value 'webkitRequestFullscreen'. (see https://amp.dev/documentation/components/amp-form)
+feature_tests/regexps.html:156:2 The attribute 'name' in tag 'input' is set to the invalid value 'webkitRequestFullscreen'. (see https://amp.dev/documentation/components/amp-form)
 |
 |  </body>
 |  </html>
 >>       ^~~~~~~~~
-feature_tests/regexps.html:157:6 The mandatory tag 'head > style[amp-boilerplate]' is missing or incorrect. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amp-boilerplate?format=websites)
+feature_tests/regexps.html:159:6 The mandatory tag 'head > style[amp-boilerplate]' is missing or incorrect. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amp-boilerplate?format=websites)
 >>       ^~~~~~~~~
-feature_tests/regexps.html:157:6 The extension 'amp-hulu' was found on this page, but is unused. Please remove this extension.
+feature_tests/regexps.html:159:6 The extension 'amp-hulu' was found on this page, but is unused. Please remove this extension.

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -322,7 +322,7 @@ tags: {
                  "https://cloud\\.typography\\.com/"
                  "[0-9]*/[0-9]*/css/fonts\\.css|"
                  "https://fast\\.fonts\\.net/.*|"
-                 "https://fonts\\.googleapis\\.com/css\\?.*|"
+                 "https://fonts\\.googleapis\\.com/css2?\\?.*|"
                  "https://fonts\\.googleapis\\.com/icon\\?.*|"
                  "https://fonts\\.googleapis\\.com/earlyaccess/.*\\.css|"
                  "https://maxcdn\\.bootstrapcdn\\.com/font-awesome/"


### PR DESCRIPTION
Adds support for the new CSS API v2 so `https://fonts.googleapis.com/css2` URLs aren't flagged as being invalid AMP.

Fixes #27881.