### PR TITLE
🚮 amp-script: never terminate the worker

### DIFF
--- a/extensions/amp-script/0.1/amp-script.js
+++ b/extensions/amp-script/0.1/amp-script.js
@@ -72,9 +72,6 @@ export class AmpScript extends AMP.BaseElement {
     /** @private @const {!../../../src/service/vsync-impl.Vsync} */
     this.vsync_ = Services.vsyncFor(this.win);
 
-    /** @private {?Worker} */
-    this.workerDom_ = null;
-
     /** @private {?UserActivationTracker} */
     this.userActivation_ = null;
 
@@ -245,9 +242,7 @@ export class AmpScript extends AMP.BaseElement {
       container || this.element,
       workerAndAuthorScripts,
       config
-    ).then((workerDom) => {
-      this.workerDom_ = workerDom;
-    });
+    );
     return workerAndAuthorScripts;
   }
 

--- a/extensions/amp-script/0.1/amp-script.js
+++ b/extensions/amp-script/0.1/amp-script.js
@@ -421,19 +421,6 @@ export class AmpScript extends AMP.BaseElement {
         const count = errors[type];
         user().error(TAG, this.mutationTypeToErrorMessage_(type, count));
       });
-
-      if (disallowedTypes.length > 0 && phase === Phase.MUTATING) {
-        this.workerDom_.terminate();
-
-        this.element.classList.remove('i-amphtml-hydrated');
-        this.element.classList.add('i-amphtml-broken');
-
-        user().error(
-          TAG,
-          '%s was terminated due to illegal mutation.',
-          this.debugId_
-        );
-      }
     });
   }
 

--- a/extensions/amp-script/0.1/test/integration/test-amp-script.js
+++ b/extensions/amp-script/0.1/test/integration/test-amp-script.js
@@ -90,7 +90,7 @@ describe
           yield browser.wait(100);
 
           // Mutation was dropped, therefore no h1s were added.
-          expect(!doc.querySelector('h1')).to.be.null;
+          expect(doc.querySelector('h1')).to.be.null;
         });
 
         it('should start long task', function* () {

--- a/extensions/amp-script/0.1/test/integration/test-amp-script.js
+++ b/extensions/amp-script/0.1/test/integration/test-amp-script.js
@@ -16,7 +16,6 @@
 
 import {BrowserController} from '../../../../../testing/test-helper';
 import {poll as classicPoll} from '../../../../../testing/iframe';
-import {h} from 'preact';
 
 const TIMEOUT = 10000;
 
@@ -87,9 +86,12 @@ describe
             .callsFake(() => false);
           browser.click('button#hello');
 
-          yield poll('dropped', () => {
-            const h1 = doc.querySelector('h1');
-            expect(h1.textContent).to.equal('Insert Hello World!');
+          // Wait for mutations to be processed
+          yield browser.wait(100);
+
+          yield poll('mutations should be dropped', () => {
+            // Mutation was dropped, therefore no h1s were added.
+            return !doc.querySelector('h1');
           });
         });
 

--- a/extensions/amp-script/0.1/test/integration/test-amp-script.js
+++ b/extensions/amp-script/0.1/test/integration/test-amp-script.js
@@ -72,7 +72,7 @@ describe
           });
         });
 
-        it('should terminate without gesture', function* () {
+        it('should drop mutations without gesture', function* () {
           yield poll('<amp-script> to be hydrated', () =>
             element.classList.contains('i-amphtml-hydrated')
           );
@@ -88,9 +88,7 @@ describe
 
           // Give mutations time to apply.
           yield browser.wait(100);
-          yield poll('terminated', () => {
-            return element.classList.contains('i-amphtml-broken');
-          });
+          yield poll('dropped', () => {});
         });
 
         it('should start long task', function* () {

--- a/extensions/amp-script/0.1/test/integration/test-amp-script.js
+++ b/extensions/amp-script/0.1/test/integration/test-amp-script.js
@@ -90,7 +90,7 @@ describe
           yield browser.wait(100);
           
           // Mutation was dropped, therefore no h1s were added.
-          expect(!doc.querySelector('h1')).to.be.undefined;
+          expect(!doc.querySelector('h1')).to.be.null;
         });
 
         it('should start long task', function* () {

--- a/extensions/amp-script/0.1/test/integration/test-amp-script.js
+++ b/extensions/amp-script/0.1/test/integration/test-amp-script.js
@@ -88,7 +88,7 @@ describe
 
           // Wait for mutations to be processed
           yield browser.wait(100);
-          
+
           // Mutation was dropped, therefore no h1s were added.
           expect(!doc.querySelector('h1')).to.be.null;
         });

--- a/extensions/amp-script/0.1/test/integration/test-amp-script.js
+++ b/extensions/amp-script/0.1/test/integration/test-amp-script.js
@@ -88,11 +88,9 @@ describe
 
           // Wait for mutations to be processed
           yield browser.wait(100);
-
-          yield poll('mutations should be dropped', () => {
-            // Mutation was dropped, therefore no h1s were added.
-            return !doc.querySelector('h1');
-          });
+          
+          // Mutation was dropped, therefore no h1s were added.
+          expect(!doc.querySelector('h1')).to.be.undefined;
         });
 
         it('should start long task', function* () {

--- a/extensions/amp-script/0.1/test/integration/test-amp-script.js
+++ b/extensions/amp-script/0.1/test/integration/test-amp-script.js
@@ -16,6 +16,7 @@
 
 import {BrowserController} from '../../../../../testing/test-helper';
 import {poll as classicPoll} from '../../../../../testing/iframe';
+import {h} from 'preact';
 
 const TIMEOUT = 10000;
 
@@ -86,9 +87,10 @@ describe
             .callsFake(() => false);
           browser.click('button#hello');
 
-          // Give mutations time to apply.
-          yield browser.wait(100);
-          yield poll('dropped', () => {});
+          yield poll('dropped', () => {
+            const h1 = doc.querySelector('h1');
+            expect(h1.textContent).to.equal('Insert Hello World!');
+          });
         });
 
         it('should start long task', function* () {


### PR DESCRIPTION
**summary**
previously, we had been terminating amp-script workers when detecting illegal mutations. this was because the worker-thread and main-thread would be out of sync, which would undoubtably cause major bugs.

now that `worker-dom` can [filter them out pre-application](https://github.com/ampproject/worker-dom/pull/764), the sync issue no longer occurs. we can reasonably allow the worker to keep running.

cc @morsssss 