### PR TITLE
🏗 Allow spaces between commas in files globs

### DIFF
--- a/build-system/common/utils.js
+++ b/build-system/common/utils.js
@@ -80,6 +80,17 @@ function logFiles(files) {
 }
 
 /**
+ * Extracts the list of files from argv.files.
+ *
+ * @return {Array<string>}
+ */
+function getFilesFromArgv() {
+  return argv.files
+    ? globby.sync(argv.files.split(',').map((s) => s.trim()))
+    : [];
+}
+
+/**
  * Gets a list of files to be checked based on command line args and the given
  * file matching globs. Used by tasks like prettify, check-links, etc.
  *
@@ -89,7 +100,7 @@ function logFiles(files) {
  */
 function getFilesToCheck(globs, options = {}) {
   if (argv.files) {
-    return logFiles(globby.sync(argv.files.split(',').map((s) => s.trim())));
+    return logFiles(getFilesFromArgv());
   }
   if (argv.local_changes) {
     const filesChanged = getFilesChanged(globs);
@@ -148,6 +159,7 @@ function installPackages(dir) {
 module.exports = {
   buildMinifiedRuntime,
   getFilesChanged,
+  getFilesFromArgv,
   getFilesToCheck,
   installPackages,
   logOnSameLine,

--- a/build-system/common/utils.js
+++ b/build-system/common/utils.js
@@ -89,7 +89,7 @@ function logFiles(files) {
  */
 function getFilesToCheck(globs, options = {}) {
   if (argv.files) {
-    return logFiles(globby.sync(argv.files.split(',')));
+    return logFiles(globby.sync(argv.files.split(',').map((s) => s.trim())));
   }
   if (argv.local_changes) {
     const filesChanged = getFilesChanged(globs);

--- a/build-system/common/utils.js
+++ b/build-system/common/utils.js
@@ -85,9 +85,7 @@ function logFiles(files) {
  * @return {Array<string>}
  */
 function getFilesFromArgv() {
-  return argv.files
-    ? globby.sync(argv.files.split(',').map((s) => s.trim()))
-    : [];
+  return argv.files ? globby.sync(argv.files.split(/\s*,\s*/)) : [];
 }
 
 /**

--- a/build-system/common/utils.js
+++ b/build-system/common/utils.js
@@ -85,7 +85,9 @@ function logFiles(files) {
  * @return {Array<string>}
  */
 function getFilesFromArgv() {
-  return argv.files ? globby.sync(argv.files.split(/\s*,\s*/)) : [];
+  return argv.files
+    ? globby.sync(argv.files.split(',').map((s) => s.trim()))
+    : [];
 }
 
 /**

--- a/build-system/tasks/e2e/index.js
+++ b/build-system/tasks/e2e/index.js
@@ -23,7 +23,11 @@ const glob = require('glob');
 const log = require('fancy-log');
 const Mocha = require('mocha');
 const path = require('path');
-const {buildMinifiedRuntime, installPackages} = require('../../common/utils');
+const {
+  buildMinifiedRuntime,
+  getFilesFromArgv,
+  installPackages,
+} = require('../../common/utils');
 const {cyan} = require('ansi-colors');
 const {isTravisBuild} = require('../../common/travis');
 const {reportTestStarted} = require('../report-test-status');
@@ -93,8 +97,7 @@ async function e2e() {
 
     // specify tests to run
     if (argv.files) {
-      // TODO: Should this allow multiple globs?
-      glob.sync(argv.files).forEach((file) => {
+      getFilesFromArgv().forEach((file) => {
         delete require.cache[file];
         mocha.addFile(file);
       });
@@ -117,8 +120,9 @@ async function e2e() {
       await resolver();
     });
   } else {
-    // TODO: Should this allow multiple globs?
-    const filesToWatch = argv.files ? [argv.files] : [config.e2eTestPaths];
+    const filesToWatch = argv.files
+      ? getFilesFromArgv()
+      : [config.e2eTestPaths];
     const watcher = watch(filesToWatch);
     log('Watching', cyan(filesToWatch), 'for changes...');
     watcher.on('change', (file) => {

--- a/build-system/tasks/e2e/index.js
+++ b/build-system/tasks/e2e/index.js
@@ -93,6 +93,7 @@ async function e2e() {
 
     // specify tests to run
     if (argv.files) {
+      // TODO: Should this allow multiple globs?
       glob.sync(argv.files).forEach((file) => {
         delete require.cache[file];
         mocha.addFile(file);
@@ -116,6 +117,7 @@ async function e2e() {
       await resolver();
     });
   } else {
+    // TODO: Should this allow multiple globs?
     const filesToWatch = argv.files ? [argv.files] : [config.e2eTestPaths];
     const watcher = watch(filesToWatch);
     log('Watching', cyan(filesToWatch), 'for changes...');

--- a/build-system/tasks/lint.js
+++ b/build-system/tasks/lint.js
@@ -27,7 +27,11 @@ const lazypipe = require('lazypipe');
 const log = require('fancy-log');
 const path = require('path');
 const watch = require('gulp-watch');
-const {getFilesChanged, logOnSameLine} = require('../common/utils');
+const {
+  getFilesChanged,
+  getFilesFromArgv,
+  logOnSameLine,
+} = require('../common/utils');
 const {gitDiffNameOnlyMaster} = require('../common/git');
 const {isTravisBuild} = require('../common/travis');
 const {maybeUpdatePackages} = require('./update-packages');
@@ -189,7 +193,7 @@ function lint() {
   maybeUpdatePackages();
   let filesToLint = config.lintGlobs;
   if (argv.files) {
-    filesToLint = getFilesToLint(argv.files.split(',').map((s) => s.trim()));
+    filesToLint = getFilesToLint(getFilesFromArgv());
   } else if (!eslintRulesChanged() && argv.local_changes) {
     const lintableFiles = getFilesChanged(config.lintGlobs);
     if (lintableFiles.length == 0) {

--- a/build-system/tasks/lint.js
+++ b/build-system/tasks/lint.js
@@ -189,7 +189,7 @@ function lint() {
   maybeUpdatePackages();
   let filesToLint = config.lintGlobs;
   if (argv.files) {
-    filesToLint = getFilesToLint(argv.files.split(','));
+    filesToLint = getFilesToLint(argv.files.split(',').map((s) => s.trim()));
   } else if (!eslintRulesChanged() && argv.local_changes) {
     const lintableFiles = getFilesChanged(config.lintGlobs);
     if (lintableFiles.length == 0) {

--- a/build-system/tasks/runtime-test/runtime-test-base.js
+++ b/build-system/tasks/runtime-test/runtime-test-base.js
@@ -129,6 +129,7 @@ function getFiles(testType) {
     case 'unit':
       files = testConfig.commonUnitTestPaths;
       if (argv.files) {
+        // TODO: Should this allow multiple globs?
         return files.concat(argv.files);
       }
       if (argv.saucelabs) {
@@ -142,6 +143,7 @@ function getFiles(testType) {
     case 'integration':
       files = testConfig.commonIntegrationTestPaths;
       if (argv.files) {
+        // TODO: Should this allow multiple globs?
         return files.concat(argv.files);
       }
       return files.concat(testConfig.integrationTestPaths);

--- a/build-system/tasks/runtime-test/runtime-test-base.js
+++ b/build-system/tasks/runtime-test/runtime-test-base.js
@@ -30,6 +30,7 @@ const {
   runTestInSauceLabs,
 } = require('./helpers');
 const {app} = require('../../server/test-server');
+const {getFilesFromArgv} = require('../../common/utils');
 const {green, yellow, cyan, red} = require('ansi-colors');
 const {isTravisBuild} = require('../../common/travis');
 const {reportTestStarted} = require('.././report-test-status');
@@ -129,8 +130,7 @@ function getFiles(testType) {
     case 'unit':
       files = testConfig.commonUnitTestPaths;
       if (argv.files) {
-        // TODO: Should this allow multiple globs?
-        return files.concat(argv.files);
+        return files.concat(getFilesFromArgv());
       }
       if (argv.saucelabs) {
         return files.concat(testConfig.unitTestOnSaucePaths);
@@ -143,8 +143,7 @@ function getFiles(testType) {
     case 'integration':
       files = testConfig.commonIntegrationTestPaths;
       if (argv.files) {
-        // TODO: Should this allow multiple globs?
-        return files.concat(argv.files);
+        return files.concat(getFilesFromArgv());
       }
       return files.concat(testConfig.integrationTestPaths);
 


### PR DESCRIPTION
I tried passing `'**/test/**/*.js, **/test-e2e/**/*.js'` to the linter, but the space after the comma caused the second glob to not match anything.