### PR TITLE
🐛 [amp-base-carousel] fix for next arrow not hidden properly when visible-count > 1

### DIFF
--- a/extensions/amp-base-carousel/0.1/amp-base-carousel.js
+++ b/extensions/amp-base-carousel/0.1/amp-base-carousel.js
@@ -537,6 +537,7 @@ class AmpCarousel extends AMP.BaseElement {
   updateUi_() {
     const index = this.carousel_.getCurrentIndex();
     const loop = this.carousel_.isLooping();
+    const visibleCount = this.carousel_.getVisibleCount();
     // TODO(sparhami) for Shadow DOM, we will need to get the assigned nodes
     // instead.
     iterateCursor(this.prevArrowSlot_.children, (child) => {
@@ -544,7 +545,7 @@ class AmpCarousel extends AMP.BaseElement {
       toggleAttribute(child, 'disabled', disabled);
     });
     iterateCursor(this.nextArrowSlot_.children, (child) => {
-      const disabled = !loop && index === this.slides_.length - 1;
+      const disabled = !loop && index >= this.slides_.length - visibleCount;
       toggleAttribute(child, 'disabled', disabled);
     });
     toggleAttribute(


### PR DESCRIPTION
This is a fix for the amp-base-carousel that do not behave properly in hiding the next arrow when reaching the end of the slides.
In particular, the hiding code was not working when there are more than one slide visible in the page (visible-count attribute set greater than 1).