### PR TITLE
Don't send PAGE_PROGRESS event from an inactive page.

### DIFF
--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -1243,7 +1243,8 @@ export class AmpStoryPage extends AMP.BaseElement {
    */
   emitProgress_(progress) {
     // Don't emit progress for ads, since the progress bar is hidden.
-    if (this.isAd()) {
+    // Don't emit progress for inactive pages, because race conditions.
+    if (this.isAd() || this.state_ === PageState.NOT_ACTIVE) {
       return;
     }
 


### PR DESCRIPTION
Don't send `PAGE_PROGRESS` event from an inactive page. There's a code path where this could happen because of the polling mechanism in page-advancement, and it'd set the progress bar back to a previous segment.