### PR TITLE
❄️ Skip tests that are known to fail on GH Actions

### DIFF
--- a/build-system/pr-check/cross-browser-tests.js
+++ b/build-system/pr-check/cross-browser-tests.js
@@ -44,6 +44,7 @@ async function main() {
       timedExecOrDie(
         'gulp integration --nobuild --compiled --headless --firefox'
       );
+      break;
     case 'darwin':
       timedExecOrDie('gulp unit --nobuild --safari');
       timedExecOrDie('gulp integration --nobuild --compiled --safari');

--- a/test/integration/test-amp-recaptcha-input.js
+++ b/test/integration/test-amp-recaptcha-input.js
@@ -18,10 +18,12 @@ import {BrowserController, RequestBank} from '../../testing/test-helper';
 import {Deferred} from '../../src/utils/promise';
 import {poll} from '../../testing/iframe';
 
-// TODO(wg-ui-and-a11y): These tests are broken on Firefox (as of v77).
+// TODO(wg-ui-and-a11y): These tests are broken on Firefox (as of v77). They
+// also fail on Safari.
 describe
   .configure()
   .skipFirefox()
+  .skipSafari()
   .run('amp-recaptcha-input', function () {
     describes.integration(
       'with form and amp-mustache',

--- a/test/integration/test-amphtml-ads.js
+++ b/test/integration/test-amphtml-ads.js
@@ -19,7 +19,8 @@ import {maybeSwitchToCompiledJs} from '../../testing/iframe';
 import {parseQueryString} from '../../src/url';
 import {xhrServiceForTesting} from '../../src/service/xhr-impl';
 
-const t = describe.configure();
+// TODO(wg-ads, #29112): Unskip on Safari.
+const t = describe.configure().skipSafari();
 
 t.run('AMPHTML ad on AMP Page', () => {
   describes.integration(

--- a/test/integration/test-user-error-reporting.js
+++ b/test/integration/test-user-error-reporting.js
@@ -16,10 +16,8 @@
 
 import {BrowserController, RequestBank} from '../../testing/test-helper';
 
-const t = describe
-  .configure()
-  .skipSafari() // TODO(zhouyx, #11459): Unskip the test on safari.
-  .skipEdge();
+// TODO(zhouyx, #11459): Unskip the test on Safari and Firefox.
+const t = describe.configure().skipSafari().skipFirefox().skipEdge();
 
 t.run('user-error', function () {
   describes.integration(


### PR DESCRIPTION
This PR skips a few known failures on Firefox / Safari, that started failing when we enabled testing on GH actions. Follow up to #29012