### PR TITLE
Supress false warnings

### DIFF
--- a/extensions/amp-story/1.0/utils.js
+++ b/extensions/amp-story/1.0/utils.js
@@ -42,7 +42,6 @@ export function timeStrToMillis(time, fallbackMs = NaN) {
   const units = match ? match[2] : undefined;
 
   if (!match || match.length !== 3 || (units !== 's' && units !== 'ms')) {
-    user().warn('AMP-STORY', 'Invalid time string', time);
     return fallbackMs;
   }
 


### PR DESCRIPTION
For each media-based advancement, there is a warning log: `[AMP-STORY] Invalid time string audio1`. This is probably very confusing for developers.

The root of the problem is we check first if the advancement is time-based, and then if it's media-based. So we are always checking for a valid time-based format, even though it's not what the intention is.
