### PR TITLE
♻️ Refactoring: Separate the convertToContainerWidth flow from maybeUpgradeToResponsive method

### DIFF
--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -187,23 +187,38 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
         getIdentityToken(this.win, this.getAmpDoc(), super.getConsentPolicy())
       );
 
-    return ResponsiveState.maybeUpgradeToResponsive(
-      this.element,
-      this.getAdClientId_()
-    ).then((state) => {
-      if (state != null) {
-        this.responsiveState_ = state;
-      }
-      if (
-        this.responsiveState_ != null &&
-        !this.responsiveState_.isContainerWidthState()
-      ) {
-        return this.responsiveState_.attemptToMatchResponsiveHeight();
-      }
-      // This should happen last, as some diversion criteria rely on some of the
-      // preceding logic (specifically responsive logic).
-      this.divertExperiments();
-    });
+    // Convert the full-width tag to container width for desktop users.
+    if (
+      this.element.hasAttribute('data-auto-format') &&
+      !ResponsiveState.isLayoutViewportNarrow_(this.element)
+    ) {
+      return ResponsiveState.convertToContainerWidth(this.element).then(
+        (state) => {
+          if (state != null) {
+            this.responsiveState_ = state;
+          }
+          this.divertExperiments();
+        }
+      );
+    } else {
+      return ResponsiveState.maybeUpgradeToResponsive(
+        this.element,
+        this.getAdClientId_()
+      ).then((state) => {
+        if (state != null) {
+          this.responsiveState_ = state;
+        }
+        if (
+          this.responsiveState_ != null &&
+          !this.responsiveState_.isContainerWidthState()
+        ) {
+          return this.responsiveState_.attemptToMatchResponsiveHeight();
+        }
+        // This should happen last, as some diversion criteria rely on some of the
+        // preceding logic (specifically responsive logic).
+        this.divertExperiments();
+      });
+    }
   }
 
   /** @override */

--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -190,7 +190,7 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
     // Convert the full-width tag to container width for desktop users.
     if (
       this.element.hasAttribute('data-auto-format') &&
-      !ResponsiveState.isLayoutViewportNarrow_(this.element)
+      !ResponsiveState.isLayoutViewportNarrow(this.element)
     ) {
       return ResponsiveState.convertToContainerWidth(this.element).then(
         (state) => {
@@ -208,10 +208,7 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
         if (state != null) {
           this.responsiveState_ = state;
         }
-        if (
-          this.responsiveState_ != null &&
-          !this.responsiveState_.isContainerWidthState()
-        ) {
+        if (this.responsiveState_ != null) {
           return this.responsiveState_.attemptToMatchResponsiveHeight();
         }
         // This should happen last, as some diversion criteria rely on some of the

--- a/extensions/amp-ad-network-adsense-impl/0.1/responsive-state.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/responsive-state.js
@@ -118,7 +118,7 @@ export class ResponsiveState {
     }
 
     // If the user already has a wide viewport layout, we don't upgrade to responsive.
-    if (!ResponsiveState.isLayoutViewportNarrow_(element)) {
+    if (!ResponsiveState.isLayoutViewportNarrow(element)) {
       return Promise.resolve(null);
     }
 
@@ -490,9 +490,8 @@ export class ResponsiveState {
    * Estimate if the viewport has a narrow layout.
    * @param {!Element} element
    * @return {boolean}
-   * @private
    */
-  static isLayoutViewportNarrow_(element) {
+  static isLayoutViewportNarrow(element) {
     const viewportSize = Services.viewportForDoc(element).getSize();
 
     return viewportSize.width < 488;

--- a/extensions/amp-ad-network-adsense-impl/0.1/responsive-state.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/responsive-state.js
@@ -86,10 +86,8 @@ export class ResponsiveState {
    *  corresponds to a responsive ad, otherwise null.
    */
   static createIfResponsive(element) {
-    if (
-      !this.isContainerWidth_ &&
-      !hasOwn(RAFMT_PARAMS, element.getAttribute('data-auto-format'))
-    ) {
+    const autoFormat = element.getAttribute('data-auto-format');
+    if (!hasOwn(RAFMT_PARAMS, autoFormat)) {
       return null;
     }
     return new ResponsiveState(element);
@@ -104,34 +102,13 @@ export class ResponsiveState {
   }
 
   /**
-   * Upgrades the ad unit to full-width responsive if it does not fall back to container width.
-   * @param {!Element} element
-   * @param {string} adClientId
-   * @return {!Promise<?ResponsiveState>} a promise that resolves when any upgrade is complete.
-   */
-  static maybeUpgradeToResponsive(element, adClientId) {
-    // For Desktop Full-width Ad request, it should fall back to container width.
-    if (
-      element.hasAttribute('data-auto-format') &&
-      !ResponsiveState.isLayoutViewportNarrow_(element)
-    ) {
-      return ResponsiveState.convertToContainerWidth_(element);
-    }
-
-    return ResponsiveState.maybeUpgradeToFullWidthResponsive(
-      element,
-      adClientId
-    );
-  }
-
-  /**
    * Upgrades the ad unit to responsive if there is an opt-in setting in localstorage.
    * See https://github.com/ampproject/amphtml/issues/23568 for design.
    * @param {!Element} element
    * @param {string} adClientId
    * @return {!Promise<?ResponsiveState>} a promise that resolves when any upgrade is complete.
    */
-  static maybeUpgradeToFullWidthResponsive(element, adClientId) {
+  static maybeUpgradeToResponsive(element, adClientId) {
     if (!ResponsiveState.isInAdSizeOptimizationExperimentBranch_(element)) {
       return Promise.resolve(null);
     }
@@ -189,9 +166,8 @@ export class ResponsiveState {
    *
    * @param {!Element} element
    * @return {!Promise<?ResponsiveState>} a promise that return container width responsive state.
-   * @private
    */
-  static convertToContainerWidth_(element) {
+  static convertToContainerWidth(element) {
     const vsync = Services.vsyncFor(toWin(element.ownerDocument.defaultView));
 
     return vsync
@@ -214,7 +190,6 @@ export class ResponsiveState {
       .then(() => {
         const state = ResponsiveState.createContainerWidthState(element);
         devAssert(state != null, 'Convert to container width state failed');
-        this.isContainerWidth_ = true;
         return /** @type {!ResponsiveState} */ (state);
       });
   }

--- a/extensions/amp-ad-network-adsense-impl/0.1/test/test-responsive-state.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/test/test-responsive-state.js
@@ -406,6 +406,36 @@ describes.realWin(
         expect(result).to.be.null;
       });
 
+      it('returns a valid responsive state and upgrades element when the ad unit is not responsive and ad size optimization is enabled', async () => {
+        forceExperimentBranch(
+          win,
+          AD_SIZE_OPTIMIZATION_EXP.branch,
+          AD_SIZE_OPTIMIZATION_EXP.experiment
+        );
+        const element = createElement({
+          'data-ad-client': AD_CLIENT_ID,
+          'height': '200px',
+          'width': '50vw',
+        });
+        storageContent[`aas-${AD_CLIENT_ID}`] = true;
+
+        const result = await ResponsiveState.maybeUpgradeToResponsive(
+          element,
+          AD_CLIENT_ID
+        );
+
+        expect(result).to.not.be.null;
+        expect(result.isValidElement()).to.be.true;
+        expect(element.getAttribute('height')).to.be.equal(
+          `${ADSENSE_RSPV_ALLOWED_HEIGHT}`
+        );
+        expect(element.getAttribute('width')).to.be.equal('100vw');
+        expect(element).to.have.attribute('data-full-width');
+        expect(element.getAttribute('data-auto-format')).to.be.equal('rspv');
+      });
+    });
+
+    describe('convertToContainerWidth', () => {
       it('Fall back to container width state for full-width responsive user on desktop site', async () => {
         const element = createElementWithNoStub({
           'data-ad-client': AD_CLIENT_ID,
@@ -447,35 +477,8 @@ describes.realWin(
         expect(element).to.not.have.attribute('data-full-width');
         expect(element).to.not.have.attribute('data-auto-format');
       });
-
-      it('returns a valid responsive state and upgrades element when the ad unit is not responsive and ad size optimization is enabled', async () => {
-        forceExperimentBranch(
-          win,
-          AD_SIZE_OPTIMIZATION_EXP.branch,
-          AD_SIZE_OPTIMIZATION_EXP.experiment
-        );
-        const element = createElement({
-          'data-ad-client': AD_CLIENT_ID,
-          'height': '200px',
-          'width': '50vw',
-        });
-        storageContent[`aas-${AD_CLIENT_ID}`] = true;
-
-        const result = await ResponsiveState.maybeUpgradeToResponsive(
-          element,
-          AD_CLIENT_ID
-        );
-
-        expect(result).to.not.be.null;
-        expect(result.isValidElement()).to.be.true;
-        expect(element.getAttribute('height')).to.be.equal(
-          `${ADSENSE_RSPV_ALLOWED_HEIGHT}`
-        );
-        expect(element.getAttribute('width')).to.be.equal('100vw');
-        expect(element).to.have.attribute('data-full-width');
-        expect(element.getAttribute('data-auto-format')).to.be.equal('rspv');
-      });
     });
+
     describe('maybeAttachSettingsListener', () => {
       describe('sets up a listener that', () => {
         let promise;

--- a/extensions/amp-ad-network-adsense-impl/0.1/test/test-responsive-state.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/test/test-responsive-state.js
@@ -433,7 +433,7 @@ describes.realWin(
           },
         });
 
-        const result = await ResponsiveState.maybeUpgradeToResponsive(
+        const result = await ResponsiveState.convertToContainerWidth(
           element,
           AD_CLIENT_ID
         );


### PR DESCRIPTION
Separate the convertToContainerWidth flow from maybeUpgradeToResponsive method, and trigger the flow from one level higher. The changes should not impact business logic.

Verifications in local mode:
mobile full width: https://screenshot.googleplex.com/dAYL7va7t6T
desktop container width: https://screenshot.googleplex.com/Cjcraf6STzV

PTAL: @kristoferbaxter, @calebcordry
