### PR TITLE
amp-script: catch user errors in worker scripts

### DIFF
--- a/examples/amp-script/amp-script-demo.js
+++ b/examples/amp-script/amp-script-demo.js
@@ -37,7 +37,6 @@ if (hello) {
     const el = document.createElement('h1');
     el.textContent = 'Hello World!';
     document.body.appendChild(el);
-    prompt('hahah');
   });
 }
 

--- a/examples/amp-script/amp-script-demo.js
+++ b/examples/amp-script/amp-script-demo.js
@@ -37,6 +37,7 @@ if (hello) {
     const el = document.createElement('h1');
     el.textContent = 'Hello World!';
     document.body.appendChild(el);
+    prompt('hahah');
   });
 }
 

--- a/extensions/amp-script/0.1/amp-script.js
+++ b/extensions/amp-script/0.1/amp-script.js
@@ -247,6 +247,13 @@ export class AmpScript extends AMP.BaseElement {
       config
     ).then((workerDom) => {
       this.workerDom_ = workerDom;
+      this.workerDom_.onerror = (errorEvent) => {
+        errorEvent.preventDefault();
+        user().error(
+          TAG,
+          `${errorEvent.message}\n    at (${errorEvent.filename}:${errorEvent.lineno})`
+        );
+      };
     });
     return workerAndAuthorScripts;
   }


### PR DESCRIPTION
**summary**
Fixes https://github.com/ampproject/amphtml/issues/28198.

Adds an `onerror` handler to the worker script so that we can rethrow all errors as user errors instead of bubbling into a dev one. This should help clear some noise from the error tracker.

Here's a screenshot of the new error format:
<img width="629" alt="Screen Shot 2020-05-05 at 3 10 53 PM" src="https://user-images.githubusercontent.com/4656974/81105867-a1693080-8ee2-11ea-8f41-0f709c6bf558.png">

cc @rcebulko @ampproject/wg-runtime 