### PR TITLE
amp-list: email should support xssi-prefix

### DIFF
--- a/extensions/amp-list/validator-amp-list.protoascii
+++ b/extensions/amp-list/validator-amp-list.protoascii
@@ -222,6 +222,7 @@ tags: {  # <amp-list>
   attrs: { name: "items" }
   attrs: { name: "max-items" }
   attrs: { name: "single-item" }
+  attrs: { name: "xssi-prefix" }
   attrs: {
     name: "src"
     mandatory: true


### PR DESCRIPTION
`b/146428532`