### PR TITLE
🦟 Pinterest data comes HTML encoded, not URL encoded.

### DIFF
--- a/examples/pinterest.amp.html
+++ b/examples/pinterest.amp.html
@@ -36,6 +36,15 @@
       data-url="https://www.pinterest.com/pin/99360735500167749/">
     </amp-pinterest>
 
+  <h3>Embedded Pins - chinese</h3>
+
+    <amp-pinterest
+      width="345"
+      height="678"
+      data-do="embedPin"
+      data-url="https://www.pinterest.com/pin/192740059037785029/">
+    </amp-pinterest>
+  
   <h3>Embedded Pins - responsive</h3>
 
     <div style="width: 320px; float: left;">

--- a/extensions/amp-pinterest/0.1/test/test-amp-pinterest.js
+++ b/extensions/amp-pinterest/0.1/test/test-amp-pinterest.js
@@ -43,6 +43,9 @@ describes.realWin(
       pin.setAttribute('data-url', pinUrl);
       pin.setAttribute('data-media', pinMedia);
       pin.setAttribute('data-description', pinDescription);
+      pin.setAttribute('layout', 'responsive');
+      pin.setAttribute('width', '100');
+      pin.setAttribute('height', '100');
       div.appendChild(pin);
       pin.implementation_.buildCallback();
       return pin.implementation_.layoutCallback().then(() => {
@@ -60,6 +63,9 @@ describes.realWin(
       const pin = env.win.document.createElement('amp-pinterest');
       pin.setAttribute('data-do', 'embedPin');
       pin.setAttribute('data-url', pinURL + pinID);
+      pin.setAttribute('layout', 'responsive');
+      pin.setAttribute('width', '100');
+      pin.setAttribute('height', '100');
       if (pinAlt) {
         pin.setAttribute('alt', pinAlt);
       }
@@ -242,7 +248,7 @@ describes.realWin(
             'pinner': {
               'about': '',
               'location': 'London',
-              'full_name': 'Paul Matthews',
+              'full_name': 'Paul Matthews&auml;',
               'follower_count': 10,
               'image_small_url':
                 'https://i.pinimg.com/30x30_RS/f0/3e/21/f03e21f499084c44fca771555f547474.jpg',
@@ -343,6 +349,10 @@ describes.realWin(
             'rails in SF, cable car rails #cablecar #sanfrancisco #endoftheline ' +
             '#tourist #rails #saturdayafternoon #california'
         );
+
+        expect(
+          pin.querySelector('.-amp-pinterest-embed-pin-pinner-name').textContent
+        ).to.equal('Paul Matthewsä');
       });
     });
 

--- a/extensions/amp-pinterest/0.1/util.js
+++ b/extensions/amp-pinterest/0.1/util.js
@@ -39,20 +39,13 @@ function log(queryParams) {
 }
 
 /**
- * Strip data from string
+ * Pinterest provides text HTML encoded. This utility transforms it back
+ * into UTF-8 text.
  * @param {string} str - the string to filter
  * @return {string}
  */
 function filter(str) {
-  let decoded, ret;
-  decoded = '';
-  ret = '';
-  try {
-    decoded = decodeURIComponent(str);
-  } catch (e) {}
-  ret = decoded.replace(/</g, '&lt;');
-  ret = ret.replace(/>/g, '&gt;');
-  return ret;
+  return new DOMParser().parseFromString(str, 'text/html').body.textContent;
 }
 
 /**

--- a/extensions/amp-pinterest/0.1/util.js
+++ b/extensions/amp-pinterest/0.1/util.js
@@ -45,7 +45,11 @@ function log(queryParams) {
  * @return {string}
  */
 function filter(str) {
-  return new DOMParser().parseFromString(str, 'text/html').body.textContent;
+  try {
+    return new DOMParser().parseFromString(str, 'text/html').body.textContent;
+  } catch (e) {
+    return str;
+  }
 }
 
 /**


### PR DESCRIPTION
Credit to @jridgewell for doing the original debugging.

Fixes #13881