### PR TITLE
amp-autocomplete: Selection `change` event should bubble

### DIFF
--- a/extensions/amp-autocomplete/0.1/amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/amp-autocomplete.js
@@ -1103,20 +1103,6 @@ export class AmpAutocomplete extends AMP.BaseElement {
       ActionTrust.HIGH
     );
 
-    // Ensure on="change" is triggered for input
-    const changeName = 'change';
-    const changeEvent = createCustomEvent(
-      this.win,
-      `amp-autocomplete.${changeName}`,
-      /** @type {!JsonObject} */ ({value})
-    );
-    this.action_.trigger(
-      dev().assertElement(this.inputElement_),
-      changeName,
-      changeEvent,
-      ActionTrust.HIGH
-    );
-
     // Ensure native change listeners are triggered
     const nativeChangeEvent = createCustomEvent(
       this.win,

--- a/extensions/amp-autocomplete/0.1/amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/amp-autocomplete.js
@@ -1121,7 +1121,8 @@ export class AmpAutocomplete extends AMP.BaseElement {
     const nativeChangeEvent = createCustomEvent(
       this.win,
       'change',
-      /** @type {!JsonObject} */ ({value})
+      /** @type {!JsonObject} */ ({value}),
+      {bubbles: true}
     );
     this.inputElement_.dispatchEvent(nativeChangeEvent);
   }

--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -834,8 +834,9 @@ export class ActionService {
   }
 
   /**
-   * Given a browser 'change' or 'input' event, add `details` property to it
-   * containing allowlisted properties of the target element.
+   * Given a browser 'change' or 'input' event, add `detail` property to it
+   * containing allowlisted properties of the target element. Noop if `detail`
+   * is readonly.
    * @param {!ActionEventDef} event
    * @private
    */
@@ -871,7 +872,9 @@ export class ActionService {
     }
 
     if (Object.keys(detail).length > 0) {
-      event.detail = detail;
+      try {
+        event.detail = detail;
+      } catch (e) {}
     }
   }
 }

--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -874,7 +874,7 @@ export class ActionService {
     if (Object.keys(detail).length > 0) {
       try {
         event.detail = detail;
-      } catch (e) {}
+      } catch {} // event.detail is readonly
     }
   }
 }


### PR DESCRIPTION
The `change` event was introduced in #26273 but did not bubble by default -- this PR changes the event init options to do just that.

Coincidentally, because this is a DOM `change` event on an `input` field, this also fires an AMP `change` event automatically from the action service: 
https://github.com/ampproject/amphtml/blob/984f380f9e6f9f2c9fed07956fc69c34bf15a8e2/src/service/action-impl.js#L358-L363

Therefore this PR also does the following:

- catches errors thrown when modifying `readonly` `detail` from programmatic events
- removes the explicit AMP `change` event fired in the amp-autocomplete (otherwise it will get fired twice)