### PR TITLE
🏗Make Sauce Labs runs non-blocking on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -126,7 +126,8 @@ jobs:
       env:
         - CACHE_NAME=PERFORMANCEJOB
   allow_failures:
-    - env: CACHE_NAME=PERFORMANCEJOB
+    - script: unbuffer node build-system/pr-check/performance-tests.js # See #28148
+    - script: unbuffer node build-system/pr-check/remote-tests.js # See #28343
   fast_finish: true
 before_cache:
   # do not store cache for pr builds or experiment stage builds


### PR DESCRIPTION
Sauce labs runs are currently unreliable due to disconnection errors. See https://github.com/ampproject/amphtml/issues/28343#issuecomment-628063934. This PR makes Sauce runs [non-blocking on Travis](https://docs.travis-ci.com/user/customizing-the-build#jobs-that-are-allowed-to-fail) until a fix is identified.

Temporary mitigation for #28343

/cc @ampproject/build-cop 

