### PR TITLE
amp-img: do not propagate data-amp-bind*

### DIFF
--- a/builtins/amp-img.js
+++ b/builtins/amp-img.js
@@ -366,7 +366,7 @@ export class AmpImg extends BaseElement {
     }
 
     for (const key in this.element.dataset) {
-      if (startsWith(key, 'data-amp-bind-')) {
+      if (startsWith(key, 'ampBind') && key !== 'ampBind') {
         continue;
       }
       if (targetElement.dataset[key] !== this.element.dataset[key]) {

--- a/builtins/amp-img.js
+++ b/builtins/amp-img.js
@@ -23,7 +23,6 @@ import {listen} from '../src/event-helper';
 import {propagateObjectFitStyles, setImportantStyles} from '../src/style';
 import {registerElement} from '../src/service/custom-element-registry';
 import {removeElement, scopedQuerySelector} from '../src/dom';
-import {startsWith} from '../src/string';
 
 /** @const {string} */
 const TAG = 'amp-img';
@@ -366,7 +365,7 @@ export class AmpImg extends BaseElement {
     }
 
     for (const key in this.element.dataset) {
-      if (startsWith(key, 'ampBind') && key !== 'ampBind') {
+      if (key.startsWith('ampBind') && key !== 'ampBind') {
         continue;
       }
       if (targetElement.dataset[key] !== this.element.dataset[key]) {

--- a/builtins/amp-img.js
+++ b/builtins/amp-img.js
@@ -366,7 +366,7 @@ export class AmpImg extends BaseElement {
     }
 
     for (const key in this.element.dataset) {
-      if (startsWith(key, 'data-amp-bind')) {
+      if (startsWith(key, 'data-amp-bind-')) {
         continue;
       }
       if (targetElement.dataset[key] !== this.element.dataset[key]) {

--- a/builtins/amp-img.js
+++ b/builtins/amp-img.js
@@ -23,6 +23,7 @@ import {listen} from '../src/event-helper';
 import {propagateObjectFitStyles, setImportantStyles} from '../src/style';
 import {registerElement} from '../src/service/custom-element-registry';
 import {removeElement, scopedQuerySelector} from '../src/dom';
+import {startsWith} from '../src/string';
 
 /** @const {string} */
 const TAG = 'amp-img';
@@ -345,6 +346,32 @@ export class AmpImg extends BaseElement {
         this.togglePlaceholder(false);
       });
       this.allowImgLoadFallback_ = false;
+    }
+  }
+
+  /**
+   * Utility method to propagate data attributes from this element
+   * to the target element. (For use with arbitrary data attributes.)
+   * Removes any data attributes that are missing on this element from
+   * the target element.
+   * AMP Bind attributes are excluded.
+   *
+   * @param {!Element} targetElement
+   */
+  propagateDataset(targetElement) {
+    for (const key in targetElement.dataset) {
+      if (!(key in this.element.dataset)) {
+        delete targetElement.dataset[key];
+      }
+    }
+
+    for (const key in this.element.dataset) {
+      if (startsWith(key, 'data-amp-bind')) {
+        continue;
+      }
+      if (targetElement.dataset[key] !== this.element.dataset[key]) {
+        targetElement.dataset[key] = this.element.dataset[key];
+      }
     }
   }
 }

--- a/extensions/amp-ad/0.1/test/test-amp-ad-xorigin-iframe-handler.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-xorigin-iframe-handler.js
@@ -234,7 +234,9 @@ describe('amp-ad-xorigin-iframe-handler', () => {
         });
       });
 
-      it('should be able to use user-error API', () => {
+      // TODO:(samouri): debug test. Works alone, but breaks when in the suite with
+      // everything else.
+      it.skip('should be able to use user-error API', () => {
         const err = new Error();
         err.message = 'error test';
         const userErrorReportSpy = window.sandbox.stub(

--- a/extensions/amp-ad/0.1/test/test-amp-ad-xorigin-iframe-handler.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-xorigin-iframe-handler.js
@@ -234,9 +234,7 @@ describe('amp-ad-xorigin-iframe-handler', () => {
         });
       });
 
-      // TODO:(samouri): debug test. Works alone, but breaks when in the suite with
-      // everything else.
-      it.skip('should be able to use user-error API', () => {
+      it('should be able to use user-error API', () => {
         const err = new Error();
         err.message = 'error test';
         const userErrorReportSpy = window.sandbox.stub(

--- a/src/base-element.js
+++ b/src/base-element.js
@@ -620,27 +620,6 @@ export class BaseElement {
   }
 
   /**
-   * Utility method to propagate all data attributes from this element
-   * to the target element. (For use with arbitrary data attributes.)
-   * Removes any data attributes that are missing on this element from
-   * the target element.
-   * @param {!Element} targetElement
-   */
-  propagateDataset(targetElement) {
-    for (const key in targetElement.dataset) {
-      if (!(key in this.element.dataset)) {
-        delete targetElement.dataset[key];
-      }
-    }
-
-    for (const key in this.element.dataset) {
-      if (targetElement.dataset[key] !== this.element.dataset[key]) {
-        targetElement.dataset[key] = this.element.dataset[key];
-      }
-    }
-  }
-
-  /**
    * Utility method that forwards the given list of non-bubbling events
    * from the given element to this element as custom events with the same name.
    * @param  {string|!Array<string>} events

--- a/test/unit/test-amp-img.js
+++ b/test/unit/test-amp-img.js
@@ -206,6 +206,21 @@ describes.sandboxed('amp-img', {}, (env) => {
     });
   });
 
+  it('should not propagate bind attributes', () => {
+    return getImg({
+      src: '/examples/img/sample.jpg',
+      width: 320,
+      height: 240,
+      'data-amp-bind-src': 'abc',
+      'data-amp-bind-foo': '123',
+    }).then((ampImg) => {
+      const img = ampImg.querySelector('img');
+      expect(img.getAttribute('data-foo')).to.equal('abc');
+      expect(img.getAttribute('data-amp-bind-src')).to.be.undefined;
+      expect(img.getAttribute('data-amp-bind-foo')).to.be.undefined;
+    });
+  });
+
   it('should propagate srcset and sizes with disable-inline-width', async () => {
     const ampImg = await getImg({
       src: '/examples/img/sample.jpg',

--- a/test/unit/test-amp-img.js
+++ b/test/unit/test-amp-img.js
@@ -211,12 +211,11 @@ describes.sandboxed('amp-img', {}, (env) => {
       src: '/examples/img/sample.jpg',
       width: 320,
       height: 240,
-      'data-amp-bind-src': 'abc',
+      'data-amp-bind': 'abc',
       'data-amp-bind-foo': '123',
     }).then((ampImg) => {
       const img = ampImg.querySelector('img');
-      expect(img.getAttribute('data-foo')).to.equal('abc');
-      expect(img.getAttribute('data-amp-bind-src')).to.be.undefined;
+      expect(img.getAttribute('data-amp-bind')).to.equal('abc');
       expect(img.getAttribute('data-amp-bind-foo')).to.be.undefined;
     });
   });

--- a/test/unit/test-amp-img.js
+++ b/test/unit/test-amp-img.js
@@ -216,7 +216,7 @@ describes.sandboxed('amp-img', {}, (env) => {
     }).then((ampImg) => {
       const img = ampImg.querySelector('img');
       expect(img.getAttribute('data-amp-bind')).to.equal('abc');
-      expect(img.getAttribute('data-amp-bind-foo')).to.be.undefined;
+      expect(img.getAttribute('data-amp-bind-foo')).to.be.null;
     });
   });
 

--- a/test/unit/test-base-element.js
+++ b/test/unit/test-base-element.js
@@ -81,18 +81,6 @@ describes.realWin('BaseElement', {amp: true}, (env) => {
     expect(target.getAttribute('data-test3')).to.equal('123');
   });
 
-  it('propagateDataset', () => {
-    const target = doc.createElement('div');
-    target.dataset.foo = 'abc';
-
-    element.propagateDataset(target);
-    expect(target.hasAttribute('data-foo')).to.be.false;
-
-    customElement.dataset.bar = '123';
-    element.propagateDataset(target);
-    expect(target.hasAttribute('data-bar', '123')).to.be.true;
-  });
-
   it('should register action', () => {
     const handler = () => {};
     element.registerAction('method1', handler);


### PR DESCRIPTION
Fixes https://github.com/ampproject/amphtml/issues/30547

While here, I noticed that `propagateDataset` is used exclusively by `amp-img` and so does not belong in `base-element` IMO