### PR TITLE
Handle decode errors in amp-video

### DIFF
--- a/extensions/amp-video/0.1/amp-video.js
+++ b/extensions/amp-video/0.1/amp-video.js
@@ -367,8 +367,9 @@ class AmpVideo extends AMP.BaseElement {
 
   /**
    * Gracefully handle media errors if possible.
+   * @param {!Event} event
    */
-  handleMediaError_() {
+  handleMediaError_(event) {
     if (
       !this.video_.error ||
       this.video_.error.code != MediaError.MEDIA_ERR_DECODE
@@ -405,6 +406,7 @@ class AmpVideo extends AMP.BaseElement {
     );
     removeElement(currentSource);
     // Resets the loading and will catch the new source if any.
+    event.stopImmediatePropagation();
     this.video_.load();
     // Unfortunately we don't know exactly what operation caused the decode to
     // fail. But to help, we need to retry. Since play is most common, we're
@@ -546,7 +548,7 @@ class AmpVideo extends AMP.BaseElement {
    */
   installEventHandlers_() {
     const video = dev().assertElement(this.video_);
-    video.addEventListener('error', () => this.handleMediaError_());
+    video.addEventListener('error', (e) => this.handleMediaError_(e));
 
     const forwardEventsUnlisten = this.forwardEvents(
       [

--- a/extensions/amp-video/0.1/amp-video.js
+++ b/extensions/amp-video/0.1/amp-video.js
@@ -97,9 +97,6 @@ class AmpVideo extends AMP.BaseElement {
 
     /** @visibleForTesting {?Element} */
     this.posterDummyImageForTesting_ = null;
-
-    /** @private {boolean} */
-    this.hasEverAttemptedToPlay_ = false;
   }
 
   /**
@@ -408,9 +405,7 @@ class AmpVideo extends AMP.BaseElement {
     // Unfortunately we don't know exactly what operation caused the decode to
     // fail. But to help, we need to retry. Since play is most common, we're
     // doing that.
-    if (this.hasEverAttemptedToPlay_) {
-      this.play(false);
-    }
+    this.play(false);
   }
 
   /**
@@ -625,7 +620,6 @@ class AmpVideo extends AMP.BaseElement {
    * @override
    */
   play(unusedIsAutoplay) {
-    this.hasEverAttemptedToPlay_ = true;
     const ret = this.video_.play();
 
     if (ret && ret.catch) {

--- a/extensions/amp-video/0.1/amp-video.js
+++ b/extensions/amp-video/0.1/amp-video.js
@@ -405,7 +405,7 @@ class AmpVideo extends AMP.BaseElement {
     // Unfortunately we don't know exactly what operation caused the decode to
     // fail. But to help, we need to retry. Since play is most common, we're
     // doing that.
-    this.play();
+    this.play(false);
   }
 
   /**

--- a/extensions/amp-video/0.1/amp-video.js
+++ b/extensions/amp-video/0.1/amp-video.js
@@ -19,6 +19,7 @@ import {Services} from '../../../src/services';
 import {VideoEvents} from '../../../src/video-interface';
 import {VisibilityState} from '../../../src/visibility-state';
 import {
+  childElement,
   childElementByTag,
   childElementsByTag,
   fullscreenEnter,
@@ -28,7 +29,7 @@ import {
   removeElement,
 } from '../../../src/dom';
 import {descendsFromStory} from '../../../src/utils/story';
-import {dev, devAssert} from '../../../src/log';
+import {dev, devAssert, user} from '../../../src/log';
 import {getMode} from '../../../src/mode';
 import {htmlFor} from '../../../src/static-template';
 import {installVideoManagerForDoc} from '../../../src/service/video-manager-impl';
@@ -365,6 +366,49 @@ class AmpVideo extends AMP.BaseElement {
   }
 
   /**
+   * Gracefully handle media errors if possible.
+   */
+  handleMediaError_() {
+    if (
+      !this.video_.error ||
+      this.video_.error.code != MediaError.MEDIA_ERR_DECODE
+    ) {
+      return;
+    }
+    // HTMLMediaElements automatically fallback to the next source if a load fails
+    // but they don't try the next source upon a decode error.
+    // This code does this fallback manually.
+    user().error(
+      TAG,
+      `Decode error in ${this.video_.currentSrc}`,
+      this.element
+    );
+    // Find the source element that caused the decode error.
+    let sourceCount = 0;
+    const currentSource = childElement(this.video_, (source) => {
+      if (source.tagName != 'SOURCE') {
+        return false;
+      }
+      sourceCount++;
+      return source.src == this.video_.currentSrc;
+    });
+    if (sourceCount == 0) {
+      return;
+    }
+    dev().assertElement(
+      currentSource,
+      `Can't find source element for currentSrc ${this.video_.currentSrc}`
+    );
+    removeElement(currentSource);
+    // Resets the loading and will catch the new source if any.
+    this.video_.load();
+    // Unfortunately we don't know exactly what operation caused the decode to
+    // fail. But to help, we need to retry. Since play is most common, we're
+    // doing that.
+    this.play();
+  }
+
+  /**
    * @private
    * Propagate sources that are cached by the CDN.
    */
@@ -498,6 +542,7 @@ class AmpVideo extends AMP.BaseElement {
    */
   installEventHandlers_() {
     const video = dev().assertElement(this.video_);
+    video.addEventListener('error', () => this.handleMediaError_());
 
     const forwardEventsUnlisten = this.forwardEvents(
       [

--- a/extensions/amp-video/0.1/amp-video.js
+++ b/extensions/amp-video/0.1/amp-video.js
@@ -383,6 +383,10 @@ class AmpVideo extends AMP.BaseElement {
       `Decode error in ${this.video_.currentSrc}`,
       this.element
     );
+    // No fallback available for bare src.
+    if (this.video_.src) {
+      return;
+    }
     // Find the source element that caused the decode error.
     let sourceCount = 0;
     const currentSource = childElement(this.video_, (source) => {

--- a/extensions/amp-video/0.1/amp-video.js
+++ b/extensions/amp-video/0.1/amp-video.js
@@ -97,6 +97,9 @@ class AmpVideo extends AMP.BaseElement {
 
     /** @visibleForTesting {?Element} */
     this.posterDummyImageForTesting_ = null;
+
+    /** @private {boolean} */
+    this.hasEverAttemptedToPlay_ = false;
   }
 
   /**
@@ -405,7 +408,9 @@ class AmpVideo extends AMP.BaseElement {
     // Unfortunately we don't know exactly what operation caused the decode to
     // fail. But to help, we need to retry. Since play is most common, we're
     // doing that.
-    this.play(false);
+    if (this.hasEverAttemptedToPlay_) {
+      this.play(false);
+    }
   }
 
   /**
@@ -620,6 +625,7 @@ class AmpVideo extends AMP.BaseElement {
    * @override
    */
   play(unusedIsAutoplay) {
+    this.hasEverAttemptedToPlay_ = true;
     const ret = this.video_.play();
 
     if (ret && ret.catch) {

--- a/extensions/amp-video/0.1/test/test-amp-video.js
+++ b/extensions/amp-video/0.1/test/test-amp-video.js
@@ -445,6 +445,58 @@ describes.realWin(
       expect(catchSpy.called).to.be.true;
     });
 
+    it('decode error retries the next source', async () => {
+      const s0 = doc.createElement('source');
+      s0.setAttribute('src', 'https://example.com/0.mp4');
+      const s1 = doc.createElement('source');
+      s1.setAttribute('src', 'https://example.com/1.mp4');
+      const video = await getVideo(
+        {
+          width: 160,
+          height: 90,
+        },
+        [s0, s1]
+      );
+      const ele = video.implementation_.video_;
+      ele.play = env.sandbox.stub();
+      ele.load = env.sandbox.stub();
+      Object.defineProperty(ele, 'error', {
+        value: {
+          code: MediaError.MEDIA_ERR_DECODE,
+        },
+      });
+      expect(ele.childElementCount).to.equal(2);
+      ele.dispatchEvent(new ErrorEvent('error'));
+      expect(ele.childElementCount).to.equal(1);
+      expect(ele.load).to.have.been.called;
+      expect(ele.play).to.have.been.called;
+    });
+
+    it('non-decode error has no side effect', async () => {
+      const s0 = doc.createElement('source');
+      s0.setAttribute('src', 'https://example.com/0.mp4');
+      const s1 = doc.createElement('source');
+      s1.setAttribute('src', 'https://example.com/1.mp4');
+      const video = await getVideo(
+        {
+          width: 160,
+          height: 90,
+        },
+        [s0, s1]
+      );
+      const ele = video.implementation_.video_;
+      ele.play = env.sandbox.stub();
+      ele.load = env.sandbox.stub();
+      Object.defineProperty(ele, 'error', {
+        value: {
+          code: MediaError.MEDIA_ERR_ABORTED,
+        },
+      });
+      expect(ele.childElementCount).to.equal(2);
+      ele.dispatchEvent(new ErrorEvent('error'));
+      expect(ele.childElementCount).to.equal(2);
+    });
+
     it('should propagate ARIA attributes', async () => {
       const v = await getVideo({
         src: 'video.mp4',

--- a/extensions/amp-video/0.1/test/test-amp-video.js
+++ b/extensions/amp-video/0.1/test/test-amp-video.js
@@ -465,11 +465,39 @@ describes.realWin(
           code: MediaError.MEDIA_ERR_DECODE,
         },
       });
+      video.implementation_.play();
       expect(ele.childElementCount).to.equal(2);
       ele.dispatchEvent(new ErrorEvent('error'));
       expect(ele.childElementCount).to.equal(1);
       expect(ele.load).to.have.been.called;
       expect(ele.play).to.have.been.called;
+    });
+
+    it('decode error retries the next source but does not play if never played', async () => {
+      const s0 = doc.createElement('source');
+      s0.setAttribute('src', 'https://example.com/0.mp4');
+      const s1 = doc.createElement('source');
+      s1.setAttribute('src', 'https://example.com/1.mp4');
+      const video = await getVideo(
+        {
+          width: 160,
+          height: 90,
+        },
+        [s0, s1]
+      );
+      const ele = video.implementation_.video_;
+      ele.play = env.sandbox.stub();
+      ele.load = env.sandbox.stub();
+      Object.defineProperty(ele, 'error', {
+        value: {
+          code: MediaError.MEDIA_ERR_DECODE,
+        },
+      });
+      expect(ele.childElementCount).to.equal(2);
+      ele.dispatchEvent(new ErrorEvent('error'));
+      expect(ele.childElementCount).to.equal(1);
+      expect(ele.load).to.have.been.called;
+      expect(ele.play).to.not.have.been.called;
     });
 
     it('non-decode error has no side effect', async () => {

--- a/extensions/amp-video/0.1/test/test-amp-video.js
+++ b/extensions/amp-video/0.1/test/test-amp-video.js
@@ -465,39 +465,11 @@ describes.realWin(
           code: MediaError.MEDIA_ERR_DECODE,
         },
       });
-      video.implementation_.play();
       expect(ele.childElementCount).to.equal(2);
       ele.dispatchEvent(new ErrorEvent('error'));
       expect(ele.childElementCount).to.equal(1);
       expect(ele.load).to.have.been.called;
       expect(ele.play).to.have.been.called;
-    });
-
-    it('decode error retries the next source but does not play if never played', async () => {
-      const s0 = doc.createElement('source');
-      s0.setAttribute('src', 'https://example.com/0.mp4');
-      const s1 = doc.createElement('source');
-      s1.setAttribute('src', 'https://example.com/1.mp4');
-      const video = await getVideo(
-        {
-          width: 160,
-          height: 90,
-        },
-        [s0, s1]
-      );
-      const ele = video.implementation_.video_;
-      ele.play = env.sandbox.stub();
-      ele.load = env.sandbox.stub();
-      Object.defineProperty(ele, 'error', {
-        value: {
-          code: MediaError.MEDIA_ERR_DECODE,
-        },
-      });
-      expect(ele.childElementCount).to.equal(2);
-      ele.dispatchEvent(new ErrorEvent('error'));
-      expect(ele.childElementCount).to.equal(1);
-      expect(ele.load).to.have.been.called;
-      expect(ele.play).to.not.have.been.called;
     });
 
     it('non-decode error has no side effect', async () => {

--- a/extensions/amp-video/0.1/test/test-amp-video.js
+++ b/extensions/amp-video/0.1/test/test-amp-video.js
@@ -465,11 +465,14 @@ describes.realWin(
           code: MediaError.MEDIA_ERR_DECODE,
         },
       });
+      const secondErrorHandler = env.sandbox.stub();
+      ele.addEventListener('error', secondErrorHandler);
       expect(ele.childElementCount).to.equal(2);
       ele.dispatchEvent(new ErrorEvent('error'));
       expect(ele.childElementCount).to.equal(1);
       expect(ele.load).to.have.been.called;
       expect(ele.play).to.have.been.called;
+      expect(secondErrorHandler).to.not.have.been.called;
     });
 
     it('non-decode error has no side effect', async () => {
@@ -492,9 +495,12 @@ describes.realWin(
           code: MediaError.MEDIA_ERR_ABORTED,
         },
       });
+      const secondErrorHandler = env.sandbox.stub();
+      ele.addEventListener('error', secondErrorHandler);
       expect(ele.childElementCount).to.equal(2);
       ele.dispatchEvent(new ErrorEvent('error'));
       expect(ele.childElementCount).to.equal(2);
+      expect(secondErrorHandler).to.have.been.called;
     });
 
     it('should propagate ARIA attributes', async () => {

--- a/extensions/amp-video/0.1/test/test-amp-video.js
+++ b/extensions/amp-video/0.1/test/test-amp-video.js
@@ -447,7 +447,7 @@ describes.realWin(
 
     it('decode error retries the next source', async () => {
       const s0 = doc.createElement('source');
-      s0.setAttribute('src', 'https://example.com/0.mp4');
+      s0.setAttribute('src', './0.mp4');
       const s1 = doc.createElement('source');
       s1.setAttribute('src', 'https://example.com/1.mp4');
       const video = await getVideo(


### PR DESCRIPTION
Decode errors do not fallback to the next available source. This code manually handles that fallback.

Fixes #27982