### PR TITLE
✨ Handle lost WebGL context

### DIFF
--- a/extensions/amp-story-360/0.1/amp-story-360.js
+++ b/extensions/amp-story-360/0.1/amp-story-360.js
@@ -458,7 +458,7 @@ export class AmpStory360 extends AMP.BaseElement {
   maybeRestoreCanvas_() {
     const distance = this.getPage_().getAttribute('distance');
     if (distance) {
-      if (parseInt(distance) < MIN_ACTIVE_WEBGL_DISTANCE && !this.canvas_) {
+      if (parseInt(distance, 10) < MIN_ACTIVE_WEBGL_DISTANCE && !this.canvas_) {
         this.setupCanvas_();
         this.layoutCallback();
       }

--- a/extensions/amp-story-360/0.1/amp-story-360.js
+++ b/extensions/amp-story-360/0.1/amp-story-360.js
@@ -346,9 +346,9 @@ export class AmpStory360 extends AMP.BaseElement {
     }
 
     this.canvasContainer_ = this.element.ownerDocument.createElement('div');
-    this.applyFillContent(this.canvasContainer_, /* replacedContent */ true);
     this.element.appendChild(this.canvasContainer_);
-    this.setUpCanvas_();
+    this.applyFillContent(this.canvasContainer_, /* replacedContent */ true);
+    this.setupCanvas_();
 
     // Initialize all services before proceeding
     return Promise.all([
@@ -439,7 +439,7 @@ export class AmpStory360 extends AMP.BaseElement {
   }
 
   /** @private */
-  setUpCanvas_() {
+  setupCanvas_() {
     this.canvas_ = this.element.ownerDocument.createElement('canvas');
     this.canvasContainer_.appendChild(this.canvas_);
 
@@ -459,7 +459,7 @@ export class AmpStory360 extends AMP.BaseElement {
     const distance = this.getPage_().getAttribute('distance');
     if (distance) {
       if (parseInt(distance) < MIN_ACTIVE_WEBGL_DISTANCE && !this.canvas_) {
-        this.setUpCanvas_();
+        this.setupCanvas_();
         this.layoutCallback();
       }
     }

--- a/extensions/amp-story-360/0.1/amp-story-360.js
+++ b/extensions/amp-story-360/0.1/amp-story-360.js
@@ -54,7 +54,7 @@ const CENTER_OFFSET = 90;
  * Minimum distance for active WebGL instances.
  * @const {number}
  */
-const MIN_ACTIVE_WEBGL_DISTANCE = 2;
+const MIN_ACTIVE_WEBGL_DISTANCE = 3;
 
 /**
  * Generates the template for the permission button.
@@ -445,8 +445,7 @@ export class AmpStory360 extends AMP.BaseElement {
 
     // This is called when there are too many WebGL instances for the browser.
     // The canvas is removed so that the WebGL context can be reset.
-    this.canvas_.addEventListener('webglcontextlost', (e) => {
-      e.preventDefault();
+    this.canvas_.addEventListener('webglcontextlost', () => {
       this.canvasContainer_.removeChild(this.canvas_);
       this.canvas_ = null;
     });

--- a/extensions/amp-story-360/0.1/amp-story-360.js
+++ b/extensions/amp-story-360/0.1/amp-story-360.js
@@ -443,7 +443,7 @@ export class AmpStory360 extends AMP.BaseElement {
     this.canvas_ = this.element.ownerDocument.createElement('canvas');
     this.canvasContainer_.appendChild(this.canvas_);
 
-    // This is called when there are too many WebGL instances for the browser.
+    // Called when there are too many WebGL instances for the browser.
     // The canvas is removed so that the WebGL context can be reset.
     this.canvas_.addEventListener('webglcontextlost', () => {
       this.canvasContainer_.removeChild(this.canvas_);


### PR DESCRIPTION
Browsers have a limit for active WebGL contexts. For chrome the maximum is 16.
If this limit is reached the WebGL context will be lost and the component will not render correctly.

This PR handles stories that exceed this limitation by:
- listening for lost webGL context in the `amp-story-360`'s canvas
- providing a method to reset the canvas if context is lost
- using the renderer's webGL context to calculate max image size

[Stress test demo](https://stories-360.web.app/examples/amp-story-360.amp.html)

Context / Fixes #29512