### PR TITLE
PropTypes: update Preact externs and use in more components

### DIFF
--- a/build-system/externs/preact.extern.js
+++ b/build-system/externs/preact.extern.js
@@ -35,7 +35,7 @@ PreactDef.VNode = function () {};
 PreactDef.Context = function () {};
 
 /**
- * @param {{value: ?}} props
+ * @param {{value: ?, children: (?PreactDef.Renderable|undefined)}} props
  * @return {PreactDef.Renderable}
  */
 PreactDef.Context.prototype.Provider = function (props) {};

--- a/build-system/externs/preact.extern.js
+++ b/build-system/externs/preact.extern.js
@@ -20,7 +20,7 @@
 var PreactDef = {};
 
 /**
- * @typedef {function(!JsonObject):PreactDef.Renderable}
+ * @typedef {function(?):PreactDef.Renderable}
  */
 PreactDef.FunctionalComponent;
 
@@ -35,7 +35,7 @@ PreactDef.VNode = function () {};
 PreactDef.Context = function () {};
 
 /**
- * @param {!JsonObject} props
+ * @param {{value: ?}} props
  * @return {PreactDef.Renderable}
  */
 PreactDef.Context.prototype.Provider = function (props) {};

--- a/extensions/amp-date-display/1.0/date-display.type.js
+++ b/extensions/amp-date-display/1.0/date-display.type.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,23 +14,22 @@
  * limitations under the License.
  */
 
-import {useResourcesNotify} from '../../../src/preact/utils';
-import {useState} from '../../../src/preact';
+/** @externs */
+
+/** @const */
+var DateDisplayDef = {};
 
 /**
- * Renders the children prop, waiting for it to resolve if it is a promise.
- *
- * @param {!DateDisplayDef.AsyncRenderProps} props
- * @return {PreactDef.Renderable}
+ * @typedef {{
+ *   children: (?PreactDef.Renderable|undefined),
+ * }}
  */
-export function AsyncRender({children}) {
-  const [state, set] = useState(children);
-  useResourcesNotify();
+DateDisplayDef.AsyncRenderProps;
 
-  if (state && state.then) {
-    Promise.resolve(children).then(set);
-    return null;
-  }
-
-  return state;
-}
+/**
+ * @typedef {{
+ *   dom: !Element,
+ *   host: !Element,
+ * }}
+ */
+DateDisplayDef.RenderDomTreeProps;

--- a/extensions/amp-date-display/1.0/render-dom-tree.js
+++ b/extensions/amp-date-display/1.0/render-dom-tree.js
@@ -23,11 +23,10 @@ import {useResourcesNotify} from '../../../src/preact/utils';
 /**
  * Clears the host element and appends the DOM tree into it.
  *
- * @param {!JsonObject} props
- * @return {null}
+ * @param {!DateDisplayDef.RenderDomTreeProps} props
+ * @return {?PreactDef.Renderable}
  */
-export function RenderDomTree(props) {
-  const {'dom': dom, 'host': host} = props;
+export function RenderDomTree({dom, host}) {
   useResourcesNotify();
 
   removeChildren(dev().assertElement(host));

--- a/extensions/amp-selector/1.0/amp-selector.js
+++ b/extensions/amp-selector/1.0/amp-selector.js
@@ -25,8 +25,8 @@ import {
   toggleAttribute,
 } from '../../../src/dom';
 import {createCustomEvent} from '../../../src/event-helper';
-import {dev, userAssert} from '../../../src/log';
-import {dict, omit} from '../../../src/utils/object';
+import {dev, devAssert, userAssert} from '../../../src/log';
+import {dict} from '../../../src/utils/object';
 import {isExperimentOn} from '../../../src/experiments';
 import {mod} from '../../../src/utils/math';
 import {toArray} from '../../../src/types';
@@ -271,24 +271,23 @@ function selectByDelta(delta, value, options) {
 }
 
 /**
- * @param {!JsonObject} props
+ * @param {!SelectorDef.OptionShimProps} props
  * @return {PreactDef.Renderable}
  */
-function OptionShim(props) {
-  const {
-    'domElement': domElement,
-    'onClick': onClick,
-    'selected': selected,
-    'isDisabled': isDisabled,
-    'role': role = 'option',
-  } = props;
+function OptionShim({
+  domElement,
+  onClick,
+  selected,
+  isDisabled,
+  role = 'option',
+}) {
   useLayoutEffect(() => {
     if (!onClick) {
       return;
     }
     domElement.addEventListener('click', onClick);
     return () => {
-      domElement.removeEventListener('click', onClick);
+      domElement.removeEventListener('click', devAssert(onClick));
     };
   }, [domElement, onClick]);
 
@@ -302,24 +301,25 @@ function OptionShim(props) {
   }, [domElement, isDisabled]);
 
   useLayoutEffect(() => {
-    domElement.setAttribute('role', role);
+    if (role) {
+      domElement.setAttribute('role', role);
+    }
   }, [domElement, role]);
 
   return <div></div>;
 }
 
 /**
- * @param {!JsonObject} props
+ * @param {!SelectorDef.SelectorShimProps} props
  * @return {PreactDef.Renderable}
  */
-function SelectorShim(props) {
-  const {
-    'domElement': domElement,
-    'role': role = 'listbox',
-    'multiple': multiple,
-    'disabled': disabled,
-  } = props;
-
+function SelectorShim({
+  domElement,
+  multiple,
+  disabled,
+  role = 'listbox',
+  ...rest
+}) {
   useLayoutEffect(() => {
     toggleAttribute(domElement, 'multiple', multiple);
     domElement.setAttribute('aria-multiselectable', !!multiple);
@@ -331,11 +331,14 @@ function SelectorShim(props) {
   }, [domElement, disabled]);
 
   useLayoutEffect(() => {
-    domElement.setAttribute('role', role);
+    if (role) {
+      domElement.setAttribute('role', role);
+    }
   }, [domElement, role]);
 
-  const rest = omit(props, ['domElement']);
-  return <Selector {...rest}></Selector>;
+  return (
+    <Selector role={role} multiple={multiple} disabled={disabled} {...rest} />
+  );
 }
 
 /** @override */

--- a/extensions/amp-selector/1.0/amp-selector.js
+++ b/extensions/amp-selector/1.0/amp-selector.js
@@ -301,16 +301,14 @@ function OptionShim({
   }, [domElement, isDisabled]);
 
   useLayoutEffect(() => {
-    if (role) {
-      domElement.setAttribute('role', role);
-    }
+    domElement.setAttribute('role', role);
   }, [domElement, role]);
 
   return <div></div>;
 }
 
 /**
- * @param {!SelectorDef.SelectorShimProps} props
+ * @param {!SelectorDef.ShimProps} props
  * @return {PreactDef.Renderable}
  */
 function SelectorShim({
@@ -331,9 +329,7 @@ function SelectorShim({
   }, [domElement, disabled]);
 
   useLayoutEffect(() => {
-    if (role) {
-      domElement.setAttribute('role', role);
-    }
+    domElement.setAttribute('role', role);
   }, [domElement, role]);
 
   return (

--- a/extensions/amp-selector/1.0/selector.js
+++ b/extensions/amp-selector/1.0/selector.js
@@ -21,7 +21,7 @@ import {useContext, useMemo, useState} from '../../../src/preact';
 const SelectorContext = Preact.createContext({});
 
 /**
- * @param {!SelectorDef.SelectorProps} props
+ * @param {!SelectorDef.Props} props
  * @return {PreactDef.Renderable}
  */
 export function Selector({
@@ -36,7 +36,7 @@ export function Selector({
 }) {
   const [selectedState, setSelectedState] = useState(value ? value : []);
   // TBD: controlled values require override of properties.
-  const selected = /** @type {!Array} */ (value ? value : selectedState);
+  const selected = value ? value : selectedState;
   const context = useMemo(
     () => ({
       selected,

--- a/extensions/amp-selector/1.0/selector.js
+++ b/extensions/amp-selector/1.0/selector.js
@@ -21,20 +21,19 @@ import {useContext, useMemo, useState} from '../../../src/preact';
 const SelectorContext = Preact.createContext({});
 
 /**
- * @param {!JsonObject} props
+ * @param {!SelectorDef.SelectorProps} props
  * @return {PreactDef.Renderable}
  */
-export function Selector(props) {
-  const {
-    'as': Comp = 'div',
-    'children': children,
-    'disabled': disabled,
-    'value': value,
-    'multiple': multiple,
-    'onChange': onChange,
-    'role': role = 'listbox',
-    ...rest
-  } = props;
+export function Selector({
+  as: Comp = 'div',
+  disabled,
+  value,
+  multiple,
+  onChange,
+  role = 'listbox',
+  children,
+  ...rest
+}) {
   const [selectedState, setSelectedState] = useState(value ? value : []);
   // TBD: controlled values require override of properties.
   const selected = /** @type {!Array} */ (value ? value : selectedState);
@@ -83,18 +82,18 @@ export function Selector(props) {
 }
 
 /**
- * @param {!JsonObject} props
+ * @param {!SelectorDef.OptionProps} props
  * @return {PreactDef.Renderable}
  */
-export function Option(props) {
-  const {
-    'as': Comp = 'div',
-    'disabled': disabled,
-    'onClick': onClick,
-    'option': option,
-    'role': role = 'option',
-    'style': style,
-  } = props;
+export function Option({
+  as: Comp = 'div',
+  disabled,
+  onClick,
+  option,
+  role = 'option',
+  style,
+  ...rest
+}) {
   const selectorContext = useContext(SelectorContext);
   const {
     'selected': selected,
@@ -102,12 +101,12 @@ export function Option(props) {
     'disabled': selectorDisabled,
     'multiple': selectorMultiple,
   } = selectorContext;
-  const clickHandler = () => {
+  const clickHandler = (e) => {
     if (selectorDisabled || disabled) {
       return;
     }
     if (onClick) {
-      onClick();
+      onClick(e);
     }
     selectOption(option);
   };
@@ -121,7 +120,8 @@ export function Option(props) {
         : CSS.SELECTED
       : CSS.OPTION;
   const optionProps = {
-    ...props,
+    ...rest,
+    disabled,
     'aria-disabled': disabled,
     onClick: clickHandler,
     option,

--- a/extensions/amp-selector/1.0/selector.type.js
+++ b/extensions/amp-selector/1.0/selector.type.js
@@ -1,0 +1,66 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** @externs */
+
+/** @const */
+var SelectorDef = {};
+
+/**
+ * @typedef {{
+ *   as: (string|PreactDef.FunctionalComponent),
+ *   disabled: (boolean|undefined),
+ *   value: (*|undefined),
+ *   multiple: (boolean|undefined),
+ *   onChange: (?function({value: *, option: *})|undefined),
+ *   role: (string|undefined),
+ *   children: (?PreactDef.Renderable|undefined),
+ * }}
+ */
+SelectorDef.SelectorProps;
+
+/**
+ * @typedef {{
+ *   domElement: !Element,
+ *   disabled: (boolean|undefined),
+ *   multiple: (boolean|undefined),
+ *   role: (string|undefined),
+ * }}
+ */
+SelectorDef.SelectorShimProps;
+
+/**
+ * @typedef {{
+ *   as: (string|PreactDef.FunctionalComponent),
+ *   option: *,
+ *   disabled: (boolean|undefined),
+ *   onClick: (?function(!Event)|undefined),
+ *   role: (string|undefined),
+ *   style: (!Object|undefined),
+ * }}
+ */
+SelectorDef.OptionProps;
+
+/**
+ * @typedef {{
+ *   domElement: !Element,
+ *   onClick: (?function(!Event)|undefined),
+ *   selected: (boolean|undefined),
+ *   isDisabled: (boolean|undefined),
+ *   role: (string|undefined),
+ * }}
+ */
+SelectorDef.OptionShimProps;

--- a/extensions/amp-selector/1.0/selector.type.js
+++ b/extensions/amp-selector/1.0/selector.type.js
@@ -16,6 +16,8 @@
 
 /** @externs */
 
+// TODO(#29293): Make "as" and "role" optional.
+
 /** @const */
 var SelectorDef = {};
 
@@ -23,24 +25,24 @@ var SelectorDef = {};
  * @typedef {{
  *   as: (string|PreactDef.FunctionalComponent),
  *   disabled: (boolean|undefined),
- *   value: (*|undefined),
+ *   value: (!Array|undefined),
  *   multiple: (boolean|undefined),
- *   onChange: (?function({value: *, option: *})|undefined),
- *   role: (string|undefined),
+ *   onChange: (?function({value: !Array, option: *})|undefined),
+ *   role: string,
  *   children: (?PreactDef.Renderable|undefined),
  * }}
  */
-SelectorDef.SelectorProps;
+SelectorDef.Props;
 
 /**
  * @typedef {{
  *   domElement: !Element,
  *   disabled: (boolean|undefined),
  *   multiple: (boolean|undefined),
- *   role: (string|undefined),
+ *   role: string,
  * }}
  */
-SelectorDef.SelectorShimProps;
+SelectorDef.ShimProps;
 
 /**
  * @typedef {{
@@ -48,7 +50,7 @@ SelectorDef.SelectorShimProps;
  *   option: *,
  *   disabled: (boolean|undefined),
  *   onClick: (?function(!Event)|undefined),
- *   role: (string|undefined),
+ *   role: string,
  *   style: (!Object|undefined),
  * }}
  */
@@ -60,7 +62,7 @@ SelectorDef.OptionProps;
  *   onClick: (?function(!Event)|undefined),
  *   selected: (boolean|undefined),
  *   isDisabled: (boolean|undefined),
- *   role: (string|undefined),
+ *   role: string,
  * }}
  */
 SelectorDef.OptionShimProps;

--- a/src/preact/index.js
+++ b/src/preact/index.js
@@ -22,7 +22,7 @@ import * as preact from /*OK*/ 'preact';
 
 /**
  * @param {!PreactDef.FunctionalComponent|string} unusedType
- * @param {(!Object|null)=} unusedProps
+ * @param {?Object=} unusedProps
  * @param {...*} var_args
  * @return {!PreactDef.VNode}
  */
@@ -32,7 +32,7 @@ export function createElement(unusedType, unusedProps, var_args) {
 
 /**
  * @param {!PreactDef.VNode} unusedElement
- * @param {(!Object|null)=} unusedProps
+ * @param {?Object=} unusedProps
  * @param {...PreactDef.Renderable} unusedChildren
  * @return {!PreactDef.VNode}
  */
@@ -49,7 +49,7 @@ export function render(vnode, container) {
 }
 
 /**
- * @param {!JsonObject} props
+ * @param {?Object=} props
  * @return {PreactDef.Renderable}
  */
 export function Fragment(props) {


### PR DESCRIPTION
The most consequential change is in the `build-system/externs/preact.extern.js`. I'm using `?` for the `FunctionalComponent`'s declaration. I couldn't find any other way that worked. I tried `Object` and `*` - they all failed in different places for reasons that are not clear to me.