### PR TITLE
 jss: make classname deterministic

### DIFF
--- a/build-system/babel-plugins/babel-plugin-transform-jss/index.js
+++ b/build-system/babel-plugins/babel-plugin-transform-jss/index.js
@@ -45,7 +45,7 @@ module.exports = function ({types: t, template}) {
     return filename.endsWith('.jss.js');
   }
 
-  let seen = new Set();
+  const seen = new Set();
   function compileJss(JSS, filename) {
     const filehash = crypto
       .createHash('sha256')

--- a/build-system/babel-plugins/babel-plugin-transform-jss/index.js
+++ b/build-system/babel-plugins/babel-plugin-transform-jss/index.js
@@ -39,6 +39,7 @@
 const crypto = require('crypto');
 const {create} = require('jss');
 const {default: preset} = require('jss-preset-default');
+const {relative, join} = require('path');
 
 module.exports = function ({types: t, template}) {
   function isJssFile(filename) {
@@ -47,9 +48,10 @@ module.exports = function ({types: t, template}) {
 
   const seen = new Set();
   function compileJss(JSS, filename) {
+    const relativeFilepath = relative(join(__dirname, '../../..'), filename);
     const filehash = crypto
       .createHash('sha256')
-      .update(filename)
+      .update(relativeFilepath)
       .digest('base64')
       .slice(0, 7);
     const jss = create({

--- a/build-system/babel-plugins/babel-plugin-transform-jss/index.js
+++ b/build-system/babel-plugins/babel-plugin-transform-jss/index.js
@@ -52,13 +52,17 @@ module.exports = function ({types: t, template}) {
     const filehash = crypto
       .createHash('sha256')
       .update(relativeFilepath)
-      .digest('base64')
+      .digest('hex')
       .slice(0, 7);
     const jss = create({
       ...preset(),
       createGenerateId: () => {
         return (rule) => {
-          const className = `${rule.key}-${filehash}`;
+          const dashCaseKey = rule.key.replace(
+            /([A-Z])/g,
+            (c) => `-${c.toLowerCase()}`
+          );
+          const className = `${dashCaseKey}-${filehash}`;
           if (seen.has(className)) {
             throw new Error(
               `Classnames must be unique across all files. Found a duplicate: ${className}`

--- a/build-system/babel-plugins/babel-plugin-transform-jss/index.js
+++ b/build-system/babel-plugins/babel-plugin-transform-jss/index.js
@@ -45,7 +45,7 @@ module.exports = function ({types: t, template}) {
   }
 
   // Naive string hashing function. For now we care more
-  // about simplicty than reducing collisions, as the number of
+  // about simplicity than reducing collisions, as the number of
   // unique documents is small, and we fail-fast on collision.
   function hashCode(str) {
     let hash = 0;

--- a/build-system/babel-plugins/babel-plugin-transform-jss/index.js
+++ b/build-system/babel-plugins/babel-plugin-transform-jss/index.js
@@ -45,8 +45,7 @@ module.exports = function ({types: t, template}) {
   }
 
   function compileJss(JSS) {
-    const jss = create();
-    jss.setup(preset());
+    const jss = create(preset());
     return jss.createStyleSheet(JSS);
   }
 

--- a/build-system/babel-plugins/babel-plugin-transform-jss/index.js
+++ b/build-system/babel-plugins/babel-plugin-transform-jss/index.js
@@ -36,6 +36,7 @@
  * ```
  */
 
+const crypto = require('crypto');
 const {create} = require('jss');
 const {default: preset} = require('jss-preset-default');
 
@@ -44,20 +45,13 @@ module.exports = function ({types: t, template}) {
     return filename.endsWith('.jss.js');
   }
 
-  // Naive string hashing function. For now we care more
-  // about simplicity than reducing collisions, as the number of
-  // unique documents is small, and we fail-fast on collision.
-  function hashCode(str) {
-    let hash = 0;
-    for (let i = 0; i < str.length; i++) {
-      hash = (31 * hash + str.charCodeAt(i)) % Number.MAX_SAFE_INTEGER;
-    }
-    return hash.toString().slice(0, 7);
-  }
-
   let seen = new Set();
   function compileJss(JSS, filename) {
-    const filehash = hashCode(filename);
+    const filehash = crypto
+      .createHash('sha256')
+      .update(filename)
+      .digest('base64')
+      .slice(0, 7);
     const jss = create({
       ...preset(),
       createGenerateId: () => {

--- a/build-system/babel-plugins/babel-plugin-transform-jss/test/fixtures/transform-assertions/should-transform-jss-var/output.mjs
+++ b/build-system/babel-plugins/babel-plugin-transform-jss/test/fixtures/transform-assertions/should-transform-jss-var/output.mjs
@@ -1,4 +1,4 @@
-var _classes = JSON.parse("{\"button\":\"button-2766284\",\"CSS\":\".button-2766284 {\\n  font-size: 12px;\\n}\"}");
+var _classes = JSON.parse("{\"button\":\"button-J8jHMYe\",\"CSS\":\".button-J8jHMYe {\\n  font-size: 12px;\\n}\"}");
 
 /**
  * Copyright 2020 The AMP HTML Authors. All Rights Reserved.

--- a/build-system/babel-plugins/babel-plugin-transform-jss/test/fixtures/transform-assertions/should-transform-jss-var/output.mjs
+++ b/build-system/babel-plugins/babel-plugin-transform-jss/test/fixtures/transform-assertions/should-transform-jss-var/output.mjs
@@ -1,4 +1,4 @@
-var _classes = JSON.parse("{\"button\":\"button-IapKgst\",\"CSS\":\".button-IapKgst {\\n  font-size: 12px;\\n}\"}");
+var _classes = JSON.parse("{\"button\":\"button-21aa4a8\",\"CSS\":\".button-21aa4a8 {\\n  font-size: 12px;\\n}\"}");
 
 /**
  * Copyright 2020 The AMP HTML Authors. All Rights Reserved.

--- a/build-system/babel-plugins/babel-plugin-transform-jss/test/fixtures/transform-assertions/should-transform-jss-var/output.mjs
+++ b/build-system/babel-plugins/babel-plugin-transform-jss/test/fixtures/transform-assertions/should-transform-jss-var/output.mjs
@@ -1,4 +1,4 @@
-var _classes = JSON.parse("{\"button\":\"button-J8jHMYe\",\"CSS\":\".button-J8jHMYe {\\n  font-size: 12px;\\n}\"}");
+var _classes = JSON.parse("{\"button\":\"button-IapKgst\",\"CSS\":\".button-IapKgst {\\n  font-size: 12px;\\n}\"}");
 
 /**
  * Copyright 2020 The AMP HTML Authors. All Rights Reserved.

--- a/build-system/babel-plugins/babel-plugin-transform-jss/test/fixtures/transform-assertions/should-transform-jss-var/output.mjs
+++ b/build-system/babel-plugins/babel-plugin-transform-jss/test/fixtures/transform-assertions/should-transform-jss-var/output.mjs
@@ -1,4 +1,4 @@
-var _classes = JSON.parse("{\"button\":\"button-0-2-1\",\"CSS\":\".button-0-2-1 {\\n  font-size: 12px;\\n}\"}");
+var _classes = JSON.parse("{\"button\":\"button-2766284\",\"CSS\":\".button-2766284 {\\n  font-size: 12px;\\n}\"}");
 
 /**
  * Copyright 2020 The AMP HTML Authors. All Rights Reserved.

--- a/build-system/babel-plugins/babel-plugin-transform-jss/test/fixtures/transform-assertions/should-transform-literal/input.js
+++ b/build-system/babel-plugins/babel-plugin-transform-jss/test/fixtures/transform-assertions/should-transform-literal/input.js
@@ -16,4 +16,4 @@
 
 import {createUseStyles} from 'react-jss';
 
-export const useStyles = createUseStyles({button: {fontSize: 12}});
+export const useStyles = createUseStyles({floatLeft: {float: 'left'}});

--- a/build-system/babel-plugins/babel-plugin-transform-jss/test/fixtures/transform-assertions/should-transform-literal/output.mjs
+++ b/build-system/babel-plugins/babel-plugin-transform-jss/test/fixtures/transform-assertions/should-transform-literal/output.mjs
@@ -1,4 +1,4 @@
-var _classes = JSON.parse("{\"button\":\"button-vRF4F5Y\",\"CSS\":\".button-vRF4F5Y {\\n  font-size: 12px;\\n}\"}");
+var _classes = JSON.parse("{\"button\":\"button-psZnf8m\",\"CSS\":\".button-psZnf8m {\\n  font-size: 12px;\\n}\"}");
 
 /**
  * Copyright 2020 The AMP HTML Authors. All Rights Reserved.

--- a/build-system/babel-plugins/babel-plugin-transform-jss/test/fixtures/transform-assertions/should-transform-literal/output.mjs
+++ b/build-system/babel-plugins/babel-plugin-transform-jss/test/fixtures/transform-assertions/should-transform-literal/output.mjs
@@ -1,4 +1,4 @@
-var _classes = JSON.parse("{\"button\":\"button-psZnf8m\",\"CSS\":\".button-psZnf8m {\\n  font-size: 12px;\\n}\"}");
+var _classes = JSON.parse("{\"floatLeft\":\"float-left-a6c6677\",\"CSS\":\".float-left-a6c6677 {\\n  float: left;\\n}\"}");
 
 /**
  * Copyright 2020 The AMP HTML Authors. All Rights Reserved.

--- a/build-system/babel-plugins/babel-plugin-transform-jss/test/fixtures/transform-assertions/should-transform-literal/output.mjs
+++ b/build-system/babel-plugins/babel-plugin-transform-jss/test/fixtures/transform-assertions/should-transform-literal/output.mjs
@@ -1,4 +1,4 @@
-var _classes = JSON.parse("{\"button\":\"button-0-3-1\",\"CSS\":\".button-0-3-1 {\\n  font-size: 12px;\\n}\"}");
+var _classes = JSON.parse("{\"button\":\"button-5622871\",\"CSS\":\".button-5622871 {\\n  font-size: 12px;\\n}\"}");
 
 /**
  * Copyright 2020 The AMP HTML Authors. All Rights Reserved.

--- a/build-system/babel-plugins/babel-plugin-transform-jss/test/fixtures/transform-assertions/should-transform-literal/output.mjs
+++ b/build-system/babel-plugins/babel-plugin-transform-jss/test/fixtures/transform-assertions/should-transform-literal/output.mjs
@@ -1,4 +1,4 @@
-var _classes = JSON.parse("{\"button\":\"button-5622871\",\"CSS\":\".button-5622871 {\\n  font-size: 12px;\\n}\"}");
+var _classes = JSON.parse("{\"button\":\"button-vRF4F5Y\",\"CSS\":\".button-vRF4F5Y {\\n  font-size: 12px;\\n}\"}");
 
 /**
  * Copyright 2020 The AMP HTML Authors. All Rights Reserved.

--- a/build-system/babel-plugins/babel-plugin-transform-jss/test/index.js
+++ b/build-system/babel-plugins/babel-plugin-transform-jss/test/index.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+const path = require('path');
 const runner = require('@babel/helper-plugin-test-runner').default;
 const babel = require('@babel/core');
 
@@ -24,11 +25,12 @@ test('throws when duplicate classname is found', () => {
 import {createUseStyles} from 'react-jss';
 export const useStyles = createUseStyles({button: {fontSize: 12}});
     `;
+  const filename = 'test.jss.js';
+  const plugins = [path.join(__dirname, '..')];
 
-  // Transforming the same file twice should yield the same classnames,
-  // resulting in an error
-  babel.transform(fileContents, {filename: 'test.jss.js', plugins:[__dirname + '/../'] });
-  expect(() =>
-    babel.transform(fileContents, {filename: 'test.jss.js', plugins: [__dirname + '/../']})
-  ).toThrow(/Classnames must be unique across all files/);
+  // Transforming the same file twice should yield the same classnames, resulting in an error
+  babel.transform(fileContents, {filename, plugins});
+  expect(() => babel.transform(fileContents, {filename, plugins})).toThrow(
+    /Classnames must be unique across all files/
+  );
 });

--- a/build-system/babel-plugins/babel-plugin-transform-jss/test/index.js
+++ b/build-system/babel-plugins/babel-plugin-transform-jss/test/index.js
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
+const babel = require('@babel/core');
 const path = require('path');
 const runner = require('@babel/helper-plugin-test-runner').default;
-const babel = require('@babel/core');
 
 runner(__dirname);
 
+// eslint-disable-next-line no-undef
 test('throws when duplicate classname is found', () => {
   const fileContents = `
 import {createUseStyles} from 'react-jss';

--- a/build-system/babel-plugins/babel-plugin-transform-jss/test/index.js
+++ b/build-system/babel-plugins/babel-plugin-transform-jss/test/index.js
@@ -15,5 +15,20 @@
  */
 
 const runner = require('@babel/helper-plugin-test-runner').default;
+const babel = require('@babel/core');
 
 runner(__dirname);
+
+test('throws when duplicate classname is found', () => {
+  const fileContents = `
+import {createUseStyles} from 'react-jss';
+export const useStyles = createUseStyles({button: {fontSize: 12}});
+    `;
+
+  // Transforming the same file twice should yield the same classnames,
+  // resulting in an error
+  babel.transform(fileContents, {filename: 'test.jss.js', plugins:[__dirname + '/../'] });
+  expect(() =>
+    babel.transform(fileContents, {filename: 'test.jss.js', plugins: [__dirname + '/../']})
+  ).toThrow(/Classnames must be unique across all files/);
+});

--- a/build-system/babel-plugins/babel-plugin-transform-jss/test/index.js
+++ b/build-system/babel-plugins/babel-plugin-transform-jss/test/index.js
@@ -28,10 +28,11 @@ export const useStyles = createUseStyles({button: {fontSize: 12}});
     `;
   const filename = 'test.jss.js';
   const plugins = [path.join(__dirname, '..')];
+  const caller = {name: 'babel-jest'};
 
   // Transforming the same file twice should yield the same classnames, resulting in an error
-  babel.transform(fileContents, {filename, plugins});
-  expect(() => babel.transform(fileContents, {filename, plugins})).toThrow(
-    /Classnames must be unique across all files/
-  );
+  babel.transformSync(fileContents, {filename, plugins, caller});
+  expect(() =>
+    babel.transformSync(fileContents, {filename, plugins, caller})
+  ).toThrow(/Classnames must be unique across all files/);
 });

--- a/extensions/amp-base-carousel/1.0/test/test-amp-base-carousel.js
+++ b/extensions/amp-base-carousel/1.0/test/test-amp-base-carousel.js
@@ -24,6 +24,7 @@ import {poll} from '../../../../testing/iframe';
 import {setStyles} from '../../../../src/style';
 import {toArray} from '../../../../src/types';
 import {toggleExperiment} from '../../../../src/experiments';
+import {useStyles} from '../base-carousel.jss';
 import {whenCalled} from '../../../../testing/test-helper';
 
 describes.realWin(
@@ -38,6 +39,9 @@ describes.realWin(
     let win;
     let element;
 
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const styles = useStyles();
+
     async function getSlidesFromShadow() {
       await whenCalled(env.sandbox.spy(element, 'attachShadow'));
       const shadow = element.shadowRoot;
@@ -45,7 +49,7 @@ describes.realWin(
         return shadow.querySelectorAll('[class*=hideScrollbar]');
       });
       const slots = await shadow.querySelectorAll(
-        '[class*=hideScrollbar] slot'
+        `[class*=${styles.hideScrollbar}] slot`
       );
       return toArray(slots).reduce(
         (acc, slot) => acc.concat(slot.assignedElements()),
@@ -167,7 +171,9 @@ describes.realWin(
         win.document.body.appendChild(element);
         await getSlidesFromShadow();
 
-        scroller = element.shadowRoot.querySelector('[class*=scrollContainer]');
+        scroller = element.shadowRoot.querySelector(
+          `[class*=${styles.scrollContainer}]`
+        );
       });
 
       function invocation(method, args = {}) {


### PR DESCRIPTION
**summary**
- Introduces a new key for classname output: key-filehash.  This means you'll get a stable key independent of order in which files are transformed, but there is a very small possibility of collisions.
- Introduces a check to fail-fast in case there is a classname collision between files.