### PR TITLE
🚀 e2e tests: support fast (unminified) mode.

### DIFF
--- a/build-system/common/utils.js
+++ b/build-system/common/utils.js
@@ -32,6 +32,8 @@ const ROOT_DIR = path.resolve(__dirname, '../../');
  *
  * @param {boolean} minified
  */
+// TODO(gh/amphtml/28312): Directly call dist() or build()
+// instead of spwaning a new process.
 function buildRuntime(minified = true) {
   execOrDie('gulp clean');
 

--- a/build-system/common/utils.js
+++ b/build-system/common/utils.js
@@ -29,6 +29,8 @@ const ROOT_DIR = path.resolve(__dirname, '../../');
 /**
  * Cleans and builds binaries with --fortesting flag and
  * overriden config.
+ *
+ * @param {boolean} minified
  */
 function buildRuntime(minified = true) {
   execOrDie('gulp clean');

--- a/build-system/common/utils.js
+++ b/build-system/common/utils.js
@@ -30,10 +30,10 @@ const ROOT_DIR = path.resolve(__dirname, '../../');
  * Cleans and builds binaries with --fortesting flag and
  * overriden config.
  */
-function buildMinifiedRuntime() {
+function buildRuntime(minified = true) {
   execOrDie('gulp clean');
 
-  let command = `gulp dist --fortesting --config ${argv.config}`;
+  let command = minified ? `gulp dist --fortesting` : `gulp build --fortesting`;
   if (argv.core_runtime_only) {
     command += ` --core_runtime_only`;
   } else if (argv.extensions) {
@@ -165,7 +165,7 @@ function installPackages(dir) {
 }
 
 module.exports = {
-  buildMinifiedRuntime,
+  buildRuntime,
   getFilesChanged,
   getFilesFromArgv,
   getFilesToCheck,

--- a/build-system/pr-check/e2e-tests.js
+++ b/build-system/pr-check/e2e-tests.js
@@ -42,7 +42,7 @@ async function main() {
   if (!isTravisPullRequestBuild()) {
     downloadDistOutput(FILENAME);
     timedExecOrDie('gulp update-packages');
-    timedExecOrDie('gulp e2e --nobuild --headless');
+    timedExecOrDie('gulp e2e --nobuild --headless --compiled');
   } else {
     printChangeSummary(FILENAME);
     const buildTargets = determineBuildTargets(FILENAME);
@@ -53,7 +53,7 @@ async function main() {
     ) {
       downloadDistOutput(FILENAME);
       timedExecOrDie('gulp update-packages');
-      timedExecOrDie('gulp e2e --nobuild --headless');
+      timedExecOrDie('gulp e2e --nobuild --headless --compiled');
     } else {
       console.log(
         `${FILELOGPREFIX} Skipping`,

--- a/build-system/pr-check/experiment-tests.js
+++ b/build-system/pr-check/experiment-tests.js
@@ -60,7 +60,7 @@ function build_(config) {
 
 function test_() {
   timedExecOrDie('gulp integration --nobuild --compiled --headless');
-  timedExecOrDie('gulp e2e --nobuild --headless');
+  timedExecOrDie('gulp e2e --nobuild --compiled --headless');
 }
 
 function main() {

--- a/build-system/tasks/e2e/index.js
+++ b/build-system/tasks/e2e/index.js
@@ -151,7 +151,8 @@ e2e.flags = {
   'config':
     '  Sets the runtime\'s AMP_CONFIG to one of "prod" (default) or "canary"',
   'core_runtime_only': '  Builds only the core runtime.',
-  'nobuild': '  Skips building the runtime via `gulp (build|dist) --fortesting`',
+  'nobuild':
+    '  Skips building the runtime via `gulp (build|dist) --fortesting`',
   'extensions': '  Builds only the listed extensions.',
   'compiled': '  Runs the tests using minified js',
   'files': '  Run tests found in a specific path (ex: **/test-e2e/*.js)',

--- a/build-system/tasks/e2e/index.js
+++ b/build-system/tasks/e2e/index.js
@@ -24,7 +24,7 @@ const log = require('fancy-log');
 const Mocha = require('mocha');
 const path = require('path');
 const {
-  buildMinifiedRuntime,
+  buildRuntime,
   getFilesFromArgv,
   installPackages,
 } = require('../../common/utils');
@@ -39,12 +39,8 @@ const PORT = 8000;
 const SLOW_TEST_THRESHOLD_MS = 2500;
 const TEST_RETRIES = isTravisBuild() ? 2 : 0;
 
-async function launchWebServer_() {
-  await startServer(
-    {host: HOST, port: PORT},
-    {quiet: !argv.debug},
-    {compiled: true}
-  );
+async function launchWebServer_(compiled) {
+  await startServer({host: HOST, port: PORT}, {quiet: !argv.debug}, {compiled});
 }
 
 async function cleanUp_() {
@@ -82,13 +78,14 @@ async function e2e() {
     headless: argv.headless,
   });
 
+
   // build runtime
   if (!argv.nobuild) {
-    buildMinifiedRuntime();
+    buildRuntime(/* minified */ !argv.fast);
   }
 
   // start up web server
-  await launchWebServer_();
+  await launchWebServer_(/* compiled */ !argv.fast);
 
   // run tests
   if (!argv.watch) {
@@ -153,6 +150,7 @@ e2e.flags = {
   'core_runtime_only': '  Builds only the core runtime.',
   'nobuild': '  Skips building the runtime via `gulp dist --fortesting`',
   'extensions': '  Builds only the listed extensions.',
+  'fast': '  Runs the tests using unminified js',
   'files': '  Run tests found in a specific path (ex: **/test-e2e/*.js)',
   'testnames': '  Lists the name of each test being run',
   'watch': '  Watches for changes in files, runs corresponding test(s)',

--- a/build-system/tasks/e2e/index.js
+++ b/build-system/tasks/e2e/index.js
@@ -39,8 +39,12 @@ const PORT = 8000;
 const SLOW_TEST_THRESHOLD_MS = 2500;
 const TEST_RETRIES = isTravisBuild() ? 2 : 0;
 
-async function launchWebServer_(compiled) {
-  await startServer({host: HOST, port: PORT}, {quiet: !argv.debug}, {compiled});
+async function launchWebServer_(minified) {
+  await startServer(
+    {host: HOST, port: PORT},
+    {quiet: !argv.debug},
+    {compiled: minified}
+  );
 }
 
 async function cleanUp_() {
@@ -78,14 +82,13 @@ async function e2e() {
     headless: argv.headless,
   });
 
-
   // build runtime
   if (!argv.nobuild) {
     buildRuntime(/* minified */ !argv.fast);
   }
 
   // start up web server
-  await launchWebServer_(/* compiled */ !argv.fast);
+  await launchWebServer_(/* minified */ !argv.fast);
 
   // run tests
   if (!argv.watch) {

--- a/build-system/tasks/e2e/index.js
+++ b/build-system/tasks/e2e/index.js
@@ -88,7 +88,7 @@ async function e2e() {
   }
 
   // start up web server
-  await launchWebServer_(/* minified */ !argv.fast);
+  await launchWebServer_(/* minified */ argv.compiled);
 
   // run tests
   if (!argv.watch) {

--- a/build-system/tasks/e2e/index.js
+++ b/build-system/tasks/e2e/index.js
@@ -84,7 +84,7 @@ async function e2e() {
 
   // build runtime
   if (!argv.nobuild) {
-    buildRuntime(/* minified */ !argv.fast);
+    buildRuntime(/* minified */ !!argv.compiled);
   }
 
   // start up web server
@@ -151,9 +151,9 @@ e2e.flags = {
   'config':
     '  Sets the runtime\'s AMP_CONFIG to one of "prod" (default) or "canary"',
   'core_runtime_only': '  Builds only the core runtime.',
-  'nobuild': '  Skips building the runtime via `gulp dist --fortesting`',
+  'nobuild': '  Skips building the runtime via `gulp (build|dist) --fortesting`',
   'extensions': '  Builds only the listed extensions.',
-  'fast': '  Runs the tests using unminified js',
+  'compiled': '  Runs the tests using minified js',
   'files': '  Run tests found in a specific path (ex: **/test-e2e/*.js)',
   'testnames': '  Lists the name of each test being run',
   'watch': '  Watches for changes in files, runs corresponding test(s)',

--- a/build-system/tasks/visual-diff/index.js
+++ b/build-system/tasks/visual-diff/index.js
@@ -38,7 +38,7 @@ const {
   gitTravisMasterBaseline,
   shortSha,
 } = require('../../common/git');
-const {buildMinifiedRuntime, installPackages} = require('../../common/utils');
+const {buildRuntime, installPackages} = require('../../common/utils');
 const {execScriptAsync} = require('../../common/exec');
 const {isTravisBuild} = require('../../common/travis');
 const {startServer, stopServer} = require('../serve');
@@ -760,7 +760,7 @@ async function ensureOrBuildAmpRuntimeInTestMode_() {
       );
     }
   } else {
-    buildMinifiedRuntime();
+    buildRuntime();
   }
 }
 


### PR DESCRIPTION
**summary**
Makes `gulp e2e` default to a faster unminified build and adds a `--compiled` flag as an option. This [brings it in line](https://github.com/ampproject/amphtml/pull/28305#discussion_r423225133) with other gulp tasks.