### PR TITLE
🏗 Run default task in parallel with storybook-amp

### DIFF
--- a/build-system/common/exec.js
+++ b/build-system/common/exec.js
@@ -52,7 +52,7 @@ function exec(cmd, options) {
  *
  * @param {string} script
  * @param {?Object} options
- * @return {!Object}
+ * @return {!ChildProcess}
  */
 function execScriptAsync(script, options) {
   return childProcess.spawn(script, {shell: shellCmd, ...options});

--- a/build-system/tasks/serve.js
+++ b/build-system/tasks/serve.js
@@ -41,8 +41,6 @@ const {watch} = require('gulp');
 
 const argv = minimist(process.argv.slice(2), {string: ['rtv']});
 
-const DEFAULT_PORT = 8000;
-
 // Used for logging.
 let url = null;
 let quiet = !!argv.quiet;
@@ -103,7 +101,7 @@ async function startServer(
     name: 'AMP Dev Server',
     root: process.cwd(),
     host: argv.host || 'localhost',
-    port: argv.port || DEFAULT_PORT,
+    port: argv.port || 8000,
     https: argv.https,
     preferHttp1: true,
     silent: true,
@@ -193,7 +191,6 @@ module.exports = {
   doServe,
   startServer,
   stopServer,
-  DEFAULT_PORT,
 };
 
 /* eslint "google-camelcase/google-camelcase": 0 */

--- a/build-system/tasks/serve.js
+++ b/build-system/tasks/serve.js
@@ -41,6 +41,8 @@ const {watch} = require('gulp');
 
 const argv = minimist(process.argv.slice(2), {string: ['rtv']});
 
+const DEFAULT_PORT = 8000;
+
 // Used for logging.
 let url = null;
 let quiet = !!argv.quiet;
@@ -101,7 +103,7 @@ async function startServer(
     name: 'AMP Dev Server',
     root: process.cwd(),
     host: argv.host || 'localhost',
-    port: argv.port || 8000,
+    port: argv.port || DEFAULT_PORT,
     https: argv.https,
     preferHttp1: true,
     silent: true,
@@ -191,6 +193,7 @@ module.exports = {
   doServe,
   startServer,
   stopServer,
+  DEFAULT_PORT,
 };
 
 /* eslint "google-camelcase/google-camelcase": 0 */

--- a/build-system/tasks/storybook/index.js
+++ b/build-system/tasks/storybook/index.js
@@ -45,7 +45,7 @@ function runStorybook(env) {
       ci ? '--ci' : '',
     ].join(' '),
     {
-      'stdio': [null, process.stdout, process.stderr],
+      stdio: [null, process.stdout, process.stderr],
       cwd: __dirname,
       env: process.env,
     }

--- a/build-system/tasks/storybook/index.js
+++ b/build-system/tasks/storybook/index.js
@@ -34,12 +34,16 @@ function runStorybook(env) {
   // install storybook-specific modules
   installPackages(__dirname);
 
-  const {ci, 'storybook_port': port = ENV_PORTS[env]} = argv;
+  const {ci, 'storybook_port': storybookPort = ENV_PORTS[env]} = argv;
 
   return execScriptAsync(
-    `./node_modules/.bin/start-storybook --quiet -c ./${env}-env -p ${port} ${
-      ci ? '--ci' : ''
-    }`,
+    [
+      './node_modules/.bin/start-storybook',
+      '--quiet',
+      '-c ./${env}-env',
+      `-p ${storybookPort}`,
+      ci ? '--ci' : '',
+    ].join(' '),
     {
       'stdio': [null, process.stdout, process.stderr],
       cwd: __dirname,

--- a/build-system/tasks/storybook/index.js
+++ b/build-system/tasks/storybook/index.js
@@ -40,7 +40,7 @@ function runStorybook(env) {
     [
       './node_modules/.bin/start-storybook',
       '--quiet',
-      '-c ./${env}-env',
+      `-c ./${env}-env`,
       `-p ${storybookPort}`,
       ci ? '--ci' : '',
     ].join(' '),

--- a/build-system/tasks/storybook/index.js
+++ b/build-system/tasks/storybook/index.js
@@ -21,19 +21,23 @@ const {defaultTask: runAmpDevBuildServer} = require('../default-task');
 const {execScriptAsync} = require('../../common/exec');
 const {installPackages} = require('../../common/utils');
 
-const MODE_PORTS = {
+const ENV_PORTS = {
   amp: 9001,
   preact: 9002,
 };
 
-function runStorybook(mode) {
+/**
+ * @param {string} env 'amp' or 'preact'
+ * @return {!ChildProcess}
+ */
+function runStorybook(env) {
   // install storybook-specific modules
   installPackages(__dirname);
 
-  const {ci, 'storybook_port': port = MODE_PORTS[mode]} = argv;
+  const {ci, 'storybook_port': port = ENV_PORTS[env]} = argv;
 
-  execScriptAsync(
-    `./node_modules/.bin/start-storybook --quiet -c ./${mode}-env -p ${port} ${
+  return execScriptAsync(
+    `./node_modules/.bin/start-storybook --quiet -c ./${env}-env -p ${port} ${
       ci ? '--ci' : ''
     }`,
     {

--- a/build-system/tasks/storybook/index.js
+++ b/build-system/tasks/storybook/index.js
@@ -59,14 +59,14 @@ function runStorybook(env) {
 async function storybookAmp() {
   await runAmpDevBuildServer();
   createCtrlcHandler('storybook-amp');
-  runStorybook('amp' /* mode */);
+  runStorybook('amp');
 }
 
 /**
  * Simple wrapper around the storybook start script.
  */
 function storybookPreact() {
-  runStorybook('preact' /* mode */);
+  runStorybook('preact');
 }
 
 module.exports = {


### PR DESCRIPTION
Previously, you'd have to run `gulp` at the same time as `storybook-amp` to serve binaries from `localhost:8000`.