### PR TITLE
Reimplement amp-animation visibility trigger via IntersectionObserver

### DIFF
--- a/extensions/amp-animation/0.1/amp-animation.js
+++ b/extensions/amp-animation/0.1/amp-animation.js
@@ -21,6 +21,7 @@ import {Services} from '../../../src/services';
 import {WebAnimationPlayState} from './web-animation-types';
 import {WebAnimationService} from './web-animation-service';
 import {clamp} from '../../../src/utils/math';
+import {dev, userAssert} from '../../../src/log';
 import {getChildJsonConfig} from '../../../src/json';
 import {getDetail, listen} from '../../../src/event-helper';
 import {getFriendlyIframeEmbedOptional} from '../../../src/iframe-helper';
@@ -28,7 +29,6 @@ import {getParentWindowFrameElement} from '../../../src/service';
 import {installWebAnimationsIfNecessary} from './web-animations-polyfill';
 import {isFiniteNumber} from '../../../src/types';
 import {setInitialDisplay, setStyles, toggle} from '../../../src/style';
-import {userAssert} from '../../../src/log';
 
 const TAG = 'amp-animation';
 
@@ -125,7 +125,7 @@ export class AmpAnimation extends AMP.BaseElement {
       this.isIntersecting_ = records[records.length - 1].isIntersecting;
       this.setVisible_(this.isIntersecting_ && ampdoc.isVisible());
     });
-    io.observe(this.element.parentElement);
+    io.observe(dev().assertElement(this.element.parentElement));
     this.cleanups_.push(() => io.disconnect());
 
     // Resize.

--- a/extensions/amp-animation/0.1/amp-animation.js
+++ b/extensions/amp-animation/0.1/amp-animation.js
@@ -297,10 +297,6 @@ export class AmpAnimation extends AMP.BaseElement {
    * @private
    */
   seekToAction_(invocation) {
-    // The animation will be triggered (in paused state) and seek will happen
-    // regardless of visibility
-    this.triggered_ = true;
-
     let positionObserverData = null;
     if (invocation.event) {
       const detail = getDetail(/** @type {!Event} */ (invocation.event));
@@ -310,6 +306,9 @@ export class AmpAnimation extends AMP.BaseElement {
     }
 
     return this.createRunnerIfNeeded_(null, positionObserverData).then(() => {
+      // The animation will be triggered (in paused state) and seek will happen
+      // regardless of visibility
+      this.triggered_ = true;
       this.pause_();
       this.pausedByAction_ = true;
       // time based seek

--- a/extensions/amp-animation/0.1/amp-animation.js
+++ b/extensions/amp-animation/0.1/amp-animation.js
@@ -116,9 +116,11 @@ export class AmpAnimation extends AMP.BaseElement {
     );
 
     // Visibility.
-    this.cleanups_.push(ampdoc.onVisibilityChanged(() => {
-      this.setVisible_(this.isIntersecting_ && ampdoc.isVisible());
-    }));
+    this.cleanups_.push(
+      ampdoc.onVisibilityChanged(() => {
+        this.setVisible_(this.isIntersecting_ && ampdoc.isVisible());
+      })
+    );
     const io = new ampdoc.win.IntersectionObserver((records) => {
       this.isIntersecting_ = records[records.length - 1].isIntersecting;
       this.setVisible_(this.isIntersecting_ && ampdoc.isVisible());
@@ -184,7 +186,7 @@ export class AmpAnimation extends AMP.BaseElement {
   detachedCallback() {
     const cleanups = this.cleanups_.slice(0);
     this.cleanups_.length = 0;
-    cleanups.forEach(cleanup => cleanup());
+    cleanups.forEach((cleanup) => cleanup());
   }
 
   /**

--- a/extensions/amp-animation/0.1/test/test-amp-animation.js
+++ b/extensions/amp-animation/0.1/test/test-amp-animation.js
@@ -19,8 +19,28 @@ import {DEFAULT_ACTION} from '../../../../src/action-constants';
 import {NativeWebAnimationRunner} from '../runners/native-web-animation-runner';
 import {WebAnimationPlayState} from '../web-animation-types';
 
-describes.sandboxed('AmpAnimation', {}, () => {
+describes.sandboxed('AmpAnimation', {}, (env) => {
+  let ioCallbacks;
+
+  beforeEach(() => {
+    ioCallbacks = [];
+  });
+
   function createAnimInWindow(win, attrs, config) {
+    let ioCallback;
+    class IoStub {
+      constructor(callback) {
+        ioCallback = callback;
+        ioCallbacks.push(callback);
+      }
+      observe(element) {
+        ioCallback([{isIntersecting: (config && config.isIntersecting) ?? true}]);
+      }
+      unobserve() {}
+      disconnect() {}
+    }
+    env.sandbox.stub(win, 'IntersectionObserver').value(IoStub);
+
     const element = win.document.createElement('amp-animation');
     element.setAttribute('id', 'anim1');
     element.setAttribute('layout', 'nodisplay');
@@ -41,6 +61,12 @@ describes.sandboxed('AmpAnimation', {}, () => {
 
     win.document.body.appendChild(element);
     return element.build().then(() => element.implementation_);
+  }
+
+  function updateIntersection(isIntersecting) {
+    ioCallbacks.forEach((callback) => {
+      callback([{isIntersecting}]);
+    });
   }
 
   describes.realWin(
@@ -135,6 +161,17 @@ describes.sandboxed('AmpAnimation', {}, () => {
         expect(anim.visible_).to.be.false;
 
         viewer.setVisibilityState_('visible');
+        expect(anim.visible_).to.be.true;
+      });
+
+      it('should update visibility from intersection observer', function* () {
+        const anim = yield createAnim({}, {duration: 1001, isIntersecting: false});
+        expect(anim.visible_).to.be.false;
+
+        viewer.setVisibilityState_('visible');
+        expect(anim.visible_).to.be.false;
+
+        updateIntersection(true);
         expect(anim.visible_).to.be.true;
       });
 
@@ -315,12 +352,8 @@ describes.sandboxed('AmpAnimation', {}, () => {
         const stub = env.sandbox.stub(anim, 'onResize_');
         const viewport = win.__AMP_SERVICES.viewport.obj;
 
-        // No size changes.
-        viewport.resizeObservable_.fire({relayoutAll: false});
-        expect(stub).to.not.be.called;
-
         // Size has changed.
-        viewport.resizeObservable_.fire({relayoutAll: true});
+        win.eventListeners.fire({type: 'resize'});
         expect(stub).to.be.calledOnce;
       });
 
@@ -787,14 +820,6 @@ describes.sandboxed('AmpAnimation', {}, () => {
       function createAnim(attrs, config) {
         return createAnimInWindow(embed.win, attrs, config);
       }
-
-      it('should update visibility from embed', function* () {
-        const anim = yield createAnim({}, {duration: 1001});
-        expect(anim.visible_).to.be.false;
-
-        embed.setVisible_(true);
-        expect(anim.visible_).to.be.true;
-      });
 
       it('should find target in the embed only via selector', function* () {
         const parentWin = env.ampdoc.win;

--- a/extensions/amp-animation/0.1/test/test-amp-animation.js
+++ b/extensions/amp-animation/0.1/test/test-amp-animation.js
@@ -33,8 +33,10 @@ describes.sandboxed('AmpAnimation', {}, (env) => {
         ioCallback = callback;
         ioCallbacks.push(callback);
       }
-      observe(element) {
-        ioCallback([{isIntersecting: (config && config.isIntersecting) ?? true}]);
+      observe() {
+        ioCallback([
+          {isIntersecting: (config && config.isIntersecting) ?? true},
+        ]);
       }
       unobserve() {}
       disconnect() {}
@@ -165,7 +167,10 @@ describes.sandboxed('AmpAnimation', {}, (env) => {
       });
 
       it('should update visibility from intersection observer', function* () {
-        const anim = yield createAnim({}, {duration: 1001, isIntersecting: false});
+        const anim = yield createAnim(
+          {},
+          {duration: 1001, isIntersecting: false}
+        );
         expect(anim.visible_).to.be.false;
 
         viewer.setVisibilityState_('visible');
@@ -350,7 +355,6 @@ describes.sandboxed('AmpAnimation', {}, (env) => {
       it('should resize from ampdoc viewport', function* () {
         const anim = yield createAnim({}, {duration: 1001});
         const stub = env.sandbox.stub(anim, 'onResize_');
-        const viewport = win.__AMP_SERVICES.viewport.obj;
 
         // Size has changed.
         win.eventListeners.fire({type: 'resize'});

--- a/extensions/amp-animation/amp-animation.md
+++ b/extensions/amp-animation/amp-animation.md
@@ -111,8 +111,9 @@ Trigger the start of one or multiple animations via the `trigger` attribute or
 an [action](#actions).
 
 You may place `amp-animation` controlled via actions anywhere in the DOM. If the
-animation contains `trigger="visibility"` it must be a direct child of the
-`<body>`.
+animation contains `trigger="visibility"` it will be triggered when
+the parent element comes into the viewport, and paused when it leaves the
+viewport.
 
 ### Defining effects
 


### PR DESCRIPTION
This is part of series to remove dependencies on FIE API to unblock the ampdoc-fie launch.

Partial for https://github.com/ampproject/amphtml/issues/22734.