### PR TITLE
Removes Collab Summit banner from README, adds Q3 survey link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,7 @@
 
 ⚡⚡⚡
 
-**Join other AMP contributors at the online OpenJS World & Collab Summit June 22-26! [Register](https://events.linuxfoundation.org/openjs-world/register/) today!**
-
-- OpenJS World (June 23 & 24) is the [OpenJS Foundation](https://openjsf.org/)’s annual event, bringing together the JavaScript and web ecosystem including Node.js, Electron, AMP and more. See the [schedule](https://events.linuxfoundation.org/openjs-world/program/schedule/) for details.
-- OpenJS Collab Summit (June 22, 25 & 26) provides an opportunity for contributors and maintainers working across all OpenJS Foundation projects to collaborate in real-time, share, learn, and get to know each other. **This year the AMP Contributor Summit has been merged into the OpenJS Collab Summit. See [AMP's talk and breakout session schedule](https://docs.google.com/spreadsheets/d/1GY9qNrjxM6Ro-jFSGscL11sKQA46msRMdSrQMhTL8K0/edit#gid=461228868); note that all times are Central US (UTC-5).**
-
-Please join the [#openjsworld2020](https://app.slack.com/client/T0ADHJGD6/C015JF065K5) channel on [AMP's Slack](https://bit.ly/amp-slack-signup) for the latest summit news and to stay in touch during the summit.
+Do you build things with AMP? If you do, please fill out the new [AMP Developer Survey](https://go.amp.dev/devx-survey)! We run this survey quarterly, so please fill this out even if you've responded to earlier surveys!
 
 ⚡⚡⚡
 


### PR DESCRIPTION
This removes the Collab Summit banner from README.md, and adds the Q3 survey link.