### PR TITLE
♻️ Renamed binary polls

### DIFF
--- a/build-system/compile/bundles.config.js
+++ b/build-system/compile/bundles.config.js
@@ -870,7 +870,7 @@ exports.extensionBundles = [
         'amp-story-hint',
         'amp-story-info-dialog',
         'amp-story-interactive',
-        'amp-story-interactive-poll',
+        'amp-story-interactive-binary-poll',
         'amp-story-interactive-quiz',
         'amp-story-share',
         'amp-story-share-menu',

--- a/examples/amp-story/interactives.html
+++ b/examples/amp-story/interactives.html
@@ -10,7 +10,7 @@
       body {
         font-family: 'Rubik', sans-serif;
       }
-      amp-story-interactive-quiz, amp-story-interactive-poll {
+      amp-story-interactive-quiz, amp-story-interactive-binary-poll {
         justify-self: center;
       }
     </style>
@@ -159,7 +159,7 @@
           </amp-story-grid-layer>
           <amp-story-grid-layer template="thirds">
             <div grid-area="lower-third" style="display: flex;align-items:center;justify-content:center;flex-direction:column;">
-              <amp-story-interactive-poll
+              <amp-story-interactive-binary-poll
 								endpoint="http://localhost:3000/interactives"
 								prompt-text="What is your favorite movie?"
 								id="movie-light-connected"
@@ -167,7 +167,7 @@
                 theme="dark"
                 option-1-text="דוקטור מוזר"
                 option-2-text="פנתר שחור">
-              </amp-story-interactive-poll>
+              </amp-story-interactive-binary-poll>
             </div>
           </amp-story-grid-layer>
           <amp-story-page-attachment layout="nodisplay" data-cta-text="Read more">
@@ -184,13 +184,13 @@
             </amp-img>
           </amp-story-grid-layer>
           <amp-story-grid-layer template="center">
-            <amp-story-interactive-poll
+            <amp-story-interactive-binary-poll
               endpoint="http://localhost:3000/interactives"
               id="movie-light-connected"
               theme="dark"
               option-1-text="Doctor Strange"
               option-2-text="Black Panther">
-            </amp-story-interactive-poll>
+            </amp-story-interactive-binary-poll>
           </amp-story-grid-layer>
         </amp-story-page>
         <amp-story-page id="poll-binary-3">
@@ -205,13 +205,13 @@
           <amp-story-grid-layer template="thirds">
             <div grid-area="lower-third" style="display: flex;align-items:center;justify-content:center;flex-direction:column;">
               <h1 style="color:white;text-align:center;line-height:40px;margin-bottom:10px;">What is your favorite movie?</h1>
-              <amp-story-interactive-poll
+              <amp-story-interactive-binary-poll
                 endpoint="http://localhost:3000/interactives"
                 id="movie-light-connected"
                 style="--interactive-accent-color: #FFC700;"
                 option-1-text="🧛"
                 option-2-text="🐆">
-              </amp-story-interactive-poll>
+              </amp-story-interactive-binary-poll>
             </div>
           </amp-story-grid-layer>
         </amp-story-page>
@@ -227,13 +227,13 @@
           <amp-story-grid-layer template="thirds">
             <div grid-area="lower-third" style="display: flex;align-items:center;justify-content:center;flex-direction:column;">
               <h1 style="color:white;text-align:center;line-height:40px;margin-bottom:10px;">What is your favorite movie?</h1>
-              <amp-story-interactive-poll
+              <amp-story-interactive-binary-poll
                 endpoint="http://localhost:3000/interactives"
                 id="movie-light-connected"
                 style="--interactive-accent-color: rgb(0, 0, 0);"
                 option-1-text="Doctor"
                 option-2-text="Panther">
-              </amp-story-interactive-poll>
+              </amp-story-interactive-binary-poll>
             </div>
           </amp-story-grid-layer>
         </amp-story-page>
@@ -247,14 +247,14 @@
             </amp-img>
           </amp-story-grid-layer>
           <amp-story-grid-layer template="vertical">
-            <amp-story-interactive-poll
+            <amp-story-interactive-binary-poll
               endpoint="http://localhost:3000/interactives"
               id="movie-light-connected"
               theme="dark"
               style="--interactive-accent-color: #FFFFFF;"
               option-1-text="This is a really long text"
               option-2-text="Panther">
-            </amp-story-interactive-poll>
+            </amp-story-interactive-binary-poll>
           </amp-story-grid-layer>
         </amp-story-page>
     </amp-story>

--- a/extensions/amp-story/1.0/amp-story-interactive-binary-poll.css
+++ b/extensions/amp-story/1.0/amp-story-interactive-binary-poll.css
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-.i-amphtml-story-interactive-poll-container {
+.i-amphtml-story-interactive-binary-poll-container {
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.12) !important;
   color: var(--i-amphtml-interactive-option-accent-color) !important;
   --post-select-scale: 0.5 !important;
@@ -25,7 +25,7 @@
 	max-width: 296px !important;
 }
 
-.i-amphtml-story-interactive-poll-option-container {
+.i-amphtml-story-interactive-binary-poll-option-container {
 	background: var(--i-amphtml-interactive-option-background-color) !important;
 	display: flex !important;
   justify-content: center !important;
@@ -61,7 +61,7 @@
   transform: translateY(0) !important;
 }
 
-.i-amphtml-story-interactive-poll-container:not(.i-amphtml-story-interactive-post-selection)
+.i-amphtml-story-interactive-binary-poll-container:not(.i-amphtml-story-interactive-post-selection)
   .i-amphtml-story-interactive-option-divider {
   height: 100% !important;
   width: 1px !important;

--- a/extensions/amp-story/1.0/amp-story-interactive-binary-poll.css
+++ b/extensions/amp-story/1.0/amp-story-interactive-binary-poll.css
@@ -42,7 +42,7 @@
   flex-direction: column !important;
   flex-grow: 50 !important;
   flex: 100 !important;
-  min-width: 0 !important;
+  overflow: hidden !important;
   position: relative !important;
   transition: flex-grow var(--animation-time) calc(var(--animation-time) * .12) var(--ease-out-curve) !important;
 }
@@ -57,8 +57,7 @@
 
 .i-amphtml-story-interactive-post-selection
   .i-amphtml-story-interactive-option-text-container {
-  transition: transform var(--animation-time) var(--ease-out-curve), 
-    opacity var(--animation-time) var(--ease-out-curve) !important;
+  transition: transform var(--animation-time) var(--ease-out-curve) !important;
   transform: translateY(0) !important;
 }
 

--- a/extensions/amp-story/1.0/amp-story-interactive-binary-poll.css
+++ b/extensions/amp-story/1.0/amp-story-interactive-binary-poll.css
@@ -42,7 +42,7 @@
   flex-direction: column !important;
   flex-grow: 50 !important;
   flex: 100 !important;
-  overflow: hidden !important;
+  min-width: 0 !important;
   position: relative !important;
   transition: flex-grow var(--animation-time) calc(var(--animation-time) * .12) var(--ease-out-curve) !important;
 }
@@ -57,7 +57,8 @@
 
 .i-amphtml-story-interactive-post-selection
   .i-amphtml-story-interactive-option-text-container {
-  transition: transform var(--animation-time) var(--ease-out-curve) !important;
+  transition: transform var(--animation-time) var(--ease-out-curve), 
+    opacity var(--animation-time) var(--ease-out-curve) !important;
   transform: translateY(0) !important;
 }
 

--- a/extensions/amp-story/1.0/amp-story-interactive-binary-poll.js
+++ b/extensions/amp-story/1.0/amp-story-interactive-binary-poll.js
@@ -15,7 +15,7 @@
  */
 
 import {AmpStoryInteractive, InteractiveType} from './amp-story-interactive';
-import {CSS} from '../../../build/amp-story-interactive-poll-1.0.css';
+import {CSS} from '../../../build/amp-story-interactive-binary-poll-1.0.css';
 import {dev} from '../../../src/log';
 import {htmlFor} from '../../../src/static-template';
 import {setStyle} from '../../../src/style';
@@ -37,9 +37,11 @@ export const FontSize = {
 const buildBinaryPollTemplate = (element) => {
   const html = htmlFor(element);
   return html`
-    <div class="i-amphtml-story-interactive-poll-container">
+    <div class="i-amphtml-story-interactive-binary-poll-container">
       <div class="i-amphtml-story-interactive-prompt-container"></div>
-      <div class="i-amphtml-story-interactive-poll-option-container"></div>
+      <div
+        class="i-amphtml-story-interactive-binary-poll-option-container"
+      ></div>
     </div>
   `;
 };
@@ -77,7 +79,7 @@ const buildBinaryOptionDividerTemplate = (element) => {
   return html` <div class="i-amphtml-story-interactive-option-divider"></div> `;
 };
 
-export class AmpStoryInteractivePoll extends AmpStoryInteractive {
+export class AmpStoryInteractiveBinaryPoll extends AmpStoryInteractive {
   /**
    * @param {!AmpElement} element
    */
@@ -113,7 +115,7 @@ export class AmpStoryInteractivePoll extends AmpStoryInteractive {
   attachContent_(root) {
     this.attachPrompt_(root);
     const options = root.querySelector(
-      '.i-amphtml-story-interactive-poll-option-container'
+      '.i-amphtml-story-interactive-binary-poll-option-container'
     );
     options.appendChild(this.generateOption_(this.options_[0]));
     options.appendChild(buildBinaryOptionDividerTemplate(root));

--- a/extensions/amp-story/1.0/amp-story-interactive-binary-poll.js
+++ b/extensions/amp-story/1.0/amp-story-interactive-binary-poll.js
@@ -28,6 +28,9 @@ export const FontSize = {
   DOUBLE_LINE: 14,
 };
 
+/** @const {number} */
+const MIN_HORIZONTAL_PADDING = 27;
+
 /**
  * Generates the template for the binary poll.
  *
@@ -204,6 +207,21 @@ export class AmpStoryInteractiveBinaryPoll extends AmpStoryInteractive {
         '.i-amphtml-story-interactive-option-percentage-text'
       ).textContent = `${percentage}%`;
       currOption.setAttribute('style', `flex-grow: ${percentage} !important`);
+
+      if (percentage < 20) {
+        const textContainer = currOption.querySelector(
+          '.i-amphtml-story-interactive-option-text-container'
+        );
+        textContainer.setAttribute(
+          'style',
+          `transform: translateX(${
+            index === 0 ? MIN_HORIZONTAL_PADDING : -MIN_HORIZONTAL_PADDING
+          }%) !important`
+        );
+        if (percentage === 0) {
+          textContainer.setAttribute('style', 'opacity: 0 !important');
+        }
+      }
     });
   }
 }

--- a/extensions/amp-story/1.0/amp-story-interactive-binary-poll.js
+++ b/extensions/amp-story/1.0/amp-story-interactive-binary-poll.js
@@ -28,9 +28,6 @@ export const FontSize = {
   DOUBLE_LINE: 14,
 };
 
-/** @const {number} */
-const MIN_HORIZONTAL_PADDING = 27;
-
 /**
  * Generates the template for the binary poll.
  *
@@ -207,21 +204,6 @@ export class AmpStoryInteractiveBinaryPoll extends AmpStoryInteractive {
         '.i-amphtml-story-interactive-option-percentage-text'
       ).textContent = `${percentage}%`;
       currOption.setAttribute('style', `flex-grow: ${percentage} !important`);
-
-      if (percentage < 20) {
-        const textContainer = currOption.querySelector(
-          '.i-amphtml-story-interactive-option-text-container'
-        );
-        textContainer.setAttribute(
-          'style',
-          `transform: translateX(${
-            index === 0 ? MIN_HORIZONTAL_PADDING : -MIN_HORIZONTAL_PADDING
-          }%) !important`
-        );
-        if (percentage === 0) {
-          textContainer.setAttribute('style', 'opacity: 0 !important');
-        }
-      }
     });
   }
 }

--- a/extensions/amp-story/1.0/amp-story.css
+++ b/extensions/amp-story/1.0/amp-story.css
@@ -925,6 +925,6 @@ amp-story .amp-video-eq,
   --i-amphtml-interactive-prompt-line-height: 24px !important;
 }
 
-amp-story-interactive-poll[theme="dark"] {
+amp-story-interactive-binary-poll[theme="dark"] {
   --i-amphtml-interactive-option-accent-color: white !important;
 }

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -50,7 +50,7 @@ import {AmpStoryCtaLayer} from './amp-story-cta-layer';
 import {AmpStoryEmbeddedComponent} from './amp-story-embedded-component';
 import {AmpStoryGridLayer} from './amp-story-grid-layer';
 import {AmpStoryHint} from './amp-story-hint';
-import {AmpStoryInteractivePoll} from './amp-story-interactive-poll';
+import {AmpStoryInteractiveBinaryPoll} from './amp-story-interactive-binary-poll';
 import {AmpStoryInteractiveQuiz} from './amp-story-interactive-quiz';
 import {AmpStoryPage, NavigationDirection, PageState} from './amp-story-page';
 import {AmpStoryPageAttachment} from './amp-story-page-attachment';
@@ -2817,6 +2817,9 @@ AMP.extension('amp-story', '1.0', (AMP) => {
   AMP.registerElement('amp-story-page', AmpStoryPage);
   AMP.registerElement('amp-story-page-attachment', AmpStoryPageAttachment);
   AMP.registerElement('amp-story-interactive-quiz', AmpStoryInteractiveQuiz);
-  AMP.registerElement('amp-story-interactive-poll', AmpStoryInteractivePoll);
+  AMP.registerElement(
+    'amp-story-interactive-binary-poll',
+    AmpStoryInteractiveBinaryPoll
+  );
   AMP.registerServiceForDoc('amp-story-render', AmpStoryRenderService);
 });

--- a/extensions/amp-story/1.0/test/test-amp-story-interactive-binary-poll.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-interactive-binary-poll.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {AmpStoryInteractivePoll} from '../amp-story-interactive-poll';
+import {AmpStoryInteractiveBinaryPoll} from '../amp-story-interactive-binary-poll';
 import {AmpStoryStoreService} from '../amp-story-store-service';
 import {Services} from '../../../../src/services';
 import {
@@ -26,7 +26,7 @@ import {measureMutateElementStub} from '../../../../testing/test-helper';
 import {registerServiceBuilder} from '../../../../src/service';
 
 describes.realWin(
-  'amp-story-interactive-poll',
+  'amp-story-interactive-binary-poll',
   {
     amp: true,
   },
@@ -44,7 +44,7 @@ describes.realWin(
         .resolves({get: () => Promise.resolve('cid')});
 
       const ampStoryPollEl = win.document.createElement(
-        'amp-story-interactive-poll'
+        'amp-story-interactive-binary-poll'
       );
       ampStoryPollEl.getResources = () => win.__AMP_SERVICES.resources.obj;
       requestService = getRequestService(win, ampStoryPollEl);
@@ -62,7 +62,7 @@ describes.realWin(
       storyEl.appendChild(storyPage);
 
       win.document.body.appendChild(storyEl);
-      ampStoryPoll = new AmpStoryInteractivePoll(ampStoryPollEl);
+      ampStoryPoll = new AmpStoryInteractiveBinaryPoll(ampStoryPollEl);
       env.sandbox
         .stub(ampStoryPoll, 'measureMutateElement')
         .callsFake(measureMutateElementStub);


### PR DESCRIPTION
To create regular poll, the current "binary polls" need to be renamed into its own component.
Since the concrete interactive classes are mostly layout implementations, the binary poll has a unique layout that shouldn't be in the same component as the regular poll.

Renamed all the interactive-poll into interactive-binary-poll.