### PR TITLE
🐛 Respect template HTML for strings of many elements

### DIFF
--- a/extensions/amp-autocomplete/0.1/amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/amp-autocomplete.js
@@ -35,7 +35,7 @@ import {dict, hasOwn, map, ownProperty} from '../../../src/utils/object';
 import {getValueForExpr, tryParseJson} from '../../../src/json';
 import {includes, startsWith} from '../../../src/string';
 import {isAmp4Email} from '../../../src/format';
-import {isArray, isEnumValue, toArray} from '../../../src/types';
+import {isArray, isEnumValue} from '../../../src/types';
 import {mod} from '../../../src/utils/math';
 import {once} from '../../../src/utils/function';
 import {removeChildren, tryFocus} from '../../../src/dom';
@@ -725,9 +725,7 @@ export class AmpAutocomplete extends AMP.BaseElement {
       renderPromise = this.getSsrTemplateHelper()
         .applySsrOrCsrTemplate(this.element, filteredData)
         .then((rendered) => {
-          const elements = isArray(rendered)
-            ? rendered
-            : toArray(rendered.children);
+          const elements = isArray(rendered) ? rendered : [rendered];
           elements.forEach((child) => {
             if (child.hasAttribute('data-disabled')) {
               child.setAttribute('aria-disabled', 'true');

--- a/extensions/amp-autocomplete/0.1/test/test-amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/test/test-amp-autocomplete.js
@@ -73,13 +73,11 @@ describes.realWin(
 
     function getRenderedSuggestions() {
       const html = htmlFor(doc);
-      return html`
-        <div>
-          <div data-value="apple"></div>
-          <div data-value="mango"></div>
-          <div data-value="pear"></div>
-        </div>
-      `;
+      return [
+        html`<div data-value="apple"></div>`,
+        html`<div data-value="mango"></div>`,
+        html`<div data-value="pear"></div>`,
+      ];
     }
 
     describe('mutatedAttributesCallback_()', () => {
@@ -956,8 +954,8 @@ describes.realWin(
       impl = await buildAmpAutocomplete(true);
       const sourceData = ['apple', 'mango', 'pear'];
       const rendered = getRenderedSuggestions();
-      rendered.children[2].removeAttribute('data-value', '');
-      rendered.children[2].setAttribute('data-disabled', '');
+      rendered[2].removeAttribute('data-value', '');
+      rendered[2].setAttribute('data-disabled', '');
       env.sandbox
         .stub(impl.getSsrTemplateHelper(), 'applySsrOrCsrTemplate')
         .returns(Promise.resolve(rendered));

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -1296,12 +1296,19 @@ export class AmpForm {
         p = this.ssrTemplateHelper_
           .applySsrOrCsrTemplate(devAssert(container), data)
           .then((rendered) => {
-            rendered.id = messageId;
-            rendered.setAttribute('i-amphtml-rendered', '');
+            let renderContainer;
+            if (isArray(rendered)) {
+              renderContainer = document.createElement('div');
+              rendered.forEach((child) => renderContainer.appendChild(child));
+            } else {
+              renderContainer = rendered;
+            }
+            renderContainer.id = messageId;
+            renderContainer.setAttribute('i-amphtml-rendered', '');
             return this.mutator_.mutateElement(
               dev().assertElement(container),
               () => {
-                container.appendChild(rendered);
+                container.appendChild(dev().assertElement(renderContainer));
                 const renderedEvent = createCustomEvent(
                   this.win_,
                   AmpEvents.DOM_UPDATE,

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -1296,10 +1296,15 @@ export class AmpForm {
         p = this.ssrTemplateHelper_
           .applySsrOrCsrTemplate(devAssert(container), data)
           .then((rendered) => {
+            // TODO(caroqliu): Simplify section appending rendered contents to DOM.
             let renderContainer;
             if (isArray(rendered)) {
-              renderContainer = document.createElement('div');
-              rendered.forEach((child) => renderContainer.appendChild(child));
+              if (rendered.length === 1) {
+                renderContainer = rendered[0];
+              } else {
+                renderContainer = document.createElement('div');
+                rendered.forEach((child) => renderContainer.appendChild(child));
+              }
             } else {
               renderContainer = rendered;
             }

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -1296,7 +1296,7 @@ export class AmpForm {
         p = this.ssrTemplateHelper_
           .applySsrOrCsrTemplate(devAssert(container), data)
           .then((rendered) => {
-            // TODO(caroqliu): Simplify section appending rendered contents to DOM.
+            // TODO(#29566): Simplify section appending rendered contents to DOM.
             let renderContainer;
             if (isArray(rendered)) {
               if (rendered.length === 1) {

--- a/extensions/amp-mustache/0.1/amp-mustache.js
+++ b/extensions/amp-mustache/0.1/amp-mustache.js
@@ -115,8 +115,7 @@ export class AmpMustache extends BaseTemplate {
   setHtml(html) {
     const wrapped = `<div>${html}</div>`;
     const serialized = this.serializeHtml_(wrapped);
-    const unwrapped = this.unwrap(serialized);
-    return unwrapped == serialized ? this.unwrapAsArray(serialized) : unwrapped;
+    return this.forceUnwrap(serialized);
   }
 
   /** @override */

--- a/extensions/amp-mustache/0.1/amp-mustache.js
+++ b/extensions/amp-mustache/0.1/amp-mustache.js
@@ -113,7 +113,10 @@ export class AmpMustache extends BaseTemplate {
 
   /** @override */
   setHtml(html) {
-    return this.serializeHtml_(html);
+    const wrapped = `<div>${html}</div>`;
+    const serialized = this.serializeHtml_(wrapped);
+    const unwrapped = this.unwrap(serialized);
+    return unwrapped == serialized ? this.unwrapAsArray(serialized) : unwrapped;
   }
 
   /** @override */

--- a/extensions/amp-mustache/0.1/amp-mustache.js
+++ b/extensions/amp-mustache/0.1/amp-mustache.js
@@ -115,7 +115,7 @@ export class AmpMustache extends BaseTemplate {
   setHtml(html) {
     const wrapped = `<div>${html}</div>`;
     const serialized = this.serializeHtml_(wrapped);
-    return this.forceUnwrap(serialized);
+    return this.unwrapChildren(serialized);
   }
 
   /** @override */
@@ -143,7 +143,7 @@ export class AmpMustache extends BaseTemplate {
     const root = doc.createElement('div');
     const sanitized = sanitizeHtml(html, doc);
     root./*OK*/ innerHTML = sanitized;
-    return this.unwrap(root);
+    return this.tryUnwrap(root);
   }
 }
 

--- a/extensions/amp-mustache/0.1/test/test-amp-mustache.js
+++ b/extensions/amp-mustache/0.1/test/test-amp-mustache.js
@@ -606,8 +606,16 @@ describes.repeated(
         expect(result./*OK*/ innerHTML).to.equal('abc');
       });
 
+      it('should wrap singular text node output', () => {
+        templateElement./*OK*/ innerHTML = 'abc';
+        template.compileCallback();
+        const result = template.setHtml('abc');
+        expect(result.tagName).to.equal('DIV');
+        expect(result./*OK*/ innerHTML).to.equal('abc');
+      });
+
       it('should unwrap output with many elements', () => {
-        templateElement./*OK*/ innerHTML = '<a>abc</a><a>def</a>';
+        templateElement./*OK*/ innerHTML = `<a>abc</a><a>def</a>`;
         template.compileCallback();
         const result = template.setHtml('<a>abc</a><a>def</a>');
         expect(result).to.have.length(2);
@@ -619,9 +627,11 @@ describes.repeated(
       });
 
       it('should unwrap output with many elements and wrap text nodes', () => {
-        templateElement./*OK*/ innerHTML = '<a>abc</a>def<a>ghi</ghi>';
+        templateElement./*OK*/ innerHTML = `  <a>abc</a>
+        def
+        <a>ghi  </a>`;
         template.compileCallback();
-        const result = template.setHtml('<a>abc</a>def<a>ghi</ghi>');
+        const result = template.setHtml('<a>abc</a>def<a>ghi</a>');
         expect(result).to.have.length(3);
         const {0: first, 1: second, 2: third} = result;
         expect(first.tagName).to.equal('A');

--- a/extensions/amp-mustache/0.1/test/test-amp-mustache.js
+++ b/extensions/amp-mustache/0.1/test/test-amp-mustache.js
@@ -627,11 +627,12 @@ describes.repeated(
       });
 
       it('should unwrap output with many elements and wrap text nodes', () => {
-        templateElement./*OK*/ innerHTML = `  <a>abc</a>
+        const html = `<a>abc</a>
         def
         <a>ghi  </a>`;
+        templateElement./*OK*/ innerHTML = html;
         template.compileCallback();
-        const result = template.setHtml('<a>abc</a>def<a>ghi</a>');
+        const result = template.setHtml(html);
         expect(result).to.have.length(3);
         const {0: first, 1: second, 2: third} = result;
         expect(first.tagName).to.equal('A');
@@ -639,7 +640,29 @@ describes.repeated(
         expect(second.tagName).to.equal('DIV');
         expect(second./*OK*/ innerHTML).to.equal('def');
         expect(third.tagName).to.equal('A');
-        expect(third./*OK*/ innerHTML).to.equal('ghi');
+        expect(third./*OK*/ innerHTML).to.equal('ghi  ');
+      });
+
+      it('should unwrap output with many elements and preserve subtrees', () => {
+        const html = `
+        <div>
+          <a>abc</a>
+        </div>
+        def
+        <a>ghi  </a>`;
+        templateElement./*OK*/ innerHTML = html;
+        template.compileCallback();
+        const result = template.setHtml(html);
+        expect(result).to.have.length(3);
+        const {0: first, 1: second, 2: third} = result;
+        expect(first.tagName).to.equal('DIV');
+        expect(first.children).to.have.length(1);
+        expect(first.firstElementChild.tagName).to.equal('A');
+        expect(first.firstElementChild./*OK*/ innerHTML).to.equal('abc');
+        expect(second.tagName).to.equal('DIV');
+        expect(second./*OK*/ innerHTML).to.equal('def');
+        expect(third.tagName).to.equal('A');
+        expect(third./*OK*/ innerHTML).to.equal('ghi  ');
       });
     });
   }

--- a/extensions/amp-mustache/0.1/test/test-amp-mustache.js
+++ b/extensions/amp-mustache/0.1/test/test-amp-mustache.js
@@ -599,7 +599,6 @@ describes.repeated(
 
     describe('setHtml()', () => {
       it('should unwrap singular element output', () => {
-        templateElement./*OK*/ innerHTML = '<a>abc</a>';
         template.compileCallback();
         const result = template.setHtml('<a>abc</a>');
         expect(result.tagName).to.equal('A');
@@ -607,7 +606,6 @@ describes.repeated(
       });
 
       it('should wrap singular text node output', () => {
-        templateElement./*OK*/ innerHTML = 'abc';
         template.compileCallback();
         const result = template.setHtml('abc');
         expect(result.tagName).to.equal('DIV');
@@ -615,7 +613,6 @@ describes.repeated(
       });
 
       it('should unwrap output with many elements', () => {
-        templateElement./*OK*/ innerHTML = `<a>abc</a><a>def</a>`;
         template.compileCallback();
         const result = template.setHtml('<a>abc</a><a>def</a>');
         expect(result).to.have.length(2);
@@ -630,7 +627,6 @@ describes.repeated(
         const html = `<a>abc</a>
         def
         <a>ghi  </a>`;
-        templateElement./*OK*/ innerHTML = html;
         template.compileCallback();
         const result = template.setHtml(html);
         expect(result).to.have.length(3);
@@ -650,7 +646,6 @@ describes.repeated(
         </div>
         def
         <a>ghi  </a>`;
-        templateElement./*OK*/ innerHTML = html;
         template.compileCallback();
         const result = template.setHtml(html);
         expect(result).to.have.length(3);

--- a/extensions/amp-mustache/0.1/test/test-amp-mustache.js
+++ b/extensions/amp-mustache/0.1/test/test-amp-mustache.js
@@ -601,15 +601,17 @@ describes.repeated(
       it('should unwrap singular element output', () => {
         template.compileCallback();
         const result = template.setHtml('<a>abc</a>');
-        expect(result.tagName).to.equal('A');
-        expect(result./*OK*/ innerHTML).to.equal('abc');
+        expect(result).to.have.length(1);
+        expect(result[0].tagName).to.equal('A');
+        expect(result[0]./*OK*/ innerHTML).to.equal('abc');
       });
 
       it('should wrap singular text node output', () => {
         template.compileCallback();
         const result = template.setHtml('abc');
-        expect(result.tagName).to.equal('DIV');
-        expect(result./*OK*/ innerHTML).to.equal('abc');
+        expect(result).to.have.length(1);
+        expect(result[0].tagName).to.equal('DIV');
+        expect(result[0]./*OK*/ innerHTML).to.equal('abc');
       });
 
       it('should unwrap output with many elements', () => {

--- a/extensions/amp-mustache/0.1/test/test-amp-mustache.js
+++ b/extensions/amp-mustache/0.1/test/test-amp-mustache.js
@@ -589,12 +589,48 @@ describes.repeated(
       });
     });
 
-    it('should unwrap output', () => {
+    it('should unwrap output on compile', () => {
       innerHtmlSetup('<a>abc</a>');
       template.compileCallback();
       const result = template.render({});
       expect(result.tagName).to.equal('A');
       expect(result./*OK*/ innerHTML).to.equal('abc');
+    });
+
+    describe('setHtml()', () => {
+      it('should unwrap singular element output', () => {
+        templateElement./*OK*/ innerHTML = '<a>abc</a>';
+        template.compileCallback();
+        const result = template.setHtml('<a>abc</a>');
+        expect(result.tagName).to.equal('A');
+        expect(result./*OK*/ innerHTML).to.equal('abc');
+      });
+
+      it('should unwrap output with many elements', () => {
+        templateElement./*OK*/ innerHTML = '<a>abc</a><a>def</a>';
+        template.compileCallback();
+        const result = template.setHtml('<a>abc</a><a>def</a>');
+        expect(result).to.have.length(2);
+        const {0: first, 1: second} = result;
+        expect(first.tagName).to.equal('A');
+        expect(first./*OK*/ innerHTML).to.equal('abc');
+        expect(second.tagName).to.equal('A');
+        expect(second./*OK*/ innerHTML).to.equal('def');
+      });
+
+      it('should unwrap output with many elements and wrap text nodes', () => {
+        templateElement./*OK*/ innerHTML = '<a>abc</a>def<a>ghi</ghi>';
+        template.compileCallback();
+        const result = template.setHtml('<a>abc</a>def<a>ghi</ghi>');
+        expect(result).to.have.length(3);
+        const {0: first, 1: second, 2: third} = result;
+        expect(first.tagName).to.equal('A');
+        expect(first./*OK*/ innerHTML).to.equal('abc');
+        expect(second.tagName).to.equal('DIV');
+        expect(second./*OK*/ innerHTML).to.equal('def');
+        expect(third.tagName).to.equal('A');
+        expect(third./*OK*/ innerHTML).to.equal('ghi');
+      });
     });
   }
 );

--- a/extensions/amp-mustache/0.2/amp-mustache.js
+++ b/extensions/amp-mustache/0.2/amp-mustache.js
@@ -118,7 +118,7 @@ export class AmpMustache extends BaseTemplate {
   setHtml(html) {
     const wrapped = `<div>${html}</div>`;
     const purified = this.purifyAndSetHtml_(wrapped);
-    return this.forceUnwrap(purified);
+    return this.unwrapChildren(purified);
   }
 
   /** @override */
@@ -145,7 +145,7 @@ export class AmpMustache extends BaseTemplate {
   purifyAndSetHtml_(html) {
     const body = this.purifier_.purifyHtml(`<div>${html}</div>`);
     const div = body.firstElementChild;
-    return this.unwrap(div);
+    return this.tryUnwrap(div);
   }
 }
 

--- a/extensions/amp-mustache/0.2/amp-mustache.js
+++ b/extensions/amp-mustache/0.2/amp-mustache.js
@@ -118,8 +118,7 @@ export class AmpMustache extends BaseTemplate {
   setHtml(html) {
     const wrapped = `<div>${html}</div>`;
     const purified = this.purifyAndSetHtml_(wrapped);
-    const unwrapped = this.unwrap(purified);
-    return unwrapped == purified ? this.unwrapAsArray(purified) : unwrapped;
+    return this.forceUnwrap(purified);
   }
 
   /** @override */

--- a/extensions/amp-mustache/0.2/amp-mustache.js
+++ b/extensions/amp-mustache/0.2/amp-mustache.js
@@ -116,7 +116,10 @@ export class AmpMustache extends BaseTemplate {
 
   /** @override */
   setHtml(html) {
-    return this.purifyAndSetHtml_(html);
+    const wrapped = `<div>${html}</div>`;
+    const purified = this.purifyAndSetHtml_(wrapped);
+    const unwrapped = this.unwrap(purified);
+    return unwrapped == purified ? this.unwrapAsArray(purified) : unwrapped;
   }
 
   /** @override */

--- a/extensions/amp-mustache/0.2/test/test-amp-mustache.js
+++ b/extensions/amp-mustache/0.2/test/test-amp-mustache.js
@@ -602,15 +602,17 @@ describes.repeated(
       it('should unwrap singular element output', () => {
         template.compileCallback();
         const result = template.setHtml('<a>abc</a>');
-        expect(result.tagName).to.equal('A');
-        expect(result./*OK*/ innerHTML).to.equal('abc');
+        expect(result).to.have.length(1);
+        expect(result[0].tagName).to.equal('A');
+        expect(result[0]./*OK*/ innerHTML).to.equal('abc');
       });
 
       it('should be undefined for singular text node output', () => {
         template.compileCallback();
         const result = template.setHtml('abc');
-        expect(result.tagName).to.equal('DIV');
-        expect(result./*OK*/ innerHTML).to.equal('abc');
+        expect(result).to.have.length(1);
+        expect(result[0].tagName).to.equal('DIV');
+        expect(result[0]./*OK*/ innerHTML).to.equal('abc');
       });
 
       it('should unwrap output with many elements', () => {

--- a/extensions/amp-mustache/0.2/test/test-amp-mustache.js
+++ b/extensions/amp-mustache/0.2/test/test-amp-mustache.js
@@ -600,7 +600,6 @@ describes.repeated(
 
     describe('setHtml()', () => {
       it('should unwrap singular element output', () => {
-        templateElement./*OK*/ innerHTML = '<a>abc</a>';
         template.compileCallback();
         const result = template.setHtml('<a>abc</a>');
         expect(result.tagName).to.equal('A');
@@ -608,7 +607,6 @@ describes.repeated(
       });
 
       it('should be undefined for singular text node output', () => {
-        templateElement./*OK*/ innerHTML = 'abc';
         template.compileCallback();
         const result = template.setHtml('abc');
         expect(result.tagName).to.equal('DIV');
@@ -616,7 +614,6 @@ describes.repeated(
       });
 
       it('should unwrap output with many elements', () => {
-        templateElement./*OK*/ innerHTML = '<a>abc</a><a>def</a>';
         template.compileCallback();
         const result = template.setHtml('<a>abc</a><a>def</a>');
         expect(result).to.have.length(2);
@@ -631,7 +628,6 @@ describes.repeated(
         const html = `<a>abc</a>
         def
         <a>ghi  </a>`;
-        templateElement./*OK*/ innerHTML = html;
         template.compileCallback();
         const result = template.setHtml(html);
         expect(result).to.have.length(3);
@@ -651,7 +647,6 @@ describes.repeated(
         </div>
         def
         <a>ghi  </a>`;
-        templateElement./*OK*/ innerHTML = html;
         template.compileCallback();
         const result = template.setHtml(html);
         expect(result).to.have.length(3);

--- a/extensions/amp-mustache/0.2/test/test-amp-mustache.js
+++ b/extensions/amp-mustache/0.2/test/test-amp-mustache.js
@@ -598,12 +598,40 @@ describes.repeated(
       });
     });
 
-    it('should unwrap output', () => {
-      templateElement./*OK*/ innerHTML = '<a>abc</a>';
-      template.compileCallback();
-      const result = template.setHtml('<a>abc</a>');
-      expect(result.tagName).to.equal('A');
-      expect(result./*OK*/ innerHTML).to.equal('abc');
+    describe('setHtml()', () => {
+      it('should unwrap singular element output', () => {
+        templateElement./*OK*/ innerHTML = '<a>abc</a>';
+        template.compileCallback();
+        const result = template.setHtml('<a>abc</a>');
+        expect(result.tagName).to.equal('A');
+        expect(result./*OK*/ innerHTML).to.equal('abc');
+      });
+
+      it('should unwrap output with many elements', () => {
+        templateElement./*OK*/ innerHTML = '<a>abc</a><a>def</a>';
+        template.compileCallback();
+        const result = template.setHtml('<a>abc</a><a>def</a>');
+        expect(result).to.have.length(2);
+        const {0: first, 1: second} = result;
+        expect(first.tagName).to.equal('A');
+        expect(first./*OK*/ innerHTML).to.equal('abc');
+        expect(second.tagName).to.equal('A');
+        expect(second./*OK*/ innerHTML).to.equal('def');
+      });
+
+      it('should unwrap output with many elements and wrap text nodes', () => {
+        templateElement./*OK*/ innerHTML = '<a>abc</a>def<a>ghi</ghi>';
+        template.compileCallback();
+        const result = template.setHtml('<a>abc</a>def<a>ghi</ghi>');
+        expect(result).to.have.length(3);
+        const {0: first, 1: second, 2: third} = result;
+        expect(first.tagName).to.equal('A');
+        expect(first./*OK*/ innerHTML).to.equal('abc');
+        expect(second.tagName).to.equal('DIV');
+        expect(second./*OK*/ innerHTML).to.equal('def');
+        expect(third.tagName).to.equal('A');
+        expect(third./*OK*/ innerHTML).to.equal('ghi');
+      });
     });
   }
 );

--- a/extensions/amp-mustache/0.2/test/test-amp-mustache.js
+++ b/extensions/amp-mustache/0.2/test/test-amp-mustache.js
@@ -628,9 +628,12 @@ describes.repeated(
       });
 
       it('should unwrap output with many elements and wrap text nodes', () => {
-        templateElement./*OK*/ innerHTML = '<a>abc</a>def<a>ghi</ghi>';
+        const html = `<a>abc</a>
+        def
+        <a>ghi  </a>`;
+        templateElement./*OK*/ innerHTML = html;
         template.compileCallback();
-        const result = template.setHtml('<a>abc</a>def<a>ghi</ghi>');
+        const result = template.setHtml(html);
         expect(result).to.have.length(3);
         const {0: first, 1: second, 2: third} = result;
         expect(first.tagName).to.equal('A');
@@ -638,7 +641,29 @@ describes.repeated(
         expect(second.tagName).to.equal('DIV');
         expect(second./*OK*/ innerHTML).to.equal('def');
         expect(third.tagName).to.equal('A');
-        expect(third./*OK*/ innerHTML).to.equal('ghi');
+        expect(third./*OK*/ innerHTML).to.equal('ghi  ');
+      });
+
+      it('should unwrap output with many elements and preserve subtrees', () => {
+        const html = `
+        <div>
+          <a>abc</a>
+        </div>
+        def
+        <a>ghi  </a>`;
+        templateElement./*OK*/ innerHTML = html;
+        template.compileCallback();
+        const result = template.setHtml(html);
+        expect(result).to.have.length(3);
+        const {0: first, 1: second, 2: third} = result;
+        expect(first.tagName).to.equal('DIV');
+        expect(first.children).to.have.length(1);
+        expect(first.firstElementChild.tagName).to.equal('A');
+        expect(first.firstElementChild./*OK*/ innerHTML).to.equal('abc');
+        expect(second.tagName).to.equal('DIV');
+        expect(second./*OK*/ innerHTML).to.equal('def');
+        expect(third.tagName).to.equal('A');
+        expect(third./*OK*/ innerHTML).to.equal('ghi  ');
       });
     });
   }

--- a/extensions/amp-mustache/0.2/test/test-amp-mustache.js
+++ b/extensions/amp-mustache/0.2/test/test-amp-mustache.js
@@ -607,6 +607,14 @@ describes.repeated(
         expect(result./*OK*/ innerHTML).to.equal('abc');
       });
 
+      it('should be undefined for singular text node output', () => {
+        templateElement./*OK*/ innerHTML = 'abc';
+        template.compileCallback();
+        const result = template.setHtml('abc');
+        expect(result.tagName).to.equal('DIV');
+        expect(result./*OK*/ innerHTML).to.equal('abc');
+      });
+
       it('should unwrap output with many elements', () => {
         templateElement./*OK*/ innerHTML = '<a>abc</a><a>def</a>';
         template.compileCallback();

--- a/src/service/template-impl.js
+++ b/src/service/template-impl.js
@@ -129,7 +129,7 @@ export class BaseTemplate {
    * Unwraps the root element and returns any children in an array.
    * Text node children are normalized inside a <div>.
    * @param {!Element} root
-   * @return {!Element|!Array<!Element>}
+   * @return {!Array<!Element>}
    * @protected @final
    */
   unwrapChildren(root) {

--- a/src/service/template-impl.js
+++ b/src/service/template-impl.js
@@ -94,29 +94,8 @@ export class BaseTemplate {
    * @protected @final
    */
   unwrap(root) {
-    let singleElement = null;
-    for (let n = root.firstChild; n != null; n = n.nextSibling) {
-      if (n.nodeType == /* TEXT */ 3) {
-        if (n.textContent.trim()) {
-          // Non-empty text node - can't unwrap.
-          singleElement = null;
-          break;
-        }
-      } else if (n.nodeType == /* COMMENT */ 8) {
-        // Ignore comments.
-      } else if (n.nodeType == /* ELEMENT */ 1) {
-        if (!singleElement) {
-          singleElement = dev().assertElement(n);
-        } else {
-          // This is not the first element - can't unwrap.
-          singleElement = null;
-          break;
-        }
-      } else {
-        singleElement = null;
-      }
-    }
-    return singleElement || root;
+    const unwrapped = this.forceUnwrap(root);
+    return dev().assertElement(unwrapped.length ? root : unwrapped);
   }
 
   /**

--- a/src/service/template-impl.js
+++ b/src/service/template-impl.js
@@ -107,9 +107,8 @@ export class BaseTemplate {
   }
 
   /**
-   * Helps the template implementation to unwrap the root element. The root
-   * element can be unwrapped only when it contains a single element or a
-   * single element surrounded by empty text nodes.
+   * Unwraps the root element. If root has a single element child,
+   * returns the child. Otherwise, returns root.
    * @param {!Element} root
    * @return {!Element}
    * @protected @final
@@ -127,19 +126,14 @@ export class BaseTemplate {
   }
 
   /**
-   * Helps the template implementation to unwrap the root element. The root
-   * element contents are unwrapped as an array of elements. Any text node
-   * children are normalized inside a <div>. Any root with non-element children
-   * is returned as is to preserve the root tag rather than replaceed with <div>.
+   * Unwraps the root element and returns any children in an array.
+   * Text node children are normalized inside a <div>.
    * @param {!Element} root
    * @return {!Element|!Array<!Element>}
    * @protected @final
    */
   unwrapChildren(root) {
     const children = [];
-    if (!root.firstElementChild) {
-      return root;
-    }
     this.visitChildren_(root, (c) => {
       if (typeof c == 'string') {
         const element = this.win.document.createElement('div');
@@ -149,7 +143,7 @@ export class BaseTemplate {
         children.push(c);
       }
     });
-    return children.length === 1 ? children[0] : children;
+    return children;
   }
 
   /**

--- a/src/service/template-impl.js
+++ b/src/service/template-impl.js
@@ -93,8 +93,8 @@ export class BaseTemplate {
    * @return {!Element}
    * @protected @final
    */
-  unwrap(root) {
-    const unwrapped = this.forceUnwrap(root);
+  tryUnwrap(root) {
+    const unwrapped = this.unwrapChildren(root);
     return dev().assertElement(unwrapped.length ? root : unwrapped);
   }
 
@@ -106,7 +106,7 @@ export class BaseTemplate {
    * @return {!Element|!Array<!Element>}
    * @protected @final
    */
-  forceUnwrap(root) {
+  unwrapChildren(root) {
     const elements = [];
     for (let n = root.firstChild; n != null; n = n.nextSibling) {
       if (n.nodeType == /* TEXT */ 3) {

--- a/src/service/template-impl.js
+++ b/src/service/template-impl.js
@@ -124,10 +124,10 @@ export class BaseTemplate {
    * element contents are unwrapped as an array of elements. Any text node
    * children are normalized inside a <div>.
    * @param {!Element} root
-   * @return {!Array<!Element>}
+   * @return {!Element|!Array<!Element>}
    * @protected @final
    */
-  unwrapAsArray(root) {
+  forceUnwrap(root) {
     const elements = [];
     for (let n = root.firstChild; n != null; n = n.nextSibling) {
       if (n.nodeType == /* TEXT */ 3) {
@@ -143,7 +143,7 @@ export class BaseTemplate {
         elements.push(dev().assertElement(n));
       }
     }
-    return elements;
+    return elements.length === 1 ? elements[0] : elements;
   }
 
   /**

--- a/src/service/template-impl.js
+++ b/src/service/template-impl.js
@@ -101,13 +101,17 @@ export class BaseTemplate {
   /**
    * Helps the template implementation to unwrap the root element. The root
    * element contents are unwrapped as an array of elements. Any text node
-   * children are normalized inside a <div>.
+   * children are normalized inside a <div>. Any root with non-element children
+   * is returned as is to preserve the root tag rather than replaceed with <div>.
    * @param {!Element} root
    * @return {!Element|!Array<!Element>}
    * @protected @final
    */
   unwrapChildren(root) {
     const elements = [];
+    if (!root.firstElementChild) {
+      return root;
+    }
     for (let n = root.firstChild; n != null; n = n.nextSibling) {
       if (n.nodeType == /* TEXT */ 3) {
         const content = n.textContent.trim();

--- a/src/ssr-template-helper.js
+++ b/src/ssr-template-helper.js
@@ -114,7 +114,7 @@ export class SsrTemplateHelper {
    * If SSR is supported, data is assumed to be from ssr() above.
    * @param {!Element} element
    * @param {(?JsonObject|string|undefined|!Array)} data
-   * @return {!Promise<!Element>}
+   * @return {!Promise<(!Element|!Array<!Element>)>}
    */
   applySsrOrCsrTemplate(element, data) {
     let renderTemplatePromise;

--- a/test/unit/test-template.js
+++ b/test/unit/test-template.js
@@ -402,17 +402,18 @@ describes.realWin('BaseTemplate', {amp: true}, (env) => {
       const root = doc.createElement('div');
       const element1 = doc.createElement('div');
       root.appendChild(element1);
-      expect(new BaseTemplate(templateElement).unwrapChildren(root)).to.equal(
-        element1
-      );
+      expect(
+        new BaseTemplate(templateElement).unwrapChildren(root)
+      ).to.have.ordered.members([element1]);
     });
 
-    it('should NOT unwrap single non-div element', () => {
+    it('should unwrap single non-div element', () => {
       const root = doc.createElement('a');
       root.textContent = 'abc';
-      expect(new BaseTemplate(templateElement).unwrapChildren(root)).to.equal(
-        root
-      );
+      const result = new BaseTemplate(templateElement).unwrapChildren(root);
+      expect(result).to.have.length(1);
+      expect(result[0].tagName).to.equal('DIV');
+      expect(result[0].textContent).to.equal('abc');
     });
 
     it('should unwrap with empty/whitespace text', () => {
@@ -421,9 +422,9 @@ describes.realWin('BaseTemplate', {amp: true}, (env) => {
       root.appendChild(doc.createTextNode('   '));
       root.appendChild(element1);
       root.appendChild(doc.createTextNode(' \n\t  '));
-      expect(new BaseTemplate(templateElement).unwrapChildren(root)).to.equal(
-        element1
-      );
+      expect(
+        new BaseTemplate(templateElement).unwrapChildren(root)
+      ).to.have.ordered.members([element1]);
     });
 
     it('should unwrap multiple elements', () => {

--- a/test/unit/test-template.js
+++ b/test/unit/test-template.js
@@ -359,7 +359,9 @@ describes.realWin('BaseTemplate', {amp: true}, (env) => {
     const root = doc.createElement('div');
     const element1 = doc.createElement('div');
     root.appendChild(element1);
-    expect(new BaseTemplate(templateElement).unwrap(root)).to.equal(element1);
+    expect(new BaseTemplate(templateElement).tryUnwrap(root)).to.equal(
+      element1
+    );
   });
 
   it('should unwrap with empty/whitespace text', () => {
@@ -368,20 +370,22 @@ describes.realWin('BaseTemplate', {amp: true}, (env) => {
     root.appendChild(doc.createTextNode('   '));
     root.appendChild(element1);
     root.appendChild(doc.createTextNode(' \n\t  '));
-    expect(new BaseTemplate(templateElement).unwrap(root)).to.equal(element1);
+    expect(new BaseTemplate(templateElement).tryUnwrap(root)).to.equal(
+      element1
+    );
   });
 
   it('should NOT unwrap multiple elements', () => {
     const root = doc.createElement('div');
     root.appendChild(doc.createElement('div'));
     root.appendChild(doc.createElement('div'));
-    expect(new BaseTemplate(templateElement).unwrap(root)).to.equal(root);
+    expect(new BaseTemplate(templateElement).tryUnwrap(root)).to.equal(root);
   });
 
   it('should NOT unwrap with non-empty/whitespace text', () => {
     const root = doc.createElement('div');
     root.appendChild(doc.createTextNode('a'));
     root.appendChild(doc.createElement('div'));
-    expect(new BaseTemplate(templateElement).unwrap(root)).to.equal(root);
+    expect(new BaseTemplate(templateElement).tryUnwrap(root)).to.equal(root);
   });
 });

--- a/test/unit/test-template.js
+++ b/test/unit/test-template.js
@@ -355,37 +355,95 @@ describes.realWin('BaseTemplate', {amp: true}, (env) => {
     }).to.throw(/Not implemented/);
   });
 
-  it('should unwrap single element', () => {
-    const root = doc.createElement('div');
-    const element1 = doc.createElement('div');
-    root.appendChild(element1);
-    expect(new BaseTemplate(templateElement).tryUnwrap(root)).to.equal(
-      element1
-    );
+  describe('tryUnwrap()', () => {
+    it('should unwrap single element', () => {
+      const root = doc.createElement('div');
+      const element1 = doc.createElement('div');
+      root.appendChild(element1);
+      expect(new BaseTemplate(templateElement).tryUnwrap(root)).to.equal(
+        element1
+      );
+    });
+
+    it('should unwrap with empty/whitespace text', () => {
+      const root = doc.createElement('div');
+      const element1 = doc.createElement('div');
+      root.appendChild(doc.createTextNode('   '));
+      root.appendChild(element1);
+      root.appendChild(doc.createTextNode(' \n\t  '));
+      expect(new BaseTemplate(templateElement).tryUnwrap(root)).to.equal(
+        element1
+      );
+    });
+
+    it('should NOT unwrap single non-div element', () => {
+      const root = doc.createElement('a');
+      root.textContent = 'abc';
+      expect(new BaseTemplate(templateElement).tryUnwrap(root)).to.equal(root);
+    });
+
+    it('should NOT unwrap multiple elements', () => {
+      const root = doc.createElement('div');
+      root.appendChild(doc.createElement('div'));
+      root.appendChild(doc.createElement('div'));
+      expect(new BaseTemplate(templateElement).tryUnwrap(root)).to.equal(root);
+    });
+
+    it('should NOT unwrap with non-empty/whitespace text', () => {
+      const root = doc.createElement('div');
+      root.appendChild(doc.createTextNode('a'));
+      root.appendChild(doc.createElement('div'));
+      expect(new BaseTemplate(templateElement).tryUnwrap(root)).to.equal(root);
+    });
   });
 
-  it('should unwrap with empty/whitespace text', () => {
-    const root = doc.createElement('div');
-    const element1 = doc.createElement('div');
-    root.appendChild(doc.createTextNode('   '));
-    root.appendChild(element1);
-    root.appendChild(doc.createTextNode(' \n\t  '));
-    expect(new BaseTemplate(templateElement).tryUnwrap(root)).to.equal(
-      element1
-    );
-  });
+  describe('unwrapChildren()', () => {
+    it('should unwrap single element', () => {
+      const root = doc.createElement('div');
+      const element1 = doc.createElement('div');
+      root.appendChild(element1);
+      expect(new BaseTemplate(templateElement).unwrapChildren(root)).to.equal(
+        element1
+      );
+    });
 
-  it('should NOT unwrap multiple elements', () => {
-    const root = doc.createElement('div');
-    root.appendChild(doc.createElement('div'));
-    root.appendChild(doc.createElement('div'));
-    expect(new BaseTemplate(templateElement).tryUnwrap(root)).to.equal(root);
-  });
+    it('should NOT unwrap single non-div element', () => {
+      const root = doc.createElement('a');
+      root.textContent = 'abc';
+      expect(new BaseTemplate(templateElement).unwrapChildren(root)).to.equal(
+        root
+      );
+    });
 
-  it('should NOT unwrap with non-empty/whitespace text', () => {
-    const root = doc.createElement('div');
-    root.appendChild(doc.createTextNode('a'));
-    root.appendChild(doc.createElement('div'));
-    expect(new BaseTemplate(templateElement).tryUnwrap(root)).to.equal(root);
+    it('should unwrap with empty/whitespace text', () => {
+      const root = doc.createElement('div');
+      const element1 = doc.createElement('div');
+      root.appendChild(doc.createTextNode('   '));
+      root.appendChild(element1);
+      root.appendChild(doc.createTextNode(' \n\t  '));
+      expect(new BaseTemplate(templateElement).unwrapChildren(root)).to.equal(
+        element1
+      );
+    });
+
+    it('should unwrap multiple elements', () => {
+      const root = doc.createElement('div');
+      const children = [doc.createElement('div'), doc.createElement('div')];
+      children.forEach((child) => root.appendChild(child));
+      expect(
+        new BaseTemplate(templateElement).unwrapChildren(root)
+      ).to.have.ordered.members(children);
+    });
+
+    it('should unwrap multiple elements and wrap any non-empty/whitespace text', () => {
+      const root = doc.createElement('div');
+      const children = [doc.createTextNode('a'), doc.createElement('div')];
+      children.forEach((child) => root.appendChild(child));
+      const result = new BaseTemplate(templateElement).unwrapChildren(root);
+      expect(result).to.have.length(2);
+      expect(result[0].tagName).to.equal('DIV');
+      expect(result[0].textContent).to.equal('a');
+      expect(result[1]).to.equal(children[1]);
+    });
   });
 });


### PR DESCRIPTION
`amp-mustache` `setHtml` wraps an HTML string of multiple elements with an outer div, silently turning
```
"<div>A</div><div>B</div><div>C</div>"
```
into
```html
<div>
  <div>A</div>
  <div>B</div>
  <div>C</div>
</div>
```

This PR allows `setHtml` to return many elements as an array instead of adding an outer `<div>`, which is not well documented behavior. In the above example it will now return:
```html
[ <div>A</div>,  <div>B</div>,  <div>C</div> ]
```

Notes:
- The result of passing singular elements to `setHtml` (`<div>A</div>`) remains the same (`<div>A</div>`).
- Setting non-element HTML (`"abc"`) results in `<div>abc</div>` prior to and after this change.
- Setting an HTML string that consists of both elements and text nodes will wrap text nodes in `<div>` elements prior to the return. That is, `"<div>A</div>B<div>C</div>"` returns `[ <div>A</div>, <div>B</div>, <div>C</div> ]`. Alternatively we could skip by returning `[ <div>A</div>, <div>C</div> ]` or default to the prior behavior by returning:
  ```
  <div>
    <div>A</div>
    B
    <div>C</div>
  </div>
  ```
  None of these options seem that intuitive so will defer to folks who may have stronger opinions here.

cc @choumx 