### PR TITLE
Implement protocol adapters

### DIFF
--- a/examples/amp-list-protocol-adapters.html
+++ b/examples/amp-list-protocol-adapters.html
@@ -1,0 +1,38 @@
+<!--
+  ## Introduction
+
+  The [`amp-list`](https://amp.dev/documentation/components/amp-list) component fetches dynamic content from a CORS JSON endpoint and renders it using a supplied template. This is good for embedding a dynamic list of related articles.
+-->
+<!-- -->
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <!-- ## Setup -->
+  <!-- Import the `amp-list` component ... -->
+  <script async custom-element="amp-list" src="https://cdn.ampproject.org/v0/amp-list-0.1.js"></script>
+  <script async custom-element="amp-script" src="https://cdn.ampproject.org/v0/amp-script-0.1.js"></script>
+  <!-- ... and the `amp-mustache` component in the header -->
+  <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-latest.js"></script>
+  <link rel="canonical" href="https://amp.dev/documentation/examples/components/amp-list/">
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+</head>
+<body>
+
+  <h3>PROTOCOL ADAPTERS</h3>
+  <amp-script width=1 height=1 script="local-script" data-ampdevmode></amp-script>
+  <script type="text/plain" target="amp-script" id="local-script">
+    function fetchData() {
+      return {items: [1, 2, 3, 4, 5]};
+    }
+    exportFunction('fetchData', fetchData);
+  </script>
+  <amp-list id="list1" width="auto" height="100" layout="fixed-height" src="amp-script:local-script.fetchData" class="m1" reset-on-refresh>
+    <template type="amp-mustache" id="amp-template-id">
+      <div>{{.}}</div>
+    </template>
+  </amp-list> 
+</body>
+</html>

--- a/examples/amp-list-protocol-adapters.html
+++ b/examples/amp-list-protocol-adapters.html
@@ -15,7 +15,7 @@
   <h1>PROTOCOL ADAPTERS</h1>
 
   <h3>basic example</h3>
-  <amp-script width=1 height=1 script="local-script" data-ampdevmode></amp-script>
+  <amp-script id="fns" width=1 height=1 script="local-script" data-ampdevmode></amp-script>
   <script type="text/plain" target="amp-script" id="local-script">
     function fetchData() {
       const items = [{name: 'apple'}, {name: 'banana'}, {name: 'pear'}];
@@ -31,7 +31,7 @@
     exportFunction('fetchData', fetchData);
     exportFunction('fetchSingleItem', fetchSingleItem);
   </script>
-  <amp-list id="list1" width="auto" height="100" layout="fixed-height" src="amp-script:local-script.fetchData">
+  <amp-list id="list1" width="auto" height="100" layout="fixed-height" src="amp-script:fns.fetchData">
     <template type="amp-mustache" id="amp-template-id">
       <div>{{name}}</div>
     </template>
@@ -43,7 +43,7 @@
     width="auto"
     height="100"
     layout="fixed-height"
-    src="amp-script:local-script.fetchSingleItem"
+    src="amp-script:fns.fetchSingleItem"
     single-item
   >
     <template type="amp-mustache" id="amp-template-id">

--- a/examples/amp-list-protocol-adapters.html
+++ b/examples/amp-list-protocol-adapters.html
@@ -1,7 +1,7 @@
 <!--
   ## Introduction
 
-  The [`amp-list`](https://amp.dev/documentation/components/amp-list) component fetches dynamic content from a CORS JSON endpoint and renders it using a supplied template. This is good for embedding a dynamic list of related articles.
+  The [`amp-list`](https://amp.dev/documentation/components/amp-list) component can fetch dynamic content by calling in to custom JS Functions.
 -->
 <!-- -->
 <!doctype html>
@@ -27,9 +27,10 @@
     function fetchData() {
       return Promise.resolve({items: [1, 2, 3, 4, 5]});
     }
+
     exportFunction('fetchData', fetchData);
   </script>
-  <amp-list id="list1" width="auto" height="100" layout="fixed-height" src="amp-script:local-script.fetchData" class="m1" reset-on-refresh>
+  <amp-list id="list1" width="auto" height="100" layout="fixed-height" src="amp-script:local-script.fetchData">
     <template type="amp-mustache" id="amp-template-id">
       <div>{{.}}</div>
     </template>

--- a/examples/amp-list-protocol-adapters.html
+++ b/examples/amp-list-protocol-adapters.html
@@ -25,7 +25,7 @@
   <amp-script width=1 height=1 script="local-script" data-ampdevmode></amp-script>
   <script type="text/plain" target="amp-script" id="local-script">
     function fetchData() {
-      return {items: [1, 2, 3, 4, 5]};
+      return Promise.resolve({items: [1, 2, 3, 4, 5]});
     }
     exportFunction('fetchData', fetchData);
   </script>

--- a/examples/amp-list-protocol-adapters.html
+++ b/examples/amp-list-protocol-adapters.html
@@ -1,19 +1,10 @@
-<!--
-  ## Introduction
-
-  The [`amp-list`](https://amp.dev/documentation/components/amp-list) component can fetch dynamic content by calling in to custom JS Functions.
--->
-<!-- -->
 <!doctype html>
 <html ⚡>
 <head>
   <meta charset="utf-8">
   <script async src="https://cdn.ampproject.org/v0.js"></script>
-  <!-- ## Setup -->
-  <!-- Import the `amp-list` component ... -->
   <script async custom-element="amp-list" src="https://cdn.ampproject.org/v0/amp-list-0.1.js"></script>
   <script async custom-element="amp-script" src="https://cdn.ampproject.org/v0/amp-script-0.1.js"></script>
-  <!-- ... and the `amp-mustache` component in the header -->
   <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-latest.js"></script>
   <link rel="canonical" href="https://amp.dev/documentation/examples/components/amp-list/">
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
@@ -21,19 +12,44 @@
 </head>
 <body>
 
-  <h3>PROTOCOL ADAPTERS</h3>
+  <h1>PROTOCOL ADAPTERS</h1>
+
+  <h3>single-item example</h3>
   <amp-script width=1 height=1 script="local-script" data-ampdevmode></amp-script>
   <script type="text/plain" target="amp-script" id="local-script">
     function fetchData() {
-      return Promise.resolve({items: [1, 2, 3, 4, 5]});
+      const items = [{name: 'apple'}, {name: 'banana'}, {name: 'pear'}];
+      return Promise.resolve({items});
+    }
+
+    function fetchSingleItem() {
+      const title = 'The Animals That Could';
+      const price = 99.99;
+      return Promise.resolve({ items: {title, price} });
     }
 
     exportFunction('fetchData', fetchData);
+    exportFunction('fetchSingleItem', fetchSingleItem);
   </script>
   <amp-list id="list1" width="auto" height="100" layout="fixed-height" src="amp-script:local-script.fetchData">
     <template type="amp-mustache" id="amp-template-id">
-      <div>{{.}}</div>
+      <div>{{name}}</div>
     </template>
-  </amp-list> 
+  </amp-list>
+
+  <h3>single-item example</h3>
+  <amp-list
+    id="list1"
+    width="auto"
+    height="100"
+    layout="fixed-height"
+    src="amp-script:local-script.fetchSingleItem"
+    single-item
+  >
+    <template type="amp-mustache" id="amp-template-id">
+      <div><b>Title</b>: {{title}}</div>
+      <div><b>Price</b>: {{price}}</div>
+    </template>
+  </amp-list>
 </body>
 </html>

--- a/examples/amp-list-protocol-adapters.html
+++ b/examples/amp-list-protocol-adapters.html
@@ -14,7 +14,7 @@
 
   <h1>PROTOCOL ADAPTERS</h1>
 
-  <h3>single-item example</h3>
+  <h3>basic example</h3>
   <amp-script width=1 height=1 script="local-script" data-ampdevmode></amp-script>
   <script type="text/plain" target="amp-script" id="local-script">
     function fetchData() {

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -419,6 +419,13 @@ export class AmpList extends AMP.BaseElement {
    * @private
    */
   isAmpScriptSrc_(src) {
+    if (getMode().development) {
+      devAssert(
+        startsWith(src, AMP_SCRIPT_URI_SCHEME) ===
+          isExperimentOn(this.win, 'protocol-adapters'),
+        'Must enable "protocol-adapters" experiment to use an amp-script src.'
+      );
+    }
     return (
       isExperimentOn(this.win, 'protocol-adapters') &&
       startsWith(src, AMP_SCRIPT_URI_SCHEME)

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -467,14 +467,11 @@ export class AmpList extends AMP.BaseElement {
    * @private
    */
   getAmpScriptJson_(src) {
-    if (!isExperimentOn(this.win, 'protocol-adapters')) {
-      return Promise.reject(`Experiment 'protocol-adapters' is not turned on.`);
-    }
-    return Services.scriptForDocOrNull(this.element)
-      .then((ampScript) => {
+    return Promise.resolve()
+      .then(() => {
         userAssert(
-          ampScript,
-          '[amp-list]: "amp-script" URLs require amp-script to be installed.'
+          isExperimentOn(this.win, 'protocol-adapters'),
+          `Experiment 'protocol-adapters' is not turned on.`
         );
         userAssert(
           !this.ssrTemplateHelper_.isEnabled(),
@@ -491,12 +488,9 @@ export class AmpList extends AMP.BaseElement {
         const fnIdentifier = args[1];
         const ampScriptEl = this.element
           .getAmpDoc()
-          .getRootNode()
-          .querySelector(
-            `amp-script[script=${escapeCssSelectorIdent(ampScriptId)}]`
-          );
+          .getElementById(ampScriptId);
         userAssert(
-          ampScriptEl,
+          ampScriptEl && ampScriptEl.tagName === 'AMP-SCRIPT',
           `[amp-list]: could not find <amp-script> with script set to ${ampScriptId}`
         );
         return ampScriptEl

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -481,6 +481,10 @@ export class AmpList extends AMP.BaseElement {
         );
 
         const args = src.slice(AMP_SCRIPT_URI_SCHEME.length).split('.');
+        userAssert(
+          args.length === 2,
+          '[amp-list]: "amp-script" URIs must be of the format "scriptId.functionIdentifier".'
+        );
         const ampScriptId = args[0];
         const fnIdentifier = args[1];
         return ampScript.callFunction(ampScriptId, fnIdentifier);

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -50,6 +50,7 @@ import {
 import {createCustomEvent, listen} from '../../../src/event-helper';
 import {dev, devAssert, user, userAssert} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
+import {escapeCssSelectorIdent} from '../../../src/css';
 import {getMode} from '../../../src/mode';
 import {getSourceOrigin} from '../../../src/url';
 import {getValueForExpr} from '../../../src/json';
@@ -65,7 +66,6 @@ import {isExperimentOn} from '../../../src/experiments';
 import {px, setImportantStyles, setStyles, toggle} from '../../../src/style';
 import {setDOM} from '../../../third_party/set-dom/set-dom';
 import {startsWith} from '../../../src/string';
-import {escapeCssSelectorIdent} from '../../../src/css';
 
 /** @const {string} */
 const TAG = 'amp-list';
@@ -77,7 +77,6 @@ const TABBABLE_ELEMENTS_QUERY =
 // Technically the ':' is not considered part of the scheme, but it is useful to include.
 const AMP_STATE_URI_SCHEME = 'amp-state:';
 const AMP_SCRIPT_URI_SCHEME = 'amp-script:';
-const PROTOCOL_ADAPTERS = 'protocol-adapters';
 
 /**
  * @typedef {{
@@ -468,10 +467,8 @@ export class AmpList extends AMP.BaseElement {
    * @private
    */
   getAmpScriptJson_(src) {
-    if (!isExperimentOn(this.win, PROTOCOL_ADAPTERS)) {
-      return Promise.reject(
-        `Experiment ${PROTOCOL_ADAPTERS} is not turned on.`
-      );
+    if (!isExperimentOn(this.win, 'protocol-adapters')) {
+      return Promise.reject(`Experiment 'protocol-adapters' is not turned on.`);
     }
     return Services.scriptForDocOrNull(this.element)
       .then((ampScript) => {

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -743,11 +743,13 @@ export class AmpList extends AMP.BaseElement {
     if (this.ssrTemplateHelper_.isEnabled()) {
       fetch = this.ssrTemplate_(opt_refresh);
     } else {
-      fetch = this.isAmpStateSrc_(elementSrc)
-        ? this.getAmpStateJson_(elementSrc)
-        : this.isAmpScriptSrc_(elementSrc)
-        ? this.getAmpScriptJson_(elementSrc)
-        : this.prepareAndSendFetch_(opt_refresh);
+      if (this.isAmpStateSrc_(elementSrc)) {
+        fetch = this.getAmpStateJson_(elementSrc);
+      } else if (this.isAmpScriptSrc_(elementSrc)) {
+        fetch = this.getAmpScriptJson_(elementSrc);
+      } else {
+        fetch = this.prepareAndSendFetch_(opt_refresh);
+      }
       fetch = fetch.then((data) => {
         // Bail if the src has changed while resolving the xhr request.
         if (elementSrc !== this.element.getAttribute('src')) {

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -50,7 +50,6 @@ import {
 import {createCustomEvent, listen} from '../../../src/event-helper';
 import {dev, devAssert, user, userAssert} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
-import {escapeCssSelectorIdent} from '../../../src/css';
 import {getMode} from '../../../src/mode';
 import {getSourceOrigin} from '../../../src/url';
 import {getValueForExpr} from '../../../src/json';

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -460,7 +460,7 @@ export class AmpList extends AMP.BaseElement {
         return json;
       });
   }
-  
+
   /**
    * Gets the json from an amp-script uri.
    *
@@ -471,13 +471,18 @@ export class AmpList extends AMP.BaseElement {
   getAmpScriptJson_(src) {
     return Services.scriptForDocOrNull(this.element)
       .then((ampScript) => {
-        userAssert(ampScript, '"amp-script:" URLs require amp-script to be installed.');
+        userAssert(
+          ampScript,
+          '"amp-script:" URLs require amp-script to be installed.'
+        );
         userAssert(
           !this.ssrTemplateHelper_.isEnabled(),
           '[amp-list]: "amp-script" URIs cannot be used in SSR mode.'
         );
 
-        const [ampScriptId, fnIdentifier ] = src.slice(AMP_SCRIPT_URI_SCHEME.length).split('.');
+        const args = src.slice(AMP_SCRIPT_URI_SCHEME.length).split('.');
+        const ampScriptId = args[0];
+        const fnIdentifier = args[1];
         return ampScript.callFunction(ampScriptId, fnIdentifier);
       })
       .then((json) => {
@@ -488,7 +493,6 @@ export class AmpList extends AMP.BaseElement {
         return json;
       });
   }
-
 
   /** @override */
   mutatedAttributesCallback(mutations) {

--- a/extensions/amp-list/0.1/test/test-amp-list.js
+++ b/extensions/amp-list/0.1/test/test-amp-list.js
@@ -25,7 +25,10 @@ import {
   createElementWithAttributes,
   whenUpgradedToCustomElement,
 } from '../../../../src/dom';
-import {toggleExperiment} from '../../../../src/experiments';
+import {
+  resetExperimentTogglesForTesting,
+  toggleExperiment,
+} from '../../../../src/experiments';
 
 describes.repeated(
   'amp-list',

--- a/extensions/amp-list/0.1/test/test-amp-list.js
+++ b/extensions/amp-list/0.1/test/test-amp-list.js
@@ -984,7 +984,7 @@ describes.repeated(
               return list.layoutCallback().catch(() => {});
             });
           });
-          describe.only('Using amp-script: protocol', () => {
+          describe('Using amp-script: protocol', () => {
             beforeEach(() => {
               env.sandbox.stub(Services, 'scriptForDocOrNull');
               resetExperimentTogglesForTesting(win);
@@ -1021,6 +1021,20 @@ describes.repeated(
               const errorMsg = /amp-script to be installed/;
               expectAsyncConsoleError(errorMsg);
               expect(list.layoutCallback()).eventually.rejectedWith(errorMsg);
+            });
+            it('should fail if function call rejects', async () => {
+              toggleExperiment(win, 'protocol-adapters', true);
+              Services.scriptForDocOrNull.returns(
+                Promise.resolve({
+                  callFunction: () =>
+                    Promise.reject('Invalid function identifier.'),
+                })
+              );
+
+              listMock.expects('toggleLoading').withExactArgs(false).once();
+              return expect(
+                list.layoutCallback()
+              ).to.eventually.be.rejectedWith(/Invalid function identifier/);
             });
 
             it('should render a list from AmpScriptService provided data', async () => {

--- a/extensions/amp-list/0.1/test/test-amp-list.js
+++ b/extensions/amp-list/0.1/test/test-amp-list.js
@@ -1093,7 +1093,8 @@ describes.repeated(
             it('should render a list from AmpScriptService provided data', async () => {
               toggleExperiment(win, 'protocol-adapters', true);
               Services.scriptForDocOrNull.returns(Promise.resolve({}));
-              ampScriptEl.getImpl = () => Promise.resolve({
+              ampScriptEl.getImpl = () =>
+                Promise.resolve({
                   callFunction(fnId) {
                     if (fnId === 'fetchData') {
                       return Promise.resolve({items: [3, 2, 1]});

--- a/extensions/amp-list/0.1/test/test-amp-list.js
+++ b/extensions/amp-list/0.1/test/test-amp-list.js
@@ -995,7 +995,7 @@ describes.repeated(
 
               env.sandbox.stub(Services, 'scriptForDocOrNull');
               ampScriptEl = document.createElement('amp-script');
-              ampScriptEl.setAttribute('script', 'example');
+              ampScriptEl.setAttribute('id', 'example');
               doc.body.appendChild(ampScriptEl);
 
               element = createAmpListElement();
@@ -1012,7 +1012,6 @@ describes.repeated(
 
             it('should throw an error if given an invalid format', async () => {
               toggleExperiment(win, 'protocol-adapters', true);
-              Services.scriptForDocOrNull.returns(Promise.resolve({}));
               const errorMsg = /URIs must be of the format/;
 
               element.setAttribute('src', 'amp-script:fetchData');
@@ -1028,18 +1027,8 @@ describes.repeated(
               expect(list.layoutCallback()).to.eventually.throw(errorMsg);
             });
 
-            it('should log an error if amp-script was not included', async () => {
-              toggleExperiment(win, 'protocol-adapters', true);
-              Services.scriptForDocOrNull.returns(Promise.resolve(null));
-
-              const errorMsg = /amp-script to be installed/;
-              expectAsyncConsoleError(errorMsg);
-              expect(list.layoutCallback()).eventually.rejectedWith(errorMsg);
-            });
-
             it('should throw if specified amp-script does not exist', () => {
               toggleExperiment(win, 'protocol-adapters', true);
-              Services.scriptForDocOrNull.returns(Promise.resolve({}));
               element.setAttribute('src', 'amp-script:doesnotexist.fn');
 
               const errorMsg = /could not find <amp-script> with/;
@@ -1049,7 +1038,6 @@ describes.repeated(
 
             it('should fail if function call rejects', async () => {
               toggleExperiment(win, 'protocol-adapters', true);
-              Services.scriptForDocOrNull.returns(Promise.resolve({}));
               ampScriptEl.getImpl = () =>
                 Promise.resolve({
                   callFunction: () =>
@@ -1066,7 +1054,6 @@ describes.repeated(
               const callFunctionResult = {'items': {title: 'Title'}};
               element.setAttribute('single-item', 'true');
               toggleExperiment(win, 'protocol-adapters', true);
-              Services.scriptForDocOrNull.returns(Promise.resolve({}));
               ampScriptEl.getImpl = () =>
                 Promise.resolve({
                   callFunction(fnId) {
@@ -1092,7 +1079,6 @@ describes.repeated(
 
             it('should render a list from AmpScriptService provided data', async () => {
               toggleExperiment(win, 'protocol-adapters', true);
-              Services.scriptForDocOrNull.returns(Promise.resolve({}));
               ampScriptEl.getImpl = () =>
                 Promise.resolve({
                   callFunction(fnId) {

--- a/extensions/amp-list/0.1/test/test-amp-list.js
+++ b/extensions/amp-list/0.1/test/test-amp-list.js
@@ -1037,6 +1037,34 @@ describes.repeated(
               ).to.eventually.be.rejectedWith(/Invalid function identifier/);
             });
 
+            it('should render non-array if single-item is set', async () => {
+              const callFunctionResult = {'items': {title: 'Title'}};
+              element.setAttribute('single-item', 'true');
+              toggleExperiment(win, 'protocol-adapters', true);
+              Services.scriptForDocOrNull.returns(
+                Promise.resolve({
+                  callFunction(scriptId, fnId) {
+                    if (scriptId === 'example' && fnId === 'fetchData') {
+                      return Promise.resolve(callFunctionResult);
+                    }
+                    return Promise.reject('Invalid function scriptId/fnId');
+                  },
+                })
+              );
+
+              listMock
+                .expects('scheduleRender_')
+                .withExactArgs(
+                  [{title: 'Title'}],
+                  /*append*/ false,
+                  callFunctionResult
+                )
+                .returns(Promise.resolve())
+                .once();
+
+              await list.layoutCallback();
+            });
+
             it('should render a list from AmpScriptService provided data', async () => {
               toggleExperiment(win, 'protocol-adapters', true);
               Services.scriptForDocOrNull.returns(

--- a/extensions/amp-list/0.1/test/test-amp-list.js
+++ b/extensions/amp-list/0.1/test/test-amp-list.js
@@ -941,6 +941,7 @@ describes.repeated(
               const errorMsg = /cannot be used in SSR mode/;
               expectAsyncConsoleError(errorMsg);
               expect(list.layoutCallback()).eventually.rejectedWith(errorMsg);
+              toggleExperiment(win, 'protocol-adapters', false);
             });
 
             it('Bound [src] should skip rendering and emit an error', async () => {
@@ -1037,8 +1038,11 @@ describes.repeated(
             });
 
             it('should throw if specified amp-script does not exist', () => {
-              const errorMsg = /could not find amp-script with/;
+              toggleExperiment(win, 'protocol-adapters', true);
+              Services.scriptForDocOrNull.returns(Promise.resolve({}));
               element.setAttribute('src', 'amp-script:doesnotexist.fn');
+
+              const errorMsg = /could not find <amp-script> with/;
               expectAsyncConsoleError(errorMsg);
               expect(list.layoutCallback()).to.eventually.throw(errorMsg);
             });
@@ -1046,11 +1050,11 @@ describes.repeated(
             it('should fail if function call rejects', async () => {
               toggleExperiment(win, 'protocol-adapters', true);
               Services.scriptForDocOrNull.returns(Promise.resolve({}));
-              ampScriptEl.getImpl = () => 
+              ampScriptEl.getImpl = () =>
                 Promise.resolve({
                   callFunction: () =>
                     Promise.reject('Invalid function identifier.'),
-                }); 
+                });
 
               listMock.expects('toggleLoading').withExactArgs(false).once();
               return expect(
@@ -1063,7 +1067,7 @@ describes.repeated(
               element.setAttribute('single-item', 'true');
               toggleExperiment(win, 'protocol-adapters', true);
               Services.scriptForDocOrNull.returns(Promise.resolve({}));
-              ampScriptEl.getImpl = () => 
+              ampScriptEl.getImpl = () =>
                 Promise.resolve({
                   callFunction(fnId) {
                     if (fnId === 'fetchData') {

--- a/extensions/amp-list/validator-amp-list.protoascii
+++ b/extensions/amp-list/validator-amp-list.protoascii
@@ -99,6 +99,7 @@ tags: {  # <amp-list> with mandatory src and/or [src] attr
     value_url: {
       protocol: "https"
       protocol: "amp-state"
+      protocol: "amp-script"
       allow_relative: true  # Will be set to false at a future date.
     }
     disallowed_value_regex: "__amp_source_origin"

--- a/extensions/amp-script/0.1/amp-script.js
+++ b/extensions/amp-script/0.1/amp-script.js
@@ -44,7 +44,7 @@ const TAG = 'amp-script';
  *   onerror: ?function(!ErrorEvent):void
  * }}
  */
-let WorkerDOMWorker;
+let WorkerDOMWorkerDef;
 
 /**
  * Max cumulative size of author scripts from all amp-script elements on page.
@@ -83,7 +83,7 @@ export class AmpScript extends AMP.BaseElement {
     /** @private @const {!../../../src/service/vsync-impl.Vsync} */
     this.vsync_ = Services.vsyncFor(this.win);
 
-    /** @private {?WorkerDOMWorker} */
+    /** @private {?WorkerDOMWorkerDef} */
     this.workerDom_ = null;
 
     /** @private {?UserActivationTracker} */

--- a/extensions/amp-script/0.1/amp-script.js
+++ b/extensions/amp-script/0.1/amp-script.js
@@ -162,9 +162,13 @@ export class AmpScript extends AMP.BaseElement {
     return this.userActivation_;
   }
 
+  /**
+   * Calls the specified function on this amp-script's worker-dom instance.
+   *
+   * @param {*} functionIdentifier
+   */
   callFunction(functionIdentifier) {
     return this.initializationCompleted_.promise.then(() => {
-      console.log('made it past the promise');
       return this.workerDom_.callFunction(functionIdentifier)
     });
   }
@@ -557,7 +561,7 @@ export class AmpScriptService {
 
   /**
    * Calls an exported function on a specific amp-script worker and returns the result.
-   * 
+   *
    * @param {string} ampScriptId
    * @param {string} fnIdentifier
    * @return {Promise<*>}

--- a/extensions/amp-script/0.1/amp-script.js
+++ b/extensions/amp-script/0.1/amp-script.js
@@ -38,6 +38,15 @@ import {utf8Encode} from '../../../src/utils/bytes';
 const TAG = 'amp-script';
 
 /**
+ * @typedef {{
+ *   terminate: function():void,
+ *   callFunction: function(string, ...*):Promise<*>,
+ *   onerror: ?function(!ErrorEvent):void
+ * }}
+ */
+let WorkerDOMWorker;
+
+/**
  * Max cumulative size of author scripts from all amp-script elements on page.
  * @const {number}
  */
@@ -74,7 +83,7 @@ export class AmpScript extends AMP.BaseElement {
     /** @private @const {!../../../src/service/vsync-impl.Vsync} */
     this.vsync_ = Services.vsyncFor(this.win);
 
-    /** @private {?Worker} */
+    /** @private {?WorkerDOMWorker} */
     this.workerDom_ = null;
 
     /** @private {?UserActivationTracker} */
@@ -166,8 +175,8 @@ export class AmpScript extends AMP.BaseElement {
   /**
    * Calls the specified function on this amp-script's worker-dom instance.
    *
-   * @param {*} functionIdentifier
-   * @return {!Promise}
+   * @param {string} functionIdentifier
+   * @return {!Promise<*>}
    */
   callFunction(functionIdentifier) {
     return this.initializationCompleted_.promise.then(() => {

--- a/src/services.js
+++ b/src/services.js
@@ -206,7 +206,7 @@ export class Services {
 
   /**
    * @param {!Element|!ShadowRoot} element
-   * @return {!Promise<?../extensions/amp-bind/0.1/amp-script.AmpScriptService>}
+   * @return {!Promise<?../extensions/amp-script/0.1/amp-script.AmpScriptService>}
    */
   static scriptForDocOrNull(element) {
     return /** @type {!Promise<?../extensions/amp-script/0.1/amp-script.AmpScriptService>} */ (getElementServiceIfAvailableForDocInEmbedScope(

--- a/src/services.js
+++ b/src/services.js
@@ -203,7 +203,7 @@ export class Services {
       'amp-bind'
     ));
   }
-  
+
   /**
    * @param {!Element|!ShadowRoot} element
    * @return {!Promise<?../extensions/amp-bind/0.1/amp-script.AmpScriptService>}

--- a/src/services.js
+++ b/src/services.js
@@ -203,6 +203,18 @@ export class Services {
       'amp-bind'
     ));
   }
+  
+  /**
+   * @param {!Element|!ShadowRoot} element
+   * @return {!Promise<?../extensions/amp-bind/0.1/amp-script.AmpScriptService>}
+   */
+  static scriptForDocOrNull(element) {
+    return /** @type {!Promise<?../extensions/amp-script/0.1/amp-script.AmpScriptService>} */ (getElementServiceIfAvailableForDocInEmbedScope(
+      element,
+      'amp-script',
+      'amp-script'
+    ));
+  }
 
   /**
    * @param {!Element|!ShadowRoot|!./service/ampdoc-impl.AmpDoc} elementOrAmpDoc

--- a/tools/experiments/experiments-config.js
+++ b/tools/experiments/experiments-config.js
@@ -237,6 +237,11 @@ export const EXPERIMENTS = [
     cleanupIssue: 'https://github.com/ampproject/amphtml/issues/24113',
   },
   {
+    id: 'protocol-adapters',
+    name: 'Allow amp-list to get its data from amp-script functions.',
+    spec: 'https://github.com/ampproject/amphtml/issues/26474',
+  },
+  {
     id: 'adsense-ad-size-optimization',
     name:
       'Per publisher server side settings for changing the ad size ' +


### PR DESCRIPTION
**summary**
Implements Protocol adapters: #25719.

Introduces the concept of the `amp-script` src for amp-list components.
I picked this to be more in line with how initializing from `amp-state` works, but if anyone feels strongly I'd be 
ok with switching back to the more terse `fn:`.

Note that amp-bind is not required for this to work.

**future work**
- introduce the "lite" parameter for a domless amp-script.
- documentation
- allow all bind expressions to reference amp-script functions (as requested https://github.com/ampproject/amphtml/issues/25684)

cc @morsssss 