### PR TITLE
✨support for amp-embed type=yahoofedads

### DIFF
--- a/3p/integration.js
+++ b/3p/integration.js
@@ -280,6 +280,7 @@ import {wisteria} from '../ads/wisteria';
 import {wpmedia} from '../ads/wpmedia';
 import {xlift} from '../ads/xlift';
 import {yahoo} from '../ads/yahoo';
+import {yahoofedads} from '../ads/yahoofedads';
 import {yahoojp} from '../ads/yahoojp';
 import {yahoonativeads} from '../ads/yahoonativeads';
 import {yandex} from '../ads/yandex';
@@ -334,6 +335,7 @@ const AMP_EMBED_ALLOWED = {
   taboola: true,
   temedya: true,
   whopainfeed: true,
+  yahoofedads: true,
   yahoonativeads: true,
   zen: true,
   zergnet: true,
@@ -578,6 +580,7 @@ register('wisteria', wisteria);
 register('wpmedia', wpmedia);
 register('xlift', xlift);
 register('yahoo', yahoo);
+register('yahoofedads', yahoofedads);
 register('yahoojp', yahoojp);
 register('yahoonativeads', yahoonativeads);
 register('yandex', yandex);

--- a/ads/_config.js
+++ b/ads/_config.js
@@ -1176,6 +1176,10 @@ const adConfig = jsonConfiguration({
     preconnect: 'https://us.adserver.yahoo.com',
   },
 
+  'yahoofedads': {
+    renderStartImplemented: true,
+  },
+
   'yahoojp': {
     prefetch: [
       'https://s.yimg.jp/images/listing/tool/yads/ydn/amp/amp.js',

--- a/ads/yahoofedads.js
+++ b/ads/yahoofedads.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ads/yahoofedads.js
+++ b/ads/yahoofedads.js
@@ -1,0 +1,52 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {loadScript, validateData} from '../3p/3p';
+
+/**
+ * @param {!Window} global
+ * @param {!Object} data
+ */
+export function yahoofedads(global, data) {
+  validateData(data, [
+    'adUnit',
+    'site',
+    'region',
+    'lang',
+    'sa',
+    'spaceId',
+    'url',
+  ]);
+
+  global.amp = true;
+  global.adConfig = {
+    'adUnit': data.adUnit,
+    'forceSource': data.forceSource,
+    'lang': data.lang,
+    'publisherUrl': data.url,
+    'region': data.region,
+    'sa': data.sa,
+    'sectionId': data.sectionId,
+    'site': data.site,
+    'spaceId': data.spaceId,
+  };
+
+  loadScript(
+    global,
+    'https://s.yimg.com/cv/apiv2/dy/fedads/fedads.mock.js',
+    () => global.context.renderStart()
+  );
+}

--- a/ads/yahoofedads.md
+++ b/ads/yahoofedads.md
@@ -1,5 +1,5 @@
 <!---
-Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+Copyright 2020 The AMP HTML Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/ads/yahoofedads.md
+++ b/ads/yahoofedads.md
@@ -1,0 +1,55 @@
+<!---
+Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS-IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# Yahoo Native-Display Ads Federation
+
+## Example
+
+Yahoo Native-Display Ads Federation only requires a configured section code to run. Please work with your account manager to configure your AMP sections.
+
+### Basic
+
+```html
+<amp-embed
+  width="320"
+  height="320"
+  layout="responsive"
+  type="yahoofedads"
+  data-site="finance"
+  data-region="US"
+  data-lang="en-US"
+
+  data-ad-unit="pencil"
+  data-sa="{&quot;LREC&quot;:&quot;300x250&quot;,&quot;secure&quot;:&quot;true&quot;,&quot;content&quot;:&quot;no_expandable;&quot;,&quot;isSupplySegment&quot;:&quot;false&quot;,&quot;lang&quot;:&quot;en-US&quot;,&quot;region&quot;:&quot;US&quot;,&quot;site_attribute&quot;:&quot;wiki_topics=\&quot;Anthony_Joshua;Tyson_Fury;Eddie_Hearn;Deontay_Wilder;Kubrat_Pulev;Tottenham_Hotspur_Stadium;Dillian_Whyte\&quot; ctopid=\&quot;2074500;2078500;2083000;2212000;13311000\&quot; hashtag=\&quot;2074500;2078500;2083000;2212000;13311000\&quot; rs=\&quot;lmsid:a0ad000000AxDnbAAF;revsp:omnisport.uk;lpstaid:71ee6f14-9c73-3688-b4a9-32e6578057d0;pct:story\&quot;&quot;}"
+  data-url="https://techcrunch.com"
+  /* Optional override parameters */
+  data-space-id="980771322"
+  data-section-id="5661957"
+>
+</amp-embed>
+```
+
+### Required parameters
+
+- `data-site`, `data-region`, `data-lang`: Unique site/region/lang code that represents your site
+- `data-ad-unit`: The template used by picked Native AD
+- `data-sa`: The site-attribute used by display AD to render
+- `data-url` : Url the AD is hosted in for tracking purpose
+
+### Optional override parameters
+
+- `data-space-id`: Use this to override what space id need to be used on picking up Display AD
+- `data-section-id`: Use this ot override what section id need to be used on picking up Native AD

--- a/examples/ads.amp.html
+++ b/examples/ads.amp.html
@@ -283,6 +283,7 @@
         <option>wpmedia</option>
         <option>xlift</option>
         <option>yahoo</option>
+        <option>yahoofedads</option>
         <option>yahoojp</option>
         <option>yahoonativeads</option>
         <option>yandex</option>
@@ -2296,6 +2297,18 @@
       data-site="news"
       data-sa='{"LREC":"300x250","secure":"true","content":"no_expandable;"}'>
   </amp-ad>
+
+  <h2>Yahoo Native-Display Ads Federation</h2>
+  <amp-embed width="320" height="320"
+    type="yahoofedads"
+    layout="responsive"
+    data-site="finance"
+    data-region="US"
+    data-lang="en-US"
+    data-ad-unit="pencil"
+    data-sa="{&quot;LREC&quot;:&quot;300x250&quot;,&quot;secure&quot;:&quot;true&quot;,&quot;content&quot;:&quot;no_expandable;&quot;,&quot;isSupplySegment&quot;:&quot;false&quot;,&quot;lang&quot;:&quot;en-US&quot;,&quot;region&quot;:&quot;US&quot;,&quot;site_attribute&quot;:&quot;wiki_topics=\&quot;Anthony_Joshua;Tyson_Fury;Eddie_Hearn;Deontay_Wilder;Kubrat_Pulev;Tottenham_Hotspur_Stadium;Dillian_Whyte\&quot; ctopid=\&quot;2074500;2078500;2083000;2212000;13311000\&quot; hashtag=\&quot;2074500;2078500;2083000;2212000;13311000\&quot; rs=\&quot;lmsid:a0ad000000AxDnbAAF;revsp:omnisport.uk;lpstaid:71ee6f14-9c73-3688-b4a9-32e6578057d0;pct:story\&quot;&quot;}"
+    data-url="https://finance.yahoo.com">
+  </amp-embed>
 
   <h2>Yahoo Native Ads</h2>
   <amp-embed width="320" height="320"

--- a/extensions/amp-ad/amp-ad.md
+++ b/extensions/amp-ad/amp-ad.md
@@ -454,6 +454,7 @@ See [amp-ad rules](https://github.com/ampproject/amphtml/blob/master/extensions/
 - [Taboola](../../ads/taboola.md)
 - [TE Medya](../../ads/temedya.md)
 - [Whopa InFeed](../../ads/whopainfeed.md)
+- [Yahoo Native-Display Ads Federation](../../ads/yahoofedads.md)
 - [Yahoo Native Ads](../../ads/yahoonativeads.md)
 - [Zen](../../ads/zen.md)
 - [ZergNet](../../ads/zergnet.md)


### PR DESCRIPTION
Adds support to render Yahoo Native-Display Ad Federation units using the amp-embed tag.

Sample Rendering
<img width="324" alt="Screen Shot 2020-05-15 at 16 34 17" src="https://user-images.githubusercontent.com/1990056/82104024-1f3ef000-96ca-11ea-8712-17d9d40b7cea.png">

Test page on localhost:
http://localhost:8000/examples/ads.amp.html?type=yahoofedads