### PR TITLE
performance-impl: always mark

### DIFF
--- a/src/enums.js
+++ b/src/enums.js
@@ -15,7 +15,7 @@
  */
 
 /**
- * Registred singleton on AMP doc.
+ * Registered singleton on AMP doc.
  * @enum {number}
  */
 export const AMPDOC_SINGLETON_NAME = {

--- a/src/service/performance-impl.js
+++ b/src/service/performance-impl.js
@@ -722,7 +722,7 @@ export class Performance {
     ) {
       return;
     }
-    this.mark_(lable, detail);
+    this.mark_(label, detail);
   }
 
   /**

--- a/src/service/performance-impl.js
+++ b/src/service/performance-impl.js
@@ -707,7 +707,7 @@ export class Performance {
    * These are for example exposed in WPT.
    * See https://developer.mozilla.org/en-US/docs/Web/API/Performance/mark
    * @param {string} label
-   * @param {Object=} detail
+   * @param {*=} detail
    */
   mark(label, detail) {
     // Bail if marking is unsupported.
@@ -722,7 +722,22 @@ export class Performance {
     ) {
       return;
     }
+    this.mark_(lable, detail);
+  }
 
+  /**
+   * A thin wrapper around performance.mark created to minimize the amount of
+   * code with typechecking suppressed. We need to suppress typechecking because
+   * Closure does not know about Performance.prototype.mark's second argument.
+   * 
+   * TODO(samouri): inline this function once Closure's types are updated.
+   *
+   * @suppress {checkTypes}
+   * @param {string} label
+   * @param {*=} detail
+   * @private
+   */
+  mark_(label, detail) {
     this.win.performance.mark(label, {detail});
   }
 

--- a/test/unit/test-performance.js
+++ b/test/unit/test-performance.js
@@ -819,7 +819,6 @@ describes.realWin('PeformanceObserver metrics', {amp: true}, (env) => {
     // offered in fake-dom.js. We can't immediately because
     // document.visibilityState is a read-only property in that object.
     fakeWin = {
-      CustomEvent: env.win.CustomEvent,
       Date: env.win.Date,
       PerformanceObserver: env.sandbox.stub(),
       addEventListener: env.sandbox.stub(),

--- a/test/unit/test-performance.js
+++ b/test/unit/test-performance.js
@@ -824,7 +824,6 @@ describes.realWin('PeformanceObserver metrics', {amp: true}, (env) => {
       PerformanceObserver: env.sandbox.stub(),
       addEventListener: env.sandbox.stub(),
       removeEventListener: env.win.removeEventListener,
-      dispatchEvent: (e) => env.win.dispatchEvent(e),
       document: {
         addEventListener: env.sandbox.stub(),
         hidden: false,


### PR DESCRIPTION
**summary**
Utilizes the secret second argument of performance.mark. It exists in the spec, but not on MDN.
Cleaner than dispatching custom events. For eventual use in `gulp performance`. See https://github.com/ampproject/amphtml/pull/29062.


It makes it simple to then retrieve all of the marks with:
```js
Object.fromEntries(performance
        .getEntriesByType('mark')
        .map((l) => [l.name, l.detail ?? l.startTime]))
```
**appendix**
spec: https://w3c.github.io/user-timing/#extensions-performance-interface