### PR TITLE
🐛Fix binary poll not clamping more than two lines

### DIFF
--- a/extensions/amp-story-interactive/0.1/amp-story-interactive-binary-poll.css
+++ b/extensions/amp-story-interactive/0.1/amp-story-interactive-binary-poll.css
@@ -117,12 +117,12 @@
   margin: 0 !important;
   line-height: 1.3em !important;
   width: 4.42em !important;
-  height: 1.3em !important;
   display: flex !important;
   align-items: center !important;
   justify-content: center !important;
   transition: transform var(--i-amphtml-interactive-animation-time)
     var(--i-amphtml-interactive-ease-out-curve) !important;
+  height: 2.6em !important;
 }
 
 .i-amphtml-story-interactive-post-selection
@@ -138,6 +138,7 @@
   -webkit-box-orient: vertical !important;
   transition: transform var(--i-amphtml-interactive-animation-time)
     var(--i-amphtml-interactive-ease-out-curve) !important;
+  max-height: 2.6em !important;
 }
 
 .i-amphtml-story-interactive-post-selection
@@ -156,7 +157,7 @@
 
 .i-amphtml-story-interactive-post-selection
   .i-amphtml-story-interactive-option-percentage-text {
-  transform: scale(1) !important;
+  transform: scale(1) translateY(-0.75em) !important;
 }
 
 .i-amphtml-story-interactive-active:not(.i-amphtml-story-interactive-post-selection) 


### PR DESCRIPTION
Binary polls with more than two lines on the title would not clamp the text appropriately.

This PR adds a max-width equal to 2 line-heights for the title container, and moves back the percentage to occupy the space it already did when the height of the title is at one line.

This is what the error looked like:
![image](https://user-images.githubusercontent.com/22420856/96033521-295a4b80-0e2e-11eb-8bad-61170cd0b4ba.png)

This is how it looks like now:
![image](https://user-images.githubusercontent.com/22420856/96033082-9e795100-0e2d-11eb-92be-43f65d688eba.png)

Fixes #30657 