### PR TITLE
🐛 #28698: Fix for bug that was incorrectly transforming anonymous function to arrow function.

### DIFF
--- a/build-system/babel-plugins/babel-plugin-transform-function-declarations/index.js
+++ b/build-system/babel-plugins/babel-plugin-transform-function-declarations/index.js
@@ -125,7 +125,7 @@ module.exports = function ({types: t}) {
     (path) => referencesAreOnlyCallExpressions(path, path.get('id').node.name),
   ];
 
-  // If CallExpression names should be exhempt from arrow conversion, denote them here.
+  // If CallExpression names should be exempt from arrow conversion, denote them here.
   const EXEMPTED_EXPRESSION_NAME_REGEXS = [/registerService/];
 
   const EXPRESSION_BAIL_OUT_CONDITIONS = [
@@ -137,11 +137,13 @@ module.exports = function ({types: t}) {
     (path) => {
       const callExpression = path.findParent((p) => p.isCallExpression());
       if (callExpression) {
-        const {name} = (callExpression.node && callExpression.node.callee) || {
+        const {name, property} = (callExpression.node &&
+          callExpression.node.callee) || {
           name: null,
+          property: null,
         };
-        return EXEMPTED_EXPRESSION_NAME_REGEXS.every((regexp) =>
-          regexp.test(name)
+        return EXEMPTED_EXPRESSION_NAME_REGEXS.every(
+          (regexp) => regexp.test(name) || regexp.test(property.name)
         );
       }
 

--- a/build-system/babel-plugins/babel-plugin-transform-function-declarations/test/fixtures/transform-assertions/argument-function/input.js
+++ b/build-system/babel-plugins/babel-plugin-transform-function-declarations/test/fixtures/transform-assertions/argument-function/input.js
@@ -16,3 +16,6 @@
 registerServiceBuilder(win, 'story-analytics', function() {
   return new StoryAnalyticsService();
 });
+
+geoDeferred = new Deferred();
+AMP.registerServiceForDoc('foo', function(){return geoDeferred.promise;});

--- a/build-system/babel-plugins/babel-plugin-transform-function-declarations/test/fixtures/transform-assertions/argument-function/output.js
+++ b/build-system/babel-plugins/babel-plugin-transform-function-declarations/test/fixtures/transform-assertions/argument-function/output.js
@@ -16,3 +16,6 @@
 registerServiceBuilder(win, 'story-analytics', function () {
   return new StoryAnalyticsService();
 });
+
+geoDeferred = new Deferred();
+AMP.registerServiceForDoc('foo', function(){return geoDeferred.promise;});


### PR DESCRIPTION
This PR attempts to address the issue that was raised in #28698, which was occurring because the bailout conditions did not consider that the exemption regex must also be tested against property identifiers.