### PR TITLE
🐛 Use correct css variables on binary poll percent bars.

### DIFF
--- a/extensions/amp-story/1.0/amp-story-interactive-binary-poll.css
+++ b/extensions/amp-story/1.0/amp-story-interactive-binary-poll.css
@@ -81,7 +81,7 @@
   position: absolute !important;
   opacity: 0 !important;
   transform-origin: left !important;
-  transition: transform var(--animation-time) var(--ease-out-curve) !important;
+  transition: transform var(--i-amphtml-interactive-animation-time) var(--i-amphtml-interactive-ease-out-curve) !important;
 }
 
 [dir=rtl] .i-amphtml-story-interactive-option


### PR DESCRIPTION
They were using old variable names.
![Screen Shot 2020-07-14 at 2 57 58 PM](https://user-images.githubusercontent.com/3860311/87465311-6cfca980-c5e2-11ea-96bc-f1b1b13a53ed.png)
