### PR TITLE
Enable sticky-ad-padding-bottom on prod

### DIFF
--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -40,5 +40,6 @@
   "version-locking": 1,
   "amp-ad-no-center-css": 0,
   "analytics-chunks": 1,
-  "fie-init-chunking": 0.1
+  "fie-init-chunking": 0.1,
+  "sticky-ad-padding-bottom": 0.05
 }


### PR DESCRIPTION
We usually see canary traffic too small to make a meaningful comparison, so we wanted to do a smaller portion of prod instead. 