### PR TITLE
Doubleclick lazy fetch

### DIFF
--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -1171,16 +1171,25 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, (env) => {
   });
 
   describe('#delayAdRequestEnabled', () => {
-    beforeEach(() => {
-      const element = createElementWithAttributes(doc, 'amp-ad', {
-        type: 'doubleclick',
-      });
-      doc.body.appendChild(element);
-      impl = new AmpAdNetworkDoubleclickImpl(element);
+    it('should return false', () => {
+      expect(impl.delayAdRequestEnabled()).to.be.false;
     });
 
-    it('should return false by default', () => {
+    it('should not respect loading strategy', () => {
+      impl.element.setAttribute(
+        'data-loading-strategy',
+        'prefer-viewability-over-views'
+      );
       expect(impl.delayAdRequestEnabled()).to.be.false;
+    });
+
+    it('should respect loading strategy', () => {
+      impl.element.setAttribute(
+        'data-loading-strategy',
+        'prefer-viewability-over-views'
+      );
+      impl.element.setAttribute('data-lazy-fetch', 'true');
+      expect(impl.delayAdRequestEnabled()).to.equal(1.25);
     });
   });
 

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -1183,13 +1183,22 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, (env) => {
       expect(impl.delayAdRequestEnabled()).to.be.false;
     });
 
-    it('should respect loading strategy', () => {
+    it('should respect loading strategy if fetch attribute present', () => {
       impl.element.setAttribute(
         'data-loading-strategy',
         'prefer-viewability-over-views'
       );
       impl.element.setAttribute('data-lazy-fetch', 'true');
       expect(impl.delayAdRequestEnabled()).to.equal(1.25);
+    });
+
+    it('should NOT delay due to non-true fetch attribute', () => {
+      impl.element.setAttribute(
+        'data-loading-strategy',
+        'prefer-viewability-over-views'
+      );
+      impl.element.setAttribute('data-lazy-fetch', 'false');
+      expect(impl.delayAdRequestEnabled()).to.be.false;
     });
   });
 

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-sra.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-sra.js
@@ -106,6 +106,18 @@ describes.realWin('Doubleclick SRA', config, (env) => {
       impl.layoutCallback();
       expect(impl.refreshManager_).to.be.null;
     });
+
+    it('should be disabled if lazy fetch enabled, despite meta tag', () => {
+      createAndAppendAdElement(
+        {name: 'amp-ad-doubleclick-sra'},
+        'meta',
+        doc.head
+      );
+      const element = createAndAppendAdElement({'data-lazy-fetch': true});
+      const impl = new AmpAdNetworkDoubleclickImpl(element);
+      impl.buildCallback();
+      expect(impl.useSra).to.be.false;
+    });
   });
 
   describe('block parameter joining', () => {

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -1339,11 +1339,6 @@ export class ResourcesImpl {
       }
     }
 
-    // With IntersectionObserver, skip phases 5+.
-    if (this.intersectionObserver_) {
-      return;
-    }
-
     if (
       this.visible_ &&
       this.exec_.getSize() == 0 &&


### PR DESCRIPTION
Current amp-ad type=doubleclick will send all requests ASAP independent of location relative to viewport (ensuring the creative is ready to render as soon as possible) but will delay render based on data-loading-strategy value. However, publishers may instead prefer to delay the ad request based on viewport location (and thus render). This PR allows publishers to do so on a per slot basis via data-lazy-fetch=true attribute. When set, fetch will be delayed until the slot is within the viewport margin specified via data-loading-strategy: absent/invalid uses 3, can set an explicit numeric value for viewports, or prefer-viewability-over-views which uses 1.25. Note the following:

lazy requesting and SRA cannot both be enabled, lazy requesting usage on ANY slot will disable SRA for ALL slots
RTC requests will also be lazily sent
any lazy fetching may have impact on competitive exclusions or roadblocks
✨ New feature