### PR TITLE
Multi-attribute prop bindings for date components

### DIFF
--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -1107,6 +1107,7 @@ const forbiddenTermsSrcInclusive = {
     allowlist: [
       'extensions/amp-timeago/0.1/amp-timeago.js',
       'extensions/amp-timeago/1.0/timeago.js',
+      'src/utils/date.js',
     ],
   },
   '\\.expandStringSync\\(': {

--- a/extensions/amp-date-display/1.0/amp-date-display.js
+++ b/extensions/amp-date-display/1.0/amp-date-display.js
@@ -101,17 +101,34 @@ AmpDateDisplay['props'] = {
  * @visibleForTesting
  */
 export function parseDateAttrs(element) {
-  const datetimeStr = element.getAttribute('datetime');
-  const datetime = parseDate(datetimeStr);
-  const timestampMs = Number(element.getAttribute('timestamp-ms'));
-  const timestampSeconds =
-    Number(element.getAttribute('timestamp-seconds')) * 1000;
-  const offsetSeconds = Number(element.getAttribute('offset-seconds')) * 1000;
+  const epoch = userAssert(
+    parseEpoch(element),
+    'One of datetime, timestamp-ms, or timestamp-seconds is required'
+  );
 
-  const epoch = datetime || timestampMs || timestampSeconds;
-  userAssert(epoch, 'Invalid date: %s', datetimeStr);
-
+  const offsetSeconds =
+    (Number(element.getAttribute('offset-seconds')) || 0) * 1000;
   return epoch + offsetSeconds;
+}
+
+/**
+ * @param {!Element} element
+ * @return {?number}
+ */
+function parseEpoch(element) {
+  const datetime = element.getAttribute('datetime');
+  if (datetime) {
+    return userAssert(parseDate(datetime), 'Invalid date: %s', datetime);
+  }
+  const timestampMs = element.getAttribute('timestamp-ms');
+  if (timestampMs) {
+    return Number(timestampMs);
+  }
+  const timestampSeconds = element.getAttribute('timestamp-seconds');
+  if (timestampSeconds) {
+    return Number(timestampSeconds) * 1000;
+  }
+  return null;
 }
 
 AMP.extension(TAG, '1.0', (AMP) => {

--- a/extensions/amp-date-display/1.0/amp-date-display.js
+++ b/extensions/amp-date-display/1.0/amp-date-display.js
@@ -23,6 +23,7 @@ import {Services} from '../../../src/services';
 import {dict} from '../../../src/utils/object';
 import {isExperimentOn} from '../../../src/experiments';
 import {isLayoutSizeDefined} from '../../../src/layout';
+import {parseDate} from '../../../src/utils/date';
 import {userAssert} from '../../../src/log';
 
 /** @const {string} */
@@ -86,13 +87,32 @@ AmpDateDisplay['passthrough'] = true;
 
 /** @override */
 AmpDateDisplay['props'] = {
+  'datetime': {
+    attrs: ['datetime', 'timestamp-ms', 'timestamp-seconds', 'offset-seconds'],
+    parseAttrs: parseDateAttrs,
+  },
   'displayIn': {attr: 'display-in'},
-  'offsetSeconds': {attr: 'offset-seconds', type: 'number'},
   'locale': {attr: 'locale'},
-  'datetime': {attr: 'datetime'},
-  'timestampMs': {attr: 'timestamp-ms', type: 'number'},
-  'timestampSeconds': {attr: 'timestamp-seconds', type: 'number'},
 };
+
+/**
+ * @param {!Element} element
+ * @return {?number}
+ * @visibleForTesting
+ */
+export function parseDateAttrs(element) {
+  const datetimeStr = element.getAttribute('datetime');
+  const datetime = parseDate(datetimeStr);
+  const timestampMs = Number(element.getAttribute('timestamp-ms'));
+  const timestampSeconds =
+    Number(element.getAttribute('timestamp-seconds')) * 1000;
+  const offsetSeconds = Number(element.getAttribute('offset-seconds')) * 1000;
+
+  const epoch = datetime || timestampMs || timestampSeconds;
+  userAssert(epoch, 'Invalid date: %s', datetimeStr);
+
+  return epoch + offsetSeconds;
+}
 
 AMP.extension(TAG, '1.0', (AMP) => {
   AMP.registerElement(TAG, AmpDateDisplay);

--- a/extensions/amp-date-display/1.0/date-display.js
+++ b/extensions/amp-date-display/1.0/date-display.js
@@ -65,7 +65,7 @@ let EnhancedVariablesV2Def;
  */
 export function DateDisplay(props) {
   const {datetime, render, children} = props;
-  const date = getDate(datetime);
+  const date = new Date(getDate(datetime));
   const data = /** @type {!JsonObject} */ (getDataForTemplate(date, props));
   useResourcesNotify();
 
@@ -73,15 +73,11 @@ export function DateDisplay(props) {
 }
 
 /**
- * @param {?Date} date
+ * @param {!Date} date
  * @param {!DateDisplayDef.Props} props
  * @return {?EnhancedVariablesV2Def}
  */
 function getDataForTemplate(date, props) {
-  if (!date) {
-    return null;
-  }
-
   const {displayIn = '', locale = DEFAULT_LOCALE} = props;
 
   const basicData =

--- a/extensions/amp-date-display/1.0/date-display.js
+++ b/extensions/amp-date-display/1.0/date-display.js
@@ -69,7 +69,7 @@ export function DateDisplay(props) {
   const data = /** @type {!JsonObject} */ (getDataForTemplate(date, props));
   useResourcesNotify();
 
-  return data ? render(data, children) : null;
+  return render(data, children);
 }
 
 /**

--- a/extensions/amp-date-display/1.0/date-display.type.js
+++ b/extensions/amp-date-display/1.0/date-display.type.js
@@ -21,11 +21,11 @@ var DateDisplayDef = {};
 
 /**
  * @typedef {{
- *   children: (?PreactDef.Renderable|undefined),
- *   datetime: (?Date|number|undefined),
+ *   datetime: (!Date|number|string),
  *   displayIn: (string|undefined),
  *   locale: (string|undefined),
  *   render: (function(!JsonObject, (?PreactDef.Renderable|undefined)):PreactDef.Renderable),
+ *   children: (?PreactDef.Renderable|undefined),
  * }}
  */
 DateDisplayDef.Props;

--- a/extensions/amp-date-display/1.0/date-display.type.js
+++ b/extensions/amp-date-display/1.0/date-display.type.js
@@ -22,13 +22,10 @@ var DateDisplayDef = {};
 /**
  * @typedef {{
  *   children: (?PreactDef.Renderable|undefined),
- *   datetime: (string|undefined),
+ *   datetime: (?Date|number|undefined),
  *   displayIn: (string|undefined),
  *   locale: (string|undefined),
  *   render: (function(!JsonObject, (?PreactDef.Renderable|undefined)):PreactDef.Renderable),
- *   offsetSeconds: (number|undefined),
- *   timestampMs: (number|undefined),
- *   timestampSeconds: (number|undefined),
  * }}
  */
 DateDisplayDef.Props;

--- a/extensions/amp-date-display/1.0/storybook/Basic.js
+++ b/extensions/amp-date-display/1.0/storybook/Basic.js
@@ -29,7 +29,7 @@ export const _default = () => {
   const dateTime = date('Date/time', new Date());
   return (
     <DateDisplay
-      timestampMs={dateTime}
+      datetime={dateTime}
       render={(date) => <span>{`The ISO date is ${date.iso}`}</span>}
     />
   );

--- a/extensions/amp-date-display/1.0/test/test-amp-date-display.js
+++ b/extensions/amp-date-display/1.0/test/test-amp-date-display.js
@@ -164,7 +164,7 @@ describes.realWin(
   }
 );
 
-describe('amp-date-display 1.0: parseDateAttrs', () => {
+describes.sandboxed('amp-date-display 1.0: parseDateAttrs', {}, () => {
   const DATE = new Date(1514793600000);
   const DATE_STRING = DATE.toISOString();
 

--- a/extensions/amp-date-display/1.0/test/test-amp-date-display.js
+++ b/extensions/amp-date-display/1.0/test/test-amp-date-display.js
@@ -15,8 +15,8 @@
  */
 
 import '../../../amp-mustache/0.2/amp-mustache';
-import '../amp-date-display';
 import * as lolex from 'lolex';
+import {parseDateAttrs} from '../amp-date-display';
 import {
   waitForChildPromise,
   whenUpgradedToCustomElement,
@@ -115,6 +115,37 @@ describes.realWin(
       expect(data.dayPeriod).to.equal('am');
     });
 
+    it('renders mustache template with "timestamp-ms"', async () => {
+      element.setAttribute(
+        'timestamp-ms',
+        Date.parse('2001-02-03T04:05:06.007Z')
+      );
+      element.setAttribute('display-in', 'UTC');
+      win.document.body.appendChild(element);
+
+      const data = await getRenderedData();
+
+      expect(data.year).to.equal('2001');
+      expect(data.yearTwoDigit).to.equal('01');
+      expect(data.month).to.equal('2');
+      expect(data.monthTwoDigit).to.equal('02');
+      expect(data.monthName).to.equal('February');
+      expect(data.monthNameShort).to.equal('Feb');
+      expect(data.day).to.equal('3');
+      expect(data.dayTwoDigit).to.equal('03');
+      expect(data.dayName).to.equal('Saturday');
+      expect(data.dayNameShort).to.equal('Sat');
+      expect(data.hour).to.equal('4');
+      expect(data.hourTwoDigit).to.equal('04');
+      expect(data.hour12).to.equal('4');
+      expect(data.hour12TwoDigit).to.equal('04');
+      expect(data.minute).to.equal('5');
+      expect(data.minuteTwoDigit).to.equal('05');
+      expect(data.second).to.equal('6');
+      expect(data.secondTwoDigit).to.equal('06');
+      expect(data.dayPeriod).to.equal('am');
+    });
+
     it('does not rerender', async () => {
       element.setAttribute('datetime', '2001-02-03T04:05:06.007Z');
       win.document.body.appendChild(element);
@@ -132,3 +163,50 @@ describes.realWin(
     });
   }
 );
+
+describe('amp-date-display 1.0: parseDateAttrs', () => {
+  const DATE = new Date(1514793600000);
+  const DATE_STRING = DATE.toISOString();
+
+  let element;
+
+  beforeEach(() => {
+    element = document.createElement('amp-date-display');
+  });
+
+  it('should throw when no date is specified', () => {
+    expect(() => parseDateAttrs(element)).to.throw(/Invalid date/);
+  });
+
+  it('should throw when invalid date is specified', () => {
+    element.setAttribute('datetime', 'invalid');
+    expect(() => parseDateAttrs(element)).to.throw(/Invalid date/);
+  });
+
+  it('should parse the "datetime" attribute', () => {
+    element.setAttribute('datetime', DATE_STRING);
+    expect(parseDateAttrs(element)).to.equal(DATE.getTime());
+
+    // With offset.
+    element.setAttribute('offset-seconds', '1');
+    expect(parseDateAttrs(element)).to.equal(DATE.getTime() + 1000);
+  });
+
+  it('should parse the "timestamp-ms" attribute', () => {
+    element.setAttribute('timestamp-ms', DATE.getTime());
+    expect(parseDateAttrs(element)).to.equal(DATE.getTime());
+
+    // With offset.
+    element.setAttribute('offset-seconds', '1');
+    expect(parseDateAttrs(element)).to.equal(DATE.getTime() + 1000);
+  });
+
+  it('should parse the "timestamp-seconds" attribute', () => {
+    element.setAttribute('timestamp-seconds', DATE.getTime() / 1000);
+    expect(parseDateAttrs(element)).to.equal(DATE.getTime());
+
+    // With offset.
+    element.setAttribute('offset-seconds', '1');
+    expect(parseDateAttrs(element)).to.equal(DATE.getTime() + 1000);
+  });
+});

--- a/extensions/amp-date-display/1.0/test/test-amp-date-display.js
+++ b/extensions/amp-date-display/1.0/test/test-amp-date-display.js
@@ -164,7 +164,7 @@ describes.realWin(
   }
 );
 
-describes.sandboxed('amp-date-display 1.0: parseDateAttrs', {}, () => {
+describes.sandboxed('amp-date-display 1.0: parseDateAttrs', {}, (env) => {
   const DATE = new Date(1514793600000);
   const DATE_STRING = DATE.toISOString();
 
@@ -175,7 +175,7 @@ describes.sandboxed('amp-date-display 1.0: parseDateAttrs', {}, () => {
   });
 
   it('should throw when no date is specified', () => {
-    expect(() => parseDateAttrs(element)).to.throw(/Invalid date/);
+    expect(() => parseDateAttrs(element)).to.throw(/required/);
   });
 
   it('should throw when invalid date is specified', () => {
@@ -192,6 +192,16 @@ describes.sandboxed('amp-date-display 1.0: parseDateAttrs', {}, () => {
     expect(parseDateAttrs(element)).to.equal(DATE.getTime() + 1000);
   });
 
+  it('should accept "datetime=now"', () => {
+    env.sandbox.useFakeTimers(DATE);
+    element.setAttribute('datetime', 'now');
+    expect(parseDateAttrs(element)).to.equal(DATE.getTime());
+
+    // With offset.
+    element.setAttribute('offset-seconds', '1');
+    expect(parseDateAttrs(element)).to.equal(DATE.getTime() + 1000);
+  });
+
   it('should parse the "timestamp-ms" attribute', () => {
     element.setAttribute('timestamp-ms', DATE.getTime());
     expect(parseDateAttrs(element)).to.equal(DATE.getTime());
@@ -201,6 +211,11 @@ describes.sandboxed('amp-date-display 1.0: parseDateAttrs', {}, () => {
     expect(parseDateAttrs(element)).to.equal(DATE.getTime() + 1000);
   });
 
+  it('should throw when invalid "timestamp-ms" is specified', () => {
+    element.setAttribute('timestamp-ms', 'invalid');
+    expect(() => parseDateAttrs(element)).to.throw(/required/);
+  });
+
   it('should parse the "timestamp-seconds" attribute', () => {
     element.setAttribute('timestamp-seconds', DATE.getTime() / 1000);
     expect(parseDateAttrs(element)).to.equal(DATE.getTime());
@@ -208,5 +223,10 @@ describes.sandboxed('amp-date-display 1.0: parseDateAttrs', {}, () => {
     // With offset.
     element.setAttribute('offset-seconds', '1');
     expect(parseDateAttrs(element)).to.equal(DATE.getTime() + 1000);
+  });
+
+  it('should throw when invalid "timestamp-seconds" is specified', () => {
+    element.setAttribute('timestamp-seconds', 'invalid');
+    expect(() => parseDateAttrs(element)).to.throw(/required/);
   });
 });

--- a/extensions/amp-date-display/1.0/test/test-date-display.js
+++ b/extensions/amp-date-display/1.0/test/test-date-display.js
@@ -95,6 +95,22 @@ describes.sandboxed('DateDisplay 1.0 preact component', {}, (env) => {
     expect(data.month).to.equal('2');
   });
 
+  it('accepts string type', () => {
+    const props = {
+      render,
+      datetime: '2001-02-03T04:05:06.007Z',
+      displayIn: 'UTC',
+    };
+    const jsx = <DateDisplay {...props} />;
+
+    const wrapper = mount(jsx);
+    const data = JSON.parse(wrapper.text());
+
+    expect(data.year).to.equal('2001');
+    expect(data.yearTwoDigit).to.equal('01');
+    expect(data.month).to.equal('2');
+  });
+
   it('provides all variables in local and English (default)', () => {
     const props = {
       render,

--- a/extensions/amp-date-display/1.0/test/test-date-display.js
+++ b/extensions/amp-date-display/1.0/test/test-date-display.js
@@ -50,7 +50,7 @@ describes.sandboxed('DateDisplay 1.0 preact component', {}, (env) => {
   it('provides all variables in UTC and English (default)', () => {
     const props = {
       render,
-      datetime: '2001-02-03T04:05:06.007Z',
+      datetime: Date.parse('2001-02-03T04:05:06.007Z'),
       displayIn: 'UTC',
     };
     const jsx = <DateDisplay {...props} />;
@@ -79,10 +79,26 @@ describes.sandboxed('DateDisplay 1.0 preact component', {}, (env) => {
     expect(data.dayPeriod).to.equal('am');
   });
 
+  it('accepts Date type', () => {
+    const props = {
+      render,
+      datetime: new Date('2001-02-03T04:05:06.007Z'),
+      displayIn: 'UTC',
+    };
+    const jsx = <DateDisplay {...props} />;
+
+    const wrapper = mount(jsx);
+    const data = JSON.parse(wrapper.text());
+
+    expect(data.year).to.equal('2001');
+    expect(data.yearTwoDigit).to.equal('01');
+    expect(data.month).to.equal('2');
+  });
+
   it('provides all variables in local and English (default)', () => {
     const props = {
       render,
-      datetime: '2001-02-03T04:05:06.007',
+      datetime: Date.parse('2001-02-03T04:05:06.007'),
     };
     const jsx = <DateDisplay {...props} />;
 
@@ -110,136 +126,10 @@ describes.sandboxed('DateDisplay 1.0 preact component', {}, (env) => {
     expect(data.dayPeriod).to.equal('am');
   });
 
-  describe('correctly parses', () => {
-    it('now keyword', () => {
-      const props = {
-        render,
-        datetime: 'now',
-      };
-      const jsx = <DateDisplay {...props} />;
-
-      const wrapper = mount(jsx);
-      const data = JSON.parse(wrapper.text());
-      const dateFromParsed = new Date(data.iso);
-
-      // Because of the runtime there could be a several ms difference.
-      expect(dateFromParsed.getTime()).to.equal(Date.now());
-    });
-
-    it('day only ISO 8601 date', () => {
-      const props = {
-        render,
-        datetime: '2001-02-03',
-      };
-      const jsx = <DateDisplay {...props} />;
-
-      const wrapper = mount(jsx);
-      const data = JSON.parse(wrapper.text());
-
-      expect(data.iso).to.equal('2001-02-03T00:00:00.000Z');
-    });
-
-    it('full ISO 8601 date in UTC time zone', () => {
-      const props = {
-        render,
-        datetime: '2001-02-03T04:05:06.007Z',
-      };
-      const jsx = <DateDisplay {...props} />;
-
-      const wrapper = mount(jsx);
-      const data = JSON.parse(wrapper.text());
-
-      expect(data.iso).to.equal('2001-02-03T04:05:06.007Z');
-    });
-
-    it('full ISO 8601 date without time zone (interpreted as local)', () => {
-      const props = {
-        render,
-        datetime: '2001-02-03T04:05:06.007',
-      };
-      const jsx = <DateDisplay {...props} />;
-
-      const wrapper = mount(jsx);
-      const data = JSON.parse(wrapper.text());
-      const result =
-        `${data.year}-${data.monthTwoDigit}-${data.dayTwoDigit}` +
-        `T${data.hourTwoDigit}:${data.minuteTwoDigit}:${data.secondTwoDigit}`;
-
-      expect(result).to.equal('2001-02-03T04:05:06');
-    });
-
-    it('full ISO 8601 date in a custom time zone', () => {
-      const props = {
-        render,
-        datetime: '2001-02-03T04:05:06.007+08:00',
-      };
-      const jsx = <DateDisplay {...props} />;
-
-      const wrapper = mount(jsx);
-      const data = JSON.parse(wrapper.text());
-
-      expect(data.iso).to.equal('2001-02-02T20:05:06.007Z');
-    });
-
-    it('seconds since the UNIX epoch', () => {
-      const props = {
-        render,
-        timestampSeconds: 981173106,
-      };
-      const jsx = <DateDisplay {...props} />;
-
-      const wrapper = mount(jsx);
-      const data = JSON.parse(wrapper.text());
-
-      expect(data.iso).to.equal('2001-02-03T04:05:06.000Z');
-    });
-
-    it('miliseconds since the UNIX epoch', () => {
-      const props = {
-        render,
-        timestampMs: 981173106007,
-      };
-      const jsx = <DateDisplay {...props} />;
-
-      const wrapper = mount(jsx);
-      const data = JSON.parse(wrapper.text());
-
-      expect(data.iso).to.equal('2001-02-03T04:05:06.007Z');
-    });
-  });
-
-  it('adds offset seconds', () => {
-    const props = {
-      render,
-      datetime: '2001-02-03T04:05:06.007Z',
-      offsetSeconds: 1234567,
-    };
-    const jsx = <DateDisplay {...props} />;
-
-    const wrapper = mount(jsx);
-    const data = JSON.parse(wrapper.text());
-
-    expect(data.iso).to.equal('2001-02-17T11:01:13.007Z');
-  });
-
-  it('subtracts offset seconds', () => {
-    const props = {
-      render,
-      datetime: '2001-02-03T04:05:06.007Z',
-      offsetSeconds: -1234567,
-    };
-    const jsx = <DateDisplay {...props} />;
-
-    const wrapper = mount(jsx);
-    const data = JSON.parse(wrapper.text());
-
-    expect(data.iso).to.equal('2001-01-19T21:08:59.007Z');
-  });
-
   it('provides variables in Czech when "cs" locale is passed', () => {
     const props = {
       render,
-      datetime: '2001-02-03T04:05:06.007Z',
+      datetime: Date.parse('2001-02-03T04:05:06.007Z'),
       displayIn: 'UTC',
       locale: 'cs',
     };

--- a/extensions/amp-timeago/1.0/amp-timeago.js
+++ b/extensions/amp-timeago/1.0/amp-timeago.js
@@ -67,17 +67,34 @@ AmpTimeago['props'] = {
 export function parseDateAttrs(element) {
   // TODO(#29246): Is this a coincidence that timeago would have the same format
   // as date-display? E.g. the format for date-countdown is somewhat different.
-  const datetimeStr = element.getAttribute('datetime');
-  const datetime = parseDate(datetimeStr);
-  const timestampMs = Number(element.getAttribute('timestamp-ms'));
-  const timestampSeconds =
-    Number(element.getAttribute('timestamp-seconds')) * 1000;
-  const offsetSeconds = Number(element.getAttribute('offset-seconds')) * 1000;
+  const epoch = userAssert(
+    parseEpoch(element),
+    'One of datetime, timestamp-ms, or timestamp-seconds is required'
+  );
 
-  const epoch = datetime || timestampMs || timestampSeconds;
-  userAssert(epoch, 'Invalid date: %s', datetimeStr);
-
+  const offsetSeconds =
+    (Number(element.getAttribute('offset-seconds')) || 0) * 1000;
   return epoch + offsetSeconds;
+}
+
+/**
+ * @param {!Element} element
+ * @return {?number}
+ */
+function parseEpoch(element) {
+  const datetime = element.getAttribute('datetime');
+  if (datetime) {
+    return userAssert(parseDate(datetime), 'Invalid date: %s', datetime);
+  }
+  const timestampMs = element.getAttribute('timestamp-ms');
+  if (timestampMs) {
+    return Number(timestampMs);
+  }
+  const timestampSeconds = element.getAttribute('timestamp-seconds');
+  if (timestampSeconds) {
+    return Number(timestampSeconds) * 1000;
+  }
+  return null;
 }
 
 AMP.extension(TAG, '1.0', (AMP) => {

--- a/extensions/amp-timeago/1.0/amp-timeago.js
+++ b/extensions/amp-timeago/1.0/amp-timeago.js
@@ -18,6 +18,7 @@ import {PreactBaseElement} from '../../../src/preact/base-element';
 import {Timeago} from './timeago';
 import {isExperimentOn} from '../../../src/experiments';
 import {isLayoutSizeDefined} from '../../../src/layout';
+import {parseDate} from '../../../src/utils/date';
 import {userAssert} from '../../../src/log';
 
 /** @const {string} */
@@ -50,10 +51,34 @@ AmpTimeago['layoutSizeDefined'] = true;
 
 /** @override */
 AmpTimeago['props'] = {
-  'datetime': {attr: 'datetime'},
-  'locale': {attr: 'locale', default: 'en'},
+  'datetime': {
+    attrs: ['datetime', 'timestamp-ms', 'timestamp-seconds', 'offset-seconds'],
+    parseAttrs: parseDateAttrs,
+  },
   'cutoff': {attr: 'cutoff', type: 'number'},
+  'locale': {attr: 'locale'},
 };
+
+/**
+ * @param {!Element} element
+ * @return {?number}
+ * @visibleForTesting
+ */
+export function parseDateAttrs(element) {
+  // TODO(#29246): Is this a coincidence that timeago would have the same format
+  // as date-display? E.g. the format for date-countdown is somewhat different.
+  const datetimeStr = element.getAttribute('datetime');
+  const datetime = parseDate(datetimeStr);
+  const timestampMs = Number(element.getAttribute('timestamp-ms'));
+  const timestampSeconds =
+    Number(element.getAttribute('timestamp-seconds')) * 1000;
+  const offsetSeconds = Number(element.getAttribute('offset-seconds')) * 1000;
+
+  const epoch = datetime || timestampMs || timestampSeconds;
+  userAssert(epoch, 'Invalid date: %s', datetimeStr);
+
+  return epoch + offsetSeconds;
+}
 
 AMP.extension(TAG, '1.0', (AMP) => {
   AMP.registerElement(TAG, AmpTimeago);

--- a/extensions/amp-timeago/1.0/storybook/Basic.js
+++ b/extensions/amp-timeago/1.0/storybook/Basic.js
@@ -38,7 +38,7 @@ export const _default = () => {
   const locale = select('Locale', allLocales, userLocale);
   return (
     <Timeago
-      datetime={new Date(dateTime).toISOString()}
+      datetime={dateTime}
       locale={locale}
       cutoff={cutoff}
       placeholder={placeholder}

--- a/extensions/amp-timeago/1.0/test/test-amp-timeago.js
+++ b/extensions/amp-timeago/1.0/test/test-amp-timeago.js
@@ -117,7 +117,7 @@ describes.realWin(
   }
 );
 
-describe('amp-timeago 1.0: parseDateAttrs', () => {
+describes.sandboxed('amp-timeago 1.0: parseDateAttrs', {}, () => {
   const DATE = new Date(1514793600000);
   const DATE_STRING = DATE.toISOString();
 

--- a/extensions/amp-timeago/1.0/test/test-amp-timeago.js
+++ b/extensions/amp-timeago/1.0/test/test-amp-timeago.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import '../amp-timeago';
+import {parseDateAttrs} from '../amp-timeago';
 import {toggleExperiment} from '../../../../src/experiments';
 import {waitFor} from '../../../../testing/test-helper.js';
 
@@ -80,6 +80,16 @@ describes.realWin(
       expect(time).to.equal('2 days ago');
     });
 
+    it('should render display 2 days ago using "timestamp-ms"', async () => {
+      const date = new Date();
+      date.setDate(date.getDate() - 2);
+      element.setAttribute('timestamp-ms', date.getTime());
+      element.textContent = date.toString();
+      win.document.body.appendChild(element);
+      const time = await getTimeFromShadow();
+      expect(time).to.equal('2 days ago');
+    });
+
     it('should display original date when older than cutoff', async () => {
       const date = new Date('2017-01-01');
       element.setAttribute('datetime', date.toISOString());
@@ -106,3 +116,50 @@ describes.realWin(
     });
   }
 );
+
+describe('amp-timeago 1.0: parseDateAttrs', () => {
+  const DATE = new Date(1514793600000);
+  const DATE_STRING = DATE.toISOString();
+
+  let element;
+
+  beforeEach(() => {
+    element = document.createElement('amp-timeago');
+  });
+
+  it('should throw when no date is specified', () => {
+    expect(() => parseDateAttrs(element)).to.throw(/Invalid date/);
+  });
+
+  it('should throw when invalid date is specified', () => {
+    element.setAttribute('datetime', 'invalid');
+    expect(() => parseDateAttrs(element)).to.throw(/Invalid date/);
+  });
+
+  it('should parse the "datetime" attribute', () => {
+    element.setAttribute('datetime', DATE_STRING);
+    expect(parseDateAttrs(element)).to.equal(DATE.getTime());
+
+    // With offset.
+    element.setAttribute('offset-seconds', '1');
+    expect(parseDateAttrs(element)).to.equal(DATE.getTime() + 1000);
+  });
+
+  it('should parse the "timestamp-ms" attribute', () => {
+    element.setAttribute('timestamp-ms', DATE.getTime());
+    expect(parseDateAttrs(element)).to.equal(DATE.getTime());
+
+    // With offset.
+    element.setAttribute('offset-seconds', '1');
+    expect(parseDateAttrs(element)).to.equal(DATE.getTime() + 1000);
+  });
+
+  it('should parse the "timestamp-seconds" attribute', () => {
+    element.setAttribute('timestamp-seconds', DATE.getTime() / 1000);
+    expect(parseDateAttrs(element)).to.equal(DATE.getTime());
+
+    // With offset.
+    element.setAttribute('offset-seconds', '1');
+    expect(parseDateAttrs(element)).to.equal(DATE.getTime() + 1000);
+  });
+});

--- a/extensions/amp-timeago/1.0/test/test-amp-timeago.js
+++ b/extensions/amp-timeago/1.0/test/test-amp-timeago.js
@@ -117,18 +117,18 @@ describes.realWin(
   }
 );
 
-describes.sandboxed('amp-timeago 1.0: parseDateAttrs', {}, () => {
+describes.sandboxed('amp-date-display 1.0: parseDateAttrs', {}, (env) => {
   const DATE = new Date(1514793600000);
   const DATE_STRING = DATE.toISOString();
 
   let element;
 
   beforeEach(() => {
-    element = document.createElement('amp-timeago');
+    element = document.createElement('amp-date-display');
   });
 
   it('should throw when no date is specified', () => {
-    expect(() => parseDateAttrs(element)).to.throw(/Invalid date/);
+    expect(() => parseDateAttrs(element)).to.throw(/required/);
   });
 
   it('should throw when invalid date is specified', () => {
@@ -145,6 +145,16 @@ describes.sandboxed('amp-timeago 1.0: parseDateAttrs', {}, () => {
     expect(parseDateAttrs(element)).to.equal(DATE.getTime() + 1000);
   });
 
+  it('should accept "datetime=now"', () => {
+    env.sandbox.useFakeTimers(DATE);
+    element.setAttribute('datetime', 'now');
+    expect(parseDateAttrs(element)).to.equal(DATE.getTime());
+
+    // With offset.
+    element.setAttribute('offset-seconds', '1');
+    expect(parseDateAttrs(element)).to.equal(DATE.getTime() + 1000);
+  });
+
   it('should parse the "timestamp-ms" attribute', () => {
     element.setAttribute('timestamp-ms', DATE.getTime());
     expect(parseDateAttrs(element)).to.equal(DATE.getTime());
@@ -154,6 +164,11 @@ describes.sandboxed('amp-timeago 1.0: parseDateAttrs', {}, () => {
     expect(parseDateAttrs(element)).to.equal(DATE.getTime() + 1000);
   });
 
+  it('should throw when invalid "timestamp-ms" is specified', () => {
+    element.setAttribute('timestamp-ms', 'invalid');
+    expect(() => parseDateAttrs(element)).to.throw(/required/);
+  });
+
   it('should parse the "timestamp-seconds" attribute', () => {
     element.setAttribute('timestamp-seconds', DATE.getTime() / 1000);
     expect(parseDateAttrs(element)).to.equal(DATE.getTime());
@@ -161,5 +176,10 @@ describes.sandboxed('amp-timeago 1.0: parseDateAttrs', {}, () => {
     // With offset.
     element.setAttribute('offset-seconds', '1');
     expect(parseDateAttrs(element)).to.equal(DATE.getTime() + 1000);
+  });
+
+  it('should throw when invalid "timestamp-seconds" is specified', () => {
+    element.setAttribute('timestamp-seconds', 'invalid');
+    expect(() => parseDateAttrs(element)).to.throw(/required/);
   });
 });

--- a/extensions/amp-timeago/1.0/timeago.js
+++ b/extensions/amp-timeago/1.0/timeago.js
@@ -50,7 +50,7 @@ export function Timeago({
   const [timestamp, setTimestamp] = useState(placeholder || '');
   const ref = useRef(null);
 
-  const date = getDate(datetime);
+  const date = new Date(getDate(datetime));
 
   useEffect(() => {
     const node = ref.current;

--- a/extensions/amp-timeago/1.0/timeago.js
+++ b/extensions/amp-timeago/1.0/timeago.js
@@ -50,17 +50,19 @@ export function Timeago({
   const [timestamp, setTimestamp] = useState(placeholder || '');
   const ref = useRef(null);
 
-  const date = new Date(getDate(datetime));
+  const date = getDate(datetime);
 
   useEffect(() => {
     const node = ref.current;
-    if (!node || !date) {
+    if (!node) {
       return undefined;
     }
     const observer = new IntersectionObserver((entries) => {
       const last = entries[entries.length - 1];
       if (last.isIntersecting) {
-        setTimestamp(getFuzzyTimestampValue(date, locale, cutoff, placeholder));
+        setTimestamp(
+          getFuzzyTimestampValue(new Date(date), locale, cutoff, placeholder)
+        );
       }
     });
     observer.observe(node);
@@ -74,7 +76,7 @@ export function Timeago({
       {...rest}
       as="time"
       ref={ref}
-      datetime={date && date.toISOString()}
+      datetime={new Date(date).toISOString()}
     >
       {timestamp}
     </Wrapper>
@@ -82,22 +84,22 @@ export function Timeago({
 }
 
 /**
- * @param {?Date} datetime
+ * @param {!Date} date
  * @param {string} locale
  * @param {number|undefined} cutoff
  * @param {string|!PreactDef.VNode|null|undefined} placeholder
  * @return {string|!PreactDef.VNode}
  */
-function getFuzzyTimestampValue(datetime, locale, cutoff, placeholder) {
+function getFuzzyTimestampValue(date, locale, cutoff, placeholder) {
   if (!cutoff) {
-    return timeago(datetime, locale);
+    return timeago(date, locale);
   }
-  const secondsAgo = Math.floor((Date.now() - datetime.getTime()) / 1000);
+  const secondsAgo = Math.floor((Date.now() - date.getTime()) / 1000);
 
   if (secondsAgo > cutoff) {
-    return placeholder ? placeholder : getDefaultPlaceholder(datetime, locale);
+    return placeholder ? placeholder : getDefaultPlaceholder(date, locale);
   }
-  return timeago(datetime, locale);
+  return timeago(date, locale);
 }
 
 /**

--- a/extensions/amp-timeago/1.0/timeago.js
+++ b/extensions/amp-timeago/1.0/timeago.js
@@ -16,6 +16,7 @@
 
 import * as Preact from '../../../src/preact';
 import {Wrapper} from '../../../src/preact/component';
+import {getDate} from '../../../src/utils/date';
 import {timeago} from '../../../third_party/timeagojs/timeago';
 import {useEffect, useRef, useState} from '../../../src/preact';
 import {useResourcesNotify} from '../../../src/preact/utils';
@@ -49,34 +50,39 @@ export function Timeago({
   const [timestamp, setTimestamp] = useState(placeholder || '');
   const ref = useRef(null);
 
+  const date = getDate(datetime);
+
   useEffect(() => {
     const node = ref.current;
-    if (!node) {
+    if (!node || !date) {
       return undefined;
     }
     const observer = new IntersectionObserver((entries) => {
       const last = entries[entries.length - 1];
       if (last.isIntersecting) {
-        setTimestamp(
-          getFuzzyTimestampValue(datetime, locale, cutoff, placeholder)
-        );
+        setTimestamp(getFuzzyTimestampValue(date, locale, cutoff, placeholder));
       }
     });
     observer.observe(node);
     return () => observer.disconnect();
-  }, [datetime, locale, cutoff, placeholder]);
+  }, [date, locale, cutoff, placeholder]);
 
   useResourcesNotify();
 
   return (
-    <Wrapper {...rest} as="time" ref={ref} datetime={datetime}>
+    <Wrapper
+      {...rest}
+      as="time"
+      ref={ref}
+      datetime={date && date.toISOString()}
+    >
       {timestamp}
     </Wrapper>
   );
 }
 
 /**
- * @param {string} datetime
+ * @param {?Date} datetime
  * @param {string} locale
  * @param {number|undefined} cutoff
  * @param {string|!PreactDef.VNode|null|undefined} placeholder
@@ -86,11 +92,10 @@ function getFuzzyTimestampValue(datetime, locale, cutoff, placeholder) {
   if (!cutoff) {
     return timeago(datetime, locale);
   }
-  const elDate = new Date(datetime);
-  const secondsAgo = Math.floor((Date.now() - elDate.getTime()) / 1000);
+  const secondsAgo = Math.floor((Date.now() - datetime.getTime()) / 1000);
 
   if (secondsAgo > cutoff) {
-    return placeholder ? placeholder : getDefaultPlaceholder(elDate, locale);
+    return placeholder ? placeholder : getDefaultPlaceholder(datetime, locale);
   }
   return timeago(datetime, locale);
 }

--- a/extensions/amp-timeago/1.0/timeago.type.js
+++ b/extensions/amp-timeago/1.0/timeago.type.js
@@ -20,7 +20,7 @@
 
 /**
  * @typedef {{
- *   datetime: string,
+ *   datetime: (?Date|number|undefined),
  *   locale: string,
  *   cutoff: (number|undefined),
  *   placeholder: (string|!PreactDef.VNode|null|undefined),

--- a/extensions/amp-timeago/1.0/timeago.type.js
+++ b/extensions/amp-timeago/1.0/timeago.type.js
@@ -20,7 +20,7 @@
 
 /**
  * @typedef {{
- *   datetime: (?Date|number|undefined),
+ *   datetime: (!Date|number|string),
  *   locale: string,
  *   cutoff: (number|undefined),
  *   placeholder: (string|!PreactDef.VNode|null|undefined),

--- a/src/preact/component/contain.js
+++ b/src/preact/component/contain.js
@@ -74,7 +74,7 @@ function ContainWrapperWithRef(
     <Comp
       {...rest}
       ref={ref}
-      className={`${className || ''} ${wrapperClassName || ''}`}
+      className={`${className || ''} ${wrapperClassName || ''}`.trim() || null}
       style={{
         ...style,
         ...wrapperStyle,

--- a/src/preact/component/wrapper.js
+++ b/src/preact/component/wrapper.js
@@ -41,7 +41,7 @@ function WrapperWithRef(
     <Comp
       {...rest}
       ref={ref}
-      className={`${className || ''} ${wrapperClassName || ''}`}
+      className={`${className || ''} ${wrapperClassName || ''}`.trim() || null}
       style={{...style, ...wrapperStyle}}
     >
       {children}

--- a/src/utils/date.js
+++ b/src/utils/date.js
@@ -1,0 +1,56 @@
+/**
+ * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Parses the date using the `Date.parse()` rules. Additionally supports the
+ * keyword "now" that indicates the "current date/time". Returns either a
+ * valid epoch value or null.
+ *
+ * @param {?string|undefined} s
+ * @return {?number}
+ */
+export function parseDate(s) {
+  if (!s) {
+    return null;
+  }
+  if (s.toLowerCase() === 'now') {
+    return Date.now();
+  }
+  const parsed = Date.parse(s);
+  return isNaN(parsed) ? null : parsed;
+}
+
+/**
+ * @param {?Date|number|undefined} date
+ * @return {?number}
+ */
+export function getEpoch(date) {
+  if (!date) {
+    return null;
+  }
+  return typeof date == 'number' ? date : date.getTime();
+}
+
+/**
+ * @param {?Date|number|undefined} date
+ * @return {?Date}
+ */
+export function getDate(date) {
+  if (!date) {
+    return null;
+  }
+  return typeof date == 'number' ? new Date(date) : date;
+}

--- a/src/utils/date.js
+++ b/src/utils/date.js
@@ -34,23 +34,20 @@ export function parseDate(s) {
 }
 
 /**
- * @param {?Date|number|undefined} date
- * @return {?number}
+ * @param {!Date|number|string|T} value
+ * @return {number|T}
+ * @template T
  */
-export function getEpoch(date) {
-  if (!date) {
+export function getDate(value) {
+  if (!value) {
     return null;
   }
-  return typeof date == 'number' ? date : date.getTime();
-}
-
-/**
- * @param {?Date|number|undefined} date
- * @return {?Date}
- */
-export function getDate(date) {
-  if (!date) {
-    return null;
+  if (typeof value == 'number') {
+    return value;
   }
-  return typeof date == 'number' ? new Date(date) : date;
+  if (typeof value == 'string') {
+    return parseDate(value);
+  }
+  // Must be a `Date` object.
+  return value.getTime();
 }

--- a/test/unit/preact/test-base-element.js
+++ b/test/unit/preact/test-base-element.js
@@ -160,7 +160,10 @@ describes.realWin('PreactBaseElement', {amp: true}, (env) => {
     });
   });
 
-  describe('no children mapping', () => {
+  describe('attribute mapping', () => {
+    const DATE_STRING = '2018-01-01T08:00:00Z';
+    const DATE = Date.parse(DATE_STRING);
+
     let element;
 
     beforeEach(async () => {
@@ -169,8 +172,14 @@ describes.realWin('PreactBaseElement', {amp: true}, (env) => {
         'valueWithDef': {attr: 'value-with-def', default: 'DEFAULT'},
         'propA': {attr: 'prop-a'},
         'minFontSize': {attr: 'min-font-size', type: 'number'},
+        'aDate': {attr: 'a-date', type: 'date'},
         'disabled': {attr: 'disabled', type: 'boolean'},
         'enabled': {attr: 'enabled', type: 'boolean'},
+        'combined': {
+          attrs: ['part-a', 'part-b'],
+          parseAttrs: (e) =>
+            `${e.getAttribute('part-a')}+${e.getAttribute('part-b')}`,
+        },
       };
       element = html`
         <amp-preact
@@ -181,9 +190,12 @@ describes.realWin('PreactBaseElement', {amp: true}, (env) => {
           min-font-size="72"
           disabled
           unknown="1"
+          part-a="A"
+          part-b="B"
         >
         </amp-preact>
       `;
+      element.setAttribute('a-date', DATE_STRING);
       doc.body.appendChild(element);
       await element.build();
       await waitFor(() => component.callCount > 0, 'component rendered');
@@ -201,16 +213,20 @@ describes.realWin('PreactBaseElement', {amp: true}, (env) => {
         valueWithDef: 'DEFAULT',
         propA: 'A',
         minFontSize: 72,
+        aDate: DATE,
         disabled: true,
         enabled: false,
+        combined: 'A+B',
       });
     });
 
     it('should mutate attributes', async () => {
       element.setAttribute('prop-a', 'B');
       element.setAttribute('min-font-size', '72.5');
+      element.setAttribute('a-date', '2018-01-01T08:00:01Z');
       element.setAttribute('enabled', '');
       element.removeAttribute('disabled');
+      element.setAttribute('part-b', 'C');
 
       await waitFor(() => component.callCount > 1, 'component re-rendered');
 
@@ -219,8 +235,10 @@ describes.realWin('PreactBaseElement', {amp: true}, (env) => {
         valueWithDef: 'DEFAULT',
         propA: 'B',
         minFontSize: 72.5,
+        aDate: DATE + 1000,
         disabled: false,
         enabled: true,
+        combined: 'A+C',
       });
     });
 

--- a/test/unit/utils/test-date.js
+++ b/test/unit/utils/test-date.js
@@ -1,0 +1,73 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {getDate, getEpoch, parseDate} from '../../../src/utils/date';
+
+describes.sandboxed('utils/date', {}, (env) => {
+  describe('parseDate', () => {
+    beforeEach(() => {
+      env.sandbox.useFakeTimers(new Date('2018-01-01T08:00:00Z'));
+    });
+
+    it('should return null for empty values', () => {
+      expect(parseDate(null)).to.be.null;
+      expect(parseDate(undefined)).to.be.null;
+      expect(parseDate('')).to.be.null;
+    });
+
+    it('should return null for invalid values', () => {
+      expect(parseDate('abc')).to.be.null;
+    });
+
+    it('should return current date for "now"', () => {
+      expect(parseDate('now')).to.equal(Date.now());
+    });
+
+    it('should parse a date', () => {
+      // +1 second.
+      expect(parseDate('2018-01-01T08:00:01Z')).to.equal(Date.now() + 1000);
+    });
+  });
+
+  describe('getDate and getEpoch', () => {
+    let date;
+
+    beforeEach(() => {
+      date = new Date(parseDate('2018-01-01T08:00:01Z'));
+    });
+
+    it('should return null for null input', () => {
+      expect(getEpoch(null)).to.be.null;
+      expect(getDate(null)).to.be.null;
+      expect(getEpoch(0)).to.be.null;
+      expect(getDate(0)).to.be.null;
+    });
+
+    it('should return the epoch value', () => {
+      expect(getEpoch(date)).to.equal(date.getTime());
+      expect(getEpoch(date.getTime())).to.equal(date.getTime());
+    });
+
+    it('should return the exact date instance value', () => {
+      expect(getDate(date)).to.equal(date);
+    });
+
+    it('should create a new date', () => {
+      expect(getDate(date.getTime()).getTime()).to.equal(date.getTime());
+      expect(getDate(date.getTime())).to.not.equal(date);
+    });
+  });
+});

--- a/test/unit/utils/test-date.js
+++ b/test/unit/utils/test-date.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {getDate, getEpoch, parseDate} from '../../../src/utils/date';
+import {getDate, parseDate} from '../../../src/utils/date';
 
 describes.sandboxed('utils/date', {}, (env) => {
   describe('parseDate', () => {
@@ -42,7 +42,7 @@ describes.sandboxed('utils/date', {}, (env) => {
     });
   });
 
-  describe('getDate and getEpoch', () => {
+  describe('getDate', () => {
     let date;
 
     beforeEach(() => {
@@ -50,24 +50,25 @@ describes.sandboxed('utils/date', {}, (env) => {
     });
 
     it('should return null for null input', () => {
-      expect(getEpoch(null)).to.be.null;
       expect(getDate(null)).to.be.null;
-      expect(getEpoch(0)).to.be.null;
       expect(getDate(0)).to.be.null;
+      expect(getDate('')).to.be.null;
+      expect(getDate(undefined)).to.be.null;
+      expect(getDate(NaN)).to.be.null;
     });
 
-    it('should return the epoch value', () => {
-      expect(getEpoch(date)).to.equal(date.getTime());
-      expect(getEpoch(date.getTime())).to.equal(date.getTime());
+    it('should return the value from Date and number types', () => {
+      expect(getDate(date)).to.equal(date.getTime());
+      expect(getDate(date.getTime())).to.equal(date.getTime());
     });
 
-    it('should return the exact date instance value', () => {
-      expect(getDate(date)).to.equal(date);
+    it('should parse a string value', () => {
+      expect(getDate(date.toISOString())).to.equal(date.getTime());
     });
 
-    it('should create a new date', () => {
-      expect(getDate(date.getTime()).getTime()).to.equal(date.getTime());
-      expect(getDate(date.getTime())).to.not.equal(date);
+    it('should parse a "now" keywrod', () => {
+      env.sandbox.useFakeTimers(date);
+      expect(getDate('now')).to.be.equal(date.getTime());
     });
   });
 });


### PR DESCRIPTION
Partial for #30189, #30052, #29246.

This PR allows a more complicated logic for a prop mapping: many attributes -> a prop. On AMP side we have to support excessive input formats because we are not tied to any particular type system. On Preact's side, we are tied to JavaScript system and thus the typing is less ambiguous. It's easier to supply a single `Date|number` type for a datetime prop than numerous props that do the same thing. The conversion code in this case is simpler than the additional documentation code.

Some key points:

1. A bunch of date attrs (`datetime`, `timestamp-ms`, etc) map into a single `datetime` prop of a stricter type. E.g. strings no longer allowed and a component has almost no conversions/computations when handling this prop.
2. The mapping looks like this: `{attrs: [attr1, attr2, ...], parseAttrs: function(Element)}`. The `parseAttrs` callback reads the attributes from the element and computes the value. But the array of attributes is still needed to make sure that mutation observe can track these attributes.
3. The `parseAttrs` function for date components is somewhat duplicative. It's actually exactly the same for `date-display` and `timeago`. However, I'm not sure yet if that's just a coincidence. E.g. `date-countdown` has a slightly different mapping. For now I kept them forked. Still better than having them even more forked inside the components.
4. For now I have `datetime` type of `Date|number` because these both are very natural for JavaScript. E.g. `Date.parse()` returns a number, only a number can be passed in a JSON object, and many date operations accept both `Date` and `number` interchangeably. But I'm not sure if it's a good idea yet. It'd be even simpler if only a single type was allowed here.

