### PR TITLE
Temporarily remove no-signing from exp a

### DIFF
--- a/build-system/global-configs/experiments-config.json
+++ b/build-system/global-configs/experiments-config.json
@@ -1,5 +1,11 @@
 {
-  "experimentA": {},
+  "experimentA": {
+    "name": "A4A No Signing RTV Experiment",
+    "environment": "AMP",
+    "issue": "https://github.com/ampproject/amphtml/issues/27189",
+    "expiration_date_utc": "2020-12-30",
+    "define_experiment_constant": "NO_SIGNING_RTV"
+  },
   "experimentB": {},
   "experimentC": {}
 }

--- a/build-system/global-configs/experiments-config.json
+++ b/build-system/global-configs/experiments-config.json
@@ -1,11 +1,5 @@
 {
-  "experimentA": {
-    "name": "A4A No Signing RTV Experiment",
-    "environment": "AMP",
-    "issue": "https://github.com/ampproject/amphtml/issues/27189",
-    "expiration_date_utc": "2020-12-30",
-    "define_experiment_constant": "NO_SIGNING_RTV"
-  },
+  "experimentA": {},
   "experimentB": {},
   "experimentC": {}
 }

--- a/build-system/global-configs/experiments-const.json
+++ b/build-system/global-configs/experiments-const.json
@@ -1,1 +1,3 @@
-{}
+{
+  "NO_SIGNING_RTV": false
+}


### PR DESCRIPTION
To unblock master while investigating test failures. Test failures are hopefully a clue to impression loss.
