### PR TITLE
Validator rollup 2020-08-31

### DIFF
--- a/validator/js/engine/validator_test.js
+++ b/validator/js/engine/validator_test.js
@@ -447,28 +447,28 @@ describe('Validator.DocSizeAmpEmail', () => {
   const validBlob = '<b>Hello, World</b>\n';
   assertStrictEqual(20, validBlob.length);
 
-  it('accepts 100000 bytes in the test document', () => {
-    const body = Array(4946).join(validBlob);
+  it('accepts 200000 bytes in the test document', () => {
+    const body = Array(9946).join(validBlob);
     const test = new ValidatorTestCase('amp4email_feature_tests/doc_size.html');
     test.ampHtmlFileContents =
         test.ampHtmlFileContents.replace('replace_body', body);
-    assertStrictEqual(100000, htmlparser.byteLength(test.ampHtmlFileContents));
+    assertStrictEqual(200000, htmlparser.byteLength(test.ampHtmlFileContents));
     test.inlineOutput = false;
     test.expectedOutput = 'PASS';
     test.run();
   });
 
-  it('will not accept 100001 bytes in the test document', () => {
-    const body = Array(4946).join(validBlob) + ' ';
+  it('will not accept 200001 bytes in the test document', () => {
+    const body = Array(9946).join(validBlob) + ' ';
     const test = new ValidatorTestCase('amp4email_feature_tests/doc_size.html');
     test.ampHtmlFileContents =
         test.ampHtmlFileContents.replace('replace_body', body);
-    assertStrictEqual(100001, htmlparser.byteLength(test.ampHtmlFileContents));
+    assertStrictEqual(200001, htmlparser.byteLength(test.ampHtmlFileContents));
     test.inlineOutput = false;
     test.expectedOutputFile = null;
     test.expectedOutput = 'FAIL\n' +
-        'amp4email_feature_tests/doc_size.html:4978:6 ' +
-        'Document exceeded 100000 bytes limit. Actual size 100001 bytes. ' +
+        'amp4email_feature_tests/doc_size.html:9978:6 ' +
+        'Document exceeded 200000 bytes limit. Actual size 200001 bytes. ' +
         '(see https://amp.dev/documentation/guides-and-tutorials/learn/' +
         'email-spec/amp-email-format/?format=email)';
     test.run();
@@ -713,11 +713,7 @@ describe('Validator.CssLengthAmpEmail', () => {
        test.ampHtmlFileContents =
            test.ampHtmlFileContents.replace('.replace_amp_custom {}', '')
                .replace('replace_inline_style', inlineStyle);
-       test.expectedOutput = 'FAIL\n' +
-           'amp4email_feature_tests/css_length.html:34:6 Document exceeded ' +
-           '100000 bytes limit. Actual size 196140 bytes. ' +
-           '(see https://amp.dev/documentation/guides-and-tutorials/learn/' +
-           'email-spec/amp-email-format/?format=email)';
+       test.expectedOutput = 'PASS';
        test.run();
      });
 
@@ -733,13 +729,8 @@ describe('Validator.CssLengthAmpEmail', () => {
                .replace('replace_inline_style', inlineStyle);
        test.expectedOutputFile = null;
        // TODO(gregable): This should not pass for the case when there are more
-       // than 75,000 bytes of inline style. It fails for now due to the 100k
-       // doc size limit.
-       test.expectedOutput = 'FAIL\n' +
-           'amp4email_feature_tests/css_length.html:34:6 Document exceeded ' +
-           '100000 bytes limit. Actual size 196166 bytes. ' +
-           '(see https://amp.dev/documentation/guides-and-tutorials/learn/' +
-           'email-spec/amp-email-format/?format=email)\n' +
+       // than 75,000 bytes of inline style.
+       test.expectedOutput = 'PASS\n' +
            'amp4email_feature_tests/css_length.html:34:6 The author ' +
            'stylesheet specified in tag \'style amp-custom\' and the ' +
            'combined inline styles is too large - document contains 75010 ' +

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -26,7 +26,7 @@ min_validator_revision_required: 475
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 1095
+spec_file_revision: 1096
 
 styles_spec_url: "https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages/"
 script_spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/validation-workflow/validation_errors/#custom-javascript-is-not-allowed"

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -26,7 +26,7 @@ min_validator_revision_required: 475
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 1097
+spec_file_revision: 1098
 
 styles_spec_url: "https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages/"
 script_spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/validation-workflow/validation_errors/#custom-javascript-is-not-allowed"
@@ -43,7 +43,7 @@ script_spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/valid
 
 doc: {
   html_format: AMP4EMAIL
-  max_bytes: 100000
+  max_bytes: 200000
   max_bytes_spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/email-spec/amp-email-format/?format=email"
 }
 

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -26,7 +26,7 @@ min_validator_revision_required: 475
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 1098
+spec_file_revision: 1099
 
 styles_spec_url: "https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages/"
 script_spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/validation-workflow/validation_errors/#custom-javascript-is-not-allowed"

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -26,7 +26,7 @@ min_validator_revision_required: 475
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 1096
+spec_file_revision: 1097
 
 styles_spec_url: "https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages/"
 script_spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/validation-workflow/validation_errors/#custom-javascript-is-not-allowed"


### PR DESCRIPTION
 - cl/329019993 Revision bump for #30036
 - cl/329000722 Update AMP4Email format document size limit to 200k.
 - cl/328995853 Revision bump for #30003
 - cl/328993182 Revision bump for #30026
