### PR TITLE
🏗 Remove branches from Travis push builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,6 @@ before_install:
 branches:
   only:
     - master
-    - release
-    - canary
-    - nightly
     - /^amp-release-.*$/
 addons:
   apt:


### PR DESCRIPTION
* `canary` - no longer exists
* `nightly` - always an unneccesary rerun on an already green commit
* `release` - no longer exists