### PR TITLE
✨ Add prebidappnexuspsp as a vendor to RTC config

### DIFF
--- a/extensions/amp-a4a/0.1/callout-vendors.js
+++ b/extensions/amp-a4a/0.1/callout-vendors.js
@@ -79,6 +79,12 @@ const RTC_VENDORS = jsonConfiguration({
     macros: ['PLACEMENT_ID', 'CONSENT_STRING', 'ACCOUNT_ID'],
     disableKeyAppend: true,
   },
+  prebidappnexuspsp: {
+    url:
+      'https://ib.adnxs.com/prebid/amp?tag_id=PLACEMENT_ID&w=ATTR(width)&h=ATTR(height)&ow=ATTR(data-override-width)&oh=ATTR(data-override-height)&ms=ATTR(data-multi-size)&slot=ATTR(data-slot)&targeting=TGT&curl=CANONICAL_URL&timeout=TIMEOUT&adcid=ADCID&purl=HREF&gdpr_consent=CONSENT_STRING&account=ACCOUNT_ID',
+    macros: ['PLACEMENT_ID', 'CONSENT_STRING', 'ACCOUNT_ID'],
+    disableKeyAppend: true,
+  },
   prebidrubicon: {
     url:
       'https://prebid-server.rubiconproject.com/openrtb2/amp?tag_id=REQUEST_ID&w=ATTR(width)&h=ATTR(height)&ow=ATTR(data-override-width)&oh=ATTR(data-override-height)&ms=ATTR(data-multi-size)&slot=ATTR(data-slot)&targeting=TGT&curl=CANONICAL_URL&timeout=TIMEOUT&adc=ADCID&purl=HREF&gdpr_consent=CONSENT_STRING&account=ACCOUNT_ID',

--- a/extensions/amp-a4a/rtc-documentation.md
+++ b/extensions/amp-a4a/rtc-documentation.md
@@ -124,6 +124,7 @@ The `errorReportingUrl` property is optional. The only available macros are ERRO
 #### Currently Supported Vendors
 
 - AppNexus
+- AppNexus PSP
 - APS
 - Automatad
 - Andbeyond

--- a/extensions/amp-a4a/rtc-publisher-implementation-guide.md
+++ b/extensions/amp-a4a/rtc-publisher-implementation-guide.md
@@ -20,6 +20,7 @@ To use RTC, you must meet the following requirements:
 ### Supported Vendors
 
 - AppNexus
+- AppNexus PSP
 - APS
 - Automatad
 - Andbeyond


### PR DESCRIPTION
Similar to https://github.com/ampproject/amphtml/pull/13355, we'd like to submit a new endpoint to the RTC config.  This endpoint will respond in the same manner as the original `prebidappnexus` endpoint, though it will be hosted from a different location.

I'm not sure if anything else needs to be updated (eg documentation-wise), so please let me know if there is.  Thanks.