### PR TITLE
🚀 Allow prerendering of more elements

### DIFF
--- a/extensions/amp-accordion/0.1/amp-accordion.js
+++ b/extensions/amp-accordion/0.1/amp-accordion.js
@@ -83,6 +83,11 @@ class AmpAccordion extends AMP.BaseElement {
   }
 
   /** @override */
+  prerenderAllowed() {
+    return true;
+  }
+
+  /** @override */
   buildCallback() {
     this.action_ = Services.actionServiceForDoc(this.element);
     this.sessionOptOut_ = this.element.hasAttribute('disable-session-states');

--- a/extensions/amp-base-carousel/0.1/amp-base-carousel.js
+++ b/extensions/amp-base-carousel/0.1/amp-base-carousel.js
@@ -160,6 +160,11 @@ class AmpCarousel extends AMP.BaseElement {
   }
 
   /** @override */
+  prerenderAllowed() {
+    return true;
+  }
+
+  /** @override */
   buildCallback() {
     this.action_ = Services.actionServiceForDoc(this.element);
 

--- a/extensions/amp-carousel/0.2/amp-carousel.js
+++ b/extensions/amp-carousel/0.2/amp-carousel.js
@@ -123,6 +123,11 @@ class AmpCarousel extends AMP.BaseElement {
   }
 
   /** @override */
+  prerenderAllowed() {
+    return true;
+  }
+
+  /** @override */
   buildCallback() {
     this.action_ = Services.actionServiceForDoc(this.element);
 

--- a/extensions/amp-inline-gallery/0.1/amp-inline-gallery-pagination.js
+++ b/extensions/amp-inline-gallery/0.1/amp-inline-gallery-pagination.js
@@ -74,6 +74,11 @@ export class AmpInlineGalleryPagination extends AMP.BaseElement {
   }
 
   /** @override */
+  prerenderAllowed() {
+    return true;
+  }
+
+  /** @override */
   buildCallback() {
     this.element.appendChild(this.createDom_());
 

--- a/extensions/amp-inline-gallery/0.1/amp-inline-gallery-thumbnails.js
+++ b/extensions/amp-inline-gallery/0.1/amp-inline-gallery-thumbnails.js
@@ -55,6 +55,11 @@ export class AmpInlineGalleryThumbnails extends AMP.BaseElement {
   }
 
   /** @override */
+  prerenderAllowed() {
+    return true;
+  }
+
+  /** @override */
   buildCallback() {
     const aspectRatioWidth =
       Number(this.element.getAttribute('aspect-ratio-width')) || 0;

--- a/extensions/amp-inline-gallery/0.1/amp-inline-gallery.js
+++ b/extensions/amp-inline-gallery/0.1/amp-inline-gallery.js
@@ -86,6 +86,11 @@ class AmpInlineGallery extends AMP.BaseElement {
   }
 
   /** @override */
+  prerenderAllowed() {
+    return true;
+  }
+
+  /** @override */
   isLayoutSupported(layout) {
     return layout === Layout.CONTAINER;
   }

--- a/extensions/amp-mega-menu/0.1/amp-mega-menu.js
+++ b/extensions/amp-mega-menu/0.1/amp-mega-menu.js
@@ -89,6 +89,11 @@ export class AmpMegaMenu extends AMP.BaseElement {
   }
 
   /** @override */
+  prerenderAllowed() {
+    return true;
+  }
+
+  /** @override */
   buildCallback() {
     this.action_ = Services.actionServiceForDoc(this.element);
   }

--- a/extensions/amp-nested-menu/0.1/amp-nested-menu.js
+++ b/extensions/amp-nested-menu/0.1/amp-nested-menu.js
@@ -120,6 +120,11 @@ export class AmpNestedMenu extends AMP.BaseElement {
     return layout == Layout.FILL;
   }
 
+  /** @override */
+  prerenderAllowed() {
+    return true;
+  }
+
   /**
    * Handler for click event on any element inside the component.
    * @param {!Event} e

--- a/extensions/amp-selector/0.1/amp-selector.js
+++ b/extensions/amp-selector/0.1/amp-selector.js
@@ -82,6 +82,11 @@ export class AmpSelector extends AMP.BaseElement {
   }
 
   /** @override */
+  prerenderAllowed() {
+    return true;
+  }
+
+  /** @override */
   buildCallback() {
     this.action_ = Services.actionServiceForDoc(this.element);
     this.isMultiple_ = this.element.hasAttribute('multiple');

--- a/extensions/amp-sidebar/0.2/amp-sidebar.js
+++ b/extensions/amp-sidebar/0.2/amp-sidebar.js
@@ -138,6 +138,11 @@ export class AmpSidebar extends AMP.BaseElement {
   }
 
   /** @override */
+  prerenderAllowed() {
+    return true;
+  }
+
+  /** @override */
   buildCallback() {
     // TODO(#25022): remove this assert when cleaning up experiment post launch.
     userAssert(

--- a/extensions/amp-stream-gallery/0.1/amp-stream-gallery.js
+++ b/extensions/amp-stream-gallery/0.1/amp-stream-gallery.js
@@ -269,6 +269,11 @@ class AmpStreamGallery extends AMP.BaseElement {
   }
 
   /** @override */
+  prerenderAllowed() {
+    return true;
+  }
+
+  /** @override */
   buildCallback() {
     userAssert(
       isExperimentOn(this.win, 'amp-stream-gallery'),


### PR DESCRIPTION
- amp-accordion
- amp-base-carousel
- amp-carousel 0.2
- amp-inline-gallery
- amp-stream-gallery
- amp-mega-menu
- amp-nested-menu
- amp-selector
- amp-sidebar
- amp-stream-gallery

Some of these likely were just oversight. Others were not opted in because they don't have a `layoutCallback` but nowadays `buildCallback` is also guarded by `prerenderAllowed`.

