### PR TITLE
New Story embed mode to hide system layer icons.

### DIFF
--- a/extensions/amp-story/1.0/amp-story-store-service.js
+++ b/extensions/amp-story/1.0/amp-story-store-service.js
@@ -610,7 +610,7 @@ export class AmpStoryStoreService {
           [StateProperty.CAN_SHOW_PREVIOUS_PAGE_HELP]: false,
           [StateProperty.CAN_SHOW_SYSTEM_LAYER_BUTTONS]: false,
         };
-      case EmbedMode.NO_SYSTEM_LAYER_ICONS:
+      case EmbedMode.NO_SHARING_NOR_AUDIO_UI:
         return {
           [StateProperty.CAN_SHOW_AUDIO_UI]: false,
           [StateProperty.CAN_SHOW_SHARING_UIS]: false,

--- a/extensions/amp-story/1.0/amp-story-store-service.js
+++ b/extensions/amp-story/1.0/amp-story-store-service.js
@@ -79,6 +79,7 @@ export let InteractiveComponentDef;
  * @typedef {{
  *    canInsertAutomaticAd: boolean,
  *    canShowBookend: boolean,
+ *    canShowAudioUi: boolean,
  *    canShowNavigationOverlayHint: boolean,
  *    canShowPaginationButtons: boolean,
  *    canShowPreviousPageHelp: boolean,
@@ -124,6 +125,7 @@ export const StateProperty = {
   // Embed options.
   CAN_INSERT_AUTOMATIC_AD: 'canInsertAutomaticAd',
   CAN_SHOW_BOOKEND: 'canShowBookend',
+  CAN_SHOW_AUDIO_UI: 'canShowAudioUi',
   CAN_SHOW_NAVIGATION_OVERLAY_HINT: 'canShowNavigationOverlayHint',
   CAN_SHOW_PAGINATION_BUTTONS: 'canShowPaginationButtons',
   CAN_SHOW_PREVIOUS_PAGE_HELP: 'canShowPreviousPageHelp',
@@ -529,6 +531,7 @@ export class AmpStoryStoreService {
     return /** @type {!State} */ ({
       [StateProperty.CAN_INSERT_AUTOMATIC_AD]: true,
       [StateProperty.CAN_SHOW_BOOKEND]: true,
+      [StateProperty.CAN_SHOW_AUDIO_UI]: true,
       [StateProperty.CAN_SHOW_NAVIGATION_OVERLAY_HINT]: true,
       [StateProperty.CAN_SHOW_PREVIOUS_PAGE_HELP]: true,
       [StateProperty.CAN_SHOW_PAGINATION_BUTTONS]: true,
@@ -609,7 +612,8 @@ export class AmpStoryStoreService {
         };
       case EmbedMode.NO_SYSTEM_LAYER_ICONS:
         return {
-          [StateProperty.CAN_SHOW_SYSTEM_LAYER_BUTTONS]: false,
+          [StateProperty.CAN_SHOW_AUDIO_UI]: false,
+          [StateProperty.CAN_SHOW_SHARING_UIS]: false,
         };
       default:
         return {};

--- a/extensions/amp-story/1.0/amp-story-store-service.js
+++ b/extensions/amp-story/1.0/amp-story-store-service.js
@@ -607,6 +607,10 @@ export class AmpStoryStoreService {
           [StateProperty.CAN_SHOW_PREVIOUS_PAGE_HELP]: false,
           [StateProperty.CAN_SHOW_SYSTEM_LAYER_BUTTONS]: false,
         };
+      case EmbedMode.NO_SYSTEM_LAYER_ICONS:
+        return {
+          [StateProperty.CAN_SHOW_SYSTEM_LAYER_BUTTONS]: false,
+        };
       default:
         return {};
     }

--- a/extensions/amp-story/1.0/amp-story-system-layer.css
+++ b/extensions/amp-story/1.0/amp-story-system-layer.css
@@ -208,6 +208,10 @@
   position: relative !important;
 }
 
+.i-amphtml-story-no-audio-ui .i-amphtml-story-sound-display {
+  display: none !important;
+}
+
 .i-amphtml-story-mute-audio-control,
 .i-amphtml-story-unmute-audio-control,
 .i-amphtml-paused-display,

--- a/extensions/amp-story/1.0/amp-story-system-layer.js
+++ b/extensions/amp-story/1.0/amp-story-system-layer.js
@@ -406,6 +406,14 @@ export class SystemLayer {
     });
 
     this.storeService_.subscribe(
+      StateProperty.CAN_SHOW_AUDIO_UI,
+      (show) => {
+        this.onCanShowAudioUiUpdate_(show);
+      },
+      true /** callToInitialize */
+    );
+
+    this.storeService_.subscribe(
       StateProperty.CAN_SHOW_SHARING_UIS,
       (show) => {
         this.onCanShowSharingUisUpdate_(show);
@@ -557,6 +565,21 @@ export class SystemLayer {
     } else {
       this.getShadowRoot().removeAttribute(HAS_SIDEBAR_ATTRIBUTE);
     }
+  }
+
+  /**
+   * Reacts to updates to whether audio UI may be shown, and updates the UI
+   * accordingly.
+   * @param {boolean} canShowAudioUi
+   * @private
+   */
+  onCanShowAudioUiUpdate_(canShowAudioUi) {
+    this.vsync_.mutate(() => {
+      this.getShadowRoot().classList.toggle(
+        'i-amphtml-story-no-audio-ui',
+        !canShowAudioUi
+      );
+    });
   }
 
   /**

--- a/extensions/amp-story/1.0/embed-mode.js
+++ b/extensions/amp-story/1.0/embed-mode.js
@@ -44,8 +44,7 @@ export const EmbedMode = {
    * redundant.
    *
    * This differs from the NOT_EMBEDDED embed mode in the following ways:
-   * - Removes "share" pill from desktop UI
-   * - Removes "share" icon from mobile UI
+   * - Removes share icon from system layer
    * - Removes sharing section from bookend
    * - TODO(#14923): Removes the link information from embedded UIs.
    */
@@ -68,9 +67,11 @@ export const EmbedMode = {
    * sharing experiences, through native controls and viewer communication.
    *
    * This differs from the NOT_EMBEDDED embed mode in the following ways:
-   * - Hides all system layer buttons
+   * - Removes share icon from system layer
+   * - Removes sharing section from bookend
+   * - Removes audio icon from system layer
    */
-  NO_SYSTEM_LAYER_ICONS: 4,
+  NO_SHARING_NOR_AUDIO_UI: 4,
 };
 
 /**

--- a/extensions/amp-story/1.0/embed-mode.js
+++ b/extensions/amp-story/1.0/embed-mode.js
@@ -62,6 +62,15 @@ export const EmbedMode = {
    * - Disallows ads
    */
   PREVIEW: 3,
+
+  /**
+   * This mode is intended for embedders that natively handle the audio and
+   * sharing experiences, through native controls and viewer communication.
+   *
+   * This differs from the NOT_EMBEDDED embed mode in the following ways:
+   * - Hides all system layer buttons
+   */
+  NO_SYSTEM_LAYER_ICONS: 4,
 };
 
 /**


### PR DESCRIPTION
Story players are increasingly trying to use native sharing and audio controls. This PR introduces a new embed mode that hides the system layer icons, without all the side effects from `embedMode=1` (unmuted, no ads, ...).

This will eventually be used by several 1p players.