### PR TITLE
🚮 remove duplicated loader selector  

### DIFF
--- a/extensions/amp-loader/0.1/amp-loader.css
+++ b/extensions/amp-loader/0.1/amp-loader.css
@@ -94,10 +94,6 @@
   margin: 12px;
 }
 
-.i-amphtml-new-loader-has-shim {
-  color: #fff !important;
-}
-
 .i-amphtml-new-loader-has-shim .i-amphtml-new-loader-shim {
   display: initial;
 }


### PR DESCRIPTION
noticed this repeated style rule while investigating https://github.com/ampproject/amphtml/issues/26319