### PR TITLE
Remove viewportCallback from amp-video

### DIFF
--- a/extensions/amp-video/0.1/amp-video.js
+++ b/extensions/amp-video/0.1/amp-video.js
@@ -192,6 +192,11 @@ class AmpVideo extends AMP.BaseElement {
     const {element} = this;
 
     this.configure_();
+    this.intersectionObserver_ = new IntersectionObserver(entries => {
+      const visible = entries[entries.length-1].isIntersecting;
+      this.element.dispatchCustomEvent(VideoEvents.VISIBILITY, {visible}); 
+    })
+    this.intersectionObserver_.observe(element);
 
     this.video_ = element.ownerDocument.createElement('video');
     if (this.element.querySelector('source[data-bitrate]')) {
@@ -292,11 +297,6 @@ class AmpVideo extends AMP.BaseElement {
     // TODO(@aghassemi, 10756) Either make metadata observable or submit
     // an event indicating metadata changed (in case metadata changes
     // while the video is playing).
-  }
-
-  /** @override */
-  viewportCallback(visible) {
-    this.element.dispatchCustomEvent(VideoEvents.VISIBILITY, {visible});
   }
 
   /** @override */


### PR DESCRIPTION
**summary**
There are 11 video AMP Components that use `viewportCallback` in exactly the same way as `<amp-video>`. This PR is meant to help establish a pattern for removing the callback in favor of IntersectionObserver.

Questions to answer:
- Is it better to have an InOb per component instance, or should we have a singular ViewportInOb singleton provided by Runtime and reused by all components?
- Is there any reason to call `unobserve` when component is unlaid out?
-  (question for another time) Are there any consumers of `VideoEvents.VISIBILITY` other than AMP? Can we wholly remove this event?

Partial for: https://github.com/ampproject/amphtml/issues/30620