### PR TITLE
🐛 Interactives only should show confetti on user selection

### DIFF
--- a/extensions/amp-story-interactive/0.1/amp-story-interactive-abstract.js
+++ b/extensions/amp-story-interactive/0.1/amp-story-interactive-abstract.js
@@ -479,7 +479,11 @@ export class AmpStoryInteractive extends AMP.BaseElement {
       this.handleOptionSelection_(optionEl);
       const confettiEmoji = this.options_[optionEl.optionIndex_].confetti;
       if (confettiEmoji) {
-        emojiConfetti(this.rootEl_, this.win, confettiEmoji);
+        emojiConfetti(
+          dev().assertElement(this.rootEl_),
+          this.win,
+          confettiEmoji
+        );
       }
     }
   }

--- a/extensions/amp-story-interactive/0.1/amp-story-interactive-abstract.js
+++ b/extensions/amp-story-interactive/0.1/amp-story-interactive-abstract.js
@@ -477,6 +477,10 @@ export class AmpStoryInteractive extends AMP.BaseElement {
     if (optionEl) {
       this.updateStoryStoreState_(optionEl.optionIndex_);
       this.handleOptionSelection_(optionEl);
+      const confettiEmoji = this.options_[optionEl.optionIndex_].confetti;
+      if (confettiEmoji) {
+        emojiConfetti(this.rootEl_, this.win, confettiEmoji);
+      }
     }
   }
 
@@ -760,10 +764,6 @@ export class AmpStoryInteractive extends AMP.BaseElement {
       selectedOption.classList.add(
         'i-amphtml-story-interactive-option-selected'
       );
-      const confettiEmoji = this.options_[selectedOption.optionIndex_].confetti;
-      if (confettiEmoji) {
-        emojiConfetti(this.rootEl_, this.win, confettiEmoji);
-      }
     }
 
     if (this.optionsData_) {


### PR DESCRIPTION
Fixes #30584 

Tested locally, with this patch the effects only show when the user selects an option for the first time, but don't show when you reload an interactive that was already selected