### PR TITLE
Fix video loading indicator on first story page.

### DIFF
--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -1624,6 +1624,11 @@ export class AmpStoryPage extends AMP.BaseElement {
           .then((poolVideoEl) => {
             if (!this.storeService_.get(StateProperty.PAUSED_STATE)) {
               this.startMeasuringVideoPerformance_(poolVideoEl);
+
+              // Restart video event listeners.
+              this.stopListeningToVideoEvents_();
+              this.startListeningToVideoEvents_();
+
               this.playMedia_(mediaPool, poolVideoEl);
             }
             if (!this.storeService_.get(StateProperty.MUTED_STATE)) {

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -1625,7 +1625,8 @@ export class AmpStoryPage extends AMP.BaseElement {
             if (!this.storeService_.get(StateProperty.PAUSED_STATE)) {
               this.startMeasuringVideoPerformance_(poolVideoEl);
 
-              // Restart video event listeners.
+              // Restart video event listeners with the new visible video. This
+              // fixes the loading indicator on the first story page.
               this.stopListeningToVideoEvents_();
               this.startListeningToVideoEvents_();
 


### PR DESCRIPTION
Restarts video event listeners when a new video becomes visible, which happens in many cases but mostly on the first page of a story.

Followup to #29032 

Fixes #28997