### PR TITLE
Unblock Preact tests that are executed against fake clock

### DIFF
--- a/extensions/amp-date-display/1.0/test/test-amp-date-display.js
+++ b/extensions/amp-date-display/1.0/test/test-amp-date-display.js
@@ -83,6 +83,7 @@ describes.realWin(
     });
 
     afterEach(() => {
+      clock.runAll();
       clock.uninstall();
     });
 

--- a/extensions/amp-date-display/1.0/test/test-amp-date-display.js
+++ b/extensions/amp-date-display/1.0/test/test-amp-date-display.js
@@ -23,7 +23,7 @@ import {
 } from '../../../../src/dom';
 
 describes.realWin(
-  'amp-date-display',
+  'amp-date-display 1.0',
   {
     amp: {
       runtimeOn: true,

--- a/extensions/amp-date-display/1.0/test/test-date-display.js
+++ b/extensions/amp-date-display/1.0/test/test-date-display.js
@@ -18,7 +18,7 @@ import * as Preact from '../../../../src/preact';
 import {DateDisplay} from '../date-display';
 import {mount} from 'enzyme';
 
-describes.sandboxed('date-display preact component', {}, (env) => {
+describes.sandboxed('DateDisplay 1.0 preact component', {}, (env) => {
   let sandbox;
   let clock;
 

--- a/extensions/amp-date-display/1.0/test/test-date-display.js
+++ b/extensions/amp-date-display/1.0/test/test-date-display.js
@@ -20,6 +20,7 @@ import {mount} from 'enzyme';
 
 describes.sandboxed('date-display preact component', {}, (env) => {
   let sandbox;
+  let clock;
 
   function render(data) {
     return JSON.stringify(
@@ -36,7 +37,11 @@ describes.sandboxed('date-display preact component', {}, (env) => {
 
   beforeEach(() => {
     sandbox = env.sandbox;
-    sandbox.useFakeTimers(new Date('2018-01-01T08:00:00Z'));
+    clock = sandbox.useFakeTimers(new Date('2018-01-01T08:00:00Z'));
+  });
+
+  afterEach(() => {
+    clock.runAll();
   });
 
   // Unfortunately, we cannot test the most interesting case of UTC datetime

--- a/extensions/amp-social-share/1.0/test/test-social-share.js
+++ b/extensions/amp-social-share/1.0/test/test-social-share.js
@@ -19,8 +19,9 @@ import {SocialShare} from '../social-share';
 import {dict} from '../../../../src/utils/object';
 import {mount} from 'enzyme';
 
-describes.sandboxed('SocialShare preact component v1.0', {}, () => {
-  it('errors when the required "type" attribute is not provided', () => {
+describes.sandboxed('SocialShare 1.0 preact component', {}, () => {
+  // TODO(#30043): unskip once #30043 is merged (Preact bug fix).
+  it.skip('errors when the required "type" attribute is not provided', () => {
     const jsx = <SocialShare />;
 
     expect(() => {
@@ -28,7 +29,8 @@ describes.sandboxed('SocialShare preact component v1.0', {}, () => {
     }).to.throw('The type attribute is required.');
   });
 
-  it(
+  // TODO(#30043): unskip once #30043 is merged (Preact bug fix).
+  it.skip(
     'errors when the required endpoint is not provided when not using' +
       ' a pre-configured type',
     () => {

--- a/extensions/amp-timeago/1.0/test/test-amp-timeago.js
+++ b/extensions/amp-timeago/1.0/test/test-amp-timeago.js
@@ -64,8 +64,7 @@ describes.realWin(
       toggleExperiment(win, 'amp-timeago-bento', false);
     });
 
-    // TODO (#29246): De-flake and un-skip this test.
-    it.skip('should render display 2 days ago when built', async () => {
+    it('should render display 2 days ago when built', async () => {
       const date = new Date();
       date.setDate(date.getDate() - 2);
       element.setAttribute('datetime', date.toISOString());
@@ -75,8 +74,7 @@ describes.realWin(
       expect(time).to.equal('2 days ago');
     });
 
-    // TODO (#29246): De-flake and un-skip this test.
-    it.skip('should display original date when older than cutoff', async () => {
+    it('should display original date when older than cutoff', async () => {
       const date = new Date('2017-01-01');
       element.setAttribute('datetime', date.toISOString());
       element.textContent = 'Sunday 1 January 2017';
@@ -86,8 +84,7 @@ describes.realWin(
       expect(time).to.equal('Sunday 1 January 2017');
     });
 
-    // TODO (#29246): De-flake and un-skip this test.
-    it.skip('should update after mutation of datetime attribute', async () => {
+    it('should update after mutation of datetime attribute', async () => {
       const date = new Date();
       date.setDate(date.getDate() - 2);
       element.setAttribute('datetime', date.toISOString());

--- a/extensions/amp-timeago/1.0/test/test-amp-timeago.js
+++ b/extensions/amp-timeago/1.0/test/test-amp-timeago.js
@@ -19,7 +19,7 @@ import {waitForChildPromise} from '../../../../src/dom';
 import {whenCalled} from '../../../../testing/test-helper.js';
 
 describes.realWin(
-  'amp-timeago',
+  'amp-timeago 1.0',
   {
     amp: {
       runtimeOn: true,


### PR DESCRIPTION
This pull request reverts #30181.

### The description of the problem 1:

Preact schedules handler only once for a queue, when [`queue.length === 1`](https://github.com/preactjs/preact/blob/84a16f2108da9f23fbd017e703500fd2f7d31e02/hooks/src/index.js#L325). We had a situation where the fake test clock was used to schedule the update for `queue.length === 1`, but then it was discarded. All followup queue pushes were not scheduled because `queue.length > 1`. But the fake timer was never executed, so the queue was stuck - more items were added to it, but handler was never called. I was actually surprised by this a bit - I though `clock.uninstall` would run all pending timers, but apparently not.

Not yet clear how to defend from this in depth. Debugging this problem is extremely difficult - there's no way to determine a "hanged" queue on Preact's side. One thing I tried is setting `Preact.options.requestAnimationFrame`, which is similar to wrapping in `act()`. However, even with this option, Preact still relies on `setTimeout`.

### The description of the problem 2:

Preact's test-utils used to break the queue when the render function fails. This has been fixed in https://github.com/preactjs/preact/commit/4efcd75d519fb37aa5bed0a6ba8653b9a9320812. However, we're currently blocked on our Preact upgrade due to unrelated Closure bug. See #30043.

In general, a failing render function is not a good idea and that should be fixed separately. However, noting this here since this is also very hard to debug.

