### PR TITLE
✨ Amp-access-scroll: Implement "activate" redirect when not on proxy

### DIFF
--- a/extensions/amp-access-scroll/0.1/scroll-bar.js
+++ b/extensions/amp-access-scroll/0.1/scroll-bar.js
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import {PROTOCOL_VERSION} from './scroll-protocol';
 import {ScrollComponent} from './scroll-component';
+import {buildUrl, connectHostname} from './scroll-url';
 import {dict} from '../../../src/utils/object';
 
 /**
@@ -27,16 +27,12 @@ export class ScrollBar extends ScrollComponent {
   /**
    * @param {!../../../src/service/ampdoc-impl.AmpDoc} doc
    * @param {!../../amp-access/0.1/amp-access-source.AccessSource} accessSource
-   * @param {string} baseUrl
    */
-  constructor(doc, accessSource, baseUrl) {
+  constructor(doc, accessSource) {
     super(doc);
 
     /** @protected */
     this.accessSource_ = accessSource;
-
-    /** @protected */
-    this.baseUrl_ = baseUrl;
 
     this.render_();
   }
@@ -83,20 +79,13 @@ export class ScrollBar extends ScrollComponent {
     this.mount();
 
     // Set iframe to scrollbar URL.
-    this.accessSource_
-      .buildUrl(
-        `${this.baseUrl_}/html/amp/scrolltab` +
-          '?rid=READER_ID' +
-          '&cid=CLIENT_ID(scroll1)' +
-          '&c=CANONICAL_URL' +
-          '&o=AMPDOC_URL' +
-          `&p=${PROTOCOL_VERSION}` +
-          '&x=QUERY_PARAM(scrollx)',
-        false
-      )
-      .then((scrollbarUrl) => {
-        this.frame_.setAttribute('src', scrollbarUrl);
-      });
+    buildUrl(
+      this.accessSource_,
+      connectHostname(this.accessSource_.getAdapterConfig()) +
+        '/html/amp/scrolltab'
+    ).then((scrollbarUrl) => {
+      this.frame_.setAttribute('src', scrollbarUrl);
+    });
   }
 
   /**

--- a/extensions/amp-access-scroll/0.1/scroll-impl.js
+++ b/extensions/amp-access-scroll/0.1/scroll-impl.js
@@ -24,7 +24,7 @@ import {Services} from '../../../src/services';
 import {Sheet} from './scroll-sheet';
 import {addParamToUrl, isProxyOrigin, parseQueryString} from '../../../src/url';
 import {buildUrl, connectHostname} from './scroll-url';
-import {createElementWithAttributes, openWindowDialog} from '../../../src/dom';
+import {createElementWithAttributes} from '../../../src/dom';
 import {dict} from '../../../src/utils/object';
 import {installStylesForDoc} from '../../../src/style-installer';
 
@@ -234,10 +234,10 @@ class ScrollContentBlocker {
     if (this.redirect_ && !isProxyOrigin(this.ampdoc_.win.location)) {
       buildUrl(this.accessSource_, 'https://scroll.com/loginwithapp').then(
         (url) => {
-          openWindowDialog(
+          const navigationService = Services.navigationForDoc(this.ampdoc_);
+          navigationService.navigateTo(
             this.ampdoc_.win,
-            addParamToUrl(url, 'feature', 'r'),
-            '_top'
+            addParamToUrl(url, 'feature', 'r')
           );
         }
       );

--- a/extensions/amp-access-scroll/0.1/scroll-impl.js
+++ b/extensions/amp-access-scroll/0.1/scroll-impl.js
@@ -22,11 +22,11 @@ import {Relay} from './scroll-relay';
 import {ScrollBar} from './scroll-bar';
 import {Services} from '../../../src/services';
 import {Sheet} from './scroll-sheet';
-import {createElementWithAttributes} from '../../../src/dom';
+import {addParamToUrl, isProxyOrigin, parseQueryString} from '../../../src/url';
+import {buildUrl, connectHostname} from './scroll-url';
+import {createElementWithAttributes, openWindowDialog} from '../../../src/dom';
 import {dict} from '../../../src/utils/object';
-import {getMode} from '../../../src/mode';
 import {installStylesForDoc} from '../../../src/style-installer';
-import {parseQueryString} from '../../../src/url';
 
 const TAG = 'amp-access-scroll-elt';
 /**
@@ -96,28 +96,6 @@ const analyticsConfig = (baseUrl) => {
 };
 
 /**
- * The eTLD for scroll URLs in development mode.
- *
- * Enables amp-access-scroll to work with dev/staging environments.
- *
- * @param {!JsonObject} config
- * @return {string}
- */
-const devEtld = (config) => {
-  return getMode().development && config['etld'] ? config['etld'] : '';
-};
-
-/**
- * The connect server hostname.
- *
- * @param {!JsonObject} config
- * @return {string}
- */
-const connectHostname = (config) => {
-  return `https://connect${devEtld(config) || '.scroll.com'}`;
-};
-
-/**
  * amp-access vendor that authenticates against the scroll.com service.
  * If the user is authenticated, also adds a fixed position iframe
  * to the page.
@@ -159,11 +137,7 @@ export class ScrollAccessVendor extends AccessClientAdapter {
       if (response && response['scroll']) {
         if (!isStory) {
           // Display Scrollbar and set up features
-          const bar = new ScrollBar(
-            this.ampdoc,
-            this.accessSource_,
-            this.baseUrl_
-          );
+          const bar = new ScrollBar(this.ampdoc, this.accessSource_);
           const sheet = new Sheet(this.ampdoc);
 
           const relay = new Relay(this.baseUrl_);
@@ -195,7 +169,11 @@ export class ScrollAccessVendor extends AccessClientAdapter {
           response['blocker'] &&
           ScrollContentBlocker.shouldCheck(this.ampdoc)
         ) {
-          new ScrollContentBlocker(this.ampdoc, this.accessSource_).check();
+          new ScrollContentBlocker(
+            this.ampdoc,
+            this.accessSource_,
+            response['features'] && response['features']['r']
+          ).check();
         }
       }
       return response;
@@ -220,13 +198,17 @@ class ScrollContentBlocker {
   /**
    * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc
    * @param {!../../amp-access/0.1/amp-access-source.AccessSource} accessSource
+   * @param {boolean} redirect
    */
-  constructor(ampdoc, accessSource) {
+  constructor(ampdoc, accessSource, redirect) {
     /** @const @private {!../../../src/service/ampdoc-impl.AmpDoc} */
     this.ampdoc_ = ampdoc;
 
     /** @const @private {!../../amp-access/0.1/amp-access-source.AccessSource} */
     this.accessSource_ = accessSource;
+
+    /** @const @private {boolean} */
+    this.redirect_ = redirect;
   }
 
   /**
@@ -241,21 +223,35 @@ class ScrollContentBlocker {
       )
       .then((blockedByScrollApp) => {
         if (blockedByScrollApp === true) {
-          // TODO(dbow): Ideally we would automatically redirect to the page
-          // here, but for now we are adding a button so we redirect on user
-          // action.
-          const baseUrl = connectHostname(
-            this.accessSource_.getAdapterConfig()
-          );
-          const bar = new ScrollBar(this.ampdoc_, this.accessSource_, baseUrl);
-          const relay = new Relay(baseUrl);
-          relay.register(bar.window, (message) => {
-            if (message['_scramp'] === 'st') {
-              bar.update(message);
-            }
-          });
+          this.handleBlocked_();
         }
       });
+  }
+
+  /** @private */
+  handleBlocked_() {
+    // Redirect app auth flow if enabled and not on AMP proxy.
+    if (this.redirect_ && !isProxyOrigin(this.ampdoc_.win.location)) {
+      buildUrl(this.accessSource_, 'https://scroll.com/loginwithapp').then(
+        (url) => {
+          openWindowDialog(
+            this.ampdoc_.win,
+            addParamToUrl(url, 'feature', 'r'),
+            '_top'
+          );
+        }
+      );
+    } else {
+      // Prompt to activate.
+      const baseUrl = connectHostname(this.accessSource_.getAdapterConfig());
+      const bar = new ScrollBar(this.ampdoc_, this.accessSource_, baseUrl);
+      const relay = new Relay(baseUrl);
+      relay.register(bar.window, (message) => {
+        if (message['_scramp'] === 'st') {
+          bar.update(message);
+        }
+      });
+    }
   }
 
   /**

--- a/extensions/amp-access-scroll/0.1/scroll-impl.js
+++ b/extensions/amp-access-scroll/0.1/scroll-impl.js
@@ -244,7 +244,7 @@ class ScrollContentBlocker {
     } else {
       // Prompt to activate.
       const baseUrl = connectHostname(this.accessSource_.getAdapterConfig());
-      const bar = new ScrollBar(this.ampdoc_, this.accessSource_, baseUrl);
+      const bar = new ScrollBar(this.ampdoc_, this.accessSource_);
       const relay = new Relay(baseUrl);
       relay.register(bar.window, (message) => {
         if (message['_scramp'] === 'st') {

--- a/extensions/amp-access-scroll/0.1/scroll-url.js
+++ b/extensions/amp-access-scroll/0.1/scroll-url.js
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {PROTOCOL_VERSION} from './scroll-protocol';
+import {getMode} from '../../../src/mode';
+
+/**
+ * The eTLD for scroll URLs in development mode.
+ *
+ * Enables amp-access-scroll to work with dev/staging environments.
+ *
+ * @param {!JsonObject} config
+ * @return {string}
+ */
+const devEtld = (config) => {
+  return getMode().development && config['etld'] ? config['etld'] : '';
+};
+
+/**
+ * The connect server hostname.
+ *
+ * @param {!JsonObject} config
+ * @return {string}
+ */
+export const connectHostname = (config) => {
+  return `https://connect${devEtld(config) || '.scroll.com'}`;
+};
+
+/**
+ * Get the url for iframe source or redirect, including necessary query params.
+ *
+ * @param {!../../amp-access/0.1/amp-access-source.AccessSource} accessSource
+ * @param {string} base
+ * @return {Promise<string>}
+ */
+export function buildUrl(accessSource, base) {
+  return accessSource.buildUrl(
+    `${base}` +
+      '?rid=READER_ID' +
+      '&cid=CLIENT_ID(scroll1)' +
+      '&c=CANONICAL_URL' +
+      '&o=AMPDOC_URL' +
+      `&p=${PROTOCOL_VERSION}` +
+      '&x=QUERY_PARAM(scrollx)',
+    false
+  );
+}


### PR DESCRIPTION
When user has Scroll app but is not signed in, and when ampdoc is not being served from proxy, redirect to app login flow.

- refactor constructing urls to buildUrl method in scroll-url.js
- refactor ScrollContentBlocker to separate logic for detecting vs handling
- add redirect case

cc @dvoytenko @kushal @dbow 

closes #20997