### PR TITLE
intersect-resources: Enable idle render

### DIFF
--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -1339,11 +1339,6 @@ export class ResourcesImpl {
       }
     }
 
-    // With IntersectionObserver, skip phases 5+.
-    if (this.intersectionObserver_) {
-      return;
-    }
-
     if (
       this.visible_ &&
       this.exec_.getSize() == 0 &&


### PR DESCRIPTION
Partial for #25428.

I originally thought that elements outside of the rootMargin need special handling (explicit measures), but I forgot that the initial observer callback includes all observed elements which will provide a measurement to all elements on the page.

So just removing the early-out might do the trick. 😅 