### PR TITLE
babel tests: support windows

### DIFF
--- a/build-system/babel-plugins/babel-plugin-amp-mode-transformer/index.js
+++ b/build-system/babel-plugins/babel-plugin-amp-mode-transformer/index.js
@@ -19,7 +19,7 @@
  * and getMode().localDev to true.
  * @param {Object} babelTypes
  */
-const {resolve, dirname} = require('path');
+const {resolve, dirname, join, relative} = require('path');
 
 let shouldResolveDevelopmentMode = true;
 
@@ -41,11 +41,14 @@ module.exports = function ({types: t}) {
         }
         specifiers.forEach((specifier) => {
           if (specifier.imported && specifier.imported.name === 'getMode') {
-            const filepath = resolve(
-              dirname(state.file.opts.filename),
-              source.value
+            const filepath = relative(
+              join(__dirname, '../../../'),
+              resolve(dirname(state.file.opts.filename), source.value)
             );
-            if (filepath.endsWith('/amphtml/src/mode')) {
+            if (
+              filepath.endsWith('src/mode') ||
+              filepath.endsWith('src\\mode')
+            ) {
               getModeFound = true;
             }
           }

--- a/build-system/babel-plugins/babel-plugin-transform-dev-methods/index.js
+++ b/build-system/babel-plugins/babel-plugin-transform-dev-methods/index.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-const {resolve, dirname} = require('path');
+const {resolve, dirname, relative, join} = require('path');
 
 // Returns a new Map<string, {detected: boolean, removeable: Array<string>}
 // key is a valid callee name to potentially remove.
@@ -65,12 +65,12 @@ module.exports = function () {
         }
         specifiers.forEach((specifier) => {
           if (specifier.imported) {
-            const filepath = resolve(
-              dirname(state.file.opts.filename),
-              source.value
+            const filepath = relative(
+              join(__dirname, '../../../'),
+              resolve(dirname(state.file.opts.filename), source.value)
             );
 
-            if (filepath.endsWith('/amphtml/src/log')) {
+            if (filepath.endsWith('src/log') || filepath.endsWith('src\\log')) {
               const propertyMapped = calleeToPropertiesMap.get(
                 specifier.imported.name
               );

--- a/build-system/babel-plugins/babel-plugin-transform-inline-configure-component/index.js
+++ b/build-system/babel-plugins/babel-plugin-transform-inline-configure-component/index.js
@@ -68,7 +68,10 @@ function transformRedefineInline({types: t}) {
       ImportDeclaration(path, {opts}) {
         const {source} = path.node;
         if (source.value.startsWith('.')) {
-          source.value = join(opts.from, source.value).replace(/^[^.]/, './$&');
+          source.value = toPosix(join(opts.from, source.value)).replace(
+            /^[^.]/,
+            './$&'
+          );
         }
       },
       MemberExpression(path, {opts}) {
@@ -221,3 +224,9 @@ module.exports = function ({types: t}) {
     },
   };
 };
+
+// Even though we are using the path module, JS Modules should never have
+// their paths specified in Windows format.
+function toPosix(filepath) {
+  return filepath.replace(/\\\\/g, '/').replace(/\\/g, '/');
+}

--- a/build-system/babel-plugins/babel-plugin-transform-jss/create-hash.js
+++ b/build-system/babel-plugins/babel-plugin-transform-jss/create-hash.js
@@ -19,5 +19,14 @@ const crypto = require('crypto');
 // This is in its own file in order to make it easy to stub in tests.
 module.exports = {
   createHash: (filepath) =>
-    crypto.createHash('sha256').update(filepath).digest('hex').slice(0, 7),
+    crypto
+      .createHash('sha256')
+      .update(toPosix(filepath))
+      .digest('hex')
+      .slice(0, 7),
 };
+
+// To support Windows, use posix separators for all filepath hashes.
+function toPosix(filepath) {
+  return filepath.replace(/\\\\/g, '/').replace(/\\/g, '/');
+}

--- a/build-system/babel-plugins/babel-plugin-transform-promise-resolve/index.js
+++ b/build-system/babel-plugins/babel-plugin-transform-promise-resolve/index.js
@@ -41,7 +41,8 @@ module.exports = function (babel, options = {}) {
         // Relative will return "foo" instead of "./foo". And if it returned
         // a "../foo", making it "./../foo" doesn't hurt.
         const source =
-          './' + filepath.relative(filepath.dirname(filename), importFrom);
+          './' +
+          toPosix(filepath.relative(filepath.dirname(filename), importFrom));
         const resolvedPromise = addNamed(path, 'resolvedPromise', source, {
           importedType: 'es6',
         });
@@ -50,3 +51,9 @@ module.exports = function (babel, options = {}) {
     },
   };
 };
+
+// Even though we are using the path module, JS Modules should never have
+// their paths specified in Windows format.
+function toPosix(filepath) {
+  return filepath.replace(/\\\\/g, '/').replace(/\\/g, '/');
+}


### PR DESCRIPTION
**summary**
Followup to https://github.com/ampproject/amphtml/pull/29115.

Make the babel tests pass on Windows.