### PR TITLE
Allow amp-story-consent to work with new amp-consent config

### DIFF
--- a/examples/amp-story/consent-geo.html
+++ b/examples/amp-story/consent-geo.html
@@ -68,12 +68,9 @@
 
       <amp-consent id='ABC' layout='nodisplay'>
         <script type="application/json">{
-          "consents": {
-            "ABC": {
-              "promptIfUnknownForGeoGroup": "eea",
-              "promptUI": "ui0"
-            }
-          }
+          "consentInstanceId": "ABC",
+          "promptIfUnknownForGeoGroup": "eea",
+          "promptUI": "ui0"
         }</script>
         <amp-story-consent id="ui0" layout="nodisplay">
           <script type="application/json">{

--- a/examples/amp-story/consent.html
+++ b/examples/amp-story/consent.html
@@ -56,12 +56,9 @@
     <amp-story standalone publisher-logo-src="https://placekitten.com/g/64/64">
       <amp-consent id='ABC' layout='nodisplay'>
         <script type="application/json">{
-          "consents": {
-            "DEF": {
-              "checkConsentHref": "http://localhost:8000/get-consent-v1",
-              "promptUI": "ui0"
-            }
-          }
+          "consentInstanceId": "DEF",
+          "checkConsentHref": "http://localhost:8000/get-consent-v1",
+          "promptUI": "ui0"
         }</script>
 
         <amp-story-consent id="ui0" layout="nodisplay">

--- a/examples/visual-tests/amp-story/amp-story-consent.html
+++ b/examples/visual-tests/amp-story/amp-story-consent.html
@@ -47,12 +47,9 @@
       <amp-consent id="myConsent" layout="nodisplay">
         <script type="application/json">
             {
-              "consents": {
-                "myConsent": {
-                  "checkConsentHref": "http://localhost:8000/get-consent-v1",
-                  "promptUI": "consentUI"
-                }
-              }
+              "consentInstanceId": "myConsent",
+              "checkConsentHref": "http://localhost:8000/get-consent-v1",
+              "promptUI": "consentUI"
             }
           </script>
         <amp-story-consent id="consentUI" layout="nodisplay">

--- a/examples/visual-tests/amp-story/amp-story-consent.rtl.html
+++ b/examples/visual-tests/amp-story/amp-story-consent.rtl.html
@@ -46,14 +46,11 @@
 
       <amp-consent id="myConsent" layout="nodisplay">
         <script type="application/json">
-            {
-              "consents": {
-                "myConsent": {
-                  "checkConsentHref": "http://localhost:8000/get-consent-v1",
-                  "promptUI": "consentUI"
-                }
-              }
-            }
+          {
+            "consentInstanceId": "myConsent",
+            "checkConsentHref": "http://localhost:8000/get-consent-v1",
+            "promptUI": "consentUI"
+          }
           </script>
         <amp-story-consent id="consentUI" layout="nodisplay">
           <script type="application/json">

--- a/extensions/amp-consent/amp-consent.md
+++ b/extensions/amp-consent/amp-consent.md
@@ -327,12 +327,8 @@ _Example_: Displays a prompt user interface on an AMP Story
 <amp-consent layout="nodisplay" id="consent-element">
   <script type="application/json">
     {
-      "consents": {
-        "my-consent": {
-          "checkConsentHref": "https://foo.com/api/show-consent",
-          "promptUI": "consent-ui"
-        }
-      }
+      "checkConsentHref": "https://foo.com/api/show-consent",
+      "promptUI": "consent-ui"
     }
   </script>
   <amp-story-consent id="consent-ui" layout="nodisplay">

--- a/extensions/amp-story/1.0/amp-story-consent.js
+++ b/extensions/amp-story/1.0/amp-story-consent.js
@@ -378,6 +378,7 @@ export class AmpStoryConsent extends AMP.BaseElement {
     if (legacyConsents) {
       const policyId = Object.keys(legacyConsents)[0];
       const policy = legacyConsents[policyId];
+      this.consentConfig_.consentInstanceId = policyId;
       this.consentConfig_.checkConsentHref = policy.checkConsentHref;
       this.consentConfig_.promptIfUnknownForGeoGroup =
         policy.promptIfUnknownForGeoGroup;

--- a/extensions/amp-story/1.0/amp-story-consent.js
+++ b/extensions/amp-story/1.0/amp-story-consent.js
@@ -311,6 +311,7 @@ export class AmpStoryConsent extends AMP.BaseElement {
     const parentEl = dev().assertElement(this.element.parentElement);
     const consentScript = childElementByTag(parentEl, 'script');
     this.consentConfig_ = consentScript && parseJson(consentScript.textContent);
+    this.mergeLegacyConsents_();
 
     // amp-consent already triggered console errors, step out to avoid polluting
     // the console.
@@ -368,24 +369,38 @@ export class AmpStoryConsent extends AMP.BaseElement {
   }
 
   /**
+   * Merge legacy `consents` policy object from
+   * amp-consent config into top level.
+   * @private
+   */
+  mergeLegacyConsents_() {
+    const legacyConsents = this.consentConfig_['consents'];
+    if (legacyConsents) {
+      const policyId = Object.keys(legacyConsents)[0];
+      const policy = legacyConsents[policyId];
+      this.consentConfig_.checkConsentHref = policy.checkConsentHref;
+      this.consentConfig_.promptIfUnknownForGeoGroup =
+        policy.promptIfUnknownForGeoGroup;
+      delete this.consentConfig_['consents'];
+    }
+  }
+
+  /**
    * @param {string} consentId
    * @private
    */
   storeConsentId_(consentId) {
-    const policyId = Object.keys(this.consentConfig_['consents'])[0];
-    const policy = this.consentConfig_['consents'][policyId];
-
     // checkConsentHref response overrides the amp-geo config, if provided.
-    if (policy.checkConsentHref) {
+    if (this.consentConfig_.checkConsentHref) {
       this.storeService_.dispatch(Action.SET_CONSENT_ID, consentId);
       return;
     }
 
     // If using amp-access with amp-geo, only set the consent id if the user is
     // in the expected geo group.
-    if (policy['promptIfUnknownForGeoGroup']) {
+    const geoGroup = this.consentConfig_.promptIfUnknownForGeoGroup;
+    if (geoGroup) {
       Services.geoForDocOrNull(this.element).then((geo) => {
-        const geoGroup = policy['promptIfUnknownForGeoGroup'];
         const matchedGeoGroups = /** @type {!Array<string>} */ (geo.matchedISOCountryGroups);
         if (geo && !matchedGeoGroups.includes(geoGroup)) {
           return;

--- a/extensions/amp-story/1.0/test/test-amp-story-consent.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-consent.js
@@ -102,6 +102,16 @@ describes.realWin('amp-story-consent', {amp: true}, (env) => {
     expect(storyConsent.storyConsentConfig_).to.deep.equal(defaultConfig);
   });
 
+  it('should parse and merge legacy consent config', () => {
+    const newConsentConfig = {
+      'consentInstanceId': 'ABC',
+      'checkConsentHref': 'https://example.com',
+      'promptIfUnknownForGeoGroup': undefined,
+    };
+    storyConsent.buildCallback();
+    expect(storyConsent.consentConfig_).to.deep.equal(newConsentConfig);
+  });
+
   it('should require a story-consent title', () => {
     delete defaultConfig.title;
     setConfig(defaultConfig);


### PR DESCRIPTION
Closes #27469
Take the `consentConfig_` and merge the legacy fields in the the top level fields: 
```
{
        "consents": {
          "ABC": {
            "checkConsentHref": "http://localhost:8000/get-consent-v1",
            "promptUI": "ui0"
          }
        }
      }
```
to
```
{
        "consentInstanceId": "ABC",
         "checkConsentHref": "http://localhost:8000/get-consent-v1",
         "promptUI": "ui0"
     }
```

The merging is not expensive (`amp-story-consent.js`), but it is duplicated work, since amp-consent basically does the same config transformation to support new and legacy config formats.  

Updated the documentation in `amp-consent.md`, examples, and visual diff tests.
