### PR TITLE
✨ Add support for writing and reading textContent on amp-fit-text.

### DIFF
--- a/extensions/amp-fit-text/0.1/amp-fit-text.js
+++ b/extensions/amp-fit-text/0.1/amp-fit-text.js
@@ -40,6 +40,13 @@ class AmpFitText extends AMP.BaseElement {
 
     /** @private {number} */
     this.maxFontSize_ = -1;
+
+    /**
+     * Synchronously stores updated textContent, but only after it has been
+     * updated.
+     * @private {string}
+     */
+    this.textContent_ = '';
   }
 
   /** @override */

--- a/extensions/amp-fit-text/0.1/amp-fit-text.js
+++ b/extensions/amp-fit-text/0.1/amp-fit-text.js
@@ -72,7 +72,7 @@ class AmpFitText extends AMP.BaseElement {
     this.getRealChildNodes().forEach((node) => {
       this.contentWrapper_.appendChild(node);
     });
-    this.measurer_./*OK*/ innerHTML = this.contentWrapper_./*OK*/ innerHTML;
+    this.updateMeasurerContent_();
     this.element.appendChild(this.content_);
     this.element.appendChild(this.measurer_);
 
@@ -81,6 +81,22 @@ class AmpFitText extends AMP.BaseElement {
 
     this.maxFontSize_ =
       getLengthNumeral(this.element.getAttribute('max-font-size')) || 72;
+
+    // Make it so that updates to the textContent of the amp-fit-text element
+    // actually update the text of the content element.
+    Object.defineProperty(this.element, 'textContent', {
+      set: (v) => {
+        this.textContent_ = v;
+        this.mutateElement(() => {
+          this.contentWrapper_.textContent = v;
+          this.updateMeasurerContent_();
+          this.updateFontSize_();
+        });
+      },
+      get: () => {
+        return this.textContent_ || this.contentWrapper_.textContent;
+      },
+    });
   }
 
   /** @override */
@@ -98,6 +114,13 @@ class AmpFitText extends AMP.BaseElement {
     return this.mutateElement(() => {
       this.updateFontSize_();
     });
+  }
+
+  /**
+   * Copies text from the displayed content to the measurer element.
+   */
+  updateMeasurerContent_() {
+    this.measurer_./*OK*/ innerHTML = this.contentWrapper_./*OK*/ innerHTML;
   }
 
   /** @private */

--- a/extensions/amp-fit-text/0.1/test/test-amp-fit-text.js
+++ b/extensions/amp-fit-text/0.1/test/test-amp-fit-text.js
@@ -59,7 +59,18 @@ describes.realWin(
         const content = ft.querySelector('.i-amphtml-fit-text-content');
         expect(content).to.not.equal(null);
         expect(content.textContent).to.equal(text);
+        expect(ft.textContent).to.equal(text);
       });
+    });
+
+    it('supports update of textContent', async () => {
+      const ft = await getFitText('Lorem ipsum');
+      const newText = 'updated';
+      ft.textContent = newText;
+      expect(ft.textContent).to.equal(newText);
+      await ft.implementation_.mutateElement(() => {});
+      const content = ft.querySelector('.i-amphtml-fit-text-content');
+      expect(content.textContent).to.equal(newText);
     });
   }
 );


### PR DESCRIPTION
Doesn't support changing HTML children, which would be much more complicated without Shadow DOM.

Fixes #17895