### PR TITLE
🐛 Align 'activate 360' button with header UI

### DIFF
--- a/extensions/amp-story-360/0.1/amp-story-360.css
+++ b/extensions/amp-story-360/0.1/amp-story-360.css
@@ -27,8 +27,8 @@ amp-story-360 amp-img {
 
 .i-amphtml-story-360-activate-button {
   position: absolute !important;
-  bottom: 8px !important;
-  right: 8px !important;
+  bottom: 12px !important;
+  right: 12px !important;
   background: rgba(0, 0, 0, .8) !important;
   color: white !important;
   outline: none !important;


### PR DESCRIPTION
Align `activate 360` button with header UI for system UI consistency.

<img width="303" alt="Screen Shot 2020-10-15 at 11 34 32 AM" src="https://user-images.githubusercontent.com/3860311/96152308-6845db00-0eda-11eb-8178-d9a15ac52a4b.png">

cc @ampproject/wg-stories @hongcatlover 