### PR TITLE
--files flag windows support

### DIFF
--- a/build-system/common/utils.js
+++ b/build-system/common/utils.js
@@ -92,7 +92,8 @@ function logFiles(files) {
  * @return {Array<string>}
  */
 function getFilesFromArgv() {
-  // globby does not support Windows paths.
+  // TODO: https://github.com/ampproject/amphtml/issues/30223
+  // Switch from globby to a lib that supports Windows.
   const toPosix = str => str.replace(/\\\\?/g, '/');
   return argv.files
     ? globby.sync(argv.files.split(',').map((s) => s.trim()).map(toPosix))

--- a/build-system/common/utils.js
+++ b/build-system/common/utils.js
@@ -92,8 +92,10 @@ function logFiles(files) {
  * @return {Array<string>}
  */
 function getFilesFromArgv() {
+  // globby does not support Windows paths.
+  const toPosix = str => str.replace(/\\\\?/g, '/');
   return argv.files
-    ? globby.sync(argv.files.split(',').map((s) => s.trim()))
+    ? globby.sync(argv.files.split(',').map((s) => s.trim()).map(toPosix))
     : [];
 }
 

--- a/build-system/common/utils.js
+++ b/build-system/common/utils.js
@@ -94,9 +94,14 @@ function logFiles(files) {
 function getFilesFromArgv() {
   // TODO: https://github.com/ampproject/amphtml/issues/30223
   // Switch from globby to a lib that supports Windows.
-  const toPosix = str => str.replace(/\\\\?/g, '/');
+  const toPosix = (str) => str.replace(/\\\\?/g, '/');
   return argv.files
-    ? globby.sync(argv.files.split(',').map((s) => s.trim()).map(toPosix))
+    ? globby.sync(
+        argv.files
+          .split(',')
+          .map((s) => s.trim())
+          .map(toPosix)
+      )
     : [];
 }
 


### PR DESCRIPTION
**summary**
Globby does not [support windows paths](https://github.com/sindresorhus/globby/issues/127).
This fix worked for `--flags`, but we may want to look into switching to a lib that explicitly cares about Windows support.