### PR TITLE
[WIP] 🐛 amp-videos in stories fire Load event

### DIFF
--- a/extensions/amp-video/0.1/amp-video.js
+++ b/extensions/amp-video/0.1/amp-video.js
@@ -597,6 +597,23 @@ class AmpVideo extends AMP.BaseElement {
       this.element.dispatchCustomEvent(mutedOrUnmutedEvent(this.muted_));
     });
 
+    // If managed by pool, let it handle the src changes and loading.
+    // Once the duration has changed, then we safely send the Load event.
+    if (this.isManagedByPool_()) {
+      const durationChangedEventUnlisten = listen(
+        video,
+        'durationchange',
+        (event) => {
+          const {target} = event;
+          if (isNaN(target.duration)) {
+            return;
+          }
+          this.element.dispatchCustomEvent(VideoEvents.LOAD);
+        }
+      );
+      this.unlisteners_.push(durationChangedEventUnlisten);
+    }
+
     this.unlisteners_.push(forwardEventsUnlisten, mutedOrUnmutedEventUnlisten);
   }
 

--- a/extensions/amp-video/0.1/amp-video.js
+++ b/extensions/amp-video/0.1/amp-video.js
@@ -362,9 +362,7 @@ class AmpVideo extends AMP.BaseElement {
         }
         throw reason;
       })
-      .then(() => {
-        this.element.dispatchCustomEvent(VideoEvents.LOAD);
-      });
+      .then(() => this.onVideoLoaded());
 
     // Resolve layoutCallback right away if the video won't preload.
     if (this.element.getAttribute('preload') === 'none') {
@@ -597,23 +595,6 @@ class AmpVideo extends AMP.BaseElement {
       this.element.dispatchCustomEvent(mutedOrUnmutedEvent(this.muted_));
     });
 
-    // If managed by pool, let it handle the src changes and loading.
-    // Once the duration has changed, then we safely send the Load event.
-    if (this.isManagedByPool_()) {
-      const durationChangedEventUnlisten = listen(
-        video,
-        'durationchange',
-        (event) => {
-          const {target} = event;
-          if (isNaN(target.duration)) {
-            return;
-          }
-          this.element.dispatchCustomEvent(VideoEvents.LOAD);
-        }
-      );
-      this.unlisteners_.push(durationChangedEventUnlisten);
-    }
-
     this.unlisteners_.push(forwardEventsUnlisten, mutedOrUnmutedEventUnlisten);
   }
 
@@ -637,6 +618,17 @@ class AmpVideo extends AMP.BaseElement {
 
     this.uninstallEventHandlers_();
     this.installEventHandlers_();
+  }
+
+  /**
+   * Once the video is loaded, with the correct duration,
+   * dispatch the `VideoEvents.LOAD` event.
+   * 
+   * This should only be called once, either by amp-video
+   * or a component that manages this one (i.e. amp-story).
+   */
+  onVideoLoaded() {
+    this.element.dispatchCustomEvent(VideoEvents.LOAD);
   }
 
   /** @override */


### PR DESCRIPTION
For #29938

For videos handled by the MediaPool within stories, the `VideoEvents.LOAD` signal was not being sent, resulting in the Video Manager never starting the `VideoPercentageTracker`.

~The fix that i've come up with is to wait for the `durationChange` event on video elements handled by the MediaPool, since it handles the srcs and loading of the video.~

We should listen to a signal from the managing component (amp-story) to signal that the video is loaded (with the correct duration), then we can dispatch the event. 