### PR TITLE
✨ Sequence <amp-story-animation>

### DIFF
--- a/extensions/amp-story/1.0/animation-types.js
+++ b/extensions/amp-story/1.0/animation-types.js
@@ -18,6 +18,8 @@ import {
   WebAnimationBuilderOptionsDef,
   WebAnimationDef,
   WebAnimationPlayState,
+  WebAnimationSelectorDef,
+  WebAnimationTimingDef,
   WebKeyframesDef,
 } from '../../amp-animation/0.1/web-animation-types';
 
@@ -26,6 +28,8 @@ export {
   WebAnimationDef,
   WebAnimationPlayState,
   WebKeyframesDef,
+  WebAnimationSelectorDef,
+  WebAnimationTimingDef,
 };
 
 /** @typedef {function(StoryAnimationDimsDef, Object<string, *>):!WebKeyframesDef} */
@@ -54,12 +58,27 @@ export let StoryAnimationPresetDef;
 
 /**
  * @typedef {{
- *  target: !Element,
- *  startAfterId: (string|undefined),
- *  preset: !StoryAnimationPresetDef,
- *  duration: (number|undefined),
- *  delay: (number|undefined),
- *  easing: (string|undefined),
+ *   source: !Element,
+ *   startAfterId: (?string),
+ *   preset: (!StoryAnimationPresetDef|undefined),
+ *   keyframeOptions: (!Object<string, *>|undefined),
+ *   spec: !WebAnimationDef,
  * }}
+ *
+ * - source: Element that defines this animation. This is either an
+ *   <amp-story-animation> element with a JSON spec, or an animated element with
+ *   a preset that is the same as the target ([animate-in] elements).
+ *
+ * - startAfterId: This animation is sequenced after the animation defined by
+ *   the element with this id.
+ *
+ * - preset: Optional, when using [animate-in]
+ *
+ * - keyframeOptions: These are taken from element attributes and passed to a
+ *   preset keyframes() function.
+ *
+ * - spec: An effect spec defined like in <amp-animation>. If a preset is also
+ *   provided, the spec's keyframes property will be resolved with the preset
+ *   configuration.
  */
-export let StoryAnimationDef;
+export let StoryAnimationConfigDef;

--- a/extensions/amp-story/1.0/animation.js
+++ b/extensions/amp-story/1.0/animation.js
@@ -22,11 +22,13 @@ import {
 } from './animation-presets';
 import {Services} from '../../../src/services';
 import {
-  StoryAnimationDef,
+  StoryAnimationConfigDef,
   StoryAnimationDimsDef,
   StoryAnimationPresetDef,
   WebAnimationDef,
   WebAnimationPlayState,
+  WebAnimationSelectorDef,
+  WebAnimationTimingDef,
   WebKeyframesCreateFnDef,
   WebKeyframesDef,
 } from './animation-types';
@@ -74,52 +76,66 @@ const PlaybackActivity = {
   FINISH: 1,
 };
 
+/**
+ * @param {!Element} root
+ * @param {!Element} element
+ * @return {?string}
+ */
+function getSequencingStartAfterId(root, element) {
+  if (!element.hasAttribute(ANIMATE_IN_AFTER_ATTRIBUTE_NAME)) {
+    return null;
+  }
+  const dependencyId = element.getAttribute(ANIMATE_IN_AFTER_ATTRIBUTE_NAME);
+
+  user().assertElement(
+    root.querySelector(`#${escapeCssSelectorIdent(dependencyId)}`),
+    `The attribute '${ANIMATE_IN_AFTER_ATTRIBUTE_NAME}' in tag ` +
+      `'${element.tagName}' is set to the invalid value ` +
+      `'${dependencyId}'. No children of parenting 'amp-story-page' ` +
+      `exist with id ${dependencyId}.`
+  );
+
+  return dependencyId;
+}
+
 /** Wraps WebAnimationRunner for story page elements. */
 export class AnimationRunner {
   /**
    * @param {!Element} page
-   * @param {!WebAnimationDef|!StoryAnimationDef} animationDef
+   * @param {!StoryAnimationConfigDef} config
    * @param {!Promise<!../../amp-animation/0.1/web-animations.Builder>} webAnimationBuilderPromise
    * @param {!../../../src/service/vsync-impl.Vsync} vsync
    * @param {!AnimationSequence} sequence
-   * @param {!Object<string, *>=} keyframeOptions
    */
-  constructor(
-    page,
-    animationDef,
-    webAnimationBuilderPromise,
-    vsync,
-    sequence,
-    keyframeOptions = {}
-  ) {
+  constructor(page, config, webAnimationBuilderPromise, vsync, sequence) {
+    const {source, preset, startAfterId, spec} = config;
+
     /** @private @const */
     this.page_ = page;
+
+    /** @private @const */
+    this.source_ = source;
 
     /** @private @const */
     this.vsync_ = vsync;
 
     /** @private @const {?Element} */
-    this.presetTarget_ = !!animationDef.preset
-      ? dev().assertElement(animationDef.target)
-      : null;
+    this.presetTarget_ = !!preset ? dev().assertElement(spec.target) : null;
 
     /** @private @const */
     this.sequence_ = sequence;
 
-    /** @private @const {string|undefined} */
-    this.startAfterId_ = animationDef.startAfterId;
+    /** @private @const {?string} */
+    this.startAfterId_ = startAfterId;
 
     /** @private @const {!Promise<!WebAnimationDef>} */
-    this.webAnimationDefPromise_ = this.getWebAnimationDef_(
-      animationDef,
-      keyframeOptions
-    );
+    this.resolvedSpecPromise_ = this.resolveSpec_(config);
 
     /**
      * @private @const {!Promise<
      *    !../../amp-animation/0.1/runners/animation-runner.AnimationRunner>}
      */
-    this.runnerPromise_ = this.webAnimationDefPromise_.then((webAnimDef) =>
+    this.runnerPromise_ = this.resolvedSpecPromise_.then((webAnimDef) =>
       webAnimationBuilderPromise.then((builder) =>
         builder.createRunner(webAnimDef)
       )
@@ -129,26 +145,24 @@ export class AnimationRunner {
      * Evaluated set of CSS properties for first animation frame.
      * @private @const {!Promise<?Object<string, *>>}
      */
-    this.firstFrameProps_ = this.webAnimationDefPromise_.then(
-      (animationDef) => {
-        const {keyframes} = animationDef;
-        if (!this.presetTarget_) {
-          // It's only possible to backfill the first frame if we can define it
-          // as native CSS. <amp-animation> has CSS extensions and can have
-          // keyframes defined in a way that prevents us from doing this.
-          //
-          // To avoid visual jumps, this depends on the author properly
-          // defining their CSS so that the initial visual state matches the
-          // initial animation frame.
-          return null;
-        }
-        devAssert(
-          !keyframes[0].offset,
-          'First keyframe offset for animation preset should be 0 or undefined'
-        );
-        return omit(keyframes[0], ['offset']);
+    this.firstFrameProps_ = this.resolvedSpecPromise_.then((spec) => {
+      const {keyframes} = spec;
+      if (!this.presetTarget_) {
+        // It's only possible to backfill the first frame if we can define it
+        // as native CSS. <amp-animation> has CSS extensions and can have
+        // keyframes defined in a way that prevents us from doing this.
+        //
+        // To avoid visual jumps, this depends on the author properly
+        // defining their CSS so that the initial visual state matches the
+        // initial animation frame.
+        return null;
       }
-    );
+      devAssert(
+        !keyframes[0].offset,
+        'First keyframe offset for animation preset should be 0 or undefined'
+      );
+      return omit(keyframes[0], ['offset']);
+    });
 
     /** @private {?../../amp-animation/0.1/runners/animation-runner.AnimationRunner} */
     this.runner_ = null;
@@ -160,8 +174,9 @@ export class AnimationRunner {
     this.scheduledWait_ = null;
 
     if (this.presetTarget_) {
+      const {delay} = /** @type {!WebAnimationTimingDef} */ (spec);
       userAssert(
-        dev().assertNumber(animationDef.delay) >= 0,
+        dev().assertNumber(delay) >= 0,
         'Negative delays are not allowed in amp-story "animate-in" animations.'
       );
     }
@@ -171,28 +186,19 @@ export class AnimationRunner {
 
   /**
    * @param {!Element} page
-   * @param {!WebAnimationDef|!StoryAnimationDef} animationDef
+   * @param {!StoryAnimationConfigDef} config
    * @param {!Promise<!../../amp-animation/0.1/web-animations.Builder>} webAnimationBuilderPromise
    * @param {!../../../src/service/vsync-impl.Vsync} vsync
    * @param {!AnimationSequence} sequence
-   * @param {!Object<string, *>=} keyframeOptions
    * @return {!AnimationRunner}
    */
-  static create(
-    page,
-    animationDef,
-    webAnimationBuilderPromise,
-    vsync,
-    sequence,
-    keyframeOptions = {}
-  ) {
+  static create(page, config, webAnimationBuilderPromise, vsync, sequence) {
     return new AnimationRunner(
       page,
-      animationDef,
+      config,
       webAnimationBuilderPromise,
       vsync,
-      sequence,
-      keyframeOptions
+      sequence
     );
   }
 
@@ -232,7 +238,7 @@ export class AnimationRunner {
   /**
    * Evaluates a preset's keyframes function using dimensions.
    * @param {!WebKeyframesDef|!WebKeyframesCreateFnDef} keyframesOrCreateFn
-   * @param {!Object<string, *>} keyframeOptions
+   * @param {!Object<string, *>=} keyframeOptions
    * @return {!Promise<!WebKeyframesDef>}
    * @private
    */
@@ -240,26 +246,34 @@ export class AnimationRunner {
     if (typeof keyframesOrCreateFn === 'function') {
       return this.getDims().then((dimensions) => {
         const fn = /** @type {!WebKeyframesCreateFnDef} */ (keyframesOrCreateFn);
-        return fn(dimensions, keyframeOptions);
+        return fn(dimensions, keyframeOptions || {});
       });
     }
     return Promise.resolve(keyframesOrCreateFn);
   }
 
   /**
-   * Normalizes an animation definition into a WebAnimationDef to consume.
-   * @param {!StoryAnimationDef|!WebAnimationDef} animationDef
-   * @param {!Object<string, *>} keyframeOptions
+   * Resolves an animation spec that may be incomplete, like from an
+   * [animate-in] preset.
+   * @param {!StoryAnimationConfigDef} storyAnimationConfig
    * @return {!Promise<!WebAnimationDef>}
    */
-  getWebAnimationDef_(animationDef, keyframeOptions) {
-    const {preset} = animationDef;
+  resolveSpec_(storyAnimationConfig) {
+    const {keyframeOptions, preset, spec} = storyAnimationConfig;
     if (!preset) {
       // This is an amp-animation config, so it's already formed how the
       // WebAnimations Builder wants it.
-      return Promise.resolve(/** @type {!WebAnimationDef} */ (animationDef));
+      return Promise.resolve(/** @type {!WebAnimationDef} */ (spec));
     }
-    const {target, delay, duration, easing} = animationDef;
+    // The need for this cast is an unfortunate result of using @mixes in
+    // WebAnimationDef. Otherwise Closure will not understand the timing props
+    // mixed in from another type.
+    const {
+      delay,
+      duration,
+      easing,
+    } = /** @type {!WebAnimationTimingDef} */ (spec);
+    const {target} = /** @type {!WebAnimationSelectorDef} */ (spec);
     return this.resolvePresetKeyframes_(preset.keyframes, keyframeOptions).then(
       (keyframes) => ({
         keyframes,
@@ -490,10 +504,8 @@ export class AnimationRunner {
 
   /** @private */
   notifyFinish_() {
-    // TODO(alanorozco): This should work with <amp-story-animation> by
-    // exposing it as a sequencing id. See https://go.amp.dev/issue/27758
-    if (this.presetTarget_ && this.presetTarget_.id) {
-      this.sequence_.notifyFinish(this.presetTarget_.id);
+    if (this.source_.id) {
+      this.sequence_.notifyFinish(this.source_.id);
     }
   }
 }
@@ -599,9 +611,9 @@ export class AnimationManager {
 
   /**
    * Gets or creates AnimationRunners.
-   * These are either from an <amp-story-animation> config (WebAnimationDefs),
-   * or resolved from presets via animate-in attributes (StoryAnimationDefs).
-   * If a page element contains both kinds of definitions, they'll run
+   * These are either from an <amp-story-animation> spec or resolved from
+   * presets via animate-in attributes.
+   * If a root element contains both kinds of definitions, they'll run
    * concurrently.
    * @return {!Array<!AnimationRunner>}
    * @private
@@ -611,21 +623,28 @@ export class AnimationManager {
       this.runners_ = Array.prototype.map
         .call(
           scopedQuerySelectorAll(this.page_, ANIMATABLE_ELEMENTS_SELECTOR),
-          (el) =>
-            this.createRunner_(
-              this.createAnimationDefFromPreset_(el, this.getPreset_(el)),
-              this.getKeyframeOptions_(el)
-            )
+          (el) => {
+            const preset = this.getPreset_(el);
+            return this.createRunner_({
+              preset,
+              source: el,
+              startAfterId: getSequencingStartAfterId(this.page_, el),
+              keyframeOptions: this.getKeyframeOptions_(el),
+              spec: this.partialAnimationSpecFromPreset_(el, preset),
+            });
+          }
         )
         .concat(
           Array.prototype.map.call(
             childElementsByTag(this.page_, 'amp-story-animation'),
             (el) =>
-              this.createRunner_(
+              this.createRunner_({
+                source: el,
+                startAfterId: getSequencingStartAfterId(this.page_, el),
                 // Casting since we're getting a JsonObject. This will be
                 // validated during preparation phase.
-                /** @type {!WebAnimationDef} */ (getChildJsonConfig(el))
-              )
+                spec: /** @type {!WebAnimationDef} */ (getChildJsonConfig(el)),
+              })
           )
         );
     }
@@ -633,34 +652,35 @@ export class AnimationManager {
   }
 
   /**
-   * @param {!WebAnimationDef|!StoryAnimationDef} animationDef
-   * @param {!Object<string, *>=} keyframeOptions
+   * @param {!StoryAnimationConfigDef} storyAnimationConfig
    * @return {!AnimationRunner}
    */
-  createRunner_(animationDef, keyframeOptions) {
+  createRunner_(storyAnimationConfig) {
     return AnimationRunner.create(
       this.page_,
-      animationDef,
+      storyAnimationConfig,
       devAssert(this.builderPromise_),
       this.vsync_,
-      this.sequence_,
-      keyframeOptions
+      this.sequence_
     );
   }
 
   /**
    * @param {!Element} el
    * @param {!StoryAnimationPresetDef} preset
-   * @return {!StoryAnimationDef}
+   * @return {!WebAnimationDef}
    * @private
    */
-  createAnimationDefFromPreset_(el, preset) {
+  partialAnimationSpecFromPreset_(el, preset) {
     const animationDef = {
-      preset,
       target: el,
       delay: preset.delay || 0,
       duration: preset.duration || 0,
       easing: preset.easing || DEFAULT_EASING,
+
+      // This field is so that we type this as a WebAnimationDef, but it's
+      // replaced when passed to an AnimationRunner.
+      keyframes: [],
     };
 
     if (el.hasAttribute(ANIMATE_IN_DURATION_ATTRIBUTE_NAME)) {
@@ -672,22 +692,6 @@ export class AnimationManager {
     if (el.hasAttribute(ANIMATE_IN_DELAY_ATTRIBUTE_NAME)) {
       animationDef.delay = timeStrToMillis(
         el.getAttribute(ANIMATE_IN_DELAY_ATTRIBUTE_NAME)
-      );
-    }
-
-    if (el.hasAttribute(ANIMATE_IN_AFTER_ATTRIBUTE_NAME)) {
-      const dependencyId = el.getAttribute(ANIMATE_IN_AFTER_ATTRIBUTE_NAME);
-
-      user().assertElement(
-        this.page_.querySelector(`#${escapeCssSelectorIdent(dependencyId)}`),
-        `The attribute '${ANIMATE_IN_AFTER_ATTRIBUTE_NAME}' in tag ` +
-          `'${el.tagName}' is set to the invalid value ` +
-          `'${dependencyId}'. No children of parenting 'amp-story-page' ` +
-          `exist with id ${dependencyId}.`
-      );
-
-      animationDef.startAfterId = el.getAttribute(
-        ANIMATE_IN_AFTER_ATTRIBUTE_NAME
       );
     }
 

--- a/extensions/amp-story/1.0/animation.js
+++ b/extensions/amp-story/1.0/animation.js
@@ -613,7 +613,7 @@ export class AnimationManager {
    * Gets or creates AnimationRunners.
    * These are either from an <amp-story-animation> spec or resolved from
    * presets via animate-in attributes.
-   * If a root element contains both kinds of definitions, they'll run
+   * If a page element contains both kinds of definitions, they'll run
    * concurrently.
    * @return {!Array<!AnimationRunner>}
    * @private

--- a/extensions/amp-story/1.0/animation.js
+++ b/extensions/amp-story/1.0/animation.js
@@ -255,11 +255,11 @@ export class AnimationRunner {
   /**
    * Resolves an animation spec that may be incomplete, like from an
    * [animate-in] preset.
-   * @param {!StoryAnimationConfigDef} storyAnimationConfig
+   * @param {!StoryAnimationConfigDef} config
    * @return {!Promise<!WebAnimationDef>}
    */
-  resolveSpec_(storyAnimationConfig) {
-    const {keyframeOptions, preset, spec} = storyAnimationConfig;
+  resolveSpec_(config) {
+    const {keyframeOptions, preset, spec} = config;
     if (!preset) {
       // This is an amp-animation config, so it's already formed how the
       // WebAnimations Builder wants it.
@@ -652,13 +652,13 @@ export class AnimationManager {
   }
 
   /**
-   * @param {!StoryAnimationConfigDef} storyAnimationConfig
+   * @param {!StoryAnimationConfigDef} config
    * @return {!AnimationRunner}
    */
-  createRunner_(storyAnimationConfig) {
+  createRunner_(config) {
     return AnimationRunner.create(
       this.page_,
-      storyAnimationConfig,
+      config,
       devAssert(this.builderPromise_),
       this.vsync_,
       this.sequence_

--- a/extensions/amp-story/1.0/test/test-animation.js
+++ b/extensions/amp-story/1.0/test/test-animation.js
@@ -73,28 +73,31 @@ describes.realWin('amp-story animations', {}, (env) => {
 
       const keyframeOptions = {foo: 'bar'};
 
-      const animationDef = {
-        duration: 0,
-        delay: 0,
-        target,
-        preset: {
-          keyframes: env.sandbox.spy(() => [{}]),
-        },
+      const preset = {
+        keyframes: env.sandbox.spy(() => [{}]),
       };
 
       const runner = new AnimationRunner(
         page,
-        animationDef,
+        {
+          source: target,
+          preset,
+          keyframeOptions,
+          spec: {
+            duration: 0,
+            delay: 0,
+            target,
+          },
+        },
         webAnimationBuilderPromise,
         vsync,
-        sequence,
-        keyframeOptions
+        sequence
       );
 
       await runner.applyFirstFrame();
 
       expect(
-        animationDef.preset.keyframes.withArgs(
+        preset.keyframes.withArgs(
           env.sandbox.match.any,
           env.sandbox.match(keyframeOptions)
         )
@@ -122,18 +125,21 @@ describes.realWin('amp-story animations', {}, (env) => {
         .stub(target, 'getBoundingClientRect')
         .returns(targetDimensions);
 
-      const animationDef = {
-        duration: 0,
-        delay: 0,
-        target,
-        preset: {
-          keyframes: env.sandbox.spy(() => [{}]),
-        },
+      const preset = {
+        keyframes: env.sandbox.spy(() => [{}]),
       };
 
       const runner = new AnimationRunner(
         page,
-        animationDef,
+        {
+          source: target,
+          preset,
+          spec: {
+            duration: 0,
+            delay: 0,
+            target,
+          },
+        },
         webAnimationBuilderPromise,
         vsync,
         sequence
@@ -142,7 +148,7 @@ describes.realWin('amp-story animations', {}, (env) => {
       await runner.applyFirstFrame();
 
       expect(
-        animationDef.preset.keyframes.withArgs(
+        preset.keyframes.withArgs(
           env.sandbox.match({
             pageWidth: pageDimensions.width,
             pageHeight: pageDimensions.height,
@@ -166,18 +172,19 @@ describes.realWin('amp-story animations', {}, (env) => {
         const page = html`<div></div>`;
         const target = html`<div></div>`;
 
-        const animationDef = {
-          duration: 0,
-          delay: 0,
-          target,
-          preset: {
-            keyframes: keyframeDefTypes[keyframeDefType],
-          },
-        };
-
         const runner = new AnimationRunner(
           page,
-          animationDef,
+          {
+            source: target,
+            preset: {
+              keyframes: keyframeDefTypes[keyframeDefType],
+            },
+            spec: {
+              duration: 0,
+              delay: 0,
+              target,
+            },
+          },
           webAnimationBuilderPromise,
           vsync,
           sequence
@@ -208,19 +215,20 @@ describes.realWin('amp-story animations', {}, (env) => {
       const duration = 123;
       const delay = 456;
 
-      const animationDef = {
-        target,
-        easing,
-        duration,
-        delay,
-        preset: {
-          keyframes: () => keyframes,
-        },
-      };
-
       new AnimationRunner(
         page,
-        animationDef,
+        {
+          source: target,
+          preset: {
+            keyframes: () => keyframes,
+          },
+          spec: {
+            target,
+            easing,
+            duration,
+            delay,
+          },
+        },
         webAnimationBuilderPromise,
         vsync,
         sequence
@@ -253,7 +261,7 @@ describes.realWin('amp-story animations', {}, (env) => {
         () => webAnimationRunner
       );
 
-      const animationDef = {
+      const spec = {
         selector: '.foo',
         easing: 'test-easing',
         duration: 123,
@@ -261,9 +269,11 @@ describes.realWin('amp-story animations', {}, (env) => {
         keyframes: [{}],
       };
 
+      const source = html`<amp-story-animation></amp-story-animation>`;
+
       new AnimationRunner(
         page,
-        animationDef,
+        {source, spec},
         webAnimationBuilderPromise,
         vsync,
         sequence
@@ -271,8 +281,8 @@ describes.realWin('amp-story animations', {}, (env) => {
 
       await nextTick();
 
-      expect(webAnimationBuilder.createRunner.withArgs(animationDef)).to.have
-        .been.calledOnce;
+      expect(webAnimationBuilder.createRunner.withArgs(spec)).to.have.been
+        .calledOnce;
     });
 
     it('starts', async () => {
@@ -287,18 +297,19 @@ describes.realWin('amp-story animations', {}, (env) => {
 
       webAnimationBuilder.createRunner = () => webAnimationRunner;
 
-      const animationDef = {
-        duration: 0,
-        delay: 0,
-        target,
-        preset: {
-          keyframes: [{}],
-        },
-      };
-
       const runner = new AnimationRunner(
         page,
-        animationDef,
+        {
+          source: target,
+          spec: {
+            duration: 0,
+            delay: 0,
+            target,
+            preset: {
+              keyframes: [{}],
+            },
+          },
+        },
         webAnimationBuilderPromise,
         vsync,
         sequence
@@ -327,19 +338,20 @@ describes.realWin('amp-story animations', {}, (env) => {
       const {resolve: resolveWaitFor, promise} = new Deferred();
       sequence.waitFor = env.sandbox.spy(() => promise);
 
-      const animationDef = {
-        duration: 0,
-        delay: 0,
-        target,
-        startAfterId,
-        preset: {
-          keyframes: [{}],
-        },
-      };
-
       const runner = new AnimationRunner(
         page,
-        animationDef,
+        {
+          source: target,
+          startAfterId,
+          preset: {
+            keyframes: [{}],
+          },
+          spec: {
+            duration: 0,
+            delay: 0,
+            target,
+          },
+        },
         webAnimationBuilderPromise,
         vsync,
         sequence
@@ -377,18 +389,19 @@ describes.realWin('amp-story animations', {}, (env) => {
 
       sequence.notifyFinish = env.sandbox.spy();
 
-      const animationDef = {
-        duration: 0,
-        delay: 0,
-        target,
-        preset: {
-          keyframes: [{}],
-        },
-      };
-
       new AnimationRunner(
         page,
-        animationDef,
+        {
+          source: target,
+          preset: {
+            keyframes: [{}],
+          },
+          spec: {
+            duration: 0,
+            delay: 0,
+            target,
+          },
+        },
         webAnimationBuilderPromise,
         vsync,
         sequence
@@ -467,9 +480,8 @@ describes.realWin('amp-story animations', {}, (env) => {
         expect(
           createAnimationRunner.withArgs(
             page,
-            env.sandbox.match({target, preset}),
+            env.sandbox.match({source: target, preset, spec: {target}}),
             webAnimationBuilderPromise,
-            env.sandbox.match.any,
             env.sandbox.match.any,
             env.sandbox.match.any
           )
@@ -483,18 +495,18 @@ describes.realWin('amp-story animations', {}, (env) => {
 
       const page = html`
         <div>
-          <amp-story-animation>
-            <script type="application/json" ref="spec1holder"></script>
+          <amp-story-animation ref="spec1source">
+            <script type="application/json"></script>
           </amp-story-animation>
-          <amp-story-animation>
-            <script type="application/json" ref="spec2holder"></script>
+          <amp-story-animation ref="spec2source">
+            <script type="application/json"></script>
           </amp-story-animation>
         </div>
       `;
 
-      const {spec1holder, spec2holder} = htmlRefs(page);
-      spec1holder.textContent = JSON.stringify(spec1);
-      spec2holder.textContent = JSON.stringify(spec2);
+      const {spec1source, spec2source} = htmlRefs(page);
+      spec1source.firstElementChild.textContent = JSON.stringify(spec1);
+      spec2source.firstElementChild.textContent = JSON.stringify(spec2);
 
       const animationManager = new AnimationManager(page, ampdoc);
       await animationManager.applyFirstFrame();
@@ -502,9 +514,8 @@ describes.realWin('amp-story animations', {}, (env) => {
       expect(
         createAnimationRunner.withArgs(
           page,
-          env.sandbox.match(spec1),
+          env.sandbox.match({source: spec1source, spec: spec1}),
           webAnimationBuilderPromise,
-          env.sandbox.match.any,
           env.sandbox.match.any,
           env.sandbox.match.any
         )
@@ -513,9 +524,8 @@ describes.realWin('amp-story animations', {}, (env) => {
       expect(
         createAnimationRunner.withArgs(
           page,
-          env.sandbox.match(spec2),
+          env.sandbox.match({source: spec2source, spec: spec2}),
           webAnimationBuilderPromise,
-          env.sandbox.match.any,
           env.sandbox.match.any,
           env.sandbox.match.any
         )
@@ -573,11 +583,14 @@ describes.realWin('amp-story animations', {}, (env) => {
         expect(
           createAnimationRunner.withArgs(
             page,
-            env.sandbox.match({target}),
+            env.sandbox.match({
+              source: target,
+              keyframeOptions: expectedOptions,
+              spec: {target},
+            }),
             env.sandbox.match.any,
             env.sandbox.match.any,
-            env.sandbox.match.any,
-            env.sandbox.match(expectedOptions)
+            env.sandbox.match.any
           )
         ).to.have.been.calledOnce;
       });
@@ -598,7 +611,7 @@ describes.realWin('amp-story animations', {}, (env) => {
       );
     });
 
-    it('fails when animate-in-after element does not exist', async () => {
+    it('fails when animate-in-aafter element does not exist', async () => {
       const page = html`
         <div>
           <div animate-in="fly-in-left" animate-in-after="does-not-exist"></div>
@@ -629,9 +642,23 @@ describes.realWin('amp-story animations', {}, (env) => {
             animate-in-after="animated-second"
             animate-in="fly-in-right"
           ></div>
+          <amp-story-animation
+            id="animated-fourth"
+            ref="animatedFourth"
+            animate-in-after="animated-third"
+          >
+            <script type="application/json">
+              {}
+            </script>
+          </amp-story-animation>
         </div>
       `;
-      const {animatedFirst, animatedSecond, animatedThird} = htmlRefs(page);
+      const {
+        animatedFirst,
+        animatedSecond,
+        animatedThird,
+        animatedFourth,
+      } = htmlRefs(page);
 
       env.win.document.body.appendChild(page);
 
@@ -641,8 +668,11 @@ describes.realWin('amp-story animations', {}, (env) => {
       expect(
         createAnimationRunner.withArgs(
           env.sandbox.match.any,
-          env.sandbox.match({target: animatedFirst, startAfterId: undefined}),
-          env.sandbox.match.any,
+          env.sandbox.match({
+            source: animatedFirst,
+            startAfterId: null,
+            spec: {target: animatedFirst},
+          }),
           env.sandbox.match.any,
           env.sandbox.match.any,
           env.sandbox.match.any
@@ -653,10 +683,10 @@ describes.realWin('amp-story animations', {}, (env) => {
         createAnimationRunner.withArgs(
           env.sandbox.match.any,
           env.sandbox.match({
-            target: animatedSecond,
+            source: animatedSecond,
             startAfterId: 'animated-first',
+            spec: {target: animatedSecond},
           }),
-          env.sandbox.match.any,
           env.sandbox.match.any,
           env.sandbox.match.any,
           env.sandbox.match.any
@@ -667,10 +697,24 @@ describes.realWin('amp-story animations', {}, (env) => {
         createAnimationRunner.withArgs(
           env.sandbox.match.any,
           env.sandbox.match({
-            target: animatedThird,
+            source: animatedThird,
             startAfterId: 'animated-second',
+            spec: {target: animatedThird},
           }),
           env.sandbox.match.any,
+          env.sandbox.match.any,
+          env.sandbox.match.any
+        )
+      ).to.have.been.calledOnce;
+
+      expect(
+        createAnimationRunner.withArgs(
+          env.sandbox.match.any,
+          env.sandbox.match({
+            source: animatedFourth,
+            startAfterId: 'animated-third',
+            spec: {},
+          }),
           env.sandbox.match.any,
           env.sandbox.match.any,
           env.sandbox.match.any

--- a/extensions/amp-story/1.0/test/test-animation.js
+++ b/extensions/amp-story/1.0/test/test-animation.js
@@ -301,13 +301,13 @@ describes.realWin('amp-story animations', {}, (env) => {
         page,
         {
           source: target,
+          preset: {
+            keyframes: [{}],
+          },
           spec: {
             duration: 0,
             delay: 0,
             target,
-            preset: {
-              keyframes: [{}],
-            },
           },
         },
         webAnimationBuilderPromise,

--- a/extensions/amp-story/1.0/test/test-animation.js
+++ b/extensions/amp-story/1.0/test/test-animation.js
@@ -611,7 +611,7 @@ describes.realWin('amp-story animations', {}, (env) => {
       );
     });
 
-    it('fails when animate-in-aafter element does not exist', async () => {
+    it('fails when animate-in-after element does not exist', async () => {
       const page = html`
         <div>
           <div animate-in="fly-in-left" animate-in-after="does-not-exist"></div>


### PR DESCRIPTION
Partial for #27758

1. Restructure `StoryAnimationConfigDef` so that it contains a `WebAnimationDef` without duplicate props.

2. Wrap `<amp-story-animation>` specs in a `StoryAnimationConfigDef`.

3. `<amp-story-animation>` passes the id of a `source` it will wait for. It can also define its own sequencing id.