### PR TITLE
🐛 FirstImpression.io integration: reverted to using window.location

### DIFF
--- a/extensions/amp-auto-ads/0.1/firstimpression.io-network-config.js
+++ b/extensions/amp-auto-ads/0.1/firstimpression.io-network-config.js
@@ -49,7 +49,7 @@ export class FirstImpressionIoConfig {
   getConfigUrl() {
     let previewId = 0;
 
-    const {host, pathname, hash} = this.autoAmpAdsElement_.ampdoc_.win.location;
+    const {host, pathname, hash} = window.location;
     const hashParams = parseQueryString(hash);
     const docInfo = Services.documentInfoForDoc(this.autoAmpAdsElement_);
 


### PR DESCRIPTION
By the results of discussion in PR #29712 with @calebcordry , in network config of `amp-auto-ads`, reverted to using `window.location` directly, rather then `ampdoc_.win.location`, because after minifying the `ampdoc_` variable name is not consistent across different JS files.