### PR TITLE
🚀 Move document-submit to amp-form.

### DIFF
--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -1828,7 +1828,9 @@ AMP.extension(TAG, '0.1', (AMP) => {
   const {ampdoc} = AMP;
   AMP.registerServiceForDoc('form-submit-service', FormSubmitService);
   AMP.registerServiceForDoc(TAG, AmpFormService);
-  ampdoc.whenReady().then(() => {
-    installGlobalSubmitListenerForDoc(ampdoc);
-  });
+  if (ampdoc) {
+    ampdoc.whenReady().then(() => {
+      installGlobalSubmitListenerForDoc(ampdoc);
+    });
+  }
 });

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -1688,7 +1688,7 @@ export class AmpFormService {
 }
 
 /**
- * @param {!./service/ampdoc-impl.AmpDoc} ampdoc
+ * @param {!../../../src/service/ampdoc-impl.Ampdoc} ampdoc
  * @return {!Promise}
  */
 function installGlobalSubmitListenerForDoc(ampdoc) {

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -35,9 +35,9 @@ import {Keys} from '../../../src/utils/key-codes';
 import {
   SOURCE_ORIGIN_PARAM,
   addParamsToUrl,
+  assertHttpsUrl,
   checkCorsUrl,
   isProxyOrigin,
-  assertHttpsUrl,
   parseQueryString,
   serializeQueryString,
 } from '../../../src/url';
@@ -1692,14 +1692,9 @@ export class AmpFormService {
  * @return {!Promise}
  */
 function installGlobalSubmitListenerForDoc(ampdoc) {
-  if (this.docSubmitInstalled_) {
-    return;
-  } else {
-    this.docSubmitInstalled_ = true;
-    ampdoc
-      .getRootNode()
-      .addEventListener('submit', onDocumentFormSubmit_, true);
-  }
+  return ampdoc
+    .getRootNode()
+    .addEventListener('submit', onDocumentFormSubmit_, true);
 }
 
 /**

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -1691,9 +1691,7 @@ export class AmpFormService {
  * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc
  */
 function installGlobalSubmitListenerForDoc(ampdoc) {
-  ampdoc
-    .getRootNode()
-    .addEventListener('submit', onDocumentFormSubmit_, true);
+  ampdoc.getRootNode().addEventListener('submit', onDocumentFormSubmit_, true);
 }
 
 /**

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -1825,12 +1825,7 @@ export function onDocumentFormSubmit_(e) {
 }
 
 AMP.extension(TAG, '0.1', (AMP) => {
-  const {ampdoc} = AMP;
   AMP.registerServiceForDoc('form-submit-service', FormSubmitService);
   AMP.registerServiceForDoc(TAG, AmpFormService);
-  if (ampdoc) {
-    ampdoc.whenReady().then(() => {
-      installGlobalSubmitListenerForDoc(ampdoc);
-    });
-  }
+  AMP.registerServiceForDoc('global-service-handler', installGlobalSubmitListenerForDoc);
 });

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -1688,11 +1688,10 @@ export class AmpFormService {
 }
 
 /**
- * @param {!../../../src/service/ampdoc-impl.Ampdoc} ampdoc
- * @return {!Promise}
+ * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc
  */
 function installGlobalSubmitListenerForDoc(ampdoc) {
-  return ampdoc
+  ampdoc
     .getRootNode()
     .addEventListener('submit', onDocumentFormSubmit_, true);
 }


### PR DESCRIPTION
@dvoytenko mentioned that the entirety of document-submit could be moved to amp-form, so this PR attempts to address that. Will need additional discussion on the race condition issue addressed by @alanorozco (to use a global locking mechanism?).