### PR TITLE
🚀  [amp-story-player] Wait for first story to load before loading next ones

### DIFF
--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -1185,6 +1185,8 @@ export class AmpStory extends AMP.BaseElement {
       /* payload */ undefined,
       {bubbles: true}
     );
+    this.viewerMessagingHandler_ &&
+      this.viewerMessagingHandler_.send(EventType.STORY_LOADED, dict({}));
     this.signals().signal(CommonSignals.INI_LOAD);
     this.mutateElement(() => {
       this.element.classList.add(STORY_LOADED_CLASS_NAME);

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -1186,7 +1186,7 @@ export class AmpStory extends AMP.BaseElement {
       {bubbles: true}
     );
     this.viewerMessagingHandler_ &&
-      this.viewerMessagingHandler_.send('storyLoaded', dict({}));
+      this.viewerMessagingHandler_.send('storyContentLoaded', dict({}));
     this.signals().signal(CommonSignals.INI_LOAD);
     this.mutateElement(() => {
       this.element.classList.add(STORY_LOADED_CLASS_NAME);

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -1186,7 +1186,7 @@ export class AmpStory extends AMP.BaseElement {
       {bubbles: true}
     );
     this.viewerMessagingHandler_ &&
-      this.viewerMessagingHandler_.send(EventType.STORY_LOADED, dict({}));
+      this.viewerMessagingHandler_.send('storyLoaded', dict({}));
     this.signals().signal(CommonSignals.INI_LOAD);
     this.mutateElement(() => {
       this.element.classList.add(STORY_LOADED_CLASS_NAME);

--- a/src/amp-story-player/amp-story-player-impl.js
+++ b/src/amp-story-player/amp-story-player-impl.js
@@ -577,7 +577,7 @@ export class AmpStoryPlayer {
   waitForStoryToLoadPromise_(iframeIdx) {
     return new Promise((resolve) => {
       this.messagingPromises_[iframeIdx].then((messaging) =>
-        messaging.registerHandler('ampstory:load', () => resolve())
+        messaging.registerHandler('storyLoaded', () => resolve())
       );
     });
   }

--- a/src/amp-story-player/amp-story-player-impl.js
+++ b/src/amp-story-player/amp-story-player-impl.js
@@ -924,7 +924,7 @@ export class AmpStoryPlayer {
    * Compares href from the story with the href in the iframe.
    * @param {string} storyHref
    * @param {string} iframeHref
-   * @return {boolean}
+   * @return {Promise<boolean>}
    * @private
    */
   hasSameHref_(storyHref, iframeHref) {

--- a/src/amp-story-player/amp-story-player-impl.js
+++ b/src/amp-story-player/amp-story-player-impl.js
@@ -820,11 +820,8 @@ export class AmpStoryPlayer {
    */
   updatePreviousIframe_(story, position) {
     const iframeIdx = story[IFRAME_IDX];
-    const iframeEl = this.iframes_[iframeIdx];
-    this.layoutIframe_(story, iframeEl, VisibilityState.PRERENDER).then(() => {
-      this.updateVisibilityState_(iframeIdx, VisibilityState.INACTIVE);
-      this.updateIframePosition_(iframeIdx, position);
-    });
+    this.updateVisibilityState_(iframeIdx, VisibilityState.INACTIVE);
+    this.updateIframePosition_(iframeIdx, position);
   }
 
   /**

--- a/src/amp-story-player/amp-story-player-impl.js
+++ b/src/amp-story-player/amp-story-player-impl.js
@@ -570,6 +570,8 @@ export class AmpStoryPlayer {
   }
 
   /**
+   * Returns a promise that resolves when story in given iframe is finished
+   * loading.
    * @param {number} iframeIdx
    * @return {!Promise}
    * @private

--- a/src/amp-story-player/amp-story-player-impl.js
+++ b/src/amp-story-player/amp-story-player-impl.js
@@ -926,6 +926,7 @@ export class AmpStoryPlayer {
    * @param {string} storyHref
    * @param {string} iframeHref
    * @return {boolean}
+   * @private
    */
   hasSameHref_(storyHref, iframeHref) {
     if (iframeHref.length <= 0) {

--- a/test/unit/test-amp-story-player.js
+++ b/test/unit/test-amp-story-player.js
@@ -113,6 +113,7 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
   it('should correctly append params at the end of the story url', async () => {
     buildStoryPlayer();
     await manager.loadPlayers();
+    await nextTick();
 
     const storyIframe = playerEl.querySelector('iframe');
 
@@ -127,6 +128,7 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
     const existingParams = '?testParam=true#myhash=hashValue';
     buildStoryPlayer(1, DEFAULT_CACHE_URL + existingParams);
     await manager.loadPlayers();
+    await nextTick();
 
     const storyIframe = playerEl.querySelector('iframe');
 
@@ -141,6 +143,7 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
   it('should set first story as visible', async () => {
     buildStoryPlayer(3);
     await manager.loadPlayers();
+    await nextTick();
 
     const storyIframes = playerEl.querySelectorAll('iframe');
     expect(storyIframes[0].getAttribute('src')).to.include(
@@ -326,7 +329,8 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
       );
     });
 
-    it('should throw error when invalid url is provided', async () => {
+    // TODO(Enriqe): unksip this test.
+    it.skip('should throw error when invalid url is provided', async () => {
       buildStoryPlayer(1, DEFAULT_ORIGIN_URL, 'www.invalid.org');
 
       return expect(() => manager.loadPlayers()).to.throw(

--- a/test/unit/test-amp-story-player.js
+++ b/test/unit/test-amp-story-player.js
@@ -156,7 +156,7 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
     await manager.loadPlayers();
     await nextTick();
 
-    fireHandler['ampstory:load']('ampstory:load', {});
+    fireHandler['storyLoaded']('storyLoaded', {});
     await nextTick();
 
     const storyIframes = playerEl.querySelectorAll('iframe');

--- a/test/unit/test-amp-story-player.js
+++ b/test/unit/test-amp-story-player.js
@@ -175,6 +175,18 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
     expect(storyIframes[1].getAttribute('src')).to.not.exist;
   });
 
+  it('should load new story if user navigated before first finished loading', async () => {
+    buildStoryPlayer(3);
+    await manager.loadPlayers();
+    await nextTick();
+
+    const storyIframes = playerEl.querySelectorAll('iframe');
+    swipeLeft();
+    await nextTick();
+
+    expect(storyIframes[1].getAttribute('src')).to.exist;
+  });
+
   it(
     'should remove iframe from a story with distance > 1 from current story ' +
       'and give it to a new story that is distance <= 1 when navigating',

--- a/test/unit/test-amp-story-player.js
+++ b/test/unit/test-amp-story-player.js
@@ -244,18 +244,8 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
     expect(registerHandlerSpy).to.have.been.calledWith('documentStateUpdate');
   });
 
-<<<<<<< HEAD
   it('should send request to get page attachment state at build time', async () => {
     const sendRequestSpy = env.sandbox.spy(fakeMessaging, 'sendRequest');
-=======
-    messagingMock.expects('registerHandler').withArgs('selectDocument');
-    messagingMock.expects('registerHandler').withArgs('touchstart');
-    messagingMock.expects('registerHandler').withArgs('touchmove');
-    messagingMock.expects('registerHandler').withArgs('touchend');
-    messagingMock.expects('registerHandler').withArgs('documentStateUpdate');
-    messagingMock.expects('setDefaultHandler');
-    messagingMock.expects('registerHandler').withArgs('storyContentLoaded');
->>>>>>> f3c5f2a18... renaming, clean up by calling cacheUrl once
 
     buildStoryPlayer();
     await manager.loadPlayers();

--- a/test/unit/test-amp-story-player.js
+++ b/test/unit/test-amp-story-player.js
@@ -148,14 +148,28 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
     );
   });
 
-  it('should prerender next stories', async () => {
+  it('should prerender next story after first one is loaded', async () => {
     buildStoryPlayer(3);
     await manager.loadPlayers();
+    await nextTick();
+
+    fireHandler['ampstory:load']('ampstory:load', {});
+    await nextTick();
 
     const storyIframes = playerEl.querySelectorAll('iframe');
     expect(storyIframes[1].getAttribute('src')).to.include(
       '#visibilityState=prerender'
     );
+  });
+
+  it('should not load next story if first one hasn not finished loading', async () => {
+    buildStoryPlayer(3);
+    await manager.loadPlayers();
+    await nextTick();
+
+    const storyIframes = playerEl.querySelectorAll('iframe');
+
+    expect(storyIframes[1].getAttribute('src')).to.not.exist;
   });
 
   it(

--- a/test/unit/test-amp-story-player.js
+++ b/test/unit/test-amp-story-player.js
@@ -180,10 +180,11 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
     await manager.loadPlayers();
     await nextTick();
 
-    const storyIframes = playerEl.querySelectorAll('iframe');
+    // Swiping without waiting for story loaded event.
     swipeLeft();
     await nextTick();
 
+    const storyIframes = playerEl.querySelectorAll('iframe');
     expect(storyIframes[1].getAttribute('src')).to.exist;
   });
 

--- a/test/unit/test-amp-story-player.js
+++ b/test/unit/test-amp-story-player.js
@@ -165,7 +165,7 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
     );
   });
 
-  it('should not load next story if first one hasn not finished loading', async () => {
+  it('should not load next story if first one has not finished loading', async () => {
     buildStoryPlayer(3);
     await manager.loadPlayers();
     await nextTick();

--- a/test/unit/test-amp-story-player.js
+++ b/test/unit/test-amp-story-player.js
@@ -352,8 +352,7 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
       );
     });
 
-    // TODO(Enriqe): unksip this test.
-    it.skip('should throw error when invalid url is provided', async () => {
+    it('should throw error when invalid url is provided', async () => {
       buildStoryPlayer(1, DEFAULT_ORIGIN_URL, 'www.invalid.org');
 
       return expect(() => manager.loadPlayers()).to.throw(

--- a/test/unit/test-amp-story-player.js
+++ b/test/unit/test-amp-story-player.js
@@ -156,7 +156,7 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
     await manager.loadPlayers();
     await nextTick();
 
-    fireHandler['storyLoaded']('storyLoaded', {});
+    fireHandler['storyContentLoaded']('storyContentLoaded', {});
     await nextTick();
 
     const storyIframes = playerEl.querySelectorAll('iframe');
@@ -244,8 +244,18 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
     expect(registerHandlerSpy).to.have.been.calledWith('documentStateUpdate');
   });
 
+<<<<<<< HEAD
   it('should send request to get page attachment state at build time', async () => {
     const sendRequestSpy = env.sandbox.spy(fakeMessaging, 'sendRequest');
+=======
+    messagingMock.expects('registerHandler').withArgs('selectDocument');
+    messagingMock.expects('registerHandler').withArgs('touchstart');
+    messagingMock.expects('registerHandler').withArgs('touchmove');
+    messagingMock.expects('registerHandler').withArgs('touchend');
+    messagingMock.expects('registerHandler').withArgs('documentStateUpdate');
+    messagingMock.expects('setDefaultHandler');
+    messagingMock.expects('registerHandler').withArgs('storyContentLoaded');
+>>>>>>> f3c5f2a18... renaming, clean up by calling cacheUrl once
 
     buildStoryPlayer();
     await manager.loadPlayers();


### PR DESCRIPTION
Fixes #29320

Loading 2 iframes initially involved a lot of changes (because of how other methods like `show()` expect there to be 3 iframes) so I'm sending those in a follow up. (Tracked  #29706)

As seen on the first table, having a story specific event that delays the subsequent stories from being loaded makes the initial load time of the current story shorter.

### Time for first story page to be loaded 


|          | current | `storyLoaded`      | `documentLoaded`  |
|----------|---------|------------------|-----------------|
| normal   | 1.88s   | 1.37s (Δ -27.13%) | 1.74s (Δ -7.45%) |
| fast 3G  | ~72s    | ~30s (Δ -58.33%)  | ~34s (Δ -52.78%) |

There is a downside though, loading subsequent stories take longer to finish pre-rendering. 

### Time for secondary stories to be pre-rendered
|          | current | new             |
|----------|---------|-----------------|
| normal   | 3.17s   | 4.14s (Δ +30.6%) |
| fast 3G  | ~77s    | ~97s (Δ +25.97%) |

_Quick calculations using different network connection emulations and with the same player sample page containing local stories._

