### PR TITLE
🏗 Use Python v3 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: node_js
 dist: xenial
 node_js:
   - 'lts/*'
-python:
-  - '2.7'
 notifications:
   email:
     recipients:
@@ -14,7 +12,13 @@ before_install:
   # Override Xenial's default Java version (github.com/travis-ci/travis-ci/issues/10290)
   - export PATH=$(echo "$PATH" | sed -e 's/:\/usr\/local\/lib\/jvm\/openjdk11\/bin//')
   - export JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64
-  - pip install --user protobuf
+  # Ensure python v2 and v3 are available, and "python" defaults to v3 (docs.travis-ci.com/user/reference/xenial/#python-support)
+  - pyenv global 3.6.7 2.7.15
+  - python3 --version
+  - python2 --version
+  - python --version
+  # Xenial's version of python-protobuf is outdated (github.com/ampproject/amphtml/pull/22528)
+  - pip3 install --user protobuf
 branches:
   only:
     - master


### PR DESCRIPTION
Now that the AMP toolchain is fully compatible with python3 (see #28037, #28036, and #28038, all courtesy @mdmower), it is time to set python v3 as the default for Travis jobs.

**PR highlights:**
- Removes top-level [`python`](https://docs.travis-ci.com/user/languages/python/) version from `.travis.yml` ([doesn't work](https://travis-ci.community/t/please-activate-python-3-by-default-for-non-python-build/3899) for `language: node_js`)
- Makes known-good versions of python v2 and v3 globally available (using [`pyenv global`](https://github.com/pyenv/pyenv/blob/master/COMMANDS.md#pyenv-global-advanced))
- Makes all invocations of `python` default to v3 (first arg to `pyenv global` [gets precedence](https://github.com/pyenv/pyenv/blob/master/COMMANDS.md#pyenv-global-advanced)) 

**Install time:**

Since Travis' `xenial` environment [guarantees](https://docs.travis-ci.com/user/reference/xenial/#python-support) the existence of python 2.7 and 3.6, the additional install time due to this PR is near zero.

![image](https://user-images.githubusercontent.com/26553114/80430343-5afd4b80-88bc-11ea-9368-519807e0207a.png)

**References:**
- https://docs.travis-ci.com/user/languages/python/
- https://travis-ci.community/t/please-activate-python-3-by-default-for-non-python-build/3899
- https://docs.travis-ci.com/user/reference/xenial/#python-support
- https://github.com/pyenv/pyenv/blob/master/COMMANDS.md

Follow up to #28037, #28036, and #28038