### PR TITLE
Always prefix auto advance advancement modes with autoAdvance.

### DIFF
--- a/extensions/amp-story/1.0/story-analytics.js
+++ b/extensions/amp-story/1.0/story-analytics.js
@@ -42,7 +42,10 @@ export const StoryAnalyticsEvent = {
   STORY_UNMUTED: 'story-audio-unmuted',
 };
 
-/** @enum {string} */
+/**
+ * @enum {string}
+ * Note: auto advance advancement should always be prefixed with "autoAdvance".
+ */
 export const AdvancementMode = {
   GO_TO_PAGE: 'goToPageAction',
   AUTO_ADVANCE_TIME: 'autoAdvanceTime',

--- a/extensions/amp-story/1.0/story-analytics.js
+++ b/extensions/amp-story/1.0/story-analytics.js
@@ -44,7 +44,7 @@ export const StoryAnalyticsEvent = {
 
 /**
  * @enum {string}
- * Note: auto advance advancement should always be prefixed with "autoAdvance".
+ * Note: auto advance advancements should always be prefixed with "autoAdvance".
  */
 export const AdvancementMode = {
   GO_TO_PAGE: 'goToPageAction',


### PR DESCRIPTION
Always prefix auto advance advancement modes with `autoAdvance`, so viewers can easily write a future proof `isAutoAdvance()` helper to use with the `selectDocument` message.