### PR TITLE
🏗 Verify whether a commit is a cherry-pick that was miscategorized to fix rare issue with version numbers

### DIFF
--- a/build-system/common/git.js
+++ b/build-system/common/git.js
@@ -203,6 +203,27 @@ function gitCommitFormattedTime(ref = 'HEAD') {
 }
 
 /**
+ * Returns the commit message of a given ref.
+ * @param {string} ref a Git reference (commit SHA, branch name, etc.) for the
+ *   commit to get the time of.
+ * @return {string}
+ */
+function gitCommitMessage(ref = 'HEAD') {
+  return getStdout(`git log ${ref} -n 1`);
+}
+
+/**
+ * Checks if a branch contains a specific ref.
+ * @param {string} ref a Git reference (commit SHA, branch name, etc.) for the
+ *   commit to get the time of.
+ * @param {string} branch the branch to check.
+ * @return {boolean}
+ */
+function gitBranchContains(ref, branch = 'master') {
+  return Boolean(getStdout(`git branch ${branch} --contains ${ref}`).trim());
+}
+
+/**
  * Returns the merge base of the current branch off of master when running on
  * a local workspace.
  * @return {string}
@@ -233,11 +254,13 @@ function gitDiffPath(path, commit) {
 }
 
 module.exports = {
+  gitBranchContains,
   gitBranchCreationPoint,
   gitBranchName,
   gitCherryMaster,
   gitCommitFormattedTime,
   gitCommitHash,
+  gitCommitMessage,
   gitCommitterEmail,
   gitDiffAddedNameOnlyMaster,
   gitDiffColor,

--- a/build-system/common/git.js
+++ b/build-system/common/git.js
@@ -209,7 +209,7 @@ function gitCommitFormattedTime(ref = 'HEAD') {
  * @return {string}
  */
 function gitCommitMessage(ref = 'HEAD') {
-  return getStdout(`git log ${ref} -n 1`);
+  return getStdout(`git log ${ref} -n 1 --pretty="%B"`);
 }
 
 /**

--- a/build-system/compile/internal-version.js
+++ b/build-system/compile/internal-version.js
@@ -94,12 +94,13 @@ function getVersion() {
 
   let numberOfCherryPicks = 0;
   const commitCherriesInfo = gitCherryMaster().reverse();
-  for (const {isCherryPick} of commitCherriesInfo) {
+  for (const {isCherryPick, sha} of commitCherriesInfo) {
     if (!isCherryPick) {
       // Sometimes cherry-picks are mistaken for new commits. Double-check here
       // by looking for the hard-coded message at the end of the commit that
-      // indicates that it was a cherry-pick.
-      const commitMessage = gitCommitMessage(commitCherriesInfo.sha);
+      // indicates that it was a cherry-pick. Requires that the cherry-pick was
+      // performed with the `-x` flag.
+      const commitMessage = gitCommitMessage(sha);
       const cherryPickedMatch = /\(cherry picked from commit ([0-9a-f]{40})\)/.exec(
         commitMessage
       );

--- a/build-system/compile/internal-version.js
+++ b/build-system/compile/internal-version.js
@@ -16,7 +16,12 @@
 'use strict';
 
 const minimist = require('minimist');
-const {gitCherryMaster, gitCommitFormattedTime} = require('../common/git');
+const {
+  gitBranchContains,
+  gitCherryMaster,
+  gitCommitMessage,
+  gitCommitFormattedTime,
+} = require('../common/git');
 
 // Allow leading zeros in --version_override, e.g. 0000000000001
 const argv = minimist(process.argv.slice(2), {
@@ -91,7 +96,20 @@ function getVersion() {
   const commitCherriesInfo = gitCherryMaster().reverse();
   for (const {isCherryPick} of commitCherriesInfo) {
     if (!isCherryPick) {
-      break;
+      // Sometimes cherry-picks are mistaken for new commits. Double-check here
+      // by looking for the hard-coded message at the end of the commit that
+      // indicates that it was a cherry-pick.
+      const commitMessage = gitCommitMessage(commitCherriesInfo.sha);
+      const cherryPickedMatch = /\(cherry picked from commit ([0-9a-f]{40})\)/.exec(
+        commitMessage
+      );
+      if (!cherryPickedMatch) {
+        break;
+      }
+
+      if (!gitBranchContains(cherryPickedMatch[1])) {
+        break;
+      }
     }
     numberOfCherryPicks++;
   }


### PR DESCRIPTION
Sometimes a commit that we verifies was cherry-picked from master is marked incorrectly as a new commit, which messes up with version numbers. This PR fixes this issue.