### PR TITLE
🐛 No Signing: add missing elements to secure frame.

### DIFF
--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -1668,6 +1668,7 @@ export class AmpA4A extends AMP.BaseElement {
     const {extensions, fonts, head} = headData;
     this.iframe = createSecureFrame(
       this.element.ownerDocument,
+      devAssert(this.adUrl_),
       head,
       this.getIframeTitle(),
       height,

--- a/extensions/amp-a4a/0.1/head-validation.js
+++ b/extensions/amp-a4a/0.1/head-validation.js
@@ -202,7 +202,11 @@ function handleLink(fonts, images, link) {
  * @param {!Element} style
  */
 function handleStyle(style) {
-  if (style.hasAttribute('amp-custom') || style.hasAttribute('amp-keyframes')) {
+  if (
+    style.hasAttribute('amp-custom') ||
+    style.hasAttribute('amp-keyframes') ||
+    style.hasAttribute('amp4ads-boilerplate')
+  ) {
     return;
   }
   removeElement(style);

--- a/extensions/amp-a4a/0.1/secure-frame.js
+++ b/extensions/amp-a4a/0.1/secure-frame.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {createElementWithAttributes} from '../../../src/dom';
+import {createElementWithAttributes, escapeHtml} from '../../../src/dom';
 import {dict} from '../../../src/utils/object';
 import {isSrcdocSupported} from '../../../src/friendly-iframe-embed';
 
@@ -39,10 +39,11 @@ const sandboxVals = [
   'allow-top-navigation',
 ];
 
-const createSecureDocSkeleton = (sanitizedHeadElements) =>
+const createSecureDocSkeleton = (url, sanitizedHeadElements) =>
   `<!DOCTYPE html>
   <html ⚡4ads lang="en">
   <head>
+    <base href="${escapeHtml(url)}">
     <meta charset="UTF-8">
     <meta http-equiv=Content-Security-Policy content="
       img-src *;
@@ -63,14 +64,14 @@ const createSecureDocSkeleton = (sanitizedHeadElements) =>
 /**
  * Create iframe with predefined CSP and sandbox attributes for security.
  * @param {!Document} document
+ * @param {string} url
  * @param {!Element} head
  * @param {string} title
  * @param {string} height
  * @param {string} width
  * @return {!HTMLIFrameElement}
- *
  */
-export function createSecureFrame(document, head, title, height, width) {
+export function createSecureFrame(document, url, head, title, height, width) {
   const iframe = /** @type {HTMLIFrameElement} */ (createElementWithAttributes(
     document,
     'iframe',
@@ -88,7 +89,7 @@ export function createSecureFrame(document, head, title, height, width) {
     })
   ));
 
-  const secureDoc = createSecureDocSkeleton(head./*OK*/ innerHTML);
+  const secureDoc = createSecureDocSkeleton(url, head./*OK*/ innerHTML);
   // TODO(ccordry): add violation reporting here or in fie.
   if (isSrcdocSupported()) {
     iframe.srcdoc = secureDoc;

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -137,6 +137,16 @@ describes.realWin('no signing', {amp: true}, (env) => {
     );
   });
 
+  it('FIE should contain <base> with adurl', async () => {
+    await a4a.buildCallback();
+    a4a.onLayoutMeasure();
+    await a4a.layoutCallback();
+    const fie = doc.body.querySelector('iframe[srcdoc]');
+    const base = fie.contentDocument.querySelector('base');
+    expect(base).to.be.ok;
+    expect(base.href).to.equal('https://adnetwork.com/');
+  });
+
   it('should complete the rendering FIE', async () => {
     const prioritySpy = env.sandbox.spy(a4a, 'updateLayoutPriority');
     await a4a.buildCallback();

--- a/extensions/amp-a4a/0.1/test/test-head-validation.js
+++ b/extensions/amp-a4a/0.1/test/test-head-validation.js
@@ -172,9 +172,10 @@ describes.realWin('head validation', {amp: true}, (env) => {
       head.innerHTML = `
         <style amp-custom></style>
         <style amp-keyframes></style>
+        <style amp4ads-boilerplate></style>
       `;
       const validated = processHead(env.win, adElement, head);
-      expect(validated.head.querySelectorAll('style')).to.have.length(2);
+      expect(validated.head.querySelectorAll('style')).to.have.length(3);
     });
 
     it('removes other styles', () => {


### PR DESCRIPTION
FIE installs a `<base>` element that I overlooked. Also copy over amp4ads boilerplate style.

#27189