### PR TITLE
Rename 3P ad intersectionObserver API to legacyAdIntersectionObserver

### DIFF
--- a/extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js
+++ b/extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js
@@ -17,7 +17,6 @@
 import {CONSTANTS, MessageType} from '../../../src/3p-frame-messaging';
 import {CommonSignals} from '../../../src/common-signals';
 import {Deferred} from '../../../src/utils/promise';
-import {legacyAdIntersectionObserver} from './legacy-ad-intersection-observer-host';
 import {Services} from '../../../src/services';
 import {
   SubscriptionApi,
@@ -34,6 +33,7 @@ import {getData} from '../../../src/event-helper';
 import {getHtml} from '../../../src/get-html';
 import {isExperimentOn} from '../../../src/experiments';
 import {isGoogleAdsA4AValidEnvironment} from '../../../ads/google/a4a/utils';
+import {legacyAdIntersectionObserver} from './legacy-ad-intersection-observer-host';
 import {removeElement} from '../../../src/dom';
 import {reportErrorToAnalytics} from '../../../src/error';
 import {setStyle} from '../../../src/style';
@@ -107,7 +107,7 @@ export class AmpAdXOriginIframeHandler {
     // (Behave like position observer)
     this.legacyIntersectionObserverApiHost_ = new legacyAdIntersectionObserver(
       this.baseInstance_,
-      this.iframe,
+      this.iframe
     );
 
     this.embedStateApi_ = new SubscriptionApi(

--- a/extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js
+++ b/extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js
@@ -17,7 +17,7 @@
 import {CONSTANTS, MessageType} from '../../../src/3p-frame-messaging';
 import {CommonSignals} from '../../../src/common-signals';
 import {Deferred} from '../../../src/utils/promise';
-import {IntersectionObserverHostForAd} from './intersection-observer-host';
+import {legacyAdIntersectionObserver} from './legacy-ad-intersection-observer-host';
 import {Services} from '../../../src/services';
 import {
   SubscriptionApi,
@@ -66,8 +66,8 @@ export class AmpAdXOriginIframeHandler {
     /** @type {?HTMLIFrameElement} iframe instance */
     this.iframe = null;
 
-    /** @private {?IntersectionObserverHostForAd} */
-    this.intersectionObserverHost_ = null;
+    /** @private {?legacyAdIntersectionObserver} */
+    this.legacyIntersectionObserverApiHost_ = null;
 
     /** @private {SubscriptionApi} */
     this.embedStateApi_ = null;
@@ -103,11 +103,11 @@ export class AmpAdXOriginIframeHandler {
     this.baseInstance_.applyFillContent(this.iframe);
     const timer = Services.timerFor(this.baseInstance_.win);
 
-    // Init IntersectionObserver service.
-    this.intersectionObserverHost_ = new IntersectionObserverHostForAd(
+    // Init the legacy observeInterection API service.
+    // (Behave like position observer)
+    this.legacyIntersectionObserverApiHost_ = new legacyAdIntersectionObserver(
       this.baseInstance_,
       this.iframe,
-      true
     );
 
     this.embedStateApi_ = new SubscriptionApi(
@@ -434,9 +434,9 @@ export class AmpAdXOriginIframeHandler {
       this.inaboxPositionApi_.destroy();
       this.inaboxPositionApi_ = null;
     }
-    if (this.intersectionObserverHost_) {
-      this.intersectionObserverHost_.destroy();
-      this.intersectionObserverHost_ = null;
+    if (this.legacyIntersectionObserverApiHost_) {
+      this.legacyIntersectionObserverApiHost_.destroy();
+      this.legacyIntersectionObserverApiHost_ = null;
     }
   }
 
@@ -601,9 +601,6 @@ export class AmpAdXOriginIframeHandler {
    * @param {boolean} inViewport
    */
   viewportCallback(inViewport) {
-    if (this.intersectionObserverHost_) {
-      this.intersectionObserverHost_.onViewportCallback(inViewport);
-    }
     this.sendEmbedInfo_(inViewport);
   }
 
@@ -613,8 +610,8 @@ export class AmpAdXOriginIframeHandler {
   onLayoutMeasure() {
     // When the framework has the need to remeasure us, our position might
     // have changed. Send an intersection record if needed.
-    if (this.intersectionObserverHost_) {
-      this.intersectionObserverHost_.fire();
+    if (this.legacyIntersectionObserverApiHost_) {
+      this.legacyIntersectionObserverApiHost_.fire();
     }
   }
 

--- a/extensions/amp-ad/0.1/legacy-ad-intersection-observer-host.js
+++ b/extensions/amp-ad/0.1/legacy-ad-intersection-observer-host.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {MessageType} from '../../../src/3p-frame-messaging';
 import {Services} from '../../../src/services';
 import {SubscriptionApi} from '../../../src/iframe-helper';
 import {devAssert} from '../../../src/log';
@@ -23,7 +24,6 @@ import {
   moveLayoutRect,
   rectIntersection,
 } from '../../../src/layout-rect';
-import {MessageType} from '../../../src/3p-frame-messaging';
 
 /**
  * The structure that defines the rectangle used in intersection observers.
@@ -204,12 +204,10 @@ export class legacyAdIntersectionObserver {
    */
   startSendingIntersectionChanges_() {
     if (!this.intersectionObserver_) {
-      this.intersectionObserver_ = new IntersectionObserver(
-        entries => {
-          const lastEntry = entries[entries.length -1];
-          this.onViewportCallback_(lastEntry.intersectionRatio != 0)
-        }
-      );
+      this.intersectionObserver_ = new IntersectionObserver((entries) => {
+        const lastEntry = entries[entries.length - 1];
+        this.onViewportCallback_(lastEntry.intersectionRatio != 0);
+      });
       this.intersectionObserver_.observe(this.baseElement_.element);
     }
     this.fire();

--- a/extensions/amp-ad/0.1/legacy-ad-intersection-observer-host.js
+++ b/extensions/amp-ad/0.1/legacy-ad-intersection-observer-host.js
@@ -23,6 +23,7 @@ import {
   moveLayoutRect,
   rectIntersection,
 } from '../../../src/layout-rect';
+import {MessageType} from '../../../src/3p-frame-messaging';
 
 /**
  * The structure that defines the rectangle used in intersection observers.
@@ -108,37 +109,40 @@ export function getIntersectionChangeEntry(element, owner, viewport) {
 }
 
 /**
- * The IntersectionObserver class lets any element share its viewport
+ * The legacyAdIntersectionObserver is deprecated and only supported in 3P ad
+ *
+ * The legacyAdIntersectionObserver class lets a 3P ad share its viewport
  * intersection data with an iframe of its choice (most likely contained within
- * the element itself.). When instantiated the class will start listening for a
- * 'send-intersections' postMessage from the iframe, and only then  would start
+ * the element itself.) in the format of IntersectionObserverEntry.
+ * When instantiated the class will start listening for a
+ * 'send-intersections' postMessage from the iframe, and only then would start
  * sending intersection data to the iframe. The intersection data would be sent
- * when the element is moved inside or outside the viewport as well as on scroll
- * and resize. The element should create an IntersectionObserver instance once
- * the Iframe element is created. The IntersectionObserver class exposes a
- * `fire` method that would send the intersection data to the iframe. The
- * IntersectionObserver class exposes a `onViewportCallback` method that should
- * be called inside if the viewportCallback of the element. This would let the
- * element sent intersection data automatically when there element comes inside
- * or goes outside the viewport and also manage sending intersection data
- * onscroll and resize. Note: The IntersectionObserver would not send any data
+ * when the element enters/exits the viewport, as well as on scroll
+ * and resize when the element intersects with the viewport.
+ * The class uses IntersectionObserver to monitor the element's enter/exit of
+ * the viewport. It also exposes a `fire` method to allow AMP to send the
+ * intersection data to the iframe at remeasure.
+ *
+ * Note: The legacyAdIntersectionObserver would not send any data
  * over to the iframe if it had not requested the intersection data already via
- * a postMessage.
+ * 'send-intersections' postMessage.
  */
-export class IntersectionObserverHostForAd {
+export class legacyAdIntersectionObserver {
   /**
    * @param {!AMP.BaseElement} baseElement
-   * @param {!Element} iframe Iframe element which requested the
+   * @param {!Element} adIframe Iframe element which requested the
    *     intersection data.
-   * @param {?boolean} opt_is3p Set to `true` when the iframe is 3'rd party.
    */
-  constructor(baseElement, iframe, opt_is3p) {
+  constructor(baseElement, adIframe) {
     /** @private @const {!AMP.BaseElement} */
     this.baseElement_ = baseElement;
+
     /** @private @const {!../../../src/service/timer-impl.Timer} */
     this.timer_ = Services.timerFor(baseElement.win);
-    /** @private {boolean} */
-    this.shouldSendIntersectionChanges_ = false;
+
+    /** @private {?IntersectionObserver} */
+    this.intersectionObserver_ = null;
+
     /** @private {boolean} */
     this.inViewport_ = false;
 
@@ -159,9 +163,9 @@ export class IntersectionObserverHostForAd {
      * @private {!SubscriptionApi}
      */
     this.postMessageApi_ = new SubscriptionApi(
-      iframe,
-      'send-intersections',
-      opt_is3p || false,
+      adIframe,
+      MessageType.SEND_INTERSECTIONS,
+      true, // is3p
       // Each time someone subscribes we make sure that they
       // get an update.
       () => this.startSendingIntersectionChanges_()
@@ -199,21 +203,23 @@ export class IntersectionObserverHostForAd {
    * @private
    */
   startSendingIntersectionChanges_() {
-    this.shouldSendIntersectionChanges_ = true;
-    this.baseElement_.getVsync().measure(() => {
-      if (this.baseElement_.isInViewport()) {
-        this.onViewportCallback(true);
-      }
-      this.fire();
-    });
+    if (!this.intersectionObserver_) {
+      this.intersectionObserver_ = new IntersectionObserver(
+        entries => {
+          const lastEntry = entries[entries.length -1];
+          this.onViewportCallback_(lastEntry.intersectionRatio != 0)
+        }
+      );
+      this.intersectionObserver_.observe(this.baseElement_.element);
+    }
+    this.fire();
   }
 
   /**
-   * Triggered by the AmpElement to when it either enters or exits the visible
-   * viewport.
+   * Triggered when the ad either enters or exits the visible viewport.
    * @param {boolean} inViewport true if the element is in viewport.
    */
-  onViewportCallback(inViewport) {
+  onViewportCallback_(inViewport) {
     if (this.inViewport_ == inViewport) {
       return;
     }
@@ -244,7 +250,7 @@ export class IntersectionObserverHostForAd {
    * @private
    */
   sendElementIntersection_() {
-    if (!this.shouldSendIntersectionChanges_) {
+    if (!this.intersectionObserver_) {
       return;
     }
     const change = this.baseElement_.element.getIntersectionChangeEntry();
@@ -273,7 +279,7 @@ export class IntersectionObserverHostForAd {
     }
     // Note that SubscribeApi multicasts the update to all interested windows.
     this.postMessageApi_.send(
-      'intersection',
+      MessageType.INTERSECTION,
       dict({
         'changes': this.pendingChanges_,
       })
@@ -285,6 +291,10 @@ export class IntersectionObserverHostForAd {
    * Provide a function to clear timeout before set this intersection to null.
    */
   destroy() {
+    if (this.intersectionObserver_) {
+      this.intersectionObserver_.disconnect();
+      this.intersectionObserver_ = null;
+    }
     this.timer_.cancel(this.flushTimeout_);
     this.unlistenOnOutViewport_();
     this.postMessageApi_.destroy();

--- a/extensions/amp-ad/0.1/test/test-legacy-ad-intersection-observer-host.js
+++ b/extensions/amp-ad/0.1/test/test-legacy-ad-intersection-observer-host.js
@@ -15,14 +15,13 @@
  */
 
 import {BaseElement} from '../../../../src/base-element';
-import {
-  legacyAdIntersectionObserver,
-  getIntersectionChangeEntry,
-} from '../legacy-ad-intersection-observer-host';
 import {createAmpElementForTesting} from '../../../../src/custom-element';
-import {layoutRectLtwh} from '../../../../src/layout-rect';
 import {deserializeMessage} from '../../../../src/3p-frame-messaging';
-
+import {
+  getIntersectionChangeEntry,
+  legacyAdIntersectionObserver,
+} from '../legacy-ad-intersection-observer-host';
+import {layoutRectLtwh} from '../../../../src/layout-rect';
 
 describes.sandboxed('getIntersectionChangeEntry', {}, () => {
   beforeEach(() => {
@@ -313,7 +312,6 @@ describes.sandboxed('IntersectionObserverHostForAd', {}, () => {
 
   beforeEach(() => {
     clock = window.sandbox.useFakeTimers();
-    testElementGetInsersectionElementLayoutBox = window.sandbox.spy();
     getIntersectionChangeEntrySpy = window.sandbox.spy();
     onScrollSpy = window.sandbox.spy();
     onChangeSpy = window.sandbox.spy();
@@ -335,9 +333,9 @@ describes.sandboxed('IntersectionObserverHostForAd', {}, () => {
     element.element = document.createElement('amp-int');
     element.element.getIntersectionChangeEntry = () => {
       getIntersectionChangeEntrySpy();
-        const rootBounds = layoutRectLtwh(198, 299, 100, 100);
-        const layoutBox = layoutRectLtwh(50, 100, 150, 200);
-        return getIntersectionChangeEntry(layoutBox, null, rootBounds);
+      const rootBounds = layoutRectLtwh(198, 299, 100, 100);
+      const layoutBox = layoutRectLtwh(50, 100, 150, 200);
+      return getIntersectionChangeEntry(layoutBox, null, rootBounds);
     };
   });
 

--- a/extensions/amp-iframe/amp-iframe.md
+++ b/extensions/amp-iframe/amp-iframe.md
@@ -246,9 +246,7 @@ window.addEventListener('message', function (event) {
 });
 ```
 
-The intersection message would be sent by the parent to the iframe when the
-iframe moves in or out of the viewport (or is partially visible), when the
-iframe is scrolled or resized.
+The intersection message would be sent by the parent to the iframe in the format of IntersectionObserver entry wheneve there is intersectionRatio change across thresholds [0, 0.05, 0.1, ... 0.9, 0.95, 1].
 
 ## Attributes
 

--- a/test/fixtures/served/iframe-intersection.html
+++ b/test/fixtures/served/iframe-intersection.html
@@ -32,7 +32,6 @@ function log(m) {
 
 window.addEventListener('message', function(event) {
   if (event.data) {
-    console.log(event.data);
     if (event.data.type == 'intersection') {
       log('Received intersection message');
       parent.parent./*OK*/postMessage({

--- a/test/fixtures/served/iframe-intersection.html
+++ b/test/fixtures/served/iframe-intersection.html
@@ -32,6 +32,7 @@ function log(m) {
 
 window.addEventListener('message', function(event) {
   if (event.data) {
+    console.log(event.data);
     if (event.data.type == 'intersection') {
       log('Received intersection message');
       parent.parent./*OK*/postMessage({

--- a/test/integration/test-amp-ad-3p.js
+++ b/test/integration/test-amp-ad-3p.js
@@ -237,11 +237,11 @@ describe('amp-ad 3P', () => {
           return lastIO != null && lastIO.intersectionRatio == 0;
         });
 
-        lastIO = null
+        lastIO = null;
         // Scroll when ad is invisible
         fixture.win.scrollTo(0, 1451);
         fixture.win.dispatchEvent(new Event('scroll'));
-        await new Promise(resolve => {
+        await new Promise((resolve) => {
           setTimeout(resolve, 100);
         });
         expect(lastIO).to.be.null;

--- a/test/integration/test-amp-ad-3p.js
+++ b/test/integration/test-amp-ad-3p.js
@@ -230,12 +230,21 @@ describe('amp-ad 3P', () => {
         );
         lastIO = null;
 
-        // Ad becomes invisible
+        // Ad first becomes invisible
         fixture.win.scrollTo(0, 1251);
         fixture.win.dispatchEvent(new Event('scroll'));
         await poll('wait for new IO entry when ad exit viewport', () => {
           return lastIO != null && lastIO.intersectionRatio == 0;
         });
+
+        lastIO = null
+        // Scroll when ad is invisible
+        fixture.win.scrollTo(0, 1451);
+        fixture.win.dispatchEvent(new Event('scroll'));
+        await new Promise(resolve => {
+          setTimeout(resolve, 100);
+        });
+        expect(lastIO).to.be.null;
       })
       .then(
         () =>


### PR DESCRIPTION
Follow up PR to #29853

1. Update comment & doc on the difference between the `send-intersections` API difference between amp-ad and amp-iframe. 
2. Rename class/file name to `legacyAdIntersectionObserver`
3. `legacyAdIntersectionObserver` to use IntersectionObserver to monitor enter/exit viewport instead of `viewportCallback()`
4. Remove unused code
5. Improved 3p ad observerIntersection integration test. 

Let me know how can I better clarify the difference between `legacyAdIntersectionObserver` and `IntersectionObserverHostApi`