### PR TITLE
🏗 Sort z-index table differently, add instructions

### DIFF
--- a/build-system/tasks/get-zindex/index.js
+++ b/build-system/tasks/get-zindex/index.js
@@ -33,6 +33,8 @@ const tableOptions = {
   hsep: '   |   ',
 };
 
+const preamble = 'Run `gulp get-zindex` to generate this file.';
+
 /**
  * @param {!Object<string, !Array<number>} acc accumulator object for selectors
  * @param {!Rules} css post css rules object
@@ -142,7 +144,7 @@ function getZindex(cb) {
       const filename = 'css/Z_INDEX.md';
       const rows = [...tableHeaders, ...createTable(filesData)];
       const tbl = table(rows, tableOptions);
-      const output = `Run \`gulp get-zindex\` to generate this file.\n\n${tbl}`;
+      const output = `${preamble}\n\n${tbl}`;
       fs.writeFileSync(filename, await prettierFormat(filename, output));
       cb();
     });

--- a/build-system/tasks/get-zindex/index.js
+++ b/build-system/tasks/get-zindex/index.js
@@ -19,6 +19,7 @@ const fs = require('fs');
 const gulp = require('gulp');
 const PluginError = require('plugin-error');
 const postcss = require('postcss');
+const prettier = require('prettier');
 const table = require('text-table');
 const through = require('through2');
 
@@ -137,14 +138,22 @@ function getZindex(cb) {
     .on('data', (chunk) => {
       filesData[chunk.name] = chunk.selectors;
     })
-    .on('end', () => {
+    .on('end', async () => {
+      const filename = 'css/Z_INDEX.md';
       const rows = createTable(filesData);
       rows.unshift.apply(rows, tableHeaders);
       const tbl = table(rows, tableOptions);
       const output = `Run \`gulp get-zindex\` to generate this file.\n\n${tbl}`;
-      fs.writeFileSync('css/Z_INDEX.md', output);
+      fs.writeFileSync(filename, await prettierFormat(filename, output));
       cb();
     });
+}
+
+async function prettierFormat(filename, output) {
+  return prettier.format(output, {
+    ...(await prettier.resolveConfig(filename)),
+    parser: 'markdown',
+  });
 }
 
 module.exports = {

--- a/build-system/tasks/get-zindex/index.js
+++ b/build-system/tasks/get-zindex/index.js
@@ -102,7 +102,19 @@ function createTable(filesData) {
   rows.sort((a, b) => {
     const aZIndex = parseInt(a[1], 10);
     const bZIndex = parseInt(b[1], 10);
-    return aZIndex - bZIndex;
+    // Word values sorted lexicographically.
+    if (isNaN(aZIndex) && isNaN(bZIndex)) {
+      return a[1].localeCompare(b[1]);
+    }
+    // Word values before length values.
+    if (isNaN(aZIndex)) {
+      return -1;
+    }
+    if (isNaN(bZIndex)) {
+      return 1;
+    }
+    // By length descending.
+    return bZIndex - aZIndex;
   });
   return rows;
 }
@@ -129,7 +141,8 @@ function getZindex(cb) {
       const rows = createTable(filesData);
       rows.unshift.apply(rows, tableHeaders);
       const tbl = table(rows, tableOptions);
-      fs.writeFileSync('css/Z_INDEX.md', tbl);
+      const output = `Run \`gulp get-zindex\` to generate this file.\n\n${tbl}`;
+      fs.writeFileSync('css/Z_INDEX.md', output);
       cb();
     });
 }

--- a/build-system/tasks/get-zindex/index.js
+++ b/build-system/tasks/get-zindex/index.js
@@ -140,8 +140,7 @@ function getZindex(cb) {
     })
     .on('end', async () => {
       const filename = 'css/Z_INDEX.md';
-      const rows = createTable(filesData);
-      rows.unshift.apply(rows, tableHeaders);
+      const rows = [...tableHeaders, ...createTable(filesData)];
       const tbl = table(rows, tableOptions);
       const output = `Run \`gulp get-zindex\` to generate this file.\n\n${tbl}`;
       fs.writeFileSync(filename, await prettierFormat(filename, output));

--- a/build-system/tasks/get-zindex/test.js
+++ b/build-system/tasks/get-zindex/test.js
@@ -26,6 +26,8 @@ const result = {
   },
   'test-2.css': {
     '.selector-4': '80',
+    '.selector-5': 'initial',
+    '.selector-6': 'auto',
   },
 };
 
@@ -46,10 +48,12 @@ test('sync - create array of arrays with z index order', (t) => {
   t.plan(1);
   const table = m.createTable(result);
   const expected = [
-    ['.selector-2', '0', 'test.css'],
-    ['.selector-1', '1', 'test.css'],
-    ['.selector-4', '80', 'test-2.css'],
+    ['.selector-6', 'auto', 'test-2.css'],
+    ['.selector-5', 'initial', 'test-2.css'],
     ['.selector-3', '99', 'test.css'],
+    ['.selector-4', '80', 'test-2.css'],
+    ['.selector-1', '1', 'test.css'],
+    ['.selector-2', '0', 'test.css'],
   ];
   t.deepEqual(table, expected);
 });

--- a/css/Z_INDEX.md
+++ b/css/Z_INDEX.md
@@ -1,130 +1,130 @@
 Run `gulp get-zindex` to generate this file.
 
-selector                                                                                                  |   z-index      |   file
----                                                                                                       |   ---          |   ---
-.i-amphtml-expanded-mode amp-story-grid-layer                                                             |   auto         |   extensions/amp-story/1.0/amp-story.css
-.i-amphtml-expanded-mode amp-story-grid-layer *                                                           |   auto         |   extensions/amp-story/1.0/amp-story.css
-amp-story amp-consent                                                                                     |   initial      |   extensions/amp-story/1.0/amp-story.css
-.amp-access-scroll-bar                                                                                    |   2147483647   |   extensions/amp-access-scroll/0.1/amp-access-scroll.css
-.amp-access-scroll-sheet                                                                                  |   2147483647   |   extensions/amp-access-scroll/0.1/amp-access-scroll.css
-amp-sidebar                                                                                               |   2147483647   |   extensions/amp-sidebar/0.1/amp-sidebar.css
-amp-sidebar                                                                                               |   2147483647   |   extensions/amp-sidebar/0.2/amp-sidebar.css
-.amp-apester-fullscreen                                                                                   |   2147483646   |   extensions/amp-apester-media/0.1/amp-apester-media.css
-.i-amphtml-sidebar-mask                                                                                   |   2147483646   |   extensions/amp-sidebar/0.1/amp-sidebar.css
-.i-amphtml-sidebar-mask                                                                                   |   2147483646   |   extensions/amp-sidebar/0.2/amp-sidebar.css
-.amp-video-docked-controls                                                                                |   2147483646   |   extensions/amp-video-docking/0.1/amp-video-docking.css
-amp-consent                                                                                               |   2147483645   |   extensions/amp-consent/0.1/amp-consent.css
-.i-amphtml-video-docked-overlay                                                                           |   2147483645   |   extensions/amp-video-docking/0.1/amp-video-docking.css
-.i-amphtml-consent-ui-mask                                                                                |   2147483644   |   extensions/amp-consent/0.1/amp-consent.css
-.i-amphtml-video-docked                                                                                   |   2147483644   |   extensions/amp-video-docking/0.1/amp-video-docking.css
-.amp-video-docked-shadow                                                                                  |   2147483643   |   extensions/amp-video-docking/0.1/amp-video-docking.css
-.i-amphtml-lbg                                                                                            |   2147483642   |   extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.css
-amp-lightbox-gallery[i-amphtml-lbg-fade]                                                                  |   2147483642   |   extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.css
-amp-subscriptions-dialog                                                                                  |   2147483641   |   extensions/amp-subscriptions/0.1/amp-subscriptions.css
-amp-story-education                                                                                       |   9999999      |   extensions/amp-story-education/0.1/amp-story-education.css
-[i-amphtml-vertical] .i-amphtml-story-page-description                                                    |   9999999      |   extensions/amp-story/1.0/amp-story-vertical.css
-.i-amphtml-story-unsupported-browser-overlay                                                              |   200001       |   extensions/amp-story/1.0/amp-story-unsupported-browser-layer.css
-.i-amphtml-story-no-rotation-overlay                                                                      |   200000       |   extensions/amp-story/1.0/amp-story-viewport-warning-layer.css
-.i-amphtml-story-consent                                                                                  |   100005       |   extensions/amp-story/1.0/amp-story-consent.css
-amp-story-access[type=blocking]                                                                           |   100004       |   extensions/amp-story/1.0/amp-story-access.css
-.i-amphtml-story-toast                                                                                    |   100004       |   extensions/amp-story/1.0/amp-story.css
-amp-story-access                                                                                          |   100003       |   extensions/amp-story/1.0/amp-story-access.css
-.i-amphtml-story-share-menu                                                                               |   100003       |   extensions/amp-story/1.0/amp-story-share-menu.css
-.i-amphtml-story-opacity-mask                                                                             |   100003       |   extensions/amp-story/1.0/amp-story.css
-.i-amphtml-story-has-new-page-notification-container                                                      |   100002       |   extensions/amp-story/1.0/amp-story-system-layer.css
-amp-story[standalone] .i-amphtml-story-developer-log                                                      |   100002       |   extensions/amp-story/1.0/amp-story.css
-.i-amphtml-story-button-move                                                                              |   100002       |   extensions/amp-story/1.0/pagination-buttons.css
-.i-amphtml-story-desktop-fullbleed .i-amphtml-story-button-container                                      |   100002       |   extensions/amp-story/1.0/pagination-buttons.css
-.i-amphtml-story-desktop-panels .i-amphtml-story-button-container                                         |   100002       |   extensions/amp-story/1.0/pagination-buttons.css
-.i-amphtml-story-page-sentinel                                                                            |   100002       |   extensions/amp-story/1.0/pagination-buttons.css
-.i-amphtml-ad-overlay-container                                                                           |   100001       |   extensions/amp-story-auto-ads/0.1/amp-story-auto-ads-ad-badge.css
-.i-amphtml-story-bookend                                                                                  |   100001       |   extensions/amp-story/1.0/amp-story-bookend.css
-.i-amphtml-story-info-dialog                                                                              |   100001       |   extensions/amp-story/1.0/amp-story-info-dialog.css
-.i-amphtml-story-progress-bar                                                                             |   100001       |   extensions/amp-story/1.0/amp-story-system-layer.css
-.i-amphtml-story-focused-state-layer                                                                      |   100001       |   extensions/amp-story/1.0/amp-story-tooltip.css
-.i-amphtml-story-page-attachment-expand                                                                   |   100000       |   extensions/amp-story/1.0/amp-story-page-attachment.css
-.i-amphtml-story-system-layer                                                                             |   100000       |   extensions/amp-story/1.0/amp-story-system-layer.css
-.i-amphtml-story-page-error                                                                               |   10000        |   extensions/amp-story/1.0/amp-story.css
-.i-amphtml-story-page-play-button                                                                         |   10000        |   extensions/amp-story/1.0/amp-story.css
-.i-amphtml-image-lightbox-trans                                                                           |   1001         |   extensions/amp-image-lightbox/0.1/amp-image-lightbox.css
-.i-amphtml-jank-meter                                                                                     |   1000         |   css/ampdoc.css
-amp-image-lightbox                                                                                        |   1000         |   extensions/amp-image-lightbox/0.1/amp-image-lightbox.css
-amp-lightbox                                                                                              |   1000         |   extensions/amp-lightbox/0.1/amp-lightbox.css
-i-amphtml-ad-close-header                                                                                 |   1000         |   extensions/amp-lightbox/0.1/amp-lightbox.css
-amp-live-list > [update]                                                                                  |   1000         |   extensions/amp-live-list/0.1/amp-live-list.css
-.i-amphtml-mega-menu-mask-parent                                                                          |   1000         |   extensions/amp-mega-menu/0.1/amp-mega-menu.css
-amp-mega-menu                                                                                             |   1000         |   extensions/amp-mega-menu/0.1/amp-mega-menu.css
-amp-user-notification                                                                                     |   1000         |   extensions/amp-user-notification/0.1/amp-user-notification.css
-i-amphtml-app-banner-top-padding                                                                          |   15           |   extensions/amp-app-banner/0.1/amp-app-banner.css
-.amp-app-banner-dismiss-button                                                                            |   14           |   extensions/amp-app-banner/0.1/amp-app-banner.css
-amp-app-banner                                                                                            |   13           |   extensions/amp-app-banner/0.1/amp-app-banner.css
-amp-sticky-ad-top-padding                                                                                 |   12           |   extensions/amp-sticky-ad/1.0/amp-sticky-ad.css
-amp-sticky-ad                                                                                             |   11           |   extensions/amp-sticky-ad/1.0/amp-sticky-ad.css
-.i-amphtml-autocomplete-results                                                                           |   10           |   extensions/amp-autocomplete/0.1/amp-autocomplete.css
-.amp-carousel-button                                                                                      |   10           |   extensions/amp-carousel/0.1/amp-carousel.css
-.amp-carousel-button                                                                                      |   10           |   extensions/amp-carousel/0.2/amp-carousel.css
-amp-date-picker[mode="overlay"] .i-amphtml-date-picker-container                                          |   10           |   extensions/amp-date-picker/0.1/amp-date-picker.css
-.i-amphtml-story-spinner                                                                                  |   10           |   extensions/amp-story/1.0/amp-story.css
-.i-amphtml-byside-content-loading-container .i-amphtml-byside-content-loading-animation:before            |   9            |   extensions/amp-byside-content/0.1/amp-byside-content.css
-100%                                                                                                      |   9            |   extensions/amp-byside-content/0.1/amp-byside-content.css
-.i-amphtml-story-ad-attribution                                                                           |   4            |   extensions/amp-story-auto-ads/0.1/amp-story-auto-ads-attribution.css
-.i-amphtml-story-desktop-panels amp-story-page[i-amphtml-desktop-position="1"][amp-access-hide]::before   |   4            |   extensions/amp-story/1.0/amp-story-desktop-panels.css
-.amp-story-draggable-drawer-root                                                                          |   4            |   extensions/amp-story/1.0/amp-story-draggable-drawer.css
-.i-amphtml-image-slider-bar                                                                               |   3            |   extensions/amp-image-slider/0.1/amp-image-slider.css
-amp-story-page[active] .i-amphtml-story-page-open-attachment                                              |   3            |   extensions/amp-story/1.0/amp-story-page-attachment.css
-amp-story-cta-layer                                                                                       |   3            |   extensions/amp-story/1.0/amp-story.css
-.i-amphtml-element > [overflow]                                                                           |   2            |   css/ampshared.css
-.i-amphtml-image-lightbox-caption                                                                         |   2            |   extensions/amp-image-lightbox/0.1/amp-image-lightbox.css
-.i-amphtml-image-slider-hint                                                                              |   2            |   extensions/amp-image-slider/0.1/amp-image-slider.css
-.i-amphtml-story-access-header                                                                            |   2            |   extensions/amp-story/1.0/amp-story-access.css
-.i-amphtml-story-consent-header                                                                           |   2            |   extensions/amp-story/1.0/amp-story-consent.css
-.i-amphtml-story-hint-container                                                                           |   2            |   extensions/amp-story/1.0/amp-story-hint.css
-.i-amphtml-story-bookend-active amp-story-page[active]::after                                             |   2            |   extensions/amp-story/1.0/amp-story.css
-amp-story-grid-layer                                                                                      |   2            |   extensions/amp-story/1.0/amp-story.css
-.i-amphtml-layout-size-defined > [fallback]                                                               |   1            |   css/ampshared.css
-.i-amphtml-layout-size-defined > [placeholder]                                                            |   1            |   css/ampshared.css
-.i-amphtml-loading-container                                                                              |   1            |   css/ampshared.css
-.amp-video-eq                                                                                             |   1            |   css/video-autoplay.css
-i-amphtml-video-mask                                                                                      |   1            |   css/video-autoplay.css
-amp-addthis .i-amphtml-addthis-close                                                                      |   1            |   extensions/amp-addthis/0.1/amp-addthis.css
-.i-amphtml-base-carousel-arrow-icon                                                                       |   1            |   extensions/amp-base-carousel/0.1/amp-base-carousel.css
-.i-amphtml-base-carousel-arrow-next-slot                                                                  |   1            |   extensions/amp-base-carousel/0.1/amp-base-carousel.css
-.i-amphtml-base-carousel-arrow-prev-slot                                                                  |   1            |   extensions/amp-base-carousel/0.1/amp-base-carousel.css
-.i-amphtml-base-carousel-arrows                                                                           |   1            |   extensions/amp-base-carousel/0.1/amp-base-carousel.css
-.i-amphtml-carousel-arrows                                                                                |   1            |   extensions/amp-carousel/0.2/amp-carousel.css
-.i-amphtml-image-lightbox-viewer                                                                          |   1            |   extensions/amp-image-lightbox/0.1/amp-image-lightbox.css
-.i-amphtml-image-lightbox-viewer-image                                                                    |   1            |   extensions/amp-image-lightbox/0.1/amp-image-lightbox.css
-.i-amphtml-image-slider-label-wrapper                                                                     |   1            |   extensions/amp-image-slider/0.1/amp-image-slider.css
-.i-amphtml-image-slider-right-mask                                                                        |   1            |   extensions/amp-image-slider/0.1/amp-image-slider.css
-.i-amphtml-inline-gallery-pagination-count                                                                |   1            |   extensions/amp-inline-gallery/0.1/amp-inline-gallery-pagination.css
-.i-amphtml-inline-gallery-pagination-dot-container                                                        |   1            |   extensions/amp-inline-gallery/0.1/amp-inline-gallery-pagination.css
-.i-amphtml-lbg-caption-scroll                                                                             |   1            |   extensions/amp-lightbox-gallery/0.1/lightbox-caption.css
-[i-amphtml-lbg-caption-state="clip"] + .i-amphtml-lbg-caption-mask                                        |   1            |   extensions/amp-lightbox-gallery/0.1/lightbox-caption.css
-.i-amphtml-lbg-top-bar                                                                                    |   1            |   extensions/amp-lightbox-gallery/0.1/lightbox-controls.css
-.i-amphtml-glass-pane                                                                                     |   1            |   extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.css
-.i-amphtml-story-consent-actions                                                                          |   1            |   extensions/amp-story/1.0/amp-story-consent.css
-.i-amphtml-story-draggable-drawer-header                                                                  |   1            |   extensions/amp-story/1.0/amp-story-draggable-drawer-header.css
-.i-amphtml-story-hint-container .i-amphtml-story-hint-tap-button-icon                                     |   1            |   extensions/amp-story/1.0/amp-story-hint.css
-.i-amphtml-story-interactive-option-text                                                                  |   1            |   extensions/amp-story/1.0/amp-story-interactive-poll.css
-.i-amphtml-story-bookend-active.i-amphtml-story-system-layer                                              |   1            |   extensions/amp-story/1.0/amp-story-system-layer.css
-.i-amphtml-expanded-mode .i-amphtml-embedded-component.i-amphtml-expanded-component                       |   1            |   extensions/amp-story/1.0/amp-story.css
-amp-story-page[active]                                                                                    |   1            |   extensions/amp-story/1.0/amp-story.css
-.i-amphtml-stream-gallery-next                                                                            |   1            |   extensions/amp-stream-gallery/0.1/arrows.css
-.i-amphtml-stream-gallery-prev                                                                            |   1            |   extensions/amp-stream-gallery/0.1/arrows.css
-.i-amphtml-byside-content-loading-container .i-amphtml-byside-content-loading-animation:after             |   0            |   extensions/amp-byside-content/0.1/amp-byside-content.css
-0%                                                                                                        |   0            |   extensions/amp-byside-content/0.1/amp-byside-content.css
-.i-amphtml-image-lightbox-container                                                                       |   0            |   extensions/amp-image-lightbox/0.1/amp-image-lightbox.css
-.i-amphtml-inline-gallery-pagination-dots                                                                 |   0            |   extensions/amp-inline-gallery/0.1/amp-inline-gallery-pagination.css
-.i-amphtml-inline-gallery-pagination-numbers                                                              |   0            |   extensions/amp-inline-gallery/0.1/amp-inline-gallery-pagination.css
-[i-amphtml-lbg-caption-state="expand"] + .i-amphtml-lbg-caption-mask                                      |   0            |   extensions/amp-lightbox-gallery/0.1/lightbox-caption.css
-.i-amphtml-story-access-content                                                                           |   0            |   extensions/amp-story/1.0/amp-story-access.css
-.i-amphtml-story-consent-content                                                                          |   0            |   extensions/amp-story/1.0/amp-story-consent.css
-.i-amphtml-story-interactive-quiz-option                                                                  |   0            |   extensions/amp-story/1.0/amp-story-interactive-quiz.css
-amp-story-page                                                                                            |   0            |   extensions/amp-story/1.0/amp-story.css
-.amp-video-docked-placeholder-background                                                                  |   0            |   extensions/amp-video-docking/0.1/amp-video-docking.css
-.i-amphtml-carousel-spacer                                                                                |   -1           |   extensions/amp-base-carousel/0.1/carousel.css
-.i-amphtml-mega-menu-mask                                                                                 |   -1           |   extensions/amp-mega-menu/0.1/amp-mega-menu.css
-.i-amphtml-story-access-logo::before                                                                      |   -1           |   extensions/amp-story/1.0/amp-story-access.css
-.i-amphtml-story-consent-logo::before                                                                     |   -1           |   extensions/amp-story/1.0/amp-story-consent.css
-amp-story-page .i-amphtml-story-page-open-attachment-icon::after                                          |   -1           |   extensions/amp-story/1.0/amp-story-page-attachment.css
-.i-amphtml-story-media-query-matcher                                                                      |   -1           |   extensions/amp-story/1.0/amp-story.css
+| selector                                                                                                | z-index    | file                                                                 |
+| ------------------------------------------------------------------------------------------------------- | ---------- | -------------------------------------------------------------------- |
+| .i-amphtml-expanded-mode amp-story-grid-layer                                                           | auto       | extensions/amp-story/1.0/amp-story.css                               |
+| .i-amphtml-expanded-mode amp-story-grid-layer \*                                                        | auto       | extensions/amp-story/1.0/amp-story.css                               |
+| amp-story amp-consent                                                                                   | initial    | extensions/amp-story/1.0/amp-story.css                               |
+| .amp-access-scroll-bar                                                                                  | 2147483647 | extensions/amp-access-scroll/0.1/amp-access-scroll.css               |
+| .amp-access-scroll-sheet                                                                                | 2147483647 | extensions/amp-access-scroll/0.1/amp-access-scroll.css               |
+| amp-sidebar                                                                                             | 2147483647 | extensions/amp-sidebar/0.1/amp-sidebar.css                           |
+| amp-sidebar                                                                                             | 2147483647 | extensions/amp-sidebar/0.2/amp-sidebar.css                           |
+| .amp-apester-fullscreen                                                                                 | 2147483646 | extensions/amp-apester-media/0.1/amp-apester-media.css               |
+| .i-amphtml-sidebar-mask                                                                                 | 2147483646 | extensions/amp-sidebar/0.1/amp-sidebar.css                           |
+| .i-amphtml-sidebar-mask                                                                                 | 2147483646 | extensions/amp-sidebar/0.2/amp-sidebar.css                           |
+| .amp-video-docked-controls                                                                              | 2147483646 | extensions/amp-video-docking/0.1/amp-video-docking.css               |
+| amp-consent                                                                                             | 2147483645 | extensions/amp-consent/0.1/amp-consent.css                           |
+| .i-amphtml-video-docked-overlay                                                                         | 2147483645 | extensions/amp-video-docking/0.1/amp-video-docking.css               |
+| .i-amphtml-consent-ui-mask                                                                              | 2147483644 | extensions/amp-consent/0.1/amp-consent.css                           |
+| .i-amphtml-video-docked                                                                                 | 2147483644 | extensions/amp-video-docking/0.1/amp-video-docking.css               |
+| .amp-video-docked-shadow                                                                                | 2147483643 | extensions/amp-video-docking/0.1/amp-video-docking.css               |
+| .i-amphtml-lbg                                                                                          | 2147483642 | extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.css         |
+| amp-lightbox-gallery[i-amphtml-lbg-fade]                                                                | 2147483642 | extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.css         |
+| amp-subscriptions-dialog                                                                                | 2147483641 | extensions/amp-subscriptions/0.1/amp-subscriptions.css               |
+| amp-story-education                                                                                     | 9999999    | extensions/amp-story-education/0.1/amp-story-education.css           |
+| [i-amphtml-vertical] .i-amphtml-story-page-description                                                  | 9999999    | extensions/amp-story/1.0/amp-story-vertical.css                      |
+| .i-amphtml-story-unsupported-browser-overlay                                                            | 200001     | extensions/amp-story/1.0/amp-story-unsupported-browser-layer.css     |
+| .i-amphtml-story-no-rotation-overlay                                                                    | 200000     | extensions/amp-story/1.0/amp-story-viewport-warning-layer.css        |
+| .i-amphtml-story-consent                                                                                | 100005     | extensions/amp-story/1.0/amp-story-consent.css                       |
+| amp-story-access[type=blocking]                                                                         | 100004     | extensions/amp-story/1.0/amp-story-access.css                        |
+| .i-amphtml-story-toast                                                                                  | 100004     | extensions/amp-story/1.0/amp-story.css                               |
+| amp-story-access                                                                                        | 100003     | extensions/amp-story/1.0/amp-story-access.css                        |
+| .i-amphtml-story-share-menu                                                                             | 100003     | extensions/amp-story/1.0/amp-story-share-menu.css                    |
+| .i-amphtml-story-opacity-mask                                                                           | 100003     | extensions/amp-story/1.0/amp-story.css                               |
+| .i-amphtml-story-has-new-page-notification-container                                                    | 100002     | extensions/amp-story/1.0/amp-story-system-layer.css                  |
+| amp-story[standalone] .i-amphtml-story-developer-log                                                    | 100002     | extensions/amp-story/1.0/amp-story.css                               |
+| .i-amphtml-story-button-move                                                                            | 100002     | extensions/amp-story/1.0/pagination-buttons.css                      |
+| .i-amphtml-story-desktop-fullbleed .i-amphtml-story-button-container                                    | 100002     | extensions/amp-story/1.0/pagination-buttons.css                      |
+| .i-amphtml-story-desktop-panels .i-amphtml-story-button-container                                       | 100002     | extensions/amp-story/1.0/pagination-buttons.css                      |
+| .i-amphtml-story-page-sentinel                                                                          | 100002     | extensions/amp-story/1.0/pagination-buttons.css                      |
+| .i-amphtml-ad-overlay-container                                                                         | 100001     | extensions/amp-story-auto-ads/0.1/amp-story-auto-ads-ad-badge.css    |
+| .i-amphtml-story-bookend                                                                                | 100001     | extensions/amp-story/1.0/amp-story-bookend.css                       |
+| .i-amphtml-story-info-dialog                                                                            | 100001     | extensions/amp-story/1.0/amp-story-info-dialog.css                   |
+| .i-amphtml-story-progress-bar                                                                           | 100001     | extensions/amp-story/1.0/amp-story-system-layer.css                  |
+| .i-amphtml-story-focused-state-layer                                                                    | 100001     | extensions/amp-story/1.0/amp-story-tooltip.css                       |
+| .i-amphtml-story-page-attachment-expand                                                                 | 100000     | extensions/amp-story/1.0/amp-story-page-attachment.css               |
+| .i-amphtml-story-system-layer                                                                           | 100000     | extensions/amp-story/1.0/amp-story-system-layer.css                  |
+| .i-amphtml-story-page-error                                                                             | 10000      | extensions/amp-story/1.0/amp-story.css                               |
+| .i-amphtml-story-page-play-button                                                                       | 10000      | extensions/amp-story/1.0/amp-story.css                               |
+| .i-amphtml-image-lightbox-trans                                                                         | 1001       | extensions/amp-image-lightbox/0.1/amp-image-lightbox.css             |
+| .i-amphtml-jank-meter                                                                                   | 1000       | css/ampdoc.css                                                       |
+| amp-image-lightbox                                                                                      | 1000       | extensions/amp-image-lightbox/0.1/amp-image-lightbox.css             |
+| amp-lightbox                                                                                            | 1000       | extensions/amp-lightbox/0.1/amp-lightbox.css                         |
+| i-amphtml-ad-close-header                                                                               | 1000       | extensions/amp-lightbox/0.1/amp-lightbox.css                         |
+| amp-live-list > [update]                                                                                | 1000       | extensions/amp-live-list/0.1/amp-live-list.css                       |
+| .i-amphtml-mega-menu-mask-parent                                                                        | 1000       | extensions/amp-mega-menu/0.1/amp-mega-menu.css                       |
+| amp-mega-menu                                                                                           | 1000       | extensions/amp-mega-menu/0.1/amp-mega-menu.css                       |
+| amp-user-notification                                                                                   | 1000       | extensions/amp-user-notification/0.1/amp-user-notification.css       |
+| i-amphtml-app-banner-top-padding                                                                        | 15         | extensions/amp-app-banner/0.1/amp-app-banner.css                     |
+| .amp-app-banner-dismiss-button                                                                          | 14         | extensions/amp-app-banner/0.1/amp-app-banner.css                     |
+| amp-app-banner                                                                                          | 13         | extensions/amp-app-banner/0.1/amp-app-banner.css                     |
+| amp-sticky-ad-top-padding                                                                               | 12         | extensions/amp-sticky-ad/1.0/amp-sticky-ad.css                       |
+| amp-sticky-ad                                                                                           | 11         | extensions/amp-sticky-ad/1.0/amp-sticky-ad.css                       |
+| .i-amphtml-autocomplete-results                                                                         | 10         | extensions/amp-autocomplete/0.1/amp-autocomplete.css                 |
+| .amp-carousel-button                                                                                    | 10         | extensions/amp-carousel/0.1/amp-carousel.css                         |
+| .amp-carousel-button                                                                                    | 10         | extensions/amp-carousel/0.2/amp-carousel.css                         |
+| amp-date-picker[mode="overlay"] .i-amphtml-date-picker-container                                        | 10         | extensions/amp-date-picker/0.1/amp-date-picker.css                   |
+| .i-amphtml-story-spinner                                                                                | 10         | extensions/amp-story/1.0/amp-story.css                               |
+| .i-amphtml-byside-content-loading-container .i-amphtml-byside-content-loading-animation:before          | 9          | extensions/amp-byside-content/0.1/amp-byside-content.css             |
+| 100%                                                                                                    | 9          | extensions/amp-byside-content/0.1/amp-byside-content.css             |
+| .i-amphtml-story-ad-attribution                                                                         | 4          | extensions/amp-story-auto-ads/0.1/amp-story-auto-ads-attribution.css |
+| .i-amphtml-story-desktop-panels amp-story-page[i-amphtml-desktop-position="1"][amp-access-hide]::before | 4          | extensions/amp-story/1.0/amp-story-desktop-panels.css                |
+| .amp-story-draggable-drawer-root                                                                        | 4          | extensions/amp-story/1.0/amp-story-draggable-drawer.css              |
+| .i-amphtml-image-slider-bar                                                                             | 3          | extensions/amp-image-slider/0.1/amp-image-slider.css                 |
+| amp-story-page[active] .i-amphtml-story-page-open-attachment                                            | 3          | extensions/amp-story/1.0/amp-story-page-attachment.css               |
+| amp-story-cta-layer                                                                                     | 3          | extensions/amp-story/1.0/amp-story.css                               |
+| .i-amphtml-element > [overflow]                                                                         | 2          | css/ampshared.css                                                    |
+| .i-amphtml-image-lightbox-caption                                                                       | 2          | extensions/amp-image-lightbox/0.1/amp-image-lightbox.css             |
+| .i-amphtml-image-slider-hint                                                                            | 2          | extensions/amp-image-slider/0.1/amp-image-slider.css                 |
+| .i-amphtml-story-access-header                                                                          | 2          | extensions/amp-story/1.0/amp-story-access.css                        |
+| .i-amphtml-story-consent-header                                                                         | 2          | extensions/amp-story/1.0/amp-story-consent.css                       |
+| .i-amphtml-story-hint-container                                                                         | 2          | extensions/amp-story/1.0/amp-story-hint.css                          |
+| .i-amphtml-story-bookend-active amp-story-page[active]::after                                           | 2          | extensions/amp-story/1.0/amp-story.css                               |
+| amp-story-grid-layer                                                                                    | 2          | extensions/amp-story/1.0/amp-story.css                               |
+| .i-amphtml-layout-size-defined > [fallback]                                                             | 1          | css/ampshared.css                                                    |
+| .i-amphtml-layout-size-defined > [placeholder]                                                          | 1          | css/ampshared.css                                                    |
+| .i-amphtml-loading-container                                                                            | 1          | css/ampshared.css                                                    |
+| .amp-video-eq                                                                                           | 1          | css/video-autoplay.css                                               |
+| i-amphtml-video-mask                                                                                    | 1          | css/video-autoplay.css                                               |
+| amp-addthis .i-amphtml-addthis-close                                                                    | 1          | extensions/amp-addthis/0.1/amp-addthis.css                           |
+| .i-amphtml-base-carousel-arrow-icon                                                                     | 1          | extensions/amp-base-carousel/0.1/amp-base-carousel.css               |
+| .i-amphtml-base-carousel-arrow-next-slot                                                                | 1          | extensions/amp-base-carousel/0.1/amp-base-carousel.css               |
+| .i-amphtml-base-carousel-arrow-prev-slot                                                                | 1          | extensions/amp-base-carousel/0.1/amp-base-carousel.css               |
+| .i-amphtml-base-carousel-arrows                                                                         | 1          | extensions/amp-base-carousel/0.1/amp-base-carousel.css               |
+| .i-amphtml-carousel-arrows                                                                              | 1          | extensions/amp-carousel/0.2/amp-carousel.css                         |
+| .i-amphtml-image-lightbox-viewer                                                                        | 1          | extensions/amp-image-lightbox/0.1/amp-image-lightbox.css             |
+| .i-amphtml-image-lightbox-viewer-image                                                                  | 1          | extensions/amp-image-lightbox/0.1/amp-image-lightbox.css             |
+| .i-amphtml-image-slider-label-wrapper                                                                   | 1          | extensions/amp-image-slider/0.1/amp-image-slider.css                 |
+| .i-amphtml-image-slider-right-mask                                                                      | 1          | extensions/amp-image-slider/0.1/amp-image-slider.css                 |
+| .i-amphtml-inline-gallery-pagination-count                                                              | 1          | extensions/amp-inline-gallery/0.1/amp-inline-gallery-pagination.css  |
+| .i-amphtml-inline-gallery-pagination-dot-container                                                      | 1          | extensions/amp-inline-gallery/0.1/amp-inline-gallery-pagination.css  |
+| .i-amphtml-lbg-caption-scroll                                                                           | 1          | extensions/amp-lightbox-gallery/0.1/lightbox-caption.css             |
+| [i-amphtml-lbg-caption-state="clip"] + .i-amphtml-lbg-caption-mask                                      | 1          | extensions/amp-lightbox-gallery/0.1/lightbox-caption.css             |
+| .i-amphtml-lbg-top-bar                                                                                  | 1          | extensions/amp-lightbox-gallery/0.1/lightbox-controls.css            |
+| .i-amphtml-glass-pane                                                                                   | 1          | extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.css             |
+| .i-amphtml-story-consent-actions                                                                        | 1          | extensions/amp-story/1.0/amp-story-consent.css                       |
+| .i-amphtml-story-draggable-drawer-header                                                                | 1          | extensions/amp-story/1.0/amp-story-draggable-drawer-header.css       |
+| .i-amphtml-story-hint-container .i-amphtml-story-hint-tap-button-icon                                   | 1          | extensions/amp-story/1.0/amp-story-hint.css                          |
+| .i-amphtml-story-interactive-option-text                                                                | 1          | extensions/amp-story/1.0/amp-story-interactive-poll.css              |
+| .i-amphtml-story-bookend-active.i-amphtml-story-system-layer                                            | 1          | extensions/amp-story/1.0/amp-story-system-layer.css                  |
+| .i-amphtml-expanded-mode .i-amphtml-embedded-component.i-amphtml-expanded-component                     | 1          | extensions/amp-story/1.0/amp-story.css                               |
+| amp-story-page[active]                                                                                  | 1          | extensions/amp-story/1.0/amp-story.css                               |
+| .i-amphtml-stream-gallery-next                                                                          | 1          | extensions/amp-stream-gallery/0.1/arrows.css                         |
+| .i-amphtml-stream-gallery-prev                                                                          | 1          | extensions/amp-stream-gallery/0.1/arrows.css                         |
+| .i-amphtml-byside-content-loading-container .i-amphtml-byside-content-loading-animation:after           | 0          | extensions/amp-byside-content/0.1/amp-byside-content.css             |
+| 0%                                                                                                      | 0          | extensions/amp-byside-content/0.1/amp-byside-content.css             |
+| .i-amphtml-image-lightbox-container                                                                     | 0          | extensions/amp-image-lightbox/0.1/amp-image-lightbox.css             |
+| .i-amphtml-inline-gallery-pagination-dots                                                               | 0          | extensions/amp-inline-gallery/0.1/amp-inline-gallery-pagination.css  |
+| .i-amphtml-inline-gallery-pagination-numbers                                                            | 0          | extensions/amp-inline-gallery/0.1/amp-inline-gallery-pagination.css  |
+| [i-amphtml-lbg-caption-state="expand"] + .i-amphtml-lbg-caption-mask                                    | 0          | extensions/amp-lightbox-gallery/0.1/lightbox-caption.css             |
+| .i-amphtml-story-access-content                                                                         | 0          | extensions/amp-story/1.0/amp-story-access.css                        |
+| .i-amphtml-story-consent-content                                                                        | 0          | extensions/amp-story/1.0/amp-story-consent.css                       |
+| .i-amphtml-story-interactive-quiz-option                                                                | 0          | extensions/amp-story/1.0/amp-story-interactive-quiz.css              |
+| amp-story-page                                                                                          | 0          | extensions/amp-story/1.0/amp-story.css                               |
+| .amp-video-docked-placeholder-background                                                                | 0          | extensions/amp-video-docking/0.1/amp-video-docking.css               |
+| .i-amphtml-carousel-spacer                                                                              | -1         | extensions/amp-base-carousel/0.1/carousel.css                        |
+| .i-amphtml-mega-menu-mask                                                                               | -1         | extensions/amp-mega-menu/0.1/amp-mega-menu.css                       |
+| .i-amphtml-story-access-logo::before                                                                    | -1         | extensions/amp-story/1.0/amp-story-access.css                        |
+| .i-amphtml-story-consent-logo::before                                                                   | -1         | extensions/amp-story/1.0/amp-story-consent.css                       |
+| amp-story-page .i-amphtml-story-page-open-attachment-icon::after                                        | -1         | extensions/amp-story/1.0/amp-story-page-attachment.css               |
+| .i-amphtml-story-media-query-matcher                                                                    | -1         | extensions/amp-story/1.0/amp-story.css                               |

--- a/css/Z_INDEX.md
+++ b/css/Z_INDEX.md
@@ -1,144 +1,130 @@
-| selector                                                                                                | z-index    | file                                                             |
-| ------------------------------------------------------------------------------------------------------- | ---------- | ---------------------------------------------------------------- |
-| .i-amphtml-story-share-icon::before                                                                     | -1         | extensions/amp-story/0.1/amp-story-share.css                     |
-| amp-story-page .i-amphtml-story-page-open-attachment-icon::after                                        | -1         | extensions/amp-story/1.0/amp-story.css                           |
-| .i-amphtml-carousel-spacer                                                                              | -1         | extensions/amp-base-carousel/0.1/carousel.css                    |
-| .i-amphtml-story-media-query-matcher                                                                    | -1         | extensions/amp-story/1.0/amp-story.css                           |
-| .i-amphtml-story-consent-logo::before                                                                   | -1         | extensions/amp-story/1.0/amp-story-consent.css                   |
-| .i-amphtml-story-bookend-inner::before                                                                  | -1         | extensions/amp-story/1.0/amp-story-bookend.css                   |
-| .i-amphtml-story-access-logo::before                                                                    | -1         | extensions/amp-story/1.0/amp-story-access.css                    |
-| .i-amphtml-story-bookend-inner::before                                                                  | -1         | extensions/amp-story/0.1/amp-story-bookend.css                   |
-| .i-amphtml-story-consent-logo::before                                                                   | -1         | extensions/amp-story/0.1/amp-story-consent.css                   |
-| [i-amphtml-lbg-caption-state="expand"] + .i-amphtml-lbg-caption-mask                                    | 0          | extensions/amp-lightbox-gallery/0.1/lightbox-caption.css         |
-| .amp-video-docked-placeholder-background                                                                | 0          | extensions/amp-video-docking/0.1/amp-video-docking.css           |
-| amp-story-page                                                                                          | 0          | extensions/amp-story/0.1/amp-story.css                           |
-| .i-amphtml-story-consent-content                                                                        | 0          | extensions/amp-story/1.0/amp-story-consent.css                   |
-| .i-amphtml-byside-content-loading-container .i-amphtml-byside-content-loading-animation:after           | 0          | extensions/amp-byside-content/0.1/amp-byside-content.css         |
-| amp-story-page                                                                                          | 0          | extensions/amp-story/1.0/amp-story.css                           |
-| .i-amphtml-story-access-content                                                                         | 0          | extensions/amp-story/1.0/amp-story-access.css                    |
-| 0%                                                                                                      | 0          | extensions/amp-byside-content/0.1/amp-byside-content.css         |
-| .i-amphtml-story-consent-content                                                                        | 0          | extensions/amp-story/0.1/amp-story-consent.css                   |
-| .i-amphtml-image-lightbox-container                                                                     | 0          | extensions/amp-image-lightbox/0.1/amp-image-lightbox.css         |
-| .i-amphtml-story-background                                                                             | 0          | extensions/amp-story/0.1/amp-story-desktop.css                   |
-| .i-amphtml-story-background                                                                             | 0          | extensions/amp-story/1.0/amp-story-desktop-panels.css            |
-| .i-amphtml-image-lightbox-viewer-image                                                                  | 1          | extensions/amp-image-lightbox/0.1/amp-image-lightbox.css         |
-| .i-amphtml-story-background.active                                                                      | 1          | extensions/amp-story/1.0/amp-story-desktop-panels.css            |
-| .i-amphtml-image-slider-label-wrapper                                                                   | 1          | extensions/amp-image-slider/0.1/amp-image-slider.css             |
-| .i-amphtml-image-slider-right-mask                                                                      | 1          | extensions/amp-image-slider/0.1/amp-image-slider.css             |
-| .i-amphtml-story-background-overlay::after                                                              | 1          | extensions/amp-story/1.0/amp-story-desktop-panels.css            |
-| .i-amphtml-layout-size-defined > [fallback]                                                             | 1          | css/ampdoc.css                                                   |
-| .i-amphtml-story-background-overlay                                                                     | 1          | extensions/amp-story/1.0/amp-story-desktop-panels.css            |
-| .i-amphtml-lbg-caption-scroll                                                                           | 1          | extensions/amp-lightbox-gallery/0.1/lightbox-caption.css         |
-| [i-amphtml-lbg-caption-state="clip"] + .i-amphtml-lbg-caption-mask                                      | 1          | extensions/amp-lightbox-gallery/0.1/lightbox-caption.css         |
-| .i-amphtml-loading-container                                                                            | 1          | css/ampdoc.css                                                   |
-| .i-amphtml-carousel-arrow-next-slot                                                                     | 1          | extensions/amp-base-carousel/0.1/amp-base-carousel.css           |
-| .i-amphtml-carousel-arrow-prev-slot                                                                     | 1          | extensions/amp-base-carousel/0.1/amp-base-carousel.css           |
-| .amp-video-eq                                                                                           | 1          | css/video-autoplay.css                                           |
-| .i-amphtml-story-consent-actions                                                                        | 1          | extensions/amp-story/1.0/amp-story-consent.css                   |
-| i-amphtml-video-mask                                                                                    | 1          | css/video-autoplay.css                                           |
-| .i-amphtml-story-hint-container .i-amphtml-story-hint-tap-button-icon                                   | 1          | extensions/amp-story/0.1/amp-story-hint.css                      |
-| .i-amphtml-glass-pane                                                                                   | 1          | extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.css         |
-| amp-story-page[active]                                                                                  | 1          | extensions/amp-story/1.0/amp-story.css                           |
-| .i-amphtml-story-bookend-fullbleed::before                                                              | 1          | extensions/amp-story/0.1/amp-story-bookend.css                   |
-| .i-amphtml-expanded-mode .i-amphtml-embedded-component.i-amphtml-expanded-component                     | 1          | extensions/amp-story/1.0/amp-story.css                           |
-| amp-story-page[active]                                                                                  | 1          | extensions/amp-story/0.1/amp-story.css                           |
-| .i-amphtml-story-consent-actions                                                                        | 1          | extensions/amp-story/0.1/amp-story-consent.css                   |
-| .i-amphtml-story-page-attachment-header                                                                 | 1          | extensions/amp-story/1.0/amp-story-page-attachment-header.css    |
-| .i-amphtml-layout-size-defined > [placeholder]                                                          | 1          | css/ampdoc.css                                                   |
-| .i-amphtml-story-hint-container .i-amphtml-story-hint-tap-button-icon                                   | 1          | extensions/amp-story/1.0/amp-story-hint.css                      |
-| .i-amphtml-story-background-overlay                                                                     | 1          | extensions/amp-story/0.1/amp-story-desktop.css                   |
-| .i-amphtml-story-background-overlay::after                                                              | 1          | extensions/amp-story/0.1/amp-story-desktop.css                   |
-| .i-amphtml-story-background.active                                                                      | 1          | extensions/amp-story/0.1/amp-story-desktop.css                   |
-| .i-amphtml-image-lightbox-viewer                                                                        | 1          | extensions/amp-image-lightbox/0.1/amp-image-lightbox.css         |
-| div.i-amphtml-story-top                                                                                 | 1          | extensions/amp-story/0.1/amp-story-desktop.css                   |
-| .i-amphtml-lbg-top-bar                                                                                  | 1          | extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.css     |
-| .i-amphtml-story-hint-container                                                                         | 2          | extensions/amp-story/1.0/amp-story-hint.css                      |
-| .i-amphtml-expanded-mode amp-story-grid-layer                                                           | auto       | extensions/amp-story/1.0/amp-story.css                           |
-| .i-amphtml-image-slider-hint                                                                            | 2          | extensions/amp-image-slider/0.1/amp-image-slider.css             |
-| .i-amphtml-story-consent-header                                                                         | 2          | extensions/amp-story/1.0/amp-story-consent.css                   |
-| .i-amphtml-story-consent-header                                                                         | 2          | extensions/amp-story/0.1/amp-story-consent.css                   |
-| amp-story-grid-layer                                                                                    | 2          | extensions/amp-story/1.0/amp-story.css                           |
-| amp-consent                                                                                             | initial    | extensions/amp-story/1.0/amp-story.css                           |
-| .i-amphtml-image-lightbox-caption                                                                       | 2          | extensions/amp-image-lightbox/0.1/amp-image-lightbox.css         |
-| .i-amphtml-loader-moving-line                                                                           | 2          | css/ampdoc.css                                                   |
-| .i-amphtml-story-access-header                                                                          | 2          | extensions/amp-story/1.0/amp-story-access.css                    |
-| .i-amphtml-element > [overflow]                                                                         | 2          | css/ampdoc.css                                                   |
-| amp-story-grid-layer                                                                                    | 2          | extensions/amp-story/0.1/amp-story.css                           |
-| amp-consent                                                                                             | initial    | extensions/amp-story/0.1/amp-story.css                           |
-| .i-amphtml-story-bookend-active > amp-story-page[active]::after                                         | 2          | extensions/amp-story/0.1/amp-story.css                           |
-| .i-amphtml-story-bookend-active amp-story-page[active]::after                                           | 2          | extensions/amp-story/1.0/amp-story.css                           |
-| .i-amphtml-story-hint-container                                                                         | 2          | extensions/amp-story/0.1/amp-story-hint.css                      |
-| .i-amphtml-expanded-mode amp-story-grid-layer \*                                                        | auto       | extensions/amp-story/1.0/amp-story.css                           |
-| amp-story-page[active] .i-amphtml-story-page-open-attachment                                            | 3          | extensions/amp-story/1.0/amp-story.css                           |
-| .i-amphtml-image-slider-bar                                                                             | 3          | extensions/amp-image-slider/0.1/amp-image-slider.css             |
-| amp-story-cta-layer                                                                                     | 3          | extensions/amp-story/0.1/amp-story.css                           |
-| amp-story-cta-layer                                                                                     | 3          | extensions/amp-story/1.0/amp-story.css                           |
-| .i-amphtml-story-desktop-panels amp-story-page[i-amphtml-desktop-position="1"][amp-access-hide]::before | 4          | extensions/amp-story/1.0/amp-story-desktop-panels.css            |
-| amp-story-page-attachment                                                                               | 4          | extensions/amp-story/1.0/amp-story-page-attachment.css           |
-| .i-amphtml-byside-content-loading-container .i-amphtml-byside-content-loading-animation:before          | 9          | extensions/amp-byside-content/0.1/amp-byside-content.css         |
-| 100%                                                                                                    | 9          | extensions/amp-byside-content/0.1/amp-byside-content.css         |
-| .amp-carousel-button                                                                                    | 10         | extensions/amp-carousel/0.1/amp-carousel.css                     |
-| amp-date-picker[mode="overlay"] .i-amphtml-date-picker-container                                        | 10         | extensions/amp-date-picker/0.1/amp-date-picker.css               |
-| .i-amphtml-autocomplete-results                                                                         | 10         | extensions/amp-autocomplete/0.1/amp-autocomplete.css             |
-| .i-amphtml-story-spinner                                                                                | 10         | extensions/amp-story/1.0/amp-story.css                           |
-| .i-amphtml-story-spinner                                                                                | 10         | extensions/amp-story/0.1/amp-story.css                           |
-| amp-sticky-ad                                                                                           | 11         | extensions/amp-sticky-ad/1.0/amp-sticky-ad.css                   |
-| amp-sticky-ad-top-padding                                                                               | 12         | extensions/amp-sticky-ad/1.0/amp-sticky-ad.css                   |
-| amp-app-banner                                                                                          | 13         | extensions/amp-app-banner/0.1/amp-app-banner.css                 |
-| .amp-app-banner-dismiss-button                                                                          | 14         | extensions/amp-app-banner/0.1/amp-app-banner.css                 |
-| i-amphtml-app-banner-top-padding                                                                        | 15         | extensions/amp-app-banner/0.1/amp-app-banner.css                 |
-| amp-image-lightbox                                                                                      | 1000       | extensions/amp-image-lightbox/0.1/amp-image-lightbox.css         |
-| amp-live-list > [update]                                                                                | 1000       | extensions/amp-live-list/0.1/amp-live-list.css                   |
-| i-amphtml-ad-close-header                                                                               | 1000       | extensions/amp-lightbox/0.1/amp-lightbox.css                     |
-| amp-lightbox                                                                                            | 1000       | extensions/amp-lightbox/0.1/amp-lightbox.css                     |
-| amp-user-notification                                                                                   | 1000       | extensions/amp-user-notification/0.1/amp-user-notification.css   |
-| .i-amphtml-jank-meter                                                                                   | 1000       | css/ampdoc.css                                                   |
-| .i-amphtml-image-lightbox-trans                                                                         | 1001       | extensions/amp-image-lightbox/0.1/amp-image-lightbox.css         |
-| .i-amphtml-story-page-play-button                                                                       | 10000      | extensions/amp-story/1.0/amp-story.css                           |
-| .i-amphtml-story-system-layer                                                                           | 100000     | extensions/amp-story/1.0/amp-story-system-layer.css              |
-| .i-amphtml-story-system-layer                                                                           | 100000     | extensions/amp-story/0.1/amp-story-system-layer.css              |
-| .i-amphtml-story-info-dialog                                                                            | 100001     | extensions/amp-story/1.0/amp-story-info-dialog.css               |
-| .i-amphtml-story-bookend                                                                                | 100001     | extensions/amp-story/1.0/amp-story-bookend.css                   |
-| .i-amphtml-ad-overlay-container                                                                         | 100001     | extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.css         |
-| .i-amphtml-story-focused-state-layer                                                                    | 100001     | extensions/amp-story/1.0/amp-story-tooltip.css                   |
-| .i-amphtml-story-progress-bar                                                                           | 100001     | extensions/amp-story/0.1/amp-story-system-layer.css              |
-| .i-amphtml-story-progress-bar                                                                           | 100001     | extensions/amp-story/1.0/amp-story-system-layer.css              |
-| .i-amphtml-story-info-dialog                                                                            | 100001     | extensions/amp-story/0.1/amp-story-info-dialog.css               |
-| .i-amphtml-story-bookend                                                                                | 100001     | extensions/amp-story/0.1/amp-story-bookend.css                   |
-| .i-amphtml-story-share-menu                                                                             | 100001     | extensions/amp-story/0.1/amp-story-share-menu.css                |
-| [desktop] .i-amphtml-story-button-container                                                             | 100002     | extensions/amp-story/0.1/amp-story-desktop.css                   |
-| .i-amphtml-story-button-move                                                                            | 100002     | extensions/amp-story/1.0/pagination-buttons.css                  |
-| amp-story[standalone] .i-amphtml-story-developer-log                                                    | 100002     | extensions/amp-story/1.0/amp-story.css                           |
-| .i-amphtml-story-desktop-fullbleed .i-amphtml-story-button-container                                    | 100002     | extensions/amp-story/1.0/pagination-buttons.css                  |
-| [desktop] .i-amphtml-story-top                                                                          | 100002     | extensions/amp-story/0.1/amp-story-desktop.css                   |
-| .i-amphtml-story-toast                                                                                  | 100002     | extensions/amp-story/0.1/amp-story.css                           |
-| .i-amphtml-story-page-sentinel                                                                          | 100002     | extensions/amp-story/0.1/amp-story-desktop.css                   |
-| .i-amphtml-story-page-sentinel                                                                          | 100002     | extensions/amp-story/1.0/pagination-buttons.css                  |
-| .i-amphtml-story-desktop-panels .i-amphtml-story-button-container                                       | 100002     | extensions/amp-story/1.0/pagination-buttons.css                  |
-| .i-amphtml-story-button-move                                                                            | 100002     | extensions/amp-story/0.1/amp-story-desktop.css                   |
-| amp-story[standalone] .i-amphtml-story-developer-log                                                    | 100002     | extensions/amp-story/0.1/amp-story.css                           |
-| amp-story-access                                                                                        | 100003     | extensions/amp-story/1.0/amp-story-access.css                    |
-| .i-amphtml-story-opacity-mask                                                                           | 100003     | extensions/amp-story/1.0/amp-story.css                           |
-| .i-amphtml-story-consent                                                                                | 100003     | extensions/amp-story/0.1/amp-story-consent.css                   |
-| .i-amphtml-story-share-menu                                                                             | 100003     | extensions/amp-story/1.0/amp-story-share-menu.css                |
-| .i-amphtml-story-toast                                                                                  | 100004     | extensions/amp-story/1.0/amp-story.css                           |
-| amp-story-access[type=blocking]                                                                         | 100004     | extensions/amp-story/1.0/amp-story-access.css                    |
-| .i-amphtml-story-consent                                                                                | 100005     | extensions/amp-story/1.0/amp-story-consent.css                   |
-| .i-amphtml-story-no-rotation-overlay                                                                    | 200000     | extensions/amp-story/1.0/amp-story-viewport-warning-layer.css    |
-| .i-amphtml-story-no-rotation-overlay                                                                    | 200000     | extensions/amp-story/0.1/amp-story-viewport-warning-layer.css    |
-| .i-amphtml-story-unsupported-browser-overlay                                                            | 200001     | extensions/amp-story/0.1/amp-story-unsupported-browser-layer.css |
-| .i-amphtml-story-unsupported-browser-overlay                                                            | 200001     | extensions/amp-story/1.0/amp-story-unsupported-browser-layer.css |
-| .i-amphtml-story-experiment-error                                                                       | 999999     | extensions/amp-story/0.1/amp-story.css                           |
-| amp-subscriptions-dialog                                                                                | 2147483641 | extensions/amp-subscriptions/0.1/amp-subscriptions.css           |
-| amp-lightbox-gallery[i-amphtml-lbg-fade]                                                                | 2147483642 | extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.css     |
-| .i-amphtml-lbg                                                                                          | 2147483642 | extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.css     |
-| .amp-video-docked-shadow                                                                                | 2147483643 | extensions/amp-video-docking/0.1/amp-video-docking.css           |
-| .i-amphtml-consent-ui-mask                                                                              | 2147483644 | extensions/amp-consent/0.1/amp-consent.css                       |
-| .i-amphtml-video-docked                                                                                 | 2147483644 | extensions/amp-video-docking/0.1/amp-video-docking.css           |
-| amp-consent                                                                                             | 2147483645 | extensions/amp-consent/0.1/amp-consent.css                       |
-| .i-amphtml-video-docked-overlay                                                                         | 2147483645 | extensions/amp-video-docking/0.1/amp-video-docking.css           |
-| .amp-apester-fullscreen                                                                                 | 2147483646 | extensions/amp-apester-media/0.1/amp-apester-media.css           |
-| .i-amphtml-sidebar-mask                                                                                 | 2147483646 | extensions/amp-sidebar/0.1/amp-sidebar.css                       |
-| .amp-video-docked-controls                                                                              | 2147483646 | extensions/amp-video-docking/0.1/amp-video-docking.css           |
-| amp-sidebar                                                                                             | 2147483647 | extensions/amp-sidebar/0.1/amp-sidebar.css                       |
-| .amp-access-scroll-bar                                                                                  | 2147483647 | extensions/amp-access-scroll/0.1/amp-access-scroll.css           |
+Run `gulp get-zindex` to generate this file.
+
+selector                                                                                                  |   z-index      |   file
+---                                                                                                       |   ---          |   ---
+.i-amphtml-expanded-mode amp-story-grid-layer                                                             |   auto         |   extensions/amp-story/1.0/amp-story.css
+.i-amphtml-expanded-mode amp-story-grid-layer *                                                           |   auto         |   extensions/amp-story/1.0/amp-story.css
+amp-story amp-consent                                                                                     |   initial      |   extensions/amp-story/1.0/amp-story.css
+.amp-access-scroll-bar                                                                                    |   2147483647   |   extensions/amp-access-scroll/0.1/amp-access-scroll.css
+.amp-access-scroll-sheet                                                                                  |   2147483647   |   extensions/amp-access-scroll/0.1/amp-access-scroll.css
+amp-sidebar                                                                                               |   2147483647   |   extensions/amp-sidebar/0.1/amp-sidebar.css
+amp-sidebar                                                                                               |   2147483647   |   extensions/amp-sidebar/0.2/amp-sidebar.css
+.amp-apester-fullscreen                                                                                   |   2147483646   |   extensions/amp-apester-media/0.1/amp-apester-media.css
+.i-amphtml-sidebar-mask                                                                                   |   2147483646   |   extensions/amp-sidebar/0.1/amp-sidebar.css
+.i-amphtml-sidebar-mask                                                                                   |   2147483646   |   extensions/amp-sidebar/0.2/amp-sidebar.css
+.amp-video-docked-controls                                                                                |   2147483646   |   extensions/amp-video-docking/0.1/amp-video-docking.css
+amp-consent                                                                                               |   2147483645   |   extensions/amp-consent/0.1/amp-consent.css
+.i-amphtml-video-docked-overlay                                                                           |   2147483645   |   extensions/amp-video-docking/0.1/amp-video-docking.css
+.i-amphtml-consent-ui-mask                                                                                |   2147483644   |   extensions/amp-consent/0.1/amp-consent.css
+.i-amphtml-video-docked                                                                                   |   2147483644   |   extensions/amp-video-docking/0.1/amp-video-docking.css
+.amp-video-docked-shadow                                                                                  |   2147483643   |   extensions/amp-video-docking/0.1/amp-video-docking.css
+.i-amphtml-lbg                                                                                            |   2147483642   |   extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.css
+amp-lightbox-gallery[i-amphtml-lbg-fade]                                                                  |   2147483642   |   extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.css
+amp-subscriptions-dialog                                                                                  |   2147483641   |   extensions/amp-subscriptions/0.1/amp-subscriptions.css
+amp-story-education                                                                                       |   9999999      |   extensions/amp-story-education/0.1/amp-story-education.css
+[i-amphtml-vertical] .i-amphtml-story-page-description                                                    |   9999999      |   extensions/amp-story/1.0/amp-story-vertical.css
+.i-amphtml-story-unsupported-browser-overlay                                                              |   200001       |   extensions/amp-story/1.0/amp-story-unsupported-browser-layer.css
+.i-amphtml-story-no-rotation-overlay                                                                      |   200000       |   extensions/amp-story/1.0/amp-story-viewport-warning-layer.css
+.i-amphtml-story-consent                                                                                  |   100005       |   extensions/amp-story/1.0/amp-story-consent.css
+amp-story-access[type=blocking]                                                                           |   100004       |   extensions/amp-story/1.0/amp-story-access.css
+.i-amphtml-story-toast                                                                                    |   100004       |   extensions/amp-story/1.0/amp-story.css
+amp-story-access                                                                                          |   100003       |   extensions/amp-story/1.0/amp-story-access.css
+.i-amphtml-story-share-menu                                                                               |   100003       |   extensions/amp-story/1.0/amp-story-share-menu.css
+.i-amphtml-story-opacity-mask                                                                             |   100003       |   extensions/amp-story/1.0/amp-story.css
+.i-amphtml-story-has-new-page-notification-container                                                      |   100002       |   extensions/amp-story/1.0/amp-story-system-layer.css
+amp-story[standalone] .i-amphtml-story-developer-log                                                      |   100002       |   extensions/amp-story/1.0/amp-story.css
+.i-amphtml-story-button-move                                                                              |   100002       |   extensions/amp-story/1.0/pagination-buttons.css
+.i-amphtml-story-desktop-fullbleed .i-amphtml-story-button-container                                      |   100002       |   extensions/amp-story/1.0/pagination-buttons.css
+.i-amphtml-story-desktop-panels .i-amphtml-story-button-container                                         |   100002       |   extensions/amp-story/1.0/pagination-buttons.css
+.i-amphtml-story-page-sentinel                                                                            |   100002       |   extensions/amp-story/1.0/pagination-buttons.css
+.i-amphtml-ad-overlay-container                                                                           |   100001       |   extensions/amp-story-auto-ads/0.1/amp-story-auto-ads-ad-badge.css
+.i-amphtml-story-bookend                                                                                  |   100001       |   extensions/amp-story/1.0/amp-story-bookend.css
+.i-amphtml-story-info-dialog                                                                              |   100001       |   extensions/amp-story/1.0/amp-story-info-dialog.css
+.i-amphtml-story-progress-bar                                                                             |   100001       |   extensions/amp-story/1.0/amp-story-system-layer.css
+.i-amphtml-story-focused-state-layer                                                                      |   100001       |   extensions/amp-story/1.0/amp-story-tooltip.css
+.i-amphtml-story-page-attachment-expand                                                                   |   100000       |   extensions/amp-story/1.0/amp-story-page-attachment.css
+.i-amphtml-story-system-layer                                                                             |   100000       |   extensions/amp-story/1.0/amp-story-system-layer.css
+.i-amphtml-story-page-error                                                                               |   10000        |   extensions/amp-story/1.0/amp-story.css
+.i-amphtml-story-page-play-button                                                                         |   10000        |   extensions/amp-story/1.0/amp-story.css
+.i-amphtml-image-lightbox-trans                                                                           |   1001         |   extensions/amp-image-lightbox/0.1/amp-image-lightbox.css
+.i-amphtml-jank-meter                                                                                     |   1000         |   css/ampdoc.css
+amp-image-lightbox                                                                                        |   1000         |   extensions/amp-image-lightbox/0.1/amp-image-lightbox.css
+amp-lightbox                                                                                              |   1000         |   extensions/amp-lightbox/0.1/amp-lightbox.css
+i-amphtml-ad-close-header                                                                                 |   1000         |   extensions/amp-lightbox/0.1/amp-lightbox.css
+amp-live-list > [update]                                                                                  |   1000         |   extensions/amp-live-list/0.1/amp-live-list.css
+.i-amphtml-mega-menu-mask-parent                                                                          |   1000         |   extensions/amp-mega-menu/0.1/amp-mega-menu.css
+amp-mega-menu                                                                                             |   1000         |   extensions/amp-mega-menu/0.1/amp-mega-menu.css
+amp-user-notification                                                                                     |   1000         |   extensions/amp-user-notification/0.1/amp-user-notification.css
+i-amphtml-app-banner-top-padding                                                                          |   15           |   extensions/amp-app-banner/0.1/amp-app-banner.css
+.amp-app-banner-dismiss-button                                                                            |   14           |   extensions/amp-app-banner/0.1/amp-app-banner.css
+amp-app-banner                                                                                            |   13           |   extensions/amp-app-banner/0.1/amp-app-banner.css
+amp-sticky-ad-top-padding                                                                                 |   12           |   extensions/amp-sticky-ad/1.0/amp-sticky-ad.css
+amp-sticky-ad                                                                                             |   11           |   extensions/amp-sticky-ad/1.0/amp-sticky-ad.css
+.i-amphtml-autocomplete-results                                                                           |   10           |   extensions/amp-autocomplete/0.1/amp-autocomplete.css
+.amp-carousel-button                                                                                      |   10           |   extensions/amp-carousel/0.1/amp-carousel.css
+.amp-carousel-button                                                                                      |   10           |   extensions/amp-carousel/0.2/amp-carousel.css
+amp-date-picker[mode="overlay"] .i-amphtml-date-picker-container                                          |   10           |   extensions/amp-date-picker/0.1/amp-date-picker.css
+.i-amphtml-story-spinner                                                                                  |   10           |   extensions/amp-story/1.0/amp-story.css
+.i-amphtml-byside-content-loading-container .i-amphtml-byside-content-loading-animation:before            |   9            |   extensions/amp-byside-content/0.1/amp-byside-content.css
+100%                                                                                                      |   9            |   extensions/amp-byside-content/0.1/amp-byside-content.css
+.i-amphtml-story-ad-attribution                                                                           |   4            |   extensions/amp-story-auto-ads/0.1/amp-story-auto-ads-attribution.css
+.i-amphtml-story-desktop-panels amp-story-page[i-amphtml-desktop-position="1"][amp-access-hide]::before   |   4            |   extensions/amp-story/1.0/amp-story-desktop-panels.css
+.amp-story-draggable-drawer-root                                                                          |   4            |   extensions/amp-story/1.0/amp-story-draggable-drawer.css
+.i-amphtml-image-slider-bar                                                                               |   3            |   extensions/amp-image-slider/0.1/amp-image-slider.css
+amp-story-page[active] .i-amphtml-story-page-open-attachment                                              |   3            |   extensions/amp-story/1.0/amp-story-page-attachment.css
+amp-story-cta-layer                                                                                       |   3            |   extensions/amp-story/1.0/amp-story.css
+.i-amphtml-element > [overflow]                                                                           |   2            |   css/ampshared.css
+.i-amphtml-image-lightbox-caption                                                                         |   2            |   extensions/amp-image-lightbox/0.1/amp-image-lightbox.css
+.i-amphtml-image-slider-hint                                                                              |   2            |   extensions/amp-image-slider/0.1/amp-image-slider.css
+.i-amphtml-story-access-header                                                                            |   2            |   extensions/amp-story/1.0/amp-story-access.css
+.i-amphtml-story-consent-header                                                                           |   2            |   extensions/amp-story/1.0/amp-story-consent.css
+.i-amphtml-story-hint-container                                                                           |   2            |   extensions/amp-story/1.0/amp-story-hint.css
+.i-amphtml-story-bookend-active amp-story-page[active]::after                                             |   2            |   extensions/amp-story/1.0/amp-story.css
+amp-story-grid-layer                                                                                      |   2            |   extensions/amp-story/1.0/amp-story.css
+.i-amphtml-layout-size-defined > [fallback]                                                               |   1            |   css/ampshared.css
+.i-amphtml-layout-size-defined > [placeholder]                                                            |   1            |   css/ampshared.css
+.i-amphtml-loading-container                                                                              |   1            |   css/ampshared.css
+.amp-video-eq                                                                                             |   1            |   css/video-autoplay.css
+i-amphtml-video-mask                                                                                      |   1            |   css/video-autoplay.css
+amp-addthis .i-amphtml-addthis-close                                                                      |   1            |   extensions/amp-addthis/0.1/amp-addthis.css
+.i-amphtml-base-carousel-arrow-icon                                                                       |   1            |   extensions/amp-base-carousel/0.1/amp-base-carousel.css
+.i-amphtml-base-carousel-arrow-next-slot                                                                  |   1            |   extensions/amp-base-carousel/0.1/amp-base-carousel.css
+.i-amphtml-base-carousel-arrow-prev-slot                                                                  |   1            |   extensions/amp-base-carousel/0.1/amp-base-carousel.css
+.i-amphtml-base-carousel-arrows                                                                           |   1            |   extensions/amp-base-carousel/0.1/amp-base-carousel.css
+.i-amphtml-carousel-arrows                                                                                |   1            |   extensions/amp-carousel/0.2/amp-carousel.css
+.i-amphtml-image-lightbox-viewer                                                                          |   1            |   extensions/amp-image-lightbox/0.1/amp-image-lightbox.css
+.i-amphtml-image-lightbox-viewer-image                                                                    |   1            |   extensions/amp-image-lightbox/0.1/amp-image-lightbox.css
+.i-amphtml-image-slider-label-wrapper                                                                     |   1            |   extensions/amp-image-slider/0.1/amp-image-slider.css
+.i-amphtml-image-slider-right-mask                                                                        |   1            |   extensions/amp-image-slider/0.1/amp-image-slider.css
+.i-amphtml-inline-gallery-pagination-count                                                                |   1            |   extensions/amp-inline-gallery/0.1/amp-inline-gallery-pagination.css
+.i-amphtml-inline-gallery-pagination-dot-container                                                        |   1            |   extensions/amp-inline-gallery/0.1/amp-inline-gallery-pagination.css
+.i-amphtml-lbg-caption-scroll                                                                             |   1            |   extensions/amp-lightbox-gallery/0.1/lightbox-caption.css
+[i-amphtml-lbg-caption-state="clip"] + .i-amphtml-lbg-caption-mask                                        |   1            |   extensions/amp-lightbox-gallery/0.1/lightbox-caption.css
+.i-amphtml-lbg-top-bar                                                                                    |   1            |   extensions/amp-lightbox-gallery/0.1/lightbox-controls.css
+.i-amphtml-glass-pane                                                                                     |   1            |   extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.css
+.i-amphtml-story-consent-actions                                                                          |   1            |   extensions/amp-story/1.0/amp-story-consent.css
+.i-amphtml-story-draggable-drawer-header                                                                  |   1            |   extensions/amp-story/1.0/amp-story-draggable-drawer-header.css
+.i-amphtml-story-hint-container .i-amphtml-story-hint-tap-button-icon                                     |   1            |   extensions/amp-story/1.0/amp-story-hint.css
+.i-amphtml-story-interactive-option-text                                                                  |   1            |   extensions/amp-story/1.0/amp-story-interactive-poll.css
+.i-amphtml-story-bookend-active.i-amphtml-story-system-layer                                              |   1            |   extensions/amp-story/1.0/amp-story-system-layer.css
+.i-amphtml-expanded-mode .i-amphtml-embedded-component.i-amphtml-expanded-component                       |   1            |   extensions/amp-story/1.0/amp-story.css
+amp-story-page[active]                                                                                    |   1            |   extensions/amp-story/1.0/amp-story.css
+.i-amphtml-stream-gallery-next                                                                            |   1            |   extensions/amp-stream-gallery/0.1/arrows.css
+.i-amphtml-stream-gallery-prev                                                                            |   1            |   extensions/amp-stream-gallery/0.1/arrows.css
+.i-amphtml-byside-content-loading-container .i-amphtml-byside-content-loading-animation:after             |   0            |   extensions/amp-byside-content/0.1/amp-byside-content.css
+0%                                                                                                        |   0            |   extensions/amp-byside-content/0.1/amp-byside-content.css
+.i-amphtml-image-lightbox-container                                                                       |   0            |   extensions/amp-image-lightbox/0.1/amp-image-lightbox.css
+.i-amphtml-inline-gallery-pagination-dots                                                                 |   0            |   extensions/amp-inline-gallery/0.1/amp-inline-gallery-pagination.css
+.i-amphtml-inline-gallery-pagination-numbers                                                              |   0            |   extensions/amp-inline-gallery/0.1/amp-inline-gallery-pagination.css
+[i-amphtml-lbg-caption-state="expand"] + .i-amphtml-lbg-caption-mask                                      |   0            |   extensions/amp-lightbox-gallery/0.1/lightbox-caption.css
+.i-amphtml-story-access-content                                                                           |   0            |   extensions/amp-story/1.0/amp-story-access.css
+.i-amphtml-story-consent-content                                                                          |   0            |   extensions/amp-story/1.0/amp-story-consent.css
+.i-amphtml-story-interactive-quiz-option                                                                  |   0            |   extensions/amp-story/1.0/amp-story-interactive-quiz.css
+amp-story-page                                                                                            |   0            |   extensions/amp-story/1.0/amp-story.css
+.amp-video-docked-placeholder-background                                                                  |   0            |   extensions/amp-video-docking/0.1/amp-video-docking.css
+.i-amphtml-carousel-spacer                                                                                |   -1           |   extensions/amp-base-carousel/0.1/carousel.css
+.i-amphtml-mega-menu-mask                                                                                 |   -1           |   extensions/amp-mega-menu/0.1/amp-mega-menu.css
+.i-amphtml-story-access-logo::before                                                                      |   -1           |   extensions/amp-story/1.0/amp-story-access.css
+.i-amphtml-story-consent-logo::before                                                                     |   -1           |   extensions/amp-story/1.0/amp-story-consent.css
+amp-story-page .i-amphtml-story-page-open-attachment-icon::after                                          |   -1           |   extensions/amp-story/1.0/amp-story-page-attachment.css
+.i-amphtml-story-media-query-matcher                                                                      |   -1           |   extensions/amp-story/1.0/amp-story.css


### PR DESCRIPTION
Changes how [`Z_INDEX.md`](https://github.com/ampproject/amphtml/blob/master/css/Z_INDEX.md) is generated.

1. Word values weren't treated especially, so you'd get `auto`/`initial` skipped across number values. Now they're sorted before numeric values.

2. Numeric values are now in descending length order, which I think makes more sense for `z-index` reference (assumption that you'd most likely want to know which layers are higher in the hierarchy.)

3. Explain how to generate from the file itself.

4. Format with `prettier` for lint compliance. 