### PR TITLE
Fix and improve Story first page videos.

### DIFF
--- a/examples/visual-tests/amp-story/basic.html
+++ b/examples/visual-tests/amp-story/basic.html
@@ -5,8 +5,6 @@
     <script async src="https://cdn.ampproject.org/v0.js"></script>
     <script async custom-element="amp-story"
         src="https://cdn.ampproject.org/v0/amp-story-1.0.js"></script>
-    <script async custom-element="amp-video"
-        src="https://cdn.ampproject.org/v0/amp-video-0.1.js"></script>
     <title>amp-story rtl visual diff</title>
     <meta name="viewport"
           content="width=device-width,minimum-scale=1,initial-scale=1">
@@ -60,8 +58,8 @@
 
       <amp-story-page id="cover">
         <amp-story-grid-layer template="fill">
-          <amp-video autoplay layout="fill" poster="/examples/visual-tests/picsum.photos/image980_1600x900.jpg">
-          </amp-video>
+          <amp-img layout="fill" src="/examples/visual-tests/picsum.photos/image980_1600x900.jpg">
+          </amp-img>
         </amp-story-grid-layer>
         <amp-story-grid-layer template="vertical">
           <h1 class="hello-world">Hello world!</h1>
@@ -71,8 +69,8 @@
 
       <amp-story-page id="page-2">
         <amp-story-grid-layer template="fill">
-          <amp-video autoplay layout="fill" poster="/examples/visual-tests/picsum.photos/image981_1600x900.jpg">
-          </amp-video>
+          <amp-img layout="fill" src="/examples/visual-tests/picsum.photos/image981_1600x900.jpg">
+          </amp-img>
         </amp-story-grid-layer>
         <amp-story-grid-layer template="vertical">
           <h1 class="hello-world">Hello world!</h1>
@@ -82,8 +80,8 @@
 
       <amp-story-page id="page-3">
         <amp-story-grid-layer template="fill">
-          <amp-video autoplay layout="fill" poster="/examples/visual-tests/picsum.photos/image982_1600x900.jpg">
-          </amp-video>
+          <amp-img autoplay layout="fill" src="/examples/visual-tests/picsum.photos/image982_1600x900.jpg">
+          </amp-img>
         </amp-story-grid-layer>
         <amp-story-grid-layer template="vertical">
           <h1 class="hello-world">Hello world!</h1>
@@ -93,8 +91,8 @@
 
       <amp-story-page id="page-4">
         <amp-story-grid-layer template="fill">
-          <amp-video autoplay layout="fill" poster="/examples/visual-tests/picsum.photos/image983_1600x900.jpg">
-          </amp-video>
+          <amp-img layout="fill" src="/examples/visual-tests/picsum.photos/image983_1600x900.jpg">
+          </amp-img>
         </amp-story-grid-layer>
         <amp-story-grid-layer template="vertical">
           <h1 class="hello-world">Hello world!</h1>

--- a/examples/visual-tests/amp-story/basic.rtl.html
+++ b/examples/visual-tests/amp-story/basic.rtl.html
@@ -5,8 +5,6 @@
     <script async src="https://cdn.ampproject.org/v0.js"></script>
     <script async custom-element="amp-story"
         src="https://cdn.ampproject.org/v0/amp-story-1.0.js"></script>
-    <script async custom-element="amp-video"
-        src="https://cdn.ampproject.org/v0/amp-video-0.1.js"></script>
     <title>amp-story rtl visual diff</title>
     <meta name="viewport"
           content="width=device-width,minimum-scale=1,initial-scale=1">
@@ -60,8 +58,8 @@
 
       <amp-story-page id="cover">
         <amp-story-grid-layer template="fill">
-          <amp-video autoplay layout="fill" poster="/examples/visual-tests/picsum.photos/image980_1600x900.jpg">
-          </amp-video>
+          <amp-img layout="fill" src="/examples/visual-tests/picsum.photos/image980_1600x900.jpg">
+          </amp-img>
         </amp-story-grid-layer>
         <amp-story-grid-layer template="vertical">
           <h1 class="hello-world">مرحبا بالعالم</h1>
@@ -71,8 +69,8 @@
 
       <amp-story-page id="page-2">
         <amp-story-grid-layer template="fill">
-          <amp-video autoplay layout="fill" poster="/examples/visual-tests/picsum.photos/image981_1600x900.jpg">
-          </amp-video>
+          <amp-img layout="fill" src="/examples/visual-tests/picsum.photos/image981_1600x900.jpg">
+          </amp-img>
         </amp-story-grid-layer>
         <amp-story-grid-layer template="vertical">
           <h1 class="hello-world">مرحبا بالعالم</h1>
@@ -82,8 +80,8 @@
 
       <amp-story-page id="page-3">
         <amp-story-grid-layer template="fill">
-          <amp-video autoplay layout="fill" poster="/examples/visual-tests/picsum.photos/image982_1600x900.jpg">
-          </amp-video>
+          <amp-img layout="fill" src="/examples/visual-tests/picsum.photos/image982_1600x900.jpg">
+          </amp-img>
         </amp-story-grid-layer>
         <amp-story-grid-layer template="vertical">
           <h1 class="hello-world">مرحبا بالعالم</h1>
@@ -93,8 +91,8 @@
 
       <amp-story-page id="page-4">
         <amp-story-grid-layer template="fill">
-          <amp-video autoplay layout="fill" poster="/examples/visual-tests/picsum.photos/image983_1600x900.jpg">
-          </amp-video>
+          <amp-img layout="fill" src="/examples/visual-tests/picsum.photos/image983_1600x900.jpg">
+          </amp-img>
         </amp-story-grid-layer>
         <amp-story-grid-layer template="vertical">
           <h1 class="hello-world">مرحبا بالعالم</h1>

--- a/examples/visual-tests/amp-story/embed-mode-1.html
+++ b/examples/visual-tests/amp-story/embed-mode-1.html
@@ -5,8 +5,6 @@
     <script async src="https://cdn.ampproject.org/v0.js"></script>
     <script async custom-element="amp-story"
         src="https://cdn.ampproject.org/v0/amp-story-1.0.js"></script>
-    <script async custom-element="amp-video"
-        src="https://cdn.ampproject.org/v0/amp-video-0.1.js"></script>
     <title>amp-story embed mode 1 visual diff</title>
     <meta name="viewport"
           content="width=device-width,minimum-scale=1,initial-scale=1">
@@ -46,8 +44,8 @@
 
       <amp-story-page id="cover">
         <amp-story-grid-layer template="fill">
-          <amp-video autoplay layout="fill" poster="/examples/visual-tests/picsum.photos/image981_1600x900.jpg">
-          </amp-video>
+          <amp-img layout="fill" src="/examples/visual-tests/picsum.photos/image981_1600x900.jpg">
+          </amp-img>
         </amp-story-grid-layer>
         <amp-story-grid-layer template="vertical">
           <h1 id="hello-world">Hello world!</h1>

--- a/examples/visual-tests/amp-story/embed-mode-2.html
+++ b/examples/visual-tests/amp-story/embed-mode-2.html
@@ -5,8 +5,6 @@
     <script async src="https://cdn.ampproject.org/v0.js"></script>
     <script async custom-element="amp-story"
         src="https://cdn.ampproject.org/v0/amp-story-1.0.js"></script>
-    <script async custom-element="amp-video"
-        src="https://cdn.ampproject.org/v0/amp-video-0.1.js"></script>
     <title>amp-story embed mode 2 visual diff</title>
     <meta name="viewport"
           content="width=device-width,minimum-scale=1,initial-scale=1">
@@ -46,8 +44,8 @@
 
       <amp-story-page id="cover">
         <amp-story-grid-layer template="fill">
-          <amp-video autoplay layout="fill" poster="/examples/visual-tests/picsum.photos/image981_1600x900.jpg">
-          </amp-video>
+          <amp-img layout="fill" src="/examples/visual-tests/picsum.photos/image981_1600x900.jpg">
+          </amp-img>
         </amp-story-grid-layer>
         <amp-story-grid-layer template="vertical">
           <h1 id="hello-world">Hello world!</h1>

--- a/examples/visual-tests/amp-story/info-dialog.rtl.html
+++ b/examples/visual-tests/amp-story/info-dialog.rtl.html
@@ -5,8 +5,6 @@
     <script async src="https://cdn.ampproject.org/v0.js"></script>
     <script async custom-element="amp-story"
         src="https://cdn.ampproject.org/v0/amp-story-1.0.js"></script>
-    <script async custom-element="amp-video"
-        src="https://cdn.ampproject.org/v0/amp-video-0.1.js"></script>
     <title>amp-story info dialog visual diff</title>
     <meta name="viewport"
           content="width=device-width,minimum-scale=1,initial-scale=1">
@@ -66,8 +64,8 @@
 
       <amp-story-page id="cover">
         <amp-story-grid-layer template="fill">
-          <amp-video autoplay layout="fill" poster="/examples/visual-tests/picsum.photos/image981_1600x900.jpg">
-          </amp-video>
+          <amp-img layout="fill" src="/examples/visual-tests/picsum.photos/image981_1600x900.jpg">
+          </amp-img>
         </amp-story-grid-layer>
         <amp-story-grid-layer template="vertical">
           <h1 id="hello-world">مرحبا بالعالم</h1>

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -51,23 +51,20 @@ import {LoadingSpinner} from './loading-spinner';
 import {LocalizedStringId} from '../../../src/localized-strings';
 import {MediaPool} from './media-pool';
 import {Services} from '../../../src/services';
-import {VideoEvents, delegateAutoplay} from '../../../src/video-interface';
 import {VideoUtils} from '../../../src/utils/video';
 import {
   addAttributesToElement,
-  childElement,
   closestAncestorElementBySelector,
-  isAmpElement,
   iterateCursor,
   matches,
   scopedQuerySelectorAll,
   whenUpgradedToCustomElement,
 } from '../../../src/dom';
 import {debounce} from '../../../src/utils/rate-limit';
+import {delegateAutoplay} from '../../../src/video-interface';
 import {dev} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
 import {getAmpdoc} from '../../../src/service';
-import {getData, listen} from '../../../src/event-helper';
 import {getFriendlyIframeEmbedOptional} from '../../../src/iframe-helper';
 import {getLocalizationService} from './amp-story-localization-service';
 import {getLogEntries} from './logging';
@@ -75,9 +72,10 @@ import {getMediaPerformanceMetricsService} from './media-performance-metrics-ser
 import {getMode} from '../../../src/mode';
 import {htmlFor} from '../../../src/static-template';
 import {isExperimentOn} from '../../../src/experiments';
-import {isMediaDisplayed, setTextBackgroundColor} from './utils';
+import {listen} from '../../../src/event-helper';
 import {px, toggle} from '../../../src/style';
 import {renderPageDescription} from './semantic-render';
+import {setTextBackgroundColor} from './utils';
 import {toArray} from '../../../src/types';
 import {upgradeBackgroundAudio} from './audio';
 
@@ -102,11 +100,14 @@ export const Selectors = {
     'amp-story-grid-layer amp-anim',
   ALL_AMP_VIDEO: 'amp-story-grid-layer amp-video',
   ALL_IFRAMED_MEDIA: 'audio, video',
+  ALL_PLAYBACK_AMP_MEDIA:
+    'amp-story-grid-layer amp-audio, amp-story-grid-layer amp-video',
   // TODO(gmajoulet): Refactor the way these selectors are used. They will be
   // passed to scopedQuerySelectorAll which expects only one selector and not
   // multiple separated by commas. `> audio` has to be kept first of the list to
   // work with this current implementation.
-  ALL_MEDIA: '> audio, amp-story-grid-layer audio, amp-story-grid-layer video',
+  ALL_PLAYBACK_MEDIA:
+    '> audio, amp-story-grid-layer audio, amp-story-grid-layer video',
   ALL_VIDEO: 'amp-story-grid-layer video',
 };
 
@@ -256,9 +257,6 @@ export class AmpStoryPage extends AMP.BaseElement {
 
     /** @private {?Element} */
     this.openAttachmentEl_ = null;
-
-    /** @private @const {!../../../src/service/resources-interface.ResourcesInterface} */
-    this.resources_ = Services.resourcesForDoc(getAmpdoc(this.win.document));
 
     /** @private @const {!../../../src/service/mutator-interface.MutatorInterface} */
     this.mutator_ = Services.mutatorForDoc(getAmpdoc(this.win.document));
@@ -648,9 +646,9 @@ export class AmpStoryPage extends AMP.BaseElement {
    * @private
    */
   waitForMediaLayout_() {
-    const mediaSet = this.getMediaBySelector_(Selectors.ALL_AMP_MEDIA);
+    const mediaSet = toArray(this.getMediaBySelector_(Selectors.ALL_AMP_MEDIA));
 
-    const mediaPromises = Array.prototype.map.call(mediaSet, (mediaEl) => {
+    const mediaPromises = mediaSet.map((mediaEl) => {
       return new Promise((resolve) => {
         switch (mediaEl.tagName.toLowerCase()) {
           case 'amp-img':
@@ -681,6 +679,36 @@ export class AmpStoryPage extends AMP.BaseElement {
       });
     });
     return Promise.all(mediaPromises).then(() => this.markPageAsLoaded_());
+  }
+
+  /**
+   * @return {!Promise}
+   * @private
+   */
+  waitForPlaybackMediaLayout_() {
+    const mediaSet = toArray(
+      this.getMediaBySelector_(Selectors.ALL_PLAYBACK_AMP_MEDIA)
+    );
+
+    const mediaPromises = mediaSet.map((mediaEl) => {
+      return new Promise((resolve) => {
+        switch (mediaEl.tagName.toLowerCase()) {
+          case 'audio': // Already laid out.
+            resolve();
+            break;
+          case 'amp-audio':
+          case 'amp-video':
+            whenUpgradedToCustomElement(mediaEl)
+              .then((el) => el.signals().whenSignal(CommonSignals.LOAD_END))
+              .then(resolve, resolve);
+            break;
+          default:
+            // Any other tags should not block loading.
+            resolve();
+        }
+      });
+    });
+    return Promise.all(mediaPromises);
   }
 
   /**
@@ -783,7 +811,7 @@ export class AmpStoryPage extends AMP.BaseElement {
    * @private
    */
   getAllMedia_() {
-    return this.getMediaBySelector_(Selectors.ALL_MEDIA);
+    return this.getMediaBySelector_(Selectors.ALL_PLAYBACK_MEDIA);
   }
 
   /**
@@ -797,14 +825,12 @@ export class AmpStoryPage extends AMP.BaseElement {
 
   /**
    * Gets media on page by given selector. Finds elements through friendly
-   * iframe (if one exists). By default, it filters the media elements and only
-   * returns those that are visible, ie: not hidden by publisher's CSS.
+   * iframe (if one exists).
    * @param {string} selector
-   * @param {boolean=} includeHiddenMedia
    * @return {!Array<?Element>}
    * @private
    */
-  getMediaBySelector_(selector, includeHiddenMedia = false) {
+  getMediaBySelector_(selector) {
     const iframe = this.element.querySelector('iframe');
     const fie =
       iframe &&
@@ -827,24 +853,7 @@ export class AmpStoryPage extends AMP.BaseElement {
       );
     }
 
-    return includeHiddenMedia
-      ? mediaSet
-      : mediaSet.filter((mediaEl) => this.isMediaDisplayed_(mediaEl));
-  }
-
-  /**
-   * Returns a boolean indicating whether the media element is visible, or
-   * hidden by any publisher CSS rule.
-   * @param {!Element} mediaEl
-   * @return {boolean}
-   * @private
-   */
-  isMediaDisplayed_(mediaEl) {
-    const ampEl = dev().assertElement(
-      isAmpElement(mediaEl) ? mediaEl : mediaEl.parentElement
-    );
-    const resource = this.resources_.getResourceForElement(ampEl);
-    return isMediaDisplayed(ampEl, resource);
+    return mediaSet;
   }
 
   /**
@@ -865,10 +874,11 @@ export class AmpStoryPage extends AMP.BaseElement {
    * @private
    */
   whenAllMediaElements_(callbackFn) {
-    const mediaSet = this.getAllMedia_();
+    const mediaSet = toArray(this.getAllMedia_());
+
     return this.mediaPoolPromise_.then((mediaPool) => {
-      const promises = Array.prototype.map.call(mediaSet, (mediaEl) => {
-        return callbackFn(mediaPool, mediaEl);
+      const promises = mediaSet.map((mediaEl) => {
+        return callbackFn(mediaPool, dev().assertElement(mediaEl));
       });
 
       return Promise.all(promises);
@@ -936,10 +946,6 @@ export class AmpStoryPage extends AMP.BaseElement {
       mediaEl.play();
       return Promise.resolve();
     } else {
-      if (!this.isMediaDisplayed_(mediaEl)) {
-        return Promise.resolve();
-      }
-
       return this.loadPromise(mediaEl).then(
         () => {
           return mediaPool
@@ -1094,11 +1100,16 @@ export class AmpStoryPage extends AMP.BaseElement {
    * @private
    */
   registerAllMedia_() {
-    this.registerAllMediaPromise_ =
-      this.registerAllMediaPromise_ ||
-      this.whenAllMediaElements_((mediaPool, mediaEl) => {
-        return this.registerMedia_(mediaPool, mediaEl);
-      });
+    if (!this.registerAllMediaPromise_) {
+      this.registerAllMediaPromise_ = this.waitForPlaybackMediaLayout_().then(
+        () => {
+          return this.whenAllMediaElements_((mediaPool, mediaEl) => {
+            return this.registerMedia_(mediaPool, mediaEl);
+          });
+        }
+      );
+    }
+
     return this.registerAllMediaPromise_;
   }
 
@@ -1114,25 +1125,9 @@ export class AmpStoryPage extends AMP.BaseElement {
       // No-op.
       return Promise.resolve();
     } else {
-      const parentEl = mediaEl.parentElement;
-      let promise = Promise.resolve();
-      if (
-        parentEl.tagName === 'AMP-VIDEO' ||
-        (parentEl.tagName === 'AMP-AUDIO' &&
-          parentEl.getAttribute('layout') !== Layout.NODISPLAY)
-      ) {
-        promise = parentEl.signals().whenSignal(CommonSignals.LOAD_END);
-      } else if (
-        parentEl.tagName === 'AMP-AUDIO' &&
-        parentEl.getAttribute('layout') === Layout.NODISPLAY
-      ) {
-        promise = parentEl.signals().whenSignal(CommonSignals.BUILT);
-      }
-      return promise.then(() => {
-        mediaPool.register(
-          /** @type {!./media-pool.DomElementDef} */ (mediaEl)
-        );
-      });
+      return mediaPool.register(
+        /** @type {!./media-pool.DomElementDef} */ (mediaEl)
+      );
     }
   }
 
@@ -1576,18 +1571,6 @@ export class AmpStoryPage extends AMP.BaseElement {
         )
       );
     });
-
-    const ampVideoEls = this.getMediaBySelector_(
-      Selectors.ALL_AMP_VIDEO,
-      true /* includeHiddenMedia */
-    );
-    Array.prototype.forEach.call(ampVideoEls, (ampVideoEl) => {
-      this.unlisteners_.push(
-        listen(ampVideoEl, VideoEvents.VISIBILITY, (event) =>
-          this.onVideoVisibilityUpdate_(event)
-        )
-      );
-    });
   }
 
   /**
@@ -1597,51 +1580,6 @@ export class AmpStoryPage extends AMP.BaseElement {
     this.debounceToggleLoadingSpinner_(false);
     this.unlisteners_.forEach((unlisten) => unlisten());
     this.unlisteners_ = [];
-  }
-
-  /**
-   * On video visibility update, either play or pause the video.
-   * @param {!Event} event
-   * @private
-   */
-  onVideoVisibilityUpdate_(event) {
-    // AmpDoc visibility updates are handled by the PAUSED state. This method
-    // only handles video visiblity updates when the ampdoc is visible, eg:
-    // media query update.
-    if (!this.getAmpDoc().isVisible()) {
-      return;
-    }
-
-    const ampVideoEl = dev().assertElement(event.target);
-    const videoEl = dev().assertElement(
-      childElement(ampVideoEl, (el) => el.tagName === 'VIDEO')
-    );
-    const visible = getData(event)['visible'];
-
-    this.mediaPoolPromise_.then((mediaPool) => {
-      if (visible) {
-        this.registerMedia_(mediaPool, videoEl)
-          .then(() => this.preloadMedia_(mediaPool, videoEl))
-          .then((poolVideoEl) => {
-            if (!this.storeService_.get(StateProperty.PAUSED_STATE)) {
-              this.startMeasuringVideoPerformance_(poolVideoEl);
-
-              // Restart video event listeners with the new visible video. This
-              // fixes the loading indicator on the first story page.
-              this.stopListeningToVideoEvents_();
-              this.startListeningToVideoEvents_();
-
-              this.playMedia_(mediaPool, poolVideoEl);
-            }
-            if (!this.storeService_.get(StateProperty.MUTED_STATE)) {
-              this.unmuteAllMedia();
-            }
-          });
-      } else {
-        this.pauseMedia_(mediaPool, videoEl, true /** rewindToBeginning */);
-        this.muteMedia_(mediaPool, videoEl);
-      }
-    });
   }
 
   /**
@@ -1836,7 +1774,7 @@ export class AmpStoryPage extends AMP.BaseElement {
     if (this.isBotUserAgent_) {
       renderPageDescription(
         this,
-        this.getMediaBySelector_(Selectors.ALL_AMP_VIDEO, true)
+        this.getMediaBySelector_(Selectors.ALL_AMP_VIDEO)
       );
     }
 

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -693,15 +693,13 @@ export class AmpStoryPage extends AMP.BaseElement {
     const mediaPromises = mediaSet.map((mediaEl) => {
       return new Promise((resolve) => {
         switch (mediaEl.tagName.toLowerCase()) {
-          case 'audio': // Already laid out.
-            resolve();
-            break;
           case 'amp-audio':
           case 'amp-video':
             whenUpgradedToCustomElement(mediaEl)
               .then((el) => el.signals().whenSignal(CommonSignals.LOAD_END))
               .then(resolve, resolve);
             break;
+          case 'audio': // Already laid out as built from background-audio attr.
           default:
             // Any other tags should not block loading.
             resolve();

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -1102,11 +1102,7 @@ export class AmpStoryPage extends AMP.BaseElement {
   registerAllMedia_() {
     if (!this.registerAllMediaPromise_) {
       this.registerAllMediaPromise_ = this.waitForPlaybackMediaLayout_().then(
-        () => {
-          return this.whenAllMediaElements_((mediaPool, mediaEl) => {
-            return this.registerMedia_(mediaPool, mediaEl);
-          });
-        }
+        () => this.whenAllMediaElements_((p, e) => this.registerMedia_(p, e))
       );
     }
 

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -2180,6 +2180,7 @@ export class AmpStory extends AMP.BaseElement {
       if (
         pageId === this.pages_[0].element.id &&
         this.activePage_ === this.pages_[this.pages_.length - 1] &&
+        this.pages_.length > 1 &&
         !this.viewer_.hasCapability('swipe')
       ) {
         distance = 1;

--- a/extensions/amp-story/1.0/page-advancement.js
+++ b/extensions/amp-story/1.0/page-advancement.js
@@ -29,11 +29,10 @@ import {closest, matches} from '../../../src/dom';
 import {dev, user} from '../../../src/log';
 import {escapeCssSelectorIdent} from '../../../src/css';
 import {getAmpdoc} from '../../../src/service';
-import {hasTapAction, isMediaDisplayed, timeStrToMillis} from './utils';
+import {hasTapAction, timeStrToMillis} from './utils';
 import {interactiveElementsSelectors} from './amp-story-embedded-component';
-import {listen, listenOnce} from '../../../src/event-helper';
+import {listenOnce} from '../../../src/event-helper';
 import {startsWith} from '../../../src/string';
-import {toArray} from '../../../src/types';
 
 /** @private @const {number} */
 const HOLD_TOUCH_THRESHOLD_MS = 500;
@@ -856,22 +855,16 @@ export class TimeBasedAdvancement extends AdvancementConfig {
 export class MediaBasedAdvancement extends AdvancementConfig {
   /**
    * @param {!Window} win
-   * @param {!Array<!Element>} elements
+   * @param {!Element} element
    */
-  constructor(win, elements) {
+  constructor(win, element) {
     super();
 
     /** @private @const {!../../../src/service/timer-impl.Timer} */
     this.timer_ = Services.timerFor(win);
 
-    /** @private @const {!../../../src/service/resources-interface.ResourcesInterface} */
-    this.resources_ = Services.resourcesForDoc(getAmpdoc(win.document));
-
-    /** @private @const {!Array<!Element>} */
-    this.elements_ = elements;
-
-    /** @private {?Element} */
-    this.element_ = this.getFirstPlayableElement_();
+    /** @private {!Element} */
+    this.element_ = element;
 
     /** @private {?Element} */
     this.mediaElement_ = null;
@@ -890,54 +883,6 @@ export class MediaBasedAdvancement extends AdvancementConfig {
 
     /** @private @const {!./amp-story-store-service.AmpStoryStoreService} */
     this.storeService_ = getStoreService(win);
-
-    this.elements_.forEach((el) => {
-      listen(el, VideoEvents.VISIBILITY, () => this.onVideoVisibilityChange_());
-    });
-  }
-
-  /**
-   * Returns the first playable element, or null. An element is considered
-   * playable if it's either visible, or a hidden AMP-AUDIO.
-   * @return {?Element}
-   * @private
-   */
-  getFirstPlayableElement_() {
-    if (this.elements_.length === 1) {
-      return this.elements_[0];
-    }
-
-    for (let i = 0; i < this.elements_.length; i++) {
-      const element = this.elements_[i];
-      const resource = this.resources_.getResourceForElement(element);
-      if (isMediaDisplayed(element, resource)) {
-        return element;
-      }
-    }
-
-    return null;
-  }
-
-  /**
-   * On video visibility change, resets the media based advancement to rely on
-   * the newly visible video, if needed.
-   * @private
-   */
-  onVideoVisibilityChange_() {
-    const element = this.getFirstPlayableElement_();
-    if (element === this.element_) {
-      return;
-    }
-    this.element_ = element;
-    this.mediaElement_ = null;
-    this.video_ = null;
-    // If the page-advancement is running, reset the event listeners so the
-    // progress bar reflects the advancement of the new video. If not running,
-    // the next call to `start()` will set the listeners on the new element.
-    if (this.isRunning()) {
-      this.stop();
-      this.start();
-    }
   }
 
   /**
@@ -976,13 +921,6 @@ export class MediaBasedAdvancement extends AdvancementConfig {
   /** @override */
   start() {
     super.start();
-
-    // If no element is visible yet, keep isRunning true by stepping out after
-    // `super.start()`. When an element becomes visible, it will call `start()`
-    // again if isRunning is still true.
-    if (!this.element_) {
-      return;
-    }
 
     // Prevents race condition when checking for video interface classname.
     (this.element_.whenBuilt
@@ -1104,45 +1042,43 @@ export class MediaBasedAdvancement extends AdvancementConfig {
    * @param {string} autoAdvanceStr The value of the auto-advance-after
    *     attribute.
    * @param {!Window} win
-   * @param {!Element} element
+   * @param {!Element} pageEl
    * @return {?AdvancementConfig} An AdvancementConfig, if media-element-based
    *     auto-advance is supported for the specified auto-advance string; null
    *     otherwise.
    */
-  static fromAutoAdvanceString(autoAdvanceStr, win, element) {
+  static fromAutoAdvanceString(autoAdvanceStr, win, pageEl) {
     try {
       // amp-video, amp-audio, as well as amp-story-page with a background audio
       // are eligible for media based auto advance.
-      const elements = toArray(
-        element.querySelectorAll(
-          `amp-video[data-id=${escapeCssSelectorIdent(autoAdvanceStr)}],
+      let element = pageEl.querySelector(
+        `amp-video[data-id=${escapeCssSelectorIdent(autoAdvanceStr)}],
           amp-video#${escapeCssSelectorIdent(autoAdvanceStr)},
           amp-audio[data-id=${escapeCssSelectorIdent(autoAdvanceStr)}],
           amp-audio#${escapeCssSelectorIdent(autoAdvanceStr)}`
-        )
       );
       if (
         matches(
-          element,
+          pageEl,
           `amp-story-page[background-audio]#${escapeCssSelectorIdent(
             autoAdvanceStr
           )}`
         )
       ) {
-        elements.push(element);
+        element = pageEl;
       }
-      if (!elements.length) {
+      if (!element) {
         if (autoAdvanceStr) {
           user().warn(
             'AMP-STORY-PAGE',
-            `Element with ID ${element.id} has no media element ` +
+            `Element with ID ${pageEl.id} has no media element ` +
               'supported for automatic advancement.'
           );
         }
         return null;
       }
 
-      return new MediaBasedAdvancement(win, elements);
+      return new MediaBasedAdvancement(win, element);
     } catch (e) {
       return null;
     }

--- a/extensions/amp-story/1.0/test/test-amp-story-page.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-page.js
@@ -171,9 +171,6 @@ describes.realWin('amp-story-page', {amp: true}, (env) => {
   });
 
   it('should perform media operations when state becomes active', (done) => {
-    env.sandbox
-      .stub(page.resources_, 'getResourceForElement')
-      .returns({isDisplayed: () => true});
     env.sandbox.stub(page, 'loadPromise').returns(Promise.resolve());
 
     const videoEl = win.document.createElement('video');
@@ -258,10 +255,6 @@ describes.realWin('amp-story-page', {amp: true}, (env) => {
   });
 
   it('should build the background audio on layoutCallback', async () => {
-    env.sandbox
-      .stub(page.resources_, 'getResourceForElement')
-      .returns({isDisplayed: () => true});
-
     element.setAttribute('background-audio', 'foo.mp3');
     page.buildCallback();
     await page.layoutCallback();
@@ -271,10 +264,6 @@ describes.realWin('amp-story-page', {amp: true}, (env) => {
   });
 
   it('should register the background audio on layoutCallback', async () => {
-    env.sandbox
-      .stub(page.resources_, 'getResourceForElement')
-      .returns({isDisplayed: () => true});
-
     element.setAttribute('background-audio', 'foo.mp3');
     page.buildCallback();
     const mediaPool = await page.mediaPoolPromise_;
@@ -286,10 +275,6 @@ describes.realWin('amp-story-page', {amp: true}, (env) => {
   });
 
   it('should preload the background audio on layoutCallback', async () => {
-    env.sandbox
-      .stub(page.resources_, 'getResourceForElement')
-      .returns({isDisplayed: () => true});
-
     element.setAttribute('background-audio', 'foo.mp3');
     page.buildCallback();
     const mediaPool = await page.mediaPoolPromise_;
@@ -301,10 +286,6 @@ describes.realWin('amp-story-page', {amp: true}, (env) => {
   });
 
   it('should wait for media layoutCallback to register it', async () => {
-    env.sandbox
-      .stub(page.resources_, 'getResourceForElement')
-      .returns({isDisplayed: () => true});
-
     const ampVideoEl = win.document.createElement('amp-video');
     const videoEl = win.document.createElement('video');
     videoEl.setAttribute('src', 'https://example.com/video.mp4');
@@ -331,10 +312,6 @@ describes.realWin('amp-story-page', {amp: true}, (env) => {
   });
 
   it('should not register media before its layoutCallback resolves', async () => {
-    env.sandbox
-      .stub(page.resources_, 'getResourceForElement')
-      .returns({isDisplayed: () => true});
-
     const ampVideoEl = win.document.createElement('amp-video');
     const videoEl = win.document.createElement('video');
     videoEl.setAttribute('src', 'https://example.com/video.mp4');
@@ -386,10 +363,6 @@ describes.realWin('amp-story-page', {amp: true}, (env) => {
   });
 
   it('should pause/rewind media when state becomes not active', (done) => {
-    env.sandbox
-      .stub(page.resources_, 'getResourceForElement')
-      .returns({isDisplayed: () => true});
-
     const videoEl = win.document.createElement('video');
     videoEl.setAttribute('src', 'https://example.com/video.mp3');
     gridLayerEl.appendChild(videoEl);
@@ -429,9 +402,6 @@ describes.realWin('amp-story-page', {amp: true}, (env) => {
   });
 
   it('should pause media when state becomes paused', (done) => {
-    env.sandbox
-      .stub(page.resources_, 'getResourceForElement')
-      .returns({isDisplayed: () => true});
     const videoEl = win.document.createElement('video');
     videoEl.setAttribute('src', 'https://example.com/video.mp3');
     gridLayerEl.appendChild(videoEl);
@@ -561,9 +531,6 @@ describes.realWin('amp-story-page', {amp: true}, (env) => {
   it('should start tracking media performance when entering the page', async () => {
     expectAsyncConsoleError(/source must start with/, 1);
 
-    env.sandbox
-      .stub(page.resources_, 'getResourceForElement')
-      .returns({isDisplayed: () => true});
     isPerformanceTrackingOn = true;
     const startMeasuringStub = env.sandbox.stub(
       page.mediaPerformanceMetricsService_,
@@ -586,9 +553,6 @@ describes.realWin('amp-story-page', {amp: true}, (env) => {
   it('should stop tracking media performance when leaving the page', async () => {
     expectAsyncConsoleError(/source must start with/, 1);
 
-    env.sandbox
-      .stub(page.resources_, 'getResourceForElement')
-      .returns({isDisplayed: () => true});
     isPerformanceTrackingOn = true;
     const stopMeasuringStub = env.sandbox.stub(
       page.mediaPerformanceMetricsService_,
@@ -614,9 +578,6 @@ describes.realWin('amp-story-page', {amp: true}, (env) => {
   it('should not start tracking media performance if tracking is off', async () => {
     expectAsyncConsoleError(/source must start with/, 1);
 
-    env.sandbox
-      .stub(page.resources_, 'getResourceForElement')
-      .returns({isDisplayed: () => true});
     isPerformanceTrackingOn = false;
     const startMeasuringStub = env.sandbox.stub(
       page.mediaPerformanceMetricsService_,

--- a/extensions/amp-story/1.0/test/test-amp-story-page.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-page.js
@@ -259,7 +259,7 @@ describes.realWin('amp-story-page', {amp: true}, (env) => {
     page.buildCallback();
     await page.layoutCallback();
     expect(
-      scopedQuerySelectorAll(element, Selectors.ALL_MEDIA)[0].tagName
+      scopedQuerySelectorAll(element, Selectors.ALL_PLAYBACK_MEDIA)[0].tagName
     ).to.equal('AUDIO');
   });
 
@@ -270,7 +270,10 @@ describes.realWin('amp-story-page', {amp: true}, (env) => {
     const mediaPoolRegister = env.sandbox.stub(mediaPool, 'register');
     await page.layoutCallback();
 
-    const audioEl = scopedQuerySelectorAll(element, Selectors.ALL_MEDIA)[0];
+    const audioEl = scopedQuerySelectorAll(
+      element,
+      Selectors.ALL_PLAYBACK_MEDIA
+    )[0];
     expect(mediaPoolRegister).to.have.been.calledOnceWithExactly(audioEl);
   });
 
@@ -281,7 +284,10 @@ describes.realWin('amp-story-page', {amp: true}, (env) => {
     const mediaPoolPreload = env.sandbox.stub(mediaPool, 'preload');
     await page.layoutCallback();
 
-    const audioEl = scopedQuerySelectorAll(element, Selectors.ALL_MEDIA)[0];
+    const audioEl = scopedQuerySelectorAll(
+      element,
+      Selectors.ALL_PLAYBACK_MEDIA
+    )[0];
     expect(mediaPoolPreload).to.have.been.calledOnceWithExactly(audioEl);
   });
 

--- a/extensions/amp-story/1.0/test/test-amp-story-page.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-page.js
@@ -221,10 +221,6 @@ describes.realWin('amp-story-page', {amp: true}, (env) => {
 
       let mediaPoolMock;
 
-      env.sandbox
-        .stub(page.resources_, 'getResourceForElement')
-        .returns({isDisplayed: () => true});
-
       page.buildCallback();
       page
         .layoutCallback()

--- a/extensions/amp-story/1.0/test/test-full-bleed-animations.js
+++ b/extensions/amp-story/1.0/test/test-full-bleed-animations.js
@@ -114,6 +114,10 @@ describes.realWin(
       img.setAttribute('animate-in', animationName);
       img.setAttribute('layout', 'fill');
 
+      env.sandbox
+        .stub(img, 'signals')
+        .callsFake({whenSignal: () => Promise.resolve()});
+
       const gridLayer = win.document.createElement('amp-story-grid-layer');
       opt_gridLayerTempalate = opt_gridLayerTempalate.length
         ? opt_gridLayerTempalate

--- a/extensions/amp-story/1.0/utils.js
+++ b/extensions/amp-story/1.0/utils.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {Layout} from '../../../src/layout';
+
 import {Services} from '../../../src/services';
 import {
   closestAncestorElementBySelector,
@@ -249,23 +249,6 @@ export function resolveImgSrc(win, url) {
     urlSrc = urlSrc.replace('/c/s/', '/i/s/');
   }
   return urlSrc;
-}
-
-/**
- * Returns a boolean indicating whether the media element is visible or has to
- * play, or hidden by any publisher CSS rule.
- * @param {!Element} ampMediaEl amp-video or amp-audio
- * @param {!../../../src/service/resource.Resource} resource
- * @return {boolean}
- */
-export function isMediaDisplayed(ampMediaEl, resource) {
-  // Considers amp-audio elements with a layout=nodisplay attribute as
-  // displayed, since they are expected to play when the page is active.
-  return (
-    resource.isDisplayed() ||
-    (ampMediaEl.tagName === 'AMP-AUDIO' &&
-      ampMediaEl.getLayout() === Layout.NODISPLAY)
-  );
 }
 
 /**

--- a/extensions/amp-video/0.1/amp-video.js
+++ b/extensions/amp-video/0.1/amp-video.js
@@ -338,7 +338,13 @@ class AmpVideo extends AMP.BaseElement {
           // load.
           return Services.timerFor(this.win)
             .promise(1)
-            .then(() => this.loadPromise(this.video_));
+            .then(() => {
+              // Don't wait for the source to load if media pool is taking over.
+              if (this.isManagedByPool_()) {
+                return;
+              }
+              return this.loadPromise(this.video_);
+            });
         });
     } else {
       this.propagateLayoutChildren_();
@@ -361,10 +367,10 @@ class AmpVideo extends AMP.BaseElement {
       return;
     }
 
-    // Resolve layoutCallback right away if the video is within a story, so it
-    // can be handled by the media pool as soon as possible.
+    // Resolve layoutCallback as soon as all sources are appended when within a
+    // story, so it can be handled by the media pool as soon as possible.
     if (this.isManagedByPool_()) {
-      return;
+      return pendingOriginPromise;
     }
 
     return promise;

--- a/extensions/amp-video/0.1/amp-video.js
+++ b/extensions/amp-video/0.1/amp-video.js
@@ -361,6 +361,12 @@ class AmpVideo extends AMP.BaseElement {
       return;
     }
 
+    // Resolve layoutCallback right away if the video is within a story, so it
+    // can be handled by the media pool as soon as possible.
+    if (this.isManagedByPool_()) {
+      return;
+    }
+
     return promise;
   }
 


### PR DESCRIPTION
Note: we will very likely ask for this PR to be cherry-picked on beta/experimental.

1. Fixes a `distance` issue that introduces race conditions for single page stories by marking the active page as `distance 1`
2. Removes the video visibility updates listener. I don't think anyone uses it, and it's made the code very complicated for no good reason. Given all the video bugs we had I think making the video code easier, and removing all the different code paths we have is very desirable. It's also required for change 3.
3. When registering elements to the media pool we query audio and video elements. In some cases with no cache (super easy to repro with a carousel of 3p iframes), amp-audio and amp-video are not built yet so our querySelector doesn't register them. Now, we wait for amp-video/audio to be laid out before registering them.
4. The signal of amp-video/audio being laid out comes after it gets the first media bytes, and then we register it into the media pool, and load again. This PR makes amp-video.layoutCallback return early for stories so the media pool can kick in faster. It'll solve another few bugs we have (joint latency tracking) and make first page videos faster.

Did some very biased performance testing (very fast network + one page story with a video on the first page)

LCP before: 1.10s
LCP after: 0.93s
Improvement: 15.4%
Testing stories: [before](https://stamp-contra-video-2.firebaseapp.com/examples/contra/7.html), [after](https://stamp-contra-video.firebaseapp.com/examples/contra/7.html)
(Videos on the "before" will fail loading quite a lot)

cc @cramforce who reported most of these issues