### PR TITLE
Revert "🚀 Compile v0/extensions in strict mode"

### DIFF
--- a/build-system/compile/compile.js
+++ b/build-system/compile/compile.js
@@ -240,16 +240,30 @@ function compile(
     }
     externs.push('build-system/externs/amp.multipass.extern.js');
 
+    // Normally setting this server-side experiment flag would be handled by
+    // the release process automatically. Since this experiment is actually on the
+    // build system instead of runtime, we never run it through babel and therefore
+    // must compute it here.
+    const isStrict = argv.define_experiment_constant === 'STRICT_COMPILATION';
+    const isEsm = argv.esm || argv.sxg;
+    let language;
+    if (isEsm) {
+      // Do not transpile down to ES5 if running with `--esm`, since we do
+      // limited transpilation in Babel.
+      language = 'NO_TRANSPILE';
+    } else if (isStrict) {
+      language = 'ECMASCRIPT5_STRICT';
+    } else {
+      language = 'ECMASCRIPT5';
+    }
+
     /* eslint "google-camelcase/google-camelcase": 0*/
     const compilerOptions = {
       compilation_level: options.compilationLevel || 'SIMPLE_OPTIMIZATIONS',
       // Turns on more optimizations.
       assume_function_wrapper: true,
       language_in: 'ECMASCRIPT_2020',
-      // Do not transpile down to ES5 if running with `--esm`, since we do
-      // limited transpilation in Babel.
-      language_out:
-        argv.esm || argv.sxg ? 'NO_TRANSPILE' : 'ECMASCRIPT5_STRICT',
+      language_out: language,
       // We do not use the polyfills provided by closure compiler.
       // If you need a polyfill. Manually include them in the
       // respective top level polyfills.js files.

--- a/build-system/global-configs/experiments-config.json
+++ b/build-system/global-configs/experiments-config.json
@@ -7,5 +7,11 @@
     "define_experiment_constant": "NO_SIGNING_RTV"
   },
   "experimentB": {},
-  "experimentC": {}
+  "experimentC": {
+    "name": "StrictCompilation",
+    "environment": "AMP",
+    "issue": "https://github.com/ampproject/amphtml/issues/19380",
+    "expiration_date_utc": "2020-08-07",
+    "define_experiment_constant": "STRICT_COMPILATION"
+  }
 }

--- a/build-system/global-configs/experiments-const.json
+++ b/build-system/global-configs/experiments-const.json
@@ -1,1 +1,3 @@
-{}
+{
+  "STRICT_COMPILATION": false
+}

--- a/build-system/tasks/check-sourcemaps.js
+++ b/build-system/tasks/check-sourcemaps.js
@@ -31,9 +31,8 @@ const sourcemapUrlMatcher =
   'https://raw.githubusercontent.com/ampproject/amphtml/\\d{13}/';
 
 // Mapping related constants
-const expectedFirstLineFile = 'src/polyfills/array-includes.js'; // First file that is compiled into v0.js.
-const expectedFirstLineCode = 'function includes(value, opt_fromIndex) {'; // First line of code in that file.
-const expectedFirstLineColumn = "'use strict;'".length; // Column at which the first line is found (after an initial 'use strict;')
+const expectedFirstLineFile = 'src/polyfills/array-includes.js';
+const expectedFirstLineCode = 'function includes(value, opt_fromIndex) {';
 
 /**
  * Throws an error with the given message
@@ -123,7 +122,7 @@ function checkSourcemapSources(sourcemapJson) {
  * 2. Extract the mapping for the first line of code in minified v0.js.
  * 3. Compute the name of the source file that corresponds to this line.
  * 4. Read the source file and extract the corresponding line of code.
- * 5. Check if the filename, line of code, and column match expected sentinel values.
+ * 5. Check if the filename and the line of code match expected sentinel values.
  *
  * @param {!Object} sourcemapJson
  */
@@ -165,8 +164,8 @@ function checkSourcemapMappings(sourcemapJson) {
     log(helpMessage);
     throwError('Found mapping for incorrect code');
   }
-  if (generatedCodeColumn != expectedFirstLineColumn || sourceCodeColumn != 0) {
-    log(red('ERROR:'), 'Found mapping for incorrect column.');
+  if (generatedCodeColumn != 0 || sourceCodeColumn != 0) {
+    log(red('ERROR:'), 'Found mapping for incorrect (non-zero) column.');
     log('generatedCodeColumn:', cyan(generatedCodeColumn));
     log('sourceCodeColumn:', cyan(sourceCodeColumn));
     throwError('Found mapping for incorrect column');


### PR DESCRIPTION
Reverts ampproject/amphtml#29929

Unsure if we want to do this. My impression was that CPing the fixes instead of this revert is cleaner. 