### PR TITLE
Wait for media layout before registering them into the mediapool.

### DIFF
--- a/extensions/amp-story/1.0/test/test-amp-story-page.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-page.js
@@ -17,6 +17,7 @@
 import {AmpDocSingle} from '../../../../src/service/ampdoc-impl';
 import {AmpStoryPage, PageState, Selectors} from '../amp-story-page';
 import {AmpStoryStoreService} from '../amp-story-store-service';
+import {Deferred} from '../../../../src/utils/promise';
 import {LocalizationService} from '../../../../src/service/localization';
 import {MediaType} from '../media-pool';
 import {
@@ -32,6 +33,8 @@ describes.realWin('amp-story-page', {amp: true}, (env) => {
   let gridLayerEl;
   let page;
   let isPerformanceTrackingOn;
+
+  const nextTick = () => new Promise((resolve) => win.setTimeout(resolve, 0));
 
   beforeEach(() => {
     win = env.win;
@@ -267,6 +270,67 @@ describes.realWin('amp-story-page', {amp: true}, (env) => {
     expect(mediaPoolRegister).to.have.been.calledOnceWithExactly(audioEl);
   });
 
+  it('should wait for media layoutCallback to register it', async () => {
+    env.sandbox
+      .stub(page.resources_, 'getResourceForElement')
+      .returns({isDisplayed: () => true});
+
+    const ampVideoEl = win.document.createElement('amp-video');
+    const videoEl = win.document.createElement('video');
+    videoEl.setAttribute('src', 'https://example.com/video.mp4');
+
+    const deferred = new Deferred();
+    ampVideoEl.signals = () => ({
+      signal: () => {},
+      whenSignal: () => deferred.promise,
+    });
+
+    ampVideoEl.appendChild(videoEl);
+    gridLayerEl.appendChild(ampVideoEl);
+
+    page.buildCallback();
+    const mediaPool = await page.mediaPoolPromise_;
+    const mediaPoolRegister = env.sandbox.spy(mediaPool, 'register');
+    await page.layoutCallback();
+    page.setState(PageState.PLAYING);
+
+    deferred.resolve();
+    await nextTick();
+
+    expect(mediaPoolRegister).to.have.been.calledOnceWithExactly(videoEl);
+  });
+
+  it('should not register media before its layoutCallback resolves', async () => {
+    env.sandbox
+      .stub(page.resources_, 'getResourceForElement')
+      .returns({isDisplayed: () => true});
+
+    const ampVideoEl = win.document.createElement('amp-video');
+    const videoEl = win.document.createElement('video');
+    videoEl.setAttribute('src', 'https://example.com/video.mp4');
+
+    const deferred = new Deferred();
+    ampVideoEl.signals = () => ({
+      signal: () => {},
+      whenSignal: () => deferred.promise,
+    });
+
+    ampVideoEl.appendChild(videoEl);
+    gridLayerEl.appendChild(ampVideoEl);
+
+    page.buildCallback();
+    const mediaPool = await page.mediaPoolPromise_;
+    const mediaPoolRegister = env.sandbox.spy(mediaPool, 'register');
+    await page.layoutCallback();
+    page.setState(PageState.PLAYING);
+
+    // Not calling deferred.resolve();
+
+    await nextTick();
+
+    expect(mediaPoolRegister).to.not.have.been.called;
+  });
+
   it('should stop the advancement when state becomes not active', async () => {
     page.buildCallback();
     const advancementStopStub = env.sandbox.stub(page.advancement_, 'stop');
@@ -465,6 +529,8 @@ describes.realWin('amp-story-page', {amp: true}, (env) => {
   });
 
   it('should start tracking media performance when entering the page', async () => {
+    expectAsyncConsoleError(/source must start with/, 1);
+
     env.sandbox
       .stub(page.resources_, 'getResourceForElement')
       .returns({isDisplayed: () => true});
@@ -475,17 +541,21 @@ describes.realWin('amp-story-page', {amp: true}, (env) => {
     );
 
     const videoEl = win.document.createElement('video');
-    videoEl.setAttribute('src', 'https://example.com/video.mp3');
+    videoEl.setAttribute('src', 'localhost/video.mp4');
     gridLayerEl.appendChild(videoEl);
 
     page.buildCallback();
     await page.layoutCallback();
     page.setState(PageState.PLAYING);
 
+    await nextTick();
+
     expect(startMeasuringStub).to.have.been.calledOnceWithExactly(videoEl);
   });
 
   it('should stop tracking media performance when leaving the page', async () => {
+    expectAsyncConsoleError(/source must start with/, 1);
+
     env.sandbox
       .stub(page.resources_, 'getResourceForElement')
       .returns({isDisplayed: () => true});
@@ -496,12 +566,13 @@ describes.realWin('amp-story-page', {amp: true}, (env) => {
     );
 
     const videoEl = win.document.createElement('video');
-    videoEl.setAttribute('src', 'https://example.com/video.mp3');
+    videoEl.setAttribute('src', 'https://example.com/video.mp4');
     gridLayerEl.appendChild(videoEl);
 
     page.buildCallback();
     await page.layoutCallback();
     page.setState(PageState.PLAYING);
+    await nextTick();
     page.setState(PageState.NOT_ACTIVE);
 
     expect(stopMeasuringStub).to.have.been.calledOnceWithExactly(
@@ -511,6 +582,8 @@ describes.realWin('amp-story-page', {amp: true}, (env) => {
   });
 
   it('should not start tracking media performance if tracking is off', async () => {
+    expectAsyncConsoleError(/source must start with/, 1);
+
     env.sandbox
       .stub(page.resources_, 'getResourceForElement')
       .returns({isDisplayed: () => true});
@@ -521,7 +594,7 @@ describes.realWin('amp-story-page', {amp: true}, (env) => {
     );
 
     const videoEl = win.document.createElement('video');
-    videoEl.setAttribute('src', 'https://example.com/video.mp3');
+    videoEl.setAttribute('src', 'https://example.com/video.mp4');
     gridLayerEl.appendChild(videoEl);
 
     page.buildCallback();


### PR DESCRIPTION
Every media element has to be registered into the mediapool before being loaded or played. This register() method is also where the sources are extracted. We wait for the amp-video we want to register to complete its layoutCallback (CommonSignals.LOAD_END), so all the sources, including the origin fallbacks, are in the DOM by the time they're extracted by the mediapool.

Note: I'm keeping preloading as a followup, cf https://github.com/ampproject/amphtml/issues/27983

Fixes https://github.com/ampproject/amphtml/issues/27109