### PR TITLE
Validator rollup for 20201020

### DIFF
--- a/extensions/amp-onetap-google/validator-amp-onetap-google.protoascii
+++ b/extensions/amp-onetap-google/validator-amp-onetap-google.protoascii
@@ -1,18 +1,18 @@
-#	
-# Copyright 2020 The AMP HTML Authors. All Rights Reserved.	
-#	
-# Licensed under the Apache License, Version 2.0 (the "License");	
-# you may not use this file except in compliance with the License.	
-# You may obtain a copy of the License at	
-#	
-#      http://www.apache.org/licenses/LICENSE-2.0	
-#	
-# Unless required by applicable law or agreed to in writing, software	
-# distributed under the License is distributed on an "AS-IS" BASIS,	
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.	
-# See the License for the specific language governing permissions and	
-# limitations under the license.	
-#	
+#
+# Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the license.
+#
 
 tags: {  # amp-onetap-google
   html_format: AMP
@@ -22,7 +22,7 @@ tags: {  # amp-onetap-google
     version: "0.1"
     version: "latest"
   }
-  attr_lists: "common-extension-attrs"	
+  attr_lists: "common-extension-attrs"
 }
 
 tags: {  # <amp-onetap-google>

--- a/validator/testdata/transformed_feature_tests/amp-img.html
+++ b/validator/testdata/transformed_feature_tests/amp-img.html
@@ -29,7 +29,12 @@
 <body>
   <!-- Valid: amp-img > img -->
   <amp-img src="/img/canoe_900x600.jpg" alt="An image about canoeing" layout="responsive" width="900" height="600" i-amphtml-ssr>
-    <img src="/img/canoe_900x600.jpg" alt="An image about canoeing" decoding="async">
+    <img src="/img/canoe_900x600.jpg" alt="An image about canoeing" class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async">
+  </amp-img>
+
+  <!-- Valid: amp-img > img, lazy -->
+  <amp-img src="/img/canoe_900x600.jpg" alt="An image about canoeing" layout="responsive" width="900" height="600" i-amphtml-ssr>
+    <img loading="lazy" src="/img/canoe_900x600.jpg" alt="An image about canoeing" class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async">
   </amp-img>
 
   <!-- Valid: amp-img[layout=intrinsic] > img -->
@@ -37,17 +42,28 @@
     <i-amphtml-sizer class="i-amphtml-sizer">
       <img alt aria-hidden="true" class="i-amphtml-intrinsic-sizer" role="presentation" src="data:image/svg+xml;charset=utf-8,<svg height=&quot;600&quot; width=&quot;900&quot; xmlns=&quot;http://www.w3.org/2000/svg&quot; version=&quot;1.1&quot;/>">
     </i-amphtml-sizer>
-    <img src="/img/canoe_900x600.jpg" alt="An image about canoeing" decoding="async">
+    <img src="/img/canoe_900x600.jpg" alt="An image about canoeing" class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async">
   </amp-img>
 
   <!-- Invalid: amp-img > img, missing i-amphtml-ssr attr -->
   <amp-img src="/img/canoe_900x600.jpg" alt="An image about canoeing" layout="responsive" width="900" height="600">
-    <img src="/img/canoe_900x600.jpg" alt="An image about canoeing" decoding="async">
+    <img src="/img/canoe_900x600.jpg" alt="An image about canoeing" class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async">
   </amp-img>
 
   <!-- Invalid: amp-img > img, missing decoding attr -->
   <amp-img src="/img/canoe_900x600.jpg" alt="An image about canoeing" layout="responsive" width="900" height="600" i-amphtml-ssr>
-    <img src="/img/canoe_900x600.jpg" alt="An image about canoeing">
+    <img src="/img/canoe_900x600.jpg" alt="An image about canoeing" class="i-amphtml-fill-content i-amphtml-replaced-content">
+  </amp-img>
+
+  <!-- Invalid: amp-img > img, missing class attr -->
+  <amp-img src="/img/canoe_900x600.jpg" alt="An image about canoeing" layout="responsive" width="900" height="600" i-amphtml-ssr>
+    <img src="/img/canoe_900x600.jpg" alt="An image about canoeing" decoding="async">
+  </amp-img>
+
+  <!-- Invalid: amp-img > img, blurry image placeholder -->
+  <amp-img src="/img/canoe_900x600.jpg" alt="An image about canoeing" layout="responsive" width="900" height="600" i-amphtml-ssr>
+    <i-amphtml-sizer style=display:block;padding-top:58.6667%;></i-amphtml-sizer>
+    <img class=i-amphtml-blurry-placeholder placeholder src="data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http%3A//www.w3.org/2000/svg' xmlns%3Axlink='http%3A//www.w3.org/1999/xlink' viewBox='0 0 9 7'%3E%3Cfilter id='b' color-interpolation-filters='sRGB'%3E%3CfeGaussianBlur stdDeviation='.5'%3E%3C/feGaussianBlur%3E%3CfeComponentTransfer%3E%3CfeFuncA type='discrete' tableValues='1 1'%3E%3C/feFuncA%3E%3C/feComponentTransfer%3E%3C/filter%3E%3Cimage filter='url(%23b)' x='0' y='0' height='100%25' width='100%25' xlink%3Ahref='data%3Aimage/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAkAAAAHCAYAAADam2dgAAAA4klEQVR4ARXBO04CURSA4f/OnHkpA4TRWGhFMg3oFlyCjTuwYRsULMEtuAgTGzUhttpZkagREwhEhwvjvI7x+8z0aqAHXYj3wA/gfpZz82yZXCakPYf8u0LspmGbGTxXaUfK21fJ7atltGiRHvn4cYOYXIl8RRSkVj5+Sv5JXvD7qWQrg2QW3BqWlDzOtuycGhSe3nOSdkmaeIjdKXfzjMNQGA1asF9wMXQ4G1Z0ogqxipuZYNyVkH4YsVg7FGuh73qcnAvecczqwSBL49AJI6a1QSolLJTexnB6bRC/4WUe8AdyJ1gLZ2JPFwAAAABJRU5ErkJggg=='%3E%3C/image%3E%3C/svg%3E">
   </amp-img>
 </body>
 </html>

--- a/validator/testdata/transformed_feature_tests/amp-img.out
+++ b/validator/testdata/transformed_feature_tests/amp-img.out
@@ -30,9 +30,12 @@ FAIL
 |  <body>
 |    <!-- Valid: amp-img > img -->
 |    <amp-img src="/img/canoe_900x600.jpg" alt="An image about canoeing" layout="responsive" width="900" height="600" i-amphtml-ssr>
-|      <img src="/img/canoe_900x600.jpg" alt="An image about canoeing" decoding="async">
->>     ^~~~~~~~~
-transformed_feature_tests/amp-img.html:32:4 The mandatory attribute 'class' is missing in tag 'img'.
+|      <img src="/img/canoe_900x600.jpg" alt="An image about canoeing" class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async">
+|    </amp-img>
+|
+|    <!-- Valid: amp-img > img, lazy -->
+|    <amp-img src="/img/canoe_900x600.jpg" alt="An image about canoeing" layout="responsive" width="900" height="600" i-amphtml-ssr>
+|      <img loading="lazy" src="/img/canoe_900x600.jpg" alt="An image about canoeing" class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async">
 |    </amp-img>
 |
 |    <!-- Valid: amp-img[layout=intrinsic] > img -->
@@ -40,25 +43,36 @@ transformed_feature_tests/amp-img.html:32:4 The mandatory attribute 'class' is m
 |      <i-amphtml-sizer class="i-amphtml-sizer">
 |        <img alt aria-hidden="true" class="i-amphtml-intrinsic-sizer" role="presentation" src="data:image/svg+xml;charset=utf-8,<svg height=&quot;600&quot; width=&quot;900&quot; xmlns=&quot;http://www.w3.org/2000/svg&quot; version=&quot;1.1&quot;/>">
 |      </i-amphtml-sizer>
-|      <img src="/img/canoe_900x600.jpg" alt="An image about canoeing" decoding="async">
->>     ^~~~~~~~~
-transformed_feature_tests/amp-img.html:40:4 The mandatory attribute 'class' is missing in tag 'img'.
+|      <img src="/img/canoe_900x600.jpg" alt="An image about canoeing" class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async">
 |    </amp-img>
 |
 |    <!-- Invalid: amp-img > img, missing i-amphtml-ssr attr -->
 |    <amp-img src="/img/canoe_900x600.jpg" alt="An image about canoeing" layout="responsive" width="900" height="600">
-|      <img src="/img/canoe_900x600.jpg" alt="An image about canoeing" decoding="async">
+|      <img src="/img/canoe_900x600.jpg" alt="An image about canoeing" class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async">
 >>     ^~~~~~~~~
-transformed_feature_tests/amp-img.html:45:4 The parent tag of tag 'img' is 'amp-img', but it can only be 'i-amphtml-sizer-intrinsic'.
+transformed_feature_tests/amp-img.html:50:4 The parent tag of tag 'img' is 'amp-img', but it can only be 'i-amphtml-sizer-intrinsic'.
 |    </amp-img>
 |
 |    <!-- Invalid: amp-img > img, missing decoding attr -->
 |    <amp-img src="/img/canoe_900x600.jpg" alt="An image about canoeing" layout="responsive" width="900" height="600" i-amphtml-ssr>
-|      <img src="/img/canoe_900x600.jpg" alt="An image about canoeing">
+|      <img src="/img/canoe_900x600.jpg" alt="An image about canoeing" class="i-amphtml-fill-content i-amphtml-replaced-content">
 >>     ^~~~~~~~~
-transformed_feature_tests/amp-img.html:50:4 The mandatory attribute 'class' is missing in tag 'img'.
+transformed_feature_tests/amp-img.html:55:4 The mandatory attribute 'decoding' is missing in tag 'img'.
+|    </amp-img>
+|
+|    <!-- Invalid: amp-img > img, missing class attr -->
+|    <amp-img src="/img/canoe_900x600.jpg" alt="An image about canoeing" layout="responsive" width="900" height="600" i-amphtml-ssr>
+|      <img src="/img/canoe_900x600.jpg" alt="An image about canoeing" decoding="async">
 >>     ^~~~~~~~~
-transformed_feature_tests/amp-img.html:50:4 The mandatory attribute 'decoding' is missing in tag 'img'.
+transformed_feature_tests/amp-img.html:60:4 The mandatory attribute 'class' is missing in tag 'img'.
+|    </amp-img>
+|
+|    <!-- Invalid: amp-img > img, blurry image placeholder -->
+|    <amp-img src="/img/canoe_900x600.jpg" alt="An image about canoeing" layout="responsive" width="900" height="600" i-amphtml-ssr>
+|      <i-amphtml-sizer style=display:block;padding-top:58.6667%;></i-amphtml-sizer>
+|      <img class=i-amphtml-blurry-placeholder placeholder src="data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http%3A//www.w3.org/2000/svg' xmlns%3Axlink='http%3A//www.w3.org/1999/xlink' viewBox='0 0 9 7'%3E%3Cfilter id='b' color-interpolation-filters='sRGB'%3E%3CfeGaussianBlur stdDeviation='.5'%3E%3C/feGaussianBlur%3E%3CfeComponentTransfer%3E%3CfeFuncA type='discrete' tableValues='1 1'%3E%3C/feFuncA%3E%3C/feComponentTransfer%3E%3C/filter%3E%3Cimage filter='url(%23b)' x='0' y='0' height='100%25' width='100%25' xlink%3Ahref='data%3Aimage/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAkAAAAHCAYAAADam2dgAAAA4klEQVR4ARXBO04CURSA4f/OnHkpA4TRWGhFMg3oFlyCjTuwYRsULMEtuAgTGzUhttpZkagREwhEhwvjvI7x+8z0aqAHXYj3wA/gfpZz82yZXCakPYf8u0LspmGbGTxXaUfK21fJ7atltGiRHvn4cYOYXIl8RRSkVj5+Sv5JXvD7qWQrg2QW3BqWlDzOtuycGhSe3nOSdkmaeIjdKXfzjMNQGA1asF9wMXQ4G1Z0ogqxipuZYNyVkH4YsVg7FGuh73qcnAvecczqwSBL49AJI6a1QSolLJTexnB6bRC/4WUe8AdyJ1gLZ2JPFwAAAABJRU5ErkJggg=='%3E%3C/image%3E%3C/svg%3E">
+>>     ^~~~~~~~~
+transformed_feature_tests/amp-img.html:66:4 The attribute 'class' in tag 'img' is set to the invalid value 'i-amphtml-blurry-placeholder'.
 |    </amp-img>
 |  </body>
 |  </html>

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -26,7 +26,7 @@ min_validator_revision_required: 475
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 1108
+spec_file_revision: 1109
 
 styles_spec_url: "https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages/"
 script_spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/validation-workflow/validation_errors/#custom-javascript-is-not-allowed"

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -26,7 +26,7 @@ min_validator_revision_required: 475
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 1105
+spec_file_revision: 1106
 
 styles_spec_url: "https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages/"
 script_spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/validation-workflow/validation_errors/#custom-javascript-is-not-allowed"
@@ -4064,7 +4064,7 @@ tags: {
 # 4.11.3 The template element
 # See extensions/amp-mustache/validator-amp-mustache.protoascii.
 
-# 11 Obsolute features
+# 11 Obsolete features
 # 11.2 Non-conforming features
 tags: {
   html_format: AMP

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -26,7 +26,7 @@ min_validator_revision_required: 475
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 1103
+spec_file_revision: 1105
 
 styles_spec_url: "https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages/"
 script_spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/validation-workflow/validation_errors/#custom-javascript-is-not-allowed"
@@ -4462,6 +4462,11 @@ tags: {
     name: "decoding"
     value: "async"
     mandatory: true
+  }
+  attrs: {
+    name: "loading"
+    value: "lazy"
+    value: "eager"
   }
 }
 

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -26,7 +26,7 @@ min_validator_revision_required: 475
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 1106
+spec_file_revision: 1107
 
 styles_spec_url: "https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages/"
 script_spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/validation-workflow/validation_errors/#custom-javascript-is-not-allowed"

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -26,7 +26,7 @@ min_validator_revision_required: 475
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 1107
+spec_file_revision: 1108
 
 styles_spec_url: "https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages/"
 script_spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/validation-workflow/validation_errors/#custom-javascript-is-not-allowed"


### PR DESCRIPTION
Changes:
 - cl/336924217 Revision bump for #30418
 - cl/336906679 Fix trailing tabs on validator-amp-onetap-google
 - cl/336771722 Revision bump for #30576
 - cl/336216200 Fix typo Obsolute -> Obsolete.
 - cl/336204310 Validator: allow loading=lazy on SSR'd amp-img > img
