### PR TITLE
Add begin to render requests to a4a ad

### DIFF
--- a/ads/google/a4a/test/test-utils.js
+++ b/ads/google/a4a/test/test-utils.js
@@ -160,7 +160,7 @@ describe('Google A4A utils', () => {
       },
     };
 
-    it.only('should extract correct config from header', () => {
+    it('should extract correct config from header', () => {
       return createIframePromise().then((fixture) => {
         setupForAdTesting(fixture);
         let url;

--- a/ads/google/a4a/test/test-utils.js
+++ b/ads/google/a4a/test/test-utils.js
@@ -132,14 +132,43 @@ describe('Google A4A utils', () => {
       },
     };
 
-    it('should extract correct config from header', () => {
+    const btrConfig = {
+      transport: {beacon: false, xhrpost: false},
+      requests: {
+        visibility1: 'https://foo.com?hello=world',
+        visibility2: 'https://bar.com?a=b',
+        btr1: 'https://example.test?id=1',
+        btr2: 'https://example.test?id=2',
+      },
+      triggers: {
+        continuousVisible: {
+          on: 'visible',
+          request: ['visibility1', 'visibility2'],
+          visibilitySpec: {
+            selector: 'amp-ad',
+            selectionMethod: 'closest',
+            visiblePercentageMin: 50,
+            continuousTimeMin: 1000,
+          },
+        },
+        beginToRender: {
+          on: 'ini-load',
+          request: ['btr1', 'btr2'],
+          selector: 'amp-ad',
+          selectionMethod: 'closest',
+        },
+      },
+    };
+
+    it.only('should extract correct config from header', () => {
       return createIframePromise().then((fixture) => {
         setupForAdTesting(fixture);
         let url;
+        let btrUrl;
         const headers = {
           get(name) {
             if (name == 'X-AmpAnalytics') {
-              return JSON.stringify({url});
+              return JSON.stringify({url, btrUrl});
             }
             if (name == 'X-QQID') {
               return 'qqid_string';
@@ -173,8 +202,17 @@ describe('Google A4A utils', () => {
         expect(extractAmpAnalyticsConfig(a4a, headers)).to.be.null;
 
         url = ['https://foo.com?hello=world', 'https://bar.com?a=b'];
-        const config = extractAmpAnalyticsConfig(a4a, headers);
+        let config = extractAmpAnalyticsConfig(a4a, headers);
         expect(config).to.deep.equal(builtConfig);
+
+        btrUrl = [];
+        config = extractAmpAnalyticsConfig(a4a, headers);
+        expect(config).to.deep.equal(builtConfig);
+
+        btrUrl = ['https://example.test?id=1', 'https://example.test?id=2'];
+        config = extractAmpAnalyticsConfig(a4a, headers);
+        expect(config).to.deep.equal(btrConfig);
+
         headers.has = function (name) {
           expect(name).to.equal('X-AmpAnalytics');
           return false;

--- a/ads/google/a4a/test/test-utils.js
+++ b/ads/google/a4a/test/test-utils.js
@@ -135,6 +135,22 @@ describe('Google A4A utils', () => {
     const btrConfig = {
       transport: {beacon: false, xhrpost: false},
       requests: {
+        btr1: 'https://example.test?id=1',
+        btr2: 'https://example.test?id=2',
+      },
+      triggers: {
+        beginToRender: {
+          on: 'ini-load',
+          request: ['btr1', 'btr2'],
+          selector: 'amp-ad',
+          selectionMethod: 'closest',
+        },
+      },
+    };
+
+    const fullConfig = {
+      transport: {beacon: false, xhrpost: false},
+      requests: {
         visibility1: 'https://foo.com?hello=world',
         visibility2: 'https://bar.com?a=b',
         btr1: 'https://example.test?id=1',
@@ -197,21 +213,26 @@ describe('Google A4A utils', () => {
         allowConsoleError(
           () => expect(extractAmpAnalyticsConfig(a4a, headers)).to.be.null
         );
+
         url = [];
+        btrUrl = [];
         expect(extractAmpAnalyticsConfig(a4a, headers)).to.not.be.ok;
         expect(extractAmpAnalyticsConfig(a4a, headers)).to.be.null;
 
         url = ['https://foo.com?hello=world', 'https://bar.com?a=b'];
+        btrUrl = [];
         let config = extractAmpAnalyticsConfig(a4a, headers);
         expect(config).to.deep.equal(builtConfig);
 
-        btrUrl = [];
-        config = extractAmpAnalyticsConfig(a4a, headers);
-        expect(config).to.deep.equal(builtConfig);
-
+        url = [];
         btrUrl = ['https://example.test?id=1', 'https://example.test?id=2'];
         config = extractAmpAnalyticsConfig(a4a, headers);
         expect(config).to.deep.equal(btrConfig);
+
+        url = ['https://foo.com?hello=world', 'https://bar.com?a=b'];
+        btrUrl = ['https://example.test?id=1', 'https://example.test?id=2'];
+        config = extractAmpAnalyticsConfig(a4a, headers);
+        expect(config).to.deep.equal(fullConfig);
 
         headers.has = function (name) {
           expect(name).to.equal('X-AmpAnalytics');

--- a/ads/google/a4a/utils.js
+++ b/ads/google/a4a/utils.js
@@ -714,7 +714,6 @@ export function extractAmpAnalyticsConfig(a4a, responseHeaders) {
     if (Array.isArray(btrUrls) && btrUrls.length) {
       const btrRequests = dict();
       for (let idx = 1; idx <= btrUrls.length; idx++) {
-        // TODO: Ensure url is valid and not freeform JS?
         btrRequests[`btr${idx}`] = `${btrUrls[idx - 1]}`;
         config['requests'][`btr${idx}`] = `${btrUrls[idx - 1]}`;
       }

--- a/ads/google/a4a/utils.js
+++ b/ads/google/a4a/utils.js
@@ -701,9 +701,9 @@ export function extractAmpAnalyticsConfig(a4a, responseHeaders) {
 
     // Discover and build visibility endpoints.
     const requests = dict();
-    for (let idx = 1; idx <= urls.length; idx++) {
+    for (let idx = 0; idx < urls.length; idx++) {
       // TODO: Ensure url is valid and not freeform JS?
-      requests[`visibility${idx}`] = `${urls[idx - 1]}`;
+      requests[`visibility${idx+1}`] = `${urls[idx]}`;
     }
     // Security review needed here.
     config['requests'] = requests;
@@ -713,9 +713,9 @@ export function extractAmpAnalyticsConfig(a4a, responseHeaders) {
     const btrUrls = analyticsConfig['btrUrl'];
     if (Array.isArray(btrUrls) && btrUrls.length) {
       const btrRequests = dict();
-      for (let idx = 1; idx <= btrUrls.length; idx++) {
-        btrRequests[`btr${idx}`] = `${btrUrls[idx - 1]}`;
-        config['requests'][`btr${idx}`] = `${btrUrls[idx - 1]}`;
+      for (let idx = 0; idx < btrUrls.length; idx++) {
+        btrRequests[`btr${idx+1}`] = `${btrUrls[idx]}`;
+        config['requests'][`btr${idx+1}`] = `${btrUrls[idx]}`;
       }
       config['triggers']['beginToRender'] = dict({
         'on': 'ini-load',

--- a/ads/google/a4a/utils.js
+++ b/ads/google/a4a/utils.js
@@ -661,7 +661,8 @@ export function getCsiAmpAnalyticsVariables(analyticsTrigger, a4a, qqid) {
 }
 
 /**
- * Extracts configuration used to build amp-analytics element for active view.
+ * Extracts configuration used to build amp-analytics element for active view
+ * and begin to render.
  *
  * @param {!../../../extensions/amp-a4a/0.1/amp-a4a.AmpA4A} a4a
  * @param {!Headers} responseHeaders
@@ -707,6 +708,24 @@ export function extractAmpAnalyticsConfig(a4a, responseHeaders) {
     // Security review needed here.
     config['requests'] = requests;
     config['triggers']['continuousVisible']['request'] = Object.keys(requests);
+
+    // Add begin to render requests
+    const btrUrls = analyticsConfig['btrUrl'];
+    if (Array.isArray(btrUrls) && btrUrls.length) {
+      const btrRequests = dict();
+      for (let idx = 1; idx <= btrUrls.length; idx++) {
+        // TODO: Ensure url is valid and not freeform JS?
+        btrRequests[`btr${idx}`] = `${btrUrls[idx - 1]}`;
+        config['requests'][`btr${idx}`] = `${btrUrls[idx - 1]}`;
+      }
+      config['triggers']['beginToRender'] = dict({
+        'on': 'ini-load',
+        'request': Object.keys(btrRequests),
+        'selector': 'amp-ad',
+        'selectionMethod': 'closest',
+      });
+    }
+
     return config;
   } catch (err) {
     dev().error(

--- a/ads/google/a4a/utils.js
+++ b/ads/google/a4a/utils.js
@@ -678,53 +678,35 @@ export function extractAmpAnalyticsConfig(a4a, responseHeaders) {
     const analyticsConfig = parseJson(
       responseHeaders.get(AMP_ANALYTICS_HEADER)
     );
-    devAssert(Array.isArray(analyticsConfig['url']));
-    const urls = analyticsConfig['url'];
-    if (!urls.length) {
+
+    const acUrls = analyticsConfig['url'];
+    const btrUrls = analyticsConfig['btrUrl'];
+    if (
+      (acUrls && !Array.isArray(acUrls)) ||
+      (btrUrls && !Array.isArray(btrUrls))
+    ) {
+      dev().error(
+        'AMP-A4A',
+        'Invalid analytics',
+        responseHeaders.get(AMP_ANALYTICS_HEADER)
+      );
+    }
+    const hasActiveViewRequests = Array.isArray(acUrls) && acUrls.length;
+    const hasBeginToRenderRequests = Array.isArray(btrUrls) && btrUrls.length;
+    if (!hasActiveViewRequests && !hasBeginToRenderRequests) {
       return null;
     }
-
-    const config = /** @type {JsonObject}*/ ({
+    const config = dict({
       'transport': {'beacon': false, 'xhrpost': false},
-      'triggers': {
-        'continuousVisible': {
-          'on': 'visible',
-          'visibilitySpec': {
-            'selector': 'amp-ad',
-            'selectionMethod': 'closest',
-            'visiblePercentageMin': 50,
-            'continuousTimeMin': 1000,
-          },
-        },
-      },
+      'requests': {},
+      'triggers': {},
     });
-
-    // Discover and build visibility endpoints.
-    const requests = dict();
-    for (let idx = 0; idx < urls.length; idx++) {
-      // TODO: Ensure url is valid and not freeform JS?
-      requests[`visibility${idx+1}`] = `${urls[idx]}`;
+    if (hasActiveViewRequests) {
+      generateActiveViewRequest(config, acUrls);
     }
-    // Security review needed here.
-    config['requests'] = requests;
-    config['triggers']['continuousVisible']['request'] = Object.keys(requests);
-
-    // Add begin to render requests
-    const btrUrls = analyticsConfig['btrUrl'];
-    if (Array.isArray(btrUrls) && btrUrls.length) {
-      const btrRequests = dict();
-      for (let idx = 0; idx < btrUrls.length; idx++) {
-        btrRequests[`btr${idx+1}`] = `${btrUrls[idx]}`;
-        config['requests'][`btr${idx+1}`] = `${btrUrls[idx]}`;
-      }
-      config['triggers']['beginToRender'] = dict({
-        'on': 'ini-load',
-        'request': Object.keys(btrRequests),
-        'selector': 'amp-ad',
-        'selectionMethod': 'closest',
-      });
+    if (hasBeginToRenderRequests) {
+      generateBeginToRenderRequest(config, btrUrls);
     }
-
     return config;
   } catch (err) {
     dev().error(
@@ -735,6 +717,49 @@ export function extractAmpAnalyticsConfig(a4a, responseHeaders) {
     );
   }
   return null;
+}
+
+/**
+ * @param {!JsonObject} config
+ * @param {!Array<string>} urls
+ */
+function generateActiveViewRequest(config, urls) {
+  config['triggers']['continuousVisible'] = dict({
+    'request': [],
+    'on': 'visible',
+    'visibilitySpec': {
+      'selector': 'amp-ad',
+      'selectionMethod': 'closest',
+      'visiblePercentageMin': 50,
+      'continuousTimeMin': 1000,
+    },
+  });
+  for (let idx = 0; idx < urls.length; idx++) {
+    // TODO: Ensure url is valid and not freeform JS?
+    config['requests'][`visibility${idx + 1}`] = `${urls[idx]}`;
+    config['triggers']['continuousVisible']['request'].push(
+      `visibility${idx + 1}`
+    );
+  }
+}
+
+/**
+ * @param {!JsonObject} config
+ * @param {!Array<string>} urls
+ */
+function generateBeginToRenderRequest(config, urls) {
+  config['triggers']['beginToRender'] = dict({
+    'request': [],
+    'on': 'ini-load',
+    'selector': 'amp-ad',
+    'selectionMethod': 'closest',
+  });
+
+  for (let idx = 0; idx < urls.length; idx++) {
+    // TODO: Ensure url is valid and not freeform JS?
+    config['requests'][`btr${idx + 1}`] = `${urls[idx]}`;
+    config['triggers']['beginToRender']['request'].push(`btr${idx + 1}`);
+  }
 }
 
 /**


### PR DESCRIPTION
As agreed in cr/325220403

The the response now also support `btrUrl` as an optional array.
The begin to render config looks like
```
{
  on: ini-load,
  selector: amp-ad,
  selectionMethod: closest
}
```