### PR TITLE
🐛 CEv1: Fix innerHTML patch in Safari <= 9 and maybe Yandex

### DIFF
--- a/src/polyfills/custom-elements.js
+++ b/src/polyfills/custom-elements.js
@@ -684,7 +684,7 @@ function installPatches(win, registry) {
       'innerHTML'
     );
   }
-  if (innerHTMLDesc.configurable) {
+  if (innerHTMLDesc && innerHTMLDesc.configurable) {
     const innerHTMLSetter = innerHTMLDesc.set;
     innerHTMLDesc.set = function (html) {
       innerHTMLSetter.call(this, html);

--- a/src/polyfills/custom-elements.js
+++ b/src/polyfills/custom-elements.js
@@ -684,16 +684,18 @@ function installPatches(win, registry) {
       'innerHTML'
     );
   }
-  const innerHTMLSetter = innerHTMLDesc.set;
-  innerHTMLDesc.set = function (html) {
-    innerHTMLSetter.call(this, html);
-    registry.upgrade(this);
-  };
-  Object.defineProperty(
-    /** @type {!Object} */ (innerHTMLProto),
-    'innerHTML',
-    innerHTMLDesc
-  );
+  if (innerHTMLDesc.configurable) {
+    const innerHTMLSetter = innerHTMLDesc.set;
+    innerHTMLDesc.set = function (html) {
+      innerHTMLSetter.call(this, html);
+      registry.upgrade(this);
+    };
+    Object.defineProperty(
+      /** @type {!Object} */ (innerHTMLProto),
+      'innerHTML',
+      innerHTMLDesc
+    );
+  }
 }
 
 /**

--- a/test/unit/test-polyfill-custom-elements.js
+++ b/test/unit/test-polyfill-custom-elements.js
@@ -38,7 +38,7 @@ describes.realWin(
       delete win.customElements;
     });
 
-    it('handles non-configurable innerHTML accessor', () => {
+    it('handles non-configurable innerHTML accessor (Safari 9)', () => {
       // Use strict is important, as strict mode code will throw an error when
       // trying to redefine a non-configurable property.
       'use strict';
@@ -53,7 +53,7 @@ describes.realWin(
       }).not.to.throw();
     });
 
-    it('handles missing innerHTML descriptor', () => {
+    it('handles missing innerHTML descriptor (Yandex)', () => {
       // Use strict is important, as strict mode code will throw an error when
       // trying to redefine a non-configurable property.
       'use strict';
@@ -68,7 +68,7 @@ describes.realWin(
       }).not.to.throw();
     });
 
-    it('handles innerHTML descriptor on HTMLElement', () => {
+    it('handles innerHTML descriptor on HTMLElement (IE11)', () => {
       // Use strict is important, as strict mode code will throw an error when
       // trying to redefine a non-configurable property.
       'use strict';

--- a/test/unit/test-polyfill-custom-elements.js
+++ b/test/unit/test-polyfill-custom-elements.js
@@ -22,16 +22,27 @@ describes.realWin(
   (env) => {
     let win;
     let innerHTMLProto;
-    beforeEach(function () {
-      win = env.win;
 
-      innerHTMLProto = win.Element.prototype;
+    function getInnerHtmlProto(win) {
+      let innerHTMLProto = win.Element.prototype;
       if (!Object.getOwnPropertyDescriptor(innerHTMLProto, 'innerHTML')) {
         innerHTMLProto = win.HTMLElement.prototype;
         if (!Object.getOwnPropertyDescriptor(innerHTMLProto, 'innerHTML')) {
-          return this.skip();
+          return null;
         }
       }
+      return innerHTMLProto;
+    }
+
+    before(function () {
+      if (!getInnerHtmlProto(window)) {
+        this.skipTest();
+      }
+    });
+
+    beforeEach(function () {
+      win = env.win;
+      innerHTMLProto = getInnerHtmlProto(win);
 
       // We want to test the full polyfill.
       delete win.Reflect;

--- a/test/unit/test-polyfill-custom-elements.js
+++ b/test/unit/test-polyfill-custom-elements.js
@@ -14,7 +14,78 @@
  * limitations under the License.
  */
 
-import {copyProperties} from '../../src/polyfills/custom-elements';
+import {copyProperties, install} from '../../src/polyfills/custom-elements';
+
+describes.realWin(
+  'install patches',
+  {skipCustomElementsPolyfill: true},
+  (env) => {
+    let win;
+    let innerHTMLProto;
+    beforeEach(function () {
+      win = env.win;
+
+      innerHTMLProto = win.Element.prototype;
+      if (!Object.getOwnPropertyDescriptor(innerHTMLProto, 'innerHTML')) {
+        innerHTMLProto = win.HTMLElement.prototype;
+        if (!Object.getOwnPropertyDescriptor(innerHTMLProto, 'innerHTML')) {
+          return this.skip();
+        }
+      }
+
+      // We want to test the full polyfill.
+      delete win.Reflect;
+      delete win.customElements;
+    });
+
+    it('handles non-configurable innerHTML accessor', () => {
+      // Use strict is important, as strict mode code will throw an error when
+      // trying to redefine a non-configurable property.
+      'use strict';
+
+      Object.defineProperty(innerHTMLProto, 'innerHTML', {configurable: false});
+      install(win, function () {});
+
+      class Test extends win.HTMLElement {}
+
+      expect(() => {
+        win.customElements.define('x-test', Test);
+      }).not.to.throw();
+    });
+
+    it('handles missing innerHTML descriptor', () => {
+      // Use strict is important, as strict mode code will throw an error when
+      // trying to redefine a non-configurable property.
+      'use strict';
+
+      delete innerHTMLProto.innerHTML;
+      install(win, function () {});
+
+      class Test extends win.HTMLElement {}
+
+      expect(() => {
+        win.customElements.define('x-test', Test);
+      }).not.to.throw();
+    });
+
+    it('handles innerHTML descriptor on HTMLElement', () => {
+      // Use strict is important, as strict mode code will throw an error when
+      // trying to redefine a non-configurable property.
+      'use strict';
+
+      const desc = Object.getOwnPropertyDescriptor(innerHTMLProto, 'innerHTML');
+      delete innerHTMLProto.innerHTML;
+      Object.defineProperty(win.HTMLElement.prototype, 'innerHTML', desc);
+      install(win, function () {});
+
+      class Test extends win.HTMLElement {}
+
+      expect(() => {
+        win.customElements.define('x-test', Test);
+      }).not.to.throw();
+    });
+  }
+);
 
 describes.fakeWin('copyProperties', {}, () => {
   it('copies own properties from proto object', () => {

--- a/testing/describes.js
+++ b/testing/describes.js
@@ -197,6 +197,7 @@ export const fakeWin = describeEnv((spec) => [
  * @param {string} name
  * @param {{
  *   fakeRegisterElement: (boolean|undefined),
+ *   skipCustomElementsPolyfill: (boolean|undefined),
  *   amp: (boolean|!AmpTestSpec|undefined),
  * }} spec
  * @param {function({
@@ -648,7 +649,7 @@ class RealWinFixture {
           Object.defineProperty(win, 'customElements', {
             get: () => customElements,
           });
-        } else {
+        } else if (!spec.skipCustomElementsPolyfill) {
           // The anonymous class parameter allows us to detect native classes
           // vs transpiled classes.
           installCustomElements(win, class {});


### PR DESCRIPTION
Old Safari has an interesting definition for `Element.p.innerHTML`: the descriptor is non-configurable and the `set` setter is undefined. In the old code, trying to patch this setter throws an error.

This leaves the document in a broken state. The first CE to be defined will not properly upgrade the elements that existed were already parsed on the page. Additionally, `innerHTML` will not properly sync-upgrade CEs that are parsed from the string, but they will async-upgrade via the `MutationObserver`.

Skipping this `innerHTML` patch shouldn't hurt, since we'll still get the async-upgrade. Safari 9 is sooo old, all we really need here is a best-effort "it kinda works".

- - -

This also adds a potential fix for Yandex browser not having an `innerHTML` descriptor. Based on the stack trace, the descriptor is not found on `Element.prototype` nor `HTMLElement.prototype`.
Fixes https://github.com/ampproject/amphtml/issues/28058