### PR TITLE
🏗✨ Enforce a minimum of 80% code coverage for AMP source code

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -24,15 +24,13 @@ coverage:
       default:
         base: auto
         if_not_found: success
-        informational: true # TODO(rsimha): Remove this line after testing
         only_pulls: true
         target: 80%
-        threshold: 10%
+        threshold: 1%
     patch:
       default:
         base: auto
-        informational: true # TODO(rsimha): Remove this line after testing
         if_not_found: success
         only_pulls: true
         target: 80%
-        threshold: 10%
+        threshold: 1%


### PR DESCRIPTION
**Background:**

One of the AMP team's long-term goals is to improve release quality via automated testing. A few of the bugs we've found recently could have easily been caught by tests that were either missing or had been skipped.

Today, the AMP runtime code ([not counting](https://github.com/ampproject/amphtml/blob/90f1f7fcff01c68d703140e1cb6f6da2ebbabbef/build-system/babel-config/test-config.js#L30-L37) ads, infrastructure, third party, and test code) has a little more than 80% code coverage from unit tests as reported on [this dashboard](https://codecov.io/gh/ampproject/amphtml/tree/master) (click through for subdirectory-level numbers).

[![image](https://user-images.githubusercontent.com/26553114/80176366-57b94580-85c6-11ea-9650-daff77e406dc.png)](https://codecov.io/gh/ampproject/amphtml/tree/master)

It's important to note that 100% code coverage does not guarantee that 100% of all code paths are tested. However, it still is worth detecting and addressing instances of code with no (or very low) coverage. For example, we have [20% coverage](https://codecov.io/gh/ampproject/amphtml/src/c619be8/builtins/amp-layout.js) for `builtins/amp-layout.js`, [<40% coverage](https://codecov.io/gh/ampproject/amphtml/tree/c619be8/src/polyfills) for `src/polyfills`, and [~55% coverage](https://codecov.io/gh/ampproject/amphtml/tree/c619be8/src/inabox) for `src/inabox`. In addition, there are numerous runtime files with [<50% coverage](https://codecov.io/gh/ampproject/amphtml/list/c619be8/src) and dozens of extension files with [<60% coverage](https://codecov.io/gh/ampproject/amphtml/tree/c619be8/extensions).

**Previous work:**

In #27843, we enabled code coverage statuses for every AMP PR in informational mode.

For PRs that touch runtime code and have test coverage, we see a status like this:

![image](https://user-images.githubusercontent.com/26553114/80175962-2f7d1700-85c5-11ea-8c67-f179cf0263e0.png)

For PRs that don't touch runtime code, we see a status like this:

![image](https://user-images.githubusercontent.com/26553114/80175988-402d8d00-85c5-11ea-96dc-264b3475c39f.png)

**PR highlights:**

This PR implements the recommendation around code coverage from a recent design review (https://github.com/ampproject/amphtml/issues/27599#issuecomment-611193359). We are moving from informational mode to blocking mode. Any PR that touches AMP runtime code and has lower than 80% patch-level coverage (i.e., coverage for the lines being changed) will be blocked. The 80% target was chosen in order to prevent PRs from lowering AMP's overall coverage. There is a further 1% threshold to prevent rounding errors, and to allow for some wiggle room.

**Local testing:**

In order to tell how an in-flight PR is likely to affect patch-level code coverage, run the following command.

```sh
gulp unit --local_changes --coverage
```

After tests complete, you will see a full coverage report for the tests you just ran in a new browser tab.

**Future work:**

With this, we should see a gradual uptick in total code coverage as tests are added for code that is currently untested. As total coverage increases over time, we can increase the target values.

In addition, if we are able to figure out how to measure code coverage (#22682) for integration, end-to-end, and visual-diff tests, we can further add to the coverage measurements and further increase the thresholds.