### PR TITLE
🏗 Switch usage of `gulp-watch` to `gulp.watch`

### DIFF
--- a/build-system/tasks/css.js
+++ b/build-system/tasks/css.js
@@ -18,7 +18,6 @@ const debounce = require('debounce');
 const file = require('gulp-file');
 const fs = require('fs-extra');
 const gulp = require('gulp');
-const gulpWatch = require('gulp-watch');
 const {
   endBuildStep,
   mkdirSync,
@@ -28,6 +27,7 @@ const {
 const {buildExtensions} = require('./extension-helpers');
 const {jsifyCssAsync} = require('./jsify-css');
 const {maybeUpdatePackages} = require('./update-packages');
+const {watch} = require('gulp');
 
 /**
  * Entry point for 'gulp css'
@@ -90,7 +90,7 @@ function compileCss(options = {}) {
     const watchFunc = () => {
       compileCss();
     };
-    gulpWatch('css/**/*.css', debounce(watchFunc, watchDebounceDelay));
+    watch('css/**/*.css').on('change', debounce(watchFunc, watchDebounceDelay));
   }
 
   /**

--- a/build-system/tasks/extension-helpers.js
+++ b/build-system/tasks/extension-helpers.js
@@ -18,7 +18,6 @@ const colors = require('ansi-colors');
 const debounce = require('debounce');
 const fs = require('fs-extra');
 const log = require('fancy-log');
-const watch = require('gulp-watch');
 const wrappers = require('../compile/compile-wrappers');
 const {
   extensionAliasBundles,
@@ -30,6 +29,7 @@ const {isTravisBuild} = require('../common/travis');
 const {jsifyCssAsync} = require('./jsify-css');
 const {maybeToEsmName, compileJs, mkdirSync} = require('./helpers');
 const {vendorConfigs} = require('./vendor-configs');
+const {watch} = require('gulp');
 
 const {green, red, cyan} = colors;
 const argv = require('minimist')(process.argv.slice(2));
@@ -393,7 +393,7 @@ function watchExtension(path, name, version, latestVersion, hasCss, options) {
       options.onWatchBuild(bundleComplete);
     }
   };
-  watch(path + '/**/*', debounce(watchFunc, watchDebounceDelay));
+  watch(`${path}/**/*`).on('change', debounce(watchFunc, watchDebounceDelay));
 }
 
 /**

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -24,7 +24,6 @@ const file = require('gulp-file');
 const fs = require('fs-extra');
 const gulp = require('gulp');
 const gulpIf = require('gulp-if');
-const gulpWatch = require('gulp-watch');
 const istanbul = require('gulp-istanbul');
 const log = require('fancy-log');
 const path = require('path');
@@ -45,6 +44,7 @@ const {isTravisBuild} = require('../common/travis');
 const {jsBundles} = require('../compile/bundles.config');
 const {thirdPartyFrames} = require('../test-configs/config');
 const {transpileTs} = require('../compile/typescript');
+const {watch: gulpWatch} = require('gulp');
 
 /**
  * Tasks that should print the `--nobuild` help text.
@@ -128,7 +128,10 @@ async function bootstrapThirdPartyFrames(options) {
       const watchFunc = () => {
         thirdPartyBootstrap(frameObject.max, frameObject.min, options);
       };
-      gulpWatch(frameObject.max, debounce(watchFunc, watchDebounceDelay));
+      gulpWatch(frameObject.max).on(
+        'change',
+        debounce(watchFunc, watchDebounceDelay)
+      );
     });
   }
   await Promise.all(promises);
@@ -249,7 +252,7 @@ async function compileMinifiedJs(srcDir, srcFilename, destDir, options) {
         options.onWatchBuild(compileComplete);
       }
     };
-    gulpWatch(entryPoint, debounce(watchFunc, watchDebounceDelay));
+    gulpWatch(entryPoint).on('change', debounce(watchFunc, watchDebounceDelay));
   }
 
   async function doCompileMinifiedJs(continueOnError) {

--- a/build-system/tasks/serve.js
+++ b/build-system/tasks/serve.js
@@ -23,7 +23,6 @@ const log = require('fancy-log');
 const minimist = require('minimist');
 const morgan = require('morgan');
 const path = require('path');
-const watch = require('gulp-watch');
 const {
   buildNewServer,
   SERVER_TRANSFORM_PATH,
@@ -38,6 +37,7 @@ const {createCtrlcHandler} = require('../common/ctrlcHandler');
 const {cyan, green, red} = require('ansi-colors');
 const {logServeMode, setServeMode} = require('../server/app-utils');
 const {watchDebounceDelay} = require('./helpers');
+const {watch} = require('gulp');
 
 const argv = minimist(process.argv.slice(2), {string: ['rtv']});
 
@@ -176,7 +176,7 @@ async function doServe(lazyBuild = false) {
   const watchFunc = async () => {
     await restartServer();
   };
-  watch(serverFiles, debounce(watchFunc, watchDebounceDelay));
+  watch(serverFiles).on('change', debounce(watchFunc, watchDebounceDelay));
   if (argv.new_server) {
     buildNewServer();
   }

--- a/build-system/tasks/vendor-configs.js
+++ b/build-system/tasks/vendor-configs.js
@@ -20,12 +20,12 @@ const debounce = require('debounce');
 const globby = require('globby');
 const gulp = require('gulp');
 const gulpif = require('gulp-if');
-const gulpWatch = require('gulp-watch');
 const jsonlint = require('gulp-jsonlint');
 const jsonminify = require('gulp-jsonminify');
 const rename = require('gulp-rename');
 const {endBuildStep, toPromise} = require('./helpers');
 const {watchDebounceDelay} = require('./helpers');
+const {watch} = require('gulp');
 
 /**
  * Entry point for 'gulp vendor-configs'
@@ -50,7 +50,7 @@ async function vendorConfigs(opt_options) {
     const watchFunc = () => {
       vendorConfigs(copyOptions);
     };
-    gulpWatch(srcPath, debounce(watchFunc, watchDebounceDelay));
+    watch(srcPath).on('change', debounce(watchFunc, watchDebounceDelay));
   }
 
   const startTime = Date.now();


### PR DESCRIPTION
This PR implements the solution outlined in https://github.com/ampproject/amphtml/issues/29214#issuecomment-668803993, and switches almost all the `watch` functionality in `build-system` from the third-party [`gulp-watch`](https://www.npmjs.com/package/gulp-watch) (last updated 2 years ago) to the built-in [`gulp.watch()`](https://gulpjs.com/docs/en/api/watch/) present in `gulp` v4.

The only remaining usage of the old `gulp-watch` is in [`lint.js`](https://github.com/ampproject/amphtml/blob/master/build-system/tasks/lint.js), whose watcher reuses the main `gulp` stream, which can't be done with `gulp.watch()` as written. Migrating requires a refactor and is out of scope for this PR.

With this, we should hopefully see fewer of the missed file changes described in #29214.

Tested by triggering ten consecutive rebuilds, and all of them fired correctly:

![image](https://user-images.githubusercontent.com/26553114/89437340-6f4fb080-d715-11ea-9ea8-47236266b01b.png)
