### PR TITLE
🖍 Enable amp-ad-no-center-css CSS for canary

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -37,5 +37,6 @@
   "random-subdomain-for-safeframe": 0.02,
   "swg-gpay-api": 1,
   "swg-gpay-native": 1,
-  "version-locking": 1
+  "version-locking": 1,
+  "amp-ad-no-center-css": 1
 }


### PR DESCRIPTION
This PR turns on the no css for canary.