### PR TITLE
📖 clarify isAdPositionAllowed

### DIFF
--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -612,7 +612,7 @@ export class AmpA4A extends AMP.BaseElement {
       user().warn(
         TAG,
         `<${this.element.tagName}> is not allowed to be ` +
-          `placed in elements with position:fixed: ${this.element}`
+          `placed in elements with position: fixed or sticky: ${this.element}`
       );
       return false;
     }


### PR DESCRIPTION
User warning indicates only `position: fixed` is disallowed, but this line indicates `position: sticky` is also disallowed: https://github.com/ampproject/amphtml/blob/master/src/ad-helper.js#L44. While `sticky` is similar to `fixed`, it's a separate css value, and should be specified, given the phrasing of the warning. This might resolve some confusions.