### PR TITLE
🖍 Changed circle color

### DIFF
--- a/extensions/amp-story/1.0/amp-story-reaction-quiz.css
+++ b/extensions/amp-story/1.0/amp-story-reaction-quiz.css
@@ -173,7 +173,7 @@ h3.i-amphtml-story-reaction-quiz-prompt {
 }
 
 .i-amphtml-story-reaction-post-selection .i-amphtml-story-reaction-option-selected > .i-amphtml-story-reaction-quiz-answer-choice {
-    border: solid 2px var(--reaction-answer-choice-border) !important;
+    border-width: 0px !important;
     animation: answer-choice-bounce forwards 600ms linear;
     background-color: var(--reaction-answer-choice-background) !important;
 }

--- a/extensions/amp-story/1.0/amp-story-reaction-quiz.css
+++ b/extensions/amp-story/1.0/amp-story-reaction-quiz.css
@@ -173,7 +173,7 @@ h3.i-amphtml-story-reaction-quiz-prompt {
 }
 
 .i-amphtml-story-reaction-post-selection .i-amphtml-story-reaction-option-selected > .i-amphtml-story-reaction-quiz-answer-choice {
-    border-width: 0px !important;
+    border-color: transparent !important;
     animation: answer-choice-bounce forwards 600ms linear;
     background-color: var(--reaction-answer-choice-background) !important;
 }
@@ -201,8 +201,6 @@ h3.i-amphtml-story-reaction-quiz-prompt {
 .i-amphtml-story-reaction-quiz-option::before {
     content: "" !important;
     position: absolute !important;
-    top: -1px !important;
-    left: -1px !important;
     width: 100% !important;
     height: 100% !important;
     border-radius: var(--reaction-chip-radius) !important;
@@ -254,14 +252,13 @@ h3.i-amphtml-story-reaction-quiz-prompt {
 }
 
 .i-amphtml-story-reaction-post-selection.i-amphtml-story-reaction-has-data .i-amphtml-story-reaction-quiz-option::before {
-    left: -101% !important;
+    left: -100% !important;
     width: 100% !important;
     height: 100% !important;
     border-radius: 0px !important;
     background: var(--reaction-theme-shading) !important;
     color: var(--reaction-theme-shading) !important;
     transition: transform 1s !important;
-    border: solid 2px !important;
 }
 
 .i-amphtml-story-reaction-post-selection.i-amphtml-story-reaction-has-data[dir=rtl] .i-amphtml-story-reaction-quiz-option::before {


### PR DESCRIPTION
Two main CSS fixes:
1) Quizzes would keep the accent color around the letter of the selected option, but it should remove the outline instead. Pictures below.
Why change the color instead of remove the border? Because the layout would shift by 4px if the border was removed. This way the circle stays centered and there are no layout shifts. Also the circle occupies the same area as before.
2) The option backgrounds would "peek" from the left when the percentage was 0% and have minor weird behaviors because of unnecessary 1px and 2px measurements. Not all glitches were caught on first image, but it shows up slightly on the unselected options at the very left (with the wider border which shows part of the background).
Before:
![image](https://user-images.githubusercontent.com/22420856/83422627-cffdfc80-a3f7-11ea-9b57-d66b3b388b1f.png)
After:
![image](https://user-images.githubusercontent.com/22420856/83424036-d9886400-a3f9-11ea-8a94-06dc27e2637d.png)
![image](https://user-images.githubusercontent.com/22420856/83423660-49e2b580-a3f9-11ea-9b56-c81b23bdae50.png)

Resolves #26617