### PR TITLE
🐛  Ads was missing 'height' attribute

### DIFF
--- a/extensions/amp-auto-ads/0.1/alright-network-config.js
+++ b/extensions/amp-auto-ads/0.1/alright-network-config.js
@@ -69,7 +69,8 @@ export class AlrightNetworkConfig {
   /** @override */
   getAttributes() {
     const attributes = dict({
-      'layout': 'fixed',
+      'layout': 'fluid',
+      'height': 'fluid',
       'data-multi-size-validation': 'false',
       'type': 'doubleclick',
       'data-ad': 'alright',

--- a/extensions/amp-auto-ads/0.1/alright-network-config.js
+++ b/extensions/amp-auto-ads/0.1/alright-network-config.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {Layout} from '../../../src/layout';
 import {Services} from '../../../src/services';
 import {buildUrl} from '../../../ads/google/a4a/shared/url-builder';
 import {dict} from '../../../src/utils/object';
@@ -69,8 +70,9 @@ export class AlrightNetworkConfig {
   /** @override */
   getAttributes() {
     const attributes = dict({
-      'layout': 'fluid',
-      'height': 'fluid',
+      'width': 300,
+      'height': 250,
+      'layout': Layout.RESPONSIVE,
       'data-multi-size-validation': 'false',
       'type': 'doubleclick',
       'data-ad': 'alright',
@@ -95,6 +97,9 @@ export class AlrightNetworkConfig {
 
   /** @override */
   getSizing() {
-    return {};
+    return {
+      width: 300,
+      height: 250,
+    };
   }
 }

--- a/extensions/amp-auto-ads/0.1/attributes.js
+++ b/extensions/amp-auto-ads/0.1/attributes.js
@@ -27,6 +27,9 @@ const TAG = 'amp-auto-ads';
 const NON_DATA_ATTRIBUTE_ALLOWLIST = {
   'type': true,
   'rtc-config': true,
+  'layout': true,
+  'height': true,
+  'width': true,
 };
 
 /**

--- a/extensions/amp-auto-ads/0.1/test/test-alright-network-config.js
+++ b/extensions/amp-auto-ads/0.1/test/test-alright-network-config.js
@@ -67,8 +67,9 @@ describes.realWin(
       it('should generate the attributes', () => {
         const adNetwork = getAdNetworkConfig('alright', ampAutoAdsElem);
         expect(adNetwork.getAttributes()).to.deep.equal({
-          'layout': 'fluid',
-          'height': 'fluid',
+          'width': 300,
+          'height': 250,
+          'layout': 'responsive',
           'data-multi-size-validation': 'false',
           'type': 'doubleclick',
           'data-ad': 'alright',

--- a/extensions/amp-auto-ads/0.1/test/test-alright-network-config.js
+++ b/extensions/amp-auto-ads/0.1/test/test-alright-network-config.js
@@ -67,7 +67,8 @@ describes.realWin(
       it('should generate the attributes', () => {
         const adNetwork = getAdNetworkConfig('alright', ampAutoAdsElem);
         expect(adNetwork.getAttributes()).to.deep.equal({
-          'layout': 'fixed',
+          'layout': 'fluid',
+          'height': 'fluid',
           'data-multi-size-validation': 'false',
           'type': 'doubleclick',
           'data-ad': 'alright',

--- a/extensions/amp-auto-ads/0.1/test/test-attributes.js
+++ b/extensions/amp-auto-ads/0.1/test/test-attributes.js
@@ -43,6 +43,7 @@ describe('attributes', () => {
       getAttributesFromConfigObj(configObj, Attributes.BASE_ATTRIBUTES)
     ).to.deep.equal({
       'type': 'val2',
+      'layout': 'val3',
       'data-something': 'val5',
       'data-1234': 'val6',
     });


### PR DESCRIPTION
changed the 'layout' attribute value to 'fluid'.
added 'height' attribute.
