### PR TITLE
🐛  Fix gulp clean refactor bug

### DIFF
--- a/build-system/tasks/clean.js
+++ b/build-system/tasks/clean.js
@@ -42,7 +42,7 @@ async function clean() {
     pathsToDelete.push('**/node_modules', '!node_modules');
   }
   const deletedPaths = await del(pathsToDelete, {
-    expandDirectories: true,
+    expandDirectories: false,
     dryRun: argv.dry_run,
   });
   if (deletedPaths.length > 0) {


### PR DESCRIPTION
`expandDirectories` wasn't set prior to the refactor; which defaults to false. By setting it to true, maybe it's deleting more than it should. This explicitly sets it to false.