### PR TITLE
🐛Remove title if not bot

### DIFF
--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -431,7 +431,9 @@ export class AmpStory extends AMP.BaseElement {
 
     // Removes title in order to prevent incorrect titles appearing on link
     // hover. (See 17654)
-    this.element.removeAttribute('title');
+    if (!this.platform_.isBot()) {
+      this.element.removeAttribute('title');
+    }
 
     // Remove text nodes which would be shown outside of the amp-story
     const textNodes = childNodes(


### PR DESCRIPTION
Remove the title only if the platform is not bot.
Used for crawling only, but remove otherwise.

Fixes #27997
