### PR TITLE
🏗 Install the latest version of Yarn for Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ notifications:
     on_success: change
     on_failure: change
 before_install:
-  # Install the latest version of Yarn (required for compatibility with `renovate`)
+  # Install the latest version of Yarn (Xenial's built-in version v1.15.2 is outdated)
   - curl -o- -L https://yarnpkg.com/install.sh | bash
   - export PATH="$HOME/.yarn/bin:$HOME/.config/yarn/global/node_modules/.bin:$PATH"
   # Override Xenial's default Java version (github.com/travis-ci/travis-ci/issues/10290)

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ notifications:
     on_success: change
     on_failure: change
 before_install:
+  # Install the latest version of Yarn (required for compatibility with `renovate`)
+  - curl -o- -L https://yarnpkg.com/install.sh | bash
+  - export PATH="$HOME/.yarn/bin:$HOME/.config/yarn/global/node_modules/.bin:$PATH"
   # Override Xenial's default Java version (github.com/travis-ci/travis-ci/issues/10290)
   - export PATH=$(echo "$PATH" | sed -e 's/:\/usr\/local\/lib\/jvm\/openjdk11\/bin//')
   - export JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64


### PR DESCRIPTION
Unblocks https://github.com/ampproject/amphtml/pull/28538 by allowing `renovate` to be installed.