### PR TITLE
🏗 De-dupe pre-build and lazy-build of `amp.js` during default `gulp`

### DIFF
--- a/build-system/compile/bundles.config.js
+++ b/build-system/compile/bundles.config.js
@@ -15,8 +15,10 @@
  */
 'use strict';
 
+const argv = require('minimist')(process.argv.slice(2));
 const colors = require('ansi-colors');
 const log = require('fancy-log');
+const wrappers = require('./compile-wrappers');
 
 const {VERSION: internalRuntimeVersion} = require('./internal-version');
 
@@ -172,6 +174,10 @@ exports.jsBundles = {
     options: {
       minifiedName: 'v0.js',
       includePolyfills: true,
+      wrapper: wrappers.mainBinary,
+      singlePassCompilation: argv.single_pass,
+      esmPassCompilation: argv.esm,
+      includeOnlyESMLevelPolyfills: argv.esm,
     },
   },
   'amp-shadow.js': {

--- a/build-system/server/lazy-build.js
+++ b/build-system/server/lazy-build.js
@@ -21,7 +21,7 @@ const {
   maybeInitializeExtensions,
   getExtensionsToBuild,
 } = require('../tasks/extension-helpers');
-const {doBuildJs, compileCoreRuntime} = require('../tasks/helpers');
+const {doBuildJs} = require('../tasks/helpers');
 const {jsBundles} = require('../compile/bundles.config');
 
 const extensionBundles = {};
@@ -128,7 +128,7 @@ async function lazyBuildJs(req, res, next) {
  * Pre-builds the core runtime and the JS files that it loads.
  */
 async function preBuildRuntimeFiles() {
-  await compileCoreRuntime(/* watch */ true, argv.compiled);
+  await build(jsBundles, 'amp.js', doBuildJs);
   await build(jsBundles, 'ww.max.js', doBuildJs);
 }
 

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
+const argv = require('minimist')(process.argv.slice(2));
 const babelify = require('babelify');
 const browserify = require('browserify');
 const buffer = require('vinyl-buffer');
-const colors = require('ansi-colors');
 const debounce = require('debounce');
 const del = require('del');
 const file = require('gulp-file');
@@ -41,12 +41,10 @@ const {altMainBundles, jsBundles} = require('../compile/bundles.config');
 const {applyConfig, removeConfig} = require('./prepend-global/index.js');
 const {closureCompile} = require('../compile/compile');
 const {EventEmitter} = require('events');
+const {green, red, cyan} = require('ansi-colors');
 const {isTravisBuild} = require('../common/travis');
 const {thirdPartyFrames} = require('../test-configs/config');
 const {transpileTs} = require('../compile/typescript');
-
-const {green, red, cyan} = colors;
-const argv = require('minimist')(process.argv.slice(2));
 
 /**
  * Tasks that should print the `--nobuild` help text.
@@ -160,14 +158,7 @@ async function bootstrapThirdPartyFrames(watch, minify) {
  * @return {!Promise}
  */
 async function compileCoreRuntime(watch, minify) {
-  await doBuildJs(jsBundles, 'amp.js', {
-    watch,
-    minify,
-    wrapper: wrappers.mainBinary,
-    singlePassCompilation: argv.single_pass,
-    esmPassCompilation: argv.esm,
-    includeOnlyESMLevelPolyfills: argv.esm,
-  });
+  await doBuildJs(jsBundles, 'amp.js', {watch, minify});
 }
 
 /**


### PR DESCRIPTION
During the default `gulp` task, we kick off a pre-build step for the core runtime and optionally some extensions, and start off the server. Meanwhile, if the developer loads an example page that tries to kick off a lazy-build for the same files, the lazy-builder uses the following mechanism to prevent a duplicate build, and waits for the pending build instead:

https://github.com/ampproject/amphtml/blob/67815dc7b6c1f434a09fcd52227a01f7b0b2c728/build-system/server/lazy-build.js#L51-L75

It turns out that the core runtime does not use this mechanism because of the special options it uses. Meanwhile, pre-built extensions do benefit from  duplicate-build detection.

This PR un-special-cases the core runtime as follows:
- Moves extra options for `amp.js` to `build-system/compile/bundles.config.js`
- Calls `build()` instead of `compileCoreRuntime()` in `lazy-build.js`, thereby preventing duplicate pre-build + lazy-build

With this, the core runtime will benefit from duplicate-build detection, while continuing to use the correct options.

Fixes #27722