### PR TITLE
Reimplement loading indicator via IntersectionObserver

### DIFF
--- a/extensions/amp-animation/0.1/test/test-amp-animation.js
+++ b/extensions/amp-animation/0.1/test/test-amp-animation.js
@@ -33,9 +33,13 @@ describes.sandboxed('AmpAnimation', {}, (env) => {
         ioCallback = callback;
         ioCallbacks.push(callback);
       }
-      observe() {
+      observe(target) {
         ioCallback([
-          {isIntersecting: (config && config.isIntersecting) ?? true},
+          {
+            target,
+            isIntersecting: (config && config.isIntersecting) ?? true,
+            boundingClientRect: target.getBoundingClientRect(),
+          },
         ]);
       }
       unobserve() {}
@@ -65,9 +69,15 @@ describes.sandboxed('AmpAnimation', {}, (env) => {
     return element.build().then(() => element.implementation_);
   }
 
-  function updateIntersection(isIntersecting) {
+  function updateIntersection(target, isIntersecting) {
     ioCallbacks.forEach((callback) => {
-      callback([{isIntersecting}]);
+      callback([
+        {
+          target,
+          isIntersecting,
+          boundingClientRect: target.getBoundingClientRect(),
+        },
+      ]);
     });
   }
 
@@ -176,7 +186,7 @@ describes.sandboxed('AmpAnimation', {}, (env) => {
         viewer.setVisibilityState_('visible');
         expect(anim.visible_).to.be.false;
 
-        updateIntersection(true);
+        updateIntersection(anim.element.parentElement, true);
         expect(anim.visible_).to.be.true;
       });
 

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -654,10 +654,10 @@ export class AmpList extends AMP.BaseElement {
     ) {
       const reset = () => {
         this.togglePlaceholder(true);
-        const ignoreLoadingState = this.element.hasAttribute(
+        const forceLoadingIndicator = this.element.hasAttribute(
           'reset-on-refresh'
         );
-        this.toggleLoading(true, ignoreLoadingState);
+        this.toggleLoading(true, forceLoadingIndicator);
         this.toggleFallback_(false);
         // Clean up bindings in children before removing them from DOM.
         if (this.bind_) {

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -565,15 +565,6 @@ export class AmpList extends AMP.BaseElement {
   }
 
   /**
-   * amp-list reuses the loading indicator when the list is fetched again via
-   * bind mutation or refresh action
-   * @override
-   */
-  isLoadingReused() {
-    return this.element.hasAttribute('reset-on-refresh');
-  }
-
-  /**
    * Creates and returns <div> that contains the template-rendered children.
    * @return {!Element}
    * @private
@@ -663,7 +654,10 @@ export class AmpList extends AMP.BaseElement {
     ) {
       const reset = () => {
         this.togglePlaceholder(true);
-        this.toggleLoading(true);
+        const ignoreLoadingState = this.element.hasAttribute(
+          'reset-on-refresh'
+        );
+        this.toggleLoading(true, ignoreLoadingState);
         this.toggleFallback_(false);
         // Clean up bindings in children before removing them from DOM.
         if (this.bind_) {

--- a/extensions/amp-list/0.1/test/test-amp-list.js
+++ b/extensions/amp-list/0.1/test/test-amp-list.js
@@ -174,7 +174,10 @@ describes.repeated(
           // If "reset-on-refresh" is set, show loading/placeholder before fetch.
           if (opts.resetOnRefresh) {
             listMock.expects('togglePlaceholder').withExactArgs(true).once();
-            listMock.expects('toggleLoading').withExactArgs(true).once();
+            listMock
+              .expects('toggleLoading')
+              .withExactArgs(true, opts.resetOnRefresh)
+              .once();
           }
 
           // Stub the rendering of the template.
@@ -1257,7 +1260,10 @@ describes.repeated(
               listMock.expects('fetchList_').never();
               // Expect display of placeholder/loading before render.
               listMock.expects('togglePlaceholder').withExactArgs(true).once();
-              listMock.expects('toggleLoading').withExactArgs(true).once();
+              listMock
+                .expects('toggleLoading')
+                .withExactArgs(true, true)
+                .once();
               // Expect hiding of placeholder/loading after render.
               listMock.expects('togglePlaceholder').withExactArgs(false).once();
               listMock.expects('toggleLoading').withExactArgs(false).once();

--- a/extensions/amp-twitter/0.1/amp-twitter.js
+++ b/extensions/amp-twitter/0.1/amp-twitter.js
@@ -193,7 +193,7 @@ class AmpTwitter extends AMP.BaseElement {
   mutatedAttributesCallback(mutations) {
     if (this.iframe_ && mutations['data-tweetid'] != null) {
       this.unlayoutCallback();
-      this.toggleLoading(true, /* ignoreLoadingState */ true);
+      this.toggleLoading(true, /* force */ true);
       this.layoutCallback();
     }
   }

--- a/extensions/amp-twitter/0.1/amp-twitter.js
+++ b/extensions/amp-twitter/0.1/amp-twitter.js
@@ -154,14 +154,6 @@ class AmpTwitter extends AMP.BaseElement {
     });
   }
 
-  /**
-   * amp-twitter reuses the loading indicator when id changes via bind mutation
-   * @override
-   */
-  isLoadingReused() {
-    return true;
-  }
-
   /** @override */
   createLoaderLogoCallback() {
     const html = htmlFor(this.element);
@@ -201,7 +193,7 @@ class AmpTwitter extends AMP.BaseElement {
   mutatedAttributesCallback(mutations) {
     if (this.iframe_ && mutations['data-tweetid'] != null) {
       this.unlayoutCallback();
-      this.toggleLoading(true);
+      this.toggleLoading(true, /* ignoreLoadingState */ true);
       this.layoutCallback();
     }
   }

--- a/src/base-element.js
+++ b/src/base-element.js
@@ -698,20 +698,11 @@ export class BaseElement {
   /**
    * Hides or shows the loading indicator.
    * @param {boolean} state
+   * @param {boolean=} ignoreLoadingState
    * @public @final
    */
-  toggleLoading(state) {
-    this.element.toggleLoading(state);
-  }
-
-  /**
-   * Returns whether the loading indicator is reused again after the first
-   * render.
-   * @return {boolean}
-   * @public
-   */
-  isLoadingReused() {
-    return false;
+  toggleLoading(state, ignoreLoadingState = false) {
+    this.element.toggleLoading(state, ignoreLoadingState);
   }
 
   /**

--- a/src/base-element.js
+++ b/src/base-element.js
@@ -698,11 +698,11 @@ export class BaseElement {
   /**
    * Hides or shows the loading indicator.
    * @param {boolean} state
-   * @param {boolean=} ignoreLoadingState
+   * @param {boolean=} force
    * @public @final
    */
-  toggleLoading(state, ignoreLoadingState = false) {
-    this.element.toggleLoading(state, ignoreLoadingState);
+  toggleLoading(state, force = false) {
+    this.element.toggleLoading(state, force);
   }
 
   /**

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -934,6 +934,7 @@ function createBaseCustomElementClass(win) {
       this.isConnected_ = false;
       this.getResources().remove(this);
       this.implementation_.detachedCallback();
+      this.toggleLoading(false);
     }
 
     /**

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -34,17 +34,15 @@ import {
   isBlockedByConsent,
   reportError,
 } from './error';
-import {createLoaderElement} from '../src/loader.js';
 import {dev, devAssert, rethrowAsync, user, userAssert} from './log';
 import {getIntersectionChangeEntry} from './utils/intersection-observer-3p-host';
 import {getMode} from './mode';
-import {htmlFor} from './static-template';
 import {parseSizeList} from './size-list';
 import {setStyle} from './style';
-import {shouldBlockOnConsentByMeta} from '../src/consent';
+import {shouldBlockOnConsentByMeta} from './consent';
 import {startupChunk} from './chunk';
 import {toWin} from './types';
-import {tryResolve} from '../src/utils/promise';
+import {tryResolve} from './utils/promise';
 
 const TAG = 'CustomElement';
 
@@ -194,18 +192,6 @@ function createBaseCustomElementClass(win) {
        * @package {?Element|undefined}
        */
       this.sizerElement = undefined;
-
-      /** @private {boolean|undefined} */
-      this.loadingDisabled_ = undefined;
-
-      /** @private {boolean|undefined} */
-      this.loadingState_ = undefined;
-
-      /** @private {?Element} */
-      this.loadingContainer_ = null;
-
-      /** @private {?Element} */
-      this.loadingElement_ = null;
 
       /** @private {?Element|undefined} */
       this.overflowElement_ = undefined;
@@ -838,8 +824,6 @@ function createBaseCustomElementClass(win) {
         if (!this.isUpgraded()) {
           this.classList.add('amp-unresolved');
           this.classList.add('i-amphtml-unresolved');
-          // amp:attached is dispatched from the ElementStub class when it
-          // replayed the firstAttachedCallback call.
           this.dispatchCustomEventForTesting(AmpEvents.STUBBED);
         }
         // Classically, sizes/media queries are applied just before
@@ -850,6 +834,8 @@ function createBaseCustomElementClass(win) {
           this.applySizesAndMediaQuery();
         }
       }
+
+      this.toggleLoading(true);
     }
 
     /**
@@ -1161,6 +1147,9 @@ function createBaseCustomElementClass(win) {
         this.getLayoutDelayMeter_().startLayout();
       }
 
+      // Potentially start the loading indicator.
+      this.toggleLoading(true);
+
       const promise = tryResolve(() => this.implementation_.layoutCallback());
       this.preconnect(/* onLayout */ true);
       this.classList.add('i-amphtml-layout');
@@ -1175,7 +1164,7 @@ function createBaseCustomElementClass(win) {
           }
           this.readyState = 'complete';
           this.layoutCount_++;
-          this.toggleLoading(false, {cleanup: true});
+          this.toggleLoading(false);
           // Check if this is the first success layout that needs
           // to call firstLayoutCompleted.
           if (!this.isFirstLayoutCompleted_) {
@@ -1196,7 +1185,7 @@ function createBaseCustomElementClass(win) {
             );
           }
           this.layoutCount_++;
-          this.toggleLoading(false, {cleanup: true});
+          this.toggleLoading(false);
           throw reason;
         }
       );
@@ -1231,28 +1220,6 @@ function createBaseCustomElementClass(win) {
         return;
       }
       this.isInViewport_ = inViewport;
-      if (this.layoutCount_ == 0) {
-        if (!inViewport) {
-          this.toggleLoading(false);
-        } else {
-          // Set a minimum delay in case the element loads very fast or if it
-          // leaves the viewport.
-          const loadingStartTime = win.Date.now();
-          Services.timerFor(toWin(this.ownerDocument.defaultView)).delay(() => {
-            // TODO(dvoytenko, #9177): cleanup `this.ownerDocument.defaultView`
-            // once investigation is complete. It appears that we get a lot of
-            // errors here once the iframe is destroyed due to timer.
-            if (
-              this.isInViewport_ &&
-              this.ownerDocument &&
-              this.ownerDocument.defaultView &&
-              this.layoutCount_ === 0 // Ensures that layoutCallback hasn't completed in this 100ms window.
-            ) {
-              this.toggleLoading(true, {startTime: loadingStartTime});
-            }
-          }, 100);
-        }
-      }
       if (this.isBuilt()) {
         this.updateInViewport_(inViewport);
       }
@@ -1622,10 +1589,11 @@ function createBaseCustomElementClass(win) {
 
     /**
      * Whether the loading can be shown for this element.
+     * @param {boolean} ignoreLoadingState
      * @return {boolean}
      * @private
      */
-    isLoadingEnabled_() {
+    isLoadingEnabled_(ignoreLoadingState) {
       // No loading indicator will be shown if either one of these conditions
       // true:
       // 1. The document is A4A.
@@ -1636,22 +1604,15 @@ function createBaseCustomElementClass(win) {
       // 5. The element has not been allowlisted;
       // 6. The element is an internal node (e.g. `placeholder` or `fallback`);
       // 7. The element's layout is not nodisplay.
-      if (this.isInA4A()) {
-        return false;
-      }
-      if (this.loadingDisabled_ === undefined) {
-        this.loadingDisabled_ = this.hasAttribute('noloading');
-      }
 
       const laidOut =
         this.layoutCount_ > 0 || this.signals_.get(CommonSignals.RENDER_START);
       if (
-        this.loadingDisabled_ ||
-        (laidOut && !this.implementation_.isLoadingReused()) ||
-        this.layoutWidth_ <= 0 || // Layout is not ready or invisible
+        this.layout_ == Layout.NODISPLAY ||
+        this.hasAttribute('noloading') ||
+        (laidOut && !ignoreLoadingState) ||
         !isLoadingAllowed(this) ||
-        isInternalOrServiceNode(this) ||
-        this.layout_ == Layout.NODISPLAY
+        isInternalOrServiceNode(this)
       ) {
         return false;
       }
@@ -1660,113 +1621,30 @@ function createBaseCustomElementClass(win) {
     }
 
     /**
-     * @return {boolean}
-     */
-    isInA4A() {
-      return (
-        // in FIE
-        (this.ampdoc_ && this.ampdoc_.win != this.ownerDocument.defaultView) ||
-        // TODO(#22733): cleanup once the ampdoc-fie is fully launched.
-        (this.ampdoc_ && !!this.ampdoc_.getParent()) ||
-        // in inabox
-        getMode().runtime == 'inabox'
-      );
-    }
-
-    /**
-     * Creates a loading object. The caller must ensure that loading can
-     * actually be shown. This method must also be called in the mutate
-     * context.
-     * @private
-     * @param {number=} startTime
-     */
-    prepareLoading_(startTime) {
-      if (!this.isLoadingEnabled_()) {
-        return;
-      }
-      if (!this.loadingContainer_) {
-        const doc = this.ownerDocument;
-        devAssert(doc);
-
-        const container = htmlFor(/** @type {!Document} */ (doc))`
-            <div class="i-amphtml-loading-container i-amphtml-fill-content
-              amp-hidden"></div>`;
-        const loadingElement = createLoaderElement(
-          this.getAmpDoc(),
-          this,
-          this.layoutWidth_,
-          this.layoutHeight_,
-          startTime
-        );
-
-        container.appendChild(loadingElement);
-
-        this.appendChild(container);
-        this.loadingContainer_ = container;
-        this.loadingElement_ = loadingElement;
-      }
-    }
-
-    /**
      * Turns the loading indicator on or off.
      * @param {boolean} state
-     * @param {{cleanup:(boolean|undefined), startTime:(number|undefined)}=} opt_options
+     * @param {boolean=} ignoreLoadingState
      * @public @final
      */
-    toggleLoading(state, opt_options) {
-      const cleanup = opt_options && opt_options.cleanup;
-      const startTime = opt_options && opt_options.startTime;
-      assertNotTemplate(this);
-
-      if (state === this.loadingState_ && !opt_options) {
-        // Loading state is the same.
-        return;
-      }
-      this.loadingState_ = state;
-      if (!state && !this.loadingContainer_) {
+    toggleLoading(state, ignoreLoadingState = false) {
+      // TODO(dvoytenko, #9177): cleanup `this.ownerDocument.defaultView`
+      // once investigation is complete. It appears that we get a lot of
+      // errors here once the iframe is destroyed due to timer.
+      if (!this.ownerDocument || !this.ownerDocument.defaultView) {
         return;
       }
 
-      // Check if loading should be shown.
-      if (state && !this.isLoadingEnabled_()) {
-        this.loadingState_ = false;
-        return;
-      }
-
-      this.mutateOrInvoke_(
-        () => {
-          let state = this.loadingState_;
-          // Repeat "loading enabled" check because it could have changed while
-          // waiting for vsync.
-          if (state && !this.isLoadingEnabled_()) {
-            state = false;
-          }
-          if (state) {
-            this.prepareLoading_(startTime);
-          }
-          if (!this.loadingContainer_) {
-            return;
-          }
-
-          this.loadingContainer_.classList.toggle('amp-hidden', !state);
-          this.loadingElement_.classList.toggle('amp-active', state);
-
-          if (!state && cleanup && !this.implementation_.isLoadingReused()) {
-            const loadingContainer = this.loadingContainer_;
-            this.loadingContainer_ = null;
-            this.loadingElement_ = null;
-            this.mutateOrInvoke_(
-              () => {
-                dom.removeElement(loadingContainer);
-              },
-              undefined,
-              true
-            );
-          }
-        },
-        undefined,
-        /* skipRemeasure */ true
+      const loadingIndicator = Services.loadingIndicatorOrNull(
+        this.getAmpDoc()
       );
+      if (loadingIndicator) {
+        state = state && this.isLoadingEnabled_(ignoreLoadingState);
+        if (state) {
+          loadingIndicator.track(this);
+        } else {
+          loadingIndicator.untrack(this);
+        }
+      }
     }
 
     /**

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -1590,11 +1590,11 @@ function createBaseCustomElementClass(win) {
 
     /**
      * Whether the loading can be shown for this element.
-     * @param {boolean} ignoreLoadingState
+     * @param {boolean} force
      * @return {boolean}
      * @private
      */
-    isLoadingEnabled_(ignoreLoadingState) {
+    isLoadingEnabled_(force) {
       // No loading indicator will be shown if either one of these conditions
       // true:
       // 1. The document is A4A.
@@ -1611,7 +1611,7 @@ function createBaseCustomElementClass(win) {
       if (
         this.layout_ == Layout.NODISPLAY ||
         this.hasAttribute('noloading') ||
-        (laidOut && !ignoreLoadingState) ||
+        (laidOut && !force) ||
         !isLoadingAllowed(this) ||
         isInternalOrServiceNode(this)
       ) {
@@ -1624,10 +1624,10 @@ function createBaseCustomElementClass(win) {
     /**
      * Turns the loading indicator on or off.
      * @param {boolean} state
-     * @param {boolean=} ignoreLoadingState
+     * @param {boolean=} force
      * @public @final
      */
-    toggleLoading(state, ignoreLoadingState = false) {
+    toggleLoading(state, force = false) {
       // TODO(dvoytenko, #9177): cleanup `this.ownerDocument.defaultView`
       // once investigation is complete. It appears that we get a lot of
       // errors here once the iframe is destroyed due to timer.
@@ -1639,7 +1639,7 @@ function createBaseCustomElementClass(win) {
         this.getAmpDoc()
       );
       if (loadingIndicator) {
-        state = state && this.isLoadingEnabled_(ignoreLoadingState);
+        state = state && this.isLoadingEnabled_(force);
         if (state) {
           loadingIndicator.track(this);
         } else {

--- a/src/service.js
+++ b/src/service.js
@@ -67,7 +67,7 @@ export class Disposable {
 export function getExistingServiceForDocInEmbedScope(element, id) {
   // TODO(#22733): completely remove this method once ampdoc-fie launches.
   // Resolve via the element's ampdoc.
-  return getServiceForDocOrNullInternal(element, id);
+  return getServiceForDocOrNull(element, id);
 }
 
 /**
@@ -216,12 +216,12 @@ export function getServiceForDoc(elementOrAmpDoc, id) {
 /**
  * Returns a service for the given id and ampdoc (a per-ampdoc singleton).
  * If service `id` is not registered, returns null.
- * @param {!Element|!ShadowRoot} element
+ * @param {!Element|!ShadowRoot|!./service/ampdoc-impl.AmpDoc} elementOrAmpDoc
  * @param {string} id
  * @return {?Object}
  */
-function getServiceForDocOrNullInternal(element, id) {
-  const ampdoc = getAmpdoc(element);
+export function getServiceForDocOrNull(elementOrAmpDoc, id) {
+  const ampdoc = getAmpdoc(elementOrAmpDoc);
   const holder = getAmpdocServiceHolder(ampdoc);
   if (isServiceRegistered(holder, id)) {
     return getServiceInternal(holder, id);

--- a/src/service/core-services.js
+++ b/src/service/core-services.js
@@ -28,6 +28,7 @@ import {installHistoryServiceForDoc} from './history-impl';
 import {installImg} from '../../builtins/amp-img';
 import {installInputService} from '../input';
 import {installLayout} from '../../builtins/amp-layout';
+import {installLoadingIndicatorForDoc} from './loading-indicator';
 import {installMutatorServiceForDoc} from './mutator-impl';
 import {installOwnersServiceForDoc} from './owners-impl';
 import {installPixel} from '../../builtins/amp-pixel';
@@ -141,4 +142,8 @@ function installAmpdocServicesInternal(ampdoc, isEmbedded) {
     : installStorageServiceForDoc(ampdoc);
   installGlobalNavigationHandlerForDoc(ampdoc);
   installGlobalSubmitListenerForDoc(ampdoc);
+  if (!isEmbedded) {
+    // Embeds do not show loading indicators.
+    installLoadingIndicatorForDoc(ampdoc);
+  }
 }

--- a/src/service/core-services.js
+++ b/src/service/core-services.js
@@ -143,7 +143,8 @@ function installAmpdocServicesInternal(ampdoc, isEmbedded) {
   installGlobalNavigationHandlerForDoc(ampdoc);
   installGlobalSubmitListenerForDoc(ampdoc);
   if (!isEmbedded) {
-    // Embeds do not show loading indicators.
+    // Embeds do not show loading indicators, since the whole embed is
+    // usually behind a parent loading indicator.
     installLoadingIndicatorForDoc(ampdoc);
   }
 }

--- a/src/service/loader-element.js
+++ b/src/service/loader-element.js
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-import {Services} from './services';
+import {Services} from '../services';
 
 /**
  * Gets a Promise for the LoaderService, initiating a request to download the
  * code.
- * @param {!./service/ampdoc-impl.AmpDoc} ampDoc
+ * @param {!./ampdoc-impl.AmpDoc} ampDoc
  * @param {!Element} element
- * @return {!Promise<!../extensions/amp-loader/0.1/amp-loader.LoaderService>}
+ * @return {!Promise<!../../extensions/amp-loader/0.1/amp-loader.LoaderService>}
  */
 function getLoaderServicePromise(ampDoc, element) {
   return Services.extensionsFor(ampDoc.win)
@@ -34,7 +34,7 @@ function getLoaderServicePromise(ampDoc, element) {
  *
  * Please see https://github.com/ampproject/amphtml/issues/20237 for details,
  * screenshots and various states of the new loader design.
- * @param {!./service/ampdoc-impl.AmpDoc} ampDoc
+ * @param {!./ampdoc-impl.AmpDoc} ampDoc
  * @param {!AmpElement} element
  * @param {number} elementWidth
  * @param {number} elementHeight

--- a/src/service/loading-indicator.js
+++ b/src/service/loading-indicator.js
@@ -1,0 +1,161 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as dom from '../dom';
+import {createLoaderElement} from './loader-element';
+import {htmlFor} from '../static-template';
+import {registerServiceBuilderForDoc} from '../service';
+
+const MIN_SIZE = 20;
+
+/**
+ * @typedef {{
+ *   shown: boolean,
+ *   loader: !Element,
+ *   container: !Element,
+ * }}
+ */
+let LoadingIndicatorStateDef;
+
+/**
+ * @param {!Node|!./ampdoc-impl.AmpDoc} nodeOrDoc
+ */
+export function installLoadingIndicatorForDoc(nodeOrDoc) {
+  registerServiceBuilderForDoc(
+    nodeOrDoc,
+    'loadingIndicator',
+    LoadingIndicatorImpl
+  );
+}
+
+/**
+ * @implements {../service.Disposable}
+ */
+export class LoadingIndicatorImpl {
+  /**
+   * @param {!./ampdoc-impl.AmpDoc} ampdoc
+   */
+  constructor(ampdoc) {
+    /** @private @const */
+    this.ampdoc_ = ampdoc;
+
+    const inViewport = this.inViewport_.bind(this);
+    /** @private @const {!IntersectionObserver} */
+    this.io_ = new ampdoc.win.IntersectionObserver((records) =>
+      /** @type {!Array<!IntersectionObserverEntry>} */ (records).forEach(
+        inViewport
+      )
+    );
+
+    /** @private @const {!WeakMap<!AmpElement, !LoadingIndicatorStateDef>} */
+    this.states_ = new WeakMap();
+  }
+
+  /** @override */
+  dispose() {
+    this.io_.disconnect();
+  }
+
+  /**
+   * @param {!AmpElement} element
+   */
+  track(element) {
+    this.io_.observe(element);
+  }
+
+  /**
+   * @param {!AmpElement} element
+   */
+  untrack(element) {
+    this.io_.unobserve(element);
+    this.cleanup_(element);
+  }
+
+  /**
+   * @param {!IntersectionObserverEntry} record
+   * @private
+   */
+  inViewport_(record) {
+    const {target, isIntersecting, boundingClientRect} = record;
+    const {width, height} = boundingClientRect;
+    const element = /** @type {!AmpElement} */ (target);
+
+    const show = isIntersecting && width > MIN_SIZE && height > MIN_SIZE;
+
+    let state = this.states_.get(element);
+    const isCurrentlyShown = (state && state.shown) || false;
+    if (show === isCurrentlyShown) {
+      // Loading state is the same.
+      return;
+    }
+
+    if (show && !state) {
+      state = this.createState_(element, width, height);
+      this.states_.set(element, state);
+    }
+    if (state) {
+      state.shown = show;
+      state.container.classList.toggle('amp-hidden', !show);
+      state.loader.classList.toggle('amp-active', show);
+    }
+  }
+
+  /**
+   * @param {!AmpElement} element
+   * @param {number} width
+   * @param {number} height
+   * @return {!LoadingIndicatorStateDef}
+   * @private
+   */
+  createState_(element, width, height) {
+    const startTime = Date.now();
+
+    const loader = createLoaderElement(
+      this.ampdoc_,
+      element,
+      width,
+      height,
+      startTime
+    );
+
+    const container = htmlFor(this.ampdoc_.win.document)`
+        <div class="i-amphtml-loading-container i-amphtml-fill-content
+            amp-hidden"></div>
+      `;
+    container.appendChild(loader);
+    element.appendChild(container);
+
+    return /** @type {!LoadingIndicatorStateDef} */ ({
+      shown: false,
+      loader,
+      container,
+    });
+  }
+
+  /**
+   * @param {!AmpElement} element
+   * @private
+   */
+  cleanup_(element) {
+    const state = this.states_.get(element);
+    if (!state) {
+      return;
+    }
+
+    this.states_.delete(element);
+    dom.removeElement(state.container);
+  }
+}

--- a/src/service/loading-indicator.js
+++ b/src/service/loading-indicator.js
@@ -59,11 +59,13 @@ export class LoadingIndicatorImpl {
         inViewport
       );
     const iframed = isIframed(win);
-    const root = iframed ? win.document : null;
     const rootMargin = '25%';
     // Classic IntersectionObserver doesn't support viewport tracking and
     // rootMargin in x-origin iframes (#25428). As of 1/2020, only Chrome 81+
     // supports it via {root: document}, which throws on other browsers.
+    const root = /** @type {?Element} */ (iframed
+      ? /** @type {*} */ (win.document)
+      : null);
     let io;
     try {
       io = new win.IntersectionObserver(ioCallback, {

--- a/src/service/loading-indicator.js
+++ b/src/service/loading-indicator.js
@@ -54,10 +54,12 @@ export class LoadingIndicatorImpl {
 
     const inViewport = this.inViewport_.bind(this);
     /** @private @const {!IntersectionObserver} */
-    this.io_ = new ampdoc.win.IntersectionObserver((records) =>
-      /** @type {!Array<!IntersectionObserverEntry>} */ (records).forEach(
-        inViewport
-      )
+    this.io_ = new ampdoc.win.IntersectionObserver(
+      (records) =>
+        /** @type {!Array<!IntersectionObserverEntry>} */ (records).forEach(
+          inViewport
+        ),
+      {rootMargin: '25%'}
     );
 
     /** @private @const {!WeakMap<!AmpElement, !LoadingIndicatorStateDef>} */
@@ -103,7 +105,7 @@ export class LoadingIndicatorImpl {
     }
 
     if (show && !state) {
-      state = this.createState_(element, width, height);
+      state = this.createLoaderState_(element, width, height);
       this.states_.set(element, state);
     }
     if (state) {
@@ -120,7 +122,7 @@ export class LoadingIndicatorImpl {
    * @return {!LoadingIndicatorStateDef}
    * @private
    */
-  createState_(element, width, height) {
+  createLoaderState_(element, width, height) {
     const startTime = Date.now();
 
     const loader = createLoaderElement(

--- a/src/services.js
+++ b/src/services.js
@@ -20,6 +20,7 @@ import {
   getExistingServiceOrNull,
   getService,
   getServiceForDoc,
+  getServiceForDocOrNull,
   getServicePromiseForDoc,
 } from './service';
 import {
@@ -350,6 +351,17 @@ export class Services {
       element,
       'inputmask',
       'amp-inputmask'
+    ));
+  }
+
+  /**
+   * @param {!Element|!./service/ampdoc-impl.AmpDoc} elementOrAmpDoc
+   * @return {?./service/loading-indicator.LoadingIndicatorImpl}
+   */
+  static loadingIndicatorOrNull(elementOrAmpDoc) {
+    return /** @type {?./service/loading-indicator.LoadingIndicatorImpl} */ (getServiceForDocOrNull(
+      elementOrAmpDoc,
+      'loadingIndicator'
     ));
   }
 

--- a/test/unit/test-amp-inabox.js
+++ b/test/unit/test-amp-inabox.js
@@ -18,6 +18,7 @@ import * as Service from '../../src/service';
 import {AmpDocSingle} from '../../src/service/ampdoc-impl';
 import {installAmpdocServices} from '../../src/service/core-services';
 import {installAmpdocServicesForInabox} from '../../src/inabox/inabox-services';
+import {removeItem} from '../../src/utils/array';
 
 describe('amp-inabox', () => {
   describes.realWin('installAmpdocServicesForInabox', {amp: false}, (env) => {
@@ -38,6 +39,8 @@ describe('amp-inabox', () => {
       installAmpdocServices(ampdoc);
 
       const installedServicesByRegularAmp = installedServices.slice(0);
+      // The inabox mode does not need the loading indicator.
+      removeItem(installedServicesByRegularAmp, 'loadingIndicator');
       installedServices = [];
       installAmpdocServicesForInabox(ampdoc);
       expect(installedServices).to.deep.equal(installedServicesByRegularAmp);

--- a/test/unit/test-custom-element.js
+++ b/test/unit/test-custom-element.js
@@ -490,29 +490,6 @@ describes.realWin('CustomElement', {amp: true}, (env) => {
           });
       });
 
-      it('Element - re-upgrade with a failed promised', () => {
-        expectAsyncConsoleError(/upgrade failed/, 1);
-        const element = new ElementClass();
-        expect(element.isUpgraded()).to.equal(false);
-        const oldImpl = element.implementation_;
-        const promise = Promise.reject(new Error('upgrade failed'));
-        oldImpl.upgradeCallback = () => promise;
-
-        container.appendChild(element);
-        expect(element.implementation_).to.equal(oldImpl);
-        expect(element.isUpgraded()).to.equal(false);
-        expect(element.upgradeState_).to.equal(/* UPGRADE_IN_PROGRESS */ 4);
-        return promise
-          .catch(() => {
-            // Ignore error.
-          })
-          .then(() => {
-            expect(element.implementation_).to.equal(oldImpl);
-            expect(element.isUpgraded()).to.equal(false);
-            expect(element.upgradeState_).to.equal(/* UPGRADE_FAILED */ 3);
-          });
-      });
-
       it('Element - can only re-upgrade once', () => {
         const element = new ElementClass();
         expect(element.isUpgraded()).to.equal(false);
@@ -1815,10 +1792,6 @@ describes.realWin('CustomElement', {amp: true}, (env) => {
         }
       }
 
-      function stubInA4A(isInA4A) {
-        env.sandbox.stub(element, 'isInA4A').callsFake(() => isInA4A);
-      }
-
       beforeEach(() => {
         win = env.win;
         doc = win.document;
@@ -1853,333 +1826,162 @@ describes.realWin('CustomElement', {amp: true}, (env) => {
         resourcesMock.verify();
       });
 
-      it('should be enabled by default', () => {
-        stubInA4A(false);
-        expect(element.isLoadingEnabled_()).to.be.true;
-      });
+      describe('toggleLoading', () => {
+        let loadingIndicatorServiceStub;
 
-      it('should be disabled in A4A', () => {
-        stubInA4A(true);
-        expect(element.isLoadingEnabled_()).to.be.false;
-      });
+        beforeEach(() => {
+          loadingIndicatorServiceStub = {
+            track: env.sandbox.spy(),
+            untrack: env.sandbox.spy(),
+          };
+          env.sandbox.stub(element, 'getAmpDoc').returns({});
+          env.sandbox
+            .stub(Services, 'loadingIndicatorOrNull')
+            .returns(loadingIndicatorServiceStub);
+        });
 
-      it('should disable when explicitly disabled by the attribute', () => {
-        stubInA4A(false);
-        element.setAttribute('noloading', '');
-        expect(element.isLoadingEnabled_()).to.be.false;
-      });
+        it('should be enabled by default', () => {
+          element.toggleLoading(true);
+          expect(loadingIndicatorServiceStub.track).to.be.calledOnce.calledWith(
+            element
+          );
+        });
 
-      it('should disable when element is not allowlisted', () => {
-        stubInA4A(false);
-        LOADING_ELEMENTS_['amp-test-loader'.toUpperCase()] = false;
-        expect(element.isLoadingEnabled_()).to.be.false;
-      });
+        it('should disable when explicitly disabled by the attribute', () => {
+          element.setAttribute('noloading', '');
+          element.toggleLoading(true);
+          expect(loadingIndicatorServiceStub.track).to.not.be.called;
+        });
 
-      it('should disable when not measured', () => {
-        stubInA4A(false);
-        element.layoutWidth_ = 0;
-        expect(element.isLoadingEnabled_()).to.be.false;
-      });
+        it('should disable when element is not allowlisted', () => {
+          LOADING_ELEMENTS_['amp-test-loader'.toUpperCase()] = false;
+          element.toggleLoading(true);
+          expect(loadingIndicatorServiceStub.track).to.not.be.called;
+        });
 
-      it('should disable when element has already been laid out', () => {
-        stubInA4A(false);
-        element.layoutCount_ = 1;
-        expect(element.isLoadingEnabled_()).to.be.false;
-      });
+        it('should disable when element has already been laid out', () => {
+          element.layoutCount_ = 1;
+          element.toggleLoading(true);
+          expect(loadingIndicatorServiceStub.track).to.not.be.called;
+        });
 
-      it('should disable when element is a placeholder itself', () => {
-        stubInA4A(false);
-        element.setAttribute('placeholder', '');
-        expect(element.isLoadingEnabled_()).to.be.false;
-      });
+        it('should disable when element is a placeholder itself', () => {
+          element.setAttribute('placeholder', '');
+          element.toggleLoading(true);
+          expect(loadingIndicatorServiceStub.track).to.not.be.called;
+        });
 
-      it('should disable when element is layout=nodisplay', () => {
-        stubInA4A(false);
-        element.layout_ = Layout.NODISPLAY;
-        expect(element.isLoadingEnabled_()).to.be.false;
-      });
+        it('should disable when element is layout=nodisplay', () => {
+          element.layout_ = Layout.NODISPLAY;
+          element.toggleLoading(true);
+          expect(loadingIndicatorServiceStub.track).to.not.be.called;
+        });
 
-      it('should enable when element is layout=container', () => {
-        stubInA4A(false);
-        element.layout_ = Layout.CONTAINER;
-        expect(element.isLoadingEnabled_()).to.be.true;
-      });
+        it('should enable when element is layout=container', () => {
+          element.layout_ = Layout.CONTAINER;
+          element.toggleLoading(true);
+          expect(loadingIndicatorServiceStub.track).to.be.calledOnce;
+        });
 
-      it('should ignore loading-off if never created', () => {
-        stubInA4A(false);
-        element.toggleLoading(false);
-        expect(element.loadingElement_).to.be.null;
-      });
+        it('should ignore loading-on if already rendered', () => {
+          clock.tick(1);
+          element.signals().signal(CommonSignals.RENDER_START);
+          element.toggleLoading(true);
+          expect(loadingIndicatorServiceStub.track).to.not.be.called;
+        });
 
-      it('should ignore loading-on if not allowed', () => {
-        stubInA4A(false);
-        element.setAttribute('noloading', '');
-        element.toggleLoading(true);
-        expect(element.loadingElement_).to.be.null;
-      });
+        it('should ignore loading-on if already loaded', () => {
+          element.layoutCount_ = 1;
+          element.toggleLoading(true);
+          expect(loadingIndicatorServiceStub.track).to.not.be.called;
+        });
 
-      it('should ignore loading-on if already rendered', () => {
-        stubInA4A(false);
-        clock.tick(1);
-        element.signals().signal(CommonSignals.RENDER_START);
-        element.toggleLoading(true);
-        expect(element.loadingElement_).to.be.null;
-      });
+        it('should cancel loading on render-start', () => {
+          clock.tick(1);
+          const stub = env.sandbox.stub(element, 'toggleLoading');
+          element.renderStarted();
+          expect(element.signals().get(CommonSignals.RENDER_START)).to.be.ok;
+          expect(stub).to.be.calledOnce.calledWith(false);
+        });
 
-      it('should ignore loading-on if already loaded', () => {
-        stubInA4A(false);
-        element.layoutCount_ = 1;
-        element.toggleLoading(true);
-        expect(element.loadingElement_).to.be.null;
-      });
-
-      it('should cancel loading on render-start', () => {
-        stubInA4A(false);
-        clock.tick(1);
-        const stub = env.sandbox.stub(element, 'toggleLoading');
-        element.renderStarted();
-        expect(element.signals().get(CommonSignals.RENDER_START)).to.be.ok;
-        expect(stub).to.be.calledOnce;
-        expect(stub.args[0][0]).to.be.false;
-      });
-
-      it('should create and turn on', () => {
-        stubInA4A(false);
-        element.setAttribute('layout', 'fill');
-        container.appendChild(element);
-        element.toggleLoading(true);
-
-        expect(element.loadingContainer_).to.not.be.null;
-        expect(element.loadingContainer_).to.not.have.class('amp-hidden');
-        expect(element.loadingElement_).to.not.be.null;
-        expect(element.loadingElement_).to.have.class('amp-active');
-      });
-
-      it('should turn on already created', () => {
-        stubInA4A(false);
-        element.setAttribute('layout', 'fill');
-        container.appendChild(element);
-        element.prepareLoading_();
-        const {
-          loadingContainer_: prevLoadingContainer,
-          loadingElement_: prevLoadingElement_,
-        } = element;
-        element.toggleLoading(true);
-
-        expect(element.loadingContainer_).to.equal(prevLoadingContainer);
-        expect(element.loadingContainer_).to.not.have.class('amp-hidden');
-        expect(element.loadingElement_).to.equal(prevLoadingElement_);
-        expect(element.loadingElement_).to.have.class('amp-active');
-      });
-
-      it('should turn off', () => {
-        stubInA4A(false);
-        element.setAttribute('layout', 'fill');
-        container.appendChild(element);
-        element.prepareLoading_();
-        element.toggleLoading(false);
-
-        expect(element.loadingContainer_).to.not.be.null;
-        expect(element.loadingContainer_).to.have.class('amp-hidden');
-        expect(element.loadingElement_).to.not.be.null;
-        expect(element.loadingElement_).to.not.have.class('amp-active');
-      });
-
-      it('should turn off and cleanup', () => {
-        stubInA4A(false);
-        element.setAttribute('layout', 'fill');
-        container.appendChild(element);
-        element.prepareLoading_();
-        element.toggleLoading(false, {cleanup: true});
-
-        expect(element.loadingContainer_).to.be.null;
-        expect(element.loadingElement_).to.be.null;
-      });
-
-      it('should NOT cleanup if re-used', () => {
-        stubInA4A(false);
-        element.setAttribute('layout', 'fill');
-        container.appendChild(element);
-        element.prepareLoading_();
-        env.sandbox
-          .stub(element.implementation_, 'isLoadingReused')
-          .callsFake(() => true);
-        element.toggleLoading(false, {cleanup: true});
-
-        expect(element.loadingContainer_).to.not.be.null;
-        expect(element.loadingElement_).to.not.be.null;
-      });
-
-      it('should ignore loading-off if never created', () => {
-        stubInA4A(false);
-        element.isInTemplate_ = true;
-        allowConsoleError(() => {
-          expect(() => {
-            element.toggleLoading(false);
-          }).to.throw(/Must never be called in template/);
+        it('should untrack when toggled off', () => {
+          element.toggleLoading(false);
+          expect(
+            loadingIndicatorServiceStub.untrack
+          ).to.be.calledOnce.calledWith(element);
         });
       });
 
-      it('should turn off when exits viewport', () => {
-        stubInA4A(false);
-        element.isInViewport_ = true;
-        const toggle = env.sandbox.spy(element, 'toggleLoading');
-        element.viewportCallback(false);
-        expect(toggle).to.be.calledOnce;
-        expect(toggle.firstCall.args[0]).to.equal(false);
-        expect(toggle.firstCall.args[1]).to.be.undefined;
-      });
+      describe('toggleLoading with layout', () => {
+        let toggle;
 
-      it('should NOT turn off when exits viewport but already laid out', () => {
-        stubInA4A(false);
-        const toggle = env.sandbox.spy(element, 'toggleLoading');
-        element.layoutCount_ = 1;
-        element.viewportCallback(false);
-        expect(toggle).to.have.not.been.called;
-      });
+        beforeEach(() => {
+          toggle = env.sandbox.spy(element, 'toggleLoading');
+        });
 
-      it('should turn on when enters viewport, after a 100ms delay', () => {
-        stubInA4A(false);
-        const toggle = env.sandbox.spy(element, 'toggleLoading');
-        element.setAttribute('layout', 'fill');
-        container.appendChild(element);
-        element.viewportCallback(true);
-        clock.tick(99);
-        expect(toggle).not.called;
-        clock.tick(100);
-        expect(toggle).calledOnceWith(true, {startTime: 42});
-      });
+        it('should toggle loading off after layout complete', () => {
+          element.setAttribute('height', '10');
+          element.setAttribute('width', '10');
+          container.appendChild(element);
+          return element.buildingPromise_
+            .then(() => {
+              toggle.resetHistory();
+              return element.layoutCallback();
+            })
+            .then(() => {
+              expect(toggle).to.be.calledTwice;
+              expect(toggle.firstCall).calledWith(true);
+              expect(toggle.secondCall).calledWith(false);
+            });
+        });
 
-      it('should not schedule it to turn on if already laid out when enters viewport', () => {
-        stubInA4A(false);
-        const timerDelay = env.sandbox.spy(Services.timerFor(win), 'delay');
-        const toggle = env.sandbox.spy(element, 'toggleLoading');
-        element.layoutCount_ = 1;
-        element.viewportCallback(true);
-        clock.tick(1000);
+        it('should toggle loading off after layout failed', () => {
+          env.sandbox
+            .stub(element.implementation_, 'layoutCallback')
+            .returns(Promise.reject());
+          element.setAttribute('height', '10');
+          element.setAttribute('width', '10');
+          container.appendChild(element);
+          return element.buildingPromise_
+            .then(() => {
+              toggle.resetHistory();
+              return element.layoutCallback();
+            })
+            .then(
+              () => {
+                throw new Error('Must have failed.');
+              },
+              () => {
+                expect(toggle).to.be.calledTwice;
+                expect(toggle.firstCall).calledWith(true);
+                expect(toggle.secondCall).calledWith(false);
+              }
+            );
+        });
 
-        expect(timerDelay).to.have.not.been.called;
-        expect(toggle).to.have.not.been.called;
-      });
-
-      it('should NOT turn on when enters viewport but already laid out', () => {
-        stubInA4A(false);
-        const timerDelay = env.sandbox.spy(Services.timerFor(win), 'delay');
-        const toggle = env.sandbox.spy(element, 'toggleLoading');
-        element.viewportCallback(true);
-        element.layoutCount_ = 1;
-        clock.tick(1000);
-        expect(timerDelay).to.have.been.called;
-        expect(toggle).to.have.not.been.called;
-      });
-
-      it('should not start loading when measured if already in viewport', () => {
-        stubInA4A(false);
-        const toggle = env.sandbox.spy(element, 'toggleLoading');
-        element.isInViewport_ = true;
-        element.setAttribute('layout', 'fill');
-        container.appendChild(element);
-        element.updateLayoutBox({top: 0, width: 300});
-        expect(toggle).to.not.be.called;
-      });
-
-      it('should toggle loading off after layout complete', () => {
-        stubInA4A(false);
-        const toggle = env.sandbox.spy(element, 'toggleLoading');
-        element.setAttribute('height', '10');
-        element.setAttribute('width', '10');
-        container.appendChild(element);
-        return element.buildingPromise_
-          .then(() => {
-            return element.layoutCallback();
-          })
-          .then(() => {
-            expect(toggle).to.be.calledOnce;
-            expect(toggle.firstCall.args[0]).to.equal(false);
-            expect(toggle.firstCall.args[1].cleanup).to.equal(true);
-          });
-      });
-
-      it('should toggle loading off after layout failed', () => {
-        stubInA4A(false);
-        const toggle = env.sandbox.spy(element, 'toggleLoading');
-        env.sandbox
-          .stub(element.implementation_, 'layoutCallback')
-          .callsFake(() => {
-            return Promise.reject();
-          });
-        element.setAttribute('height', '10');
-        element.setAttribute('width', '10');
-        container.appendChild(element);
-        return element.buildingPromise_
-          .then(() => {
-            return element.layoutCallback();
-          })
-          .then(
-            () => {
-              throw new Error('Must have failed.');
-            },
-            () => {
-              expect(toggle).to.be.calledOnce;
-              expect(toggle.firstCall.args[0]).to.equal(false);
-              expect(toggle.firstCall.args[1].cleanup).to.equal(true);
-            }
-          );
-      });
-
-      it('should disable toggle loading on after layout failed', () => {
-        stubInA4A(false);
-        const prepareLoading = env.sandbox.spy(element, 'prepareLoading_');
-        env.sandbox
-          .stub(element.implementation_, 'layoutCallback')
-          .callsFake(() => {
-            return Promise.reject();
-          });
-        element.setAttribute('height', '10');
-        element.setAttribute('width', '10');
-        container.appendChild(element);
-        return element.buildingPromise_
-          .then(() => {
-            expect(element.layoutCount_).to.equal(0);
-            expect(element.isLoadingEnabled_()).to.equal(true);
-            return element.layoutCallback();
-          })
-          .then(
-            () => {
-              throw new Error('Must have failed.');
-            },
-            () => {
-              expect(element.layoutCount_).to.equal(1);
-              expect(element.isLoadingEnabled_()).to.equal(false);
-              element.toggleLoading(true);
-              expect(prepareLoading).to.not.have.been.called;
-            }
-          );
-      });
-
-      // TODO(jridgewell): fix this test
-      it.skip('should ignore loading "on" if layout completed before vsync', () => {
-        stubInA4A(false);
-        resourcesMock.expects('mutateElement').once();
-        container.appendChild(element);
-        element.prepareLoading_();
-        element.toggleLoading(true);
-        return element
-          .build()
-          .then(() => {
-            return element.layoutCallback();
-          })
-          .then(() => {
-            // The first mutate started by toggleLoading(true), but it must
-            // immediately proceed to switch it to off.
-            // vsyncTasks.shift()();
-            expect(element.loadingContainer_).to.have.class('amp-hidden');
-            expect(element.loadingElement_).to.not.have.class('amp-active');
-
-            // Second vsync should perform cleanup.
-            // vsyncTasks.shift()();
-            expect(element.loadingContainer_).to.be.null;
-          });
+        it('should disable toggle loading on after layout failed', () => {
+          env.sandbox
+            .stub(element.implementation_, 'layoutCallback')
+            .returns(Promise.reject());
+          element.setAttribute('height', '10');
+          element.setAttribute('width', '10');
+          container.appendChild(element);
+          return element.buildingPromise_
+            .then(() => {
+              expect(element.layoutCount_).to.equal(0);
+              expect(element.isLoadingEnabled_()).to.equal(true);
+              return element.layoutCallback();
+            })
+            .then(
+              () => {
+                throw new Error('Must have failed.');
+              },
+              () => {
+                expect(element.layoutCount_).to.equal(1);
+                expect(element.isLoadingEnabled_()).to.equal(false);
+              }
+            );
+        });
       });
     });
 });

--- a/test/unit/test-loader.js
+++ b/test/unit/test-loader.js
@@ -16,7 +16,7 @@
 
 import * as lolex from 'lolex';
 import {Services} from '../../src/services';
-import {createLoaderElement} from '../../src/loader';
+import {createLoaderElement} from '../../src/service/loader-element';
 
 describes.fakeWin('Loader', {amp: true}, (env) => {
   let clock;

--- a/test/unit/test-loading-indicator.js
+++ b/test/unit/test-loading-indicator.js
@@ -1,0 +1,190 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {LoadingIndicatorImpl} from '../../src/service/loading-indicator';
+import {Services} from '../../src/services';
+import {pushIfNotExist, removeItem} from '../../src/utils/array';
+
+describes.realWin('LoadingIndicatorImpl', {amp: true}, (env) => {
+  let ampdoc;
+  let service;
+  let loaderService;
+  let io;
+  let failRoot;
+  let el;
+
+  beforeEach(() => {
+    ampdoc = env.ampdoc;
+
+    failRoot = false;
+    env.sandbox
+      .stub(env.win, 'IntersectionObserver')
+      .value(IntersectionObserverStub);
+
+    service = new LoadingIndicatorImpl(ampdoc);
+
+    loaderService = {
+      initializeLoader: env.sandbox.spy(),
+    };
+    env.sandbox
+      .stub(Services, 'extensionsFor')
+      .returns({installExtensionForDoc: () => sync()});
+    env.sandbox
+      .stub(Services, 'loaderServiceForDoc')
+      .returns(sync(loaderService));
+
+    el = document.createElement('div');
+  });
+
+  class IntersectionObserverStub {
+    constructor(callback, options) {
+      if (options.root && failRoot) {
+        throw new Error('root is not allowed');
+      }
+      this.callback = callback;
+      this.options = options;
+      this.observed = [];
+      io = this;
+    }
+
+    observe(el) {
+      pushIfNotExist(this.observed, el);
+    }
+
+    unobserve(el) {
+      removeItem(this.observed, el);
+    }
+
+    record(record) {
+      this.callback([record]);
+    }
+  }
+
+  function sync(value) {
+    return {then: (callback) => callback(value)};
+  }
+
+  function getLoader() {
+    return el.querySelector('.i-amphtml-loading-container');
+  }
+
+  it('should use root when supported', () => {
+    failRoot = false;
+    service = new LoadingIndicatorImpl(ampdoc);
+    expect(io.options.root).to.equal(ampdoc.win.document);
+
+    service.track(el);
+    expect(io.observed).to.include(el);
+  });
+
+  it('should fail over when root is not supported', () => {
+    failRoot = true;
+    service = new LoadingIndicatorImpl(ampdoc);
+    expect(io.options.root).to.be.undefined;
+
+    service.track(el);
+    expect(io.observed).to.include(el);
+  });
+
+  it('should not create the loader on out-of-viewport', async () => {
+    service.track(el);
+    // No loader yet.
+    expect(getLoader()).to.not.exist;
+
+    // Observe out-of-viewport.
+    io.record({
+      target: el,
+      isIntersecting: false,
+      boundingClientRect: {width: 100, height: 100},
+    });
+    expect(getLoader()).to.not.exist;
+    expect(loaderService.initializeLoader).to.not.be.called;
+  });
+
+  it('should create the loader on the first in-viewport', async () => {
+    service.track(el);
+    // No loader yet.
+    expect(getLoader()).to.not.exist;
+
+    // Observe in-viewport.
+    io.record({
+      target: el,
+      isIntersecting: true,
+      boundingClientRect: {width: 100, height: 100},
+    });
+    expect(getLoader()).to.exist;
+    expect(loaderService.initializeLoader).to.be.calledOnce;
+  });
+
+  it('should NOT create the loader when size is too small', async () => {
+    service.track(el);
+    // No loader yet.
+    expect(getLoader()).to.not.exist;
+
+    // Observe in-viewport.
+    io.record({
+      target: el,
+      isIntersecting: true,
+      boundingClientRect: {width: 1, height: 1},
+    });
+    expect(getLoader()).to.not.exist;
+    expect(loaderService.initializeLoader).to.not.be.called;
+  });
+
+  it('should hide the loader on out-of-viewport', async () => {
+    service.track(el);
+    io.record({
+      target: el,
+      isIntersecting: true,
+      boundingClientRect: {width: 100, height: 100},
+    });
+    expect(getLoader()).to.exist;
+    expect(getLoader()).to.not.have.class('amp-hidden');
+    expect(getLoader().firstElementChild).to.have.class('amp-active');
+
+    // Out-of-viewport.
+    io.record({
+      target: el,
+      isIntersecting: false,
+      boundingClientRect: {width: 100, height: 100},
+    });
+    expect(getLoader()).to.have.class('amp-hidden');
+    expect(getLoader().firstElementChild).to.not.have.class('amp-active');
+
+    // In-viewport.
+    io.record({
+      target: el,
+      isIntersecting: true,
+      boundingClientRect: {width: 100, height: 100},
+    });
+    expect(getLoader()).to.not.have.class('amp-hidden');
+    expect(getLoader().firstElementChild).to.have.class('amp-active');
+  });
+
+  it('should cleanup when tracking is stopped', async () => {
+    service.track(el);
+    io.record({
+      target: el,
+      isIntersecting: true,
+      boundingClientRect: {width: 100, height: 100},
+    });
+    expect(getLoader()).to.exist;
+
+    // Untrack.
+    service.untrack(el);
+    expect(getLoader()).to.not.exist;
+  });
+});


### PR DESCRIPTION
Partial #30620.

TODO:
- [x] Tests

Key points:
1. Most refactoring is straightforward code move from `custom-element.js` to `loading-indicator.js`.
2. However, one critical change: the `inViewport` callback is no longer used and instead `IntersectionObserver` is used. Thus, the main API that custom element calls is: `track` (start tracking the element in case loading indicator needs to be shown) and `untrack` (stop tracking and cleanup).
3. The `isLoadingReused` is removed because it's not a property of an element but rather the property of a loader - whether or not the loader is shown for layout or for any other reason.
4. The `LoadingIndicator` service tracks the element's state in a weak map.
5. The `LoadingIndicator` service is installed _only_ in the environments where it's used. E.g. it's ignored for A4A or inabox.

