### PR TITLE
✨ [bento] Add passthroughNonEmpty mode for handling children in Bento

### DIFF
--- a/src/preact/base-element.js
+++ b/src/preact/base-element.js
@@ -263,7 +263,8 @@ PreactBaseElement['passthrough'] = false;
  * mode except that when there are no children elements, the returned
  * prop['children'] will be null instead of the unnamed <slot>.  This allows
  * the Preact environment to have conditional behavior depending on whether
- * or not there are children.
+ * or not there are children.  Consider using a Mutation Observer in your
+ * component for detailed control of rerender when children are updated.
  *
  * @protected {boolean}
  */
@@ -346,8 +347,15 @@ function collectProps(Ctor, element, defaultProps) {
     props['children'] = [<Slot />];
   } else if (passthroughNonEmpty) {
     devAssert(!childrenDefs, errorMessage);
-    props['children'] =
-      element.getRealChildNodes().length > 0 ? [<Slot />] : null;
+    // If all children are whitespace text nodes, consider the element as
+    // having no children
+    props['children'] = element
+      .getRealChildNodes()
+      .every(
+        (node) => node.nodeType === 3 && node.nodeValue.trim().length === 0
+      )
+      ? null
+      : [<Slot />];
   } else if (childrenDefs) {
     const children = [];
     props['children'] = children;

--- a/src/preact/base-element.js
+++ b/src/preact/base-element.js
@@ -352,7 +352,9 @@ function collectProps(Ctor, element, defaultProps) {
     props['children'] = element
       .getRealChildNodes()
       .every(
-        (node) => node.nodeType === 3 && node.nodeValue.trim().length === 0
+        (node) =>
+          node.nodeType === /* TEXT_NODE */ 3 &&
+          node.nodeValue.trim().length === 0
       )
       ? null
       : [<Slot />];


### PR DESCRIPTION
Add 'passthroughNonEmpty' mode for handling children in bento.

Handling children with passthroughNonEmpty mode is the same as passthrough mode except that when there are no children elements, the returned prop['children'] will be null instead of the unnamed `<slot>`.  This allows the Preact environment to have conditional behavior depending on whether or not there are children.

Note: The framework will treat whitespace as a child text node.  

![image](https://user-images.githubusercontent.com/25626770/87952910-5f2ea480-ca78-11ea-9d66-2810cbbb4324.png)
This will be considered to have a child text node with a return and some spaces.

![image](https://user-images.githubusercontent.com/25626770/87952984-75d4fb80-ca78-11ea-9a4f-5e1dc6407fda.png)
This will not be considered to have any children.


Edit:  7/21/2020
Added logic to check if all children are whitespace only text nodes and if so, consider there to be no children and return `props['children'] = null`.