### PR TITLE
🐛 Get natural dimensions of image in checkImageReSize_

### DIFF
--- a/extensions/amp-story-360/0.1/amp-story-360.js
+++ b/extensions/amp-story-360/0.1/amp-story-360.js
@@ -219,7 +219,7 @@ export class AmpStory360 extends AMP.BaseElement {
   }
 
   /**
-   * Checks if the image is larger than the GPUs max texture size.
+   * Checks if the images natural size is larger than the GPUs max texture size.
    * Scales the image down if neededed.
    * Returns the image element if image is within bounds.
    * If image is out of bounds, returns a scaled canvas element.
@@ -232,11 +232,14 @@ export class AmpStory360 extends AMP.BaseElement {
     const gl = canvasForGL.getContext('webgl');
     const MAX_TEXTURE_SIZE = gl.getParameter(gl.MAX_TEXTURE_SIZE);
 
-    if (imgEl.width > MAX_TEXTURE_SIZE || imgEl.height > MAX_TEXTURE_SIZE) {
+    if (
+      imgEl.naturalWidth > MAX_TEXTURE_SIZE ||
+      imgEl.naturalHeight > MAX_TEXTURE_SIZE
+    ) {
       const canvas = document.createElement('canvas');
       const ctx = canvas.getContext('2d');
-      canvas.width = Math.min(imgEl.width, MAX_TEXTURE_SIZE);
-      canvas.height = Math.min(imgEl.height, MAX_TEXTURE_SIZE);
+      canvas.width = Math.min(imgEl.naturalWidth, MAX_TEXTURE_SIZE);
+      canvas.height = Math.min(imgEl.naturalHeight, MAX_TEXTURE_SIZE);
       ctx.drawImage(imgEl, 0, 0, canvas.width, canvas.height);
       return canvas;
     } else {

--- a/extensions/amp-story-360/0.1/amp-story-360.js
+++ b/extensions/amp-story-360/0.1/amp-story-360.js
@@ -219,7 +219,7 @@ export class AmpStory360 extends AMP.BaseElement {
   }
 
   /**
-   * Checks if the images natural size is larger than the GPUs max texture size.
+   * Checks if the image is larger than the GPUs max texture size.
    * Scales the image down if neededed.
    * Returns the image element if image is within bounds.
    * If image is out of bounds, returns a scaled canvas element.


### PR DESCRIPTION
This is a follow up to #29882

Use `naturalWidth` and `naturalHeight` from `imgEl` instead of `width` and `height`.
Otherwise if the user specifies smaller image dimensions the code will fail.

Such as in this example:
![Screen Shot 2020-08-25 at 3 33 57 PM](https://user-images.githubusercontent.com/3860311/91219310-69336b00-e6e8-11ea-86e2-c1b665a482e2.png)
`imgEl.width` would equal `10` and the code will fail.
We need to use `imgEl.naturalWidth` to get the source image dimension which is `7168`

