### PR TITLE
Add hint about amp.dev's boilerplate generator to boilerplate spec

### DIFF
--- a/spec/amp-boilerplate.md
+++ b/spec/amp-boilerplate.md
@@ -30,3 +30,7 @@ mutations as minimal as possible. Currently, the allowed mutations are:
 <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
 ```
 <!-- prettier-ignore-end -->
+
+[tip]
+You can use the [boilerplate generator](https://amp.dev/boilerplate) to quickly setup a basic skeleton for your AMP page. It also provides snippets for structured data, to create a PWA and more!
+[/tip]


### PR DESCRIPTION
Resolves https://github.com/ampproject/amp.dev/issues/3940.

The boilerplate generator while being a useful tool gets little recognition. Adding this hint to the boilerplate spec which surfaces at amp.dev/documentation/guides-and-tutorials/learn/spec/amp-boilerplate/ might help.