### PR TITLE
amp-list[diffable]: Make initial content visible pre-build

### DIFF
--- a/css/ampdoc.css
+++ b/css/ampdoc.css
@@ -15,6 +15,10 @@
  */
 
 /**
+ * @fileoverview CSS specifically for non-AMP4ADS formats.
+ */
+
+/**
  * Horizontal scrolling interferes with embedded scenarios and predominantly
  * the result of the non-responsive design.
  *

--- a/css/ampdoc.css
+++ b/css/ampdoc.css
@@ -277,6 +277,20 @@ amp-list[load-more] [load-more-end]
 }
 
 /**
+ * amp-list error messaging container should be hidden at first.
+ */
+ amp-list [fetch-error] {
+  display: none;
+}
+
+/**
+ * amp-list initial content should be displayed (similar to placeholder).
+ */
+amp-list[diffable] div[role="list"] {
+  display: block;
+}
+
+/**
  * amp-story
  */
 amp-story[standalone], amp-story-page {

--- a/css/ampshared.css
+++ b/css/ampshared.css
@@ -15,6 +15,10 @@
  */
 
 /**
+ * @fileoverview CSS shared across AMP4ADS and other formats.
+ */
+
+/**
  * We intentionally break with HTML5's default [hidden] styling to apply
  * !important.
  */

--- a/css/ampshared.css
+++ b/css/ampshared.css
@@ -402,20 +402,12 @@ html.i-amphtml-fie > amp-analytics {
   position: initial !important;
 }
 
-
 /**
  * Forms error/success messaging containers should be hidden at first.
  */
 form [submitting],
 form [submit-success],
 form [submit-error] {
-  display: none;
-}
-
-/**
- * amp-list error messaging container should be hidden at first.
- */
-amp-list [fetch-error] {
   display: none;
 }
 

--- a/examples/visual-tests/amp-list/amp-list.amp.html
+++ b/examples/visual-tests/amp-list/amp-list.amp.html
@@ -25,7 +25,7 @@
 </head>
 <body>
   <h3>Doesn't overflow</h3>
-  <amp-list id="list1" width="300" height="130" src="./amp-list-data.json?RANDOM">
+  <amp-list id="list1" width="300" height="130" src="./amp-list-data.json">
     <template type="amp-mustache" id="template1">
       <div>
         <amp-img src="{{imageUrl}}" width=80 height=60></amp-img>
@@ -36,17 +36,17 @@
   </amp-list>
 
   <h3>Overflows (layout=fixed)</h3>
-  <amp-list id="list2" width="300" height="100" src="./amp-list-data.json?RANDOM" template="template1">
+  <amp-list id="list2" width="300" height="100" src="./amp-list-data.json" template="template1">
     <div overflow>div[overflow]</div>
   </amp-list>
 
   <h3>Overflows (layout=responsive)</h3>
-  <amp-list id="list3" width="300" height="50" layout="responsive" src="./amp-list-data.json?RANDOM" template="template1">
+  <amp-list id="list3" width="300" height="50" layout="responsive" src="./amp-list-data.json" template="template1">
     <div overflow>div[overflow]</div>
   </amp-list>
 
   <h3>Diffable</h3>
-  <amp-list id="list4" diffable width="auto" height="130" layout="fixed-height" src="./amp-list-data.json?RANDOM" template="template1">
+  <amp-list id="list4" diffable width="auto" height="130" layout="fixed-height" src="./amp-list-data.json" template="template1">
     <div fetch-error>div[fetch-error]</div>
     <div role="list" class="i-amphtml-fill-content i-amphtml-replaced-content"><div role="listitem" tabindex="0">
       <amp-img height="60" width="80" src="http://localhost:8000/examples/visual-tests/amp-list/img1.jpg" i-amphtml-ignore="" class="i-amphtml-element i-amphtml-layout-fixed i-amphtml-layout-size-defined i-amphtml-layout" i-amphtml-layout="fixed" style="width: 80px; height: 60px;"><img decoding="async" src="http://localhost:8000/examples/visual-tests/amp-list/img1.jpg" class="i-amphtml-fill-content i-amphtml-replaced-content"></amp-img>

--- a/examples/visual-tests/amp-list/amp-list.amp.html
+++ b/examples/visual-tests/amp-list/amp-list.amp.html
@@ -10,22 +10,13 @@
       body {
         padding: 15px;
       }
-
       amp-list {
         border: 1px solid lightgray;
       }
-
-      amp-list#list1 > div[overflow] {
+      div[overflow] {
         background: gray;
         color: #fff;
-        cursor: pointer;
-        position: absolute;
-        bottom: 0;
-        left: 0;
-        right: 0;
-        z-index: 2;
         padding: 16px;
-        opacity: 0.5;
       }
   </style>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
@@ -33,42 +24,37 @@
   <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-latest.js"></script>
 </head>
 <body>
-
-  <h2>Overflowing</h2>
-  <amp-list class="list1" width="300" height="100" src="./amp-list-data.json?RANDOM">
-    <template type="amp-mustache">
+  <h3>Doesn't overflow</h3>
+  <amp-list id="list1" width="300" height="130" src="./amp-list-data.json?RANDOM">
+    <template type="amp-mustache" id="template1">
       <div>
         <amp-img src="{{imageUrl}}" width=80 height=60></amp-img>
         {{title}}
       </div>
     </template>
-    <div overflow>
-      SEE MORE
-    </div>
+    <div overflow>div[overflow]</div>
   </amp-list>
 
-  <h2>Complete</h2>
-  <amp-list class="list2" width="300" height="130" src="./amp-list-data.json?RANDOM">
-    <template type="amp-mustache">
-      <div>
-        <amp-img src="{{imageUrl}}" width=80 height=60></amp-img>
-        {{title}}
-      </div>
-    </template>
-    <div overflow>
-      SEE MORE
-    </div>
+  <h3>Overflows (layout=fixed)</h3>
+  <amp-list id="list2" width="300" height="100" src="./amp-list-data.json?RANDOM" template="template1">
+    <div overflow>div[overflow]</div>
   </amp-list>
 
-  <h3>Sanitizer should preserve custom AMP attributes e.g. "layout"</h3>
-  <p>Expected: The images should fill the width of the its parent amp-list.</p>
-  <amp-list class="list2" width="300" height="130" src="./amp-list-data.json?RANDOM">
-    <template type="amp-mustache">
-      <div>
-        <amp-img src="{{imageUrl}}" width=80 height=60 layout=responsive></amp-img>
-        {{title}}
-      </div>
-    </template>
+  <h3>Overflows (layout=responsive)</h3>
+  <amp-list id="list3" width="300" height="50" layout="responsive" src="./amp-list-data.json?RANDOM" template="template1">
+    <div overflow>div[overflow]</div>
+  </amp-list>
+
+  <h3>Diffable</h3>
+  <amp-list id="list4" diffable width="auto" height="130" layout="fixed-height" src="./amp-list-data.json?RANDOM" template="template1">
+    <div fetch-error>div[fetch-error]</div>
+    <div role="list" class="i-amphtml-fill-content i-amphtml-replaced-content"><div role="listitem" tabindex="0">
+      <amp-img height="60" width="80" src="http://localhost:8000/examples/visual-tests/amp-list/img1.jpg" i-amphtml-ignore="" class="i-amphtml-element i-amphtml-layout-fixed i-amphtml-layout-size-defined i-amphtml-layout" i-amphtml-layout="fixed" style="width: 80px; height: 60px;"><img decoding="async" src="http://localhost:8000/examples/visual-tests/amp-list/img1.jpg" class="i-amphtml-fill-content i-amphtml-replaced-content"></amp-img>
+      Video games
+    </div><div role="listitem" tabindex="0">
+      <amp-img height="60" width="80" src="http://localhost:8000/examples/visual-tests/amp-list/img1.jpg" i-amphtml-ignore="" class="i-amphtml-element i-amphtml-layout-fixed i-amphtml-layout-size-defined i-amphtml-layout" i-amphtml-layout="fixed" style="width: 80px; height: 60px;"><img decoding="async" src="http://localhost:8000/examples/visual-tests/amp-list/img2.jpg" class="i-amphtml-fill-content i-amphtml-replaced-content"></amp-img>
+      Video games
+    </div></div>
   </amp-list>
 </body>
 </html>

--- a/test/visual-diff/visual-tests
+++ b/test/visual-diff/visual-tests
@@ -195,10 +195,9 @@
       "url": "examples/visual-tests/amp-list/amp-list.amp.html",
       "name": "AMP List and Mustache",
       "loading_complete_selectors": [
-        "#list1.i-amphtml-layout",
-        "#list2.i-amphtml-layout",
-        "#list3.i-amphtml-layout",
-        "#list4.i-amphtml-layout"
+        "#list1 > div[role='list']",
+        "#list2 > div[role='list']",
+        "#list3 > div[role='list']",
       ],
       "interactive_tests": "examples/visual-tests/amp-list/amp-list.amp.js"
     },

--- a/test/visual-diff/visual-tests
+++ b/test/visual-diff/visual-tests
@@ -195,8 +195,10 @@
       "url": "examples/visual-tests/amp-list/amp-list.amp.html",
       "name": "AMP List and Mustache",
       "loading_complete_selectors": [
-        ".list1",
-        ".list2"
+        "#list1.i-amphtml-layout",
+        "#list2.i-amphtml-layout",
+        "#list3.i-amphtml-layout",
+        "#list4.i-amphtml-layout"
       ],
       "interactive_tests": "examples/visual-tests/amp-list/amp-list.amp.js"
     },


### PR DESCRIPTION
Partial for #26872.

"Initial content" is an alternative way of displaying placeholder content that supports DOM diffing. 

Currently, an amp-list's "initial content" is hidden before `buildCallback` due to existing AMP CSS rules. This PR adds a line of CSS to make it match the behavior of `[placeholder]`.