### PR TITLE
🔥 Upgrade WorkerDOM to fix ES5 transpilation issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@ampproject/animations": "0.2.2",
     "@ampproject/toolbox-cache-url": "2.5.4",
     "@ampproject/viewer-messaging": "1.1.0",
-    "@ampproject/worker-dom": "0.25.0",
+    "@ampproject/worker-dom": "0.25.1",
     "dompurify": "2.0.7",
     "intersection-observer": "0.11.0",
     "moment": "2.24.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -39,10 +39,10 @@
   resolved "https://registry.yarnpkg.com/@ampproject/viewer-messaging/-/viewer-messaging-1.1.0.tgz#404f92c5754bac61014ed2272dd5e87174b9af84"
   integrity sha512-SoR1dGl2Pl8eJlyGCU/9Gz/orOggmW/13wUh7NnuGvDYqLdlhnRBzvEGqEAlq/fQKel9ZM6RNtu85Jw8WC3K2Q==
 
-"@ampproject/worker-dom@0.25.0":
-  version "0.25.0"
-  resolved "https://registry.yarnpkg.com/@ampproject/worker-dom/-/worker-dom-0.25.0.tgz#c6f2e14806e1a3d063725c07bef8c29dd07d66dd"
-  integrity sha512-/m4UEQU37MCNO1ac1kxerh21pSpjkUQSaE1PFUp/FakxWSmJ+IFY84VWoRWR4vqHZw3fahJnQqXqH3gA8vU4rg==
+"@ampproject/worker-dom@0.25.1":
+  version "0.25.1"
+  resolved "https://registry.yarnpkg.com/@ampproject/worker-dom/-/worker-dom-0.25.1.tgz#3f97441b94ee5d84f882f4f1262ca0c4888b11b6"
+  integrity sha512-6qfHzg7YFNwcUr9a2iWWQp0ZTUlM+O4UUDFClM5O3ZZ28CooK4xdhOdLCOQr04zQ0td+6zd02rUip2JBcWx4aQ==
 
 "@ava/babel-plugin-throws-helper@^4.0.0":
   version "4.0.0"


### PR DESCRIPTION
WorkerDOM was transpiled using `loose` mode for AMP which specifically broke `classList` support.