### PR TITLE
♻️ bind-impl: remove outdated amp-list attr

### DIFF
--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -95,8 +95,7 @@ let BoundElementDef;
  */
 const BIND_ONLY_ATTRIBUTES = map({
   'AMP-CAROUSEL': ['slide'],
-  // TODO (#18875): add is-layout-container to validator file for amp-list
-  'AMP-LIST': ['state', 'is-layout-container'],
+  'AMP-LIST': ['is-layout-container'],
   'AMP-SELECTOR': ['selected'],
 });
 


### PR DESCRIPTION
**summary**
- `state` has already been removed as a possible attribute. It already fails validation so it is safe to remove from bind
- The `is-layout-container` attribute is already in the validator test, so we can remove the comment.