### PR TITLE
🏗 Run integration tests and only some unit tests on Sauce Labs, only during push builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -85,6 +85,7 @@ jobs:
         - unbuffer node build-system/pr-check/dist-tests.js
     - stage: test
       name: 'Remote (Sauce Labs) Tests'
+      if: type = push
       script:
         - unbuffer node build-system/pr-check/remote-tests.js
       after_script:

--- a/build-system/pr-check/remote-tests.js
+++ b/build-system/pr-check/remote-tests.js
@@ -17,21 +17,25 @@
 
 /**
  * @fileoverview
- * This script kicks off the integration tests on Sauce Labs during push builds.
+ * This script kicks off the unit and integration tests on Sauce Labs.
  * This is run during the CI stage = test; job = remote tests.
  */
 
+const colors = require('ansi-colors');
 const {
   downloadDistOutput,
+  printChangeSummary,
   startTimer,
   stopTimer,
   startSauceConnect,
   stopSauceConnect,
   timedExecOrDie: timedExecOrDieBase,
 } = require('./utils');
+const {determineBuildTargets} = require('./build-targets');
 const {isTravisPullRequestBuild} = require('../common/travis');
 
 const FILENAME = 'remote-tests.js';
+const FILELOGPREFIX = colors.bold(colors.yellow(`${FILENAME}:`));
 const timedExecOrDie = (cmd) => timedExecOrDieBase(cmd, FILENAME);
 
 async function main() {
@@ -42,11 +46,51 @@ async function main() {
     timedExecOrDie('gulp update-packages');
 
     await startSauceConnect(FILENAME);
+    timedExecOrDie('gulp unit --nobuild --saucelabs');
     timedExecOrDie(
       'gulp integration --nobuild --compiled --saucelabs --stable'
     );
     timedExecOrDie('gulp integration --nobuild --compiled --saucelabs --beta');
 
+    stopSauceConnect(FILENAME);
+  } else {
+    printChangeSummary(FILENAME);
+    const buildTargets = determineBuildTargets(FILENAME);
+    if (
+      !buildTargets.has('RUNTIME') &&
+      !buildTargets.has('FLAG_CONFIG') &&
+      !buildTargets.has('UNIT_TEST') &&
+      !buildTargets.has('INTEGRATION_TEST')
+    ) {
+      console.log(
+        `${FILELOGPREFIX} Skipping`,
+        colors.cyan('Remote (Sauce Labs) Tests'),
+        'because this commit does not affect the runtime, flag configs,',
+        'unit tests, or integration tests.'
+      );
+      stopTimer(FILENAME, FILENAME, startTime);
+      return;
+    }
+    downloadDistOutput(FILENAME);
+    timedExecOrDie('gulp update-packages');
+    await startSauceConnect(FILENAME);
+
+    if (buildTargets.has('RUNTIME') || buildTargets.has('UNIT_TEST')) {
+      timedExecOrDie('gulp unit --nobuild --saucelabs');
+    }
+
+    if (
+      buildTargets.has('RUNTIME') ||
+      buildTargets.has('FLAG_CONFIG') ||
+      buildTargets.has('INTEGRATION_TEST')
+    ) {
+      timedExecOrDie(
+        'gulp integration --nobuild --compiled --saucelabs --stable'
+      );
+      timedExecOrDie(
+        'gulp integration --nobuild --compiled --saucelabs --beta'
+      );
+    }
     stopSauceConnect(FILENAME);
   }
 

--- a/build-system/pr-check/remote-tests.js
+++ b/build-system/pr-check/remote-tests.js
@@ -17,25 +17,21 @@
 
 /**
  * @fileoverview
- * This script kicks off the unit and integration tests on Sauce Labs.
+ * This script kicks off the integration tests on Sauce Labs during push builds.
  * This is run during the CI stage = test; job = remote tests.
  */
 
-const colors = require('ansi-colors');
 const {
   downloadDistOutput,
-  printChangeSummary,
   startTimer,
   stopTimer,
   startSauceConnect,
   stopSauceConnect,
   timedExecOrDie: timedExecOrDieBase,
 } = require('./utils');
-const {determineBuildTargets} = require('./build-targets');
 const {isTravisPullRequestBuild} = require('../common/travis');
 
 const FILENAME = 'remote-tests.js';
-const FILELOGPREFIX = colors.bold(colors.yellow(`${FILENAME}:`));
 const timedExecOrDie = (cmd) => timedExecOrDieBase(cmd, FILENAME);
 
 async function main() {
@@ -46,51 +42,11 @@ async function main() {
     timedExecOrDie('gulp update-packages');
 
     await startSauceConnect(FILENAME);
-    timedExecOrDie('gulp unit --nobuild --saucelabs');
     timedExecOrDie(
       'gulp integration --nobuild --compiled --saucelabs --stable'
     );
     timedExecOrDie('gulp integration --nobuild --compiled --saucelabs --beta');
 
-    stopSauceConnect(FILENAME);
-  } else {
-    printChangeSummary(FILENAME);
-    const buildTargets = determineBuildTargets(FILENAME);
-    if (
-      !buildTargets.has('RUNTIME') &&
-      !buildTargets.has('FLAG_CONFIG') &&
-      !buildTargets.has('UNIT_TEST') &&
-      !buildTargets.has('INTEGRATION_TEST')
-    ) {
-      console.log(
-        `${FILELOGPREFIX} Skipping`,
-        colors.cyan('Remote (Sauce Labs) Tests'),
-        'because this commit does not affect the runtime, flag configs,',
-        'unit tests, or integration tests.'
-      );
-      stopTimer(FILENAME, FILENAME, startTime);
-      return;
-    }
-    downloadDistOutput(FILENAME);
-    timedExecOrDie('gulp update-packages');
-    await startSauceConnect(FILENAME);
-
-    if (buildTargets.has('RUNTIME') || buildTargets.has('UNIT_TEST')) {
-      timedExecOrDie('gulp unit --nobuild --saucelabs');
-    }
-
-    if (
-      buildTargets.has('RUNTIME') ||
-      buildTargets.has('FLAG_CONFIG') ||
-      buildTargets.has('INTEGRATION_TEST')
-    ) {
-      timedExecOrDie(
-        'gulp integration --nobuild --compiled --saucelabs --stable'
-      );
-      timedExecOrDie(
-        'gulp integration --nobuild --compiled --saucelabs --beta'
-      );
-    }
     stopSauceConnect(FILENAME);
   }
 

--- a/build-system/pr-check/utils.js
+++ b/build-system/pr-check/utils.js
@@ -16,7 +16,6 @@
 'use strict';
 
 const colors = require('ansi-colors');
-const requestPromise = require('request-promise');
 const {
   gitBranchCreationPoint,
   gitBranchName,
@@ -115,15 +114,13 @@ function printChangeSummary(fileName) {
 }
 
 /**
- * Starts connection to Sauce Labs after getting account credentials
+ * Starts connection to Sauce Labs using account credentials from env vars.
  * @param {string} functionName
  */
 async function startSauceConnect(functionName) {
-  process.env['SAUCE_USERNAME'] = 'amphtml';
-  const response = await requestPromise(
-    'https://amphtml-sauce-token-dealer.appspot.com/getJwtToken'
-  );
-  process.env['SAUCE_ACCESS_KEY'] = response.trim();
+  if (!process.env.SAUCE_USERNAME || !process.env.SAUCE_ACCESS_KEY) {
+    throw new Error('Missing Sauce Labs credentials');
+  }
   const startScCmd = 'build-system/sauce_connect/start_sauce_connect.sh';
   const fileLogPrefix = colors.bold(colors.yellow(`${functionName}:`));
   console.log(

--- a/build-system/tasks/report-test-status.js
+++ b/build-system/tasks/report-test-status.js
@@ -29,14 +29,11 @@ const IS_GULP_UNIT = argv._[0] === 'unit';
 const IS_GULP_E2E = argv._[0] === 'e2e';
 
 const IS_LOCAL_CHANGES = !!argv.local_changes;
-const IS_SAUCELABS = !!argv.saucelabs;
-const IS_SAUCELABS_STABLE = !!argv.saucelabs && !!argv.stable;
-const IS_SAUCELABS_BETA = !!argv.saucelabs && !!argv.beta;
 const IS_DIST = !!argv.compiled;
 
 const TEST_TYPE_SUBTYPES = new Map([
-  ['integration', ['local', 'minified', 'saucelabs-beta', 'saucelabs-stable']],
-  ['unit', ['local', 'local-changes', 'saucelabs']],
+  ['integration', ['local', 'minified']],
+  ['unit', ['local', 'local-changes']],
   ['e2e', ['local']],
 ]);
 const TEST_TYPE_BUILD_TARGETS = new Map([
@@ -63,13 +60,7 @@ function inferTestType() {
     return `${type}/local-changes`;
   }
 
-  if (IS_SAUCELABS_BETA) {
-    return `${type}/saucelabs-beta`;
-  } else if (IS_SAUCELABS_STABLE) {
-    return `${type}/saucelabs-stable`;
-  } else if (IS_SAUCELABS) {
-    return `${type}/saucelabs`;
-  } else if (IS_DIST) {
+  if (IS_DIST) {
     return `${type}/minified`;
   }
 

--- a/build-system/tasks/report-test-status.js
+++ b/build-system/tasks/report-test-status.js
@@ -58,13 +58,11 @@ function inferTestType() {
 
   if (IS_LOCAL_CHANGES) {
     return `${type}/local-changes`;
-  }
-
-  if (IS_DIST) {
+  } else if (IS_DIST) {
     return `${type}/minified`;
+  } else {
+    return `${type}/local`;
   }
-
-  return `${type}/local`;
 }
 
 function postReport(type, action) {

--- a/build-system/test-configs/config.js
+++ b/build-system/test-configs/config.js
@@ -81,11 +81,8 @@ const unitTestPaths = [
   'extensions/**/test/unit/*.js',
 ];
 
-const unitTestOnSaucePaths = [
-  'test/unit/**/*.js',
-  'ads/**/test/test-*.js',
-  'ads/**/test/unit/test-*.js',
-];
+// TODO(rsimha, #28838): Refine this opt-in mechanism.
+const unitTestOnSaucePaths = ['test/unit/test-error.js'];
 
 const integrationTestPaths = [
   'test/integration/**/*.js',


### PR DESCRIPTION
The credentials have already been set as secure env vars on Travis (available during push builds).

Partial mitigation for #28343.
Related to #28790.