### PR TITLE
🐛 Don't throw errors for unsupported metrics APIs in amp-analytics

### DIFF
--- a/src/service/performance-impl.js
+++ b/src/service/performance-impl.js
@@ -121,10 +121,7 @@ export class Performance {
 
     // If Paint Timing API is not supported, cannot determine first contentful paint
     if (!supportedEntryTypes.includes('paint')) {
-      this.metrics_.rejectSignal(
-        TickLabel.FIRST_CONTENTFUL_PAINT,
-        new Error('First Contentful Paint not supported')
-      );
+      this.metrics_.rejectSignal(TickLabel.FIRST_CONTENTFUL_PAINT);
     }
 
     /**
@@ -136,10 +133,7 @@ export class Performance {
     this.supportsLayoutShift_ = supportedEntryTypes.includes('layout-shift');
 
     if (!this.supportsLayoutShift_) {
-      this.metrics_.rejectSignal(
-        TickLabel.CUMULATIVE_LAYOUT_SHIFT,
-        new Error('Cumulative Layout Shift not supported')
-      );
+      this.metrics_.rejectSignal(TickLabel.CUMULATIVE_LAYOUT_SHIFT);
     }
 
     /**
@@ -151,10 +145,7 @@ export class Performance {
     this.supportsEventTiming_ = supportedEntryTypes.includes('first-input');
 
     if (!this.supportsEventTiming_) {
-      this.metrics_.rejectSignal(
-        TickLabel.FIRST_INPUT_DELAY,
-        new Error('First Input Delay not supported')
-      );
+      this.metrics_.rejectSignal(TickLabel.FIRST_INPUT_DELAY);
     }
 
     /**
@@ -167,10 +158,7 @@ export class Performance {
     );
 
     if (!this.supportsLargestContentfulPaint_) {
-      this.metrics_.rejectSignal(
-        TickLabel.LARGEST_CONTENTFUL_PAINT_VISIBLE,
-        new Error('Largest Contentful Paint not supported')
-      );
+      this.metrics_.rejectSignal(TickLabel.LARGEST_CONTENTFUL_PAINT_VISIBLE);
     }
 
     /**

--- a/src/service/performance-impl.js
+++ b/src/service/performance-impl.js
@@ -121,7 +121,10 @@ export class Performance {
 
     // If Paint Timing API is not supported, cannot determine first contentful paint
     if (!supportedEntryTypes.includes('paint')) {
-      this.metrics_.rejectSignal(TickLabel.FIRST_CONTENTFUL_PAINT);
+      this.metrics_.rejectSignal(
+        TickLabel.FIRST_CONTENTFUL_PAINT,
+        dev().createExpectedError('First Contentful Paint not supported')
+      );
     }
 
     /**
@@ -133,7 +136,10 @@ export class Performance {
     this.supportsLayoutShift_ = supportedEntryTypes.includes('layout-shift');
 
     if (!this.supportsLayoutShift_) {
-      this.metrics_.rejectSignal(TickLabel.CUMULATIVE_LAYOUT_SHIFT);
+      this.metrics_.rejectSignal(
+        TickLabel.CUMULATIVE_LAYOUT_SHIFT,
+        dev().createExpectedError('Cumulative Layout Shift not supported')
+      );
     }
 
     /**
@@ -145,7 +151,10 @@ export class Performance {
     this.supportsEventTiming_ = supportedEntryTypes.includes('first-input');
 
     if (!this.supportsEventTiming_) {
-      this.metrics_.rejectSignal(TickLabel.FIRST_INPUT_DELAY);
+      this.metrics_.rejectSignal(
+        TickLabel.FIRST_INPUT_DELAY,
+        dev().createExpectedError('First Input Delay not supported')
+      );
     }
 
     /**
@@ -158,7 +167,10 @@ export class Performance {
     );
 
     if (!this.supportsLargestContentfulPaint_) {
-      this.metrics_.rejectSignal(TickLabel.LARGEST_CONTENTFUL_PAINT_VISIBLE);
+      this.metrics_.rejectSignal(
+        TickLabel.LARGEST_CONTENTFUL_PAINT_VISIBLE,
+        dev().createExpectedError('Largest Contentful Paint not supported')
+      );
     }
 
     /**

--- a/src/utils/signals.js
+++ b/src/utils/signals.js
@@ -126,6 +126,7 @@ export class Signals {
     const promiseStruct = this.promiseMap_ && this.promiseMap_[name];
     if (promiseStruct && promiseStruct.reject) {
       promiseStruct.reject(error);
+      promiseStruct.promise.catch(() => {});
       promiseStruct.resolve = undefined;
       promiseStruct.reject = undefined;
     }

--- a/test/unit/test-performance.js
+++ b/test/unit/test-performance.js
@@ -1309,19 +1309,6 @@ describes.realWin('PeformanceObserver metrics', {amp: true}, (env) => {
       const value = await perf.getMetric('mbv');
       expect(value).to.eq(1);
     });
-
-    describe('when API not supported', () => {
-      it('throws an error', async () => {
-        const perf = getPerformance();
-        try {
-          await perf.getMetric('lcpv');
-        } catch (error) {
-          expect(error.message).to.equal(
-            'Largest Contentful Paint not supported'
-          );
-        }
-      });
-    });
   });
 
   describe('forwards navigation metrics', () => {


### PR DESCRIPTION
Per discussion this is expected and should not throw an error 