### PR TITLE
🧪 Add story ad rendering to inabox.

### DIFF
--- a/build-system/compile/bundles.config.js
+++ b/build-system/compile/bundles.config.js
@@ -937,6 +937,8 @@ exports.extensionBundles = [
       cssBinaries: [
         'amp-story-auto-ads-ad-badge',
         'amp-story-auto-ads-attribution',
+        'amp-story-auto-ads-inabox',
+        'amp-story-auto-ads-shared',
       ],
     },
     type: TYPES.MISC,

--- a/build-system/global-configs/experiments-config.json
+++ b/build-system/global-configs/experiments-config.json
@@ -6,6 +6,12 @@
     "expiration_date_utc": "2020-12-30",
     "define_experiment_constant": "NO_SIGNING_RTV"
   },
-  "experimentB": {},
+  "experimentB": {
+    "name": "Inabox Story Ads",
+    "environment": "INABOX",
+    "issue": "https://github.com/ampproject/amphtml/issues/27189",
+    "expiration_date_utc": "2020-12-30",
+    "define_experiment_constant": "STORY_AD_INABOX"
+  },
   "experimentC": {}
 }

--- a/build-system/global-configs/experiments-config.json
+++ b/build-system/global-configs/experiments-config.json
@@ -9,7 +9,7 @@
   "experimentB": {
     "name": "Inabox Story Ads",
     "environment": "INABOX",
-    "issue": "https://github.com/ampproject/amphtml/issues/27189",
+    "issue": "https://github.com/ampproject/amphtml/issues/30781",
     "expiration_date_utc": "2020-12-30",
     "define_experiment_constant": "STORY_AD_INABOX"
   },

--- a/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads-inabox.css
+++ b/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads-inabox.css
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ amp-story-cta-layer {
+  display: block !important;
+  position: absolute !important;
+  top: 80% !important;
+  right: 0 !important;
+  bottom: 0 !important;
+  left: 0 !important;
+  margin: 0 !important;
+  z-index: 3 !important;
+}

--- a/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads-shared.css
+++ b/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads-shared.css
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* CSS shared between amp-story-auto-ads and inabox story ad rendering. */
+
+.i-amphtml-cta-container {
+  display: flex !important;
+  flex-direction: column !important;
+  align-items: center !important;
+}
+
+/* If you are changing anything here that affects font, please update measurer
+ in story-ad-button-text-fitter.js */
+ .i-amphtml-story-ad-link {
+  background-color: #FFFFFF !important;
+  border-radius: 20px !important;
+  box-sizing: border-box !important;
+  bottom: 32px !important;
+  box-shadow: 0px 2px 12px rgba(0, 0, 0, 0.16) !important;
+  color: #4285F4 !important;
+  font-family: 'Roboto', sans-serif !important;
+  font-weight: bold !important;
+  height: 36px !important;
+  letter-spacing: 0.2px !important;
+  line-height: 36px !important;
+  overflow: hidden !important;
+  /* no important on opacity b/c ff does not allow keyframes to override. */
+  opacity: 0;
+  padding: 0 10px !important;
+  position: absolute !important;
+  text-align: center !important;
+  text-decoration: none !important;
+  min-width: 120px !important;
+  max-width: calc(100vw - 64px);
+}
+
+amp-story-page[active] .i-amphtml-story-ad-link,
+.i-amphtml-inabox .i-amphtml-story-ad-link {
+  animation-delay: 100ms !important;
+  animation-duration: 300ms !important;
+  animation-timing-function: cubic-bezier(0.4, 0.0, 0.2, 1) !important;
+  animation-fill-mode: forwards !important;
+  animation-name: ad-cta !important;
+}
+
+@keyframes ad-cta {
+  from {
+    opacity: 0;
+    transform: scale(0);
+  }
+
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}

--- a/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.css
+++ b/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.css
@@ -32,55 +32,14 @@
   top: 67.5% !important;
 }
 
-/* If you are changing anything here that affects font, please update measurer
- in story-ad-button-text-fitter.js */
-.i-amphtml-story-ad-link {
-  background-color: #FFFFFF !important;
-  border-radius: 20px !important;
-  box-sizing: border-box !important;
-  bottom: 32px !important;
-  box-shadow: 0px 2px 12px rgba(0, 0, 0, 0.16) !important;
-  color: #4285F4 !important;
-  font-family: 'Roboto', sans-serif !important;
-  font-weight: bold !important;
-  height: 36px !important;
-  letter-spacing: 0.2px !important;
-  line-height: 36px !important;
-  overflow: hidden !important;
-  /* no important on opacity b/c ff does not allow keyframes to override. */
-  opacity: 0;
-  padding: 0 10px !important;
-  position: absolute !important;
-  text-align: center !important;
-  text-decoration: none !important;
-  min-width: 120px !important;
-  max-width: calc(100vw - 64px);
-}
-
-amp-story-page[active] .i-amphtml-story-ad-link {
-  animation-delay: 100ms !important;
-  animation-duration: 300ms !important;
-  animation-timing-function: cubic-bezier(0.4, 0.0, 0.2, 1) !important;
-  animation-fill-mode: forwards !important;
-  animation-name: ad-cta !important;
-}
-
-@keyframes ad-cta {
-  from {
-    opacity: 0;
-    transform: scale(0);
-  }
-
-  to {
-    opacity: 1;
-    transform: scale(1);
-  }
-}
-
 .i-amphtml-glass-pane {
   height: 100% !important;
   width: 100% !important;
   z-index: 1 !important;
+}
+
+amp-story-page[xdomain-ad] .i-amphtml-glass-pane {
+  height: 80% !important;
 }
 
 /* TODO(ccordry): refactor centering logic in amp-ad.css and remove this hack.  */

--- a/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js
+++ b/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js
@@ -38,6 +38,7 @@ import {dev, devAssert, userAssert} from '../../../src/log';
 import {dict, hasOwn} from '../../../src/utils/object';
 import {getServicePromiseForDoc} from '../../../src/service';
 import {lastItem} from '../../../src/utils/array';
+import {CSS as sharedCSS} from '../../../build/amp-story-auto-ads-shared-0.1.css';
 
 /** @const {number} */
 const FIRST_AD_MIN = 7;
@@ -701,6 +702,6 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
 }
 
 AMP.extension('amp-story-auto-ads', '0.1', (AMP) => {
-  AMP.registerElement('amp-story-auto-ads', AmpStoryAutoAds, CSS);
+  AMP.registerElement('amp-story-auto-ads', AmpStoryAutoAds, CSS + sharedCSS);
   AMP.registerServiceForDoc(STORY_AD_ANALYTICS, StoryAdAnalytics);
 });

--- a/extensions/amp-story-auto-ads/0.1/story-ad-page.js
+++ b/extensions/amp-story-auto-ads/0.1/story-ad-page.js
@@ -231,6 +231,7 @@ export class StoryAdPage {
    */
   maybeCreateCta() {
     return Promise.resolve().then(() => {
+      // Inabox story ads control their own CTA creation.
       if (this.is3pAdFrame_) {
         return true;
       }
@@ -325,8 +326,9 @@ export class StoryAdPage {
   }
 
   /**
-   * Sets listeners to receive signal that ad is ready to be shown
+   * Creates listeners to receive signal that ad is ready to be shown
    * for both FIE & inabox case.
+   * @private
    */
   listenForAdLoadSignals_() {
     // Friendly frame INI_LOAD.

--- a/extensions/amp-story-auto-ads/0.1/story-ad-page.js
+++ b/extensions/amp-story-auto-ads/0.1/story-ad-page.js
@@ -42,9 +42,9 @@ import {
 } from '../../../src/dom';
 import {dev, devAssert, userAssert} from '../../../src/log';
 import {dict, map} from '../../../src/utils/object';
+import {getData, listen} from '../../../src/event-helper';
 import {getFrameDoc} from './utils';
 import {getServicePromiseForDoc} from '../../../src/service';
-import {listen} from '../../../src/event-helper';
 import {parseJson} from '../../../src/json';
 import {setStyle} from '../../../src/style';
 
@@ -106,7 +106,7 @@ export class StoryAdPage {
     /** @private {?Element} */
     this.adElement_ = null;
 
-    /** @private {?Element} */
+    /** @private {?HTMLIFrameElement} */
     this.adFrame_ = null;
 
     /** @private {?Element} */
@@ -340,7 +340,7 @@ export class StoryAdPage {
 
     // Inabox custom event.
     const removeListener = listen(this.win_, 'message', (e) => {
-      if (e.data !== 'amp-story-ad-load') {
+      if (getData(e) !== 'amp-story-ad-load') {
         return;
       }
       if (this.getAdFrame_() && e.source === this.adFrame_.contentWindow) {
@@ -360,7 +360,10 @@ export class StoryAdPage {
     if (this.adFrame_) {
       return this.adFrame_;
     }
-    return (this.adFrame_ = elementByTag(this.pageElement_, 'iframe'));
+    return (this.adFrame_ = /** @type {?HTMLIFrameElement} */ (elementByTag(
+      devAssert(this.pageElement_),
+      'iframe'
+    )));
   }
 
   /**

--- a/extensions/amp-story-auto-ads/0.1/story-ad-ui.js
+++ b/extensions/amp-story-auto-ads/0.1/story-ad-ui.js
@@ -74,7 +74,7 @@ export function getStoryAdMetaTags(doc) {
  * Creates object containing information extracted from the creative
  * that is needed to render story ad ui e.g. cta, attribution, etc.
  * @param {!Document} doc
- * @return {Object}
+ * @return {StoryAdUIMetadata}
  */
 export function getStoryAdMetadataFromDoc(doc) {
   const storyMetaTags = getStoryAdMetaTags(doc);

--- a/src/inabox/amp-inabox.js
+++ b/src/inabox/amp-inabox.js
@@ -44,6 +44,7 @@ import {
   makeBodyVisibleRecovery,
 } from '../style-installer';
 import {internalRuntimeVersion} from '../internal-version';
+import {maybeRenderInaboxAsStoryAd} from './inabox-story-ad';
 import {maybeValidate} from '../validator-integration';
 import {stubElementsForDoc} from '../service/custom-element-registry';
 
@@ -111,6 +112,9 @@ startupChunk(self.document, function initial() {
         self.document,
         function final() {
           Navigation.installAnchorClickInterceptor(ampdoc, self);
+          if (STORY_AD_INABOX) {
+            maybeRenderInaboxAsStoryAd(ampdoc);
+          }
           maybeValidate(self);
           makeBodyVisible(self.document);
         },

--- a/src/inabox/amp-inabox.js
+++ b/src/inabox/amp-inabox.js
@@ -112,6 +112,7 @@ startupChunk(self.document, function initial() {
         self.document,
         function final() {
           Navigation.installAnchorClickInterceptor(ampdoc, self);
+          // eslint-disable-next-line no-undef
           if (STORY_AD_INABOX) {
             maybeRenderInaboxAsStoryAd(ampdoc);
           }

--- a/src/inabox/inabox-story-ad.js
+++ b/src/inabox/inabox-story-ad.js
@@ -1,0 +1,51 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {ButtonTextFitter} from '../../extensions/amp-story-auto-ads/0.1/story-ad-button-text-fitter';
+import {
+  createCta,
+  getStoryAdMetadataFromDoc,
+  maybeCreateAttribution,
+  validateCtaMetadata,
+} from '../../extensions/amp-story-auto-ads/0.1/story-ad-ui';
+import {createElementWithAttributes} from '../dom';
+import {CSS as inaboxCSS} from '../../build/amp-story-auto-ads-inabox-0.1.css';
+import {installStylesForDoc} from '../style-installer';
+import {CSS as sharedCSS} from '../../build/amp-story-auto-ads-shared-0.1.css';
+
+/**
+ * If story ad metatags exist, render this creative as a story ad.
+ * @param {!../service/ampdoc-impl.AmpDoc} ampdoc
+ */
+export function maybeRenderInaboxAsStoryAd(ampdoc) {
+  const {win} = ampdoc;
+  const doc = win.document;
+  const storyAdMetadata = getStoryAdMetadataFromDoc(doc);
+  if (!validateCtaMetadata(storyAdMetadata)) {
+    return;
+  }
+  installStylesForDoc(ampdoc, sharedCSS + inaboxCSS);
+  maybeCreateAttribution(win, storyAdMetadata, doc.body);
+
+  const buttonFitter = new ButtonTextFitter(ampdoc);
+  const ctaContainer = createElementWithAttributes(doc, 'div');
+  createCta(doc, buttonFitter, ctaContainer, storyAdMetadata);
+  doc.body.appendChild(ctaContainer);
+
+  if (win.parent) {
+    win.parent./*OK*/ postMessage('amp-story-ad-load', '*');
+  }
+}

--- a/src/inabox/inabox-story-ad.js
+++ b/src/inabox/inabox-story-ad.js
@@ -21,7 +21,6 @@ import {
   maybeCreateAttribution,
   validateCtaMetadata,
 } from '../../extensions/amp-story-auto-ads/0.1/story-ad-ui';
-import {createElementWithAttributes} from '../dom';
 import {CSS as inaboxCSS} from '../../build/amp-story-auto-ads-inabox-0.1.css';
 import {installStylesForDoc} from '../style-installer';
 import {CSS as sharedCSS} from '../../build/amp-story-auto-ads-shared-0.1.css';
@@ -37,11 +36,11 @@ export function maybeRenderInaboxAsStoryAd(ampdoc) {
   if (!validateCtaMetadata(storyAdMetadata)) {
     return;
   }
-  installStylesForDoc(ampdoc, sharedCSS + inaboxCSS);
+  installStylesForDoc(ampdoc, sharedCSS + inaboxCSS, () => {});
   maybeCreateAttribution(win, storyAdMetadata, doc.body);
 
   const buttonFitter = new ButtonTextFitter(ampdoc);
-  const ctaContainer = createElementWithAttributes(doc, 'div');
+  const ctaContainer = doc.createElement('div');
   createCta(doc, buttonFitter, ctaContainer, storyAdMetadata);
   doc.body.appendChild(ctaContainer);
 


### PR DESCRIPTION
Introduces new logic to inabox that detects for story ad metadata, and if it exists, renders as a story ad. 

Part of #27851