### PR TITLE
♻️ Switch Lazy Loading Animation Polyfill to WeakMap

### DIFF
--- a/extensions/amp-animation/0.1/install-polyfill.js
+++ b/extensions/amp-animation/0.1/install-polyfill.js
@@ -16,7 +16,8 @@
 import {Deferred} from '../../../src/utils/promise';
 import {Services} from '../../../src/services';
 
-const polyfillPromiseMap = new Map();
+/** @type {!WeakMap<Window, Deferred>} */
+const polyfillPromiseMap = new WeakMap();
 
 /**
  * @param {!Window} win


### PR DESCRIPTION
Per comment from @dvoytenko, FIE instances are created and destroyed often. Using a `WeakMap` instead of a `Map` allows for the VM to clean up these instances instead of retaining them for the sake of the polyfill map.