### PR TITLE
🏗 Use allowlist instead of whitelist

### DIFF
--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -31,7 +31,7 @@ const requiresReviewPrivacy =
 
 const privateServiceFactory =
   'This service should only be installed in ' +
-  'the whitelisted files. Other modules should use a public function ' +
+  'the allowlisted files. Other modules should use a public function ' +
   'typically called serviceNameFor.';
 
 const shouldNeverBeUsed =
@@ -48,10 +48,10 @@ const realiasGetMode =
 // Terms that must not appear in our source files.
 const forbiddenTerms = {
   'DO NOT SUBMIT': '',
-  // TODO(dvoytenko, #8464): cleanup whitelist.
+  // TODO(dvoytenko, #8464): cleanup allowlist.
   '(^-amp-|\\W-amp-)': {
     message: 'Switch to new internal class form',
-    whitelist: [
+    allowlist: [
       'build-system/server/amp4test.js',
       'build-system/server/app-index/boilerplate.js',
       'build-system/server/variable-substitution.js',
@@ -68,7 +68,7 @@ const forbiddenTerms = {
   },
   '(^i-amp-|\\Wi-amp-)': {
     message: 'Switch to new internal ID form',
-    whitelist: [
+    allowlist: [
       'build-system/tasks/create-golden-css/css/main.css',
       'build-system/tasks/extension-generator/index.js',
       'build-system/tasks/storybook/amp-env/decorator.js',
@@ -106,8 +106,8 @@ const forbiddenTerms = {
   'console\\.\\w+\\(': {
     message:
       'If you run against this, use console/*OK*/.[log|error] to ' +
-      'whitelist a legit case.',
-    whitelist: [
+      'allowlist a legit case.',
+    allowlist: [
       'build-system/common/check-package-manager.js',
       'build-system/compile/single-pass.js',
       'build-system/pr-check/build.js',
@@ -148,7 +148,7 @@ const forbiddenTerms = {
   },
   '\\bgetModeObject\\(': {
     message: realiasGetMode,
-    whitelist: [
+    allowlist: [
       'src/mode-object.js',
       'src/iframe-attributes.js',
       'dist.3p/current/integration.js',
@@ -158,7 +158,7 @@ const forbiddenTerms = {
     message:
       'IS_DEV local var only allowed in mode.js and ' +
       'dist.3p/current/integration.js',
-    whitelist: ['src/mode.js', 'dist.3p/current/integration.js'],
+    allowlist: ['src/mode.js', 'dist.3p/current/integration.js'],
   },
   '\\.prefetch\\(': {
     message: 'Do not use preconnect.prefetch, use preconnect.preload instead.',
@@ -166,7 +166,7 @@ const forbiddenTerms = {
   'iframePing': {
     message:
       'This is only available in vendor config for temporary workarounds.',
-    whitelist: [
+    allowlist: [
       'build-system/server/routes/analytics.js',
       'extensions/amp-analytics/0.1/config.js',
       'extensions/amp-analytics/0.1/requests.js',
@@ -175,7 +175,7 @@ const forbiddenTerms = {
   // Service factories that should only be installed once.
   'installActionServiceForDoc': {
     message: privateServiceFactory,
-    whitelist: [
+    allowlist: [
       'src/inabox/inabox-services.js',
       'src/service/action-impl.js',
       'src/service/core-services.js',
@@ -184,7 +184,7 @@ const forbiddenTerms = {
   },
   'installActionHandler': {
     message: privateServiceFactory,
-    whitelist: [
+    allowlist: [
       'src/service/action-impl.js',
       'extensions/amp-access/0.1/amp-access.js',
       'extensions/amp-form/0.1/amp-form.js',
@@ -193,18 +193,18 @@ const forbiddenTerms = {
   },
   'installActivityService': {
     message: privateServiceFactory,
-    whitelist: [
+    allowlist: [
       'extensions/amp-analytics/0.1/activity-impl.js',
       'extensions/amp-analytics/0.1/amp-analytics.js',
     ],
   },
   'cidServiceForDocForTesting': {
     message: privateServiceFactory,
-    whitelist: ['src/service/cid-impl.js'],
+    allowlist: ['src/service/cid-impl.js'],
   },
   'installCryptoService': {
     message: privateServiceFactory,
-    whitelist: [
+    allowlist: [
       'src/runtime.js',
       'src/service/core-services.js',
       'src/service/crypto-impl.js',
@@ -212,7 +212,7 @@ const forbiddenTerms = {
   },
   'installDocService': {
     message: privateServiceFactory,
-    whitelist: [
+    allowlist: [
       'src/amp.js',
       'src/amp-shadow.js',
       'src/inabox/amp-inabox.js',
@@ -223,7 +223,7 @@ const forbiddenTerms = {
   },
   'installMutatorServiceForDoc': {
     message: privateServiceFactory,
-    whitelist: [
+    allowlist: [
       'src/inabox/inabox-services.js',
       'src/service/core-services.js',
       'src/service/mutator-impl.js',
@@ -231,7 +231,7 @@ const forbiddenTerms = {
   },
   'installPerformanceService': {
     message: privateServiceFactory,
-    whitelist: [
+    allowlist: [
       'src/amp.js',
       'src/amp-shadow.js',
       'src/inabox/amp-inabox.js',
@@ -240,7 +240,7 @@ const forbiddenTerms = {
   },
   'installResourcesServiceForDoc': {
     message: privateServiceFactory,
-    whitelist: [
+    allowlist: [
       'src/inabox/inabox-services.js',
       'src/service/core-services.js',
       'src/service/resources-impl.js',
@@ -248,7 +248,7 @@ const forbiddenTerms = {
   },
   'installStorageServiceForDoc': {
     message: privateServiceFactory,
-    whitelist: [
+    allowlist: [
       'src/runtime.js',
       'src/service/core-services.js',
       'src/service/storage-impl.js',
@@ -256,7 +256,7 @@ const forbiddenTerms = {
   },
   'installTemplatesService': {
     message: privateServiceFactory,
-    whitelist: [
+    allowlist: [
       'src/runtime.js',
       'src/service/core-services.js',
       'src/service/template-impl.js',
@@ -264,7 +264,7 @@ const forbiddenTerms = {
   },
   'installUrlReplacementsServiceForDoc': {
     message: privateServiceFactory,
-    whitelist: [
+    allowlist: [
       'src/inabox/inabox-services.js',
       'src/service/core-services.js',
       'src/service/url-replacements-impl.js',
@@ -272,7 +272,7 @@ const forbiddenTerms = {
   },
   'installViewerServiceForDoc': {
     message: privateServiceFactory,
-    whitelist: [
+    allowlist: [
       'src/runtime.js',
       'src/inabox/inabox-services.js',
       'src/service/core-services.js',
@@ -281,7 +281,7 @@ const forbiddenTerms = {
   },
   'installViewportServiceForDoc': {
     message: privateServiceFactory,
-    whitelist: [
+    allowlist: [
       'src/runtime.js',
       'src/service/core-services.js',
       'src/service/viewport/viewport-impl.js',
@@ -289,7 +289,7 @@ const forbiddenTerms = {
   },
   'installVsyncService': {
     message: privateServiceFactory,
-    whitelist: [
+    allowlist: [
       'src/runtime.js',
       'src/service/core-services.js',
       'src/service/resources-impl.js',
@@ -299,7 +299,7 @@ const forbiddenTerms = {
   },
   'installXhrService': {
     message: privateServiceFactory,
-    whitelist: [
+    allowlist: [
       'src/runtime.js',
       'src/service/core-services.js',
       'src/service/xhr-impl.js',
@@ -307,7 +307,7 @@ const forbiddenTerms = {
   },
   'installPositionObserverServiceForDoc': {
     message: privateServiceFactory,
-    whitelist: [
+    allowlist: [
       // Please keep list alphabetically sorted.
       'extensions/amp-fx-collection/0.1/providers/fx-provider.js',
       'extensions/amp-list/0.1/amp-list.js',
@@ -324,8 +324,8 @@ const forbiddenTerms = {
     message:
       'Synchronous access to element services is unreliable (#22414). ' +
       'Use getServicePromiseForDoc() instead.',
-    whitelist: [
-      // Do not whitelist additional "extensions/*" paths.
+    allowlist: [
+      // Do not allowlist additional "extensions/*" paths.
       // TODO(#22414): Remove paths as they are migrated off of sync API.
       'extensions/amp-analytics/0.1/instrumentation.js',
       'extensions/amp-analytics/0.1/variables.js',
@@ -340,7 +340,7 @@ const forbiddenTerms = {
   },
   'initLogConstructor|setReportError': {
     message: 'Should only be called from JS binary entry files.',
-    whitelist: [
+    allowlist: [
       '3p/integration.js',
       '3p/ampcontext-lib.js',
       '3p/iframe-transport-client-lib.js',
@@ -359,7 +359,7 @@ const forbiddenTerms = {
   },
   'parseUrlWithA': {
     message: 'Use parseUrl instead.',
-    whitelist: [
+    allowlist: [
       'src/url.js',
       'src/service/navigation.js',
       'src/service/url-impl.js',
@@ -369,7 +369,7 @@ const forbiddenTerms = {
   },
   '\\.sendMessage\\(': {
     message: 'Usages must be reviewed.',
-    whitelist: [
+    allowlist: [
       // viewer-impl.sendMessage
       'src/error.js',
       'src/service/navigation.js',
@@ -394,7 +394,7 @@ const forbiddenTerms = {
   },
   '\\.sendMessageAwaitResponse\\(': {
     message: 'Usages must be reviewed.',
-    whitelist: [
+    allowlist: [
       'extensions/amp-access/0.1/login-dialog.js',
       'extensions/amp-access/0.1/signin.js',
       'extensions/amp-story-education/0.1/amp-story-education.js',
@@ -412,7 +412,7 @@ const forbiddenTerms = {
   // Privacy sensitive
   'cidForDoc|cidForDocOrNull': {
     message: requiresReviewPrivacy,
-    whitelist: [
+    allowlist: [
       // CID service is not allowed in amp4ads. No usage should there be
       // in extensions listed in the amp4ads spec:
       // https://amp.dev/documentation/guides-and-tutorials/learn/a4a_spec
@@ -432,11 +432,11 @@ const forbiddenTerms = {
   },
   'getBaseCid': {
     message: requiresReviewPrivacy,
-    whitelist: ['src/service/cid-impl.js', 'src/service/viewer-impl.js'],
+    allowlist: ['src/service/cid-impl.js', 'src/service/viewer-impl.js'],
   },
   'isTrustedViewer': {
     message: requiresReviewPrivacy,
-    whitelist: [
+    allowlist: [
       'extensions/amp-bind/0.1/bind-impl.js',
       'src/error.js',
       'src/utils/xhr-utils.js',
@@ -453,7 +453,7 @@ const forbiddenTerms = {
   },
   'prerenderSafe': {
     message: requiresReviewPrivacy,
-    whitelist: [
+    allowlist: [
       'build-system/externs/amp.extern.js',
       'extensions/amp-subscriptions-google/0.1/amp-subscriptions-google.js',
       'src/utils/xhr-utils.js',
@@ -461,7 +461,7 @@ const forbiddenTerms = {
   },
   'eval\\(': {
     message: shouldNeverBeUsed,
-    whitelist: ['extension/amp-bind/0.1/test/test-bind-expr.js'],
+    allowlist: ['extension/amp-bind/0.1/test/test-bind-expr.js'],
   },
   'storageForDoc': {
     message:
@@ -470,7 +470,7 @@ const forbiddenTerms = {
       ' the storage service usage.' +
       ' Once approved, please also update the spec/amp-localstorage.md to' +
       ' include your usage.',
-    whitelist: [
+    allowlist: [
       // Storage service is not allowed in amp4ads. No usage should there be
       // in extensions listed in the amp4ads spec:
       // https://amp.dev/documentation/guides-and-tutorials/learn/a4a_spec
@@ -484,7 +484,7 @@ const forbiddenTerms = {
   },
   'localStorage': {
     message: requiresReviewPrivacy,
-    whitelist: [
+    allowlist: [
       'extensions/amp-access/0.1/amp-access-iframe.js',
       'extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js',
       'extensions/amp-script/0.1/amp-script.js',
@@ -498,7 +498,7 @@ const forbiddenTerms = {
   },
   'sessionStorage': {
     message: requiresReviewPrivacy,
-    whitelist: [
+    allowlist: [
       'extensions/amp-access/0.1/amp-access-iframe.js',
       'extensions/amp-accordion/0.1/amp-accordion.js',
       'extensions/amp-script/0.1/amp-script.js',
@@ -513,7 +513,7 @@ const forbiddenTerms = {
   'webkitRequestFileSystem': requiresReviewPrivacy,
   'getAccessReaderId': {
     message: requiresReviewPrivacy,
-    whitelist: [
+    allowlist: [
       'build-system/externs/amp.extern.js',
       'extensions/amp-access/0.1/amp-access.js',
       'extensions/amp-access/0.1/access-vars.js',
@@ -524,7 +524,7 @@ const forbiddenTerms = {
   },
   'getAuthdataField': {
     message: requiresReviewPrivacy,
-    whitelist: [
+    allowlist: [
       'build-system/externs/amp.extern.js',
       'extensions/amp-access/0.1/amp-access.js',
       'extensions/amp-access/0.1/access-vars.js',
@@ -536,7 +536,7 @@ const forbiddenTerms = {
   // Overridden APIs.
   '(doc.*)\\.referrer': {
     message: 'Use Viewer.getReferrerUrl() instead.',
-    whitelist: [
+    allowlist: [
       '3p/integration.js',
       'ads/google/a4a/utils.js',
       'dist.3p/current/integration.js',
@@ -548,7 +548,7 @@ const forbiddenTerms = {
   },
   'getUnconfirmedReferrerUrl': {
     message: 'Use Viewer.getReferrerUrl() instead.',
-    whitelist: [
+    allowlist: [
       'extensions/amp-dynamic-css-classes/0.1/amp-dynamic-css-classes.js',
       'src/3p-frame.js',
       'src/iframe-attributes.js',
@@ -561,7 +561,7 @@ const forbiddenTerms = {
     message:
       'Use `listen()` in either `event-helper` or `3p-frame-messaging`' +
       ', depending on your use case.',
-    whitelist: [
+    allowlist: [
       'src/3p-frame-messaging.js',
       'src/event-helper.js',
       'src/event-helper-listen.js',
@@ -570,7 +570,7 @@ const forbiddenTerms = {
   },
   'setTimeout.*throw': {
     message: 'Use dev.error or user.error instead.',
-    whitelist: ['src/log.js'],
+    allowlist: ['src/log.js'],
   },
   '(dev|user)\\(\\)\\.(fine|info|warn|error)\\((?!\\s*([A-Z0-9-]+|[\'"`][A-Z0-9-]+[\'"`]))[^,)\n]*': {
     // eslint-disable-line max-len
@@ -580,12 +580,12 @@ const forbiddenTerms = {
   },
   '\\.schedulePass\\(': {
     message: 'schedulePass is heavy, think twice before using it',
-    whitelist: ['src/service/mutator-impl.js', 'src/service/resources-impl.js'],
+    allowlist: ['src/service/mutator-impl.js', 'src/service/resources-impl.js'],
   },
   '\\.requireLayout\\(': {
     message:
       'requireLayout is restricted b/c it affects non-contained elements', // eslint-disable-line max-len
-    whitelist: [
+    allowlist: [
       'extensions/amp-animation/0.1/web-animations.js',
       'extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js',
       'src/service/resources-impl.js',
@@ -593,7 +593,7 @@ const forbiddenTerms = {
   },
   '\\.updateLayoutPriority\\(': {
     message: 'updateLayoutPriority is a restricted API.',
-    whitelist: [
+    allowlist: [
       'extensions/amp-a4a/0.1/amp-a4a.js',
       'src/base-element.js',
       'src/service/resources-impl.js',
@@ -601,7 +601,7 @@ const forbiddenTerms = {
   },
   'overrideVisibilityState': {
     message: 'overrideVisibilityState is a restricted API.',
-    whitelist: [
+    allowlist: [
       'src/multidoc-manager.js',
       'src/service/ampdoc-impl.js',
       'src/service/viewer-impl.js',
@@ -609,19 +609,19 @@ const forbiddenTerms = {
   },
   '\\.scheduleLayoutOrPreload\\(': {
     message: 'scheduleLayoutOrPreload is a restricted API.',
-    whitelist: ['src/service/owners-impl.js', 'src/service/resources-impl.js'],
+    allowlist: ['src/service/owners-impl.js', 'src/service/resources-impl.js'],
   },
   '(win|Win)(dow)?(\\(\\))?\\.open\\W': {
     message: 'Use dom.openWindowDialog',
-    whitelist: ['src/dom.js'],
+    allowlist: ['src/dom.js'],
   },
   '\\.getWin\\(': {
     message: backwardCompat,
-    whitelist: [],
+    allowlist: [],
   },
   '/\\*\\* @type \\{\\!Element\\} \\*/': {
     message: 'Use assertElement instead of casting to !Element.',
-    whitelist: [
+    allowlist: [
       'src/log.js', // Has actual implementation of assertElement.
       'dist.3p/current/integration.js', // Includes the previous.
       'src/polyfills/custom-elements.js',
@@ -631,7 +631,7 @@ const forbiddenTerms = {
   },
   'startupChunk\\(': {
     message: 'startupChunk( should only be used during startup',
-    whitelist: [
+    allowlist: [
       'src/amp.js',
       'src/chunk.js',
       'src/inabox/amp-inabox.js',
@@ -644,7 +644,7 @@ const forbiddenTerms = {
     message:
       'Do not access AMP_CONFIG directly. Use isExperimentOn() ' +
       'and getMode() to access config',
-    whitelist: [
+    allowlist: [
       'build-system/externs/amp.extern.js',
       'build-system/server/app.js',
       'build-system/tasks/e2e/index.js',
@@ -673,17 +673,17 @@ const forbiddenTerms = {
   },
   'new CustomEvent\\(': {
     message: 'Use createCustomEvent() helper instead.',
-    whitelist: ['src/event-helper.js'],
+    allowlist: ['src/event-helper.js'],
   },
   'new FormData\\(': {
     message:
       'Use createFormDataWrapper() instead and call ' +
       'formDataWrapper.getFormData() to get the native FormData object.',
-    whitelist: ['src/form-data-wrapper.js'],
+    allowlist: ['src/form-data-wrapper.js'],
   },
   '([eE]xit|[eE]nter|[cC]ancel|[rR]equest)Full[Ss]creen\\(': {
     message: 'Use fullscreenEnter() and fullscreenExit() from dom.js instead.',
-    whitelist: [
+    allowlist: [
       'ads/google/imaVideo.js',
       'dist.3p/current/integration.js',
       'src/video-iframe-integration.js',
@@ -700,20 +700,20 @@ const forbiddenTerms = {
   },
   'eslint no-unused-vars': {
     message: 'Use a line-level "no-unused-vars" rule instead.',
-    whitelist: ['extensions/amp-access/0.1/iframe-api/access-controller.js'],
+    allowlist: ['extensions/amp-access/0.1/iframe-api/access-controller.js'],
   },
   'this\\.skip\\(\\)': {
     message:
       'Use of `this.skip()` is forbidden in test files. Use ' +
       '`this.skipTest()` from within a `before()` block instead. See #17245.',
     checkInTestFolder: true,
-    whitelist: ['test/_init_tests.js'],
+    allowlist: ['test/_init_tests.js'],
   },
   '[^\\.]makeBodyVisible\\(': {
     message:
       'This is a protected function. If you are calling this to show ' +
       'body after an error please use `makeBodyVisibleRecovery`',
-    whitelist: [
+    allowlist: [
       'src/amp.js',
       'src/amp-shadow.js',
       'src/style-installer.js',
@@ -724,7 +724,7 @@ const forbiddenTerms = {
     message:
       'This is a protected API. Please only override it the element is ' +
       'render blocking',
-    whitelist: [
+    allowlist: [
       'src/service/resources-impl.js',
       'src/service/resource.js',
       'src/custom-element.js',
@@ -737,7 +737,7 @@ const forbiddenTerms = {
     message:
       'Top-level "describe" blocks in test files have been deprecated. ' +
       'Use "describes.{realWin|sandboxed|fakeWin|integration}".',
-    whitelist: [
+    allowlist: [
       // Non test files. These can remain.
       'build-system/server/app-index/test/test-amphtml-helpers.js',
       'build-system/server/app-index/test/test-file-list.js',
@@ -756,7 +756,7 @@ const forbiddenTerms = {
       'validator/engine/parse-url_test.js',
       'validator/engine/validator_test.js',
       'validator/gulpjs/test/validate.js',
-      // Test files. TODO(#24144): Fix these and remove from the whitelist.
+      // Test files. TODO(#24144): Fix these and remove from the allowlist.
       'ads/google/a4a/shared/test/test-content-recommendation.js',
       'ads/google/a4a/shared/test/test-url-builder.js',
       'ads/google/a4a/test/test-line-delimited-response-handler.js',
@@ -906,7 +906,7 @@ const ThreePTermsMessage =
 
 const forbidden3pTerms = {
   // We need to forbid promise usage because we don't have our own polyfill
-  // available. This whitelisting of callNext is a major hack to allow one
+  // available. This allowlisting of callNext is a major hack to allow one
   // usage in babel's external helpers that is in a code path that we do
   // not use.
   '\\.then\\((?!callNext)': ThreePTermsMessage,
@@ -973,7 +973,7 @@ const forbiddenTermsSrcInclusive = {
   '\\.scheduleUnlayout\\(': bannedTermsHelpString,
   '\\.postMessage\\(': {
     message: bannedTermsHelpString,
-    whitelist: [
+    allowlist: [
       'extensions/amp-install-serviceworker/0.1/amp-install-serviceworker.js',
     ],
   },
@@ -981,13 +981,13 @@ const forbiddenTermsSrcInclusive = {
     message:
       'Due to various bugs in Firefox, you must use the computedStyle ' +
       'helper in style.js.',
-    whitelist: ['src/style.js', 'dist.3p/current/integration.js'],
+    allowlist: ['src/style.js', 'dist.3p/current/integration.js'],
   },
   'decodeURIComponent\\(': {
     message:
       'decodeURIComponent throws for malformed URL components. Please ' +
       'use tryDecodeUriComponent from src/url.js',
-    whitelist: [
+    allowlist: [
       '3p/integration.js',
       'dist.3p/current/integration.js',
       'examples/pwa/pwa.js',
@@ -1004,7 +1004,7 @@ const forbiddenTermsSrcInclusive = {
     message:
       'TextEncoder/TextDecoder is not supported in all browsers.' +
       ' Please use UTF8 utilities from src/bytes.js',
-    whitelist: [
+    allowlist: [
       'ads/google/a4a/line-delimited-response-handler.js',
       'examples/pwa/pwa.js',
       'src/utils/bytes.js',
@@ -1012,7 +1012,7 @@ const forbiddenTermsSrcInclusive = {
   },
   'contentHeightChanged': {
     message: bannedTermsHelpString,
-    whitelist: [
+    allowlist: [
       'src/inabox/inabox-viewport.js',
       'src/service/resources-impl.js',
       'src/service/viewport/viewport-binding-def.js',
@@ -1024,7 +1024,7 @@ const forbiddenTermsSrcInclusive = {
   },
   'preloadExtension': {
     message: bannedTermsHelpString,
-    whitelist: [
+    allowlist: [
       'src/element-stub.js',
       'src/friendly-iframe-embed.js',
       'src/polyfillstub/intersection-observer-stub.js',
@@ -1046,7 +1046,7 @@ const forbiddenTermsSrcInclusive = {
   },
   'loadElementClass': {
     message: bannedTermsHelpString,
-    whitelist: [
+    allowlist: [
       'src/runtime.js',
       'src/service/extensions-impl.js',
       'extensions/amp-ad/0.1/amp-ad.js',
@@ -1062,7 +1062,7 @@ const forbiddenTermsSrcInclusive = {
   },
   '[^.]loadPromise': {
     message: 'Most users should use BaseElement…loadPromise.',
-    whitelist: [
+    allowlist: [
       'src/base-element.js',
       'src/event-helper.js',
       'src/friendly-iframe-embed.js',
@@ -1081,21 +1081,21 @@ const forbiddenTermsSrcInclusive = {
   },
   '\\.getTime\\(\\)': {
     message: 'Unless you do weird date math (allowlist), use Date.now().',
-    whitelist: [
+    allowlist: [
       'extensions/amp-timeago/0.1/amp-timeago.js',
       'extensions/amp-timeago/1.0/timeago.js',
     ],
   },
   '\\.expandStringSync\\(': {
     message: requiresReviewPrivacy,
-    whitelist: [
+    allowlist: [
       'extensions/amp-form/0.1/amp-form.js',
       'src/service/url-replacements-impl.js',
     ],
   },
   '\\.expandStringAsync\\(': {
     message: requiresReviewPrivacy,
-    whitelist: [
+    allowlist: [
       'extensions/amp-form/0.1/amp-form.js',
       'src/service/url-replacements-impl.js',
       'extensions/amp-analytics/0.1/config.js',
@@ -1106,21 +1106,21 @@ const forbiddenTermsSrcInclusive = {
   },
   '\\.expandInputValueSync\\(': {
     message: requiresReviewPrivacy,
-    whitelist: [
+    allowlist: [
       'extensions/amp-form/0.1/amp-form.js',
       'src/service/url-replacements-impl.js',
     ],
   },
   '\\.expandInputValueAsync\\(': {
     message: requiresReviewPrivacy,
-    whitelist: [
+    allowlist: [
       'extensions/amp-form/0.1/amp-form.js',
       'src/service/url-replacements-impl.js',
     ],
   },
   '\\.setNonBoolean\\(': {
     message: requiresReviewPrivacy,
-    whitelist: [
+    allowlist: [
       'src/service/storage-impl.js',
       'extensions/amp-consent/0.1/consent-state-manager.js',
     ],
@@ -1129,7 +1129,7 @@ const forbiddenTermsSrcInclusive = {
     message:
       'The CDN domain should typically not be hardcoded in source ' +
       'code. Use a property of urls from src/config.js instead.',
-    whitelist: [
+    allowlist: [
       'ads/_a4a-config.js',
       'build-system/server/amp4test.js',
       'build-system/server/app-index/amphtml-helpers.js',
@@ -1166,22 +1166,22 @@ const forbiddenTermsSrcInclusive = {
   },
   '\\.indexOf\\([\'"][^)]+\\)\\s*===?\\s*0\\b': {
     message: 'use startsWith helper in src/string.js',
-    whitelist: ['dist.3p/current/integration.js', 'build-system/server/app.js'],
+    allowlist: ['dist.3p/current/integration.js', 'build-system/server/app.js'],
   },
   '\\.indexOf\\(.*===?.*\\.length': 'use endsWith helper in src/string.js',
   '/url-parse-query-string': {
     message: 'Import parseQueryString from `src/url.js`',
-    whitelist: ['src/url.js', 'src/mode.js', 'dist.3p/current/integration.js'],
+    allowlist: ['src/url.js', 'src/mode.js', 'dist.3p/current/integration.js'],
   },
   '\\.trim(Left|Right)\\(\\)': {
     message: 'Unsupported on IE; use trim() or a helper instead.',
-    whitelist: ['validator/engine/validator.js'],
+    allowlist: ['validator/engine/validator.js'],
   },
   "process\\.env(\\.TRAVIS|\\[\\'TRAVIS)": {
     message:
       'Do not directly use process.env.TRAVIS. Instead, add a ' +
       'function to build-system/common/travis.js',
-    whitelist: [
+    allowlist: [
       'build-system/common/check-package-manager.js',
       'build-system/common/travis.js',
     ],
@@ -1258,13 +1258,13 @@ function matchTerms(file, terms) {
   return Object.keys(terms)
     .map(function (term) {
       let fix;
-      const {whitelist, checkInTestFolder} = terms[term];
+      const {allowlist, checkInTestFolder} = terms[term];
       // NOTE: we could do a glob test instead of exact check in the future
       // if needed but that might be too permissive.
       if (
         isInBuildSystemFixtureFolder(relative) ||
-        (Array.isArray(whitelist) &&
-          (whitelist.indexOf(relative) != -1 ||
+        (Array.isArray(allowlist) &&
+          (allowlist.indexOf(relative) != -1 ||
             (isInTestFolder(relative) && !checkInTestFolder)))
       ) {
         return false;


### PR DESCRIPTION
In Presubmit Checks and other locations, the term `whitelist` is used when `allowlist` is preferred.

This PR moves Presubmit Checks over to `allowlist`.