### PR TITLE
✨ Clear media session on cleanup / unmount

### DIFF
--- a/extensions/amp-video/1.0/test/test-video-wrapper.js
+++ b/extensions/amp-video/1.0/test/test-video-wrapper.js
@@ -128,6 +128,36 @@ describes.sandboxed('VideoWrapper Preact component', {}, (env) => {
       ).to.have.been.calledOnce;
     });
 
+    it('should not clear on pause', async () => {
+      const wrapper = mount(<VideoWrapper component={TestPlayer} />);
+
+      await wrapper.find(TestPlayer).invoke('onLoadedMetadata')();
+      await wrapper.find(TestPlayer).invoke('onCanPlay')();
+      await wrapper.find(TestPlayer).invoke('onPlaying')();
+
+      expect(navigator.mediaSession.metadata).to.eql(defaultMetadata);
+      expect(
+        navigator.mediaSession.setActionHandler.withArgs(
+          'play',
+          env.sandbox.match.typeOf('function')
+        )
+      ).to.have.been.calledOnce;
+      expect(
+        navigator.mediaSession.setActionHandler.withArgs(
+          'pause',
+          env.sandbox.match.typeOf('function')
+        )
+      ).to.have.been.calledOnce;
+
+      await wrapper.find(TestPlayer).invoke('onPause')();
+
+      expect(navigator.mediaSession.metadata).to.eql(defaultMetadata);
+      expect(navigator.mediaSession.setActionHandler.withArgs('play', null)).to
+        .not.have.been.called;
+      expect(navigator.mediaSession.setActionHandler.withArgs('pause', null)).to
+        .not.have.been.called;
+    });
+
     it('should clear when unmounted', async () => {
       const wrapper = mount(<VideoWrapper component={TestPlayer} />);
 

--- a/extensions/amp-video/1.0/video-wrapper.js
+++ b/extensions/amp-video/1.0/video-wrapper.js
@@ -30,6 +30,7 @@ import {
 import {useStyles as useAutoplayStyles} from './autoplay.jss';
 import {
   useCallback,
+  useEffect,
   useLayoutEffect,
   useMemo,
   useRef,
@@ -85,6 +86,8 @@ export function VideoWrapper({
   const [metadata, setMetadata] = useState(null);
   const [userInteracted, setUserInteracted] = useState(false);
 
+  const clearMediaSession = useRef(null);
+
   const wrapperRef = useRef(null);
   const playerRef = useRef(null);
 
@@ -106,9 +109,24 @@ export function VideoWrapper({
 
   useLayoutEffect(() => {
     if (mediasession && playing && metadata) {
-      return setMediaSession(window, metadata, play, pause);
+      clearMediaSession.current = setMediaSession(
+        window,
+        metadata,
+        play,
+        pause
+      );
     }
   }, [mediasession, playing, metadata, play, pause]);
+
+  useEffect(
+    // Clear only on unmount.
+    () => () => {
+      if (clearMediaSession.current) {
+        clearMediaSession.current();
+      }
+    },
+    []
+  );
 
   return (
     <ContainWrapper

--- a/extensions/amp-video/1.0/video-wrapper.js
+++ b/extensions/amp-video/1.0/video-wrapper.js
@@ -106,12 +106,8 @@ export function VideoWrapper({
 
   useLayoutEffect(() => {
     if (mediasession && playing && metadata) {
-      setMediaSession(window, metadata, play, pause);
+      return setMediaSession(window, metadata, play, pause);
     }
-    return () => {
-      // TODO(alanorozco): Clear media session.
-      // (Tricky because we don't want to clear a different active session.)
-    };
   }, [mediasession, playing, metadata, play, pause]);
 
   return (

--- a/src/mediasession-helper.js
+++ b/src/mediasession-helper.js
@@ -44,7 +44,7 @@ let lastMediaSession = 0;
  * @param {!MetadataDef} metadata
  * @param {function()=} playHandler
  * @param {function()=} pauseHandler
- * @return {!UnlistenDef} clears it
+ * @return {!UnlistenDef|undefined} Clears it, undefined when session not set.
  */
 export function setMediaSession(win, metadata, playHandler, pauseHandler) {
   const {navigator} = win;
@@ -71,7 +71,6 @@ export function setMediaSession(win, metadata, playHandler, pauseHandler) {
       navigator.mediaSession.setActionHandler('pause', null);
     };
   }
-  return () => {};
 }
 
 /**

--- a/src/mediasession-helper.js
+++ b/src/mediasession-helper.js
@@ -47,16 +47,16 @@ let lastMediaSession = 0;
  * @return {!UnlistenDef|undefined} Clears it, undefined when session not set.
  */
 export function setMediaSession(win, metadata, playHandler, pauseHandler) {
-  const {navigator} = win;
-  if ('mediaSession' in navigator && win.MediaMetadata) {
+  if ('mediaSession' in win.navigator && win.MediaMetadata) {
+    const {mediaSession} = win.navigator;
     // Clear mediaSession (required to fix a bug when switching between two
     // videos)
-    navigator.mediaSession.metadata = new win.MediaMetadata(EMPTY_METADATA);
+    mediaSession.metadata = new win.MediaMetadata(EMPTY_METADATA);
 
-    navigator.mediaSession.metadata = new win.MediaMetadata(metadata);
+    mediaSession.metadata = new win.MediaMetadata(metadata);
 
-    navigator.mediaSession.setActionHandler('play', playHandler);
-    navigator.mediaSession.setActionHandler('pause', pauseHandler);
+    mediaSession.setActionHandler('play', playHandler);
+    mediaSession.setActionHandler('pause', pauseHandler);
 
     // TODO(@wassgha) Implement seek & next/previous
 
@@ -65,10 +65,9 @@ export function setMediaSession(win, metadata, playHandler, pauseHandler) {
       if (currentMediaSession !== lastMediaSession) {
         return;
       }
-
-      navigator.mediaSession.metadata = null;
-      navigator.mediaSession.setActionHandler('play', null);
-      navigator.mediaSession.setActionHandler('pause', null);
+      mediaSession.metadata = null;
+      mediaSession.setActionHandler('play', null);
+      mediaSession.setActionHandler('pause', null);
     };
   }
 }

--- a/src/mediasession-helper.js
+++ b/src/mediasession-helper.js
@@ -36,12 +36,15 @@ export const EMPTY_METADATA = {
   'artwork': [{'src': ''}],
 };
 
+let lastMediaSession = 0;
+
 /**
  * Updates the Media Session API's metadata
  * @param {!Window} win
  * @param {!MetadataDef} metadata
  * @param {function()=} playHandler
  * @param {function()=} pauseHandler
+ * @return {!UnlistenDef} clears it
  */
 export function setMediaSession(win, metadata, playHandler, pauseHandler) {
   const {navigator} = win;
@@ -56,7 +59,19 @@ export function setMediaSession(win, metadata, playHandler, pauseHandler) {
     navigator.mediaSession.setActionHandler('pause', pauseHandler);
 
     // TODO(@wassgha) Implement seek & next/previous
+
+    const currentMediaSession = ++lastMediaSession;
+    return () => {
+      if (currentMediaSession !== lastMediaSession) {
+        return;
+      }
+
+      navigator.mediaSession.metadata = null;
+      navigator.mediaSession.setActionHandler('play', null);
+      navigator.mediaSession.setActionHandler('pause', null);
+    };
   }
+  return () => {};
 }
 
 /**


### PR DESCRIPTION
Tracker #30303

Clears [`MediaSession`](https://developer.mozilla.org/en-US/docs/Web/API/Media_Session_API) on effect cleanup.

Ensures that a different active session is not cleared (`lastMediaSession`).
<!--
# Instructions:

- Pick a meaningful title for your pull request. (Use sentence case.)
  - Prefix the title with an emoji to identify what is being done. (Copy-paste the emoji from the list below.)
  - Do not overuse punctuation in the title (like `(chore):`).
  - If it is helpful, use a simple prefix (like `ProjectX: Implement some feature`).
- Enter a succinct description that says why the PR is necessary, and what it does.
  - Mention the GitHub issue that is being addressed by the pull request.
  - The keywords `Fixes`, `Closes`, or `Resolves` followed the issue number will automatically close the issue.

> NOTE: All non-trivial changes (like introducing new features or components) should have an associated issue or reference an I2I (intent-to-implement: go.amp.dev/i2i). Please read through the contribution process (go.amp.dev/contributing/code) for more information.

# Example of a good description:

- Implement aspect X
- Leave out feature Y because of A
- Improve performance by B
- Improve accessibility by C

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Reverting a previous change
♻️ Refactoring
🚮 Deleting code
🧪 Experimental code
-->
