### PR TITLE
🐛 Don't attempt to unhide the body for expected errors.

### DIFF
--- a/src/error.js
+++ b/src/error.js
@@ -311,8 +311,8 @@ export function installErrorReporting(win) {
  * @this {!Window|undefined}
  */
 function onError(message, filename, line, col, error) {
-  // Make an attempt to unhide the body.
-  if (this && this.document) {
+  // Make an attempt to unhide the body but don't if the error is actually expected.
+  if (this && this.document && (!error || !error.expected)) {
     makeBodyVisibleRecovery(this.document);
   }
   if (getMode().localDev || getMode().development || getMode().test) {


### PR DESCRIPTION
Fixes #28649

However, we still need to investigate why there is an "expected error" on every story page load.