### PR TITLE
🐛 Fix case where ads iframe is measured before resize

### DIFF
--- a/src/friendly-iframe-embed.js
+++ b/src/friendly-iframe-embed.js
@@ -399,6 +399,8 @@ export class FriendlyIframeEmbed {
     if (this.ampdoc) {
       this.whenReady().then(() => this.ampdoc.setReady());
     }
+
+    this.iframe.onresize = () => this.handleResize_();
   }
 
   /**
@@ -509,6 +511,15 @@ export class FriendlyIframeEmbed {
     return /** @type {!HTMLBodyElement} */ ((
       this.iframe.contentDocument || this.iframe.contentWindow.document
     ).body);
+  }
+
+  /**
+   * Force remeasure inside FIE doc when iframe is resized.
+   * @private
+   */
+  handleResize_() {
+    debugger;
+    this.getMutator_().mutateElement(this.win.document, () => {} /* NOOP */);
   }
 
   /**

--- a/src/friendly-iframe-embed.js
+++ b/src/friendly-iframe-embed.js
@@ -400,7 +400,7 @@ export class FriendlyIframeEmbed {
       this.whenReady().then(() => this.ampdoc.setReady());
     }
 
-    this.iframe.onresize = () => this.handleResize_();
+    this.win.onresize = () => this.handleResize_();
   }
 
   /**
@@ -518,8 +518,10 @@ export class FriendlyIframeEmbed {
    * @private
    */
   handleResize_() {
-    debugger;
-    this.getMutator_().mutateElement(this.win.document, () => {} /* NOOP */);
+    this.getMutator_().mutateElement(
+      this.win.document.documentElement,
+      () => {} // NOOP.
+    );
   }
 
   /**

--- a/src/friendly-iframe-embed.js
+++ b/src/friendly-iframe-embed.js
@@ -400,7 +400,7 @@ export class FriendlyIframeEmbed {
       this.whenReady().then(() => this.ampdoc.setReady());
     }
 
-    this.win.onresize = () => this.handleResize_();
+    this.win.addEventListener('resize', () => this.handleResize_());
   }
 
   /**


### PR DESCRIPTION
This was happening a lot in stories, but probably exists in all google ads cases. The iframe is originally set to have 0 height and width, then later resized using `setStyle` in adsense/doubleclick impl. This creates a race where the elements inside the iframe can be measured before the iframe has size, and because the runtime thinks they have no size, it never lays them out.

The fix attaches a listener to the frame to force remeasure when resized.

cc/ @ampproject/wg-ads 