### PR TITLE
✨Consent: Pass consent string and metadata to amp-delight-player

### DIFF
--- a/extensions/amp-delight-player/0.1/amp-delight-player.js
+++ b/extensions/amp-delight-player/0.1/amp-delight-player.js
@@ -72,6 +72,7 @@ const DelightEvent = {
   SEEK: 'x-dl8-to-iframe-seek',
   CUSTOM_TICK: 'x-dl8-to-parent-amp-custom-tick',
   CONSENT_DATA: 'x-dl8-to-iframe-consent-data',
+  PLAYER_READY: 'x-dl8-to-parent-player-ready',
 
   PING: 'x-dl8-ping',
   PONG: 'x-dl8-pong',
@@ -306,7 +307,10 @@ class AmpDelightPlayer extends AMP.BaseElement {
       case DelightEvent.READY: {
         element.dispatchCustomEvent(VideoEvents.LOAD);
         this.playerReadyResolver_(this.iframe_);
-        this.sendConsentData_()
+        break;
+      }
+      case DelightEvent.PLAYER_READY: {
+        this.sendConsentData_();
         break;
       }
       case DelightEvent.TIME_UPDATE: {
@@ -520,7 +524,6 @@ class AmpDelightPlayer extends AMP.BaseElement {
    */
   sendConsentData_() {
     const consentPolicyId = super.getConsentPolicy() || 'default';
-
     const consentStringPromise = getConsentPolicyInfo(
       this.element,
       consentPolicyId

--- a/extensions/amp-delight-player/0.1/amp-delight-player.js
+++ b/extensions/amp-delight-player/0.1/amp-delight-player.js
@@ -549,7 +549,7 @@ class AmpDelightPlayer extends AMP.BaseElement {
         'consentString': consents[1],
         'consentPolicyState': consents[2],
         'consentPolicySharedData': consents[3],
-      })
+      });
     });
   }
 


### PR DESCRIPTION
Since publishers that use the amp-delight-player rely on the correct handling of tcf2 consent strings in the video player it is necessary for the amp-delight-player element to retrieve consent data and send that data via post message to the underlying video player iframe.
