### PR TITLE
📖 [bento][amp-date-countdown] Add and update existing storybook for amp-date-countdown

### DIFF
--- a/extensions/amp-date-countdown/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-date-countdown/1.0/storybook/Basic.amp.js
@@ -1,0 +1,257 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as Preact from '../../../../src/preact';
+import {date, select, text, withKnobs} from '@storybook/addon-knobs';
+import {withA11y} from '@storybook/addon-a11y';
+import {withAmp} from '@ampproject/storybook-addon';
+
+export default {
+  title: 'amp-date-countdown-1_0',
+  decorators: [withKnobs, withA11y, withAmp],
+
+  parameters: {
+    extensions: [
+      {name: 'amp-date-countdown', version: '1.0'},
+      {name: 'amp-mustache', version: '0.2'},
+    ],
+    experiments: ['amp-date-countdown-bento'],
+  },
+};
+
+const DATE_ATTRIBUTE_CONFIGURATIONS = [
+  'end-date',
+  'timeleft-ms',
+  'timestamp-ms',
+  'timestamp-seconds',
+];
+
+const LOCALE_CONFIGURATIONS = [
+  'google',
+  'de',
+  'en',
+  'es',
+  'fr',
+  'id',
+  'it',
+  'ja',
+  'ko',
+  'nl',
+  'pt',
+  'ru',
+  'th',
+  'tr',
+  'vi',
+  'zh-cn',
+  'zh-tw',
+];
+
+const WHEN_ENDED_CONFIGURATIONS = ['stop', 'continue'];
+
+const BIGGEST_UNIT_CONFIGURATIONS = [
+  null,
+  'DAYS',
+  'HOURS',
+  'MINUTES',
+  'SECONDS',
+];
+
+export const Default = () => {
+  const dateAttribute = select(
+    'Select a "Date Attribute"',
+    DATE_ATTRIBUTE_CONFIGURATIONS,
+    DATE_ATTRIBUTE_CONFIGURATIONS[0]
+  );
+  const endDate = date('end-date', new Date(Date.now() + 10000));
+  const timeleftMs = text('timeleft-ms', 20000);
+  const timestampMs = text('timestamp-ms', Date.now() + 30000);
+  const timestampSeconds = text(
+    'timestamp-seconds',
+    Math.floor(Date.now() / 1000) + 40
+  );
+
+  const offsetSeconds = text('offset-seconds', 0);
+  const locale = select(
+    'locale',
+    LOCALE_CONFIGURATIONS,
+    LOCALE_CONFIGURATIONS[0]
+  );
+  const whenEnded = select(
+    'whenEnded',
+    WHEN_ENDED_CONFIGURATIONS,
+    WHEN_ENDED_CONFIGURATIONS[0]
+  );
+  const biggestUnit = select(
+    'biggestUnit',
+    BIGGEST_UNIT_CONFIGURATIONS,
+    BIGGEST_UNIT_CONFIGURATIONS[0]
+  );
+
+  return (
+    <amp-date-countdown
+      end-date={dateAttribute === 'end-date' ? new Date(endDate) : ''}
+      timeleft-ms={dateAttribute === 'timeleft-ms' ? timeleftMs : ''}
+      timestamp-ms={dateAttribute === 'timestamp-ms' ? timestampMs : ''}
+      timestamp-seconds={
+        dateAttribute === 'timestamp-seconds' ? timestampSeconds : ''
+      }
+      offset-seconds={offsetSeconds}
+      locale={locale}
+      when-ended={whenEnded}
+      biggest-unit={biggestUnit}
+      layout="fixed-height"
+      height="100"
+    >
+      <template type="amp-mustache">
+        <div>
+          <span>{'{{days}} {{dd}} {{d}}'}</span>
+          <br />
+          <span>{'{{hours}} {{hh}} {{h}}'}</span>
+          <br />
+          <span>{'{{minutes}} {{mm}} {{m}}'}</span>
+          <br />
+          <span>{'{{seconds}} {{ss}} {{s}}'}</span>
+        </div>
+      </template>
+    </amp-date-countdown>
+  );
+};
+
+Default.story = {
+  name: 'default',
+};
+
+export const DefaultRenderer = () => {
+  const dateAttribute = select(
+    'Select a "Date Attribute"',
+    DATE_ATTRIBUTE_CONFIGURATIONS,
+    DATE_ATTRIBUTE_CONFIGURATIONS[0]
+  );
+  const endDate = date('end-date', new Date(Date.now() + 10000));
+  const timeleftMs = text('timeleft-ms', 20000);
+  const timestampMs = text('timestamp-ms', Date.now() + 30000);
+  const timestampSeconds = text(
+    'timestamp-seconds',
+    Math.floor(Date.now() / 1000) + 40
+  );
+
+  const offsetSeconds = text('offset-seconds', 0);
+  const locale = select(
+    'locale',
+    LOCALE_CONFIGURATIONS,
+    LOCALE_CONFIGURATIONS[0]
+  );
+  const whenEnded = select(
+    'whenEnded',
+    WHEN_ENDED_CONFIGURATIONS,
+    WHEN_ENDED_CONFIGURATIONS[0]
+  );
+  const biggestUnit = select(
+    'biggestUnit',
+    BIGGEST_UNIT_CONFIGURATIONS,
+    BIGGEST_UNIT_CONFIGURATIONS[0]
+  );
+
+  return (
+    <amp-date-countdown
+      end-date={dateAttribute === 'end-date' ? new Date(endDate) : ''}
+      timeleft-ms={dateAttribute === 'timeleft-ms' ? timeleftMs : ''}
+      timestamp-ms={dateAttribute === 'timestamp-ms' ? timestampMs : ''}
+      timestamp-seconds={
+        dateAttribute === 'timestamp-seconds' ? timestampSeconds : ''
+      }
+      offset-seconds={offsetSeconds}
+      locale={locale}
+      when-ended={whenEnded}
+      biggest-unit={biggestUnit}
+      layout="fixed-height"
+      height="100"
+    ></amp-date-countdown>
+  );
+};
+
+DefaultRenderer.story = {
+  name: 'default renderer',
+};
+
+export const ExternalTemplate = () => {
+  const template = select('template', ['template1', 'template2'], 'template1');
+  const dateAttribute = select(
+    'Select a "Date Attribute"',
+    DATE_ATTRIBUTE_CONFIGURATIONS,
+    DATE_ATTRIBUTE_CONFIGURATIONS[0]
+  );
+  const endDate = date('end-date', new Date(Date.now() + 10000));
+  const timeleftMs = text('timeleft-ms', 20000);
+  const timestampMs = text('timestamp-ms', Date.now() + 30000);
+  const timestampSeconds = text(
+    'timestamp-seconds',
+    Math.floor(Date.now() / 1000) + 40
+  );
+
+  const offsetSeconds = text('offset-seconds', 0);
+  const locale = select(
+    'locale',
+    LOCALE_CONFIGURATIONS,
+    LOCALE_CONFIGURATIONS[0]
+  );
+  const whenEnded = select(
+    'whenEnded',
+    WHEN_ENDED_CONFIGURATIONS,
+    WHEN_ENDED_CONFIGURATIONS[0]
+  );
+  const biggestUnit = select(
+    'biggestUnit',
+    BIGGEST_UNIT_CONFIGURATIONS,
+    BIGGEST_UNIT_CONFIGURATIONS[0]
+  );
+
+  return (
+    <div>
+      <template type="amp-mustache" id="template1">
+        <div>
+          {`Template 1: {{s}} {{seconds}} {{m}} {{minutes}} {{h}} {{hours}}` +
+            ` {{d}} {{days}} `}
+        </div>
+      </template>
+      <template type="amp-mustache" id="template2">
+        <div>
+          {`Template 2: {{dd}} {{days}} {{hh}} {{hours}} {{mm}}` +
+            ` {{minutes}} {{ss}} {{seconds}}`}
+        </div>
+      </template>
+      <amp-date-countdown
+        end-date={dateAttribute === 'end-date' ? new Date(endDate) : ''}
+        timeleft-ms={dateAttribute === 'timeleft-ms' ? timeleftMs : ''}
+        timestamp-ms={dateAttribute === 'timestamp-ms' ? timestampMs : ''}
+        timestamp-seconds={
+          dateAttribute === 'timestamp-seconds' ? timestampSeconds : ''
+        }
+        offset-seconds={offsetSeconds}
+        locale={locale}
+        when-ended={whenEnded}
+        biggest-unit={biggestUnit}
+        template={template}
+        layout="fixed-height"
+        height="100"
+      ></amp-date-countdown>
+    </div>
+  );
+};
+
+ExternalTemplate.story = {
+  name: 'external template',
+};

--- a/extensions/amp-date-countdown/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-date-countdown/1.0/storybook/Basic.amp.js
@@ -102,11 +102,11 @@ export const Default = () => {
 
   return (
     <amp-date-countdown
-      end-date={dateAttribute === 'end-date' ? new Date(endDate) : ''}
-      timeleft-ms={dateAttribute === 'timeleft-ms' ? timeleftMs : ''}
-      timestamp-ms={dateAttribute === 'timestamp-ms' ? timestampMs : ''}
+      end-date={dateAttribute === 'end-date' ? new Date(endDate) : undefined}
+      timeleft-ms={dateAttribute === 'timeleft-ms' ? timeleftMs : undefined}
+      timestamp-ms={dateAttribute === 'timestamp-ms' ? timestampMs : undefined}
       timestamp-seconds={
-        dateAttribute === 'timestamp-seconds' ? timestampSeconds : ''
+        dateAttribute === 'timestamp-seconds' ? timestampSeconds : undefined
       }
       offset-seconds={offsetSeconds}
       locale={locale}
@@ -167,11 +167,11 @@ export const DefaultRenderer = () => {
 
   return (
     <amp-date-countdown
-      end-date={dateAttribute === 'end-date' ? new Date(endDate) : ''}
-      timeleft-ms={dateAttribute === 'timeleft-ms' ? timeleftMs : ''}
-      timestamp-ms={dateAttribute === 'timestamp-ms' ? timestampMs : ''}
+      end-date={dateAttribute === 'end-date' ? new Date(endDate) : undefined}
+      timeleft-ms={dateAttribute === 'timeleft-ms' ? timeleftMs : undefined}
+      timestamp-ms={dateAttribute === 'timestamp-ms' ? timestampMs : undefined}
       timestamp-seconds={
-        dateAttribute === 'timestamp-seconds' ? timestampSeconds : ''
+        dateAttribute === 'timestamp-seconds' ? timestampSeconds : undefined
       }
       offset-seconds={offsetSeconds}
       locale={locale}
@@ -234,11 +234,13 @@ export const ExternalTemplate = () => {
         </div>
       </template>
       <amp-date-countdown
-        end-date={dateAttribute === 'end-date' ? new Date(endDate) : ''}
-        timeleft-ms={dateAttribute === 'timeleft-ms' ? timeleftMs : ''}
-        timestamp-ms={dateAttribute === 'timestamp-ms' ? timestampMs : ''}
+        end-date={dateAttribute === 'end-date' ? new Date(endDate) : undefined}
+        timeleft-ms={dateAttribute === 'timeleft-ms' ? timeleftMs : undefined}
+        timestamp-ms={
+          dateAttribute === 'timestamp-ms' ? timestampMs : undefined
+        }
         timestamp-seconds={
-          dateAttribute === 'timestamp-seconds' ? timestampSeconds : ''
+          dateAttribute === 'timestamp-seconds' ? timestampSeconds : undefined
         }
         offset-seconds={offsetSeconds}
         locale={locale}

--- a/extensions/amp-date-countdown/1.0/storybook/Basic.js
+++ b/extensions/amp-date-countdown/1.0/storybook/Basic.js
@@ -16,7 +16,7 @@
 
 import * as Preact from '../../../../src/preact';
 import {DateCountdown} from '../date-countdown';
-import {date, number, select, withKnobs} from '@storybook/addon-knobs';
+import {date, select, withKnobs} from '@storybook/addon-knobs';
 import {withA11y} from '@storybook/addon-a11y';
 
 export default {
@@ -25,74 +25,102 @@ export default {
   decorators: [withA11y, withKnobs],
 };
 
+const LOCALE_CONFIGURATIONS = [
+  'google',
+  'de',
+  'en',
+  'es',
+  'fr',
+  'id',
+  'it',
+  'ja',
+  'ko',
+  'nl',
+  'pt',
+  'ru',
+  'th',
+  'tr',
+  'vi',
+  'zh-cn',
+  'zh-tw',
+];
+
+const WHEN_ENDED_CONFIGURATIONS = ['stop', 'continue'];
+
+const BIGGEST_UNIT_CONFIGURATIONS = [
+  null,
+  'DAYS',
+  'HOURS',
+  'MINUTES',
+  'SECONDS',
+];
+
 export const _default = () => {
-  const localeConfigurations = [
-    'google',
-    'de',
-    'en',
-    'es',
-    'fr',
-    'id',
-    'it',
-    'ja',
-    'ko',
-    'nl',
-    'pt',
-    'ru',
-    'th',
-    'tr',
-    'vi',
-    'zh-cn',
-    'zh-tw',
-  ];
-
-  const whenEndedConfigurations = ['stop', 'continue'];
-
-  const biggestUnitConfigurations = [
-    undefined,
-    'DAYS',
-    'HOURS',
-    'MINUTES',
-    'SECONDS',
-  ];
-
-  const endDate = date('endDate', new Date());
-  const offsetSeconds = number('offsetSeconds', null);
+  const datetime = date('endDate', new Date(Date.now() + 10000));
   const locale = select(
     'locale',
-    localeConfigurations,
-    localeConfigurations[0]
+    LOCALE_CONFIGURATIONS,
+    LOCALE_CONFIGURATIONS[0]
   );
   const whenEnded = select(
     'whenEnded',
-    whenEndedConfigurations,
-    whenEndedConfigurations[0]
+    WHEN_ENDED_CONFIGURATIONS,
+    WHEN_ENDED_CONFIGURATIONS[0]
   );
   const biggestUnit = select(
     'biggestUnit',
-    biggestUnitConfigurations,
-    biggestUnitConfigurations[0]
+    BIGGEST_UNIT_CONFIGURATIONS,
+    BIGGEST_UNIT_CONFIGURATIONS[0]
   );
 
   return (
     <div>
       <DateCountdown
-        endDate={new Date(endDate).toISOString()}
-        offsetSeconds={offsetSeconds}
+        datetime={datetime}
         locale={locale}
         whenEnded={whenEnded}
         biggestUnit={biggestUnit}
         render={(data) => (
           <div>
-            <span>{`Days ${data.days} ${data.dd} ${data.d}`}</span>
+            <span>{`${data.days} ${data.dd} ${data.d}`}</span>
             <br />
-            <span>{`Hours ${data.hours} ${data.hh} ${data.h}`}</span>
+            <span>{`${data.hours} ${data.hh} ${data.h}`}</span>
             <br />
-            <span>{`Minutes ${data.minutes} ${data.mm} ${data.m}`}</span>
+            <span>{`${data.minutes} ${data.mm} ${data.m}`}</span>
             <br />
-            <span>{`Seconds ${data.seconds} ${data.ss} ${data.s}`}</span>
+            <span>{`${data.seconds} ${data.ss} ${data.s}`}</span>
           </div>
         )}
+      ></DateCountdown>
+    </div>
+  );
+};
+
+export const defaultRenderer = () => {
+  const datetime = date('endDate', new Date(Date.now() + 10000));
+  const locale = select(
+    'locale',
+    LOCALE_CONFIGURATIONS,
+    LOCALE_CONFIGURATIONS[0]
+  );
+  const whenEnded = select(
+    'whenEnded',
+    WHEN_ENDED_CONFIGURATIONS,
+    WHEN_ENDED_CONFIGURATIONS[0]
+  );
+  const biggestUnit = select(
+    'biggestUnit',
+    BIGGEST_UNIT_CONFIGURATIONS,
+    BIGGEST_UNIT_CONFIGURATIONS[0]
+  );
+
+  return (
+    <div>
+      <DateCountdown
+        datetime={datetime}
+        locale={locale}
+        whenEnded={whenEnded}
+        biggestUnit={biggestUnit}
       ></DateCountdown>
     </div>
   );


### PR DESCRIPTION
Date Countdown Tracking Issue: https://github.com/ampproject/amphtml/issues/30052

Add storybook for AMP component
Update storybook for Preact component

AMP Component determines time from one of four attributes:

-`end-date`
-`timeleft-ms`
-`timestamp-ms`
-`timestamp-seconds`

If `end-date` is available, it will use `end-date`.  If not, it will use `timeleft-ms`, then `timestamp-ms`, etc.

Since the `end-date` knob is a `date` type knob, it cannot be configured to be a null value.  So `end-date` will always be included and the other 3 values will not have a chance to be used.

To get around this, I added an additional knob on the AMP storybook `Select a "date-attribute"`.  This allows the user to toggle one of the four date attributes `end-date`, `timeleft-ms`, `timestamp-ms`, and `timestamp-seconds`.  Only the selected attribute will be passed to the component.
