### PR TITLE
🐛 Fix broken ads client side experiments

### DIFF
--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -212,22 +212,22 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
   divertExperiments() {
     const experimentInfoMap = /** @type {!Object<string,
         !../../../src/experiments.ExperimentInfo>} */ ({
-      [[RENDER_ON_IDLE_FIX_EXP.id]]: {
+      [RENDER_ON_IDLE_FIX_EXP.id]: {
         isTrafficEligible: () => true,
         branches: [
-          [RENDER_ON_IDLE_FIX_EXP.control],
-          [RENDER_ON_IDLE_FIX_EXP.experiment],
+          RENDER_ON_IDLE_FIX_EXP.control,
+          RENDER_ON_IDLE_FIX_EXP.experiment,
         ],
       },
       [NO_SIGNING_EXP.id]: {
         isTrafficEligible: () => true,
-        branches: [[NO_SIGNING_EXP.control], [NO_SIGNING_EXP.experiment]],
+        branches: [NO_SIGNING_EXP.control, NO_SIGNING_EXP.experiment],
       },
       [STICKY_AD_PADDING_BOTTOM_EXP.id]: {
         isTrafficEligible: () => true,
         branches: [
-          [STICKY_AD_PADDING_BOTTOM_EXP.control],
-          [STICKY_AD_PADDING_BOTTOM_EXP.experiment],
+          STICKY_AD_PADDING_BOTTOM_EXP.control,
+          STICKY_AD_PADDING_BOTTOM_EXP.experiment,
         ],
       },
       ...AMPDOC_FIE_EXPERIMENT_INFO_MAP,

--- a/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
@@ -19,13 +19,14 @@
 // always available for them. However, when we test an impl in isolation,
 // AmpAd is not loaded already, so we need to load it separately.
 import '../../../amp-ad/0.1/amp-ad';
+import * as experiments from '../../../../src/experiments';
 import {AD_SIZE_OPTIMIZATION_EXP} from '../responsive-state';
 import {AmpA4A} from '../../../amp-a4a/0.1/amp-a4a';
-import {AmpAd} from '../../../amp-ad/0.1/amp-ad';
+import {AmpAd} from '../../../amp-ad/0.1/amp-ad'; // eslint-disable-line no-unused-vars
 import {
   AmpAdNetworkAdsenseImpl,
   resetSharedState,
-} from '../amp-ad-network-adsense-impl'; // eslint-disable-line no-unused-vars
+} from '../amp-ad-network-adsense-impl';
 import {
   AmpAdXOriginIframeHandler, // eslint-disable-line no-unused-vars
 } from '../../../amp-ad/0.1/amp-ad-xorigin-iframe-handler';
@@ -1393,6 +1394,26 @@ describes.realWin(
         doc.body.appendChild(ampStickyAd);
         const letCreativeTriggerRenderStart = impl.letCreativeTriggerRenderStart();
         expect(letCreativeTriggerRenderStart).to.equal(false);
+      });
+    });
+
+    describe('#divertExperiments', () => {
+      it('should have correctly formatted experiment map', () => {
+        const randomlySelectUnsetExperimentsStub = env.sandbox.stub(
+          experiments,
+          'randomlySelectUnsetExperiments'
+        );
+        randomlySelectUnsetExperimentsStub.returns({});
+        impl.divertExperiments();
+        const experimentMap =
+          randomlySelectUnsetExperimentsStub.firstCall.args[1];
+        Object.keys(experimentMap).forEach((key) => {
+          expect(key).to.be.a('string');
+          const {branches} = experimentMap[key];
+          expect(branches).to.exist;
+          expect(branches).to.be.a('array');
+          branches.forEach((branch) => expect(branch).to.be.a('string'));
+        });
       });
     });
   }

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -460,29 +460,29 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
           RANDOM_SUBDOMAIN_SAFEFRAME_BRANCHES.EXPERIMENT,
         ],
       },
-      [[EXPAND_JSON_TARGETING_EXP.ID]]: {
+      [EXPAND_JSON_TARGETING_EXP.ID]: {
         isTrafficEligible: () => true,
         branches: [
-          [EXPAND_JSON_TARGETING_EXP.CONTROL],
-          [EXPAND_JSON_TARGETING_EXP.EXPERIMENT],
+          EXPAND_JSON_TARGETING_EXP.CONTROL,
+          EXPAND_JSON_TARGETING_EXP.EXPERIMENT,
         ],
       },
-      [[RENDER_ON_IDLE_FIX_EXP.id]]: {
+      [RENDER_ON_IDLE_FIX_EXP.id]: {
         isTrafficEligible: () => true,
         branches: [
-          [RENDER_ON_IDLE_FIX_EXP.control],
-          [RENDER_ON_IDLE_FIX_EXP.experiment],
+          RENDER_ON_IDLE_FIX_EXP.control,
+          RENDER_ON_IDLE_FIX_EXP.experiment,
         ],
       },
       [NO_SIGNING_EXP.id]: {
         isTrafficEligible: () => true,
-        branches: [[NO_SIGNING_EXP.control], [NO_SIGNING_EXP.experiment]],
+        branches: [NO_SIGNING_EXP.control, NO_SIGNING_EXP.experiment],
       },
       [STICKY_AD_PADDING_BOTTOM_EXP.id]: {
         isTrafficEligible: () => true,
         branches: [
-          [STICKY_AD_PADDING_BOTTOM_EXP.control],
-          [STICKY_AD_PADDING_BOTTOM_EXP.experiment],
+          STICKY_AD_PADDING_BOTTOM_EXP.control,
+          STICKY_AD_PADDING_BOTTOM_EXP.experiment,
         ],
       },
       ...AMPDOC_FIE_EXPERIMENT_INFO_MAP,

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -1890,6 +1890,20 @@ describes.realWin(
         toggleExperiment(env.win, 'envDfpInvOrigDeprecated', false);
       });
 
+      it('should have correctly formatted experiment map', () => {
+        randomlySelectUnsetExperimentsStub.returns({});
+        impl.buildCallback();
+        const experimentMap =
+          randomlySelectUnsetExperimentsStub.firstCall.args[0];
+        Object.keys(experimentMap).forEach((key) => {
+          expect(key).to.be.a('string');
+          const {branches} = experimentMap[key];
+          expect(branches).to.exist;
+          expect(branches).to.be.a('array');
+          branches.forEach((branch) => expect(branch).to.be.a('string'));
+        });
+      });
+
       it('should select SRA experiments', () => {
         randomlySelectUnsetExperimentsStub.returns({
           doubleclickSraExp: '117152667',

--- a/extensions/amp-sticky-ad/1.0/amp-sticky-ad.js
+++ b/extensions/amp-sticky-ad/1.0/amp-sticky-ad.js
@@ -71,8 +71,8 @@ class AmpStickyAd extends AMP.BaseElement {
         [STICKY_AD_PADDING_BOTTOM_EXP.id]: {
           isTrafficEligible: () => true,
           branches: [
-            [STICKY_AD_PADDING_BOTTOM_EXP.control],
-            [STICKY_AD_PADDING_BOTTOM_EXP.experiment],
+            STICKY_AD_PADDING_BOTTOM_EXP.control,
+            STICKY_AD_PADDING_BOTTOM_EXP.experiment,
           ],
         },
       });

--- a/src/ampdoc-fie.js
+++ b/src/ampdoc-fie.js
@@ -40,7 +40,7 @@ const EXPERIMENT = {
 export const EXPERIMENT_INFO_MAP = {
   [EXPERIMENT_ID]: {
     isTrafficEligible: () => true,
-    branches: [[EXPERIMENT.control], [EXPERIMENT.experiment]],
+    branches: [EXPERIMENT.control, EXPERIMENT.experiment],
   },
 };
 


### PR DESCRIPTION
We are running a few client side experiments where the `experimentInfoMap` is formatted incorrectly. Specifically our branch ids are arrays `['123']` when they should be strings `'123'`. This causes checks like https://github.com/ampproject/amphtml/blob/242e092ff440aa70334a4fdf9b06362c4a69ac56/extensions/amp-sticky-ad/1.0/amp-sticky-ad.js#L81-L82 to never be true 😬.

Unfortunately the logic that formats the url flattens these out using `Number(['123'])` resulting in `123` or we would have probably caught this earlier. https://github.com/ampproject/amphtml/blob/242e092ff440aa70334a4fdf9b06362c4a69ac56/ads/google/a4a/utils.js#L724 This means that it appears we are running client side diversions and see an equal split on rasta even though client side the logic is not actually diverted.

We also sometimes pass an array as the experiment name to the object, but it has no effect as the native object code casts these to strings for us. 

This fixes the formatting, and introduces a couple of tests to hopefully catch this in the future. This does raise some concern that some of our previous client side exps may have been invalid.
