### PR TITLE
[amp-story-player] Pass object with controls key

### DIFF
--- a/src/amp-story-player/amp-story-player-impl.js
+++ b/src/amp-story-player/amp-story-player-impl.js
@@ -453,7 +453,7 @@ export class AmpStoryPlayer {
     }
 
     try {
-      this.playerConfig_ = /** @type {@ConfigDef} */ (parseJson(
+      this.playerConfig_ = /** @type {!ConfigDef} */ (parseJson(
         scriptTag.textContent
       ));
     } catch (reason) {

--- a/src/amp-story-player/amp-story-player-impl.js
+++ b/src/amp-story-player/amp-story-player-impl.js
@@ -121,6 +121,13 @@ let DocumentStateTypeDef;
  */
 let StoryDef;
 
+/**
+ * @typedef {{
+ *   controls: (!Array),
+ * }}
+ */
+let ConfigDef;
+
 /** @type {string} */
 const TAG = 'amp-story-player';
 
@@ -178,7 +185,7 @@ export class AmpStoryPlayer {
     /** @private {!SwipingState} */
     this.swipingState_ = SwipingState.NOT_SWIPING;
 
-    /** @private {?JsonObject} */
+    /** @private {?ConfigDef} */
     this.playerConfig_ = null;
 
     /** @private {!Object} */
@@ -429,7 +436,7 @@ export class AmpStoryPlayer {
   /**
    * Gets publisher configuration for the player
    * @private
-   * @return {?JsonObject}
+   * @return {?ConfigDef}
    */
   readPlayerConfig_() {
     if (this.playerConfig_) {
@@ -445,12 +452,15 @@ export class AmpStoryPlayer {
       throw new Error('<script> child must have type="application/json"');
     }
 
+    let config;
     try {
-      this.playerConfig_ = parseJson(scriptTag.textContent);
+      config = parseJson(scriptTag.textContent);
     } catch (reason) {
       console /*OK*/
         .error(`[${TAG}] `, reason);
     }
+    this.playerConfig_ = {};
+    this.playerConfig_.controls = config['controls'];
 
     return this.playerConfig_;
   }
@@ -546,11 +556,12 @@ export class AmpStoryPlayer {
             );
           });
 
-          const customControls =
-            this.playerConfig_ && this.playerConfig_['controls'];
-
-          if (customControls) {
-            messaging.sendRequest('customDocumentUI', customControls, false);
+          if (this.playerConfig_) {
+            messaging.sendRequest(
+              'customDocumentUI',
+              /** @type {!JsonObject} */ (this.playerConfig_),
+              false
+            );
           }
 
           resolve(messaging);

--- a/src/amp-story-player/amp-story-player-impl.js
+++ b/src/amp-story-player/amp-story-player-impl.js
@@ -452,15 +452,14 @@ export class AmpStoryPlayer {
       throw new Error('<script> child must have type="application/json"');
     }
 
-    let config;
     try {
-      config = parseJson(scriptTag.textContent);
+      this.playerConfig_ = /** @type {@ConfigDef} */ (parseJson(
+        scriptTag.textContent
+      ));
     } catch (reason) {
       console /*OK*/
         .error(`[${TAG}] `, reason);
     }
-    this.playerConfig_ = {};
-    this.playerConfig_.controls = config['controls'];
 
     return this.playerConfig_;
   }
@@ -559,7 +558,7 @@ export class AmpStoryPlayer {
           if (this.playerConfig_) {
             messaging.sendRequest(
               'customDocumentUI',
-              /** @type {!JsonObject} */ (this.playerConfig_),
+              dict({'controls': this.playerConfig_.controls}),
               false
             );
           }

--- a/src/amp-story-player/amp-story-player-impl.js
+++ b/src/amp-story-player/amp-story-player-impl.js
@@ -555,7 +555,7 @@ export class AmpStoryPlayer {
             );
           });
 
-          if (this.playerConfig_) {
+          if (this.playerConfig_ && this.playerConfig_.controls) {
             messaging.sendRequest(
               'customDocumentUI',
               dict({'controls': this.playerConfig_.controls}),


### PR DESCRIPTION
Follow up for #30500

When sending a `customDocumentUI ` message, passes a new object with the "controls" key for future-proofing.

<!--
# Instructions:

- Pick a meaningful title for your pull request. (Use sentence case.)
  - Prefix the title with an emoji to identify what is being done. (Copy-paste the emoji from the list below.)
  - Do not overuse punctuation in the title (like `(chore):`).
  - If it is helpful, use a simple prefix (like `ProjectX: Implement some feature`).
- Enter a succinct description that says why the PR is necessary, and what it does.
  - Mention the GitHub issue that is being addressed by the pull request.
  - The keywords `Fixes`, `Closes`, or `Resolves` followed the issue number will automatically close the issue.

> NOTE: All non-trivial changes (like introducing new features or components) should have an associated issue or reference an I2I (intent-to-implement: go.amp.dev/i2i). Please read through the contribution process (go.amp.dev/contributing/code) for more information.

# Example of a good description:

- Implement aspect X
- Leave out feature Y because of A
- Improve performance by B
- Improve accessibility by C

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Reverting a previous change
♻️ Refactoring
🚮 Deleting code
🧪 Experimental code
-->
