### PR TITLE
🐛Add CSS rule to hide amp-loaders from stories

### DIFF
--- a/css/ampdoc.css
+++ b/css/ampdoc.css
@@ -321,6 +321,10 @@ amp-story .amp-active > div {
   display: none !important;
 }
 
+amp-story .i-amphtml-loader-background {
+  display: none !important;
+} 
+
 /**
  * Uses a selector that stops targeting amp-story-page elements once they have a
  * [distance] or [active] attribute, so amp-story.css doesn't have to rely on

--- a/css/ampdoc.css
+++ b/css/ampdoc.css
@@ -317,13 +317,13 @@ amp-story-page {
   background-color: #757575;
 }
 
-amp-story .amp-active > div {
-  display: none !important;
-}
-
+/* Hide amp-loader in stories
+ * TODO(maxbittker): remove after amp-loader is no longer imported in stories
+ */
+amp-story .amp-active > div,
 amp-story .i-amphtml-loader-background {
   display: none !important;
-} 
+}
 
 /**
  * Uses a selector that stops targeting amp-story-page elements once they have a

--- a/extensions/amp-loader/0.1/amp-loader.css
+++ b/extensions/amp-loader/0.1/amp-loader.css
@@ -94,10 +94,6 @@
   margin: 12px;
 }
 
-.i-amphtml-new-loader-has-shim {
-  color: #fff !important;
-}
-
 .i-amphtml-new-loader-has-shim .i-amphtml-new-loader-shim {
   display: initial;
 }


### PR DESCRIPTION
amp-loader is causing images with transparency (pngs, svgs, webps and gifs) render a distracting white background while being loaded.


This hides the loader background for the time-being inside stories, while we discuss removing amp-loader entirely  


fixes #26319
