### PR TITLE
Support verifying a sender using messagingToken

### DIFF
--- a/extensions/amp-viewer-integration/0.1/amp-viewer-integration.js
+++ b/extensions/amp-viewer-integration/0.1/amp-viewer-integration.js
@@ -116,7 +116,8 @@ export class AmpViewerIntegration {
     const port = new WindowPortEmulator(
       this.win,
       origin,
-      this.win.parent /* target */
+      this.win.parent /* target */,
+      messagingToken
     );
     return this.openChannelAndStart_(
       viewer,

--- a/extensions/amp-viewer-integration/0.1/messaging/messaging.js
+++ b/extensions/amp-viewer-integration/0.1/messaging/messaging.js
@@ -63,7 +63,7 @@ export class WindowPortEmulator {
    * @param {!Window} win
    * @param {string} origin
    * @param {!Window} target
-   * @param {string} opt_token
+   * @param {?string=} opt_token
    */
   constructor(win, origin, target, opt_token) {
     /** @const @private {!Window} */
@@ -72,8 +72,8 @@ export class WindowPortEmulator {
     this.origin_ = origin;
     /** @const @private {!Window} */
     this.target_ = target;
-    /** @const @private {string} */
-    this.token_ = opt_token;
+    /** @const @private {?string} */
+    this.token_ = opt_token || null;
   }
 
   /**

--- a/extensions/amp-viewer-integration/0.1/messaging/package.json
+++ b/extensions/amp-viewer-integration/0.1/messaging/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ampproject/viewer-messaging",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Messaging between an AMP Doc and a Viewer",
   "author": "The AMP HTML Authors",
   "license": "Apache-2.0",


### PR DESCRIPTION
Currently, `WindowPortEmulator ` inside `messaging.js` [compares](https://github.com/ampproject/amphtml/blob/87d71fc4ee87622ae4c0591bff6ba39f82f1f615/extensions/amp-viewer-integration/0.1/messaging/messaging.js#L82) the `event.origin` to its `this.origin_` set by the `amp-viewer-integration` code:

https://github.com/ampproject/amphtml/blob/471bbb957ba9ee4c3d1778dbb987d8fee3352e0b/extensions/amp-viewer-integration/0.1/amp-viewer-integration.js#L87

https://github.com/ampproject/amphtml/blob/471bbb957ba9ee4c3d1778dbb987d8fee3352e0b/extensions/amp-viewer-integration/0.1/amp-viewer-integration.js#L122-L124

This causes issues when the parent window of the viewer does not have an origin (#28225).

This PR will allow the `amp-story-player` to send a `messagingToken` in the `waitForHandshakeFromDocument ` method when establishing a handshake with the STAMP. Paired with the `#messagingToken=storyPlayerToken` parameter set on the STAMP's url, the `WindowPortEmulator` can then use those to verify the communication instead of comparing the `origin`s of the window and event.

https://github.com/ampproject/amphtml/blob/471bbb957ba9ee4c3d1778dbb987d8fee3352e0b/src/amp-story-player/amp-story-player-impl.js#L241-L245