### PR TITLE
🏗🐛 Fix AMP version logic on Windows

### DIFF
--- a/build-system/common/git.js
+++ b/build-system/common/git.js
@@ -197,8 +197,9 @@ function gitCherryMaster() {
  * @return {string}
  */
 function gitCommitFormattedTime(ref = 'HEAD') {
+  const envPrefix = process.platform == 'win32' ? 'set TZ=UTC &&' : 'TZ=UTC';
   return getStdout(
-    `TZ=UTC git log ${ref} -1 --pretty="%cd" --date=format-local:%y%m%d%H%M%S`
+    `${envPrefix} git log ${ref} -1 --pretty="%cd" --date=format-local:%y%m%d%H%M%S`
   ).trim();
 }
 


### PR DESCRIPTION
The logic that determines the runtime version is [broken](https://github.com/ampproject/amphtml/pull/29115/checks?check_run_id=846716418#step:6:22) on Windows because it doesn't recognize Posix style environment variables.

![image](https://user-images.githubusercontent.com/26553114/86976662-f4f93400-c148-11ea-85c7-ab199315a236.png)


This PR fixes versioning on Windows.

