### PR TITLE
🏗 Add a `--flavor` flag to `gulp release`

### DIFF
--- a/build-system/tasks/release/index.js
+++ b/build-system/tasks/release/index.js
@@ -445,9 +445,9 @@ async function release() {
   log('Prepending config to entry files...');
   await prependConfig_(outputDir);
 
-  log('Copying from temporary directory to', cyan('net-wildcard'));
   if (!argv.flavor || argv.flavor == 'base') {
     // Only populate the net-wildcard directory if --flavor=base or if --flavor is not set.
+    log('Copying from temporary directory to', cyan('net-wildcard'));
     await populateNetWildcard_(tempDir, outputDir);
   }
 

--- a/build-system/tasks/release/index.js
+++ b/build-system/tasks/release/index.js
@@ -290,7 +290,7 @@ async function populateOrgCdn_(distFlavors, tempDir, outputDir) {
     if (flavorType == 'base') {
       Object.entries(experimentsConfig)
         .filter(([, {environment}]) => environment == 'INABOX')
-        .map(([experimentFlavor]) => {
+        .forEach(([experimentFlavor]) => {
           const rtvPrefix =
             EXPERIMENTAL_RTV_PREFIXES['INABOX'][`${experimentFlavor}-control`];
           rtvCopyingPromises.push(rtvCopyingPromise(rtvPrefix, 'base'));

--- a/build-system/tasks/release/index.js
+++ b/build-system/tasks/release/index.js
@@ -435,7 +435,9 @@ async function release() {
     return;
   }
 
-  log('Compiling all', `${green('flavors')}...`);
+  if (!argv.flavor) {
+    log('Compiling all', `${green('flavors')}...`);
+  }
   await compileDistFlavors_(distFlavors, tempDir);
 
   log('Fetching npm package', `${cyan('@ampproject/amp-sw')}...`);

--- a/build-system/tasks/release/index.js
+++ b/build-system/tasks/release/index.js
@@ -153,7 +153,7 @@ function discoverDistFlavors_() {
       })),
   ].filter(
     // If --flavor is defined, filter out the rest.
-    ([flavorType]) => !argv.flavor || flavorType == argv.flavor
+    ({flavorType}) => !argv.flavor || flavorType == argv.flavor
   );
 
   log(

--- a/build-system/tasks/release/index.js
+++ b/build-system/tasks/release/index.js
@@ -277,19 +277,24 @@ async function populateOrgCdn_(distFlavors, tempDir, outputDir) {
   };
 
   const rtvCopyingPromises = [];
-  for (const {environment, flavorType, rtvPrefixes} of distFlavors) {
+  for (const {flavorType, rtvPrefixes} of distFlavors) {
     rtvCopyingPromises.push(
       ...rtvPrefixes.map((rtvPrefix) =>
         rtvCopyingPromise(rtvPrefix, flavorType)
       )
     );
 
-    // Special handling for INABOX experiments, which requires that their
-    // control population be created from the base flavor.
-    if (environment == 'INABOX') {
-      const rtvPrefix =
-        EXPERIMENTAL_RTV_PREFIXES['INABOX'][`${flavorType}-control`];
-      rtvCopyingPromises.push(rtvCopyingPromise(rtvPrefix, 'base'));
+    // Special handling for INABOX experiments when compiling the base flavor.
+    // INABOX experiments need to have their control population be created from
+    // the base flavor.
+    if (flavorType == 'base') {
+      experimentsConfig
+        .filter(({environment}) => environment == 'INABOX')
+        .map(({flavorType: experimentFlavor}) => {
+          const rtvPrefix =
+            EXPERIMENTAL_RTV_PREFIXES['INABOX'][`${experimentFlavor}-control`];
+          rtvCopyingPromises.push(rtvCopyingPromise(rtvPrefix, 'base'));
+        });
     }
   }
   await Promise.all(rtvCopyingPromises);

--- a/build-system/tasks/release/index.js
+++ b/build-system/tasks/release/index.js
@@ -288,9 +288,9 @@ async function populateOrgCdn_(distFlavors, tempDir, outputDir) {
     // INABOX experiments need to have their control population be created from
     // the base flavor.
     if (flavorType == 'base') {
-      experimentsConfig
-        .filter(({environment}) => environment == 'INABOX')
-        .map(({flavorType: experimentFlavor}) => {
+      Object.entries(experimentsConfig)
+        .filter(([, {environment}]) => environment == 'INABOX')
+        .map(([experimentFlavor]) => {
           const rtvPrefix =
             EXPERIMENTAL_RTV_PREFIXES['INABOX'][`${experimentFlavor}-control`];
           rtvCopyingPromises.push(rtvCopyingPromise(rtvPrefix, 'base'));


### PR DESCRIPTION
This flag will enable running different flavors (`base`/`experimentN`) in parallel VMs