### PR TITLE
✨ Set default orientation in gyroscope mode

### DIFF
--- a/examples/amp-story-360.amp.html
+++ b/examples/amp-story-360.amp.html
@@ -41,7 +41,7 @@
       </amp-story-page>
       <amp-story-page id="page2">
         <amp-story-grid-layer template="fill">
-          <amp-story-360 layout="fill" heading-end="-45" pitch-end="-20" heading-start="95" pitch-start="-10" zoom-start="4" duration="30s" controls="gyroscope">
+          <amp-story-360 layout="fill" heading-end="-45" pitch-end="-20" heading-start="95" pitch-start="-10" zoom-start="4" duration="3s" controls="gyroscope">
             <amp-img src="img/Equirectangular_projection_SW.jpg" width="2058" height="1036"></amp-img>
           </amp-story-360>
         </amp-story-grid-layer>

--- a/examples/amp-story-360.amp.html
+++ b/examples/amp-story-360.amp.html
@@ -31,7 +31,7 @@
       </amp-story-page>
       <amp-story-page id="page1">
         <amp-story-grid-layer template="fill">
-          <amp-story-360 layout="fill" heading-start="205" pitch-start="10" heading-end="140" pitch-end="10" zoom-end="1" duration="1s" controls="gyroscope"
+          <amp-story-360 layout="fill" heading-start="45" pitch-start="-20" heading-end="115" pitch-end="10" zoom-end="1.5" duration="3s" controls="gyroscope"
           scene-pitch="-5">
             <!-- Curiosity self-portrat, Sol 1462 (September 2016) Credit: NASA / JPL / MSSS / Seán Doran -->
             <!-- https://informal.jpl.nasa.gov/museum/360-video -->
@@ -41,9 +41,7 @@
       </amp-story-page>
       <amp-story-page id="page2">
         <amp-story-grid-layer template="fill">
-          <amp-story-360 layout="fill" heading-start="110" heading-end="127" pitch-end="0"  pitch-start="-10" zoom-start="1" duration="1s" controls="gyroscope"
-            scene-heading="-20"
-            >
+          <amp-story-360 layout="fill" heading-end="-45" pitch-end="-20" heading-start="95" pitch-start="-10" zoom-start="4" duration="30s" controls="gyroscope">
             <amp-img src="img/Equirectangular_projection_SW.jpg" width="2058" height="1036"></amp-img>
           </amp-story-360>
         </amp-story-grid-layer>

--- a/examples/amp-story-360.amp.html
+++ b/examples/amp-story-360.amp.html
@@ -31,7 +31,7 @@
       </amp-story-page>
       <amp-story-page id="page1">
         <amp-story-grid-layer template="fill">
-          <amp-story-360 layout="fill" heading-start="45" pitch-start="-20" heading-end="115" pitch-end="10" zoom-end="1.5" duration="3s" controls="gyroscope"
+          <amp-story-360 layout="fill" heading-start="115" pitch-start="10" heading-end="50" pitch-end="10" zoom-end="1" duration="1s" controls="gyroscope"
           scene-pitch="-5">
             <!-- Curiosity self-portrat, Sol 1462 (September 2016) Credit: NASA / JPL / MSSS / Seán Doran -->
             <!-- https://informal.jpl.nasa.gov/museum/360-video -->
@@ -41,7 +41,9 @@
       </amp-story-page>
       <amp-story-page id="page2">
         <amp-story-grid-layer template="fill">
-          <amp-story-360 layout="fill" heading-end="-45" pitch-end="-20" heading-start="95" pitch-start="-10" zoom-start="4" duration="3s" controls="gyroscope">
+          <amp-story-360 layout="fill" heading-start="20" heading-end="37" pitch-end="0"  pitch-start="-10" zoom-start="1" duration="1s" controls="gyroscope"
+            scene-heading="-20"
+            >
             <amp-img src="img/Equirectangular_projection_SW.jpg" width="2058" height="1036"></amp-img>
           </amp-story-360>
         </amp-story-grid-layer>

--- a/examples/amp-story-360.amp.html
+++ b/examples/amp-story-360.amp.html
@@ -31,7 +31,7 @@
       </amp-story-page>
       <amp-story-page id="page1">
         <amp-story-grid-layer template="fill">
-          <amp-story-360 layout="fill" heading-start="115" pitch-start="10" heading-end="50" pitch-end="10" zoom-end="1" duration="1s" controls="gyroscope"
+          <amp-story-360 layout="fill" heading-start="205" pitch-start="10" heading-end="140" pitch-end="10" zoom-end="1" duration="1s" controls="gyroscope"
           scene-pitch="-5">
             <!-- Curiosity self-portrat, Sol 1462 (September 2016) Credit: NASA / JPL / MSSS / Seán Doran -->
             <!-- https://informal.jpl.nasa.gov/museum/360-video -->
@@ -41,7 +41,7 @@
       </amp-story-page>
       <amp-story-page id="page2">
         <amp-story-grid-layer template="fill">
-          <amp-story-360 layout="fill" heading-start="20" heading-end="37" pitch-end="0"  pitch-start="-10" zoom-start="1" duration="1s" controls="gyroscope"
+          <amp-story-360 layout="fill" heading-start="110" heading-end="127" pitch-end="0"  pitch-start="-10" zoom-start="1" duration="1s" controls="gyroscope"
             scene-heading="-20"
             >
             <amp-img src="img/Equirectangular_projection_SW.jpg" width="2058" height="1036"></amp-img>

--- a/extensions/amp-story-360/0.1/amp-story-360.js
+++ b/extensions/amp-story-360/0.1/amp-story-360.js
@@ -282,10 +282,10 @@ export class AmpStory360 extends AMP.BaseElement {
     /** @private {?Element|?EventTarget} */
     this.ampVideoEl_ = null;
 
-    /** @private {!number} */
+    /** @private {number} */
     this.orientationAlpha_ = 0;
 
-    /** @private {!number} */
+    /** @private {number} */
     this.headingOffset_ = 0;
   }
 

--- a/extensions/amp-story-360/0.1/amp-story-360.js
+++ b/extensions/amp-story-360/0.1/amp-story-360.js
@@ -474,7 +474,7 @@ export class AmpStory360 extends AMP.BaseElement {
         const offsetHeading =
           90 + parseFloat(defaultHeading) + this.orientationAlpha_;
         this.renderer_.setImageOrientation(
-          offsetHeading,
+          this.sceneHeading_ + offsetHeading,
           this.scenePitch_,
           this.sceneRoll_
         );

--- a/extensions/amp-story-360/0.1/amp-story-360.js
+++ b/extensions/amp-story-360/0.1/amp-story-360.js
@@ -461,18 +461,24 @@ export class AmpStory360 extends AMP.BaseElement {
   }
 
   /**
+   * Ensures user is facing a specified point of interest.
    * @private
    */
   maybeSetGyroscopeDefaultHeading_() {
     if (this.isOnActivePage_ && this.gyroscopeControls_ && this.isReady_) {
       const defaultHeading = parseFloat(
-        this.element.getAttribute('heading-end')
+        this.element.getAttribute('heading-end') ||
+          this.element.getAttribute('heading-start')
       );
-      this.renderer_.setImageOrientation(
-        90 + defaultHeading + this.orientationAlpha_,
-        this.scenePitch_,
-        this.sceneRoll_
-      );
+      if (defaultHeading) {
+        const offsetHeading =
+          90 + parseFloat(defaultHeading) + this.orientationAlpha_;
+        this.renderer_.setImageOrientation(
+          offsetHeading,
+          this.scenePitch_,
+          this.sceneRoll_
+        );
+      }
     }
   }
 

--- a/extensions/amp-story-360/0.1/amp-story-360.js
+++ b/extensions/amp-story-360/0.1/amp-story-360.js
@@ -45,7 +45,7 @@ const TAG = 'AMP_STORY_360';
 const HAVE_CURRENT_DATA = 2;
 
 /**
- * Centers heading value between [-90; 90]
+ * Centers heading and pitch value between [-90; 90]
  * @const {number}
  */
 const CENTER_OFFSET = 90;

--- a/extensions/amp-story-360/0.1/amp-story-360.js
+++ b/extensions/amp-story-360/0.1/amp-story-360.js
@@ -276,7 +276,7 @@ export class AmpStory360 extends AMP.BaseElement {
     this.ampVideoEl_ = null;
 
     /** @private {!number} */
-    this.orientationAlpha_ = null;
+    this.orientationAlpha_ = 0;
   }
 
   /** @override */
@@ -728,7 +728,9 @@ export class AmpStory360 extends AMP.BaseElement {
 
   /** @private */
   renderInitialPosition_() {
-    if (this.gyroscopeControls_) return;
+    if (this.gyroscopeControls_) {
+      return;
+    }
     this.mutateElement(() => {
       this.renderer_.setCamera(
         this.orientations_[0].rotation,

--- a/extensions/amp-story-360/0.1/amp-story-360.js
+++ b/extensions/amp-story-360/0.1/amp-story-360.js
@@ -458,6 +458,7 @@ export class AmpStory360 extends AMP.BaseElement {
       // Debounce onDeviceOrientation_ to rAF.
       let rafTimeout;
       this.win.addEventListener('deviceorientation', (e) => {
+        // Used to set default heading when navigating to this page.
         this.orientationAlpha_ = e.alpha;
         if (this.isReady_ && this.isOnActivePage_) {
           rafTimeout && this.win.cancelAnimationFrame(rafTimeout);
@@ -701,6 +702,9 @@ export class AmpStory360 extends AMP.BaseElement {
           }
           this.renderInitialPosition_();
           this.isReady_ = true;
+          if (this.gyroscopeControls_) {
+            this.maybeSetGyroscopeDefaultHeading_();
+          }
           if (this.isPlaying_) {
             this.animate_();
           }

--- a/extensions/amp-story-360/0.1/amp-story-360.js
+++ b/extensions/amp-story-360/0.1/amp-story-360.js
@@ -138,7 +138,7 @@ class CameraOrientation {
   static fromDegrees(heading, pitch, zoom) {
     return new CameraOrientation(
       deg2rad(-pitch - 90),
-      deg2rad(90 + heading),
+      deg2rad(heading),
       1 / zoom
     );
   }
@@ -482,9 +482,7 @@ export class AmpStory360 extends AMP.BaseElement {
           this.element.getAttribute('heading-end') ||
             this.element.getAttribute('heading-start') ||
             0
-        ) +
-        90 +
-        this.orientationAlpha_;
+        ) + this.orientationAlpha_;
     }
   }
 

--- a/extensions/amp-story-360/0.1/amp-story-360.js
+++ b/extensions/amp-story-360/0.1/amp-story-360.js
@@ -45,6 +45,12 @@ const TAG = 'AMP_STORY_360';
 const HAVE_CURRENT_DATA = 2;
 
 /**
+ * Centers heading value between [-90; 90]
+ * @const {number}
+ */
+const CENTER_OFFSET = 90;
+
+/**
  * Generates the template for the permission button.
  *
  * @param {!Element} element
@@ -138,7 +144,7 @@ class CameraOrientation {
   static fromDegrees(heading, pitch, zoom) {
     return new CameraOrientation(
       deg2rad(-pitch - 90),
-      deg2rad(heading),
+      deg2rad(CENTER_OFFSET + heading),
       1 / zoom
     );
   }
@@ -482,7 +488,9 @@ export class AmpStory360 extends AMP.BaseElement {
           this.element.getAttribute('heading-end') ||
             this.element.getAttribute('heading-start') ||
             0
-        ) + this.orientationAlpha_;
+        ) +
+        CENTER_OFFSET +
+        this.orientationAlpha_;
     }
   }
 

--- a/extensions/amp-story-360/0.1/amp-story-360.js
+++ b/extensions/amp-story-360/0.1/amp-story-360.js
@@ -143,7 +143,7 @@ class CameraOrientation {
    */
   static fromDegrees(heading, pitch, zoom) {
     return new CameraOrientation(
-      deg2rad(-pitch - 90),
+      deg2rad(-pitch - CENTER_OFFSET),
       deg2rad(CENTER_OFFSET + heading),
       1 / zoom
     );


### PR DESCRIPTION
Sets default heading orientation when in gyroscope mode.
[Demo](https://stories-360.web.app/examples/amp-story-360.amp.html) 

This is called on the active page on:
- page navigation
- gyroscope enabled
- layout callback

Context / Fixes #30002