### PR TITLE
🐛 Fix amp-img SSR with blurry-image placeholder

### DIFF
--- a/builtins/amp-img.js
+++ b/builtins/amp-img.js
@@ -17,12 +17,12 @@
 import {BaseElement} from '../src/base-element';
 import {Layout, isLayoutSizeDefined} from '../src/layout';
 import {Services} from '../src/services';
-import {childElementByTag, removeElement} from '../src/dom';
 import {dev} from '../src/log';
 import {guaranteeSrcForSrcsetUnsupportedBrowsers} from '../src/utils/img';
 import {listen} from '../src/event-helper';
 import {propagateObjectFitStyles, setImportantStyles} from '../src/style';
 import {registerElement} from '../src/service/custom-element-registry';
+import {removeElement, scopedQuerySelector} from '../src/dom';
 
 /** @const {string} */
 const TAG = 'amp-img';
@@ -164,7 +164,7 @@ export class AmpImg extends BaseElement {
     // For inabox SSR, image will have been written directly to DOM so no need
     // to recreate.  Calling appendChild again will have no effect.
     if (this.element.hasAttribute('i-amphtml-ssr')) {
-      this.img_ = childElementByTag(this.element, 'img');
+      this.img_ = scopedQuerySelector(this.element, '> img:not([placeholder])');
     }
     this.img_ = this.img_ || new Image();
     this.img_.setAttribute('decoding', 'async');

--- a/test/unit/test-amp-img.js
+++ b/test/unit/test-amp-img.js
@@ -481,6 +481,8 @@ describes.sandboxed('amp-img', {}, (env) => {
     function getImgWithBlur(addPlaceholder, addBlurClass) {
       const el = document.createElement('amp-img');
       const img = document.createElement('img');
+      el.setAttribute('src', '/examples/img/sample.jpg');
+      img.src = 'data:image/svg+xml;charset=utf-8,%3Csvg%3E%3C/svg%3E';
       if (addPlaceholder) {
         img.setAttribute('placeholder', '');
         el.getPlaceholder = () => img;
@@ -533,6 +535,49 @@ describes.sandboxed('amp-img', {}, (env) => {
       el = impl.element;
       img = el.firstChild;
       expect(impl.togglePlaceholder).to.have.been.calledWith(false);
+    });
+
+    it('does not interfere with SSR img creation', () => {
+      const impl = getImgWithBlur(true, true);
+      const ampImg = impl.element;
+      ampImg.setAttribute('i-amphtml-ssr', '');
+      impl.buildCallback();
+      impl.layoutCallback();
+
+      expect(ampImg.querySelector('img[src*="sample.jpg"]')).to.exist;
+      expect(ampImg.querySelector('img[src*="image/svg+xml"]')).to.exist;
+    });
+
+    it('does not interfere with SSR img before placeholder', () => {
+      const impl = getImgWithBlur(true, true);
+      const ampImg = impl.element;
+      ampImg.setAttribute('i-amphtml-ssr', '');
+
+      const img = document.createElement('img');
+      img.src = ampImg.getAttribute('src');
+      ampImg.insertBefore(img, impl.getPlaceholder());
+
+      impl.buildCallback();
+      impl.layoutCallback();
+
+      expect(ampImg.querySelector('img[src*="sample.jpg"]')).to.exist;
+      expect(ampImg.querySelector('img[src*="image/svg+xml"]')).to.exist;
+    });
+
+    it('does not interfere with SSR img after placeholder', () => {
+      const impl = getImgWithBlur(true, true);
+      const ampImg = impl.element;
+      ampImg.setAttribute('i-amphtml-ssr', '');
+
+      const img = document.createElement('img');
+      img.src = ampImg.getAttribute('src');
+      ampImg.appendChild(img);
+
+      impl.buildCallback();
+      impl.layoutCallback();
+
+      expect(ampImg.querySelector('img[src*="sample.jpg"]')).to.exist;
+      expect(ampImg.querySelector('img[src*="image/svg+xml"]')).to.exist;
     });
   });
 


### PR DESCRIPTION
Blurry image placeholders are also `<img>` tags inserted as a direct child of the `<amp-img>` element. This will cause conflicts with the `<amp-img>`'s SSR rendering.

We want to ignore the blurry image placeholder when finding the real `<img>` child to reuse.

Re: https://github.com/ampproject/amphtml/pull/28758