### PR TITLE
🏗 Clean up duplicate logging in `gulp dist` during `worker-dom` resource copying

### DIFF
--- a/build-system/tasks/extension-helpers.js
+++ b/build-system/tasks/extension-helpers.js
@@ -575,11 +575,6 @@ async function copyWorkerDomResources(version) {
   const startTime = Date.now();
   const workerDomDir = 'node_modules/@ampproject/worker-dom';
   const targetDir = 'dist/v0';
-  log(
-    green('Copying @ampproject/worker-dom resources:'),
-    cyan('worker.js, worker.nodom.js')
-  );
-
   const dir = `${workerDomDir}/dist`;
   const workerFilesToDeploy = new Map([
     ['amp-production/worker/worker.js', `amp-script-worker-${version}.js`],
@@ -638,11 +633,7 @@ async function copyWorkerDomResources(version) {
   for (const [src, dest] of workerFilesToDeploy) {
     await fs.copy(`${dir}/${src}`, `${targetDir}/${dest}`);
   }
-  endBuildStep(
-    'Copied @ampproject/worker-dom resources',
-    'worker.js, worker.nodom.js',
-    startTime
-  );
+  endBuildStep('Copied', '@ampproject/worker-dom resources', startTime);
 }
 
 module.exports = {


### PR DESCRIPTION
This PR cleans up the duplicate logging introduced by #30141.

Addresses https://github.com/ampproject/amphtml/pull/30141#discussion_r485963577

