### PR TITLE
♻️ Remove firstAttachedCallback and createdCallback

### DIFF
--- a/builtins/amp-img.js
+++ b/builtins/amp-img.js
@@ -52,9 +52,6 @@ export class AmpImg extends BaseElement {
     /** @private {boolean} */
     this.allowImgLoadFallback_ = true;
 
-    /** @private {boolean} */
-    this.prerenderAllowed_ = true;
-
     /** @private {?Element} */
     this.img_ = null;
 
@@ -135,13 +132,6 @@ export class AmpImg extends BaseElement {
           onLayout
         );
       }
-    }
-  }
-
-  /** @override */
-  firstAttachedCallback() {
-    if (this.element.hasAttribute('noprerender')) {
-      this.prerenderAllowed_ = false;
     }
   }
 
@@ -262,7 +252,7 @@ export class AmpImg extends BaseElement {
 
   /** @override */
   prerenderAllowed() {
-    return this.prerenderAllowed_;
+    return ! this.element.hasAttribute('noprerender');
   }
 
   /** @override */

--- a/builtins/amp-img.js
+++ b/builtins/amp-img.js
@@ -52,6 +52,9 @@ export class AmpImg extends BaseElement {
     /** @private {boolean} */
     this.allowImgLoadFallback_ = true;
 
+    /** @private {?boolean} */
+    this.prerenderAllowed_ = null;
+
     /** @private {?Element} */
     this.img_ = null;
 
@@ -252,7 +255,10 @@ export class AmpImg extends BaseElement {
 
   /** @override */
   prerenderAllowed() {
-    return !this.element.hasAttribute('noprerender');
+    if (this.prerenderAllowed_ == null) {
+      this.prerenderAllowed_ = !this.element.hasAttribute('noprerender');
+    }
+    return this.prerenderAllowed_;
   }
 
   /** @override */

--- a/builtins/amp-img.js
+++ b/builtins/amp-img.js
@@ -252,7 +252,7 @@ export class AmpImg extends BaseElement {
 
   /** @override */
   prerenderAllowed() {
-    return ! this.element.hasAttribute('noprerender');
+    return !this.element.hasAttribute('noprerender');
   }
 
   /** @override */

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -780,8 +780,6 @@ describe('amp-a4a', () => {
       a4aElement = createA4aElement(doc);
       a4a = new MockA4AImpl(a4aElement);
       a4a.releaseType_ = '0';
-      a4a.createdCallback();
-      a4a.firstAttachedCallback();
       a4a.buildCallback();
       expect(onCreativeRenderSpy).to.not.be.called;
     });

--- a/extensions/amp-analytics/0.1/test/test-amp-analytics.js
+++ b/extensions/amp-analytics/0.1/test/test-amp-analytics.js
@@ -152,7 +152,6 @@ describes.realWin(
 
       el.connectedCallback();
       const analytics = new AmpAnalytics(el);
-      analytics.createdCallback();
       analytics.buildCallback();
       return analytics;
     }
@@ -201,7 +200,6 @@ describes.realWin(
         const analytics = new AmpAnalytics(el);
         doc.body.appendChild(el);
         el.connectedCallback();
-        analytics.createdCallback();
         analytics.buildCallback();
         // Initialization has not started.
         expect(analytics.iniPromise_).to.be.null;
@@ -250,7 +248,6 @@ describes.realWin(
         doc.body.appendChild(el);
         const analytics = new AmpAnalytics(el);
         el.connectedCallback();
-        analytics.createdCallback();
         analytics.buildCallback();
 
         return waitForNoSendRequest(analytics);
@@ -266,7 +263,6 @@ describes.realWin(
         doc.body.appendChild(el);
         const analytics = new AmpAnalytics(el);
         el.connectedCallback();
-        analytics.createdCallback();
         analytics.buildCallback();
 
         return waitForNoSendRequest(analytics);

--- a/extensions/amp-analytics/0.1/test/test-vendors.js
+++ b/extensions/amp-analytics/0.1/test/test-vendors.js
@@ -218,7 +218,6 @@ function getAnalyticsTag(doc, vendor) {
   doc.body.appendChild(el);
   el.connectedCallback();
   const analytics = new AmpAnalytics(el);
-  analytics.createdCallback();
   analytics.buildCallback();
   return analytics;
 }

--- a/extensions/amp-iframe/0.1/amp-iframe.js
+++ b/extensions/amp-iframe/0.1/amp-iframe.js
@@ -261,24 +261,6 @@ export class AmpIframe extends AMP.BaseElement {
     );
   }
 
-  /** @override */
-  firstAttachedCallback() {
-    this.sandbox_ = this.element.getAttribute('sandbox');
-
-    const iframeSrc = /** @type {string} */ (this.transformSrc_(
-      this.element.getAttribute('src')
-    ) ||
-      this.transformSrcDoc_(
-        this.element.getAttribute('srcdoc'),
-        this.sandbox_
-      ));
-    this.iframeSrc = this.assertSource_(
-      iframeSrc,
-      window.location.href,
-      this.sandbox_
-    );
-  }
-
   /**
    * @param {boolean=} onLayout
    * @override
@@ -295,6 +277,21 @@ export class AmpIframe extends AMP.BaseElement {
 
   /** @override */
   buildCallback() {
+    this.sandbox_ = this.element.getAttribute('sandbox');
+
+    const iframeSrc = /** @type {string} */ (this.transformSrc_(
+      this.element.getAttribute('src')
+    ) ||
+      this.transformSrcDoc_(
+        this.element.getAttribute('srcdoc'),
+        this.sandbox_
+      ));
+    this.iframeSrc = this.assertSource_(
+      iframeSrc,
+      window.location.href,
+      this.sandbox_
+    );
+
     this.placeholder_ = this.getPlaceholder();
     this.isClickToPlay_ = !!this.placeholder_;
 

--- a/extensions/amp-story/1.0/amp-story-grid-layer.js
+++ b/extensions/amp-story/1.0/amp-story-grid-layer.js
@@ -83,7 +83,7 @@ export class AmpStoryGridLayer extends AmpStoryBaseLayer {
   constructor(element) {
     super(element);
 
-    /** @private {null|boolean} */
+    /** @private {?boolean} */
     this.isFirstPage_ = false;
 
     /** @private {?{horiz: number, vert: number}} */

--- a/extensions/amp-story/1.0/amp-story-grid-layer.js
+++ b/extensions/amp-story/1.0/amp-story-grid-layer.js
@@ -83,20 +83,8 @@ export class AmpStoryGridLayer extends AmpStoryBaseLayer {
   constructor(element) {
     super(element);
 
-    /** @private {boolean} */
-    this.prerenderAllowed_ = false;
-
     /** @private {?{horiz: number, vert: number}} */
     this.aspectRatio_ = null;
-  }
-
-  /** @override */
-  firstAttachedCallback() {
-    // Only prerender if child of the first page.
-    this.prerenderAllowed_ = matches(
-      this.element,
-      'amp-story-page:first-of-type amp-story-grid-layer'
-    );
   }
 
   /** @override */
@@ -110,7 +98,11 @@ export class AmpStoryGridLayer extends AmpStoryBaseLayer {
 
   /** @override */
   prerenderAllowed() {
-    return this.prerenderAllowed_;
+    // Only prerender if child of the first page.
+    return matches(
+      this.element,
+      'amp-story-page:first-of-type amp-story-grid-layer'
+    );
   }
 
   /** @private */

--- a/extensions/amp-story/1.0/amp-story-grid-layer.js
+++ b/extensions/amp-story/1.0/amp-story-grid-layer.js
@@ -84,7 +84,7 @@ export class AmpStoryGridLayer extends AmpStoryBaseLayer {
     super(element);
 
     /** @private {?boolean} */
-    this.isFirstPage_ = false;
+    this.isFirstPage_ = null;
 
     /** @private {?{horiz: number, vert: number}} */
     this.aspectRatio_ = null;

--- a/extensions/amp-story/1.0/amp-story-grid-layer.js
+++ b/extensions/amp-story/1.0/amp-story-grid-layer.js
@@ -83,8 +83,25 @@ export class AmpStoryGridLayer extends AmpStoryBaseLayer {
   constructor(element) {
     super(element);
 
+    /** @private {null|boolean} */
+    this.isFirstPage_ = false;
+
     /** @private {?{horiz: number, vert: number}} */
     this.aspectRatio_ = null;
+  }
+
+  /**
+   * Returns true if a child of the first page.
+   * @return {boolean}
+   */
+  isFirstPage() {
+    if (this.isFirstPage_ === null) {
+      this.isFirstPage_ = matches(
+        this.element,
+        'amp-story-page:first-of-type amp-story-grid-layer'
+      );
+    }
+    return this.isFirstPage_;
   }
 
   /** @override */
@@ -98,11 +115,7 @@ export class AmpStoryGridLayer extends AmpStoryBaseLayer {
 
   /** @override */
   prerenderAllowed() {
-    // Only prerender if child of the first page.
-    return matches(
-      this.element,
-      'amp-story-page:first-of-type amp-story-grid-layer'
-    );
+    return this.isFirstPage();
   }
 
   /** @private */

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -244,7 +244,7 @@ export class AmpStoryPage extends AMP.BaseElement {
       100
     );
 
-    /** @private {null|boolean}  */
+    /** @private {?boolean}  */
     this.isFirstPage_ = null;
 
     /** @private {?LoadingSpinner} */

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -244,8 +244,8 @@ export class AmpStoryPage extends AMP.BaseElement {
       100
     );
 
-    /** @private {boolean}  */
-    this.isFirstPage_ = false;
+    /** @private {null|boolean}  */
+    this.isFirstPage_ = null;
 
     /** @private {?LoadingSpinner} */
     this.loadingSpinner_ = null;
@@ -338,12 +338,6 @@ export class AmpStoryPage extends AMP.BaseElement {
   }
 
   /** @override */
-  firstAttachedCallback() {
-    // Only prerender the first story page.
-    this.isFirstPage_ = matches(this.element, 'amp-story-page:first-of-type');
-  }
-
-  /** @override */
   buildCallback() {
     this.delegateVideoAutoplay();
     this.markMediaElementsWithPreload_();
@@ -386,6 +380,13 @@ export class AmpStoryPage extends AMP.BaseElement {
         })
       );
     }
+  }
+
+  isFirstPage() {
+    if (this.isFirstPage_=== null)  {
+      this.isFirstPage_ = matches(this.element, 'amp-story-page:first-of-type'); 
+    } 
+    return this.isFirstPage_;
   }
 
   /**
@@ -585,7 +586,7 @@ export class AmpStoryPage extends AMP.BaseElement {
     // Only measures from the first story page, that always gets built because
     // of the prerendering optimizations in place.
     if (
-      !this.isFirstPage_ ||
+      !this.isFirstPage() ||
       (this.layoutBox_ &&
         this.layoutBox_.width === layoutBox.width &&
         this.layoutBox_.height === layoutBox.height)
@@ -836,7 +837,7 @@ export class AmpStoryPage extends AMP.BaseElement {
 
   /** @override */
   prerenderAllowed() {
-    return this.isFirstPage_;
+    return this.isFirstPage();
   }
 
   /**

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -382,10 +382,14 @@ export class AmpStoryPage extends AMP.BaseElement {
     }
   }
 
+  /**
+   * Returns true if a child of the first page.
+   * @return {boolean}
+   */
   isFirstPage() {
-    if (this.isFirstPage_=== null)  {
-      this.isFirstPage_ = matches(this.element, 'amp-story-page:first-of-type'); 
-    } 
+    if (this.isFirstPage_ === null) {
+      this.isFirstPage_ = matches(this.element, 'amp-story-page:first-of-type');
+    }
     return this.isFirstPage_;
   }
 

--- a/extensions/amp-truncate-text/0.1/amp-truncate-text.js
+++ b/extensions/amp-truncate-text/0.1/amp-truncate-text.js
@@ -81,6 +81,13 @@ export class AmpTruncateText extends AMP.BaseElement {
 
   /** @override */
   buildCallback() {
+    this.mutationObserver_.observe(this.element, {
+      attributes: true,
+      characterData: true,
+      childList: true,
+      subtree: true,
+    });
+
     this.useShadow_ =
       !!this.element.attachShadow &&
       isExperimentOn(this.win, 'amp-truncate-text-shadow');
@@ -176,16 +183,6 @@ export class AmpTruncateText extends AMP.BaseElement {
   layoutCallback() {
     return this.mutateElement(() => {
       this.truncate_();
-    });
-  }
-
-  /** @override */
-  firstAttachedCallback() {
-    this.mutationObserver_.observe(this.element, {
-      attributes: true,
-      characterData: true,
-      childList: true,
-      subtree: true,
     });
   }
 

--- a/extensions/amp-video/0.1/amp-video.js
+++ b/extensions/amp-video/0.1/amp-video.js
@@ -86,7 +86,7 @@ class AmpVideo extends AMP.BaseElement {
     /** @private {boolean} */
     this.muted_ = false;
 
-    /** @private {null|boolean} */
+    /** @private {?boolean} */
     this.prerenderAllowed_ = null;
 
     /** @private {!../../../src/mediasession-helper.MetadataDef} */

--- a/extensions/amp-video/0.1/amp-video.js
+++ b/extensions/amp-video/0.1/amp-video.js
@@ -86,9 +86,6 @@ class AmpVideo extends AMP.BaseElement {
     /** @private {boolean} */
     this.muted_ = false;
 
-    /** @private {boolean} */
-    this.prerenderAllowed_ = false;
-
     /** @private {!../../../src/mediasession-helper.MetadataDef} */
     this.metadata_ = EMPTY_METADATA;
 
@@ -111,18 +108,6 @@ class AmpVideo extends AMP.BaseElement {
         opt_onLayout
       );
     });
-  }
-
-  /**
-   * @override
-   */
-  firstAttachedCallback() {
-    // Only allow prerender if video sources are cached on CDN, or if video has
-    // a poster image. Set this value in `firstAttachedCallback` since
-    // `buildCallback` is too late and the element children may not be available
-    // in the constructor.
-    const posterAttr = this.element.getAttribute('poster');
-    this.prerenderAllowed_ = !!posterAttr || this.hasAnyCachedSources_();
   }
 
   /**
@@ -161,7 +146,10 @@ class AmpVideo extends AMP.BaseElement {
    * @override
    */
   prerenderAllowed() {
-    return this.prerenderAllowed_;
+    // Only allow prerender if video sources are cached on CDN, or if video has
+    // a poster image. 
+    const posterAttr = this.element.getAttribute('poster');
+    return !!posterAttr || this.hasAnyCachedSources_();
   }
 
   /**

--- a/extensions/amp-video/0.1/amp-video.js
+++ b/extensions/amp-video/0.1/amp-video.js
@@ -86,6 +86,9 @@ class AmpVideo extends AMP.BaseElement {
     /** @private {boolean} */
     this.muted_ = false;
 
+    /** @private {null|boolean} */
+    this.prerenderAllowed_ = null;
+
     /** @private {!../../../src/mediasession-helper.MetadataDef} */
     this.metadata_ = EMPTY_METADATA;
 
@@ -147,9 +150,12 @@ class AmpVideo extends AMP.BaseElement {
    */
   prerenderAllowed() {
     // Only allow prerender if video sources are cached on CDN, or if video has
-    // a poster image. 
-    const posterAttr = this.element.getAttribute('poster');
-    return !!posterAttr || this.hasAnyCachedSources_();
+    // a poster image.
+    if (this.prerenderAllowed_ == null) {
+      const posterAttr = this.element.getAttribute('poster');
+      this.prerenderAllowed_ = !!posterAttr || this.hasAnyCachedSources_();
+    }
+    return this.prerenderAllowed_;
   }
 
   /**

--- a/src/base-element.js
+++ b/src/base-element.js
@@ -36,10 +36,6 @@ import {isArray, toWin} from './types';
  *
  * The complete lifecycle of a custom DOM element is:
  *
- *           ||
- *           || createdCallback
- *           ||
- *           \/
  *    State: <NOT BUILT> <NOT UPGRADED>
  *           ||
  *           || upgrade

--- a/src/base-element.js
+++ b/src/base-element.js
@@ -311,14 +311,6 @@ export class BaseElement {
   }
 
   /**
-   * Called when the element is first created. Note that for element created
-   * using createElement this may be before any children are added.
-   */
-  createdCallback() {
-    // Subclasses may override.
-  }
-
-  /**
    * Override in subclass if the element needs to rebuilt its DOM content.
    * Until the element has been rebuilt its content are not shown with an only
    * exception of [placeholder] elements. From the moment the element is created

--- a/src/base-element.js
+++ b/src/base-element.js
@@ -40,14 +40,9 @@ import {isArray, toWin} from './types';
  *           || createdCallback
  *           ||
  *           \/
- *    State: <NOT BUILT> <NOT UPGRADED> <NOT ATTACHED>
+ *    State: <NOT BUILT> <NOT UPGRADED>
  *           ||
  *           || upgrade
- *           ||
- *           \/
- *    State: <NOT BUILT> <NOT ATTACHED>
- *           ||
- *           || firstAttachedCallback
  *           ||
  *           \/
  *    State: <NOT BUILT>
@@ -320,15 +315,6 @@ export class BaseElement {
    * using createElement this may be before any children are added.
    */
   createdCallback() {
-    // Subclasses may override.
-  }
-
-  /**
-   * Override in subclass to adjust the element when it is being added to the
-   * DOM. Could e.g. be used to insert a fallback. Should not typically start
-   * loading a resource.
-   */
-  firstAttachedCallback() {
     // Subclasses may override.
   }
 

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -747,7 +747,7 @@ function createBaseCustomElementClass(win) {
     }
 
     /**
-     * Called when the element is first connected to the DOM. 
+     * Called when the element is first connected to the DOM.
      *
      * This callback is guarded by checks to see if the element is still
      * connected.  Chrome and Safari can trigger connectedCallback even when

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -378,7 +378,6 @@ function createBaseCustomElementClass(win) {
       this.assertLayout_();
       // TODO(wg-runtime): Don't set BaseElement ivars externally.
       this.implementation_.layout_ = this.layout_;
-      this.implementation_.firstAttachedCallback();
       this.dispatchCustomEventForTesting(AmpEvents.ATTACHED);
       this.getResources().upgraded(this);
       this.signals_.signal(CommonSignals.UPGRADED);
@@ -749,8 +748,7 @@ function createBaseCustomElementClass(win) {
     }
 
     /**
-     * Called when the element is first connected to the DOM. Calls
-     * {@link firstAttachedCallback} if this is the first attachment.
+     * Called when the element is first connected to the DOM. 
      *
      * This callback is guarded by checks to see if the element is still
      * connected.  Chrome and Safari can trigger connectedCallback even when

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -374,7 +374,6 @@ function createBaseCustomElementClass(win) {
       this.implementation_ = newImpl;
       this.classList.remove('amp-unresolved');
       this.classList.remove('i-amphtml-unresolved');
-      this.implementation_.createdCallback();
       this.assertLayout_();
       // TODO(wg-runtime): Don't set BaseElement ivars externally.
       this.implementation_.layout_ = this.layout_;

--- a/test/unit/test-amp-img.js
+++ b/test/unit/test-amp-img.js
@@ -251,7 +251,6 @@ describes.sandboxed('amp-img', {}, (env) => {
       el.getPlaceholder = sandbox.stub();
       el.getLayoutWidth = () => 100;
       impl = new AmpImg(el);
-      impl.createdCallback();
       el.toggleFallback = function () {};
       el.togglePlaceholder = function () {};
       toggleFallbackSpy = sandbox.spy(el, 'toggleFallback');
@@ -383,7 +382,6 @@ describes.sandboxed('amp-img', {}, (env) => {
     el.setAttribute('height', 100);
     el.setAttribute('noprerender', '');
     const impl = new AmpImg(el);
-    impl.firstAttachedCallback();
     expect(impl.prerenderAllowed()).to.equal(false);
   });
 
@@ -603,7 +601,6 @@ describes.sandboxed('amp-img', {}, (env) => {
       el.getPlaceholder = sandbox.stub();
       el.getLayoutWidth = () => layoutWidth;
       const impl = new AmpImg(el);
-      impl.createdCallback();
       sandbox.stub(impl, 'getLayout').returns(attributes['layout']);
       el.toggleFallback = function () {};
       el.togglePlaceholder = function () {};

--- a/test/unit/test-custom-element.js
+++ b/test/unit/test-custom-element.js
@@ -39,9 +39,7 @@ describes.realWin('CustomElement', {amp: true}, (env) => {
       let container;
       let ElementClass, StubElementClass;
 
-      let testElementCreatedCallback;
       let testElementPreconnectCallback;
-      let testElementFirstAttachedCallback;
       let testElementBuildCallback;
       let testElementCreatePlaceholderCallback;
       let testElementLayoutCallback;
@@ -55,14 +53,8 @@ describes.realWin('CustomElement', {amp: true}, (env) => {
         isLayoutSupported(unusedLayout) {
           return true;
         }
-        createdCallback() {
-          testElementCreatedCallback();
-        }
         preconnectCallback(onLayout) {
           testElementPreconnectCallback(onLayout);
-        }
-        firstAttachedCallback() {
-          testElementFirstAttachedCallback();
         }
         buildCallback() {
           testElementBuildCallback();
@@ -127,9 +119,7 @@ describes.realWin('CustomElement', {amp: true}, (env) => {
         win.__AMP_EXTENDED_ELEMENTS['amp-stub'] = ElementStub;
         ampdoc.declareExtension('amp-stub');
 
-        testElementCreatedCallback = env.sandbox.spy();
         testElementPreconnectCallback = env.sandbox.spy();
-        testElementFirstAttachedCallback = env.sandbox.spy();
         testElementBuildCallback = env.sandbox.spy();
         testElementCreatePlaceholderCallback = env.sandbox.spy();
         testElementLayoutCallback = env.sandbox.spy();
@@ -178,14 +168,12 @@ describes.realWin('CustomElement', {amp: true}, (env) => {
         expect(element.readyState).to.equal('loading');
         expect(element.everAttached).to.equal(false);
         expect(element.layout_).to.equal(Layout.NODISPLAY);
-        expect(testElementCreatedCallback).to.have.not.been.called;
 
         container.appendChild(element);
         expect(element).to.have.class('i-amphtml-element');
         expect(element).to.have.class('i-amphtml-notbuilt');
         expect(element).to.have.class('amp-notbuilt');
         expect(element.everAttached).to.equal(true);
-        expect(testElementCreatedCallback).to.be.calledOnce;
         expect(element.isUpgraded()).to.equal(true);
         expect(build.calledOnce).to.equal(true);
 
@@ -204,14 +192,12 @@ describes.realWin('CustomElement', {amp: true}, (env) => {
         expect(element.readyState).to.equal('loading');
         expect(element.everAttached).to.equal(false);
         expect(element.layout_).to.equal(Layout.NODISPLAY);
-        expect(testElementCreatedCallback).to.have.not.been.called;
 
         container.appendChild(element);
         expect(element).to.have.class('i-amphtml-element');
         expect(element).to.have.class('i-amphtml-notbuilt');
         expect(element).to.have.class('amp-notbuilt');
         expect(element.everAttached).to.equal(true);
-        expect(testElementCreatedCallback).to.have.not.been.called;
         expect(element.isUpgraded()).to.equal(false);
         // TODO(jeffkaufman, #13422): this test was silently failing.  `build` was
         // the return value from `env.sandbox.stub(element, 'build')`.
@@ -398,7 +384,6 @@ describes.realWin('CustomElement', {amp: true}, (env) => {
       it('StubElement - upgrade after attached', () => {
         const element = new StubElementClass();
         expect(element.isUpgraded()).to.equal(false);
-        expect(testElementCreatedCallback).to.have.not.been.called;
 
         element.setAttribute('layout', 'fill');
         element.updateLayoutBox({top: 0, left: 0, width: 111, height: 51});
@@ -410,15 +395,12 @@ describes.realWin('CustomElement', {amp: true}, (env) => {
         expect(element.isUpgraded()).to.equal(true);
         expect(element.implementation_).to.be.instanceOf(TestElement);
         expect(element.implementation_.layout_).to.equal(Layout.FILL);
-        expect(testElementCreatedCallback).to.be.calledOnce;
-        expect(testElementFirstAttachedCallback).to.be.calledOnce;
         expect(element.isBuilt()).to.equal(false);
       });
 
       it('StubElement - upgrade before attached', () => {
         const element = new StubElementClass();
         expect(element.isUpgraded()).to.equal(false);
-        expect(testElementCreatedCallback).to.have.not.been.called;
 
         element.setAttribute('layout', 'fill');
         element.updateLayoutBox({top: 0, left: 0, width: 111, height: 51});
@@ -428,8 +410,6 @@ describes.realWin('CustomElement', {amp: true}, (env) => {
 
         expect(element.isUpgraded()).to.equal(false);
         expect(element.implementation_).to.be.instanceOf(TestElement);
-        expect(testElementCreatedCallback).to.have.not.been.called;
-        expect(testElementFirstAttachedCallback).to.have.not.been.called;
         expect(element.isBuilt()).to.equal(false);
       });
 
@@ -562,13 +542,11 @@ describes.realWin('CustomElement', {amp: true}, (env) => {
       it('StubElement - re-upgrade', () => {
         const element = new StubElementClass();
         expect(element.isUpgraded()).to.equal(false);
-        expect(testElementCreatedCallback).to.have.not.been.called;
         resourcesMock.expects('upgraded').withExactArgs(element).never();
 
         element.upgrade(TestElementWithReUpgrade);
 
         expect(element.isUpgraded()).to.equal(false);
-        expect(testElementCreatedCallback).to.have.not.been.called;
       });
 
       it('Element - build NOT allowed before attachment', () => {
@@ -783,7 +761,6 @@ describes.realWin('CustomElement', {amp: true}, (env) => {
       it('Element - attachedCallback', () => {
         const element = new ElementClass();
         element.setAttribute('layout', 'fill');
-        expect(testElementFirstAttachedCallback).to.have.not.been.called;
         expect(element.everAttached).to.equal(false);
         expect(element.layout_).to.equal(Layout.NODISPLAY);
 
@@ -794,13 +771,11 @@ describes.realWin('CustomElement', {amp: true}, (env) => {
         expect(element.everAttached).to.equal(true);
         expect(element.layout_).to.equal(Layout.FILL);
         expect(element.implementation_.layout_).to.equal(Layout.FILL);
-        expect(testElementFirstAttachedCallback).to.be.calledOnce;
       });
 
       it('StubElement - attachedCallback', () => {
         const element = new StubElementClass();
         element.setAttribute('layout', 'fill');
-        expect(testElementFirstAttachedCallback).to.have.not.been.called;
         expect(element.everAttached).to.equal(false);
         expect(element.layout_).to.equal(Layout.NODISPLAY);
 
@@ -810,8 +785,6 @@ describes.realWin('CustomElement', {amp: true}, (env) => {
         expect(element.everAttached).to.equal(true);
         expect(element.layout_).to.equal(Layout.FILL);
         // Not upgraded yet!
-        expect(testElementCreatedCallback).to.have.not.been.called;
-        expect(testElementFirstAttachedCallback).to.have.not.been.called;
         expect(element).to.have.class('amp-unresolved');
         expect(element).to.have.class('i-amphtml-unresolved');
 
@@ -822,8 +795,6 @@ describes.realWin('CustomElement', {amp: true}, (env) => {
         expect(element.layout_).to.equal(Layout.FILL);
         expect(element.implementation_.layout_).to.equal(Layout.FILL);
         // Now it's called.
-        expect(testElementCreatedCallback).to.be.calledOnce;
-        expect(testElementFirstAttachedCallback).to.be.calledOnce;
         expect(element).to.not.have.class('amp-unresolved');
         expect(element).to.not.have.class('i-amphtml-unresolved');
       });
@@ -831,7 +802,6 @@ describes.realWin('CustomElement', {amp: true}, (env) => {
       it('Element - detachedCallback', () => {
         const element = new ElementClass();
         element.setAttribute('layout', 'fill');
-        expect(testElementFirstAttachedCallback).to.have.not.been.called;
         expect(element.everAttached).to.equal(false);
         expect(element.layout_).to.equal(Layout.NODISPLAY);
 
@@ -845,13 +815,11 @@ describes.realWin('CustomElement', {amp: true}, (env) => {
         expect(element.everAttached).to.equal(true);
         expect(element.layout_).to.equal(Layout.FILL);
         expect(element.implementation_.layout_).to.equal(Layout.FILL);
-        expect(testElementFirstAttachedCallback).to.be.calledOnce;
       });
 
       it('Element - handles async detachedCallback when connected', () => {
         const element = new ElementClass();
         element.setAttribute('layout', 'fill');
-        expect(testElementFirstAttachedCallback).to.have.not.been.called;
         expect(element.everAttached).to.equal(false);
         expect(element.layout_).to.equal(Layout.NODISPLAY);
 
@@ -868,7 +836,6 @@ describes.realWin('CustomElement', {amp: true}, (env) => {
         expect(element.everAttached).to.equal(true);
         expect(element.layout_).to.equal(Layout.FILL);
         expect(element.implementation_.layout_).to.equal(Layout.FILL);
-        expect(testElementFirstAttachedCallback).to.be.calledOnce;
       });
 
       it('Element - layoutCallback before build', () => {

--- a/testing/describes.js
+++ b/testing/describes.js
@@ -942,7 +942,6 @@ function createAmpElement(win, opt_name, opt_implementationClass) {
   const element = new ctor();
   element.implementationClassForTesting =
     opt_implementationClass || BaseElement;
-  element.createdCallback();
   element.classList.add('i-amphtml-element');
   return element;
 }

--- a/testing/describes.js
+++ b/testing/describes.js
@@ -942,6 +942,7 @@ function createAmpElement(win, opt_name, opt_implementationClass) {
   const element = new ctor();
   element.implementationClassForTesting =
     opt_implementationClass || BaseElement;
+  element.createdCallback();
   element.classList.add('i-amphtml-element');
   return element;
 }


### PR DESCRIPTION
Addresses https://github.com/ampproject/amphtml/issues/30487

Changes:
- 0 instances found of an overrided BaseElement `createdCallback`, so I just removed it.
- 4 instances of overriden `firstAttachedCallback`. There were only two kinds:
  1. Calculation and caching of `prerenderAllowed`. Depending on if the calculation seemed expensive, I either inlined or made the caching lazy. Note that this is the primary valid-ish use-case, although I'd argue (and implement here) that a lazy calc of the value within the prerenderAllowed() method is better. 
  2. Code that could have been in `buildCallback`, so I moved it.