### PR TITLE
amp-list: support amp-state and amp-script for load-more

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -27,7 +27,5 @@
   "[yaml]": {"editor.formatOnSave": true},
   "[json]": {"editor.formatOnSave": true},
   "[json5]": {"editor.formatOnSave": true},
-  "[markdown]": {
-    "editor.formatOnSave": true
-  }
+  "[markdown]": {"editor.formatOnSave": true}
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -27,5 +27,7 @@
   "[yaml]": {"editor.formatOnSave": true},
   "[json]": {"editor.formatOnSave": true},
   "[json5]": {"editor.formatOnSave": true},
-  "[markdown]": {"editor.formatOnSave": true}
+  "[markdown]": {
+    "editor.formatOnSave": true
+  }
 }

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -174,7 +174,7 @@ export class AmpList extends AMP.BaseElement {
     this.registerAction('refresh', () => {
       if (this.layoutCompleted_) {
         this.resetIfNecessary_();
-        return this.fetchList_(/* opt_refresh */ true);
+        return this.fetchList_({refresh: true});
       }
     });
 
@@ -751,11 +751,11 @@ export class AmpList extends AMP.BaseElement {
    * the list has been populated with rendered list items. If the viewer is
    * capable of rendering the templates, then the fetching of the list and
    * transformation of the template is handled by the viewer.
-   * @param {boolean=} opt_refresh
+   * @param {{refresh: (boolean|undefined), append: (boolean|undefined)}=} options
    * @return {!Promise}
    * @private
    */
-  fetchList_(opt_refresh = false) {
+  fetchList_({refresh = false, append = false} = {}) {
     const elementSrc = this.element.getAttribute('src');
     if (!elementSrc) {
       return Promise.resolve();
@@ -770,7 +770,7 @@ export class AmpList extends AMP.BaseElement {
       } else if (this.isAmpScriptSrc_(elementSrc)) {
         fetch = this.getAmpScriptJson_(elementSrc);
       } else {
-        fetch = this.prepareAndSendFetch_(opt_refresh);
+        fetch = this.prepareAndSendFetch_(refresh);
       }
       fetch = fetch.then((data) => {
         // Bail if the src has changed while resolving the xhr request.
@@ -783,47 +783,21 @@ export class AmpList extends AMP.BaseElement {
           this.updateLoadMoreSrc_(/** @type {!JsonObject} */ (data));
         }
 
-        return this.scheduleRender_(
-          items,
-          /*opt_append*/ false,
-          data
-        ).then(() => this.maybeSetLoadMore_());
+        return this.scheduleRender_(items, append, data).then(() =>
+          this.maybeSetLoadMore_()
+        );
       });
     }
 
     return fetch.catch((error) => {
+      // Append flow has its own error handling
+      if (append) {
+        throw error;
+      }
+
       this.triggerFetchErrorEvent_(error);
       this.showFallback_();
       throw error;
-    });
-  }
-
-  /**
-   * Fetch and render items intended to be appended to the current list
-   * @return {!Promise}
-   */
-  fetchListAndAppend_() {
-    if (!this.element.getAttribute('src')) {
-      return Promise.resolve();
-    }
-
-    let fetch;
-    if (this.isAmpStateSrc_(elementSrc)) {
-      fetch = this.getAmpStateJson_(elementSrc);
-    } else if (this.isAmpScriptSrc_(elementSrc)) {
-      fetch = this.getAmpScriptJson_(elementSrc);
-    } else {
-      fetch = this.prepareAndSendFetch_();
-    }
-
-    return fetch.then((data) => {
-      const items = this.computeListItems_(data);
-      this.updateLoadMoreSrc_(/** @type {!JsonObject} */ (data));
-      return this.scheduleRender_(
-        items,
-        /*opt_append*/ true,
-        /*opt_payload*/ data
-      );
     });
   }
 
@@ -1539,7 +1513,7 @@ export class AmpList extends AMP.BaseElement {
     this.mutateElement(() => {
       this.getLoadMoreService_().toggleLoadMoreLoading(true);
     });
-    return this.fetchListAndAppend_()
+    return this.fetchList_({append: true})
       .then(() => {
         return this.mutateElement(() => {
           if (this.loadMoreSrc_) {

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -806,7 +806,17 @@ export class AmpList extends AMP.BaseElement {
     if (!this.element.getAttribute('src')) {
       return Promise.resolve();
     }
-    return this.prepareAndSendFetch_().then((data) => {
+
+    let fetch;
+    if (this.isAmpStateSrc_(elementSrc)) {
+      fetch = this.getAmpStateJson_(elementSrc);
+    } else if (this.isAmpScriptSrc_(elementSrc)) {
+      fetch = this.getAmpScriptJson_(elementSrc);
+    } else {
+      fetch = this.prepareAndSendFetch_();
+    }
+
+    return fetch.then((data) => {
       const items = this.computeListItems_(data);
       this.updateLoadMoreSrc_(/** @type {!JsonObject} */ (data));
       return this.scheduleRender_(

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -763,7 +763,7 @@ export class AmpList extends AMP.BaseElement {
 
     let fetch;
     if (this.ssrTemplateHelper_.isEnabled()) {
-      fetch = this.ssrTemplate_(opt_refresh);
+      fetch = this.ssrTemplate_(refresh);
     } else {
       if (this.isAmpStateSrc_(elementSrc)) {
         fetch = this.getAmpStateJson_(elementSrc);

--- a/extensions/amp-list/0.1/test-e2e/test-function-src.js
+++ b/extensions/amp-list/0.1/test-e2e/test-function-src.js
@@ -56,17 +56,23 @@ describes.endtoend(
     });
 
     it('should load more when button is clicked until no more load-more-src', async function () {
-      const loadMore = await controller.findElement('[load-more-button]');
-      await controller.click(loadMore)
+      // These two assertions are just to create a wait period ensuring the loadMore button
+      // is "clickable".
+      // TODO(samouri): expose a method on controller to wait for an element to be interactable.
+      await controller.findElement('[role=listitem]:nth-child(3)');
+      const loadMore = await controller.findElement('[load-more-clickable]');
 
-      return poll(25, async () => {
-        const listItems = await getListItems(controller);
-        return listItems.length === 15;
-      }); 
+      await controller.click(loadMore);
+
+      const fifteenthItem = await controller.findElement(
+        '[role=listitem]:nth-child(15)'
+      );
+      await expect(fifteenthItem).to.be.ok;
+      const items = await getListItems(controller);
+      await expect(items.length).equal(15);
     });
   }
 );
-
 
 function getListContainer(controller) {
   return controller.findElement('div[role=list]');

--- a/extensions/amp-list/0.1/test-e2e/test-function-src.js
+++ b/extensions/amp-list/0.1/test-e2e/test-function-src.js
@@ -40,6 +40,34 @@ describes.endtoend(
   }
 );
 
+describes.endtoend(
+  'amp-list "amp-script:" with load-more',
+  {
+    testUrl:
+      'http://localhost:8000/test/fixtures/e2e/amp-list/amp-list-function-load-more.html',
+    experiments: ['protocol-adapters'],
+    environments: ['single'],
+  },
+  async (env) => {
+    let controller;
+
+    beforeEach(async () => {
+      controller = env.controller;
+    });
+
+    it('should load more when button is clicked until no more load-more-src', async function () {
+      const loadMore = await controller.findElement('[load-more-button]');
+      await controller.click(loadMore)
+
+      return poll(25, async () => {
+        const listItems = await getListItems(controller);
+        return listItems.length === 15;
+      }); 
+    });
+  }
+);
+
+
 function getListContainer(controller) {
   return controller.findElement('div[role=list]');
 }

--- a/extensions/amp-list/0.1/test-e2e/test-function-src.js
+++ b/extensions/amp-list/0.1/test-e2e/test-function-src.js
@@ -68,8 +68,6 @@ describes.endtoend(
         '[role=listitem]:nth-child(15)'
       );
       await expect(fifteenthItem).to.be.ok;
-      const items = await getListItems(controller);
-      await expect(items.length).equal(15);
     });
   }
 );

--- a/extensions/amp-list/0.1/test-e2e/test-function-src.js
+++ b/extensions/amp-list/0.1/test-e2e/test-function-src.js
@@ -29,17 +29,14 @@ describes.endtoend(
       controller = env.controller;
     });
 
-    it.configure().run(
-      'should render list backed by amp-script data',
-      async function () {
-        const container = await getListContainer(controller);
-        await verifyContainer(controller, container);
+    it('should render list backed by amp-script data', async function () {
+      const container = await getListContainer(controller);
+      await verifyContainer(controller, container);
 
-        // Verify that all items rendered.
-        const listItems = await getListItems(controller);
-        await expect(listItems).to.have.length(2);
-      }
-    );
+      // Verify that all items rendered.
+      const listItems = await getListItems(controller);
+      await expect(listItems).to.have.length(2);
+    });
   }
 );
 

--- a/extensions/amp-list/0.1/test/test-amp-list.js
+++ b/extensions/amp-list/0.1/test/test-amp-list.js
@@ -996,6 +996,7 @@ describes.repeated(
               return list.layoutCallback().catch(() => {});
             });
           });
+
           describe('Using amp-script: protocol', () => {
             let ampScriptEl;
             beforeEach(() => {

--- a/test/fixtures/e2e/amp-list/amp-list-function-load-more.html
+++ b/test/fixtures/e2e/amp-list/amp-list-function-load-more.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html ⚡>
+<head>
+    <meta charset="utf-8">
+    <script async src="https://cdn.ampproject.org/v0.js"></script>
+    <script async custom-element="amp-list" src="https://cdn.ampproject.org/v0/amp-list-0.1.js"></script>
+    <script async custom-element="amp-script" src="https://cdn.ampproject.org/v0/amp-script-0.1.js"></script>
+    <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.2.js"></script>
+    <style amp4email-boilerplate>body{visibility:hidden}</style>
+</head>
+<body>
+    <amp-script id="fns" script="local-script" nodom data-ampdevmode ></amp-script>
+    <script type="text/plain" target="amp-script" id="local-script">
+      let count = 0;
+      function fetchData() {
+        if (count >= 5) {
+          return {items: []};
+        }
+        count++;
+        const items = [{name: 'apple'}, {name: 'banana'}, {name: 'pear'}];
+        return Promise.resolve({items, "load-more-src": "amp-script:fns.fetchData"});
+      }
+
+      exportFunction('fetchData', fetchData);
+    </script>
+    <amp-list
+      id="list1"
+      width="auto"
+      height="100"
+      layout="fixed-height"
+      src="amp-script:fns.fetchData"
+      load-more="auto"
+    >
+      <template type="amp-mustache" id="amp-template-id">
+        <div>{{name}}</div>
+      </template>
+    </amp-list>
+  </body>
+
+</html>


### PR DESCRIPTION
**summary**
Fixes https://github.com/ampproject/amphtml/issues/30095

The load-more option was broken when attempting to use it with `amp-script` as a data source. This is because it has a separate fetch flow that didn't consider `amp-script:` or `amp-state:` URIs.

This PR combines the two fetch flows, as well as adds a new e2e test for this interaction. In a future PR we should add documentation for how these two features interact.