### PR TITLE
[Carousel]: Initial Preact Component

### DIFF
--- a/extensions/amp-base-carousel/1.0/arrow.js
+++ b/extensions/amp-base-carousel/1.0/arrow.js
@@ -23,15 +23,15 @@ import {mod} from '../../../src/utils/math';
  * @return {PreactDef.Renderable}
  */
 export function Arrow(props) {
-  const {dir, restingIndex, setRestingIndex, length, customArrow, loop} = props;
+  const {customArrow, dir, length, loop, restingIndex, setRestingIndex} = props;
   const button = customArrow ? customArrow : renderDefaultArrow({dir});
   const nextSlide = restingIndex + dir;
   const {children, 'disabled': disabled, onClick, ...rest} = button.props;
   const isDisabled =
     disabled || (loop ? false : nextSlide < 0 || nextSlide >= length);
-  const handleClick = () => {
+  const handleClick = (e) => {
     if (onClick) {
-      onClick();
+      onClick(e);
     }
     setRestingIndex(mod(restingIndex + dir, length));
   };

--- a/extensions/amp-base-carousel/1.0/arrow.js
+++ b/extensions/amp-base-carousel/1.0/arrow.js
@@ -16,18 +16,26 @@
 
 import * as Preact from '../../../src/preact';
 import * as styles from './base-carousel.css';
+import {dict} from '../../../src/utils/object';
 
 /**
  * @param {!JsonObject} props
  * @return {PreactDef.Renderable}
  */
 export function Arrow(props) {
-  const {customArrow, dir, onClick, disabled} = props;
-  const button = customArrow ? customArrow : renderDefaultArrow({dir});
   const {
-    children,
+    'customArrow': customArrow,
+    'dir': dir,
+    'onClick': onClick,
+    'disabled': disabled,
+  } = props;
+  const button = customArrow
+    ? customArrow
+    : renderDefaultArrow(dict({'dir': dir}));
+  const {
+    'children': children,
     'disabled': customDisabled,
-    onCustomClick,
+    'onCustomClick': onCustomClick,
     ...rest
   } = button.props;
   const isDisabled = disabled || customDisabled;
@@ -66,7 +74,7 @@ export function Arrow(props) {
 function renderDefaultArrow(props) {
   return (
     <button style={styles.defaultArrowButton}>
-      {props.dir < 0 ? '<<' : '>>'}
+      {props['dir'] < 0 ? '<<' : '>>'}
     </button>
   );
 }

--- a/extensions/amp-base-carousel/1.0/arrow.js
+++ b/extensions/amp-base-carousel/1.0/arrow.js
@@ -1,0 +1,66 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as Preact from '../../../src/preact';
+import * as styles from './base-carousel.css';
+import {mod} from '../../../src/utils/math';
+
+/**
+ * @param {!JsonObject} props
+ * @return {PreactDef.Renderable}
+ */
+export function Arrow(props) {
+  const {dir, restingIndex, setRestingIndex, length, customArrow, loop} = props;
+  const button = customArrow ? customArrow : renderDefaultArrow({dir});
+  const nextSlide = restingIndex + dir;
+  const {children, 'disabled': disabled, onClick, ...rest} = button.props;
+  const isDisabled =
+    disabled || (loop ? false : nextSlide < 0 || nextSlide >= length);
+  const handleClick = () => {
+    if (onClick) {
+      onClick();
+    }
+    setRestingIndex(mod(restingIndex + dir, length));
+  };
+  return Preact.cloneElement(
+    button,
+    {
+      onClick: handleClick,
+      disabled: isDisabled,
+      ...rest,
+    },
+    children
+  );
+}
+
+/**
+ * @param {!JsonObject} props
+ * @return {PreactDef.Renderable}
+ */
+function renderDefaultArrow(props) {
+  const {dir} = props;
+  return (
+    <button
+      style={{
+        // Offset button from the edge.
+        [dir < 0 ? 'left' : 'right']: '8px',
+        ...styles.defaultArrowButton,
+      }}
+    >
+      {props.dir < 0 ? '<<' : '>>'}
+    </button>
+  );
+}

--- a/extensions/amp-base-carousel/1.0/arrow.js
+++ b/extensions/amp-base-carousel/1.0/arrow.js
@@ -26,7 +26,7 @@ export function Arrow(props) {
   const {
     'customArrow': customArrow,
     'dir': dir,
-    'onClick': onClick,
+    'advance': advance,
     'disabled': disabled,
   } = props;
   const button = customArrow
@@ -35,15 +35,15 @@ export function Arrow(props) {
   const {
     'children': children,
     'disabled': customDisabled,
-    'onCustomClick': onCustomClick,
+    'onClick': onCustomClick,
     ...rest
   } = button.props;
   const isDisabled = disabled || customDisabled;
-  const handleClick = (e) => {
+  const onClick = (e) => {
     if (onCustomClick) {
       onCustomClick(e);
     }
-    onClick();
+    advance();
   };
   return (
     <div
@@ -56,8 +56,8 @@ export function Arrow(props) {
       {Preact.cloneElement(
         button,
         {
-          onClick: handleClick,
-          disabled: isDisabled,
+          'onClick': onClick,
+          'disabled': isDisabled,
           'aria-disabled': isDisabled,
           ...rest,
         },

--- a/extensions/amp-base-carousel/1.0/arrow.js
+++ b/extensions/amp-base-carousel/1.0/arrow.js
@@ -16,24 +16,26 @@
 
 import * as Preact from '../../../src/preact';
 import * as styles from './base-carousel.css';
-import {mod} from '../../../src/utils/math';
 
 /**
  * @param {!JsonObject} props
  * @return {PreactDef.Renderable}
  */
 export function Arrow(props) {
-  const {customArrow, dir, length, loop, restingIndex, setRestingIndex} = props;
+  const {customArrow, dir, onClick, disabled} = props;
   const button = customArrow ? customArrow : renderDefaultArrow({dir});
-  const nextSlide = restingIndex + dir;
-  const {children, 'disabled': disabled, onClick, ...rest} = button.props;
-  const isDisabled =
-    disabled || (loop ? false : nextSlide < 0 || nextSlide >= length);
+  const {
+    children,
+    'disabled': customDisabled,
+    onCustomClick,
+    ...rest
+  } = button.props;
+  const isDisabled = disabled || customDisabled;
   const handleClick = (e) => {
-    if (onClick) {
-      onClick(e);
+    if (onCustomClick) {
+      onCustomClick(e);
     }
-    setRestingIndex(mod(restingIndex + dir, length));
+    onClick();
   };
   return (
     <div
@@ -48,6 +50,7 @@ export function Arrow(props) {
         {
           onClick: handleClick,
           disabled: isDisabled,
+          'aria-disabled': isDisabled,
           ...rest,
         },
         children

--- a/extensions/amp-base-carousel/1.0/arrow.js
+++ b/extensions/amp-base-carousel/1.0/arrow.js
@@ -35,14 +35,24 @@ export function Arrow(props) {
     }
     setRestingIndex(mod(restingIndex + dir, length));
   };
-  return Preact.cloneElement(
-    button,
-    {
-      onClick: handleClick,
-      disabled: isDisabled,
-      ...rest,
-    },
-    children
+  return (
+    <div
+      style={{
+        ...styles.arrowPlacement,
+        // Offset button from the edge.
+        [dir < 0 ? 'left' : 'right']: '0px',
+      }}
+    >
+      {Preact.cloneElement(
+        button,
+        {
+          onClick: handleClick,
+          disabled: isDisabled,
+          ...rest,
+        },
+        children
+      )}
+    </div>
   );
 }
 
@@ -51,15 +61,8 @@ export function Arrow(props) {
  * @return {PreactDef.Renderable}
  */
 function renderDefaultArrow(props) {
-  const {dir} = props;
   return (
-    <button
-      style={{
-        // Offset button from the edge.
-        [dir < 0 ? 'left' : 'right']: '8px',
-        ...styles.defaultArrowButton,
-      }}
-    >
+    <button style={styles.defaultArrowButton}>
       {props.dir < 0 ? '<<' : '>>'}
     </button>
   );

--- a/extensions/amp-base-carousel/1.0/base-carousel.css.js
+++ b/extensions/amp-base-carousel/1.0/base-carousel.css.js
@@ -1,0 +1,55 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const slideElement = {
+  flex: '0 0 100%',
+  height: '100%',
+  position: 'relative',
+  overflow: 'hidden',
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  justifyContent: 'center',
+  scrollSnapAlign: 'start',
+};
+
+export const scrollContainer = {
+  height: '100%',
+  position: 'absolute',
+  top: 0,
+  left: 0,
+  right: 0,
+  bottom: 0,
+  overflowX: 'auto',
+  overflowY: 'hidden',
+  display: 'flex',
+  flexDirection: 'row',
+  flexWrap: 'nowrap',
+  // TBD: smooth behavior causes a lot of `setState` problems.
+  // scrollBehavior: 'smooth',
+  WebkitOverflowScrolling: 'touch',
+  scrollSnapType: 'x mandatory',
+};
+
+export const defaultArrowButton = {
+  position: 'absolute',
+  // Center the button vertically.
+  top: '50%',
+  transform: 'translateY(-50%)',
+  width: '32px',
+  height: '32px',
+  background: 'rgba(0, 0, 0, 0.25)',
+};

--- a/extensions/amp-base-carousel/1.0/base-carousel.css.js
+++ b/extensions/amp-base-carousel/1.0/base-carousel.css.js
@@ -42,6 +42,7 @@ export const scrollContainer = {
   // scrollBehavior: 'smooth',
   WebkitOverflowScrolling: 'touch',
   scrollSnapType: 'x mandatory',
+  scrollBehavior: 'smooth',
 };
 
 export const arrowPlacement = {

--- a/extensions/amp-base-carousel/1.0/base-carousel.css.js
+++ b/extensions/amp-base-carousel/1.0/base-carousel.css.js
@@ -53,3 +53,35 @@ export const defaultArrowButton = {
   height: '32px',
   background: 'rgba(0, 0, 0, 0.25)',
 };
+
+/*
+ * Styles to hide scrollbars, with three different methods:
+ *
+ * 1. scrollbar-width
+ *  - Note: this is actually scrollbar *thickness* and applies to horizontal
+ *    scrollbars as well
+ * 2. ::-webkit-scrollbar
+ * 3. Using padding to push scrollbar outside of the overflow
+ *
+ * The last method has side-effect of having the bottom of the slides being
+ * cut-off, since the height (or width) of the scrollbar is included when
+ * calculating the 100% height (or width) of the slide.
+ */
+/* Firefox */
+export const hideScrollbar = {
+  scrollbarWidth: 'none',
+};
+/* Chrome, Safari */
+export const hideScrollbarPseudo = `[hide-scrollbar]::-webkit-scrollbar {
+  display: none;
+  box-sizing: content-box !important;
+  }`;
+export const horizontalScroll = {
+  flexDirection: 'row',
+  /* Firefox, IE */
+  scrollSnapTypeX: 'mandatory',
+  scrollSnapType: 'x mandatory',
+  /* Hide scrollbar */
+  paddingBottom: '20px',
+  overflowY: 'hidden',
+};

--- a/extensions/amp-base-carousel/1.0/base-carousel.css.js
+++ b/extensions/amp-base-carousel/1.0/base-carousel.css.js
@@ -44,11 +44,18 @@ export const scrollContainer = {
   scrollSnapType: 'x mandatory',
 };
 
-export const defaultArrowButton = {
+export const arrowPlacement = {
   position: 'absolute',
+  zIndex: 1,
+  display: 'flex',
+  flexDirection: 'row',
+  justifyContent: 'space-between',
   // Center the button vertically.
   top: '50%',
   transform: 'translateY(-50%)',
+};
+
+export const defaultArrowButton = {
   width: '32px',
   height: '32px',
   background: 'rgba(0, 0, 0, 0.25)',

--- a/extensions/amp-base-carousel/1.0/base-carousel.css.js
+++ b/extensions/amp-base-carousel/1.0/base-carousel.css.js
@@ -38,11 +38,9 @@ export const scrollContainer = {
   display: 'flex',
   flexDirection: 'row',
   flexWrap: 'nowrap',
-  // TBD: smooth behavior causes a lot of `setState` problems.
-  // scrollBehavior: 'smooth',
+  scrollBehavior: 'smooth',
   WebkitOverflowScrolling: 'touch',
   scrollSnapType: 'x mandatory',
-  scrollBehavior: 'smooth',
 };
 
 export const arrowPlacement = {

--- a/extensions/amp-base-carousel/1.0/base-carousel.js
+++ b/extensions/amp-base-carousel/1.0/base-carousel.js
@@ -16,7 +16,6 @@
 import * as Preact from '../../../src/preact';
 import {Arrow} from './arrow';
 import {Scroller} from './scroller';
-import {mod} from '../../../src/utils/math';
 import {toChildArray, useRef, useState} from '../../../src/preact';
 
 /**
@@ -39,7 +38,14 @@ export function BaseCarousel(props) {
     ignoreProgrammaticScroll.current = true;
     setCurSlide(i);
   };
-  const advance = (dir) => setRestingIndex(mod(curSlide + dir, length));
+  const scrollRef = useRef(null);
+  const advance = (dir) => {
+    const container = scrollRef.current;
+    // Modify scrollLeft is preferred to `setCurSlide` to enable smooth scroll.
+    // Note: `setCurSlide` will still be called on debounce by scroll handler.
+    container./* OK */ scrollLeft =
+      container./* OK */ scrollLeft + container./* OK */ offsetWidth * dir;
+  };
   const disableForDir = (dir) =>
     !loop && (curSlide + dir < 0 || curSlide + dir >= length);
   return (
@@ -49,6 +55,7 @@ export function BaseCarousel(props) {
         loop={loop}
         restingIndex={curSlide}
         setRestingIndex={setRestingIndex}
+        scrollRef={scrollRef}
       >
         {children}
       </Scroller>

--- a/extensions/amp-base-carousel/1.0/base-carousel.js
+++ b/extensions/amp-base-carousel/1.0/base-carousel.js
@@ -43,8 +43,7 @@ export function BaseCarousel(props) {
     const container = scrollRef.current;
     // Modify scrollLeft is preferred to `setCurSlide` to enable smooth scroll.
     // Note: `setCurSlide` will still be called on debounce by scroll handler.
-    container./* OK */ scrollLeft =
-      container./* OK */ scrollLeft + container./* OK */ offsetWidth * dir;
+    container./* OK */ scrollLeft += container./* OK */ offsetWidth * dir;
   };
   const disableForDir = (dir) =>
     !loop && (curSlide + dir < 0 || curSlide + dir >= length);

--- a/extensions/amp-base-carousel/1.0/base-carousel.js
+++ b/extensions/amp-base-carousel/1.0/base-carousel.js
@@ -1,0 +1,89 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as Preact from '../../../src/preact';
+import * as styles from './base-carousel.css';
+import {Scroller} from './scroller';
+import {useStateFromProp} from '../../../src/preact/utils';
+
+/**
+ * @param {!JsonObject} props
+ * @return {PreactDef.Renderable}
+ */
+export function BaseCarousel(props) {
+  const {style, arrowPrev, arrowNext, children, currentSlide} = props;
+  const {0: curSlide, 1: setCurSlide} = useStateFromProp(currentSlide || 0);
+
+  return (
+    <div style={style}>
+      <Scroller currentSlide={curSlide} setCurrentSlide={setCurSlide}>
+        {children}
+      </Scroller>
+      <Arrow
+        dir={-1}
+        currentSlide={curSlide}
+        setCurrentSlide={setCurSlide}
+        length={children.length}
+        customArrow={arrowPrev}
+      ></Arrow>
+      <Arrow
+        dir={1}
+        currentSlide={curSlide}
+        setCurrentSlide={setCurSlide}
+        length={children.length}
+        customArrow={arrowNext}
+      ></Arrow>
+    </div>
+  );
+}
+
+/**
+ * @param {!JsonObject} props
+ * @return {PreactDef.Renderable}
+ */
+export function Arrow(props) {
+  const {dir, currentSlide, setCurrentSlide, length, customArrow} = props;
+  const button = customArrow ? customArrow : DefaultArrow({dir});
+  const nextSlide = currentSlide + dir;
+  const {style = {}, children} = button.props;
+  return Preact.cloneElement(
+    button,
+    {
+      onClick: () => setCurrentSlide(currentSlide + dir),
+      disabled: nextSlide < 0 || nextSlide >= length,
+      style: style ? style : {},
+    },
+    children
+  );
+}
+
+/**
+ * @param {!JsonObject} props
+ * @return {PreactDef.Renderable}
+ */
+function DefaultArrow(props) {
+  const {dir} = props;
+  return (
+    <button
+      style={{
+        // Offset button from the edge.
+        [dir < 0 ? 'left' : 'right']: '8px',
+        ...styles.defaultArrowButton,
+      }}
+    >
+      {props.dir < 0 ? '<<' : '>>'}
+    </button>
+  );
+}

--- a/extensions/amp-base-carousel/1.0/base-carousel.js
+++ b/extensions/amp-base-carousel/1.0/base-carousel.js
@@ -16,7 +16,8 @@
 import * as Preact from '../../../src/preact';
 import {Arrow} from './arrow';
 import {Scroller} from './scroller';
-import {useRef, useState} from '../../../src/preact';
+import {mod} from '../../../src/utils/math';
+import {toChildArray, useRef, useState} from '../../../src/preact';
 
 /**
  * @param {!JsonObject} props
@@ -24,13 +25,16 @@ import {useRef, useState} from '../../../src/preact';
  */
 export function BaseCarousel(props) {
   const {style, arrowPrev, arrowNext, children, currentSlide, loop} = props;
+  const {length} = toChildArray(children);
   const {0: curSlide, 1: setCurSlide} = useState(currentSlide || 0);
   const ignoreProgrammaticScroll = useRef(true);
   const setRestingIndex = (i) => {
     ignoreProgrammaticScroll.current = true;
     setCurSlide(i);
   };
-
+  const advance = (dir) => setRestingIndex(mod(curSlide + dir, length));
+  const disableForDir = (dir) =>
+    !loop && (curSlide + dir < 0 || curSlide + dir >= length);
   return (
     <div style={style}>
       <Scroller
@@ -44,19 +48,15 @@ export function BaseCarousel(props) {
       <Arrow
         customArrow={arrowPrev}
         dir={-1}
-        length={children.length}
-        loop={loop}
-        restingIndex={curSlide}
-        setRestingIndex={setRestingIndex}
-      ></Arrow>
+        disabled={disableForDir(-1)}
+        onClick={() => advance(-1)}
+      />
       <Arrow
         customArrow={arrowNext}
         dir={1}
-        length={children.length}
-        loop={loop}
-        restingIndex={curSlide}
-        setRestingIndex={setRestingIndex}
-      ></Arrow>
+        disabled={disableForDir(1)}
+        onClick={() => advance(1)}
+      />
     </div>
   );
 }

--- a/extensions/amp-base-carousel/1.0/base-carousel.js
+++ b/extensions/amp-base-carousel/1.0/base-carousel.js
@@ -42,20 +42,20 @@ export function BaseCarousel(props) {
         {children}
       </Scroller>
       <Arrow
+        customArrow={arrowPrev}
         dir={-1}
+        length={children.length}
         loop={loop}
         restingIndex={curSlide}
         setRestingIndex={setRestingIndex}
-        length={children.length}
-        customArrow={arrowPrev}
       ></Arrow>
       <Arrow
+        customArrow={arrowNext}
         dir={1}
+        length={children.length}
         loop={loop}
         restingIndex={curSlide}
         setRestingIndex={setRestingIndex}
-        length={children.length}
-        customArrow={arrowNext}
       ></Arrow>
     </div>
   );

--- a/extensions/amp-base-carousel/1.0/base-carousel.js
+++ b/extensions/amp-base-carousel/1.0/base-carousel.js
@@ -27,12 +27,13 @@ export function BaseCarousel(props) {
     'arrowPrev': arrowPrev,
     'arrowNext': arrowNext,
     'children': children,
-    'currentSlide': currentSlide,
+    'defaultSlide': defaultSlide,
     'loop': loop,
     ...rest
   } = props;
-  const {length} = toChildArray(children);
-  const {0: curSlide, 1: setCurSlide} = useState(currentSlide || 0);
+  const childrenArray = toChildArray(children);
+  const {length} = childrenArray;
+  const [curSlide, setCurSlide] = useState(defaultSlide || 0);
   const ignoreProgrammaticScroll = useRef(true);
   const setRestingIndex = (i) => {
     ignoreProgrammaticScroll.current = true;
@@ -56,19 +57,19 @@ export function BaseCarousel(props) {
         setRestingIndex={setRestingIndex}
         scrollRef={scrollRef}
       >
-        {children}
+        {childrenArray}
       </Scroller>
       <Arrow
         customArrow={arrowPrev}
         dir={-1}
         disabled={disableForDir(-1)}
-        onClick={() => advance(-1)}
+        advance={() => advance(-1)}
       />
       <Arrow
         customArrow={arrowNext}
         dir={1}
         disabled={disableForDir(1)}
-        onClick={() => advance(1)}
+        advance={() => advance(1)}
       />
     </div>
   );

--- a/extensions/amp-base-carousel/1.0/base-carousel.js
+++ b/extensions/amp-base-carousel/1.0/base-carousel.js
@@ -14,11 +14,9 @@
  * limitations under the License.
  */
 import * as Preact from '../../../src/preact';
-import * as styles from './base-carousel.css';
+import {Arrow} from './arrow';
 import {Scroller} from './scroller';
-import {mod} from '../../../src/utils/math';
-import {useRef} from '../../../src/preact';
-import {useStateFromProp} from '../../../src/preact/utils';
+import {useRef, useState} from '../../../src/preact';
 
 /**
  * @param {!JsonObject} props
@@ -26,7 +24,7 @@ import {useStateFromProp} from '../../../src/preact/utils';
  */
 export function BaseCarousel(props) {
   const {style, arrowPrev, arrowNext, children, currentSlide, loop} = props;
-  const {0: curSlide, 1: setCurSlide} = useStateFromProp(currentSlide || 0);
+  const {0: curSlide, 1: setCurSlide} = useState(currentSlide || 0);
   const ignoreProgrammaticScroll = useRef(true);
   const setRestingIndex = (i) => {
     ignoreProgrammaticScroll.current = true;
@@ -60,52 +58,5 @@ export function BaseCarousel(props) {
         customArrow={arrowNext}
       ></Arrow>
     </div>
-  );
-}
-
-/**
- * @param {!JsonObject} props
- * @return {PreactDef.Renderable}
- */
-function Arrow(props) {
-  const {dir, restingIndex, setRestingIndex, length, customArrow, loop} = props;
-  const button = customArrow ? customArrow : DefaultArrow({dir});
-  const nextSlide = restingIndex + dir;
-  const {children, 'disabled': disabled, onClick, ...rest} = button.props;
-  const isDisabled =
-    disabled || (loop ? false : nextSlide < 0 || nextSlide >= length);
-  const handleClick = () => {
-    if (onClick) {
-      onClick();
-    }
-    setRestingIndex(mod(restingIndex + dir, length));
-  };
-  return Preact.cloneElement(
-    button,
-    {
-      onClick: handleClick,
-      disabled: isDisabled,
-      ...rest,
-    },
-    children
-  );
-}
-
-/**
- * @param {!JsonObject} props
- * @return {PreactDef.Renderable}
- */
-function DefaultArrow(props) {
-  const {dir} = props;
-  return (
-    <button
-      style={{
-        // Offset button from the edge.
-        [dir < 0 ? 'left' : 'right']: '8px',
-        ...styles.defaultArrowButton,
-      }}
-    >
-      {props.dir < 0 ? '<<' : '>>'}
-    </button>
   );
 }

--- a/extensions/amp-base-carousel/1.0/base-carousel.js
+++ b/extensions/amp-base-carousel/1.0/base-carousel.js
@@ -24,7 +24,14 @@ import {toChildArray, useRef, useState} from '../../../src/preact';
  * @return {PreactDef.Renderable}
  */
 export function BaseCarousel(props) {
-  const {style, arrowPrev, arrowNext, children, currentSlide, loop} = props;
+  const {
+    'arrowPrev': arrowPrev,
+    'arrowNext': arrowNext,
+    'children': children,
+    'currentSlide': currentSlide,
+    'loop': loop,
+    ...rest
+  } = props;
   const {length} = toChildArray(children);
   const {0: curSlide, 1: setCurSlide} = useState(currentSlide || 0);
   const ignoreProgrammaticScroll = useRef(true);
@@ -36,7 +43,7 @@ export function BaseCarousel(props) {
   const disableForDir = (dir) =>
     !loop && (curSlide + dir < 0 || curSlide + dir >= length);
   return (
-    <div style={style}>
+    <div {...rest}>
       <Scroller
         ignoreProgrammaticScroll={ignoreProgrammaticScroll}
         loop={loop}

--- a/extensions/amp-base-carousel/1.0/scroller.js
+++ b/extensions/amp-base-carousel/1.0/scroller.js
@@ -18,7 +18,7 @@ import * as styles from './base-carousel.css';
 import {WithAmpContext} from '../../../src/preact/context';
 import {debounce} from '../../../src/utils/rate-limit';
 import {mod} from '../../../src/utils/math';
-import {useLayoutEffect, useRef} from '../../../src/preact';
+import {toChildArray, useLayoutEffect, useRef} from '../../../src/preact';
 
 /**
  * How long to wait prior to resetting the scrolling position after the last
@@ -190,7 +190,7 @@ function renderSlides(props) {
   const {length} = children;
   const slides = [];
 
-  children.forEach((child, index) => {
+  toChildArray(children).forEach((child, index) => {
     const key = `slide-${child.key || index}`;
     slides.push(
       <WithAmpContext

--- a/extensions/amp-base-carousel/1.0/scroller.js
+++ b/extensions/amp-base-carousel/1.0/scroller.js
@@ -19,6 +19,7 @@ import {WithAmpContext} from '../../../src/preact/context';
 import {debounce} from '../../../src/utils/rate-limit';
 import {dict} from '../../../src/utils/object';
 import {mod} from '../../../src/utils/math';
+import {setStyle} from '../../../src/style';
 import {
   toChildArray,
   useLayoutEffect,
@@ -81,9 +82,11 @@ export function Scroller(props) {
     // TODO: We should use forwardRef to dedup scrollRef and containerRef.
     const container = (scrollRef.current = containerRef.current);
     ignoreProgrammaticScroll.current = true;
+    setStyle(container, 'scrollBehavior', 'auto');
     container./* OK */ scrollLeft = loop
       ? container./* OK */ offsetWidth * pivotIndex
       : container./* OK */ offsetWidth * restingIndex;
+    setStyle(container, 'scrollBehavior', 'smooth');
   }, [ignoreProgrammaticScroll, loop, restingIndex, pivotIndex, scrollRef]);
 
   // Trigger render by setting the resting index to the current scroll state.

--- a/extensions/amp-base-carousel/1.0/scroller.js
+++ b/extensions/amp-base-carousel/1.0/scroller.js
@@ -20,12 +20,7 @@ import {debounce} from '../../../src/utils/rate-limit';
 import {dict} from '../../../src/utils/object';
 import {mod} from '../../../src/utils/math';
 import {setStyle} from '../../../src/style';
-import {
-  toChildArray,
-  useLayoutEffect,
-  useMemo,
-  useRef,
-} from '../../../src/preact';
+import {useLayoutEffect, useMemo, useRef} from '../../../src/preact';
 
 /**
  * How long to wait prior to resetting the scrolling position after the last
@@ -43,7 +38,7 @@ const RESET_SCROLL_REFERENCE_POINT_WAIT_MS = 200;
  */
 export function Scroller(props) {
   const {
-    'children': children,
+    'children': children, // Must be an array.
     'ignoreProgrammaticScroll': ignoreProgrammaticScroll,
     'loop': loop,
     'restingIndex': restingIndex,
@@ -212,7 +207,7 @@ function renderSlides(props) {
   const {length} = children;
   const slides = [];
 
-  toChildArray(children).forEach((child, index) => {
+  children.forEach((child, index) => {
     const key = `slide-${child.key || index}`;
     slides.push(
       <WithAmpContext

--- a/extensions/amp-base-carousel/1.0/scroller.js
+++ b/extensions/amp-base-carousel/1.0/scroller.js
@@ -72,9 +72,9 @@ export function Scroller(props) {
     }
     const container = containerRef.current;
     ignoreProgrammaticScroll.current = true;
-    container /* OK */.scrollLeft = loop
-      ? container /* OK */.offsetWidth * pivotIndex
-      : container /* OK */.offsetWidth * restingIndex;
+    container./* OK */ scrollLeft = loop
+      ? container./* OK */ offsetWidth * pivotIndex
+      : container./* OK */ offsetWidth * restingIndex;
   }, [ignoreProgrammaticScroll, restingIndex, pivotIndex, loop]);
 
   // Trigger render by setting the resting index to the current scroll state.
@@ -99,9 +99,9 @@ export function Scroller(props) {
   const updateCurrentIndex = () => {
     const container = containerRef.current;
     const slideOffset = Math.round(
-      (container /* OK */.scrollLeft -
-        offsetRef.current * container /* OK */.offsetWidth) /
-        container /* OK */.offsetWidth
+      (container./* OK */ scrollLeft -
+        offsetRef.current * container./* OK */ offsetWidth) /
+        container./* OK */ offsetWidth
     );
     currentIndex.current = mod(slideOffset, children.length);
   };

--- a/extensions/amp-base-carousel/1.0/scroller.js
+++ b/extensions/amp-base-carousel/1.0/scroller.js
@@ -1,0 +1,81 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as Preact from '../../../src/preact';
+import * as styles from './base-carousel.css';
+import {WithAmpContext} from '../../../src/preact/context';
+import {useEffect, useLayoutEffect, useRef} from '../../../src/preact';
+
+/**
+ * @param {!JsonObject} props
+ * @return {PreactDef.Renderable}
+ */
+export function Scroller(props) {
+  const {children, onSlideChange, currentSlide, setCurrentSlide} = props;
+  const slides = children || [];
+  const containerRef = useRef();
+
+  // Note: this has to be useLayoutEffect, not useEffect.
+  useLayoutEffect(() => {
+    if (!containerRef.current) {
+      return;
+    }
+    const container = containerRef.current;
+    container /* OK */.scrollLeft =
+      container /* OK */.offsetWidth * currentSlide;
+  }, [currentSlide]);
+
+  // Event. Don't need to be render-blocking.
+  useEffect(() => {
+    if (onSlideChange) {
+      onSlideChange({currentSlide});
+    }
+  }, [currentSlide, onSlideChange]);
+
+  /**
+   *
+   */
+  function scrollHandler() {
+    // TBD: Is this a good idea to manage currentSlide via state? Amount of
+    // re-rendering is very small and mostly affects `scrollLeft`, which is
+    // not renderable at all.
+    // TBD: Ideally we need to wait for "scrollend" event, that's still WIP
+    // in most of browsers.
+    const container = containerRef.current;
+    const slide = Math.round(
+      container /* OK */.scrollLeft / container /* OK */.offsetWidth
+    );
+    setCurrentSlide(slide);
+  }
+
+  return (
+    <div
+      key="container"
+      ref={containerRef}
+      onScroll={scrollHandler}
+      style={styles.scrollContainer}
+    >
+      {slides.map((child, index) => (
+        <WithAmpContext
+          key={`slide-${child.key || index}`}
+          renderable={index == currentSlide}
+          playable={index == currentSlide}
+        >
+          <div style={styles.slideElement}>{child}</div>
+        </WithAmpContext>
+      ))}
+    </div>
+  );
+}

--- a/extensions/amp-base-carousel/1.0/scroller.js
+++ b/extensions/amp-base-carousel/1.0/scroller.js
@@ -17,6 +17,7 @@ import * as Preact from '../../../src/preact';
 import * as styles from './base-carousel.css';
 import {WithAmpContext} from '../../../src/preact/context';
 import {debounce} from '../../../src/utils/rate-limit';
+import {dict} from '../../../src/utils/object';
 import {mod} from '../../../src/utils/math';
 import {
   toChildArray,
@@ -41,11 +42,11 @@ const RESET_SCROLL_REFERENCE_POINT_WAIT_MS = 200;
  */
 export function Scroller(props) {
   const {
-    children,
-    ignoreProgrammaticScroll,
-    loop,
-    restingIndex,
-    setRestingIndex,
+    'children': children,
+    'ignoreProgrammaticScroll': ignoreProgrammaticScroll,
+    'loop': loop,
+    'restingIndex': restingIndex,
+    'setRestingIndex': setRestingIndex,
   } = props;
 
   /**
@@ -59,14 +60,16 @@ export function Scroller(props) {
    * is with respect to its scrolling order. Only needed if loop=true.
    */
   const offsetRef = useRef(restingIndex);
-  const containerRef = useRef();
-  const slides = renderSlides({
-    children,
-    loop,
-    offsetRef,
-    pivotIndex,
-    restingIndex,
-  });
+  const containerRef = useRef(null);
+  const slides = renderSlides(
+    dict({
+      'children': children,
+      'loop': loop,
+      'offsetRef': offsetRef,
+      'pivotIndex': pivotIndex,
+      'restingIndex': restingIndex,
+    })
+  );
   const currentIndex = useRef(restingIndex);
 
   // useLayoutEffect needed to avoid FOUC while scrolling
@@ -194,7 +197,13 @@ export function Scroller(props) {
  * @return {PreactDef.Renderable}
  */
 function renderSlides(props) {
-  const {children, restingIndex, offsetRef, pivotIndex, loop} = props;
+  const {
+    'children': children,
+    'restingIndex': restingIndex,
+    'offsetRef': offsetRef,
+    'pivotIndex': pivotIndex,
+    'loop': loop,
+  } = props;
   const {length} = children;
   const slides = [];
 

--- a/extensions/amp-base-carousel/1.0/scroller.js
+++ b/extensions/amp-base-carousel/1.0/scroller.js
@@ -16,16 +16,54 @@
 import * as Preact from '../../../src/preact';
 import * as styles from './base-carousel.css';
 import {WithAmpContext} from '../../../src/preact/context';
-import {useEffect, useLayoutEffect, useRef} from '../../../src/preact';
+import {debounce} from '../../../src/utils/rate-limit';
+import {mod} from '../../../src/utils/math';
+import {useLayoutEffect, useRef} from '../../../src/preact';
+
+/**
+ * How long to wait prior to resetting the scrolling position after the last
+ * scroll event. Ideally this should be low, so that once the user stops
+ * scrolling, things are immediately centered again. Since there can be some
+ * delay between scroll events, and we do not want to interrupt a scroll with a
+ * render, it cannot be too small. 200ms seems to be around the lower limit for
+ * this value on Android / iOS.
+ */
+const RESET_SCROLL_REFERENCE_POINT_WAIT_MS = 200;
 
 /**
  * @param {!JsonObject} props
  * @return {PreactDef.Renderable}
  */
 export function Scroller(props) {
-  const {children, onSlideChange, currentSlide, setCurrentSlide} = props;
-  const slides = children || [];
+  const {
+    children = [],
+    loop,
+    ignoreProgrammaticScroll,
+    restingIndex,
+    setRestingIndex,
+  } = props;
+
+  /**
+   * The number of slides we want to place before the
+   * reference or resting index. Only needed if loop=true.
+   */
+  const pivotIndex = Math.floor(children.length / 2);
+
+  /**
+   * The dynamic position that the slide at the resting index
+   * is with respect to its scrolling order. Only needed if loop=true.
+   */
+  const offsetRef = useRef(restingIndex);
   const containerRef = useRef();
+  const slides = Slides({
+    children,
+    restingIndex,
+    container: containerRef,
+    offsetRef,
+    pivotIndex,
+    loop,
+  });
+  const currentIndex = useRef(restingIndex);
 
   // Note: this has to be useLayoutEffect, not useEffect.
   useLayoutEffect(() => {
@@ -33,58 +71,163 @@ export function Scroller(props) {
       return;
     }
     const container = containerRef.current;
-    container /* OK */.scrollLeft =
-      container /* OK */.offsetWidth * currentSlide;
-  }, [currentSlide]);
+    ignoreProgrammaticScroll.current = true;
+    container /* OK */.scrollLeft = loop
+      ? container /* OK */.offsetWidth * pivotIndex
+      : container /* OK */.offsetWidth * restingIndex;
+  }, [ignoreProgrammaticScroll, restingIndex, pivotIndex, loop]);
 
-  // Event. Don't need to be render-blocking.
-  useEffect(() => {
-    if (onSlideChange) {
-      onSlideChange({currentSlide});
+  // Trigger render by setting the resting index to the current scroll state.
+  const resetScrollReferencePoint = () => {
+    // Check if the resting index we are centered around is the same as where
+    // we stopped scrolling. If so, we do not need to move anything.
+    if (currentIndex.current === restingIndex) {
+      return;
     }
-  }, [currentSlide, onSlideChange]);
+    setRestingIndex(currentIndex.current);
+  };
 
-  /**
-   *
-   */
-  function scrollHandler() {
-    // TBD: Is this a good idea to manage currentSlide via state? Amount of
-    // re-rendering is very small and mostly affects `scrollLeft`, which is
-    // not renderable at all.
-    // TBD: Ideally we need to wait for "scrollend" event, that's still WIP
-    // in most of browsers.
+  const debouncedResetScrollReferencePoint = debounce(
+    window,
+    resetScrollReferencePoint,
+    RESET_SCROLL_REFERENCE_POINT_WAIT_MS
+  );
+
+  // Track current slide without forcing render.
+  // This is necessary for smooth scrolling because
+  // intermediary renders will interupt scroll and cause jank.
+  const updateCurrentIndex = () => {
     const container = containerRef.current;
-    const slide = Math.round(
-      container /* OK */.scrollLeft / container /* OK */.offsetWidth
+    const slideOffset = Math.round(
+      (container /* OK */.scrollLeft -
+        offsetRef.current * container /* OK */.offsetWidth) /
+        container /* OK */.offsetWidth
     );
-    setCurrentSlide(slide);
-  }
+    currentIndex.current = mod(slideOffset, children.length);
+  };
+
+  const handleScroll = () => {
+    if (ignoreProgrammaticScroll.current) {
+      ignoreProgrammaticScroll.current = false;
+      return;
+    }
+    updateCurrentIndex();
+    debouncedResetScrollReferencePoint();
+  };
 
   return (
     <>
       <style>{styles.hideScrollbarPseudo}</style>
       <div
-        horizontal
         hide-scrollbar
         key="container"
         ref={containerRef}
-        onScroll={scrollHandler}
+        onScroll={handleScroll}
         style={{
           ...styles.scrollContainer,
           ...styles.hideScrollbar,
           ...styles.horizontalScroll,
         }}
+        tabindex={0}
       >
-        {slides.map((child, index) => (
-          <WithAmpContext
-            key={`slide-${child.key || index}`}
-            renderable={index == currentSlide}
-            playable={index == currentSlide}
-          >
-            <div style={styles.slideElement}>{child}</div>
-          </WithAmpContext>
-        ))}
+        {slides}
       </div>
+    </>
+  );
+}
+
+/**
+ * How the slides are ordered when looping:
+ *
+ * We want to make sure that the user can scroll all the way to the opposite
+ * end (either forwards or backwards) of the carousel, but no further (no
+ * looping back past where you started). We render elements dynamically
+ * for a desirable scrolling order to allow the browser to scroll as well as
+ * providing targets for the browser to snap on. This is important as these
+ * targets need to be present before the scroll starts for things to work
+ * correctly.
+ *
+ * The elements are ordered depending on the reference point, called
+ * the restingIndex to allow full movement forwards and backwards. You can
+ * imagine the DOM structure looks like the following if you have 5 slides:
+ *
+ * [1][2][3][4][5]
+ *
+ * When the restingIndex is the first index, we should translate slides as follows:
+ *
+ * [4][5][1][2][3]
+ *
+ * This ensures that if you move left or right, there is a slide to show.
+ *
+ * When the user stops scrolling, we update the restingIndex and show/hide the
+ * appropriate spacers. For example, if the user started at slide '1' and moved
+ * left to slide '4', the UI would eventually stop because there is
+ * nothing more to the left of slide '4'.
+ *
+ * [4][5][1][2][3]
+ *
+ * Once scrolling stops, however, the reference point would be reset and this would
+ * update to the following with the next render:
+ *
+ * [2][3][4][5][1]
+ *
+ * Ordering slides:
+ *
+ * Slides are ordered to be before or after the current slide and do not rearrange
+ * dynamically as the user scrolls. Only once the scrolling has ended do they rearrange.
+ * Currently, half the slides are ordered before and half the slides are ordered after.
+ * This could be a bit smarter and only place as many as are necessary on either side of
+ * the reference point to have a sufficient amount of buffer.
+ *
+ * Initial index:
+ *
+ * The initial index can be specified, which will make the carousel scroll to
+ * the desired index when it first renders.
+ *
+ * @param {!JsonObject} props
+ * @return {PreactDef.Renderable}
+ */
+function Slides(props) {
+  const {children, restingIndex, offsetRef, pivotIndex, loop} = props;
+  const {length} = children;
+  const slides = [];
+
+  children.forEach((child, index) => {
+    const key = `slide-${child.key || index}`;
+    slides.push(
+      <WithAmpContext
+        key={key}
+        renderable={index == restingIndex}
+        playable={index == restingIndex}
+      >
+        <div style={styles.slideElement}>{child}</div>
+      </WithAmpContext>
+    );
+  });
+
+  if (!loop) {
+    return slides;
+  }
+
+  const before = [];
+  const after = [];
+  const shift = mod(length - restingIndex + pivotIndex, length);
+  if (restingIndex <= pivotIndex) {
+    for (let i = 0; i < shift; i++) {
+      before.unshift(slides.pop());
+    }
+  } else {
+    for (let i = 0; i < length - shift; i++) {
+      after.push(slides.shift());
+    }
+  }
+
+  offsetRef.current = before.length ? before.length : -after.length;
+  return (
+    <>
+      {before}
+      {slides}
+      {after}
     </>
   );
 }

--- a/extensions/amp-base-carousel/1.0/scroller.js
+++ b/extensions/amp-base-carousel/1.0/scroller.js
@@ -61,21 +61,30 @@ export function Scroller(props) {
   }
 
   return (
-    <div
-      key="container"
-      ref={containerRef}
-      onScroll={scrollHandler}
-      style={styles.scrollContainer}
-    >
-      {slides.map((child, index) => (
-        <WithAmpContext
-          key={`slide-${child.key || index}`}
-          renderable={index == currentSlide}
-          playable={index == currentSlide}
-        >
-          <div style={styles.slideElement}>{child}</div>
-        </WithAmpContext>
-      ))}
-    </div>
+    <>
+      <style>{styles.hideScrollbarPseudo}</style>
+      <div
+        horizontal
+        hide-scrollbar
+        key="container"
+        ref={containerRef}
+        onScroll={scrollHandler}
+        style={{
+          ...styles.scrollContainer,
+          ...styles.hideScrollbar,
+          ...styles.horizontalScroll,
+        }}
+      >
+        {slides.map((child, index) => (
+          <WithAmpContext
+            key={`slide-${child.key || index}`}
+            renderable={index == currentSlide}
+            playable={index == currentSlide}
+          >
+            <div style={styles.slideElement}>{child}</div>
+          </WithAmpContext>
+        ))}
+      </div>
+    </>
   );
 }

--- a/extensions/amp-base-carousel/1.0/scroller.js
+++ b/extensions/amp-base-carousel/1.0/scroller.js
@@ -36,9 +36,9 @@ const RESET_SCROLL_REFERENCE_POINT_WAIT_MS = 200;
  */
 export function Scroller(props) {
   const {
-    children = [],
-    loop,
+    children,
     ignoreProgrammaticScroll,
+    loop,
     restingIndex,
     setRestingIndex,
   } = props;
@@ -55,13 +55,12 @@ export function Scroller(props) {
    */
   const offsetRef = useRef(restingIndex);
   const containerRef = useRef();
-  const slides = Slides({
+  const slides = renderSlides({
     children,
-    restingIndex,
-    container: containerRef,
+    loop,
     offsetRef,
     pivotIndex,
-    loop,
+    restingIndex,
   });
   const currentIndex = useRef(restingIndex);
 
@@ -75,7 +74,7 @@ export function Scroller(props) {
     container./* OK */ scrollLeft = loop
       ? container./* OK */ offsetWidth * pivotIndex
       : container./* OK */ offsetWidth * restingIndex;
-  }, [ignoreProgrammaticScroll, restingIndex, pivotIndex, loop]);
+  }, [ignoreProgrammaticScroll, loop, restingIndex, pivotIndex]);
 
   // Trigger render by setting the resting index to the current scroll state.
   const resetScrollReferencePoint = () => {
@@ -86,7 +85,6 @@ export function Scroller(props) {
     }
     setRestingIndex(currentIndex.current);
   };
-
   const debouncedResetScrollReferencePoint = debounce(
     window,
     resetScrollReferencePoint,
@@ -187,7 +185,7 @@ export function Scroller(props) {
  * @param {!JsonObject} props
  * @return {PreactDef.Renderable}
  */
-function Slides(props) {
+function renderSlides(props) {
   const {children, restingIndex, offsetRef, pivotIndex, loop} = props;
   const {length} = children;
   const slides = [];

--- a/extensions/amp-base-carousel/1.0/scroller.js
+++ b/extensions/amp-base-carousel/1.0/scroller.js
@@ -47,6 +47,7 @@ export function Scroller(props) {
     'loop': loop,
     'restingIndex': restingIndex,
     'setRestingIndex': setRestingIndex,
+    'scrollRef': scrollRef,
   } = props;
 
   /**
@@ -77,12 +78,13 @@ export function Scroller(props) {
     if (!containerRef.current) {
       return;
     }
-    const container = containerRef.current;
+    // TODO: We should use forwardRef to dedup scrollRef and containerRef.
+    const container = (scrollRef.current = containerRef.current);
     ignoreProgrammaticScroll.current = true;
     container./* OK */ scrollLeft = loop
       ? container./* OK */ offsetWidth * pivotIndex
       : container./* OK */ offsetWidth * restingIndex;
-  }, [ignoreProgrammaticScroll, loop, restingIndex, pivotIndex]);
+  }, [ignoreProgrammaticScroll, loop, restingIndex, pivotIndex, scrollRef]);
 
   // Trigger render by setting the resting index to the current scroll state.
   const debouncedResetScrollReferencePoint = useMemo(

--- a/extensions/amp-base-carousel/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-base-carousel/1.0/storybook/Basic.amp.js
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as Preact from '../../../../src/preact';
+import {storiesOf} from '@storybook/preact';
+import {withA11y} from '@storybook/addon-a11y';
+import {withKnobs} from '@storybook/addon-knobs';
+import withAmp from '../../../../build-system/tasks/storybook/amp-env/decorator.js';
+
+// eslint-disable-next-line
+storiesOf('amp-base-carousel', module)
+  .addDecorator(withKnobs)
+  .addDecorator(withA11y)
+  .addDecorator(withAmp)
+  .addParameters({extensions: [{name: 'amp-base-carousel', version: '0.1'}]})
+  .add('default', () => {
+    return (
+      <amp-base-carousel width="440" height="225">
+        {['lightcoral', 'peachpuff', 'lavender'].map((color) => (
+          <amp-layout width="440" height="225">
+            <svg viewBox="0 0 440 225">
+              <rect style={{fill: color}} width="440" height="225" />
+              Sorry, your browser does not support inline SVG.
+            </svg>
+          </amp-layout>
+        ))}
+      </amp-base-carousel>
+    );
+  });

--- a/extensions/amp-base-carousel/1.0/storybook/Basic.js
+++ b/extensions/amp-base-carousel/1.0/storybook/Basic.js
@@ -76,14 +76,25 @@ export const WithLooping = () => {
       style={{width, height, position: 'relative'}}
     >
       {[
+        'lightpink',
         'lightcoral',
         'peachpuff',
+        'powderblue',
         'lavender',
-        'azure',
-        'honeydew',
-        'rebeccapurple',
-      ].map((color) => (
-        <div style={{backgroundColor: color, width, height}}></div>
+        'thistle',
+      ].map((color, index) => (
+        <div
+          style={{
+            backgroundColor: color,
+            width,
+            height,
+            textAlign: 'center',
+            fontSize: '48pt',
+            lineHeight: height + 'px',
+          }}
+        >
+          {index}
+        </div>
       ))}
     </BaseCarousel>
   );

--- a/extensions/amp-base-carousel/1.0/storybook/Basic.js
+++ b/extensions/amp-base-carousel/1.0/storybook/Basic.js
@@ -28,7 +28,7 @@ export default {
 export const _default = () => {
   const width = number('width', 440);
   const height = number('height', 225);
-  const slideCount = number('slide count', 1, {min: 0, max: 99});
+  const slideCount = number('slide count', 5, {min: 0, max: 99});
   const colorIncrement = Math.floor(255 / (slideCount + 1));
   return (
     <BaseCarousel style={{width, height, position: 'relative'}}>

--- a/extensions/amp-base-carousel/1.0/storybook/Basic.js
+++ b/extensions/amp-base-carousel/1.0/storybook/Basic.js
@@ -28,11 +28,18 @@ export default {
 export const _default = () => {
   const width = number('width', 440);
   const height = number('height', 225);
+  const slideCount = number('slide count', 1, {min: 0, max: 99});
+  const colorIncrement = Math.floor(255 / (slideCount + 1));
   return (
     <BaseCarousel style={{width, height, position: 'relative'}}>
-      {['lightcoral', 'peachpuff', 'lavender'].map((color) => (
-        <div style={{backgroundColor: color, width, height}}></div>
-      ))}
+      {Array.from({length: slideCount}, (x, i) => {
+        const v = colorIncrement * (i + 1);
+        return (
+          <div
+            style={{backgroundColor: `rgb(${v}, 100, 100)`, width, height}}
+          ></div>
+        );
+      })}
     </BaseCarousel>
   );
 };

--- a/extensions/amp-base-carousel/1.0/storybook/Basic.js
+++ b/extensions/amp-base-carousel/1.0/storybook/Basic.js
@@ -40,23 +40,19 @@ export const _default = () => {
 export const provideArrows = () => {
   const width = number('width', 440);
   const height = number('height', 225);
-  const myButtonStyle = (side) => ({
+  const myButtonStyle = {
     background: 'lightblue',
     borderRadius: '50%',
     fontSize: 14,
     color: 'white',
-    bottom: 0,
-    [side]: 0,
     width: '30px',
     height: '30px',
-    position: 'absolute',
-    textAlign: 'center',
-  });
+  };
   return (
     <BaseCarousel
       style={{width, height, position: 'relative'}}
-      arrowPrev={<button style={myButtonStyle('left')}>←</button>}
-      arrowNext={<button style={myButtonStyle('right')}>→</button>}
+      arrowPrev={<button style={myButtonStyle}>←</button>}
+      arrowNext={<button style={myButtonStyle}>→</button>}
     >
       {['lightcoral', 'peachpuff', 'lavender'].map((color) => (
         <div style={{backgroundColor: color, width, height}}></div>

--- a/extensions/amp-base-carousel/1.0/storybook/Basic.js
+++ b/extensions/amp-base-carousel/1.0/storybook/Basic.js
@@ -43,29 +43,20 @@ export const provideArrows = () => {
   const myButtonStyle = (side) => ({
     background: 'lightblue',
     borderRadius: '50%',
-    fontSize: 20,
+    fontSize: 14,
     color: 'white',
     bottom: 0,
     [side]: 0,
     width: '30px',
     height: '30px',
     position: 'absolute',
-    lineHeight: '30px',
     textAlign: 'center',
   });
   return (
     <BaseCarousel
       style={{width, height, position: 'relative'}}
-      arrowPrev={
-        <div role="button" style={myButtonStyle('left')}>
-          ←
-        </div>
-      }
-      arrowNext={
-        <div role="button" style={myButtonStyle('right')}>
-          →
-        </div>
-      }
+      arrowPrev={<button style={myButtonStyle('left')}>←</button>}
+      arrowNext={<button style={myButtonStyle('right')}>→</button>}
     >
       {['lightcoral', 'peachpuff', 'lavender'].map((color) => (
         <div style={{backgroundColor: color, width, height}}></div>

--- a/extensions/amp-base-carousel/1.0/storybook/Basic.js
+++ b/extensions/amp-base-carousel/1.0/storybook/Basic.js
@@ -64,3 +64,27 @@ export const provideArrows = () => {
     </BaseCarousel>
   );
 };
+
+export const WithLooping = () => {
+  const width = number('width', 440);
+  const height = number('height', 225);
+  const currentSlide = number('currentSlide', 0);
+  return (
+    <BaseCarousel
+      currentSlide={currentSlide}
+      loop
+      style={{width, height, position: 'relative'}}
+    >
+      {[
+        'lightcoral',
+        'peachpuff',
+        'lavender',
+        'azure',
+        'honeydew',
+        'rebeccapurple',
+      ].map((color) => (
+        <div style={{backgroundColor: color, width, height}}></div>
+      ))}
+    </BaseCarousel>
+  );
+};

--- a/extensions/amp-base-carousel/1.0/storybook/Basic.js
+++ b/extensions/amp-base-carousel/1.0/storybook/Basic.js
@@ -1,0 +1,75 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as Preact from '../../../../src/preact';
+import {BaseCarousel} from '../base-carousel';
+import {number, withKnobs} from '@storybook/addon-knobs';
+import {withA11y} from '@storybook/addon-a11y';
+
+export default {
+  title: 'BaseCarousel',
+  component: BaseCarousel,
+  decorators: [withA11y, withKnobs],
+};
+
+export const _default = () => {
+  const width = number('width', 440);
+  const height = number('height', 225);
+  return (
+    <BaseCarousel style={{width, height, position: 'relative'}}>
+      {['lightcoral', 'peachpuff', 'lavender'].map((color) => (
+        <div style={{backgroundColor: color, width, height}}></div>
+      ))}
+    </BaseCarousel>
+  );
+};
+
+export const provideArrows = () => {
+  const width = number('width', 440);
+  const height = number('height', 225);
+  const myButtonStyle = (side) => ({
+    background: 'lightblue',
+    borderRadius: '50%',
+    fontSize: 20,
+    color: 'white',
+    bottom: 0,
+    [side]: 0,
+    width: '30px',
+    height: '30px',
+    position: 'absolute',
+    lineHeight: '30px',
+    textAlign: 'center',
+  });
+  return (
+    <BaseCarousel
+      style={{width, height, position: 'relative'}}
+      arrowPrev={
+        <div role="button" style={myButtonStyle('left')}>
+          ←
+        </div>
+      }
+      arrowNext={
+        <div role="button" style={myButtonStyle('right')}>
+          →
+        </div>
+      }
+    >
+      {['lightcoral', 'peachpuff', 'lavender'].map((color) => (
+        <div style={{backgroundColor: color, width, height}}></div>
+      ))}
+    </BaseCarousel>
+  );
+};

--- a/extensions/amp-base-carousel/1.0/storybook/Basic.js
+++ b/extensions/amp-base-carousel/1.0/storybook/Basic.js
@@ -71,10 +71,10 @@ export const provideArrows = () => {
 export const WithLooping = () => {
   const width = number('width', 440);
   const height = number('height', 225);
-  const currentSlide = number('currentSlide', 0);
+  const defaultSlide = number('default slide', 0);
   return (
     <BaseCarousel
-      currentSlide={currentSlide}
+      defaultSlide={defaultSlide}
       loop
       style={{width, height, position: 'relative'}}
     >

--- a/extensions/amp-base-carousel/1.0/test/test-base-carousel.js
+++ b/extensions/amp-base-carousel/1.0/test/test-base-carousel.js
@@ -32,7 +32,9 @@ describes.sandboxed('BaseCarousel preact component', {}, () => {
 
     const scroller = wrapper.find('Scroller');
     expect(scroller).to.have.lengthOf(1);
-    expect(scroller.props().children).to.equal(wrapper.props().children);
+    expect(scroller.props().children).to.have.ordered.members(
+      wrapper.props().children
+    );
   });
 
   it('should render custom Arrows when given', () => {

--- a/extensions/amp-base-carousel/1.0/test/test-base-carousel.js
+++ b/extensions/amp-base-carousel/1.0/test/test-base-carousel.js
@@ -1,0 +1,90 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as Preact from '../../../../src/preact';
+import {BaseCarousel} from '../base-carousel';
+import {mount} from 'enzyme';
+
+describes.sandboxed('BaseCarousel preact component', {}, () => {
+  it('should render Arrows and propagates children to Scroller', () => {
+    const jsx = (
+      <BaseCarousel>
+        <div>slide 1</div>
+        <div>slide 2</div>
+        <div>slide 3</div>
+      </BaseCarousel>
+    );
+    const wrapper = mount(jsx);
+    expect(wrapper.find('Arrow')).to.have.lengthOf(2);
+
+    const scroller = wrapper.find('Scroller');
+    expect(scroller).to.have.lengthOf(1);
+    expect(scroller.props().children).to.equal(wrapper.props().children);
+  });
+
+  it('should render custom Arrows when given', () => {
+    const arrowPrev = <div class="my-custom-arrow-prev">left</div>;
+    const arrowNext = <div class="my-custom-arrow-next">right</div>;
+    const jsx = (
+      <BaseCarousel arrowPrev={arrowPrev} arrowNext={arrowNext}>
+        <div>slide 1</div>
+        <div>slide 2</div>
+        <div>slide 3</div>
+      </BaseCarousel>
+    );
+    const wrapper = mount(jsx);
+    const arrows = wrapper.find('Arrow');
+    expect(arrows).to.have.lengthOf(2);
+    expect(arrows.first().props().customArrow).to.equal(arrowPrev);
+    expect(arrows.last().props().customArrow).to.equal(arrowNext);
+  });
+
+  it('should not loop by default', () => {
+    const jsx = (
+      <BaseCarousel>
+        <div class="my-slide">slide 1</div>
+        <div class="my-slide">slide 2</div>
+        <div class="my-slide">slide 3</div>
+      </BaseCarousel>
+    );
+    const wrapper = mount(jsx);
+    const slides = wrapper.find('div.my-slide');
+    expect(slides).to.have.lengthOf(3);
+
+    // Given slides [1][2][3] should be rendered as is
+    expect(slides.first().text()).to.equal('slide 1');
+    expect(slides.at(1).text()).to.equal('slide 2');
+    expect(slides.last().text()).to.equal('slide 3');
+  });
+
+  it('should render in preparation for looping with loop prop', () => {
+    const jsx = (
+      <BaseCarousel loop>
+        <div class="my-slide">slide 1</div>
+        <div class="my-slide">slide 2</div>
+        <div class="my-slide">slide 3</div>
+      </BaseCarousel>
+    );
+    const wrapper = mount(jsx);
+    const slides = wrapper.find('div.my-slide');
+    expect(slides).to.have.lengthOf(3);
+
+    // Given slides [1][2][3] should be rendered as [3][1][2]
+    expect(slides.first().text()).to.equal('slide 3');
+    expect(slides.at(1).text()).to.equal('slide 1');
+    expect(slides.last().text()).to.equal('slide 2');
+  });
+});

--- a/src/preact/index.js
+++ b/src/preact/index.js
@@ -31,6 +31,16 @@ export function createElement(unusedType, unusedProps, var_args) {
 }
 
 /**
+ * @param {!PreactDef.VNode} unusedElement
+ * @param {(!Object|null)=} unusedProps
+ * @param {...PreactDef.Renderable} unusedChildren
+ * @return {!PreactDef.VNode}
+ */
+export function cloneElement(unusedElement, unusedProps, unusedChildren) {
+  return preact.cloneElement.apply(undefined, arguments);
+}
+
+/**
  * @param {!PreactDef.VNode} vnode
  * @param {Node} container
  */

--- a/src/preact/index.js
+++ b/src/preact/index.js
@@ -18,7 +18,7 @@ import * as hooks from /*OK*/ 'preact/hooks';
 import * as preact from /*OK*/ 'preact';
 
 // Defines the type interfaces for the approved Preact APIs.
-// TODO: hydrate, isValidElement, Component, cloneElement, toChildArray
+// TODO: hydrate, isValidElement, Component
 
 /**
  * @param {!PreactDef.FunctionalComponent|string} unusedType
@@ -135,4 +135,12 @@ export function useMemo(cb, opt_deps) {
  */
 export function useCallback(cb, opt_deps) {
   return hooks.useCallback(cb, opt_deps);
+}
+
+/**
+ * @param {PreactDef.Renderable} unusedChildren
+ * @return {!Array<PreactDef.Renderable>}
+ */
+export function toChildArray(unusedChildren) {
+  return preact.toChildArray.apply(undefined, arguments);
 }

--- a/src/preact/index.js
+++ b/src/preact/index.js
@@ -138,7 +138,7 @@ export function useCallback(cb, opt_deps) {
 }
 
 /**
- * @param {PreactDef.Renderable} unusedChildren
+ * @param {!PreactDef.Renderable} unusedChildren
  * @return {!Array<PreactDef.Renderable>}
  */
 export function toChildArray(unusedChildren) {

--- a/src/preact/utils.js
+++ b/src/preact/utils.js
@@ -15,7 +15,13 @@
  */
 
 import {getAmpContext} from './context';
-import {useContext, useEffect, useLayoutEffect} from './index';
+import {
+  useContext,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from './index';
 
 /**
  * @param {function()} callback
@@ -48,4 +54,34 @@ export function useResourcesNotify() {
       notify();
     }
   });
+}
+
+/**
+ * Experimental hook to sync a state based on a property. The state is:
+ * - Initialized from the property;
+ * - Updated independently of the property when property is unchaged;
+ * - Reset to the new property value when the property is updated.
+ * @param {S|function():S} prop
+ * @return {{0: S, 1: function((S|function(S):S)):undefined}}
+ * @template S
+ */
+export function useStateFromProp(prop) {
+  const valueRef = useRef(prop);
+  const prevPropRef = useRef(prop);
+  const [, setCounter] = useState(0);
+  if (!Object.is(prop, prevPropRef.current)) {
+    valueRef.current = prevPropRef.current = prop;
+  }
+  return {
+    0: valueRef.current,
+    // TBD/TODO: make a stable function. Per React's docs:
+    // "React guarantees that setState function identity is stable and won't
+    // change on re-renders."
+    1: function set(value) {
+      if (!Object.is(value, valueRef.current)) {
+        valueRef.current = value;
+        setCounter((state) => state + 1);
+      }
+    },
+  };
 }

--- a/src/preact/utils.js
+++ b/src/preact/utils.js
@@ -15,13 +15,7 @@
  */
 
 import {getAmpContext} from './context';
-import {
-  useContext,
-  useEffect,
-  useLayoutEffect,
-  useRef,
-  useState,
-} from './index';
+import {useContext, useEffect, useLayoutEffect} from './index';
 
 /**
  * @param {function()} callback
@@ -54,34 +48,4 @@ export function useResourcesNotify() {
       notify();
     }
   });
-}
-
-/**
- * Experimental hook to sync a state based on a property. The state is:
- * - Initialized from the property;
- * - Updated independently of the property when property is unchaged;
- * - Reset to the new property value when the property is updated.
- * @param {S|function():S} prop
- * @return {{0: S, 1: function((S|function(S):S)):undefined}}
- * @template S
- */
-export function useStateFromProp(prop) {
-  const valueRef = useRef(prop);
-  const prevPropRef = useRef(prop);
-  const [, setCounter] = useState(0);
-  if (!Object.is(prop, prevPropRef.current)) {
-    valueRef.current = prevPropRef.current = prop;
-  }
-  return {
-    0: valueRef.current,
-    // TBD/TODO: make a stable function. Per React's docs:
-    // "React guarantees that setState function identity is stable and won't
-    // change on re-renders."
-    1: function set(value) {
-      if (!Object.is(value, valueRef.current)) {
-        valueRef.current = value;
-        setCounter((state) => state + 1);
-      }
-    },
-  };
 }


### PR DESCRIPTION
This PR makes the following changes:

- [x] Create AMP and Preact Storybook examples
- [x] Bring in [amp-react-carousel.js](https://github.com/ampproject/amp-react-prototype/blob/master/src/amp-react-carousel.js) as a rough prototype for the `BaseCarousel` Preact component which builds off of `Scroller` and `Arrow`
- [x] Integrate `Scroller` with `extensions/amp-base-carousel/0.1/carousel.js` looping logic class in the Preact pattern

I would recommend the following item to be split up into subsequent PRs by logical chunks.
- [ ] Expose a basic subset of the [documented AMP attributes](https://amp.dev/documentation/components/amp-base-carousel/) as `props` for `BaseCarousel`; existing attributes in addition to the already implemented `loop`:
    - `mixed-length`, `visible-count`, `advance-count`, `auto-advance`, `auto-advance-count`, `auto-advance-interval`, `auto-advance-loops`, `snap`, `snap-align`, `snap-by`, `slide`, `horizontal`
- [ ] Style default arrows similarly to existing ones on `amp-base-carousel`