### PR TITLE
🏗 Pin `yarn` stable version to v1.22.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,6 @@ notifications:
     on_success: change
     on_failure: change
 before_install:
-  # Install Yarn v1.22.5 (Xenial's built-in version v1.15.2 is outdated)
-  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.22.5
-  - export PATH="$HOME/.yarn/bin:$HOME/.config/yarn/global/node_modules/.bin:$PATH"
   # Override Xenial's default Java version (github.com/travis-ci/travis-ci/issues/10290)
   - export PATH=$(echo "$PATH" | sed -e 's/:\/usr\/local\/lib\/jvm\/openjdk11\/bin//')
   - export JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64

--- a/build-system/common/check-package-manager.js
+++ b/build-system/common/check-package-manager.js
@@ -183,9 +183,10 @@ function getNodeLatestLtsVersion(distributionsJson) {
 // If yarn is being run, perform a version check and proceed with the install.
 function checkYarnVersion() {
   const yarnVersion = getStdout(yarnExecutable + ' --version').trim();
-  // TODO (KB): Revert #30478 once `yarn` stable is fixed
-  // At this time current stable is failing GPG checks.
-  const stableVersion = '1.22.5';
+  // TODO (kristoferbaxter): Remove once yarn stable is fixed.
+  // TODO (rsimha): Revisit the use of yarn v1 for AMP package management.
+  // At this time current stable version is failing GPG checks, so we use 1.22.4.
+  const stableVersion = '1.22.4';
   if (stableVersion === '') {
     console.log(
       yellow(


### PR DESCRIPTION
AMP uses `yarn` v1 for package management. The latest two stable versions 1.22.10 and 1.22.5 appear to have intermittent [GPG signature problems](https://travis-ci.org/github/ampproject/amphtml/jobs/735788977#L326) during installation. This PR does two things:

- Pins the local dev version of `yarn` to 1.22.4
- Removes the extra installation step for Travis' Xenial machines, which now come with 1.22.4 preinstalled

The long term fix is to pursue a replacement of our package management solution via #30518.
