### PR TITLE
🐛 Bug fix: Undo the changes for adsense ad size overwrite logic.

### DIFF
--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -298,13 +298,15 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
       this.element.getAttribute('data-adtest') ||
       isInManualExperiment(this.element);
 
-    // By default, the ad uses full-width. It will be overwritten
-    // if the publisher uses fixed size tag or it's converted to container-width.
-    this.size_ = this.getIntersectionElementLayoutBox();
     const width = Number(this.element.getAttribute('width'));
     const height = Number(this.element.getAttribute('height'));
-    if (!isNaN(width) && !isNaN(height)) {
+    if (
+      this.responsiveState_ != null &&
+      this.responsiveState_.isContainerWidthState()
+    ) {
       this.size_ = {width, height};
+    } else {
+      this.size_ = this.getIntersectionElementLayoutBox();
     }
 
     const sizeToSend = this.isSinglePageStoryAd

--- a/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
@@ -96,6 +96,18 @@ describes.realWin(
           return Promise.reject(new Error('No token'));
         },
       });
+      env.sandbox
+        .stub(impl, 'getIntersectionElementLayoutBox')
+        .callsFake(() => {
+          return {
+            top: 0,
+            bottom: 0,
+            left: 0,
+            right: 0,
+            width: 320,
+            height: 50,
+          };
+        });
     });
 
     /**


### PR DESCRIPTION
**Overview**
In a previous experiment cleanup [submit](https://github.com/ampproject/amphtml/pull/28957/files), the [code changes](https://screenshot.googleplex.com/fsSHfQm2RYq) introduced a bug during refactoring. This CL tried to undo the changes to the ad size logic but keep the outdated experiment deleted.

**Issues:**
Based on the current logic, if the AMP ad elements happen to have odd attribute values like width=0, the right values from getIntersectionElementLayoutBox could be overwritten.

An example from @nbeloglazov:  https://kban.me/article/9045?amp=1&display=b&amp_event-read-body 
The ad request will look like
`GET /pagead/ads?adsid=*&client=ca-pub-7593099783759275&format=0x320&w=0&h=320&iu=6222457915&adk=2108771703&output=html&bc=7&pv=1&wgl=1&asnt=0-2321678494345226860&dff=Gudea%2C%20Tahoma%2C%20Arial&prev_fmts=0x320&prev_slotnames=8036234470&brdim=0%2C0%2C0%2C0%2C375%2C0%2C375%2C812%2C375%2C749&ifi=2&pfx=0&adf=1071831201&nhd=0&adx=21&ady=15026&oid=2&is_amp=5&amp_v=2007040248002&d_imp=1&c=21000565&ga_cid=*&ga_hid=*&dt=1595239060098&biw=375&bih=749&u_aw=375&u_ah=812&u_cd=32&u_w=375&u_h=812&u_tz=540&u_his=5&vis=1&scr_x=0&scr_y=12166&url=https%3A%2F%2Fkban.me%2Farticle%2F9045&loc=https%3A%2F%2Fkban.me%2Farticle%2F9045%3Famp%3D1%26display%3Db%26amp_event-read-body&ref=https%3A%2F%2Fkban-me.cdn.ampproject.org&bdt=124629&dtd=8&__amp_source_origin=https%3A%2F%2Fkban.me HTTP/1.1`

See the internal [issue link](https://buganizer.corp.google.com/issues/161723080) for more details.



**The verifications after the fix:**
Using the same example, I run local mode to verify that the 'format' will be rendered correctly once the changes are undo:
See the screenshot for details: https://screenshot.googleplex.com/kBHKAyXAT89


PTAL: @glevitzky, @nbeloglazov, @yuanlx, @charliereams



