### PR TITLE
♿ [a11y-fixit][amp-accordion] Add various a11y attributes to amp-accordion

### DIFF
--- a/extensions/amp-accordion/0.1/amp-accordion.js
+++ b/extensions/amp-accordion/0.1/amp-accordion.js
@@ -114,14 +114,11 @@ class AmpAccordion extends AMP.BaseElement {
           'amp-accordion/amp-accordion.md. Found in: %s',
         this.element
       );
-      const header = sectionComponents[0];
-      const content = sectionComponents[1];
+      const {0: header, 1: content} = sectionComponents;
       content.classList.add('i-amphtml-accordion-content');
 
-      // To ensure that we pass Accessibility audits -
-      // we need to make sure that each accordion has a unique ID.
-      // In case the accordion doesn't have an ID we use a
-      // random number to ensure uniqueness.
+      // Ensure each accordion has a unique id, helping screen readers
+      // understand the relationship between the pieces of content.
       let contentId = content.getAttribute('id');
       if (!contentId) {
         contentId = this.prefix_ + '_AMP_content_' + index;

--- a/extensions/amp-accordion/0.1/amp-accordion.js
+++ b/extensions/amp-accordion/0.1/amp-accordion.js
@@ -114,16 +114,23 @@ class AmpAccordion extends AMP.BaseElement {
           'amp-accordion/amp-accordion.md. Found in: %s',
         this.element
       );
+      const header = sectionComponents[0];
       const content = sectionComponents[1];
       content.classList.add('i-amphtml-accordion-content');
+
+      // To ensure that we pass Accessibility audits -
+      // we need to make sure that each accordion has a unique ID.
+      // In case the accordion doesn't have an ID we use a
+      // random number to ensure uniqueness.
       let contentId = content.getAttribute('id');
       if (!contentId) {
-        // To ensure that we pass Accessibility audits -
-        // we need to make sure that each accordion has a unique ID.
-        // In case the accordion doesn't have an ID we use a
-        // random number to ensure uniqueness.
         contentId = this.prefix_ + '_AMP_content_' + index;
         content.setAttribute('id', contentId);
+      }
+      let headerId = header.getAttribute('id');
+      if (!headerId) {
+        headerId = this.prefix_ + '_AMP_header_' + index;
+        header.setAttribute('id', headerId);
       }
 
       this.registerAction('toggle', (i) => this.handleAction_(i));
@@ -161,7 +168,6 @@ class AmpAccordion extends AMP.BaseElement {
       });
 
       const isExpanded = section.hasAttribute('expanded');
-      const header = sectionComponents[0];
       header.classList.add('i-amphtml-accordion-header');
       header.setAttribute('role', 'button');
       header.setAttribute('aria-controls', contentId);
@@ -170,6 +176,8 @@ class AmpAccordion extends AMP.BaseElement {
         header.setAttribute('tabindex', 0);
       }
       this.headers_.push(header);
+      content.setAttribute('aria-labelledby', headerId);
+      content.setAttribute('role', 'region');
 
       userAssert(
         this.action_.hasAction(header, 'tap', section) == false,

--- a/extensions/amp-accordion/0.1/test/test-amp-accordion.js
+++ b/extensions/amp-accordion/0.1/test/test-amp-accordion.js
@@ -860,6 +860,71 @@ describes.realWin(
         );
       });
     });
+
+    it('should include a11y related attributes', () => {
+      return getAmpAccordion().then(() => {
+        const sectionElements = doc.querySelectorAll('section');
+        expect(sectionElements.length).to.equal(3);
+
+        const section0 = sectionElements[0];
+        const section1 = sectionElements[1];
+        const section2 = sectionElements[2];
+        const {
+          firstElementChild: header0,
+          lastElementChild: content0,
+        } = section0;
+        const {
+          firstElementChild: header1,
+          lastElementChild: content1,
+        } = section1;
+        const {
+          firstElementChild: header2,
+          lastElementChild: content2,
+        } = section2;
+
+        expect(header0).to.have.attribute('id');
+        expect(header0.getAttribute('aria-controls')).to.equal('test0');
+        expect(header0.getAttribute('tabindex')).to.equal('0');
+        expect(header0.getAttribute('role')).to.equal('button');
+        expect(content0).to.have.attribute('aria-labelledby');
+        expect(content0.getAttribute('id')).to.equal('test0');
+        expect(content0.getAttribute('role')).to.equal('region');
+        expect(header0.getAttribute('aria-controls')).to.equal(
+          content0.getAttribute('id')
+        );
+        expect(header0.getAttribute('id')).to.equal(
+          content0.getAttribute('aria-labelledby')
+        );
+
+        expect(header1).to.have.attribute('id');
+        expect(header1.getAttribute('aria-controls')).to.equal('test1');
+        expect(header1.getAttribute('tabindex')).to.equal('0');
+        expect(header1.getAttribute('role')).to.equal('button');
+        expect(content1).to.have.attribute('aria-labelledby');
+        expect(content1.getAttribute('id')).to.equal('test1');
+        expect(content1.getAttribute('role')).to.equal('region');
+        expect(header1.getAttribute('aria-controls')).to.equal(
+          content1.getAttribute('id')
+        );
+        expect(header1.getAttribute('id')).to.equal(
+          content1.getAttribute('aria-labelledby')
+        );
+
+        expect(header2).to.have.attribute('id');
+        expect(header2.getAttribute('aria-controls')).to.equal('test2');
+        expect(header2.getAttribute('tabindex')).to.equal('0');
+        expect(header2.getAttribute('role')).to.equal('button');
+        expect(content2).to.have.attribute('aria-labelledby');
+        expect(content2.getAttribute('id')).to.equal('test2');
+        expect(content2.getAttribute('role')).to.equal('region');
+        expect(header2.getAttribute('aria-controls')).to.equal(
+          content2.getAttribute('id')
+        );
+        expect(header2.getAttribute('id')).to.equal(
+          content2.getAttribute('aria-labelledby')
+        );
+      });
+    });
   }
 );
 

--- a/extensions/amp-accordion/amp-accordion.md
+++ b/extensions/amp-accordion/amp-accordion.md
@@ -351,7 +351,7 @@ Keep the following points in mind when you style an amp-accordion:
 - `aria-expanded (state)`: Applied to the header element of each `amp-accordion` section.
 - `aria-labelledby`: Applied to the content element of each `amp-accordion` section.
 
-`amp-accordion` automatically adds the following
+`amp-accordion` also automatically adds the following accessibility attributes:
 
 - `tabindex`: Applied to the header element of each `amp-accordion` section.
 - `role=button`: Applied to the header element of each `amp-accordion` section.

--- a/extensions/amp-accordion/amp-accordion.md
+++ b/extensions/amp-accordion/amp-accordion.md
@@ -345,9 +345,17 @@ Keep the following points in mind when you style an amp-accordion:
 
 ## Accessibility
 
-- `amp-accordion` automatically adds the following [ARIA attributes](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA):
+`amp-accordion` automatically adds the following [ARIA attributes](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA):
+
 - `aria-controls`: Applied to the header element of each `amp-accordion` section.
 - `aria-expanded (state)`: Applied to the header element of each `amp-accordion` section.
+- `aria-labelledby`: Applied to the content element of each `amp-accordion` section.
+
+`amp-accordion` automatically adds the following
+
+- `tabindex`: Applied to the header element of each `amp-accordion` section.
+- `role=button`: Applied to the header element of each `amp-accordion` section.
+- `role=region`: Applied to the content element of each `amp-accordion` section.
 
 ## Validation
 


### PR DESCRIPTION
Add the `role` and `aria-labelledby` attributes to the `content` element of each `accordion` section.

Fixes: https://github.com/ampproject/amphtml/issues/30727