### PR TITLE
🏗 Stop running "Remote Tests (Sauce Labs)" on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -84,14 +84,6 @@ jobs:
       script:
         - unbuffer node build-system/pr-check/dist-tests.js
     - stage: test
-      name: 'Remote (Sauce Labs) Tests'
-      if: type = push
-      script:
-        - unbuffer node build-system/pr-check/remote-tests.js
-      after_script:
-        - build-system/sauce_connect/stop_sauce_connect.sh
-        - ps -ef
-    - stage: test
       name: 'End to End Tests'
       script:
         - unbuffer node build-system/pr-check/e2e-tests.js


### PR DESCRIPTION
Our Sauce Labs account has been shut down and `master` is red as a result. This PR merely stops running the "Remote Tests (Sauce Labs)" job on Travis. A full cleanup is out for review in #29038.

