### PR TITLE
amp-ad-xorigin-iframe-handler: fix test

### DIFF
--- a/extensions/amp-ad/0.1/test/test-amp-ad-xorigin-iframe-handler.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-xorigin-iframe-handler.js
@@ -237,7 +237,7 @@ describe('amp-ad-xorigin-iframe-handler', () => {
       it('should be able to use user-error API', () => {
         const err = new Error();
         err.message = 'error test';
-        const userErrorReportSpy = window.sandbox./*OK*/ spy(
+        const userErrorReportSpy = window.sandbox.stub(
           iframeHandler,
           'userErrorForAnalytics_'
         );


### PR DESCRIPTION
Fix broken test found in https://github.com/ampproject/amphtml/pull/30578.

Root cause was a call to `reportErrorToAnalytics` which happens async and was searching for an ampdoc even after the test completed (and therefore fixtures were torn down). Fix is as simple as switching a spy to a stub.