### PR TITLE
jss: fix potential issue with quotes

### DIFF
--- a/build-system/babel-plugins/babel-plugin-transform-jss/index.js
+++ b/build-system/babel-plugins/babel-plugin-transform-jss/index.js
@@ -117,7 +117,7 @@ module.exports = function ({template}) {
         // Export a variable named CSS with the compiled CSS.
         const cssExport = template.ast`export const CSS = "${transformCssSync(
           sheet.toString()
-        )}"`; 
+        )}"`;
         path
           .findParent((p) => p.type === 'ExportNamedDeclaration')
           .insertAfter(cssExport);

--- a/build-system/babel-plugins/babel-plugin-transform-jss/index.js
+++ b/build-system/babel-plugins/babel-plugin-transform-jss/index.js
@@ -117,8 +117,7 @@ module.exports = function ({template}) {
         // Export a variable named CSS with the compiled CSS.
         const cssExport = template.ast`export const CSS = "${transformCssSync(
           sheet.toString()
-        )}"`;
-
+        )}"`; 
         path
           .findParent((p) => p.type === 'ExportNamedDeclaration')
           .insertAfter(cssExport);

--- a/build-system/babel-plugins/babel-plugin-transform-jss/index.js
+++ b/build-system/babel-plugins/babel-plugin-transform-jss/index.js
@@ -102,9 +102,9 @@ module.exports = function ({template}) {
 
         // Create the classes var.
         const id = path.scope.generateUidIdentifier('classes');
-        const init = template.expression.ast`{${Object.entries(sheet.classes)
-          .map(([k, v]) => `${k}:"${v}"`)
-          .join(',')}}`;
+        const init = template.expression.ast`${stringifyUnquotedProps(
+          sheet.classes
+        )}`;
         path.scope.push({id, init});
         path.scope.bindings[id.name].path.parentPath.addComment(
           'leading',
@@ -118,6 +118,7 @@ module.exports = function ({template}) {
         const cssExport = template.ast`export const CSS = "${transformCssSync(
           sheet.toString()
         )}"`;
+
         path
           .findParent((p) => p.type === 'ExportNamedDeclaration')
           .insertAfter(cssExport);
@@ -137,6 +138,21 @@ module.exports = function ({template}) {
     },
   };
 };
+
+/**
+ * An equivalent to JSON.stringify except the properties are unquoted.
+ * @param {Object} obj
+ * @return {string}
+ */
+function stringifyUnquotedProps(obj) {
+  return (
+    '{' +
+    Object.entries(obj)
+      .map(([k, v]) => `${k}:"${v}"`)
+      .join(',') +
+    '}'
+  );
+}
 
 // Abuses spawnSync to let us run an async function sync.
 function transformCssSync(cssText) {

--- a/build-system/babel-plugins/babel-plugin-transform-jss/index.js
+++ b/build-system/babel-plugins/babel-plugin-transform-jss/index.js
@@ -102,7 +102,9 @@ module.exports = function ({template}) {
 
         // Create the classes var.
         const id = path.scope.generateUidIdentifier('classes');
-        const init = template.expression.ast`${JSON.stringify(sheet.classes)}`;
+        const init = template.expression.ast`{${Object.entries(sheet.classes)
+          .map(([k, v]) => `${k}:"${v}"`)
+          .join(',')}}`;
         path.scope.push({id, init});
         path.scope.bindings[id.name].path.parentPath.addComment(
           'leading',

--- a/build-system/babel-plugins/babel-plugin-transform-jss/test/fixtures/transform-assertions/should-transform-jss-var/output.mjs
+++ b/build-system/babel-plugins/babel-plugin-transform-jss/test/fixtures/transform-assertions/should-transform-jss-var/output.mjs
@@ -1,5 +1,5 @@
 /** @enum {string}*/
-var _classes = {"button":"button-21aa4a8"};
+var _classes = {button:"button-21aa4a8"};
 
 /**
  * Copyright 2020 The AMP HTML Authors. All Rights Reserved.

--- a/build-system/babel-plugins/babel-plugin-transform-jss/test/fixtures/transform-assertions/should-transform-literal/output.mjs
+++ b/build-system/babel-plugins/babel-plugin-transform-jss/test/fixtures/transform-assertions/should-transform-literal/output.mjs
@@ -1,5 +1,5 @@
 /** @enum {string}*/
-var _classes = {"floatLeft":"float-left-a6c6677","fill":"fill-a6c6677"};
+var _classes = {floatLeft:"float-left-a6c6677",fill:"fill-a6c6677"};
 
 /**
  * Copyright 2020 The AMP HTML Authors. All Rights Reserved.


### PR DESCRIPTION
**summary**
Unsure how necessary this is. I'm currently pretty confused by Closure Compiler's sometimes inconsistent mangling. Seeing this issue in online closure tools, but not in dist builds.

[Broken compilation examle](https://closure-compiler.appspot.com/home#code%3D%252F%252F%2520%253D%253DClosureCompiler%253D%253D%250A%252F%252F%2520%2540compilation_level%2520ADVANCED_OPTIMIZATIONS%250A%252F%252F%2520%2540output_file_name%2520default.js%250A%252F%252F%2520%2540formatting%2520pretty_print%250A%252F%252F%2520%2540language_out%2520ECMASCRIPT5_STRICT%250A%252F%252F%2520%253D%253D%252FClosureCompiler%253D%253D%250A%250A%250Aconst%2520a%2520%253D%2520%257B%2520%2522cx1%2522%253A%2520'hello'%252C%2520%2522cx2%2522%253A%2520'world'%257D%253B%250Aconst%2520getA%2520%253D%2520()%2520%253D%253E%2520a%253B%250Aconsole.log(getA().cx1)%253B%250Aconsole.log(getA().cx2))