### PR TITLE
intersect-resources: Force immediate first measure for ads

### DIFF
--- a/test/unit/test-resources.js
+++ b/test/unit/test-resources.js
@@ -1569,7 +1569,7 @@ describes.fakeWin('Resources.add/upgrade/remove', {amp: true}, (env) => {
 
     resources.add(child1);
 
-    expect(resource1.requestMeasure).to.not.be.called;
+    expect(resource1.requestMeasure).to.be.calledOnce;
     expect(observer.observe).to.be.calledOnceWith(child1);
   });
 


### PR DESCRIPTION
Partial for #25428. 

Reduce time-to-first-measure for ads (only) by manually measuring instead of waiting for the client rect from the `IntersectionObserver` callback.

Also allow measure requests from owned elements (probably an oversight).