### PR TITLE
🐛 Fix infinite loop in story ads

### DIFF
--- a/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js
+++ b/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js
@@ -263,7 +263,6 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
   /**
    * Determine if enough pages in the story are left for ad placement to be
    * possible.
-   * TODO(ccordry): also use this on subsequent ad requests.
    * @param {number} pageIndex
    * @return {boolean}
    * @private
@@ -432,6 +431,8 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
   }
 
   /**
+   * Respond to page navigation event. This method is not called for the first
+   * page that is shown on load.
    * @param {number} pageIndex
    * @param {string} pageId
    * @private
@@ -487,12 +488,14 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
       this.idOfAdShowing_ = adIndex;
     }
 
-    // If there is already an ad inserted, but not viewed it doesn't matter how
-    // many pages we have seen, we should not keep trying to insert more ads.
     if (
       !this.pendingAdView_ &&
       this.enoughContentPagesViewed_() &&
-      !this.tryingToPlace_
+      // If there is already an ad inserted, but not viewed it doesn't matter how
+      // many pages we have seen, we should not keep trying to insert more ads.
+      !this.tryingToPlace_ &&
+      // Prevent edge case where we try to place an ad twice. See #28840.
+      this.adsPlaced_ < this.adPagesCreated_
     ) {
       this.tryToPlaceAdAfterPage_(pageId).then((adState) => {
         this.tryingToPlace_ = false;


### PR DESCRIPTION
If a story has less than 7 pages left when an ad is viewed we do not fetch another ad. There is an edge case where a user can still see 7 un-viewed pages after this by moving backwards through the story, or if there are 6 pages left in the story + the ad page itself. In the case we incorrectly try to place the same ad twice causing user to get stuck in a loop.

Closes #28840

cc/ @mszylkowski 