### PR TITLE
new lint rule: no static this

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -152,6 +152,7 @@ module.exports = {
     'local/no-module-exports': 2,
     'local/no-rest': 2,
     'local/no-spread': 2,
+    'local/no-static-this': 2,
     'local/no-style-display': 2,
     'local/no-style-property-setting': 2,
     'local/no-swallow-return-from-allow-console-error': 2,

--- a/build-system/eslint-rules/no-static-this.js
+++ b/build-system/eslint-rules/no-static-this.js
@@ -1,0 +1,87 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+// Forbids use of `this` inside static class methods
+//
+// Good:
+// ```
+// class Foo {
+//   static s() {
+//     Foo.prop;
+//   }
+//
+//   i() {
+//     this.prop;
+//     Foo.prop;
+//   }
+// }
+//
+// Foo.prop = 1;
+// ```
+//
+// Bad:
+// ```
+// class Foo {
+//   static s() {
+//     this.prop;
+//   }
+// }
+//
+// Foo.prop = 1;
+// ```
+module.exports = { 
+  create(context) {
+    return {
+      'MethodDefinition[static=true] ThisExpression': function (node) {
+        const ancestry = context.getAncestors().slice().reverse();
+        let i = 0;
+        for (; i < ancestry.length; i++) {
+          const ancestor = ancestry[i];
+          const {type} = ancestor;
+
+          // Arrow functions inherit `this` from their lexical scope, so we need
+          // to continue searching if it's an arrow.
+          if (
+            !type.includes('Function') ||
+            type === 'ArrowFunctionExpression'
+          ) {
+            continue;
+          }
+
+          // If the direct parent of this function is a static method definition,
+          // then we've found our root method. If it's non-static, then it's a
+          // nested class expression's instance method, which is safe.
+          if (i < ancestry.length - 2) {
+            const parent = ancestry[i + 1];
+            if (parent.type === 'MethodDefinition' && parent.static) {
+              break;
+            }
+          }
+
+          // Found a function with it's own `this`, so it's safe.
+          return;
+        }
+
+        context.report({
+          node,
+          message:
+            '`this` in static methods is broken by Advanced Closure Compiler optimizations. Please use the class name directly.',
+        });
+      },
+    };
+  },
+};

--- a/build-system/eslint-rules/no-static-this.js
+++ b/build-system/eslint-rules/no-static-this.js
@@ -43,7 +43,15 @@
 //
 // Foo.prop = 1;
 // ```
-module.exports = { 
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        "Disallow using `this` within static functions, since Closure Compiler's Advanced Compilation breaks it",
+      context: 'https://github.com/google/closure-compiler/issues/2397',
+    },
+  },
   create(context) {
     return {
       'MethodDefinition[static=true] ThisExpression': function (node) {

--- a/testing/test-helper.js
+++ b/testing/test-helper.js
@@ -183,14 +183,14 @@ export class RequestBank {
    */
   static withdraw(requestId) {
     const url = `${REQUEST_URL}/withdraw/${requestId}/`;
-    return this.fetch_(url, `withdraw(${requestId ?? ''})`).then((res) =>
+    return RequestBank.fetch_(url, `withdraw(${requestId ?? ''})`).then((res) =>
       res.json()
     );
   }
 
   static tearDown() {
     const url = `${REQUEST_URL}/teardown/`;
-    return this.fetch_(url, 'tearDown');
+    return RequestBank.fetch_(url, 'tearDown');
   }
 
   static fetch_(url, action, timeout = 10000) {


### PR DESCRIPTION
Closure Compiler doesn't support static this. It doesn't explode either, it just behaves strangely at runtime.
This lint rule should help up catch it early.

Most of the credit goes to Justin for writing the meat of the rule.

cc @kristoferbaxter 

Blocked by https://github.com/ampproject/amphtml/pull/29695