### PR TITLE
🏗 Tag release on-duty team in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/cherry_pick_template.md
+++ b/.github/ISSUE_TEMPLATE/cherry_pick_template.md
@@ -83,4 +83,4 @@ TIP: How can we:
 
 ---
 
-/cc @ampproject/wg-approvers @ampproject/cherry-pick-approvers
+/cc @ampproject/release-on-duty @ampproject/wg-approvers @ampproject/cherry-pick-approvers

--- a/.github/ISSUE_TEMPLATE/error-report.md
+++ b/.github/ISSUE_TEMPLATE/error-report.md
@@ -44,3 +44,5 @@ Notes
 ---
 <Additional notes>
 -->
+
+/cc @ampproject/release-on-duty

--- a/.github/ISSUE_TEMPLATE/release-tracking-issue.md
+++ b/.github/ISSUE_TEMPLATE/release-tracking-issue.md
@@ -54,3 +54,5 @@ If you perform cherry picks, add/update the checkboxes above as needed e.g.
 See the [release documentation](https://github.com/ampproject/amphtml/blob/master/contributing/release-schedule.md) for more information on the release process, including how to test changes in the Experimental channel.
 
 If you find a bug in this build, please file an [issue](https://github.com/ampproject/amphtml/issues/new). If you believe the bug should be fixed in this build, follow the instructions in the [cherry picks documentation](https://go.amp.dev/cherry-picks).
+
+/cc @ampproject/release-on-duty


### PR DESCRIPTION
Adds `/cc @ampproject/release-on-duty` to issue templates for releases, cherry-picks, and error reports, now that https://github.com/ampproject/amp-github-apps/issues/778 has added them.