### PR TITLE
🐛♻️ Remove unused 'opt_collectVars' from expandUrlSync 

### DIFF
--- a/extensions/amp-ad-exit/0.1/amp-ad-exit.js
+++ b/extensions/amp-ad-exit/0.1/amp-ad-exit.js
@@ -270,12 +270,7 @@ export class AmpAdExit extends AMP.BaseElement {
       }
     }
     return (url) =>
-      replacements.expandUrlSync(
-        url,
-        substitutionFunctions,
-        undefined /* opt_collectVars */,
-        whitelist
-      );
+      replacements.expandUrlSync(url, substitutionFunctions, whitelist);
   }
 
   /**

--- a/extensions/amp-link-rewriter/0.1/link-rewriter.js
+++ b/extensions/amp-link-rewriter/0.1/link-rewriter.js
@@ -162,7 +162,6 @@ export class LinkRewriter {
       this.rewrittenUrl_,
       /** expandUrlSync doesn't fill DOCUMENT_REFERRER so we pass it*/
       {DOCUMENT_REFERRER: this.referrer_},
-      undefined,
       PAGE_PROP_WHITELIST
     );
   }

--- a/src/service/navigation.js
+++ b/src/service/navigation.js
@@ -830,7 +830,6 @@ function maybeExpandUrlParams(ampdoc, e) {
   const newHref = Services.urlReplacementsForDoc(target).expandUrlSync(
     hrefToExpand,
     vars,
-    undefined,
     /* opt_whitelist */ {
       // For now we only allow to replace the click location vars
       // and nothing else.

--- a/src/service/url-replacements-impl.js
+++ b/src/service/url-replacements-impl.js
@@ -814,16 +814,15 @@ export class UrlReplacements {
    * variables or override existing ones.  Any async bindings are ignored.
    * @param {string} source
    * @param {!Object<string, (ResolverReturnDef|!SyncResolverDef)>=} opt_bindings
-   * @param {!Object<string, ResolverReturnDef>=} opt_collectVars
    * @param {!Object<string, boolean>=} opt_whiteList Optional white list of
    *     names that can be substituted.
    * @return {string}
    */
-  expandStringSync(source, opt_bindings, opt_collectVars, opt_whiteList) {
+  expandStringSync(source, opt_bindings, opt_whiteList) {
     return /** @type {string} */ (new Expander(
       this.variableSource_,
       opt_bindings,
-      opt_collectVars,
+      /* opt_collectVars */ undefined,
       /* opt_sync */ true,
       opt_whiteList,
       /* opt_noEncode */ true
@@ -856,18 +855,17 @@ export class UrlReplacements {
    * variables or override existing ones.  Any async bindings are ignored.
    * @param {string} url
    * @param {!Object<string, (ResolverReturnDef|!SyncResolverDef)>=} opt_bindings
-   * @param {!Object<string, ResolverReturnDef>=} opt_collectVars
    * @param {!Object<string, boolean>=} opt_whiteList Optional white list of
    *     names that can be substituted.
    * @return {string}
    */
-  expandUrlSync(url, opt_bindings, opt_collectVars, opt_whiteList) {
+  expandUrlSync(url, opt_bindings, opt_whiteList) {
     return this.ensureProtocolMatches_(
       url,
       /** @type {string} */ (new Expander(
         this.variableSource_,
         opt_bindings,
-        opt_collectVars,
+        /* opt_collectVars */ undefined,
         /* opt_sync */ true,
         opt_whiteList
       )./*OK*/ expand(url))
@@ -1089,7 +1087,6 @@ export class UrlReplacements {
         defaultUrlParams = this.expandUrlSync(
           defaultUrlParams,
           /* opt_bindings */ undefined,
-          /* opt_collectVars */ undefined,
           /* opt_whitelist */ overrideWhitelist
         );
       }
@@ -1111,7 +1108,6 @@ export class UrlReplacements {
       ? this.expandUrlSync(
           href,
           /* opt_bindings */ undefined,
-          /* opt_collectVars */ undefined,
           /* opt_whitelist */ allowedList
         )
       : href;

--- a/test/unit/test-url-replacements.js
+++ b/test/unit/test-url-replacements.js
@@ -1507,7 +1507,6 @@ describes.sandboxed('UrlReplacements', {}, (env) => {
             documentElement
           );
           urlReplacements.ampdoc.win.performance.timing.loadEventStart = 109;
-          const collectVars = {};
           const expanded = urlReplacements.expandUrlSync(
             'r=RANDOM&c=CONST&f=FUNCT(hello,world)&a=b&d=PROM&e=PAGE_LOAD_TIME',
             {
@@ -1519,18 +1518,11 @@ describes.sandboxed('UrlReplacements', {}, (env) => {
               'PROM': function () {
                 return Promise.resolve('boo');
               },
-            },
-            collectVars
+            }
           );
           expect(expanded).to.match(
             /^r=\d(\.\d+)?&c=ABC&f=helloworld&a=b&d=&e=9$/
           );
-          expect(collectVars).to.deep.equal({
-            'RANDOM': parseFloat(/^r=(\d+(\.\d+)?)/.exec(expanded)[1]),
-            'CONST': 'ABC',
-            'FUNCT(hello,world)': 'helloworld',
-            'PAGE_LOAD_TIME': 9,
-          });
         });
 
         it('should reject protocol changes', () => {
@@ -1586,7 +1578,6 @@ describes.sandboxed('UrlReplacements', {}, (env) => {
               throw Error('Should not be called');
             },
           },
-          undefined,
           {
             'CONST': true,
           }


### PR DESCRIPTION
I wanted to clean up the urlReplacement Service and refactor the Expander class a bit. 
First thing I noticed is that `expandUrlSync` and `expandStringSync` takes in unused variable `opt_collectVars`. 
There's no need to collect vars synchronously. 

I removed the unused variables. This also fix a bug in RTC where we failed to handle the allowed macro list. 
https://github.com/ampproject/amphtml/blob/49f075c0f4c2ee02d7dee9eb92c02fb3609b6475/extensions/amp-a4a/0.1/real-time-config-manager.js#L143
