### PR TITLE
Validator: require i-amphtml-intrinsic-sizer class in transformed intrinsic output

### DIFF
--- a/validator/engine/validator.js
+++ b/validator/engine/validator.js
@@ -4736,7 +4736,7 @@ function validateScriptSrcAttr(srcAttr, tagSpec, context, result) {
  * @param {!Context} context
  * @param {!generated.ValidationResult} result
  */
-function validateAttrClass(attr, tagSpec, context, result) {
+function validateClassAttr(attr, tagSpec, context, result) {
   const re = /(^|\W)i-amphtml-/;
   if (re.test(attr.value)) {
     context.addError(
@@ -5062,7 +5062,7 @@ function validateAttributes(
       }
     } else if (attr.name === 'class') {
       // For non-transformed AMP, `class` must not contain 'i-amphtml-' prefix.
-      validateAttrClass(attr, spec, context, result.validationResult);
+      validateClassAttr(attr, spec, context, result.validationResult);
       if (result.validationResult.status ===
           generated.ValidationResult.Status.FAIL) {
         continue;

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -3626,7 +3626,7 @@ attr_lists: {
     disabled_by: "amp4email"
     name: "list"
   }
-  attrs: { 
+  attrs: {
     disabled_by: "amp4email"
     name: "enterkeyhint"
   }
@@ -4624,6 +4624,12 @@ tags: {
     mandatory: true
   }
   attrs: {
+    name: "class"
+    value: "i-amphtml-intrinsic-sizer"
+    mandatory: true
+    dispatch_key: NAME_VALUE_DISPATCH
+  }
+  attrs: {
     name: "role"
     value: "presentation"
     mandatory: true
@@ -5475,12 +5481,11 @@ attr_lists: {
   # 3.2.5 HTML5 Global attributes.
   attrs: { name: "accesskey" }
   attrs: {
-    # attribute "class" for transformed is handled within the Validator engine.
+    # attribute "class" for is handled within the Validator engine.
     # If this changes, please be sure to also update:
     # amp-experiment 1.0 implementation.
-    disabled_by: "transformed"
     name: "class"
-    disallowed_value_regex: "(^|\\W)i-amphtml-"
+    # disallowed_value_regex: "(^|\\W)i-amphtml-"
   }
   attrs: { name: "dir" }
   attrs: { name: "draggable" }


### PR DESCRIPTION
This PR moves the `class` validation logic out of the protoascii and into the validator engine. The `disabled_by: "transformed"` was causing issues with validation of explicit class values:

- `class` is `disabled_by` globally (for all elements)
- If an attribute appears and is `disabled_by`, it'll cause a validation error (so any element with a `class` would fail)
- Due to this, we had to skip `class` attr validation
- Due to the skip,  we couldn't validate the value, nor make the value mandatory.

Instead, moving the validation logic into the engine allows us to allow `class` on every element, and place a stricter validation when not-transformed.

This fixes an issue from https://github.com/ampproject/amphtml/pull/24119#discussion_r316404852.

