### PR TITLE
add try/catch to calls to PerformanceObserver.prototype.observe and add tests

### DIFF
--- a/src/service/performance-impl.js
+++ b/src/service/performance-impl.js
@@ -394,7 +394,7 @@ export class Performance {
         this.win.performance.getEntriesByType('paint').forEach(processEntry);
         entryTypesToObserve.push('paint');
       } catch (err) {
-        dev().error(err);
+        dev()./*OK*/ error(err);
       }
     }
 
@@ -405,7 +405,7 @@ export class Performance {
         );
         firstInputObserver.observe({type: 'first-input', buffered: true});
       } catch (err) {
-        dev().error(err);
+        dev()./*OK*/ error(err);
       }
     }
 
@@ -419,7 +419,7 @@ export class Performance {
           buffered: true,
         });
       } catch (err) {
-        dev().error(err);
+        dev()./*OK*/ error(err);
       }
     }
 
@@ -428,7 +428,7 @@ export class Performance {
         const lcpObserver = this.createPerformanceObserver_(processEntry);
         lcpObserver.observe({type: 'largest-contentful-paint', buffered: true});
       } catch (err) {
-        dev().error(err);
+        dev()./*OK*/ error(err);
       }
     }
 
@@ -441,7 +441,7 @@ export class Performance {
         );
         navigationObserver.observe({type: 'navigation', buffered: true});
       } catch (err) {
-        dev().error(err);
+        dev()./*OK*/ error(err);
       }
     }
 

--- a/src/service/performance-impl.js
+++ b/src/service/performance-impl.js
@@ -446,7 +446,7 @@ export class Performance {
       });
       obs.observe(init);
     } catch (err) {
-      dev().warn(TAG, err);
+      dev().warn(err);
     }
   }
 

--- a/src/service/performance-impl.js
+++ b/src/service/performance-impl.js
@@ -387,28 +387,49 @@ export class Performance {
 
     const entryTypesToObserve = [];
     if (this.win.PerformancePaintTiming) {
-      // Programmatically read once as currently PerformanceObserver does not
-      // report past entries as of Chromium 61.
-      // https://bugs.chromium.org/p/chromium/issues/detail?id=725567
-      this.win.performance.getEntriesByType('paint').forEach(processEntry);
-      entryTypesToObserve.push('paint');
+      try {
+        // Programmatically read once as currently PerformanceObserver does not
+        // report past entries as of Chromium 61.
+        // https://bugs.chromium.org/p/chromium/issues/detail?id=725567
+        this.win.performance.getEntriesByType('paint').forEach(processEntry);
+        entryTypesToObserve.push('paint');
+      } catch (err) {
+        dev().error(err);
+      }
     }
 
     if (this.supportsEventTiming_) {
-      const firstInputObserver = this.createPerformanceObserver_(processEntry);
-      firstInputObserver.observe({type: 'first-input', buffered: true});
+      try {
+        const firstInputObserver = this.createPerformanceObserver_(
+          processEntry
+        );
+        firstInputObserver.observe({type: 'first-input', buffered: true});
+      } catch (err) {
+        dev().error(err);
+      }
     }
 
     if (this.supportsLayoutShift_) {
-      const layoutInstabilityObserver = this.createPerformanceObserver_(
-        processEntry
-      );
-      layoutInstabilityObserver.observe({type: 'layout-shift', buffered: true});
+      try {
+        const layoutInstabilityObserver = this.createPerformanceObserver_(
+          processEntry
+        );
+        layoutInstabilityObserver.observe({
+          type: 'layout-shift',
+          buffered: true,
+        });
+      } catch (err) {
+        dev().error(err);
+      }
     }
 
     if (this.supportsLargestContentfulPaint_) {
-      const lcpObserver = this.createPerformanceObserver_(processEntry);
-      lcpObserver.observe({type: 'largest-contentful-paint', buffered: true});
+      try {
+        const lcpObserver = this.createPerformanceObserver_(processEntry);
+        lcpObserver.observe({type: 'largest-contentful-paint', buffered: true});
+      } catch (err) {
+        dev().error(err);
+      }
     }
 
     if (this.supportsNavigation_) {
@@ -420,8 +441,7 @@ export class Performance {
         );
         navigationObserver.observe({type: 'navigation', buffered: true});
       } catch (err) {
-        dev() /*OK*/
-          .error(err);
+        dev().error(err);
       }
     }
 

--- a/src/service/performance-impl.js
+++ b/src/service/performance-impl.js
@@ -39,6 +39,8 @@ const QUEUE_LIMIT = 50;
 /** @const {string} */
 const VISIBILITY_CHANGE_EVENT = 'visibilitychange';
 
+const TAG = 'Performance';
+
 /**
  * Fields:
  * {{
@@ -446,7 +448,7 @@ export class Performance {
       });
       obs.observe(init);
     } catch (err) {
-      dev().warn(err);
+      dev().warn(TAG, err);
     }
   }
 
@@ -545,7 +547,6 @@ export class Performance {
       return;
     }
     if (!this.resources_) {
-      const TAG = 'Performance';
       dev().error(TAG, 'Failed to tick ser due to null resources');
       return;
     }

--- a/src/service/performance-impl.js
+++ b/src/service/performance-impl.js
@@ -395,7 +395,7 @@ export class Performance {
     }
 
     if (this.supportsEventTiming_) {
-      const firstInputObserver = this.createPerformanceObserver_(processEntry, {
+      this.createPerformanceObserver_(processEntry, {
         type: 'first-input',
         buffered: true,
       });
@@ -419,17 +419,17 @@ export class Performance {
     if (this.supportsNavigation_) {
       // Wrap in a try statement as there are some browsers (ex. chrome 73)
       // that will say it supports navigation but throws.
-      const navigationObserver = this.createPerformanceObserver_(processEntry, {
+      this.createPerformanceObserver_(processEntry, {
         type: 'navigation',
         buffered: true,
       });
     }
 
-    if (entryTypesToObserve.length === 0) {
-      return;
+    if (entryTypesToObserve.length > 0) {
+      this.createPerformanceObserver_(processEntry, {
+        entryTypes: entryTypesToObserve,
+      });
     }
-
-    const observer = this.createPerformanceObserver_(processEntry);
   }
 
   /**

--- a/test/unit/test-performance.js
+++ b/test/unit/test-performance.js
@@ -16,10 +16,13 @@
 
 import * as IniLoad from '../../src/ini-load';
 import * as lolex from 'lolex';
+import {
+  Performance,
+  installPerformanceService,
+} from '../../src/service/performance-impl';
 import {Services} from '../../src/services';
 import {VisibilityState} from '../../src/visibility-state';
 import {getMode} from '../../src/mode';
-import {installPerformanceService, Performance} from '../../src/service/performance-impl';
 import {installPlatformService} from '../../src/service/platform-impl';
 import {installRuntimeServices} from '../../src/service/core-services';
 

--- a/test/unit/test-performance.js
+++ b/test/unit/test-performance.js
@@ -19,9 +19,20 @@ import * as lolex from 'lolex';
 import {Services} from '../../src/services';
 import {VisibilityState} from '../../src/visibility-state';
 import {getMode} from '../../src/mode';
-import {installPerformanceService} from '../../src/service/performance-impl';
+import {installPerformanceService, Performance} from '../../src/service/performance-impl';
 import {installPlatformService} from '../../src/service/platform-impl';
 import {installRuntimeServices} from '../../src/service/core-services';
+
+describes.realWin('performance', {amp: false}, (env) => {
+  it('should be resilient to unsupported PerformanceObserver entry types', () => {
+    env.sandbox.stub(env.win.PerformanceObserver.prototype, 'observe').throws();
+    allowConsoleError(() => {
+      expect(() => {
+        new Performance(env.win);
+      }).to.not.throw();
+    });
+  });
+});
 
 describes.realWin('performance', {amp: true}, (env) => {
   let perf;


### PR DESCRIPTION
the performance tracking instance is initialized very early in the amp initialization lifecycle. A throw to a call to `observe` can occur and break the initialization of the whole runtime. Make it more resilient to this case by wrapping all calls to observe in a try catch block