### PR TITLE
✨ Add https to default task flags.

### DIFF
--- a/build-system/tasks/default-task.js
+++ b/build-system/tasks/default-task.js
@@ -85,6 +85,7 @@ defaultTask.flags = {
   version_override: '  Overrides the version written to AMP_CONFIG',
   host: '  Host to serve the project on. localhost by default.',
   port: '  Port to serve the project on. 8000 by default.',
+  https: ' Use https server. http by default.',
   define_experiment_constant:
     '  Builds runtime with the EXPERIMENT constant set to true',
 };


### PR DESCRIPTION
Allow the `--https` flag when starting the dev server.
The `amp-story-360` component will use `DeviceOrientationEvent` which requires https. [WIP PR #29626](https://github.com/ampproject/amphtml/pull/29626).
Adding this flag will allow developers to work on this feature locally.

Current error when running with the flags:
![unnamed](https://user-images.githubusercontent.com/3860311/89560815-9bd2fd80-d7e5-11ea-8b74-fe776694d82c.png)
