### PR TITLE
🖍✅✨  [amp-story-player] Implement back and close buttons

### DIFF
--- a/css/amp-story-player-iframe.css
+++ b/css/amp-story-player-iframe.css
@@ -62,16 +62,22 @@ main .story-player-iframe[i-amphtml-iframe-position="-1"] {
 
 .amp-story-player-close-button {
   position: absolute;
-  color: white;
-  font-size: 45px;
-  padding-left: 10px;
-  padding-top: 4px;
+  height: 48px;
+  width: 48px;
+  background-repeat: no-repeat;
+  background-position: 50%;
+  margin-top: 7px;
+  background-size: 28px;
+  background-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" height="24" width="24" fill="%23FFF"><path d="M0 0h24v24H0z" fill="none"/><path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"/></svg>');
 }
 
 .amp-story-player-back-button {
   position: absolute;
-  color: white;
-  font-size: 50px;
-  padding-left: 5px;
-  margin-top: -3px;
+  height: 48px;
+  width: 48px;
+  background-repeat: no-repeat;
+  background-position: 50%;
+  margin-top: 7px;
+  background-size: 28px;
+  background-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" height="24" width="24" fill="%23FFF"><path d="M0 0h24v24H0z" fill="none"/><path d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z"/></svg>');
 }

--- a/css/amp-story-player-iframe.css
+++ b/css/amp-story-player-iframe.css
@@ -59,3 +59,19 @@ main .story-player-iframe[i-amphtml-iframe-position="1"] {
 main .story-player-iframe[i-amphtml-iframe-position="-1"] {
   transform: translate3d(-100%, 0, 0);
 }
+
+.amp-story-player-close-button {
+  position: absolute;
+  color: white;
+  font-size: 45px;
+  padding-left: 10px;
+  padding-top: 4px;
+}
+
+.amp-story-player-back-button {
+  position: absolute;
+  color: white;
+  font-size: 50px;
+  padding-left: 5px;
+  margin-top: -3px;
+}

--- a/css/amp-story-player-iframe.css
+++ b/css/amp-story-player-iframe.css
@@ -60,17 +60,7 @@ main .story-player-iframe[i-amphtml-iframe-position="-1"] {
   transform: translate3d(-100%, 0, 0);
 }
 
-.amp-story-player-close-button {
-  position: absolute;
-  height: 48px;
-  width: 48px;
-  background-repeat: no-repeat;
-  background-position: 50%;
-  margin-top: 7px;
-  background-size: 28px;
-  background-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" height="24" width="24" fill="%23FFF"><path d="M0 0h24v24H0z" fill="none"/><path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"/></svg>');
-}
-
+.amp-story-player-close-button,
 .amp-story-player-back-button {
   position: absolute;
   height: 48px;
@@ -79,5 +69,12 @@ main .story-player-iframe[i-amphtml-iframe-position="-1"] {
   background-position: 50%;
   margin-top: 7px;
   background-size: 28px;
+}
+
+.amp-story-player-close-button {
+  background-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" height="24" width="24" fill="%23FFF"><path d="M0 0h24v24H0z" fill="none"/><path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"/></svg>');
+}
+
+.amp-story-player-back-button {
   background-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" height="24" width="24" fill="%23FFF"><path d="M0 0h24v24H0z" fill="none"/><path d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z"/></svg>');
 }

--- a/css/amp-story-player-iframe.css
+++ b/css/amp-story-player-iframe.css
@@ -69,6 +69,9 @@ main .story-player-iframe[i-amphtml-iframe-position="-1"] {
   background-position: 50%;
   margin-top: 7px;
   background-size: 28px;
+  border: 0px;
+  background-color: transparent;
+  outline: transparent;
 }
 
 .amp-story-player-close-button {

--- a/examples/amp-story/player-with-button.html
+++ b/examples/amp-story/player-with-button.html
@@ -1,0 +1,67 @@
+<html>
+  <head>
+    <title>Story Player (Non-AMP)</title>
+    <script async src="../../dist/amp-story-player.js"></script>
+    <link href="../../build/css/amp-story-player-v0.css" rel='stylesheet' type='text/css'>
+    <style page>
+      body {
+        font-family: sans-serif;
+      }
+    </style>
+    <style injected>
+      .story-player-iframe {
+        background-size: cover;
+        display: block;
+        position: relative;
+        height: 100%;
+        width: 100%;
+        flex: 0 0 100%;
+      }
+
+      .title {
+        background: linear-gradient(to bottom, rgba(0, 0, 0, 0), rgba(0, 0, 0, 1));
+        display: block;
+        position: absolute;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        color: #fff;
+        font-size: 40px;
+        padding: 88px 32px 32px 32px;
+        line-height: 1.25;
+        text-shadow: 3px 3px #000;
+      }
+    </style>
+    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  </head>
+  <body>
+    <h1>This is a NON-AMP page that embeds a story below:</h1>
+    <div>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras viverra neque ex, sit amet varius sem maximus sed. Suspendisse potenti. Donec erat purus, sagittis sit amet tincidunt ut, maximus sit amet massa. Maecenas venenatis fringilla dui vitae vestibulum. Fusce imperdiet euismod lobortis. Nullam sagittis nunc at tristique mattis. In sodales consectetur mollis. Maecenas sollicitudin, ex vel tempor rutrum, turpis eros interdum enim, sit amet volutpat tortor dolor at ipsum. Nam posuere velit vel urna vulputate interdum. Aenean eu vulputate lorem. Praesent nec nunc sodales, egestas orci sed, hendrerit mauris. Ut blandit turpis non erat sagittis, quis fermentum odio feugiat.</div>
+    <amp-story-player style="width: 360px; height: 600px;" button="close">
+        <a href="https://www-washingtonpost-com.cdn.ampproject.org/v/s/www.washingtonpost.com/graphics/2019/lifestyle/travel/amp-stories/a-locals-guide-to-what-to-eat-and-do-in-new-york-city/"
+            style="--story-player-poster: url('https://www-washingtonpost-com.cdn.ampproject.org/i/s/www.washingtonpost.com/graphics/2019/lifestyle/travel/amp-stories/a-locals-guide-to-what-to-eat-and-do-in-new-york-city/img/promo3x4.jpg');"
+            class="story">
+          <span class="title">A local’s guide to what to eat and do in New York City</span>
+        </a>
+        <a href="https://www-washingtonpost-com.cdn.ampproject.org/v/s/www.washingtonpost.com/graphics/2019/lifestyle/travel/amp-stories/a-locals-guide-to-what-to-eat-and-do-in-miami/"
+            data-poster-portrait-src="https://www-washingtonpost-com.cdn.ampproject.org/v/s/www.washingtonpost.com/graphics/2019/lifestyle/travel/amp-stories/a-locals-guide-to-what-to-eat-and-do-in-miami/img/promo3x4.jpg"
+            class="story">
+          <span class="title">A local’s guide to what to eat and do in Miami</span>
+        </a>
+        <a href="https://www-washingtonpost-com.cdn.ampproject.org/v/s/www.washingtonpost.com/graphics/2019/lifestyle/travel/amp-stories/a-locals-guide-to-what-to-eat-and-do-in-mexico-city/"
+            data-poster-portrait-src="https://www-washingtonpost-com.cdn.ampproject.org/v/s/www.washingtonpost.com/graphics/2019/lifestyle/travel/amp-stories/a-locals-guide-to-what-to-eat-and-do-in-mexico-city/img/promo3x4.jpg"
+            class="story">
+          <span class="title">A local’s guide to what to eat and do in Mexico City</span>
+        </a>
+        <a href="https://www-washingtonpost-com.cdn.ampproject.org/v/s/www.washingtonpost.com/graphics/2019/lifestyle/travel/amp-stories/a-locals-guide-to-what-to-eat-and-do-in-rome/"
+            data-poster-portrait-src="https://www-washingtonpost-com.cdn.ampproject.org/v/s/washingtonpost.com/graphics/2019/lifestyle/travel/amp-stories/a-locals-guide-to-what-to-do-and-eat-in-rome/img/promo3x4.jpg"
+            class="story">
+          <span class="title">A local’s guide to what to eat and do in Rome</span>
+        </a>
+    </amp-story-player>
+    <div>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras viverra neque ex, sit amet varius sem maximus sed. Suspendisse potenti. Donec erat purus, sagittis sit amet tincidunt ut, maximus sit amet massa. Maecenas venenatis fringilla dui vitae vestibulum. Fusce imperdiet euismod lobortis. Nullam sagittis nunc at tristique mattis. In sodales consectetur mollis. Maecenas sollicitudin, ex vel tempor rutrum, turpis eros interdum enim, sit amet volutpat tortor dolor at ipsum. Nam posuere velit vel urna vulputate interdum. Aenean eu vulputate lorem. Praesent nec nunc sodales, egestas orci sed, hendrerit mauris. Ut blandit turpis non erat sagittis, quis fermentum odio feugiat.</div>
+  <script>
+    document.getElementsByTagName("amp-story-player")[0].addEventListener("close", (e) => alert("Hello!"));
+  </script>  
+  </body>
+</html>

--- a/examples/amp-story/player-with-button.html
+++ b/examples/amp-story/player-with-button.html
@@ -61,7 +61,7 @@
     </amp-story-player>
     <div>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras viverra neque ex, sit amet varius sem maximus sed. Suspendisse potenti. Donec erat purus, sagittis sit amet tincidunt ut, maximus sit amet massa. Maecenas venenatis fringilla dui vitae vestibulum. Fusce imperdiet euismod lobortis. Nullam sagittis nunc at tristique mattis. In sodales consectetur mollis. Maecenas sollicitudin, ex vel tempor rutrum, turpis eros interdum enim, sit amet volutpat tortor dolor at ipsum. Nam posuere velit vel urna vulputate interdum. Aenean eu vulputate lorem. Praesent nec nunc sodales, egestas orci sed, hendrerit mauris. Ut blandit turpis non erat sagittis, quis fermentum odio feugiat.</div>
   <script>
-    document.getElementsByTagName("amp-story-player")[0].addEventListener("amp-story-player-close", (e) => alert("Hello!"));
+    document.querySelector("amp-story-player").addEventListener("amp-story-player-close", (e) => alert("Hello!"));
   </script>  
   </body>
 </html>

--- a/examples/amp-story/player-with-button.html
+++ b/examples/amp-story/player-with-button.html
@@ -37,7 +37,7 @@
   <body>
     <h1>This is a NON-AMP page that embeds a story below:</h1>
     <div>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras viverra neque ex, sit amet varius sem maximus sed. Suspendisse potenti. Donec erat purus, sagittis sit amet tincidunt ut, maximus sit amet massa. Maecenas venenatis fringilla dui vitae vestibulum. Fusce imperdiet euismod lobortis. Nullam sagittis nunc at tristique mattis. In sodales consectetur mollis. Maecenas sollicitudin, ex vel tempor rutrum, turpis eros interdum enim, sit amet volutpat tortor dolor at ipsum. Nam posuere velit vel urna vulputate interdum. Aenean eu vulputate lorem. Praesent nec nunc sodales, egestas orci sed, hendrerit mauris. Ut blandit turpis non erat sagittis, quis fermentum odio feugiat.</div>
-    <amp-story-player style="width: 360px; height: 600px;" button="close">
+    <amp-story-player style="width: 360px; height: 600px;" exit-control="close-button">
         <a href="https://www-washingtonpost-com.cdn.ampproject.org/v/s/www.washingtonpost.com/graphics/2019/lifestyle/travel/amp-stories/a-locals-guide-to-what-to-eat-and-do-in-new-york-city/"
             style="--story-player-poster: url('https://www-washingtonpost-com.cdn.ampproject.org/i/s/www.washingtonpost.com/graphics/2019/lifestyle/travel/amp-stories/a-locals-guide-to-what-to-eat-and-do-in-new-york-city/img/promo3x4.jpg');"
             class="story">
@@ -61,7 +61,7 @@
     </amp-story-player>
     <div>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras viverra neque ex, sit amet varius sem maximus sed. Suspendisse potenti. Donec erat purus, sagittis sit amet tincidunt ut, maximus sit amet massa. Maecenas venenatis fringilla dui vitae vestibulum. Fusce imperdiet euismod lobortis. Nullam sagittis nunc at tristique mattis. In sodales consectetur mollis. Maecenas sollicitudin, ex vel tempor rutrum, turpis eros interdum enim, sit amet volutpat tortor dolor at ipsum. Nam posuere velit vel urna vulputate interdum. Aenean eu vulputate lorem. Praesent nec nunc sodales, egestas orci sed, hendrerit mauris. Ut blandit turpis non erat sagittis, quis fermentum odio feugiat.</div>
   <script>
-    document.getElementsByTagName("amp-story-player")[0].addEventListener("close", (e) => alert("Hello!"));
+    document.getElementsByTagName("amp-story-player")[0].addEventListener("amp-story-player-close", (e) => alert("Hello!"));
   </script>  
   </body>
 </html>

--- a/src/amp-story-player/amp-story-player-impl.js
+++ b/src/amp-story-player/amp-story-player-impl.js
@@ -68,8 +68,8 @@ const MAX_IFRAMES = 3;
 
 /** @enum {string} */
 const BUTTON_TYPES = {
-  BACK: "back", 
-  CLOSE: "close"
+  BACK: 'back',
+  CLOSE: 'close',
 };
 
 /** @const {string} */
@@ -222,15 +222,15 @@ export class AmpStoryPlayer {
    */
   initializeButton_() {
     const option = this.element_.getAttribute('button');
-    if (option in BUTTON_TYPES) { return; }
+    if (option in BUTTON_TYPES) {
+      return;
+    }
 
     const button = this.doc_.createElement('a');
     button.classList.add('amp-story-player-' + option + '-button');
 
     button.addEventListener('click', () => {
-      this.element_.dispatchEvent(
-        createCustomEvent(this.win_, option, {})
-      );
+      this.element_.dispatchEvent(createCustomEvent(this.win_, option, {}));
     });
 
     this.rootEl_.appendChild(button);

--- a/src/amp-story-player/amp-story-player-impl.js
+++ b/src/amp-story-player/amp-story-player-impl.js
@@ -68,8 +68,20 @@ const MAX_IFRAMES = 3;
 
 /** @enum {string} */
 const BUTTON_TYPES = {
-  BACK: 'back',
-  CLOSE: 'close',
+  BACK: 'back-button',
+  CLOSE: 'close-button',
+};
+
+/** @enum {string} */
+const BUTTON_CLASSES = {
+  [BUTTON_TYPES.BACK]: 'amp-story-player-back-button',
+  [BUTTON_TYPES.CLOSE]: 'amp-story-player-close-button',
+};
+
+/** @enum {string} */
+const BUTTON_EVENTS = {
+  [BUTTON_TYPES.BACK]: 'amp-story-player-back',
+  [BUTTON_TYPES.CLOSE]: 'amp-story-player-close',
 };
 
 /** @const {string} */
@@ -221,16 +233,16 @@ export class AmpStoryPlayer {
    * @private
    */
   initializeButton_() {
-    const option = this.element_.getAttribute('button');
+    const option = this.element_.getAttribute('exit-control');
     if (!Object.values(BUTTON_TYPES).includes(option)) {
       return;
     }
 
     const button = this.doc_.createElement('a');
-    button.classList.add('amp-story-player-' + option + '-button');
+    button.classList.add(BUTTON_CLASSES[option]);
 
     button.addEventListener('click', () => {
-      this.element_.dispatchEvent(createCustomEvent(this.win_, option, {}));
+      this.element_.dispatchEvent(createCustomEvent(this.win_, BUTTON_EVENTS[option], {}));
     });
 
     this.rootEl_.appendChild(button);

--- a/src/amp-story-player/amp-story-player-impl.js
+++ b/src/amp-story-player/amp-story-player-impl.js
@@ -172,6 +172,7 @@ export class AmpStoryPlayer {
     this.stories_ = toArray(this.element_.querySelectorAll('a'));
 
     this.initializeShadowRoot_();
+    this.initializeButton_();
     this.initializeIframes_();
     this.signalReady_();
     this.isBuilt_ = true;
@@ -209,6 +210,20 @@ export class AmpStoryPlayer {
     styleEl.textContent = cssText;
     shadowRoot.appendChild(styleEl);
     shadowRoot.appendChild(this.rootEl_);
+  }
+
+  /**
+   * Helper to create a button.
+   * @param {!Element} element
+   * @private
+   */
+  initializeButton_() {
+    const button = document.createElement('a');
+    button.textContent = true ? '×' : '←';
+    button.addEventListener("click", (e) => {
+      e.target.dispatchEvent(createCustomEvent(this.win_, 'close', {}));
+    });
+    this.rootEl_.appendChild(button);
   }
 
   /**

--- a/src/amp-story-player/amp-story-player-impl.js
+++ b/src/amp-story-player/amp-story-player-impl.js
@@ -221,17 +221,15 @@ export class AmpStoryPlayer {
     if (!option) {
       return;
     }
+    const optionBool = option === 'close';
 
     const button = this.doc_.createElement('a');
-    setStyle(button, 'position', 'absolute');
-    setStyle(button, 'color', 'white');
-    setStyle(button, 'fontSize', '40px');
-    setStyle(button, 'paddingLeft', '7px');
+    button.classList.add('amp-story-player-' + option + '-button');
 
-    button.textContent = option === 'close' ? '×' : '←';
+    button.textContent = optionBool ? '×' : '←';
     button.addEventListener('click', () => {
       this.element_.dispatchEvent(
-        createCustomEvent(this.win_, option === 'close' ? 'close' : 'back', {})
+        createCustomEvent(this.win_, optionBool ? 'close' : 'back', {})
       );
     });
     this.rootEl_.appendChild(button);

--- a/src/amp-story-player/amp-story-player-impl.js
+++ b/src/amp-story-player/amp-story-player-impl.js
@@ -218,7 +218,7 @@ export class AmpStoryPlayer {
    */
   initializeButton_() {
     const option = this.element_.getAttribute('button');
-    if (!option) {
+    if (!option || (option !== 'close' && option !== 'back')) {
       return;
     }
     const optionBool = option === 'close';

--- a/src/amp-story-player/amp-story-player-impl.js
+++ b/src/amp-story-player/amp-story-player-impl.js
@@ -225,6 +225,7 @@ export class AmpStoryPlayer {
 
     const button = this.doc_.createElement('a');
     button.classList.add('amp-story-player-' + option + '-button');
+    button.id = option + '-button';
 
     button.textContent = optionBool ? '×' : '←';
     button.addEventListener('click', () => {

--- a/src/amp-story-player/amp-story-player-impl.js
+++ b/src/amp-story-player/amp-story-player-impl.js
@@ -222,15 +222,17 @@ export class AmpStoryPlayer {
       return;
     }
 
-    const button = document.createElement('a');
-    button.style.position = 'absolute';
-    button.style.color = 'white';
-    button.style.fontSize = '40px';
-    button.style.paddingLeft = '7px';
-    
+    const button = this.doc_.createElement('a');
+    setStyle(button, 'position', 'absolute');
+    setStyle(button, 'color', 'white');
+    setStyle(button, 'fontSize', '40px');
+    setStyle(button, 'paddingLeft', '7px');
+
     button.textContent = option === 'close' ? '×' : '←';
-    button.addEventListener("click", (e) => {
-      this.element_.dispatchEvent(createCustomEvent(this.win_, option === 'close' ? 'close' : 'back', {}));
+    button.addEventListener('click', () => {
+      this.element_.dispatchEvent(
+        createCustomEvent(this.win_, option === 'close' ? 'close' : 'back', {})
+      );
     });
     this.rootEl_.appendChild(button);
   }

--- a/src/amp-story-player/amp-story-player-impl.js
+++ b/src/amp-story-player/amp-story-player-impl.js
@@ -238,7 +238,7 @@ export class AmpStoryPlayer {
       return;
     }
 
-    const button = this.doc_.createElement('a');
+    const button = this.doc_.createElement('button');
     button.classList.add(BUTTON_CLASSES[option]);
 
     button.addEventListener('click', () => {

--- a/src/amp-story-player/amp-story-player-impl.js
+++ b/src/amp-story-player/amp-story-player-impl.js
@@ -242,7 +242,9 @@ export class AmpStoryPlayer {
     button.classList.add(BUTTON_CLASSES[option]);
 
     button.addEventListener('click', () => {
-      this.element_.dispatchEvent(createCustomEvent(this.win_, BUTTON_EVENTS[option], {}));
+      this.element_.dispatchEvent(
+        createCustomEvent(this.win_, BUTTON_EVENTS[option], {})
+      );
     });
 
     this.rootEl_.appendChild(button);

--- a/src/amp-story-player/amp-story-player-impl.js
+++ b/src/amp-story-player/amp-story-player-impl.js
@@ -222,7 +222,7 @@ export class AmpStoryPlayer {
    */
   initializeButton_() {
     const option = this.element_.getAttribute('button');
-    if (option in BUTTON_TYPES) {
+    if (!Object.values(BUTTON_TYPES).includes(option)) {
       return;
     }
 

--- a/src/amp-story-player/amp-story-player-impl.js
+++ b/src/amp-story-player/amp-story-player-impl.js
@@ -227,7 +227,6 @@ export class AmpStoryPlayer {
     const button = this.doc_.createElement('a');
     button.classList.add('amp-story-player-' + option + '-button');
 
-    button.textContent = option == BUTTON_TYPES.CLOSE ? '×' : '←';
     button.addEventListener('click', () => {
       this.element_.dispatchEvent(
         createCustomEvent(this.win_, option, {})

--- a/src/amp-story-player/amp-story-player-impl.js
+++ b/src/amp-story-player/amp-story-player-impl.js
@@ -172,8 +172,8 @@ export class AmpStoryPlayer {
     this.stories_ = toArray(this.element_.querySelectorAll('a'));
 
     this.initializeShadowRoot_();
-    this.initializeButton_();
     this.initializeIframes_();
+    this.initializeButton_();
     this.signalReady_();
     this.isBuilt_ = true;
   }
@@ -214,14 +214,23 @@ export class AmpStoryPlayer {
 
   /**
    * Helper to create a button.
-   * @param {!Element} element
    * @private
    */
   initializeButton_() {
+    const option = this.element_.getAttribute('button');
+    if (!option) {
+      return;
+    }
+
     const button = document.createElement('a');
-    button.textContent = true ? '×' : '←';
+    button.style.position = 'absolute';
+    button.style.color = 'white';
+    button.style.fontSize = '40px';
+    button.style.paddingLeft = '7px';
+    
+    button.textContent = option === 'close' ? '×' : '←';
     button.addEventListener("click", (e) => {
-      e.target.dispatchEvent(createCustomEvent(this.win_, 'close', {}));
+      this.element_.dispatchEvent(createCustomEvent(this.win_, option === 'close' ? 'close' : 'back', {}));
     });
     this.rootEl_.appendChild(button);
   }

--- a/src/amp-story-player/amp-story-player-impl.js
+++ b/src/amp-story-player/amp-story-player-impl.js
@@ -53,9 +53,7 @@ const SUPPORTED_CACHES = ['cdn.ampproject.org', 'www.bing-amp.com'];
 /** @const @type {!Array<string>} */
 const SANDBOX_MIN_LIST = ['allow-top-navigation'];
 
-/**
- * @enum {number}
- */
+/** @enum {number} */
 const SwipingState = {
   NOT_SWIPING: 0,
   SWIPING_TO_LEFT: 1,
@@ -67,6 +65,12 @@ const TOGGLE_THRESHOLD_PX = 50;
 
 /** @const {number} */
 const MAX_IFRAMES = 3;
+
+/** @enum {string} */
+const BUTTON_TYPES = {
+  BACK: "back", 
+  CLOSE: "close"
+};
 
 /** @const {string} */
 export const IFRAME_IDX = '__AMP_IFRAME_IDX__';
@@ -218,21 +222,18 @@ export class AmpStoryPlayer {
    */
   initializeButton_() {
     const option = this.element_.getAttribute('button');
-    if (!option || (option !== 'close' && option !== 'back')) {
-      return;
-    }
-    const optionBool = option === 'close';
+    if (option in BUTTON_TYPES) { return; }
 
     const button = this.doc_.createElement('a');
     button.classList.add('amp-story-player-' + option + '-button');
-    button.id = option + '-button';
 
-    button.textContent = optionBool ? '×' : '←';
+    button.textContent = option == BUTTON_TYPES.CLOSE ? '×' : '←';
     button.addEventListener('click', () => {
       this.element_.dispatchEvent(
-        createCustomEvent(this.win_, optionBool ? 'close' : 'back', {})
+        createCustomEvent(this.win_, option, {})
       );
     });
+
     this.rootEl_.appendChild(button);
   }
 

--- a/test/unit/test-amp-story-player.js
+++ b/test/unit/test-amp-story-player.js
@@ -380,8 +380,12 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
 
       await player.load();
 
-      expect(playerEl.shadowRoot.querySelector('a.amp-story-player-back-button')).to.exist;
-      expect(playerEl.shadowRoot.querySelector('a.amp-story-player-close-button')).to.not.exist;
+      expect(
+        playerEl.shadowRoot.querySelector('a.amp-story-player-back-button')
+      ).to.exist;
+      expect(
+        playerEl.shadowRoot.querySelector('a.amp-story-player-close-button')
+      ).to.not.exist;
     });
 
     it('close button should be created and back button should not', async () => {
@@ -393,8 +397,12 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
 
       await player.load();
 
-      expect(playerEl.shadowRoot.querySelector('a.amp-story-player-close-button')).to.exist;
-      expect(playerEl.shadowRoot.querySelector('a.amp-story-player-back-button')).to.not.exist;
+      expect(
+        playerEl.shadowRoot.querySelector('a.amp-story-player-close-button')
+      ).to.exist;
+      expect(
+        playerEl.shadowRoot.querySelector('a.amp-story-player-back-button')
+      ).to.not.exist;
     });
 
     it('no button should be created', async () => {
@@ -406,8 +414,12 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
 
       await player.load();
 
-      expect(playerEl.shadowRoot.querySelector('a.amp-story-player-close-button')).to.not.exist;
-      expect(playerEl.shadowRoot.querySelector('a.amp-story-player-back-button')).to.not.exist;
+      expect(
+        playerEl.shadowRoot.querySelector('a.amp-story-player-close-button')
+      ).to.not.exist;
+      expect(
+        playerEl.shadowRoot.querySelector('a.amp-story-player-back-button')
+      ).to.not.exist;
     });
 
     it('back button should fire back event once', async () => {
@@ -422,7 +434,9 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
       const readySpy = env.sandbox.spy();
       playerEl.addEventListener('amp-story-player-back', readySpy);
 
-      playerEl.shadowRoot.querySelector('a.amp-story-player-back-button').click();
+      playerEl.shadowRoot
+        .querySelector('a.amp-story-player-back-button')
+        .click();
 
       expect(readySpy).to.have.been.calledOnce;
     });
@@ -439,7 +453,9 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
       const readySpy = env.sandbox.spy();
       playerEl.addEventListener('amp-story-player-close', readySpy);
 
-      playerEl.shadowRoot.querySelector('a.amp-story-player-close-button').click();
+      playerEl.shadowRoot
+        .querySelector('a.amp-story-player-close-button')
+        .click();
 
       expect(readySpy).to.have.been.calledOnce;
     });

--- a/test/unit/test-amp-story-player.js
+++ b/test/unit/test-amp-story-player.js
@@ -370,5 +370,57 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
         'Story URL not found in the player: https://example.com/story6.html'
       );
     });
+
+    it('testing back button', async () => {
+      const playerEl = win.document.createElement('amp-story-player');
+      appendStoriesToPlayer(playerEl, 5);
+
+      const player = new AmpStoryPlayer(win, playerEl);
+      player.setAttribute('button', 'back');
+      
+      await player.load();
+      
+      const readySpy = env.sandbox.spy();
+      playerEl.addEventListener('back', readySpy);
+      
+      win.document.getElement('back-button').click();
+
+      expect(readySpy).to.have.been.calledOnce;
+    });
+
+    // it('', async () => {
+    //   const playerEl = win.document.createElement('amp-story-player');
+    //   appendStoriesToPlayer(playerEl, 5);
+
+    //   const player = new AmpStoryPlayer(win, playerEl);
+    //   player.setAttribute('button', 'close');
+      
+    //   await player.load();
+      
+    //   const readySpy = env.sandbox.spy();
+    //   playerEl.addEventListener('close', readySpy);
+      
+      
+      
+
+    //   expect(readySpy).to.have.been.calledOnce;
+    // });
+
+    // it('', async () => {
+    //   const playerEl = win.document.createElement('amp-story-player');
+    //   appendStoriesToPlayer(playerEl, 5);
+
+    //   const player = new AmpStoryPlayer(win, playerEl);
+    //   player.setAttribute('button', 'brokenattribute');
+      
+    //   await player.load();
+      
+    //   const readySpy = env.sandbox.spy();
+    //   playerEl.addEventListener('close', readySpy);
+      
+      
+
+    //   expect(readySpy).to.have.been.calledOnce;
+    // });
   });
 });

--- a/test/unit/test-amp-story-player.js
+++ b/test/unit/test-amp-story-player.js
@@ -380,7 +380,7 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
 
       await player.load();
 
-      expect(playerEl.shadowRoot.getElementById('back-button')).to.exist;
+      expect(playerEl.shadowRoot.querySelector('a')).to.exist;
     });
 
     it('close button should be created', async () => {
@@ -392,7 +392,7 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
 
       await player.load();
 
-      expect(playerEl.shadowRoot.getElementById('close-button')).to.exist;
+      expect(playerEl.shadowRoot.querySelector('a')).to.exist;
     });
 
     it('no button should be created', async () => {
@@ -407,8 +407,7 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
       // Previous implementation relied on a ternary statement that defaulted to back-button
       // if the attribute was set to a value other than close or back. This test ensures that
       // correct behavior of the button not being created in the mentioned case.
-      expect(playerEl.shadowRoot.getElementById('back-button')).to.not.exist;
-      expect(playerEl.shadowRoot.getElementById('close-button')).to.not.exist;
+      expect(playerEl.shadowRoot.querySelector('a')).to.not.exist;
     });
 
     it('back button should fire back event once', async () => {
@@ -424,7 +423,7 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
       playerEl.addEventListener('close', readySpy);
       playerEl.addEventListener('back', readySpy);
 
-      playerEl.shadowRoot.getElementById('back-button').click();
+      playerEl.shadowRoot.querySelector('a').click();
 
       expect(readySpy).to.have.been.calledOnce;
     });
@@ -442,7 +441,7 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
       playerEl.addEventListener('close', readySpy);
       playerEl.addEventListener('back', readySpy);
 
-      playerEl.shadowRoot.getElementById('close-button').click();
+      playerEl.shadowRoot.querySelector('a').click();
 
       expect(readySpy).to.have.been.calledOnce;
     });

--- a/test/unit/test-amp-story-player.js
+++ b/test/unit/test-amp-story-player.js
@@ -381,10 +381,12 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
       await player.load();
 
       expect(
-        playerEl.shadowRoot.querySelector('a.amp-story-player-back-button')
+        playerEl.shadowRoot.querySelector('button.amp-story-player-back-button')
       ).to.exist;
       expect(
-        playerEl.shadowRoot.querySelector('a.amp-story-player-close-button')
+        playerEl.shadowRoot.querySelector(
+          'button.amp-story-player-close-button'
+        )
       ).to.not.exist;
     });
 
@@ -398,10 +400,12 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
       await player.load();
 
       expect(
-        playerEl.shadowRoot.querySelector('a.amp-story-player-close-button')
+        playerEl.shadowRoot.querySelector(
+          'button.amp-story-player-close-button'
+        )
       ).to.exist;
       expect(
-        playerEl.shadowRoot.querySelector('a.amp-story-player-back-button')
+        playerEl.shadowRoot.querySelector('button.amp-story-player-back-button')
       ).to.not.exist;
     });
 
@@ -415,10 +419,12 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
       await player.load();
 
       expect(
-        playerEl.shadowRoot.querySelector('a.amp-story-player-close-button')
+        playerEl.shadowRoot.querySelector(
+          'button.amp-story-player-close-button'
+        )
       ).to.not.exist;
       expect(
-        playerEl.shadowRoot.querySelector('a.amp-story-player-back-button')
+        playerEl.shadowRoot.querySelector('button.amp-story-player-back-button')
       ).to.not.exist;
     });
 
@@ -435,7 +441,7 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
       playerEl.addEventListener('amp-story-player-back', readySpy);
 
       playerEl.shadowRoot
-        .querySelector('a.amp-story-player-back-button')
+        .querySelector('button.amp-story-player-back-button')
         .click();
 
       expect(readySpy).to.have.been.calledOnce;
@@ -454,7 +460,7 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
       playerEl.addEventListener('amp-story-player-close', readySpy);
 
       playerEl.shadowRoot
-        .querySelector('a.amp-story-player-close-button')
+        .querySelector('button.amp-story-player-close-button')
         .click();
 
       expect(readySpy).to.have.been.calledOnce;

--- a/test/unit/test-amp-story-player.js
+++ b/test/unit/test-amp-story-player.js
@@ -377,9 +377,9 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
       appendStoriesToPlayer(playerEl, 5);
 
       const player = new AmpStoryPlayer(win, playerEl);
-      
+
       await player.load();
-      
+
       expect(playerEl.shadowRoot.getElementById('back-button')).to.exist;
     });
 
@@ -389,9 +389,9 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
       appendStoriesToPlayer(playerEl, 5);
 
       const player = new AmpStoryPlayer(win, playerEl);
-      
+
       await player.load();
-      
+
       expect(playerEl.shadowRoot.getElementById('close-button')).to.exist;
     });
 
@@ -401,9 +401,9 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
       appendStoriesToPlayer(playerEl, 5);
 
       const player = new AmpStoryPlayer(win, playerEl);
-      
+
       await player.load();
-      
+
       // Previous implementation relied on a ternary statement that defaulted to back-button
       // if the attribute was set to a value other than close or back. This test ensures that
       // correct behavior of the button not being created in the mentioned case.
@@ -417,13 +417,13 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
       appendStoriesToPlayer(playerEl, 5);
 
       const player = new AmpStoryPlayer(win, playerEl);
-      
+
       await player.load();
-      
+
       const readySpy = env.sandbox.spy();
       playerEl.addEventListener('close', readySpy);
       playerEl.addEventListener('back', readySpy);
-      
+
       playerEl.shadowRoot.getElementById('back-button').click();
 
       expect(readySpy).to.have.been.calledOnce;
@@ -435,13 +435,13 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
       appendStoriesToPlayer(playerEl, 5);
 
       const player = new AmpStoryPlayer(win, playerEl);
-      
+
       await player.load();
-      
+
       const readySpy = env.sandbox.spy();
       playerEl.addEventListener('close', readySpy);
       playerEl.addEventListener('back', readySpy);
-      
+
       playerEl.shadowRoot.getElementById('close-button').click();
 
       expect(readySpy).to.have.been.calledOnce;

--- a/test/unit/test-amp-story-player.js
+++ b/test/unit/test-amp-story-player.js
@@ -371,56 +371,80 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
       );
     });
 
-    it('testing back button', async () => {
+    it('back button should be created', async () => {
       const playerEl = win.document.createElement('amp-story-player');
+      playerEl.setAttribute('button', 'back');
       appendStoriesToPlayer(playerEl, 5);
 
       const player = new AmpStoryPlayer(win, playerEl);
-      player.setAttribute('button', 'back');
+      
+      await player.load();
+      
+      expect(playerEl.shadowRoot.getElementById('back-button')).to.exist;
+    });
+
+    it('close button should be created', async () => {
+      const playerEl = win.document.createElement('amp-story-player');
+      playerEl.setAttribute('button', 'close');
+      appendStoriesToPlayer(playerEl, 5);
+
+      const player = new AmpStoryPlayer(win, playerEl);
+      
+      await player.load();
+      
+      expect(playerEl.shadowRoot.getElementById('close-button')).to.exist;
+    });
+
+    it('no button should be created', async () => {
+      const playerEl = win.document.createElement('amp-story-player');
+      playerEl.setAttribute('button', 'brokenattribute');
+      appendStoriesToPlayer(playerEl, 5);
+
+      const player = new AmpStoryPlayer(win, playerEl);
+      
+      await player.load();
+      
+      // Previous implementation relied on a ternary statement that defaulted to back-button
+      // if the attribute was set to a value other than close or back. This test ensures that
+      // correct behavior of the button not being created in the mentioned case.
+      expect(playerEl.shadowRoot.getElementById('back-button')).to.not.exist;
+      expect(playerEl.shadowRoot.getElementById('close-button')).to.not.exist;
+    });
+
+    it('back button should fire back event once', async () => {
+      const playerEl = win.document.createElement('amp-story-player');
+      playerEl.setAttribute('button', 'back');
+      appendStoriesToPlayer(playerEl, 5);
+
+      const player = new AmpStoryPlayer(win, playerEl);
       
       await player.load();
       
       const readySpy = env.sandbox.spy();
+      playerEl.addEventListener('close', readySpy);
       playerEl.addEventListener('back', readySpy);
       
-      win.document.getElement('back-button').click();
+      playerEl.shadowRoot.getElementById('back-button').click();
 
       expect(readySpy).to.have.been.calledOnce;
     });
 
-    // it('', async () => {
-    //   const playerEl = win.document.createElement('amp-story-player');
-    //   appendStoriesToPlayer(playerEl, 5);
+    it('close button should fire close event once', async () => {
+      const playerEl = win.document.createElement('amp-story-player');
+      playerEl.setAttribute('button', 'close');
+      appendStoriesToPlayer(playerEl, 5);
 
-    //   const player = new AmpStoryPlayer(win, playerEl);
-    //   player.setAttribute('button', 'close');
+      const player = new AmpStoryPlayer(win, playerEl);
       
-    //   await player.load();
+      await player.load();
       
-    //   const readySpy = env.sandbox.spy();
-    //   playerEl.addEventListener('close', readySpy);
+      const readySpy = env.sandbox.spy();
+      playerEl.addEventListener('close', readySpy);
+      playerEl.addEventListener('back', readySpy);
       
-      
-      
+      playerEl.shadowRoot.getElementById('close-button').click();
 
-    //   expect(readySpy).to.have.been.calledOnce;
-    // });
-
-    // it('', async () => {
-    //   const playerEl = win.document.createElement('amp-story-player');
-    //   appendStoriesToPlayer(playerEl, 5);
-
-    //   const player = new AmpStoryPlayer(win, playerEl);
-    //   player.setAttribute('button', 'brokenattribute');
-      
-    //   await player.load();
-      
-    //   const readySpy = env.sandbox.spy();
-    //   playerEl.addEventListener('close', readySpy);
-      
-      
-
-    //   expect(readySpy).to.have.been.calledOnce;
-    // });
+      expect(readySpy).to.have.been.calledOnce;
+    });
   });
 });

--- a/test/unit/test-amp-story-player.js
+++ b/test/unit/test-amp-story-player.js
@@ -371,48 +371,48 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
       );
     });
 
-    it('back button should be created', async () => {
+    it('back button should be created and close button should not', async () => {
       const playerEl = win.document.createElement('amp-story-player');
-      playerEl.setAttribute('button', 'back');
+      playerEl.setAttribute('exit-control', 'back-button');
       appendStoriesToPlayer(playerEl, 5);
 
       const player = new AmpStoryPlayer(win, playerEl);
 
       await player.load();
 
-      expect(playerEl.shadowRoot.querySelector('a')).to.exist;
+      expect(playerEl.shadowRoot.querySelector('a.amp-story-player-back-button')).to.exist;
+      expect(playerEl.shadowRoot.querySelector('a.amp-story-player-close-button')).to.not.exist;
     });
 
-    it('close button should be created', async () => {
+    it('close button should be created and back button should not', async () => {
       const playerEl = win.document.createElement('amp-story-player');
-      playerEl.setAttribute('button', 'close');
+      playerEl.setAttribute('exit-control', 'close-button');
       appendStoriesToPlayer(playerEl, 5);
 
       const player = new AmpStoryPlayer(win, playerEl);
 
       await player.load();
 
-      expect(playerEl.shadowRoot.querySelector('a')).to.exist;
+      expect(playerEl.shadowRoot.querySelector('a.amp-story-player-close-button')).to.exist;
+      expect(playerEl.shadowRoot.querySelector('a.amp-story-player-back-button')).to.not.exist;
     });
 
     it('no button should be created', async () => {
       const playerEl = win.document.createElement('amp-story-player');
-      playerEl.setAttribute('button', 'brokenattribute');
+      playerEl.setAttribute('exit-control', 'brokenattribute');
       appendStoriesToPlayer(playerEl, 5);
 
       const player = new AmpStoryPlayer(win, playerEl);
 
       await player.load();
 
-      // Previous implementation relied on a ternary statement that defaulted to back-button
-      // if the attribute was set to a value other than close or back. This test ensures that
-      // correct behavior of the button not being created in the mentioned case.
-      expect(playerEl.shadowRoot.querySelector('a')).to.not.exist;
+      expect(playerEl.shadowRoot.querySelector('a.amp-story-player-close-button')).to.not.exist;
+      expect(playerEl.shadowRoot.querySelector('a.amp-story-player-back-button')).to.not.exist;
     });
 
     it('back button should fire back event once', async () => {
       const playerEl = win.document.createElement('amp-story-player');
-      playerEl.setAttribute('button', 'back');
+      playerEl.setAttribute('exit-control', 'back-button');
       appendStoriesToPlayer(playerEl, 5);
 
       const player = new AmpStoryPlayer(win, playerEl);
@@ -420,17 +420,16 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
       await player.load();
 
       const readySpy = env.sandbox.spy();
-      playerEl.addEventListener('close', readySpy);
-      playerEl.addEventListener('back', readySpy);
+      playerEl.addEventListener('amp-story-player-back', readySpy);
 
-      playerEl.shadowRoot.querySelector('a').click();
+      playerEl.shadowRoot.querySelector('a.amp-story-player-back-button').click();
 
       expect(readySpy).to.have.been.calledOnce;
     });
 
     it('close button should fire close event once', async () => {
       const playerEl = win.document.createElement('amp-story-player');
-      playerEl.setAttribute('button', 'close');
+      playerEl.setAttribute('exit-control', 'close-button');
       appendStoriesToPlayer(playerEl, 5);
 
       const player = new AmpStoryPlayer(win, playerEl);
@@ -438,10 +437,9 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
       await player.load();
 
       const readySpy = env.sandbox.spy();
-      playerEl.addEventListener('close', readySpy);
-      playerEl.addEventListener('back', readySpy);
+      playerEl.addEventListener('amp-story-player-close', readySpy);
 
-      playerEl.shadowRoot.querySelector('a').click();
+      playerEl.shadowRoot.querySelector('a.amp-story-player-close-button').click();
 
       expect(readySpy).to.have.been.calledOnce;
     });


### PR DESCRIPTION
<!--
> NOTE: All non-trivial changes (like introducing new features or components) should have an associated issue or reference an I2I (intent-to-implement: go.amp.dev/i2i). Please read through the contribution process (go.amp.dev/contributing/code) for more information.
-->

- Implement back and close button functionality, specify which by setting the button attribute of the amp-story-player tag to be "close" or "back" and the button, when clicked, will fire the appropriate event. (Visual diff tests are in a separate PR)
![Screenshot 2020-07-01 at 12 59 06 PM](https://user-images.githubusercontent.com/23634958/86271321-aec93100-bb9a-11ea-8cfc-164575fd2687.png)
![Screenshot 2020-07-01 at 12 55 06 PM](https://user-images.githubusercontent.com/23634958/86271004-2cd90800-bb9a-11ea-9b58-ee6c182535d8.png)

Partial for: #28416

/cc @Enriqe @newmuis 