### PR TITLE
🧪 Remove branches from JSON targeting macro exp

### DIFF
--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -99,14 +99,13 @@ import {
   waitFor3pThrottle,
 } from '../../amp-ad/0.1/concurrent-load';
 import {getCryptoRandomBytesArray, utf8Decode} from '../../../src/utils/bytes';
-import {
-  getExperimentBranch,
-  isExperimentOn,
-  randomlySelectUnsetExperiments,
-} from '../../../src/experiments';
 import {getMode} from '../../../src/mode';
 import {getMultiSizeDimensions} from '../../../ads/google/utils';
 import {getOrCreateAdCid} from '../../../src/ad-cid';
+import {
+  isExperimentOn,
+  randomlySelectUnsetExperiments,
+} from '../../../src/experiments';
 
 import {insertAnalyticsElement} from '../../../src/extension-analytics';
 import {isArray} from '../../../src/types';
@@ -146,17 +145,6 @@ const ZINDEX_EXP = 'zIndexExp';
 const ZINDEX_EXP_BRANCHES = {
   NO_ZINDEX: '21065356',
   HOLDBACK: '21065357',
-};
-
-/**
- * @const @enum {string}
- * @visibleForTesting
- * TODO(#28555): Clean up experiment
- */
-export const EXPAND_JSON_TARGETING_EXP = {
-  ID: 'expand-json-targeting',
-  CONTROL: '21066261',
-  EXPERIMENT: '21066262',
 };
 
 /** @const @enum {string} */
@@ -448,14 +436,6 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
         experimentId: ZINDEX_EXP,
         isTrafficEligible: () => true,
         branches: Object.values(ZINDEX_EXP_BRANCHES),
-      },
-      {
-        experimentId: EXPAND_JSON_TARGETING_EXP.ID,
-        isTrafficEligible: () => true,
-        branches: [
-          EXPAND_JSON_TARGETING_EXP.CONTROL,
-          EXPAND_JSON_TARGETING_EXP.EXPERIMENT,
-        ],
       },
       {
         experimentId: RENDER_ON_IDLE_FIX_EXP.id,
@@ -768,10 +748,10 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
     });
 
     // TODO(#28555): Delete extra logic when 'expand-json-targeting' exp launches.
-    const isJsonTargetingExpOn =
-      isExperimentOn(this.win, 'expand-json-targeting') &&
-      getExperimentBranch(this.win, EXPAND_JSON_TARGETING_EXP.ID) ===
-        EXPAND_JSON_TARGETING_EXP.EXPERIMENT;
+    const isJsonTargetingExpOn = isExperimentOn(
+      this.win,
+      'expand-json-targeting'
+    );
 
     const targetingExpansionPromise = isJsonTargetingExpOn
       ? timerService

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -34,7 +34,6 @@ import {
 import {AmpAd} from '../../../amp-ad/0.1/amp-ad';
 import {
   AmpAdNetworkDoubleclickImpl,
-  EXPAND_JSON_TARGETING_EXP,
   getNetworkId,
   getPageviewStateTokensForAdRequest,
   resetLocationQueryParametersForTesting,
@@ -48,10 +47,7 @@ import {QQID_HEADER} from '../../../../ads/google/a4a/utils';
 import {SafeframeHostApi} from '../safeframe-host';
 import {Services} from '../../../../src/services';
 import {createElementWithAttributes} from '../../../../src/dom';
-import {
-  forceExperimentBranch,
-  toggleExperiment,
-} from '../../../../src/experiments';
+import {toggleExperiment} from '../../../../src/experiments';
 
 /**
  * We're allowing external resources because otherwise using realWin causes
@@ -812,11 +808,6 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, (env) => {
 
     it('expands CLIENT_ID in targeting', () => {
       toggleExperiment(win, 'expand-json-targeting', true, true);
-      forceExperimentBranch(
-        win,
-        EXPAND_JSON_TARGETING_EXP.ID,
-        EXPAND_JSON_TARGETING_EXP.EXPERIMENT
-      );
       element.setAttribute(
         'json',
         `{
@@ -833,11 +824,6 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, (env) => {
 
     it('expands CLIENT_ID in targeting inside array', () => {
       toggleExperiment(win, 'expand-json-targeting', true, true);
-      forceExperimentBranch(
-        win,
-        EXPAND_JSON_TARGETING_EXP.ID,
-        EXPAND_JSON_TARGETING_EXP.EXPERIMENT
-      );
       element.setAttribute(
         'json',
         `{


### PR DESCRIPTION
In accordance with our new strategy. Remove the branches, but leave the doc level experiment on for easy revert.