### PR TITLE
Change experiment setting to arrays

### DIFF
--- a/ads/google/a4a/experiment-utils.js
+++ b/ads/google/a4a/experiment-utils.js
@@ -63,12 +63,13 @@ export class ExperimentUtils {
    * @return {?string}
    */
   maybeSelectExperiment(win, element, selectionBranches, experimentName) {
-    const experimentInfoMap = /** @type {!Object<string, !ExperimentInfo>} */ ({});
-    experimentInfoMap[experimentName] = {
+    const experimentInfoList = /** @type {!Array<!ExperimentInfo>} */ ([]);
+    experimentInfoList.push({
+      experimentId: experimentName,
       isTrafficEligible: () => true,
       branches: selectionBranches,
-    };
-    randomlySelectUnsetExperiments(win, experimentInfoMap);
+    });
+    randomlySelectUnsetExperiments(win, experimentInfoList);
     return getExperimentBranch(win, experimentName);
   }
 }

--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -20,7 +20,7 @@
 // Most other ad networks will want to put their A4A code entirely in the
 // extensions/amp-ad-network-${NETWORK_NAME}-impl directory.
 
-import {EXPERIMENT_INFO_MAP as AMPDOC_FIE_EXPERIMENT_INFO_MAP} from '../../../src/ampdoc-fie';
+import {EXPERIMENT_INFO_LIST as AMPDOC_FIE_EXPERIMENT_INFO_LIST} from '../../../src/ampdoc-fie';
 import {AdsenseSharedState} from './adsense-shared-state';
 import {AmpA4A, NO_SIGNING_EXP} from '../../amp-a4a/0.1/amp-a4a';
 import {CONSENT_POLICY_STATE} from '../../../src/consent-state';
@@ -210,29 +210,33 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
    * @visibleForTesting
    */
   divertExperiments() {
-    const experimentInfoMap = /** @type {!Object<string,
-        !../../../src/experiments.ExperimentInfo>} */ ({
-      [RENDER_ON_IDLE_FIX_EXP.id]: {
+    const experimentInfoList = /** @type {!Array<!../../../src/experiments.ExperimentInfo>} */ ([
+      {
+        experimentId: RENDER_ON_IDLE_FIX_EXP.id,
         isTrafficEligible: () => true,
         branches: [
           RENDER_ON_IDLE_FIX_EXP.control,
           RENDER_ON_IDLE_FIX_EXP.experiment,
         ],
       },
-      [NO_SIGNING_EXP.id]: {
+      {
+        experimentId: NO_SIGNING_EXP.id,
         isTrafficEligible: () => true,
         branches: [NO_SIGNING_EXP.control, NO_SIGNING_EXP.experiment],
       },
-      [STICKY_AD_PADDING_BOTTOM_EXP.id]: {
+      {
+        experimentId: STICKY_AD_PADDING_BOTTOM_EXP.id,
         isTrafficEligible: () => true,
         branches: [
           STICKY_AD_PADDING_BOTTOM_EXP.control,
           STICKY_AD_PADDING_BOTTOM_EXP.experiment,
         ],
       },
-      ...AMPDOC_FIE_EXPERIMENT_INFO_MAP,
-    });
-    const setExps = randomlySelectUnsetExperiments(this.win, experimentInfoMap);
+    ]).concat(AMPDOC_FIE_EXPERIMENT_INFO_LIST);
+    const setExps = randomlySelectUnsetExperiments(
+      this.win,
+      experimentInfoList
+    );
     Object.keys(setExps).forEach((expName) =>
       addExperimentIdToElement(setExps[expName], this.element)
     );

--- a/extensions/amp-ad-network-adsense-impl/0.1/responsive-state.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/responsive-state.js
@@ -415,18 +415,18 @@ export class ResponsiveState {
    * @return {boolean}
    */
   static isInAdSizeOptimizationExperimentBranch_(element) {
-    const experimentInfoMap = /** @type {!Object<string,
-        !../../../src/experiments.ExperimentInfo>} */ ({
-      [[AD_SIZE_OPTIMIZATION_EXP.branch]]: {
+    const experimentInfoList = /** @type {!Array<!../../../src/experiments.ExperimentInfo>} */ ([
+      {
+        experimentId: AD_SIZE_OPTIMIZATION_EXP.branch,
         isTrafficEligible: () => true,
         branches: [
-          [AD_SIZE_OPTIMIZATION_EXP.control],
-          [AD_SIZE_OPTIMIZATION_EXP.experiment],
+          AD_SIZE_OPTIMIZATION_EXP.control,
+          AD_SIZE_OPTIMIZATION_EXP.experiment,
         ],
       },
-    });
+    ]);
     const win = toWin(element.ownerDocument.defaultView);
-    const setExps = randomlySelectUnsetExperiments(win, experimentInfoMap);
+    const setExps = randomlySelectUnsetExperiments(win, experimentInfoList);
     Object.keys(setExps).forEach((expName) =>
       addExperimentIdToElement(setExps[expName], element)
     );
@@ -442,16 +442,16 @@ export class ResponsiveState {
    * @private
    */
   isInResponsiveHeightFixExperimentBranch_() {
-    const experimentInfoMap = /** @type {!Object<string,
-        !../../../src/experiments.ExperimentInfo>} */ ({
-      [[MAX_HEIGHT_EXP.branch]]: {
+    const experimentInfoList = /** @type {!Array<!../../../src/experiments.ExperimentInfo>} */ ([
+      {
+        experimentId: MAX_HEIGHT_EXP.branch,
         isTrafficEligible: () => true,
-        branches: [[MAX_HEIGHT_EXP.control], [MAX_HEIGHT_EXP.experiment]],
+        branches: [MAX_HEIGHT_EXP.control, MAX_HEIGHT_EXP.experiment],
       },
-    });
+    ]);
     const setExps = randomlySelectUnsetExperiments(
       this.win_,
-      experimentInfoMap
+      experimentInfoList
     );
     Object.keys(setExps).forEach((expName) =>
       addExperimentIdToElement(setExps[expName], this.element_)

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -21,7 +21,7 @@
 // extensions/amp-ad-network-${NETWORK_NAME}-impl directory.
 
 import '../../amp-a4a/0.1/real-time-config-manager';
-import {EXPERIMENT_INFO_MAP as AMPDOC_FIE_EXPERIMENT_INFO_MAP} from '../../../src/ampdoc-fie';
+import {EXPERIMENT_INFO_LIST as AMPDOC_FIE_EXPERIMENT_INFO_LIST} from '../../../src/ampdoc-fie';
 import {
   AmpA4A,
   ConsentTupleDef,
@@ -436,8 +436,9 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
         this.experimentIds.push(forcedExperimentId);
       }
     }
-    const experimentInfoMap = /** @type {!Object<string, !../../../src/experiments.ExperimentInfo>} */ ({
-      [DOUBLECLICK_SRA_EXP]: {
+    const experimentInfoList = /** @type {!Array<!../../../src/experiments.ExperimentInfo>} */ ([
+      {
+        experimentId: DOUBLECLICK_SRA_EXP,
         isTrafficEligible: () =>
           !forcedExperimentId &&
           !this.win.document./*OK*/ querySelector(
@@ -449,45 +450,50 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
           (key) => DOUBLECLICK_SRA_EXP_BRANCHES[key]
         ),
       },
-      [ZINDEX_EXP]: {
+      {
+        experimentId: ZINDEX_EXP,
         isTrafficEligible: () => true,
         branches: Object.values(ZINDEX_EXP_BRANCHES),
       },
-      [RANDOM_SUBDOMAIN_SAFEFRAME_EXP]: {
+      {
+        experimentId: RANDOM_SUBDOMAIN_SAFEFRAME_EXP,
         isTrafficEligible: () => true,
         branches: [
           RANDOM_SUBDOMAIN_SAFEFRAME_BRANCHES.CONTROL,
           RANDOM_SUBDOMAIN_SAFEFRAME_BRANCHES.EXPERIMENT,
         ],
       },
-      [EXPAND_JSON_TARGETING_EXP.ID]: {
+      {
+        experimentId: EXPAND_JSON_TARGETING_EXP.ID,
         isTrafficEligible: () => true,
         branches: [
           EXPAND_JSON_TARGETING_EXP.CONTROL,
           EXPAND_JSON_TARGETING_EXP.EXPERIMENT,
         ],
       },
-      [RENDER_ON_IDLE_FIX_EXP.id]: {
+      {
+        experimentId: RENDER_ON_IDLE_FIX_EXP.id,
         isTrafficEligible: () => true,
         branches: [
           RENDER_ON_IDLE_FIX_EXP.control,
           RENDER_ON_IDLE_FIX_EXP.experiment,
         ],
       },
-      [NO_SIGNING_EXP.id]: {
+      {
+        experimentId: NO_SIGNING_EXP.id,
         isTrafficEligible: () => true,
         branches: [NO_SIGNING_EXP.control, NO_SIGNING_EXP.experiment],
       },
-      [STICKY_AD_PADDING_BOTTOM_EXP.id]: {
+      {
+        experimentId: STICKY_AD_PADDING_BOTTOM_EXP.id,
         isTrafficEligible: () => true,
         branches: [
           STICKY_AD_PADDING_BOTTOM_EXP.control,
           STICKY_AD_PADDING_BOTTOM_EXP.experiment,
         ],
       },
-      ...AMPDOC_FIE_EXPERIMENT_INFO_MAP,
-    });
-    const setExps = this.randomlySelectUnsetExperiments_(experimentInfoMap);
+    ]).concat(AMPDOC_FIE_EXPERIMENT_INFO_LIST);
+    const setExps = this.randomlySelectUnsetExperiments_(experimentInfoList);
     Object.keys(setExps).forEach(
       (expName) => setExps[expName] && this.experimentIds.push(setExps[expName])
     );
@@ -498,11 +504,11 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
 
   /**
    * For easier unit testing.
-   * @param {!Object<string, !../../../src/experiments.ExperimentInfo>} experimentInfoMap
+   * @param {!Array<!../../../src/experiments.ExperimentInfo>} experimentInfoList
    * @return {!Object<string, string>}
    */
-  randomlySelectUnsetExperiments_(experimentInfoMap) {
-    return randomlySelectUnsetExperiments(this.win, experimentInfoMap);
+  randomlySelectUnsetExperiments_(experimentInfoList) {
+    return randomlySelectUnsetExperiments(this.win, experimentInfoList);
   }
 
   /**

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -1927,9 +1927,8 @@ describes.realWin(
           impl.setPageLevelExperiments();
           // args format is call array followed by parameter array so expect
           // first call, first param.
-          experimentInfoMap =
-            randomlySelectUnsetExperimentsStub.args[0][0]['doubleclickSraExp'];
-          expect(experimentInfoMap).to.be.ok;
+          experimentInfoMap = randomlySelectUnsetExperimentsStub.args[0][0][0];
+          expect(experimentInfoMap.experimentId).to.equal('doubleclickSraExp');
           expect(impl.useSra).to.be.false;
         });
 

--- a/extensions/amp-sticky-ad/1.0/amp-sticky-ad.js
+++ b/extensions/amp-sticky-ad/1.0/amp-sticky-ad.js
@@ -66,17 +66,17 @@ class AmpStickyAd extends AMP.BaseElement {
 
     // Setting padding-bottom to avoid iPhone home bar
     if (isExperimentOn(this.win, 'sticky-ad-padding-bottom')) {
-      const experimentInfoMap = /** @type {!Object<string,
-        !../../../src/experiments.ExperimentInfo>} */ ({
-        [STICKY_AD_PADDING_BOTTOM_EXP.id]: {
+      const experimentInfoList = /** @type {!Array<!../../../src/experiments.ExperimentInfo>} */ ([
+        {
+          experimentId: STICKY_AD_PADDING_BOTTOM_EXP.id,
           isTrafficEligible: () => true,
           branches: [
             STICKY_AD_PADDING_BOTTOM_EXP.control,
             STICKY_AD_PADDING_BOTTOM_EXP.experiment,
           ],
         },
-      });
-      randomlySelectUnsetExperiments(this.win, experimentInfoMap);
+      ]);
+      randomlySelectUnsetExperiments(this.win, experimentInfoList);
       if (
         getExperimentBranch(this.win, STICKY_AD_PADDING_BOTTOM_EXP.id) ==
         STICKY_AD_PADDING_BOTTOM_EXP.experiment

--- a/src/ampdoc-fie.js
+++ b/src/ampdoc-fie.js
@@ -35,14 +35,15 @@ const EXPERIMENT = {
 };
 
 /**
- * @const {!Object<string, !./experiments.ExperimentInfo>}
+ * @const {!Array<!./experiments.ExperimentInfo>}
  */
-export const EXPERIMENT_INFO_MAP = {
-  [EXPERIMENT_ID]: {
+export const EXPERIMENT_INFO_LIST = [
+  {
+    experimentId: EXPERIMENT_ID,
     isTrafficEligible: () => true,
     branches: [EXPERIMENT.control, EXPERIMENT.experiment],
   },
-};
+];
 
 /**
  * @param {!Window} win
@@ -61,6 +62,6 @@ export function isInAmpdocFieExperiment(win) {
   if (!isExperimentOn(win, 'ampdoc-fie')) {
     return false;
   }
-  randomlySelectUnsetExperiments(win, EXPERIMENT_INFO_MAP);
+  randomlySelectUnsetExperiments(win, EXPERIMENT_INFO_LIST);
   return getExperimentBranch(win, EXPERIMENT_ID) === EXPERIMENT.experiment;
 }

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -1213,17 +1213,17 @@ export class ResourcesImpl {
       return;
     }
     this.divertedRenderOnIdleFixExperiment_ = true;
-    const experimentInfoMap = /** @type {!Object<string,
-        !../experiments.ExperimentInfo>} */ ({
-      [RENDER_ON_IDLE_FIX_EXP.id]: {
+    const experimentInfoList = /** @type {!Array<!../experiments.ExperimentInfo>} */ ([
+      {
+        experimentId: RENDER_ON_IDLE_FIX_EXP.id,
         isTrafficEligible: () => true,
         branches: [
           RENDER_ON_IDLE_FIX_EXP.control,
           RENDER_ON_IDLE_FIX_EXP.experiment,
         ],
       },
-    });
-    randomlySelectUnsetExperiments(this.win, experimentInfoMap);
+    ]);
+    randomlySelectUnsetExperiments(this.win, experimentInfoList);
   }
 
   /**

--- a/test/unit/test-experiments.js
+++ b/test/unit/test-experiments.js
@@ -568,16 +568,17 @@ describe('experiment branch tests', () => {
   describe('#randomlySelectUnsetExperiments', () => {
     let accurateRandomStub;
     let cachedAccuratePrng;
-    let testExperimentSet;
+    let testExperimentList;
 
     beforeEach(() => {
       const experimentFrequency = 1.0;
-      testExperimentSet = {
-        testExperimentId: {
+      testExperimentList = [
+        {
+          experimentId: 'testExperimentId',
           isTrafficEligible: () => true,
           branches: ['branch1_id', 'branch2_id'],
         },
-      };
+      ];
       window.sandbox.win = {
         location: {
           hostname: 'test.server.name.com',
@@ -613,7 +614,7 @@ describe('experiment branch tests', () => {
     it('handles experiment not diverted path', () => {
       // Opt out of experiment.
       toggleExperiment(window.sandbox.win, 'testExperimentId', false, true);
-      randomlySelectUnsetExperiments(window.sandbox.win, testExperimentSet);
+      randomlySelectUnsetExperiments(window.sandbox.win, testExperimentList);
       expect(
         isExperimentOn(window.sandbox.win, 'testExperimentId'),
         'experiment is on'
@@ -628,7 +629,7 @@ describe('experiment branch tests', () => {
       // force the control branch to be chosen by making the accurate PRNG
       // return a value < 0.5.
       RANDOM_NUMBER_GENERATORS.accuratePrng.onFirstCall().returns(0.3);
-      randomlySelectUnsetExperiments(window.sandbox.win, testExperimentSet);
+      randomlySelectUnsetExperiments(window.sandbox.win, testExperimentList);
       expect(
         isExperimentOn(window.sandbox.win, 'testExperimentId'),
         'experiment is on'
@@ -644,7 +645,7 @@ describe('experiment branch tests', () => {
       // Force the experiment branch to be chosen by making the accurate PRNG
       // return a value > 0.5.
       RANDOM_NUMBER_GENERATORS.accuratePrng.onFirstCall().returns(0.6);
-      randomlySelectUnsetExperiments(window.sandbox.win, testExperimentSet);
+      randomlySelectUnsetExperiments(window.sandbox.win, testExperimentList);
       expect(
         isExperimentOn(window.sandbox.win, 'testExperimentId'),
         'experiment is on'
@@ -657,14 +658,15 @@ describe('experiment branch tests', () => {
     it('picks a branch if traffic eligible', () => {
       toggleExperiment(window.sandbox.win, 'expt_0', true, true);
       window.sandbox.win.trafficEligible = true;
-      const experimentInfo = {
-        'expt_0': {
+      const experimentInfo = [
+        {
+          experimentId: 'expt_0',
           isTrafficEligible: (win) => {
             return win.trafficEligible;
           },
           branches: ['0_0', '0_1'],
         },
-      };
+      ];
       RANDOM_NUMBER_GENERATORS.accuratePrng.returns(0.3);
       randomlySelectUnsetExperiments(window.sandbox.win, experimentInfo);
       expect(isExperimentOn(window.sandbox.win, 'expt_0')).to.be.true;
@@ -674,14 +676,15 @@ describe('experiment branch tests', () => {
     it("doesn't pick a branch if traffic ineligible", () => {
       toggleExperiment(window.sandbox.win, 'expt_0', true, true);
       window.sandbox.win.trafficEligible = false;
-      const experimentInfo = {
-        'expt_0': {
+      const experimentInfo = [
+        {
+          experimentId: 'expt_0',
           isTrafficEligible: (win) => {
             return win.trafficEligible;
           },
           branches: ['0_0', '0_1'],
         },
-      };
+      ];
       RANDOM_NUMBER_GENERATORS.accuratePrng.returns(0.3);
       randomlySelectUnsetExperiments(window.sandbox.win, experimentInfo);
       expect(isExperimentOn(window.sandbox.win, 'expt_0')).to.be.true;
@@ -690,12 +693,13 @@ describe('experiment branch tests', () => {
 
     it("doesn't pick a branch if no traffic eligibility function", () => {
       toggleExperiment(window.sandbox.win, 'expt_0', true, true);
-      const experimentInfo = {
-        'expt_0': {
+      const experimentInfo = [
+        {
+          experimentId: 'expt_0',
           isTrafficEligible: undefined,
           branches: ['0_0', '0_1'],
         },
-      };
+      ];
       RANDOM_NUMBER_GENERATORS.accuratePrng.returns(0.3);
       randomlySelectUnsetExperiments(window.sandbox.win, experimentInfo);
       expect(isExperimentOn(window.sandbox.win, 'expt_0')).to.be.true;
@@ -708,14 +712,15 @@ describe('experiment branch tests', () => {
       () => {
         toggleExperiment(window.sandbox.win, 'expt_0', true, true);
         window.sandbox.win.trafficEligible = false;
-        const experimentInfo = {
-          'expt_0': {
+        const experimentInfo = [
+          {
+            experimentId: 'expt_0',
             isTrafficEligible: (win) => {
               return win.trafficEligible;
             },
             branches: ['0_0', '0_1'],
           },
-        };
+        ];
         RANDOM_NUMBER_GENERATORS.accuratePrng.returns(0.3);
 
         randomlySelectUnsetExperiments(window.sandbox.win, experimentInfo);
@@ -736,21 +741,24 @@ describe('experiment branch tests', () => {
       toggleExperiment(window.sandbox.win, 'expt_2', true, true);
       toggleExperiment(window.sandbox.win, 'expt_3', true, true);
 
-      const experimentInfo = {
-        'expt_0': {
+      const experimentInfo = [
+        {
+          experimentId: 'expt_0',
           isTrafficEligible: () => true,
           branches: ['0_c', '0_e'],
         },
-        'expt_1': {
+        {
+          experimentId: 'expt_1',
           isTrafficEligible: () => true,
           branches: ['1_c', '1_e'],
         },
-        'expt_2': {
+        {
+          experimentId: 'expt_2',
           isTrafficEligible: () => true,
           branches: ['2_c', '2_e'],
         },
         // expt_3 omitted.
-      };
+      ];
       RANDOM_NUMBER_GENERATORS.accuratePrng.returns(0.6);
       randomlySelectUnsetExperiments(window.sandbox.win, experimentInfo);
       expect(isExperimentOn(window.sandbox.win, 'expt_0'), 'expt_0 is on').to.be
@@ -770,12 +778,13 @@ describe('experiment branch tests', () => {
 
     it('handles multi-way branches', () => {
       toggleExperiment(window.sandbox.win, 'expt_0', true, true);
-      const experimentInfo = {
-        'expt_0': {
+      const experimentInfo = [
+        {
+          experimentId: 'expt_0',
           isTrafficEligible: () => true,
           branches: ['0_0', '0_1', '0_2', '0_3', '0_4'],
         },
-      };
+      ];
       RANDOM_NUMBER_GENERATORS.accuratePrng.returns(0.7);
       randomlySelectUnsetExperiments(window.sandbox.win, experimentInfo);
       expect(isExperimentOn(window.sandbox.win, 'expt_0'), 'expt_0 is on').to.be
@@ -789,20 +798,23 @@ describe('experiment branch tests', () => {
       toggleExperiment(window.sandbox.win, 'expt_2', true, true);
       toggleExperiment(window.sandbox.win, 'expt_3', true, true);
 
-      const experimentInfo = {
-        'expt_0': {
+      const experimentInfo = [
+        {
+          experimentId: 'expt_0',
           isTrafficEligible: () => true,
           branches: ['0_0', '0_1', '0_2', '0_3', '0_4'],
         },
-        'expt_1': {
+        {
+          experimentId: 'expt_1',
           isTrafficEligible: () => true,
           branches: ['1_0', '1_1', '1_2', '1_3', '1_4'],
         },
-        'expt_2': {
+        {
+          experimentId: 'expt_2',
           isTrafficEligible: () => true,
           branches: ['2_0', '2_1', '2_2', '2_3', '2_4'],
         },
-      };
+      ];
       RANDOM_NUMBER_GENERATORS.accuratePrng.onFirstCall().returns(0.7);
       RANDOM_NUMBER_GENERATORS.accuratePrng.onSecondCall().returns(0.3);
       randomlySelectUnsetExperiments(window.sandbox.win, experimentInfo);
@@ -822,18 +834,20 @@ describe('experiment branch tests', () => {
     });
 
     it('should not process the same experiment twice', () => {
-      const exptAInfo = {
-        'fooExpt': {
+      const exptAInfo = [
+        {
+          experimentId: 'fooExpt',
           isTrafficEligible: () => true,
           branches: ['012345', '987654'],
         },
-      };
-      const exptBInfo = {
-        'fooExpt': {
+      ];
+      const exptBInfo = [
+        {
+          experimentId: 'fooExpt',
           isTrafficEligible: () => true,
           branches: ['246810', '108642'],
         },
-      };
+      ];
       toggleExperiment(window.sandbox.win, 'fooExpt', false, true);
       randomlySelectUnsetExperiments(window.sandbox.win, exptAInfo);
       randomlySelectUnsetExperiments(window.sandbox.win, exptBInfo);
@@ -860,7 +874,7 @@ describe('experiment branch tests', () => {
       RANDOM_NUMBER_GENERATORS.accuratePrng.onFirstCall().returns(0.3);
       const exps = randomlySelectUnsetExperiments(
         window.sandbox.win,
-        testExperimentSet
+        testExperimentList
       );
       expect(exps).to.deep.equal({'testExperimentId': 'branch1_id'});
     });
@@ -871,20 +885,23 @@ describe('experiment branch tests', () => {
       toggleExperiment(window.sandbox.win, 'expt_2', true, true);
       toggleExperiment(window.sandbox.win, 'expt_3', true, true);
 
-      const experimentInfo = {
-        'expt_0': {
+      const experimentInfo = [
+        {
+          experimentId: 'expt_0',
           isTrafficEligible: () => true,
           branches: ['0_0', '0_1', '0_2', '0_3', '0_4'],
         },
-        'expt_1': {
+        {
+          experimentId: 'expt_1',
           isTrafficEligible: () => true,
           branches: ['1_0', '1_1', '1_2', '1_3', '1_4'],
         },
-        'expt_2': {
+        {
+          experimentId: 'expt_2',
           isTrafficEligible: () => true,
           branches: ['2_0', '2_1', '2_2', '2_3', '2_4'],
         },
-      };
+      ];
       RANDOM_NUMBER_GENERATORS.accuratePrng.onFirstCall().returns(0.7);
       RANDOM_NUMBER_GENERATORS.accuratePrng.onSecondCall().returns(0.3);
       const exps = randomlySelectUnsetExperiments(


### PR DESCRIPTION
There are no strong reasons to use an object/map when defining experiments. This PR changes them to use arrays to prevent possible key name type mismatch problems. It won't by itself solve Closure's problem of not checking the element within object/array.