### PR TITLE
Validator: Allow SSR for amp-img's img

### DIFF
--- a/validator/testdata/transformed_feature_tests/amp-img.html
+++ b/validator/testdata/transformed_feature_tests/amp-img.html
@@ -1,0 +1,53 @@
+<!--
+  Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS-IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the license.
+-->
+<!--
+  Test Description:
+  This tests that <img> is allowed as child tag for <amp-img>.
+-->
+<!doctype html>
+<html ⚡ transformed="google;v=1">
+<head>
+  <meta charset="utf-8">
+  <style amp-runtime i-amphtml-version=123456789012345>.omitted-for-brevity{}</style>
+  <meta name="viewport" content="width=device-width">
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <link rel="canonical" href="./regular-html-version.html">
+</head>
+<body>
+  <!-- Valid: amp-img > img -->
+  <amp-img src="/img/canoe_900x600.jpg" alt="An image about canoeing" layout="responsive" width="900" height="600" i-amphtml-ssr>
+    <img src="/img/canoe_900x600.jpg" alt="An image about canoeing" decoding="async">
+  </amp-img>
+
+  <!-- Valid: amp-img[layout=intrinsic] > img -->
+  <amp-img src="/img/canoe_900x600.jpg" alt="An image about canoeing" layout="intrinsic" width="900" height="600" i-amphtml-layout="intrinsic" i-amphtml-ssr>
+    <i-amphtml-sizer class="i-amphtml-sizer">
+      <img alt aria-hidden="true" class="i-amphtml-intrinsic-sizer" role="presentation" src="data:image/svg+xml;charset=utf-8,<svg height=&quot;600&quot; width=&quot;900&quot; xmlns=&quot;http://www.w3.org/2000/svg&quot; version=&quot;1.1&quot;/>">
+    </i-amphtml-sizer>
+    <img src="/img/canoe_900x600.jpg" alt="An image about canoeing" decoding="async">
+  </amp-img>
+
+  <!-- Invalid: amp-img > img, missing i-amphtml-ssr attr -->
+  <amp-img src="/img/canoe_900x600.jpg" alt="An image about canoeing" layout="responsive" width="900" height="600">
+    <img src="/img/canoe_900x600.jpg" alt="An image about canoeing" decoding="async">
+  </amp-img>
+
+  <!-- Invalid: amp-img > img, missing decoding attr -->
+  <amp-img src="/img/canoe_900x600.jpg" alt="An image about canoeing" layout="responsive" width="900" height="600">
+    <img src="/img/canoe_900x600.jpg" alt="An image about canoeing">
+  </amp-img>
+</body>
+</html>

--- a/validator/testdata/transformed_feature_tests/amp-img.html
+++ b/validator/testdata/transformed_feature_tests/amp-img.html
@@ -29,7 +29,7 @@
 <body>
   <!-- Valid: amp-img > img -->
   <amp-img src="/img/canoe_900x600.jpg" alt="An image about canoeing" layout="responsive" width="900" height="600" i-amphtml-ssr>
-    <img src="/img/canoe_900x600.jpg" alt="An image about canoeing" decoding="async">
+    <img src="/img/canoe_900x600.jpg" alt="An image about canoeing" decoding="async" loading="lazy">
   </amp-img>
 
   <!-- Valid: amp-img[layout=intrinsic] > img -->
@@ -37,17 +37,22 @@
     <i-amphtml-sizer class="i-amphtml-sizer">
       <img alt aria-hidden="true" class="i-amphtml-intrinsic-sizer" role="presentation" src="data:image/svg+xml;charset=utf-8,<svg height=&quot;600&quot; width=&quot;900&quot; xmlns=&quot;http://www.w3.org/2000/svg&quot; version=&quot;1.1&quot;/>">
     </i-amphtml-sizer>
-    <img src="/img/canoe_900x600.jpg" alt="An image about canoeing" decoding="async">
+    <img src="/img/canoe_900x600.jpg" alt="An image about canoeing" decoding="async" loading="lazy">
   </amp-img>
 
   <!-- Invalid: amp-img > img, missing i-amphtml-ssr attr -->
   <amp-img src="/img/canoe_900x600.jpg" alt="An image about canoeing" layout="responsive" width="900" height="600">
-    <img src="/img/canoe_900x600.jpg" alt="An image about canoeing" decoding="async">
+    <img src="/img/canoe_900x600.jpg" alt="An image about canoeing" decoding="async" loading="lazy">
   </amp-img>
 
   <!-- Invalid: amp-img > img, missing decoding attr -->
-  <amp-img src="/img/canoe_900x600.jpg" alt="An image about canoeing" layout="responsive" width="900" height="600">
-    <img src="/img/canoe_900x600.jpg" alt="An image about canoeing">
+  <amp-img src="/img/canoe_900x600.jpg" alt="An image about canoeing" layout="responsive" width="900" height="600" i-amphtml-ssr>
+    <img src="/img/canoe_900x600.jpg" alt="An image about canoeing" loading="lazy">
+  </amp-img>
+
+  <!-- Invalid: amp-img > img, missing loading attr -->
+  <amp-img src="/img/canoe_900x600.jpg" alt="An image about canoeing" layout="responsive" width="900" height="600" i-amphtml-ssr>
+    <img src="/img/canoe_900x600.jpg" alt="An image about canoeing" decoding="async">
   </amp-img>
 </body>
 </html>

--- a/validator/testdata/transformed_feature_tests/amp-img.html
+++ b/validator/testdata/transformed_feature_tests/amp-img.html
@@ -29,7 +29,7 @@
 <body>
   <!-- Valid: amp-img > img -->
   <amp-img src="/img/canoe_900x600.jpg" alt="An image about canoeing" layout="responsive" width="900" height="600" i-amphtml-ssr>
-    <img src="/img/canoe_900x600.jpg" alt="An image about canoeing" decoding="async" loading="lazy">
+    <img src="/img/canoe_900x600.jpg" alt="An image about canoeing" class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" loading="lazy">
   </amp-img>
 
   <!-- Valid: amp-img[layout=intrinsic] > img -->
@@ -37,22 +37,27 @@
     <i-amphtml-sizer class="i-amphtml-sizer">
       <img alt aria-hidden="true" class="i-amphtml-intrinsic-sizer" role="presentation" src="data:image/svg+xml;charset=utf-8,<svg height=&quot;600&quot; width=&quot;900&quot; xmlns=&quot;http://www.w3.org/2000/svg&quot; version=&quot;1.1&quot;/>">
     </i-amphtml-sizer>
-    <img src="/img/canoe_900x600.jpg" alt="An image about canoeing" decoding="async" loading="lazy">
+    <img src="/img/canoe_900x600.jpg" alt="An image about canoeing" class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" loading="lazy">
   </amp-img>
 
   <!-- Invalid: amp-img > img, missing i-amphtml-ssr attr -->
   <amp-img src="/img/canoe_900x600.jpg" alt="An image about canoeing" layout="responsive" width="900" height="600">
+    <img src="/img/canoe_900x600.jpg" alt="An image about canoeing" class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" loading="lazy">
+  </amp-img>
+
+  <!-- Invalid: amp-img > img, missing class attr -->
+  <amp-img src="/img/canoe_900x600.jpg" alt="An image about canoeing" layout="responsive" width="900" height="600" i-amphtml-ssr>
     <img src="/img/canoe_900x600.jpg" alt="An image about canoeing" decoding="async" loading="lazy">
   </amp-img>
 
   <!-- Invalid: amp-img > img, missing decoding attr -->
   <amp-img src="/img/canoe_900x600.jpg" alt="An image about canoeing" layout="responsive" width="900" height="600" i-amphtml-ssr>
-    <img src="/img/canoe_900x600.jpg" alt="An image about canoeing" loading="lazy">
+    <img src="/img/canoe_900x600.jpg" alt="An image about canoeing" class="i-amphtml-fill-content i-amphtml-replaced-content" loading="lazy">
   </amp-img>
 
   <!-- Invalid: amp-img > img, missing loading attr -->
   <amp-img src="/img/canoe_900x600.jpg" alt="An image about canoeing" layout="responsive" width="900" height="600" i-amphtml-ssr>
-    <img src="/img/canoe_900x600.jpg" alt="An image about canoeing" decoding="async">
+    <img src="/img/canoe_900x600.jpg" alt="An image about canoeing" class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async">
   </amp-img>
 </body>
 </html>

--- a/validator/testdata/transformed_feature_tests/amp-img.out
+++ b/validator/testdata/transformed_feature_tests/amp-img.out
@@ -1,0 +1,58 @@
+FAIL
+|  <!--
+|    Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+|
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|
+|        http://www.apache.org/licenses/LICENSE-2.0
+|
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    This tests that <img> is allowed as child tag for <amp-img>.
+|  -->
+|  <!doctype html>
+|  <html ⚡ transformed="google;v=1">
+|  <head>
+|    <meta charset="utf-8">
+|    <style amp-runtime i-amphtml-version=123456789012345>.omitted-for-brevity{}</style>
+|    <meta name="viewport" content="width=device-width">
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    <link rel="canonical" href="./regular-html-version.html">
+|  </head>
+|  <body>
+|    <!-- Valid: amp-img > img -->
+|    <amp-img src="/img/canoe_900x600.jpg" alt="An image about canoeing" layout="responsive" width="900" height="600" i-amphtml-ssr>
+|      <img src="/img/canoe_900x600.jpg" alt="An image about canoeing" decoding="async">
+|    </amp-img>
+|
+|    <!-- Valid: amp-img[layout=intrinsic] > img -->
+|    <amp-img src="/img/canoe_900x600.jpg" alt="An image about canoeing" layout="intrinsic" width="900" height="600" i-amphtml-layout="intrinsic" i-amphtml-ssr>
+|      <i-amphtml-sizer class="i-amphtml-sizer">
+|        <img alt aria-hidden="true" class="i-amphtml-intrinsic-sizer" role="presentation" src="data:image/svg+xml;charset=utf-8,<svg height=&quot;600&quot; width=&quot;900&quot; xmlns=&quot;http://www.w3.org/2000/svg&quot; version=&quot;1.1&quot;/>">
+|      </i-amphtml-sizer>
+|      <img src="/img/canoe_900x600.jpg" alt="An image about canoeing" decoding="async">
+|    </amp-img>
+|
+|    <!-- Invalid: amp-img > img, missing i-amphtml-ssr attr -->
+|    <amp-img src="/img/canoe_900x600.jpg" alt="An image about canoeing" layout="responsive" width="900" height="600">
+|      <img src="/img/canoe_900x600.jpg" alt="An image about canoeing" decoding="async">
+>>     ^~~~~~~~~
+transformed_feature_tests/amp-img.html:45:4 The parent tag of tag 'img' is 'amp-img', but it can only be 'i-amphtml-sizer-intrinsic'.
+|    </amp-img>
+|
+|    <!-- Invalid: amp-img > img, missing decoding attr -->
+|    <amp-img src="/img/canoe_900x600.jpg" alt="An image about canoeing" layout="responsive" width="900" height="600">
+|      <img src="/img/canoe_900x600.jpg" alt="An image about canoeing">
+>>     ^~~~~~~~~
+transformed_feature_tests/amp-img.html:50:4 The parent tag of tag 'img' is 'amp-img', but it can only be 'i-amphtml-sizer-intrinsic'.
+|    </amp-img>
+|  </body>
+|  </html>

--- a/validator/testdata/transformed_feature_tests/amp-img.out
+++ b/validator/testdata/transformed_feature_tests/amp-img.out
@@ -30,7 +30,7 @@ FAIL
 |  <body>
 |    <!-- Valid: amp-img > img -->
 |    <amp-img src="/img/canoe_900x600.jpg" alt="An image about canoeing" layout="responsive" width="900" height="600" i-amphtml-ssr>
-|      <img src="/img/canoe_900x600.jpg" alt="An image about canoeing" decoding="async">
+|      <img src="/img/canoe_900x600.jpg" alt="An image about canoeing" decoding="async" loading="lazy">
 |    </amp-img>
 |
 |    <!-- Valid: amp-img[layout=intrinsic] > img -->
@@ -38,21 +38,28 @@ FAIL
 |      <i-amphtml-sizer class="i-amphtml-sizer">
 |        <img alt aria-hidden="true" class="i-amphtml-intrinsic-sizer" role="presentation" src="data:image/svg+xml;charset=utf-8,<svg height=&quot;600&quot; width=&quot;900&quot; xmlns=&quot;http://www.w3.org/2000/svg&quot; version=&quot;1.1&quot;/>">
 |      </i-amphtml-sizer>
-|      <img src="/img/canoe_900x600.jpg" alt="An image about canoeing" decoding="async">
+|      <img src="/img/canoe_900x600.jpg" alt="An image about canoeing" decoding="async" loading="lazy">
 |    </amp-img>
 |
 |    <!-- Invalid: amp-img > img, missing i-amphtml-ssr attr -->
 |    <amp-img src="/img/canoe_900x600.jpg" alt="An image about canoeing" layout="responsive" width="900" height="600">
-|      <img src="/img/canoe_900x600.jpg" alt="An image about canoeing" decoding="async">
+|      <img src="/img/canoe_900x600.jpg" alt="An image about canoeing" decoding="async" loading="lazy">
 >>     ^~~~~~~~~
-transformed_feature_tests/amp-img.html:45:4 The parent tag of tag 'img' is 'amp-img', but it can only be 'i-amphtml-sizer-intrinsic'.
+transformed_feature_tests/amp-img.html:45:4 The parent tag of tag 'img' is 'amp-img', but it can only be 'amp-img (transformed)'.
 |    </amp-img>
 |
 |    <!-- Invalid: amp-img > img, missing decoding attr -->
-|    <amp-img src="/img/canoe_900x600.jpg" alt="An image about canoeing" layout="responsive" width="900" height="600">
-|      <img src="/img/canoe_900x600.jpg" alt="An image about canoeing">
+|    <amp-img src="/img/canoe_900x600.jpg" alt="An image about canoeing" layout="responsive" width="900" height="600" i-amphtml-ssr>
+|      <img src="/img/canoe_900x600.jpg" alt="An image about canoeing" loading="lazy">
 >>     ^~~~~~~~~
-transformed_feature_tests/amp-img.html:50:4 The parent tag of tag 'img' is 'amp-img', but it can only be 'i-amphtml-sizer-intrinsic'.
+transformed_feature_tests/amp-img.html:50:4 The mandatory attribute 'decoding' is missing in tag 'img'.
+|    </amp-img>
+|
+|    <!-- Invalid: amp-img > img, missing loading attr -->
+|    <amp-img src="/img/canoe_900x600.jpg" alt="An image about canoeing" layout="responsive" width="900" height="600" i-amphtml-ssr>
+|      <img src="/img/canoe_900x600.jpg" alt="An image about canoeing" decoding="async">
+>>     ^~~~~~~~~
+transformed_feature_tests/amp-img.html:55:4 The mandatory attribute 'loading' is missing in tag 'img'.
 |    </amp-img>
 |  </body>
 |  </html>

--- a/validator/testdata/transformed_feature_tests/amp-img.out
+++ b/validator/testdata/transformed_feature_tests/amp-img.out
@@ -45,7 +45,7 @@ FAIL
 |    <amp-img src="/img/canoe_900x600.jpg" alt="An image about canoeing" layout="responsive" width="900" height="600">
 |      <img src="/img/canoe_900x600.jpg" alt="An image about canoeing" decoding="async" loading="lazy">
 >>     ^~~~~~~~~
-transformed_feature_tests/amp-img.html:45:4 The parent tag of tag 'img' is 'amp-img', but it can only be 'amp-img (transformed)'.
+transformed_feature_tests/amp-img.html:45:4 The parent tag of tag 'img' is 'amp-img', but it can only be 'i-amphtml-sizer-intrinsic'.
 |    </amp-img>
 |
 |    <!-- Invalid: amp-img > img, missing decoding attr -->

--- a/validator/testdata/transformed_feature_tests/amp-img.out
+++ b/validator/testdata/transformed_feature_tests/amp-img.out
@@ -30,7 +30,7 @@ FAIL
 |  <body>
 |    <!-- Valid: amp-img > img -->
 |    <amp-img src="/img/canoe_900x600.jpg" alt="An image about canoeing" layout="responsive" width="900" height="600" i-amphtml-ssr>
-|      <img src="/img/canoe_900x600.jpg" alt="An image about canoeing" decoding="async" loading="lazy">
+|      <img src="/img/canoe_900x600.jpg" alt="An image about canoeing" class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" loading="lazy">
 |    </amp-img>
 |
 |    <!-- Valid: amp-img[layout=intrinsic] > img -->
@@ -38,28 +38,35 @@ FAIL
 |      <i-amphtml-sizer class="i-amphtml-sizer">
 |        <img alt aria-hidden="true" class="i-amphtml-intrinsic-sizer" role="presentation" src="data:image/svg+xml;charset=utf-8,<svg height=&quot;600&quot; width=&quot;900&quot; xmlns=&quot;http://www.w3.org/2000/svg&quot; version=&quot;1.1&quot;/>">
 |      </i-amphtml-sizer>
-|      <img src="/img/canoe_900x600.jpg" alt="An image about canoeing" decoding="async" loading="lazy">
+|      <img src="/img/canoe_900x600.jpg" alt="An image about canoeing" class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" loading="lazy">
 |    </amp-img>
 |
 |    <!-- Invalid: amp-img > img, missing i-amphtml-ssr attr -->
 |    <amp-img src="/img/canoe_900x600.jpg" alt="An image about canoeing" layout="responsive" width="900" height="600">
-|      <img src="/img/canoe_900x600.jpg" alt="An image about canoeing" decoding="async" loading="lazy">
+|      <img src="/img/canoe_900x600.jpg" alt="An image about canoeing" class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" loading="lazy">
 >>     ^~~~~~~~~
 transformed_feature_tests/amp-img.html:45:4 The parent tag of tag 'img' is 'amp-img', but it can only be 'i-amphtml-sizer-intrinsic'.
 |    </amp-img>
 |
+|    <!-- Invalid: amp-img > img, missing class attr -->
+|    <amp-img src="/img/canoe_900x600.jpg" alt="An image about canoeing" layout="responsive" width="900" height="600" i-amphtml-ssr>
+|      <img src="/img/canoe_900x600.jpg" alt="An image about canoeing" decoding="async" loading="lazy">
+>>     ^~~~~~~~~
+transformed_feature_tests/amp-img.html:50:4 The mandatory attribute 'class' is missing in tag 'img'.
+|    </amp-img>
+|
 |    <!-- Invalid: amp-img > img, missing decoding attr -->
 |    <amp-img src="/img/canoe_900x600.jpg" alt="An image about canoeing" layout="responsive" width="900" height="600" i-amphtml-ssr>
-|      <img src="/img/canoe_900x600.jpg" alt="An image about canoeing" loading="lazy">
+|      <img src="/img/canoe_900x600.jpg" alt="An image about canoeing" class="i-amphtml-fill-content i-amphtml-replaced-content" loading="lazy">
 >>     ^~~~~~~~~
-transformed_feature_tests/amp-img.html:50:4 The mandatory attribute 'decoding' is missing in tag 'img'.
+transformed_feature_tests/amp-img.html:55:4 The mandatory attribute 'decoding' is missing in tag 'img'.
 |    </amp-img>
 |
 |    <!-- Invalid: amp-img > img, missing loading attr -->
 |    <amp-img src="/img/canoe_900x600.jpg" alt="An image about canoeing" layout="responsive" width="900" height="600" i-amphtml-ssr>
-|      <img src="/img/canoe_900x600.jpg" alt="An image about canoeing" decoding="async">
+|      <img src="/img/canoe_900x600.jpg" alt="An image about canoeing" class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async">
 >>     ^~~~~~~~~
-transformed_feature_tests/amp-img.html:55:4 The mandatory attribute 'loading' is missing in tag 'img'.
+transformed_feature_tests/amp-img.html:60:4 The mandatory attribute 'loading' is missing in tag 'img'.
 |    </amp-img>
 |  </body>
 |  </html>

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -4516,6 +4516,7 @@ tags: {  # <amp-img i-amphtml-ssr>
   attrs: { name: "object-fit" }
   attrs: { name: "object-position" }
   attrs: { name: "placeholder" }
+  attrs: { name: "referrerpolicy" }
   # <amp-bind>
   attrs: { name: "[alt]" }
   attrs: { name: "[attribution]" }

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -4696,6 +4696,11 @@ tags: {
     value: "async"
     mandatory: true
   }
+  attrs: {
+    name: "loading"
+    value: "lazy"
+    mandatory: true
+  }
 }
 
 # AMP Layout attributes: implied for TagSpecs with amp_layout field

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -4694,7 +4694,8 @@ tags: {
   # SSR requires these explicit attributes
   attrs: {
     name: "class"
-    value_regex: "i-amphtml-fill-content\s+i-amphtml-replaced-content|i-amphtml-replaced-content\s+i-amphtml-fill-content"
+    value_regex: "i-amphtml-fill-content\\s+i-amphtml-replaced-content|"
+        "i-amphtml-replaced-content\\s+i-amphtml-fill-content"
     mandatory: true
   }
   attrs: {

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -1776,7 +1776,7 @@ tags: {
 
 # 4.7 Embedded Content
 # AMP HTML allows embedded content only via its own tags (e.g. amp-img), with
-# the exception of tags inside of a <noscript> ancestor.
+# the exception of tags inside of a <noscript> ancestor and transformed amp-img.
 # 4.7.1 The img element
 tags: {
   html_format: AMP  # Disallowed in AMP4ADS because <noscript> is disallowed.
@@ -4500,6 +4500,41 @@ tags: {  # <amp-img>
     supported_layouts: RESPONSIVE
   }
 }
+# A duplicate of amp-img, but requires i-amphtml-ssr flag.
+tags: {  # <amp-img i-amphtml-ssr>
+  html_format: AMP
+  enabled_by: "transformed"
+  tag_name: "AMP-IMG"
+  spec_name: "amp-img (transformed)"
+  attrs: {
+    dispatch_key: NAME_DISPATCH
+    name: "i-amphtml-ssr"
+    mandatory: true
+  }
+  attrs: { name: "alt" }
+  attrs: { name: "attribution" }
+  attrs: { name: "object-fit" }
+  attrs: { name: "object-position" }
+  attrs: { name: "placeholder" }
+  # <amp-bind>
+  attrs: { name: "[alt]" }
+  attrs: { name: "[attribution]" }
+  attrs: { name: "[src]" }
+  attrs: { name: "[srcset]" }
+  attr_lists: "extended-amp-global"
+  attr_lists: "lightboxable-elements"
+  attr_lists: "mandatory-src-or-srcset"
+  spec_url: "https://amp.dev/documentation/components/amp-img/"
+  amp_layout: {
+    supported_layouts: FILL
+    supported_layouts: FIXED
+    supported_layouts: FIXED_HEIGHT
+    supported_layouts: FLEX_ITEM
+    supported_layouts: INTRINSIC
+    supported_layouts: NODISPLAY
+    supported_layouts: RESPONSIVE
+  }
+}
 # See the restrictions on mandatory-src-amp4email, as well as the removal of
 # `object-fit` and `object-position`.
 tags: {  # <amp-img>
@@ -4634,6 +4669,31 @@ tags: {
   attrs: {
     name: "src"
     value_regex: "data:image\\/svg\\+xml;charset=utf-8,\\s*<svg height=\"\\d+(\\.\\d+)?\" width=\"\\d+(\\.\\d+)?\" xmlns=\"http:\\/\\/www\\.w3\\.org\\/2000\\/svg\" version=\"1\\.1\"\\/>|data:image\\/svg\\+xml;charset=utf-8,\\s*<svg height='\\d+(\\.\\d+)?\' width='\\d+(\\.\\d+)?\' xmlns='http:\\/\\/www\\.w3\\.org\\/2000\\/svg' version='1\\.1'\\/>|data:image\\/svg\\+xml;base64,[a-zA-Z0-9+\\/=]+"
+    mandatory: true
+  }
+}
+
+tags: {
+  html_format: AMP
+  enabled_by: "transformed"
+  tag_name: "IMG"
+  spec_name: "amp-img > img (transformed)"
+  # Ideally we'd be able to use regular amp-img parent, but runtime currently
+  # requires an i-amphtml-ssr attribute on the amp-img. We could do away with
+  # that, though.
+  mandatory_parent: "amp-img (transformed)"
+  attrs: { name: "alt" }
+  attrs: { name: "attribution" }
+  attrs: { name: "object-fit" }
+  attrs: { name: "object-position" }
+  attrs: { name: "referrerpolicy" }
+  attrs: { name: "sizes" }
+  attrs: { name: "title" }
+  attr_lists: "mandatory-src-or-srcset"
+  # SSR requires these explicit attributes
+  attrs: {
+    name: "decoding"
+    value: "async"
     mandatory: true
   }
 }

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -4693,6 +4693,11 @@ tags: {
   attr_lists: "mandatory-src-or-srcset"
   # SSR requires these explicit attributes
   attrs: {
+    name: "class"
+    value_regex: "i-amphtml-fill-content\s+i-amphtml-replaced-content|i-amphtml-replaced-content\s+i-amphtml-fill-content"
+    mandatory: true
+  }
+  attrs: {
     name: "decoding"
     value: "async"
     mandatory: true


### PR DESCRIPTION
This adds validator support for server-side rendering an `<amp-img>`.

The one weird part of this is the requirement that the SSR'd `<amp-img>` include a `i-amphtml-ssr` attribute. I think this was necessary because we couldn't properly support intrinsic and blurry-image placeholder SSR at the same time. But with recent bug fixes, this shouldn't be a blocker anymore. So, we could remove the `i-amphtml-ssr` requirement, which will remove the duplicate tag spec here.

Fixes https://github.com/ampproject/amphtml/issues/28672.