### PR TITLE
🚀 Don't log user/dev errors to console in ESM

### DIFF
--- a/build-system/babel-plugins/babel-plugin-transform-dev-methods/index.js
+++ b/build-system/babel-plugins/babel-plugin-transform-dev-methods/index.js
@@ -27,14 +27,14 @@ function defaultCalleeToPropertiesMap() {
       'dev',
       {
         detected: false,
-        removeable: ['info', 'fine'],
+        removeable: ['info', 'fine', 'warn', 'error'],
       },
     ],
     [
       'user',
       {
         detected: false,
-        removeable: ['fine'],
+        removeable: ['info', 'fine', 'warn', 'error'],
       },
     ],
   ]);

--- a/extensions/amp-story/1.0/amp-story-access.js
+++ b/extensions/amp-story/1.0/amp-story-access.js
@@ -255,12 +255,14 @@ export class AmpStoryAccess extends AMP.BaseElement {
     );
     const logoSrc = storyEl && storyEl.getAttribute('publisher-logo-src');
 
-    logoSrc
-      ? assertHttpsUrl(logoSrc, storyEl, 'publisher-logo-src')
-      : user().warn(
-          TAG,
-          'Expected "publisher-logo-src" attribute on <amp-story>'
-        );
+    if (logoSrc) {
+      assertHttpsUrl(logoSrc, storyEl, 'publisher-logo-src');
+    } else {
+      user().warn(
+        TAG,
+        'Expected "publisher-logo-src" attribute on <amp-story>'
+      );
+    }
 
     return logoSrc;
   }

--- a/extensions/amp-story/1.0/amp-story-consent.js
+++ b/extensions/amp-story/1.0/amp-story-consent.js
@@ -217,12 +217,14 @@ export class AmpStoryConsent extends AMP.BaseElement {
 
     const logoSrc = storyEl && storyEl.getAttribute('publisher-logo-src');
 
-    logoSrc
-      ? assertHttpsUrl(logoSrc, storyEl, 'publisher-logo-src')
-      : user().warn(
-          TAG,
-          'Expected "publisher-logo-src" attribute on <amp-story>'
-        );
+    if (logoSrc) {
+      assertHttpsUrl(logoSrc, storyEl, 'publisher-logo-src');
+    } else {
+      user().warn(
+        TAG,
+        'Expected "publisher-logo-src" attribute on <amp-story>'
+      );
+    }
 
     // Story consent config is set by the `assertAndParseConfig_` method.
     if (this.storyConsentConfig_) {


### PR DESCRIPTION
These "errors" are expected and targeted at developers. Since ESM is only served to documents from the cache, we don't need to include these developer logs. Removing these logs saves 1.53kb compressed, bringing the ESM build to 58.86kb. If we move forward there can also be additional savings from other expected errors that are thrown directly now instead of using these methods. 