### PR TITLE
Remove use of clamp due to dependency on getMode

### DIFF
--- a/extensions/amp-base-carousel/1.0/base-carousel.js
+++ b/extensions/amp-base-carousel/1.0/base-carousel.js
@@ -18,7 +18,6 @@ import {ArrowNext, ArrowPrev} from './arrow';
 import {CarouselContext} from './carousel-context';
 import {ContainWrapper} from '../../../src/preact/component';
 import {Scroller} from './scroller';
-import {clamp} from '../../../src/utils/math';
 import {forwardRef} from '../../../src/preact/compat';
 import {
   toChildArray,
@@ -52,7 +51,7 @@ function BaseCarouselWithRef(
   const advance = useCallback((by) => scrollRef.current.advance(by), []);
   const setRestingIndex = useCallback(
     (index) => {
-      index = length > 0 ? clamp(index, 0, length - 1) : -1;
+      index = length > 0 ? Math.min(Math.max(index, 0), length - 1) : -1;
       if (index < 0) {
         return;
       }


### PR DESCRIPTION
The broken  dependency is `clamp -> getMode -> IS_ESM`.