### PR TITLE
Doubleclick lazy fetch support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -91,6 +91,10 @@ jobs:
       script:
         - unbuffer node build-system/pr-check/local-tests.js
     - stage: test
+      name: 'Dist Tests'
+      script:
+        - unbuffer node build-system/pr-check/dist-tests.js
+    - stage: test
       name: 'Remote (Sauce Labs) Tests'
       script:
         - unbuffer node build-system/pr-check/remote-tests.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,6 @@ branches:
     - /^amp-release-.*$/
 addons:
   apt:
-    sources:
-      - ubuntu-toolchain-r-test
     packages:
       # Use unbuffer (from expect-dev) for log coloring (github.com/travis-ci/travis-ci/issues/7967)
       - expect-dev

--- a/build-system/pr-check/dist-tests.js
+++ b/build-system/pr-check/dist-tests.js
@@ -1,0 +1,80 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+/**
+ * @fileoverview
+ * This script runs the unit and integration tests against minified code
+ * on a local Travis VM.
+ * This is run during the CI stage = test; job = dist tests.
+ */
+
+const colors = require('ansi-colors');
+const {
+  downloadDistOutput,
+  printChangeSummary,
+  startTimer,
+  stopTimer,
+  timedExecOrDie: timedExecOrDieBase,
+} = require('./utils');
+const {determineBuildTargets} = require('./build-targets');
+const {isTravisPullRequestBuild} = require('../common/travis');
+
+const FILENAME = 'dist-tests.js';
+const FILELOGPREFIX = colors.bold(colors.yellow(`${FILENAME}:`));
+const timedExecOrDie = (cmd) => timedExecOrDieBase(cmd, FILENAME);
+
+function main() {
+  const startTime = startTimer(FILENAME, FILENAME);
+
+  if (!isTravisPullRequestBuild()) {
+    downloadDistOutput(FILENAME);
+    timedExecOrDie('gulp update-packages');
+    timedExecOrDie('gulp integration --nobuild --headless --compiled');
+  } else {
+    printChangeSummary(FILENAME);
+    const buildTargets = determineBuildTargets(FILENAME);
+    if (
+      !buildTargets.has('RUNTIME') &&
+      !buildTargets.has('FLAG_CONFIG') &&
+      !buildTargets.has('INTEGRATION_TEST')
+    ) {
+      console.log(
+        `${FILELOGPREFIX} Skipping`,
+        colors.cyan('Dist Tests'),
+        'because this commit not affect the runtime, flag configs,',
+        'or integration tests.'
+      );
+      stopTimer(FILENAME, FILENAME, startTime);
+      return;
+    }
+
+    downloadDistOutput(FILENAME);
+    timedExecOrDie('gulp update-packages');
+
+    if (
+      buildTargets.has('RUNTIME') ||
+      buildTargets.has('FLAG_CONFIG') ||
+      buildTargets.has('INTEGRATION_TEST')
+    ) {
+      timedExecOrDie('gulp integration --nobuild --headless --compiled');
+    }
+  }
+
+  stopTimer(FILENAME, FILENAME, startTime);
+}
+
+main();

--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -114,6 +114,7 @@ const forbiddenTerms = {
       'build-system/pr-check/build-targets.js',
       'build-system/pr-check/checks.js',
       'build-system/pr-check/dist-bundle-size.js',
+      'build-system/pr-check/dist-tests.js',
       'build-system/pr-check/module-dist-bundle-size.js',
       'build-system/pr-check/experiment-tests.js',
       'build-system/pr-check/e2e-tests.js',

--- a/build-system/tasks/report-test-status.js
+++ b/build-system/tasks/report-test-status.js
@@ -33,11 +33,12 @@ const IS_SAUCELABS = !!argv.saucelabs;
 const IS_SAUCELABS_STABLE = !!argv.saucelabs && !!argv.stable;
 const IS_SAUCELABS_BETA = !!argv.saucelabs && !!argv.beta;
 const IS_SINGLE_PASS = !!argv.single_pass;
+const IS_DIST = !!argv.compiled;
 
 const TEST_TYPE_SUBTYPES = new Map([
   [
     'integration',
-    ['local', 'single-pass', 'saucelabs-beta', 'saucelabs-stable'],
+    ['local', 'minified', 'single-pass', 'saucelabs-beta', 'saucelabs-stable'],
   ],
   ['unit', ['local', 'local-changes', 'saucelabs']],
   ['e2e', ['local']],
@@ -66,16 +67,18 @@ function inferTestType() {
     return `${type}/local-changes`;
   }
 
+  if (IS_SINGLE_PASS) {
+    return `${type}/single-pass`;
+  }
+
   if (IS_SAUCELABS_BETA) {
     return `${type}/saucelabs-beta`;
   } else if (IS_SAUCELABS_STABLE) {
     return `${type}/saucelabs-stable`;
   } else if (IS_SAUCELABS) {
     return `${type}/saucelabs`;
-  }
-
-  if (IS_SINGLE_PASS) {
-    return `${type}/single-pass`;
+  } else if (IS_DIST) {
+    return `${type}/minified`;
   }
 
   return `${type}/local`;

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -1171,16 +1171,25 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, (env) => {
   });
 
   describe('#delayAdRequestEnabled', () => {
-    beforeEach(() => {
-      const element = createElementWithAttributes(doc, 'amp-ad', {
-        type: 'doubleclick',
-      });
-      doc.body.appendChild(element);
-      impl = new AmpAdNetworkDoubleclickImpl(element);
+    it('should return false', () => {
+      expect(impl.delayAdRequestEnabled()).to.be.false;
     });
 
-    it('should return false by default', () => {
+    it('should not respect loading strategy', () => {
+      impl.element.setAttribute(
+        'data-loading-strategy',
+        'prefer-viewability-over-views'
+      );
       expect(impl.delayAdRequestEnabled()).to.be.false;
+    });
+
+    it('should respect loading strategy', () => {
+      impl.element.setAttribute(
+        'data-loading-strategy',
+        'prefer-viewability-over-views'
+      );
+      impl.element.setAttribute('data-lazy-fetch', 'true');
+      expect(impl.delayAdRequestEnabled()).to.equal(1.25);
     });
   });
 

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -1183,13 +1183,22 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, (env) => {
       expect(impl.delayAdRequestEnabled()).to.be.false;
     });
 
-    it('should respect loading strategy', () => {
+    it('should respect loading strategy if fetch attribute present', () => {
       impl.element.setAttribute(
         'data-loading-strategy',
         'prefer-viewability-over-views'
       );
       impl.element.setAttribute('data-lazy-fetch', 'true');
       expect(impl.delayAdRequestEnabled()).to.equal(1.25);
+    });
+
+    it('should NOT delay due to non-true fetch attribute', () => {
+      impl.element.setAttribute(
+        'data-loading-strategy',
+        'prefer-viewability-over-views'
+      );
+      impl.element.setAttribute('data-lazy-fetch', 'false');
+      expect(impl.delayAdRequestEnabled()).to.be.false;
     });
   });
 

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-sra.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-sra.js
@@ -106,6 +106,18 @@ describes.realWin('Doubleclick SRA', config, (env) => {
       impl.layoutCallback();
       expect(impl.refreshManager_).to.be.null;
     });
+
+    it('should be disabled if lazy fetch enabled, despite meta tag', () => {
+      createAndAppendAdElement(
+        {name: 'amp-ad-doubleclick-sra'},
+        'meta',
+        doc.head
+      );
+      const element = createAndAppendAdElement({'data-lazy-fetch': true});
+      const impl = new AmpAdNetworkDoubleclickImpl(element);
+      impl.buildCallback();
+      expect(impl.useSra).to.be.false;
+    });
   });
 
   describe('block parameter joining', () => {


### PR DESCRIPTION
Current amp-ad type=doubleclick will send all requests ASAP independent of location relative to viewport (ensuring the creative is ready to render as soon as possible) but will delay render based on data-loading-strategy value.  However, publishers may instead prefer to delay the ad request based on viewport location (and thus render).  This PR allows publishers to do so on a per slot basis via data-lazy-fetch=true attribute.  When set, fetch will be delayed until the slot is within the viewport margin specified via data-loading-strategy: absent/invalid uses 3, can set an explicit numeric value for viewports, or prefer-viewability-over-views which uses 1.25.  Note the following:

- lazy requesting and SRA cannot both be enabled, lazy requesting usage on ANY slot will disable SRA for ALL slots
- RTC requests will also be lazily sent
- any lazy fetching may have impact on competitive exclusions or roadblocks

✨ New feature