### PR TITLE
🐛 Don't re-register previously registered video players

### DIFF
--- a/src/service/video-manager-impl.js
+++ b/src/service/video-manager-impl.js
@@ -187,13 +187,19 @@ export class VideoManager {
   register(video) {
     devAssert(video);
 
+    this.entries_ = this.entries_ || [];
+
+    // Don't register duplicate entries
+    if (this.entries_.some((entry) => entry.video === video)) {
+      return;
+    }
+
     this.registerCommonActions_(video);
 
     if (!video.supportsPlatform()) {
       return;
     }
 
-    this.entries_ = this.entries_ || [];
     const entry = new VideoEntry(this, video);
     this.maybeInstallVisibilityObserver_(entry);
     this.entries_.push(entry);

--- a/test/integration/test-video-manager.js
+++ b/test/integration/test-video-manager.js
@@ -254,6 +254,12 @@ describe
           });
         });
 
+        it('should not register duplicate entries', () => {
+          videoManager.register(impl);
+          videoManager.register(impl);
+          expect(videoManager.entries_.length).to.equal(1);
+        });
+
         beforeEach(() => {
           klass = createFakeVideoPlayerClass(env.win);
           video = env.createAmpElement('amp-test-fake-videoplayer', klass);


### PR DESCRIPTION
Video players could be registered more than once, creating more than one video manager entry. Beacuse of this, as in #29364, a player in a lightbox displayed and hidden multiple times could not play content the second or subsequent time. On the playing event, each entry would try to pause other managed players, immediately pausing playback.

This change skips registering the video, if it is already registered.

Fixes #29364

