### PR TITLE
🐛  [amp-story] Build pagination buttons for pre-rendered stories

### DIFF
--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -961,6 +961,11 @@ export class AmpStory extends AMP.BaseElement {
           this.upgradeCtaAnchorTagsForTracking_(page, index);
         });
         this.initializeStoryNavigationPath_();
+
+        // Build pagination buttons if they can be displayed.
+        if (this.storeService_.get(StateProperty.CAN_SHOW_PAGINATION_BUTTONS)) {
+          new PaginationButtons(this);
+        }
       })
       .then(() => this.initializeBookend_())
       .then(() => {
@@ -1008,11 +1013,6 @@ export class AmpStory extends AMP.BaseElement {
       });
 
     this.maybeLoadStoryEducation_();
-
-    // Build pagination buttons if they can be displayed.
-    if (this.storeService_.get(StateProperty.CAN_SHOW_PAGINATION_BUTTONS)) {
-      new PaginationButtons(this);
-    }
 
     // Story is being prerendered: resolve the layoutCallback when the first
     // page is built. Other pages will only build if the document becomes

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -1009,6 +1009,11 @@ export class AmpStory extends AMP.BaseElement {
 
     this.maybeLoadStoryEducation_();
 
+    // Build pagination buttons if they can be displayed.
+    if (this.storeService_.get(StateProperty.CAN_SHOW_PAGINATION_BUTTONS)) {
+      new PaginationButtons(this);
+    }
+
     // Story is being prerendered: resolve the layoutCallback when the first
     // page is built. Other pages will only build if the document becomes
     // visible.
@@ -1016,11 +1021,6 @@ export class AmpStory extends AMP.BaseElement {
       return whenUpgradedToCustomElement(firstPageEl).then(() => {
         return firstPageEl.whenBuilt();
       });
-    }
-
-    // Build pagination buttons if they can be displayed.
-    if (this.storeService_.get(StateProperty.CAN_SHOW_PAGINATION_BUTTONS)) {
-      new PaginationButtons(this);
     }
 
     // Will resolve when all pages are built.

--- a/extensions/amp-story/1.0/pagination-buttons.css
+++ b/extensions/amp-story/1.0/pagination-buttons.css
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-/* 
- * In desktop panel mode i-amphtml-story-button-container acts as a sentinel 
+/*
+ * In desktop panel mode i-amphtml-story-button-container acts as a sentinel
  * and covers the previous and next pages.
- * In mobile it is focusable for screen readers and the buttons are hidden. 
+ * In mobile it is focusable for screen readers and the buttons are hidden.
  * In desktop full bleed it is not focusable since the buttons are visible.
  */
 .i-amphtml-story-button-container {
@@ -162,7 +162,7 @@ amp-story:not([desktop]) .i-amphtml-story-button-container {
   opacity: 1!important;
 }
 
-.i-amphtml-story-desktop-panels.i-amphtml-story-next-hover > .i-amphtml-story-fwd-replay >    
+.i-amphtml-story-desktop-panels.i-amphtml-story-next-hover > .i-amphtml-story-fwd-replay >
     .i-amphtml-story-button-move {
   opacity: 1 !important;
 }


### PR DESCRIPTION
While working on #30031 I noticed pagination buttons weren't being built for documents that were initially prerendered. This is because the `layoutCallback()` was being short circuited here for prerendered documents:

https://github.com/ampproject/amphtml/blob/056f82bf5ec3a9aac06a3747b37bea0b8e42e842/extensions/amp-story/1.0/amp-story.js#L1012-L1019

Which is right before the pagination buttons are built.

<!--
# Instructions:

- Pick a meaningful title for your pull request. (Use sentence case.)
  - Prefix the title with an emoji to identify what is being done. (Copy-paste the emoji from the list below.)
  - Do not overuse punctuation in the title (like `(chore):`).
  - If it is helpful, use a simple prefix (like `ProjectX: Implement some feature`).
- Enter a succinct description that says why the PR is necessary, and what it does.
  - Mention the GitHub issue that is being addressed by the pull request.
  - The keywords `Fixes`, `Closes`, or `Resolves` followed the issue number will automatically close the issue.

> NOTE: All non-trivial changes (like introducing new features or components) should have an associated issue or reference an I2I (intent-to-implement: go.amp.dev/i2i). Please read through the contribution process (go.amp.dev/contributing/code) for more information.

# Example of a good description:

- Implement aspect X
- Leave out feature Y because of A
- Improve performance by B
- Improve accessibility by C

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Reverting a previous change
♻️ Refactoring
🚮 Deleting code
🧪 Experimental code
-->
