### PR TITLE
🏗 Pin yarn to 1.22.4 due to 429 response code from yarn API

### DIFF
--- a/build-system/common/check-package-manager.js
+++ b/build-system/common/check-package-manager.js
@@ -185,7 +185,7 @@ function checkYarnVersion() {
   const yarnVersion = getStdout(yarnExecutable + ' --version').trim();
   // TODO (KB): Revert #30478 once `yarn` stable is fixed
   // At this time current stable is failing GPG checks.
-  const stableVersion = '1.22.5';
+  const stableVersion = '1.22.4';
   if (stableVersion === '') {
     console.log(
       yellow(


### PR DESCRIPTION
Yarn's API servers are returning 429 status codes, so pinning to 1.22.4 will use the installed version on travis VMs.