### PR TITLE
🐛 Bug fix: Fix the logic for saving the enableAutoAdSize flag in local storage.

### DIFF
--- a/extensions/amp-ad-network-adsense-impl/0.1/responsive-state.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/responsive-state.js
@@ -29,6 +29,7 @@ import {getData} from '../../../src/event-helper';
 import {hasOwn} from '../../../src/utils/object';
 import {randomlySelectUnsetExperiments} from '../../../src/experiments';
 import {toWin} from '../../../src/types';
+import {tryParseJson} from '../../../src/json';
 
 const TAG = 'amp-ad-network-adsense-impl';
 
@@ -174,10 +175,15 @@ export class ResponsiveState {
 
     const listener = (event) => {
       const data = getData(event);
-      if (!data.includes('googMsgType')) {
+      let dataList = null;
+      if (typeof data == 'string') {
+        dataList = tryParseJson(data);
+      } else if (typeof data == 'object') {
+        dataList = data;
+      }
+      if (dataList == null) {
         return;
       }
-      const dataList = JSON.parse(data);
 
       // dataList will look like this:
       // {

--- a/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
@@ -476,7 +476,7 @@ describes.realWin(
           'enableAutoAdSize': '1',
         };
 
-        win.postMessage(data, '*');
+        win.postMessage(JSON.stringify(data), '*');
 
         await savePromise;
 

--- a/extensions/amp-ad-network-adsense-impl/0.1/test/test-responsive-state.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/test/test-responsive-state.js
@@ -410,29 +410,10 @@ describes.realWin(
       });
     });
     describe('maybeAttachSettingsListener', () => {
-      it("doesn't set up a listener if the experiment is not enabled", () => {
-        const element = createElement({
-          'data-ad-client': AD_CLIENT_ID,
-          'height': '200px',
-          'width': '50vw',
-        });
-        const promise = ResponsiveState.maybeAttachSettingsListener(
-          element,
-          fakeIframe,
-          AD_CLIENT_ID
-        );
-        expect(promise).to.be.null;
-      });
-
       describe('sets up a listener that', () => {
         let promise;
 
         beforeEach(() => {
-          forceExperimentBranch(
-            win,
-            AD_SIZE_OPTIMIZATION_EXP.branch,
-            AD_SIZE_OPTIMIZATION_EXP.experiment
-          );
           const element = createElement({
             'data-ad-client': AD_CLIENT_ID,
             'height': '200px',
@@ -452,7 +433,7 @@ describes.realWin(
             'adClient': AD_CLIENT_ID,
             'enableAutoAdSize': '1',
           };
-          win.postMessage(data, '*');
+          win.postMessage(JSON.stringify(data), '*');
 
           await promise;
 
@@ -465,7 +446,7 @@ describes.realWin(
             'adClient': AD_CLIENT_ID,
             'enableAutoAdSize': '0',
           };
-          win.postMessage(data, '*');
+          win.postMessage(JSON.stringify(data), '*');
 
           await promise;
 
@@ -480,13 +461,13 @@ describes.realWin(
             'adClient': AD_CLIENT_ID,
             'enableAutoAdSize': '1',
           };
-          win.postMessage(badData, '*');
+          win.postMessage(JSON.stringify(badData), '*');
           const goodData = {
             'googMsgType': 'adsense-settings',
             'adClient': AD_CLIENT_ID,
             'enableAutoAdSize': '0',
           };
-          win.postMessage(goodData, '*');
+          win.postMessage(JSON.stringify(goodData), '*');
 
           await promise;
 
@@ -501,13 +482,13 @@ describes.realWin(
             'adClient': AD_CLIENT_ID + 'i',
             'enableAutoAdSize': '1',
           };
-          win.postMessage(badData, '*');
+          win.postMessage(JSON.stringify(badData), '*');
           const goodData = {
             'googMsgType': 'adsense-settings',
             'adClient': AD_CLIENT_ID,
             'enableAutoAdSize': '0',
           };
-          win.postMessage(goodData, '*');
+          win.postMessage(JSON.stringify(goodData), '*');
 
           await promise;
 

--- a/extensions/amp-ad-network-adsense-impl/OWNERS
+++ b/extensions/amp-ad-network-adsense-impl/OWNERS
@@ -6,6 +6,7 @@
     {
       owners: [
         {name: 'ampproject/wg-ads-reviewers'},
+        {name: 'Jiaming-X', notify: true},
         {name: 'jeffkaufman', notify: true},
       ],
     },


### PR DESCRIPTION
Fix the logic for saving the enableAutoAdSize flag in local storage:
1. The flag saving flow should not be controlled by the experiment.
2. The data will be returned in the form of string and need an extra step for JSON parsing.