### PR TITLE
🏗 Skip `gulp unit --local_changes` on Travis if too many tests were affected

### DIFF
--- a/build-system/tasks/runtime-test/helpers-unit.js
+++ b/build-system/tasks/runtime-test/helpers-unit.js
@@ -30,6 +30,7 @@ const {isTravisBuild} = require('../../common/travis');
 const {reportTestSkipped} = require('../report-test-status');
 
 const LARGE_REFACTOR_THRESHOLD = 50;
+const TEST_FILE_COUNT_THRESHOLD = 20;
 const ROOT_DIR = path.resolve(__dirname, '../../../');
 let testsToRun = null;
 
@@ -140,6 +141,14 @@ function getUnitTestsToRun() {
     log(
       green('INFO:'),
       'No unit tests were directly affected by local changes.'
+    );
+    reportTestSkipped();
+    return;
+  }
+  if (isTravisBuild() && tests.length > TEST_FILE_COUNT_THRESHOLD) {
+    log(
+      green('INFO:'),
+      'Several tests were affected by local changes. Running all tests below.'
     );
     reportTestSkipped();
     return;


### PR DESCRIPTION
In #28131, the detection logic for affected files was fixed, resulting in PRs running more tests during `gulp unit --local_changes`. While this is good for local development (e.g. testing CSS changes is easier), it can lead to inefficiencies on Travis (e.g. A logging file is touched and ~4000 tests are affected, causing all those tests to be run twice).

This PR skips the `--local_changes` run on Travis when more than 20 test files are affected by a PR.