### PR TITLE
Validator Roll up

### DIFF
--- a/validator/engine/parse-css.js
+++ b/validator/engine/parse-css.js
@@ -1426,8 +1426,10 @@ const SelectorVisitor = class extends RuleVisitor {
     const tokenStream = new TokenStream(qualifiedRule.prelude);
     tokenStream.consume();
     const maybeSelector = parseASelectorsGroup(tokenStream);
-    if (maybeSelector instanceof tokenize_css.ErrorToken)
+    if (maybeSelector instanceof tokenize_css.ErrorToken) {
       this.errors_.push(maybeSelector);
+      return;
+    }
 
     /** @type {!Array<!Selector>} */
     const toVisit = [maybeSelector];

--- a/validator/engine/parse-css_test.js
+++ b/validator/engine/parse-css_test.js
@@ -1857,6 +1857,19 @@ describe('css_selectors', () => {
         selector);
   });
 
+  it('records one selector parsing error', () => {
+    const css = '/*error*/ {}';
+    const errors = [];
+    const tokenlist = tokenize_css.tokenize(css, 1, 0, errors);
+    const sheet = parse_css.parseAStylesheet(
+        tokenlist, ampAtRuleParsingSpec, parse_css.BlockType.PARSE_AS_IGNORE,
+        errors);
+    assertStrictEqual(0, errors.length);
+    const visitor = new parse_css.SelectorVisitor(errors);
+    sheet.accept(visitor);
+    assertStrictEqual(1, errors.length);
+  });
+
   it('implements visitor pattern', () => {
     class CollectCombinatorNodes extends parse_css.SelectorVisitor {
       constructor() {
@@ -1884,6 +1897,7 @@ describe('css_selectors', () => {
         errors);
     const visitor = new CollectCombinatorNodes();
     sheet.accept(visitor);
+    assertStrictEqual(0, errors.length);
     assertStrictEqual(4, visitor.combinatorNodes.length);
     assertStrictEqual(
         'GENERAL_SIBLING', visitor.combinatorNodes[0].combinatorType);

--- a/validator/testdata/feature_tests/regexps.out
+++ b/validator/testdata/feature_tests/regexps.out
@@ -170,10 +170,10 @@ feature_tests/regexps.html:122:2 The text inside tag 'style amp-custom' contains
 |    <div class="example-amp-font"></div>
 |    <div class="example-amp-font i-amphtml-hidden"></div>
 >>   ^~~~~~~~~
-feature_tests/regexps.html:140:2 The attribute 'class' in tag 'div' is set to the invalid value 'example-amp-font i-amphtml-hidden'.
+feature_tests/regexps.html:140:2 The attribute 'class' in tag 'div' is set to the invalid value 'example-amp-font i-amphtml-hidden'. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages/#disallowed-styles)
 |    <div class="i-amphtml-hidden example-amp-font"></div>
 >>   ^~~~~~~~~
-feature_tests/regexps.html:141:2 The attribute 'class' in tag 'div' is set to the invalid value 'i-amphtml-hidden example-amp-font'.
+feature_tests/regexps.html:141:2 The attribute 'class' in tag 'div' is set to the invalid value 'i-amphtml-hidden example-amp-font'. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages/#disallowed-styles)
 |
 |    <!--
 |    id disallowed_value_regex: lengthy, see protoascii

--- a/validator/testdata/transformed_feature_tests/amp-img.html
+++ b/validator/testdata/transformed_feature_tests/amp-img.html
@@ -1,0 +1,53 @@
+<!--
+  Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS-IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the license.
+-->
+<!--
+  Test Description:
+  This tests that <img> is allowed as child tag for <amp-img>.
+-->
+<!doctype html>
+<html ⚡ transformed="google;v=1">
+<head>
+  <meta charset="utf-8">
+  <style amp-runtime i-amphtml-version=123456789012345>.omitted-for-brevity{}</style>
+  <meta name="viewport" content="width=device-width">
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <link rel="canonical" href="./regular-html-version.html">
+</head>
+<body>
+  <!-- Valid: amp-img > img -->
+  <amp-img src="/img/canoe_900x600.jpg" alt="An image about canoeing" layout="responsive" width="900" height="600" i-amphtml-ssr>
+    <img src="/img/canoe_900x600.jpg" alt="An image about canoeing" decoding="async">
+  </amp-img>
+
+  <!-- Valid: amp-img[layout=intrinsic] > img -->
+  <amp-img src="/img/canoe_900x600.jpg" alt="An image about canoeing" layout="intrinsic" width="900" height="600" i-amphtml-layout="intrinsic" i-amphtml-ssr>
+    <i-amphtml-sizer class="i-amphtml-sizer">
+      <img alt aria-hidden="true" class="i-amphtml-intrinsic-sizer" role="presentation" src="data:image/svg+xml;charset=utf-8,<svg height=&quot;600&quot; width=&quot;900&quot; xmlns=&quot;http://www.w3.org/2000/svg&quot; version=&quot;1.1&quot;/>">
+    </i-amphtml-sizer>
+    <img src="/img/canoe_900x600.jpg" alt="An image about canoeing" decoding="async">
+  </amp-img>
+
+  <!-- Invalid: amp-img > img, missing i-amphtml-ssr attr -->
+  <amp-img src="/img/canoe_900x600.jpg" alt="An image about canoeing" layout="responsive" width="900" height="600">
+    <img src="/img/canoe_900x600.jpg" alt="An image about canoeing" decoding="async">
+  </amp-img>
+
+  <!-- Invalid: amp-img > img, missing decoding attr -->
+  <amp-img src="/img/canoe_900x600.jpg" alt="An image about canoeing" layout="responsive" width="900" height="600" i-amphtml-ssr>
+    <img src="/img/canoe_900x600.jpg" alt="An image about canoeing">
+  </amp-img>
+</body>
+</html>

--- a/validator/testdata/transformed_feature_tests/amp-img.out
+++ b/validator/testdata/transformed_feature_tests/amp-img.out
@@ -1,0 +1,64 @@
+FAIL
+|  <!--
+|    Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+|
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|
+|        http://www.apache.org/licenses/LICENSE-2.0
+|
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    This tests that <img> is allowed as child tag for <amp-img>.
+|  -->
+|  <!doctype html>
+|  <html ⚡ transformed="google;v=1">
+|  <head>
+|    <meta charset="utf-8">
+|    <style amp-runtime i-amphtml-version=123456789012345>.omitted-for-brevity{}</style>
+|    <meta name="viewport" content="width=device-width">
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    <link rel="canonical" href="./regular-html-version.html">
+|  </head>
+|  <body>
+|    <!-- Valid: amp-img > img -->
+|    <amp-img src="/img/canoe_900x600.jpg" alt="An image about canoeing" layout="responsive" width="900" height="600" i-amphtml-ssr>
+|      <img src="/img/canoe_900x600.jpg" alt="An image about canoeing" decoding="async">
+>>     ^~~~~~~~~
+transformed_feature_tests/amp-img.html:32:4 The mandatory attribute 'class' is missing in tag 'img'.
+|    </amp-img>
+|
+|    <!-- Valid: amp-img[layout=intrinsic] > img -->
+|    <amp-img src="/img/canoe_900x600.jpg" alt="An image about canoeing" layout="intrinsic" width="900" height="600" i-amphtml-layout="intrinsic" i-amphtml-ssr>
+|      <i-amphtml-sizer class="i-amphtml-sizer">
+|        <img alt aria-hidden="true" class="i-amphtml-intrinsic-sizer" role="presentation" src="data:image/svg+xml;charset=utf-8,<svg height=&quot;600&quot; width=&quot;900&quot; xmlns=&quot;http://www.w3.org/2000/svg&quot; version=&quot;1.1&quot;/>">
+|      </i-amphtml-sizer>
+|      <img src="/img/canoe_900x600.jpg" alt="An image about canoeing" decoding="async">
+>>     ^~~~~~~~~
+transformed_feature_tests/amp-img.html:40:4 The mandatory attribute 'class' is missing in tag 'img'.
+|    </amp-img>
+|
+|    <!-- Invalid: amp-img > img, missing i-amphtml-ssr attr -->
+|    <amp-img src="/img/canoe_900x600.jpg" alt="An image about canoeing" layout="responsive" width="900" height="600">
+|      <img src="/img/canoe_900x600.jpg" alt="An image about canoeing" decoding="async">
+>>     ^~~~~~~~~
+transformed_feature_tests/amp-img.html:45:4 The parent tag of tag 'img' is 'amp-img', but it can only be 'i-amphtml-sizer-intrinsic'.
+|    </amp-img>
+|
+|    <!-- Invalid: amp-img > img, missing decoding attr -->
+|    <amp-img src="/img/canoe_900x600.jpg" alt="An image about canoeing" layout="responsive" width="900" height="600" i-amphtml-ssr>
+|      <img src="/img/canoe_900x600.jpg" alt="An image about canoeing">
+>>     ^~~~~~~~~
+transformed_feature_tests/amp-img.html:50:4 The mandatory attribute 'class' is missing in tag 'img'.
+>>     ^~~~~~~~~
+transformed_feature_tests/amp-img.html:50:4 The mandatory attribute 'decoding' is missing in tag 'img'.
+|    </amp-img>
+|  </body>
+|  </html>

--- a/validator/testdata/transformed_feature_tests/nonce_attribute_error.html
+++ b/validator/testdata/transformed_feature_tests/nonce_attribute_error.html
@@ -15,7 +15,7 @@
 -->
 <!--
   Test Description:
-  Tests for the presence of disallowed nonce attribute in transformed AMP.
+  Tests for the presence of allowed nonce attribute in transformed AMP.
 -->
 <!doctype html>
 <html ⚡ transformed="google;v=1">

--- a/validator/testdata/transformed_feature_tests/nonce_attribute_error.out
+++ b/validator/testdata/transformed_feature_tests/nonce_attribute_error.out
@@ -1,4 +1,4 @@
-FAIL
+PASS
 |  <!--
 |    Copyright 2019 The AMP HTML Authors. All Rights Reserved.
 |
@@ -16,7 +16,7 @@ FAIL
 |  -->
 |  <!--
 |    Test Description:
-|    Tests for the presence of disallowed nonce attribute in transformed AMP.
+|    Tests for the presence of allowed nonce attribute in transformed AMP.
 |  -->
 |  <!doctype html>
 |  <html ⚡ transformed="google;v=1">
@@ -25,28 +25,16 @@ FAIL
 |    <style amp-runtime i-amphtml-version=123456789012345>.omitted-for-brevity{}</style>
 |    <meta name="viewport" content="width=device-width">
 |    <script async nonce src="https://cdn.ampproject.org/v0.js"></script>
->>   ^~~~~~~~~
-transformed_feature_tests/nonce_attribute_error.html:26:2 The attribute 'nonce' may not appear in tag 'amphtml engine v0.js script'. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#required-markup)
 |    <script async custom-element="amp-bind" nonce src="https://cdn.ampproject.org/v0/amp-bind-0.1.js"></script>
->>   ^~~~~~~~~
-transformed_feature_tests/nonce_attribute_error.html:27:2 The attribute 'nonce' may not appear in tag 'amp-bind extension .js script'. (see https://amp.dev/documentation/components/amp-bind)
 |    <style nonce amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
->>   ^~~~~~~~~
-transformed_feature_tests/nonce_attribute_error.html:28:2 The attribute 'nonce' may not appear in tag 'head > style[amp-boilerplate]'. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amp-boilerplate/?format=websites)
 |    <link rel="canonical" href="./regular-html-version.html">
 |    <script nonce type=application/ld+json>{}</script>
->>   ^~~~~~~~~
-transformed_feature_tests/nonce_attribute_error.html:30:2 The attribute 'nonce' may not appear in tag 'script type=application/ld+json'.
 |    <script id=amp-rtc nonce type=application/json>{}</script>
->>   ^~~~~~~~~
-transformed_feature_tests/nonce_attribute_error.html:31:2 The attribute 'nonce' may not appear in tag 'script'.
 |  </head>
 |  <body>
 |    Hello, world.
 |    <amp-state id=nonce>
 |      <script nonce type=application/json>{}</script>
->>     ^~~~~~~~~
-transformed_feature_tests/nonce_attribute_error.html:36:4 The attribute 'nonce' may not appear in tag 'script'. (see https://amp.dev/documentation/components/amp-bind/)
 |    </amp-state>
 |  </body>
 |  </html>

--- a/validator/testdata/transformed_feature_tests/server_side_rendering.html
+++ b/validator/testdata/transformed_feature_tests/server_side_rendering.html
@@ -61,6 +61,10 @@
     <img alt="" aria-hidden="true" class="i-amphtml-intrinsic-sizer" role="presentation" src="data:image/svg+xml;charset=utf-8,<svg height='100' width='300' xmlns='http://www.w3.org/2000/svg' version='1.1'/>">
     </i-amphtml-sizer>
   </amp-img>
+  <!-- Invalid i-amphtml-sizer > img  does not specify class -->
+  <amp-img src="image.png" height="100" width="300" layout="intrinsic" class="i-amphtml-layout-intrinsic i-amphtml-layout-size-defined" i-amphtml-layout="intrinsic">
+    <i-amphtml-sizer class="i-amphtml-sizer"><img alt="" aria-hidden="true" role="presentation" src="data:image/svg+xml;base64,PHN2ZyBoZWlnaHQ9Ijc1IiB3aWR0aD0iNzUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgdmVyc2lvbj0iMS4xIi8+"></i-amphtml-sizer>
+  </amp-img>
   <!-- Valid -->
   <amp-social-share class="i-amphtml-layout-fixed i-amphtml-layout-size-defined" i-amphtml-layout=fixed style=width:60px;height:44px; type=test></amp-social-share>
   <!-- Invalid i-amphtml-layout attribute value does not match layout value -->

--- a/validator/testdata/transformed_feature_tests/server_side_rendering.out
+++ b/validator/testdata/transformed_feature_tests/server_side_rendering.out
@@ -66,35 +66,41 @@ transformed_feature_tests/server_side_rendering.html:56:45 The attribute 'src' i
 transformed_feature_tests/server_side_rendering.html:61:4 The parent tag of tag 'img' is 'i-amphtml-sizer', but it can only be 'i-amphtml-sizer-intrinsic'.
 |      </i-amphtml-sizer>
 |    </amp-img>
+|    <!-- Invalid i-amphtml-sizer > img  does not specify class -->
+|    <amp-img src="image.png" height="100" width="300" layout="intrinsic" class="i-amphtml-layout-intrinsic i-amphtml-layout-size-defined" i-amphtml-layout="intrinsic">
+|      <i-amphtml-sizer class="i-amphtml-sizer"><img alt="" aria-hidden="true" role="presentation" src="data:image/svg+xml;base64,PHN2ZyBoZWlnaHQ9Ijc1IiB3aWR0aD0iNzUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgdmVyc2lvbj0iMS4xIi8+"></i-amphtml-sizer>
+>>                                              ^~~~~~~~~
+transformed_feature_tests/server_side_rendering.html:66:45 The mandatory attribute 'class' is missing in tag 'img'.
+|    </amp-img>
 |    <!-- Valid -->
 |    <amp-social-share class="i-amphtml-layout-fixed i-amphtml-layout-size-defined" i-amphtml-layout=fixed style=width:60px;height:44px; type=test></amp-social-share>
 |    <!-- Invalid i-amphtml-layout attribute value does not match layout value -->
 |    <amp-img class="i-amphtml-layout-responsive i-amphtml-layout-size-defined" height=2911 i-amphtml-layout=nodisplay layout=responsive src=https://example-com.cdn.ampproject.org/i/s/example.com/lemur-narrow.jpg srcset="https://example-com.cdn.ampproject.org/i/s/example.com/lemur-wide.jpg 640w, https://example-com.cdn.ampproject.org/i/s/example.com/lemur-narrow.jpg 320w" width=1698>
 >>   ^~~~~~~~~
-transformed_feature_tests/server_side_rendering.html:67:2 Invalid value 'nodisplay' for attribute 'i-amphtml-layout' in tag 'amp-img' - for layout 'RESPONSIVE', set the attribute 'i-amphtml-layout' to value 'responsive'. (see https://amp.dev/documentation/components/amp-img/)
+transformed_feature_tests/server_side_rendering.html:71:2 Invalid value 'nodisplay' for attribute 'i-amphtml-layout' in tag 'amp-img' - for layout 'RESPONSIVE', set the attribute 'i-amphtml-layout' to value 'responsive'. (see https://amp.dev/documentation/components/amp-img/)
 |      <i-amphtml-sizer style=display:block;padding-top:171.4370%;></i-amphtml-sizer>
 |    </amp-img>
 |    <!-- Invalid class attribute value due to not matching layout value -->
 |    <amp-img class="i-amphtml-layout-nodisplay i-amphtml-layout-size-defined" height=2911 i-amphtml-layout=responsive layout=responsive src=https://example-com.cdn.ampproject.org/i/s/example.com/lemur-narrow.jpg srcset="https://example-com.cdn.ampproject.org/i/s/example.com/lemur-wide.jpg 640w, https://example-com.cdn.ampproject.org/i/s/example.com/lemur-narrow.jpg 320w" width=1698>
 >>   ^~~~~~~~~
-transformed_feature_tests/server_side_rendering.html:71:2 The attribute 'class' in tag 'amp-img' is set to the invalid value 'i-amphtml-layout-nodisplay i-amphtml-layout-size-defined'. (see https://amp.dev/documentation/components/amp-img/)
+transformed_feature_tests/server_side_rendering.html:75:2 The attribute 'class' in tag 'amp-img' is set to the invalid value 'i-amphtml-layout-nodisplay i-amphtml-layout-size-defined'. (see https://amp.dev/documentation/components/amp-img/)
 |      <i-amphtml-sizer style=display:block;padding-top:171.4370%;></i-amphtml-sizer>
 |    </amp-img>
 |    <!-- Invalid class attribute value due to layout not being size defined (spaces) -->
 |    <amp-img class="i-amphtml-layout-nodisplay i-amphtml-layout-size-defined" i-amphtml-layout=nodisplay layout=nodisplay></amp-img>
 >>   ^~~~~~~~~
-transformed_feature_tests/server_side_rendering.html:75:2 The attribute 'class' in tag 'amp-img' is set to the invalid value 'i-amphtml-layout-nodisplay i-amphtml-layout-size-defined'. (see https://amp.dev/documentation/components/amp-img/)
+transformed_feature_tests/server_side_rendering.html:79:2 The attribute 'class' in tag 'amp-img' is set to the invalid value 'i-amphtml-layout-nodisplay i-amphtml-layout-size-defined'. (see https://amp.dev/documentation/components/amp-img/)
 |    <!-- Invalid class attribute value due to layout not being size defined (tabs) -->
 |    <amp-img class="i-amphtml-layout-nodisplay  i-amphtml-layout-size-defined" i-amphtml-layout=nodisplay layout=nodisplay></amp-img>
 >>   ^~~~~~~~~
-transformed_feature_tests/server_side_rendering.html:77:2 The attribute 'class' in tag 'amp-img' is set to the invalid value 'i-amphtml-layout-nodisplay i-amphtml-layout-size-defined'. (see https://amp.dev/documentation/components/amp-img/)
+transformed_feature_tests/server_side_rendering.html:81:2 The attribute 'class' in tag 'amp-img' is set to the invalid value 'i-amphtml-layout-nodisplay i-amphtml-layout-size-defined'. (see https://amp.dev/documentation/components/amp-img/)
 |    <!-- Invalid i-amphtml-sizer due to css declarations -->
 |    <amp-img class="i-amphtml-layout-responsive i-amphtml-layout-size-defined" height=2911 i-amphtml-layout=responsive layout=responsive src=https://example-com.cdn.ampproject.org/i/s/example.com/lemur-narrow.jpg srcset="https://example-com.cdn.ampproject.org/i/s/example.com/lemur-wide.jpg 640w, https://example-com.cdn.ampproject.org/i/s/example.com/lemur-narrow.jpg 320w" width=1698>
 |      <i-amphtml-sizer style=display:none;padding-bottom:171.4370%;></i-amphtml-sizer>
 >>     ^~~~~~~~~
-transformed_feature_tests/server_side_rendering.html:80:4 CSS syntax error in tag 'i-amphtml-sizer' - the property 'display' is set to the disallowed value 'none'. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages/)
+transformed_feature_tests/server_side_rendering.html:84:4 CSS syntax error in tag 'i-amphtml-sizer' - the property 'display' is set to the disallowed value 'none'. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages/)
 >>     ^~~~~~~~~
-transformed_feature_tests/server_side_rendering.html:80:4 The property 'padding-bottom' in attribute 'style' in tag 'i-amphtml-sizer' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages/)
+transformed_feature_tests/server_side_rendering.html:84:4 The property 'padding-bottom' in attribute 'style' in tag 'i-amphtml-sizer' is disallowed. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages/)
 |    </amp-img>
 |
 |  </body>

--- a/validator/testdata/transformed_feature_tests/transformed_but_not_identified_transformed.out
+++ b/validator/testdata/transformed_feature_tests/transformed_but_not_identified_transformed.out
@@ -39,7 +39,7 @@ transformed_feature_tests/transformed_but_not_identified_transformed.html:24:2 T
 |  <body>
 |    <amp-img class="i-amphtml-layout-responsive i-amphtml-layout-size-defined" height=2911 i-amphtml-layout=responsive layout=responsive src=https://example-com.cdn.ampproject.org/i/s/example.com/lemur-narrow.jpg srcset="https://example-com.cdn.ampproject.org/i/s/example.com/lemur-wide.jpg 640w, https://example-com.cdn.ampproject.org/i/s/example.com/lemur-narrow.jpg 320w" width=1698>
 >>   ^~~~~~~~~
-transformed_feature_tests/transformed_but_not_identified_transformed.html:31:2 The attribute 'class' in tag 'amp-img' is set to the invalid value 'i-amphtml-layout-responsive i-amphtml-layout-size-defined'. (see https://amp.dev/documentation/components/amp-img/)
+transformed_feature_tests/transformed_but_not_identified_transformed.html:31:2 The attribute 'class' in tag 'amp-img' is set to the invalid value 'i-amphtml-layout-responsive i-amphtml-layout-size-defined'. (see https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages/#disallowed-styles)
 >>   ^~~~~~~~~
 transformed_feature_tests/transformed_but_not_identified_transformed.html:31:2 The attribute 'i-amphtml-layout' may not appear in tag 'amp-img'. (see https://amp.dev/documentation/components/amp-img/)
 |      <i-amphtml-sizer style=display:block;padding-top:171.4370%;></i-amphtml-sizer>

--- a/validator/validator-css.protoascii
+++ b/validator/validator-css.protoascii
@@ -753,7 +753,6 @@ tags: {  # <style amp-custom>, AMP4EMAIL, data-css-strict
       }
       at_rule_spec: { name: 'page' }
       selector_spec: {
-        attribute_name: "foo"
         attribute_name: "active"
         attribute_name: "alt"
         attribute_name: "autocomplete"

--- a/validator/validator-css.protoascii
+++ b/validator/validator-css.protoascii
@@ -842,6 +842,7 @@ tags: {  # `<style amp-boilerplate>`, transformed [AMP, ACTIONS]
   descriptive_name: "head > style[amp-boilerplate]"
   unique: true
   mandatory_parent: "HEAD"
+  attr_lists: "nonce-attr"
   attrs: {
     name: "amp-boilerplate"
     mandatory: true
@@ -940,6 +941,7 @@ tags: {  # `<style amp-boilerplate>`, transformed [AMP, ACTIONS]
   unique: true
   mandatory_parent: "NOSCRIPT"
   mandatory_ancestor: "HEAD"
+  attr_lists: "nonce-attr"
   attrs: {
     name: "amp-boilerplate"
     mandatory: true
@@ -999,6 +1001,7 @@ tags: {  # '<style amp-runtime>`, transformed AMP
   mandatory: true
   unique: true
   mandatory_parent: "HEAD"
+  attr_lists: "nonce-attr"
   attrs: {
     name: "amp-runtime"
     mandatory: true

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -26,7 +26,7 @@ min_validator_revision_required: 475
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 1065
+spec_file_revision: 1066
 
 styles_spec_url: "https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages/"
 script_spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/validation-workflow/validation_errors/#custom-javascript-is-not-allowed"
@@ -1776,7 +1776,7 @@ tags: {
 
 # 4.7 Embedded Content
 # AMP HTML allows embedded content only via its own tags (e.g. amp-img), with
-# the exception of tags inside of a <noscript> ancestor.
+# the exception of tags inside of a <noscript> ancestor and transformed amp-img.
 # 4.7.1 The img element
 tags: {
   html_format: AMP  # Disallowed in AMP4ADS because <noscript> is disallowed.
@@ -4500,6 +4500,42 @@ tags: {  # <amp-img>
     supported_layouts: RESPONSIVE
   }
 }
+# A duplicate of amp-img, but requires i-amphtml-ssr flag.
+tags: {  # <amp-img i-amphtml-ssr>
+  html_format: AMP
+  enabled_by: "transformed"
+  tag_name: "AMP-IMG"
+  spec_name: "amp-img (transformed)"
+  attrs: {
+    dispatch_key: NAME_DISPATCH
+    name: "i-amphtml-ssr"
+    mandatory: true
+  }
+  attrs: { name: "alt" }
+  attrs: { name: "attribution" }
+  attrs: { name: "object-fit" }
+  attrs: { name: "object-position" }
+  attrs: { name: "placeholder" }
+  attrs: { name: "referrerpolicy" }
+  # <amp-bind>
+  attrs: { name: "[alt]" }
+  attrs: { name: "[attribution]" }
+  attrs: { name: "[src]" }
+  attrs: { name: "[srcset]" }
+  attr_lists: "extended-amp-global"
+  attr_lists: "lightboxable-elements"
+  attr_lists: "mandatory-src-or-srcset"
+  spec_url: "https://amp.dev/documentation/components/amp-img/"
+  amp_layout: {
+    supported_layouts: FILL
+    supported_layouts: FIXED
+    supported_layouts: FIXED_HEIGHT
+    supported_layouts: FLEX_ITEM
+    supported_layouts: INTRINSIC
+    supported_layouts: NODISPLAY
+    supported_layouts: RESPONSIVE
+  }
+}
 # See the restrictions on mandatory-src-amp4email, as well as the removal of
 # `object-fit` and `object-position`.
 tags: {  # <amp-img>
@@ -4638,6 +4674,37 @@ tags: {
   attrs: {
     name: "src"
     value_regex: "data:image\\/svg\\+xml;charset=utf-8,\\s*<svg height=\"\\d+(\\.\\d+)?\" width=\"\\d+(\\.\\d+)?\" xmlns=\"http:\\/\\/www\\.w3\\.org\\/2000\\/svg\" version=\"1\\.1\"\\/>|data:image\\/svg\\+xml;charset=utf-8,\\s*<svg height='\\d+(\\.\\d+)?\' width='\\d+(\\.\\d+)?\' xmlns='http:\\/\\/www\\.w3\\.org\\/2000\\/svg' version='1\\.1'\\/>|data:image\\/svg\\+xml;base64,[a-zA-Z0-9+\\/=]+"
+    mandatory: true
+  }
+}
+
+tags: {
+  html_format: AMP
+  enabled_by: "transformed"
+  tag_name: "IMG"
+  spec_name: "amp-img > img (transformed)"
+  # Ideally we'd be able to use regular amp-img parent, but runtime currently
+  # requires an i-amphtml-ssr attribute on the amp-img. We could do away with
+  # that, though.
+  mandatory_parent: "amp-img (transformed)"
+  attrs: { name: "alt" }
+  attrs: { name: "attribution" }
+  attrs: { name: "object-fit" }
+  attrs: { name: "object-position" }
+  attrs: { name: "referrerpolicy" }
+  attrs: { name: "sizes" }
+  attrs: { name: "title" }
+  attr_lists: "mandatory-src-or-srcset"
+  # SSR requires these explicit attributes
+  attrs: {
+    name: "class"
+    value_regex: "i-amphtml-fill-content\\s+i-amphtml-replaced-content|"
+        "i-amphtml-replaced-content\\s+i-amphtml-fill-content"
+    mandatory: true
+  }
+  attrs: {
+    name: "decoding"
+    value: "async"
     mandatory: true
   }
 }

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -26,7 +26,7 @@ min_validator_revision_required: 475
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 1064
+spec_file_revision: 1065
 
 styles_spec_url: "https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages/"
 script_spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/validation-workflow/validation_errors/#custom-javascript-is-not-allowed"
@@ -5780,6 +5780,12 @@ attr_lists: {
   attrs: {
     name: "subscriptions-service"
     requires_extension: "amp-subscriptions"
+  }
+  # amp-subscriptions-google specific attributes, see
+  # https://amp.dev/documentation/components/amp-subscriptions-google
+  attrs: {
+    name: "subscriptions-google-rtc"
+    requires_extension: "amp-subscriptions-google"
   }
   # amp-subscriptions-google specific attributes, see
   # https://amp.dev/documentation/components/amp-subscriptions-google

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -26,7 +26,7 @@ min_validator_revision_required: 475
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 1062
+spec_file_revision: 1063
 
 styles_spec_url: "https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages/"
 script_spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/validation-workflow/validation_errors/#custom-javascript-is-not-allowed"
@@ -4509,7 +4509,6 @@ tags: {  # <amp-img>
   attrs: { name: "alt" }
   attrs: { name: "attribution" }
   attrs: { name: "placeholder" }
-  attrs: { name: "referrerpolicy" }
   attr_lists: "extended-amp-global"
   attr_lists: "mandatory-src-amp4email"
   # <amp-bind>

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -20,13 +20,13 @@
 # in production from crashing. This id is not relevant to validator.js
 # because thus far, engine (validator.js) and spec file
 # (validator-main.protoascii, etc) are always released together.
-min_validator_revision_required: 474
+min_validator_revision_required: 475
 
 # The spec file revision allows the validator engine to distinguish
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 1060
+spec_file_revision: 1061
 
 styles_spec_url: "https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages/"
 script_spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/validation-workflow/validation_errors/#custom-javascript-is-not-allowed"
@@ -4627,6 +4627,11 @@ tags: {
     mandatory: true
   }
   attrs: {
+    name: "class"
+    value: "i-amphtml-intrinsic-sizer"
+    mandatory: true
+  }
+  attrs: {
     name: "role"
     value: "presentation"
     mandatory: true
@@ -5478,12 +5483,11 @@ attr_lists: {
   # 3.2.5 HTML5 Global attributes.
   attrs: { name: "accesskey" }
   attrs: {
-    # attribute "class" for transformed is handled within the Validator engine.
-    # If this changes, please be sure to also update:
-    # amp-experiment 1.0 implementation.
-    disabled_by: "transformed"
     name: "class"
-    disallowed_value_regex: "(^|\\W)i-amphtml-"
+    # attribute "class" is handled within the Validator engine, since we need to
+    # handle transformed and non-transformed cases while still allowing "class"
+    # attribute generically.
+    # disallowed_value_regex: "(^|[\t\n\f\r ])i-amphtml-"
   }
   attrs: { name: "dir" }
   attrs: { name: "draggable" }

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -26,7 +26,7 @@ min_validator_revision_required: 475
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 1061
+spec_file_revision: 1062
 
 styles_spec_url: "https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages/"
 script_spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/validation-workflow/validation_errors/#custom-javascript-is-not-allowed"

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -5787,12 +5787,6 @@ attr_lists: {
     name: "subscriptions-google-rtc"
     requires_extension: "amp-subscriptions-google"
   }
-  # amp-subscriptions-google specific attributes, see
-  # https://amp.dev/documentation/components/amp-subscriptions-google
-  attrs: {
-    name: "subscriptions-google-rtc"
-    requires_extension: "amp-subscriptions-google"
-  }
   # amp-next-page specific attributes, see
   # https://amp.dev/documentation/components/amp-next-page
   attrs: {

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -26,7 +26,7 @@ min_validator_revision_required: 475
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 1068
+spec_file_revision: 1069
 
 styles_spec_url: "https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages/"
 script_spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/validation-workflow/validation_errors/#custom-javascript-is-not-allowed"

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -26,7 +26,7 @@ min_validator_revision_required: 475
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 1063
+spec_file_revision: 1064
 
 styles_spec_url: "https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages/"
 script_spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/validation-workflow/validation_errors/#custom-javascript-is-not-allowed"

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -26,7 +26,7 @@ min_validator_revision_required: 475
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 1066
+spec_file_revision: 1067
 
 styles_spec_url: "https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages/"
 script_spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/validation-workflow/validation_errors/#custom-javascript-is-not-allowed"
@@ -4737,7 +4737,6 @@ attr_lists: {
   name: "nonce-attr"
   attrs: {
     disabled_by: "amp4email"
-    disabled_by: "transformed"
     name: "nonce"
   }
 }
@@ -4756,7 +4755,6 @@ attr_lists: {
     value: "anonymous"
   }
   attrs: {
-    disabled_by: "transformed"
     disabled_by: "amp4email"
     name: "nonce"
   }

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -26,7 +26,7 @@ min_validator_revision_required: 475
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 1067
+spec_file_revision: 1068
 
 styles_spec_url: "https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages/"
 script_spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/validation-workflow/validation_errors/#custom-javascript-is-not-allowed"


### PR DESCRIPTION
 - cl/322254670 Revision bump for #29327
 - cl/321989558 Fix small discrepancy in parsing qualified rules between C++ and JS.
 - cl/321822274 Revision bump for #29235
 - cl/321630472 Allow nonces in transformed AMP documents.
 - cl/321463348 Allow SSR for amp-img's img
 - remove duplicate
 - cl/320987796 Revision bump for #26223
 - cl/320436845 Remove accidental 'foo' attribute selector from email css spec.
 - cl/320241466 Remove referrerpolicy from amp-img on amp4email
 - cl/319802856 Revision bump for #29104
 - cl/319301388 Require i-amphtml-intrinsic-sizer class in transformed intrinsic output
