### PR TITLE
🏗 Fix errors in new server transforms and make logs less noisy

### DIFF
--- a/build-system/server/new-server/transforms/tsconfig.json
+++ b/build-system/server/new-server/transforms/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compileOnSave": true,
   "compilerOptions": {
-    "lib": ["esnext"],
+    "lib": ["dom", "esnext"],
     "outDir": "dist",
     "sourceMap": true,
     "moduleResolution": "node",

--- a/build-system/server/new-server/transforms/utilities/script.ts
+++ b/build-system/server/new-server/transforms/utilities/script.ts
@@ -19,8 +19,6 @@ import {URL} from 'url';
 import {extname} from 'path';
 import {VALID_CDN_ORIGIN} from './cdn';
 import {parse, format} from 'path';
-import log from 'fancy-log';
-import {cyan, yellow} from 'ansi-colors';
 
 export interface ScriptNode extends PostHTML.Node {
   tag: 'script';
@@ -76,17 +74,14 @@ export function toExtension(url: URL, extension: string): URL {
 
 /**
  * This is a temporary measure to allow for a relaxed parsing of our
- * fixture files src url's before they are all fixed accordingly.
+ * fixture files' src urls before they are all fixed accordingly.
  */
 export function tryGetUrl(src: string, port: number = 8000): URL {
   let url;
   try {
     url = new URL(src);
   } catch (e) {
-    const resource = `http://localhost:${port}`;
-    log(yellow('WARNING:'), cyan(`Resource name given "${src}" is implied ` +
-      `to be localhost. Using ${resource}.`));
-    url = new URL(src, resource);
+    url = new URL(src, `http://localhost:${port}`);
   } finally {
     return url as URL;
   }


### PR DESCRIPTION
Two small fixes in this PR:

1. Explicitly adds a dependency [on the `dom` library](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/29733#issuecomment-430077183). (The implicit dependency is causing errors in an [unrelated PR](https://github.com/ampproject/amphtml/pull/29967).)
![image](https://user-images.githubusercontent.com/26553114/96205652-17170500-0f35-11eb-9bac-bb825e778185.png)
2. Silences a message so that Travis and local testing logs are less noisy.
![image](https://user-images.githubusercontent.com/26553114/96205713-488fd080-0f35-11eb-876e-3fc892e60cd1.png)



