### PR TITLE
Turn on analytics-chunks in prod

### DIFF
--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -34,5 +34,6 @@
   "swg-gpay-api": 1,
   "swg-gpay-native": 1,
   "version-locking": 1,
-  "amp-ad-no-center-css": 0.05
+  "amp-ad-no-center-css": 0.05,
+  "analytics-chunks": 1
 }


### PR DESCRIPTION
analytics-chunks experiment = Break the analytics initialization to chunks (doesn't apply in inabox). 

While it's uncertain if the experiment helped with FID, it didn't lead to new errors. (errors from #28264 and #28200 were surfaced, not caused by the experiment). Should be safe to turn on in prod. 


