### PR TITLE
Fix media performance tracking on first story page.

### DIFF
--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -526,15 +526,14 @@ export class AmpStoryPage extends AMP.BaseElement {
               this.advancement_.start();
             }
           });
-        this.startMeasuringAllVideoPerformance_();
-        this.preloadAllMedia_()
-          .then(() => this.startListeningToVideoEvents_())
-          .then(() => {
-            this.playAllMedia_();
-            if (!this.storeService_.get(StateProperty.MUTED_STATE)) {
-              this.unmuteAllMedia();
-            }
-          });
+        this.preloadAllMedia_().then(() => {
+          this.startMeasuringAllVideoPerformance_();
+          this.startListeningToVideoEvents_();
+          this.playAllMedia_();
+          if (!this.storeService_.get(StateProperty.MUTED_STATE)) {
+            this.unmuteAllMedia();
+          }
+        });
       });
       this.prefersReducedMotion_()
         ? this.maybeFinishAnimations_()

--- a/extensions/amp-story/1.0/test/test-amp-story-page.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-page.js
@@ -639,7 +639,11 @@ describes.realWin('amp-story-page', {amp: {extensions}}, (env) => {
 
     await nextTick();
 
-    expect(startMeasuringStub).to.have.been.calledOnceWithExactly(videoEl);
+    const poolVideoEl = element.querySelector('video');
+    // Not called with the original video.
+    expect(startMeasuringStub).to.not.have.been.calledOnceWithExactly(videoEl);
+    // Called with the media pool replaced video.
+    expect(startMeasuringStub).to.have.been.calledOnceWithExactly(poolVideoEl);
   });
 
   it('should stop tracking media performance when leaving the page', async () => {
@@ -661,8 +665,9 @@ describes.realWin('amp-story-page', {amp: {extensions}}, (env) => {
     await nextTick();
     page.setState(PageState.NOT_ACTIVE);
 
+    const poolVideoEl = element.querySelector('video');
     expect(stopMeasuringStub).to.have.been.calledOnceWithExactly(
-      videoEl,
+      poolVideoEl,
       true /* sendMetrics */
     );
   });


### PR DESCRIPTION
Wait until after `preloadAllMedia_()` for the actual `video` element to be available and start tracking media performance. #29233 made amp-video/audio.layoutCallback() resolve instantly, and media pool swap in/out are now synchronous, so register and preload operations are synchronous and thus very fast.

In addition to #29233, this fixes https://github.com/ampproject/amphtml/issues/29105