### PR TITLE
🐛 [amp-list] Call scheduleUnlayout when amp-list container is updated

### DIFF
--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -610,7 +610,7 @@ export class AmpList extends AMP.BaseElement {
           dev().assertElement(this.container_).children
         ).forEach((child) =>
           this.owners_./*OK*/ scheduleUnlayout(
-            /** @type {!Element} */ (this.container_),
+            dev().assertElement(this.container_),
             child
           )
         );

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -609,7 +609,10 @@ export class AmpList extends AMP.BaseElement {
         toArray(
           dev().assertElement(this.container_).children
         ).forEach((child) =>
-          this.owners_./*OK*/ scheduleUnlayout(this.container_, child)
+          this.owners_./*OK*/ scheduleUnlayout(
+            /** @type {!Element} */ (this.container_),
+            child
+          )
         );
         removeChildren(dev().assertElement(this.container_));
       };

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -1060,7 +1060,7 @@ export class AmpList extends AMP.BaseElement {
       } else {
         if (!opt_append) {
           toArray(container.children).forEach((child) =>
-            this.owners_.scheduleUnlayout(this.element, child)
+            this.owners_./*OK*/ scheduleUnlayout(container, child)
           );
           removeChildren(container);
         }

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -606,6 +606,11 @@ export class AmpList extends AMP.BaseElement {
             'update': false,
           });
         }
+        toArray(
+          dev().assertElement(this.container_).children
+        ).forEach((child) =>
+          this.owners_./*OK*/ scheduleUnlayout(this.container_, child)
+        );
         removeChildren(dev().assertElement(this.container_));
       };
 

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -191,7 +191,7 @@ export class AmpList extends AMP.BaseElement {
     /** @private {?../../../src/service/action-impl.ActionService} */
     this.action_ = null;
 
-    /** @private {?../../../src/service/owners-impl.OwnersImpl} */
+    /** @private {?../../../src/service/owners-interface.OwnersInterface} */
     this.owners_ = null;
   }
 

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -190,6 +190,9 @@ export class AmpList extends AMP.BaseElement {
 
     /** @private {?../../../src/service/action-impl.ActionService} */
     this.action_ = null;
+
+    /** @private {?../../../src/service/owners-impl.OwnersImpl} */
+    this.owners_ = null;
   }
 
   /** @override */
@@ -217,6 +220,7 @@ export class AmpList extends AMP.BaseElement {
   /** @override */
   buildCallback() {
     this.action_ = Services.actionServiceForDoc(this.element);
+    this.owners_ = Services.ownersForDoc(this.element);
     /** If the element is in an email document,
      * allow its `changeToLayoutContainer` and `refresh` actions. */
     this.action_.addToWhitelist(
@@ -1055,6 +1059,9 @@ export class AmpList extends AMP.BaseElement {
         this.diff_(container, elements);
       } else {
         if (!opt_append) {
+          toArray(container.children).forEach((child) =>
+            this.owners_.scheduleUnlayout(this.element, child)
+          );
           removeChildren(container);
         }
         this.addElementsToContainer_(elements, container);

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -1061,6 +1061,8 @@ export class AmpList extends AMP.BaseElement {
       this.hideFallbackAndPlaceholder_();
 
       if (this.element.hasAttribute('diffable') && container.hasChildNodes()) {
+        // TODO:(wg-ui-and-a11y)(#28781) Ensure owners_.scheduleUnlayout() is
+        // called for diff elements that are removed
         this.diff_(container, elements);
       } else {
         if (!opt_append) {

--- a/extensions/amp-list/0.1/test/test-amp-list.js
+++ b/extensions/amp-list/0.1/test/test-amp-list.js
@@ -97,6 +97,10 @@ describes.repeated(
           env.sandbox.stub(Services, 'bindForDocOrNull').returns(promise);
           setBindService = resolve;
 
+          env.sandbox
+            .stub(Services, 'ownersForDoc')
+            .returns({scheduleUnlayout: env.sandbox.stub()});
+
           ssrTemplateHelper = {
             isEnabled: () => false,
             ssr: () => Promise.resolve(),


### PR DESCRIPTION
Fixes: https://github.com/ampproject/amphtml/issues/21680

Issue: 
- When a component is used within amp-list, and amp-list re-renders its list contents, the previous elements do not have their `unlayoutCallback()` (amp lifecycle callback) called.
- In the issue linked above, `amp-bind` with a new `src` triggers the re-render
- `Amp-date-countdown` uses `setInterval()` to periodically update its date.  It then does `clearInterval` in it's `unlayoutCallback()` when it is no longer used
- Since the `unlayoutCallback()` is not called when `amp-date-countdown` is used within `amp-list`, after `amp-list` re-renders, the intervals is still set and continues to run it's callback
- In this situation, the callback tries to access the root node of the element (which is no longer the DOM's root) and  repeatedly errors out when it cannot do `getElementById()`

Fix:
- Call `scheduleUnlayout` on removed elements from `amp-list` (which runs `unlayoutCallback()`) each time it re-renders
- In addition to `amp-date-countdown` this should also fix any undiscovered bugs related to amp-elements not being cleaned up with `unlayoutCallback()` when used within `amp-list`