### PR TITLE
Fix AMP.navigateTo with relative URLs on cache

### DIFF
--- a/src/service/navigation.js
+++ b/src/service/navigation.js
@@ -30,7 +30,7 @@ import {
   installServiceInEmbedScope,
   registerServiceBuilderForDoc,
 } from '../service';
-import {isLocalhostOrigin} from '../url';
+import {isLocalhostOrigin, resolveRelativeUrl} from '../url';
 import {toWin} from '../types';
 import PriorityQueue from '../utils/priority-queue';
 
@@ -285,8 +285,9 @@ export class Navigation {
       `Target '${target}' not supported.`
     );
 
-    // Resolve navigateTos relative to the source URL, not the proxy URL.
-    url = urlService.getSourceUrl(url);
+    // If we're on cache, resolve relative URLs to the publisher (non-cache) origin.
+    const sourceUrl = urlService.getSourceUrl(win.location);
+    url = resolveRelativeUrl(url, sourceUrl);
 
     // If we have a target of "_blank", we will want to open a new window. A
     // target of "_top" should behave like it would on an anchor tag and

--- a/src/service/navigation.js
+++ b/src/service/navigation.js
@@ -287,7 +287,7 @@ export class Navigation {
 
     // If we're on cache, resolve relative URLs to the publisher (non-cache) origin.
     const sourceUrl = urlService.getSourceUrl(win.location);
-    url = resolveRelativeUrl(url, sourceUrl);
+    url = urlService.resolveRelativeUrl(url, sourceUrl);
 
     // If we have a target of "_blank", we will want to open a new window. A
     // target of "_top" should behave like it would on an anchor tag and

--- a/src/service/navigation.js
+++ b/src/service/navigation.js
@@ -30,7 +30,7 @@ import {
   installServiceInEmbedScope,
   registerServiceBuilderForDoc,
 } from '../service';
-import {isLocalhostOrigin, resolveRelativeUrl} from '../url';
+import {isLocalhostOrigin} from '../url';
 import {toWin} from '../types';
 import PriorityQueue from '../utils/priority-queue';
 

--- a/src/service/url-impl.js
+++ b/src/service/url-impl.js
@@ -24,6 +24,7 @@ import {
   isProxyOrigin,
   isSecureUrlDeprecated,
   parseUrlWithA,
+  resolveRelativeUrl,
 } from '../url';
 import {
   installServiceInEmbedScope,
@@ -118,6 +119,16 @@ export class Url {
    */
   getSourceUrl(url) {
     return getSourceUrl(this.parse_(url));
+  }
+
+  /**
+   * Returns absolute URL resolved based on the relative URL and the base.
+   * @param {string} relativeUrlString
+   * @param {string|!Location} baseUrl
+   * @return {string}
+   */
+  resolveRelativeUrl(relativeUrlString, baseUrl) {
+    return resolveRelativeUrl(relativeUrlString, this.parse_(baseUrl));
   }
 
   /**

--- a/src/url.js
+++ b/src/url.js
@@ -581,7 +581,7 @@ export function resolveRelativeUrl(relativeUrlString, baseUrl) {
  * @param {string} relativeUrlString
  * @param {string|!Location} baseUrl
  * @return {string}
- * @private Visible for testing.
+ * @private @visibleForTesting
  */
 export function resolveRelativeUrlFallback_(relativeUrlString, baseUrl) {
   if (typeof baseUrl == 'string') {

--- a/test/unit/test-navigation.js
+++ b/test/unit/test-navigation.js
@@ -637,15 +637,15 @@ describes.sandboxed('Navigation', {}, () => {
         });
 
         it('should navigate relative to source url', () => {
+          // URLs relative to root.
           win.location.href =
             'https://cdn.ampproject.org/c/s/www.pub.com/dir/page.html';
-          const urlService = Services.urlForDoc(doc.documentElement);
+          handler.navigateTo(win, '/abc.html');
+          expect(win.location.href).to.equal('https://www.pub.com/abc.html');
 
-          env.sandbox.stub(urlService, 'getSourceUrl').callsFake((url) => {
-            expect(url).to.equal('abc.html');
-            return 'https://www.pub.com/dir/abc.html';
-          });
-
+          // URLs relative to current directory.
+          win.location.href =
+            'https://cdn.ampproject.org/c/s/www.pub.com/dir/page.html';
           handler.navigateTo(win, 'abc.html');
           expect(win.location.href).to.equal(
             'https://www.pub.com/dir/abc.html'


### PR DESCRIPTION
Fixes #26248 and patches #22376.

- `getSourceUrl('/path/to/page.html')` causes a userAssert on cache since `*.cdn.ampproject.org/path/` is not a valid CDN prefix