### PR TITLE
Add support for module/nomodule script pairs

### DIFF
--- a/src/multidoc-manager.js
+++ b/src/multidoc-manager.js
@@ -28,6 +28,7 @@ import {disposeServicesForDoc, getServicePromiseOrNullForDoc} from './service';
 import {getMode} from './mode';
 import {installStylesForDoc} from './style-installer';
 import {isArray, isObject} from './types';
+import {parseExtensionUrl} from './service/extension-location';
 import {parseUrlDeprecated} from './url';
 import {setStyle} from './style';
 
@@ -417,15 +418,12 @@ export class MultidocManager {
             if (n.hasAttribute('src')) {
               dev().fine(TAG, '- src script: ', n);
               const src = n.getAttribute('src');
-              const isRuntime =
-                src.indexOf('/amp.js') != -1 || src.indexOf('/v0.js') != -1;
+              const urlParts = parseExtensionUrl(src);
+              const isRuntime = !urlParts.extensionId;
               // Note: Some extensions don't have [custom-element] or
               // [custom-template] e.g. amp-viewer-integration.
               const customElement = n.getAttribute('custom-element');
               const customTemplate = n.getAttribute('custom-template');
-              const versionRe = /-(\d+.\d+)(.max)?\.js$/;
-              const match = versionRe.exec(src);
-              const version = match ? match[1] : '0.1';
               if (isRuntime) {
                 dev().fine(TAG, '- ignore runtime script: ', src);
               } else if (customElement || customTemplate) {
@@ -433,14 +431,14 @@ export class MultidocManager {
                 this.extensions_.installExtensionForDoc(
                   ampdoc,
                   customElement || customTemplate,
-                  version
+                  urlParts.extensionVersion
                 );
                 dev().fine(
                   TAG,
                   '- load extension: ',
                   customElement || customTemplate,
                   ' ',
-                  version
+                  urlParts.extensionVersion
                 );
                 if (customElement) {
                   extensionIds.push(customElement);

--- a/src/service/extensions-impl.js
+++ b/src/service/extensions-impl.js
@@ -243,11 +243,15 @@ export class Extensions {
    */
   reloadExtension(extensionId) {
     // Ignore inserted script elements to prevent recursion.
-    const el = this.getExtensionScript_(
+    const els = this.getExtensionScript_(
       extensionId,
       /* includeInserted */ false
     );
-    devAssert(el, 'Cannot find script for extension: %s', extensionId);
+    devAssert(
+      els.length > 0,
+      'Cannot find script for extension: %s',
+      extensionId
+    );
     // The previously awaited extension loader must not have finished or
     // failed.
     const holder = this.extensions_[extensionId];
@@ -255,8 +259,10 @@ export class Extensions {
       devAssert(!holder.loaded && !holder.error);
       holder.scriptPresent = false;
     }
-    el.setAttribute('i-amphtml-loaded-new-version', extensionId);
-    const urlParts = parseExtensionUrl(el.src);
+    els.forEach((el) =>
+      el.setAttribute('i-amphtml-loaded-new-version', extensionId)
+    );
+    const urlParts = parseExtensionUrl(els[0].src);
     return this.preloadExtension(extensionId, urlParts.extensionVersion);
   }
 
@@ -266,7 +272,7 @@ export class Extensions {
    * @param {string} extensionId
    * @param {boolean=} includeInserted If true, includes script elements that
    *   are inserted by the runtime dynamically. Default is true.
-   * @return {?Element}
+   * @return {!Array<!Element>}
    * @private
    */
   getExtensionScript_(extensionId, includeInserted = true) {
@@ -279,14 +285,15 @@ export class Extensions {
     const matches = this.win.document.head./*OK*/ querySelectorAll(
       `script[src*="/${extensionId}-"]` + modifier
     );
+    const filtered = [];
     for (let i = 0; i < matches.length; i++) {
       const match = matches[i];
       const urlParts = parseExtensionUrl(match.src);
       if (urlParts.extensionId === extensionId) {
-        return match;
+        filtered.push(match);
       }
     }
-    return null;
+    return filtered;
   }
 
   /**
@@ -545,8 +552,8 @@ export class Extensions {
       return false;
     }
     if (holder.scriptPresent === undefined) {
-      const scriptInHead = this.getExtensionScript_(extensionId);
-      holder.scriptPresent = !!scriptInHead;
+      const scriptsInHead = this.getExtensionScript_(extensionId);
+      holder.scriptPresent = scriptsInHead.length > 0;
     }
     return !holder.scriptPresent;
   }

--- a/src/service/extensions-impl.js
+++ b/src/service/extensions-impl.js
@@ -243,7 +243,7 @@ export class Extensions {
    */
   reloadExtension(extensionId) {
     // Ignore inserted script elements to prevent recursion.
-    const els = this.getExtensionScript_(
+    const els = this.getExtensionScripts_(
       extensionId,
       /* includeInserted */ false
     );
@@ -275,7 +275,7 @@ export class Extensions {
    * @return {!Array<!Element>}
    * @private
    */
-  getExtensionScript_(extensionId, includeInserted = true) {
+  getExtensionScripts_(extensionId, includeInserted = true) {
     // Always ignore <script> elements that have a mismatched RTV.
     const modifier =
       ':not([i-amphtml-loaded-new-version])' +
@@ -552,7 +552,7 @@ export class Extensions {
       return false;
     }
     if (holder.scriptPresent === undefined) {
-      const scriptsInHead = this.getExtensionScript_(extensionId);
+      const scriptsInHead = this.getExtensionScripts_(extensionId);
       holder.scriptPresent = scriptsInHead.length > 0;
     }
     return !holder.scriptPresent;

--- a/test/unit/test-extensions.js
+++ b/test/unit/test-extensions.js
@@ -795,7 +795,6 @@ describes.sandboxed('Extensions', {}, () => {
           'src',
           'https://cdn.ampproject.org/v0/amp-list-0.1.mjs'
         );
-        mod.setAttribute('i-amphtml-inserted', '');
         mod.setAttribute('type', 'module');
         win.document.head.appendChild(mod);
 
@@ -805,7 +804,6 @@ describes.sandboxed('Extensions', {}, () => {
           'src',
           'https://cdn.ampproject.org/v0/amp-list-0.1.js'
         );
-        nomod.setAttribute('i-amphtml-inserted', '');
         nomod.setAttribute('nomodule', '');
         win.document.head.appendChild(nomod);
 
@@ -828,7 +826,6 @@ describes.sandboxed('Extensions', {}, () => {
           'src',
           'https://cdn.ampproject.org/v0/amp-list-latest.mjs'
         );
-        mod.setAttribute('i-amphtml-inserted', '');
         mod.setAttribute('type', 'module');
         win.document.head.appendChild(mod);
 
@@ -838,7 +835,6 @@ describes.sandboxed('Extensions', {}, () => {
           'src',
           'https://cdn.ampproject.org/v0/amp-list-latest.js'
         );
-        nomod.setAttribute('i-amphtml-inserted', '');
         nomod.setAttribute('nomodule', '');
         win.document.head.appendChild(nomod);
 

--- a/test/unit/test-extensions.js
+++ b/test/unit/test-extensions.js
@@ -645,100 +645,283 @@ describes.sandboxed('Extensions', {}, () => {
       env.sandbox.stub(extensions, 'preloadExtension');
     });
 
-    it('should devAssert if script cannot be found', () => {
-      expect(() => {
-        allowConsoleError(() => extensions.reloadExtension('amp-list'));
-      }).to.throw('Cannot find script for extension: amp-list');
+    describe('regular scripts', () => {
+      it('should devAssert if script cannot be found', () => {
+        expect(() => {
+          allowConsoleError(() => extensions.reloadExtension('amp-list'));
+        }).to.throw('Cannot find script for extension: amp-list');
 
-      expect(extensions.preloadExtension).to.not.be.called;
+        expect(extensions.preloadExtension).to.not.be.called;
+      });
+
+      it('should ignore inserted scripts', () => {
+        const list = document.createElement('script');
+        list.setAttribute('custom-element', 'amp-list');
+        list.setAttribute(
+          'src',
+          'https://cdn.ampproject.org/v0/amp-list-0.1.js'
+        );
+        list.setAttribute('i-amphtml-inserted', '');
+        win.document.head.appendChild(list);
+
+        expect(() => {
+          allowConsoleError(() => extensions.reloadExtension('amp-list'));
+        }).to.throw('Cannot find script for extension: amp-list');
+
+        expect(list.hasAttribute('i-amphtml-loaded-new-version')).to.be.false;
+        expect(extensions.preloadExtension).to.not.be.called;
+      });
+
+      it('should support [custom-element] scripts', () => {
+        const list = document.createElement('script');
+        list.setAttribute('custom-element', 'amp-list');
+        list.setAttribute(
+          'src',
+          'https://cdn.ampproject.org/v0/amp-list-0.1.js'
+        );
+        win.document.head.appendChild(list);
+
+        extensions.reloadExtension('amp-list');
+
+        expect(list.getAttribute('i-amphtml-loaded-new-version')).to.equal(
+          'amp-list'
+        );
+        expect(extensions.preloadExtension).to.be.calledWith('amp-list', '0.1');
+      });
+
+      it('should support "latest" version scripts', () => {
+        const list = document.createElement('script');
+        list.setAttribute('custom-element', 'amp-list');
+        list.setAttribute(
+          'src',
+          'https://cdn.ampproject.org/v0/amp-list-latest.js'
+        );
+        win.document.head.appendChild(list);
+
+        extensions.reloadExtension('amp-list');
+
+        expect(list.getAttribute('i-amphtml-loaded-new-version')).to.equal(
+          'amp-list'
+        );
+        expect(extensions.preloadExtension).to.be.calledWith(
+          'amp-list',
+          'latest'
+        );
+      });
+
+      it('should support [custom-template] scripts', () => {
+        const mustache = document.createElement('script');
+        mustache.setAttribute('custom-template', 'amp-mustache');
+        mustache.setAttribute(
+          'src',
+          'https://cdn.ampproject.org/v0/amp-mustache-0.2.js'
+        );
+        win.document.head.appendChild(mustache);
+
+        extensions.reloadExtension('amp-mustache');
+
+        expect(mustache.getAttribute('i-amphtml-loaded-new-version')).to.equal(
+          'amp-mustache'
+        );
+        expect(extensions.preloadExtension).to.be.calledWith(
+          'amp-mustache',
+          '0.2'
+        );
+      });
+
+      it('should support no-attribute scripts', () => {
+        const viewer = document.createElement('script');
+        viewer.setAttribute(
+          'src',
+          'https://cdn.ampproject.org/v0/amp-viewer-integration-0.1.js'
+        );
+        win.document.head.appendChild(viewer);
+
+        extensions.reloadExtension('amp-viewer-integration');
+
+        expect(viewer.getAttribute('i-amphtml-loaded-new-version')).to.equal(
+          'amp-viewer-integration'
+        );
+        expect(extensions.preloadExtension).to.be.calledWith(
+          'amp-viewer-integration',
+          '0.1'
+        );
+      });
     });
 
-    it('should ignore inserted scripts', () => {
-      const list = document.createElement('script');
-      list.setAttribute('custom-element', 'amp-list');
-      list.setAttribute('src', 'https://cdn.ampproject.org/v0/amp-list-0.1.js');
-      list.setAttribute('i-amphtml-inserted', '');
-      win.document.head.appendChild(list);
+    describe('module/nomdule script pairs', () => {
+      it('should devAssert if script cannot be found', () => {
+        expect(() => {
+          allowConsoleError(() => extensions.reloadExtension('amp-list'));
+        }).to.throw('Cannot find script for extension: amp-list');
 
-      expect(() => {
-        allowConsoleError(() => extensions.reloadExtension('amp-list'));
-      }).to.throw('Cannot find script for extension: amp-list');
+        expect(extensions.preloadExtension).to.not.be.called;
+      });
 
-      expect(list.hasAttribute('i-amphtml-loaded-new-version')).to.be.false;
-      expect(extensions.preloadExtension).to.not.be.called;
-    });
+      it('should ignore inserted scripts', () => {
+        const mod = document.createElement('script');
+        mod.setAttribute('custom-element', 'amp-list');
+        mod.setAttribute(
+          'src',
+          'https://cdn.ampproject.org/v0/amp-list-0.1.mjs'
+        );
+        mod.setAttribute('i-amphtml-inserted', '');
+        mod.setAttribute('type', 'module');
+        win.document.head.appendChild(mod);
 
-    it('should support [custom-element] scripts', () => {
-      const list = document.createElement('script');
-      list.setAttribute('custom-element', 'amp-list');
-      list.setAttribute('src', 'https://cdn.ampproject.org/v0/amp-list-0.1.js');
-      win.document.head.appendChild(list);
+        const nomod = document.createElement('script');
+        nomod.setAttribute('custom-element', 'amp-list');
+        nomod.setAttribute(
+          'src',
+          'https://cdn.ampproject.org/v0/amp-list-0.1.js'
+        );
+        nomod.setAttribute('i-amphtml-inserted', '');
+        nomod.setAttribute('nomodule', '');
+        win.document.head.appendChild(nomod);
 
-      extensions.reloadExtension('amp-list');
+        expect(() => {
+          allowConsoleError(() => extensions.reloadExtension('amp-list'));
+        }).to.throw('Cannot find script for extension: amp-list');
 
-      expect(list.getAttribute('i-amphtml-loaded-new-version')).to.equal(
-        'amp-list'
-      );
-      expect(extensions.preloadExtension).to.be.calledWith('amp-list', '0.1');
-    });
+        expect(mod.hasAttribute('i-amphtml-loaded-new-version')).to.be.false;
+        expect(nomod.hasAttribute('i-amphtml-loaded-new-version')).to.be.false;
+        expect(extensions.preloadExtension).to.not.be.called;
+      });
 
-    it('should support "latest" version scripts', () => {
-      const list = document.createElement('script');
-      list.setAttribute('custom-element', 'amp-list');
-      list.setAttribute(
-        'src',
-        'https://cdn.ampproject.org/v0/amp-list-latest.js'
-      );
-      win.document.head.appendChild(list);
+      it('should support [custom-element] scripts', () => {
+        const mod = document.createElement('script');
+        mod.setAttribute('custom-element', 'amp-list');
+        mod.setAttribute(
+          'src',
+          'https://cdn.ampproject.org/v0/amp-list-0.1.mjs'
+        );
+        mod.setAttribute('i-amphtml-inserted', '');
+        mod.setAttribute('type', 'module');
+        win.document.head.appendChild(mod);
 
-      extensions.reloadExtension('amp-list');
+        const nomod = document.createElement('script');
+        nomod.setAttribute('custom-element', 'amp-list');
+        nomod.setAttribute(
+          'src',
+          'https://cdn.ampproject.org/v0/amp-list-0.1.js'
+        );
+        nomod.setAttribute('i-amphtml-inserted', '');
+        nomod.setAttribute('nomodule', '');
+        win.document.head.appendChild(nomod);
 
-      expect(list.getAttribute('i-amphtml-loaded-new-version')).to.equal(
-        'amp-list'
-      );
-      expect(extensions.preloadExtension).to.be.calledWith(
-        'amp-list',
-        'latest'
-      );
-    });
+        extensions.reloadExtension('amp-list');
 
-    it('should support [custom-template] scripts', () => {
-      const mustache = document.createElement('script');
-      mustache.setAttribute('custom-template', 'amp-mustache');
-      mustache.setAttribute(
-        'src',
-        'https://cdn.ampproject.org/v0/amp-mustache-0.2.js'
-      );
-      win.document.head.appendChild(mustache);
+        expect(mod.getAttribute('i-amphtml-loaded-new-version')).to.equal(
+          'amp-list'
+        );
+        expect(nomod.getAttribute('i-amphtml-loaded-new-version')).to.equal(
+          'amp-list'
+        );
+        expect(extensions.preloadExtension).to.be.calledOnce;
+        expect(extensions.preloadExtension).to.be.calledWith('amp-list', '0.1');
+      });
 
-      extensions.reloadExtension('amp-mustache');
+      it('should support "latest" version scripts', () => {
+        const mod = document.createElement('script');
+        mod.setAttribute('custom-element', 'amp-list');
+        mod.setAttribute(
+          'src',
+          'https://cdn.ampproject.org/v0/amp-list-latest.mjs'
+        );
+        mod.setAttribute('i-amphtml-inserted', '');
+        mod.setAttribute('type', 'module');
+        win.document.head.appendChild(mod);
 
-      expect(mustache.getAttribute('i-amphtml-loaded-new-version')).to.equal(
-        'amp-mustache'
-      );
-      expect(extensions.preloadExtension).to.be.calledWith(
-        'amp-mustache',
-        '0.2'
-      );
-    });
+        const nomod = document.createElement('script');
+        nomod.setAttribute('custom-element', 'amp-list');
+        nomod.setAttribute(
+          'src',
+          'https://cdn.ampproject.org/v0/amp-list-latest.js'
+        );
+        nomod.setAttribute('i-amphtml-inserted', '');
+        nomod.setAttribute('nomodule', '');
+        win.document.head.appendChild(nomod);
 
-    it('should support no-attribute scripts', () => {
-      const viewer = document.createElement('script');
-      viewer.setAttribute(
-        'src',
-        'https://cdn.ampproject.org/v0/amp-viewer-integration-0.1.js'
-      );
-      win.document.head.appendChild(viewer);
+        extensions.reloadExtension('amp-list');
 
-      extensions.reloadExtension('amp-viewer-integration');
+        expect(mod.getAttribute('i-amphtml-loaded-new-version')).to.equal(
+          'amp-list'
+        );
+        expect(nomod.getAttribute('i-amphtml-loaded-new-version')).to.equal(
+          'amp-list'
+        );
+        expect(extensions.preloadExtension).to.be.calledOnce;
+        expect(extensions.preloadExtension).to.be.calledWith(
+          'amp-list',
+          'latest'
+        );
+      });
 
-      expect(viewer.getAttribute('i-amphtml-loaded-new-version')).to.equal(
-        'amp-viewer-integration'
-      );
-      expect(extensions.preloadExtension).to.be.calledWith(
-        'amp-viewer-integration',
-        '0.1'
-      );
+      it('should support [custom-template] scripts', () => {
+        const mod = document.createElement('script');
+        mod.setAttribute('custom-template', 'amp-mustache');
+        mod.setAttribute(
+          'src',
+          'https://cdn.ampproject.org/v0/amp-mustache-0.2.mjs'
+        );
+        mod.setAttribute('type', 'module');
+        win.document.head.appendChild(mod);
+
+        const nomod = document.createElement('script');
+        nomod.setAttribute('custom-template', 'amp-mustache');
+        nomod.setAttribute(
+          'src',
+          'https://cdn.ampproject.org/v0/amp-mustache-0.2.js'
+        );
+        nomod.setAttribute('nomodule', '');
+        win.document.head.appendChild(nomod);
+
+        extensions.reloadExtension('amp-mustache');
+
+        expect(mod.getAttribute('i-amphtml-loaded-new-version')).to.equal(
+          'amp-mustache'
+        );
+        expect(nomod.getAttribute('i-amphtml-loaded-new-version')).to.equal(
+          'amp-mustache'
+        );
+        expect(extensions.preloadExtension).to.be.calledOnce;
+        expect(extensions.preloadExtension).to.be.calledWith(
+          'amp-mustache',
+          '0.2'
+        );
+      });
+
+      it('should support no-attribute scripts', () => {
+        const mod = document.createElement('script');
+        mod.setAttribute(
+          'src',
+          'https://cdn.ampproject.org/v0/amp-viewer-integration-0.1.mjs'
+        );
+        mod.setAttribute('type', 'module');
+        win.document.head.appendChild(mod);
+
+        const nomod = document.createElement('script');
+        nomod.setAttribute(
+          'src',
+          'https://cdn.ampproject.org/v0/amp-viewer-integration-0.1.js'
+        );
+        nomod.setAttribute('nomodule', '');
+        win.document.head.appendChild(nomod);
+
+        extensions.reloadExtension('amp-viewer-integration');
+
+        expect(mod.getAttribute('i-amphtml-loaded-new-version')).to.equal(
+          'amp-viewer-integration'
+        );
+        expect(nomod.getAttribute('i-amphtml-loaded-new-version')).to.equal(
+          'amp-viewer-integration'
+        );
+        expect(extensions.preloadExtension).to.be.calledOnce;
+        expect(extensions.preloadExtension).to.be.calledWith(
+          'amp-viewer-integration',
+          '0.1'
+        );
+      });
     });
   });
 

--- a/test/unit/test-runtime.js
+++ b/test/unit/test-runtime.js
@@ -1086,7 +1086,10 @@ describes.realWin(
 
         const script = win.document.createElement('script');
         script.setAttribute('custom-element', 'amp-ext');
-        script.setAttribute('src', '');
+        script.setAttribute(
+          'src',
+          'https://cdn.ampproject.org/v0/amp-ext-0.1.js'
+        );
         importDoc.head.appendChild(script);
 
         win.AMP.attachShadowDoc(hostElement, importDoc, docUrl);
@@ -1218,11 +1221,20 @@ describes.realWin(
         ).to.contain('.keyframes');
       });
 
-      it('should ignore runtime extension', () => {
+      it('should ignore runtime', () => {
         extensionsMock.expects('preloadExtension').never();
 
         const scriptEl = win.document.createElement('script');
         scriptEl.setAttribute('src', 'https://cdn.ampproject.org/v0.js');
+        importDoc.head.appendChild(scriptEl);
+        win.AMP.attachShadowDoc(hostElement, importDoc, docUrl);
+      });
+
+      it('should ignore mjs runtime', () => {
+        extensionsMock.expects('preloadExtension').never();
+
+        const scriptEl = win.document.createElement('script');
+        scriptEl.setAttribute('src', 'https://cdn.ampproject.org/v0.mjs');
         importDoc.head.appendChild(scriptEl);
         win.AMP.attachShadowDoc(hostElement, importDoc, docUrl);
       });
@@ -1261,6 +1273,41 @@ describes.realWin(
         scriptEl.setAttribute('custom-element', 'amp-ext1');
         scriptEl.setAttribute('src', '');
         importDoc.head.appendChild(scriptEl);
+        win.AMP.attachShadowDoc(hostElement, importDoc, docUrl);
+        expect(win.document.querySelector('script[custom-element="amp-ext1"]'))
+          .to.not.exist;
+      });
+
+      it('should import module/nomodule extension element', () => {
+        extensionsMock
+          .expects('preloadExtension')
+          .withExactArgs('amp-ext1', '0.1')
+          .returns(
+            Promise.resolve({
+              elements: {
+                'amp-ext1': function () {},
+              },
+            })
+          )
+          .once();
+
+        const mod = win.document.createElement('script');
+        mod.setAttribute('custom-element', 'amp-ext1');
+        mod.setAttribute(
+          'src',
+          'https://cdn.ampproject.org/v0/amp-ext-0.1.mjs'
+        );
+        mod.setAttribute('type', 'module');
+        const nomod = win.document.createElement('script');
+        nomod.setAttribute('custom-element', 'amp-ext1');
+        nomod.setAttribute(
+          'src',
+          'https://cdn.ampproject.org/v0/amp-ext-0.1.js'
+        );
+        nomod.setAttribute('nomodule', '');
+
+        importDoc.head.appendChild(mod);
+        importDoc.head.appendChild(nomod);
         win.AMP.attachShadowDoc(hostElement, importDoc, docUrl);
         expect(win.document.querySelector('script[custom-element="amp-ext1"]'))
           .to.not.exist;

--- a/test/unit/test-runtime.js
+++ b/test/unit/test-runtime.js
@@ -542,7 +542,7 @@ describes.fakeWin(
         const s = document.createElement('script');
         const name = 'amp-test-element' + index;
         s.setAttribute('custom-element', name);
-        s.setAttribute('src', `/${name}-0.1.js`);
+        s.setAttribute('src', `https://cdn.ampproject.org/v0/${name}-0.1.js`);
         win.document.head.appendChild(s);
         return s;
       }
@@ -1271,7 +1271,10 @@ describes.realWin(
 
         const scriptEl = win.document.createElement('script');
         scriptEl.setAttribute('custom-element', 'amp-ext1');
-        scriptEl.setAttribute('src', '');
+        scriptEl.setAttribute(
+          'src',
+          'https://cdn.ampproject.org/v0/amp-ext-0.1.js'
+        );
         importDoc.head.appendChild(scriptEl);
         win.AMP.attachShadowDoc(hostElement, importDoc, docUrl);
         expect(win.document.querySelector('script[custom-element="amp-ext1"]'))
@@ -1347,7 +1350,10 @@ describes.realWin(
 
         const scriptEl = win.document.createElement('script');
         scriptEl.setAttribute('custom-template', 'amp-ext1');
-        scriptEl.setAttribute('src', '');
+        scriptEl.setAttribute(
+          'src',
+          'https://cdn.ampproject.org/v0/amp-ext1-0.1.js'
+        );
         importDoc.head.appendChild(scriptEl);
         win.AMP.attachShadowDoc(hostElement, importDoc, docUrl);
         expect(win.document.querySelector('script[custom-template="amp-ext1"]'))
@@ -1503,7 +1509,9 @@ describes.realWin(
             },
           });
 
-          writer.write('<script custom-element="amp-ext" src=""></script>');
+          writer.write(
+            '<script custom-element="amp-ext" src="https://cdn.ampproject.org/v0/amp-ext-0.1.js"></script>'
+          );
           writer.write('<body>');
 
           return ampdoc.waitForBodyOpen().then(() => {
@@ -1674,11 +1682,6 @@ describes.realWin(
         });
 
         it('should ignore unknown script', () => {
-          expectAsyncConsoleError(
-            '[multidoc-manager] - unknown script:  [object HTMLScriptElement] ' +
-              'https://cdn.ampproject.org/other.js'
-          );
-
           shadowDoc = win.AMP.attachShadowDocAsStream(hostElement, docUrl);
           writer = shadowDoc.writer;
           extensionsMock.expects('preloadExtension').never();
@@ -1712,7 +1715,9 @@ describes.realWin(
               })
             )
             .once();
-          writer.write('<script custom-element="amp-ext1" src=""></script>');
+          writer.write(
+            '<script custom-element="amp-ext1" src="https://cdn.ampproject.org/v0/amp-ext1-0.1.js"></script>'
+          );
           writer.write('<body>');
           return ampdoc.waitForBodyOpen().then(() => {
             expect(
@@ -1729,7 +1734,9 @@ describes.realWin(
             .withExactArgs('amp-ext1', '0.1')
             .returns(Promise.resolve({elements: {}}))
             .once();
-          writer.write('<script custom-template="amp-ext1" src=""></script>');
+          writer.write(
+            '<script custom-template="amp-ext1" src="https://cdn.ampproject.org/v0/amp-ext1-0.1.js"></script>'
+          );
           writer.write('<body>');
           return ampdoc.waitForBodyOpen().then(() => {
             expect(


### PR DESCRIPTION
Fixes the only two (that I've found) issues with module/nomodule script pairs:

1. When extensions are reloaded, we didn't mark all current scripts as "replaced".
2. When Multidoc inserts scripts into the new ampdoc, it couldn't correctly parse `v0.mjs`.

Everywhere else won't care about script pairs. The extension service collates all `custom-element` attributes into a set. Multidoc will try to insert the pairs twice (once for each script), but only the first will actually insert since it'll be registered. And reloading/inserting will always insert the correct `.js` or `.mjs` based on whether the runtime is currently using `getMode().esm`.