### PR TITLE
🏗 Report Travis job/build URLs to test case reporting

### DIFF
--- a/build-system/common/travis.js
+++ b/build-system/common/travis.js
@@ -64,6 +64,21 @@ function travisBuildNumber() {
 }
 
 /**
+ * Return the build URL of the ongoing Travis build.
+ * @return {string}
+ */
+function travisBuildUrl() {
+  if (!isTravisBuild()) {
+    log(
+      red('ERROR:'),
+      'This is not a Travis build. Cannot get',
+      cyan('process.env.TRAVIS_BUILD_WEB_URL') + '.'
+    );
+  }
+  return process.env.TRAVIS_BUILD_WEB_URL;
+}
+
+/**
  * Returns the job number of the ongoing Travis job.
  * @return {string}
  */
@@ -173,6 +188,7 @@ module.exports = {
   isTravisPullRequestBuild,
   isTravisPushBuild,
   travisBuildNumber,
+  travisBuildUrl,
   travisCommitSha,
   travisJobNumber,
   travisJobUrl,

--- a/build-system/common/travis.js
+++ b/build-system/common/travis.js
@@ -56,7 +56,7 @@ function isTravisPushBuild() {
  * @param {string} envKey
  * @return {function()}
  */
-function maybeGetTravisEnv(testFn, errorMsg, envKey) {
+function travisEnv(testFn, errorMsg, envKey) {
   return function () {
     if (!testFn()) {
       log(red('ERROR:'), errorMsg, 'Cannot get', cyan(`process.env.${envKey}`));
@@ -65,61 +65,44 @@ function maybeGetTravisEnv(testFn, errorMsg, envKey) {
   };
 }
 
+const travisBuildEnv = (envKey) =>
+  travisEnv(isTravisBuild, 'This is not a Travis build.', envKey);
+
 /**
  * Returns the build number of the ongoing Travis build.
  * @return {string}
  */
-const travisBuildNumber = maybeGetTravisEnv(
-  isTravisBuild,
-  'This is not a Travis build.',
-  'TRAVIS_BUILD_NUMBER'
-);
+const travisBuildNumber = travisBuildEnv('TRAVIS_BUILD_NUMBER');
 
 /**
  * Return the build URL of the ongoing Travis build.
  * @return {string}
  */
-const travisBuildUrl = maybeGetTravisEnv(
-  isTravisBuild,
-  'This is not a Travis build.',
-  'TRAVIS_BUILD_WEB_URL'
-);
+const travisBuildUrl = travisBuildEnv('TRAVIS_BUILD_WEB_URL');
 
 /**
  * Returns the job number of the ongoing Travis job.
  * @return {string}
  */
-const travisJobNumber = maybeGetTravisEnv(
-  isTravisBuild,
-  'This is not a Travis build.',
-  'TRAVIS_JOB_NUMBER'
-);
+const travisJobNumber = travisBuildEnv('TRAVIS_JOB_NUMBER');
 
 /**
  * Return the job URL of the ongoing Travis job.
  * @return {string}
  */
-const travisJobUrl = maybeGetTravisEnv(
-  isTravisBuild,
-  'This is not a Travis build.',
-  'TRAVIS_JOB_WEB_URL'
-);
+const travisJobUrl = travisBuildEnv('TRAVIS_JOB_WEB_URL');
 
 /**
  * Returns the repo slug associated with the ongoing Travis build.
  * @return {string}
  */
-const travisRepoSlug = maybeGetTravisEnv(
-  isTravisBuild,
-  'This is not a Travis build.',
-  'TRAVIS_REPO_SLUG'
-);
+const travisRepoSlug = travisBuildEnv('TRAVIS_REPO_SLUG');
 
 /**
  * Returns the commit SHA being tested by the ongoing Travis PR build.
  * @return {string}
  */
-const travisPullRequestSha = maybeGetTravisEnv(
+const travisPullRequestSha = travisEnv(
   isTravisPullRequestBuild,
   'This is not a Travis PR build.',
   'TRAVIS_PULL_REQUEST_SHA'
@@ -129,7 +112,7 @@ const travisPullRequestSha = maybeGetTravisEnv(
  * Returns the name of the branch being tested by the ongoing Travis PR build.
  * @return {string}
  */
-const travisPullRequestBranch = maybeGetTravisEnv(
+const travisPullRequestBranch = travisEnv(
   isTravisPullRequestBuild,
   'This is not a Travis PR build.',
   'TRAVIS_PULL_REQUEST_BRANCH'
@@ -139,7 +122,7 @@ const travisPullRequestBranch = maybeGetTravisEnv(
  * Returns the Travis branch for push builds.
  * @return {string}
  */
-const travisPushBranch = maybeGetTravisEnv(
+const travisPushBranch = travisEnv(
   isTravisPushBuild,
   'This is not a Travis push build.',
   'TRAVIS_BRANCH'
@@ -149,11 +132,7 @@ const travisPushBranch = maybeGetTravisEnv(
  * Returns the commit SHA being tested by the ongoing Travis build.
  * @return {string}
  */
-const travisCommitSha = maybeGetTravisEnv(
-  isTravisBuild,
-  'This is not a Travis build.',
-  'TRAVIS_COMMIT'
-);
+const travisCommitSha = travisBuildEnv('TRAVIS_COMMIT');
 
 module.exports = {
   isTravisBuild,

--- a/build-system/common/travis.js
+++ b/build-system/common/travis.js
@@ -54,7 +54,7 @@ function isTravisPushBuild() {
  * @param {function():boolean} testFn
  * @param {string} errorMsg
  * @param {string} envKey
- * @return {function()}
+ * @return {function():string}
  */
 function travisEnv(testFn, errorMsg, envKey) {
   return function () {

--- a/build-system/common/travis.js
+++ b/build-system/common/travis.js
@@ -49,139 +49,111 @@ function isTravisPushBuild() {
 }
 
 /**
+ * Returns a function to test the environment and look up a Travis environment
+ * variable
+ * @param {function():boolean} testFn
+ * @param {string} errorMsg
+ * @param {string} envKey
+ * @return {function()}
+ */
+function maybeGetTravisEnv(testFn, errorMsg, envKey) {
+  return function () {
+    if (!testFn()) {
+      log(red('ERROR:'), errorMsg, 'Cannot get', cyan(`process.env.${envKey}`));
+    }
+    return process.env[envKey];
+  };
+}
+
+/**
  * Returns the build number of the ongoing Travis build.
  * @return {string}
  */
-function travisBuildNumber() {
-  if (!isTravisBuild()) {
-    log(
-      red('ERROR:'),
-      'This is not a Travis build. Cannot get',
-      cyan('process.env.TRAVIS_BUILD_NUMBER') + '.'
-    );
-  }
-  return process.env.TRAVIS_BUILD_NUMBER;
-}
+const travisBuildNumber = maybeGetTravisEnv(
+  isTravisBuild,
+  'This is not a Travis build.',
+  'TRAVIS_BUILD_NUMBER'
+);
 
 /**
  * Return the build URL of the ongoing Travis build.
  * @return {string}
  */
-function travisBuildUrl() {
-  if (!isTravisBuild()) {
-    log(
-      red('ERROR:'),
-      'This is not a Travis build. Cannot get',
-      cyan('process.env.TRAVIS_BUILD_WEB_URL') + '.'
-    );
-  }
-  return process.env.TRAVIS_BUILD_WEB_URL;
-}
+const travisBuildUrl = maybeGetTravisEnv(
+  isTravisBuild,
+  'This is not a Travis build.',
+  'TRAVIS_BUILD_WEB_URL'
+);
 
 /**
  * Returns the job number of the ongoing Travis job.
  * @return {string}
  */
-function travisJobNumber() {
-  if (!isTravisBuild()) {
-    log(
-      red('ERROR:'),
-      'This is not a Travis build. Cannot get',
-      cyan('process.env.TRAVIS_JOB_NUMBER') + '.'
-    );
-  }
-  return process.env.TRAVIS_JOB_NUMBER;
-}
+const travisJobNumber = maybeGetTravisEnv(
+  isTravisBuild,
+  'This is not a Travis build.',
+  'TRAVIS_JOB_NUMBER'
+);
 
 /**
  * Return the job URL of the ongoing Travis job.
  * @return {string}
  */
-function travisJobUrl() {
-  if (!isTravisBuild()) {
-    log(
-      red('ERROR:'),
-      'This is not a Travis build. Cannot get',
-      cyan('process.env.TRAVIS_JOB_WEB_URL') + '.'
-    );
-  }
-  return process.env.TRAVIS_JOB_WEB_URL;
-}
+const travisJobUrl = maybeGetTravisEnv(
+  isTravisBuild,
+  'This is not a Travis build.',
+  'TRAVIS_JOB_WEB_URL'
+);
 
 /**
  * Returns the repo slug associated with the ongoing Travis build.
  * @return {string}
  */
-function travisRepoSlug() {
-  if (!isTravisBuild()) {
-    log(
-      red('ERROR:'),
-      'This is not a Travis build. Cannot get',
-      cyan('process.env.TRAVIS_REPO_SLUG') + '.'
-    );
-  }
-  return process.env.TRAVIS_REPO_SLUG;
-}
+const travisRepoSlug = maybeGetTravisEnv(
+  isTravisBuild,
+  'This is not a Travis build.',
+  'TRAVIS_REPO_SLUG'
+);
 
 /**
  * Returns the commit SHA being tested by the ongoing Travis PR build.
  * @return {string}
  */
-function travisPullRequestSha() {
-  if (!isTravisPullRequestBuild()) {
-    log(
-      red('ERROR:'),
-      'This is not a Travis PR build. Cannot get',
-      cyan('process.env.TRAVIS_PULL_REQUEST_SHA') + '.'
-    );
-  }
-  return process.env.TRAVIS_PULL_REQUEST_SHA;
-}
+const travisPullRequestSha = maybeGetTravisEnv(
+  isTravisPullRequestBuild,
+  'This is not a Travis PR build.',
+  'TRAVIS_PULL_REQUEST_SHA'
+);
 
 /**
  * Returns the name of the branch being tested by the ongoing Travis PR build.
  * @return {string}
  */
-function travisPullRequestBranch() {
-  if (!isTravisPullRequestBuild()) {
-    log(
-      red('ERROR:'),
-      'This is not a Travis PR build. Cannot get',
-      cyan('process.env.TRAVIS_PULL_REQUEST_BRANCH') + '.'
-    );
-  }
-  return process.env.TRAVIS_PULL_REQUEST_BRANCH;
-}
+const travisPullRequestBranch = maybeGetTravisEnv(
+  isTravisPullRequestBuild,
+  'This is not a Travis PR build.',
+  'TRAVIS_PULL_REQUEST_BRANCH'
+);
 
 /**
  * Returns the Travis branch for push builds.
  * @return {string}
  */
-function travisPushBranch() {
-  if (!isTravisPushBuild()) {
-    log(
-      red('ERRROR:'),
-      'This is not a Travis push build. Cannot get',
-      cyan('process.env.TRAVIS_BRANCH') + '.'
-    );
-  }
-  return process.env.TRAVIS_BRANCH;
-}
+const travisPushBranch = maybeGetTravisEnv(
+  isTravisPushBuild,
+  'This is not a Travis push build.',
+  'TRAVIS_BRANCH'
+);
 
 /**
  * Returns the commit SHA being tested by the ongoing Travis build.
  * @return {string}
  */
-function travisCommitSha() {
-  if (!isTravisBuild()) {
-    log(
-      red('ERROR:'),
-      'This is not a Travis build. Cannot get',
-      cyan('process.env.TRAVIS_COMMIT') + '.'
-    );
-  }
-  return process.env.TRAVIS_COMMIT;
-}
+const travisCommitSha = maybeGetTravisEnv(
+  isTravisBuild,
+  'This is not a Travis build.',
+  'TRAVIS_COMMIT'
+);
 
 module.exports = {
   isTravisBuild,

--- a/build-system/tasks/test-report-upload.js
+++ b/build-system/tasks/test-report-upload.js
@@ -27,7 +27,9 @@ const log = require('fancy-log');
 const path = require('path');
 const {
   travisBuildNumber,
+  travisBuildUrl,
   travisJobNumber,
+  travisJobUrl,
   travisCommitSha,
 } = require('../common/travis');
 const {cyan, green, red, yellow} = require('ansi-colors');
@@ -68,17 +70,19 @@ function addJobAndBuildInfo(testType, reportJson) {
     throw new ReferenceError('Travis fields are not defined.');
   }
 
-  const build = {
-    buildNumber,
-    commitSha,
+  return {
+    results: reportJson,
+    build: {
+      buildNumber,
+      commitSha,
+      url: travisBuildUrl(),
+    },
+    job: {
+      jobNumber,
+      testSuiteType: testType,
+      url: travisJobUrl(),
+    },
   };
-
-  const job = {
-    jobNumber,
-    testSuiteType: testType,
-  };
-
-  return {build, job, results: reportJson};
 }
 
 /**


### PR DESCRIPTION
Oddly enough, there is no way to link to a Travis job/build log with just the repo and job/build number.