### PR TITLE
♿ [a11y-fixit][amp-social-share] Add custom CSS when focussed for amp-social-share

### DIFF
--- a/extensions/amp-social-share/0.1/amp-social-share.css
+++ b/extensions/amp-social-share/0.1/amp-social-share.css
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-@import "../../../third_party/optimized-svg-icons/amp-social-share-svgs.css";
+@import '../../../third_party/optimized-svg-icons/amp-social-share-svgs.css';
 
 amp-social-share {
   background-repeat: no-repeat;
@@ -23,6 +23,11 @@ amp-social-share {
   text-decoration: none;
   cursor: pointer;
   position: relative;
+}
+
+amp-social-share:focus {
+  outline: #0389ff solid 2px;
+  outline-offset: 2px;
 }
 
 /**
@@ -78,7 +83,7 @@ amp-social-share {
 
 /* SMS Styling */
 .amp-social-share-sms {
-  background-color: #CA2B63;
+  background-color: #ca2b63;
 }
 
 /* "system" styling */

--- a/extensions/amp-social-share/0.1/test/test-amp-social-share.js
+++ b/extensions/amp-social-share/0.1/test/test-amp-social-share.js
@@ -17,6 +17,7 @@
 import '../amp-social-share';
 import {Keys} from '../../../../src/utils/key-codes';
 import {Services} from '../../../../src/services';
+import {tryFocus} from '../../../../src/dom';
 
 const STRINGS = {
   'text': 'Hello world',
@@ -380,6 +381,31 @@ describes.realWin(
     it('has tabindex set to 0 by default', () => {
       return getShare('twitter').then((el) => {
         expect(el.getAttribute('tabindex')).to.equal('0');
+      });
+    });
+
+    it('uses custom CSS when element is focused', () => {
+      const share = doc.createElement('amp-social-share');
+
+      share.setAttribute('type', 'twitter');
+      share.setAttribute('width', 60);
+      share.setAttribute('height', 44);
+
+      doc.body.appendChild(share);
+
+      return loaded(share).then((el) => {
+        expect(win.getComputedStyle(el)['outline']).to.equal(
+          'rgb(0, 0, 0) none 0px'
+        );
+        expect(win.getComputedStyle(el)['outline-offset']).to.equal('0px');
+
+        tryFocus(el);
+        expect(doc.activeElement).to.equal(el);
+
+        expect(win.getComputedStyle(share)['outline']).to.equal(
+          'rgb(3, 137, 255) solid 2px'
+        );
+        expect(win.getComputedStyle(share)['outline-offset']).to.equal('2px');
       });
     });
 

--- a/extensions/amp-social-share/0.1/test/test-amp-social-share.js
+++ b/extensions/amp-social-share/0.1/test/test-amp-social-share.js
@@ -402,10 +402,11 @@ describes.realWin(
         tryFocus(el);
         expect(doc.activeElement).to.equal(el);
 
-        expect(win.getComputedStyle(share)['outline']).to.equal(
+        // updated styles after focusing on element
+        expect(win.getComputedStyle(el)['outline']).to.equal(
           'rgb(3, 137, 255) solid 2px'
         );
-        expect(win.getComputedStyle(share)['outline-offset']).to.equal('2px');
+        expect(win.getComputedStyle(el)['outline-offset']).to.equal('2px');
       });
     });
 

--- a/extensions/amp-social-share/amp-social-share.md
+++ b/extensions/amp-social-share/amp-social-share.md
@@ -253,6 +253,10 @@ amp-social-share[type='twitter'] {
 
 When customizing the style of an `amp-social-share` icon please ensure that the customized icon meets the branding guidelines set out by the provider (e.g Twitter, Facebook, etc.)
 
+## Accessibility
+
+The `amp-social-share` element defaults to a blue outline as a visible focus indicator. It also defaults `tabindex=0` making it easy for a user to follow along as he or she tabs through multiple `amp-social-share` elements used together on a page.
+
 ## Validation
 
 See [amp-social-share rules](https://github.com/ampproject/amphtml/blob/master/extensions/amp-social-share/validator-amp-social-share.protoascii) in the AMP validator specification.

--- a/extensions/amp-social-share/amp-social-share.md
+++ b/extensions/amp-social-share/amp-social-share.md
@@ -257,6 +257,30 @@ When customizing the style of an `amp-social-share` icon please ensure that the 
 
 The `amp-social-share` element defaults to a blue outline as a visible focus indicator. It also defaults `tabindex=0` making it easy for a user to follow along as he or she tabs through multiple `amp-social-share` elements used together on a page.
 
+The default focus indicator is achieved with the following CSS rule-set.
+
+```css
+amp-social-share:focus {
+  outline: #0389ff solid 2px;
+  outline-offset: 2px;
+}
+```
+
+The default focus indicator can be overwritten by defining CSS styles for focus and including them within a `style` tag on an AMP HTML page. In the example below, the first CSS rule-set removes the focus indicator on all `amp-social-share` elements by setting the `outline` property to `none`. The second rule-set specifies a red outline (instead of the default blue) and also sets the `outline-offset` to be `3px` for all `amp-social-share` elements with the class `custom-focus`.
+
+```css
+amp-social-share:focus{
+  outline: none;
+}
+
+amp-social-share.custom-focus:focus {
+  outline: red solid 2px;
+  outline-offset: 3px;
+}
+```
+
+With these CSS rules, `amp-social-share` elements would not show the visible focus indicator unless they included the class `custom-focus` in which case they would have the red outlined indicator.
+
 ## Validation
 
 See [amp-social-share rules](https://github.com/ampproject/amphtml/blob/master/extensions/amp-social-share/validator-amp-social-share.protoascii) in the AMP validator specification.


### PR DESCRIPTION
a11y fixit week issue: https://github.com/ampproject/amphtml/issues/29561

Add a custom CSS (blue outline)(see Twitter in screenshot below) when an `amp-social-share` element is focused.  Chose not to use polyfill required CSS selector mentioned in issue as feature works great for all users not just keyboard users.  Choice of color is based on other focus items used in amp, see `main.css` (see this example: https://github.com/ampproject/amphtml/blob/master/build-system/server/app-index/main.css#L208)

![image](https://user-images.githubusercontent.com/25626770/96649162-95d9bc80-12fe-11eb-9ca7-cbeaa0f174be.png)
