### PR TITLE
Add error message for unparseable checkConsentHref response

### DIFF
--- a/extensions/amp-consent/0.1/amp-consent.js
+++ b/extensions/amp-consent/0.1/amp-consent.js
@@ -611,7 +611,14 @@ export class AmpConsent extends AMP.BaseElement {
                 .fetchJson(expandedHref, init)
                 .then((res) =>
                   xhrService.xssiJson(res, this.consentConfig_['xssiPrefix'])
-                );
+                )
+                .catch((e) => {
+                  user().error(
+                    TAG,
+                    'Could not parse the `checkConsentHref` response.',
+                    e.message
+                  );
+                });
             }
           );
         });

--- a/extensions/amp-consent/0.1/amp-consent.js
+++ b/extensions/amp-consent/0.1/amp-consent.js
@@ -607,18 +607,19 @@ export class AmpConsent extends AMP.BaseElement {
         return ampdoc.whenFirstVisible().then(() => {
           return expandConsentEndpointUrl(this.element, resolvedHref).then(
             (expandedHref) => {
-              return xhrService
-                .fetchJson(expandedHref, init)
-                .then((res) =>
-                  xhrService.xssiJson(res, this.consentConfig_['xssiPrefix'])
-                )
-                .catch((e) => {
-                  user().error(
-                    TAG,
-                    'Could not parse the `checkConsentHref` response.',
-                    e.message
+              return xhrService.fetchJson(expandedHref, init).then((res) => {
+                try {
+                  return xhrService.xssiJson(
+                    res,
+                    this.consentConfig_['xssiPrefix']
                   );
-                });
+                } catch (e) {
+                  userAssert(
+                    false,
+                    'Could not parse the `checkConsentHref` response.'
+                  );
+                }
+              });
             }
           );
         });


### PR DESCRIPTION
Closes #29655 by catching errors that occur while trying to parse the JSON response.