### PR TITLE
performance-impl: emit custom events for each csi metric

### DIFF
--- a/src/service/performance-impl.js
+++ b/src/service/performance-impl.js
@@ -695,15 +695,13 @@ export class Performance {
     }
 
     // Emit events. Used by `gulp performance`.
-    if (getMode().test) {
-      this.win.dispatchEvent(
-        createCustomEvent(
-          this.win,
-          'perf',
-          /** @type {JsonObject} */ ({label, delta})
-        )
-      );
-    }
+    this.win.dispatchEvent(
+      createCustomEvent(
+        this.win,
+        'perf',
+        /** @type {JsonObject} */ ({label, delta})
+      )
+    );
 
     if (this.isMessagingReady_ && this.isPerformanceTrackingOn_) {
       this.viewer_.sendMessage('tick', data);

--- a/src/service/performance-impl.js
+++ b/src/service/performance-impl.js
@@ -459,7 +459,7 @@ export class Performance {
    */
   onVisibilityChange_() {
     if (this.win.document.visibilityState === 'hidden') {
-      this.tickVariableMetrics_();
+      this.tickCumulativeMetrics_();
     }
   }
 
@@ -470,7 +470,7 @@ export class Performance {
    */
   onAmpDocVisibilityChange_() {
     if (this.ampdoc_.getVisibilityState() === VisibilityState.INACTIVE) {
-      this.tickVariableMetrics_();
+      this.tickCumulativeMetrics_();
     }
   }
 
@@ -478,7 +478,7 @@ export class Performance {
    * Tick the metrics whose values change over time.
    * @private
    */
-  tickVariableMetrics_() {
+  tickCumulativeMetrics_() {
     if (this.supportsLayoutShift_) {
       this.tickLayoutShiftScore_();
     }

--- a/test/unit/test-performance.js
+++ b/test/unit/test-performance.js
@@ -819,11 +819,12 @@ describes.realWin('PeformanceObserver metrics', {amp: true}, (env) => {
     // offered in fake-dom.js. We can't immediately because
     // document.visibilityState is a read-only property in that object.
     fakeWin = {
+      CustomEvent: env.win.CustomEvent,
       Date: env.win.Date,
       PerformanceObserver: env.sandbox.stub(),
       addEventListener: env.sandbox.stub(),
       removeEventListener: env.win.removeEventListener,
-      dispatchEvent: env.win.dispatchEvent,
+      dispatchEvent: (e) => env.win.dispatchEvent(e),
       document: {
         addEventListener: env.sandbox.stub(),
         hidden: false,


### PR DESCRIPTION
**summary**
In an effort to pipe custom metrics through to the `gulp perfomance` task, this teeny PR makes it so that `performance-impl` emits a custom metric on every tick.

Initially I was planning on having this PR in the same one as the changes to the performance task, but it was difficult to compare `master` vs. `this branch` because master wasn't emitting events (and `gulp performance` only emits metrics that are in both).

In the next PR, I believe it should be possible to delete most of the custom metric collection code in `tasks/performance/measure-documents` 🎉 .