### PR TITLE
Release gulp-amphtml-validator @1.0.6

### DIFF
--- a/validator/js/gulpjs/README.md
+++ b/validator/js/gulpjs/README.md
@@ -41,6 +41,10 @@ To treat warnings as errors, replace the last line of the validation closure wit
 
 ## Release Notes
 
+### 1.0.6
+
+- Use fancy-log log.info (#30744)
+
 ### 1.0.5
 
 - Update repository location.

--- a/validator/js/gulpjs/package.json
+++ b/validator/js/gulpjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-amphtml-validator",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Gulp plugin for the official AMP HTML validator (www.ampproject.org)",
   "keywords": [
     "gulpplugin",


### PR DESCRIPTION
This PR includes updating the readme and version in package.json.

Already released as [1.0.6](https://www.npmjs.com/package/gulp-amphtml-validator/v/1.0.6).

Includes PR #30744 
