### PR TITLE
🚮 Deleting code: Remove obsoleted Adsense format experiment.

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -4,7 +4,9 @@
     "analytics-chunks",
     "analytics-chunks-inabox"
   ],
-  "allow-url-opt-in": ["pump-early-frame"],
+  "allow-url-opt-in": [
+    "pump-early-frame"
+  ],
   "canary": 1,
   "a4aProfilingRate": 0.01,
   "adsense-ad-size-optimization": 0.01,
@@ -21,7 +23,6 @@
   "amp-story-responsive-units": 1,
   "amp-story-v1": 1,
   "ampdoc-closest": 1,
-  "as-use-attr-for-format": 0.01,
   "chunked-amp": 1,
   "doubleclickSraExp": 0.01,
   "doubleclickSraReportExcludedBlock": 0.1,

--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -4,9 +4,7 @@
     "analytics-chunks",
     "analytics-chunks-inabox"
   ],
-  "allow-url-opt-in": [
-    "pump-early-frame"
-  ],
+  "allow-url-opt-in": ["pump-early-frame"],
   "canary": 1,
   "a4aProfilingRate": 0.01,
   "adsense-ad-size-optimization": 0.01,

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -4,9 +4,7 @@
     "analytics-chunks",
     "analytics-chunks-inabox"
   ],
-  "allow-url-opt-in": [
-    "pump-early-frame"
-  ],
+  "allow-url-opt-in": ["pump-early-frame"],
   "canary": 0,
   "a4aProfilingRate": 0.01,
   "adsense-ad-size-optimization": 0.01,

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -4,7 +4,9 @@
     "analytics-chunks",
     "analytics-chunks-inabox"
   ],
-  "allow-url-opt-in": ["pump-early-frame"],
+  "allow-url-opt-in": [
+    "pump-early-frame"
+  ],
   "canary": 0,
   "a4aProfilingRate": 0.01,
   "adsense-ad-size-optimization": 0.01,
@@ -22,7 +24,6 @@
   "amp-story-responsive-units": 1,
   "amp-story-v1": 1,
   "ampdoc-closest": 1,
-  "as-use-attr-for-format": 0.01,
   "chunked-amp": 1,
   "doubleclickSraExp": 0.01,
   "doubleclickSraReportExcludedBlock": 0.1,

--- a/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
@@ -554,14 +554,11 @@ describes.realWin(
     });
 
     describe('#getAdUrl', () => {
-      const adsenseFormatExpName = 'as-use-attr-for-format';
-
       beforeEach(() => {
         resetSharedState();
       });
 
       afterEach(() => {
-        toggleExperiment(impl.win, adsenseFormatExpName, false);
         toggleExperiment(
           impl.win,
           'ADSENSE_AMP_AUTO_ADS_HOLDOUT_EXPERIMENT_NAME',
@@ -623,8 +620,7 @@ describes.realWin(
         element.setAttribute('width', 'auto');
         expect(impl.element.getAttribute('width')).to.equal('auto');
         return impl.getAdUrl().then((url) =>
-          // With exp as-use-attr-for-format off, we can't test for specific
-          // numbers, but we know that the values should be numeric.
+          // The values should be numeric.
           expect(url).to.match(/format=\d+x\d+&w=\d+&h=\d+/)
         );
       });
@@ -632,13 +628,11 @@ describes.realWin(
         element.setAttribute('height', 'auto');
         expect(impl.element.getAttribute('height')).to.equal('auto');
         return impl.getAdUrl().then((url) =>
-          // With exp as-use-attr-for-format off, we can't test for specific
-          // numbers, but we know that the values should be numeric.
+          // The values should be numeric.
           expect(url).to.match(/format=\d+x\d+&w=\d+&h=\d+/)
         );
       });
-      it('has correct format when as-use-attr-for-format is on', () => {
-        forceExperimentBranch(impl.win, adsenseFormatExpName, '21062004');
+      it('has correct format when width and height are specified', () => {
         impl.divertExperiments();
         const width = element.getAttribute('width');
         const height = element.getAttribute('height');
@@ -649,20 +643,6 @@ describes.realWin(
               new RegExp(`format=${width}x${height}&w=${width}&h=${height}`)
             )
           );
-      });
-      it('has experiment eid in adsense frmt exp and width/height numeric', () => {
-        forceExperimentBranch(impl.win, adsenseFormatExpName, '21062004');
-        impl.divertExperiments();
-        return impl
-          .getAdUrl()
-          .then((url) => expect(url).to.match(/eid=[^&]*21062004/));
-      });
-      it('has control eid in adsense frmt exp and width/height numeric', () => {
-        forceExperimentBranch(impl.win, adsenseFormatExpName, '21062003');
-        impl.divertExperiments();
-        return impl
-          .getAdUrl()
-          .then((url) => expect(url).to.match(/eid=[^&]*21062003/));
       });
       it('returns the right URL', () => {
         env.sandbox.stub(impl, 'isXhrAllowed').returns(true);
@@ -782,7 +762,6 @@ describes.realWin(
         const impl1 = new AmpAdNetworkAdsenseImpl(elem1);
         const impl2 = new AmpAdNetworkAdsenseImpl(elem2);
         const impl3 = new AmpAdNetworkAdsenseImpl(elem3);
-        toggleExperiment(impl1.win, 'as-use-attr-for-format', true);
         return impl1.getAdUrl().then((adUrl1) => {
           expect(adUrl1).to.match(/pv=2/);
           expect(adUrl1).to.not.match(/prev_fmts/);

--- a/tools/experiments/experiments-config.js
+++ b/tools/experiments/experiments-config.js
@@ -153,10 +153,6 @@ export const EXPERIMENTS = [
     name: 'Display jank meter',
   },
   {
-    id: 'as-use-attr-for-format',
-    name: 'Use slot width/height attribute for AdSense size format',
-  },
-  {
     id: 'input-debounced',
     name: 'A debounced input event for AMP actions',
     cleanupIssue: 'https://github.com/ampproject/amphtml/issues/9413',


### PR DESCRIPTION
Remove the obsoleted Adsense format experiment to avoid the confusion and make the flow cleaner.

See manual testing & verification details [here](https://docs.google.com/document/d/1QXyfQTpHkDp2oxbHwEjYKX0IhKf_4GHng63CZ-4aECE/edit).

PTAL when you have time. Thanks.
@keithwrightbos, @glevitzky