### PR TITLE
🏗Fix test-report-upload in push builds

### DIFF
--- a/build-system/pr-check/dist-tests.js
+++ b/build-system/pr-check/dist-tests.js
@@ -47,7 +47,9 @@ function main() {
     timedExecOrDie('gulp update-packages');
 
     try {
-      timedExecOrThrow('gulp integration --nobuild --headless --compiled');
+      timedExecOrThrow(
+        'gulp integration --nobuild --headless --compiled --report'
+      );
     } catch (e) {
       if (e.status) {
         process.exitCode = e.status;

--- a/build-system/pr-check/e2e-tests.js
+++ b/build-system/pr-check/e2e-tests.js
@@ -46,7 +46,7 @@ async function main() {
     timedExecOrDie('gulp update-packages');
 
     try {
-      timedExecOrThrow('gulp e2e --nobuild --headless --compiled');
+      timedExecOrThrow('gulp e2e --nobuild --headless --compiled --report');
     } catch (e) {
       if (e.status) {
         process.exitCode = e.status;


### PR DESCRIPTION
Currently, dist and e2e tests try to report test results on master push builds, but fail because the commands are not called with the `--report` flag, so the file read fails. This throws an error in the test-report-upload task, which fails the build.

This PR 1) adds the necessary `--report` flags to ensure the result report itself is created and 2) adds error handling to the test-report-upload task so failures don't cause the task to fail. An alternative to 2 would be letting the task fail, and using `timedExec` instead of `timedExecOrDie` for the test-report-upload task, so failures don't fail the build. I can make that change if desired.

Note that these errors make the master build red, but do not occur locally or on PR builds, so they should not block other progress (this is also what made the changes difficult to test/catch).