### PR TITLE
Support aspect-ratio CSS for layout=responsive

### DIFF
--- a/build-system/tasks/storybook/amp-env/main.js
+++ b/build-system/tasks/storybook/amp-env/main.js
@@ -16,7 +16,10 @@
 
 // eslint-disable-next-line local/no-module-exports, no-undef
 module.exports = {
-  stories: ['../../../../extensions/**/*.*/storybook/*.amp.js'],
+  stories: [
+    '../../../../builtins/storybook/*.amp.js',
+    '../../../../extensions/**/*.*/storybook/*.amp.js',
+  ],
   addons: [
     '@storybook/addon-a11y',
     '@storybook/addon-viewport',

--- a/builtins/storybook/amp-layout-with-aspect-ratio-css.amp.js
+++ b/builtins/storybook/amp-layout-with-aspect-ratio-css.amp.js
@@ -1,0 +1,101 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as Preact from '../../src/preact';
+import {date, number, text, withKnobs} from '@storybook/addon-knobs';
+import {storiesOf} from '@storybook/preact';
+import {withA11y} from '@storybook/addon-a11y';
+import {withAmp} from '@ampproject/storybook-addon';
+
+export default {
+  title: '0/amp-layout with aspect ratio CSS',
+  decorators: [withA11y, withKnobs, withAmp],
+  parameters: {
+    experiments: ['layout-aspect-ratio-css1'],
+  },
+};
+
+export const responsiveWidthBound = () => {
+  const width = number('width', 400);
+  const height = number('height', 300);
+  return (
+    <main>
+      <style jsx global>
+        {`
+          .content {
+            background: cyan;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            width: 100%;
+            height: 100%;
+          }
+        `}
+      </style>
+      <amp-layout
+        layout="responsive"
+        width={width}
+        height={height}
+      >
+        <div className="content">
+          {width}:{height}
+        </div>
+      </amp-layout>
+    </main>
+  );
+};
+
+export const responsiveHeightBound = () => {
+  const width = number('width', 400);
+  const height = number('height', 300);
+  return (
+    <main>
+      <style jsx global>
+        {`
+          .container {
+            background: lightgray;
+            position: relative;
+            display: flex;
+            flex-direction: row;
+            height: 200px;
+          }
+          .container > amp-layout {
+            height: 100%;
+          }
+          .content {
+            background: cyan;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            width: 100%;
+            height: 100%;
+          }
+        `}
+      </style>
+      <div class="container">
+        <amp-layout
+          layout="responsive"
+          width={width}
+          height={height}
+        >
+          <div class="content">
+            {width}:{height}
+          </div>
+        </amp-layout>
+      </div>
+    </main>
+  );
+};

--- a/builtins/storybook/amp-layout-with-aspect-ratio-css.amp.js
+++ b/builtins/storybook/amp-layout-with-aspect-ratio-css.amp.js
@@ -15,8 +15,7 @@
  */
 
 import * as Preact from '../../src/preact';
-import {date, number, text, withKnobs} from '@storybook/addon-knobs';
-import {storiesOf} from '@storybook/preact';
+import {number, withKnobs} from '@storybook/addon-knobs';
 import {withA11y} from '@storybook/addon-a11y';
 import {withAmp} from '@ampproject/storybook-addon';
 
@@ -45,11 +44,7 @@ export const responsiveWidthBound = () => {
           }
         `}
       </style>
-      <amp-layout
-        layout="responsive"
-        width={width}
-        height={height}
-      >
+      <amp-layout layout="responsive" width={width} height={height}>
         <div className="content">
           {width}:{height}
         </div>
@@ -86,11 +81,7 @@ export const responsiveHeightBound = () => {
         `}
       </style>
       <div class="container">
-        <amp-layout
-          layout="responsive"
-          width={width}
-          height={height}
-        >
+        <amp-layout layout="responsive" width={width} height={height}>
           <div class="content">
             {width}:{height}
           </div>

--- a/builtins/storybook/amp-layout.amp.js
+++ b/builtins/storybook/amp-layout.amp.js
@@ -15,8 +15,7 @@
  */
 
 import * as Preact from '../../src/preact';
-import {date, number, text, withKnobs} from '@storybook/addon-knobs';
-import {storiesOf} from '@storybook/preact';
+import {number, withKnobs} from '@storybook/addon-knobs';
 import {withA11y} from '@storybook/addon-a11y';
 import {withAmp} from '@ampproject/storybook-addon';
 
@@ -42,11 +41,7 @@ export const responsive = () => {
           }
         `}
       </style>
-      <amp-layout
-        layout="responsive"
-        width={width}
-        height={height}
-      >
+      <amp-layout layout="responsive" width={width} height={height}>
         <div className="content">
           {width}:{height}
         </div>

--- a/builtins/storybook/amp-layout.amp.js
+++ b/builtins/storybook/amp-layout.amp.js
@@ -1,0 +1,92 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as Preact from '../../src/preact';
+import {date, number, text, withKnobs} from '@storybook/addon-knobs';
+import {storiesOf} from '@storybook/preact';
+import {withA11y} from '@storybook/addon-a11y';
+import {withAmp} from '@ampproject/storybook-addon';
+
+export default {
+  title: '0/amp-layout',
+  decorators: [withA11y, withKnobs, withAmp],
+};
+
+export const responsive = () => {
+  const width = number('width', 400);
+  const height = number('height', 300);
+  return (
+    <main>
+      <style jsx global>
+        {`
+          .content {
+            background: cyan;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            width: 100%;
+            height: 100%;
+          }
+        `}
+      </style>
+      <amp-layout
+        layout="responsive"
+        width={width}
+        height={height}
+      >
+        <div className="content">
+          {width}:{height}
+        </div>
+      </amp-layout>
+    </main>
+  );
+};
+
+export const intrinsic = () => {
+  const width = number('width', 800);
+  const height = number('height', 600);
+  const maxWidth = number('maxWidth', 400);
+  return (
+    <main>
+      <style jsx global>
+        {`
+          .container {
+            background: lightgray;
+            position: relative;
+            float: left;
+          }
+          .content {
+            background: cyan;
+            width: 100%;
+            height: 100%;
+          }
+        `}
+      </style>
+      <div class="container">
+        <amp-layout
+          layout="intrinsic"
+          width={width}
+          height={height}
+          style={{maxWidth}}
+        >
+          <div class="content">
+            {width}:{height}
+          </div>
+        </amp-layout>
+      </div>
+    </main>
+  );
+};

--- a/css/ampshared.css
+++ b/css/ampshared.css
@@ -155,6 +155,16 @@ i-amphtml-sizer {
   display: block !important;
 }
 
+/*
+ * Disable `i-amphtml-sizer` when aspect ratio is supported by both the
+ * borwser and the optimizer.
+ */
+@supports (aspect-ratio: 1 / 1) {
+  i-amphtml-sizer.i-amphtml-disable-for-ar {
+    display: none !important;
+  }
+}
+
 .i-amphtml-fill-content,
 .i-amphtml-blurry-placeholder {
   display: block;

--- a/test/unit/test-layout.js
+++ b/test/unit/test-layout.js
@@ -643,69 +643,69 @@ describes.realWin('Layout: aspect-ratio CSS', {amp: true}, function (env) {
     .configure()
     .enableIe()
     .run('aspect-ratio not supported', function () {
-    before(function () {
-      if (CSS.supports('aspect-ratio: 1/1')) {
-        this.skipTest();
-      }
-    });
+      before(function () {
+        if (CSS.supports('aspect-ratio: 1/1')) {
+          this.skipTest();
+        }
+      });
 
-    it('should apply legacy layout for layout=responsive', () => {
-      element.setAttribute('layout', 'responsive');
-      element.setAttribute('width', 100);
-      element.setAttribute('height', 200);
-      expect(applyStaticLayout(element)).to.equal(Layout.RESPONSIVE);
-      expect(element.style.aspectRatio).to.not.be.ok;
-      expect(element.style.width).to.equal('');
-      expect(element.style.height).to.equal('');
-      expect(element).to.have.class('i-amphtml-layout-responsive');
-      expect(element).to.have.class('i-amphtml-layout-size-defined');
-      // Sizer has been added.
-      const sizer = element.querySelector('i-amphtml-sizer');
-      expect(sizer).to.be.ok;
-      expect(getComputedStyle(sizer).display).to.equal('block');
-    });
+      it('should apply legacy layout for layout=responsive', () => {
+        element.setAttribute('layout', 'responsive');
+        element.setAttribute('width', 100);
+        element.setAttribute('height', 200);
+        expect(applyStaticLayout(element)).to.equal(Layout.RESPONSIVE);
+        expect(element.style.aspectRatio).to.not.be.ok;
+        expect(element.style.width).to.equal('');
+        expect(element.style.height).to.equal('');
+        expect(element).to.have.class('i-amphtml-layout-responsive');
+        expect(element).to.have.class('i-amphtml-layout-size-defined');
+        // Sizer has been added.
+        const sizer = element.querySelector('i-amphtml-sizer');
+        expect(sizer).to.be.ok;
+        expect(getComputedStyle(sizer).display).to.equal('block');
+      });
 
-    it('should pass through SSR sizer for responsive layout', () => {
-      element.setAttribute('i-amphtml-layout', 'responsive');
-      element.appendChild(ssrSizer);
-      expect(applyStaticLayout(element)).to.equal(Layout.RESPONSIVE);
-      expect(element.sizerElement).to.equal(ssrSizer);
-      expect(ssrSizer.getAttribute('slot')).to.equal('i-amphtml-svc');
-      expect(getComputedStyle(ssrSizer).display).to.equal('block');
+      it('should pass through SSR sizer for responsive layout', () => {
+        element.setAttribute('i-amphtml-layout', 'responsive');
+        element.appendChild(ssrSizer);
+        expect(applyStaticLayout(element)).to.equal(Layout.RESPONSIVE);
+        expect(element.sizerElement).to.equal(ssrSizer);
+        expect(ssrSizer.getAttribute('slot')).to.equal('i-amphtml-svc');
+        expect(getComputedStyle(ssrSizer).display).to.equal('block');
+      });
     });
-  });
 
   describe
     .configure()
     .enableIe()
     .run('aspect-ratio supported', function () {
-    before(function () {
-      if (!CSS.supports('aspect-ratio: 1/1')) {
-        this.skipTest();
-      }
-    });
+      before(function () {
+        if (!CSS.supports('aspect-ratio: 1/1')) {
+          this.skipTest();
+        }
+      });
 
-    it('should apply layout=responsive via aspect-ratio', () => {
-      element.setAttribute('layout', 'responsive');
-      element.setAttribute('width', 100);
-      element.setAttribute('height', 200);
-      expect(applyStaticLayout(element)).to.equal(Layout.RESPONSIVE);
-      expect(element.style.aspectRatio).to.equal('100 / 200');
-      expect(element.style.width).to.equal('');
-      expect(element.style.height).to.equal('');
-      expect(element).to.have.class('i-amphtml-layout-responsive');
-      expect(element).to.have.class('i-amphtml-layout-size-defined');
-      // No sizer added.
-      expect(element.querySelector('i-amphtml-sizer')).to.be.null;
-    });
+      it('should apply layout=responsive via aspect-ratio', () => {
+        element.setAttribute('layout', 'responsive');
+        element.setAttribute('width', 100);
+        element.setAttribute('height', 200);
+        expect(applyStaticLayout(element)).to.equal(Layout.RESPONSIVE);
+        expect(element.style.aspectRatio).to.equal('100 / 200');
+        expect(element.style.width).to.equal('');
+        expect(element.style.height).to.equal('');
+        expect(element).to.have.class('i-amphtml-layout-responsive');
+        expect(element).to.have.class('i-amphtml-layout-size-defined');
+        // No sizer added.
+        expect(element.querySelector('i-amphtml-sizer')).to.be.null;
+      });
 
-    it('should disable SSR sizer for responsive layout', () => {
-      element.setAttribute('i-amphtml-layout', 'responsive');
-      element.appendChild(ssrSizer);
-      expect(applyStaticLayout(element)).to.equal(Layout.RESPONSIVE);
-      expect(element.sizerElement).to.equal(ssrSizer);
-      expect(ssrSizer.getAttribute('slot')).to.equal('i-amphtml-svc');
-      expect(getComputedStyle(ssrSizer).display).to.equal('none');
+      it('should disable SSR sizer for responsive layout', () => {
+        element.setAttribute('i-amphtml-layout', 'responsive');
+        element.appendChild(ssrSizer);
+        expect(applyStaticLayout(element)).to.equal(Layout.RESPONSIVE);
+        expect(element.sizerElement).to.equal(ssrSizer);
+        expect(ssrSizer.getAttribute('slot')).to.equal('i-amphtml-svc');
+        expect(getComputedStyle(ssrSizer).display).to.equal('none');
+      });
     });
-  });
 });

--- a/test/unit/test-layout.js
+++ b/test/unit/test-layout.js
@@ -639,7 +639,10 @@ describes.realWin('Layout: aspect-ratio CSS', {amp: true}, function (env) {
     resetShouldUseAspectRatioCssForTesting();
   });
 
-  describe('aspect-ratio not supported', function () {
+  describe
+    .configure()
+    .enableIe()
+    .run('aspect-ratio not supported', function () {
     before(function () {
       if (CSS.supports('aspect-ratio: 1/1')) {
         this.skipTest();
@@ -672,7 +675,10 @@ describes.realWin('Layout: aspect-ratio CSS', {amp: true}, function (env) {
     });
   });
 
-  describe('aspect-ratio supported', function () {
+  describe
+    .configure()
+    .enableIe()
+    .run('aspect-ratio supported', function () {
     before(function () {
       if (!CSS.supports('aspect-ratio: 1/1')) {
         this.skipTest();

--- a/test/unit/test-layout.js
+++ b/test/unit/test-layout.js
@@ -24,7 +24,9 @@ import {
   isLoadingAllowed,
   parseLayout,
   parseLength,
+  resetShouldUseAspectRatioCssForTesting,
 } from '../../src/layout';
+import {toggleExperiment} from '../../src/experiments';
 
 describe('Layout', () => {
   let div;
@@ -611,5 +613,93 @@ describe('Layout', () => {
     const clone = div.cloneNode(true);
     expect(applyStaticLayout(clone)).to.equal(Layout.RESPONSIVE);
     expect(clone.querySelectorAll('i-amphtml-sizer')).to.have.length(1);
+  });
+});
+
+describes.realWin('Layout: aspect-ratio CSS', {amp: true}, function (env) {
+  let win, doc;
+  let element;
+  let ssrSizer;
+
+  beforeEach(() => {
+    win = env.win;
+    doc = win.document;
+    toggleExperiment(win, 'layout-aspect-ratio-css', true, true);
+    resetShouldUseAspectRatioCssForTesting();
+
+    element = doc.createElement('amp-element');
+    element.classList.add('i-amphtml-element');
+    doc.body.appendChild(element);
+
+    ssrSizer = doc.createElement('i-amphtml-sizer');
+    ssrSizer.classList.add('i-amphtml-disable-for-ar');
+  });
+
+  afterEach(() => {
+    resetShouldUseAspectRatioCssForTesting();
+  });
+
+  describe('aspect-ratio not supported', function () {
+    before(function () {
+      if (CSS.supports('aspect-ratio: 1/1')) {
+        this.skipTest();
+      }
+    });
+
+    it('should apply legacy layout for layout=responsive', () => {
+      element.setAttribute('layout', 'responsive');
+      element.setAttribute('width', 100);
+      element.setAttribute('height', 200);
+      expect(applyStaticLayout(element)).to.equal(Layout.RESPONSIVE);
+      expect(element.style.aspectRatio).to.not.be.ok;
+      expect(element.style.width).to.equal('');
+      expect(element.style.height).to.equal('');
+      expect(element).to.have.class('i-amphtml-layout-responsive');
+      expect(element).to.have.class('i-amphtml-layout-size-defined');
+      // Sizer has been added.
+      const sizer = element.querySelector('i-amphtml-sizer');
+      expect(sizer).to.be.ok;
+      expect(getComputedStyle(sizer).display).to.equal('block');
+    });
+
+    it('should pass through SSR sizer for responsive layout', () => {
+      element.setAttribute('i-amphtml-layout', 'responsive');
+      element.appendChild(ssrSizer);
+      expect(applyStaticLayout(element)).to.equal(Layout.RESPONSIVE);
+      expect(element.sizerElement).to.equal(ssrSizer);
+      expect(ssrSizer.getAttribute('slot')).to.equal('i-amphtml-svc');
+      expect(getComputedStyle(ssrSizer).display).to.equal('block');
+    });
+  });
+
+  describe('aspect-ratio supported', function () {
+    before(function () {
+      if (!CSS.supports('aspect-ratio: 1/1')) {
+        this.skipTest();
+      }
+    });
+
+    it('should apply layout=responsive via aspect-ratio', () => {
+      element.setAttribute('layout', 'responsive');
+      element.setAttribute('width', 100);
+      element.setAttribute('height', 200);
+      expect(applyStaticLayout(element)).to.equal(Layout.RESPONSIVE);
+      expect(element.style.aspectRatio).to.equal('100 / 200');
+      expect(element.style.width).to.equal('');
+      expect(element.style.height).to.equal('');
+      expect(element).to.have.class('i-amphtml-layout-responsive');
+      expect(element).to.have.class('i-amphtml-layout-size-defined');
+      // No sizer added.
+      expect(element.querySelector('i-amphtml-sizer')).to.be.null;
+    });
+
+    it('should disable SSR sizer for responsive layout', () => {
+      element.setAttribute('i-amphtml-layout', 'responsive');
+      element.appendChild(ssrSizer);
+      expect(applyStaticLayout(element)).to.equal(Layout.RESPONSIVE);
+      expect(element.sizerElement).to.equal(ssrSizer);
+      expect(ssrSizer.getAttribute('slot')).to.equal('i-amphtml-svc');
+      expect(getComputedStyle(ssrSizer).display).to.equal('none');
+    });
   });
 });

--- a/tools/experiments/experiments-config.js
+++ b/tools/experiments/experiments-config.js
@@ -294,4 +294,9 @@ export const EXPERIMENTS = [
     name: 'Move ads placement into layoutCallback',
     spec: 'https://github.com/ampproject/amphtml/issues/27068',
   },
+  {
+    id: 'layout-aspect-ratio-css',
+    name: 'Responsive layouts implemented via aspect-ratio CSS',
+    spec: 'https://github.com/ampproject/amphtml/issues/30291',
+  },
 ];


### PR DESCRIPTION
Partial for #30291

This pull request implements two features:

1. When `aspect-ratio` is supported, the `layout=responsive` is implemented via this property and the private `sizer` element is not added.
2. The optimized AMP page can supply both `sizer` and `aspect-ratio` and AMP Runtime will hide the `sizer` if the browser supports the `aspect-ratio` CSS.

Additionally added few storybooks for the responsive layouts, with and without aspect-ratio support.
