### PR TITLE
✨ Allow sticky ads be shown on amp-ad

### DIFF
--- a/3p/ampcontext.js
+++ b/3p/ampcontext.js
@@ -300,6 +300,13 @@ export class AbstractAmpContext {
   }
 
   /**
+   *  Make the ad interactive.
+   */
+  signalInteractive() {
+    this.client_.sendMessage(MessageType.SIGNAL_INTERACTIVE);
+  }
+
+  /**
    *  Takes the current name on the window, and attaches it to
    *  the name of the iframe.
    *  @param {HTMLIFrameElement} iframe The iframe we are adding the context to.

--- a/extensions/amp-ad/0.1/amp-ad-3p-impl.js
+++ b/extensions/amp-ad/0.1/amp-ad-3p-impl.js
@@ -31,7 +31,7 @@ import {
 import {Services} from '../../../src/services';
 import {adConfig} from '../../../ads/_config';
 import {clamp} from '../../../src/utils/math';
-import {computedStyle, setStyle} from '../../../src/style';
+import {computedStyle, setStyle, setStyles} from '../../../src/style';
 import {dev, devAssert, userAssert} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
 import {getAdCid} from '../../../src/ad-cid';
@@ -201,6 +201,8 @@ export class AmpAd3PImpl extends AMP.BaseElement {
     if (this.isFullWidthRequested_) {
       return this.attemptFullWidthSizeChange_();
     }
+
+    this.maybeSetStyleForSticky_();
   }
 
   /**
@@ -225,6 +227,19 @@ export class AmpAd3PImpl extends AMP.BaseElement {
       '#${this.getResource().getId()} Full width requested'
     );
     return true;
+  }
+
+  /**
+   * Set sidekick ads
+   */
+  maybeSetStyleForSticky_() {
+    if (this.element.hasAttribute('sticky')) {
+      setStyles(this.element, {
+        position: 'fixed',
+        bottom: '0',
+        right: '0',
+      });
+    }
   }
 
   /**
@@ -346,9 +361,9 @@ export class AmpAd3PImpl extends AMP.BaseElement {
       return this.layoutPromise_;
     }
     userAssert(
-      !this.isInFixedContainer_,
+      !this.isInFixedContainer_ || this.element.hasAttribute('sticky'),
       '<amp-ad> is not allowed to be placed in elements with ' +
-        'position:fixed: %s',
+        'position:fixed: %s unless it has sticky attribute',
       this.element
     );
 

--- a/extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js
+++ b/extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js
@@ -183,6 +183,21 @@ export class AmpAdXOriginIframeHandler {
       )
     );
 
+    if (this.element_.hasAttribute('sticky')) {
+      setStyle(iframe, 'pointer-events', 'none');
+      this.unlisteners_.push(
+        listenFor(
+          this.iframe,
+          'signal-interactive',
+          () => {
+            setStyle(iframe, 'pointer-events', 'auto');
+          },
+          true,
+          true
+        )
+      );
+    }
+
     this.unlisteners_.push(
       this.baseInstance_.getAmpDoc().onVisibilityChanged(() => {
         this.sendEmbedInfo_(this.baseInstance_.isInViewport());

--- a/src/3p-frame-messaging.js
+++ b/src/3p-frame-messaging.js
@@ -43,6 +43,7 @@ export const MessageType = {
   NO_CONTENT: 'no-content',
   GET_HTML: 'get-html',
   GET_CONSENT_STATE: 'get-consent-state',
+  SIGNAL_INTERACTIVE: 'signal-interactive',
 
   // For the frame to be placed in full overlay mode for lightboxes
   FULL_OVERLAY_FRAME: 'full-overlay-frame',


### PR DESCRIPTION
This PR allows amp-ad to render a sticky ad if it has a `sticky` attribute in it. It also adds an interface in the ampcontext API so that the ad can tell the runtime whenever it is ready to be interacted.