### PR TITLE
🐛 Fixing window reference for amp-ad type kargo

### DIFF
--- a/ads/kargo.js
+++ b/ads/kargo.js
@@ -45,9 +45,9 @@ export function kargo(global, data) {
     'kargo-load',
     function (done) {
       // load AdTag in Master window
-      loadScript(this, kargoScriptUrl, () => {
+      loadScript(window, kargoScriptUrl, () => {
         let success = false;
-        if (this.Kargo != null && this.Kargo.loaded) {
+        if (window.Kargo != null && window.Kargo.loaded) {
           success = true;
         }
 

--- a/ads/kargo.js
+++ b/ads/kargo.js
@@ -45,9 +45,9 @@ export function kargo(global, data) {
     'kargo-load',
     function (done) {
       // load AdTag in Master window
-      loadScript(window, kargoScriptUrl, () => {
+      loadScript(global, kargoScriptUrl, () => {
         let success = false;
-        if (window.Kargo != null && window.Kargo.loaded) {
+        if (global.Kargo != null && global.Kargo.loaded) {
           success = true;
         }
 


### PR DESCRIPTION
- Replaces `this` reference in loadScript call with local `window`