### PR TITLE
amp-ad type broadstreetads: Support renderStart()

### DIFF
--- a/ads/_config.js
+++ b/ads/_config.js
@@ -349,6 +349,7 @@ const adConfig = jsonConfiguration({
 
   'broadstreetads': {
     prefetch: 'https://cdn.broadstreetads.com/init-2.min.js',
+    renderStartImplemented: true,
   },
 
   'byplay': {},

--- a/ads/broadstreetads.js
+++ b/ads/broadstreetads.js
@@ -37,11 +37,14 @@ export function broadstreetads(global, data) {
   global.document.getElementById('c').appendChild(d);
 
   global.broadstreet = global.broadstreet || {};
-  global.broadstreet.loadZone = global.broadstreet.loadZone || (() => ({}));
+  global.broadstreet.loadAMPZone =
+    global.broadstreet.loadAMPZone || (() => ({}));
   global.broadstreet.run = global.broadstreet.run || [];
   global.broadstreet.run.push(() => {
-    global.broadstreet.loadZone(d, {
+    global.broadstreet.loadAMPZone(d, {
       amp: true,
+      ampGlobal: global,
+      ampData: data,
       height: data.height,
       keywords: data.keywords,
       networkId: data.network,


### PR DESCRIPTION
This PR implements the render-start requested by the AMP team on https://github.com/ampproject/amphtml/pull/12475 