### PR TITLE
🏗 Split off renovate updates for babel packages into a separate PR

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -84,6 +84,16 @@
     },
 
     {
+      "packagePatterns": ["\\bbabel\\b"],
+
+      "groupName": "babel devDependencies",
+      "major": {
+        "groupName": null,
+        "managerBranchPrefix": "babel-"
+      }
+    },
+
+    {
       "packagePatterns": ["renovate"],
       "depTypeList": ["devDependencies"],
       "groupName": "Renovate Bot"

--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -84,7 +84,7 @@
     },
 
     {
-      "packagePatterns": ["\\bbabel\\b"],
+      "packagePatterns": ["\\bbabel"],
 
       "groupName": "babel devDependencies",
       "major": {


### PR DESCRIPTION
Babel updates often require accompanying code changes. This PR splits them off into a dedicated PR so that other updates are not blocked.

