### PR TITLE
🐛 amp-auto-ads: Fix a typo in firstimpression.io network config

### DIFF
--- a/extensions/amp-auto-ads/0.1/firstimpression.io-network-config.js
+++ b/extensions/amp-auto-ads/0.1/firstimpression.io-network-config.js
@@ -86,7 +86,7 @@ export class FirstImpressionIoConfig {
       queryParams['fi_reveal'] = fiReveal;
     }
     if (fiDemand) {
-      queryParams['fi_demand'] = fiReveal;
+      queryParams['fi_demand'] = fiDemand;
     }
     if (fiGeo) {
       queryParams['fi_geo'] = fiGeo;


### PR DESCRIPTION
Fixed a minor typo in network config code