### PR TITLE
intersect-resources: Add missing 25% loadRect expansion to rootMargin

### DIFF
--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -258,7 +258,8 @@ export class ResourcesImpl {
       try {
         this.intersectionObserver_ = new IntersectionObserver(
           (e) => this.intersect(e),
-          {root, rootMargin: '200% 25%'}
+          // rootMargin matches size of loadRect: (150vw 300vh) * 1.25.
+          {root, rootMargin: '250% 32%'}
         );
 
         // Wait for intersection callback instead of measuring all elements

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -259,7 +259,7 @@ export class ResourcesImpl {
         this.intersectionObserver_ = new IntersectionObserver(
           (e) => this.intersect(e),
           // rootMargin matches size of loadRect: (150vw 300vh) * 1.25.
-          {root, rootMargin: '250% 32%'}
+          {root, rootMargin: '250% 31.25%'}
         );
 
         // Wait for intersection callback instead of measuring all elements


### PR DESCRIPTION
Partial for #25428.

`rootMargin` was missing this: https://github.com/ampproject/amphtml/blob/c2fef917e518c739358d751090a6c2e16d78bc8b/src/service/resources-impl.js#L1388-L1393

Now, according to the comment, it sounds like that code was added back when `loadRect == viewportSize`. But it's live now and anything that deviates causes ads regressions. :)