### PR TITLE
Validator rollup

### DIFF
--- a/validator/testdata/amp4email_feature_tests/css_declarations.html
+++ b/validator/testdata/amp4email_feature_tests/css_declarations.html
@@ -257,6 +257,7 @@
       text-combine-upright: foo;
       text-decoration-color: foo;
       text-decoration-line: foo;
+      text-decoration-skip-ink: foo;
       text-decoration-style: foo;
       text-decoration: foo;
       text-fill-color: foo;
@@ -533,6 +534,7 @@
 <b style='text-combine-upright: foo'></b>
 <b style='text-decoration-color: foo'></b>
 <b style='text-decoration-line: foo'></b>
+<b style='text-decoration-skip-ink: foo'></b>
 <b style='text-decoration-style: foo'></b>
 <b style='text-decoration: foo'></b>
 <b style='text-fill-color: foo'></b>

--- a/validator/testdata/amp4email_feature_tests/css_declarations.out
+++ b/validator/testdata/amp4email_feature_tests/css_declarations.out
@@ -258,6 +258,7 @@ FAIL
 |        text-combine-upright: foo;
 |        text-decoration-color: foo;
 |        text-decoration-line: foo;
+|        text-decoration-skip-ink: foo;
 |        text-decoration-style: foo;
 |        text-decoration: foo;
 |        text-fill-color: foo;
@@ -311,7 +312,7 @@ FAIL
 |  <b style='align-self: foo'></b>
 |  <b style='alignment-baseline: foo'></b>
 >> ^~~~~~~~~
-amp4email_feature_tests/css_declarations.html:311:0 The property 'alignment-baseline' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
+amp4email_feature_tests/css_declarations.html:312:0 The property 'alignment-baseline' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
 |  <b style='all: foo'></b>
 |  <b style='animation-delay: foo'></b>
 |  <b style='animation-direction: foo'></b>
@@ -335,7 +336,7 @@ amp4email_feature_tests/css_declarations.html:311:0 The property 'alignment-base
 |  <b style='background: foo'></b>
 |  <b style='baseline-shift: foo'></b>
 >> ^~~~~~~~~
-amp4email_feature_tests/css_declarations.html:333:0 The property 'baseline-shift' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
+amp4email_feature_tests/css_declarations.html:334:0 The property 'baseline-shift' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
 |  <b style='border-bottom-color: foo'></b>
 |  <b style='border-bottom-left-radius: foo'></b>
 |  <b style='border-bottom-right-radius: foo'></b>
@@ -381,23 +382,23 @@ amp4email_feature_tests/css_declarations.html:333:0 The property 'baseline-shift
 |  <b style='clear: foo'></b>
 |  <b style='clip-path: foo'></b>
 >> ^~~~~~~~~
-amp4email_feature_tests/css_declarations.html:377:0 The property 'clip-path' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
+amp4email_feature_tests/css_declarations.html:378:0 The property 'clip-path' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
 |  <b style='clip-rule: foo'></b>
 >> ^~~~~~~~~
-amp4email_feature_tests/css_declarations.html:378:0 The property 'clip-rule' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
+amp4email_feature_tests/css_declarations.html:379:0 The property 'clip-rule' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
 |  <b style='clip: foo'></b>
 |  <b style='color-interpolation-filters: foo'></b>
 >> ^~~~~~~~~
-amp4email_feature_tests/css_declarations.html:380:0 The property 'color-interpolation-filters' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
+amp4email_feature_tests/css_declarations.html:381:0 The property 'color-interpolation-filters' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
 |  <b style='color-interpolation: foo'></b>
 >> ^~~~~~~~~
-amp4email_feature_tests/css_declarations.html:381:0 The property 'color-interpolation' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
+amp4email_feature_tests/css_declarations.html:382:0 The property 'color-interpolation' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
 |  <b style='color-profile: foo'></b>
 >> ^~~~~~~~~
-amp4email_feature_tests/css_declarations.html:382:0 The property 'color-profile' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
+amp4email_feature_tests/css_declarations.html:383:0 The property 'color-profile' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
 |  <b style='color-rendering: foo'></b>
 >> ^~~~~~~~~
-amp4email_feature_tests/css_declarations.html:383:0 The property 'color-rendering' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
+amp4email_feature_tests/css_declarations.html:384:0 The property 'color-rendering' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
 |  <b style='color: foo'></b>
 |  <b style='column-count: foo'></b>
 |  <b style='column-fill: foo'></b>
@@ -417,20 +418,20 @@ amp4email_feature_tests/css_declarations.html:383:0 The property 'color-renderin
 |  <b style='display: foo'></b>
 |  <b style='dominant-baseline: foo'></b>
 >> ^~~~~~~~~
-amp4email_feature_tests/css_declarations.html:401:0 The property 'dominant-baseline' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
+amp4email_feature_tests/css_declarations.html:402:0 The property 'dominant-baseline' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
 |  <b style='empty-cells: foo'></b>
 |  <b style='enable-background: foo'></b>
 >> ^~~~~~~~~
-amp4email_feature_tests/css_declarations.html:403:0 The property 'enable-background' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
+amp4email_feature_tests/css_declarations.html:404:0 The property 'enable-background' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
 |  <b style='fill-opacity: foo'></b>
 >> ^~~~~~~~~
-amp4email_feature_tests/css_declarations.html:404:0 The property 'fill-opacity' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
+amp4email_feature_tests/css_declarations.html:405:0 The property 'fill-opacity' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
 |  <b style='fill-rule: foo'></b>
 >> ^~~~~~~~~
-amp4email_feature_tests/css_declarations.html:405:0 The property 'fill-rule' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
+amp4email_feature_tests/css_declarations.html:406:0 The property 'fill-rule' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
 |  <b style='fill: foo'></b>
 >> ^~~~~~~~~
-amp4email_feature_tests/css_declarations.html:406:0 The property 'fill' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
+amp4email_feature_tests/css_declarations.html:407:0 The property 'fill' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
 |  <b style='filter: foo'></b>
 |  <b style='flex-basis: foo'></b>
 |  <b style='flex-direction: foo'></b>
@@ -442,10 +443,10 @@ amp4email_feature_tests/css_declarations.html:406:0 The property 'fill' in attri
 |  <b style='float: foo'></b>
 |  <b style='flood-color: foo'></b>
 >> ^~~~~~~~~
-amp4email_feature_tests/css_declarations.html:416:0 The property 'flood-color' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
+amp4email_feature_tests/css_declarations.html:417:0 The property 'flood-color' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
 |  <b style='flood-opacity: foo'></b>
 >> ^~~~~~~~~
-amp4email_feature_tests/css_declarations.html:417:0 The property 'flood-opacity' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
+amp4email_feature_tests/css_declarations.html:418:0 The property 'flood-opacity' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
 |  <b style='font-family: foo'></b>
 |  <b style='font-feature-settings: foo'></b>
 |  <b style='font-kerning: foo'></b>
@@ -466,10 +467,10 @@ amp4email_feature_tests/css_declarations.html:417:0 The property 'flood-opacity'
 |  <b style='font: foo'></b>
 |  <b style='glyph-orientation-horizontal: foo'></b>
 >> ^~~~~~~~~
-amp4email_feature_tests/css_declarations.html:436:0 The property 'glyph-orientation-horizontal' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
+amp4email_feature_tests/css_declarations.html:437:0 The property 'glyph-orientation-horizontal' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
 |  <b style='glyph-orientation-vertical: foo'></b>
 >> ^~~~~~~~~
-amp4email_feature_tests/css_declarations.html:437:0 The property 'glyph-orientation-vertical' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
+amp4email_feature_tests/css_declarations.html:438:0 The property 'glyph-orientation-vertical' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
 |  <b style='grid-area: foo'></b>
 |  <b style='grid-auto-columns: foo'></b>
 |  <b style='grid-auto-flow: foo'></b>
@@ -496,12 +497,12 @@ amp4email_feature_tests/css_declarations.html:437:0 The property 'glyph-orientat
 |  <b style='justify-content: foo'></b>
 |  <b style='kerning: foo'></b>
 >> ^~~~~~~~~
-amp4email_feature_tests/css_declarations.html:462:0 The property 'kerning' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
+amp4email_feature_tests/css_declarations.html:463:0 The property 'kerning' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
 |  <b style='left: foo'></b>
 |  <b style='letter-spacing: foo'></b>
 |  <b style='lighting-color: foo'></b>
 >> ^~~~~~~~~
-amp4email_feature_tests/css_declarations.html:465:0 The property 'lighting-color' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
+amp4email_feature_tests/css_declarations.html:466:0 The property 'lighting-color' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
 |  <b style='line-break: foo'></b>
 |  <b style='line-height: foo'></b>
 |  <b style='list-style-image: foo'></b>
@@ -515,19 +516,19 @@ amp4email_feature_tests/css_declarations.html:465:0 The property 'lighting-color
 |  <b style='margin: foo'></b>
 |  <b style='marker-end: foo'></b>
 >> ^~~~~~~~~
-amp4email_feature_tests/css_declarations.html:477:0 The property 'marker-end' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
+amp4email_feature_tests/css_declarations.html:478:0 The property 'marker-end' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
 |  <b style='marker-mid: foo'></b>
 >> ^~~~~~~~~
-amp4email_feature_tests/css_declarations.html:478:0 The property 'marker-mid' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
+amp4email_feature_tests/css_declarations.html:479:0 The property 'marker-mid' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
 |  <b style='marker-start: foo'></b>
 >> ^~~~~~~~~
-amp4email_feature_tests/css_declarations.html:479:0 The property 'marker-start' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
+amp4email_feature_tests/css_declarations.html:480:0 The property 'marker-start' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
 |  <b style='marker: foo'></b>
 >> ^~~~~~~~~
-amp4email_feature_tests/css_declarations.html:480:0 The property 'marker' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
+amp4email_feature_tests/css_declarations.html:481:0 The property 'marker' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
 |  <b style='mask: foo'></b>
 >> ^~~~~~~~~
-amp4email_feature_tests/css_declarations.html:481:0 The property 'mask' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
+amp4email_feature_tests/css_declarations.html:482:0 The property 'mask' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
 |  <b style='max-height: foo'></b>
 |  <b style='max-width: foo'></b>
 |  <b style='min-height: foo'></b>
@@ -565,47 +566,48 @@ amp4email_feature_tests/css_declarations.html:481:0 The property 'mask' in attri
 |  <b style='right: foo'></b>
 |  <b style='shape-rendering: foo'></b>
 >> ^~~~~~~~~
-amp4email_feature_tests/css_declarations.html:517:0 The property 'shape-rendering' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
+amp4email_feature_tests/css_declarations.html:518:0 The property 'shape-rendering' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
 |  <b style='stop-color: foo'></b>
 >> ^~~~~~~~~
-amp4email_feature_tests/css_declarations.html:518:0 The property 'stop-color' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
+amp4email_feature_tests/css_declarations.html:519:0 The property 'stop-color' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
 |  <b style='stop-opacity: foo'></b>
 >> ^~~~~~~~~
-amp4email_feature_tests/css_declarations.html:519:0 The property 'stop-opacity' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
+amp4email_feature_tests/css_declarations.html:520:0 The property 'stop-opacity' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
 |  <b style='stroke-dasharray: foo'></b>
 >> ^~~~~~~~~
-amp4email_feature_tests/css_declarations.html:520:0 The property 'stroke-dasharray' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
+amp4email_feature_tests/css_declarations.html:521:0 The property 'stroke-dasharray' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
 |  <b style='stroke-dashoffset: foo'></b>
 >> ^~~~~~~~~
-amp4email_feature_tests/css_declarations.html:521:0 The property 'stroke-dashoffset' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
+amp4email_feature_tests/css_declarations.html:522:0 The property 'stroke-dashoffset' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
 |  <b style='stroke-linecap: foo'></b>
 >> ^~~~~~~~~
-amp4email_feature_tests/css_declarations.html:522:0 The property 'stroke-linecap' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
+amp4email_feature_tests/css_declarations.html:523:0 The property 'stroke-linecap' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
 |  <b style='stroke-linejoin: foo'></b>
 >> ^~~~~~~~~
-amp4email_feature_tests/css_declarations.html:523:0 The property 'stroke-linejoin' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
+amp4email_feature_tests/css_declarations.html:524:0 The property 'stroke-linejoin' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
 |  <b style='stroke-miterlimit: foo'></b>
 >> ^~~~~~~~~
-amp4email_feature_tests/css_declarations.html:524:0 The property 'stroke-miterlimit' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
+amp4email_feature_tests/css_declarations.html:525:0 The property 'stroke-miterlimit' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
 |  <b style='stroke-opacity: foo'></b>
 >> ^~~~~~~~~
-amp4email_feature_tests/css_declarations.html:525:0 The property 'stroke-opacity' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
+amp4email_feature_tests/css_declarations.html:526:0 The property 'stroke-opacity' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
 |  <b style='stroke-width: foo'></b>
 >> ^~~~~~~~~
-amp4email_feature_tests/css_declarations.html:526:0 The property 'stroke-width' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
+amp4email_feature_tests/css_declarations.html:527:0 The property 'stroke-width' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
 |  <b style='stroke: foo'></b>
 >> ^~~~~~~~~
-amp4email_feature_tests/css_declarations.html:527:0 The property 'stroke' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
+amp4email_feature_tests/css_declarations.html:528:0 The property 'stroke' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
 |  <b style='tab-size: foo'></b>
 |  <b style='table-layout: foo'></b>
 |  <b style='text-align-last: foo'></b>
 |  <b style='text-align: foo'></b>
 |  <b style='text-anchor: foo'></b>
 >> ^~~~~~~~~
-amp4email_feature_tests/css_declarations.html:532:0 The property 'text-anchor' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
+amp4email_feature_tests/css_declarations.html:533:0 The property 'text-anchor' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
 |  <b style='text-combine-upright: foo'></b>
 |  <b style='text-decoration-color: foo'></b>
 |  <b style='text-decoration-line: foo'></b>
+|  <b style='text-decoration-skip-ink: foo'></b>
 |  <b style='text-decoration-style: foo'></b>
 |  <b style='text-decoration: foo'></b>
 |  <b style='text-fill-color: foo'></b>
@@ -615,7 +617,7 @@ amp4email_feature_tests/css_declarations.html:532:0 The property 'text-anchor' i
 |  <b style='text-overflow: foo'></b>
 |  <b style='text-rendering: foo'></b>
 >> ^~~~~~~~~
-amp4email_feature_tests/css_declarations.html:543:0 The property 'text-rendering' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
+amp4email_feature_tests/css_declarations.html:545:0 The property 'text-rendering' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
 |  <b style='text-shadow: foo'></b>
 |  <b style='text-stroke-color: foo'></b>
 |  <b style='text-stroke-width: foo'></b>
@@ -646,13 +648,13 @@ amp4email_feature_tests/css_declarations.html:543:0 The property 'text-rendering
 |  <!-- Made-up decls -->
 |  <b style='amplitude: foo'></b>
 >> ^~~~~~~~~
-amp4email_feature_tests/css_declarations.html:572:0 The property 'amplitude' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
+amp4email_feature_tests/css_declarations.html:574:0 The property 'amplitude' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
 |  <b style='barometric-pressure: foo'></b>
 >> ^~~~~~~~~
-amp4email_feature_tests/css_declarations.html:573:0 The property 'barometric-pressure' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
+amp4email_feature_tests/css_declarations.html:575:0 The property 'barometric-pressure' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
 |  <b style='degrees-celsius: foo'></b>
 >> ^~~~~~~~~
-amp4email_feature_tests/css_declarations.html:574:0 The property 'degrees-celsius' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
+amp4email_feature_tests/css_declarations.html:576:0 The property 'degrees-celsius' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
 |  <!-- Vendor Prefix -->
 |  <b style="-webkit-user-select: foo;"></b>
 |  </body>

--- a/validator/testdata/feature_tests/css_declarations.html
+++ b/validator/testdata/feature_tests/css_declarations.html
@@ -260,6 +260,7 @@
       text-combine-upright: foo;
       text-decoration-color: foo;
       text-decoration-line: foo;
+      text-decoration-skip-ink: foo;
       text-decoration-style: foo;
       text-decoration: foo;
       text-fill-color: foo;
@@ -536,6 +537,7 @@
 <b style='text-combine-upright: foo'></b>
 <b style='text-decoration-color: foo'></b>
 <b style='text-decoration-line: foo'></b>
+<b style='text-decoration-skip-ink: foo'></b>
 <b style='text-decoration-style: foo'></b>
 <b style='text-decoration: foo'></b>
 <b style='text-fill-color: foo'></b>
@@ -808,6 +810,7 @@
   <path style='text-combine-upright: foo'></path>
   <path style='text-decoration-color: foo'></path>
   <path style='text-decoration-line: foo'></path>
+  <path style='text-decoration-skip-ink: foo'></b>
   <path style='text-decoration-style: foo'></path>
   <path style='text-decoration: foo'></path>
   <path style='text-fill-color: foo'></path>

--- a/validator/testdata/feature_tests/css_declarations.out
+++ b/validator/testdata/feature_tests/css_declarations.out
@@ -261,6 +261,7 @@ FAIL
 |        text-combine-upright: foo;
 |        text-decoration-color: foo;
 |        text-decoration-line: foo;
+|        text-decoration-skip-ink: foo;
 |        text-decoration-style: foo;
 |        text-decoration: foo;
 |        text-fill-color: foo;
@@ -314,7 +315,7 @@ FAIL
 |  <b style='align-self: foo'></b>
 |  <b style='alignment-baseline: foo'></b>
 >> ^~~~~~~~~
-feature_tests/css_declarations.html:314:0 The property 'alignment-baseline' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
+feature_tests/css_declarations.html:315:0 The property 'alignment-baseline' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
 |  <b style='all: foo'></b>
 |  <b style='animation-delay: foo'></b>
 |  <b style='animation-direction: foo'></b>
@@ -338,7 +339,7 @@ feature_tests/css_declarations.html:314:0 The property 'alignment-baseline' in a
 |  <b style='background: foo'></b>
 |  <b style='baseline-shift: foo'></b>
 >> ^~~~~~~~~
-feature_tests/css_declarations.html:336:0 The property 'baseline-shift' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
+feature_tests/css_declarations.html:337:0 The property 'baseline-shift' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
 |  <b style='border-bottom-color: foo'></b>
 |  <b style='border-bottom-left-radius: foo'></b>
 |  <b style='border-bottom-right-radius: foo'></b>
@@ -385,20 +386,20 @@ feature_tests/css_declarations.html:336:0 The property 'baseline-shift' in attri
 |  <b style='clip-path: foo'></b>
 |  <b style='clip-rule: foo'></b>
 >> ^~~~~~~~~
-feature_tests/css_declarations.html:381:0 The property 'clip-rule' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
+feature_tests/css_declarations.html:382:0 The property 'clip-rule' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
 |  <b style='clip: foo'></b>
 |  <b style='color-interpolation-filters: foo'></b>
 >> ^~~~~~~~~
-feature_tests/css_declarations.html:383:0 The property 'color-interpolation-filters' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
+feature_tests/css_declarations.html:384:0 The property 'color-interpolation-filters' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
 |  <b style='color-interpolation: foo'></b>
 >> ^~~~~~~~~
-feature_tests/css_declarations.html:384:0 The property 'color-interpolation' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
+feature_tests/css_declarations.html:385:0 The property 'color-interpolation' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
 |  <b style='color-profile: foo'></b>
 >> ^~~~~~~~~
-feature_tests/css_declarations.html:385:0 The property 'color-profile' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
+feature_tests/css_declarations.html:386:0 The property 'color-profile' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
 |  <b style='color-rendering: foo'></b>
 >> ^~~~~~~~~
-feature_tests/css_declarations.html:386:0 The property 'color-rendering' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
+feature_tests/css_declarations.html:387:0 The property 'color-rendering' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
 |  <b style='color: foo'></b>
 |  <b style='column-count: foo'></b>
 |  <b style='column-fill: foo'></b>
@@ -418,20 +419,20 @@ feature_tests/css_declarations.html:386:0 The property 'color-rendering' in attr
 |  <b style='display: foo'></b>
 |  <b style='dominant-baseline: foo'></b>
 >> ^~~~~~~~~
-feature_tests/css_declarations.html:404:0 The property 'dominant-baseline' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
+feature_tests/css_declarations.html:405:0 The property 'dominant-baseline' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
 |  <b style='empty-cells: foo'></b>
 |  <b style='enable-background: foo'></b>
 >> ^~~~~~~~~
-feature_tests/css_declarations.html:406:0 The property 'enable-background' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
+feature_tests/css_declarations.html:407:0 The property 'enable-background' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
 |  <b style='fill-opacity: foo'></b>
 >> ^~~~~~~~~
-feature_tests/css_declarations.html:407:0 The property 'fill-opacity' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
+feature_tests/css_declarations.html:408:0 The property 'fill-opacity' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
 |  <b style='fill-rule: foo'></b>
 >> ^~~~~~~~~
-feature_tests/css_declarations.html:408:0 The property 'fill-rule' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
+feature_tests/css_declarations.html:409:0 The property 'fill-rule' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
 |  <b style='fill: foo'></b>
 >> ^~~~~~~~~
-feature_tests/css_declarations.html:409:0 The property 'fill' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
+feature_tests/css_declarations.html:410:0 The property 'fill' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
 |  <b style='filter: foo'></b>
 |  <b style='flex-basis: foo'></b>
 |  <b style='flex-direction: foo'></b>
@@ -443,10 +444,10 @@ feature_tests/css_declarations.html:409:0 The property 'fill' in attribute 'styl
 |  <b style='float: foo'></b>
 |  <b style='flood-color: foo'></b>
 >> ^~~~~~~~~
-feature_tests/css_declarations.html:419:0 The property 'flood-color' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
+feature_tests/css_declarations.html:420:0 The property 'flood-color' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
 |  <b style='flood-opacity: foo'></b>
 >> ^~~~~~~~~
-feature_tests/css_declarations.html:420:0 The property 'flood-opacity' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
+feature_tests/css_declarations.html:421:0 The property 'flood-opacity' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
 |  <b style='font-family: foo'></b>
 |  <b style='font-feature-settings: foo'></b>
 |  <b style='font-kerning: foo'></b>
@@ -467,10 +468,10 @@ feature_tests/css_declarations.html:420:0 The property 'flood-opacity' in attrib
 |  <b style='font: foo'></b>
 |  <b style='glyph-orientation-horizontal: foo'></b>
 >> ^~~~~~~~~
-feature_tests/css_declarations.html:439:0 The property 'glyph-orientation-horizontal' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
+feature_tests/css_declarations.html:440:0 The property 'glyph-orientation-horizontal' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
 |  <b style='glyph-orientation-vertical: foo'></b>
 >> ^~~~~~~~~
-feature_tests/css_declarations.html:440:0 The property 'glyph-orientation-vertical' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
+feature_tests/css_declarations.html:441:0 The property 'glyph-orientation-vertical' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
 |  <b style='grid-area: foo'></b>
 |  <b style='grid-auto-columns: foo'></b>
 |  <b style='grid-auto-flow: foo'></b>
@@ -497,12 +498,12 @@ feature_tests/css_declarations.html:440:0 The property 'glyph-orientation-vertic
 |  <b style='justify-content: foo'></b>
 |  <b style='kerning: foo'></b>
 >> ^~~~~~~~~
-feature_tests/css_declarations.html:465:0 The property 'kerning' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
+feature_tests/css_declarations.html:466:0 The property 'kerning' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
 |  <b style='left: foo'></b>
 |  <b style='letter-spacing: foo'></b>
 |  <b style='lighting-color: foo'></b>
 >> ^~~~~~~~~
-feature_tests/css_declarations.html:468:0 The property 'lighting-color' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
+feature_tests/css_declarations.html:469:0 The property 'lighting-color' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
 |  <b style='line-break: foo'></b>
 |  <b style='line-height: foo'></b>
 |  <b style='list-style-image: foo'></b>
@@ -516,19 +517,19 @@ feature_tests/css_declarations.html:468:0 The property 'lighting-color' in attri
 |  <b style='margin: foo'></b>
 |  <b style='marker-end: foo'></b>
 >> ^~~~~~~~~
-feature_tests/css_declarations.html:480:0 The property 'marker-end' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
+feature_tests/css_declarations.html:481:0 The property 'marker-end' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
 |  <b style='marker-mid: foo'></b>
 >> ^~~~~~~~~
-feature_tests/css_declarations.html:481:0 The property 'marker-mid' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
+feature_tests/css_declarations.html:482:0 The property 'marker-mid' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
 |  <b style='marker-start: foo'></b>
 >> ^~~~~~~~~
-feature_tests/css_declarations.html:482:0 The property 'marker-start' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
+feature_tests/css_declarations.html:483:0 The property 'marker-start' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
 |  <b style='marker: foo'></b>
 >> ^~~~~~~~~
-feature_tests/css_declarations.html:483:0 The property 'marker' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
+feature_tests/css_declarations.html:484:0 The property 'marker' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
 |  <b style='mask: foo'></b>
 >> ^~~~~~~~~
-feature_tests/css_declarations.html:484:0 The property 'mask' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
+feature_tests/css_declarations.html:485:0 The property 'mask' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
 |  <b style='max-height: foo'></b>
 |  <b style='max-width: foo'></b>
 |  <b style='min-height: foo'></b>
@@ -566,47 +567,48 @@ feature_tests/css_declarations.html:484:0 The property 'mask' in attribute 'styl
 |  <b style='right: foo'></b>
 |  <b style='shape-rendering: foo'></b>
 >> ^~~~~~~~~
-feature_tests/css_declarations.html:520:0 The property 'shape-rendering' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
+feature_tests/css_declarations.html:521:0 The property 'shape-rendering' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
 |  <b style='stop-color: foo'></b>
 >> ^~~~~~~~~
-feature_tests/css_declarations.html:521:0 The property 'stop-color' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
+feature_tests/css_declarations.html:522:0 The property 'stop-color' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
 |  <b style='stop-opacity: foo'></b>
 >> ^~~~~~~~~
-feature_tests/css_declarations.html:522:0 The property 'stop-opacity' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
+feature_tests/css_declarations.html:523:0 The property 'stop-opacity' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
 |  <b style='stroke-dasharray: foo'></b>
 >> ^~~~~~~~~
-feature_tests/css_declarations.html:523:0 The property 'stroke-dasharray' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
+feature_tests/css_declarations.html:524:0 The property 'stroke-dasharray' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
 |  <b style='stroke-dashoffset: foo'></b>
 >> ^~~~~~~~~
-feature_tests/css_declarations.html:524:0 The property 'stroke-dashoffset' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
+feature_tests/css_declarations.html:525:0 The property 'stroke-dashoffset' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
 |  <b style='stroke-linecap: foo'></b>
 >> ^~~~~~~~~
-feature_tests/css_declarations.html:525:0 The property 'stroke-linecap' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
+feature_tests/css_declarations.html:526:0 The property 'stroke-linecap' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
 |  <b style='stroke-linejoin: foo'></b>
 >> ^~~~~~~~~
-feature_tests/css_declarations.html:526:0 The property 'stroke-linejoin' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
+feature_tests/css_declarations.html:527:0 The property 'stroke-linejoin' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
 |  <b style='stroke-miterlimit: foo'></b>
 >> ^~~~~~~~~
-feature_tests/css_declarations.html:527:0 The property 'stroke-miterlimit' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
+feature_tests/css_declarations.html:528:0 The property 'stroke-miterlimit' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
 |  <b style='stroke-opacity: foo'></b>
 >> ^~~~~~~~~
-feature_tests/css_declarations.html:528:0 The property 'stroke-opacity' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
+feature_tests/css_declarations.html:529:0 The property 'stroke-opacity' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
 |  <b style='stroke-width: foo'></b>
 >> ^~~~~~~~~
-feature_tests/css_declarations.html:529:0 The property 'stroke-width' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
+feature_tests/css_declarations.html:530:0 The property 'stroke-width' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
 |  <b style='stroke: foo'></b>
 >> ^~~~~~~~~
-feature_tests/css_declarations.html:530:0 The property 'stroke' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
+feature_tests/css_declarations.html:531:0 The property 'stroke' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
 |  <b style='tab-size: foo'></b>
 |  <b style='table-layout: foo'></b>
 |  <b style='text-align-last: foo'></b>
 |  <b style='text-align: foo'></b>
 |  <b style='text-anchor: foo'></b>
 >> ^~~~~~~~~
-feature_tests/css_declarations.html:535:0 The property 'text-anchor' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
+feature_tests/css_declarations.html:536:0 The property 'text-anchor' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
 |  <b style='text-combine-upright: foo'></b>
 |  <b style='text-decoration-color: foo'></b>
 |  <b style='text-decoration-line: foo'></b>
+|  <b style='text-decoration-skip-ink: foo'></b>
 |  <b style='text-decoration-style: foo'></b>
 |  <b style='text-decoration: foo'></b>
 |  <b style='text-fill-color: foo'></b>
@@ -616,7 +618,7 @@ feature_tests/css_declarations.html:535:0 The property 'text-anchor' in attribut
 |  <b style='text-overflow: foo'></b>
 |  <b style='text-rendering: foo'></b>
 >> ^~~~~~~~~
-feature_tests/css_declarations.html:546:0 The property 'text-rendering' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
+feature_tests/css_declarations.html:548:0 The property 'text-rendering' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
 |  <b style='text-shadow: foo'></b>
 |  <b style='text-stroke-color: foo'></b>
 |  <b style='text-stroke-width: foo'></b>
@@ -647,13 +649,13 @@ feature_tests/css_declarations.html:546:0 The property 'text-rendering' in attri
 |  <!-- Made-up decls -->
 |  <b style='amplitude: foo'></b>
 >> ^~~~~~~~~
-feature_tests/css_declarations.html:575:0 The property 'amplitude' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
+feature_tests/css_declarations.html:577:0 The property 'amplitude' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
 |  <b style='barometric-pressure: foo'></b>
 >> ^~~~~~~~~
-feature_tests/css_declarations.html:576:0 The property 'barometric-pressure' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
+feature_tests/css_declarations.html:578:0 The property 'barometric-pressure' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
 |  <b style='degrees-celsius: foo'></b>
 >> ^~~~~~~~~
-feature_tests/css_declarations.html:577:0 The property 'degrees-celsius' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
+feature_tests/css_declarations.html:579:0 The property 'degrees-celsius' in attribute 'style' in tag 'b' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
 |  <!-- Vendor Prefix -->
 |  <b style="-webkit-user-select: foo;"></b>
 |
@@ -887,6 +889,7 @@ feature_tests/css_declarations.html:577:0 The property 'degrees-celsius' in attr
 |    <path style='text-combine-upright: foo'></path>
 |    <path style='text-decoration-color: foo'></path>
 |    <path style='text-decoration-line: foo'></path>
+|    <path style='text-decoration-skip-ink: foo'></b>
 |    <path style='text-decoration-style: foo'></path>
 |    <path style='text-decoration: foo'></path>
 |    <path style='text-fill-color: foo'></path>
@@ -925,13 +928,13 @@ feature_tests/css_declarations.html:577:0 The property 'degrees-celsius' in attr
 |    <!-- Made-up decls -->
 |    <path style='amplitude: foo'></path>
 >>   ^~~~~~~~~
-feature_tests/css_declarations.html:847:2 The property 'amplitude' in attribute 'style' in tag 'path' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
+feature_tests/css_declarations.html:850:2 The property 'amplitude' in attribute 'style' in tag 'path' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
 |    <path style='barometric-pressure: foo'></path>
 >>   ^~~~~~~~~
-feature_tests/css_declarations.html:848:2 The property 'barometric-pressure' in attribute 'style' in tag 'path' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
+feature_tests/css_declarations.html:851:2 The property 'barometric-pressure' in attribute 'style' in tag 'path' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
 |    <path style='degrees-celsius: foo'></path>
 >>   ^~~~~~~~~
-feature_tests/css_declarations.html:849:2 The property 'degrees-celsius' in attribute 'style' in tag 'path' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
+feature_tests/css_declarations.html:852:2 The property 'degrees-celsius' in attribute 'style' in tag 'path' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages)
 |    <!-- Vendor Prefix -->
 |    <path style="-webkit-user-select: foo;"></b>
 |  </svg>

--- a/validator/testdata/feature_tests/regexps.html
+++ b/validator/testdata/feature_tests/regexps.html
@@ -48,7 +48,7 @@
 
   <!--
   href value_regex: "https://fonts\\.googleapis\\.com/css2?\\?.*|https://fast\\.fonts\\.net/.*"
-  The first three examples are valid, the third example is invalid.
+  The first three examples are valid, the fourth example is invalid.
   -->
   <link rel="stylesheet" type="text/css"
         href="https://fonts.googleapis.com/css?foobar">

--- a/validator/testdata/feature_tests/regexps.out
+++ b/validator/testdata/feature_tests/regexps.out
@@ -59,7 +59,7 @@ feature_tests/regexps.html:46:2 The attribute 'href' in tag 'link rel=stylesheet
 |
 |    <!--
 |    href value_regex: "https://fonts\\.googleapis\\.com/css2?\\?.*|https://fast\\.fonts\\.net/.*"
-|    The first three examples are valid, the third example is invalid.
+|    The first three examples are valid, the fourth example is invalid.
 |    -->
 |    <link rel="stylesheet" type="text/css"
 |          href="https://fonts.googleapis.com/css?foobar">

--- a/validator/validator-css.protoascii
+++ b/validator/validator-css.protoascii
@@ -217,6 +217,7 @@ declaration_list {
   declaration: { name: "text-decoration" }
   declaration: { name: "text-decoration-color" }
   declaration: { name: "text-decoration-line" }
+  declaration: { name: "text-decoration-skip-ink" }
   declaration: { name: "text-decoration-style" }
   declaration: { name: "text-fill-color" }
   declaration: { name: "text-indent" }

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -26,7 +26,7 @@ min_validator_revision_required: 455
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 1043
+spec_file_revision: 1044
 
 styles_spec_url: "https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages"
 script_spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags"

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -26,7 +26,7 @@ min_validator_revision_required: 455
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 1044
+spec_file_revision: 1045
 
 styles_spec_url: "https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages"
 script_spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags"


### PR DESCRIPTION
Changelog (copied to clipboard):
 - cl/309498692 text-decoration-skip-ink CSS property to be allowed in inline styles
 - cl/308922441 Fix a comment.