### PR TITLE
Remove dependency on the global window for impression tracking

### DIFF
--- a/extensions/amp-analytics/0.1/test/test-cookie-writer.js
+++ b/extensions/amp-analytics/0.1/test/test-cookie-writer.js
@@ -20,6 +20,10 @@ import {CookieWriter} from '../cookie-writer';
 import {dict} from '../../../../src/utils/object';
 import {installLinkerReaderService} from '../linker-reader';
 import {installVariableServiceForTesting} from '../variables';
+import {
+  maybeTrackImpression,
+  resetTrackImpressionPromiseForTesting,
+} from '../../../../src/impression';
 import {stubService} from '../../../../testing/test-helper';
 
 const TAG = '[amp-analytics/cookie-writer]';
@@ -218,12 +222,14 @@ describes.fakeWin('amp-analytics.cookie-writer value', {amp: true}, (env) => {
       target: window,
       now: new Date('2018-01-01T08:00:00Z'),
     });
+    maybeTrackImpression(env.win);
     installVariableServiceForTesting(doc);
     installLinkerReaderService(win);
   });
 
   afterEach(() => {
     clock.uninstall();
+    resetTrackImpressionPromiseForTesting();
   });
 
   it('should read value from QUERY_PARAM and LINKER_PARAM', () => {

--- a/extensions/amp-analytics/0.1/test/test-variables.js
+++ b/extensions/amp-analytics/0.1/test/test-variables.js
@@ -28,6 +28,10 @@ import {
   installLinkerReaderService,
   linkerReaderServiceFor,
 } from '../linker-reader';
+import {
+  maybeTrackImpression,
+  resetTrackImpressionPromiseForTesting,
+} from '../../../../src/impression';
 
 const fakeElement = document.documentElement;
 
@@ -35,8 +39,13 @@ describes.fakeWin('amp-analytics.VariableService', {amp: true}, (env) => {
   let variables;
 
   beforeEach(() => {
+    maybeTrackImpression(env.win);
     installLinkerReaderService(env.win);
     variables = new VariableService(env.ampdoc);
+  });
+
+  afterEach(() => {
+    resetTrackImpressionPromiseForTesting();
   });
 
   describe('encodeVars', () => {

--- a/extensions/amp-analytics/0.1/test/test-vendors.js
+++ b/extensions/amp-analytics/0.1/test/test-vendors.js
@@ -25,6 +25,10 @@ import {
 import {Services} from '../../../../src/services';
 import {hasOwn} from '../../../../src/utils/object';
 import {macroTask} from '../../../../testing/yield';
+import {
+  maybeTrackImpression,
+  resetTrackImpressionPromiseForTesting,
+} from '../../../../src/impression';
 
 /* global require: false */
 const VENDOR_REQUESTS = require('./vendor-requests.json');
@@ -52,6 +56,11 @@ describes.realWin(
         'COOKIE': null,
         'CONSENT_STATE': null,
       };
+      maybeTrackImpression(env.win);
+    });
+
+    afterEach(() => {
+      resetTrackImpressionPromiseForTesting();
     });
 
     describe('Should not contain iframe transport if not allowlisted', () => {

--- a/testing/describes.js
+++ b/testing/describes.js
@@ -107,7 +107,6 @@ import {installDocService} from '../src/service/ampdoc-impl';
 import {installExtensionsService} from '../src/service/extensions-impl';
 import {installFriendlyIframeEmbed} from '../src/friendly-iframe-embed';
 import {install as installIntersectionObserver} from '../src/polyfills/intersection-observer';
-import {maybeTrackImpression} from '../src/impression';
 import {resetScheduledElementForTesting} from '../src/service/custom-element-registry';
 import {setStyles} from '../src/style';
 import fetchMock from 'fetch-mock/es5/client-bundle';
@@ -739,7 +738,6 @@ class AmpFixture {
       // Notice that ampdoc's themselves install runtime styles in shadow roots.
       // Thus, not changes needed here.
     }
-    maybeTrackImpression(self);
     const extensionIds = [];
     if (spec.extensions) {
       spec.extensions.forEach((extensionIdWithVersion) => {


### PR DESCRIPTION
This is a small change that only affects tests to avoid leaking global state.