### PR TITLE
Revert "Enable 'intersect-resources' in 100% of prod"

### DIFF
--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -29,7 +29,7 @@
   "fixed-elements-in-lightbox": 1,
   "flexAdSlots": 0.05,
   "hidden-mutation-observer": 1,
-  "intersect-resources": 1,
+  "intersect-resources": 0.1,
   "ios-fixed-no-transfer": 0,
   "layoutbox-invalidate-on-scroll": 1,
   "pump-early-frame": 1,


### PR DESCRIPTION
Reverts ampproject/amphtml#29049.

Likely culprit of a ~1% query/impression regression, probably because forgot to include [this 25% loading rect expansion](https://github.com/ampproject/amphtml/blob/c2fef917e518c739358d751090a6c2e16d78bc8b/src/service/resources-impl.js#L1388-L1393) in the `IntersectionObserver.rootMargin`. 

Will cherry-pick to RC and try again later.