### PR TITLE
🖍 Fixes display of small percentages in binary polls.

### DIFF
--- a/extensions/amp-story/1.0/amp-story-interactive-poll.css
+++ b/extensions/amp-story/1.0/amp-story-interactive-poll.css
@@ -42,7 +42,7 @@
   flex-direction: column !important;
   flex-grow: 50 !important;
   flex: 100 !important;
-  overflow: hidden !important;
+  min-width: 0;
   position: relative !important;
   transition: flex-grow var(--animation-time) calc(var(--animation-time) * .12) var(--ease-out-curve) !important;
 }
@@ -57,7 +57,8 @@
 
 .i-amphtml-story-interactive-post-selection
   .i-amphtml-story-interactive-option-text-container {
-  transition: transform var(--animation-time) var(--ease-out-curve) !important;
+  transition: transform var(--animation-time) var(--ease-out-curve), 
+    opacity var(--animation-time) var(--ease-out-curve) !important;
   transform: translateY(0) !important;
 }
 

--- a/extensions/amp-story/1.0/amp-story-interactive-poll.js
+++ b/extensions/amp-story/1.0/amp-story-interactive-poll.js
@@ -202,6 +202,19 @@ export class AmpStoryInteractivePoll extends AmpStoryInteractive {
         '.i-amphtml-story-interactive-option-percentage-text'
       ).textContent = `${percentage}%`;
       currOption.setAttribute('style', `flex-grow: ${percentage} !important`);
+
+      if (percentage < 20) {
+        const textContainer = currOption.querySelector(
+          '.i-amphtml-story-interactive-option-text-container'
+        );
+        textContainer.setAttribute(
+          'style',
+          `transform: translateX(${index === 0 ? 27 : -27}%) !important`
+        );
+        if (percentage === 0) {
+          textContainer.setAttribute('style', 'opacity: 0 !important');
+        }
+      }
     });
   }
 }

--- a/extensions/amp-story/1.0/amp-story-interactive-poll.js
+++ b/extensions/amp-story/1.0/amp-story-interactive-poll.js
@@ -28,6 +28,9 @@ export const FontSize = {
   DOUBLE_LINE: 14,
 };
 
+/** @const {number} */
+const MIN_HORIZONTAL_PADDING = 27;
+
 /**
  * Generates the template for the binary poll.
  *
@@ -209,7 +212,9 @@ export class AmpStoryInteractivePoll extends AmpStoryInteractive {
         );
         textContainer.setAttribute(
           'style',
-          `transform: translateX(${index === 0 ? 27 : -27}%) !important`
+          `transform: translateX(${
+            index === 0 ? MIN_HORIZONTAL_PADDING : -MIN_HORIZONTAL_PADDING
+          }%) !important`
         );
         if (percentage === 0) {
           textContainer.setAttribute('style', 'opacity: 0 !important');


### PR DESCRIPTION
### [Demo](https://poll-animation.web.app/examples/amp-story/interactives.html)

Small percentages are now visible.
[screenshot](https://drive.google.com/file/d/1Z4GUjbleGixGs_J8xE8ApmbJXqPrDKYL/view?usp=sharing)

Before, small percentages were clipped.
[screenshot](https://drive.google.com/file/d/1-l3Ugk8pIoNyjvTMFmyI3jmLuBAVU1ml/view?usp=sharing)

If a poll is 0% it is not visible.
[screenshot](https://drive.google.com/file/d/18EkZyCoENepyZAQ41OWnz8PfPkYg2ZgS/view?usp=sharing)