### PR TITLE
amp-list: Fix layoutCallback promise chain in SSR path

### DIFF
--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -895,7 +895,7 @@ export class AmpList extends AMP.BaseElement {
         if (elementSrc !== this.element.getAttribute('src')) {
           return;
         }
-        this.scheduleRender_(data, /* append */ false);
+        return this.scheduleRender_(data, /* append */ false);
       });
   }
 

--- a/extensions/amp-list/0.1/test/test-amp-list.js
+++ b/extensions/amp-list/0.1/test/test-amp-list.js
@@ -870,26 +870,34 @@ describes.repeated(
               const listItem = document.createElement('div');
               listItem.setAttribute('role', 'item');
               listContainer.appendChild(listItem);
+
               env.sandbox
                 .stub(ssrTemplateHelper, 'ssr')
                 .returns(Promise.resolve({html}));
               ssrTemplateHelper.applySsrOrCsrTemplate.returns(
-                Promise.resolve(listContainer)
+                Promise.resolve(rendered)
               );
+
               listMock
                 .expects('updateBindings_')
                 .returns(Promise.resolve(listContainer))
                 .once();
+              const renderSpy = env.sandbox.spy();
               listMock
                 .expects('render_')
                 .withExactArgs(listContainer, false)
-                .returns(Promise.resolve());
+                .callsFake(() => {
+                  renderSpy();
+                  return Promise.resolve();
+                })
+                .once();
 
-              ssrTemplateHelper.applySsrOrCsrTemplate
-                .withArgs(element, html)
-                .returns(Promise.resolve(rendered));
-
-              yield list.layoutCallback();
+              const layoutSpy = env.sandbox.spy();
+              yield list.layoutCallback().then(() => {
+                layoutSpy();
+              });
+              // layoutCallback() should be chained to render_().
+              expect(renderSpy).to.be.calledBefore(layoutSpy);
 
               const request = env.sandbox.match({
                 xhrUrl:


### PR DESCRIPTION
Fixes a regression in #25964 which causes `amp-list[layout=container]` to have zero height during render (with SSR). 

This is caused by `firstLayoutCompleted() -> togglePlaceholder(false)` before render of real children finishes, which causes the `layout=container` amp-list to lose its height (defined by its placeholder) have its `height` style locked to 0.