### PR TITLE
🏗 Catch Minify Errors

### DIFF
--- a/build-system/compile/post-closure-babel.js
+++ b/build-system/compile/post-closure-babel.js
@@ -21,7 +21,6 @@ const remapping = require('@ampproject/remapping');
 const terser = require('terser');
 const through = require('through2');
 const {debug, CompilationLifecycles} = require('./debug-compilation-lifecycle');
-const { catch } = require('fetch-mock');
 
 /**
  * Minify passed string.
@@ -96,7 +95,7 @@ exports.postClosureBabel = function () {
         () => null,
         !argv.full_sourcemaps
       );
-    } catch(e) {
+    } catch (e) {
       return next(e);
     }
 


### PR DESCRIPTION
A followup to https://github.com/ampproject/amphtml/pull/29705.

Now that we're using async/await for Terser, we should propagate errors via the `next` callback.

There are no tests for this or other build-system code, so I added errors and manually verified.

