### PR TITLE
intersect-resources: Fix bug that skips onLayoutMeasure

### DIFF
--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -566,6 +566,7 @@ function createBaseCustomElementClass(win) {
 
     /**
      * Updates the layout box of the element.
+     * Should only be called by Resources.
      * @param {!./layout-rect.LayoutRectDef} layoutBox
      * @param {boolean} sizeChanged
      */
@@ -580,6 +581,7 @@ function createBaseCustomElementClass(win) {
     /**
      * Calls onLayoutMeasure() (and onMeasureChanged() if size changed)
      * on the BaseElement implementation.
+     * Should only be called by Resources.
      * @param {boolean} sizeChanged
      */
     onMeasure(sizeChanged = false) {

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -567,20 +567,30 @@ function createBaseCustomElementClass(win) {
     /**
      * Updates the layout box of the element.
      * @param {!./layout-rect.LayoutRectDef} layoutBox
-     * @param {boolean=} opt_measurementsChanged
+     * @param {boolean} sizeChanged
      */
-    updateLayoutBox(layoutBox, opt_measurementsChanged) {
+    updateLayoutBox(layoutBox, sizeChanged = false) {
       this.layoutWidth_ = layoutBox.width;
       this.layoutHeight_ = layoutBox.height;
       if (this.isBuilt()) {
-        try {
-          this.implementation_.onLayoutMeasure();
-          if (opt_measurementsChanged) {
-            this.implementation_.onMeasureChanged();
-          }
-        } catch (e) {
-          reportError(e, this);
+        this.onMeasure(sizeChanged);
+      }
+    }
+
+    /**
+     * Calls onLayoutMeasure() (and onMeasureChanged() if size changed)
+     * on the BaseElement implementation.
+     * @param {boolean} sizeChanged
+     */
+    onMeasure(sizeChanged = false) {
+      devAssert(this.isBuilt());
+      try {
+        this.implementation_.onLayoutMeasure();
+        if (sizeChanged) {
+          this.implementation_.onMeasureChanged();
         }
+      } catch (e) {
+        reportError(e, this);
       }
     }
 

--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -338,10 +338,9 @@ export class Resource {
         this.isBuilding_ = false;
         // With IntersectionObserver, measure can happen before build
         // so check if we're "ready for layout" (measured and built) here.
-        if (this.intersect_) {
-          this.state_ = this.hasBeenMeasured()
-            ? ResourceState.READY_FOR_LAYOUT
-            : ResourceState.NOT_LAID_OUT;
+        if (this.intersect_ && this.hasBeenMeasured()) {
+          this.state_ = ResourceState.READY_FOR_LAYOUT;
+          this.element.onMeasure(/* sizeChanged */ true);
         } else {
           this.state_ = ResourceState.NOT_LAID_OUT;
         }


### PR DESCRIPTION
In `intersect-resources`, it's more likely for elements to be measured before build (known case). But, `measure() > updateLayoutBox()` only calls `onLayoutMeasure`/`onMeasureChanged` if the element is built (oops).

Somewhat happily though, this fix means `intersect-resources` shouldn't be affected by #26866.

This affects all elements that rely on `onLayoutMeasure`, but especially `amp-ad` which face-plants if an element receives `layoutCallback` (render) before `onLayoutMeasure` (query).