### PR TITLE
ContextNode: fix recursive computations with dependencies

### DIFF
--- a/src/context/values.js
+++ b/src/context/values.js
@@ -585,13 +585,13 @@ export class Values {
       if (inputValues && !compute) {
         newValue = inputValues[0];
       } else if (isRecursive(prop)) {
-        if (inputValues) {
+        if (inputValues || depValues.length > 0) {
           // The node specifies its own input values and they need to be
           // recomputed with parent and dep values.
           newValue = callRecursiveCompute(
             compute,
             node,
-            inputValues,
+            inputValues || EMPTY_ARRAY,
             parentValue,
             depValues
           );

--- a/test/unit/context/test-node-values.js
+++ b/test/unit/context/test-node-values.js
@@ -35,6 +35,14 @@ const Computed = contextProp('Computed', {
     `${inputs[0] ?? 'no-input'}/${nonRecursive}/${recursive}/${concat}`,
 });
 
+const ComputedRecursiveWithDeps = contextProp('Computed', {
+  deps: [Recursive],
+  needsParent: true,
+  defaultValue: 'DEF',
+  compute: (contextNode, inputs, parentValue, recursive) =>
+    `${inputs[0] ?? 'no-input'}/${parentValue}/${recursive}`,
+});
+
 describes.realWin('ContextNode - values', {}, (env) => {
   let sandbox;
   let win, doc;
@@ -811,6 +819,51 @@ describes.realWin('ContextNode - values', {}, (env) => {
       expect(cousin1Stub).to.not.be.called;
       // 1x `NonRecursive` + 1x `Computed`
       expect(calcSpy).to.have.callCount(2);
+    });
+  });
+
+  describe('connected, recursive, with deps', () => {
+    let sibling1, sibling1Stub;
+    let sibling2, sibling2Stub;
+    let cousin1, cousin1Stub;
+    let parent, parentStub;
+    let grandparent, grandparentStub;
+
+    beforeEach(async () => {
+      doc.body.appendChild(tree);
+      sibling1 = ContextNode.get(el('T-1-1-1'));
+      sibling2 = ContextNode.get(el('T-1-1-2'));
+      cousin1 = ContextNode.get(el('T-1-2-1'));
+      parent = ContextNode.get(el('T-1-1'));
+      grandparent = ContextNode.get(el('T-1'));
+
+      sibling1Stub = sandbox.stub();
+      sibling2Stub = sandbox.stub();
+      cousin1Stub = sandbox.stub();
+      parentStub = sandbox.stub();
+      grandparentStub = sandbox.stub();
+
+      await waitForDiscover(grandparent, parent, sibling1, sibling2, cousin1);
+
+      sibling1.values.subscribe(ComputedRecursiveWithDeps, sibling1Stub);
+      sibling2.values.subscribe(ComputedRecursiveWithDeps, sibling2Stub);
+      cousin1.values.subscribe(ComputedRecursiveWithDeps, cousin1Stub);
+      parent.values.subscribe(ComputedRecursiveWithDeps, parentStub);
+      grandparent.values.subscribe(ComputedRecursiveWithDeps, grandparentStub);
+      clock.runAll();
+      calcSpy.resetHistory();
+    });
+
+    it('should compute without input', () => {
+      expect(grandparentStub).to.not.be.called;
+      expect(parentStub).to.not.be.called;
+      expect(sibling1Stub).to.not.be.called;
+      expect(sibling2Stub).to.not.be.called;
+      expect(cousin1Stub).to.not.be.called;
+
+      grandparent.values.set(Recursive, 'OWNER1', 'A');
+      clock.runAll();
+      expect(sibling1Stub).to.be.calledOnce.calledWith('no-input/DEF/A');
     });
   });
 


### PR DESCRIPTION
A recursive value with dependencies cannot simply use the parent value when no input is specified. It has to take into the account the dependencies as well.

For instance, a `CanPlay` prop can be defined as `CanPlay = CanRender && CanPlay.input && CanPlay.parent`. If `CanRender == false`, then the resulting `CanPlay` would also be `false` regardless of whether there's an input set for `CanPlay` itself.

