### PR TITLE
🔥 Include AbortController in ESM polyfills

### DIFF
--- a/build-system/compile/compile.js
+++ b/build-system/compile/compile.js
@@ -186,7 +186,11 @@ function compile(
         // custom-elements polyfill must be included.
         // install intersection-observer to esm build as iOS safari 11.1 to
         // 12.1 do not have InObs.
-        return !['custom-elements.js', 'intersection-observer.js'].includes(p);
+        return ![
+          'abort-controller.js',
+          'custom-elements.js',
+          'intersection-observer.js',
+        ].includes(p);
       });
       srcs.push(
         '!build/fake-module/src/polyfills.js',


### PR DESCRIPTION
This includes `AbortController` in the approved ESM polyfills.

For some reason, ESM polyfills are still stripped in the build-system code _and_ in source code (via `IS_ESM` guards), so when I added `AbortController` with only the source code it was still stripped by the build system.