### PR TITLE
1% experiment - AdSense/GAM ad request ptt parameter

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -36,6 +36,6 @@
   "analytics-chunks": 1,
   "render-on-idle-fix": 1,
   "build-in-chunks": 1,
-  "adsensePttExp": 0.02,
-  "doubleclickPttExp": 0.02
+  "adsense-ptt-exp": 0.02,
+  "doubleclick-ptt-exp": 0.02
 }

--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -35,5 +35,7 @@
   "amp-ad-no-center-css": 0,
   "analytics-chunks": 1,
   "render-on-idle-fix": 1,
-  "build-in-chunks": 1
+  "build-in-chunks": 1,
+  "adsensePttExp": 0.02,
+  "doubleclickPttExp": 0.02,
 }

--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -37,5 +37,5 @@
   "render-on-idle-fix": 1,
   "build-in-chunks": 1,
   "adsensePttExp": 0.02,
-  "doubleclickPttExp": 0.02,
+  "doubleclickPttExp": 0.02
 }

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -33,5 +33,7 @@
   "swg-gpay-api": 1,
   "swg-gpay-native": 1,
   "amp-ad-no-center-css": 0,
-  "analytics-chunks": 1
+  "analytics-chunks": 1,
+  "adsensePttExp": 0.02,
+  "doubleclickPttExp": 0.02,
 }

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -35,5 +35,5 @@
   "amp-ad-no-center-css": 0,
   "analytics-chunks": 1,
   "adsensePttExp": 0.02,
-  "doubleclickPttExp": 0.02,
+  "doubleclickPttExp": 0.02
 }

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -34,6 +34,6 @@
   "swg-gpay-native": 1,
   "amp-ad-no-center-css": 0,
   "analytics-chunks": 1,
-  "adsensePttExp": 0.02,
-  "doubleclickPttExp": 0.02
+  "adsense-ptt-exp": 0.02,
+  "doubleclick-ptt-exp": 0.02
 }

--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -232,11 +232,13 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
    * @visibleForTesting
    */
   divertExperiments() {
-    const experimentInfoList = /** @type {!Array<!../../../src/experiments.ExperimentInfo>} */ ([{
-      experimentId: PTT_EXP,
-      isTrafficEligible: () => true,
-      branches: Object.values(PTT_EXP_BRANCHES),
-    }]);
+    const experimentInfoList = /** @type {!Array<!../../../src/experiments.ExperimentInfo>} */ ([
+      {
+        experimentId: PTT_EXP,
+        isTrafficEligible: () => true,
+        branches: Object.values(PTT_EXP_BRANCHES),
+      },
+    ]);
     const setExps = randomlySelectUnsetExperiments(
       this.win,
       experimentInfoList
@@ -340,8 +342,9 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
       'w': sizeToSend.width,
       'h': sizeToSend.height,
       'ptt':
-        getExperimentBranch(this.win, PTT_EXP) ===	PTT_EXP_BRANCHES.EXPERIMENT
-          ? 12 : null,
+        getExperimentBranch(this.win, PTT_EXP) === PTT_EXP_BRANCHES.EXPERIMENT
+          ? 12
+          : null,
       'iu': slotname,
       'npa':
         consentState == CONSENT_POLICY_STATE.INSUFFICIENT ||

--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -70,7 +70,7 @@ const ADSENSE_BASE_URL = 'https://googleads.g.doubleclick.net/pagead/ads';
 const TAG = 'amp-ad-network-adsense-impl';
 
 /** @const {string} */
-const PTT_EXP = 'adsensePttExp';
+const PTT_EXP = 'adsense-ptt-exp';
 
 /** @const @enum{string} */
 const PTT_EXP_BRANCHES = {

--- a/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
@@ -736,7 +736,8 @@ describes.realWin(
         it('sets ptt parameter', () => {
           forceExperimentBranch(impl.win, 'adsense-ptt-exp', '21068092');
           return expect(impl.getAdUrl()).to.eventually.match(
-            /(\?|&)ptt=12(&|$)/);
+            /(\?|&)ptt=12(&|$)/
+          );
         });
       });
 

--- a/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
@@ -736,7 +736,7 @@ describes.realWin(
         it('sets ptt parameter', () => {
           forceExperimentBranch(impl.win, 'adsense-ptt-exp', '21068092');
           return expect(impl.getAdUrl()).to.eventually.match(
-            /(\?|&)ptt=(&|$)/);
+            /(\?|&)ptt=12(&|$)/);
         });
       });
 

--- a/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
@@ -732,11 +732,11 @@ describes.realWin(
           );
         });
         it('does not set ptt parameter by default', () =>
-          expect(impl.getAdUrl()).to.not.eventually.match(/(\?|&)ptt=12(&|$)/));
+          expect(impl.getAdUrl()).to.not.eventually.match(/(\?|&)ptt=(&|$)/));
         it('sets ptt parameter', () => {
-          forceExperimentBranch(impl.win, 'adsensePttExp', '21068092');
+          forceExperimentBranch(impl.win, 'adsense-ptt-exp', '21068092');
           return expect(impl.getAdUrl()).to.eventually.match(
-            /(\?|&)ptt=12(&|$)/);
+            /(\?|&)ptt=(&|$)/);
         });
       });
 

--- a/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
@@ -731,6 +731,13 @@ describes.realWin(
             /(\?|&)is_amp=5(&|$)/
           );
         });
+        it('does not set ptt parameter by default', () =>
+          expect(impl.getAdUrl()).to.not.eventually.match(/(\?|&)ptt=12(&|$)/));
+        it('sets ptt parameter', () => {
+          forceExperimentBranch(impl.win, 'adsensePttExp', '21068092');
+          return expect(impl.getAdUrl()).to.eventually.match(
+            /(\?|&)ptt=12(&|$)/);
+        });
       });
 
       // Not using arrow function here because otherwise the way closure behaves

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -145,7 +145,7 @@ const ZINDEX_EXP_BRANCHES = {
 };
 
 /** @const {string} */
-const PTT_EXP = 'doubleclickPttExp';
+const PTT_EXP = 'doubleclick-ptt-exp';
 
 /** @const @enum{string} */
 const PTT_EXP_BRANCHES = {

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -573,8 +573,9 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
     const {consentString, gdprApplies} = consentTuple;
 
     return {
-      'ptt':
-        this.experimentIds.includes(PTT_EXP_BRANCHES.EXPERIMENT) ? 13 : null,
+      'ptt': this.experimentIds.includes(PTT_EXP_BRANCHES.EXPERIMENT)
+        ? 13
+        : null,
       'npa':
         consentTuple.consentState == CONSENT_POLICY_STATE.INSUFFICIENT ||
         consentTuple.consentState == CONSENT_POLICY_STATE.UNKNOWN

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -144,6 +144,15 @@ const ZINDEX_EXP_BRANCHES = {
   HOLDBACK: '21065357',
 };
 
+/** @const {string} */
+const PTT_EXP = 'doubleclickPttExp';
+
+/** @const @enum{string} */
+const PTT_EXP_BRANCHES = {
+  CONTROL: '21068093',
+  EXPERIMENT: '21068094',
+};
+
 /**
  * Required size to be sent with fluid requests.
  * @const {string}
@@ -430,6 +439,11 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
         isTrafficEligible: () => true,
         branches: Object.values(ZINDEX_EXP_BRANCHES),
       },
+      {
+        experimentId: PTT_EXP,
+        isTrafficEligible: () => true,
+        branches: Object.values(PTT_EXP_BRANCHES),
+      },
     ]);
     const setExps = this.randomlySelectUnsetExperiments_(experimentInfoList);
     Object.keys(setExps).forEach(
@@ -559,6 +573,8 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
     const {consentString, gdprApplies} = consentTuple;
 
     return {
+      'ptt':
+        this.experimentIds.includes(PTT_EXP_BRANCHES.EXPERIMENT) ? 13 : null,
       'npa':
         consentTuple.consentState == CONSENT_POLICY_STATE.INSUFFICIENT ||
         consentTuple.consentState == CONSENT_POLICY_STATE.UNKNOWN

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -1084,8 +1084,7 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, (env) => {
       expect(impl.getAdUrl()).to.not.eventually.match(/(\?|&)ptt=(&|$)/));
     it('sets ptt parameter', () => {
       impl.experimentIds = ['21068094'];
-      return expect(impl.getAdUrl()).to.eventually.match(
-        /(\?|&)ptt=13(&|$)/);
+      return expect(impl.getAdUrl()).to.eventually.match(/(\?|&)ptt=13(&|$)/);
     });
   });
 

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -1079,6 +1079,14 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, (env) => {
         expect(url).to.not.match(/(=|%2C)2106317(3|4)(%2C|&|$)/);
       });
     });
+
+    it('does not set ptt parameter by default', () =>
+      expect(impl.getAdUrl()).to.not.eventually.match(/(\?|&)ptt=13(&|$)/));
+    it('sets ptt parameter', () => {
+      impl.experimentIds = ['21068094'];
+      return expect(impl.getAdUrl()).to.eventually.match(
+        /(\?|&)ptt=13(&|$)/);
+    });
   });
 
   describe('#getPageParameters', () => {

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -1085,7 +1085,7 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, (env) => {
     it('sets ptt parameter', () => {
       impl.experimentIds = ['21068094'];
       return expect(impl.getAdUrl()).to.eventually.match(
-        /(\?|&)ptt=(&|$)/);
+        /(\?|&)ptt=13(&|$)/);
     });
   });
 

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -1081,11 +1081,11 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, (env) => {
     });
 
     it('does not set ptt parameter by default', () =>
-      expect(impl.getAdUrl()).to.not.eventually.match(/(\?|&)ptt=13(&|$)/));
+      expect(impl.getAdUrl()).to.not.eventually.match(/(\?|&)ptt=(&|$)/));
     it('sets ptt parameter', () => {
       impl.experimentIds = ['21068094'];
       return expect(impl.getAdUrl()).to.eventually.match(
-        /(\?|&)ptt=13(&|$)/);
+        /(\?|&)ptt=(&|$)/);
     });
   });
 


### PR DESCRIPTION
For amp-ad type=adsense or doubleclick, 1% experiment that sends new ptt parameter on ad request with fixed value.