### PR TITLE
📖 Fix dead link in AMP dev docs

### DIFF
--- a/contributing/DEVELOPING.md
+++ b/contributing/DEVELOPING.md
@@ -35,7 +35,6 @@ Before you start writing code, consult these resources for guidance and guidelin
 - **CSS**: [Writing CSS For AMP Runtime](writing-css.md)
 - **Creating new components**:
   - [Instructions and Guidelines for building an AMP component](building-an-amp-extension.md)
-  - Learn to create your first component in this [codelab](https://codelabs.developers.google.com/codelabs/creating-your-first-amp-component/#0)
   - Watch this [YouTube video](https://youtu.be/FJEhQFNKeaQ?list=PLXTOW_XMsIDTDXYO-NAi2OpEH0zyguvqX) to learn about "Building a new AMP component"
 - **Integrating third-party software, embeds, services**: [Guidelines](../3p/README.md)
 

--- a/contributing/component-validator-rules.md
+++ b/contributing/component-validator-rules.md
@@ -38,11 +38,11 @@ Common usage of this extended component might look like:
 
 Your first step will be writing the extended component JavaScript code. Place
 this code in the amphtml src tree at the location of
-`amphtml/extensions/amp-cat/0.1/`. This document only describes how to
-specify validation rules for an extended component - it does not cover
-implementing its runtime behavior. For the latter, see the codelab [Creating
-your first AMP
-Component](https://codelabs.developers.google.com/codelabs/creating-your-first-amp-component/).
+`amphtml/extensions/amp-cat/0.1/`. This document only describes how to specify
+validation rules for an extended component - it does not cover implementing its
+runtime behavior. For the latter, see the [Building an AMP
+Extension](https://github.com/ampproject/amphtml/blob/master/contributing/building-an-amp-extension.md)
+guide.
 
 ## Validation Rules
 

--- a/contributing/contributing-code.md
+++ b/contributing/contributing-code.md
@@ -74,7 +74,7 @@ Once you have found a guide, make sure to @-mention them on any issues / PRs rel
     - **CSS**: [Writing CSS For AMP Runtime](./writing-css.md)
     - **Creating new components**:
       - [Instructions and Guidelines for building an AMP component](./building-an-amp-extension.md)
-      - Learn to create your first component in this [codelab](https://codelabs.developers.google.com/codelabs/creating-your-first-amp-component/#0)
+      - Learn to create your first component in this [guide](https://github.com/ampproject/amphtml/blob/master/contributing/building-an-amp-extension.md)
       - Watch this [YouTube video](https://youtu.be/FJEhQFNKeaQ?list=PLXTOW_XMsIDTDXYO-NAi2OpEH0zyguvqX) to learn about "Building a new AMP component"
     - **Integrating third-party software, embeds, services**: [Guidelines](../3p/README.md)
     - **Accessibility**:
@@ -117,7 +117,6 @@ In particular, we strive to design the overall component set, so that a large nu
 We have a few additional resources that provide an introduction to contributing extended components:
 
 - ["Building an AMP Extension"](./building-an-amp-extension.md) has a detailed description of how to build an AMP component.
-- ["Creating your first AMP Component" codelab](https://codelabs.developers.google.com/codelabs/creating-your-first-amp-component/#0) provides a quick overview of the steps you need to go through to create a component with examples you can modify for your component.
 - The ["Building a new AMP component" talk at AMP Conf 2017](https://youtu.be/FJEhQFNKeaQ?list=PLXTOW_XMsIDTDXYO-NAi2OpEH0zyguvqX) provides an introduction to contributing AMP components.
 
 For further detail on integrating third-party services (e.g., fonts, embeds, etc.), see our [3p contribution guidelines](https://github.com/ampproject/amphtml/tree/master/3p).

--- a/contributing/getting-started-e2e.md
+++ b/contributing/getting-started-e2e.md
@@ -609,7 +609,7 @@ If you're looking for ideas on your next contribution feel free to reach out to 
 
 This end-to-end guide provided enough details to get a basic understanding of a typical workflow for contributing code to the AMP open source project. If you find yourself wanting to know more there are a lot of resources available. Here are a few:
 
-- The ["Creating your first AMP Component" codelab](https://codelabs.developers.google.com/codelabs/creating-your-first-amp-component/index.html) provides step-by-step instructions for a common type of code contribution to AMP. Even if your project involves modifying an existing AMP component this codelab will give you an overview of how AMP components work.
+- The ["Building an AMP Extension" guide](https://github.com/ampproject/amphtml/blob/master/contributing/building-an-amp-extension.md) provides step-by-step instructions for a common type of code contribution to AMP. Even if your project involves modifying an existing AMP component, this guide will give you an overview of how AMP components work.
 - GitHub has a lot of helpful introductory material, including:
   - a [Hello World tutorial](https://guides.github.com/activities/hello-world/) that's a bit less in depth than this guide, but it covers things like creating a new repository and merging in code after a pull request
   - the [Git cheat sheet](https://services.github.com/on-demand/downloads/github-git-cheat-sheet.pdf) from GitHub provides a quick reference to some common commands, including many we didn't cover in this guide (such as [diff](https://www.git-tower.com/learn/git/ebook/en/command-line/advanced-topics/diffs) and [log](https://git-scm.com/book/en/v2/Git-Basics-Viewing-the-Commit-History))


### PR DESCRIPTION
Our dev docs point to the codelab at https://codelabs.developers.google.com/codelabs/creating-your-first-amp-component/index.html as a good starting point for writing a new AMP component.

![image](https://user-images.githubusercontent.com/26553114/96503799-cb5ca800-1221-11eb-8e79-aadaff2bc5ea.png)

The codelab has disappeared and the link 404s, so this PR replaces it with [this guide](https://github.com/ampproject/amphtml/blob/master/contributing/building-an-amp-extension.md) wherever applicable.
