### PR TITLE
🐛 Fix unmuted audio bug in FF

### DIFF
--- a/extensions/amp-story/1.0/media-pool.js
+++ b/extensions/amp-story/1.0/media-pool.js
@@ -277,6 +277,9 @@ export class MediaPool {
         mediaEl.addEventListener('error', this.onMediaError_, {capture: true});
         const sources = this.getDefaultSource_(type);
         mediaEl.id = POOL_ELEMENT_ID_PREFIX + poolIdCounter++;
+        // In Firefox, cloneNode() does not properly copy the muted property
+        // that was set in the seed. We need to set it again here.
+        mediaEl.muted = true;
         mediaEl[MEDIA_ELEMENT_ORIGIN_PROPERTY_NAME] = MediaElementOrigin.POOL;
         this.enqueueMediaElementTask_(
           mediaEl,


### PR DESCRIPTION
Fixes #28625

In Firefox, `cloneNode()` does not properly copy the `muted` audio/video DOM property that was set in the seed node. This seems like a Firefox bug, because this does not happen in Chrome.

To repro, try this in Chrome / Firefox:

```
videoEl.muted = true;
const clonedEl = videoEl.cloneNode(true /** deep */ )
```

Firefox:
```
clonedEl.muted 
> false
videoEl.muted
> true
```
Chrome
```
clonedEl.muted
> true
videoEl.muted
> true
```
<!--
# Instructions:

- Pick a meaningful title for your pull request. (Use sentence case.)
  - Prefix the title with an emoji to identify what is being done. (Copy-paste the emoji from the list below.)
  - Do not overuse punctuation in the title (like `(chore):`).
  - If it is helpful, use a simple prefix (like `ProjectX: Implement some feature`).
- Enter a succinct description that says why the PR is necessary, and what it does.
  - Mention the GitHub issue that is being addressed by the pull request.
  - The keywords `Fixes`, `Closes`, or `Resolves` followed the issue number will automatically close the issue.

> NOTE: All non-trivial changes (like introducing new features or components) should have an associated issue or reference an I2I (intent-to-implement: go.amp.dev/i2i). Please read through the contribution process (go.amp.dev/contributing/code) for more information.

# Example of a good description:

- Implement aspect X
- Leave out feature Y because of A
- Improve performance by B
- Improve accessibility by C

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Reverting a previous change
♻️ Refactoring
🚮 Deleting code
-->
