### PR TITLE
🏗 Make tests on IE more resilient

### DIFF
--- a/build-system/tasks/runtime-test/runtime-test-base.js
+++ b/build-system/tasks/runtime-test/runtime-test-base.js
@@ -67,7 +67,7 @@ function updateBrowsers(config) {
       customLaunchers: {
         IeNoAddOns: {
           base: 'IE',
-          flags: ['-extoff'],
+          flags: ['-extoff -noframemerging'],
         },
       },
     });


### PR DESCRIPTION
This PR attempts to make test runs on IE more resilient to crashes / failures due to browser window launches.

Reference: https://github.com/karma-runner/karma-ie-launcher/issues/104