### PR TITLE
🏗 Add of `--sxg` flag to `release`.

### DIFF
--- a/build-system/tasks/release/index.js
+++ b/build-system/tasks/release/index.js
@@ -34,7 +34,7 @@ const BASE_FLAVOR_CONFIG = {
   name: 'base',
   rtvPrefixes: ['00', '01', '02', '03', '04', '05'],
   // TODO(#28168, erwinmombay): relace with single `--module --nomodule` command.
-  command: 'gulp dist --noconfig --esm && gulp dist --noconfig',
+  command: 'gulp dist --noconfig --esm && gulp dist --noconfig && gulp dist --noconfig --sxg',
   environment: 'AMP',
 };
 

--- a/build-system/tasks/release/index.js
+++ b/build-system/tasks/release/index.js
@@ -34,7 +34,8 @@ const BASE_FLAVOR_CONFIG = {
   name: 'base',
   rtvPrefixes: ['00', '01', '02', '03', '04', '05'],
   // TODO(#28168, erwinmombay): relace with single `--module --nomodule` command.
-  command: 'gulp dist --noconfig --sxg && gulp dist --noconfig --esm && gulp dist --noconfig',
+  command:
+    'gulp dist --noconfig --sxg && gulp dist --noconfig --esm && gulp dist --noconfig',
   environment: 'AMP',
 };
 

--- a/build-system/tasks/release/index.js
+++ b/build-system/tasks/release/index.js
@@ -34,7 +34,7 @@ const BASE_FLAVOR_CONFIG = {
   name: 'base',
   rtvPrefixes: ['00', '01', '02', '03', '04', '05'],
   // TODO(#28168, erwinmombay): relace with single `--module --nomodule` command.
-  command: 'gulp dist --noconfig --esm && gulp dist --noconfig && gulp dist --noconfig --sxg',
+  command: 'gulp dist --noconfig --sxg && gulp dist --noconfig --esm && gulp dist --noconfig',
   environment: 'AMP',
 };
 


### PR DESCRIPTION
One-line change made to include SxG build in the base flavor of AMP.