### PR TITLE
🚮  amp-list: remove experiment 'protocol-adapters'

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -28,7 +28,6 @@
   "flexAdSlots": 0.05,
   "intersect-resources": 1,
   "ios-fixed-no-transfer": 1,
-  "protocol-adapters": 1,
   "pump-early-frame": 1,
   "remove-task-timeout": 0,
   "swg-gpay-api": 1,

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -29,7 +29,6 @@
   "flexAdSlots": 0.05,
   "intersect-resources": 1,
   "ios-fixed-no-transfer": 0,
-  "protocol-adapters": 1,
   "pump-early-frame": 1,
   "swg-gpay-api": 1,
   "swg-gpay-native": 1,

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -484,10 +484,6 @@ export class AmpList extends AMP.BaseElement {
     return Promise.resolve()
       .then(() => {
         userAssert(
-          isExperimentOn(this.win, 'protocol-adapters'),
-          `Experiment 'protocol-adapters' is not turned on.`
-        );
-        userAssert(
           !this.ssrTemplateHelper_.isEnabled(),
           '[amp-list]: "amp-script" URIs cannot be used in SSR mode.'
         );

--- a/extensions/amp-list/0.1/test-e2e/test-function-src.js
+++ b/extensions/amp-list/0.1/test-e2e/test-function-src.js
@@ -44,7 +44,6 @@ describes.endtoend(
   {
     testUrl:
       'http://localhost:8000/test/fixtures/e2e/amp-list/amp-list-function-load-more.html',
-    experiments: ['protocol-adapters'],
     environments: ['single'],
   },
   async (env) => {

--- a/extensions/amp-list/0.1/test-e2e/test-function-src.js
+++ b/extensions/amp-list/0.1/test-e2e/test-function-src.js
@@ -19,7 +19,6 @@ describes.endtoend(
   {
     testUrl:
       'http://localhost:8000/test/fixtures/e2e/amp-list/amp-list-function-src.html',
-    experiments: ['protocol-adapters'],
     environments: ['single'],
   },
   async (env) => {

--- a/extensions/amp-list/0.1/test/test-amp-list.js
+++ b/extensions/amp-list/0.1/test/test-amp-list.js
@@ -941,7 +941,6 @@ describes.repeated(
             });
 
             it('"amp-script:" uri should skip rendering and emit an error', () => {
-              toggleExperiment(win, 'protocol-adapters', true);
               list.element.setAttribute('src', 'amp-script:fetchData');
 
               listMock.expects('scheduleRender_').never();
@@ -949,7 +948,6 @@ describes.repeated(
               const errorMsg = /cannot be used in SSR mode/;
               expectAsyncConsoleError(errorMsg);
               expect(list.layoutCallback()).eventually.rejectedWith(errorMsg);
-              toggleExperiment(win, 'protocol-adapters', false);
             });
 
             it('Bound [src] should skip rendering and emit an error', async () => {
@@ -1013,14 +1011,7 @@ describes.repeated(
               list = createAmpList(element);
             });
 
-            it('should throw an error if used without the experiment enabled', async () => {
-              const errorMsg = /Invalid value: amp-script:example.fetchData/;
-              expectAsyncConsoleError(errorMsg);
-              expect(list.layoutCallback()).to.eventually.throw(errorMsg);
-            });
-
             it('should throw an error if given an invalid format', async () => {
-              toggleExperiment(win, 'protocol-adapters', true);
               const errorMsg = /URIs must be of the format/;
 
               element.setAttribute('src', 'amp-script:fetchData');
@@ -1037,7 +1028,6 @@ describes.repeated(
             });
 
             it('should throw if specified amp-script does not exist', () => {
-              toggleExperiment(win, 'protocol-adapters', true);
               element.setAttribute('src', 'amp-script:doesnotexist.fn');
 
               const errorMsg = /could not find <amp-script> with/;
@@ -1046,7 +1036,6 @@ describes.repeated(
             });
 
             it('should fail if function call rejects', async () => {
-              toggleExperiment(win, 'protocol-adapters', true);
               ampScriptEl.getImpl = () =>
                 Promise.resolve({
                   callFunction: () =>
@@ -1062,7 +1051,6 @@ describes.repeated(
             it('should render non-array if single-item is set', async () => {
               const callFunctionResult = {'items': {title: 'Title'}};
               element.setAttribute('single-item', 'true');
-              toggleExperiment(win, 'protocol-adapters', true);
               ampScriptEl.getImpl = () =>
                 Promise.resolve({
                   callFunction(fnId) {
@@ -1087,7 +1075,6 @@ describes.repeated(
             });
 
             it('should render a list from AmpScriptService provided data', async () => {
-              toggleExperiment(win, 'protocol-adapters', true);
               ampScriptEl.getImpl = () =>
                 Promise.resolve({
                   callFunction(fnId) {

--- a/tools/experiments/experiments-config.js
+++ b/tools/experiments/experiments-config.js
@@ -231,11 +231,6 @@ export const EXPERIMENTS = [
     cleanupIssue: 'https://github.com/ampproject/amphtml/issues/24113',
   },
   {
-    id: 'protocol-adapters',
-    name: 'Allow amp-list to get its data from amp-script functions.',
-    spec: 'https://github.com/ampproject/amphtml/issues/26474',
-  },
-  {
     id: 'adsense-ad-size-optimization',
     name:
       'Per publisher server side settings for changing the ad size ' +


### PR DESCRIPTION
Cleanup for [protocol adapters](https://github.com/ampproject/amphtml/issues/26474)