### PR TITLE
🐛 Switch analytics video play event to video play event.

### DIFF
--- a/extensions/amp-analytics/amp-video-analytics.md
+++ b/extensions/amp-analytics/amp-video-analytics.md
@@ -56,6 +56,8 @@ The `video-play` trigger is fired when the video begins playing from a user clic
 }
 ```
 
+_Note:_ This event was initially mapped to the `playing` event emitted by video elements instead of the `play` event. This may lead to overcounting as those events are also emitted when playing was interrupted by network issues. While this bug has been fixed in general, individual video players may continue to use the `playing` event internally instead of the `play` event.
+
 ### Video pause trigger (`"on": "video-pause"`)
 
 The `video-pause` trigger is fired when the video stops playing from a user clicking pause, from autoplay pausing, or from the video reaching the end. Use these configurations to fire a request for this event.

--- a/extensions/amp-video/0.1/amp-video.js
+++ b/extensions/amp-video/0.1/amp-video.js
@@ -555,6 +555,7 @@ class AmpVideo extends AMP.BaseElement {
         VideoEvents.LOADEDMETADATA,
         VideoEvents.PAUSE,
         VideoEvents.PLAYING,
+        VideoEvents.PLAY,
       ],
       video
     );

--- a/extensions/amp-video/0.1/test/test-amp-video.js
+++ b/extensions/amp-video/0.1/test/test-amp-video.js
@@ -599,7 +599,9 @@ describes.realWin(
       impl.mute();
       await listenOncePromise(v, VideoEvents.MUTED);
       impl.play();
+      const playPromise = listenOncePromise(v, VideoEvents.PLAY);
       await listenOncePromise(v, VideoEvents.PLAYING);
+      await playPromise;
       impl.pause();
       await listenOncePromise(v, VideoEvents.PAUSE);
       impl.unmute();

--- a/src/service/video-manager-impl.js
+++ b/src/service/video-manager-impl.js
@@ -517,6 +517,9 @@ class VideoEntry {
       this.videoLoaded()
     );
     listen(video.element, VideoEvents.PAUSE, () => this.videoPaused_());
+    listen(video.element, VideoEvents.PLAY, () =>
+      analyticsEvent(this, VideoAnalyticsEvents.PLAY)
+    );
     listen(video.element, VideoEvents.PLAYING, () => this.videoPlayed_());
     listen(video.element, VideoEvents.MUTED, () => (this.muted_ = true));
     listen(video.element, VideoEvents.UNMUTED, () => {
@@ -681,7 +684,6 @@ class VideoEntry {
     if (this.isVisible_) {
       this.visibilitySessionManager_.beginSession();
     }
-    analyticsEvent(this, VideoAnalyticsEvents.PLAY);
   }
 
   /**

--- a/src/service/video-manager-impl.js
+++ b/src/service/video-manager-impl.js
@@ -492,6 +492,9 @@ class VideoEntry {
     /** @private {boolean} */
     this.muted_ = false;
 
+    /** @private {boolean} */
+    this.hasSeenPlayEvent_ = false;
+
     this.hasAutoplay = video.element.hasAttribute(VideoAttributes.AUTOPLAY);
 
     if (this.hasAutoplay) {
@@ -517,9 +520,10 @@ class VideoEntry {
       this.videoLoaded()
     );
     listen(video.element, VideoEvents.PAUSE, () => this.videoPaused_());
-    listen(video.element, VideoEvents.PLAY, () =>
-      analyticsEvent(this, VideoAnalyticsEvents.PLAY)
-    );
+    listen(video.element, VideoEvents.PLAY, () => {
+      this.hasSeenPlayEvent_ = true;
+      analyticsEvent(this, VideoAnalyticsEvents.PLAY);
+    });
     listen(video.element, VideoEvents.PLAYING, () => this.videoPlayed_());
     listen(video.element, VideoEvents.MUTED, () => (this.muted_ = true));
     listen(video.element, VideoEvents.UNMUTED, () => {
@@ -683,6 +687,14 @@ class VideoEntry {
     this.actionSessionManager_.beginSession();
     if (this.isVisible_) {
       this.visibilitySessionManager_.beginSession();
+    }
+
+    // The PLAY event was omitted from the original VideoInterface. Thus
+    // not every implementation emits it. It should always happen before
+    // PLAYING. Hence we treat the PLAYING as an indication to emit the
+    // Analytics PLAY event if we haven't seen PLAY.
+    if (!this.hasSeenPlayEvent_) {
+      analyticsEvent(this, VideoAnalyticsEvents.PLAY);
     }
   }
 

--- a/src/video-interface.js
+++ b/src/video-interface.js
@@ -286,6 +286,9 @@ export const VideoEvents = {
    *
    * Fired when the video plays (either because of autoplay or the play method).
    *
+   * Note: Because this event was not originally present in this interface, we
+   * cannot rely on all all implementations to emit it.
+   *
    * @event play
    */
   PLAY: 'play',

--- a/src/video-interface.js
+++ b/src/video-interface.js
@@ -282,6 +282,15 @@ export const VideoEvents = {
   LOADEDMETADATA: 'loadedmetadata',
 
   /**
+   * play
+   *
+   * Fired when the video plays (either because of autoplay or the play method).
+   *
+   * @event play
+   */
+  PLAY: 'play',
+
+  /**
    * playing
    *
    * Fired when the video begins playing.


### PR DESCRIPTION
For backward compat, because not all video players emit a play event, this change continues to emit the analytics play upon the video playing event if no video play event has been seen.

The existing integration tests should cover this as there isn't a change in behavior for simple cases (where playback isn't interrupted by network issues).

Fixes #23509 