### PR TITLE
🖍 Cleanup autoplay JSS/fix :before, :after

### DIFF
--- a/extensions/amp-video/1.0/autoplay.jss.js
+++ b/extensions/amp-video/1.0/autoplay.jss.js
@@ -36,6 +36,7 @@ const eqCol = {
   marginRight: 1,
   position: 'relative',
   '&:before, &:after': {
+    content: '""',
     animation: '0s linear infinite alternate $eq-animation',
     backgroundColor: '#FAFAFA',
     height: '100%',
@@ -45,40 +46,20 @@ const eqCol = {
     animationPlayState: 'paused',
   },
   '&:nth-child(1)': {
-    '&:before, &:after': {
-      transform: 'translateY(60%)',
-      animationDuration: '0.3s',
-    },
-    '&:after': {
-      animationDuration: '0.45s',
-    },
+    '&:before': {animationDuration: '0.3s'},
+    '&:after': {animationDuration: '0.45s'},
   },
   '&:nth-child(2)': {
-    '&:before, &:after': {
-      transform: 'translateY(30%)',
-      animationDuration: '0.5s',
-    },
-    '&:after': {
-      animationDuration: '0.4s',
-    },
+    '&:before': {animationDuration: '0.5s'},
+    '&:after': {animationDuration: '0.4s'},
   },
   '&:nth-child(3)': {
-    '&:before, &:after': {
-      transform: 'translateY(70%)',
-      animationDuration: '0.3s',
-    },
-    '&:after': {
-      animationDuration: '0.35s',
-    },
+    '&:before': {animationDuration: '0.3s'},
+    '&:after': {animationDuration: '0.35s'},
   },
   '&:nth-child(4)': {
-    '&:before, &:after': {
-      transform: 'translateY(50%)',
-      animationDuration: '0.4s',
-    },
-    '&:after': {
-      animationDuration: '0.25s',
-    },
+    '&:before': {animationDuration: '0.4s'},
+    '&:after': {animationDuration: '0.25s'},
   },
 };
 


### PR DESCRIPTION
**Adding `content`**
This slipped me before, and without it `:before/:after` pseudoelements are not displayed.

**Removing `transform`**

Default translate values were used for a workaround where instead of setting `animation-play-state, we'd remove the entire animation`:

https://github.com/ampproject/amphtml/blob/c4a663d0ba13d0488c6fe73c55dc8c971ac6ec0d/src/service/video/autoplay.js#L73-L76

The bug this worked around is no longer [present](https://glitch.com/edit/#!/animation-play-state-transform) in iOS, so we can remove it. If we remove the default transform value, we can also remove the dual selector in `:before, :after {}`.