### PR TITLE
♻️  Refactor AES-GCM decryption function.

### DIFF
--- a/extensions/amp-subscriptions/0.1/crypto-handler.js
+++ b/extensions/amp-subscriptions/0.1/crypto-handler.js
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-import {decryptAesGcm} from '../../../third_party/subscriptions-project/aes_gcm';
+import {
+  base64Decode,
+  decryptAesGcmImpl,
+  safeAesGcmImportKey,
+} from '../../../third_party/subscriptions-project/aes_gcm';
 import {iterateCursor} from '../../../src/dom';
 import {padStart} from '../../../src/string';
 import {toArray} from '../../../src/types';
@@ -116,21 +120,27 @@ export class CryptoHandler {
       return this.decryptionPromise_;
     }
     this.decryptionPromise_ = this.ampdoc_.whenReady().then(() => {
-      const encryptedSections = this.ampdoc_
-        .getRootNode()
-        .querySelectorAll('script[ciphertext]');
-      const promises = [];
-      iterateCursor(encryptedSections, (encryptedSection) => {
-        promises.push(
-          decryptAesGcm(
-            decryptedDocumentKey,
-            encryptedSection.textContent
-          ).then((decryptedContent) => {
-            encryptedSection./*OK*/ outerHTML = decryptedContent;
-          })
-        );
+      const keybytes = base64Decode(decryptedDocumentKey);
+      return safeAesGcmImportKey(keybytes.buffer).then((formattedkey) => {
+        const encryptedSections = this.ampdoc_
+          .getRootNode()
+          .querySelectorAll('script[ciphertext]');
+        const promises = [];
+        iterateCursor(encryptedSections, (encryptedSection) => {
+          const text = encryptedSection.textContent.replace(/\s+/g, '');
+          const constbuff = base64Decode(text).buffer;
+          const iv = constbuff.slice(0, 12);
+          const bytesToDecrypt = constbuff.slice(12);
+          promises.push(
+            decryptAesGcmImpl(formattedkey, iv, bytesToDecrypt).then(
+              (decryptedContent) => {
+                encryptedSection./*OK*/ outerHTML = decryptedContent;
+              }
+            )
+          );
+        });
+        return Promise.all(promises);
       });
-      return Promise.all(promises);
     });
     return this.decryptionPromise_;
   }

--- a/extensions/amp-subscriptions/0.1/crypto-handler.js
+++ b/extensions/amp-subscriptions/0.1/crypto-handler.js
@@ -128,9 +128,9 @@ export class CryptoHandler {
         const promises = [];
         iterateCursor(encryptedSections, (encryptedSection) => {
           const text = encryptedSection.textContent.replace(/\s+/g, '');
-          const constbuff = base64Decode(text).buffer;
-          const iv = constbuff.slice(0, 12);
-          const bytesToDecrypt = constbuff.slice(12);
+          const contentBuffer = base64Decode(text).buffer;
+          const iv = contentBuffer.slice(0, 12);
+          const bytesToDecrypt = contentBuffer.slice(12);
           promises.push(
             decryptAesGcmImpl(formattedkey, iv, bytesToDecrypt).then(
               (decryptedContent) => {

--- a/third_party/subscriptions-project/aes_gcm.js
+++ b/third_party/subscriptions-project/aes_gcm.js
@@ -16,42 +16,66 @@
 
 /**
  * Subtle-based AES-GCM decryption supported on all browser types.
- * Decrypts the input text using AES-GCM with the input key.
+ * Decrypts the input text using AES-GCM with the input base64 encoded key
+ * and importing the key using subtle.importKey.
  * @param {string} key
  * @param {string} text
  * @return {!Promise}
  */
 export function decryptAesGcm(key, text) {
   const keybytes = base64Decode(key);
+  return safeAesGcmImportKey(keybytes.buffer).then((formattedkey) => {
+    text = text.replace(/\s+/g, '');
+    const contbuff = base64Decode(text).buffer;
+    const iv = contbuff.slice(0, 12);
+    const bytesToDecrypt = contbuff.slice(12);
+    return decryptAesGcmImpl(formattedkey, iv, bytesToDecrypt)
+  });
+  }
+    
+/**
+ * Subtle-based AES-GCM decryption supported on all browser types.
+ * Decrypts the input text using AES-GCM with the input key and IV.
+ * @param {!CryptoKey} key
+ * @param {!ArrayBuffer} iv
+ * @param {!ArrayBuffer} text
+ * @return {!Promise}
+ */
+export function decryptAesGcmImpl(key, iv, text) {
   const isIE = !!self.msCrypto;
   const subtle = isIE ? self.msCrypto.subtle : self.crypto.subtle;
-  return wrapCryptoOp(subtle.importKey('raw', keybytes.buffer,
-    'AES-GCM',
-    true, ['decrypt'])).
-    then((formattedkey) => {
-      text = text.replace(/\s+/g, '');
-      const contbuff = base64Decode(text).buffer;
-      const iv = contbuff.slice(0, 12);
-      const bytesToDecrypt = contbuff.slice(12);
-      return wrapCryptoOp(subtle
-        .decrypt(
-          {
-            name: 'AES-GCM',
-            iv: iv,
-            // IE requires "tag" of length 16.
-            tag: isIE ? bytesToDecrypt.slice(bytesToDecrypt.byteLength - 16) : undefined,
-            // Edge requires "tagLength".
-            tagLength: 128 // block size (16): 1-128
-          },
-          formattedkey,
-          // IE requires "tag" to be removed from the bytes.
-          isIE ? bytesToDecrypt.slice(0, bytesToDecrypt.byteLength - 16) : bytesToDecrypt
-        ))
-        .then((buffer) => {
-          // 5. Decryption gives us raw bytes and we need to turn them into text.
-          return utf8Decode(new Uint8Array(buffer));
-        });
+  return wrapCryptoOp(subtle
+    .decrypt(
+      {
+        name: 'AES-GCM',
+        iv: iv,
+        // IE requires "tag" of length 16.
+        tag: isIE ? text.slice(text.byteLength - 16) : undefined,
+        // Edge requires "tagLength".
+        tagLength: 128 // block size (16): 1-128
+      },
+      key,
+      // IE requires "tag" to be removed from the bytes.
+      isIE ? text.slice(0, text.byteLength - 16) : text
+    ))
+    .then((buffer) => {
+      // 5. Decryption gives us raw bytes and we need to turn them into text.
+      return utf8Decode(new Uint8Array(buffer));
     });
+}
+
+      /**
+ * Subtle import key for AES-GCM key types that is supported
+ * on all browser types.
+ * @param {!ArrayBuffer} key
+ * @return {!Promise}
+ */
+export function safeAesGcmImportKey(key) {
+  const isIE = !!self.msCrypto;
+  const subtle = isIE ? self.msCrypto.subtle : self.crypto.subtle;
+  return wrapCryptoOp(subtle.importKey('raw', key,
+    'AES-GCM',
+    true, ['decrypt']));
 }
 
 /** 
@@ -94,7 +118,7 @@ function utf8Decode(bytes) {
  * @param {string} str
  * @return {!Uint8Array}
  */
-function base64Decode(str) {
+export function base64Decode(str) {
   const bytes = atob(str);
   const len = bytes.length;
   const array = new Uint8Array(len);

--- a/third_party/subscriptions-project/aes_gcm.js
+++ b/third_party/subscriptions-project/aes_gcm.js
@@ -26,9 +26,9 @@ export function decryptAesGcm(key, text) {
   const keybytes = base64Decode(key);
   return safeAesGcmImportKey(keybytes.buffer).then((formattedkey) => {
     text = text.replace(/\s+/g, '');
-    const contbuff = base64Decode(text).buffer;
-    const iv = contbuff.slice(0, 12);
-    const bytesToDecrypt = contbuff.slice(12);
+    const contentBuffer = base64Decode(text).buffer;
+    const iv = contentBuffer.slice(0, 12);
+    const bytesToDecrypt = contentBuffer.slice(12);
     return decryptAesGcmImpl(formattedkey, iv, bytesToDecrypt)
   });
   }
@@ -64,7 +64,7 @@ export function decryptAesGcmImpl(key, iv, text) {
     });
 }
 
-      /**
+/**
  * Subtle import key for AES-GCM key types that is supported
  * on all browser types.
  * @param {!ArrayBuffer} key


### PR DESCRIPTION
- Refactor decryptAesGcm function to remove decoding from function and accept decoded IV
- Calls subtle.importkey once for all decryption sections instead of once per section.


