### PR TITLE
utility: add viewport-observer

### DIFF
--- a/src/viewport-observer.js
+++ b/src/viewport-observer.js
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import {devAssert} from '../src/log';
 import {isIframed} from './dom';
 
 /**
@@ -60,9 +61,15 @@ const viewportCallbacks = new WeakMap();
  * enter and exit the viewport. Fires viewportCallback when this happens.
  *
  * @param {!Element} element
- * @param {!function(boolean)} viewportCallback
+ * @param {function(boolean)} viewportCallback
  */
 export function observe(element, viewportCallback) {
+  // There should never be two unique observers of the same element.
+  devAssert(
+    !viewportCallbacks.has(element) ||
+      viewportCallbacks.get(element) === viewportCallback
+  );
+
   const win = element.ownerDocument.defaultView;
   if (!viewportObservers.has(win)) {
     viewportObservers.set(win, createViewportObserver(ioCallback, win));

--- a/src/viewport-observer.js
+++ b/src/viewport-observer.js
@@ -1,0 +1,105 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {isIframed} from './dom';
+
+/**
+ * Returns an IntersectionObserver tracking the Viewport.
+ * Only use this if x-origin iframe rootMargin support is considered nice-to-have,
+ * since if not supported this InOb will fallback to one without rootMargin.
+ *
+ * - If iframed: rootMargin is ignored unless natively supported (Chrome 81+).
+ * - If not iframed: all features work properly in both polyfill and built-in.
+ *
+ * @param {function(!Array<!IntersectionObserverEntry>)} ioCallback
+ * @param {!Window} win
+ * @param {string=} threshold
+ *
+ * @return {!IntersectionObserver}
+ */
+export function getViewportObserver(ioCallback, win, threshold) {
+  const iframed = isIframed(win);
+  const root = /** @type {?Element} */ (iframed
+    ? /** @type {*} */ (win.document)
+    : null);
+
+  // TODO(amphtml): Determine if rootMargin is still necessary.
+  const rootMargin = '25%';
+
+  try {
+    return new win.IntersectionObserver(ioCallback, {
+      root,
+      rootMargin,
+      threshold,
+    });
+  } catch (e) {
+    return new win.IntersectionObserver(ioCallback, {rootMargin, threshold});
+  }
+}
+
+/**
+ * @type Map<!Window, !IntersectionObserver}>
+ */
+const viewportObservers = new Map();
+
+/** @type WeakMap<!Element, function(bool)> */
+const viewportCallbacks = new WeakMap();
+
+/**
+ * Lazily creates an IntersectionObserver per Window to track when elements
+ * enter and exit the viewport. Fires viewportCallback when this happens.
+ *
+ * @param {!Element} element
+ * @param {function(boolean)} viewportCallback
+ */
+export function observe(element, viewportCallback) {
+  const win = element.ownerDocument.defaultView;
+  if (!viewportObservers.has(win)) {
+    viewportObservers.set(win, getViewportObserver(ioCallback, win));
+  }
+  viewportCallbacks.set(element, viewportCallback);
+  viewportObservers.get(win).observe(element);
+}
+
+/**
+ * Unobserve an element.
+ * @param {!Element} element
+ */
+export function unobserve(element) {
+  const win = element.ownerDocument.defaultView;
+  if (viewportObservers.has(win)) {
+    viewportObservers.get(win).unobserve(element);
+  }
+  viewportCallbacks.delete(element);
+}
+
+/**
+ * Call the registered callbacks for each element that has crossed the
+ * viewport bounday.
+ *
+ * @param {!Array<!IntersectionObserverEntry>} entries
+ */
+function ioCallback(entries) {
+  for (let i = 0; i < entries.length; i++) {
+    const {isIntersecting, target} = entries[i];
+    const viewportCallback = viewportCallbacks.get(target);
+
+    // The callback may not exist if it wasn't cleaned up
+    // but the element has been GCed.
+    if (viewportCallback) {
+      viewportCallback(isIntersecting);
+    }
+  }
+}

--- a/src/viewport-observer.js
+++ b/src/viewport-observer.js
@@ -26,7 +26,7 @@ import {isIframed} from './dom';
  *
  * @param {function(!Array<!IntersectionObserverEntry>)} ioCallback
  * @param {!Window} win
- * @param {number=|!Array<number>=} threshold
+ * @param {(number|!Array<number>)=} threshold
  *
  * @return {!IntersectionObserver}
  */

--- a/src/viewport-observer.js
+++ b/src/viewport-observer.js
@@ -36,7 +36,8 @@ export function createViewportObserver(ioCallback, win, threshold) {
     ? /** @type {*} */ (win.document)
     : null);
 
-  // Historically viewportCallback used a 25% rootMargin, so emulate it here.
+  // TODO(30794): See if we can safely remove rootMargin without adversely
+  // affecting metrics.
   const rootMargin = '25%';
 
   try {

--- a/src/viewport-observer.js
+++ b/src/viewport-observer.js
@@ -85,7 +85,7 @@ export function unobserve(element) {
 
 /**
  * Call the registered callbacks for each element that has crossed the
- * viewport bounday.
+ * viewport boundary.
  *
  * @param {!Array<!IntersectionObserverEntry>} entries
  */
@@ -94,10 +94,13 @@ function ioCallback(entries) {
     const {isIntersecting, target} = entries[i];
     const viewportCallback = viewportCallbacks.get(target);
 
-    // The callback may not exist if it wasn't cleaned up
+    // The callback may not exist if unobserve wasn't called
     // but the element has been GCed.
-    if (viewportCallback) {
-      viewportCallback(isIntersecting);
+    if (!viewportCallback) {
+      unobserve(target);
+      return;
     }
+
+    viewportCallback(isIntersecting);
   }
 }

--- a/src/viewport-observer.js
+++ b/src/viewport-observer.js
@@ -36,7 +36,7 @@ export function createViewportObserver(ioCallback, win, threshold) {
     ? /** @type {*} */ (win.document)
     : null);
 
-  // TODO(30794): See if we can safely remove rootMargin without adversely
+  // TODO(#30794): See if we can safely remove rootMargin without adversely
   // affecting metrics.
   const rootMargin = '25%';
 

--- a/src/viewport-observer.js
+++ b/src/viewport-observer.js
@@ -49,12 +49,10 @@ export function getViewportObserver(ioCallback, win, threshold) {
   }
 }
 
-/**
- * @type Map<!Window, !IntersectionObserver}>
- */
+/** @type {Map<!Window, !IntersectionObserver>} */
 const viewportObservers = new Map();
 
-/** @type WeakMap<!Element, function(bool)> */
+/** @type {WeakMap<!Element, function(bool)>} */
 const viewportCallbacks = new WeakMap();
 
 /**

--- a/src/viewport-observer.js
+++ b/src/viewport-observer.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import {devAssert} from '../src/log';
+import {getMode} from './mode';
 import {isIframed} from './dom';
 
 /**
@@ -68,10 +69,12 @@ const viewportCallbacks = new WeakMap();
  */
 export function observeWithSharedInOb(element, viewportCallback) {
   // There should never be two unique observers of the same element.
-  devAssert(
-    !viewportCallbacks.has(element) ||
-      viewportCallbacks.get(element) === viewportCallback
-  );
+  if (getMode().localDev) {
+    devAssert(
+      !viewportCallbacks.has(element) ||
+        viewportCallbacks.get(element) === viewportCallback
+    );
+  }
 
   const win = element.ownerDocument.defaultView;
   let viewportObserver = viewportObservers.get(win);

--- a/test/unit/test-viewport-observer.js
+++ b/test/unit/test-viewport-observer.js
@@ -15,13 +15,13 @@
  */
 
 import {
-  getViewportObserver,
+  createViewportObserver,
   observe,
   unobserve,
 } from '../../src/viewport-observer';
 
 describes.sandboxed('Viewport Observer', {}, (env) => {
-  describe('getViewportObserver', () => {
+  describe('createViewportObserver', () => {
     let win;
     let ctorSpy;
     const noop = () => {};
@@ -37,7 +37,7 @@ describes.sandboxed('Viewport Observer', {}, (env) => {
     });
 
     it('When not iframed, uses null root.', () => {
-      getViewportObserver(noop, win);
+      createViewportObserver(noop, win);
 
       expect(ctorSpy).calledWith(noop, {
         root: null,
@@ -48,7 +48,7 @@ describes.sandboxed('Viewport Observer', {}, (env) => {
 
     it('When iframed, use document root.', () => {
       setIframed();
-      getViewportObserver(noop, win);
+      createViewportObserver(noop, win);
 
       expect(ctorSpy).calledWith(noop, {
         root: win.document,
@@ -64,7 +64,7 @@ describes.sandboxed('Viewport Observer', {}, (env) => {
           throw new Error();
         }
       });
-      getViewportObserver(noop, win);
+      createViewportObserver(noop, win);
 
       expect(ctorSpy).calledWith(noop, {
         root: win.document,
@@ -78,11 +78,11 @@ describes.sandboxed('Viewport Observer', {}, (env) => {
     });
 
     it('Pass along threshold argument', () => {
-      getViewportObserver(noop, win, '50%');
+      createViewportObserver(noop, win, 0.5);
       expect(ctorSpy).calledWith(noop, {
         root: null,
         rootMargin: '25%',
-        threshold: '50%',
+        threshold: 0.5,
       });
     });
   });

--- a/test/unit/test-viewport-observer.js
+++ b/test/unit/test-viewport-observer.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/test-viewport-observer.js
+++ b/test/unit/test-viewport-observer.js
@@ -1,0 +1,162 @@
+/**
+ * Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  getViewportObserver,
+  observe,
+  unobserve,
+} from '../../src/viewport-observer';
+
+describes.sandboxed('Viewport Observer', {}, (env) => {
+  describe('getViewportObserver', () => {
+    let win;
+    let ctorSpy;
+    const noop = () => {};
+
+    const setIframed = () => (win.parent = {});
+    beforeEach(() => {
+      ctorSpy = env.sandbox.stub();
+      win = {
+        parent: null,
+        document: {},
+        IntersectionObserver: ctorSpy,
+      };
+    });
+
+    it('When not iframed, uses null root.', () => {
+      getViewportObserver(noop, win);
+
+      expect(ctorSpy).calledWith(noop, {
+        root: null,
+        rootMargin: '25%',
+        threshold: undefined,
+      });
+    });
+
+    it('When iframed, use document root.', () => {
+      setIframed();
+      getViewportObserver(noop, win);
+
+      expect(ctorSpy).calledWith(noop, {
+        root: win.document,
+        rootMargin: '25%',
+        threshold: undefined,
+      });
+    });
+
+    it('If ctor throws, fallback to rootless', () => {
+      setIframed();
+      ctorSpy.callsFake((_cb, {root}) => {
+        if (root === win.document) {
+          throw new Error();
+        }
+      });
+      getViewportObserver(noop, win);
+
+      expect(ctorSpy).calledWith(noop, {
+        root: win.document,
+        rootMargin: '25%',
+        threshold: undefined,
+      });
+      expect(ctorSpy).calledWith(noop, {
+        rootMargin: '25%',
+        threshold: undefined,
+      });
+    });
+
+    it('Pass along threshold argument', () => {
+      getViewportObserver(noop, win, '50%');
+      expect(ctorSpy).calledWith(noop, {
+        root: null,
+        rootMargin: '25%',
+        threshold: '50%',
+      });
+    });
+  });
+
+  describe('Shared viewport observer', () => {
+    let inOb;
+    let win;
+    let doc;
+    let el1;
+    let el2;
+    let tracked;
+
+    beforeEach(() => {
+      inOb = env.sandbox.stub();
+      tracked = new Set();
+      inOb.callsFake(() => ({
+        observe: (el) => tracked.add(el),
+        unobserve: (el) => tracked.delete(el),
+      }));
+
+      win = {IntersectionObserver: inOb};
+      doc = {defaultView: win};
+      el1 = {ownerDocument: doc};
+      el2 = {ownerDocument: doc};
+    });
+
+    /**
+     * Simulate an IntersectionObserver callback for an element.
+     * @param {!Element} el
+     * @param {boolean} inViewport
+     */
+    function toggleViewport(el, inViewport) {
+      const win = el.ownerDocument.defaultView;
+      // Grabs the IO Callback shared by all the viewport observers.
+      const ioCallback = win.IntersectionObserver.getCall(0).args[0];
+      if (tracked.has(el)) {
+        ioCallback([{target: el, isIntersecting: inViewport}]);
+      }
+    }
+
+    it('observed element should have its callback fired each time it enters/exist the viewport.', () => {
+      const viewportEvents = [];
+      observe(el1, (inViewport) => viewportEvents.push(inViewport));
+      toggleViewport(el1, true);
+      toggleViewport(el1, false);
+
+      expect(viewportEvents).eql([true, false]);
+    });
+
+    it('can independently observe multiple elements', () => {
+      const el1Events = [];
+      const el2Events = [];
+
+      observe(el1, (inViewport) => el1Events.push(inViewport));
+      observe(el2, (inViewport) => el2Events.push(inViewport));
+      toggleViewport(el1, false);
+      toggleViewport(el2, true);
+      toggleViewport(el1, true);
+
+      expect(el1Events).eql([false, true]);
+      expect(el2Events).eql([true]);
+    });
+
+    it('once unobserved, the callback is no longer fired', () => {
+      const el1Events = [];
+
+      observe(el1, (inViewport) => el1Events.push(inViewport));
+      toggleViewport(el1, false);
+
+      unobserve(el1);
+      toggleViewport(el1, true);
+      toggleViewport(el1, false);
+
+      expect(el1Events).eql([false]);
+    });
+  });
+});

--- a/test/unit/test-viewport-observer.js
+++ b/test/unit/test-viewport-observer.js
@@ -158,5 +158,15 @@ describes.sandboxed('Viewport Observer', {}, (env) => {
 
       expect(el1Events).eql([false]);
     });
+
+    it('Observing twice with the same callback is fine, but unique ones throw', () => {
+      const noop = () => {};
+      observe(el1, noop);
+      observe(el1, noop);
+
+      allowConsoleError(() => {
+        expect(() => observe(el1, () => {})).throws('Assertion failed');
+      });
+    });
   });
 });

--- a/test/unit/test-viewport-observer.js
+++ b/test/unit/test-viewport-observer.js
@@ -16,8 +16,8 @@
 
 import {
   createViewportObserver,
-  observe,
-  unobserve,
+  observeWithSharedInOb,
+  unobserveWithSharedInOb,
 } from '../../src/viewport-observer';
 
 describes.sandboxed('Viewport Observer', {}, (env) => {
@@ -125,7 +125,9 @@ describes.sandboxed('Viewport Observer', {}, (env) => {
 
     it('observed element should have its callback fired each time it enters/exist the viewport.', () => {
       const viewportEvents = [];
-      observe(el1, (inViewport) => viewportEvents.push(inViewport));
+      observeWithSharedInOb(el1, (inViewport) =>
+        viewportEvents.push(inViewport)
+      );
       toggleViewport(el1, true);
       toggleViewport(el1, false);
 
@@ -136,8 +138,8 @@ describes.sandboxed('Viewport Observer', {}, (env) => {
       const el1Events = [];
       const el2Events = [];
 
-      observe(el1, (inViewport) => el1Events.push(inViewport));
-      observe(el2, (inViewport) => el2Events.push(inViewport));
+      observeWithSharedInOb(el1, (inViewport) => el1Events.push(inViewport));
+      observeWithSharedInOb(el2, (inViewport) => el2Events.push(inViewport));
       toggleViewport(el1, false);
       toggleViewport(el2, true);
       toggleViewport(el1, true);
@@ -149,10 +151,10 @@ describes.sandboxed('Viewport Observer', {}, (env) => {
     it('once unobserved, the callback is no longer fired', () => {
       const el1Events = [];
 
-      observe(el1, (inViewport) => el1Events.push(inViewport));
+      observeWithSharedInOb(el1, (inViewport) => el1Events.push(inViewport));
       toggleViewport(el1, false);
 
-      unobserve(el1);
+      unobserveWithSharedInOb(el1);
       toggleViewport(el1, true);
       toggleViewport(el1, false);
 
@@ -161,11 +163,13 @@ describes.sandboxed('Viewport Observer', {}, (env) => {
 
     it('Observing twice with the same callback is fine, but unique ones throw', () => {
       const noop = () => {};
-      observe(el1, noop);
-      observe(el1, noop);
+      observeWithSharedInOb(el1, noop);
+      observeWithSharedInOb(el1, noop);
 
       allowConsoleError(() => {
-        expect(() => observe(el1, () => {})).throws('Assertion failed');
+        expect(() => observeWithSharedInOb(el1, () => {})).throws(
+          'Assertion failed'
+        );
       });
     });
   });


### PR DESCRIPTION
**summary**

Adds `viewport-observer` file with three exported functions.
1. `getViewportObserver`: its a helper for creating a viewport-tracking IntersectionObserver. Attempts to add 25% rootMargin as a nice-to-have, but if impossible proceeds without it.
2. `observe`: a method for registering a callback for when an element enters/exits viewport. essentially an on-demand viewportCallback that ~10 components will use (as opposed to all). This allows them to share the same InOb, one per window. While theoretically a shared InOb for all use cases could cause conflicts if multiple actors try to observe/unobserve the same set of elements, this shouldn't happen when each component is only responsible for managing themselves.
3. `unobserve`: cleanup function for observe.

Notes: 
- Only one callback can be registered per element in the current design. Hypothetically it could be setup to understand multiple actors/callbacks, but that doesn't seem necessary given the use-case.
- Currently this is not a service. Which means this will end up being 1 instance per extension that uses it vs. one InOb for all components.