### PR TITLE
🐛 Prevent screen reader from announcing img src if alt tag is not specified.

### DIFF
--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -1860,12 +1860,17 @@ export class AmpStoryPage extends AMP.BaseElement {
    * @private
    */
   initializeImgAltTags_() {
-    Array.prototype.forEach.call(
-      this.element.querySelectorAll('amp-img'),
-      (imageTag) => {
-        !imageTag.getAttribute('alt') && imageTag.setAttribute('alt', ' ');
+    toArray(this.element.querySelectorAll('amp-img')).forEach((ampImgNode) => {
+      if (!ampImgNode.getAttribute('alt')) {
+        ampImgNode.setAttribute('alt', ' ');
+        // If the child img element is in the dom, propogate the attribute to it.
+        const childImgNode = ampImgNode.querySelector('img');
+        childImgNode &&
+          ampImgNode
+            .getImpl()
+            .then((ampImg) => ampImg.propagateAttributes('alt', childImgNode));
       }
-    );
+    });
   }
 
   /**

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -361,6 +361,7 @@ export class AmpStoryPage extends AMP.BaseElement {
     );
     this.setPageDescription_();
     this.element.setAttribute('role', 'region');
+    this.initializeImgAltTags_();
   }
 
   /** @private */
@@ -1851,6 +1852,20 @@ export class AmpStoryPage extends AMP.BaseElement {
       }
       this.element.removeAttribute('title');
     }
+  }
+
+  /**
+   * Adds an empty alt tag to amp-img elements if not present.
+   * Prevents screen readers from announcing the img src value.
+   * @private
+   */
+  initializeImgAltTags_() {
+    Array.prototype.forEach.call(
+      this.element.querySelectorAll('amp-img'),
+      (imageTag) => {
+        !imageTag.getAttribute('alt') && imageTag.setAttribute('alt', ' ');
+      }
+    );
   }
 
   /**

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -417,7 +417,7 @@ export class AmpStory extends AMP.BaseElement {
     this.initializeListenersForDev_();
     this.initializePageIds_();
     this.initializeStoryPlayer_();
-    this.initializeAltTags_();
+    this.initializeImgAltTags_();
 
     this.storeService_.dispatch(Action.TOGGLE_UI, this.getUIType_());
 
@@ -1318,7 +1318,7 @@ export class AmpStory extends AMP.BaseElement {
    * Prevents screen readers from announcing the img src value.
    * @private
    */
-  initializeAltTags_() {
+  initializeImgAltTags_() {
     this.element.querySelectorAll('amp-img').forEach((imageTag) => {
       !imageTag.getAttribute('alt') && imageTag.setAttribute('alt', ' ');
     });

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -1319,11 +1319,9 @@ export class AmpStory extends AMP.BaseElement {
    * @private
    */
   initializeAltTags_() {
-    const imageTags = scopedQuerySelectorAll(this.element, 'amp-img');
-
-    for (const imageTag of imageTags) {
+    this.element.querySelectorAll('amp-img').forEach((imageTag) => {
       !imageTag.getAttribute('alt') && imageTag.setAttribute('alt', ' ');
-    }
+    });
   }
 
   /**

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -1319,9 +1319,12 @@ export class AmpStory extends AMP.BaseElement {
    * @private
    */
   initializeImgAltTags_() {
-    Array.from(this.element.querySelectorAll('amp-img')).forEach((imageTag) => {
-      !imageTag.getAttribute('alt') && imageTag.setAttribute('alt', ' ');
-    });
+    Array.prototype.forEach.call(
+      this.element.querySelectorAll('amp-img'),
+      (imageTag) => {
+        !imageTag.getAttribute('alt') && imageTag.setAttribute('alt', ' ');
+      }
+    );
   }
 
   /**

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -417,6 +417,7 @@ export class AmpStory extends AMP.BaseElement {
     this.initializeListenersForDev_();
     this.initializePageIds_();
     this.initializeStoryPlayer_();
+    this.initializeAltTags_();
 
     this.storeService_.dispatch(Action.TOGGLE_UI, this.getUIType_());
 
@@ -1310,6 +1311,19 @@ export class AmpStory extends AMP.BaseElement {
       this.getAmpDoc(),
       'amp-viewer-integration'
     );
+  }
+
+  /**
+   * Adds an empty alt tag to img elements if an alt tag is not present.
+   * Prevents screen readers from announcing the img src value.
+   * @private
+   */
+  initializeAltTags_() {
+    const imageTags = scopedQuerySelectorAll(this.element, 'amp-img');
+
+    for (const imageTag of imageTags) {
+      !imageTag.getAttribute('alt') && imageTag.setAttribute('alt', ' ');
+    }
   }
 
   /**

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -1314,7 +1314,7 @@ export class AmpStory extends AMP.BaseElement {
   }
 
   /**
-   * Adds an empty alt tag to img elements if an alt tag is not present.
+   * Adds an empty alt tag to amp-img elements if not present.
    * Prevents screen readers from announcing the img src value.
    * @private
    */

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -1319,7 +1319,7 @@ export class AmpStory extends AMP.BaseElement {
    * @private
    */
   initializeImgAltTags_() {
-    this.element.querySelectorAll('amp-img').forEach((imageTag) => {
+    Array.from(this.element.querySelectorAll('amp-img')).forEach((imageTag) => {
       !imageTag.getAttribute('alt') && imageTag.setAttribute('alt', ' ');
     });
   }

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -417,7 +417,6 @@ export class AmpStory extends AMP.BaseElement {
     this.initializeListenersForDev_();
     this.initializePageIds_();
     this.initializeStoryPlayer_();
-    this.initializeImgAltTags_();
 
     this.storeService_.dispatch(Action.TOGGLE_UI, this.getUIType_());
 
@@ -1310,20 +1309,6 @@ export class AmpStory extends AMP.BaseElement {
     Services.extensionsFor(this.win).installExtensionForDoc(
       this.getAmpDoc(),
       'amp-viewer-integration'
-    );
-  }
-
-  /**
-   * Adds an empty alt tag to amp-img elements if not present.
-   * Prevents screen readers from announcing the img src value.
-   * @private
-   */
-  initializeImgAltTags_() {
-    Array.prototype.forEach.call(
-      this.element.querySelectorAll('amp-img'),
-      (imageTag) => {
-        !imageTag.getAttribute('alt') && imageTag.setAttribute('alt', ' ');
-      }
     );
   }
 


### PR DESCRIPTION
This prevents screen readers from announcing the `src` value of an image if an `alt` is not specified.

This fix assumes that if publishers do not specify an `alt` their images are [decorative](https://www.w3.org/WAI/tutorials/images/decorative/).

context / fixes #28410