### PR TITLE
POC: using externs for component props

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -311,7 +311,7 @@ module.exports = {
       },
     },
     {
-      'files': ['**/*.extern.js'],
+      'files': ['**/*.extern.js', '**/*.type.js'],
       'rules': {
         'no-var': 0,
         'no-undef': 0,

--- a/extensions/amp-fit-text/1.0/fit-text.js
+++ b/extensions/amp-fit-text/1.0/fit-text.js
@@ -22,16 +22,15 @@ import {useCallback, useLayoutEffect, useRef} from '../../../src/preact';
 const {LINE_HEIGHT_EM_} = styles;
 
 /**
- * @param {!JsonObject} props
+ * @param {!FitTextProps} props
  * @return {PreactDef.Renderable}
  */
-export function FitText(props) {
-  const {
-    'children': children,
-    'minFontSize': minFontSize = 6,
-    'maxFontSize': maxFontSize = 72,
-    ...rest
-  } = props;
+export function FitText({
+  children,
+  minFontSize = 6,
+  maxFontSize = 72,
+  ...rest
+}) {
   const contentRef = useRef(null);
   const measurerRef = useRef(null);
 

--- a/extensions/amp-fit-text/1.0/fit-text.type.js
+++ b/extensions/amp-fit-text/1.0/fit-text.type.js
@@ -16,15 +16,11 @@
 
 /** @externs */
 
-/** @interface */
-class FitTextProps {
-
-  /** @return {number} */
-  get minFontSize() {}
-
-  /** @return {number} */
-  get maxFontSize() {}
-
-  /** @return {?PreactDef.Renderable} */
-  get children() {}
-}
+/**
+ * @typedef {{
+ *   minFontSize: number,
+ *   maxFontSize: number,
+ *   children: ?PreactDef.Renderable,
+ * }}
+ */
+var FitTextProps;

--- a/extensions/amp-fit-text/1.0/fit-text.type.js
+++ b/extensions/amp-fit-text/1.0/fit-text.type.js
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** @externs */
+
+/** @interface */
+class FitTextProps {
+
+  /** @return {number} */
+  get minFontSize() {}
+
+  /** @return {number} */
+  get maxFontSize() {}
+
+  /** @return {?PreactDef.Renderable} */
+  get children() {}
+}

--- a/extensions/amp-fit-text/1.0/fit-text.type.js
+++ b/extensions/amp-fit-text/1.0/fit-text.type.js
@@ -18,9 +18,9 @@
 
 /**
  * @typedef {{
- *   minFontSize: number,
- *   maxFontSize: number,
- *   children: ?PreactDef.Renderable,
+ *   minFontSize: (number|undefined),
+ *   maxFontSize: (number|undefined),
+ *   children: (?PreactDef.Renderable|undefined),
  * }}
  */
 var FitTextProps;

--- a/extensions/amp-fit-text/1.0/fit-text.type.js
+++ b/extensions/amp-fit-text/1.0/fit-text.type.js
@@ -18,8 +18,8 @@
 
 /**
  * @typedef {{
- *   minFontSize: (number|undefined),
- *   maxFontSize: (number|undefined),
+ *   minFontSize: number,
+ *   maxFontSize: number,
  *   children: (?PreactDef.Renderable|undefined),
  * }}
  */


### PR DESCRIPTION
The goal: remove quotes when accessing props fields in components.

The proposal: use closure externs for props types. This is an alternative to a babel plugin that would allow unquoted prop access.

Key points:
1. This requires us to have a separate file like `fit-text.type.js` marked as `@externs` and containing types. This is not a very big burden however, and is similar to the `d.ts` files used elsewhere.
2. `...rest` ends up being an untyped object. But this is usually ok since it's only used to pass it through.
3. For type declarations, we can use either `@interface` or `@typedef`. The reason I went with `@typedef` here is because `@interface` doesn't allow us to access `props['aria-label']`.
4. I tried `@interface` as well. One benefit: it allows `@extends`. However, I think the need for extends would be rare for props.

PTAL and let me know if I might be missing here any nuance with the compiler/obfuscation/linter/etc.
