### PR TITLE
Log current state and element with error report during broken layout flow

### DIFF
--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -897,9 +897,12 @@ export class Resource {
 
     if (this.state_ != ResourceState.LAYOUT_SCHEDULED) {
       const err = dev().createError(
-        'startLayout called but not LAYOUT_SCHEDULED'
+        'startLayout called but not LAYOUT_SCHEDULED',
+        'currently: ',
+        this.state_
       );
-      reportError(err, this.element);
+      err.associatedElement = this.element;
+      reportError(err);
       return Promise.reject(err);
     }
 


### PR DESCRIPTION
The error report isn't giving enough information for me to properly debug this. So, I'm now logging the current state, and attaching the associated element the element so the tagname is also reported.