### PR TITLE
🏗 Update amp-asserts transform to match AmpPass's transformations

### DIFF
--- a/build-system/babel-plugins/babel-plugin-transform-amp-asserts/index.js
+++ b/build-system/babel-plugins/babel-plugin-transform-amp-asserts/index.js
@@ -36,7 +36,7 @@ const REMOVABLE = {
 };
 
 module.exports = function (babel) {
-  const {types: t, template} = babel;
+  const {types: t} = babel;
 
   /**
    * @param {!NodePath} path
@@ -76,7 +76,7 @@ module.exports = function (babel) {
       if (evaluation.confident) {
         if (type) {
           if (typeof evaluation.value !== type) {
-            path.replaceWith(template.ast`
+            path.replaceWith(babel.template.ast`
               (function() {
                 throw new Error('static type assertion failure');
               }());
@@ -84,7 +84,7 @@ module.exports = function (babel) {
             return;
           }
         } else if (!evaluation.value) {
-          path.replaceWith(template.ast`
+          path.replaceWith(babel.template.ast`
             (function() {
               throw new Error('static assertion failure');
             }());

--- a/build-system/babel-plugins/babel-plugin-transform-amp-asserts/test/fixtures/transform-assertions/transform-dev-assert-boolean-non/output.js
+++ b/build-system/babel-plugins/babel-plugin-transform-amp-asserts/test/fixtures/transform-assertions/transform-dev-assert-boolean-non/output.js
@@ -13,6 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-(function () {
-  throw new Error('static type assertion failure');
-})();
+
+/** @type {boolean} */
+(null);

--- a/build-system/babel-plugins/babel-plugin-transform-amp-asserts/test/fixtures/transform-assertions/transform-dev-assert-number-non/output.js
+++ b/build-system/babel-plugins/babel-plugin-transform-amp-asserts/test/fixtures/transform-assertions/transform-dev-assert-number-non/output.js
@@ -13,6 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-(function () {
-  throw new Error('static type assertion failure');
-})();
+
+/** @type {number} */
+(null);

--- a/build-system/babel-plugins/babel-plugin-transform-amp-asserts/test/fixtures/transform-assertions/transform-dev-assert-string-not-string-non/output.js
+++ b/build-system/babel-plugins/babel-plugin-transform-amp-asserts/test/fixtures/transform-assertions/transform-dev-assert-string-not-string-non/output.js
@@ -13,6 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-(function () {
-  throw new Error('static type assertion failure');
-})();
+
+/** @type {string} */
+(null);

--- a/build-system/babel-plugins/babel-plugin-transform-amp-asserts/test/fixtures/transform-assertions/transform-devAssert-empty-string/output.js
+++ b/build-system/babel-plugins/babel-plugin-transform-amp-asserts/test/fixtures/transform-assertions/transform-devAssert-empty-string/output.js
@@ -13,6 +13,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-(function () {
-  throw new Error('static assertion failure');
-})();
+devAssert('');

--- a/build-system/babel-plugins/babel-plugin-transform-amp-asserts/test/fixtures/transform-assertions/transform-devAssert-false/output.js
+++ b/build-system/babel-plugins/babel-plugin-transform-amp-asserts/test/fixtures/transform-assertions/transform-devAssert-false/output.js
@@ -13,6 +13,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-(function () {
-  throw new Error('static assertion failure');
-})();
+devAssert(false);

--- a/build-system/babel-plugins/babel-plugin-transform-amp-asserts/test/fixtures/transform-assertions/transform-devAssert-null/output.js
+++ b/build-system/babel-plugins/babel-plugin-transform-amp-asserts/test/fixtures/transform-assertions/transform-devAssert-null/output.js
@@ -13,6 +13,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-(function () {
-  throw new Error('static assertion failure');
-})();
+devAssert(null);

--- a/build-system/babel-plugins/babel-plugin-transform-amp-asserts/test/fixtures/transform-assertions/transform-devAssert-zero/output.js
+++ b/build-system/babel-plugins/babel-plugin-transform-amp-asserts/test/fixtures/transform-assertions/transform-devAssert-zero/output.js
@@ -13,6 +13,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-(function () {
-  throw new Error('static assertion failure');
-})();
+devAssert(0);

--- a/build-system/babel-plugins/babel-plugin-transform-amp-asserts/test/fixtures/transform-assertions/transform-devAssert/output.js
+++ b/build-system/babel-plugins/babel-plugin-transform-amp-asserts/test/fixtures/transform-assertions/transform-devAssert/output.js
@@ -15,4 +15,4 @@
  */
 devAssert(1 + 1);
 devAssert(dev().assert(2 + 2));
-let result = devAssert(foo, 'hello', 'world');
+let result = devAssert(foo);

--- a/build-system/babel-plugins/babel-plugin-transform-amp-asserts/test/fixtures/transform-assertions/transform-user-fine/output.js
+++ b/build-system/babel-plugins/babel-plugin-transform-amp-asserts/test/fixtures/transform-assertions/transform-user-fine/output.js
@@ -13,6 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-(1);
-let result = (user());
+let result;
 let result2 = undefined;


### PR DESCRIPTION
This updates amp-asserts babel transform to match the code that AmpPass (which is being removed) generates.

Necessary for https://github.com/ampproject/amphtml/pull/24047