### PR TITLE
🏗 Introducing `IS_SXG` in Babel transformers.

### DIFF
--- a/build-system/babel-config/helpers.js
+++ b/build-system/babel-config/helpers.js
@@ -56,7 +56,14 @@ function getReplacePlugin() {
     };
   }
 
-  const replacements = [createReplacement('IS_ESM', argv.esm)];
+  // We build on the idea that SxG is an upgrade to the ESM build.
+  // Therefore, all conditions set by ESM will also hold for SxG.
+  // However, we will also need to introduce a separate IS_SxG flag
+  // for conditions only true for SxG.
+  const replacements = [
+    createReplacement('IS_ESM', argv.esm || argv.sxg),
+    createReplacement('IS_SXG', argv.sxg),
+  ];
 
   const experimentConstant = getExperimentConstant();
   if (experimentConstant) {


### PR DESCRIPTION
Small change that will introduce `IS_SXG`, which will become a boolean value depending on input `argv.sxg`.