### PR TITLE
♻️ Carousel: Use forwardRef

### DIFF
--- a/build-system/compile/sources.js
+++ b/build-system/compile/sources.js
@@ -60,6 +60,8 @@ const COMMON_GLOBS = [
   'node_modules/preact/dist/*.js',
   'node_modules/preact/hooks/package.json',
   'node_modules/preact/hooks/dist/*.js',
+  'node_modules/preact/compat/package.json',
+  'node_modules/preact/compat/dist/*.js',
 ];
 
 /**

--- a/extensions/amp-base-carousel/1.0/base-carousel.js
+++ b/extensions/amp-base-carousel/1.0/base-carousel.js
@@ -16,8 +16,8 @@
 import * as Preact from '../../../src/preact';
 import {ArrowNext, ArrowPrev} from './arrow';
 import {Scroller} from './scroller';
-import {createRef, toChildArray, useState} from '../../../src/preact';
 import {forwardRef} from '../../../src/preact/compat';
+import {toChildArray, useRef, useState} from '../../../src/preact';
 import {useMountEffect} from '../../../src/preact/utils';
 
 /**
@@ -36,7 +36,7 @@ export function BaseCarousel({
   const childrenArray = toChildArray(children);
   const {length} = childrenArray;
   const [curSlide, setCurSlide] = useState(0);
-  const scrollRef = createRef();
+  const scrollRef = useRef(null);
   const advance = (dir) => {
     const container = scrollRef.current;
     // Modify scrollLeft is preferred to `setCurSlide` to enable smooth scroll.

--- a/extensions/amp-base-carousel/1.0/base-carousel.js
+++ b/extensions/amp-base-carousel/1.0/base-carousel.js
@@ -16,7 +16,6 @@
 import * as Preact from '../../../src/preact';
 import {ArrowNext, ArrowPrev} from './arrow';
 import {Scroller} from './scroller';
-import {forwardRef} from '../../../src/preact/compat';
 import {toChildArray, useRef, useState} from '../../../src/preact';
 import {useMountEffect} from '../../../src/preact/utils';
 
@@ -59,14 +58,14 @@ export function BaseCarousel({
     !loop && (curSlide + dir < 0 || curSlide + dir >= length);
   return (
     <div {...rest}>
-      <ScrollerWithRef
+      <Scroller
         loop={loop}
         restingIndex={curSlide}
         setRestingIndex={setRestingIndex}
         ref={scrollRef}
       >
         {childrenArray}
-      </ScrollerWithRef>
+      </Scroller>
       <ArrowPrev
         customArrow={arrowPrev}
         disabled={disableForDir(-1)}
@@ -80,8 +79,3 @@ export function BaseCarousel({
     </div>
   );
 }
-
-const ScrollerWithRef = forwardRef((props, ref) =>
-  Scroller(/** @type {BaseCarouselDef.ScrollerProps} */ ({ref, ...props}))
-);
-ScrollerWithRef.displayName = 'Scroller'; // Make findable for tests.

--- a/extensions/amp-base-carousel/1.0/base-carousel.js
+++ b/extensions/amp-base-carousel/1.0/base-carousel.js
@@ -16,7 +16,8 @@
 import * as Preact from '../../../src/preact';
 import {ArrowNext, ArrowPrev} from './arrow';
 import {Scroller} from './scroller';
-import {toChildArray, useRef, useState} from '../../../src/preact';
+import {createRef, toChildArray, useState} from '../../../src/preact';
+import {forwardRef} from '../../../src/preact/compat';
 import {useMountEffect} from '../../../src/preact/utils';
 
 /**
@@ -35,6 +36,7 @@ export function BaseCarousel({
   const childrenArray = toChildArray(children);
   const {length} = childrenArray;
   const [curSlide, setCurSlide] = useState(0);
+  const scrollRef = createRef();
   const advance = (dir) => {
     const container = scrollRef.current;
     // Modify scrollLeft is preferred to `setCurSlide` to enable smooth scroll.
@@ -53,19 +55,18 @@ export function BaseCarousel({
       onSlideChange(i);
     }
   };
-  const scrollRef = useRef(null);
   const disableForDir = (dir) =>
     !loop && (curSlide + dir < 0 || curSlide + dir >= length);
   return (
     <div {...rest}>
-      <Scroller
+      <ScrollerWithRef
         loop={loop}
         restingIndex={curSlide}
         setRestingIndex={setRestingIndex}
-        scrollRef={scrollRef}
+        ref={scrollRef}
       >
         {childrenArray}
-      </Scroller>
+      </ScrollerWithRef>
       <ArrowPrev
         customArrow={arrowPrev}
         disabled={disableForDir(-1)}
@@ -79,3 +80,8 @@ export function BaseCarousel({
     </div>
   );
 }
+
+const ScrollerWithRef = forwardRef((props, ref) =>
+  Scroller(/** @type {BaseCarouselDef.ScrollerProps} */ ({ref, ...props}))
+);
+ScrollerWithRef.displayName = 'Scroller'; // Make findable for tests.

--- a/extensions/amp-base-carousel/1.0/base-carousel.js
+++ b/extensions/amp-base-carousel/1.0/base-carousel.js
@@ -36,12 +36,7 @@ export function BaseCarousel({
   const {length} = childrenArray;
   const [curSlide, setCurSlide] = useState(0);
   const scrollRef = useRef(null);
-  const advance = (dir) => {
-    const container = scrollRef.current;
-    // Modify scrollLeft is preferred to `setCurSlide` to enable smooth scroll.
-    // Note: `setCurSlide` will still be called on debounce by scroll handler.
-    container./* OK */ scrollLeft += container./* OK */ offsetWidth * dir;
-  };
+  const advance = (by) => scrollRef.current.advance(by);
   useMountEffect(() => {
     if (setAdvance) {
       setAdvance(advance);

--- a/extensions/amp-base-carousel/1.0/scroller.js
+++ b/extensions/amp-base-carousel/1.0/scroller.js
@@ -35,13 +35,7 @@ const RESET_SCROLL_REFERENCE_POINT_WAIT_MS = 200;
  * @param {!BaseCarouselDef.ScrollerProps} props
  * @return {PreactDef.Renderable}
  */
-export function Scroller({
-  children,
-  loop,
-  restingIndex,
-  setRestingIndex,
-  scrollRef,
-}) {
+export function Scroller({children, loop, ref, restingIndex, setRestingIndex}) {
   /**
    * The number of slides we want to place before the
    * reference or resting index. Only needed if loop=true.
@@ -54,7 +48,6 @@ export function Scroller({
    */
   const offsetRef = useRef(restingIndex);
   const ignoreProgrammaticScrollRef = useRef(true);
-  const containerRef = useRef(null);
   const slides = renderSlides({
     children,
     loop,
@@ -66,18 +59,17 @@ export function Scroller({
 
   // useLayoutEffect needed to avoid FOUC while scrolling
   useLayoutEffect(() => {
-    if (!containerRef.current) {
+    if (!ref.current) {
       return;
     }
-    // TODO: We should use forwardRef to dedup scrollRef and containerRef.
-    const container = (scrollRef.current = containerRef.current);
+    const container = ref.current;
     ignoreProgrammaticScrollRef.current = true;
     setStyle(container, 'scrollBehavior', 'auto');
     container./* OK */ scrollLeft = loop
       ? container./* OK */ offsetWidth * pivotIndex
       : container./* OK */ offsetWidth * restingIndex;
     setStyle(container, 'scrollBehavior', 'smooth');
-  }, [loop, restingIndex, pivotIndex, scrollRef]);
+  }, [loop, restingIndex, pivotIndex, ref]);
 
   // Trigger render by setting the resting index to the current scroll state.
   const debouncedResetScrollReferencePoint = useMemo(
@@ -105,7 +97,7 @@ export function Scroller({
   // This is necessary for smooth scrolling because
   // intermediary renders will interupt scroll and cause jank.
   const updateCurrentIndex = () => {
-    const container = containerRef.current;
+    const container = ref.current;
     const slideOffset = Math.round(
       (container./* OK */ scrollLeft -
         offsetRef.current * container./* OK */ offsetWidth) /
@@ -127,7 +119,7 @@ export function Scroller({
     <div
       hide-scrollbar
       key="container"
-      ref={containerRef}
+      ref={ref}
       onScroll={handleScroll}
       style={{
         ...styles.scrollContainer,

--- a/extensions/amp-base-carousel/1.0/scroller.js
+++ b/extensions/amp-base-carousel/1.0/scroller.js
@@ -43,10 +43,7 @@ const RESET_SCROLL_REFERENCE_POINT_WAIT_MS = 200;
  * @return {PreactDef.Renderable}
  * @template T
  */
-export function ScrollerWithRef(
-  {children, loop, restingIndex, setRestingIndex},
-  ref
-) {
+function ScrollerWithRef({children, loop, restingIndex, setRestingIndex}, ref) {
   // We still need our own ref that we can always rely on to be there.
   const containerRef = useRef(null);
   useImperativeHandle(ref, () => ({
@@ -156,10 +153,11 @@ export function ScrollerWithRef(
   );
 }
 
-export const Scroller = forwardRef((props, ref) =>
+const Scroller = forwardRef((props, ref) =>
   ScrollerWithRef(/** @type {BaseCarouselDef.ScrollerProps} */ (props), ref)
 );
 Scroller.displayName = 'Scroller'; // Make findable for tests.
+export {Scroller};
 
 /**
  * How the slides are ordered when looping:

--- a/extensions/amp-base-carousel/1.0/scroller.js
+++ b/extensions/amp-base-carousel/1.0/scroller.js
@@ -17,6 +17,7 @@ import * as Preact from '../../../src/preact';
 import * as styles from './base-carousel.css';
 import {WithAmpContext} from '../../../src/preact/context';
 import {debounce} from '../../../src/utils/rate-limit';
+import {forwardRef} from '../../../src/preact/compat';
 import {mod} from '../../../src/utils/math';
 import {setStyle} from '../../../src/style';
 import {useLayoutEffect, useMemo, useRef} from '../../../src/preact';
@@ -33,9 +34,13 @@ const RESET_SCROLL_REFERENCE_POINT_WAIT_MS = 200;
 
 /**
  * @param {!BaseCarouselDef.ScrollerProps} props
+ * @param {{current: (Element|null)}} ref
  * @return {PreactDef.Renderable}
  */
-export function Scroller({children, loop, ref, restingIndex, setRestingIndex}) {
+export function ScrollerWithRef(
+  {children, loop, restingIndex, setRestingIndex},
+  ref
+) {
   /**
    * The number of slides we want to place before the
    * reference or resting index. Only needed if loop=true.
@@ -132,6 +137,11 @@ export function Scroller({children, loop, ref, restingIndex, setRestingIndex}) {
     </div>
   );
 }
+
+export const Scroller = forwardRef((props, ref) =>
+  ScrollerWithRef(/** @type {BaseCarouselDef.ScrollerProps} */ (props), ref)
+);
+Scroller.displayName = 'Scroller'; // Make findable for tests.
 
 /**
  * How the slides are ordered when looping:

--- a/extensions/amp-base-carousel/1.0/scroller.js
+++ b/extensions/amp-base-carousel/1.0/scroller.js
@@ -92,7 +92,7 @@ export function ScrollerWithRef(
       ? container./* OK */ offsetWidth * pivotIndex
       : container./* OK */ offsetWidth * restingIndex;
     setStyle(container, 'scrollBehavior', 'smooth');
-  }, [loop, restingIndex, pivotIndex, ref]);
+  }, [loop, restingIndex, pivotIndex]);
 
   // Trigger render by setting the resting index to the current scroll state.
   const debouncedResetScrollReferencePoint = useMemo(

--- a/extensions/amp-base-carousel/1.0/scroller.js
+++ b/extensions/amp-base-carousel/1.0/scroller.js
@@ -53,8 +53,8 @@ export function ScrollerWithRef(
     // Expose "advance" action for navigating between slides by the given quantity of slides.
     advance: (by) => {
       const container = containerRef.current;
-      // Modify scrollLeft is preferred to `setCurSlide` to enable smooth scroll.
-      // Note: `setCurSlide` will still be called on debounce by scroll handler.
+      // Modify scrollLeft is preferred to `setRestingIndex` to enable smooth scroll.
+      // Note: `setRestingIndex` will still be called on debounce by scroll handler.
       container./* OK */ scrollLeft += container./* OK */ offsetWidth * by;
     },
   }));

--- a/src/preact/compat.js
+++ b/src/preact/compat.js
@@ -18,7 +18,7 @@ import * as compat from /*OK*/ 'preact/compat';
 
 /**
  * @param {function(JsonObject, {current: (T|null)}):PreactDef.Renderable} fn
- * @return {PreactDef.Renderable}
+ * @return {function():PreactDef.Renderable}
  * @template T
  */
 export function forwardRef(fn) {

--- a/src/preact/index.js
+++ b/src/preact/index.js
@@ -140,6 +140,17 @@ export function useCallback(cb, opt_deps) {
 }
 
 /**
+ * @param {{current: (T|null)}} ref
+ * @param {function():T} create
+ * @param {!Array<*>=} opt_deps
+ * @return {undefined}
+ * @template T
+ */
+export function useImperativeHandle(ref, create, opt_deps) {
+  return hooks.useImperativeHandle(ref, create, opt_deps);
+}
+
+/**
  * @param {!PreactDef.Renderable} unusedChildren
  * @return {!Array<PreactDef.Renderable>}
  */


### PR DESCRIPTION
Use `forwardRef` to [dedup refs](https://github.com/ampproject/amphtml/pull/28704#discussion_r454696809) referenced between `Scroller` and `BaseCarousel`. Partial for #28284