### PR TITLE
🚮 Remove unused eslint-disable

### DIFF
--- a/build-system/babel-plugins/babel-plugin-transform-jss/test/index.js
+++ b/build-system/babel-plugins/babel-plugin-transform-jss/test/index.js
@@ -20,7 +20,6 @@ const runner = require('@babel/helper-plugin-test-runner').default;
 
 runner(__dirname);
 
-// eslint-disable-next-line no-undef
 const fileContents = `
 import {createUseStyles} from 'react-jss';
 export const useStyles = createUseStyles({button: {fontSize: 12}});`;

--- a/build-system/server/app-index/boilerplate.js
+++ b/build-system/server/app-index/boilerplate.js
@@ -13,6 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* eslint-disable max-len */
 module.exports =
   '<style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>';

--- a/build-system/server/app-index/file-list.js
+++ b/build-system/server/app-index/file-list.js
@@ -15,7 +15,6 @@
  */
 
 /* eslint-disable local/html-template */
-/* eslint-disable indent */
 
 const documentModes = require('./document-modes');
 const {AmpState, ampStateKey, containsExpr} = require('./amphtml-helpers');

--- a/build-system/server/app-index/settings.js
+++ b/build-system/server/app-index/settings.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* eslint-disable indent */
 /* eslint-disable local/html-template */
 const {html, joinFragments} = require('./html');
 

--- a/build-system/server/app-index/template.js
+++ b/build-system/server/app-index/template.js
@@ -15,7 +15,6 @@
  */
 
 /* eslint-disable local/html-template */
-/* eslint-disable indent */
 
 'use strict';
 

--- a/build-system/server/shadow-viewer.js
+++ b/build-system/server/shadow-viewer.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 /* eslint-disable local/html-template */
-/* eslint-disable indent */
 
 const {html} = require('./app-index/html');
 

--- a/build-system/tasks/e2e/describes-e2e.js
+++ b/build-system/tasks/e2e/describes-e2e.js
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 // import to install chromedriver and geckodriver
-require('chromedriver'); // eslint-disable-line no-unused-vars
-require('geckodriver'); // eslint-disable-line no-unused-vars
+require('chromedriver');
+require('geckodriver');
 
 const chrome = require('selenium-webdriver/chrome');
 const firefox = require('selenium-webdriver/firefox');

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -516,7 +516,6 @@ function printConfigHelp(command) {
  */
 function printNobuildHelp() {
   for (const task of NOBUILD_HELP_TASKS) {
-    // eslint-disable-line local/no-for-of-statement
     if (argv._.includes(task)) {
       log(
         green('To skip building during future'),

--- a/build-system/tasks/storybook/amp-env/main.js
+++ b/build-system/tasks/storybook/amp-env/main.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-// eslint-disable-next-line local/no-module-exports, no-undef
 module.exports = {
   stories: [
     '../../../../builtins/storybook/*.amp.js',

--- a/build-system/tasks/storybook/preact-env/main.js
+++ b/build-system/tasks/storybook/preact-env/main.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-// eslint-disable-next-line local/no-module-exports, no-undef
 module.exports = {
   stories: [
     '../../../../src/**/storybook/!(*.amp).js',

--- a/extensions/amp-addthis/0.1/addthis-utils/classify.js
+++ b/extensions/amp-addthis/0.1/addthis-utils/classify.js
@@ -26,7 +26,6 @@ const REFERRER_BITS = {
   ON_DOMAIN: 0x2,
   OFF_DOMAIN: 0x4,
 };
-// eslint-disable-next-line max-len
 const RE_SEARCH_TERMS = /^(?:q|search|bs|wd|p|kw|keyword|query|qry|querytext|text|searchcriteria|searchstring|searchtext|sp_q)=(.*)/i;
 const RE_SEARCH_REFERRER = /ws\/results\/(web|images|video|news)/;
 const RE_SEARCH_GOOGLE = /google.*\/(search|url|aclk|m\?)/;

--- a/extensions/amp-animation/0.1/web-animations.js
+++ b/extensions/amp-animation/0.1/web-animations.js
@@ -16,7 +16,7 @@
 
 import {CssNumberNode, CssTimeNode, isVarCss} from './parsers/css-expr-ast';
 import {
-  InternalWebAnimationRequestDef, // eslint-disable-line no-unused-vars
+  InternalWebAnimationRequestDef,
   WebAnimationDef,
   WebAnimationSelectorDef,
   WebAnimationSubtargetDef,

--- a/extensions/amp-apester-media/0.1/monetization/companion/video.js
+++ b/extensions/amp-apester-media/0.1/monetization/companion/video.js
@@ -148,12 +148,12 @@ function getSrMacros(interactionModel, campaignId, apesterElement, consentObj) {
     'param1': interactionId,
     'param2': publisherId,
     'param6': campaignId,
-    'page_url': pageUrl, // eslint-disable-line google-camelcase/google-camelcase
+    'page_url': pageUrl,
   });
 
   if (consentObj['gdpr']) {
     macros['gdpr'] = consentObj['gdpr'];
-    macros['user_consent'] = consentObj['user_consent']; // eslint-disable-line google-camelcase/google-camelcase
+    macros['user_consent'] = consentObj['user_consent'];
     macros['param4'] = consentObj['gdprString'];
   }
 

--- a/extensions/amp-base-carousel/1.0/test/test-amp-base-carousel.js
+++ b/extensions/amp-base-carousel/1.0/test/test-amp-base-carousel.js
@@ -38,7 +38,6 @@ describes.realWin(
     let win;
     let element;
 
-    // eslint-disable-next-line react-hooks/rules-of-hooks
     const styles = useStyles();
 
     async function getSlideWrappersFromShadow() {

--- a/extensions/amp-geo/0.1/test/test-amp-geo.js
+++ b/extensions/amp-geo/0.1/test/test-amp-geo.js
@@ -30,7 +30,7 @@ describes.realWin(
   },
   (env) => {
     const expectedState =
-      '<amp-state id="ampGeo"><script type="application/json">{"ISOCountry":"unknown","nafta":true,"unknown":true,"ISOCountryGroups":["nafta","unknown"]}</script></amp-state>'; // eslint-disable-line
+      '<amp-state id="ampGeo"><script type="application/json">{"ISOCountry":"unknown","nafta":true,"unknown":true,"ISOCountryGroups":["nafta","unknown"]}</script></amp-state>';
 
     const config = {
       ISOCountryGroups: {

--- a/extensions/amp-script/0.1/test/integration/test-amp-script.js
+++ b/extensions/amp-script/0.1/test/integration/test-amp-script.js
@@ -34,14 +34,12 @@ describe
     describes.integration(
       'container ',
       {
-        /* eslint-disable max-len */
         body: `
       <amp-script layout=container src="/examples/amp-script/amp-script-demo.js">
         <button id="hello">Insert Hello World!</button>
         <button id="long">Long task</button>
       </amp-script>
     `,
-        /* eslint-enable max-len */
         extensions: ['amp-script'],
       },
       (env) => {
@@ -121,7 +119,6 @@ describe
     describes.integration(
       'sanitizer',
       {
-        /* eslint-disable max-len */
         body: `
       <amp-script layout=container src="/examples/amp-script/amp-script-demo.js">
         <p>Number of mutations: <span id="mutationCount">0</span></p>
@@ -129,7 +126,6 @@ describe
         <button id="img">Insert img</button>
       </amp-script>
     `,
-        /* eslint-enable max-len */
         extensions: ['amp-script'],
       },
       (env) => {
@@ -190,14 +186,12 @@ describe
     describes.integration(
       'defined-layout',
       {
-        /* eslint-disable max-len */
         body: `
       <amp-script layout=fixed width=300 height=200
           src="/examples/amp-script/amp-script-demo.js">
         <button id="hello">Insert</button>
       </amp-script>
     `,
-        /* eslint-enable max-len */
         extensions: ['amp-script'],
       },
       (env) => {

--- a/extensions/amp-story/1.0/_locales/km.js
+++ b/extensions/amp-story/1.0/_locales/km.js
@@ -128,7 +128,6 @@ const strings = {
   [LocalizedStringId.AMP_STORY_WARNING_UNSUPPORTED_BROWSER_TEXT]: {
     string:
       'សូម​អភ័យទោស ' +
-      // eslint-disable-next-line max-len
       'កម្មវិធីរុករកតាមអ៊ីនធឺណិត​របស់អ្នក​ហាក់ដូចជា​មិនស្គាល់​បទពិសោធន៍​នេះ​ទេ',
   },
 };

--- a/extensions/amp-subscriptions/0.1/test/test-crypto-handler.js
+++ b/extensions/amp-subscriptions/0.1/test/test-crypto-handler.js
@@ -39,13 +39,10 @@ describes.realWin(
         },
       ],
     };
-    // eslint-disable-next-line max-len
     const encryptedContent =
       '8bCQpCyIBxBHwTZVRaMuA+DGXSTzVHR/Eh/l6QqfvcXQbn5uF/HzL539jw6Ok8+oppqo2eP/H9oqaYCi4Ya50uVFzdTCBzOSTlJDmeXhqO1DIBYHIQTK3z+NweOAJci7aXwSOLtJZd1KrrCesoBjAlQ55GwyPe6xPVcUESjtT15Z7Ez1GSetSE99MIbn8fWjq5CjUZn4q3jDKdNGdM6NZ86lqL5ZsbbUQRQ2dIVExrwS9GuuFsuFi8Eahe3/eZaibZY4PzPuVR6jjCrDrgF5qw+N+uacDumoA5he/1WrHiYHzoV28Xo9yuBBm5JWEcMepoUkQgKVywOFZS4otSR81va9JNwk1F1AIQ4VOqezFE6ce92qbzo+aMVzceZJqPhVqsA=';
-    // eslint-disable-next-line max-len
     const decryptedContent =
       "\n              This is section is top secret.\n              You should only be able to read this if you have the correct permissions.\n              If you don't have the correct permissions, you shouldn't be able to read this section at all.\n            ";
-    // eslint-disable-next-line max-len
     const encryptedKey =
       "ENCRYPT({'AccessRequirements': ['googleAccessRequirements:123'], 'Key':'mSfq5tRx5omXoOX20Oqq8g=='})";
     const decryptedDocKey = 'mSfq5tRx5omXoOX20Oqq8g==';
@@ -130,7 +127,6 @@ describes.realWin(
     });
 
     describe('tryToDecryptDocument', () => {
-      // eslint-disable-next-line max-len
       it('should replace the encrypted content with decrypted content in multiple sections', async () => {
         cryptoHandler = new CryptoHandler(ampdoc);
         await cryptoHandler.tryToDecryptDocument(decryptedDocKey);

--- a/src/amp-shadow.js
+++ b/src/amp-shadow.js
@@ -20,7 +20,7 @@
  */
 
 // src/polyfills.js must be the first import.
-import './polyfills'; // eslint-disable-line sort-imports-es6-autofix/sort-imports-es6
+import './polyfills';
 
 import {adoptShadowMode} from './runtime';
 import {bodyAlwaysVisible} from './style-installer';

--- a/src/amp.js
+++ b/src/amp.js
@@ -19,7 +19,7 @@
  */
 
 // src/polyfills.js must be the first import.
-import './polyfills'; // eslint-disable-line sort-imports-es6-autofix/sort-imports-es6
+import './polyfills';
 
 import {Services} from './services';
 import {TickLabel} from './enums';

--- a/src/iframe-helper.js
+++ b/src/iframe-helper.js
@@ -586,7 +586,6 @@ export function canInspectWindow(win) {
     // to optimize this check away.
     return !!win.location.href && (win['test'] || true);
   } catch (unusedErr) {
-    // eslint-disable-line no-unused-vars
     return false;
   }
 }

--- a/src/service/origin-experiments-impl.js
+++ b/src/service/origin-experiments-impl.js
@@ -32,7 +32,7 @@ const PUBLIC_JWK = /** @type {!webCrypto.JsonWebKey} */ ({
   'key_ops': ['verify'],
   'kty': 'RSA',
   'n':
-    'uAGSMYKze8Fit508UaGHz1eZowfX4YsA0lmyi-65xQfjF7nMo61c4Iz4erdqgRp-ov662yVPquhPmTxgB-nzNcTPrj15Jo05Js78Q9hS2hrPIjKMlzcKSYQN_08QieWKOSmVbLSv_-4n9Ms5ta8nRs4pwc_2nX5n7m5B5GH4VerGbqIWIn9FRNYMShBRQ9TCHpb6BIUTwUn6iwmJLenq0A1xhGrQ9rswGC1QJhjotkeReKXZDLLWaFr0uRw-IyvRa5RiiEGntgOvcbvamM5TnbKavc2rxvg2TWTCNQnb7lWSAzldJA_yAOYet_MjnHMyj2srUdbQSDCk8kPWWuafiQ', // eslint-disable-line max-len
+    'uAGSMYKze8Fit508UaGHz1eZowfX4YsA0lmyi-65xQfjF7nMo61c4Iz4erdqgRp-ov662yVPquhPmTxgB-nzNcTPrj15Jo05Js78Q9hS2hrPIjKMlzcKSYQN_08QieWKOSmVbLSv_-4n9Ms5ta8nRs4pwc_2nX5n7m5B5GH4VerGbqIWIn9FRNYMShBRQ9TCHpb6BIUTwUn6iwmJLenq0A1xhGrQ9rswGC1QJhjotkeReKXZDLLWaFr0uRw-IyvRa5RiiEGntgOvcbvamM5TnbKavc2rxvg2TWTCNQnb7lWSAzldJA_yAOYet_MjnHMyj2srUdbQSDCk8kPWWuafiQ',
 });
 
 /**

--- a/src/service/position-observer/position-observer-impl.js
+++ b/src/service/position-observer/position-observer-impl.js
@@ -16,7 +16,7 @@
 
 import {
   PositionObserverFidelity, // eslint-disable-line no-unused-vars
-  PositionObserverWorker, // eslint-disable-line no-unused-vars
+  PositionObserverWorker,
 } from './position-observer-worker';
 import {Services} from '../../services';
 import {debounce} from '../../utils/rate-limit';

--- a/src/service/video-manager-impl.js
+++ b/src/service/video-manager-impl.js
@@ -1446,7 +1446,7 @@ export class AnalyticsPercentageTracker {
   constructor(win, entry) {
     // This is destructured in `calculate_()`, but the linter thinks it's unused
     /** @private @const {!./timer-impl.Timer} */
-    this.timer_ = Services.timerFor(win); // eslint-disable-line
+    this.timer_ = Services.timerFor(win);
 
     /** @private @const {!VideoEntry} */
     this.entry_ = entry;

--- a/src/service/viewport/viewport-binding-ios-embed-wrapper.js
+++ b/src/service/viewport/viewport-binding-ios-embed-wrapper.js
@@ -69,7 +69,6 @@ export class ViewportBindingIosEmbedWrapper_ {
     /** @const {function()} */
     this.boundScrollEventListener_ = this.onScrolled_.bind(this);
 
-    // eslint-disable-next-line jsdoc/require-returns
     /** @const {function()} */
     this.boundResizeEventListener_ = () => this.resizeObservable_.fire();
 

--- a/src/service/viewport/viewport-binding-natural.js
+++ b/src/service/viewport/viewport-binding-natural.js
@@ -59,7 +59,6 @@ export class ViewportBindingNatural_ {
     /** @const {function()} */
     this.boundScrollEventListener_ = this.handleScrollEvent_.bind(this);
 
-    // eslint-disable-next-line jsdoc/require-returns
     /** @const {function()} */
     this.boundResizeEventListener_ = () => this.resizeObservable_.fire();
 

--- a/test/integration/test-amp-bind.js
+++ b/test/integration/test-amp-bind.js
@@ -34,13 +34,11 @@ describe
     describes.integration(
       'basic',
       {
-        /* eslint-disable max-len */
         body: `
       <button on="tap:AMP.setState({t: 'after_text'})" id="changeText"></button>
       <button on="tap:AMP.setState({c: 'after_class'})" id="changeClass"></button>
       <p class="before_class" [class]="c" [text]="t">before_text</p>
     `,
-        /* eslint-enable max-len */
         extensions: ['amp-bind'],
       },
       (env) => {
@@ -129,7 +127,6 @@ describe
     describes.integration(
       '+ forms',
       {
-        /* eslint-disable max-len */
         body: `
       <input type="range" min=0 max=100 value=0 on="change:AMP.setState({rangeChange: event})">
       <p id="range" [text]="rangeChange.min + ' <= ' + rangeChange.value + ' <= ' + rangeChange.max">before_range</p>
@@ -141,7 +138,6 @@ describe
       <input type="radio" on="change:AMP.setState({radioChange: event})">
       <p id="radio" [text]="'checked: ' + radioChange.checked" id="radioText">before_radio</p>
     `,
-        /* eslint-enable max-len */
         extensions: ['amp-bind'],
       },
       (env) => {
@@ -202,7 +198,6 @@ describe
     describes.integration(
       '+ amp-carousel',
       {
-        /* eslint-disable max-len */
         body: `
       <button on="tap:AMP.setState({slide: 1})" id="goToSlideOne"></button>
       <p [text]="slide">0</p>
@@ -212,7 +207,6 @@ describe
         <amp-img src="http://example.com/bar.jpg" width=10 height=10></amp-img>
       </amp-carousel>
     `,
-        /* eslint-enable max-len */
         extensions: ['amp-bind', 'amp-carousel'],
       },
       (env) => {
@@ -262,7 +256,6 @@ describe
       }
     );
 
-    /* eslint-disable max-len */
     const list = `
     <amp-state id="foo">
       <script type="application/json">
@@ -276,7 +269,6 @@ describe
       <p [text]="foo.bar"></p>
     </template>
   `;
-    /* eslint-enable max-len */
 
     const listTests = (env) => {
       let doc;
@@ -331,7 +323,6 @@ describe
     describes.integration(
       '+ amp-selector',
       {
-        /* eslint-disable max-len */
         body: `
       <button on="tap:AMP.setState({selected: 2})"></button>
       <p [text]="selected"></p>
@@ -341,7 +332,6 @@ describe
         <amp-img src="/2.jpg" width=10 height=10 option=2></amp-img>
       </amp-selector>
     `,
-        /* eslint-enable max-len */
         extensions: ['amp-bind', 'amp-selector'],
       },
       (env) => {

--- a/test/integration/test-amp-recaptcha-input.js
+++ b/test/integration/test-amp-recaptcha-input.js
@@ -28,7 +28,6 @@ describe
     describes.integration(
       'with form and amp-mustache',
       {
-        /* eslint-disable max-len */
         body: `
     <form
       method="POST"
@@ -113,7 +112,6 @@ describe
         display: block;
       }
     `,
-        /* eslint-enable max-len */
         extensions: ['amp-recaptcha-input', 'amp-form', 'amp-mustache:0.2'],
         experiments: ['amp-recaptcha-input'],
       },
@@ -184,7 +182,6 @@ describe
     describes.integration(
       recaptchaRequestId.GET,
       {
-        /* eslint-disable max-len */
         body: `
     <form
       method="GET"
@@ -206,7 +203,6 @@ describe
       </fieldset>
     </form>
   `,
-        /* eslint-enable max-len */
         extensions: ['amp-recaptcha-input', 'amp-form'],
         experiments: ['amp-recaptcha-input'],
       },
@@ -239,7 +235,6 @@ describe
     describes.integration(
       recaptchaRequestId.POST,
       {
-        /* eslint-disable max-len */
         body: `
     <form
       method="POST"
@@ -261,7 +256,6 @@ describe
       </fieldset>
     </form>
   `,
-        /* eslint-enable max-len */
         extensions: ['amp-recaptcha-input', 'amp-form'],
         experiments: ['amp-recaptcha-input'],
       },

--- a/test/unit/test-origin-experiments.js
+++ b/test/unit/test-origin-experiments.js
@@ -26,7 +26,7 @@ describes.fakeWin('OriginExperiments', {amp: true}, (env) => {
   const TAG = 'OriginExperiments';
   // Token enables experiment "foo" for origin "https://origin.com".
   const token =
-    'AAAAAFd7Im9yaWdpbiI6Imh0dHBzOi8vb3JpZ2luLmNvbSIsImV4cGVyaW1lbnQiOiJmb28iLCJleHBpcmF0aW9uIjoxLjc5NzY5MzEzNDg2MjMxNTdlKzMwOH0+0WnsFJFtFJzkrzqxid2h3jnFI2C7FTK+8iRYcU1r+9PZtnMPJCVCkNkxWGpXFZ6z2FwIa/hY4XDM//GJHr+2pdChx67wm6RIY1NDwcYqFbUrugEqWiT/2RviS9PPhtP6PKgUDI+0opQUt2ibXhsc1KynroAcGTaaxofmpnuMdj7vjGlWTF+6WCFYfAzqcLJB5a4+Drop9ZTEYRbRROMVROC8EGHwugeMfoNf3roCqaJydADQ/tSTY/fPZOlcwOtGW8GE4s/KlNyFaonjEYOROuLctJxYAqwIStQ4TdS7xfy70hsgVLCKnLeXIRJKN0eaJCkLy6BFbIrCH5FhjhbY'; // eslint-disable-line max-len
+    'AAAAAFd7Im9yaWdpbiI6Imh0dHBzOi8vb3JpZ2luLmNvbSIsImV4cGVyaW1lbnQiOiJmb28iLCJleHBpcmF0aW9uIjoxLjc5NzY5MzEzNDg2MjMxNTdlKzMwOH0+0WnsFJFtFJzkrzqxid2h3jnFI2C7FTK+8iRYcU1r+9PZtnMPJCVCkNkxWGpXFZ6z2FwIa/hY4XDM//GJHr+2pdChx67wm6RIY1NDwcYqFbUrugEqWiT/2RviS9PPhtP6PKgUDI+0opQUt2ibXhsc1KynroAcGTaaxofmpnuMdj7vjGlWTF+6WCFYfAzqcLJB5a4+Drop9ZTEYRbRROMVROC8EGHwugeMfoNf3roCqaJydADQ/tSTY/fPZOlcwOtGW8GE4s/KlNyFaonjEYOROuLctJxYAqwIStQ4TdS7xfy70hsgVLCKnLeXIRJKN0eaJCkLy6BFbIrCH5FhjhbY';
 
   let ampdoc;
   let isPkcsAvailable;

--- a/testing/yield.js
+++ b/testing/yield.js
@@ -21,7 +21,7 @@
  * Check test-yield.js for how-to.
  */
 export function installYieldIt(realIt) {
-  it = enableYield.bind(null, realIt); // eslint-disable-line no-native-reassign, no-undef
+  it = enableYield.bind(null, realIt); // eslint-disable-line no-native-reassign
   it./*OK*/ only = enableYield.bind(null, realIt.only);
   it.skip = realIt.skip;
 }


### PR DESCRIPTION
These eslint-disables are showing up on check-types as unnecessary. Removing them will make the logs easier to view.