### PR TITLE
AdSense/Doubleclick Ad - Round Positions Experiment

### DIFF
--- a/ads/google/a4a/test/test-utils.js
+++ b/ads/google/a4a/test/test-utils.js
@@ -68,8 +68,8 @@ function noopMethods(
   ampdoc,
   sandbox,
   pageLayoutBox = {
-    top: 11,
-    left: 12,
+    top: 11.1,
+    left: 12.1,
     right: 0,
     bottom: 0,
     width: 0,
@@ -322,9 +322,13 @@ describe('Google A4A utils', () => {
         const impl = new MockA4AImpl(elem);
         noopMethods(impl, fixture.ampdoc, window.sandbox);
         return fixture.addElement(elem).then(() => {
-          return googleAdUrl(impl, '', 0, [], []).then((url1) => {
-            expect(url1).to.match(/ady=11/);
-            expect(url1).to.match(/adx=12/);
+          return googleAdUrl(impl, '', 0, [], false, []).then((url1) => {
+            expect(url1).to.match(/ady=11.1/);
+            expect(url1).to.match(/adx=12.1/);
+            return googleAdUrl(impl, '', 0, [], true, []).then((url1) => {
+              expect(url1).to.match(/ady=11/);
+              expect(url1).to.match(/adx=12/);
+            });
           });
         });
       });
@@ -348,12 +352,15 @@ describe('Google A4A utils', () => {
         const getSize = () => {
           return {'width': 100, 'height': 200};
         };
-        const getScrollLeft = () => 12;
-        const getScrollTop = () => 34;
+        const getScrollLeft = () => 12.1;
+        const getScrollTop = () => 34.2;
         const viewportStub = window.sandbox.stub(Services, 'viewportForDoc');
         viewportStub.returns({getRect, getSize, getScrollTop, getScrollLeft});
         return fixture.addElement(elem).then(() => {
-          return googleAdUrl(impl, '', 0, {}, []).then((url1) => {
+          return googleAdUrl(impl, '', 0, {}, false, []).then((url1) => {
+            expect(url1).to.match(/scr_x=12.1&scr_y=34.2/);
+          });
+          return googleAdUrl(impl, '', 0, {}, true, []).then((url1) => {
             expect(url1).to.match(/scr_x=12&scr_y=34/);
           });
         });
@@ -376,9 +383,11 @@ describe('Google A4A utils', () => {
         const impl = new MockA4AImpl(elem);
         noopMethods(impl, fixture.ampdoc, window.sandbox);
         return fixture.addElement(elem).then(() => {
-          return googleAdUrl(impl, '', 0, {}, ['789', '098']).then((url1) => {
-            expect(url1).to.match(/eid=123%2C456%2C789%2C098/);
-          });
+          return googleAdUrl(impl, '', 0, {}, false, ['789', '098']).then(
+            (url1) => {
+              expect(url1).to.match(/eid=123%2C456%2C789%2C098/);
+            }
+          );
         });
       });
     });
@@ -398,7 +407,7 @@ describe('Google A4A utils', () => {
         impl.win.AMP_CONFIG = {type: 'production'};
         impl.win.location.hash = 'foo,deid=123456,654321,bar';
         return fixture.addElement(elem).then(() => {
-          return googleAdUrl(impl, '', 0, [], []).then((url1) => {
+          return googleAdUrl(impl, '', 0, [], false, []).then((url1) => {
             expect(url1).to.match(/[&?]debug_experiment_id=123456%2C654321/);
           });
         });
@@ -419,7 +428,7 @@ describe('Google A4A utils', () => {
         noopMethods(impl, fixture.ampdoc, window.sandbox);
         impl.win.gaGlobal = {cid: 'foo', hid: 'bar'};
         return fixture.addElement(elem).then(() => {
-          return googleAdUrl(impl, '', 0, [], []).then((url) => {
+          return googleAdUrl(impl, '', 0, [], false, []).then((url) => {
             expect(url).to.match(/[&?]ga_cid=foo[&$]/);
             expect(url).to.match(/[&?]ga_hid=bar[&$]/);
           });
@@ -449,9 +458,9 @@ describe('Google A4A utils', () => {
           },
         });
         return fixture.addElement(elem).then(() => {
-          return expect(googleAdUrl(impl, '', 0, {}, [])).to.eventually.match(
-            /[&?]bc=7[&$]/
-          );
+          return expect(
+            googleAdUrl(impl, '', 0, {}, false, [])
+          ).to.eventually.match(/[&?]bc=7[&$]/);
         });
       });
     });
@@ -476,9 +485,9 @@ describe('Google A4A utils', () => {
           sandbox: {},
         });
         return fixture.addElement(elem).then(() => {
-          return expect(googleAdUrl(impl, '', 0, {}, [])).to.eventually.match(
-            /[&?]bc=1[&$]/
-          );
+          return expect(
+            googleAdUrl(impl, '', 0, {}, false, [])
+          ).to.eventually.match(/[&?]bc=1[&$]/);
         });
       });
     });
@@ -507,7 +516,7 @@ describe('Google A4A utils', () => {
         });
         return fixture.addElement(elem).then(() => {
           return expect(
-            googleAdUrl(impl, '', 0, {}, [])
+            googleAdUrl(impl, '', 0, {}, false, [])
           ).to.eventually.not.match(/[&?]bc=1[&$]/);
         });
       });
@@ -540,7 +549,7 @@ describe('Google A4A utils', () => {
         expectAsyncConsoleError(/Referrer timeout/, 1);
         return fixture.addElement(elem).then(() => {
           return expect(
-            googleAdUrl(impl, '', 0, {}, [])
+            googleAdUrl(impl, '', 0, {}, false, [])
           ).to.eventually.not.match(/[&?]ref=[&$]/);
         });
       });
@@ -555,9 +564,11 @@ describe('Google A4A utils', () => {
         const impl = new MockA4AImpl(elem);
         noopMethods(impl, fixture.ampdoc, window.sandbox);
         return fixture.addElement(elem).then(() => {
-          return googleAdUrl(impl, '', Date.now(), [], []).then((url) => {
-            expect(url).to.match(/[&?]bdt=[1-9][0-9]*[&$]/);
-          });
+          return googleAdUrl(impl, '', Date.now(), [], false, []).then(
+            (url) => {
+              expect(url).to.match(/[&?]bdt=[1-9][0-9]*[&$]/);
+            }
+          );
         });
       });
     });

--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -37,5 +37,6 @@
   "swg-gpay-native": 1,
   "version-locking": 1,
   "amp-ad-no-center-css": 0,
-  "analytics-chunks": 1
+  "analytics-chunks": 1,
+  "ad-adsense-gam-round-params": 0.02
 }

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -40,5 +40,6 @@
   "amp-ad-no-center-css": 0,
   "analytics-chunks": 1,
   "sticky-ad-padding-bottom": 0.05,
-  "render-on-idle-fix": 0.02
+  "render-on-idle-fix": 0.02,
+  "ad-adsense-gam-round-params": 0.02
 }

--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -47,6 +47,7 @@ import {ResponsiveState} from './responsive-state';
 import {Services} from '../../../src/services';
 import {
   addExperimentIdToElement,
+  isInExperiment,
   isInManualExperiment,
 } from '../../../ads/google/a4a/traffic-experiments';
 import {computedStyle, setStyles} from '../../../src/style';
@@ -67,6 +68,13 @@ const ADSENSE_BASE_URL = 'https://googleads.g.doubleclick.net/pagead/ads';
 
 /** @const {string} */
 const TAG = 'amp-ad-network-adsense-impl';
+
+/** @const @enum {string} */
+const ROUND_LOCATION_PARAMS_EXP = {
+  ID: 'ad-adsense-gam-round-params',
+  CONTROL: '21066726',
+  EXPERIMENT: '21066727',
+};
 
 /**
  * Shared state for AdSense ad slots. This is used primarily for ad request url
@@ -232,6 +240,14 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
           STICKY_AD_PADDING_BOTTOM_EXP.experiment,
         ],
       },
+      {
+        experimentId: ROUND_LOCATION_PARAMS_EXP.ID,
+        isTrafficEligible: () => true,
+        branches: [
+          ROUND_LOCATION_PARAMS_EXP.CONTROL,
+          ROUND_LOCATION_PARAMS_EXP.EXPERIMENT,
+        ],
+      },
     ]).concat(AMPDOC_FIE_EXPERIMENT_INFO_LIST);
     const setExps = randomlySelectUnsetExperiments(
       this.win,
@@ -390,6 +406,7 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
           'pucrd': identity.pucrd || null,
           ...parameters,
         },
+        isInExperiment(this.element, ROUND_LOCATION_PARAMS_EXP.EXPERIMENT),
         experimentIds
       );
     });

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -2035,7 +2035,7 @@ function constructSRARequest_(a4a, instances) {
       googlePageParameters(
         a4a,
         startTime,
-        this.experimentIds.includes(ROUND_LOCATION_PARAMS_EXP.EXPERIMENT)
+        a4a.experimentIds.includes(ROUND_LOCATION_PARAMS_EXP.EXPERIMENT)
       )
     )
     .then((googPageLevelParameters) => {

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -2035,7 +2035,9 @@ function constructSRARequest_(a4a, instances) {
       googlePageParameters(
         a4a,
         startTime,
-        a4a.experimentIds.includes(ROUND_LOCATION_PARAMS_EXP.EXPERIMENT)
+        instances[0].experimentIds.includes(
+          ROUND_LOCATION_PARAMS_EXP.EXPERIMENT
+        )
       )
     )
     .then((googPageLevelParameters) => {

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -172,6 +172,13 @@ export const EXPAND_JSON_TARGETING_EXP = {
   EXPERIMENT: '21066262',
 };
 
+/** @const @enum {string} */
+const ROUND_LOCATION_PARAMS_EXP = {
+  ID: 'ad-adsense-gam-round-params',
+  CONTROL: '21066728',
+  EXPERIMENT: '21066729',
+};
+
 /**
  * Required size to be sent with fluid requests.
  * @const {string}
@@ -492,6 +499,14 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
           STICKY_AD_PADDING_BOTTOM_EXP.experiment,
         ],
       },
+      {
+        experimentId: ROUND_LOCATION_PARAMS_EXP.ID,
+        isTrafficEligible: () => true,
+        branches: [
+          ROUND_LOCATION_PARAMS_EXP.CONTROL,
+          ROUND_LOCATION_PARAMS_EXP.EXPERIMENT,
+        ],
+      },
     ]).concat(AMPDOC_FIE_EXPERIMENT_INFO_LIST);
     const setExps = this.randomlySelectUnsetExperiments_(experimentInfoList);
     Object.keys(setExps).forEach(
@@ -682,7 +697,10 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
       'spsa': this.isSinglePageStoryAd
         ? `${pageLayoutBox.width}x${pageLayoutBox.height}`
         : null,
-      ...googleBlockParameters(this),
+      ...googleBlockParameters(
+        this,
+        this.experimentIds.includes(ROUND_LOCATION_PARAMS_EXP.EXPERIMENT)
+      ),
     };
   }
 
@@ -796,6 +814,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
           this.getPageParameters(consentTuple, /* instances= */ undefined),
           rtcParams
         ),
+        this.experimentIds.includes(ROUND_LOCATION_PARAMS_EXP.EXPERIMENT),
         this.experimentIds
       ).then((adUrl) => this.getAdUrlDeferred.resolve(adUrl));
     });
@@ -2012,7 +2031,13 @@ function constructSRARequest_(a4a, instances) {
   return Promise.all(
     instances.map((instance) => instance.getAdUrlDeferred.promise)
   )
-    .then(() => googlePageParameters(a4a, startTime))
+    .then(() =>
+      googlePageParameters(
+        a4a,
+        startTime,
+        this.experimentIds.includes(ROUND_LOCATION_PARAMS_EXP.EXPERIMENT)
+      )
+    )
     .then((googPageLevelParameters) => {
       const blockParameters = constructSRABlockParameters(instances);
       return truncAndTimeUrl(


### PR DESCRIPTION
amp-ad type=adsense or doubleclick, setup experiment that rounds position pixel parameters given expectation of integer values.

🐛 Bug fix
🧪 Experimental code