### PR TITLE
ContextNode: child props and components with auto-cleanup

### DIFF
--- a/src/context/component-hooks.js
+++ b/src/context/component-hooks.js
@@ -61,6 +61,10 @@ export function useRef(initialValue = undefined) {
 }
 
 /**
+ * Returns a callback with the component passed as the first argument. The
+ * returned function has a stable identity, i.e. it doesn't change in the
+ * lifetime of the component.
+ *
  * @param {function(!./component.Component, ...?):?} callback
  * @return {function(...?):?}
  * @package
@@ -165,29 +169,30 @@ export function useSyncEffect(callback, deps = undefined) {
 }
 
 /**
- * This hook returns a function that can be used to set a child property. A
- * child property can be set on the component's node or any other in the same
- * tree. When this component is removed, all child properties are also removed.
+ * This hook returns a function that can be used to set a managed property. A
+ * managed property can be set on the component's node or any other in the same
+ * tree. When this component is removed, all managed properties are also
+ * removed.
  *
  * See `setProp` for more info.
  *
  * @return {function(!ContextProp<T>, T, !Node=)}
  * @template T
  */
-export function useSetChildProp() {
-  return useComponentCallback(setChildProp);
+export function useSetProp() {
+  return useComponentCallback(setManagedProp);
 }
 
 /**
- * This hook returns a function that can be used to remove a child property,
- * that was previously set by the `useSetChildProp`.
+ * This hook returns a function that can be used to remove a managed property,
+ * that was previously set by the `useSetProp`.
  *
  * See `removeProp` for more info.
  *
  * @return {function(!ContextProp, !Node=)}
  */
-export function useRemoveChildProp() {
-  return useComponentCallback(removeChildProp);
+export function useRemoveProp() {
+  return useComponentCallback(removeManagedProp);
 }
 
 /**
@@ -197,7 +202,7 @@ export function useRemoveChildProp() {
  * @param {!Node|undefined} node
  * @template T
  */
-function setChildProp(component, prop, value, node) {
+function setManagedProp(component, prop, value, node) {
   component.setProp(prop, value, node);
 }
 
@@ -206,7 +211,7 @@ function setChildProp(component, prop, value, node) {
  * @param {!ContextProp} prop
  * @param {!Node|undefined} node
  */
-function removeChildProp(component, prop, node) {
+function removeManagedProp(component, prop, node) {
   component.removeProp(prop, node);
 }
 

--- a/src/context/component-hooks.js
+++ b/src/context/component-hooks.js
@@ -61,6 +61,20 @@ export function useRef(initialValue = undefined) {
 }
 
 /**
+ * @param {function(!./component.Component, ...?):?} callback
+ * @return {function(...?):?}
+ * @package
+ */
+export function useComponentCallback(callback) {
+  const ref = useRef();
+  if (!ref.current) {
+    const component = getComponent();
+    ref.current = callback.bind(null, component);
+  }
+  return ref.current;
+}
+
+/**
  * A hook to compute a persistent value. Mostly the same as the React's
  * `useMemo` API.
  *
@@ -148,6 +162,52 @@ export function useSyncEffect(callback, deps = undefined) {
     cleanupRef.current = newCleanup;
     component.pushCleanup(newCleanup);
   }
+}
+
+/**
+ * This hook returns a function that can be used to set a child property. A
+ * child property can be set on the component's node or any other in the same
+ * tree. When this component is removed, all child properties are also removed.
+ *
+ * See `setProp` for more info.
+ *
+ * @return {function(!ContextProp<T>, T, !Node=)}
+ * @template T
+ */
+export function useSetChildProp() {
+  return useComponentCallback(setChildProp);
+}
+
+/**
+ * This hook returns a function that can be used to remove a child property,
+ * that was previously set by the `useSetChildProp`.
+ *
+ * See `removeProp` for more info.
+ *
+ * @return {function(!ContextProp, !Node=)}
+ */
+export function useRemoveChildProp() {
+  return useComponentCallback(removeChildProp);
+}
+
+/**
+ * @param {!./component.Component} component
+ * @param {!ContextProp<T>} prop
+ * @param {T} value
+ * @param {!Node|undefined} node
+ * @template T
+ */
+function setChildProp(component, prop, value, node) {
+  component.setProp(prop, value, node);
+}
+
+/**
+ * @param {!./component.Component} component
+ * @param {!ContextProp} prop
+ * @param {!Node|undefined} node
+ */
+function removeChildProp(component, prop, node) {
+  component.removeProp(prop, node);
 }
 
 /**

--- a/src/context/component-hooks.js
+++ b/src/context/component-hooks.js
@@ -69,7 +69,7 @@ export function useRef(initialValue = undefined) {
  * @return {function(...?):?}
  * @package
  */
-export function useComponentCallback(callback) {
+export function useInternalCallbackWithComponent(callback) {
   const ref = useRef();
   if (!ref.current) {
     const component = getComponent();
@@ -180,7 +180,7 @@ export function useSyncEffect(callback, deps = undefined) {
  * @template T
  */
 export function useSetProp() {
-  return useComponentCallback(setManagedProp);
+  return useInternalCallbackWithComponent(setManagedProp);
 }
 
 /**
@@ -192,7 +192,7 @@ export function useSetProp() {
  * @return {function(!ContextProp, !Node=)}
  */
 export function useRemoveProp() {
-  return useComponentCallback(removeManagedProp);
+  return useInternalCallbackWithComponent(removeManagedProp);
 }
 
 /**

--- a/src/context/component-install.js
+++ b/src/context/component-install.js
@@ -18,7 +18,7 @@ import {Component} from './component';
 import {ContextNode} from './node';
 import {arrayOrSingleItemToArray} from '../types';
 import {getDeps, getId} from './component-meta';
-import {useComponentCallback} from './component-hooks';
+import {useInternalCallbackWithComponent} from './component-hooks';
 
 const NO_INPUT = undefined;
 
@@ -97,7 +97,7 @@ export function unsubscribe(node, callback) {
  * @template I
  */
 export function useMountComponent() {
-  return useComponentCallback(mountManagedComponent);
+  return useInternalCallbackWithComponent(mountManagedComponent);
 }
 
 /**
@@ -109,7 +109,7 @@ export function useMountComponent() {
  * @return {function(function(...?), !Node=)}
  */
 export function useUnmountComponent() {
-  return useComponentCallback(unmountManagedComponent);
+  return useInternalCallbackWithComponent(unmountManagedComponent);
 }
 
 /**
@@ -123,7 +123,7 @@ export function useUnmountComponent() {
  * @return {function((!ContextProp|!Array<!ContextProp>), function(...?), !Node=)}
  */
 export function useSubscribe() {
-  return useComponentCallback(subscribeManaged);
+  return useInternalCallbackWithComponent(subscribeManaged);
 }
 
 /**
@@ -135,7 +135,7 @@ export function useSubscribe() {
  * @return {function(function(...?), !Node=)}
  */
 export function useUnsubscribe() {
-  return useComponentCallback(unmountManagedComponent);
+  return useInternalCallbackWithComponent(unmountManagedComponent);
 }
 
 /**

--- a/src/context/component-install.js
+++ b/src/context/component-install.js
@@ -18,6 +18,7 @@ import {Component} from './component';
 import {ContextNode} from './node';
 import {getDeps, getId} from './component-meta';
 import {isArray} from '../types';
+import {useComponentCallback} from './component-hooks';
 
 const NO_INPUT = undefined;
 
@@ -81,6 +82,99 @@ export function subscribe(node, deps, callback) {
  */
 export function unsubscribe(node, callback) {
   removeComponent(node, callback);
+}
+
+/**
+ * This hook returns a function that can be used to set a child component. A
+ * child component can be set on this component's node or any other in the same
+ * tree. When this component is removed, all child components are also removed.
+ *
+ * See `setComponent` for more info.
+ *
+ * @return {function(function(!Node, I, ...?), I, !Node=)}
+ * @template I
+ */
+export function useSetChildComponent() {
+  return useComponentCallback(setChildComponent);
+}
+
+/**
+ * This hook returns a function that can be used to remove a child component,
+ * that was previously set by the `useSetChildComponent`.
+ *
+ * See `removeComponent` for more info.
+ *
+ * @return {function(function(...?), !Node=)}
+ */
+export function useRemoveChildComponent() {
+  return useComponentCallback(removeChildComponent);
+}
+
+/**
+ * This hook returns a function that can be used to set a child subscriber. A
+ * child subscriber can be set on this component's node or any other in the same
+ * tree. When this component is removed, all child subscribers are also removed.
+ *
+ * See `subscribe` for more info.
+ *
+ * @return {function((!ContextProp|!Array<!ContextProp>), function(...?), !Node=)}
+ */
+export function useSubscribeChild() {
+  return useComponentCallback(subscribeChild);
+}
+
+/**
+ * This hook returns a function that can be used to remove a child subscriber,
+ * that was previously set by the `useSubscribeChild`.
+ *
+ * See `unsubscribe` for more info.
+ *
+ * @return {function(function(...?), !Node=)}
+ */
+export function useUnsubscribeChild() {
+  return useComponentCallback(removeChildComponent);
+}
+
+/**
+ * @param {!Component} component
+ * @param {function(!Node, I, ...?)} func
+ * @param {I} input
+ * @param {!Node|undefined} node
+ * @template I
+ */
+function setChildComponent(component, func, input, node) {
+  const id = getId(func);
+  const deps = getDeps(func);
+  component.setComponent(
+    id,
+    componentWithInputFactory,
+    func,
+    deps,
+    input,
+    node
+  );
+}
+
+/**
+ * @param {!Component} component
+ * @param {function(...?)} func
+ * @param {!Node} node
+ */
+function removeChildComponent(component, func, node) {
+  const id = getId(func);
+  component.removeComponent(id, node);
+}
+
+/**
+ * @param {!Component} component
+ * @param {!ContextProp|!Array<!ContextProp>} deps
+ * @param {function(...?)} callback
+ * @param {!Node|undefined} node
+ */
+function subscribeChild(component, deps, callback, node) {
+  deps = isArray(deps) ? /** @type {!Array<!ContextProp>} */ (deps) : [deps];
+  const id = getId(callback);
+  component.setComponent(id, subscriberFactory, callback, deps, NO_INPUT, node);
 }
 
 /**

--- a/src/context/component.js
+++ b/src/context/component.js
@@ -127,7 +127,7 @@ export class Component {
 
   /**
    * Called when the component is completely discarded, for instance via
-   * `removeComponent` API.
+   * `unmountComponent` API.
    */
   dispose() {
     // Unsubscribe from all dependencies.
@@ -272,11 +272,11 @@ export class Component {
    * @param {!Node=} node
    * @package
    */
-  setComponent(id, factory, func, deps, input, node = undefined) {
+  mountComponent(id, factory, func, deps, input, node = undefined) {
     const contextNode = node ? ContextNode.get(node) : this.contextNode;
 
     // Set the component.
-    contextNode.setComponent(id, factory, func, deps, input);
+    contextNode.mountComponent(id, factory, func, deps, input);
 
     // Track the child component on the node.
     const childComps = this.childComps_ || (this.childComps_ = new Map());
@@ -294,17 +294,17 @@ export class Component {
   }
 
   /**
-   * Removes the child component previously set by the `setComponent`.
+   * Removes the child component previously set by the `mountComponent`.
    *
    * @param {*} id
    * @param {!Node=} node
    * @package
    */
-  removeComponent(id, node = undefined) {
+  unmountComponent(id, node = undefined) {
     const contextNode = node ? ContextNode.get(node) : this.contextNode;
 
     // Remove the component.
-    contextNode.removeComponent(id);
+    contextNode.unmountComponent(id);
 
     // Untrack the child component.
     const childComps = this.childComps_;
@@ -378,7 +378,7 @@ export class Component {
         this.childComps_ = null;
         childComps.forEach((comps, contextNode) => {
           comps.forEach((id) => {
-            contextNode.removeComponent(id);
+            contextNode.unmountComponent(id);
           });
         });
       }
@@ -444,7 +444,7 @@ export class Component {
     const comps = childComps && childComps.get(child);
     if (comps) {
       childComps.delete(child);
-      comps.forEach((id) => child.removeComponent(id));
+      comps.forEach((id) => child.unmountComponent(id));
     }
   }
 }

--- a/src/context/component.js
+++ b/src/context/component.js
@@ -365,16 +365,17 @@ export class Component {
     if (cleanupChildren) {
       const childProps = this.childProps_;
       if (childProps) {
+        this.childProps_ = null;
         childProps.forEach((props, contextNode) => {
           props.forEach((prop) => {
             contextNode.values.remove(prop, /* setter */ this);
           });
         });
-        this.childProps_ = null;
       }
 
       const childComps = this.childComps_;
       if (childComps) {
+        this.childComps_ = null;
         childComps.forEach((comps, contextNode) => {
           comps.forEach((id) => {
             contextNode.removeComponent(id);

--- a/src/context/index.js
+++ b/src/context/index.js
@@ -23,12 +23,18 @@ export {
   removeComponent,
   subscribe,
   unsubscribe,
+  useSetChildComponent,
+  useRemoveChildComponent,
+  useSubscribeChild,
+  useUnsubscribeChild,
 } from './component-install';
 export {
   useRef,
   useMemo,
   useDisposableMemo,
   useSyncEffect,
+  useSetChildProp,
+  useRemoveChildProp,
 } from './component-hooks';
 
 /**

--- a/src/context/index.js
+++ b/src/context/index.js
@@ -19,22 +19,22 @@ import {ContextNode} from './node';
 export {contextProp} from './prop';
 export {withMetaData} from './component-meta';
 export {
-  setComponent,
-  removeComponent,
+  mountComponent,
+  unmountComponent,
   subscribe,
   unsubscribe,
-  useSetChildComponent,
-  useRemoveChildComponent,
-  useSubscribeChild,
-  useUnsubscribeChild,
+  useMountComponent,
+  useUnmountComponent,
+  useSubscribe,
+  useUnsubscribe,
 } from './component-install';
 export {
   useRef,
   useMemo,
   useDisposableMemo,
   useSyncEffect,
-  useSetChildProp,
-  useRemoveChildProp,
+  useSetProp,
+  useRemoveProp,
 } from './component-hooks';
 
 /**

--- a/src/context/node.js
+++ b/src/context/node.js
@@ -313,7 +313,7 @@ export class ContextNode {
    * @param {!Array<!ContextProp>} deps
    * @param {*} input
    */
-  setComponent(id, factory, func, deps, input) {
+  mountComponent(id, factory, func, deps, input) {
     const components = this.components_ || (this.components_ = new Map());
     let comp = components.get(id);
     if (!comp) {
@@ -324,11 +324,11 @@ export class ContextNode {
   }
 
   /**
-   * Removes the component previously set with `setComponent`.
+   * Removes the component previously set with `mountComponent`.
    *
    * @param {*} id
    */
-  removeComponent(id) {
+  unmountComponent(id) {
     const components = this.components_;
     const comp = components && components.get(id);
     if (comp) {

--- a/src/types.js
+++ b/src/types.js
@@ -46,6 +46,19 @@ export function toArray(arrayLike) {
 }
 
 /**
+ * If the specified argument is an array, it's returned as is. If it's a
+ * single item, the array containing this item is created and returned.
+ * @param {!Array<T>|T} arrayOrSingleItem
+ * @return {!Array<T>}
+ * @template T
+ */
+export function arrayOrSingleItemToArray(arrayOrSingleItem) {
+  return isArray(arrayOrSingleItem)
+    ? /** @type {!Array<T>} */ (arrayOrSingleItem)
+    : [arrayOrSingleItem];
+}
+
+/**
  * Determines if value is actually an Object.
  * @param {*} value
  * @return {boolean}

--- a/test/unit/context/test-node-components.js
+++ b/test/unit/context/test-node-components.js
@@ -17,21 +17,21 @@
 import {ContextNode} from '../../../src/context/node';
 import {contextProp} from '../../../src/context/prop';
 import {
-  removeComponent,
-  setComponent,
+  mountComponent,
   subscribe,
+  unmountComponent,
   unsubscribe,
-  useRemoveChildComponent,
-  useSetChildComponent,
-  useSubscribeChild,
-  useUnsubscribeChild,
+  useMountComponent,
+  useSubscribe,
+  useUnmountComponent,
+  useUnsubscribe,
 } from '../../../src/context/component-install';
 import {
   useDisposableMemo,
   useMemo,
   useRef,
-  useRemoveChildProp,
-  useSetChildProp,
+  useRemoveProp,
+  useSetProp,
   useSyncEffect,
 } from '../../../src/context/component-hooks';
 import {withMetaData} from '../../../src/context/component-meta';
@@ -185,7 +185,7 @@ describes.realWin('ContextNode - components', {}, (env) => {
       });
 
       it('should only call component once w/o input', () => {
-        setComponent(parent.node, Component1);
+        mountComponent(parent.node, Component1);
         expect(component1Spy).to.not.be.called;
 
         clock.runAll();
@@ -194,29 +194,29 @@ describes.realWin('ContextNode - components', {}, (env) => {
           undefined
         );
 
-        setComponent(parent.node, Component1);
+        mountComponent(parent.node, Component1);
         clock.runAll();
         expect(component1Spy).to.be.calledOnce; // no changes.
       });
 
       it('should only call component once per input', () => {
-        setComponent(parent.node, Component1, 1);
+        mountComponent(parent.node, Component1, 1);
         clock.runAll();
         expect(component1Spy).to.be.calledOnce.calledWith(parent.node, 1);
 
         // Rerun the component due to the input change.
-        setComponent(parent.node, Component1, 2);
+        mountComponent(parent.node, Component1, 2);
         clock.runAll();
         expect(component1Spy).to.be.calledTwice.calledWith(parent.node, 2);
 
         // Input didn't change - do not rerun.
-        setComponent(parent.node, Component1, 2);
+        mountComponent(parent.node, Component1, 2);
         clock.runAll();
         expect(component1Spy).to.be.calledTwice;
       });
 
       it('should reconnect component when the node is reconnected', async () => {
-        setComponent(parent.node, Component1, 1);
+        mountComponent(parent.node, Component1, 1);
         clock.runAll();
         expect(component1Spy).to.be.calledOnce.calledWith(parent.node, 1);
 
@@ -224,7 +224,7 @@ describes.realWin('ContextNode - components', {}, (env) => {
         await rediscover(parent);
         clock.runAll();
 
-        setComponent(parent.node, Component1, 2);
+        mountComponent(parent.node, Component1, 2);
         clock.runAll();
         expect(component1Spy).to.be.calledOnce;
 
@@ -235,7 +235,7 @@ describes.realWin('ContextNode - components', {}, (env) => {
       });
 
       it('should wait until all deps satisfied', () => {
-        setComponent(parent.node, ComponentWithDeps, 1);
+        mountComponent(parent.node, ComponentWithDeps, 1);
 
         clock.runAll();
         expect(componentWithDepsSpy).to.not.be.called;
@@ -263,7 +263,7 @@ describes.realWin('ContextNode - components', {}, (env) => {
       });
 
       it('should cleanup on input change and removal', () => {
-        setComponent(parent.node, ComponentWithCleanup, 1);
+        mountComponent(parent.node, ComponentWithCleanup, 1);
 
         clock.runAll();
         expect(cleanupSpy).to.not.be.called;
@@ -272,7 +272,7 @@ describes.realWin('ContextNode - components', {}, (env) => {
           1
         );
 
-        setComponent(parent.node, ComponentWithCleanup, 2);
+        mountComponent(parent.node, ComponentWithCleanup, 2);
 
         clock.runAll();
         expect(cleanupSpy).to.be.calledOnce;
@@ -283,7 +283,7 @@ describes.realWin('ContextNode - components', {}, (env) => {
       });
 
       it('should cleanup on removal', () => {
-        setComponent(parent.node, ComponentWithCleanup, 1);
+        mountComponent(parent.node, ComponentWithCleanup, 1);
 
         clock.runAll();
         expect(cleanupSpy).to.not.be.called;
@@ -292,14 +292,14 @@ describes.realWin('ContextNode - components', {}, (env) => {
           1
         );
 
-        removeComponent(parent.node, ComponentWithCleanup);
+        unmountComponent(parent.node, ComponentWithCleanup);
         clock.runAll();
         expect(cleanupSpy).to.be.calledOnce;
         expect(componentWithCleanupSpy).to.be.calledOnce; // no change.
       });
 
       it('should cleanup on disconnect', async () => {
-        setComponent(parent.node, ComponentWithCleanup, 1);
+        mountComponent(parent.node, ComponentWithCleanup, 1);
 
         clock.runAll();
         expect(cleanupSpy).to.not.be.called;
@@ -440,13 +440,13 @@ describes.realWin('ContextNode - components', {}, (env) => {
         };
 
         // 1st call.
-        setComponent(parent.node, Comp, 1);
+        mountComponent(parent.node, Comp, 1);
         clock.runAll();
         expect(values).to.have.length(1);
         expect(values[0]).to.equal(11);
 
         // 2nd call.
-        setComponent(parent.node, Comp, 2);
+        mountComponent(parent.node, Comp, 2);
         clock.runAll();
         expect(values).to.have.length(2);
         expect(values[0]).to.equal(12);
@@ -465,21 +465,21 @@ describes.realWin('ContextNode - components', {}, (env) => {
         };
 
         // 1st call.
-        setComponent(parent.node, Comp, 1);
+        mountComponent(parent.node, Comp, 1);
         clock.runAll();
         expect(values).to.have.length(1);
         expect(values[0]).to.equal(0);
         expect(memoSpy).to.be.calledOnce;
 
         // 2nd call: no recompute.
-        setComponent(parent.node, Comp, 2);
+        mountComponent(parent.node, Comp, 2);
         clock.runAll();
         expect(values).to.have.length(2);
         expect(values[0]).to.equal(0);
         expect(memoSpy).to.be.calledOnce; // no change.
 
         // 3rd call: recompute.
-        setComponent(parent.node, Comp, 12);
+        mountComponent(parent.node, Comp, 12);
         clock.runAll();
         expect(values).to.have.length(3);
         expect(values[0]).to.equal(1);
@@ -502,7 +502,7 @@ describes.realWin('ContextNode - components', {}, (env) => {
         };
 
         // 1st call: init.
-        setComponent(parent.node, Comp, 1);
+        mountComponent(parent.node, Comp, 1);
         clock.runAll();
         expect(values).to.have.length(1);
         expect(values[0]).to.equal(0);
@@ -510,7 +510,7 @@ describes.realWin('ContextNode - components', {}, (env) => {
         expect(disposeSpy).to.not.be.called;
 
         // 2nd call: reuse.
-        setComponent(parent.node, Comp, 2);
+        mountComponent(parent.node, Comp, 2);
         clock.runAll();
         expect(values).to.have.length(2);
         expect(values[0]).to.equal(0);
@@ -518,7 +518,7 @@ describes.realWin('ContextNode - components', {}, (env) => {
         expect(disposeSpy).to.not.be.called; // no change.
 
         // 3rd call: re-init.
-        setComponent(parent.node, Comp, 12);
+        mountComponent(parent.node, Comp, 12);
         clock.runAll();
         expect(values).to.have.length(3);
         expect(values[0]).to.equal(1);
@@ -526,7 +526,7 @@ describes.realWin('ContextNode - components', {}, (env) => {
         expect(disposeSpy).to.be.calledOnce;
 
         // Remove.
-        removeComponent(parent.node, Comp);
+        unmountComponent(parent.node, Comp);
         clock.runAll();
         expect(disposeSpy).to.be.calledTwice;
         expect(values).to.have.length(3); // no change.
@@ -544,25 +544,25 @@ describes.realWin('ContextNode - components', {}, (env) => {
         };
 
         // 1st call.
-        setComponent(parent.node, Comp, 1);
+        mountComponent(parent.node, Comp, 1);
         clock.runAll();
         expect(effectSpy).to.be.calledOnce.calledWith(1);
         expect(cleanupSpy).to.not.be.called;
 
         // 2nd call: no-op.
-        setComponent(parent.node, Comp, 2);
+        mountComponent(parent.node, Comp, 2);
         clock.runAll();
         expect(effectSpy).to.be.calledOnce; // no change.
         expect(cleanupSpy).to.not.be.called; // no change.
 
         // 3rd call: re-run.
-        setComponent(parent.node, Comp, 12);
+        mountComponent(parent.node, Comp, 12);
         clock.runAll();
         expect(effectSpy).to.be.calledTwice.calledWith(12);
         expect(cleanupSpy).to.be.calledOnce;
 
         // Remove.
-        removeComponent(parent.node, Comp);
+        unmountComponent(parent.node, Comp);
         clock.runAll();
         expect(cleanupSpy).to.be.calledTwice;
         expect(effectSpy).to.be.calledTwice; // no change.
@@ -579,49 +579,49 @@ describes.realWin('ContextNode - components', {}, (env) => {
         };
 
         // 1st call.
-        setComponent(parent.node, Comp, 1);
+        mountComponent(parent.node, Comp, 1);
         clock.runAll();
         expect(effectSpy).to.be.calledOnce.calledWith(1);
         expect(cleanupSpy).to.not.be.called;
 
         // 2nd call: no-op.
-        setComponent(parent.node, Comp, 2);
+        mountComponent(parent.node, Comp, 2);
         clock.runAll();
         expect(effectSpy).to.be.calledOnce; // no change.
         expect(cleanupSpy).to.not.be.called; // no change.
 
         // Remove.
-        removeComponent(parent.node, Comp);
+        unmountComponent(parent.node, Comp);
         clock.runAll();
         expect(cleanupSpy).to.be.calledOnce;
         expect(effectSpy).to.be.calledOnce; // no change.
       });
     });
 
-    describe('child props', () => {
-      let ComponentSelfProps;
-      let ComponentParentProps;
+    describe('autocleanup props', () => {
+      let ComponentSettingPropsOnSelf;
+      let ComponentSettingPropsOnOther;
       let sibling1Stub;
       let parentStub;
       let grandparentStub;
 
       beforeEach(() => {
-        ComponentSelfProps = (unusedNode, input) => {
-          const setChildProp = useSetChildProp();
-          const removeChildProp = useRemoveChildProp();
+        ComponentSettingPropsOnSelf = (unusedNode, input) => {
+          const setProp = useSetProp();
+          const removeProp = useRemoveProp();
           if (input) {
-            setChildProp(Concat, input);
+            setProp(Concat, input);
           } else {
-            removeChildProp(Concat);
+            removeProp(Concat);
           }
         };
-        ComponentParentProps = (unusedNode, input) => {
-          const setChildProp = useSetChildProp();
-          const removeChildProp = useRemoveChildProp();
+        ComponentSettingPropsOnOther = (unusedNode, input) => {
+          const setProp = useSetProp();
+          const removeProp = useRemoveProp();
           if (input) {
-            setChildProp(Concat, input, parent.node);
+            setProp(Concat, input, parent.node);
           } else {
-            removeChildProp(Concat, parent.node);
+            removeProp(Concat, parent.node);
           }
         };
 
@@ -638,13 +638,13 @@ describes.realWin('ContextNode - components', {}, (env) => {
       });
 
       it('should set props in components', () => {
-        setComponent(grandparent.node, ComponentSelfProps, 'A');
+        mountComponent(grandparent.node, ComponentSettingPropsOnSelf, 'A');
         clock.runAll();
         expect(sibling1Stub).to.be.calledOnce.calledWith('A');
         expect(parentStub).to.be.calledOnce.calledWith('A');
         expect(grandparentStub).to.be.calledOnce.calledWith('A');
 
-        setComponent(grandparent.node, ComponentParentProps, 'B');
+        mountComponent(grandparent.node, ComponentSettingPropsOnOther, 'B');
         clock.runAll();
         expect(sibling1Stub).to.be.calledTwice.calledWith('AB');
         expect(parentStub).to.be.calledTwice.calledWith('AB');
@@ -652,20 +652,20 @@ describes.realWin('ContextNode - components', {}, (env) => {
       });
 
       it('should remove props', () => {
-        setComponent(grandparent.node, ComponentSelfProps, 'A');
-        setComponent(grandparent.node, ComponentParentProps, 'B');
+        mountComponent(grandparent.node, ComponentSettingPropsOnSelf, 'A');
+        mountComponent(grandparent.node, ComponentSettingPropsOnOther, 'B');
         clock.runAll();
         expect(sibling1Stub).to.be.calledOnce.calledWith('AB');
         expect(parentStub).to.be.calledOnce.calledWith('AB');
         expect(grandparentStub).to.be.calledOnce.calledWith('A');
 
-        setComponent(grandparent.node, ComponentSelfProps, null);
+        mountComponent(grandparent.node, ComponentSettingPropsOnSelf, null);
         clock.runAll();
         expect(sibling1Stub).to.be.calledTwice.calledWith('B');
         expect(parentStub).to.be.calledTwice.calledWith('B');
         expect(grandparentStub).to.be.calledTwice.calledWith('');
 
-        setComponent(grandparent.node, ComponentParentProps, null);
+        mountComponent(grandparent.node, ComponentSettingPropsOnOther, null);
         clock.runAll();
         expect(sibling1Stub).to.be.calledThrice.calledWith('');
         expect(parentStub).to.be.calledThrice.calledWith('');
@@ -673,20 +673,20 @@ describes.realWin('ContextNode - components', {}, (env) => {
       });
 
       it('should remove props when component is disconnected', () => {
-        setComponent(grandparent.node, ComponentSelfProps, 'A');
-        setComponent(grandparent.node, ComponentParentProps, 'B');
+        mountComponent(grandparent.node, ComponentSettingPropsOnSelf, 'A');
+        mountComponent(grandparent.node, ComponentSettingPropsOnOther, 'B');
         clock.runAll();
         expect(sibling1Stub).to.be.calledOnce.calledWith('AB');
         expect(parentStub).to.be.calledOnce.calledWith('AB');
         expect(grandparentStub).to.be.calledOnce.calledWith('A');
 
-        removeComponent(grandparent.node, ComponentSelfProps);
+        unmountComponent(grandparent.node, ComponentSettingPropsOnSelf);
         clock.runAll();
         expect(sibling1Stub).to.be.calledTwice.calledWith('B');
         expect(parentStub).to.be.calledTwice.calledWith('B');
         expect(grandparentStub).to.be.calledTwice.calledWith('');
 
-        removeComponent(grandparent.node, ComponentParentProps);
+        unmountComponent(grandparent.node, ComponentSettingPropsOnOther);
         clock.runAll();
         expect(sibling1Stub).to.be.calledThrice.calledWith('');
         expect(parentStub).to.be.calledThrice.calledWith('');
@@ -694,8 +694,8 @@ describes.realWin('ContextNode - components', {}, (env) => {
       });
 
       it('should remove props when child node is disconnected', async () => {
-        setComponent(grandparent.node, ComponentSelfProps, 'A');
-        setComponent(grandparent.node, ComponentParentProps, 'B');
+        mountComponent(grandparent.node, ComponentSettingPropsOnSelf, 'A');
+        mountComponent(grandparent.node, ComponentSettingPropsOnOther, 'B');
         clock.runAll();
         expect(sibling1Stub).to.be.calledOnce.calledWith('AB');
         expect(parentStub).to.be.calledOnce.calledWith('AB');
@@ -709,8 +709,8 @@ describes.realWin('ContextNode - components', {}, (env) => {
       });
 
       it('should remove props when the node is disconnected', async () => {
-        setComponent(grandparent.node, ComponentSelfProps, 'A');
-        setComponent(grandparent.node, ComponentParentProps, 'B');
+        mountComponent(grandparent.node, ComponentSettingPropsOnSelf, 'A');
+        mountComponent(grandparent.node, ComponentSettingPropsOnOther, 'B');
         clock.runAll();
         expect(sibling1Stub).to.be.calledOnce.calledWith('AB');
         expect(parentStub).to.be.calledOnce.calledWith('AB');
@@ -724,156 +724,212 @@ describes.realWin('ContextNode - components', {}, (env) => {
       });
     });
 
-    describe('child components', () => {
-      let ComponentSelfChildren;
-      let ComponentParentChildren;
-      let ChildComponent, childComponentSpy, childCleanupSpy;
+    describe('subcomponents', () => {
+      let ComponentMountingSubcomponentsOnSelf;
+      let ComponentMountingSubcomponentsOnOther;
+      let Subcomponent, subcomponentSpy, subcomponentCleanupSpy;
 
       beforeEach(() => {
-        ComponentSelfChildren = (unusedNode, input) => {
-          const setChildComponent = useSetChildComponent();
-          const removeChildComponent = useRemoveChildComponent();
+        ComponentMountingSubcomponentsOnSelf = (unusedNode, input) => {
+          const mountComponent = useMountComponent();
+          const unmountComponent = useUnmountComponent();
           if (input) {
-            setChildComponent(ChildComponent, input);
+            mountComponent(Subcomponent, input);
           } else {
-            removeChildComponent(ChildComponent);
+            unmountComponent(Subcomponent);
           }
         };
-        ComponentParentChildren = (unusedNode, input) => {
-          const setChildComponent = useSetChildComponent();
-          const removeChildComponent = useRemoveChildComponent();
+        ComponentMountingSubcomponentsOnOther = (unusedNode, input) => {
+          const mountComponent = useMountComponent();
+          const unmountComponent = useUnmountComponent();
           if (input) {
-            setChildComponent(ChildComponent, input, parent.node);
+            mountComponent(Subcomponent, input, parent.node);
           } else {
-            removeChildComponent(ChildComponent, parent.node);
+            unmountComponent(Subcomponent, parent.node);
           }
         };
 
-        childComponentSpy = sandbox.spy();
-        childCleanupSpy = sandbox.spy();
-        ChildComponent = function (...args) {
-          childComponentSpy.apply(null, args);
-          useSyncEffect(() => childCleanupSpy);
+        subcomponentSpy = sandbox.spy();
+        subcomponentCleanupSpy = sandbox.spy();
+        Subcomponent = function (...args) {
+          subcomponentSpy.apply(null, args);
+          useSyncEffect(() => subcomponentCleanupSpy);
         };
       });
 
-      it('should set child component', () => {
-        setComponent(grandparent.node, ComponentSelfChildren, 'A');
+      it('should set a subcomponent', () => {
+        mountComponent(
+          grandparent.node,
+          ComponentMountingSubcomponentsOnSelf,
+          'A'
+        );
         clock.runAll();
-        expect(childComponentSpy).to.be.calledOnce.calledWith(
+        expect(subcomponentSpy).to.be.calledOnce.calledWith(
           grandparent.node,
           'A'
         );
 
-        setComponent(grandparent.node, ComponentParentChildren, 'B');
-        clock.runAll();
-        expect(childComponentSpy).to.be.calledTwice.calledWith(
-          parent.node,
+        mountComponent(
+          grandparent.node,
+          ComponentMountingSubcomponentsOnOther,
           'B'
         );
+        clock.runAll();
+        expect(subcomponentSpy).to.be.calledTwice.calledWith(parent.node, 'B');
 
-        expect(childCleanupSpy).to.not.be.called;
+        expect(subcomponentCleanupSpy).to.not.be.called;
       });
 
-      it('should remove child component', () => {
-        setComponent(grandparent.node, ComponentSelfChildren, 'A');
+      it('should remove a subcomponent', () => {
+        mountComponent(
+          grandparent.node,
+          ComponentMountingSubcomponentsOnSelf,
+          'A'
+        );
         clock.runAll();
-        expect(childComponentSpy).to.be.calledOnce.calledWith(
+        expect(subcomponentSpy).to.be.calledOnce.calledWith(
           grandparent.node,
           'A'
         );
 
-        setComponent(grandparent.node, ComponentParentChildren, 'B');
-        clock.runAll();
-        expect(childComponentSpy).to.be.calledTwice.calledWith(
-          parent.node,
+        mountComponent(
+          grandparent.node,
+          ComponentMountingSubcomponentsOnOther,
           'B'
         );
+        clock.runAll();
+        expect(subcomponentSpy).to.be.calledTwice.calledWith(parent.node, 'B');
 
         // Null input removes the component.
-        setComponent(grandparent.node, ComponentParentChildren, null);
+        mountComponent(
+          grandparent.node,
+          ComponentMountingSubcomponentsOnOther,
+          null
+        );
         clock.runAll();
-        expect(childComponentSpy).to.be.calledTwice; // no changes.
-        expect(childCleanupSpy).to.be.calledOnce;
+        expect(subcomponentSpy).to.be.calledTwice; // no changes.
+        expect(subcomponentCleanupSpy).to.be.calledOnce;
 
-        setComponent(grandparent.node, ComponentSelfChildren, null);
+        mountComponent(
+          grandparent.node,
+          ComponentMountingSubcomponentsOnSelf,
+          null
+        );
         clock.runAll();
-        expect(childComponentSpy).to.be.calledTwice; // no changes.
-        expect(childCleanupSpy).to.be.calledTwice;
+        expect(subcomponentSpy).to.be.calledTwice; // no changes.
+        expect(subcomponentCleanupSpy).to.be.calledTwice;
       });
 
-      it('should update child component', () => {
-        setComponent(grandparent.node, ComponentSelfChildren, 'A');
+      it('should update a subcomponent', () => {
+        mountComponent(
+          grandparent.node,
+          ComponentMountingSubcomponentsOnSelf,
+          'A'
+        );
         clock.runAll();
-        expect(childComponentSpy).to.be.calledOnce.calledWith(
+        expect(subcomponentSpy).to.be.calledOnce.calledWith(
           grandparent.node,
           'A'
         );
 
-        setComponent(grandparent.node, ComponentSelfChildren, 'B');
+        mountComponent(
+          grandparent.node,
+          ComponentMountingSubcomponentsOnSelf,
+          'B'
+        );
         clock.runAll();
-        expect(childComponentSpy).to.be.calledTwice.calledWith(
+        expect(subcomponentSpy).to.be.calledTwice.calledWith(
           grandparent.node,
           'B'
         );
 
-        expect(childCleanupSpy).to.not.be.called;
+        expect(subcomponentCleanupSpy).to.not.be.called;
       });
 
-      it('should remove child component on removal', () => {
-        setComponent(grandparent.node, ComponentSelfChildren, 'A');
-        setComponent(grandparent.node, ComponentParentChildren, 'B');
+      it('should remove a subcomponent on removal', () => {
+        mountComponent(
+          grandparent.node,
+          ComponentMountingSubcomponentsOnSelf,
+          'A'
+        );
+        mountComponent(
+          grandparent.node,
+          ComponentMountingSubcomponentsOnOther,
+          'B'
+        );
         clock.runAll();
-        expect(childComponentSpy)
+        expect(subcomponentSpy)
           .to.be.calledTwice.calledWith(grandparent.node, 'A')
           .calledWith(parent.node, 'B');
-        expect(childCleanupSpy).to.not.be.called;
+        expect(subcomponentCleanupSpy).to.not.be.called;
 
-        removeComponent(grandparent.node, ComponentSelfChildren);
+        unmountComponent(
+          grandparent.node,
+          ComponentMountingSubcomponentsOnSelf
+        );
         clock.runAll();
-        expect(childCleanupSpy).to.be.calledOnce;
+        expect(subcomponentCleanupSpy).to.be.calledOnce;
 
-        removeComponent(grandparent.node, ComponentParentChildren);
+        unmountComponent(
+          grandparent.node,
+          ComponentMountingSubcomponentsOnOther
+        );
         clock.runAll();
-        expect(childCleanupSpy).to.be.calledTwice;
+        expect(subcomponentCleanupSpy).to.be.calledTwice;
       });
 
       it('should remove component when child node is disconnected', async () => {
-        setComponent(grandparent.node, ComponentSelfChildren, 'A');
-        setComponent(grandparent.node, ComponentParentChildren, 'B');
+        mountComponent(
+          grandparent.node,
+          ComponentMountingSubcomponentsOnSelf,
+          'A'
+        );
+        mountComponent(
+          grandparent.node,
+          ComponentMountingSubcomponentsOnOther,
+          'B'
+        );
         clock.runAll();
-        expect(childComponentSpy)
+        expect(subcomponentSpy)
           .to.be.calledTwice.calledWith(grandparent.node, 'A')
           .calledWith(parent.node, 'B');
-        expect(childCleanupSpy).to.not.be.called;
+        expect(subcomponentCleanupSpy).to.not.be.called;
 
         parent.node.remove();
         await rediscover(parent);
         clock.runAll();
-        expect(childComponentSpy).to.be.calledTwice; // no changes.
-        expect(childCleanupSpy).to.be.calledOnce;
+        expect(subcomponentSpy).to.be.calledTwice; // no changes.
+        expect(subcomponentCleanupSpy).to.be.calledOnce;
       });
 
       it('should remove component when the node is disconnected', async () => {
-        setComponent(grandparent.node, ComponentSelfChildren, 'A');
-        setComponent(grandparent.node, ComponentParentChildren, 'B');
+        mountComponent(
+          grandparent.node,
+          ComponentMountingSubcomponentsOnSelf,
+          'A'
+        );
+        mountComponent(
+          grandparent.node,
+          ComponentMountingSubcomponentsOnOther,
+          'B'
+        );
         clock.runAll();
-        expect(childComponentSpy)
+        expect(subcomponentSpy)
           .to.be.calledTwice.calledWith(grandparent.node, 'A')
           .calledWith(parent.node, 'B');
-        expect(childCleanupSpy).to.not.be.called;
+        expect(subcomponentCleanupSpy).to.not.be.called;
 
         grandparent.node.remove();
         await rediscover(grandparent);
         clock.runAll();
-        expect(childComponentSpy).to.be.calledTwice; // no changes.
-        expect(childCleanupSpy).to.be.calledTwice;
+        expect(subcomponentSpy).to.be.calledTwice; // no changes.
+        expect(subcomponentCleanupSpy).to.be.calledTwice;
       });
     });
 
-    describe('child subscriber', () => {
-      let ComponentSelfChildren;
-      let ComponentParentChildren;
+    describe('subcomponent subscriber', () => {
+      let ComponentSubscribingOnSelf;
+      let ComponentSubscribingOnParent;
       let subscriber, subscriberSpy, subscriberCleanupSpy;
 
       beforeEach(() => {
@@ -885,22 +941,22 @@ describes.realWin('ContextNode - components', {}, (env) => {
           return subscriberCleanupSpy;
         };
 
-        ComponentSelfChildren = (unusedNode, input) => {
-          const subscribeChild = useSubscribeChild();
-          const unsubscribeChild = useUnsubscribeChild();
+        ComponentSubscribingOnSelf = (unusedNode, input) => {
+          const subscribe = useSubscribe();
+          const unsubscribe = useUnsubscribe();
           if (input) {
-            subscribeChild([Concat], subscriber);
+            subscribe([Concat], subscriber);
           } else {
-            unsubscribeChild(subscriber);
+            unsubscribe(subscriber);
           }
         };
-        ComponentParentChildren = (unusedNode, input) => {
-          const subscribeChild = useSubscribeChild();
-          const unsubscribeChild = useUnsubscribeChild();
+        ComponentSubscribingOnParent = (unusedNode, input) => {
+          const subscribe = useSubscribe();
+          const unsubscribe = useUnsubscribe();
           if (input) {
-            subscribeChild([Concat], subscriber, parent.node);
+            subscribe([Concat], subscriber, parent.node);
           } else {
-            unsubscribeChild(subscriber, parent.node);
+            unsubscribe(subscriber, parent.node);
           }
         };
 
@@ -908,68 +964,68 @@ describes.realWin('ContextNode - components', {}, (env) => {
         clock.runAll();
       });
 
-      it('should set child subscriber', () => {
-        setComponent(grandparent.node, ComponentSelfChildren, 'A');
+      it('should set subscriber', () => {
+        mountComponent(grandparent.node, ComponentSubscribingOnSelf, 'A');
         clock.runAll();
         expect(subscriberSpy).to.be.calledOnce.calledWith('C');
 
-        setComponent(grandparent.node, ComponentParentChildren, 'B');
+        mountComponent(grandparent.node, ComponentSubscribingOnParent, 'B');
         clock.runAll();
         expect(subscriberSpy).to.be.calledTwice.calledWith('C');
 
         expect(subscriberCleanupSpy).to.not.be.called;
       });
 
-      it('should remove child subscriber', () => {
-        setComponent(grandparent.node, ComponentSelfChildren, 'A');
+      it('should remove subscriber', () => {
+        mountComponent(grandparent.node, ComponentSubscribingOnSelf, 'A');
         clock.runAll();
         expect(subscriberSpy).to.be.calledOnce.calledWith('C');
 
-        setComponent(grandparent.node, ComponentParentChildren, 'B');
+        mountComponent(grandparent.node, ComponentSubscribingOnParent, 'B');
         clock.runAll();
         expect(subscriberSpy).to.be.calledTwice.calledWith('C');
 
         // Null input removes the subscriber.
-        setComponent(grandparent.node, ComponentParentChildren, null);
+        mountComponent(grandparent.node, ComponentSubscribingOnParent, null);
         clock.runAll();
         expect(subscriberSpy).to.be.calledTwice; // no changes.
         expect(subscriberCleanupSpy).to.be.calledOnce;
 
-        setComponent(grandparent.node, ComponentSelfChildren, null);
+        mountComponent(grandparent.node, ComponentSubscribingOnSelf, null);
         clock.runAll();
         expect(subscriberSpy).to.be.calledTwice; // no changes.
         expect(subscriberCleanupSpy).to.be.calledTwice;
       });
 
-      it('should update child subscriber', () => {
-        setComponent(grandparent.node, ComponentSelfChildren, 'A');
+      it('should update subscriber', () => {
+        mountComponent(grandparent.node, ComponentSubscribingOnSelf, 'A');
         clock.runAll();
         expect(subscriberSpy).to.be.calledOnce.calledWith('C');
 
-        setComponent(grandparent.node, ComponentSelfChildren, 'B');
+        mountComponent(grandparent.node, ComponentSubscribingOnSelf, 'B');
         clock.runAll();
         expect(subscriberSpy).to.be.calledOnce; // no changes.
         expect(subscriberCleanupSpy).to.not.be.called;
       });
 
-      it('should remove child subscriber on removal', () => {
-        setComponent(grandparent.node, ComponentSelfChildren, 'A');
-        setComponent(grandparent.node, ComponentParentChildren, 'B');
+      it('should remove subscriber on removal', () => {
+        mountComponent(grandparent.node, ComponentSubscribingOnSelf, 'A');
+        mountComponent(grandparent.node, ComponentSubscribingOnParent, 'B');
         clock.runAll();
         expect(subscriberSpy).to.be.calledTwice.calledWith('C');
 
-        removeComponent(grandparent.node, ComponentSelfChildren);
+        unmountComponent(grandparent.node, ComponentSubscribingOnSelf);
         clock.runAll();
         expect(subscriberCleanupSpy).to.be.calledOnce;
 
-        removeComponent(grandparent.node, ComponentParentChildren);
+        unmountComponent(grandparent.node, ComponentSubscribingOnParent);
         clock.runAll();
         expect(subscriberCleanupSpy).to.be.calledTwice;
       });
 
       it('should remove subscriber when child node is disconnected', async () => {
-        setComponent(grandparent.node, ComponentSelfChildren, 'A');
-        setComponent(grandparent.node, ComponentParentChildren, 'B');
+        mountComponent(grandparent.node, ComponentSubscribingOnSelf, 'A');
+        mountComponent(grandparent.node, ComponentSubscribingOnParent, 'B');
         clock.runAll();
         expect(subscriberSpy).to.be.calledTwice.calledWith('C');
         expect(subscriberCleanupSpy).to.not.be.called;
@@ -982,8 +1038,8 @@ describes.realWin('ContextNode - components', {}, (env) => {
       });
 
       it('should remove subscriber when the node is disconnected', async () => {
-        setComponent(grandparent.node, ComponentSelfChildren, 'A');
-        setComponent(grandparent.node, ComponentParentChildren, 'B');
+        mountComponent(grandparent.node, ComponentSubscribingOnSelf, 'A');
+        mountComponent(grandparent.node, ComponentSubscribingOnParent, 'B');
         clock.runAll();
         expect(subscriberSpy).to.be.calledTwice.calledWith('C');
         expect(subscriberCleanupSpy).to.not.be.called;

--- a/test/unit/test-types.js
+++ b/test/unit/test-types.js
@@ -59,6 +59,32 @@ describe('Types', () => {
     });
   });
 
+  describe('arrayOrSingleItemToArray', () => {
+    it('should return empty array for an empty array', () => {
+      const input = [];
+      const result = types.arrayOrSingleItemToArray(input);
+      expect(result).to.deep.equal([]);
+      expect(result).to.equal(input);
+    });
+
+    it('should return the array array as specified', () => {
+      const input = [1, 2, 3];
+      const result = types.arrayOrSingleItemToArray(input);
+      expect(result).to.deep.equal([1, 2, 3]);
+      expect(result).to.equal(input);
+    });
+
+    it('should return the item as an array', () => {
+      const result = types.arrayOrSingleItemToArray(1);
+      expect(result).to.deep.equal([1]);
+    });
+
+    it('should return a null as an array', () => {
+      const result = types.arrayOrSingleItemToArray(null);
+      expect(result).to.deep.equal([null]);
+    });
+  });
+
   describe('isFiniteNumber', () => {
     it('should yield false for non-numbers', () => {
       expect(types.isFiniteNumber(null)).to.be.false;


### PR DESCRIPTION
This pull request completes the APIs described in the [design doc](https://docs.google.com/document/d/1mEk_myi5-Q51RffLuoWU5o8UcacEBaKhiwfm32ghIdo/edit#bookmark=id.c4uh12mrsjv3).

These APIs extend `setProp`, `setComponent`, and `subscribe` APIs and intended to be used as hooks inside a component. These actually main APIs and their primary goal is to implement auto-cleanup when any related node disappears from the DOM. This avoids excessive and error-prone cleanup code.
