### PR TITLE
Create build rules for extensions protoascii 

### DIFF
--- a/extensions/BUILD
+++ b/extensions/BUILD
@@ -1,0 +1,13 @@
+package(default_visibility = ["//visibility:public"])
+
+
+genrule(
+    name = "validator-extensions-protoascii-gen",
+    srcs = glob(
+        [
+            "*/validator-*.protoascii",
+        ],
+    ),
+    outs = ["validator-extensions.protoascii"],
+    cmd = "cat $(SRCS) > $@",
+)

--- a/extensions/WORKSPACE
+++ b/extensions/WORKSPACE
@@ -1,0 +1,1 @@
+workspace(name = "amphtml-extensions")

--- a/validator/BUILD
+++ b/validator/BUILD
@@ -15,6 +15,13 @@ cc_proto_library(
     deps = [":validator-proto"],
 )
 
+filegroup(
+    name = "extensions-protoascii-files",
+    srcs = [
+        "@amphtml-extensions//:extensions/*/validator-*.protoascii",
+    ],
+)
+
 # <validator rules protoascii>
 # The validator rules, stored in a series of .protoascii files.
 # This set of rules is what is released to cdn.ampproject.org/v0/validator.js
@@ -23,11 +30,8 @@ genrule(
     srcs = [
         "validator-main.protoascii",
         "validator-css.protoascii",
-    ] + glob(
-        [
-            "extensions/*/validator-*.protoascii",
-        ],
-    ),
+        "@amphtml-extensions//:validator-extensions.protoascii",
+    ],
     outs = ["validator.protoascii"],
     cmd = "cat $(SRCS) > $@",
 )


### PR DESCRIPTION
protoascii in extensions are needed by validator project workspace.
