### PR TITLE
🐛 Analytics config: Do not check inline transport setting without vendor specified

### DIFF
--- a/extensions/amp-analytics/0.1/config.js
+++ b/extensions/amp-analytics/0.1/config.js
@@ -405,7 +405,7 @@ export class AnalyticsConfig {
    * @param {!JsonObject} inlineConfig
    */
   validateTransport_(inlineConfig) {
-    if (this.vendorConfig_) {
+    if (this.element_.getAttribute('type')) {
       // TODO(zhouyx, #7096) Track overwrite percentage. Prevent transport
       // overwriting
       if (inlineConfig['transport'] || this.remoteConfig_['transport']) {

--- a/test/manual/analytics-batching.amp.html
+++ b/test/manual/analytics-batching.amp.html
@@ -41,7 +41,7 @@ Nam posuere velit euismod risus pulvinar, in sollicitudin sapien consectetur. Ve
 <p>
 Integer in felis at lacus mattis facilisis. Curabitur tincidunt, felis porttitor mollis finibus, tortor elit elementum dolor, vel vulputate lorem dui id ante. Vivamus in velit at lectus blandit gravida vitae quis arcu. Nam et magna magna. Fusce condimentum diam lacus, ac ullamcorper purus malesuada eu. Mauris ullamcorper elit et venenatis faucibus. Nullam lobortis molestie purus quis pellentesque. Sed at libero id nisi rhoncus tincidunt. Praesent vestibulum vehicula tristique. Etiam rutrum, nunc id porta interdum, nulla nisi molestie leo, at fermentum justo dolor at lorem. Duis in egestas sapien.
 </p>
-<amp-analytics type="_ping_">
+<amp-analytics>
   <script type="application/json">
   {
     "requests": {


### PR DESCRIPTION
Fix a regression caused by #28261.

`AnalyticsConfig.vendorConfig_` is always a json object. Check for `type` attribute instead. 

Change in behavior: Now we also throw error for invalid vendor type. I'm ok with this change. 