### PR TITLE
carousel: remove onViewportCallback

### DIFF
--- a/extensions/amp-carousel/0.1/base-carousel.js
+++ b/extensions/amp-carousel/0.1/base-carousel.js
@@ -56,18 +56,10 @@ export class BaseCarousel extends AMP.BaseElement {
 
   /** @override */
   viewportCallback(inViewport) {
-    this.onViewportCallback(inViewport);
     if (inViewport) {
       this.hintControls();
     }
   }
-
-  /**
-   * Handles element specific viewport based events.
-   * @param {boolean} unusedInViewport
-   * @protected
-   */
-  onViewportCallback(unusedInViewport) {}
 
   /**
    * Builds a carousel button for next/prev.

--- a/extensions/amp-carousel/0.1/base-slides.js
+++ b/extensions/amp-carousel/0.1/base-slides.js
@@ -95,8 +95,8 @@ export class BaseSlides extends BaseCarousel {
   }
 
   /** @override */
-  onViewportCallback(inViewport) {
-    this.updateViewportState(inViewport);
+  viewportCallback(inViewport) {
+    super.viewportCallback(inViewport);
     if (inViewport) {
       this.autoplay_();
     } else {
@@ -125,13 +125,6 @@ export class BaseSlides extends BaseCarousel {
   moveSlide(unusedDir, unusedAnimate, unusedTrust) {
     // Subclasses may override.
   }
-
-  /**
-   * Updates the viewport state when there is a viewport callback.
-   * @param {boolean} unusedInViewport
-   * @protected
-   */
-  updateViewportState(unusedInViewport) {}
 
   /**
    * Checks if a carousel is eligible to loop, regardless of the loop attribute.

--- a/extensions/amp-carousel/0.1/scrollable-carousel.js
+++ b/extensions/amp-carousel/0.1/scrollable-carousel.js
@@ -118,7 +118,8 @@ export class AmpScrollableCarousel extends BaseCarousel {
   }
 
   /** @override */
-  onViewportCallback(unusedInViewport) {
+  viewportCallback(inViewport) {
+    super.viewportCallback(inViewport);
     this.updateInViewport_(this.pos_, this.pos_);
   }
 

--- a/extensions/amp-carousel/0.1/slidescroll.js
+++ b/extensions/amp-carousel/0.1/slidescroll.js
@@ -352,7 +352,8 @@ export class AmpSlideScroll extends BaseSlides {
   }
 
   /** @override */
-  updateViewportState(inViewport) {
+  viewportCallback(inViewport) {
+    super.viewportCallback(inViewport);
     if (this.slideIndex_ !== null) {
       Services.ownersForDoc(this.element).updateInViewport(
         this.element,

--- a/extensions/amp-carousel/0.1/test/test-base-slide.js
+++ b/extensions/amp-carousel/0.1/test/test-base-slide.js
@@ -35,7 +35,7 @@ import {BaseSlides} from '../base-slides';
 describes.fakeWin('BaseSlides', {amp: true}, (env) => {
   let win, doc;
   let buildSlidesSpy;
-  let onViewportCallbackSpy;
+  let viewportCallbackSpy;
   let hasPrevSpy;
   let hasNextSpy;
   let goCallbackSpy;
@@ -52,7 +52,7 @@ describes.fakeWin('BaseSlides', {amp: true}, (env) => {
     win = env.win;
     doc = win.document;
     buildSlidesSpy = env.sandbox.spy();
-    onViewportCallbackSpy = env.sandbox.spy();
+    viewportCallbackSpy = env.sandbox.spy();
     hasPrevSpy = env.sandbox.spy();
     hasNextSpy = env.sandbox.spy();
     goCallbackSpy = env.sandbox.spy();
@@ -66,9 +66,9 @@ describes.fakeWin('BaseSlides', {amp: true}, (env) => {
     hintControlsSpy = env.sandbox.spy(BaseSlides.prototype, 'hintControls');
     autoplaySpy = env.sandbox.spy(BaseSlides.prototype, 'autoplay_');
     clearAutoplaySpy = env.sandbox.spy(BaseSlides.prototype, 'clearAutoplay');
-    onViewportCallbackSpy = env.sandbox.spy(
+    viewportCallbackSpy = env.sandbox.spy(
       BaseSlides.prototype,
-      'onViewportCallback'
+      'viewportCallback'
     );
   });
 
@@ -175,7 +175,7 @@ describes.fakeWin('BaseSlides', {amp: true}, (env) => {
     );
 
     carousel.viewportCallback(true);
-    expect(onViewportCallbackSpy).to.have.been.calledWith(true);
+    expect(viewportCallbackSpy).to.have.been.calledWith(true);
     expect(hintControlsSpy).to.have.been.called;
     expect(autoplaySpy).to.have.been.called;
     expect(clearAutoplaySpy).to.not.have.been.called;
@@ -190,7 +190,7 @@ describes.fakeWin('BaseSlides', {amp: true}, (env) => {
     );
 
     carousel.viewportCallback(false);
-    expect(onViewportCallbackSpy).to.have.been.calledWith(false);
+    expect(viewportCallbackSpy).to.have.been.calledWith(false);
     expect(hintControlsSpy).to.not.have.been.called;
     expect(autoplaySpy).to.not.have.been.called;
     expect(clearAutoplaySpy).to.have.been.called;


### PR DESCRIPTION
**summary**
While working on removing `viewportCallback` (https://github.com/ampproject/amphtml/issues/30620), I noticed this extraneous lifecycle hook within amp-carousel 0.1 components. It was basically manual inheritance and may as well take advantage of actual inheritance instead.

**testing**
- [x] manual testing, sanity check clicking through carousels within example/. Will do before merge.
