### PR TITLE
🐛 Hide border if user is not using keyboard input.

### DIFF
--- a/extensions/amp-story/1.0/amp-story.css
+++ b/extensions/amp-story/1.0/amp-story.css
@@ -957,6 +957,10 @@ amp-story-page.i-amphtml-story-desktop-panels .i-amphtml-story-interactive-compo
   border: none !important;
 }
 
+body:not(.amp-mode-keyboard-active) .i-amphtml-story-screen-reader-back-button {
+  outline: none !important;
+}
+
 [dir=rtl]amp-story .i-amphtml-story-screen-reader-back-button {
   right: 0 !important;
 }

--- a/extensions/amp-story/1.0/amp-story.css
+++ b/extensions/amp-story/1.0/amp-story.css
@@ -957,6 +957,9 @@ amp-story-page.i-amphtml-story-desktop-panels .i-amphtml-story-interactive-compo
   border: none !important;
 }
 
+/* Hides border unless user is using a keyboard */
+/* This is okay for mobile screen readers like TalkBack since they add 
+   a focus border by default */
 body:not(.amp-mode-keyboard-active) .i-amphtml-story-screen-reader-back-button {
   outline: none !important;
 }

--- a/extensions/amp-story/1.0/amp-story.css
+++ b/extensions/amp-story/1.0/amp-story.css
@@ -955,12 +955,8 @@ amp-story-page.i-amphtml-story-desktop-panels .i-amphtml-story-interactive-compo
   margin: auto 0 !important;
   background: none !important;
   border: none !important;
-}
-
-/* Hides border unless user is using a keyboard */
-/* This is okay for mobile screen readers like TalkBack since they add 
-   a focus border by default */
-body:not(.amp-mode-keyboard-active) .i-amphtml-story-screen-reader-back-button {
+  /* Hiding the outline since this button is intended to be used with
+     mobile screen readers such as TalkBack which add focus lines. */
   outline: none !important;
 }
 


### PR DESCRIPTION
context, fixes #29802

Button highlights when using TalkBack or VoiceOver.
[Demo](https://stamp-a11y.web.app/examples/amp-story/ampconf.html)

