### PR TITLE
🏗 Improve Sauce Labs logging

### DIFF
--- a/build-system/tasks/runtime-test/helpers.js
+++ b/build-system/tasks/runtime-test/helpers.js
@@ -25,7 +25,7 @@ const {
   reportTestFinished,
   reportTestRunComplete,
 } = require('../report-test-status');
-const {green, yellow, cyan, red} = require('ansi-colors');
+const {green, yellow, cyan} = require('ansi-colors');
 const {isTravisBuild} = require('../../common/travis');
 const {Server} = require('karma');
 
@@ -188,15 +188,6 @@ function maybePrintCoverageMessage() {
  * @param {Object} browser
  * @private
  */
-function karmaBrowserStart_(browser) {
-  console./*OK*/ log('\n');
-  log(`${browser.name}: ${green('STARTED')}`);
-}
-
-/**
- * @param {Object} browser
- * @private
- */
 async function karmaBrowserComplete_(browser) {
   const result = browser.lastResult;
   result.total = result.success + result.failed + result.skipped;
@@ -209,22 +200,7 @@ async function karmaBrowserComplete_(browser) {
       'Received a status with zero tests:',
       cyan(JSON.stringify(result))
     );
-
-    return;
   }
-  // Print a summary for each browser as soon as tests complete.
-  let message =
-    `${browser.name}: Executed ` +
-    `${result.success + result.failed} of ${result.total} ` +
-    `(Skipped ${result.skipped}) `;
-  if (result.failed === 0) {
-    message += green('SUCCESS');
-  } else {
-    message += red(result.failed + ' FAILED');
-  }
-  message += '\n';
-  console./*OK*/ log('\n');
-  log(message);
 }
 
 /**
@@ -383,9 +359,8 @@ async function runTestInBatchesWithBrowsers_(
     configBatch.browsers = browsers.slice(startIndex, endIndex);
     log(
       green('Batch'),
-      cyan(`#${batch}`) + green(': Running tests on'),
-      cyan(configBatch.browsers.length),
-      green('Sauce Labs browser(s)...')
+      cyan(`#${batch}`) + green(':'),
+      cyan(configBatch.browsers.join(', '))
     );
     batchExitCodes.push(await createKarmaServer(configBatch, runCompleteFn));
     startIndex = batch * BATCHSIZE;
@@ -421,7 +396,6 @@ async function createKarmaServer(
   karmaServer
     .on('run_start', karmaRunStart_)
     .on('browsers_ready', karmaBrowsersReady_)
-    .on('browser_start', karmaBrowserStart_)
     .on('browser_complete', karmaBrowserComplete_)
     .on('run_complete', runCompleteFn);
 


### PR DESCRIPTION
We used to print messages during Sauce Labs runs for the `browser_start` and `browser_complete` [Karma events](http://karma-runner.github.io/4.0/dev/public-api.html). This was done in order to help debug stalled builds. With recent work, it turns out that these messages are unnecessary, and in fact, can make the logs confusing to read.

**PR highlights:**
- Prints the list of the browsers being tested at the start of each batch
- Eliminates inline logging for `browser_start`
- Eliminates non-error inline logging for `browser_complete`

**Screenshots:**

| Before  | After |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/26553114/81971422-0d3c4f00-95ef-11ea-9284-f3dd95712c60.png) | ![image](https://user-images.githubusercontent.com/26553114/81971469-21804c00-95ef-11ea-9676-a1665d2fb861.png) |


Fixes #26852

