### PR TITLE
Include data-vars value to all analytics events by default

### DIFF
--- a/extensions/amp-access/0.1/amp-access-source.js
+++ b/extensions/amp-access/0.1/amp-access-source.js
@@ -281,7 +281,7 @@ export class AccessSource {
     triggerAnalyticsEvent(
       this.getRootElement_(),
       eventType,
-      undefined,
+      /** vars */ undefined,
       /** enableDataVars */ false
     );
   }

--- a/extensions/amp-access/0.1/amp-access-source.js
+++ b/extensions/amp-access/0.1/amp-access-source.js
@@ -278,7 +278,12 @@ export class AccessSource {
    * @private
    */
   analyticsEvent_(eventType) {
-    triggerAnalyticsEvent(this.getRootElement_(), eventType);
+    triggerAnalyticsEvent(
+      this.getRootElement_(),
+      eventType,
+      undefined,
+      /** enableDataVars */ false
+    );
   }
 
   /**

--- a/extensions/amp-access/0.1/amp-access.js
+++ b/extensions/amp-access/0.1/amp-access.js
@@ -298,7 +298,12 @@ export class AccessService {
    * @private
    */
   analyticsEvent_(eventType) {
-    triggerAnalyticsEvent(this.getRootElement_(), eventType);
+    triggerAnalyticsEvent(
+      this.getRootElement_(),
+      eventType,
+      undefined,
+      /** enableDataVars */ false
+    );
   }
 
   /**

--- a/extensions/amp-access/0.1/amp-access.js
+++ b/extensions/amp-access/0.1/amp-access.js
@@ -301,7 +301,7 @@ export class AccessService {
     triggerAnalyticsEvent(
       this.getRootElement_(),
       eventType,
-      undefined,
+      /** vars */ undefined,
       /** enableDataVars */ false
     );
   }

--- a/extensions/amp-analytics/0.1/events.js
+++ b/extensions/amp-analytics/0.1/events.js
@@ -248,19 +248,17 @@ export class AnalyticsEvent {
   /**
    * @param {!Element} target The most relevant target element.
    * @param {string} type The type of event.
-   * @param {?JsonObject=} opt_vars A map of vars and their values.
+   * @param {!JsonObject} vars A map of vars and their values.
    * @param {boolean} enableDataVars A boolean to indicate if data-vars-*
    * attribute value from target element should be included.
    */
-  constructor(target, type, opt_vars, enableDataVars = true) {
+  constructor(target, type, vars = dict(), enableDataVars = true) {
     /** @const */
     this['target'] = target;
     /** @const */
     this['type'] = type;
     /** @const */
-    this['vars'] = enableDataVars
-      ? mergeDataVars(target, opt_vars || dict())
-      : opt_vars || dict();
+    this['vars'] = enableDataVars ? mergeDataVars(target, vars) : vars;
   }
 }
 
@@ -1415,11 +1413,11 @@ function normalizeVideoEventType(type, details) {
 
 /**
  * @param {?JsonObject|undefined} details
- * @return {?JsonObject|undefined}
+ * @return {!JsonObject|undefined}
  */
 function removeInternalVars(details) {
   if (!details) {
-    return details;
+    return dict();
   }
   const clean = {...details};
   delete clean[videoAnalyticsCustomEventTypeKey];

--- a/extensions/amp-analytics/0.1/events.js
+++ b/extensions/amp-analytics/0.1/events.js
@@ -22,8 +22,8 @@ import {
   VideoAnalyticsEvents,
   videoAnalyticsCustomEventTypeKey,
 } from '../../../src/video-interface';
+import {deepMerge, dict, hasOwn} from '../../../src/utils/object';
 import {dev, devAssert, user, userAssert} from '../../../src/log';
-import {dict, hasOwn} from '../../../src/utils/object';
 import {getData} from '../../../src/event-helper';
 import {getDataParamsFromAttributes} from '../../../src/dom';
 import {isArray, isEnumValue, isFiniteNumber} from '../../../src/types';
@@ -204,6 +204,22 @@ export function getTrackerTypesForParentType(parentType) {
 }
 
 /**
+ * Expand the event variables to include default data-vars
+ * @param {!Element} target
+ * @param {!JsonObject} eventVars
+ * @return {!JsonObject}
+ */
+function mergeDataVars(target, eventVars) {
+  const vars = getDataParamsFromAttributes(
+    target,
+    /* computeParamNameFunc */ undefined,
+    VARIABLE_DATA_ATTRIBUTE_KEY
+  );
+  deepMerge(vars, eventVars, 1);
+  return vars;
+}
+
+/**
  * @interface
  */
 class SignalTrackerDef {
@@ -230,14 +246,17 @@ export class AnalyticsEvent {
    * @param {!Element} target The most relevant target element.
    * @param {string} type The type of event.
    * @param {?JsonObject=} opt_vars A map of vars and their values.
+   * @param {boolean} enableDataVars
    */
-  constructor(target, type, opt_vars) {
+  constructor(target, type, opt_vars, enableDataVars = true) {
     /** @const */
     this['target'] = target;
     /** @const */
     this['type'] = type;
     /** @const */
-    this['vars'] = opt_vars || dict();
+    this['vars'] = enableDataVars
+      ? mergeDataVars(target, opt_vars || dict())
+      : opt_vars || dict();
   }
 }
 
@@ -544,12 +563,7 @@ export class ClickEventTracker extends EventTracker {
    * @private
    */
   handleClick_(listener, target, unusedEvent) {
-    const params = getDataParamsFromAttributes(
-      target,
-      /* computeParamNameFunc */ undefined,
-      VARIABLE_DATA_ATTRIBUTE_KEY
-    );
-    listener(new AnalyticsEvent(target, 'click', params));
+    listener(new AnalyticsEvent(target, 'click'));
   }
 }
 
@@ -709,7 +723,8 @@ export class ScrollEventTracker extends EventTracker {
         new AnalyticsEvent(
           this.root_.getRootElement(),
           AnalyticsEventType.SCROLL,
-          vars
+          vars,
+          /** enableDataVars */ false
         )
       );
     }
@@ -1206,7 +1221,8 @@ export class TimerEventTracker extends EventTracker {
     return new AnalyticsEvent(
       this.root.getRootElement(),
       eventType,
-      this.trackers_[timerId].getTimerVars()
+      this.trackers_[timerId].getTimerVars(),
+      /** enableDataVars */ false
     );
   }
 
@@ -1698,6 +1714,7 @@ export class VisibilityTracker extends EventTracker {
    * @private
    */
   onEvent_(eventType, listener, target, state) {
+    // TODO: Verify usage and change behavior to have state override data-vars
     const attr = getDataParamsFromAttributes(
       target,
       /* computeParamNameFunc */ undefined,
@@ -1706,6 +1723,8 @@ export class VisibilityTracker extends EventTracker {
     for (const key in attr) {
       state[key] = attr[key];
     }
-    listener(new AnalyticsEvent(target, eventType, state));
+    listener(
+      new AnalyticsEvent(target, eventType, state, /** enableDataVars */ false)
+    );
   }
 }

--- a/extensions/amp-analytics/0.1/events.js
+++ b/extensions/amp-analytics/0.1/events.js
@@ -205,6 +205,7 @@ export function getTrackerTypesForParentType(parentType) {
 
 /**
  * Expand the event variables to include default data-vars
+ * eventVars value will override data-vars value
  * @param {!Element} target
  * @param {!JsonObject} eventVars
  * @return {!JsonObject}
@@ -215,7 +216,9 @@ function mergeDataVars(target, eventVars) {
     /* computeParamNameFunc */ undefined,
     VARIABLE_DATA_ATTRIBUTE_KEY
   );
-  deepMerge(vars, eventVars, 1);
+  // Merge eventVars into vars, depth=0 because
+  // vars and eventVars are not supposed to contain nested object.
+  deepMerge(vars, eventVars, 0);
   return vars;
 }
 
@@ -246,7 +249,8 @@ export class AnalyticsEvent {
    * @param {!Element} target The most relevant target element.
    * @param {string} type The type of event.
    * @param {?JsonObject=} opt_vars A map of vars and their values.
-   * @param {boolean} enableDataVars
+   * @param {boolean} enableDataVars A boolean to indicate if data-vars-*
+   * attribute value from target element should be included.
    */
   constructor(target, type, opt_vars, enableDataVars = true) {
     /** @const */

--- a/extensions/amp-analytics/0.1/instrumentation.js
+++ b/extensions/amp-analytics/0.1/instrumentation.js
@@ -92,9 +92,15 @@ export class InstrumentationService {
    * @param {!Element} target
    * @param {string} eventType
    * @param {!JsonObject=} opt_vars A map of vars and their values.
+   * @param {boolean} enableDataVars
    */
-  triggerEventForTarget(target, eventType, opt_vars) {
-    const event = new AnalyticsEvent(target, eventType, opt_vars);
+  triggerEventForTarget(target, eventType, opt_vars, enableDataVars = true) {
+    const event = new AnalyticsEvent(
+      target,
+      eventType,
+      opt_vars,
+      enableDataVars
+    );
     const root = this.findRoot_(target);
     const trackerName = getTrackerKeyName(eventType);
     const tracker = /** @type {!CustomEventTracker|!AmpStoryEventTracker} */ (root.getTracker(

--- a/extensions/amp-analytics/0.1/instrumentation.js
+++ b/extensions/amp-analytics/0.1/instrumentation.js
@@ -92,7 +92,8 @@ export class InstrumentationService {
    * @param {!Element} target
    * @param {string} eventType
    * @param {!JsonObject=} opt_vars A map of vars and their values.
-   * @param {boolean} enableDataVars
+   * @param {boolean} enableDataVars A boolean to indicate if data-vars-*
+   * attribute value from target element should be included.
    */
   triggerEventForTarget(target, eventType, opt_vars, enableDataVars = true) {
     const event = new AnalyticsEvent(

--- a/extensions/amp-analytics/0.1/instrumentation.js
+++ b/extensions/amp-analytics/0.1/instrumentation.js
@@ -24,6 +24,7 @@ import {
 import {AmpdocAnalyticsRoot, EmbedAnalyticsRoot} from './analytics-root';
 import {AnalyticsGroup} from './analytics-group';
 import {Services} from '../../../src/services';
+import {dict} from '../../../src/utils/object';
 import {getFriendlyIframeEmbedOptional} from '../../../src/iframe-helper';
 import {
   getParentWindowFrameElement,
@@ -91,17 +92,17 @@ export class InstrumentationService {
    *
    * @param {!Element} target
    * @param {string} eventType
-   * @param {!JsonObject=} opt_vars A map of vars and their values.
+   * @param {!JsonObject} vars A map of vars and their values.
    * @param {boolean} enableDataVars A boolean to indicate if data-vars-*
    * attribute value from target element should be included.
    */
-  triggerEventForTarget(target, eventType, opt_vars, enableDataVars = true) {
-    const event = new AnalyticsEvent(
-      target,
-      eventType,
-      opt_vars,
-      enableDataVars
-    );
+  triggerEventForTarget(
+    target,
+    eventType,
+    vars = dict(),
+    enableDataVars = true
+  ) {
+    const event = new AnalyticsEvent(target, eventType, vars, enableDataVars);
     const root = this.findRoot_(target);
     const trackerName = getTrackerKeyName(eventType);
     const tracker = /** @type {!CustomEventTracker|!AmpStoryEventTracker} */ (root.getTracker(

--- a/extensions/amp-analytics/0.1/test/test-events.js
+++ b/extensions/amp-analytics/0.1/test/test-events.js
@@ -71,6 +71,50 @@ describes.realWin('Events', {amp: 1}, (env) => {
     target2.appendChild(child2);
   });
 
+  describe('AnalyticsEvent', () => {
+    it('should handle data-vars', () => {
+      let analyticsEvent = new AnalyticsEvent(target, 'custom-event', {
+        'var': 'test',
+      });
+      expect(analyticsEvent.vars).to.deep.equal({
+        'var': 'test',
+      });
+
+      target.setAttribute('data-params-test-param', 'error');
+      target.setAttribute('data-vars-test-var', 'default');
+      analyticsEvent = new AnalyticsEvent(target, 'custom-event');
+      expect(analyticsEvent.vars).to.deep.equal({
+        'testVar': 'default',
+      });
+
+      analyticsEvent = new AnalyticsEvent(
+        target,
+        'custom-event',
+        {
+          'var': 'test',
+        },
+        false
+      );
+      expect(analyticsEvent.vars).to.deep.equal({
+        'var': 'test',
+      });
+    });
+
+    it('event vars should override data-vars', () => {
+      target.setAttribute('data-vars-test-var', 'error');
+      target.setAttribute('data-vars-test-var1', 'test1');
+      const analyticsEvent = new AnalyticsEvent(target, 'custom-event', {
+        'testVar': 'override',
+        'someVar': 'test',
+      });
+      expect(analyticsEvent.vars).to.deep.equal({
+        'testVar': 'override',
+        'testVar1': 'test1',
+        'someVar': 'test',
+      });
+    });
+  });
+
   describe('AnalyticsEventType', () => {
     it('should match TRACKER_TYPES', () => {
       const analyticsEventTypes = Object.values(AnalyticsEventType);

--- a/extensions/amp-next-page/1.0/service.js
+++ b/extensions/amp-next-page/1.0/service.js
@@ -477,7 +477,8 @@ export class NextPageService {
       /** @type {!JsonObject} */ ({
         'title': title,
         'url': url,
-      })
+      }),
+      /** enableDataVars */ false
     );
   }
 
@@ -1072,7 +1073,8 @@ export class NextPageService {
           /** @type {!JsonObject} */ ({
             'title': page.title,
             'url': page.url,
-          })
+          }),
+          /** enableDataVars */ false
         );
         const a2a = this.navigation_.navigateToAmpUrl(
           page.url,

--- a/extensions/amp-subscriptions/0.1/analytics.js
+++ b/extensions/amp-subscriptions/0.1/analytics.js
@@ -129,7 +129,12 @@ export class SubscriptionAnalytics {
     user().info(TAG, loggedString, opt_vars || '');
 
     opt_vars = opt_vars || dict({});
-    triggerAnalyticsEvent(this.element_, loggedString, opt_vars);
+    triggerAnalyticsEvent(
+      this.element_,
+      loggedString,
+      opt_vars,
+      /** enableDataVars */ false
+    );
 
     for (let l = 0; l < this.listeners_.length; l++) {
       this.listeners_[l](eventType, opt_vars, internalVars);

--- a/src/analytics.js
+++ b/src/analytics.js
@@ -22,12 +22,23 @@ import {Services} from './services';
  * @param {!Element} target
  * @param {string} eventType
  * @param {!JsonObject=} opt_vars A map of vars and their values.
+ * @param {boolean} enableDataVars
  */
-export function triggerAnalyticsEvent(target, eventType, opt_vars) {
+export function triggerAnalyticsEvent(
+  target,
+  eventType,
+  opt_vars,
+  enableDataVars = true
+) {
   Services.analyticsForDocOrNull(target).then((analytics) => {
     if (!analytics) {
       return;
     }
-    analytics.triggerEventForTarget(target, eventType, opt_vars);
+    analytics.triggerEventForTarget(
+      target,
+      eventType,
+      opt_vars,
+      enableDataVars
+    );
   });
 }

--- a/src/analytics.js
+++ b/src/analytics.js
@@ -22,7 +22,8 @@ import {Services} from './services';
  * @param {!Element} target
  * @param {string} eventType
  * @param {!JsonObject=} opt_vars A map of vars and their values.
- * @param {boolean} enableDataVars
+ * @param {boolean} enableDataVars A boolean to indicate if data-vars-*
+ * attribute value from target element should be included.
  */
 export function triggerAnalyticsEvent(
   target,

--- a/src/analytics.js
+++ b/src/analytics.js
@@ -15,31 +15,27 @@
  */
 
 import {Services} from './services';
+import {dict} from './utils/object';
 
 /**
  * Helper method to trigger analytics event if amp-analytics is available.
  * TODO: Do not expose this function
  * @param {!Element} target
  * @param {string} eventType
- * @param {!JsonObject=} opt_vars A map of vars and their values.
+ * @param {!JsonObject} vars A map of vars and their values.
  * @param {boolean} enableDataVars A boolean to indicate if data-vars-*
  * attribute value from target element should be included.
  */
 export function triggerAnalyticsEvent(
   target,
   eventType,
-  opt_vars,
+  vars = dict(),
   enableDataVars = true
 ) {
   Services.analyticsForDocOrNull(target).then((analytics) => {
     if (!analytics) {
       return;
     }
-    analytics.triggerEventForTarget(
-      target,
-      eventType,
-      opt_vars,
-      enableDataVars
-    );
+    analytics.triggerEventForTarget(target, eventType, vars, enableDataVars);
   });
 }

--- a/src/error.js
+++ b/src/error.js
@@ -737,7 +737,12 @@ export function reportErrorToAnalytics(error, win) {
       'errorName': error.name,
       'errorMessage': error.message,
     });
-    triggerAnalyticsEvent(getRootElement_(win), 'user-error', vars);
+    triggerAnalyticsEvent(
+      getRootElement_(win),
+      'user-error',
+      vars,
+      /** enableDataVars */ false
+    );
   }
 }
 

--- a/src/extension-analytics.js
+++ b/src/extension-analytics.js
@@ -126,7 +126,8 @@ class CustomEventReporter {
     triggerAnalyticsEvent(
       this.parent_,
       this.getEventTypeInSandbox_(eventType),
-      opt_vars
+      opt_vars,
+      /** enableDataVars */ false
     );
   }
   /**

--- a/test/manual/amp-analytics/default-data-vars.html
+++ b/test/manual/amp-analytics/default-data-vars.html
@@ -1,0 +1,52 @@
+<!doctype html>
+<html ⚡>
+
+<head>
+	<meta charset="utf-8">
+	<title>My AMP Page</title>
+	<link rel="canonical" href="self.html" />
+	<script async custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
+	<script async custom-element="amp-form" src="https://cdn.ampproject.org/v0/amp-form-0.1.js"></script>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+	<meta name="viewport" content="width=device-width,minimum-scale=1">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+</head>
+
+<body>
+<h2>Testing feature</h2>
+<p>data-vars should be passed to analytics and can be used as a filter</p>
+<ul>
+  <li>
+  Add to cart should send a ping to exampl.test
+  </li>
+  <li>
+  View cart should NOT send an analytics ping
+  </li>
+</ul>
+  <form data-vars-add-to-cart-form=true method="post"
+    action-xhr="https://example.com/subscribe"  target="_top">
+    <button type="submit">Add to cart</button>
+  </form>
+  <form data-vars-add-to-cart-form=false method="post"
+    action-xhr="https://example.com/subscribe"  target="_top">
+    <button type="submit">View Cart</button>
+  </form>
+	<amp-analytics>
+		<script type="application/json">
+			{
+        "requests": {
+          "test": "https://example.test?test-form"
+        },
+        "triggers":{
+          "trackForm":{
+            "on":"amp-form-submit",
+            "enabled": "${addToCartForm}",
+            "request":"test"
+          }
+        }
+     	 }
+		</script>
+	</amp-analytics>
+</body>
+
+</html>


### PR DESCRIPTION
Closes #28636 

As we agreed all attributes starts with `data-vars` from the target element will be passed as analytics variables. Extension defined variables will override the publisher set data-vars. 
