### PR TITLE
📖 [bento][amp-social-share] Clean up storybooks for social share

### DIFF
--- a/extensions/amp-social-share/0.1/storybook/Basic.amp.js
+++ b/extensions/amp-social-share/0.1/storybook/Basic.amp.js
@@ -21,7 +21,7 @@ import {withA11y} from '@storybook/addon-a11y';
 import {withAmp} from '@ampproject/storybook-addon';
 
 // eslint-disable-next-line
-storiesOf('amp-social-share v1', module)
+storiesOf('amp-social-share-0_1', module)
   .addDecorator(withKnobs)
   .addDecorator(withA11y)
   .addDecorator(withAmp)
@@ -68,6 +68,7 @@ storiesOf('amp-social-share v1', module)
       'sms',
       'system',
       'custom',
+      undefined,
     ];
     const type = select('type', typeConfigurations, typeConfigurations[0]);
     const customEndpoint = text('data-share-endpoint', undefined);
@@ -76,6 +77,8 @@ storiesOf('amp-social-share v1', module)
     const paramAttribution = text('data-param-attribution', undefined);
     const paramMedia = text('data-param-media', undefined);
     const appId = text('data-param-app_id', '254325784911610');
+    const width = text('width', undefined);
+    const height = text('height', undefined);
     return (
       <amp-social-share
         type={type}
@@ -85,6 +88,8 @@ storiesOf('amp-social-share v1', module)
         data-param-attribution={paramAttribution}
         data-param-media={paramMedia}
         data-param-app_id={appId}
+        width={width}
+        height={height}
       ></amp-social-share>
     );
   });

--- a/extensions/amp-social-share/0.1/storybook/Basic.amp.js
+++ b/extensions/amp-social-share/0.1/storybook/Basic.amp.js
@@ -71,14 +71,14 @@ storiesOf('amp-social-share-0_1', module)
       undefined,
     ];
     const type = select('type', typeConfigurations, typeConfigurations[0]);
-    const customEndpoint = text('data-share-endpoint', undefined);
-    const paramUrl = text('data-param-url', undefined);
-    const paramText = text('data-param-text', undefined);
-    const paramAttribution = text('data-param-attribution', undefined);
-    const paramMedia = text('data-param-media', undefined);
+    const customEndpoint = text('data-share-endpoint', null);
+    const paramUrl = text('data-param-url', null);
+    const paramText = text('data-param-text', null);
+    const paramAttribution = text('data-param-attribution', null);
+    const paramMedia = text('data-param-media', null);
     const appId = text('data-param-app_id', '254325784911610');
-    const width = text('width', undefined);
-    const height = text('height', undefined);
+    const width = text('width', null);
+    const height = text('height', null);
     return (
       <amp-social-share
         type={type}

--- a/extensions/amp-social-share/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-social-share/1.0/storybook/Basic.amp.js
@@ -21,7 +21,7 @@ import {withA11y} from '@storybook/addon-a11y';
 import {withAmp} from '@ampproject/storybook-addon';
 
 // eslint-disable-next-line
-storiesOf('amp-social-share 1_0', module)
+storiesOf('amp-social-share-1_0', module)
   .addDecorator(withKnobs)
   .addDecorator(withA11y)
   .addDecorator(withAmp)
@@ -72,6 +72,7 @@ storiesOf('amp-social-share 1_0', module)
       'sms',
       'system',
       'custom',
+      undefined,
     ];
     const type = select('type', typeConfigurations, typeConfigurations[0]);
     const customEndpoint = text('data-share-endpoint', undefined);
@@ -80,6 +81,9 @@ storiesOf('amp-social-share 1_0', module)
     const paramAttribution = text('data-param-attribution', undefined);
     const paramMedia = text('data-param-media', undefined);
     const appId = text('data-param-app_id', '254325784911610');
+    const layout = text('layout', undefined);
+    const width = text('width', undefined);
+    const height = text('height', undefined);
     return (
       <amp-social-share
         type={type}
@@ -89,42 +93,9 @@ storiesOf('amp-social-share 1_0', module)
         data-param-attribution={paramAttribution}
         data-param-media={paramMedia}
         data-param-app_id={appId}
-      ></amp-social-share>
-    );
-  })
-  .add('responsive', () => {
-    const typeConfigurations = [
-      'email',
-      'facebook',
-      'linkedin',
-      'pinterest',
-      'tumblr',
-      'twitter',
-      'whatsapp',
-      'line',
-      'sms',
-      'system',
-      'custom',
-    ];
-    const type = select('type', typeConfigurations, typeConfigurations[0]);
-    const customEndpoint = text('data-share-endpoint', undefined);
-    const paramUrl = text('data-param-url', undefined);
-    const paramText = text('data-param-text', undefined);
-    const paramAttribution = text('data-param-attribution', undefined);
-    const paramMedia = text('data-param-media', undefined);
-    const appId = text('data-param-app_id', '254325784911610');
-    return (
-      <amp-social-share
-        type={type}
-        data-share-endpoint={customEndpoint}
-        data-param-text={paramText}
-        data-param-url={paramUrl}
-        data-param-attribution={paramAttribution}
-        data-param-media={paramMedia}
-        data-param-app_id={appId}
-        layout="responsive"
-        width="100"
-        height="100"
+        layout={layout}
+        width={width}
+        height={height}
       ></amp-social-share>
     );
   });

--- a/extensions/amp-social-share/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-social-share/1.0/storybook/Basic.amp.js
@@ -75,15 +75,15 @@ storiesOf('amp-social-share-1_0', module)
       undefined,
     ];
     const type = select('type', typeConfigurations, typeConfigurations[0]);
-    const customEndpoint = text('data-share-endpoint', undefined);
-    const paramUrl = text('data-param-url', undefined);
-    const paramText = text('data-param-text', undefined);
-    const paramAttribution = text('data-param-attribution', undefined);
-    const paramMedia = text('data-param-media', undefined);
+    const customEndpoint = text('data-share-endpoint', null);
+    const paramUrl = text('data-param-url', null);
+    const paramText = text('data-param-text', null);
+    const paramAttribution = text('data-param-attribution', null);
+    const paramMedia = text('data-param-media', null);
     const appId = text('data-param-app_id', '254325784911610');
-    const layout = text('layout', undefined);
-    const width = text('width', undefined);
-    const height = text('height', undefined);
+    const layout = text('layout', null);
+    const width = text('width', null);
+    const height = text('height', null);
     return (
       <amp-social-share
         type={type}

--- a/extensions/amp-social-share/1.0/storybook/Basic.js
+++ b/extensions/amp-social-share/1.0/storybook/Basic.js
@@ -16,11 +16,11 @@
 
 import * as Preact from '../../../../src/preact';
 import {SocialShare} from '../social-share';
-import {object, select, text, withKnobs} from '@storybook/addon-knobs';
+import {color, object, select, text, withKnobs} from '@storybook/addon-knobs';
 import {withA11y} from '@storybook/addon-a11y';
 
 export default {
-  title: 'Social Share',
+  title: 'SocialShare',
   component: SocialShare,
   decorators: [withA11y, withKnobs],
 };
@@ -37,10 +37,8 @@ export const _default = () => {
     'line',
     'sms',
     'system',
-    'custom endpoint',
+    'custom',
     undefined,
-    '',
-    'random',
   ];
   const type = select('type', knobConfigurations, knobConfigurations[0]);
   const endpoint = text('customEndpoint', undefined);
@@ -48,22 +46,21 @@ export const _default = () => {
   const target = text('target', undefined);
   const width = text('width', undefined);
   const height = text('height', undefined);
+  const foregroundColor = color('color', undefined);
+  const background = color('background', undefined);
+  const children = text('children', undefined);
 
   return (
-    <div>
-      <p>
-        Click the button below to share this page using the configured provider.
-        Update the provider using storybook knobs. Choose Provider Type: 'custom
-        endpoint' to specify your own share endpoint.
-      </p>
-      <SocialShare
-        type={type}
-        endpoint={endpoint}
-        params={additionalParams}
-        target={target}
-        width={width}
-        height={height}
-      />
-    </div>
+    <SocialShare
+      type={type}
+      endpoint={endpoint}
+      params={additionalParams}
+      target={target}
+      width={width}
+      height={height}
+      color={foregroundColor}
+      background={background}
+      children={children}
+    />
   );
 };

--- a/extensions/amp-social-share/1.0/storybook/Basic.js
+++ b/extensions/amp-social-share/1.0/storybook/Basic.js
@@ -41,14 +41,14 @@ export const _default = () => {
     undefined,
   ];
   const type = select('type', knobConfigurations, knobConfigurations[0]);
-  const endpoint = text('customEndpoint', undefined);
+  const endpoint = text('customEndpoint', null);
   const additionalParams = object('additionalParams', {'subject': 'test'});
-  const target = text('target', undefined);
-  const width = text('width', undefined);
-  const height = text('height', undefined);
-  const foregroundColor = color('color', undefined);
-  const background = color('background', undefined);
-  const children = text('children', undefined);
+  const target = text('target', null);
+  const width = text('width', null);
+  const height = text('height', null);
+  const foregroundColor = color('color');
+  const background = color('background');
+  const children = text('children', null);
 
   return (
     <SocialShare


### PR DESCRIPTION
Update storybooks for amp-social-share

Updated storybook labels (i.e. amp-social-share-0_1)

1. amp-social-share-0_1 (pre-bento)
  - Add `undefined` type
  - Add `width` and `height` knobs
2. amp-social-share-1_0
  - Add `undefined` type
  - Add `width` and `height` knobs
  - Add `layout` knob, user can input `responsive`, removed `responsive` storybook example
3. SocialShare
  - Add knobs for `foreground` and `background` colors
  - Add knob for `children`