### PR TITLE
✅ Fix amp-ad-3p sourceUrl assertion for IE11

### DIFF
--- a/test/integration/test-amp-ad-3p.js
+++ b/test/integration/test-amp-ad-3p.js
@@ -125,11 +125,11 @@ describe('amp-ad 3P', () => {
           );
         }
         expect(context.startTime).to.be.a('number');
-        // Edge has different opinion about window.location in srcdoc iframe.
+        // Edge\IE has different opinion about window.location in srcdoc iframe.
         // Nevertheless this only happens in test. In real world AMP will not
         // in srcdoc iframe.
         expect(context.sourceUrl).to.equal(
-          platform.isEdge()
+          platform.isEdge() || platform.isIE()
             ? 'http://localhost:9876/context.html'
             : 'about:srcdoc'
         );

--- a/test/integration/test-amp-ad-3p.js
+++ b/test/integration/test-amp-ad-3p.js
@@ -129,7 +129,7 @@ describe('amp-ad 3P', () => {
         // Nevertheless this only happens in test. In real world AMP will not
         // in srcdoc iframe.
         expect(context.sourceUrl).to.equal(
-          platform.isEdge() || platform.isIE()
+          platform.isEdge() || platform.isIe()
             ? 'http://localhost:9876/context.html'
             : 'about:srcdoc'
         );

--- a/test/integration/test-amp-ad-3p.js
+++ b/test/integration/test-amp-ad-3p.js
@@ -125,7 +125,7 @@ describe('amp-ad 3P', () => {
           );
         }
         expect(context.startTime).to.be.a('number');
-        // Edge\IE has different opinion about window.location in srcdoc iframe.
+        // Edge/IE has different opinion about window.location in srcdoc iframe.
         // Nevertheless this only happens in test. In real world AMP will not
         // in srcdoc iframe.
         expect(context.sourceUrl).to.equal(


### PR DESCRIPTION
`window.location` in a srcdoc iframe is `"about:srcdoc"` in sane browsers and a special magic string in Edge and IE. The special-case handling was in place already for Edge, but not for IE, causing the IE11 integration test to fail. This PR adds the IE11 check to the special-case check.

Part of broad effort under #28152 to enable IE11 integration tests as blocking

![image](https://user-images.githubusercontent.com/6694512/94194345-8d1cd480-fe7f-11ea-8a47-fe2c8308c941.png)

<!--
# Instructions:

- Pick a meaningful title for your pull request. (Use sentence case.)
  - Prefix the title with an emoji to identify what is being done. (Copy-paste the emoji from the list below.)
  - Do not overuse punctuation in the title (like `(chore):`).
  - If it is helpful, use a simple prefix (like `ProjectX: Implement some feature`).
- Enter a succinct description that says why the PR is necessary, and what it does.
  - Mention the GitHub issue that is being addressed by the pull request.
  - The keywords `Fixes`, `Closes`, or `Resolves` followed the issue number will automatically close the issue.

> NOTE: All non-trivial changes (like introducing new features or components) should have an associated issue or reference an I2I (intent-to-implement: go.amp.dev/i2i). Please read through the contribution process (go.amp.dev/contributing/code) for more information.

# Example of a good description:

- Implement aspect X
- Leave out feature Y because of A
- Improve performance by B
- Improve accessibility by C

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Reverting a previous change
♻️ Refactoring
🚮 Deleting code
🧪 Experimental code
-->
