### PR TITLE
Introduce 'analytics-chunks-inabox' experiment

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -1,5 +1,9 @@
 {
-  "allow-doc-opt-in": ["amp-next-page", "analytics-chunks", "analytics-chunks-inabox"],
+  "allow-doc-opt-in": [
+    "amp-next-page",
+    "analytics-chunks",
+    "analytics-chunks-inabox"
+  ],
   "allow-url-opt-in": ["pump-early-frame"],
   "canary": 1,
   "a4aProfilingRate": 0.01,

--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -1,5 +1,5 @@
 {
-  "allow-doc-opt-in": ["amp-next-page", "analytics-chunks"],
+  "allow-doc-opt-in": ["amp-next-page", "analytics-chunks", "analytics-chunks-inabox"],
   "allow-url-opt-in": ["pump-early-frame"],
   "canary": 1,
   "a4aProfilingRate": 0.01,

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -1,5 +1,5 @@
 {
-  "allow-doc-opt-in": ["amp-next-page", "analytics-chunks"],
+  "allow-doc-opt-in": ["amp-next-page", "analytics-chunks", "analytics-chunks-inabox"],
   "allow-url-opt-in": ["pump-early-frame"],
   "canary": 0,
   "a4aProfilingRate": 0.01,

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -1,5 +1,9 @@
 {
-  "allow-doc-opt-in": ["amp-next-page", "analytics-chunks", "analytics-chunks-inabox"],
+  "allow-doc-opt-in": [
+    "amp-next-page",
+    "analytics-chunks",
+    "analytics-chunks-inabox"
+  ],
   "allow-url-opt-in": ["pump-early-frame"],
   "canary": 0,
   "a4aProfilingRate": 0.01,

--- a/extensions/amp-analytics/0.1/amp-analytics.js
+++ b/extensions/amp-analytics/0.1/amp-analytics.js
@@ -40,8 +40,8 @@ import {dict, hasOwn} from '../../../src/utils/object';
 import {expandTemplate} from '../../../src/string';
 import {getMode} from '../../../src/mode';
 import {installLinkerReaderService} from './linker-reader';
+import {isAnalyticsChunksExperimentOn} from './analytics-group';
 import {isArray, isEnumValue} from '../../../src/types';
-import {isExperimentOn} from '../../../src/experiments';
 import {isIframed} from '../../../src/dom';
 import {isInFie} from '../../../src/iframe-helper';
 import {toggle} from '../../../src/style';
@@ -231,7 +231,7 @@ export class AmpAnalytics extends AMP.BaseElement {
           const configPromise = new AnalyticsConfig(this.element).loadConfig();
           loadConfigDeferred.resolve(configPromise);
         };
-        if (isExperimentOn(this.win, 'analytics-chunks') && !this.isInabox_) {
+        if (isAnalyticsChunksExperimentOn(this.win)) {
           chunk(this.element, loadConfigTask, ChunkPriority.HIGH);
         } else {
           loadConfigTask();
@@ -583,7 +583,7 @@ export class AmpAnalytics extends AMP.BaseElement {
     const linkerTask = () => {
       this.linkerManager_.init();
     };
-    if (isExperimentOn(this.win, 'analytics-chunks') && !this.isInabox_) {
+    if (isAnalyticsChunksExperimentOn(this.win)) {
       chunk(this.element, linkerTask, ChunkPriority.LOW);
     } else {
       linkerTask();
@@ -720,7 +720,7 @@ export class AmpAnalytics extends AMP.BaseElement {
           .then((digest) => digest * 100 < threshold);
         sampleDeferred.resolve(samplePromise);
       };
-      if (isExperimentOn(this.win, 'analytics-chunks') && !this.isInabox_) {
+      if (isAnalyticsChunksExperimentOn(this.win)) {
         chunk(this.element, sampleInTask, ChunkPriority.LOW);
       } else {
         sampleInTask();

--- a/extensions/amp-analytics/0.1/analytics-group.js
+++ b/extensions/amp-analytics/0.1/analytics-group.js
@@ -106,8 +106,7 @@ export class AnalyticsGroup {
     };
     if (
       this.triggerCount_ < IMMEDIATE_TRIGGER_THRES ||
-      !isExperimentOn(this.win_, 'analytics-chunks') ||
-      getMode(this.win_).runtime == 'inabox'
+      !isAnalyticsChunksExperimentOn(this.win_)
     ) {
       task();
     } else {
@@ -120,4 +119,16 @@ export class AnalyticsGroup {
     this.triggerCount_++;
     return deferred.promise;
   }
+}
+
+/**
+ * Determine if the analytics-chunks experiment should be applied
+ * @param {!Window} win
+ * @return {boolean}
+ */
+export function isAnalyticsChunksExperimentOn(win) {
+  if (getMode(win).runtime == 'inabox') {
+    return false;
+  }
+  return isExperimentOn(win, 'analytics-chunks');
 }

--- a/extensions/amp-analytics/0.1/analytics-group.js
+++ b/extensions/amp-analytics/0.1/analytics-group.js
@@ -128,7 +128,7 @@ export class AnalyticsGroup {
  */
 export function isAnalyticsChunksExperimentOn(win) {
   if (getMode(win).runtime == 'inabox') {
-    return false;
+    return isExperimentOn(win, 'analytics-chunks-inabox');
   }
   return isExperimentOn(win, 'analytics-chunks');
 }

--- a/extensions/amp-analytics/0.1/cookie-writer.js
+++ b/extensions/amp-analytics/0.1/cookie-writer.js
@@ -18,10 +18,9 @@ import {BASE_CID_MAX_AGE_MILLIS} from '../../../src/service/cid-impl';
 import {ChunkPriority, chunk} from '../../../src/chunk';
 import {Deferred} from '../../../src/utils/promise';
 import {Services} from '../../../src/services';
-import {getMode} from '../../../src/mode';
 import {hasOwn} from '../../../src/utils/object';
+import {isAnalyticsChunksExperimentOn} from './analytics-group';
 import {isCookieAllowed} from './cookie-reader';
-import {isExperimentOn} from '../../../src/experiments';
 import {isObject} from '../../../src/types';
 import {setCookie} from '../../../src/cookies';
 import {user} from '../../../src/log';
@@ -73,10 +72,7 @@ export class CookieWriter {
       const task = () => {
         this.writeDeferred_.resolve(this.init_());
       };
-      if (
-        isExperimentOn(this.win_, 'analytics-chunks') &&
-        getMode(this.win_).runtime != 'inabox'
-      ) {
+      if (isAnalyticsChunksExperimentOn(this.win_)) {
         chunk(this.element_, task, ChunkPriority.LOW);
       } else {
         task();

--- a/tools/experiments/experiments-config.js
+++ b/tools/experiments/experiments-config.js
@@ -309,9 +309,15 @@ export const EXPERIMENTS = [
   },
   {
     id: 'analytics-chunks',
-    name: 'AMP Analytics Break long tasks to chunks',
-    spec: 'TODO: add before merge',
-    cleanupIssue: 'TODO: create issue before merge',
+    name: 'AMP Analytics Break long tasks to chunks (AMP docs only)',
+    spec: 'https://github.com/ampproject/amphtml/issues/28435',
+    cleanupIssue: 'https://github.com/ampproject/amphtml/issues/28435',
+  },
+  {
+    id: 'analytics-chunks-inabox',
+    name: 'AMP Analytics Break long tasks to chunks (AMP Ads only)',
+    spec: 'https://github.com/ampproject/amphtml/issues/28435',
+    cleanupIssue: 'https://github.com/ampproject/amphtml/issues/28435',
   },
   {
     id: 'amp-ad-no-center-css',


### PR DESCRIPTION
Since there's no objection from the ads team, I'll start with experimenting the feature in AMPHTML ads. 
Introduced a separate experiment because `analytics-chunks` has been turned on to AMP docs. 