### PR TITLE
♿ Focus on consent modal immediately (and don't show SR button)

### DIFF
--- a/extensions/amp-consent/0.1/consent-ui.js
+++ b/extensions/amp-consent/0.1/consent-ui.js
@@ -570,11 +570,12 @@ export class ConsentUI {
   showIframe_() {
     const {classList} = this.parent_;
     classList.add(consentUiClasses.iframeActive);
-    if (this.modalEnabled_) {
-      classList.add(consentUiClasses.modal);
-    }
     toggle(dev().assertElement(this.placeholder_), false);
     toggle(dev().assertElement(this.ui_), true);
+    if (this.modalEnabled_) {
+      classList.add(consentUiClasses.modal);
+      tryFocus(dev().assertElement(this.ui_));
+    }
 
     // Remove transition styles added by the fixed layer
     // Transform styles applied by us for the animation.
@@ -636,10 +637,12 @@ export class ConsentUI {
    * If this is the first time viewing the iframe, create
    * an 'invisible' alert dialog with a title and a button.
    * Clicking on the button will transfer focus to the iframe.
+   *
+   * This only applies for bottom pane iframes.
    */
   maybeShowSrAlert_() {
     // If the SR alert has been shown, don't show it again
-    if (this.srAlertShown_) {
+    if (this.srAlertShown_ || this.modalEnabled_) {
       return;
     }
 

--- a/extensions/amp-consent/0.1/test/test-consent-ui.js
+++ b/extensions/amp-consent/0.1/test/test-consent-ui.js
@@ -764,6 +764,31 @@ describes.realWin(
         });
       });
 
+      it('should focus on ui when modal', async () => {
+        consentUI = new ConsentUI(mockInstance, {
+          'promptUISrc': 'https//promptUISrc',
+          'uiConfig': {},
+        });
+
+        consentUI.show(true);
+        consentUI.handleIframeMessages_({
+          source: consentUI.ui_.contentWindow,
+          data: {
+            type: 'consent-ui',
+            action: 'ready',
+            initialHeight: '80vh',
+            border: false,
+          },
+        });
+        await macroTask();
+
+        expect(consentUI.srAlertShown_).to.be.false;
+        expect(consentUI.srAlert_).to.be.null;
+        expect(doc.activeElement).to.equal(consentUI.ui_);
+        expect(consentUI.parent_.classList.contains(consentUiClasses.modal)).to
+          .be.true;
+      });
+
       it('should handle a border value', () => {
         return getReadyIframeCmpConsentUi().then((consentUI) => {
           expect(consentUI.borderEnabled_).to.be.equal(true);


### PR DESCRIPTION
Closes #30736

With the introduction of the modal UI for amp-consent, we should focus on it once loads. Additionally we do not have to show the SR button in this case, that would allow the user to focus on the dialog.