### PR TITLE
amp-autocomplete: Silently disregard `suggest-first`

### DIFF
--- a/extensions/amp-autocomplete/0.1/autocomplete-binding-single.js
+++ b/extensions/amp-autocomplete/0.1/autocomplete-binding-single.js
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import {user} from '../../../src/log';
+
 /**
  * Single implementation of autocomplete. This supports autocompleting
  * a single input value in its entirety.
@@ -33,9 +35,12 @@ export class AutocompleteBindingSingle {
      * See displayActiveItemInInput() for more.
      * @private {boolean}
      */
-    this.shouldSuggestFirst_ =
-      element.hasAttribute('suggest-first') &&
-      element.getAttribute('filter') === 'prefix';
+    this.shouldSuggestFirst_ = element.hasAttribute('suggest-first');
+    const filter = element.getAttribute('filter');
+    if (this.shouldSuggestFirst_ && filter !== 'prefix') {
+      this.shouldSuggestFirst_ = false;
+      user().warn('"suggest-first" expected "filter" type "prefix".');
+    }
 
     /**
      * The Single implementation of autocomplete will allow form

--- a/extensions/amp-autocomplete/0.1/autocomplete-binding-single.js
+++ b/extensions/amp-autocomplete/0.1/autocomplete-binding-single.js
@@ -39,7 +39,10 @@ export class AutocompleteBindingSingle {
     const filter = element.getAttribute('filter');
     if (this.shouldSuggestFirst_ && filter !== 'prefix') {
       this.shouldSuggestFirst_ = false;
-      user().warn('"suggest-first" expected "filter" type "prefix".');
+      user().warn(
+        'AMP-AUTOCOMPLETE',
+        '"suggest-first" expected "filter" type "prefix".'
+      );
     }
 
     /**

--- a/extensions/amp-autocomplete/0.1/autocomplete-binding-single.js
+++ b/extensions/amp-autocomplete/0.1/autocomplete-binding-single.js
@@ -1,5 +1,3 @@
-import {userAssert} from '../../../src/log';
-
 /**
  * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
  *
@@ -28,9 +26,6 @@ export class AutocompleteBindingSingle {
    */
   constructor(ampElement) {
     const {element} = ampElement;
-    /** @private {!Element} */
-    this.element_ = element;
-
     /**
      * The Single implementation of autocomplete should highlight
      * the diff between the user input and the active suggestion
@@ -38,15 +33,9 @@ export class AutocompleteBindingSingle {
      * See displayActiveItemInInput() for more.
      * @private {boolean}
      */
-    this.shouldSuggestFirst_ = element.hasAttribute('suggest-first');
-    const filter = element.getAttribute('filter');
-    userAssert(
-      !this.shouldSuggestFirst_ || filter === 'prefix',
-      '"suggest-first" requires "filter" type "prefix". ' +
-        ' Unexpected "filter" type: %s, %s',
-      filter,
-      this.element_
-    );
+    this.shouldSuggestFirst_ =
+      element.hasAttribute('suggest-first') &&
+      element.getAttribute('filter') === 'prefix';
 
     /**
      * The Single implementation of autocomplete will allow form

--- a/extensions/amp-autocomplete/0.1/test/test-amp-autocomplete-bindings.js
+++ b/extensions/amp-autocomplete/0.1/test/test-amp-autocomplete-bindings.js
@@ -75,15 +75,14 @@ describes.realWin(
         expect(binding.shouldSuggestFirst()).to.be.false;
       });
 
-      it('should error when suggest first is present without prefix filter', () => {
-        expect(() => getBindingSingle({'suggest-first': 'true'})).to.throw(
-          /"suggest-first" requires "filter" type "prefix"/
-        );
+      it('should ignore when suggest first is present without prefix filter', () => {
+        binding = getBindingSingle({'suggest-first': ''});
+        expect(binding.shouldSuggestFirst()).to.be.false;
       });
 
-      it('should not suggest first when attribute is not present', () => {
+      it('should suggest first when attribute is present', () => {
         binding = getBindingSingle({
-          'suggest-first': 'true',
+          'suggest-first': '',
           'filter': 'prefix',
         });
         expect(binding.shouldSuggestFirst()).to.be.true;


### PR DESCRIPTION
As described in the [attribute documentation](https://amp.dev/documentation/components/amp-autocomplete/#suggest-first)