### PR TITLE
🐛 Prevent layoutCallback if resource state changes after scheduling layout

### DIFF
--- a/src/inabox/inabox-resources.js
+++ b/src/inabox/inabox-resources.js
@@ -198,6 +198,7 @@ export class InaboxResources {
    * @private
    */
   doPass_() {
+    const now = Date.now();
     dev().fine(TAG, 'doPass');
     // measure in a batch
     this.resources_.forEach((resource) => {
@@ -212,6 +213,7 @@ export class InaboxResources {
         resource.getState() === ResourceState.READY_FOR_LAYOUT &&
         resource.isDisplayed()
       ) {
+        resource.layoutScheduled(now);
         resource.startLayout();
       }
     });

--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -19,7 +19,7 @@ import {Layout} from '../layout';
 import {Services} from '../services';
 import {computedStyle, toggle} from '../style';
 import {dev, devAssert} from '../log';
-import {isBlockedByConsent} from '../error';
+import {isBlockedByConsent, reportError} from '../error';
 import {
   layoutRectLtwh,
   layoutRectSizeEquals,
@@ -885,6 +885,13 @@ export class Resource {
     }
     if (this.state_ == ResourceState.LAYOUT_FAILED) {
       return Promise.reject(this.lastLayoutError_);
+    }
+    if (this.state_ != ResourceState.LAYOUT_SCHEDULED) {
+      const err = dev().createError(
+        'startLayout called but not LAYOUT_SCHEDULED'
+      );
+      reportError(err, this.element);
+      return Promise.reject(err);
     }
 
     devAssert(

--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -886,13 +886,6 @@ export class Resource {
     if (this.state_ == ResourceState.LAYOUT_FAILED) {
       return Promise.reject(this.lastLayoutError_);
     }
-    if (this.state_ != ResourceState.LAYOUT_SCHEDULED) {
-      const err = dev().createError(
-        'startLayout called but not LAYOUT_SCHEDULED'
-      );
-      reportError(err, this.element);
-      return Promise.reject(err);
-    }
 
     devAssert(
       this.state_ != ResourceState.NOT_BUILT,
@@ -901,6 +894,14 @@ export class Resource {
       this.state_
     );
     devAssert(this.isDisplayed(), 'Not displayed for layout: %s', this.debugid);
+
+    if (this.state_ != ResourceState.LAYOUT_SCHEDULED) {
+      const err = dev().createError(
+        'startLayout called but not LAYOUT_SCHEDULED'
+      );
+      reportError(err, this.element);
+      return Promise.reject(err);
+    }
 
     // Unwanted re-layouts are ignored.
     if (this.layoutCount_ > 0 && !this.element.isRelayoutNeeded()) {

--- a/test/unit/test-resource.js
+++ b/test/unit/test-resource.js
@@ -551,6 +551,7 @@ describes.realWin('Resource', {amp: true}, (env) => {
 
   it('should ignore startLayout if already completed or failed or going', () => {
     elementMock.expects('layoutCallback').never();
+    resource.layoutBox_ = {left: 11, top: 12, width: 10, height: 10};
 
     resource.state_ = ResourceState.LAYOUT_COMPLETE;
     resource.startLayout();
@@ -559,6 +560,11 @@ describes.realWin('Resource', {amp: true}, (env) => {
     resource.startLayout();
 
     resource.state_ = ResourceState.READY_FOR_LAYOUT;
+    allowConsoleError(() => {
+      resource.startLayout();
+    });
+
+    resource.state_ = ResourceState.LAYOUT_SCHEDULED;
     resource.layoutPromise_ = {};
     resource.startLayout();
   });
@@ -576,7 +582,7 @@ describes.realWin('Resource', {amp: true}, (env) => {
 
   it('should ignore startLayout if not visible', () => {
     elementMock.expects('layoutCallback').never();
-    resource.state_ = ResourceState.READY_FOR_LAYOUT;
+    resource.state_ = ResourceState.LAYOUT_SCHEDULED;
     resource.layoutBox_ = {left: 11, top: 12, width: 0, height: 0};
     allowConsoleError(() => {
       expect(() => {
@@ -588,7 +594,7 @@ describes.realWin('Resource', {amp: true}, (env) => {
   it('should force startLayout for first layout', () => {
     elementMock.expects('layoutCallback').returns(Promise.resolve()).once();
 
-    resource.state_ = ResourceState.READY_FOR_LAYOUT;
+    resource.state_ = ResourceState.LAYOUT_SCHEDULED;
     resource.layoutBox_ = {left: 11, top: 12, width: 10, height: 10};
     resource.startLayout();
     expect(resource.getState()).to.equal(ResourceState.LAYOUT_SCHEDULED);
@@ -597,7 +603,7 @@ describes.realWin('Resource', {amp: true}, (env) => {
   it('should ignore startLayout for re-layout when not opt-in', () => {
     elementMock.expects('layoutCallback').never();
 
-    resource.state_ = ResourceState.READY_FOR_LAYOUT;
+    resource.state_ = ResourceState.LAYOUT_SCHEDULED;
     resource.layoutBox_ = {left: 11, top: 12, width: 10, height: 10};
     resource.layoutCount_ = 1;
     elementMock.expects('isRelayoutNeeded').returns(false).atLeast(1);
@@ -608,7 +614,7 @@ describes.realWin('Resource', {amp: true}, (env) => {
   it('should force startLayout for re-layout when opt-in', () => {
     elementMock.expects('layoutCallback').returns(Promise.resolve()).once();
 
-    resource.state_ = ResourceState.READY_FOR_LAYOUT;
+    resource.state_ = ResourceState.LAYOUT_SCHEDULED;
     resource.layoutBox_ = {left: 11, top: 12, width: 10, height: 10};
     resource.layoutCount_ = 1;
     elementMock.expects('isRelayoutNeeded').returns(true).atLeast(1);
@@ -619,7 +625,7 @@ describes.realWin('Resource', {amp: true}, (env) => {
   it('should complete startLayout', () => {
     elementMock.expects('layoutCallback').returns(Promise.resolve()).once();
 
-    resource.state_ = ResourceState.READY_FOR_LAYOUT;
+    resource.state_ = ResourceState.LAYOUT_SCHEDULED;
     resource.layoutBox_ = {left: 11, top: 12, width: 10, height: 10};
     const loaded = resource.loadedOnce();
     const promise = resource.startLayout();
@@ -637,7 +643,7 @@ describes.realWin('Resource', {amp: true}, (env) => {
     elementMock.expects('layoutCallback').returns(Promise.resolve()).once();
     elementMock.expects('getLayout').returns('fluid').once();
 
-    resource.state_ = ResourceState.READY_FOR_LAYOUT;
+    resource.state_ = ResourceState.LAYOUT_SCHEDULED;
     resource.layoutBox_ = {left: 11, top: 12, width: 10, height: 0};
     const loaded = resource.loadedOnce();
     const promise = resource.startLayout();
@@ -655,7 +661,7 @@ describes.realWin('Resource', {amp: true}, (env) => {
     const error = new Error('intentional');
     elementMock.expects('layoutCallback').returns(Promise.reject(error)).once();
 
-    resource.state_ = ResourceState.READY_FOR_LAYOUT;
+    resource.state_ = ResourceState.LAYOUT_SCHEDULED;
     resource.layoutBox_ = {left: 11, top: 12, width: 10, height: 10};
     const promise = resource.startLayout();
     expect(resource.layoutPromise_).to.not.equal(null);
@@ -698,7 +704,7 @@ describes.realWin('Resource', {amp: true}, (env) => {
   });
 
   it('should not record layout schedule time in startLayout', () => {
-    resource.state_ = ResourceState.READY_FOR_LAYOUT;
+    resource.state_ = ResourceState.LAYOUT_SCHEDULED;
     resource.layoutBox_ = {left: 11, top: 12, width: 10, height: 10};
     allowConsoleError(() => resource.startLayout());
 
@@ -878,6 +884,7 @@ describes.realWin('Resource', {amp: true}, (env) => {
 
       resource.unlayout();
 
+      resource.state_ = ResourceState.LAYOUT_SCHEDULED;
       elementMock.expects('layoutCallback').returns(Promise.resolve()).once();
       resource.measure();
       resource.startLayout();


### PR DESCRIPTION
I think there's a race condition where:

1. The element is schedule for layout
2. The page becomes hidden (swipe to next page, or change tabs)
3. The element's scheduled layout finally starts

I think the `state` is being reset to `NOT_LAID_OUT` or `READY_FOR_LAYOUT`, and somehow the `startLayout` method is being called. Either state is acceptable for `startLayout` for some reason. Really, we should only be accepting the resource when it's `LAYOUT_SCHEDULED`, which happens when the (async) layout flow is started. If anything happens between the start of that flow and the time the `startLayout` method is called, we're in a broken flow.

Re: https://github.com/ampproject/amphtml/issues/21116