### PR TITLE
🐛[amp-base-carousel] Fix - Do not move carousel to slide 0 

### DIFF
--- a/extensions/amp-base-carousel/0.1/amp-base-carousel.js
+++ b/extensions/amp-base-carousel/0.1/amp-base-carousel.js
@@ -30,6 +30,7 @@ import {createCustomEvent, getDetail} from '../../../src/event-helper';
 import {dev, devAssert} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
 import {htmlFor} from '../../../src/static-template';
+import {isFiniteNumber, toArray} from '../../../src/types';
 import {isLayoutSizeDefined} from '../../../src/layout';
 import {
   isRTL,
@@ -37,7 +38,6 @@ import {
   scopedQuerySelectorAll,
   toggleAttribute,
 } from '../../../src/dom';
-import {toArray} from '../../../src/types';
 
 /**
  * @enum {number}
@@ -448,9 +448,12 @@ class AmpCarousel extends AMP.BaseElement {
       'goToSlide',
       (actionInvocation) => {
         const {args, trust} = actionInvocation;
-        this.carousel_.goToSlide(args['index'] || -1, {
-          actionSource: this.getActionSource_(trust),
-        });
+        this.carousel_.goToSlide(
+          isFiniteNumber(args['index']) ? args['index'] : -1,
+          {
+            actionSource: this.getActionSource_(trust),
+          }
+        );
       },
       ActionTrust.LOW
     );

--- a/extensions/amp-base-carousel/0.1/test-e2e/test-carousel.js
+++ b/extensions/amp-base-carousel/0.1/test-e2e/test-carousel.js
@@ -243,5 +243,26 @@ describes.endtoend(
         });
       });
     });
+
+    describe('gotoSlide', function () {
+      it('should go to slide 1', async function () {
+        this.timeout(testTimeout);
+        const goToSlideButton = await controller.findElement('#goToSlide1');
+        const firstSlide = await getSlide(controller, 0);
+
+        // Wait for the first and last slides to load.
+        await waitForCarouselImg(controller, 0);
+        await waitForCarouselImg(controller, SLIDE_COUNT - 1);
+
+        // Press a button to go back to the first slide.
+        await controller.click(goToSlideButton);
+        const slideWidth = await prop(firstSlide, 'offsetWidth');
+
+        await expect(controller.getElementRect(firstSlide)).to.include({
+          x: 0,
+          width: slideWidth,
+        });
+      });
+    });
   }
 );

--- a/test/manual/amp-base-carousel/basic.amp.html
+++ b/test/manual/amp-base-carousel/basic.amp.html
@@ -29,6 +29,7 @@
   </amp-base-carousel>
   <button on="tap:carousel-1.prev()">Prev</button>
   <button on="tap:carousel-1.next()">Next</button>
-  <button on="tap:carousel-1.goToSlide(index = 1)">Slide 2 (1 indexed)</button>
+  <button id="goToSlide1" on="tap:carousel-1.goToSlide(index = 0)">Slide 1</button>
+  <button id="goToSlide2" on="tap:carousel-1.goToSlide(index = 1)">Slide 2 (1 indexed)</button>
 </body>
 </html>


### PR DESCRIPTION
Fixes #29098

The `goToSlide` method of `amp-base-carousel` returned -1 for `0`, so I fixed it to check if index is a numeric value instead of a falsy value.

<!--
# Instructions:

- Pick a meaningful title for your pull request. (Use sentence case.)
  - Prefix the title with an emoji to identify what is being done. (Copy-paste the emoji from the list below.)
  - Do not overuse punctuation in the title (like `(chore):`).
  - If it is helpful, use a simple prefix (like `ProjectX: Implement some feature`).
- Enter a succinct description that says why the PR is necessary, and what it does.
  - Mention the GitHub issue that is being addressed by the pull request.
  - The keywords `Fixes`, `Closes`, or `Resolves` followed the issue number will automatically close the issue.

> NOTE: All non-trivial changes (like introducing new features or components) should have an associated issue or reference an I2I (intent-to-implement: go.amp.dev/i2i). Please read through the contribution process (go.amp.dev/contributing/code) for more information.

# Example of a good description:

- Implement aspect X
- Leave out feature Y because of A
- Improve performance by B
- Improve accessibility by C

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Reverting a previous change
♻️ Refactoring
🚮 Deleting code
🧪 Experimental code
-->
