### PR TITLE
🏗 Reduce coverage threshold for `codecov` check

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -7,7 +7,7 @@ codecov:
   max_report_age: 24
   require_ci_to_pass: yes
   notify:
-    wait_for_ci: yes
+    wait_for_ci: no
 
 # Pull request comments disabled because they were too noisy
 # See https://docs.codecov.io/docs/pull-request-comments
@@ -18,19 +18,19 @@ comment: false
 coverage:
   precision: 2
   round: down
-  range: '80...100'
+  range: '75...100'
   status:
     project:
       default:
         base: auto
         if_not_found: success
         only_pulls: true
-        target: 80%
+        target: 75%
         threshold: 1%
     patch:
       default:
         base: auto
         if_not_found: success
         only_pulls: true
-        target: 80%
+        target: 75%
         threshold: 1%

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -5,7 +5,7 @@ codecov:
   ci:
     - 'travis.org'
   max_report_age: 24
-  require_ci_to_pass: yes
+  require_ci_to_pass: no
   notify:
     wait_for_ci: no
 

--- a/build-system/pr-check/local-tests.js
+++ b/build-system/pr-check/local-tests.js
@@ -83,7 +83,12 @@ function main() {
       timedExecOrDie('gulp unit --nobuild --headless --coverage');
     }
 
-    if (buildTargets.has('RUNTIME')) {
+    if (
+      buildTargets.has('RUNTIME') ||
+      buildTargets.has('FLAG_CONFIG') ||
+      buildTargets.has('INTEGRATION_TEST') ||
+      buildTargets.has('UNIT_TEST')
+    ) {
       timedExecOrDie('gulp codecov-upload');
     }
   }

--- a/build-system/pr-check/local-tests.js
+++ b/build-system/pr-check/local-tests.js
@@ -83,12 +83,7 @@ function main() {
       timedExecOrDie('gulp unit --nobuild --headless --coverage');
     }
 
-    if (
-      buildTargets.has('RUNTIME') ||
-      buildTargets.has('FLAG_CONFIG') ||
-      buildTargets.has('INTEGRATION_TEST') ||
-      buildTargets.has('UNIT_TEST')
-    ) {
+    if (buildTargets.has('RUNTIME')) {
       timedExecOrDie('gulp codecov-upload');
     }
   }


### PR DESCRIPTION
**Background:**

- There appears to be a problem with our `codecov` check, where it reports incorrect coverage levels for PRs from old branches: https://github.com/ampproject/amphtml/issues/28212#issuecomment-624286549
- In addition, there doesn't seem to be a straightforward way to override the baseline for comparisons: https://github.com/ampproject/amphtml/issues/28212#issuecomment-624326511 and https://github.com/codecov/codecov-bash/issues/83#issuecomment-606674059
- Meanwhile, it appears that the total project-level coverage was reduced from 80.5% to ~76-77% by https://github.com/ampproject/amphtml/commit/f26a825a35711b834d01165666f59e1d11f1b879. (It's currently unknown why this was so.)

**PR highlights:**

This PR makes a few changes to temporarily work around the issues described above and to enable better debugging:

- Reduce project-level threshold from 80% to 75%
- Apply coverage status immediately after the coverage report is uploaded (don't wait for entire Travis build to complete)
- Don't require entire CI build to pass

**Future work:**

Continue debugging and figure out if there's a workaround for `codecov` issue https://github.com/codecov/codecov-bash/issues/83#issuecomment-606674059, and consider using a different service if this continues to be a dealbreaker.

Related to #28212