### PR TITLE
🛑Disable all perf observers in inabox.

### DIFF
--- a/src/service/performance-impl.js
+++ b/src/service/performance-impl.js
@@ -117,14 +117,8 @@ export class Performance {
      */
     this.aggregateShiftScore_ = 0;
 
-    // TODO(ccordry): there is a lot of other unnecessary work happening in
-    // this class for inabox case, but will require a larger refactor.
-    const isInabox = getMode(this.win).runtime === 'inabox';
-
     const supportedEntryTypes =
-      // Turn off most performance metrics for inabox as there is no viewer.
-      (!isInabox &&
-        this.win.PerformanceObserver &&
+      (this.win.PerformanceObserver &&
         this.win.PerformanceObserver.supportedEntryTypes) ||
       [];
     /**
@@ -295,6 +289,14 @@ export class Performance {
    * See https://github.com/WICG/paint-timing
    */
   registerPerformanceObserver_() {
+    // Turn off performanceObserver derived metrics for inabox as there
+    // will never be a viewer to report to.
+    // TODO(ccordry): we are still doing some other unnecessary measurements for
+    // the inabox case, but would need a larger refactor.
+    if (getMode(this.win).runtime === 'inabox') {
+      return;
+    }
+
     // Chromium doesn't implement the buffered flag for PerformanceObserver.
     // That means we need to read existing entries and maintain state
     // as to whether we have reported a value yet, since in the future it may

--- a/src/service/performance-impl.js
+++ b/src/service/performance-impl.js
@@ -117,8 +117,14 @@ export class Performance {
      */
     this.aggregateShiftScore_ = 0;
 
+    // TODO(ccordry): there is a lot of other unnecessary work happening in
+    // this class for inabox case, but will require a larger refactor.
+    const isInabox = getMode(this.win).runtime === 'inabox';
+
     const supportedEntryTypes =
-      (this.win.PerformanceObserver &&
+      // Turn off most performance metrics for inabox as there is no viewer.
+      (!isInabox &&
+        this.win.PerformanceObserver &&
         this.win.PerformanceObserver.supportedEntryTypes) ||
       [];
     /**

--- a/test/unit/test-performance.js
+++ b/test/unit/test-performance.js
@@ -1363,9 +1363,6 @@ describes.realWin('PeformanceObserver metrics', {amp: true}, (env) => {
     });
 
     it('disables many observers', () => {
-      // Disable creation of paint observer.
-      env.win.PerformancePaintTiming = null;
-
       PerformanceObserverConstructorStub.supportedEntryTypes = [
         'navigation',
         'largest-contentful-paint',
@@ -1373,8 +1370,7 @@ describes.realWin('PeformanceObserver metrics', {amp: true}, (env) => {
         'layout-shift',
       ];
       installPerformanceService(env.win);
-      const mode = getMode(env.win);
-      mode.runtime = 'inabox';
+      env.win.__AMP_MODE.runtime = 'inabox';
       Services.performanceFor(env.win);
       // Each supported entryType currently leads to creation of new observer.
       expect(PerformanceObserverConstructorStub).not.to.be.called;

--- a/test/unit/test-performance.js
+++ b/test/unit/test-performance.js
@@ -1351,4 +1351,33 @@ describes.realWin('PeformanceObserver metrics', {amp: true}, (env) => {
       ]);
     });
   });
+
+  describe('inabox environment', () => {
+    let PerformanceObserverConstructorStub;
+
+    beforeEach(() => {
+      PerformanceObserverConstructorStub = env.sandbox.stub(
+        env.win,
+        'PerformanceObserver'
+      );
+    });
+
+    it('disables many observers', () => {
+      // Disable creation of paint observer.
+      env.win.PerformancePaintTiming = null;
+
+      PerformanceObserverConstructorStub.supportedEntryTypes = [
+        'navigation',
+        'largest-contentful-paint',
+        'first-input',
+        'layout-shift',
+      ];
+      installPerformanceService(env.win);
+      const mode = getMode(env.win);
+      mode.runtime = 'inabox';
+      Services.performanceFor(env.win);
+      // Each supported entryType currently leads to creation of new observer.
+      expect(PerformanceObserverConstructorStub).not.to.be.called;
+    });
+  });
 });


### PR DESCRIPTION
Fixes regression blocking 4/7 inabox release. There are likely other perf improvements we could make for inabox in the `performance-impl` since the viewer will never exist, but those would be much larger changes.
