### PR TITLE
Move viewportCallback out of resources and into separate util.

### DIFF
--- a/extensions/amp-3d-gltf/0.1/amp-3d-gltf.js
+++ b/extensions/amp-3d-gltf/0.1/amp-3d-gltf.js
@@ -22,6 +22,7 @@ import {dict} from '../../../src/utils/object';
 import {getIframe, preloadBootstrap} from '../../../src/3p-frame';
 import {isLayoutSizeDefined} from '../../../src/layout';
 import {listenFor, postMessage} from '../../../src/iframe-helper';
+import {observe, unobserve} from '../../../src/viewport-observer';
 import {removeElement} from '../../../src/dom';
 
 const TAG = 'amp-3d-gltf';
@@ -80,6 +81,7 @@ export class Amp3dGltf extends AMP.BaseElement {
 
   /** @override */
   unlayoutCallback() {
+    unobserve(this.element);
     if (this.iframe_) {
       removeElement(this.iframe_);
       this.iframe_ = null;
@@ -145,6 +147,7 @@ export class Amp3dGltf extends AMP.BaseElement {
 
   /** @override */
   layoutCallback() {
+    observe(this.element, (inViewport) => this.viewportCallback_(inViewport));
     if (!isWebGLSupported()) {
       this.toggleFallback(true);
       return Promise.resolve();
@@ -215,10 +218,10 @@ export class Amp3dGltf extends AMP.BaseElement {
 
   /**
    * @param {boolean} inViewport
-   * @override
+   * @private
    */
-  viewportCallback(inViewport) {
-    return this.sendCommandWhenReady_('toggleAmpViewport', inViewport);
+  viewportCallback_(inViewport) {
+    this.sendCommandWhenReady_('toggleAmpViewport', inViewport);
   }
 
   /** @override */

--- a/extensions/amp-3q-player/0.1/amp-3q-player.js
+++ b/extensions/amp-3q-player/0.1/amp-3q-player.js
@@ -130,11 +130,6 @@ class Amp3QPlayer extends AMP.BaseElement {
   }
 
   /** @override */
-  viewportCallback(visible) {
-    this.element.dispatchCustomEvent(VideoEvents.VISIBILITY, {visible});
-  }
-
-  /** @override */
   pauseCallback() {
     if (this.iframe_) {
       this.pause();

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -58,6 +58,7 @@ import {installUrlReplacementsForEmbed} from '../../../src/service/url-replaceme
 import {isAdPositionAllowed} from '../../../src/ad-helper';
 import {isArray, isEnumValue, isObject} from '../../../src/types';
 import {listenOnce} from '../../../src/event-helper';
+import {observe, unobserve} from '../../../src/viewport-observer';
 import {padStart} from '../../../src/string';
 import {parseJson} from '../../../src/json';
 import {processHead} from './head-validation';
@@ -1232,6 +1233,7 @@ export class AmpA4A extends AMP.BaseElement {
 
   /** @override */
   layoutCallback() {
+    observe(this.element, (inViewport) => this.viewportCallback_(inViewport));
     if (this.isRefreshing) {
       this.destroyFrame(true);
     }
@@ -1326,6 +1328,7 @@ export class AmpA4A extends AMP.BaseElement {
 
   /** @override  */
   unlayoutCallback() {
+    unobserve(this.element);
     this.tearDownSlot();
     return true;
   }
@@ -1402,8 +1405,11 @@ export class AmpA4A extends AMP.BaseElement {
     }
   }
 
-  /** @override  */
-  viewportCallback(inViewport) {
+  /**
+   * @param {boolean} inViewport
+   * @private
+   */
+  viewportCallback_(inViewport) {
     if (this.xOriginIframeHandler_) {
       this.xOriginIframeHandler_.viewportCallback(inViewport);
     }

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -111,6 +111,7 @@ import {
   lineDelimitedStreamer,
   metaJsonCreativeGrouper,
 } from '../../../ads/google/a4a/line-delimited-response-handler';
+import {observe, unobserve} from '../../../src/viewport-observer';
 import {parseQueryString} from '../../../src/url';
 import {stringHash32} from '../../../src/string';
 import {tryParseJson} from '../../../src/json';
@@ -1132,9 +1133,11 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
     return super.renderNonAmpCreative();
   }
 
-  /** @override */
-  viewportCallback(inViewport) {
-    super.viewportCallback(inViewport);
+  /**
+   * @param {boolean} inViewport
+   * @private
+   */
+  viewportCallback_(inViewport) {
     if (this.reattemptToExpandFluidCreative_ && !inViewport) {
       // If the initial expansion attempt failed (e.g., the slot was within the
       // viewport), then we will re-attempt to expand it here whenever the slot
@@ -1143,8 +1146,14 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
     }
   }
 
+  /** @override */
+  layoutCallback() {
+    observe(this.element, (inViewport) => this.viewportCallback_(inViewport));
+  }
+
   /** @override  */
   unlayoutCallback() {
+    unobserve(this.element);
     if (this.refreshManager_) {
       this.refreshManager_.unobserve();
     }

--- a/extensions/amp-ad/0.1/amp-ad-3p-impl.js
+++ b/extensions/amp-ad/0.1/amp-ad-3p-impl.js
@@ -50,6 +50,7 @@ import {
 import {getIframe, preloadBootstrap} from '../../../src/3p-frame';
 import {listen} from '../../../src/event-helper';
 import {moveLayoutRect} from '../../../src/layout-rect';
+import {observe, unobserve} from '../../../src/viewport-observer';
 import {toWin} from '../../../src/types';
 
 /** @const {string} Tag name for 3P AD implementation. */
@@ -394,6 +395,7 @@ export class AmpAd3PImpl extends AMP.BaseElement {
       this.element
     );
 
+    observe(this.element, (inViewport) => this.viewportCallback_(inViewport));
     const consentPromise = this.getConsentState();
     const consentPolicyId = super.getConsentPolicy();
     const consentStringPromise = consentPolicyId
@@ -456,9 +458,9 @@ export class AmpAd3PImpl extends AMP.BaseElement {
 
   /**
    * @param {boolean} inViewport
-   * @override
+   * @private
    */
-  viewportCallback(inViewport) {
+  viewportCallback_(inViewport) {
     if (this.xOriginIframeHandler_) {
       this.xOriginIframeHandler_.viewportCallback(inViewport);
     }
@@ -471,6 +473,7 @@ export class AmpAd3PImpl extends AMP.BaseElement {
 
   /** @override  */
   unlayoutCallback() {
+    unobserve(this.element);
     this.unlisteners_.forEach((unlisten) => unlisten());
     this.unlisteners_.length = 0;
 

--- a/extensions/amp-anim/0.1/amp-anim.js
+++ b/extensions/amp-anim/0.1/amp-anim.js
@@ -18,6 +18,7 @@ import * as st from '../../../src/style';
 import {dev} from '../../../src/log';
 import {guaranteeSrcForSrcsetUnsupportedBrowsers} from '../../../src/utils/img';
 import {isLayoutSizeDefined} from '../../../src/layout';
+import {observe, unobserve} from '../../../src/viewport-observer';
 import {propagateObjectFitStyles} from '../../../src/style';
 
 const TAG = 'amp-anim';
@@ -40,9 +41,6 @@ export class AmpAnim extends AMP.BaseElement {
 
     /** @private {?Element} */
     this.img_ = null;
-
-    /** @private {boolean} */
-    this.hasLoaded_ = false;
   }
 
   /** @override */
@@ -84,6 +82,7 @@ export class AmpAnim extends AMP.BaseElement {
 
   /** @override */
   layoutCallback() {
+    observe(this.element, () => this.updateInViewport_());
     const img = dev().assertElement(this.img_);
     // Remove missing attributes to remove the placeholder srcset if none is
     // specified on the element.
@@ -104,16 +103,8 @@ export class AmpAnim extends AMP.BaseElement {
   }
 
   /** @override */
-  viewportCallback(unusedInViewport) {
-    if (!this.hasLoaded_) {
-      // do nothing if element has not laid out.
-      return;
-    }
-    this.updateInViewport_();
-  }
-
-  /** @override */
   unlayoutCallback() {
+    unobserve(this.element);
     // Release memory held by the image - animations are typically large.
     this.img_.src = SRC_PLACEHOLDER;
     this.img_.srcset = SRC_PLACEHOLDER;

--- a/extensions/amp-brightcove/0.1/amp-brightcove.js
+++ b/extensions/amp-brightcove/0.1/amp-brightcove.js
@@ -101,13 +101,6 @@ class AmpBrightcove extends AMP.BaseElement {
   }
 
   /** @override */
-  viewportCallback(visible) {
-    this.element.dispatchCustomEvent(VideoEvents.VISIBILITY, {
-      visible,
-    });
-  }
-
-  /** @override */
   buildCallback() {
     this.urlReplacements_ = Services.urlReplacementsForDoc(this.element);
 

--- a/extensions/amp-carousel/0.1/base-carousel.js
+++ b/extensions/amp-carousel/0.1/base-carousel.js
@@ -16,6 +16,7 @@
 import {Keys} from '../../../src/utils/key-codes';
 import {Services} from '../../../src/services';
 import {isAmp4Email} from '../../../src/format';
+import {observe, unobserve} from '../../../src/viewport-observer';
 import {toggleAttribute} from '../../../src/dom';
 
 /**
@@ -38,6 +39,7 @@ export class BaseCarousel extends AMP.BaseElement {
 
   /** @override */
   buildCallback() {
+    observe(this.element, (inViewport) => this.viewportCallback_(inViewport));
     const input = Services.inputFor(this.win);
     const doc = /** @type {!Document} */ (this.element.ownerDocument);
     this.showControls_ =
@@ -54,8 +56,11 @@ export class BaseCarousel extends AMP.BaseElement {
     this.setControlsState();
   }
 
-  /** @override */
-  viewportCallback(inViewport) {
+  /**
+   * @param {boolean} inViewport
+   * @private
+   */
+  viewportCallback_(inViewport) {
     this.onViewportCallback(inViewport);
     if (inViewport) {
       this.hintControls();
@@ -232,7 +237,13 @@ export class BaseCarousel extends AMP.BaseElement {
   }
 
   /** @override */
+  layoutCallback() {
+    observe(this.element, (inViewport) => this.viewportCallback_(inViewport));
+  }
+
+  /** @override */
   unlayoutCallback() {
+    unobserve(this.element);
     return true;
   }
 

--- a/extensions/amp-dailymotion/0.1/amp-dailymotion.js
+++ b/extensions/amp-dailymotion/0.1/amp-dailymotion.js
@@ -146,11 +146,6 @@ class AmpDailymotion extends AMP.BaseElement {
   }
 
   /** @override */
-  viewportCallback(visible) {
-    this.element.dispatchCustomEvent(VideoEvents.VISIBILITY, {visible});
-  }
-
-  /** @override */
   buildCallback() {
     this.videoid_ = userAssert(
       this.element.getAttribute('data-videoid'),

--- a/extensions/amp-fx-flying-carpet/0.1/amp-fx-flying-carpet.js
+++ b/extensions/amp-fx-flying-carpet/0.1/amp-fx-flying-carpet.js
@@ -101,15 +101,6 @@ export class AmpFlyingCarpet extends AMP.BaseElement {
     );
   }
 
-  /** @override */
-  viewportCallback(inViewport) {
-    Services.ownersForDoc(this.element).updateInViewport(
-      this.element,
-      this.children_,
-      inViewport
-    );
-  }
-
   /**
    * Asserts that the flying carpet does not appear in the first or last
    * viewport.

--- a/extensions/amp-ima-video/0.1/amp-ima-video.js
+++ b/extensions/amp-ima-video/0.1/amp-ima-video.js
@@ -206,11 +206,6 @@ class AmpImaVideo extends AMP.BaseElement {
   }
 
   /** @override */
-  viewportCallback(visible) {
-    this.element.dispatchCustomEvent(VideoEvents.VISIBILITY, {visible});
-  }
-
-  /** @override */
   unlayoutCallback() {
     if (this.iframe_) {
       removeElement(this.iframe_);

--- a/extensions/amp-ima-video/0.1/test/test-amp-ima-video.js
+++ b/extensions/amp-ima-video/0.1/test/test-amp-ima-video.js
@@ -41,6 +41,10 @@ describes.realWin(
       timer = Services.timerFor(env.win);
     });
 
+    afterEach(() => {
+      Services.videoManagerForDoc(doc).dispose();
+    });
+
     function getVideoPlayerMock() {
       return {
         load: function () {},

--- a/extensions/amp-ima-video/0.1/test/test-amp-ima-video.js
+++ b/extensions/amp-ima-video/0.1/test/test-amp-ima-video.js
@@ -41,10 +41,6 @@ describes.realWin(
       timer = Services.timerFor(env.win);
     });
 
-    afterEach(() => {
-      Services.videoManagerForDoc(doc).dispose();
-    });
-
     function getVideoPlayerMock() {
       return {
         load: function () {},

--- a/extensions/amp-image-slider/0.1/amp-image-slider.js
+++ b/extensions/amp-image-slider/0.1/amp-image-slider.js
@@ -24,6 +24,7 @@ import {clamp} from '../../../src/utils/math';
 import {dev, user, userAssert} from '../../../src/log';
 import {isLayoutSizeDefined} from '../../../src/layout';
 import {listen} from '../../../src/event-helper';
+import {observe, unobserve} from '../../../src/viewport-observer';
 import {setStyles} from '../../../src/style';
 
 export class AmpImageSlider extends AMP.BaseElement {
@@ -714,6 +715,7 @@ export class AmpImageSlider extends AMP.BaseElement {
 
   /** @override */
   layoutCallback() {
+    observe(this.element, (inViewport) => this.viewportCallback_(inViewport));
     // Extensions such as amp-carousel still uses .setOwner()
     // This would break the rendering of the images as carousel
     // will call .scheduleLayout on the slider but not the contents
@@ -757,6 +759,7 @@ export class AmpImageSlider extends AMP.BaseElement {
 
   /** @override */
   unlayoutCallback() {
+    unobserve(this.element);
     this.unregisterEvents_();
     return true;
   }
@@ -771,8 +774,11 @@ export class AmpImageSlider extends AMP.BaseElement {
     this.registerEvents_();
   }
 
-  /** @override */
-  viewportCallback(inViewport) {
+  /**
+   * @param {boolean} inViewport
+   * @private
+   */
+  viewportCallback_(inViewport) {
     // Show hint if back into viewport and user does not explicitly
     // disable this
     if (inViewport && this.shouldHintReappear_) {

--- a/extensions/amp-mowplayer/0.1/amp-mowplayer.js
+++ b/extensions/amp-mowplayer/0.1/amp-mowplayer.js
@@ -95,11 +95,6 @@ class AmpMowplayer extends AMP.BaseElement {
   }
 
   /** @override */
-  viewportCallback(visible) {
-    this.element.dispatchCustomEvent(VideoEvents.VISIBILITY, {visible});
-  }
-
-  /** @override */
   buildCallback() {
     this.mediaid_ = userAssert(
       this.element.getAttribute('data-mediaid'),

--- a/extensions/amp-nexxtv-player/0.1/amp-nexxtv-player.js
+++ b/extensions/amp-nexxtv-player/0.1/amp-nexxtv-player.js
@@ -137,11 +137,6 @@ class AmpNexxtvPlayer extends AMP.BaseElement {
   }
 
   /** @override */
-  viewportCallback(visible) {
-    this.element.dispatchCustomEvent(VideoEvents.VISIBILITY, {visible});
-  }
-
-  /** @override */
   layoutCallback() {
     const iframe = createFrameFor(this, this.getVideoIframeSrc_());
 

--- a/extensions/amp-ooyala-player/0.1/amp-ooyala-player.js
+++ b/extensions/amp-ooyala-player/0.1/amp-ooyala-player.js
@@ -166,11 +166,6 @@ class AmpOoyalaPlayer extends AMP.BaseElement {
   }
 
   /** @override */
-  viewportCallback(visible) {
-    this.element.dispatchCustomEvent(VideoEvents.VISIBILITY, {visible});
-  }
-
-  /** @override */
   pauseCallback() {
     // Only send pauseVideo command if the player is playing. Otherwise
     // The player breaks if the user haven't played the video yet specially

--- a/extensions/amp-ooyala-player/0.1/test/test-amp-ooyala.js
+++ b/extensions/amp-ooyala-player/0.1/test/test-amp-ooyala.js
@@ -40,6 +40,7 @@ describes.realWin(
       opt_placeholder
     ) {
       const player = doc.createElement('amp-ooyala-player');
+      player.setAttribute('layout', 'fixed');
       if (embedCode) {
         player.setAttribute('data-embedcode', embedCode);
       }

--- a/extensions/amp-powr-player/0.1/amp-powr-player.js
+++ b/extensions/amp-powr-player/0.1/amp-powr-player.js
@@ -99,13 +99,6 @@ class AmpPowrPlayer extends AMP.BaseElement {
   }
 
   /** @override */
-  viewportCallback(visible) {
-    this.element.dispatchCustomEvent(VideoEvents.VISIBILITY, {
-      visible,
-    });
-  }
-
-  /** @override */
   buildCallback() {
     this.urlReplacements_ = Services.urlReplacementsForDoc(this.element);
 

--- a/extensions/amp-timeago/0.1/amp-timeago.js
+++ b/extensions/amp-timeago/0.1/amp-timeago.js
@@ -73,7 +73,7 @@ export class AmpTimeAgo extends AMP.BaseElement {
 
   /** @override */
   layoutCallback() {
-    observe(this.element, this.viewportCallback);
+    observe(this.element, (inViewport) => this.viewportCallback_(inViewport));
   }
 
   /** @override */

--- a/extensions/amp-timeago/0.1/amp-timeago.js
+++ b/extensions/amp-timeago/0.1/amp-timeago.js
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import {getViewportObserver} from '../../../src/viewport-observer';
 import {isLayoutSizeDefined} from '../../../src/layout';
+import {observe, unobserve} from '../../../src/viewport-observer';
 import {timeago} from '../../../third_party/timeagojs/timeago';
 import {userAssert} from '../../../src/log';
 
@@ -38,9 +38,6 @@ export class AmpTimeAgo extends AMP.BaseElement {
 
     /** @private {boolean} */
     this.cutOffReached_ = false;
-
-    /** @private {IntersectionObserver} */
-    this.viewportObserver_ = null;
   }
 
   /** @override */
@@ -65,28 +62,23 @@ export class AmpTimeAgo extends AMP.BaseElement {
 
     this.setFuzzyTimestampValue_();
     this.element.appendChild(this.timeElement_);
+  }
 
-    this.viewportObserver_ = getViewportObserver((records) => {
-      let shouldUpdate = false;
-      records.forEach(({isIntersecting}) => {
-        if (isIntersecting && !this.cutOffReached_) {
-          shouldUpdate = true;
-        }
-      });
-      if (shouldUpdate) {
-        this.setFuzzyTimestampValue_();
-      }
-    }, this.win);
+  /** @param {boolean} inViewport */
+  viewportCallback_(inViewport) {
+    if (inViewport && !this.cutOffReached_) {
+      this.setFuzzyTimestampValue_();
+    }
   }
 
   /** @override */
   layoutCallback() {
-    this.viewportObserver_.observe(this.element);
+    observe(this.element, this.viewportCallback);
   }
 
   /** @override */
   unLayoutCallback() {
-    this.viewportObserver_.unobserve(this.element);
+    unobserve(this.element);
   }
 
   /** @override */

--- a/extensions/amp-video/0.1/amp-video.js
+++ b/extensions/amp-video/0.1/amp-video.js
@@ -295,11 +295,6 @@ class AmpVideo extends AMP.BaseElement {
   }
 
   /** @override */
-  viewportCallback(visible) {
-    this.element.dispatchCustomEvent(VideoEvents.VISIBILITY, {visible});
-  }
-
-  /** @override */
   layoutCallback() {
     this.video_ = dev().assertElement(this.video_);
 

--- a/extensions/amp-video/0.1/test/test-amp-video.js
+++ b/extensions/amp-video/0.1/test/test-amp-video.js
@@ -37,6 +37,10 @@ describes.realWin(
       timer = Services.timerFor(win);
     });
 
+    afterEach(() => {
+      Services.videoManagerForDoc(doc).dispose();
+    });
+
     function getFooVideoSrc(filetype) {
       return '//someHost/foo.' + filetype.slice(filetype.indexOf('/') + 1); // assumes no optional params
     }

--- a/extensions/amp-wistia-player/0.1/amp-wistia-player.js
+++ b/extensions/amp-wistia-player/0.1/amp-wistia-player.js
@@ -144,11 +144,6 @@ class AmpWistiaPlayer extends AMP.BaseElement {
   }
 
   /** @override */
-  viewportCallback(visible) {
-    this.element.dispatchCustomEvent(VideoEvents.VISIBILITY, {visible});
-  }
-
-  /** @override */
   pauseCallback() {
     if (this.iframe_) {
       this.pause();

--- a/extensions/amp-youtube/0.1/amp-youtube.js
+++ b/extensions/amp-youtube/0.1/amp-youtube.js
@@ -142,11 +142,6 @@ class AmpYoutube extends AMP.BaseElement {
   }
 
   /** @override */
-  viewportCallback(visible) {
-    this.element.dispatchCustomEvent(VideoEvents.VISIBILITY, {visible});
-  }
-
-  /** @override */
   buildCallback() {
     this.videoid_ = this.getVideoId_();
     this.liveChannelid_ = this.getLiveChannelId_();

--- a/extensions/amp-youtube/0.1/test/test-amp-youtube.js
+++ b/extensions/amp-youtube/0.1/test/test-amp-youtube.js
@@ -283,7 +283,7 @@ describes.realWin(
       );
     });
 
-    it('loads only sddefault when it exists if source is videoid', async () => {
+    it('loads only default when it exists if source is videoid', async () => {
       const yt = await getYt({'data-videoid': EXAMPLE_VIDEOID}, true, function (
         yt
       ) {

--- a/src/base-element.js
+++ b/src/base-element.js
@@ -454,13 +454,6 @@ export class BaseElement {
   }
 
   /**
-   * Instructs the resource that it has either entered or exited the visible
-   * viewport. Intended to be implemented by actual components.
-   * @param {boolean} unusedInViewport
-   */
-  viewportCallback(unusedInViewport) {}
-
-  /**
    * Requests the element to stop its activity when the document goes into
    * inactive state. The scope is up to the actual component. Among other
    * things the active playback of video or audio content must be stopped.

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -1232,7 +1232,6 @@ function createBaseCustomElementClass(win) {
      */
     updateInViewport_(inViewport) {
       this.implementation_.inViewport_ = inViewport;
-      this.implementation_.viewportCallback(inViewport);
       if (inViewport && this.perfOn_) {
         this.getLayoutDelayMeter_().enterViewport();
       }

--- a/src/service/video-manager-impl.js
+++ b/src/service/video-manager-impl.js
@@ -176,6 +176,7 @@ export class VideoManager {
     }
   }
 
+  // TODO(#30723): create unregister() for cleanup.
   /** @param {!../video-interface.VideoInterface} video */
   register(video) {
     devAssert(video);

--- a/src/service/video-manager-impl.js
+++ b/src/service/video-manager-impl.js
@@ -1607,9 +1607,6 @@ export function installVideoManagerForDoc(nodeOrDoc) {
  */
 function getViewportObserver(ioCallback, win) {
   const iframed = isIframed(win);
-  // Classic IntersectionObserver doesn't support viewport tracking and
-  // rootMargin in x-origin iframes (#25428). As of 1/2020, only Chrome 81+
-  // supports it via {root: document}, which throws on other browsers.
   const root = /** @type {?Element} */ (iframed
     ? /** @type {*} */ (win.document)
     : null);

--- a/src/service/video-manager-impl.js
+++ b/src/service/video-manager-impl.js
@@ -185,7 +185,9 @@ export class VideoManager {
       return;
     }
     if (!this.viewportObserver_) {
-      const viewportCallback = (records) =>
+      const viewportCallback = (
+        /** @type {!Array<!IntersectionObserverEntry>} */ records
+      ) =>
         records.forEach(({target, isIntersecting}) => {
           this.getEntry_(target).updateVisibility(
             /* isVisible */ isIntersecting

--- a/src/viewport-observer.js
+++ b/src/viewport-observer.js
@@ -95,6 +95,11 @@ function ioCallback(entries) {
   for (let i = 0; i < entries.length; i++) {
     const {isIntersecting, target} = entries[i];
     const viewportCallback = viewportCallbacks.get(target);
-    viewportCallback(isIntersecting);
+
+    // The callback may not exist if it wasn't cleaned up
+    // but the element has been GCed.
+    if (viewportCallback) {
+      viewportCallback(isIntersecting);
+    }
   }
 }

--- a/src/viewport-observer.js
+++ b/src/viewport-observer.js
@@ -25,7 +25,7 @@ import {isIframed} from './dom';
  *
  * @param {function(!Array<!IntersectionObserverEntry>)} ioCallback
  * @param {!Window} win
- * @param {string} threshold
+ * @param {string=} threshold
  *
  * @return {!IntersectionObserver}
  */

--- a/src/viewport-observer.js
+++ b/src/viewport-observer.js
@@ -1,0 +1,50 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {isIframed} from './dom';
+
+/**
+ * Returns an IntersectionObserver tracking the Viewport.
+ * Only use this if x-origin iframe rootMargin support is considered nice-to-have,
+ * since if not supported this InOb will fallback to one without rootMargin.
+ *
+ * - If iframed: rootMargin is ignored unless natively supported (Chrome 81+).
+ * - If not iframed: all features work properly in both polyfill and built-in.
+ *
+ * @param {function(!Array<!IntersectionObserverEntry>)} ioCallback
+ * @param {!Window} win
+ * @param {string} threshold
+ *
+ * @return {!IntersectionObserver}
+ */
+export function getViewportObserver(ioCallback, win, threshold) {
+  const iframed = isIframed(win);
+  const root = /** @type {?Element} */ (iframed
+    ? /** @type {*} */ (win.document)
+    : null);
+
+  // TODO(amphtml): Determine if rootMargin is still necessary.
+  const rootMargin = '25%';
+
+  try {
+    return new win.IntersectionObserver(ioCallback, {
+      root,
+      rootMargin,
+      threshold,
+    });
+  } catch (e) {
+    return new win.IntersectionObserver(ioCallback, {rootMargin, threshold});
+  }
+}

--- a/test/integration/test-video-manager.js
+++ b/test/integration/test-video-manager.js
@@ -301,9 +301,7 @@ describe
         },
       };
 
-      win = {
-        document: doc,
-      };
+      win = {document: doc};
 
       isLite = false;
 
@@ -437,11 +435,6 @@ function createFakeVideoPlayerClass(win) {
       return Promise.resolve().then(() => {
         this.element.dispatchCustomEvent(VideoEvents.LOAD);
       });
-    }
-
-    /** @override */
-    viewportCallback(visible) {
-      this.element.dispatchCustomEvent(VideoEvents.VISIBILITY, {visible});
     }
 
     // VideoInterface Implementation. See ../src/video-interface.VideoInterface

--- a/test/integration/test-video-players-helper.js
+++ b/test/integration/test-video-players-helper.js
@@ -382,7 +382,7 @@ export function runVideoPlayerIntegrationTests(
         );
       });
 
-      it('should not play when not in view port initially', () => {
+      it('should not play when initially outside viewport', () => {
         return getVideoPlayer({outsideView: true, autoplay: true}).then((r) => {
           const timer = Services.timerFor(r.video.implementation_.win);
           const p = listenOncePromise(r.video, VideoEvents.PLAYING).then(() => {
@@ -551,7 +551,7 @@ export function runVideoPlayerIntegrationTests(
 
   function getVideoPlayer(options) {
     options = options || {};
-    const top = options.outsideView ? '100vh' : '0';
+    const top = options.outsideView ? '126vh' : '0';
     let fixture;
     return createFixtureIframe('test/fixtures/video-players.html', FRAME_HEIGHT)
       .then((f) => {

--- a/test/unit/test-viewport-observer.js
+++ b/test/unit/test-viewport-observer.js
@@ -1,0 +1,82 @@
+/**
+ * Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {getViewportObserver} from '../../src/viewport-observer';
+
+describes.sandboxed('Viewport Observer', {}, (env) => {
+  let win;
+  let ctorSpy;
+  const noop = () => {};
+
+  const setIframed = () => (win.parent = {});
+  beforeEach(() => {
+    ctorSpy = env.sandbox.stub();
+    win = {
+      parent: null,
+      document: {},
+      IntersectionObserver: ctorSpy,
+    };
+  });
+
+  it('When not iframed, uses null root.', () => {
+    getViewportObserver(noop, win);
+
+    expect(ctorSpy).calledWith(noop, {
+      root: null,
+      rootMargin: '25%',
+      threshold: undefined,
+    });
+  });
+
+  it('When iframed, use document root.', () => {
+    setIframed();
+    getViewportObserver(noop, win);
+
+    expect(ctorSpy).calledWith(noop, {
+      root: win.document,
+      rootMargin: '25%',
+      threshold: undefined,
+    });
+  });
+
+  it('If ctor throws, fallback to rootless', () => {
+    setIframed();
+    ctorSpy.callsFake((_cb, {root}) => {
+      if (root === win.document) {
+        throw new Error();
+      }
+    });
+    getViewportObserver(noop, win);
+
+    expect(ctorSpy).calledWith(noop, {
+      root: win.document,
+      rootMargin: '25%',
+      threshold: undefined,
+    });
+    expect(ctorSpy).calledWith(noop, {
+      rootMargin: '25%',
+      threshold: undefined,
+    });
+  });
+
+  it('Pass along threshold argument', () => {
+    getViewportObserver(noop, win, '50%');
+    expect(ctorSpy).calledWith(noop, {
+      rootMargin: '25%',
+      threshold: '50%',
+    });
+  });
+});

--- a/testing/fake-dom.js
+++ b/testing/fake-dom.js
@@ -63,6 +63,8 @@ export class FakeWindow {
     /** @const */
     this.Promise = window.Promise;
     /** @const */
+    this.IntersectionObserver = window.IntersectionObserver;
+    /** @const */
     this./*OK*/ pageYOffset = window./*OK*/ pageYOffset;
 
     /** @const */


### PR DESCRIPTION
**wip**
- Introduces new `viewport-observer` file with `observe()` and `unobserve()` so that we can track all elements with the same InOb (specifically for viewportCallback)

partial for https://github.com/ampproject/amphtml/issues/30620