### PR TITLE
🐛 Add metadata user error restriction

### DIFF
--- a/extensions/amp-consent/0.1/amp-consent.js
+++ b/extensions/amp-consent/0.1/amp-consent.js
@@ -714,6 +714,9 @@ export class AmpConsent extends AMP.BaseElement {
    * @return {?JsonObject|undefined}
    */
   configureMetadataByConsentString_(opt_metadata, opt_consentString) {
+    if (!opt_metadata) {
+      return;
+    }
     if (!isObject(opt_metadata) || !opt_consentString) {
       user().error(
         TAG,


### PR DESCRIPTION
Don't throw user error if no metadata is included