### PR TITLE
🧪 Enable build-in-chunks experiment in canary-config.json

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -36,5 +36,6 @@
   "version-locking": 1,
   "amp-ad-no-center-css": 0,
   "analytics-chunks": 1,
-  "render-on-idle-fix": 1
+  "render-on-idle-fix": 1,
+  "build-in-chunks": 1
 }


### PR DESCRIPTION
Enables experiment from https://github.com/ampproject/amphtml/pull/28553 to limit number of elements that can be built in a single pass. This issue is affecting amp.dev and causing a long task .