### PR TITLE
❄️ Fix amphtml-ad visual diff test flakiness

### DIFF
--- a/examples/visual-tests/amphtml-ads/resource/amp-ads-fallback.html
+++ b/examples/visual-tests/amphtml-ads/resource/amp-ads-fallback.html
@@ -14,7 +14,7 @@
 <amp-ad width="300" height="250"
         type="fake"
         id="i-amphtml-demo-id-1"
-        src="nonexistent">
+        src="/nonexistent">
   <div fallback style="background-color: red;">Could not display the fake ad :(</div>
 </amp-ad>
 <h2 style="height: 1000px;">Placeholder</h2>


### PR DESCRIPTION
Without this slash, the URL is interpreted as a domain name. Travis somehow just blocks rather than fails fast, causing it to timeout and the loading indicator present. This PR changes the domain name to a path that returns 404.