### PR TITLE
Enable 'intersect-resources' on 10% of prod

### DIFF
--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -30,6 +30,7 @@
   "fixed-elements-in-lightbox": 1,
   "flexAdSlots": 0.05,
   "hidden-mutation-observer": 1,
+  "intersect-resources": 0.1,
   "ios-fixed-no-transfer": 0,
   "layoutbox-invalidate-on-scroll": 1,
   "pump-early-frame": 1,


### PR DESCRIPTION
Partial for #25428.

CSI graphs look good and ad metrics are neutral. Did some manual testing on Chrome desktop on Safari iOS on the Top Stories/Visual Stories carousels and amp.dev. 