### PR TITLE
🐛🌐 amp-consent: Minor CSS fix for better RTL support

### DIFF
--- a/extensions/amp-consent/0.1/amp-consent.css
+++ b/extensions/amp-consent/0.1/amp-consent.css
@@ -94,6 +94,11 @@ amp-consent.amp-hidden {
   top: auto;
 }
 
+[dir=rtl] .i-amphtml-consent-alertdialog {
+  right: -10000px;
+  left: auto;
+}
+
 .i-amphtml-consent-ui-fill {
   position: absolute;
   top: 0;


### PR DESCRIPTION
- The `<amp-consent>` banner currently displays empty when running in a RTL (right-to-left, e.g. Arabic) page. 
- This small CSS fix allows the banner to run properly without having to force `dir="ltr"` on `<amp-consent>`.