### PR TITLE
🏗 Refactor `gulp clean` and add logging

### DIFF
--- a/build-system/tasks/clean.js
+++ b/build-system/tasks/clean.js
@@ -46,7 +46,7 @@ async function clean() {
     dryRun: argv.dry_run,
   });
   if (deletedPaths.length > 0) {
-    log(argv.dry_run ? 'Paths that will be deleted:' : 'Deleted paths:');
+    log(argv.dry_run ? "Paths that would've been deleted:" : 'Deleted paths:');
     deletedPaths.forEach((deletedPath) => {
       log('\t' + cyan(path.relative(ROOT_DIR, deletedPath)));
     });

--- a/build-system/tasks/clean.js
+++ b/build-system/tasks/clean.js
@@ -15,28 +15,51 @@
  */
 'use strict';
 
+const argv = require('minimist')(process.argv.slice(2));
 const del = require('del');
+const log = require('fancy-log');
+const path = require('path');
+const {cyan} = require('ansi-colors');
+
+const ROOT_DIR = path.resolve(__dirname, '../../');
 
 /**
- * Clean up the build artifacts
- * @return {!Promise}
+ * Cleans up various build and test artifacts
  */
 async function clean() {
-  return del([
+  const pathsToDelete = [
+    '.amp-build',
+    '.karma-cache',
+    'build',
+    'build-system/server/new-server/transforms/dist',
+    'deps.txt',
     'dist',
     'dist.3p',
     'dist.tools',
-    'build',
-    '.amp-build',
-    '.karma-cache',
-    'deps.txt',
-    'build-system/server/new-server/transforms/dist',
     'test-bin',
-  ]);
+  ];
+  if (argv.include_subpackages) {
+    pathsToDelete.push('**/node_modules', '!node_modules');
+  }
+  const deletedPaths = await del(pathsToDelete, {
+    expandDirectories: true,
+    dryRun: argv.dry_run,
+  });
+  if (deletedPaths.length > 0) {
+    log(argv.dry_run ? 'Paths that will be deleted:' : 'Deleted paths:');
+    deletedPaths.forEach((deletedPath) => {
+      log('\t' + cyan(path.relative(ROOT_DIR, deletedPath)));
+    });
+  }
 }
 
 module.exports = {
   clean,
 };
 
-clean.description = 'Removes build output';
+clean.description = 'Cleans up various build and test artifacts';
+clean.flags = {
+  'dry_run': '  Does a dry run without actually deleting anything',
+  'include_subpackages':
+    '  Also cleans up inner node_modules package directories',
+};


### PR DESCRIPTION
**PR highlights:**
- Refactors `gulp clean` to use `async/await`
- Adds logging for files that were actually deleted
- Adds a `--dry_run` flag to indicate what will be deleted
- Adds a `--include_subpackages` flag to include inner `node_modules` directories that aren't easy to delete manually. (The root `node_modules` directory cannot be deleted because `gulp clean` uses a bunch of those directories.)

Fixes #28537