### PR TITLE
Update the webui validator code to use go1.13.

### DIFF
--- a/validator/webui/.gcloudignore
+++ b/validator/webui/.gcloudignore
@@ -1,0 +1,1 @@
+serve-standalone.go

--- a/validator/webui/app.yaml
+++ b/validator/webui/app.yaml
@@ -1,9 +1,10 @@
-runtime: googlelegacy
-api_version: go1
+runtime: go113
+
+main: ./main
 
 handlers:
 - url: /fetch
-  script: _go_app
+  script: auto
   secure: always
 
 - url: /$
@@ -20,6 +21,3 @@ handlers:
   static_files: logo-blue.svg
   upload: logo-blue\.svg$
   secure: always
-
-skip_files:
-  serve-standalone.go

--- a/validator/webui/main/serve.go
+++ b/validator/webui/main/serve.go
@@ -21,22 +21,17 @@
 // (2) Type 'goapp serve .' in the dist/webui_appengine directory.
 // (3) Point your web browser at http://localhost:8080/
 
-package webui
+package main
 
 import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"net/http"
 	"net/url"
-
-	"appengine"
-	"appengine/urlfetch"
+	"os"
 )
-
-func init() {
-	http.HandleFunc("/", handler)
-}
 
 func handler(w http.ResponseWriter, r *http.Request) {
 	if r.Method != "POST" ||
@@ -50,8 +45,8 @@ func handler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Bad request.", http.StatusBadRequest)
 		return
 	}
-	ctx := appengine.NewContext(r)
-	client := urlfetch.Client(ctx)
+
+	client := &http.Client {}
 	req, err := http.NewRequest("GET", u.String(), nil)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("Bad gateway (%v)", err.Error()),
@@ -88,3 +83,16 @@ func handler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-type", "application/json")
 	w.Write(bytes)
 }
+
+func main() {
+	http.HandleFunc("/", handler)
+
+  port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+	addr := fmt.Sprintf(":%s", port)
+	log.Printf("listening on %s", addr)
+	log.Fatal(http.ListenAndServe(addr, nil))
+}
+


### PR DESCRIPTION
Update the webui validator code to use go1.13 and replace appengine with google cloud APIs.