### PR TITLE
unit tests: align with prod-config

### DIFF
--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -1928,7 +1928,10 @@ export class ResourcesImpl {
    * @private
    */
   cleanupTasks_(resource, opt_removePending) {
-    if (resource.getState() == ResourceState.NOT_LAID_OUT) {
+    if (
+      resource.getState() == ResourceState.NOT_LAID_OUT ||
+      resource.getState() == ResourceState.READY_FOR_LAYOUT
+    ) {
       // If the layout promise for this resource has not resolved yet, remove
       // it from the task queues to make sure this resource can be rescheduled
       // for layout again later on.

--- a/test/_init_tests.js
+++ b/test/_init_tests.js
@@ -402,7 +402,7 @@ function beforeTest() {
   activateChunkingForTesting();
   window.__AMP_MODE = undefined;
   window.context = undefined;
-  window.AMP_CONFIG = {};
+  window.AMP_CONFIG = require('../build-system/global-configs/prod-config.json');
   window.__AMP_TEST = true;
   installDocService(window, /* isSingleDoc */ true);
   const ampdoc = Services.ampdocServiceFor(window).getSingleDoc();

--- a/test/_init_tests.js
+++ b/test/_init_tests.js
@@ -402,6 +402,7 @@ function beforeTest() {
   activateChunkingForTesting();
   window.__AMP_MODE = undefined;
   window.context = undefined;
+  // eslint-disable-next-line no-undef
   window.AMP_CONFIG = require('../build-system/global-configs/prod-config.json');
   window.__AMP_TEST = true;
   installDocService(window, /* isSingleDoc */ true);


### PR DESCRIPTION
Addresses https://github.com/ampproject/amphtml/issues/30522

- resources-impl fix: with intersect-resources, components that are unlaid are moved back to `READY_FOR_LAYOUT` instead of `NOT_YET_BUILT` since they in general don't need explicit measurements. Therefore the cleanup() function was missing them.

cc @jridgewell to review the resources change