### PR TITLE
✨ [bento][amp-accordion] Add Imperative API for amp-accordion with Tests and Storybook

### DIFF
--- a/extensions/amp-accordion/1.0/accordion.js
+++ b/extensions/amp-accordion/1.0/accordion.js
@@ -129,14 +129,14 @@ function AccordionWithRef(
   const expand = useCallback(
     (id) => {
       if (id) {
-        if (id in expandedMap && !isExpanded(id)) {
+        if (!isExpanded(id, true)) {
           toggleExpanded(id);
         }
       } else {
         // Expand all should do nothing when expandSingleSection is true
         if (!expandSingleSection) {
           for (const k in expandedMap) {
-            if (!isExpanded(k)) {
+            if (!isExpanded(k, true)) {
               toggleExpanded(k);
             }
           }
@@ -149,12 +149,12 @@ function AccordionWithRef(
   const collapse = useCallback(
     (id) => {
       if (id) {
-        if (id in expandedMap && isExpanded(id)) {
+        if (isExpanded(id, false)) {
           toggleExpanded(id);
         }
       } else {
         for (const k in expandedMap) {
-          if (isExpanded(k)) {
+          if (isExpanded(k, false)) {
             toggleExpanded(k);
           }
         }

--- a/extensions/amp-accordion/1.0/accordion.js
+++ b/extensions/amp-accordion/1.0/accordion.js
@@ -17,7 +17,7 @@
 import * as Preact from '../../../src/preact';
 import {animateCollapse, animateExpand} from './animations';
 import {forwardRef} from '../../../src/preact/compat';
-import {hasOwn, omit} from '../../../src/utils/object';
+import {omit} from '../../../src/utils/object';
 
 import {
   randomIdGenerator,
@@ -112,7 +112,7 @@ function AccordionWithRef(
   const toggle = useCallback(
     (id) => {
       if (id) {
-        if (hasOwn(expandedMap, id)) {
+        if (id in expandedMap) {
           toggleExpanded(id);
         }
       } else {
@@ -130,7 +130,7 @@ function AccordionWithRef(
   const expand = useCallback(
     (id) => {
       if (id) {
-        if (hasOwn(expandedMap, id) && !isExpanded(id)) {
+        if (id in expandedMap && !isExpanded(id)) {
           toggleExpanded(id);
         }
       } else {
@@ -150,7 +150,7 @@ function AccordionWithRef(
   const collapse = useCallback(
     (id) => {
       if (id) {
-        if (hasOwn(expandedMap, id) && isExpanded(id)) {
+        if (id in expandedMap && isExpanded(id)) {
           toggleExpanded(id);
         }
       } else {

--- a/extensions/amp-accordion/1.0/accordion.js
+++ b/extensions/amp-accordion/1.0/accordion.js
@@ -18,7 +18,6 @@ import * as Preact from '../../../src/preact';
 import {animateCollapse, animateExpand} from './animations';
 import {forwardRef} from '../../../src/preact/compat';
 import {omit} from '../../../src/utils/object';
-
 import {
   randomIdGenerator,
   sequentialIdGenerator,
@@ -239,7 +238,8 @@ export function AccordionSection({
   children,
   ...rest
 }) {
-  const [id] = useState(propId || generateSectionId);
+  const [genId] = useState(generateSectionId);
+  const id = propId || genId;
   const [suffix] = useState(generateRandomId);
   const [expandedState, setExpandedState] = useState(defaultExpanded);
   const contentRef = useRef(null);

--- a/extensions/amp-accordion/1.0/accordion.type.js
+++ b/extensions/amp-accordion/1.0/accordion.type.js
@@ -70,3 +70,21 @@ AccordionDef.ContentProps;
  * }}
  */
 AccordionDef.ContextProps;
+
+/** @interface */
+AccordionDef.AccordionApi = class {
+  /**
+   * @param {string|undefined} section
+   */
+  toggle(section) {}
+
+  /**
+   * @param {string|undefined} section
+   */
+  expand(section) {}
+
+  /**
+   * @param {string|undefined} section
+   */
+  collapse(section) {}
+};

--- a/extensions/amp-accordion/1.0/amp-accordion.js
+++ b/extensions/amp-accordion/1.0/amp-accordion.js
@@ -16,7 +16,6 @@
 
 import * as Preact from '../../../src/preact';
 import {Accordion, AccordionSection} from './accordion';
-import {ActionTrust} from '../../../src/action-constants';
 import {CSS} from '../../../build/amp-accordion-1.0.css';
 import {PreactBaseElement} from '../../../src/preact/base-element';
 import {childElementsByTag, toggleAttribute} from '../../../src/dom';
@@ -39,23 +38,14 @@ const SECTION_POST_RENDER = '__AMP_PR';
 class AmpAccordion extends PreactBaseElement {
   /** @override */
   init() {
-    this.registerApiAction(
-      'toggle',
-      (api, invocation) =>
-        api.toggle(invocation.args && invocation.args['section']),
-      ActionTrust.LOW
+    this.registerApiAction('toggle', (api, invocation) =>
+      api.toggle(invocation.args && invocation.args['section'])
     );
-    this.registerApiAction(
-      'expand',
-      (api, invocation) =>
-        api.expand(invocation.args && invocation.args['section']),
-      ActionTrust.LOW
+    this.registerApiAction('expand', (api, invocation) =>
+      api.expand(invocation.args && invocation.args['section'])
     );
-    this.registerApiAction(
-      'collapse',
-      (api, invocation) =>
-        api.collapse(invocation.args && invocation.args['section']),
-      ActionTrust.LOW
+    this.registerApiAction('collapse', (api, invocation) =>
+      api.collapse(invocation.args && invocation.args['section'])
     );
 
     const {element} = this;

--- a/extensions/amp-accordion/1.0/amp-accordion.js
+++ b/extensions/amp-accordion/1.0/amp-accordion.js
@@ -16,6 +16,7 @@
 
 import * as Preact from '../../../src/preact';
 import {Accordion, AccordionSection} from './accordion';
+import {ActionTrust} from '../../../src/action-constants';
 import {CSS} from '../../../build/amp-accordion-1.0.css';
 import {PreactBaseElement} from '../../../src/preact/base-element';
 import {childElementsByTag, toggleAttribute} from '../../../src/dom';
@@ -34,9 +35,29 @@ const HEADER_SHIM_PROP = '__AMP_H_SHIM';
 const CONTENT_SHIM_PROP = '__AMP_C_SHIM';
 const SECTION_POST_RENDER = '__AMP_PR';
 
+/** @extends {PreactBaseElement<AccordionDef.AccordionApi>} */
 class AmpAccordion extends PreactBaseElement {
   /** @override */
   init() {
+    this.registerApiAction(
+      'toggle',
+      (api, invocation) =>
+        api.toggle(invocation.args && invocation.args['section']),
+      ActionTrust.LOW
+    );
+    this.registerApiAction(
+      'expand',
+      (api, invocation) =>
+        api.expand(invocation.args && invocation.args['section']),
+      ActionTrust.LOW
+    );
+    this.registerApiAction(
+      'collapse',
+      (api, invocation) =>
+        api.collapse(invocation.args && invocation.args['section']),
+      ActionTrust.LOW
+    );
+
     const {element} = this;
 
     const mu = new MutationObserver(() => {
@@ -94,6 +115,7 @@ function getState(element, mu) {
       'headerAs': headerShim,
       'contentAs': contentShim,
       'expanded': expanded,
+      'id': section.getAttribute('id'),
     });
     return <AccordionSection {...props} />;
   });

--- a/extensions/amp-accordion/1.0/amp-accordion.js
+++ b/extensions/amp-accordion/1.0/amp-accordion.js
@@ -39,13 +39,13 @@ class AmpAccordion extends PreactBaseElement {
   /** @override */
   init() {
     this.registerApiAction('toggle', (api, invocation) =>
-      api.toggle(invocation.args && invocation.args['section'])
+      api./*OK*/ toggle(invocation.args && invocation.args['section'])
     );
     this.registerApiAction('expand', (api, invocation) =>
-      api.expand(invocation.args && invocation.args['section'])
+      api./*OK*/ expand(invocation.args && invocation.args['section'])
     );
     this.registerApiAction('collapse', (api, invocation) =>
-      api.collapse(invocation.args && invocation.args['section'])
+      api./*OK*/ collapse(invocation.args && invocation.args['section'])
     );
 
     const {element} = this;

--- a/extensions/amp-accordion/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-accordion/1.0/storybook/Basic.amp.js
@@ -32,6 +32,8 @@ export default {
 export const _default = () => {
   const expandSingleSection = boolean('expandSingleSection', false);
   const animate = boolean('animate', false);
+  const createApiString = (action, section) =>
+    `tap:accordion.${action}(${section ? `section='${section}'` : ''})`;
   return (
     <main>
       <amp-accordion
@@ -54,18 +56,18 @@ export const _default = () => {
       </amp-accordion>
 
       <div class="buttons" style={{marginTop: 8}}>
-        <button on="tap:accordion.toggle(section='section1')">
+        <button on={createApiString('toggle', 'section1')}>
           toggle(section1)
         </button>
-        <button on="tap:accordion.toggle()">toggle all</button>
-        <button on="tap:accordion.expand(section='section1')">
+        <button on={createApiString('toggle')}>toggle all</button>
+        <button on={createApiString('expand', 'section1')}>
           expand(section1)
         </button>
-        <button on="tap:accordion.expand()">expand all</button>
-        <button on="tap:accordion.collapse(section='section1')">
+        <button on={createApiString('expand')}>expand all</button>
+        <button on={createApiString('collapse', 'section1')}>
           collapse(section1)
         </button>
-        <button on="tap:accordion.collapse()">collapse all</button>
+        <button on={createApiString('collapse')}>collapse all</button>
       </div>
     </main>
   );

--- a/extensions/amp-accordion/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-accordion/1.0/storybook/Basic.amp.js
@@ -33,22 +33,40 @@ export const _default = () => {
   const expandSingleSection = boolean('expandSingleSection', false);
   const animate = boolean('animate', false);
   return (
-    <amp-accordion
-      expand-single-section={expandSingleSection}
-      animate={animate}
-    >
-      <section>
-        <h2>Section 1</h2>
-        <p>Content in section 1.</p>
-      </section>
-      <section>
-        <h2>Section 2</h2>
-        <div>Content in section 2.</div>
-      </section>
-      <section expanded>
-        <h2>Section 3</h2>
-        <div>Content in section 3.</div>
-      </section>
-    </amp-accordion>
+    <main>
+      <amp-accordion
+        id="accordion"
+        expand-single-section={expandSingleSection}
+        animate={animate}
+      >
+        <section id="section1">
+          <h2>Section 1</h2>
+          <p>Content in section 1.</p>
+        </section>
+        <section>
+          <h2>Section 2</h2>
+          <div>Content in section 2.</div>
+        </section>
+        <section expanded>
+          <h2>Section 3</h2>
+          <div>Content in section 3.</div>
+        </section>
+      </amp-accordion>
+
+      <div class="buttons" style={{marginTop: 8}}>
+        <button on="tap:accordion.toggle(section='section1')">
+          toggle(section1)
+        </button>
+        <button on="tap:accordion.toggle()">toggle all</button>
+        <button on="tap:accordion.expand(section='section1')">
+          expand(section1)
+        </button>
+        <button on="tap:accordion.expand()">expand all</button>
+        <button on="tap:accordion.collapse(section='section1')">
+          collapse(section1)
+        </button>
+        <button on="tap:accordion.collapse()">collapse all</button>
+      </div>
+    </main>
   );
 };

--- a/extensions/amp-accordion/1.0/storybook/Basic.js
+++ b/extensions/amp-accordion/1.0/storybook/Basic.js
@@ -37,18 +37,20 @@ function AccordionWithActions(props) {
     <section>
       <Accordion ref={ref} {...props} />
       <div style={{marginTop: 8}}>
-        <button onClick={() => ref.current.toggle('section1')}>
+        <button onClick={() => ref.current./*OK*/ toggle('section1')}>
           toggle(section1)
         </button>
-        <button onClick={() => ref.current.toggle()}>toggle all</button>
-        <button onClick={() => ref.current.expand('section1')}>
+        <button onClick={() => ref.current./*OK*/ toggle()}>toggle all</button>
+        <button onClick={() => ref.current./*OK*/ expand('section1')}>
           expand(section1)
         </button>
-        <button onClick={() => ref.current.expand()}>expand all</button>
-        <button onClick={() => ref.current.collapse('section1')}>
+        <button onClick={() => ref.current./*OK*/ expand()}>expand all</button>
+        <button onClick={() => ref.current./*OK*/ collapse('section1')}>
           collapse(section1)
         </button>
-        <button onClick={() => ref.current.collapse()}>collapse all</button>
+        <button onClick={() => ref.current./*OK*/ collapse()}>
+          collapse all
+        </button>
       </div>
     </section>
   );

--- a/extensions/amp-accordion/1.0/storybook/Basic.js
+++ b/extensions/amp-accordion/1.0/storybook/Basic.js
@@ -37,18 +37,18 @@ function AccordionWithActions(props) {
     <section>
       <Accordion ref={ref} {...props} />
       <div style={{marginTop: 8}}>
-        <button onClick={() => ref.current.toggle('blah')}>
-          Toggle('blah')
+        <button onClick={() => ref.current.toggle('section1')}>
+          toggle(section1)
         </button>
-        <button onClick={() => ref.current.toggle()}>Toggle All</button>' ---- '
-        <button onClick={() => ref.current.expand('blah')}>
-          Expand('blah')
+        <button onClick={() => ref.current.toggle()}>toggle all</button>
+        <button onClick={() => ref.current.expand('section1')}>
+          expand(section1)
         </button>
-        <button onClick={() => ref.current.expand()}>Expand All</button>' ---- '
-        <button onClick={() => ref.current.collapse('blah')}>
-          Collapse('blah')
+        <button onClick={() => ref.current.expand()}>expand all</button>
+        <button onClick={() => ref.current.collapse('section1')}>
+          collapse(section1)
         </button>
-        <button onClick={() => ref.current.collapse()}>Collapse All</button>
+        <button onClick={() => ref.current.collapse()}>collapse all</button>
       </div>
     </section>
   );
@@ -63,18 +63,13 @@ export const _default = () => {
         expandSingleSection={expandSingleSection}
         animate={animate}
       >
-        <AccordionSection key={1} header={<h2>Section 1</h2>}>
+        <AccordionSection id="section1" key={1} header={<h2>Section 1</h2>}>
           <p>Content in section 1.</p>
         </AccordionSection>
         <AccordionSection key={2} header={<h2>Section 2</h2>}>
           <div>Content in section 2.</div>
         </AccordionSection>
-        <AccordionSection
-          id="blah"
-          key={3}
-          expanded
-          header={<h2>Section 3</h2>}
-        >
+        <AccordionSection key={3} expanded header={<h2>Section 3</h2>}>
           <div>Content in section 2.</div>
         </AccordionSection>
       </AccordionWithActions>

--- a/extensions/amp-accordion/1.0/storybook/Basic.js
+++ b/extensions/amp-accordion/1.0/storybook/Basic.js
@@ -25,20 +25,59 @@ export default {
   decorators: [withA11y, withKnobs],
 };
 
+/**
+ * @param {!Object} props
+ * @return {*}
+ */
+function AccordionWithActions(props) {
+  // TODO(#30447): replace imperative calls with "button" knobs when the
+  // Storybook 6.1 is released.
+  const ref = Preact.useRef();
+  return (
+    <section>
+      <Accordion ref={ref} {...props} />
+      <div style={{marginTop: 8}}>
+        <button onClick={() => ref.current.toggle('blah')}>
+          Toggle('blah')
+        </button>
+        <button onClick={() => ref.current.toggle()}>Toggle All</button>' ---- '
+        <button onClick={() => ref.current.expand('blah')}>
+          Expand('blah')
+        </button>
+        <button onClick={() => ref.current.expand()}>Expand All</button>' ---- '
+        <button onClick={() => ref.current.collapse('blah')}>
+          Collapse('blah')
+        </button>
+        <button onClick={() => ref.current.collapse()}>Collapse All</button>
+      </div>
+    </section>
+  );
+}
+
 export const _default = () => {
   const expandSingleSection = boolean('expandSingleSection', false);
   const animate = boolean('animate', false);
   return (
-    <Accordion expandSingleSection={expandSingleSection} animate={animate}>
-      <AccordionSection key={1} header={<h2>Section 1</h2>}>
-        <p>Content in section 1.</p>
-      </AccordionSection>
-      <AccordionSection key={2} header={<h2>Section 2</h2>}>
-        <div>Content in section 2.</div>
-      </AccordionSection>
-      <AccordionSection key={3} expanded header={<h2>Section 3</h2>}>
-        <div>Content in section 2.</div>
-      </AccordionSection>
-    </Accordion>
+    <main>
+      <AccordionWithActions
+        expandSingleSection={expandSingleSection}
+        animate={animate}
+      >
+        <AccordionSection key={1} header={<h2>Section 1</h2>}>
+          <p>Content in section 1.</p>
+        </AccordionSection>
+        <AccordionSection key={2} header={<h2>Section 2</h2>}>
+          <div>Content in section 2.</div>
+        </AccordionSection>
+        <AccordionSection
+          id="blah"
+          key={3}
+          expanded
+          header={<h2>Section 3</h2>}
+        >
+          <div>Content in section 2.</div>
+        </AccordionSection>
+      </AccordionWithActions>
+    </main>
   );
 };

--- a/extensions/amp-accordion/1.0/test/test-accordion.js
+++ b/extensions/amp-accordion/1.0/test/test-accordion.js
@@ -19,7 +19,6 @@ import {Accordion, AccordionSection} from '../accordion';
 import {mount} from 'enzyme';
 
 describes.sandboxed('Accordion preact component', {}, (env) => {
-  let win;
   describe('standalone accordion section', () => {
     it('should render a default section', () => {
       const wrapper = mount(
@@ -468,7 +467,7 @@ describes.sandboxed('Accordion preact component', {}, (env) => {
 
     describe('multi-expand accordion', () => {
       beforeEach(() => {
-        ref = Preact.useRef();
+        ref = Preact.createRef();
         wrapper = mount(
           <Accordion ref={ref}>
             <AccordionSection key={1} expanded header="header1" id="section1">

--- a/extensions/amp-accordion/1.0/test/test-accordion.js
+++ b/extensions/amp-accordion/1.0/test/test-accordion.js
@@ -94,7 +94,6 @@ describes.sandboxed('Accordion preact component', {}, (env) => {
     let wrapper;
 
     beforeEach(() => {
-      win = env.win;
       wrapper = mount(
         <Accordion>
           <AccordionSection key={1} expanded header="header1">
@@ -106,8 +105,7 @@ describes.sandboxed('Accordion preact component', {}, (env) => {
           <AccordionSection key={3} header="header3">
             content3
           </AccordionSection>
-        </Accordion>,
-        {attachTo: win}
+        </Accordion>
       );
     });
 
@@ -457,6 +455,200 @@ describes.sandboxed('Accordion preact component', {}, (env) => {
 
       // Immediately hidden, which means animation has not been even tried.
       expect(content.hidden).to.be.true;
+    });
+  });
+
+  describe('imperative api', () => {
+    let wrapper;
+    let ref;
+
+    let section1;
+    let section2;
+    let section3;
+
+    describe('multi-expand accordion', () => {
+      beforeEach(() => {
+        ref = Preact.useRef();
+        wrapper = mount(
+          <Accordion ref={ref}>
+            <AccordionSection key={1} expanded header="header1" id="section1">
+              content1
+            </AccordionSection>
+            <AccordionSection key={2} header="header2" id="section2">
+              content2
+            </AccordionSection>
+            <AccordionSection key={3} header="header3">
+              content3
+            </AccordionSection>
+          </Accordion>
+        );
+
+        const sections = wrapper.find(AccordionSection);
+        section1 = sections.at(0).getDOMNode();
+        section2 = sections.at(1).getDOMNode();
+        section3 = sections.at(2).getDOMNode();
+      });
+
+      it('toggle all', () => {
+        ref.current.toggle();
+        wrapper.update();
+
+        // All sections are toggled
+        expect(section1).to.not.have.attribute('expanded');
+        expect(section2).to.have.attribute('expanded');
+        expect(section3).to.have.attribute('expanded');
+      });
+
+      it('toggle one section', async () => {
+        ref.current.toggle('section1');
+        wrapper.update();
+
+        // Only section 1 is toggled
+        expect(section1).to.not.have.attribute('expanded');
+        expect(section2).to.not.have.attribute('expanded');
+        expect(section3).to.not.have.attribute('expanded');
+      });
+
+      it('expand all', async () => {
+        ref.current.expand();
+        wrapper.update();
+
+        // All sections are expanded
+        expect(section1).to.have.attribute('expanded');
+        expect(section2).to.have.attribute('expanded');
+        expect(section3).to.have.attribute('expanded');
+      });
+
+      it('expand one section', async () => {
+        // Collapse first section to setup the test
+        ref.current.collapse();
+        wrapper.update();
+
+        // Expand the first section
+        ref.current.expand('section1');
+        wrapper.update();
+
+        // Only the first section is expanded
+        expect(section1).to.have.attribute('expanded');
+        expect(section2).to.not.have.attribute('expanded');
+        expect(section3).to.not.have.attribute('expanded');
+      });
+
+      it('collapse all', async () => {
+        ref.current.collapse();
+        wrapper.update();
+
+        // All sections are collapsed
+        expect(section1).to.not.have.attribute('expanded');
+        expect(section2).to.not.have.attribute('expanded');
+        expect(section3).to.not.have.attribute('expanded');
+      });
+
+      it('collapse one section', async () => {
+        ref.current.collapse('section1');
+        wrapper.update();
+
+        // Only the first section is collapsed
+        expect(section1).to.not.have.attribute('expanded');
+        expect(section2).to.not.have.attribute('expanded');
+        expect(section3).to.not.have.attribute('expanded');
+      });
+    });
+
+    describe('single-expand accordion', () => {
+      beforeEach(() => {
+        ref = Preact.useRef();
+        wrapper = mount(
+          <Accordion ref={ref} expandSingleSection>
+            <AccordionSection key={1} expanded header="header1" id="section1">
+              content1
+            </AccordionSection>
+            <AccordionSection key={2} header="header2" id="section2">
+              content2
+            </AccordionSection>
+            <AccordionSection key={3} header="header3">
+              content3
+            </AccordionSection>
+          </Accordion>
+        );
+
+        const sections = wrapper.find(AccordionSection);
+        section1 = sections.at(0).getDOMNode();
+        section2 = sections.at(1).getDOMNode();
+        section3 = sections.at(2).getDOMNode();
+      });
+
+      it('toggle all', async () => {
+        ref.current.toggle();
+        wrapper.update();
+
+        // Accordion is unchanged (toggle does nothing for single-expand
+        // accordion)
+        expect(section1).to.have.attribute('expanded');
+        expect(section2).to.not.have.attribute('expanded');
+        expect(section3).to.not.have.attribute('expanded');
+      });
+
+      it('toggle one section', async () => {
+        ref.current.toggle('section2');
+        wrapper.update();
+
+        // Verify that the second section is expanded and the first
+        // section is un-expanded
+        expect(section1).to.not.have.attribute('expanded');
+        expect(section2).to.have.attribute('expanded');
+        expect(section3).to.not.have.attribute('expanded');
+
+        ref.current.toggle('section2');
+        wrapper.update();
+
+        // Verify that the second section is collapsed
+        expect(section1).to.not.have.attribute('expanded');
+        expect(section2).to.not.have.attribute('expanded');
+        expect(section3).to.not.have.attribute('expanded');
+      });
+
+      it('expand all', async () => {
+        ref.current.expand();
+        wrapper.update();
+
+        // Accordion is unchanged (expand does nothing for single-expand
+        // accordion)
+        expect(section1).to.have.attribute('expanded');
+        expect(section2).to.not.have.attribute('expanded');
+        expect(section3).to.not.have.attribute('expanded');
+      });
+
+      it('expand one section', async () => {
+        ref.current.expand('section2');
+        wrapper.update();
+
+        // Verify that the second section is expanded and the first
+        // section is un-expanded
+        expect(section1).to.not.have.attribute('expanded');
+        expect(section2).to.have.attribute('expanded');
+        expect(section3).to.not.have.attribute('expanded');
+      });
+
+      it('collapse all', async () => {
+        ref.current.collapse();
+        wrapper.update();
+
+        // All sections are collapsed
+        expect(section1).to.not.have.attribute('expanded');
+        expect(section2).to.not.have.attribute('expanded');
+        expect(section3).to.not.have.attribute('expanded');
+      });
+
+      it('collapse one section', async () => {
+        ref.current.collapse('section1');
+        wrapper.update();
+
+        // Section 1 is collapsed
+        expect(section1).to.not.have.attribute('expanded');
+        expect(section2).to.not.have.attribute('expanded');
+        expect(section3).to.not.have.attribute('expanded');
+      });
     });
   });
 });

--- a/extensions/amp-accordion/1.0/test/test-amp-accordion.js
+++ b/extensions/amp-accordion/1.0/test/test-amp-accordion.js
@@ -445,6 +445,7 @@ describes.realWin(
 
           section1 = element.children[0];
           section2 = element.children[1];
+          section3 = element.children[2];
         });
 
         it('toggle all', async () => {

--- a/extensions/amp-accordion/1.0/test/test-amp-accordion.js
+++ b/extensions/amp-accordion/1.0/test/test-amp-accordion.js
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 import '../amp-accordion';
+import {ActionInvocation} from '../../../../src/service/action-impl';
+import {ActionTrust} from '../../../../src/action-constants';
 import {htmlFor} from '../../../../src/static-template';
 import {toggleExperiment} from '../../../../src/experiments';
 import {waitFor} from '../../../../testing/test-helper';
@@ -43,7 +45,7 @@ describes.realWin(
       toggleExperiment(win, 'amp-accordion-bento', true, true);
       element = html`
         <amp-accordion layout="fixed" width="300" height="200">
-          <section expanded>
+          <section expanded id="section1">
             <h1>header1</h1>
             <div>content1</div>
           </section>
@@ -318,6 +320,210 @@ describes.realWin(
         animation.onfinish();
         await waitForExpanded(sections[0], false);
         expect(section.lastElementChild).to.have.display('none');
+      });
+    });
+
+    describe('imperative api', () => {
+      let section1;
+      let section2;
+      let section3;
+
+      beforeEach(() => {
+        section1 = element.children[0];
+        section2 = element.children[1];
+        section3 = element.children[2];
+      });
+
+      function invocation(method, args = {}) {
+        const source = null;
+        const caller = null;
+        const event = null;
+        const trust = ActionTrust.DEFAULT;
+        return new ActionInvocation(
+          element,
+          method,
+          args,
+          source,
+          caller,
+          event,
+          trust
+        );
+      }
+
+      describe('multi-expand accordion', () => {
+        it('toggle all', async () => {
+          element.enqueAction(invocation('toggle'));
+          await waitForExpanded(section1, false);
+
+          // All sections are toggled
+          expect(section1).to.not.have.attribute('expanded');
+          expect(section2).to.have.attribute('expanded');
+          expect(section3).to.have.attribute('expanded');
+        });
+
+        it('toggle one section', async () => {
+          element.enqueAction(invocation('toggle', {section: 'section1'}));
+          await waitForExpanded(section1, false);
+
+          // Only section 1 is toggled
+          expect(section1).to.not.have.attribute('expanded');
+          expect(section2).to.not.have.attribute('expanded');
+          expect(section3).to.not.have.attribute('expanded');
+        });
+
+        it('expand all', async () => {
+          element.enqueAction(invocation('expand'));
+          await waitForExpanded(section2, true);
+
+          // All sections are expanded
+          expect(section1).to.have.attribute('expanded');
+          expect(section2).to.have.attribute('expanded');
+          expect(section3).to.have.attribute('expanded');
+        });
+
+        it('expand one section', async () => {
+          // Collapse first section to setup the test
+          element.enqueAction(invocation('collapse'));
+          await waitForExpanded(section1, false);
+
+          // Expand the first section
+          element.enqueAction(invocation('expand', {section: 'section1'}));
+          await waitForExpanded(section1, true);
+
+          // Only the first section is expanded
+          expect(section1).to.have.attribute('expanded');
+          expect(section2).to.not.have.attribute('expanded');
+          expect(section3).to.not.have.attribute('expanded');
+        });
+
+        it('collapse all', async () => {
+          element.enqueAction(invocation('collapse'));
+          await waitForExpanded(section1, false);
+
+          // All sections are collapsed
+          expect(section1).to.not.have.attribute('expanded');
+          expect(section2).to.not.have.attribute('expanded');
+          expect(section3).to.not.have.attribute('expanded');
+        });
+
+        it('collapse one section', async () => {
+          element.enqueAction(invocation('collapse', {section: 'section1'}));
+          await waitForExpanded(section1, false);
+
+          // Only the first section is collapsed
+          expect(section1).to.not.have.attribute('expanded');
+          expect(section2).to.not.have.attribute('expanded');
+          expect(section3).to.not.have.attribute('expanded');
+        });
+      });
+
+      describe('single-expand accordion', () => {
+        beforeEach(async () => {
+          element = html`
+            <amp-accordion
+              expand-single-section
+              layout="fixed"
+              width="300"
+              height="200"
+            >
+              <section expanded id="section1">
+                <h1>header1</h1>
+                <div>content1</div>
+              </section>
+              <section id="section2">
+                <h1>header2</h1>
+                <div>content2</div>
+              </section>
+              <section>
+                <h1>header3</h1>
+                <div>content3</div>
+              </section>
+            </amp-accordion>
+          `;
+          win.document.body.appendChild(element);
+          await element.build();
+
+          section1 = element.children[0];
+          section2 = element.children[1];
+        });
+
+        it('toggle all', async () => {
+          // First action should do nothing
+          element.enqueAction(invocation('toggle'));
+
+          // Use a second action as we need something to waitFor
+          element.enqueAction(invocation('toggle', {section: 'section1'}));
+          await waitForExpanded(section1, false);
+
+          // Verify state after both actions (should reflect only 2nd action)
+          expect(section1).to.not.have.attribute('expanded');
+          expect(section2).to.not.have.attribute('expanded');
+          expect(section3).to.not.have.attribute('expanded');
+        });
+
+        it('toggle one section', async () => {
+          element.enqueAction(invocation('toggle', {section: 'section2'}));
+          await waitForExpanded(section1, false);
+
+          // Verify that the second section is expanded and the first
+          // section is un-expanded
+          expect(section1).to.not.have.attribute('expanded');
+          expect(section2).to.have.attribute('expanded');
+          expect(section3).to.not.have.attribute('expanded');
+
+          element.enqueAction(invocation('toggle', {section: 'section2'}));
+          await waitForExpanded(section2, false);
+
+          // Verify that the second section is collapsed
+          expect(section1).to.not.have.attribute('expanded');
+          expect(section2).to.not.have.attribute('expanded');
+          expect(section3).to.not.have.attribute('expanded');
+        });
+
+        it('expand all', async () => {
+          // First action should do nothing
+          element.enqueAction(invocation('expand'));
+
+          // Use a second action as we need something to waitFor
+          element.enqueAction(invocation('toggle', {section: 'section1'}));
+          await waitForExpanded(section1, false);
+
+          // Verify state after both actions (should reflect only 2nd action)
+          expect(section1).to.not.have.attribute('expanded');
+          expect(section2).to.not.have.attribute('expanded');
+          expect(section3).to.not.have.attribute('expanded');
+        });
+
+        it('expand one section', async () => {
+          element.enqueAction(invocation('expand', {section: 'section2'}));
+          await waitForExpanded(section1, false);
+
+          // Verify that the second section is expanded and the first
+          // section is un-expanded
+          expect(section1).to.not.have.attribute('expanded');
+          expect(section2).to.have.attribute('expanded');
+          expect(section3).to.not.have.attribute('expanded');
+        });
+
+        it('collapse all', async () => {
+          element.enqueAction(invocation('collapse'));
+          await waitForExpanded(section1, false);
+
+          // All sections are collapsed
+          expect(section1).to.not.have.attribute('expanded');
+          expect(section2).to.not.have.attribute('expanded');
+          expect(section3).to.not.have.attribute('expanded');
+        });
+
+        it('collapse one section', async () => {
+          element.enqueAction(invocation('collapse', {section: 'section1'}));
+          await waitForExpanded(section1, false);
+
+          // Section 1 is collapsed
+          expect(section1).to.not.have.attribute('expanded');
+          expect(section2).to.not.have.attribute('expanded');
+          expect(section3).to.not.have.attribute('expanded');
+        });
       });
     });
   }

--- a/src/preact/base-element.js
+++ b/src/preact/base-element.js
@@ -15,6 +15,7 @@
  */
 
 import * as Preact from './index';
+import {ActionTrust} from '../action-constants';
 import {AmpEvents} from '../amp-events';
 import {CanPlay, CanRender, LoadingProp} from '../contextprops';
 import {Deferred} from '../utils/promise';
@@ -308,7 +309,7 @@ export class PreactBaseElement extends AMP.BaseElement {
    * @param {../action-constants.ActionTrust} minTrust
    * @protected
    */
-  registerApiAction(alias, handler, minTrust) {
+  registerApiAction(alias, handler, minTrust = ActionTrust.DEFAULT) {
     this.registerAction(
       alias,
       (invocation) => handler(this.api(), invocation),


### PR DESCRIPTION
API Update 10/27

`toggle()` and `expand()` API methods called with no arguments for an accordion that has the attribute `expand-single-section` are special cases and are handled uniquely.  These two actions will not change the behavior of the accordion at all by definition.  These functions do not have a clearly defined behavior for accordions of more than 1 section.  To stay consistent, they will also not have an impact on accordions with 1 section.

****
Initial Description Below (10/20)

There are three API functions for Accordion in Preact mode

1. `toggle(id)` - if called with an `id`, the accordion will check for an Accordion section that has the same `id` and toggle it.  If called without an `id` it will toggle all sections.  Behavior is undefined for toggle all sections when `expand-single-section` is true.
2. `expand(id)` - if called with an `id`, the accordion will check for an Accordion section that has the same `id` and expand it.  If called without an `id` it will expand all sections.  Behavior is undefined for expand all sections when `expand-single-section` is true. 
3. `collapse(id)` - if called with an `id`, the accordion will check for an Accordion section that has the same `id` and collapse it.  If called without an `id` it will collapse all sections.  

Implementation Note:
This PR introduces a new state variable `realIdMap` which is a JSON object set by `useRef`.  This is a mapping from an accordion section's `id` prop to an internal `id` that is used by the accordion to track each section.  This is needed because the `toggle`, `expand`, `collapse` functions should only operate on a publisher provided `id` and not on internal `id`.  If multiple accordion sections have the same `id`, only the first one will be saved in the `realIdMap`.

Outstanding Issues:
1. `expandedMap` must be included in the dependency list of `useImperativeHandle` or else functionality is not as expected.  It appears that the functions do not get updated with the `expandedMap` unless `expandedMap` is included in the dependency list.  The compiler does not seem to like that `expandedMap` is in the dependency list (jump to line https://github.com/ampproject/amphtml/pull/30754/files#diff-29014805b49be0bc534bc1ea1a75299e796116cc8c26d01fa1e2042ac2107f26R94)
2. behavior still not fully working when `expand-single-section` is true