### PR TITLE
✅ Fix IE11 tests for on=tap

### DIFF
--- a/testing/iframe.js
+++ b/testing/iframe.js
@@ -118,7 +118,7 @@ export function createFixtureIframe(
           if (events[eventName] >= count) {
             resolve();
           } else {
-            win.addEventListener(eventName, () => {
+            win.addEventListener(eventName, function () {
               if (events[eventName] == count) {
                 resolve();
               }

--- a/testing/iframe.js
+++ b/testing/iframe.js
@@ -128,7 +128,7 @@ export function createFixtureIframe(
       };
       // Record firing of custom events.
       for (const name in events) {
-        win.addEventListener(name, () => {
+        win.addEventListener(name, function () {
           events[name]++;
         });
       }


### PR DESCRIPTION
This PR fixes the last failing IE11 test, one which has a rather cryptic error message:
![image](https://user-images.githubusercontent.com/6694512/94219939-edc70400-feb5-11ea-931e-b70956c5e9aa.png)

Explanation forthcoming

Part of broad effort under #28152 to enable IE11 integration tests as blocking

<!--
# Instructions:

- Pick a meaningful title for your pull request. (Use sentence case.)
  - Prefix the title with an emoji to identify what is being done. (Copy-paste the emoji from the list below.)
  - Do not overuse punctuation in the title (like `(chore):`).
  - If it is helpful, use a simple prefix (like `ProjectX: Implement some feature`).
- Enter a succinct description that says why the PR is necessary, and what it does.
  - Mention the GitHub issue that is being addressed by the pull request.
  - The keywords `Fixes`, `Closes`, or `Resolves` followed the issue number will automatically close the issue.

> NOTE: All non-trivial changes (like introducing new features or components) should have an associated issue or reference an I2I (intent-to-implement: go.amp.dev/i2i). Please read through the contribution process (go.amp.dev/contributing/code) for more information.

# Example of a good description:

- Implement aspect X
- Leave out feature Y because of A
- Improve performance by B
- Improve accessibility by C

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Reverting a previous change
♻️ Refactoring
🚮 Deleting code
🧪 Experimental code
-->
