### PR TITLE
Fix yield pro use of implicit this

### DIFF
--- a/ads/yieldpro.js
+++ b/ads/yieldpro.js
@@ -49,13 +49,12 @@ export function yieldpro(global, data) {
     'yieldpro-request',
     (done) => {
       let success = false;
-      const masterWin = this;
-      if (!masterWin.showadAMPAdapter) {
-        masterWin.showadAMPAdapter = {
+      if (!global.showadAMPAdapter) {
+        global.showadAMPAdapter = {
           registerSlot: () => {},
         };
-        loadScript(this, scriptUrl, () => {
-          if (masterWin.showadAMPAdapter.inited) {
+        loadScript(global, scriptUrl, () => {
+          if (global.showadAMPAdapter.inited) {
             success = true;
           }
           done(success);


### PR DESCRIPTION
After https://github.com/ampproject/amphtml/pull/29929, it is no longer supported to use implicit this. Therefore the reference to *this* needs to be changed to *global*.

@tsanders42 FYI. Regrettably it might have broken your ad since last week and we are working on a fix.