### PR TITLE
🐛  [amp-story-player] Adds intermediate element and removes default size

### DIFF
--- a/css/amp-story-player-iframe.css
+++ b/css/amp-story-player-iframe.css
@@ -24,7 +24,7 @@
   position: absolute;
 }
 
-.i-amphtml-story-player-shadow-dom-intermediary {
+.i-amphtml-story-player-shadow-root-intermediary {
   width: 100%;
   height: 100%;
 }

--- a/css/amp-story-player-iframe.css
+++ b/css/amp-story-player-iframe.css
@@ -24,6 +24,11 @@
   position: absolute;
 }
 
+.i-amphtml-story-player-shadow-dom-intermediary {
+  width: 100%;
+  height: 100%;
+}
+
 .i-amphtml-story-player-main-container {
   height: 100%;
   position: relative;

--- a/css/amp-story-player.css
+++ b/css/amp-story-player.css
@@ -15,8 +15,6 @@
  */
 
 amp-story-player {
-  width: 360px;
-  height: 600px;
   position: relative;
   display: block;
 }

--- a/src/amp-story-player/amp-story-player-impl.js
+++ b/src/amp-story-player/amp-story-player-impl.js
@@ -394,7 +394,7 @@ export class AmpStoryPlayer {
     // For AMP version.
     shadowContainer.classList.add(
       'i-amphtml-fill-content',
-      'i-amphtml-story-player-shadow-dom-intermediary'
+      'i-amphtml-story-player-shadow-root-intermediary'
     );
 
     this.element_.appendChild(shadowContainer);

--- a/src/amp-story-player/amp-story-player-impl.js
+++ b/src/amp-story-player/amp-story-player-impl.js
@@ -392,7 +392,10 @@ export class AmpStoryPlayer {
     const shadowContainer = this.doc_.createElement('div');
 
     // For AMP version.
-    shadowContainer.classList.add('i-amphtml-fill-content');
+    shadowContainer.classList.add(
+      'i-amphtml-fill-content',
+      'i-amphtml-story-player-shadow-dom-intermediary'
+    );
 
     this.element_.appendChild(shadowContainer);
 

--- a/src/amp-story-player/amp-story-player-impl.js
+++ b/src/amp-story-player/amp-story-player-impl.js
@@ -389,10 +389,17 @@ export class AmpStoryPlayer {
     this.rootEl_ = this.doc_.createElement('div');
     this.rootEl_.classList.add('i-amphtml-story-player-main-container');
 
+    const shadowContainer = this.doc_.createElement('div');
+
+    // For AMP version.
+    shadowContainer.classList.add('i-amphtml-fill-content');
+
+    this.element_.appendChild(shadowContainer);
+
     const containerToUse =
       getMode().test || !this.element_.attachShadow
-        ? this.element_
-        : this.element_.attachShadow({mode: 'open'});
+        ? shadowContainer
+        : shadowContainer.attachShadow({mode: 'open'});
 
     // Inject default styles
     const styleEl = this.doc_.createElement('style');


### PR DESCRIPTION
Closes #30423

I tested different layouts in AMP (responsive, fixed...) and they seemed to work fine.

Also tested without shadow DOM in case it's not supported.

Note that since there's no way of calling `this.applyFillContent(element)` from the `amp-story-player-impl.js` class directly (since it does not inherit from base element), I had to apply the CSS class `i-amphtml-fill-content` manually.

<!--
# Instructions:

- Pick a meaningful title for your pull request. (Use sentence case.)
  - Prefix the title with an emoji to identify what is being done. (Copy-paste the emoji from the list below.)
  - Do not overuse punctuation in the title (like `(chore):`).
  - If it is helpful, use a simple prefix (like `ProjectX: Implement some feature`).
- Enter a succinct description that says why the PR is necessary, and what it does.
  - Mention the GitHub issue that is being addressed by the pull request.
  - The keywords `Fixes`, `Closes`, or `Resolves` followed the issue number will automatically close the issue.

> NOTE: All non-trivial changes (like introducing new features or components) should have an associated issue or reference an I2I (intent-to-implement: go.amp.dev/i2i). Please read through the contribution process (go.amp.dev/contributing/code) for more information.

# Example of a good description:

- Implement aspect X
- Leave out feature Y because of A
- Improve performance by B
- Improve accessibility by C

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Reverting a previous change
♻️ Refactoring
🚮 Deleting code
🧪 Experimental code
-->
