### PR TITLE
🐛 Register `LINKER_CREATED` on ampdoc instead of attribute

### DIFF
--- a/build-system/test-configs/dep-check-config.js
+++ b/build-system/test-configs/dep-check-config.js
@@ -369,6 +369,11 @@ exports.rules = [
       // Experiment moving Fixed Layer to extension
       'extensions/amp-viewer-integration/0.1/amp-viewer-integration.js->' +
         'src/service/fixed-layer.js',
+      // Accessing AMPDOC_SINGLETON_NAME
+      'extensions/amp-iframe/0.1/amp-iframe.js->' +
+        'src/service/ampdoc-impl.js',
+      'extensions/amp-analytics/0.1/linker-manager.js->' +
+        'src/service/ampdoc-impl.js',
     ],
   },
   {

--- a/build-system/test-configs/dep-check-config.js
+++ b/build-system/test-configs/dep-check-config.js
@@ -369,11 +369,6 @@ exports.rules = [
       // Experiment moving Fixed Layer to extension
       'extensions/amp-viewer-integration/0.1/amp-viewer-integration.js->' +
         'src/service/fixed-layer.js',
-      // Accessing AMPDOC_SINGLETON_NAME
-      'extensions/amp-iframe/0.1/amp-iframe.js->' +
-        'src/service/ampdoc-impl.js',
-      'extensions/amp-analytics/0.1/linker-manager.js->' +
-        'src/service/ampdoc-impl.js',
     ],
   },
   {

--- a/extensions/amp-analytics/0.1/linker-manager.js
+++ b/extensions/amp-analytics/0.1/linker-manager.js
@@ -232,19 +232,11 @@ export class LinkerManager {
       return false;
     }
 
-    const headNode = this.ampdoc_.getHeadNode();
-    const linkerCreatedEl =
-      headNode instanceof ShadowRoot
-        ? this.ampdoc_.getBody()
-        : headNode.querySelector(
-            'meta[name="amp-google-client-id-api"][content="googleanalytics"]'
-          );
-
-    if (linkerCreatedEl.hasAttribute(LINKER_CREATED)) {
+    if (this.ampdoc_.getBody().hasAttribute(LINKER_CREATED)) {
       return false;
     }
 
-    linkerCreatedEl.setAttribute(LINKER_CREATED, '');
+    this.ampdoc_.getBody().setAttribute(LINKER_CREATED, '');
     return true;
   }
 

--- a/extensions/amp-analytics/0.1/linker-manager.js
+++ b/extensions/amp-analytics/0.1/linker-manager.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {AMPDOC_SINGLETON_NAME} from '../../../src/service/ampdoc-impl';
+import {AMPDOC_SINGLETON_NAME} from '../../../src/enums';
 import {ExpansionOptions, variableServiceForDoc} from './variables';
 import {Priority} from '../../../src/service/navigation';
 import {Services} from '../../../src/services';

--- a/extensions/amp-analytics/0.1/linker-manager.js
+++ b/extensions/amp-analytics/0.1/linker-manager.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {AMPDOC_SINGLETON_NAME} from '../../../src/service/ampdoc-impl';
 import {ExpansionOptions, variableServiceForDoc} from './variables';
 import {Priority} from '../../../src/service/navigation';
 import {Services} from '../../../src/services';
@@ -28,9 +29,6 @@ import {user} from '../../../src/log';
 
 /** @const {string} */
 const TAG = 'amp-analytics/linker-manager';
-
-/** @const {string} */
-const LINKER_CREATED = 'linker-created';
 
 export class LinkerManager {
   /**
@@ -232,11 +230,7 @@ export class LinkerManager {
       return false;
     }
 
-    if (!this.ampdoc_.registerService(LINKER_CREATED)) {
-      return false;
-    }
-
-    return true;
+    return this.ampdoc_.registerSingleton(AMPDOC_SINGLETON_NAME.LINKER);
   }
 
   /**

--- a/extensions/amp-analytics/0.1/linker-manager.js
+++ b/extensions/amp-analytics/0.1/linker-manager.js
@@ -30,7 +30,7 @@ import {user} from '../../../src/log';
 const TAG = 'amp-analytics/linker-manager';
 
 /** @const {string} */
-const LINKER_CREATED = 'i-amphtml-linker-created';
+const LINKER_CREATED = 'linker-created';
 
 export class LinkerManager {
   /**
@@ -232,11 +232,10 @@ export class LinkerManager {
       return false;
     }
 
-    if (this.ampdoc_.getBody().hasAttribute(LINKER_CREATED)) {
+    if (!this.ampdoc_.registerService(LINKER_CREATED)) {
       return false;
     }
 
-    this.ampdoc_.getBody().setAttribute(LINKER_CREATED, '');
     return true;
   }
 

--- a/extensions/amp-iframe/0.1/amp-iframe.js
+++ b/extensions/amp-iframe/0.1/amp-iframe.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {AMPDOC_SINGLETON_NAME} from '../../../src/service/ampdoc-impl';
 import {ActionTrust} from '../../../src/action-constants';
 import {IntersectionObserverHostApi} from '../../../src/utils/intersection-observer-polyfill';
 import {LayoutPriority, isLayoutSizeDefined} from '../../../src/layout';
@@ -56,9 +57,6 @@ const ATTRIBUTES_TO_PROPAGATE = [
   'tabindex',
   'title',
 ];
-
-/** @const {string} */
-const TRACKING_IFRAME = 'tracking_iframe';
 
 /** @type {number}  */
 let count = 0;
@@ -398,7 +396,11 @@ export class AmpIframe extends AMP.BaseElement {
     }
 
     if (this.isTrackingFrame_) {
-      if (!this.getAmpDoc().registerService(TRACKING_IFRAME)) {
+      if (
+        !this.getAmpDoc().registerSingleton(
+          AMPDOC_SINGLETON_NAME.TRACKING_IFRAME
+        )
+      ) {
         console /*OK*/
           .error(
             'Only 1 analytics/tracking iframe allowed per ' +

--- a/extensions/amp-iframe/0.1/amp-iframe.js
+++ b/extensions/amp-iframe/0.1/amp-iframe.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {AMPDOC_SINGLETON_NAME} from '../../../src/service/ampdoc-impl';
+import {AMPDOC_SINGLETON_NAME} from '../../../src/enums';
 import {ActionTrust} from '../../../src/action-constants';
 import {IntersectionObserverHostApi} from '../../../src/utils/intersection-observer-polyfill';
 import {LayoutPriority, isLayoutSizeDefined} from '../../../src/layout';

--- a/extensions/amp-iframe/0.1/amp-iframe.js
+++ b/extensions/amp-iframe/0.1/amp-iframe.js
@@ -57,6 +57,9 @@ const ATTRIBUTES_TO_PROPAGATE = [
   'title',
 ];
 
+/** @const {string} */
+const TRACKING_IFRAME = 'tracking_iframe';
+
 /** @type {number}  */
 let count = 0;
 
@@ -395,7 +398,7 @@ export class AmpIframe extends AMP.BaseElement {
     }
 
     if (this.isTrackingFrame_) {
-      if (!this.getAmpDoc().registerTrackingIframe()) {
+      if (!this.getAmpDoc().registerService(TRACKING_IFRAME)) {
         console /*OK*/
           .error(
             'Only 1 analytics/tracking iframe allowed per ' +

--- a/src/enums.js
+++ b/src/enums.js
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Registred singleton on AMP doc.
+ * @enum {number}
+ */
+export const AMPDOC_SINGLETON_NAME = {
+  TRACKING_IFRAME: 1,
+  LINKER: 2,
+};

--- a/src/service/ampdoc-impl.js
+++ b/src/service/ampdoc-impl.js
@@ -59,6 +59,15 @@ const AmpDocSignals = {
 };
 
 /**
+ * Registred singleton on AMP doc.
+ * @enum {number}
+ */
+export const AMPDOC_SINGLETON_NAME = {
+  TRACKING_IFRAME: 1,
+  LINKER: 2,
+};
+
+/**
  * This service helps locate an ampdoc (`AmpDoc` instance) for any node,
  * either in the single-doc or shadow-doc environments.
  *
@@ -308,8 +317,8 @@ export class AmpDoc {
     /** @public @const {!Window} */
     this.win = win;
 
-    /** @private {!Object<string, boolean>} */
-    this.registeredService_ = map();
+    /** @private {!Object<AMPDOC_SINGLETON_NAME, boolean>} */
+    this.registeredSingleton_ = map();
 
     /** @public @const {?AmpDoc} */
     this.parent_ = parent;
@@ -754,19 +763,14 @@ export class AmpDoc {
   }
 
   /**
-   * Attempt to register a service that is allowed/required one for each ampdoc.
+   * Attempt to register a singleton for each ampdoc.
    * Caller need to handle user error when registration returns false.
-   *
-   * Please list your service name below:
-   * 'tracking_iframe',
-   * 'linker-created',
-   *
-   * @param {string} name
+   * @param {AMPDOC_SINGLETON_NAME} name
    * @return {boolean}
    */
-  registerService(name) {
-    if (!this.registeredService_[name]) {
-      this.registeredService_[name] = true;
+  registerSingleton(name) {
+    if (!this.registeredSingleton_[name]) {
+      this.registeredSingleton_[name] = true;
       return true;
     }
     return false;

--- a/src/service/ampdoc-impl.js
+++ b/src/service/ampdoc-impl.js
@@ -308,8 +308,8 @@ export class AmpDoc {
     /** @public @const {!Window} */
     this.win = win;
 
-    /** @private */
-    this.hasTrackingIframe_ = false;
+    /** @private {!Object<string, boolean>} */
+    this.registeredService_ = map();
 
     /** @public @const {?AmpDoc} */
     this.parent_ = parent;
@@ -754,16 +754,22 @@ export class AmpDoc {
   }
 
   /**
-   * Allow one tracking iframe for each amp doc. Caller need to handle user
-   * error when registeration returns false
+   * Attempt to register a service that is allowed/required one for each ampdoc.
+   * Caller need to handle user error when registration returns false.
+   *
+   * Please list your service name below:
+   * 'tracking_iframe',
+   * 'linker-created',
+   *
+   * @param {string} name
    * @return {boolean}
    */
-  registerTrackingIframe() {
-    if (this.hasTrackingIframe_) {
-      return false;
+  registerService(name) {
+    if (!this.registeredService_[name]) {
+      this.registeredService_[name] = true;
+      return true;
     }
-    this.hasTrackingIframe_ = true;
-    return true;
+    return false;
   }
 }
 

--- a/src/service/ampdoc-impl.js
+++ b/src/service/ampdoc-impl.js
@@ -59,15 +59,6 @@ const AmpDocSignals = {
 };
 
 /**
- * Registred singleton on AMP doc.
- * @enum {number}
- */
-export const AMPDOC_SINGLETON_NAME = {
-  TRACKING_IFRAME: 1,
-  LINKER: 2,
-};
-
-/**
  * This service helps locate an ampdoc (`AmpDoc` instance) for any node,
  * either in the single-doc or shadow-doc environments.
  *
@@ -317,7 +308,7 @@ export class AmpDoc {
     /** @public @const {!Window} */
     this.win = win;
 
-    /** @private {!Object<AMPDOC_SINGLETON_NAME, boolean>} */
+    /** @private {!Object<../enums.AMPDOC_SINGLETON_NAME, boolean>} */
     this.registeredSingleton_ = map();
 
     /** @public @const {?AmpDoc} */
@@ -765,7 +756,7 @@ export class AmpDoc {
   /**
    * Attempt to register a singleton for each ampdoc.
    * Caller need to handle user error when registration returns false.
-   * @param {AMPDOC_SINGLETON_NAME} name
+   * @param {!../enums.AMPDOC_SINGLETON_NAME} name
    * @return {boolean}
    */
   registerSingleton(name) {


### PR DESCRIPTION
To fix #28220. 

TBH I still don't know what's causing the error. But the purpose of the check is to only initiate the linker manager once for each ampdoc. No need to check for `ShadowRoot`, the attribute can be applied to the document.body. 