### PR TITLE
Resources: send a documentHeight message after ampInitialized if height has changed.

### DIFF
--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -647,6 +647,7 @@ export class ResourcesImpl {
   /** @override */
   ampInitComplete() {
     this.ampInitialized_ = true;
+    this.maybeChangeHeight_ = true;
     dev().fine(TAG_, 'ampInitComplete');
     this.schedulePass();
   }

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -685,7 +685,7 @@ export class ResourcesImpl {
     this.prerenderSize_ = this.viewer_.getPrerenderSize();
 
     const firstPassAfterDocumentReady =
-      this.documentReady_ && this.firstPassAfterDocumentReady_;
+      this.documentReady_ && this.firstPassAfterDocumentReady_ && this.ampInitialized_;
     if (firstPassAfterDocumentReady) {
       this.firstPassAfterDocumentReady_ = false;
       const doc = this.win.document;

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -686,7 +686,7 @@ export class ResourcesImpl {
     this.prerenderSize_ = this.viewer_.getPrerenderSize();
 
     const firstPassAfterDocumentReady =
-      this.documentReady_ && this.firstPassAfterDocumentReady_ && this.ampInitialized_;
+      this.documentReady_ && this.firstPassAfterDocumentReady_;
     if (firstPassAfterDocumentReady) {
       this.firstPassAfterDocumentReady_ = false;
       const doc = this.win.document;

--- a/test/unit/test-resources.js
+++ b/test/unit/test-resources.js
@@ -642,6 +642,7 @@ describes.realWin('Resources discoverWork', {amp: true}, (env) => {
     resources.resources_ = [resource1, resource2];
     resources.vsync_ = {
       mutate: (callback) => callback(),
+      measure: (callback) => callback(),
       measurePromise: (callback) => Promise.resolve(callback()),
     };
   });


### PR DESCRIPTION
**summary**
Context `b/154603596`

This PR tells the resources service to send a `documentHeight` message after all amp elements have all laid themselves out. This message should correct previously sent messages which all occurred before amp finished applying styles.

Repro steps:
1. Go to the AMP4Email playground: https://amp.gmail.dev/playground/
2. Click on the Carousel template. Notice how it doesn't render properly

Testing done:
1. I used Charles Proxy on GMail and the Playground. I mapped both `v0.js` and the entire `v0/` folder to the local files after running `gulp dist` on this branch.
2. I then ensured that the carousel loads properly

**next steps**
- Add integration tests that we send out the correct `documentHeight`

cc @choumx 