### PR TITLE
♿ Assign correct aria-role to tooltips and give them focus.

### DIFF
--- a/extensions/amp-story/1.0/amp-story-embedded-component.js
+++ b/extensions/amp-story/1.0/amp-story-embedded-component.js
@@ -32,7 +32,12 @@ import {EventType, dispatch} from './events';
 import {Keys} from '../../../src/utils/key-codes';
 import {LocalizedStringId} from '../../../src/localized-strings';
 import {Services} from '../../../src/services';
-import {addAttributesToElement, closest, matches} from '../../../src/dom';
+import {
+  addAttributesToElement,
+  closest,
+  matches,
+  tryFocus,
+} from '../../../src/dom';
 import {createShadowRootWithStyle, getSourceOriginForElement} from './utils';
 import {dev, devAssert, user, userAssert} from '../../../src/log';
 import {dict} from '../../../src/utils/object';

--- a/extensions/amp-story/1.0/amp-story-embedded-component.js
+++ b/extensions/amp-story/1.0/amp-story-embedded-component.js
@@ -786,7 +786,9 @@ export class AmpStoryEmbeddedComponent {
       () => {
         this.focusedStateOverlay_.classList.toggle('i-amphtml-hidden', false);
         tryFocus(
-          this.focusedStateOverlay_.querySelector('a.i-amphtml-story-tooltip')
+          dev().assertElement(
+            this.focusedStateOverlay_.querySelector('a.i-amphtml-story-tooltip')
+          )
         );
       }
     );

--- a/extensions/amp-story/1.0/amp-story-embedded-component.js
+++ b/extensions/amp-story/1.0/amp-story-embedded-component.js
@@ -780,6 +780,9 @@ export class AmpStoryEmbeddedComponent {
       dev().assertElement(this.focusedStateOverlay_),
       () => {
         this.focusedStateOverlay_.classList.toggle('i-amphtml-hidden', false);
+        tryFocus(
+          this.focusedStateOverlay_.querySelector('a.i-amphtml-story-tooltip')
+        );
       }
     );
   }
@@ -1356,7 +1359,12 @@ export class AmpStoryEmbeddedComponent {
                     i-amphtml-story-tooltip-nav-button-right"
           ></button>
         </div>
-        <a class="i-amphtml-story-tooltip" target="_blank" ref="tooltip">
+        <a
+          class="i-amphtml-story-tooltip"
+          target="_blank"
+          ref="tooltip"
+          role="tooltip"
+        >
           <div class="i-amphtml-story-tooltip-custom-icon"></div>
           <p class="i-amphtml-tooltip-text" ref="text"></p>
           <div class="i-amphtml-tooltip-action-icon"></div>


### PR DESCRIPTION
- I think the role should be preferred over a custom label.
- Adding focus fixes keyboard navigation of links.

Fixes #25729
