### PR TITLE
🔥 Only collapse sticky-ad when ad collapses

### DIFF
--- a/extensions/amp-sticky-ad/1.0/amp-sticky-ad.js
+++ b/extensions/amp-sticky-ad/1.0/amp-sticky-ad.js
@@ -126,7 +126,12 @@ class AmpStickyAd extends AMP.BaseElement {
   }
 
   /** @override */
-  collapsedCallback() {
+  collapsedCallback(element) {
+    // We will only collapse the stick-ad when the ad collapses. The analytics
+    // element will collapse after it's done initializing, which is normal.
+    if (element !== this.ad_) {
+      return;
+    }
     this.collapsed_ = true;
     this.visible_ = false;
     toggle(this.element, false);


### PR DESCRIPTION
This fixes a new regression introduced by #30426.

In it, I changed `amp-analytics` to call `collapse` instead of `toggle`. This causes the analytics element's owner to be notified via `collapsedCallback`. `amp-sticky-ad` receives that notification, and then [collapses itself](https://github.com/ampproject/amphtml/blob/master/extensions/amp-sticky-ad/1.0/amp-sticky-ad.js#L128-L136). What should happen is the sticky ad should only collapse if the _ad_ its wrapping collapses, and we can just ignore everything else.