### PR TITLE
use fancy-log.info()

### DIFF
--- a/validator/js/gulpjs/index.js
+++ b/validator/js/gulpjs/index.js
@@ -94,7 +94,7 @@ module.exports.format = function(logger) {
   }
 
   function formatResults(callback) {
-    logger.log('AMP Validation results:\n\n' +
+    logger.info('AMP Validation results:\n\n' +
         results.map(printResult).join('\n'));
     return callback();
   }


### PR DESCRIPTION
Fixes #30527

By [default](https://github.com/ampproject/amphtml/blob/64c46649d55d5fb56e548455981de742af56a3a4/validator/js/gulpjs/index.js#L22) the gulp implementation of the validator uses [fancy-log](https://www.npmjs.com/package/fancy-log) for logging. However it calls the non-existing method `.log` to report results. Instead use `.info`.

Verified now working as intended.