### PR TITLE
🐛 Add error messages to thrown bare Error()s in `amp-script`

### DIFF
--- a/extensions/amp-script/0.1/amp-script.js
+++ b/extensions/amp-script/0.1/amp-script.js
@@ -337,19 +337,13 @@ export class AmpScript extends AMP.BaseElement {
               startsWith(contentType, 'text/javascript')
             )
           ) {
-            user().error(
+            // TODO(#24266): Refactor to %s interpolation when error string
+            // extraction is ready.
+            throw user().createError(
               TAG,
               'Same-origin "src" requires "Content-Type: text/javascript" or "Content-Type: application/javascript". ' +
-                'Fetched source for %s has "Content-Type: %s". ' +
-                'See https://amp.dev/documentation/components/amp-script/#security-features.',
-              debugId,
-              contentType
-            );
-            // TODO(#24266): user().createError() messages are not extracted and
-            // don't perform string substitution.
-            throw user().createError(
-              'Same-origin "src" requires "Content-Type: text/javascript" or ' +
-                '"Content-Type: application/javascript".'
+                `Fetched source for ${debugId} has "Content-Type: ${contentType}". ` +
+                'See https://amp.dev/documentation/components/amp-script/#security-features.'
             );
           }
           return response.text();
@@ -517,17 +511,12 @@ export class AmpScriptService {
     const bytes = utf8Encode(script);
     return this.crypto_.sha384Base64(bytes).then((hash) => {
       if (!hash || !this.sources_.includes('sha384-' + hash)) {
-        user().error(
-          TAG,
-          'Script hash not found. %s must have "sha384-%s" in meta[name="amp-script-src"].' +
-            ' See https://amp.dev/documentation/components/amp-script/#security-features.',
-          debugId,
-          hash
-        );
-        // TODO(#24266): user().createError() messages are not extracted and
-        // don't perform string substitution.
+        // TODO(#24266): Refactor to %s interpolation when error string
+        // extraction is ready.
         throw user().createError(
-          'Script hash not found; sha384 missing from meta tag.'
+          TAG,
+          `Script hash not found. ${debugId} must have "sha384-${hash}" in meta[name="amp-script-src"].` +
+            ' See https://amp.dev/documentation/components/amp-script/#security-features.'
         );
       }
     });

--- a/extensions/amp-script/0.1/amp-script.js
+++ b/extensions/amp-script/0.1/amp-script.js
@@ -347,7 +347,10 @@ export class AmpScript extends AMP.BaseElement {
             );
             // TODO(#24266): user().createError() messages are not extracted and
             // don't perform string substitution.
-            throw new Error();
+            throw user().createError(
+              'Same-origin "src" requires "Content-Type: text/javascript" or ' +
+                '"Content-Type: application/javascript".'
+            );
           }
           return response.text();
         } else {
@@ -523,7 +526,9 @@ export class AmpScriptService {
         );
         // TODO(#24266): user().createError() messages are not extracted and
         // don't perform string substitution.
-        throw new Error();
+        throw user().createError(
+          'Script hash not found; sha384 missing from meta tag.'
+        );
       }
     });
   }


### PR DESCRIPTION
As part of https://github.com/ampproject/amphtml/issues/24266, error messages with substitutions aren't logged properly. Some parts of amp-script use `user().error()` to log locally, then `throw new Error()`, resulting in AMP Error Reporting getting a smattering of bare `Error: Error` reports, which add to error reporting noise and are difficult for a release on-duty to assess/debug

This PR updates those bare `throw`s to instead throw a user error with a useful message.

Closes https://github.com/ampproject/amphtml/issues/28184