### PR TITLE
Upgrade IntersectionObserver polyfill to 0.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@ampproject/viewer-messaging": "1.1.0",
     "@ampproject/worker-dom": "0.25.0",
     "dompurify": "2.0.7",
-    "intersection-observer": "0.10.0",
+    "intersection-observer": "0.11.0",
     "moment": "2.24.0",
     "preact": "10.2.1",
     "promise-pjs": "1.1.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9680,10 +9680,10 @@ interpret@^1.1.0:
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.2.0.tgz#d5061a6224be58e8083985f5014d844359576296"
   integrity sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==
 
-intersection-observer@0.10.0:
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/intersection-observer/-/intersection-observer-0.10.0.tgz#4d11d63c1ff67e21e62987be24d55218da1a1a69"
-  integrity sha512-fn4bQ0Xq8FTej09YC/jqKZwtijpvARlRp6wxL5WTA6yPe2YWSJ5RJh7Nm79rK2qB0wr6iDQzH60XGq5V/7u8YQ==
+intersection-observer@0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/intersection-observer/-/intersection-observer-0.11.0.tgz#f4ea067070326f68393ee161cc0a2ca4c0040c6f"
+  integrity sha512-KZArj2QVnmdud9zTpKf279m2bbGfG+4/kn16UU0NL3pTVl52ZHiJ9IRNSsnn6jaHrL9EGLFM5eWjTx2fz/+zoQ==
 
 into-stream@^3.1.0:
   version "3.1.0"


### PR DESCRIPTION
Partial for #27807.
Fixes #28994.

This version mainly fixes the case where the polyfill is loaded directly in a same-origin iframe.
