### PR TITLE
🏗 Group minor and patch upgrades in once-a-day PRs

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -8,5 +8,17 @@
   "dependencies": {
     "enabled": false
   },
-  "ignorePaths": []
+  "ignorePaths": [],
+  "packageRules": [
+    {
+      "updateTypes": ["patch"],
+      "groupName": "dependencies (patch)",
+      "schedule": "before 8am every weekday"
+    },
+    {
+      "updateTypes": ["minor"],
+      "groupName": "dependencies (minor)",
+      "schedule": "before 8am every weekday"
+    }
+  ]
 }

--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -9,16 +9,17 @@
     "enabled": false
   },
   "ignorePaths": [],
+  "timezone": "America/Los_Angeles",
   "packageRules": [
     {
       "updateTypes": ["patch"],
       "groupName": "dependencies (patch)",
-      "schedule": "before 8am every weekday"
+      "schedule": "12am every weekday"
     },
     {
       "updateTypes": ["minor"],
       "groupName": "dependencies (minor)",
-      "schedule": "before 8am every weekday"
+      "schedule": "12am every weekday"
     }
   ]
 }


### PR DESCRIPTION
First step of https://github.com/ampproject/amphtml/issues/28322 , grouping PATCH and MINOR updates (separately) to once-a-day PRs weekday mornings. 