### PR TITLE
Carousel: use ::part to make default arrow buttons customizable

### DIFF
--- a/extensions/amp-base-carousel/1.0/arrow.js
+++ b/extensions/amp-base-carousel/1.0/arrow.js
@@ -85,6 +85,7 @@ function DefaultArrow({by, ...rest}) {
   const classes = useStyles();
   return (
     <button
+      part={`arrow ${by > 0 ? 'next' : 'prev'}`}
       class={classes.defaultArrowButton}
       aria-label={
         by < 0 ? 'Previous item in carousel' : 'Next item in carousel'

--- a/extensions/amp-base-carousel/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-base-carousel/1.0/storybook/Basic.amp.js
@@ -42,4 +42,30 @@ storiesOf('amp-base-carousel', module)
         ))}
       </amp-base-carousel>
     );
+  })
+  .add('customize button CSS', () => {
+    return (
+      <>
+        <style jsx global>
+          {`
+            amp-base-carousel::part(arrow next) {
+              color: green;
+            }
+            amp-base-carousel::part(arrow next):hover {
+              color: blue;
+            }
+          `}
+        </style>
+        <amp-base-carousel width="440" height="225">
+          {['lightcoral', 'peachpuff', 'lavender'].map((color) => (
+            <amp-layout width="440" height="225">
+              <svg viewBox="0 0 440 225">
+                <rect style={{fill: color}} width="440" height="225" />
+                Sorry, your browser does not support inline SVG.
+              </svg>
+            </amp-layout>
+          ))}
+        </amp-base-carousel>
+      </>
+    );
   });


### PR DESCRIPTION
A very small proof-of-concept while we are actively working on other CSS issues. This pull request uses [`::part`](https://developer.mozilla.org/en-US/docs/Web/CSS/::part) CSS.

Some important notes here:

1. It only realistically can customize foreground color of the default button. This is because the button's markup is pretty "fancy" (and also complicated). This is a clear tradeoff: we can either make markup simpler and default button more customizable, or we can keep it as is and require users to wholly replace default button for any customization.
2. This is not a polyfillable feature. But also not a critical customization. IMHO if an older browser ignores this styles and shows default buttons, it's totally ok. Otherwise the browser support is pretty good. At least 1 year on all major browsers.


Partial for: https://github.com/ampproject/amphtml/issues/28284
Partial for: https://github.com/ampproject/wg-bento/issues/12
Partial for: https://github.com/ampproject/wg-bento/issues/15