### PR TITLE
[amp-accordion] Remove requirement for element headers to be H-elements. 

### DIFF
--- a/examples/accordion.amp.html
+++ b/examples/accordion.amp.html
@@ -43,6 +43,9 @@
 
   <button on="tap:AMP.setState({expandAc2: true})">Expand section 1</button>
   <button on="tap:AMP.setState({expandAc2: false})">Collapse section 1</button>
+
+  <button on="tap:AMP.setState({expandAcv: true})">Expand AMP-video headed section</button>
+  <button on="tap:AMP.setState({expandAcv: false})">Collapse AMP-video headed section</button>
   <header class="menu">
     <h3>MENU</h3>
     <nav>
@@ -112,6 +115,41 @@
     <section>
       <header>The header tag is supported as well.</header>
       <p>Even more awesome.</p>
+    </section>
+    <section>
+      <p>Section with p-tagged header</p>
+      <p>More awesome content</p>
+    </section>
+    <section>
+      <details>
+        <summary>
+          Clicking any child of an AMP-accordion header overrides the default
+          action and expands this section
+        </summary>
+        Viewers can't access the detail here.
+      </details>
+      <p>But they can see this section's content!!</p>
+    </section>
+    <section>
+      <p>Except if the header's child is an <a href="#">anchor</a></p>
+      <p>Clicking the anchor does not expand this section.</p>
+    </section>
+    <section [data-expand]="expandAcv" on="expand:AMP.setState({expandAcv: true});collapse:AMP.setState({expandAcv: false})">
+      <amp-video
+        id=myVideoHeader
+        title="Big Buck Bunny"
+        artist="Blender Foundation"
+        poster="img/bigbuckbunny.jpg"
+        album="The Peach Open Movie Project"
+        src="https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4"
+        width="360"
+        height="202"
+        controls>
+      </amp-video>
+      <p>
+        Or if the header element has a tap target, like in an AMP-video. Clicking the video does
+        not expand this section.
+      </p>
     </section>
   </amp-accordion>
 </body>

--- a/extensions/amp-accordion/0.1/amp-accordion.css
+++ b/extensions/amp-accordion/0.1/amp-accordion.css
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-/* heading/clontent */
+/* heading/content */
 .i-amphtml-accordion-header,
 .i-amphtml-accordion-content {
   margin: 0;
@@ -42,9 +42,11 @@ amp-accordion > section:not([expanded]) > :last-child[rendersubtree] {
   width: 100% !important;
 }
 
-/* Media should never play when a section is collapsed */
-amp-accordion > section:not([expanded]) .i-amphtml-media-component,
-amp-accordion > section:not([expanded]) .i-amphtml-media-component * {
+/* Media should never play when a section is collapsed, except if it
+ * is in the heading element.
+ */
+amp-accordion > section:not([expanded]) > :not(:first-child) .i-amphtml-media-component,
+amp-accordion > section:not([expanded]) > :not(:first-child) .i-amphtml-media-component * {
   display: none !important;
   visibility: hidden !important;
 }

--- a/extensions/amp-accordion/0.1/test/validator-amp-accordion.html
+++ b/extensions/amp-accordion/0.1/test/validator-amp-accordion.html
@@ -52,8 +52,8 @@
       </amp-accordion>
     </section>
     <section>
-      <header>The header tag is supported as well.</header>
-      <p>Even more awesome.</p>
+      <p>Section with differently-styled header</p>
+      <p>More awesome content</p>
     </section>
     <section [data-expand]="">
       <h2>Section with bound [data-expand] attribute</h2>
@@ -67,9 +67,9 @@
     </amp-accordion>
     <p>Some paragraph of text that doesn't belong here.</p>
     <section>
-      <div>header which isn't h1-h6.</div>
+      <div>a first child</div>
       <div>a second child</div>
-      <div>a third child</div>
+      <div>an invalid third child</div>
     </section>
   </amp-accordion>
 </body>

--- a/extensions/amp-accordion/0.1/test/validator-amp-accordion.html
+++ b/extensions/amp-accordion/0.1/test/validator-amp-accordion.html
@@ -52,7 +52,7 @@
       </amp-accordion>
     </section>
     <section>
-      <p>Section with differently-styled header</p>
+      <p>Section with differently-tagged header</p>
       <p>More awesome content</p>
     </section>
     <section [data-expand]="">

--- a/extensions/amp-accordion/0.1/test/validator-amp-accordion.out
+++ b/extensions/amp-accordion/0.1/test/validator-amp-accordion.out
@@ -53,7 +53,7 @@ FAIL
 |        </amp-accordion>
 |      </section>
 |      <section>
-|        <p>Section with differently-styled header</p>
+|        <p>Section with differently-tagged header</p>
 |        <p>More awesome content</p>
 |      </section>
 |      <section [data-expand]="">

--- a/extensions/amp-accordion/0.1/test/validator-amp-accordion.out
+++ b/extensions/amp-accordion/0.1/test/validator-amp-accordion.out
@@ -53,8 +53,8 @@ FAIL
 |        </amp-accordion>
 |      </section>
 |      <section>
-|        <header>The header tag is supported as well.</header>
-|        <p>Even more awesome.</p>
+|        <p>Section with differently-styled header</p>
+|        <p>More awesome content</p>
 |      </section>
 |      <section [data-expand]="">
 |        <h2>Section with bound [data-expand] attribute</h2>
@@ -74,11 +74,9 @@ amp-accordion/0.1/test/validator-amp-accordion.html:68:4 Tag 'p' is disallowed a
 |      <section>
 >>     ^~~~~~~~~
 amp-accordion/0.1/test/validator-amp-accordion.html:69:4 Tag 'amp-accordion > section' must have 2 child tags - saw 3 child tags.
-|        <div>header which isn't h1-h6.</div>
->>       ^~~~~~~~~
-amp-accordion/0.1/test/validator-amp-accordion.html:70:6 Tag 'div' is disallowed as first child of tag 'amp-accordion > section'. First child tag must be one of ['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'header'].
+|        <div>a first child</div>
 |        <div>a second child</div>
-|        <div>a third child</div>
+|        <div>an invalid third child</div>
 |      </section>
 |    </amp-accordion>
 |  </body>

--- a/extensions/amp-accordion/amp-accordion.md
+++ b/extensions/amp-accordion/amp-accordion.md
@@ -41,10 +41,9 @@ on mobile devices.
   children.
 - Each `<section>` must contain exactly two direct children.
 - The first child in a `<section>` is the heading for that section of the
-  `amp-accordion`. It must be a heading element such as `<h1>-<h6>` or
-  `<header>`.
-- The second child in a `<section>` is the expandable/collapsible content. It
-  can be any tag allowed in [AMP HTML](https://github.com/ampproject/amphtml/blob/master/spec/amp-html-format.md).
+  `amp-accordion`, while the second child in a `<section>` is the 
+  expandable/collapsible content.
+- The children of a `<section>` can be any tag allowed in [AMP HTML](https://github.com/ampproject/amphtml/blob/master/spec/amp-html-format.md).
 - A click or tap on a `<section>` heading expands or collapses the section.
 - An `amp-accordion` with a defined `id` preserves the collapsed or expanded
   state of each section while the user remains on your domain.
@@ -57,10 +56,9 @@ on mobile devices.
   children.
 - Each `<section>` must contain exactly two direct children.
 - The first child in a `<section>` is the heading for that section of the
-  `amp-accordion`. It must be a heading element such as `<h1>-<h6>` or
-  `<header>`.
-- The second child in a `<section>` is the expandable/collapsible content. It
-  can be any tag allowed in [AMP for Email](https://github.com/ampproject/amphtml/blob/master/spec/email/amp-email-html.md).
+  `amp-accordion`, while the second child in a `<section>` is the
+  expandable/collapsible content.
+- The children of a `<section>` can be any tag allowed in [AMP for Email](https://github.com/ampproject/amphtml/blob/master/spec/email/amp-email-html.md).
 - A click or tap on a `<section>` heading expands or collapses the section.
 
 [/filter]

--- a/extensions/amp-accordion/amp-accordion.md
+++ b/extensions/amp-accordion/amp-accordion.md
@@ -41,7 +41,7 @@ on mobile devices.
   children.
 - Each `<section>` must contain exactly two direct children.
 - The first child in a `<section>` is the heading for that section of the
-  `amp-accordion`, while the second child in a `<section>` is the 
+  `amp-accordion`, while the second child in a `<section>` is the
   expandable/collapsible content.
 - The children of a `<section>` can be any tag allowed in [AMP HTML](https://github.com/ampproject/amphtml/blob/master/spec/amp-html-format.md).
 - A click or tap on a `<section>` heading expands or collapses the section.

--- a/extensions/amp-accordion/validator-amp-accordion.protoascii
+++ b/extensions/amp-accordion/validator-amp-accordion.protoascii
@@ -80,12 +80,5 @@ tags: {  # <amp-accordion> > <section>
   }
   child_tags: {
     mandatory_num_child_tags: 2
-    first_child_tag_name_oneof: "H1"
-    first_child_tag_name_oneof: "H2"
-    first_child_tag_name_oneof: "H3"
-    first_child_tag_name_oneof: "H4"
-    first_child_tag_name_oneof: "H5"
-    first_child_tag_name_oneof: "H6"
-    first_child_tag_name_oneof: "HEADER"
   }
 }


### PR DESCRIPTION
<!--
# Instructions:

- Pick a meaningful title for your pull request. (Use sentence case.)
  - Prefix the title with an emoji to identify what is being done. (Copy-paste the emoji from the list below.)
  - Do not overuse punctuation in the title (like `(chore):`).
  - If it is helpful, use a simple prefix (like `ProjectX: Implement some feature`).
- Enter a succinct description that says why the PR is necessary, and what it does.
  - Mention the GitHub issue that is being addressed by the pull request.
  - The keywords `Fixes`, `Closes`, or `Resolves` followed the issue number will automatically close the issue.

> NOTE: All non-trivial changes (like introducing new features or components) should have an associated issue or reference an I2I (intent-to-implement: go.amp.dev/i2i). Please read through the contribution process (go.amp.dev/contributing/code) for more information.

# Example of a good description:

- Implement aspect X
- Leave out feature Y because of A
- Improve performance by B
- Improve accessibility by C

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Reverting a previous change
♻️ Refactoring
🚮 Deleting code
🧪 Experimental code
-->
Resolves #21046
Removes requirement that the first element of an `<amp-accordion>`'s `<section>` tag be `<h1>-<h6>` or `<header>` to allow more developer freedom and make `<amp-accordion>` consistent with other AMP components.