### PR TITLE
♿  Remove aria-live attribute on amp-story.

### DIFF
--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -460,7 +460,6 @@ export class AmpStory extends AMP.BaseElement {
         );
       });
     }
-    this.element.setAttribute('aria-live', 'polite');
   }
 
   /**


### PR DESCRIPTION
This prevents TalkBack from reading/announcing information and labels that are not currently visible on the page.

This prevents TalkBack from reading story page content automatically, making the experience more consistent with TalkBack's default behavior.

This makes #28780 obsolete.
This fixes #28408 and #28294.