### PR TITLE
🐛 Restrict display:block/position:relative styles to implicit responsive layout

### DIFF
--- a/css/ampshared.css
+++ b/css/ampshared.css
@@ -58,7 +58,7 @@
 
 .i-amphtml-layout-responsive,
 [layout=responsive][width][height]:not(.i-amphtml-layout-responsive),
-[width][height][sizes]:not([disable-inline-width]):not(.i-amphtml-layout-responsive)
+[width][height][sizes]:not([layout]):not(.i-amphtml-layout-responsive)
 {
   display: block;
   position: relative;

--- a/css/ampshared.css
+++ b/css/ampshared.css
@@ -58,7 +58,7 @@
 
 .i-amphtml-layout-responsive,
 [layout=responsive][width][height]:not(.i-amphtml-layout-responsive),
-[width][height][sizes]:not(.i-amphtml-layout-responsive)
+[width][height][sizes]:not([disable-inline-width]):not(.i-amphtml-layout-responsive)
 {
   display: block;
   position: relative;


### PR DESCRIPTION
In #27083 the `disable-inline-width` attribute was introduced to allow “specifying the `sizes` on elements without getting the sizing behavior of sizes in AMP (which adds a width based on which media query matches).” This addressed #21736. 

In the WordPress AMP plugin we wrestled a lot with AMP's `sizes` behavior (#17053), leading us ultimately to remove the `sizes` attribute altogether to avoid it (https://github.com/ampproject/amp-wp/pull/2036). This was not ideal because even though WordPress generates images with `sizes` and `srcset`, for the sake of AMP we had to strip the `sizes` out. 

When [updating the validator spec](https://github.com/ampproject/amp-wp/pull/4548) in the plugin, I discovered the new `disable-inline-width` attribute and [confirmed](https://github.com/ampproject/amphtml/pull/27083#issuecomment-610767867 ) with @caroqliu that it would prevents AMP's default `sizes` behavior.

So we [proceeded](https://github.com/ampproject/amp-wp/pull/4622) to eliminate the removal of the `sizes` attribute in favor of adding the `disable-inline-width` attribute when converting `img` to `amp-img`. It all seemed to work perfectly except for one particular case, where an image is added inline within a paragraph.

In the non-AMP version and the AMP version when `sizes` is removed, the inline image is rendered like so:

> ![image](https://user-images.githubusercontent.com/134745/80143446-ab457800-8561-11ea-894f-6144983b9a08.png)

However, when `sizes` is retained with `disable-inline-width` added, the result is the image appearing on its own line:

> ![image](https://user-images.githubusercontent.com/134745/80143523-ca440a00-8561-11ea-8fdb-d5ef4ecf7a88.png)

This is due to this CSS rule in `ampshared.css`:

https://github.com/ampproject/amphtml/blob/97099ce8bf4826a08d964e7a02da55a7641b1090/css/ampshared.css#L59-L65

It appears that the last selector in this rule (`[width][height][sizes]:not(.i-amphtml-layout-responsive)`) was not updated to account for the presence of the `disable-inline-width` attribute: 

```diff
- [width][height][sizes]:not(.i-amphtml-layout-responsive)
+ [width][height][sizes]:not([disable-inline-width]):not(.i-amphtml-layout-responsive)
```

The result is the element [unexpectedly](https://github.com/ampproject/amp-wp/pull/4622#issuecomment-618632173) getting a `display:block` style rather than the expected `display:inline-block`.

Is there any need for elements with the `disable-inline-width` attribute to have these styles applied? If not, this PR excludes such elements from getting the styles unnecessarily.