### PR TITLE
add an mjs or js suffix to output json file

### DIFF
--- a/build-system/compile/log-messages.js
+++ b/build-system/compile/log-messages.js
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+const argv = require('minimist')(process.argv.slice(2));
 const fs = require('fs-extra');
 const log = require('fancy-log');
 const {cyan} = require('colors');
@@ -23,7 +24,9 @@ const pathPrefix = 'dist/log-messages';
  * Source of truth for extracted messages during build, but should not be
  * deployed. Shaped `{message: {id, message, ...}}`.
  */
-const extractedPath = `${pathPrefix}.by-message.json`;
+const extractedPath = `${pathPrefix}${
+  argv.esm ? '-mjs' : 'js'
+}.by-message.json`;
 
 const formats = {
   // Consumed by logging server. Format may allow further fields.


### PR DESCRIPTION
since module builds and nomodule builds are built in different runs it is unlikely that they are able to share the same extracted messages table. the module build and nomodule build each need to have theyre own json file with theyre unique tables.