### PR TITLE
🖍 Lock video position inside Story

### DIFF
--- a/extensions/amp-story/1.0/amp-story.css
+++ b/extensions/amp-story/1.0/amp-story.css
@@ -378,6 +378,14 @@ amp-story-grid-layer {
 }
 
 /**
+ * Prevents pre-load placeholders from pushing content offscreen. 
+ */
+.i-amphtml-story-grid-template-fill amp-img img,
+.i-amphtml-story-grid-template-fill amp-video video {
+  position: absolute !important;
+}
+
+/**
  * Prevents amp-video to layout until its element has been swapped by the media
  * pool. See #26718 for context.
  */

--- a/extensions/amp-story/1.0/amp-story.css
+++ b/extensions/amp-story/1.0/amp-story.css
@@ -379,6 +379,7 @@ amp-story-grid-layer {
 
 /**
  * Prevents pre-load placeholders from pushing content offscreen. 
+ * Prevents preload placeholders from pushing content offscreen. 
  */
 .i-amphtml-story-grid-template-fill amp-img img,
 .i-amphtml-story-grid-template-fill amp-video video {


### PR DESCRIPTION
Fixes #28199

Enforces `position: absolute` on video elements in stories.

cc @ampproject/wg-stories