### PR TITLE
Fix check for unknown deps regex

### DIFF
--- a/build-system/compile/check-for-unknown-deps.js
+++ b/build-system/compile/check-for-unknown-deps.js
@@ -20,14 +20,14 @@ const through = require('through2');
 const {red, cyan, yellow} = require('ansi-colors');
 
 /**
- * Searches for the identifier "$$module$", which Closure uses to uniquely
+ * Searches for the identifier "module$", which Closure uses to uniquely
  * reference module imports. If any are found, that means Closure couldn't
  * import the module correctly.
  *
  * @return {!Stream}
  */
 exports.checkForUnknownDeps = function () {
-  const regex = /[\w$]+?module\$[\w$]+/;
+  const regex = /[\w$]*module\$[\w$]+/;
 
   return through.obj(function (file, encoding, cb) {
     const contents = file.contents.toString();

--- a/build-system/compile/check-for-unknown-deps.js
+++ b/build-system/compile/check-for-unknown-deps.js
@@ -27,17 +27,17 @@ const {red, cyan, yellow} = require('ansi-colors');
  * @return {!Stream}
  */
 exports.checkForUnknownDeps = function () {
-  const regex = /[\w$]+?\$\$module\$[\w$]+/;
+  const regex = /[\w$]+?module\$[\w$]+/;
 
   return through.obj(function (file, encoding, cb) {
     const contents = file.contents.toString();
-    if (!contents.includes('$$module$')) {
+    if (!contents.includes('module$')) {
       // Fast check, since regexes can backtrack like crazy.
       return cb(null, file);
     }
 
     const match = regex.exec(contents) || [
-      `couldn't parse the dep. Look for "$$module$" in the file`,
+      `couldn't parse the dep. Look for "module$" in the file`,
     ];
 
     log(


### PR DESCRIPTION
Fixing regex checking for unknown dependencies. Apparently Closure changed the import identifier format
