### PR TITLE
🐛 Bug fix: Avoid aligning to the viewport if the full-width resize failed before.

### DIFF
--- a/extensions/amp-ad-network-adsense-impl/0.1/responsive-state.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/responsive-state.js
@@ -373,7 +373,7 @@ export class ResponsiveState {
           if (this.isContainerWidth_) {
             setStyle(this.element_, 'width', '100%');
           } else {
-            // Exit if the full-width resize did not success before.
+            // Exit if the full-width resize did not succeed before.
             if (elementStyleWidth != viewportSize.width) {
               return;
             }

--- a/extensions/amp-ad-network-adsense-impl/0.1/responsive-state.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/responsive-state.js
@@ -23,7 +23,7 @@ import {
 import {Services} from '../../../src/services';
 import {addExperimentIdToElement} from '../../../ads/google/a4a/traffic-experiments';
 import {clamp} from '../../../src/utils/math';
-import {computedStyle, setStyle} from '../../../src/style';
+import {computedStyle, getStyle, setStyle} from '../../../src/style';
 import {dev, devAssert, user} from '../../../src/log';
 import {getData} from '../../../src/event-helper';
 import {hasOwn} from '../../../src/utils/object';
@@ -351,6 +351,11 @@ export class ResponsiveState {
     this.isAlignedToViewport_ = true;
     const vsync = Services.vsyncFor(this.win_);
     const layoutBox = this.element_.getLayoutBox();
+    const viewportSize = Services.viewportForDoc(
+      this.element_.getAmpDoc()
+    ).getSize();
+    const elementStyleWidth =
+      parseInt(getStyle(this.element_, 'width'), 10) || 0;
     // Nudge into the correct horizontal position by changing side margin.
     vsync.run(
       {
@@ -368,6 +373,10 @@ export class ResponsiveState {
           if (this.isContainerWidth_) {
             setStyle(this.element_, 'width', '100%');
           } else {
+            // Exit if the full-width resize did not success before.
+            if (elementStyleWidth != viewportSize.width) {
+              return;
+            }
             if (state.direction == 'rtl') {
               setStyle(this.element_, 'marginRight', layoutBox.left, 'px');
             } else {
@@ -462,16 +471,16 @@ export class ResponsiveState {
     // Attempt to resize to the correct height. The width should already be
     // 100vw, but is fixed here so that future resizes of the viewport don't
     // affect it.
-    return this.element_
-      .getImpl(/* waitForBuild= */ false)
-      .then((impl) =>
-        impl
-          .attemptChangeSize(
-            this.getResponsiveHeight_(viewportSize),
-            viewportSize.width
-          )
-          .catch(() => {})
-      );
+    return this.element_.getImpl(/* waitForBuild= */ false).then((impl) =>
+      impl
+        .attemptChangeSize(
+          this.getResponsiveHeight_(viewportSize),
+          viewportSize.width
+        )
+        .catch(() => {
+          dev().info(TAG, `Change size attempt failed.`);
+        })
+    );
   }
 
   /**

--- a/extensions/amp-ad-network-adsense-impl/0.1/test/test-responsive-state.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/test/test-responsive-state.js
@@ -255,9 +255,10 @@ describes.realWin(
         const state = createState({
           'data-auto-format': [ADSENSE_RSPV_TAG],
           'data-full-width': '',
-          'height': '500px',
+          'height': '200px',
           'width': '100vw',
         });
+        element.style.width = '375px';
 
         state.alignToViewport();
 
@@ -269,15 +270,34 @@ describes.realWin(
         const state = createState({
           'data-auto-format': [ADSENSE_RSPV_TAG],
           'data-full-width': '',
-          'height': '500px',
+          'height': '200px',
           'width': '100vw',
         });
+        element.style.width = '375px';
         element.parentElement.style.direction = 'rtl';
 
         state.alignToViewport();
 
         expect(element.style.marginLeft).to.be.equal('');
         expect(element.style.marginRight).to.be.equal('50px');
+
+        element.parentElement.style.direction = '';
+      });
+
+      it('Do not align the element if its full-width resize failed', () => {
+        const state = createState({
+          'data-auto-format': [ADSENSE_RSPV_TAG],
+          'data-full-width': '',
+          'height': '100px',
+          'width': '100vw',
+        });
+        // The viewport width is 375.
+        element.style.width = '200px';
+
+        state.alignToViewport();
+
+        expect(element.style.marginLeft).to.be.equal('');
+        expect(element.style.marginRight).to.be.equal('');
 
         element.parentElement.style.direction = '';
       });


### PR DESCRIPTION
AMP could reject ad size optimization's attempt to resize the element in the viewport. This fix add a check to avoid the unnecessary alignment with viewport if the resize failed.

@calebcordry PTAL.