### PR TITLE
🐛🌐 amp-consent: fix rtl support caused by alertDialog

### DIFF
--- a/extensions/amp-consent/0.1/amp-consent.css
+++ b/extensions/amp-consent/0.1/amp-consent.css
@@ -90,8 +90,8 @@ amp-consent.amp-hidden {
   position: absolute;
   height: 1px;
   width: 1px;
-  left: -10000px;
   top: auto;
+  left: auto;
 }
 
 .i-amphtml-consent-ui-fill {


### PR DESCRIPTION
The `alertDialog` class is meant to style an 'invisible' element, that the screen reader will pick up always. 

Due to the the `alertDialog` class having `left: -10000px`, pages with `dir="rtl"` fail to show the amp-consent 3p iframe.

[Original reasoning](https://github.com/ampproject/amphtml/pull/26456#discussion_r375034203) for large negative `left` value was to essentially hide the element. Using `left: auto` will let the browser determine where the left edge is. This keeps the existing behavior and fixes the `dir=rtl` problem.

Another solution could be to create 2 alert dialog classes based upon direction:
```
amp-consent[dir="rtl"] .i-amphtml-consent-alertdialog{ right: -10000px; }
amp-consent[dir="ltr"] .i-amphtml-consent-alertdialog{ left: -10000px; }
```