### PR TITLE
Export imperative API from carousel

### DIFF
--- a/extensions/amp-base-carousel/1.0/amp-base-carousel.js
+++ b/extensions/amp-base-carousel/1.0/amp-base-carousel.js
@@ -28,18 +28,25 @@ import {userAssert} from '../../../src/log';
 /** @const {string} */
 const TAG = 'amp-base-carousel';
 
+/** @extends {PreactBaseElement<BaseCarouselDef.CarouselApi>} */
 class AmpBaseCarousel extends PreactBaseElement {
   /** @override */
   init() {
     const {element} = this;
-    let advance = () => {};
-    this.registerAction('prev', () => advance(-1), ActionTrust.LOW);
-    this.registerAction('next', () => advance(1), ActionTrust.LOW);
+    this.registerApiAction('prev', (api) => api.advance(-1), ActionTrust.LOW);
+    this.registerApiAction('next', (api) => api.advance(1), ActionTrust.LOW);
+    this.registerApiAction(
+      'goToSlide',
+      (api, invocation) => {
+        const {args} = invocation;
+        api.goToSlide(args['index'] || -1);
+      },
+      ActionTrust.LOW
+    );
     return dict({
       'onSlideChange': (index) => {
         fireSlideChangeEvent(this.win, element, index, ActionTrust.HIGH);
       },
-      'setAdvance': (a) => (advance = a),
     });
   }
 

--- a/extensions/amp-base-carousel/1.0/base-carousel.js
+++ b/extensions/amp-base-carousel/1.0/base-carousel.js
@@ -18,6 +18,7 @@ import {ArrowNext, ArrowPrev} from './arrow';
 import {CarouselContext} from './carousel-context';
 import {ContainWrapper} from '../../../src/preact/component';
 import {Scroller} from './scroller';
+import {clamp} from '../../../src/utils/math';
 import {forwardRef} from '../../../src/preact/compat';
 import {
   toChildArray,
@@ -50,13 +51,17 @@ function BaseCarouselWithRef(
 
   const advance = useCallback((by) => scrollRef.current.advance(by), []);
   const setRestingIndex = useCallback(
-    (i) => {
-      setCurrentSlide(i);
+    (index) => {
+      index = length > 0 ? clamp(index, 0, length - 1) : -1;
+      if (index < 0) {
+        return;
+      }
+      setCurrentSlide(index);
       if (onSlideChange) {
-        onSlideChange(i);
+        onSlideChange(index);
       }
     },
-    [setCurrentSlide, onSlideChange]
+    [length, setCurrentSlide, onSlideChange]
   );
 
   useImperativeHandle(

--- a/extensions/amp-base-carousel/1.0/base-carousel.js
+++ b/extensions/amp-base-carousel/1.0/base-carousel.js
@@ -18,28 +18,26 @@ import {ArrowNext, ArrowPrev} from './arrow';
 import {CarouselContext} from './carousel-context';
 import {ContainWrapper} from '../../../src/preact/component';
 import {Scroller} from './scroller';
+import {forwardRef} from '../../../src/preact/compat';
 import {
   toChildArray,
+  useCallback,
   useContext,
   useEffect,
+  useImperativeHandle,
   useRef,
   useState,
 } from '../../../src/preact';
-import {useMountEffect} from '../../../src/preact/utils';
 
 /**
  * @param {!BaseCarouselDef.Props} props
+ * @param {{current: (!BaseCarouselDef.CarouselApi|null)}} ref
  * @return {PreactDef.Renderable}
  */
-export function BaseCarousel({
-  arrowPrev,
-  arrowNext,
-  children,
-  loop,
-  onSlideChange,
-  setAdvance,
-  ...rest
-}) {
+function BaseCarouselWithRef(
+  {arrowPrev, arrowNext, children, loop, onSlideChange, ...rest},
+  ref
+) {
   const childrenArray = toChildArray(children);
   const {length} = childrenArray;
   const carouselContext = useContext(CarouselContext);
@@ -49,21 +47,32 @@ export function BaseCarousel({
     carouselContext.setCurrentSlide ?? setCurrentSlideState;
   const {setSlideCount} = carouselContext;
   const scrollRef = useRef(null);
-  const advance = (by) => scrollRef.current.advance(by);
-  useMountEffect(() => {
-    if (setAdvance) {
-      setAdvance(advance);
-    }
-  });
+
+  const advance = useCallback((by) => scrollRef.current.advance(by), []);
+  const setRestingIndex = useCallback(
+    (i) => {
+      setCurrentSlide(i);
+      if (onSlideChange) {
+        onSlideChange(i);
+      }
+    },
+    [setCurrentSlide, onSlideChange]
+  );
+
+  useImperativeHandle(
+    ref,
+    () =>
+      /** @type {!BaseCarouselDef.CarouselApi} */ ({
+        advance,
+        goToSlide: (index) => setRestingIndex(index),
+      }),
+    [advance, setRestingIndex]
+  );
+
   useEffect(() => {
     setSlideCount(length);
   }, [setSlideCount, length]);
-  const setRestingIndex = (i) => {
-    setCurrentSlide(i);
-    if (onSlideChange) {
-      onSlideChange(i);
-    }
-  };
+
   const disableForDir = (dir) =>
     !loop && (currentSlide + dir < 0 || currentSlide + dir >= length);
   return (
@@ -89,3 +98,7 @@ export function BaseCarousel({
     </ContainWrapper>
   );
 }
+
+const BaseCarousel = forwardRef(BaseCarouselWithRef);
+BaseCarousel.displayName = 'BaseCarousel'; // Make findable for tests.
+export {BaseCarousel};

--- a/extensions/amp-base-carousel/1.0/base-carousel.type.js
+++ b/extensions/amp-base-carousel/1.0/base-carousel.type.js
@@ -26,7 +26,6 @@ var BaseCarouselDef = {};
  *   children: (!PreactDef.Renderable),
  *   loop: (boolean|undefined),
  *   onSlideChange: (function(number):undefined|undefined),
- *   setAdvance: (function(function(number):undefined):undefined|undefined),
  * }}
  */
 BaseCarouselDef.Props;
@@ -67,3 +66,17 @@ BaseCarouselDef.ArrowProps;
  * }}
  */
 BaseCarouselDef.ContextProps;
+
+/** @interface */
+BaseCarouselDef.CarouselApi = class {
+  /**
+   * @param {number} by Number of slides to advance. Positive: advance forward,
+   * negative: advance backward.
+   */
+  advance(by) {}
+
+  /**
+   * @param {number} index
+   */
+  goToSlide(index) {}
+};

--- a/extensions/amp-base-carousel/1.0/base-carousel.type.js
+++ b/extensions/amp-base-carousel/1.0/base-carousel.type.js
@@ -59,9 +59,9 @@ BaseCarouselDef.ArrowProps;
 
 /**
  * @typedef {{
- *   currentSlide: number,
+ *   currentSlide: (number|undefined),
  *   setCurrentSlide: (function(number):undefined),
- *   slideCount: (number|null),
+ *   slideCount: (number|undefined),
  *   setSlideCount: (function(number):undefined),
  * }}
  */

--- a/extensions/amp-base-carousel/1.0/scroller.js
+++ b/extensions/amp-base-carousel/1.0/scroller.js
@@ -151,9 +151,7 @@ function ScrollerWithRef({children, loop, restingIndex, setRestingIndex}, ref) {
   );
 }
 
-const Scroller = forwardRef((props, ref) =>
-  ScrollerWithRef(/** @type {BaseCarouselDef.ScrollerProps} */ (props), ref)
-);
+const Scroller = forwardRef(ScrollerWithRef);
 Scroller.displayName = 'Scroller'; // Make findable for tests.
 export {Scroller};
 

--- a/extensions/amp-base-carousel/1.0/test/test-amp-base-carousel.js
+++ b/extensions/amp-base-carousel/1.0/test/test-amp-base-carousel.js
@@ -158,7 +158,7 @@ describes.realWin(
       expect(renderedSlides[2]).to.equal(userSuppliedChildren[1]);
     });
 
-    describe.only('imperative api', () => {
+    describe('imperative api', () => {
       let scroller;
 
       beforeEach(async () => {

--- a/extensions/amp-inline-gallery/1.0/inline-gallery.type.js
+++ b/extensions/amp-inline-gallery/1.0/inline-gallery.type.js
@@ -26,7 +26,6 @@ var InlineGalleryDef = {};
  *   children: (!PreactDef.Renderable),
  *   loop: (boolean|undefined),
  *   onSlideChange: (function(number):undefined|undefined),
- *   setAdvance: (function(function(number):undefined):undefined|undefined),
  * }}
  */
 InlineGalleryDef.Props;

--- a/src/preact/compat.js
+++ b/src/preact/compat.js
@@ -17,9 +17,9 @@
 import * as compat from /*OK*/ 'preact/compat';
 
 /**
- * @param {function(JsonObject, {current: (T|null)}):PreactDef.Renderable} fn
- * @return {function():PreactDef.Renderable}
- * @template T
+ * @param {function(T, {current: (R|null)}):PreactDef.Renderable} fn
+ * @return {function(T):PreactDef.Renderable}
+ * @template T, R
  */
 export function forwardRef(fn) {
   return compat.forwardRef(fn);

--- a/src/preact/index.js
+++ b/src/preact/index.js
@@ -41,7 +41,7 @@ export function cloneElement(unusedElement, unusedProps, unusedChildren) {
 }
 
 /**
- * @param {!PreactDef.VNode} vnode
+ * @param {?PreactDef.VNode} vnode
  * @param {Node} container
  */
 export function render(vnode, container) {
@@ -130,9 +130,9 @@ export function useMemo(cb, opt_deps) {
 }
 
 /**
- * @param {function(...*):T|undefined} cb
+ * @param {T} cb
  * @param {!Array<*>=} opt_deps
- * @return {function(...*):T|undefined}
+ * @return {T}
  * @template T
  */
 export function useCallback(cb, opt_deps) {


### PR DESCRIPTION
This pull request uses Preact's `useImperativeHandle` to export the component's imperative API to the AMP layer. The most common use for this is support of AMP actions. This pull request implements `next`, `prev`, and `goToSlide` actions. The imperative API itself is declared and described in the `type.js` file.