### PR TITLE
Bento Carousel: `outsetArrows` prop

### DIFF
--- a/extensions/amp-base-carousel/1.0/amp-base-carousel.js
+++ b/extensions/amp-base-carousel/1.0/amp-base-carousel.js
@@ -104,6 +104,7 @@ AmpBaseCarousel['children'] = {
 AmpBaseCarousel['props'] = {
   'controls': {attr: 'controls', type: 'string'},
   'loop': {attr: 'loop', type: 'boolean'},
+  'outsetArrows': {attr: 'outset-arrows', type: 'boolean'},
   'snap': {
     attrs: ['snap'],
     parseAttrs: (element) => parseStrBoolAttr(element, 'snap', true),

--- a/extensions/amp-base-carousel/1.0/arrow.js
+++ b/extensions/amp-base-carousel/1.0/arrow.js
@@ -28,6 +28,9 @@ export function Arrow({customArrow, by, advance, disabled, outsetArrows}) {
   } = customArrow.props;
   const isDisabled = disabled || customDisabled;
   const onClick = (e) => {
+    if (isDisabled) {
+      return;
+    }
     if (onCustomClick) {
       onCustomClick(e);
     }

--- a/extensions/amp-base-carousel/1.0/arrow.js
+++ b/extensions/amp-base-carousel/1.0/arrow.js
@@ -21,7 +21,7 @@ import {useStyles} from './base-carousel.jss';
  * @param {!BaseCarouselDef.ArrowProps} props
  * @return {PreactDef.Renderable}
  */
-export function Arrow({customArrow, by, advance, disabled}) {
+export function Arrow({customArrow, by, advance, disabled, outsetArrows}) {
   const {
     'disabled': customDisabled,
     'onClick': onCustomClick,
@@ -34,9 +34,11 @@ export function Arrow({customArrow, by, advance, disabled}) {
     advance(by);
   };
   const classes = useStyles();
-  const classNames = `${classes.arrowPlacement} ${
+  const classNames = `${classes.arrow} ${
     by < 0 ? classes.arrowPrev : classes.arrowNext
-  } ${isDisabled ? classes.arrowDisabled : ''}`;
+  } ${isDisabled ? classes.arrowDisabled : ''} ${
+    outsetArrows ? classes.outsetArrow : classes.insetArrow
+  }`;
 
   return (
     <div class={classNames}>

--- a/extensions/amp-base-carousel/1.0/base-carousel.js
+++ b/extensions/amp-base-carousel/1.0/base-carousel.js
@@ -50,7 +50,7 @@ function BaseCarouselWithRef(
     arrowPrev,
     arrowNext,
     children,
-    controls = outsetArrows ? Controls.ALWAYS : Controls.AUTO,
+    controls = Controls.AUTO,
     loop,
     onSlideChange,
     outsetArrows,
@@ -103,14 +103,14 @@ function BaseCarouselWithRef(
 
   const [hadTouch, setHadTouch] = useState(false);
   const hideControls = useMemo(() => {
+    if (controls === Controls.ALWAYS || outsetArrows) {
+      return false;
+    }
     if (controls === Controls.NEVER) {
       return true;
     }
-    if (controls === Controls.ALWAYS) {
-      return false;
-    }
     return hadTouch;
-  }, [hadTouch, controls]);
+  }, [hadTouch, controls, outsetArrows]);
 
   return (
     <ContainWrapper

--- a/extensions/amp-base-carousel/1.0/base-carousel.js
+++ b/extensions/amp-base-carousel/1.0/base-carousel.js
@@ -50,9 +50,10 @@ function BaseCarouselWithRef(
     arrowPrev,
     arrowNext,
     children,
-    controls = Controls.AUTO,
+    controls = outsetArrows ? Controls.ALWAYS : Controls.AUTO,
     loop,
     onSlideChange,
+    outsetArrows,
     snap = true,
     ...rest
   },
@@ -112,7 +113,21 @@ function BaseCarouselWithRef(
   }, [hadTouch, controls]);
 
   return (
-    <ContainWrapper size={true} layout={true} paint={true} {...rest}>
+    <ContainWrapper
+      size={true}
+      layout={true}
+      paint={true}
+      contentStyle={{display: 'flex'}}
+      {...rest}
+    >
+      {!hideControls && (
+        <ArrowPrev
+          advance={advance}
+          customArrow={arrowPrev}
+          disabled={disableForDir(-1)}
+          outsetArrows={outsetArrows}
+        />
+      )}
       <Scroller
         loop={loop}
         restingIndex={currentSlide}
@@ -143,18 +158,12 @@ function BaseCarouselWithRef(
         )}
       </Scroller>
       {!hideControls && (
-        <>
-          <ArrowPrev
-            customArrow={arrowPrev}
-            disabled={disableForDir(-1)}
-            advance={advance}
-          />
-          <ArrowNext
-            customArrow={arrowNext}
-            disabled={disableForDir(1)}
-            advance={advance}
-          />
-        </>
+        <ArrowNext
+          advance={advance}
+          customArrow={arrowNext}
+          disabled={disableForDir(1)}
+          outsetArrows={outsetArrows}
+        />
       )}
     </ContainWrapper>
   );

--- a/extensions/amp-base-carousel/1.0/base-carousel.jss.js
+++ b/extensions/amp-base-carousel/1.0/base-carousel.jss.js
@@ -125,8 +125,13 @@ const arrow = {
 const arrowPrev = {left: 0};
 const arrowNext = {right: 0};
 const arrowDisabled = {
-  opacity: 0,
   pointerEvents: 'none',
+  '&$insetArrow': {
+    opacity: 0,
+  },
+  '&$outsetArrow': {
+    opacity: 0.5,
+  },
 };
 
 const insetArrow = {
@@ -170,16 +175,16 @@ const defaultArrowButton = {
   stroke: 'currentColor',
   transition: '200ms stroke',
   color: '#FFF',
-  '&:hover': {
+  '&:hover:not([disabled])': {
     color: '#222',
   },
-  '&:active': {
+  '&:active:not([disabled])': {
     transitionDuration: '0ms',
   },
-  '&:hover $arrowBackground': {
+  '&:hover:not([disabled]) $arrowBackground': {
     backgroundColor: 'rgba(255, 255, 255, 0.8)',
   },
-  '&:active $arrowBackground': {
+  '&:active:not([disabled]) $arrowBackground': {
     backgroundColor: 'rgba(255, 255, 255, 1.0)',
     transitionDuration: '0ms',
   },

--- a/extensions/amp-base-carousel/1.0/base-carousel.jss.js
+++ b/extensions/amp-base-carousel/1.0/base-carousel.jss.js
@@ -143,7 +143,6 @@ const outsetArrow = {
   position: 'relative',
   flexShrink: 0,
   height: '100%',
-  padding: '4px',
   borderRadius: '50%',
   backgroundSize: '24px 24px',
   // Center the button vertically.
@@ -152,12 +151,12 @@ const outsetArrow = {
   alignItems: 'center',
   pointerEvents: 'auto',
   '&$arrowPrev': {
-    marginInlineStart: '3px',
-    marginInlineEnd: '9px',
+    marginInlineStart: '4px',
+    marginInlineEnd: '10px',
   },
   '&$arrowNext': {
-    marginInlineStart: '9px',
-    marginInlineEnd: '3px',
+    marginInlineStart: '10px',
+    marginInlineEnd: '4px',
   },
 };
 

--- a/extensions/amp-base-carousel/1.0/base-carousel.jss.js
+++ b/extensions/amp-base-carousel/1.0/base-carousel.jss.js
@@ -17,7 +17,7 @@
 import {createUseStyles} from 'react-jss';
 
 const scrollContainer = {
-  position: 'absolute',
+  position: 'relative',
   top: 0,
   left: 0,
   right: 0,
@@ -29,6 +29,7 @@ const scrollContainer = {
 
   display: 'flex',
   flexWrap: 'nowrap',
+  flexGrow: 1,
 
   scrollBehavior: 'smooth',
   WebkitOverflowScrolling: 'touch',
@@ -110,8 +111,7 @@ const slideSizing = {
   },
 };
 
-const arrowPlacement = {
-  position: 'absolute',
+const arrow = {
   zIndex: 1,
   display: 'flex',
   flexDirection: 'row',
@@ -129,6 +129,33 @@ const arrowDisabled = {
   pointerEvents: 'none',
 };
 
+const insetArrow = {
+  position: 'absolute',
+  padding: '12px',
+};
+
+const outsetArrow = {
+  position: 'relative',
+  flexShrink: 0,
+  height: '100%',
+  padding: '4px',
+  borderRadius: '50%',
+  backgroundSize: '24px 24px',
+  // Center the button vertically.
+  top: '50%',
+  transform: 'translateY(-50%)',
+  alignItems: 'center',
+  pointerEvents: 'auto',
+  '&$arrowPrev': {
+    marginInlineStart: '3px',
+    marginInlineEnd: '9px',
+  },
+  '&$arrowNext': {
+    marginInlineStart: '9px',
+    marginInlineEnd: '3px',
+  },
+};
+
 const defaultArrowButton = {
   position: 'relative',
   display: 'flex',
@@ -137,7 +164,6 @@ const defaultArrowButton = {
   width: '36px',
   height: '36px',
   padding: 0,
-  margin: '12px',
   backgroundColor: 'transparent',
   border: 'none',
   outline: 'none',
@@ -198,10 +224,12 @@ const JSS = {
   enableSnap,
   disableSnap,
   slideSizing,
-  arrowPlacement,
+  arrow,
   arrowPrev,
   arrowNext,
   arrowDisabled,
+  insetArrow,
+  outsetArrow,
   defaultArrowButton,
   arrowBaseStyle,
   arrowFrosting,

--- a/extensions/amp-base-carousel/1.0/base-carousel.jss.js
+++ b/extensions/amp-base-carousel/1.0/base-carousel.jss.js
@@ -18,10 +18,6 @@ import {createUseStyles} from 'react-jss';
 
 const scrollContainer = {
   position: 'relative',
-  top: 0,
-  left: 0,
-  right: 0,
-  bottom: 0,
   boxSizing: 'content-box !important',
   width: '100%',
   height: '100%',

--- a/extensions/amp-base-carousel/1.0/base-carousel.type.js
+++ b/extensions/amp-base-carousel/1.0/base-carousel.type.js
@@ -60,7 +60,7 @@ BaseCarouselDef.SlideProps;
  *   customArrow: (PreactDef.VNode|undefined),
  *   by: number,
  *   disabled: (boolean|undefined),
- *   outsetArrows: (boolean|undefined)
+ *   outsetArrows: (boolean|undefined),
  * }}
  */
 BaseCarouselDef.ArrowProps;

--- a/extensions/amp-base-carousel/1.0/base-carousel.type.js
+++ b/extensions/amp-base-carousel/1.0/base-carousel.type.js
@@ -59,7 +59,8 @@ BaseCarouselDef.SlideProps;
  *   advance: (function(number):undefined|undefined),
  *   customArrow: (PreactDef.VNode|undefined),
  *   by: number,
- *   disabled: (boolean|undefined)
+ *   disabled: (boolean|undefined),
+ *   outsetArrows: (boolean|undefined)
  * }}
  */
 BaseCarouselDef.ArrowProps;

--- a/extensions/amp-base-carousel/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-base-carousel/1.0/storybook/Basic.amp.js
@@ -31,10 +31,12 @@ export default {
 
 export const Default = () => {
   const snap = boolean('snap', true);
+  const outsetArrows = boolean('outset arrows', false);
   const controls = select('show controls', ['auto', 'always', 'never']);
   return (
     <amp-base-carousel
       controls={controls}
+      outset-arrows={outsetArrows}
       snap={String(snap)}
       width="440"
       height="225"

--- a/extensions/amp-base-carousel/1.0/storybook/Basic.js
+++ b/extensions/amp-base-carousel/1.0/storybook/Basic.js
@@ -33,12 +33,14 @@ export const _default = () => {
   const slideCount = number('slide count', 5, {min: 0, max: 99});
   const snap = boolean('snap', true);
   const loop = boolean('loop', true);
+  const outsetArrows = boolean('outset arrows', false);
   const colorIncrement = Math.floor(255 / (slideCount + 1));
   const controls = select('show controls', CONTROLS);
   return (
     <BaseCarousel
       controls={controls}
       loop={loop}
+      outsetArrows={outsetArrows}
       snap={snap}
       style={{width, height}}
     >
@@ -64,6 +66,7 @@ export const _default = () => {
 };
 
 export const provideArrows = () => {
+  const outsetArrows = boolean('outset arrows', false);
   const width = number('width', 440);
   const height = number('height', 225);
   const controls = select('show controls', CONTROLS);
@@ -87,6 +90,7 @@ export const provideArrows = () => {
     <BaseCarousel
       controls={controls}
       style={{width, height}}
+      outsetArrows={outsetArrows}
       arrowPrev={<MyButton>←</MyButton>}
       arrowNext={<MyButton>→</MyButton>}
     >

--- a/extensions/amp-base-carousel/1.0/test/test-amp-base-carousel.js
+++ b/extensions/amp-base-carousel/1.0/test/test-amp-base-carousel.js
@@ -287,7 +287,7 @@ describes.realWin(
       expect(buttons).to.have.length(2);
     });
 
-    it('should render not arrows when controls=never', async () => {
+    it('should not render arrows when controls=never', async () => {
       element.setAttribute('controls', 'never');
       const userSuppliedChildren = setSlides(3);
       userSuppliedChildren.forEach((child) => element.appendChild(child));
@@ -301,7 +301,8 @@ describes.realWin(
       expect(buttons).to.have.length(0);
     });
 
-    it('should respect outset-arrows', async () => {
+    it('should respect outset-arrows even if controls=never', async () => {
+      element.setAttribute('controls', 'never');
       element.setAttribute('outset-arrows', '');
       const userSuppliedChildren = setSlides(3);
       userSuppliedChildren.forEach((child) => element.appendChild(child));

--- a/extensions/amp-base-carousel/1.0/test/test-amp-base-carousel.js
+++ b/extensions/amp-base-carousel/1.0/test/test-amp-base-carousel.js
@@ -300,5 +300,25 @@ describes.realWin(
       const buttons = element.shadowRoot.querySelectorAll('button');
       expect(buttons).to.have.length(0);
     });
+
+    it('should respect outset-arrows', async () => {
+      element.setAttribute('outset-arrows', '');
+      const userSuppliedChildren = setSlides(3);
+      userSuppliedChildren.forEach((child) => element.appendChild(child));
+      win.document.body.appendChild(element);
+
+      await whenCalled(env.sandbox.spy(element, 'attachShadow'));
+      const shadow = element.shadowRoot;
+
+      // Container is 300px and arrows each take up 50px after padding
+      expect(element.offsetWidth).to.equal(300);
+      const scroller = shadow.querySelector(`[class*=${styles.hideScrollbar}]`);
+      expect(scroller.offsetWidth).to.equal(200);
+
+      const prevButton = shadow.querySelector(`[class*=${styles.arrowPrev}]`);
+      expect(prevButton.offsetWidth).to.equal(36);
+      const nextButton = shadow.querySelector(`[class*=${styles.arrowNext}]`);
+      expect(nextButton.offsetWidth).to.equal(36);
+    });
   }
 );

--- a/extensions/amp-base-carousel/1.0/test/test-base-carousel.js
+++ b/extensions/amp-base-carousel/1.0/test/test-base-carousel.js
@@ -122,6 +122,17 @@ describes.sandboxed('BaseCarousel preact component', {}, () => {
     expect(wrapper.find('Arrow')).to.have.lengthOf(2);
   });
 
+  it('should render Arrows with controls=never and outset-arrows', () => {
+    const wrapper = mount(
+      <BaseCarousel controls="never" outsetArrows>
+        <div>slide 1</div>
+        <div>slide 2</div>
+        <div>slide 3</div>
+      </BaseCarousel>
+    );
+    expect(wrapper.find('Arrow')).to.have.lengthOf(2);
+  });
+
   it('should not render Arrows with controls=never', () => {
     const wrapper = mount(
       <BaseCarousel controls="never">


### PR DESCRIPTION
This PR adds the `outsetArrows` prop to `amp-base-carousel` with unit tests. 

`outsetArrows` = `Boolean`
- Whether to display next and prev arrows beside the carousel (`true`) or on top of it (`false`). Defaults to `false`. 
- When `true`, there are the following additional side effects: 
  - The width of the slides is `100px` less than the width of the full carousel to account for the arrows (`50px` each). 
  - `controls` attribute is ignored and defaults to value `"always"`
- `true`:
![image](https://user-images.githubusercontent.com/10456171/95923917-839ed200-0d84-11eb-9b24-55ddeef4abf6.png)

- `false`:
![image](https://user-images.githubusercontent.com/10456171/95923919-85689580-0d84-11eb-9301-85dbd0b2387d.png)

Note this prop was originally exclusive to `amp-stream-gallery` but is being moved to `amp-base-carousel` instead. Partial for #28284