### PR TITLE
Fixed Link anchor don't jump to the right heading ampproject/amp.dev#4167

### DIFF
--- a/extensions/amp-story/amp-story.md
+++ b/extensions/amp-story/amp-story.md
@@ -259,7 +259,7 @@ The `amp-story` component represents an entire story. The component itself imple
     <td width="40%"><strong>background-audio [optional]</strong></td>
     <td>A URL to an audio file that plays throughout the story.</td>
   </tr>
-  <tr id="live-story">
+  <tr id="live-story-live-optional">
     <td width="40%"><strong>live-story [optional]</strong></td>
     <td>Enables the <a href="#Live-story">Live story</a> functionality.</td>
   </tr>


### PR DESCRIPTION
Fixed Link anchors don't jump to the right heading Issue ampproject/amp.dev#4167 by replacing #live-story to #live-story-optional  in additional  tr tag 
📖 Documentation
🐛 Bug fix
<!--
# Instructions:

- Pick a meaningful title for your pull request. (Use sentence case.)
  - Prefix the title with an emoji to identify what is being done. (Copy-paste the emoji from the list below.)
  - Do not overuse punctuation in the title (like `(chore):`).
  - If it is helpful, use a simple prefix (like `ProjectX: Implement some feature`).
- Enter a succinct description that says why the PR is necessary, and what it does.
  - Mention the GitHub issue that is being addressed by the pull request.
  - The keywords `Fixes`, `Closes`, or `Resolves` followed the issue number will automatically close the issue.

> NOTE: All non-trivial changes (like introducing new features or components) should have an associated issue or reference an I2I (intent-to-implement: go.amp.dev/i2i). Please read through the contribution process (go.amp.dev/contributing/code) for more information.

# Example of a good description:

- Implement aspect X
- Leave out feature Y because of A
- Improve performance by B
- Improve accessibility by C

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
🏗 Infrastructure / Tooling / Builds / CI
⏪ Reverting a previous change
♻️ Refactoring
🚮 Deleting code
🧪 Experimental code
-->
