### PR TITLE
dependencies: bump worker-dom

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@ampproject/animations": "0.2.2",
     "@ampproject/toolbox-cache-url": "2.5.4",
     "@ampproject/viewer-messaging": "1.1.0",
-    "@ampproject/worker-dom": "0.27.2",
+    "@ampproject/worker-dom": "0.27.3",
     "dompurify": "2.0.7",
     "intersection-observer": "0.11.0",
     "jss": "10.3.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@ampproject/animations": "0.2.2",
     "@ampproject/toolbox-cache-url": "2.5.4",
     "@ampproject/viewer-messaging": "1.1.0",
-    "@ampproject/worker-dom": "0.27.1",
+    "@ampproject/worker-dom": "0.27.2",
     "dompurify": "2.0.7",
     "intersection-observer": "0.11.0",
     "jss": "10.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -104,10 +104,10 @@
   resolved "https://registry.yarnpkg.com/@ampproject/viewer-messaging/-/viewer-messaging-1.1.0.tgz#404f92c5754bac61014ed2272dd5e87174b9af84"
   integrity sha512-SoR1dGl2Pl8eJlyGCU/9Gz/orOggmW/13wUh7NnuGvDYqLdlhnRBzvEGqEAlq/fQKel9ZM6RNtu85Jw8WC3K2Q==
 
-"@ampproject/worker-dom@0.27.1":
-  version "0.27.1"
-  resolved "https://registry.yarnpkg.com/@ampproject/worker-dom/-/worker-dom-0.27.1.tgz#42b1e3a87e982fe184791681e3b197a8eae42455"
-  integrity sha512-LOsZDYiOJSlA6b4yu83PeiY38gjZSZvGP4eYG49ME55yFhl2EinwmIIWf7+6kySSfriXxuTdWHWCH84qurlwSQ==
+"@ampproject/worker-dom@0.27.2":
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/@ampproject/worker-dom/-/worker-dom-0.27.2.tgz#165bea4f00b693a3dcb186adab534267ef0374b6"
+  integrity sha512-/XcCnwKQacYAdSbJuAr7u+xMjKzUDWQdOaxzPZNoemrYZ8CV2Ma+TOiQNCh8sjgfm984j6W6LQaGK5CqVOoUIw==
 
 "@ava/babel-plugin-throws-helper@^4.0.0":
   version "4.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -104,10 +104,10 @@
   resolved "https://registry.yarnpkg.com/@ampproject/viewer-messaging/-/viewer-messaging-1.1.0.tgz#404f92c5754bac61014ed2272dd5e87174b9af84"
   integrity sha512-SoR1dGl2Pl8eJlyGCU/9Gz/orOggmW/13wUh7NnuGvDYqLdlhnRBzvEGqEAlq/fQKel9ZM6RNtu85Jw8WC3K2Q==
 
-"@ampproject/worker-dom@0.27.2":
-  version "0.27.2"
-  resolved "https://registry.yarnpkg.com/@ampproject/worker-dom/-/worker-dom-0.27.2.tgz#165bea4f00b693a3dcb186adab534267ef0374b6"
-  integrity sha512-/XcCnwKQacYAdSbJuAr7u+xMjKzUDWQdOaxzPZNoemrYZ8CV2Ma+TOiQNCh8sjgfm984j6W6LQaGK5CqVOoUIw==
+"@ampproject/worker-dom@0.27.3":
+  version "0.27.3"
+  resolved "https://registry.yarnpkg.com/@ampproject/worker-dom/-/worker-dom-0.27.3.tgz#1c5a46b7ddf6e0499d8f51e06017ce6f80f60203"
+  integrity sha512-BpSMiEVnSr7VVlEWkf5uE9BAzK5SdoW5d+MZXvBqXN5CGwqol3BmNT15dd2E62D/sE6cc6xk2z+tsgwUaFjVKA==
 
 "@ava/babel-plugin-throws-helper@^4.0.0":
   version "4.0.0"


### PR DESCRIPTION
include partial support for innerHTML entity decoding.