### PR TITLE
✨ amp-story & player: change story embed mode through messaging

### DIFF
--- a/extensions/amp-story/1.0/amp-story-store-service.js
+++ b/extensions/amp-story/1.0/amp-story-store-service.js
@@ -469,6 +469,48 @@ const actions = (state, action, data) => {
   }
 };
 
+// @TODO(gmajoulet): These should get their own file if they start growing.
+/**
+ * Provides the state configuration for a given embed mode
+ * @param {?EmbedMode} embedMode
+ * @return {!Object<StateProperty, *>} Partial state
+ */
+const getEmbedOverrides = (embedMode) => {
+  switch (embedMode) {
+    case EmbedMode.NAME_TBD:
+      return {
+        [StateProperty.CAN_INSERT_AUTOMATIC_AD]: false,
+        [StateProperty.CAN_SHOW_BOOKEND]: false,
+        [StateProperty.CAN_SHOW_NAVIGATION_OVERLAY_HINT]: false,
+        [StateProperty.CAN_SHOW_PAGINATION_BUTTONS]: false,
+        [StateProperty.CAN_SHOW_PREVIOUS_PAGE_HELP]: true,
+        [StateProperty.CAN_SHOW_SYSTEM_LAYER_BUTTONS]: false,
+        [StateProperty.MUTED_STATE]: false,
+      };
+    case EmbedMode.NO_SHARING:
+      return {
+        [StateProperty.CAN_SHOW_SHARING_UIS]: false,
+      };
+    case EmbedMode.PREVIEW:
+      return {
+        [StateProperty.PREVIEW_STATE]: true,
+        [StateProperty.CAN_INSERT_AUTOMATIC_AD]: false,
+        [StateProperty.CAN_SHOW_BOOKEND]: false,
+        [StateProperty.CAN_SHOW_NAVIGATION_OVERLAY_HINT]: false,
+        [StateProperty.CAN_SHOW_PAGINATION_BUTTONS]: false,
+        [StateProperty.CAN_SHOW_PREVIOUS_PAGE_HELP]: false,
+        [StateProperty.CAN_SHOW_SYSTEM_LAYER_BUTTONS]: false,
+      };
+    case EmbedMode.NO_SHARING_NOR_AUDIO_UI:
+      return {
+        [StateProperty.CAN_SHOW_AUDIO_UI]: false,
+        [StateProperty.CAN_SHOW_SHARING_UIS]: false,
+      };
+    default:
+      return {};
+  }
+};
+
 /**
  * Store service.
  */
@@ -486,7 +528,7 @@ export class AmpStoryStoreService {
     /** @private {!State} */
     this.state_ = /** @type {!State} */ ({
       ...this.getDefaultState_(),
-      ...this.getEmbedOverrides_(),
+      ...this.getDefaultEmbedOverrides_(),
     });
   }
 
@@ -607,46 +649,14 @@ export class AmpStoryStoreService {
     });
   }
 
-  // @TODO(gmajoulet): These should get their own file if they start growing.
   /**
-   * Retrieves the embed mode config, that will override the default state.
+   * Retrieves the embed mode config based on the fragment provided in the story URL,
+   * which will override the default state.
    * @return {!Object<StateProperty, *>} Partial state
    * @protected
    */
-  getEmbedOverrides_() {
+  getDefaultEmbedOverrides_() {
     const embedMode = parseEmbedMode(this.win_.location.hash);
-    switch (embedMode) {
-      case EmbedMode.NAME_TBD:
-        return {
-          [StateProperty.CAN_INSERT_AUTOMATIC_AD]: false,
-          [StateProperty.CAN_SHOW_BOOKEND]: false,
-          [StateProperty.CAN_SHOW_NAVIGATION_OVERLAY_HINT]: false,
-          [StateProperty.CAN_SHOW_PAGINATION_BUTTONS]: false,
-          [StateProperty.CAN_SHOW_PREVIOUS_PAGE_HELP]: true,
-          [StateProperty.CAN_SHOW_SYSTEM_LAYER_BUTTONS]: false,
-          [StateProperty.MUTED_STATE]: false,
-        };
-      case EmbedMode.NO_SHARING:
-        return {
-          [StateProperty.CAN_SHOW_SHARING_UIS]: false,
-        };
-      case EmbedMode.PREVIEW:
-        return {
-          [StateProperty.PREVIEW_STATE]: true,
-          [StateProperty.CAN_INSERT_AUTOMATIC_AD]: false,
-          [StateProperty.CAN_SHOW_BOOKEND]: false,
-          [StateProperty.CAN_SHOW_NAVIGATION_OVERLAY_HINT]: false,
-          [StateProperty.CAN_SHOW_PAGINATION_BUTTONS]: false,
-          [StateProperty.CAN_SHOW_PREVIOUS_PAGE_HELP]: false,
-          [StateProperty.CAN_SHOW_SYSTEM_LAYER_BUTTONS]: false,
-        };
-      case EmbedMode.NO_SHARING_NOR_AUDIO_UI:
-        return {
-          [StateProperty.CAN_SHOW_AUDIO_UI]: false,
-          [StateProperty.CAN_SHOW_SHARING_UIS]: false,
-        };
-      default:
-        return {};
-    }
+    return getEmbedOverrides(embedMode);
   }
 }

--- a/extensions/amp-story/1.0/amp-story-store-service.js
+++ b/extensions/amp-story/1.0/amp-story-store-service.js
@@ -215,6 +215,7 @@ export const Action = {
   TOGGLE_VIEWPORT_WARNING: 'toggleViewportWarning',
   ADD_NEW_PAGE_ID: 'addNewPageId',
   SET_PAGE_SIZE: 'updatePageSize',
+  SET_EMBED_MODE: 'updateEmbedMode',
 };
 
 /**
@@ -463,6 +464,11 @@ const actions = (state, action, data) => {
         ...state,
         [StateProperty.PAGE_SIZE]: data,
       });
+    case Action.SET_EMBED_MODE:
+      return {
+        ...state,
+        ...getEmbedOverrides(data),
+      };
     default:
       dev().error(TAG, 'Unknown action %s.', action);
       return state;

--- a/extensions/amp-story/1.0/amp-story-viewer-messaging-handler.js
+++ b/extensions/amp-story/1.0/amp-story-viewer-messaging-handler.js
@@ -20,6 +20,7 @@ import {
   getStoreService,
 } from './amp-story-store-service';
 import {AnalyticsVariable, getVariableService} from './variable-service';
+import {EmbedMode} from './embed-mode';
 import {dev, user} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
 
@@ -72,6 +73,10 @@ const SET_STATE_CONFIGURATIONS = {
   'MUTED_STATE': {
     action: Action.TOGGLE_MUTED,
     isValueValid: (value) => typeof value === 'boolean',
+  },
+  'EMBED_MODE': {
+    action: Action.SET_EMBED_MODE,
+    isValueValid: (value) => value in EmbedMode,
   },
 };
 

--- a/src/amp-story-player/amp-story-player-impl.js
+++ b/src/amp-story-player/amp-story-player-impl.js
@@ -876,6 +876,22 @@ export class AmpStoryPlayer {
   }
 
   /**
+   * Updates the embed mode of the story inside the iframe.
+   * @param {number} iframeIdx
+   * @param {!EmbedMode} embedMode
+   * @private
+   */
+  updateEmbedMode_(iframeIdx, embedMode) {
+    this.messagingPromises_[iframeIdx].then((messaging) => {
+      messaging.sendRequest(
+        'setDocumentState',
+        {state: 'EMBED_MODE', value: embedMode},
+        true
+      );
+    });
+  }
+
+  /**
    * Updates the muted state of the story inside the iframe.
    * @param {number} iframeIdx
    * @param {boolean} mutedValue


### PR DESCRIPTION
This adds an action to apply embed-mode settings to an amp-story, which could be triggered through messaging for manipulation through the player.

Currently, these changes prepare the messaging service for this feature, although the resulting changes to the state are incorrect. This is because the embed-mode overrides only overwrite the settings relevant to themselves, leaving traces of previous embed-mode settings behind, and not changing them back to their original value.

\\ CC: @newmuis @Enriqe @bettyashley @connielei @gmajoulet 