### PR TITLE
🧪Removal of `pull-to-refresh` and `viewport-binding-ios-embed` for SxG build.

### DIFF
--- a/src/amp.js
+++ b/src/amp.js
@@ -93,7 +93,9 @@ function bootstrap(ampdoc, perf) {
   startupChunk(
     self.document,
     function final() {
-      installPullToRefreshBlocker(self);
+      if(!IS_SXG){
+        installPullToRefreshBlocker(self);
+      }
       installAutoLightboxExtension(ampdoc);
       installStandaloneExtension(ampdoc);
       maybeValidate(self);

--- a/src/amp.js
+++ b/src/amp.js
@@ -93,7 +93,7 @@ function bootstrap(ampdoc, perf) {
   startupChunk(
     self.document,
     function final() {
-      if(!IS_SXG){
+      if (!IS_SXG) {
         installPullToRefreshBlocker(self);
       }
       installAutoLightboxExtension(ampdoc);

--- a/src/service/viewport/viewport-impl.js
+++ b/src/service/viewport/viewport-impl.js
@@ -1169,7 +1169,8 @@ function createViewport(ampdoc) {
   let binding;
   if (
     ampdoc.isSingleDoc() &&
-    getViewportType(win, viewer) == ViewportType.NATURAL_IOS_EMBED
+    getViewportType(win, viewer) == ViewportType.NATURAL_IOS_EMBED &&
+    !IS_SXG
   ) {
     binding = new ViewportBindingIosEmbedWrapper_(win);
   } else {


### PR DESCRIPTION
@dvoytenko pointed out that these two modules would probably not be needed in SxG build, so these can be excluded from it. These two changes remove 1KB from `v0.js`.