### PR TITLE
✨ [bento][amp-date-countdown] Bento version of AMP component

### DIFF
--- a/build-system/compile/bundles.config.js
+++ b/build-system/compile/bundles.config.js
@@ -485,7 +485,7 @@ exports.extensionBundles = [
   },
   {
     name: 'amp-date-countdown',
-    version: '0.1',
+    version: ['0.1', '1.0'],
     latestVersion: '0.1',
     type: TYPES.MISC,
   },

--- a/extensions/amp-date-countdown/1.0/amp-date-countdown.js
+++ b/extensions/amp-date-countdown/1.0/amp-date-countdown.js
@@ -1,0 +1,143 @@
+/**
+ * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as Preact from '../../../src/preact';
+import {ActionTrust} from '../../../src/action-constants';
+import {DateCountdown} from './date-countdown';
+import {PreactBaseElement} from '../../../src/preact/base-element';
+import {Services} from '../../../src/services';
+import {dict} from '../../../src/utils/object';
+import {isLayoutSizeDefined} from '../../../src/layout';
+import {removeChildren} from '../../../src/dom';
+import {user, userAssert} from '../../../src/log';
+
+/** @const {string} */
+const TAG = 'amp-date-countdown';
+
+/** @const {string} */
+const DEFAULT_LOCALE = 'en';
+
+/** @const {string} */
+const DEFAULT_WHEN_ENDED = 'stop';
+
+/** @const {string} */
+const DEFAULT_BIGGEST_UNIT = 'DAYS';
+
+/** @const {number} */
+const DEFAULT_OFFSET_SECONDS = 0;
+
+/** @const {number} */
+const MILLISECONDS_IN_DAY = 24 * 60 * 60 * 1000;
+
+/** @const {number} */
+const MILLISECONDS_IN_HOUR = 60 * 60 * 1000;
+
+/** @const {number} */
+const MILLISECONDS_IN_MINUTE = 60 * 1000;
+
+/** @const {number} */
+const MILLISECONDS_IN_SECOND = 1000;
+
+/** @const {Object} */
+//https://ctrlq.org/code/19899-google-translate-languages refer to google code
+const LOCALE_WORD = {
+  'de': ['Jahren', 'Monaten', 'Tagen', 'Stunden', 'Minuten', 'Sekunden'],
+  'en': ['Years', 'Months', 'Days', 'Hours', 'Minutes', 'Seconds'],
+  'es': ['años', 'meses', 'días', 'horas', 'minutos', 'segundos'],
+  'fr': ['ans', 'mois', 'jours', 'heures', 'minutes', 'secondes'],
+  'id': ['tahun', 'bulan', 'hari', 'jam', 'menit', 'detik'],
+  'it': ['anni', 'mesi', 'giorni', 'ore', 'minuti', 'secondi'],
+  'ja': ['年', 'ヶ月', '日', '時間', '分', '秒'],
+  'ko': ['년', '달', '일', '시간', '분', '초'],
+  'nl': ['jaar', 'maanden', 'dagen', 'uur', 'minuten', 'seconden'],
+  'pt': ['anos', 'meses', 'dias', 'horas', 'minutos', 'segundos'],
+  'ru': ['год', 'месяц', 'день', 'час', 'минута', 'секунда'],
+  'th': ['ปี', 'เดือน', 'วัน', 'ชั่วโมง', 'นาที', 'วินาที'],
+  'tr': ['yıl', 'ay', 'gün', 'saat', 'dakika', 'saniye'],
+  'vi': ['năm', 'tháng', 'ngày', 'giờ', 'phút', 'giây'],
+  'zh-cn': ['年', '月', '天', '小时', '分钟', '秒'],
+  'zh-tw': ['年', '月', '天', '小時', '分鐘', '秒'],
+};
+
+class AmpDateCountdown extends PreactBaseElement {
+  /** @override */
+  init() {
+    const templates = Services.templatesFor(this.win);
+    let rendered = false;
+
+    return dict({
+      /**
+       * @param {!JsonObject} data
+       * @param {*} children
+       * @return {*}
+       */
+      'render': (data, children) => {
+        // We only render once in AMP mode, but React mode may rerender
+        // serveral times.
+        if (rendered) {
+          return children;
+        }
+        rendered = true;
+
+        const host = this.element;
+        const domPromise = templates
+          .findAndRenderTemplate(host, data)
+          .then((rendered) => {
+            const container = document.createElement('div');
+            container.appendChild(rendered);
+
+            return <RenderDomTree dom={container} host={host} />;
+          });
+
+        return (
+          <>
+            {children}
+            <AsyncRender>{domPromise}</AsyncRender>
+          </>
+        );
+      },
+    });
+  }
+
+  /** @override */
+  isLayoutSupported(layout) {
+    userAssert(
+      isExperimentOn(this.win, 'amp-date-countdown-bento'),
+      'expected amp-date-countdown-bento experiment to be enabled'
+    );
+    return isLayoutSizeDefined(layout);
+  }
+}
+
+/** @override */
+AmpDateCountdown['Component'] = DateCountdown;
+
+/** @override */
+AmpDateCountdown['passthrough'] = true;
+
+/** @override */
+AmpDateCountdown['props'] = {
+  'displayIn': {attr: 'display-in'},
+  'offsetSeconds': {attr: 'offset-seconds', type: 'number'},
+  'locale': {attr: 'locale'},
+  'datetime': {attr: 'datetime'},
+  'timestampMs': {attr: 'timestamp-ms', type: 'number'},
+  'timestampSeconds': {attr: 'timestamp-seconds', type: 'number'},
+};
+
+AMP.extension(TAG, '1.0', (AMP) => {
+  AMP.registerElement(TAG, AmpDateCountdown);
+});

--- a/extensions/amp-date-countdown/1.0/amp-date-countdown.js
+++ b/extensions/amp-date-countdown/1.0/amp-date-countdown.js
@@ -55,28 +55,29 @@ class AmpDateCountdown extends PreactBaseElement {
     const templates =
       this.templates_ || (this.templates_ = Services.templatesFor(this.win));
     const template = templates.maybeFindTemplate(this.element);
-    if (template != this.template_) {
-      this.template_ = template;
-      if (template) {
-        // Only overwrite `render` when template is ready to minimize FOUC.
-        templates.whenReady(template).then(() => {
-          if (template != this.template_) {
-            // A new template has been set while the old one was initializing.
-            return;
-          }
-          this.mutateProps(
-            dict({
-              'render': (data) => {
-                return templates
-                  .renderTemplateAsString(dev().assertElement(template), data)
-                  .then((html) => dict({'__html': html}));
-              },
-            })
-          );
-        });
-      } else {
-        this.mutateProps(dict({'render': null}));
-      }
+    if (template === this.template_) {
+      return;
+    }
+    this.template_ = template;
+    if (template) {
+      // Only overwrite `render` when template is ready to minimize FOUC.
+      templates.whenReady(template).then(() => {
+        if (template != this.template_) {
+          // A new template has been set while the old one was initializing.
+          return;
+        }
+        this.mutateProps(
+          dict({
+            'render': (data) => {
+              return templates
+                .renderTemplateAsString(dev().assertElement(template), data)
+                .then((html) => dict({'__html': html}));
+            },
+          })
+        );
+      });
+    } else {
+      this.mutateProps(dict({'render': null}));
     }
   }
 
@@ -128,7 +129,7 @@ AmpDateCountdown['props'] = {
 export function parseDateAttrs(element) {
   const epoch = userAssert(
     parseEpoch(element),
-    `One of end-date, timeleft-ms, timestamp-ms, timestamp-seconds` +
+    `One of end-date, timeleft-ms, timestamp-ms, timestamp-seconds ` +
       `is required. ${TAG}`
   );
 

--- a/extensions/amp-date-countdown/1.0/amp-date-countdown.js
+++ b/extensions/amp-date-countdown/1.0/amp-date-countdown.js
@@ -104,7 +104,7 @@ AmpDateCountdown['usesTemplate'] = true;
 
 /** @override */
 AmpDateCountdown['props'] = {
-  'dateTime': {
+  'datetime': {
     attrs: [
       'end-date',
       'timeleft-ms',

--- a/extensions/amp-date-countdown/1.0/date-countdown.js
+++ b/extensions/amp-date-countdown/1.0/date-countdown.js
@@ -62,7 +62,7 @@ const DEFAULT_RENDER = (data) =>
   /** @type {string} */ (`${data['days']} ${data['dd']}, ` +
     `${data['hours']} ${data['hh']}, ` +
     `${data['minutes']} ${data['mm']}, ` +
-    `${data['seconds']} ${data['ss']}, `);
+    `${data['seconds']} ${data['ss']}`);
 
 /**
  * @param {!DateCountdownPropsDef} props
@@ -114,6 +114,7 @@ export function DateCountdown({
     return () => win.clearInterval(interval);
   }, [playable, epoch, whenEnded]);
 
+  console.log(data);
   const rendered = useRenderer(render, data);
   const isHtml =
     rendered && typeof rendered == 'object' && '__html' in rendered;

--- a/extensions/amp-date-countdown/1.0/date-countdown.js
+++ b/extensions/amp-date-countdown/1.0/date-countdown.js
@@ -81,7 +81,7 @@ export function DateCountdown({
   );
 
   // How much time is left in our countdown
-  const [timeleft, setTimeleft] = useState(epoch - Date.now());
+  const setTimeleft = useState(epoch - Date.now())[1];
 
   // One time calculation of time labels in specified locale
   const localeStrings = useMemo(() => getLocaleWord(locale), [locale]);

--- a/extensions/amp-date-countdown/1.0/date-countdown.js
+++ b/extensions/amp-date-countdown/1.0/date-countdown.js
@@ -114,7 +114,6 @@ export function DateCountdown({
     return () => win.clearInterval(interval);
   }, [playable, epoch, whenEnded]);
 
-  console.log(data);
   const rendered = useRenderer(render, data);
   const isHtml =
     rendered && typeof rendered == 'object' && '__html' in rendered;

--- a/extensions/amp-date-countdown/1.0/date-countdown.js
+++ b/extensions/amp-date-countdown/1.0/date-countdown.js
@@ -69,7 +69,7 @@ const DEFAULT_RENDER = (data) =>
  * @return {PreactDef.Renderable}
  */
 export function DateCountdown({
-  dateTime,
+  datetime,
   whenEnded = DEFAULT_WHEN_ENDED,
   locale = DEFAULT_LOCALE,
   biggestUnit = DEFAULT_BIGGEST_UNIT,
@@ -79,10 +79,10 @@ export function DateCountdown({
   useResourcesNotify();
   const {playable} = useAmpContext();
 
-  const epoch = getDate(dateTime);
+  const epoch = getDate(datetime);
 
   // How much time is left in our countdown
-  const setTimeleft = useState(epoch - Date.now())[1];
+  const [, setTimeleft] = useState(epoch - Date.now());
 
   // One time calculation of time labels in specified locale
   const localeStrings = useMemo(

--- a/extensions/amp-date-countdown/1.0/date-countdown.js
+++ b/extensions/amp-date-countdown/1.0/date-countdown.js
@@ -16,6 +16,7 @@
 
 import * as Preact from '../../../src/preact';
 import {Wrapper, useRenderer} from '../../../src/preact/component';
+import {dict} from '../../../src/utils/object';
 import {getDate} from '../../../src/utils/date';
 import {getLocaleStrings} from './messages';
 import {useAmpContext} from '../../../src/preact/context';
@@ -74,7 +75,10 @@ export function DateCountdown({
   const setTimeleft = useState(epoch - Date.now())[1];
 
   // One time calculation of time labels in specified locale
-  const localeStrings = useMemo(() => getLocaleWord(locale), [locale]);
+  const localeStrings = useMemo(
+    () => getLocaleWord(/** @type {string} */ (locale)),
+    [locale]
+  );
 
   // Reference to DOM element to get access to correct window
   const rootRef = useRef(null);
@@ -83,11 +87,14 @@ export function DateCountdown({
   // A reference is used so we can use the same object instance between
   // successive re-renders
   const dataRef = useRef(
-    getYDHMSFromMs(epoch - Date.now() + DELAY, biggestUnit)
+    getYDHMSFromMs(
+      epoch - Date.now() + DELAY,
+      /** @type {string} */ (biggestUnit)
+    )
   );
 
   // Put localeStrings into the data object
-  Object.assign(dataRef.current, localeStrings);
+  Object.assign(/** @type {!Object} */ (dataRef.current), localeStrings);
 
   useEffect(() => {
     if (!playable || !rootRef.current) {
@@ -102,7 +109,10 @@ export function DateCountdown({
 
       // Update dataRef to a new object to trigger re-calculation of 'rendered'
       // (in the useRenderer function)
-      const data = getYDHMSFromMs(newTimeleft, biggestUnit);
+      const data = getYDHMSFromMs(
+        newTimeleft,
+        /** @type {string} */ (biggestUnit)
+      );
       dataRef.current = data;
 
       if (whenEnded === DEFAULT_WHEN_ENDED && newTimeleft < 1000) {
@@ -112,7 +122,10 @@ export function DateCountdown({
     return () => win.clearInterval(interval);
   }, [playable, epoch, whenEnded, biggestUnit, setTimeleft]);
 
-  const rendered = useRenderer(render, dataRef.current);
+  const rendered = useRenderer(
+    render,
+    /** @type {!JsonObject} */ (dataRef.current)
+  );
   const isHtml =
     rendered && typeof rendered == 'object' && '__html' in rendered;
 
@@ -141,14 +154,14 @@ function getLocaleWord(locale) {
     locale = DEFAULT_LOCALE;
   }
   const localeWordList = getLocaleStrings(locale);
-  return {
+  return dict({
     'years': localeWordList[0],
     'months': localeWordList[1],
     'days': localeWordList[2],
     'hours': localeWordList[3],
     'minutes': localeWordList[4],
     'seconds': localeWordList[5],
-  };
+  });
 }
 
 /**
@@ -187,7 +200,7 @@ function getYDHMSFromMs(ms, biggestUnit) {
           Math.floor((ms % MILLISECONDS_IN_MINUTE) / MILLISECONDS_IN_SECOND)
         );
 
-  return {
+  return dict({
     'd': d,
     'dd': padStart(d),
     'h': h,
@@ -196,7 +209,7 @@ function getYDHMSFromMs(ms, biggestUnit) {
     'mm': padStart(m),
     's': s,
     'ss': padStart(s),
-  };
+  });
 }
 
 /**

--- a/extensions/amp-date-countdown/1.0/date-countdown.js
+++ b/extensions/amp-date-countdown/1.0/date-countdown.js
@@ -55,6 +55,16 @@ const DEFAULT_WHEN_ENDED = 'stop';
 const DEFAULT_BIGGEST_UNIT = 'DAYS';
 
 /**
+ * @param {!JsonObject} data
+ * @return {string}
+ */
+const DEFAULT_RENDER = (data) =>
+  /** @type {string} */ (`${data['days']} ${data['dd']}, ` +
+    `${data['hours']} ${data['hh']}, ` +
+    `${data['minutes']} ${data['mm']}, ` +
+    `${data['seconds']} ${data['ss']}, `);
+
+/**
  * @param {!DateCountdownPropsDef} props
  * @return {PreactDef.Renderable}
  */
@@ -63,7 +73,7 @@ export function DateCountdown({
   whenEnded = DEFAULT_WHEN_ENDED,
   locale = DEFAULT_LOCALE,
   biggestUnit = DEFAULT_BIGGEST_UNIT,
-  render,
+  render = DEFAULT_RENDER,
   ...rest
 }) {
   useResourcesNotify();

--- a/extensions/amp-date-countdown/1.0/date-countdown.type.js
+++ b/extensions/amp-date-countdown/1.0/date-countdown.type.js
@@ -18,16 +18,11 @@
 
 /**
  * @typedef {{
- *   endDate: (string|undefined),
- *   timeleftMs: (number|undefined),
- *   timestampMs: (number|undefined),
- *   timestampSeconds: (number|undefined),
- *   offsetSeconds: (number|undefined),
+ *   dateTime: (!Date|number|string),
  *   whenEnded: (string|undefined),
  *   locale: (string|undefined),
  *   biggestUnit: (string|undefined),
- *   render: (function(!JsonObject, (?PreactDef.Renderable|undefined)):PreactDef.Renderable),
- *   children: (?PreactDef.Renderable|undefined),
+ *   render: (?RendererFunctionType|undefined),
  * }}
  */
 var DateCountdownPropsDef;

--- a/extensions/amp-date-countdown/1.0/test/test-amp-date-countdown.js
+++ b/extensions/amp-date-countdown/1.0/test/test-amp-date-countdown.js
@@ -1,0 +1,330 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import '../../../amp-mustache/0.2/amp-mustache';
+import {parseDateAttrs} from '../amp-date-countdown';
+import {waitFor} from '../../../../testing/test-helper.js';
+import {whenUpgradedToCustomElement} from '../../../../src/dom';
+
+describes.realWin(
+  'amp-date-countdown 1.0',
+  {
+    amp: {
+      extensions: ['amp-mustache:0.2', 'amp-date-countdown:1.0'],
+    },
+  },
+  (env) => {
+    let win;
+    let element, template;
+    let originalDateNow;
+
+    async function waitRendered() {
+      await whenUpgradedToCustomElement(element);
+      await element.build();
+      await waitFor(() => {
+        // The rendered container inserts a <div> element.
+        const div = element.querySelector('div');
+        return div && div.textContent;
+      }, 'wrapper div rendered');
+      return element.querySelector('div');
+    }
+
+    async function getRenderedData() {
+      const wrapper = await waitRendered();
+      return JSON.parse(wrapper.textContent);
+    }
+
+    beforeEach(() => {
+      win = env.win;
+      element = win.document.createElement('amp-date-countdown');
+      template = win.document.createElement('template');
+      template.setAttribute('type', 'amp-mustache');
+      template.content.textContent = JSON.stringify({
+        years: '{{years}}',
+        months: '{{months}}',
+        days: '{{days}}',
+        hours: '{{hours}}',
+        minutes: '{{minutes}}',
+        seconds: '{{seconds}}',
+        d: '{{d}}',
+        dd: '{{dd}}',
+        h: '{{h}}',
+        hh: '{{hh}}',
+        m: '{{m}}',
+        mm: '{{mm}}',
+        s: '{{s}}',
+        ss: '{{ss}}',
+      });
+      element.appendChild(template);
+      element.setAttribute('layout', 'nodisplay');
+
+      // Mock Date.now()
+      originalDateNow = Date.now;
+      const mockedDateNow = () => Date.parse('2018-01-01T08:00:00Z');
+      Date.now = mockedDateNow;
+    });
+
+    afterEach(() => {
+      // Replace Date.now with its original native function
+      Date.now = originalDateNow;
+    });
+
+    it('renders mustache template into element', async () => {
+      element.setAttribute('end-date', '2018-01-01T08:00:10Z');
+      win.document.body.appendChild(element);
+
+      const data = await getRenderedData();
+
+      expect(data['d']).to.equal('0');
+      expect(data['dd']).to.equal('00');
+      expect(data['h']).to.equal('0');
+      expect(data['hh']).to.equal('00');
+      expect(data['m']).to.equal('0');
+      expect(data['mm']).to.equal('00');
+      expect(data['s']).to.equal('11');
+      expect(data['ss']).to.equal('11');
+
+      expect(data['years']).to.equal('Years');
+      expect(data['months']).to.equal('Months');
+      expect(data['days']).to.equal('Days');
+      expect(data['hours']).to.equal('Hours');
+      expect(data['minutes']).to.equal('Minutes');
+      expect(data['seconds']).to.equal('Seconds');
+    });
+
+    it('renders default template into element', async () => {
+      element.setAttribute('end-date', '2018-01-01T08:00:10Z');
+      element.removeChild(template);
+      win.document.body.appendChild(element);
+
+      const wrapper = await waitRendered();
+      expect(wrapper.textContent).to.equal(
+        'Days 00, Hours 00, Minutes 00, Seconds 11'
+      );
+    });
+
+    it('does not rerender', async () => {
+      element.setAttribute('end-date', '2018-01-01T08:00:10Z');
+      win.document.body.appendChild(element);
+
+      await getRenderedData();
+
+      const mo = new MutationObserver(() => {});
+      mo.observe(element, {childList: true, subtree: true});
+
+      element.setAttribute('end-date', '2020-01-01T08:00:10Z');
+      element.mutatedAttributesCallback({
+        'end-date': '2020-01-01T08:00:10Z',
+      });
+
+      const records = mo.takeRecords();
+      expect(records).to.be.empty;
+    });
+
+    it('renders template with end-date attribute', async () => {
+      element.setAttribute('end-date', '2018-01-01T08:00:10Z');
+      win.document.body.appendChild(element);
+
+      const data = await getRenderedData();
+
+      // component adds 1 second delay for real world execution delay
+      expect(data['d']).to.equal('0');
+      expect(data['dd']).to.equal('00');
+      expect(data['h']).to.equal('0');
+      expect(data['hh']).to.equal('00');
+      expect(data['m']).to.equal('0');
+      expect(data['mm']).to.equal('00');
+      expect(data['s']).to.equal('11');
+      expect(data['ss']).to.equal('11');
+    });
+
+    it('renders template with timeleft-ms attribute', async () => {
+      // count to 10 seconds (10000ms) from now
+      element.setAttribute('timeleft-ms', '10000');
+      win.document.body.appendChild(element);
+
+      const data = await getRenderedData();
+
+      // component adds 1 second delay for real world execution delay
+      expect(data['d']).to.equal('0');
+      expect(data['dd']).to.equal('00');
+      expect(data['h']).to.equal('0');
+      expect(data['hh']).to.equal('00');
+      expect(data['m']).to.equal('0');
+      expect(data['mm']).to.equal('00');
+      expect(data['s']).to.equal('11');
+      expect(data['ss']).to.equal('11');
+    });
+
+    it('renders template with timestamp-ms attribute', async () => {
+      // this is epoch time of '2018-01-01T08:00:10Z'
+      // clock starts with 10 seconds on it
+      element.setAttribute('timestamp-ms', Date.parse('2018-01-01T08:00:10Z'));
+      win.document.body.appendChild(element);
+
+      const data = await getRenderedData();
+
+      // component adds 1 second delay for real world execution delay
+      expect(data['d']).to.equal('0');
+      expect(data['dd']).to.equal('00');
+      expect(data['h']).to.equal('0');
+      expect(data['hh']).to.equal('00');
+      expect(data['m']).to.equal('0');
+      expect(data['mm']).to.equal('00');
+      expect(data['s']).to.equal('11');
+      expect(data['ss']).to.equal('11');
+    });
+
+    it('renders template with timestamp-seconds attribute', async () => {
+      // this is epoch time of '2018-01-01T08:00:10Z'
+      // clock starts with 10 seconds on it
+      element.setAttribute(
+        'timestamp-seconds',
+        Date.parse('2018-01-01T08:00:10Z') / 1000
+      );
+      win.document.body.appendChild(element);
+
+      const data = await getRenderedData();
+
+      // component adds 1 second delay for real world execution delay
+      expect(data['d']).to.equal('0');
+      expect(data['dd']).to.equal('00');
+      expect(data['h']).to.equal('0');
+      expect(data['hh']).to.equal('00');
+      expect(data['m']).to.equal('0');
+      expect(data['mm']).to.equal('00');
+      expect(data['s']).to.equal('11');
+      expect(data['ss']).to.equal('11');
+    });
+
+    it('renders template with offset-seconds attribute', async () => {
+      element.setAttribute('end-date', '2018-01-01T08:00:10Z');
+      element.setAttribute('offset-seconds', '10');
+      win.document.body.appendChild(element);
+
+      const data = await getRenderedData();
+
+      // component adds 1 second delay for real world execution delay
+      expect(data['d']).to.equal('0');
+      expect(data['dd']).to.equal('00');
+      expect(data['h']).to.equal('0');
+      expect(data['hh']).to.equal('00');
+      expect(data['m']).to.equal('0');
+      expect(data['mm']).to.equal('00');
+      expect(data['s']).to.equal('21');
+      expect(data['ss']).to.equal('21');
+    });
+  }
+);
+
+describes.sandboxed('amp-date-countdown 1.0: parseDateAttrs', {}, (env) => {
+  const DATE = new Date(1514793600000);
+  const DATE_STRING = DATE.toISOString();
+
+  let element;
+
+  beforeEach(() => {
+    element = document.createElement('amp-date-countdown');
+  });
+
+  it('should throw when no date is specified', () => {
+    allowConsoleError(() => {
+      expect(() => parseDateAttrs(element)).to.throw(/required/);
+    });
+  });
+
+  it('should throw when invalid date is specified', () => {
+    element.setAttribute('end-date', 'invalid');
+    allowConsoleError(() => {
+      expect(() => parseDateAttrs(element)).to.throw(/Invalid date/);
+    });
+  });
+
+  it('should parse the "end-date" attribute', () => {
+    element.setAttribute('end-date', DATE_STRING);
+    expect(parseDateAttrs(element)).to.equal(DATE.getTime());
+
+    // With offset.
+    element.setAttribute('offset-seconds', '1');
+    expect(parseDateAttrs(element)).to.equal(DATE.getTime() + 1000);
+  });
+
+  it('should accept "end-date=now"', () => {
+    env.sandbox.useFakeTimers(DATE);
+    element.setAttribute('end-date', 'now');
+    expect(parseDateAttrs(element)).to.equal(DATE.getTime());
+
+    // With offset.
+    element.setAttribute('offset-seconds', '1');
+    expect(parseDateAttrs(element)).to.equal(DATE.getTime() + 1000);
+  });
+
+  it('should parse the "timeleft-ms" attribute', () => {
+    // Mock Date.now()
+    const originalDateNow = Date.now;
+    const mockedDateNow = () => DATE.getTime();
+    Date.now = mockedDateNow;
+
+    element.setAttribute('timeleft-ms', 10000);
+    expect(parseDateAttrs(element)).to.equal(DATE.getTime() + 10000);
+
+    // With offset.
+    element.setAttribute('offset-seconds', '1');
+    expect(parseDateAttrs(element)).to.equal(DATE.getTime() + 10000 + 1000);
+
+    // Replace Date.now with its original native function
+    Date.now = originalDateNow;
+  });
+
+  it('should throw when invalid "timeleft-ms" is specified', () => {
+    element.setAttribute('timeleft-ms', 'invalid');
+    allowConsoleError(() => {
+      expect(() => parseDateAttrs(element)).to.throw(/required/);
+    });
+  });
+
+  it('should parse the "timestamp-ms" attribute', () => {
+    element.setAttribute('timestamp-ms', DATE.getTime());
+    expect(parseDateAttrs(element)).to.equal(DATE.getTime());
+
+    // With offset.
+    element.setAttribute('offset-seconds', '1');
+    expect(parseDateAttrs(element)).to.equal(DATE.getTime() + 1000);
+  });
+
+  it('should throw when invalid "timestamp-ms" is specified', () => {
+    element.setAttribute('timestamp-ms', 'invalid');
+    allowConsoleError(() => {
+      expect(() => parseDateAttrs(element)).to.throw(/required/);
+    });
+  });
+
+  it('should parse the "timestamp-seconds" attribute', () => {
+    element.setAttribute('timestamp-seconds', DATE.getTime() / 1000);
+    expect(parseDateAttrs(element)).to.equal(DATE.getTime());
+
+    // With offset.
+    element.setAttribute('offset-seconds', '1');
+    expect(parseDateAttrs(element)).to.equal(DATE.getTime() + 1000);
+  });
+
+  it('should throw when invalid "timestamp-seconds" is specified', () => {
+    element.setAttribute('timestamp-seconds', 'invalid');
+    allowConsoleError(() => {
+      expect(() => parseDateAttrs(element)).to.throw(/required/);
+    });
+  });
+});

--- a/extensions/amp-date-countdown/1.0/test/test-amp-date-countdown.js
+++ b/extensions/amp-date-countdown/1.0/test/test-amp-date-countdown.js
@@ -116,30 +116,6 @@ describes.realWin(
       );
     });
 
-    it('does not rerender when template is not updated', async () => {
-      element.setAttribute('end-date', '2018-01-01T08:00:10Z');
-      win.document.body.appendChild(element);
-
-      await getRenderedData();
-
-      const mo = new MutationObserver(() => {});
-      mo.observe(element, {
-        childList: true,
-        subtree: true,
-      });
-
-      element.setAttribute('end-date', '2020-01-01T08:00:10Z');
-      element.mutatedAttributesCallback({
-        'end-date': '2020-01-01T08:00:10Z',
-      });
-
-      // Since we only change the date and not the template, we confirm that
-      // Preact only updates the template attributes and does not re-paint
-      // the template's DOM nodes
-      const records = mo.takeRecords();
-      expect(records).to.be.empty;
-    });
-
     it('renders template with end-date attribute', async () => {
       element.setAttribute('end-date', '2018-01-01T08:00:10Z');
       win.document.body.appendChild(element);

--- a/extensions/amp-date-countdown/1.0/test/test-amp-date-countdown.js
+++ b/extensions/amp-date-countdown/1.0/test/test-amp-date-countdown.js
@@ -116,20 +116,26 @@ describes.realWin(
       );
     });
 
-    it('does not rerender', async () => {
+    it('does not rerender when template is not updated', async () => {
       element.setAttribute('end-date', '2018-01-01T08:00:10Z');
       win.document.body.appendChild(element);
 
       await getRenderedData();
 
       const mo = new MutationObserver(() => {});
-      mo.observe(element, {childList: true, subtree: true});
+      mo.observe(element, {
+        childList: true,
+        subtree: true,
+      });
 
       element.setAttribute('end-date', '2020-01-01T08:00:10Z');
       element.mutatedAttributesCallback({
         'end-date': '2020-01-01T08:00:10Z',
       });
 
+      // Since we only change the date and not the template, we confirm that
+      // Preact only updates the template attributes and does not re-paint
+      // the template's DOM nodes
       const records = mo.takeRecords();
       expect(records).to.be.empty;
     });

--- a/extensions/amp-date-countdown/1.0/test/test-date-countdown.js
+++ b/extensions/amp-date-countdown/1.0/test/test-date-countdown.js
@@ -57,8 +57,7 @@ describes.sandboxed('DateCountdown 1.0 preact component', {}, (env) => {
       render,
       datetime: Date.parse('2018-01-01T08:00:00Z'),
     };
-    const jsx = <DateCountdown {...props} />;
-    const wrapper = mount(jsx);
+    const wrapper = mount(<DateCountdown {...props} />);
 
     // Generic test for the Wrapper
     // This is actually fairly arbitrary that it should be a "div". But it's
@@ -77,8 +76,7 @@ describes.sandboxed('DateCountdown 1.0 preact component', {}, (env) => {
       datetime: Date.parse('2018-01-01T08:00:00Z'),
       locale: 'invalid-locale',
     };
-    const jsx = <DateCountdown {...props} />;
-    const wrapper = mount(jsx);
+    const wrapper = mount(<DateCountdown {...props} />);
     const data = JSON.parse(wrapper.text());
 
     // Check that warning message is print to the screen
@@ -104,8 +102,7 @@ describes.sandboxed('DateCountdown 1.0 preact component', {}, (env) => {
       render,
       datetime: Date.parse('2018-01-01T08:00:10Z'),
     };
-    const jsx = <DateCountdown {...props} />;
-    const wrapper = mount(jsx);
+    const wrapper = mount(<DateCountdown {...props} />);
     let data = JSON.parse(wrapper.text());
 
     // Component adds one second delay for slight execution delay in real world
@@ -141,8 +138,7 @@ describes.sandboxed('DateCountdown 1.0 preact component', {}, (env) => {
       render,
       datetime: Date.parse('2017-01-01T08:00:00Z'),
     };
-    const jsx = <DateCountdown {...props} />;
-    const wrapper = mount(jsx);
+    const wrapper = mount(<DateCountdown {...props} />);
     const data = JSON.parse(wrapper.text());
 
     // Component adds one second delay for slight execution delay in real world
@@ -163,8 +159,7 @@ describes.sandboxed('DateCountdown 1.0 preact component', {}, (env) => {
       render,
       datetime: Date.parse('2018-01-01T08:00:10Z'),
     };
-    const jsx = <DateCountdown {...props} />;
-    const wrapper = mount(jsx);
+    const wrapper = mount(<DateCountdown {...props} />);
     let data = JSON.parse(wrapper.text());
 
     // Count down 15 seconds
@@ -190,8 +185,7 @@ describes.sandboxed('DateCountdown 1.0 preact component', {}, (env) => {
       datetime: Date.parse('2018-01-01T08:00:10Z'),
       whenEnded: 'continue',
     };
-    const jsx = <DateCountdown {...props} />;
-    const wrapper = mount(jsx);
+    const wrapper = mount(<DateCountdown {...props} />);
     let data = JSON.parse(wrapper.text());
 
     // Count down 15 seconds
@@ -218,8 +212,7 @@ describes.sandboxed('DateCountdown 1.0 preact component', {}, (env) => {
       render,
       datetime: Date.parse('2018-01-02T08:00:10Z'),
     };
-    const jsx = <DateCountdown {...props} />;
-    const wrapper = mount(jsx);
+    const wrapper = mount(<DateCountdown {...props} />);
     const data = JSON.parse(wrapper.text());
 
     // Component adds one second delay for slight execution delay in real world
@@ -244,8 +237,7 @@ describes.sandboxed('DateCountdown 1.0 preact component', {}, (env) => {
       datetime: Date.parse('2018-01-02T08:00:10Z'),
       biggestUnit: 'HOURS',
     };
-    const jsx = <DateCountdown {...props} />;
-    const wrapper = mount(jsx);
+    const wrapper = mount(<DateCountdown {...props} />);
     const data = JSON.parse(wrapper.text());
 
     // Component adds one second delay for slight execution delay in real world
@@ -270,8 +262,7 @@ describes.sandboxed('DateCountdown 1.0 preact component', {}, (env) => {
       datetime: Date.parse('2018-01-02T08:00:10Z'),
       biggestUnit: 'MINUTES',
     };
-    const jsx = <DateCountdown {...props} />;
-    const wrapper = mount(jsx);
+    const wrapper = mount(<DateCountdown {...props} />);
     const data = JSON.parse(wrapper.text());
 
     // Component adds one second delay for slight execution delay in real world
@@ -296,8 +287,7 @@ describes.sandboxed('DateCountdown 1.0 preact component', {}, (env) => {
       datetime: Date.parse('2018-01-02T08:00:10Z'),
       biggestUnit: 'SECONDS',
     };
-    const jsx = <DateCountdown {...props} />;
-    const wrapper = mount(jsx);
+    const wrapper = mount(<DateCountdown {...props} />);
     const data = JSON.parse(wrapper.text());
 
     // Component adds one second delay for slight execution delay in real world
@@ -321,8 +311,7 @@ describes.sandboxed('DateCountdown 1.0 preact component', {}, (env) => {
       render: (data) => syncPromise(render(data)),
       datetime: Date.parse('2018-01-01T08:00:10Z'),
     };
-    const jsx = <DateCountdown {...props} />;
-    const wrapper = mount(jsx);
+    const wrapper = mount(<DateCountdown {...props} />);
     const data = JSON.parse(wrapper.text());
 
     // Component adds one second delay for slight execution delay in real world
@@ -343,8 +332,7 @@ describes.sandboxed('DateCountdown 1.0 preact component', {}, (env) => {
     const props = {
       datetime: Date.parse('2018-01-01T08:00:10Z'),
     };
-    const jsx = <DateCountdown {...props} />;
-    const wrapper = mount(jsx);
+    const wrapper = mount(<DateCountdown {...props} />);
 
     // Component adds one second delay for slight execution delay in real world
     // In our mocked clock situation, we start with 11 seconds on the clock
@@ -360,8 +348,7 @@ describes.sandboxed('DateCountdown 1.0 preact component', {}, (env) => {
       render,
       datetime: new Date('2018-01-01T08:00:10Z'),
     };
-    const jsx = <DateCountdown {...props} />;
-    const wrapper = mount(jsx);
+    const wrapper = mount(<DateCountdown {...props} />);
     const data = JSON.parse(wrapper.text());
 
     // Component adds one second delay for slight execution delay in real world
@@ -383,8 +370,7 @@ describes.sandboxed('DateCountdown 1.0 preact component', {}, (env) => {
       render,
       datetime: '2018-01-01T08:00:10Z',
     };
-    const jsx = <DateCountdown {...props} />;
-    const wrapper = mount(jsx);
+    const wrapper = mount(<DateCountdown {...props} />);
     const data = JSON.parse(wrapper.text());
 
     // Component adds one second delay for slight execution delay in real world

--- a/extensions/amp-date-countdown/1.0/test/test-date-countdown.js
+++ b/extensions/amp-date-countdown/1.0/test/test-date-countdown.js
@@ -1,0 +1,401 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as Preact from '../../../../src/preact';
+import {DateCountdown} from '../date-countdown';
+import {mount} from 'enzyme';
+
+describes.sandboxed('DateCountdown 1.0 preact component', {}, (env) => {
+  let sandbox;
+  let clock;
+
+  function render(data) {
+    return JSON.stringify(
+      data,
+      (key, value) => {
+        if (typeof value === 'number') {
+          return String(value);
+        }
+        return value;
+      },
+      4
+    );
+  }
+
+  beforeEach(() => {
+    sandbox = env.sandbox;
+    clock = sandbox.useFakeTimers(new Date('2018-01-01T08:00:00Z'));
+  });
+
+  afterEach(() => {
+    clock.runAll();
+  });
+
+  function syncPromise(response) {
+    return {
+      then(callback) {
+        callback(response);
+      },
+    };
+  }
+
+  it('should render as a div by default', () => {
+    const props = {
+      render,
+      datetime: Date.parse('2018-01-01T08:00:00Z'),
+    };
+    const jsx = <DateCountdown {...props} />;
+    const wrapper = mount(jsx);
+
+    // Generic test for the Wrapper
+    // This is actually fairly arbitrary that it should be a "div". But it's
+    // checked here to ensure that we can change it controllably when needed.
+    expect(wrapper.getDOMNode().tagName).to.equal('DIV');
+  });
+
+  it('should default to english locale if invalid locale provided', () => {
+    const originalWarn = console.warn;
+    const consoleOutput = [];
+    const mockedWarn = (output) => consoleOutput.push(output);
+    console.warn = mockedWarn;
+
+    const props = {
+      render,
+      datetime: Date.parse('2018-01-01T08:00:00Z'),
+      locale: 'invalid-locale',
+    };
+    const jsx = <DateCountdown {...props} />;
+    const wrapper = mount(jsx);
+    const data = JSON.parse(wrapper.text());
+
+    // Check that warning message is print to the screen
+    expect(consoleOutput.length).to.equal(1);
+    expect(consoleOutput[0]).to.equal(
+      'Invalid locale invalid-locale, defaulting to en. DateCountdown'
+    );
+
+    expect(data['years']).to.equal('Years');
+    expect(data['months']).to.equal('Months');
+    expect(data['days']).to.equal('Days');
+    expect(data['hours']).to.equal('Hours');
+    expect(data['minutes']).to.equal('Minutes');
+    expect(data['seconds']).to.equal('Seconds');
+
+    console.warn = originalWarn;
+  });
+
+  it('should count down if target date is in the future', () => {
+    // Reference date is 2018-01-01T08:00:00Z
+    // Timer should have 10 seconds on it
+    const props = {
+      render,
+      datetime: Date.parse('2018-01-01T08:00:10Z'),
+    };
+    const jsx = <DateCountdown {...props} />;
+    const wrapper = mount(jsx);
+    let data = JSON.parse(wrapper.text());
+
+    // Component adds one second delay for slight execution delay in real world
+    // In our mocked clock situation, we start with 11 seconds on the clock
+    expect(data['d']).to.equal('0');
+    expect(data['dd']).to.equal('00');
+    expect(data['h']).to.equal('0');
+    expect(data['hh']).to.equal('00');
+    expect(data['m']).to.equal('0');
+    expect(data['mm']).to.equal('00');
+    expect(data['s']).to.equal('11');
+    expect(data['ss']).to.equal('11');
+
+    // Count down 3 seconds
+    clock.tick(3000);
+    wrapper.update();
+    data = JSON.parse(wrapper.text());
+
+    expect(data['d']).to.equal('0');
+    expect(data['dd']).to.equal('00');
+    expect(data['h']).to.equal('0');
+    expect(data['hh']).to.equal('00');
+    expect(data['m']).to.equal('0');
+    expect(data['mm']).to.equal('00');
+    expect(data['s']).to.equal('8');
+    expect(data['ss']).to.equal('08');
+  });
+
+  it('should display a negative number if target date is in the past', () => {
+    // Reference date is 2018-01-01T08:00:00Z
+    // Timer should have negative 1 year on it
+    const props = {
+      render,
+      datetime: Date.parse('2017-01-01T08:00:00Z'),
+    };
+    const jsx = <DateCountdown {...props} />;
+    const wrapper = mount(jsx);
+    const data = JSON.parse(wrapper.text());
+
+    // Component adds one second delay for slight execution delay in real world
+    expect(data['d']).to.equal('-364');
+    expect(data['dd']).to.equal('-364');
+    expect(data['h']).to.equal('-23');
+    expect(data['hh']).to.equal('-23');
+    expect(data['m']).to.equal('-59');
+    expect(data['mm']).to.equal('-59');
+    expect(data['s']).to.equal('-58');
+    expect(data['ss']).to.equal('-58');
+  });
+
+  it('should count down to and stop at 0 by default', () => {
+    // Reference date is 2018-01-01T08:00:00Z
+    // Timer should have 10 seconds on it
+    const props = {
+      render,
+      datetime: Date.parse('2018-01-01T08:00:10Z'),
+    };
+    const jsx = <DateCountdown {...props} />;
+    const wrapper = mount(jsx);
+    let data = JSON.parse(wrapper.text());
+
+    // Count down 15 seconds
+    clock.tick(15000);
+    wrapper.update();
+    data = JSON.parse(wrapper.text());
+
+    expect(data['d']).to.equal('0');
+    expect(data['dd']).to.equal('00');
+    expect(data['h']).to.equal('0');
+    expect(data['hh']).to.equal('00');
+    expect(data['m']).to.equal('0');
+    expect(data['mm']).to.equal('00');
+    expect(data['s']).to.equal('0');
+    expect(data['ss']).to.equal('00');
+  });
+
+  it('should count down past 0 if whenEnded is set to "continue"', () => {
+    // Reference date is 2018-01-01T08:00:00Z
+    // Timer should have 10 seconds on it
+    const props = {
+      render,
+      datetime: Date.parse('2018-01-01T08:00:10Z'),
+      whenEnded: 'continue',
+    };
+    const jsx = <DateCountdown {...props} />;
+    const wrapper = mount(jsx);
+    let data = JSON.parse(wrapper.text());
+
+    // Count down 15 seconds
+    clock.tick(15000);
+    wrapper.update();
+    data = JSON.parse(wrapper.text());
+
+    expect(data['d']).to.equal('0');
+    expect(data['dd']).to.equal('00');
+    expect(data['h']).to.equal('0');
+    expect(data['hh']).to.equal('00');
+    expect(data['m']).to.equal('0');
+    expect(data['mm']).to.equal('00');
+    expect(data['s']).to.equal('-3');
+    expect(data['ss']).to.equal('-03');
+
+    wrapper.unmount();
+  });
+
+  it('should display biggest unit as "days" by default', () => {
+    // Reference date is 2018-01-01T08:00:00Z
+    // Timer should have 1 day and 10 seconds on it
+    const props = {
+      render,
+      datetime: Date.parse('2018-01-02T08:00:10Z'),
+    };
+    const jsx = <DateCountdown {...props} />;
+    const wrapper = mount(jsx);
+    const data = JSON.parse(wrapper.text());
+
+    // Component adds one second delay for slight execution delay in real world
+    // In our mocked clock situation, we start with 11 seconds on the clock
+    expect(data['d']).to.equal('1');
+    expect(data['dd']).to.equal('01');
+    expect(data['h']).to.equal('0');
+    expect(data['hh']).to.equal('00');
+    expect(data['m']).to.equal('0');
+    expect(data['mm']).to.equal('00');
+    expect(data['s']).to.equal('11');
+    expect(data['ss']).to.equal('11');
+
+    wrapper.unmount();
+  });
+
+  it('should display biggest unit as "hours" when set', () => {
+    // Reference date is 2018-01-01T08:00:00Z
+    // Timer should have 1 day and 10 seconds on it
+    const props = {
+      render,
+      datetime: Date.parse('2018-01-02T08:00:10Z'),
+      biggestUnit: 'HOURS',
+    };
+    const jsx = <DateCountdown {...props} />;
+    const wrapper = mount(jsx);
+    const data = JSON.parse(wrapper.text());
+
+    // Component adds one second delay for slight execution delay in real world
+    // In our mocked clock situation, we start with 11 seconds on the clock
+    expect(data['d']).to.equal('0');
+    expect(data['dd']).to.equal('00');
+    expect(data['h']).to.equal('24');
+    expect(data['hh']).to.equal('24');
+    expect(data['m']).to.equal('0');
+    expect(data['mm']).to.equal('00');
+    expect(data['s']).to.equal('11');
+    expect(data['ss']).to.equal('11');
+
+    wrapper.unmount();
+  });
+
+  it('should display biggest unit as "minutes" when set', () => {
+    // Reference date is 2018-01-01T08:00:00Z
+    // Timer should have 1 day and 10 seconds on it
+    const props = {
+      render,
+      datetime: Date.parse('2018-01-02T08:00:10Z'),
+      biggestUnit: 'MINUTES',
+    };
+    const jsx = <DateCountdown {...props} />;
+    const wrapper = mount(jsx);
+    const data = JSON.parse(wrapper.text());
+
+    // Component adds one second delay for slight execution delay in real world
+    // In our mocked clock situation, we start with 11 seconds on the clock
+    expect(data['d']).to.equal('0');
+    expect(data['dd']).to.equal('00');
+    expect(data['h']).to.equal('0');
+    expect(data['hh']).to.equal('00');
+    expect(data['m']).to.equal('1440');
+    expect(data['mm']).to.equal('1440');
+    expect(data['s']).to.equal('11');
+    expect(data['ss']).to.equal('11');
+
+    wrapper.unmount();
+  });
+
+  it('should display biggest unit as "seconds" when set', () => {
+    // Reference date is 2018-01-01T08:00:00Z
+    // Timer should have 1 day and 10 seconds on it
+    const props = {
+      render,
+      datetime: Date.parse('2018-01-02T08:00:10Z'),
+      biggestUnit: 'SECONDS',
+    };
+    const jsx = <DateCountdown {...props} />;
+    const wrapper = mount(jsx);
+    const data = JSON.parse(wrapper.text());
+
+    // Component adds one second delay for slight execution delay in real world
+    // In our mocked clock situation, we start with 11 seconds on the clock
+    expect(data['d']).to.equal('0');
+    expect(data['dd']).to.equal('00');
+    expect(data['h']).to.equal('0');
+    expect(data['hh']).to.equal('00');
+    expect(data['m']).to.equal('0');
+    expect(data['mm']).to.equal('00');
+    expect(data['s']).to.equal('86411');
+    expect(data['ss']).to.equal('86411');
+
+    wrapper.unmount();
+  });
+
+  it('should handle an async renderer', () => {
+    // Reference date is 2018-01-01T08:00:00Z
+    // Timer should have 10 seconds on it
+    const props = {
+      render: (data) => syncPromise(render(data)),
+      datetime: Date.parse('2018-01-01T08:00:10Z'),
+    };
+    const jsx = <DateCountdown {...props} />;
+    const wrapper = mount(jsx);
+    const data = JSON.parse(wrapper.text());
+
+    // Component adds one second delay for slight execution delay in real world
+    // In our mocked clock situation, we start with 11 seconds on the clock
+    expect(data['d']).to.equal('0');
+    expect(data['dd']).to.equal('00');
+    expect(data['h']).to.equal('0');
+    expect(data['hh']).to.equal('00');
+    expect(data['m']).to.equal('0');
+    expect(data['mm']).to.equal('00');
+    expect(data['s']).to.equal('11');
+    expect(data['ss']).to.equal('11');
+  });
+
+  it('should use the default renderer when a renderer is not provided', () => {
+    // Reference date is 2018-01-01T08:00:00Z
+    // Timer should have 10 seconds on it
+    const props = {
+      datetime: Date.parse('2018-01-01T08:00:10Z'),
+    };
+    const jsx = <DateCountdown {...props} />;
+    const wrapper = mount(jsx);
+
+    // Component adds one second delay for slight execution delay in real world
+    // In our mocked clock situation, we start with 11 seconds on the clock
+    expect(wrapper.text()).to.equal(
+      'Days 00, Hours 00, Minutes 00, Seconds 11'
+    );
+  });
+
+  it('should accept a Date type object for the datetime prop', () => {
+    // Reference date is 2018-01-01T08:00:00Z
+    // Timer should have 10 seconds on it
+    const props = {
+      render,
+      datetime: new Date('2018-01-01T08:00:10Z'),
+    };
+    const jsx = <DateCountdown {...props} />;
+    const wrapper = mount(jsx);
+    const data = JSON.parse(wrapper.text());
+
+    // Component adds one second delay for slight execution delay in real world
+    // In our mocked clock situation, we start with 11 seconds on the clock
+    expect(data['d']).to.equal('0');
+    expect(data['dd']).to.equal('00');
+    expect(data['h']).to.equal('0');
+    expect(data['hh']).to.equal('00');
+    expect(data['m']).to.equal('0');
+    expect(data['mm']).to.equal('00');
+    expect(data['s']).to.equal('11');
+    expect(data['ss']).to.equal('11');
+  });
+
+  it('should accept a String type object for the datetime prop', () => {
+    // Reference date is 2018-01-01T08:00:00Z
+    // Timer should have 10 seconds on it
+    const props = {
+      render,
+      datetime: '2018-01-01T08:00:10Z',
+    };
+    const jsx = <DateCountdown {...props} />;
+    const wrapper = mount(jsx);
+    const data = JSON.parse(wrapper.text());
+
+    // Component adds one second delay for slight execution delay in real world
+    // In our mocked clock situation, we start with 11 seconds on the clock
+    expect(data['d']).to.equal('0');
+    expect(data['dd']).to.equal('00');
+    expect(data['h']).to.equal('0');
+    expect(data['hh']).to.equal('00');
+    expect(data['m']).to.equal('0');
+    expect(data['mm']).to.equal('00');
+    expect(data['s']).to.equal('11');
+    expect(data['ss']).to.equal('11');
+  });
+});


### PR DESCRIPTION
Date-countdown items: https://github.com/ampproject/amphtml/issues/30052

Bento version of AMP component for `amp-date-countdown`

Added the amp component
Updated the preact component.  Some nuanced notes on the design below:

1. `useRenderer` sets state of the `value` / `rendered` variable
2. this triggers a re-render of the preact component (this variable is controlled by `useState`)
3. on this re-render, the `data` object passed into `useRenderer` should NOT be changed (properties can change, but actual object should be the same instance).  If it is changed, `useRenderer` will attempt to set state of `value` / `rendered` again, causing an infinite loop
4. the `data` object is therefore stored in `dataRef` (`useRef` hook).  On the renders (and re-renders) the `data` object is NOT changed (avoiding this infinite loop)

The `setInterval` callback does use a brand new object to trigger `useRenderer` to updated `render` / `value`.  However, w/o a component re-render `useRenderer` never gets called.  So the `setInterval` callback also calls `setState` on our `timeleft` variable to trigger to re-render.