### PR TITLE
turn off function decl transformer temporarily in pre closure

### DIFF
--- a/build-system/babel-config/pre-closure-config.js
+++ b/build-system/babel-config/pre-closure-config.js
@@ -87,9 +87,10 @@ function getPreClosureConfig() {
     replacePlugin,
     './build-system/babel-plugins/babel-plugin-transform-amp-asserts',
     argv.esm ? filterImportsPlugin : null,
-    argv.esm
-      ? './build-system/babel-plugins/babel-plugin-transform-function-declarations'
-      : null,
+    // TODO(erwinm, #28698): fix this in fixit week
+    //argv.esm
+    //? './build-system/babel-plugins/babel-plugin-transform-function-declarations'
+    //: null,
     !isCheckTypes
       ? './build-system/babel-plugins/babel-plugin-transform-json-configuration'
       : null,


### PR DESCRIPTION
this is currently breaking the prod version of esm build. turn it off temporarily