### PR TITLE
🚮  [amp-list] cleanup experiment 'amp-list-init-from-state'

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -12,7 +12,6 @@
   "amp-action-macro": 1,
   "amp-ad-ff-adx-ady": 0.01,
   "amp-auto-ads-adsense-holdout": 0.1,
-  "amp-list-init-from-state": 1,
   "amp-mega-menu": 1,
   "amp-nested-menu": 1,
   "amp-playbuzz": 1,

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -12,7 +12,6 @@
   "amp-action-macro": 1,
   "amp-ad-ff-adx-ady": 0.01,
   "amp-auto-ads-adsense-holdout": 0.1,
-  "amp-list-init-from-state": 1,
   "amp-mega-menu": 1,
   "amp-nested-menu": 1,
   "amp-playbuzz": 1,

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -407,10 +407,7 @@ export class AmpList extends AMP.BaseElement {
    * @private
    */
   isAmpStateSrc_(src) {
-    return (
-      isExperimentOn(this.win, 'amp-list-init-from-state') &&
-      startsWith(src, AMP_STATE_URI_SCHEME)
-    );
+    return startsWith(src, AMP_STATE_URI_SCHEME);
   }
 
   /**

--- a/extensions/amp-list/0.1/test/test-amp-list.js
+++ b/extensions/amp-list/0.1/test/test-amp-list.js
@@ -25,10 +25,7 @@ import {
   createElementWithAttributes,
   whenUpgradedToCustomElement,
 } from '../../../../src/dom';
-import {
-  resetExperimentTogglesForTesting,
-  toggleExperiment,
-} from '../../../../src/experiments';
+import {toggleExperiment} from '../../../../src/experiments';
 
 describes.repeated(
   'amp-list',

--- a/extensions/amp-list/0.1/test/test-amp-list.js
+++ b/extensions/amp-list/0.1/test/test-amp-list.js
@@ -917,8 +917,6 @@ describes.repeated(
             });
 
             it('"amp-state:" uri should skip rendering and emit an error', () => {
-              toggleExperiment(win, 'amp-list-init-from-state', true);
-
               const ampStateEl = doc.createElement('amp-state');
               ampStateEl.setAttribute('id', 'okapis');
               const ampStateJson = doc.createElement('script');
@@ -1335,24 +1333,14 @@ describes.repeated(
           });
 
           describe('Using amp-state: protocol', () => {
-            const experimentName = 'amp-list-init-from-state';
-
             beforeEach(() => {
-              resetExperimentTogglesForTesting(win);
               element = createAmpListElement();
               element.setAttribute('src', 'amp-state:okapis');
               element.toggleLoading = () => {};
               list = createAmpList(element);
             });
 
-            it('should throw an error if used without the experiment enabled', async () => {
-              const errorMsg = /Invalid value: amp-state:okapis/;
-              expectAsyncConsoleError(errorMsg);
-              expect(list.layoutCallback()).to.eventually.throw(errorMsg);
-            });
-
             it('should throw error if there is no associated amp-state el', async () => {
-              toggleExperiment(win, experimentName, true);
               bind.getStateAsync = () => Promise.reject();
 
               const errorMsg = /element with id 'okapis' was not found/;
@@ -1361,7 +1349,6 @@ describes.repeated(
             });
 
             it('should log an error if amp-bind was not included', async () => {
-              toggleExperiment(win, experimentName, true);
               Services.bindForDocOrNull.returns(Promise.resolve(null));
 
               const ampStateEl = doc.createElement('amp-state');
@@ -1377,7 +1364,6 @@ describes.repeated(
             });
 
             it('should render a list using local data', async () => {
-              toggleExperiment(win, experimentName, true);
               bind.getStateAsync = () => Promise.resolve({items: [1, 2, 3]});
 
               const ampStateEl = doc.createElement('amp-state');
@@ -1397,7 +1383,6 @@ describes.repeated(
             });
 
             it('should render a list using async data', async () => {
-              toggleExperiment(win, experimentName, true);
               const {resolve, promise} = new Deferred();
               bind.getStateAsync = () => promise;
 

--- a/tools/experiments/experiments-config.js
+++ b/tools/experiments/experiments-config.js
@@ -96,11 +96,6 @@ export const EXPERIMENTS = [
     spec: 'https://github.com/ampproject/amphtml/issues/7743',
   },
   {
-    id: 'amp-list-init-from-state',
-    name: 'Allows amp-list to initialize off of amp-state',
-    spec: 'https://github.com/ampproject/amphtml/issues/26009',
-  },
-  {
     id: 'amp-playbuzz',
     name: 'AMP extension for playbuzz items (launched)',
     spec: 'https://github.com/ampproject/amphtml/issues/6106',


### PR DESCRIPTION
Removes the experiment from https://github.com/ampproject/amphtml/issues/26473 now that the feature has been launched for months.