### PR TITLE
gulp performance: force headless/devtools to bool

### DIFF
--- a/build-system/tasks/performance/load-config.js
+++ b/build-system/tasks/performance/load-config.js
@@ -50,12 +50,8 @@ function loadConfig() {
   if (Object.keys(config.urlToHandlers).length < 1) {
     throw new Error('No URLs found in config.');
   }
-  if (argv.headless) {
-    config.headless = true;
-  }
-  if (argv.devtools) {
-    config.devtools = true;
-  }
+  config.headless = !!argv.headless;
+  config.devtools = !!argv.devtools;
 
   maybeExtractAdsUrls(config);
   return config;

--- a/build-system/tasks/performance/measure-documents.js
+++ b/build-system/tasks/performance/measure-documents.js
@@ -297,8 +297,8 @@ function writeMetrics(url, version, metrics) {
  */
 async function measureDocument(url, version, config) {
   const browser = await puppeteer.launch({
-    headless: config.headless,
-    devtools: config.devtools,
+    headless: !!config.headless,
+    devtools: !!config.devtools,
     args: [
       '--allow-file-access-from-files',
       '--enable-blink-features=LayoutInstabilityAPI',

--- a/build-system/tasks/performance/measure-documents.js
+++ b/build-system/tasks/performance/measure-documents.js
@@ -297,8 +297,8 @@ function writeMetrics(url, version, metrics) {
  */
 async function measureDocument(url, version, config) {
   const browser = await puppeteer.launch({
-    headless: !!config.headless,
-    devtools: !!config.devtools,
+    headless: config.headless,
+    devtools: config.devtools,
     args: [
       '--allow-file-access-from-files',
       '--enable-blink-features=LayoutInstabilityAPI',


### PR DESCRIPTION
pupeteer treats an `undefined` value for a key as `true`. this pr explicitly sets it to false.

**to test**
- confirm that `gulp performance` runs in headless mode
- confirm that `gulp performance` on this branch does not run headless.