### PR TITLE
Allow amp-list[layout=container] to opt into default loaders

### DIFF
--- a/examples/amp-list-layout-container.amp.html
+++ b/examples/amp-list-layout-container.amp.html
@@ -35,6 +35,38 @@
     <button on="tap:text.toggleVisibility">
       Toggle text
     </button>
+    <amp-list
+      layout="container"
+      src="https://amp.dev/documentation/examples/api/slow-json/?delay=10000"
+      binding="no">
+    <div placeholder>
+      <div role="listitem">
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus vel quam
+        eu turpis eleifend pretium. Aenean sagittis, leo ac congue mattis, est
+        nisl accumsan eros, sit amet suscipit massa lectus non nibh. In justo
+        libero, ultricies sed tristique vel, tincidunt non nulla. Pellentesque vel
+        pharetra risus. Donec tempus tortor at est vulputate ultrices. Quisque
+        sagittis pretium facilisis. Aliquam dignissim dapibus nibh sed bibendum.
+        Phasellus et nulla pulvinar, placerat sapien ac, vehicula mauris. Mauris
+        efficitur quis orci sed convallis.
+      </div>
+      <div role="listitem">
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus vel quam
+        eu turpis eleifend pretium. Aenean sagittis, leo ac congue mattis, est
+        nisl accumsan eros, sit amet suscipit massa lectus non nibh. In justo
+        libero, ultricies sed tristique vel, tincidunt non nulla. Pellentesque vel
+        pharetra risus. Donec tempus tortor at est vulputate ultrices. Quisque
+        sagittis pretium facilisis. Aliquam dignissim dapibus nibh sed bibendum.
+        Phasellus et nulla pulvinar, placerat sapien ac, vehicula mauris. Mauris
+        efficitur quis orci sed convallis.
+      </div>
+    </div>
+    <template type="amp-mustache">
+      <div>
+        <p>{{title}}</p>
+      </div>
+    </template>
+  </amp-list>
     <h3>amp-list with layout="container"</h3>
     <amp-list
       id="list1"

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -21,7 +21,6 @@ import {ElementStub} from './element-stub';
 import {
   Layout,
   applyStaticLayout,
-  isContainerLoadingAllowed,
   isInternalElement,
   isLoadingAllowed,
 } from './layout';
@@ -1631,7 +1630,7 @@ function createBaseCustomElementClass(win) {
       // 4. The element is too small or has not yet been measured;
       // 5. The element has not been allowlisted;
       // 6. The element is an internal node (e.g. `placeholder` or `fallback`);
-      // 7. The element's layout is not a size-defined layout or otherwise allowlisted.
+      // 7. The element's layout is not nodisplay.
       if (this.isInA4A()) {
         return false;
       }
@@ -1647,8 +1646,7 @@ function createBaseCustomElementClass(win) {
         this.layoutWidth_ <= 0 || // Layout is not ready or invisible
         !isLoadingAllowed(this) ||
         isInternalOrServiceNode(this) ||
-        this.layout_ == Layout.NODISPLAY ||
-        (this.layout_ == Layout.CONTAINER && !isContainerLoadingAllowed(this))
+        this.layout_ == Layout.NODISPLAY
       ) {
         return false;
       }

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -1648,7 +1648,7 @@ function createBaseCustomElementClass(win) {
         !isLoadingAllowed(this) ||
         isInternalOrServiceNode(this) ||
         this.layout_ == Layout.NODISPLAY ||
-        (this.layout_ == Layout.Container && !isContainerLoadingAllowed(this))
+        (this.layout_ == Layout.CONTAINER && !isContainerLoadingAllowed(this))
       ) {
         return false;
       }

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -21,8 +21,8 @@ import {ElementStub} from './element-stub';
 import {
   Layout,
   applyStaticLayout,
+  isContainerLoadingAllowed,
   isInternalElement,
-  isLayoutSizeDefined,
   isLoadingAllowed,
 } from './layout';
 import {LayoutDelayMeter} from './layout-delay-meter';
@@ -1631,7 +1631,7 @@ function createBaseCustomElementClass(win) {
       // 4. The element is too small or has not yet been measured;
       // 5. The element has not been allowlisted;
       // 6. The element is an internal node (e.g. `placeholder` or `fallback`);
-      // 7. The element's layout is not a size-defining layout.
+      // 7. The element's layout is not a size-defined layout or otherwise allowlisted.
       if (this.isInA4A()) {
         return false;
       }
@@ -1647,7 +1647,8 @@ function createBaseCustomElementClass(win) {
         this.layoutWidth_ <= 0 || // Layout is not ready or invisible
         !isLoadingAllowed(this) ||
         isInternalOrServiceNode(this) ||
-        !isLayoutSizeDefined(this.layout_)
+        this.layout_ == Layout.NODISPLAY ||
+        (this.layout_ == Layout.Container && !isContainerLoadingAllowed(this))
       ) {
         return false;
       }

--- a/src/layout.js
+++ b/src/layout.js
@@ -108,6 +108,17 @@ export const LOADING_ELEMENTS_ = {
   'AMP-PLAYBUZZ': true,
   'AMP-TWITTER': true,
 };
+
+/**
+ * Elements that are exempt from the layout size-defined requirement
+ * for showing progress.
+ * @enum {boolean}
+ * @private  Visible for testing only!
+ */
+export const LOADING_CONTAINER_ELEMENTS_ = {
+  'AMP-LIST': true, // amp-list[layout=container] requires a size-defining placeholder.
+};
+
 /**
  * All video player components must either have a) "video" or b) "player" in
  * their name. A few components don't follow this convention for historical
@@ -304,6 +315,18 @@ export function getNaturalDimensions(element) {
 export function isLoadingAllowed(element) {
   const tagName = element.tagName.toUpperCase();
   return LOADING_ELEMENTS_[tagName] || isIframeVideoPlayerComponent(tagName);
+}
+
+/**
+ * Whether the loading can be shown for the specified element. This set has
+ * to be externalized since the element's implementation may not be
+ * downloaded yet.
+ * @param {!Element} element
+ * @return {boolean}
+ */
+export function isContainerLoadingAllowed(element) {
+  const tagName = element.tagName.toUpperCase();
+  return LOADING_CONTAINER_ELEMENTS_[tagName] || false;
 }
 
 /**

--- a/src/layout.js
+++ b/src/layout.js
@@ -110,16 +110,6 @@ export const LOADING_ELEMENTS_ = {
 };
 
 /**
- * Elements that are exempt from the layout size-defined requirement
- * for showing progress.
- * @enum {boolean}
- * @private  Visible for testing only!
- */
-export const LOADING_CONTAINER_ELEMENTS_ = {
-  'AMP-LIST': true, // amp-list[layout=container] requires a size-defining placeholder.
-};
-
-/**
  * All video player components must either have a) "video" or b) "player" in
  * their name. A few components don't follow this convention for historical
  * reasons, so they are listed individually.
@@ -315,18 +305,6 @@ export function getNaturalDimensions(element) {
 export function isLoadingAllowed(element) {
   const tagName = element.tagName.toUpperCase();
   return LOADING_ELEMENTS_[tagName] || isIframeVideoPlayerComponent(tagName);
-}
-
-/**
- * Whether the loading can be shown for the specified element. This set has
- * to be externalized since the element's implementation may not be
- * downloaded yet.
- * @param {!Element} element
- * @return {boolean}
- */
-export function isContainerLoadingAllowed(element) {
-  const tagName = element.tagName.toUpperCase();
-  return !!LOADING_CONTAINER_ELEMENTS_[tagName];
 }
 
 /**

--- a/src/layout.js
+++ b/src/layout.js
@@ -108,7 +108,6 @@ export const LOADING_ELEMENTS_ = {
   'AMP-PLAYBUZZ': true,
   'AMP-TWITTER': true,
 };
-
 /**
  * All video player components must either have a) "video" or b) "player" in
  * their name. A few components don't follow this convention for historical

--- a/src/layout.js
+++ b/src/layout.js
@@ -326,7 +326,7 @@ export function isLoadingAllowed(element) {
  */
 export function isContainerLoadingAllowed(element) {
   const tagName = element.tagName.toUpperCase();
-  return LOADING_CONTAINER_ELEMENTS_[tagName] || false;
+  return !!LOADING_CONTAINER_ELEMENTS_[tagName];
 }
 
 /**

--- a/test/unit/test-custom-element.js
+++ b/test/unit/test-custom-element.js
@@ -19,7 +19,11 @@ import {AmpEvents} from '../../src/amp-events';
 import {BaseElement} from '../../src/base-element';
 import {CommonSignals} from '../../src/common-signals';
 import {ElementStub} from '../../src/element-stub';
-import {LOADING_ELEMENTS_, Layout} from '../../src/layout';
+import {
+  LOADING_CONTAINER_ELEMENTS_,
+  LOADING_ELEMENTS_,
+  Layout,
+} from '../../src/layout';
 import {ResourceState} from '../../src/service/resource';
 import {Services} from '../../src/services';
 import {chunkInstanceForTesting} from '../../src/chunk';
@@ -1845,6 +1849,13 @@ describes.realWin('CustomElement', {amp: true}, (env) => {
 
         element.layout_ = Layout.NODISPLAY;
         expect(element.isLoadingEnabled_()).to.be.false;
+      });
+
+      it('should enable when element is not sized but allowlisted', () => {
+        stubInA4A(false);
+        LOADING_CONTAINER_ELEMENTS_['amp-test-loader'.toUpperCase()] = true;
+        element.layout_ = Layout.CONTAINER;
+        expect(element.isLoadingEnabled_()).to.be.true;
       });
 
       it('should ignore loading-off if never created', () => {

--- a/test/unit/test-custom-element.js
+++ b/test/unit/test-custom-element.js
@@ -19,11 +19,7 @@ import {AmpEvents} from '../../src/amp-events';
 import {BaseElement} from '../../src/base-element';
 import {CommonSignals} from '../../src/common-signals';
 import {ElementStub} from '../../src/element-stub';
-import {
-  LOADING_CONTAINER_ELEMENTS_,
-  LOADING_ELEMENTS_,
-  Layout,
-} from '../../src/layout';
+import {LOADING_ELEMENTS_, Layout} from '../../src/layout';
 import {ResourceState} from '../../src/service/resource';
 import {Services} from '../../src/services';
 import {chunkInstanceForTesting} from '../../src/chunk';
@@ -1842,18 +1838,14 @@ describes.realWin('CustomElement', {amp: true}, (env) => {
         expect(element.isLoadingEnabled_()).to.be.false;
       });
 
-      it('should disable when element is not sized', () => {
+      it('should disable when element is layout=nodisplay', () => {
         stubInA4A(false);
-        element.layout_ = Layout.CONTAINER;
-        expect(element.isLoadingEnabled_()).to.be.false;
-
         element.layout_ = Layout.NODISPLAY;
         expect(element.isLoadingEnabled_()).to.be.false;
       });
 
-      it('should enable when element is not sized but allowlisted', () => {
+      it('should enable when element is layout=container', () => {
         stubInA4A(false);
-        LOADING_CONTAINER_ELEMENTS_['amp-test-loader'.toUpperCase()] = true;
         element.layout_ = Layout.CONTAINER;
         expect(element.isLoadingEnabled_()).to.be.true;
       });


### PR DESCRIPTION
#27911 allowed `amp-list` to have `layout=container` on the condition that it contains a size-defined `placeholder` element to display while items are being fetched and rendered. Default loaders do not currently apply to any `layout=container` AMP elements because, by virtue of not being size-defined, the element size could shift due to insertion of the loader.

A few important notes:
- amp-list has `position:relative` styling as a consequence of being `layout=container`
- The loading indicator is desirable to overlay across the whole amp-list, as this is consistent with other layout types of amp-list
- We still want to see content behind the loader because this may include the placeholder or initial contents
- `load-more` is not impacted here since `layout=container` and `load-more` are distinct
- amp-list is still under experiment so we will not be changing any behavior that people may be relying on now