### PR TITLE
Attribute nodom contains no value

### DIFF
--- a/extensions/amp-script/validator-amp-script.protoascii
+++ b/extensions/amp-script/validator-amp-script.protoascii
@@ -198,7 +198,10 @@ tags: {  # <amp-script>
       also_requires_attr: "script"
     }
   }
-  attrs: { name: "nodom" }
+  attrs: {
+    name: "nodom"
+    value: ""
+  }
   attrs: { name: "sandbox" }
   attrs: {
     name: "script"


### PR DESCRIPTION
`nodom` and `nodom=nodom` are valid, any other value is invalid
