### PR TITLE
Enable 50% on prod for amp-ad-no-center-css

### DIFF
--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -38,7 +38,7 @@
   "swg-gpay-api": 1,
   "swg-gpay-native": 1,
   "version-locking": 1,
-  "amp-ad-no-center-css": 0.05,
+  "amp-ad-no-center-css": 1,
   "analytics-chunks": 1,
   "fie-init-chunking": 0.1
 }


### PR DESCRIPTION
Expanding the experiment from 2.5% to 50%. This PR removes the amp-ad's centering CSS rule.