### PR TITLE
🚀 Fix & enable Move FixedLayer experiment

### DIFF
--- a/build-system/global-configs/experiments-config.json
+++ b/build-system/global-configs/experiments-config.json
@@ -7,6 +7,13 @@
     "expiration_date_utc": "2020-06-30",
     "define_experiment_constant": "INTERSECTION_OBSERVER_POLYFILL_INABOX"
   },
-  "experimentB": {},
+  "experimentB": {
+    "name": "MoveFixedLayer",
+    "environment": "AMP",
+    "command": "gulp dist --define_experiment_constant=MOVE_FIXED_LAYER",
+    "issue": "https://github.com/ampproject/amphtml/issues/27120",
+    "expiration_date_utc": "2021-01-01",
+    "define_experiment_constant": "MOVE_FIXED_LAYER"
+  },
   "experimentC": {}
 }

--- a/src/inabox/inabox-viewport.js
+++ b/src/inabox/inabox-viewport.js
@@ -348,7 +348,9 @@ class InaboxViewportImpl {
   }
 
   /** @override */
-  updateFixedLayer() {}
+  updateFixedLayer() {
+    return Promise.resolve();
+  }
 
   /** @override */
   addToFixedLayer(unusedElement, opt_forceTransfer) {

--- a/src/service/viewport/viewport-impl.js
+++ b/src/service/viewport/viewport-impl.js
@@ -599,7 +599,9 @@ export class ViewportImpl {
     );
 
     this.enterOverlayMode();
-    this.fixedLayer_.enterLightbox(opt_requestingElement, opt_onComplete);
+    if (this.fixedLayer_) {
+      this.fixedLayer_.enterLightbox(opt_requestingElement, opt_onComplete);
+    }
 
     if (opt_requestingElement) {
       this.maybeEnterFieLightboxMode(
@@ -618,7 +620,9 @@ export class ViewportImpl {
       /* cancelUnsent */ true
     );
 
-    this.fixedLayer_.leaveLightbox();
+    if (this.fixedLayer_) {
+      this.fixedLayer_.leaveLightbox();
+    }
     this.leaveOverlayMode();
 
     if (opt_requestingElement) {
@@ -779,16 +783,25 @@ export class ViewportImpl {
 
   /** @override */
   updateFixedLayer() {
-    this.fixedLayer_.update();
+    if (!this.fixedLayer_) {
+      return Promise.resolve();
+    }
+    return this.fixedLayer_.update();
   }
 
   /** @override */
   addToFixedLayer(element, opt_forceTransfer) {
+    if (!this.fixedLayer_) {
+      return Promise.resolve();
+    }
     return this.fixedLayer_.addElement(element, opt_forceTransfer);
   }
 
   /** @override */
   removeFromFixedLayer(element) {
+    if (!this.fixedLayer_) {
+      return;
+    }
     this.fixedLayer_.removeElement(element);
   }
 
@@ -1034,10 +1047,7 @@ export class ViewportImpl {
     const oldSize = this.size_;
     this.size_ = null; // Need to recalc.
     const newSize = this.getSize();
-    const promise = this.fixedLayer_
-      ? this.fixedLayer_.update()
-      : Promise.resolve();
-    promise.then(() => {
+    this.updateFixedLayer().then(() => {
       const widthChanged = !oldSize || oldSize.width != newSize.width;
       this.changed_(/*relayoutAll*/ widthChanged, 0);
       const sizeChanged = widthChanged || oldSize.height != newSize.height;

--- a/src/service/viewport/viewport-interface.js
+++ b/src/service/viewport/viewport-interface.js
@@ -299,6 +299,7 @@ export class ViewportInterface extends Disposable {
 
   /**
    * Updates the fixed layer.
+   * @return {!Promise}
    */
   updateFixedLayer() {}
 


### PR DESCRIPTION
Enables Move FixedLayer experiment and resolves issues with experiment. Tests were failing due to missing `fixedLayer_` property on viewport, used by `amp-sidebar` via publicly accessible APIs. 

Verified tests failing [here](https://travis-ci.org/github/ampproject/amphtml/jobs/687565149) are resolved via running commands from `experiment-tests.js` gulp task. 