### PR TITLE
[amp-carousel:0.2] Do not autoplay when document is not visible

### DIFF
--- a/extensions/amp-base-carousel/0.1/auto-advance.js
+++ b/extensions/amp-base-carousel/0.1/auto-advance.js
@@ -16,7 +16,6 @@
 
 import {ActionSource} from './action-source';
 import {CarouselEvents} from './carousel-events';
-import {VisibilityState} from '../../../src/visibility-state';
 import {debounce} from '../../../src/utils/rate-limit';
 import {getDetail, listen, listenOnce} from '../../../src/event-helper';
 
@@ -85,12 +84,6 @@ export class AutoAdvance {
 
     /** @private {!../../../src/service/ampdoc-impl.AmpDoc} */
     this.ampdoc_ = element.getAmpDoc();
-
-    /** @private {?VisibilityState} */
-    this.visibilityState_ = this.ampdoc_.getVisibilityState();
-    this.ampdoc_.onVisibilityChanged(
-      () => (this.visibilityState_ = this.ampdoc_.getVisibilityState())
-    );
 
     this.createDebouncedAdvance_(this.autoAdvanceInterval_);
     this.scrollContainer_.addEventListener(
@@ -224,7 +217,7 @@ export class AutoAdvance {
   shouldAutoAdvance_() {
     return (
       this.autoAdvance_ &&
-      this.visibilityState_ == VisibilityState.VISIBLE &&
+      this.ampdoc_.isVisible() &&
       !this.paused_ &&
       !this.stopped_ &&
       this.advances_ < this.maxAdvances_

--- a/extensions/amp-base-carousel/0.1/auto-advance.js
+++ b/extensions/amp-base-carousel/0.1/auto-advance.js
@@ -16,6 +16,7 @@
 
 import {ActionSource} from './action-source';
 import {CarouselEvents} from './carousel-events';
+import {VisibilityState} from '../../../src/visibility-state';
 import {debounce} from '../../../src/utils/rate-limit';
 import {getDetail, listen, listenOnce} from '../../../src/event-helper';
 
@@ -81,6 +82,15 @@ export class AutoAdvance {
 
     /** @private {number} */
     this.maxAdvances_ = Number.POSITIVE_INFINITY;
+
+    /** @private {!../../../src/service/ampdoc-impl.AmpDoc} */
+    this.ampdoc_ = element.getAmpDoc();
+
+    /** @private {?VisibilityState} */
+    this.visibilityState_ = this.ampdoc_.getVisibilityState();
+    this.ampdoc_.onVisibilityChanged(
+      () => (this.visibilityState_ = this.ampdoc_.getVisibilityState())
+    );
 
     this.createDebouncedAdvance_(this.autoAdvanceInterval_);
     this.scrollContainer_.addEventListener(
@@ -214,6 +224,7 @@ export class AutoAdvance {
   shouldAutoAdvance_() {
     return (
       this.autoAdvance_ &&
+      this.visibilityState_ == VisibilityState.VISIBLE &&
       !this.paused_ &&
       !this.stopped_ &&
       this.advances_ < this.maxAdvances_

--- a/extensions/amp-base-carousel/0.1/test/test-carousel.js
+++ b/extensions/amp-base-carousel/0.1/test/test-carousel.js
@@ -98,6 +98,7 @@ describes.realWin('carousel implementation', {}, (env) => {
 
     element.appendChild(scrollContainer);
     doc.body.appendChild(element);
+    element.getAmpDoc = () => env.ampdoc;
   });
 
   afterEach(() => {


### PR DESCRIPTION
Related to #28248: `prerenderAllowed` was enabled for `amp-base-carousel` and `amp-carousel` in #28203, but the pre-existing `pauseCallback` does not suffice to prevent carousel from auto-advancing when the document is in the prerender visibility state. This change explicitly checks for the visibility state as part of `shouldAutoAdvance_`, a tool that is used by both `amp-base-carousel` and `amp-carousel:0.2`.

Try this out by running `gulp` with the following local targets, modifying (and refreshing) between `#visibilityState=visible` and `#visibilityState=prerender`:
- [amp-carousel:0.2](http://localhost:8000/proxy/s/output.jsbin.com/zuvexej/quiet#visibilityState=visible)
- [amp-base-carousel](http://localhost:8000/proxy/s/output.jsbin.com/berayedowe/quiet#visibilityState=visible)

cc @jridgewell 