### PR TITLE
🐛 "activate 360" button always above content

### DIFF
--- a/css/Z_INDEX.md
+++ b/css/Z_INDEX.md
@@ -41,6 +41,7 @@ Run `gulp get-zindex` to generate this file.
 | .i-amphtml-story-focused-state-layer                                                                    | 100001     | extensions/amp-story/1.0/amp-story-tooltip.css                       |
 | .i-amphtml-story-page-attachment-expand                                                                 | 100000     | extensions/amp-story/1.0/amp-story-page-attachment.css               |
 | .i-amphtml-story-system-layer                                                                           | 100000     | extensions/amp-story/1.0/amp-story-system-layer.css                  |
+| .i-amphtml-story-360-activate-button                                                                    | 100000     | extensions/amp-story-360.css                                         |
 | .i-amphtml-story-page-error                                                                             | 10000      | extensions/amp-story/1.0/amp-story.css                               |
 | .i-amphtml-story-page-play-button                                                                       | 10000      | extensions/amp-story/1.0/amp-story.css                               |
 | .i-amphtml-image-lightbox-trans                                                                         | 1001       | extensions/amp-image-lightbox/0.1/amp-image-lightbox.css             |

--- a/extensions/amp-story-360/0.1/amp-story-360.css
+++ b/extensions/amp-story-360/0.1/amp-story-360.css
@@ -40,7 +40,7 @@ amp-story-360 amp-img {
   font-family: 'Roboto', sans-serif !important;
   display: flex !important;
   align-items: center !important;
-  z-index: 100000;
+  z-index: 100000 !important;
 }
 
 .i-amphtml-story-360-activate-button-icon {

--- a/extensions/amp-story-360/0.1/amp-story-360.css
+++ b/extensions/amp-story-360/0.1/amp-story-360.css
@@ -40,6 +40,7 @@ amp-story-360 amp-img {
   font-family: 'Roboto', sans-serif !important;
   display: flex !important;
   align-items: center !important;
+  z-index: 100000;
 }
 
 .i-amphtml-story-360-activate-button-icon {


### PR DESCRIPTION
Sets z-index on `i-amphtml-story-360-activate-button` to be same as `i-amphtml-story-system-layer`.
This ensures it will always be above content.
Updates Z_INDEX.md

cc @ampproject/wg-stories @t0mg 