### PR TITLE
♿  Prevent TalkBack from reading content behind education layer.

### DIFF
--- a/extensions/amp-story-education/0.1/amp-story-education.js
+++ b/extensions/amp-story-education/0.1/amp-story-education.js
@@ -29,6 +29,7 @@ import {dict} from '../../../src/utils/object';
 import {htmlFor} from '../../../src/static-template';
 import {removeChildren} from '../../../src/dom';
 import {toggle} from '../../../src/style';
+import {setModalAsClosed, setModalAsOpen} from '../../../src/modal';
 
 /** @type {string} */
 const TAG = 'amp-story-education';
@@ -203,6 +204,8 @@ export class AmpStoryEducation extends AMP.BaseElement {
             Action.TOGGLE_PAUSED,
             this.storyPausedStateToRestore_
           );
+          setModalAsClosed(this.element);
+          this.element.setAttribute('aria-modal', 'false');
         });
         break;
       case State.NAVIGATION_TAP:
@@ -272,6 +275,8 @@ export class AmpStoryEducation extends AMP.BaseElement {
       removeChildren(this.containerEl_);
       toggle(this.containerEl_, true);
       this.containerEl_.appendChild(template);
+      setModalAsOpen(this.element);
+      this.element.setAttribute('aria-modal', 'true');
     });
   }
 

--- a/extensions/amp-story/1.0/amp-story-system-layer.css
+++ b/extensions/amp-story/1.0/amp-story-system-layer.css
@@ -155,19 +155,22 @@
 }
 
 [i-amphtml-story-messagedisplay="noshow"] .i-amphtml-message-container {
-  transition: opacity 0.2s cubic-bezier(0.4, 0.0, 1, 1), transform 0.0s 0.2s !important;
-  transform: translateX(10px) !important;
+  transition: opacity 0.2s cubic-bezier(0.4, 0.0, 1, 1), visibility 0.2s, transform 0.0s 0.2s !important;
   opacity: 0 !important;
+  visibility: hidden !important;
+  transform: translateX(10px) !important;
 }
 
 [i-amphtml-story-has-new-page="noshow"] .i-amphtml-story-has-new-page-notification-container {
-  transition: opacity 1.5s !important;
+  transition: opacity 1.5s, visibility 1.5s !important;
   opacity: 0 !important;
+  visibility: hidden !important;
 }
 
 .i-amphtml-last-page-active[i-amphtml-story-has-new-page="show"] .i-amphtml-story-has-new-page-notification-container {
-  transition: opacity 1.5s !important;
+  transition: opacity 1.5s, visibility 1.5s !important;
   opacity: 1 !important;
+  visibility: visible !important;
 }
 
 [dir=rtl][i-amphtml-story-messagedisplay="noshow"] .i-amphtml-message-container {
@@ -175,8 +178,9 @@
 }
 
 [i-amphtml-story-messagedisplay="show"] .i-amphtml-message-container {
-  transition: opacity 0.2s cubic-bezier(0.0, 0.0, 0.2, 1), transform 0.2s cubic-bezier(0.4, 0.0, 0.2, 1) !important;
+  transition: opacity 0.2s cubic-bezier(0.0, 0.0, 0.2, 1), visibility 0.2s, transform 0.2s cubic-bezier(0.4, 0.0, 0.2, 1) !important;
   opacity: 1 !important;
+  visibility: visible !important;
   transform: translateX(0px) !important;
 }
 


### PR DESCRIPTION
By using the `setModalAsOpen` and `setModalAsClosed` methods in [modal.js](https://github.com/ampproject/amphtml/blob/b6313e372fdd1298928e2417dcc616b03288e051/src/modal.js) we are able to hide all content outside of story education from screen readers.
This contributes to #28410.

This follows the pattern used in amp-sidebar.js:
[setModalAsOpen](https://github.com/ampproject/amphtml/blob/1d29dfbc5ebb1bf89a77091afaa2a712457c1db6/extensions/amp-sidebar/0.2/amp-sidebar.js#L396-L397) in amp-sidebar.js
[setModalAsClosed](https://github.com/ampproject/amphtml/blob/1d29dfbc5ebb1bf89a77091afaa2a712457c1db6/extensions/amp-sidebar/0.2/amp-sidebar.js#L445-L446) in amp-sidebar.js