### PR TITLE
🖍 Cleanup several unresolved amp-layout CSS states

### DIFF
--- a/css/ampshared.css
+++ b/css/ampshared.css
@@ -87,7 +87,7 @@
 }
 
 .i-amphtml-layout-fixed-height,
-[layout=fixed-height][height]:not(i-amphtml-layout-fixed-height)
+[layout=fixed-height][height]:not(.i-amphtml-layout-fixed-height)
 {
   display: block;
   position: relative;

--- a/css/ampshared.css
+++ b/css/ampshared.css
@@ -63,7 +63,8 @@
 
 .i-amphtml-layout-responsive,
 [layout=responsive][width][height]:not(.i-amphtml-layout-responsive),
-[width][height][sizes]:not([layout]):not(.i-amphtml-layout-responsive)
+[width][height][sizes]:not([layout]):not(.i-amphtml-layout-responsive),
+[width][height][heights]:not([layout]):not(.i-amphtml-layout-responsive)
 {
   display: block;
   position: relative;
@@ -231,7 +232,8 @@ i-amphtml-sizer {
 
 .i-amphtml-notbuilt,
 [layout]:not(.i-amphtml-element),
-[width][height][sizes]:not([layout]):not(.i-amphtml-element)
+[width][height][sizes]:not([layout]):not(.i-amphtml-element),
+[width][height][heights]:not([layout]):not(.i-amphtml-element)
 {
   position: relative;
   overflow: hidden !important;
@@ -241,7 +243,8 @@ i-amphtml-sizer {
 /* Hide all children of non-container elements. */
 .i-amphtml-notbuilt:not(.i-amphtml-layout-container) > * ,
 [layout]:not([layout=container]):not(.i-amphtml-element) > *,
-[width][height][sizes]:not([layout]):not(.i-amphtml-element) > *
+[width][height][sizes]:not([layout]):not(.i-amphtml-element) > *,
+[width][height][heights]:not([layout]):not(.i-amphtml-element) > *
 {
   display: none;
 }
@@ -260,7 +263,8 @@ i-amphtml-sizer {
 
 .i-amphtml-element > [placeholder],
 [layout]:not(.i-amphtml-element) > [placeholder],
-[width][height][sizes]:not([layout]):not(.i-amphtml-element) > [placeholder]
+[width][height][sizes]:not([layout]):not(.i-amphtml-element) > [placeholder],
+[width][height][heights]:not([layout]):not(.i-amphtml-element) > [placeholder]
 {
   display: block;
 }

--- a/css/ampshared.css
+++ b/css/ampshared.css
@@ -69,10 +69,15 @@
   position: relative;
 }
 
-.i-amphtml-layout-intrinsic
+.i-amphtml-layout-intrinsic,
+[layout=intrinsic][width][height]:not(.i-amphtml-layout-intrinsic)
 {
   display: inline-block;
   position: relative;
+  max-width: 100%;
+}
+
+.i-amphtml-layout-intrinsic .i-amphtml-sizer {
   max-width: 100%;
 }
 
@@ -82,7 +87,7 @@
 }
 
 .i-amphtml-layout-fixed-height,
-[layout=fixed-height][height]
+[layout=fixed-height][height]:not(i-amphtml-layout-fixed-height)
 {
   display: block;
   position: relative;
@@ -156,10 +161,6 @@ i-amphtml-sizer {
   right: 0;
 }
 
-.i-amphtml-layout-intrinsic .i-amphtml-sizer {
-  max-width: 100%;
-}
-
 .i-amphtml-replaced-content {
   padding: 0 !important;
   border: none !important;
@@ -229,7 +230,8 @@ i-amphtml-sizer {
 }
 
 .i-amphtml-notbuilt,
-[layout]:not(.i-amphtml-element)
+[layout]:not(.i-amphtml-element),
+[width][height][sizes]:not([layout]):not(.i-amphtml-element)
 {
   position: relative;
   overflow: hidden !important;
@@ -238,7 +240,8 @@ i-amphtml-sizer {
 
 /* Hide all children of non-container elements. */
 .i-amphtml-notbuilt:not(.i-amphtml-layout-container) > * ,
-[layout]:not([layout=container]):not(.i-amphtml-element) > *
+[layout]:not([layout=container]):not(.i-amphtml-element) > *,
+[width][height][sizes]:not([layout]):not(.i-amphtml-element) > *
 {
   display: none;
 }
@@ -256,7 +259,9 @@ i-amphtml-sizer {
 }
 
 .i-amphtml-element > [placeholder],
-[layout]:not(.i-amphtml-element) > [placeholder] {
+[layout]:not(.i-amphtml-element) > [placeholder],
+[width][height][sizes]:not([layout]):not(.i-amphtml-element) > [placeholder]
+{
   display: block;
 }
 


### PR DESCRIPTION
- Adds unresolved layout for `intrinsic` styles
- Fixes specificity for unresolved `fixed-height` styles
- Adds unresolved implicit layout `responsive` styles