### PR TITLE
[amp-accordion] Implement Display Locking via CSS property

### DIFF
--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -10,7 +10,6 @@
   "adsense-ad-size-optimization": 0.01,
   "amp-access-iframe": 1,
   "amp-action-macro": 1,
-  "amp-accordion-display-locking": 0.01,
   "amp-ad-ff-adx-ady": 0.01,
   "amp-auto-ads-adsense-holdout": 0.1,
   "amp-consent-restrict-fullscreen": 1,

--- a/examples/accordion.amp.html
+++ b/examples/accordion.amp.html
@@ -52,7 +52,7 @@
             <section id="item1" on="expand:ac2.collapse(section='item2'),AMP.setState({expandAc1: true});collapse:AMP.setState({expandAc1: false})" [data-expand]="expandAc1">
               <h1>Item 1 (Expanding it closes Item 2)</h1>
               <div>
-                <p id="initClosed">1A</p>
+                <p>1A</p>
                 <p>1B</p>
               </div>
             </section>
@@ -89,15 +89,16 @@
         controls>
     </amp-video>
     </section>
-    <section expanded>
+    <section>
       <h2>Section 2</h2>
-      <div>Bunch of awesome content</div>
+      <div id="initClosed">Bunch of awesome content</div>
     </section>
     <section>
       <h2>Section 3</h2>
       <div>
           <amp-img src="./img/sea@1x.jpg" width="300" height="300"></amp-img>
           Check out the sea!
+          <input>
       </div>
     </section>
     <section>
@@ -111,7 +112,7 @@
     </section>
     <section>
       <header>The header tag is supported as well.</header>
-      <p>Even more awesome.</p>
+      <p>Even more awesome. <input> </p>
     </section>
   </amp-accordion>
 </body>

--- a/extensions/amp-accordion/0.1/amp-accordion.css
+++ b/extensions/amp-accordion/0.1/amp-accordion.css
@@ -30,16 +30,13 @@
   border: solid 1px #dfdfdf;
 }
 
-amp-accordion > section:not([expanded]) > :last-child[rendersubtree] {
-  border: none !important;
+amp-accordion.i-amphtml-display-locking > section:not([expanded]) > :last-child,
+amp-accordion.i-amphtml-display-locking
+  > section:not([expanded])
+  > :last-child
+  * {
+  content-visibility: hidden-matchable !important;
   display: block !important;
-  height: 0px !important;
-  margin: 0px !important;
-  opacity: 0 !important;
-  padding: 0 !important;
-  position: absolute !important;
-  top: -999999px !important;
-  width: 100% !important;
 }
 
 /* Media should never play when a section is collapsed */

--- a/extensions/amp-accordion/0.1/amp-accordion.js
+++ b/extensions/amp-accordion/0.1/amp-accordion.js
@@ -46,7 +46,10 @@ const COLLAPSE_CURVE_ = bezierCurve(0.39, 0.575, 0.565, 1);
 const isDisplayLockingEnabledForAccordion = (win) => {
   return (
     isExperimentOn(win, 'amp-accordion-display-locking') &&
-    ('renderSubtree' in Element.prototype || getMode().test)
+    (('CSS' in window &&
+      window.CSS.supports &&
+      window.CSS.supports('content-visibility', 'hidden-matchable')) ||
+      getMode().test)
   );
 };
 
@@ -155,10 +158,6 @@ class AmpAccordion extends AMP.BaseElement {
       header.setAttribute('role', 'button');
       header.setAttribute('aria-controls', contentId);
       header.setAttribute('aria-expanded', String(isExpanded));
-      this.setRenderSubtreeIfEnabled_(
-        content,
-        isExpanded ? '' : 'invisible skip-viewport-activation'
-      );
       if (!header.hasAttribute('tabindex')) {
         header.setAttribute('tabindex', 0);
       }
@@ -173,7 +172,8 @@ class AmpAccordion extends AMP.BaseElement {
       header.addEventListener('keydown', this.keyDownHandler_.bind(this));
 
       if (isDisplayLockingEnabledForAccordion(this.win)) {
-        content.addEventListener('rendersubtreeactivation', (event) => {
+        this.element.classList.add('i-amphtml-display-locking');
+        content.addEventListener('beforematch', (event) => {
           // Event occurs on the content element whose parent is the section to open.
           const parentSection = dev().assertElement(event.target.parentElement);
           this.toggle_(parentSection, ActionTrust.LOW, /* force expand */ true);
@@ -322,26 +322,17 @@ class AmpAccordion extends AMP.BaseElement {
     if (this.element.hasAttribute('animate')) {
       if (toExpand) {
         header.setAttribute('aria-expanded', 'true');
-        this.setRenderSubtreeIfEnabled_(content, '');
         this.animateExpand_(section, trust);
         if (this.element.hasAttribute('expand-single-section')) {
           this.sections_.forEach((sectionIter) => {
             if (sectionIter != section) {
               this.animateCollapse_(sectionIter, trust);
               sectionIter.children[0].setAttribute('aria-expanded', 'false');
-              this.setRenderSubtreeIfEnabled_(
-                sectionIter.children[1],
-                'invisible skip-viewport-activation'
-              );
             }
           });
         }
       } else {
         header.setAttribute('aria-expanded', 'false');
-        this.setRenderSubtreeIfEnabled_(
-          content,
-          'invisible skip-viewport-activation'
-        );
         this.animateCollapse_(section, trust);
       }
     } else {
@@ -350,7 +341,6 @@ class AmpAccordion extends AMP.BaseElement {
         if (toExpand) {
           this.triggerEvent_('expand', section, trust);
           section.setAttribute('expanded', '');
-          this.setRenderSubtreeIfEnabled_(content, '');
           header.setAttribute('aria-expanded', 'true');
           // if expand-single-section is set, only allow one <section> to be
           // expanded at a time
@@ -362,10 +352,6 @@ class AmpAccordion extends AMP.BaseElement {
                   sectionIter.removeAttribute('expanded');
                 }
                 sectionIter.children[0].setAttribute('aria-expanded', 'false');
-                this.setRenderSubtreeIfEnabled_(
-                  sectionIter.children[1],
-                  'invisible skip-viewport-activation'
-                );
               }
             });
           }
@@ -373,29 +359,11 @@ class AmpAccordion extends AMP.BaseElement {
           this.triggerEvent_('collapse', section, trust);
           section.removeAttribute('expanded');
           header.setAttribute('aria-expanded', 'false');
-          this.setRenderSubtreeIfEnabled_(
-            content,
-            'invisible skip-viewport-activation'
-          );
         }
       }, section);
     }
     this.currentState_[contentId] = !isSectionClosedAfterClick;
     this.setSessionState_();
-  }
-
-  /**
-   * If Display Locking API is enabled, set the renderSubtree attribute
-   * on the given element with the given value.
-   * @param {Element} element
-   * @param {string} value
-   * @private
-   */
-  setRenderSubtreeIfEnabled_(element, value) {
-    if (!isDisplayLockingEnabledForAccordion(this.win) || !element) {
-      return;
-    }
-    element['renderSubtree'] = value;
   }
 
   /**

--- a/extensions/amp-accordion/0.1/test/test-amp-accordion.js
+++ b/extensions/amp-accordion/0.1/test/test-amp-accordion.js
@@ -244,7 +244,7 @@ describes.realWin(
         const content = section.children[1];
         expect(section.hasAttribute('expanded')).to.be.false;
         expect(header.getAttribute('aria-expanded')).to.equal('false');
-        content.dispatchEvent(new Event('rendersubtreeactivation'));
+        content.dispatchEvent(new Event('beforematch'));
         expect(section.hasAttribute('expanded')).to.be.true;
         expect(header.getAttribute('aria-expanded')).to.equal('true');
         toggleExperiment(win, 'amp-accordion-display-locking', false);


### PR DESCRIPTION
This change modifies the existing `amp-accordion-display-locking` experiment with the `content-visibility` CSS property implementation. [[Demo](https://accordion-display-locking.firebaseapp.com/)] FYI @dvoytenko 

**Status update as of 2020-06-25**
This change is ready to go, pending the following:
- Bug fix to coordinate asynchronous section expansion with synchronous scrolling and manual testing upon resolution
- Experimental availability of `content: hidden-matchable` and the `beforematch` event on the Chrome side. 

cc @vmpstr