### PR TITLE
🏗 Remove final remnants of single-pass

### DIFF
--- a/build-system/compile/OWNERS
+++ b/build-system/compile/OWNERS
@@ -19,13 +19,6 @@
       owners: [{name: 'rsimha', notify: true}],
     },
     {
-      pattern: 'single-pass.js',
-      owners: [
-        {name: 'erwinmombay', notify: true},
-        {name: 'rsimha', notify: true},
-      ],
-    },
-    {
       pattern: 'internal-version.js',
       owners: [{name: 'danielrozenberg', notify: true}],
     },

--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -109,7 +109,6 @@ const forbiddenTerms = {
       'allowlist a legit case.',
     allowlist: [
       'build-system/common/check-package-manager.js',
-      'build-system/compile/single-pass.js',
       'build-system/pr-check/build.js',
       'build-system/pr-check/build-targets.js',
       'build-system/pr-check/checks.js',
@@ -121,7 +120,6 @@ const forbiddenTerms = {
       'build-system/pr-check/local-tests.js',
       'build-system/pr-check/performance-tests.js',
       'build-system/pr-check/remote-tests.js',
-      'build-system/pr-check/single-pass-tests.js',
       'build-system/pr-check/utils.js',
       'build-system/pr-check/validator-tests.js',
       'build-system/pr-check/visual-diff-tests.js',

--- a/build-system/tasks/report-test-status.js
+++ b/build-system/tasks/report-test-status.js
@@ -35,10 +35,7 @@ const IS_SAUCELABS_BETA = !!argv.saucelabs && !!argv.beta;
 const IS_DIST = !!argv.compiled;
 
 const TEST_TYPE_SUBTYPES = new Map([
-  [
-    'integration',
-    ['local', 'minified', 'single-pass', 'saucelabs-beta', 'saucelabs-stable'],
-  ],
+  ['integration', ['local', 'minified', 'saucelabs-beta', 'saucelabs-stable']],
   ['unit', ['local', 'local-changes', 'saucelabs']],
   ['e2e', ['local']],
 ]);


### PR DESCRIPTION
Removes status from PRs for removed tests.