### PR TITLE
🚀 springAds: removing revised and no longer used prefetch

### DIFF
--- a/ads/_config.js
+++ b/ads/_config.js
@@ -1058,7 +1058,6 @@ const adConfig = jsonConfiguration({
   },
 
   'springAds': {
-    prefetch: 'https://www.asadcdn.com/adlib/adlib_seq.js',
     preconnect: ['https://ib.adnxs.com'],
     renderStartImplemented: true,
   },


### PR DESCRIPTION
codeBase upgrade removed adlib_seq from repository so prefetching it is no longer useful