### PR TITLE
🐛 Geo location was not set to the blueconic-analytics-vendor

### DIFF
--- a/extensions/amp-analytics/0.1/test/vendor-requests.json
+++ b/extensions/amp-analytics/0.1/test/vendor-requests.json
@@ -40,7 +40,7 @@
   "blueconic": {
     "event": "https://!tenantId/s/!pixelId.gif?",
     "trackingIdentifier": "https://!tenantId/s/!pixelId.gif?property=!property&!property=_client_id(cid-scope-cookie-fallback-name)_!extraTrackingValues",
-    "defaultTrackingValues": "https://!tenantId/s/!pixelId.gif?property=!property&!property=_client_id(cid-scope-cookie-fallback-name)_!extraTrackingValues&sourceUrl=_source_url_&canonicalUrl=_canonical_url_&referrer=_document_referrer_&title=_title_&visitDate=_timestamp_&geoLocation=_amp_geo_&userAgent=_user_agent_"
+    "defaultTrackingValues": "https://!tenantId/s/!pixelId.gif?property=!property&!property=_client_id(cid-scope-cookie-fallback-name)_!extraTrackingValues&sourceUrl=_source_url_&canonicalUrl=_canonical_url_&referrer=_document_referrer_&title=_title_&visitDate=_timestamp_&geoLocation=_amp_geo(ISOCountry)_&userAgent=_user_agent_"
   },
   "browsi": {
     "host": "https://events.browsiprod.com/events/amp",

--- a/extensions/amp-analytics/0.1/vendors/blueconic.json
+++ b/extensions/amp-analytics/0.1/vendors/blueconic.json
@@ -2,9 +2,14 @@
   "requests": {
     "event": "https://${tenantId}/s/${pixelId}.gif?",
     "trackingIdentifier": "${event}property=${property}&${property}=${clientId(cid-scope-cookie-fallback-name)}${extraTrackingValues}",
-    "defaultTrackingValues": "${trackingIdentifier}&sourceUrl=${sourceUrl}&canonicalUrl=${canonicalUrl}&referrer=${documentReferrer}&title=${title}&visitDate=${timestamp}&geoLocation=${ampGeo}&userAgent=${userAgent}"
+    "defaultTrackingValues": "${trackingIdentifier}&sourceUrl=${sourceUrl}&canonicalUrl=${canonicalUrl}&referrer=${documentReferrer}&title=${title}&visitDate=${timestamp}&geoLocation=${ampGeo(ISOCountry)}&userAgent=${userAgent}"
   },
   "vars": {
     "extraTrackingValues": ""
+  },
+  "transport": {
+    "beacon": false,
+    "xhrpost": false,
+    "image": true
   }
 }


### PR DESCRIPTION
- Changed ${ampGeo} to ${ampGeo(ISOCountry) in the blueconic.json;
- Changed this for vendor-requests.json for the test as well;
- Transport added to the blueconic.json, we only support the image mechanisme;