### PR TITLE
🐛 [bento][amp-social-share] Preact component should not throw error

### DIFF
--- a/extensions/amp-social-share/1.0/social-share.js
+++ b/extensions/amp-social-share/1.0/social-share.js
@@ -134,7 +134,7 @@ function processChildren(type, children, color, background, size) {
  * @param {number|string|undefined} width
  * @param {number|string|undefined} height
  * @param {JsonObject|Object|undefined} params
- * @return {null|{
+ * @return {?{
  *   finalEndpoint: string,
  *   checkedWidth: (number|string),
  *   checkedHeight: (number|string),

--- a/extensions/amp-social-share/1.0/social-share.js
+++ b/extensions/amp-social-share/1.0/social-share.js
@@ -54,11 +54,11 @@ export function SocialShare({
     checkedWidth,
     checkedHeight,
     checkedTarget,
-    errorState,
+    renderNull,
   } = checkProps(type, endpoint, target, width, height, params);
 
   // Early exit if checkProps did not pass
-  if (errorState) {
+  if (renderNull) {
     return null;
   }
 
@@ -131,7 +131,7 @@ function processChildren(type, children, color, background, size) {
  *   checkedWidth: (number|string),
  *   checkedHeight: (number|string),
  *   checkedTarget: string,
- *   errorState: boolean,
+ *   renderNull: boolean,
  * }}
  */
 function checkProps(type, endpoint, target, width, height, params) {
@@ -143,7 +143,7 @@ function checkProps(type, endpoint, target, width, height, params) {
       checkedWidth: '',
       checkedHeight: '',
       checkedTarget: '',
-      errorState: true,
+      renderNull: true,
     };
   }
 
@@ -160,7 +160,7 @@ function checkProps(type, endpoint, target, width, height, params) {
       checkedWidth: '',
       checkedHeight: '',
       checkedTarget: '',
-      errorState: true,
+      renderNull: true,
     };
   }
 
@@ -185,7 +185,7 @@ function checkProps(type, endpoint, target, width, height, params) {
     checkedWidth,
     checkedHeight,
     checkedTarget,
-    errorState: false,
+    renderNull: false,
   };
 }
 

--- a/extensions/amp-social-share/1.0/social-share.js
+++ b/extensions/amp-social-share/1.0/social-share.js
@@ -57,31 +57,34 @@ export function SocialShare({
     errorState,
   } = checkProps(type, endpoint, target, width, height, params);
 
+  // Early exit if checkProps did not pass
+  if (errorState) {
+    return null;
+  }
+
   const size = dict({
     'width': checkedWidth,
     'height': checkedHeight,
   });
 
-  if (!errorState) {
-    return (
-      <div
-        {...rest}
-        role="button"
-        tabindex={tabIndex}
-        onKeyDown={(e) => handleKeyPress(e, finalEndpoint, checkedTarget)}
-        onClick={() => handleActivation(finalEndpoint, checkedTarget)}
-        style={{...size, ...style}}
-      >
-        {processChildren(
-          /** @type {string} */ (type),
-          children,
-          color,
-          background,
-          size
-        )}
-      </div>
-    );
-  }
+  return (
+    <div
+      {...rest}
+      role="button"
+      tabindex={tabIndex}
+      onKeyDown={(e) => handleKeyPress(e, finalEndpoint, checkedTarget)}
+      onClick={() => handleActivation(finalEndpoint, checkedTarget)}
+      style={{...size, ...style}}
+    >
+      {processChildren(
+        /** @type {string} */ (type),
+        children,
+        color,
+        background,
+        size
+      )}
+    </div>
+  );
 }
 
 /**
@@ -132,42 +135,32 @@ function processChildren(type, children, color, background, size) {
  * }}
  */
 function checkProps(type, endpoint, target, width, height, params) {
-  // Defaults
-  const checkedWidth = width || DEFAULT_WIDTH;
-  const checkedHeight = height || DEFAULT_HEIGHT;
-  const checkedTarget = target || DEFAULT_TARGET;
-
-  let finalEndpoint = '';
-  let errorState = false;
-
-  // Verify type is provided
+  // Verify type is provided, early exit if not provided
   if (type === undefined) {
     displayWarning(`The type attribute is required. ${NAME}`);
-    errorState = true;
     return {
-      finalEndpoint,
-      checkedWidth,
-      checkedHeight,
-      checkedTarget,
-      errorState,
+      finalEndpoint: '',
+      checkedWidth: '',
+      checkedHeight: '',
+      checkedTarget: '',
+      errorState: true,
     };
   }
 
   // User must provide endpoint if they choose a type that is not
-  // pre-configured
+  // pre-configured, early exit if not provided
   const typeConfig = getSocialConfig(/** @type {string} */ (type)) || {};
   let baseEndpoint = endpoint || typeConfig.shareEndpoint;
   if (baseEndpoint === undefined) {
     displayWarning(
       `An endpoint is required if not using a pre-configured type. ${NAME}`
     );
-    errorState = true;
     return {
-      finalEndpoint,
-      checkedWidth,
-      checkedHeight,
-      checkedTarget,
-      errorState,
+      finalEndpoint: '',
+      checkedWidth: '',
+      checkedHeight: '',
+      checkedTarget: '',
+      errorState: true,
     };
   }
 
@@ -177,17 +170,22 @@ function checkProps(type, endpoint, target, width, height, params) {
   }
 
   // Add params to baseEndpoint
-  finalEndpoint = addParamsToUrl(
+  const finalEndpoint = addParamsToUrl(
     /** @type {string} */ (baseEndpoint),
     /** @type {!JsonObject} */ (params)
   );
+
+  // Defaults
+  const checkedWidth = width || DEFAULT_WIDTH;
+  const checkedHeight = height || DEFAULT_HEIGHT;
+  const checkedTarget = target || DEFAULT_TARGET;
 
   return {
     finalEndpoint,
     checkedWidth,
     checkedHeight,
     checkedTarget,
-    errorState,
+    errorState: false,
   };
 }
 

--- a/extensions/amp-social-share/1.0/social-share.js
+++ b/extensions/amp-social-share/1.0/social-share.js
@@ -49,18 +49,26 @@ export function SocialShare({
   ...rest
 }) {
   useResourcesNotify();
+  const checkPropsReturnValue = checkProps(
+    type,
+    endpoint,
+    target,
+    width,
+    height,
+    params
+  );
+
+  // Early exit if checkProps did not pass
+  if (!checkPropsReturnValue) {
+    return null;
+  }
+
   const {
     finalEndpoint,
     checkedWidth,
     checkedHeight,
     checkedTarget,
-    renderNull,
-  } = checkProps(type, endpoint, target, width, height, params);
-
-  // Early exit if checkProps did not pass
-  if (renderNull) {
-    return null;
-  }
+  } = checkPropsReturnValue;
 
   const size = dict({
     'width': checkedWidth,
@@ -126,27 +134,14 @@ function processChildren(type, children, color, background, size) {
  * @param {number|string|undefined} width
  * @param {number|string|undefined} height
  * @param {JsonObject|Object|undefined} params
- * @return {{
+ * @return {null|{
  *   finalEndpoint: string,
  *   checkedWidth: (number|string),
  *   checkedHeight: (number|string),
  *   checkedTarget: string,
- *   renderNull: boolean,
  * }}
  */
 function checkProps(type, endpoint, target, width, height, params) {
-  // Verify type is provided, early exit if not provided
-  if (type === undefined) {
-    displayWarning(`The type attribute is required. ${NAME}`);
-    return {
-      finalEndpoint: '',
-      checkedWidth: '',
-      checkedHeight: '',
-      checkedTarget: '',
-      renderNull: true,
-    };
-  }
-
   // User must provide endpoint if they choose a type that is not
   // pre-configured, early exit if not provided
   const typeConfig = getSocialConfig(/** @type {string} */ (type)) || {};
@@ -155,13 +150,7 @@ function checkProps(type, endpoint, target, width, height, params) {
     displayWarning(
       `An endpoint is required if not using a pre-configured type. ${NAME}`
     );
-    return {
-      finalEndpoint: '',
-      checkedWidth: '',
-      checkedHeight: '',
-      checkedTarget: '',
-      renderNull: true,
-    };
+    return null;
   }
 
   // Special case when type is 'email'
@@ -185,7 +174,6 @@ function checkProps(type, endpoint, target, width, height, params) {
     checkedWidth,
     checkedHeight,
     checkedTarget,
-    renderNull: false,
   };
 }
 

--- a/extensions/amp-social-share/1.0/social-share.type.js
+++ b/extensions/amp-social-share/1.0/social-share.type.js
@@ -18,7 +18,7 @@
 
 /**
  * @typedef {{
- *   type: (!string),
+ *   type: (string),
  *   endpoint: (string|undefined),
  *   params: (JsonObject|Object|undefined),
  *   target: (string|undefined),

--- a/extensions/amp-social-share/1.0/social-share.type.js
+++ b/extensions/amp-social-share/1.0/social-share.type.js
@@ -18,7 +18,7 @@
 
 /**
  * @typedef {{
- *   type: (string|undefined),
+ *   type: (string),
  *   endpoint: (string|undefined),
  *   params: (JsonObject|Object|undefined),
  *   target: (string|undefined),

--- a/extensions/amp-social-share/1.0/social-share.type.js
+++ b/extensions/amp-social-share/1.0/social-share.type.js
@@ -18,7 +18,7 @@
 
 /**
  * @typedef {{
- *   type: (string),
+ *   type: (!string),
  *   endpoint: (string|undefined),
  *   params: (JsonObject|Object|undefined),
  *   target: (string|undefined),

--- a/extensions/amp-social-share/1.0/test/test-social-share.js
+++ b/extensions/amp-social-share/1.0/test/test-social-share.js
@@ -30,8 +30,9 @@ describes.sandboxed('SocialShare 1.0 preact component', {}, () => {
     console.warn = mockedWarn;
 
     const jsx = <SocialShare />;
-    mount(jsx);
+    const wrapper = mount(jsx);
 
+    expect(wrapper.exists('div')).to.equal(false);
     expect(consoleOutput.length).to.equal(1);
     expect(consoleOutput[0]).to.equal(
       'The type attribute is required. SocialShare'
@@ -47,8 +48,9 @@ describes.sandboxed('SocialShare 1.0 preact component', {}, () => {
       console.warn = mockedWarn;
 
       const jsx = <SocialShare {...dict({'type': 'not-configured-type'})} />;
-      mount(jsx);
+      const wrapper = mount(jsx);
 
+      expect(wrapper.exists('div')).to.equal(false);
       expect(consoleOutput.length).to.equal(1);
       expect(consoleOutput[0]).to.equal(
         'An endpoint is required if not using a pre-configured type. SocialShare'

--- a/extensions/amp-social-share/1.0/test/test-social-share.js
+++ b/extensions/amp-social-share/1.0/test/test-social-share.js
@@ -24,21 +24,6 @@ describes.sandboxed('SocialShare 1.0 preact component', {}, () => {
 
   afterEach(() => (console.warn = originalWarn));
 
-  it('warns when the required "type" attribute is not provided', () => {
-    const consoleOutput = [];
-    const mockedWarn = (output) => consoleOutput.push(output);
-    console.warn = mockedWarn;
-
-    const jsx = <SocialShare />;
-    const wrapper = mount(jsx);
-
-    expect(wrapper.exists('div')).to.equal(false);
-    expect(consoleOutput.length).to.equal(1);
-    expect(consoleOutput[0]).to.equal(
-      'The type attribute is required. SocialShare'
-    );
-  });
-
   it(
     'warns when the required endpoint is not provided when not using' +
       ' a pre-configured type',

--- a/extensions/amp-social-share/1.0/test/test-social-share.js
+++ b/extensions/amp-social-share/1.0/test/test-social-share.js
@@ -20,27 +20,38 @@ import {dict} from '../../../../src/utils/object';
 import {mount} from 'enzyme';
 
 describes.sandboxed('SocialShare 1.0 preact component', {}, () => {
-  // TODO(#30043): unskip once #30043 is merged (Preact bug fix).
-  it.skip('errors when the required "type" attribute is not provided', () => {
-    const jsx = <SocialShare />;
+  const originalWarn = console.warn;
 
-    expect(() => {
-      mount(jsx);
-    }).to.throw('The type attribute is required.');
+  afterEach(() => (console.warn = originalWarn));
+
+  it('warns when the required "type" attribute is not provided', () => {
+    const consoleOutput = [];
+    const mockedWarn = (output) => consoleOutput.push(output);
+    console.warn = mockedWarn;
+
+    const jsx = <SocialShare />;
+    mount(jsx);
+
+    expect(consoleOutput.length).to.equal(1);
+    expect(consoleOutput[0]).to.equal(
+      'The type attribute is required. SocialShare'
+    );
   });
 
-  // TODO(#30043): unskip once #30043 is merged (Preact bug fix).
-  it.skip(
-    'errors when the required endpoint is not provided when not using' +
+  it(
+    'warns when the required endpoint is not provided when not using' +
       ' a pre-configured type',
     () => {
-      const props = dict({'type': 'not-configured-type'});
-      const jsx = <SocialShare {...props} />;
+      const consoleOutput = [];
+      const mockedWarn = (output) => consoleOutput.push(output);
+      console.warn = mockedWarn;
 
-      expect(() => {
-        mount(jsx);
-      }).to.throw(
-        'An endpoint is required if not using a pre-configured type.'
+      const jsx = <SocialShare {...dict({'type': 'not-configured-type'})} />;
+      mount(jsx);
+
+      expect(consoleOutput.length).to.equal(1);
+      expect(consoleOutput[0]).to.equal(
+        'An endpoint is required if not using a pre-configured type. SocialShare'
       );
     }
   );


### PR DESCRIPTION
Tracking Issue: https://github.com/ampproject/amphtml/issues/28283

Updated Preact component and automated tests for Social Share.

Preact component should not throw an error.