### PR TITLE
add a try catch for navigation performanceobserver

### DIFF
--- a/src/service/performance-impl.js
+++ b/src/service/performance-impl.js
@@ -404,8 +404,17 @@ export class Performance {
     }
 
     if (this.supportsNavigation_) {
-      const navigationObserver = this.createPerformanceObserver_(processEntry);
-      navigationObserver.observe({type: 'navigation', buffered: true});
+      // Wrap in a try statement as there are some browsers (ex. chrome 73)
+      // that will say it supports navigation but throws.
+      try {
+        const navigationObserver = this.createPerformanceObserver_(
+          processEntry
+        );
+        navigationObserver.observe({type: 'navigation', buffered: true});
+      } catch (err) {
+        dev() /*OK*/
+          .error(err);
+      }
     }
 
     if (entryTypesToObserve.length === 0) {


### PR DESCRIPTION
we are seeing a higher rate of this error in module build and this affects the startup chunk process. Wrap the observe call in a try/catch, this seems to be a bug in chrome 73

Fixes https://github.com/ampproject/amphtml/issues/29399