### PR TITLE
Add asterisk to comments that were meant to be jsdocs in amp.extern

### DIFF
--- a/build-system/externs/amp.extern.js
+++ b/build-system/externs/amp.extern.js
@@ -181,13 +181,13 @@ window.context.tagName;
 
 // Safeframe
 // TODO(bradfrizzell) Move to its own extern. Not relevant to all AMP.
-/* @type {?Object} */
+/** @type {?Object} */
 window.sf_ = {};
-/* @type {?Object} */
+/** @type {?Object} */
 window.sf_.cfg;
 
 // Exposed to custom ad iframes.
-/* @type {!Function} */
+/** @type {function(function(!Object, function(!Object)), !Array<string>=, !Array<string>=)} */
 window.draw3p;
 
 // AMP's globals
@@ -314,7 +314,7 @@ let VegaParser;
  * @typedef {{parse: VegaParser}}
  */
 let VegaObject;
-/* @type {!VegaObject} */
+/** @type {!VegaObject} */
 window.vg;
 
 // amp-date-picker externs


### PR DESCRIPTION
related thought for future prevention: could add a lint check against `/* type {`, since that would almost always be a mistake.