### PR TITLE
resources-impl: fix alwayFixed

### DIFF
--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -348,7 +348,8 @@ export class Resource {
         if (this.intersect_ && this.hasBeenMeasured()) {
           this.state_ = ResourceState.READY_FOR_LAYOUT;
           // The InOb premeasurement couldn't account for fixed position since
-          // implementation wasn't loaded yet. Do so now.
+          // implementation wasn't loaded yet. Perform a remeasure now that we know it
+          // is fixed.
           if (this.element.isAlwaysFixed() && !this.isFixed_) {
             this.requestMeasure();
           }

--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -350,7 +350,7 @@ export class Resource {
           // The InOb premeasurement couldn't account for fixed position since
           // implementation wasn't loaded yet. Do so now.
           if (this.element.isAlwaysFixed()) {
-            this.computeMeasurements_(this.layoutBox);
+            this.computeMeasurements_(this.getPageLayoutBox());
           }
           this.element.onMeasure(/* sizeChanged */ true);
         } else {

--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -349,8 +349,8 @@ export class Resource {
           this.state_ = ResourceState.READY_FOR_LAYOUT;
           // The InOb premeasurement couldn't account for fixed position since
           // implementation wasn't loaded yet. Do so now.
-          if (this.element.isAlwaysFixed()) {
-            this.computeMeasurements_(this.getPageLayoutBox());
+          if (this.element.isAlwaysFixed() && !this.isFixed_) {
+            this.requestMeasure();
           }
           this.element.onMeasure(/* sizeChanged */ true);
         } else {

--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -347,6 +347,11 @@ export class Resource {
         // so check if we're "ready for layout" (measured and built) here.
         if (this.intersect_ && this.hasBeenMeasured()) {
           this.state_ = ResourceState.READY_FOR_LAYOUT;
+          // The InOb premeasurement couldn't account for fixed position since
+          // implementation wasn't loaded yet. Do so now.
+          if (this.element.isAlwaysFixed()) {
+            this.computeMeasurements_(this.layoutBox);
+          }
           this.element.onMeasure(/* sizeChanged */ true);
         } else {
           this.state_ = ResourceState.NOT_LAID_OUT;

--- a/test/unit/test-resource.js
+++ b/test/unit/test-resource.js
@@ -122,25 +122,20 @@ describes.realWin('Resource', {amp: true}, (env) => {
       });
     });
 
-    it('should recalculate layoutBox if measured before upgrade and isFixed', () => {
+    it('should remeasure if measured before upgrade and isFixed', () => {
       // First measure
       element.isAlwaysFixed = () => false;
       resource.premeasure({left: 0, top: 0, width: 100, height: 100});
       resource.measure(/* usePremeasuredRect */ true);
-      expect(resource.getLayoutBox()).to.eql(layoutRectLtwh(0, 0, 100, 100));
 
       // Now adjust implementation to be alwaysFixed and call build.
-      const viewport = Services.viewportForDoc(resource.element);
-      env.sandbox.stub(viewport, 'getScrollTop').returns(11);
       element.isUpgraded = () => true;
       element.isAlwaysFixed = () => true;
       element.build = () => Promise.resolve();
       element.onMeasure = () => {};
+      resource.requestMeasure = env.sandbox.stub();
       return resource.build().then(() => {
-        expect(resource.getLayoutBox()).to.eql(layoutRectLtwh(0, 11, 100, 100));
-        expect(resource.getPageLayoutBox()).to.eql(
-          layoutRectLtwh(0, 0, 100, 100)
-        );
+        expect(resource.requestMeasure).calledOnce;
       });
     });
   });

--- a/test/unit/test-resource.js
+++ b/test/unit/test-resource.js
@@ -121,6 +121,28 @@ describes.realWin('Resource', {amp: true}, (env) => {
         expect(resource.getState()).to.equal(ResourceState.READY_FOR_LAYOUT);
       });
     });
+
+    it('should recalculate layoutBox if measured before upgrade and isFixed', () => {
+      // First measure
+      element.isAlwaysFixed = () => false;
+      resource.premeasure({left: 0, top: 0, width: 100, height: 100});
+      resource.measure(/* usePremeasuredRect */ true);
+      expect(resource.getLayoutBox()).to.eql(layoutRectLtwh(0, 0, 100, 100));
+
+      // Now adjust implementation to be alwaysFixed and call build.
+      const viewport = Services.viewportForDoc(resource.element);
+      env.sandbox.stub(viewport, 'getScrollTop').returns(11);
+      element.isUpgraded = () => true;
+      element.isAlwaysFixed = () => true;
+      element.build = () => Promise.resolve();
+      element.onMeasure = () => {};
+      return resource.build().then(() => {
+        expect(resource.getLayoutBox()).to.eql(layoutRectLtwh(0, 11, 100, 100));
+        expect(resource.getPageLayoutBox()).to.eql(
+          layoutRectLtwh(0, 0, 100, 100)
+        );
+      });
+    });
   });
 
   it('should build if element is currently building', () => {


### PR DESCRIPTION
Fixes https://github.com/ampproject/amphtml/issues/30379.

Affected components: 
- amp-addthis
- amp-analytics
- amp-bind-macro
- amp-state
- amp-sticky-ad
- amp-user-notifications

Root cause is related to `intersect-resources` experiment. Since measurement can (and often will) occur before the extension loads, measurement is then done while still a stub. At that moment, `isAlwaysFixed` is always false.

Therefore layoutBox computations were not adjusted for `position:fixed` and components would not be laid out. Band-aid fix in this PR is to recompute measurements once the extension loads using the same computed rect as earlier (but now taking the fixed position into account).

Future work: instead of relying upon some notion like `isAlwaysFixed`, we should have a simpler flag for `shouldAlwaysLayout` that doesn't need to fan out into more computations 