### PR TITLE
🐛  Center emulated video posters.

### DIFF
--- a/extensions/amp-video/0.1/amp-video.js
+++ b/extensions/amp-video/0.1/amp-video.js
@@ -659,6 +659,7 @@ class AmpVideo extends AMP.BaseElement {
     setStyles(poster, {
       'background-image': `url(${src})`,
       'background-size': 'cover',
+      'background-position': 'center',
     });
     poster.classList.add('i-amphtml-android-poster-bug');
     this.applyFillContent(poster);


### PR DESCRIPTION
This is how real posters behave. Only needed if the poster size isn't the same as the video size.

Manually validated that this makes poster positioning perfect.

Fixes #28586