### PR TITLE
copy worker-dom files from the new amp-production directory when it exists

### DIFF
--- a/build-system/compile/sources.js
+++ b/build-system/compile/sources.js
@@ -55,7 +55,7 @@ const COMMON_GLOBS = [
   'node_modules/@ampproject/viewer-messaging/package.json',
   'node_modules/@ampproject/viewer-messaging/messaging.js',
   'node_modules/@ampproject/worker-dom/package.json',
-  'node_modules/@ampproject/worker-dom/dist/amp/main.mjs',
+  'node_modules/@ampproject/worker-dom/dist/amp-production/main.mjs',
   'node_modules/preact/package.json',
   'node_modules/preact/dist/*.js',
   'node_modules/preact/hooks/package.json',

--- a/build-system/tasks/extension-helpers.js
+++ b/build-system/tasks/extension-helpers.js
@@ -565,10 +565,16 @@ async function buildExtensionJs(path, name, version, latestVersion, options) {
   }
 }
 
+/**
+ * Copies the required resources from @ampproject/worker-dom and renames
+ * them accordingly.
+ *
+ * @param {string} version
+ */
 async function copyWorkerDomResources(version) {
+  const startTime = Date.now();
   const workerDomDir = 'node_modules/@ampproject/worker-dom';
   const targetDir = 'dist/v0';
-
   log(
     green('Copying @ampproject/worker-dom resources:'),
     cyan('worker.js, worker.nodom.js')
@@ -632,6 +638,11 @@ async function copyWorkerDomResources(version) {
   for (const [src, dest] of workerFilesToDeploy) {
     await fs.copy(`${dir}/${src}`, `${targetDir}/${dest}`);
   }
+  endBuildStep(
+    'Copied @ampproject/worker-dom resources',
+    'worker.js, worker.nodom.js',
+    startTime
+  );
 }
 
 module.exports = {

--- a/build-system/tasks/extension-helpers.js
+++ b/build-system/tasks/extension-helpers.js
@@ -567,7 +567,6 @@ async function buildExtensionJs(path, name, version, latestVersion, options) {
 
 async function copyWorkerDomResources(version) {
   const workerDomDir = 'node_modules/@ampproject/worker-dom';
-  const newDirExists = fs.existsSync(`${workerDomDir}/dist/amp-production`);
   const targetDir = 'dist/v0';
 
   log(
@@ -575,86 +574,63 @@ async function copyWorkerDomResources(version) {
     cyan('worker.js, worker.nodom.js')
   );
 
-  if (newDirExists) {
-    const dir = `${workerDomDir}/dist`;
-    const workerFilesToDeploy = new Map([
-      ['amp-production/worker/worker.js', `amp-script-worker-${version}.js`],
-      [
-        'amp-production/worker/worker.nodom.js',
-        `amp-script-worker-nodom-${version}.js`,
-      ],
-      ['amp-production/worker/worker.mjs', `amp-script-worker-${version}.mjs`],
-      [
-        'amp-production/worker/worker.nodom.mjs',
-        `amp-script-worker-nodom-${version}.mjs`,
-      ],
-      [
-        'amp-production/worker/worker.js.map',
-        `amp-script-worker-${version}.js.map`,
-      ],
-      [
-        'amp-production/worker/worker.nodom.js.map',
-        `amp-script-worker-nodom-${version}.js.map`,
-      ],
-      [
-        'amp-production/worker/worker.mjs.map',
-        `amp-script-worker-${version}.mjs.map`,
-      ],
-      [
-        'amp-production/worker/worker.nodom.mjs.map',
-        `amp-script-worker-nodom-${version}.mjs.map`,
-      ],
-      ['amp-debug/worker/worker.js', `amp-script-worker-${version}.max.js`],
-      [
-        'amp-debug/worker/worker.nodom.js',
-        `amp-script-worker-nodom-${version}.max.js`,
-      ],
-      ['amp-debug/worker/worker.mjs', `amp-script-worker-${version}.max.mjs`],
-      [
-        'amp-debug/worker/worker.nodom.mjs',
-        `amp-script-worker-nodom-${version}.max.mjs`,
-      ],
-      [
-        'amp-debug/worker/worker.js.map',
-        `amp-script-worker-${version}.max.js.map`,
-      ],
-      [
-        'amp-debug/worker/worker.nodom.js.map',
-        `amp-script-worker-nodom-${version}.max.js.map`,
-      ],
-      [
-        'amp-debug/worker/worker.mjs.map',
-        `amp-script-worker-${version}.max.mjs.map`,
-      ],
-      [
-        'amp-debug/worker/worker.nodom.mjs.map',
-        `amp-script-worker-nodom-${version}.max.mjs.map`,
-      ],
-    ]);
-    for (const [src, dest] of workerFilesToDeploy) {
-      await fs.copy(`${dir}/${src}`, `${targetDir}/${dest}`);
-    }
-    // TODO(#30142, erwinm): remove else block once
-    // https://github.com/ampproject/worker-dom/pull/929 is the new version
-    // installed by AMP.
-  } else {
-    const dir = `${workerDomDir}/dist/amp/worker/`;
-    const file = `${targetDir}/amp-script-worker-${version}`;
-    // The "js" output is minified and transpiled to ES5.
-    await fs.copy(`${dir}/worker.js`, `${file}.js`);
-    await fs.copy(`${dir}/worker.js.map`, `${file}.js.map`);
-    // Copy the current worker code as the "mjs" file as well.
-    // This is a temporary fix.
-    await fs.copy(`${dir}/worker.js`, `${file}.mjs`);
-    await fs.copy(`${dir}/worker.js.map`, `${file}.mjs.map`);
-
-    const noDomFile = `${targetDir}/amp-script-worker-nodom-${version}`;
-    // Same as above but for the nodom worker variant.
-    await fs.copy(`${dir}/worker.nodom.js`, `${noDomFile}.js`);
-    await fs.copy(`${dir}/worker.nodom.js.map`, `${noDomFile}.js.map`);
-    // Copy the current worker nodom code as the "mjs" file as well.
-    await fs.copy(`${dir}/worker.nodom.js`, `${noDomFile}.mjs`);
-    await fs.copy(`${dir}/worker.nodom.js.map`, `${noDomFile}.mjs.map`);
+  const dir = `${workerDomDir}/dist`;
+  const workerFilesToDeploy = new Map([
+    ['amp-production/worker/worker.js', `amp-script-worker-${version}.js`],
+    [
+      'amp-production/worker/worker.nodom.js',
+      `amp-script-worker-nodom-${version}.js`,
+    ],
+    ['amp-production/worker/worker.mjs', `amp-script-worker-${version}.mjs`],
+    [
+      'amp-production/worker/worker.nodom.mjs',
+      `amp-script-worker-nodom-${version}.mjs`,
+    ],
+    [
+      'amp-production/worker/worker.js.map',
+      `amp-script-worker-${version}.js.map`,
+    ],
+    [
+      'amp-production/worker/worker.nodom.js.map',
+      `amp-script-worker-nodom-${version}.js.map`,
+    ],
+    [
+      'amp-production/worker/worker.mjs.map',
+      `amp-script-worker-${version}.mjs.map`,
+    ],
+    [
+      'amp-production/worker/worker.nodom.mjs.map',
+      `amp-script-worker-nodom-${version}.mjs.map`,
+    ],
+    ['amp-debug/worker/worker.js', `amp-script-worker-${version}.max.js`],
+    [
+      'amp-debug/worker/worker.nodom.js',
+      `amp-script-worker-nodom-${version}.max.js`,
+    ],
+    ['amp-debug/worker/worker.mjs', `amp-script-worker-${version}.max.mjs`],
+    [
+      'amp-debug/worker/worker.nodom.mjs',
+      `amp-script-worker-nodom-${version}.max.mjs`,
+    ],
+    [
+      'amp-debug/worker/worker.js.map',
+      `amp-script-worker-${version}.max.js.map`,
+    ],
+    [
+      'amp-debug/worker/worker.nodom.js.map',
+      `amp-script-worker-nodom-${version}.max.js.map`,
+    ],
+    [
+      'amp-debug/worker/worker.mjs.map',
+      `amp-script-worker-${version}.max.mjs.map`,
+    ],
+    [
+      'amp-debug/worker/worker.nodom.mjs.map',
+      `amp-script-worker-nodom-${version}.max.mjs.map`,
+    ],
+  ]);
+  for (const [src, dest] of workerFilesToDeploy) {
+    await fs.copy(`${dir}/${src}`, `${targetDir}/${dest}`);
   }
 }
 

--- a/build-system/tasks/extension-helpers.js
+++ b/build-system/tasks/extension-helpers.js
@@ -17,9 +17,7 @@
 const colors = require('ansi-colors');
 const debounce = require('debounce');
 const fs = require('fs-extra');
-const globby = require('globby');
 const log = require('fancy-log');
-const pathmod = require('path');
 const wrappers = require('../compile/compile-wrappers');
 const {
   extensionAliasBundles,
@@ -563,54 +561,100 @@ async function buildExtensionJs(path, name, version, latestVersion, options) {
   }
 
   if (name === 'amp-script') {
-    const workerDomDir = 'node_modules/@ampproject/worker-dom';
-    const newDirExists = fs.existsSync(`${workerDomDir}/dist/amp-production`);
-    const targetDir = 'dist/v0';
+    copyWorkerDomResources(version);
+  }
+}
 
-    log('Copying required @ampproject/worker-dom files.');
+async function copyWorkerDomResources(version) {
+  const workerDomDir = 'node_modules/@ampproject/worker-dom';
+  const newDirExists = fs.existsSync(`${workerDomDir}/dist/amp-production`);
+  const targetDir = 'dist/v0';
 
-    if (newDirExists) {
-      const dir = `${workerDomDir}/dist`;
-      const workerFilesToDeploy = await globby(
-        `${dir}/amp-production/worker/*`,
-        `${dir}/amp-debug/worker/*`
-      );
-      for (const filepath of workerFilesToDeploy) {
-        const maxFile = /amp-debug/.test(filepath);
-        const basename = pathmod.basename(filepath);
-        // Modify the current name to be either amp-script-worker or
-        // amp-script-worker-nodom.
-        const newBasename = basename
-          .replace(/^worker/, 'amp-script-worker')
-          .replace(/\.nodom/, '-nodom');
-        const nameParts = newBasename.split('.');
-        // Modify the basename part to have the version and the max.
-        nameParts[0] = nameParts[0] + `-${version}${maxFile ? '.max' : ''}`;
-        const newFilename = nameParts.join('.');
-        await fs.copy(filepath, `${targetDir}/${newFilename}`);
-      }
-      // TODO(#30142, erwinm): remove else block once
-      // https://github.com/ampproject/worker-dom/pull/929 is the new version
-      // installed by AMP.
-    } else {
-      const dir = `${workerDomDir}/dist/amp/worker/`;
-      const file = `${targetDir}/amp-script-worker-${version}`;
-      // The "js" output is minified and transpiled to ES5.
-      await fs.copy(`${dir}/worker.js`, `${file}.js`);
-      await fs.copy(`${dir}/worker.js.map`, `${file}.js.map`);
-      // Copy the current worker code as the "mjs" file as well.
-      // This is a temporary fix.
-      await fs.copy(`${dir}/worker.js`, `${file}.mjs`);
-      await fs.copy(`${dir}/worker.js.map`, `${file}.mjs.map`);
+  log(
+    green('Copying @ampproject/worker-dom resources:'),
+    cyan('worker.js, worker.nodom.js')
+  );
 
-      const noDomFile = `${targetDir}/amp-script-worker-nodom-${version}`;
-      // Same as above but for the nodom worker variant.
-      await fs.copy(`${dir}/worker.nodom.js`, `${noDomFile}.js`);
-      await fs.copy(`${dir}/worker.nodom.js.map`, `${noDomFile}.js.map`);
-      // Copy the current worker nodom code as the "mjs" file as well.
-      await fs.copy(`${dir}/worker.nodom.js`, `${noDomFile}.mjs`);
-      await fs.copy(`${dir}/worker.nodom.js.map`, `${noDomFile}.mjs.map`);
+  if (newDirExists) {
+    const dir = `${workerDomDir}/dist`;
+    const workerFilesToDeploy = new Map([
+      ['amp-production/worker/worker.js', `amp-script-worker-${version}.js`],
+      [
+        'amp-production/worker/worker.nodom.js',
+        `amp-script-worker-nodom-${version}.js`,
+      ],
+      ['amp-production/worker/worker.mjs', `amp-script-worker-${version}.mjs`],
+      [
+        'amp-production/worker/worker.nodom.mjs',
+        `amp-script-worker-nodom-${version}.mjs`,
+      ],
+      [
+        'amp-production/worker/worker.js.map',
+        `amp-script-worker-${version}.js.map`,
+      ],
+      [
+        'amp-production/worker/worker.nodom.js.map',
+        `amp-script-worker-nodom-${version}.js.map`,
+      ],
+      [
+        'amp-production/worker/worker.mjs.map',
+        `amp-script-worker-${version}.mjs.map`,
+      ],
+      [
+        'amp-production/worker/worker.nodom.mjs.map',
+        `amp-script-worker-nodom-${version}.mjs.map`,
+      ],
+      ['amp-debug/worker/worker.js', `amp-script-worker-${version}.max.js`],
+      [
+        'amp-debug/worker/worker.nodom.js',
+        `amp-script-worker-nodom-${version}.max.js`,
+      ],
+      ['amp-debug/worker/worker.mjs', `amp-script-worker-${version}.max.mjs`],
+      [
+        'amp-debug/worker/worker.nodom.mjs',
+        `amp-script-worker-nodom-${version}.max.mjs`,
+      ],
+      [
+        'amp-debug/worker/worker.js.map',
+        `amp-script-worker-${version}.max.js.map`,
+      ],
+      [
+        'amp-debug/worker/worker.nodom.js.map',
+        `amp-script-worker-nodom-${version}.max.js.map`,
+      ],
+      [
+        'amp-debug/worker/worker.mjs.map',
+        `amp-script-worker-${version}.max.mjs.map`,
+      ],
+      [
+        'amp-debug/worker/worker.nodom.mjs.map',
+        `amp-script-worker-nodom-${version}.max.mjs.map`,
+      ],
+    ]);
+    for (const [src, dest] of workerFilesToDeploy) {
+      await fs.copy(`${dir}/${src}`, `${targetDir}/${dest}`);
     }
+    // TODO(#30142, erwinm): remove else block once
+    // https://github.com/ampproject/worker-dom/pull/929 is the new version
+    // installed by AMP.
+  } else {
+    const dir = `${workerDomDir}/dist/amp/worker/`;
+    const file = `${targetDir}/amp-script-worker-${version}`;
+    // The "js" output is minified and transpiled to ES5.
+    await fs.copy(`${dir}/worker.js`, `${file}.js`);
+    await fs.copy(`${dir}/worker.js.map`, `${file}.js.map`);
+    // Copy the current worker code as the "mjs" file as well.
+    // This is a temporary fix.
+    await fs.copy(`${dir}/worker.js`, `${file}.mjs`);
+    await fs.copy(`${dir}/worker.js.map`, `${file}.mjs.map`);
+
+    const noDomFile = `${targetDir}/amp-script-worker-nodom-${version}`;
+    // Same as above but for the nodom worker variant.
+    await fs.copy(`${dir}/worker.nodom.js`, `${noDomFile}.js`);
+    await fs.copy(`${dir}/worker.nodom.js.map`, `${noDomFile}.js.map`);
+    // Copy the current worker nodom code as the "mjs" file as well.
+    await fs.copy(`${dir}/worker.nodom.js`, `${noDomFile}.mjs`);
+    await fs.copy(`${dir}/worker.nodom.js.map`, `${noDomFile}.mjs.map`);
   }
 }
 

--- a/extensions/amp-script/0.1/amp-script.js
+++ b/extensions/amp-script/0.1/amp-script.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as WorkerDOM from '@ampproject/worker-dom/dist/amp/main.mjs';
+import * as WorkerDOM from '@ampproject/worker-dom/dist/amp-production/main.mjs';
 import {CSS} from '../../../build/amp-script-0.1.css';
 import {Deferred} from '../../../src/utils/promise';
 import {Layout, isLayoutSizeDefined} from '../../../src/layout';

--- a/extensions/amp-script/0.1/test/unit/test-amp-script.js
+++ b/extensions/amp-script/0.1/test/unit/test-amp-script.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as WorkerDOM from '@ampproject/worker-dom/dist/amp/main.mjs';
+import * as WorkerDOM from '@ampproject/worker-dom/dist/amp-production/main.mjs';
 import {
   AmpScript,
   AmpScriptService,

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@ampproject/animations": "0.2.2",
     "@ampproject/toolbox-cache-url": "2.5.4",
     "@ampproject/viewer-messaging": "1.1.0",
-    "@ampproject/worker-dom": "0.25.2",
+    "@ampproject/worker-dom": "0.27.1",
     "dompurify": "2.0.7",
     "intersection-observer": "0.11.0",
     "jss": "10.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -104,10 +104,10 @@
   resolved "https://registry.yarnpkg.com/@ampproject/viewer-messaging/-/viewer-messaging-1.1.0.tgz#404f92c5754bac61014ed2272dd5e87174b9af84"
   integrity sha512-SoR1dGl2Pl8eJlyGCU/9Gz/orOggmW/13wUh7NnuGvDYqLdlhnRBzvEGqEAlq/fQKel9ZM6RNtu85Jw8WC3K2Q==
 
-"@ampproject/worker-dom@0.25.2":
-  version "0.25.2"
-  resolved "https://registry.yarnpkg.com/@ampproject/worker-dom/-/worker-dom-0.25.2.tgz#910eed5b0f842ed139ab84719097297ca67fa23a"
-  integrity sha512-l6H1vJ2AfvvkXiGH2a5HDT4ft+YDhnbtzd0GslIiRDYcmKJ6yiJXdicvpBWQu9PLapa59Q4hW0HMxEaYRZOHeg==
+"@ampproject/worker-dom@0.27.1":
+  version "0.27.1"
+  resolved "https://registry.yarnpkg.com/@ampproject/worker-dom/-/worker-dom-0.27.1.tgz#42b1e3a87e982fe184791681e3b197a8eae42455"
+  integrity sha512-LOsZDYiOJSlA6b4yu83PeiY38gjZSZvGP4eYG49ME55yFhl2EinwmIIWf7+6kySSfriXxuTdWHWCH84qurlwSQ==
 
 "@ava/babel-plugin-throws-helper@^4.0.0":
   version "4.0.0"


### PR DESCRIPTION
- remove the copying of "mjs" files into "max.js" files (turning modules into nomodules is a big no no)
- copy the "js" files to "mjs" files to fix the missing "mjs" files for when the module version of amp is loaded (this is OK for now as a temp fix)
- if /dist/amp-production exists in worker-dom then the new directory structure implemented has https://github.com/ampproject/worker-dom/pull/929 is merged and we should copy from the new directories
- make sure to copy source map files as well
- upgrade worker-dom version
- fix import paths to main.mjs