### PR TITLE
♻️ Remove use of parseUrlDeprecated from amp-analytics

### DIFF
--- a/extensions/amp-analytics/0.1/resource-timing.js
+++ b/extensions/amp-analytics/0.1/resource-timing.js
@@ -17,7 +17,6 @@
 import {ExpansionOptions, variableServiceForDoc} from './variables';
 import {findIndex} from '../../../src/utils/array';
 import {isObject} from '../../../src/types';
-import {parseUrlDeprecated} from '../../../src/url';
 import {user} from '../../../src/log';
 
 /**
@@ -163,7 +162,7 @@ function entryToExpansionOptions(entry, name, format) {
  * @return {?string} The name of the entry, or null if no matching name exists.
  */
 function nameForEntry(entry, resourcesByHost) {
-  const url = parseUrlDeprecated(entry.name);
+  const url = entry.name;
   for (let i = 0; i < resourcesByHost.length; ++i) {
     const {hostPattern, resources} = resourcesByHost[i];
     if (!hostPattern.test(url.host)) {

--- a/extensions/amp-analytics/0.1/test/test-resource-timing.js
+++ b/extensions/amp-analytics/0.1/test/test-resource-timing.js
@@ -66,8 +66,13 @@ export function newPerformanceResourceTiming(
   const tcpTime = cached ? 0 : duration * 0.2;
   const serverTime = cached ? duration : duration * 0.4;
   const transferTime = cached ? 0 : duration * 0.3;
+  function urlify(url) {
+    const a = document.createElement('a');
+    a.href = url;
+    return {host: a.host, pathname: a.pathname, search: a.search};
+  }
   return {
-    name: url,
+    name: urlify(url),
     initiatorType,
     startTime,
     duration,


### PR DESCRIPTION
Part of https://github.com/ampproject/amphtml/issues/16226

The use here was unnecessary because `entry.name` is of type `URL` which already has accessors for host, etc. 