### PR TITLE
Carousel: imperative API in storybooks

### DIFF
--- a/extensions/amp-base-carousel/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-base-carousel/1.0/storybook/Basic.amp.js
@@ -38,34 +38,49 @@ export const Default = () => {
   const controls = select('show controls', ['auto', 'always', 'never']);
   const slideCount = number('slide count', 5, {min: 0, max: 99});
   const colorIncrement = Math.floor(255 / (slideCount + 1));
+
   return (
-    <amp-base-carousel
-      advance-count={advanceCount}
-      controls={controls}
-      outset-arrows={outsetArrows}
-      width="880"
-      height="225"
-      snap={String(snap)}
-      loop={loop}
-      layout="responsive"
-      visible-count={visibleCount}
-    >
-      {Array.from({length: slideCount}, (x, i) => {
-        const v = colorIncrement * (i + 1);
-        return (
-          <amp-layout width="440" height="225" layout="responsive">
-            <svg viewBox="0 0 440 225">
-              <rect
-                style={{fill: `rgb(${v}, 100, 100)`}}
-                width="440"
-                height="225"
-              />
-              Sorry, your browser does not support inline SVG.
-            </svg>
-          </amp-layout>
-        );
-      })}
-    </amp-base-carousel>
+    <main>
+      <amp-base-carousel
+        id="carousel"
+        advance-count={advanceCount}
+        controls={controls}
+        outset-arrows={outsetArrows}
+        width="880"
+        height="225"
+        snap={String(snap)}
+        loop={loop}
+        layout="responsive"
+        visible-count={visibleCount}
+      >
+        {Array.from({length: slideCount}, (x, i) => {
+          const v = colorIncrement * (i + 1);
+          return (
+            <amp-layout width="440" height="225" layout="responsive">
+              <div
+                style={{
+                  backgroundColor: `rgb(${v}, 100, 100)`,
+                  width: '100%',
+                  height: '100%',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  fontSize: '48pt',
+                }}
+              >
+                {i}
+              </div>
+            </amp-layout>
+          );
+        })}
+      </amp-base-carousel>
+
+      <div class="buttons" style={{marginTop: 8}}>
+        <button on="tap:carousel.goToSlide(index=3)">goToSlide(index=3)</button>
+        <button on="tap:carousel.next">Next</button>
+        <button on="tap:carousel.prev">Prev</button>
+      </div>
+    </main>
   );
 };
 

--- a/extensions/amp-base-carousel/1.0/storybook/Basic.js
+++ b/extensions/amp-base-carousel/1.0/storybook/Basic.js
@@ -27,6 +27,26 @@ export default {
   decorators: [withA11y, withKnobs],
 };
 
+/**
+ * @param {!Object} props
+ * @return {*}
+ */
+function CarouselWithActions(props) {
+  // TODO(#30447): replace imperative calls with "button" knobs when the
+  // Storybook 6.1 is released.
+  const ref = Preact.useRef();
+  return (
+    <section>
+      <BaseCarousel ref={ref} {...props} />
+      <div style={{marginTop: 8}}>
+        <button onClick={() => ref.current.goToSlide(3)}>goToSlide(3)</button>
+        <button onClick={() => ref.current.next()}>next</button>
+        <button onClick={() => ref.current.prev()}>prev</button>
+      </div>
+    </section>
+  );
+}
+
 export const _default = () => {
   const width = number('width', 440);
   const height = number('height', 225);
@@ -39,7 +59,7 @@ export const _default = () => {
   const colorIncrement = Math.floor(255 / (slideCount + 1));
   const controls = select('show controls', CONTROLS);
   return (
-    <BaseCarousel
+    <CarouselWithActions
       advanceCount={advanceCount}
       controls={controls}
       loop={loop}
@@ -65,7 +85,7 @@ export const _default = () => {
           </div>
         );
       })}
-    </BaseCarousel>
+    </CarouselWithActions>
   );
 };
 


### PR DESCRIPTION
Unfortunately, we're still blocked from using `button` knobs until we Storybook 6.1 is released.