### PR TITLE
🏗 Add `OWNERS` files to simplify package updates in `amphtml` subdirs

### DIFF
--- a/extensions/amp-access/0.1/iframe-api/OWNERS
+++ b/extensions/amp-access/0.1/iframe-api/OWNERS
@@ -1,0 +1,14 @@
+// For an explanation of the OWNERS rules and syntax, see:
+// https://github.com/ampproject/amp-github-apps/blob/master/owners/OWNERS.example
+
+{
+  rules: [
+    {
+      pattern: 'package.json',
+      owners: [
+        {name: 'ampproject/wg-infra', requestReviews: false},
+        {name: 'ampproject/wg-performance', requestReviews: false},
+      ],
+    },
+  ],
+}

--- a/src/purifier/OWNERS
+++ b/src/purifier/OWNERS
@@ -1,0 +1,14 @@
+// For an explanation of the OWNERS rules and syntax, see:
+// https://github.com/ampproject/amp-github-apps/blob/master/owners/OWNERS.example
+
+{
+  rules: [
+    {
+      pattern: 'package.json',
+      owners: [
+        {name: 'ampproject/wg-infra', requestReviews: false},
+        {name: 'ampproject/wg-performance', requestReviews: false},
+      ],
+    },
+  ],
+}

--- a/third_party/amp-toolbox-cache-url/OWNERS
+++ b/third_party/amp-toolbox-cache-url/OWNERS
@@ -1,0 +1,14 @@
+// For an explanation of the OWNERS rules and syntax, see:
+// https://github.com/ampproject/amp-github-apps/blob/master/owners/OWNERS.example
+
+{
+  rules: [
+    {
+      pattern: 'package.json',
+      owners: [
+        {name: 'ampproject/wg-infra', requestReviews: false},
+        {name: 'ampproject/wg-performance', requestReviews: false},
+      ],
+    },
+  ],
+}


### PR DESCRIPTION
This PR adds the infra and performance WGs as silent owners of `package.json` files in `amphtml` subdirectories. The original owners of these packages will continue to be notified of changes, while making infrastructure maintenance and upgrades easier.