### PR TITLE
🏗 Fix prefer-destructuring to support rest properties

### DIFF
--- a/build-system/eslint-rules/dict-string-keys.js
+++ b/build-system/eslint-rules/dict-string-keys.js
@@ -42,7 +42,7 @@ function checkNode(node, context) {
     node.properties.forEach(function (prop) {
       if (!prop.key.raw && !prop.computed) {
         context.report({
-          node,
+          node: prop,
           message:
             'Found: ' +
             prop.key.name +

--- a/build-system/eslint-rules/prefer-destructuring.js
+++ b/build-system/eslint-rules/prefer-destructuring.js
@@ -193,12 +193,13 @@ module.exports = {
               const names = setStruct(variables, base, decl, node);
               const {properties} = id;
               for (let k = 0; k < properties.length; k++) {
-                const {key} = properties[k];
-                if (key.type !== 'Identifier') {
-                  // Deep destructuring, too complicated.
-                  return;
+                const prop = properties[k];
+                names.add(sourceCode.getText(prop));
+                if (!prop.key) {
+                  // rest element
+                  processMaps([letMap, constMap]);
+                  break;
                 }
-                names.add(key.name);
               }
             }
           }


### PR DESCRIPTION
`...rest` properties when destructuring was causing an error to be thrown by the `prefer-destructuring` lint rule.