### PR TITLE
✨ [bento][amp-accordion] Move aria-expanded from section to header

### DIFF
--- a/extensions/amp-accordion/1.0/accordion.js
+++ b/extensions/amp-accordion/1.0/accordion.js
@@ -211,13 +211,14 @@ export function AccordionSection({
   }, [expanded, animate]);
 
   return (
-    <Comp {...rest} expanded={expanded} aria-expanded={String(expanded)}>
+    <Comp {...rest} expanded={expanded}>
       <HeaderComp
         role="button"
         aria-controls={contentId}
         tabIndex="0"
         style={CHILD_STYLE}
         onClick={expandHandler}
+        aria-expanded={String(expanded)}
       >
         {header}
       </HeaderComp>

--- a/extensions/amp-accordion/1.0/amp-accordion.js
+++ b/extensions/amp-accordion/1.0/amp-accordion.js
@@ -107,7 +107,6 @@ function getState(element, mu) {
 function SectionShim(sectionElement, {expanded, children}) {
   useLayoutEffect(() => {
     toggleAttribute(sectionElement, 'expanded', expanded);
-    sectionElement.setAttribute('aria-expanded', String(expanded));
     if (sectionElement[SECTION_POST_RENDER]) {
       sectionElement[SECTION_POST_RENDER]();
     }
@@ -126,7 +125,10 @@ const bindSectionShimToElement = (element) => SectionShim.bind(null, element);
  * @param {!AccordionDef.HeaderProps} props
  * @return {PreactDef.Renderable}
  */
-function HeaderShim(sectionElement, {onClick, 'aria-controls': ariaControls}) {
+function HeaderShim(
+  sectionElement,
+  {onClick, 'aria-controls': ariaControls, 'aria-expanded': ariaExpanded}
+) {
   const headerElement = sectionElement.firstElementChild;
   useLayoutEffect(() => {
     if (!headerElement || !onClick) {
@@ -136,6 +138,7 @@ function HeaderShim(sectionElement, {onClick, 'aria-controls': ariaControls}) {
     if (!headerElement.hasAttribute('tabindex')) {
       headerElement.setAttribute('tabindex', 0);
     }
+    headerElement.setAttribute('aria-expanded', ariaExpanded);
     headerElement.setAttribute('aria-controls', ariaControls);
     headerElement.setAttribute('role', 'button');
     if (sectionElement[SECTION_POST_RENDER]) {
@@ -144,7 +147,7 @@ function HeaderShim(sectionElement, {onClick, 'aria-controls': ariaControls}) {
     return () => {
       headerElement.removeEventListener('click', devAssert(onClick));
     };
-  }, [sectionElement, headerElement, onClick, ariaControls]);
+  }, [sectionElement, headerElement, onClick, ariaControls, ariaExpanded]);
   return <header />;
 }
 

--- a/extensions/amp-accordion/1.0/test/test-accordion.js
+++ b/extensions/amp-accordion/1.0/test/test-accordion.js
@@ -28,12 +28,12 @@ describes.sandboxed('Accordion preact component', {}, (env) => {
       const dom = wrapper.getDOMNode();
       expect(dom.localName).to.equal('section');
       expect(dom).to.not.have.attribute('expanded');
-      expect(dom.getAttribute('aria-expanded')).to.equal('false');
       expect(dom.children).to.have.lengthOf(2);
 
       const header = dom.children[0];
       expect(header.localName).to.equal('header');
       expect(header.innerHTML).to.equal('<h1>header1</h1>');
+      expect(header.getAttribute('aria-expanded')).to.equal('false');
 
       const content = dom.children[1];
       expect(content.localName).to.equal('div');
@@ -50,11 +50,11 @@ describes.sandboxed('Accordion preact component', {}, (env) => {
 
       const dom = wrapper.getDOMNode();
       expect(dom).to.have.attribute('expanded');
-      expect(dom.getAttribute('aria-expanded')).to.equal('true');
 
       const header = dom.children[0];
       expect(header.localName).to.equal('header');
       expect(header.innerHTML).to.equal('<h1>header1</h1>');
+      expect(header.getAttribute('aria-expanded')).to.equal('true');
 
       const content = dom.children[1];
       expect(content.localName).to.equal('div');
@@ -67,23 +67,24 @@ describes.sandboxed('Accordion preact component', {}, (env) => {
         <AccordionSection header={<h1>header1</h1>}>content1</AccordionSection>
       );
       const dom = wrapper.getDOMNode();
+      const header = dom.children[0];
       const content = dom.children[1];
 
       // Start unexpanded.
       expect(dom).to.not.have.attribute('expanded');
-      expect(dom.getAttribute('aria-expanded')).to.equal('false');
+      expect(header.getAttribute('aria-expanded')).to.equal('false');
       expect(content.hidden).to.be.true;
 
       // Click on header to expand.
       wrapper.find('header').simulate('click');
       expect(dom).to.have.attribute('expanded');
-      expect(dom.getAttribute('aria-expanded')).to.equal('true');
+      expect(header.getAttribute('aria-expanded')).to.equal('true');
       expect(content.hidden).to.be.false;
 
       // Click on header again to collapse.
       wrapper.find('header').simulate('click');
       expect(dom).to.not.have.attribute('expanded');
-      expect(dom.getAttribute('aria-expanded')).to.equal('false');
+      expect(header.getAttribute('aria-expanded')).to.equal('false');
       expect(content.hidden).to.be.true;
     });
   });
@@ -147,28 +148,31 @@ describes.sandboxed('Accordion preact component', {}, (env) => {
       const content1 = sections.at(1).find('div').getDOMNode();
       const content2 = sections.at(2).find('div').getDOMNode();
 
-      expect(sections.at(0).getDOMNode()).to.have.attribute('aria-expanded');
       expect(header0).to.have.attribute('tabindex');
       expect(header0).to.have.attribute('aria-controls');
       expect(header0).to.have.attribute('role');
+      expect(header0).to.have.attribute('aria-expanded');
+      expect(header0.getAttribute('aria-expanded')).to.equal('true');
       expect(content0).to.have.attribute('id');
       expect(header0.getAttribute('aria-controls')).to.equal(
         content0.getAttribute('id')
       );
 
-      expect(sections.at(1).getDOMNode()).to.have.attribute('aria-expanded');
       expect(header1).to.have.attribute('tabindex');
       expect(header1).to.have.attribute('aria-controls');
       expect(header1).to.have.attribute('role');
+      expect(header1).to.have.attribute('aria-expanded');
+      expect(header1.getAttribute('aria-expanded')).to.equal('false');
       expect(content1).to.have.attribute('id');
       expect(header1.getAttribute('aria-controls')).to.equal(
         content1.getAttribute('id')
       );
 
-      expect(sections.at(2).getDOMNode()).to.have.attribute('aria-expanded');
       expect(header2).to.have.attribute('tabindex');
       expect(header2).to.have.attribute('aria-controls');
       expect(header2).to.have.attribute('role');
+      expect(header2).to.have.attribute('aria-expanded');
+      expect(header2.getAttribute('aria-expanded')).to.equal('false');
       expect(content2).to.have.attribute('id');
       expect(header2.getAttribute('aria-controls')).to.equal(
         content2.getAttribute('id')

--- a/extensions/amp-accordion/1.0/test/test-amp-accordion.js
+++ b/extensions/amp-accordion/1.0/test/test-amp-accordion.js
@@ -64,15 +64,21 @@ describes.realWin(
     it('should render expanded and collapsed sections', () => {
       const sections = element.children;
       expect(sections[0]).to.have.attribute('expanded');
-      expect(sections[0].getAttribute('aria-expanded')).to.equal('true');
+      expect(
+        sections[0].firstElementChild.getAttribute('aria-expanded')
+      ).to.equal('true');
       expect(sections[0].lastElementChild).to.have.display('block');
 
       expect(sections[1]).to.not.have.attribute('expanded');
-      expect(sections[1].getAttribute('aria-expanded')).to.equal('false');
+      expect(
+        sections[1].firstElementChild.getAttribute('aria-expanded')
+      ).to.equal('false');
       expect(sections[1].lastElementChild).to.have.display('none');
 
       expect(sections[2]).to.not.have.attribute('expanded');
-      expect(sections[2].getAttribute('aria-expanded')).to.equal('false');
+      expect(
+        sections[2].firstElementChild.getAttribute('aria-expanded')
+      ).to.equal('false');
       expect(sections[2].lastElementChild).to.have.display('none');
     });
 
@@ -164,28 +170,31 @@ describes.realWin(
         lastElementChild: content2,
       } = sections[2];
 
-      expect(sections[0]).to.have.attribute('aria-expanded');
       expect(header0).to.have.attribute('tabindex');
       expect(header0).to.have.attribute('aria-controls');
       expect(header0).to.have.attribute('role');
+      expect(header0).to.have.attribute('aria-expanded');
+      expect(header0.getAttribute('aria-expanded')).to.equal('true');
       expect(content0).to.have.attribute('id');
       expect(header0.getAttribute('aria-controls')).to.equal(
         content0.getAttribute('id')
       );
 
-      expect(sections[1]).to.have.attribute('aria-expanded');
       expect(header1).to.have.attribute('tabindex');
       expect(header1).to.have.attribute('aria-controls');
       expect(header1).to.have.attribute('role');
+      expect(header1).to.have.attribute('aria-expanded');
+      expect(header1.getAttribute('aria-expanded')).to.equal('false');
       expect(content1).to.have.attribute('id');
       expect(header1.getAttribute('aria-controls')).to.equal(
         content1.getAttribute('id')
       );
 
-      expect(sections[2]).to.have.attribute('aria-expanded');
       expect(header2).to.have.attribute('tabindex');
       expect(header2).to.have.attribute('aria-controls');
       expect(header2).to.have.attribute('role');
+      expect(header2).to.have.attribute('aria-expanded');
+      expect(header2.getAttribute('aria-expanded')).to.equal('false');
       expect(content2).to.have.attribute('id');
       expect(header2.getAttribute('aria-controls')).to.equal(
         content2.getAttribute('id')


### PR DESCRIPTION
Accordion Tracker Issue: https://github.com/ampproject/amphtml/issues/30445

Move the `aria-expanded` attribute from the `section` to its first child element `header` to match `0.1`.