### PR TITLE
Ramp AdSense/Doubleclick correct position param experiment

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -36,5 +36,5 @@
   "version-locking": 1,
   "amp-ad-no-center-css": 0,
   "analytics-chunks": 1,
-  "ad-adsense-gam-round-params": 0.02
+  "ad-adsense-gam-round-params": 0.2
 }

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -37,5 +37,5 @@
   "analytics-chunks": 1,
   "sticky-ad-padding-bottom": 0.05,
   "render-on-idle-fix": 0.02,
-  "ad-adsense-gam-round-params": 0.02
+  "ad-adsense-gam-round-params": 0.2
 }


### PR DESCRIPTION
Ramp experiment to 10% that corrects amp-ad type AdSense/Doubleclick position parameters to be valid integers, See #29248

🐛 Bug fix

