### PR TITLE
🏗  Lint for $ in animation-name

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -128,6 +128,7 @@ module.exports = {
     'local/html-template': 2,
     'local/is-experiment-on': 2,
     'local/json-configuration': 2,
+    'local/jss-animation-name': 2,
     'local/no-array-destructuring': 2,
     'local/no-arrow-on-register-functions': 2,
     'local/no-bigint': 2,

--- a/build-system/eslint-rules/jss-animation-name.js
+++ b/build-system/eslint-rules/jss-animation-name.js
@@ -47,7 +47,7 @@ module.exports = function (context) {
           node: node.value,
           message:
             `Use string literals for ${keyName} values.` +
-            (keyName == 'animation'
+            (keyName === 'animation'
               ? '\n(Independent animation-* properties (e.g. animation-delay) are exempt from this rule, except for animation-name.)'
               : ''),
         });

--- a/build-system/eslint-rules/jss-animation-name.js
+++ b/build-system/eslint-rules/jss-animation-name.js
@@ -22,10 +22,12 @@
  * Bad:
  *   const JSS = {
  *     foo: {animationName: 'bar-global'},
+ *     foo: {animation: '0.5s bar-global infinite'},
  *   };
  * Good:
  *   const JSS = {
  *     foo: {animationName: '$bar-local'},
+ *     foo: {animation: '0.5s $bar-local infinite'},
  *   };
  * @return {!Object}
  */

--- a/build-system/eslint-rules/jss-animation-name.js
+++ b/build-system/eslint-rules/jss-animation-name.js
@@ -44,7 +44,7 @@ module.exports = function (context) {
       if (typeof node.value.value !== 'string') {
         context.report({
           loc: node.value.loc,
-          message: `Use string literals for ${node.key.name} values.`,
+          message: `Use string literals for ${keyName} values.`,
         });
         return;
       }

--- a/build-system/eslint-rules/jss-animation-name.js
+++ b/build-system/eslint-rules/jss-animation-name.js
@@ -44,7 +44,7 @@ module.exports = function (context) {
       }
       if (typeof node.value.value !== 'string') {
         context.report({
-          loc: node.value.loc,
+          node: node.value,
           message: `Use string literals for ${keyName} values.`,
         });
         return;

--- a/build-system/eslint-rules/jss-animation-name.js
+++ b/build-system/eslint-rules/jss-animation-name.js
@@ -51,7 +51,7 @@ module.exports = function (context) {
           message:
             `Use string literals for ${keyName} values.` +
             (isAnimation
-              ? '\n(Independent animation-* properties (e.g. animation-delay) are exempt from this rule, except for animation-name.)'
+              ? '\n(animation-* properties other than animation-name are exempt from this rule.)'
               : ''),
         });
         return;

--- a/build-system/eslint-rules/jss-animation-name.js
+++ b/build-system/eslint-rules/jss-animation-name.js
@@ -55,7 +55,9 @@ module.exports = {
         ) {
           context.report({
             loc: node.value.loc,
-            message: `The animation name in property ${keyName} should start with $. This scopes it to a keyframes rule present in this module.`,
+            message:
+              `The animation name in property ${keyName} should start with $.\n` +
+              'This scopes it to a keyframes rule present in this module.',
             fix:
               keyName !== 'animationName'
                 ? undefined

--- a/build-system/eslint-rules/jss-animation-name.js
+++ b/build-system/eslint-rules/jss-animation-name.js
@@ -1,0 +1,73 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+/**
+ * Prevents animation/animationName from using global names. They should
+ * always be scoped with $.
+ *
+ * Bad:
+ *   const JSS = {
+ *     foo: {animationName: 'bar-global'},
+ *   };
+ * Good:
+ *   const JSS = {
+ *     foo: {animationName: 'bar-local'},
+ *     '@keyframes bar-local': {},
+ *   };
+ * @return {!Object}
+ */
+module.exports = {
+  meta: {fixable: 'code'},
+  create: function (context) {
+    return {
+      Property(node) {
+        if (!/\.jss.js$/.test(context.getFilename())) {
+          return;
+        }
+        const keyName = node.key.name || node.key.value;
+        if (keyName !== 'animationName' && keyName !== 'animation') {
+          return;
+        }
+        if (typeof node.value.value !== 'string') {
+          context.report({
+            loc: node.value.loc,
+            message: `Use string literals for ${node.key.name} values.`,
+          });
+          return;
+        }
+        if (
+          (keyName === 'animationName' && !/^\$/.test(node.value.value)) ||
+          (keyName === 'animation' && node.value.value.indexOf('$') < 0)
+        ) {
+          context.report({
+            loc: node.value.loc,
+            message: `The animation name in property ${keyName} should start with $. This scopes it to a keyframes rule present in this module.`,
+            fix:
+              keyName !== 'animationName'
+                ? undefined
+                : (fixer) => {
+                    return fixer.replaceText(
+                      node.value,
+                      `'$${node.value.value}'`
+                    );
+                  },
+          });
+        }
+      },
+    };
+  },
+};

--- a/build-system/eslint-rules/jss-animation-name.js
+++ b/build-system/eslint-rules/jss-animation-name.js
@@ -50,7 +50,7 @@ module.exports = function (context) {
       }
       if (
         (keyName === 'animationName' && !/^\$/.test(node.value.value)) ||
-        (keyName === 'animation' && node.value.value.indexOf('$') < 0)
+        (keyName === 'animation' && !/(^| )\$/.test(node.value.value))
       ) {
         context.report({
           loc: node.value.loc,

--- a/build-system/eslint-rules/jss-animation-name.js
+++ b/build-system/eslint-rules/jss-animation-name.js
@@ -37,6 +37,7 @@ module.exports = function (context) {
       if (!/\.jss.js$/.test(context.getFilename())) {
         return;
       }
+      // Could be {key: val} identifier or {'key': val} string
       const keyName = node.key.name || node.key.value;
       if (keyName !== 'animationName' && keyName !== 'animation') {
         return;

--- a/build-system/eslint-rules/jss-animation-name.js
+++ b/build-system/eslint-rules/jss-animation-name.js
@@ -45,7 +45,11 @@ module.exports = function (context) {
       if (typeof node.value.value !== 'string') {
         context.report({
           node: node.value,
-          message: `Use string literals for ${keyName} values.`,
+          message:
+            `Use string literals for ${keyName} values.` +
+            (keyName == 'animation'
+              ? '\n(Independent animation-* properties (e.g. animation-delay) are exempt from this rule, except for animation-name.)'
+              : ''),
         });
         return;
       }

--- a/build-system/eslint-rules/jss-animation-name.js
+++ b/build-system/eslint-rules/jss-animation-name.js
@@ -54,7 +54,7 @@ module.exports = function (context) {
         (keyName === 'animation' && !/(^| )\$/.test(node.value.value))
       ) {
         context.report({
-          loc: node.value.loc,
+          node: node.value,
           message: `The animation name in property ${keyName} should start with $${
             keyName === 'animationName' ? ` (e.g. $${node.value.value})` : ''
           }.\nThis scopes it to a @keyframes rule present in this module.`,

--- a/build-system/eslint-rules/jss-animation-name.js
+++ b/build-system/eslint-rules/jss-animation-name.js
@@ -25,8 +25,7 @@
  *   };
  * Good:
  *   const JSS = {
- *     foo: {animationName: 'bar-local'},
- *     '@keyframes bar-local': {},
+ *     foo: {animationName: '$bar-local'},
  *   };
  * @return {!Object}
  */

--- a/build-system/eslint-rules/jss-animation-name.js
+++ b/build-system/eslint-rules/jss-animation-name.js
@@ -39,7 +39,10 @@ module.exports = function (context) {
       }
       // Could be {key: val} identifier or {'key': val} string
       const keyName = node.key.name || node.key.value;
-      if (keyName !== 'animationName' && keyName !== 'animation') {
+      const isAnimation = keyName === 'animation';
+      const isAnimationName =
+        keyName === 'animationName' || keyName === 'animation-name';
+      if (!isAnimationName && !isAnimation) {
         return;
       }
       if (typeof node.value.value !== 'string') {
@@ -47,20 +50,20 @@ module.exports = function (context) {
           node: node.value,
           message:
             `Use string literals for ${keyName} values.` +
-            (keyName === 'animation'
+            (isAnimation
               ? '\n(Independent animation-* properties (e.g. animation-delay) are exempt from this rule, except for animation-name.)'
               : ''),
         });
         return;
       }
       if (
-        (keyName === 'animationName' && !/^\$/.test(node.value.value)) ||
-        (keyName === 'animation' && !/(^| )\$/.test(node.value.value))
+        (isAnimationName && !/^\$/.test(node.value.value)) ||
+        (isAnimation && !/(^| )\$/.test(node.value.value))
       ) {
         context.report({
           node: node.value,
           message: `The animation name in property ${keyName} should start with $${
-            keyName === 'animationName' ? ` (e.g. $${node.value.value})` : ''
+            isAnimationName ? ` (e.g. $${node.value.value})` : ''
           }.\nThis scopes it to a @keyframes rule present in this module.`,
         });
       }

--- a/build-system/eslint-rules/jss-animation-name.js
+++ b/build-system/eslint-rules/jss-animation-name.js
@@ -29,46 +29,34 @@
  *   };
  * @return {!Object}
  */
-module.exports = {
-  meta: {fixable: 'code'},
-  create: function (context) {
-    return {
-      Property(node) {
-        if (!/\.jss.js$/.test(context.getFilename())) {
-          return;
-        }
-        const keyName = node.key.name || node.key.value;
-        if (keyName !== 'animationName' && keyName !== 'animation') {
-          return;
-        }
-        if (typeof node.value.value !== 'string') {
-          context.report({
-            loc: node.value.loc,
-            message: `Use string literals for ${node.key.name} values.`,
-          });
-          return;
-        }
-        if (
-          (keyName === 'animationName' && !/^\$/.test(node.value.value)) ||
-          (keyName === 'animation' && node.value.value.indexOf('$') < 0)
-        ) {
-          context.report({
-            loc: node.value.loc,
-            message:
-              `The animation name in property ${keyName} should start with $.\n` +
-              'This scopes it to a keyframes rule present in this module.',
-            fix:
-              keyName !== 'animationName'
-                ? undefined
-                : (fixer) => {
-                    return fixer.replaceText(
-                      node.value,
-                      `'$${node.value.value}'`
-                    );
-                  },
-          });
-        }
-      },
-    };
-  },
+module.exports = function (context) {
+  return {
+    Property(node) {
+      if (!/\.jss.js$/.test(context.getFilename())) {
+        return;
+      }
+      const keyName = node.key.name || node.key.value;
+      if (keyName !== 'animationName' && keyName !== 'animation') {
+        return;
+      }
+      if (typeof node.value.value !== 'string') {
+        context.report({
+          loc: node.value.loc,
+          message: `Use string literals for ${node.key.name} values.`,
+        });
+        return;
+      }
+      if (
+        (keyName === 'animationName' && !/^\$/.test(node.value.value)) ||
+        (keyName === 'animation' && node.value.value.indexOf('$') < 0)
+      ) {
+        context.report({
+          loc: node.value.loc,
+          message: `The animation name in property ${keyName} should start with $${
+            keyName === 'animationName' ? ` (e.g. $${node.value.value})` : ''
+          }.\nThis scopes it to a @keyframes rule present in this module.`,
+        });
+      }
+    },
+  };
 };


### PR DESCRIPTION
Will error:

```diff
  const JSS = {
    foo: {
+ // The animation name in property animationName should start with $ (e.g. $foo).
+ // This scopes it to a keyframes rule present in this module.
      animationName: 'bar',
+ // ----------------^
    },
  };
```

```diff
  const JSS = {
    foo: {
+ // The animation name in property animation should start with $.
+ // This scopes it to a keyframes rule present in this module.
      animation: 'bar linear 0.5s',
+ // ------------^
    },
  };
```