### PR TITLE
gulp babel-plugin-test failure should fail ci

### DIFF
--- a/build-system/babel-plugins/babel-plugin-transform-dev-methods/index.js
+++ b/build-system/babel-plugins/babel-plugin-transform-dev-methods/index.js
@@ -41,9 +41,8 @@ function defaultCalleeToPropertiesMap() {
 }
 
 // This Babel Plugin removes
-// 1. `dev().info(...)`
-// 2. `dev().fine(...)`
-// 3. `user().fine(...)`
+// - `dev().(info|fine|warn)(...)`
+// - `user().(info|fine|warn)(...)`
 // CallExpressions for production ESM builds.
 module.exports = function () {
   let calleeToPropertiesMap = defaultCalleeToPropertiesMap();

--- a/build-system/babel-plugins/babel-plugin-transform-dev-methods/test/fixtures/transform-assertions/imported-both-usage/input.js
+++ b/build-system/babel-plugins/babel-plugin-transform-dev-methods/test/fixtures/transform-assertions/imported-both-usage/input.js
@@ -34,7 +34,8 @@ function hello() {
   );
   dev().fine(TAG, 'fine');
   user().fine(TAG, 'fine');
-  user().info('Should not be removed');
+  user().info('Should be removed');
+  user().error('Should not be removed');
   return false;
 }
 
@@ -45,8 +46,8 @@ export function helloAgain() {
     fromLocation.search
   );
   dev().fine(TAG, 'fine');
-  user().fine(TAG, 'fine');
-  user().info('Should not be removed');
+  user().warn(TAG, 'warn');
+  user().error('Should not be removed');
   return false;
 }
 
@@ -59,6 +60,7 @@ class Foo {
     );
     dev().fine(TAG, 'fine');
     user().fine(TAG, 'fine');
-    user().info('Should not be removed');
+    dev().error(TAG, 'Should not be removed');
+    user().error('Should not be removed');
   }
 }

--- a/build-system/babel-plugins/babel-plugin-transform-dev-methods/test/fixtures/transform-assertions/imported-both-usage/output.mjs
+++ b/build-system/babel-plugins/babel-plugin-transform-dev-methods/test/fixtures/transform-assertions/imported-both-usage/output.mjs
@@ -16,21 +16,21 @@
 import { dev, user } from '../../../../../../../src/log';
 dev().info;
 user().fine;
-user().info('Should not be removed');
 
 function hello() {
-  user().info('Should not be removed');
+  user().error('Should not be removed');
   return false;
 }
 
 export function helloAgain() {
-  user().info('Should not be removed');
+  user().error('Should not be removed');
   return false;
 }
 
 class Foo {
   method() {
-    user().info('Should not be removed');
+    dev().error(TAG, 'Should not be removed');
+    user().error('Should not be removed');
   }
 
 }

--- a/build-system/babel-plugins/babel-plugin-transform-dev-methods/test/fixtures/transform-assertions/imported-user-usage/input.js
+++ b/build-system/babel-plugins/babel-plugin-transform-dev-methods/test/fixtures/transform-assertions/imported-user-usage/input.js
@@ -18,23 +18,23 @@ import {user} from '../../../../../../../src/log';
 
 user().fine(TAG, 'fine');
 user().fine;
-user().info('Should not be removed');
+user().error('Should not be removed');
 
 function hello() {
   user().fine(TAG, 'fine');
-  user().info('Should not be removed');
+  user().info('Should be removed');
   return false;
 }
 
 export function helloAgain() {
   user().fine(TAG, 'fine');
-  user().info('Should not be removed');
+  user().error('Should not be removed');
   return false;
 }
 
 class Foo {
   method() {
     user().fine(TAG, 'fine');
-    user().info('Should not be removed');
+    user().info('Should be removed');
   }
 }

--- a/build-system/babel-plugins/babel-plugin-transform-dev-methods/test/fixtures/transform-assertions/imported-user-usage/output.mjs
+++ b/build-system/babel-plugins/babel-plugin-transform-dev-methods/test/fixtures/transform-assertions/imported-user-usage/output.mjs
@@ -15,21 +15,18 @@
  */
 import { user } from '../../../../../../../src/log';
 user().fine;
-user().info('Should not be removed');
+user().error('Should not be removed');
 
 function hello() {
-  user().info('Should not be removed');
   return false;
 }
 
 export function helloAgain() {
-  user().info('Should not be removed');
+  user().error('Should not be removed');
   return false;
 }
 
 class Foo {
-  method() {
-    user().info('Should not be removed');
-  }
+  method() {}
 
 }

--- a/build-system/tasks/babel-plugin-tests.js
+++ b/build-system/tasks/babel-plugin-tests.js
@@ -35,7 +35,11 @@ async function babelPluginTests() {
     testRegex: '/babel-plugins/[^/]+/test/.+\\.m?js$',
     transformIgnorePatterns: ['/node_modules/'],
   };
-  await jest.runCLI(options, projects);
+
+  const aggregatedResults = await jest.runCLI(options, projects);
+  if (!aggregatedResults.success) {
+    throw new Error('See the logs above for details.');
+  }
 }
 
 module.exports = {

--- a/build-system/tasks/babel-plugin-tests.js
+++ b/build-system/tasks/babel-plugin-tests.js
@@ -36,6 +36,8 @@ async function babelPluginTests() {
     transformIgnorePatterns: ['/node_modules/'],
   };
 
+  // The `jest.runCLI` command is undocumented. See the types file for object shape:
+  // https://github.com/facebook/jest/blob/bd76829f66c5c0f3c6907b80010f19893cb0fc8c/packages/jest-test-result/src/types.ts#L74-L91.
   const aggregatedResults = await jest.runCLI(options, projects);
   if (!aggregatedResults.results.success) {
     throw new Error('See the logs above for details.');

--- a/build-system/tasks/babel-plugin-tests.js
+++ b/build-system/tasks/babel-plugin-tests.js
@@ -37,7 +37,7 @@ async function babelPluginTests() {
   };
 
   const aggregatedResults = await jest.runCLI(options, projects);
-  if (!aggregatedResults.success) {
+  if (!aggregatedResults.results.success) {
     throw new Error('See the logs above for details.');
   }
 }


### PR DESCRIPTION
Fixes https://github.com/ampproject/amphtml/issues/29988, as well as updates the tests for `babel-plugin-transform-dev-methods` which recently became out of sync.

Surprisingly, the `Promise` returned from `jest.runCLI` doesn't return a rejected promise in the case of test failure, we need to check for `results.success`. After this PR the task should fail ci as appropriate:

<img width="936" alt="Screen Shot 2020-08-27 at 8 17 17 AM" src="https://user-images.githubusercontent.com/4656974/91444290-854b1f80-e842-11ea-9a2c-e3a0cf121202.png">
