### PR TITLE
🐛 Fix .getImpl race condition on Android

### DIFF
--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -409,12 +409,14 @@ export class AmpStoryPage extends AMP.BaseElement {
       'amp-story-page must be a descendant of amp-story.'
     );
 
-    storyEl.getImpl().then(
-      (storyImpl) => {
-        this.mediaPoolResolveFn_(MediaPool.for(storyImpl));
-      },
-      (reason) => this.mediaPoolRejectFn_(reason)
-    );
+    whenUpgradedToCustomElement(storyEl).then(() => {
+      storyEl.getImpl().then(
+        (storyImpl) => {
+          this.mediaPoolResolveFn_(MediaPool.for(storyImpl));
+        },
+        (reason) => this.mediaPoolRejectFn_(reason)
+      );
+    });
   }
 
   /**

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -409,14 +409,14 @@ export class AmpStoryPage extends AMP.BaseElement {
       'amp-story-page must be a descendant of amp-story.'
     );
 
-    whenUpgradedToCustomElement(storyEl).then(() => {
-      storyEl.getImpl().then(
+    whenUpgradedToCustomElement(storyEl)
+      .then(() => storyEl.getImpl())
+      .then(
         (storyImpl) => {
           this.mediaPoolResolveFn_(MediaPool.for(storyImpl));
         },
         (reason) => this.mediaPoolRejectFn_(reason)
       );
-    });
   }
 
   /**

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -412,9 +412,7 @@ export class AmpStoryPage extends AMP.BaseElement {
     whenUpgradedToCustomElement(storyEl)
       .then(() => storyEl.getImpl())
       .then(
-        (storyImpl) => {
-          this.mediaPoolResolveFn_(MediaPool.for(storyImpl));
-        },
+        (storyImpl) => this.mediaPoolResolveFn_(MediaPool.for(storyImpl)),
         (reason) => this.mediaPoolRejectFn_(reason)
       );
   }

--- a/extensions/amp-story/1.0/test/test-amp-story-grid-layer.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-grid-layer.js
@@ -57,7 +57,9 @@ describes.realWin('amp-story-grid-layer', {amp: true}, (env) => {
     });
 
     const story = win.document.createElement('amp-story');
+    // Makes whenUpgradedToCustomElement() resolve immediately.
     story.getImpl = () => Promise.resolve(mediaPoolRoot);
+    story.createdCallback = Promise.resolve();
 
     element = win.document.createElement('amp-story-page');
     gridLayerEl = win.document.createElement('amp-story-grid-layer');

--- a/extensions/amp-story/1.0/test/test-amp-story-grid-layer.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-grid-layer.js
@@ -57,8 +57,8 @@ describes.realWin('amp-story-grid-layer', {amp: true}, (env) => {
     });
 
     const story = win.document.createElement('amp-story');
-    // Makes whenUpgradedToCustomElement() resolve immediately.
     story.getImpl = () => Promise.resolve(mediaPoolRoot);
+    // Makes whenUpgradedToCustomElement() resolve immediately.
     story.createdCallback = Promise.resolve();
 
     element = win.document.createElement('amp-story-page');

--- a/extensions/amp-story/1.0/test/test-amp-story-page.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-page.js
@@ -72,8 +72,8 @@ describes.realWin('amp-story-page', {amp: {extensions}}, (env) => {
     });
 
     const story = win.document.createElement('amp-story');
-    // Makes whenUpgradedToCustomElement() resolve immediately.
     story.getImpl = () => Promise.resolve(mediaPoolRoot);
+    // Makes whenUpgradedToCustomElement() resolve immediately.
     story.createdCallback = Promise.resolve();
 
     element = win.document.createElement('amp-story-page');

--- a/extensions/amp-story/1.0/test/test-amp-story-page.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-page.js
@@ -72,7 +72,9 @@ describes.realWin('amp-story-page', {amp: {extensions}}, (env) => {
     });
 
     const story = win.document.createElement('amp-story');
+    // Makes whenUpgradedToCustomElement() resolve immediately.
     story.getImpl = () => Promise.resolve(mediaPoolRoot);
+    story.createdCallback = Promise.resolve();
 
     element = win.document.createElement('amp-story-page');
     gridLayerEl = win.document.createElement('amp-story-grid-layer');


### PR DESCRIPTION
Fixes https://github.com/ampproject/error-reporting/issues/13

GetImpl is being called without waiting for the custom element to load so sometimes the getImpl doesn't exist for the story.