### PR TITLE
📖 Update Cherry-pick template with QA section

### DIFF
--- a/.github/ISSUE_TEMPLATE/cherry_pick_template.md
+++ b/.github/ISSUE_TEMPLATE/cherry_pick_template.md
@@ -2,10 +2,10 @@
 name: Cherry-pick request
 about: Used to request a cherry-pick. See go.amp.dev/cherry-picks
 title: "\U0001F338 Cherry-pick request for #<ISSUE_NUMBER> into #<RELEASE_ISSUE> (Pending)"
-labels:
-  'Cherry-pick: Beta, Cherry-pick: Experimental, Cherry-pick: LTS, Cherry-pick: Stable, Type:
-  Release'
+labels: 'Cherry-pick: Beta, Cherry-pick: Experimental, Cherry-pick: LTS, Cherry-pick:
+  Stable, Type: Release'
 assignees: ''
+
 ---
 
 <!--
@@ -48,6 +48,10 @@ CONDITION: Cherry-picking into LTS. Otherwise, delete.
 ## Why is an LTS cherry-pick needed?
 
 <_YOUR_REASONS_>
+
+## List the steps to manually verify the changes in this cherry-pick
+
+<_TEST_STEPS_>
 
 <!--
 MUST: Filling out the mini-PM template is required _after_ the deployment of a stable cherry-pick. If this cherry-pick does not include stable, the mini-PM section can be deleted.

--- a/.github/ISSUE_TEMPLATE/page-experience.md
+++ b/.github/ISSUE_TEMPLATE/page-experience.md
@@ -1,7 +1,7 @@
 ---
-name: Page experience 
+name: Page experience
 about: Used to report issues where AMP pages don't meet page experience criteria.
-title: "Page experience issue"
+title: Page experience issue
 labels: 'Type: Page experience'
 assignees: ''
 

--- a/.github/ISSUE_TEMPLATE/release-tracking-issue.md
+++ b/.github/ISSUE_TEMPLATE/release-tracking-issue.md
@@ -1,11 +1,11 @@
 ---
 name: Release tracking issue
-about:
-  Create a tracking issue for a new AMP release (to be used by release on-duty
+about: Create a tracking issue for a new AMP release (to be used by release on-duty
   engineers)
 title: "\U0001F684 Release tracking issue for release <RELEASE_NUMBER>"
 labels: 'Type: Release'
 assignees: ''
+
 ---
 
 # Release tracking issue


### PR DESCRIPTION
This PR adds a new section to the CP template to enable AMP's QA expert to verify changes after they are cherry-picked.