### PR TITLE
🏗 Added SXG mode of locating script in local dev mode and RTV mode for extensions.

### DIFF
--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -126,8 +126,6 @@ const forbiddenTerms = {
       'build-system/pr-check/e2e-tests.js',
       'build-system/pr-check/local-tests.js',
       'build-system/pr-check/performance-tests.js',
-      'build-system/pr-check/sxg-dist.js',
-      'build-system/pr-check/sxg-tests.js',
       'build-system/pr-check/utils.js',
       'build-system/pr-check/validator-tests.js',
       'build-system/pr-check/visual-diff-tests.js',

--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -126,6 +126,8 @@ const forbiddenTerms = {
       'build-system/pr-check/e2e-tests.js',
       'build-system/pr-check/local-tests.js',
       'build-system/pr-check/performance-tests.js',
+      'build-system/pr-check/sxg-dist.js',
+      'build-system/pr-check/sxg-tests.js',
       'build-system/pr-check/utils.js',
       'build-system/pr-check/validator-tests.js',
       'build-system/pr-check/visual-diff-tests.js',

--- a/src/mode-object.js
+++ b/src/mode-object.js
@@ -27,6 +27,7 @@ export function getModeObject(opt_win) {
     localDev: getMode(opt_win).localDev,
     development: getMode(opt_win).development,
     esm: IS_ESM,
+    sxg: IS_SXG,
     minified: getMode(opt_win).minified,
     lite: getMode(opt_win).lite,
     test: getMode(opt_win).test,

--- a/src/mode.js
+++ b/src/mode.js
@@ -29,7 +29,8 @@ import {parseQueryString_} from './url-parse-query-string';
  *   rtvVersion: string,
  *   runtime: (null|string|undefined),
  *   a4aId: (null|string|undefined),
- *   esm: (boolean|undefined)
+ *   esm: (boolean|undefined),
+ *   sxg: (boolean|undefined)
  * }}
  */
 export let ModeDef;
@@ -102,6 +103,7 @@ function getMode_(win) {
     ),
     examiner: hashQuery['development'] == '2',
     esm: IS_ESM,
+    sxg: IS_SXG,
     // amp-geo override
     geoOverride: hashQuery['amp-geo'],
     minified: IS_MINIFIED,

--- a/src/service/extension-location.js
+++ b/src/service/extension-location.js
@@ -60,14 +60,7 @@ export function calculateExtensionScriptUrl(
   opt_extensionVersion,
   opt_isLocalDev
 ) {
-  let fileExtension;
-  if (getMode().sxg && opt_isLocalDev) {
-    fileExtension = '.sxg.js';
-  } else if (getMode().sxg || getMode().esm) {
-    fileExtension = '.mjs';
-  } else {
-    fileExtension = '.js';
-  }
+  const fileExtension = calculateFileExtension(opt_isLocalDev);
   const base = calculateScriptBaseUrl(location, opt_isLocalDev);
   const rtv = getMode().rtvVersion;
   if (opt_extensionVersion == null) {
@@ -76,7 +69,7 @@ export function calculateExtensionScriptUrl(
   const extensionVersion = opt_extensionVersion
     ? '-' + opt_extensionVersion
     : '';
-  return finalizeScriptUrl(
+  return maybeAddQueryParams(
     `${base}/rtv/${rtv}/v0/${extensionId}${extensionVersion}${fileExtension}`,
     opt_isLocalDev
   );
@@ -97,25 +90,18 @@ export function calculateEntryPointScriptUrl(
   isLocalDev,
   opt_rtv
 ) {
-  let fileExtension;
-  if (getMode().sxg && isLocalDev) {
-    fileExtension = '.sxg.js';
-  } else if (getMode().sxg || getMode().esm) {
-    fileExtension = '.mjs';
-  } else {
-    fileExtension = '.js';
-  }
+  const fileExtension = calculateFileExtension(isLocalDev);
   const base = calculateScriptBaseUrl(location, isLocalDev);
   if (isLocalDev) {
     return `${base}/${entryPoint}${fileExtension}`;
   }
   if (opt_rtv) {
-    return finalizeScriptUrl(
+    return maybeAddQueryParams(
       `${base}/rtv/${getMode().rtvVersion}/${entryPoint}${fileExtension}`,
       isLocalDev
     );
   }
-  return finalizeScriptUrl(`${base}/${entryPoint}${fileExtension}`, isLocalDev);
+  return maybeAddQueryParams(`${base}/${entryPoint}${fileExtension}`, isLocalDev);
 }
 
 /**
@@ -135,12 +121,26 @@ export function parseExtensionUrl(scriptUrl) {
 }
 
 /**
- * Add additional values to the script url depending on mode, such as query parameters.
+ * Based on mode, determine which file extension to use for the script URL.
+ * @param {boolean=} isLocalDev 
+ */
+function calculateFileExtension(isLocalDev){
+  if (getMode().sxg && isLocalDev) {
+    return '.sxg.js';
+  } else if (getMode().sxg || getMode().esm) {
+    return '.mjs';
+  } else {
+    return '.js';
+  }
+}
+
+/**
+ * Add additional values to the script URL depending on mode, such as query parameters.
  * @param {string} scriptUrl
  * @param {boolean=} opt_isLocalDev
  * @return {string}
  */
-function finalizeScriptUrl(scriptUrl, opt_isLocalDev) {
+function maybeAddQueryParams(scriptUrl, opt_isLocalDev) {
   // If opt_isLocalDev is true, then .sxg.js is already appended and thus we don't need to add a query param.
   return getMode().sxg && !opt_isLocalDev
     ? addParamToUrl(scriptUrl, 'f', 'sxg')

--- a/src/service/extension-location.js
+++ b/src/service/extension-location.js
@@ -126,7 +126,7 @@ export function calculateEntryPointScriptUrl(
 export function parseExtensionUrl(scriptUrl) {
   // Note that the "(\.max)?" group only applies to local dev.
   const matches = scriptUrl.match(
-    /^(.*)\/(.*)-([0-9.]+|latest)(\.max)?\.(?:js|mjs)?(\?.*)$/i
+    /^(.*)\/(.*)-([0-9.]+|latest)(\.max)?\.(?:js|mjs)(\?.*)?$/i
   );
   return {
     extensionId: matches ? matches[2] : undefined,

--- a/src/service/extension-location.js
+++ b/src/service/extension-location.js
@@ -115,7 +115,7 @@ export function calculateEntryPointScriptUrl(
 export function parseExtensionUrl(scriptUrl) {
   // Note that the "(\.max)?" group only applies to local dev.
   const matches = scriptUrl.match(
-    /^(.*)\/(.*)-([0-9.]+|latest)(\.max)?\.(?:js|mjs)(\?.*)?$/i
+    /^(.*)\/(.*)-([0-9.]+|latest)(\.max)?\.(?:js|mjs|sxg\.js)(\?.*)?$/i
   );
   return {
     extensionId: matches ? matches[2] : undefined,

--- a/src/service/extension-location.js
+++ b/src/service/extension-location.js
@@ -101,7 +101,10 @@ export function calculateEntryPointScriptUrl(
       isLocalDev
     );
   }
-  return maybeAddQueryParams(`${base}/${entryPoint}${fileExtension}`, isLocalDev);
+  return maybeAddQueryParams(
+    `${base}/${entryPoint}${fileExtension}`,
+    isLocalDev
+  );
 }
 
 /**
@@ -122,9 +125,10 @@ export function parseExtensionUrl(scriptUrl) {
 
 /**
  * Based on mode, determine which file extension to use for the script URL.
- * @param {boolean=} isLocalDev 
+ * @param {boolean=} isLocalDev
+ * @return {string}
  */
-function calculateFileExtension(isLocalDev){
+function calculateFileExtension(isLocalDev) {
   if (getMode().sxg && isLocalDev) {
     return '.sxg.js';
   } else if (getMode().sxg || getMode().esm) {

--- a/src/service/extension-location.js
+++ b/src/service/extension-location.js
@@ -125,17 +125,16 @@ export function parseExtensionUrl(scriptUrl) {
 
 /**
  * Based on mode, determine which file extension to use for the script URL.
- * @param {boolean=} isLocalDev
+ * @param {boolean=} opt_isLocalDev
  * @return {string}
  */
-function calculateFileExtension(isLocalDev) {
-  if (getMode().sxg && isLocalDev) {
+function calculateFileExtension(opt_isLocalDev) {
+  if (getMode().sxg && opt_isLocalDev) {
     return '.sxg.js';
   } else if (getMode().sxg || getMode().esm) {
     return '.mjs';
-  } else {
-    return '.js';
   }
+  return '.js';
 }
 
 /**

--- a/test/unit/3p/test-3p-frame.js
+++ b/test/unit/3p/test-3p-frame.js
@@ -207,6 +207,7 @@ describe
             'test': false,
             'version': '$internalRuntimeVersion$',
             'esm': false,
+            'sxg': false,
           },
           'canary': true,
           'hidden': false,

--- a/test/unit/test-extension-location.js
+++ b/test/unit/test-extension-location.js
@@ -486,5 +486,14 @@ describes.sandboxed('SXG Extension Location', {}, () => {
       expect(urlParts.extensionId).to.equal('amp-ad');
       expect(urlParts.extensionVersion).to.equal('latest');
     });
+
+    it('additional query params', () => {
+      window.__AMP_MODE = {sxg: 1};
+      const urlParts = parseExtensionUrl(
+        'https://cdn.ampproject.org/v0/amp-ad-latest.max.mjs?optin=beta&f=sxg'
+      );
+      expect(urlParts.extensionId).to.equal('amp-ad');
+      expect(urlParts.extensionVersion).to.equal('latest');
+    });
   });
 });


### PR DESCRIPTION
For extension scripts, if SXG mode is detected, we add `f=sxg` query param to the URL. If local dev mode is detected, we simply replace the ending with `.sxg.js`. Some unit tests are also added to reflect the correct end behavior.
As such, this PR depends on #30126.