### PR TITLE
amp-list: Allow layout=container and diffable together

### DIFF
--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -318,6 +318,12 @@ export class AmpList extends AMP.BaseElement {
   }
 
   /**
+   * A "diffable placeholder" is just a div[role=list] child without the
+   * [placeholder] attribute.
+   *
+   * It's used to display pre-fetch (stale) list content that can be
+   * DOM diffed with the fetched (fresh) content later.
+   *
    * @return {?Element}
    * @private
    */

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -151,11 +151,8 @@ export class AmpList extends AMP.BaseElement {
      */
     this.initialSrc_ = null;
 
-    /**
-     * Does the amp-list have initial content that's not a placeholder?
-     * @private {boolean}
-     */
-    this.hasInitialContent_ = false;
+    /** @private {?Element|undefined} */
+    this.diffablePlaceholder_ = undefined;
 
     /** @private {?../../../extensions/amp-bind/0.1/bind-impl.Bind} */
     this.bind_ = null;
@@ -206,11 +203,9 @@ export class AmpList extends AMP.BaseElement {
         'Experiment "amp-list-layout-container" is not turned on.'
       );
       userAssert(
-        this.getPlaceholder(),
-        '%s with layout=container relies on a placeholder to determine an initial height. ' +
-          'For more info on adding a placeholder see: ' +
-          'https://go.amp.dev/c/amp-list/#placeholder-and-fallback. %s',
-        TAG,
+        this.getPlaceholder() || this.getDiffablePlaceholder_(),
+        'amp-list[layout=container] requires a placeholder to establish an initial size. ' +
+          'See https://go.amp.dev/c/amp-list/#placeholder-and-fallback. %s',
         this.element
       );
       return (this.enableManagedResizing_ = true);
@@ -250,17 +245,18 @@ export class AmpList extends AMP.BaseElement {
     // is missing attributes in the constructor.
     this.initialSrc_ = this.element.getAttribute('src');
 
-    // TODO(amphtml): Decouple "initial content" from diffing in new version.
     if (this.element.hasAttribute('diffable')) {
-      // Set container to the initial content, if it exists. This allows
-      // us to DOM diff with the rendered result.
-      const initialContent = scopedQuerySelector(
-        this.element,
-        '> div[role=list]:not([placeholder]):not([fallback]):not([fetch-error])'
-      );
-      if (initialContent) {
-        this.container_ = initialContent;
-        this.hasInitialContent_ = true;
+      // Initialize container to the diffable placeholder, if it exists.
+      // This enables DOM diffing with the rendered result.
+      const diffablePlaceholder = this.getDiffablePlaceholder_();
+      if (diffablePlaceholder) {
+        this.container_ = diffablePlaceholder;
+      } else {
+        user().warn(
+          TAG,
+          'Could not find child div[role=list] for diffing.',
+          this.element
+        );
       }
     }
     if (!this.container_) {
@@ -306,7 +302,7 @@ export class AmpList extends AMP.BaseElement {
     const placeholder = this.getPlaceholder();
     if (placeholder) {
       this.attemptToFit_(placeholder);
-    } else if (this.hasInitialContent_) {
+    } else if (this.getDiffablePlaceholder_()) {
       this.attemptToFit_(dev().assertElement(this.container_));
     }
 
@@ -319,6 +315,20 @@ export class AmpList extends AMP.BaseElement {
     }
 
     return this.fetchList_();
+  }
+
+  /**
+   * @return {?Element}
+   * @private
+   */
+  getDiffablePlaceholder_() {
+    if (this.diffablePlaceholder_ === undefined) {
+      this.diffablePlaceholder_ = scopedQuerySelector(
+        this.element,
+        '> div[role=list]:not([placeholder]):not([fallback]):not([fetch-error])'
+      );
+    }
+    return this.diffablePlaceholder_;
   }
 
   /**
@@ -1178,10 +1188,10 @@ export class AmpList extends AMP.BaseElement {
     const newContainer = this.createContainer_();
     this.addElementsToContainer_(elements, newContainer);
 
-    // Typically, diff-marking elements happens during template sanitization.
-    // This obviously doesn't apply to initial content, so we mark them manually
-    // here to enable diffing in the first render.
-    if (this.hasInitialContent_) {
+    // On renders N>1, diff-marking happens during template sanitization.
+    // For render N=1, the placeholder already exists in DOM and is not
+    // sanitized, so mark it manually to enable diffing.
+    if (this.getDiffablePlaceholder_()) {
       this.markContainerForDiffing_(container);
     }
 
@@ -1205,8 +1215,8 @@ export class AmpList extends AMP.BaseElement {
     // to guarantee uniqueness.
     let key = -1;
     // (1) AMP elements and (2) elements with bindings need diff marking.
-    // But, we only need to do (1) here because bindings in initial content
-    // are inert by design (as are bindings in placeholder content).
+    // But, we only need to do (1) here because bindings in the diffable
+    // placeholder are inert by design (as are bindings in normal placeholder).
     const elements = toArray(container.querySelectorAll('.i-amphtml-element'));
     elements.forEach((element) => {
       markElementForDiffing(element, () => String(key--));
@@ -1646,7 +1656,7 @@ export class AmpList extends AMP.BaseElement {
    */
   showFallback_() {
     this.element.classList.add('i-amphtml-list-fetch-error');
-    // Displaying [fetch-error] may offset initial content, so resize to fit.
+    // Displaying [fetch-error] may offset diffable placeholder, so resize to fit.
     if (childElementByAttr(this.element, 'fetch-error')) {
       // Note that we're measuring against the element instead of the container.
       this.attemptToFit_(this.element);

--- a/extensions/amp-list/0.1/test/test-amp-list.js
+++ b/extensions/amp-list/0.1/test/test-amp-list.js
@@ -314,7 +314,7 @@ describes.repeated(
                   list.getPlaceholder = () => null;
                   allowConsoleError(() => {
                     expect(() => list.isLayoutSupported('container')).to.throw(
-                      /amp-list[layout=container] requires a placeholder/
+                      /amp-list\[layout=container\] requires a placeholder/
                     );
                   });
                 });

--- a/extensions/amp-list/0.1/test/test-amp-list.js
+++ b/extensions/amp-list/0.1/test/test-amp-list.js
@@ -314,7 +314,7 @@ describes.repeated(
                   list.getPlaceholder = () => null;
                   allowConsoleError(() => {
                     expect(() => list.isLayoutSupported('container')).to.throw(
-                      /amp-list with layout=container relies on a placeholder/
+                      /amp-list[layout=container] requires a placeholder/
                     );
                   });
                 });


### PR DESCRIPTION
Just avoids the `userAssert` in `isLayoutSupported`. The rest is renaming "initial content" to "diffable placeholder".