### PR TITLE
✨ [amp-social-share][bento] Duplicate target logic from amp component to bento

### DIFF
--- a/extensions/amp-social-share/1.0/social-share.js
+++ b/extensions/amp-social-share/1.0/social-share.js
@@ -160,11 +160,11 @@ function handleActivation(finalEndpoint, target) {
         `Could not complete system share.  Navigator unavailable. ${NAME}`
       );
     }
-  } else if (protocol === 'sms') {
+  } else if (protocol === 'sms' || protocol === 'mailto') {
     openWindowDialog(
       window,
-      finalEndpoint.replace('?', '?&'),
-      target,
+      protocol === 'sms' ? finalEndpoint.replace('?', '?&') : finalEndpoint,
+      isIos() ? '_top' : target,
       windowFeatures
     );
   } else {
@@ -183,6 +183,20 @@ function getQueryString(endpoint) {
   q = q === -1 ? endpoint.length : q;
   h = h === -1 ? endpoint.length : h;
   return endpoint.slice(q, h);
+}
+
+/**
+ * Checks whether or not the userAgent of the current device indicates
+ * that this is an Ios device
+ * @return {boolean}
+ */
+function isIos() {
+  return (
+    window &&
+    window.navigator &&
+    window.navigator.userAgent &&
+    window.navigator.userAgent.search(/iPhone|iPad|iPod/i) >= 0
+  );
 }
 
 /**

--- a/extensions/amp-social-share/1.0/social-share.js
+++ b/extensions/amp-social-share/1.0/social-share.js
@@ -192,12 +192,10 @@ function getQueryString(endpoint) {
  * @return {boolean}
  */
 function isIos() {
-  return (
-    window &&
+  return /** @type {boolean} */ (window &&
     window.navigator &&
     window.navigator.userAgent &&
-    window.navigator.userAgent.search(/iPhone|iPad|iPod/i) >= 0
-  );
+    window.navigator.userAgent.search(/iPhone|iPad|iPod/i) >= 0);
 }
 
 /**

--- a/extensions/amp-social-share/1.0/social-share.js
+++ b/extensions/amp-social-share/1.0/social-share.js
@@ -186,8 +186,9 @@ function getQueryString(endpoint) {
 }
 
 /**
- * Checks whether or not the userAgent of the current device indicates
- * that this is an Ios device
+ * Checks whether or not the userAgent of the current device indicates that
+ * this is an Ios device.  Checked for 'mailto:' and 'sms:' protocols which
+ * break when opened in _blank on iOS Safari.
  * @return {boolean}
  */
 function isIos() {


### PR DESCRIPTION
Added additional check for userAgent in Preact component (execute during click)
Does a regex against window.navigator.userAgent which is the same way its checked in AMP
Did not remove check on AMP side (in case only AMP has access to userAgent)
AMP implementation: https://github.com/ampproject/amphtml/blob/master/src/service/platform-impl.js#L47