### PR TITLE
✨ Add a defense-in-depth to the viewer in case communication fails

### DIFF
--- a/src/service/viewer-impl.js
+++ b/src/service/viewer-impl.js
@@ -40,6 +40,7 @@ import {map} from '../utils/object';
 import {registerServiceBuilderForDoc} from '../service';
 import {reportError} from '../error';
 import {urls} from '../config';
+import {listenOnce} from '../event-helper';
 
 const TAG_ = 'Viewer';
 
@@ -266,6 +267,8 @@ export class ViewerImpl {
     this.ampdoc.whenFirstVisible().then(() => {
       this.maybeUpdateFragmentForCct();
     });
+
+    this.visibleOnUserAction_();
   }
 
   /** @private */
@@ -876,6 +879,34 @@ export class ViewerImpl {
     } catch (e) {
       dev().error(TAG_, 'replaceUrl failed', e);
     }
+  }
+
+  /**
+   * Defense in-depth against viewer communication issues: Will make the
+   * document visible if it receives a user action without having been
+   * made visible by the viewer.
+   */
+  visibleOnUserAction_() {
+    if (this.ampdoc.getVisibilityState() == VisibilityState.VISIBLE) {
+      return;
+    }
+    const unlisten = [];
+    const doUnlisten = () => unlisten.forEach((fn) => fn());
+    const makeVisible = () => {
+      this.setVisibilityState_(VisibilityState.VISIBLE);
+      doUnlisten();
+      dev().error(TAG_, 'Received user action in non-visible doc');
+    };
+    const options = {
+      capture: true,
+      passive: true,
+    };
+    unlisten.push(
+      listenOnce(this.win, 'keydown', makeVisible, options),
+      listenOnce(this.win, 'touchstart', makeVisible, options),
+      listenOnce(this.win, 'mousedown', makeVisible, options)
+    );
+    this.whenFirstVisible().then(doUnlisten);
   }
 }
 

--- a/src/service/viewer-impl.js
+++ b/src/service/viewer-impl.js
@@ -36,11 +36,11 @@ import {
   serializeQueryString,
 } from '../url';
 import {isIframed} from '../dom';
+import {listen} from '../event-helper';
 import {map} from '../utils/object';
 import {registerServiceBuilderForDoc} from '../service';
 import {reportError} from '../error';
 import {urls} from '../config';
-import {listenOnce} from '../event-helper';
 
 const TAG_ = 'Viewer';
 
@@ -902,9 +902,9 @@ export class ViewerImpl {
       passive: true,
     };
     unlisten.push(
-      listenOnce(this.win, 'keydown', makeVisible, options),
-      listenOnce(this.win, 'touchstart', makeVisible, options),
-      listenOnce(this.win, 'mousedown', makeVisible, options)
+      listen(this.win, 'keydown', makeVisible, options),
+      listen(this.win, 'touchstart', makeVisible, options),
+      listen(this.win, 'mousedown', makeVisible, options)
     );
     this.whenFirstVisible().then(doUnlisten);
   }

--- a/test/unit/test-viewer.js
+++ b/test/unit/test-viewer.js
@@ -82,6 +82,13 @@ describes.sandboxed('Viewer', {}, (env) => {
       ancestorOrigins: null,
       search: '',
     };
+    windowApi.addEventListener = (type, listener) => {
+      events[type] = listener;
+    };
+    windowApi.removeEventListener = (type, listener) => {
+      expect(events[type]).to.equal(listener);
+      delete events[type];
+    };
     windowApi.document = {
       nodeType: /* DOCUMENT */ 9,
       defaultView: windowApi,
@@ -644,6 +651,33 @@ describes.sandboxed('Viewer', {}, (env) => {
       changeVisibility('visible');
       expect(ampdoc.getVisibilityState()).to.equal('visible');
     });
+  });
+
+  describe('User action makes doc visible', () => {
+    const eventTest = (eventName) => {
+      ampdoc.overrideVisibilityState('prerender');
+      viewer = new ViewerImpl(ampdoc);
+      expect(ampdoc.getVisibilityState()).to.equal('prerender');
+
+      expect(events.touchstart).to.not.be.undefined;
+      expect(events.keydown).to.not.be.undefined;
+      expect(events.mousedown).to.not.be.undefined;
+
+      events[eventName]();
+      expect(ampdoc.getVisibilityState()).to.equal('visible');
+      expect(events.touchstart).to.be.undefined;
+      expect(events.keydown).to.be.undefined;
+      expect(events.mousedown).to.be.undefined;
+    };
+
+    it(
+      'should become visible on touchstart',
+      eventTest.bind(null, 'touchstart')
+    );
+
+    it('should become visible on mousedown', eventTest.bind(null, 'mousedown'));
+
+    it('should become visible on keydown', eventTest.bind(null, 'keydown'));
   });
 
   describe('Messaging not embedded', () => {


### PR DESCRIPTION
This will declare a doc to be visible if it isn't but gets a user action.

In Google Search this should never happen, because the doc isn't actually shown until the viewer handshake happened.

But other viewers do show documents right away, and we've seen cases where docs where presented to the user, but not interactive, because they never got the respective message.

Fixes #28227 
