### PR TITLE
🏗 Print experiment info as part of help text in `gulp dist`

### DIFF
--- a/build-system/tasks/dist.js
+++ b/build-system/tasks/dist.js
@@ -99,6 +99,13 @@ function printDistHelp(options) {
   } else {
     parseExtensionFlags();
   }
+  if (argv.define_experiment_constant) {
+    log(
+      green('Enabling the'),
+      cyan(argv.define_experiment_constant),
+      green('experiment.')
+    );
+  }
 }
 
 /**


### PR DESCRIPTION
This PR logs the experiment being enabled when `--define_experiment_constant` is used with `gulp dist`.

<img width="1287" alt="Screen Shot 2020-05-28 at 5 51 20 PM" src="https://user-images.githubusercontent.com/26553114/83197703-e829ff00-a10b-11ea-8a68-65b9c1bfa99a.png">

We should have done this a long time ago. Hopefully, it will help debug build problems with experiments.