### PR TITLE
Enable `amp-accordion-display-locking` experiment on 1% traffic

### DIFF
--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -9,6 +9,7 @@
   "a4aProfilingRate": 0.01,
   "adsense-ad-size-optimization": 0.05,
   "amp-access-iframe": 1,
+  "amp-accordion-display-locking": 0.01,
   "amp-action-macro": 1,
   "amp-ad-ff-adx-ady": 0.01,
   "amp-auto-ads-adsense-holdout": 0.1,


### PR DESCRIPTION
Reverting the removal from #28196, to merge when ready.