### PR TITLE
Keep error and expectedError in ESM builds

### DIFF
--- a/build-system/babel-plugins/babel-plugin-transform-dev-methods/index.js
+++ b/build-system/babel-plugins/babel-plugin-transform-dev-methods/index.js
@@ -27,14 +27,14 @@ function defaultCalleeToPropertiesMap() {
       'dev',
       {
         detected: false,
-        removeable: ['info', 'fine', 'warn', 'error', 'expectedError'],
+        removeable: ['info', 'fine', 'warn'],
       },
     ],
     [
       'user',
       {
         detected: false,
-        removeable: ['info', 'fine', 'warn', 'error', 'expectedError'],
+        removeable: ['info', 'fine', 'warn'],
       },
     ],
   ]);


### PR DESCRIPTION
We use `.error()` and `.expectedError()` to send error reports to amp-error-reporting server.

Undoes part of https://github.com/ampproject/amphtml/pull/29913.