### PR TITLE
[amp-story-player] Add ShadowDOM fallback for edge

### DIFF
--- a/css/amp-story-player-iframe.css
+++ b/css/amp-story-player-iframe.css
@@ -14,15 +14,6 @@
  * limitations under the License.
  */
 
-:host {
-  all: initial;
-  display: block;
-  border-radius: 0 !important;
-  width: 360px;
-  height: 600px;
-  overflow: auto;
-}
-
 .story-player-iframe {
   height: 100%;
   width: 100%;
@@ -33,7 +24,7 @@
   position: absolute;
 }
 
-main {
+.amp-story-player-main-container {
   height: 100%;
   position: relative;
   overflow: hidden;
@@ -45,18 +36,18 @@ main {
   transition: transform 200ms cubic-bezier(0.4, 0, 0.2, 1);
 }
 
-iframe:nth-of-type(1),
-main .story-player-iframe[i-amphtml-iframe-position="0"] {
+.amp-story-player-main-container iframe:nth-of-type(1),
+.amp-story-player-main-container .story-player-iframe[i-amphtml-iframe-position="0"] {
   transform: translate3d(0, 0, 1px);
 }
 
-iframe:nth-of-type(2),
-iframe:nth-of-type(3),
-main .story-player-iframe[i-amphtml-iframe-position="1"] {
+.amp-story-player-main-container iframe:nth-of-type(2),
+.amp-story-player-main-container iframe:nth-of-type(3),
+.amp-story-player-main-container .story-player-iframe[i-amphtml-iframe-position="1"] {
   transform: translate3d(100%, 0, 0);
 }
 
-main .story-player-iframe[i-amphtml-iframe-position="-1"] {
+.amp-story-player-main-container .story-player-iframe[i-amphtml-iframe-position="-1"] {
   transform: translate3d(-100%, 0, 0);
 }
 

--- a/css/amp-story-player-iframe.css
+++ b/css/amp-story-player-iframe.css
@@ -24,7 +24,7 @@
   position: absolute;
 }
 
-.amp-story-player-main-container {
+.i-amphtml-story-player-main-container {
   height: 100%;
   position: relative;
   overflow: hidden;
@@ -36,18 +36,18 @@
   transition: transform 200ms cubic-bezier(0.4, 0, 0.2, 1);
 }
 
-.amp-story-player-main-container iframe:nth-of-type(1),
-.amp-story-player-main-container .story-player-iframe[i-amphtml-iframe-position="0"] {
+.i-amphtml-story-player-main-container iframe:nth-of-type(1),
+.i-amphtml-story-player-main-container .story-player-iframe[i-amphtml-iframe-position="0"] {
   transform: translate3d(0, 0, 1px);
 }
 
-.amp-story-player-main-container iframe:nth-of-type(2),
-.amp-story-player-main-container iframe:nth-of-type(3),
-.amp-story-player-main-container .story-player-iframe[i-amphtml-iframe-position="1"] {
+.i-amphtml-story-player-main-container iframe:nth-of-type(2),
+.i-amphtml-story-player-main-container iframe:nth-of-type(3),
+.i-amphtml-story-player-main-container .story-player-iframe[i-amphtml-iframe-position="1"] {
   transform: translate3d(100%, 0, 0);
 }
 
-.amp-story-player-main-container .story-player-iframe[i-amphtml-iframe-position="-1"] {
+.i-amphtml-story-player-main-container .story-player-iframe[i-amphtml-iframe-position="-1"] {
   transform: translate3d(-100%, 0, 0);
 }
 

--- a/css/amp-story-player.css
+++ b/css/amp-story-player.css
@@ -29,9 +29,14 @@ amp-story-player a:first-of-type {
   display: block;
 }
 
-amp-story-player a:not(:first-of-type), amp-story-player.i-amphtml-story-player-loaded a {
+amp-story-player a:not(:first-of-type) {
   visibility: hidden;
-  display: none;
+}
+
+amp-story-player.i-amphtml-story-player-loaded a:first-of-type {
+  visibility: hidden;
+  width: auto;
+  height: auto;
 }
 
 amp-story-player::after {

--- a/css/amp-story-player.css
+++ b/css/amp-story-player.css
@@ -34,9 +34,7 @@ amp-story-player a:not(:first-of-type) {
 }
 
 amp-story-player.i-amphtml-story-player-loaded a:first-of-type {
-  visibility: hidden;
-  width: auto;
-  height: auto;
+  display: none;
 }
 
 amp-story-player::after {

--- a/css/amp-story-player.css
+++ b/css/amp-story-player.css
@@ -29,8 +29,9 @@ amp-story-player a:first-of-type {
   display: block;
 }
 
-amp-story-player a:not(:first-of-type) {
+amp-story-player a:not(:first-of-type), amp-story-player.i-amphtml-story-player-loaded a {
   visibility: hidden;
+  display: none;
 }
 
 amp-story-player::after {

--- a/src/amp-story-player/amp-story-player-impl.js
+++ b/src/amp-story-player/amp-story-player-impl.js
@@ -388,9 +388,10 @@ export class AmpStoryPlayer {
   initializeShadowRoot_() {
     this.rootEl_ = this.doc_.createElement('main');
 
-    const containerToUse = getMode().test
-      ? this.element_
-      : this.element_.attachShadow({mode: 'open'});
+    const containerToUse =
+      getMode().test || !this.element_.attachShadow
+        ? this.element_
+        : this.element_.attachShadow({mode: 'open'});
 
     // Inject default styles
     const styleEl = this.doc_.createElement('style');

--- a/src/amp-story-player/amp-story-player-impl.js
+++ b/src/amp-story-player/amp-story-player-impl.js
@@ -387,7 +387,7 @@ export class AmpStoryPlayer {
   /** @private */
   initializeShadowRoot_() {
     this.rootEl_ = this.doc_.createElement('div');
-    this.rootEl_.classList.add('amp-story-player-main-container');
+    this.rootEl_.classList.add('i-amphtml-story-player-main-container');
 
     const containerToUse =
       getMode().test || !this.element_.attachShadow

--- a/src/amp-story-player/amp-story-player-impl.js
+++ b/src/amp-story-player/amp-story-player-impl.js
@@ -386,7 +386,8 @@ export class AmpStoryPlayer {
 
   /** @private */
   initializeShadowRoot_() {
-    this.rootEl_ = this.doc_.createElement('main');
+    this.rootEl_ = this.doc_.createElement('div');
+    this.rootEl_.classList.add('amp-story-player-main-container');
 
     const containerToUse =
       getMode().test || !this.element_.attachShadow
@@ -397,7 +398,7 @@ export class AmpStoryPlayer {
     const styleEl = this.doc_.createElement('style');
     styleEl.textContent = cssText;
     containerToUse.appendChild(styleEl);
-    containerToUse.appendChild(this.rootEl_);
+    containerToUse.insertBefore(this.rootEl_, containerToUse.firstElementChild);
   }
 
   /**


### PR DESCRIPTION
Closes #27358

Adds a fallback for older Edge browsers that don't support `attachShadow` by using the player element as container instead of a shadow root.

It also resets the width/height of the `<a>`, so that it doesn't push the stories below when using the player element as a container.

<!--
# Instructions:

- Pick a meaningful title for your pull request. (Use sentence case.)
  - Prefix the title with an emoji to identify what is being done. (Copy-paste the emoji from the list below.)
  - Do not overuse punctuation in the title (like `(chore):`).
  - If it is helpful, use a simple prefix (like `ProjectX: Implement some feature`).
- Enter a succinct description that says why the PR is necessary, and what it does.
  - Mention the GitHub issue that is being addressed by the pull request.
  - The keywords `Fixes`, `Closes`, or `Resolves` followed the issue number will automatically close the issue.

> NOTE: All non-trivial changes (like introducing new features or components) should have an associated issue or reference an I2I (intent-to-implement: go.amp.dev/i2i). Please read through the contribution process (go.amp.dev/contributing/code) for more information.

# Example of a good description:

- Implement aspect X
- Leave out feature Y because of A
- Improve performance by B
- Improve accessibility by C

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Reverting a previous change
♻️ Refactoring
🚮 Deleting code
🧪 Experimental code
-->
