### PR TITLE
🏗 Reduce JSON.stringify cost during Closure Compilation

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@babel/plugin-transform-react-jsx": "7.10.1",
     "@babel/preset-env": "7.10.2",
     "@jest/core": "26.1.0",
-    "@kristoferbaxter/google-closure-compiler": "20200517.1.0",
+    "@kristoferbaxter/google-closure-compiler": "20200517.2.1",
     "@types/minimist": "1.2.0",
     "acorn-globals": "6.0.0",
     "amphtml-validator": "1.0.31",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1965,34 +1965,34 @@
   resolved "https://registry.yarnpkg.com/@kristoferbaxter/async/-/async-1.0.0.tgz#33c8e8c6b055f15f4ee8a711b9594336a6fb1671"
   integrity sha512-CAQQQ8mUUBKI2P7stYojHwHb+ShdFN8SrC90/96V4m2XlDSctXAA+5PD5CqCICs0o5c/83cYJCeub+FSetKLrw==
 
-"@kristoferbaxter/google-closure-compiler-java@^20200517.1.0":
-  version "20200517.1.0"
-  resolved "https://registry.yarnpkg.com/@kristoferbaxter/google-closure-compiler-java/-/google-closure-compiler-java-20200517.1.0.tgz#11f5783079c8492c772c8db0fd699788acb7da7a"
-  integrity sha512-ise8+sOtDD5OJP0ZegmuJTrKlioMhPrQf80fy5NthuEmdHd4LCRtjt0Xo4IEkG/NhC9hzSB1oNuAuiEoJrEUlQ==
+"@kristoferbaxter/google-closure-compiler-java@^20200517.2.1":
+  version "20200517.2.1"
+  resolved "https://registry.yarnpkg.com/@kristoferbaxter/google-closure-compiler-java/-/google-closure-compiler-java-20200517.2.1.tgz#8866ab3e0f68f97d23e0e697273e13295bca4004"
+  integrity sha512-F5fCeJRJU6Y7vAkwrul7tWYqrblYjv8yZPAtu6wGSIz7EAcHcDSKjjiEf+HnF2Ug7hDCqXIZ6TWLhESL8R+LmA==
 
-"@kristoferbaxter/google-closure-compiler-linux@^20200517.1.0":
-  version "20200517.1.0"
-  resolved "https://registry.yarnpkg.com/@kristoferbaxter/google-closure-compiler-linux/-/google-closure-compiler-linux-20200517.1.0.tgz#a835691e834afe2dca7ba33c84a739a688a42368"
-  integrity sha512-ukg+QE9BAVnA7qVdxcVqQxliYcyMX4o5RbEtCzSV8I/aMaNFKKrBsJz99cZF5KBkXWKZvfmeDtzNdAZa4HFyMQ==
+"@kristoferbaxter/google-closure-compiler-linux@^20200517.2.1":
+  version "20200517.2.1"
+  resolved "https://registry.yarnpkg.com/@kristoferbaxter/google-closure-compiler-linux/-/google-closure-compiler-linux-20200517.2.1.tgz#7662faa00bded6ecd9e92f6084464eb0d96489e8"
+  integrity sha512-GK3Lucxza4Qm631uqyADMkiy4Zsswi153cTCobCV6TR5znwCGxQL1VajoMvFH4DZ5R/qB0x1zTuczQO1/y8keA==
 
-"@kristoferbaxter/google-closure-compiler-osx@^20200517.1.0":
-  version "20200517.1.0"
-  resolved "https://registry.yarnpkg.com/@kristoferbaxter/google-closure-compiler-osx/-/google-closure-compiler-osx-20200517.1.0.tgz#c5c75c7b87c00a2194b427aa1f753e56f8e62f55"
-  integrity sha512-QlO7ODst4xZDHkMkCB9tE+KzTHJ4an1ph5CtEVCOU+kFb1OmEk/ALO5gOckg67Fa0T0QkgIk5Pwn9MXHt+QfVw==
+"@kristoferbaxter/google-closure-compiler-osx@^20200517.2.1":
+  version "20200517.2.1"
+  resolved "https://registry.yarnpkg.com/@kristoferbaxter/google-closure-compiler-osx/-/google-closure-compiler-osx-20200517.2.1.tgz#1180752ed336bf52ae8ee1b4953909299bbc2351"
+  integrity sha512-BbfiuqYMqBaSq5SoB+poGBheiP/m0l6tH4Bbh0ytTipxUVCLw0MFqoFVBOiIfEWoUtAwcGTcCUBBalP0xe0BcA==
 
-"@kristoferbaxter/google-closure-compiler@20200517.1.0":
-  version "20200517.1.0"
-  resolved "https://registry.yarnpkg.com/@kristoferbaxter/google-closure-compiler/-/google-closure-compiler-20200517.1.0.tgz#c56c43672f3e6b2b339c5745b99b3804debcfb55"
-  integrity sha512-8QS5ZiJDY2LtXJksX/kUPiOyXUsgfhVgkPIh/3g2oYWrt5bxUoo3aJpcFFcwhgXzttRBKNcFpieyqZ8joMmeAg==
+"@kristoferbaxter/google-closure-compiler@20200517.2.1":
+  version "20200517.2.1"
+  resolved "https://registry.yarnpkg.com/@kristoferbaxter/google-closure-compiler/-/google-closure-compiler-20200517.2.1.tgz#d5b0f3231261139ac1ae32134052ce4515ba7751"
+  integrity sha512-2bI8PEob/vbadAw3+wMDjLmmllj5gw/+xiML/HjHyCOzxEh3UZaYRuFczy50BTYC99H+Odsh3RQ4Ulp0BFs2Kg==
   dependencies:
-    "@kristoferbaxter/google-closure-compiler-java" "^20200517.1.0"
+    "@kristoferbaxter/google-closure-compiler-java" "^20200517.2.1"
     kleur "4.0.2"
     minimist "1.x"
     vinyl "2.x"
     vinyl-sourcemaps-apply "^0.2.0"
   optionalDependencies:
-    "@kristoferbaxter/google-closure-compiler-linux" "^20200517.1.0"
-    "@kristoferbaxter/google-closure-compiler-osx" "^20200517.1.0"
+    "@kristoferbaxter/google-closure-compiler-linux" "^20200517.2.1"
+    "@kristoferbaxter/google-closure-compiler-osx" "^20200517.2.1"
 
 "@nodelib/fs.scandir@2.1.2":
   version "2.1.2"


### PR DESCRIPTION
Caches some input file JSON.stringify output to reduce the repetition in stringifying the same content.