### PR TITLE
♿ [a11y-fixit][amp-social-share] Add social share aria-label

### DIFF
--- a/extensions/amp-social-share/0.1/amp-social-share.js
+++ b/extensions/amp-social-share/0.1/amp-social-share.js
@@ -118,6 +118,9 @@ class AmpSocialShare extends AMP.BaseElement {
     if (!element.hasAttribute('tabindex')) {
       element.setAttribute('tabindex', '0');
     }
+    if (!element.hasAttribute('aria-label')) {
+      element.setAttribute('aria-label', `Share by ${typeAttr}`);
+    }
     element.addEventListener('click', () => this.handleClick_());
     element.addEventListener('keydown', this.handleKeyPress_.bind(this));
     element.classList.add(`amp-social-share-${typeAttr}`);

--- a/extensions/amp-social-share/0.1/amp-social-share.js
+++ b/extensions/amp-social-share/0.1/amp-social-share.js
@@ -118,7 +118,7 @@ class AmpSocialShare extends AMP.BaseElement {
     if (!element.hasAttribute('tabindex')) {
       element.setAttribute('tabindex', '0');
     }
-    if (!element.hasAttribute('aria-label')) {
+    if (!element.getAttribute('aria-label')) {
       element.setAttribute('aria-label', `Share by ${typeAttr}`);
     }
     element.addEventListener('click', () => this.handleClick_());

--- a/extensions/amp-social-share/0.1/storybook/Basic.amp.js
+++ b/extensions/amp-social-share/0.1/storybook/Basic.amp.js
@@ -81,6 +81,7 @@ export const Default = () => {
   const appId = text('data-param-app_id', '254325784911610');
   const width = text('width', null);
   const height = text('height', null);
+  const ariaLabel = text('aria-label', null);
   return (
     <amp-social-share
       type={type}
@@ -92,6 +93,7 @@ export const Default = () => {
       data-param-app_id={appId}
       width={width}
       height={height}
+      aria-label={ariaLabel}
     ></amp-social-share>
   );
 };

--- a/extensions/amp-social-share/0.1/test/test-amp-social-share.js
+++ b/extensions/amp-social-share/0.1/test/test-amp-social-share.js
@@ -206,6 +206,20 @@ describes.realWin(
       });
     });
 
+    it('overwrites default aria-label value when a non-empty value is provided', () => {
+      const share = doc.createElement('amp-social-share');
+
+      share.setAttribute('type', 'twitter');
+      share.setAttribute('width', 60);
+      share.setAttribute('height', 44);
+      share.setAttribute('aria-label', 'test value');
+
+      doc.body.appendChild(share);
+      return loaded(share).then((el) => {
+        expect(el.getAttribute('aria-label')).to.be.equal('test value');
+      });
+    });
+
     it('opens share window in _blank', () => {
       return getShare('twitter').then((el) => {
         el.implementation_.handleClick_();

--- a/extensions/amp-social-share/0.1/test/test-amp-social-share.js
+++ b/extensions/amp-social-share/0.1/test/test-amp-social-share.js
@@ -193,6 +193,19 @@ describes.realWin(
       });
     });
 
+    it('adds a default value for aria-label', () => {
+      const share = doc.createElement('amp-social-share');
+
+      share.setAttribute('type', 'twitter');
+      share.setAttribute('width', 60);
+      share.setAttribute('height', 44);
+
+      doc.body.appendChild(share);
+      return loaded(share).then((el) => {
+        expect(el.getAttribute('aria-label')).to.be.equal('Share by twitter');
+      });
+    });
+
     it('opens share window in _blank', () => {
       return getShare('twitter').then((el) => {
         el.implementation_.handleClick_();

--- a/extensions/amp-social-share/amp-social-share.md
+++ b/extensions/amp-social-share/amp-social-share.md
@@ -226,6 +226,10 @@ Some popular providers have pre-configured share endpoints. For details, see the
 
 All `data-param-*` prefixed attributes are turned into URL parameters and passed to the share endpoint.
 
+### aria-label
+
+By default, the `aria-label` attribute will be populated with `Share by type` where 'type' is the `type` attribute provided to the component. If a value is passed in to `aria-label` it will overwrite the default value.
+
 ## Styling
 
 ### Default Styles

--- a/extensions/amp-social-share/amp-social-share.md
+++ b/extensions/amp-social-share/amp-social-share.md
@@ -228,7 +228,7 @@ All `data-param-*` prefixed attributes are turned into URL parameters and passed
 
 ### aria-label
 
-By default, the `aria-label` attribute will be populated with `Share by type` where 'type' is the `type` attribute provided to the component. If a value is passed in to `aria-label` it will overwrite the default value.
+By default, the `aria-label` attribute will be populated with `Share by type` where 'type' is the `type` attribute provided to the component. If a non-empty value is passed in to `aria-label` it will overwrite the default value.
 
 ## Styling
 


### PR DESCRIPTION
Add a default value for `aria-label` on social share.

Fixes: https://github.com/ampproject/amphtml/issues/29563