### PR TITLE
runtime perf pages: amp-list should use state

### DIFF
--- a/examples/runtime/animals.json
+++ b/examples/runtime/animals.json
@@ -1,3 +1,0 @@
-{
-  "items": ["man", "bear", "pig"]
-}

--- a/examples/runtime/list-always.html
+++ b/examples/runtime/list-always.html
@@ -17,8 +17,13 @@
       { "man": "bill", "bear": "honey", "pig": "zoinks"}
     </script>
   </amp-state>
+  <amp-state id="animals">
+    <script type="application/json">
+      { "items": ["man", "bear", "pig"]}
+    </script>
+  </amp-state>
 
-  <amp-list src="./animals.json" layout="fixed-height" height="300px" binding="always">
+  <amp-list src="amp-state:animals" layout="fixed-height" height="300px" binding="always">
     <template type="amp-mustache">
       <li [text]="'a {{.}} named ' + nameMap.{{.}}"]></li>
     </template>


### PR DESCRIPTION
**summary**
https://github.com/ampproject/amphtml/pull/28503 introduced a few issues. This addresses one of them. Namely that `file://` paths can't be used as the src for an `amp-list`.

![image](https://user-images.githubusercontent.com/4656974/83693924-13599600-a5c5-11ea-8a6a-a6fd6b7fc3be.png)

**testing done**
- page still looks the same when accessed through `gulp` default server.