### PR TITLE
🚀 Change user error to warn in document-submit.js

### DIFF
--- a/src/document-submit.js
+++ b/src/document-submit.js
@@ -118,17 +118,12 @@ export function onDocumentFormSubmit_(e) {
   } else if (method == 'POST') {
     if (action) {
       const TAG = 'form';
-      user().error(
-        TAG,
-        'action attribute is invalid for method=POST: %s',
-        form
-      );
+      user().warn(TAG, 'action attribute is invalid for method=POST: %s', form);
     }
 
     if (!actionXhr) {
       e.preventDefault();
-      userAssert(
-        false,
+      user().warn(
         'Only XHR based (via action-xhr attribute) submissions are support ' +
           'for POST requests. %s',
         form

--- a/src/document-submit.js
+++ b/src/document-submit.js
@@ -123,7 +123,9 @@ export function onDocumentFormSubmit_(e) {
 
     if (!actionXhr) {
       e.preventDefault();
+      const TAG = 'form';
       user().warn(
+        TAG,
         'Only XHR based (via action-xhr attribute) submissions are support ' +
           'for POST requests. %s',
         form

--- a/test/unit/test-document-submit.js
+++ b/test/unit/test-document-submit.js
@@ -167,6 +167,7 @@ describes.sandboxed('test-document-submit', {}, (env) => {
       allowConsoleError(() => {
         onDocumentFormSubmit_(evt);
         expect(warnSpy).to.be.calledWith(
+          'form',
           env.sandbox.match(
             /Only XHR based \(via action-xhr attribute\) submissions/
           ),

--- a/test/unit/test-document-submit.js
+++ b/test/unit/test-document-submit.js
@@ -19,6 +19,7 @@ import {
   installGlobalSubmitListenerForDoc,
   onDocumentFormSubmit_,
 } from '../../src/document-submit';
+import {user} from '../../src/log';
 
 describes.sandboxed('test-document-submit', {}, (env) => {
   describe('installGlobalSubmitListenerForDoc', () => {
@@ -160,11 +161,16 @@ describes.sandboxed('test-document-submit', {}, (env) => {
     });
 
     it('should fail when POST and action-xhr is not set', () => {
+      const warnSpy = env.sandbox.spy(user(), 'warn');
       evt.target.removeAttribute('action');
       evt.target.setAttribute('method', 'post');
       allowConsoleError(() => {
-        expect(() => onDocumentFormSubmit_(evt)).to.throw(
-          /Only XHR based \(via action-xhr attribute\) submissions/
+        onDocumentFormSubmit_(evt);
+        expect(warnSpy).to.be.calledWith(
+          env.sandbox.match(
+            /Only XHR based \(via action-xhr attribute\) submissions/
+          ),
+          env.sandbox.match.any
         );
       });
       expect(preventDefaultSpy).to.have.been.called;


### PR DESCRIPTION
`user().error()` logs to our error reporting service, and doesn't get stripped from the esm build where `user().warn()` is removed by a Babel transform. Additionally `userAssert(false, ...)` is the same as `user().error()`. Unless we are acting on this message when reported to the logging service, we should turn it into a warning. 