### PR TITLE
🚀 Safari 14 Fixed the Web Animations API implementation

### DIFF
--- a/extensions/amp-animation/0.1/install-polyfill.js
+++ b/extensions/amp-animation/0.1/install-polyfill.js
@@ -32,10 +32,11 @@ export function installWebAnimationsIfNecessary(ampdoc) {
   polyfillPromiseMap.set(ampdoc, promise);
 
   const {win} = ampdoc;
-  if (Services.platformFor(win).isSafari()) {
+  const platform = Services.platformFor(win);
+  if (platform.isSafari() && platform.getMajorVersion() < 14) {
     /*
-      Force Web Animations polyfill on Safari.
-      Native Web Animations on WebKit do not respect easing for individual
+      Force Web Animations polyfill on Safari versions before 14.
+      Native Web Animations on WebKit did not respect easing for individual
       keyframes and break overall timing. See https://go.amp.dev/issue/27762 and
       https://bugs.webkit.org/show_bug.cgi?id=210526
       */


### PR DESCRIPTION
We need only polyfill when the major version of Safari is less than 14.

Example of Safari not polyfilled and working as expected.
![safari-no-polyfill](https://user-images.githubusercontent.com/61764/93642167-78899980-f9b2-11ea-9ad4-5a237daa214a.gif)

Example inside Web Story.
![safari-no-polyfill-story](https://user-images.githubusercontent.com/61764/93642406-e766f280-f9b2-11ea-9a0f-03377d9ce7a7.gif)
