### PR TITLE
🏗🐛 Fix build target logic by adding an explicit `RUNTIME` target

### DIFF
--- a/build-system/pr-check/build-targets.js
+++ b/build-system/pr-check/build-targets.js
@@ -147,6 +147,12 @@ const targetMatchers = {
   'PACKAGE_UPGRADE': (file) => {
     return file == 'package.json' || file == 'yarn.lock';
   },
+  'RUNTIME': (file) => {
+    if (isOwnersFile(file)) {
+      return false;
+    }
+    return file.startsWith('src/');
+  },
   'SERVER': (file) => {
     if (isOwnersFile(file)) {
       return false;


### PR DESCRIPTION
For package upgrades, we add all build targets to the set of targets to be tested / checked. However, `RUNTIME`, which is a special case target, was left out.

This PR adds an explicit build target for `RUNTIME` (that includes all files in the `src/` directory). Note that other files that do not explicitly match a target will still fall through to the `RUNTIME` target, and get tested.

It turns out this was the root cause of #28316 and the resulting failures on `master`.

Follow up to #27297.