### PR TITLE
Include Slack channel in Support page

### DIFF
--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -14,7 +14,6 @@ If you are looking for help to get started using AMP on your site or you are hav
 - [AMP tools](https://amp.dev/documentation/tools) helping you get started with building AMP pages.
 - [AMP supported browsers](https://amp.dev/support/faq/supported-browsers) to learn which browsers support AMP.
 - [Stack Overflow](http://stackoverflow.com/questions/tagged/amp-html) is our recommended way to find answers to questions about AMP. Since members of the AMP Project community regularly monitor Stack Overflow, you will probably receive the fastest response to your questions there.
-- [The AMP Slack channel](https://amphtml.slack.com) for discussions with other developers and the AMP team. [Click here](https://bit.ly/amp-slack-signup) to sign up.
 - For AMP on Google Search questions or issues, please use [Google's AMP forum](https://goo.gl/utQ1KZ).
 - To check the status of AMP serving and its related services, see the [AMP Status](https://status.ampproject.org/) page.
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -13,7 +13,8 @@ If you are looking for help to get started using AMP on your site or you are hav
 - [Pre-styled templates and components](https://amp.dev/documentation/templates/) that you can use to create styled AMP sites from scratch.
 - [AMP tools](https://amp.dev/documentation/tools) helping you get started with building AMP pages.
 - [AMP supported browsers](https://amp.dev/support/faq/supported-browsers) to learn which browsers support AMP.
-- [Stack Overflow](http://stackoverflow.com/questions/tagged/amp-html) is our recommended way to find answers to questions about AMP; since members of the AMP Project community regularly monitor Stack Overflow you will probably receive the fastest response to your questions there.
+- [Stack Overflow](http://stackoverflow.com/questions/tagged/amp-html) is our recommended way to find answers to questions about AMP. Since members of the AMP Project community regularly monitor Stack Overflow, you will probably receive the fastest response to your questions there.
+- [The AMP Slack channel](https://amphtml.slack.com) for discussions with other developers and the AMP team. [Click here](https://bit.ly/amp-slack-signup) to sign up.
 - For AMP on Google Search questions or issues, please use [Google's AMP forum](https://goo.gl/utQ1KZ).
 - To check the status of AMP serving and its related services, see the [AMP Status](https://status.ampproject.org/) page.
 


### PR DESCRIPTION
📖  I figured we should include the Slack channel on [our Support page](https://amp.dev/support)!

If you think we shouldn't, please comment here....