### PR TITLE
✨ Add basic GDPR support for AdUp Technology amp-ad tag

### DIFF
--- a/ads/_config.js
+++ b/ads/_config.js
@@ -227,8 +227,13 @@ const adConfig = jsonConfiguration({
 
   'aduptech': {
     prefetch: 'https://s.d.adup-tech.com/jsapi',
-    preconnect: ['https://d.adup-tech.com', 'https://m.adup-tech.com'],
+    preconnect: [
+      'https://d.adup-tech.com',
+      'https://m.adup-tech.com',
+      'https://v.adup-tech.com',
+    ],
     renderStartImplemented: true,
+    consentHandlingOverride: true,
   },
 
   'adventive': {

--- a/ads/ads.extern.js
+++ b/ads/ads.extern.js
@@ -338,7 +338,15 @@ data.siteId;
 // aduptech.js
 window.uAd = {};
 window.uAd.embed;
+data.amp;
 data.responsive;
+data.placementkey;
+data.mincpc;
+data.query;
+data.pageurl;
+data.gdpr;
+data.gdpr_consent;
+data.adtest;
 data.onAds;
 data.onNoAds;
 

--- a/ads/aduptech.js
+++ b/ads/aduptech.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,35 +17,87 @@
 import {loadScript, validateData} from '../3p/3p';
 
 /**
+ * ID for the html container
+ *
+ * @const {string}
+ */
+export const ADUPTECH_ELEMENT_ID = 'aduptech';
+
+/**
+ * URL to the AdUp Technology javascript api
+ *
+ * @const {string}
+ */
+export const ADUPTECH_API_URL = 'https://s.d.adup-tech.com/jsapi';
+
+/**
+ * Logic for the AdUp Technology amp-ad tag
+ *
  * @param {!Window} global
  * @param {!Object} data
  */
 export function aduptech(global, data) {
-  const elementId = 'aduptech';
+  const {context, document} = global;
 
-  validateData(data, ['placementkey'], ['query', 'mincpc', 'adtest']);
+  validateData(
+    data,
+    ['placementkey'],
+    ['mincpc', 'query', 'pageurl', 'gdpr', 'gdpr_consent', 'adtest']
+  );
 
-  // add id attriubte to given container (required)
-  global.document.getElementById('c').setAttribute('id', elementId);
+  // add id attriubte to container
+  document.getElementById('c').setAttribute('id', ADUPTECH_ELEMENT_ID);
 
-  // load aduptech js api
-  loadScript(global, 'https://s.d.adup-tech.com/jsapi', () => {
-    // force responsive ads for amp
-    data.responsive = true;
+  // init api options
+  const options = {
+    amp: true,
+    responsive: true,
+    placementkey: data.placementkey,
+    onAds: () => context.renderStart(),
+    onNoAds: () => context.noContentAvailable(),
+  };
 
-    // ads callback => render start
-    //
-    // NOTE: Not using "data.onAds = global.context.renderStart;"
-    //       because the "onAds()" callback returns our API object
-    //       as first parameter which will cause errors
-    data.onAds = () => {
-      global.context.renderStart();
-    };
+  if ('mincpc' in data) {
+    options.mincpc = data.mincpc;
+  }
 
-    // no ads callback => noContentAvailable
-    data.onNoAds = global.context.noContentAvailable;
+  if ('query' in data) {
+    options.query = data.query;
+  }
 
-    // embed iframe
-    global.uAd.embed(elementId, data);
-  });
+  if ('adtest' in data) {
+    options.adtest = data.adtest;
+  }
+
+  if ('pageurl' in data) {
+    options.pageurl = data.pageurl;
+  } else if (context.sourceUrl) {
+    options.pageurl = context.sourceUrl;
+  } else if (context.location && context.location.href) {
+    options.pageurl = context.location.href;
+  }
+
+  if ('gdpr' in data) {
+    options.gdpr = data.gdpr;
+  }
+
+  // prefer consent string from consentSharedData (if defined)
+  // otherwise use consent string from optional tag attribute
+  if (
+    context.consentSharedData !== null &&
+    typeof context.consentSharedData === 'object' &&
+    context.consentSharedData.consentString &&
+    context.consentSharedData.consentString !== ''
+  ) {
+    // eslint-disable-next-line google-camelcase/google-camelcase
+    options.gdpr_consent = context.consentSharedData.consentString;
+  } else if ('gdpr_consent' in data) {
+    // eslint-disable-next-line google-camelcase/google-camelcase
+    options.gdpr_consent = data.gdpr_consent;
+  }
+
+  // load api and embed ads iframe
+  loadScript(global, ADUPTECH_API_URL, () =>
+    global.uAd.embed(ADUPTECH_ELEMENT_ID, options)
+  );
 }

--- a/ads/aduptech.md
+++ b/ads/aduptech.md
@@ -14,10 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-# Ad Up Technology
+# AdUp Technology
 
-Please visit [www.adup-tech.com](http://www.adup-tech.com) for more information
-on how to get required ad tag or placement keys.
+Please visit [www.adup-tech.com](http://www.adup-tech.com) for more information and sign up as publisher to create your placement.
 
 ## Examples
 
@@ -97,16 +96,25 @@ Uses available space but respecting aspect ratio by given `width` and `height` (
 
 ## Configuration
 
-### Required parameters
+| Attribute           | Optional | Description                                                                                   |
+| ------------------- | :------: | --------------------------------------------------------------------------------------------- |
+| `data-placementkey` |          | The unique placement key                                                                      |
+| `data-mincpc`       |    X     | The mininum price per click in €                                                              |
+| `data-query`        |    X     | Additional query keywords separated by semicolon                                              |
+| `data-pageurl`      |    X     | The page url (if different from current url)                                                  |
+| `data-gdpr`         |    X     | `1` = GDPR applies / `0` = GDPR does not apply / omit = unknown wether GDPR applies (default) |
+| `data-gdpr_consent` |    X     | The base64url-encoded IAB consent string                                                      |
+| `data-adtest`       |    X     | `1` = testing mode enabled / `0` = testing mode disabled (default)                            |
 
-- `data-placementkey`
+## User Consent Integration
 
-### Optional parameters
+If avaiable, the following consent data will always be send to our adserver:
 
-- `data-query`
-- `data-mincpc`
-- `data-adtest`
+- `window.context.consentSharedData.consentString` as IAB consent string
 
-## Design/Layout
+Otherwise following (optional) tag attributes will be send to our adserver:
 
-Please visit [www.adup-tech.com](http://www.adup-tech.com) and sign up as publisher to create your own placement.
+- `data-gdpr` as "GDPR applies" state
+- `data-gdpr_consent` as IAB consent string
+
+If none of above values are given, we try to fetch users consent data via TCF API (if avaiable).

--- a/examples/ads-legacy.amp.html
+++ b/examples/ads-legacy.amp.html
@@ -125,7 +125,7 @@
       src="https://adserver.adtechus.com/addyn/3.0/5280.1/2274008/0/-1/ADTECH;size=300x250;key=plumber;alias=careerbear-ros-middle1;loc=300;;target=_blank;grp=27980912;misc=3767074">
   </amp-ad>
 
-  <h2>Ad Up Technology</h2>
+  <h2>AdUp Technology</h2>
   <amp-ad type="aduptech"
       layout="fixed"
       width="500"

--- a/examples/ads.amp.esm.html
+++ b/examples/ads.amp.esm.html
@@ -719,7 +719,7 @@
       data-sizes="300x250">
   </amp-ad>
 
-  <h2>Ad Up Technology</h2>
+  <h2>AdUp Technology</h2>
   <amp-ad width="500" height="250"
       type="aduptech"
       layout="fixed"
@@ -2163,7 +2163,7 @@
       data-pid="42266"
       layout="responsive">
   </amp-ad>
-  
+
   <h2>TE Medya</h2>
   <amp-embed width="320" height="320"
     type="temedya"

--- a/examples/ads.amp.html
+++ b/examples/ads.amp.html
@@ -734,7 +734,7 @@
       data-sizes="300x250">
   </amp-ad>
 
-  <h2>Ad Up Technology</h2>
+  <h2>AdUp Technology</h2>
   <amp-ad width="500" height="250"
       type="aduptech"
       layout="fixed"

--- a/extensions/amp-ad/amp-ad.md
+++ b/extensions/amp-ad/amp-ad.md
@@ -287,7 +287,7 @@ See [amp-ad rules](validator-amp-ad.protoascii) in the AMP validator specificati
 - [AdTech](../../ads/adtech.md)
 - [AdThrive](../../ads/adthrive.md)
 - [AdUnity](../../ads/adunity.md)
-- [Ad Up Technology](../../ads/aduptech.md)
+- [AdUp Technology](../../ads/aduptech.md)
 - [Adventive](../../ads/adventive.md)
 - [Adverline](../../ads/adverline.md)
 - [Adverticum](../../ads/adverticum.md)

--- a/test/unit/ads/test-aduptech.js
+++ b/test/unit/ads/test-aduptech.js
@@ -1,0 +1,194 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as _3p from '../../../3p/3p';
+import {
+  ADUPTECH_API_URL,
+  ADUPTECH_ELEMENT_ID,
+  aduptech,
+} from '../../../ads/aduptech';
+import {createIframePromise} from '../../../testing/iframe';
+
+describes.fakeWin('amp-ad-aduptech-impl', {}, (env) => {
+  let win;
+  let loadScriptSpy;
+
+  beforeEach(() => {
+    return createIframePromise(true).then((iframe) => {
+      win = iframe.win;
+      win.context = {
+        initialIntersection: {
+          boundingClientRect: {
+            height: 0,
+          },
+        },
+        requestResize() {},
+        onResizeSuccess() {},
+        onResizeDenied() {},
+        noContentAvailable() {},
+        referrer: null,
+      };
+      const div = win.document.createElement('div');
+      div.id = 'c';
+      win.document.body.appendChild(div);
+
+      // create and spy on fake aduptech api
+      win.uAd = {
+        embed: env.sandbox.spy(),
+      };
+
+      // spy on stub for loadScript
+      loadScriptSpy = env.sandbox
+        .stub(_3p, 'loadScript')
+        .callsFake((_, __, callback) => {
+          callback();
+        });
+
+      // just to be sure
+      expect(win.document.getElementById(ADUPTECH_ELEMENT_ID)).to.be.null;
+      expect(loadScriptSpy).not.to.have.been.called;
+      expect(win.uAd.embed).not.to.have.been.called;
+    });
+  });
+
+  it('should validate missing placementkey', () => {
+    expect(() => aduptech(win, {})).to.throw(/Missing attribute/);
+  });
+
+  it('should add id to html container', () => {
+    aduptech(win, {placementkey: 'crazyPlacementKey'});
+
+    expect(win.document.getElementById(ADUPTECH_ELEMENT_ID)).not.to.be.null;
+  });
+
+  it('should load api', () => {
+    aduptech(win, {placementkey: 'crazyPlacementKey'});
+
+    expect(loadScriptSpy).to.have.been.calledOnceWith(
+      win,
+      ADUPTECH_API_URL,
+      env.sandbox.match.func
+    );
+  });
+
+  it('should call api with minimum attributes', () => {
+    aduptech(win, {placementkey: 'crazyPlacementKey'});
+
+    expect(win.uAd.embed).to.have.been.calledOnceWith(ADUPTECH_ELEMENT_ID, {
+      amp: true,
+      onAds: env.sandbox.match.func,
+      onNoAds: env.sandbox.match.func,
+      placementkey: 'crazyPlacementKey',
+      responsive: true,
+    });
+  });
+
+  it('should call api with all attributes', () => {
+    aduptech(win, {
+      placementkey: 'crazyPlacementKey',
+      mincpc: '0.33',
+      query: 'foo;bar',
+      pageurl: 'http://www.adup-tech.com',
+      gdpr: '0',
+      // eslint-disable-next-line google-camelcase/google-camelcase
+      gdpr_consent: 'crazyConsentString',
+      adtest: '1',
+    });
+
+    expect(win.uAd.embed).to.have.been.calledOnceWith(ADUPTECH_ELEMENT_ID, {
+      adtest: '1',
+      amp: true,
+      gdpr: '0',
+      // eslint-disable-next-line google-camelcase/google-camelcase
+      gdpr_consent: 'crazyConsentString',
+      mincpc: '0.33',
+      onAds: env.sandbox.match.func,
+      onNoAds: env.sandbox.match.func,
+      pageurl: 'http://www.adup-tech.com',
+      placementkey: 'crazyPlacementKey',
+      query: 'foo;bar',
+      responsive: true,
+    });
+  });
+
+  it('should call api with "context.sourceUrl" as fallback for "pageurl"', () => {
+    win.context.sourceUrl = 'http://www.source.url';
+
+    aduptech(win, {placementkey: 'crazyPlacementKey'});
+
+    expect(win.uAd.embed).to.have.been.calledOnce;
+    expect(win.uAd.embed.getCall(0).args[1].pageurl).to.equal(
+      win.context.sourceUrl
+    );
+  });
+
+  it('should call api with "context.location.href" as fallback for "pageurl"', () => {
+    win.context.sourceUrl = null;
+    win.context.location = {href: 'http://www.win.location.href'};
+
+    aduptech(win, {placementkey: 'crazyPlacementKey'});
+
+    expect(win.uAd.embed).to.have.been.calledOnce;
+    expect(win.uAd.embed.getCall(0).args[1].pageurl).to.equal(
+      win.context.location.href
+    );
+  });
+
+  it('should call api with prefered "context.consentSharedData.consentString" as "gdpr_consent"', () => {
+    win.context.consentSharedData = {
+      consentString: 'realConsentString',
+    };
+
+    aduptech(win, {
+      placementkey: 'crazyPlacementKey',
+      gdpr: true,
+      // eslint-disable-next-line google-camelcase/google-camelcase
+      gdpr_consent: 'customConsentString',
+    });
+
+    expect(win.uAd.embed).to.have.been.calledOnce;
+    expect(win.uAd.embed.getCall(0).args[1].gdpr).to.be.true;
+    // eslint-disable-next-line google-camelcase/google-camelcase
+    expect(win.uAd.embed.getCall(0).args[1].gdpr_consent).to.equal(
+      'realConsentString'
+    );
+  });
+
+  it('should call "context.renderStart()" on "onAds" callback', () => {
+    win.context.renderStart = env.sandbox.spy();
+    win.context.noContentAvailable = env.sandbox.spy();
+
+    aduptech(win, {placementkey: 'crazyPlacementKey'});
+
+    expect(win.uAd.embed).to.have.been.calledOnce;
+    win.uAd.embed.getCall(0).args[1].onAds();
+
+    expect(win.context.renderStart).to.have.been.calledOnce;
+    expect(win.context.noContentAvailable).not.to.have.been.called;
+  });
+
+  it('should call "context.noContentAvailable()" on "onNoAds" callback', () => {
+    win.context.renderStart = env.sandbox.spy();
+    win.context.noContentAvailable = env.sandbox.spy();
+
+    aduptech(win, {placementkey: 'crazyPlacementKey'});
+
+    expect(win.uAd.embed).to.have.been.calledOnce;
+    win.uAd.embed.getCall(0).args[1].onNoAds();
+
+    expect(win.context.renderStart).not.to.have.been.called;
+    expect(win.context.noContentAvailable).to.have.been.calledOnce;
+  });
+});

--- a/validator/testdata/feature_tests/ads.html
+++ b/validator/testdata/feature_tests/ads.html
@@ -380,7 +380,7 @@
       data-sizes="300x250">
   </amp-ad>
 
-  <h2>Ad Up Technology</h2>
+  <h2>AdUp Technology</h2>
   <amp-ad width="500" height="250"
       type="aduptech"
       layout="fixed"

--- a/validator/testdata/feature_tests/ads.out
+++ b/validator/testdata/feature_tests/ads.out
@@ -381,7 +381,7 @@ PASS
 |        data-sizes="300x250">
 |    </amp-ad>
 |
-|    <h2>Ad Up Technology</h2>
+|    <h2>AdUp Technology</h2>
 |    <amp-ad width="500" height="250"
 |        type="aduptech"
 |        layout="fixed"


### PR DESCRIPTION
-  Add GDPR support for `aduptech` amp-ad tag
    - Add new optional `gdpr` and `gdpr_consent` data-attributes
    - Prefer consent string from `global.context.consentSharedData`
-  Add new optional `pageurl` data-attribute
    - Using `global.context.sourceUrl` or `global.context.location.href` as fallback
-  Refactored/Optimized code
-  Added tests 
-  Fixed documentation
-  Fixed company naming in several files from "Ad Up" to  "AdUp"
