### PR TITLE
amp-accordion: Enable display locking based on `beforematch`

### DIFF
--- a/extensions/amp-accordion/0.1/amp-accordion.js
+++ b/extensions/amp-accordion/0.1/amp-accordion.js
@@ -46,9 +46,7 @@ const COLLAPSE_CURVE_ = bezierCurve(0.39, 0.575, 0.565, 1);
 const isDisplayLockingEnabledForAccordion = (win) => {
   return (
     isExperimentOn(win, 'amp-accordion-display-locking') &&
-    (('CSS' in window &&
-      window.CSS.supports &&
-      window.CSS.supports('content-visibility', 'hidden-matchable')) ||
+    (document.body.onbeforematch !== undefined ||
       getMode().test)
   );
 };

--- a/extensions/amp-accordion/0.1/amp-accordion.js
+++ b/extensions/amp-accordion/0.1/amp-accordion.js
@@ -46,8 +46,7 @@ const COLLAPSE_CURVE_ = bezierCurve(0.39, 0.575, 0.565, 1);
 const isDisplayLockingEnabledForAccordion = (win) => {
   return (
     isExperimentOn(win, 'amp-accordion-display-locking') &&
-    (document.body.onbeforematch !== undefined ||
-      getMode().test)
+    (document.body.onbeforematch !== undefined || getMode().test)
   );
 };
 


### PR DESCRIPTION
This is a workaround for https://bugs.chromium.org/p/chromium/issues/detail?id=1134237