### PR TITLE
🏗 Pre-emptive lint fixes + clean up

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -10,7 +10,7 @@
     },
     {
       "files": "*.md",
-      "options": {"parser": "markdown"}
+      "options": {"parser": "markdown", "embeddedLanguageFormatting": "off"}
     },
     {
       "files": [".prettierrc", ".renovaterc.json", "*.json"],

--- a/build-system/tasks/lint.js
+++ b/build-system/tasks/lint.js
@@ -191,7 +191,7 @@ function getFilesToLint(files) {
  */
 function lint() {
   maybeUpdatePackages();
-  let filesToLint = config.lintGlobs;
+  let filesToLint = globby.sync(config.lintGlobs, {gitignore: true});
   if (argv.files) {
     filesToLint = getFilesToLint(getFilesFromArgv());
   } else if (!eslintRulesChanged() && argv.local_changes) {

--- a/contributing/TESTING.md
+++ b/contributing/TESTING.md
@@ -159,7 +159,7 @@ There are 5 serving modes:
 - RTV mode serves the bundle from the given RTV number (a 15 digit number). E.g. `001907161745080`. Serve RTV mode by running `gulp serve --rtv <rtv_number>`
 - ESM mode serves the esm (module) binaries. First run `gulp dist --fortesting --esm` and then serve esm mode by running `gulp serve --new_server --esm`. _This mode is new, and under active development._
 
-To switch serving mode during runtime, go to http://localhost:8000/serve_mode=\$mode and set the `$mode` to one of the following values: `default`, `compiled`, `cdn` or `<RTV_NUMBER>`.
+To switch serving mode during runtime, go to http://localhost:8000/serve_mode=MODE and set `MODE` to one of the following values: `default`, `compiled`, `cdn` or `<RTV_NUMBER>`.
 
 ### Examples
 

--- a/contributing/TESTING.md
+++ b/contributing/TESTING.md
@@ -159,7 +159,7 @@ There are 5 serving modes:
 - RTV mode serves the bundle from the given RTV number (a 15 digit number). E.g. `001907161745080`. Serve RTV mode by running `gulp serve --rtv <rtv_number>`
 - ESM mode serves the esm (module) binaries. First run `gulp dist --fortesting --esm` and then serve esm mode by running `gulp serve --new_server --esm`. _This mode is new, and under active development._
 
-To switch serving mode during runtime, go to http://localhost:8000/serve_mode=$mode and set the `$mode` to one of the following values: `default`, `compiled`, `cdn` or `<RTV_NUMBER>`.
+To switch serving mode during runtime, go to http://localhost:8000/serve_mode=\$mode and set the `$mode` to one of the following values: `default`, `compiled`, `cdn` or `<RTV_NUMBER>`.
 
 ### Examples
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -15637,15 +15637,10 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@2.1.2:
+prettier@2.1.2, prettier@^2.0.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.1.2.tgz#3050700dae2e4c8b67c4c3f666cdb8af405e1ce5"
   integrity sha512-16c7K+x4qVlJg9rEbXl7HEGmQyZlG4R9AgP+oHKRMsMsuk8s+ATStlf1NpDqyBI1HpVyfjLOeMhH2LvuNvV5Vg==
-
-prettier@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.0.1.tgz#3f00ac71263be34684b2b2c8d7e7f63737592dac"
-  integrity sha512-piXGBcY1zoFOG0MvHpNE5reAGseLmaCRifQ/fmfF49BcYkInEs/naD/unxGNAeOKFA5+JxVrPyMvMlpzcd20UA==
 
 pretty-bytes@5.4.1, pretty-bytes@^5.1.0:
   version "5.4.1"


### PR DESCRIPTION
Yarn can sometimes incorrectly resolve [caret semver versions](https://docs.npmjs.com/misc/semver#caret-ranges-123-025-004) in its lockfile (typically during upgrades). E.g. `prettier` version `^2.0.0` is resolved to `2.0.1` instead of `2.1.2` in [`yarn.lock`](https://raw.githubusercontent.com/ampproject/amphtml/d3202baae0d7959edd375a0f672e2970a4ec041b/yarn.lock) (search for `"prettier@^2.0.0:"`). NPM correctly resolves caret versions, and doesn't have this bug.

This PR contains a couple of pre-emptive fixes that will prevent a bunch of new Prettier errors from appearing when we switch from Yarn to NPM:

1. Updates the default globs used by `gulp lint` to explicitly ignore files in `.gitignore`
2. Uses the exact same `prettier` version for `gulp lint` and `gulp prettify`

With this PR, the switch from Yarn to NPM should be free of any new linting errors.

Unblocks #30694