### PR TITLE
Bento: contain wrapper for most typical embedding scenarios

### DIFF
--- a/extensions/amp-fit-text/1.0/amp-fit-text.js
+++ b/extensions/amp-fit-text/1.0/amp-fit-text.js
@@ -51,10 +51,7 @@ class AmpFitText extends PreactBaseElement {
       subtree: true,
     });
 
-    const props = getFontSizeAttrs(this.element);
-    props['style'] = {width: '100%', height: '100%', position: 'absolute'};
-
-    return props;
+    return getFontSizeAttrs(this.element);
   }
 
   /** @override */
@@ -72,6 +69,9 @@ AmpFitText['Component'] = FitText;
 
 /** @override */
 AmpFitText['passthrough'] = true;
+
+/** @override */
+AmpFitText['layoutSizeDefined'] = true;
 
 AMP.extension(TAG, '1.0', (AMP) => {
   AMP.registerElement(TAG, AmpFitText);

--- a/extensions/amp-fit-text/1.0/fit-text.js
+++ b/extensions/amp-fit-text/1.0/fit-text.js
@@ -16,6 +16,7 @@
 
 import * as Preact from '../../../src/preact';
 import * as styles from './fit-text.css';
+import {ContainWrapper} from '../../../src/preact/component';
 import {px, resetStyles, setStyle, setStyles} from '../../../src/style';
 import {useCallback, useLayoutEffect, useRef} from '../../../src/preact';
 
@@ -68,20 +69,18 @@ export function FitText({
   }, [children, resize]);
 
   return (
-    <div {...rest}>
-      <div
-        ref={contentRef}
-        style={{
-          ...styles.fitTextContent,
-          'width': '100%',
-          'height': '100%',
-        }}
-      >
-        <div ref={measurerRef} style={styles.fitTextContentWrapper}>
-          {children}
-        </div>
+    <ContainWrapper
+      size={true}
+      layout={true}
+      paint={true}
+      contentRef={contentRef}
+      contentStyle={styles.fitTextContent}
+      {...rest}
+    >
+      <div ref={measurerRef} style={styles.fitTextContentWrapper}>
+        {children}
       </div>
-    </div>
+    </ContainWrapper>
   );
 }
 

--- a/extensions/amp-timeago/1.0/amp-timeago.js
+++ b/extensions/amp-timeago/1.0/amp-timeago.js
@@ -47,6 +47,9 @@ AmpTimeago['Component'] = Timeago;
 AmpTimeago['passthrough'] = true;
 
 /** @override */
+AmpTimeago['layoutSizeDefined'] = true;
+
+/** @override */
 AmpTimeago['props'] = {
   'datetime': {attr: 'datetime'},
   'locale': {attr: 'locale', default: 'en'},

--- a/extensions/amp-timeago/1.0/timeago.js
+++ b/extensions/amp-timeago/1.0/timeago.js
@@ -15,6 +15,7 @@
  */
 
 import * as Preact from '../../../src/preact';
+import {ContainWrapper} from '../../../src/preact/component';
 import {timeago} from '../../../third_party/timeagojs/timeago';
 import {useEffect, useRef, useState} from '../../../src/preact';
 import {useResourcesNotify} from '../../../src/preact/utils';
@@ -31,6 +32,7 @@ export function Timeago({
   locale = DEFAULT_LOCALE,
   cutoff,
   cutoffText,
+  containSize = false,
   ...rest
 }) {
   const [timestamp, setTimestamp] = useState('');
@@ -53,10 +55,19 @@ export function Timeago({
   }, [datetime, locale, cutoff, cutoffText]);
 
   useResourcesNotify();
+
   return (
-    <time datetime={datetime} ref={ref} {...rest}>
+    <ContainWrapper
+      as="time"
+      size={containSize}
+      layout={true}
+      paint={true}
+      contentRef={ref}
+      datetime={datetime}
+      {...rest}
+    >
       {timestamp}
-    </time>
+    </ContainWrapper>
   );
 }
 

--- a/extensions/amp-timeago/1.0/timeago.js
+++ b/extensions/amp-timeago/1.0/timeago.js
@@ -58,13 +58,13 @@ export function Timeago({
 
   return (
     <ContainWrapper
+      {...rest}
       as="time"
       size={containSize}
       layout={true}
       paint={true}
       contentRef={ref}
       datetime={datetime}
-      {...rest}
     >
       {timestamp}
     </ContainWrapper>

--- a/extensions/amp-timeago/1.0/timeago.type.js
+++ b/extensions/amp-timeago/1.0/timeago.type.js
@@ -24,6 +24,7 @@
  *   locale: string,
  *   cutoff: (number|undefined),
  *   cutoffText: (string|undefined),
+ *   containSize: (boolean|undefined),
  * }}
  */
 var TimeagoProps;

--- a/src/preact/base-element.js
+++ b/src/preact/base-element.js
@@ -49,6 +49,16 @@ const PASSTHROUGH_NON_EMPTY_MUTATION_INIT = {
 };
 
 /**
+ * The same as `applyFillContent`, but inside the shadow.
+ * @const {!Object}
+ */
+const SIZE_DEFINED_STYLE = {
+  'position': 'absolute',
+  'width': '100%',
+  'height': '100%',
+};
+
+/**
  * Wraps a Preact Component in a BaseElement class.
  *
  * Most functionality should be done in Preact. We don't expose the BaseElement
@@ -268,6 +278,15 @@ PreactBaseElement['Component'] = function () {
 };
 
 /**
+ * An override to specify that the component requires `layoutSizeDefined`.
+ * This typically means that the element's `isLayoutSupported()` is
+ * implemented via `isLayoutSizeDefined()`.
+ *
+ * @protected {string}
+ */
+PreactBaseElement['layoutSizeDefined'] = false;
+
+/**
  * An override to specify an exact className prop to Preact.
  *
  * @protected {string}
@@ -325,6 +344,7 @@ function collectProps(Ctor, element, defaultProps) {
 
   const {
     'className': className,
+    'layoutSizeDefined': layoutSizeDefined,
     'props': propDefs,
     'passthrough': passthrough,
     'passthroughNonEmpty': passthroughNonEmpty,
@@ -334,6 +354,12 @@ function collectProps(Ctor, element, defaultProps) {
   // Class.
   if (className) {
     props['className'] = className;
+  }
+
+  // Common styles.
+  if (layoutSizeDefined) {
+    props['style'] = SIZE_DEFINED_STYLE;
+    props['containSize'] = true;
   }
 
   // Props.

--- a/src/preact/component/component.type.js
+++ b/src/preact/component/component.type.js
@@ -14,21 +14,20 @@
  * limitations under the License.
  */
 
-export const LINE_HEIGHT_EM_ = 1.15;
+/** @externs */
 
-export const fitTextContent = {
-  'display': 'flex',
-  'flexDirection': 'column',
-  'flexWrap': 'nowrap',
-  'justifyContent': 'center',
-};
-
-/* Legacy comment: We have to use the old-style flex box with line clamping. It will only
-    work in WebKit, but unfortunately there's no alternative. */
-export const fitTextContentWrapper = {
-  lineHeight: `${LINE_HEIGHT_EM_}em`,
-  'display': '-webkit-box',
-  '-webkit-box-orient': 'vertical',
-  'overflow': 'hidden',
-  'textOverflow': 'ellipsis',
-};
+/**
+ * See https://developer.mozilla.org/en-US/docs/Web/CSS/contain
+ *
+ * @typedef {{
+ *   as: (string|!Function|undefined),
+ *   size: (boolean|undefined),
+ *   layout: (boolean|undefined),
+ *   paint: (boolean|undefined),
+ *   wrapperStyle: (?Object|undefined),
+ *   contentRef: ({current: ?}|function(!Element)|undefined),
+ *   contentStyle: (?Object|undefined),
+ *   children: (?PreactDef.Renderable|undefined),
+ * }}
+ */
+var ContainWrapperProps;

--- a/src/preact/component/contain.js
+++ b/src/preact/component/contain.js
@@ -1,0 +1,85 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as Preact from '../../../src/preact';
+
+const CONTAIN = [
+  null, // 0: none
+  'paint', // 1: paint
+  'layout', // 2: layout
+  'content', // 3: content = layout + paint
+  'size', // 4: size
+  'size paint', // 5: size + paint
+  'size layout', // 6: size + layout
+  'strict', // 7: strict = size + layout + paint
+];
+
+const SIZE_CONTENT_STYLE = {
+  'position': 'relative',
+  'width': '100%',
+  'height': '100%',
+};
+
+/**
+ * The wrapper component that implements different "contain" parameters.
+ *
+ * See https://developer.mozilla.org/en-US/docs/Web/CSS/contain
+ *
+ * Contain parameters:
+ * - size: the element's size does not depend on its content.
+ * - layout: nothing outside the element may affect its internal layout and
+ *   vice versa.
+ * - paint: the element's content doesn't display outside the element's bounds.
+ *
+ * @param {!ContainWrapperProps} props
+ * @return {PreactDef.Renderable}
+ */
+export function ContainWrapper({
+  as: Comp = 'div',
+  size = false,
+  layout = false,
+  paint = false,
+  style,
+  wrapperStyle,
+  contentRef,
+  contentStyle,
+  children,
+  ...rest
+}) {
+  // The formula: `size << 2 | layout << 1 | paint`.
+  const containIndex = (size ? 4 : 0) + (layout ? 2 : 0) + (paint ? 1 : 0);
+  return (
+    <Comp
+      style={{
+        ...style,
+        ...wrapperStyle,
+        contain: CONTAIN[containIndex],
+      }}
+      {...rest}
+    >
+      <div
+        ref={contentRef}
+        style={{
+          ...(size && SIZE_CONTENT_STYLE),
+          'overflow': paint ? 'hidden' : 'visible',
+          ...contentStyle,
+        }}
+      >
+        {children}
+      </div>
+    </Comp>
+  );
+}

--- a/src/preact/component/index.js
+++ b/src/preact/component/index.js
@@ -14,21 +14,4 @@
  * limitations under the License.
  */
 
-export const LINE_HEIGHT_EM_ = 1.15;
-
-export const fitTextContent = {
-  'display': 'flex',
-  'flexDirection': 'column',
-  'flexWrap': 'nowrap',
-  'justifyContent': 'center',
-};
-
-/* Legacy comment: We have to use the old-style flex box with line clamping. It will only
-    work in WebKit, but unfortunately there's no alternative. */
-export const fitTextContentWrapper = {
-  lineHeight: `${LINE_HEIGHT_EM_}em`,
-  'display': '-webkit-box',
-  '-webkit-box-orient': 'vertical',
-  'overflow': 'hidden',
-  'textOverflow': 'ellipsis',
-};
+export {ContainWrapper} from './contain';


### PR DESCRIPTION
After some research, it looks like most of our embedding scenarios can now be neatly expressed in terms of [CSS contain](https://developer.mozilla.org/en-US/docs/Web/CSS/contain) (which is not very surprising). The implementation is mostly factored out of `fit-text.js` and re-expressed in terms of `contain: ?`.

The main nuance in how `contain: strict` is implemented. It's done with via a wrapper with the following markup/styles:

```
<div (wrapper) style="contain: strict; ...{user styles}" class={user classes}>
  <div (content) style="position: relative; width: 100%; height: 100%"></div>
</div>
```

This gives us a good compromise:
 1. If a dev does not give the right sizing to component it's essentially has 0 size and very broken. It makes it clear that the sizing must be provided for correct functioning.
 2. The choice of how to supply sizing is completely up to dev: any mechanism/framework/library would work without conflict with the component itself.
