### PR TITLE
🏗 Allow .sxg.js.

### DIFF
--- a/build-system/server/app-utils.js
+++ b/build-system/server/app-utils.js
@@ -127,27 +127,27 @@ const replaceUrls = (mode, file, hostName, inabox, storyV1) => {
     }
   } else if (mode == 'compiled') {
     file = file.replace(
-      /https:\/\/cdn\.ampproject\.org\/v0\.(m|sxg\.)?js/g,
-      hostName + '/dist/v0.$1js'
+      /https:\/\/cdn\.ampproject\.org\/v0\.(mjs|sxg.js|js)/g,
+      hostName + '/dist/v0.$1'
     );
     file = file.replace(
-      /https:\/\/cdn\.ampproject\.org\/shadow-v0\.(m|sxg\.)?js/g,
-      hostName + '/dist/shadow-v0.$1js'
+      /https:\/\/cdn\.ampproject\.org\/shadow-v0\.(mjs|sxg.js|js)/g,
+      hostName + '/dist/shadow-v0.$1'
     );
     file = file.replace(
-      /https:\/\/cdn\.ampproject\.org\/amp4ads-v0\.(m|sxg\.)?js/g,
-      hostName + '/dist/amp4ads-v0.$1js'
+      /https:\/\/cdn\.ampproject\.org\/amp4ads-v0\.(mjs|sxg.js|js)/g,
+      hostName + '/dist/amp4ads-v0.$1'
     );
     file = file.replace(
-      /https:\/\/cdn\.ampproject\.org\/video-iframe-integration-v0\.(m|sxg\.)?js/g,
-      hostName + '/dist/video-iframe-integration-v0.$1js'
+      /https:\/\/cdn\.ampproject\.org\/video-iframe-integration-v0\.(mjs|sxg.js|js)/g,
+      hostName + '/dist/video-iframe-integration-v0.$1'
     );
     file = file.replace(
-      /https:\/\/cdn\.ampproject\.org\/v0\/(.+?)\.(m|sxg\.)?js/g,
+      /https:\/\/cdn\.ampproject\.org\/v0\/(.+?)\.(mjs|sxg.js|js)/g,
       hostName + '/dist/v0/$1.$2js'
     );
     file = file.replace(
-      /\/dist\/v0\/examples\/(.*)\.max\.(m|sxg\.)?js/g,
+      /\/dist\/v0\/examples\/(.*)\.max\.(mjs|sxg.js|js)/g,
       '/dist/v0/examples/$1.$2js'
     );
     file = file.replace(
@@ -164,14 +164,14 @@ const replaceUrls = (mode, file, hostName, inabox, storyV1) => {
 
     if (inabox) {
       file = file.replace(
-        /https:\/\/cdn\.ampproject\.org\/rtv\/\d{15}\/v0\.(m|sxg\.)?js/g,
-        hostName + 'amp4ads-v0.$1js'
+        /https:\/\/cdn\.ampproject\.org\/rtv\/\d{15}\/v0\.(mjs|sxg.js|js)/g,
+        hostName + 'amp4ads-v0.$1'
       );
     }
   } else if (inabox) {
     file = file.replace(
-      /https:\/\/cdn\.ampproject\.org\/v0\.(m|sxg\.)?js/g,
-      'https://cdn.ampproject.org/amp4ads-v0.$1js'
+      /https:\/\/cdn\.ampproject\.org\/v0\.(mjs|sxg.js|js)/g,
+      'https://cdn.ampproject.org/amp4ads-v0.$1'
     );
   }
   return file;

--- a/build-system/server/app-utils.js
+++ b/build-system/server/app-utils.js
@@ -127,28 +127,28 @@ const replaceUrls = (mode, file, hostName, inabox, storyV1) => {
     }
   } else if (mode == 'compiled') {
     file = file.replace(
-      /https:\/\/cdn\.ampproject\.org\/v0\.js/g,
-      hostName + '/dist/v0.js'
+      /https:\/\/cdn\.ampproject\.org\/v0\.(m|sxg\.)?js/g,
+      hostName + '/dist/v0.$1js'
     );
     file = file.replace(
-      /https:\/\/cdn\.ampproject\.org\/shadow-v0\.js/g,
-      hostName + '/dist/shadow-v0.js'
+      /https:\/\/cdn\.ampproject\.org\/shadow-v0\.(m|sxg\.)?js/g,
+      hostName + '/dist/shadow-v0.$1js'
     );
     file = file.replace(
-      /https:\/\/cdn\.ampproject\.org\/amp4ads-v0\.js/g,
-      hostName + '/dist/amp4ads-v0.js'
+      /https:\/\/cdn\.ampproject\.org\/amp4ads-v0\.(m|sxg\.)?js/g,
+      hostName + '/dist/amp4ads-v0.$1js'
     );
     file = file.replace(
-      /https:\/\/cdn\.ampproject\.org\/video-iframe-integration-v0\.js/g,
-      hostName + '/dist/video-iframe-integration-v0.js'
+      /https:\/\/cdn\.ampproject\.org\/video-iframe-integration-v0\.(m|sxg\.)?js/g,
+      hostName + '/dist/video-iframe-integration-v0.$1js'
     );
     file = file.replace(
-      /https:\/\/cdn\.ampproject\.org\/v0\/(.+?).js/g,
-      hostName + '/dist/v0/$1.js'
+      /https:\/\/cdn\.ampproject\.org\/v0\/(.+?)\.(m|sxg\.)?js/g,
+      hostName + '/dist/v0/$1.$2js'
     );
     file = file.replace(
-      /\/dist\/v0\/examples\/(.*)\.max.js/g,
-      '/dist/v0/examples/$1.js'
+      /\/dist\/v0\/examples\/(.*)\.max\.(m|sxg\.)?js/g,
+      '/dist/v0/examples/$1.$2js'
     );
     file = file.replace(
       /\/dist.3p\/current\/(.*)\.max.html/g,
@@ -164,14 +164,14 @@ const replaceUrls = (mode, file, hostName, inabox, storyV1) => {
 
     if (inabox) {
       file = file.replace(
-        /https:\/\/cdn\.ampproject\.org\/rtv\/\d{15}\/v0\.js/g,
-        hostName + 'amp4ads-v0.js'
+        /https:\/\/cdn\.ampproject\.org\/rtv\/\d{15}\/v0\.(m|sxg\.)?js/g,
+        hostName + 'amp4ads-v0.$1js'
       );
     }
   } else if (inabox) {
     file = file.replace(
-      /https:\/\/cdn\.ampproject\.org\/v0\.js/g,
-      'https://cdn.ampproject.org/amp4ads-v0.js'
+      /https:\/\/cdn\.ampproject\.org\/v0\.(m|sxg\.)?js/g,
+      'https://cdn.ampproject.org/amp4ads-v0.$1js'
     );
   }
   return file;

--- a/build-system/server/app-utils.js
+++ b/build-system/server/app-utils.js
@@ -144,11 +144,11 @@ const replaceUrls = (mode, file, hostName, inabox, storyV1) => {
     );
     file = file.replace(
       /https:\/\/cdn\.ampproject\.org\/v0\/(.+?)\.(mjs|sxg.js|js)/g,
-      hostName + '/dist/v0/$1.$2js'
+      hostName + '/dist/v0/$1.$2'
     );
     file = file.replace(
       /\/dist\/v0\/examples\/(.*)\.max\.(mjs|sxg.js|js)/g,
-      '/dist/v0/examples/$1.$2js'
+      '/dist/v0/examples/$1.$2'
     );
     file = file.replace(
       /\/dist.3p\/current\/(.*)\.max.html/g,

--- a/build-system/server/app.js
+++ b/build-system/server/app.js
@@ -65,9 +65,6 @@ app.use('/amp4test', require('./amp4test').app);
 app.use('/analytics', require('./routes/analytics'));
 app.use('/list/', require('./routes/list'));
 app.use('/test', require('./routes/test'));
-if (argv.coverage) {
-  app.use('/coverage', require('istanbul-middleware').createHandler());
-}
 
 // Append ?csp=1 to the URL to turn on the CSP header.
 // TODO: shall we turn on CSP all the time?
@@ -911,15 +908,18 @@ app.get('/iframe-echo-message', (req, res) => {
  * <script async custom-element="amp-form"
  *    src="https://cdn.ampproject.org/v0/amp-form-0.1.js?sleep=5"></script>
  */
-app.use(['/dist/v0/amp-*.js', '/dist/amp*.js'], (req, res, next) => {
-  const sleep = parseInt(req.query.sleep || 0, 10) * 1000;
-  setTimeout(next, sleep);
-});
+app.use(
+  ['/dist/v0/amp-*.(sxg.js|mjs|js)', '/dist/amp*.(sxg.js|mjs|js)'],
+  (req, res, next) => {
+    const sleep = parseInt(req.query.sleep || 0, 10) * 1000;
+    setTimeout(next, sleep);
+  }
+);
 
 /**
  * Disable caching for extensions if the --no_caching_extensions flag is used.
  */
-app.get(['/dist/v0/amp-*.js'], (req, res, next) => {
+app.get(['/dist/v0/amp-*.(sxg.js|mjs|js)'], (req, res, next) => {
   if (argv.no_caching_extensions) {
     res.header('Cache-Control', 'no-store');
   }
@@ -1202,7 +1202,7 @@ app.get('/adzerk/*', (req, res) => {
  * Serve extension scripts and their source maps.
  */
 app.get(
-  ['/dist/rtv/*/v0/*.js', '/dist/rtv/*/v0/*.js.map'],
+  ['/dist/rtv/*/v0/*.(sxg.js|mjs|js)', '/dist/rtv/*/v0/*.(sxg.js|mjs|js).map'],
   (req, res, next) => {
     const mode = SERVE_MODE;
     const fileName = path.basename(req.path).replace('.max.', '.');
@@ -1222,7 +1222,7 @@ app.get(
     }
     const isJsMap = filePath.endsWith('.map');
     if (isJsMap) {
-      filePath = filePath.replace(/\.js\.map$/, '.js');
+      filePath = filePath.replace(/\.(sxg\.js|mjs|js)\.map$/, '.$1');
     }
     filePath = replaceUrls(mode, filePath);
     req.url = filePath + (isJsMap ? '.map' : '');
@@ -1234,7 +1234,11 @@ app.get(
  * Serve entry point script url
  */
 app.get(
-  ['/dist/sw.js', '/dist/sw-kill.js', '/dist/ww.js'],
+  [
+    '/dist/sw.(sxg.js|mjs|js)',
+    '/dist/sw-kill.(sxg.js|mjs|js)',
+    '/dist/ww.(sxg.js|mjs|js)',
+  ],
   (req, res, next) => {
     // Special case for entry point script url. Use compiled for testing
     const mode = SERVE_MODE;
@@ -1254,18 +1258,21 @@ app.get(
       return;
     }
     if (mode == 'default') {
-      req.url = req.url.replace(/\.js$/, '.max.js');
+      req.url = req.url.replace(/\.(sxg\.js|mjs|js)$/, '.max.$1');
     }
     next();
   }
 );
 
-app.get('/dist/iframe-transport-client-lib.js', (req, res, next) => {
-  req.url = req.url.replace(/dist/, 'dist.3p/current');
-  next();
-});
+app.get(
+  '/dist/iframe-transport-client-lib.(sxg.js|mjs|js)',
+  (req, res, next) => {
+    req.url = req.url.replace(/dist/, 'dist.3p/current');
+    next();
+  }
+);
 
-app.get('/dist/amp-inabox-host.js', (req, res, next) => {
+app.get('/dist/amp-inabox-host.(sxg.js|mjs|js)', (req, res, next) => {
   const mode = SERVE_MODE;
   if (mode != 'default') {
     req.url = req.url.replace('amp-inabox-host', 'amp4ads-host-v0');
@@ -1276,7 +1283,7 @@ app.get('/dist/amp-inabox-host.js', (req, res, next) => {
 /*
  * Start Cache SW LOCALDEV section
  */
-app.get('/dist/sw(.max)?.js', (req, res, next) => {
+app.get('/dist/sw(.max)?.(sxg.js|mjs|js)', (req, res, next) => {
   const filePath = req.path;
   fs.promises
     .readFile(pc.cwd() + filePath, 'utf8')
@@ -1301,7 +1308,7 @@ app.get('/dist/sw(.max)?.js', (req, res, next) => {
     .catch(next);
 });
 
-app.get('/dist/rtv/9[89]*/*.js', (req, res, next) => {
+app.get('/dist/rtv/9[89]*/*.(sxg.js|mjs|js)', (req, res, next) => {
   res.setHeader('Content-Type', 'application/javascript');
   res.setHeader('Date', new Date().toUTCString());
   res.setHeader('Cache-Control', 'no-cache;max-age=31536000');
@@ -1373,7 +1380,7 @@ app.get('/dist/diversions', (req, res) => {
 /**
  * Web worker binary.
  */
-app.get('/dist/ww(.max)?.js', (req, res) => {
+app.get('/dist/ww(.max)?.(sxg.js|mjs|js)', (req, res) => {
   fs.promises.readFile(pc.cwd() + req.path).then((file) => {
     res.setHeader('Content-Type', 'text/javascript');
     res.setHeader('Access-Control-Allow-Origin', '*');

--- a/build-system/test-configs/config.js
+++ b/build-system/test-configs/config.js
@@ -35,7 +35,7 @@ const fixturesExamplesPaths = [
 
 const builtRuntimePaths = [
   {
-    pattern: 'dist/**/*.js',
+    pattern: 'dist/**/*.{sxg.js, js, mjs}',
     included: false,
     nocache: false,
     watched: true,
@@ -47,7 +47,7 @@ const builtRuntimePaths = [
     watched: true,
   },
   {
-    pattern: 'dist.tools/**/*.js',
+    pattern: 'dist.tools/**/*.{sxg.js, js, mjs}',
     included: false,
     nocache: false,
     watched: true,

--- a/build-system/test-configs/config.js
+++ b/build-system/test-configs/config.js
@@ -35,7 +35,7 @@ const fixturesExamplesPaths = [
 
 const builtRuntimePaths = [
   {
-    pattern: 'dist/**/*.{sxg.js, js, mjs}',
+    pattern: 'dist/**/*.js',
     included: false,
     nocache: false,
     watched: true,
@@ -47,19 +47,31 @@ const builtRuntimePaths = [
     watched: true,
   },
   {
+    pattern: 'dist/**/*.sxg.js',
+    included: false,
+    nocache: false,
+    watched: true,
+  },
+  {
     pattern: 'dist.3p/**/*',
     included: false,
     nocache: false,
     watched: true,
   },
   {
-    pattern: 'dist.tools/**/*.{sxg.js, js, mjs}',
+    pattern: 'dist.tools/**/*.js',
     included: false,
     nocache: false,
     watched: true,
   },
   {
     pattern: 'dist.tools/**/*.mjs',
+    included: false,
+    nocache: false,
+    watched: true,
+  },
+  {
+    pattern: 'dist.tools/**/*.sxg.js',
     included: false,
     nocache: false,
     watched: true,


### PR DESCRIPTION
This adopts changes from #30378 but adds `.sxg.js` to be matched in the transformer regexes.