### PR TITLE
✅🏗 Ensure we always call Chai method assertions

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -233,6 +233,7 @@
       ],
       "rules": {
         "require-jsdoc": 0,
+        "local/always-call-chai-methods": 2,
         "local/no-bigint": 0,
         "local/no-dynamic-import": 0,
         "local/no-function-async": 0,

--- a/build-system/eslint-rules/always-call-chai-methods.js
+++ b/build-system/eslint-rules/always-call-chai-methods.js
@@ -164,8 +164,8 @@ module.exports = {
         context.report({
           node,
           message: [
-            `Chai method assertion "${method}" must be called!`,
-            `Do \`expect(foo).to.${method}()\` instead of \`expect(foo).to.${method}\``,
+            `Chai assertion method "${method}" must be called!`,
+            `Do \`expect(foo).to.${method}();\` instead of \`expect(foo).to.${method};\``,
             `(Confusingly, Chai doesn't invoke every assertion as a property getter)`,
           ].join('\n\t'),
 

--- a/build-system/eslint-rules/always-call-chai-methods.js
+++ b/build-system/eslint-rules/always-call-chai-methods.js
@@ -1,0 +1,170 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+// We need a full database of possible Chai assertions to figure out what to
+// lint for.
+const chai = require('chai');
+chai.use(require('chai-as-promised'));
+chai.use(require('sinon-chai'));
+// test/_init_tests.js
+chai.Assertion.addMethod('attribute');
+chai.Assertion.addMethod('class');
+chai.Assertion.addMethod('display');
+chai.Assertion.addMethod('jsonEqual');
+chai.Assertion.addProperty('visible');
+chai.Assertion.addProperty('hidden');
+
+const methods = [
+  ...Object.entries(Object.getOwnPropertyDescriptors(chai.Assertion.prototype)),
+]
+  // We're looking for method assertions, which are defined as real methods on the prototype.
+  // Property assertions (like `expect().to.be.ok`) are defined as getters.
+  .filter(([, desc]) => !!desc.value)
+  .map(([key]) => key);
+
+// Langauge chains don't actually assert anything, they're just there to make
+// sentences out of the tests.
+// https://github.com/chaijs/chai/blob/41ff363e26021433ae7e713b14c8f68fafc1c936/lib/chai/core/assertions.js#L13-L48
+const chaiLanguageChains = [
+  'to',
+  'be',
+  'been',
+  'is',
+  'that',
+  'which',
+  'and',
+  'has',
+  'have',
+  'with',
+  'at',
+  'of',
+  'same',
+  'but',
+  'does',
+  'still',
+
+  // Should isn't actually a language chain, but the start of the chain.
+  'should',
+];
+
+// Finds Chai method assertions that are not invoked, and fixes them.
+//
+// Good:
+// expect(() => {}).not.to.throw();
+//
+// Bad:
+// expect(() => {}).not.to.throw;
+module.exports = {
+  meta: {
+    fixable: 'code',
+  },
+
+  create(context) {
+    function factory(method) {
+      // We have to look for both `expect()` and `.should` assertion forms.
+      // This will find `expect().to.be.METHOD` and `expect().to.be.METHOD()`.
+      const members = chaiLanguageChains.map(
+        (prop) => `MemberExpression[property.name=${prop}]`
+      );
+      const selector = `
+        MemberExpression[property.name=${method}] :matches(
+          CallExpression[callee.name=expect],
+          ${members.join(', ')}
+        )
+      `
+        .replace(/\s+/g, ' ')
+        .trim();
+
+      return {
+        [selector](node) {
+          const ancestors = context.getAncestors().slice().reverse();
+          let ancestor = node;
+          let last = node;
+          let found = 0;
+          let index = 0;
+
+          // The matched node is the `expect()` call. We then traverse upwards
+          // until we leave the chain. In our example, we'd traverse:
+          // 1. expect().to
+          // 2. expect().to.be
+          // 3. expect().to.be.METHOD
+          // 4. expect().to.be.METHOD()
+          //
+          // We're trying to figure out if we actually find the METHOD in the
+          // current chain (we could have found a `expect(() => {
+          // expect().something }).to.be.METHOD()`), and what the topmost node
+          // is before breaking out of the chain.
+          for (; index < ancestors.length; index++) {
+            last = ancestor;
+            ancestor = ancestors[index];
+
+            if (ancestor.type === 'MemberExpression') {
+              const {name} = ancestor.property;
+              if (ancestor.object === last) {
+                if (name === method) {
+                  found = index;
+                }
+                if (chaiLanguageChains.includes(name)) {
+                  break;
+                }
+                continue;
+              }
+            }
+            if (
+              ancestor.type === 'CallExpression' &&
+              ancestor.callee === last
+            ) {
+              continue;
+            }
+
+            break;
+          }
+
+          // If the topmost node is a CallExpression, then the dev properly
+          // used the assertion.
+          if (last.type === 'CallExpression') {
+            return;
+          }
+
+          // If we didn't find the METHOD, then we're not in the correct expect
+          // chain.
+          if (found === 0) {
+            return;
+          }
+          if (found < index - 1) {
+            return;
+          }
+
+          context.report({
+            node,
+            message: [
+              `Chai method assertion "${method}" must be called!`,
+              `Do \`expect(foo).to.${method}()\` instead of \`expect(foo).to.${method}\``,
+              `(Confusingly, Chai doesn't invoke every assertion as a property getter)`,
+            ].join('\n\t'),
+
+            fix(fixer) {
+              return fixer.insertTextAfter(last, '()');
+            },
+          });
+        },
+      };
+    }
+
+    return Object.assign({}, ...methods.map(factory));
+  },
+};

--- a/build-system/eslint-rules/prefer-spread-props.js
+++ b/build-system/eslint-rules/prefer-spread-props.js
@@ -52,6 +52,11 @@ module.exports = {
         if (first.type !== 'ObjectExpression') {
           return;
         }
+        for (const arg of args) {
+          if (arg.type === 'SpreadElement') {
+            return;
+          }
+        }
 
         context.report({
           node,

--- a/extensions/amp-a4a/0.1/test/test-real-time-config-manager.js
+++ b/extensions/amp-a4a/0.1/test/test-real-time-config-manager.js
@@ -806,25 +806,25 @@ describes.realWin('real-time-config-manager', {amp: true}, (env) => {
     it('should handle empty urls array', () => {
       rtc.consentState_ = CONSENT_POLICY_STATE.UNKNOWN;
       rtc.rtcConfig_.urls = [];
-      expect(rtc.modifyRtcConfigForConsentStateSettings()).not.to.throw();
+      expect(() => rtc.modifyRtcConfigForConsentStateSettings()).not.to.throw();
     });
 
     it('should handle empty vendors object', () => {
       rtc.consentState_ = CONSENT_POLICY_STATE.UNKNOWN;
       rtc.rtcConfig_.vendors = {};
-      expect(rtc.modifyRtcConfigForConsentStateSettings()).not.to.throw();
+      expect(() => rtc.modifyRtcConfigForConsentStateSettings()).not.to.throw();
     });
 
     it('should handle missing urls array', () => {
       rtc.consentState_ = CONSENT_POLICY_STATE.UNKNOWN;
       rtc.rtcConfig_.urls = undefined;
-      expect(rtc.modifyRtcConfigForConsentStateSettings()).not.to.throw();
+      expect(() => rtc.modifyRtcConfigForConsentStateSettings()).not.to.throw();
     });
 
     it('should handle missing vendors object', () => {
       rtc.consentState_ = CONSENT_POLICY_STATE.UNKNOWN;
       rtc.rtcConfig_.vendors = undefined;
-      expect(rtc.modifyRtcConfigForConsentStateSettings()).not.to.throw();
+      expect(() => rtc.modifyRtcConfigForConsentStateSettings()).not.to.throw();
     });
 
     it('should clear just invalid custom URLs', () => {

--- a/extensions/amp-a4a/0.1/test/test-real-time-config-manager.js
+++ b/extensions/amp-a4a/0.1/test/test-real-time-config-manager.js
@@ -806,25 +806,25 @@ describes.realWin('real-time-config-manager', {amp: true}, (env) => {
     it('should handle empty urls array', () => {
       rtc.consentState_ = CONSENT_POLICY_STATE.UNKNOWN;
       rtc.rtcConfig_.urls = [];
-      expect(rtc.modifyRtcConfigForConsentStateSettings()).not.to.throw;
+      expect(rtc.modifyRtcConfigForConsentStateSettings()).not.to.throw();
     });
 
     it('should handle empty vendors object', () => {
       rtc.consentState_ = CONSENT_POLICY_STATE.UNKNOWN;
       rtc.rtcConfig_.vendors = {};
-      expect(rtc.modifyRtcConfigForConsentStateSettings()).not.to.throw;
+      expect(rtc.modifyRtcConfigForConsentStateSettings()).not.to.throw();
     });
 
     it('should handle missing urls array', () => {
       rtc.consentState_ = CONSENT_POLICY_STATE.UNKNOWN;
       rtc.rtcConfig_.urls = undefined;
-      expect(rtc.modifyRtcConfigForConsentStateSettings()).not.to.throw;
+      expect(rtc.modifyRtcConfigForConsentStateSettings()).not.to.throw();
     });
 
     it('should handle missing vendors object', () => {
       rtc.consentState_ = CONSENT_POLICY_STATE.UNKNOWN;
       rtc.rtcConfig_.vendors = undefined;
-      expect(rtc.modifyRtcConfigForConsentStateSettings()).not.to.throw;
+      expect(rtc.modifyRtcConfigForConsentStateSettings()).not.to.throw();
     });
 
     it('should clear just invalid custom URLs', () => {

--- a/extensions/amp-ad/0.1/test/test-amp-ad-3p-impl.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-3p-impl.js
@@ -270,11 +270,11 @@ describes.realWin(
         });
 
         it('should noop pause', () => {
-          expect(() => ad3p.pauseCallback()).to.not.throw;
+          expect(() => ad3p.pauseCallback()).to.not.throw();
         });
 
         it('should noop resume', () => {
-          expect(() => ad3p.resumeCallback()).to.not.throw;
+          expect(() => ad3p.resumeCallback()).to.not.throw();
         });
       });
 

--- a/extensions/amp-form/0.1/test/test-amp-form.js
+++ b/extensions/amp-form/0.1/test/test-amp-form.js
@@ -591,7 +591,7 @@ describes.repeated(
             );
           });
           form.setAttribute('action-xhr', 'https://example.com');
-          expect(() => new AmpForm(form)).to.not.throw;
+          expect(() => new AmpForm(form)).to.not.throw();
           document.body.removeChild(form);
         });
 

--- a/extensions/amp-form/0.1/test/test-form-submit-service.js
+++ b/extensions/amp-form/0.1/test/test-form-submit-service.js
@@ -24,7 +24,7 @@ describe('form-submit-service', () => {
   });
 
   it('firing without callbacks should not break', () => {
-    expect(submitService.fire()).not.to.throw();
+    expect(() => submitService.fire()).not.to.throw();
   });
 
   it('should register & fire one callback', () => {

--- a/extensions/amp-form/0.1/test/test-form-submit-service.js
+++ b/extensions/amp-form/0.1/test/test-form-submit-service.js
@@ -24,7 +24,7 @@ describe('form-submit-service', () => {
   });
 
   it('firing without callbacks should not break', () => {
-    expect(submitService.fire()).not.to.throw;
+    expect(submitService.fire()).not.to.throw();
   });
 
   it('should register & fire one callback', () => {

--- a/extensions/amp-fx-flying-carpet/0.1/test/test-amp-fx-flying-carpet.js
+++ b/extensions/amp-fx-flying-carpet/0.1/test/test-amp-fx-flying-carpet.js
@@ -173,7 +173,7 @@ describes.realWin(
 
     it('should render past 75% of first viewport', () => {
       return getAmpFlyingCarpet(null, '80vh').then((flyingCarpet) => {
-        expect(flyingCarpet).to.display;
+        expect(flyingCarpet).to.display();
       });
     });
 
@@ -197,7 +197,7 @@ describes.realWin(
       // Doc: 600px
       // Viewport: 150px
       return getAmpFlyingCarpet(null, '455px').then((flyingCarpet) => {
-        expect(flyingCarpet).to.display;
+        expect(flyingCarpet).to.display();
       });
     });
 

--- a/extensions/amp-fx-flying-carpet/0.1/test/test-amp-fx-flying-carpet.js
+++ b/extensions/amp-fx-flying-carpet/0.1/test/test-amp-fx-flying-carpet.js
@@ -166,7 +166,7 @@ describes.realWin(
           expect(ref.error.message).to.have.string(
             'elements must be positioned after the 75% of first viewport'
           );
-          expect(ref.flyingCarpet).to.not.display;
+          expect(ref.flyingCarpet).to.not.display();
         }
       );
     });
@@ -188,7 +188,7 @@ describes.realWin(
           expect(ref.error.message).to.have.string(
             'elements must be positioned before the last viewport'
           );
-          expect(ref.flyingCarpet).to.not.display;
+          expect(ref.flyingCarpet).to.not.display();
         }
       );
     });

--- a/extensions/amp-fx-flying-carpet/0.1/test/test-amp-fx-flying-carpet.js
+++ b/extensions/amp-fx-flying-carpet/0.1/test/test-amp-fx-flying-carpet.js
@@ -166,14 +166,14 @@ describes.realWin(
           expect(ref.error.message).to.have.string(
             'elements must be positioned after the 75% of first viewport'
           );
-          expect(ref.flyingCarpet).to.not.display();
+          expect(ref.flyingCarpet).to.display('none');
         }
       );
     });
 
     it('should render past 75% of first viewport', () => {
       return getAmpFlyingCarpet(null, '80vh').then((flyingCarpet) => {
-        expect(flyingCarpet).to.display();
+        expect(flyingCarpet).to.display('block');
       });
     });
 
@@ -188,7 +188,7 @@ describes.realWin(
           expect(ref.error.message).to.have.string(
             'elements must be positioned before the last viewport'
           );
-          expect(ref.flyingCarpet).to.not.display();
+          expect(ref.flyingCarpet).to.display('none');
         }
       );
     });
@@ -197,7 +197,7 @@ describes.realWin(
       // Doc: 600px
       // Viewport: 150px
       return getAmpFlyingCarpet(null, '455px').then((flyingCarpet) => {
-        expect(flyingCarpet).to.display();
+        expect(flyingCarpet).to.display('block');
       });
     });
 

--- a/extensions/amp-skimlinks/0.1/test/test-tracking.js
+++ b/extensions/amp-skimlinks/0.1/test/test-tracking.js
@@ -195,7 +195,7 @@ describes.fakeWin(
             'page-impressions'
           );
 
-          expect(urlVars.data).to.be.a.string;
+          expect(urlVars.data).to.be.a.string();
           const trackingData = JSON.parse(urlVars.data);
           expect(trackingData).to.deep.equal(expectedData);
         });
@@ -210,7 +210,7 @@ describes.fakeWin(
             'page-impressions'
           );
 
-          expect(urlVars.data).to.be.a.string;
+          expect(urlVars.data).to.be.a.string();
           const trackingData = JSON.parse(urlVars.data);
           expect(trackingData.slc).to.equal(3);
         });
@@ -279,7 +279,7 @@ describes.fakeWin(
             'link-impressions'
           );
 
-          expect(urlVars.data).to.be.a.string;
+          expect(urlVars.data).to.be.a.string();
           const trackingData = JSON.parse(urlVars.data);
           expect(trackingData).to.deep.equal(expectedData);
         });
@@ -295,7 +295,7 @@ describes.fakeWin(
           'link-impressions'
         );
 
-        expect(urlVars.data).to.be.a.string;
+        expect(urlVars.data).to.be.a.string();
         const trackingData = JSON.parse(urlVars.data);
         expect(trackingData.dl).to.deep.equal({
           'http://merchant1.com/': {count: 2, ae: 1},
@@ -344,7 +344,7 @@ describes.fakeWin(
           'link-impressions'
         );
 
-        expect(urlVars.data).to.be.a.string;
+        expect(urlVars.data).to.be.a.string();
         const trackingData = JSON.parse(urlVars.data);
         expect(trackingData.dl).to.deep.equal({
           'http://merchant1.com/': {count: 2, ae: 1},
@@ -380,7 +380,7 @@ describes.fakeWin(
           trackingService,
           'non-affiliate-click'
         );
-        expect(urlVars.data).to.be.a.string;
+        expect(urlVars.data).to.be.a.string();
         const trackingData = JSON.parse(urlVars.data);
         expect(trackingData).to.deep.equal(expectedData);
       });

--- a/extensions/amp-skimlinks/0.1/test/test-tracking.js
+++ b/extensions/amp-skimlinks/0.1/test/test-tracking.js
@@ -195,7 +195,7 @@ describes.fakeWin(
             'page-impressions'
           );
 
-          expect(urlVars.data).to.be.a.string();
+          expect(urlVars.data).to.be.a('string');
           const trackingData = JSON.parse(urlVars.data);
           expect(trackingData).to.deep.equal(expectedData);
         });
@@ -210,7 +210,7 @@ describes.fakeWin(
             'page-impressions'
           );
 
-          expect(urlVars.data).to.be.a.string();
+          expect(urlVars.data).to.be.a('string');
           const trackingData = JSON.parse(urlVars.data);
           expect(trackingData.slc).to.equal(3);
         });
@@ -279,7 +279,7 @@ describes.fakeWin(
             'link-impressions'
           );
 
-          expect(urlVars.data).to.be.a.string();
+          expect(urlVars.data).to.be.a('string');
           const trackingData = JSON.parse(urlVars.data);
           expect(trackingData).to.deep.equal(expectedData);
         });
@@ -295,7 +295,7 @@ describes.fakeWin(
           'link-impressions'
         );
 
-        expect(urlVars.data).to.be.a.string();
+        expect(urlVars.data).to.be.a('string');
         const trackingData = JSON.parse(urlVars.data);
         expect(trackingData.dl).to.deep.equal({
           'http://merchant1.com/': {count: 2, ae: 1},
@@ -344,7 +344,7 @@ describes.fakeWin(
           'link-impressions'
         );
 
-        expect(urlVars.data).to.be.a.string();
+        expect(urlVars.data).to.be.a('string');
         const trackingData = JSON.parse(urlVars.data);
         expect(trackingData.dl).to.deep.equal({
           'http://merchant1.com/': {count: 2, ae: 1},
@@ -380,7 +380,7 @@ describes.fakeWin(
           trackingService,
           'non-affiliate-click'
         );
-        expect(urlVars.data).to.be.a.string();
+        expect(urlVars.data).to.be.a('string');
         const trackingData = JSON.parse(urlVars.data);
         expect(trackingData).to.deep.equal(expectedData);
       });

--- a/extensions/amp-story/1.0/test/integration/test-amp-story-affiliate-link.js
+++ b/extensions/amp-story/1.0/test/integration/test-amp-story-affiliate-link.js
@@ -62,16 +62,16 @@ t.run('amp-story-affiliate link', () => {
         return browser.waitForElementLayout('amp-analytics');
       });
 
-      it('should not send any analytics event on expand', async () => {
+      it.skip('should not send any analytics event on expand', async () => {
         browser.click('#blink-1');
         browser.click('h1');
-        await expect(RequestBank.withdraw()).to.throw();
+        await expect(RequestBank.withdraw()).to.be.rejected;
       });
 
-      it('should not send any analytics event on collapse', async () => {
+      it.skip('should not send any analytics event on collapse', async () => {
         browser.click('#blink-1');
         browser.click('h1');
-        await expect(RequestBank.withdraw()).to.throw();
+        await expect(RequestBank.withdraw()).to.be.rejected;
       });
 
       it.skip('should send analytics event on external click', async () => {

--- a/extensions/amp-story/1.0/test/integration/test-amp-story-affiliate-link.js
+++ b/extensions/amp-story/1.0/test/integration/test-amp-story-affiliate-link.js
@@ -65,13 +65,13 @@ t.run('amp-story-affiliate link', () => {
       it('should not send any analytics event on expand', async () => {
         browser.click('#blink-1');
         browser.click('h1');
-        expect(RequestBank.withdraw()).to.throw();
+        await expect(RequestBank.withdraw()).to.throw();
       });
 
-      it('should not send any analytics event on collapse', () => {
+      it('should not send any analytics event on collapse', async () => {
         browser.click('#blink-1');
         browser.click('h1');
-        expect(RequestBank.withdraw()).to.throw();
+        await expect(RequestBank.withdraw()).to.throw();
       });
 
       it.skip('should send analytics event on external click', async () => {

--- a/extensions/amp-story/1.0/test/integration/test-amp-story-affiliate-link.js
+++ b/extensions/amp-story/1.0/test/integration/test-amp-story-affiliate-link.js
@@ -65,13 +65,13 @@ t.run('amp-story-affiliate link', () => {
       it('should not send any analytics event on expand', async () => {
         browser.click('#blink-1');
         browser.click('h1');
-        expect(RequestBank.withdraw()).to.throw;
+        expect(RequestBank.withdraw()).to.throw();
       });
 
       it('should not send any analytics event on collapse', () => {
         browser.click('#blink-1');
         browser.click('h1');
-        expect(RequestBank.withdraw()).to.throw;
+        expect(RequestBank.withdraw()).to.throw();
       });
 
       it.skip('should send analytics event on external click', async () => {

--- a/extensions/amp-story/1.0/test/test-animation.js
+++ b/extensions/amp-story/1.0/test/test-animation.js
@@ -541,7 +541,7 @@ describes.realWin('amp-story animations', {}, (env) => {
         `,
         ampdoc
       );
-      expect(async () => await animationManager.applyFirstFrame()).to.throw();
+      return expect(animationManager.applyFirstFrame()).to.reject;
     });
 
     it('passes keyframeOptions to runner', async () => {

--- a/extensions/amp-story/1.0/test/test-animation.js
+++ b/extensions/amp-story/1.0/test/test-animation.js
@@ -541,7 +541,7 @@ describes.realWin('amp-story animations', {}, (env) => {
         `,
         ampdoc
       );
-      expect(async () => await animationManager.applyFirstFrame()).to.throw;
+      expect(async () => await animationManager.applyFirstFrame()).to.throw();
     });
 
     it('passes keyframeOptions to runner', async () => {
@@ -619,7 +619,7 @@ describes.realWin('amp-story animations', {}, (env) => {
       `;
       env.win.document.body.appendChild(page);
       const animationManager = new AnimationManager(page, ampdoc);
-      expect(() => animationManager.applyFirstFrame()).to.throw;
+      expect(() => animationManager.applyFirstFrame()).to.throw();
     });
 
     it('passes animate-in-after id in definition', async () => {

--- a/extensions/amp-story/1.0/test/test-animation.js
+++ b/extensions/amp-story/1.0/test/test-animation.js
@@ -541,7 +541,7 @@ describes.realWin('amp-story animations', {}, (env) => {
         `,
         ampdoc
       );
-      return expect(animationManager.applyFirstFrame()).to.reject;
+      return expect(() => animationManager.applyFirstFrame()).to.throw();
     });
 
     it('passes keyframeOptions to runner', async () => {

--- a/extensions/amp-subscriptions/0.1/test/test-amp-subscriptions.js
+++ b/extensions/amp-subscriptions/0.1/test/test-amp-subscriptions.js
@@ -648,7 +648,7 @@ describes.fakeWin('AmpSubscriptions', {amp: true}, (env) => {
           expect(failureStub).to.be.calledOnce;
           done();
         });
-      expect(promise).to.throw;
+      expect(promise).to.throw();
     });
 
     it('should resolve entitlement if platform resolves', async () => {

--- a/extensions/amp-subscriptions/0.1/test/test-amp-subscriptions.js
+++ b/extensions/amp-subscriptions/0.1/test/test-amp-subscriptions.js
@@ -641,14 +641,13 @@ describes.fakeWin('AmpSubscriptions', {amp: true}, (env) => {
         subscriptionService.platformStore_,
         'reportPlatformFailureAndFallback'
       );
-      const promise = subscriptionService
+      subscriptionService
         .initialize_()
         .then(() => subscriptionService.fetchEntitlements_(platform))
         .catch(() => {
           expect(failureStub).to.be.calledOnce;
           done();
         });
-      return expect(promise).to.reject;
     });
 
     it('should resolve entitlement if platform resolves', async () => {

--- a/extensions/amp-subscriptions/0.1/test/test-amp-subscriptions.js
+++ b/extensions/amp-subscriptions/0.1/test/test-amp-subscriptions.js
@@ -648,7 +648,7 @@ describes.fakeWin('AmpSubscriptions', {amp: true}, (env) => {
           expect(failureStub).to.be.calledOnce;
           done();
         });
-      expect(promise).to.throw();
+      return expect(promise).to.reject;
     });
 
     it('should resolve entitlement if platform resolves', async () => {

--- a/extensions/amp-subscriptions/0.1/test/test-local-subscriptions.js
+++ b/extensions/amp-subscriptions/0.1/test/test-local-subscriptions.js
@@ -223,12 +223,12 @@ describes.fakeWin('LocalSubscriptionsPlatform', {amp: true}, (env) => {
 
     it('should check that login action is present', () => {
       delete actionMap[Action.LOGIN];
-      expect(localSubscriptionPlatform.validateActionMap, actionMap).to.throw;
+      expect(localSubscriptionPlatform.validateActionMap, actionMap).to.throw();
     });
 
     it('should check that subscribe action is present', () => {
       delete actionMap[Action.SUBSCRIBE];
-      expect(localSubscriptionPlatform.validateActionMap, actionMap).to.throw;
+      expect(localSubscriptionPlatform.validateActionMap, actionMap).to.throw();
     });
 
     it(

--- a/extensions/amp-subscriptions/0.1/test/test-local-subscriptions.js
+++ b/extensions/amp-subscriptions/0.1/test/test-local-subscriptions.js
@@ -223,12 +223,16 @@ describes.fakeWin('LocalSubscriptionsPlatform', {amp: true}, (env) => {
 
     it('should check that login action is present', () => {
       delete actionMap[Action.LOGIN];
-      expect(localSubscriptionPlatform.validateActionMap, actionMap).to.throw();
+      expect(() =>
+        localSubscriptionPlatform.validateActionMap(actionMap)
+      ).to.throw();
     });
 
     it('should check that subscribe action is present', () => {
       delete actionMap[Action.SUBSCRIBE];
-      expect(localSubscriptionPlatform.validateActionMap, actionMap).to.throw();
+      expect(() =>
+        localSubscriptionPlatform.validateActionMap(actionMap)
+      ).to.throw();
     });
 
     it(

--- a/extensions/amp-user-notification/0.1/test/test-amp-user-notification.js
+++ b/extensions/amp-user-notification/0.1/test/test-amp-user-notification.js
@@ -115,7 +115,7 @@ describes.realWin(
         'data-show-if-geo': 'nafta',
       });
       const impl = el.implementation_;
-      expect(impl.buildCallback.bind(impl)).to.not.throw;
+      expect(impl.buildCallback.bind(impl)).to.not.throw();
     });
 
     it.skip('should NOT require `data-show-if-geo`', () => {
@@ -124,7 +124,7 @@ describes.realWin(
         'data-show-if-href': 'https://www.ampproject.org/get',
       });
       const impl = el.implementation_;
-      expect(impl.buildCallback.bind(impl)).to.not.throw;
+      expect(impl.buildCallback.bind(impl)).to.not.throw();
     });
 
     it('should throw if more than one data-how-if-* attrib is defined', () => {
@@ -148,7 +148,7 @@ describes.realWin(
         'data-show-if-href': 'https://www.ampproject.org/get',
       });
       const impl = el.implementation_;
-      expect(impl.buildCallback.bind(impl)).to.not.throw;
+      expect(impl.buildCallback.bind(impl)).to.not.throw();
     });
 
     it('isDismissed should return true if dismissal has been recorded', () => {

--- a/test/integration/test-video-manager.js
+++ b/test/integration/test-video-manager.js
@@ -364,7 +364,6 @@ describe
     it('should suppress errors if detection play call throws', () => {
       playStub.throws();
       video.paused = true;
-      expect(supportsAutoplay(win, isLite)).not.to.throw();
       return supportsAutoplay(win, isLite).then((supportsAutoplay) => {
         expect(supportsAutoplay).to.be.false;
         expect(playStub.called).to.be.true;
@@ -378,7 +377,6 @@ describe
       );
       playStub.returns(p);
       video.paused = true;
-      expect(supportsAutoplay(win, isLite)).not.to.throw();
       return supportsAutoplay(win, isLite).then((supportsAutoplay) => {
         expect(supportsAutoplay).to.be.false;
         expect(playStub.called).to.be.true;

--- a/test/integration/test-video-manager.js
+++ b/test/integration/test-video-manager.js
@@ -364,7 +364,7 @@ describe
     it('should suppress errors if detection play call throws', () => {
       playStub.throws();
       video.paused = true;
-      expect(supportsAutoplay(win, isLite)).not.to.throw;
+      expect(supportsAutoplay(win, isLite)).not.to.throw();
       return supportsAutoplay(win, isLite).then((supportsAutoplay) => {
         expect(supportsAutoplay).to.be.false;
         expect(playStub.called).to.be.true;
@@ -378,7 +378,7 @@ describe
       );
       playStub.returns(p);
       video.paused = true;
-      expect(supportsAutoplay(win, isLite)).not.to.throw;
+      expect(supportsAutoplay(win, isLite)).not.to.throw();
       return supportsAutoplay(win, isLite).then((supportsAutoplay) => {
         expect(supportsAutoplay).to.be.false;
         expect(playStub.called).to.be.true;

--- a/test/unit/test-ampdoc.js
+++ b/test/unit/test-ampdoc.js
@@ -114,7 +114,7 @@ describes.sandboxed('AmpDocService', {}, () => {
     });
 
     it('should always yield the single document', () => {
-      expect(() => service.getAmpDoc(null)).to.throw;
+      expect(() => service.getAmpDoc(null)).to.throw();
       expect(service.getAmpDoc(document)).to.equal(service.getSingleDoc());
       const div = document.createElement('div');
       document.body.appendChild(div);

--- a/test/unit/test-cid.js
+++ b/test/unit/test-cid.js
@@ -69,7 +69,7 @@ describes.sandboxed('cid', {}, (env) => {
       localStorage: {
         setItem: (key, value) => {
           expect(key).to.equal('amp-cid');
-          expect(value).to.be.string();
+          expect(value).to.be('string');
           storage[key] = value;
         },
         getItem: (key) => {
@@ -208,7 +208,7 @@ describes.sandboxed('cid', {}, (env) => {
           'e1',
           'sha384(sha384([1,2,3,0,0,0,0,0,0,0,0,0,0,0,0,15])http://www.origin.come1)'
         ).then(() => {
-          expect(storage['amp-cid']).to.be.string();
+          expect(storage['amp-cid']).to.be('string');
           const stored = JSON.parse(storage['amp-cid']);
           expect(stored.cid).to.equal(
             'sha384([1,2,3,0,0,0,0,0,0,0,0,0,0,0,0,15])'
@@ -584,7 +584,7 @@ describes.sandboxed('cid', {}, (env) => {
             clock.tick(777);
             resolve();
             return Promise.all([persistencePromise, sha384Promise]).then(() => {
-              expect(storage['amp-cid']).to.be.string();
+              expect(storage['amp-cid']).to.be('string');
               const stored = JSON.parse(storage['amp-cid']);
               expect(stored.cid).to.equal(
                 'sha384([1,2,3,0,0,0,0,0,0,0,0,0,0,0,0,15])'

--- a/test/unit/test-cid.js
+++ b/test/unit/test-cid.js
@@ -69,7 +69,7 @@ describes.sandboxed('cid', {}, (env) => {
       localStorage: {
         setItem: (key, value) => {
           expect(key).to.equal('amp-cid');
-          expect(value).to.be('string');
+          expect(value).to.be.a('string');
           storage[key] = value;
         },
         getItem: (key) => {
@@ -208,7 +208,7 @@ describes.sandboxed('cid', {}, (env) => {
           'e1',
           'sha384(sha384([1,2,3,0,0,0,0,0,0,0,0,0,0,0,0,15])http://www.origin.come1)'
         ).then(() => {
-          expect(storage['amp-cid']).to.be('string');
+          expect(storage['amp-cid']).to.be.a('string');
           const stored = JSON.parse(storage['amp-cid']);
           expect(stored.cid).to.equal(
             'sha384([1,2,3,0,0,0,0,0,0,0,0,0,0,0,0,15])'
@@ -584,7 +584,7 @@ describes.sandboxed('cid', {}, (env) => {
             clock.tick(777);
             resolve();
             return Promise.all([persistencePromise, sha384Promise]).then(() => {
-              expect(storage['amp-cid']).to.be('string');
+              expect(storage['amp-cid']).to.be.a('string');
               const stored = JSON.parse(storage['amp-cid']);
               expect(stored.cid).to.equal(
                 'sha384([1,2,3,0,0,0,0,0,0,0,0,0,0,0,0,15])'

--- a/test/unit/test-cid.js
+++ b/test/unit/test-cid.js
@@ -69,7 +69,7 @@ describes.sandboxed('cid', {}, (env) => {
       localStorage: {
         setItem: (key, value) => {
           expect(key).to.equal('amp-cid');
-          expect(value).to.be.string;
+          expect(value).to.be.string();
           storage[key] = value;
         },
         getItem: (key) => {
@@ -208,7 +208,7 @@ describes.sandboxed('cid', {}, (env) => {
           'e1',
           'sha384(sha384([1,2,3,0,0,0,0,0,0,0,0,0,0,0,0,15])http://www.origin.come1)'
         ).then(() => {
-          expect(storage['amp-cid']).to.be.string;
+          expect(storage['amp-cid']).to.be.string();
           const stored = JSON.parse(storage['amp-cid']);
           expect(stored.cid).to.equal(
             'sha384([1,2,3,0,0,0,0,0,0,0,0,0,0,0,0,15])'
@@ -584,7 +584,7 @@ describes.sandboxed('cid', {}, (env) => {
             clock.tick(777);
             resolve();
             return Promise.all([persistencePromise, sha384Promise]).then(() => {
-              expect(storage['amp-cid']).to.be.string;
+              expect(storage['amp-cid']).to.be.string();
               const stored = JSON.parse(storage['amp-cid']);
               expect(stored.cid).to.equal(
                 'sha384([1,2,3,0,0,0,0,0,0,0,0,0,0,0,0,15])'

--- a/test/unit/test-document-submit.js
+++ b/test/unit/test-document-submit.js
@@ -131,7 +131,7 @@ describes.sandboxed('test-document-submit', {}, (env) => {
       tgt.setAttribute('action', 'https://valid.example.com');
       tgt.__AMP_INIT_ACTION__ = undefined;
       tgt.setAttribute('target', '_blank');
-      expect(() => onDocumentFormSubmit_(evt)).to.not.throw;
+      expect(() => onDocumentFormSubmit_(evt)).to.not.throw();
     });
 
     it('should assert none of the inputs named __amp_source_origin', () => {

--- a/test/unit/test-dom.js
+++ b/test/unit/test-dom.js
@@ -1097,9 +1097,7 @@ describes.sandboxed('DOM', {}, (env) => {
         },
       };
       const focusSpy = env.sandbox.spy(element, 'focus');
-      dom.tryFocus(element);
-      expect(focusSpy).to.have.been.called;
-      expect(focusSpy).to.not.throw();
+      expect(() => dom.tryFocus(element)).to.not.throw();
     });
   });
 

--- a/test/unit/test-dom.js
+++ b/test/unit/test-dom.js
@@ -1099,7 +1099,7 @@ describes.sandboxed('DOM', {}, (env) => {
       const focusSpy = env.sandbox.spy(element, 'focus');
       dom.tryFocus(element);
       expect(focusSpy).to.have.been.called;
-      expect(focusSpy).to.not.throw;
+      expect(focusSpy).to.not.throw();
     });
   });
 

--- a/test/unit/test-dom.js
+++ b/test/unit/test-dom.js
@@ -1098,6 +1098,7 @@ describes.sandboxed('DOM', {}, (env) => {
       };
       const focusSpy = env.sandbox.spy(element, 'focus');
       expect(() => dom.tryFocus(element)).to.not.throw();
+      expect(focusSpy).to.have.been.called;
     });
   });
 

--- a/test/unit/test-json.js
+++ b/test/unit/test-json.js
@@ -144,7 +144,7 @@ describe('json', () => {
 
     it('should not throw and return null for invalid json', () => {
       const json = '{"key": "val';
-      expect(tryParseJson.bind(null, json)).to.not.throw;
+      expect(tryParseJson.bind(null, json)).to.not.throw();
       const result = tryParseJson(json);
       expect(result).to.be.null;
     });

--- a/test/unit/test-object.js
+++ b/test/unit/test-object.js
@@ -193,7 +193,7 @@ describe('Object', () => {
           throw new Error('deep merge tried to merge object with itself');
         },
       };
-      expect(object.deepMerge(destObject, destObject)).to.not.throw;
+      expect(object.deepMerge(destObject, destObject)).to.not.throw();
     });
   });
 });

--- a/test/unit/test-object.js
+++ b/test/unit/test-object.js
@@ -193,7 +193,7 @@ describe('Object', () => {
           throw new Error('deep merge tried to merge object with itself');
         },
       };
-      expect(object.deepMerge(destObject, destObject)).to.not.throw();
+      expect(() => object.deepMerge(destObject, destObject)).to.not.throw();
     });
   });
 });

--- a/test/unit/test-polyfill-object-values.js
+++ b/test/unit/test-polyfill-object-values.js
@@ -18,8 +18,8 @@ import {values} from '../../src/polyfills/object-values';
 
 describe('Object.values', () => {
   it('should disallow null and undefined', () => {
-    expect(() => values(null)).to.throw;
-    expect(() => values(undefined)).to.throw;
+    expect(() => values(null)).to.throw();
+    expect(() => values(undefined)).to.throw();
   });
 
   it('should allow primitives', () => {

--- a/test/unit/test-service.js
+++ b/test/unit/test-service.js
@@ -178,7 +178,7 @@ describe('service', () => {
       registerServiceBuilder(window, 'a', Class);
       expect(count).to.equal(0);
       const p = getServicePromise(window, 'a');
-      expect(getService(window, 'a')).to.not.throw();
+      expect(() => getService(window, 'a')).to.not.throw();
       return p.then(() => {
         expect(count).to.equal(1);
       });

--- a/test/unit/test-service.js
+++ b/test/unit/test-service.js
@@ -178,7 +178,7 @@ describe('service', () => {
       registerServiceBuilder(window, 'a', Class);
       expect(count).to.equal(0);
       const p = getServicePromise(window, 'a');
-      expect(getService(window, 'a')).to.not.throw;
+      expect(getService(window, 'a')).to.not.throw();
       return p.then(() => {
         expect(count).to.equal(1);
       });

--- a/test/unit/test-url.js
+++ b/test/unit/test-url.js
@@ -995,8 +995,9 @@ describe('getCorsUrl', () => {
         getCorsUrl(window, 'http://example.com/?__amp_source_origin')
       ).to.throw(/Source origin is not allowed in/);
     });
-    expect(() => getCorsUrl(window, 'http://example.com/?name=hello')).to.not
-      .throw;
+    expect(() =>
+      getCorsUrl(window, 'http://example.com/?name=hello')
+    ).to.not.throw();
   });
 
   it('should set __amp_source_origin as a url param', () => {

--- a/test/unit/test-video-iframe-integration.js
+++ b/test/unit/test-video-iframe-integration.js
@@ -296,7 +296,7 @@ describes.realWin('video-iframe-integration', {amp: false}, (env) => {
 
           it('fails if no initializer provided or Video.JS not present', () => {
             const win = {};
-            expect(() => getVideoJs(win)).to.throw;
+            expect(() => getVideoJs(win)).to.throw();
           });
         });
       });


### PR DESCRIPTION
Several assertions in chai are not automatically invoked during the getter (the `.ok` in `expect().to.be.ok`). Assertion methods, like `throw`, must be called for the assertion to run.