### PR TITLE
Expose `files` event detail when available

### DIFF
--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -33,7 +33,7 @@ import {
   registerServiceBuilderForDoc,
 } from '../service';
 import {isAmp4Email} from '../format';
-import {isArray, isFiniteNumber, toWin} from '../types';
+import {isArray, isFiniteNumber, toArray, toWin} from '../types';
 import {isEnabled} from '../dom';
 import {reportError} from '../error';
 
@@ -860,6 +860,14 @@ export class ActionService {
     if (target.min !== undefined || target.max !== undefined) {
       detail['min'] = target.min;
       detail['max'] = target.max;
+    }
+
+    if (target.files) {
+      detail['files'] = toArray(target.files).map((file) => ({
+        'name': file.name,
+        'size': file.size,
+        'type': file.type,
+      }));
     }
 
     if (Object.keys(detail).length > 0) {

--- a/test/unit/test-action.js
+++ b/test/unit/test-action.js
@@ -1529,6 +1529,19 @@ describes.fakeWin('Core events', {amp: true}, (env) => {
     );
   });
 
+  it('should trigger change event for <input type="file"> elements', () => {
+    const handler = window.document.addEventListener.getCall(3).args[1];
+    const element = document.createElement('input');
+    element.setAttribute('type', 'file');
+    const event = {target: element};
+    handler(event);
+    expect(action.trigger).to.have.been.calledWith(
+      element,
+      'change',
+      env.sandbox.match((e) => e.detail.files.length == 0)
+    );
+  });
+
   it('should trigger change event with details for <select> elements', () => {
     const handler = window.document.addEventListener.getCall(3).args[1];
     const element = document.createElement('select');


### PR DESCRIPTION
Closes #26632

This PR exposes the `name`, `type`, and `size` properties of any [`File`](https://developer.mozilla.org/en-US/docs/Web/API/File) included in the `files` property available on an [`<input type="file">`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file), making this data available and usable with AMP state.

An example usage with the given change:
```html
<input
  type="file"
  name="myFiles"
  on="change:fileText.show, AMP.setState({first: event.value, files: event.files})"
  multiple
/>
<span id="fileText" hidden [text]="files.map((x, i) => x.size)">
  All sizes of selected files go here.
</span>
<span id="firstText" hidden [text]="first">
  The first selected file name goes here.
</span>
```