### PR TITLE
Do not loop background audio when used to auto-advance.

### DIFF
--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -524,7 +524,11 @@ export class AmpStoryPage extends AMP.BaseElement {
 
   /** @override */
   layoutCallback() {
-    const audioEl = upgradeBackgroundAudio(this.element);
+    // Do not loop if the audio is used to auto-advance.
+    const loop =
+      this.element.getAttribute('id') !==
+      this.element.getAttribute('auto-advance-after');
+    const audioEl = upgradeBackgroundAudio(this.element, loop);
     if (audioEl) {
       this.mediaPoolPromise_.then((mediaPool) => {
         this.registerMedia_(mediaPool, dev().assertElement(audioEl));

--- a/extensions/amp-story/1.0/audio.js
+++ b/extensions/amp-story/1.0/audio.js
@@ -25,9 +25,10 @@ const BACKGROUND_AUDIO_ELEMENT_CLASS_NAME = 'i-amphtml-story-background-audio';
  * Adds support for the background-audio property on the specified element.
  * @param {!Element} element The element to upgrade with support for background
  *     audio.
+ * @param {boolean=} loop
  * @return {?Element} audioEl
  */
-export function upgradeBackgroundAudio(element) {
+export function upgradeBackgroundAudio(element, loop = true) {
   if (!element.hasAttribute('background-audio')) {
     return null;
   }
@@ -38,7 +39,9 @@ export function upgradeBackgroundAudio(element) {
   );
   audioEl.setAttribute('src', audioSrc);
   audioEl.setAttribute('preload', 'auto');
-  audioEl.setAttribute('loop', '');
+  if (loop) {
+    audioEl.setAttribute('loop', '');
+  }
   audioEl.setAttribute('autoplay', '');
   audioEl.setAttribute('muted', '');
   audioEl.muted = true;


### PR DESCRIPTION
Removes the `loop` attribute on the `audio` tag when a page is configured to auto-advance after its background-audio. Otherwise the page keeps looping rather than auto advancing.

eg: `<amp-story-page id="foo" background-audio="bar.mp3" auto-advance-after="foo">...</>`

Found while working on https://github.com/ampproject/amphtml/issues/28010