### PR TITLE
♻️ [bento][amp-social-share] Minor cleanup of typedefs PR

### DIFF
--- a/extensions/amp-social-share/1.0/social-share-config.js
+++ b/extensions/amp-social-share/1.0/social-share-config.js
@@ -19,7 +19,7 @@ import {dict} from '../../../src/utils/object';
 /**
  * Get social share configurations by supported type.
  * @param  {string} type
- * @return {SocialShareDef.Config|undefined}
+ * @return {SocialShareConfigDef|undefined}
  */
 export function getSocialConfig(type) {
   return BUILTINS[type];
@@ -40,11 +40,18 @@ export function getSocialConfig(type) {
  *   bindings {?Array<string>} - Used for email, allows passing in an
  *     attribute that can be used in the endpoint, but not as a search param
  *
- * See social-share.types.js for typedef of this type.
+ * @typedef {{
+ *   shareEndpont: string,
+ *   defaultParams: Object<string, string>,
+ *   defaultColor: string,
+ *   defaultBackgroundColor: string,
+ *   bindings: (!Array<string>|undefined),
+ * }}
  */
+let SocialShareConfigDef;
 
 /**
- * @type {Object<string, SocialShareDef.Config>}
+ * @type {Object<string, SocialShareConfigDef>}
  */
 const BUILTINS = {
   'twitter': {

--- a/extensions/amp-social-share/1.0/social-share.js
+++ b/extensions/amp-social-share/1.0/social-share.js
@@ -31,7 +31,7 @@ const DEFAULT_TARGET = '_blank';
 const WINDOW_FEATURES = 'resizable,scrollbars,width=640,height=480';
 
 /**
- * @param {!SocialShareDef.Props} props
+ * @param {!SocialSharePropsDef} props
  * @return {PreactDef.Renderable}
  */
 export function SocialShare({
@@ -63,12 +63,12 @@ export function SocialShare({
 
   return (
     <div
+      {...rest}
       role="button"
       tabindex={tabIndex}
       onKeyDown={(e) => handleKeyPress(e, finalEndpoint, checkedTarget)}
       onClick={() => handleActivation(finalEndpoint, checkedTarget)}
       style={{...size, ...style}}
-      {...rest}
     >
       {processChildren(
         /** @type {string} */ (type),

--- a/extensions/amp-social-share/1.0/social-share.type.js
+++ b/extensions/amp-social-share/1.0/social-share.type.js
@@ -16,9 +16,6 @@
 
 /** @externs */
 
-/** @const */
-var SocialShareDef = {};
-
 /**
  * @typedef {{
  *   type: (string|undefined),
@@ -34,15 +31,4 @@ var SocialShareDef = {};
  *   children: (?PreactDef.Renderable|undefined),
  * }}
  */
-SocialShareDef.Props;
-
-/**
- * @typedef {{
- *   shareEndpont: string,
- *   defaultParams: Object<string, string>,
- *   defaultColor: string,
- *   defaultBackgroundColor: string,
- *   bindings: (!Array<string>|undefined),
- * }}
- */
-SocialShareDef.Config;
+var SocialSharePropsDef;


### PR DESCRIPTION
Follow Up to: https://github.com/ampproject/amphtml/pull/29658
Bento Tracking Issue: https://github.com/ampproject/amphtml/issues/28283

Changes include:
1. Remove Config typedef from externs file - Externs should serve as API for the entire module.  Config type should be used internally and does not need to be exposed.  Also, externs items are not minified, but since config is essentially private, it should be minified.

2. Move {...rest} to be first item within Components returned JSX - Otherwise, user could accidentally overwrite existing attributes on the div.  We do not want to let them accidentally do this.