### PR TITLE
Add gmajoulet to amp-video OWNERS.

### DIFF
--- a/extensions/amp-video/OWNERS
+++ b/extensions/amp-video/OWNERS
@@ -4,7 +4,14 @@
 {
   rules: [
     {
-      owners: [{name: 'ampproject/wg-ui-and-a11y'}],
+      owners: [
+        {
+          name: 'ampproject/wg-ui-and-a11y',
+        },
+        {
+          name: 'gmajoulet',
+        },
+      ],
     },
   ],
 }


### PR DESCRIPTION
I have been authoring (eg: https://github.com/ampproject/amphtml/pull/21972, https://github.com/ampproject/amphtml/pull/23360, https://github.com/ampproject/amphtml/pull/25456, https://github.com/ampproject/amphtml/pull/29233) and reviewing (eg: https://github.com/ampproject/amphtml/pull/28005, https://github.com/ampproject/amphtml/pull/29182, https://github.com/ampproject/amphtml/pull/29308) many PRs related to `amp-video` and its `loadPromise` helper over the past 2+ years. @ampproject/wg-stories  has many video related fixes or improvements and having someone from the working group part of `amp-video` OWNERS would help with smaller scope fixes such as https://github.com/ampproject/amphtml/pull/30481 and more to come.

cc @ampproject/wg-ui-and-a11y 