### PR TITLE
🐛A4A: add more functionality to secure frame

### DIFF
--- a/extensions/amp-a4a/0.1/secure-frame.js
+++ b/extensions/amp-a4a/0.1/secure-frame.js
@@ -33,6 +33,7 @@ const fontProviderAllowList = [
 
 const sandboxVals = [
   'allow-forms',
+  'allow-popups',
   'allow-popups-to-escape-sandbox',
   'allow-same-origin',
   'allow-top-navigation',
@@ -47,6 +48,7 @@ const createSecureDocSkeleton = (sanitizedHeadElements) =>
       img-src *;
       media-src *;
       font-src *;
+      connect-src *;
       script-src 'none';
       object-src 'none';
       child-src 'none';

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -108,8 +108,8 @@ describes.realWin('no signing', {amp: true}, (env) => {
     await a4a.layoutCallback();
     const fie = doc.body.querySelector('iframe[srcdoc]');
     expect(fie.getAttribute('sandbox')).to.equal(
-      'allow-forms allow-popups-to-escape-sandbox allow-same-origin ' +
-        'allow-top-navigation'
+      'allow-forms allow-popups allow-popups-to-escape-sandbox ' +
+        'allow-same-origin allow-top-navigation'
     );
     const cspMeta = fie.contentDocument.querySelector(
       'meta[http-equiv=Content-Security-Policy]'
@@ -118,6 +118,7 @@ describes.realWin('no signing', {amp: true}, (env) => {
     expect(cspMeta.content).to.include('img-src *;');
     expect(cspMeta.content).to.include('media-src *;');
     expect(cspMeta.content).to.include('font-src *;');
+    expect(cspMeta.content).to.include('connect-src *;');
     expect(cspMeta.content).to.include("script-src 'none';");
     expect(cspMeta.content).to.include("object-src 'none';");
     expect(cspMeta.content).to.include("child-src 'none';");


### PR DESCRIPTION
`connect-src *` for analytics to be able to send pings, and `allow popups` so that clicks are allowed to open landing pages in new window. Found in incoming PR to enable integration tests.

Part of #27189