### PR TITLE
🐛 [WIP] ScrollTrigger use getScrollWidth/Height for scrollEvent

### DIFF
--- a/extensions/amp-analytics/0.1/scroll-manager.js
+++ b/extensions/amp-analytics/0.1/scroll-manager.js
@@ -113,8 +113,8 @@ export class ScrollManager {
         left: this.viewport_.getScrollLeft() - scrollLeft,
         width: size.width,
         height: size.height,
-        scrollHeight,
-        scrollWidth,
+        scrollWidth: this.viewport_.getScrollWidth(),
+        scrollHeight: this.viewport_.getScrollHeight(),
         initialSize: {scrollHeight, scrollWidth},
       };
       handler(scrollEvent);
@@ -142,12 +142,7 @@ export class ScrollManager {
       // Initial root layout rectangle
       const {height: initialScrollHeight, width: initialScrollWidth} = rects[0];
       // Current root layout rectangle
-      const {
-        top: scrollTop,
-        left: scrollLeft,
-        width: scrollWidth,
-        height: scrollHeight,
-      } = rects[1];
+      const {top: scrollTop, left: scrollLeft} = rects[1];
       /** {./scroll-manager.ScrollEventDef} */
       const scrollEvent = {
         // In the case of shadow documents (e.g. amp-next-page), we offset
@@ -160,8 +155,8 @@ export class ScrollManager {
         left: e.left - scrollLeft,
         width: e.width,
         height: e.height,
-        scrollWidth,
-        scrollHeight,
+        scrollWidth: this.viewport_.getScrollWidth(),
+        scrollHeight: this.viewport_.getScrollHeight(),
         initialSize: {
           scrollHeight: initialScrollHeight,
           scrollWidth: initialScrollWidth,

--- a/extensions/amp-analytics/0.1/test/test-events.js
+++ b/extensions/amp-analytics/0.1/test/test-events.js
@@ -253,6 +253,8 @@ describes.realWin('Events', {amp: 1}, (env) => {
           .returns({top: 0, left: 0, height: 200, width: 200}),
         'getScrollTop': env.sandbox.stub().returns(0),
         'getScrollLeft': env.sandbox.stub().returns(0),
+        'getScrollHeight': env.sandbox.stub().returns(1224),
+        'getScrollWidth': env.sandbox.stub().returns(364),
         'getLayoutRect': env.sandbox
           .stub()
           .returns({width: 500, height: 500, top: 0, left: 0}),
@@ -291,6 +293,7 @@ describes.realWin('Events', {amp: 1}, (env) => {
     });
 
     it('fires on scroll', async () => {
+      fakeViewport['getScrollHeight'] = env.sandbox.stub().returns(500);
       const fn1 = env.sandbox.stub();
       const fn2 = env.sandbox.stub();
       tracker.add(

--- a/extensions/amp-analytics/0.1/test/test-scroll-manager.js
+++ b/extensions/amp-analytics/0.1/test/test-scroll-manager.js
@@ -59,6 +59,8 @@ describes.realWin('ScrollManager', {amp: 1}, (env) => {
         .returns({top: 0, left: 0, height: 200, width: 200}),
       'getScrollTop': env.sandbox.stub().returns(0),
       'getScrollLeft': env.sandbox.stub().returns(0),
+      'getScrollHeight': env.sandbox.stub().returns(624),
+      'getScrollWidth': env.sandbox.stub().returns(364),
       'getLayoutRect': env.sandbox
         .stub()
         .returns({width: 500, height: 500, top: 0, left: 0}),
@@ -130,8 +132,8 @@ describes.realWin('ScrollManager', {amp: 1}, (env) => {
       left: 500,
       height: 250,
       width: 250,
-      scrollWidth: 800,
-      scrollHeight: 700,
+      scrollWidth: 364,
+      scrollHeight: 624,
       initialSize: {scrollHeight: 500, scrollWidth: 500},
     };
 
@@ -174,8 +176,8 @@ describes.realWin('ScrollManager', {amp: 1}, (env) => {
       left: 450,
       height: 250,
       width: 250,
-      scrollWidth: 800,
-      scrollHeight: 700,
+      scrollWidth: 364,
+      scrollHeight: 624,
       initialSize: {scrollHeight: 500, scrollWidth: 500},
     };
 


### PR DESCRIPTION
Closes #29026

For scrollEvents that occur, we have been calculating [`this.viewport_.getLayoutRect(this.root_)`](https://github.com/ampproject/amphtml/blob/master/extensions/amp-analytics/0.1/scroll-manager.js#L212), and using it's height and width value for the scrollEvents' `scrollWidth` and `scrollHeight ` (which could result in incorrect height values). 

https://github.com/ampproject/amphtml/blob/21bc483bbc6f82907b099fea16679d48b3273b86/extensions/amp-analytics/0.1/scroll-manager.js#L97-L102

In both the normal ampdoc and shadowdoc cases, `viewport_.getScrollWidth()/getScrollHeight()` actually returns the correct scrolling values. 
