### PR TITLE
Remove reset timer from analytics handler

### DIFF
--- a/build-system/tasks/performance/measure-documents.js
+++ b/build-system/tasks/performance/measure-documents.js
@@ -242,7 +242,6 @@ async function setupAdditionalHandlers(
             if (!handlerOptions.endTime) {
               Object.assign(handlerOptions, {
                 endTime,
-                'timeout': 0,
               });
               // Resolve and short circuit setTimeout
               resolve();


### PR DESCRIPTION
Remove in favor of existing `resolve()`