### PR TITLE
AdSense/Doubleclick ensure ad request timing accounts for prerender

### DIFF
--- a/ads/google/a4a/utils.js
+++ b/ads/google/a4a/utils.js
@@ -286,7 +286,11 @@ export function googlePageParameters(a4a, startTime) {
       dev().expectedError('AMP-A4A', 'Referrer timeout!');
       return '';
     });
-  const domLoading = getNavigationTiming(win, 'domLoading');
+  // Set dom loading time to first visible if page started in prerender state
+  // determined by truthy value for visibilityState param.
+  const domLoading = a4a.getAmpDoc().getParam('visibilityState') ?
+    a4a.getAmpDoc().getLastVisibleTime() :
+    getNavigationTiming(win, 'domLoading');
   return Promise.all([
     getOrCreateAdCid(ampDoc, 'AMP_ECID_GOOGLE', '_ga'),
     referrerPromise,

--- a/ads/google/a4a/utils.js
+++ b/ads/google/a4a/utils.js
@@ -288,9 +288,9 @@ export function googlePageParameters(a4a, startTime) {
     });
   // Set dom loading time to first visible if page started in prerender state
   // determined by truthy value for visibilityState param.
-  const domLoading = a4a.getAmpDoc().getParam('visibilityState') ?
-    a4a.getAmpDoc().getLastVisibleTime() :
-    getNavigationTiming(win, 'domLoading');
+  const domLoading = a4a.getAmpDoc().getParam('visibilityState')
+    ? a4a.getAmpDoc().getLastVisibleTime()
+    : getNavigationTiming(win, 'domLoading');
   return Promise.all([
     getOrCreateAdCid(ampDoc, 'AMP_ECID_GOOGLE', '_ga'),
     referrerPromise,


### PR DESCRIPTION
For amp-ad type=adsense or doubleclick requests, ensure timing parameter accounts for prerendered pages within the viewport.