### PR TITLE
🐛 Transforming stream race condition

### DIFF
--- a/src/utils/dom-tranform-stream.js
+++ b/src/utils/dom-tranform-stream.js
@@ -51,11 +51,11 @@ export class DomTransformStream {
     const targetBodyDefer = new Deferred();
     /**
      * Resolves when target body is ready to receive elements.
-     * @private {!Promise<!element>}
+     * @private {!Promise<!Element>}
      */
     this.targetBodyPromise_ = targetBodyDefer.promise;
 
-    /** @const @private {!function(!Promise)} */
+    /** @const @private {!function(!Element)} */
     this.targetBodyResolver_ = targetBodyDefer.resolve;
 
     /** @private {?Promise} */

--- a/src/utils/dom-tranform-stream.js
+++ b/src/utils/dom-tranform-stream.js
@@ -25,14 +25,21 @@ export class DomTransformStream {
    */
   constructor(win) {
     const headDefer = new Deferred();
-    /** @const @private {!Promise<!Element>} */
+    /**
+     * Resolves when head has been written to in memory document.
+     * @const @private {!Promise<!Element>}
+     */
     this.headPromise_ = headDefer.promise;
 
     /** @const @private {!function(!Element)} */
     this.headResolver_ = headDefer.resolve;
 
     const transferDefer = new Deferred();
-    /** @const @private {!Promise} */
+    /**
+     * Resovles when complete doc has been transfered to the target
+     * body.
+     * @const @private {!Promise}
+     */
     this.bodyTransferPromise_ = transferDefer.promise;
 
     /** @const @private {!function(!Promise)} */
@@ -41,8 +48,15 @@ export class DomTransformStream {
     /** @private {?Element} */
     this.detachedBody_ = null;
 
-    /** @private {?Element} */
-    this.targetBody_ = null;
+    const targetBodyDefer = new Deferred();
+    /**
+     * Resolves when target body is ready to receive elements.
+     * @private {!Promise<!element>}
+     */
+    this.targetBodyPromise_ = targetBodyDefer.promise;
+
+    /** @const @private {!function(!Promise)} */
+    this.targetBodyResolver_ = targetBodyDefer.resolve;
 
     /** @private {?Promise} */
     this.currentChunkTransferPromise_ = null;
@@ -109,7 +123,7 @@ export class DomTransformStream {
     );
 
     this.shouldTransfer_ = true;
-    this.targetBody_ = targetBody;
+    this.targetBodyResolver_(targetBody);
 
     this.transferBodyChunk_();
 
@@ -125,12 +139,16 @@ export class DomTransformStream {
       return this.currentChunkTransferPromise_;
     }
 
-    this.currentChunkTransferPromise_ = this.headPromise_.then(() =>
+    this.currentChunkTransferPromise_ = Promise.all([
+      this.targetBodyPromise_,
+      this.headPromise_,
+    ]).then((resolvedElements) =>
       this.vsync_.mutatePromise(() => {
         this.currentChunkTransferPromise_ = null;
+        const targetBody = resolvedElements[0];
         removeNoScriptElements(dev().assertElement(this.detachedBody_));
         while (this.detachedBody_.firstChild) {
-          this.targetBody_.appendChild(this.detachedBody_.firstChild);
+          targetBody.appendChild(this.detachedBody_.firstChild);
         }
       })
     );

--- a/test/unit/utils/test-dom-transform-stream.js
+++ b/test/unit/utils/test-dom-transform-stream.js
@@ -15,6 +15,7 @@
  */
 
 import {DomTransformStream} from '../../../src/utils/dom-tranform-stream';
+import {Services} from '../../../src/services';
 import {macroTask} from '../../../testing/yield';
 
 describes.fakeWin('DomTransformStream', {amp: true}, (env) => {
@@ -32,6 +33,41 @@ describes.fakeWin('DomTransformStream', {amp: true}, (env) => {
     win = env.win;
     detachedDoc = win.document.implementation.createHTMLDocument().open();
     transformer = new DomTransformStream(win);
+  });
+
+  describe('#onEnd', () => {
+    it('should only transfer after targetBody is ready', async () => {
+      const mutateSpy = env.sandbox.spy(
+        Services.vsyncFor(env.win),
+        'mutatePromise'
+      );
+      const {body} = win.document;
+
+      detachedDoc.write(`
+        <!doctype html>
+        <html ⚡>
+        <head>
+        <script async src="https://cdn.ampproject.org/v0.js"></script>
+        </head>
+        <body>
+        <child-one></child-one>
+        <child-two></child-two>
+        </body>
+      `);
+
+      transformer.onChunk(detachedDoc);
+      transformer.onEnd();
+      await flush();
+
+      expect(mutateSpy).not.to.have.been.called;
+      transformer.transferBody(body /* targetBody */);
+
+      await flush();
+
+      expect(mutateSpy).to.have.been.calledOnce;
+      expect(body.querySelector('child-one')).to.exist;
+      expect(body.querySelector('child-two')).to.exist;
+    });
   });
 
   describe('#waitForHead', () => {


### PR DESCRIPTION
There is a race where the response may finish (`onEnd` is called) before the target body is ready (`transferBody` has not been called). In this case we should wait for the target body before trying to transfer elements.

Related to #27189