### PR TITLE
🐛Fix `check-types` failure due to new closure version

### DIFF
--- a/3p/twitter.js
+++ b/3p/twitter.js
@@ -16,6 +16,7 @@
 
 // TODO(malteubl) Move somewhere else since this is not an ad.
 
+import {dev} from '../src/log';
 import {loadScript} from './3p';
 import {setStyles} from '../src/style';
 import {startsWith} from '../src/string';
@@ -97,7 +98,7 @@ export function twitter(global, data) {
       return;
     }
 
-    resize(el);
+    resize(dev().assertElement(el));
     twttr.events.bind('resize', (event) => {
       // To be safe, make sure the resize event was triggered for the widget we
       // created below.

--- a/3p/twitter.js
+++ b/3p/twitter.js
@@ -16,7 +16,6 @@
 
 // TODO(malteubl) Move somewhere else since this is not an ad.
 
-import {dev} from '../src/log';
 import {loadScript} from './3p';
 import {setStyles} from '../src/style';
 import {startsWith} from '../src/string';
@@ -98,7 +97,7 @@ export function twitter(global, data) {
       return;
     }
 
-    resize(dev().assertElement(el));
+    resize(/** @type {!Element} */ (el));
     twttr.events.bind('resize', (event) => {
       // To be safe, make sure the resize event was triggered for the widget we
       // created below.

--- a/3p/twitter.js
+++ b/3p/twitter.js
@@ -102,7 +102,7 @@ export function twitter(global, data) {
       // To be safe, make sure the resize event was triggered for the widget we
       // created below.
       if (el === event.target) {
-        resize(el);
+        resize(/** @type {!Element} */ (el));
       }
     });
   }

--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -625,6 +625,7 @@ const forbiddenTerms = {
       'dist.3p/current/integration.js', // Includes the previous.
       'src/polyfills/custom-elements.js',
       'ads/google/imaVideo.js', // Required until #22277 is fixed.
+      '3p/twitter.js', // Runs in a 3p window context, so cannot import log.js.
     ],
   },
   'startupChunk\\(': {


### PR DESCRIPTION
This PR fixes a failure that snuck in with #28243.

It turns out we were missing a few runtime checks for package upgrades. Fix sent out in #28317.