### PR TITLE
Temporarily remove ads from performance test pages

### DIFF
--- a/test/manual/amp-analytics/performanceTestPages/visible-multiple.html
+++ b/test/manual/amp-analytics/performanceTestPages/visible-multiple.html
@@ -1,12 +1,13 @@
 <!-- This testing page is meant to imitate a longer page with multiple sets of 
-text, images, links, and ads. -->
+text, images, links, and ads.
+TODO(micajuineho) add back ads when serving compiled js -->
 <!DOCTYPE html>
 <html lang="en" amp="" i-amphtml-layout="" transformed="self;v=1">
 
 <head>
     <script async="" src="https://cdn.ampproject.org/v0.js"></script>
     <script async="" custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
-    <script async="" custom-element="amp-ad" src="https://cdn.ampproject.org/v0/amp-ad-0.1.js"></script>
+    <!-- <script async="" custom-element="amp-ad" src="https://cdn.ampproject.org/v0/amp-ad-0.1.js"></script> -->
     <title>Test Article</title>
     <style amp-boilerplate="">
         body {
@@ -231,7 +232,7 @@ text, images, links, and ads. -->
 
   <div>
       <amp-layout id="gtm-ad-141698" >
-          <amp-ad width="300" height="400" type="fake" id='i-amphtml-demo-id' data-vars-analytics-var="bar" src="/extensions/amp-ad-network-fake-impl/0.1/data/fake_amp.html">
+          <!-- <amp-ad width="300" height="400" type="fake" id='i-amphtml-demo-id' data-vars-analytics-var="bar" src="/extensions/amp-ad-network-fake-impl/0.1/data/fake_amp.html">
               <div placeholder></div>
               <div fallback></div>
           </amp-ad>
@@ -246,7 +247,7 @@ text, images, links, and ads. -->
           <amp-ad width="300" height="400" type="fake" id='i-amphtml-demo-id' data-vars-analytics-var="bar" src="/extensions/amp-ad-network-fake-impl/0.1/data/fake_amp.html">
               <div placeholder></div>
               <div fallback></div>
-          </amp-ad>
+          </amp-ad> -->
       </amp-layout>
   </div>
   <div>
@@ -351,7 +352,7 @@ text, images, links, and ads. -->
       <div>
           <div>
               <amp-layout id="gtm-ad-141699">
-                  <amp-ad width="300" height="400" type="fake" id='i-amphtml-demo-id' data-vars-analytics-var="bar" src="/extensions/amp-ad-network-fake-impl/0.1/data/fake_amp.html">
+                  <!-- <amp-ad width="300" height="400" type="fake" id='i-amphtml-demo-id' data-vars-analytics-var="bar" src="/extensions/amp-ad-network-fake-impl/0.1/data/fake_amp.html">
                       <div placeholder></div>
                       <div fallback></div>
                   </amp-ad>
@@ -366,7 +367,7 @@ text, images, links, and ads. -->
                   <amp-ad width="300" height="400" type="fake" id='i-amphtml-demo-id' data-vars-analytics-var="bar" src="/extensions/amp-ad-network-fake-impl/0.1/data/fake_amp.html">
                       <div placeholder></div>
                       <div fallback></div>
-                  </amp-ad>
+                  </amp-ad> -->
               </amp-layout>
           </div>
       </div>
@@ -396,7 +397,7 @@ text, images, links, and ads. -->
           <div>
               <div>
                   <amp-layout id="gtm-ad-141701">
-                      <amp-ad width="300" height="400" type="fake" id='i-amphtml-demo-id' data-vars-analytics-var="bar" src="/extensions/amp-ad-network-fake-impl/0.1/data/fake_amp.html">
+                      <!-- <amp-ad width="300" height="400" type="fake" id='i-amphtml-demo-id' data-vars-analytics-var="bar" src="/extensions/amp-ad-network-fake-impl/0.1/data/fake_amp.html">
                           <div placeholder></div>
                           <div fallback></div>
                       </amp-ad>
@@ -411,7 +412,7 @@ text, images, links, and ads. -->
                       <amp-ad width="300" height="400" type="fake" id='i-amphtml-demo-id' data-vars-analytics-var="bar" src="/extensions/amp-ad-network-fake-impl/0.1/data/fake_amp.html">
                           <div placeholder></div>
                           <div fallback></div>
-                      </amp-ad>
+                      </amp-ad> -->
                   </amp-layout>
               </div>
           </div>


### PR DESCRIPTION
Ads are currently not handled in the performance task. Will take a look at them after we stop the `performance experiment` from [failing](https://travis-ci.org/github/ampproject/amphtml/jobs/683920395).