### PR TITLE
validator: Python3 compatibility fixes

### DIFF
--- a/validator/validator_gen.py
+++ b/validator/validator_gen.py
@@ -60,7 +60,7 @@ def FindDescriptors(validator_pb2, msg_desc_by_name, enum_desc_by_name):
     msg_desc_by_name: A map of message descriptors, keyed by full_name.
     enum_desc_by_name: A map of enum descriptors, keyed by full name.
   """
-  for msg_type in validator_pb2.DESCRIPTOR.message_types_by_name.values():
+  for msg_type in list(validator_pb2.DESCRIPTOR.message_types_by_name.values()):
     msg_desc_by_name[msg_type.full_name] = msg_type
     for enum_type in msg_type.enum_types:
       enum_desc_by_name[enum_type.full_name] = enum_type
@@ -107,7 +107,7 @@ def NonRepeatedValueToString(descriptor, field_desc, value):
   """
   if field_desc.type == descriptor.FieldDescriptor.TYPE_STRING:
     escaped = ('' + value).encode('unicode-escape')
-    return "'%s'" % escaped.replace("'", "\\'")
+    return "'%s'" % escaped.decode().replace("'", "\\'")
   if field_desc.type == descriptor.FieldDescriptor.TYPE_BOOL:
     if value:
       return 'true'
@@ -255,7 +255,7 @@ def GenerateValidatorGeneratedJs(specfile, validator_pb2, text_format,
   FindDescriptors(validator_pb2, msg_desc_by_name, enum_desc_by_name)
 
   rules_obj = '%s.RULES' % validator_pb2.DESCRIPTOR.package
-  all_names = [rules_obj] + msg_desc_by_name.keys() + enum_desc_by_name.keys()
+  all_names = [rules_obj] + list(msg_desc_by_name.keys()) + list(enum_desc_by_name.keys())
   all_names.sort()
 
   out.append('//')

--- a/validator/validator_gen_js.py
+++ b/validator/validator_gen_js.py
@@ -61,7 +61,7 @@ def FindDescriptors(validator_pb2, msg_desc_by_name, enum_desc_by_name):
     msg_desc_by_name: A map of message descriptors, keyed by full_name.
     enum_desc_by_name: A map of enum descriptors, keyed by full name.
   """
-  for msg_type in validator_pb2.DESCRIPTOR.message_types_by_name.values():
+  for msg_type in list(validator_pb2.DESCRIPTOR.message_types_by_name.values()):
     msg_desc_by_name[msg_type.full_name] = msg_type
     for enum_type in msg_type.enum_types:
       enum_desc_by_name[enum_type.full_name] = enum_type
@@ -321,7 +321,7 @@ def ValueToString(descriptor, field_desc, value):
   """
   if field_desc.type == descriptor.FieldDescriptor.TYPE_STRING:
     escaped = ('' + value).encode('unicode-escape')
-    return "'%s'" % escaped.replace("'", "\\'")
+    return "'%s'" % escaped.decode().replace("'", "\\'")
   if field_desc.type == descriptor.FieldDescriptor.TYPE_BOOL:
     if value:
       return 'true'
@@ -757,7 +757,7 @@ def GenerateValidatorGeneratedJs(specfile, validator_pb2, generate_proto_only,
   FindDescriptors(validator_pb2, msg_desc_by_name, enum_desc_by_name)
 
   rules_obj = '%s.RULES' % validator_pb2.DESCRIPTOR.package
-  all_names = [rules_obj] + msg_desc_by_name.keys() + enum_desc_by_name.keys()
+  all_names = [rules_obj] + list(msg_desc_by_name.keys()) + list(enum_desc_by_name.keys())
   all_names.sort()
 
   out = OutputFormatter(out)

--- a/validator/webui/build.py
+++ b/validator/webui/build.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 #
 # Copyright 2016 The AMP HTML Authors. All Rights Reserved.
 #
@@ -38,7 +38,7 @@ def Die(msg):
   Args:
     msg: The error message to emit
   """
-  print >> sys.stderr, msg
+  print(msg, file=sys.stderr)
   sys.exit(1)
 
 

--- a/validator/webui/build.py
+++ b/validator/webui/build.py
@@ -50,7 +50,7 @@ def GetNodeJsCmd():
   for cmd in ['node', 'nodejs']:
     try:
       output = subprocess.check_output([cmd, '--eval', 'console.log("42")'])
-      if output.strip() == '42':
+      if output.strip() == b'42':
         logging.info('... done')
         return cmd
     except (subprocess.CalledProcessError, OSError):
@@ -147,7 +147,7 @@ def CreateWebuiAppengineDist(out_dir):
     shutil.rmtree(tempdir)
   webui_out = os.path.join(out_dir, 'webui_appengine')
   shutil.copytree('.', webui_out, ignore=shutil.ignore_patterns('dist'))
-  f = open(os.path.join(webui_out, 'index.html'), 'w')
+  f = open(os.path.join(webui_out, 'index.html'), 'wb')
   f.write(vulcanized_index_html)
   f.close()
   logging.info('... success')

--- a/validator/webui/build.py
+++ b/validator/webui/build.py
@@ -22,6 +22,7 @@
 # Polymer project, and unlike for the parent directory there's no
 # particular benefit to using Python.
 
+from __future__ import print_function
 import logging
 import os
 import platform


### PR DESCRIPTION
Changes are compatible with both Python 2.7 and Python 3.
- Remove 2.7 from shebang in `webui/build.py`
- Update `print` usage in `webui/build.py`
- Explicitly cast variables or fix types where necessary

Fixes: #26279