### PR TITLE
CSI: Report SSR experiments via the USQP meta

### DIFF
--- a/src/service/performance-impl.js
+++ b/src/service/performance-impl.js
@@ -85,10 +85,8 @@ export class Performance {
     /** @private {boolean} */
     this.isPerformanceTrackingOn_ = false;
 
-    /** @private {!Object<string,boolean>} */
-    this.enabledExperiments_ = map();
-    /** @private {string} */
-    this.ampexp_ = '';
+    /** @private {!Array<string>} */
+    this.enabledExperiments_ = [];
 
     /** @private {Signals} */
     this.metrics_ = new Signals();
@@ -272,6 +270,13 @@ export class Performance {
 
         // Tick timeOrigin so that epoch time can be calculated by consumers.
         this.tick(TickLabel.TIME_ORIGIN, undefined, this.timeOrigin_);
+
+        const usqp = this.ampdoc_.getMetaByName('amp-usqp');
+        if (usqp) {
+          usqp.split(',').forEach((exp) => {
+            this.addEnabledExperiment('ssr-' + exp);
+          });
+        }
 
         return this.maybeAddStoryExperimentId_();
       })
@@ -761,7 +766,7 @@ export class Performance {
       this.viewer_.sendMessage(
         'sendCsi',
         dict({
-          'ampexp': this.ampexp_,
+          'ampexp': this.enabledExperiments_.join(','),
         }),
         /* cancelUnsent */ true
       );
@@ -783,8 +788,7 @@ export class Performance {
    * @param {string} experimentId
    */
   addEnabledExperiment(experimentId) {
-    this.enabledExperiments_[experimentId] = true;
-    this.ampexp_ = Object.keys(this.enabledExperiments_).join(',');
+    this.enabledExperiments_.push(experimentId);
   }
 
   /**

--- a/src/service/performance-impl.js
+++ b/src/service/performance-impl.js
@@ -20,7 +20,7 @@ import {TickLabel} from '../enums';
 import {VisibilityState} from '../visibility-state';
 import {createCustomEvent} from '../event-helper';
 import {dev, devAssert} from '../log';
-import {dict, map} from '../utils/object';
+import {dict} from '../utils/object';
 import {getMode} from '../mode';
 import {getService, registerServiceBuilder} from '../service';
 import {isStoryDocument} from '../utils/story';

--- a/test/unit/test-performance.js
+++ b/test/unit/test-performance.js
@@ -779,6 +779,30 @@ describes.realWin('performance with experiment', {amp: true}, (env) => {
       );
     });
   });
+
+  it('adds ssr experiments', () => {
+    env.sandbox
+      .stub(env.ampdoc, 'getMetaByName')
+      .withArgs('amp-usqp')
+      .returns('1=1,2=0');
+    return perf.coreServicesAvailable().then(() => {
+      viewerSendMessageStub.reset();
+      perf.flush();
+      expect(viewerSendMessageStub).to.be.calledWith(
+        'sendCsi',
+        env.sandbox.match((payload) => {
+          const experiments = payload.ampexp.split(',');
+          expect(experiments).to.have.length(3);
+          expect(experiments).to.have.members([
+            'rtv-' + getMode(win).rtvVersion,
+            'ssr-1=1',
+            'ssr-2=0',
+          ]);
+          return true;
+        })
+      );
+    });
+  });
 });
 
 describes.realWin('PeformanceObserver metrics', {amp: true}, (env) => {


### PR DESCRIPTION
This collects the SSR experiments enabled in the `<meta name=amp-usqp>` for CSI metrics.

See the related cl/335090010 for injecting the new meta tag.