### PR TITLE
♻️ Use IS_ESM to skip polyfills/fixes

### DIFF
--- a/3p/polyfills.js
+++ b/3p/polyfills.js
@@ -23,6 +23,8 @@ import {install as installMathSign} from '../src/polyfills/math-sign';
 import {install as installObjectAssign} from '../src/polyfills/object-assign';
 import {install as installObjectValues} from '../src/polyfills/object-values';
 
-installMathSign(self);
-installObjectAssign(self);
-installObjectValues(self);
+if (!IS_ESM) {
+  installMathSign(self);
+  installObjectAssign(self);
+  installObjectValues(self);
+}

--- a/build-system/babel-config/pre-closure-config.js
+++ b/build-system/babel-config/pre-closure-config.js
@@ -16,7 +16,7 @@
 'use strict';
 
 const argv = require('minimist')(process.argv.slice(2));
-const {getExperimentConstant, getReplacePlugin} = require('./helpers');
+const {getReplacePlugin} = require('./helpers');
 
 /**
  * Gets the config for pre-closure babel transforms run during `gulp dist`.
@@ -29,34 +29,13 @@ function getPreClosureConfig() {
   const isTestTask = testTasks.some((task) => argv._.includes(task));
   const isFortesting = argv.fortesting || isTestTask;
 
-  // For experiment, remove FixedLayer import from v0.js, otherwise remove
-  // from amp-viewer-integration
-  const fixedLayerImport =
-    getExperimentConstant() == 'MOVE_FIXED_LAYER'
-      ? './../fixed-layer'
-      : '../../../src/service/fixed-layer';
   const filterImportsPlugin = [
     'filter-imports',
     {
       imports: {
-        // Imports removed for all ESM builds.
-        './polyfills/document-contains': ['installDocContains'],
-        './polyfills/domtokenlist': ['installDOMTokenList'],
-        './polyfills/fetch': ['installFetch'],
-        './polyfills/math-sign': ['installMathSign'],
-        './polyfills/object-assign': ['installObjectAssign'],
-        './polyfills/object-values': ['installObjectValues'],
-        './polyfills/promise': ['installPromise'],
-        './polyfills/array-includes': ['installArrayIncludes'],
-        './ie-media-bug': ['ieMediaCheckAndFix'],
-        '../third_party/css-escape/css-escape': ['cssEscape'],
         // Imports that are not needed for valid transformed documents.
         '../build/ampshared.css': ['cssText', 'ampSharedCss'],
         '../build/ampdoc.css': ['cssText', 'ampDocCss'],
-        // Srcset fallbacks aren't needed in ESM builds
-        '../src/utils/img': ['guaranteeSrcForSrcsetUnsupportedBrowsers'],
-        // Used by experiment
-        [fixedLayerImport]: ['FixedLayer'],
       },
     },
   ];

--- a/builtins/amp-img.js
+++ b/builtins/amp-img.js
@@ -99,7 +99,10 @@ export class AmpImg extends BaseElement {
         /* opt_removeMissingAttrs */ true
       );
       this.propagateDataset(this.img_);
-      guaranteeSrcForSrcsetUnsupportedBrowsers(this.img_);
+
+      if (!IS_ESM) {
+        guaranteeSrcForSrcsetUnsupportedBrowsers(this.img_);
+      }
     }
   }
 
@@ -185,7 +188,9 @@ export class AmpImg extends BaseElement {
     this.maybeGenerateSizes_(/* sync setAttribute */ true);
     this.propagateAttributes(ATTRIBUTES_TO_PROPAGATE, this.img_);
     this.propagateDataset(this.img_);
-    guaranteeSrcForSrcsetUnsupportedBrowsers(this.img_);
+    if (!IS_ESM) {
+      guaranteeSrcForSrcsetUnsupportedBrowsers(this.img_);
+    }
     this.applyFillContent(this.img_, true);
     propagateObjectFitStyles(this.element, this.img_);
 

--- a/src/css.js
+++ b/src/css.js
@@ -105,9 +105,8 @@ export function prependSelectorsWith(selector, distribute) {
 export function escapeCssSelectorIdent(ident) {
   if (IS_ESM) {
     return CSS.escape(ident);
-  } else {
-    return cssEscape(ident);
   }
+  return cssEscape(ident);
 }
 
 /**

--- a/src/polyfills.js
+++ b/src/polyfills.js
@@ -29,18 +29,22 @@ import {install as installObjectAssign} from './polyfills/object-assign';
 import {install as installObjectValues} from './polyfills/object-values';
 import {install as installPromise} from './polyfills/promise';
 
-installFetch(self);
-installMathSign(self);
-installObjectAssign(self);
-installObjectValues(self);
-installPromise(self);
-installArrayIncludes(self);
+if (!IS_ESM) {
+  installFetch(self);
+  installMathSign(self);
+  installObjectAssign(self);
+  installObjectValues(self);
+  installPromise(self);
+  installArrayIncludes(self);
+}
 
 // Polyfills that depend on DOM availability
 if (self.document) {
-  installDOMTokenList(self);
-  installDocContains(self);
-  installGetBoundingClientRect(self);
+  if (!IS_ESM) {
+    installDOMTokenList(self);
+    installDocContains(self);
+    installGetBoundingClientRect(self);
+  }
   // The anonymous class parameter allows us to detect native classes vs
   // transpiled classes.
   installCustomElements(self, class {});

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -374,6 +374,10 @@ export class ResourcesImpl {
       const input = Services.inputFor(this.win);
       input.setupInputModeClasses(this.ampdoc);
 
+      if (IS_ESM) {
+        return;
+      }
+
       // With IntersectionObserver, no need for remeasuring hacks.
       if (!this.intersectionObserver_) {
         const fixPromise = ieMediaCheckAndFix(this.win);


### PR DESCRIPTION
This will still allow the code to DCE, and is less brittle than using the import's path and local binding. See https://github.com/ampproject/amphtml/pull/28817/files#r438452603.

Also skips `installGetBoundingClientRect`, which is only needed for old IE.