### PR TITLE
📖 Quick fix to amp-youtube markdown code error

### DIFF
--- a/extensions/amp-youtube/amp-youtube.md
+++ b/extensions/amp-youtube/amp-youtube.md
@@ -111,10 +111,8 @@ Requires [`amp-video-docking`](../amp-video-docking/amp-video-docking.md) compon
 
 Defines a `credentials` option as specified by the [Fetch API](https://fetch.spec.whatwg.org/).
 
-<ul>
-  <li>Supported values: `omit`, `include`</li>
-  <li>Default: `include`</li>
-</ul>
+- Supported values: `omit`, `include`
+- Default: `include`
 
 If you want to use the [YouTube player in privacy-enhanced mode](http://www.google.com/support/youtube/bin/answer.py?answer=141046), pass the value of `omit`.
 


### PR DESCRIPTION
Fixing this: 
![Screenshot 2020-09-29 at 12 52 50 PM](https://user-images.githubusercontent.com/24800437/94609862-3f73e380-0254-11eb-8d62-3dcdf7286f0f.png)

Markdown isn't able to show code within `<ul>` so this is a workaround.
