### PR TITLE
🏗 Move `filesize` config into its own file

### DIFF
--- a/build-system/tasks/bundle-size/filesize.json
+++ b/build-system/tasks/bundle-size/filesize.json
@@ -1,0 +1,11 @@
+{
+  "filesize": {
+    "track": [
+      "dist/*.js",
+      "dist/v0/*-?.?.js",
+      "dist/*.mjs",
+      "dist/v0/*-?.?.mjs"
+    ],
+    "trackFormat": ["brotli"]
+  }
+}

--- a/build-system/tasks/bundle-size/index.js
+++ b/build-system/tasks/bundle-size/index.js
@@ -18,7 +18,6 @@
 const argv = require('minimist')(process.argv.slice(2));
 const globby = require('globby');
 const log = require('fancy-log');
-const packageJson = require('../../../package.json');
 const path = require('path');
 const url = require('url');
 const util = require('util');
@@ -41,7 +40,8 @@ const {report, Report} = require('@ampproject/filesize');
 
 const requestPost = util.promisify(require('request').post);
 
-const fileGlobs = packageJson.filesize.track;
+const filesizeConfigPath = require.resolve('./filesize.json');
+const fileGlobs = require(filesizeConfigPath).filesize.track;
 const normalizedRtvNumber = '1234567890123';
 
 const expectedGitHubRepoSlug = 'ampproject/amphtml';
@@ -59,7 +59,7 @@ async function getBrotliBundleSizes() {
 
   log(cyan('brotli'), 'bundle sizes are:');
   await report(
-    process.cwd(),
+    filesizeConfigPath,
     (content) => content.replace(replacementExpression, normalizedRtvNumber),
     class extends Report {
       update(context) {

--- a/package.json
+++ b/package.json
@@ -191,14 +191,5 @@
     "vinyl-source-stream": "2.0.0",
     "vinyl-sourcemaps-apply": "0.2.1",
     "watchify": "3.11.1"
-  },
-  "filesize": {
-    "track": [
-      "dist/*.js",
-      "dist/v0/*-?.?.js",
-      "dist/*.mjs",
-      "dist/v0/*-?.?.mjs"
-    ],
-    "trackFormat": ["brotli"]
   }
 }


### PR DESCRIPTION
The `gulp bundle-size` check uses `@ampproject/filesize` to determine `brotli` sizes for minified JS files.

Storing the `filesize` config in `package.json` [breaks compatibility](https://travis-ci.org/github/ampproject/amphtml/jobs/678816324#L406-L411) between `yarn add` and `prettier`, causing them to go back and forth on formatting. See https://github.com/ampproject/filesize/issues/83#issue-605945124.

This PR moves the config from `package.json` to `build-system/tasks/bundle-size/filesize.json`. (`@ampproject/filesize` has already been updated in #28079.)

