### PR TITLE
🐛 Prevent interaction with blurry-image placeholder

### DIFF
--- a/css/ampshared.css
+++ b/css/ampshared.css
@@ -34,6 +34,7 @@
 
 .i-amphtml-blurry-placeholder {
   transition: opacity 0.3s cubic-bezier(0.0, 0.0, 0.2, 1) !important;
+  pointer-events: none;
 }
 
 /* layout=nodisplay are automatically hidden until JS initializes. */


### PR DESCRIPTION
The blurry image placeholder uses a transition to slowly fade the blur into the real image. When it's done, the blurry image is "hidden" via `opacity: 0` styles. Unfortunately, users can still interact with this blurry image, and because it overlays the entire image, can't interact with the real image.

Adding `pointer-events: none` seems to be the easiest fix. Other possibilities include adding a `transitionend` event to toggle `display: none` (requires JS, and slow), or converting to a CSS animation (unsure of browser support and smoothness).

Fixes b/153094647

Any chance this can fix b/149038942?