### PR TITLE
✨ Integration of iubenda in amp-consent

### DIFF
--- a/examples/amp-consent/cmp-vendors.amp.html
+++ b/examples/amp-consent/cmp-vendors.amp.html
@@ -79,7 +79,6 @@
     }
 
     </style>
-
     <script async custom-element="amp-geo" src="https://cdn.ampproject.org/v0/amp-geo-0.1.js"></script>
     <script async custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
     <script async custom-element="amp-form" src="https://cdn.ampproject.org/v0/amp-form-0.1.js"></script>
@@ -192,14 +191,9 @@
         <script type="application/json">
           {
             "consentRequired": true,
-            "promptUI": "iubenda-consent-ui"
+            "promptUISrc": "https://cdn.iubenda.com/cs/test/cs-for-amp.html"
           }
         </script>
-        <div id="iubenda-consent-ui" class="popupOverlay">
-          <amp-iframe layout="fill" sandbox="allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox" src="https://cdn.iubenda.com/cs/test/cs-for-amp.html">
-            <div placeholder>Loading</div>
-          </amp-iframe>
-        </div>
       </amp-consent>
       <!-- End iubenda example -->
 

--- a/examples/amp-consent/cmp-vendors.amp.html
+++ b/examples/amp-consent/cmp-vendors.amp.html
@@ -79,6 +79,31 @@
     }
 
     </style>
+
+    <!-- iubenda example CSS -->
+    <style amp-custom>
+      .popupOverlay {
+        position: fixed;
+        top: 0;
+        bottom: 0;
+        left: 0;
+        right: 0;
+      }
+    
+      amp-iframe {
+        margin: 0;
+      }
+      
+      amp-consent.amp-active {
+        top: 0;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        position: fixed;
+      }
+    </style>
+    <!-- End iubenda example CSS -->
+
     <script async custom-element="amp-geo" src="https://cdn.ampproject.org/v0/amp-geo-0.1.js"></script>
     <script async custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
     <script async custom-element="amp-form" src="https://cdn.ampproject.org/v0/amp-form-0.1.js"></script>
@@ -97,6 +122,7 @@
           <option>_ping_</option>
           <option>appconsent</option>
           <option>didomi</option>
+          <option>iubenda</option>
           <option>sirdata</option>
           <option>Marfeel</option>
           <option>Ogury</option>
@@ -184,6 +210,30 @@
           </div>
         </amp-consent>
         <!-- End didomi example -->
+
+      <!-- iubenda example -->
+      <amp-consent id="iubenda" layout="nodisplay" type="iubenda">
+        <!--
+          If you want to request consent only to EU users then replace "consentRequired": true with "promptIfUnknownForGeoGroup": "eu" -> allows to ask consent only to EU users.
+        -->
+        <script type="application/json">
+          {
+            "consentRequired": true,
+            "promptUI": "iubenda-consent-ui"
+          }
+        </script>
+        <div id="iubenda-consent-ui" class="popupOverlay">
+          <!--
+            Set src attribute to your webpage with the CS for the AMP pages.
+            Note: it must be served over HTTPS
+            See https://cdn.iubenda.com/cs/test/cs-for-amp.html for an example on how to set a page to embed CS
+          -->
+          <amp-iframe layout="fill" sandbox="allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox" src="https://cdn.iubenda.com/cs/test/cs-for-amp.html">
+            <div placeholder>Loading</div>
+          </amp-iframe>
+        </div>
+      </amp-consent>
+      <!-- End iubenda example -->
 
       <!-- sirdata example -->
       <amp-consent id="consent" layout="nodisplay" type="sirdata">

--- a/examples/amp-consent/cmp-vendors.amp.html
+++ b/examples/amp-consent/cmp-vendors.amp.html
@@ -190,10 +190,14 @@
       <amp-consent id="iubenda" layout="nodisplay" type="iubenda">
         <script type="application/json">
           {
-            "consentRequired": true,
-            "promptUISrc": "https://cdn.iubenda.com/cs/test/cs-for-amp.html"
+            "promptUISrc": "https://cdn.iubenda.com/cs/test/cs-for-amp.html",
+            "postPromptUI": "iubendaPostPromptUI"
           }
         </script>
+        <div id="iubendaPostPromptUI">
+          Post Prompt UI
+          <button on="tap:iubenda.prompt(consent=iubenda)" role="button">Manage</button>
+        </div>
       </amp-consent>
       <!-- End iubenda example -->
 

--- a/examples/amp-consent/cmp-vendors.amp.html
+++ b/examples/amp-consent/cmp-vendors.amp.html
@@ -80,30 +80,6 @@
 
     </style>
 
-    <!-- iubenda example CSS -->
-    <style amp-custom>
-      .popupOverlay {
-        position: fixed;
-        top: 0;
-        bottom: 0;
-        left: 0;
-        right: 0;
-      }
-    
-      amp-iframe {
-        margin: 0;
-      }
-      
-      amp-consent.amp-active {
-        top: 0;
-        bottom: 0;
-        left: 0;
-        right: 0;
-        position: fixed;
-      }
-    </style>
-    <!-- End iubenda example CSS -->
-
     <script async custom-element="amp-geo" src="https://cdn.ampproject.org/v0/amp-geo-0.1.js"></script>
     <script async custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
     <script async custom-element="amp-form" src="https://cdn.ampproject.org/v0/amp-form-0.1.js"></script>
@@ -213,9 +189,6 @@
 
       <!-- iubenda example -->
       <amp-consent id="iubenda" layout="nodisplay" type="iubenda">
-        <!--
-          If you want to request consent only to EU users then replace "consentRequired": true with "promptIfUnknownForGeoGroup": "eu" -> allows to ask consent only to EU users.
-        -->
         <script type="application/json">
           {
             "consentRequired": true,
@@ -223,11 +196,6 @@
           }
         </script>
         <div id="iubenda-consent-ui" class="popupOverlay">
-          <!--
-            Set src attribute to your webpage with the CS for the AMP pages.
-            Note: it must be served over HTTPS
-            See https://cdn.iubenda.com/cs/test/cs-for-amp.html for an example on how to set a page to embed CS
-          -->
           <amp-iframe layout="fill" sandbox="allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox" src="https://cdn.iubenda.com/cs/test/cs-for-amp.html">
             <div placeholder>Loading</div>
           </amp-iframe>

--- a/extensions/amp-consent/0.1/cmps.js
+++ b/extensions/amp-consent/0.1/cmps.js
@@ -47,6 +47,11 @@ CMP_CONFIG['didomi'] = {
   'promptUISrc': 'https://sdk-amp.privacy-center.org/loader.html',
 };
 
+CMP_CONFIG['iubenda'] = {
+  'consentInstanceId': 'iubenda',
+  'checkConsentHref': 'https://hits.iubenda.com/cs/amp/checkConsent',
+};
+
 CMP_CONFIG['sirdata'] = {
   'consentInstanceId': 'sirdata',
   'checkConsentHref': 'https://sddan.mgr.consensu.org/api/v1/public/amp/check',
@@ -75,9 +80,4 @@ CMP_CONFIG['Usercentrics'] = {
   'consentInstanceId': 'Usercentrics',
   'checkConsentHref': 'https://consents.usercentrics.eu/amp/checkConsent',
   'promptUISrc': 'https://amp.usercentrics.eu/amp.html',
-};
-
-CMP_CONFIG['iubenda'] = {
-  'consentInstanceId': 'iubenda',
-  'checkConsentHref': 'https://hits.iubenda.com/cs/amp/checkConsent',
 };

--- a/extensions/amp-consent/0.1/cmps.js
+++ b/extensions/amp-consent/0.1/cmps.js
@@ -76,3 +76,8 @@ CMP_CONFIG['Usercentrics'] = {
   'checkConsentHref': 'https://consents.usercentrics.eu/amp/checkConsent',
   'promptUISrc': 'https://amp.usercentrics.eu/amp.html',
 };
+
+CMP_CONFIG['iubenda'] = {
+  'consentInstanceId': 'iubenda',
+  'checkConsentHref': 'https://hits.iubenda.com/cs/amp/checkConsent',
+};

--- a/extensions/amp-consent/0.1/cmps.js
+++ b/extensions/amp-consent/0.1/cmps.js
@@ -49,7 +49,7 @@ CMP_CONFIG['didomi'] = {
 
 CMP_CONFIG['iubenda'] = {
   'consentInstanceId': 'iubenda',
-  'checkConsentHref': 'https://hits.iubenda.com/cs/amp/checkConsent',
+  'checkConsentHref': 'https://cdn.iubenda.com/cs/amp/checkConsent',
 };
 
 CMP_CONFIG['sirdata'] = {

--- a/extensions/amp-consent/0.1/cmps.js
+++ b/extensions/amp-consent/0.1/cmps.js
@@ -50,6 +50,7 @@ CMP_CONFIG['didomi'] = {
 CMP_CONFIG['iubenda'] = {
   'consentInstanceId': 'iubenda',
   'checkConsentHref': 'https://cdn.iubenda.com/cs/amp/checkConsent',
+  'promptUISrc': 'https://www.iubenda.com/en/help/22135-cookie-solution-amp',
 };
 
 CMP_CONFIG['sirdata'] = {

--- a/extensions/amp-consent/amp-consent.md
+++ b/extensions/amp-consent/amp-consent.md
@@ -633,6 +633,7 @@ Join in on the discussion where we are discussing [upcoming potential features](
 
 - AppConsent : [Website](https://appconsent.io/en) - [Documentation](./cmps/appconsent.md)
 - Didomi : [Website](https://www.didomi.io/) - [Documentation](https://developers.didomi.io/cmp/amp)
+- iubenda : [Website](https://www.iubenda.com/) - [Documentation](./cmps/iubenda.md)
 - Sirdata : [Website](http://www.sirdata.com/) - [Documentation](https://cmp.sirdata.com/#/docs)
 - Marfeel : [Website](https://www.marfeel.com/) - [Documentation](./cmps/marfeel.md)
 - Ogury : [Website](https://www.ogury.com/) - [Documentation](./cmps/ogury.md)

--- a/extensions/amp-consent/cmps/iubenda.md
+++ b/extensions/amp-consent/cmps/iubenda.md
@@ -38,5 +38,6 @@ iubenda makes your sites & apps legally compliant across multiple languages and 
 ```
 
 ## Contacts for future maintenance
-@Facens, @Vasile-Peste
 
+@Facens
+@Vasile-Peste

--- a/extensions/amp-consent/cmps/iubenda.md
+++ b/extensions/amp-consent/cmps/iubenda.md
@@ -30,10 +30,13 @@ iubenda makes your sites & apps legally compliant across multiple languages and 
   </script>
   <div id="iubendaPostPromptUI">
     Post Prompt UI
-    <button on="tap:iubenda.prompt(consent=iubenda)" role="button">Manage</button>
+    <button on="tap:iubenda.prompt(consent=iubenda)" role="button">
+      Manage
+    </button>
   </div>
 </amp-consent>
 ```
 
 ## Contacts for future maintenance
 @Facens, @Vasile-Peste
+

--- a/extensions/amp-consent/cmps/iubenda.md
+++ b/extensions/amp-consent/cmps/iubenda.md
@@ -1,5 +1,5 @@
 <!---
-Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+Copyright 2020 The AMP HTML Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -21,50 +21,17 @@ iubenda makes your sites & apps legally compliant across multiple languages and 
 ## Example
 
 ```html
-<!-- Add the following to your document head. -->
-<style amp-custom>
-  .popupOverlay {
-    position: fixed;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-  }
-
-  amp-iframe {
-    margin: 0;
-  }
-  
-  amp-consent.amp-active {
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    position: fixed;
-  }
-</style>
-```
-```html
 <amp-consent id="iubenda" layout="nodisplay" type="iubenda">
-  <!--
-    If you want to request consent only to EU users then replace "consentRequired": true with "promptIfUnknownForGeoGroup": "eu" -> allows to ask consent only to EU users.
-  -->
   <script type="application/json">
     {
-      "consentRequired": true,
-      "promptUI": "iubenda-consent-ui"
+      "promptUISrc": "https://cdn.iubenda.com/cs/test/cs-for-amp.html",
+      "postPromptUI": "iubendaPostPromptUI"
     }
   </script>
-  <div id="iubenda-consent-ui" class="popupOverlay">
-        <!--
-        	Set src attribute to your webpage with the CS for the AMP pages.
-        	Note: it must be served over HTTPS
-        	See https://cdn.iubenda.com/cs/test/cs-for-amp.html for an example on how to set a page to embed CS
-      	-->
-        <amp-iframe layout="fill" sandbox="allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox" src="https://cdn.iubenda.com/cs/test/cs-for-amp.html">
-            <div placeholder>Loading</div>
-        </amp-iframe>
-    </div>
+  <div id="iubendaPostPromptUI">
+    Post Prompt UI
+    <button on="tap:iubenda.prompt(consent=iubenda)" role="button">Manage</button>
+  </div>
 </amp-consent>
 ```
 

--- a/extensions/amp-consent/cmps/iubenda.md
+++ b/extensions/amp-consent/cmps/iubenda.md
@@ -1,0 +1,72 @@
+<!---
+Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS-IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# iubenda
+
+iubenda makes your sites & apps legally compliant across multiple languages and legislations (including the GDPR) with lawyer-crafted, self-updating solutions. [Read our guide](https://www.iubenda.com/en/help/22135-cookie-solution-amp) to integrate our Cookie Solution in your AMP pages.
+
+## Example
+
+```html
+<!-- Add the following to your document head. -->
+<style amp-custom>
+  .popupOverlay {
+    position: fixed;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+  }
+
+  amp-iframe {
+    margin: 0;
+  }
+  
+  amp-consent.amp-active {
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    position: fixed;
+  }
+</style>
+```
+```html
+<amp-consent id="iubenda" layout="nodisplay" type="iubenda">
+  <!--
+    If you want to request consent only to EU users then replace "consentRequired": true with "promptIfUnknownForGeoGroup": "eu" -> allows to ask consent only to EU users.
+  -->
+  <script type="application/json">
+    {
+      "consentRequired": true,
+      "promptUI": "iubenda-consent-ui"
+    }
+  </script>
+  <div id="iubenda-consent-ui" class="popupOverlay">
+        <!--
+        	Set src attribute to your webpage with the CS for the AMP pages.
+        	Note: it must be served over HTTPS
+        	See https://cdn.iubenda.com/cs/test/cs-for-amp.html for an example on how to set a page to embed CS
+      	-->
+        <amp-iframe layout="fill" sandbox="allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox" src="https://cdn.iubenda.com/cs/test/cs-for-amp.html">
+            <div placeholder>Loading</div>
+        </amp-iframe>
+    </div>
+</amp-consent>
+```
+
+## Contacts for future maintenance
+@Facens, @Vasile-Peste


### PR DESCRIPTION
This PR introduces the integration of the iubenda Cookie Solution configuration in the amp-consent component.

https://www.iubenda.com

iubenda makes sites & apps legally compliant across multiple languages and legislations (including the GDPR) with lawyer-crafted, self-updating solutions and it's used by thousand of websites. Part of them have requested to support AMP pages.

Clarifications:

1. promptUI has not been specified in the configuration cause it's different for each customer. We ask our customers to host their promptUI on their own website, so this property must be set by customers.

2. There was no way to test the added configuration locally (cmps.js) since there are no instructions on how to build and use AMP locally, in addition the example page is using the AMP version in production so I guess that I must wait the configuration to be live before testing.

3. We would like to load the consent iframe even after the consent has been given (promptUI), at each pageview, cause we count the pageviews of our product. At this time there is only one way to load the iframe at each page view: by returning expireCache: true at each request to our check consent endpoint. But this clears the consent string. What do you think about creating another option like forcePromptUI to load the prompt UI at each page view? Thanks.

cc @ampproject/wg-monetization