### PR TITLE
🏗 Reduce closure concurrency on Travis from 4 to 2

### DIFF
--- a/build-system/compile/compile.js
+++ b/build-system/compile/compile.js
@@ -46,7 +46,7 @@ let inProgress = 0;
 // during various local development scenarios.
 // See https://github.com/google/closure-compiler-npm/issues/9
 const MAX_PARALLEL_CLOSURE_INVOCATIONS = isTravisBuild()
-  ? 4
+  ? 2
   : parseInt(argv.closure_concurrency, 10) || 1;
 
 // Compiles AMP with the closure compiler. This is intended only for


### PR DESCRIPTION
We're seeing increasing instances of stalled `gulp dist` invocations on Travis.

![image](https://user-images.githubusercontent.com/26553114/80648013-6e83f000-8a3d-11ea-9473-3e6af8a70350.png)

The root cause of these stalls appears to be concurrency problems with our custom closure compiler `runner.jar`. Actually solving this problem needs us to eliminate `AmpPass.java` (#24047), which is currently blocked by #23960.

Meanwhile, this PR reduces closure concurrency on Travis from 4 to 2, to match the [number of cores](https://docs.travis-ci.com/user/reference/overview/#virtualisation-environment-vs-operating-system) in the default Xenial VMs.

Addresses https://github.com/ampproject/amphtml/issues/24487#issuecomment-621471530
