### PR TITLE
❄️ Attempt to deflake messaging-handshake test

### DIFF
--- a/extensions/amp-viewer-integration/0.1/test/integration/test-messaging-handshake.js
+++ b/extensions/amp-viewer-integration/0.1/test/integration/test-messaging-handshake.js
@@ -88,8 +88,6 @@ describes.sandboxed('AmpViewerMessagingIntegration', {}, () => {
       });
 
       it('should perform polling handshake', function () {
-        this.timeout(2000);
-
         const params = serializeQueryString({
           origin: getWinOrigin(window),
           cap: 'handshakepoll',

--- a/extensions/amp-viewer-integration/0.1/test/integration/test-messaging-handshake.js
+++ b/extensions/amp-viewer-integration/0.1/test/integration/test-messaging-handshake.js
@@ -88,7 +88,7 @@ describes.sandboxed('AmpViewerMessagingIntegration', {}, () => {
       });
 
       it('should perform polling handshake', function () {
-        this.timeout(10000);
+        this.timeout(2000);
 
         const params = serializeQueryString({
           origin: getWinOrigin(window),

--- a/extensions/amp-viewer-integration/0.1/test/integration/test-messaging-handshake.js
+++ b/extensions/amp-viewer-integration/0.1/test/integration/test-messaging-handshake.js
@@ -87,26 +87,6 @@ describes.sandboxed('AmpViewerMessagingIntegration', {}, () => {
           });
       });
 
-      it('should fail if messaging token is wrong', () => {
-        const params = serializeQueryString({
-          origin: getWinOrigin(window),
-          messagingToken: 'foo',
-        });
-        const ampDocUrl = `${iframeOrigin}${ampDocSrc}#${params}`;
-        viewerIframe.setAttribute('src', ampDocUrl);
-
-        return Messaging.waitForHandshakeFromDocument(
-          window,
-          viewerIframe.contentWindow,
-          iframeOrigin,
-          'bar'
-        ).then((messaging) => {
-          const handlerStub = window.sandbox.stub();
-          messaging.setDefaultHandler(handlerStub);
-          expect(handlerStub).to.not.have.been.called;
-        });
-      });
-
       it('should perform polling handshake', function () {
         this.timeout(10000);
 
@@ -129,6 +109,26 @@ describes.sandboxed('AmpViewerMessagingIntegration', {}, () => {
           .then((name) => {
             expect(name).to.equal('documentLoaded');
           });
+      });
+
+      it('should fail if messaging token is wrong', () => {
+        const params = serializeQueryString({
+          origin: getWinOrigin(window),
+          messagingToken: 'foo',
+        });
+        const ampDocUrl = `${iframeOrigin}${ampDocSrc}#${params}`;
+        viewerIframe.setAttribute('src', ampDocUrl);
+
+        return Messaging.waitForHandshakeFromDocument(
+          window,
+          viewerIframe.contentWindow,
+          iframeOrigin,
+          'bar'
+        ).then((messaging) => {
+          const handlerStub = window.sandbox.stub();
+          messaging.setDefaultHandler(handlerStub);
+          expect(handlerStub).to.not.have.been.called;
+        });
       });
     });
 });


### PR DESCRIPTION
Closes #30217

I didn't quite understand, but changing the order helped when I run the test locally.

The test only fails when I run all four unit tests within this file in headless chrome. I wonder if it because we fail to clean up and reset the testing environment. 
