### PR TITLE
🐛 Use deep copy of extraUrlParams for sending requests

### DIFF
--- a/extensions/amp-analytics/0.1/requests.js
+++ b/extensions/amp-analytics/0.1/requests.js
@@ -183,7 +183,9 @@ export class RequestHandler {
         });
     }
 
-    const params = {...configParams, ...trigger['extraUrlParams']};
+    const triggerCopy = JSON.parse(JSON.stringify(trigger['extraUrlParams']));
+    const configParamsCopy = JSON.parse(JSON.stringify(configParams));
+    const params = {...configParamsCopy, ...triggerCopy};
     const timestamp = this.win.Date.now();
     const batchSegmentPromise = expandExtraUrlParams(
       this.variableService_,

--- a/extensions/amp-analytics/0.1/requests.js
+++ b/extensions/amp-analytics/0.1/requests.js
@@ -183,9 +183,7 @@ export class RequestHandler {
         });
     }
 
-    const triggerCopy = JSON.parse(JSON.stringify(trigger['extraUrlParams']));
-    const configParamsCopy = JSON.parse(JSON.stringify(configParams));
-    const params = {...configParamsCopy, ...triggerCopy};
+    const params = {...configParams, ...trigger['extraUrlParams']};
     const timestamp = this.win.Date.now();
     const batchSegmentPromise = expandExtraUrlParams(
       this.variableService_,
@@ -470,6 +468,7 @@ function expandExtraUrlParams(
   element,
   opt_allowlist
 ) {
+  const newParams = {};
   const requestPromises = [];
   // Don't encode param values here,
   // as we'll do it later in the getExtraUrlParamsString call.
@@ -479,27 +478,41 @@ function expandExtraUrlParams(
     true /* noEncode */
   );
 
-  const expandObject = (params, key) => {
-    const value = params[key];
+  const expandObject = (data, key, expandedData) => {
+    const value = data[key];
 
     if (typeof value === 'string') {
+      expandedData[key] = undefined;
       const request = variableService
         .expandTemplate(value, option, element)
         .then((value) =>
           urlReplacements.expandStringAsync(value, bindings, opt_allowlist)
         )
-        .then((value) => (params[key] = value));
+        .then((value) => {
+          expandedData[key] = value;
+        });
       requestPromises.push(request);
     } else if (isArray(value)) {
-      /** @type {!Array} */ (value).forEach((_, index) =>
-        expandObject(value, index)
-      );
+      expandedData[key] = [];
+      for (let index = 0; index < value.length; index++) {
+        expandObject(value, index, expandedData[key]);
+      }
     } else if (isObject(value) && value !== null) {
-      Object.keys(value).forEach((key) => expandObject(value, key));
+      expandedData[key] = {};
+      const valueKeys = Object.keys(value);
+      for (let index = 0; index < valueKeys.length; index++) {
+        expandObject(value, valueKeys[index], expandedData[key]);
+      }
+    } else {
+      // Number, bool, null
+      expandedData[key] = value;
     }
   };
 
-  Object.keys(params).forEach((key) => expandObject(params, key));
+  const paramKeys = Object.keys(params);
+  for (let index = 0; index < paramKeys.length; index++) {
+    expandObject(params, paramKeys[index], newParams);
+  }
 
-  return Promise.all(requestPromises).then(() => params);
+  return Promise.all(requestPromises).then(() => newParams);
 }


### PR DESCRIPTION
closes #29580

`extraUrlParams` can be an object with variables that need to be expanded. 
```
"extraUrlParams": {
     "body": {
           "data": {
                "product": "${product}",
           }
      }
}
```

Currently, we send a shallow copy of `extraUrlParams` to `requests#expandExtraUrlParams()` which expands the variables and modifies `extraUrlParams`'s nested objects for subsequent requests, instead of expanding them per each request. 