### PR TITLE
intersection-observer: don't use premeasure if there is a more recent measure

### DIFF
--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -485,11 +485,10 @@ export class Resource {
     const oldBox = this.layoutBox_;
     if (usePremeasuredRect) {
       this.computeMeasurements_(devAssert(this.premeasuredRect_));
-      this.premeasuredRect_ = null;
     } else {
       this.computeMeasurements_();
-      this.premeasuredRect_ = null;
     }
+    this.premeasuredRect_ = null;
     const newBox = this.layoutBox_;
 
     // Note that "left" doesn't affect readiness for the layout.

--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -488,6 +488,7 @@ export class Resource {
       this.premeasuredRect_ = null;
     } else {
       this.computeMeasurements_();
+      this.premeasuredRect_ = null;
     }
     const newBox = this.layoutBox_;
 


### PR DESCRIPTION
**summary**
Fixes an issue with `intersect-resources` experiment where it can use an out-of-date rect. Specifically we were seeing a regression in `amp-ad` where a carousel 1.0 slides were not being laid out at all. This is due to a mismatch in `isDisplayed` between the premeasure rect and the more-recent measure within owners.

The sequence of events that causes this bug were:
1. io callback premeasure occurs with zero height/width (this is valid / can happen for various reasons)
2. explicit measure happens via the owners system, and a layout is scheduled
3. an attempt at layout begins but the task is skipped due to checking `isDisplayed` with the premeasuredRect - see below for the snippet that does the skipping.
4. io callback premeasure occurs again with positive width/height, but its too late and the slides wont be laid out until the next pass (which isn't scheduled).

https://github.com/ampproject/amphtml/blob/cc14c967903570c19a5e60027a1661a367b3c5f3/src/service/resources-impl.js#L1547-L1556

There are numerous ways of trying to fix this. The first two I thought of were:
1. schedule a new pass each time io callback fires, since we may need to lay items out that were skipped previously
2. toss out any premeasures if we have something more recent

I went with (2) within this PR

**repro html**
```html
<!doctype html>
<html amp lang="en">
  <head>
    <meta charset="utf-8">
    <script async src="https://cdn.ampproject.org/v0.js"></script>
    <title>DBM AMP Test Page</title>
    <link rel="canonical" href="http://example.ampproject.org/article-metadata.html">
    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
  </head>
  <body>
    <h1> Test AMP Custom Bundle </h1>
    <amp-ad width=300 height=250
        type="doubleclick"
        data-slot="/93132893/suship_jordan_display_08222018">
    </amp-ad>
  </body>
</html>

```