### PR TITLE
✨Introduce new macro for experiment branches.

### DIFF
--- a/extensions/amp-analytics/0.1/default-config.js
+++ b/extensions/amp-analytics/0.1/default-config.js
@@ -46,6 +46,7 @@ const defaultConfig = jsonConfiguration({
     'documentReferrer': 'DOCUMENT_REFERRER',
     'domainLookupTime': 'DOMAIN_LOOKUP_TIME',
     'domInteractiveTime': 'DOM_INTERACTIVE_TIME',
+    'experimentBranches': 'EXPERIMENT_BRANCHES',
     'externalReferrer': 'EXTERNAL_REFERRER',
     'firstContentfulPaint': 'FIRST_CONTENTFUL_PAINT',
     'firstInputDelay': 'FIRST_INPUT_DELAY',

--- a/extensions/amp-analytics/0.1/test/test-variables.js
+++ b/extensions/amp-analytics/0.1/test/test-variables.js
@@ -23,6 +23,7 @@ import {
   variableServiceForDoc,
 } from '../variables';
 import {Services} from '../../../../src/services';
+import {forceExperimentBranch} from '../../../../src/experiments';
 import {
   installLinkerReaderService,
   linkerReaderServiceFor,
@@ -495,6 +496,16 @@ describes.fakeWin('amp-analytics.VariableService', {amp: true}, (env) => {
 
     it('should replace CUMULATIVE_LAYOUT_SHIFT', () => {
       return check('CUMULATIVE_LAYOUT_SHIFT', '1');
+    });
+
+    it('should expand EXPERIMENT_BRANCHES to comma separated list', () => {
+      forceExperimentBranch(env.win, 'exp1', '1234');
+      forceExperimentBranch(env.win, 'exp2', '5678');
+      return check('EXPERIMENT_BRANCHES', '1234%2C5678');
+    });
+
+    it('EXPERIMENT_BRANCHES should be empty string if no branches', () => {
+      return check('EXPERIMENT_BRANCHES', '');
     });
 
     describe('$MATCH', () => {

--- a/extensions/amp-analytics/0.1/test/test-variables.js
+++ b/extensions/amp-analytics/0.1/test/test-variables.js
@@ -508,6 +508,15 @@ describes.fakeWin('amp-analytics.VariableService', {amp: true}, (env) => {
       return check('EXPERIMENT_BRANCHES', '');
     });
 
+    it('should expand EXPERIMENT_BRANCHES(expName) to experiment value', () => {
+      forceExperimentBranch(env.win, 'exp1', '1234');
+      return check('EXPERIMENT_BRANCHES(exp1)', '1234');
+    });
+
+    it('EXPERIMENT_BRANCHES(expName) should be empty string if not set', () => {
+      return check('EXPERIMENT_BRANCHES(exp1)', '');
+    });
+
     describe('$MATCH', () => {
       it('handles default index', () => {
         return check('$MATCH(thisisatest, thisisatest)', 'thisisatest');

--- a/extensions/amp-analytics/0.1/test/test-variables.js
+++ b/extensions/amp-analytics/0.1/test/test-variables.js
@@ -498,10 +498,10 @@ describes.fakeWin('amp-analytics.VariableService', {amp: true}, (env) => {
       return check('CUMULATIVE_LAYOUT_SHIFT', '1');
     });
 
-    it('should expand EXPERIMENT_BRANCHES to comma separated list', () => {
+    it('should expand EXPERIMENT_BRANCHES to name:value comma separated list', () => {
       forceExperimentBranch(env.win, 'exp1', '1234');
       forceExperimentBranch(env.win, 'exp2', '5678');
-      return check('EXPERIMENT_BRANCHES', '1234%2C5678');
+      return check('EXPERIMENT_BRANCHES', 'exp1%3A1234%2Cexp2%3A5678');
     });
 
     it('EXPERIMENT_BRANCHES should be empty string if no branches', () => {

--- a/extensions/amp-analytics/0.1/variables.js
+++ b/extensions/amp-analytics/0.1/variables.js
@@ -21,7 +21,10 @@ import {base64UrlEncodeFromString} from '../../../src/utils/base64';
 import {cookieReader} from './cookie-reader';
 import {dev, devAssert, user, userAssert} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
-import {getActiveExperimentBranches} from '../../../src/experiments';
+import {
+  getActiveExperimentBranches,
+  getExperimentBranch,
+} from '../../../src/experiments';
 import {getConsentPolicyState} from '../../../src/consent';
 import {
   getServiceForDoc,
@@ -175,12 +178,17 @@ function matchMacro(string, matchPattern, opt_matchingGroupIndexStr) {
 }
 
 /**
- * Returns a comma separated list of active branch experiment values and their
- * names, or an empty string if none exist.
+ * If given an experiment name returns the branch id if a branch is selected.
+ * If no branch name given, it returns a comma separated list of active branch
+ * experiment ids and their names or an empty string if none exist.
  * @param {!Window} win
+ * @param {string=} opt_expName
  * @return {string}
  */
-function experimentBranchesMacro(win) {
+function experimentBranchesMacro(win, opt_expName) {
+  if (opt_expName) {
+    return getExperimentBranch(win, opt_expName) || '';
+  }
   const branches = getActiveExperimentBranches(win);
   return Object.keys(branches)
     .map((expName) => `${expName}:${branches[expName]}`)
@@ -251,8 +259,8 @@ export class VariableService {
       Math.round(Services.viewportForDoc(this.ampdoc_).getScrollLeft())
     );
 
-    this.register_('EXPERIMENT_BRANCHES', () =>
-      experimentBranchesMacro(this.ampdoc_.win)
+    this.register_('EXPERIMENT_BRANCHES', (opt_expName) =>
+      experimentBranchesMacro(this.ampdoc_.win, opt_expName)
     );
   }
 

--- a/extensions/amp-analytics/0.1/variables.js
+++ b/extensions/amp-analytics/0.1/variables.js
@@ -21,6 +21,7 @@ import {base64UrlEncodeFromString} from '../../../src/utils/base64';
 import {cookieReader} from './cookie-reader';
 import {dev, devAssert, user, userAssert} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
+import {getActiveExperimentBranches} from '../../../src/experiments';
 import {getConsentPolicyState} from '../../../src/consent';
 import {
   getServiceForDoc,
@@ -174,6 +175,17 @@ function matchMacro(string, matchPattern, opt_matchingGroupIndexStr) {
 }
 
 /**
+ * Returns a comma separated list of active experiment branches or null
+ * if none are active.
+ * @param {!Window} win
+ * @return {?string}
+ */
+function experimentBranchesMacro(win) {
+  const branches = getActiveExperimentBranches(win);
+  return branches ? Object.values(branches).join(',') : null;
+}
+
+/**
  * Provides support for processing of advanced variable syntax like nested
  * expansions macros etc.
  */
@@ -235,6 +247,10 @@ export class VariableService {
     // Returns a promise resolving to viewport.getScrollLeft.
     this.register_('SCROLL_LEFT', () =>
       Math.round(Services.viewportForDoc(this.ampdoc_).getScrollLeft())
+    );
+
+    this.register_('EXPERIMENT_BRANCHES', () =>
+      experimentBranchesMacro(this.ampdoc_.win)
     );
   }
 

--- a/extensions/amp-analytics/0.1/variables.js
+++ b/extensions/amp-analytics/0.1/variables.js
@@ -177,10 +177,12 @@ function matchMacro(string, matchPattern, opt_matchingGroupIndexStr) {
 /**
  * Returns a comma separated list of active experiment branches or null
  * if none are active.
- * @param {!Window} win
+ * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc
  * @return {?string}
  */
-function experimentBranchesMacro(win) {
+function experimentBranchesMacro(ampdoc) {
+  const parent = ampdoc.getParent();
+  const win = parent ? parent.win : ampdoc.win;
   const branches = getActiveExperimentBranches(win);
   return branches ? Object.values(branches).join(',') : null;
 }
@@ -250,7 +252,7 @@ export class VariableService {
     );
 
     this.register_('EXPERIMENT_BRANCHES', () =>
-      experimentBranchesMacro(this.ampdoc_.win)
+      experimentBranchesMacro(this.ampdoc_)
     );
   }
 

--- a/extensions/amp-analytics/0.1/variables.js
+++ b/extensions/amp-analytics/0.1/variables.js
@@ -175,8 +175,8 @@ function matchMacro(string, matchPattern, opt_matchingGroupIndexStr) {
 }
 
 /**
- * Returns a comma separated list of active experiment branches or null
- * if none are active.
+ * Returns a comma separated list of active branch experiment names and their
+ * values, or `null` if none are active.
  * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc
  * @return {?string}
  */
@@ -184,7 +184,12 @@ function experimentBranchesMacro(ampdoc) {
   const parent = ampdoc.getParent();
   const win = parent ? parent.win : ampdoc.win;
   const branches = getActiveExperimentBranches(win);
-  return branches ? Object.values(branches).join(',') : null;
+  if (!branches) {
+    return null;
+  }
+  return Object.keys(branches)
+    .map((expName) => `${expName}:${branches[expName]}`)
+    .join(',');
 }
 
 /**

--- a/extensions/amp-analytics/0.1/variables.js
+++ b/extensions/amp-analytics/0.1/variables.js
@@ -175,18 +175,13 @@ function matchMacro(string, matchPattern, opt_matchingGroupIndexStr) {
 }
 
 /**
- * Returns a comma separated list of active branch experiment names and their
- * values, or `null` if none are active.
- * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc
- * @return {?string}
+ * Returns a comma separated list of active branch experiment values and their
+ * names, or an empty string if none exist.
+ * @param {!Window} win
+ * @return {string}
  */
-function experimentBranchesMacro(ampdoc) {
-  const parent = ampdoc.getParent();
-  const win = parent ? parent.win : ampdoc.win;
+function experimentBranchesMacro(win) {
   const branches = getActiveExperimentBranches(win);
-  if (!branches) {
-    return null;
-  }
   return Object.keys(branches)
     .map((expName) => `${expName}:${branches[expName]}`)
     .join(',');
@@ -257,7 +252,7 @@ export class VariableService {
     );
 
     this.register_('EXPERIMENT_BRANCHES', () =>
-      experimentBranchesMacro(this.ampdoc_)
+      experimentBranchesMacro(this.ampdoc_.win)
     );
   }
 

--- a/src/experiments.js
+++ b/src/experiments.js
@@ -377,7 +377,7 @@ export function getActiveExperimentBranches(win) {
   if (!topWin.__AMP_EXPERIMENT_BRANCHES) {
     topWin.__AMP_EXPERIMENT_BRANCHES = {};
   }
-  return topWin.__AMP_EXPERIMENT_BRANCHES;
+  return {...topWin.__AMP_EXPERIMENT_BRANCHES};
 }
 
 /**

--- a/src/experiments.js
+++ b/src/experiments.js
@@ -365,6 +365,16 @@ export function getExperimentBranch(win, experimentName) {
 }
 
 /**
+ * Returns an object containing all active experiment branches.
+ *
+ * @param {!Window} win Window context to check for experiment state.
+ * @return {?Object} contains all experiment branches and their ids.
+ */
+export function getActiveExperimentBranches(win) {
+  return win.__AMP_EXPERIMENT_BRANCHES ? win.__AMP_EXPERIMENT_BRANCHES : null;
+}
+
+/**
  * Force enable (or disable) a specific branch of a given experiment name.
  * Disables the experiment name altogether if branchId is falseish.
  *

--- a/src/experiments.js
+++ b/src/experiments.js
@@ -23,6 +23,7 @@
 
 import {dev, user} from './log';
 import {getMode} from './mode';
+import {getTopWindow} from './service';
 import {hasOwn} from './utils/object';
 import {parseQueryString} from './url';
 
@@ -365,13 +366,18 @@ export function getExperimentBranch(win, experimentName) {
 }
 
 /**
- * Returns an object containing all active experiment branches.
+ * Returns an object containing all active experiment branches on the
+ * top Window.
  *
  * @param {!Window} win Window context to check for experiment state.
- * @return {?Object} contains all experiment branches and their ids.
+ * @return {!Object} contains all experiment branches and their ids.
  */
 export function getActiveExperimentBranches(win) {
-  return win.__AMP_EXPERIMENT_BRANCHES ? win.__AMP_EXPERIMENT_BRANCHES : null;
+  const topWin = getTopWindow(win);
+  if (!topWin.__AMP_EXPERIMENT_BRANCHES) {
+    topWin.__AMP_EXPERIMENT_BRANCHES = {};
+  }
+  return topWin.__AMP_EXPERIMENT_BRANCHES;
 }
 
 /**

--- a/test/unit/test-experiments.js
+++ b/test/unit/test-experiments.js
@@ -17,6 +17,8 @@
 import {
   RANDOM_NUMBER_GENERATORS,
   experimentToggles,
+  forceExperimentBranch,
+  getActiveExperimentBranches,
   getBinaryType,
   getExperimentBranch,
   getExperimentTogglesForTesting,
@@ -913,6 +915,21 @@ describe('experiment branch tests', () => {
         'expt_0': '0_3',
         'expt_2': '2_1',
       });
+    });
+  });
+});
+
+describes.fakeWin('getActiveExperimentBranches', {}, (env) => {
+  it('should return null if no active branches', () => {
+    expect(getActiveExperimentBranches(env.win)).to.be.null;
+  });
+
+  it('should return obj containing all branches', () => {
+    forceExperimentBranch(env.win, 'exp1', '1234');
+    forceExperimentBranch(env.win, 'exp2', '5678');
+    expect(getActiveExperimentBranches(env.win)).to.eql({
+      exp1: '1234',
+      exp2: '5678',
     });
   });
 });

--- a/test/unit/test-experiments.js
+++ b/test/unit/test-experiments.js
@@ -920,8 +920,8 @@ describe('experiment branch tests', () => {
 });
 
 describes.fakeWin('getActiveExperimentBranches', {}, (env) => {
-  it('should return null if no active branches', () => {
-    expect(getActiveExperimentBranches(env.win)).to.be.null;
+  it('should return an empty object if no active branches', () => {
+    expect(getActiveExperimentBranches(env.win)).to.eql({});
   });
 
   it('should return obj containing all branches', () => {


### PR DESCRIPTION
`EXPERIMENT_BRANCHES` || `${experimentBranches}`. Can be used to slice analytics reports by control/experiment.