### PR TITLE
🐛Update beop URLs after domain change

### DIFF
--- a/3p/beopinion.js
+++ b/3p/beopinion.js
@@ -25,7 +25,7 @@ import {setStyles} from '../src/style';
  * @param {!Window} global
  */
 function getBeOpinion(global) {
-  loadScript(global, 'https://widget.beopinion.com/sdk.js', function () {});
+  loadScript(global, 'https://widget.beop.io/sdk.js', function () {});
 }
 
 /**

--- a/ads/_config.js
+++ b/ads/_config.js
@@ -309,11 +309,11 @@ const adConfig = jsonConfiguration({
   },
 
   'beopinion': {
-    prefetch: 'https://widget.beopinion.com/sdk.js',
+    prefetch: 'https://widget.beop.io/sdk.js',
     preconnect: [
-      'https://t.beopinion.com',
-      'https://s.beopinion.com',
-      'https://data.beopinion.com',
+      'https://t.beop.io',
+      'https://s.beop.io',
+      'https://data.beop.io',
     ],
     renderStartImplemented: true,
   },

--- a/extensions/amp-beopinion/0.1/amp-beopinion.js
+++ b/extensions/amp-beopinion/0.1/amp-beopinion.js
@@ -42,14 +42,14 @@ class AmpBeOpinion extends AMP.BaseElement {
     // Hosts the script that renders widgets.
     preconnect.preload(
       this.getAmpDoc(),
-      'https://widget.beopinion.com/sdk.js',
+      'https://widget.beop.io/sdk.js',
       'script'
     );
-    preconnect.url(this.getAmpDoc(), 'https://s.beopinion.com', opt_onLayout);
-    preconnect.url(this.getAmpDoc(), 'https://t.beopinion.com', opt_onLayout);
+    preconnect.url(this.getAmpDoc(), 'https://s.beop.io', opt_onLayout);
+    preconnect.url(this.getAmpDoc(), 'https://t.beop.io', opt_onLayout);
     preconnect.url(
       this.getAmpDoc(),
-      'https://data.beopinion.com',
+      'https://data.beop.io',
       opt_onLayout
     );
   }

--- a/extensions/amp-beopinion/0.1/amp-beopinion.js
+++ b/extensions/amp-beopinion/0.1/amp-beopinion.js
@@ -47,11 +47,7 @@ class AmpBeOpinion extends AMP.BaseElement {
     );
     preconnect.url(this.getAmpDoc(), 'https://s.beop.io', opt_onLayout);
     preconnect.url(this.getAmpDoc(), 'https://t.beop.io', opt_onLayout);
-    preconnect.url(
-      this.getAmpDoc(),
-      'https://data.beop.io',
-      opt_onLayout
-    );
+    preconnect.url(this.getAmpDoc(), 'https://data.beop.io', opt_onLayout);
   }
 
   /** @override */

--- a/extensions/amp-beopinion/amp-beopinion.md
+++ b/extensions/amp-beopinion/amp-beopinion.md
@@ -26,7 +26,7 @@ limitations under the License.
 
 ## Behavior
 
-The `amp-beopinion` component allows you to embed [BeOpinion](https://beopinion.com/) content in your AMP page for a given BeOpinion account. BeOpinion is a tool for content creators to add interactive blocks such as polls and quizzes to their pages. BeOpinion mostly works with journalists of major media groups in Europe.
+The `amp-beopinion` component allows you to embed [BeOpinion](https://beop.io/) content in your AMP page for a given BeOpinion account. BeOpinion is a tool for content creators to add interactive blocks such as polls and quizzes to their pages. BeOpinion mostly works with journalists of major media groups in Europe.
 
 ### Integration examples
 


### PR DESCRIPTION
We changed domains and recently stopped using our old one. This PR fixes the `preconnect` links and scripts URLs.