### PR TITLE
Propagate amp-img crossorigin attribute.

### DIFF
--- a/builtins/amp-img.js
+++ b/builtins/amp-img.js
@@ -36,6 +36,7 @@ const ATTRIBUTES_TO_PROPAGATE = [
   'aria-describedby',
   'aria-label',
   'aria-labelledby',
+  'crossorigin',
   'referrerpolicy',
   'sizes',
   'src',

--- a/test/unit/test-amp-img.js
+++ b/test/unit/test-amp-img.js
@@ -222,6 +222,18 @@ describes.sandboxed('amp-img', {}, (env) => {
     );
   });
 
+  it('should propagate crossorigin attribute', () => {
+    return getImg({
+      src: '/examples/img/sample.jpg',
+      width: 320,
+      height: 240,
+      crossorigin: 'anonymous',
+    }).then((ampImg) => {
+      const img = ampImg.querySelector('img');
+      expect(img.getAttribute('crossorigin')).to.equal('anonymous');
+    });
+  });
+
   describe('#fallback on initial load', () => {
     let el;
     let impl;

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -4476,6 +4476,7 @@ tags: {  # <amp-img>
   tag_name: "AMP-IMG"
   attrs: { name: "alt" }
   attrs: { name: "attribution" }
+  attrs: { name: "crossorigin" }
   attrs: { name: "object-fit" }
   attrs: { name: "object-position" }
   attrs: { name: "placeholder" }


### PR DESCRIPTION
The `img` tag needs to have a `crossorigin` attribute in order to be used in a canvas context, cf https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image

We're using an `amp-img` tag to build a new `amp-story-360` extension that will use this image in a canvas in https://github.com/ampproject/amphtml/pull/29023