### PR TITLE
Preliminary boilerplate and poc for shadow stylesheets

### DIFF
--- a/build-system/externs/amp.extern.js
+++ b/build-system/externs/amp.extern.js
@@ -913,4 +913,4 @@ HTMLIFrameElement.prototype.featurePolicy;
  *
  * @param {string} cssText
  */
-CSSStyleSheet.prototype.replaceSync = function(cssText) {};
+CSSStyleSheet.prototype.replaceSync = function (cssText) {};

--- a/build-system/externs/amp.extern.js
+++ b/build-system/externs/amp.extern.js
@@ -905,3 +905,12 @@ class FeaturePolicy {
  * @type {?FeaturePolicy}
  */
 HTMLIFrameElement.prototype.featurePolicy;
+
+/**
+ * Going through the standardization process now.
+ *
+ * See https://developers.google.com/web/updates/2019/02/constructable-stylesheets.
+ *
+ * @param {string} cssText
+ */
+CSSStyleSheet.prototype.replaceSync = function(cssText) {};

--- a/extensions/amp-base-carousel/1.0/amp-base-carousel.js
+++ b/extensions/amp-base-carousel/1.0/amp-base-carousel.js
@@ -22,6 +22,7 @@ import {createCustomEvent} from '../../../src/event-helper';
 import {dict} from '../../../src/utils/object';
 import {isExperimentOn} from '../../../src/experiments';
 import {isLayoutSizeDefined} from '../../../src/layout';
+import {scrollerStyles} from './base-carousel.css';
 import {userAssert} from '../../../src/log';
 
 /** @const {string} */
@@ -79,6 +80,9 @@ AmpBaseCarousel['children'] = {
 AmpBaseCarousel['props'] = {
   'loop': {attr: 'loop', type: 'boolean'},
 };
+
+/** @override */
+AmpBaseCarousel['shadowCss'] = scrollerStyles;
 
 /**
  * Triggers a 'slideChange' event with one data param:

--- a/extensions/amp-base-carousel/1.0/scroller.js
+++ b/extensions/amp-base-carousel/1.0/scroller.js
@@ -124,23 +124,20 @@ export function Scroller({
   };
 
   return (
-    <>
-      <style>{styles.scrollerStyles}</style>
-      <div
-        hide-scrollbar
-        key="container"
-        ref={containerRef}
-        onScroll={handleScroll}
-        style={{
-          ...styles.scrollContainer,
-          ...styles.hideScrollbar,
-          ...styles.horizontalScroll,
-        }}
-        tabindex={0}
-      >
-        {slides}
-      </div>
-    </>
+    <div
+      hide-scrollbar
+      key="container"
+      ref={containerRef}
+      onScroll={handleScroll}
+      style={{
+        ...styles.scrollContainer,
+        ...styles.hideScrollbar,
+        ...styles.horizontalScroll,
+      }}
+      tabindex={0}
+    >
+      {slides}
+    </div>
   );
 }
 

--- a/extensions/amp-base-carousel/1.0/storybook/Basic.js
+++ b/extensions/amp-base-carousel/1.0/storybook/Basic.js
@@ -17,6 +17,7 @@
 import * as Preact from '../../../../src/preact';
 import {BaseCarousel} from '../base-carousel';
 import {number, withKnobs} from '@storybook/addon-knobs';
+import {scrollerStyles} from '../base-carousel.css';
 import {withA11y} from '@storybook/addon-a11y';
 
 export default {
@@ -31,16 +32,18 @@ export const _default = () => {
   const slideCount = number('slide count', 5, {min: 0, max: 99});
   const colorIncrement = Math.floor(255 / (slideCount + 1));
   return (
-    <BaseCarousel style={{width, height, position: 'relative'}}>
-      {Array.from({length: slideCount}, (x, i) => {
-        const v = colorIncrement * (i + 1);
-        return (
-          <div
-            style={{backgroundColor: `rgb(${v}, 100, 100)`, width, height}}
-          ></div>
-        );
-      })}
-    </BaseCarousel>
+    <WithStyles>
+      <BaseCarousel style={{width, height, position: 'relative'}}>
+        {Array.from({length: slideCount}, (x, i) => {
+          const v = colorIncrement * (i + 1);
+          return (
+            <div
+              style={{backgroundColor: `rgb(${v}, 100, 100)`, width, height}}
+            ></div>
+          );
+        })}
+      </BaseCarousel>
+    </WithStyles>
   );
 };
 
@@ -64,15 +67,17 @@ export const provideArrows = () => {
     );
   };
   return (
-    <BaseCarousel
-      style={{width, height, position: 'relative'}}
-      arrowPrev={<MyButton>←</MyButton>}
-      arrowNext={<MyButton>→</MyButton>}
-    >
-      {['lightcoral', 'peachpuff', 'lavender'].map((color) => (
-        <div style={{backgroundColor: color, width, height}}></div>
-      ))}
-    </BaseCarousel>
+    <WithStyles>
+      <BaseCarousel
+        style={{width, height, position: 'relative'}}
+        arrowPrev={<MyButton>←</MyButton>}
+        arrowNext={<MyButton>→</MyButton>}
+      >
+        {['lightcoral', 'peachpuff', 'lavender'].map((color) => (
+          <div style={{backgroundColor: color, width, height}}></div>
+        ))}
+      </BaseCarousel>
+    </WithStyles>
   );
 };
 
@@ -80,59 +85,74 @@ export const WithLooping = () => {
   const width = number('width', 440);
   const height = number('height', 225);
   return (
-    <BaseCarousel loop style={{width, height, position: 'relative'}}>
-      {[
-        'lightpink',
-        'lightcoral',
-        'peachpuff',
-        'powderblue',
-        'lavender',
-        'thistle',
-      ].map((color, index) => (
-        <div
-          style={{
-            backgroundColor: color,
-            width,
-            height,
-            textAlign: 'center',
-            fontSize: '48pt',
-            lineHeight: height + 'px',
-          }}
-        >
-          {index}
-        </div>
-      ))}
-    </BaseCarousel>
+    <WithStyles>
+      <BaseCarousel loop style={{width, height, position: 'relative'}}>
+        {[
+          'lightpink',
+          'lightcoral',
+          'peachpuff',
+          'powderblue',
+          'lavender',
+          'thistle',
+        ].map((color, index) => (
+          <div
+            style={{
+              backgroundColor: color,
+              width,
+              height,
+              textAlign: 'center',
+              fontSize: '48pt',
+              lineHeight: height + 'px',
+            }}
+          >
+            {index}
+          </div>
+        ))}
+      </BaseCarousel>
+    </WithStyles>
   );
 };
 
 export const WithCaptions = () => {
   return (
-    <BaseCarousel
-      loop
-      style={{width: '500px', height: '400px', position: 'relative'}}
-    >
-      <figure>
-        <img
-          style={{width: '500px', height: '300px'}}
-          src="https://amp.dev/static/samples/img/landscape_lake_1280x857.jpg"
-        />
-        <figcaption>Each image has a different caption.</figcaption>
-      </figure>
-      <figure>
-        <img
-          style={{width: '600px', height: '300px'}}
-          src="https://amp.dev/static/samples/img/landscape_village_1280x853.jpg"
-        />
-        <figcaption>This caption is different.</figcaption>
-      </figure>
-      <figure>
-        <img
-          style={{width: '500px', height: '300px'}}
-          src="https://amp.dev/static/samples/img/landscape_desert_1280x853.jpg"
-        />
-        <figcaption>The third image has its caption.</figcaption>
-      </figure>
-    </BaseCarousel>
+    <WithStyles>
+      <BaseCarousel
+        loop
+        style={{width: '500px', height: '400px', position: 'relative'}}
+      >
+        <figure>
+          <img
+            style={{width: '500px', height: '300px'}}
+            src="https://amp.dev/static/samples/img/landscape_lake_1280x857.jpg"
+          />
+          <figcaption>Each image has a different caption.</figcaption>
+        </figure>
+        <figure>
+          <img
+            style={{width: '600px', height: '300px'}}
+            src="https://amp.dev/static/samples/img/landscape_village_1280x853.jpg"
+          />
+          <figcaption>This caption is different.</figcaption>
+        </figure>
+        <figure>
+          <img
+            style={{width: '500px', height: '300px'}}
+            src="https://amp.dev/static/samples/img/landscape_desert_1280x853.jpg"
+          />
+          <figcaption>The third image has its caption.</figcaption>
+        </figure>
+      </BaseCarousel>
+    </WithStyles>
+  );
+};
+
+const WithStyles = ({children}) => {
+  // TODO(wg-bento#7): remove this method once the stylesheet is bundled
+  // with the component.
+  return (
+    <div>
+      <style>${scrollerStyles}</style>
+      {children}
+    </div>
   );
 };

--- a/src/preact/base-element.js
+++ b/src/preact/base-element.js
@@ -20,6 +20,7 @@ import {Slot, createSlot} from './slot';
 import {WithAmpContext} from './context';
 import {devAssert} from '../log';
 import {hasOwn} from '../utils/object';
+import {installShadowStyle} from '../shadow-embed';
 import {matches} from '../dom';
 import {render} from './index';
 
@@ -216,7 +217,13 @@ export class PreactBaseElement extends AMP.BaseElement {
             'when configured with "children", "passthrough", or ' +
             '"passthroughNonEmpty" properties.'
         );
-        this.container_ = this.element.attachShadow({mode: 'open'});
+        const shadowRoot = this.element.attachShadow({mode: 'open'});
+        this.container_ = shadowRoot;
+
+        const shadowCss = Ctor['shadowCss'];
+        if (shadowCss) {
+          installShadowStyle(shadowRoot, this.element.tagName, shadowCss);
+        }
 
         // Create a slot for internal service elements i.e. "i-amphtml-sizer"
         const serviceSlot = this.win.document.createElement('slot');
@@ -312,6 +319,13 @@ PreactBaseElement['passthrough'] = false;
  * @protected {boolean}
  */
 PreactBaseElement['passthroughNonEmpty'] = false;
+
+/**
+ * The CSS for shadow stylesheets.
+ *
+ * @protected {?string}
+ */
+PreactBaseElement['shadowCss'] = null;
 
 /**
  * Enabling detached mode alters the children to be rendered in an

--- a/src/shadow-embed.js
+++ b/src/shadow-embed.js
@@ -326,12 +326,12 @@ export function installShadowStyle(shadowRoot, name, cssText) {
   const win = toWin(doc.defaultView);
   if (
     shadowRoot.adoptedStyleSheets !== undefined &&
-    CSSStyleSheet.prototype.replaceSync !== undefined
+    win.CSSStyleSheet.prototype.replaceSync !== undefined
   ) {
     const cache = win[SHADOW_CSS_CACHE] || (win[SHADOW_CSS_CACHE] = {});
     let styleSheet = cache[name];
     if (!styleSheet) {
-      styleSheet = new CSSStyleSheet();
+      styleSheet = new win.CSSStyleSheet();
       styleSheet.replaceSync(cssText);
       cache[name] = styleSheet;
     }

--- a/src/shadow-embed.js
+++ b/src/shadow-embed.js
@@ -324,8 +324,10 @@ function getStylesheetRules(doc, css) {
 export function installShadowStyle(shadowRoot, name, cssText) {
   const doc = shadowRoot.ownerDocument;
   const win = toWin(doc.defaultView);
-  if (shadowRoot.adoptedStyleSheets !== undefined &&
-      CSSStyleSheet.prototype.replaceSync !== undefined) {
+  if (
+    shadowRoot.adoptedStyleSheets !== undefined &&
+    CSSStyleSheet.prototype.replaceSync !== undefined
+  ) {
     const cache = win[SHADOW_CSS_CACHE] || (win[SHADOW_CSS_CACHE] = {});
     let styleSheet = cache[name];
     if (!styleSheet) {
@@ -333,7 +335,9 @@ export function installShadowStyle(shadowRoot, name, cssText) {
       styleSheet.replaceSync(cssText);
       cache[name] = styleSheet;
     }
-    shadowRoot.adoptedStyleSheets = [styleSheet];
+    shadowRoot.adoptedStyleSheets = shadowRoot.adoptedStyleSheets.concat(
+      styleSheet
+    );
   } else {
     const styleEl = doc.createElement('style');
     styleEl.setAttribute('data-name', name);

--- a/test/unit/test-shadow-embed.js
+++ b/test/unit/test-shadow-embed.js
@@ -324,18 +324,18 @@ describes.sandboxed('shadow-embed', {}, () => {
     beforeEach(() => {
       shadowRoot = document.createElement('div');
       shadowRoot2 = document.createElement('div');
-      resetShadowStyleCacheForTesting(window);
     });
 
     afterEach(() => {
       resetShadowStyleCacheForTesting(window);
     });
 
-    it('should re-use constructable stylesheet when supported', () => {
+    it('should re-use constructable stylesheet when supported', function () {
       try {
         new CSSStyleSheet();
       } catch (e) {
         // Leave. Not supported.
+        this.skip();
         return;
       }
 
@@ -350,13 +350,17 @@ describes.sandboxed('shadow-embed', {}, () => {
       );
       expect(shadowRoot.querySelector('style')).to.be.null;
 
+      // A different stylesheet.
+      installShadowStyle(shadowRoot, 'B', '* {color: blue}');
+      expect(shadowRoot.adoptedStyleSheets).to.have.length(2);
+
       // Repeated call uses the cache.
       shadowRoot2.adoptedStyleSheets = [];
       installShadowStyle(shadowRoot2, 'A', 'not even CSS');
       expect(shadowRoot2.adoptedStyleSheets).to.have.length(1);
       expect(shadowRoot2.adoptedStyleSheets[0]).to.equal(styleSheet1);
 
-      // A different stylesheet.
+      // A different stylesheet in a differet root.
       shadowRoot2.adoptedStyleSheets = [];
       installShadowStyle(shadowRoot2, 'B', '* {color: blue}');
       expect(shadowRoot2.adoptedStyleSheets).to.have.length(1);

--- a/test/unit/test-shadow-embed.js
+++ b/test/unit/test-shadow-embed.js
@@ -359,7 +359,7 @@ describes.sandboxed('shadow-embed', {}, () => {
         expect(shadowRoot2.adoptedStyleSheets).to.have.length(1);
         expect(shadowRoot2.adoptedStyleSheets[0]).to.equal(styleSheet1);
 
-        // A different stylesheet in a differet root.
+        // A different stylesheet in a different root.
         shadowRoot2.adoptedStyleSheets = [];
         installShadowStyle(shadowRoot2, 'B', '* {color: blue}');
         expect(shadowRoot2.adoptedStyleSheets).to.have.length(1);

--- a/test/unit/test-shadow-embed.js
+++ b/test/unit/test-shadow-embed.js
@@ -330,41 +330,41 @@ describes.sandboxed('shadow-embed', {}, () => {
       resetShadowStyleCacheForTesting(window);
     });
 
-    it('should re-use constructable stylesheet when supported', function () {
-      try {
-        new CSSStyleSheet();
-      } catch (e) {
-        // Leave. Not supported.
-        this.skip();
-        return;
-      }
+    describe('adopted stylesheets supported', () => {
+      before(function () {
+        if (!document.adoptedStyleSheets) {
+          this.skipTest();
+        }
+      });
 
-      shadowRoot.adoptedStyleSheets = [];
-      installShadowStyle(shadowRoot, 'A', '* {color: red}');
+      it('should re-use constructable stylesheet when supported', function () {
+        shadowRoot.adoptedStyleSheets = [];
+        installShadowStyle(shadowRoot, 'A', '* {color: red}');
 
-      expect(shadowRoot.adoptedStyleSheets).to.have.length(1);
-      const styleSheet1 = shadowRoot.adoptedStyleSheets[0];
-      expect(styleSheet1.rules).to.have.length(1);
-      expect(styleSheet1.rules[0].cssText.replace(/(\s|;)/g, '')).to.equal(
-        '*{color:red}'
-      );
-      expect(shadowRoot.querySelector('style')).to.be.null;
+        expect(shadowRoot.adoptedStyleSheets).to.have.length(1);
+        const styleSheet1 = shadowRoot.adoptedStyleSheets[0];
+        expect(styleSheet1.rules).to.have.length(1);
+        expect(styleSheet1.rules[0].cssText.replace(/(\s|;)/g, '')).to.equal(
+          '*{color:red}'
+        );
+        expect(shadowRoot.querySelector('style')).to.be.null;
 
-      // A different stylesheet.
-      installShadowStyle(shadowRoot, 'B', '* {color: blue}');
-      expect(shadowRoot.adoptedStyleSheets).to.have.length(2);
+        // A different stylesheet.
+        installShadowStyle(shadowRoot, 'B', '* {color: blue}');
+        expect(shadowRoot.adoptedStyleSheets).to.have.length(2);
 
-      // Repeated call uses the cache.
-      shadowRoot2.adoptedStyleSheets = [];
-      installShadowStyle(shadowRoot2, 'A', 'not even CSS');
-      expect(shadowRoot2.adoptedStyleSheets).to.have.length(1);
-      expect(shadowRoot2.adoptedStyleSheets[0]).to.equal(styleSheet1);
+        // Repeated call uses the cache.
+        shadowRoot2.adoptedStyleSheets = [];
+        installShadowStyle(shadowRoot2, 'A', 'not even CSS');
+        expect(shadowRoot2.adoptedStyleSheets).to.have.length(1);
+        expect(shadowRoot2.adoptedStyleSheets[0]).to.equal(styleSheet1);
 
-      // A different stylesheet in a differet root.
-      shadowRoot2.adoptedStyleSheets = [];
-      installShadowStyle(shadowRoot2, 'B', '* {color: blue}');
-      expect(shadowRoot2.adoptedStyleSheets).to.have.length(1);
-      expect(shadowRoot2.adoptedStyleSheets[0]).to.not.equal(styleSheet1);
+        // A different stylesheet in a differet root.
+        shadowRoot2.adoptedStyleSheets = [];
+        installShadowStyle(shadowRoot2, 'B', '* {color: blue}');
+        expect(shadowRoot2.adoptedStyleSheets).to.have.length(1);
+        expect(shadowRoot2.adoptedStyleSheets[0]).to.not.equal(styleSheet1);
+      });
     });
 
     it('should create a legacy stylesheet when constructable not supported', () => {

--- a/test/unit/test-shadow-embed.js
+++ b/test/unit/test-shadow-embed.js
@@ -26,6 +26,8 @@ import {
   createShadowRoot,
   getShadowRootNode,
   importShadowBody,
+  installShadowStyle,
+  resetShadowStyleCacheForTesting,
   scopeShadowCss,
   setShadowDomStreamingSupportedForTesting,
 } from '../../src/shadow-embed';
@@ -313,6 +315,59 @@ describes.sandboxed('shadow-embed', {}, () => {
       expect(scope('body-x {}')).to.equal('.h body-x {}');
       expect(scope('body_x {}')).to.equal('.h body_x {}');
       expect(scope('body1 {}')).to.equal('.h body1 {}');
+    });
+  });
+
+  describe('installShadowStyle', () => {
+    let shadowRoot, shadowRoot2;
+
+    beforeEach(() => {
+      shadowRoot = document.createElement('div');
+      shadowRoot2 = document.createElement('div');
+      resetShadowStyleCacheForTesting(window);
+    });
+
+    afterEach(() => {
+      resetShadowStyleCacheForTesting(window);
+    });
+
+    it('should re-use constructable stylesheet when supported', () => {
+      try {
+        new CSSStyleSheet();
+      } catch (e) {
+        // Leave. Not supported.
+        return;
+      }
+
+      shadowRoot.adoptedStyleSheets = [];
+      installShadowStyle(shadowRoot, 'A', '* {color: red}');
+
+      expect(shadowRoot.adoptedStyleSheets).to.have.length(1);
+      const styleSheet1 = shadowRoot.adoptedStyleSheets[0];
+      expect(styleSheet1.rules).to.have.length(1);
+      expect(styleSheet1.rules[0].cssText.replace(/(\s|;)/g, '')).to.equal(
+        '*{color:red}'
+      );
+      expect(shadowRoot.querySelector('style')).to.be.null;
+
+      // Repeated call uses the cache.
+      shadowRoot2.adoptedStyleSheets = [];
+      installShadowStyle(shadowRoot2, 'A', 'not even CSS');
+      expect(shadowRoot2.adoptedStyleSheets).to.have.length(1);
+      expect(shadowRoot2.adoptedStyleSheets[0]).to.equal(styleSheet1);
+
+      // A different stylesheet.
+      shadowRoot2.adoptedStyleSheets = [];
+      installShadowStyle(shadowRoot2, 'B', '* {color: blue}');
+      expect(shadowRoot2.adoptedStyleSheets).to.have.length(1);
+      expect(shadowRoot2.adoptedStyleSheets[0]).to.not.equal(styleSheet1);
+    });
+
+    it('should create a legacy stylesheet when constructable not supported', () => {
+      installShadowStyle(shadowRoot, 'A', '* {color: red}');
+
+      const styleEl = shadowRoot.querySelector('style');
+      expect(styleEl.textContent).to.equal('* {color: red}');
     });
   });
 


### PR DESCRIPTION
Partial for https://github.com/ampproject/wg-bento/issues/7

Design doc: https://docs.google.com/document/d/14gMbnzsTG3F1gxfbLck4kr7At62UYWa-DyrI3nDMJJw/edit#

This is the first and very preliminary step. The goal of this step is to place the shadow stylesheet into an adopted constructed stylesheet. This is a significantly faster option than `<style>` tag. However, there's no yet React-specific solution and this is why Storybook part is for now "hacked together".

In the follow-up steps we will construct a toolchain that will remove duplication and manual steps.