### PR TITLE
🏗 Add missing `await` to `stopServer()` invocations

### DIFF
--- a/build-system/tasks/e2e/index.js
+++ b/build-system/tasks/e2e/index.js
@@ -47,8 +47,8 @@ async function launchWebServer_() {
   );
 }
 
-function cleanUp_() {
-  stopServer();
+async function cleanUp_() {
+  await stopServer();
 }
 
 function createMocha_() {
@@ -113,7 +113,7 @@ async function e2e() {
     await reportTestStarted();
     mocha.run(async (failures) => {
       // end web server
-      cleanUp_();
+      await cleanUp_();
 
       // end task
       process.exitCode = failures ? 1 : 0;

--- a/build-system/tasks/runtime-test/runtime-test-base.js
+++ b/build-system/tasks/runtime-test/runtime-test-base.js
@@ -256,7 +256,7 @@ class RuntimeTestRunner {
   }
 
   async teardown() {
-    stopServer();
+    await stopServer();
     exitCtrlcHandler(this.env.get('handlerProcess'));
 
     if (this.exitCode != 0) {

--- a/build-system/tasks/visual-diff/index.js
+++ b/build-system/tasks/visual-diff/index.js
@@ -799,7 +799,7 @@ async function cleanup_() {
   if (browser_) {
     await browser_.close();
   }
-  stopServer();
+  await stopServer();
   await exitPercyAgent_();
 }
 


### PR DESCRIPTION
`stopServer()` in `build-system/tasks/serve.js` was converted to an `async` function in [#27471](https://github.com/ampproject/amphtml/pull/27471/files#diff-68eb307bd570cd1da4673aa2f01e235c), but not all call sites were updated. Luckily, this hasn't broken things (yet) because they don't all trigger the asynchronous behavior.

This PR updates all call sites with `await`.

Addresses https://github.com/ampproject/amphtml/pull/28148#discussion_r419758970