### PR TITLE
📖  Update component documentation with templating detail

### DIFF
--- a/extensions/amp-autocomplete/amp-autocomplete.md
+++ b/extensions/amp-autocomplete/amp-autocomplete.md
@@ -98,7 +98,7 @@ Would most predictably be applied and rendered if instead provided as follows:
 <template type="amp-mustache">
   {% raw %}
   <!-- RECOMMENDED -->
-  <div>
+  <div data-value="{{items}}">
     <div class="item">{{item}}</div>
     <div class="price">{{price}}</div>
   </div>

--- a/extensions/amp-autocomplete/amp-autocomplete.md
+++ b/extensions/amp-autocomplete/amp-autocomplete.md
@@ -80,7 +80,7 @@ You can specify a template in one of two ways:
 For more details on templates, see [AMP HTML Templates](../../spec/amp-html-templates.md).
 
 [tip type="note"]
-Note also that template contents will place multiple top-level elements into an outer wrapping `<div>`. This means the following input:
+Note also that a good practice is to place these in a single top-level element to prevent unintended side effects. Some possible consequences of providing multiple top-level elements: each top-level element could be treated as a distinct item in a list, or all same-level elements could be wrapped by an additional <div> layer, potentially breaking structure-based CSS rules. This means the following input:
 
 ```html
 <template type="amp-mustache">
@@ -91,7 +91,7 @@ Note also that template contents will place multiple top-level elements into an 
 </template>
 ```
 
-Will effectively be treated as the following:
+Might be effectively treated as is OR as following, depending on the template renderer being employed:
 
 ```html
 <template type="amp-mustache">
@@ -104,7 +104,7 @@ Will effectively be treated as the following:
 </template>
 ```
 
-A best practice is to ensure the provided template contains a singular top-level element so that [`data-value` and `data-disabled`](https://amp.dev/documentation/examples/components/amp-autocomplete/#suggesting-rich-content) attributes can be provided accordingly on the delimiting element.
+A best practice is to ensure the provided template contains a singular top-level element to avoid unpredictable behavior, as well as so that [`data-value` and `data-disabled`](https://amp.dev/documentation/examples/components/amp-autocomplete/#suggesting-rich-content) attributes can be provided accordingly on the delimiting element.
 
 [/tip]
 

--- a/extensions/amp-autocomplete/amp-autocomplete.md
+++ b/extensions/amp-autocomplete/amp-autocomplete.md
@@ -80,22 +80,24 @@ You can specify a template in one of two ways:
 For more details on templates, see [AMP HTML Templates](../../spec/amp-html-templates.md).
 
 [tip type="note"]
-Note also that a good practice is to place these in a single top-level element to prevent unintended side effects. Some possible consequences of providing multiple top-level elements: each top-level element could be treated as a distinct item in a list, or all same-level elements could be wrapped by an additional <div> layer, potentially breaking structure-based CSS rules. This means the following input:
+Note also that a good practice is to provide templates a single top-level element to prevent unintended side effects. This also guarantees control of the [`data-value` or `data-disabled`](https://amp.dev/documentation/examples/components/amp-autocomplete/#suggesting-rich-content) attribute on the delimiting element. As an example, the following input:
 
 ```html
 <template type="amp-mustache">
   {% raw %}
+  <!-- NOT RECOMMENDED -->
   <div class="item">{{item}}</div>
   <div class="price">{{price}}</div>
   {% endraw %}
 </template>
 ```
 
-Might be effectively treated as is OR as following, depending on the template renderer being employed:
+Would most predictably be applied and rendered if instead provided as follows:
 
 ```html
 <template type="amp-mustache">
   {% raw %}
+  <!-- RECOMMENDED -->
   <div>
     <div class="item">{{item}}</div>
     <div class="price">{{price}}</div>
@@ -103,8 +105,6 @@ Might be effectively treated as is OR as following, depending on the template re
   {% endraw %}
 </template>
 ```
-
-A best practice is to ensure the provided template contains a singular top-level element to avoid unpredictable behavior, as well as so that [`data-value` and `data-disabled`](https://amp.dev/documentation/examples/components/amp-autocomplete/#suggesting-rich-content) attributes can be provided accordingly on the delimiting element.
 
 [/tip]
 

--- a/extensions/amp-autocomplete/amp-autocomplete.md
+++ b/extensions/amp-autocomplete/amp-autocomplete.md
@@ -58,15 +58,55 @@ Example:
 
 ```html
 <amp-autocomplete
-  filter="substring"
   id="myAutocomplete"
-  src="/static/samples/json/amp-autocomplete-cities.json"
+  src="{{server_for_email}}/static/samples/json/amp-autocomplete-cities.json"
 >
   <input />
+  <template type="amp-mustache">
+    <div data-value="{{.}}">{{.}}</div>
+  </template>
 </amp-autocomplete>
 ```
 
 [/filter] <!-- formats="email" -->
+
+When using the `src` attribute with `amp-autocomplete`, the response from the endpoint contains data to be rendered in the specified template.
+
+You can specify a template in one of two ways:
+
+- a `template` attribute that references an ID of an existing templating element.
+- a templating element nested directly inside the `amp-autocomplete` element.
+
+For more details on templates, see [AMP HTML Templates](../../spec/amp-html-templates.md).
+
+[tip type="note"]
+Note also that template contents will place multiple top-level elements into an outer wrapping `<div>`. This means the following input:
+
+```html
+<template type="amp-mustache">
+  {% raw %}
+  <div class="item">{{item}}</div>
+  <div class="price">{{price}}</div>
+  {% endraw %}
+</template>
+```
+
+Will effectively be treated as the following:
+
+```html
+<template type="amp-mustache">
+  {% raw %}
+  <div>
+    <div class="item">{{item}}</div>
+    <div class="price">{{price}}</div>
+  </div>
+  {% endraw %}
+</template>
+```
+
+A best practice is to ensure the provided template contains a singular top-level element so that [`data-value` and `data-disabled`](https://amp.dev/documentation/examples/components/amp-autocomplete/#suggesting-rich-content) attributes can be provided accordingly on the delimiting element.
+
+[/tip]
 
 ## Attributes
 

--- a/extensions/amp-list/amp-list.md
+++ b/extensions/amp-list/amp-list.md
@@ -113,7 +113,7 @@ If `<amp-list>` needs more space after loading, it requests the AMP runtime to u
 By default, `<amp-list>` adds a `list` ARIA role to the list element and a `listitem` role to item elements rendered via the template. If the list element or any of its children are not "tabbable" (accessible by keyboard keys such as the `a` and `button` elements or any elements with a positive `tabindex`), a `tabindex` of `0` will be added by default to the list item.
 
 [tip type="note"]
-Note also that template contents will place multiple top-level elements into an outer wrapping `<div>`. This means the following input:
+Note also that a good practice is to provide templates a single top-level element to prevent unintended side effects. Some possible consequences of providing multiple top-level elements: each top-level element could be treated as a distinct item in a list, or all same-level elements could be wrapped by an additional <div> layer, potentially breaking structure-based CSS rules. This means the following input:
 
 ```html
 <template type="amp-mustache">
@@ -124,7 +124,7 @@ Note also that template contents will place multiple top-level elements into an 
 </template>
 ```
 
-Will effectively be treated as the following:
+Might be effectively treated as is OR as following, depending on the template renderer being employed:
 
 ```html
 <template type="amp-mustache">
@@ -136,6 +136,8 @@ Will effectively be treated as the following:
   {% endraw %}
 </template>
 ```
+
+A best practice is to ensure the provided template contains a singular top-level element to avoid unpredictable behavior.
 
 [/tip]
 

--- a/extensions/amp-list/amp-list.md
+++ b/extensions/amp-list/amp-list.md
@@ -113,7 +113,7 @@ If `<amp-list>` needs more space after loading, it requests the AMP runtime to u
 By default, `<amp-list>` adds a `list` ARIA role to the list element and a `listitem` role to item elements rendered via the template. If the list element or any of its children are not "tabbable" (accessible by keyboard keys such as the `a` and `button` elements or any elements with a positive `tabindex`), a `tabindex` of `0` will be added by default to the list item.
 
 [tip type="note"]
-Note also that a good practice is to provide templates a single top-level element to prevent unintended side effects. Some possible consequences of providing multiple top-level elements: each top-level element could be treated as a distinct item in a list, or all same-level elements could be wrapped by an additional <div> layer, potentially breaking structure-based CSS rules. This means the following input:
+Note also that a good practice is to provide templates a single top-level element to prevent unintended side effects. This means the following input:
 
 ```html
 <template type="amp-mustache">
@@ -124,7 +124,7 @@ Note also that a good practice is to provide templates a single top-level elemen
 </template>
 ```
 
-Might be effectively treated as is OR as following, depending on the template renderer being employed:
+Would most predictably be applied and rendered if instead provided as follows:
 
 ```html
 <template type="amp-mustache">
@@ -136,8 +136,6 @@ Might be effectively treated as is OR as following, depending on the template re
   {% endraw %}
 </template>
 ```
-
-A best practice is to ensure the provided template contains a singular top-level element to avoid unpredictable behavior.
 
 [/tip]
 

--- a/extensions/amp-list/amp-list.md
+++ b/extensions/amp-list/amp-list.md
@@ -112,6 +112,33 @@ If `<amp-list>` needs more space after loading, it requests the AMP runtime to u
 
 By default, `<amp-list>` adds a `list` ARIA role to the list element and a `listitem` role to item elements rendered via the template. If the list element or any of its children are not "tabbable" (accessible by keyboard keys such as the `a` and `button` elements or any elements with a positive `tabindex`), a `tabindex` of `0` will be added by default to the list item.
 
+[tip type="note"]
+Note also that template contents will place multiple top-level elements into an outer wrapping `<div>`. This means the following input:
+
+```html
+<template type="amp-mustache">
+  {% raw %}
+  <div class="item">{{item}}</div>
+  <div class="price">{{price}}</div>
+  {% endraw %}
+</template>
+```
+
+Will effectively be treated as the following:
+
+```html
+<template type="amp-mustache">
+  {% raw %}
+  <div>
+    <div class="item">{{item}}</div>
+    <div class="price">{{price}}</div>
+  </div>
+  {% endraw %}
+</template>
+```
+
+[/tip]
+
 ### XHR batching
 
 AMP batches XMLHttpRequests (XHRs) to JSON endpoints, that is, you can use a single JSON data request as a data source for multiple consumers (e.g., multiple `<amp-list>` elements) on an AMP page. For example, if your `<amp-list>` makes an XHR to an endpoint, while the XHR is in flight, all subsequent XHRs to the same endpoint won't trigger and will instead return the results from the first XHR.


### PR DESCRIPTION
amp-mustache will unwrap multiple top-level elements with an outer `div`. This PR updates `amp-autocomplete` and `amp-list` to note this.