### PR TITLE
🐛 Talkback button, no pointer events

### DIFF
--- a/extensions/amp-story/1.0/amp-story.css
+++ b/extensions/amp-story/1.0/amp-story.css
@@ -979,6 +979,7 @@ amp-story-page.i-amphtml-story-desktop-panels .i-amphtml-story-interactive-compo
   /* Hiding the outline since this button is intended to be used with
      mobile screen readers such as TalkBack which add focus lines. */
   outline: none !important;
+  pointer-events: none !important;
 }
 
 [dir=rtl]amp-story .i-amphtml-story-screen-reader-back-button {


### PR DESCRIPTION
Follow up to #29803

Prevents the button from intercepting pointer events.
Button is still clickable with TalkBack.