### PR TITLE
E2e viewer fixture

### DIFF
--- a/build-system/tasks/e2e/amp-driver.js
+++ b/build-system/tasks/e2e/amp-driver.js
@@ -44,7 +44,7 @@ const EnvironmentBehaviorMap = {
   [AmpdocEnvironment.VIEWER_DEMO]: {
     ready(controller) {
       return controller
-        .findElement('#AMP_DOC_dynamic[data-loaded]')
+        .findElement('#viewer[data-loaded]')
         .then((frame) => controller.switchToFrame(frame));
     },
 
@@ -61,7 +61,7 @@ const EnvironmentBehaviorMap = {
       url = url.replace('#', '&');
       // TODO(estherkim): somehow allow non-8000 port and domain
       return (
-        `http://localhost:8000/examples/viewer.html#href=${url}` +
+        `http://localhost:8000/test/fixtures/e2e/amp-viewer-integration/viewer.html#href=${url}` +
         `&caps=${defaultCaps.join(',')}`
       );
     },

--- a/build-system/tasks/e2e/describes-e2e.js
+++ b/build-system/tasks/e2e/describes-e2e.js
@@ -513,12 +513,7 @@ class EndToEndFixture {
       // Set env props that require the fixture to be set up.
       if (env.environment === AmpdocEnvironment.VIEWER_DEMO) {
         env.receivedMessages = await controller.evaluate(() => {
-          // The viewer.html file will launch 10 test viewers, only one of which is the requested url.
-          // TODO(gh/amphtml/28200): only load the one viewer.
-          const viewer = window.parent.allViewers.find((v) =>
-            v.id.includes('dynamic')
-          );
-          return viewer.receivedMessages;
+          return window.parent.viewer.receivedMessages;
         });
       }
     } catch (ex) {

--- a/examples/viewer.html
+++ b/examples/viewer.html
@@ -188,17 +188,6 @@
       text-decoration: underline;
     }
 
-    viewer[data-show-container="dynamic"] #container-dynamic {
-      visibility: visible;
-      -webkit-transform: none;
-      -ms-transform: none;
-      transform: none;
-    }
-
-    viewer[data-show-container="dynamic"] #show-container-dynamic-anchor {
-      text-decoration: underline;
-    }
-
     viewer.natural container {
       overflow-y: hidden;
     }
@@ -744,21 +733,9 @@
           '9',
           './amp-autocomplete.ssr.html?amp_js_v=0.1',
           false).start();
-      addShowContainer('9');
+      addShowContainer('9'); 
 
-      if (href) {
-        new Viewer(
-            'container-dynamic',
-            'dynamic',
-            addQueryParam(href, 'amp_js_v', '0.1'),
-            true,
-            caps).start();
-        document.getElementById('show-containerdynamic-anchor').hidden = false;
-        addShowContainer('dynamic');
-        showContainer('dynamic');
-      } else {
-        showContainer('1');
-      }
+      showContainer('1');
     }
 
     function addShowContainer(id) {
@@ -804,7 +781,6 @@
       <a class="show-container-anchor" id="show-container7-anchor">Seven</a>
       <a class="show-container-anchor" id="show-container8-anchor">Eight</a>
       <a class="show-container-anchor" id="show-container9-anchor">Nine</a>
-      <a class="show-container-anchor" id="show-containerdynamic-anchor" hidden>Dynamic</a>
       <a>|</a>
       <a id="visibilityToggle">Visible</a>
     </header>
@@ -839,11 +815,6 @@
       </div>
     </container>
     <container id="container7">
-      <div class="wait">
-        Please wait, the AMP doc will appear here...
-      </div>
-    </container>
-    <container id="container-dynamic">
       <div class="wait">
         Please wait, the AMP doc will appear here...
       </div>

--- a/test/e2e/test-document-height.js
+++ b/test/e2e/test-document-height.js
@@ -32,7 +32,7 @@ describes.endtoend(
 
       // Example message: ['documentHeight, { height: 200 }]
       const firstHeight = documentHeightMessages[0].data.height;
-      await expect(Math.floor(firstHeight)).equal(447);
+      await expect(Math.floor(firstHeight)).equal(383);
     });
   }
 );

--- a/test/fixtures/e2e/amp-viewer-integration/viewer.html
+++ b/test/fixtures/e2e/amp-viewer-integration/viewer.html
@@ -70,7 +70,7 @@
   </style>
 
   <script>
-    let viewer = null;
+    var viewer = null;
     function Viewer(containerId, id, url, opt_caps) {
       this.id = id;
       this.url = url;

--- a/test/fixtures/e2e/amp-viewer-integration/viewer.html
+++ b/test/fixtures/e2e/amp-viewer-integration/viewer.html
@@ -39,11 +39,14 @@
       justify-content: flex-start;
       align-items: center;
       padding: 0 8px;
+    } 
+    header h1 {
+      font-size: 22px; 
     }
 
     container {
       position: absolute;
-      top: 0;
+      top: 50px;
       left: 0;
       right: 0;
       bottom: 0;
@@ -57,11 +60,6 @@
       height: 100%;
     }
 
-    header h1 {
-      font-size: 22px;
-      flex-grow: 1;
-    }
-
     .wait {
       position: absolute;
       z-index: 3;
@@ -73,7 +71,7 @@
 
   <script>
     let viewer = null;
-    function Viewer(containerId, id, url) {
+    function Viewer(containerId, id, url, opt_caps) {
       this.id = id;
       this.url = url;
       this.alreadyLoaded_ = false;
@@ -82,14 +80,13 @@
       this.csi_ = 1;
       this.startResolve_ = null;
       this.startPromise_ = null;
-      this.caps_ = 'a2a,focus-rect,foo,keyboard,swipe,iframeScroll';
+      this.caps_ = opt_caps || 'a2a,focus-rect,foo,keyboard,swipe,iframeScroll';
       this.receivedMessages = []
 
       this.viewer = document.querySelector('viewer');
       this.header = document.querySelector('header');
       this.container = document.getElementById(containerId);
       this.iframe = document.createElement('iframe');
-      this.iframe.setAttribute('id', 'AMP_DOC_' + this.id);
       this.iframe.setAttribute('sandbox',
           'allow-popups allow-scripts allow-forms allow-pointer-lock' +
           ' allow-popups-to-escape-sandbox allow-same-origin');
@@ -111,7 +108,6 @@
         width: this.container./*OK*/offsetWidth,
         height: this.container./*OK*/offsetHeight,
         paddingTop: this.header./*OK*/offsetHeight,
-        visibilityState: this.visibilityState_,
         prerenderSize: this.prerenderSize_,
         origin: parseUrlDeprecated(window.location.href).origin,
         csi: this.csi_,
@@ -300,19 +296,6 @@
       }
     };
 
-    Viewer.prototype.handleXhrIntercept_ = function(data) {
-    // Mocked response.
-    return Promise.resolve({
-        "body" : '{"items": [{"title": "Intercepted response", "url": "http://ampdev.org"}]}',
-        "init" : {
-          "headers": {
-            "Content-Type": "application/json",
-          },
-          "type": 'application/json',
-        },
-      });
-    };
-
     Viewer.prototype.handleUnload_ = function(type, data, awaitResponse) {
       log('Viewer.prototype.handleUnload_');
       if (this.messaging_) {
@@ -419,12 +402,13 @@
       const hash = window.location.hash;
       const hashParams = parseQueryString(hash);
       const href = hashParams['href'];
+      const caps = hashParams['caps'];
 
       new Viewer(
-          'container-dynamic',
-          'dynamic',
+          'viewer-container',
+          'viewer',
           addQueryParam(href, 'amp_js_v', '0.1'),
-          true
+          caps
           ).start();
     } 
     window.onload = loadAmpDoc;
@@ -435,7 +419,7 @@
     <header>
       <h1>Viewer</h1>
     </header>
-    <container id="container-dynamic">
+    <container id="viewer-container">
       <div class="wait">
         Please wait, the AMP doc will appear here...
       </div>

--- a/test/fixtures/e2e/amp-viewer-integration/viewer.html
+++ b/test/fixtures/e2e/amp-viewer-integration/viewer.html
@@ -1,412 +1,388 @@
-<!doctype html>
+<!DOCTYPE html>
 <html>
-<head>
-  <meta charset="utf-8">
-  <title>Viewer</title>
-  <meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=1,user-scalable=no,minimal-ui">
-  <script src="/dist/v0/examples/amp-viewer-host.max.js"></script>
-  <style>
-    html, body {
-      overflow: hidden;
-    } 
-    body, viewer {
-      position: absolute;
-      top: 0;
-      left: 0;
-      right: 0;
-      bottom: 0;
-      overflow: hidden;
-      margin: 0;
-      padding: 0;
-    }
+  <head>
+    <meta charset="utf-8" />
+    <title>Viewer</title>
+    <meta
+      name="viewport"
+      content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=1,user-scalable=no,minimal-ui"
+    />
+    <script src="/dist/v0/examples/amp-viewer-host.max.js"></script>
+    <style>
+      html,
+      body {
+        overflow: hidden;
+      }
+      body,
+      viewer {
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        overflow: hidden;
+        margin: 0;
+        padding: 0;
+      }
 
-    viewer {
-      background: #eee;
-    }
+      viewer {
+        background: #eee;
+      }
 
-    header {
-      position: absolute;
-      z-index: 1;
-      top: 0;
-      left: 0;
-      right: 0;
-      height: 50px;
-      background: #4285F4;
-      opacity: 0.7;
-      color: #fff;
-      display: flex;
-      flex-direction: row;
-      justify-content: flex-start;
-      align-items: center;
-      padding: 0 8px;
-    } 
-    header h1 {
-      font-size: 22px; 
-    }
+      header {
+        position: absolute;
+        z-index: 1;
+        top: 0;
+        left: 0;
+        right: 0;
+        height: 50px;
+        background: #4285f4;
+        opacity: 0.7;
+        color: #fff;
+        display: flex;
+        flex-direction: row;
+        justify-content: flex-start;
+        align-items: center;
+        padding: 0 8px;
+      }
+      header h1 {
+        font-size: 22px;
+      }
 
-    container {
-      position: absolute;
-      top: 50px;
-      left: 0;
-      right: 0;
-      bottom: 0;
-    }
-    
-    container iframe {
-      border: 0;
-      margin: 0;
-      padding: 0;
-      width: 100%;
-      height: 100%;
-    }
+      container {
+        position: absolute;
+        top: 50px;
+        left: 0;
+        right: 0;
+        bottom: 0;
+      }
 
-    .wait {
-      position: absolute;
-      z-index: 3;
-      top: 100px;
-      left: 20px;
-      font-size: 12px;
-    } 
-  </style>
+      container iframe {
+        border: 0;
+        margin: 0;
+        padding: 0;
+        width: 100%;
+        height: 100%;
+      }
 
-  <script>
-    var viewer = null;
-    function Viewer(containerId, id, url, opt_caps) {
-      this.id = id;
-      this.url = url;
-      this.alreadyLoaded_ = false;
-      this.stackIndex_ = 0;
-      this.prerenderSize_ = 1;
-      this.csi_ = 1;
-      this.startResolve_ = null;
-      this.startPromise_ = null;
-      this.caps_ = opt_caps || 'a2a,focus-rect,foo,keyboard,swipe,iframeScroll';
-      this.receivedMessages = []
+      .wait {
+        position: absolute;
+        z-index: 3;
+        top: 100px;
+        left: 20px;
+        font-size: 12px;
+      }
+    </style>
+    <script>
+      var viewer = null;
+      function Viewer(containerId, id, url, opt_caps) {
+        this.id = id;
+        this.url = url;
+        this.alreadyLoaded_ = false;
+        this.stackIndex_ = 0;
+        this.prerenderSize_ = 1;
+        this.csi_ = 1;
+        this.caps_ =
+          opt_caps || 'a2a,focus-rect,foo,keyboard,swipe,iframeScroll';
+        this.receivedMessages = [];
 
-      this.viewer = document.querySelector('viewer');
-      this.container = document.getElementById(containerId);
-      this.iframe = document.createElement('iframe');
-      this.iframe.setAttribute('id', this.id);
-      this.iframe.setAttribute('sandbox',
+        this.viewer = document.querySelector('viewer');
+        this.container = document.getElementById(containerId);
+        this.iframe = document.createElement('iframe');
+        this.iframe.setAttribute('id', this.id);
+        this.iframe.setAttribute(
+          'sandbox',
           'allow-popups allow-scripts allow-forms allow-pointer-lock' +
-          ' allow-popups-to-escape-sandbox allow-same-origin');
-      this.iframe.setAttribute('scrolling', 'yes');
-      this.iframe.setAttribute('height', '800');
-      this.iframe.setAttribute('width', '1200');
-      this.viewer.classList.add('natural'); 
+            ' allow-popups-to-escape-sandbox allow-same-origin'
+        );
+        this.iframe.setAttribute('scrolling', 'yes');
+        this.iframe.setAttribute('height', '800');
+        this.iframe.setAttribute('width', '1200');
+        this.viewer.classList.add('natural');
 
-      window.addEventListener('resize', this.onResize_.bind(this));
-      window.addEventListener('popstate', this.onPopState_.bind(this));
-    };
+        window.addEventListener('resize', this.onResize_.bind(this));
+        window.addEventListener('popstate', this.onPopState_.bind(this));
 
-
-    Viewer.prototype.start = function() {
-      viewer = this;
-
-      var params = {
-        history: 1,
-        width: this.container./*OK*/offsetWidth,
-        height: this.container./*OK*/offsetHeight,
-        prerenderSize: this.prerenderSize_,
-        origin: parseUrlDeprecated(window.location.href).origin,
-        csi: this.csi_,
-        cap: this.caps_,
-      };
-      log('Params:' + JSON.stringify(params));
-
-      var inputUrl = this.url + '#' + paramsStr(params);
-      if (window.location.hash && window.location.hash.length > 1) {
-        inputUrl += '&' + window.location.hash.substring(1);
+        this.start();
       }
-      var parsedUrl = parseUrlDeprecated(inputUrl);
-      var url = parsedUrl.href;
-      this.frameOrigin_ = parsedUrl.origin;
-      log('AMP URL = ', url);
-    //   this.iframe.style.display = 'none';
-      this.container.appendChild(this.iframe);
 
-      this.ampViewerHost_ = new AmpViewerHost(window, this.iframe,
-        this.frameOrigin_, this.processRequest_.bind(this),
-        /* logs id */ this.id);
+      Viewer.prototype.start = function () {
+        var params = {
+          history: 1,
+          width: this.container./*OK*/ offsetWidth,
+          height: this.container./*OK*/ offsetHeight,
+          prerenderSize: this.prerenderSize_,
+          origin: parseUrlDeprecated(window.location.href).origin,
+          csi: this.csi_,
+          cap: this.caps_,
+        };
+        log('Params:' + JSON.stringify(params));
 
-      setTimeout(function() {
-        this.iframe.setAttribute('src', url);
-      }.bind(this));
-
-      return this.startPromise_ = new Promise(resolve => {
-        this.startResolve_ = resolve;
-      });
-    }; 
-
-    Viewer.prototype.loaded_ = function() {
-      if (this.alreadyLoaded_) {
-        return;
-      }
-      log('AMP Loaded');
-      this.iframe.dataset['loaded'] = '';
-      this.alreadyLoaded_ = true;
-      var waiter = this.container.querySelector('.wait');
-      if (waiter) {
-        waiter.parentElement.removeChild(waiter);
-      }
-      this.startResolve_();
-    };
-
-
-    Viewer.prototype.documentReady_ = function() {
-      log('AMP document ready');
-      this.loaded_();
-      return Promise.resolve();
-    };
-
-
-    Viewer.prototype.onScroll_ = function() {
-      log('Viewer.prototype.onScroll_');
-      this.ampViewerHost_.sendRequest('viewport', {
-        scrollTop: this.container./*OK*/scrollTop
-      }, false);
-    };
-
-
-    Viewer.prototype.onResize_ = function() {
-      log('Resized to ', this.container./*OK*/offsetWidth,
-          this.container./*OK*/offsetHeight,
-          this.container./*OK*/scrollTop);
-      this.ampViewerHost_.sendRequest('viewport', {
-        scrollTop: this.container./*OK*/scrollTop,
-        width: this.container./*OK*/offsetWidth,
-        height: this.container./*OK*/offsetHeight,
-      }, false);
-    };
-
-    Viewer.prototype.pushHistory_ = function(stackIndex) {
-      log('push history to ', stackIndex);
-      // Super trivial. Only one step allowed.
-      if (stackIndex != this.stackIndex_ + 1) {
-        throw new Error('Only one step push allowed');
-      }
-      this.stackIndex_ = stackIndex;
-      window.history.pushState({}, '');
-      return Promise.resolve();
-    };
-
-
-    Viewer.prototype.popHistory_ = function(stackIndex) {
-      log('pop history at ', stackIndex);
-      // Super trivial. Only one step allowed.
-      if (stackIndex != this.stackIndex_) {
-        throw new Error('Only one step pop allowed');
-      }
-      this.stackIndex_ = stackIndex;
-      window.history.go(-1);
-      return Promise.resolve();
-    };
-
-
-    Viewer.prototype.onPopState_ = function() {
-      // Even more trivial. Always assumes that only one step was popped in
-      // history.
-      this.stackIndex_--;
-      this.ampViewerHost_.sendRequest('historyPopped', {
-        newStackIndex: this.stackIndex_
-      }, false);
-      log('history popped to ', this.stackIndex_);
-    };
-
-
-    Viewer.prototype.broadcast_ = function(message) {
-      log('broadcast: ', message);
-    };
-
-
-    Viewer.prototype.scrollAmpDoc = function(scrollTop) {
-      log('viewer scroll amp doc: ', scrollTop);
-      this.ampViewerHost_.sendRequest('scroll', {scrollTop: scrollTop}, true);
-    };
-
-
-    Viewer.prototype.processRequest_ = function(name, data, awaitResponse) {
-      log(this.id + ': Viewer.prototype.processRequest_', name);
-      this.receivedMessages.push({name, data});
-      switch(name) {
-        case 'bindReady':
-          return Promise.resolve();
-        case 'documentLoaded':
-          return this.documentReady_();
-        case 'focusin':
-          log('Focusin event', data);
-          return Promise.resolve();
-        case 'requestFullOverlay':
-          return Promise.resolve()
-        case 'cancelFullOverlay':
-          return Promise.resolve()
-        case 'pushHistory':
-          return this.pushHistory_(data.stackIndex);
-        case 'popHistory':
-          return this.popHistory_(data.stackIndex);
-        case 'broadcast':
-          return this.broadcast_(data);
-        case 'unloaded':
-          log('unloaded');
-          return this.handleUnload_();
-        case 'tick':
-          log('[CSI] tick. label:', data.label);
-          return Promise.resolve();
-        case 'a2aNavigate':
-          log('a2a navigation', data);
-          return Promise.resolve();
-        case 'sendCsi':
-          log('[CSI] sendCsi.');
-          return Promise.resolve();
-        case 'touchstart':
-        case 'touchmove':
-        case 'touchend':
-          log('touch event!', name);
-          return Promise.resolve();
-        case 'viewerRenderTemplate':
-          return Promise.reject({error: 'Not configured for SSR.'})
-        case 'documentHeight':
-        case 'setFlushParams':
-        case 'prerenderComplete':
-        case 'scroll':
-        case 'replaceHistory':
-        case 'visibilitychange':
-          return Promise.resolve();
-        case 'xhr':
-          return Promise.reject('xhr intercept not supported');
-        default:
-          return Promise.reject('request not supported: ', name);
-      }
-    };
-
-    Viewer.prototype.handleUnload_ = function(type, data, awaitResponse) {
-      log('Viewer.prototype.handleUnload_');
-      if (this.messaging_) {
-        this.messaging_ = null;
-      }
-      return Promise.resolve();
-    };
-
-
-    function log() {
-      var var_args = Array.prototype.slice.call(arguments, 0);
-      var_args.unshift('[VIEWER]');
-      console/*OK*/.log.apply(console, var_args);
-    }
-
-    function parseUrlDeprecated(urlString) {
-      var a = document.createElement('a');
-      a.href = urlString;
-      return {
-        href: a.href,
-        protocol: a.protocol,
-        host: a.host,
-        hostname: a.hostname,
-        port: a.port == '0' ? '' : a.port,
-        pathname: a.pathname,
-        search: a.search,
-        hash: a.hash,
-        origin: a.protocol + '//' + a.host
-      };
-    }
-
-
-    function paramsStr(params) {
-      var s = '';
-      for (var k in params) {
-        var v = params[k];
-        if (v === null || v === undefined) {
-          continue;
+        var inputUrl = this.url + '#' + paramsStr(params);
+        if (window.location.hash && window.location.hash.length > 1) {
+          inputUrl += '&' + window.location.hash.substring(1);
         }
-        if (s.length > 0) {
-          s += '&';
-        }
-        s += encodeURIComponent(k) + '=' + encodeURIComponent(v);
-      }
-      return s;
-    }
+        var parsedUrl = parseUrlDeprecated(inputUrl);
+        var url = parsedUrl.href;
+        this.frameOrigin_ = parsedUrl.origin;
+        log('AMP URL = ', url);
+        this.container.appendChild(this.iframe);
 
-    /**
-     * Parses the query string of an URL. This method returns a simple key/value
-     * map. If there are duplicate keys the latest value is returned.
-     * @param {string} queryString
-     * @return {!Object<string>}
-     */
-    function parseQueryString(queryString) {
-      const params = Object.create(null);
-      if (!queryString) {
+        this.ampViewerHost_ = new AmpViewerHost(
+          window,
+          this.iframe,
+          this.frameOrigin_,
+          this.processRequest_.bind(this),
+          /* logs id */ this.id
+        );
+
+        setTimeout(
+          function () {
+            this.iframe.setAttribute('src', url);
+          }.bind(this)
+        );
+      };
+
+      Viewer.prototype.loaded_ = function () {
+        if (this.alreadyLoaded_) {
+          return;
+        }
+        log('AMP Loaded');
+        this.iframe.dataset['loaded'] = '';
+        this.alreadyLoaded_ = true;
+      };
+
+      Viewer.prototype.documentReady_ = function () {
+        log('AMP document ready');
+        this.loaded_();
+        return Promise.resolve();
+      };
+
+      Viewer.prototype.onScroll_ = function () {
+        log('Viewer.prototype.onScroll_');
+        this.ampViewerHost_.sendRequest(
+          'viewport',
+          {
+            scrollTop: this.container./*OK*/ scrollTop,
+          },
+          false
+        );
+      };
+
+      Viewer.prototype.onResize_ = function () {
+        log(
+          'Resized to ',
+          this.container./*OK*/ offsetWidth,
+          this.container./*OK*/ offsetHeight,
+          this.container./*OK*/ scrollTop
+        );
+        this.ampViewerHost_.sendRequest(
+          'viewport',
+          {
+            scrollTop: this.container./*OK*/ scrollTop,
+            width: this.container./*OK*/ offsetWidth,
+            height: this.container./*OK*/ offsetHeight,
+          },
+          false
+        );
+      };
+
+      Viewer.prototype.pushHistory_ = function (stackIndex) {
+        log('push history to ', stackIndex);
+        // Super trivial. Only one step allowed.
+        if (stackIndex != this.stackIndex_ + 1) {
+          throw new Error('Only one step push allowed');
+        }
+        this.stackIndex_ = stackIndex;
+        window.history.pushState({}, '');
+        return Promise.resolve();
+      };
+
+      Viewer.prototype.popHistory_ = function (stackIndex) {
+        log('pop history at ', stackIndex);
+        // Super trivial. Only one step allowed.
+        if (stackIndex != this.stackIndex_) {
+          throw new Error('Only one step pop allowed');
+        }
+        this.stackIndex_ = stackIndex;
+        window.history.go(-1);
+        return Promise.resolve();
+      };
+
+      Viewer.prototype.onPopState_ = function () {
+        // Even more trivial. Always assumes that only one step was popped in
+        // history.
+        this.stackIndex_--;
+        this.ampViewerHost_.sendRequest(
+          'historyPopped',
+          {
+            newStackIndex: this.stackIndex_,
+          },
+          false
+        );
+        log('history popped to ', this.stackIndex_);
+      };
+
+      Viewer.prototype.scrollAmpDoc = function (scrollTop) {
+        log('viewer scroll amp doc: ', scrollTop);
+        this.ampViewerHost_.sendRequest('scroll', {scrollTop: scrollTop}, true);
+      };
+
+      Viewer.prototype.processRequest_ = function (name, data, awaitResponse) {
+        log(this.id + ': Viewer.prototype.processRequest_', name);
+        this.receivedMessages.push({name, data});
+        switch (name) {
+          case 'documentLoaded':
+            return this.documentReady_();
+          case 'pushHistory':
+            return this.pushHistory_(data.stackIndex);
+          case 'popHistory':
+            return this.popHistory_(data.stackIndex);
+          case 'broadcast':
+          case 'bindReady':
+          case 'focusin':
+          case 'requestFullOverlay':
+          case 'cancelFullOverlay':
+          case 'unloaded':
+          case 'tick':
+          case 'a2aNavigate':
+          case 'sendCsi':
+          case 'touchstart':
+          case 'touchmove':
+          case 'touchend':
+          case 'documentHeight':
+          case 'setFlushParams':
+          case 'prerenderComplete':
+          case 'scroll':
+          case 'replaceHistory':
+          case 'visibilitychange':
+            return Promise.resolve();
+          case 'xhr':
+          case 'viewerRenderTemplate':
+          default:
+            return Promise.reject('Request not supported: ', name);
+        }
+      };
+
+      function log() {
+        var var_args = Array.prototype.slice.call(arguments, 0);
+        var_args.unshift('[VIEWER]');
+        console /*OK*/.log
+          .apply(console, var_args);
+      }
+
+      function parseUrlDeprecated(urlString) {
+        var a = document.createElement('a');
+        a.href = urlString;
+        return {
+          href: a.href,
+          protocol: a.protocol,
+          host: a.host,
+          hostname: a.hostname,
+          port: a.port == '0' ? '' : a.port,
+          pathname: a.pathname,
+          search: a.search,
+          hash: a.hash,
+          origin: a.protocol + '//' + a.host,
+        };
+      }
+
+      function paramsStr(params) {
+        var s = '';
+        for (var k in params) {
+          var v = params[k];
+          if (v === null || v === undefined) {
+            continue;
+          }
+          if (s.length > 0) {
+            s += '&';
+          }
+          s += encodeURIComponent(k) + '=' + encodeURIComponent(v);
+        }
+        return s;
+      }
+
+      /**
+       * Parses the query string of an URL. This method returns a simple key/value
+       * map. If there are duplicate keys the latest value is returned.
+       * @param {string} queryString
+       * @return {!Object<string>}
+       */
+      function parseQueryString(queryString) {
+        const params = Object.create(null);
+        if (!queryString) {
+          return params;
+        }
+        if (startsWith(queryString, '?') || startsWith(queryString, '#')) {
+          queryString = queryString.substr(1);
+        }
+        const pairs = queryString.split('&');
+        for (let i = 0; i < pairs.length; i++) {
+          const pair = pairs[i];
+          const eqIndex = pair.indexOf('=');
+          let name;
+          let value;
+          if (eqIndex != -1) {
+            name = decodeURIComponent(pair.substring(0, eqIndex)).trim();
+            value = decodeURIComponent(pair.substring(eqIndex + 1)).trim();
+          } else {
+            name = decodeURIComponent(pair).trim();
+            value = '';
+          }
+          if (name) {
+            params[name] = value;
+          }
+        }
         return params;
       }
-      if (startsWith(queryString, '?') || startsWith(queryString, '#')) {
-        queryString = queryString.substr(1);
-      }
-      const pairs = queryString.split('&');
-      for (let i = 0; i < pairs.length; i++) {
-        const pair = pairs[i];
-        const eqIndex = pair.indexOf('=');
-        let name;
-        let value;
-        if (eqIndex != -1) {
-          name = decodeURIComponent(pair.substring(0, eqIndex)).trim();
-          value = decodeURIComponent(pair.substring(eqIndex + 1)).trim();
-        } else {
-          name = decodeURIComponent(pair).trim();
-          value = '';
-        }
-        if (name) {
-          params[name] = value;
-        }
-      }
-      return params;
-    }
 
-    function startsWith(string, prefix) {
-      return string.lastIndexOf(prefix, 0) == 0;
-    }
+      function startsWith(string, prefix) {
+        return string.lastIndexOf(prefix, 0) == 0;
+      }
 
-    /**
-     * @param {string} url
-     * @param {string} param
-     * @param {*} value
-     * @return {string}
-     */
-    function addQueryParam(url, param, value) {
-      const paramValue =
+      /**
+       * @param {string} url
+       * @param {string} param
+       * @param {*} value
+       * @return {string}
+       */
+      function addQueryParam(url, param, value) {
+        const paramValue =
           encodeURIComponent(param) + '=' + encodeURIComponent(value);
-      if (!url.includes('?')) {
-        url += '?' + paramValue;
-      } else {
-        url += '&' + paramValue;
+        if (!url.includes('?')) {
+          url += '?' + paramValue;
+        } else {
+          url += '&' + paramValue;
+        }
+        return url;
       }
-      return url;
-    }
 
-    function loadAmpDoc() {
-      const hash = window.location.hash;
-      const hashParams = parseQueryString(hash);
-      const href = hashParams['href'];
-      const caps = hashParams['caps'];
+      function loadAmpDoc() {
+        const hash = window.location.hash;
+        const hashParams = parseQueryString(hash);
+        const href = hashParams['href'];
+        const caps = hashParams['caps'];
 
-      new Viewer(
+        viewer = new Viewer(
           'viewer-container',
           'viewer',
           addQueryParam(href, 'amp_js_v', '0.1'),
           caps
-          ).start();
-    } 
-    window.onload = loadAmpDoc;
-  </script>
-</head>
-<body>
-  <viewer>
-    <header>
-      <h1>Viewer</h1>
-    </header>
-    <container id="viewer-container">
-      <div class="wait">
-        Please wait, the AMP doc will appear here...
-      </div>
-    </container>
-  </viewer>
-</body>
+        );
+      }
+      window.onload = loadAmpDoc;
+    </script>
+  </head>
+  <body>
+    <viewer>
+      <header>
+        <h1>Viewer</h1>
+      </header>
+      <container id="viewer-container">
+        <div class="wait">
+          Please wait, the AMP doc will appear here...
+        </div>
+      </container>
+    </viewer>
+  </body>
 </html>

--- a/test/fixtures/e2e/amp-viewer-integration/viewer.html
+++ b/test/fixtures/e2e/amp-viewer-integration/viewer.html
@@ -87,6 +87,7 @@
       this.header = document.querySelector('header');
       this.container = document.getElementById(containerId);
       this.iframe = document.createElement('iframe');
+      this.iframe.setAttribute('id', this.id);
       this.iframe.setAttribute('sandbox',
           'allow-popups allow-scripts allow-forms allow-pointer-lock' +
           ' allow-popups-to-escape-sandbox allow-same-origin');
@@ -144,6 +145,7 @@
         return;
       }
       log('AMP Loaded');
+      this.iframe.dataset['loaded'] = '';
       this.alreadyLoaded_ = true;
       var waiter = this.container.querySelector('.wait');
       if (waiter) {

--- a/test/fixtures/e2e/amp-viewer-integration/viewer.html
+++ b/test/fixtures/e2e/amp-viewer-integration/viewer.html
@@ -1,0 +1,445 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Viewer</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=1,user-scalable=no,minimal-ui">
+  <script src="/dist/v0/examples/amp-viewer-host.max.js"></script>
+  <style>
+    html, body {
+      overflow: hidden;
+    } 
+    body, viewer {
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      overflow: hidden;
+      margin: 0;
+      padding: 0;
+    }
+
+    viewer {
+      background: #eee;
+    }
+
+    header {
+      position: absolute;
+      z-index: 1;
+      top: 0;
+      left: 0;
+      right: 0;
+      height: 50px;
+      background: #4285F4;
+      opacity: 0.7;
+      color: #fff;
+      display: flex;
+      flex-direction: row;
+      justify-content: flex-start;
+      align-items: center;
+      padding: 0 8px;
+    }
+
+    container {
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+    }
+    
+    container iframe {
+      border: 0;
+      margin: 0;
+      padding: 0;
+      width: 100%;
+      height: 100%;
+    }
+
+    header h1 {
+      font-size: 22px;
+      flex-grow: 1;
+    }
+
+    .wait {
+      position: absolute;
+      z-index: 3;
+      top: 100px;
+      left: 20px;
+      font-size: 12px;
+    } 
+  </style>
+
+  <script>
+    let viewer = null;
+    function Viewer(containerId, id, url) {
+      this.id = id;
+      this.url = url;
+      this.alreadyLoaded_ = false;
+      this.stackIndex_ = 0;
+      this.prerenderSize_ = 1;
+      this.csi_ = 1;
+      this.startResolve_ = null;
+      this.startPromise_ = null;
+      this.caps_ = 'a2a,focus-rect,foo,keyboard,swipe,iframeScroll';
+      this.receivedMessages = []
+
+      this.viewer = document.querySelector('viewer');
+      this.header = document.querySelector('header');
+      this.container = document.getElementById(containerId);
+      this.iframe = document.createElement('iframe');
+      this.iframe.setAttribute('id', 'AMP_DOC_' + this.id);
+      this.iframe.setAttribute('sandbox',
+          'allow-popups allow-scripts allow-forms allow-pointer-lock' +
+          ' allow-popups-to-escape-sandbox allow-same-origin');
+      this.iframe.setAttribute('scrolling', 'yes');
+      this.iframe.setAttribute('height', '800');
+      this.iframe.setAttribute('width', '1200');
+      this.viewer.classList.add('natural'); 
+
+      window.addEventListener('resize', this.onResize_.bind(this));
+      window.addEventListener('popstate', this.onPopState_.bind(this));
+    };
+
+
+    Viewer.prototype.start = function() {
+      viewer = this;
+
+      var params = {
+        history: 1,
+        width: this.container./*OK*/offsetWidth,
+        height: this.container./*OK*/offsetHeight,
+        paddingTop: this.header./*OK*/offsetHeight,
+        visibilityState: this.visibilityState_,
+        prerenderSize: this.prerenderSize_,
+        origin: parseUrlDeprecated(window.location.href).origin,
+        csi: this.csi_,
+        cap: this.caps_,
+      };
+      log('Params:' + JSON.stringify(params));
+
+      var inputUrl = this.url + '#' + paramsStr(params);
+      if (window.location.hash && window.location.hash.length > 1) {
+        inputUrl += '&' + window.location.hash.substring(1);
+      }
+      var parsedUrl = parseUrlDeprecated(inputUrl);
+      var url = parsedUrl.href;
+      this.frameOrigin_ = parsedUrl.origin;
+      log('AMP URL = ', url);
+    //   this.iframe.style.display = 'none';
+      this.container.appendChild(this.iframe);
+
+      this.ampViewerHost_ = new AmpViewerHost(window, this.iframe,
+        this.frameOrigin_, this.processRequest_.bind(this),
+        /* logs id */ this.id);
+
+      setTimeout(function() {
+        this.iframe.setAttribute('src', url);
+      }.bind(this));
+
+      return this.startPromise_ = new Promise(resolve => {
+        this.startResolve_ = resolve;
+      });
+    }; 
+
+    Viewer.prototype.loaded_ = function() {
+      if (this.alreadyLoaded_) {
+        return;
+      }
+      log('AMP Loaded');
+      this.alreadyLoaded_ = true;
+      var waiter = this.container.querySelector('.wait');
+      if (waiter) {
+        waiter.parentElement.removeChild(waiter);
+      }
+      this.startResolve_();
+    };
+
+
+    Viewer.prototype.documentReady_ = function() {
+      log('AMP document ready');
+      this.loaded_();
+      return Promise.resolve();
+    };
+
+
+    Viewer.prototype.onScroll_ = function() {
+      log('Viewer.prototype.onScroll_');
+      this.ampViewerHost_.sendRequest('viewport', {
+        scrollTop: this.container./*OK*/scrollTop
+      }, false);
+    };
+
+
+    Viewer.prototype.onResize_ = function() {
+      log('Resized to ', this.container./*OK*/offsetWidth,
+          this.container./*OK*/offsetHeight,
+          this.header./*OK*/offsetHeight,
+          this.container./*OK*/scrollTop);
+      this.ampViewerHost_.sendRequest('viewport', {
+        scrollTop: this.container./*OK*/scrollTop,
+        width: this.container./*OK*/offsetWidth,
+        height: this.container./*OK*/offsetHeight,
+        paddingTop: this.header./*OK*/offsetHeight
+      }, false);
+    };
+
+
+    Viewer.prototype.requestFullOverlay_ = function() {
+      log('requestFullOverlay');
+      this.header.style.opacity = 0;
+      return Promise.resolve();
+    };
+
+
+    Viewer.prototype.cancelFullOverlay_ = function() {
+      log('cancelFullOverlay');
+      this.header.style.opacity = 1;
+      return Promise.resolve();
+    };
+
+
+    Viewer.prototype.pushHistory_ = function(stackIndex) {
+      log('push history to ', stackIndex);
+      // Super trivial. Only one step allowed.
+      if (stackIndex != this.stackIndex_ + 1) {
+        throw new Error('Only one step push allowed');
+      }
+      this.stackIndex_ = stackIndex;
+      window.history.pushState({}, '');
+      return Promise.resolve();
+    };
+
+
+    Viewer.prototype.popHistory_ = function(stackIndex) {
+      log('pop history at ', stackIndex);
+      // Super trivial. Only one step allowed.
+      if (stackIndex != this.stackIndex_) {
+        throw new Error('Only one step pop allowed');
+      }
+      this.stackIndex_ = stackIndex;
+      window.history.go(-1);
+      return Promise.resolve();
+    };
+
+
+    Viewer.prototype.onPopState_ = function() {
+      // Even more trivial. Always assumes that only one step was popped in
+      // history.
+      this.stackIndex_--;
+      this.ampViewerHost_.sendRequest('historyPopped', {
+        newStackIndex: this.stackIndex_
+      }, false);
+      log('history popped to ', this.stackIndex_);
+    };
+
+
+    Viewer.prototype.broadcast_ = function(message) {
+      log('broadcast: ', message);
+    };
+
+
+    Viewer.prototype.scrollAmpDoc = function(scrollTop) {
+      log('viewer scroll amp doc: ', scrollTop);
+      this.ampViewerHost_.sendRequest('scroll', {scrollTop: scrollTop}, true);
+    };
+
+
+    Viewer.prototype.processRequest_ = function(name, data, awaitResponse) {
+      log(this.id + ': Viewer.prototype.processRequest_', name);
+      this.receivedMessages.push({name, data});
+      switch(name) {
+        case 'bindReady':
+          return Promise.resolve();
+        case 'documentLoaded':
+          return this.documentReady_();
+        case 'focusin':
+          log('Focusin event', data);
+          return Promise.resolve();
+        case 'requestFullOverlay':
+          return this.requestFullOverlay_();
+        case 'cancelFullOverlay':
+          return this.cancelFullOverlay_();
+        case 'pushHistory':
+          return this.pushHistory_(data.stackIndex);
+        case 'popHistory':
+          return this.popHistory_(data.stackIndex);
+        case 'broadcast':
+          return this.broadcast_(data);
+        case 'unloaded':
+          log('unloaded');
+          return this.handleUnload_();
+        case 'tick':
+          log('[CSI] tick. label:', data.label);
+          return Promise.resolve();
+        case 'a2aNavigate':
+          log('a2a navigation', data);
+          return Promise.resolve();
+        case 'sendCsi':
+          log('[CSI] sendCsi.');
+          return Promise.resolve();
+        case 'touchstart':
+        case 'touchmove':
+        case 'touchend':
+          log('touch event!', name);
+          return Promise.resolve();
+        case 'viewerRenderTemplate':
+          return Promise.reject({error: 'Not configured for SSR.'})
+        case 'documentHeight':
+        case 'setFlushParams':
+        case 'prerenderComplete':
+        case 'scroll':
+        case 'replaceHistory':
+        case 'visibilitychange':
+          return Promise.resolve();
+        case 'xhr':
+          return Promise.reject('xhr intercept not supported');
+        default:
+          return Promise.reject('request not supported: ', name);
+      }
+    };
+
+    Viewer.prototype.handleXhrIntercept_ = function(data) {
+    // Mocked response.
+    return Promise.resolve({
+        "body" : '{"items": [{"title": "Intercepted response", "url": "http://ampdev.org"}]}',
+        "init" : {
+          "headers": {
+            "Content-Type": "application/json",
+          },
+          "type": 'application/json',
+        },
+      });
+    };
+
+    Viewer.prototype.handleUnload_ = function(type, data, awaitResponse) {
+      log('Viewer.prototype.handleUnload_');
+      if (this.messaging_) {
+        this.messaging_ = null;
+      }
+      return Promise.resolve();
+    };
+
+
+    function log() {
+      var var_args = Array.prototype.slice.call(arguments, 0);
+      var_args.unshift('[VIEWER]');
+      console/*OK*/.log.apply(console, var_args);
+    }
+
+    function parseUrlDeprecated(urlString) {
+      var a = document.createElement('a');
+      a.href = urlString;
+      return {
+        href: a.href,
+        protocol: a.protocol,
+        host: a.host,
+        hostname: a.hostname,
+        port: a.port == '0' ? '' : a.port,
+        pathname: a.pathname,
+        search: a.search,
+        hash: a.hash,
+        origin: a.protocol + '//' + a.host
+      };
+    }
+
+
+    function paramsStr(params) {
+      var s = '';
+      for (var k in params) {
+        var v = params[k];
+        if (v === null || v === undefined) {
+          continue;
+        }
+        if (s.length > 0) {
+          s += '&';
+        }
+        s += encodeURIComponent(k) + '=' + encodeURIComponent(v);
+      }
+      return s;
+    }
+
+    /**
+     * Parses the query string of an URL. This method returns a simple key/value
+     * map. If there are duplicate keys the latest value is returned.
+     * @param {string} queryString
+     * @return {!Object<string>}
+     */
+    function parseQueryString(queryString) {
+      const params = Object.create(null);
+      if (!queryString) {
+        return params;
+      }
+      if (startsWith(queryString, '?') || startsWith(queryString, '#')) {
+        queryString = queryString.substr(1);
+      }
+      const pairs = queryString.split('&');
+      for (let i = 0; i < pairs.length; i++) {
+        const pair = pairs[i];
+        const eqIndex = pair.indexOf('=');
+        let name;
+        let value;
+        if (eqIndex != -1) {
+          name = decodeURIComponent(pair.substring(0, eqIndex)).trim();
+          value = decodeURIComponent(pair.substring(eqIndex + 1)).trim();
+        } else {
+          name = decodeURIComponent(pair).trim();
+          value = '';
+        }
+        if (name) {
+          params[name] = value;
+        }
+      }
+      return params;
+    }
+
+    function startsWith(string, prefix) {
+      return string.lastIndexOf(prefix, 0) == 0;
+    }
+
+    /**
+     * @param {string} url
+     * @param {string} param
+     * @param {*} value
+     * @return {string}
+     */
+    function addQueryParam(url, param, value) {
+      const paramValue =
+          encodeURIComponent(param) + '=' + encodeURIComponent(value);
+      if (!url.includes('?')) {
+        url += '?' + paramValue;
+      } else {
+        url += '&' + paramValue;
+      }
+      return url;
+    }
+
+    function loadAmpDoc() {
+      const hash = window.location.hash;
+      const hashParams = parseQueryString(hash);
+      const href = hashParams['href'];
+
+      new Viewer(
+          'container-dynamic',
+          'dynamic',
+          addQueryParam(href, 'amp_js_v', '0.1'),
+          true
+          ).start();
+    } 
+    window.onload = loadAmpDoc;
+  </script>
+</head>
+<body>
+  <viewer>
+    <header>
+      <h1>Viewer</h1>
+    </header>
+    <container id="container-dynamic">
+      <div class="wait">
+        Please wait, the AMP doc will appear here...
+      </div>
+    </container>
+  </viewer>
+</body>
+</html>

--- a/test/fixtures/e2e/amp-viewer-integration/viewer.html
+++ b/test/fixtures/e2e/amp-viewer-integration/viewer.html
@@ -84,7 +84,6 @@
       this.receivedMessages = []
 
       this.viewer = document.querySelector('viewer');
-      this.header = document.querySelector('header');
       this.container = document.getElementById(containerId);
       this.iframe = document.createElement('iframe');
       this.iframe.setAttribute('id', this.id);
@@ -108,7 +107,6 @@
         history: 1,
         width: this.container./*OK*/offsetWidth,
         height: this.container./*OK*/offsetHeight,
-        paddingTop: this.header./*OK*/offsetHeight,
         prerenderSize: this.prerenderSize_,
         origin: parseUrlDeprecated(window.location.href).origin,
         csi: this.csi_,
@@ -173,30 +171,13 @@
     Viewer.prototype.onResize_ = function() {
       log('Resized to ', this.container./*OK*/offsetWidth,
           this.container./*OK*/offsetHeight,
-          this.header./*OK*/offsetHeight,
           this.container./*OK*/scrollTop);
       this.ampViewerHost_.sendRequest('viewport', {
         scrollTop: this.container./*OK*/scrollTop,
         width: this.container./*OK*/offsetWidth,
         height: this.container./*OK*/offsetHeight,
-        paddingTop: this.header./*OK*/offsetHeight
       }, false);
     };
-
-
-    Viewer.prototype.requestFullOverlay_ = function() {
-      log('requestFullOverlay');
-      this.header.style.opacity = 0;
-      return Promise.resolve();
-    };
-
-
-    Viewer.prototype.cancelFullOverlay_ = function() {
-      log('cancelFullOverlay');
-      this.header.style.opacity = 1;
-      return Promise.resolve();
-    };
-
 
     Viewer.prototype.pushHistory_ = function(stackIndex) {
       log('push history to ', stackIndex);
@@ -256,9 +237,9 @@
           log('Focusin event', data);
           return Promise.resolve();
         case 'requestFullOverlay':
-          return this.requestFullOverlay_();
+          return Promise.resolve()
         case 'cancelFullOverlay':
-          return this.cancelFullOverlay_();
+          return Promise.resolve()
         case 'pushHistory':
           return this.pushHistory_(data.stackIndex);
         case 'popHistory':


### PR DESCRIPTION
**Summary**
The current e2e viewer fixture is a mishmash of code for manual and automated testing. This yields a slightly more confusing test harness than necessary, and very likely slower e2e tests because for every 1 test page we load 9 unrelated ones (not that e2e tests are a bottleneck in our dev process). This PR separates out the two.

I followed these steps:
1. `cp examples/viewer.html test/fixtures/e2e/amp-viewer-integration/viewer.html`
2. Deleted everything that seemed related to only manual testing from the new file.
3. Deleted everything related to e2e testing from `examples/viewer.html`

Addresses https://github.com/ampproject/amphtml/issues/28200.
