### PR TITLE
✨ extend support for pingback on to platforms.

### DIFF
--- a/extensions/amp-subscriptions/0.1/amp-subscriptions.js
+++ b/extensions/amp-subscriptions/0.1/amp-subscriptions.js
@@ -606,8 +606,8 @@ export class SubscriptionService {
           .forEach((subscriptionPlatform) => {
             // Iterate the platforms and pingback if it's enabled on that platform
             if (subscriptionPlatform.isPingbackEnabled()) {
-              // Platforms can choose if they want all entitlments
-              // or just the granting entitlment
+              // Platforms can choose if they want all entitlements
+              // or just the granting entitlement
               if (subscriptionPlatform.pingbackReturnsAllEntitlements()) {
                 this.platformStore_
                   .getAllPlatformsEntitlements()

--- a/extensions/amp-subscriptions/0.1/amp-subscriptions.js
+++ b/extensions/amp-subscriptions/0.1/amp-subscriptions.js
@@ -376,7 +376,6 @@ export class SubscriptionService {
     this.renderer_.toggleLoading(false);
 
     // Set Pingback viewer timer
-
     this.viewTrackerPromise_ = this.viewerTracker_.scheduleView(2000);
 
     // If the viewer is providing a paywall we don't want the publisher

--- a/extensions/amp-subscriptions/0.1/local-subscription-platform-base.js
+++ b/extensions/amp-subscriptions/0.1/local-subscription-platform-base.js
@@ -240,8 +240,6 @@ export class LocalSubscriptionBasePlatform {
 
   /**
    * @override
-   * @param {?./entitlement.Entitlement} unusedEntitlement
-   * @return {!Promise|undefined}
    */
   pingback(unusedEntitlement) {}
 

--- a/extensions/amp-subscriptions/0.1/subscription-platform.js
+++ b/extensions/amp-subscriptions/0.1/subscription-platform.js
@@ -69,7 +69,7 @@ export class SubscriptionPlatform {
 
   /**
    * Performs the pingback to the subscription platform.
-   * @param {./entitlement.Entitlement|Array<./entitlement.Entitlement>} unusedSelectedPlatform
+   * @param {./entitlement.Entitlement|Array<./entitlement.Entitlement>} unusedEntitlement
    * @return {!Promise|undefined}
    */
   pingback(unusedSelectedPlatform) {}

--- a/extensions/amp-subscriptions/0.1/subscription-platform.js
+++ b/extensions/amp-subscriptions/0.1/subscription-platform.js
@@ -72,7 +72,7 @@ export class SubscriptionPlatform {
    * @param {./entitlement.Entitlement|Array<./entitlement.Entitlement>} unusedEntitlement
    * @return {!Promise|undefined}
    */
-  pingback(unusedSelectedPlatform) {}
+  pingback(unusedEntitlement) {}
 
   /**
    * Tells if the platform supports a score factor

--- a/extensions/amp-subscriptions/0.1/subscription-platform.js
+++ b/extensions/amp-subscriptions/0.1/subscription-platform.js
@@ -69,7 +69,7 @@ export class SubscriptionPlatform {
 
   /**
    * Performs the pingback to the subscription platform.
-   * @param {!./entitlement.Entitlement} unusedSelectedPlatform
+   * @param {./entitlement.Entitlement|Array<./entitlement.Entitlement>} unusedSelectedPlatform
    * @return {!Promise|undefined}
    */
   pingback(unusedSelectedPlatform) {}


### PR DESCRIPTION
## Preparation for adding pingback to `amp-subscriptions-google`

Removes special case of only pinging back local platform.  Sends pingback in platform preferred format to each platform that requests it.

Tides up some type issues

Make test of waiting for viewer more robust.