### PR TITLE
Resources: wait until amp init before sending documentHeight

### DIFF
--- a/build-system/tasks/e2e/describes-e2e.js
+++ b/build-system/tasks/e2e/describes-e2e.js
@@ -510,6 +510,16 @@ class EndToEndFixture {
 
     try {
       await setUpTest(env, this.spec);
+      if (env.environment === AmpdocEnvironment.VIEWER_DEMO) {
+        env.receivedMessages = await controller.evaluate(() => {
+          // The viewer.html file will launch 7 test viewers, only one of which is the requested url.
+          // TODO(gh/amphtml/28200): only load the one viewer.
+          const viewer = window.parent.allViewers.find((v) =>
+            v.url.includes('document-height')
+          );
+          return viewer.receivedMessages;
+        });
+      }
     } catch (ex) {
       if (retries > 0) {
         await this.setup(env, browserName, --retries);

--- a/build-system/tasks/e2e/describes-e2e.js
+++ b/build-system/tasks/e2e/describes-e2e.js
@@ -515,7 +515,7 @@ class EndToEndFixture {
           // The viewer.html file will launch 7 test viewers, only one of which is the requested url.
           // TODO(gh/amphtml/28200): only load the one viewer.
           const viewer = window.parent.allViewers.find((v) =>
-            v.url.includes('document-height')
+            v.id.includes('container-dynamic')
           );
           return viewer.receivedMessages;
         });

--- a/build-system/tasks/e2e/describes-e2e.js
+++ b/build-system/tasks/e2e/describes-e2e.js
@@ -510,23 +510,23 @@ class EndToEndFixture {
 
     try {
       await setUpTest(env, this.spec);
+      // Set env props that require the fixture to be set up.
+      if (env.environment === AmpdocEnvironment.VIEWER_DEMO) {
+        env.receivedMessages = await controller.evaluate(() => {
+          // The viewer.html file will launch 7 test viewers, only one of which is the requested url.
+          // TODO(gh/amphtml/28200): only load the one viewer.
+          const viewer = window.parent.allViewers.find((v) =>
+            v.id.includes('dynamic')
+          );
+          return viewer.receivedMessages;
+        });
+      }
     } catch (ex) {
       if (retries > 0) {
         await this.setup(env, browserName, --retries);
       } else {
         throw ex;
       }
-    }
-    // Set env props that require the fixture to be set up.
-    if (env.environment === AmpdocEnvironment.VIEWER_DEMO) {
-      env.receivedMessages = await controller.evaluate(() => {
-        // The viewer.html file will launch 7 test viewers, only one of which is the requested url.
-        // TODO(gh/amphtml/28200): only load the one viewer.
-        const viewer = window.parent.allViewers.find((v) =>
-          v.id.includes('dynamic')
-        );
-        return viewer.receivedMessages;
-      });
     }
   }
 

--- a/build-system/tasks/e2e/describes-e2e.js
+++ b/build-system/tasks/e2e/describes-e2e.js
@@ -513,7 +513,7 @@ class EndToEndFixture {
       // Set env props that require the fixture to be set up.
       if (env.environment === AmpdocEnvironment.VIEWER_DEMO) {
         env.receivedMessages = await controller.evaluate(() => {
-          // The viewer.html file will launch 7 test viewers, only one of which is the requested url.
+          // The viewer.html file will launch 10 test viewers, only one of which is the requested url.
           // TODO(gh/amphtml/28200): only load the one viewer.
           const viewer = window.parent.allViewers.find((v) =>
             v.id.includes('dynamic')

--- a/build-system/tasks/e2e/describes-e2e.js
+++ b/build-system/tasks/e2e/describes-e2e.js
@@ -510,22 +510,23 @@ class EndToEndFixture {
 
     try {
       await setUpTest(env, this.spec);
-      if (env.environment === AmpdocEnvironment.VIEWER_DEMO) {
-        env.receivedMessages = await controller.evaluate(() => {
-          // The viewer.html file will launch 7 test viewers, only one of which is the requested url.
-          // TODO(gh/amphtml/28200): only load the one viewer.
-          const viewer = window.parent.allViewers.find((v) =>
-            v.id.includes('dynamic')
-          );
-          return viewer.receivedMessages;
-        });
-      }
     } catch (ex) {
       if (retries > 0) {
         await this.setup(env, browserName, --retries);
       } else {
         throw ex;
       }
+    }
+    // Set env props that require the fixture to be set up.
+    if (env.environment === AmpdocEnvironment.VIEWER_DEMO) {
+      env.receivedMessages = await controller.evaluate(() => {
+        // The viewer.html file will launch 7 test viewers, only one of which is the requested url.
+        // TODO(gh/amphtml/28200): only load the one viewer.
+        const viewer = window.parent.allViewers.find((v) =>
+          v.id.includes('dynamic')
+        );
+        return viewer.receivedMessages;
+      });
     }
   }
 

--- a/build-system/tasks/e2e/describes-e2e.js
+++ b/build-system/tasks/e2e/describes-e2e.js
@@ -515,7 +515,7 @@ class EndToEndFixture {
           // The viewer.html file will launch 7 test viewers, only one of which is the requested url.
           // TODO(gh/amphtml/28200): only load the one viewer.
           const viewer = window.parent.allViewers.find((v) =>
-            v.id.includes('container-dynamic')
+            v.id.includes('dynamic')
           );
           return viewer.receivedMessages;
         });

--- a/examples/viewer.html
+++ b/examples/viewer.html
@@ -230,6 +230,7 @@
       this.startResolve_ = null;
       this.startPromise_ = null;
       this.caps_ = opt_caps || 'a2a,focus-rect,foo,keyboard,swipe,viewerRenderTemplate,iframeScroll';
+      this.receivedMessages = []
 
       this.viewer = document.querySelector('viewer');
       this.header = document.querySelector('header');
@@ -248,7 +249,7 @@
         if (activeId == this.id) {
           this.toggleVisibility(this.visibilityState_ != 'visible', true);
         }
-      }.bind(this));
+      }.bind(this)); 
 
       window.addEventListener('resize', this.onResize_.bind(this));
       window.addEventListener('popstate', this.onPopState_.bind(this));
@@ -436,6 +437,7 @@
 
     Viewer.prototype.processRequest_ = function(name, data, awaitResponse) {
       log(this.id + ': Viewer.prototype.processRequest_', name);
+      this.receivedMessages.push([name, data]); 
       switch(name) {
         case 'bindReady':
           return Promise.resolve();

--- a/examples/viewer.html
+++ b/examples/viewer.html
@@ -439,7 +439,7 @@
 
     Viewer.prototype.processRequest_ = function(name, data, awaitResponse) {
       log(this.id + ': Viewer.prototype.processRequest_', name);
-      this.receivedMessages.push([name, data]); 
+      this.receivedMessages.push({name, data});
       switch(name) {
         case 'bindReady':
           return Promise.resolve();

--- a/examples/viewer.html
+++ b/examples/viewer.html
@@ -241,8 +241,8 @@
           'allow-popups allow-scripts allow-forms allow-pointer-lock' +
           ' allow-popups-to-escape-sandbox allow-same-origin');
       this.iframe.setAttribute('scrolling', 'yes');
-      // this.iframe.setAttribute('width', '500px');
-      // this.iframe.setAttribute('height', '500px');
+      this.iframe.setAttribute('height', '800');
+      this.iframe.setAttribute('width', '1200');
       this.viewer.classList.add('natural');
 
       this.visibilityToggle_ = document.getElementById('visibilityToggle');

--- a/examples/viewer.html
+++ b/examples/viewer.html
@@ -249,7 +249,7 @@
         if (activeId == this.id) {
           this.toggleVisibility(this.visibilityState_ != 'visible', true);
         }
-      }.bind(this)); 
+      }.bind(this));
 
       window.addEventListener('resize', this.onResize_.bind(this));
       window.addEventListener('popstate', this.onPopState_.bind(this));

--- a/examples/viewer.html
+++ b/examples/viewer.html
@@ -241,8 +241,8 @@
           'allow-popups allow-scripts allow-forms allow-pointer-lock' +
           ' allow-popups-to-escape-sandbox allow-same-origin');
       this.iframe.setAttribute('scrolling', 'yes');
-      this.iframe.setAttribute('width', '500px');
-      this.iframe.setAttribute('height', '500px');
+      // this.iframe.setAttribute('width', '500px');
+      // this.iframe.setAttribute('height', '500px');
       this.viewer.classList.add('natural');
 
       this.visibilityToggle_ = document.getElementById('visibilityToggle');

--- a/examples/viewer.html
+++ b/examples/viewer.html
@@ -241,6 +241,8 @@
           'allow-popups allow-scripts allow-forms allow-pointer-lock' +
           ' allow-popups-to-escape-sandbox allow-same-origin');
       this.iframe.setAttribute('scrolling', 'yes');
+      this.iframe.setAttribute('width', '500px');
+      this.iframe.setAttribute('height', '500px');
       this.viewer.classList.add('natural');
 
       this.visibilityToggle_ = document.getElementById('visibilityToggle');

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -647,7 +647,6 @@ export class ResourcesImpl {
   /** @override */
   ampInitComplete() {
     this.ampInitialized_ = true;
-    this.maybeChangeHeight_ = true;
     dev().fine(TAG_, 'ampInitComplete');
     this.schedulePass();
   }
@@ -686,7 +685,7 @@ export class ResourcesImpl {
     this.prerenderSize_ = this.viewer_.getPrerenderSize();
 
     const firstPassAfterDocumentReady =
-      this.documentReady_ && this.firstPassAfterDocumentReady_;
+      this.documentReady_ && this.firstPassAfterDocumentReady_ && this.ampInitialized_;
     if (firstPassAfterDocumentReady) {
       this.firstPassAfterDocumentReady_ = false;
       const doc = this.win.document;

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -685,7 +685,9 @@ export class ResourcesImpl {
     this.prerenderSize_ = this.viewer_.getPrerenderSize();
 
     const firstPassAfterDocumentReady =
-      this.documentReady_ && this.firstPassAfterDocumentReady_ && this.ampInitialized_;
+      this.documentReady_ &&
+      this.firstPassAfterDocumentReady_ &&
+      this.ampInitialized_;
     if (firstPassAfterDocumentReady) {
       this.firstPassAfterDocumentReady_ = false;
       const doc = this.win.document;

--- a/test/e2e/test-document-height.js
+++ b/test/e2e/test-document-height.js
@@ -24,12 +24,14 @@ describes.endtoend(
   async (env) => {
     it('should send documentHeight once amp has completed init', async () => {
       const messages = env.receivedMessages;
-      const documentHeights = messages.filter(
-        (msg) => msg[0] === 'documentHeight'
+      const documentHeightMessages = messages.filter(
+        ([type, _heightObj]) => type === 'documentHeight'
       );
-      const firstHeight = documentHeights[0][1].height;
 
-      await expect(documentHeights.length).equal(1);
+      await expect(documentHeightMessages.length).equal(1);
+
+      // Example message: ['documentHeight, { height: 200 }]
+      const firstHeight = documentHeights[0][1].height;
       await expect(Math.floor(firstHeight)).equal(447);
     });
   }

--- a/test/e2e/test-document-height.js
+++ b/test/e2e/test-document-height.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ describes.endtoend(
     it('should send documentHeight once amp has completed init', async () => {
       const messages = await controller.evaluate(() => {
         // The viewer.html file will launch 7 test viewers, only one of which is the requested url.
+        // TODO(gh/amphtml/28200): only load the one viewer.
         const viewer = window.parent.allViewers.find((v) =>
           v.url.includes('document-height')
         );
@@ -39,12 +40,10 @@ describes.endtoend(
       const documentHeights = messages.filter(
         (msg) => msg[0] === 'documentHeight'
       );
+      const firstHeight = documentHeights[0][1].height;
 
-      // TODO: currently a magic number. Can we do better?
-      // Do I even have access to matchers here.
-      await expect(documentHeights).deep.equal([
-        ['documentHeight', {height: 447.875}],
-      ]);
+      await expect(documentHeights.length).equal(1);
+      await expect(Math.floor(firstHeight)).equal(447);
     });
   }
 );

--- a/test/e2e/test-document-height.js
+++ b/test/e2e/test-document-height.js
@@ -25,13 +25,13 @@ describes.endtoend(
     it('should send documentHeight once amp has completed init', async () => {
       const messages = env.receivedMessages;
       const documentHeightMessages = messages.filter(
-        ([type, _heightObj]) => type === 'documentHeight'
+        ({name}) => name === 'documentHeight'
       );
 
       await expect(documentHeightMessages.length).equal(1);
 
       // Example message: ['documentHeight, { height: 200 }]
-      const firstHeight = documentHeights[0][1].height;
+      const firstHeight = documentHeightMessages[0].data.height;
       await expect(Math.floor(firstHeight)).equal(447);
     });
   }

--- a/test/e2e/test-document-height.js
+++ b/test/e2e/test-document-height.js
@@ -40,7 +40,8 @@ describes.endtoend(
         (msg) => msg[0] === 'documentHeight'
       );
 
-      // TODO: make not a magic number.
+      // TODO: currently a magic number. Can we do better?
+      // Do I even have access to matchers here.
       await expect(documentHeights).deep.equal([
         ['documentHeight', {height: 447.875}],
       ]);

--- a/test/e2e/test-document-height.js
+++ b/test/e2e/test-document-height.js
@@ -22,21 +22,8 @@ describes.endtoend(
     environments: ['viewer-demo'],
   },
   async (env) => {
-    let controller;
-
-    beforeEach(async () => {
-      controller = env.controller;
-    });
-
     it('should send documentHeight once amp has completed init', async () => {
-      const messages = await controller.evaluate(() => {
-        // The viewer.html file will launch 7 test viewers, only one of which is the requested url.
-        // TODO(gh/amphtml/28200): only load the one viewer.
-        const viewer = window.parent.allViewers.find((v) =>
-          v.url.includes('document-height')
-        );
-        return viewer.receivedMessages;
-      });
+      const messages = env.receivedMessages;
       const documentHeights = messages.filter(
         (msg) => msg[0] === 'documentHeight'
       );

--- a/test/e2e/test-document-height.js
+++ b/test/e2e/test-document-height.js
@@ -31,7 +31,7 @@ describes.endtoend(
     it('should send documentHeight once amp has completed init', async () => {
       const messages = await controller.evaluate(() => {
         // The viewer.html file will launch 7 test viewers, only one of which is the requested url.
-        let viewer = window.parent.allViewers.find((v) =>
+        const viewer = window.parent.allViewers.find((v) =>
           v.url.includes('document-height')
         );
         return viewer.receivedMessages;

--- a/test/e2e/test-document-height.js
+++ b/test/e2e/test-document-height.js
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+describes.endtoend(
+  'documentHeight',
+  {
+    testUrl:
+      'http://localhost:8000/test/fixtures/e2e/amp-carousel/0.1/document-height.html',
+    environments: ['viewer-demo'],
+  },
+  async (env) => {
+    let controller;
+
+    beforeEach(async () => {
+      controller = env.controller;
+    });
+
+    it('should send documentHeight once amp has completed init', async () => {
+      const messages = await controller.evaluate(() => {
+        // The viewer.html file will launch 7 test viewers, only one of which is the requested url.
+        let viewer = window.parent.allViewers.find((v) =>
+          v.url.includes('document-height')
+        );
+        return viewer.receivedMessages;
+      });
+      const documentHeights = messages.filter(
+        (msg) => msg[0] === 'documentHeight'
+      );
+
+      // TODO: make not a magic number.
+      await expect(documentHeights).deep.equal([
+        ['documentHeight', {height: 447.875}],
+      ]);
+    });
+  }
+);

--- a/test/fixtures/e2e/amp-carousel/0.1/document-height.html
+++ b/test/fixtures/e2e/amp-carousel/0.1/document-height.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>AMP documentHeight test</title>
+  <link rel="canonical" href="amps.html" >
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <script async custom-element="amp-carousel" src="https://cdn.ampproject.org/v0/amp-carousel-0.1.js"></script>
+  <style amp-custom>
+  /* END AMP.CSS */
+
+  .hidden {
+    display: none;
+  }
+
+  .visible {
+    display: block;
+  }
+  </style>
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+</head>
+<body>
+  <h1>amp carousel</h1>
+  <amp-carousel id="carousel-1" width=400 height=300 type=slides controls>
+    <amp-img src="https://lh3.googleusercontent.com/5rcQ32ml8E5ONp9f9-Rf78IofLb9QjS5_0mqsY1zEFc=w300-h200-no" layout=fill></amp-img>
+    <amp-img src="https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w300-h200-no" width=80 height=60></amp-img>
+    <amp-img src="https://lh3.googleusercontent.com/Z4gtm5Bkxyv21Z2PtbTf95Clb9AE4VTR6olbBKYrenM=w300-h300-no" width=400 height=300></amp-img>
+    <amp-img src="https://lh3.googleusercontent.com/5rcQ32ml8E5ONp9f9-Rf78IofLb9QjS5_0mqsY1zEFc=w300-h200-no" layout=fill></amp-img>
+    <amp-img src="https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w300-h200-no" width=400 height=300></amp-img>
+    <amp-img src="https://lh3.googleusercontent.com/Z4gtm5Bkxyv21Z2PtbTf95Clb9AE4VTR6olbBKYrenM=w300-h300-no" width=400 height=300></amp-img>
+  </amp-carousel> 
+</body>
+</html>
+

--- a/test/fixtures/e2e/amp-carousel/0.1/document-height.html
+++ b/test/fixtures/e2e/amp-carousel/0.1/document-height.html
@@ -6,17 +6,6 @@
   <link rel="canonical" href="amps.html" >
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <script async custom-element="amp-carousel" src="https://cdn.ampproject.org/v0/amp-carousel-0.1.js"></script>
-  <style amp-custom>
-  /* END AMP.CSS */
-
-  .hidden {
-    display: none;
-  }
-
-  .visible {
-    display: block;
-  }
-  </style>
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
 </head>

--- a/test/unit/test-resources.js
+++ b/test/unit/test-resources.js
@@ -1233,11 +1233,29 @@ describes.realWin(
       });
     });
 
-    it('should measure initial contentHeight', () => {
+    it('should measure initial contentHeight and send it to the viewer', () => {
       const contentHeight = resources.viewport_.getContentHeight();
       expect(resources.maybeChangeHeight_).to.equal(false);
       expect(resources.documentReady_).to.equal(true);
       expect(resources.contentHeight_).to.equal(contentHeight);
+    });
+
+    it('should only send contentHeight to the viewer once amp finishes init', () => {
+      resources.firstPassAfterDocumentReady_ = false;
+      resources.documentReady_ = false;
+      resources.ampInitialized_ = false;
+      resources.doPass();
+      expect(viewerSendMessageStub).not.called;
+
+      resources.firstPassAfterDocumentReady_ = true;
+      resources.documentReady_ = true;
+      resources.ampInitialized_ = true;
+      resources.doPass();
+      expect(viewerSendMessageStub).calledWithExactly(
+        'documentHeight',
+        {height: 0},
+        true
+      );
     });
 
     it('should send contentHeight to viewer if height was changed', () => {

--- a/test/unit/test-resources.js
+++ b/test/unit/test-resources.js
@@ -1233,7 +1233,7 @@ describes.realWin(
       });
     });
 
-    it('should measure initial contentHeight and send it to the viewer', () => {
+    it('should measure initial contentHeight', () => {
       const contentHeight = resources.viewport_.getContentHeight();
       expect(resources.maybeChangeHeight_).to.equal(false);
       expect(resources.documentReady_).to.equal(true);


### PR DESCRIPTION
**do not merge until may 5th**

Better long term fix for https://github.com/ampproject/amphtml/pull/28065.

We decided to initially opt for #28065 because it is less risky and we'd like to unblock gmail, and then switch to this solution for future cuts. It was less risky because it preserves behavior.

Old behavior during init for a `display:none` iframe was as follows:

1. documentHeight: 0
2. documentHeight: 20 (incorrect and sent before amp finishes initializing)
3. documentHeight: correct number

New behavior with this PR will be:
1. documentHeight: 0
2. documentHeight: correct number

This should result in fewer flickers for consumers of the `documentHeight` message.

cc @ampproject/wg-runtime 

TODO:
- [x] add a unit test
- [x] add an e2e test