### PR TITLE
🌐 Allow language override from viewer context

### DIFF
--- a/src/service/localization.js
+++ b/src/service/localization.js
@@ -18,6 +18,7 @@
 // LocalizedStringId enum values and any other strings.
 // eslint-disable-next-line no-unused-vars
 import {LocalizedStringId} from '../localized-strings';
+import {Services} from '../services';
 import {closest} from '../dom';
 
 /**
@@ -95,6 +96,11 @@ export class LocalizationService {
     this.element_ = element;
 
     /**
+     * @private @const {?string}
+     */
+    this.viewerLanguageCode_ = Services.viewerForDoc(element).getParam('lang');
+
+    /**
      * A mapping of language code to localized string bundle.
      * @private @const {!Object<string, !../localized-strings.LocalizedStringBundleDef>}
      */
@@ -109,7 +115,13 @@ export class LocalizationService {
   getLanguageCodesForElement_(element) {
     const languageEl = closest(element, (el) => el.hasAttribute('lang'));
     const languageCode = languageEl ? languageEl.getAttribute('lang') : null;
-    return getLanguageCodesFromString(languageCode || '');
+    const languageCodesToUse = getLanguageCodesFromString(languageCode || '');
+
+    if (this.viewerLanguageCode_) {
+      languageCodesToUse.unshift(this.viewerLanguageCode_);
+    }
+
+    return languageCodesToUse;
   }
 
   /**

--- a/test/unit/test-localization.js
+++ b/test/unit/test-localization.js
@@ -22,6 +22,7 @@ import {
   LocalizedStringId,
   createPseudoLocale,
 } from '../../src/localized-strings';
+import {Services} from '../../src/services';
 
 describes.fakeWin('localization', {amp: true}, (env) => {
   let win;
@@ -177,9 +178,7 @@ describes.fakeWin('viewer localization', {amp: true}, (env) => {
     });
 
     it('should take precedence over document language', () => {
-      const localizationService = Services.localizationForDoc(
-        win.document.body
-      );
+      const localizationService = new LocalizationService(win.document.body);
       localizationService.registerLocalizedStringBundle('fr', {
         'test_string_id': {
           string: 'oui',
@@ -197,9 +196,7 @@ describes.fakeWin('viewer localization', {amp: true}, (env) => {
     });
 
     it('should fall back if string is not found', () => {
-      const localizationService = Services.localizationForDoc(
-        win.document.body
-      );
+      const localizationService = new LocalizationService(win.document.body);
       localizationService.registerLocalizedStringBundle('fr', {
         'incorrect_test_string_id': {
           string: 'non',
@@ -217,9 +214,7 @@ describes.fakeWin('viewer localization', {amp: true}, (env) => {
     });
 
     it('should fall back if language code is not registered', () => {
-      const localizationService = Services.localizationForDoc(
-        win.document.body
-      );
+      const localizationService = new LocalizationService(win.document.body);
       localizationService.registerLocalizedStringBundle('en', {
         'test_string_id': {
           string: 'yes',

--- a/test/unit/test-localization.js
+++ b/test/unit/test-localization.js
@@ -164,3 +164,71 @@ describes.fakeWin('localization', {amp: true}, (env) => {
     });
   });
 });
+
+describes.fakeWin('viewer localization', {amp: true}, (env) => {
+  describe('viewer language override', () => {
+    let win;
+
+    beforeEach(() => {
+      win = env.win;
+      env.sandbox
+        .stub(Services.viewerForDoc(env.ampdoc), 'getParam')
+        .returns('fr');
+    });
+
+    it('should take precedence over document language', () => {
+      const localizationService = Services.localizationForDoc(
+        win.document.body
+      );
+      localizationService.registerLocalizedStringBundle('fr', {
+        'test_string_id': {
+          string: 'oui',
+        },
+      });
+      localizationService.registerLocalizedStringBundle('en', {
+        'test_string_id': {
+          string: 'yes',
+        },
+      });
+
+      expect(localizationService.getLocalizedString('test_string_id')).to.equal(
+        'oui'
+      );
+    });
+
+    it('should fall back if string is not found', () => {
+      const localizationService = Services.localizationForDoc(
+        win.document.body
+      );
+      localizationService.registerLocalizedStringBundle('fr', {
+        'incorrect_test_string_id': {
+          string: 'non',
+        },
+      });
+      localizationService.registerLocalizedStringBundle('en', {
+        'correct_test_string_id': {
+          string: 'yes',
+        },
+      });
+
+      expect(
+        localizationService.getLocalizedString('correct_test_string_id')
+      ).to.equal('yes');
+    });
+
+    it('should fall back if language code is not registered', () => {
+      const localizationService = Services.localizationForDoc(
+        win.document.body
+      );
+      localizationService.registerLocalizedStringBundle('en', {
+        'test_string_id': {
+          string: 'yes',
+        },
+      });
+
+      expect(localizationService.getLocalizedString('test_string_id')).to.equal(
+        'yes'
+      );
+    });
+  });
+});


### PR DESCRIPTION
Closes #27023

Original description:

In platform contexts, it makes sense for document-rendered system-level user interfaces to be consistent across documents. This PR allows an AMP viewer or story player to specify a fragment parameter to indicate the language to be used, falling back to the document's language if unspecified.

Follows up on #27990 #27053 

<!--
# Instructions:

- Pick a meaningful title for your pull request. (Use sentence case.)
  - Prefix the title with an emoji to identify what is being done. (Copy-paste the emoji from the list below.)
  - Do not overuse punctuation in the title (like `(chore):`).
  - If it is helpful, use a simple prefix (like `ProjectX: Implement some feature`).
- Enter a succinct description that says why the PR is necessary, and what it does.
  - Mention the GitHub issue that is being addressed by the pull request.
  - The keywords `Fixes`, `Closes`, or `Resolves` followed the issue number will automatically close the issue.

> NOTE: All non-trivial changes (like introducing new features or components) should have an associated issue or reference an I2I (intent-to-implement: go.amp.dev/i2i). Please read through the contribution process (go.amp.dev/contributing/code) for more information.

# Example of a good description:

- Implement aspect X
- Leave out feature Y because of A
- Improve performance by B
- Improve accessibility by C

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Reverting a previous change
♻️ Refactoring
🚮 Deleting code
-->
