### PR TITLE
Added muted attribute to amp-story

### DIFF
--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -2508,7 +2508,7 @@ export class AmpStory extends AMP.BaseElement {
    */
   onMutedStateUpdate_(isMuted) {
     isMuted ? this.mute_() : this.unmute_();
-    this.element.toggleAttribute('muted', isMuted);
+    this.element.toggleAttribute(Attributes.MUTED, isMuted);
   }
 
   /**

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -154,6 +154,7 @@ const Attributes = {
   AUTO_ADVANCE_AFTER: 'auto-advance-after',
   AUTO_ADVANCE_TO: 'auto-advance-to',
   DESKTOP_POSITION: 'i-amphtml-desktop-position',
+  MUTED: 'muted',
   ORIENTATION: 'orientation',
   PUBLIC_ADVANCE_TO: 'advance-to',
   RETURN_TO: 'i-amphtml-return-to',

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -2507,6 +2507,7 @@ export class AmpStory extends AMP.BaseElement {
    */
   onMutedStateUpdate_(isMuted) {
     isMuted ? this.mute_() : this.unmute_();
+    this.element.toggleAttribute('muted', isMuted);
   }
 
   /**

--- a/extensions/amp-story/1.0/test/test-amp-story.js
+++ b/extensions/amp-story/1.0/test/test-amp-story.js
@@ -1056,7 +1056,7 @@ describes.realWin(
         });
       });
 
-      it('should add or remove the muted attribute on muted state change', async () => {
+      it('should remove the muted attribute on unmuted state change', async () => {
         await createStoryWithPages(2, ['cover', 'page-1']);
 
         await story.layoutCallback();
@@ -1065,6 +1065,12 @@ describes.realWin(
 
         story.storeService_.dispatch(Action.TOGGLE_MUTED, false);
         expect(story.element.hasAttribute('muted')).to.be.false;
+      });
+
+      it('should add the muted attribute on unmuted state change', async () => {
+        await createStoryWithPages(2, ['cover', 'page-1']);
+
+        await story.layoutCallback();
 
         story.storeService_.dispatch(Action.TOGGLE_MUTED, true);
         expect(story.element.hasAttribute('muted')).to.be.true;

--- a/extensions/amp-story/1.0/test/test-amp-story.js
+++ b/extensions/amp-story/1.0/test/test-amp-story.js
@@ -1056,6 +1056,20 @@ describes.realWin(
         });
       });
 
+      it('should add or remove the muted attribute on muted state change', async () => {
+        await createStoryWithPages(2, ['cover', 'page-1']);
+
+        await story.layoutCallback();
+
+        expect(story.element.hasAttribute('muted')).to.be.true;
+
+        story.storeService_.dispatch(Action.TOGGLE_MUTED, false);
+        expect(story.element.hasAttribute('muted')).to.be.false;
+
+        story.storeService_.dispatch(Action.TOGGLE_MUTED, true);
+        expect(story.element.hasAttribute('muted')).to.be.true;
+      });
+
       describe('#getMaxMediaElementCounts', () => {
         it('should create 2 audio & video elements when no elements found', async () => {
           await createStoryWithPages(2, ['cover', 'page-1']);


### PR DESCRIPTION
Adds `<amp-story muted>` attribute when story is muted, and tests to check functionality.

Can be used in CSS to change styles using `amp-story[muted]` or `amp-story:not([muted])`

Resolves #28395