### PR TITLE
Refactor onResizeSuccess/onResizeFailure to requestResize

### DIFF
--- a/3p/ampcontext.js
+++ b/3p/ampcontext.js
@@ -215,8 +215,8 @@ export class AbstractAmpContext {
   /**
    *  Send message to runtime requesting to resize ad to height and width.
    *    This is not guaranteed to succeed. All this does is make the request.
-   *  @param {number} width The new width for the ad we are requesting.
-   *  @param {number} height The new height for the ad we are requesting.
+   *  @param {number|undefined} width The new width for the ad we are requesting.
+   *  @param {number|undefined} height The new height for the ad we are requesting.
    *  @param {boolean=} hasOverflow Whether the ad handles its own overflow ele
    *  @return {Promise} Signify the success/failure of the request.
    */

--- a/ads/google/csa.js
+++ b/ads/google/csa.js
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import {devAssert} from '../../src/log';
 import {getStyle, setStyle, setStyles} from '../../src/style';
 import {loadScript, validateData} from '../../3p/3p';
 import {tryParseJson} from '../../src/json.js';
@@ -98,14 +99,6 @@ export function csa(global, data) {
     orientationChangeHandler.bind(null, global, containerDiv)
   );
 
-  // Register resize callbacks
-  global.context.onResizeSuccess(
-    resizeSuccessHandler.bind(null, global, containerDiv)
-  );
-  global.context.onResizeDenied(
-    resizeDeniedHandler.bind(null, global, containerDiv)
-  );
-
   // Only call for ads once the script has loaded
   loadScript(
     global,
@@ -129,22 +122,36 @@ function orientationChangeHandler(global, containerDiv) {
     // eslint-disable-next-line no-unused-vars
     const ignore = global.document.body./*OK*/ offsetHeight;
     // Capture new height.
-    let newHeight = getStyle(containerDiv, 'height');
+    const newHeight = getStyle(containerDiv, 'height');
     // In older versions of iOS, this height will be different because the
     // container height is resized.
     // In Chrome and iOS 10.0.2 the height is the same because
     // the container isn't resized.
     if (oldHeight != newHeight && newHeight != currentAmpHeight) {
       // style.height returns "60px" (for example), so turn this into an int
-      newHeight = parseInt(newHeight, 10);
+      const newHeightPx = parseInt(newHeight, 10);
       // Also update the onclick function to resize to the right height.
       const overflow = global.document.getElementById('overflow');
       if (overflow) {
         overflow.onclick = () =>
-          global.context.requestResize(undefined, newHeight);
+          global.context
+            .requestResize(undefined, newHeightPx)
+            .then(() => {
+              resizeSuccessHandler(global, containerDiv, newHeightPx);
+            })
+            .catch(() => {
+              resizeDeniedHandler(global, containerDiv, newHeightPx);
+            });
       }
       // Resize the container to the correct height.
-      global.context.requestResize(undefined, newHeight);
+      global.context
+        .requestResize(undefined, newHeightPx)
+        .then(() => {
+          resizeSuccessHandler(global, containerDiv, newHeightPx);
+        })
+        .catch(() => {
+          resizeDeniedHandler(global, containerDiv, newHeightPx);
+        });
     }
   }, 250); /* 250 is time in ms to wait before executing orientation */
 }
@@ -296,7 +303,14 @@ export function resizeIframe(global, containerName) {
     createOverflow(global, container, height);
   }
   // Attempt to resize to actual CSA container height
-  global.context.requestResize(undefined, height);
+  global.context
+    .requestResize(undefined, height)
+    .then(() => {
+      resizeSuccessHandler(global, devAssert(container), height);
+    })
+    .catch(() => {
+      resizeDeniedHandler(global, devAssert(container), height);
+    });
 }
 
 /**
@@ -309,7 +323,15 @@ export function resizeIframe(global, containerName) {
 function createOverflow(global, container, height) {
   const overflow = getOverflowElement(global);
   // When overflow is clicked, resize to full height
-  overflow.onclick = () => global.context.requestResize(undefined, height);
+  overflow.onclick = () =>
+    global.context
+      .requestResize(undefined, height)
+      .then(() => {
+        resizeSuccessHandler(global, container, height);
+      })
+      .catch(() => {
+        resizeDeniedHandler(global, container, height);
+      });
   global.document.getElementById('c').appendChild(overflow);
   // Resize the CSA container to not conflict with overflow
   resizeCsa(container, currentAmpHeight - overflowHeight);

--- a/ads/google/csa.js
+++ b/ads/google/csa.js
@@ -134,24 +134,10 @@ function orientationChangeHandler(global, containerDiv) {
       const overflow = global.document.getElementById('overflow');
       if (overflow) {
         overflow.onclick = () =>
-          global.context
-            .requestResize(undefined, newHeightPx)
-            .then(() => {
-              resizeSuccessHandler(global, containerDiv, newHeightPx);
-            })
-            .catch(() => {
-              resizeDeniedHandler(global, containerDiv, newHeightPx);
-            });
+          requestResizeInternal(global, containerDiv, newHeightPx);
       }
       // Resize the container to the correct height.
-      global.context
-        .requestResize(undefined, newHeightPx)
-        .then(() => {
-          resizeSuccessHandler(global, containerDiv, newHeightPx);
-        })
-        .catch(() => {
-          resizeDeniedHandler(global, containerDiv, newHeightPx);
-        });
+      requestResizeInternal(global, containerDiv, newHeightPx);
     }
   }, 250); /* 250 is time in ms to wait before executing orientation */
 }
@@ -303,13 +289,23 @@ export function resizeIframe(global, containerName) {
     createOverflow(global, container, height);
   }
   // Attempt to resize to actual CSA container height
+  requestResizeInternal(global, devAssert(container), height);
+}
+
+/**
+ * Helper function to call requestResize
+ * @param {!Window} global
+ * @param {!Element} container
+ * @param {number} height
+ */
+function requestResizeInternal(global, container, height) {
   global.context
     .requestResize(undefined, height)
     .then(() => {
-      resizeSuccessHandler(global, devAssert(container), height);
+      resizeSuccessHandler(global, container, height);
     })
     .catch(() => {
-      resizeDeniedHandler(global, devAssert(container), height);
+      resizeDeniedHandler(global, container, height);
     });
 }
 
@@ -323,15 +319,7 @@ export function resizeIframe(global, containerName) {
 function createOverflow(global, container, height) {
   const overflow = getOverflowElement(global);
   // When overflow is clicked, resize to full height
-  overflow.onclick = () =>
-    global.context
-      .requestResize(undefined, height)
-      .then(() => {
-        resizeSuccessHandler(global, container, height);
-      })
-      .catch(() => {
-        resizeDeniedHandler(global, container, height);
-      });
+  overflow.onclick = () => requestResizeInternal(global, container, height);
   global.document.getElementById('c').appendChild(overflow);
   // Resize the CSA container to not conflict with overflow
   resizeCsa(container, currentAmpHeight - overflowHeight);

--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -911,18 +911,6 @@ const forbiddenTerms = {
   },
 };
 
-const ThreePTermsMessage =
-  'The 3p bootstrap iframe has no polyfills loaded' +
-  ' and can thus not use most modern web APIs.';
-
-const forbidden3pTerms = {
-  // We need to forbid promise usage because we don't have our own polyfill
-  // available. This allowlisting of callNext is a major hack to allow one
-  // usage in babel's external helpers that is in a code path that we do
-  // not use.
-  '\\.then\\((?!callNext)': ThreePTermsMessage,
-};
-
 const bannedTermsHelpString =
   'Please review viewport service for helper ' +
   'methods or mark with `/*OK*/` or `/*REVIEW*/` and consult the AMP team. ' +
@@ -1356,7 +1344,6 @@ function hasAnyTerms(file) {
   const basename = path.basename(pathname);
   let hasTerms = false;
   let hasSrcInclusiveTerms = false;
-  let has3pTerms = false;
 
   hasTerms = matchTerms(file, forbiddenTerms);
 
@@ -1368,18 +1355,7 @@ function hasAnyTerms(file) {
     hasSrcInclusiveTerms = matchTerms(file, forbiddenTermsSrcInclusive);
   }
 
-  const is3pFile =
-    /\/(3p|ads)\//.test(pathname) ||
-    basename == '3p.js' ||
-    basename == 'style.js';
-  // Yet another reason to move ads/google/a4a somewhere else
-  const isA4A = /\/a4a\//.test(pathname);
-  const isRecaptcha = basename == 'recaptcha.js';
-  if (is3pFile && !isRecaptcha && !isTestFile && !isA4A) {
-    has3pTerms = matchTerms(file, forbidden3pTerms);
-  }
-
-  return hasTerms || hasSrcInclusiveTerms || has3pTerms;
+  return hasTerms || hasSrcInclusiveTerms;
 }
 
 /**

--- a/test/unit/ads/test-adplugg.js
+++ b/test/unit/ads/test-adplugg.js
@@ -36,8 +36,6 @@ describes.fakeWin('amp-ad-adplugg-impl', {}, (env) => {
           },
         },
         requestResize() {},
-        onResizeSuccess() {},
-        onResizeDenied() {},
         renderStart() {},
         noContentAvailable() {},
         referrer: null,

--- a/test/unit/ads/test-aduptech.js
+++ b/test/unit/ads/test-aduptech.js
@@ -35,8 +35,6 @@ describes.fakeWin('amp-ad-aduptech-impl', {}, (env) => {
           },
         },
         requestResize() {},
-        onResizeSuccess() {},
-        onResizeDenied() {},
         noContentAvailable() {},
         referrer: null,
       };


### PR DESCRIPTION
It should not change the behavior. 

3p iframe is now polyfilled, so we can get rid of promise use restriction.
<!--
# Instructions:

- Pick a meaningful title for your pull request. (Use sentence case.)
  - Prefix the title with an emoji to identify what is being done. (Copy-paste the emoji from the list below.)
  - Do not overuse punctuation in the title (like `(chore):`).
  - If it is helpful, use a simple prefix (like `ProjectX: Implement some feature`).
- Enter a succinct description that says why the PR is necessary, and what it does.
  - Mention the GitHub issue that is being addressed by the pull request.
  - The keywords `Fixes`, `Closes`, or `Resolves` followed the issue number will automatically close the issue.

> NOTE: All non-trivial changes (like introducing new features or components) should have an associated issue or reference an I2I (intent-to-implement: go.amp.dev/i2i). Please read through the contribution process (go.amp.dev/contributing/code) for more information.

# Example of a good description:

- Implement aspect X
- Leave out feature Y because of A
- Improve performance by B
- Improve accessibility by C

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Reverting a previous change
♻️ Refactoring
🚮 Deleting code
🧪 Experimental code
-->
