### PR TITLE
amp-script: improved error messages

### DIFF
--- a/extensions/amp-script/0.1/amp-script.js
+++ b/extensions/amp-script/0.1/amp-script.js
@@ -288,31 +288,24 @@ export class AmpScript extends AMP.BaseElement {
     };
 
     // Create worker and hydrate.
-    WorkerDOM.upgrade(container || this.element, workerAndAuthorScripts, config)
-      .then((workerDom) => {
-        this.workerDom_ = workerDom;
-        this.initialize_.resolve();
-        // workerDom will be null if it failed to init.
-        if (this.workerDom_) {
-          this.workerDom_.onerror = (errorEvent) => {
-            errorEvent.preventDefault();
-            user().error(
-              TAG,
-              `${errorEvent.message}\n    at (${errorEvent.filename}:${errorEvent.lineno})`
-            );
-          };
-        }
-      })
-      .catch((err) => {
-        // Catch errors if due to an issue with workerAndAuthorScripts rejection.
-        return workerAndAuthorScripts
-          .then(() => {
-            throw err;
-          })
-          .catch(() => {});
-      });
-
-    return workerAndAuthorScripts;
+    return WorkerDOM.upgrade(
+      container || this.element,
+      workerAndAuthorScripts,
+      config
+    ).then((workerDom) => {
+      this.workerDom_ = workerDom;
+      this.initialize_.resolve();
+      // workerDom will be null if it failed to init.
+      if (this.workerDom_) {
+        this.workerDom_.onerror = (errorEvent) => {
+          errorEvent.preventDefault();
+          user().error(
+            TAG,
+            `${errorEvent.message}\n    at (${errorEvent.filename}:${errorEvent.lineno})`
+          );
+        };
+      }
+    });
   }
 
   /**

--- a/extensions/amp-script/0.1/amp-script.js
+++ b/extensions/amp-script/0.1/amp-script.js
@@ -578,7 +578,7 @@ export class AmpScriptService {
         // extraction is ready.
         throw user().createExpectedError(
           TAG,
-          `Script hash not found for ${debugId}. You must include <meta name="amp-script-src" content="sha384-${hash}">.` +
+          `Script hash not found for ${debugId}. You must include <meta name="amp-script-src" content="sha384-${hash}">. ` +
             'See https://amp.dev/documentation/components/amp-script/#script-hash.'
         );
       }

--- a/extensions/amp-script/0.1/amp-script.js
+++ b/extensions/amp-script/0.1/amp-script.js
@@ -569,7 +569,7 @@ export class AmpScriptService {
    *
    * @param {string} script The script contents.
    * @param {string} debugId An element identifier for error messages.
-   * @return {Promise}
+   * @return {!Promise}
    */
   checkSha384(script, debugId) {
     const bytes = utf8Encode(script);

--- a/extensions/amp-script/0.1/amp-script.js
+++ b/extensions/amp-script/0.1/amp-script.js
@@ -576,7 +576,7 @@ export class AmpScriptService {
       if (!hash || !this.sources_.includes('sha384-' + hash)) {
         // TODO(#24266): Refactor to %s interpolation when error string
         // extraction is ready.
-        throw user().createExpectedError(
+        throw user().createError(
           TAG,
           `Script hash not found for ${debugId}. You must include <meta name="amp-script-src" content="sha384-${hash}">. ` +
             'See https://amp.dev/documentation/components/amp-script/#script-hash.'

--- a/extensions/amp-script/0.1/amp-script.js
+++ b/extensions/amp-script/0.1/amp-script.js
@@ -572,7 +572,7 @@ export class AmpScriptService {
         // extraction is ready.
         throw user().createError(
           TAG,
-          `Script hash not found for ${debugId}. You must include <meta name="amp-script-src" content="sha384-${hash}">. ` +
+          `Script hash not found or incorrect for ${debugId}. You must include <meta name="amp-script-src" content="sha384-${hash}">. ` +
             'See https://amp.dev/documentation/components/amp-script/#script-hash.'
         );
       }

--- a/extensions/amp-script/0.1/amp-script.js
+++ b/extensions/amp-script/0.1/amp-script.js
@@ -304,11 +304,12 @@ export class AmpScript extends AMP.BaseElement {
         }
       })
       .catch((err) => {
-        // Exclude all errors created via workerAndAuthorScripts rejection.
-        if (err.message.indexOf('amp-script') > -1) {
-          return;
-        }
-        throw err;
+        // Catch errors if due to an issue with workerAndAuthorScripts rejection.
+        return workerAndAuthorScripts
+          .then(() => {
+            throw err;
+          })
+          .catch(() => {});
       });
 
     return workerAndAuthorScripts;

--- a/extensions/amp-script/0.1/amp-script.js
+++ b/extensions/amp-script/0.1/amp-script.js
@@ -574,7 +574,7 @@ export class AmpScriptService {
         throw user().createError(
           TAG,
           `Script hash not found. ${debugId} must have "sha384-${hash}" in meta[name="amp-script-src"].` +
-            ' See https://amp.dev/documentation/components/amp-script/#security-features.'
+            ' See https://amp.dev/documentation/components/amp-script/#script-hash.'
         );
       }
     });

--- a/extensions/amp-script/0.1/test/unit/test-amp-script.js
+++ b/extensions/amp-script/0.1/test/unit/test-amp-script.js
@@ -56,8 +56,10 @@ describes.fakeWin('AmpScript', {amp: {runtimeOn: false}}, (env) => {
       .resolves({text: () => Promise.resolve('/* noop */')});
     env.sandbox.stub(Services, 'xhrFor').returns(xhr);
 
-    // Make @ampproject/worker-dom dependency a no-op for these unit tests.
-    env.sandbox.stub(WorkerDOM, 'upgrade').resolves();
+    // Make @ampproject/worker-dom dependency essentially a noop for these tests.
+    env.sandbox
+      .stub(WorkerDOM, 'upgrade')
+      .callsFake((unused, scriptsPromise) => scriptsPromise);
   });
 
   function stubFetch(url, headers, text, responseUrl) {

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -1572,7 +1572,7 @@ export class ResourcesImpl {
               this.taskComplete_.bind(this, task, true),
               this.taskComplete_.bind(this, task, false)
             )
-            .catch(/** @type {function (*)} */ (reportError));
+            .catch(/** @type {function (*)} */ (reportError))
         } else {
           dev().fine(TAG_, 'cancelled', task.id);
           resource.layoutCanceled();

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -1572,7 +1572,7 @@ export class ResourcesImpl {
               this.taskComplete_.bind(this, task, true),
               this.taskComplete_.bind(this, task, false)
             )
-            .catch(/** @type {function (*)} */ (reportError))
+            .catch(/** @type {function (*)} */ (reportError));
         } else {
           dev().fine(TAG_, 'cancelled', task.id);
           resource.layoutCanceled();


### PR DESCRIPTION
Fixes https://github.com/ampproject/amphtml/issues/29614

For the reviewer: adding a `.catch` to `WorkerDOM.upgrade` was hacky. If an error occurs within the worker-dom code, we'd probably want an uncaught exception to throw, whereas if it is caused by the code to retrieve authorScript, then we don't want that.

The cleanest way of having the same effect would be to have the entire upgrade path within a `.then()` callback of the scripts, although that would then delay the start of the upgrade until after they've resolved (not that I think worker-dom actually does much work before they do, but it is what caused my hesitation).