### PR TITLE
jss transform: transform via postcss

### DIFF
--- a/build-system/babel-plugins/babel-plugin-transform-jss/index.js
+++ b/build-system/babel-plugins/babel-plugin-transform-jss/index.js
@@ -40,6 +40,7 @@ const hash = require('./create-hash');
 const {create} = require('jss');
 const {default: preset} = require('jss-preset-default');
 const {relative, join} = require('path');
+const {spawnSync} = require('child_process');
 
 module.exports = function ({types: t, template}) {
   function isJssFile(filename) {
@@ -104,7 +105,7 @@ module.exports = function ({types: t, template}) {
           init: template.expression.ast`JSON.parse(${t.stringLiteral(
             JSON.stringify({
               ...sheet.classes,
-              'CSS': sheet.toString(),
+              'CSS': transformCssSync(sheet.toString()),
             })
           )})`,
         });
@@ -126,3 +127,18 @@ module.exports = function ({types: t, template}) {
     },
   };
 };
+
+// Abuses spawnSync to let us run an async function sync.
+function transformCssSync(cssText) {
+  const programText = `
+  const {transformCss} = require('../../../build-system/tasks/jsify-css');
+  transformCss(\`${cssText}\`).then((css) => console.log(css.toString()));
+  `;
+  const spawnedProcess = spawnSync(`node`, [`-e`, programText], {
+    cwd: __dirname,
+    env: process.env,
+    encoding: 'utf-8',
+    stdio: 'pipe',
+  });
+  return spawnedProcess.stdout;
+}

--- a/build-system/babel-plugins/babel-plugin-transform-jss/index.js
+++ b/build-system/babel-plugins/babel-plugin-transform-jss/index.js
@@ -143,5 +143,10 @@ function transformCssSync(cssText) {
     encoding: 'utf-8',
     stdio: 'pipe',
   });
+  if (spawnedProcess.status !== 0) {
+    throw new Error(
+      `Transforming CSS returned status code: ${spawnedProcess.status}. stderr: "${spawnedProcess.stderr}".`
+    );
+  }
   return spawnedProcess.stdout;
 }

--- a/build-system/babel-plugins/babel-plugin-transform-jss/index.js
+++ b/build-system/babel-plugins/babel-plugin-transform-jss/index.js
@@ -137,7 +137,7 @@ function transformCssSync(cssText) {
 
   // TODO: migrate to the helpers in build-system exec.js
   // after adding args support.
-  const spawnedProcess = spawnSync(`node`, [`-e`, programText], {
+  const spawnedProcess = spawnSync('node', ['-e', programText], {
     cwd: __dirname,
     env: process.env,
     encoding: 'utf-8',

--- a/build-system/babel-plugins/babel-plugin-transform-jss/index.js
+++ b/build-system/babel-plugins/babel-plugin-transform-jss/index.js
@@ -131,9 +131,12 @@ module.exports = function ({types: t, template}) {
 // Abuses spawnSync to let us run an async function sync.
 function transformCssSync(cssText) {
   const programText = `
-  const {transformCss} = require('../../../build-system/tasks/jsify-css');
-  transformCss(\`${cssText}\`).then((css) => console.log(css.toString()));
+    const {transformCss} = require('../../../build-system/tasks/jsify-css');
+    transformCss(\`${cssText}\`).then((css) => console.log(css.toString()));
   `;
+
+  // TODO: migrate to the helpers in build-system exec.js
+  // after adding args support.
   const spawnedProcess = spawnSync(`node`, [`-e`, programText], {
     cwd: __dirname,
     env: process.env,

--- a/build-system/babel-plugins/babel-plugin-transform-jss/index.js
+++ b/build-system/babel-plugins/babel-plugin-transform-jss/index.js
@@ -132,7 +132,7 @@ module.exports = function ({types: t, template}) {
 function transformCssSync(cssText) {
   const programText = `
     const {transformCss} = require('../../../build-system/tasks/jsify-css');
-    transformCss(\`${cssText}\`).then((css) => console.log(css.toString()));
+    transformCss(\`${cssText}\`).then((css) => console./* OK */log(css.toString()));
   `;
 
   // TODO: migrate to the helpers in build-system exec.js

--- a/build-system/babel-plugins/babel-plugin-transform-jss/test/fixtures/transform-assertions/should-transform-jss-var/output.mjs
+++ b/build-system/babel-plugins/babel-plugin-transform-jss/test/fixtures/transform-assertions/should-transform-jss-var/output.mjs
@@ -1,4 +1,4 @@
-var _classes = JSON.parse("{\"button\":\"button-21aa4a8\",\"CSS\":\".button-21aa4a8 {\\n  font-size: 12px;\\n}\"}");
+var _classes = JSON.parse("{\"button\":\"button-21aa4a8\",\"CSS\":\".button-21aa4a8{font-size:12px}\\n\"}");
 
 /**
  * Copyright 2020 The AMP HTML Authors. All Rights Reserved.

--- a/build-system/babel-plugins/babel-plugin-transform-jss/test/fixtures/transform-assertions/should-transform-literal/input.js
+++ b/build-system/babel-plugins/babel-plugin-transform-jss/test/fixtures/transform-assertions/should-transform-literal/input.js
@@ -16,4 +16,6 @@
 
 import {createUseStyles} from 'react-jss';
 
-export const useStyles = createUseStyles({floatLeft: {float: 'left'}});
+export const useStyles = createUseStyles({
+  floatLeft: {float: 'left', border: 'black solid 1px'},
+});

--- a/build-system/babel-plugins/babel-plugin-transform-jss/test/fixtures/transform-assertions/should-transform-literal/input.js
+++ b/build-system/babel-plugins/babel-plugin-transform-jss/test/fixtures/transform-assertions/should-transform-literal/input.js
@@ -18,4 +18,9 @@ import {createUseStyles} from 'react-jss';
 
 export const useStyles = createUseStyles({
   floatLeft: {float: 'left', border: 'black solid 1px'},
+  fill: {
+    display: 'block',
+    position: 'relative',
+    flex: '1 1 auto',
+  },
 });

--- a/build-system/babel-plugins/babel-plugin-transform-jss/test/fixtures/transform-assertions/should-transform-literal/output.mjs
+++ b/build-system/babel-plugins/babel-plugin-transform-jss/test/fixtures/transform-assertions/should-transform-literal/output.mjs
@@ -1,4 +1,4 @@
-var _classes = JSON.parse("{\"floatLeft\":\"float-left-a6c6677\",\"CSS\":\".float-left-a6c6677{float:left;border:1px solid #000}\\n\"}");
+var _classes = JSON.parse("{\"floatLeft\":\"float-left-a6c6677\",\"fill\":\"fill-a6c6677\",\"CSS\":\".float-left-a6c6677{float:left;border:1px solid #000}.fill-a6c6677{-ms-flex:1 1 auto;flex:1 1 auto;display:block;position:relative}\\n\"}");
 
 /**
  * Copyright 2020 The AMP HTML Authors. All Rights Reserved.

--- a/build-system/babel-plugins/babel-plugin-transform-jss/test/fixtures/transform-assertions/should-transform-literal/output.mjs
+++ b/build-system/babel-plugins/babel-plugin-transform-jss/test/fixtures/transform-assertions/should-transform-literal/output.mjs
@@ -1,4 +1,4 @@
-var _classes = JSON.parse("{\"floatLeft\":\"float-left-a6c6677\",\"CSS\":\".float-left-a6c6677 {\\n  float: left;\\n}\"}");
+var _classes = JSON.parse("{\"floatLeft\":\"float-left-a6c6677\",\"CSS\":\".float-left-a6c6677{float:left;border:1px solid #000}\\n\"}");
 
 /**
  * Copyright 2020 The AMP HTML Authors. All Rights Reserved.

--- a/build-system/tasks/create-golden-css/index.js
+++ b/build-system/tasks/create-golden-css/index.js
@@ -15,10 +15,10 @@
  */
 'use strict';
 const fs = require('fs-extra');
-const {transformCss} = require('../jsify-css');
+const {transformCssFile} = require('../jsify-css');
 
 async function createGoldenCss() {
-  const result = await transformCss(
+  const result = await transformCssFile(
     './build-system/tasks/create-golden-css/css/main.css',
     {
       normalizeWhitespace: false,

--- a/build-system/tasks/jsify-css.js
+++ b/build-system/tasks/jsify-css.js
@@ -72,14 +72,9 @@ function transformCss(cssStr, opt_cssnano, opt_filename) {
   );
   const cssnanoTransformer = cssnano({preset: ['default', cssnanoOptions]});
   const transformers = [postcssImport, cssprefixer, cssnanoTransformer];
-  return postcss(transformers).process(
-    cssStr,
-    opt_filename
-      ? {
-          'from': opt_filename,
-        }
-      : undefined
-  );
+  return postcss(transformers).process(cssStr, {
+    'from': opt_filename,
+  });
 }
 
 /**
@@ -108,7 +103,7 @@ function transformCssFile(filename, opt_cssnano) {
  *    processing
  */
 function jsifyCssAsync(filename) {
-  return transformCss(filename).then(function (result) {
+  return transformCssFile(filename).then(function (result) {
     result.warnings().forEach(function (warn) {
       log(colors.red(warn.toString()));
     });


### PR DESCRIPTION
**summary**
Transform the extracted css via our custom `postcss` function.

This is pretty gnarly. `postcss` runs async but babel can only run sync. I get around this by using `spawnSync`, but it is needlessly expensive.  When we start transforming more files it may pay to invest in starting up an external server and communicate over ports to amortize the cost as they do in [babel-plugin-transform-css](https://github.com/wbyoung/babel-plugin-transform-postcss).

The more obvious and better solution is to use jss plugins. this seems harebrained