### PR TITLE
Prop types: restore |undefined type

### DIFF
--- a/extensions/amp-fit-text/1.0/fit-text.type.js
+++ b/extensions/amp-fit-text/1.0/fit-text.type.js
@@ -18,8 +18,8 @@
 
 /**
  * @typedef {{
- *   minFontSize: number,
- *   maxFontSize: number,
+ *   minFontSize: (number|undefined),
+ *   maxFontSize: (number|undefined),
  *   children: (?PreactDef.Renderable|undefined),
  * }}
  */

--- a/extensions/amp-fit-text/1.0/fit-text.type.js
+++ b/extensions/amp-fit-text/1.0/fit-text.type.js
@@ -18,8 +18,8 @@
 
 /**
  * @typedef {{
- *   minFontSize: (number|undefined),
- *   maxFontSize: (number|undefined),
+ *   minFontSize: number,
+ *   maxFontSize: number,
  *   children: (?PreactDef.Renderable|undefined),
  * }}
  */


### PR DESCRIPTION
Follow up on https://github.com/ampproject/amphtml/pull/29224 for a more accurate prop type extern definition. The problem is that Closure compiler fails for this, because it doesn't understand that `minFontSize = 6` removes the `|undefined` type from the union.

Related to https://github.com/ampproject/amphtml/issues/29293