### PR TITLE
✅ Fix amp-ad-3p Event constructor calls

### DIFF
--- a/test/integration/test-amp-ad-3p.js
+++ b/test/integration/test-amp-ad-3p.js
@@ -15,6 +15,7 @@
  */
 
 import {Services} from '../../src/services';
+import {createCustomEvent} from '../../src/event-helper';
 import {createFixtureIframe, poll} from '../../testing/iframe';
 import {installPlatformService} from '../../src/service/platform-impl';
 import {layoutRectLtwh} from '../../src/layout-rect';
@@ -195,7 +196,9 @@ describe('amp-ad 3P', () => {
         // Ad is still fully visible. observeIntersection fire when
         // ads is fully visible with position change
         fixture.win.scrollTo(0, 1000);
-        fixture.win.dispatchEvent(new Event('scroll'));
+        fixture.win.dispatchEvent(
+          createCustomEvent(fixture.win, 'scroll', null)
+        );
         await poll('wait for new IO entry when ad is fully visible', () => {
           return (
             lastIO != null &&
@@ -210,7 +213,9 @@ describe('amp-ad 3P', () => {
 
         // Ad is partially visible (around 50%)
         fixture.win.scrollTo(0, 1125);
-        fixture.win.dispatchEvent(new Event('scroll'));
+        fixture.win.dispatchEvent(
+          createCustomEvent(fixture.win, 'scroll', null)
+        );
         await poll(
           'wait for new IO entry when intersectionRatio changes',
           () => {
@@ -229,7 +234,9 @@ describe('amp-ad 3P', () => {
 
         // Ad first becomes invisible
         fixture.win.scrollTo(0, 1251);
-        fixture.win.dispatchEvent(new Event('scroll'));
+        fixture.win.dispatchEvent(
+          createCustomEvent(fixture.win, 'scroll', null)
+        );
         await poll('wait for new IO entry when ad exit viewport', () => {
           return lastIO != null && lastIO.intersectionRatio == 0;
         });
@@ -241,7 +248,9 @@ describe('amp-ad 3P', () => {
 
         // Scroll when ad is invisible
         fixture.win.scrollTo(0, 1451);
-        fixture.win.dispatchEvent(new Event('scroll'));
+        fixture.win.dispatchEvent(
+          createCustomEvent(fixture.win, 'scroll', null)
+        );
         await new Promise((resolve) => {
           setTimeout(resolve, 100);
         });


### PR DESCRIPTION
Creating and dispatching custom events in IE11 requires a workaround rather than using the `Event` constructor directly. This PR replaces calls to `new Error()` with calls to the existing `createCustomEvent` helper. Fixes remaining failures in this test on IE11.

Part of broad effort under #28152 to enable IE11 integration tests as blocking

Fixed error (revealed by #30389, fixing a failure earlier in the test):
![image](https://user-images.githubusercontent.com/6694512/94199923-8eea9600-fe87-11ea-9362-714bfadc839e.png)

<!--
# Instructions:

- Pick a meaningful title for your pull request. (Use sentence case.)
  - Prefix the title with an emoji to identify what is being done. (Copy-paste the emoji from the list below.)
  - Do not overuse punctuation in the title (like `(chore):`).
  - If it is helpful, use a simple prefix (like `ProjectX: Implement some feature`).
- Enter a succinct description that says why the PR is necessary, and what it does.
  - Mention the GitHub issue that is being addressed by the pull request.
  - The keywords `Fixes`, `Closes`, or `Resolves` followed the issue number will automatically close the issue.

> NOTE: All non-trivial changes (like introducing new features or components) should have an associated issue or reference an I2I (intent-to-implement: go.amp.dev/i2i). Please read through the contribution process (go.amp.dev/contributing/code) for more information.

# Example of a good description:

- Implement aspect X
- Leave out feature Y because of A
- Improve performance by B
- Improve accessibility by C

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Reverting a previous change
♻️ Refactoring
🚮 Deleting code
🧪 Experimental code
-->
