### PR TITLE
amp-autocomplete: Replace "max-entries" with "max-items"

### DIFF
--- a/extensions/amp-autocomplete/0.1/amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/amp-autocomplete.js
@@ -102,10 +102,10 @@ export class AmpAutocomplete extends AMP.BaseElement {
     this.minChars_ = 1;
 
     /**
-     * The value of the "max-entries" attribute on <autocomplete>.
+     * The value of the "max-items" attribute on <autocomplete>.
      * @private {?number}
      */
-    this.maxEntries_ = null;
+    this.maxItems_ = null;
 
     /**
      * If the "suggest-first" attribute is present on <autocomplete>.
@@ -324,7 +324,9 @@ export class AmpAutocomplete extends AMP.BaseElement {
     this.minChars_ = this.element.hasAttribute('min-characters')
       ? parseInt(this.element.getAttribute('min-characters'), 10)
       : 1;
-    this.maxEntries_ = this.element.hasAttribute('max-entries')
+    this.maxItems_ = this.element.hasAttribute('max-items')
+      ? parseInt(this.element.getAttribute('max-items'), 10)
+      : this.element.hasAttribute('max-entries')
       ? parseInt(this.element.getAttribute('max-entries'), 10)
       : null;
     this.shouldSuggestFirst_ = this.binding_.shouldSuggestFirst();
@@ -423,7 +425,7 @@ export class AmpAutocomplete extends AMP.BaseElement {
         const attributes = dict({
           'ampAutocompleteAttributes': {
             'items': itemsExpr,
-            'maxEntries': this.maxEntries_,
+            'maxItems': this.maxItems_,
           },
         });
         return this.getSsrTemplateHelper().ssr(
@@ -771,7 +773,7 @@ export class AmpAutocomplete extends AMP.BaseElement {
   filterData_(data, input) {
     // Server-side filtering.
     if (this.filter_ === FilterType.NONE) {
-      return this.truncateToMaxEntries_(data);
+      return this.truncateToMaxItems_(data);
     }
 
     // Client-side filtering.
@@ -809,7 +811,7 @@ export class AmpAutocomplete extends AMP.BaseElement {
       }
     });
 
-    return this.truncateToMaxEntries_(filteredData);
+    return this.truncateToMaxItems_(filteredData);
   }
 
   /**
@@ -905,14 +907,14 @@ export class AmpAutocomplete extends AMP.BaseElement {
   }
 
   /**
-   * Truncate the given data to a maximum length of the max-entries attribute.
+   * Truncate the given data to a maximum length of the max-items attribute.
    * @param {!Array<!JsonObject|string>} data
    * @return {!Array<!JsonObject|string>}
    * @private
    */
-  truncateToMaxEntries_(data) {
-    if (this.maxEntries_ && this.maxEntries_ < data.length) {
-      data = data.slice(0, this.maxEntries_);
+  truncateToMaxItems_(data) {
+    if (this.maxItems_ && this.maxItems_ < data.length) {
+      data = data.slice(0, this.maxItems_);
     }
     return data;
   }

--- a/extensions/amp-autocomplete/0.1/amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/amp-autocomplete.js
@@ -324,11 +324,13 @@ export class AmpAutocomplete extends AMP.BaseElement {
     this.minChars_ = this.element.hasAttribute('min-characters')
       ? parseInt(this.element.getAttribute('min-characters'), 10)
       : 1;
-    this.maxItems_ = this.element.hasAttribute('max-items')
-      ? parseInt(this.element.getAttribute('max-items'), 10)
-      : this.element.hasAttribute('max-entries')
-      ? parseInt(this.element.getAttribute('max-entries'), 10)
-      : null;
+    if (this.element.hasAttribute('max-entries')) {
+      user().warn(TAG, '"max-items" attribute is preferred to "max-entries"');
+    }
+    const maxItems =
+      this.element.getAttribute('max-items') ||
+      this.element.getAttribute('max-entries');
+    this.maxItems_ = maxItems ? parseInt(maxItems, 10) : null;
     this.shouldSuggestFirst_ = this.binding_.shouldSuggestFirst();
     this.highlightUserEntry_ = this.element.hasAttribute(
       'highlight-user-entry'

--- a/extensions/amp-autocomplete/0.1/test/test-amp-autocomplete-init.js
+++ b/extensions/amp-autocomplete/0.1/test/test-amp-autocomplete-init.js
@@ -208,10 +208,18 @@ describes.realWin(
         'filter': 'substring',
         'max-entries': '10',
       }).then((ampAutocomplete) => {
-        expect(ampAutocomplete.implementation_.maxEntries_).to.equal(10);
+        expect(ampAutocomplete.implementation_.maxItems_).to.equal(10);
       });
     });
 
+    it('should render with max-items passed', () => {
+      return getAutocomplete({
+        'filter': 'substring',
+        'max-items': '10',
+      }).then((ampAutocomplete) => {
+        expect(ampAutocomplete.implementation_.maxItems_).to.equal(10);
+      });
+    });
     it('should error with invalid JSON script', () => {
       expectAsyncConsoleError(
         'Unexpected token o in JSON at position 32 [object HTMLElement]'

--- a/extensions/amp-autocomplete/0.1/test/test-amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/test/test-amp-autocomplete.js
@@ -422,18 +422,18 @@ describes.realWin(
       expect(impl.tokenPrefixMatch_(item, 'd c')).to.be.false;
     });
 
-    it('truncateToMaxEntries_() should truncate given data', () => {
+    it('truncateToMaxItems_() should truncate given data', () => {
       expect(
-        impl.truncateToMaxEntries_(['a', 'b', 'c', 'd'])
+        impl.truncateToMaxItems_(['a', 'b', 'c', 'd'])
       ).to.have.ordered.members(['a', 'b', 'c', 'd']);
-      impl.maxEntries_ = 3;
+      impl.maxItems_ = 3;
       expect(
-        impl.truncateToMaxEntries_(['a', 'b', 'c', 'd'])
+        impl.truncateToMaxItems_(['a', 'b', 'c', 'd'])
       ).to.have.ordered.members(['a', 'b', 'c']);
       expect(
-        impl.truncateToMaxEntries_(['a', 'b', 'c'])
+        impl.truncateToMaxItems_(['a', 'b', 'c'])
       ).to.have.ordered.members(['a', 'b', 'c']);
-      expect(impl.truncateToMaxEntries_(['a', 'b'])).to.have.ordered.members([
+      expect(impl.truncateToMaxItems_(['a', 'b'])).to.have.ordered.members([
         'a',
         'b',
       ]);

--- a/extensions/amp-autocomplete/0.1/test/validator-amp-autocomplete.html
+++ b/extensions/amp-autocomplete/0.1/test/validator-amp-autocomplete.html
@@ -311,10 +311,27 @@
       </script>
     </amp-autocomplete>
 
+    <!-- Valid: amp-component with static data and max-items attribute -->
+    <amp-autocomplete filter="prefix" max-items="10">
+      <input />
+      <script type="application/json">
+        {}
+      </script>
+    </amp-autocomplete>
+
     <!-- Valid: amp-component with remote data and max-entries attribute -->
     <amp-autocomplete
       filter="prefix"
       max-entries="10"
+      src="https://data.com/articles.json?ref=CANONICAL_URL"
+    >
+      <input />
+    </amp-autocomplete>
+
+    <!-- Valid: amp-component with remote data and max-items attribute -->
+    <amp-autocomplete
+      filter="prefix"
+      max-items="10"
       src="https://data.com/articles.json?ref=CANONICAL_URL"
     >
       <input />

--- a/extensions/amp-autocomplete/0.1/test/validator-amp-autocomplete.out
+++ b/extensions/amp-autocomplete/0.1/test/validator-amp-autocomplete.out
@@ -312,10 +312,27 @@ FAIL
 |        </script>
 |      </amp-autocomplete>
 |
+|      <!-- Valid: amp-component with static data and max-items attribute -->
+|      <amp-autocomplete filter="prefix" max-items="10">
+|        <input />
+|        <script type="application/json">
+|          {}
+|        </script>
+|      </amp-autocomplete>
+|
 |      <!-- Valid: amp-component with remote data and max-entries attribute -->
 |      <amp-autocomplete
 |        filter="prefix"
 |        max-entries="10"
+|        src="https://data.com/articles.json?ref=CANONICAL_URL"
+|      >
+|        <input />
+|      </amp-autocomplete>
+|
+|      <!-- Valid: amp-component with remote data and max-items attribute -->
+|      <amp-autocomplete
+|        filter="prefix"
+|        max-items="10"
 |        src="https://data.com/articles.json?ref=CANONICAL_URL"
 |      >
 |        <input />
@@ -479,7 +496,7 @@ FAIL
 |      <!-- Invalid: filter unspecified -->
 |      <amp-autocomplete>
 >>     ^~~~~~~~~
-amp-autocomplete/0.1/test/validator-amp-autocomplete.html:479:4 The mandatory attribute 'filter' is missing in tag 'amp-autocomplete'. (see https://amp.dev/documentation/components/amp-autocomplete/)
+amp-autocomplete/0.1/test/validator-amp-autocomplete.html:496:4 The mandatory attribute 'filter' is missing in tag 'amp-autocomplete'. (see https://amp.dev/documentation/components/amp-autocomplete/)
 |        <input />
 |        <script type="application/json">
 |          {}
@@ -489,7 +506,7 @@ amp-autocomplete/0.1/test/validator-amp-autocomplete.html:479:4 The mandatory at
 |      <!-- Invalid: width is mistyped -->
 |      <amp-autocomplete widht="100" filter="prefix">
 >>     ^~~~~~~~~
-amp-autocomplete/0.1/test/validator-amp-autocomplete.html:487:4 The attribute 'widht' may not appear in tag 'amp-autocomplete'. (see https://amp.dev/documentation/components/amp-autocomplete/)
+amp-autocomplete/0.1/test/validator-amp-autocomplete.html:504:4 The attribute 'widht' may not appear in tag 'amp-autocomplete'. (see https://amp.dev/documentation/components/amp-autocomplete/)
 |        <input />
 |        <script type="application/json">
 |          {}
@@ -499,7 +516,7 @@ amp-autocomplete/0.1/test/validator-amp-autocomplete.html:487:4 The attribute 'w
 |      <!-- Invalid: responsive layout is not supported -->
 |      <amp-autocomplete layout="responsive" filter="prefix">
 >>     ^~~~~~~~~
-amp-autocomplete/0.1/test/validator-amp-autocomplete.html:495:4 The specified layout 'RESPONSIVE' is not supported by tag 'amp-autocomplete'. (see https://amp.dev/documentation/components/amp-autocomplete/)
+amp-autocomplete/0.1/test/validator-amp-autocomplete.html:512:4 The specified layout 'RESPONSIVE' is not supported by tag 'amp-autocomplete'. (see https://amp.dev/documentation/components/amp-autocomplete/)
 |        <input />
 |        <script type="application/json">
 |          {}
@@ -509,10 +526,10 @@ amp-autocomplete/0.1/test/validator-amp-autocomplete.html:495:4 The specified la
 |      <!-- Invalid: amp-autocomplete with invalid input types -->
 |      <amp-autocomplete widht="100" filter="prefix">
 >>     ^~~~~~~~~
-amp-autocomplete/0.1/test/validator-amp-autocomplete.html:503:4 The attribute 'widht' may not appear in tag 'amp-autocomplete'. (see https://amp.dev/documentation/components/amp-autocomplete/)
+amp-autocomplete/0.1/test/validator-amp-autocomplete.html:520:4 The attribute 'widht' may not appear in tag 'amp-autocomplete'. (see https://amp.dev/documentation/components/amp-autocomplete/)
 |        <input type="file" />
 >>       ^~~~~~~~~
-amp-autocomplete/0.1/test/validator-amp-autocomplete.html:504:6 The tag 'input' may only appear as a descendant of tag 'form [method=post]'. (see https://amp.dev/documentation/components/amp-form/)
+amp-autocomplete/0.1/test/validator-amp-autocomplete.html:521:6 The tag 'input' may only appear as a descendant of tag 'form [method=post]'. (see https://amp.dev/documentation/components/amp-form/)
 |        <script type="application/json">
 |          {}
 |        </script>
@@ -521,7 +538,7 @@ amp-autocomplete/0.1/test/validator-amp-autocomplete.html:504:6 The tag 'input' 
 |      <!-- Invalid: amp-autocomplete with filter=custom and no filter-expr attribute -->
 |      <amp-autocomplete filter="custom">
 >>     ^~~~~~~~~
-amp-autocomplete/0.1/test/validator-amp-autocomplete.html:511:4 The attribute 'filter-expr' in tag 'amp-autocomplete' is missing or incorrect, but required by attribute 'filter'. (see https://amp.dev/documentation/components/amp-autocomplete/)
+amp-autocomplete/0.1/test/validator-amp-autocomplete.html:528:4 The attribute 'filter-expr' in tag 'amp-autocomplete' is missing or incorrect, but required by attribute 'filter'. (see https://amp.dev/documentation/components/amp-autocomplete/)
 |        <input />
 |        <script type="application/json">
 |          {}
@@ -531,7 +548,7 @@ amp-autocomplete/0.1/test/validator-amp-autocomplete.html:511:4 The attribute 'f
 |      <!-- Invalid: amp-autocomplete with filter=custom and no filter-expr attribute -->
 |      <amp-autocomplete
 >>     ^~~~~~~~~
-amp-autocomplete/0.1/test/validator-amp-autocomplete.html:519:4 The attribute 'filter-expr' in tag 'amp-autocomplete' is missing or incorrect, but required by attribute 'filter'. (see https://amp.dev/documentation/components/amp-autocomplete/)
+amp-autocomplete/0.1/test/validator-amp-autocomplete.html:536:4 The attribute 'filter-expr' in tag 'amp-autocomplete' is missing or incorrect, but required by attribute 'filter'. (see https://amp.dev/documentation/components/amp-autocomplete/)
 |        filter="custom"
 |        src="https://data.com/articles.json?ref=CANONICAL_URL"
 |      >
@@ -541,7 +558,7 @@ amp-autocomplete/0.1/test/validator-amp-autocomplete.html:519:4 The attribute 'f
 |      <!-- Invalid: amp-autocomplete with unexpected filter -->
 |      <amp-autocomplete filter="random">
 >>     ^~~~~~~~~
-amp-autocomplete/0.1/test/validator-amp-autocomplete.html:527:4 The attribute 'filter' in tag 'amp-autocomplete' is set to the invalid value 'random'. (see https://amp.dev/documentation/components/amp-autocomplete/)
+amp-autocomplete/0.1/test/validator-amp-autocomplete.html:544:4 The attribute 'filter' in tag 'amp-autocomplete' is set to the invalid value 'random'. (see https://amp.dev/documentation/components/amp-autocomplete/)
 |        <input />
 |        <script type="application/json">
 |          {}
@@ -551,7 +568,7 @@ amp-autocomplete/0.1/test/validator-amp-autocomplete.html:527:4 The attribute 'f
 |      <!-- Invalid: amp-autocomplete with unexpected filter and src attr -->
 |      <amp-autocomplete
 >>     ^~~~~~~~~
-amp-autocomplete/0.1/test/validator-amp-autocomplete.html:535:4 The attribute 'filter' in tag 'amp-autocomplete' is set to the invalid value 'random'. (see https://amp.dev/documentation/components/amp-autocomplete/)
+amp-autocomplete/0.1/test/validator-amp-autocomplete.html:552:4 The attribute 'filter' in tag 'amp-autocomplete' is set to the invalid value 'random'. (see https://amp.dev/documentation/components/amp-autocomplete/)
 |        filter="random"
 |        src="https://data.com/articles.json?ref=CANONICAL_URL"
 |      >
@@ -561,7 +578,7 @@ amp-autocomplete/0.1/test/validator-amp-autocomplete.html:535:4 The attribute 'f
 |      <!-- Invalid: amp-autocomplete with query attr missing src attr -->
 |      <amp-autocomplete filter="prefix" query="q">
 >>     ^~~~~~~~~
-amp-autocomplete/0.1/test/validator-amp-autocomplete.html:543:4 The attribute 'src' in tag 'amp-autocomplete' is missing or incorrect, but required by attribute 'query'. (see https://amp.dev/documentation/components/amp-autocomplete/)
+amp-autocomplete/0.1/test/validator-amp-autocomplete.html:560:4 The attribute 'src' in tag 'amp-autocomplete' is missing or incorrect, but required by attribute 'query'. (see https://amp.dev/documentation/components/amp-autocomplete/)
 |        <input />
 |      </amp-autocomplete>
 |    </body>

--- a/extensions/amp-autocomplete/amp-autocomplete.md
+++ b/extensions/amp-autocomplete/amp-autocomplete.md
@@ -80,7 +80,7 @@ The filtering mechanism applied to source data to produce filtered results for u
 - `prefix`: if the user input is a prefix of an item, then the item gets suggested
 - `token-prefix`: if the user input is a prefix of any word in a multi-worded item, then the item gets suggested; example “je” is a token-prefix in “blue jeans”
 - `fuzzy`: typos in the input field can result in partial match items appearing in the filtered results—need further research
-- `none`: no client-side filter; renders retrieved data based on bound <code>[src]</code> attribute; truncates to <code>max-entries</code> attribute if provided
+- `none`: no client-side filter; renders retrieved data based on bound <code>[src]</code> attribute; truncates to <code>max-items</code> attribute if provided
 - `custom`: a conditional statement involving an item and a user input to be applied to each item such that evaluating to true implies the item gets suggested; using this filter requires including <code>amp-bind</code> if <code>filter==custom</code>, an additional attribute <code>filter-expr</code> is required to specify a boolean expression by which to perform the custom filter
 
 ### `filter-expr`
@@ -105,7 +105,7 @@ The query parameter to generate a static remote endpoint that returns the JSON t
 
 The min character length of a user input to provide results, default 1
 
-### `max-entries`
+### `max-items`
 
 The max specified number of items to suggest at once based on a user input, displays all if unspecified
 

--- a/extensions/amp-autocomplete/validator-amp-autocomplete.protoascii
+++ b/extensions/amp-autocomplete/validator-amp-autocomplete.protoascii
@@ -63,6 +63,7 @@ tags: {  # <amp-autocomplete>
   attrs: { name: "inline" }
   attrs: { name: "items" }
   attrs: { name: "max-entries" }
+  attrs: { name: "max-items" }
   attrs: { name: "min-characters" }
   attrs: {
     name: "query"
@@ -105,6 +106,7 @@ tags: {  # <amp-autocomplete>
   attrs: { name: "inline" }
   attrs: { name: "items" }
   attrs: { name: "max-entries" }
+  attrs: { name: "max-items" }
   attrs: { name: "min-characters" }
   attrs: {
     name: "query"

--- a/validator/testdata/amp4email_feature_tests/amp-autocomplete.html
+++ b/validator/testdata/amp4email_feature_tests/amp-autocomplete.html
@@ -75,6 +75,7 @@
       inline
       min-characters="0"
       max-entries="3"
+      max-items="3"
       submit-on-enter
       suggest-first
     >

--- a/validator/testdata/amp4email_feature_tests/amp-autocomplete.out
+++ b/validator/testdata/amp4email_feature_tests/amp-autocomplete.out
@@ -78,6 +78,7 @@ amp4email_feature_tests/amp-autocomplete.html:22:0 The attribute 'data-amp-autoc
 |        inline
 |        min-characters="0"
 |        max-entries="3"
+|        max-items="3"
 |        submit-on-enter
 |        suggest-first
 |      >
@@ -87,11 +88,11 @@ amp4email_feature_tests/amp-autocomplete.html:22:0 The attribute 'data-amp-autoc
 |      <!-- Invalid: amp-component with static data -->
 |      <amp-autocomplete>
 >>     ^~~~~~~~~
-amp4email_feature_tests/amp-autocomplete.html:85:4 The mandatory attribute 'src' is missing in tag 'amp-autocomplete'. (see https://amp.dev/documentation/components/amp-autocomplete)
+amp4email_feature_tests/amp-autocomplete.html:86:4 The mandatory attribute 'src' is missing in tag 'amp-autocomplete'. (see https://amp.dev/documentation/components/amp-autocomplete)
 |        <input />
 |        <script type="application/json">
 >>       ^~~~~~~~~
-amp4email_feature_tests/amp-autocomplete.html:87:6 Custom JavaScript is not allowed. (see https://amp.dev/documentation/guides-and-tutorials/learn/validation-workflow/validation_errors/#custom-javascript-is-not-allowed)
+amp4email_feature_tests/amp-autocomplete.html:88:6 Custom JavaScript is not allowed. (see https://amp.dev/documentation/guides-and-tutorials/learn/validation-workflow/validation_errors/#custom-javascript-is-not-allowed)
 |          {}
 |        </script>
 |      </amp-autocomplete>
@@ -99,7 +100,7 @@ amp4email_feature_tests/amp-autocomplete.html:87:6 Custom JavaScript is not allo
 |      <!-- Invalid: amp-component with filter attribute -->
 |      <amp-autocomplete
 >>     ^~~~~~~~~
-amp4email_feature_tests/amp-autocomplete.html:93:4 The attribute 'filter' may not appear in tag 'amp-autocomplete'. (see https://amp.dev/documentation/components/amp-autocomplete)
+amp4email_feature_tests/amp-autocomplete.html:94:4 The attribute 'filter' may not appear in tag 'amp-autocomplete'. (see https://amp.dev/documentation/components/amp-autocomplete)
 |        filter="prefix"
 |        src="https://data.com/articles.json?ref=CANONICAL_URL"
 |      >
@@ -109,7 +110,7 @@ amp4email_feature_tests/amp-autocomplete.html:93:4 The attribute 'filter' may no
 |      <!-- Invalid: amp-component with filter-value attribute -->
 |      <amp-autocomplete
 >>     ^~~~~~~~~
-amp4email_feature_tests/amp-autocomplete.html:101:4 The attribute 'filter-value' may not appear in tag 'amp-autocomplete'. (see https://amp.dev/documentation/components/amp-autocomplete)
+amp4email_feature_tests/amp-autocomplete.html:102:4 The attribute 'filter-value' may not appear in tag 'amp-autocomplete'. (see https://amp.dev/documentation/components/amp-autocomplete)
 |        filter-value="property"
 |        src="https://data.com/articles.json?ref=CANONICAL_URL"
 |      >
@@ -123,12 +124,12 @@ amp4email_feature_tests/amp-autocomplete.html:101:4 The attribute 'filter-value'
 |          <div>
 |            <amp-autocomplete
 >>           ^~~~~~~~~
-amp4email_feature_tests/amp-autocomplete.html:113:10 The tag 'amp-autocomplete' may not appear as a descendant of tag 'amp-autocomplete'. (see https://amp.dev/documentation/components/amp-autocomplete)
+amp4email_feature_tests/amp-autocomplete.html:114:10 The tag 'amp-autocomplete' may not appear as a descendant of tag 'amp-autocomplete'. (see https://amp.dev/documentation/components/amp-autocomplete)
 |              src="https://data.com/articles.json?ref=CANONICAL_URL"
 |            >
 |              <template type="amp-mustache" id="1234">
 >>             ^~~~~~~~~
-amp4email_feature_tests/amp-autocomplete.html:116:12 The tag 'template' may not appear as a descendant of tag 'template (amp4email)'. (see https://amp.dev/documentation/components/amp-mustache)
+amp4email_feature_tests/amp-autocomplete.html:117:12 The tag 'template' may not appear as a descendant of tag 'template (amp4email)'. (see https://amp.dev/documentation/components/amp-mustache)
 |                <div>
 |                  <a href="https://somelink.com">{{blah}}</a>
 |                </div>
@@ -144,12 +145,12 @@ amp4email_feature_tests/amp-autocomplete.html:116:12 The tag 'template' may not 
 |          <div>
 |            <amp-state src="https://someserver.json">
 >>           ^~~~~~~~~
-amp4email_feature_tests/amp-autocomplete.html:130:10 The tag 'amp-state' may not appear as a descendant of tag 'template'. (see https://amp.dev/documentation/components/amp-bind/)
+amp4email_feature_tests/amp-autocomplete.html:131:10 The tag 'amp-state' may not appear as a descendant of tag 'template'. (see https://amp.dev/documentation/components/amp-bind/)
 >>           ^~~~~~~~~
-amp4email_feature_tests/amp-autocomplete.html:130:10 The tag 'amp-state' requires including the 'amp-bind' extension JavaScript. (see https://amp.dev/documentation/components/amp-bind/)
+amp4email_feature_tests/amp-autocomplete.html:131:10 The tag 'amp-state' requires including the 'amp-bind' extension JavaScript. (see https://amp.dev/documentation/components/amp-bind/)
 |              <script type="application/json">
 >>             ^~~~~~~~~
-amp4email_feature_tests/amp-autocomplete.html:131:12 The tag 'script' requires including the 'amp-bind' extension JavaScript. (see https://amp.dev/documentation/components/amp-bind/)
+amp4email_feature_tests/amp-autocomplete.html:132:12 The tag 'script' requires including the 'amp-bind' extension JavaScript. (see https://amp.dev/documentation/components/amp-bind/)
 |                {}
 |              </script>
 |            </amp-state>
@@ -163,7 +164,7 @@ amp4email_feature_tests/amp-autocomplete.html:131:12 The tag 'script' requires i
 |          <div>
 |            <amp-autocomplete
 >>           ^~~~~~~~~
-amp4email_feature_tests/amp-autocomplete.html:143:10 The tag 'amp-autocomplete' may not appear as a descendant of tag 'amp-autocomplete'. (see https://amp.dev/documentation/components/amp-autocomplete)
+amp4email_feature_tests/amp-autocomplete.html:144:10 The tag 'amp-autocomplete' may not appear as a descendant of tag 'amp-autocomplete'. (see https://amp.dev/documentation/components/amp-autocomplete)
 |              src="https://data.com/articles.json?ref=CANONICAL_URL"
 |              template="1234"
 |            >
@@ -178,12 +179,12 @@ amp4email_feature_tests/amp-autocomplete.html:143:10 The tag 'amp-autocomplete' 
 |          <div>
 |            <amp-state id="123" src="https://someserver.json" template="1234">
 >>           ^~~~~~~~~
-amp4email_feature_tests/amp-autocomplete.html:156:10 The tag 'amp-state' may not appear as a descendant of tag 'template'. (see https://amp.dev/documentation/components/amp-bind/)
+amp4email_feature_tests/amp-autocomplete.html:157:10 The tag 'amp-state' may not appear as a descendant of tag 'template'. (see https://amp.dev/documentation/components/amp-bind/)
 >>           ^~~~~~~~~
-amp4email_feature_tests/amp-autocomplete.html:156:10 The tag 'amp-state' requires including the 'amp-bind' extension JavaScript. (see https://amp.dev/documentation/components/amp-bind/)
+amp4email_feature_tests/amp-autocomplete.html:157:10 The tag 'amp-state' requires including the 'amp-bind' extension JavaScript. (see https://amp.dev/documentation/components/amp-bind/)
 |              <script type="application/json">
 >>             ^~~~~~~~~
-amp4email_feature_tests/amp-autocomplete.html:157:12 The tag 'script' requires including the 'amp-bind' extension JavaScript. (see https://amp.dev/documentation/components/amp-bind/)
+amp4email_feature_tests/amp-autocomplete.html:158:12 The tag 'script' requires including the 'amp-bind' extension JavaScript. (see https://amp.dev/documentation/components/amp-bind/)
 |                {}
 |              </script>
 |            </amp-state>
@@ -196,7 +197,7 @@ amp4email_feature_tests/amp-autocomplete.html:157:12 The tag 'script' requires i
 |        <div>
 |          <amp-autocomplete
 >>         ^~~~~~~~~
-amp4email_feature_tests/amp-autocomplete.html:168:8 The tag 'amp-autocomplete' may not appear as a descendant of tag 'template'. (see https://amp.dev/documentation/components/amp-autocomplete)
+amp4email_feature_tests/amp-autocomplete.html:169:8 The tag 'amp-autocomplete' may not appear as a descendant of tag 'template'. (see https://amp.dev/documentation/components/amp-autocomplete)
 |            src="https://data.com/articles.json?ref=CANONICAL_URL"
 |            template="1234"
 |          >
@@ -207,47 +208,47 @@ amp4email_feature_tests/amp-autocomplete.html:168:8 The tag 'amp-autocomplete' m
 |      <!-- Invalid: URLs cannot be empty. -->
 |      <amp-autocomplete src="">
 >>     ^~~~~~~~~
-amp4email_feature_tests/amp-autocomplete.html:177:4 Missing URL for attribute 'src' in tag 'amp-autocomplete'. (see https://amp.dev/documentation/components/amp-autocomplete)
+amp4email_feature_tests/amp-autocomplete.html:178:4 Missing URL for attribute 'src' in tag 'amp-autocomplete'. (see https://amp.dev/documentation/components/amp-autocomplete)
 |        <input />
 |      </amp-autocomplete>
 |
 |      <!-- Invalid: The protocol can only be https -->
 |      <amp-autocomplete src="http://data.com/articles.json?ref=CANONICAL_URL">
 >>     ^~~~~~~~~
-amp4email_feature_tests/amp-autocomplete.html:182:4 Invalid URL protocol 'http:' for attribute 'src' in tag 'amp-autocomplete'. (see https://amp.dev/documentation/components/amp-autocomplete)
+amp4email_feature_tests/amp-autocomplete.html:183:4 Invalid URL protocol 'http:' for attribute 'src' in tag 'amp-autocomplete'. (see https://amp.dev/documentation/components/amp-autocomplete)
 |        <input />
 |      </amp-autocomplete>
 |
 |      <!-- Invalid: src of amp-autocomplete is not bindable -->
 |      <amp-autocomplete [src]="data">
 >>     ^~~~~~~~~
-amp4email_feature_tests/amp-autocomplete.html:187:4 The attribute '[src]' may not appear in tag 'amp-autocomplete'. (see https://amp.dev/documentation/components/amp-autocomplete)
+amp4email_feature_tests/amp-autocomplete.html:188:4 The attribute '[src]' may not appear in tag 'amp-autocomplete'. (see https://amp.dev/documentation/components/amp-autocomplete)
 |        <input />
 |      </amp-autocomplete>
 |
 |      <!-- Invalid: Mustache delimiters are disallowed in src -->
 |      <amp-autocomplete src="foo{{bar">
 >>     ^~~~~~~~~
-amp4email_feature_tests/amp-autocomplete.html:192:4 The relative URL 'foo{{bar' for attribute 'src' in tag 'amp-autocomplete' is disallowed. (see https://amp.dev/documentation/components/amp-autocomplete)
+amp4email_feature_tests/amp-autocomplete.html:193:4 The relative URL 'foo{{bar' for attribute 'src' in tag 'amp-autocomplete' is disallowed. (see https://amp.dev/documentation/components/amp-autocomplete)
 |        <input />
 |      </amp-autocomplete>
 |
 |      <!-- Invalid: Mustache delimiters are disallowed in src -->
 |      <amp-autocomplete src="foo{{bar">
 >>     ^~~~~~~~~
-amp4email_feature_tests/amp-autocomplete.html:197:4 The relative URL 'foo{{bar' for attribute 'src' in tag 'amp-autocomplete' is disallowed. (see https://amp.dev/documentation/components/amp-autocomplete)
+amp4email_feature_tests/amp-autocomplete.html:198:4 The relative URL 'foo{{bar' for attribute 'src' in tag 'amp-autocomplete' is disallowed. (see https://amp.dev/documentation/components/amp-autocomplete)
 |        <input />
 |      </amp-autocomplete>
 |
 |      <!-- Invalid: Mustache variables cannot be concatenated in href -->
 |      <amp-autocomplete src="http://data.com/articles.json?ref=CANONICAL_URL">
 >>     ^~~~~~~~~
-amp4email_feature_tests/amp-autocomplete.html:202:4 Invalid URL protocol 'http:' for attribute 'src' in tag 'amp-autocomplete'. (see https://amp.dev/documentation/components/amp-autocomplete)
+amp4email_feature_tests/amp-autocomplete.html:203:4 Invalid URL protocol 'http:' for attribute 'src' in tag 'amp-autocomplete'. (see https://amp.dev/documentation/components/amp-autocomplete)
 |        <input />
 |        <template type="amp-mustache">
 |          <a href="{{bar}}{{foo}}">disallowed</a>
 >>         ^~~~~~~~~
-amp4email_feature_tests/amp-autocomplete.html:205:8 The attribute 'href' in tag 'a' is set to the invalid value '{{bar}}{{foo}}'.
+amp4email_feature_tests/amp-autocomplete.html:206:8 The attribute 'href' in tag 'a' is set to the invalid value '{{bar}}{{foo}}'.
 |        </template>
 |      </amp-autocomplete>
 |    </body>


### PR DESCRIPTION
This change is to create a more consistent API surface between amp-autocomplete and amp-list, which after this change will both share `items` and `max-items` attributes along with expected sourcedata shapes. cc @bill97819