### PR TITLE
calcTaskTimeout: turn off experiment now that experimental data was c…

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -30,7 +30,7 @@
   "ios-fixed-no-transfer": 1,
   "layoutbox-invalidate-on-scroll": 1,
   "pump-early-frame": 1,
-  "remove-task-timeout": 1,
+  "remove-task-timeout": 0,
   "swg-gpay-api": 1,
   "swg-gpay-native": 1,
   "version-locking": 1,


### PR DESCRIPTION
turning down to remove potential testing conflicts with other canary experiments. have enough data to evaluate csi now.