### PR TITLE
Revert "Ramp "intersect-resources" to 100% (second try)"

### DIFF
--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -26,7 +26,7 @@
   "fixed-elements-in-lightbox": 1,
   "flexAdSlots": 0.05,
   "hidden-mutation-observer": 1,
-  "intersect-resources": 1,
+  "intersect-resources": 0.1,
   "ios-fixed-no-transfer": 0,
   "layoutbox-invalidate-on-scroll": 1,
   "pump-early-frame": 1,


### PR DESCRIPTION
Reverts ampproject/amphtml#29354. 

~1% regression in ads queries still present -- appears to be primarily Android. Needs more investigation.