### PR TITLE
🐛  Allowlist amp-accordion actions in AMP4Email

### DIFF
--- a/extensions/amp-accordion/0.1/amp-accordion.js
+++ b/extensions/amp-accordion/0.1/amp-accordion.js
@@ -132,6 +132,12 @@ class AmpAccordion extends AMP.BaseElement {
       this.registerAction('toggle', (i) => this.handleAction_(i));
       this.registerAction('expand', (i) => this.handleAction_(i));
       this.registerAction('collapse', (i) => this.handleAction_(i));
+      /** If the element is in an email document, allow its `open` and `close` actions. */
+      this.action_.addToAllowlist(
+        TAG,
+        ['toggle', 'expand', 'collapse'],
+        ['email']
+      );
 
       // Listen for mutations on the 'data-expand' attribute.
       const expandObserver = new this.win.MutationObserver((mutations) => {

--- a/spec/amp-actions-and-events.md
+++ b/spec/amp-actions-and-events.md
@@ -172,7 +172,7 @@ event.value</pre>
   </tr>
 </table>
 
-### amp-accordion <a name="amp-accordion"></a>
+### amp-accordion > section <a name="amp-accordion"></a>
 
 <table>
   <tr>

--- a/spec/amp-actions-and-events.md
+++ b/spec/amp-actions-and-events.md
@@ -172,6 +172,26 @@ event.value</pre>
   </tr>
 </table>
 
+### amp-accordion <a name="amp-accordion"></a>
+
+<table>
+  <tr>
+    <th width="25%">Event</th>
+    <th width="35%">Description</th>
+    <th width="40%">Data</th>
+  </tr>
+  <tr>
+    <td><code>expand</code></td>
+    <td>Fired when an accordion section expands.</td>
+    <td>None.</td>
+  </tr>
+  <tr>
+    <td><code>collapse</code></td>
+    <td>Fired when an accordion section collapses.</td>
+    <td>None.</td>
+  </tr>
+</table>
+
 ### amp-carousel[type="slides"] <a name="amp-carouseltypeslides"></a>
 
 <table>
@@ -430,6 +450,27 @@ event.response</pre></td>
   <tr>
     <td><code>seekTo(percent=[0,1])</code></td>
     <td>Uses the given percentage value to determine the currentTime of the animation to the specified value and pauses animation. </td>
+  </tr>
+</table>
+
+### amp-accordion <a name="amp-accordion-1"></a>
+
+<table>
+  <tr>
+    <th>Action</th>
+    <th>Description</th>
+  </tr>
+  <tr>
+    <td><code>toggle(section=STRING)</code></td>
+    <td>Toggles the <code>expanded</code> and <code>collapsed</code> states of <code>amp-accordion</code> sections. When called with no arguments, it toggles all sections of the accordion. To specify a specific section, add the <code>section</code> argument and use its corresponding <code>id</code> as the value.</td>
+  </tr>
+  <tr>
+    <td><code>expand(section=STRING)</code></td>
+    <td>Expands the sections of the accordion. If a section is already expanded, it stays expanded. When called with no arguments, it expands all sections of the accordion. To specify a specific section, add the <code>section</code> argument and use its corresponding <code>id</code> as the value.</td>
+  </tr>
+  <tr>
+    <td><code>collapse(section=STRING)</code></td>
+    <td>Collapses the sections of the accordion. If a section is already collapsed, it stays collapsed. When called with no arguments, it collapses all sections of the accordion. To specify a specific section, add the <code>section</code> argument and use its corresponding <code>id</code> as the value.</td>
   </tr>
 </table>
 

--- a/spec/amp-actions-and-events.md
+++ b/spec/amp-actions-and-events.md
@@ -462,15 +462,15 @@ event.response</pre></td>
   </tr>
   <tr>
     <td><code>toggle(section=STRING)</code></td>
-    <td>Toggles the <code>expanded</code> and <code>collapsed</code> states of <code>amp-accordion</code> sections. When called with no arguments, it toggles all sections of the accordion. To specify a specific section, add the <code>section</code> argument and use its corresponding <code>id</code> as the value.</td>
+    <td>Toggles the <code>expanded</code> and <code>collapsed</code> states of <code>amp-accordion</code> sections. When called with no arguments, it toggles all sections of the accordion. Trigger on a specific section by providing the section id: <code>on="tap:myAccordion.toggle(section='section-id')"</code>.
   </tr>
   <tr>
     <td><code>expand(section=STRING)</code></td>
-    <td>Expands the sections of the accordion. If a section is already expanded, it stays expanded. When called with no arguments, it expands all sections of the accordion. To specify a specific section, add the <code>section</code> argument and use its corresponding <code>id</code> as the value.</td>
+    <td>Expands the sections of the accordion. If a section is already expanded, it stays expanded. When called with no arguments, it expands all sections of the accordion. Trigger on a specific section by providing the section id: <code>on="tap:myAccordion.expand(section='section-id')"</code>.</td>
   </tr>
   <tr>
     <td><code>collapse(section=STRING)</code></td>
-    <td>Collapses the sections of the accordion. If a section is already collapsed, it stays collapsed. When called with no arguments, it collapses all sections of the accordion. To specify a specific section, add the <code>section</code> argument and use its corresponding <code>id</code> as the value.</td>
+    <td>Collapses the sections of the accordion. If a section is already collapsed, it stays collapsed. When called with no arguments, it collapses all sections of the accordion. Trigger on a specific section by providing the section id: <code>on="tap:myAccordion.collapse(section='section-id')"</code>.</td>
   </tr>
 </table>
 

--- a/spec/amp-email-actions-and-events.md
+++ b/spec/amp-email-actions-and-events.md
@@ -169,7 +169,7 @@ event.value</pre>
   </tr>
 </table>
 
-### amp-accordion <a name="amp-accordion"></a>
+### amp-accordion > section <a name="amp-accordion"></a>
 
 <table>
   <tr>

--- a/spec/amp-email-actions-and-events.md
+++ b/spec/amp-email-actions-and-events.md
@@ -379,15 +379,15 @@ event.response</pre></td>
   </tr>
   <tr>
     <td><code>toggle(section=STRING)</code></td>
-    <td>Toggles the <code>expanded</code> and <code>collapsed</code> states of <code>amp-accordion</code> sections. When called with no arguments, it toggles all sections of the accordion. To specify a specific section, add the <code>section</code> argument and use its corresponding <code>id</code> as the value.</td>
+    <td>Toggles the <code>expanded</code> and <code>collapsed</code> states of <code>amp-accordion</code> sections. When called with no arguments, it toggles all sections of the accordion. Trigger on a specific section by providing the section id: <code>on="tap:myAccordion.toggle(section='section-id')"</code>.
   </tr>
   <tr>
     <td><code>expand(section=STRING)</code></td>
-    <td>Expands the sections of the accordion. If a section is already expanded, it stays expanded. When called with no arguments, it expands all sections of the accordion. To specify a specific section, add the <code>section</code> argument and use its corresponding <code>id</code> as the value.</td>
+    <td>Expands the sections of the accordion. If a section is already expanded, it stays expanded. When called with no arguments, it expands all sections of the accordion. Trigger on a specific section by providing the section id: <code>on="tap:myAccordion.expand(section='section-id')"</code>.</td>
   </tr>
   <tr>
     <td><code>collapse(section=STRING)</code></td>
-    <td>Collapses the sections of the accordion. If a section is already collapsed, it stays collapsed. When called with no arguments, it collapses all sections of the accordion. To specify a specific section, add the <code>section</code> argument and use its corresponding <code>id</code> as the value.</td>
+    <td>Collapses the sections of the accordion. If a section is already collapsed, it stays collapsed. When called with no arguments, it collapses all sections of the accordion. Trigger on a specific section by providing the section id: <code>on="tap:myAccordion.collapse(section='section-id')"</code>.</td>
   </tr>
 </table>
 

--- a/spec/amp-email-actions-and-events.md
+++ b/spec/amp-email-actions-and-events.md
@@ -169,6 +169,26 @@ event.value</pre>
   </tr>
 </table>
 
+### amp-accordion <a name="amp-accordion"></a>
+
+<table>
+  <tr>
+    <th width="25%">Event</th>
+    <th width="35%">Description</th>
+    <th width="40%">Data</th>
+  </tr>
+  <tr>
+    <td><code>expand</code></td>
+    <td>Fired when an accordion section expands.</td>
+    <td>None.</td>
+  </tr>
+  <tr>
+    <td><code>collapse</code></td>
+    <td>Fired when an accordion section collapses.</td>
+    <td>None.</td>
+  </tr>
+</table>
+
 ### amp-carousel[type="slides"] <a name="amp-carouseltypeslides"></a>
 
 <table>
@@ -347,6 +367,27 @@ event.response</pre></td>
     on another element (usually parent element). We strongly advise against
     losing focus by focusing on <code>body</code>/<code>documentElement</code>
     for accessibility reasons.</td>
+  </tr>
+</table>
+
+### amp-accordion <a name="amp-accordion-1"></a>
+
+<table>
+  <tr>
+    <th>Action</th>
+    <th>Description</th>
+  </tr>
+  <tr>
+    <td><code>toggle(section=STRING)</code></td>
+    <td>Toggles the <code>expanded</code> and <code>collapsed</code> states of <code>amp-accordion</code> sections. When called with no arguments, it toggles all sections of the accordion. To specify a specific section, add the <code>section</code> argument and use its corresponding <code>id</code> as the value.</td>
+  </tr>
+  <tr>
+    <td><code>expand(section=STRING)</code></td>
+    <td>Expands the sections of the accordion. If a section is already expanded, it stays expanded. When called with no arguments, it expands all sections of the accordion. To specify a specific section, add the <code>section</code> argument and use its corresponding <code>id</code> as the value.</td>
+  </tr>
+  <tr>
+    <td><code>collapse(section=STRING)</code></td>
+    <td>Collapses the sections of the accordion. If a section is already collapsed, it stays collapsed. When called with no arguments, it collapses all sections of the accordion. To specify a specific section, add the <code>section</code> argument and use its corresponding <code>id</code> as the value.</td>
   </tr>
 </table>
 


### PR DESCRIPTION
- Allows amp-accordion `toggle`, `collapse`, and `expand` actions in AMP4Email.
- Adds amp-accordion to the AMP actions and events documentation.

Double checked [email components](https://amp.dev/documentation/components/?format=email) and accordion should be the only one that was not originally included. b/162131613