### PR TITLE
build-system: Support python 3.5+

### DIFF
--- a/build-system/common/check-package-manager.js
+++ b/build-system/common/check-package-manager.js
@@ -310,13 +310,19 @@ function runGulpChecks() {
 }
 
 function checkPythonVersion() {
-  // Python prints its version to stderr: https://bugs.python.org/issue18338
-  const pythonVersionResult = getStderr(`${pythonExecutable} --version`).trim();
+  // Python2 prints its version to stderr (fixed in Python 3.4)
+  // See: https://bugs.python.org/issue18338
+  const pythonVersionResult =
+    getStderr(`${pythonExecutable} --version`).trim() ||
+    getStdout(`${pythonExecutable} --version`).trim();
   const pythonVersion = pythonVersionResult.match(/Python (.*?)$/);
   if (pythonVersion && pythonVersion.length == 2) {
-    const recommendedVersion = '2.7';
+    // Python 2.7 is EOL but still supported
+    // Python 3.5+ are still supported (TODO: deprecate 3.5 on 2020-09-13)
+    // https://devguide.python.org/#status-of-python-branches
+    const recommendedVersion = /^2\.7|^3\.[5-9]/;
     const versionNumber = pythonVersion[1];
-    if (versionNumber.startsWith(recommendedVersion)) {
+    if (recommendedVersion.test(versionNumber)) {
       console.log(
         green('Detected'),
         cyan('python'),

--- a/build-system/common/check-package-manager.js
+++ b/build-system/common/check-package-manager.js
@@ -352,7 +352,7 @@ function checkPythonVersion() {
       cyan(pythonExecutable),
       yellow('is in your'),
       cyan('PATH'),
-      yello('and is version'),
+      yellow('and is version'),
       cyan(recommendedVersion) + yellow('.')
     );
   }

--- a/build-system/common/check-package-manager.js
+++ b/build-system/common/check-package-manager.js
@@ -310,6 +310,12 @@ function runGulpChecks() {
 }
 
 function checkPythonVersion() {
+  // Python 2.7 is EOL but still supported
+  // Python 3.5+ are still supported (TODO: deprecate 3.5 on 2020-09-13)
+  // https://devguide.python.org/#status-of-python-branches
+  const recommendedVersion = '2.7 or 3.5+';
+  const recommendedVersionRegex = /^2\.7|^3\.[5-9]/;
+
   // Python2 prints its version to stderr (fixed in Python 3.4)
   // See: https://bugs.python.org/issue18338
   const pythonVersionResult =
@@ -317,12 +323,8 @@ function checkPythonVersion() {
     getStdout(`${pythonExecutable} --version`).trim();
   const pythonVersion = pythonVersionResult.match(/Python (.*?)$/);
   if (pythonVersion && pythonVersion.length == 2) {
-    // Python 2.7 is EOL but still supported
-    // Python 3.5+ are still supported (TODO: deprecate 3.5 on 2020-09-13)
-    // https://devguide.python.org/#status-of-python-branches
-    const recommendedVersion = /^2\.7|^3\.[5-9]/;
     const versionNumber = pythonVersion[1];
-    if (recommendedVersion.test(versionNumber)) {
+    if (recommendedVersionRegex.test(versionNumber)) {
       console.log(
         green('Detected'),
         cyan('python'),
@@ -338,16 +340,18 @@ function checkPythonVersion() {
       );
       console.log(
         yellow('⤷ To fix this, install the correct version from'),
-        cyan(`https://www.python.org/download/releases/${recommendedVersion}`) +
-          yellow('.')
+        cyan('https://www.python.org/downloads') + yellow('.')
       );
     }
   } else {
     console.log(
-      yellow(
-        'WARNING: Could not determine the local version of python.\n' +
-          'Make sure "python" is in your PATH and is version 2.7 or 3.5+.'
-      )
+      yellow('WARNING: Could not determine the local version of python.')
+    );
+    console.log(
+      yellow('⤷ To fix this, make sure'),
+      cyan(pythonExecutable),
+      yellow('is in your PATH and is version'),
+      cyan(recommendedVersion) + yellow('.')
     );
   }
 }

--- a/build-system/common/check-package-manager.js
+++ b/build-system/common/check-package-manager.js
@@ -345,9 +345,8 @@ function checkPythonVersion() {
   } else {
     console.log(
       yellow(
-        'WARNING: ' +
-          'Could not determine the local version of python. ' +
-          'AMP development requires python 2.7.'
+        'WARNING: Could not determine the local version of python.\n' +
+          'Make sure "python" is in your PATH and is version 2.7 or 3.5+.'
       )
     );
   }

--- a/build-system/common/check-package-manager.js
+++ b/build-system/common/check-package-manager.js
@@ -339,7 +339,7 @@ function checkPythonVersion() {
         cyan(recommendedVersion) + yellow('.')
       );
       console.log(
-        yellow('⤷ To fix this, install the correct version from'),
+        yellow('⤷ To fix this, install a supported version from'),
         cyan('https://www.python.org/downloads') + yellow('.')
       );
     }
@@ -350,7 +350,9 @@ function checkPythonVersion() {
     console.log(
       yellow('⤷ To fix this, make sure'),
       cyan(pythonExecutable),
-      yellow('is in your PATH and is version'),
+      yellow('is in your'),
+      cyan('PATH'),
+      yello('and is version'),
       cyan(recommendedVersion) + yellow('.')
     );
   }

--- a/build-system/common/check-package-manager.js
+++ b/build-system/common/check-package-manager.js
@@ -340,7 +340,7 @@ function checkPythonVersion() {
       );
       console.log(
         yellow('⤷ To fix this, install a supported version from'),
-        cyan('https://www.python.org/downloads') + yellow('.')
+        cyan('https://www.python.org/downloads/') + yellow('.')
       );
     }
   } else {


### PR DESCRIPTION
Python 2.7 is EOL but still supported
Python 3.5+ are still supported (TODO: deprecate 3.5 on 2020-09-13)
https://devguide.python.org/#status-of-python-branches

Depends on #28037 and #28036