### PR TITLE
FIE: ensure that custom-element-registry is only used via extensions service

### DIFF
--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -1045,6 +1045,7 @@ const forbiddenTermsSrcInclusive = {
     allowlist: [
       'src/element-stub.js',
       'src/friendly-iframe-embed.js',
+      'src/friendly-iframe-embed-legacy.js',
       'src/polyfillstub/intersection-observer-stub.js',
       'src/runtime.js',
       'src/service/extensions-impl.js',
@@ -1085,6 +1086,7 @@ const forbiddenTermsSrcInclusive = {
       'src/base-element.js',
       'src/event-helper.js',
       'src/friendly-iframe-embed.js',
+      'src/friendly-iframe-embed-legacy.js',
       'src/service/performance-impl.js',
       'src/service/resources-impl.js',
       'src/service/url-replacements-impl.js',

--- a/build-system/test-configs/dep-check-config.js
+++ b/build-system/test-configs/dep-check-config.js
@@ -434,6 +434,10 @@ exports.rules = [
       'src/friendly-iframe-embed.js->src/polyfills/document-contains.js',
       'src/friendly-iframe-embed.js->src/polyfills/domtokenlist.js',
       'src/friendly-iframe-embed.js->src/polyfills/intersection-observer.js',
+      'src/friendly-iframe-embed-legacy.js->src/polyfills/custom-elements.js',
+      'src/friendly-iframe-embed-legacy.js->src/polyfills/document-contains.js',
+      'src/friendly-iframe-embed-legacy.js->src/polyfills/domtokenlist.js',
+      'src/friendly-iframe-embed-legacy.js->src/polyfills/intersection-observer.js',
     ],
   },
   {
@@ -451,6 +455,17 @@ exports.rules = [
     filesMatching: 'src/**/*.js',
     mustNotDependOn: 'ads/**/*.js',
     allowlist: 'src/ad-cid.js->ads/_config.js',
+  },
+  {
+    filesMatching: '**/*.js',
+    mustNotDependOn: 'src/service/custom-element-registry.js',
+    allowlist: [
+      'builtins/**->src/service/custom-element-registry.js',
+      'src/amp.js->src/service/custom-element-registry.js',
+      'src/friendly-iframe-embed-legacy.js->src/service/custom-element-registry.js',
+      'src/runtime.js->src/service/custom-element-registry.js',
+      'src/service/extensions-impl.js->src/service/custom-element-registry.js',
+    ],
   },
 
   // A4A

--- a/examples/analytics-visibility.amp.html
+++ b/examples/analytics-visibility.amp.html
@@ -30,22 +30,31 @@
   <script type="application/json">
     {
       "requests": {
-        "endpoint": "/analytics/no-referrer"
+        "endpoint": "/analytics/no-referrer?trigger=${trigger}"
       },
       "triggers": {
         "pageview": {
           "on": "visible",
-          "request": "endpoint"
+          "request": "endpoint",
+          "vars": {
+            "trigger": "pageview"
+          }
         },
         "root": {
           "on": "visible",
           "request": "endpoint",
-          "selector": ":root"
+          "selector": ":root",
+          "vars": {
+            "trigger": "root"
+          }
         },
         "img1": {
           "on": "visible",
           "request": "endpoint",
-          "selector": "#img1"
+          "selector": "#img1",
+          "vars": {
+            "trigger": "img1"
+          }
         },
         "img1_with_spec": {
           "on": "visible",
@@ -57,12 +66,18 @@
             "totalTimeMin": 5000,
             "continuousTimeMin": 2000,
             "waitFor": "ini-load"
+          },
+          "vars": {
+            "trigger": "img1_with_spec"
           }
         },
         "img2": {
           "on": "visible",
           "request": "endpoint",
-          "selector": "#img2"
+          "selector": "#img2",
+          "vars": {
+            "trigger": "img2"
+          }
         }
       },
       "transport": {

--- a/src/friendly-iframe-embed-legacy.js
+++ b/src/friendly-iframe-embed-legacy.js
@@ -1,0 +1,293 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// TODO(#22733): remove when ampdoc-fie is launched.
+
+import {LEGACY_ELEMENTS, stubLegacyElements} from './service/extensions-impl';
+import {Services} from './services';
+import {cssText as ampSharedCss} from '../build/ampshared.css';
+import {
+  copyElementToChildWindow,
+  stubElementIfNotKnown,
+  upgradeOrRegisterElement,
+} from './service/custom-element-registry';
+import {dev} from './log';
+import {
+  getAmpdoc,
+  installServiceInEmbedIfEmbeddable,
+  setParentWindow,
+} from './service';
+import {getMode} from './mode';
+import {install as installCustomElements} from './polyfills/custom-elements';
+import {install as installDOMTokenList} from './polyfills/domtokenlist';
+import {install as installDocContains} from './polyfills/document-contains';
+import {installForChildWin as installIntersectionObserver} from './polyfills/intersection-observer';
+import {installStylesLegacy} from './style-installer';
+import {installTimerInEmbedWindow} from './service/timer-impl';
+import {toWin} from './types';
+
+/**
+ * Static installers that can be easily stubbed for tests. Exposed via
+ * a static class to simply stubbing in tests.
+ */
+export class LegacyInstaller {
+  /**
+   * Install extensions in the child window (friendly iframe).
+   * It injects polyfills, CSS for AMP runtime, standard services, built-in
+   * elements and stubs all other elements.
+   * @param {!./service/extensions-impl.Extensions} extensions
+   * @param {!Window} childWin
+   * @param {!Array<string>} extensionIds
+   * @param {function(!Window, ?./service/ampdoc-impl.AmpDoc=)|undefined} preinstallCallback
+   * @param {function()} startRender
+   * @param {function(!Promise)=} opt_installComplete
+   * @return {!Promise}
+   * @visibleForTesting
+   */
+  static installExtensionsInChildWindow(
+    extensions,
+    childWin,
+    extensionIds,
+    preinstallCallback,
+    startRender,
+    opt_installComplete
+  ) {
+    const getDelayPromise = getDelayPromiseProducer();
+    return getDelayPromise(undefined)
+      .then(() =>
+        preInstallExtensionsInChildWindow(
+          extensions,
+          childWin,
+          extensionIds,
+          preinstallCallback
+        )
+      )
+      .then(() => {
+        // Ready to be shown.
+        startRender();
+      })
+      .then(() => {
+        if (!childWin.frameElement) {
+          return;
+        }
+        // Intentionally do not wait for the full installation to complete.
+        // It's enough of initialization done to return the embed.
+        const promise = installExtensionsInChildWindow(
+          extensions,
+          childWin,
+          extensionIds
+        );
+        if (opt_installComplete) {
+          opt_installComplete(promise);
+        }
+      });
+  }
+}
+
+/**
+ * Adopt predefined core services for the child window (friendly iframe).
+ * @param {!Window} childWin
+ * @visibleForTesting
+ */
+export function installStandardServicesInEmbed(childWin) {
+  const frameElement = dev().assertElement(
+    childWin.frameElement,
+    'frameElement not found for embed'
+  );
+  const standardServices = [
+    // The order of service adoptations is important.
+    Services.urlForDoc(frameElement),
+    Services.actionServiceForDoc(frameElement),
+    Services.standardActionsForDoc(frameElement),
+    Services.navigationForDoc(frameElement),
+  ];
+  const ampdoc = getAmpdoc(frameElement);
+  standardServices.forEach((service) => {
+    // Static functions must be invoked on the class, not the instance.
+    service.constructor.installInEmbedWindow(childWin, ampdoc);
+  });
+  installTimerInEmbedWindow(childWin);
+}
+
+/**
+ * Prepare for installing extensions in the child window (friendly iframe).
+ * It injects polyfills, CSS for AMP runtime, standard services, built-in
+ * elements and stubs all other elements.
+ * The pre-install callback, if specified, is executed after polyfills have been configured.
+ * @param {!./service/extensions-impl.Extensions} extensions
+ * @param {!Window} childWin
+ * @param {!Array<string>} extensionIds
+ * @param {function(!Window, ?./service/ampdoc-impl.AmpDoc=)|undefined} preinstallCallback
+ * @return {!Promise}
+ */
+function preInstallExtensionsInChildWindow(
+  extensions,
+  childWin,
+  extensionIds,
+  preinstallCallback
+) {
+  const topWin = extensions.win;
+  const parentWin = toWin(childWin.frameElement.ownerDocument.defaultView);
+  setParentWindow(childWin, parentWin);
+  const getDelayPromise = getDelayPromiseProducer();
+
+  return getDelayPromise(undefined)
+    .then(() => {
+      // Install necessary polyfills.
+      installPolyfillsInChildWindow(parentWin, childWin);
+    })
+    .then(getDelayPromise)
+    .then(() => {
+      // Install runtime styles.
+      installStylesLegacy(
+        childWin.document,
+        ampSharedCss,
+        /* callback */ null,
+        /* opt_isRuntimeCss */ true,
+        /* opt_ext */ 'amp-runtime'
+      );
+    })
+    .then(getDelayPromise)
+    .then(() => {
+      // Run pre-install callback.
+      if (preinstallCallback) {
+        preinstallCallback(childWin);
+      }
+    })
+    .then(getDelayPromise)
+    .then(() => {
+      // Install embeddable standard services.
+      installStandardServicesInEmbed(childWin);
+    })
+    .then(getDelayPromise)
+    .then(() => {
+      // Install built-ins elements.
+      copyBuiltinElementsToChildWindow(topWin, childWin);
+      stubLegacyElements(childWin);
+    })
+    .then(getDelayPromise)
+    .then(() => {
+      extensionIds.forEach((extensionId) => {
+        // This will extend automatic upgrade of custom elements from top
+        // window to the child window.
+        if (!LEGACY_ELEMENTS.includes(extensionId)) {
+          stubElementIfNotKnown(childWin, extensionId);
+        }
+      });
+    })
+    .then(getDelayPromise);
+}
+
+/**
+ * Install non-built-in extensions in the child window (friendly iframe).
+ * @param {!./service/extensions-impl.Extensions} extensions
+ * @param {!Window} childWin
+ * @param {!Array<string>} extensionIds
+ * @return {!Promise}
+ * @visibleForTesting
+ */
+function installExtensionsInChildWindow(extensions, childWin, extensionIds) {
+  const getDelayPromise = getDelayPromiseProducer();
+
+  const promises = [];
+  extensionIds.forEach((extensionId) => {
+    const promise = getDelayPromise(undefined)
+      .then(() => extensions.preloadExtension(extensionId))
+      .then((extension) => {
+        // Adopt embeddable extension services.
+        /** @type {!Array} */ (extension.services).forEach((service) => {
+          installServiceInEmbedIfEmbeddable(childWin, service.serviceClass);
+        });
+
+        // Adopt the custom elements.
+        let elementPromises = null;
+        for (const elementName in extension.elements) {
+          const elementDef = extension.elements[elementName];
+          const elementPromise = new Promise((resolve) => {
+            if (elementDef.css) {
+              installStylesLegacy(
+                childWin.document,
+                elementDef.css,
+                /* completeCallback */ resolve,
+                /* isRuntime */ false,
+                extensionId
+              );
+            } else {
+              resolve();
+            }
+          }).then(() => {
+            upgradeOrRegisterElement(
+              childWin,
+              elementName,
+              elementDef.implementationClass
+            );
+          });
+          if (elementPromises) {
+            elementPromises.push(elementPromise);
+          } else {
+            elementPromises = [elementPromise];
+          }
+        }
+        if (elementPromises) {
+          return Promise.all(elementPromises).then(() => extension);
+        }
+        return extension;
+      });
+    promises.push(promise);
+  });
+  return Promise.all(promises);
+}
+
+/**
+ * @return {function(*): !Promise<*>}
+ */
+function getDelayPromiseProducer() {
+  return (val) =>
+    new Promise((resolve) => {
+      setTimeout(() => resolve(val), 1);
+    });
+}
+
+/**
+ * Copy builtins to a child window.
+ * @param {!Window} parentWin
+ * @param {!Window} childWin
+ */
+function copyBuiltinElementsToChildWindow(parentWin, childWin) {
+  copyElementToChildWindow(parentWin, childWin, 'amp-img');
+  copyElementToChildWindow(parentWin, childWin, 'amp-pixel');
+}
+
+/**
+ * Install polyfills in the child window (friendly iframe).
+ * @param {!Window} parentWin
+ * @param {!Window} childWin
+ */
+function installPolyfillsInChildWindow(parentWin, childWin) {
+  installDocContains(childWin);
+  installDOMTokenList(childWin);
+  // The anonymous class parameter allows us to detect native classes vs
+  // transpiled classes.
+  installCustomElements(childWin, class {});
+  if (
+    // eslint-disable-next-line no-undef
+    INTERSECTION_OBSERVER_POLYFILL ||
+    getMode().localDev ||
+    getMode().test
+  ) {
+    installIntersectionObserver(parentWin, childWin);
+  }
+}

--- a/src/friendly-iframe-embed.js
+++ b/src/friendly-iframe-embed.js
@@ -16,21 +16,14 @@
 
 import {CommonSignals} from './common-signals';
 import {FIE_EMBED_PROP} from './iframe-helper';
-import {LEGACY_ELEMENTS, stubLegacyElements} from './service/extensions-impl';
+import {LegacyInstaller} from './friendly-iframe-embed-legacy';
 import {Services} from './services';
 import {Signals} from './utils/signals';
 import {cssText as ampSharedCss} from '../build/ampshared.css';
-import {
-  copyElementToChildWindow,
-  stubElementIfNotKnown,
-  upgradeOrRegisterElement,
-} from './service/custom-element-registry';
 import {dev, rethrowAsync, userAssert} from './log';
 import {
   disposeServicesForEmbed,
-  getAmpdoc,
   getTopWindow,
-  installServiceInEmbedIfEmbeddable,
   setParentWindow,
 } from './service';
 import {escapeHtml} from './dom';
@@ -40,7 +33,7 @@ import {install as installCustomElements} from './polyfills/custom-elements';
 import {install as installDOMTokenList} from './polyfills/domtokenlist';
 import {install as installDocContains} from './polyfills/document-contains';
 import {installForChildWin as installIntersectionObserver} from './polyfills/intersection-observer';
-import {installStylesForDoc, installStylesLegacy} from './style-installer';
+import {installStylesForDoc} from './style-installer';
 import {installTimerInEmbedWindow} from './service/timer-impl';
 import {isDocumentReady} from './document-ready';
 import {isInAmpdocFieExperiment} from './ampdoc-fie';
@@ -190,7 +183,6 @@ export function installFriendlyIframeEmbed(
   // no other reliable signal for `readyState` in a child window and thus
   // we have to fallback to polling.
   let readyPromise;
-  const getDelayPromise = getDelayPromiseProducer();
   if (isIframeReady(iframe)) {
     readyPromise = Promise.resolve();
   } else {
@@ -226,49 +218,39 @@ export function installFriendlyIframeEmbed(
     const embed = new FriendlyIframeEmbed(iframe, spec, loadedPromise, ampdoc);
     iframe[FIE_EMBED_PROP] = embed;
 
+    // Window might have been destroyed.
+    if (!childWin.frameElement) {
+      return null;
+    }
+
     // Add extensions.
     const extensionIds = spec.extensionIds || [];
     if (ampdoc && ampdocFieExperimentOn) {
-      embed.installExtensionsInFie(
+      return installExtensionsInEmbed(
+        embed,
         extensions,
         ampdoc,
         extensionIds,
         opt_preinstallCallback
-      );
-
-      // Ready to be shown.
-      embed.startRender_();
-      return embed;
+      ).then(() => {
+        if (!childWin.frameElement) {
+          return null;
+        }
+        return embed;
+      });
     } else {
-      // Window might have been destroyed.
-      if (!childWin.frameElement) {
-        return null;
-      }
-      return getDelayPromise(undefined)
-        .then(() =>
-          embed.preInstallExtensionsInChildWindow(
-            extensions,
-            childWin,
-            extensionIds,
-            opt_preinstallCallback
-          )
-        )
-        .then(() => {
-          // Ready to be shown.
-          embed.startRender_();
-        })
-        .then(() => {
-          if (!childWin.frameElement) {
-            return null;
-          }
-          embed.doInstallExtensionsInChildWindow(
-            extensions,
-            childWin,
-            extensionIds
-          );
-          return embed;
-        })
-        .then(getDelayPromise);
+      return LegacyInstaller.installExtensionsInChildWindow(
+        extensions,
+        childWin,
+        extensionIds,
+        opt_preinstallCallback,
+        () => embed.startRender_()
+      ).then(() => {
+        if (!childWin.frameElement) {
+          return null;
+        }
+        return embed;
+      });
     }
   });
 }
@@ -661,193 +643,95 @@ export class FriendlyIframeEmbed {
       },
     });
   }
+}
 
-  /**
-   * Install extensions in the child window (friendly iframe). The pre-install
-   * callback, if specified, is executed after polyfills have been configured
-   * but before the first extension is installed.
-   * @param {!./service/extensions-impl.Extensions} extensions
-   * @param {!./service/ampdoc-impl.AmpDocFie} ampdoc
-   * @param {!Array<string>} extensionIds
-   * @param {function(!Window, ?./service/ampdoc-impl.AmpDoc=)=} opt_preinstallCallback
-   * @return {!Promise}
-   * @visibleForTesting
-   */
-  installExtensionsInFie(
-    extensions,
-    ampdoc,
-    extensionIds,
-    opt_preinstallCallback
-  ) {
-    const topWin = extensions.win;
-    const childWin = ampdoc.win;
-    const parentWin = toWin(childWin.frameElement.ownerDocument.defaultView);
-    setParentWindow(childWin, parentWin);
+/**
+ * Install extensions in the child window (friendly iframe). The pre-install
+ * callback, if specified, is executed after polyfills have been configured
+ * but before the first extension is installed.
+ * @param {!FriendlyIframeEmbed} embed
+ * @param {!./service/extensions-impl.Extensions} extensions
+ * @param {!./service/ampdoc-impl.AmpDocFie} ampdoc
+ * @param {!Array<string>} extensionIds
+ * @param {function(!Window, ?./service/ampdoc-impl.AmpDoc=)|undefined} preinstallCallback
+ * @param {function(!Promise)=} opt_installComplete
+ * @return {!Promise}
+ * @visibleForTesting
+ */
+export function installExtensionsInEmbed(
+  embed,
+  extensions,
+  ampdoc,
+  extensionIds,
+  preinstallCallback,
+  opt_installComplete
+) {
+  const childWin = ampdoc.win;
+  const parentWin = toWin(childWin.frameElement.ownerDocument.defaultView);
+  setParentWindow(childWin, parentWin);
+  const getDelayPromise = getDelayPromiseProducer();
 
-    // Install necessary polyfills.
-    installPolyfillsInChildWindow(parentWin, childWin);
-
-    // Install runtime styles.
-    installStylesForDoc(
-      ampdoc,
-      ampSharedCss,
-      /* callback */ null,
-      /* opt_isRuntimeCss */ true,
-      /* opt_ext */ 'amp-runtime'
-    );
-
-    // Run pre-install callback.
-    if (opt_preinstallCallback) {
-      opt_preinstallCallback(ampdoc.win, ampdoc);
-    }
-
-    // Install embeddable standard services.
-    installStandardServicesInEmbeddedDoc(ampdoc);
-
-    // Install built-ins and legacy elements.
-    copyBuiltinElementsToChildWindow(topWin, childWin);
-    stubLegacyElements(childWin);
-
-    return Promise.all(
-      extensionIds.map((extensionId) => {
-        // This will extend automatic upgrade of custom elements from top
-        // window to the child window.
-        if (!LEGACY_ELEMENTS.includes(extensionId)) {
-          stubElementIfNotKnown(childWin, extensionId);
-        }
-        return extensions.installExtensionInDoc(ampdoc, extensionId);
-      })
-    );
-  }
-  /**
-   * Prepare for installing extensions in the child window (friendly iframe).
-   * It injects polyfills, CSS for AMP runtime, standard services, built-in
-   * elements and stubs all other elements.
-   * The pre-install callback, if specified, is executed after polyfills have been configured.
-   * @param {!./service/extensions-impl.Extensions} extensions
-   * @param {!Window} childWin
-   * @param {!Array<string>} extensionIds
-   * @param {function(!Window, ?./service/ampdoc-impl.AmpDoc=)=} opt_preinstallCallback
-   * @return {!Promise}
-   * @visibleForTesting
-   */
-  preInstallExtensionsInChildWindow(
-    extensions,
-    childWin,
-    extensionIds,
-    opt_preinstallCallback
-  ) {
-    const topWin = extensions.win;
-    const parentWin = toWin(childWin.frameElement.ownerDocument.defaultView);
-    setParentWindow(childWin, parentWin);
-    const getDelayPromise = getDelayPromiseProducer();
-
-    return getDelayPromise(undefined)
-      .then(() => {
-        // Install necessary polyfills.
-        installPolyfillsInChildWindow(parentWin, childWin);
-      })
-      .then(getDelayPromise)
-      .then(() => {
-        // Install runtime styles.
-        installStylesLegacy(
-          childWin.document,
-          ampSharedCss,
-          /* callback */ null,
-          /* opt_isRuntimeCss */ true,
-          /* opt_ext */ 'amp-runtime'
-        );
-      })
-      .then(getDelayPromise)
-      .then(() => {
-        // Run pre-install callback.
-        if (opt_preinstallCallback) {
-          opt_preinstallCallback(childWin);
-        }
-      })
-      .then(getDelayPromise)
-      .then(() => {
-        // Install embeddable standard services.
-        installStandardServicesInEmbed(childWin);
-      })
-      .then(getDelayPromise)
-      .then(() => {
-        // Install built-ins elements.
-        copyBuiltinElementsToChildWindow(topWin, childWin);
-        stubLegacyElements(childWin);
-      })
-      .then(getDelayPromise)
-      .then(() => {
-        extensionIds.forEach((extensionId) => {
-          // This will extend automatic upgrade of custom elements from top
-          // window to the child window.
-          if (!LEGACY_ELEMENTS.includes(extensionId)) {
-            stubElementIfNotKnown(childWin, extensionId);
-          }
-        });
-      })
-      .then(getDelayPromise);
-  }
-
-  /**
-   * Install non-built-in extensions in the child window (friendly iframe).
-   * @param {!./service/extensions-impl.Extensions} extensions
-   * @param {!Window} childWin
-   * @param {!Array<string>} extensionIds
-   * @return {!Promise}
-   * @visibleForTesting
-   */
-  doInstallExtensionsInChildWindow(extensions, childWin, extensionIds) {
-    const getDelayPromise = getDelayPromiseProducer();
-
-    const promises = [];
-    extensionIds.forEach((extensionId) => {
-      const promise = getDelayPromise(undefined)
-        .then(() => extensions.preloadExtension(extensionId))
-        .then((extension) => {
-          // Adopt embeddable extension services.
-          /** @type {!Array} */ (extension.services).forEach((service) => {
-            installServiceInEmbedIfEmbeddable(childWin, service.serviceClass);
-          });
-
-          // Adopt the custom elements.
-          let elementPromises = null;
-          for (const elementName in extension.elements) {
-            const elementDef = extension.elements[elementName];
-            const elementPromise = new Promise((resolve) => {
-              if (elementDef.css) {
-                installStylesLegacy(
-                  childWin.document,
-                  elementDef.css,
-                  /* completeCallback */ resolve,
-                  /* isRuntime */ false,
-                  extensionId
-                );
-              } else {
-                resolve();
-              }
-            }).then(() => {
-              upgradeOrRegisterElement(
-                childWin,
-                elementName,
-                elementDef.implementationClass
-              );
-            });
-            if (elementPromises) {
-              elementPromises.push(elementPromise);
-            } else {
-              elementPromises = [elementPromise];
-            }
-          }
-          if (elementPromises) {
-            return Promise.all(elementPromises).then(() => extension);
-          }
-          return extension;
-        });
-      promises.push(promise);
+  return getDelayPromise(undefined)
+    .then(() => {
+      // Install necessary polyfills.
+      installPolyfillsInChildWindow(parentWin, childWin);
+    })
+    .then(getDelayPromise)
+    .then(() => {
+      // Install runtime styles.
+      installStylesForDoc(
+        ampdoc,
+        ampSharedCss,
+        /* callback */ null,
+        /* opt_isRuntimeCss */ true,
+        /* opt_ext */ 'amp-runtime'
+      );
+    })
+    .then(getDelayPromise)
+    .then(() => {
+      if (!childWin.frameElement) {
+        return;
+      }
+      // Run pre-install callback.
+      if (preinstallCallback) {
+        preinstallCallback(ampdoc.win, ampdoc);
+      }
+    })
+    .then(getDelayPromise)
+    .then(() => {
+      if (!childWin.frameElement) {
+        return;
+      }
+      // Install embeddable standard services.
+      Installers.installStandardServicesInEmbed(ampdoc);
+    })
+    .then(getDelayPromise)
+    .then(() => {
+      if (!childWin.frameElement) {
+        return;
+      }
+      extensions.preinstallEmbed(ampdoc, extensionIds);
+    })
+    .then(getDelayPromise)
+    .then(() => {
+      if (!childWin.frameElement) {
+        return;
+      }
+      // Ready to be shown.
+      embed.startRender_();
+    })
+    .then(getDelayPromise)
+    .then(() => {
+      if (!childWin.frameElement) {
+        return;
+      }
+      // Intentionally do not wait for the full installation to complete.
+      // It's enough of initialization done to return the embed.
+      const promise = extensions.installExtensionsInDoc(ampdoc, extensionIds);
+      if (opt_installComplete) {
+        opt_installComplete(promise);
+      }
     });
-    return Promise.all(promises);
-  }
 }
 
 /**
@@ -872,46 +756,16 @@ function installPolyfillsInChildWindow(parentWin, childWin) {
 }
 
 /**
- * Copy builtins to a child window.
- * @param {!Window} parentWin
- * @param {!Window} childWin
- */
-function copyBuiltinElementsToChildWindow(parentWin, childWin) {
-  copyElementToChildWindow(parentWin, childWin, 'amp-img');
-  copyElementToChildWindow(parentWin, childWin, 'amp-pixel');
-}
-
-/**
- * Adopt predefined core services for the embedded ampdoc (friendly iframe).
- * @param {!./service/ampdoc-impl.AmpDoc} ampdoc
- */
-function installStandardServicesInEmbeddedDoc(ampdoc) {
-  installAmpdocServices(ampdoc);
-  installTimerInEmbedWindow(ampdoc.win);
-}
-
-/**
- * Adopt predefined core services for the child window (friendly iframe).
- * @param {!Window} childWin
+ * Static installers that can be easily stubbed for tests.
  * @visibleForTesting
  */
-export function installStandardServicesInEmbed(childWin) {
-  // TODO(#22733): remove when ampdoc-fie is launched.
-  const frameElement = dev().assertElement(
-    childWin.frameElement,
-    'frameElement not found for embed'
-  );
-  const standardServices = [
-    // The order of service adoptations is important.
-    Services.urlForDoc(frameElement),
-    Services.actionServiceForDoc(frameElement),
-    Services.standardActionsForDoc(frameElement),
-    Services.navigationForDoc(frameElement),
-  ];
-  const ampdoc = getAmpdoc(frameElement);
-  standardServices.forEach((service) => {
-    // Static functions must be invoked on the class, not the instance.
-    service.constructor.installInEmbedWindow(childWin, ampdoc);
-  });
-  installTimerInEmbedWindow(childWin);
+export class Installers {
+  /**
+   * Adopt predefined core services for the embedded ampdoc (friendly iframe).
+   * @param {!./service/ampdoc-impl.AmpDoc} ampdoc
+   */
+  static installStandardServicesInEmbed(ampdoc) {
+    installAmpdocServices(ampdoc);
+    installTimerInEmbedWindow(ampdoc.win);
+  }
 }

--- a/src/service/extensions-impl.js
+++ b/src/service/extensions-impl.js
@@ -20,16 +20,17 @@ import {
   calculateExtensionScriptUrl,
   parseExtensionUrl,
 } from './extension-location';
+import {
+  copyElementToChildWindow,
+  stubElementIfNotKnown,
+  upgradeOrRegisterElement,
+} from './custom-element-registry';
 import {dev, devAssert, rethrowAsync, user} from '../log';
 import {getMode} from '../mode';
 import {installStylesForDoc} from '../style-installer';
 import {map} from '../utils/object';
 import {registerServiceBuilder, registerServiceBuilderForDoc} from '../service';
 import {startsWith} from '../string';
-import {
-  stubElementIfNotKnown,
-  upgradeOrRegisterElement,
-} from './custom-element-registry';
 
 export const LEGACY_ELEMENTS = ['amp-ad', 'amp-embed', 'amp-video'];
 const TAG = 'extensions';
@@ -422,6 +423,30 @@ export class Extensions {
   }
 
   /**
+   * Preinstalls built-ins and legacy elements in the emebedded ampdoc.
+   * @param {!./ampdoc-impl.AmpDoc} ampdoc
+   * @param {!Array<string>} extensionIds
+   * @restricted
+   */
+  preinstallEmbed(ampdoc, extensionIds) {
+    const topWin = this.win;
+    const childWin = ampdoc.win;
+
+    // Install built-ins and legacy elements.
+    copyBuiltinElementsToChildWindow(topWin, childWin);
+    stubLegacyElements(childWin);
+
+    // Stub extensions.
+    extensionIds.forEach((extensionId) => {
+      // This will extend automatic upgrade of custom elements from top
+      // window to the child window.
+      if (!LEGACY_ELEMENTS.includes(extensionId)) {
+        stubElementIfNotKnown(childWin, extensionId);
+      }
+    });
+  }
+
+  /**
    * Installs all ampdoc factories previously registered with
    * `addDocFactory`.
    * @param {!./ampdoc-impl.AmpDoc} ampdoc
@@ -430,11 +455,11 @@ export class Extensions {
    * @restricted
    */
   installExtensionsInDoc(ampdoc, extensionIds) {
-    const promises = [];
-    extensionIds.forEach((extensionId) => {
-      promises.push(this.installExtensionInDoc(ampdoc, extensionId));
-    });
-    return Promise.all(promises);
+    return Promise.all(
+      extensionIds.map((extensionId) =>
+        this.installExtensionInDoc(ampdoc, extensionId)
+      )
+    );
   }
 
   /**
@@ -625,6 +650,16 @@ export function stubLegacyElements(win) {
   LEGACY_ELEMENTS.forEach((name) => {
     stubElementIfNotKnown(win, name);
   });
+}
+
+/**
+ * Copy builtins to a child window.
+ * @param {!Window} parentWin
+ * @param {!Window} childWin
+ */
+function copyBuiltinElementsToChildWindow(parentWin, childWin) {
+  copyElementToChildWindow(parentWin, childWin, 'amp-img');
+  copyElementToChildWindow(parentWin, childWin, 'amp-pixel');
 }
 
 /**

--- a/test/unit/test-friendly-iframe-embed.js
+++ b/test/unit/test-friendly-iframe-embed.js
@@ -18,11 +18,16 @@ import {BaseElement} from '../../src/base-element';
 import {ElementStub} from '../../src/element-stub';
 import {
   FriendlyIframeEmbed,
+  Installers,
+  installExtensionsInEmbed,
   installFriendlyIframeEmbed,
-  installStandardServicesInEmbed,
   mergeHtmlForTesting,
   setSrcdocSupportedForTesting,
 } from '../../src/friendly-iframe-embed';
+import {
+  LegacyInstaller,
+  installStandardServicesInEmbed,
+} from '../../src/friendly-iframe-embed-legacy';
 import {Services} from '../../src/services';
 import {Signals} from '../../src/utils/signals';
 import {getFriendlyIframeEmbedOptional} from '../../src/iframe-helper';
@@ -46,9 +51,9 @@ describes.realWin('friendly-iframe-embed', {amp: true}, (env) => {
   let extensionsMock;
   let resourcesMock;
   let ampdocServiceMock;
-  let preInstallExtensionsInChildWindowStub;
-  let doInstallExtensionsInChildWindowStub;
-  let installExtensionsInFieStub;
+  let customElementsDefineStub;
+  let installServicesStub;
+  let preinstallCallback, preinstallCallbackSpy;
 
   beforeEach(() => {
     window = env.win;
@@ -68,17 +73,17 @@ describes.realWin('friendly-iframe-embed', {amp: true}, (env) => {
 
     iframe = document.createElement('iframe');
 
-    preInstallExtensionsInChildWindowStub = env.sandbox
-      .stub(FriendlyIframeEmbed.prototype, 'preInstallExtensionsInChildWindow')
-      .returns(Promise.resolve());
+    customElementsDefineStub = null;
+    preinstallCallbackSpy = env.sandbox.spy();
+    preinstallCallback = (win, ampdoc) => {
+      preinstallCallbackSpy(win, ampdoc);
+      customElementsDefineStub = env.sandbox.stub(win.customElements, 'define');
+    };
 
-    doInstallExtensionsInChildWindowStub = env.sandbox
-      .stub(FriendlyIframeEmbed.prototype, 'doInstallExtensionsInChildWindow')
-      .returns(Promise.resolve());
-
-    installExtensionsInFieStub = env.sandbox
-      .stub(FriendlyIframeEmbed.prototype, 'installExtensionsInFie')
-      .returns(Promise.resolve());
+    installServicesStub = env.sandbox.stub(
+      Installers,
+      'installStandardServicesInEmbed'
+    );
   });
 
   afterEach(() => {
@@ -179,11 +184,15 @@ describes.realWin('friendly-iframe-embed', {amp: true}, (env) => {
 
     // AmpDoc is created.
     const ampdocSignals = new Signals();
+    let childWinForAmpDoc;
     const ampdoc = {
+      get win() {
+        return childWinForAmpDoc;
+      },
       setReady: env.sandbox.spy(),
       signals: () => ampdocSignals,
+      getHeadNode: () => childWinForAmpDoc.document.head,
     };
-    let childWinForAmpDoc;
     ampdocServiceMock
       .expects('installFieDoc')
       .withExactArgs(
@@ -208,6 +217,15 @@ describes.realWin('friendly-iframe-embed', {amp: true}, (env) => {
       .withExactArgs('amp-test')
       .returns(Promise.resolve())
       .once();
+    extensionsMock
+      .expects('preinstallEmbed')
+      .withExactArgs(ampdoc, ['amp-test'])
+      .once();
+    extensionsMock
+      .expects('installExtensionsInDoc')
+      .withExactArgs(ampdoc, ['amp-test'])
+      .returns(Promise.resolve())
+      .once();
 
     let readyResolver = null;
     const readyPromise = new Promise((resolve) => {
@@ -217,19 +235,21 @@ describes.realWin('friendly-iframe-embed', {amp: true}, (env) => {
       .stub(FriendlyIframeEmbed.prototype, 'whenReady')
       .callsFake(() => readyPromise);
 
-    const embedPromise = installFriendlyIframeEmbed(iframe, document.body, {
-      url: 'https://acme.org/url1',
-      html: '<amp-test></amp-test>',
-      extensionIds: ['amp-test'],
-    });
+    const embedPromise = installFriendlyIframeEmbed(
+      iframe,
+      document.body,
+      {
+        url: 'https://acme.org/url1',
+        html: '<amp-test></amp-test>',
+        extensionIds: ['amp-test'],
+      },
+      preinstallCallback
+    );
     return embedPromise
       .then((embed) => {
         expect(childWinForAmpDoc).to.equal(embed.win);
         expect(ampdoc).to.equal(embed.ampdoc);
-        expect(installExtensionsInFieStub).to.be.calledWithMatch(
-          env.sandbox.match.any,
-          env.sandbox.match.same(ampdoc)
-        );
+        expect(installServicesStub).to.be.calledOnce.calledWith(ampdoc);
         expect(ampdoc.setReady).to.not.be.called;
         readyResolver();
         return readyPromise;
@@ -252,8 +272,12 @@ describes.realWin('friendly-iframe-embed', {amp: true}, (env) => {
     // AmpDoc is created.
     let ampdocSignals = null;
     const ampdoc = {
+      get win() {
+        return childWinForAmpDoc;
+      },
       setReady: env.sandbox.spy(),
       signals: () => ampdocSignals,
+      getHeadNode: () => childWinForAmpDoc.document.head,
     };
     let childWinForAmpDoc;
     ampdocServiceMock
@@ -281,6 +305,15 @@ describes.realWin('friendly-iframe-embed', {amp: true}, (env) => {
       .withExactArgs('amp-test')
       .returns(Promise.resolve())
       .once();
+    extensionsMock
+      .expects('preinstallEmbed')
+      .withExactArgs(ampdoc, ['amp-test'])
+      .once();
+    extensionsMock
+      .expects('installExtensionsInDoc')
+      .withExactArgs(ampdoc, ['amp-test'])
+      .returns(Promise.resolve())
+      .once();
 
     let readyResolver = null;
     const readyPromise = new Promise((resolve) => {
@@ -290,20 +323,22 @@ describes.realWin('friendly-iframe-embed', {amp: true}, (env) => {
       .stub(FriendlyIframeEmbed.prototype, 'whenReady')
       .callsFake(() => readyPromise);
 
-    const embedPromise = installFriendlyIframeEmbed(iframe, document.body, {
-      url: 'https://acme.org/url1',
-      html: '<amp-test></amp-test>',
-      extensionIds: ['amp-test'],
-      host,
-    });
+    const embedPromise = installFriendlyIframeEmbed(
+      iframe,
+      document.body,
+      {
+        url: 'https://acme.org/url1',
+        html: '<amp-test></amp-test>',
+        extensionIds: ['amp-test'],
+        host,
+      },
+      preinstallCallback
+    );
     return embedPromise
       .then((embed) => {
         expect(childWinForAmpDoc).to.equal(embed.win);
         expect(ampdoc).to.equal(embed.ampdoc);
-        expect(installExtensionsInFieStub).to.be.calledWithMatch(
-          env.sandbox.match.any,
-          env.sandbox.match.same(ampdoc)
-        );
+        expect(installServicesStub).to.be.calledOnce.calledWith(ampdoc);
         expect(ampdoc.setReady).to.not.be.called;
         readyResolver();
         return readyPromise;
@@ -315,47 +350,27 @@ describes.realWin('friendly-iframe-embed', {amp: true}, (env) => {
       });
   });
 
-  it('should install extensions', () => {
+  it('should install extensions', async () => {
     // Extensions preloading have been requested.
     extensionsMock
       .expects('preloadExtension')
       .withExactArgs('amp-test')
       .returns(Promise.resolve())
-      .once();
+      .atLeast(1);
 
-    const embedPromise = installFriendlyIframeEmbed(iframe, document.body, {
-      url: 'https://acme.org/url1',
-      html: '<amp-test></amp-test>',
-      extensionIds: ['amp-test'],
-    });
-    return embedPromise.then((embed) => {
-      expect(preInstallExtensionsInChildWindowStub).to.be.calledWith(
-        env.sandbox.match.any,
-        env.sandbox.match.same(embed.win)
-      );
-      expect(doInstallExtensionsInChildWindowStub).to.be.calledWith(
-        env.sandbox.match.any,
-        env.sandbox.match.same(embed.win)
-      );
-    });
-  });
-
-  it('should pass pre-install callback', () => {
-    const preinstallCallback = function () {};
-
-    const embedPromise = installFriendlyIframeEmbed(
+    await installFriendlyIframeEmbed(
       iframe,
       document.body,
       {
         url: 'https://acme.org/url1',
         html: '<amp-test></amp-test>',
+        extensionIds: ['amp-test'],
       },
       preinstallCallback
     );
-    return embedPromise.then(() => {
-      expect(preInstallExtensionsInChildWindowStub).to.be.calledOnce;
-      expect(doInstallExtensionsInChildWindowStub).to.be.calledOnce;
-    });
+    expect(customElementsDefineStub.callCount).to.be.above(0);
+    expect(customElementsDefineStub).to.be.calledWith('amp-img');
+    expect(customElementsDefineStub).to.be.calledWith('amp-test');
   });
 
   it.skip('should install and dispose services', () => {
@@ -387,12 +402,29 @@ describes.realWin('friendly-iframe-embed', {amp: true}, (env) => {
 
     // AmpDoc is created.
     const ampdocSignals = new Signals();
+    let childWinForAmpDoc;
     const ampdoc = {
+      get win() {
+        return childWinForAmpDoc;
+      },
       setReady: env.sandbox.spy(),
       signals: () => ampdocSignals,
+      getHeadNode: () => childWinForAmpDoc.document.head,
       dispose: env.sandbox.spy(),
     };
-    ampdocServiceMock.expects('installFieDoc').returns(ampdoc).once();
+    ampdocServiceMock
+      .expects('installFieDoc')
+      .withExactArgs(
+        'https://acme.org/url1',
+        env.sandbox.match((arg) => {
+          // Match childWin argument.
+          childWinForAmpDoc = arg;
+          return true;
+        }),
+        env.sandbox.match(() => true)
+      )
+      .returns(ampdoc)
+      .once();
 
     // Extensions preloading have been requested.
     extensionsMock
@@ -400,19 +432,33 @@ describes.realWin('friendly-iframe-embed', {amp: true}, (env) => {
       .withExactArgs('amp-test')
       .returns(Promise.resolve())
       .once();
+    extensionsMock
+      .expects('preinstallEmbed')
+      .withExactArgs(ampdoc, ['amp-test'])
+      .once();
+    extensionsMock
+      .expects('installExtensionsInDoc')
+      .withExactArgs(ampdoc, ['amp-test'])
+      .returns(Promise.resolve())
+      .once();
 
     env.sandbox
       .stub(FriendlyIframeEmbed.prototype, 'whenReady')
       .returns(Promise.resolve());
 
-    const embedPromise = installFriendlyIframeEmbed(iframe, document.body, {
-      url: 'https://acme.org/url1',
-      html: '<amp-test></amp-test>',
-      extensionIds: ['amp-test'],
-    });
+    const embedPromise = installFriendlyIframeEmbed(
+      iframe,
+      document.body,
+      {
+        url: 'https://acme.org/url1',
+        html: '<amp-test></amp-test>',
+        extensionIds: ['amp-test'],
+      },
+      preinstallCallback
+    );
     return embedPromise
       .then((embed) => {
-        expect(installExtensionsInFieStub).to.be.calledOnce;
+        expect(installServicesStub).to.be.calledOnce.calledWith(ampdoc);
         embed.destroy();
       })
       .then(() => {
@@ -706,9 +752,9 @@ describes.realWin('friendly-iframe-embed', {amp: true}, (env) => {
     let contentDocument;
     let contentBody;
     let container;
-    let loadListener, errorListener;
+    let loadListener;
     let polls;
-    let renderStartStub;
+    let installStub;
 
     beforeEach(() => {
       setSrcdocSupportedForTesting(true);
@@ -748,25 +794,26 @@ describes.realWin('friendly-iframe-embed', {amp: true}, (env) => {
         addEventListener: (eventType, listener) => {
           if (eventType == 'load') {
             loadListener = listener;
-          } else if (eventType == 'error') {
-            errorListener = listener;
           }
         },
         removeEventListener: () => {},
       };
+      contentDocument = {};
       contentWindow = {
         addEventListener: () => {},
-        frameElement: {},
+        frameElement: {
+          ownerDocument: contentDocument,
+        },
       };
-      contentDocument = {};
+      contentDocument.defaultView = contentWindow;
       contentBody = {nodeType: 1, style: {}};
       container = {
         appendChild: () => {},
       };
-      renderStartStub = env.sandbox.stub(
-        FriendlyIframeEmbed.prototype,
-        'startRender_'
-      );
+
+      installStub = env.sandbox
+        .stub(LegacyInstaller, 'installExtensionsInChildWindow')
+        .returns(Promise.resolve());
     });
 
     afterEach(() => {
@@ -775,10 +822,15 @@ describes.realWin('friendly-iframe-embed', {amp: true}, (env) => {
 
     it('should poll until ready', () => {
       iframe.contentWindow = contentWindow;
-      const embedPromise = installFriendlyIframeEmbed(iframe, container, {
-        url: 'https://acme.org/url1',
-        html: '<body></body>',
-      });
+      const embedPromise = installFriendlyIframeEmbed(
+        iframe,
+        container,
+        {
+          url: 'https://acme.org/url1',
+          html: '<body></body>',
+        },
+        preinstallCallback
+      );
       let ready = false;
       embedPromise.then(() => {
         ready = true;
@@ -829,7 +881,7 @@ describes.realWin('friendly-iframe-embed', {amp: true}, (env) => {
         });
     });
 
-    it('should stop polling when loaded', () => {
+    it('should stop polling when loaded', async () => {
       iframe.contentWindow = contentWindow;
       const embedPromise = installFriendlyIframeEmbed(iframe, container, {
         url: 'https://acme.org/url1',
@@ -841,25 +893,10 @@ describes.realWin('friendly-iframe-embed', {amp: true}, (env) => {
         clock.tick(5);
       }, 5);
       loadListener();
-      return embedPromise.then(() => {
-        expect(polls).to.have.length(0);
-        expect(renderStartStub).to.be.calledOnce;
-      });
-    });
 
-    // TODO(#16916): Make this test work with synchronous throws.
-    it.skip('should stop polling when loading failed', () => {
-      iframe.contentWindow = contentWindow;
-      const embedPromise = installFriendlyIframeEmbed(iframe, container, {
-        url: 'https://acme.org/url1',
-        html: '<body></body>',
-      });
-      expect(polls).to.have.length(1);
-      iframe.contentWindow = contentWindow;
-      errorListener();
-      return embedPromise.then(() => {
-        expect(polls).to.have.length(0);
-      });
+      await embedPromise;
+      expect(polls).to.have.length(0);
+      expect(installStub).to.be.calledOnce;
     });
   });
 
@@ -1016,9 +1053,11 @@ describes.realWin('installExtensionsInChildWindow', {amp: true}, (env) => {
   let extensionsMock;
   let iframe;
   let iframeWin;
-  let fie;
+  let startRender;
+  let preinstallCallback;
+  let installComplete, installCompletePromise;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     parentWin = env.win;
     resetScheduledElementForTesting(parentWin, 'amp-test');
     installExtensionsService(parentWin);
@@ -1039,6 +1078,13 @@ describes.realWin('installExtensionsInChildWindow', {amp: true}, (env) => {
       env.sandbox.stub(Services, s).returns(new FakeService());
     });
 
+    startRender = env.sandbox.spy();
+    preinstallCallback = env.sandbox.spy();
+    installComplete = undefined;
+    installCompletePromise = new Promise((resolve) => {
+      installComplete = resolve;
+    });
+
     iframe = parentWin.document.createElement('iframe');
     const promise = loadPromise(iframe);
     const html = '<div id="one"></div>';
@@ -1052,19 +1098,10 @@ describes.realWin('installExtensionsInChildWindow', {amp: true}, (env) => {
       childDoc.close();
     }
     parentWin.document.body.appendChild(iframe);
-    fie = new FriendlyIframeEmbed(
-      iframe,
-      {
-        url: 'https://acme.org/url1',
-        html: '<body></body>',
-      },
-      Promise.resolve(),
-      env.ampdoc
-    );
-    return promise.then(() => {
-      iframeWin = iframe.contentWindow;
-      setParentWindow(iframeWin, parentWin);
-    });
+
+    await promise;
+    iframeWin = iframe.contentWindow;
+    setParentWindow(iframeWin, parentWin);
   });
 
   afterEach(() => {
@@ -1074,85 +1111,89 @@ describes.realWin('installExtensionsInChildWindow', {amp: true}, (env) => {
     extensionsMock.verify();
   });
 
-  it('should set window hierarchy', () => {
-    fie.preInstallExtensionsInChildWindow(extensions, iframeWin, []);
+  it('should set window hierarchy', async () => {
+    await LegacyInstaller.installExtensionsInChildWindow(
+      extensions,
+      iframeWin,
+      [],
+      preinstallCallback,
+      startRender,
+      installComplete
+    );
     expect(iframeWin.__AMP_PARENT).to.equal(parentWin);
     expect(iframeWin.__AMP_TOP).to.equal(parentWin);
+    expect(preinstallCallback).to.be.calledOnce;
+    expect(startRender).to.be.calledOnce;
   });
 
-  it('should install runtime styles', () => {
-    return fie
-      .preInstallExtensionsInChildWindow(extensions, iframeWin, [])
-      .then(() => {
-        expect(iframeWin.document.querySelector('style[amp-runtime]')).to.exist;
-      });
+  it('should install runtime styles', async () => {
+    await LegacyInstaller.installExtensionsInChildWindow(
+      extensions,
+      iframeWin,
+      [],
+      preinstallCallback,
+      startRender,
+      installComplete
+    );
+    expect(iframeWin.document.querySelector('style[amp-runtime]')).to.exist;
   });
 
-  it('should install built-ins', () => {
-    return fie
-      .preInstallExtensionsInChildWindow(extensions, iframeWin, [])
-      .then(() => {
-        expect(iframeWin.__AMP_EXTENDED_ELEMENTS).to.exist;
-        expect(iframeWin.__AMP_EXTENDED_ELEMENTS['amp-img']).to.exist;
-        expect(iframeWin.__AMP_EXTENDED_ELEMENTS['amp-img']).to.not.equal(
-          ElementStub
-        );
-        expect(iframeWin.__AMP_EXTENDED_ELEMENTS['amp-pixel']).to.exist;
-        expect(iframeWin.__AMP_EXTENDED_ELEMENTS['amp-pixel']).to.not.equal(
-          ElementStub
-        );
-        // Legacy elements are installed as well.
-        expect(iframeWin.__AMP_EXTENDED_ELEMENTS['amp-ad']).to.equal(
-          ElementStub
-        );
-        expect(iframeWin.__AMP_EXTENDED_ELEMENTS['amp-embed']).to.equal(
-          ElementStub
-        );
-        expect(iframeWin.__AMP_EXTENDED_ELEMENTS['amp-video']).to.equal(
-          ElementStub
-        );
-      });
+  it('should install built-ins', async () => {
+    await LegacyInstaller.installExtensionsInChildWindow(
+      extensions,
+      iframeWin,
+      [],
+      preinstallCallback,
+      startRender,
+      installComplete
+    );
+    expect(iframeWin.__AMP_EXTENDED_ELEMENTS).to.exist;
+    expect(iframeWin.__AMP_EXTENDED_ELEMENTS['amp-img']).to.exist;
+    expect(iframeWin.__AMP_EXTENDED_ELEMENTS['amp-img']).to.not.equal(
+      ElementStub
+    );
+    expect(iframeWin.__AMP_EXTENDED_ELEMENTS['amp-pixel']).to.exist;
+    expect(iframeWin.__AMP_EXTENDED_ELEMENTS['amp-pixel']).to.not.equal(
+      ElementStub
+    );
+    // Legacy elements are installed as well.
+    expect(iframeWin.__AMP_EXTENDED_ELEMENTS['amp-ad']).to.equal(ElementStub);
+    expect(iframeWin.__AMP_EXTENDED_ELEMENTS['amp-embed']).to.equal(
+      ElementStub
+    );
+    expect(iframeWin.__AMP_EXTENDED_ELEMENTS['amp-video']).to.equal(
+      ElementStub
+    );
   });
 
-  it('should adopt standard services', () => {
-    return fie
-      .preInstallExtensionsInChildWindow(extensions, iframeWin, [])
-      .then(() => {
-        const any = {}; // Input doesn't matter since services are stubbed.
-        const url = Services.urlForDoc(any);
-        const actions = Services.actionServiceForDoc(any);
-        const standardActions = Services.standardActionsForDoc(any);
-        const navigation = Services.navigationForDoc(any);
+  it('should adopt standard services', async () => {
+    await LegacyInstaller.installExtensionsInChildWindow(
+      extensions,
+      iframeWin,
+      [],
+      preinstallCallback,
+      startRender,
+      installComplete
+    );
 
-        expect(url.constructor.installInEmbedWindow).to.be.called;
-        expect(actions.constructor.installInEmbedWindow).to.be.called;
-        expect(standardActions.constructor.installInEmbedWindow).to.be.called;
-        expect(navigation.constructor.installInEmbedWindow).to.be.called;
+    const any = {}; // Input doesn't matter since services are stubbed.
+    const url = Services.urlForDoc(any);
+    const actions = Services.actionServiceForDoc(any);
+    const standardActions = Services.standardActionsForDoc(any);
+    const navigation = Services.navigationForDoc(any);
 
-        expect(getService(iframeWin, 'timer')).to.exist;
-      });
+    expect(url.constructor.installInEmbedWindow).to.be.called;
+    expect(actions.constructor.installInEmbedWindow).to.be.called;
+    expect(standardActions.constructor.installInEmbedWindow).to.be.called;
+    expect(navigation.constructor.installInEmbedWindow).to.be.called;
+
+    expect(getService(iframeWin, 'timer')).to.exist;
   });
 
-  it('should install extensions in child window', () => {
+  it('should install extensions in child window', async () => {
     const extHolder = extensions.getExtensionHolder_('amp-test');
     extHolder.scriptPresent = true;
-    const promise = fie
-      .preInstallExtensionsInChildWindow(extensions, iframeWin, ['amp-test'])
-      .then(() => {
-        // Must be stubbed already.
-        expect(iframeWin.__AMP_EXTENDED_ELEMENTS['amp-test']).to.equal(
-          ElementStub
-        );
-        expect(
-          iframeWin.document.createElement('amp-test').implementation_
-        ).to.be.instanceOf(ElementStub);
-        expect(iframeWin.__AMP_EXTENDED_ELEMENTS['amp-test-sub']).to.be
-          .undefined;
 
-        return fie.doInstallExtensionsInChildWindow(extensions, iframeWin, [
-          'amp-test',
-        ]);
-      });
     // Resolve the promise.
     extensions.registerExtension(
       'amp-test',
@@ -1164,33 +1205,50 @@ describes.realWin('installExtensionsInChildWindow', {amp: true}, (env) => {
       },
       parentWin.AMP
     );
-    return promise.then(() => {
-      // Main extension.
-      expect(parentWin.__AMP_EXTENDED_ELEMENTS['amp-test']).to.be.undefined;
-      expect(iframeWin.__AMP_EXTENDED_ELEMENTS['amp-test']).to.equal(AmpTest);
-      expect(iframeWin.document.querySelector('style[amp-extension=amp-test]'))
-        .to.exist;
-      // Must be upgraded already.
-      expect(
-        iframeWin.document.createElement('amp-test').implementation_
-      ).to.be.instanceOf(AmpTest);
 
-      // Secondary extension.
-      expect(parentWin.__AMP_EXTENDED_ELEMENTS['amp-test-sub']).to.be.undefined;
-      expect(iframeWin.__AMP_EXTENDED_ELEMENTS['amp-test-sub']).to.equal(
-        AmpTestSub
-      );
-      expect(
-        iframeWin.document.querySelector('style[amp-extension=amp-test-sub]')
-      ).to.not.exist;
-      // Must be upgraded already.
-      expect(
-        iframeWin.document.createElement('amp-test-sub').implementation_
-      ).to.be.instanceOf(AmpTestSub);
-    });
+    await LegacyInstaller.installExtensionsInChildWindow(
+      extensions,
+      iframeWin,
+      ['amp-test'],
+      preinstallCallback,
+      startRender,
+      installComplete
+    );
+
+    // Must be stubbed already.
+    expect(iframeWin.__AMP_EXTENDED_ELEMENTS['amp-test']).to.equal(ElementStub);
+    expect(
+      iframeWin.document.createElement('amp-test').implementation_
+    ).to.be.instanceOf(ElementStub);
+    expect(iframeWin.__AMP_EXTENDED_ELEMENTS['amp-test-sub']).to.be.undefined;
+
+    await installCompletePromise;
+
+    // Main extension.
+    expect(parentWin.__AMP_EXTENDED_ELEMENTS['amp-test']).to.be.undefined;
+    expect(iframeWin.__AMP_EXTENDED_ELEMENTS['amp-test']).to.equal(AmpTest);
+    expect(iframeWin.document.querySelector('style[amp-extension=amp-test]')).to
+      .exist;
+    // Must be upgraded already.
+    expect(
+      iframeWin.document.createElement('amp-test').implementation_
+    ).to.be.instanceOf(AmpTest);
+
+    // Secondary extension.
+    expect(parentWin.__AMP_EXTENDED_ELEMENTS['amp-test-sub']).to.be.undefined;
+    expect(iframeWin.__AMP_EXTENDED_ELEMENTS['amp-test-sub']).to.equal(
+      AmpTestSub
+    );
+    expect(
+      iframeWin.document.querySelector('style[amp-extension=amp-test-sub]')
+    ).to.not.exist;
+    // Must be upgraded already.
+    expect(
+      iframeWin.document.createElement('amp-test-sub').implementation_
+    ).to.be.instanceOf(AmpTestSub);
   });
 
-  it('should adopt extension services', () => {
+  it('should adopt extension services', async () => {
     class FooService {
       static installInEmbedWindow() {}
     }
@@ -1215,13 +1273,15 @@ describes.realWin('installExtensionsInChildWindow', {amp: true}, (env) => {
 
     const extHolder = extensions.getExtensionHolder_('amp-test');
     extHolder.scriptPresent = true;
-    const install = fie
-      .preInstallExtensionsInChildWindow(extensions, iframeWin, ['amp-test'])
-      .then(() =>
-        fie.doInstallExtensionsInChildWindow(extensions, iframeWin, [
-          'amp-test',
-        ])
-      );
+
+    await LegacyInstaller.installExtensionsInChildWindow(
+      extensions,
+      iframeWin,
+      ['amp-test'],
+      preinstallCallback,
+      startRender,
+      installComplete
+    );
 
     // Resolve the promise `install`.
     extensions.registerExtension(
@@ -1232,62 +1292,10 @@ describes.realWin('installExtensionsInChildWindow', {amp: true}, (env) => {
       parentWin.AMP
     );
 
-    return install.then(() => {
-      expect(FooService.installInEmbedWindow).calledOnce;
-      expect(BarService.installInEmbedWindow).to.not.be.called;
-    });
-  });
+    await installCompletePromise;
 
-  // TODO(#16916): Make this test work with synchronous throws.
-  it.skip('should call pre-install callback before other installs', () => {
-    let preinstallCount = 0;
-    const extHolder = extensions.getExtensionHolder_('amp-test');
-    extHolder.scriptPresent = true;
-    const promise = fie
-      .preInstallExtensionsInChildWindow(
-        extensions,
-        iframeWin,
-        ['amp-test'],
-        function () {
-          // Built-ins not installed yet.
-          expect(
-            iframeWin.__AMP_EXTENDED_ELEMENTS &&
-              iframeWin.__AMP_EXTENDED_ELEMENTS['amp-img']
-          ).to.not.exist;
-          // Extension is not loaded yet.
-          expect(
-            iframeWin.__AMP_EXTENDED_ELEMENTS &&
-              iframeWin.__AMP_EXTENDED_ELEMENTS['amp-test']
-          ).to.not.exist;
-          preinstallCount++;
-        }
-      )
-      .then(() =>
-        fie.doInstallExtensionsInChildWindow(extensions, iframeWin, [
-          'amp-test',
-        ])
-      );
-    expect(preinstallCount).to.equal(1);
-    expect(iframeWin.__AMP_EXTENDED_ELEMENTS).to.exist;
-    expect(iframeWin.__AMP_EXTENDED_ELEMENTS['amp-img']).to.exist;
-    expect(iframeWin.__AMP_EXTENDED_ELEMENTS['amp-img']).to.not.equal(
-      ElementStub
-    );
-    expect(iframeWin.__AMP_EXTENDED_ELEMENTS['amp-test']).to.equal(ElementStub);
-
-    // Resolve the promise.
-    extensions.registerExtension(
-      'amp-test',
-      (AMP) => {
-        AMP.registerElement('amp-test', AmpTest);
-      },
-      parentWin.AMP
-    );
-    return promise.then(() => {
-      // Extension elements are stubbed immediately, but registered only
-      // after extension is loaded.
-      expect(iframeWin.__AMP_EXTENDED_ELEMENTS['amp-test']).to.equal(AmpTest);
-    });
+    expect(FooService.installInEmbedWindow).calledOnce;
+    expect(BarService.installInEmbedWindow).to.not.be.called;
   });
 
   describe('installStandardServicesInEmbed', () => {
@@ -1314,7 +1322,7 @@ describes.realWin('installExtensionsInChildWindow', {amp: true}, (env) => {
   });
 });
 
-describes.realWin('installExtensionsInFie', {amp: true}, (env) => {
+describes.realWin('installExtensionsInEmbed', {amp: true}, (env) => {
   let parentWin;
   let extensions;
   let extensionsMock;
@@ -1322,8 +1330,10 @@ describes.realWin('installExtensionsInFie', {amp: true}, (env) => {
   let iframeWin, iframeDocEl;
   let ampdoc;
   let fie;
+  let startRender;
+  let installComplete, installCompletePromise;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     parentWin = env.win;
     toggleAmpdocFieForTesting(parentWin, true);
     resetScheduledElementForTesting(parentWin, 'amp-test');
@@ -1355,15 +1365,22 @@ describes.realWin('installExtensionsInFie', {amp: true}, (env) => {
       Promise.resolve(),
       env.ampdoc
     );
-    return promise.then(() => {
-      iframeWin = iframe.contentWindow;
-      iframeDocEl = iframeWin.document.documentElement;
-      setParentWindow(iframeWin, parentWin);
-      ampdoc = ampdocService.installFieDoc(
-        'https://example.test/embed',
-        iframeWin
-      );
+
+    startRender = env.sandbox.stub(fie, 'startRender_');
+    installComplete = undefined;
+    installCompletePromise = new Promise((resolve) => {
+      installComplete = resolve;
     });
+
+    // Wait for the iframe to load.
+    await promise;
+    iframeWin = iframe.contentWindow;
+    iframeDocEl = iframeWin.document.documentElement;
+    setParentWindow(iframeWin, parentWin);
+    ampdoc = ampdocService.installFieDoc(
+      'https://example.test/embed',
+      iframeWin
+    );
   });
 
   afterEach(() => {
@@ -1374,19 +1391,20 @@ describes.realWin('installExtensionsInFie', {amp: true}, (env) => {
     extensionsMock.verify();
   });
 
-  it('should set window hierarchy', () => {
-    fie.installExtensionsInFie(extensions, ampdoc, []);
+  it('should set window hierarchy', async () => {
+    await installExtensionsInEmbed(fie, extensions, ampdoc, []);
     expect(iframeWin.__AMP_PARENT).to.equal(parentWin);
     expect(iframeWin.__AMP_TOP).to.equal(parentWin);
+    expect(startRender).to.be.calledOnce;
   });
 
-  it('should install runtime styles', () => {
-    fie.installExtensionsInFie(extensions, ampdoc, []);
+  it('should install runtime styles', async () => {
+    await installExtensionsInEmbed(fie, extensions, ampdoc, []);
     expect(iframeWin.document.querySelector('style[amp-runtime]')).to.exist;
   });
 
-  it('should install built-ins', () => {
-    fie.installExtensionsInFie(extensions, ampdoc, []);
+  it('should install built-ins', async () => {
+    await installExtensionsInEmbed(fie, extensions, ampdoc, []);
     expect(iframeWin.__AMP_EXTENDED_ELEMENTS).to.exist;
     expect(iframeWin.__AMP_EXTENDED_ELEMENTS['amp-img']).to.exist;
     expect(iframeWin.__AMP_EXTENDED_ELEMENTS['amp-img']).to.not.equal(
@@ -1406,8 +1424,8 @@ describes.realWin('installExtensionsInFie', {amp: true}, (env) => {
     );
   });
 
-  it('should create new standard services', () => {
-    fie.installExtensionsInFie(extensions, ampdoc, []);
+  it('should create new standard services', async () => {
+    await installExtensionsInEmbed(fie, extensions, ampdoc, []);
 
     const url = Services.urlForDoc(iframeDocEl);
     const actions = Services.actionServiceForDoc(iframeDocEl);
@@ -1425,8 +1443,8 @@ describes.realWin('installExtensionsInFie', {amp: true}, (env) => {
     expect(url).to.not.equal(parentUrl);
   });
 
-  it('should adopt parent standard services', () => {
-    fie.installExtensionsInFie(extensions, ampdoc, []);
+  it('should adopt parent standard services', async () => {
+    await installExtensionsInEmbed(fie, extensions, ampdoc, []);
 
     const viewer = Services.urlForDoc(iframeDocEl);
     const parentViewer = Services.urlForDoc(parentWin.document.head);
@@ -1435,12 +1453,19 @@ describes.realWin('installExtensionsInFie', {amp: true}, (env) => {
     expect(viewer).to.not.equal(parentViewer);
   });
 
-  it('should install extensions in child window', () => {
+  it('should install extensions in child window', async () => {
     const extHolder = extensions.getExtensionHolder_('amp-test');
     extHolder.scriptPresent = true;
-    const promise = fie.installExtensionsInFie(extensions, ampdoc, [
-      'amp-test',
-    ]);
+
+    await installExtensionsInEmbed(
+      fie,
+      extensions,
+      ampdoc,
+      ['amp-test'],
+      null,
+      installComplete
+    );
+
     // Must be stubbed already.
     expect(iframeWin.__AMP_EXTENDED_ELEMENTS['amp-test']).to.equal(ElementStub);
     expect(
@@ -1458,33 +1483,34 @@ describes.realWin('installExtensionsInFie', {amp: true}, (env) => {
       },
       parentWin.AMP
     );
-    return promise.then(() => {
-      // Main extension.
-      expect(parentWin.__AMP_EXTENDED_ELEMENTS['amp-test']).to.be.undefined;
-      expect(iframeWin.__AMP_EXTENDED_ELEMENTS['amp-test']).to.equal(AmpTest);
-      expect(iframeWin.document.querySelector('style[amp-extension=amp-test]'))
-        .to.exist;
-      // Must be upgraded already.
-      expect(
-        iframeWin.document.createElement('amp-test').implementation_
-      ).to.be.instanceOf(AmpTest);
 
-      // Secondary extension.
-      expect(parentWin.__AMP_EXTENDED_ELEMENTS['amp-test-sub']).to.be.undefined;
-      expect(iframeWin.__AMP_EXTENDED_ELEMENTS['amp-test-sub']).to.equal(
-        AmpTestSub
-      );
-      expect(
-        iframeWin.document.querySelector('style[amp-extension=amp-test-sub]')
-      ).to.not.exist;
-      // Must be upgraded already.
-      expect(
-        iframeWin.document.createElement('amp-test-sub').implementation_
-      ).to.be.instanceOf(AmpTestSub);
-    });
+    await installCompletePromise;
+
+    // Main extension.
+    expect(parentWin.__AMP_EXTENDED_ELEMENTS['amp-test']).to.be.undefined;
+    expect(iframeWin.__AMP_EXTENDED_ELEMENTS['amp-test']).to.equal(AmpTest);
+    expect(iframeWin.document.querySelector('style[amp-extension=amp-test]')).to
+      .exist;
+    // Must be upgraded already.
+    expect(
+      iframeWin.document.createElement('amp-test').implementation_
+    ).to.be.instanceOf(AmpTest);
+
+    // Secondary extension.
+    expect(parentWin.__AMP_EXTENDED_ELEMENTS['amp-test-sub']).to.be.undefined;
+    expect(iframeWin.__AMP_EXTENDED_ELEMENTS['amp-test-sub']).to.equal(
+      AmpTestSub
+    );
+    expect(
+      iframeWin.document.querySelector('style[amp-extension=amp-test-sub]')
+    ).to.not.exist;
+    // Must be upgraded already.
+    expect(
+      iframeWin.document.createElement('amp-test-sub').implementation_
+    ).to.be.instanceOf(AmpTestSub);
   });
 
-  it('should adopt extension services', () => {
+  it('should adopt extension services', async () => {
     const fooConstructorSpy = env.sandbox.spy();
     class FooService {
       constructor(arg) {
@@ -1513,9 +1539,15 @@ describes.realWin('installExtensionsInFie', {amp: true}, (env) => {
 
     const extHolder = extensions.getExtensionHolder_('amp-test');
     extHolder.scriptPresent = true;
-    const install = fie.installExtensionsInFie(extensions, ampdoc, [
-      'amp-test',
-    ]);
+
+    await installExtensionsInEmbed(
+      fie,
+      extensions,
+      ampdoc,
+      ['amp-test'],
+      null,
+      installComplete
+    );
 
     // Resolve the promise `install`.
     extensions.registerExtension(
@@ -1526,17 +1558,19 @@ describes.realWin('installExtensionsInFie', {amp: true}, (env) => {
       parentWin.AMP
     );
 
-    return install.then(() => {
-      expect(fooConstructorSpy).calledOnce.calledWith(ampdoc);
-      expect(barConstructorSpy).to.not.be.called;
-    });
+    await installCompletePromise;
+
+    expect(fooConstructorSpy).calledOnce.calledWith(ampdoc);
+    expect(barConstructorSpy).to.not.be.called;
   });
 
-  it('should call pre-install callback before other installs', () => {
+  it('should call pre-install callback before other installs', async () => {
     let preinstallCount = 0;
     const extHolder = extensions.getExtensionHolder_('amp-test');
     extHolder.scriptPresent = true;
-    const promise = fie.installExtensionsInFie(
+
+    await installExtensionsInEmbed(
+      fie,
       extensions,
       ampdoc,
       ['amp-test'],
@@ -1554,8 +1588,10 @@ describes.realWin('installExtensionsInFie', {amp: true}, (env) => {
             iframeWin.__AMP_EXTENDED_ELEMENTS['amp-test']
         ).to.not.exist;
         preinstallCount++;
-      }
+      },
+      installComplete
     );
+
     expect(preinstallCount).to.equal(1);
     expect(iframeWin.__AMP_EXTENDED_ELEMENTS).to.exist;
     expect(iframeWin.__AMP_EXTENDED_ELEMENTS['amp-img']).to.exist;
@@ -1572,10 +1608,11 @@ describes.realWin('installExtensionsInFie', {amp: true}, (env) => {
       },
       parentWin.AMP
     );
-    return promise.then(() => {
-      // Extension elements are stubbed immediately, but registered only
-      // after extension is loaded.
-      expect(iframeWin.__AMP_EXTENDED_ELEMENTS['amp-test']).to.equal(AmpTest);
-    });
+
+    await installCompletePromise;
+
+    // Extension elements are stubbed immediately, but registered only
+    // after extension is loaded.
+    expect(iframeWin.__AMP_EXTENDED_ELEMENTS['amp-test']).to.equal(AmpTest);
   });
 });


### PR DESCRIPTION
1. The non ampdoc-fie code is moved to a separate `friendly-iframe-embed-legacy.js` to (1) easier to prohibit dependencies, and (2) ease of experiment cleanup.
2. The move from `friendly-iframe-embed.js` to `friendly-iframe-embed-legacy.js` is a trivial move.