### PR TITLE
Allow amp-image-lightbox to "open" in AMP4Email

### DIFF
--- a/extensions/amp-image-lightbox/0.1/amp-image-lightbox.js
+++ b/extensions/amp-image-lightbox/0.1/amp-image-lightbox.js
@@ -784,6 +784,14 @@ class AmpImageLightbox extends AMP.BaseElement {
     this.registerDefaultAction((invocation) => this.open_(invocation), 'open');
   }
 
+  /** @override */
+  buildCallback() {
+    /** If the element is in an email document, allow its `open` action. */
+    Services.actionServiceForDoc(
+      this.element
+    ).addToWhitelist('AMP-IMAGE-LIGHTBOX', 'open', ['email']);
+  }
+
   /**
    * Lazily builds the image-lightbox DOM on the first open.
    * @private
@@ -792,10 +800,6 @@ class AmpImageLightbox extends AMP.BaseElement {
     if (this.container_) {
       return;
     }
-    /** If the element is in an email document, allow its `open` action. */
-    Services.actionServiceForDoc(
-      this.element
-    ).addToWhitelist('AMP-IMAGE-LIGHTBOX', 'open', ['email']);
 
     this.container_ = this.element.ownerDocument.createElement('div');
     this.container_.classList.add('i-amphtml-image-lightbox-container');

--- a/extensions/amp-image-lightbox/0.1/test/test-amp-image-lightbox.js
+++ b/extensions/amp-image-lightbox/0.1/test/test-amp-image-lightbox.js
@@ -266,7 +266,6 @@ describes.realWin(
       await dom.whenUpgradedToCustomElement(element);
 
       const impl = await element.getImpl();
-      impl.buildLightbox_();
       env.sandbox.stub(impl, 'open_');
       action.execute(
         element,


### PR DESCRIPTION
Moves the `addToWhitelist` from `buildLightbox_` to `buildCallback`. Fixes #28504 