### PR TITLE
Messaging queue for incoming viewer communication.

### DIFF
--- a/src/service/viewer-impl.js
+++ b/src/service/viewer-impl.js
@@ -126,6 +126,14 @@ export class ViewerImpl {
     this.messageQueue_ = [];
 
     /**
+     * @private {!Object<string, !Array<!{
+     *   data: !JsonObject,
+     *   deferred: !Deferred
+     * }>>}
+     */
+    this.receivedMessageQueue_ = {};
+
+    /**
      * Subset of this.params_ that only contains parameters in the URL hash,
      * e.g. "#foo=bar".
      * @const @private {!Object<string, string>}
@@ -661,12 +669,29 @@ export class ViewerImpl {
       observable = new Observable();
       this.messageObservables_[eventType] = observable;
     }
-    return observable.add(handler);
+    const unlistenFn = observable.add(handler);
+    if (this.receivedMessageQueue_[eventType]) {
+      this.receivedMessageQueue_[eventType].forEach((message) => {
+        observable.fire(message.data);
+        message.deferred.resolve();
+      });
+      this.receivedMessageQueue_[eventType] = [];
+    }
+    return unlistenFn;
   }
 
   /** @override */
   onMessageRespond(eventType, responder) {
     this.messageResponders_[eventType] = responder;
+    if (this.receivedMessageQueue_[eventType]) {
+      this.receivedMessageQueue_[eventType].forEach((message) => {
+        responder(message.data).then(
+          message.deferred.resolve,
+          message.deferred.reject
+        );
+      });
+      this.receivedMessageQueue_[eventType] = [];
+    }
     return () => {
       if (this.messageResponders_[eventType] === responder) {
         delete this.messageResponders_[eventType];
@@ -687,17 +712,25 @@ export class ViewerImpl {
       return Promise.resolve();
     }
     const observable = this.messageObservables_[eventType];
+    const responder = this.messageResponders_[eventType];
+
+    // Queue the message if there are no handlers. Returns a pending promise to
+    // be resolved once a handler/responder is registered.
+    if (!observable && !responder) {
+      this.receivedMessageQueue_[eventType] =
+        this.receivedMessageQueue_[eventType] || [];
+      const deferred = new Deferred();
+      this.receivedMessageQueue_[eventType].push({data, deferred});
+      return deferred.promise;
+    }
     if (observable) {
       observable.fire(data);
     }
-    const responder = this.messageResponders_[eventType];
     if (responder) {
       return responder(data);
     } else if (observable) {
       return Promise.resolve();
     }
-    dev().fine(TAG_, 'unknown message:', eventType);
-    return undefined;
   }
 
   /** @override */

--- a/test/unit/test-viewer.js
+++ b/test/unit/test-viewer.js
@@ -1793,4 +1793,79 @@ describes.sandboxed('Viewer', {}, (env) => {
       return result;
     });
   });
+
+  describe('onMessage', () => {
+    it('should fire observer on event', () => {
+      const onMessageSpy = env.sandbox.spy();
+      viewer.onMessage('event', onMessageSpy);
+      viewer.receiveMessage('event', {foo: 'bar'});
+      expect(onMessageSpy).to.have.been.calledOnceWithExactly({foo: 'bar'});
+    });
+
+    it('should not fire observer on other events', () => {
+      const onMessageSpy = env.sandbox.spy();
+      viewer.onMessage('event', onMessageSpy);
+      viewer.receiveMessage('otherevent', {foo: 'bar'});
+      expect(onMessageSpy).to.not.have.been.called;
+    });
+
+    it('should fire observer with queued messages on handler registration', () => {
+      const onMessageSpy = env.sandbox.spy();
+      viewer.receiveMessage('event', {foo: 'bar'});
+      viewer.onMessage('event', onMessageSpy);
+      expect(onMessageSpy).to.have.been.calledOnceWithExactly({foo: 'bar'});
+    });
+
+    it('should empty queued messages after first handler registration', () => {
+      const onMessageSpy = env.sandbox.spy();
+      viewer.receiveMessage('event', {foo: 'bar'});
+      viewer.onMessage('event', onMessageSpy);
+      viewer.onMessage('event', onMessageSpy);
+      expect(onMessageSpy).to.have.been.calledOnceWithExactly({foo: 'bar'});
+    });
+  });
+
+  describe('onMessageRespond', () => {
+    it('should call responder on event', () => {
+      const onMessageRespondStub = env.sandbox.stub().resolves();
+      viewer.onMessageRespond('event', onMessageRespondStub);
+      viewer.receiveMessage('event', {foo: 'bar'});
+      expect(onMessageRespondStub).to.have.been.calledOnceWithExactly({
+        foo: 'bar',
+      });
+    });
+
+    it('should not call responder on other events', () => {
+      const onMessageRespondStub = env.sandbox.stub().resolves();
+      viewer.onMessageRespond('event', onMessageRespondStub);
+      viewer.receiveMessage('otherevent', {foo: 'bar'});
+      expect(onMessageRespondStub).to.not.have.been.called;
+    });
+
+    it('should call responder with queued messages on responder registration', () => {
+      const onMessageRespondStub = env.sandbox.stub().resolves();
+      viewer.receiveMessage('event', {foo: 'bar'});
+      viewer.onMessageRespond('event', onMessageRespondStub);
+      expect(onMessageRespondStub).to.have.been.calledOnceWithExactly({
+        foo: 'bar',
+      });
+    });
+
+    it('should empty queued messages after first responder registration', () => {
+      const onMessageRespondStub = env.sandbox.stub().resolves();
+      viewer.receiveMessage('event', {foo: 'bar'});
+      viewer.onMessageRespond('event', onMessageRespondStub);
+      viewer.onMessageRespond('event', onMessageRespondStub);
+      expect(onMessageRespondStub).to.have.been.calledOnceWithExactly({
+        foo: 'bar',
+      });
+    });
+
+    it('should return responder response when enqueing message on responder registration', async () => {
+      const onMessageRespondStub = env.sandbox.stub().resolves('response');
+      const promise = viewer.receiveMessage('event', {foo: 'bar'});
+      viewer.onMessageRespond('event', onMessageRespondStub);
+      expect(await promise).to.equal('response');
+    });
+  });
 });


### PR DESCRIPTION
Adding a messaging queue for incoming viewer communication.

Viewers rely on runtime events to know when they can start sending messages to the AMP document. When these runtime events are fired, some extensions might not already be loaded and any message sent by a viewer could be missed.
To allow for extensions to register viewer message handlers/responders without race conditions, we need this messaging queue.

cc @ampproject/wg-runtime 