### PR TITLE
🐛 Correct scene-heading value in euler_ method

### DIFF
--- a/third_party/zuho/zuho.js
+++ b/third_party/zuho/zuho.js
@@ -254,7 +254,7 @@ export class Renderer {
   /** @private */
   euler_(heading, pitch, roll) {
     const te = Matrix.identity(3);
-    const x = -roll, y = -pitch, z = heading;
+    const x = -roll, y = -pitch, z = -heading;
 
     const a = Math.cos(x), b = Math.sin(x);
     const c = Math.cos(y), d = Math.sin(y);


### PR DESCRIPTION
`scene-heading` value needs to be reversed in `euler_` so api behavior is symmetric with `heading-start` and `heading-end`.
Noticed while working on #30002
<img width="1004" alt="Screen Shot 2020-10-06 at 3 37 38 PM" src="https://user-images.githubusercontent.com/3860311/95251677-e1ae4100-07e9-11eb-9eee-99d0a06c2b7b.png">