### PR TITLE
🐛 Don't use `getChildJsonConfig` in amp-animation

### DIFF
--- a/extensions/amp-animation/0.1/amp-animation.js
+++ b/extensions/amp-animation/0.1/amp-animation.js
@@ -20,15 +20,16 @@ import {Pass} from '../../../src/pass';
 import {Services} from '../../../src/services';
 import {WebAnimationPlayState} from './web-animation-types';
 import {WebAnimationService} from './web-animation-service';
+import {childElementByTag} from '../../../src/dom';
 import {clamp} from '../../../src/utils/math';
-import {getChildJsonConfig} from '../../../src/json';
 import {getDetail, listen} from '../../../src/event-helper';
 import {getFriendlyIframeEmbedOptional} from '../../../src/iframe-helper';
 import {getParentWindowFrameElement} from '../../../src/service';
 import {installWebAnimationsIfNecessary} from './web-animations-polyfill';
 import {isFiniteNumber} from '../../../src/types';
 import {setInitialDisplay, setStyles, toggle} from '../../../src/style';
-import {userAssert} from '../../../src/log';
+import {tryParseJson} from '../../../src/json';
+import {user, userAssert} from '../../../src/log';
 
 const TAG = 'amp-animation';
 
@@ -90,7 +91,14 @@ export class AmpAnimation extends AMP.BaseElement {
       );
     }
 
-    this.configJson_ = getChildJsonConfig(this.element);
+    // Parse config.
+    const scriptElement = userAssert(
+      childElementByTag(this.element, 'script'),
+      '"<script type=application/json>" must be present'
+    );
+    this.configJson_ = tryParseJson(scriptElement.textContent, (error) => {
+      throw user().createError('failed to parse animation script', error);
+    });
 
     if (this.triggerOnVisibility_) {
       // Make the element minimally displayed to make sure that `layoutCallback`


### PR DESCRIPTION
It looks like some pages incorrectly use `type=application/ld+json`. This is not validated against, and the change caused a regression from checking the `type` attribute by using the utility.

Fixes #28271

<!--
# Instructions:

- Pick a meaningful title for your pull request. (Use sentence case.)
  - Prefix the title with an emoji to identify what is being done. (Copy-paste the emoji from the list below.)
  - Do not overuse punctuation in the title (like `(chore):`).
  - If it is helpful, use a simple prefix (like `ProjectX: Implement some feature`).
- Enter a succinct description that says why the PR is necessary, and what it does.
  - Mention the GitHub issue that is being addressed by the pull request.
  - The keywords `Fixes`, `Closes`, or `Resolves` followed the issue number will automatically close the issue.

> NOTE: All non-trivial changes (like introducing new features or components) should have an associated issue or reference an I2I (intent-to-implement: go.amp.dev/i2i). Please read through the contribution process (go.amp.dev/contributing/code) for more information.

# Example of a good description:

- Implement aspect X
- Leave out feature Y because of A
- Improve performance by B
- Improve accessibility by C

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Reverting a previous change
♻️ Refactoring
🚮 Deleting code
-->
