### PR TITLE
✨ [bento][amp-accordion] Protect id attribute on content in accordion section for a11y (1st approach)

### DIFF
--- a/extensions/amp-accordion/1.0/accordion.js
+++ b/extensions/amp-accordion/1.0/accordion.js
@@ -160,6 +160,7 @@ export function AccordionSection({
   contentAs: ContentComp = 'div',
   expanded: defaultExpanded = false,
   animate: defaultAnimate = false,
+  contentId,
   header,
   children,
   ...rest
@@ -199,7 +200,8 @@ export function AccordionSection({
 
   const expanded = isExpanded ? isExpanded(id, defaultExpanded) : expandedState;
   const animate = contextAnimate ?? defaultAnimate;
-  const contentId = `${prefix || 'a'}-content-${id}-${suffix}`;
+  const finalContentId =
+    contentId || `${prefix || 'a'}-content-${id}-${suffix}`;
 
   useLayoutEffect(() => {
     const hasMounted = hasMountedRef.current;
@@ -214,7 +216,7 @@ export function AccordionSection({
     <Comp {...rest} expanded={expanded} aria-expanded={String(expanded)}>
       <HeaderComp
         role="button"
-        aria-controls={contentId}
+        aria-controls={finalContentId}
         tabIndex="0"
         style={CHILD_STYLE}
         onClick={expandHandler}
@@ -222,7 +224,7 @@ export function AccordionSection({
         {header}
       </HeaderComp>
       <ContentComp
-        id={contentId}
+        id={finalContentId}
         ref={contentRef}
         style={CHILD_STYLE}
         hidden={!expanded}

--- a/extensions/amp-accordion/1.0/accordion.type.js
+++ b/extensions/amp-accordion/1.0/accordion.type.js
@@ -36,6 +36,7 @@ AccordionDef.Props;
  *   contentAs: (string|PreactDef.FunctionalComponent|undefined),
  *   expanded: (boolean|undefined),
  *   animate: (boolean|undefined),
+ *   contentId: (?string|undefined),
  *   header: (!PreactDef.Renderable),
  *   children: (?PreactDef.Renderable|undefined),
  * }}

--- a/extensions/amp-accordion/1.0/amp-accordion.js
+++ b/extensions/amp-accordion/1.0/amp-accordion.js
@@ -87,12 +87,15 @@ function getState(element, mu) {
       bindContentShimToElement
     );
     const expanded = section.hasAttribute('expanded');
+    const contentId =
+      section.lastElementChild && section.lastElementChild.getAttribute('id');
     const props = dict({
       'key': section,
       'as': sectionShim,
       'headerAs': headerShim,
       'contentAs': contentShim,
       'expanded': expanded,
+      'contentId': contentId,
     });
     return <AccordionSection {...props} />;
   });

--- a/extensions/amp-accordion/1.0/test/test-accordion.js
+++ b/extensions/amp-accordion/1.0/test/test-accordion.js
@@ -94,7 +94,12 @@ describes.sandboxed('Accordion preact component', {}, (env) => {
     beforeEach(() => {
       wrapper = mount(
         <Accordion>
-          <AccordionSection key={1} expanded header="header1">
+          <AccordionSection
+            key={1}
+            expanded
+            header="header1"
+            contentId="testId"
+          >
             content1
           </AccordionSection>
           <AccordionSection key={2} header="header2">
@@ -155,6 +160,8 @@ describes.sandboxed('Accordion preact component', {}, (env) => {
       expect(header0.getAttribute('aria-controls')).to.equal(
         content0.getAttribute('id')
       );
+      expect(header0.getAttribute('aria-controls')).to.equal('testId');
+      expect(content0.getAttribute('id')).to.equal('testId');
 
       expect(sections.at(1).getDOMNode()).to.have.attribute('aria-expanded');
       expect(header1).to.have.attribute('tabindex');

--- a/extensions/amp-accordion/1.0/test/test-amp-accordion.js
+++ b/extensions/amp-accordion/1.0/test/test-amp-accordion.js
@@ -45,7 +45,7 @@ describes.realWin(
         <amp-accordion layout="fixed" width="300" height="200">
           <section expanded>
             <h1>header1</h1>
-            <div>content1</div>
+            <div id="testId">content1</div>
           </section>
           <section>
             <h1>header2</h1>
@@ -172,6 +172,8 @@ describes.realWin(
       expect(header0.getAttribute('aria-controls')).to.equal(
         content0.getAttribute('id')
       );
+      expect(header0.getAttribute('aria-controls')).to.equal('testId');
+      expect(content0.getAttribute('id')).to.equal('testId');
 
       expect(sections[1]).to.have.attribute('aria-expanded');
       expect(header1).to.have.attribute('tabindex');


### PR DESCRIPTION
Accordion sections have a header and a content node.  The `aria-controls` on the header matches the `id` on the content node.  This is generally set by component logic.  However, if the `id` on the content is provided by the publisher, we should not overwrite it.

This change takes that `id` (if it exists) and puts it into `aria-controls` of the header.  Previously, a random id generated by the component would be used in both the `id` of the section and the `aria-controls` of the header, overwriting the existing publisher provided `id`.

This change matches `0.1` logic.

------

This changes introduces a `contentId` prop to the `AccordionSection`.  This is a small API change in Preact mode, however, the API in Preact is already somewhat different than `0.1` amp mode (not a direct mapping) so does not seem like a big issue.

An alternative approach that does not introduce this API change could be to update the `header` shim in `amp` side code to take in another variable and pass in an `id` before sending the shim to Preact side.  This could be worth considering as well and am open to comments.  I opted against this as the design seems slightly less readable, and the API change seems minor.
