### PR TITLE
DO NOT MERGE: Runtime using renderable and loadable services

### DIFF
--- a/build-system/compile/bundles.config.js
+++ b/build-system/compile/bundles.config.js
@@ -396,6 +396,12 @@ exports.extensionBundles = [
     type: TYPES.MISC,
   },
   {
+    name: 'amp-bento-info',
+    version: '1.0',
+    latestVersion: '1.0',
+    type: TYPES.MISC,
+  },
+  {
     name: 'amp-beopinion',
     version: '0.1',
     latestVersion: '0.1',

--- a/build-system/global-configs/experiments-const.json
+++ b/build-system/global-configs/experiments-const.json
@@ -1,1 +1,3 @@
-{}
+{
+  "RUNTIME3": true
+}

--- a/examples/everything.amp.html
+++ b/examples/everything.amp.html
@@ -16,10 +16,6 @@
       margin: 8px;
     }
 
-    amp-lightbox {
-      background-color: rgba(0, 0, 0, 0.9);
-    }
-
     .bordered {
       border: 1px solid black;
     }
@@ -52,6 +48,10 @@
       right: 0;
       width: 20px;
       height: 20px;
+    }
+
+    amp-base-carousel {
+      border: 1px dotted;
     }
 
     @media screen and (min-width: 380px) {
@@ -124,11 +124,11 @@
   <script async custom-element="amp-font" src="https://cdn.ampproject.org/v0/amp-font-0.1.js"></script>
   <script async custom-element="amp-iframe" src="https://cdn.ampproject.org/v0/amp-iframe-0.1.js"></script>
   <script async custom-element="amp-instagram" src="https://cdn.ampproject.org/v0/amp-instagram-0.1.js"></script>
-  <script async custom-element="amp-image-lightbox" src="https://cdn.ampproject.org/v0/amp-image-lightbox-0.1.js"></script>
-  <script async custom-element="amp-lightbox" src="https://cdn.ampproject.org/v0/amp-lightbox-0.1.js"></script>
   <script async custom-element="amp-twitter" src="https://cdn.ampproject.org/v0/amp-twitter-0.1.js"></script>
   <script async custom-element="amp-youtube" src="https://cdn.ampproject.org/v0/amp-youtube-0.1.js"></script>
   <script async custom-element="amp-video" src="https://cdn.ampproject.org/v0/amp-video-0.1.js"></script>
+  <script async custom-element="amp-bento-info" src="https://cdn.ampproject.org/v0/amp-bento-info-1.0.js"></script>
+  <script async custom-element="amp-base-carousel" src="https://cdn.ampproject.org/v0/amp-base-carousel-1.0.js"></script>
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
 </head>
@@ -138,28 +138,7 @@
 
 <article>
 
-<h1 id="top">AMP #0</h1>
-<a href="#amp-iframe">Go to iframe</a>
-  <p class="comic-amp">
-    Quisque ultricies id augue a convallis. Vivamus euismod est quis tellus laoreet lacinia. In quam tellus, mollis nec porta eget, volutpat sit amet nibh. Duis ac odio sem. Sed consequat, ante gravida fringilla suscipit, libero libero ullamcorper metus, nec porta est elit at est. Curabitur vel diam ligula. Nulla bibendum malesuada odio.
-  </p>
-  <p>
-    <amp-fit-text width="300" height="200" layout="responsive" class="box1">
-      Lorem ipsum dolor sit amet, has nisl nihil convenire et, vim at aeque inermis reprehendunt.
-    </amp-fit-text>
-  </p>
-  <p>
-    <div class="box1">
-      Lorem ipsum dolor sit amet, has nisl nihil convenire et, vim at aeque inermis reprehendunt.
-    </div>
-  </p>
-
-  <p>
-    <a class="goto" href="#top">Top</a>
-    <a class="goto" href="#img0">Image0</a>
-    <a class="goto" href="#footer">Footer</a>
-  </p>
-
+  <!--
   <p>
     <div style="width:400px; height:300px; overflow-x: scroll !important;">
       <amp-img src="https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w400-h300-no-n" width=400 height=300 layout=intrinsic style="float: left"></amp-img>
@@ -174,12 +153,14 @@
       </amp-anim>
     </div>
   </p>
+
   <p>
     <amp-carousel width=400 height=300 layout=responsive type=slides>
       <amp-img src="https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w400-h300-no-n" layout=fill></amp-img>
       <amp-img src="https://lh3.googleusercontent.com/5rcQ32ml8E5ONp9f9-Rf78IofLb9QjS5_0mqsY1zEFc=w400-h300-no-n" width=400 height=300 layout=responsive></amp-img>
       <amp-img src="https://lh3.googleusercontent.com/Z4gtm5Bkxyv21Z2PtbTf95Clb9AE4VTR6olbBKYrenM=w400-h300-no-n" width=400 height=300 layout=responsive></amp-img>
       <amp-anim
+          id="carousel1-anim"
           src="https://lh3.googleusercontent.com/qNn8GDz8Jfd-s9lt3Nc4lJeLjVyEaqGJTk1vuCUWazCmAeOBVjSWDD0SMTU7x0zhVe5UzOTKR0n-kN4SXx7yElvpKYvCMaRyS_g-jydhJ_cEVYmYPiZ_j1Y9de43mlKxU6s06uK1NAlpbSkL_046amEKOdgIACICkuWfOBwlw2hUDfjPOWskeyMrcTu8XOEerCLuVqXugG31QC345hz3lUyOlkdT9fMYVUynSERGNzHba7bXMOxKRe3izS5DIWUgJs3oeKYqA-V8iqgCvneD1jj0Ff68V_ajm4BDchQubBJU0ytXVkoWh27ngeEHubpnApOS6fcGsjPxeuMjnzAUtoTsiXz2FZi1mMrxrblJ-kZoAq1DJ95cnoqoa2CYq3BTgq2E8BRe2paNxLJ5GXBCTpNdXMpVJc6eD7ceijQyn-2qanilX-iK3ChbOq0uBHMvsdoC_LsFOu5KzbbNH71vM3DPkvDGmHJmF67Vj8sQ6uBrLnzpYlCyN4-Y9frR8zugDcqX5Q=w400-h300-no"
           width="400" height="300">
         <amp-img placeholder
@@ -188,30 +169,28 @@
       </amp-anim>
     </amp-carousel>
   </p>
+  -->
+
+  <!--
   <p>
-    <amp-carousel width=auto height=200>
-      <amp-img src="https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w300-h200-no-n" width=300 height=200></amp-img>
-      <amp-img src="https://lh3.googleusercontent.com/5rcQ32ml8E5ONp9f9-Rf78IofLb9QjS5_0mqsY1zEFc=w300-h200-no-n" width=300 height=200></amp-img>
-      <amp-img src="https://lh3.googleusercontent.com/Z4gtm5Bkxyv21Z2PtbTf95Clb9AE4VTR6olbBKYrenM=w300-h200-no-n" width=300 height=200></amp-img>
-      <amp-anim
-          src="https://lh3.googleusercontent.com/qNn8GDz8Jfd-s9lt3Nc4lJeLjVyEaqGJTk1vuCUWazCmAeOBVjSWDD0SMTU7x0zhVe5UzOTKR0n-kN4SXx7yElvpKYvCMaRyS_g-jydhJ_cEVYmYPiZ_j1Y9de43mlKxU6s06uK1NAlpbSkL_046amEKOdgIACICkuWfOBwlw2hUDfjPOWskeyMrcTu8XOEerCLuVqXugG31QC345hz3lUyOlkdT9fMYVUynSERGNzHba7bXMOxKRe3izS5DIWUgJs3oeKYqA-V8iqgCvneD1jj0Ff68V_ajm4BDchQubBJU0ytXVkoWh27ngeEHubpnApOS6fcGsjPxeuMjnzAUtoTsiXz2FZi1mMrxrblJ-kZoAq1DJ95cnoqoa2CYq3BTgq2E8BRe2paNxLJ5GXBCTpNdXMpVJc6eD7ceijQyn-2qanilX-iK3ChbOq0uBHMvsdoC_LsFOu5KzbbNH71vM3DPkvDGmHJmF67Vj8sQ6uBrLnzpYlCyN4-Y9frR8zugDcqX5Q=w300-h200-no"
-          width="300" height="200">
-        <amp-img placeholder
-            src="https://lh3.googleusercontent.com/qNn8GDz8Jfd-s9lt3Nc4lJeLjVyEaqGJTk1vuCUWazCmAeOBVjSWDD0SMTU7x0zhVe5UzOTKR0n-kN4SXx7yElvpKYvCMaRyS_g-jydhJ_cEVYmYPiZ_j1Y9de43mlKxU6s06uK1NAlpbSkL_046amEKOdgIACICkuWfOBwlw2hUDfjPOWskeyMrcTu8XOEerCLuVqXugG31QC345hz3lUyOlkdT9fMYVUynSERGNzHba7bXMOxKRe3izS5DIWUgJs3oeKYqA-V8iqgCvneD1jj0Ff68V_ajm4BDchQubBJU0ytXVkoWh27ngeEHubpnApOS6fcGsjPxeuMjnzAUtoTsiXz2FZi1mMrxrblJ-kZoAq1DJ95cnoqoa2CYq3BTgq2E8BRe2paNxLJ5GXBCTpNdXMpVJc6eD7ceijQyn-2qanilX-iK3ChbOq0uBHMvsdoC_LsFOu5KzbbNH71vM3DPkvDGmHJmF67Vj8sQ6uBrLnzpYlCyN4-Y9frR8zugDcqX5Q=w300-h200-no-k"
-            width="300" height="200"></amp-img>
-      </amp-anim>
-    </amp-carousel>
-  </p>
-  <p>
-    <amp-anim
+    <amp-anim id="anim1"
         src="https://lh3.googleusercontent.com/qNn8GDz8Jfd-s9lt3Nc4lJeLjVyEaqGJTk1vuCUWazCmAeOBVjSWDD0SMTU7x0zhVe5UzOTKR0n-kN4SXx7yElvpKYvCMaRyS_g-jydhJ_cEVYmYPiZ_j1Y9de43mlKxU6s06uK1NAlpbSkL_046amEKOdgIACICkuWfOBwlw2hUDfjPOWskeyMrcTu8XOEerCLuVqXugG31QC345hz3lUyOlkdT9fMYVUynSERGNzHba7bXMOxKRe3izS5DIWUgJs3oeKYqA-V8iqgCvneD1jj0Ff68V_ajm4BDchQubBJU0ytXVkoWh27ngeEHubpnApOS6fcGsjPxeuMjnzAUtoTsiXz2FZi1mMrxrblJ-kZoAq1DJ95cnoqoa2CYq3BTgq2E8BRe2paNxLJ5GXBCTpNdXMpVJc6eD7ceijQyn-2qanilX-iK3ChbOq0uBHMvsdoC_LsFOu5KzbbNH71vM3DPkvDGmHJmF67Vj8sQ6uBrLnzpYlCyN4-Y9frR8zugDcqX5Q=w400-h225-no"
         width="400" height="225" layout="responsive">
-      <amp-img placeholder
+      <amp-img placeholder id="anim1-placeholder"
           src="https://lh3.googleusercontent.com/qNn8GDz8Jfd-s9lt3Nc4lJeLjVyEaqGJTk1vuCUWazCmAeOBVjSWDD0SMTU7x0zhVe5UzOTKR0n-kN4SXx7yElvpKYvCMaRyS_g-jydhJ_cEVYmYPiZ_j1Y9de43mlKxU6s06uK1NAlpbSkL_046amEKOdgIACICkuWfOBwlw2hUDfjPOWskeyMrcTu8XOEerCLuVqXugG31QC345hz3lUyOlkdT9fMYVUynSERGNzHba7bXMOxKRe3izS5DIWUgJs3oeKYqA-V8iqgCvneD1jj0Ff68V_ajm4BDchQubBJU0ytXVkoWh27ngeEHubpnApOS6fcGsjPxeuMjnzAUtoTsiXz2FZi1mMrxrblJ-kZoAq1DJ95cnoqoa2CYq3BTgq2E8BRe2paNxLJ5GXBCTpNdXMpVJc6eD7ceijQyn-2qanilX-iK3ChbOq0uBHMvsdoC_LsFOu5KzbbNH71vM3DPkvDGmHJmF67Vj8sQ6uBrLnzpYlCyN4-Y9frR8zugDcqX5Q=w400-h225-no-k"
           width="400" height="225" layout="responsive"></amp-img>
     </amp-anim>
   </p>
+  -->
 
+  <amp-base-carousel layout="fixed" width="300" height="100">
+    <amp-bento-info id="slide1" layout="fixed" width="300" height="100"></amp-bento-info>
+    <amp-bento-info id="slide2" layout="fixed" width="300" height="100"></amp-bento-info>
+    <amp-bento-info id="slide3" layout="fixed" width="300" height="100"></amp-bento-info>
+    <amp-bento-info id="slide4" layout="fixed" width="300" height="100"></amp-bento-info>
+  </amp-base-carousel>
+
+  <!--
   <h2>Video</h2>
   <amp-video
       src="https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerJoyrides.mp4"
@@ -224,264 +203,8 @@
   <amp-youtube
       data-videoid="mGENRKrdoGY"
       width="480" height="270"></amp-youtube>
+  -->
 
-  <amp-youtube
-      data-videoid="mGENRKrdoGY"
-      layout="responsive"
-      width="480" height="270"></amp-youtube>
-
-
-  <h2>Audio</h2>
-    <amp-audio src="/examples/av/audio.mp3"></amp-audio>
-
-  <h2>Lightbox</h2>
-  <amp-lightbox id="lightbox" layout="nodisplay">
-    <p>
-      <button on="tap:lightbox.close" class="lightbox-close-button">
-          Close Lightbox
-      </button>
-    </p>
-    <p>
-      <amp-img src="https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w300-h200-no" width=300 height=200></amp-img>
-    </p>
-    <p class="lightbox-text">
-      Lorem ipsum dolor sit amet, has nisl nihil convenire et, vim at aeque inermis reprehendunt. Propriae tincidunt id nec, elit nusquam te mea, ius noster platonem in. Mea an idque minim, sit sale deleniti apeirian et. Omnium legendos tractatos cu mea. Vix in stet dolorem accusamus. Iisque rationibus consetetur in cum, quo unum nulla legere ut. Simul numquam saperet no sit.
-    </p>
-  </amp-lightbox>
-
-  <button on="tap:lightbox">
-      Open Lightbox
-  </button>
-
-  <h2>Scrollable Lightbox</h2>
-  <amp-lightbox scrollable id="lightbox-scrollable" layout="nodisplay">
-    <button on="tap:lightbox-scrollable.close" class="lightbox-close-button">
-      Close Scrollable Lightbox
-    </button>
-    <p>
-      <amp-img src="https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w300-h200-no" width=300 height=200></amp-img>
-    </p>
-    <p class="lightbox-text">
-      Lorem ipsum dolor sit amet, has nisl nihil convenire et, vim at aeque inermis reprehendunt. Propriae tincidunt id nec, elit nusquam te mea, ius noster platonem in. Mea an idque minim, sit sale deleniti apeirian et. Omnium legendos tractatos cu mea. Vix in stet dolorem accusamus. Iisque rationibus consetetur in cum, quo unum nulla legere ut. Simul numquam saperet no sit.
-    </p>
-    <p>
-      <amp-img src="https://lh3.googleusercontent.com/5rcQ32ml8E5ONp9f9-Rf78IofLb9QjS5_0mqsY1zEFc=w300-h200-no" width=300 height=200></amp-img>
-    </p>
-    <p class="lightbox-text">
-      Lorem ipsum dolor sit amet, has nisl nihil convenire et, vim at aeque inermis reprehendunt. Propriae tincidunt id nec, elit nusquam te mea, ius noster platonem in. Mea an idque minim, sit sale deleniti apeirian et. Omnium legendos tractatos cu mea. Vix in stet dolorem accusamus. Iisque rationibus consetetur in cum, quo unum nulla legere ut. Simul numquam saperet no sit.
-    </p>
-    <p>
-      <amp-img src="https://lh3.googleusercontent.com/Z4gtm5Bkxyv21Z2PtbTf95Clb9AE4VTR6olbBKYrenM=w300-h200-no" width=300 height=200></amp-img>
-    </p>
-    <p class="lightbox-text">
-      Lorem ipsum dolor sit amet, has nisl nihil convenire et, vim at aeque inermis reprehendunt. Propriae tincidunt id nec, elit nusquam te mea, ius noster platonem in. Mea an idque minim, sit sale deleniti apeirian et. Omnium legendos tractatos cu mea. Vix in stet dolorem accusamus. Iisque rationibus consetetur in cum, quo unum nulla legere ut. Simul numquam saperet no sit.
-    </p>
-    <amp-twitter width=486 height=657
-                 media="(min-width: 401px)"
-                 layout="responsive"
-                 data-tweetID="585110598171631616"></amp-twitter>
-    <amp-youtube
-        data-videoid="mGENRKrdoGY"
-        layout="responsive"
-        width="480" height="270"></amp-youtube>
-    <p class="lightbox-text">
-      Lorem ipsum dolor sit amet, has nisl nihil convenire et, vim at aeque inermis reprehendunt. Propriae tincidunt id nec, elit nusquam te mea, ius noster platonem in. Mea an idque minim, sit sale deleniti apeirian et. Omnium legendos tractatos cu mea. Vix in stet dolorem accusamus. Iisque rationibus consetetur in cum, quo unum nulla legere ut. Simul numquam saperet no sit.
-      Lorem ipsum dolor sit amet, has nisl nihil convenire et, vim at aeque inermis reprehendunt. Propriae tincidunt id nec, elit nusquam te mea, ius noster platonem in. Mea an idque minim, sit sale deleniti apeirian et. Omnium legendos tractatos cu mea. Vix in stet dolorem accusamus. Iisque rationibus consetetur in cum, quo unum nulla legere ut. Simul numquam saperet no sit.
-      Lorem ipsum dolor sit amet, has nisl nihil convenire et, vim at aeque inermis reprehendunt. Propriae tincidunt id nec, elit nusquam te mea, ius noster platonem in. Mea an idque minim, sit sale deleniti apeirian et. Omnium legendos tractatos cu mea. Vix in stet dolorem accusamus. Iisque rationibus consetetur in cum, quo unum nulla legere ut. Simul numquam saperet no sit.
-    </p>
-  </amp-lightbox>
-
-  <button on="tap:lightbox-scrollable">
-    Open Scrollable Lightbox
-  </button>
-
-  <h2>Images</h2>
-  <p>
-  Responsive (w/srcset, w/image-lightbox)
-  <p>
-    <amp-image-lightbox id="imagelightbox1" layout="nodisplay"></amp-image-lightbox>
-    <amp-img id="img0"
-        srcset="
-            https://lh4.googleusercontent.com/-okOlNNHeoOc/VbYyrlFYFII/AAAAAAABYdA/La-3j3c-QQI/w2004-h734-no/PANO_20150726_171347%257E2.jpg 2004w,
-            https://lh4.googleusercontent.com/-okOlNNHeoOc/VbYyrlFYFII/AAAAAAABYdA/La-3j3c-QQI/w1002-h367-no/PANO_20150726_171347%257E2.jpg 1002w"
-        width=527 height=193 layout="responsive"
-        on="tap:imagelightbox1" role="button" tabindex="0"></amp-img>
-  </p>
-
-  <p>
-  Fixed
-  <p>
-    <amp-img id="img1" src="https://lh4.googleusercontent.com/-okOlNNHeoOc/VbYyrlFYFII/AAAAAAABYdA/La-3j3c-QQI/w2004-h734-no/PANO_20150726_171347%257E2.jpg" width=264 height=96></amp-img>
-  </p>
-
-  <p>
-  None
-  <p class="bordered">
-    <amp-img id="img2" src="https://lh4.googleusercontent.com/-okOlNNHeoOc/VbYyrlFYFII/AAAAAAABYdA/La-3j3c-QQI/w2004-h734-no/PANO_20150726_171347%257E2.jpg" width=527 height=193 layout="nodisplay"></amp-img>
-  </p>
-  <p>
-    Lorem ipsum dolor sit amet.
-  </p>
-  <amp-ad width="400" height="300"
-      type = "a9"
-      data-amzn_assoc_placement = "adunit0"
-      data-amzn_assoc_search_bar = "true"
-      data-amzn_assoc_tracking_id = "deepak2015-20"
-      data-amzn_assoc_search_bar_position = "bottom"
-      data-amzn_assoc_ad_mode = "search"
-      data-amzn_assoc_ad_type = "smart"
-      data-amzn_assoc_marketplace = "amazon"
-      data-amzn_assoc_region = "US"
-      data-amzn_assoc_title = "Shop Related Products"
-      data-amzn_assoc_default_search_phrase = "apple watches"
-      data-amzn_assoc_default_category = "All"
-      data-amzn_assoc_linkid = "b01186f9b305e15fc51214bb45187875"
-      data-regionurl = "https://z-na.amazon-adsystem.com/widgets/onejs?MarketPlace=US">
-  </amp-ad>
-  <p>
-    Lorem ipsum dolor sit amet, has nisl nihil convenire et, vim at aeque inermis reprehendunt. Propriae tincidunt id nec, elit nusquam te mea, ius noster platonem in. Mea an idque minim, sit sale deleniti apeirian et. Omnium legendos tractatos cu mea. Vix in stet dolorem accusamus. Iisque rationibus consetetur in cum, quo unum nulla legere ut. Simul numquam saperet no sit.
-  </p>
-
-  <p>
-    Lorem ipsum dolor sit amet, has nisl nihil convenire et, vim at aeque inermis reprehendunt. Propriae tincidunt id nec, elit nusquam te mea, ius noster platonem in. Mea an idque minim, sit sale deleniti apeirian et. Omnium legendos tractatos cu mea. Vix in stet dolorem accusamus. Iisque rationibus consetetur in cum, quo unum nulla legere ut. Simul numquam saperet no sit.
-  </p>
-  <p>
-    <amp-img id="img3" src="https://lh4.googleusercontent.com/-okOlNNHeoOc/VbYyrlFYFII/AAAAAAABYdA/La-3j3c-QQI/w2004-h734-no/PANO_20150726_171347%257E2.jpg" width=527 height=193 layout="responsive" ></amp-img>
-  </p>
-  <p>
-    <amp-img id="img4" src="https://lh4.googleusercontent.com/-okOlNNHeoOc/VbYyrlFYFII/AAAAAAABYdA/La-3j3c-QQI/w2004-h734-no/PANO_20150726_171347%257E2.jpg" width=527 height=193 layout="responsive" ></amp-img>
-  </p>
-  <p>
-    <amp-img id="img5" src="https://lh4.googleusercontent.com/-okOlNNHeoOc/VbYyrlFYFII/AAAAAAABYdA/La-3j3c-QQI/w2004-h734-no/PANO_20150726_171347%257E2.jpg" width=527 height=193 layout="responsive" ></amp-img>
-  </p>
-  <p>
-    Lorem ipsum dolor sit amet, has nisl nihil convenire et, vim at aeque inermis reprehendunt. Propriae tincidunt id nec, elit nusquam te mea, ius noster platonem in. Mea an idque minim, sit sale deleniti apeirian et. Omnium legendos tractatos cu mea. Vix in stet dolorem accusamus. Iisque rationibus consetetur in cum, quo unum nulla legere ut. Simul numquam saperet no sit.
-  </p>
-  <section>
-    <h1>Media query selection<h1>
-    <amp-img
-        media="(min-width: 650px)"
-        id="img6" src="https://lh5.googleusercontent.com/-vmSp-YN10lA/VcH6S35gAWI/AAAAAAABYqk/6wuA5T3ApSk/w1832-h1376-no/IMG_20150805_131745-ANIMATION.gif"
-        width=466
-        height=355 layout="responsive" ></amp-img>
-    <amp-img
-        media="(max-width: 649px)"
-        id="img7" src="https://lh4.googleusercontent.com/-okOlNNHeoOc/VbYyrlFYFII/AAAAAAABYdA/La-3j3c-QQI/w2004-h734-no/PANO_20150726_171347%257E2.jpg"
-        width=527
-        height=193 layout="responsive" ></amp-img>
-  </section>
-  <p>
-    <amp-img src="https://lh4.googleusercontent.com/-okOlNNHeoOc/VbYyrlFYFII/AAAAAAABYdA/La-3j3c-QQI/w2004-h734-no/PANO_20150726_171347%257E2.jpg" width=527 height=193 layout="responsive" ></amp-img>
-  </p>
-  <p>
-    <amp-img src="https://lh4.googleusercontent.com/-okOlNNHeoOc/VbYyrlFYFII/AAAAAAABYdA/La-3j3c-QQI/w2004-h734-no/PANO_20150726_171347%257E2.jpg" width=527 height=193 layout="responsive" ></amp-img>
-  </p>
-  <p>
-    <amp-img src="https://lh4.googleusercontent.com/-okOlNNHeoOc/VbYyrlFYFII/AAAAAAABYdA/La-3j3c-QQI/w2004-h734-no/PANO_20150726_171347%257E2.jpg" width=527 height=193 layout="responsive" ></amp-img>
-  </p>
-  <p>
-    Lorem ipsum dolor sit amet, has nisl nihil convenire et, vim at aeque inermis reprehendunt. Propriae tincidunt id nec, elit nusquam te mea, ius noster platonem in. Mea an idque minim, sit sale deleniti apeirian et. Omnium legendos tractatos cu mea. Vix in stet dolorem accusamus. Iisque rationibus consetetur in cum, quo unum nulla legere ut. Simul numquam saperet no sit.
-  </p>
-  <p>
-    <amp-img src="https://lh4.googleusercontent.com/-okOlNNHeoOc/VbYyrlFYFII/AAAAAAABYdA/La-3j3c-QQI/w2004-h734-no/PANO_20150726_171347%257E2.jpg" width=527 height=193 layout="responsive" ></amp-img>
-  </p>
-  <p>
-    <amp-img src="https://lh4.googleusercontent.com/-okOlNNHeoOc/VbYyrlFYFII/AAAAAAABYdA/La-3j3c-QQI/w2004-h734-no/PANO_20150726_171347%257E2.jpg" width=527 height=193 layout="responsive" ></amp-img>
-  </p>
-  <p>
-    <amp-img src="https://lh4.googleusercontent.com/-okOlNNHeoOc/VbYyrlFYFII/AAAAAAABYdA/La-3j3c-QQI/w2004-h734-no/PANO_20150726_171347%257E2.jpg" width=527 height=193 layout="responsive" ></amp-img>
-  </p>
-  <h2>Twitter</h2>
-  <amp-twitter width=486 height=657
-      media="(min-width: 401px)"
-      layout="responsive"
-      data-tweetID="585110598171631616">
-  </amp-twitter>
-  <amp-twitter width=306 height=525
-      media="(max-width: 400px)"
-      layout="responsive"
-      data-tweetID="585110598171631616">
-  </amp-twitter>
-  <!-- no cards -->
-  <amp-twitter width=486 height=256
-      layout="responsive"
-      data-tweetID="585110598171631616"
-      data-cards="hidden">
-  </amp-twitter>
-  <p>
-    <amp-img src="https://lh4.googleusercontent.com/-okOlNNHeoOc/VbYyrlFYFII/AAAAAAABYdA/La-3j3c-QQI/w2004-h734-no/PANO_20150726_171347%257E2.jpg" width=527 height=193 layout="responsive" ></amp-img>
-  </p>
-  <p>
-    Lorem ipsum dolor sit amet, has nisl nihil convenire et, vim at aeque inermis reprehendunt. Propriae tincidunt id nec, elit nusquam te mea, ius noster platonem in. Mea an idque minim, sit sale deleniti apeirian et. Omnium legendos tractatos cu mea. Vix in stet dolorem accusamus. Iisque rationibus consetetur in cum, quo unum nulla legere ut. Simul numquam saperet no sit.
-  </p>
-  <h2>Instagram</h2>
-  <amp-instagram
-    data-shortcode="fBwFP"
-    width="320"
-    height="320"
-    layout="responsive">
-  </amp-instagram>
-  <p>
-    Lorem ipsum dolor sit amet, has nisl nihil convenire et, vim at aeque inermis reprehendunt. Propriae tincidunt id nec, elit nusquam te mea, ius noster platonem in. Mea an idque minim, sit sale deleniti apeirian et. Omnium legendos tractatos cu mea. Vix in stet dolorem accusamus. Iisque rationibus consetetur in cum, quo unum nulla legere ut. Simul numquam saperet no sit.
-  </p>
-  <h2>AddThis</h2>
-  <amp-addthis
-    width="320"
-    height="192"
-    data-pub-id="ra-59c2c366435ef478"
-    data-widget-id="0fyg">
-  </amp-addthis>
-  <h2 id="amp-iframe">IFrame</h2>
-  <amp-iframe width=300 height=300
-      sandbox="allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox"
-      layout="responsive"
-      frameborder="0"
-      src="https://www.google.com/maps/embed/v1/place?key=AIzaSyDG9YXIhKBhqclZizcSzJ0ROiE0qgVfwzI&q=Alameda,%20CA">
-  </amp-iframe>
-  <div>
-    <a on="tap:AMP.goBack">Go back</a>
-  </div>
-  </p>
-  <amp-ad width=300 height=200
-      type="adsense"
-      data-ad-client="ca-pub-9350112648257122">
-  </amp-ad>
-
-  <h2>SVG</h2>
-  <svg width="400" height="296" viewBox="1400 500 3000 2500">
-    <path d="m 3766.9354,1578.1181 c 58.2769,-756.81944 -408.1876,-717.21057 -510.4769,-701.02201 -79.902,12.64545 -239.2559,90.53098 -313.8601,318.92831 -82.3686,252.1683 143.3895,461.6098 259.4436,801.3231 172.8182,640.8523 -882.0196,923.1062 -1227.7959,798.7381 -69.3048,-30.0286 -182.3973,-108.7232 -158.8806,-186.5382 8.5153,-72.4218 -105.5719,-107.3077 -82.4098,-11.1024 95.373,379.694 618.3608,323.5968 1066.1849,144.2115 250.0432,-100.16 489.5859,-347.2474 489.7608,-633.164 -50.7024,-386.8592 -391.2774,-599.5297 -282.7825,-917.5279 173.2946,-330.57664 355.7612,-318.24308 596.6594,-169.4657 82.8022,96.8444 115.4521,181.225 119.5309,313.0092 2.5525,82.4609 -36.2889,260.8703 44.6262,242.61 z" fill="#669900"/>
-    <path d="m 4416.0026,1455.3672 c 77.2745,23.6811 73.5053,107.3467 75.9575,166.8979 15.3869,149.8221 -6.2292,300.1828 4.2896,450.1688 -8.5601,219.3654 0.7438,438.9849 -1.682,658.4723 -9.842,56.6077 34.5512,148.3936 -55.7836,165.4604 -81.0177,12.4369 -163.7234,-0.9781 -245.5127,3.3739 -248.997,-1.7285 -498.1326,1.9053 -747.01,-2.3009 -86.3231,6.2887 -77.5196,-71.1333 -75.8856,-133.0733 43.1106,-461.6582 -55.107,-895.0067 58.8105,-1302.5316 173.2754,-4.339 702.7558,-6.7657 986.8163,-6.4675 z" fill="#6699ff"/>
-    <path d="m 3534.2772,1717.8648 c 221.2517,21.2119 572.0499,-17.0571 851.7094,28.1009 -21.0892,135.2035 -26.2108,343.7127 -18.8464,481.1314 0.6629,160.8137 -8.6026,320.1194 -0.3032,497.6322 -118.3583,29.6629 -269.1727,23.1546 -403.9033,17.3782 -156.4796,-6.7087 -363.7832,20.958 -488.8767,-22.9287 16.6915,-141.6537 14.7827,-372.2907 21.3755,-514.5289 7.5082,-162.6119 26.4066,-324.4933 38.8447,-486.7851 z" fill="#3366cc"/>
-    <path d="m 3889.2766,1650.5266 c 27.7364,23.6886 72.1445,20.4506 101.2331,1.0458 22.3604,-17.6131 19.1236,-56.6446 -8.0767,-68.5575 -51.3171,-39.4426 -125.0811,27.5752 -93.1564,67.5117 z" fill="#ff6600"/>
-    <path d="m 3985.4115,1806.5993 c -54.1134,86.3413 -120.9065,155.5988 -208.7186,279.6705 -98.9752,111.8484 -122.1792,163.717 136.357,69.2462 175.8375,-36.4294 35.4891,130.704 -15.9848,267.0009 -45.1026,119.4263 -83.2501,196.2986 -92.2725,256.8308 139.8358,-155.934 233.9965,-339.5471 357.0405,-505.614 167.1182,-233.0853 -225.0018,-15.3832 -266.0121,-102.9119 38.3338,-115.9788 97.6167,-173.7877 89.7826,-252.6178 l -0.1926,-11.6047 0,0 z" fill="#ffcc00"/>
-    <path d="m 4099.9162,1659.9255 c 27.7366,23.6887 72.1447,20.4507 101.2333,1.046 22.3604,-17.6133 19.1235,-56.6446 -8.0768,-68.5575 -51.3168,-39.4426 -125.0812,27.5752 -93.1565,67.5115 z" fill="#ff6600"/>
-    <path d="m 3681.6605,1651.4038 c 27.7364,23.6888 72.1445,20.4506 101.2332,1.046 22.3603,-17.6132 19.1234,-56.6448 -8.0769,-68.5575 -51.3169,-39.4428 -125.0811,27.5751 -93.1563,67.5115 z" fill="#ff6600"/>
-    <path d="m 2575.0536,1072.0944 c -41.7949,-215.28999 -198.1073,64.4153 -379.7157,193.092 -133.7465,94.7647 -234.5954,11.3165 -570.0903,133.4228 -401.8972,146.2742 -388.2427,684.9442 -224.4598,986.8548 366.0107,674.6879 1103.0419,131.271 1216.6407,-55.3662 104.6211,-171.8874 330.8926,-138.9279 453.9675,-237.6837 59.7216,-47.9209 -5.9599,-359.9096 -105.7909,-337.7945 -648.2816,143.6118 -380.3137,-629.7889 -390.5515,-682.5252 z" fill="#ffcc00"/>
-    <path d="m 2058.3207,1381.3517 c -555.3851,-61.9665 -825.72,463.8013 -645.5204,442.4364 185.0637,-21.9416 158.9799,-504.669 310.9149,49.8713 57.2299,208.8816 401.8092,439.7925 494.821,638.6355 11.6767,57.5407 75.9987,46.3975 104.7889,25.124 31.5505,-23.313 18.9107,-80.0105 6.3288,-117.0635 -83.6721,-143.0048 -274.9312,-272.5734 -377.898,-377.9464 -120.8368,-136.4516 -208.1109,-334.9469 -151.0128,-495.0356 34.8137,-61.4683 63.3834,-80.7131 124.7882,-78.1048 55.22,9.7787 202.4079,237.5436 211.6533,157.296 6.1561,-44.3048 11.1555,-235.1689 -78.8639,-245.2129 z" fill="#ff6600"/>
-    <path d="m 4005.3105,689.39563 c -132.1157,120.32132 -1412.0359,816.95107 -1555.1646,911.30147 160.4961,184.2922 15.234,-12.8488 95.6898,137.9579 550.1675,-329.2476 954.2058,-586.1938 1528.6046,-873.93017 75.1515,-104.89315 -12.1136,-113.30773 -69.1298,-175.3292 z" fill="#3366cc"/>
-    <path d="m 2194.3681,1352.5268 c 9.2935,-33.3595 115.3351,-96.1488 116.2957,-60.9354 14.1803,519.7676 226.8596,740.1443 346.5092,899.2496 -9.1403,53.8137 -95.4967,108.843 -112.5912,76.6163 -104.516,-105.815 -172.0892,-466.006 -263.1765,-522.0611 -35.4594,-21.8216 12.7645,157.4396 -44.8138,184.0385 -77.4149,35.7627 -124.043,-138.0522 -229.1002,-113.7727 -18.3195,211.0153 555.9431,443.0665 505.2979,529.8185 -23.9237,43.5892 -81.9643,131.8588 -116.5557,78.0317 -146.1854,-207.6808 -213.2253,-245.8824 -420.072,-434.4752 -155.6003,-141.8688 -136.5394,-403.4861 -68.1091,-424.1442 116.1363,-27.4812 191.9444,245.9541 275.2956,188.1784 65.7711,-140.9662 -10.6629,-310.5452 11.0201,-400.5444 z" fill="#669900"/>
-    <path d="m 1640.1413,1783.8678 c -1.2739,288.86 586.9469,664.0874 521.3165,807.9936 -69.3201,51.7542 -264.7475,48.6232 -223.0496,-59.7663 40.7522,-117.7527 -130.0456,-272.4627 -303.3394,-291.2684 -296.5803,-32.1851 105.9828,212.4171 191.594,291.2294 36.2581,33.3788 125.7201,137.2209 -60.6765,119.5389 -142.0502,-35.061 -243.6721,-174.3502 -325.3694,-295.8032 -78.4159,-116.5746 -186.0507,-483.4195 -48.246,-480.286 125.3372,6.1146 22.5452,202.8366 86.2367,275.034 41.4944,47.0359 443.4581,128.9297 80.3823,-189.183 -157.9532,-138.3924 81.516,-260.2092 81.1514,-177.489 z" fill="#3366cc"/>
-    <path d="m 4079.5806,868.74488 c -18.4503,-3.3062 -24.5591,-6.34261 -33.5316,-16.66736 -4.696,-5.40376 -13.8197,-14.12548 -20.2749,-19.38163 -15.4956,-12.61776 -67.3382,-71.44012 -79.5473,-90.25706 -5.3049,-8.17621 -11.2871,-16.48111 -13.2935,-18.45531 -3.2617,-3.20909 -2.0572,-6.35995 11.3672,-29.73174 8.2588,-14.37823 17.879,-28.42525 21.3781,-31.21559 5.1887,-4.13699 12.0245,-5.80701 37.0394,-9.04885 16.8723,-2.18653 54.8305,-8.80671 84.352,-14.71151 29.5216,-5.90476 65.0265,-12.78154 78.8997,-15.28165 l 25.2242,-4.54567 23.7713,9.77618 c 62.8275,25.83824 111.7721,65.33019 111.7721,90.18546 1e-4,5.06675 -4.6709,12.80857 -17.366,28.78381 -52.1377,65.60993 -108.3882,110.96089 -146.1569,117.83656 -19.9034,3.62333 -69.5666,5.23515 -83.6338,2.71436 z" fill="#ff6600"/>
-    <path d="m 2377.3238,1269.2624 c -26.787,279.7212 111.0044,672.201 309.1165,843.6212 80.8729,69.9767 240.8138,-4.026 318.9086,-41.6454 45.2094,-35.9724 35.0313,-101.296 26.1997,-150.9873 -17.4339,-69.7557 -49.832,-121.797 -100.685,-116.1204 -45.4057,5.0682 -68.5356,8.8251 -64.9322,120.9642 1.3601,42.327 -40.4759,93.1741 -89.0657,90.4079 -52.9357,4.327 -75.8994,-38.881 -101.1012,-69.9814 -212.4085,-262.1247 -233.2146,-599.5762 -162.849,-813.093 10.758,-32.6441 5.6189,-86.0919 -34.34,-65.3213 -75.6217,39.3078 -93.8408,124.7689 -101.2517,202.1555 z" fill="#ff6600"/>
-  </svg>
-
-  <div id="footer">The end. <a href="#top">Back to top.</a></div>
-
-  <amp-pixel src="https://pubads.g.doubleclick.net/activity;dc_iu=/12344/pixel;ord=$RANDOM?"></amp-pixel>
-
-  <amp-font
-    layout="nodisplay"
-    font-family="Comic Amp"
-    timeout="3000"
-    on-load-remove-class="comic-amp-font-loading"
-    on-error-remove-class="comic-amp-font-loading"
-    on-error-add-class="comic-amp-font-missing"
-    on-load-add-class="comic-amp-font-loaded">
-  </amp-font>
-
-  <div id="breaker">
-    <div id="breaking"></div>
-  </div>
 </article>
 </body>
 </html>

--- a/extensions/amp-bento-info/1.0/amp-bento-info.js
+++ b/extensions/amp-bento-info/1.0/amp-bento-info.js
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {BentoInfo} from './bento-info';
+import {PreactBaseElement} from '../../../src/preact/base-element';
+
+/** @const {string} */
+export const TAG = 'amp-bento-info';
+
+export class AmpBentoInfo extends PreactBaseElement {
+  /** @override */
+  isLayoutSupported() {
+    return true;
+  }
+}
+
+/** @override */
+AmpBentoInfo['Component'] = BentoInfo;
+
+/** @override */
+AmpBentoInfo['loadable'] = true;
+
+/** @override */
+AmpBentoInfo['props'] = {};
+
+/** @override */
+AmpBentoInfo['children'] = {};
+
+AMP.extension(TAG, '1.0', (AMP) => {
+  AMP.registerElement(TAG, AmpBentoInfo);
+});

--- a/extensions/amp-bento-info/1.0/bento-info.js
+++ b/extensions/amp-bento-info/1.0/bento-info.js
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as Preact from '../../../src/preact';
+import {useAmpContext, useLoad} from '../../../src/preact/context';
+
+/**
+ * @return {PreactDef.Renderable}
+ */
+export function BentoInfo({loading, onLoad, onLoadError, ...rest}) {
+  const context = useAmpContext();
+  const load = useLoad(loading);
+
+  const src = 'http://localhost:8000/examples/img/sea@1x.jpg';
+
+  return (
+    <div>
+      <div>context.renderable: {String(context.renderable)}</div>
+      <div>context.playable: {String(context.playable)}</div>
+      <div>context.loading: {String(context.loading)}</div>
+      <div>props.loading: {String(loading)}</div>
+      <div>command.load: {String(load)}</div>
+      <img
+        src={load ? src : null}
+        onLoad={onLoad}
+        onError={onLoadError}
+        style={{width: 40, height: 40}}
+      />
+    </div>
+  );
+}

--- a/extensions/amp-bento-info/1.0/storybook/Basic.js
+++ b/extensions/amp-bento-info/1.0/storybook/Basic.js
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as Preact from '../../../../src/preact';
+import {BentoInfo} from '../bento-info';
+import {Shim} from './shim';
+import {WithAmpContext} from '../../../../src/preact/context';
+import {boolean, select, withKnobs} from '@storybook/addon-knobs';
+import {withA11y} from '@storybook/addon-a11y';
+
+export default {
+  title: 'BentoInfo',
+  component: BentoInfo,
+  decorators: [withA11y, withKnobs],
+};
+
+export const _default = () => {
+  return <Shim />;
+};

--- a/extensions/amp-bento-info/1.0/storybook/shim.js
+++ b/extensions/amp-bento-info/1.0/storybook/shim.js
@@ -1,0 +1,81 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as Preact from '../../../../src/preact';
+import {BentoInfo} from '../bento-info';
+import {WithAmpContext} from '../../../../src/preact/context';
+import {useMemo, useState} from '../../../../src/preact';
+
+export function Shim({}) {
+  const width = 200;
+  const height = 100;
+  const style = {width, height};
+
+  const [renderable, setRenderable] = useState(true);
+  const [playable, setPlayable] = useState(true);
+  const [loadingContext, setLoadingContext] = useState('auto');
+  const contextProps = {renderable, playable, loading: loadingContext};
+
+  const [loading, setLoading] = useState('auto');
+
+  return (
+    <div>
+      <div style={{border: '1px solid', margin: 8, padding: 8}}>
+        <h2>Knobs</h2>
+        <div>
+          context.renderable:
+          <input
+            type="checkbox"
+            checked={renderable}
+            onChange={(e) => setRenderable(e.target.checked)}
+          />
+        </div>
+        <div>
+          context.playable:
+          <input
+            type="checkbox"
+            checked={playable}
+            onChange={(e) => setPlayable(e.target.checked)}
+          />
+        </div>
+        <div>
+          context.loading:
+          <select
+            value={loadingContext}
+            onChange={(e) => setLoadingContext(e.target.value)}
+          >
+            <option value="auto">auto</option>
+            <option value="lazy">lazy</option>
+            <option value="eager">eager</option>
+            <option value="unload">unload</option>
+          </select>
+        </div>
+        <div>
+          props.loading:
+          <select value={loading} onChange={(e) => setLoading(e.target.value)}>
+            <option value="auto">auto</option>
+            <option value="lazy">lazy</option>
+            <option value="eager">eager</option>
+            <option value="unload">unload</option>
+          </select>
+        </div>
+      </div>
+
+      <WithAmpContext {...contextProps}>
+        <BentoInfo style={style} loading={loading} />
+      </WithAmpContext>
+    </div>
+  );
+}

--- a/extensions/amp-carousel/0.1/slidescroll.js
+++ b/extensions/amp-carousel/0.1/slidescroll.js
@@ -192,7 +192,9 @@ export class AmpSlideScroll extends BaseSlides {
       this.dataSlideIdArr_.push(
         slide.getAttribute('data-slide-id') || index.toString()
       );
-      Services.ownersForDoc(this.element).setOwner(slide, this.element);
+      if (!RUNTIME3) {
+        Services.ownersForDoc(this.element).setOwner(slide, this.element);
+      }
       slide.classList.add('amp-carousel-slide');
 
       const slideWrapper = this.win.document.createElement('div');
@@ -329,14 +331,16 @@ export class AmpSlideScroll extends BaseSlides {
         'E#19457 this.slideIndex_'
       );
       const scrollLeft = this.getScrollLeftForIndex_(index);
-      // When display is toggled on a partcular media or element resizes,
-      // it will need to be re-laid-out. This is only needed when the slide
-      // does not change (example when browser window size changes,
-      // or orientation changes)
-      Services.ownersForDoc(this.element).scheduleLayout(
-        this.element,
-        this.slides_[index]
-      );
+      if (!RUNTIME3) {
+        // When display is toggled on a partcular media or element resizes,
+        // it will need to be re-laid-out. This is only needed when the slide
+        // does not change (example when browser window size changes,
+        // or orientation changes)
+        Services.ownersForDoc(this.element).scheduleLayout(
+          this.element,
+          this.slides_[index]
+        );
+      }
       // Reset scrollLeft on orientationChange or anything that changes the
       // size of the carousel.
       this.slidesContainer_./*OK*/ scrollLeft = scrollLeft;
@@ -353,14 +357,16 @@ export class AmpSlideScroll extends BaseSlides {
 
   /** @override */
   updateViewportState(inViewport) {
-    if (this.slideIndex_ !== null) {
-      Services.ownersForDoc(this.element).updateInViewport(
-        this.element,
-        this.slides_[
-          user().assertNumber(this.slideIndex_, 'E#19457 this.slideIndex_')
-        ],
-        inViewport
-      );
+    if (!RUNTIME3) {
+      if (this.slideIndex_ !== null) {
+        Services.ownersForDoc(this.element).updateInViewport(
+          this.element,
+          this.slides_[
+            user().assertNumber(this.slideIndex_, 'E#19457 this.slideIndex_')
+          ],
+          inViewport
+        );
+      }
     }
   }
 
@@ -690,13 +696,15 @@ export class AmpSlideScroll extends BaseSlides {
       showIndexArr.push(nextIndex);
     }
     if (this.slideIndex_ !== null) {
-      Services.ownersForDoc(this.element).updateInViewport(
-        this.element,
-        this.slides_[
-          user().assertNumber(this.slideIndex_, 'E#19457 this.slideIndex_')
-        ],
-        false
-      );
+      if (!RUNTIME3) {
+        Services.ownersForDoc(this.element).updateInViewport(
+          this.element,
+          this.slides_[
+            user().assertNumber(this.slideIndex_, 'E#19457 this.slideIndex_')
+          ],
+          false
+        );
+      }
     }
     const newSlideInView = this.slides_[newIndex];
 
@@ -709,24 +717,33 @@ export class AmpSlideScroll extends BaseSlides {
       );
       return false;
     }
-    Services.ownersForDoc(this.element).updateInViewport(
-      this.element,
-      newSlideInView,
-      true
-    );
+    if (!RUNTIME3) {
+      Services.ownersForDoc(this.element).updateInViewport(
+        this.element,
+        newSlideInView,
+        true
+      );
+    }
     showIndexArr.forEach((showIndex, loopIndex) => {
       if (this.shouldLoop) {
         setStyle(this.slideWrappers_[showIndex], 'order', loopIndex + 1);
       }
       this.slideWrappers_[showIndex].classList.add(SHOWN_CSS_CLASS);
-      const owners = Services.ownersForDoc(this.element);
-      if (showIndex == newIndex) {
-        owners.scheduleLayout(this.element, this.slides_[showIndex]);
-        owners.scheduleResume(this.element, this.slides_[showIndex]);
-        this.slides_[showIndex].setAttribute('aria-hidden', 'false');
+      if (RUNTIME3) {
+        this.slides_[showIndex].setAttribute(
+          'aria-hidden',
+          String(showIndex != newIndex)
+        );
       } else {
-        owners.schedulePreload(this.element, this.slides_[showIndex]);
-        this.slides_[showIndex].setAttribute('aria-hidden', 'true');
+        const owners = Services.ownersForDoc(this.element);
+        if (showIndex == newIndex) {
+          owners.scheduleLayout(this.element, this.slides_[showIndex]);
+          owners.scheduleResume(this.element, this.slides_[showIndex]);
+          this.slides_[showIndex].setAttribute('aria-hidden', 'false');
+        } else {
+          owners.schedulePreload(this.element, this.slides_[showIndex]);
+          this.slides_[showIndex].setAttribute('aria-hidden', 'true');
+        }
       }
     });
     this.slidesContainer_./*OK*/ scrollLeft = this.getScrollLeftForIndex_(
@@ -817,10 +834,12 @@ export class AmpSlideScroll extends BaseSlides {
       }
       // Pause if not the current slide
       if (this.slideIndex_ != i) {
-        Services.ownersForDoc(this.element).schedulePause(
-          this.element,
-          this.slides_[i]
-        );
+        if (!RUNTIME3) {
+          Services.ownersForDoc(this.element).schedulePause(
+            this.element,
+            this.slides_[i]
+          );
+        }
       }
     }
   }

--- a/src/amp.js
+++ b/src/amp.js
@@ -106,7 +106,9 @@ function bootstrap(ampdoc, perf) {
   );
   startupChunk(self.document, function finalTick() {
     perf.tick(TickLabel.END_INSTALL_STYLES);
-    Services.resourcesForDoc(ampdoc).ampInitComplete();
+    if (!RUNTIME3) {
+      Services.resourcesForDoc(ampdoc).ampInitComplete();
+    }
     // TODO(erwinm): move invocation of the `flush` method when we have the
     // new ticks in place to batch the ticks properly.
     perf.flush();

--- a/src/base-element.js
+++ b/src/base-element.js
@@ -291,6 +291,11 @@ export class BaseElement {
   }
 
   /**
+   * @param {boolean} isDisplayed
+   */
+  displayedCallback(isDisplayed) {}
+
+  /**
    * @return {boolean}
    */
   isInViewport() {

--- a/src/preact/base-element.js
+++ b/src/preact/base-element.js
@@ -135,15 +135,6 @@ export class PreactBaseElement extends AMP.BaseElement {
       notify: () => this.mutateElement(() => {}),
     };
 
-    /** @private {?Node} */
-    this.container_ = null;
-
-    /** @private {boolean} */
-    this.scheduledRender_ = false;
-
-    /** @private {?Deferred} */
-    this.renderDeferred_ = null;
-
     /** @private {{current: ?API_TYPE}} */
     this.ref_ = createRef();
 
@@ -377,14 +368,6 @@ export class PreactBaseElement extends AMP.BaseElement {
     }
   }
 
-  /** @private */
-  onLoad_() {
-    if (this.loadDeferred_) {
-      this.loadDeferred_.resolve();
-      this.loadDeferred_ = null;
-    }
-  }
-
   /**
    * @param {*} opt_reason
    * @private
@@ -581,13 +564,6 @@ export class PreactBaseElement extends AMP.BaseElement {
 PreactBaseElement['Component'] = function () {
   devAssert(false, 'Must provide Component');
 };
-
-/**
- * Whether the component implements a loading protocol.
- *
- * @protected {boolean}
- */
-PreactBaseElement['loadable'] = false;
 
 /**
  * @protected {!Array<!ContextProp>}

--- a/src/preact/context.js
+++ b/src/preact/context.js
@@ -54,7 +54,6 @@ export function WithAmpContext({
   playable: playableProp = true,
   loading: loadingProp = 'auto',
   notify: notifyProp,
-  loading: loadingProp,
   children,
 }) {
   const parent = useAmpContext();

--- a/src/preact/context.js
+++ b/src/preact/context.js
@@ -54,6 +54,7 @@ export function WithAmpContext({
   playable: playableProp = true,
   loading: loadingProp = 'auto',
   notify: notifyProp,
+  loading: loadingProp,
   children,
 }) {
   const parent = useAmpContext();

--- a/src/service/core-services.js
+++ b/src/service/core-services.js
@@ -19,6 +19,7 @@ import {installActionServiceForDoc} from './action-impl';
 import {installBatchedXhrService} from './batched-xhr-impl';
 import {installCidService} from './cid-impl';
 import {installCryptoService} from './crypto-impl';
+import {installCustomElements} from './custom-elements';
 import {installDocumentInfoServiceForDoc} from './document-info-impl';
 import {installGlobalNavigationHandlerForDoc} from './navigation';
 import {installGlobalSubmitListenerForDoc} from '../document-submit';
@@ -27,6 +28,7 @@ import {installHistoryServiceForDoc} from './history-impl';
 import {installImg} from '../../builtins/amp-img';
 import {installInputService} from '../input';
 import {installLayout} from '../../builtins/amp-layout';
+import {installLoadScheduler} from './load-scheduler';
 import {installMutatorServiceForDoc} from './mutator-impl';
 import {installOwnersServiceForDoc} from './owners-impl';
 import {installPixel} from '../../builtins/amp-pixel';
@@ -80,6 +82,11 @@ export function installRuntimeServices(global) {
 export function installAmpdocServices(ampdoc) {
   const isEmbedded = !!ampdoc.getParent();
 
+  if (RUNTIME3) {
+    installCustomElements(ampdoc);
+    installLoadScheduler(ampdoc);
+  }
+
   // When making changes to this method:
   // 1. Order is important!
   // 2. Consider to install same services to amp-inabox.js
@@ -101,15 +108,17 @@ export function installAmpdocServices(ampdoc) {
   isEmbedded
     ? adoptServiceForEmbedDoc(ampdoc, 'history')
     : installHistoryServiceForDoc(ampdoc);
-  isEmbedded
-    ? adoptServiceForEmbedDoc(ampdoc, 'resources')
-    : installResourcesServiceForDoc(ampdoc);
-  isEmbedded
-    ? adoptServiceForEmbedDoc(ampdoc, 'owners')
-    : installOwnersServiceForDoc(ampdoc);
-  isEmbedded
-    ? adoptServiceForEmbedDoc(ampdoc, 'mutator')
-    : installMutatorServiceForDoc(ampdoc);
+  if (!RUNTIME3) {
+    isEmbedded
+      ? adoptServiceForEmbedDoc(ampdoc, 'resources')
+      : installResourcesServiceForDoc(ampdoc);
+    isEmbedded
+      ? adoptServiceForEmbedDoc(ampdoc, 'owners')
+      : installOwnersServiceForDoc(ampdoc);
+    isEmbedded
+      ? adoptServiceForEmbedDoc(ampdoc, 'mutator')
+      : installMutatorServiceForDoc(ampdoc);
+  }
   isEmbedded
     ? adoptServiceForEmbedDoc(ampdoc, 'url-replace')
     : installUrlReplacementsServiceForDoc(ampdoc);

--- a/src/service/custom-elements.js
+++ b/src/service/custom-elements.js
@@ -1,0 +1,160 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {hasNextNodeInDocumentOrder} from '../dom';
+import {registerServiceBuilderForDoc} from '../service';
+import {removeItem} from '../utils/array';
+
+/**
+ * @typedef {{
+ *   readyToBuild: (boolean|undefined),
+ *   domReady: (boolean|undefined),
+ *   displayed: (boolean|undefined),
+ * }}
+ */
+let ElementDataDef;
+
+/**
+ * This is Resources v2 but much more taregtted. It deals only with questions
+ * of renderability.
+ *
+ * @implements {../service.Disposable}
+ */
+export class CustomElements {
+  /**
+   * @param {./ampdoc-impl.AmpDoc} ampdoc
+   */
+  constructor(ampdoc) {
+    /** @const */
+    this.ampdoc = ampdoc;
+
+    /** @private @const */
+    this.displayTracker_ = new IntersectionObserver(
+      this.handleDisplay_.bind(this),
+      {
+        root: ampdoc.getBody(),
+      }
+    );
+
+    /** @private @const {!Map<!Element, !ElementDataDef>} */
+    this.elements_ = new Map();
+
+    /** @private @const {!Array<!AmpElement>} */
+    this.pendingDomReady_ = [];
+
+    ampdoc.whenReady().then(() => this.checkPendingDomReady_());
+  }
+
+  /** @override */
+  dispose() {
+    this.elements_.clear();
+    this.pendingDomReady_.length = 0;
+    this.displayTracker_.disconnect();
+  }
+
+  /**
+   * @param {!AmpElement} element
+   */
+  connected(element) {
+    if (!this.elements_.has(element)) {
+      this.elements_.set(element, {});
+    }
+    if (this.ampdoc.isReady()) {
+      this.update_(element, {domReady: true});
+    } else if (!this.pendingDomReady_.includes(element)) {
+      this.pendingDomReady_.push(element);
+      this.checkPendingDomReady_();
+    }
+  }
+
+  /**
+   * @param {!AmpElement} element
+   */
+  disconnected(element) {
+    this.elements_.delete(element);
+    removeItem(this.pendingDomReady_, element);
+    this.displayTracker_.unobserve(element);
+  }
+
+  /**
+   * @param {!AmpElement} element
+   */
+  readyToBuild(element) {
+    this.update_(element, {readyToBuild: true});
+  }
+
+  /**
+   * @param {!AmpElement} element
+   * @param {!ElementDataDef} data
+   */
+  update_(element, data) {
+    const existingData = this.elements_.get(element);
+    if (!existingData) {
+      return;
+    }
+    Object.assign(existingData, data);
+    console.log(
+      'CustomElements.update_',
+      element.nodeName + '#' + element.id,
+      data,
+      '=>',
+      existingData
+    );
+
+    const {domReady, readyToBuild, displayed} = existingData;
+
+    const trackDisplay = domReady && readyToBuild;
+    if (trackDisplay) {
+      this.displayTracker_.observe(element);
+    } else {
+      this.displayTracker_.unobserve(element);
+    }
+
+    element.displayedCallback(displayed);
+  }
+
+  /**
+   * @param {!Array<!IntersectionObserverEntry>} records
+   * @private
+   */
+  handleDisplay_(records) {
+    records.forEach(({target, isIntersecting}) => {
+      this.update_(target, {displayed: isIntersecting});
+    });
+  }
+
+  /** @private */
+  checkPendingDomReady_() {
+    const root = this.ampdoc.getRootNode();
+    const docReady = this.ampdoc.isReady();
+    for (let i = 0; i < this.pendingDomReady_.length; i++) {
+      const node = this.pendingDomReady_[i];
+      if (docReady || hasNextNodeInDocumentOrder(node, root)) {
+        // Remove resource before build to remove it from the pending list
+        // in either case the build succeed or throws an error.
+        this.pendingDomReady_.splice(i--, 1);
+        this.update_(element, {domReady: true});
+      }
+    }
+  }
+}
+
+/**
+ * @param {!./ampdoc-impl.AmpDoc} ampdoc
+ */
+export function installCustomElements(ampdoc) {
+  registerServiceBuilderForDoc(ampdoc, 'customElements', CustomElements);
+}

--- a/src/service/load-scheduler.js
+++ b/src/service/load-scheduler.js
@@ -1,0 +1,80 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {registerServiceBuilderForDoc} from '../service';
+
+/**
+ * This is Resources v2 but much more taregtted. It deals only with questions
+ * of loading.
+ *
+ * @implements {../service.Disposable}
+ */
+export class LoadScheduler {
+  /**
+   * @param {./ampdoc-impl.AmpDoc} ampdoc
+   */
+  constructor(ampdoc) {
+    /** @const */
+    this.ampdoc = ampdoc;
+
+    /** @private @const */
+    this.io_ = new IntersectionObserver(this.handleIntersections_.bind(this), {
+      root: ampdoc.win.document,
+      rootMargin: '100% 25%',
+    });
+  }
+
+  /** @override */
+  dispose() {
+    this.io_.disconnect();
+  }
+
+  /**
+   * @param {!AmpElement} element
+   */
+  schedule(element) {
+    this.io_.observe(element);
+  }
+
+  /**
+   * @param {!AmpElement} element
+   */
+  unschedule(element) {
+    this.io_.unobserve(element);
+  }
+
+  /**
+   * @param {!Array<!IntersectionObserverEntry>} records
+   * @private
+   */
+  handleIntersections_(records) {
+    records.forEach(({target, isIntersecting}) => {
+      if (isIntersecting) {
+        this.io_.unobserve(target);
+        setTimeout(() => {
+          target.load();
+        }, 2000);
+      }
+    });
+  }
+}
+
+/**
+ * @param {!./ampdoc-impl.AmpDoc} ampdoc
+ */
+export function installLoadScheduler(ampdoc) {
+  registerServiceBuilderForDoc(ampdoc, 'loadScheduler', LoadScheduler);
+}

--- a/src/service/performance-impl.js
+++ b/src/service/performance-impl.js
@@ -222,7 +222,9 @@ export class Performance {
     const {documentElement} = this.win.document;
     this.ampdoc_ = Services.ampdoc(documentElement);
     this.viewer_ = Services.viewerForDoc(documentElement);
-    this.resources_ = Services.resourcesForDoc(documentElement);
+    if (!RUNTIME3) {
+      this.resources_ = Services.resourcesForDoc(documentElement);
+    }
 
     this.isPerformanceTrackingOn_ =
       this.viewer_.isEmbedded() && this.viewer_.getParam('csi') === '1';
@@ -650,6 +652,9 @@ export class Performance {
    * @private
    */
   whenViewportLayoutComplete_() {
+    if (RUNTIME3) {
+      return Promise.resolve();
+    }
     return this.resources_.whenFirstPass().then(() => {
       const {documentElement} = this.win.document;
       const size = Services.viewportForDoc(documentElement).getSize();

--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -88,6 +88,7 @@ export class Resource {
    * @return {!Resource}
    */
   static forElement(element) {
+    devAssert(!RUNTIME3);
     return /** @type {!Resource} */ (devAssert(
       Resource.forElementOptional(element),
       'Missing resource prop on %s',
@@ -100,6 +101,7 @@ export class Resource {
    * @return {Resource}
    */
   static forElementOptional(element) {
+    devAssert(!RUNTIME3);
     return /** @type {Resource} */ (element[RESOURCE_PROP_]);
   }
 
@@ -110,6 +112,7 @@ export class Resource {
    * @param {!AmpElement} owner
    */
   static setOwner(element, owner) {
+    devAssert(!RUNTIME3);
     devAssert(owner.contains(element), 'Owner must contain the element');
     if (Resource.forElementOptional(element)) {
       Resource.forElementOptional(element).updateOwner(owner);

--- a/src/service/standard-actions-impl.js
+++ b/src/service/standard-actions-impl.js
@@ -78,8 +78,10 @@ export class StandardActions {
       ? opt_win.document.documentElement
       : ampdoc.getHeadNode();
 
-    /** @const @private {!./mutator-interface.MutatorInterface} */
-    this.mutator_ = Services.mutatorForDoc(ampdoc);
+    if (!RUNTIME3) {
+      /** @const @private {!./mutator-interface.MutatorInterface} */
+      this.mutator_ = Services.mutatorForDoc(ampdoc);
+    }
 
     /** @const @private {!./viewport/viewport-interface.ViewportInterface} */
     this.viewport_ = Services.viewportForDoc(ampdoc);

--- a/src/services.js
+++ b/src/services.js
@@ -794,4 +794,26 @@ export class Services {
   static xhrFor(window) {
     return /** @type {!./service/xhr-impl.Xhr} */ (getService(window, 'xhr'));
   }
+
+  /**
+   * @param {!Element|!./service/ampdoc-impl.AmpDoc} elementOrAmpDoc
+   * @return {!./service/custom-elements.CustomElements}
+   */
+  static customElements(elementOrAmpDoc) {
+    return /** @type {!./service/custom-elements.CustomElements} */ (getServiceForDoc(
+      elementOrAmpDoc,
+      'customElements'
+    ));
+  }
+
+  /**
+   * @param {!Element|!./service/ampdoc-impl.AmpDoc} elementOrAmpDoc
+   * @return {!./service/load-scheduler.LoadScheduler}
+   */
+  static loadScheduler(elementOrAmpDoc) {
+    return /** @type {!./service/load-scheduler.LoadScheduler} */ (getServiceForDoc(
+      elementOrAmpDoc,
+      'loadScheduler'
+    ));
+  }
 }

--- a/src/style-installer.js
+++ b/src/style-installer.js
@@ -268,8 +268,10 @@ export function makeBodyVisible(doc) {
       const ampdoc = getAmpdoc(doc);
       ampdoc.signals().signal(CommonSignals.RENDER_START);
       if (services.length > 0) {
-        const resources = Services.resourcesForDoc(doc.documentElement);
-        resources./*OK*/ schedulePass(1, /* relayoutAll */ true);
+        if (!RUNTIME3) {
+          const resources = Services.resourcesForDoc(doc.documentElement);
+          resources./*OK*/ schedulePass(1, /* relayoutAll */ true);
+        }
       }
       try {
         const perf = Services.performanceFor(win);


### PR DESCRIPTION
This pull request can be viewed as an alternative to the #29904. Most of this code is actually applicable to the Context API as well, but it can be done independently. This is sort of a "old way of doing things" and thus more familiar and more incremental, which is both plus and minus.

Here are the key review points:
1. Note that `Owners`, and `Mutator` systems are completely gone.
2. The `Resources` is split into two services: `CustomElements` and `LoadScheduler`. The former is responsible for renderability and the latter is focused on loading behavior. These roughly map to `CanRender` and `Loading` props from #29904.
3. Most of logic is done via a new `displayedCallback` callback. I might rename it. It's real meaning is really `canRenderCallback`.
3. Instead of a state machine, the custom-element implements "build when requested" and "load when requested". The idea is that both build and load can be deferred and scheduled as needed.
4. Please complete ignore `amp-bento-info` - this is just for testing.
5. A lot of `src/preact/base-element.js` diff is from #30282, still in review. Feel free to ignore.
6. All of the `src/preact/context.js` and `src/preact/context.type.js` diff is from #30282, still in review. Feel free to ignore.
7. Notice that the use of `IntersectionObserver` in `CustomElements` is very inefficient in a polyfill (native seems ok though). We'd need to rewrite this part of the polyfill. But I think it's not too hard.
8. Note that very importantly, this approach is fully compatible with `content-visibility: hidden|auto`.

A more direct comparison to #29904 and Context APIs. To repeat, it's not necessarily either-or. But:
1. There's still somewhat of a "state machine" here. The chain of callback calls is not obvious. For instance, `readyToBuild` signal is sent from `CustomElement` to `CustomElements` and as the result `CustomElements` calls `CustomElement.displayCallback`. There are many such N-way callbacks going. In Context API the callbacks are always 1-way.
2. `CustomElements` and `LoadScheduler` have to depend on the `AmpDoc` API and thus couple us tighter into AMP Runtime. Consequently, extensions are less independent.
3. The re-enterability of code is done manually. E.g. `if (old != new) {...}` is repeated all over the place.
4. Do/undo (or effect/cleanup) are too far from each other and not obvious. E.g. see `displayCallback`: `if/else` are not symmetrical, etc. Have to always remember to call `displayCallback(false)` from `unlayoutCallback` and such.
5. No service overrides for DOM subtrees. E.g. only one `LoadScheduler` per ampdoc. Not necessarily a blocker though, since we only have a few of these.
6. Hard to chunk code. Context API essentially has a single and consistent queue. But here we have to make separate queues inside each service.
7. An element's state is spread out across many services. E.g. `CustomElements` has its map with `Element->ElementData` and likely so will `LoadScheduler` and many more. Context API centralizes the state and it's observable on the element itself, which is easier for debugging and testing. As a consequence the dependency graph is more complicated.
8. I can't quite separate loading indicator easily here. But it should still be doable, just probably somewhat ugly.
9. `CanPlay` concept is absent here. Instead, `CanRender` is used as its proxy, which is not sufficient in some cases. E.g. `visibility:hidden` and similar cases cannot be done this way. This is still a problem to solve, but I have a few ideas on how.
10. Beyond `CanPlay`, we basically can only really support properties that can be directly derived from intersection observer. Those are the most important once at this time, but it's somewhat limiting.
11. Because we rely strictly on IntersectionObserver, it makes it harder to support viewer and document visibility. But I have some ideas in this area.
12. We can't link context back from a component. E.g. a composite component cannot directly say "this subtree is not renderable" and have it applied via DOM to child elements. This concerns me a lot. It seems like a useful feature for a composite component to annotate its subtrees.

Open questions:
1. What do we do with `attemptChangeSize` API that's still in `Resources`?
2. What do we do with `pause` and `unload` call based on document/viewer state that's still in `Resources`?
