### PR TITLE
🚀 FID improvement use isInputPending if available for chunk.

### DIFF
--- a/src/chunk.js
+++ b/src/chunk.js
@@ -309,10 +309,9 @@ class Chunks {
     /** @private {number} */
     this.durationOfLastExecution_ = 0;
     /** @private @const {boolean} */
-    this.supportsInputPending_ = !!(
-      this.win_.navigator.scheduling &&
-      this.win_.navigator.scheduling.isInputPending
-    );
+    this.supportsInputPending_ =
+      'scheduling' in this.win_.navigator &&
+      'isInputPending' in this.win_.navigator.scheduling;
 
     /**
      * Set to true if we scheduled a macro or micro task to execute the next

--- a/src/chunk.js
+++ b/src/chunk.js
@@ -462,7 +462,8 @@ class Chunks {
       !allowLongTasks &&
       this.bodyIsVisible_ &&
       (this.supportsInputPending_
-        ? this.win_.navigator.scheduling.isInputPending()
+        ? /** @type {!{scheduling: {isInputPending: Function}}} */ (this.win_
+            .navigator).scheduling.isInputPending()
         : this.durationOfLastExecution_ > 5)
     ) {
       this.durationOfLastExecution_ = 0;

--- a/src/chunk.js
+++ b/src/chunk.js
@@ -309,9 +309,10 @@ class Chunks {
     /** @private {number} */
     this.durationOfLastExecution_ = 0;
     /** @private @const {boolean} */
-    this.supportsInputPending_ =
-      'scheduling' in this.win_.navigator &&
-      'isInputPending' in this.win_.navigator.scheduling;
+    this.supportsInputPending_ = !!(
+      this.win_.navigator.scheduling &&
+      this.win_.navigator.scheduling.isInputPending
+    );
 
     /**
      * Set to true if we scheduled a macro or micro task to execute the next

--- a/src/chunk.js
+++ b/src/chunk.js
@@ -31,9 +31,6 @@ const TAG = 'CHUNK';
  */
 let deactivated = /nochunking=1/.test(self.location.hash);
 let allowLongTasks = false;
-const supportsInputPending =
-  'scheduling' in self.navigator &&
-  'isInputPending' in self.navigator.scheduling;
 
 /**
  * @const {!Promise}
@@ -311,6 +308,10 @@ class Chunks {
     this.boundExecute_ = this.execute_.bind(this);
     /** @private {number} */
     this.durationOfLastExecution_ = 0;
+    /** @private @const {boolean} */
+    this.supportsInputPending_ =
+      'scheduling' in this.win_.navigator &&
+      'isInputPending' in this.win_.navigator.scheduling;
 
     /**
      * Set to true if we scheduled a macro or micro task to execute the next
@@ -459,8 +460,8 @@ class Chunks {
     if (
       !allowLongTasks &&
       this.bodyIsVisible_ &&
-      (supportsInputPending
-        ? self.navigator.scheduling.isInputPending()
+      (this.supportsInputPending_
+        ? this.win_.navigator.scheduling.isInputPending()
         : this.durationOfLastExecution_ > 5)
     ) {
       this.durationOfLastExecution_ = 0;

--- a/src/chunk.js
+++ b/src/chunk.js
@@ -456,7 +456,7 @@ class Chunks {
   executeAsap_(idleDeadline) {
     // If the user-agent supports isInputPending, use it to break to a macro task as necessary.
     // Otherwise If we've spent over 5 millseconds executing the
-    // last instruction yeild back to the main thread.
+    // last instruction yield back to the main thread.
     // 5 milliseconds is a magic number.
     if (
       !allowLongTasks &&

--- a/test/unit/test-chunk.js
+++ b/test/unit/test-chunk.js
@@ -414,7 +414,7 @@ describe('long tasks', () => {
         ).macroAfterLongTask_ = true;
       });
 
-      it('should not run macro tasks with invisible bodys', (done) => {
+      it('should not break out of microtask loop when body is invisible', (done) => {
         startupChunk(env.win.document, complete('init', true));
         startupChunk(env.win.document, complete('a', true));
         startupChunk(env.win.document, complete('b', true));
@@ -547,7 +547,7 @@ describe('isInputPending usage', () => {
         ).macroAfterLongTask_ = true;
       });
 
-      it('should not run macro tasks with invisible bodys', (done) => {
+      it('should not break out of microtask loop when body is invisible', (done) => {
         startupChunk(env.win.document, complete('init', true));
         startupChunk(env.win.document, complete('a', true));
         startupChunk(env.win.document, complete('b', true));


### PR DESCRIPTION
`isInputPending` is launching soon. This API is a better replacement for our current mechanism tracking the time spent in a current macrotask during chunking.

https://groups.google.com/a/chromium.org/g/blink-dev/c/8Vt2atMrNNs/m/1DGx9DKsBwAJ

This is a draft PR, and I'll continue iterating on it on Monday.