### PR TITLE
✅🏗 Ban chai should assertions

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -90,6 +90,7 @@
     "local/closure-type-primitives": 2,
     "local/dict-string-keys": 2,
     "local/html-template": 2,
+    "local/i-really-really-really-dislike-chai": 2,
     "local/is-experiment-on": 2,
     "local/json-configuration": 2,
     "local/no-array-destructuring": 2,

--- a/.eslintrc
+++ b/.eslintrc
@@ -90,7 +90,6 @@
     "local/closure-type-primitives": 2,
     "local/dict-string-keys": 2,
     "local/html-template": 2,
-    "local/i-really-really-really-dislike-chai": 2,
     "local/is-experiment-on": 2,
     "local/json-configuration": 2,
     "local/no-array-destructuring": 2,
@@ -233,6 +232,7 @@
       ],
       "rules": {
         "require-jsdoc": 0,
+        "local/i-really-really-really-dislike-chai": 2,
         "local/no-bigint": 0,
         "local/no-dynamic-import": 0,
         "local/no-function-async": 0,

--- a/build-system/eslint-rules/i-really-really-really-dislike-chai.js
+++ b/build-system/eslint-rules/i-really-really-really-dislike-chai.js
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+module.exports = {
+  meta: {
+    fixable: 'code',
+  },
+
+  create(context) {
+    return {
+      'MemberExpression[property.name=should]': function (node) {
+        // Ban using .should assertions.
+        context.report({
+          node,
+          message: 'Use expect() assertions only',
+
+          fix(fixer) {
+            const start = node.property.start - 1;
+            return [
+              fixer.insertTextBefore(node.object, 'expect('),
+              fixer.replaceTextRange([start, start + '.should'.length], ').to'),
+            ];
+          },
+        });
+      },
+    };
+  },
+};

--- a/extensions/amp-3q-player/0.1/test/test-amp-3q-player.js
+++ b/extensions/amp-3q-player/0.1/test/test-amp-3q-player.js
@@ -68,7 +68,7 @@ describes.realWin(
 
     it('requires data-id', () => {
       return allowConsoleError(() => {
-        return get3QElement('').should.eventually.be.rejectedWith(
+        return expect(get3QElement('')).to.eventually.be.rejectedWith(
           /The data-id attribute is required/
         );
       });

--- a/extensions/amp-ad-exit/0.1/test/test-amp-ad-exit.js
+++ b/extensions/amp-ad-exit/0.1/test/test-amp-ad-exit.js
@@ -219,7 +219,7 @@ describes.realWin(
       win.document.body.appendChild(el);
       let promise;
       allowConsoleError(() => (promise = el.build()));
-      return promise.should.be.rejectedWith(/application\/json/);
+      return expect(promise).to.be.rejectedWith(/application\/json/);
     });
 
     it('should do nothing for missing targets', () => {

--- a/extensions/amp-app-banner/0.1/test/test-amp-app-banner.js
+++ b/extensions/amp-app-banner/0.1/test/test-amp-app-banner.js
@@ -137,13 +137,13 @@ describes.realWin(
 
     function testButtonMissing() {
       return allowConsoleError(() => {
-        return getAppBanner({
-          iosMeta,
-          androidManifest,
-          noOpenButton: true,
-        }).should.eventually.be.rejectedWith(
-          /<button open-button> is required/
-        );
+        return expect(
+          getAppBanner({
+            iosMeta,
+            androidManifest,
+            noOpenButton: true,
+          })
+        ).to.eventually.be.rejectedWith(/<button open-button> is required/);
       });
     }
 
@@ -229,12 +229,14 @@ describes.realWin(
 
       it('should parse meta content and validate app-argument url', () => {
         return allowConsoleError(() => {
-          return getAppBanner({
-            iosMeta: {
-              content:
-                'app-id=828256236, app-argument=javascript:alert("foo");',
-            },
-          }).should.eventually.be.rejectedWith(
+          return expect(
+            getAppBanner({
+              iosMeta: {
+                content:
+                  'app-id=828256236, app-argument=javascript:alert("foo");',
+              },
+            })
+          ).to.eventually.be.rejectedWith(
             /The url in app-argument has invalid protocol/
           );
         });

--- a/extensions/amp-brid-player/0.1/test/test-amp-brid-player.js
+++ b/extensions/amp-brid-player/0.1/test/test-amp-brid-player.js
@@ -99,10 +99,12 @@ describes.realWin(
 
     it('requires data-partner', () => {
       return allowConsoleError(() => {
-        return getBridPlayer({
-          'data-player': '4144',
-          'data-video': '13663',
-        }).should.eventually.be.rejectedWith(
+        return expect(
+          getBridPlayer({
+            'data-player': '4144',
+            'data-video': '13663',
+          })
+        ).to.eventually.be.rejectedWith(
           /The data-partner attribute is required for/
         );
       });
@@ -110,10 +112,12 @@ describes.realWin(
 
     it('requires data-player', () => {
       return allowConsoleError(() => {
-        return getBridPlayer({
-          'data-partner': '264',
-          'data-video': '13663',
-        }).should.eventually.be.rejectedWith(
+        return expect(
+          getBridPlayer({
+            'data-partner': '264',
+            'data-video': '13663',
+          })
+        ).to.eventually.be.rejectedWith(
           /The data-player attribute is required for/
         );
       });

--- a/extensions/amp-brightcove/0.1/test/test-amp-brightcove.js
+++ b/extensions/amp-brightcove/0.1/test/test-amp-brightcove.js
@@ -90,7 +90,7 @@ describes.realWin(
 
     it('requires data-account', () => {
       expectAsyncConsoleError(/The data-account attribute is required for/, 1);
-      return getBrightcove({}).should.eventually.be.rejectedWith(
+      return expect(getBrightcove({})).to.eventually.be.rejectedWith(
         /The data-account attribute is required for/
       );
     });

--- a/extensions/amp-byside-content/0.1/test/test-amp-byside-content.js
+++ b/extensions/amp-byside-content/0.1/test/test-amp-byside-content.js
@@ -86,9 +86,11 @@ describes.realWin(
 
     it('requires data-label', () => {
       return allowConsoleError(() => {
-        return getElement({
-          'data-webcare-id': 'D6604AE5D0',
-        }).should.eventually.be.rejectedWith(
+        return expect(
+          getElement({
+            'data-webcare-id': 'D6604AE5D0',
+          })
+        ).to.eventually.be.rejectedWith(
           /The data-label attribute is required for/
         );
       });
@@ -96,9 +98,11 @@ describes.realWin(
 
     it('requires data-webcare-id', () => {
       return allowConsoleError(() => {
-        return getElement({
-          'data-label': 'placeholder-label',
-        }).should.eventually.be.rejectedWith(
+        return expect(
+          getElement({
+            'data-label': 'placeholder-label',
+          })
+        ).to.eventually.be.rejectedWith(
           /The data-webcare-id attribute is required for/
         );
       });

--- a/extensions/amp-connatix-player/0.1/test/test-amp-connatix-player.js
+++ b/extensions/amp-connatix-player/0.1/test/test-amp-connatix-player.js
@@ -76,9 +76,11 @@ describes.realWin(
 
     it('fails if no playerId is specified', () => {
       return allowConsoleError(() => {
-        return getConnatixPlayer({
-          'data-media-id': '527207df-2007-43c4-b87a-f90814bafd2e',
-        }).should.eventually.be.rejectedWith(
+        return expect(
+          getConnatixPlayer({
+            'data-media-id': '527207df-2007-43c4-b87a-f90814bafd2e',
+          })
+        ).to.eventually.be.rejectedWith(
           /The data-player-id attribute is required for/
         );
       });

--- a/extensions/amp-dailymotion/0.1/test/test-amp-dailymotion.js
+++ b/extensions/amp-dailymotion/0.1/test/test-amp-dailymotion.js
@@ -78,7 +78,7 @@ describes.realWin(
 
     it('requires data-videoid', () => {
       return allowConsoleError(() => {
-        return getDailymotion('').should.eventually.be.rejectedWith(
+        return expect(getDailymotion('')).to.eventually.be.rejectedWith(
           /The data-videoid attribute is required for/
         );
       });

--- a/extensions/amp-delight-player/0.1/test/test-amp-delight-player.js
+++ b/extensions/amp-delight-player/0.1/test/test-amp-delight-player.js
@@ -73,9 +73,11 @@ describes.realWin(
 
     it('fails if no content is specified', () => {
       return allowConsoleError(() => {
-        return getDelightPlayer({
-          'data-content-id': '',
-        }).should.eventually.be.rejectedWith(
+        return expect(
+          getDelightPlayer({
+            'data-content-id': '',
+          })
+        ).to.eventually.be.rejectedWith(
           /The data-content-id attribute is required/
         );
       });

--- a/extensions/amp-experiment/1.0/test/test-amp-experiment.js
+++ b/extensions/amp-experiment/1.0/test/test-amp-experiment.js
@@ -110,9 +110,9 @@ describes.realWin(
       expectAsyncConsoleError(/Experiment/);
       addConfigElement('script');
       doc.body.appendChild(el);
-      return experiment
-        .buildCallback()
-        .should.eventually.be.rejectedWith(/Experiment/);
+      return expect(experiment.buildCallback()).to.eventually.be.rejectedWith(
+        /Experiment/
+      );
     });
 
     it('should not throw on valid config', () => {

--- a/extensions/amp-gfycat/0.1/test/test-amp-gfycat.js
+++ b/extensions/amp-gfycat/0.1/test/test-amp-gfycat.js
@@ -118,7 +118,7 @@ describes.realWin(
 
     it('requires data-gfyid', () => {
       return allowConsoleError(() => {
-        return getGfycat('').should.eventually.be.rejectedWith(
+        return expect(getGfycat('')).to.eventually.be.rejectedWith(
           /The data-gfyid attribute is required for/
         );
       });

--- a/extensions/amp-google-vrview-image/0.1/test/test-amp-google-vrview-image.js
+++ b/extensions/amp-google-vrview-image/0.1/test/test-amp-google-vrview-image.js
@@ -90,7 +90,7 @@ describes.realWin(
 
     it('requires src', () => {
       return allowConsoleError(() => {
-        return getVrImage({}).should.eventually.be.rejectedWith(
+        return expect(getVrImage({})).to.eventually.be.rejectedWith(
           /must be available/
         );
       });
@@ -98,9 +98,11 @@ describes.realWin(
 
     it('requires https src', () => {
       return allowConsoleError(() => {
-        return getVrImage({
-          'src': 'http://example.com/image1',
-        }).should.eventually.be.rejectedWith(/https/);
+        return expect(
+          getVrImage({
+            'src': 'http://example.com/image1',
+          })
+        ).to.eventually.be.rejectedWith(/https/);
       });
     });
   }

--- a/extensions/amp-hulu/0.1/test/test-amp-hulu.js
+++ b/extensions/amp-hulu/0.1/test/test-amp-hulu.js
@@ -67,7 +67,7 @@ describes.realWin(
 
     it('requires data-eid', () => {
       return allowConsoleError(() => {
-        return getHulu('').should.eventually.be.rejectedWith(
+        return expect(getHulu('')).to.eventually.be.rejectedWith(
           /The data-eid attribute is required for/
         );
       });

--- a/extensions/amp-izlesene/0.1/test/test-amp-izlesene.js
+++ b/extensions/amp-izlesene/0.1/test/test-amp-izlesene.js
@@ -69,7 +69,7 @@ describes.realWin(
 
     it('requires data-videoid', () => {
       return allowConsoleError(() => {
-        return getIzlesene('').should.eventually.be.rejectedWith(
+        return expect(getIzlesene('')).to.eventually.be.rejectedWith(
           /The data-videoid attribute is required for/
         );
       });

--- a/extensions/amp-jwplayer/0.1/test/test-amp-jwplayer.js
+++ b/extensions/amp-jwplayer/0.1/test/test-amp-jwplayer.js
@@ -107,9 +107,11 @@ describes.realWin(
     });
     it('fails if no media is specified', () => {
       return allowConsoleError(() => {
-        return getjwplayer({
-          'data-player-id': 'sDZEo0ea',
-        }).should.eventually.be.rejectedWith(
+        return expect(
+          getjwplayer({
+            'data-player-id': 'sDZEo0ea',
+          })
+        ).to.eventually.be.rejectedWith(
           /Either the data-media-id or the data-playlist-id attributes must be/
         );
       });
@@ -117,9 +119,11 @@ describes.realWin(
 
     it('fails if no player is specified', () => {
       return allowConsoleError(() => {
-        return getjwplayer({
-          'data-media-id': 'Wferorsv',
-        }).should.eventually.be.rejectedWith(
+        return expect(
+          getjwplayer({
+            'data-media-id': 'Wferorsv',
+          })
+        ).to.eventually.be.rejectedWith(
           /The data-player-id attribute is required for/
         );
       });

--- a/extensions/amp-kaltura-player/0.1/test/test-amp-kaltura-player.js
+++ b/extensions/amp-kaltura-player/0.1/test/test-amp-kaltura-player.js
@@ -82,13 +82,13 @@ describes.realWin(
 
     it('requires data-account', () => {
       return allowConsoleError(() => {
-        return getKaltura({})
-          .then((kp) => {
+        return expect(
+          getKaltura({}).then((kp) => {
             kp.build();
           })
-          .should.eventually.be.rejectedWith(
-            /The data-partner attribute is required for/
-          );
+        ).to.eventually.be.rejectedWith(
+          /The data-partner attribute is required for/
+        );
       });
     });
 

--- a/extensions/amp-mowplayer/0.1/test/test-amp-mowplayer.js
+++ b/extensions/amp-mowplayer/0.1/test/test-amp-mowplayer.js
@@ -97,7 +97,7 @@ describes.realWin(
 
       it('requires data-mediaid', () =>
         allowConsoleError(() =>
-          getMowPlayer({}).should.eventually.be.rejectedWith(
+          expect(getMowPlayer({})).to.eventually.be.rejectedWith(
             /The data-mediaid attribute is required for/
           )
         ));

--- a/extensions/amp-next-page/0.1/test/test-amp-next-page.js
+++ b/extensions/amp-next-page/0.1/test/test-amp-next-page.js
@@ -252,7 +252,7 @@ describes.realWin(
           'amp-next-page should contain a <script> child, a URL specified in ' +
           '[src], or a [type]';
         expectAsyncConsoleError(error);
-        return nextPage.buildCallback().should.be.rejectedWith(error);
+        return expect(nextPage.buildCallback()).to.be.rejectedWith(error);
       });
 
       it('fetches remote config when specified in src', function* () {
@@ -298,7 +298,7 @@ describes.realWin(
         expectAsyncConsoleError(error);
         element.setAttribute('type', 'adsense');
         element.setAttribute('data-slot', '12345');
-        return nextPage.buildCallback().should.be.rejectedWith(error);
+        return expect(nextPage.buildCallback()).to.be.rejectedWith(error);
       });
 
       it('errors without slot', () => {
@@ -306,7 +306,7 @@ describes.realWin(
         expectAsyncConsoleError(error);
         element.setAttribute('type', 'adsense');
         element.setAttribute('data-client', 'ca-pub-12345');
-        return nextPage.buildCallback().should.be.rejectedWith(error);
+        return expect(nextPage.buildCallback()).to.be.rejectedWith(error);
       });
 
       it('errors for invalid client format', () => {
@@ -317,7 +317,7 @@ describes.realWin(
         element.setAttribute('type', 'adsense');
         element.setAttribute('data-client', 'doggos');
         element.setAttribute('data-slot', '12345');
-        return nextPage.buildCallback().should.be.rejectedWith(error);
+        return expect(nextPage.buildCallback()).to.be.rejectedWith(error);
       });
 
       it('errors for invalid slot format', () => {
@@ -326,7 +326,7 @@ describes.realWin(
         element.setAttribute('type', 'adsense');
         element.setAttribute('data-client', 'ca-pub-12345');
         element.setAttribute('data-slot', 'doggos');
-        return nextPage.buildCallback().should.be.rejectedWith(error);
+        return expect(nextPage.buildCallback()).to.be.rejectedWith(error);
       });
     });
 

--- a/extensions/amp-o2-player/0.1/test/test-amp-o2-player.js
+++ b/extensions/amp-o2-player/0.1/test/test-amp-o2-player.js
@@ -75,27 +75,27 @@ describes.realWin(
 
     it('requires data-pid', () => {
       return allowConsoleError(() => {
-        return getO2player({
-          'data-bcid': '50d595ec0364e95588c77bd2',
-        }).should.eventually.be.rejectedWith(
-          /data-pid attribute is required for/
-        );
+        return expect(
+          getO2player({
+            'data-bcid': '50d595ec0364e95588c77bd2',
+          })
+        ).to.eventually.be.rejectedWith(/data-pid attribute is required for/);
       });
     });
 
     it('requires data-bcid', () => {
       return allowConsoleError(() => {
-        return getO2player({
-          'data-pid': '573acb47e4b0564ec2e10011',
-        }).should.eventually.be.rejectedWith(
-          /data-bcid attribute is required for/
-        );
+        return expect(
+          getO2player({
+            'data-pid': '573acb47e4b0564ec2e10011',
+          })
+        ).to.eventually.be.rejectedWith(/data-bcid attribute is required for/);
       });
     });
 
     it('requires data-pid && data-bcid', () => {
       return allowConsoleError(() => {
-        return getO2player({}).should.eventually.be.rejectedWith(
+        return expect(getO2player({})).to.eventually.be.rejectedWith(
           /data-pid attribute is required for/
         );
       });

--- a/extensions/amp-ooyala-player/0.1/test/test-amp-ooyala.js
+++ b/extensions/amp-ooyala-player/0.1/test/test-amp-ooyala.js
@@ -105,33 +105,37 @@ describes.realWin(
     });
 
     it('fails without an embed code', () => {
-      return getOoyalaElement(
-        null,
-        '6440813504804d76ba35c8c787a4b33c',
-        '5zb2wxOlZcNCe_HVT3a6cawW298X'
-      ).should.eventually.be.rejectedWith(
+      return expect(
+        getOoyalaElement(
+          null,
+          '6440813504804d76ba35c8c787a4b33c',
+          '5zb2wxOlZcNCe_HVT3a6cawW298X'
+        )
+      ).to.eventually.be.rejectedWith(
         /The data-embedcode attribute is required/
       );
     });
 
     it('fails without a player ID', () => {
-      return getOoyalaElement(
-        'Vxc2k0MDE6Y_C7J5podo3UDxlFxGaZrQ',
-        null,
-        '5zb2wxOlZcNCe_HVT3a6cawW298X'
-      ).should.eventually.be.rejectedWith(
+      return expect(
+        getOoyalaElement(
+          'Vxc2k0MDE6Y_C7J5podo3UDxlFxGaZrQ',
+          null,
+          '5zb2wxOlZcNCe_HVT3a6cawW298X'
+        )
+      ).to.eventually.be.rejectedWith(
         /The data-playerid attribute is required/
       );
     });
 
     it('fails without a p-code', () => {
-      return getOoyalaElement(
-        'Vxc2k0MDE6Y_C7J5podo3UDxlFxGaZrQ',
-        '6440813504804d76ba35c8c787a4b33c',
-        null
-      ).should.eventually.be.rejectedWith(
-        /The data-pcode attribute is required/
-      );
+      return expect(
+        getOoyalaElement(
+          'Vxc2k0MDE6Y_C7J5podo3UDxlFxGaZrQ',
+          '6440813504804d76ba35c8c787a4b33c',
+          null
+        )
+      ).to.eventually.be.rejectedWith(/The data-pcode attribute is required/);
     });
   }
 );

--- a/extensions/amp-ooyala-player/0.1/test/test-amp-ooyala.js
+++ b/extensions/amp-ooyala-player/0.1/test/test-amp-ooyala.js
@@ -62,6 +62,10 @@ describes.realWin(
         player.setAttribute('data-placeholder', opt_placeholder);
       }
 
+      player.setAttribute('layout', 'fixed');
+      player.setAttribute('width', '100');
+      player.setAttribute('height', '100');
+
       doc.body.appendChild(player);
       return player.build().then(() => {
         player.layoutCallback();

--- a/extensions/amp-powr-player/0.1/test/test-amp-powr-player.js
+++ b/extensions/amp-powr-player/0.1/test/test-amp-powr-player.js
@@ -95,16 +95,18 @@ describes.realWin(
 
     it('requires data-account', () => {
       expectAsyncConsoleError(/The data-account attribute is required for/, 1);
-      return getPowrPlayer({}).should.eventually.be.rejectedWith(
+      return expect(getPowrPlayer({})).to.eventually.be.rejectedWith(
         /The data-account attribute is required for/
       );
     });
 
     it('requires data-player', () => {
       expectAsyncConsoleError(/The data-player attribute is required for/, 1);
-      return getPowrPlayer({
-        'data-account': '945',
-      }).should.eventually.be.rejectedWith(
+      return expect(
+        getPowrPlayer({
+          'data-account': '945',
+        })
+      ).to.eventually.be.rejectedWith(
         /The data-player attribute is required for/
       );
     });

--- a/extensions/amp-recaptcha-input/0.1/test/test-amp-recaptcha-input.js
+++ b/extensions/amp-recaptcha-input/0.1/test/test-amp-recaptcha-input.js
@@ -66,11 +66,9 @@ describes.realWin(
         delete ampRecaptchaInputConfig['name'];
 
         return allowConsoleError(() => {
-          return getRecaptchaInput(
-            ampRecaptchaInputConfig
-          ).should.eventually.be.rejectedWith(
-            /The name attribute is required for/
-          );
+          return expect(
+            getRecaptchaInput(ampRecaptchaInputConfig)
+          ).to.eventually.be.rejectedWith(/The name attribute is required for/);
         });
       });
 
@@ -79,9 +77,9 @@ describes.realWin(
         delete ampRecaptchaInputConfig['data-sitekey'];
 
         return allowConsoleError(() => {
-          return getRecaptchaInput(
-            ampRecaptchaInputConfig
-          ).should.eventually.be.rejectedWith(
+          return expect(
+            getRecaptchaInput(ampRecaptchaInputConfig)
+          ).to.eventually.be.rejectedWith(
             /The data-sitekey attribute is required for/
           );
         });
@@ -92,9 +90,9 @@ describes.realWin(
         delete ampRecaptchaInputConfig['data-action'];
 
         return allowConsoleError(() => {
-          return getRecaptchaInput(
-            ampRecaptchaInputConfig
-          ).should.eventually.be.rejectedWith(
+          return expect(
+            getRecaptchaInput(ampRecaptchaInputConfig)
+          ).to.eventually.be.rejectedWith(
             /The data-action attribute is required for/
           );
         });

--- a/extensions/amp-redbull-player/0.1/test/test-amp-redbull.js
+++ b/extensions/amp-redbull-player/0.1/test/test-amp-redbull.js
@@ -64,7 +64,7 @@ describes.realWin(
     });
 
     it('fails without videoId', () => {
-      return getRedBullElement(null).should.eventually.be.rejectedWith(
+      return expect(getRedBullElement(null)).to.eventually.be.rejectedWith(
         /The data-param-videoid attribute is required/
       );
     });

--- a/extensions/amp-reddit/0.1/test/test-amp-reddit.js
+++ b/extensions/amp-reddit/0.1/test/test-amp-reddit.js
@@ -106,16 +106,18 @@ describes.realWin(
     });
 
     it('requires data-src', () => {
-      return getReddit('', 'post').should.eventually.be.rejectedWith(
+      return expect(getReddit('', 'post')).to.eventually.be.rejectedWith(
         /The data-src attribute is required for/
       );
     });
 
     it('requires data-embedtype', () => {
-      return getReddit(
-        'https://www.reddit.com/r/me_irl/comments/52rmir/me_irl/?ref=share&amp;ref_source=embed',
-        ''
-      ).should.eventually.be.rejectedWith(
+      return expect(
+        getReddit(
+          'https://www.reddit.com/r/me_irl/comments/52rmir/me_irl/?ref=share&amp;ref_source=embed',
+          ''
+        )
+      ).to.eventually.be.rejectedWith(
         /The data-embedtype attribute is required for/
       );
     });

--- a/extensions/amp-script/0.1/test/unit/test-amp-script.js
+++ b/extensions/amp-script/0.1/test/unit/test-amp-script.js
@@ -81,7 +81,7 @@ describes.fakeWin('AmpScript', {amp: {runtimeOn: false}}, (env) => {
     );
 
     expectAsyncConsoleError(/Same-origin "src" requires/);
-    return script.layoutCallback().should.be.rejected;
+    return expect(script.layoutCallback()).to.be.rejected;
   });
 
   it('should work with "text/javascript" content-type for same-origin src', () => {
@@ -95,7 +95,7 @@ describes.fakeWin('AmpScript', {amp: {runtimeOn: false}}, (env) => {
     );
 
     expectAsyncConsoleError(/should require JS content-type/);
-    return script.layoutCallback().should.be.fulfilled;
+    return expect(script.layoutCallback()).to.be.fulfilled;
   });
 
   it('should check sha384(author_js) for cross-origin src', async () => {
@@ -155,7 +155,7 @@ describes.fakeWin('AmpScript', {amp: {runtimeOn: false}}, (env) => {
     );
 
     service.checkSha384.withArgs('alert(1)').rejects(/Invalid sha384/);
-    return script.layoutCallback().should.be.rejected;
+    return expect(script.layoutCallback()).to.be.rejected;
   });
 
   it('should check response URL to handle redirects', () => {
@@ -170,7 +170,7 @@ describes.fakeWin('AmpScript', {amp: {runtimeOn: false}}, (env) => {
     );
 
     service.checkSha384.withArgs('alert(1)').rejects(/Invalid sha384/);
-    return script.layoutCallback().should.be.rejected;
+    return expect(script.layoutCallback()).to.be.rejected;
   });
 
   it('should check sha384(author_js) for local scripts', async () => {
@@ -199,7 +199,7 @@ describes.fakeWin('AmpScript', {amp: {runtimeOn: false}}, (env) => {
     env.ampdoc.getBody().appendChild(local);
 
     service.checkSha384.withArgs('alert(1)').rejects(/Invalid sha384/);
-    return script.layoutCallback().should.be.rejected;
+    return expect(script.layoutCallback()).to.be.rejected;
   });
 
   describe('development mode', () => {
@@ -279,7 +279,7 @@ describes.repeated(
             crypto.sha384Base64.resolves('my_fake_hash');
 
             const promise = service.checkSha384('alert(1)', 'foo');
-            return promise.should.be.fulfilled;
+            return expect(promise).to.be.fulfilled;
           });
 
           it('should reject if hash does not exist in meta tag', () => {
@@ -291,7 +291,7 @@ describes.repeated(
             crypto.sha384Base64.resolves('my_fake_hash');
 
             const promise = service.checkSha384('alert(1)', 'foo');
-            return promise.should.be.rejected;
+            return expect(promise).to.be.rejected;
           });
         });
       }

--- a/extensions/amp-springboard-player/0.1/test/test-amp-springboard-player.js
+++ b/extensions/amp-springboard-player/0.1/test/test-amp-springboard-player.js
@@ -83,61 +83,71 @@ describes.realWin(
     });
 
     it('requires data-site-id', () => {
-      return getSpringboardPlayer({
-        'data-mode': 'video',
-        'data-content-id': '1578473',
-        'data-player-id': 'test401',
-        'data-domain': 'test.com',
-        'data-items': '10',
-      }).should.eventually.be.rejectedWith(
+      return expect(
+        getSpringboardPlayer({
+          'data-mode': 'video',
+          'data-content-id': '1578473',
+          'data-player-id': 'test401',
+          'data-domain': 'test.com',
+          'data-items': '10',
+        })
+      ).to.eventually.be.rejectedWith(
         /The data-site-id attribute is required for/
       );
     });
 
     it('requires data-mode', () => {
-      return getSpringboardPlayer({
-        'data-site-id': '261',
-        'data-content-id': '1578473',
-        'data-player-id': 'test401',
-        'data-domain': 'test.com',
-        'data-items': '10',
-      }).should.eventually.be.rejectedWith(
+      return expect(
+        getSpringboardPlayer({
+          'data-site-id': '261',
+          'data-content-id': '1578473',
+          'data-player-id': 'test401',
+          'data-domain': 'test.com',
+          'data-items': '10',
+        })
+      ).to.eventually.be.rejectedWith(
         /The data-mode attribute is required for/
       );
     });
 
     it('requires data-content-id', () => {
-      return getSpringboardPlayer({
-        'data-mode': 'video',
-        'data-site-id': '261',
-        'data-player-id': 'test401',
-        'data-domain': 'test.com',
-        'data-items': '10',
-      }).should.eventually.be.rejectedWith(
+      return expect(
+        getSpringboardPlayer({
+          'data-mode': 'video',
+          'data-site-id': '261',
+          'data-player-id': 'test401',
+          'data-domain': 'test.com',
+          'data-items': '10',
+        })
+      ).to.eventually.be.rejectedWith(
         /The data-content-id attribute is required for/
       );
     });
 
     it('requires data-player-id', () => {
-      return getSpringboardPlayer({
-        'data-mode': 'video',
-        'data-site-id': '261',
-        'data-content-id': '1578473',
-        'data-domain': 'test.com',
-        'data-items': '10',
-      }).should.eventually.be.rejectedWith(
+      return expect(
+        getSpringboardPlayer({
+          'data-mode': 'video',
+          'data-site-id': '261',
+          'data-content-id': '1578473',
+          'data-domain': 'test.com',
+          'data-items': '10',
+        })
+      ).to.eventually.be.rejectedWith(
         /The data-player-id attribute is required for/
       );
     });
 
     it('requires data-domain', () => {
-      return getSpringboardPlayer({
-        'data-mode': 'video',
-        'data-site-id': '261',
-        'data-content-id': '1578473',
-        'data-player-id': 'test401',
-        'data-items': '10',
-      }).should.eventually.be.rejectedWith(
+      return expect(
+        getSpringboardPlayer({
+          'data-mode': 'video',
+          'data-site-id': '261',
+          'data-content-id': '1578473',
+          'data-player-id': 'test401',
+          'data-items': '10',
+        })
+      ).to.eventually.be.rejectedWith(
         /The data-domain attribute is required for/
       );
     });

--- a/extensions/amp-story/0.1/test/test-amp-story-system-layer.js
+++ b/extensions/amp-story/0.1/test/test-amp-story-system-layer.js
@@ -80,7 +80,7 @@ describes.fakeWin('amp-story system layer', {amp: true}, (env) => {
   it('should set the active page index', () => {
     [0, 1, 2, 3, 4].forEach((index) => {
       systemLayer.setActivePageId(index);
-      progressBarStub.setActiveSegmentId.should.have.been.calledWith(index);
+      expect(progressBarStub.setActiveSegmentId).to.have.been.calledWith(index);
     });
   });
 });

--- a/extensions/amp-vimeo/0.1/test/test-amp-vimeo.js
+++ b/extensions/amp-vimeo/0.1/test/test-amp-vimeo.js
@@ -61,7 +61,7 @@ describes.realWin(
     });
 
     it('requires data-videoid', () => {
-      return getVimeo('').should.eventually.be.rejectedWith(
+      return expect(getVimeo('')).to.eventually.be.rejectedWith(
         /The data-videoid attribute is required for/
       );
     });

--- a/extensions/amp-vine/0.1/test/test-amp-vine.js
+++ b/extensions/amp-vine/0.1/test/test-amp-vine.js
@@ -66,7 +66,7 @@ describes.realWin(
     });
 
     it('requires data-vineid', () => {
-      return getVine('').should.eventually.be.rejectedWith(
+      return expect(getVine('')).to.eventually.be.rejectedWith(
         /The data-vineid attribute is required for/
       );
     });

--- a/extensions/amp-viqeo-player/0.1/test/test-amp-viqeo-player.js
+++ b/extensions/amp-viqeo-player/0.1/test/test-amp-viqeo-player.js
@@ -57,7 +57,7 @@ describes.realWin(
       it('requires data-videoid', () => {
         const error = /The data-videoid attribute is required for/;
         expectAsyncConsoleError(error);
-        return getViqeo({viqeoId: null}).should.eventually.be.rejectedWith(
+        return expect(getViqeo({viqeoId: null})).to.eventually.be.rejectedWith(
           error
         );
       });
@@ -65,9 +65,11 @@ describes.realWin(
       it('requires data-profileid', () => {
         const error = /The data-profileid attribute is required for/;
         expectAsyncConsoleError(error);
-        return getViqeo({
-          viqeoProfileId: null,
-        }).should.eventually.be.rejectedWith(error);
+        return expect(
+          getViqeo({
+            viqeoProfileId: null,
+          })
+        ).to.eventually.be.rejectedWith(error);
       });
     });
 

--- a/extensions/amp-vk/0.1/test/test-amp-vk.js
+++ b/extensions/amp-vk/0.1/test/test-amp-vk.js
@@ -73,7 +73,7 @@ describes.realWin(
       const params = {...POST_PARAMS};
       delete params['embedtype'];
       return allowConsoleError(() => {
-        return createAmpVkElement(params).should.eventually.be.rejectedWith(
+        return expect(createAmpVkElement(params)).to.eventually.be.rejectedWith(
           /The data-embedtype attribute is required for/
         );
       });
@@ -96,7 +96,7 @@ describes.realWin(
       const params = {...POST_PARAMS};
       delete params['hash'];
       return allowConsoleError(() => {
-        return createAmpVkElement(params).should.eventually.be.rejectedWith(
+        return expect(createAmpVkElement(params)).to.eventually.be.rejectedWith(
           /The data-hash attribute is required for/
         );
       });
@@ -106,7 +106,7 @@ describes.realWin(
       const params = {...POST_PARAMS};
       delete params['owner-id'];
       return allowConsoleError(() => {
-        return createAmpVkElement(params).should.eventually.be.rejectedWith(
+        return expect(createAmpVkElement(params)).to.eventually.be.rejectedWith(
           /The data-owner-id attribute is required for/
         );
       });
@@ -116,7 +116,7 @@ describes.realWin(
       const params = {...POST_PARAMS};
       delete params['post-id'];
       return allowConsoleError(() => {
-        return createAmpVkElement(params).should.eventually.be.rejectedWith(
+        return expect(createAmpVkElement(params)).to.eventually.be.rejectedWith(
           /The data-post-id attribute is required for/
         );
       });
@@ -158,7 +158,7 @@ describes.realWin(
       const params = {...POLL_PARAMS};
       delete params['api-id'];
       return allowConsoleError(() => {
-        return createAmpVkElement(params).should.eventually.be.rejectedWith(
+        return expect(createAmpVkElement(params)).to.eventually.be.rejectedWith(
           /The data-api-id attribute is required for/
         );
       });
@@ -168,7 +168,7 @@ describes.realWin(
       const params = {...POLL_PARAMS};
       delete params['poll-id'];
       return allowConsoleError(() => {
-        return createAmpVkElement(params).should.eventually.be.rejectedWith(
+        return expect(createAmpVkElement(params)).to.eventually.be.rejectedWith(
           /The data-poll-id attribute is required for/
         );
       });

--- a/extensions/amp-web-push/0.1/test/test-web-push-service.js
+++ b/extensions/amp-web-push/0.1/test/test-web-push-service.js
@@ -76,9 +76,9 @@ describes.realWin(
         value: undefined,
       });
       // Should not error out
-      return webPush
-        .start()
-        .should.eventually.be.rejectedWith(/Web push is not supported/);
+      return expect(webPush.start()).to.eventually.be.rejectedWith(
+        /Web push is not supported/
+      );
     });
   }
 );

--- a/extensions/amp-wistia-player/0.1/test/test-amp-wistia-player.js
+++ b/extensions/amp-wistia-player/0.1/test/test-amp-wistia-player.js
@@ -55,7 +55,7 @@ describes.realWin(
     });
 
     it('requires data-media-hashed-id', () => {
-      return getWistiaEmbed('').should.eventually.be.rejectedWith(
+      return expect(getWistiaEmbed('')).to.eventually.be.rejectedWith(
         /The data-media-hashed-id attribute is required for/
       );
     });

--- a/extensions/amp-youtube/0.1/test/test-amp-youtube.js
+++ b/extensions/amp-youtube/0.1/test/test-amp-youtube.js
@@ -232,7 +232,7 @@ describes.realWin(
 
     it('requires data-videoid or data-live-channelid', () => {
       return allowConsoleError(() => {
-        return getYt({}).should.eventually.be.rejectedWith(
+        return expect(getYt({})).to.eventually.be.rejectedWith(
           /Exactly one of data-videoid or data-live-channelid should/
         );
       });

--- a/test/unit/test-batched-json.js
+++ b/test/unit/test-batched-json.js
@@ -89,9 +89,11 @@ describe('batchFetchJsonFor', () => {
 
         const optIn = UrlReplacementPolicy.OPT_IN;
         const rejectError = /Please add data-amp-replace="BAR" to the <AMP-LIST> element./;
-        return batchFetchJsonFor(ampdoc, el, {
-          urlReplacement: optIn,
-        }).should.eventually.be.rejectedWith(rejectError);
+        return expect(
+          batchFetchJsonFor(ampdoc, el, {
+            urlReplacement: optIn,
+          })
+        ).to.eventually.be.rejectedWith(rejectError);
       }
     );
 

--- a/test/unit/test-cid.js
+++ b/test/unit/test-cid.js
@@ -1069,7 +1069,9 @@ describes.fakeWin('cid optout:', {amp: true}, (env) => {
 
     it('should reject promise if storage set fails', () => {
       storageSetStub.returns(Promise.reject('failed!'));
-      return optOutOfCid(ampdoc).should.eventually.be.rejectedWith('failed!');
+      return expect(optOutOfCid(ampdoc)).to.eventually.be.rejectedWith(
+        'failed!'
+      );
     });
   });
 

--- a/test/unit/test-impression.js
+++ b/test/unit/test-impression.js
@@ -69,7 +69,7 @@ describe('impression', () => {
   it('should do nothing if the experiment is off', () => {
     viewer.getParam.throws(new Error('Should not be called'));
     maybeTrackImpression(window);
-    return getTrackImpressionPromise().should.be.fulfilled;
+    return expect(getTrackImpressionPromise()).to.be.fulfilled;
   });
 
   it('should resolve if no click no replaceUrl', () => {
@@ -122,7 +122,7 @@ describe('impression', () => {
       viewer.getParam.withArgs('click').returns('');
       maybeTrackImpression(window);
       expect(xhr.fetchJson).to.have.not.been.called;
-      return getTrackImpressionPromise().should.be.fulfilled;
+      return expect(getTrackImpressionPromise()).to.be.fulfilled;
     });
 
     it('should do nothing if there is the click arg is http', () => {
@@ -130,7 +130,7 @@ describe('impression', () => {
       viewer.getParam.withArgs('click').returns('http://www.example.com');
       maybeTrackImpression(window);
       expect(xhr.fetchJson).to.have.not.been.called;
-      return getTrackImpressionPromise().should.be.fulfilled;
+      return expect(getTrackImpressionPromise()).to.be.fulfilled;
     });
 
     it('should invoke click URL with experiment on', function* () {
@@ -289,7 +289,7 @@ describe('impression', () => {
       maybeTrackImpression(window);
       yield macroTask();
       expect(viewer.replaceUrl).to.have.not.been.called;
-      return getTrackImpressionPromise().should.be.fulfilled;
+      return expect(getTrackImpressionPromise()).to.be.fulfilled;
     });
 
     it('should use init replaceUrl parm if viewer has no capability', () => {

--- a/test/unit/test-xhr.js
+++ b/test/unit/test-xhr.js
@@ -337,17 +337,19 @@ describe
 
           it('should resolve if success', () => {
             mockXhr.status = 200;
-            return assertSuccess(createResponseInstance('', mockXhr)).then(
-              (response) => {
-                expect(response.status).to.equal(200);
-              }
-            ).should.not.be.rejected;
+            return expect(
+              assertSuccess(createResponseInstance('', mockXhr)).then(
+                (response) => {
+                  expect(response.status).to.equal(200);
+                }
+              )
+            ).to.not.be.rejected;
           });
 
           it('should reject if error', () => {
             mockXhr.status = 500;
-            return assertSuccess(createResponseInstance('', mockXhr)).should.be
-              .rejected;
+            return expect(assertSuccess(createResponseInstance('', mockXhr))).to
+              .be.rejected;
           });
 
           it('should include response in error', () => {
@@ -365,8 +367,9 @@ describe
             mockXhr.responseText = '{"a": "hello"}';
             mockXhr.headers['Content-Type'] = 'application/json';
             mockXhr.getResponseHeader = () => 'application/json';
-            return assertSuccess(createResponseInstance('{"a": 2}', mockXhr))
-              .should.not.be.fulfilled;
+            return expect(
+              assertSuccess(createResponseInstance('{"a": 2}', mockXhr))
+            ).to.not.be.fulfilled;
           });
         });
 


### PR DESCRIPTION
Stage 1 of a multi part cleanup of our test suites. Unlovingly called "i really really really hate chai", because it's **far** to easy to write broken tests. These tests aren't bad themselves, but they way chai allows you to write certain assertions leads to bugs. The fault is with chai's format, not with the tests themselves.

The main reason is that I'm writing several autofixers, and I need to convert the codebase to `expect` syntax so that its easier to find all cases.

But, using `should` is kinda bad. For it to work, it has to put a non-enumerable getter on `Object.prototype` (always a bad idea to monkey with builtin prototypes). And it's inconsistent, try doing `foo.should.be.ok` when `foo` is `undefined` or `Object.create(null)`.

Current roadmap:
- Ban `should` usage
- Ban chai-as-promised
- Lint for chai assertion methods that are not called.