### PR TITLE
🐛 jss transform: support watch mode by allowing dupes if same file

### DIFF
--- a/build-system/babel-plugins/babel-plugin-transform-jss/create-hash.js
+++ b/build-system/babel-plugins/babel-plugin-transform-jss/create-hash.js
@@ -1,0 +1,23 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const crypto = require('crypto');
+
+// This is in its own file in order to make it easy to stub in tests.
+module.exports = {
+  createHash: (filepath) =>
+    crypto.createHash('sha256').update(filepath).digest('hex').slice(0, 7),
+};

--- a/build-system/babel-plugins/babel-plugin-transform-jss/index.js
+++ b/build-system/babel-plugins/babel-plugin-transform-jss/index.js
@@ -36,7 +36,7 @@
  * ```
  */
 
-const crypto = require('crypto');
+const hash = require('./create-hash');
 const {create} = require('jss');
 const {default: preset} = require('jss-preset-default');
 const {relative, join} = require('path');
@@ -49,11 +49,7 @@ module.exports = function ({types: t, template}) {
   const seen = new Map();
   function compileJss(JSS, filename) {
     const relativeFilepath = relative(join(__dirname, '../../..'), filename);
-    const filehash = crypto
-      .createHash('sha256')
-      .update(relativeFilepath)
-      .digest('hex')
-      .slice(0, 7);
+    const filehash = hash.createHash(relativeFilepath);
     const jss = create({
       ...preset(),
       createGenerateId: () => {
@@ -79,7 +75,6 @@ module.exports = function ({types: t, template}) {
   return {
     visitor: {
       CallExpression(path, state) {
-        // TODO: Can I skip the whole file if not jss?
         const {filename} = state.file.opts;
         if (!isJssFile(filename)) {
           return;

--- a/build-system/babel-plugins/babel-plugin-transform-jss/index.js
+++ b/build-system/babel-plugins/babel-plugin-transform-jss/index.js
@@ -46,7 +46,7 @@ module.exports = function ({types: t, template}) {
     return filename.endsWith('.jss.js');
   }
 
-  const seen = new Set();
+  const seen = new Map();
   function compileJss(JSS, filename) {
     const relativeFilepath = relative(join(__dirname, '../../..'), filename);
     const filehash = crypto
@@ -63,12 +63,12 @@ module.exports = function ({types: t, template}) {
             (c) => `-${c.toLowerCase()}`
           );
           const className = `${dashCaseKey}-${filehash}`;
-          if (seen.has(className)) {
+          if (seen.has(className) && seen.get(className) !== filename) {
             throw new Error(
               `Classnames must be unique across all files. Found a duplicate: ${className}`
             );
           }
-          seen.add(className);
+          seen.set(className, filename);
           return className;
         };
       },

--- a/build-system/babel-plugins/babel-plugin-transform-jss/test/index.js
+++ b/build-system/babel-plugins/babel-plugin-transform-jss/test/index.js
@@ -21,33 +21,31 @@ const runner = require('@babel/helper-plugin-test-runner').default;
 runner(__dirname);
 
 // eslint-disable-next-line no-undef
-describe('jss transform tests', () => {
-  const fileContents = `
+const fileContents = `
 import {createUseStyles} from 'react-jss';
 export const useStyles = createUseStyles({button: {fontSize: 12}});`;
 
-  const plugins = [path.join(__dirname, '..')];
-  const caller = {name: 'babel-jest'};
+const plugins = [path.join(__dirname, '..')];
+const caller = {name: 'babel-jest'};
 
-  // eslint-disable-next-line no-undef
-  test.only('transforming the same file contents twice should throw if there is a hash collision with filename', () => {
-    let filename;
-    expect(() => {
-      stubCreateHash(() => {
-        filename = 'test1.jss.js';
-        babel.transformSync(fileContents, {filename, plugins, caller});
-        filename = 'test2.jss.js';
-        babel.transformSync(fileContents, {filename, plugins, caller});
-      });
-    }).toThrow(/Classnames must be unique across all files/);
-  });
+// eslint-disable-next-line no-undef
+test('transforming the same file contents twice should throw if there is a hash collision with filename', () => {
+  let filename;
+  expect(() => {
+    stubCreateHash(() => {
+      filename = 'test1.jss.js';
+      babel.transformSync(fileContents, {filename, plugins, caller});
+      filename = 'test2.jss.js';
+      babel.transformSync(fileContents, {filename, plugins, caller});
+    });
+  }).toThrow(/Classnames must be unique across all files/);
+});
 
-  // eslint-disable-next-line no-undef
-  test('transforming same exact file twice is fine (e.g. watch mode)', () => {
-    const filename = 'test.jss.js';
-    babel.transformSync(fileContents, {filename, plugins, caller});
-    babel.transformSync(fileContents, {filename, plugins, caller});
-  });
+// eslint-disable-next-line no-undef
+test('transforming same exact file twice is fine (e.g. watch mode)', () => {
+  const filename = 'test.jss.js';
+  babel.transformSync(fileContents, {filename, plugins, caller});
+  babel.transformSync(fileContents, {filename, plugins, caller});
 });
 
 function stubCreateHash(fn) {

--- a/build-system/babel-plugins/babel-plugin-transform-jss/test/index.js
+++ b/build-system/babel-plugins/babel-plugin-transform-jss/test/index.js
@@ -26,13 +26,20 @@ test('throws when duplicate classname is found', () => {
 import {createUseStyles} from 'react-jss';
 export const useStyles = createUseStyles({button: {fontSize: 12}});
     `;
-  const filename = 'test.jss.js';
   const plugins = [path.join(__dirname, '..')];
   const caller = {name: 'babel-jest'};
+  let filename;
 
-  // Transforming the same file twice should yield the same classnames, resulting in an error
+  // Transforming the same file contents twice should yield the same classnames, resulting in an error.
+  expect(() => {
+    filename = 'test1.jss.js';
+    babel.transformSync(fileContents, {filename, plugins, caller});
+    filename = 'test2.jss.js';
+    babel.transformSync(fileContents, {filename, plugins, caller});
+  }).toThrow(/Classnames must be unique across all files/);
+
+  // Transforming the actual same file twice should work (e.g. watch mode).
+  filename = 'test.jss.js';
   babel.transformSync(fileContents, {filename, plugins, caller});
-  expect(() =>
-    babel.transformSync(fileContents, {filename, plugins, caller})
-  ).toThrow(/Classnames must be unique across all files/);
+  babel.transformSync(fileContents, {filename, plugins, caller});
 });


### PR DESCRIPTION
**summary**
The recently introduced jss transform bans duplicate classnames from appearing.
As written, it breaks `watch` mode since when the same file is compiled twice it of course generates the same classnames.

This PR fixes it by allowing for dupes within the same file.