### PR TITLE
♻️ Require trigger="visibility" to run an <amp-story-animation> effect

### DIFF
--- a/examples/amp-story/amp-story-animation.html
+++ b/examples/amp-story/amp-story-animation.html
@@ -38,7 +38,7 @@
             fly-in with animate-in, after the previous element
           </div>
         </amp-story-grid-layer>
-        <amp-story-animation trigger="in">
+        <amp-story-animation layout="nodisplay" trigger="in">
           <script type="application/json">
             {
               "selector": ".animate",
@@ -59,7 +59,7 @@
             fly-in with animate-in, after the previous element
           </div>
         </amp-story-grid-layer>
-        <amp-story-animation trigger="in">
+        <amp-story-animation layout="nodisplay" trigger="in">
           <script type="application/json">
             {
               "selector": ".animate",
@@ -80,7 +80,7 @@
           <div class="box animate-bottom"></div>
           <div class="box animate-right"></div>
         </amp-story-grid-layer>
-        <amp-story-animation trigger="in">
+        <amp-story-animation layout="nodisplay" trigger="in">
           <script type="application/json">
             [
               {

--- a/examples/amp-story/amp-story-animation.html
+++ b/examples/amp-story/amp-story-animation.html
@@ -38,7 +38,7 @@
             fly-in with animate-in, after the previous element
           </div>
         </amp-story-grid-layer>
-        <amp-story-animation layout="nodisplay" trigger="in">
+        <amp-story-animation layout="nodisplay" trigger="visibility">
           <script type="application/json">
             {
               "selector": ".animate",
@@ -59,7 +59,7 @@
             fly-in with animate-in, after the previous element
           </div>
         </amp-story-grid-layer>
-        <amp-story-animation layout="nodisplay" trigger="in">
+        <amp-story-animation layout="nodisplay" trigger="visibility">
           <script type="application/json">
             {
               "selector": ".animate",
@@ -80,7 +80,7 @@
           <div class="box animate-bottom"></div>
           <div class="box animate-right"></div>
         </amp-story-grid-layer>
-        <amp-story-animation layout="nodisplay" trigger="in">
+        <amp-story-animation layout="nodisplay" trigger="visibility">
           <script type="application/json">
             [
               {

--- a/examples/amp-story/amp-story-animation.html
+++ b/examples/amp-story/amp-story-animation.html
@@ -38,7 +38,7 @@
             fly-in with animate-in, after the previous element
           </div>
         </amp-story-grid-layer>
-        <amp-story-animation layout="nodisplay">
+        <amp-story-animation trigger="in">
           <script type="application/json">
             {
               "selector": ".animate",
@@ -59,7 +59,7 @@
             fly-in with animate-in, after the previous element
           </div>
         </amp-story-grid-layer>
-        <amp-story-animation layout="nodisplay">
+        <amp-story-animation trigger="in">
           <script type="application/json">
             {
               "selector": ".animate",
@@ -80,7 +80,7 @@
           <div class="box animate-bottom"></div>
           <div class="box animate-right"></div>
         </amp-story-grid-layer>
-        <amp-story-animation layout="nodisplay">
+        <amp-story-animation trigger="in">
           <script type="application/json">
             [
               {

--- a/extensions/amp-story/1.0/animation.js
+++ b/extensions/amp-story/1.0/animation.js
@@ -634,7 +634,9 @@ export class AnimationManager {
         )
         .concat(
           Array.prototype.map.call(
-            this.page_.querySelectorAll('amp-story-animation[trigger=in]'),
+            this.page_.querySelectorAll(
+              'amp-story-animation[trigger=visibility]'
+            ),
             (el) =>
               this.createRunner_({
                 source: el,

--- a/extensions/amp-story/1.0/animation.js
+++ b/extensions/amp-story/1.0/animation.js
@@ -33,15 +33,11 @@ import {
   WebKeyframesDef,
 } from './animation-types';
 import {assertDoesNotContainDisplay, setStyles} from '../../../src/style';
-import {
-  childElementsByTag,
-  scopedQuerySelector,
-  scopedQuerySelectorAll,
-} from '../../../src/dom';
 import {dev, devAssert, user, userAssert} from '../../../src/log';
 import {escapeCssSelectorIdent} from '../../../src/css';
 import {getChildJsonConfig} from '../../../src/json';
 import {map, omit} from '../../../src/utils/object';
+import {scopedQuerySelector, scopedQuerySelectorAll} from '../../../src/dom';
 import {timeStrToMillis, unscaledClientRect} from './utils';
 
 /** @const {string} */

--- a/extensions/amp-story/1.0/animation.js
+++ b/extensions/amp-story/1.0/animation.js
@@ -638,7 +638,7 @@ export class AnimationManager {
         )
         .concat(
           Array.prototype.map.call(
-            childElementsByTag(this.page_, 'amp-story-animation'),
+            this.page_.querySelectorAll('amp-story-animation[trigger=in]'),
             (el) =>
               this.createRunner_({
                 source: el,

--- a/extensions/amp-story/1.0/test/test-animation.js
+++ b/extensions/amp-story/1.0/test/test-animation.js
@@ -496,10 +496,10 @@ describes.realWin('amp-story animations', {}, (env) => {
 
       const page = html`
         <div>
-          <amp-story-animation trigger="in" ref="spec1source">
+          <amp-story-animation trigger="visibility" ref="spec1source">
             <script type="application/json"></script>
           </amp-story-animation>
-          <amp-story-animation trigger="in" ref="spec2source">
+          <amp-story-animation trigger="visibility" ref="spec2source">
             <script type="application/json"></script>
           </amp-story-animation>
         </div>
@@ -647,7 +647,7 @@ describes.realWin('amp-story animations', {}, (env) => {
             id="animated-fourth"
             ref="animatedFourth"
             animate-in-after="animated-third"
-            trigger="in"
+            trigger="visibility"
           >
             <script type="application/json">
               {}

--- a/extensions/amp-story/1.0/test/test-animation.js
+++ b/extensions/amp-story/1.0/test/test-animation.js
@@ -496,10 +496,10 @@ describes.realWin('amp-story animations', {}, (env) => {
 
       const page = html`
         <div>
-          <amp-story-animation ref="spec1source">
+          <amp-story-animation trigger="in" ref="spec1source">
             <script type="application/json"></script>
           </amp-story-animation>
-          <amp-story-animation ref="spec2source">
+          <amp-story-animation trigger="in" ref="spec2source">
             <script type="application/json"></script>
           </amp-story-animation>
         </div>
@@ -647,6 +647,7 @@ describes.realWin('amp-story animations', {}, (env) => {
             id="animated-fourth"
             ref="animatedFourth"
             animate-in-after="animated-third"
+            trigger="in"
           >
             <script type="application/json">
               {}


### PR DESCRIPTION
This disambiguates effect specs that trigger with page entrance versus those that are triggered by other specs (subanimations).

Note that subanimations are not currently supported, but this change prevents issues when introducing the feature.