### PR TITLE
Allow ini-load & render-start trigger in sandboxed analytics component

### DIFF
--- a/extensions/amp-analytics/0.1/amp-analytics.js
+++ b/extensions/amp-analytics/0.1/amp-analytics.js
@@ -53,6 +53,8 @@ const MAX_REPLACES = 16; // The maximum number of entries in a extraUrlParamsRep
 const ALLOWLIST_EVENT_IN_SANDBOX = [
   AnalyticsEventType.VISIBLE,
   AnalyticsEventType.HIDDEN,
+  AnalyticsEventType.INI_LOAD,
+  AnalyticsEventType.RENDER_START,
 ];
 
 export class AmpAnalytics extends AMP.BaseElement {


### PR DESCRIPTION
Follow up to #29779 
This is to fix the beginToRender request which waits for the `ini-load` signal. 

Tested with the fake ad type. We can make the fake ad  support the `extractAmpAnalyticsConfig()` feature that insert analytics component based on `x-analytics` is response header or a meta tag.