### PR TITLE
🚮 Remove version-locking in prod builds

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -33,7 +33,6 @@
   "remove-task-timeout": 0,
   "swg-gpay-api": 1,
   "swg-gpay-native": 1,
-  "version-locking": 1,
   "amp-ad-no-center-css": 0,
   "analytics-chunks": 1,
   "render-on-idle-fix": 1

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -33,7 +33,6 @@
   "pump-early-frame": 1,
   "swg-gpay-api": 1,
   "swg-gpay-native": 1,
-  "version-locking": 1,
   "amp-ad-no-center-css": 0,
   "analytics-chunks": 1
 }

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -451,16 +451,12 @@ export function adoptShadowMode(global) {
  * If they are different, returns false, and initiates a load
  * of the respective extension via a versioned URL.
  *
- * This is currently guarded by the 'version-locking' experiment.
- * With this active, all scripts in a given page are guaranteed
- * to have the same AMP release version.
- *
  * @param {!Window} win
  * @param {function(!Object, !Object)|!ExtensionPayload} fnOrStruct
  * @return {boolean}
  */
 function maybeLoadCorrectVersion(win, fnOrStruct) {
-  if (!isExperimentOn(win, 'version-locking')) {
+  if (getMode().localDev && isExperimentOn(win, 'disable-version-locking')) {
     return false;
   }
   if (typeof fnOrStruct == 'function') {

--- a/test/unit/test-runtime.js
+++ b/test/unit/test-runtime.js
@@ -321,6 +321,7 @@ describes.fakeWin(
           expect(amp).to.equal(win.AMP);
           progress += 'HIGH';
         },
+        v: '$internalRuntimeVersion$',
       });
       expect(queueExtensions).to.have.length(2);
       expect(progress).to.equal('');
@@ -345,6 +346,7 @@ describes.fakeWin(
               expect(amp).to.equal(win.AMP);
               progress += 'A';
             },
+            v: '$internalRuntimeVersion$',
           });
           runChunksForTesting(win.document);
           return promise.then(() => {
@@ -365,6 +367,7 @@ describes.fakeWin(
           progress += 'C';
         },
         i: 'ext1',
+        v: '$internalRuntimeVersion$',
       });
       win.AMP.push({
         n: 'ext1',
@@ -373,6 +376,7 @@ describes.fakeWin(
           progress += 'A';
         },
         i: '_base_ext',
+        v: '$internalRuntimeVersion$',
       });
 
       win.AMP.push({
@@ -381,6 +385,7 @@ describes.fakeWin(
           expect(amp).to.equal(win.AMP);
           progress += 'B';
         },
+        v: '$internalRuntimeVersion$',
       });
 
       let script = win.document.querySelector('[data-script=_base_ext]');
@@ -418,6 +423,7 @@ describes.fakeWin(
           progress += 'A';
         },
         i: ['_base_ext1', '_base_ext2'],
+        v: '$internalRuntimeVersion$',
       });
 
       win.AMP.push({
@@ -427,6 +433,7 @@ describes.fakeWin(
           progress += 'B';
         },
         i: ['_base_ext1'],
+        v: '$internalRuntimeVersion$',
       });
 
       win.AMP.push({
@@ -435,6 +442,7 @@ describes.fakeWin(
           expect(amp).to.equal(win.AMP);
           progress += 'C';
         },
+        v: '$internalRuntimeVersion$',
       });
 
       let script1 = win.document.querySelector('[data-script=_base_ext1]');
@@ -711,6 +719,7 @@ describes.fakeWin(
           f: (amp) => {
             amp.registerElement('amp-ext', win.AMP.BaseElement);
           },
+          v: '$internalRuntimeVersion$',
         });
         runChunksForTesting(win.document);
         yield extensions.waitForExtension(win, 'amp-ext');
@@ -753,6 +762,7 @@ describes.fakeWin(
           f: (amp) => {
             amp.registerElement('amp-ext', win.AMP.BaseElement, 'a{}');
           },
+          v: '$internalRuntimeVersion$',
         });
         runChunksForTesting(win.document);
 
@@ -798,6 +808,7 @@ describes.fakeWin(
           f: (amp) => {
             amp.registerServiceForDoc('service1', Service1);
           },
+          v: '$internalRuntimeVersion$',
         });
         runChunksForTesting(win.document);
 
@@ -827,6 +838,7 @@ describes.fakeWin(
           f: (amp) => {
             amp.registerServiceForDoc('service1', factory);
           },
+          v: '$internalRuntimeVersion$',
         });
         runChunksForTesting(win.document);
 
@@ -878,6 +890,7 @@ describes.fakeWin(
           f: (amp) => {
             amp.registerElement('amp-ext', win.AMP.BaseElement);
           },
+          v: '$internalRuntimeVersion$',
         });
         runChunksForTesting(win.document);
 
@@ -925,6 +938,7 @@ describes.fakeWin(
           f: (amp) => {
             amp.registerElement('amp-ext', win.AMP.BaseElement, 'a{}');
           },
+          v: '$internalRuntimeVersion$',
         });
         runChunksForTesting(win.document);
 
@@ -975,6 +989,7 @@ describes.fakeWin(
           f: (amp) => {
             amp.registerServiceForDoc('service1', Service1);
           },
+          v: '$internalRuntimeVersion$',
         });
         runChunksForTesting(win.document);
 
@@ -1079,6 +1094,7 @@ describes.realWin(
           f: (amp) => {
             amp.registerServiceForDoc('service1', Service1);
           },
+          v: '$internalRuntimeVersion$',
         });
 
         const script = win.document.createElement('script');
@@ -1504,6 +1520,7 @@ describes.realWin(
             f: (amp) => {
               amp.registerServiceForDoc('service1', Service1);
             },
+            v: '$internalRuntimeVersion$',
           });
 
           writer.write(

--- a/test/unit/test-runtime.js
+++ b/test/unit/test-runtime.js
@@ -538,7 +538,6 @@ describes.fakeWin(
       self.__AMP_MODE = {
         rtvVersion: 'test-version',
       };
-      toggleExperiment(win, 'version-locking', true);
       function addExisting(index) {
         const s = document.createElement('script');
         const name = 'amp-test-element' + index;

--- a/tools/experiments/experiments-config.js
+++ b/tools/experiments/experiments-config.js
@@ -126,13 +126,6 @@ export const EXPERIMENTS = [
     cleanupIssue: 'https://github.com/ampproject/amphtml/issues/8237',
   },
   {
-    id: 'version-locking',
-    name:
-      'Force all extensions to have the same release ' +
-      'as the main JS binary',
-    cleanupIssue: 'https://github.com/ampproject/amphtml/issues/8236',
-  },
-  {
     id: 'web-worker',
     name: 'Web worker for background processing',
     cleanupIssue: 'https://github.com/ampproject/amphtml/issues/7156',


### PR DESCRIPTION
I'm the last one still disabling version locking, and it's easier to just override the local versions or manually opt-out in my local builds.