### PR TITLE
Revert "🧪Enable A4A integration test for no-signing exp"

### DIFF
--- a/extensions/amp-a4a/0.1/head-validation.js
+++ b/extensions/amp-a4a/0.1/head-validation.js
@@ -15,8 +15,6 @@
  */
 
 import {Services} from '../../../src/services';
-import {getMode} from '../../../src/mode';
-import {includes} from '../../../src/string';
 import {map} from '../../../src/utils/object';
 import {parseExtensionUrl} from '../../../src/service/extension-location';
 import {removeElement} from '../../../src/dom';
@@ -156,12 +154,7 @@ function handleScript(extensions, script) {
   }
 
   const {src} = script;
-  const isTesting = getMode().test || getMode().localDev;
-  if (
-    EXTENSION_URL_PREFIX.test(src) ||
-    // Integration tests point to local files.
-    (isTesting && includes(src, '/dist/'))
-  ) {
+  if (EXTENSION_URL_PREFIX.test(src)) {
     const extensionInfo = parseExtensionUrl(src);
     if (EXTENSION_ALLOWLIST[extensionInfo.extensionId]) {
       extensions.push(extensionInfo);

--- a/extensions/amp-ad-network-fake-impl/0.1/amp-ad-network-fake-impl.js
+++ b/extensions/amp-ad-network-fake-impl/0.1/amp-ad-network-fake-impl.js
@@ -17,17 +17,10 @@
 import {AmpA4A} from '../../amp-a4a/0.1/amp-a4a';
 import {AmpAdMetadataTransformer} from './amp-ad-metadata-transformer';
 import {ExternalReorderHeadTransformer} from './external-reorder-head-transformer';
-import {forceExperimentBranch} from '../../../src/experiments';
 import {includes, startsWith} from '../../../src/string';
 import {user, userAssert} from '../../../src/log';
 
 const TAG = 'AMP-AD-NETWORK-FAKE-IMPL';
-
-/**
- * Allow elements to opt into an experiment branch.
- * @const {string}
- */
-const EXPERIMENT_BRANCH_ATTR = 'data-experiment-id';
 
 export class AmpAdNetworkFakeImpl extends AmpA4A {
   /**
@@ -49,15 +42,6 @@ export class AmpAdNetworkFakeImpl extends AmpA4A {
       'Attribute src or srcdoc required for <amp-ad type="fake">: %s',
       this.element
     );
-    if (this.element.hasAttribute(EXPERIMENT_BRANCH_ATTR)) {
-      this.element
-        .getAttribute(EXPERIMENT_BRANCH_ATTR)
-        .split(',')
-        .forEach((experiment) => {
-          const expParts = experiment.split(':');
-          forceExperimentBranch(this.win, expParts[0], expParts[1]);
-        });
-    }
     super.buildCallback();
   }
 

--- a/test/integration/test-amphtml-ads.js
+++ b/test/integration/test-amphtml-ads.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import {NO_SIGNING_EXP} from '../../extensions/amp-a4a/0.1/amp-a4a';
 import {RequestBank} from '../../testing/test-helper';
 import {maybeSwitchToCompiledJs} from '../../testing/iframe';
 import {parseQueryString} from '../../src/url';
@@ -23,14 +22,13 @@ import {xhrServiceForTesting} from '../../src/service/xhr-impl';
 // TODO(wg-ads, #29112): Unskip on Safari.
 const t = describe.configure().skipSafari();
 
-[NO_SIGNING_EXP.control, NO_SIGNING_EXP.experiment].forEach((branch) => {
-  t.run(`AMPHTML ad on AMP Page ${NO_SIGNING_EXP.id}:${branch}`, () => {
-    describes.integration(
-      'ATF',
-      {
-        amp: true,
-        extensions: ['amp-ad'],
-        body: `
+t.run('AMPHTML ad on AMP Page', () => {
+  describes.integration(
+    'ATF',
+    {
+      amp: true,
+      extensions: ['amp-ad'],
+      body: `
   <amp-ad
       width="300" height="250"
       id="i-amphtml-demo-id"
@@ -38,30 +36,29 @@ const t = describe.configure().skipSafari();
       a4a-conversion="true"
       checksig=""
       disable3pfallback="true"
-      data-experiment-id=${NO_SIGNING_EXP.id}:${branch}
       src="//ads.localhost:9876/amp4test/a4a/${RequestBank.getBrowserId()}">
   </amp-ad>
       `,
-      },
-      () => {
-        afterEach(() => {
-          return RequestBank.tearDown();
-        });
+    },
+    () => {
+      afterEach(() => {
+        return RequestBank.tearDown();
+      });
 
-        it('should layout amp-img, amp-pixel, amp-analytics', () => {
-          // Open http://ads.localhost:9876/amp4test/a4a/12345 to see ad content
-          return testAmpComponents();
-        });
-      }
-    );
+      it('should layout amp-img, amp-pixel, amp-analytics', () => {
+        // Open http://ads.localhost:9876/amp4test/a4a/12345 to see ad content
+        return testAmpComponents();
+      });
+    }
+  );
 
-    describes.integration(
-      'BTF',
-      {
-        amp: true,
-        extensions: ['amp-ad'],
-        frameStyle: 'height: 100vh',
-        body: `
+  describes.integration(
+    'BTF',
+    {
+      amp: true,
+      extensions: ['amp-ad'],
+      frameStyle: 'height: 100vh',
+      body: `
   <div style="height: 100vh"></div>
   <amp-ad
       width="300" height="250"
@@ -70,24 +67,22 @@ const t = describe.configure().skipSafari();
       a4a-conversion="true"
       checksig=""
       disable3pfallback="true"
-      data-experiment-id=${branch}
       src="//ads.localhost:9876/amp4test/a4a/${RequestBank.getBrowserId()}">
   </amp-ad>
       `,
-      },
-      (env) => {
-        afterEach(() => {
-          return RequestBank.tearDown();
-        });
+    },
+    (env) => {
+      afterEach(() => {
+        return RequestBank.tearDown();
+      });
 
-        // TODO(#24657): Flaky on Travis.
-        it.skip('should layout amp-img, amp-pixel, amp-analytics', () => {
-          // Open http://ads.localhost:9876/amp4test/a4a/12345 to see ad content
-          return testAmpComponentsBTF(env.win);
-        });
-      }
-    );
-  });
+      // TODO(#24657): Flaky on Travis.
+      it.skip('should layout amp-img, amp-pixel, amp-analytics', () => {
+        // Open http://ads.localhost:9876/amp4test/a4a/12345 to see ad content
+        return testAmpComponentsBTF(env.win);
+      });
+    }
+  );
 });
 
 t.run('AMPHTML ad on non-AMP page (inabox)', () => {


### PR DESCRIPTION
Reverts ampproject/amphtml#29393

Breaking integration tests on Linux GH Actions.