### PR TITLE
Remove unnecessary requires_usage and deprecated_allow_duplicates 

### DIFF
--- a/extensions/amp-accordion/validator-amp-accordion.protoascii
+++ b/extensions/amp-accordion/validator-amp-accordion.protoascii
@@ -35,8 +35,6 @@ tags: {  # amp-accordion
     name: "amp-accordion"
     # AMP4EMAIL doesn't allow version: "latest".
     version: "0.1"
-    requires_usage: EXEMPTED
-    deprecated_allow_duplicates: true
   }
   attr_lists: "common-extension-attrs"
 }

--- a/extensions/amp-fit-text/validator-amp-fit-text.protoascii
+++ b/extensions/amp-fit-text/validator-amp-fit-text.protoascii
@@ -36,8 +36,6 @@ tags: {  # amp-fit-text (AMP4EMAIL)
     name: "amp-fit-text"
     # AMP4EMAIL doesn't allow version: "latest".
     version: "0.1"
-    requires_usage: EXEMPTED
-    deprecated_allow_duplicates: true
   }
   attr_lists: "common-extension-attrs"
 }

--- a/extensions/amp-form/validator-amp-form.protoascii
+++ b/extensions/amp-form/validator-amp-form.protoascii
@@ -37,8 +37,6 @@ tags: {  # amp-form
     name: "amp-form"
     # AMP4EMAIL doesn't allow version: "latest".
     version: "0.1"
-    deprecated_allow_duplicates: true
-    requires_usage: EXEMPTED
   }
   attr_lists: "common-extension-attrs"
 }

--- a/validator/testdata/amp4email_feature_tests/no_latest_extensions.out
+++ b/validator/testdata/amp4email_feature_tests/no_latest_extensions.out
@@ -63,9 +63,15 @@ amp4email_feature_tests/no_latest_extensions.html:36:2 The attribute 'src' in ta
 |  </body>
 |  </html>
 >>       ^~~~~~~~~
+amp4email_feature_tests/no_latest_extensions.html:41:6 The extension 'amp-accordion' was found on this page, but is unused. Please remove this extension.
+>>       ^~~~~~~~~
 amp4email_feature_tests/no_latest_extensions.html:41:6 The extension 'amp-anim' was found on this page, but is unused. Please remove this extension.
 >>       ^~~~~~~~~
 amp4email_feature_tests/no_latest_extensions.html:41:6 The extension 'amp-carousel' was found on this page, but is unused. Please remove this extension.
+>>       ^~~~~~~~~
+amp4email_feature_tests/no_latest_extensions.html:41:6 The extension 'amp-fit-text' was found on this page, but is unused. Please remove this extension.
+>>       ^~~~~~~~~
+amp4email_feature_tests/no_latest_extensions.html:41:6 The extension 'amp-form' was found on this page, but is unused. Please remove this extension.
 >>       ^~~~~~~~~
 amp4email_feature_tests/no_latest_extensions.html:41:6 The extension 'amp-list' was found on this page, but is unused. Please remove this extension.
 >>       ^~~~~~~~~


### PR DESCRIPTION
In #24854 the validation for the AMP Email format script tags was separated from other AMP formats. This allowed for the removing support of version: latest and explicitly required a numerical version.

As a result of this separation from other HTML formats, it is not necessary to include requires_usage: EXEMPT or deprecated_allow_duplicates: true as part of the AMP Email format. Those were included to support the AMP format.

Fix #25249
