### PR TITLE
Update amp-asserts transform to match AmpPass's transformations

### DIFF
--- a/build-system/babel-plugins/babel-plugin-transform-amp-asserts/index.js
+++ b/build-system/babel-plugins/babel-plugin-transform-amp-asserts/index.js
@@ -36,7 +36,7 @@ const REMOVABLE = {
 };
 
 module.exports = function (babel) {
-  const {types: t, template} = babel;
+  const {types: t} = babel;
 
   /**
    * @param {!NodePath} path
@@ -70,13 +70,14 @@ module.exports = function (babel) {
 
     const arg = argument.node;
     if (assertion) {
-      const evaluation = argument.evaluate();
-
       // If we can statically evaluate the value to a falsey expression
+      // TODO(jridgewell): enable this later.
+      /*
+      const evaluation = argument.evaluate();
       if (evaluation.confident) {
         if (type) {
           if (typeof evaluation.value !== type) {
-            path.replaceWith(template.ast`
+            path.replaceWith(babel.template.ast`
               (function() {
                 throw new Error('static type assertion failure');
               }());
@@ -84,7 +85,7 @@ module.exports = function (babel) {
             return;
           }
         } else if (!evaluation.value) {
-          path.replaceWith(template.ast`
+          path.replaceWith(babel.template.ast`
             (function() {
               throw new Error('static assertion failure');
             }());
@@ -92,6 +93,7 @@ module.exports = function (babel) {
           return;
         }
       }
+      */
     }
 
     if (type) {
@@ -103,7 +105,7 @@ module.exports = function (babel) {
       // Add a cast annotation to fix type.
       path.addComment('leading', `* @type {${type}} `);
     } else if (!assertion) {
-      path.replaceWith(t.parenthesizedExpression(arg));
+      path.remove();
     }
   }
 
@@ -113,7 +115,12 @@ module.exports = function (babel) {
         const callee = path.get('callee');
 
         if (callee.isIdentifier({name: 'devAssert'})) {
-          return eliminate(path, '', /* assertion */ true);
+          const args = path.get('arguments');
+          // Remove all but the first argument.
+          for (let i = args.length - 1; i >= 1; i--) {
+            args[i].remove();
+          }
+          return;
         }
 
         const isMemberAndCallExpression =

--- a/build-system/babel-plugins/babel-plugin-transform-amp-asserts/test/fixtures/transform-assertions/transform-dev-assert-boolean-non/output.js
+++ b/build-system/babel-plugins/babel-plugin-transform-amp-asserts/test/fixtures/transform-assertions/transform-dev-assert-boolean-non/output.js
@@ -13,6 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-(function () {
-  throw new Error('static type assertion failure');
-})();
+
+/** @type {boolean} */
+(null);

--- a/build-system/babel-plugins/babel-plugin-transform-amp-asserts/test/fixtures/transform-assertions/transform-dev-assert-number-non/output.js
+++ b/build-system/babel-plugins/babel-plugin-transform-amp-asserts/test/fixtures/transform-assertions/transform-dev-assert-number-non/output.js
@@ -13,6 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-(function () {
-  throw new Error('static type assertion failure');
-})();
+
+/** @type {number} */
+(null);

--- a/build-system/babel-plugins/babel-plugin-transform-amp-asserts/test/fixtures/transform-assertions/transform-dev-assert-string-not-string-non/output.js
+++ b/build-system/babel-plugins/babel-plugin-transform-amp-asserts/test/fixtures/transform-assertions/transform-dev-assert-string-not-string-non/output.js
@@ -13,6 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-(function () {
-  throw new Error('static type assertion failure');
-})();
+
+/** @type {string} */
+(null);

--- a/build-system/babel-plugins/babel-plugin-transform-amp-asserts/test/fixtures/transform-assertions/transform-devAssert-empty-string/output.js
+++ b/build-system/babel-plugins/babel-plugin-transform-amp-asserts/test/fixtures/transform-assertions/transform-devAssert-empty-string/output.js
@@ -13,6 +13,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-(function () {
-  throw new Error('static assertion failure');
-})();
+devAssert('');

--- a/build-system/babel-plugins/babel-plugin-transform-amp-asserts/test/fixtures/transform-assertions/transform-devAssert-false/output.js
+++ b/build-system/babel-plugins/babel-plugin-transform-amp-asserts/test/fixtures/transform-assertions/transform-devAssert-false/output.js
@@ -13,6 +13,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-(function () {
-  throw new Error('static assertion failure');
-})();
+devAssert(false);

--- a/build-system/babel-plugins/babel-plugin-transform-amp-asserts/test/fixtures/transform-assertions/transform-devAssert-null/output.js
+++ b/build-system/babel-plugins/babel-plugin-transform-amp-asserts/test/fixtures/transform-assertions/transform-devAssert-null/output.js
@@ -13,6 +13,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-(function () {
-  throw new Error('static assertion failure');
-})();
+devAssert(null);

--- a/build-system/babel-plugins/babel-plugin-transform-amp-asserts/test/fixtures/transform-assertions/transform-devAssert-zero/output.js
+++ b/build-system/babel-plugins/babel-plugin-transform-amp-asserts/test/fixtures/transform-assertions/transform-devAssert-zero/output.js
@@ -13,6 +13,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-(function () {
-  throw new Error('static assertion failure');
-})();
+devAssert(0);

--- a/build-system/babel-plugins/babel-plugin-transform-amp-asserts/test/fixtures/transform-assertions/transform-devAssert/output.js
+++ b/build-system/babel-plugins/babel-plugin-transform-amp-asserts/test/fixtures/transform-assertions/transform-devAssert/output.js
@@ -15,4 +15,4 @@
  */
 devAssert(1 + 1);
 devAssert(dev().assert(2 + 2));
-let result = devAssert(foo, 'hello', 'world');
+let result = devAssert(foo);

--- a/build-system/babel-plugins/babel-plugin-transform-amp-asserts/test/fixtures/transform-assertions/transform-user-fine/output.js
+++ b/build-system/babel-plugins/babel-plugin-transform-amp-asserts/test/fixtures/transform-assertions/transform-user-fine/output.js
@@ -13,6 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-(1);
-let result = (user());
+let result;
 let result2 = undefined;

--- a/src/layout.js
+++ b/src/layout.js
@@ -233,9 +233,8 @@ export function assertLengthOrPercent(length) {
  */
 export function getLengthUnits(length) {
   assertLength(length);
-  dev().assertString(length);
   const m = userAssert(
-    length.match(/[a-z]+/i),
+    /[a-z]+/i.exec(length),
     'Failed to read units from %s',
     length
   );


### PR DESCRIPTION
This updates amp-asserts babel transform to match the code that AmpPass (which is being removed) generates.

Necessary for #24047
Fixes #23960.