### PR TITLE
✨ [bento][amp-accordion] CSS Port draft for amp accordion

### DIFF
--- a/extensions/amp-accordion/1.0/accordion.js
+++ b/extensions/amp-accordion/1.0/accordion.js
@@ -25,6 +25,7 @@ import {
   useMemo,
   useState,
 } from '../../../src/preact';
+import {useStyles} from './accordion.jss';
 
 const AccordionContext = Preact.createContext(
   /** @type {AccordionDef.ContextProps} */ ({})
@@ -136,6 +137,8 @@ export function AccordionSection({
   headerAs: HeaderComp = 'header',
   contentAs: ContentComp = 'div',
   expanded: defaultExpanded = false,
+  headerStyling,
+  contentStyling,
   header,
   children,
   ...rest
@@ -162,13 +165,26 @@ export function AccordionSection({
   }, [id, toggleExpanded]);
 
   const expanded = isExpanded ? isExpanded(id, defaultExpanded) : expandedState;
+  const classes = useStyles();
 
   return (
     <Comp {...rest} expanded={expanded} aria-expanded={String(expanded)}>
-      <HeaderComp role="button" onClick={expandHandler}>
+      <HeaderComp
+        role="button"
+        onClick={expandHandler}
+        class={headerStyling || classes.defaultHeaderStyle}
+      >
         {header}
       </HeaderComp>
-      <ContentComp hidden={!expanded}>{children}</ContentComp>
+      <ContentComp
+        hidden={!expanded}
+        style={contentStyling}
+        class={`${contentStyling || classes.defaultContentStyle} ${
+          expanded ? null : classes.hiddenContentStyle
+        }`}
+      >
+        {children}
+      </ContentComp>
     </Comp>
   );
 }

--- a/extensions/amp-accordion/1.0/accordion.jss.js
+++ b/extensions/amp-accordion/1.0/accordion.jss.js
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {createUseStyles} from 'react-jss';
+
+const defaultHeaderStyle = {
+  cursor: 'pointer',
+  backgroundColor: '#efefef',
+  paddingRight: '20px',
+  border: 'solid 1px #dfdfdf',
+  margin: '0',
+};
+
+const defaultContentStyle = {
+  margin: '0',
+  backgroundColor: 'red',
+};
+
+const hiddenContentStyle = {
+  display: 'none !important',
+  visibility: 'hidden !important',
+};
+
+const JSS = {
+  defaultHeaderStyle,
+  defaultContentStyle,
+  hiddenContentStyle,
+};
+
+// useStyles gets replaced for AMP builds via `babel-plugin-transform-jss`.
+// eslint-disable-next-line local/no-export-side-effect
+export const useStyles = createUseStyles(JSS);

--- a/extensions/amp-accordion/1.0/amp-accordion.css
+++ b/extensions/amp-accordion/1.0/amp-accordion.css
@@ -13,3 +13,45 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+/* DRAFT!!
+*/
+
+amp-accordion > section > :first-child {
+  cursor: pointer;
+  background-color: #efefef;
+  padding-right: 20px;
+  border: solid 1px #dfdfdf;
+}
+
+/* heading/clontent */
+.i-amphtml-accordion-header,
+.i-amphtml-accordion-content {
+  margin: 0;
+}
+
+/* heading
+ * TODO(dvoytenko): remove most of these styles, except maybe for `cursor`.
+ */
+.i-amphtml-accordion-header {
+  cursor: pointer;
+  background-color: #efefef;
+  padding-right: 20px;
+  border: solid 1px #dfdfdf;
+}
+
+amp-accordion.i-amphtml-display-locking > section:not([expanded]) > :last-child,
+amp-accordion.i-amphtml-display-locking
+  > section:not([expanded])
+  > :last-child
+  * {
+  content-visibility: hidden-matchable !important;
+  display: block !important;
+}
+
+/* Media should never play when a section is collapsed */
+amp-accordion > section:not([expanded]) .i-amphtml-media-component,
+amp-accordion > section:not([expanded]) .i-amphtml-media-component * {
+  display: none !important;
+  visibility: hidden !important;
+}


### PR DESCRIPTION
Partial #30445.

Changes
1. Add JSS to amp-accordion for styling in Preact mode
2. Rough draft of amp-accordion CSS (does not seem to be working)

Outstanding Issues
1. In Preact mode, there is an extra layer of nodes under `section`.  Cannot style the children of these (see storybook)
2. amp level CSS does not seem to be working

Questions
1. Why do JSS changes not show up in Amp mode?  Is this mean for Preact mode only?
2. What is the reason in 0.1 there is CSS in `amp-accordion.css` and in `main.css`, to prevent FOUC?
