### PR TITLE
e2e tests: support building specific extensions instead of everything.

### DIFF
--- a/build-system/common/utils.js
+++ b/build-system/common/utils.js
@@ -32,7 +32,15 @@ const ROOT_DIR = path.resolve(__dirname, '../../');
  */
 function buildMinifiedRuntime() {
   execOrDie('gulp clean');
-  execOrDie(`gulp dist --fortesting --config ${argv.config}`);
+
+  let command = `gulp dist --fortesting --config ${argv.config}`;
+  if (argv.core_runtime_only) {
+    command += ` --core_runtime_only`;
+  } else if (argv.extensions) {
+    command += ` --extensions=${argv.extensions}`;
+  }
+
+  execOrDie(command);
 }
 
 /**

--- a/build-system/tasks/e2e/index.js
+++ b/build-system/tasks/e2e/index.js
@@ -150,7 +150,9 @@ e2e.flags = {
     '`chrome`, `firefox`, `safari`.',
   'config':
     '  Sets the runtime\'s AMP_CONFIG to one of "prod" (default) or "canary"',
+  'core_runtime_only': '  Builds only the core runtime.',
   'nobuild': '  Skips building the runtime via `gulp dist --fortesting`',
+  'extensions': '  Builds only the listed extensions.',
   'files': '  Run tests found in a specific path (ex: **/test-e2e/*.js)',
   'testnames': '  Lists the name of each test being run',
   'watch': '  Watches for changes in files, runs corresponding test(s)',


### PR DESCRIPTION
**summary**
Currently, running e2e tests automatically launches a `dist` build of the runtime + extensions.  This PR adds the ability for the `gulp e2e` command to accept both the `--extensions` and `--core_runtime_only` flags which `dist` already accepts. This can significantly speed up the change/test loop.