### PR TITLE
🧪Introduce a4a-no-signing experiment diversion

### DIFF
--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -821,7 +821,7 @@ export class AmpA4A extends AMP.BaseElement {
       })
       .then((fetchResponse) =>
         getExperimentBranch(this.win, NO_SIGNING_EXP.id) ===
-        NO_SIGNING_EXP.control
+        NO_SIGNING_EXP.experiment
           ? this.streamResponse_(fetchResponse)
           : this.startValidationFlow_(fetchResponse, checkStillCurrent)
       )

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -51,6 +51,7 @@ import {
   getConsentPolicyState,
 } from '../../../src/consent';
 import {getContextMetadata} from '../../../src/iframe-attributes';
+import {getExperimentBranch} from '../../../src/experiments';
 import {getMode} from '../../../src/mode';
 import {insertAnalyticsElement} from '../../../src/extension-analytics';
 import {
@@ -174,6 +175,15 @@ const LIFECYCLE_STAGE_TO_ANALYTICS_TRIGGER = {
   'renderCrossDomainEnd': AnalyticsTrigger.AD_RENDER_END,
   'friendlyIframeIniLoad': AnalyticsTrigger.AD_IFRAME_LOADED,
   'crossDomainIframeLoaded': AnalyticsTrigger.AD_IFRAME_LOADED,
+};
+
+/**
+ * @const @enum {string}
+ */
+export const NO_SIGNING_EXP = {
+  id: 'a4a-no-signing',
+  control: '21066324',
+  experiment: '21066325',
 };
 
 /**
@@ -810,7 +820,10 @@ export class AmpA4A extends AMP.BaseElement {
         return fetchResponse;
       })
       .then((fetchResponse) =>
-        this.startValidationFlow_(fetchResponse, checkStillCurrent)
+        getExperimentBranch(this.win, NO_SIGNING_EXP.id) ===
+        NO_SIGNING_EXP.control
+          ? this.streamResponse_(fetchResponse)
+          : this.startValidationFlow_(fetchResponse, checkStillCurrent)
       )
       .catch((error) => {
         switch (error.message || error) {
@@ -831,6 +844,14 @@ export class AmpA4A extends AMP.BaseElement {
         this.promiseErrorHandler_(error);
         return null;
       });
+  }
+
+  /**
+   * @param {!Response} unusedResponse
+   */
+  streamResponse_(unusedResponse) {
+    // TODO(ccordry): implement
+    dev().error(TAG, 'unsigned path not yet implemented');
   }
 
   /**

--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -40,7 +40,7 @@ import {
   maybeAppendErrorParameter,
 } from '../../../ads/google/a4a/utils';
 import {AdsenseSharedState} from './adsense-shared-state';
-import {AmpA4A} from '../../amp-a4a/0.1/amp-a4a';
+import {AmpA4A, NO_SIGNING_EXP} from '../../amp-a4a/0.1/amp-a4a';
 import {CONSENT_POLICY_STATE} from '../../../src/consent-state';
 import {FIE_INIT_CHUNKING_EXP} from '../../../src/friendly-iframe-embed';
 import {Navigation} from '../../../src/service/navigation';
@@ -248,6 +248,10 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
           [RENDER_ON_IDLE_FIX_EXP.control],
           [RENDER_ON_IDLE_FIX_EXP.experiment],
         ],
+      },
+      [NO_SIGNING_EXP.id]: {
+        isTrafficEligible: () => true,
+        branches: [[NO_SIGNING_EXP.control], [NO_SIGNING_EXP.experiment]],
       },
       ...AMPDOC_FIE_EXPERIMENT_INFO_MAP,
     });

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -48,6 +48,7 @@ import {
   AmpA4A,
   ConsentTupleDef,
   DEFAULT_SAFEFRAME_VERSION,
+  NO_SIGNING_EXP,
   XORIGIN_MODE,
   assignAdUrlToError,
 } from '../../amp-a4a/0.1/amp-a4a';
@@ -487,6 +488,10 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
           [RENDER_ON_IDLE_FIX_EXP.control],
           [RENDER_ON_IDLE_FIX_EXP.experiment],
         ],
+      },
+      [NO_SIGNING_EXP.id]: {
+        isTrafficEligible: () => true,
+        branches: [[NO_SIGNING_EXP.control], [NO_SIGNING_EXP.experiment]],
       },
       ...AMPDOC_FIE_EXPERIMENT_INFO_MAP,
     });

--- a/tools/experiments/experiments-config.js
+++ b/tools/experiments/experiments-config.js
@@ -329,4 +329,9 @@ export const EXPERIMENTS = [
     name: 'More chunking for friendly iframe initialization',
     spec: 'https://github.com/ampproject/amphtml/issues/27584',
   },
+  {
+    id: 'a4a-no-signing',
+    name: 'Remove signing requirement for AMPHTML ads',
+    spec: 'https://github.com/ampproject/amphtml/issues/27189',
+  },
 ];


### PR DESCRIPTION
Adds diversion point, experiment will not be launched until logic is complete.

Part of #27189