### PR TITLE
Add "debug" flag to `gulp integration`

### DIFF
--- a/build-system/tasks/integration.js
+++ b/build-system/tasks/integration.js
@@ -68,8 +68,8 @@ integration.flags = {
   'config':
     '  Sets the runtime\'s AMP_CONFIG to one of "prod" (default) or "canary"',
   'coverage': '  Run tests in code coverage mode',
-  'allow_debugger':
-    'Allow "debugger" statements by auto opening devtools. NOTE: This only ' +
+  'debug':
+    '  Allow debug statements by auto opening devtools. NOTE: This only ' +
     'works in non headless mode.',
   'firefox': '  Runs tests on Firefox',
   'files': '  Runs tests for specific files',

--- a/build-system/tasks/integration.js
+++ b/build-system/tasks/integration.js
@@ -68,6 +68,9 @@ integration.flags = {
   'config':
     '  Sets the runtime\'s AMP_CONFIG to one of "prod" (default) or "canary"',
   'coverage': '  Run tests in code coverage mode',
+  'allow_debugger':
+    'Allow "debugger" statements by auto opening devtools. NOTE: This only ' +
+    'works in non headless mode.',
   'firefox': '  Runs tests on Firefox',
   'files': '  Runs tests for specific files',
   'grep': '  Runs tests that match the pattern',

--- a/build-system/tasks/karma.conf.js
+++ b/build-system/tasks/karma.conf.js
@@ -23,6 +23,8 @@ const globby = require('globby');
 const {gitCommitterEmail} = require('../common/git');
 const {isTravisBuild, travisJobNumber} = require('../common/travis');
 
+const argv = require('minimist')(process.argv.slice(2));
+
 const TEST_SERVER_PORT = 8081;
 
 const COMMON_CHROME_FLAGS = [
@@ -31,6 +33,10 @@ const COMMON_CHROME_FLAGS = [
   // Allows simulating user actions (e.g unmute) which otherwise will be denied.
   '--autoplay-policy=no-user-gesture-required',
 ];
+
+if (argv.allow_debugger) {
+  COMMON_CHROME_FLAGS.push('--auto-open-devtools-for-tabs');
+}
 
 // Reduces the odds of Sauce labs timing out during tests. See #16135 and #24286.
 // Reference: https://wiki.saucelabs.com/display/DOCS/Test+Configuration+Options#TestConfigurationOptions-Timeouts

--- a/build-system/tasks/karma.conf.js
+++ b/build-system/tasks/karma.conf.js
@@ -15,6 +15,7 @@
  */
 'use strict';
 
+const argv = require('minimist')(process.argv.slice(2));
 const browserifyPersistFs = require('browserify-persist-fs');
 const crypto = require('crypto');
 const fs = require('fs');
@@ -22,8 +23,6 @@ const globby = require('globby');
 
 const {gitCommitterEmail} = require('../common/git');
 const {isTravisBuild, travisJobNumber} = require('../common/travis');
-
-const argv = require('minimist')(process.argv.slice(2));
 
 const TEST_SERVER_PORT = 8081;
 
@@ -34,7 +33,7 @@ const COMMON_CHROME_FLAGS = [
   '--autoplay-policy=no-user-gesture-required',
 ];
 
-if (argv.allow_debugger) {
+if (argv.debug) {
   COMMON_CHROME_FLAGS.push('--auto-open-devtools-for-tabs');
 }
 


### PR DESCRIPTION
I'm not sure if this is useful or not, but it has allowed me to add "debugger" statements while fixing/creating integration tests. is there an alternative to this or a process that i dont know while doing integration?