### PR TITLE
🏗 Use status instead of stderr to detect failure in execOrThrow

### DIFF
--- a/build-system/common/check-package-manager.js
+++ b/build-system/common/check-package-manager.js
@@ -23,7 +23,7 @@
  */
 const fs = require('fs');
 const https = require('https');
-const {getStdout, getStderr} = require('./exec');
+const {getStdout, getStderr} = require('./process');
 
 const setupInstructionsUrl =
   'https://github.com/ampproject/amphtml/blob/master/contributing/getting-started-quick.md#one-time-setup';

--- a/build-system/common/exec.js
+++ b/build-system/common/exec.js
@@ -93,8 +93,10 @@ function execWithError(cmd) {
  */
 function execOrThrow(cmd) {
   const p = exec(cmd, {'stdio': ['inherit', 'inherit', 'pipe']});
-  if (p.stderr.length > 0) {
-    const error = new Error(p.stderr.toString());
+  if (p.status && p.status != 0) {
+    const error = new Error(
+      `Error executing \`${cmd}\: \n${p.stderr.toString()}`
+    );
     error.status = p.status;
     throw error;
   }

--- a/build-system/common/exec.js
+++ b/build-system/common/exec.js
@@ -20,6 +20,8 @@
  */
 
 const childProcess = require('child_process');
+const log = require('fancy-log');
+const {yellow} = require('ansi-colors');
 
 const shellCmd = process.platform == 'win32' ? 'cmd' : '/bin/bash';
 
@@ -86,17 +88,18 @@ function execWithError(cmd) {
 }
 
 /**
- * Executes the provided command, piping the parent process' stderr, thorwing
- * an error if stderr is not empty, and returns process object.
+ * Executes the provided command, piping the parent process' stderr, throwing
+ * an error with the provided message the command fails, and returns the
+ * process object.
  * @param {string} cmd
+ * @param {string} msg
  * @return {!Object}
  */
-function execOrThrow(cmd) {
+function execOrThrow(cmd, msg) {
   const p = exec(cmd, {'stdio': ['inherit', 'inherit', 'pipe']});
   if (p.status && p.status != 0) {
-    const error = new Error(
-      `Error executing \`${cmd}\: \n${p.stderr.toString()}`
-    );
+    log(yellow('ERROR:'), msg);
+    const error = new Error(p.stderr);
     error.status = p.status;
     throw error;
   }

--- a/build-system/common/exec.js
+++ b/build-system/common/exec.js
@@ -21,20 +21,10 @@
 
 const childProcess = require('child_process');
 const log = require('fancy-log');
+const {spawnProcess, getOutput, getStdout, getStderr} = require('./process');
 const {yellow} = require('ansi-colors');
 
 const shellCmd = process.platform == 'win32' ? 'cmd' : '/bin/bash';
-
-/**
- * Spawns the given command in a child process with the given options.
- *
- * @param {string} cmd
- * @param {?Object} options
- * @return {!Object}
- */
-function spawnProcess(cmd, options) {
-  return childProcess.spawnSync(cmd, {shell: shellCmd, ...options});
-}
 
 /**
  * Executes the provided command with the given options, returning the process
@@ -104,42 +94,6 @@ function execOrThrow(cmd, msg) {
     throw error;
   }
   return p;
-}
-
-/**
- * Executes the provided command, returning the process object.
- * @param {string} cmd
- * @param {?Object} options
- * @return {!Object}
- */
-function getOutput(cmd, options = {}) {
-  const p = spawnProcess(cmd, {
-    'cwd': options.cwd || process.cwd(),
-    'env': options.env || process.env,
-    'stdio': options.stdio || 'pipe',
-    'encoding': options.encoding || 'utf-8',
-  });
-  return p;
-}
-
-/**
- * Executes the provided command, returning its stdout.
- * @param {string} cmd
- * @param {?Object} options
- * @return {string}
- */
-function getStdout(cmd, options) {
-  return getOutput(cmd, options).stdout;
-}
-
-/**
- * Executes the provided command, returning its stderr.
- * @param {string} cmd
- * @param {?Object} options
- * @return {string}
- */
-function getStderr(cmd, options) {
-  return getOutput(cmd, options).stderr;
 }
 
 module.exports = {

--- a/build-system/common/process.js
+++ b/build-system/common/process.js
@@ -1,0 +1,79 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+/**
+ * @fileoverview Provides functions for executing tasks in a child process.
+ * Separated from `exec` to allow import before `yarn` installs dependencies.
+ */
+
+const childProcess = require('child_process');
+
+const shellCmd = process.platform == 'win32' ? 'cmd' : '/bin/bash';
+
+/**
+ * Spawns the given command in a child process with the given options.
+ *
+ * @param {string} cmd
+ * @param {?Object} options
+ * @return {!Object}
+ */
+function spawnProcess(cmd, options) {
+  return childProcess.spawnSync(cmd, {shell: shellCmd, ...options});
+}
+
+/**
+ * Executes the provided command, returning the process object.
+ * @param {string} cmd
+ * @param {?Object} options
+ * @return {!Object}
+ */
+function getOutput(cmd, options = {}) {
+  const p = spawnProcess(cmd, {
+    'cwd': options.cwd || process.cwd(),
+    'env': options.env || process.env,
+    'stdio': options.stdio || 'pipe',
+    'encoding': options.encoding || 'utf-8',
+  });
+  return p;
+}
+
+/**
+ * Executes the provided command, returning its stdout.
+ * @param {string} cmd
+ * @param {?Object} options
+ * @return {string}
+ */
+function getStdout(cmd, options) {
+  return getOutput(cmd, options).stdout;
+}
+
+/**
+ * Executes the provided command, returning its stderr.
+ * @param {string} cmd
+ * @param {?Object} options
+ * @return {string}
+ */
+function getStderr(cmd, options) {
+  return getOutput(cmd, options).stderr;
+}
+
+module.exports = {
+  getOutput,
+  getStderr,
+  getStdout,
+  spawnProcess,
+};

--- a/build-system/pr-check/dist-tests.js
+++ b/build-system/pr-check/dist-tests.js
@@ -37,7 +37,7 @@ const {isTravisPullRequestBuild} = require('../common/travis');
 const FILENAME = 'dist-tests.js';
 const FILELOGPREFIX = colors.bold(colors.yellow(`${FILENAME}:`));
 const timedExecOrDie = (cmd) => timedExecOrDieBase(cmd, FILENAME);
-const timedExecOrThrow = (cmd) => timedExecOrThrowBase(cmd, FILENAME);
+const timedExecOrThrow = (cmd, msg) => timedExecOrThrowBase(cmd, FILENAME, msg);
 
 function main() {
   const startTime = startTimer(FILENAME, FILENAME);
@@ -48,7 +48,8 @@ function main() {
 
     try {
       timedExecOrThrow(
-        'gulp integration --nobuild --headless --compiled --report'
+        'gulp integration --nobuild --headless --compiled --report',
+        'Integration tests failed!'
       );
     } catch (e) {
       if (e.status) {

--- a/build-system/pr-check/e2e-tests.js
+++ b/build-system/pr-check/e2e-tests.js
@@ -36,7 +36,7 @@ const {isTravisPullRequestBuild} = require('../common/travis');
 const FILENAME = 'e2e-tests.js';
 const FILELOGPREFIX = colors.bold(colors.yellow(`${FILENAME}:`));
 const timedExecOrDie = (cmd) => timedExecOrDieBase(cmd, FILENAME);
-const timedExecOrThrow = (cmd) => timedExecOrThrowBase(cmd, FILENAME);
+const timedExecOrThrow = (cmd, msg) => timedExecOrThrowBase(cmd, FILENAME, msg);
 
 async function main() {
   const startTime = startTimer(FILENAME, FILENAME);
@@ -46,7 +46,10 @@ async function main() {
     timedExecOrDie('gulp update-packages');
 
     try {
-      timedExecOrThrow('gulp e2e --nobuild --headless --compiled --report');
+      timedExecOrThrow(
+        'gulp e2e --nobuild --headless --compiled --report',
+        'End-to-end tests failed!'
+      );
     } catch (e) {
       if (e.status) {
         process.exitCode = e.status;

--- a/build-system/pr-check/local-tests.js
+++ b/build-system/pr-check/local-tests.js
@@ -36,7 +36,7 @@ const {isTravisPullRequestBuild} = require('../common/travis');
 const FILENAME = 'local-tests.js';
 const FILELOGPREFIX = colors.bold(colors.yellow(`${FILENAME}:`));
 const timedExecOrDie = (cmd) => timedExecOrDieBase(cmd, FILENAME);
-const timedExecOrThrow = (cmd) => timedExecOrThrowBase(cmd, FILENAME);
+const timedExecOrThrow = (cmd, msg) => timedExecOrThrowBase(cmd, FILENAME, msg);
 
 function main() {
   const startTime = startTimer(FILENAME, FILENAME);
@@ -47,10 +47,17 @@ function main() {
 
     try {
       timedExecOrThrow(
-        'gulp integration --nobuild --headless --coverage --report'
+        'gulp integration --nobuild --headless --coverage --report',
+        'Integration tests failed! Skipping remaining tests.'
       );
-      timedExecOrThrow('gulp unit --nobuild --headless --coverage --report');
-      timedExecOrThrow('gulp codecov-upload');
+      timedExecOrThrow(
+        'gulp unit --nobuild --headless --coverage --report',
+        'Unit tests failed!'
+      );
+      timedExecOrThrow(
+        'gulp codecov-upload',
+        'Failed to upload code coverage to Codecov!'
+      );
     } catch (e) {
       if (e.status) {
         process.exitCode = e.status;

--- a/build-system/pr-check/utils.js
+++ b/build-system/pr-check/utils.js
@@ -168,7 +168,7 @@ function stopTimedJob(fileName, startTime) {
  * @return {!Function(string, string=): ?}
  */
 function timedExecFn(execFn) {
-  return (cmd, fileName = 'utils.js', ...rest) => {
+  return (cmd, fileName, ...rest) => {
     const startTime = startTimer(cmd, fileName);
     const p = execFn(cmd, ...rest);
     stopTimer(cmd, fileName, startTime);

--- a/build-system/pr-check/utils.js
+++ b/build-system/pr-check/utils.js
@@ -168,9 +168,9 @@ function stopTimedJob(fileName, startTime) {
  * @return {!Function(string, string=): ?}
  */
 function timedExecFn(execFn) {
-  return (cmd, fileName = 'utils.js') => {
+  return (cmd, fileName = 'utils.js', ...rest) => {
     const startTime = startTimer(cmd, fileName);
-    const p = execFn(cmd);
+    const p = execFn(cmd, ...rest);
     stopTimer(cmd, fileName, startTime);
     return p;
   };

--- a/build-system/tasks/cherry-pick.js
+++ b/build-system/tasks/cherry-pick.js
@@ -17,25 +17,8 @@
 
 const argv = require('minimist')(process.argv.slice(2));
 const log = require('fancy-log');
-const {getOutput} = require('../common/exec');
+const {execOrThrow, getOutput} = require('../common/exec');
 const {green, cyan, red, yellow} = require('ansi-colors');
-
-/**
- * Executes a shell command, and logs an error message if the command fails.
- *
- * @param {string} cmd
- * @param {string} msg
- * @return {!Object}
- */
-function execOrThrow(cmd, msg) {
-  const result = getOutput(cmd);
-  if (result.status) {
-    log(yellow('ERROR:'), msg);
-    throw new Error(result.stderr);
-  }
-
-  return result;
-}
 
 /**
  * Determines the name of the cherry-pick branch.


### PR DESCRIPTION
When introducing the helper `execOrThrow`, I built on `execWithError`, which uses stderr to detect a failure. This fails when nothing is written  to stderr, but the process status code is non-zero. This PR switches the logic to mirror `execOrDie` instead.
<!--
# Instructions:

- Pick a meaningful title for your pull request. (Use sentence case.)
  - Prefix the title with an emoji to identify what is being done. (Copy-paste the emoji from the list below.)
  - Do not overuse punctuation in the title (like `(chore):`).
  - If it is helpful, use a simple prefix (like `ProjectX: Implement some feature`).
- Enter a succinct description that says why the PR is necessary, and what it does.
  - Mention the GitHub issue that is being addressed by the pull request.
  - The keywords `Fixes`, `Closes`, or `Resolves` followed the issue number will automatically close the issue.

> NOTE: All non-trivial changes (like introducing new features or components) should have an associated issue or reference an I2I (intent-to-implement: go.amp.dev/i2i). Please read through the contribution process (go.amp.dev/contributing/code) for more information.

# Example of a good description:

- Implement aspect X
- Leave out feature Y because of A
- Improve performance by B
- Improve accessibility by C

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Reverting a previous change
♻️ Refactoring
🚮 Deleting code
🧪 Experimental code
-->
