### PR TITLE
✨Added pointer events caching only on selectable items

### DIFF
--- a/extensions/amp-story-interactive/1.0/amp-story-interactive.css
+++ b/extensions/amp-story-interactive/1.0/amp-story-interactive.css
@@ -66,6 +66,7 @@
 .i-amphtml-story-interactive-container:not(.i-amphtml-story-interactive-post-selection) 
   .i-amphtml-story-interactive-option {
   cursor: pointer !important;
+  pointer-events: all;
 }
 
 .i-amphtml-story-interactive-confetti-wrapper {

--- a/extensions/amp-story/1.0/amp-story.css
+++ b/extensions/amp-story/1.0/amp-story.css
@@ -875,8 +875,9 @@ amp-story .amp-video-eq,
 
 .i-amphtml-story-interactive-component {
   align-self: center;
-  width: auto !important;
+  width: auto;
   height: auto !important;
+  pointer-events: none !important;
   /* 224px = the width of a narrow phone (320px) - tap-safe margins (48px * 2) */
   min-width: 224px !important;
   max-width: 400px !important;


### PR DESCRIPTION
Closes #29792 

On local tests:
- Clicking on the prompt or anywhere not in the options takes you to the next page
- Clicking on the options on pre-select, does not change the page but selects the option
- Clicking on the options on post-select takes you to the next page

Also: width cannot be currently overriden by the creators, but it should. Removed !important from width so that they can specify `width:320px`. Currently they can set a max width if they enclose it in a div and set the width of that div, but it's not desired if they can just set it with a CSS attribute