### PR TITLE
🐛 Also look at the content of the response when detecting Scroll

### DIFF
--- a/extensions/amp-access-scroll/0.1/scroll-impl.js
+++ b/extensions/amp-access-scroll/0.1/scroll-impl.js
@@ -218,7 +218,7 @@ class ScrollContentBlocker {
     Services.xhrFor(this.ampdoc_.win)
       .fetchJson('https://block.scroll.com/check.json')
       .then(
-        () => false,
+        (response) => response.json().then((json) => json['dns'] === true),
         (e) => this.blockedByScrollApp_(e.message)
       )
       .then((blockedByScrollApp) => {


### PR DESCRIPTION
Previously, Scroll was only interested in whether the file was blocked in order to determine next steps for the viewer. Now we also check if a particular value is in the response.

