### PR TITLE
🐛  amp-inputmask: query is too zealous

### DIFF
--- a/extensions/amp-inputmask/0.1/amp-inputmask.js
+++ b/extensions/amp-inputmask/0.1/amp-inputmask.js
@@ -44,7 +44,9 @@ export class AmpInputmaskService {
    * Install the inputmask service and controllers.
    */
   install() {
-    const maskElements = this.ampdoc.getRootNode().querySelectorAll('input[mask]');
+    const maskElements = this.ampdoc
+      .getRootNode()
+      .querySelectorAll('input[mask]');
     iterateCursor(maskElements, (element) => {
       if (TextMask.isMasked(element)) {
         return;

--- a/extensions/amp-inputmask/0.1/amp-inputmask.js
+++ b/extensions/amp-inputmask/0.1/amp-inputmask.js
@@ -44,7 +44,7 @@ export class AmpInputmaskService {
    * Install the inputmask service and controllers.
    */
   install() {
-    const maskElements = this.ampdoc.getRootNode().querySelectorAll('[mask]');
+    const maskElements = this.ampdoc.getRootNode().querySelectorAll('input[mask]');
     iterateCursor(maskElements, (element) => {
       if (TextMask.isMasked(element)) {
         return;

--- a/extensions/amp-inputmask/0.1/inputmask-custom-alias.js
+++ b/extensions/amp-inputmask/0.1/inputmask-custom-alias.js
@@ -54,10 +54,6 @@ export function getAliasDefinition() {
        * @return {string}
        */
       'onBeforeMask': function (value, opts) {
-        if (value === undefined) {
-          return '';
-        }
-
         const prefixes = opts['prefixes'];
         const trimZeros = opts['trimZeros'] || 0;
 

--- a/extensions/amp-inputmask/0.1/inputmask-custom-alias.js
+++ b/extensions/amp-inputmask/0.1/inputmask-custom-alias.js
@@ -54,6 +54,10 @@ export function getAliasDefinition() {
        * @return {string}
        */
       'onBeforeMask': function (value, opts) {
+        if (value === undefined) {
+          return '';
+        }
+
         const prefixes = opts['prefixes'];
         const trimZeros = opts['trimZeros'] || 0;
 


### PR DESCRIPTION
Fixes https://github.com/ampproject/amphtml/issues/29100, https://github.com/ampproject/amphtml/issues/28062. The issue is due to trying to mask elements that may have the `mask` attribute but aren't `<input>`s.

From checking example documents with this error, it often occurs in SVGs

**for the reviewer**: are there any situation in which the input mask can be called on a non `<input>` element? If so then we'll need a different fix.