### PR TITLE
[amp-story] Add attachmentPageId to the store

### DIFF
--- a/extensions/amp-story/1.0/amp-story-page-attachment.js
+++ b/extensions/amp-story/1.0/amp-story-page-attachment.js
@@ -228,7 +228,8 @@ export class AmpStoryPageAttachment extends DraggableDrawer {
 
     super.open(shouldAnimate);
 
-    this.storeService_.dispatch(Action.TOGGLE_SYSTEM_UI_IS_VISIBLE, false);
+    const pageId = this.storeService_.get(StateProperty.CURRENT_PAGE_ID);
+    this.storeService_.dispatch(Action.SET_ATTACHMENT_PAGE_ID, pageId);
 
     // Don't create a new history entry for remote attachment as user is
     // navigating away.
@@ -238,9 +239,7 @@ export class AmpStoryPageAttachment extends DraggableDrawer {
       ));
       const historyState = {
         ...currentHistoryState,
-        [HistoryState.ATTACHMENT_PAGE_ID]: this.storeService_.get(
-          StateProperty.CURRENT_PAGE_ID
-        ),
+        [HistoryState.ATTACHMENT_PAGE_ID]: pageId,
       };
       this.historyService_.push(() => this.closeInternal_(), historyState);
     }
@@ -264,7 +263,6 @@ export class AmpStoryPageAttachment extends DraggableDrawer {
     const animationEl = this.win.document.createElement('div');
     animationEl.classList.add('i-amphtml-story-page-attachment-expand');
     const storyEl = closest(this.element, (el) => el.tagName === 'AMP-STORY');
-    this.storeService_.dispatch(Action.TOGGLE_SYSTEM_UI_IS_VISIBLE, false);
 
     this.mutateElement(() => {
       storyEl.appendChild(animationEl);
@@ -313,7 +311,7 @@ export class AmpStoryPageAttachment extends DraggableDrawer {
 
     super.closeInternal_(shouldAnimate);
 
-    this.storeService_.dispatch(Action.TOGGLE_SYSTEM_UI_IS_VISIBLE, true);
+    this.storeService_.dispatch(Action.SET_ATTACHMENT_PAGE_ID, null);
 
     const storyEl = closest(this.element, (el) => el.tagName === 'AMP-STORY');
     const animationEl = storyEl.querySelector(

--- a/extensions/amp-story/1.0/amp-story-page-attachment.js
+++ b/extensions/amp-story/1.0/amp-story-page-attachment.js
@@ -228,8 +228,8 @@ export class AmpStoryPageAttachment extends DraggableDrawer {
 
     super.open(shouldAnimate);
 
-    const pageId = this.storeService_.get(StateProperty.CURRENT_PAGE_ID);
-    this.storeService_.dispatch(Action.SET_ATTACHMENT_PAGE_ID, pageId);
+    this.storeService_.dispatch(Action.TOGGLE_PAGE_ATTACHMENT_STATE, true);
+    this.storeService_.dispatch(Action.TOGGLE_SYSTEM_UI_IS_VISIBLE, false);
 
     // Don't create a new history entry for remote attachment as user is
     // navigating away.
@@ -239,7 +239,9 @@ export class AmpStoryPageAttachment extends DraggableDrawer {
       ));
       const historyState = {
         ...currentHistoryState,
-        [HistoryState.ATTACHMENT_PAGE_ID]: pageId,
+        [HistoryState.ATTACHMENT_PAGE_ID]: this.storeService_.get(
+          StateProperty.CURRENT_PAGE_ID
+        ),
       };
       this.historyService_.push(() => this.closeInternal_(), historyState);
     }
@@ -311,7 +313,8 @@ export class AmpStoryPageAttachment extends DraggableDrawer {
 
     super.closeInternal_(shouldAnimate);
 
-    this.storeService_.dispatch(Action.SET_ATTACHMENT_PAGE_ID, null);
+    this.storeService_.dispatch(Action.TOGGLE_PAGE_ATTACHMENT_STATE, false);
+    this.storeService_.dispatch(Action.TOGGLE_SYSTEM_UI_IS_VISIBLE, true);
 
     const storyEl = closest(this.element, (el) => el.tagName === 'AMP-STORY');
     const animationEl = storyEl.querySelector(

--- a/extensions/amp-story/1.0/amp-story-store-service.js
+++ b/extensions/amp-story/1.0/amp-story-store-service.js
@@ -88,7 +88,7 @@ export let InteractiveComponentDef;
  *    canShowSystemLayerButtons: boolean,
  *    accessState: boolean,
  *    adState: boolean,
- *    attachmentPageId: ?number,
+ *    pageAttachmentState: boolean,
  *    affiliateLinkState: !Element,
  *    bookendState: boolean,
  *    desktopState: boolean,
@@ -138,7 +138,7 @@ export const StateProperty = {
   // App States.
   ACCESS_STATE: 'accessState', // amp-access paywall.
   AD_STATE: 'adState',
-  ATTACHMENT_PAGE_ID: 'attachmentPageId',
+  PAGE_ATTACHMENT_STATE: 'pageAttachmentState',
   BOOKEND_STATE: 'bookendState',
   AFFILIATE_LINK_STATE: 'affiliateLinkState',
   DESKTOP_STATE: 'desktopState',
@@ -186,7 +186,6 @@ export const Action = {
   ADD_TO_ACTIONS_ALLOWLIST: 'addToActionsAllowlist',
   CHANGE_PAGE: 'setCurrentPageId',
   SET_CONSENT_ID: 'setConsentId',
-  SET_ATTACHMENT_PAGE_ID: 'setAttachmentPageId',
   SET_ADVANCEMENT_MODE: 'setAdvancementMode',
   SET_NAVIGATION_PATH: 'setNavigationPath',
   SET_PAGE_IDS: 'setPageIds',
@@ -200,6 +199,7 @@ export const Action = {
   TOGGLE_INFO_DIALOG: 'toggleInfoDialog',
   TOGGLE_INTERACTIVE_COMPONENT: 'toggleInteractiveComponent',
   TOGGLE_MUTED: 'toggleMuted',
+  TOGGLE_PAGE_ATTACHMENT_STATE: 'togglePageAttachmentState',
   TOGGLE_PAGE_HAS_AUDIO: 'togglePageHasAudio',
   TOGGLE_PAGE_HAS_ELEMENT_WITH_PLAYBACK: 'togglePageHasElementWithPlayblack',
   TOGGLE_PAUSED: 'togglePaused',
@@ -284,11 +284,10 @@ const actions = (state, action, data) => {
         [StateProperty.ACCESS_STATE]: !!data,
         [StateProperty.PAUSED_STATE]: !!data,
       });
-    case Action.SET_ATTACHMENT_PAGE_ID:
+    case Action.TOGGLE_PAGE_ATTACHMENT_STATE:
       return /** @type {!State} */ ({
         ...state,
-        [StateProperty.ATTACHMENT_PAGE_ID]: data,
-        [StateProperty.SYSTEM_UI_IS_VISIBLE_STATE]: !data,
+        [StateProperty.PAGE_ATTACHMENT_STATE]: data,
       });
     // Triggers the ad UI.
     case Action.TOGGLE_AD:
@@ -566,7 +565,6 @@ export class AmpStoryStoreService {
       [StateProperty.CAN_SHOW_PAGINATION_BUTTONS]: true,
       [StateProperty.CAN_SHOW_SHARING_UIS]: true,
       [StateProperty.CAN_SHOW_SYSTEM_LAYER_BUTTONS]: true,
-      [StateProperty.ATTACHMENT_PAGE_ID]: null,
       [StateProperty.ACCESS_STATE]: false,
       [StateProperty.AD_STATE]: false,
       [StateProperty.AFFILIATE_LINK_STATE]: null,
@@ -580,6 +578,7 @@ export class AmpStoryStoreService {
       },
       [StateProperty.INTERACTIVE_REACT_STATE]: {},
       [StateProperty.MUTED_STATE]: true,
+      [StateProperty.PAGE_ATTACHMENT_STATE]: false,
       [StateProperty.PAGE_HAS_AUDIO_STATE]: false,
       [StateProperty.PAGE_HAS_ELEMENTS_WITH_PLAYBACK_STATE]: false,
       [StateProperty.PAUSED_STATE]: false,

--- a/extensions/amp-story/1.0/amp-story-store-service.js
+++ b/extensions/amp-story/1.0/amp-story-store-service.js
@@ -287,7 +287,7 @@ const actions = (state, action, data) => {
     case Action.TOGGLE_PAGE_ATTACHMENT_STATE:
       return /** @type {!State} */ ({
         ...state,
-        [StateProperty.PAGE_ATTACHMENT_STATE]: data,
+        [StateProperty.PAGE_ATTACHMENT_STATE]: !!data,
       });
     // Triggers the ad UI.
     case Action.TOGGLE_AD:

--- a/extensions/amp-story/1.0/amp-story-store-service.js
+++ b/extensions/amp-story/1.0/amp-story-store-service.js
@@ -88,6 +88,7 @@ export let InteractiveComponentDef;
  *    canShowSystemLayerButtons: boolean,
  *    accessState: boolean,
  *    adState: boolean,
+ *    attachmentPageId: ?number,
  *    affiliateLinkState: !Element,
  *    bookendState: boolean,
  *    desktopState: boolean,
@@ -137,6 +138,7 @@ export const StateProperty = {
   // App States.
   ACCESS_STATE: 'accessState', // amp-access paywall.
   AD_STATE: 'adState',
+  ATTACHMENT_PAGE_ID: 'attachmentPageId',
   BOOKEND_STATE: 'bookendState',
   AFFILIATE_LINK_STATE: 'affiliateLinkState',
   DESKTOP_STATE: 'desktopState',
@@ -184,6 +186,7 @@ export const Action = {
   ADD_TO_ACTIONS_ALLOWLIST: 'addToActionsAllowlist',
   CHANGE_PAGE: 'setCurrentPageId',
   SET_CONSENT_ID: 'setConsentId',
+  SET_ATTACHMENT_PAGE_ID: 'setAttachmentPageId',
   SET_ADVANCEMENT_MODE: 'setAdvancementMode',
   SET_NAVIGATION_PATH: 'setNavigationPath',
   SET_PAGE_IDS: 'setPageIds',
@@ -280,6 +283,12 @@ const actions = (state, action, data) => {
         ...state,
         [StateProperty.ACCESS_STATE]: !!data,
         [StateProperty.PAUSED_STATE]: !!data,
+      });
+    case Action.SET_ATTACHMENT_PAGE_ID:
+      return /** @type {!State} */ ({
+        ...state,
+        [StateProperty.ATTACHMENT_PAGE_ID]: data,
+        [StateProperty.SYSTEM_UI_IS_VISIBLE_STATE]: !data,
       });
     // Triggers the ad UI.
     case Action.TOGGLE_AD:
@@ -557,6 +566,7 @@ export class AmpStoryStoreService {
       [StateProperty.CAN_SHOW_PAGINATION_BUTTONS]: true,
       [StateProperty.CAN_SHOW_SHARING_UIS]: true,
       [StateProperty.CAN_SHOW_SYSTEM_LAYER_BUTTONS]: true,
+      [StateProperty.ATTACHMENT_PAGE_ID]: null,
       [StateProperty.ACCESS_STATE]: false,
       [StateProperty.AD_STATE]: false,
       [StateProperty.AFFILIATE_LINK_STATE]: null,

--- a/extensions/amp-story/1.0/amp-story-viewer-messaging-handler.js
+++ b/extensions/amp-story/1.0/amp-story-viewer-messaging-handler.js
@@ -20,9 +20,9 @@ import {
   getStoreService,
 } from './amp-story-store-service';
 import {AnalyticsVariable, getVariableService} from './variable-service';
-import {HistoryState, getHistoryState} from './history';
 import {dev, user} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
+import {getHistoryState} from './history';
 
 /** @type {string} */
 const TAG = 'amp-story-viewer-messaging-handler';
@@ -57,8 +57,8 @@ const GET_STATE_CONFIGURATIONS = {
     property: StateProperty.MUTED_STATE,
   },
   'PAGE_ATTACHMENT_STATE': {
-    dataSource: DataSources.HISTORY,
-    property: HistoryState.ATTACHMENT_PAGE_ID,
+    dataSource: DataSources.STORE_SERVICE,
+    property: StateProperty.ATTACHMENT_PAGE_ID,
   },
   'STORY_PROGRESS': {
     dataSource: DataSources.VARIABLE_SERVICE,

--- a/extensions/amp-story/1.0/amp-story-viewer-messaging-handler.js
+++ b/extensions/amp-story/1.0/amp-story-viewer-messaging-handler.js
@@ -22,7 +22,6 @@ import {
 import {AnalyticsVariable, getVariableService} from './variable-service';
 import {dev, user} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
-import {getHistoryState} from './history';
 
 /** @type {string} */
 const TAG = 'amp-story-viewer-messaging-handler';
@@ -30,7 +29,6 @@ const TAG = 'amp-story-viewer-messaging-handler';
 /** @enum {number} */
 const DataSources = {
   STORE_SERVICE: 0,
-  HISTORY: 1,
   VARIABLE_SERVICE: 2,
 };
 
@@ -58,7 +56,7 @@ const GET_STATE_CONFIGURATIONS = {
   },
   'PAGE_ATTACHMENT_STATE': {
     dataSource: DataSources.STORE_SERVICE,
-    property: StateProperty.ATTACHMENT_PAGE_ID,
+    property: StateProperty.PAGE_ATTACHMENT_STATE,
   },
   'STORY_PROGRESS': {
     dataSource: DataSources.VARIABLE_SERVICE,
@@ -94,9 +92,6 @@ export class AmpStoryViewerMessagingHandler {
 
     /** @private @const {!../../../src/service/viewer-interface.ViewerInterface} */
     this.viewer_ = viewer;
-
-    /** @private @const {!Window} */
-    this.win_ = win;
   }
 
   /**
@@ -140,9 +135,6 @@ export class AmpStoryViewerMessagingHandler {
     let value;
 
     switch (config.dataSource) {
-      case DataSources.HISTORY:
-        value = !!getHistoryState(this.win_, config.property);
-        break;
       case DataSources.STORE_SERVICE:
         value = this.storeService_.get(config.property);
         break;

--- a/extensions/amp-story/1.0/amp-story-viewer-messaging-handler.js
+++ b/extensions/amp-story/1.0/amp-story-viewer-messaging-handler.js
@@ -37,7 +37,7 @@ const DataSources = {
 /**
  * @typedef {{
  *   dataSource: !DataSources,
- *   property: (!StateProperty|!HistoryState|!AnalyticsVariable)
+ *   property: (!StateProperty|!AnalyticsVariable)
  * }}
  */
 let GetStateConfigurationDef;

--- a/extensions/amp-story/1.0/test/test-amp-story-viewer-messaging-handler.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-viewer-messaging-handler.js
@@ -20,7 +20,6 @@ import {
   getStoreService,
 } from '../amp-story-store-service';
 import {AmpStoryViewerMessagingHandler} from '../amp-story-viewer-messaging-handler';
-import {HistoryState, setHistoryState} from '../history';
 
 describes.fakeWin('amp-story-viewer-messaging-handler', {}, (env) => {
   let fakeViewerService;

--- a/extensions/amp-story/1.0/test/test-amp-story-viewer-messaging-handler.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-viewer-messaging-handler.js
@@ -97,7 +97,7 @@ describes.fakeWin('amp-story-viewer-messaging-handler', {}, (env) => {
     });
 
     it('should return the PAGE_ATTACHMENT_STATE', async () => {
-      setHistoryState(env.win, HistoryState.ATTACHMENT_PAGE_ID, 'SOME_ID');
+      storeService.dispatch(Action.TOGGLE_PAGE_ATTACHMENT_STATE, true);
       const response = await fakeViewerService.receiveMessage(
         'getDocumentState',
         {state: 'PAGE_ATTACHMENT_STATE'}
@@ -106,7 +106,6 @@ describes.fakeWin('amp-story-viewer-messaging-handler', {}, (env) => {
         state: 'PAGE_ATTACHMENT_STATE',
         value: true,
       });
-      setHistoryState(env.win, HistoryState.ATTACHMENT_PAGE_ID, null);
     });
 
     it('should return the STORY_PROGRESS', async () => {


### PR DESCRIPTION
@connielei noticed there's no way for us to subscribe for changes in the page attachment, since it's only stored in history. 

This PR adds attachmentPageId to the store so we can listen to the state changes at the player level.

Partial for #29219