### PR TITLE
Pause/play Story level background audio on viewer/tab visibility change.

### DIFF
--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -471,6 +471,7 @@ export class AmpStory extends AMP.BaseElement {
       StateProperty.PAUSED_STATE
     );
     this.storeService_.dispatch(Action.TOGGLE_PAUSED, true);
+    this.pauseBackgroundAudio_();
   }
 
   /**
@@ -483,6 +484,7 @@ export class AmpStory extends AMP.BaseElement {
       Action.TOGGLE_PAUSED,
       this.pausedStateToRestore_
     );
+    this.playBackgroundAudio_();
   }
 
   /**


### PR DESCRIPTION
Pause/play Story level background audio on viewer/tab visibility change.

Story level background audio is not bound to the PAUSED state like other page media, as it's meant to play throughout the story without any interruption. But we forgot to play/pause it when the tab becomes inactive, or when the viewer marks the document as inactive.
Repro case: https://jumprope.com/g/amp/fajitas-on-the-double-burner-griddle/inxwgkXJ