### PR TITLE
a11y: [amp-video] autoplay

### DIFF
--- a/extensions/amp-video/1.0/video-wrapper.js
+++ b/extensions/amp-video/1.0/video-wrapper.js
@@ -206,6 +206,7 @@ function Autoplay({
       {displayOverlay && (
         <div
           role="button"
+          tabindex="0"
           style={fillContentOverlay}
           onClick={onOverlayClick}
         ></div>


### PR DESCRIPTION
♿ Accessibility

Relates to issue [30565](https://github.com/ampproject/amphtml/issues/30565)

**What's the issue?**
When we add autoplay attribute to amp-video, the component is not fully keyboard operable unless user clicks on the video first. This is an accessibility issue for users that navigate the website by keyboard.

**How do we reproduce the issue?**
Go to the amp-video autoplay example: https://amp.dev/documentation/examples/components/amp-video/#autoplay
Tab through the page and see if the video plays on tab.
Unless the user clicks on the video, the component is not keyboard operable.

**What browsers are affected?**
All browsers

**Which AMP version is affected?**
2009252320001
