### PR TITLE
Remove consent string restriction on metadata

### DIFF
--- a/extensions/amp-consent/0.1/amp-consent.js
+++ b/extensions/amp-consent/0.1/amp-consent.js
@@ -290,16 +290,13 @@ export class AmpConsent extends AMP.BaseElement {
               TAG,
               'Consent string value %s not applicable on user dismiss, ' +
                 'stored value will be kept and used',
-              consentString
+              data['info']
             );
           }
           data['info'] = undefined;
         }
         consentString = data['info'];
-        metadata = this.configureMetadataByConsentString_(
-          data['consentMetadata'],
-          consentString
-        );
+        metadata = this.validateMetadata_(data['consentMetadata']);
       }
 
       const iframes = this.element.querySelectorAll('iframe');
@@ -559,10 +556,7 @@ export class AmpConsent extends AMP.BaseElement {
       this.consentStateManager_.updateConsentInstanceState(
         consentStateValue,
         responseConsentString,
-        this.configureMetadataByConsentString_(
-          opt_responseMetadata,
-          responseConsentString
-        )
+        this.validateMetadata_(opt_responseMetadata)
       );
     }
   }
@@ -713,22 +707,16 @@ export class AmpConsent extends AMP.BaseElement {
   }
 
   /**
-   * If consentString is undefined or invalid, don't
-   * include any metadata in update. Otherwise, convert to
-   * to ConsentMetadataDef
+   * Convert valid opt_metadta into ConsentMetadataDef
    * @param {JsonObject=} opt_metadata
-   * @param {string=} opt_consentString
    * @return {ConsentMetadataDef|undefined}
    */
-  configureMetadataByConsentString_(opt_metadata, opt_consentString) {
+  validateMetadata_(opt_metadata) {
     if (!opt_metadata) {
       return;
     }
-    if (!isObject(opt_metadata) || !opt_consentString) {
-      user().error(
-        TAG,
-        'CMP metadata is invalid or no consent string is found.'
-      );
+    if (!isObject(opt_metadata)) {
+      user().error(TAG, 'CMP metadata is not an object.');
       return;
     }
     assertMetadataValues(opt_metadata);

--- a/extensions/amp-consent/0.1/test/test-amp-consent.js
+++ b/extensions/amp-consent/0.1/test/test-amp-consent.js
@@ -773,35 +773,30 @@ describes.realWin(
 
       it('should error and return undefined on invalid metadata', () => {
         const spy = env.sandbox.stub(user(), 'error');
-        const metadata = ampConsent.configureMetadataByConsentString_(
+        const metadata = ampConsent.validateMetadata_(
           'bad metadata',
           'consentString'
         );
-        expect(spy.args[0][1]).to.match(
-          /CMP metadata is invalid or no consent string is found./
-        );
+        expect(spy.args[0][1]).to.match(/CMP metadata is not an object./);
         expect(metadata).to.be.undefined;
       });
 
-      it('should return undefined with no consent string', () => {
+      it('should work with no consent string', () => {
         const spy = env.sandbox.stub(user(), 'error');
-        const metadata = ampConsent.configureMetadataByConsentString_({
+        const metadata = ampConsent.validateMetadata_({
           'gdprApplies': true,
         });
-        expect(spy.args[0][1]).to.match(
-          /CMP metadata is invalid or no consent string is found./
+        expect(spy).to.not.be.called;
+        expect(metadata).to.deep.equals(
+          constructMetadata(undefined, undefined, true)
         );
-        expect(metadata).to.be.undefined;
       });
 
       it('should remove invalid consentStringType', () => {
         const spy = env.sandbox.stub(user(), 'error');
         const responseMetadata = {'consentStringType': 4};
         expect(
-          ampConsent.configureMetadataByConsentString_(
-            responseMetadata,
-            'consentString'
-          )
+          ampConsent.validateMetadata_(responseMetadata, 'consentString')
         ).to.deep.equals(constructMetadata());
         expect(spy.args[0][1]).to.match(
           /Consent metadata value "%s" is invalid./
@@ -809,10 +804,7 @@ describes.realWin(
         expect(spy.args[0][2]).to.match(/consentStringType/);
         responseMetadata['consentStringType'] = CONSENT_STRING_TYPE.TCF_V2;
         expect(
-          ampConsent.configureMetadataByConsentString_(
-            responseMetadata,
-            'consentString'
-          )
+          ampConsent.validateMetadata_(responseMetadata, 'consentString')
         ).to.deep.equals(constructMetadata(2));
       });
 
@@ -820,10 +812,7 @@ describes.realWin(
         const spy = env.sandbox.stub(user(), 'error');
         const responseMetadata = {'additionalConsent': 4};
         expect(
-          ampConsent.configureMetadataByConsentString_(
-            responseMetadata,
-            'consentString'
-          )
+          ampConsent.validateMetadata_(responseMetadata, 'consentString')
         ).to.deep.equals(constructMetadata());
         expect(spy.args[0][1]).to.match(
           /Consent metadata value "%s" is invalid./
@@ -835,10 +824,7 @@ describes.realWin(
         const spy = env.sandbox.stub(user(), 'error');
         const responseMetadata = {'gdprApplies': 4};
         expect(
-          ampConsent.configureMetadataByConsentString_(
-            responseMetadata,
-            'consentString'
-          )
+          ampConsent.validateMetadata_(responseMetadata, 'consentString')
         ).to.deep.equals(constructMetadata());
         expect(spy.args[0][1]).to.match(
           /Consent metadata value "%s" is invalid./


### PR DESCRIPTION
From this discussion: https://github.com/ampproject/amphtml/issues/28634#issuecomment-690605633

Remove the restriction on `consentMetadata` to only be updated in conjunction with `consentString`.

For the purposes of updating from `checkConsentHref`, `consentStateValue` will have to be defined, and `consentRequired` will have to be true as well.