### PR TITLE
📖 Update validator install instructions

### DIFF
--- a/validator/README.md
+++ b/validator/README.md
@@ -61,7 +61,7 @@ Install these packages using apt-get:
 - `npm`
 - `openjdk-7-jre`
 - `protobuf-compiler`
-- `python2.7`
+- `python3`
 
 Then use pip to `pip install protobuf`.
 
@@ -75,11 +75,14 @@ In addition, install Node.js v4.4.2. E.g.,
 Dependencies:
 
 - npm
-- python 3 (should already be installed on OSX)
 - [homebrew](https://brew.sh/)
 
-  - protobuf
+  - python 3
+    ```sh
+    brew install python
+    ```
 
+  - protobuf
     ```sh
     pip3 install --user protobuf
     ```

--- a/validator/README.md
+++ b/validator/README.md
@@ -75,15 +75,13 @@ In addition, install Node.js v4.4.2. E.g.,
 Dependencies:
 
 - npm
-- python 2.7 (should already be installed on OSX)
+- python 3 (should already be installed on OSX)
 - [homebrew](https://brew.sh/)
 
   - protobuf
 
     ```sh
-    brew install protobuf
-    mkdir -p /Users/$(whoami)/Library/Python/2.7/lib/python/site-packages
-    echo 'import site; site.addsitedir("/usr/local/lib/python2.7/site-packages")' >> /Users/$(whoami)/Library/Python/2.7/lib/python/site-packages/homebrew.pth
+    pip3 install --user protobuf
     ```
 
   - openjdk-7-jre

--- a/validator/README.md
+++ b/validator/README.md
@@ -62,8 +62,9 @@ Install these packages using apt-get:
 - `openjdk-7-jre`
 - `protobuf-compiler`
 - `python3`
+- `python3-pip`
 
-Then use pip to `pip install protobuf`.
+Then `pip3 install protobuf`.
 
 In addition, install Node.js v4.4.2. E.g.,
 [by downloading](https://nodejs.org/en/download/) or

--- a/validator/README.md
+++ b/validator/README.md
@@ -80,11 +80,13 @@ Dependencies:
 - python 3 (e.g. [these instructions](https://docs.python-guide.org/starting/install3/osx/))
 
   - protobuf
+
     ```sh
     pip3 install --user protobuf
     ```
 
   - openjdk-7-jre
+
     ```sh
     brew tap homebrew/cask
     brew install Caskroom/cask/java

--- a/validator/README.md
+++ b/validator/README.md
@@ -76,11 +76,7 @@ Dependencies:
 
 - npm
 - [homebrew](https://brew.sh/)
-
-  - python 3
-    ```sh
-    brew install python
-    ```
+- python 3 (e.g. [these instructions](https://docs.python-guide.org/starting/install3/osx/))
 
   - protobuf
     ```sh


### PR DESCRIPTION
Updates both Linux and OSX instructions to Python 3, and changes OSX to use pip-provided protobuf library instead of brew, since the latter seems to be too old to work with our current build.py.