### PR TITLE
✅ Aggregate coverage during testing and report after

### DIFF
--- a/build-system/tasks/e2e/describes-e2e.js
+++ b/build-system/tasks/e2e/describes-e2e.js
@@ -19,8 +19,8 @@ require('geckodriver');
 
 const argv = require('minimist')(process.argv.slice(2));
 const chrome = require('selenium-webdriver/chrome');
+const fetch = require('node-fetch');
 const firefox = require('selenium-webdriver/firefox');
-const http = require('http');
 const puppeteer = require('puppeteer');
 const {
   clearLastExpectError,
@@ -356,23 +356,10 @@ async function collectCoverage(env) {
  */
 async function reportCoverage() {
   const coverage = getCoverageObject();
-  await new Promise((resolve, reject) => {
-    const req = http.request(
-      {
-        host: HOST,
-        port: PORT,
-        path: COV_REPORT_PATH,
-        method: 'POST',
-        headers: {'Content-type': 'application/json'},
-      },
-      (res) => {
-        res.on('data', () => {});
-        res.on('end', resolve);
-        res.on('error', reject);
-      }
-    );
-    req.write(JSON.stringify(coverage));
-    req.end();
+  await fetch(`https://${HOST}:${PORT}${COV_REPORT_PATH}`, {
+    method: 'POST',
+    body: JSON.stringify(coverage),
+    headers: {'Content-type': 'application/json'},
   });
 }
 

--- a/build-system/tasks/e2e/describes-e2e.js
+++ b/build-system/tasks/e2e/describes-e2e.js
@@ -343,7 +343,7 @@ class ItConfig {
  * @param {!Object} env e2e driver environment.
  * @return {Promise<void>}
  */
-async function collectCoverage(env) {
+async function updateCoverage(env) {
   const coverage = await env.controller.evaluate(() => window.__coverage__);
   if (coverage) {
     mergeClientCoverage(coverage);
@@ -467,7 +467,7 @@ function describeEnv(factory) {
 
       afterEach(async function () {
         if (argv.coverage) {
-          await collectCoverage(env);
+          await updateCoverage(env);
         }
 
         // If there is an async expect error, throw it in the final state.


### PR DESCRIPTION
Hooks into the `istanbul-middleware/lib/core` module to directly merge coverage objects extracted from the page after each test, and reports them all at once at the end of the e2e test suite.