### PR TITLE
🐛 Fix story ads in no signing exp

### DIFF
--- a/extensions/amp-story-auto-ads/0.1/story-ad-page.js
+++ b/extensions/amp-story-auto-ads/0.1/story-ad-page.js
@@ -39,10 +39,11 @@ import {
 import {createShadowRootWithStyle} from '../../amp-story/1.0/utils';
 import {dev, user, userAssert} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
-import {getA4AVarsMetaTags, getAmpCtaMetaTags, getFrameDoc} from './utils';
+import {getFrameDoc, getStoryAdMetaTags} from './utils';
 import {getServicePromiseForDoc} from '../../../src/service';
 import {parseJson} from '../../../src/json';
 import {setStyle} from '../../../src/style';
+import {startsWith} from '../../../src/string';
 
 /** @const {string} */
 const TAG = 'amp-story-auto-ads:page';
@@ -55,6 +56,12 @@ const GLASS_PANE_CLASS = 'i-amphtml-glass-pane';
 
 /** @const {string} */
 const DESKTOP_FULLBLEED_CLASS = 'i-amphtml-story-ad-fullbleed';
+
+/** @const {string} */
+const CTA_META_PREFIX = 'amp-cta-';
+
+/** @const {string} */
+const A4A_VARS_META_PREFIX = 'amp4ads-vars-';
 
 /** @enum {string} */
 const PageAttributes = {
@@ -424,17 +431,16 @@ export class StoryAdPage {
    * @private
    */
   extractA4AVars_() {
-    const a4aVarsTags = getA4AVarsMetaTags(this.adDoc_);
+    const a4aVarsTags = getStoryAdMetaTags(this.adDoc_);
     iterateCursor(a4aVarsTags, (tag) => {
-      const name = tag.name.split('amp4ads-vars-')[1];
-      const {content} = tag;
-      this.a4aVars_[name] = content;
-    });
-    const ampCtaTags = getAmpCtaMetaTags(this.adDoc_);
-    iterateCursor(ampCtaTags, (tag) => {
-      const name = tag.name.split('amp-')[1];
-      const {content} = tag;
-      this.a4aVars_[name] = content;
+      const {name, content} = tag;
+      if (startsWith(name, CTA_META_PREFIX)) {
+        const key = name.split('amp-')[1];
+        this.a4aVars_[key] = content;
+      } else if (startsWith(name, A4A_VARS_META_PREFIX)) {
+        const key = name.split(A4A_VARS_META_PREFIX)[1];
+        this.a4aVars_[key] = content;
+      }
     });
   }
 

--- a/extensions/amp-story-auto-ads/0.1/story-ad-page.js
+++ b/extensions/amp-story-auto-ads/0.1/story-ad-page.js
@@ -39,7 +39,7 @@ import {
 import {createShadowRootWithStyle} from '../../amp-story/1.0/utils';
 import {dev, user, userAssert} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
-import {getA4AMetaTags, getFrameDoc} from './utils';
+import {getA4AVarsMetaTags, getAmpCtaMetaTags, getFrameDoc} from './utils';
 import {getServicePromiseForDoc} from '../../../src/service';
 import {parseJson} from '../../../src/json';
 import {setStyle} from '../../../src/style';
@@ -419,13 +419,20 @@ export class StoryAdPage {
   }
 
   /**
-   * Find all `amp4ads-vars-` prefixed meta tags and store them in single obj.
+   * Find all `amp4ads-vars-` & `amp-cta-` prefixed meta tags and store them
+   * in single obj.
    * @private
    */
   extractA4AVars_() {
-    const tags = getA4AMetaTags(this.adDoc_);
-    iterateCursor(tags, (tag) => {
+    const a4aVarsTags = getA4AVarsMetaTags(this.adDoc_);
+    iterateCursor(a4aVarsTags, (tag) => {
       const name = tag.name.split('amp4ads-vars-')[1];
+      const {content} = tag;
+      this.a4aVars_[name] = content;
+    });
+    const ampCtaTags = getAmpCtaMetaTags(this.adDoc_);
+    iterateCursor(ampCtaTags, (tag) => {
+      const name = tag.name.split('amp-')[1];
       const {content} = tag;
       this.a4aVars_[name] = content;
     });

--- a/extensions/amp-story-auto-ads/0.1/story-ad-page.js
+++ b/extensions/amp-story-auto-ads/0.1/story-ad-page.js
@@ -431,8 +431,8 @@ export class StoryAdPage {
    * @private
    */
   extractA4AVars_() {
-    const a4aVarsTags = getStoryAdMetaTags(this.adDoc_);
-    iterateCursor(a4aVarsTags, (tag) => {
+    const storyMetaTags = getStoryAdMetaTags(this.adDoc_);
+    iterateCursor(storyMetaTags, (tag) => {
       const {name, content} = tag;
       if (startsWith(name, CTA_META_PREFIX)) {
         const key = name.split('amp-')[1];

--- a/extensions/amp-story-auto-ads/0.1/utils.js
+++ b/extensions/amp-story-auto-ads/0.1/utils.js
@@ -42,12 +42,12 @@ export function getUniqueId(win) {
 }
 
 /**
- * Finds all meta tags starting with `amp4ads-vars-`.
+ * Finds all meta tags starting with `amp4ads-vars-` or `amp-cta`.
  * @param {Document} doc
  * @return {!IArrayLike}
  */
-export function getA4AVarsMetaTags(doc) {
-  const selector = 'meta[name^=amp4ads-vars-]';
+export function getStoryAdMetaTags(doc) {
+  const selector = 'meta[name^=amp4ads-vars-],meta[name^=amp-cta-]';
   return doc.querySelectorAll(selector);
 }
 

--- a/extensions/amp-story-auto-ads/0.1/utils.js
+++ b/extensions/amp-story-auto-ads/0.1/utils.js
@@ -52,15 +52,6 @@ export function getStoryAdMetaTags(doc) {
 }
 
 /**
- * Finds all story ad meta tags starting with `amp-cta-`.
- * @param {Document} doc
- * @return {!IArrayLike}
- */
-export function getAmpCtaMetaTags(doc) {
-  return doc.querySelectorAll('meta[name^=amp-cta-]');
-}
-
-/**
  * Returns document from given iframe, or null if non FIE.
  * @param {HTMLIFrameElement} iframe
  * @return {!Document}

--- a/extensions/amp-story-auto-ads/0.1/utils.js
+++ b/extensions/amp-story-auto-ads/0.1/utils.js
@@ -46,9 +46,18 @@ export function getUniqueId(win) {
  * @param {Document} doc
  * @return {!IArrayLike}
  */
-export function getA4AMetaTags(doc) {
+export function getA4AVarsMetaTags(doc) {
   const selector = 'meta[name^=amp4ads-vars-]';
   return doc.querySelectorAll(selector);
+}
+
+/**
+ * Finds all story ad meta tags starting with `amp-cta-`.
+ * @param {Document} doc
+ * @return {!IArrayLike}
+ */
+export function getAmpCtaMetaTags(doc) {
+  return doc.querySelectorAll('meta[name^=amp-cta-]');
 }
 
 /**


### PR DESCRIPTION
In the normal case the cta url & cta type are extracted from the metadata obj and added as data-var attrs to the <amp-ad> element. In the no-signing case the metadata obj does not exist. This PR extends what we query for in the ad doc to find the `<meta name=amp-cta-*>` elements.

Should fix broken experimentA on master builds.