### PR TITLE
⏪ Revert "🏗 Generate test reports on Travis build runs. (#28943)"

### DIFF
--- a/build-system/tasks/karma.conf.js
+++ b/build-system/tasks/karma.conf.js
@@ -298,7 +298,6 @@ module.exports = {
     'karma-fixture',
     'karma-html2js-preprocessor',
     'karma-ie-launcher',
-    'karma-structured-json-reporter',
     'karma-mocha',
     'karma-mocha-reporter',
     'karma-safari-launcher',

--- a/build-system/tasks/runtime-test/runtime-test-base.js
+++ b/build-system/tasks/runtime-test/runtime-test-base.js
@@ -31,7 +31,7 @@ const {
 const {app} = require('../../server/test-server');
 const {getFilesFromArgv} = require('../../common/utils');
 const {green, yellow, cyan, red} = require('ansi-colors');
-const {isTravisBuild, isTravisPushBuild} = require('../../common/travis');
+const {isTravisBuild} = require('../../common/travis');
 const {reportTestStarted} = require('.././report-test-status');
 const {startServer, stopServer} = require('../serve');
 const {unitTestsToRun} = require('./helpers-unit');
@@ -168,13 +168,6 @@ function updateReporters(config) {
 
   if (argv.saucelabs) {
     config.reporters.push('saucelabs');
-  }
-
-  if (isTravisPushBuild()) {
-    config.reporters.push('json-result');
-    config.jsonReporter = {
-      outputFile: `results_${config.testType}.json`,
-    };
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -140,7 +140,6 @@
     "karma-simple-reporter": "2.0.0",
     "karma-sinon-chai": "2.0.2",
     "karma-source-map-support": "1.4.0",
-    "karma-structured-json-reporter": "1.0.1",
     "karma-super-dots-reporter": "0.2.0",
     "lazypipe": "1.0.2",
     "list-imports-exports": "0.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11610,11 +11610,6 @@ karma-source-map-support@1.4.0:
   dependencies:
     source-map-support "^0.5.5"
 
-karma-structured-json-reporter@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/karma-structured-json-reporter/-/karma-structured-json-reporter-1.0.1.tgz#1d6409ea65c0168b345caf77d3d2bd9f4ced15d5"
-  integrity sha1-HWQJ6mXAFos0XK9309K9n0ztFdU=
-
 karma-super-dots-reporter@0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/karma-super-dots-reporter/-/karma-super-dots-reporter-0.2.0.tgz#71c3ac8ee0b7353ef2234fe43815f740d254544a"


### PR DESCRIPTION
Unbreak the build: https://travis-ci.org/github/ampproject/amphtml/jobs/699880037

There was a typo in https://github.com/ampproject/amphtml/pull/28951/commits/fe3bf7b7107a75f086f59144fb449e0d00bba17b#diff-0ee67c46629bb85f060f8bfe6bb6def4L175 -- I set `config.jsonReporter` instead of `config.jsonResultReporter`. The error was not detected before pull-requesting because `isTravisPushBuild()` was false during the pull request, meaning that the offending code didn't run.

I'll remove the `isTravisPushBuild()`check, see if fixing the typo fixes the issue, then add the check again.