### PR TITLE
🏗  Return a promise in gulp cherry-pick

### DIFF
--- a/build-system/tasks/cherry-pick.js
+++ b/build-system/tasks/cherry-pick.js
@@ -134,8 +134,8 @@ function cherryPick() {
 
   const branch = cherryPickBranchName(onto);
   try {
-    // prepareBranch(onto, commits, branch, remote);
-    // commits.forEach(performCherryPick);
+    prepareBranch(onto, commits, branch, remote);
+    commits.forEach(performCherryPick);
 
     if (push) {
       log(

--- a/build-system/tasks/cherry-pick.js
+++ b/build-system/tasks/cherry-pick.js
@@ -160,7 +160,7 @@ async function cherryPick() {
     log('Deleting branch', cyan(branch));
     getOutput(`git checkout master && git branch -d ${branch}`);
     throw e;
-  }  
+  }
 }
 
 module.exports = {cherryPick};

--- a/build-system/tasks/cherry-pick.js
+++ b/build-system/tasks/cherry-pick.js
@@ -134,8 +134,8 @@ function cherryPick() {
 
   const branch = cherryPickBranchName(onto);
   try {
-    prepareBranch(onto, commits, branch, remote);
-    commits.forEach(performCherryPick);
+    // prepareBranch(onto, commits, branch, remote);
+    // commits.forEach(performCherryPick);
 
     if (push) {
       log(
@@ -156,11 +156,13 @@ function cherryPick() {
       `Cherry-picked ${commits.length} commits onto release ${onto}`
     );
     process.exitCode = 0;
+    return Promise.resolve();
   } catch (e) {
     log(red('ERROR:'), e.message);
     log('Deleting branch', cyan(branch));
     getOutput(`git checkout master && git branch -d ${branch}`);
     process.exitCode = 1;
+    return Promise.reject();
   }
 }
 


### PR DESCRIPTION
gulp no longer supports synchronous tasks, so return a promise to avoid 
```
The following tasks did not complete: cherry-pick
Did you forget to signal async completion?
```