### PR TITLE
🚀 🐛  [amp-story-player] show() improvements

### DIFF
--- a/src/amp-story-player/amp-story-player-iframe-pool.js
+++ b/src/amp-story-player/amp-story-player-iframe-pool.js
@@ -79,23 +79,6 @@ export class IframePool {
   }
 
   /**
-   * Clears stored story indices.
-   * @return {!Array<number>}
-   */
-  evictStories() {
-    const evictedStories = this.storyIdsWithIframe_;
-    this.storyIdsWithIframe_ = [];
-    return evictedStories;
-  }
-
-  /**
-   * @return {!Array<number>}
-   */
-  getAvailableIframeIdx() {
-    return this.iframePool_;
-  }
-
-  /**
    * Finds adjacent iframe indices given an index.
    * Examples of resulting adjacent arrays:
    * 0 -> [0] [1] [2] [] []

--- a/src/amp-story-player/amp-story-player-iframe-pool.js
+++ b/src/amp-story-player/amp-story-player-iframe-pool.js
@@ -55,8 +55,7 @@ export class IframePool {
   rotateFirst(nextStoryIdx) {
     const detachedStoryIdx = this.storyIdsWithIframe_.shift();
     this.storyIdsWithIframe_.push(nextStoryIdx);
-
-    this.iframePool_.push(this.iframePool_.shift());
+    this.storyIdsWithIframe_.sort();
 
     return detachedStoryIdx;
   }
@@ -71,9 +70,8 @@ export class IframePool {
    */
   rotateLast(nextStoryIdx) {
     const detachedStoryIdx = this.storyIdsWithIframe_.pop();
-    this.storyIdsWithIframe_.unshift(nextStoryIdx);
-
-    this.iframePool_.unshift(this.iframePool_.pop());
+    this.storyIdsWithIframe_.push(nextStoryIdx);
+    this.storyIdsWithIframe_.sort();
 
     return detachedStoryIdx;
   }
@@ -95,8 +93,11 @@ export class IframePool {
     // If index is at rightmost part of the array, adjacent iframes will all be
     // at the left.
     let cursor = storyIdx + 1 > maxIdx ? storyIdx - 2 : storyIdx - 1;
+
+    // Place current story index first to prioritize loading over adjacent ones.
+    adjacent.push(storyIdx);
     while (adjacent.length < this.iframePool_.length) {
-      if (cursor < 0) {
+      if (cursor < 0 || cursor === storyIdx) {
         ++cursor;
         continue;
       }

--- a/src/amp-story-player/amp-story-player-impl.js
+++ b/src/amp-story-player/amp-story-player-impl.js
@@ -599,6 +599,7 @@ export class AmpStoryPlayer {
    * @param {string} storyUrl
    */
   show(storyUrl) {
+    // TODO(enriqe): sanitize URLs for matching.
     const storyIdx = findIndex(this.stories_, ({href}) => href === storyUrl);
 
     // TODO(Enriqe): replace for add() once implemented.

--- a/src/amp-story-player/amp-story-player-impl.js
+++ b/src/amp-story-player/amp-story-player-impl.js
@@ -614,6 +614,10 @@ export class AmpStoryPlayer {
       this.stories_.length - 1
     );
 
+    // Place current story index first to prioritize loading over adjacent ones.
+    adjacentStoriesIdx.splice(adjacentStoriesIdx.indexOf(storyIdx), 1);
+    adjacentStoriesIdx.unshift(storyIdx);
+
     adjacentStoriesIdx.forEach((idx) => {
       const story = this.stories_[idx];
       let iframe = story[IFRAME_IDX];

--- a/src/amp-story-player/amp-story-player-impl.js
+++ b/src/amp-story-player/amp-story-player-impl.js
@@ -601,6 +601,7 @@ export class AmpStoryPlayer {
   show(storyUrl) {
     const storyIdx = findIndex(this.stories_, ({href}) => href === storyUrl);
 
+    // TODO(Enriqe): replace for add() once implemented.
     if (!this.stories_[storyIdx]) {
       throw new Error(`Story URL not found in the player: ${storyUrl}`);
     }

--- a/src/amp-story-player/amp-story-player-impl.js
+++ b/src/amp-story-player/amp-story-player-impl.js
@@ -599,10 +599,8 @@ export class AmpStoryPlayer {
    * @param {string} storyUrl
    */
   show(storyUrl) {
-    // TODO(enriqe): sanitize URLs for matching.
     const storyIdx = findIndex(this.stories_, ({href}) => href === storyUrl);
 
-    // TODO(proyectoramirez): replace for add() once implemented.
     if (!this.stories_[storyIdx]) {
       throw new Error(`Story URL not found in the player: ${storyUrl}`);
     }
@@ -611,11 +609,30 @@ export class AmpStoryPlayer {
       return;
     }
 
+    const adjacentStoriesIdx = this.iframePool_.findAdjacent(
+      storyIdx,
+      this.stories_.length - 1
+    );
+
+    adjacentStoriesIdx.forEach((idx) => {
+      const story = this.stories_[idx];
+      let iframe = story[IFRAME_IDX];
+
+      if (iframe === undefined) {
+        this.allocateIframeForStory_(idx, idx < this.currentIdx_);
+        iframe = story[IFRAME_IDX];
+      }
+
+      if (idx === storyIdx) {
+        this.updateCurrentIframe_(story);
+      } else {
+        const position =
+          idx > storyIdx ? IframePosition.NEXT : IframePosition.PREVIOUS;
+        this.updateIframePosition_(iframe, position);
+      }
+    });
+
     this.currentIdx_ = storyIdx;
-
-    this.evictStoriesFromIframes_();
-    this.assignIframesForStoryIdx_(storyIdx);
-
     this.signalNavigation_();
   }
 
@@ -643,65 +660,6 @@ export class AmpStoryPlayer {
         break;
       default:
         break;
-    }
-  }
-
-  /**
-   * Evicts stories from iframes.
-   * @private
-   */
-  evictStoriesFromIframes_() {
-    const evictedStories = this.iframePool_.evictStories();
-
-    evictedStories.forEach((storyIdx) => {
-      const story = this.stories_[storyIdx];
-      this.messagingPromises_[story[IFRAME_IDX]].then((messaging) => {
-        messaging.unregisterHandler('documentStateUpdate');
-        messaging.unregisterHandler('selectDocument');
-      });
-      story[IFRAME_IDX] = undefined;
-    });
-  }
-
-  /**
-   * Sets up new iframe arrangement given a story index. The adjacent stories
-   * will be prerendered and positioned accordingly. All messaging will be
-   * setup.
-   * @param {number} storyIdx
-   * @private
-   */
-  assignIframesForStoryIdx_(storyIdx) {
-    const availableIframeIdx = this.iframePool_.getAvailableIframeIdx();
-    const adjacentStoriesIdx = this.iframePool_.findAdjacent(
-      storyIdx,
-      this.stories_.length - 1
-    );
-
-    for (let i = 0; i < adjacentStoriesIdx.length; i++) {
-      const story = this.stories_[adjacentStoriesIdx[i]];
-      story[IFRAME_IDX] = availableIframeIdx[i];
-      this.iframePool_.addStoryIdx(adjacentStoriesIdx[i]);
-
-      const iframe = this.iframes_[story[IFRAME_IDX]];
-
-      this.layoutIframe_(
-        story,
-        iframe,
-        adjacentStoriesIdx[i] === storyIdx
-          ? VisibilityState.VISIBLE
-          : VisibilityState.PRERENDER
-      );
-
-      this.updateIframePosition_(
-        availableIframeIdx[i],
-        adjacentStoriesIdx[i] === storyIdx
-          ? IframePosition.CURRENT
-          : adjacentStoriesIdx[i] > storyIdx
-          ? IframePosition.NEXT
-          : IframePosition.PREVIOUS
-      );
-
-      this.setUpMessagingForIframe_(story, iframe);
     }
   }
 

--- a/test/unit/test-amp-story-player.js
+++ b/test/unit/test-amp-story-player.js
@@ -421,9 +421,9 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
 
       expect(stories[0][IFRAME_IDX]).to.eql(undefined);
       expect(stories[1][IFRAME_IDX]).to.eql(undefined);
-      expect(stories[2][IFRAME_IDX]).to.eql(0);
-      expect(stories[3][IFRAME_IDX]).to.eql(1);
-      expect(stories[4][IFRAME_IDX]).to.eql(2);
+      expect(stories[2][IFRAME_IDX]).to.eql(2);
+      expect(stories[3][IFRAME_IDX]).to.eql(0);
+      expect(stories[4][IFRAME_IDX]).to.eql(1);
     });
 
     // TODO(proyectoramirez): delete once add() is implemented.


### PR DESCRIPTION
Closes #28987

Simplifies logic by:
* Checking if navigated story using `show(story)` has iframe
  * if it does, just reposition the iframe
  * if it doesn't, detach iframe and allocate to new current story.

It also leverages new loading strategy introduced in #29703 to prioritize loading the current story over the adjacent ones.
