### PR TITLE
Strip srcset fallback for ESM builds

### DIFF
--- a/build-system/babel-config/pre-closure-config.js
+++ b/build-system/babel-config/pre-closure-config.js
@@ -53,6 +53,8 @@ function getPreClosureConfig() {
         // Imports that are not needed for valid transformed documents.
         '../build/ampshared.css': ['cssText', 'ampSharedCss'],
         '../build/ampdoc.css': ['cssText', 'ampDocCss'],
+        // Srcset fallbacks aren't needed in ESM builds
+        '../src/utils/img': ['guaranteeSrcForSrcsetUnsupportedBrowsers'],
         // Used by experiment
         [fixedLayerImport]: ['FixedLayer'],
       },


### PR DESCRIPTION
The fallback sets a `src` attribute if there is not one and the browser doesn't understand `srcset`. It's just for IE.