### PR TITLE
🐛 Fix amp-fit-text with content div that is smaller than the container.

### DIFF
--- a/extensions/amp-fit-text/0.1/amp-fit-text.js
+++ b/extensions/amp-fit-text/0.1/amp-fit-text.js
@@ -111,7 +111,6 @@ class AmpFitText extends AMP.BaseElement {
       this.minFontSize_,
       this.maxFontSize_
     );
-
     setStyle(this.contentWrapper_, 'fontSize', px(fontSize));
     updateOverflow_(this.contentWrapper_, this.measurer_, maxHeight, fontSize);
   }

--- a/extensions/amp-fit-text/0.1/amp-fit-text.js
+++ b/extensions/amp-fit-text/0.1/amp-fit-text.js
@@ -102,8 +102,8 @@ class AmpFitText extends AMP.BaseElement {
 
   /** @private */
   updateFontSize_() {
-    const maxHeight = this.element./*OK*/ offsetHeight;
-    const maxWidth = this.element./*OK*/ offsetWidth;
+    const maxHeight = this.content_./*OK*/ offsetHeight;
+    const maxWidth = this.content_./*OK*/ offsetWidth;
     const fontSize = calculateFontSize_(
       this.measurer_,
       maxHeight,
@@ -111,6 +111,7 @@ class AmpFitText extends AMP.BaseElement {
       this.minFontSize_,
       this.maxFontSize_
     );
+
     setStyle(this.contentWrapper_, 'fontSize', px(fontSize));
     updateOverflow_(this.contentWrapper_, this.measurer_, maxHeight, fontSize);
   }


### PR DESCRIPTION
I'm slightly puzzled how exactly this is happening, but this makes `amp-fit-text` robust for the case where content div isn't the same size as the element itself.

Fixes #28330