### PR TITLE
ContextNode: components, subscribers, and hooks

### DIFF
--- a/src/context/component-hooks.js
+++ b/src/context/component-hooks.js
@@ -1,0 +1,191 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {devAssert} from '../log';
+import {protectedNoInline} from './scheduler';
+
+const EMPTY_DEPS = [];
+
+/**
+ * @type {!./component.Component|undefined}
+ */
+let currentComponent;
+
+/**
+ * Sets the component as a current component and executes the callback. Clears
+ * out the current component after the callback is done.
+ *
+ * @param {!./component.Component} component
+ * @param {function()} callback
+ * @package
+ */
+export function withComponent(component, callback) {
+  currentComponent = component;
+  try {
+    callback();
+  } finally {
+    currentComponent = undefined;
+  }
+}
+
+/**
+ * @return {!./component.Component}
+ */
+function getComponent() {
+  return devAssert(currentComponent);
+}
+
+/**
+ * A reusable reference value hook. Mostly the same as the React's `useHook`.
+ *
+ * @param {T} def
+ * @return {{current: T}}
+ * @template T
+ */
+export function useRef(def = undefined) {
+  return getComponent().allocRef(def);
+}
+
+/**
+ * A hook to compute a persistent value. Mostly the same as the React's
+ * `useMemo` API.
+ *
+ * @param {function():T} compute
+ * @param {!Array} deps
+ * @return {T}
+ * @template T
+ */
+export function useMemo(compute, deps) {
+  const ref = useRef();
+  useSyncEffect(() => {
+    ref.current = compute();
+  }, deps);
+  return ref.current;
+}
+
+/**
+ * Functions similarly to `useMemo`, but besides being able to return a computed
+ * value, it also provides a cleanup callback.
+ *
+ * @param {function(!Node, ...?):({value: T, dispose: function()}|function())} factory
+ * @param {!Array=} deps
+ * @return {T}
+ * @template T
+ */
+export function useDisposable(factory, deps = undefined) {
+  deps = deps || EMPTY_DEPS;
+  const component = getComponent();
+  const ref = component.allocRef();
+  useSyncEffect(() => {
+    const result = callFactory(
+      factory,
+      component.contextNode.node,
+      devAssert(deps)
+    );
+    let value, dispose;
+    if (typeof result == 'function') {
+      dispose = result;
+    } else {
+      ({value, dispose} = result);
+    }
+    ref.current = value;
+    return () => {
+      ref.current = undefined;
+      if (dispose) {
+        dispose();
+      }
+    };
+  }, deps);
+  return ref.current;
+}
+
+/**
+ * Similar to the React's `useEffect`, but it's executed synchronously.
+ * Another distinction: if the `deps` argument is not provided, it's assumed
+ * to be an empty array.
+ *
+ * @param {function():(void|function())} callback
+ * @param {!Array=} deps
+ */
+export function useSyncEffect(callback, deps = undefined) {
+  deps = deps || EMPTY_DEPS;
+  const component = getComponent();
+  const depRef = component.allocRef();
+  const cleanupRef = component.allocRef();
+  if (!depRef.current) {
+    // Mounting.
+    component.pushCleanup(() => {
+      depRef.current = undefined;
+      cleanupRef.current = undefined;
+    });
+  }
+  const changed = !depRef.current || !eq(depRef.current, deps);
+  if (changed) {
+    depRef.current = deps.slice(0);
+
+    // Cleanup.
+    const cleanup = cleanupRef.current;
+    if (cleanup) {
+      cleanupRef.current = null;
+      component.popCleanup(cleanup);
+      protectedNoInline(cleanup);
+    }
+
+    const newCleanup = callback();
+    if (newCleanup) {
+      cleanupRef.current = newCleanup;
+      component.pushCleanup(newCleanup);
+    }
+  }
+}
+
+/**
+ * @param {!Array} a1
+ * @param {!Array} a2
+ * @return {boolean}
+ */
+function eq(a1, a2) {
+  if (a1.length != a2.length) {
+    return false;
+  }
+  for (let i = 0; i < a1.length; i++) {
+    if (a1[i] !== a2[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * @param {function(...?):?} factory
+ * @param {!Node} node
+ * @param {!Array} deps
+ * @return {?}
+ */
+function callFactory(factory, node, deps) {
+  switch (deps.length) {
+    case 0:
+      return factory(node);
+    case 1:
+      return factory(node, deps[0]);
+    case 2:
+      return factory(node, deps[0], deps[1]);
+    case 3:
+      return factory(node, deps[0], deps[1], deps[2]);
+    default:
+      return factory.apply(null, [node].concat(deps));
+  }
+}

--- a/src/context/component-install.js
+++ b/src/context/component-install.js
@@ -84,7 +84,7 @@ export function unsubscribe(node, callback) {
 }
 
 /**
- * Creates an input-based comonent.
+ * Creates an input-based component.
  *
  * @param {*} id
  * @param {!./node.ContextNode} contextNode

--- a/src/context/component-install.js
+++ b/src/context/component-install.js
@@ -1,0 +1,139 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Component} from './component';
+import {ContextNode} from './node';
+import {getDeps, getId} from './component-meta';
+import {isArray} from '../types';
+
+const NO_INPUT = undefined;
+
+/**
+ * Installs or updates the component specified by its function. The component
+ * function can be optionally annotated with `withMetaData` to provide
+ * dependencies. Some key points:
+ * - The component is only called when all dependencies are satisfied.
+ * - The component is only called when either an input or any dependencies
+ *   change.
+ * - A component can optionally return a cleanup function.
+ *
+ * @param {!Node} node
+ * @param {function(!Node, I, ...?)} func
+ * @param {I} input
+ * @template I
+ */
+export function setComponent(node, func, input = undefined) {
+  const id = getId(func);
+  const deps = getDeps(func);
+  const contextNode = ContextNode.get(node);
+  contextNode.setComponent(id, componentWithInputFactory, func, deps, input);
+}
+
+/**
+ * Removes the component that has been previously installed with `setComponent`.
+ *
+ * @param {!Node} node
+ * @param {function(...?)} func
+ */
+export function removeComponent(node, func) {
+  const id = getId(func);
+  const contextNode = ContextNode.get(node);
+  contextNode.removeComponent(id);
+}
+
+/**
+ * Subscribes to the specified dependencies. The key API points:
+ * - The subscriber is only called when all its dependencies are satisfied.
+ * - If all its dependencies are satisfied at the time the subscriber is added,
+ *   it's called right away.
+ * - The subscriber is called whenever any of its dependencies change.
+ * - A subscriber can optionally return a cleanup function.
+ *
+ * @param {!Node} node
+ * @param {!ContextProp|!Array<!ContextProp>} deps
+ * @param {function(...?)} callback
+ */
+export function subscribe(node, deps, callback) {
+  deps = isArray(deps) ? /** @type {!Array<!ContextProp>} */ (deps) : [deps];
+  const id = getId(callback);
+  const contextNode = ContextNode.get(node);
+  contextNode.setComponent(id, subscriberFactory, callback, deps, NO_INPUT);
+}
+
+/**
+ * Removes the subscriber prevoiously registered with `subscribe` API.
+ *
+ * @param {!Node} node
+ * @param {function(...?)} callback
+ */
+export function unsubscribe(node, callback) {
+  removeComponent(node, callback);
+}
+
+/**
+ * Creates an input-based comonent.
+ *
+ * @param {*} id
+ * @param {!./node.ContextNode} contextNode
+ * @param {function(!Node, ...?)} func
+ * @param {!Array<!ContextProp>} deps
+ * @return {!./component.Component}
+ */
+function componentWithInputFactory(id, contextNode, func, deps) {
+  const comp = (component, input, deps) => {
+    const {node} = component.contextNode;
+    switch (deps.length) {
+      case 0:
+        return func(node, input);
+      case 1:
+        return func(node, input, deps[0]);
+      case 2:
+        return func(node, input, deps[0], deps[1]);
+      case 3:
+        return func(node, input, deps[0], deps[1], deps[2]);
+      default:
+        return func.apply(null, [node, input].concat(deps));
+    }
+  };
+  return new Component(id, contextNode, comp, deps);
+}
+
+/**
+ * Creates a subscriber.
+ *
+ * @param {*} id
+ * @param {!./node.ContextNode} contextNode
+ * @param {function(...?)} callback
+ * @param {!Array<!ContextProp>} deps
+ * @return {!./component.Component}
+ */
+function subscriberFactory(id, contextNode, callback, deps) {
+  const comp = (component, unusedInput, deps) => {
+    switch (deps.length) {
+      case 0:
+        return callback();
+      case 1:
+        return callback(deps[0]);
+      case 2:
+        return callback(deps[0], deps[1]);
+      case 3:
+        return callback(deps[0], deps[1], deps[2]);
+      default:
+        return callback.apply(null, deps);
+    }
+  };
+  return new Component(id, contextNode, comp, deps);
+}

--- a/src/context/component-meta.js
+++ b/src/context/component-meta.js
@@ -1,0 +1,86 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {devAssert} from '../log';
+
+const EMPTY_DEPS = [];
+
+/**
+ * The following arguments are expected:
+ * - a required component function.
+ * - an optional array of `ContextProp` dependencies.
+ * - an optional string key for a global component identifier.
+ *
+ * Returns the provided function with metadata attached to it.
+ *
+ * @param {...?} args
+ * @return {function(...?):?}
+ */
+export function withMetaData(...args) {
+  let func, deps, key;
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (typeof arg == 'function') {
+      func = arg;
+    } else if (typeof arg == 'string') {
+      key = arg;
+    } else {
+      deps = arg;
+    }
+  }
+  devAssert(func);
+  return setMetaData(func, deps, key);
+}
+
+/**
+ * Returns the dependencies attached to the component function. If none
+ * available, defaults to an empty array.
+ *
+ * @param {function(...?):?} func
+ * @return {!Array<!ContextProp>}
+ * @package
+ */
+export function getDeps(func) {
+  return func['deps'] || EMPTY_DEPS;
+}
+
+/**
+ * Returns the component's ID. If none is available, defaults to the function's
+ * identity.
+ *
+ * @param {function(...?):?} func
+ * @return {*}
+ * @package
+ */
+export function getId(func) {
+  return func['key'] || func;
+}
+
+/**
+ * @param {!Function} func
+ * @param {!Array<!ContextProp>|undefined} deps
+ * @param {string|undefined} key
+ * @return {function(...?):?}
+ */
+function setMetaData(func, deps, key) {
+  if (deps) {
+    func['deps'] = deps;
+  }
+  if (key) {
+    func['key'] = key;
+  }
+  return func;
+}

--- a/src/context/component-meta.js
+++ b/src/context/component-meta.js
@@ -14,9 +14,6 @@
  * limitations under the License.
  */
 
-import {devAssert} from '../log';
-import {isArray} from '../types';
-
 const EMPTY_DEPS = [];
 
 /**
@@ -27,25 +24,13 @@ const EMPTY_DEPS = [];
  *
  * Returns the provided function with metadata attached to it.
  *
- * @param {...?} args
+ * @param {!Array<!ContextProp>} deps
+ * @param {function(...?):?} func
+ * @param {string=} opt_key
  * @return {function(...?):?}
  */
-export function withMetaData(...args) {
-  let func, deps, key;
-  for (let i = 0; i < args.length; i++) {
-    const arg = args[i];
-    if (typeof arg == 'function') {
-      func = arg;
-    } else if (typeof arg == 'string') {
-      key = arg;
-    } else if (isArray(arg)) {
-      deps = arg;
-    } else {
-      devAssert(false);
-    }
-  }
-  devAssert(func);
-  return setMetaData(func, deps, key);
+export function withMetaData(deps, func, opt_key) {
+  return setMetaData(func, deps, opt_key);
 }
 
 /**

--- a/src/context/component-meta.js
+++ b/src/context/component-meta.js
@@ -15,6 +15,7 @@
  */
 
 import {devAssert} from '../log';
+import {isArray} from '../types';
 
 const EMPTY_DEPS = [];
 
@@ -37,8 +38,10 @@ export function withMetaData(...args) {
       func = arg;
     } else if (typeof arg == 'string') {
       key = arg;
-    } else {
+    } else if (isArray(arg)) {
       deps = arg;
+    } else {
+      devAssert(false);
     }
   }
   devAssert(func);

--- a/src/context/component.js
+++ b/src/context/component.js
@@ -1,0 +1,261 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {protectedNoInline, throttleTail} from './scheduler';
+import {pushIfNotExist, removeItem} from '../utils/array';
+import {withComponent} from './component-hooks';
+
+const EMPTY_ARRAY = [];
+const EMPTY_FUNC = () => {};
+
+/**
+ * @typedef {function(*, !./node.ContextNode, !Function, !Array<ContextProp>):!Component}
+ * @package
+ *
+ * The factory arguments are:
+ * 1. An opaque ID value.
+ * 2. The context node where component is attached.
+ * 3. The component's function.
+ * 4. An array of dependencies.
+ */
+export let ComponentFactoryDef;
+
+/**
+ * The component holder. It encapsulates the component's dependencies, input,
+ * internal state, and cleanup functions.
+ *
+ * @package
+ */
+export class Component {
+  /**
+   * @param {*} id An opaque component ID.
+   * @param {!./node.ContextNode} contextNode
+   * @param {!Function} func
+   * @param {!Array<!ContextProp>} deps
+   */
+  constructor(id, contextNode, func, deps) {
+    /** @package @const {*} */
+    this.id = id;
+
+    /** @package @const {!./node.ContextNode} */
+    this.contextNode = contextNode;
+
+    /** @private @const {!Function} */
+    this.func_ = func;
+
+    /** @private @const {!Array<!ContextProp>} */
+    this.deps_ = deps;
+
+    /** @private @const {!Array} */
+    this.depValues_ = deps.length > 0 ? deps.map(EMPTY_FUNC) : EMPTY_ARRAY;
+
+    /** @private @const {!Array<function(*)>} */
+    this.depSubscribers_ =
+      deps.length > 0
+        ? deps.map((dep, index) => (value) => {
+            this.depValues_[index] = value;
+            this.update_();
+          })
+        : EMPTY_ARRAY;
+
+    /** @private {*|undefined} */
+    this.input_ = undefined;
+
+    /** @private {boolean} */
+    this.running_ = false;
+
+    /** @private {?Array<{current: ?}>} */
+    this.refs_ = null;
+
+    /** @private {number} */
+    this.refPointer_ = -1;
+
+    /** @private {?function()} */
+    this.runCleanup_ = null;
+
+    /** @private {?Array<function()>} */
+    this.cleanups_ = null;
+
+    // Schedulers.
+    /** @private @const {function()} */
+    this.update_ = throttleTail(this.update_.bind(this), setTimeout);
+
+    /** @private @const {function()} */
+    this.run_ = this.run_.bind(this);
+
+    // Subscribe to all dependencies.
+    if (deps.length > 0) {
+      const {values} = this.contextNode;
+      deps.forEach((dep, index) =>
+        values.subscribe(dep, this.depSubscribers_[index])
+      );
+    }
+
+    // Run the first time.
+    if (this.isConnected_()) {
+      this.update_();
+    }
+  }
+
+  /**
+   * Called when the component is completely discarded, for instance via
+   * `removeComponent` API.
+   */
+  dispose() {
+    // Unsubscribe from all dependencies.
+    if (this.deps_.length > 0) {
+      const {values} = this.contextNode;
+      this.deps_.forEach((dep, index) =>
+        values.unsubscribe(dep, this.depSubscribers_[index])
+      );
+    }
+
+    this.cleanup_();
+  }
+
+  /**
+   * Called when the node's root has changed. It can be a different root or
+   * the node can be disconnected entirely.
+   */
+  rootUpdated() {
+    const isConnected = this.isConnected_();
+    this.cleanup_();
+    if (isConnected) {
+      this.update_();
+    }
+  }
+
+  /**
+   * Sets the component's input.
+   * @param {*} input
+   */
+  set(input) {
+    if (this.input_ !== input) {
+      this.input_ = input;
+      if (this.isConnected_()) {
+        this.update_();
+      }
+    }
+  }
+
+  /**
+   * Allocates a new reference in the component's internal state.
+   *
+   * See `useRef` hook for more info.
+   *
+   * @param {T} def
+   * @return {{current: T}}
+   * @template T
+   */
+  allocRef(def = undefined) {
+    const refs = this.refs_ || (this.refs_ = []);
+    const pointer = ++this.refPointer_;
+    return refs[pointer] || (refs[pointer] = {current: def});
+  }
+
+  /**
+   * Register a cleanup handler that will be called when the component is
+   * cleaned up, either due to the node being disconnected, or the component
+   * being removed.
+   *
+   * @param {function()} cleanup
+   */
+  pushCleanup(cleanup) {
+    const cleanups = this.cleanups_ || (this.cleanups_ = []);
+    pushIfNotExist(cleanups, cleanup);
+  }
+
+  /**
+   * Unregisters a cleanup handler previously registered with `pushCleanup`.
+   *
+   * @param {function()} cleanup
+   */
+  popCleanup(cleanup) {
+    const cleanups = this.cleanups_;
+    if (cleanups) {
+      removeItem(cleanups, cleanup);
+    }
+  }
+
+  /**
+   * @return {boolean}
+   * @private
+   */
+  isConnected_() {
+    return !!this.contextNode.root;
+  }
+
+  /** @private */
+  update_() {
+    if (!this.isConnected_()) {
+      // The node was disconnected at some point.
+      return;
+    }
+    const running = this.depValues_.every(isDefined);
+    if (running) {
+      this.running_ = true;
+      this.refPointer_ = -1;
+      withComponent(this, this.run_);
+    } else if (this.running_) {
+      this.running_ = false;
+      this.cleanup_();
+    }
+  }
+
+  /** @private */
+  run_() {
+    // Cleanup the previous run.
+    if (this.runCleanup_) {
+      protectedNoInline(this.runCleanup_);
+      this.runCleanup_ = null;
+    }
+
+    // Run the component.
+    const func = this.func_;
+    this.runCleanup_ = func(this, this.input_, this.depValues_);
+  }
+
+  /** @private */
+  cleanup_() {
+    // The last run's cleanup.
+    if (this.runCleanup_) {
+      protectedNoInline(this.runCleanup_);
+      this.runCleanup_ = null;
+    }
+
+    // Hook cleanups.
+    const cleanups = this.cleanups_;
+    if (cleanups) {
+      for (let i = 0; i < cleanups.length; i++) {
+        protectedNoInline(cleanups[i]);
+      }
+      this.cleanups_.length = 0;
+    }
+  }
+}
+
+/**
+ * Whether the value is defined.
+ *
+ * This function only exists to avoid function allocation when calling
+ * `Array.every()` and `Array.some()`.
+ *
+ * @param {*} v
+ * @return {boolean}
+ */
+function isDefined(v) {
+  return v !== undefined;
+}

--- a/src/context/component.js
+++ b/src/context/component.js
@@ -65,7 +65,7 @@ export class Component {
     /** @private @const {!Array<function(*)>} */
     this.depSubscribers_ =
       deps.length > 0
-        ? deps.map((dep, index) => (value) => {
+        ? deps.map((unusedDep, index) => (value) => {
             this.depValues_[index] = value;
             this.update_();
           })

--- a/src/context/component.js
+++ b/src/context/component.js
@@ -59,7 +59,12 @@ export class Component {
     /** @private @const {!Array<!ContextProp>} */
     this.deps_ = deps;
 
-    /** @private @const {!Array} */
+    /**
+     * @private @const {!Array}
+     *
+     * Start with a pre-allocated array filled with `undefined`. The filling
+     * is important to ensure the correct `Array.every` execution.
+     */
     this.depValues_ = deps.length > 0 ? deps.map(EMPTY_FUNC) : EMPTY_ARRAY;
 
     /** @private @const {!Array<function(*)>} */

--- a/src/context/index.js
+++ b/src/context/index.js
@@ -14,9 +14,17 @@
  * limitations under the License.
  */
 
-export {contextProp} from './prop';
-
 import {ContextNode} from './node';
+
+export {contextProp} from './prop';
+export {withMetaData} from './component-meta';
+export {
+  setComponent,
+  removeComponent,
+  subscribe,
+  unsubscribe,
+} from './component-install';
+export {useRef, useMemo, useDisposable, useSyncEffect} from './component-hooks';
 
 /**
  * Direct slot assignment. Works the same way as shadow slots, but does not

--- a/src/context/index.js
+++ b/src/context/index.js
@@ -24,7 +24,12 @@ export {
   subscribe,
   unsubscribe,
 } from './component-install';
-export {useRef, useMemo, useDisposable, useSyncEffect} from './component-hooks';
+export {
+  useRef,
+  useMemo,
+  useDisposableMemo,
+  useSyncEffect,
+} from './component-hooks';
 
 /**
  * Direct slot assignment. Works the same way as shadow slots, but does not

--- a/src/context/scheduler.js
+++ b/src/context/scheduler.js
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import {rethrowAsync} from '../log';
+
 /**
  * Creates a scheduling function that executes the callback based on the
  * scheduler, but only one task at a time.
@@ -39,4 +41,20 @@ export function throttleTail(handler, defaultScheduler = null) {
     }
   };
   return scheduleIfNotScheduled;
+}
+
+/**
+ * Executes the provided callback in a try/catch and rethrows any errors
+ * asynchronously. To be used by schedules to avoid errors interrupting
+ * queues.
+ *
+ * @param {function():*} callback
+ * @return {*}
+ */
+export function protectedNoInline(callback) {
+  try {
+    return callback();
+  } catch (e) {
+    rethrowAsync(e);
+  }
 }

--- a/test/unit/context/test-node-components.js
+++ b/test/unit/context/test-node-components.js
@@ -35,7 +35,7 @@ const NonRecursive = contextProp('NonRecursive');
 const Concat = contextProp('Concat', {
   needsParent: true,
   compute: (contextNode, inputs, parentValue) =>
-    `${parentValue}${inputs.length > 1 ? `(${inputs.join('|')})` : inputs[0]}`,
+    `${parentValue}${inputs.join('|')}`,
   defaultValue: '',
 });
 
@@ -162,7 +162,7 @@ describes.realWin('ContextNode - components', {}, (env) => {
 
       beforeEach(() => {
         component1Spy = sandbox.spy();
-        Component1 = withMetaData(component1Spy);
+        Component1 = withMetaData([], component1Spy);
 
         componentWithDepsSpy = sandbox.spy();
         ComponentWithDeps = withMetaData(

--- a/test/unit/context/test-node-components.js
+++ b/test/unit/context/test-node-components.js
@@ -1,0 +1,631 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {ContextNode} from '../../../src/context/node';
+import {contextProp} from '../../../src/context/prop';
+import {
+  removeComponent,
+  setComponent,
+  subscribe,
+  unsubscribe,
+} from '../../../src/context/component-install';
+import {
+  useDisposable,
+  useMemo,
+  useRef,
+  useSyncEffect,
+} from '../../../src/context/component-hooks';
+import {withMetaData} from '../../../src/context/component-meta';
+
+const NonRecursive = contextProp('NonRecursive');
+
+const Concat = contextProp('Concat', {
+  needsParent: true,
+  compute: (contextNode, inputs, parentValue) =>
+    `${parentValue}${inputs.length > 1 ? `(${inputs.join('|')})` : inputs[0]}`,
+  defaultValue: '',
+});
+
+describes.realWin('ContextNode - components', {}, (env) => {
+  let sandbox;
+  let win, doc;
+  let tree;
+  let clock;
+  let discoverWrapper;
+
+  beforeEach(() => {
+    sandbox = env.sandbox;
+    win = env.win;
+    doc = win.document;
+    clock = sandbox.useFakeTimers();
+
+    tree = (() => {
+      function createSubtree(id, children, depth) {
+        const el = doc.createElement('div');
+        el.id = id;
+        el.textContent = id;
+        if (depth > 1) {
+          for (let i = 0; i < children; i++) {
+            const child = createSubtree(`${id}-${i + 1}`, children, depth - 1);
+            el.appendChild(child);
+          }
+        }
+        return el;
+      }
+      return createSubtree('T', 4, 4);
+    })();
+
+    discoverWrapper = wrapper(ContextNode.prototype, 'discover_');
+
+    // Customize output of the ContextNode for easy debug.
+    ContextNode.prototype.inspect = function () {
+      const contextNode = this;
+      return `ContextNode(${contextNode.node.id || contextNode.node.nodeName})`;
+    };
+  });
+
+  afterEach(() => {
+    delete ContextNode.prototype.inspect;
+  });
+
+  function el(id) {
+    if (id == 'T') {
+      return tree;
+    }
+    const found = tree.querySelector(`#${id}`);
+    if (!found) {
+      throw new Error(`element not found ${id}`);
+    }
+    return found;
+  }
+
+  /**
+   * @param {Object} obj
+   * @param {string} name
+   */
+  function wrapper(obj, name) {
+    const original = obj[name];
+    const stub = env.sandbox.stub(ContextNode.prototype, name);
+    const wrapperName = `__wrapper_${name}`;
+    stub.callsFake(function (...args) {
+      const obj = this;
+      const resolvers = obj[wrapperName] ?? (obj[wrapperName] = []);
+      const result = original.apply(this, args);
+      const current = resolvers.slice(0);
+      resolvers.length = 0;
+      current.forEach((resolver) => resolver(result));
+      return result;
+    });
+    return {
+      spy: stub,
+      waitFor: (obj) => {
+        const resolvers = obj[wrapperName] ?? (obj[wrapperName] = []);
+        return new Promise((resolve) => {
+          resolvers.push(resolve);
+        });
+      },
+    };
+  }
+
+  function waitForDiscover(...nodesOrContextNodes) {
+    const contextNodes = nodesOrContextNodes.map((arg) =>
+      arg.nodeType ? ContextNode.get(arg) : arg
+    );
+    const promises = contextNodes.map((contextNode) =>
+      discoverWrapper.waitFor(contextNode)
+    );
+    clock.tick(1);
+    return Promise.all(promises);
+  }
+
+  function rediscover(...nodesOrContextNodes) {
+    const contextNodes = nodesOrContextNodes.map((arg) =>
+      arg.nodeType ? ContextNode.get(arg) : arg
+    );
+    contextNodes.forEach((cn) => cn.discover());
+    return waitForDiscover.apply(null, contextNodes);
+  }
+
+  describe('connected', () => {
+    let sibling1;
+    let sibling2;
+    let cousin1;
+    let parent;
+    let grandparent;
+
+    beforeEach(async () => {
+      doc.body.appendChild(tree);
+      sibling1 = ContextNode.get(el('T-1-1-1'));
+      sibling2 = ContextNode.get(el('T-1-1-2'));
+      cousin1 = ContextNode.get(el('T-1-2-1'));
+      parent = ContextNode.get(el('T-1-1'));
+      grandparent = ContextNode.get(el('T-1'));
+      await waitForDiscover(grandparent, parent, sibling1, sibling2, cousin1);
+    });
+
+    describe('component', () => {
+      let Component1, component1Spy;
+      let ComponentWithDeps, componentWithDepsSpy;
+      let ComponentWithCleanup, componentWithCleanupSpy, cleanupSpy;
+
+      beforeEach(() => {
+        component1Spy = sandbox.spy();
+        Component1 = withMetaData(component1Spy);
+
+        componentWithDepsSpy = sandbox.spy();
+        ComponentWithDeps = withMetaData(
+          [NonRecursive, Concat],
+          componentWithDepsSpy
+        );
+
+        componentWithCleanupSpy = sandbox.spy();
+        cleanupSpy = sandbox.spy();
+        ComponentWithCleanup = (...args) => {
+          componentWithCleanupSpy.apply(null, args);
+          return cleanupSpy;
+        };
+      });
+
+      it('should only call component once w/o input', () => {
+        setComponent(parent.node, Component1);
+        expect(component1Spy).to.not.be.called;
+
+        clock.runAll();
+        expect(component1Spy).to.be.calledOnce.calledWith(
+          parent.node,
+          undefined
+        );
+
+        setComponent(parent.node, Component1);
+        clock.runAll();
+        expect(component1Spy).to.be.calledOnce; // no changes.
+      });
+
+      it('should only call component once per input', () => {
+        setComponent(parent.node, Component1, 1);
+        clock.runAll();
+        expect(component1Spy).to.be.calledOnce.calledWith(parent.node, 1);
+
+        // Rerun the component due to the input change.
+        setComponent(parent.node, Component1, 2);
+        clock.runAll();
+        expect(component1Spy).to.be.calledTwice.calledWith(parent.node, 2);
+
+        // Input didn't change - do not rerun.
+        setComponent(parent.node, Component1, 2);
+        clock.runAll();
+        expect(component1Spy).to.be.calledTwice;
+      });
+
+      it('should reconnect component when the node is reconnected', async () => {
+        setComponent(parent.node, Component1, 1);
+        clock.runAll();
+        expect(component1Spy).to.be.calledOnce.calledWith(parent.node, 1);
+
+        parent.node.remove();
+        await rediscover(parent);
+        clock.runAll();
+
+        setComponent(parent.node, Component1, 2);
+        clock.runAll();
+        expect(component1Spy).to.be.calledOnce;
+
+        grandparent.node.appendChild(parent.node);
+        await rediscover(parent);
+        clock.runAll();
+        expect(component1Spy).to.be.calledTwice.calledWith(parent.node, 2);
+      });
+
+      it('should wait until all deps satisfied', () => {
+        setComponent(parent.node, ComponentWithDeps, 1);
+
+        clock.runAll();
+        expect(componentWithDepsSpy).to.not.be.called;
+
+        grandparent.values.set(Concat, 'OWNER1', 'A');
+        clock.runAll();
+        expect(componentWithDepsSpy).to.not.be.called;
+
+        parent.values.set(Concat, 'OWNER1', 'B');
+        clock.runAll();
+        expect(componentWithDepsSpy).to.not.be.called;
+
+        parent.values.set(NonRecursive, 'OWNER1', 'NR');
+        clock.runAll();
+        expect(componentWithDepsSpy).to.be.calledOnce.calledWith(
+          parent.node,
+          1,
+          'NR',
+          'AB'
+        );
+
+        parent.values.remove(NonRecursive, 'OWNER1');
+        clock.runAll();
+        expect(componentWithDepsSpy).to.be.calledOnce;
+      });
+
+      it('should cleanup on input change and removal', () => {
+        setComponent(parent.node, ComponentWithCleanup, 1);
+
+        clock.runAll();
+        expect(cleanupSpy).to.not.be.called;
+        expect(componentWithCleanupSpy).to.be.calledOnce.calledWith(
+          parent.node,
+          1
+        );
+
+        setComponent(parent.node, ComponentWithCleanup, 2);
+
+        clock.runAll();
+        expect(cleanupSpy).to.be.calledOnce;
+        expect(componentWithCleanupSpy).to.be.calledTwice.calledWith(
+          parent.node,
+          2
+        );
+      });
+
+      it('should cleanup on removal', () => {
+        setComponent(parent.node, ComponentWithCleanup, 1);
+
+        clock.runAll();
+        expect(cleanupSpy).to.not.be.called;
+        expect(componentWithCleanupSpy).to.be.calledOnce.calledWith(
+          parent.node,
+          1
+        );
+
+        removeComponent(parent.node, ComponentWithCleanup);
+        clock.runAll();
+        expect(cleanupSpy).to.be.calledOnce;
+        expect(componentWithCleanupSpy).to.be.calledOnce; // no change.
+      });
+
+      it('should cleanup on disconnect', async () => {
+        setComponent(parent.node, ComponentWithCleanup, 1);
+
+        clock.runAll();
+        expect(cleanupSpy).to.not.be.called;
+        expect(componentWithCleanupSpy).to.be.calledOnce.calledWith(
+          parent.node,
+          1
+        );
+
+        parent.node.remove();
+        await rediscover(parent);
+
+        clock.runAll();
+        expect(cleanupSpy).to.be.calledOnce;
+        expect(componentWithCleanupSpy).to.be.calledOnce; // no change.
+      });
+    });
+
+    describe('subscriber', () => {
+      let spy;
+      let cleanupSpy;
+      let subscriber;
+
+      beforeEach(() => {
+        spy = sandbox.spy();
+        cleanupSpy = sandbox.spy();
+        subscriber = (...args) => {
+          spy.apply(null, args);
+          return cleanupSpy;
+        };
+      });
+
+      it('should subscribe with a single dep', () => {
+        subscribe(parent.node, NonRecursive, subscriber);
+        clock.runAll();
+        expect(spy).to.not.be.called;
+        expect(cleanupSpy).to.not.be.called;
+
+        parent.values.set(NonRecursive, 'OWNER1', 'NR');
+        clock.runAll();
+        expect(spy).to.be.calledOnce.calledWith('NR');
+        expect(cleanupSpy).to.not.be.called;
+
+        // Repeat: no changes.
+        parent.values.set(NonRecursive, 'OWNER1', 'NR');
+        clock.runAll();
+        expect(spy).to.be.calledOnce.calledWith('NR');
+        expect(cleanupSpy).to.not.be.called;
+
+        // Change value.
+        parent.values.set(NonRecursive, 'OWNER1', 'NR2');
+        clock.runAll();
+        expect(spy).to.be.calledTwice.calledWith('NR2');
+        expect(cleanupSpy).to.be.calledOnce;
+
+        // Remove value.
+        parent.values.remove(NonRecursive, 'OWNER1');
+        clock.runAll();
+        expect(spy).to.be.calledTwice; // no change.
+        expect(cleanupSpy).to.be.calledTwice;
+      });
+
+      it('should subscribe with multiple deps', () => {
+        subscribe(parent.node, [NonRecursive, Concat], subscriber);
+        clock.runAll();
+        expect(spy).to.not.be.called;
+        expect(cleanupSpy).to.not.be.called;
+
+        grandparent.values.set(Concat, 'OWNER1', 'A');
+        clock.runAll();
+        expect(spy).to.not.be.called;
+        expect(cleanupSpy).to.not.be.called;
+
+        parent.values.set(NonRecursive, 'OWNER1', 'NR');
+        clock.runAll();
+        expect(spy).to.be.calledOnce.calledWith('NR', 'A');
+        expect(cleanupSpy).to.not.be.called;
+
+        // Change value.
+        parent.values.set(Concat, 'OWNER1', 'B');
+        clock.runAll();
+        expect(spy).to.be.calledTwice.calledWith('NR', 'AB');
+        expect(cleanupSpy).to.be.calledOnce;
+
+        // Remove value.
+        parent.values.remove(NonRecursive, 'OWNER1');
+        clock.runAll();
+        expect(spy).to.be.calledTwice; // no change.
+        expect(cleanupSpy).to.be.calledTwice;
+      });
+
+      it('should unsubscribe', () => {
+        subscribe(parent.node, [NonRecursive], subscriber);
+        parent.values.set(NonRecursive, 'OWNER1', 'NR');
+        clock.runAll();
+        expect(spy).to.be.calledOnce;
+        expect(cleanupSpy).to.not.be.called;
+
+        unsubscribe(parent.node, subscriber);
+        clock.runAll();
+        expect(spy).to.be.calledOnce; // no change.
+        expect(cleanupSpy).to.be.calledOnce;
+
+        // Change value.
+        parent.values.set(NonRecursive, 'OWNER1', 'NR2');
+        clock.runAll();
+        expect(spy).to.be.calledOnce; // no change.
+        expect(cleanupSpy).to.be.calledOnce; // no change.
+      });
+
+      it('should reconnect the subscriber when the node is reconnected', async () => {
+        subscribe(parent.node, [NonRecursive], subscriber);
+        parent.values.set(NonRecursive, 'OWNER1', 'NR');
+        clock.runAll();
+        expect(spy).to.be.calledOnce;
+        expect(cleanupSpy).to.not.be.called;
+
+        parent.node.remove();
+        await rediscover(parent);
+        clock.runAll();
+        expect(spy).to.be.calledOnce; // no change.
+        expect(cleanupSpy).to.be.calledOnce;
+
+        grandparent.node.appendChild(parent.node);
+        await rediscover(parent);
+        clock.runAll();
+        expect(spy).to.be.calledTwice;
+        expect(cleanupSpy).to.be.calledOnce; // no change.
+      });
+    });
+
+    describe('hooks', () => {
+      it('should initialize and persist useRef', () => {
+        const values = [];
+        const Comp = () => {
+          const ref = useRef(10);
+          ref.current++;
+          values.unshift(ref.current);
+        };
+
+        // 1st call.
+        setComponent(parent.node, Comp, 1);
+        clock.runAll();
+        expect(values).to.have.length(1);
+        expect(values[0]).to.equal(11);
+
+        // 2nd call.
+        setComponent(parent.node, Comp, 2);
+        clock.runAll();
+        expect(values).to.have.length(2);
+        expect(values[0]).to.equal(12);
+      });
+
+      it('should initialize and persist useMemo', () => {
+        const values = [];
+        const memoSpy = env.sandbox.spy();
+        const Comp = (node, input) => {
+          const dep = Math.floor(input / 10);
+          const value = useMemo(() => {
+            memoSpy();
+            return dep;
+          }, [dep]);
+          values.unshift(value);
+        };
+
+        // 1st call.
+        setComponent(parent.node, Comp, 1);
+        clock.runAll();
+        expect(values).to.have.length(1);
+        expect(values[0]).to.equal(0);
+        expect(memoSpy).to.be.calledOnce;
+
+        // 2nd call: no recompute.
+        setComponent(parent.node, Comp, 2);
+        clock.runAll();
+        expect(values).to.have.length(2);
+        expect(values[0]).to.equal(0);
+        expect(memoSpy).to.be.calledOnce; // no change.
+
+        // 3rd call: recompute.
+        setComponent(parent.node, Comp, 12);
+        clock.runAll();
+        expect(values).to.have.length(3);
+        expect(values[0]).to.equal(1);
+        expect(memoSpy).to.be.calledTwice;
+      });
+
+      it('should initialize and reuse useDisposable', () => {
+        const values = [];
+        const initSpy = env.sandbox.spy();
+        const disposeSpy = env.sandbox.spy();
+        const Comp = (node, input) => {
+          const value = useDisposable(() => {
+            initSpy(input);
+            return {
+              value: Math.floor(input / 10),
+              dispose: disposeSpy,
+            };
+          }, [Math.floor(input / 10)]);
+          values.unshift(value);
+        };
+
+        // 1st call: init.
+        setComponent(parent.node, Comp, 1);
+        clock.runAll();
+        expect(values).to.have.length(1);
+        expect(values[0]).to.equal(0);
+        expect(initSpy).to.be.calledOnce.calledWith(1);
+        expect(disposeSpy).to.not.be.called;
+
+        // 2nd call: reuse.
+        setComponent(parent.node, Comp, 2);
+        clock.runAll();
+        expect(values).to.have.length(2);
+        expect(values[0]).to.equal(0);
+        expect(initSpy).to.be.calledOnce; // no change.
+        expect(disposeSpy).to.not.be.called; // no change.
+
+        // 3rd call: re-init.
+        setComponent(parent.node, Comp, 12);
+        clock.runAll();
+        expect(values).to.have.length(3);
+        expect(values[0]).to.equal(1);
+        expect(initSpy).to.be.calledTwice.calledWith(12);
+        expect(disposeSpy).to.be.calledOnce;
+
+        // Remove.
+        removeComponent(parent.node, Comp);
+        clock.runAll();
+        expect(disposeSpy).to.be.calledTwice;
+        expect(values).to.have.length(3); // no change.
+        expect(initSpy).to.be.calledTwice; // no change.
+      });
+
+      it('should initialize and reuse cleanup-only useDisposable', () => {
+        const initSpy = env.sandbox.spy();
+        const disposeSpy = env.sandbox.spy();
+        const Comp = (node, input) => {
+          useDisposable(() => {
+            initSpy(input);
+            return disposeSpy;
+          }, [Math.floor(input / 10)]);
+        };
+
+        // 1st call: init.
+        setComponent(parent.node, Comp, 1);
+        clock.runAll();
+        expect(initSpy).to.be.calledOnce.calledWith(1);
+        expect(disposeSpy).to.not.be.called;
+
+        // 2nd call: reuse.
+        setComponent(parent.node, Comp, 2);
+        clock.runAll();
+        expect(initSpy).to.be.calledOnce; // no change.
+        expect(disposeSpy).to.not.be.called; // no change.
+
+        // 3rd call: re-init.
+        setComponent(parent.node, Comp, 12);
+        clock.runAll();
+        expect(initSpy).to.be.calledTwice.calledWith(12);
+        expect(disposeSpy).to.be.calledOnce;
+
+        // Remove.
+        removeComponent(parent.node, Comp);
+        clock.runAll();
+        expect(disposeSpy).to.be.calledTwice;
+        expect(initSpy).to.be.calledTwice; // no change.
+      });
+
+      it('should schedule and cleanup useSyncEffect', () => {
+        const effectSpy = env.sandbox.spy();
+        const cleanupSpy = env.sandbox.spy();
+        const Comp = (node, input) => {
+          useSyncEffect(() => {
+            effectSpy(input);
+            return cleanupSpy;
+          }, [Math.floor(input / 10)]);
+        };
+
+        // 1st call.
+        setComponent(parent.node, Comp, 1);
+        clock.runAll();
+        expect(effectSpy).to.be.calledOnce.calledWith(1);
+        expect(cleanupSpy).to.not.be.called;
+
+        // 2nd call: no-op.
+        setComponent(parent.node, Comp, 2);
+        clock.runAll();
+        expect(effectSpy).to.be.calledOnce; // no change.
+        expect(cleanupSpy).to.not.be.called; // no change.
+
+        // 3rd call: re-run.
+        setComponent(parent.node, Comp, 12);
+        clock.runAll();
+        expect(effectSpy).to.be.calledTwice.calledWith(12);
+        expect(cleanupSpy).to.be.calledOnce;
+
+        // Remove.
+        removeComponent(parent.node, Comp);
+        clock.runAll();
+        expect(cleanupSpy).to.be.calledTwice;
+        expect(effectSpy).to.be.calledTwice; // no change.
+      });
+
+      it('should schedule and cleanup mount/dismount', () => {
+        const effectSpy = env.sandbox.spy();
+        const cleanupSpy = env.sandbox.spy();
+        const Comp = (node, input) => {
+          useSyncEffect(() => {
+            effectSpy(input);
+            return cleanupSpy;
+          });
+        };
+
+        // 1st call.
+        setComponent(parent.node, Comp, 1);
+        clock.runAll();
+        expect(effectSpy).to.be.calledOnce.calledWith(1);
+        expect(cleanupSpy).to.not.be.called;
+
+        // 2nd call: no-op.
+        setComponent(parent.node, Comp, 2);
+        clock.runAll();
+        expect(effectSpy).to.be.calledOnce; // no change.
+        expect(cleanupSpy).to.not.be.called; // no change.
+
+        // Remove.
+        removeComponent(parent.node, Comp);
+        clock.runAll();
+        expect(cleanupSpy).to.be.calledOnce;
+        expect(effectSpy).to.be.calledOnce; // no change.
+      });
+    });
+  });
+});


### PR DESCRIPTION
Follow up on #28665 and #29197.

Key points:

- `ContextNode` only now contains as set of components and two methods to add/remove. But it doesn't depend on `Component` class itself. The caller must provide it. This accomplishes: a more versatile types of components, and a smaller binary footprint of the `ContextNode` itself. Otherwise the component code inside `ContextNode` follows the `Values` .
- `Component` object is a placeholder for the component's dependencies and states. It subscribes to dependent values using `Values` APIs. It also has a persistent state for a component, that's used by hooks.
- Additionally `Component` trackers cleanup functions that can be registered by hooks.
- Component, component factories, and hooks are all designed to optimize for dead code elimination - that only add to the binary size when they are actually used.
