### PR TITLE
Pass `maxEntries` to SSR template

### DIFF
--- a/extensions/amp-autocomplete/0.1/amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/amp-autocomplete.js
@@ -406,6 +406,7 @@ export class AmpAutocomplete extends AMP.BaseElement {
         const attributes = dict({
           'ampAutocompleteAttributes': {
             'items': itemsExpr,
+            'maxEntries': this.maxEntries_,
           },
         });
         return this.getSsrTemplateHelper().ssr(


### PR DESCRIPTION
This PR makes the `max-entries` attribute available when delegating rendering to the server. This is so the server can truncate the results it sends to the `max-entries` size.
/cc @bill97819