### PR TITLE
Fix race condition that fails to hide video loading indicator

### DIFF
--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -1529,7 +1529,10 @@ export class AmpStoryPage extends AMP.BaseElement {
     const videoEls = this.getAllVideos_();
 
     if (videoEls.length) {
-      this.debounceToggleLoadingSpinner_(true);
+      const alreadyPlaying = videoEls.some((video) => video.currentTime != 0);
+      if (!alreadyPlaying) {
+        this.debounceToggleLoadingSpinner_(true);
+      }
     }
 
     Array.prototype.forEach.call(videoEls, (videoEl) => {


### PR DESCRIPTION
Auto-playing videos might have already started pllaying by the time we attach the playing event listener. Since there isn't a direct attribute to tell whether a video is playing, this checks whether the `currentTime` is 0.

Fixes #28275