### PR TITLE
🏗 Add `gulp serve --coverage=live` to auto-report coverage while browsing

### DIFF
--- a/build-system/tasks/serve.js
+++ b/build-system/tasks/serve.js
@@ -22,6 +22,7 @@ const header = require('connect-header');
 const log = require('fancy-log');
 const minimist = require('minimist');
 const morgan = require('morgan');
+const open = require('opn');
 const path = require('path');
 const {
   buildNewServer,
@@ -115,6 +116,11 @@ async function startServer(
   await startedPromise;
   url = `http${options.https ? 's' : ''}://${options.host}:${options.port}`;
   log(green('Started'), cyan(options.name), green('at'), cyan(url));
+  if (argv.coverage == 'live') {
+    const covUrl = `${url}/coverage`;
+    log(green('Collecting live code coverage at'), cyan(covUrl));
+    await Promise.all([open(covUrl), open(url)]);
+  }
   logServeMode();
 }
 
@@ -213,5 +219,7 @@ serve.flags = {
   esm: '  Serve ESM JS (requires the use of --new_server)',
   cdn: '  Serve current prod JS',
   rtv: '  Serve JS from the RTV provided',
-  coverage: '  Serve instrumented code to collect coverage info',
+  coverage:
+    '  Serve instrumented code to collect coverage info; use ' +
+    '--compiled=live to auto-report coverage on page unload',
 };

--- a/build-system/tasks/serve.js
+++ b/build-system/tasks/serve.js
@@ -221,5 +221,5 @@ serve.flags = {
   rtv: '  Serve JS from the RTV provided',
   coverage:
     '  Serve instrumented code to collect coverage info; use ' +
-    '--compiled=live to auto-report coverage on page unload',
+    '--coverage=live to auto-report coverage on page unload',
 };


### PR DESCRIPTION
By appending an `onunload` event handler when this flag is set, this will report the code coverage each time the browser exits a page, hits back, closes the tab, etc. With this in place, it should be possible to manually test pages under `examples/` and see exactly what lines of code have been manually tested.

Node this only works with code compiled using `gulp (build|dist) --coverage`, which takes longer than a non-instrumented build.

---

### To test this workflow

```bash
# 1. Check out this branch
git checkout -b rcebulko-unload master
git pull https://github.com/rcebulko/amphtml.git rcebulko/unload

# 2. Build the instrumented runtime and extensions
# Note: Instrumented code takes much longer to build. It is recommended to just
# use `gulp build`, not `gulp dist`.
gulp build --fortesting --coverage

# 3. Launch the coverage-enabled server
gulp serve --coverage=live
```

4. Visit one or more `examples/` pages served by the AMP Dev Server (a tab should open automatically), play with components, etc.
5. Close each tab, or use the **Back** button to navigate away
6. Refresh the coverage page (also opened automatically in a separate tab)

