### PR TITLE
AdvertServe Custom Field Support

### DIFF
--- a/ads/advertserve.js
+++ b/ads/advertserve.js
@@ -21,7 +21,23 @@ import {validateData, writeScript} from '../3p/3p';
  * @param {!Object} data
  */
 export function advertserve(global, data) {
-  validateData(data, [], ['zid', 'pid', 'client']);
+  validateData(
+    data,
+    ['zid', 'pid', 'client'],
+    ['custom1', 'custom2', 'custom3', 'custom4', 'custom5',
+      'custom6', 'custom7', 'custom8', 'custom9', 'custom10']
+  );
+  
+  const customFields = (function() {
+    let params = '';
+    for (let i = 1; i <= 10; i++) {
+      const fieldName = 'custom' + i;
+      if (data[fieldName]) {
+        params += '&' + fieldName + '=' + encodeURIComponent(data[fieldName]);
+      }
+    }
+    return params;
+  })();
 
   const url =
     'https://' +
@@ -32,6 +48,7 @@ export function advertserve(global, data) {
     encodeURIComponent(data.zid) +
     '&pid=' +
     encodeURIComponent(data.pid) +
+    customFields +
     '&random=' +
     Math.floor(89999999 * Math.random() + 10000000) +
     '&millis=' +

--- a/ads/advertserve.js
+++ b/ads/advertserve.js
@@ -24,11 +24,21 @@ export function advertserve(global, data) {
   validateData(
     data,
     ['zid', 'pid', 'client'],
-    ['custom1', 'custom2', 'custom3', 'custom4', 'custom5',
-      'custom6', 'custom7', 'custom8', 'custom9', 'custom10']
+    [
+      'custom1',
+      'custom2',
+      'custom3',
+      'custom4',
+      'custom5',
+      'custom6',
+      'custom7',
+      'custom8',
+      'custom9',
+      'custom10',
+    ]
   );
-  
-  const customFields = (function() {
+
+  const customFields = (function () {
     let params = '';
     for (let i = 1; i <= 10; i++) {
       const fieldName = 'custom' + i;

--- a/ads/advertserve.js
+++ b/ads/advertserve.js
@@ -32,7 +32,7 @@ export function advertserve(global, data) {
     let params = '';
     for (let i = 1; i <= 10; i++) {
       const fieldName = 'custom' + i;
-      if (data[fieldName]) {
+      if (data[fieldName] !== undefined) {
         params += '&' + fieldName + '=' + encodeURIComponent(data[fieldName]);
       }
     }

--- a/ads/advertserve.md
+++ b/ads/advertserve.md
@@ -55,4 +55,3 @@ Optional parameters:
 - `data-custom8`: custom field 8
 - `data-custom9`: custom field 9
 - `data-custom10`: custom field 10
-

--- a/ads/advertserve.md
+++ b/ads/advertserve.md
@@ -26,6 +26,7 @@ limitations under the License.
   data-client="tester"
   data-pid="0"
   data-zid="68"
+  data-custom1="example"
 >
   <div placeholder>Loading ad.</div>
   <div fallback>Ad could not be loaded.</div>
@@ -36,8 +37,22 @@ limitations under the License.
 
 For details on the configuration semantics, please contact the ad network or refer to their documentation.
 
-Supported parameters:
+Required parameters:
 
 - `data-client`: client id
 - `data-pid`: publisher id
 - `data-zid`: zone id
+
+Optional parameters:
+
+- `data-custom1`: custom field 1
+- `data-custom2`: custom field 2
+- `data-custom3`: custom field 3
+- `data-custom4`: custom field 4
+- `data-custom5`: custom field 5
+- `data-custom6`: custom field 6
+- `data-custom7`: custom field 7
+- `data-custom8`: custom field 8
+- `data-custom9`: custom field 9
+- `data-custom10`: custom field 10
+


### PR DESCRIPTION
Added support and documentation for custom fields to the AdvertServe AMP ad tag that allow users to pass anywhere from 1-10 category/keyword fields for ad targeting purposes.