### PR TITLE
🏗 Update the class names that visual-diff uses to verify loading is complete

### DIFF
--- a/build-system/tasks/visual-diff/helpers.js
+++ b/build-system/tasks/visual-diff/helpers.js
@@ -160,7 +160,7 @@ async function verifySelectorsVisible(page, testName, selectors) {
 async function waitForLoaderDots(page, testName) {
   const allLoaderDotsGone = await waitForElementVisibility(
     page,
-    '.i-amphtml-loader-dot',
+    '[class~="i-amphtml-loader"], [class~="i-amphtml-loading"]',
     {hidden: true}
   );
   if (!allLoaderDotsGone) {

--- a/build-system/tasks/visual-diff/helpers.js
+++ b/build-system/tasks/visual-diff/helpers.js
@@ -151,19 +151,19 @@ async function verifySelectorsVisible(page, testName, selectors) {
 }
 
 /**
- * Wait for all AMP loader dot to disappear.
+ * Wait for all AMP loader indicators to disappear.
  *
  * @param {!puppeteer.Page} page page to wait on.
  * @param {string} testName the full name of the test.
  * @throws {Error} an encountered error.
  */
-async function waitForLoaderDots(page, testName) {
-  const allLoaderDotsGone = await waitForElementVisibility(
+async function waitForPageLoad(page, testName) {
+  const allLoadersGone = await waitForElementVisibility(
     page,
     '[class~="i-amphtml-loader"], [class~="i-amphtml-loading"]',
     {hidden: true}
   );
-  if (!allLoaderDotsGone) {
+  if (!allLoadersGone) {
     throw new Error(
       `${colors.cyan(testName)} still has the AMP loader dot ` +
         `after ${CSS_SELECTOR_TIMEOUT_MS} ms`
@@ -265,7 +265,7 @@ async function waitForSelectorExistence(page, selector) {
 module.exports = {
   escapeHtml,
   log,
-  waitForLoaderDots,
+  waitForPageLoad,
   verifySelectorsInvisible,
   verifySelectorsVisible,
 };

--- a/build-system/tasks/visual-diff/index.js
+++ b/build-system/tasks/visual-diff/index.js
@@ -28,7 +28,7 @@ const {
 const {
   escapeHtml,
   log,
-  waitForLoaderDots,
+  waitForPageLoad,
   verifySelectorsInvisible,
   verifySelectorsVisible,
 } = require('./helpers');
@@ -527,7 +527,7 @@ async function snapshotWebpages(browser, webpages) {
         // displayed), then, depending on the test configurations, wait for
         // invisibility/visibility of specific elements that match the
         // configured CSS selectors.
-        await waitForLoaderDots(page, name);
+        await waitForPageLoad(page, name);
         if (webpage.loading_incomplete_selectors) {
           await verifySelectorsInvisible(
             page,


### PR DESCRIPTION
AMP has modified the way it displays loading indicators a while back, this PR updates the visual diff task to catch up and, hopefully, deal with any recent flakiness