### PR TITLE
🏗 [test-case-reporting] Enable report flag in e2e task

### DIFF
--- a/build-system/pr-check/e2e-tests.js
+++ b/build-system/pr-check/e2e-tests.js
@@ -42,7 +42,7 @@ async function main() {
   if (!isTravisPullRequestBuild()) {
     downloadDistOutput(FILENAME);
     timedExecOrDie('gulp update-packages');
-    timedExecOrDie('gulp e2e --nobuild --headless --compiled');
+    timedExecOrDie('gulp e2e --nobuild --headless --compiled --report');
   } else {
     printChangeSummary(FILENAME);
     const buildTargets = determineBuildTargets(FILENAME);

--- a/build-system/tasks/e2e/mocha-custom-json-reporter.js
+++ b/build-system/tasks/e2e/mocha-custom-json-reporter.js
@@ -15,7 +15,7 @@
  */
 'use strict';
 
-const fs = require('fs').promises;
+const fs = require('fs');
 const {
   EVENT_TEST_PASS,
   EVENT_TEST_FAIL,

--- a/build-system/tasks/e2e/mocha-custom-json-reporter.js
+++ b/build-system/tasks/e2e/mocha-custom-json-reporter.js
@@ -30,6 +30,12 @@ const {inherits} = require('mocha').utils;
 async function writeOutput(output, filename) {
   try {
     await fs.writeFile(filename, JSON.stringify(output, null, 4));
+    process.stdout.write(
+      Base.color(
+        'green',
+        `Successfully wrote test result report to file '${filename}'`
+      )
+    );
   } catch (error) {
     process.stdout.write(
       Base.color(

--- a/build-system/tasks/e2e/mocha-custom-json-reporter.js
+++ b/build-system/tasks/e2e/mocha-custom-json-reporter.js
@@ -56,14 +56,14 @@ function JsonReporter(runner) {
   const testEvents = [];
   let suiteList = [];
 
+  // We need a fresh array copy every time we enter a new suite,
+  // so we can't use push or pop here (because the suiteList info of previous
+  // tests in the same suite would be changed)
   runner.on(EVENT_SUITE_BEGIN, function (suite) {
-    suiteList.push(suite.title);
+    suiteList = suiteList.concat([suite.title]);
   });
 
   runner.on(EVENT_SUITE_END, function () {
-    // We need a fresh copy every time we make a new suite,
-    // so we can't use pop here (or the suiteList info of previous
-    // tests would be changed)
     suiteList = suiteList.slice(0, -1);
   });
 

--- a/build-system/tasks/e2e/mocha-custom-json-reporter.js
+++ b/build-system/tasks/e2e/mocha-custom-json-reporter.js
@@ -27,9 +27,12 @@ const {
 const {Base} = require('mocha').reporters;
 const {inherits} = require('mocha').utils;
 
-function writeOutput(output, filename) {
+function writeOutput(output, dir, filename) {
   try {
-    fs.writeFileSync(filename, JSON.stringify(output, null, 4));
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir);
+    }
+    fs.writeFileSync(`${dir}/${filename}`, JSON.stringify(output, null, 4));
     process.stdout.write(
       Base.color(
         'green',
@@ -40,10 +43,10 @@ function writeOutput(output, filename) {
     process.stdout.write(
       Base.color(
         'fail',
-        `Could not write test result report to file '${filename}'`
+        `Could not write test result report to file '${filename}'` +
+          `\n${error}`
       )
     );
-    process.stdout.write(Base.color('fail', error.toString()));
   }
 }
 
@@ -83,7 +86,7 @@ function JsonReporter(runner) {
       time: test.duration, // in milliseconds
     }));
 
-    writeOutput({testResults}, `result-reports/e2e.json`);
+    writeOutput({testResults}, 'result-reports', 'e2e.json');
   });
 }
 

--- a/build-system/tasks/e2e/mocha-custom-json-reporter.js
+++ b/build-system/tasks/e2e/mocha-custom-json-reporter.js
@@ -36,7 +36,7 @@ function writeOutput(output, dir, filename) {
     process.stdout.write(
       Base.color(
         'green',
-        `Successfully wrote test result report to file '${filename}'`
+        `Successfully wrote test result report to file '${filename}'\n`
       )
     );
   } catch (error) {

--- a/build-system/tasks/e2e/mocha-custom-json-reporter.js
+++ b/build-system/tasks/e2e/mocha-custom-json-reporter.js
@@ -27,9 +27,9 @@ const {
 const {Base} = require('mocha').reporters;
 const {inherits} = require('mocha').utils;
 
-async function writeOutput(output, filename) {
+function writeOutput(output, filename) {
   try {
-    await fs.writeFile(filename, JSON.stringify(output, null, 4));
+    fs.writeFileSync(filename, JSON.stringify(output, null, 4));
     process.stdout.write(
       Base.color(
         'green',
@@ -73,7 +73,7 @@ function JsonReporter(runner) {
     });
   });
 
-  runner.on(EVENT_RUN_END, async function () {
+  runner.on(EVENT_RUN_END, function () {
     const testResults = testEvents.map(({test, suiteList, event}) => ({
       description: test.title,
       suite: suiteList,
@@ -85,7 +85,7 @@ function JsonReporter(runner) {
     // Apparently we'll need to add a --no-exit flag when calling this
     // to allow for the asynchronous reporter.
     // See https://github.com/mochajs/mocha/issues/812
-    await writeOutput({testResults}, `result-reports/e2e.json`);
+    writeOutput({testResults}, `result-reports/e2e.json`);
   });
 }
 

--- a/build-system/tasks/e2e/mocha-custom-json-reporter.js
+++ b/build-system/tasks/e2e/mocha-custom-json-reporter.js
@@ -43,6 +43,7 @@ function writeOutput(output, filename) {
         `Could not write test result report to file '${filename}'`
       )
     );
+    process.stdout.write(Base.color('fail', error.toString()));
   }
 }
 

--- a/build-system/tasks/e2e/mocha-custom-json-reporter.js
+++ b/build-system/tasks/e2e/mocha-custom-json-reporter.js
@@ -23,7 +23,7 @@ const {
   EVENT_TEST_PENDING,
   EVENT_SUITE_BEGIN,
   EVENT_SUITE_END,
-} = require('mocha').Runner;
+} = require('mocha').Runner.constants;
 const {Base} = require('mocha').reporters;
 const {inherits} = require('mocha').utils;
 

--- a/build-system/tasks/e2e/mocha-custom-json-reporter.js
+++ b/build-system/tasks/e2e/mocha-custom-json-reporter.js
@@ -82,9 +82,6 @@ function JsonReporter(runner) {
       time: test.duration, // in milliseconds
     }));
 
-    // Apparently we'll need to add a --no-exit flag when calling this
-    // to allow for the asynchronous reporter.
-    // See https://github.com/mochajs/mocha/issues/812
     writeOutput({testResults}, `result-reports/e2e.json`);
   });
 }


### PR DESCRIPTION
<!--
# Instructions:

- Pick a meaningful title for your pull request. (Use sentence case.)
  - Prefix the title with an emoji to identify what is being done. (Copy-paste the emoji from the list below.)
  - Do not overuse punctuation in the title (like `(chore):`).
  - If it is helpful, use a simple prefix (like `ProjectX: Implement some feature`).
- Enter a succinct description that says why the PR is necessary, and what it does.
  - Mention the GitHub issue that is being addressed by the pull request.
  - The keywords `Fixes`, `Closes`, or `Resolves` followed the issue number will automatically close the issue.

> NOTE: All non-trivial changes (like introducing new features or components) should have an associated issue or reference an I2I (intent-to-implement: go.amp.dev/i2i). Please read through the contribution process (go.amp.dev/contributing/code) for more information.

# Example of a good description:

- Implement aspect X
- Leave out feature Y because of A
- Improve performance by B
- Improve accessibility by C

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Reverting a previous change
♻️ Refactoring
🚮 Deleting code
🧪 Experimental code
-->

Normally, we can't tell whether or not these changes break the build (since they only run on push builds). However, manually enabling the flag for the PR build wrote the file successfully, as shown by the following job: https://travis-ci.org/github/ampproject/amphtml/jobs/719671382