### PR TITLE
gulp performance: take advantage of performance.mark.

### DIFF
--- a/src/enums.js
+++ b/src/enums.js
@@ -15,7 +15,7 @@
  */
 
 /**
- * Registred singleton on AMP doc.
+ * Registered singleton on AMP doc.
  * @enum {number}
  */
 export const AMPDOC_SINGLETON_NAME = {

--- a/src/service/performance-impl.js
+++ b/src/service/performance-impl.js
@@ -18,7 +18,6 @@ import {Services} from '../services';
 import {Signals} from '../utils/signals';
 import {TickLabel} from '../enums';
 import {VisibilityState} from '../visibility-state';
-import {createCustomEvent} from '../event-helper';
 import {dev, devAssert} from '../log';
 import {dict, map} from '../utils/object';
 import {getMode} from '../mode';
@@ -684,23 +683,15 @@ export class Performance {
 
     if (opt_delta != undefined) {
       data['delta'] = delta = Math.max(opt_delta, 0);
+      this.mark(label, delta);
     } else if (opt_value != undefined) {
       data['value'] = opt_value;
+      this.mark(label, opt_value);
     } else {
-      // Marking only makes sense for non-overridden values (and no deltas).
-      this.mark(label);
       delta = this.win.performance.now();
       data['value'] = this.timeOrigin_ + delta;
+      this.mark(label);
     }
-
-    // Emit events. Used by `gulp performance`.
-    this.win.dispatchEvent(
-      createCustomEvent(
-        this.win,
-        'perf',
-        /** @type {JsonObject} */ ({label, delta})
-      )
-    );
 
     if (this.isMessagingReady_ && this.isPerformanceTrackingOn_) {
       this.viewer_.sendMessage('tick', data);
@@ -716,15 +707,23 @@ export class Performance {
    * These are for example exposed in WPT.
    * See https://developer.mozilla.org/en-US/docs/Web/API/Performance/mark
    * @param {string} label
+   * @param {Object=} detail
    */
-  mark(label) {
+  mark(label, detail) {
+    // Bail if it is an unsupported API.
+    if (!(this.win.performance && this.win.performance.mark)) {
+      return;
+    }
+    // Bail if the label isn't valid for marking.
     if (
       this.win.performance &&
-      this.win.performance.mark &&
-      arguments.length == 1
+      this.win.performance.timing &&
+      label in this.win.performance.timing
     ) {
-      this.win.performance.mark(label);
+      return;
     }
+
+    this.win.performance.mark(label, {detail});
   }
 
   /**

--- a/test/unit/test-performance.js
+++ b/test/unit/test-performance.js
@@ -824,7 +824,6 @@ describes.realWin('PeformanceObserver metrics', {amp: true}, (env) => {
       PerformanceObserver: env.sandbox.stub(),
       addEventListener: env.sandbox.stub(),
       removeEventListener: env.win.removeEventListener,
-      dispatchEvent: (e) => env.win.dispatchEvent(e),
       document: {
         addEventListener: env.sandbox.stub(),
         hidden: false,


### PR DESCRIPTION
Depends on https://github.com/ampproject/amphtml/pull/28635/

Utilizes the secret second argument of [performance.mark](https://w3c.github.io/user-timing/#extensions-performance-interface). It exists in the spec, but not on MDN.