### PR TITLE
build-system: Use python2.7 executable name

### DIFF
--- a/build-system/common/check-package-manager.js
+++ b/build-system/common/check-package-manager.js
@@ -33,7 +33,7 @@ const gulpHelpUrl =
 
 const yarnExecutable = 'npx yarn';
 const gulpExecutable = 'npx gulp';
-const pythonExecutable = 'python';
+const pythonExecutable = 'python2.7';
 
 const wrongGulpPaths = [
   '/bin/',

--- a/build-system/tasks/validator.js
+++ b/build-system/tasks/validator.js
@@ -27,7 +27,7 @@ if (argv.update_tests) {
  * Simple wrapper around the python based validator build.
  */
 async function validator() {
-  execOrDie('python build.py' + validatorArgs, {
+  execOrDie('python2.7 build.py' + validatorArgs, {
     cwd: 'validator',
     stdio: 'inherit',
   });
@@ -47,7 +47,7 @@ async function validatorJava() {
  * Simple wrapper around the python based validator webui build.
  */
 async function validatorWebui() {
-  execOrDie('python build.py' + validatorArgs, {
+  execOrDie('python2.7 build.py' + validatorArgs, {
     cwd: 'validator/webui',
     stdio: 'inherit',
   });

--- a/third_party/ant/bin/runant.py
+++ b/third_party/ant/bin/runant.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2.7
 # Licensed to the Apache Software Foundation (ASF) under one or more
 #  contributor license agreements.  See the NOTICE file distributed with
 #  this work for additional information regarding copyright ownership.

--- a/third_party/nailgun/nailgun-runner
+++ b/third_party/nailgun/nailgun-runner
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 #
 # Copyright 2004-2015, Martian Software, Inc.
 # Copyright 2017-Present Facebook, Inc.

--- a/validator/README.md
+++ b/validator/README.md
@@ -94,15 +94,15 @@ Dependencies:
 
 ### Usage
 
-Then, run `python build.py`. This creates `dist/validator_minified.js`, which is
+Then, run `python2.7 build.py`. This creates `dist/validator_minified.js`, which is
 equivalent to the validator deployed at cdn.ampproject.org. You may now
 use the `--validator_js` command line flag to
 [amphtml-validator](https://amp.dev/documentation/guides-and-tutorials/learn/validation-workflow/validate_amp#command-line-tool) to use this validator.
 
-For use for testing with extensions, you can simply run `python build.py`
+For use for testing with extensions, you can simply run `python2.7 build.py`
 to run all of the validator tests in the amphtml repo.
 To create/update `validator-*.out` files that are used in the test,
-run `python build.py --update_tests`.
+run `python2.7 build.py --update_tests`.
 
 ```sh
 $ amphtml-validator --validator_js dist/validator_minified.js testdata/feature_tests/several_errors.html
@@ -118,7 +118,7 @@ testdata/feature_tests/several_errors.html:34:2 The attribute 'width' in tag 'am
 _Note: This is for building the validator from source. If you are simply running validator tests for extensions, see the Installation steps instead._
 
 - Download protobuf with `brew install protobuf` via [homebrew](https://brew.sh/).
-- Use pip to `pip install google` and `pip install protobuf`. If you don't have pip, you can get it either via `brew install python` or [get-pip.py](https://bootstrap.pypa.io/get-pip.py).
+- Use pip to `pip install google` and `pip install protobuf`. If you don't have pip, you can get it either via `brew install python@2` or [get-pip.py](https://bootstrap.pypa.io/get-pip.py).
 - If your [npm](https://www.npmjs.com/) is out of date, run `npm i -g npm` to update it.
 
 To verify that you have the necessary prerequisites, run and verify:
@@ -131,9 +131,9 @@ libprotoc 3.5.1
 and
 
 ```sh
-$ python
+$ python2.7
 >>> import google.protobuf
 >>>
 ```
 
-Now `cd amphtml/validator` and run `python build.py`.
+Now `cd amphtml/validator` and run `python2.7 build.py`.

--- a/validator/build.py
+++ b/validator/build.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 #
 # Copyright 2015 The AMP HTML Authors. All Rights Reserved.
 #

--- a/validator/validator_gen_js.py
+++ b/validator/validator_gen_js.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python2.7
 #
 # Copyright 2015 The AMP HTML Authors. All Rights Reserved.
 #


### PR DESCRIPTION
As Python3 continues to take market share from Python2, we cannot rely
on `python` reliably mapping to `python2.7`. Ubuntu 20.04 does away with
`python` completely (users need to manually setup `update-alternatives`
or alias it themselves). Since the build system requests Python 2.7 when
checking packages, go ahead and explicitly call `python2.7`.

<!--
# Instructions:

- Pick a meaningful title for your pull request. (Use sentence case.)
  - Prefix the title with an emoji to identify what is being done. (Copy-paste the emoji from the list below.)
  - Do not overuse punctuation in the title (like `(chore):`).
  - If it is helpful, use a simple prefix (like `ProjectX: Implement some feature`).
- Enter a succinct description that says why the PR is necessary, and what it does.
  - Mention the GitHub issue that is being addressed by the pull request.
  - The keywords `Fixes`, `Closes`, or `Resolves` followed the issue number will automatically close the issue.

> NOTE: All non-trivial changes (like introducing new features or components) should have an associated issue or reference an I2I (intent-to-implement: go.amp.dev/i2i). Please read through the contribution process (go.amp.dev/contributing/code) for more information.

# Example of a good description:

- Implement aspect X
- Leave out feature Y because of A
- Improve performance by B
- Improve accessibility by C

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Reverting a previous change
♻️ Refactoring
🚮 Deleting code
-->
