### PR TITLE
🐛  Allow `select` and `use` as descendants of mega-menu and nested-menu

### DIFF
--- a/extensions/amp-mega-menu/validator-amp-mega-menu.protoascii
+++ b/extensions/amp-mega-menu/validator-amp-mega-menu.protoascii
@@ -203,6 +203,7 @@ descendant_tag_list {
   tag: "P"
   tag: "PATH"
   tag: "SECTION"
+  tag: "SELECT"
   tag: "SPAN"
   tag: "STRIKE"
   tag: "STRONG"
@@ -219,4 +220,5 @@ descendant_tag_list {
   tag: "TR"
   tag: "U"
   tag: "UL"
+  tag: "USE"
 }

--- a/extensions/amp-nested-menu/validator-amp-nested-menu.protoascii
+++ b/extensions/amp-nested-menu/validator-amp-nested-menu.protoascii
@@ -156,6 +156,7 @@ descendant_tag_list {
   tag: "P"
   tag: "PATH"
   tag: "SECTION"
+  tag: "SELECT"
   tag: "SPAN"
   tag: "STRIKE"
   tag: "STRONG"
@@ -172,4 +173,5 @@ descendant_tag_list {
   tag: "TR"
   tag: "U"
   tag: "UL"
+  tag: "USE"
 }


### PR DESCRIPTION
Closes #29300