### PR TITLE
🐛 try/catch when pausing animations

### DIFF
--- a/extensions/amp-story/1.0/animation.js
+++ b/extensions/amp-story/1.0/animation.js
@@ -373,9 +373,11 @@ export class AnimationRunner {
       return;
     }
 
-    if (this.runner_) {
-      // Init or no-op if the runner was already running.
-      this.runner_.start();
+    if (
+      this.runner_ &&
+      this.runner_.getPlayState() !== WebAnimationPlayState.FINISHED &&
+      this.runner_.getPlayState() !== WebAnimationPlayState.IDLE
+    ) {
       this.runner_.pause();
     }
   }

--- a/extensions/amp-story/1.0/animation.js
+++ b/extensions/amp-story/1.0/animation.js
@@ -373,12 +373,13 @@ export class AnimationRunner {
       return;
     }
 
-    if (
-      this.runner_ &&
-      this.runner_.getPlayState() !== WebAnimationPlayState.FINISHED &&
-      this.runner_.getPlayState() !== WebAnimationPlayState.IDLE
-    ) {
-      this.runner_.pause();
+    if (this.runner_) {
+      try {
+        this.runner_.pause();
+      } catch {
+        // This fails when the animation is finished explicitly
+        // (runner.finish()) since this destroys internal players. This is fine.
+      }
     }
   }
 


### PR DESCRIPTION
`start()` was previously a workaround for `pause()` calls failing in case the animation is `finish()`ed and internal players are orphaned:

https://github.com/ampproject/amphtml/blob/b6313e372fdd1298928e2417dcc616b03288e051/extensions/amp-animation/0.1/runners/native-web-animation-runner.js#L204-L205

(Players are _not_ orphaned when the animation is finished naturally, only when calling `finish()`)

However, `start`ing a finished animation will restart it, instead of keeping it in its finished state. This is problematic when trying to tap elements that get paused on `touchstart`.

<!--
# Instructions:

- Pick a meaningful title for your pull request. (Use sentence case.)
  - Prefix the title with an emoji to identify what is being done. (Copy-paste the emoji from the list below.)
  - Do not overuse punctuation in the title (like `(chore):`).
  - If it is helpful, use a simple prefix (like `ProjectX: Implement some feature`).
- Enter a succinct description that says why the PR is necessary, and what it does.
  - Mention the GitHub issue that is being addressed by the pull request.
  - The keywords `Fixes`, `Closes`, or `Resolves` followed the issue number will automatically close the issue.

> NOTE: All non-trivial changes (like introducing new features or components) should have an associated issue or reference an I2I (intent-to-implement: go.amp.dev/i2i). Please read through the contribution process (go.amp.dev/contributing/code) for more information.

# Example of a good description:

- Implement aspect X
- Leave out feature Y because of A
- Improve performance by B
- Improve accessibility by C

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Reverting a previous change
♻️ Refactoring
🚮 Deleting code
-->
