### PR TITLE
🧪Enable A4A integration test for no-signing exp

### DIFF
--- a/extensions/amp-a4a/0.1/head-validation.js
+++ b/extensions/amp-a4a/0.1/head-validation.js
@@ -15,6 +15,8 @@
  */
 
 import {Services} from '../../../src/services';
+import {getMode} from '../../../src/mode';
+import {includes} from '../../../src/string';
 import {map} from '../../../src/utils/object';
 import {parseExtensionUrl} from '../../../src/service/extension-location';
 import {removeElement} from '../../../src/dom';
@@ -154,7 +156,12 @@ function handleScript(extensions, script) {
   }
 
   const {src} = script;
-  if (EXTENSION_URL_PREFIX.test(src)) {
+  const isTesting = getMode().test || getMode().localDev;
+  if (
+    EXTENSION_URL_PREFIX.test(src) ||
+    // Integration tests point to local files.
+    (isTesting && includes(src, '/dist/'))
+  ) {
     const extensionInfo = parseExtensionUrl(src);
     if (EXTENSION_ALLOWLIST[extensionInfo.extensionId]) {
       extensions.push(extensionInfo);

--- a/extensions/amp-ad-network-fake-impl/0.1/amp-ad-network-fake-impl.js
+++ b/extensions/amp-ad-network-fake-impl/0.1/amp-ad-network-fake-impl.js
@@ -17,10 +17,17 @@
 import {AmpA4A} from '../../amp-a4a/0.1/amp-a4a';
 import {AmpAdMetadataTransformer} from './amp-ad-metadata-transformer';
 import {ExternalReorderHeadTransformer} from './external-reorder-head-transformer';
+import {forceExperimentBranch} from '../../../src/experiments';
 import {includes, startsWith} from '../../../src/string';
 import {user, userAssert} from '../../../src/log';
 
 const TAG = 'AMP-AD-NETWORK-FAKE-IMPL';
+
+/**
+ * Allow elements to opt into an experiment branch.
+ * @const {string}
+ */
+const EXPERIMENT_BRANCH_ATTR = 'data-experiment-id';
 
 export class AmpAdNetworkFakeImpl extends AmpA4A {
   /**
@@ -42,6 +49,15 @@ export class AmpAdNetworkFakeImpl extends AmpA4A {
       'Attribute src or srcdoc required for <amp-ad type="fake">: %s',
       this.element
     );
+    if (this.element.hasAttribute(EXPERIMENT_BRANCH_ATTR)) {
+      this.element
+        .getAttribute(EXPERIMENT_BRANCH_ATTR)
+        .split(',')
+        .forEach((experiment) => {
+          const expParts = experiment.split(':');
+          forceExperimentBranch(this.win, expParts[0], expParts[1]);
+        });
+    }
     super.buildCallback();
   }
 

--- a/test/integration/test-amphtml-ads.js
+++ b/test/integration/test-amphtml-ads.js
@@ -22,13 +22,15 @@ import {xhrServiceForTesting} from '../../src/service/xhr-impl';
 // TODO(wg-ads, #29112): Unskip on Safari.
 const t = describe.configure().skipSafari();
 
-t.run('AMPHTML ad on AMP Page', () => {
-  describes.integration(
-    'ATF',
-    {
-      amp: true,
-      extensions: ['amp-ad'],
-      body: `
+['a4a-no-signing:21066324', 'a4a-no-signing:21066325'].forEach((branch) => {
+  t.run(`AMPHTML ad on AMP Page: ${branch}`, () => {
+    describes.integration(
+      'ATF',
+      {
+        amp: true,
+        experiments: [branch],
+        extensions: ['amp-ad'],
+        body: `
   <amp-ad
       width="300" height="250"
       id="i-amphtml-demo-id"
@@ -36,29 +38,30 @@ t.run('AMPHTML ad on AMP Page', () => {
       a4a-conversion="true"
       checksig=""
       disable3pfallback="true"
+      data-experiment-id=${branch}
       src="//ads.localhost:9876/amp4test/a4a/${RequestBank.getBrowserId()}">
   </amp-ad>
       `,
-    },
-    () => {
-      afterEach(() => {
-        return RequestBank.tearDown();
-      });
+      },
+      () => {
+        afterEach(() => {
+          return RequestBank.tearDown();
+        });
 
-      it('should layout amp-img, amp-pixel, amp-analytics', () => {
-        // Open http://ads.localhost:9876/amp4test/a4a/12345 to see ad content
-        return testAmpComponents();
-      });
-    }
-  );
+        it('should layout amp-img, amp-pixel, amp-analytics', () => {
+          // Open http://ads.localhost:9876/amp4test/a4a/12345 to see ad content
+          return testAmpComponents();
+        });
+      }
+    );
 
-  describes.integration(
-    'BTF',
-    {
-      amp: true,
-      extensions: ['amp-ad'],
-      frameStyle: 'height: 100vh',
-      body: `
+    describes.integration(
+      'BTF',
+      {
+        amp: true,
+        extensions: ['amp-ad'],
+        frameStyle: 'height: 100vh',
+        body: `
   <div style="height: 100vh"></div>
   <amp-ad
       width="300" height="250"
@@ -67,22 +70,24 @@ t.run('AMPHTML ad on AMP Page', () => {
       a4a-conversion="true"
       checksig=""
       disable3pfallback="true"
+      data-experiment-id=${branch}
       src="//ads.localhost:9876/amp4test/a4a/${RequestBank.getBrowserId()}">
   </amp-ad>
       `,
-    },
-    (env) => {
-      afterEach(() => {
-        return RequestBank.tearDown();
-      });
+      },
+      (env) => {
+        afterEach(() => {
+          return RequestBank.tearDown();
+        });
 
-      // TODO(#24657): Flaky on Travis.
-      it.skip('should layout amp-img, amp-pixel, amp-analytics', () => {
-        // Open http://ads.localhost:9876/amp4test/a4a/12345 to see ad content
-        return testAmpComponentsBTF(env.win);
-      });
-    }
-  );
+        // TODO(#24657): Flaky on Travis.
+        it.skip('should layout amp-img, amp-pixel, amp-analytics', () => {
+          // Open http://ads.localhost:9876/amp4test/a4a/12345 to see ad content
+          return testAmpComponentsBTF(env.win);
+        });
+      }
+    );
+  });
 });
 
 t.run('AMPHTML ad on non-AMP page (inabox)', () => {

--- a/test/integration/test-amphtml-ads.js
+++ b/test/integration/test-amphtml-ads.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {NO_SIGNING_EXP} from '../../extensions/amp-a4a/0.1/amp-a4a';
 import {RequestBank} from '../../testing/test-helper';
 import {maybeSwitchToCompiledJs} from '../../testing/iframe';
 import {parseQueryString} from '../../src/url';
@@ -22,13 +23,12 @@ import {xhrServiceForTesting} from '../../src/service/xhr-impl';
 // TODO(wg-ads, #29112): Unskip on Safari.
 const t = describe.configure().skipSafari();
 
-['a4a-no-signing:21066324', 'a4a-no-signing:21066325'].forEach((branch) => {
-  t.run(`AMPHTML ad on AMP Page: ${branch}`, () => {
+[NO_SIGNING_EXP.control, NO_SIGNING_EXP.experiment].forEach((branch) => {
+  t.run(`AMPHTML ad on AMP Page ${NO_SIGNING_EXP.id}:${branch}`, () => {
     describes.integration(
       'ATF',
       {
         amp: true,
-        experiments: [branch],
         extensions: ['amp-ad'],
         body: `
   <amp-ad
@@ -38,7 +38,7 @@ const t = describe.configure().skipSafari();
       a4a-conversion="true"
       checksig=""
       disable3pfallback="true"
-      data-experiment-id=${branch}
+      data-experiment-id=${NO_SIGNING_EXP.id}:${branch}
       src="//ads.localhost:9876/amp4test/a4a/${RequestBank.getBrowserId()}">
   </amp-ad>
       `,


### PR DESCRIPTION
Introduces an element level attribute to opt into experiment branch for fake ad impl, and turns on a couple integration tests. 

Related to #27189