### PR TITLE
include intersection observer polyfill back into ESM

### DIFF
--- a/build-system/compile/compile.js
+++ b/build-system/compile/compile.js
@@ -184,13 +184,14 @@ function compile(
       const polyfills = fs.readdirSync('src/polyfills');
       const polyfillsShadowList = polyfills.filter((p) => {
         // custom-elements polyfill must be included.
-        return p !== 'custom-elements.js';
+        return !['custom-elements.js', 'intersection-observer.js'].includes(p);
       });
       srcs.push(
         '!build/fake-module/src/polyfills.js',
         '!build/fake-module/src/polyfills/**/*.js',
         '!build/fake-polyfills/src/polyfills.js',
         'src/polyfills/custom-elements.js',
+        'src/polyfills/intersection-observer.js',
         'build/fake-polyfills/**/*.js'
       );
       polyfillsShadowList.forEach((polyfillFile) => {

--- a/build-system/compile/compile.js
+++ b/build-system/compile/compile.js
@@ -184,6 +184,8 @@ function compile(
       const polyfills = fs.readdirSync('src/polyfills');
       const polyfillsShadowList = polyfills.filter((p) => {
         // custom-elements polyfill must be included.
+        // install intersection-observer to esm build as iOS safari 11.1 to
+        // 12.1 do not have InObs.
         return !['custom-elements.js', 'intersection-observer.js'].includes(p);
       });
       srcs.push(


### PR DESCRIPTION
Not all iOS versions that support module build (esm) has Intersection Observer. (11.1 to 12.1)

we need to install IntersectionObserver polyfill even in module build

as a follow up, we need to get rid of this closure and writefile transform to a babel transform to get rid of this hacky shadow polyfill removal code in compile (cc @rsimha)