### PR TITLE
Make any amphtml-reviewer an owner of md file changes

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -17,11 +17,7 @@
     },
     {
       pattern: '**/*.md',
-      owners: [
-        {name: 'mrjoro'},
-        {name: 'ampproject/wg-outreach'},
-        {name: 'ampproject/reviewers-amphtml'},
-      ],
+      owners: [{name: '*'},],
     },
     {
       pattern: '{.*,gulpfile.js}',

--- a/OWNERS
+++ b/OWNERS
@@ -17,7 +17,7 @@
     },
     {
       pattern: '**/*.md',
-      owners: [{name: '*'},],
+      owners: [{name: '*'}],
     },
     {
       pattern: '{.*,gulpfile.js}',

--- a/OWNERS
+++ b/OWNERS
@@ -17,7 +17,11 @@
     },
     {
       pattern: '**/*.md',
-      owners: [{name: 'mrjoro'}, {name: 'ampproject/wg-outreach'}],
+      owners: [
+        {name: 'mrjoro'},
+        {name: 'ampproject/wg-outreach'},
+        {name: 'ampproject/reviewers-amphtml'},
+      ],
     },
     {
       pattern: '{.*,gulpfile.js}',


### PR DESCRIPTION
This change (I think) makes it so that any member of reviewers-amphtml can be an OWNER for .md file changes.

(I'm currently often the bottleneck for PRs that involve a change to an .md file when I probably don't need to be. :))

@rcebulko, will this do what I expect?