### PR TITLE
Fix single-pass module dependency finding

### DIFF
--- a/build-system/babel-config/single-pass-config.js
+++ b/build-system/babel-config/single-pass-config.js
@@ -44,7 +44,17 @@ function getSinglePassPostConfig() {
  */
 function getSinglePassDepsConfig() {
   const singlePassDepsConfig = getPreClosureConfig();
-  singlePassDepsConfig.plugins.push('transform-es2015-modules-commonjs');
+  singlePassDepsConfig.presets = [
+    [
+      '@babel/preset-env',
+      {
+        'targets': {
+          'esmodules': true,
+        },
+        'modules': 'commonjs',
+      },
+    ],
+  ];
   return singlePassDepsConfig;
 }
 


### PR DESCRIPTION
Single pass' module-deps finding doesn't understand all of the latest syntax (I think it's using acorn parser, which lags behind ES syntax a little). So, have browserify transform the latest syntax before sending it to module-deps.

Fixes https://github.com/ampproject/amphtml/issues/28432.