### PR TITLE
🏗 Pin yarn to 1.22.5 temporarily

### DIFF
--- a/build-system/common/check-package-manager.js
+++ b/build-system/common/check-package-manager.js
@@ -183,6 +183,8 @@ function getNodeLatestLtsVersion(distributionsJson) {
 // If yarn is being run, perform a version check and proceed with the install.
 function checkYarnVersion() {
   const yarnVersion = getStdout(yarnExecutable + ' --version').trim();
+  // TODO (KB): Revert #30478 once `yarn` stable is fixed
+  // At this time current stable is failing GPG checks.
   const stableVersion = '1.22.4';
   if (stableVersion === '') {
     console.log(
@@ -199,7 +201,9 @@ function checkYarnVersion() {
     );
     console.log(
       yellow('⤷ To fix this, run'),
-      cyan('"curl -o- -L https://yarnpkg.com/install.sh | bash"'),
+      cyan(
+        `"curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version ${stableVersion}"`
+      ),
       yellow('or see'),
       cyan('https://yarnpkg.com/docs/install'),
       yellow('for instructions.')

--- a/build-system/common/check-package-manager.js
+++ b/build-system/common/check-package-manager.js
@@ -183,9 +183,7 @@ function getNodeLatestLtsVersion(distributionsJson) {
 // If yarn is being run, perform a version check and proceed with the install.
 function checkYarnVersion() {
   const yarnVersion = getStdout(yarnExecutable + ' --version').trim();
-  const yarnInfo = getStdout(yarnExecutable + ' info --json yarn').trim();
-  const yarnInfoJson = JSON.parse(yarnInfo.split('\n')[0]); // First line
-  const stableVersion = getYarnStableVersion(yarnInfoJson);
+  const stableVersion = '1.22.4';
   if (stableVersion === '') {
     console.log(
       yellow(
@@ -214,18 +212,6 @@ function checkYarnVersion() {
       green('version'),
       cyan(yarnVersion + ' (stable)') + green('. Installing packages...')
     );
-  }
-}
-
-function getYarnStableVersion(infoJson) {
-  if (
-    infoJson &&
-    infoJson.hasOwnProperty('data') &&
-    infoJson.data.hasOwnProperty('version')
-  ) {
-    return infoJson.data.version;
-  } else {
-    return '';
   }
 }
 

--- a/build-system/common/check-package-manager.js
+++ b/build-system/common/check-package-manager.js
@@ -185,7 +185,7 @@ function checkYarnVersion() {
   const yarnVersion = getStdout(yarnExecutable + ' --version').trim();
   // TODO (KB): Revert #30478 once `yarn` stable is fixed
   // At this time current stable is failing GPG checks.
-  const stableVersion = '1.22.4';
+  const stableVersion = '1.22.5';
   if (stableVersion === '') {
     console.log(
       yellow(


### PR DESCRIPTION
There is an issue with the current release of `yarn`, this PR temporarily pins us to 1.22.4 until we can resolve.