### PR TITLE
Do not override inabox host handler

### DIFF
--- a/ads/inabox/inabox-messaging-host.js
+++ b/ads/inabox/inabox-messaging-host.js
@@ -48,7 +48,8 @@ class NamedObservable {
    */
   listen(key, callback) {
     if (key in this.map_) {
-      dev().fine(TAG, `Overriding message callback [${key}]`);
+      dev().warn(TAG, `Overriding message callback [${key}] not allowed`);
+      return;
     }
     this.map_[key] = callback;
   }


### PR DESCRIPTION
Closes #27899 
I put a `dev().warn()` because long term we should remove the double event register. 
Another fix would be for the inabox iframeClient to not register listener twice. 