### PR TITLE
🏗🐛 Fix mismatched HTML5 tag in `experiments.html`

### DIFF
--- a/tools/experiments/experiments.html
+++ b/tools/experiments/experiments.html
@@ -261,7 +261,7 @@
         <input id="rtv" placeholder="E.g., 011912312359590" maxlength="15" type="text">
         <button id="rtv-submit" disabled>opt-in</button>
       </div>
-    </detail>
+    </details>
   </section>
 
   <!-- Only displayed on top-level cdn.ampproject.org. -->


### PR DESCRIPTION
This PR fixes the mismatched closing [`details` tag](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details) for the "Advanced" section in `experiments.html`.

Speculative fix for #29439.
