### PR TITLE
✨  [bento] Add mutation observer to 'passthroughNonEmpty' children mode in base-element

### DIFF
--- a/extensions/amp-social-share/1.0/amp-social-share.js
+++ b/extensions/amp-social-share/1.0/amp-social-share.js
@@ -73,6 +73,16 @@ const systemShareSupported = (viewer, platform) => {
 
 class AmpSocialShare extends PreactBaseElement {
   /** @override */
+  constructor(element) {
+    super(element);
+
+    /** @private {MutationObserver} */
+    this.observer_ = new MutationObserver(() => {
+      this.mutateProps(dict({}));
+    });
+  }
+
+  /** @override */
   init() {
     const viewer = Services.viewerForDoc(this.element);
     const platform = Services.platformFor(window);
@@ -106,6 +116,20 @@ class AmpSocialShare extends PreactBaseElement {
       isExperimentOn(this.win, 'amp-social-share-bento'),
       'expected amp-social-share-bento experiment to be enabled'
     );
+    return true;
+  }
+
+  /** @override */
+  layoutCallback() {
+    this.observer_.observe(this.element, {
+      childList: true,
+      characterData: true,
+    });
+  }
+
+  /** @override */
+  unlayoutCallback() {
+    this.observer_.disconnect();
     return true;
   }
 
@@ -158,6 +182,7 @@ class AmpSocialShare extends PreactBaseElement {
 /** @override */
 AmpSocialShare['Component'] = SocialShare;
 
+/** @override */
 AmpSocialShare['passthroughNonEmpty'] = true;
 
 /** @override */

--- a/extensions/amp-social-share/1.0/amp-social-share.js
+++ b/extensions/amp-social-share/1.0/amp-social-share.js
@@ -78,7 +78,7 @@ class AmpSocialShare extends PreactBaseElement {
 
     /** @private {MutationObserver} */
     this.observer_ = new MutationObserver(() => {
-      this.mutateProps(dict({}));
+      this.scheduleRender_();
     });
   }
 

--- a/extensions/amp-social-share/1.0/amp-social-share.js
+++ b/extensions/amp-social-share/1.0/amp-social-share.js
@@ -73,16 +73,6 @@ const systemShareSupported = (viewer, platform) => {
 
 class AmpSocialShare extends PreactBaseElement {
   /** @override */
-  constructor(element) {
-    super(element);
-
-    /** @private {MutationObserver} */
-    this.observer_ = new MutationObserver(() => {
-      this.scheduleRender_();
-    });
-  }
-
-  /** @override */
   init() {
     const viewer = Services.viewerForDoc(this.element);
     const platform = Services.platformFor(window);
@@ -116,20 +106,6 @@ class AmpSocialShare extends PreactBaseElement {
       isExperimentOn(this.win, 'amp-social-share-bento'),
       'expected amp-social-share-bento experiment to be enabled'
     );
-    return true;
-  }
-
-  /** @override */
-  layoutCallback() {
-    this.observer_.observe(this.element, {
-      childList: true,
-      characterData: true,
-    });
-  }
-
-  /** @override */
-  unlayoutCallback() {
-    this.observer_.disconnect();
     return true;
   }
 
@@ -183,7 +159,15 @@ class AmpSocialShare extends PreactBaseElement {
 AmpSocialShare['Component'] = SocialShare;
 
 /** @override */
-AmpSocialShare['passthroughNonEmpty'] = true;
+AmpSocialShare['passthroughNonEmpty'] = dict({
+  'callback': function () {
+    this.scheduleRender_();
+  },
+  'options': {
+    'childList': true,
+    'characterData': true,
+  },
+});
 
 /** @override */
 AmpSocialShare['props'] = {

--- a/extensions/amp-social-share/1.0/amp-social-share.js
+++ b/extensions/amp-social-share/1.0/amp-social-share.js
@@ -159,15 +159,7 @@ class AmpSocialShare extends PreactBaseElement {
 AmpSocialShare['Component'] = SocialShare;
 
 /** @override */
-AmpSocialShare['passthroughNonEmpty'] = dict({
-  'callback': function () {
-    this.scheduleRender_();
-  },
-  'options': {
-    'childList': true,
-    'characterData': true,
-  },
-});
+AmpSocialShare['passthroughNonEmpty'] = true;
 
 /** @override */
 AmpSocialShare['props'] = {

--- a/src/preact/base-element.js
+++ b/src/preact/base-element.js
@@ -82,11 +82,11 @@ export class PreactBaseElement extends AMP.BaseElement {
     /** @private {boolean} */
     this.mounted_ = true;
 
-    /** @private {MutationObserver|null} */
+    /** @private {?MutationObserver} */
     this.observer_ = this.constructor['passthroughNonEmpty']
-      ? new MutationObserver(
-          this.constructor['passthroughNonEmpty']['callback'].bind(this)
-        )
+      ? new MutationObserver(() => {
+          this.scheduleRender_();
+        })
       : null;
   }
 
@@ -131,7 +131,7 @@ export class PreactBaseElement extends AMP.BaseElement {
     if (this.observer_) {
       this.observer_.observe(
         this.element,
-        this.constructor['passthroughNonEmpty']['options']
+        this.constructor['mutationObserverOptions']['passthroughNonEmpty']
       );
     }
     return deferred.promise;
@@ -287,17 +287,21 @@ PreactBaseElement['passthrough'] = false;
  * the Preact environment to have conditional behavior depending on whether
  * or not there are children.
  *
- * The base-element provides support for a mutation observer when using
- * passthroughNonEmpty.  Provide the following two properties in an object
- *  - callback: This will be called when a mutation is observed.  Use an
- *      anonymous function (not an arrow function) if the callback references
- *      other methods within this class.
- *  - options: Specify the types of mutations to observe.  More information:
- *      https://developer.mozilla.org/en-US/docs/Web/API/MutationObserverInit
- *
- * @protected {JsonObject|null}
+ * @protected {boolean}
  */
-PreactBaseElement['passthroughNonEmpty'] = null;
+PreactBaseElement['passthroughNonEmpty'] = false;
+
+/**
+ * A static map for storing sets of options to be used in the Mutation Observer
+ *
+ * @protected {boolean}
+ */
+PreactBaseElement['mutationObserverOptions'] = {
+  'passthroughNonEmpty': {
+    'childList': true,
+    'characterData': true,
+  },
+};
 
 /**
  * Enabling detached mode alters the children to be rendered in an

--- a/src/preact/base-element.js
+++ b/src/preact/base-element.js
@@ -42,13 +42,12 @@ let AmpElementPropDef;
  */
 let ChildDef;
 
-/** @const {Object} */
-const MUTATION_OBSERVER_OPTIONS = {
-  passthroughNonEmpty: {
-    childList: true,
-    characterData: true,
-  },
+/** @const {!MutationObserverInit} */
+const PASSTHROUGH_NON_EMPTY_MUTATION_INIT = {
+  childList: true,
+  characterData: true,
 };
+
 /**
  * Wraps a Preact Component in a BaseElement class.
  *
@@ -136,10 +135,7 @@ export class PreactBaseElement extends AMP.BaseElement {
     this.context_.playable = true;
     this.scheduleRender_();
     if (this.observer_) {
-      this.observer_.observe(
-        this.element,
-        MUTATION_OBSERVER_OPTIONS.passthroughNonEmpty
-      );
+      this.observer_.observe(this.element, PASSTHROUGH_NON_EMPTY_MUTATION_INIT);
     }
     return deferred.promise;
   }

--- a/src/preact/base-element.js
+++ b/src/preact/base-element.js
@@ -294,7 +294,7 @@ PreactBaseElement['passthroughNonEmpty'] = false;
 /**
  * A static map for storing sets of options to be used in the Mutation Observer
  *
- * @protected {boolean}
+ * @protected {Object<string, Object<string, boolean|Array<string>>>}
  */
 PreactBaseElement['mutationObserverOptions'] = {
   'passthroughNonEmpty': {

--- a/src/preact/base-element.js
+++ b/src/preact/base-element.js
@@ -42,6 +42,13 @@ let AmpElementPropDef;
  */
 let ChildDef;
 
+/** @const {Object} */
+const MUTATION_OBSERVER_OPTIONS = {
+  passthroughNonEmpty: {
+    childList: true,
+    characterData: true,
+  },
+};
 /**
  * Wraps a Preact Component in a BaseElement class.
  *
@@ -131,7 +138,7 @@ export class PreactBaseElement extends AMP.BaseElement {
     if (this.observer_) {
       this.observer_.observe(
         this.element,
-        this.constructor['mutationObserverOptions']['passthroughNonEmpty']
+        MUTATION_OBSERVER_OPTIONS.passthroughNonEmpty
       );
     }
     return deferred.promise;
@@ -290,18 +297,6 @@ PreactBaseElement['passthrough'] = false;
  * @protected {boolean}
  */
 PreactBaseElement['passthroughNonEmpty'] = false;
-
-/**
- * A static map for storing sets of options to be used in the Mutation Observer
- *
- * @protected {Object<string, Object<string, boolean|Array<string>>>}
- */
-PreactBaseElement['mutationObserverOptions'] = {
-  'passthroughNonEmpty': {
-    'childList': true,
-    'characterData': true,
-  },
-};
 
 /**
  * Enabling detached mode alters the children to be rendered in an


### PR DESCRIPTION
Add mutation observer to bento's base-element (parent class for bento components).  Mutation observer should be used in combination with `passthroughNonEmpty` mode for handling children.  The mutation observer allows the Preact component to re-render when child nodes or characterData of the current element are updated as this may change whether or not the unnamed slot should be included in the Preact rendered nodes in amp mode.