### PR TITLE
🐛 Fix ad index value in IMA video

### DIFF
--- a/ads/ads.extern.js
+++ b/ads/ads.extern.js
@@ -223,6 +223,8 @@ google.ima.Ad;
 google.ima.Ad.getSkipTimeOffset;
 google.ima.Ad.getAdPodInfo;
 google.ima.AdPodInfo;
+google.ima.AdPodInfo.getAdPosition;
+google.ima.AdPodInfo.getTotalAds;
 google.ima.AdDisplayContainer;
 google.ima.AdDisplayContainer.initialize;
 google.ima.ImaSdkSettings;

--- a/ads/ads.extern.js
+++ b/ads/ads.extern.js
@@ -221,6 +221,8 @@ var google;
 google.ima;
 google.ima.Ad;
 google.ima.Ad.getSkipTimeOffset;
+google.ima.Ad.getAdPodInfo;
+google.ima.AdPodInfo;
 google.ima.AdDisplayContainer;
 google.ima.AdDisplayContainer.initialize;
 google.ima.ImaSdkSettings;

--- a/ads/google/imaVideo.js
+++ b/ads/google/imaVideo.js
@@ -896,11 +896,13 @@ export function onAdLoad(global) {
 
 /**
  * Called intermittently as the ad plays, allowing us to display ad counter.
- * @param {!Object} global
+ * @param {!Object} unusedEvent
  * @visibleForTesting
  */
-export function onAdProgress(global) {
-  const {adPosition, totalAds} = global.getAdData();
+export function onAdProgress(unusedEvent) {
+  const adPodInfo = currentAd.getAdPodInfo();
+  const adPosition = adPodInfo.getAdPosition();
+  const totalAds = adPodInfo.getTotalAds();
   const remainingTime = adsManager.getRemainingTime();
   const remainingMinutes = Math.floor(remainingTime / 60);
   let remainingSeconds = Math.floor(remainingTime % 60);

--- a/extensions/amp-ima-video/0.1/test/test-amp-ima-video.js
+++ b/extensions/amp-ima-video/0.1/test/test-amp-ima-video.js
@@ -192,7 +192,14 @@ describes.realWin(
         },
       ];
 
+      const adPodInfo = {};
+
+      imaVideoObj.onAdLoad({
+        getAd: () => ({getAdPodInfo: () => adPodInfo}),
+      });
+
       tests.forEach(({mock, label, expected}) => {
+        const {remainingTime, totalAds, adPosition} = mock;
         let defaults = videoDefaults;
         if (label) {
           defaults = Object.assign(defaults, {adLabel: label});
@@ -200,13 +207,11 @@ describes.realWin(
         imaVideoObj.imaVideo(win, defaults);
         const {controlsDiv} = imaVideoObj.getPropertiesForTesting();
         const countdownDiv = controlsDiv.querySelector('#ima-countdown > div');
-        const adsManagerMock = getAdsManagerMock({
-          remainingTime: mock.remainingTime,
-        });
+        const adsManagerMock = getAdsManagerMock({remainingTime});
+        adPodInfo.getTotalAds = () => totalAds;
+        adPodInfo.getAdPosition = () => adPosition;
         imaVideoObj.setAdsManagerForTesting(adsManagerMock);
-        imaVideoObj.onAdProgress({
-          getAdData: () => mock,
-        });
+        imaVideoObj.onAdProgress({});
         expect(countdownDiv.textContent).to.eql(expected);
       });
     });


### PR DESCRIPTION
See #30155.

Data from IMA SDK gives incorrect values required for interpolated label with currently used APIs, but a different one is equivalent.

Before:

![image](https://user-images.githubusercontent.com/254946/93280296-1fd1bb00-f77e-11ea-91b9-f758e7cf57bc.png)
