### PR TITLE
SwG Release 0.1.22.121

### DIFF
--- a/third_party/subscriptions-project/config.js
+++ b/third_party/subscriptions-project/config.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/** Version: 0.1.22.120 */
+/** Version: 0.1.22.121 */
 /**
  * Copyright 2018 The Subscribe with Google Authors. All Rights Reserved.
  *


### PR DESCRIPTION
## Version: 0.1.22.121

## Previous release: [0.1.22.120](https://github.com/subscriptions-project/swg-js/releases/tag/0.1.22.120)

  - Change minified name for GSI JS. (#1282)
  - Update dependency rollup to v2.28.2 (#1281)
  - Adds handling of subscribe button on metering toast iframe (#1280)
  - Update dependency postcss to v8.0.9 (#1279)
  - Update dependency postcss to v8.0.8 (#1278)
  - Update dependency postcss to v8.0.7 (#1276)
  - GSI: Renders GSI iframe (#1273)
  - Update dependency postcss to v8.0.6 (#1274)
  - Update dependency rollup to v2.28.1 (#1275)
  - Sends list of allowed origins in example iframe. (#1272)
  - Create Example Google Sign-in iframe (#1238)
  - Update dependency rollup to v2.27.1 (#1271)
  - Update dependency postcss to v8.0.5 (#1270)
  - Update dependency postcss to v8.0.4 (#1269)
  - Update dependency rollup to v2.27.0 (#1268)
  - Update dependency prettier to v2.1.2 (#1267)
  - Update dependency postcss to v8.0.3 (#1266)
  - Update dependency autoprefixer to v10 (#1265)
  - Update dependency postcss to v8.0.2 (#1264)
  - Update dependency postcss to v8 (#1263)
  - Entitlements Manager: Adds tests for consume method (#1260)
  - Metering Entitlements demo: Adds Regwall (#1262)
  - Bump node-fetch from 2.6.0 to 2.6.1 (#1258)
  - Update dependency eslint to v7.9.0 (#1259)
  - Improve coverage for Analytics Service (#1254)
  - Metering Demo now handles existing subscription entitlements (#1257)
  - Metering Entitlements don't trigger Toast anymore (#1256)
  - Compiler checks --frontend param (#1255)
  - Enables E2E tests in Travis (#1253)
  - Fix e2e tests (#1252)
  - Update dependency rollup to v2.26.11 (#1248)
  - Update dependency karma to v5.2.2 (#1249)
  - Update dependency chromedriver to v85.0.1 (#1251)
  - Meter regwall (forked from Chen's PR #1208) (#1250)
  - Update dependency @babel/core to v7.11.6 (#1246)