### PR TITLE
🐛  amp-autocomplete: Set default filter to "none"

### DIFF
--- a/extensions/amp-autocomplete/0.1/amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/amp-autocomplete.js
@@ -304,21 +304,14 @@ export class AmpAutocomplete extends AMP.BaseElement {
         !this.element.hasAttribute('filter'),
         `${TAG} does not support client-side filter when server-side render is required.`
       );
-      this.filter_ = FilterType.NONE;
-    } else {
-      this.filter_ = userAssert(
-        this.element.getAttribute('filter'),
-        '%s requires "filter" attribute. %s',
-        TAG,
-        this.element
-      );
-      userAssert(
-        isEnumValue(FilterType, this.filter_),
-        'Unexpected filter: %s. %s',
-        this.filter_,
-        this.element
-      );
     }
+    this.filter_ = this.element.getAttribute('filter') || FilterType.NONE;
+    userAssert(
+      isEnumValue(FilterType, this.filter_),
+      'Unexpected filter: %s. %s',
+      this.filter_,
+      this.element
+    );
 
     // Read configuration attributes
     this.minChars_ = this.element.hasAttribute('min-characters')

--- a/extensions/amp-autocomplete/0.1/test/test-amp-autocomplete-init.js
+++ b/extensions/amp-autocomplete/0.1/test/test-amp-autocomplete-init.js
@@ -176,14 +176,6 @@ describes.realWin(
         });
     });
 
-    it('should require filter attribute', () => {
-      return allowConsoleError(() => {
-        return expect(getAutocomplete({})).to.be.rejectedWith(
-          /requires "filter" attribute/
-        );
-      });
-    });
-
     it('should require valid filter attribute', () => {
       return allowConsoleError(() => {
         return expect(


### PR DESCRIPTION
The "filter" attribute is banned in the email format because it describes the client-side filter method to follow. Prior to this change, the default value `none` (indicating no client-side filter) was set only for SSR-enabled documents. 

This change sets the default filter value as `none` whenever the attribute `filter` is unset, as it always is for valid email documents and never is for valid web documents.