### PR TITLE
🐛 Don't error if null adPromise after resumeCallback

### DIFF
--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -1146,7 +1146,7 @@ export class AmpA4A extends AMP.BaseElement {
   attemptToRenderCreative() {
     // Promise may be null if element was determined to be invalid for A4A.
     if (!this.adPromise_) {
-      if (this.shouldInitializePromiseChain_()) {
+      if (this.shouldInitializePromiseChain_() && !this.fromResumeCallback) {
         dev().error(TAG, 'Null promise in layoutCallback');
       }
       return Promise.resolve();


### PR DESCRIPTION
All day trying to debug for a 1/2 line change :)

There is some sort of weird hard to reproduce condition where a *non-amp* creative is unloaded (`this.adPromise_ = null`) then `layoutCallback` is called without `onLayoutMeasure` starting the ad request first. 

Hopefully solves #21116. This is one of our largest recurring errors. My plan is to monitor the new nightly after this is merged, and hope the error goes away. 

The rest are just notes to myself in case the error persists:
- I was able to see the error in prod 2 times but involved frantic swiping around of the carousel :( 
- Verified that it happens in pages with neither sra nor refresh.
- Doubleclick impl only calls `super.unlayoutCallback` on non amp creatives.
- There is logic here that explicitly will call `onlayoutMeasure` if the resource is not scheduled to be measured
https://github.com/ampproject/amphtml/blob/145403d4bd795b2c9515019fd87f3da06af4942d/extensions/amp-a4a/0.1/amp-a4a.js#L535
but in my testing the measure was always automatically scheduled.
 
