### PR TITLE
create a postHTML transformer that modifies script src url for sxg mode

### DIFF
--- a/build-system/server/new-server/transforms/sxg/sxg-transform.ts
+++ b/build-system/server/new-server/transforms/sxg/sxg-transform.ts
@@ -16,52 +16,34 @@
 
 import {PostHTML} from 'posthtml';
 import {URL} from 'url';
-import {isValidScript, ScriptNode} from '../utilities/script';
-import {CDNURLToLocalDistURL} from '../utilities/cdn';
+import {isValidScript} from '../utilities/script';
 import {OptionSet} from '../utilities/option-set';
 import minimist from 'minimist';
 const argv = minimist(process.argv.slice(2));
 
 /**
- * @param head
- * @param script
- * @param compiled 
- */
-function appendSxg(script: ScriptNode, compiled: boolean): PostHTML.Node {
-  /*
-  if (argv.compiled || compiled) {
-    let sxgPath = CDNURLToLocalDistURL(
-      new URL(script.attrs.src || ''),
-      undefined
-    ).toString();
-    script.attrs.src = sxgPath.replace('.js', '.sxg.js');
-  }
-  else {
-    const urlName = script.attrs.src.toString();
-    if (urlName.includes('js?')){
-        script.attrs.src = urlName + '&f=sxg';
-    }
-    else{
-        script.attrs.src = urlName + '?f=sxg';
-    }
-  }
-
-  script.attrs.type = 'sxg';
-  */
- if(argv.compiled || compiled){
-   script.attrs
- }
-  return script;
-}
-
-/**
- * Returns a function that will transform script node sources into module/nomodule pair.
+ * Returns a function that will transform script node sources into their sxg counterparts.
  * @param options
  */
 export default function(options: OptionSet = {}): (tree: PostHTML.Node) => void {
   return function(tree: PostHTML.Node) {
     tree.match({tag: 'script'}, (script) => {
-      script = 'l';
+      if(!isValidScript(script)){
+        return script;
+      }
+
+      let url;
+      if(options.compiled || argv.compiled){
+        url = script.attrs.src.toString();
+        script.attrs.src = url.replace('.js', '.sxg.js');
+      }
+      else{
+        url = new URL(script.attrs.src);
+        url.searchParams.append('f', 'sxg');
+        script.attrs.src = url.toString();
+      }
+      script.attrs.type = 'sxg';
+      return script;
     });
   }
 }

--- a/build-system/server/new-server/transforms/sxg/sxg-transform.ts
+++ b/build-system/server/new-server/transforms/sxg/sxg-transform.ts
@@ -16,7 +16,7 @@
 
 import {PostHTML} from 'posthtml';
 import {URL} from 'url';
-import {isValidScript} from '../utilities/script';
+import {isJsonScript, isValidScript} from '../utilities/script';
 import {OptionSet} from '../utilities/option-set';
 import minimist from 'minimist';
 const argv = minimist(process.argv.slice(2));
@@ -28,21 +28,22 @@ const argv = minimist(process.argv.slice(2));
 export default function(options: OptionSet = {}): (tree: PostHTML.Node) => void {
   return function(tree: PostHTML.Node) {
     tree.match({tag: 'script'}, (script) => {
-      if(!isValidScript(script)){
+      if (isJsonScript(script)) {
+        return script;
+      }
+      if (!isValidScript(script)) {
         return script;
       }
 
-      let url;
-      if(options.compiled || argv.compiled){
-        url = script.attrs.src.toString();
+      if (options.compiled) {
+        const url = script.attrs.src.toString();
         script.attrs.src = url.replace('.js', '.sxg.js');
       }
-      else{
-        url = new URL(script.attrs.src);
+      else {
+        const url = new URL(script.attrs.src);
         url.searchParams.append('f', 'sxg');
         script.attrs.src = url.toString();
       }
-      script.attrs.type = 'sxg';
       return script;
     });
   }

--- a/build-system/server/new-server/transforms/sxg/sxg-transform.ts
+++ b/build-system/server/new-server/transforms/sxg/sxg-transform.ts
@@ -27,7 +27,8 @@ const argv = minimist(process.argv.slice(2));
  * @param script
  * @param compiled 
  */
-function appendSxgScript(head: PostHTML.Node, script: ScriptNode, compiled: boolean): void {
+function appendSxg(script: ScriptNode, compiled: boolean): PostHTML.Node {
+  /*
   if (argv.compiled || compiled) {
     let sxgPath = CDNURLToLocalDistURL(
       new URL(script.attrs.src || ''),
@@ -46,6 +47,11 @@ function appendSxgScript(head: PostHTML.Node, script: ScriptNode, compiled: bool
   }
 
   script.attrs.type = 'sxg';
+  */
+ if(argv.compiled || compiled){
+   script.attrs
+ }
+  return script;
 }
 
 /**
@@ -53,29 +59,9 @@ function appendSxgScript(head: PostHTML.Node, script: ScriptNode, compiled: bool
  * @param options
  */
 export default function(options: OptionSet = {}): (tree: PostHTML.Node) => void {
-  return function(tree: PostHTML.Node): void {
-    let head: PostHTML.Node | undefined = undefined;
-    let compiled: boolean = options.compiled || false;
-    const scripts: Array<ScriptNode> = [];
-    tree.walk(node => {
-      if (node.tag === 'head') {
-        head = node;
-      }
-      if (!isValidScript(node)) {
-        return node;
-      }
-
-      scripts.push(node);
-      return node;
+  return function(tree: PostHTML.Node) {
+    tree.match({tag: 'script'}, (script) => {
+      script = 'l';
     });
-
-    if (head === undefined) {
-      console.log('Could not find a head element in the document');
-      return;
-    }
-
-    for (const script of scripts) {
-      appendSxgScript(head, script, compiled);
-    }
   }
 }

--- a/build-system/server/new-server/transforms/sxg/sxg-transform.ts
+++ b/build-system/server/new-server/transforms/sxg/sxg-transform.ts
@@ -1,0 +1,81 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {PostHTML} from 'posthtml';
+import {URL} from 'url';
+import {isValidScript, ScriptNode} from '../utilities/script';
+import {CDNURLToLocalDistURL} from '../utilities/cdn';
+import {OptionSet} from '../utilities/option-set';
+import minimist from 'minimist';
+const argv = minimist(process.argv.slice(2));
+
+/**
+ * @param head
+ * @param script
+ * @param compiled 
+ */
+function appendSxgScript(head: PostHTML.Node, script: ScriptNode, compiled: boolean): void {
+  if (argv.compiled || compiled) {
+    let sxgPath = CDNURLToLocalDistURL(
+      new URL(script.attrs.src || ''),
+      undefined
+    ).toString();
+    script.attrs.src = sxgPath.replace('.js', '.sxg.js');
+  }
+  else {
+    const urlName = script.attrs.src.toString();
+    if (urlName.includes('js?')){
+        script.attrs.src = urlName + '&f=sxg';
+    }
+    else{
+        script.attrs.src = urlName + '?f=sxg';
+    }
+  }
+
+  script.attrs.type = 'sxg';
+}
+
+/**
+ * Returns a function that will transform script node sources into module/nomodule pair.
+ * @param options
+ */
+export default function(options: OptionSet = {}): (tree: PostHTML.Node) => void {
+  return function(tree: PostHTML.Node): void {
+    let head: PostHTML.Node | undefined = undefined;
+    let compiled: boolean = options.compiled || false;
+    const scripts: Array<ScriptNode> = [];
+    tree.walk(node => {
+      if (node.tag === 'head') {
+        head = node;
+      }
+      if (!isValidScript(node)) {
+        return node;
+      }
+
+      scripts.push(node);
+      return node;
+    });
+
+    if (head === undefined) {
+      console.log('Could not find a head element in the document');
+      return;
+    }
+
+    for (const script of scripts) {
+      appendSxgScript(head, script, compiled);
+    }
+  }
+}

--- a/build-system/server/new-server/transforms/sxg/sxg-transform.ts
+++ b/build-system/server/new-server/transforms/sxg/sxg-transform.ts
@@ -26,22 +26,26 @@ import {OptionSet} from '../utilities/option-set';
 export default function(options: OptionSet = {}): (tree: PostHTML.Node) => void {
   return function(tree: PostHTML.Node) {
     tree.match({tag: 'script'}, (script) => {
+      // Make sure that isJsonScript is used before `isValidScript`. We bail out
+      // early if the ScriptNofe is of type="application/json" since it wouldn't
+      // have any src url to modify.
       if (isJsonScript(script)) {
         return script;
       }
+
       if (!isValidScript(script)) {
         return script;
       }
 
       if (options.compiled) {
-        const url = script.attrs.src.toString();
-        script.attrs.src = url.replace('.js', '.sxg.js');
-      }
-      else {
+        const src = script.attrs.src;
+        script.attrs.src = src.replace('.js', '.sxg.js');
+      } else {
         const url = new URL(script.attrs.src);
         url.searchParams.append('f', 'sxg');
         script.attrs.src = url.toString();
       }
+
       return script;
     });
   }

--- a/build-system/server/new-server/transforms/sxg/sxg-transform.ts
+++ b/build-system/server/new-server/transforms/sxg/sxg-transform.ts
@@ -18,8 +18,6 @@ import {PostHTML} from 'posthtml';
 import {URL} from 'url';
 import {isJsonScript, isValidScript} from '../utilities/script';
 import {OptionSet} from '../utilities/option-set';
-import minimist from 'minimist';
-const argv = minimist(process.argv.slice(2));
 
 /**
  * Returns a function that will transform script node sources into their sxg counterparts.

--- a/build-system/server/new-server/transforms/sxg/test/sxg-env-compiled/input.html
+++ b/build-system/server/new-server/transforms/sxg/test/sxg-env-compiled/input.html
@@ -1,0 +1,3 @@
+<head>
+<script async src="https://cdn.ampproject.org/v0.js"></script>
+</head>

--- a/build-system/server/new-server/transforms/sxg/test/sxg-env-compiled/options.json
+++ b/build-system/server/new-server/transforms/sxg/test/sxg-env-compiled/options.json
@@ -1,0 +1,3 @@
+{
+  "compiled": true
+}

--- a/build-system/server/new-server/transforms/sxg/test/sxg-env-compiled/output.html
+++ b/build-system/server/new-server/transforms/sxg/test/sxg-env-compiled/output.html
@@ -1,0 +1,3 @@
+<head>
+<script async="" src="http://localhost:8000/dist/v0.sxg.js" type="sxg"></script>
+</head>

--- a/build-system/server/new-server/transforms/sxg/test/sxg-env-compiled/output.html
+++ b/build-system/server/new-server/transforms/sxg/test/sxg-env-compiled/output.html
@@ -1,3 +1,3 @@
 <head>
-<script async="" src="http://localhost:8000/dist/v0.sxg.js" type="sxg"></script>
+<script async="" src="https://cdn.ampproject.org/v0.sxg.js" type="sxg"></script>
 </head>

--- a/build-system/server/new-server/transforms/sxg/test/sxg-env-compiled/output.html
+++ b/build-system/server/new-server/transforms/sxg/test/sxg-env-compiled/output.html
@@ -1,3 +1,3 @@
 <head>
-<script async="" src="https://cdn.ampproject.org/v0.sxg.js" type="sxg"></script>
+<script async="" src="https://cdn.ampproject.org/v0.sxg.js"></script>
 </head>

--- a/build-system/server/new-server/transforms/sxg/test/sxg-env/input.html
+++ b/build-system/server/new-server/transforms/sxg/test/sxg-env/input.html
@@ -1,0 +1,3 @@
+<head>
+<script async src="https://cdn.ampproject.org/v0.js"></script>
+</head>

--- a/build-system/server/new-server/transforms/sxg/test/sxg-env/options.json
+++ b/build-system/server/new-server/transforms/sxg/test/sxg-env/options.json
@@ -1,0 +1,3 @@
+{
+  "compiled": false
+}

--- a/build-system/server/new-server/transforms/sxg/test/sxg-env/output.html
+++ b/build-system/server/new-server/transforms/sxg/test/sxg-env/output.html
@@ -1,3 +1,3 @@
 <head>
-<script async="" src="https://cdn.ampproject.org/v0.js?f=sxg" type="sxg"></script>
+<script async="" src="https://cdn.ampproject.org/v0.js?f=sxg"></script>
 </head>

--- a/build-system/server/new-server/transforms/sxg/test/sxg-env/output.html
+++ b/build-system/server/new-server/transforms/sxg/test/sxg-env/output.html
@@ -1,0 +1,3 @@
+<head>
+<script async="" src="https://cdn.ampproject.org/v0.js?f=sxg" type="sxg"></script>
+</head>

--- a/build-system/server/new-server/transforms/sxg/test/sxg-query-param/input.html
+++ b/build-system/server/new-server/transforms/sxg/test/sxg-query-param/input.html
@@ -1,0 +1,3 @@
+<head>
+<script async src="https://cdn.ampproject.org/v0.js?optin=beta"></script>
+</head>

--- a/build-system/server/new-server/transforms/sxg/test/sxg-query-param/options.json
+++ b/build-system/server/new-server/transforms/sxg/test/sxg-query-param/options.json
@@ -1,0 +1,3 @@
+{
+  "compiled": false
+}

--- a/build-system/server/new-server/transforms/sxg/test/sxg-query-param/output.html
+++ b/build-system/server/new-server/transforms/sxg/test/sxg-query-param/output.html
@@ -1,3 +1,3 @@
 <head>
-<script async="" src="https://cdn.ampproject.org/v0.js?optin=beta&f=sxg" type="sxg"></script>
+<script async="" src="https://cdn.ampproject.org/v0.js?optin=beta&f=sxg"></script>
 </head>

--- a/build-system/server/new-server/transforms/sxg/test/sxg-query-param/output.html
+++ b/build-system/server/new-server/transforms/sxg/test/sxg-query-param/output.html
@@ -1,0 +1,3 @@
+<head>
+<script async="" src="https://cdn.ampproject.org/v0.js?optin=beta&f=sxg" type="sxg"></script>
+</head>

--- a/build-system/server/new-server/transforms/transform.ts
+++ b/build-system/server/new-server/transforms/transform.ts
@@ -22,7 +22,6 @@ import transformScriptPaths from './scripts/scripts-transform';
 import transformStories from './stories/stories-transform';
 import transformCss from './css/css-transform';
 
-
 const argv = minimist(process.argv.slice(2));
 const transforms = [transformStories(), transformScriptPaths(), transformCss()];
 

--- a/build-system/server/new-server/transforms/transform.ts
+++ b/build-system/server/new-server/transforms/transform.ts
@@ -21,17 +21,13 @@ import transformModules from './modules/modules-transform';
 import transformScriptPaths from './scripts/scripts-transform';
 import transformStories from './stories/stories-transform';
 import transformCss from './css/css-transform';
-//import transformSxg from './sxg/sxg-transform';
+
 
 const argv = minimist(process.argv.slice(2));
 const transforms = [transformStories(), transformScriptPaths(), transformCss()];
-//const COMPILED = !!argv.compiled;
 
 export async function transform(fileLocation: string): Promise<string> {
-  if (argv.sxg){
-    //transforms.unshift(transformSxg({compiled: COMPILED,}));
-  }
-  else if (argv.esm) {
+  if (argv.esm) {
     transforms.unshift(transformModules());
   }
 

--- a/build-system/server/new-server/transforms/transform.ts
+++ b/build-system/server/new-server/transforms/transform.ts
@@ -21,12 +21,16 @@ import transformModules from './modules/modules-transform';
 import transformScriptPaths from './scripts/scripts-transform';
 import transformStories from './stories/stories-transform';
 import transformCss from './css/css-transform';
+//import transformSxg from './sxg/sxg-transform';
 
 const argv = minimist(process.argv.slice(2));
 const transforms = [transformStories(), transformScriptPaths(), transformCss()];
 
 export async function transform(fileLocation: string): Promise<string> {
-  if (argv.esm) {
+  if (argv.sxg){
+    //transforms.unshift(transformSxg());
+  }
+  else if (argv.esm) {
     transforms.unshift(transformModules());
   }
 

--- a/build-system/server/new-server/transforms/transform.ts
+++ b/build-system/server/new-server/transforms/transform.ts
@@ -25,10 +25,11 @@ import transformCss from './css/css-transform';
 
 const argv = minimist(process.argv.slice(2));
 const transforms = [transformStories(), transformScriptPaths(), transformCss()];
+//const COMPILED = !!argv.compiled;
 
 export async function transform(fileLocation: string): Promise<string> {
   if (argv.sxg){
-    //transforms.unshift(transformSxg());
+    //transforms.unshift(transformSxg({compiled: COMPILED,}));
   }
   else if (argv.esm) {
     transforms.unshift(transformModules());

--- a/build-system/server/new-server/transforms/utilities/script.ts
+++ b/build-system/server/new-server/transforms/utilities/script.ts
@@ -40,3 +40,12 @@ export function isValidScript(node: PostHTML.Node): node is ScriptNode {
   const src = new URL(attrs.src || '');
   return src.origin === VALID_CDN_ORIGIN && extname(src.pathname) === '.js';
 }
+
+export function isJsonScript(node: PostHTML.Node): boolean {
+  if (node.tag !== 'script') {
+    return false;
+  }
+  const attrs = node.attrs || {};
+  const type = attrs.type || '';
+  return type.toLowerCase() === 'application/json';
+}


### PR DESCRIPTION
pulling this in instead of https://github.com/ampproject/amphtml/pull/30401 since Derek has finished his internship and i will take over his PRs.

this modifies the script src to either use ".sxg.js" as the suffix to the path when in `--compiled` mode, otherwise it just appends the `f=sxg` query param