### PR TITLE
when in ESM mode, copy the the parent runtime CSS into the friendly iframe

### DIFF
--- a/src/friendly-iframe-embed.js
+++ b/src/friendly-iframe-embed.js
@@ -692,14 +692,26 @@ export function installExtensionsInEmbed(
     })
     .then(getDelayPromise)
     .then(() => {
-      // Install runtime styles.
-      installStylesForDoc(
-        ampdoc,
-        ampSharedCss,
-        /* callback */ null,
-        /* opt_isRuntimeCss */ true,
-        /* opt_ext */ 'amp-runtime'
-      );
+      if (IS_ESM) {
+        const css = parentWin.document.querySelector('style[amp-runtime]')
+          .textContent;
+        installStylesForDoc(
+          ampdoc,
+          css,
+          /* callback */ null,
+          /* opt_isRuntimeCss */ true,
+          /* opt_ext */ 'amp-runtime'
+        );
+      } else {
+        // Install runtime styles.
+        installStylesForDoc(
+          ampdoc,
+          ampSharedCss,
+          /* callback */ null,
+          /* opt_isRuntimeCss */ true,
+          /* opt_ext */ 'amp-runtime'
+        );
+      }
     })
     .then(getDelayPromise)
     .then(() => {


### PR DESCRIPTION
This caused a major bug while we were experimenting with ads.

this would **silently** (because it is pre closure) remove the call for [installStylesForDoc](https://github.com/ampproject/amphtml/blob/master/src/friendly-iframe-embed.js#L696) in src/friendly-iframe-embed.js which would then break ads because no styles are installed in the friendly iframe.

this was only triggered in the esm build because the ["filter-imports" plugin](https://github.com/ampproject/amphtml/blob/master/build-system/babel-config/pre-closure-config.js#L32-L41) was only turned on in the esm build.