### PR TITLE
SwG Release 0.1.22.120

### DIFF
--- a/third_party/subscriptions-project/config.js
+++ b/third_party/subscriptions-project/config.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/** Version: 0.1.22.119 */
+/** Version: 0.1.22.120 */
 /**
  * Copyright 2018 The Subscribe with Google Authors. All Rights Reserved.
  *

--- a/third_party/subscriptions-project/swg.js
+++ b/third_party/subscriptions-project/swg.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/** Version: 0.1.22.119 */
+/** Version: 0.1.22.120 */
 /**
  * Copyright 2018 The Subscribe with Google Authors. All Rights Reserved.
  *
@@ -5712,6 +5712,7 @@ const SubscriptionFlows = {
   LINK_ACCOUNT: 'linkAccount',
   SHOW_LOGIN_PROMPT: 'showLoginPrompt',
   SHOW_LOGIN_NOTIFICATION: 'showLoginNotification',
+  SHOW_METER_TOAST: 'showMeterToast',
 };
 
 /**
@@ -6013,7 +6014,7 @@ function feCached(url) {
  */
 function feArgs(args) {
   return Object.assign(args, {
-    '_client': 'SwG 0.1.22.119',
+    '_client': 'SwG 0.1.22.120',
   });
 }
 
@@ -7132,7 +7133,7 @@ class ActivityPorts$1 {
         'analyticsContext': context.toArray(),
         'publicationId': pageConfig.getPublicationId(),
         'productId': pageConfig.getProductId(),
-        '_client': 'SwG 0.1.22.119',
+        '_client': 'SwG 0.1.22.120',
         'supportsEventManager': true,
       },
       args || {}
@@ -7981,7 +7982,7 @@ class AnalyticsService {
       context.setTransactionId(getUuid());
     }
     context.setReferringOrigin(parseUrl$1(this.getReferrer_()).origin);
-    context.setClientVersion('SwG 0.1.22.119');
+    context.setClientVersion('SwG 0.1.22.120');
     context.setUrl(getCanonicalUrl(this.doc_));
 
     const utmParams = parseQueryString$1(this.getQueryString_());
@@ -10374,6 +10375,22 @@ class DialogManager {
   }
 }
 
+/**
+ * Copyright 2018 The Subscribe with Google Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /** @enum {number}  */
 const MeterClientTypes = {
   /** Meter client type for content licensed by Google. */
@@ -10567,11 +10584,10 @@ class Toast {
  */
 
 /**
- * @param {!Date} date
+ * @param {!number} millis
  * @return {!Timestamp}
  */
-function toTimestamp(date) {
-  const millis = date.getTime();
+function toTimestamp(millis) {
   return new Timestamp(
     [Math.floor(millis / 1000), (millis % 1000) * 1000000],
     false
@@ -10674,15 +10690,7 @@ class EntitlementsManager {
   }
 
   /**
-   * @return {string}
-   * @private
-   */
-  getQueryString_() {
-    return this.win_.location.search;
-  }
-
-  /**
-   * @param {!GetEntitlementsParamsExternal=} params
+   * @param {!GetEntitlementsParamsExternalDef=} params
    * @return {!Promise<!Entitlements>}
    */
   getEntitlements(params) {
@@ -10690,11 +10698,11 @@ class EntitlementsManager {
     // `encryptedDocumentKey` string as a first param.
     if (typeof params === 'string') {
       // TODO: Delete the fallback if nobody needs it. Use a log to verify.
-      if (Date.now() > 1598899876598) {
+      if (Date.now() > 1600289016959) {
         // TODO: Remove the conditional check for this warning
         // after the AMP extension is updated to pass an object.
         log_4(
-          `[swg.js:getEntitlements]: If present, the first param of getEntitlements() should be an object of type GetEntitlementsParamsExternal.`
+          `[swg.js:getEntitlements]: If present, the first param of getEntitlements() should be an object of type GetEntitlementsParamsExternalDef.`
         );
       }
 
@@ -10748,7 +10756,7 @@ class EntitlementsManager {
 
     const message = new EntitlementsRequest();
     message.setUsedEntitlement(jwt);
-    message.setClientEventTime(toTimestamp(new Date()));
+    message.setClientEventTime(toTimestamp(Date.now()));
 
     const url =
       '/publication/' +
@@ -10759,7 +10767,7 @@ class EntitlementsManager {
   }
 
   /**
-   * @param {!GetEntitlementsParamsExternal=} params
+   * @param {!GetEntitlementsParamsExternalDef=} params
    * @return {!Promise<!Entitlements>}
    * @private
    */
@@ -10771,7 +10779,7 @@ class EntitlementsManager {
   }
 
   /**
-   * @param {!GetEntitlementsParamsExternal=} params
+   * @param {!GetEntitlementsParamsExternalDef=} params
    * @return {!Promise<!Entitlements>}
    * @private
    */
@@ -10808,7 +10816,7 @@ class EntitlementsManager {
   }
 
   /**
-   * @param {!GetEntitlementsParamsExternal=} params
+   * @param {!GetEntitlementsParamsExternalDef=} params
    * @return {!Promise<!Entitlements>}
    * @private
    */
@@ -11025,9 +11033,6 @@ class EntitlementsManager {
    */
   consume_(entitlements, onCloseDialog) {
     if (entitlements.enablesThisWithGoogleMetering()) {
-      // NOTE: This is just a placeholder. Once the metering prompt UI is ready,
-      // it will be opened here instead of the contributions iframe.
-      // TODO: Open metering prompt here instead of contributions iframe.
       const activityIframeView_ = new ActivityIframeView(
         this.win_,
         this.deps_.activities(),
@@ -11053,7 +11058,7 @@ class EntitlementsManager {
   }
 
   /**
-   * @param {!GetEntitlementsParamsExternal=} params
+   * @param {!GetEntitlementsParamsExternalDef=} params
    * @return {!Promise<!Entitlements>}
    * @private
    */
@@ -11073,7 +11078,7 @@ class EntitlementsManager {
         // Add metering params.
         const productId = this.pageConfig_.getProductId();
         if (productId && params && params.metering && params.metering.state) {
-          /** @type {!GetEntitlementsParamsInternal} */
+          /** @type {!GetEntitlementsParamsInternalDef} */
           const encodableParams = {
             metering: {
               clientTypes: [MeterClientTypes.LICENSED_BY_GOOGLE],
@@ -15649,22 +15654,8 @@ class PayClient {
     /** @private {?PaymentsAsyncClient} */
     this.client_ = null;
 
-    if (!isExperimentOn(this.win_, ExperimentFlags.PAY_CLIENT_LAZYLOAD)) {
-      this.client_ = this.createClient_(
-        /** @type {!PaymentOptions} */
-        ({
-          environment: 'PRODUCTION',
-          'i': {
-            'redirectKey': this.redirectVerifierHelper_.restoreKey(),
-          },
-        }),
-        this.analytics_.getTransactionId(),
-        this.handleResponse_.bind(this)
-      );
-    } else {
-      /** @private @const {!Preconnect} */
-      this.preconnect_ = new Preconnect(this.win_.document);
-    }
+    /** @private @const {!Preconnect} */
+    this.preconnect_ = new Preconnect(this.win_.document);
 
     // Prepare new verifier pair.
     this.redirectVerifierHelper_.prepare();
@@ -15718,10 +15709,7 @@ class PayClient {
   start(paymentRequest, options = {}) {
     this.request_ = paymentRequest;
 
-    if (
-      isExperimentOn(this.win_, ExperimentFlags.PAY_CLIENT_LAZYLOAD) &&
-      !this.client_
-    ) {
+    if (!this.client_) {
       this.preconnect(this.preconnect_);
       this.client_ = this.createClient_(
         /** @type {!PaymentOptions} */
@@ -16691,9 +16679,6 @@ class ConfiguredRuntime {
     preconnect.preconnect('https://www.google.com/');
     LinkCompleteFlow.configurePending(this);
     PayCompleteFlow.configurePending(this);
-    if (!isExperimentOn(this.win_, ExperimentFlags.PAY_CLIENT_LAZYLOAD)) {
-      this.payClient_.preconnect(preconnect);
-    }
 
     injectStyleSheet(this.doc_, CSS$1);
 


### PR DESCRIPTION
  - The demo now validates Google Article Access (GAA) URL params (#1247)
  - Updates a test that was using the deprecated `getEntitlements` string param (#1245)
  - Entitlements Manager: Improves test coverage (#1244)
  - Update dependency karma to v5.2.1 (#1243)
  - Update dependency eslint to v7.8.1 (#1242)
  - Fixes Travis config (#1241)
  - Improves comments (#1239)
  - Improves test coverage of EntitlementsManager (#1236)
  - Update dependency rollup to v2.26.9 (#1237)
  - Metering demo: "gaa_at" URL param triggers "metering" flow (#1234)
  - Update dependency eslint to v7.8.0 (#1235)
  - Update babel monorepo to v7.11.5 (#1233)
  - Update dependency rollup to v2.26.8 (#1231)
  - Update dependency karma to v5.2.0 (#1232)
  - Remove Pay Client Lazyload experiment (#1230)
  - Update dependency mocha to v8.1.3 (#1229)
  - Improves Metering demo (#1228)
  - Meter toast (#1209)
  - Consistently uses arrow fns when possible (#1216)
  - Update dependency rollup to v2.26.7 (#1227)