### PR TITLE
✨ [bento][amp-social-share] Do not throw error when no params are provided for email type

### DIFF
--- a/extensions/amp-social-share/1.0/social-share.js
+++ b/extensions/amp-social-share/1.0/social-share.js
@@ -152,7 +152,7 @@ function checkProps(props) {
 
   // Special case when type is 'email'
   if (type === 'email' && !endpoint) {
-    baseEndpoint = `mailto:${params['recipient'] || ''}`;
+    baseEndpoint = `mailto:${(params && params['recipient']) || ''}`;
   }
 
   // Add params to baseEndpoint


### PR DESCRIPTION
Social Share Tracking Issue: https://github.com/ampproject/amphtml/issues/28283

Currently throws an error if params are not defined when type is `email`.  Check if params exist first so no error is thrown.  (If params do not exist, return empty string in the line of code that is changed)