### PR TITLE
🐛 Fix A4A check in custom element

### DIFF
--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -1661,6 +1661,8 @@ function createBaseCustomElementClass(win) {
       return (
         // in FIE
         (this.ampdoc_ && this.ampdoc_.win != this.ownerDocument.defaultView) ||
+        // TODO(#22733): cleanup once the ampdoc-fie is fully launched.
+        (this.ampdoc_ && this.ampdoc_.getParent()) ||
         // in inabox
         getMode().runtime == 'inabox'
       );

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -1662,7 +1662,7 @@ function createBaseCustomElementClass(win) {
         // in FIE
         (this.ampdoc_ && this.ampdoc_.win != this.ownerDocument.defaultView) ||
         // TODO(#22733): cleanup once the ampdoc-fie is fully launched.
-        (this.ampdoc_ && this.ampdoc_.getParent()) ||
+        (this.ampdoc_ && !!this.ampdoc_.getParent()) ||
         // in inabox
         getMode().runtime == 'inabox'
       );


### PR DESCRIPTION
In ampdoc-fie the existing check would not correctly detect FIE case.

cc/ @lannka 