### PR TITLE
intersect-resources: Fix elements relayout when doc inactive->active

### DIFF
--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -1015,7 +1015,13 @@ export class Resource {
     this.setInViewport(false);
     if (this.element.unlayoutCallback()) {
       this.element.togglePlaceholder(true);
-      this.state_ = ResourceState.NOT_LAID_OUT;
+      // With IntersectionObserver, the element won't receive another
+      // measurement if/when the document becomes active again.
+      // Therefore, its post-unlayout state must be READY_FOR_LAYOUT
+      // (built and measured) to become eligible for relayout later.
+      this.state_ = this.intersect_
+        ? ResourceState.READY_FOR_LAYOUT
+        : ResourceState.NOT_LAID_OUT;
       this.layoutCount_ = 0;
       this.layoutPromise_ = null;
     }

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -257,7 +257,7 @@ export class ResourcesImpl {
         : null);
       try {
         this.intersectionObserver_ = new IntersectionObserver(
-          (e) => this.intersects_(e),
+          (e) => this.intersect(e),
           {root, rootMargin: '200% 25%'}
         );
 
@@ -332,9 +332,9 @@ export class ResourcesImpl {
 
   /**
    * @param {!Array<!IntersectionObserverEntry>} entries
-   * @private
+   * @visibleForTesting
    */
-  intersects_(entries) {
+  intersect(entries) {
     devAssert(this.intersectionObserver_);
 
     // TODO(willchou): Remove assert once #27167 is fixed.


### PR DESCRIPTION
Partial for #25428.

Fixes a bug I discovered when trying to enable `intersect-resources` in 100% prod. A test case in `test-visibility-state.js` caught this, yay coverage.

I also surveyed the other cases where resources are set to `NOT_LAID_OUT` state and this appears to be the only problematic one.