### PR TITLE
🐛 Clone IntersectionObserverEntry for cross-origin postMessages

### DIFF
--- a/src/utils/intersection-observer-polyfill.js
+++ b/src/utils/intersection-observer-polyfill.js
@@ -114,11 +114,10 @@ export class IntersectionObserverHostApi {
 
     this.intersectionObserver_ = new IntersectionObserver(
       (entries) => {
-        // Remove target info from cross origin iframe.
-        for (let i = 0; i < entries.length; i++) {
-          delete entries[i]['target'];
-        }
-        this.subscriptionApi_.send('intersection', dict({'changes': entries}));
+        this.subscriptionApi_.send(
+          'intersection',
+          dict({'changes': entries.map(cloneEntryForCrossOrigin)})
+        );
       },
       {threshold: DEFAULT_THRESHOLD}
     );
@@ -238,5 +237,19 @@ function calculateChangeEntry(element, hostViewport, intersection, ratio) {
     boundingClientRect,
     intersectionRect: intersection,
     intersectionRatio: ratio,
+  });
+}
+
+/**
+ * @param {!IntersectionObserverEntry} entry
+ * @return {!IntersectionObserverEntry}
+ */
+function cloneEntryForCrossOrigin(entry) {
+  return /** @type {!IntersectionObserverEntry} */ ({
+    'time': entry.time,
+    'rootBounds': entry.rootBounds,
+    'boundingClientRect': entry.boundingClientRect,
+    'intersectionRect': entry.intersectionRect,
+    'intersectionRatio': entry.intersectionRatio,
   });
 }


### PR DESCRIPTION
The `target` property points to a DOM element, which is not structured clonable (a requirement for `postMessage`). We used to `delete entry.target`, to get around this.

But when using native `IntersectionObserver`, the `IntersectionObserverEntry`s has no own properties. Instead, the properties are getters that exist on the prototype. `delete` doesn't work for prototype-inherited properties, so this workaround stopped working. Now, we'll just create a new object with the properties we care about, which is honestly cleaner (you shouldn't mutate objects you don't own).

Fixes https://github.com/ampproject/amphtml/issues/29747