### PR TITLE
🐛 [amp-sidebar] Prevent console errors on swipe in amp-sidebar

### DIFF
--- a/extensions/amp-sidebar/0.1/amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/amp-sidebar.js
@@ -554,7 +554,7 @@ export class AmpSidebar extends AMP.BaseElement {
     // stop propagation of swipe event inside amp-viewer
     const gestures = Gestures.get(
       dev().assertElement(element),
-      /* shouldNotPreventDefault */ false,
+      /* shouldNotPreventDefault */ true,
       /* shouldStopPropagation */ true
     );
     gestures.onGesture(SwipeXRecognizer, (e) => {


### PR DESCRIPTION
Fixes: #28902

`touchmove` events are considered passive events.  Chrome does not like it when we prevent.default() for these events.  Turning off the prevent.default() setting.