### PR TITLE
🏗 Remove includeOnlyESMLevelPolyfills

### DIFF
--- a/build-system/compile/bundles.config.js
+++ b/build-system/compile/bundles.config.js
@@ -186,7 +186,6 @@ exports.jsBundles = {
       includePolyfills: true,
       wrapper: wrappers.mainBinary,
       esmPassCompilation: argv.esm || argv.sxg,
-      includeOnlyESMLevelPolyfills: argv.esm || argv.sxg,
     },
   },
   'amp-shadow.js': {

--- a/build-system/compile/compile.js
+++ b/build-system/compile/compile.js
@@ -180,34 +180,7 @@ function compile(
     // Many files include the polyfills, but we only want to deliver them
     // once. Since all files automatically wait for the main binary to load
     // this works fine.
-    if (options.includeOnlyESMLevelPolyfills) {
-      const polyfills = fs.readdirSync('src/polyfills');
-      const polyfillsShadowList = polyfills.filter((p) => {
-        // custom-elements polyfill must be included.
-        // install intersection-observer to esm build as iOS safari 11.1 to
-        // 12.1 do not have InObs.
-        return ![
-          'abort-controller.js',
-          'custom-elements.js',
-          'intersection-observer.js',
-        ].includes(p);
-      });
-      srcs.push(
-        '!build/fake-module/src/polyfills.js',
-        '!build/fake-module/src/polyfills/**/*.js',
-        '!build/fake-polyfills/src/polyfills.js',
-        'src/polyfills/custom-elements.js',
-        'src/polyfills/intersection-observer.js',
-        'build/fake-polyfills/**/*.js'
-      );
-      polyfillsShadowList.forEach((polyfillFile) => {
-        srcs.push(`!src/polyfills/${polyfillFile}`);
-        fs.writeFileSync(
-          'build/fake-polyfills/src/polyfills/' + polyfillFile,
-          'export function install() {}'
-        );
-      });
-    } else if (options.includePolyfills) {
+    if (options.includePolyfills) {
       srcs.push(
         '!build/fake-module/src/polyfills.js',
         '!build/fake-module/src/polyfills/**/*.js',


### PR DESCRIPTION
All polyfills are already guarded by `IS_ESM` and `IS_SXG` checks already, so an additional build-time removal is not necessary anymore.