### PR TITLE
✨ amp-video: Add intrinsic to supported_layouts

### DIFF
--- a/extensions/amp-video/validator-amp-video.protoascii
+++ b/extensions/amp-video/validator-amp-video.protoascii
@@ -127,6 +127,7 @@ tags: {  # <amp-video> not in amp-story.
     supported_layouts: FIXED
     supported_layouts: FIXED_HEIGHT
     supported_layouts: FLEX_ITEM
+    supported_layouts: INTRINSIC
     supported_layouts: NODISPLAY
     supported_layouts: RESPONSIVE
   }


### PR DESCRIPTION
When adding a portrait video to a [blog post](https://blog.amp.dev/2020/05/12/infinite-recommendations-with-a-new-and-improved-amp-next-page/) on the AMP blog, it ended up rendering poorly as it showed up exceedingly large in relation to the text:

> ![image](https://user-images.githubusercontent.com/134745/81733658-3b7f2a80-9447-11ea-8f68-55d07270b5cc.png)

This is because WordPress is adding the `amp-video` with the `layout=responsive`. This was undesirable. What was actually wanted was the video to have an `intrinsic` layout so it will show with its natural dimensions but then shrink to fit its container on smaller viewports:

> ![image](https://user-images.githubusercontent.com/134745/81733759-5d78ad00-9447-11ea-96d4-6924c1be6a7d.png)

Nevertheless, the intrinsic layout is not valid AMP. To work around this issue, we resorted to use a `layout=fixed-height` for the time being, but the result is not ideal given the excessive width being given to the element:

> ![image](https://user-images.githubusercontent.com/134745/81733993-b8120900-9447-11ea-9acc-dd34065a76be.png)

It also turns out that adding `layout=intrinsic` to the `amp-video` actually results in the expected behavior, even though it gets flagged as invalid. 

See examples: https://amp-video-intrinsic-layout.glitch.me/

So this leads me to think that the `intrinsic` layout may have just been unintentionally left out and should be added.