### PR TITLE
Register localization from amp-story

### DIFF
--- a/build-system/test-configs/dep-check-config.js
+++ b/build-system/test-configs/dep-check-config.js
@@ -243,6 +243,7 @@ exports.rules = [
       'extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js->extensions/amp-story/1.0/amp-story-store-service.js',
       'extensions/amp-story-auto-ads/0.1/story-ad-page.js->extensions/amp-story/1.0/amp-story-store-service.js',
       'extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js->extensions/amp-story/1.0/events.js',
+      'extensions/amp-story-auto-ads/0.1/story-ad-localization.js->extensions/amp-story/1.0/amp-story.js',
       // TODO(#24080) Remove this when story ads have full ad network support.
       'extensions/amp-story-auto-ads/0.1/story-ad-page.js->extensions/amp-ad-exit/0.1/config.js',
       // TODO(ccordry): remove this after createShadowRootWithStyle is moved to src
@@ -251,6 +252,7 @@ exports.rules = [
       // Story education
       'extensions/amp-story-education/0.1/amp-story-education.js->extensions/amp-story/1.0/amp-story-store-service.js',
       'extensions/amp-story-education/0.1/amp-story-education.js->extensions/amp-story/1.0/utils.js',
+      'extensions/amp-story-education/0.1/amp-story-education.js->extensions/amp-story/1.0/amp-story.js',
 
       // Subscriptions.
       'extensions/amp-subscriptions/0.1/expr.js->extensions/amp-access/0.1/access-expr.js',

--- a/build-system/test-configs/dep-check-config.js
+++ b/build-system/test-configs/dep-check-config.js
@@ -363,6 +363,9 @@ exports.rules = [
       // For action macros.
       'extensions/amp-link-rewriter/0.1/amp-link-rewriter.js->' +
         'src/service/navigation.js',
+      // For localization.
+      'extensions/amp-story/0.1/amp-story.js->src/service/localization.js',
+      'extensions/amp-story/1.0/amp-story.js->src/service/localization.js',
       // Accessing calculateScriptBaseUrl() for vendor config URLs
       'extensions/amp-analytics/0.1/config.js->' +
         'src/service/extension-location.js',

--- a/build-system/test-configs/dep-check-config.js
+++ b/build-system/test-configs/dep-check-config.js
@@ -243,7 +243,6 @@ exports.rules = [
       'extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js->extensions/amp-story/1.0/amp-story-store-service.js',
       'extensions/amp-story-auto-ads/0.1/story-ad-page.js->extensions/amp-story/1.0/amp-story-store-service.js',
       'extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js->extensions/amp-story/1.0/events.js',
-      'extensions/amp-story-auto-ads/0.1/story-ad-localization.js->extensions/amp-story/1.0/amp-story.js',
       // TODO(#24080) Remove this when story ads have full ad network support.
       'extensions/amp-story-auto-ads/0.1/story-ad-page.js->extensions/amp-ad-exit/0.1/config.js',
       // TODO(ccordry): remove this after createShadowRootWithStyle is moved to src
@@ -252,7 +251,7 @@ exports.rules = [
       // Story education
       'extensions/amp-story-education/0.1/amp-story-education.js->extensions/amp-story/1.0/amp-story-store-service.js',
       'extensions/amp-story-education/0.1/amp-story-education.js->extensions/amp-story/1.0/utils.js',
-      'extensions/amp-story-education/0.1/amp-story-education.js->extensions/amp-story/1.0/amp-story.js',
+      'extensions/amp-story-education/0.1/amp-story-education.js->extensions/amp-story/1.0/amp-story-localization-service.js',
 
       // Subscriptions.
       'extensions/amp-subscriptions/0.1/expr.js->extensions/amp-access/0.1/access-expr.js',
@@ -366,8 +365,9 @@ exports.rules = [
       'extensions/amp-link-rewriter/0.1/amp-link-rewriter.js->' +
         'src/service/navigation.js',
       // For localization.
-      'extensions/amp-story/0.1/amp-story.js->src/service/localization.js',
-      'extensions/amp-story/1.0/amp-story.js->src/service/localization.js',
+      'extensions/amp-story/0.1/amp-story-localization-service.js->src/service/localization.js',
+      'extensions/amp-story/1.0/amp-story-localization-service.js->src/service/localization.js',
+      'extensions/amp-story-auto-ads/0.1/story-ad-localization.js->src/service/localization.js',
       // Accessing calculateScriptBaseUrl() for vendor config URLs
       'extensions/amp-analytics/0.1/config.js->' +
         'src/service/extension-location.js',

--- a/extensions/amp-story-auto-ads/0.1/story-ad-localization.js
+++ b/extensions/amp-story-auto-ads/0.1/story-ad-localization.js
@@ -18,7 +18,7 @@ import {
   LocalizedStringId,
   createPseudoLocale,
 } from '../../../src/localized-strings';
-import {Services} from '../../../src/services';
+import {getLocalizationService} from '../../amp-story/1.0/amp-story';
 import LocalizedStringsAr from './_locales/ar';
 import LocalizedStringsDe from './_locales/de';
 import LocalizedStringsEn from './_locales/en';
@@ -95,9 +95,7 @@ export class StoryAdLocalization {
    * Create localization service and register all bundles.
    */
   init_() {
-    this.localizationService_ = Services.localizationForDoc(
-      this.storyAutoAdsEl_
-    );
+    this.localizationService_ = getLocalizationService(this.storyAutoAdsEl_);
 
     const enXaPseudoLocaleBundle = createPseudoLocale(
       LocalizedStringsEn,

--- a/extensions/amp-story-auto-ads/0.1/story-ad-localization.js
+++ b/extensions/amp-story-auto-ads/0.1/story-ad-localization.js
@@ -14,11 +14,13 @@
  * limitations under the License.
  */
 
+import {LocalizationService} from '../../../src/service/localization';
 import {
   LocalizedStringId,
   createPseudoLocale,
 } from '../../../src/localized-strings';
-import {getLocalizationService} from '../../amp-story/1.0/amp-story';
+import {Services} from '../../../src/services';
+import {registerServiceBuilderForDoc} from '../../../src/service';
 import LocalizedStringsAr from './_locales/ar';
 import LocalizedStringsDe from './_locales/de';
 import LocalizedStringsEn from './_locales/en';
@@ -67,6 +69,25 @@ export const CtaTypes = {
   WATCH: LocalizedStringId.AMP_STORY_AUTO_ADS_BUTTON_LABEL_WATCH,
   WATCH_EPISODE:
     LocalizedStringId.AMP_STORY_AUTO_ADS_BUTTON_LABEL_WATCH_EPISODE,
+};
+
+/**
+ * Util function to retrieve the localization service. Ensures we can retrieve
+ * the service synchronously without running into race conditions.
+ * @param {!Element} element
+ * @return {!../../../src/service/localization.LocalizationService}
+ */
+const getLocalizationService = (element) => {
+  let localizationService = Services.localizationForDoc(element);
+
+  if (!localizationService) {
+    localizationService = new LocalizationService(element);
+    registerServiceBuilderForDoc(element, 'localization', function () {
+      return localizationService;
+    });
+  }
+
+  return localizationService;
 };
 
 export class StoryAdLocalization {

--- a/extensions/amp-story-auto-ads/0.1/test/test-amp-story-auto-ads.js
+++ b/extensions/amp-story-auto-ads/0.1/test/test-amp-story-auto-ads.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import * as Service from '../../../../src/service';
 import * as storyEvents from '../../../amp-story/1.0/events';
 import {
   Action,
@@ -24,6 +25,7 @@ import {
 import {AmpStory} from '../../../amp-story/1.0/amp-story';
 import {AmpStoryAutoAds, Attributes} from '../amp-story-auto-ads';
 import {CommonSignals} from '../../../../src/common-signals';
+import {LocalizationService} from '../../../../src/service/localization';
 import {
   MockStoryImpl,
   addStoryAutoAdsConfig,
@@ -58,9 +60,8 @@ describes.realWin(
     beforeEach(() => {
       win = env.win;
       doc = win.document;
-      const localizationService = Services.localizationForDoc(
-        win.document.body
-      );
+      const localizationService = new LocalizationService(win.document.body);
+      env.sandbox.stub(Service, 'registerServiceBuilderForDoc');
       env.sandbox
         .stub(Services, 'localizationForDoc')
         .returns(localizationService);

--- a/extensions/amp-story-auto-ads/0.1/test/test-amp-story-auto-ads.js
+++ b/extensions/amp-story-auto-ads/0.1/test/test-amp-story-auto-ads.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as Service from '../../../../src/service';
 import * as storyEvents from '../../../amp-story/1.0/events';
 import {
   Action,
@@ -61,7 +60,6 @@ describes.realWin(
       win = env.win;
       doc = win.document;
       const localizationService = new LocalizationService(win.document.body);
-      env.sandbox.stub(Service, 'registerServiceBuilderForDoc');
       env.sandbox
         .stub(Services, 'localizationForDoc')
         .returns(localizationService);

--- a/extensions/amp-story-education/0.1/amp-story-education.js
+++ b/extensions/amp-story-education/0.1/amp-story-education.js
@@ -26,6 +26,7 @@ import {Services} from '../../../src/services';
 import {createShadowRootWithStyle} from '../../amp-story/1.0/utils';
 import {dev} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
+import {getLocalizationService} from '../../amp-story/1.0/amp-story';
 import {htmlFor} from '../../../src/static-template';
 import {removeChildren} from '../../../src/dom';
 import {toggle} from '../../../src/style';
@@ -75,7 +76,7 @@ export class AmpStoryEducation extends AMP.BaseElement {
     this.containerEl_ = this.win.document.createElement('div');
 
     /** @private @const {!../../../src/service/localization.LocalizationService} */
-    this.localizationService_ = Services.localizationForDoc(element);
+    this.localizationService_ = getLocalizationService(element);
 
     /** @private {?boolean} */
     this.storyPausedStateToRestore_ = null;

--- a/extensions/amp-story-education/0.1/amp-story-education.js
+++ b/extensions/amp-story-education/0.1/amp-story-education.js
@@ -26,7 +26,7 @@ import {Services} from '../../../src/services';
 import {createShadowRootWithStyle} from '../../amp-story/1.0/utils';
 import {dev} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
-import {getLocalizationService} from '../../amp-story/1.0/amp-story';
+import {getLocalizationService} from '../../amp-story/1.0/amp-story-localization-service';
 import {htmlFor} from '../../../src/static-template';
 import {removeChildren} from '../../../src/dom';
 import {toggle} from '../../../src/style';

--- a/extensions/amp-story-education/0.1/test/test-amp-story-education.js
+++ b/extensions/amp-story-education/0.1/test/test-amp-story-education.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import * as Service from '../../../../src/service';
 import {
   Action,
   AmpStoryStoreService,
@@ -21,6 +22,7 @@ import {
 } from '../../../amp-story/1.0/amp-story-store-service';
 import {AmpDocSingle} from '../../../../src/service/ampdoc-impl';
 import {AmpStoryEducation, State} from '../amp-story-education';
+import {LocalizationService} from '../../../../src/service/localization';
 import {Services} from '../../../../src/services';
 import {registerServiceBuilder} from '../../../../src/service';
 
@@ -34,6 +36,12 @@ describes.realWin('amp-story-education', {amp: true}, (env) => {
 
   beforeEach(() => {
     win = env.win;
+
+    const localizationService = new LocalizationService(win.document.body);
+    env.sandbox.stub(Service, 'registerServiceBuilderForDoc');
+    env.sandbox
+      .stub(Services, 'localizationForDoc')
+      .returns(localizationService);
 
     storeService = new AmpStoryStoreService(win);
     registerServiceBuilder(win, 'story-store', function () {

--- a/extensions/amp-story-education/0.1/test/test-amp-story-education.js
+++ b/extensions/amp-story-education/0.1/test/test-amp-story-education.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as Service from '../../../../src/service';
 import {
   Action,
   AmpStoryStoreService,
@@ -38,7 +37,6 @@ describes.realWin('amp-story-education', {amp: true}, (env) => {
     win = env.win;
 
     const localizationService = new LocalizationService(win.document.body);
-    env.sandbox.stub(Service, 'registerServiceBuilderForDoc');
     env.sandbox
       .stub(Services, 'localizationForDoc')
       .returns(localizationService);

--- a/extensions/amp-story/0.1/amp-story-info-dialog.js
+++ b/extensions/amp-story/0.1/amp-story-info-dialog.js
@@ -23,6 +23,7 @@ import {closest} from '../../../src/dom';
 import {createShadowRootWithStyle} from './utils';
 import {dev} from '../../../src/log';
 import {getAmpdoc} from '../../../src/service';
+import {getLocalizationService} from './amp-story';
 import {htmlFor} from '../../../src/static-template';
 
 /** @const {string} Class to toggle the info dialog. */
@@ -55,7 +56,7 @@ export class InfoDialog {
     this.isBuilt_ = false;
 
     /** @private @const {!../../../src/service/localization.LocalizationService} */
-    this.localizationService_ = Services.localizationForDoc(parentEl);
+    this.localizationService_ = getLocalizationService(parentEl);
 
     /** @private @const {!./amp-story-store-service.AmpStoryStoreService} */
     this.storeService_ = Services.storyStoreServiceV01(this.win_);

--- a/extensions/amp-story/0.1/amp-story-info-dialog.js
+++ b/extensions/amp-story/0.1/amp-story-info-dialog.js
@@ -23,7 +23,7 @@ import {closest} from '../../../src/dom';
 import {createShadowRootWithStyle} from './utils';
 import {dev} from '../../../src/log';
 import {getAmpdoc} from '../../../src/service';
-import {getLocalizationService} from './amp-story';
+import {getLocalizationService} from './amp-story-localization-service';
 import {htmlFor} from '../../../src/static-template';
 
 /** @const {string} Class to toggle the info dialog. */

--- a/extensions/amp-story/0.1/amp-story-localization-service.js
+++ b/extensions/amp-story/0.1/amp-story-localization-service.js
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {LocalizationService} from '../../../src/service/localization';
+import {Services} from '../../../src/services';
+import {registerServiceBuilderForDoc} from '../../../src/service';
+
+/**
+ * Util function to retrieve the localization service. Ensures we can retrieve
+ * the service synchronously from the amp-story codebase without running into
+ * race conditions.
+ * @param {!Element} element
+ * @return {!../../../src/service/localization.LocalizationService}
+ */
+export const getLocalizationService = (element) => {
+  let localizationService = Services.localizationForDoc(element);
+
+  if (!localizationService) {
+    localizationService = new LocalizationService(element);
+    registerServiceBuilderForDoc(element, 'localization', function () {
+      return localizationService;
+    });
+  }
+
+  return localizationService;
+};

--- a/extensions/amp-story/0.1/amp-story-share.js
+++ b/extensions/amp-story/0.1/amp-story-share.js
@@ -22,6 +22,7 @@ import {
 } from '../../../src/clipboard';
 import {dev, devAssert, user} from '../../../src/log';
 import {dict, map} from './../../../src/utils/object';
+import {getLocalizationService} from './amp-story';
 import {isObject} from '../../../src/types';
 import {listen} from '../../../src/event-helper';
 import {px, setImportantStyles} from '../../../src/style';
@@ -268,7 +269,7 @@ export class ShareWidget {
     const url = Services.documentInfoForDoc(this.getAmpDoc_()).canonicalUrl;
 
     if (!copyTextToClipboard(this.win, url)) {
-      const localizationService = Services.localizationForDoc(this.parentEl_);
+      const localizationService = getLocalizationService(this.parentEl_);
       devAssert(localizationService, 'Could not retrieve LocalizationService.');
       const failureString = localizationService.getLocalizedString(
         LocalizedStringId.AMP_STORY_SHARING_CLIPBOARD_FAILURE_TEXT

--- a/extensions/amp-story/0.1/amp-story-share.js
+++ b/extensions/amp-story/0.1/amp-story-share.js
@@ -22,7 +22,7 @@ import {
 } from '../../../src/clipboard';
 import {dev, devAssert, user} from '../../../src/log';
 import {dict, map} from './../../../src/utils/object';
-import {getLocalizationService} from './amp-story';
+import {getLocalizationService} from './amp-story-localization-service';
 import {isObject} from '../../../src/types';
 import {listen} from '../../../src/event-helper';
 import {px, setImportantStyles} from '../../../src/style';

--- a/extensions/amp-story/0.1/amp-story.js
+++ b/extensions/amp-story/0.1/amp-story.js
@@ -183,6 +183,26 @@ const HIDE_ON_BOOKEND_SELECTOR =
   'amp-story-page, .i-amphtml-story-system-layer';
 
 /**
+ * Util function to retrieve the localization service. Ensures we can retrieve
+ * the service synchronously from the amp-story codebase without running into
+ * race conditions.
+ * @param {!Element} element
+ * @return {!../../../src/service/localization.LocalizationService}
+ */
+export const getLocalizationService = (element) => {
+  let localizationService = Services.localizationForDoc(element);
+
+  if (!localizationService) {
+    localizationService = new LocalizationService(element);
+    registerServiceBuilderForDoc(element, 'localization', function () {
+      return localizationService;
+    });
+  }
+
+  return localizationService;
+};
+
+/**
  * @implements {./media-pool.MediaPoolRoot}
  */
 export class AmpStory extends AMP.BaseElement {
@@ -215,12 +235,7 @@ export class AmpStory extends AMP.BaseElement {
     this.vsync_ = this.getVsync();
 
     /** @private @const {!../../../src/service/localization.LocalizationService} */
-    this.localizationService_ = new LocalizationService(this.element);
-
-    const localizationService = this.localizationService_;
-    registerServiceBuilderForDoc(this.element, 'localization', function () {
-      return localizationService;
-    });
+    this.localizationService_ = getLocalizationService(this.element);
 
     this.localizationService_
       .registerLocalizedStringBundle('default', LocalizedStringsDefault)

--- a/extensions/amp-story/0.1/amp-story.js
+++ b/extensions/amp-story/0.1/amp-story.js
@@ -55,6 +55,7 @@ import {Gestures} from '../../../src/gesture';
 import {InfoDialog} from './amp-story-info-dialog';
 import {Keys} from '../../../src/utils/key-codes';
 import {Layout} from '../../../src/layout';
+import {LocalizationService} from '../../../src/service/localization';
 import {
   LocalizedStringId,
   createPseudoLocale,
@@ -96,7 +97,10 @@ import {getMode} from '../../../src/mode';
 import {getSourceOrigin, parseUrlDeprecated} from '../../../src/url';
 import {getState} from '../../../src/history';
 import {isExperimentOn, toggleExperiment} from '../../../src/experiments';
-import {registerServiceBuilder} from '../../../src/service';
+import {
+  registerServiceBuilder,
+  registerServiceBuilderForDoc,
+} from '../../../src/service';
 import {renderSimpleTemplate} from './simple-template';
 import {stringHash32} from '../../../src/string';
 import {upgradeBackgroundAudio} from './audio';
@@ -211,7 +215,12 @@ export class AmpStory extends AMP.BaseElement {
     this.vsync_ = this.getVsync();
 
     /** @private @const {!../../../src/service/localization.LocalizationService} */
-    this.localizationService_ = Services.localizationForDoc(this.element);
+    this.localizationService_ = new LocalizationService(this.element);
+
+    const localizationService = this.localizationService_;
+    registerServiceBuilderForDoc(this.element, 'localization', function () {
+      return localizationService;
+    });
 
     this.localizationService_
       .registerLocalizedStringBundle('default', LocalizedStringsDefault)

--- a/extensions/amp-story/0.1/amp-story.js
+++ b/extensions/amp-story/0.1/amp-story.js
@@ -55,7 +55,6 @@ import {Gestures} from '../../../src/gesture';
 import {InfoDialog} from './amp-story-info-dialog';
 import {Keys} from '../../../src/utils/key-codes';
 import {Layout} from '../../../src/layout';
-import {LocalizationService} from '../../../src/service/localization';
 import {
   LocalizedStringId,
   createPseudoLocale,
@@ -93,14 +92,12 @@ import {dict} from '../../../src/utils/object';
 import {escapeCssSelectorIdent} from '../../../src/css';
 import {findIndex} from '../../../src/utils/array';
 import {getDetail} from '../../../src/event-helper';
+import {getLocalizationService} from './amp-story-localization-service';
 import {getMode} from '../../../src/mode';
 import {getSourceOrigin, parseUrlDeprecated} from '../../../src/url';
 import {getState} from '../../../src/history';
 import {isExperimentOn, toggleExperiment} from '../../../src/experiments';
-import {
-  registerServiceBuilder,
-  registerServiceBuilderForDoc,
-} from '../../../src/service';
+import {registerServiceBuilder} from '../../../src/service';
 import {renderSimpleTemplate} from './simple-template';
 import {stringHash32} from '../../../src/string';
 import {upgradeBackgroundAudio} from './audio';
@@ -181,26 +178,6 @@ const SHARE_WIDGET_PILL_CONTAINER = {
  */
 const HIDE_ON_BOOKEND_SELECTOR =
   'amp-story-page, .i-amphtml-story-system-layer';
-
-/**
- * Util function to retrieve the localization service. Ensures we can retrieve
- * the service synchronously from the amp-story codebase without running into
- * race conditions.
- * @param {!Element} element
- * @return {!../../../src/service/localization.LocalizationService}
- */
-export const getLocalizationService = (element) => {
-  let localizationService = Services.localizationForDoc(element);
-
-  if (!localizationService) {
-    localizationService = new LocalizationService(element);
-    registerServiceBuilderForDoc(element, 'localization', function () {
-      return localizationService;
-    });
-  }
-
-  return localizationService;
-};
 
 /**
  * @implements {./media-pool.MediaPoolRoot}

--- a/extensions/amp-story/0.1/simple-template.js
+++ b/extensions/amp-story/0.1/simple-template.js
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 import {LocalizedStringId} from '../../../src/localized-strings'; // eslint-disable-line no-unused-vars
-import {Services} from '../../../src/services';
+
 import {createElementWithAttributes} from '../../../src/dom';
 import {devAssert} from '../../../src/log';
+import {getLocalizationService} from './amp-story';
 import {isArray} from '../../../src/types';
 
 /**
@@ -75,9 +76,7 @@ function renderSingle(doc, elementDef) {
     : doc.createElement(elementDef.tag);
 
   if (elementDef.localizedStringId) {
-    const localizationService = Services.localizationForDoc(
-      devAssert(doc.body)
-    );
+    const localizationService = getLocalizationService(devAssert(doc.body));
 
     devAssert(localizationService, 'Could not retrieve LocalizationService.');
     el.textContent = localizationService.getLocalizedString(

--- a/extensions/amp-story/0.1/simple-template.js
+++ b/extensions/amp-story/0.1/simple-template.js
@@ -17,7 +17,7 @@ import {LocalizedStringId} from '../../../src/localized-strings'; // eslint-disa
 
 import {createElementWithAttributes} from '../../../src/dom';
 import {devAssert} from '../../../src/log';
-import {getLocalizationService} from './amp-story';
+import {getLocalizationService} from './amp-story-localization-service';
 import {isArray} from '../../../src/types';
 
 /**

--- a/extensions/amp-story/0.1/test/test-amp-story-info-dialog.js
+++ b/extensions/amp-story/0.1/test/test-amp-story-info-dialog.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
+import * as Service from '../../../../src/service';
 import {
   Action,
   AmpStoryStoreService,
@@ -24,10 +24,11 @@ import {
   InfoDialog,
   MOREINFO_VISIBLE_CLASS,
 } from '../amp-story-info-dialog';
+import {LocalizationService} from '../../../../src/service/localization';
 import {Services} from '../../../../src/services';
 import {registerServiceBuilder} from '../../../../src/service';
 
-describes.realWin('amp-story-share-menu', {amp: true}, (env) => {
+describes.realWin('amp-story-info-dialog', {amp: true}, (env) => {
   let moreInfoLinkUrl;
   let embedded;
   let parentEl;
@@ -39,6 +40,11 @@ describes.realWin('amp-story-share-menu', {amp: true}, (env) => {
 
   beforeEach(() => {
     win = env.win;
+    const localizationService = new LocalizationService(win.document.body);
+    env.sandbox.stub(Service, 'registerServiceBuilderForDoc');
+    env.sandbox
+      .stub(Services, 'localizationForDoc')
+      .returns(localizationService);
     storeService = new AmpStoryStoreService(win);
     embedded = true;
     registerServiceBuilder(win, 'story-store', function () {

--- a/extensions/amp-story/0.1/test/test-amp-story-info-dialog.js
+++ b/extensions/amp-story/0.1/test/test-amp-story-info-dialog.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as Service from '../../../../src/service';
+
 import {
   Action,
   AmpStoryStoreService,
@@ -41,7 +41,6 @@ describes.realWin('amp-story-info-dialog', {amp: true}, (env) => {
   beforeEach(() => {
     win = env.win;
     const localizationService = new LocalizationService(win.document.body);
-    env.sandbox.stub(Service, 'registerServiceBuilderForDoc');
     env.sandbox
       .stub(Services, 'localizationForDoc')
       .returns(localizationService);

--- a/extensions/amp-story/0.1/test/test-amp-story.js
+++ b/extensions/amp-story/0.1/test/test-amp-story.js
@@ -13,11 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+import * as Service from '../../../../src/service';
 import {Action} from '../amp-story-store-service';
 import {AmpStory} from '../amp-story';
 import {AmpStoryPage} from '../amp-story-page';
 import {EventType} from '../events';
 import {Keys} from '../../../../src/utils/key-codes';
+import {LocalizationService} from '../../../../src/service/localization';
 import {PaginationButtons} from '../pagination-buttons';
 import {Services} from '../../../../src/services';
 
@@ -88,9 +91,8 @@ describes.realWin(
 
     beforeEach(() => {
       win = env.win;
-      const localizationService = Services.localizationForDoc(
-        win.document.body
-      );
+      const localizationService = new LocalizationService(win.document.body);
+      env.sandbox.stub(Service, 'registerServiceBuilderForDoc');
       env.sandbox
         .stub(Services, 'localizationForDoc')
         .returns(localizationService);

--- a/extensions/amp-story/0.1/test/test-amp-story.js
+++ b/extensions/amp-story/0.1/test/test-amp-story.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as Service from '../../../../src/service';
 import {Action} from '../amp-story-store-service';
 import {AmpStory} from '../amp-story';
 import {AmpStoryPage} from '../amp-story-page';
@@ -92,7 +91,6 @@ describes.realWin(
     beforeEach(() => {
       win = env.win;
       const localizationService = new LocalizationService(win.document.body);
-      env.sandbox.stub(Service, 'registerServiceBuilderForDoc');
       env.sandbox
         .stub(Services, 'localizationForDoc')
         .returns(localizationService);

--- a/extensions/amp-story/1.0/amp-story-embedded-component.js
+++ b/extensions/amp-story/1.0/amp-story-embedded-component.js
@@ -37,6 +37,7 @@ import {createShadowRootWithStyle, getSourceOriginForElement} from './utils';
 import {dev, devAssert, user, userAssert} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
 import {getAmpdoc} from '../../../src/service';
+import {getLocalizationService} from './amp-story';
 import {htmlFor, htmlRefs} from '../../../src/static-template';
 import {isProtocolValid, parseUrlDeprecated} from '../../../src/url';
 import {px, resetStyles, setImportantStyles, toggle} from '../../../src/style';
@@ -1095,7 +1096,7 @@ export class AmpStoryEmbeddedComponent {
   updateTooltipText_(target, embedConfig) {
     const tooltipText =
       target.getAttribute('data-tooltip-text') ||
-      Services.localizationForDoc(this.storyEl_).getLocalizedString(
+      getLocalizationService(this.storyEl_).getLocalizedString(
         embedConfig.localizedStringId
       ) ||
       getSourceOriginForElement(target, this.getElementHref_(target));

--- a/extensions/amp-story/1.0/amp-story-embedded-component.js
+++ b/extensions/amp-story/1.0/amp-story-embedded-component.js
@@ -37,7 +37,7 @@ import {createShadowRootWithStyle, getSourceOriginForElement} from './utils';
 import {dev, devAssert, user, userAssert} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
 import {getAmpdoc} from '../../../src/service';
-import {getLocalizationService} from './amp-story';
+import {getLocalizationService} from './amp-story-localization-service';
 import {htmlFor, htmlRefs} from '../../../src/static-template';
 import {isProtocolValid, parseUrlDeprecated} from '../../../src/url';
 import {px, resetStyles, setImportantStyles, toggle} from '../../../src/style';

--- a/extensions/amp-story/1.0/amp-story-info-dialog.js
+++ b/extensions/amp-story/1.0/amp-story-info-dialog.js
@@ -32,6 +32,7 @@ import {closest} from '../../../src/dom';
 import {createShadowRootWithStyle} from './utils';
 import {dev} from '../../../src/log';
 import {getAmpdoc} from '../../../src/service';
+import {getLocalizationService} from './amp-story';
 import {htmlFor} from '../../../src/static-template';
 
 /** @const {string} Class to toggle the info dialog. */
@@ -64,7 +65,7 @@ export class InfoDialog {
     this.isBuilt_ = false;
 
     /** @private @const {!../../../src/service/localization.LocalizationService} */
-    this.localizationService_ = Services.localizationForDoc(parentEl);
+    this.localizationService_ = getLocalizationService(parentEl);
 
     /** @private @const {!./amp-story-store-service.AmpStoryStoreService} */
     this.storeService_ = getStoreService(this.win_);

--- a/extensions/amp-story/1.0/amp-story-info-dialog.js
+++ b/extensions/amp-story/1.0/amp-story-info-dialog.js
@@ -32,7 +32,7 @@ import {closest} from '../../../src/dom';
 import {createShadowRootWithStyle} from './utils';
 import {dev} from '../../../src/log';
 import {getAmpdoc} from '../../../src/service';
-import {getLocalizationService} from './amp-story';
+import {getLocalizationService} from './amp-story-localization-service';
 import {htmlFor} from '../../../src/static-template';
 
 /** @const {string} Class to toggle the info dialog. */

--- a/extensions/amp-story/1.0/amp-story-localization-service.js
+++ b/extensions/amp-story/1.0/amp-story-localization-service.js
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {LocalizationService} from '../../../src/service/localization';
+import {Services} from '../../../src/services';
+import {registerServiceBuilderForDoc} from '../../../src/service';
+
+/**
+ * Util function to retrieve the localization service. Ensures we can retrieve
+ * the service synchronously from the amp-story codebase without running into
+ * race conditions.
+ * @param {!Element} element
+ * @return {!../../../src/service/localization.LocalizationService}
+ */
+export const getLocalizationService = (element) => {
+  let localizationService = Services.localizationForDoc(element);
+
+  if (!localizationService) {
+    localizationService = new LocalizationService(element);
+    registerServiceBuilderForDoc(element, 'localization', function () {
+      return localizationService;
+    });
+  }
+
+  return localizationService;
+};

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -69,6 +69,7 @@ import {dict} from '../../../src/utils/object';
 import {getAmpdoc} from '../../../src/service';
 import {getData, listen} from '../../../src/event-helper';
 import {getFriendlyIframeEmbedOptional} from '../../../src/iframe-helper';
+import {getLocalizationService} from './amp-story';
 import {getLogEntries} from './logging';
 import {getMediaPerformanceMetricsService} from './media-performance-metrics-service';
 import {getMode} from '../../../src/mode';
@@ -1642,7 +1643,7 @@ export class AmpStoryPage extends AMP.BaseElement {
     const labelEl = this.playMessageEl_.querySelector(
       '.i-amphtml-story-page-play-label'
     );
-    labelEl.textContent = Services.localizationForDoc(
+    labelEl.textContent = getLocalizationService(
       this.element
     ).getLocalizedString(LocalizedStringId.AMP_STORY_PAGE_PLAY_VIDEO);
 
@@ -1689,7 +1690,7 @@ export class AmpStoryPage extends AMP.BaseElement {
     const labelEl = this.errorMessageEl_.querySelector(
       '.i-amphtml-story-page-error-label'
     );
-    labelEl.textContent = Services.localizationForDoc(
+    labelEl.textContent = getLocalizationService(
       this.element
     ).getLocalizedString(LocalizedStringId.AMP_STORY_PAGE_ERROR_VIDEO);
 
@@ -1744,7 +1745,7 @@ export class AmpStoryPage extends AMP.BaseElement {
       const openLabelAttr = attachmentEl.getAttribute('data-cta-text');
       const openLabel =
         (openLabelAttr && openLabelAttr.trim()) ||
-        Services.localizationForDoc(this.element).getLocalizedString(
+        getLocalizationService(this.element).getLocalizedString(
           LocalizedStringId.AMP_STORY_PAGE_ATTACHMENT_OPEN_LABEL
         );
 

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -69,7 +69,7 @@ import {dict} from '../../../src/utils/object';
 import {getAmpdoc} from '../../../src/service';
 import {getData, listen} from '../../../src/event-helper';
 import {getFriendlyIframeEmbedOptional} from '../../../src/iframe-helper';
-import {getLocalizationService} from './amp-story';
+import {getLocalizationService} from './amp-story-localization-service';
 import {getLogEntries} from './logging';
 import {getMediaPerformanceMetricsService} from './media-performance-metrics-service';
 import {getMode} from '../../../src/mode';

--- a/extensions/amp-story/1.0/amp-story-reaction-quiz.js
+++ b/extensions/amp-story/1.0/amp-story-reaction-quiz.js
@@ -17,9 +17,9 @@
 import {AmpStoryReaction, ReactionType} from './amp-story-reaction';
 import {CSS} from '../../../build/amp-story-reaction-quiz-1.0.css';
 import {LocalizedStringId} from '../../../src/localized-strings';
-import {Services} from '../../../src/services';
 import {createShadowRootWithStyle} from './utils';
 import {dev} from '../../../src/log';
+import {getLocalizationService} from './amp-story';
 import {htmlFor} from '../../../src/static-template';
 import {toArray} from '../../../src/types';
 
@@ -72,7 +72,7 @@ export class AmpStoryReactionQuiz extends AmpStoryReaction {
     this.answerChoiceOptions_ = ['A', 'B', 'C', 'D'];
 
     /** @private {!../../../src/service/localization.LocalizationService} */
-    this.localizationService_ = Services.localizationForDoc(element);
+    this.localizationService_ = getLocalizationService(element);
   }
 
   /** @override */

--- a/extensions/amp-story/1.0/amp-story-reaction-quiz.js
+++ b/extensions/amp-story/1.0/amp-story-reaction-quiz.js
@@ -19,7 +19,7 @@ import {CSS} from '../../../build/amp-story-reaction-quiz-1.0.css';
 import {LocalizedStringId} from '../../../src/localized-strings';
 import {createShadowRootWithStyle} from './utils';
 import {dev} from '../../../src/log';
-import {getLocalizationService} from './amp-story';
+import {getLocalizationService} from './amp-story-localization-service';
 import {htmlFor} from '../../../src/static-template';
 import {toArray} from '../../../src/types';
 

--- a/extensions/amp-story/1.0/amp-story-share.js
+++ b/extensions/amp-story/1.0/amp-story-share.js
@@ -22,6 +22,7 @@ import {
 } from '../../../src/clipboard';
 import {dev, devAssert, user} from '../../../src/log';
 import {dict, map} from './../../../src/utils/object';
+import {getLocalizationService} from './amp-story';
 import {getRequestService} from './amp-story-request-service';
 import {isObject} from '../../../src/types';
 import {listen} from '../../../src/event-helper';
@@ -285,7 +286,7 @@ export class ShareWidget {
     const url = Services.documentInfoForDoc(this.getAmpDoc_()).canonicalUrl;
 
     if (!copyTextToClipboard(this.win, url)) {
-      const localizationService = Services.localizationForDoc(this.storyEl);
+      const localizationService = getLocalizationService(this.storyEl);
       devAssert(localizationService, 'Could not retrieve LocalizationService.');
       const failureString = localizationService.getLocalizedString(
         LocalizedStringId.AMP_STORY_SHARING_CLIPBOARD_FAILURE_TEXT

--- a/extensions/amp-story/1.0/amp-story-share.js
+++ b/extensions/amp-story/1.0/amp-story-share.js
@@ -22,7 +22,7 @@ import {
 } from '../../../src/clipboard';
 import {dev, devAssert, user} from '../../../src/log';
 import {dict, map} from './../../../src/utils/object';
-import {getLocalizationService} from './amp-story';
+import {getLocalizationService} from './amp-story-localization-service';
 import {getRequestService} from './amp-story-request-service';
 import {isObject} from '../../../src/types';
 import {listen} from '../../../src/event-helper';

--- a/extensions/amp-story/1.0/amp-story-viewport-warning-layer.js
+++ b/extensions/amp-story/1.0/amp-story-viewport-warning-layer.js
@@ -23,6 +23,7 @@ import {
   getStoreService,
 } from './amp-story-store-service';
 import {createShadowRootWithStyle} from './utils';
+import {getLocalizationService} from './amp-story';
 import {htmlFor} from '../../../src/static-template';
 import {listen} from '../../../src/event-helper';
 import {throttle} from '../../../src/utils/rate-limit';
@@ -114,7 +115,7 @@ export class ViewportWarningLayer {
     }
 
     this.overlayEl_ = this.getViewportWarningOverlayTemplate_();
-    this.localizationService_ = Services.localizationForDoc(this.storyElement_);
+    this.localizationService_ = getLocalizationService(this.storyElement_);
 
     this.isBuilt_ = true;
     const root = this.win_.document.createElement('div');

--- a/extensions/amp-story/1.0/amp-story-viewport-warning-layer.js
+++ b/extensions/amp-story/1.0/amp-story-viewport-warning-layer.js
@@ -23,7 +23,7 @@ import {
   getStoreService,
 } from './amp-story-store-service';
 import {createShadowRootWithStyle} from './utils';
-import {getLocalizationService} from './amp-story';
+import {getLocalizationService} from './amp-story-localization-service';
 import {htmlFor} from '../../../src/static-template';
 import {listen} from '../../../src/event-helper';
 import {throttle} from '../../../src/utils/rate-limit';

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -72,6 +72,7 @@ import {InfoDialog} from './amp-story-info-dialog';
 import {Keys} from '../../../src/utils/key-codes';
 import {Layout} from '../../../src/layout';
 import {LiveStoryManager} from './live-story-manager';
+import {LocalizationService} from '../../../src/service/localization';
 import {MediaPool, MediaType} from './media-pool';
 import {PaginationButtons} from './pagination-buttons';
 import {Services} from '../../../src/services';
@@ -112,6 +113,7 @@ import {getMode} from '../../../src/mode';
 import {getState} from '../../../src/history';
 import {isExperimentOn} from '../../../src/experiments';
 import {parseQueryString} from '../../../src/url';
+import {registerServiceBuilderForDoc} from '../../../src/service';
 import {toArray} from '../../../src/types';
 import {upgradeBackgroundAudio} from './audio';
 import LocalizedStringsAr from './_locales/ar';
@@ -358,7 +360,12 @@ export class AmpStory extends AMP.BaseElement {
     this.liveStoryManager_ = null;
 
     /** @private @const {!../../../src/service/localization.LocalizationService} */
-    this.localizationService_ = Services.localizationForDoc(this.element);
+    this.localizationService_ = new LocalizationService(this.element);
+
+    const localizationService = this.localizationService_;
+    registerServiceBuilderForDoc(this.element, 'localization', function () {
+      return localizationService;
+    });
 
     this.localizationService_
       .registerLocalizedStringBundle('default', LocalizedStringsDefault)

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -361,12 +361,7 @@ export class AmpStory extends AMP.BaseElement {
 
     /** @private @const {!../../../src/service/localization.LocalizationService} */
     this.localizationService_ = new LocalizationService(this.element);
-
     const localizationService = this.localizationService_;
-    registerServiceBuilderForDoc(this.element, 'localization', function () {
-      return localizationService;
-    });
-
     this.localizationService_
       .registerLocalizedStringBundle('default', LocalizedStringsDefault)
       .registerLocalizedStringBundle('ar', LocalizedStringsAr)
@@ -399,6 +394,10 @@ export class AmpStory extends AMP.BaseElement {
       'en-xa',
       enXaPseudoLocaleBundle
     );
+
+    registerServiceBuilderForDoc(this.element, 'localization', function () {
+      return localizationService;
+    });
   }
 
   /** @override */

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -231,6 +231,26 @@ const SIDEBAR_OBSERVER_OPTIONS = {
 };
 
 /**
+ * Util function to retrieve the localization service. Ensures we can retrieve
+ * the service synchronously from the amp-story codebase without running into
+ * race conditions.
+ * @param {!Element} element
+ * @return {!../../../src/service/localization.LocalizationService}
+ */
+export const getLocalizationService = (element) => {
+  let localizationService = Services.localizationForDoc(element);
+
+  if (!localizationService) {
+    localizationService = new LocalizationService(element);
+    registerServiceBuilderForDoc(element, 'localization', function () {
+      return localizationService;
+    });
+  }
+
+  return localizationService;
+};
+
+/**
  * @implements {./media-pool.MediaPoolRoot}
  */
 export class AmpStory extends AMP.BaseElement {
@@ -360,8 +380,8 @@ export class AmpStory extends AMP.BaseElement {
     this.liveStoryManager_ = null;
 
     /** @private @const {!../../../src/service/localization.LocalizationService} */
-    this.localizationService_ = new LocalizationService(this.element);
-    const localizationService = this.localizationService_;
+    this.localizationService_ = getLocalizationService(this.element);
+
     this.localizationService_
       .registerLocalizedStringBundle('default', LocalizedStringsDefault)
       .registerLocalizedStringBundle('ar', LocalizedStringsAr)
@@ -394,10 +414,6 @@ export class AmpStory extends AMP.BaseElement {
       'en-xa',
       enXaPseudoLocaleBundle
     );
-
-    registerServiceBuilderForDoc(this.element, 'localization', function () {
-      return localizationService;
-    });
   }
 
   /** @override */

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -72,7 +72,6 @@ import {InfoDialog} from './amp-story-info-dialog';
 import {Keys} from '../../../src/utils/key-codes';
 import {Layout} from '../../../src/layout';
 import {LiveStoryManager} from './live-story-manager';
-import {LocalizationService} from '../../../src/service/localization';
 import {MediaPool, MediaType} from './media-pool';
 import {PaginationButtons} from './pagination-buttons';
 import {Services} from '../../../src/services';
@@ -108,12 +107,12 @@ import {escapeCssSelectorIdent} from '../../../src/css';
 import {findIndex, lastItem} from '../../../src/utils/array';
 import {getConsentPolicyState} from '../../../src/consent';
 import {getDetail} from '../../../src/event-helper';
+import {getLocalizationService} from './amp-story-localization-service';
 import {getMediaQueryService} from './amp-story-media-query-service';
 import {getMode} from '../../../src/mode';
 import {getState} from '../../../src/history';
 import {isExperimentOn} from '../../../src/experiments';
 import {parseQueryString} from '../../../src/url';
-import {registerServiceBuilderForDoc} from '../../../src/service';
 import {toArray} from '../../../src/types';
 import {upgradeBackgroundAudio} from './audio';
 import LocalizedStringsAr from './_locales/ar';
@@ -228,26 +227,6 @@ const DEFAULT_THEME_COLOR = '#202125';
 const SIDEBAR_OBSERVER_OPTIONS = {
   attributes: true,
   attributeFilter: ['open'],
-};
-
-/**
- * Util function to retrieve the localization service. Ensures we can retrieve
- * the service synchronously from the amp-story codebase without running into
- * race conditions.
- * @param {!Element} element
- * @return {!../../../src/service/localization.LocalizationService}
- */
-export const getLocalizationService = (element) => {
-  let localizationService = Services.localizationForDoc(element);
-
-  if (!localizationService) {
-    localizationService = new LocalizationService(element);
-    registerServiceBuilderForDoc(element, 'localization', function () {
-      return localizationService;
-    });
-  }
-
-  return localizationService;
 };
 
 /**

--- a/extensions/amp-story/1.0/bookend/amp-story-bookend.js
+++ b/extensions/amp-story/1.0/bookend/amp-story-bookend.js
@@ -42,6 +42,7 @@ import {dev, devAssert, user, userAssert} from '../../../../src/log';
 import {dict} from '../../../../src/utils/object';
 import {getAmpdoc} from '../../../../src/service';
 import {getJsonLd} from '../jsonld';
+import {getLocalizationService} from '../amp-story';
 import {getRequestService} from '../amp-story-request-service';
 import {isArray} from '../../../../src/types';
 import {renderAsElement} from '../simple-template';
@@ -629,7 +630,7 @@ export class AmpStoryBookend extends DraggableDrawer {
       return;
     }
 
-    const localizationService = Services.localizationForDoc(this.element);
+    const localizationService = getLocalizationService(this.element);
     if (!localizationService) {
       user().error(TAG, 'Unable to fetch localization service.');
       return;

--- a/extensions/amp-story/1.0/bookend/amp-story-bookend.js
+++ b/extensions/amp-story/1.0/bookend/amp-story-bookend.js
@@ -42,7 +42,7 @@ import {dev, devAssert, user, userAssert} from '../../../../src/log';
 import {dict} from '../../../../src/utils/object';
 import {getAmpdoc} from '../../../../src/service';
 import {getJsonLd} from '../jsonld';
-import {getLocalizationService} from '../amp-story';
+import {getLocalizationService} from '../amp-story-localization-service';
 import {getRequestService} from '../amp-story-request-service';
 import {isArray} from '../../../../src/types';
 import {renderAsElement} from '../simple-template';

--- a/extensions/amp-story/1.0/simple-template.js
+++ b/extensions/amp-story/1.0/simple-template.js
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 import {LocalizedStringId} from '../../../src/localized-strings'; // eslint-disable-line no-unused-vars
-import {Services} from '../../../src/services';
 import {createElementWithAttributes} from '../../../src/dom';
 import {devAssert} from '../../../src/log';
+import {getLocalizationService} from './amp-story';
 import {hasOwn} from '../../../src/utils/object';
 import {isArray} from '../../../src/types';
 
@@ -83,9 +83,7 @@ function renderSingle(doc, elementDef) {
   const hasLocalizedTextContent = hasOwn(elementDef, 'localizedStringId');
   const hasLocalizedLabel = hasOwn(elementDef, 'localizedLabelId');
   if (hasLocalizedTextContent || hasLocalizedLabel) {
-    const localizationService = Services.localizationForDoc(
-      devAssert(doc.body)
-    );
+    const localizationService = getLocalizationService(devAssert(doc.body));
     devAssert(localizationService, 'Could not retrieve LocalizationService.');
 
     if (hasLocalizedTextContent) {

--- a/extensions/amp-story/1.0/simple-template.js
+++ b/extensions/amp-story/1.0/simple-template.js
@@ -16,7 +16,7 @@
 import {LocalizedStringId} from '../../../src/localized-strings'; // eslint-disable-line no-unused-vars
 import {createElementWithAttributes} from '../../../src/dom';
 import {devAssert} from '../../../src/log';
-import {getLocalizationService} from './amp-story';
+import {getLocalizationService} from './amp-story-localization-service';
 import {hasOwn} from '../../../src/utils/object';
 import {isArray} from '../../../src/types';
 

--- a/extensions/amp-story/1.0/test/test-amp-story-bookend.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-bookend.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import * as Service from '../../../../src/service';
 import {Action} from '../amp-story-store-service';
 import {AmpStoryBookend} from '../bookend/amp-story-bookend';
 import {AmpStoryRequestService} from '../amp-story-request-service';
@@ -21,6 +22,7 @@ import {AnalyticsVariable, getVariableService} from '../variable-service';
 import {ArticleComponent} from '../bookend/components/article';
 import {CtaLinkComponent} from '../bookend/components/cta-link';
 import {LandscapeComponent} from '../bookend/components/landscape';
+import {LocalizationService} from '../../../../src/service/localization';
 import {PortraitComponent} from '../bookend/components/portrait';
 import {Services} from '../../../../src/services';
 import {StoryAnalyticsEvent, getAnalyticsService} from '../story-analytics';
@@ -126,6 +128,11 @@ describes.fakeWin('amp-story-bookend', {win: {location}, amp: true}, (env) => {
   beforeEach(() => {
     win = env.win;
     doc = win.document;
+    const localizationService = new LocalizationService(win.document.body);
+    env.sandbox.stub(Service, 'registerServiceBuilderForDoc');
+    env.sandbox
+      .stub(Services, 'localizationForDoc')
+      .returns(localizationService);
     storyElem = doc.createElement('amp-story');
     storyElem.appendChild(doc.createElement('amp-story-page'));
     doc.body.appendChild(storyElem);

--- a/extensions/amp-story/1.0/test/test-amp-story-bookend.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-bookend.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as Service from '../../../../src/service';
 import {Action} from '../amp-story-store-service';
 import {AmpStoryBookend} from '../bookend/amp-story-bookend';
 import {AmpStoryRequestService} from '../amp-story-request-service';
@@ -129,7 +128,6 @@ describes.fakeWin('amp-story-bookend', {win: {location}, amp: true}, (env) => {
     win = env.win;
     doc = win.document;
     const localizationService = new LocalizationService(win.document.body);
-    env.sandbox.stub(Service, 'registerServiceBuilderForDoc');
     env.sandbox
       .stub(Services, 'localizationForDoc')
       .returns(localizationService);

--- a/extensions/amp-story/1.0/test/test-amp-story-consent.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-consent.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as Service from '../../../../src/service';
 import {AmpStoryConsent} from '../amp-story-consent';
 import {AmpStoryStoreService, StateProperty} from '../amp-story-store-service';
 import {LocalizationService} from '../../../../src/service/localization';
@@ -39,7 +38,6 @@ describes.realWin('amp-story-consent', {amp: true}, (env) => {
   beforeEach(() => {
     win = env.win;
     const localizationService = new LocalizationService(win.document.body);
-    env.sandbox.stub(Service, 'registerServiceBuilderForDoc');
     env.sandbox
       .stub(Services, 'localizationForDoc')
       .returns(localizationService);

--- a/extensions/amp-story/1.0/test/test-amp-story-consent.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-consent.js
@@ -14,8 +14,10 @@
  * limitations under the License.
  */
 
+import * as Service from '../../../../src/service';
 import {AmpStoryConsent} from '../amp-story-consent';
 import {AmpStoryStoreService, StateProperty} from '../amp-story-store-service';
+import {LocalizationService} from '../../../../src/service/localization';
 import {Services} from '../../../../src/services';
 import {registerServiceBuilder} from '../../../../src/service';
 
@@ -36,6 +38,11 @@ describes.realWin('amp-story-consent', {amp: true}, (env) => {
 
   beforeEach(() => {
     win = env.win;
+    const localizationService = new LocalizationService(win.document.body);
+    env.sandbox.stub(Service, 'registerServiceBuilderForDoc');
+    env.sandbox
+      .stub(Services, 'localizationForDoc')
+      .returns(localizationService);
     const storeService = new AmpStoryStoreService(win);
     registerServiceBuilder(win, 'story-store', function () {
       return storeService;

--- a/extensions/amp-story/1.0/test/test-amp-story-embedded-component.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-embedded-component.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as Service from '../../../../src/service';
 import * as analyticsApi from '../../../../src/analytics';
 import {
   Action,
@@ -44,7 +43,6 @@ describes.realWin('amp-story-embedded-component', {amp: true}, (env) => {
     win = env.win;
 
     const localizationService = new LocalizationService(win.document.body);
-    env.sandbox.stub(Service, 'registerServiceBuilderForDoc');
     env.sandbox
       .stub(Services, 'localizationForDoc')
       .returns(localizationService);

--- a/extensions/amp-story/1.0/test/test-amp-story-embedded-component.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-embedded-component.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import * as Service from '../../../../src/service';
 import * as analyticsApi from '../../../../src/analytics';
 import {
   Action,
@@ -22,6 +23,7 @@ import {
 } from '../amp-story-store-service';
 import {AmpStoryEmbeddedComponent} from '../amp-story-embedded-component';
 import {EventType} from '../events';
+import {LocalizationService} from '../../../../src/service/localization';
 import {Services} from '../../../../src/services';
 import {StoryAnalyticsEvent} from '../story-analytics';
 import {addAttributesToElement} from '../../../../src/dom';
@@ -40,6 +42,12 @@ describes.realWin('amp-story-embedded-component', {amp: true}, (env) => {
 
   beforeEach(() => {
     win = env.win;
+
+    const localizationService = new LocalizationService(win.document.body);
+    env.sandbox.stub(Service, 'registerServiceBuilderForDoc');
+    env.sandbox
+      .stub(Services, 'localizationForDoc')
+      .returns(localizationService);
 
     // Making sure mutator tasks run synchronously.
     env.sandbox.stub(Services, 'mutatorForDoc').returns({

--- a/extensions/amp-story/1.0/test/test-amp-story-hint.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-hint.js
@@ -14,8 +14,10 @@
  * limitations under the License.
  */
 
+import * as Service from '../../../../src/service';
 import {AmpStoryHint} from '../amp-story-hint';
 import {AmpStoryStoreService} from '../amp-story-store-service';
+import {LocalizationService} from '../../../../src/service/localization';
 import {Services} from '../../../../src/services';
 import {registerServiceBuilder} from '../../../../src/service';
 
@@ -29,7 +31,8 @@ describes.fakeWin('amp-story hint layer', {amp: true}, (env) => {
   beforeEach(() => {
     win = env.win;
 
-    const localizationService = Services.localizationForDoc(win.document.body);
+    const localizationService = new LocalizationService(win.document.body);
+    env.sandbox.stub(Service, 'registerServiceBuilderForDoc');
     env.sandbox
       .stub(Services, 'localizationForDoc')
       .returns(localizationService);

--- a/extensions/amp-story/1.0/test/test-amp-story-hint.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-hint.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as Service from '../../../../src/service';
 import {AmpStoryHint} from '../amp-story-hint';
 import {AmpStoryStoreService} from '../amp-story-store-service';
 import {LocalizationService} from '../../../../src/service/localization';
@@ -32,7 +31,6 @@ describes.fakeWin('amp-story hint layer', {amp: true}, (env) => {
     win = env.win;
 
     const localizationService = new LocalizationService(win.document.body);
-    env.sandbox.stub(Service, 'registerServiceBuilderForDoc');
     env.sandbox
       .stub(Services, 'localizationForDoc')
       .returns(localizationService);

--- a/extensions/amp-story/1.0/test/test-amp-story-info-dialog.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-info-dialog.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import * as Service from '../../../../src/service';
 import {
   Action,
   AmpStoryStoreService,
@@ -24,6 +25,7 @@ import {
   InfoDialog,
   MOREINFO_VISIBLE_CLASS,
 } from '../amp-story-info-dialog';
+import {LocalizationService} from '../../../../src/service/localization';
 import {Services} from '../../../../src/services';
 import {registerServiceBuilder} from '../../../../src/service';
 
@@ -39,6 +41,12 @@ describes.realWin('amp-story-info-dialog', {amp: true}, (env) => {
 
   beforeEach(() => {
     win = env.win;
+    const localizationService = new LocalizationService(win.document.body);
+    env.sandbox.stub(Service, 'registerServiceBuilderForDoc');
+    env.sandbox
+      .stub(Services, 'localizationForDoc')
+      .returns(localizationService);
+
     storeService = new AmpStoryStoreService(win);
     embedded = true;
     registerServiceBuilder(win, 'story-store', function () {

--- a/extensions/amp-story/1.0/test/test-amp-story-info-dialog.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-info-dialog.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as Service from '../../../../src/service';
 import {
   Action,
   AmpStoryStoreService,
@@ -42,7 +41,6 @@ describes.realWin('amp-story-info-dialog', {amp: true}, (env) => {
   beforeEach(() => {
     win = env.win;
     const localizationService = new LocalizationService(win.document.body);
-    env.sandbox.stub(Service, 'registerServiceBuilderForDoc');
     env.sandbox
       .stub(Services, 'localizationForDoc')
       .returns(localizationService);

--- a/extensions/amp-story/1.0/test/test-amp-story-page.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-page.js
@@ -14,10 +14,12 @@
  * limitations under the License.
  */
 
+import * as Service from '../../../../src/service';
 import {AmpDocSingle} from '../../../../src/service/ampdoc-impl';
 import {AmpStoryPage, PageState, Selectors} from '../amp-story-page';
 import {AmpStoryStoreService} from '../amp-story-store-service';
 import {Deferred} from '../../../../src/utils/promise';
+import {LocalizationService} from '../../../../src/service/localization';
 import {MediaType} from '../media-pool';
 import {Services} from '../../../../src/services';
 import {
@@ -48,7 +50,8 @@ describes.realWin('amp-story-page', {amp: true}, (env) => {
       }),
     };
 
-    const localizationService = Services.localizationForDoc(win.document.body);
+    const localizationService = new LocalizationService(win.document.body);
+    env.sandbox.stub(Service, 'registerServiceBuilderForDoc');
     env.sandbox
       .stub(Services, 'localizationForDoc')
       .returns(localizationService);

--- a/extensions/amp-story/1.0/test/test-amp-story-page.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-page.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as Service from '../../../../src/service';
 import {AmpDocSingle} from '../../../../src/service/ampdoc-impl';
 import {AmpStoryPage, PageState, Selectors} from '../amp-story-page';
 import {AmpStoryStoreService} from '../amp-story-store-service';
@@ -51,7 +50,6 @@ describes.realWin('amp-story-page', {amp: true}, (env) => {
     };
 
     const localizationService = new LocalizationService(win.document.body);
-    env.sandbox.stub(Service, 'registerServiceBuilderForDoc');
     env.sandbox
       .stub(Services, 'localizationForDoc')
       .returns(localizationService);

--- a/extensions/amp-story/1.0/test/test-amp-story-reaction-quiz.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-reaction-quiz.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as Service from '../../../../src/service';
 import {AmpStoryReactionQuiz} from '../amp-story-reaction-quiz';
 import {AmpStoryStoreService} from '../amp-story-store-service';
 import {AnalyticsVariable, getVariableService} from '../variable-service';
@@ -134,7 +133,6 @@ describes.realWin(
       win = env.win;
 
       const localizationService = new LocalizationService(win.document.body);
-      env.sandbox.stub(Service, 'registerServiceBuilderForDoc');
       env.sandbox
         .stub(Services, 'localizationForDoc')
         .returns(localizationService);

--- a/extensions/amp-story/1.0/test/test-amp-story-reaction-quiz.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-reaction-quiz.js
@@ -14,9 +14,11 @@
  * limitations under the License.
  */
 
+import * as Service from '../../../../src/service';
 import {AmpStoryReactionQuiz} from '../amp-story-reaction-quiz';
 import {AmpStoryStoreService} from '../amp-story-store-service';
 import {AnalyticsVariable, getVariableService} from '../variable-service';
+import {LocalizationService} from '../../../../src/service/localization';
 import {Services} from '../../../../src/services';
 import {getAnalyticsService} from '../story-analytics';
 import {getRequestService} from '../amp-story-request-service';
@@ -130,6 +132,12 @@ describes.realWin(
 
     beforeEach(() => {
       win = env.win;
+
+      const localizationService = new LocalizationService(win.document.body);
+      env.sandbox.stub(Service, 'registerServiceBuilderForDoc');
+      env.sandbox
+        .stub(Services, 'localizationForDoc')
+        .returns(localizationService);
 
       env.sandbox
         .stub(Services, 'cidForDoc')

--- a/extensions/amp-story/1.0/test/test-amp-story-system-layer.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-system-layer.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as Service from '../../../../src/service';
+
 import {
   Action,
   AmpStoryStoreService,
@@ -38,7 +38,6 @@ describes.fakeWin('amp-story system layer', {amp: true}, (env) => {
     win = env.win;
 
     const localizationService = new LocalizationService(win.document.body);
-    env.sandbox.stub(Service, 'registerServiceBuilderForDoc');
     env.sandbox
       .stub(Services, 'localizationForDoc')
       .returns(localizationService);

--- a/extensions/amp-story/1.0/test/test-amp-story-system-layer.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-system-layer.js
@@ -13,11 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import * as Service from '../../../../src/service';
 import {
   Action,
   AmpStoryStoreService,
   StateProperty,
 } from '../amp-story-store-service';
+import {LocalizationService} from '../../../../src/service/localization';
 import {ProgressBar} from '../progress-bar';
 import {Services} from '../../../../src/services';
 import {SystemLayer} from '../amp-story-system-layer';
@@ -34,6 +36,12 @@ describes.fakeWin('amp-story system layer', {amp: true}, (env) => {
 
   beforeEach(() => {
     win = env.win;
+
+    const localizationService = new LocalizationService(win.document.body);
+    env.sandbox.stub(Service, 'registerServiceBuilderForDoc');
+    env.sandbox
+      .stub(Services, 'localizationForDoc')
+      .returns(localizationService);
 
     storeService = new AmpStoryStoreService(win);
     registerServiceBuilder(win, 'story-store', function () {

--- a/extensions/amp-story/1.0/test/test-amp-story.js
+++ b/extensions/amp-story/1.0/test/test-amp-story.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as Service from '../../../../src/service';
 import * as consent from '../../../../src/consent';
 import * as utils from '../utils';
 import {
@@ -120,7 +119,6 @@ describes.realWin(
       env.ampdoc.defaultView = env.win;
 
       const localizationService = new LocalizationService(win.document.body);
-      env.sandbox.stub(Service, 'registerServiceBuilderForDoc');
       env.sandbox
         .stub(Services, 'localizationForDoc')
         .returns(localizationService);

--- a/extensions/amp-story/1.0/test/test-amp-story.js
+++ b/extensions/amp-story/1.0/test/test-amp-story.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import * as Service from '../../../../src/service';
 import * as consent from '../../../../src/consent';
 import * as utils from '../utils';
 import {
@@ -29,6 +30,7 @@ import {AmpStoryBookend} from '../bookend/amp-story-bookend';
 import {AmpStoryConsent} from '../amp-story-consent';
 import {CommonSignals} from '../../../../src/common-signals';
 import {Keys} from '../../../../src/utils/key-codes';
+import {LocalizationService} from '../../../../src/service/localization';
 import {MediaType} from '../media-pool';
 import {PageState} from '../amp-story-page';
 import {PaginationButtons} from '../pagination-buttons';
@@ -117,9 +119,8 @@ describes.realWin(
       win.document.title = 'Story';
       env.ampdoc.defaultView = env.win;
 
-      const localizationService = Services.localizationForDoc(
-        win.document.body
-      );
+      const localizationService = new LocalizationService(win.document.body);
+      env.sandbox.stub(Service, 'registerServiceBuilderForDoc');
       env.sandbox
         .stub(Services, 'localizationForDoc')
         .returns(localizationService);

--- a/extensions/amp-story/1.0/test/test-full-bleed-animations.js
+++ b/extensions/amp-story/1.0/test/test-full-bleed-animations.js
@@ -18,15 +18,20 @@
  * @fileoverview Tests full-bleed animations like panning and zooming.
  */
 
+import * as Service from '../../../../src/service';
 import {AmpStory} from '../amp-story';
 import {AmpStoryStoreService} from '../amp-story-store-service';
+import {LocalizationService} from '../../../../src/service/localization';
 import {Services} from '../../../../src/services';
 import {
   calculateTargetScalingFactor,
   targetFitsWithinPage,
 } from '../animation-presets-utils';
 import {presets} from '../animation-presets';
-import {registerServiceBuilder} from '../../../../src/service';
+import {
+  registerServiceBuilder,
+  registerServiceBuilderForDoc,
+} from '../../../../src/service';
 
 describes.realWin(
   'amp-story-full-bleed-animations',
@@ -58,9 +63,8 @@ describes.realWin(
         };
       });
 
-      const localizationService = Services.localizationForDoc(
-        win.document.body
-      );
+      const localizationService = new LocalizationService(win.document.body);
+      env.sandbox.stub(Service, 'registerServiceBuilderForDoc');
       env.sandbox
         .stub(Services, 'localizationForDoc')
         .returns(localizationService);

--- a/extensions/amp-story/1.0/test/test-full-bleed-animations.js
+++ b/extensions/amp-story/1.0/test/test-full-bleed-animations.js
@@ -18,7 +18,6 @@
  * @fileoverview Tests full-bleed animations like panning and zooming.
  */
 
-import * as Service from '../../../../src/service';
 import {AmpStory} from '../amp-story';
 import {AmpStoryStoreService} from '../amp-story-store-service';
 import {LocalizationService} from '../../../../src/service/localization';
@@ -28,10 +27,7 @@ import {
   targetFitsWithinPage,
 } from '../animation-presets-utils';
 import {presets} from '../animation-presets';
-import {
-  registerServiceBuilder,
-  registerServiceBuilderForDoc,
-} from '../../../../src/service';
+import {registerServiceBuilder} from '../../../../src/service';
 
 describes.realWin(
   'amp-story-full-bleed-animations',
@@ -64,7 +60,6 @@ describes.realWin(
       });
 
       const localizationService = new LocalizationService(win.document.body);
-      env.sandbox.stub(Service, 'registerServiceBuilderForDoc');
       env.sandbox
         .stub(Services, 'localizationForDoc')
         .returns(localizationService);

--- a/extensions/amp-story/1.0/test/test-live-story-manager.js
+++ b/extensions/amp-story/1.0/test/test-live-story-manager.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as Service from '../../../../src/service';
 import {Action} from '../amp-story-store-service';
 import {AmpStory} from '../amp-story';
 import {AmpStoryPage} from '../amp-story-page';
@@ -62,7 +61,6 @@ describes.realWin(
       win = env.win;
 
       const localizationService = new LocalizationService(win.document.body);
-      env.sandbox.stub(Service, 'registerServiceBuilderForDoc');
       env.sandbox
         .stub(Services, 'localizationForDoc')
         .returns(localizationService);

--- a/extensions/amp-story/1.0/test/test-live-story-manager.js
+++ b/extensions/amp-story/1.0/test/test-live-story-manager.js
@@ -14,11 +14,13 @@
  * limitations under the License.
  */
 
+import * as Service from '../../../../src/service';
 import {Action} from '../amp-story-store-service';
 import {AmpStory} from '../amp-story';
 import {AmpStoryPage} from '../amp-story-page';
 import {CommonSignals} from '../../../../src/common-signals';
 import {LiveStoryManager} from '../live-story-manager';
+import {LocalizationService} from '../../../../src/service/localization';
 import {Services} from '../../../../src/services';
 import {addAttributesToElement} from '../../../../src/dom';
 import {registerServiceBuilder} from '../../../../src/service';
@@ -59,9 +61,8 @@ describes.realWin(
     beforeEach(async () => {
       win = env.win;
 
-      const localizationService = Services.localizationForDoc(
-        win.document.body
-      );
+      const localizationService = new LocalizationService(win.document.body);
+      env.sandbox.stub(Service, 'registerServiceBuilderForDoc');
       env.sandbox
         .stub(Services, 'localizationForDoc')
         .returns(localizationService);

--- a/src/service/localization.js
+++ b/src/service/localization.js
@@ -92,12 +92,7 @@ export class LocalizationService {
    * @param {!Element} element
    */
   constructor(element) {
-    const rootEl = element.ownerDocument.documentElement;
-
-    /**
-     * @private @const {!Array<string>}
-     */
-    this.rootLanguageCodes_ = this.getLanguageCodesForElement_(rootEl);
+    this.element_ = element;
 
     /**
      * A mapping of language code to localized string bundle.
@@ -146,9 +141,9 @@ export class LocalizationService {
    * @return {string|null}
    */
   getLocalizedString(localizedStringId, elementToUse = undefined) {
-    const languageCodes = elementToUse
-      ? this.getLanguageCodesForElement_(elementToUse)
-      : this.rootLanguageCodes_;
+    const languageCodes = this.getLanguageCodesForElement_(
+      elementToUse || this.element_
+    );
 
     return findLocalizedString(
       this.localizedStringBundles_,

--- a/src/service/localization.js
+++ b/src/service/localization.js
@@ -140,10 +140,8 @@ export class LocalizationService {
    *     one exists, or the default otherwise.
    * @return {string|null}
    */
-  getLocalizedString(localizedStringId, elementToUse = undefined) {
-    const languageCodes = this.getLanguageCodesForElement_(
-      elementToUse || this.element_
-    );
+  getLocalizedString(localizedStringId, elementToUse = this.element_) {
+    const languageCodes = this.getLanguageCodesForElement_(elementToUse);
 
     return findLocalizedString(
       this.localizedStringBundles_,

--- a/src/services.js
+++ b/src/services.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import {LocalizationService} from './service/localization';
 import {
   getAmpdoc,
   getExistingServiceForDocInEmbedScope,
@@ -22,7 +21,6 @@ import {
   getService,
   getServiceForDoc,
   getServicePromiseForDoc,
-  registerServiceBuilderForDoc,
 } from './service';
 import {
   getElementServiceForDoc,
@@ -550,18 +548,10 @@ export class Services {
    * @param {!Element} element
    */
   static localizationForDoc(element) {
-    let service = /** @type {?./service/localization.LocalizationService} */ (getExistingServiceForDocInEmbedScope(
+    return /** @type {!./service/localization.LocalizationService} */ (getExistingServiceForDocInEmbedScope(
       element,
       'localization'
     ));
-
-    if (!service) {
-      service = new LocalizationService(element);
-      registerServiceBuilderForDoc(element, 'localization', function () {
-        return service;
-      });
-    }
-    return service;
   }
 
   /**

--- a/src/services.js
+++ b/src/services.js
@@ -544,11 +544,11 @@ export class Services {
   }
 
   /**
-   * @return {!./service/localization.LocalizationService}
    * @param {!Element} element
+   * @return {?./service/localization.LocalizationService}
    */
   static localizationForDoc(element) {
-    return /** @type {!./service/localization.LocalizationService} */ (getExistingServiceForDocInEmbedScope(
+    return /** @type {?./service/localization.LocalizationService} */ (getExistingServiceForDocInEmbedScope(
       element,
       'localization'
     ));

--- a/test/unit/test-localization.js
+++ b/test/unit/test-localization.js
@@ -15,11 +15,13 @@
  */
 
 import {
+  LocalizationService,
+  getLanguageCodesFromString,
+} from '../../src/service/localization';
+import {
   LocalizedStringId,
   createPseudoLocale,
 } from '../../src/localized-strings';
-import {Services} from '../../src/services';
-import {getLanguageCodesFromString} from '../../src/service/localization';
 
 describes.fakeWin('localization', {amp: true}, (env) => {
   let win;
@@ -65,9 +67,7 @@ describes.fakeWin('localization', {amp: true}, (env) => {
 
   describe('localization service', () => {
     it('should get string text', () => {
-      const localizationService = Services.localizationForDoc(
-        win.document.body
-      );
+      const localizationService = new LocalizationService(win.document.body);
       localizationService.registerLocalizedStringBundle('en', {
         'test_string_id': {
           string: 'test string content',
@@ -81,9 +81,7 @@ describes.fakeWin('localization', {amp: true}, (env) => {
 
     it('should handle registration of uppercase locales', () => {
       env.win.document.documentElement.setAttribute('lang', 'zh-CN');
-      const localizationService = Services.localizationForDoc(
-        win.document.body
-      );
+      const localizationService = new LocalizationService(win.document.body);
       localizationService.registerLocalizedStringBundle('zh-CN', {
         '123': {
           string: '买票',
@@ -94,9 +92,7 @@ describes.fakeWin('localization', {amp: true}, (env) => {
     });
 
     it('should utilize fallback if string is missing', () => {
-      const localizationService = Services.localizationForDoc(
-        win.document.body
-      );
+      const localizationService = new LocalizationService(win.document.body);
       localizationService.registerLocalizedStringBundle('en', {
         'test_string_id': {
           fallback: 'test fallback content',
@@ -109,9 +105,7 @@ describes.fakeWin('localization', {amp: true}, (env) => {
     });
 
     it('should not utilize fallback if string is present', () => {
-      const localizationService = Services.localizationForDoc(
-        win.document.body
-      );
+      const localizationService = new LocalizationService(win.document.body);
       localizationService.registerLocalizedStringBundle('en', {
         'test_string_id': {
           string: 'test string content',


### PR DESCRIPTION
In the last change done to `LocalizationService` (#27990), I was importing `localization.js` in `services.js` in order to register it. This causes a circular dependency when trying to use `Services` inside of `localization.js`(#28182). 

This PR registers the `LocalizationService` in amp-story directly to avoid the circular dependency.

<!--
# Instructions:

- Pick a meaningful title for your pull request. (Use sentence case.)
  - Prefix the title with an emoji to identify what is being done. (Copy-paste the emoji from the list below.)
  - Do not overuse punctuation in the title (like `(chore):`).
  - If it is helpful, use a simple prefix (like `ProjectX: Implement some feature`).
- Enter a succinct description that says why the PR is necessary, and what it does.
  - Mention the GitHub issue that is being addressed by the pull request.
  - The keywords `Fixes`, `Closes`, or `Resolves` followed the issue number will automatically close the issue.

> NOTE: All non-trivial changes (like introducing new features or components) should have an associated issue or reference an I2I (intent-to-implement: go.amp.dev/i2i). Please read through the contribution process (go.amp.dev/contributing/code) for more information.

# Example of a good description:

- Implement aspect X
- Leave out feature Y because of A
- Improve performance by B
- Improve accessibility by C

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Reverting a previous change
♻️ Refactoring
🚮 Deleting code
-->
