### PR TITLE
✨ [bento][amp-accordion] Adding a11y to bento accordion

### DIFF
--- a/extensions/amp-accordion/1.0/accordion.js
+++ b/extensions/amp-accordion/1.0/accordion.js
@@ -17,7 +17,10 @@
 import * as Preact from '../../../src/preact';
 import {animateCollapse, animateExpand} from './animations';
 import {omit} from '../../../src/utils/object';
-import {sequentialIdGenerator} from '../../../src/utils/id-generator';
+import {
+  randomIdGenerator,
+  sequentialIdGenerator,
+} from '../../../src/utils/id-generator';
 import {
   useCallback,
   useContext,
@@ -36,6 +39,7 @@ const AccordionContext = Preact.createContext(
 const EMPTY_EXPANDED_MAP = {};
 
 const generateSectionId = sequentialIdGenerator();
+const generateRandomId = randomIdGenerator();
 
 const CHILD_STYLE = {
   // Make animations measurable. Without this, padding and margin can skew
@@ -61,7 +65,8 @@ export function Accordion({
   ...rest
 }) {
   const [expandedMap, setExpandedMap] = useState(EMPTY_EXPANDED_MAP);
-  const [prefix] = useState(id ? id : Math.floor(Math.random() * 100));
+  const [randomPrefix] = useState(generateRandomId);
+  const prefix = id || randomPrefix;
 
   useEffect(() => {
     if (!expandSingleSection) {
@@ -193,7 +198,7 @@ export function AccordionSection({
 
   const expanded = isExpanded ? isExpanded(id, defaultExpanded) : expandedState;
   const animate = contextAnimate ?? defaultAnimate;
-  const contentId = prefix + '_AMP_content_' + id;
+  const contentId = `${prefix || 'a'}_AMP_content_'${id}-${generateRandomId()}`;
 
   useLayoutEffect(() => {
     const hasMounted = hasMountedRef.current;

--- a/extensions/amp-accordion/1.0/accordion.js
+++ b/extensions/amp-accordion/1.0/accordion.js
@@ -39,7 +39,7 @@ const AccordionContext = Preact.createContext(
 const EMPTY_EXPANDED_MAP = {};
 
 const generateSectionId = sequentialIdGenerator();
-const generateRandomId = randomIdGenerator();
+const generateRandomId = randomIdGenerator(100000);
 
 const CHILD_STYLE = {
   // Make animations measurable. Without this, padding and margin can skew
@@ -199,7 +199,7 @@ export function AccordionSection({
 
   const expanded = isExpanded ? isExpanded(id, defaultExpanded) : expandedState;
   const animate = contextAnimate ?? defaultAnimate;
-  const contentId = `${prefix || 'a'}_AMP_content_${id}-${suffix}`;
+  const contentId = `${prefix || 'a'}-content-${id}-${suffix}`;
 
   useLayoutEffect(() => {
     const hasMounted = hasMountedRef.current;

--- a/extensions/amp-accordion/1.0/accordion.js
+++ b/extensions/amp-accordion/1.0/accordion.js
@@ -198,7 +198,7 @@ export function AccordionSection({
 
   const expanded = isExpanded ? isExpanded(id, defaultExpanded) : expandedState;
   const animate = contextAnimate ?? defaultAnimate;
-  const contentId = `${prefix || 'a'}_AMP_content_'${id}-${generateRandomId()}`;
+  const contentId = `${prefix || 'a'}_AMP_content_${id}-${generateRandomId()}`;
 
   useLayoutEffect(() => {
     const hasMounted = hasMountedRef.current;

--- a/extensions/amp-accordion/1.0/accordion.js
+++ b/extensions/amp-accordion/1.0/accordion.js
@@ -57,9 +57,11 @@ export function Accordion({
   expandSingleSection = false,
   animate = false,
   children,
+  id,
   ...rest
 }) {
   const [expandedMap, setExpandedMap] = useState(EMPTY_EXPANDED_MAP);
+  const [prefix] = useState(id ? id : Math.floor(Math.random() * 100));
 
   useEffect(() => {
     if (!expandSingleSection) {
@@ -107,12 +109,13 @@ export function Accordion({
         toggleExpanded,
         isExpanded: (id, defaultExpanded) => expandedMap[id] ?? defaultExpanded,
         animate,
+        prefix,
       }),
-    [animate, expandedMap, registerSection, toggleExpanded]
+    [animate, expandedMap, registerSection, toggleExpanded, prefix]
   );
 
   return (
-    <Comp {...rest}>
+    <Comp id={id} {...rest}>
       <AccordionContext.Provider value={context}>
         {children}
       </AccordionContext.Provider>
@@ -166,6 +169,7 @@ export function AccordionSection({
     animate: contextAnimate,
     isExpanded,
     toggleExpanded,
+    prefix,
   } = useContext(AccordionContext);
 
   useEffect(() => {
@@ -189,6 +193,7 @@ export function AccordionSection({
 
   const expanded = isExpanded ? isExpanded(id, defaultExpanded) : expandedState;
   const animate = contextAnimate ?? defaultAnimate;
+  const contentId = prefix + '_AMP_content_' + id;
 
   useLayoutEffect(() => {
     const hasMounted = hasMountedRef.current;
@@ -201,10 +206,21 @@ export function AccordionSection({
 
   return (
     <Comp {...rest} expanded={expanded} aria-expanded={String(expanded)}>
-      <HeaderComp role="button" style={CHILD_STYLE} onClick={expandHandler}>
+      <HeaderComp
+        role="button"
+        aria-controls={contentId}
+        tabIndex="0"
+        style={CHILD_STYLE}
+        onClick={expandHandler}
+      >
         {header}
       </HeaderComp>
-      <ContentComp ref={contentRef} style={CHILD_STYLE} hidden={!expanded}>
+      <ContentComp
+        id={contentId}
+        ref={contentRef}
+        style={CHILD_STYLE}
+        hidden={!expanded}
+      >
         {children}
       </ContentComp>
     </Comp>

--- a/extensions/amp-accordion/1.0/accordion.js
+++ b/extensions/amp-accordion/1.0/accordion.js
@@ -66,7 +66,7 @@ export function Accordion({
 }) {
   const [expandedMap, setExpandedMap] = useState(EMPTY_EXPANDED_MAP);
   const [randomPrefix] = useState(generateRandomId);
-  const prefix = id || randomPrefix;
+  const prefix = id || `a${randomPrefix}`;
 
   useEffect(() => {
     if (!expandSingleSection) {
@@ -165,6 +165,7 @@ export function AccordionSection({
   ...rest
 }) {
   const [id] = useState(generateSectionId);
+  const [suffix] = useState(generateRandomId);
   const [expandedState, setExpandedState] = useState(defaultExpanded);
   const contentRef = useRef(null);
   const hasMountedRef = useRef(false);
@@ -198,7 +199,7 @@ export function AccordionSection({
 
   const expanded = isExpanded ? isExpanded(id, defaultExpanded) : expandedState;
   const animate = contextAnimate ?? defaultAnimate;
-  const contentId = `${prefix || 'a'}_AMP_content_${id}-${generateRandomId()}`;
+  const contentId = `${prefix || 'a'}_AMP_content_${id}-${suffix}`;
 
   useLayoutEffect(() => {
     const hasMounted = hasMountedRef.current;

--- a/extensions/amp-accordion/1.0/amp-accordion.js
+++ b/extensions/amp-accordion/1.0/amp-accordion.js
@@ -126,20 +126,31 @@ const bindSectionShimToElement = (element) => SectionShim.bind(null, element);
  * @param {!AccordionDef.HeaderProps} props
  * @return {PreactDef.Renderable}
  */
-function HeaderShim(sectionElement, {onClick}) {
+function HeaderShim(sectionElement, props) {
+  const {onClick} = props;
+  const ariaControls = props['aria-controls'];
   const headerElement = sectionElement.firstElementChild;
   useLayoutEffect(() => {
     if (!headerElement || !onClick) {
       return;
     }
     headerElement.addEventListener('click', onClick);
+    const hasTabIndex = headerElement.hasAttribute('tabindex');
+    if (!hasTabIndex) {
+      headerElement.setAttribute('tabindex', 0);
+    }
+    headerElement.setAttribute('aria-controls', ariaControls);
+    headerElement.setAttribute('role', 'button');
     if (sectionElement[SECTION_POST_RENDER]) {
       sectionElement[SECTION_POST_RENDER]();
     }
     return () => {
       headerElement.removeEventListener('click', devAssert(onClick));
+      if (!hasTabIndex) {
+        headerElement.removeAttribute('tabindex');
+      }
     };
-  }, [sectionElement, headerElement, onClick]);
+  }, [sectionElement, headerElement, onClick, ariaControls]);
   return <header />;
 }
 
@@ -155,18 +166,19 @@ const bindHeaderShimToElement = (element) => HeaderShim.bind(null, element);
  * @param {{current: ?}} ref
  * @return {PreactDef.Renderable}
  */
-function ContentShimWithRef(sectionElement, {hidden}, ref) {
+function ContentShimWithRef(sectionElement, {hidden, id}, ref) {
   const contentElement = sectionElement.lastElementChild;
   useImperativeHandle(ref, () => contentElement, [contentElement]);
   useLayoutEffect(() => {
     if (!contentElement) {
       return;
     }
+    contentElement.setAttribute('id', id);
     toggleAttribute(contentElement, 'hidden', hidden);
     if (sectionElement[SECTION_POST_RENDER]) {
       sectionElement[SECTION_POST_RENDER]();
     }
-  }, [sectionElement, contentElement, hidden]);
+  }, [sectionElement, contentElement, hidden, id]);
   return <div />;
 }
 

--- a/extensions/amp-accordion/1.0/amp-accordion.js
+++ b/extensions/amp-accordion/1.0/amp-accordion.js
@@ -133,8 +133,7 @@ function HeaderShim(sectionElement, {onClick, 'aria-controls': ariaControls}) {
       return;
     }
     headerElement.addEventListener('click', onClick);
-    const hasTabIndex = headerElement.hasAttribute('tabindex');
-    if (!hasTabIndex) {
+    if (!headerElement.hasAttribute('tabindex')) {
       headerElement.setAttribute('tabindex', 0);
     }
     headerElement.setAttribute('aria-controls', ariaControls);

--- a/extensions/amp-accordion/1.0/amp-accordion.js
+++ b/extensions/amp-accordion/1.0/amp-accordion.js
@@ -126,9 +126,7 @@ const bindSectionShimToElement = (element) => SectionShim.bind(null, element);
  * @param {!AccordionDef.HeaderProps} props
  * @return {PreactDef.Renderable}
  */
-function HeaderShim(sectionElement, props) {
-  const {onClick} = props;
-  const ariaControls = props['aria-controls'];
+function HeaderShim(sectionElement, {onClick, 'aria-controls': ariaControls}) {
   const headerElement = sectionElement.firstElementChild;
   useLayoutEffect(() => {
     if (!headerElement || !onClick) {
@@ -146,9 +144,6 @@ function HeaderShim(sectionElement, props) {
     }
     return () => {
       headerElement.removeEventListener('click', devAssert(onClick));
-      if (!hasTabIndex) {
-        headerElement.removeAttribute('tabindex');
-      }
     };
   }, [sectionElement, headerElement, onClick, ariaControls]);
   return <header />;

--- a/extensions/amp-accordion/1.0/test/test-accordion.js
+++ b/extensions/amp-accordion/1.0/test/test-accordion.js
@@ -133,6 +133,48 @@ describes.sandboxed('Accordion preact component', {}, (env) => {
       expect(sections.at(2).find('div').getDOMNode().hidden).to.be.true;
     });
 
+    it('should include a11y related attributes', () => {
+      const dom = wrapper.getDOMNode();
+      expect(dom.localName).to.equal('section');
+
+      const sections = wrapper.find(AccordionSection);
+      expect(sections).to.have.lengthOf(3);
+
+      const header0 = sections.at(0).find('header').getDOMNode();
+      const header1 = sections.at(1).find('header').getDOMNode();
+      const header2 = sections.at(2).find('header').getDOMNode();
+      const content0 = sections.at(0).find('div').getDOMNode();
+      const content1 = sections.at(1).find('div').getDOMNode();
+      const content2 = sections.at(2).find('div').getDOMNode();
+
+      expect(sections.at(0).getDOMNode()).to.have.attribute('aria-expanded');
+      expect(header0).to.have.attribute('tabindex');
+      expect(header0).to.have.attribute('aria-controls');
+      expect(header0).to.have.attribute('role');
+      expect(content0).to.have.attribute('id');
+      expect(header0.getAttribute('aria-controls')).to.equal(
+        content0.getAttribute('id')
+      );
+
+      expect(sections.at(1).getDOMNode()).to.have.attribute('aria-expanded');
+      expect(header1).to.have.attribute('tabindex');
+      expect(header1).to.have.attribute('aria-controls');
+      expect(header1).to.have.attribute('role');
+      expect(content1).to.have.attribute('id');
+      expect(header1.getAttribute('aria-controls')).to.equal(
+        content1.getAttribute('id')
+      );
+
+      expect(sections.at(2).getDOMNode()).to.have.attribute('aria-expanded');
+      expect(header2).to.have.attribute('tabindex');
+      expect(header2).to.have.attribute('aria-controls');
+      expect(header2).to.have.attribute('role');
+      expect(content2).to.have.attribute('id');
+      expect(header2.getAttribute('aria-controls')).to.equal(
+        content2.getAttribute('id')
+      );
+    });
+
     it('should expand a section on click', () => {
       const dom = wrapper.getDOMNode();
       expect(dom.localName).to.equal('section');

--- a/extensions/amp-accordion/1.0/test/test-amp-accordion.js
+++ b/extensions/amp-accordion/1.0/test/test-amp-accordion.js
@@ -148,6 +148,50 @@ describes.realWin(
       expect(sections[2].lastElementChild).to.have.display('none');
     });
 
+    it('should include a11y related attributes', async () => {
+      const sections = element.children;
+
+      const {
+        firstElementChild: header0,
+        lastElementChild: content0,
+      } = sections[0];
+      const {
+        firstElementChild: header1,
+        lastElementChild: content1,
+      } = sections[1];
+      const {
+        firstElementChild: header2,
+        lastElementChild: content2,
+      } = sections[2];
+
+      expect(sections[0]).to.have.attribute('aria-expanded');
+      expect(header0).to.have.attribute('tabindex');
+      expect(header0).to.have.attribute('aria-controls');
+      expect(header0).to.have.attribute('role');
+      expect(content0).to.have.attribute('id');
+      expect(header0.getAttribute('aria-controls')).to.equal(
+        content0.getAttribute('id')
+      );
+
+      expect(sections[1]).to.have.attribute('aria-expanded');
+      expect(header1).to.have.attribute('tabindex');
+      expect(header1).to.have.attribute('aria-controls');
+      expect(header1).to.have.attribute('role');
+      expect(content1).to.have.attribute('id');
+      expect(header1.getAttribute('aria-controls')).to.equal(
+        content1.getAttribute('id')
+      );
+
+      expect(sections[2]).to.have.attribute('aria-expanded');
+      expect(header2).to.have.attribute('tabindex');
+      expect(header2).to.have.attribute('aria-controls');
+      expect(header2).to.have.attribute('role');
+      expect(content2).to.have.attribute('id');
+      expect(header2.getAttribute('aria-controls')).to.equal(
+        content2.getAttribute('id')
+      );
+    });
+
     describe('animate', () => {
       let animateStub;
 

--- a/src/utils/id-generator.js
+++ b/src/utils/id-generator.js
@@ -25,9 +25,10 @@ export function sequentialIdGenerator() {
 
 /**
  * Returns a function that generates a random id in string format.  The random
- * id will be an integer from 0-99999.
+ * id will be an integer from 0 to maxValue (non-inclusive).
+ * @param {number} maxValue
  * @return {function():string}
  */
-export function randomIdGenerator() {
-  return () => String(Math.floor(Math.random() * 100000));
+export function randomIdGenerator(maxValue) {
+  return () => String(Math.floor(Math.random() * maxValue));
 }

--- a/src/utils/id-generator.js
+++ b/src/utils/id-generator.js
@@ -25,12 +25,9 @@ export function sequentialIdGenerator() {
 
 /**
  * Returns a function that generates a random id in string format.  The random
- * id is an [a-zA-Z] character followed by an integer from 0-99,999.
+ * id will be an integer from 0-99999.
  * @return {function():string}
  */
 export function randomIdGenerator() {
-  return () =>
-    `${'abcdefghijklmnopqrstuvxwyzABCDEFGHIJKLMNOPQRSTUVWXYZ'.charAt(
-      Math.floor(Math.random() * 52)
-    )}${Math.floor(Math.random() * 100000)}`;
+  return () => String(Math.floor(Math.random() * 100000));
 }

--- a/src/utils/id-generator.js
+++ b/src/utils/id-generator.js
@@ -22,3 +22,15 @@ export function sequentialIdGenerator() {
   let counter = 0;
   return () => String(++counter);
 }
+
+/**
+ * Returns a function that generates a random id in string format.  The random
+ * id is an [a-zA-Z] character followed by an integer from 0-99,999.
+ * @return {function():string}
+ */
+export function randomIdGenerator() {
+  return () =>
+    `${'abcdefghijklmnopqrstuvxwyzABCDEFGHIJKLMNOPQRSTUVWXYZ'.charAt(
+      Math.floor(Math.random() * 52)
+    )}${Math.floor(Math.random() * 100000)}`;
+}


### PR DESCRIPTION
Tracking Issue for amp-accordion: https://github.com/ampproject/amphtml/issues/30445


This PR adds the following a11y attributes to amp-accordion.

**Adding the following attributes to `header`:**

role="button"
aria-controls={contentId}
tabIndex="0"

**Adding to `content`:**

id={contentId}


**Outstanding question (answered below):**
1. In amp-mode we may overwrite an existing `id`.  Not sure how to check for existing id and pass it to header.
2. Should we remove things like `role` and `aria-controls` on callback of `headershim's` `layoutEffect`?  Currently am only checking for `tabIndex` since I am checking whether or not `tabIndex` already exists prior to overwriting.

**Answers**
1. This is marked as todo in Tracking Issue: https://github.com/ampproject/amphtml/issues/30445 (handle protect existing `id` on content node)
2. Not needed, only removing event listeners for memory leak purposes. 