### PR TITLE
🐛 amp-live-list: Respect `disabled` when on visible

### DIFF
--- a/extensions/amp-live-list/0.1/live-list-manager.js
+++ b/extensions/amp-live-list/0.1/live-list-manager.js
@@ -299,7 +299,7 @@ export class LiveListManager {
   setupVisibilityHandler_() {
     // Polling should always be stopped when document is no longer visible.
     this.ampdoc.onVisibilityChanged(() => {
-      if (this.ampdoc.isVisible()) {
+      if (this.ampdoc.isVisible() && this.hasActiveLiveLists_()) {
         // We use immediate so that the user starts getting updates
         // right away when they've switched back to the page.
         this.poller_.start(/** immediate */ true);


### PR DESCRIPTION
`amp-live-list` should only restart the poller when the document becomes visible _**if**_ the component is enabled.
Fixes #29488