### PR TITLE
[amp-social-share][bento] Remove endpoint check from amp component

### DIFF
--- a/extensions/amp-social-share/1.0/amp-social-share.js
+++ b/extensions/amp-social-share/1.0/amp-social-share.js
@@ -24,7 +24,7 @@ import {getDataParamsFromAttributes} from '../../../src/dom';
 import {getSocialConfig} from './social-share-config';
 import {isExperimentOn} from '../../../src/experiments';
 import {toggle} from '../../../src/style';
-import {user, userAssert} from '../../../src/log';
+import {userAssert} from '../../../src/log';
 
 /** @const {string} */
 const TAG = 'amp-social-share';
@@ -113,10 +113,7 @@ class AmpSocialShare extends PreactBaseElement {
    */
   renderWithHrefAndTarget_(typeConfig) {
     const customEndpoint = this.element.getAttribute('data-share-endpoint');
-    const shareEndpoint = user().assertString(
-      customEndpoint || typeConfig['shareEndpoint'],
-      'The data-share-endpoint attribute is required. %s'
-    );
+    const shareEndpoint = customEndpoint || typeConfig['shareEndpoint'] || '';
     const urlParams = typeConfig['defaultParams'] || dict();
     Object.assign(urlParams, getDataParamsFromAttributes(this.element));
     const hrefWithVars = addParamsToUrl(shareEndpoint, urlParams);


### PR DESCRIPTION
@dvoytenko 

I was wondering your opinion on this change.  The social-share component has an error check to see if a custom endpoint is provided when the `type` is not one of the pre-configured types.  I am thinking that we can remove this check from the amp side, since most of the error checking is done on the Preact side (this way don't do a duplicate check on both amp and preact).

Link to Preact side error check: https://github.com/ampproject/amphtml/blob/master/extensions/amp-social-share/1.0/social-share.js#L106

One side effect I noticed was that the Preact side will actually throw the error twice.  Once on the initial render, and a second time when the amp side passes asynchronous props and triggers a second render.  I think this is okay for now, but just wanted to bring it up.