### PR TITLE
🐛 amp-mathml: disabled focus operation

### DIFF
--- a/3p/mathml.js
+++ b/3p/mathml.js
@@ -59,6 +59,9 @@ export function mathml(global, data) {
       global.document.body.appendChild(div);
       mathjax.Hub.Config({
         showMathMenu: false,
+        menuSettings: {
+          inTabOrder: false,
+        },
       });
       mathjax.Hub.Queue(function () {
         const rendered = document.getElementById('MathJax-Element-1-Frame');
@@ -76,6 +79,7 @@ export function mathml(global, data) {
           rendered./*OK*/ offsetWidth,
           rendered./*OK*/ offsetHeight
         );
+        setStyle(rendered, 'outline', 'none');
         setStyle(div, 'visibility', 'visible');
       });
     }


### PR DESCRIPTION
<!--
# Instructions:

- Pick a meaningful title for your pull request. (Use sentence case.)
  - Prefix the title with an emoji to identify what is being done. (Copy-paste the emoji from the list below.)
  - Do not overuse punctuation in the title (like `(chore):`).
  - If it is helpful, use a simple prefix (like `ProjectX: Implement some feature`).
- Enter a succinct description that says why the PR is necessary, and what it does.
  - Mention the GitHub issue that is being addressed by the pull request.
  - The keywords `Fixes`, `Closes`, or `Resolves` followed the issue number will automatically close the issue.

> NOTE: All non-trivial changes (like introducing new features or components) should have an associated issue or reference an I2I (intent-to-implement: go.amp.dev/i2i). Please read through the contribution process (go.amp.dev/contributing/code) for more information.

# Example of a good description:

- Implement aspect X
- Leave out feature Y because of A
- Improve performance by B
- Improve accessibility by C

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Reverting a previous change
♻️ Refactoring
🚮 Deleting code
-->

resolved #26082

`amp-mathml` is no longer a focusable element, thus I disabled the `inTabOrder` option and added the `outline: none` style.

