### PR TITLE
🏗Add `gulp browse` task to open browser to URL

### DIFF
--- a/build-system/tasks/browse.js
+++ b/build-system/tasks/browse.js
@@ -80,7 +80,7 @@ function doBrowse(url) {
   return exec(`${browseCmd} ${url}`);
 }
 
-module.exports = {browse};
+module.exports = {browse, doBrowse};
 
 browse.description = 'Open a URL in the browser';
 browse.flags = {

--- a/build-system/tasks/browse.js
+++ b/build-system/tasks/browse.js
@@ -1,0 +1,88 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+const argv = require('minimist')(process.argv.slice(2));
+const log = require('fancy-log');
+const {cyan, green, red} = require('ansi-colors');
+const {exec} = require('../common/exec');
+
+/* Command to start the browser for each OS. */
+const BROWSE_CMD = {
+  OSX: 'open',
+  LINUX: 'sensible-browser',
+  WINDOWS: 'start chrome',
+};
+
+/* Returns the command to open the browse to a URL on the current platform. */
+function platformBrowseCmd() {
+  // See https://nodejs.org/api/process.html#process_process_platform
+  switch (process.platform) {
+    case 'darwin':
+      return BROWSE_CMD.OSX;
+    case 'win32':
+      return BROWSE_CMD.WINDOWS;
+    case 'aix':
+    case 'freebsd':
+    case 'linux':
+    case 'openbsd':
+    case 'sunos':
+      return BROWSE_CMD.LINUX;
+    default:
+      return null;
+  }
+}
+
+async function browse() {
+  const {url} = argv;
+
+  if (!url) {
+    log(
+      red('ERROR:'),
+      'No URL provided; please use',
+      cyan('--url'),
+      'to specify webpage URL to browse.'
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  return doBrowse(url);
+}
+
+function doBrowse(url) {
+  const browseCmd = platformBrowseCmd();
+  if (browseCmd === null) {
+    log(
+      red('ERROR:'),
+      'Unrecognized platform',
+      `${cyan(process.platform)};`,
+      'could not open browser.'
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  log(green('INFO:'), 'Opening', cyan(url), 'in browser...');
+  return exec(`${browseCmd} ${url}`);
+}
+
+module.exports = {browse};
+
+browse.description = 'Open a URL in the browser';
+browse.flags = {
+  url: '  URL to open',
+};

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -37,6 +37,7 @@ const {
 const {a4a} = require('./build-system/tasks/a4a');
 const {ava} = require('./build-system/tasks/ava');
 const {babelPluginTests} = require('./build-system/tasks/babel-plugin-tests');
+const {browse} = require('./build-system/tasks/browse');
 const {build, watch} = require('./build-system/tasks/build');
 const {bundleSize} = require('./build-system/tasks/bundle-size');
 const {cachesJson} = require('./build-system/tasks/caches-json');
@@ -133,6 +134,7 @@ function checkFlags(name, taskFunc) {
 createTask('a4a', a4a);
 createTask('ava', ava);
 createTask('babel-plugin-tests', babelPluginTests);
+createTask('browse', browse);
 createTask('build', build);
 createTask('bundle-size', bundleSize);
 createTask('caches-json', cachesJson);


### PR DESCRIPTION
`gulp browse --url <URL>` uses the platforms default browser (or, in the case of Windows, Chrome) to open a specified page. To be used for upcoming changes, including automatically opening a coverage UI after running e2e tests with the `--coverage` and `--browse` flags. Can also add `gulp serve --browse` for the same effect.
  
![image](https://user-images.githubusercontent.com/6694512/92142996-a8e20d00-ede2-11ea-8d61-231f83c59d6b.png)


<!--
# Instructions:

- Pick a meaningful title for your pull request. (Use sentence case.)
  - Prefix the title with an emoji to identify what is being done. (Copy-paste the emoji from the list below.)
  - Do not overuse punctuation in the title (like `(chore):`).
  - If it is helpful, use a simple prefix (like `ProjectX: Implement some feature`).
- Enter a succinct description that says why the PR is necessary, and what it does.
  - Mention the GitHub issue that is being addressed by the pull request.
  - The keywords `Fixes`, `Closes`, or `Resolves` followed the issue number will automatically close the issue.

> NOTE: All non-trivial changes (like introducing new features or components) should have an associated issue or reference an I2I (intent-to-implement: go.amp.dev/i2i). Please read through the contribution process (go.amp.dev/contributing/code) for more information.

# Example of a good description:

- Implement aspect X
- Leave out feature Y because of A
- Improve performance by B
- Improve accessibility by C

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Reverting a previous change
♻️ Refactoring
🚮 Deleting code
🧪 Experimental code
-->
