### PR TITLE
✨Creating an interactive-results-category component

### DIFF
--- a/build-system/compile/bundles.config.js
+++ b/build-system/compile/bundles.config.js
@@ -883,6 +883,7 @@ exports.extensionBundles = [
         'amp-story-interactive-binary-poll',
         'amp-story-interactive-poll',
         'amp-story-interactive-quiz',
+        'amp-story-interactive-results',
         'amp-story-share',
         'amp-story-share-menu',
         'amp-story-system-layer',

--- a/examples/amp-story/interactive_results.html
+++ b/examples/amp-story/interactive_results.html
@@ -1,0 +1,166 @@
+<!doctype html>
+<html ⚡ lang="es">
+  <head>
+    <meta charset="utf-8">
+    <title >Interactive Story</title>
+    <link rel="canonical" href="interactive_Results.html">
+    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+    <script async src="https://cdn.ampproject.org/v0.js"></script>
+    <script async custom-element="amp-story" src="https://cdn.ampproject.org/v0/amp-story-1.0.js"></script>
+    <style amp-custom>
+    body {
+      font-family: 'Poppins', sans-serif;
+    }
+
+    amp-story-interactive-poll, amp-story-interactive-results {
+      align-self: center;
+      justify-self: center;
+    }
+    </style>
+  </head>
+  <body>
+    <amp-story
+        standalone
+        title="Interactive Story"
+        publisher="AMP Story testing"
+        publisher-logo-src="example.com/logo.png"
+        poster-portrait-src="example.com/poster.jpg">
+        <amp-story-page id="cover">
+          <amp-story-grid-layer template="fill">
+            <amp-img
+                animate-in="pan-left"
+                animate-in-duration="30s"
+                src="https://images.unsplash.com/photo-1415369629372-26f2fe60c467?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1268&q=80"
+                layout="responsive"
+                height="1600"
+                width="900">
+            </amp-img>
+          </amp-story-grid-layer>
+          <amp-story-grid-layer template="thirds">
+            <div style="color:white;padding:10px;align-self:end" grid-area="lower-third">
+              <h1>What adorable animal are you?</h1>
+              <p>The ultimate animal quiz</p>
+              <p>Provided with love by the AMP team</p>
+            </div>
+          </amp-story-grid-layer>
+        </amp-story-page>
+        <amp-story-page id="quiz-1">
+          <amp-story-grid-layer template="fill">
+            <amp-img style="filter:blur(4px) saturate(0.7);"
+                src="https://images.unsplash.com/photo-1546548970-71785318a17b?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1268&q=80" layout="responsive" height="1600" width="900">
+            </amp-img>
+          </amp-story-grid-layer>
+          <amp-story-grid-layer template="center">
+            <amp-story-interactive-poll
+                prompt-text="Whats your favorite food?"
+                endpoint="http://localhost:3000/interactives"
+                theme="dark"
+                chip-style="shadow"
+                style="--interactive-prompt-background: linear-gradient(120deg, rgb(255,103,38), rgb(235,69,69));"
+                option-1-text="Bones" option-1-results-category="Dog" 
+                option-2-text="Fish" option-2-results-category="Cat" 
+                option-3-text="Carrots" option-3-results-category="Bunny" 
+                option-4-text="Cheese" option-4-results-category="Mouse">
+            </amp-story-interactive-poll>
+          </amp-story-grid-layer>
+        </amp-story-page>
+        <amp-story-page id="quiz-2">
+          <amp-story-grid-layer template="fill">
+            <amp-img
+                src="img/green-stuff.jpg" layout="responsive" height="1600" width="900">
+            </amp-img>
+          </amp-story-grid-layer>
+          <amp-story-grid-layer template="center">
+            <amp-story-interactive-poll
+                prompt-text="How do you spend your free time?"
+                endpoint="http://localhost:3000/interactives"
+                style="--interactive-prompt-background: linear-gradient(120deg, rgb(251, 255, 38), rgb(144, 235, 69)); --interactive-prompt-text-color: black"
+                chip-style="shadow"
+                option-1-text="Stretching your back" option-1-results-category="Cat" 
+                option-2-text="Caressing your mustache" option-2-results-category="Mouse" 
+                option-3-text="Jumping all over the place" option-3-results-category="Bunny" 
+                option-4-text="Running behind a ball" option-4-results-category="Dog">
+            </amp-story-interactive-poll>
+          </amp-story-grid-layer>
+        </amp-story-page>
+        <amp-story-page id="quiz-3">
+          <amp-story-grid-layer template="fill">
+            <amp-img style="filter:blur(4px)"
+                src="https://images.unsplash.com/photo-1534534573898-db5148bc8b0c?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1275&q=80" layout="responsive" height="1600" width="900">
+            </amp-img>
+          </amp-story-grid-layer>
+          <amp-story-grid-layer template="center">
+            <amp-story-interactive-poll
+                prompt-text="What would you do for holidays?"
+                style="--interactive-prompt-background: linear-gradient(120deg, rgb(83, 32, 10), rgb(143, 89, 8));"
+                endpoint="http://localhost:3000/interactives"
+                theme="dark"
+                option-1-text="Easter island" option-1-results-category="Bunny" 
+                option-2-text="Drive with your tongue out" option-2-results-category="Dog" 
+                option-3-text="Get far away from cats" option-3-results-category="Mouse" 
+                option-4-text="Stay in bed sleeping" option-4-results-category="Cat">
+            </amp-story-interactive-poll>
+          </amp-story-grid-layer>
+        </amp-story-page>
+        <amp-story-page id="quiz-4">
+          <amp-story-grid-layer template="fill">
+            <amp-img
+                src="https://images.unsplash.com/photo-1559807424-a38a6b10c833?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1268&q=80" layout="responsive" height="1600" width="900">
+            </amp-img>
+          </amp-story-grid-layer>
+          <amp-story-grid-layer template="center">
+            <amp-story-interactive-poll
+                prompt-text="What's your favorite place in the house?"
+                endpoint="http://localhost:3000/interactives"
+                option-1-text="Inside my spacious cage" option-1-results-category="Mouse" 
+                option-2-text="On the backyard" option-2-results-category="Bunny" 
+                option-3-text="Where my owner is" option-3-results-category="Dog" 
+                option-4-text="On top of the fridge" option-4-results-category="Cat">
+            </amp-story-interactive-poll>
+          </amp-story-grid-layer>
+        </amp-story-page>
+        <amp-story-page id="quiz-results">
+          <amp-story-grid-layer template="fill">
+            <amp-img style="filter:blur(4px)"
+                src="https://www.positive.news/wp-content/uploads/2019/03/feat-1800x0-c-center.jpg"
+                layout="responsive"
+                height="1600"
+                width="900">
+            </amp-img>
+          </amp-story-grid-layer>
+          <amp-story-grid-layer>
+            <amp-story-interactive-results
+								style="--interactive-accent-color: #F34E4E"
+								prompt-text="You are a"
+                option-1-results-category="Cat" option-1-text="Everyone loves cats, and so do you! Cats are the best companion to WFH" option-1-image="https://images.pexels.com/photos/104827/cat-pet-animal-domestic-104827.jpeg"
+                option-2-results-category="Dog" option-2-text="You always have energy and love being with friends. Outdoors is your favorite place" option-2-image="https://images.pexels.com/photos/1108099/pexels-photo-1108099.jpeg"
+                option-3-results-category="Bunny" option-3-text="You love jumping around and having fun. Your bubbly personality is contagious, and your love for carrots is unconditional" option-3-image="https://images.pexels.com/photos/326012/pexels-photo-326012.jpeg"
+                option-4-results-category="Mouse" option-4-text="Even though you're small, you're also full of curiosity and love going around finding new things to do" option-4-image="https://images.pexels.com/photos/51340/rat-pets-eat-51340.jpeg">
+            </amp-story-interactive-results>
+          </amp-story-grid-layer>
+				</amp-story-page>
+				<amp-story-page id="quiz-results-2">
+          <amp-story-grid-layer template="fill">
+            <amp-img style="filter:blur(4px)"
+                src="https://www.positive.news/wp-content/uploads/2019/03/feat-1800x0-c-center.jpg"
+                layout="responsive"
+                height="1600"
+                width="900">
+            </amp-img>
+          </amp-story-grid-layer>
+          <amp-story-grid-layer>
+            <amp-story-interactive-results
+								style="--interactive-accent-color: #F34E4E"
+								prompt-text="You are a"
+								theme="dark"
+                option-1-results-category="Cat" option-1-text="Everyone loves cats, and so do you! Cats are the best companion to WFH" option-1-image="https://images.pexels.com/photos/104827/cat-pet-animal-domestic-104827.jpeg"
+                option-2-results-category="Dog" option-2-text="You always have energy and love being with friends. Outdoors is your favorite place" option-2-image="https://images.pexels.com/photos/1108099/pexels-photo-1108099.jpeg"
+                option-3-results-category="Bunny" option-3-text="You love jumping around and having fun. Your bubbly personality is contagious, and your love for carrots is unconditional" option-3-image="https://images.pexels.com/photos/326012/pexels-photo-326012.jpeg"
+                option-4-results-category="Mouse" option-4-text="Even though you're small, you're also full of curiosity and love going around finding new things to do" option-4-image="https://images.pexels.com/photos/51340/rat-pets-eat-51340.jpeg">
+            </amp-story-interactive-results>
+          </amp-story-grid-layer>
+        </amp-story-page>
+    </amp-story>
+  </body>
+</html>

--- a/examples/amp-story/interactives.html
+++ b/examples/amp-story/interactives.html
@@ -55,7 +55,7 @@
             <amp-story-interactive-quiz
                 id="first-cup-dark"
                 endpoint="http://localhost:3000/interactives"
-                style="--interactive-accent-color: rgb(16, 218, 93);--interactive-prompt-background-color: rgb(4, 41, 18);--interactive-prompt-text-color: rgb(16, 218, 93);"
+                style="--interactive-accent-color: rgb(16, 218, 93);--interactive-prompt-background: rgb(4, 41, 18);--interactive-prompt-text-color: rgb(16, 218, 93);"
                 theme="dark"
                 prompt-text="Is this an international quiz?"
                 option-1-text="你好，这是马蒂亚斯"
@@ -170,7 +170,7 @@
 								endpoint="http://localhost:3000/interactives"
 								prompt-text="What is your favorite movie?"
 								id="movie-light-connected"
-								style="--interactive-accent-color: rgb(16, 218, 93);--interactive-prompt-background-color: rgb(4, 41, 18);--interactive-prompt-text-color: rgb(16, 218, 93);"
+								style="--interactive-accent-color: rgb(16, 218, 93);--interactive-prompt-background: rgb(4, 41, 18);--interactive-prompt-text-color: rgb(16, 218, 93);"
                 theme="dark"
                 option-1-text="דוקטור מוזר"
                 option-2-text="פנתר שחור"

--- a/extensions/amp-story/1.0/amp-story-interactive-binary-poll.css
+++ b/extensions/amp-story/1.0/amp-story-interactive-binary-poll.css
@@ -15,21 +15,21 @@
  */
 
 .i-amphtml-story-interactive-binary-poll-container {
-  box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.12) !important;
   color: var(--i-amphtml-interactive-option-accent-color) !important;
   --post-select-scale: 0.5 !important;
   --post-select-scale-variable: 1 !important;
-	border-radius: 32px !important;
-	max-width: 296px !important;
+  border-radius: 32px !important;
+  max-width: 296px !important;
 }
 
 .i-amphtml-story-interactive-binary-poll-option-container {
-	background: var(--i-amphtml-interactive-option-background-color) !important;
-	display: flex !important;
+  background: var(--i-amphtml-interactive-option-background-color) !important;
+  display: flex !important;
   justify-content: center !important;
   height: 90px !important;
-	border-radius: 16px !important;
-	overflow: hidden !important;
+  border-radius: 16px !important;
+  overflow: hidden !important;
+  box-shadow: var(--i-amphtml-interactive-component-shadow) !important;
   /* overflow bug fix for percent bar animation on ios safari  */
   transform: translateZ(0) !important;
 }
@@ -45,7 +45,7 @@
 }
 
 .i-amphtml-story-interactive-prompt {
-	text-align: center !important;
+  text-align: center !important;
 }
 
 .i-amphtml-story-interactive-option-text-container {
@@ -58,8 +58,10 @@
 
 .i-amphtml-story-interactive-post-selection
   .i-amphtml-story-interactive-option-text-container {
-  transition: transform var(--i-amphtml-interactive-animation-time) var(--i-amphtml-interactive-ease-out-curve),
-    opacity var(--i-amphtml-interactive-animation-time) var(--i-amphtml-interactive-ease-out-curve) !important;
+  transition: transform var(--i-amphtml-interactive-animation-time)
+      var(--i-amphtml-interactive-ease-out-curve),
+    opacity var(--i-amphtml-interactive-animation-time)
+      var(--i-amphtml-interactive-ease-out-curve) !important;
   transform: translateY(0) !important;
 }
 
@@ -78,30 +80,35 @@
   position: absolute !important;
   opacity: 0 !important;
   transform-origin: left !important;
-  transition: transform var(--i-amphtml-interactive-animation-time) var(--i-amphtml-interactive-ease-out-curve) !important;
+  transition: transform var(--i-amphtml-interactive-animation-time)
+    var(--i-amphtml-interactive-ease-out-curve) !important;
 }
 
-[dir=rtl] .i-amphtml-story-interactive-option
+[dir='rtl']
+  .i-amphtml-story-interactive-option
   .i-amphtml-story-interactive-option-percent-bar {
   transform-origin: right !important;
 }
 
-.i-amphtml-story-interactive-option:last-child 
+.i-amphtml-story-interactive-option:last-child
   .i-amphtml-story-interactive-option-percent-bar {
   transform-origin: right !important;
 }
 
-[dir=rtl] .i-amphtml-story-interactive-option:last-child 
+[dir='rtl']
+  .i-amphtml-story-interactive-option:last-child
   .i-amphtml-story-interactive-option-percent-bar {
   transform-origin: left !important;
 }
 
 .i-amphtml-story-interactive-post-selection
-  .i-amphtml-story-interactive-option.i-amphtml-story-interactive-option-selected 
-    .i-amphtml-story-interactive-option-percent-bar {
+  .i-amphtml-story-interactive-option.i-amphtml-story-interactive-option-selected
+  .i-amphtml-story-interactive-option-percent-bar {
   background-color: var(--i-amphtml-interactive-option-accent-color) !important;
-  opacity: .2 !important;
-  animation: i-amphtml-interactive-animation-flash-background forwards var(--i-amphtml-interactive-animation-time) var(--i-amphtml-interactive-ease-out-curve);
+  opacity: 0.2 !important;
+  animation: i-amphtml-interactive-animation-flash-background forwards
+    var(--i-amphtml-interactive-animation-time)
+    var(--i-amphtml-interactive-ease-out-curve);
 }
 
 .i-amphtml-story-interactive-option-title {
@@ -114,7 +121,8 @@
   display: flex !important;
   align-items: center !important;
   justify-content: center !important;
-  transition: transform var(--i-amphtml-interactive-animation-time) var(--i-amphtml-interactive-ease-out-curve) !important;
+  transition: transform var(--i-amphtml-interactive-animation-time)
+    var(--i-amphtml-interactive-ease-out-curve) !important;
 }
 
 .i-amphtml-story-interactive-post-selection
@@ -128,7 +136,8 @@
   display: -webkit-box !important;
   -webkit-line-clamp: 2 !important;
   -webkit-box-orient: vertical !important;
-  transition: transform var(--i-amphtml-interactive-animation-time) var(--i-amphtml-interactive-ease-out-curve) !important;
+  transition: transform var(--i-amphtml-interactive-animation-time)
+    var(--i-amphtml-interactive-ease-out-curve) !important;
 }
 
 .i-amphtml-story-interactive-post-selection
@@ -141,7 +150,8 @@
   font-size: 22px !important;
   transform: scale(0) !important;
   display: inline-block !important;
-  transition: transform var(--i-amphtml-interactive-animation-time) var(--i-amphtml-interactive-ease-out-curve) !important;
+  transition: transform var(--i-amphtml-interactive-animation-time)
+    var(--i-amphtml-interactive-ease-out-curve) !important;
 }
 
 .i-amphtml-story-interactive-post-selection

--- a/extensions/amp-story/1.0/amp-story-interactive-poll.css
+++ b/extensions/amp-story/1.0/amp-story-interactive-poll.css
@@ -14,9 +14,6 @@
  * limitations under the License.
  */
 
-.i-amphtml-story-interactive-poll-container {
-  background-color: var(--interactive-prompt-background-color) !important;
-}
 
 .i-amphtml-story-interactive-option-container {
   background-color: var(--i-amphtml-interactive-option-background-color) !important;
@@ -76,12 +73,19 @@
   transform: translateX(calc(100% - var(--option-percentage)))!important;
 }
 
+.i-amphtml-story-interactive-poll-container:not(.i-amphtml-story-interactive-has-data) .i-amphtml-story-interactive-option::after {
+  display: none !important;
+}
+
 .i-amphtml-story-interactive-option-text {
   font-size: 22px !important;
   margin: 0 !important;
   z-index: 1 !important;
   transition: transform var(--i-amphtml-interactive-animation-time) var(--i-amphtml-interactive-ease-out-curve) !important;
   transform-origin: left !important;
+  white-space: nowrap !important;
+  overflow: hidden !important;
+  text-overflow: ellipsis !important;
 }
 
 .i-amphtml-story-interactive-poll-container[dir="rtl"] .i-amphtml-story-interactive-option-text{

--- a/extensions/amp-story/1.0/amp-story-interactive-quiz.css
+++ b/extensions/amp-story/1.0/amp-story-interactive-quiz.css
@@ -15,378 +15,574 @@
  */
 
 .i-amphtml-story-interactive-quiz-container {
-    --correct-color: #5BBA74 !important;
-    --correct-color-shaded: #00600f !important;
-    --incorrect-color: #F34E4E !important;
-    --incorrect-color-shaded: #B71C1C !important;
-    --option-1-percentage: 0%;
-    --option-2-percentage: 0%;
-    --option-3-percentage: 0%;
-    --option-4-percentage: 0%;
+  --correct-color: #5bba74 !important;
+  --correct-color-shaded: #00600f !important;
+  --incorrect-color: #f34e4e !important;
+  --incorrect-color-shaded: #b71c1c !important;
+  --option-1-percentage: 0%;
+  --option-2-percentage: 0%;
+  --option-3-percentage: 0%;
+  --option-4-percentage: 0%;
 }
 
 .i-amphtml-story-interactive-quiz-option-container {
-    display: flex !important;
-    flex-direction: column;
-    background-color: var(--i-amphtml-interactive-option-background-color) !important;
-    border-radius: var(--i-amphtml-interactive-chip-radius) !important;
-    padding: 8px 8px 0px 8px !important;
+  display: flex !important;
+  flex-direction: column;
+  background-color: var(
+    --i-amphtml-interactive-option-background-color
+  ) !important;
+  border-radius: var(--i-amphtml-interactive-chip-radius) !important;
+  padding: 8px 8px 0px 8px !important;
+  box-shadow: var(--i-amphtml-interactive-component-shadow) !important;
 }
 
 .i-amphtml-story-interactive-quiz-option {
-    position: relative !important;
-    display: flex !important;
-    justify-items: start !important;
-    align-items: center !important;
-    border-radius: var(--i-amphtml-interactive-chip-radius) !important;
-    padding: 8px 16px 8px 8px !important;
-    background-color: var(--i-amphtml-interactive-option-background-color) !important;
-    margin-bottom: 8px !important;
-    color: var(--i-amphtml-interactive-option-text-color) !important;
-    box-shadow: var(--i-amphtml-interactive-chip-shadow), inset 0px 0px 0px 1px var(--i-amphtml-interactive-theme-border) !important;
-    -webkit-box-shadow: var(--i-amphtml-interactive-chip-shadow), inset 0px 0px 0px 1px var(--i-amphtml-interactive-theme-border) !important;
-    -moz-box-shadow: var(--i-amphtml-interactive-chip-shadow), inset 0px 0px 0px 1px var(--i-amphtml-interactive-theme-border) !important;
-    font-size: 16px !important;
-    line-height: 20px !important;
-    overflow: hidden !important;
-    z-index: 0 !important;
+  position: relative !important;
+  display: flex !important;
+  justify-items: start !important;
+  align-items: center !important;
+  border-radius: var(--i-amphtml-interactive-chip-radius) !important;
+  padding: 8px 16px 8px 8px !important;
+  background-color: var(
+    --i-amphtml-interactive-option-background-color
+  ) !important;
+  margin-bottom: 8px !important;
+  color: var(--i-amphtml-interactive-option-text-color) !important;
+  box-shadow: var(--i-amphtml-interactive-chip-shadow),
+    inset 0px 0px 0px 1px var(--i-amphtml-interactive-theme-border) !important;
+  -webkit-box-shadow: var(--i-amphtml-interactive-chip-shadow),
+    inset 0px 0px 0px 1px var(--i-amphtml-interactive-theme-border) !important;
+  -moz-box-shadow: var(--i-amphtml-interactive-chip-shadow),
+    inset 0px 0px 0px 1px var(--i-amphtml-interactive-theme-border) !important;
+  font-size: 16px !important;
+  line-height: 20px !important;
+  overflow: hidden !important;
+  z-index: 0 !important;
 }
 
-[dir=rtl] .i-amphtml-story-interactive-quiz-option {
-    padding: 8px 8px 8px 16px !important;
+[dir='rtl'] .i-amphtml-story-interactive-quiz-option {
+  padding: 8px 8px 8px 16px !important;
 }
 
 /* Truncate option text and add an ellipsis after 2 lines. */
 .i-amphtml-story-interactive-quiz-option-text {
-    max-height: 40px !important;
-    overflow : hidden !important;
-    text-overflow: ellipsis !important;
-    display: -webkit-box !important;
-    -webkit-line-clamp: 2 !important;
-    -webkit-box-orient: vertical !important;
-    visibility: visible !important;
+  max-height: 40px !important;
+  overflow: hidden !important;
+  text-overflow: ellipsis !important;
+  display: -webkit-box !important;
+  -webkit-line-clamp: 2 !important;
+  -webkit-box-orient: vertical !important;
+  visibility: visible !important;
 }
 
-.i-amphtml-story-interactive-post-selection .i-amphtml-story-interactive-option-selected {
-    color: white !important;
-    border: solid 1px transparent !important;
+.i-amphtml-story-interactive-post-selection
+  .i-amphtml-story-interactive-option-selected {
+  color: white !important;
+  border: solid 1px transparent !important;
 }
 
 .i-amphtml-story-interactive-quiz-answer-choice {
-    display: flex !important;
-    justify-content: center !important;
-    align-items: center !important;
-    height: 24px !important;
-    width: 24px !important;
-    min-width: 24px !important;
-    border-radius: 50% !important;
-    border: solid 2px !important;
-    padding: 5px !important;
-    margin-right: 16px !important;
-    color: var(--interactive-accent-color) !important;
-    border-color: var(--i-amphtml-interactive-answer-choice-border) !important;
-    font-size: 16px !important;
-    line-height: 16px !important;
-    font-weight: bold !important;
+  display: flex !important;
+  justify-content: center !important;
+  align-items: center !important;
+  height: 24px !important;
+  width: 24px !important;
+  min-width: 24px !important;
+  border-radius: 50% !important;
+  border: solid 2px !important;
+  padding: 5px !important;
+  margin-right: 16px !important;
+  color: var(--interactive-accent-color) !important;
+  border-color: var(--i-amphtml-interactive-answer-choice-border) !important;
+  font-size: 16px !important;
+  line-height: 16px !important;
+  font-weight: bold !important;
 }
 
-[dir=rtl ] .i-amphtml-story-interactive-quiz-answer-choice {
-    margin-left: 16px !important;
-    margin-right: 0px !important;
+[dir='rtl'] .i-amphtml-story-interactive-quiz-answer-choice {
+  margin-left: 16px !important;
+  margin-right: 0px !important;
 }
 
 .i-amphtml-story-interactive-quiz-percentage-text {
-    display: flex !important;
-    padding-left: 10px !important;
-    margin-left: auto !important;
-    color: #AAAAAA !important;
-    visibility: hidden !important;
+  display: flex !important;
+  padding-left: 10px !important;
+  margin-left: auto !important;
+  color: #aaaaaa !important;
+  visibility: hidden !important;
 }
 
-[dir=rtl ] .i-amphtml-story-interactive-quiz-percentage-text {
-    padding-left: 0px !important;
-    padding-right: 10px !important;
-    margin-right: auto !important;
-    margin-left: 0px !important;
+[dir='rtl'] .i-amphtml-story-interactive-quiz-percentage-text {
+  padding-left: 0px !important;
+  padding-right: 10px !important;
+  margin-right: auto !important;
+  margin-left: 0px !important;
 }
 
-.i-amphtml-story-interactive-post-selection.i-amphtml-story-interactive-has-data .i-amphtml-story-interactive-quiz-percentage-text {
-    visibility: visible !important;
+.i-amphtml-story-interactive-post-selection.i-amphtml-story-interactive-has-data
+  .i-amphtml-story-interactive-quiz-percentage-text {
+  visibility: visible !important;
 }
 
-.i-amphtml-story-interactive-post-selection .i-amphtml-story-interactive-option-selected > .i-amphtml-story-interactive-quiz-percentage-text {
-    color: white !important;
+.i-amphtml-story-interactive-post-selection
+  .i-amphtml-story-interactive-option-selected
+  > .i-amphtml-story-interactive-quiz-percentage-text {
+  color: white !important;
 }
 
-.i-amphtml-story-interactive-post-selection :not([correct]) > .i-amphtml-story-interactive-quiz-answer-choice {
-    color: var(--incorrect-color) !important;
-    border-color: var(--incorrect-color) !important;
+.i-amphtml-story-interactive-post-selection
+  :not([correct])
+  > .i-amphtml-story-interactive-quiz-answer-choice {
+  color: var(--incorrect-color) !important;
+  border-color: var(--incorrect-color) !important;
 }
 
-.i-amphtml-story-interactive-post-selection [correct] > .i-amphtml-story-interactive-quiz-answer-choice {
-    color: var(--correct-color) !important;
-    border-color: var(--correct-color) !important;
+.i-amphtml-story-interactive-post-selection
+  [correct]
+  > .i-amphtml-story-interactive-quiz-answer-choice {
+  color: var(--correct-color) !important;
+  border-color: var(--correct-color) !important;
 }
 
-.i-amphtml-story-interactive-post-selection .i-amphtml-story-interactive-option-selected > .i-amphtml-story-interactive-quiz-answer-choice {
-    border-color: transparent !important;
-    animation: answer-choice-bounce forwards 600ms linear;
-    background-color: var(--i-amphtml-interactive-answer-choice-background) !important;
+.i-amphtml-story-interactive-post-selection
+  .i-amphtml-story-interactive-option-selected
+  > .i-amphtml-story-interactive-quiz-answer-choice {
+  border-color: transparent !important;
+  animation: answer-choice-bounce forwards 600ms linear;
+  background-color: var(
+    --i-amphtml-interactive-answer-choice-background
+  ) !important;
 }
 
 /** TODO(jackbsteinberg): Use a more a11y-friendly approach than font-size: 0px; */
 
-.i-amphtml-story-interactive-post-selection [correct] > .i-amphtml-story-interactive-quiz-answer-choice {
-    background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24px' height='24px' viewBox='0 0 24 24' fill='%235BBA74'%3E%3Cpath fill='none' d='M0 0h24v24H0z'/%3E%3Cpath d='M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z'/%3E%3C/svg%3E") !important;
-    background-repeat: no-repeat !important;
-    background-position: center !important;
-    font-size: 0 !important;
+.i-amphtml-story-interactive-post-selection
+  [correct]
+  > .i-amphtml-story-interactive-quiz-answer-choice {
+  background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24px' height='24px' viewBox='0 0 24 24' fill='%235BBA74'%3E%3Cpath fill='none' d='M0 0h24v24H0z'/%3E%3Cpath d='M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z'/%3E%3C/svg%3E") !important;
+  background-repeat: no-repeat !important;
+  background-position: center !important;
+  font-size: 0 !important;
 }
 
-.i-amphtml-story-interactive-post-selection :not([correct]) > .i-amphtml-story-interactive-quiz-answer-choice {
-    background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24px' height='24px' viewBox='0 0 24 24' fill='%23F34E4E'%3E%3Cpath d='M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z'/%3E%3Cpath d='M0 0h24v24H0z' fill='none'/%3E%3C/svg%3E") !important;
-    background-repeat: no-repeat !important;
-    background-position: center !important;
-    font-size: 0 !important;
+.i-amphtml-story-interactive-post-selection
+  :not([correct])
+  > .i-amphtml-story-interactive-quiz-answer-choice {
+  background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24px' height='24px' viewBox='0 0 24 24' fill='%23F34E4E'%3E%3Cpath d='M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z'/%3E%3Cpath d='M0 0h24v24H0z' fill='none'/%3E%3C/svg%3E") !important;
+  background-repeat: no-repeat !important;
+  background-position: center !important;
+  font-size: 0 !important;
 }
 
 .i-amphtml-story-interactive-quiz-option > * {
-    position: relative !important;
+  position: relative !important;
 }
 
 .i-amphtml-story-interactive-quiz-option::before {
-    content: "" !important;
-    position: absolute !important;
-    width: 100% !important;
-    height: 100% !important;
-    border-radius: var(--i-amphtml-interactive-chip-radius) !important;
-    font-size: 16px !important;
-    line-height: 20px !important;
+  content: '' !important;
+  position: absolute !important;
+  width: 100% !important;
+  height: 100% !important;
+  border-radius: var(--i-amphtml-interactive-chip-radius) !important;
+  font-size: 16px !important;
+  line-height: 20px !important;
 }
 
-.i-amphtml-story-interactive-post-selection:not(.i-amphtml-story-interactive-has-data) .i-amphtml-story-interactive-quiz-option-selected[correct].i-amphtml-story-interactive-quiz-option::before {
-    animation: option-select-correct forwards 150ms cubic-bezier(0.0, 0.0, 0.2, 1) !important;
-    border: solid 1px !important;
+.i-amphtml-story-interactive-post-selection:not(.i-amphtml-story-interactive-has-data)
+  .i-amphtml-story-interactive-quiz-option-selected[correct].i-amphtml-story-interactive-quiz-option::before {
+  animation: option-select-correct forwards 150ms cubic-bezier(0, 0, 0.2, 1) !important;
+  border: solid 1px !important;
 }
 
-.i-amphtml-story-interactive-post-selection:not(.i-amphtml-story-interactive-has-data) .i-amphtml-story-interactive-quiz-option-selected:not([correct]).i-amphtml-story-interactive-quiz-option::before {
-    animation: option-select-incorrect forwards 150ms cubic-bezier(0.0, 0.0, 0.2, 1) !important;
-    border: solid 1px !important;
+.i-amphtml-story-interactive-post-selection:not(.i-amphtml-story-interactive-has-data)
+  .i-amphtml-story-interactive-quiz-option-selected:not([correct]).i-amphtml-story-interactive-quiz-option::before {
+  animation: option-select-incorrect forwards 150ms cubic-bezier(0, 0, 0.2, 1) !important;
+  border: solid 1px !important;
 }
 
-.i-amphtml-story-interactive-post-selection.i-amphtml-story-interactive-has-data .i-amphtml-story-interactive-quiz-option:nth-of-type(1)::before {
-    transform: translateX(var(--option-1-percentage)) !important;
+.i-amphtml-story-interactive-post-selection.i-amphtml-story-interactive-has-data
+  .i-amphtml-story-interactive-quiz-option:nth-of-type(1)::before {
+  transform: translateX(var(--option-1-percentage)) !important;
 }
 
-.i-amphtml-story-interactive-post-selection.i-amphtml-story-interactive-has-data .i-amphtml-story-interactive-quiz-option:nth-of-type(2)::before {
-    transform: translateX(var(--option-2-percentage)) !important;
+.i-amphtml-story-interactive-post-selection.i-amphtml-story-interactive-has-data
+  .i-amphtml-story-interactive-quiz-option:nth-of-type(2)::before {
+  transform: translateX(var(--option-2-percentage)) !important;
 }
 
-.i-amphtml-story-interactive-post-selection.i-amphtml-story-interactive-has-data .i-amphtml-story-interactive-quiz-option:nth-of-type(3)::before {
-    transform: translateX(var(--option-3-percentage)) !important;
+.i-amphtml-story-interactive-post-selection.i-amphtml-story-interactive-has-data
+  .i-amphtml-story-interactive-quiz-option:nth-of-type(3)::before {
+  transform: translateX(var(--option-3-percentage)) !important;
 }
 
-.i-amphtml-story-interactive-post-selection.i-amphtml-story-interactive-has-data .i-amphtml-story-interactive-quiz-option:nth-of-type(4)::before {
-    transform: translateX(var(--option-4-percentage)) !important;
+.i-amphtml-story-interactive-post-selection.i-amphtml-story-interactive-has-data
+  .i-amphtml-story-interactive-quiz-option:nth-of-type(4)::before {
+  transform: translateX(var(--option-4-percentage)) !important;
 }
 
-
-.i-amphtml-story-interactive-post-selection.i-amphtml-story-interactive-has-data[dir=rtl] .i-amphtml-story-interactive-quiz-option:nth-of-type(1)::before {
-    transform: translateX(calc(-1 * var(--option-1-percentage))) !important;
+.i-amphtml-story-interactive-post-selection.i-amphtml-story-interactive-has-data[dir='rtl']
+  .i-amphtml-story-interactive-quiz-option:nth-of-type(1)::before {
+  transform: translateX(calc(-1 * var(--option-1-percentage))) !important;
 }
 
-.i-amphtml-story-interactive-post-selection.i-amphtml-story-interactive-has-data[dir=rtl] .i-amphtml-story-interactive-quiz-option:nth-of-type(2)::before {
-    transform: translateX(calc(-1 * var(--option-2-percentage))) !important;
+.i-amphtml-story-interactive-post-selection.i-amphtml-story-interactive-has-data[dir='rtl']
+  .i-amphtml-story-interactive-quiz-option:nth-of-type(2)::before {
+  transform: translateX(calc(-1 * var(--option-2-percentage))) !important;
 }
 
-.i-amphtml-story-interactive-post-selection.i-amphtml-story-interactive-has-data[dir=rtl] .i-amphtml-story-interactive-quiz-option:nth-of-type(3)::before {
-    transform: translateX(calc(-1 * var(--option-3-percentage))) !important;
+.i-amphtml-story-interactive-post-selection.i-amphtml-story-interactive-has-data[dir='rtl']
+  .i-amphtml-story-interactive-quiz-option:nth-of-type(3)::before {
+  transform: translateX(calc(-1 * var(--option-3-percentage))) !important;
 }
 
-.i-amphtml-story-interactive-post-selection.i-amphtml-story-interactive-has-data[dir=rtl] .i-amphtml-story-interactive-quiz-option:nth-of-type(4)::before {
-    transform: translateX(calc(-1 * var(--option-4-percentage))) !important;
+.i-amphtml-story-interactive-post-selection.i-amphtml-story-interactive-has-data[dir='rtl']
+  .i-amphtml-story-interactive-quiz-option:nth-of-type(4)::before {
+  transform: translateX(calc(-1 * var(--option-4-percentage))) !important;
 }
 
-.i-amphtml-story-interactive-post-selection.i-amphtml-story-interactive-has-data .i-amphtml-story-interactive-quiz-option::before {
-    left: -100% !important;
-    width: 100% !important;
-    height: 100% !important;
-    border-radius: 0px !important;
-    background: var(--i-amphtml-interactive-theme-shading) !important;
-    color: var(--i-amphtml-interactive-theme-shading) !important;
-    transition: transform var(--i-amphtml-interactive-animation-time) var(--i-amphtml-interactive-ease-out-curve) !important;
+.i-amphtml-story-interactive-post-selection.i-amphtml-story-interactive-has-data
+  .i-amphtml-story-interactive-quiz-option::before {
+  left: -100% !important;
+  width: 100% !important;
+  height: 100% !important;
+  border-radius: 0px !important;
+  background: var(--i-amphtml-interactive-theme-shading) !important;
+  color: var(--i-amphtml-interactive-theme-shading) !important;
+  transition: transform var(--i-amphtml-interactive-animation-time)
+    var(--i-amphtml-interactive-ease-out-curve) !important;
 }
 
-.i-amphtml-story-interactive-post-selection.i-amphtml-story-interactive-has-data[dir=rtl] .i-amphtml-story-interactive-quiz-option::before {
-    left: 101% !important;
+.i-amphtml-story-interactive-post-selection.i-amphtml-story-interactive-has-data[dir='rtl']
+  .i-amphtml-story-interactive-quiz-option::before {
+  left: 101% !important;
 }
 
-.i-amphtml-story-interactive-post-selection .i-amphtml-story-interactive-option-selected[correct].i-amphtml-story-interactive-quiz-option {
-    background: var(--correct-color) !important;
-    box-shadow: var(--i-amphtml-interactive-chip-shadow-inset) !important;
+.i-amphtml-story-interactive-post-selection
+  .i-amphtml-story-interactive-option-selected[correct].i-amphtml-story-interactive-quiz-option {
+  background: var(--correct-color) !important;
+  box-shadow: var(--i-amphtml-interactive-chip-shadow-inset) !important;
 }
 
-.i-amphtml-story-interactive-post-selection .i-amphtml-story-interactive-option-selected:not([correct]).i-amphtml-story-interactive-quiz-option {
-    background: var(--incorrect-color) !important;
-    box-shadow: var(--i-amphtml-interactive-chip-shadow-inset) !important;
+.i-amphtml-story-interactive-post-selection
+  .i-amphtml-story-interactive-option-selected:not([correct]).i-amphtml-story-interactive-quiz-option {
+  background: var(--incorrect-color) !important;
+  box-shadow: var(--i-amphtml-interactive-chip-shadow-inset) !important;
 }
 
 .i-amphtml-story-interactive-option-selected.i-amphtml-story-interactive-quiz-option {
-    border: none !important;
-    box-shadow: var(--i-amphtml-interactive-chip-shadow-inset) !important;
+  border: none !important;
+  box-shadow: var(--i-amphtml-interactive-chip-shadow-inset) !important;
 }
 
-.i-amphtml-story-interactive-post-selection.i-amphtml-story-interactive-has-data .i-amphtml-story-interactive-option-selected[correct].i-amphtml-story-interactive-quiz-option::before {
-    background: var(--correct-color-shaded) !important;
-    color: var(--correct-color-shaded) !important;
+.i-amphtml-story-interactive-post-selection.i-amphtml-story-interactive-has-data
+  .i-amphtml-story-interactive-option-selected[correct].i-amphtml-story-interactive-quiz-option::before {
+  background: var(--correct-color-shaded) !important;
+  color: var(--correct-color-shaded) !important;
 }
 
-.i-amphtml-story-interactive-post-selection.i-amphtml-story-interactive-has-data .i-amphtml-story-interactive-option-selected:not([correct]).i-amphtml-story-interactive-quiz-option::before {
-    background: var(--incorrect-color-shaded) !important;
-    color: var(--incorrect-color-shaded) !important;
+.i-amphtml-story-interactive-post-selection.i-amphtml-story-interactive-has-data
+  .i-amphtml-story-interactive-option-selected:not([correct]).i-amphtml-story-interactive-quiz-option::before {
+  background: var(--incorrect-color-shaded) !important;
+  color: var(--incorrect-color-shaded) !important;
 }
 
 /**
- * Proper bounce animation scale values calculated in a CodePen
- * using methodology from Medium post "Spring Animation in CSS"
- * by Thai Pangsakulyanont.
- *
- * https://codepen.io/jackbsteinberg/pen/ExaZpjZ
- * https://medium.com/@dtinth/spring-animation-in-css-2039de6e1a03
- */
+* Proper bounce animation scale values calculated in a CodePen
+* using methodology from Medium post "Spring Animation in CSS"
+* by Thai Pangsakulyanont.
+*
+* https://codepen.io/jackbsteinberg/pen/ExaZpjZ
+* https://medium.com/@dtinth/spring-animation-in-css-2039de6e1a03
+*/
 @keyframes answer-choice-bounce {
-    0% {
-        visibility: hidden;
-        border: solid 2px var(--i-amphtml-interactive-answer-choice-background);
-        transform: scale(0);
-    }
-    20% {
-        visibility: hidden;
-    }
-    21% { 
-        visibility: visible;
-        transform: scale(0.01); 
-    }
-    22% { transform: scale(0.013); }
-    23% { transform: scale(0.051); }
-    24% { transform: scale(0.109); }
-    25% { transform: scale(0.183); }
-    26% { transform: scale(0.268); }
-    27% { transform: scale(0.361); }
-    28% { transform: scale(0.457); }
-    29% { transform: scale(0.555); }
-    30% { transform: scale(0.650); }
-    31% { transform: scale(0.742); }
-    32% { transform: scale(0.827); }
-    33% { transform: scale(0.905); }
-    34% { transform: scale(0.975); }
-    35% { transform: scale(1.035); }
-    36% { transform: scale(1.086); }
-    37% { transform: scale(1.127); }
-    38% { transform: scale(1.160); }
-    39% { transform: scale(1.183); }
-    40% { transform: scale(1.198); }
-    41% { transform: scale(1.206); }
-    42% { transform: scale(1.207); }
-    43% { transform: scale(1.203); }
-    44% { transform: scale(1.193); }
-    45% { transform: scale(1.180); }
-    46% { transform: scale(1.164); }
-    47% { transform: scale(1.146); }
-    48% { transform: scale(1.126); }
-    49% { transform: scale(1.106); }
-    50% { transform: scale(1.086); }
-    51% { transform: scale(1.066); }
-    52% { transform: scale(1.047); }
-    53% { transform: scale(1.030); }
-    54% { transform: scale(1.014); }
-    55% { transform: scale(1.000); }
-    56% { transform: scale(0.989); }
-    57% { transform: scale(0.979); }
-    58% { transform: scale(0.971); }
-    59% { transform: scale(0.964); }
-    60% { transform: scale(0.960); }
-    61% { transform: scale(0.958); }
-    62% { transform: scale(0.956); }
-    63% { transform: scale(0.957); }
-    64% { transform: scale(0.958); }
-    65% { transform: scale(0.960); }
-    66% { transform: scale(0.963); }
-    67% { transform: scale(0.967); }
-    68% { transform: scale(0.970); }
-    69% { transform: scale(0.975); }
-    70% { transform: scale(0.979); }
-    71% { transform: scale(0.983); }
-    72% { transform: scale(0.987); }
-    73% { transform: scale(0.991); }
-    74% { transform: scale(0.994); }
-    75% { transform: scale(0.997); }
-    76% { transform: scale(1.000); }
-    77% { transform: scale(1.002); }
-    78% { transform: scale(1.004); }
-    79% { transform: scale(1.006); }
-    80% { transform: scale(1.007); }
-    81% { transform: scale(1.008); }
-    82% { transform: scale(1.008); }
-    83% { transform: scale(1.008); }
-    84% { transform: scale(1.008); }
-    85% { transform: scale(1.008); }
-    86% { transform: scale(1.008); }
-    87% { transform: scale(1.007); }
-    88% { transform: scale(1.006); }
-    89% { transform: scale(1.005); }
-    90% { transform: scale(1.004); }
-    91% { transform: scale(1.004); }
-    92% { transform: scale(1.003); }
-    93% { transform: scale(1.002); }
-    94% { transform: scale(1.001); }
-    95% { transform: scale(1.000); }
-    96% { transform: scale(1.000); }
-    97% { transform: scale(0.999); }
-    98% { transform: scale(0.999); }
-    99% { transform: scale(0.998); }
-    100% { 
-        border: solid 2px var(--i-amphtml-interactive-answer-choice-background);
-        transform: scale(1); 
-    }
+  0% {
+    visibility: hidden;
+    border: solid 2px var(--i-amphtml-interactive-answer-choice-background);
+    transform: scale(0);
+  }
+  20% {
+    visibility: hidden;
+  }
+  21% {
+    visibility: visible;
+    transform: scale(0.01);
+  }
+  22% {
+    transform: scale(0.013);
+  }
+  23% {
+    transform: scale(0.051);
+  }
+  24% {
+    transform: scale(0.109);
+  }
+  25% {
+    transform: scale(0.183);
+  }
+  26% {
+    transform: scale(0.268);
+  }
+  27% {
+    transform: scale(0.361);
+  }
+  28% {
+    transform: scale(0.457);
+  }
+  29% {
+    transform: scale(0.555);
+  }
+  30% {
+    transform: scale(0.65);
+  }
+  31% {
+    transform: scale(0.742);
+  }
+  32% {
+    transform: scale(0.827);
+  }
+  33% {
+    transform: scale(0.905);
+  }
+  34% {
+    transform: scale(0.975);
+  }
+  35% {
+    transform: scale(1.035);
+  }
+  36% {
+    transform: scale(1.086);
+  }
+  37% {
+    transform: scale(1.127);
+  }
+  38% {
+    transform: scale(1.16);
+  }
+  39% {
+    transform: scale(1.183);
+  }
+  40% {
+    transform: scale(1.198);
+  }
+  41% {
+    transform: scale(1.206);
+  }
+  42% {
+    transform: scale(1.207);
+  }
+  43% {
+    transform: scale(1.203);
+  }
+  44% {
+    transform: scale(1.193);
+  }
+  45% {
+    transform: scale(1.18);
+  }
+  46% {
+    transform: scale(1.164);
+  }
+  47% {
+    transform: scale(1.146);
+  }
+  48% {
+    transform: scale(1.126);
+  }
+  49% {
+    transform: scale(1.106);
+  }
+  50% {
+    transform: scale(1.086);
+  }
+  51% {
+    transform: scale(1.066);
+  }
+  52% {
+    transform: scale(1.047);
+  }
+  53% {
+    transform: scale(1.03);
+  }
+  54% {
+    transform: scale(1.014);
+  }
+  55% {
+    transform: scale(1);
+  }
+  56% {
+    transform: scale(0.989);
+  }
+  57% {
+    transform: scale(0.979);
+  }
+  58% {
+    transform: scale(0.971);
+  }
+  59% {
+    transform: scale(0.964);
+  }
+  60% {
+    transform: scale(0.96);
+  }
+  61% {
+    transform: scale(0.958);
+  }
+  62% {
+    transform: scale(0.956);
+  }
+  63% {
+    transform: scale(0.957);
+  }
+  64% {
+    transform: scale(0.958);
+  }
+  65% {
+    transform: scale(0.96);
+  }
+  66% {
+    transform: scale(0.963);
+  }
+  67% {
+    transform: scale(0.967);
+  }
+  68% {
+    transform: scale(0.97);
+  }
+  69% {
+    transform: scale(0.975);
+  }
+  70% {
+    transform: scale(0.979);
+  }
+  71% {
+    transform: scale(0.983);
+  }
+  72% {
+    transform: scale(0.987);
+  }
+  73% {
+    transform: scale(0.991);
+  }
+  74% {
+    transform: scale(0.994);
+  }
+  75% {
+    transform: scale(0.997);
+  }
+  76% {
+    transform: scale(1);
+  }
+  77% {
+    transform: scale(1.002);
+  }
+  78% {
+    transform: scale(1.004);
+  }
+  79% {
+    transform: scale(1.006);
+  }
+  80% {
+    transform: scale(1.007);
+  }
+  81% {
+    transform: scale(1.008);
+  }
+  82% {
+    transform: scale(1.008);
+  }
+  83% {
+    transform: scale(1.008);
+  }
+  84% {
+    transform: scale(1.008);
+  }
+  85% {
+    transform: scale(1.008);
+  }
+  86% {
+    transform: scale(1.008);
+  }
+  87% {
+    transform: scale(1.007);
+  }
+  88% {
+    transform: scale(1.006);
+  }
+  89% {
+    transform: scale(1.005);
+  }
+  90% {
+    transform: scale(1.004);
+  }
+  91% {
+    transform: scale(1.004);
+  }
+  92% {
+    transform: scale(1.003);
+  }
+  93% {
+    transform: scale(1.002);
+  }
+  94% {
+    transform: scale(1.001);
+  }
+  95% {
+    transform: scale(1);
+  }
+  96% {
+    transform: scale(1);
+  }
+  97% {
+    transform: scale(0.999);
+  }
+  98% {
+    transform: scale(0.999);
+  }
+  99% {
+    transform: scale(0.998);
+  }
+  100% {
+    border: solid 2px var(--i-amphtml-interactive-answer-choice-background);
+    transform: scale(1);
+  }
 }
 
 @keyframes option-select-correct {
-    0% {
-        border-color: var(--correct-color);
-        background: var(--correct-color);
-        opacity: 0.2;
-        transform: scale(0.1);
-        color: var(--correct-color);
-    }
-    50% {
-        opacity: 1;
-        color: var(--correct-color);
-    }
-    100% {
-        border-color: var(--correct-color);
-        background: var(--correct-color);
-        transform: scale(1);
-        color: white;
-    }
+  0% {
+    border-color: var(--correct-color);
+    background: var(--correct-color);
+    opacity: 0.2;
+    transform: scale(0.1);
+    color: var(--correct-color);
+  }
+  50% {
+    opacity: 1;
+    color: var(--correct-color);
+  }
+  100% {
+    border-color: var(--correct-color);
+    background: var(--correct-color);
+    transform: scale(1);
+    color: white;
+  }
 }
 
 @keyframes option-select-incorrect {
-    0% {
-        border-color: var(--incorrect-color);
-        background: var(--incorrect-color);
-        opacity: 0.2;
-        transform: scale(0.1);
-        color: var(--incorrect-color);
-    }
-    50% {
-        opacity: 1;
-        color: var(--incorrect-color);
-    }
-    100% {
-        border-color: var(--incorrect-color);
-        background: var(--incorrect-color);
-        transform: scale(1);
-        color: white;
-    }
+  0% {
+    border-color: var(--incorrect-color);
+    background: var(--incorrect-color);
+    opacity: 0.2;
+    transform: scale(0.1);
+    color: var(--incorrect-color);
+  }
+  50% {
+    opacity: 1;
+    color: var(--incorrect-color);
+  }
+  100% {
+    border-color: var(--incorrect-color);
+    background: var(--incorrect-color);
+    transform: scale(1);
+    color: white;
+  }
 }

--- a/extensions/amp-story/1.0/amp-story-interactive-results.css
+++ b/extensions/amp-story/1.0/amp-story-interactive-results.css
@@ -1,0 +1,95 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.i-amphtml-story-interactive-results-container {
+  font-family: 'Poppins', sans-serif !important;
+  background: var(--i-amphtml-interactive-option-background-color) !important;
+  border-radius: var(--i-amphtml-interactive-chip-radius) !important;
+  color: var(--i-amphtml-interactive-strong-text-color) !important;
+  text-align: center !important;
+  max-width: 300px !important;
+  box-shadow: var(--i-amphtml-interactive-component-shadow) !important;
+  display: flex !important;
+  flex-direction: column !important;
+  align-items: center !important;
+  padding: 20px 5px !important;
+}
+
+.i-amphtml-story-interactive-results-line {
+  background-color: var(--interactive-accent-color) !important;
+  width: 30px !important;
+  height: 4px !important;
+  margin-bottom: 20px !important;
+  border-radius: 2px !important;
+}
+
+.i-amphtml-story-interactive-results-dots {
+  background-image: radial-gradient(
+    var(--interactive-accent-color) 20%,
+    transparent 20%
+  ) !important;
+  width: 52px !important;
+  height: 94px !important;
+  background-position: top !important;
+  background-size: 8px 8px !important;
+}
+
+.i-amphtml-story-interactive-results-visuals {
+  display: flex !important;
+  flex-direction: row !important;
+  align-items: center !important;
+}
+
+.i-amphtml-story-interactive-results-image {
+  width: 130px !important;
+  height: 130px !important;
+  background-size: cover !important;
+  background-position: center !important;
+  border-radius: 50% !important;
+}
+
+.i-amphtml-story-interactive-results-image-border {
+  background: linear-gradient(
+    180deg,
+    transparent 56%,
+    var(--interactive-accent-color) 56%
+  );
+  margin: 0px 10px !important;
+  padding: 10px !important;
+  border-radius: 50% !important;
+  border: 2px solid var(--interactive-accent-color) !important;
+}
+
+.i-amphtml-story-interactive-results-prompt {
+  text-transform: uppercase !important;
+  font-size: 12px !important;
+  margin-top: 20px !important;
+  font-weight: bold !important;
+  letter-spacing: 2px !important;
+}
+
+.i-amphtml-story-interactive-results-title {
+  font-size: 28px !important;
+  font-weight: bold !important;
+}
+
+.i-amphtml-story-interactive-results-description {
+  font-size: 14px !important;
+  text-align: center !important;
+  color: var(--i-amphtml-interactive-option-text-color) !important;
+  margin-top: 8px !important;
+  padding: 0px 20px !important;
+}

--- a/extensions/amp-story/1.0/amp-story-interactive-results.js
+++ b/extensions/amp-story/1.0/amp-story-interactive-results.js
@@ -1,0 +1,162 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {AmpStoryInteractive, InteractiveType} from './amp-story-interactive';
+import {CSS} from '../../../build/amp-story-interactive-results-1.0.css';
+import {StateProperty} from './amp-story-store-service';
+import {htmlFor} from '../../../src/static-template';
+import {setStyle} from '../../../src/style';
+
+/**
+ * @typedef {{
+ *    category: string,
+ * }}
+ */
+export let InteractiveResultsDef;
+
+/**
+ * Generates the template for the quiz.
+ *
+ * @param {!Element} element
+ * @return {!Element}
+ */
+const buildResultsTemplate = (element) => {
+  const html = htmlFor(element);
+  return html`
+    <div class="i-amphtml-story-interactive-results-container">
+      <div class="i-amphtml-story-interactive-results-line"></div>
+      <div class="i-amphtml-story-interactive-results-visuals">
+        <div class="i-amphtml-story-interactive-results-dots"></div>
+        <div class="i-amphtml-story-interactive-results-image-border">
+          <div class="i-amphtml-story-interactive-results-image"></div>
+        </div>
+        <div class="i-amphtml-story-interactive-results-dots"></div>
+      </div>
+      <div class="i-amphtml-story-interactive-results-prompt"></div>
+      <div class="i-amphtml-story-interactive-results-title"></div>
+      <div class="i-amphtml-story-interactive-results-description"></div>
+    </div>
+  `;
+};
+
+/**
+ * Processes the state and returns the condensed results.
+ * @param {!Map<string, {option: ?./amp-story-interactive.OptionConfigType, interactiveId: string}>} interactiveState
+ * @param {?Array<!./amp-story-interactive.OptionConfigType>} options needed to ensure the first options take precedence on ties
+ * @return {InteractiveResultsDef} the results
+ */
+const processResults = (interactiveState, options) => {
+  const categories = {};
+  // Add options in order to prefer earlier categories before later ones.
+  options.forEach((option) => {
+    categories[option.resultscategory] = 0;
+  });
+  Object.values(interactiveState).forEach((e) => {
+    if (e.option != null) {
+      categories[e.option.resultscategory] += 1;
+    }
+  });
+  return {
+    category: Object.keys(categories).reduce((a, b) =>
+      categories[a] >= categories[b] ? a : b
+    ),
+  };
+};
+
+export class AmpStoryInteractiveResults extends AmpStoryInteractive {
+  /**
+   * @param {!AmpElement} element
+   */
+  constructor(element) {
+    super(element, InteractiveType.RESULTS, [2, 4]);
+  }
+
+  /** @override */
+  buildCallback() {
+    super.buildCallback(CSS);
+  }
+
+  /** @override */
+  buildComponent() {
+    this.rootEl_ = buildResultsTemplate(this.element);
+    return this.rootEl_;
+  }
+
+  /** @override */
+  layoutCallback() {
+    if (this.element.hasAttribute('prompt-text')) {
+      this.rootEl_.querySelector(
+        '.i-amphtml-story-interactive-results-prompt'
+      ).textContent = this.element.getAttribute('prompt-text');
+    }
+    this.storeService_.subscribe(
+      StateProperty.INTERACTIVE_REACT_STATE,
+      (data) => this.onInteractiveReactStateUpdate_(data),
+      true
+    );
+  }
+
+  /**
+   * Receives state updates and fills up DOM with the result
+   * @param {!Map<string, {option: ?./amp-story-interactive.OptionConfigType, interactiveId: string}>} interactiveState
+   * @private
+   */
+  onInteractiveReactStateUpdate_(interactiveState) {
+    const results = processResults(interactiveState, this.options_);
+    this.options_.forEach((e) => {
+      if (e.resultscategory === results.category) {
+        this.mutateElement(() => {
+          this.updateCategory_(e);
+          this.updateToPostSelectionState_(null);
+        });
+      }
+    });
+  }
+
+  /**
+   * Updates the element with the correct category
+   * @param {./amp-story-interactive.OptionConfigType} categorySelected
+   * @private
+   */
+  updateCategory_(categorySelected) {
+    setStyle(
+      this.rootEl_.querySelector('.i-amphtml-story-interactive-results-image'),
+      'background',
+      'url(' + categorySelected.image + ')'
+    );
+    this.rootEl_.querySelector(
+      '.i-amphtml-story-interactive-results-title'
+    ).textContent = categorySelected.resultscategory;
+    this.rootEl_.querySelector(
+      '.i-amphtml-story-interactive-results-description'
+    ).textContent = categorySelected.text || '';
+  }
+
+  /** @override */
+  handleTap_(unusedEvent) {
+    // Disallow click handler since there are no options.
+  }
+
+  /** @override */
+  updateOptionPercentages_(unusedOptionsData) {
+    // TODO(mszylkowski): Show percentages of categories if endpoint.
+  }
+
+  /** @override */
+  updateStoryStoreState_(unusedOption) {
+    // Prevent from updating the state.
+  }
+}

--- a/extensions/amp-story/1.0/amp-story-interactive.css
+++ b/extensions/amp-story/1.0/amp-story-interactive.css
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-.i-amphtml-story-interactive-container {
+ .i-amphtml-story-interactive-container {
   font-family: 'Poppins', sans-serif !important;
 }
 
 .i-amphtml-story-interactive-container {
-  background: var(--interactive-prompt-background-color) !important;
+  background: var(--interactive-prompt-background) !important;
   border-radius: 32px !important;
 }
 

--- a/extensions/amp-story/1.0/amp-story-interactive.js
+++ b/extensions/amp-story/1.0/amp-story-interactive.js
@@ -208,6 +208,7 @@ export class AmpStoryInteractive extends AMP.BaseElement {
   }
 
   /**
+   * Gets the interactive ID
    * @private
    * @return {string}
    */
@@ -437,7 +438,7 @@ export class AmpStoryInteractive extends AMP.BaseElement {
   /**
    * Handles a tap event on the quiz element.
    * @param {Event} e
-   * @private
+   * @protected
    */
   handleTap_(e) {
     if (this.hasUserSelection_) {
@@ -728,22 +729,25 @@ export class AmpStoryInteractive extends AMP.BaseElement {
   }
 
   /**
-   * Updates the selected classes on option selected.
-   * @param {!Element} selectedOption
-   * @private
+   * Updates the selected classes on component and option selected.
+   * @param {?Element} selectedOption
+   * @protected
    */
   updateToPostSelectionState_(selectedOption) {
     this.rootEl_.classList.add('i-amphtml-story-interactive-post-selection');
-    selectedOption.classList.add('i-amphtml-story-interactive-option-selected');
+    if (selectedOption != null) {
+      selectedOption.classList.add(
+        'i-amphtml-story-interactive-option-selected'
+      );
+      const confettiEmoji = this.options_[selectedOption.optionIndex_].confetti;
+      if (confettiEmoji) {
+        emojiConfetti(this.rootEl_, this.win, confettiEmoji);
+      }
+    }
 
     if (this.optionsData_) {
       this.rootEl_.classList.add('i-amphtml-story-interactive-has-data');
       this.updateOptionPercentages_(this.optionsData_);
-    }
-
-    const confettiEmoji = this.options_[selectedOption.optionIndex_].confetti;
-    if (confettiEmoji) {
-      emojiConfetti(this.rootEl_, this.win, confettiEmoji);
     }
   }
 

--- a/extensions/amp-story/1.0/amp-story.css
+++ b/extensions/amp-story/1.0/amp-story.css
@@ -882,7 +882,7 @@ amp-story .amp-video-eq,
   max-width: 400px !important;
   /* Properties overrideable by user */
   --interactive-accent-color: #005AF0;
-  --interactive-prompt-background-color: var(--interactive-accent-color);
+  --interactive-prompt-background: var(--interactive-accent-color);
   --interactive-prompt-text-color: white;
   --interactive-prompt-alignment: initial;
   /* Shared properties by interactives */
@@ -903,6 +903,7 @@ amp-story .amp-video-eq,
   --i-amphtml-interactive-animation-time: .3s !important;
   --i-amphtml-interactive-ease-out-curve: cubic-bezier(.3, 0, 0, 1) !important;
   --i-amphtml-interactive-animation-delay: 0s !important;
+  --i-amphtml-interactive-component-shadow: 0px 4px 12px rgba(60, 64, 67, 0.08), 0px 2px 4px rgba(60, 64, 67, 0.12);
 }
 
 .i-amphtml-story-interactive-component[theme="dark"] {

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -53,6 +53,7 @@ import {AmpStoryHint} from './amp-story-hint';
 import {AmpStoryInteractiveBinaryPoll} from './amp-story-interactive-binary-poll';
 import {AmpStoryInteractivePoll} from './amp-story-interactive-poll';
 import {AmpStoryInteractiveQuiz} from './amp-story-interactive-quiz';
+import {AmpStoryInteractiveResults} from './amp-story-interactive-results';
 import {AmpStoryPage, NavigationDirection, PageState} from './amp-story-page';
 import {AmpStoryPageAttachment} from './amp-story-page-attachment';
 import {AmpStoryRenderService} from './amp-story-render-service';
@@ -2830,5 +2831,9 @@ AMP.extension('amp-story', '1.0', (AMP) => {
   );
   AMP.registerElement('amp-story-interactive-poll', AmpStoryInteractivePoll);
   AMP.registerElement('amp-story-interactive-quiz', AmpStoryInteractiveQuiz);
+  AMP.registerElement(
+    'amp-story-interactive-results',
+    AmpStoryInteractiveResults
+  );
   AMP.registerServiceForDoc('amp-story-render', AmpStoryRenderService);
 });

--- a/extensions/amp-story/1.0/story-analytics.js
+++ b/extensions/amp-story/1.0/story-analytics.js
@@ -21,7 +21,7 @@ import {map} from '../../../src/utils/object';
 import {registerServiceBuilder} from '../../../src/service';
 import {triggerAnalyticsEvent} from '../../../src/analytics';
 
-/** @package @const {string} */
+/** @const {string} */
 export const ANALYTICS_TAG_NAME = '__AMP_ANALYTICS_TAG_NAME__';
 
 /** @enum {string} */

--- a/extensions/amp-story/1.0/test/test-amp-story-interactive-results.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-interactive-results.js
@@ -1,0 +1,98 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Action, AmpStoryStoreService} from '../amp-story-store-service';
+import {AmpStoryInteractiveResults} from '../amp-story-interactive-results';
+import {addConfigToInteractive} from './test-amp-story-interactive';
+import {registerServiceBuilder} from '../../../../src/service';
+
+describes.realWin(
+  'amp-story-interactive-results',
+  {
+    amp: true,
+  },
+  (env) => {
+    let win;
+    let ampStoryResults;
+    let storyEl;
+    let storeService;
+
+    beforeEach(() => {
+      win = env.win;
+
+      const ampStoryResultsEl = win.document.createElement(
+        'amp-story-interactive-results'
+      );
+      ampStoryResultsEl.getResources = () => win.__AMP_SERVICES.resources.obj;
+
+      storeService = new AmpStoryStoreService(win);
+      registerServiceBuilder(win, 'story-store', function () {
+        return storeService;
+      });
+
+      storyEl = win.document.createElement('amp-story');
+      const storyPage = win.document.createElement('amp-story-page');
+      const gridLayer = win.document.createElement('amp-story-grid-layer');
+      gridLayer.appendChild(ampStoryResultsEl);
+      storyPage.appendChild(gridLayer);
+      storyEl.appendChild(storyPage);
+
+      win.document.body.appendChild(storyEl);
+      ampStoryResults = new AmpStoryInteractiveResults(ampStoryResultsEl);
+      env.sandbox
+        .stub(ampStoryResults, 'mutateElement')
+        .callsFake((fn) => fn());
+    });
+
+    it('should throw an error with fewer than two options', () => {
+      addConfigToInteractive(ampStoryResults, 1);
+      allowConsoleError(() => {
+        expect(() => {
+          ampStoryResults.buildCallback();
+        }).to.throw(/Improper number of options/);
+      });
+    });
+
+    it('should not throw an error with two-four options', () => {
+      addConfigToInteractive(ampStoryResults, 3);
+      expect(() => ampStoryResults.buildCallback()).to.not.throw();
+    });
+
+    it('should throw an error with more than four options', () => {
+      addConfigToInteractive(ampStoryResults, 5);
+      allowConsoleError(() => {
+        expect(() => {
+          ampStoryResults.buildCallback();
+        }).to.throw(/Improper number of options/);
+      });
+    });
+
+    it('should set the text for the category on update', async () => {
+      addConfigToInteractive(ampStoryResults, 3);
+      ampStoryResults.buildCallback();
+      await ampStoryResults.layoutCallback();
+      storeService.dispatch(Action.ADD_INTERACTIVE_REACT, {
+        'interactiveId': 'i',
+        'option': {'resultscategory': 'results-category 2'},
+      });
+      expect(
+        ampStoryResults.rootEl_.querySelector(
+          '.i-amphtml-story-interactive-results-title'
+        ).textContent
+      ).to.equal('results-category 2');
+    });
+  }
+);


### PR DESCRIPTION
This PR creates the results page for categorical results.

The amp-story-interactive-results will receive the state update when an interactive is completed, and calculate the category to fetch the attributes for it and populate the component.

The interactive-results-category component can be configured as follows:

```html
<amp-story-interactive-results
    style="--interactive-accent-color: red" theme="dark"
    prompt-text="You are a"
    option-1-results-category="Dog" option-1-text="You are a fun intelligent creature" option-1-image="dog.png"
    option-2-results-category="Cat" option-1-text="You are a calm humble creature" option-2-image="cat.png">
</amp-story-interactive-results>
```

Likewise, poll components that want to specify the category per-option can do it as follows:
```html
<amp-story-interactive-poll
    style="--interactive-accent-color: red" theme="dark"
    prompt-text="What is your favorite food?"
    option-1-results-category="Dog" option-1-text="Bones"
    option-2-results-category="Cat" option-1-text="Fish">
</amp-story-interactive-poll>
```

This makes the configurations very similar, making the `option-#-category` attribute match to assign a given category to the option. The `option-#-text` attribute is reused, as well as `option-#-image` for (future) image polls.
It also uses the same `--interactive-accent-color` and `theme="dark"` variants by using the same variables.

Light theme vs dark theme vs customizable text attributes (annotated):
<img src="https://user-images.githubusercontent.com/22420856/85773612-09bade00-b6ec-11ea-898f-75884e1dcac7.png" height=300px> <img src="https://user-images.githubusercontent.com/22420856/85773639-12abaf80-b6ec-11ea-8893-e0de859388c7.png" height=300px> <img src="https://user-images.githubusercontent.com/22420856/85779265-6b317b80-b6f1-11ea-867d-785c2f8ae089.png" height=300px>