### PR TITLE
[amp-story-player] Suppress expected element errors in iframe focus

### DIFF
--- a/src/focus-history.js
+++ b/src/focus-history.js
@@ -60,7 +60,9 @@ export class FocusHistory {
       // implemented here. We wait for a blur to arrive on the main window
       // and after a short time check which element is active.
       Services.timerFor(win).delay(() => {
-        this.pushFocus_(dev().assertElement(this.win.document.activeElement));
+        if (this.win.document.activeElement) {
+          this.pushFocus_(this.win.document.activeElement);
+        }
       }, 500);
     };
     this.win.document.addEventListener('focus', this.captureFocus_, true);


### PR DESCRIPTION
When calling `tryFocus()` on the change of iframe in the player, an error would be thrown `Element expected:  null`. This checks if there's an `activeElement` before calling `this.pushFocus_` on it.

<!--
# Instructions:

- Pick a meaningful title for your pull request. (Use sentence case.)
  - Prefix the title with an emoji to identify what is being done. (Copy-paste the emoji from the list below.)
  - Do not overuse punctuation in the title (like `(chore):`).
  - If it is helpful, use a simple prefix (like `ProjectX: Implement some feature`).
- Enter a succinct description that says why the PR is necessary, and what it does.
  - Mention the GitHub issue that is being addressed by the pull request.
  - The keywords `Fixes`, `Closes`, or `Resolves` followed the issue number will automatically close the issue.

> NOTE: All non-trivial changes (like introducing new features or components) should have an associated issue or reference an I2I (intent-to-implement: go.amp.dev/i2i). Please read through the contribution process (go.amp.dev/contributing/code) for more information.

# Example of a good description:

- Implement aspect X
- Leave out feature Y because of A
- Improve performance by B
- Improve accessibility by C

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Reverting a previous change
♻️ Refactoring
🚮 Deleting code
🧪 Experimental code
-->
