### PR TITLE
🖍  Grid layer relative padding 

### DIFF
--- a/extensions/amp-story/1.0/amp-story-user-overridable.css
+++ b/extensions/amp-story/1.0/amp-story-user-overridable.css
@@ -56,6 +56,10 @@ amp-story-grid-layer {
   padding: 68px 32px 32px; /* 44 + 24 */
 }
 
+amp-story-grid-layer[aspect-ratio] {
+  padding: 0.5em; /* px padding breaks letterboxed mode */
+}
+
 amp-story-grid-layer.i-amphtml-story-has-page-attachment.i-amphtml-story-has-interactive {
   padding-bottom: 104px;
 }

--- a/extensions/amp-story/1.0/amp-story-user-overridable.css
+++ b/extensions/amp-story/1.0/amp-story-user-overridable.css
@@ -57,7 +57,7 @@ amp-story-grid-layer {
 }
 
 amp-story-grid-layer[aspect-ratio] {
-  padding: 0.5em; /* px padding breaks letterboxed mode */
+  padding: 1em 0.5em 0.5em; /* px padding breaks letterboxed mode */
 }
 
 amp-story-grid-layer.i-amphtml-story-has-page-attachment.i-amphtml-story-has-interactive {


### PR DESCRIPTION
amp-story-grid-layer has a fixed aspect ratio mode when when aspect-ratio attribute is set.

The best way to use this mode is to position things as absolute with percentages - but it can still be useful without absolute positions.

The main property of this mode is that the layout of the grid layer is consistent across different sizes.
I found that property can be violated because of this default padding in px. 

This PR proposes one solution via usage of em instead of px. 

Another solution could be to remove the padding in this mode entirely. 