### PR TITLE
♻️ Remove parseUrlDeprecated use from amp-analytics

### DIFF
--- a/extensions/amp-analytics/0.1/linker-reader.js
+++ b/extensions/amp-analytics/0.1/linker-reader.js
@@ -14,14 +14,11 @@
  * limitations under the License.
  */
 
+import {Services} from '../../../src/services';
 import {getService, registerServiceBuilder} from '../../../src/service';
 import {hasOwn} from '../../../src/utils/object';
 import {parseLinker} from './linker';
-import {
-  parseQueryString,
-  parseUrlDeprecated,
-  removeParamsFromSearch,
-} from '../../../src/url';
+import {parseQueryString, removeParamsFromSearch} from '../../../src/url';
 
 import {user} from '../../../src/log';
 
@@ -69,7 +66,10 @@ export class LinkerReader {
    * @return {?Object<string, string>}
    */
   parseAndCleanQueryString_(name) {
-    const parsedUrl = parseUrlDeprecated(this.win_.location.href);
+    const service = Services.urlForDoc(this.win_.document.documentElement);
+    const parsedUrl = /** @type {!Location} */ (service.parse(
+      this.win_.location.href
+    ));
     const params = parseQueryString(parsedUrl.search);
     if (!hasOwn(params, name)) {
       // Linker param not found.

--- a/extensions/amp-analytics/0.1/test/test-linker-manager.js
+++ b/extensions/amp-analytics/0.1/test/test-linker-manager.js
@@ -290,6 +290,7 @@ describes.realWin('Linker Manager', {amp: true}, (env) => {
 
       windowInterface.history = {replaceState: () => {}};
       windowInterface.location = {href: linkerUrl};
+      windowInterface.document = doc;
 
       installLinkerReaderService(windowInterface);
       const linkerReader = linkerReaderServiceFor(windowInterface);

--- a/extensions/amp-analytics/0.1/test/test-linker-reader.js
+++ b/extensions/amp-analytics/0.1/test/test-linker-reader.js
@@ -44,6 +44,7 @@ describe('LinkerReader', () => {
         mockWin.location.href = newHref;
       },
     };
+    mockWin.document = document;
     installLinkerReaderService(mockWin);
     linkerReader = linkerReaderServiceFor(mockWin);
   });


### PR DESCRIPTION
Part of https://github.com/ampproject/amphtml/issues/16226 