### PR TITLE
🏗 Addition of `--sxg` flag in `dist`.

### DIFF
--- a/build-system/tasks/dist.js
+++ b/build-system/tasks/dist.js
@@ -436,4 +436,5 @@ dist.flags = {
     '  Builds runtime with the EXPERIMENT constant set to true',
   sanitize_vars_for_diff:
     '  Sanitize the output to diff build results. Requires --pseudo_names',
+  sxg: '  Outputs the compiled code for the SxG build',
 };


### PR DESCRIPTION
Remade PR due to CLA check, as well as no longer using the `.sxg.js` approach discussed earlier with Infra.