### PR TITLE
🐛 Inabox visibility reporting: listen to window resize event

### DIFF
--- a/extensions/amp-analytics/0.1/test/test-amp-analytics.js
+++ b/extensions/amp-analytics/0.1/test/test-amp-analytics.js
@@ -1469,7 +1469,10 @@ describes.realWin(
       beforeEach(() => {
         // Unfortunately need to fake sandbox analytics element's parent
         // to an AMP element
+        // Set the doc width/height to 1 to trigger visible event.
         doc.body.classList.add('i-amphtml-element');
+        doc.body.style.minWidth = '1px';
+        doc.body.style.minHeight = '1px';
       });
 
       afterEach(() => {
@@ -1750,6 +1753,11 @@ describes.realWin(
 
     describe('parentPostMessage', () => {
       let postMessageSpy;
+
+      beforeEach(() => {
+        doc.body.style.minWidth = '1px';
+        doc.body.style.minHeight = '1px';
+      });
 
       function waitForParentPostMessage(opt_max) {
         if (postMessageSpy.callCount) {

--- a/extensions/amp-analytics/0.1/test/test-visibility-manager.js
+++ b/extensions/amp-analytics/0.1/test/test-visibility-manager.js
@@ -202,6 +202,7 @@ describes.fakeWin('VisibilityManagerForDoc', {amp: true}, (env) => {
         target: otherTarget,
         intersectionRatio: 0.3,
         intersectionRect: layoutRectLtwh(0, 0, 1, 1),
+        boundingClientRect: layoutRectLtwh(1, 1, 1, 1),
       },
     ]);
     expect(root.getRootVisibility()).to.equal(0);
@@ -212,11 +213,13 @@ describes.fakeWin('VisibilityManagerForDoc', {amp: true}, (env) => {
         target: otherTarget,
         intersectionRatio: 0.5,
         intersectionRect: layoutRectLtwh(0, 0, 1, 1),
+        boundingClientRect: layoutRectLtwh(1, 1, 1, 1),
       },
       {
         target: win.document.documentElement,
         intersectionRatio: 0.3,
         intersectionRect: layoutRectLtwh(0, 0, 1, 1),
+        boundingClientRect: layoutRectLtwh(1, 1, 1, 1),
       },
     ]);
     expect(root.getRootVisibility()).to.equal(0.3);
@@ -227,6 +230,7 @@ describes.fakeWin('VisibilityManagerForDoc', {amp: true}, (env) => {
         target: win.document.documentElement,
         intersectionRatio: 0,
         intersectionRect: layoutRectLtwh(0, 0, 0, 0),
+        boundingClientRect: layoutRectLtwh(1, 1, 1, 1),
       },
     ]);
     expect(root.getRootVisibility()).to.equal(0);
@@ -549,6 +553,7 @@ describes.fakeWin('VisibilityManagerForDoc', {amp: true}, (env) => {
         target,
         intersectionRatio: 0.3,
         intersectionRect: layoutRectLtwh(0, 0, 1, 1),
+        boundingClientRect: layoutRectLtwh(1, 1, 1, 1),
       },
     ]);
     expect(model.getVisibility_()).to.equal(0.3);
@@ -593,6 +598,7 @@ describes.fakeWin('VisibilityManagerForDoc', {amp: true}, (env) => {
         target,
         intersectionRatio: 0.3,
         intersectionRect: layoutRectLtwh(0, 0, 1, 1),
+        boundingClientRect: layoutRectLtwh(1, 1, 1, 1),
       },
     ]);
     expect(model.getVisibility_()).to.equal(0.3);
@@ -603,6 +609,7 @@ describes.fakeWin('VisibilityManagerForDoc', {amp: true}, (env) => {
         target,
         intersectionRatio: -0.01,
         intersectionRect: layoutRectLtwh(0, 0, 1, 1),
+        boundingClientRect: layoutRectLtwh(1, 1, 1, 1),
       },
     ]);
     expect(model.getVisibility_()).to.equal(0);
@@ -612,6 +619,7 @@ describes.fakeWin('VisibilityManagerForDoc', {amp: true}, (env) => {
         target,
         intersectionRatio: -1000,
         intersectionRect: layoutRectLtwh(0, 0, 1, 1),
+        boundingClientRect: layoutRectLtwh(1, 1, 1, 1),
       },
     ]);
     expect(model.getVisibility_()).to.equal(0);
@@ -622,6 +630,7 @@ describes.fakeWin('VisibilityManagerForDoc', {amp: true}, (env) => {
         target,
         intersectionRatio: 1.01,
         intersectionRect: layoutRectLtwh(0, 0, 1, 1),
+        boundingClientRect: layoutRectLtwh(1, 1, 1, 1),
       },
     ]);
     expect(model.getVisibility_()).to.equal(1);
@@ -631,9 +640,53 @@ describes.fakeWin('VisibilityManagerForDoc', {amp: true}, (env) => {
         target,
         intersectionRatio: 1000,
         intersectionRect: layoutRectLtwh(0, 0, 1, 1),
+        boundingClientRect: layoutRectLtwh(1, 1, 1, 1),
       },
     ]);
     expect(model.getVisibility_()).to.equal(1);
+  });
+
+  it('should protect from zero size element', () => {
+    const target = win.document.createElement('div');
+    root.listenElement(target, {}, null, null, eventResolver);
+    expect(root.models_).to.have.length(1);
+    const model = root.models_[0];
+
+    const inOb = root.getIntersectionObserver_();
+    expect(model.getVisibility_()).to.equal(0);
+
+    // Valid element size
+    inOb.callback([
+      {
+        target,
+        intersectionRatio: 1,
+        intersectionRect: layoutRectLtwh(0, 0, 1, 1),
+        boundingClientRect: layoutRectLtwh(1, 1, 10, 10),
+      },
+    ]);
+    expect(model.getVisibility_()).to.equal(1);
+
+    // zero element size.
+    inOb.callback([
+      {
+        target,
+        intersectionRatio: 1,
+        intersectionRect: layoutRectLtwh(0, 0, 1, 1),
+        boundingClientRect: layoutRectLtwh(1, 1, 0, 10),
+      },
+    ]);
+    expect(model.getVisibility_()).to.equal(0);
+
+    // zero element size, high resolution screen.
+    inOb.callback([
+      {
+        target,
+        intersectionRatio: 0.8,
+        intersectionRect: layoutRectLtwh(0, 0, 1, 1),
+        boundingClientRect: layoutRectLtwh(1, 1, 10, 0.452),
+      },
+    ]);
+    expect(model.getVisibility_()).to.equal(0);
   });
 
   it('should listen on a element with different specs', () => {
@@ -661,6 +714,7 @@ describes.fakeWin('VisibilityManagerForDoc', {amp: true}, (env) => {
         target,
         intersectionRatio: 0.3,
         intersectionRect: layoutRectLtwh(0, 0, 1, 1),
+        boundingClientRect: layoutRectLtwh(1, 1, 1, 1),
       },
     ]);
     expect(model1.getVisibility_()).to.equal(0.3);
@@ -736,6 +790,7 @@ describes.fakeWin('VisibilityManagerForDoc', {amp: true}, (env) => {
         target,
         intersectionRatio: 0.3,
         intersectionRect: layoutRectLtwh(0, 0, 1, 1),
+        boundingClientRect: layoutRectLtwh(1, 1, 1, 1),
       },
     ]);
 
@@ -919,6 +974,7 @@ describes.realWin(
           target: embed.host,
           intersectionRatio: 0.5,
           intersectionRect: layoutRectLtwh(0, 0, 1, 1),
+          boundingClientRect: layoutRectLtwh(1, 1, 1, 1),
         },
       ]);
       expect(root.getRootVisibility()).to.equal(0.5);
@@ -931,6 +987,7 @@ describes.realWin(
           target: otherTarget,
           intersectionRatio: 0.45,
           intersectionRect: layoutRectLtwh(0, 0, 1, 1),
+          boundingClientRect: layoutRectLtwh(1, 1, 1, 1),
         },
       ]);
       expect(root.getRootVisibility()).to.equal(0.5);
@@ -957,6 +1014,7 @@ describes.realWin(
           target: embed.host,
           intersectionRatio: 0,
           intersectionRect: layoutRectLtwh(0, 0, 1, 1),
+          boundingClientRect: layoutRectLtwh(1, 1, 1, 1),
         },
       ]);
       expect(root.getRootVisibility()).to.equal(0);
@@ -969,6 +1027,7 @@ describes.realWin(
           target: otherTarget,
           intersectionRatio: 0.55,
           intersectionRect: layoutRectLtwh(0, 0, 1, 1),
+          boundingClientRect: layoutRectLtwh(1, 1, 1, 1),
         },
       ]);
       expect(root.getRootVisibility()).to.equal(0);
@@ -981,6 +1040,7 @@ describes.realWin(
           target: embed.host,
           intersectionRatio: 0.7,
           intersectionRect: layoutRectLtwh(0, 0, 1, 1),
+          boundingClientRect: layoutRectLtwh(1, 1, 1, 1),
         },
       ]);
       expect(root.getRootVisibility()).to.equal(0.7);

--- a/extensions/amp-analytics/0.1/test/test-visibility-manager.js
+++ b/extensions/amp-analytics/0.1/test/test-visibility-manager.js
@@ -232,6 +232,30 @@ describes.fakeWin('VisibilityManagerForDoc', {amp: true}, (env) => {
     expect(root.getRootVisibility()).to.equal(0);
   });
 
+  it('should switch visibility on window resize for inabox', () => {
+    win.__AMP_MODE = {runtime: 'inabox'};
+    root = new VisibilityManagerForDoc(ampdoc);
+
+    // Check observer is correctly set.
+    const inOb = root.intersectionObserver_;
+    expect(inOb).to.be.instanceOf(IntersectionObserverStub);
+    expect(inOb.elements).to.contain(win.document.documentElement);
+
+    inOb.callback([
+      {
+        target: win.document.documentElement,
+        intersectionRatio: 1,
+        intersectionRect: layoutRectLtwh(0, 0, 0, 0),
+        boundingClientRect: layoutRectLtwh(1, 1, 100, 0),
+      },
+    ]);
+
+    expect(root.getRootVisibility()).to.equal(0);
+    const resizeEvent = new Event('resize');
+    ampdoc.win.eventListeners.fire(resizeEvent);
+    expect(root.getRootVisibility()).to.equal(1);
+  });
+
   it('should switch root model to no-visibility on dispose', () => {
     expect(root.getRootVisibility()).to.equal(1);
     root.dispose();

--- a/extensions/amp-analytics/0.1/visibility-manager.js
+++ b/extensions/amp-analytics/0.1/visibility-manager.js
@@ -680,7 +680,7 @@ export class VisibilityManagerForDoc extends VisibilityManager {
      *   element: !Element,
      *   intersectionRatio: number,
      *   isVisible: boolean,
-     *   boundingClientRectTemp: ?../../../src/layout-rect.LayoutRectDef,
+     *   boundingClientRect: ?../../../src/layout-rect.LayoutRectDef,
      *   listeners: !Array<function(number)>
      * }>}
      */
@@ -906,7 +906,6 @@ export class VisibilityManagerForDoc extends VisibilityManager {
         Number(intersection.width),
         Number(intersection.height)
       );
-      // TODO(#29618): Remove after ampim investigation
       let {boundingClientRect} = change;
       boundingClientRect =
         boundingClientRect &&
@@ -926,7 +925,6 @@ export class VisibilityManagerForDoc extends VisibilityManager {
   }
 
   /**
-   * TODO(#29618): Clean up boundingClientRect after ampim investigation
    * @param {!Element} target
    * @param {number} intersectionRatio
    * @param {!../../../src/layout-rect.LayoutRectDef} intersectionRect

--- a/extensions/amp-analytics/0.1/visibility-manager.js
+++ b/extensions/amp-analytics/0.1/visibility-manager.js
@@ -679,6 +679,7 @@ export class VisibilityManagerForDoc extends VisibilityManager {
      * @private {!Object<number, {
      *   element: !Element,
      *   intersectionRatio: number,
+     *   isVisible: boolean,
      *   boundingClientRectTemp: ?../../../src/layout-rect.LayoutRectDef,
      *   listeners: !Array<function(number)>
      * }>}
@@ -701,6 +702,30 @@ export class VisibilityManagerForDoc extends VisibilityManager {
       this.unsubscribe(
         this.observe(rootElement, this.setRootVisibility.bind(this))
       );
+      // Observe inabox window resize event.
+      const resizeListener = () => {
+        const id = getElementId(rootElement);
+        const trackedRoot = this.trackedElements_[id];
+        if (!trackedRoot) {
+          return;
+        }
+        if (
+          this.ampdoc.win./*OK*/ innerHeight < 1 ||
+          this.ampdoc.win./*OK*/ innerWidth < 1
+        ) {
+          trackedRoot.isVisible = false;
+        } else {
+          trackedRoot.isVisible = true;
+        }
+        this.setRootVisibility(
+          trackedRoot.isVisible ? trackedRoot.intersectionRatio : 0
+        );
+      };
+      this.ampdoc.win.addEventListener('resize', resizeListener);
+
+      this.unsubscribe(() => {
+        this.ampdoc.win.removeEventListener('resize', resizeListener);
+      });
     } else {
       // Main document: visibility is based on the ampdoc.
       this.setRootVisibility(this.ampdoc.isVisible() ? 1 : 0);
@@ -776,11 +801,15 @@ export class VisibilityManagerForDoc extends VisibilityManager {
         element,
         intersectionRatio: 0,
         intersectionRect: null,
+        isVisible: false,
         boundingClientRectTemp: null, // TODO(#29618) Clean up
         listeners: [],
       };
       this.trackedElements_[id] = trackedElement;
-    } else if (trackedElement.intersectionRatio > 0) {
+    } else if (
+      trackedElement.intersectionRatio > 0 &&
+      trackedElement.isVisible
+    ) {
       // This has already been tracked and the `intersectionRatio` is fresh.
       listener(trackedElement.intersectionRatio);
     }
@@ -808,7 +837,12 @@ export class VisibilityManagerForDoc extends VisibilityManager {
     }
     const id = getElementId(element);
     const trackedElement = this.trackedElements_[id];
-    return (trackedElement && trackedElement.intersectionRatio) || 0;
+    return (
+      (trackedElement &&
+        trackedElement.isVisible &&
+        trackedElement.intersectionRatio) ||
+      0
+    );
   }
 
   /**
@@ -908,12 +942,26 @@ export class VisibilityManagerForDoc extends VisibilityManager {
     intersectionRatio = Math.min(Math.max(intersectionRatio, 0), 1);
     const id = getElementId(target);
     const trackedElement = this.trackedElements_[id];
+
+    // This is different from the InOb v2 isVisible definition.
+    // isVisible here only checks for element size
+    let isVisible = true;
+
+    if (boundingClientRect.width < 1 || boundingClientRect.height < 1) {
+      // Set isVisible to false when the element is not visible.
+      // Use < 1 because the width/height can
+      // be a double value on high resolution screen
+      isVisible = false;
+    }
     if (trackedElement) {
+      trackedElement.isVisible = isVisible;
       trackedElement.intersectionRatio = intersectionRatio;
       trackedElement.intersectionRect = intersectionRect;
       trackedElement.boundingClientRectTemp = boundingClientRect;
       for (let i = 0; i < trackedElement.listeners.length; i++) {
-        trackedElement.listeners[i](intersectionRatio);
+        trackedElement.listeners[i](
+          trackedElement.isVisible ? intersectionRatio : 0
+        );
       }
     }
   }

--- a/extensions/amp-analytics/0.1/visibility-manager.js
+++ b/extensions/amp-analytics/0.1/visibility-manager.js
@@ -802,7 +802,7 @@ export class VisibilityManagerForDoc extends VisibilityManager {
         intersectionRatio: 0,
         intersectionRect: null,
         isVisible: false,
-        boundingClientRectTemp: null, // TODO(#29618) Clean up
+        boundingClientRect: null,
         listeners: [],
       };
       this.trackedElements_[id] = trackedElement;
@@ -855,7 +855,7 @@ export class VisibilityManagerForDoc extends VisibilityManager {
     }
     const id = getElementId(element);
     const trackedElement = this.trackedElements_[id];
-    return trackedElement && trackedElement.boundingClientRectTemp;
+    return trackedElement && trackedElement.boundingClientRect;
   }
 
   /**
@@ -955,7 +955,7 @@ export class VisibilityManagerForDoc extends VisibilityManager {
       trackedElement.isVisible = isVisible;
       trackedElement.intersectionRatio = intersectionRatio;
       trackedElement.intersectionRect = intersectionRect;
-      trackedElement.boundingClientRectTemp = boundingClientRect;
+      trackedElement.boundingClientRect = boundingClientRect;
       for (let i = 0; i < trackedElement.listeners.length; i++) {
         trackedElement.listeners[i](
           trackedElement.isVisible ? intersectionRatio : 0


### PR DESCRIPTION
#30105 added check element size
The visibility tracking relies on the IntersectionObserverEntry, this means if the element resizes itself within the viewport, and its intersectionRatio doesn't change,  a new IntersectionObserverEntry won't be fired. 

With the current implementation, the analytics service won't be able to pick up visibility change due to element resize within the viewport. Fortunately this won't be an issue within AMP because it doesn't allow element resizing within the viewport. One exception is if it's an inabox ad served in a non AMP page. 

The fix is to add an event listener to listen to window resize event when it is inabox mode.   

cc @jeffkaufman 