### PR TITLE
Slot: `ref` should not be an element

### DIFF
--- a/src/preact/slot.js
+++ b/src/preact/slot.js
@@ -45,8 +45,7 @@ export function Slot(props) {
   const ref = useRef(/** @type {?Element} */ (null));
   const slotProps = {...props, ref};
   useEffect(() => {
-    const {current} = dev().assertElement(ref);
-    const slot = dev().assertElement(current);
+    const slot = dev().assertElement(ref.current);
     const assignedElements = getAssignedElements(props, slot);
     slot.__assignedElements = assignedElements;
 


### PR DESCRIPTION
`dev().assertElement()` was [recently introduced](https://github.com/ampproject/amphtml/pull/24047/files#diff-f5e4baf202eba6455d4b3142d8809a4bR48) but should be removed.