### PR TITLE
🐛Check for unlayout before merging rtc response

### DIFF
--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -760,9 +760,12 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
         return /**@type {!../../../ads/google/a4a/utils.IdentityToken}*/ ({});
       });
 
-    const rtcParamsPromise = opt_rtcResponsesPromise.then((results) =>
-      this.mergeRtcResponses_(results)
-    );
+    const checkStillCurrent = this.verifyStillCurrent();
+
+    const rtcParamsPromise = opt_rtcResponsesPromise.then((results) => {
+      checkStillCurrent();
+      return this.mergeRtcResponses_(results);
+    });
 
     // TODO(#28555): Delete extra logic when 'expand-json-targeting' exp launches.
     const isJsonTargetingExpOn =
@@ -777,8 +780,6 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
             dev().warn(TAG, 'JSON Targeting expansion failed/timed out.');
           })
       : Promise.resolve();
-
-    const checkStillCurrent = this.verifyStillCurrent();
 
     Promise.all([
       rtcParamsPromise,


### PR DESCRIPTION
Previously the call to `mergeRtcResponses_` was protected by `checkStillCurrent` function, but in #28575 I moved the call site. As a result the rtc response could come back after `unlayout` and the merge method would throw.

For reasons I don't understand this error is only showing up in Safari. The equivalent error for Chrome `Cannot read property 'targeting' of null` does not show up in our logs. Curious if anyone has a good guess why?

Closes #28744