### PR TITLE
✨ [amp-social-share][bento] Allow easy styling of Social Share icons

### DIFF
--- a/extensions/amp-social-share/1.0/amp-social-share.css
+++ b/extensions/amp-social-share/1.0/amp-social-share.css
@@ -1,0 +1,93 @@
+/**
+ * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+amp-social-share {
+  text-decoration: none;
+  cursor: pointer;
+  position: relative;
+}
+
+/**
+  * Note: Attribute selectors were used initially here but we switched to using
+  * class-based selector to style each type because of a bug on iOS Safari 8.
+  * See https://github.com/ampproject/amphtml/issues/4277 for more details.
+  */
+
+/* Twitter Styling */
+.amp-social-share-twitter {
+  color: #fff;
+  background-color: #1da1f2;
+}
+
+/* Facebook Styling */
+.amp-social-share-facebook {
+  color: #fff;
+  background-color: #32529f;
+}
+
+/* Pinterest Styling */
+.amp-social-share-pinterest {
+  color: #fff;
+  background-color: #e60023;
+}
+
+/* LinkedIn Styling */
+.amp-social-share-linkedin {
+  color: #fff;
+  background-color: #0077b5;
+}
+
+/* Google+ Styling */
+.amp-social-share-gplus {
+  color: #fff;
+  background-color: #dc4e41;
+}
+
+/* Tumblr Styling */
+.amp-social-share-tumblr {
+  color: #fff;
+  background-color: #3c5a77;
+}
+
+/* Email Styling */
+.amp-social-share-email {
+  color: #fff;
+  background-color: #000000;
+}
+
+/* Whatsapp Styling */
+.amp-social-share-whatsapp {
+  color: #fff;
+  background-color: #25d366;
+}
+
+/* line Styling */
+.amp-social-share-line {
+  color: #fff;
+  background-color: #52b448;
+}
+
+/* SMS Styling */
+.amp-social-share-sms {
+  color: #fff;
+  background-color: #ca2b63;
+}
+
+/* "system" styling */
+.amp-social-share-system {
+  color: #fff;
+  background-color: #000000;
+}

--- a/extensions/amp-social-share/1.0/amp-social-share.js
+++ b/extensions/amp-social-share/1.0/amp-social-share.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {CSS} from '../../../build/amp-social-share-1.0.css';
 import {Layout} from '../../../src/layout';
 import {PreactBaseElement} from '../../../src/preact/base-element';
 import {Services} from '../../../src/services';
@@ -87,6 +88,7 @@ class AmpSocialShare extends PreactBaseElement {
       return;
     }
 
+    this.element.classList.add(`amp-social-share-${type}`);
     this.renderWithHrefAndTarget_(typeConfig, platform);
     const responsive =
       this.element.getAttribute('layout') === Layout.RESPONSIVE && '100%';
@@ -171,5 +173,5 @@ AmpSocialShare['props'] = {
 };
 
 AMP.extension(TAG, '1.0', (AMP) => {
-  AMP.registerElement(TAG, AmpSocialShare);
+  AMP.registerElement(TAG, AmpSocialShare, CSS);
 });

--- a/extensions/amp-social-share/1.0/social-share.css.js
+++ b/extensions/amp-social-share/1.0/social-share.css.js
@@ -21,36 +21,3 @@ export const BASE_STYLE = {
   'cursor': 'pointer',
   'position': 'relative',
 };
-
-/* Twitter Styling */
-export const TWITTER = {'backgroundColor': '1da1f2'};
-
-/* Facebook Styling */
-export const FACEBOOK = {'backgroundColor': '#32529f'};
-
-/* Pinterest Styling */
-export const PINTEREST = {'backgroundColor': 'e60023'};
-
-/* LinkedIn Styling */
-export const LINKEDIN = {'backgroundColor': '0077b5'};
-
-/* Google+ Styling */
-export const GPLUS = {'backgroundColor': 'dc4e41'};
-
-/* Tumblr Styling */
-export const TUMBLR = {'backgroundColor': '3c5a77'};
-
-/* Email Styling */
-export const EMAIL = {'backgroundColor': '000000'};
-
-/* Whatsapp Styling */
-export const WHATSAPP = {'backgroundColor': '25d366'};
-
-/* line Styling */
-export const LINE = {'backgroundColor': '52b448'};
-
-/* SMS Styling */
-export const SMS = {'backgroundColor': 'ca2b63'};
-
-/* "system" styling */
-export const SYSTEM = {'backgroundColor': '000000'};

--- a/extensions/amp-social-share/1.0/social-share.js
+++ b/extensions/amp-social-share/1.0/social-share.js
@@ -52,7 +52,6 @@ export function SocialShare(props) {
 
   const type = props['type'].toUpperCase();
   const baseStyle = CSS.BASE_STYLE;
-  const backgroundStyle = CSS[type];
   const size = {
     width: checkedWidth,
     height: checkedHeight,
@@ -65,10 +64,7 @@ export function SocialShare(props) {
       onClick={() => handleActivation(finalEndpoint, checkedTarget)}
       style={{...size, ...props['style']}}
     >
-      <SocialShareIcon
-        style={{...backgroundStyle, ...baseStyle, ...size}}
-        type={type}
-      />
+      <SocialShareIcon style={{...baseStyle, ...size}} type={type} />
     </div>
   );
 }


### PR DESCRIPTION
Tracking Issue: #28283

This change allows the publisher to style the icons by setting the `color` and `background-color` CSS properties on the parent `amp-social-share` component (when in AMP mode).  The `color` was previously hardcoded and could not be changed and `background-color` was set using in-line styles in the Preact component so also difficult for the publisher to change (due to high CSS specificity of inline styles).

Now the SVGs elements within the icons will inherit their `color` from their parent and `background-color` will also be inherited.  Default colors will remain in AMP mode using low specificity amp component styling (amp framework css specific to the component) which can be easily overwritten by the publisher in AMP mode.

In Preact mode, default colors will no longer be available.