### PR TITLE
Fix Node API on Node >12

### DIFF
--- a/validator/build.py
+++ b/validator/build.py
@@ -334,10 +334,10 @@ def RunSmokeTest(out_dir):
     out_dir: output directory
   """
   logging.info('entering ...')
-  # Run index.js on the minimum valid amp and observe that it passes.
+  # Run cli.js on the minimum valid amp and observe that it passes.
   p = subprocess.Popen(
       [
-          'node', 'nodejs/index.js', '--validator_js',
+          'node', 'nodejs/cli.js', '--validator_js',
           '%s/validator_minified.js' % out_dir,
           'testdata/feature_tests/minimum_valid_amp.html', '--format=text'
       ],
@@ -349,10 +349,10 @@ def RunSmokeTest(out_dir):
     Die('Smoke test failed. returncode=%d stdout="%s" stderr="%s"' %
         (p.returncode, stdout, stderr))
 
-  # Run index.js on an empty file and observe that it fails.
+  # Run cli.js on an empty file and observe that it fails.
   p = subprocess.Popen(
       [
-          'node', 'nodejs/index.js', '--validator_js',
+          'node', 'nodejs/cli.js', '--validator_js',
           '%s/validator_minified.js' % out_dir,
           'testdata/feature_tests/empty.html', '--format=text'
       ],

--- a/validator/nodejs/cli.js
+++ b/validator/nodejs/cli.js
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+/**
+ * @license
+ * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the license.
+ */
+
+'use strict';
+
+const {main} = require('./index');
+
+main();
+

--- a/validator/nodejs/index.js
+++ b/validator/nodejs/index.js
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 /**
  * @license
  * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
@@ -498,6 +497,4 @@ function main() {
       });
 }
 
-if (require.main === module) {
-  main();
-}
+exports.main = main

--- a/validator/nodejs/index_test.js
+++ b/validator/nodejs/index_test.js
@@ -191,7 +191,7 @@ it('emits text if --format=text is specified on command line', function(done) {
   execFile(
       process.execPath,
       [
-        '../nodejs/index.js', '--format=text',
+        '../nodejs/cli.js', '--format=text',
         '--validator_js=../dist/validator_minified.js',
         'feature_tests/several_errors.html',
         'feature_tests/minimum_valid_amp.html',
@@ -209,7 +209,7 @@ it('emits json if --format=json is specified on command line', function(done) {
   execFile(
       process.execPath,
       [
-        '../nodejs/index.js', '--format=json',
+        '../nodejs/cli.js', '--format=json',
         '--validator_js=../dist/validator_minified.js',
         'feature_tests/several_errors.html',
         'feature_tests/minimum_valid_amp.html',
@@ -249,7 +249,7 @@ it('supports AMP4ADS with --html_format command line option', function(done) {
   execFile(
       process.execPath,
       [
-        '../nodejs/index.js', '--format=text', '--html_format=AMP4ADS',
+        '../nodejs/cli.js', '--format=text', '--html_format=AMP4ADS',
         '--validator_js=../dist/validator_minified.js',
         'amp4ads_feature_tests/style-amp-custom.html',
         'amp4ads_feature_tests/min_valid_amp4ads.html',

--- a/validator/nodejs/package.json
+++ b/validator/nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amphtml-validator",
-  "version": "1.0.30",
+  "version": "1.0.31",
   "description": "Official validator for AMP HTML (www.ampproject.org)",
   "keywords": [
     "AMP",

--- a/validator/nodejs/package.json
+++ b/validator/nodejs/package.json
@@ -16,7 +16,7 @@
     "url": "https://github.com/ampproject/amphtml/tree/master/validator/nodejs/"
   },
   "bin": {
-    "amphtml-validator": "index.js"
+    "amphtml-validator": "./cli.js"
   },
   "dependencies": {
     "colors": "1.2.5",


### PR DESCRIPTION
The hashbang #!/usr/bin/env at the top of the node validator implementation causes problems when importing the file via require in Node >12. To address this, this commit moves the cli script into a separate file.

Fixes #28158
