### PR TITLE
🐛 [amp-mathml] Update config to remove math formulas from tabIndex

### DIFF
--- a/3p/mathml.js
+++ b/3p/mathml.js
@@ -59,6 +59,9 @@ export function mathml(global, data) {
       global.document.body.appendChild(div);
       mathjax.Hub.Config({
         showMathMenu: false,
+        // (#26082): From a11y perspective, user should not be able to tab to
+        // the math formula which has no functionality to interact with.  This
+        // configuration removes the formula from the tab-index.
         menuSettings: {
           inTabOrder: false,
         },

--- a/3p/mathml.js
+++ b/3p/mathml.js
@@ -59,6 +59,9 @@ export function mathml(global, data) {
       global.document.body.appendChild(div);
       mathjax.Hub.Config({
         showMathMenu: false,
+        menuSettings: {
+          inTabOrder: false,
+        },
       });
       mathjax.Hub.Queue(function () {
         const rendered = document.getElementById('MathJax-Element-1-Frame');


### PR DESCRIPTION
Fixes: https://github.com/ampproject/amphtml/issues/26082

Update the config object for the `mathjax` library to remove math formulas from tabIndex (user will no longer be able to access the math formula by tabbing to it, (this is desired))