### PR TITLE
🐛 Fix interactive prompt not centering when CSS variable is center

### DIFF
--- a/extensions/amp-story-interactive/0.1/amp-story-interactive.css
+++ b/extensions/amp-story-interactive/0.1/amp-story-interactive.css
@@ -43,6 +43,7 @@
   line-height: var(--i-amphtml-interactive-prompt-line-height) !important;
   font-weight: bold !important;
   text-align: var(--interactive-prompt-alignment) !important;
+  width: 100% !important;
 }
 
 @keyframes i-amphtml-interactive-animation-flash-background {


### PR DESCRIPTION
Fixes #30531 

Screenshot of working state in issue linked.
