### PR TITLE
Remove viewportCallback from the rest of non-ads related components.

### DIFF
--- a/extensions/amp-3d-gltf/0.1/amp-3d-gltf.js
+++ b/extensions/amp-3d-gltf/0.1/amp-3d-gltf.js
@@ -22,6 +22,7 @@ import {dict} from '../../../src/utils/object';
 import {getIframe, preloadBootstrap} from '../../../src/3p-frame';
 import {isLayoutSizeDefined} from '../../../src/layout';
 import {listenFor, postMessage} from '../../../src/iframe-helper';
+import {observe, unobserve} from '../../../src/viewport-observer';
 import {removeElement} from '../../../src/dom';
 
 const TAG = 'amp-3d-gltf';
@@ -80,6 +81,7 @@ export class Amp3dGltf extends AMP.BaseElement {
 
   /** @override */
   unlayoutCallback() {
+    unobserve(this.element);
     if (this.iframe_) {
       removeElement(this.iframe_);
       this.iframe_ = null;
@@ -145,6 +147,7 @@ export class Amp3dGltf extends AMP.BaseElement {
 
   /** @override */
   layoutCallback() {
+    observe(this.element, (inViewport) => this.viewportCallback_(inViewport));
     if (!isWebGLSupported()) {
       this.toggleFallback(true);
       return Promise.resolve();
@@ -215,10 +218,10 @@ export class Amp3dGltf extends AMP.BaseElement {
 
   /**
    * @param {boolean} inViewport
-   * @override
+   * @private
    */
-  viewportCallback(inViewport) {
-    return this.sendCommandWhenReady_('toggleAmpViewport', inViewport);
+  viewportCallback_(inViewport) {
+    this.sendCommandWhenReady_('toggleAmpViewport', inViewport);
   }
 
   /** @override */

--- a/extensions/amp-3d-gltf/0.1/amp-3d-gltf.js
+++ b/extensions/amp-3d-gltf/0.1/amp-3d-gltf.js
@@ -85,6 +85,7 @@ export class Amp3dGltf extends AMP.BaseElement {
   /** @override */
   unlayoutCallback() {
     unobserveWithSharedInOb(this.element);
+    this.viewportCallback_(false);
     if (this.iframe_) {
       removeElement(this.iframe_);
       this.iframe_ = null;

--- a/extensions/amp-3d-gltf/0.1/amp-3d-gltf.js
+++ b/extensions/amp-3d-gltf/0.1/amp-3d-gltf.js
@@ -22,7 +22,10 @@ import {dict} from '../../../src/utils/object';
 import {getIframe, preloadBootstrap} from '../../../src/3p-frame';
 import {isLayoutSizeDefined} from '../../../src/layout';
 import {listenFor, postMessage} from '../../../src/iframe-helper';
-import {observe, unobserve} from '../../../src/viewport-observer';
+import {
+  observeWithSharedInOb,
+  unobserveWithSharedInOb,
+} from '../../../src/viewport-observer';
 import {removeElement} from '../../../src/dom';
 
 const TAG = 'amp-3d-gltf';
@@ -81,7 +84,7 @@ export class Amp3dGltf extends AMP.BaseElement {
 
   /** @override */
   unlayoutCallback() {
-    unobserve(this.element);
+    unobserveWithSharedInOb(this.element);
     if (this.iframe_) {
       removeElement(this.iframe_);
       this.iframe_ = null;
@@ -147,7 +150,9 @@ export class Amp3dGltf extends AMP.BaseElement {
 
   /** @override */
   layoutCallback() {
-    observe(this.element, (inViewport) => this.viewportCallback_(inViewport));
+    observeWithSharedInOb(this.element, (inViewport) =>
+      this.viewportCallback_(inViewport)
+    );
     if (!isWebGLSupported()) {
       this.toggleFallback(true);
       return Promise.resolve();

--- a/extensions/amp-anim/0.1/amp-anim.js
+++ b/extensions/amp-anim/0.1/amp-anim.js
@@ -109,6 +109,7 @@ export class AmpAnim extends AMP.BaseElement {
   /** @override */
   unlayoutCallback() {
     unobserveWithSharedInOb(this.element);
+    this.viewportCallback_(false);
     // Release memory held by the image - animations are typically large.
     this.img_.src = SRC_PLACEHOLDER;
     this.img_.srcset = SRC_PLACEHOLDER;

--- a/extensions/amp-anim/0.1/amp-anim.js
+++ b/extensions/amp-anim/0.1/amp-anim.js
@@ -18,7 +18,10 @@ import * as st from '../../../src/style';
 import {dev} from '../../../src/log';
 import {guaranteeSrcForSrcsetUnsupportedBrowsers} from '../../../src/utils/img';
 import {isLayoutSizeDefined} from '../../../src/layout';
-import {observe, unobserve} from '../../../src/viewport-observer';
+import {
+  observeWithSharedInOb,
+  unobserveWithSharedInOb,
+} from '../../../src/viewport-observer';
 import {propagateObjectFitStyles} from '../../../src/style';
 
 const TAG = 'amp-anim';
@@ -92,7 +95,9 @@ export class AmpAnim extends AMP.BaseElement {
     );
     guaranteeSrcForSrcsetUnsupportedBrowsers(img);
     return this.loadPromise(img).then(() => {
-      observe(this.element, (inViewport) => this.viewportCallback_(inViewport));
+      observeWithSharedInOb(this.element, (inViewport) =>
+        this.viewportCallback_(inViewport)
+      );
     });
   }
 
@@ -103,7 +108,7 @@ export class AmpAnim extends AMP.BaseElement {
 
   /** @override */
   unlayoutCallback() {
-    unobserve(this.element);
+    unobserveWithSharedInOb(this.element);
     // Release memory held by the image - animations are typically large.
     this.img_.src = SRC_PLACEHOLDER;
     this.img_.srcset = SRC_PLACEHOLDER;

--- a/extensions/amp-anim/0.1/amp-anim.js
+++ b/extensions/amp-anim/0.1/amp-anim.js
@@ -18,6 +18,7 @@ import * as st from '../../../src/style';
 import {dev} from '../../../src/log';
 import {guaranteeSrcForSrcsetUnsupportedBrowsers} from '../../../src/utils/img';
 import {isLayoutSizeDefined} from '../../../src/layout';
+import {observe, unobserve} from '../../../src/viewport-observer';
 import {propagateObjectFitStyles} from '../../../src/style';
 
 const TAG = 'amp-anim';
@@ -40,9 +41,6 @@ export class AmpAnim extends AMP.BaseElement {
 
     /** @private {?Element} */
     this.img_ = null;
-
-    /** @private {boolean} */
-    this.hasLoaded_ = false;
   }
 
   /** @override */
@@ -93,37 +91,30 @@ export class AmpAnim extends AMP.BaseElement {
       /* opt_removeMissingAttrs */ true
     );
     guaranteeSrcForSrcsetUnsupportedBrowsers(img);
-    return this.loadPromise(img);
+    return this.loadPromise(img).then(() => {
+      observe(this.element, (inViewport) => this.viewportCallback_(inViewport));
+    });
   }
 
   /** @override */
   firstLayoutCompleted() {
     // Keep the placeholder: amp-anim is using it to start/stop playing.
-    this.hasLoaded_ = true;
-    this.updateInViewport_();
-  }
-
-  /** @override */
-  viewportCallback(unusedInViewport) {
-    if (!this.hasLoaded_) {
-      // do nothing if element has not laid out.
-      return;
-    }
-    this.updateInViewport_();
   }
 
   /** @override */
   unlayoutCallback() {
+    unobserve(this.element);
     // Release memory held by the image - animations are typically large.
     this.img_.src = SRC_PLACEHOLDER;
     this.img_.srcset = SRC_PLACEHOLDER;
-    this.hasLoaded_ = false;
     return true;
   }
 
-  /** @private */
-  updateInViewport_() {
-    const inViewport = this.isInViewport();
+  /**
+   * @param {boolean} inViewport
+   * @private
+   */
+  viewportCallback_(inViewport) {
     this.togglePlaceholder(!inViewport);
     st.toggle(dev().assertElement(this.img_), inViewport);
   }

--- a/extensions/amp-apester-media/0.1/amp-apester-media.js
+++ b/extensions/amp-apester-media/0.1/amp-apester-media.js
@@ -28,7 +28,10 @@ import {
 } from './utils';
 import {getLengthNumeral, isLayoutSizeDefined} from '../../../src/layout';
 import {handleCompanionAds} from './monetization';
-import {observe, unobserve} from '../../../src/viewport-observer';
+import {
+  observeWithSharedInOb,
+  unobserveWithSharedInOb,
+} from '../../../src/viewport-observer';
 import {removeElement} from '../../../src/dom';
 import {setStyles} from '../../../src/style';
 
@@ -337,8 +340,10 @@ class AmpApesterMedia extends AMP.BaseElement {
               });
             });
           })
-          .then(() => { 
-            observe(this.element, (inViewport) => this.viewportCallback_(inViewport)); 
+          .then(() => {
+            observeWithSharedInOb(this.element, (inViewport) =>
+              this.viewportCallback_(inViewport)
+            );
           })
           .catch((error) => {
             dev().error(TAG, 'Display', error);
@@ -383,7 +388,7 @@ class AmpApesterMedia extends AMP.BaseElement {
 
   /** @override */
   unlayoutCallback() {
-    unobserve(this.element);
+    unobserveWithSharedInOb(this.element);
     if (this.iframe_) {
       this.intersectionObserverHostApi_.destroy();
       this.intersectionObserverHostApi_ = null;

--- a/extensions/amp-carousel/0.1/base-carousel.js
+++ b/extensions/amp-carousel/0.1/base-carousel.js
@@ -247,6 +247,7 @@ export class BaseCarousel extends AMP.BaseElement {
     observeWithSharedInOb(this.element, (inViewport) =>
       this.viewportCallback_(inViewport)
     );
+    return Promise.resolve();
   }
   /** @override */
   unlayoutCallback() {

--- a/extensions/amp-carousel/0.1/base-carousel.js
+++ b/extensions/amp-carousel/0.1/base-carousel.js
@@ -16,8 +16,8 @@
 import {Keys} from '../../../src/utils/key-codes';
 import {Services} from '../../../src/services';
 import {isAmp4Email} from '../../../src/format';
+import {observe, unobserve} from '../../../src/viewport-observer';
 import {toggleAttribute} from '../../../src/dom';
-import {observe, unobserve} from '../../../src/viewport-observer'; 
 
 const _CONTROL_HIDE_ATTRIBUTE = 'i-amphtml-carousel-hide-buttons';
 const _HAS_CONTROL_CLASS = 'i-amphtml-carousel-has-controls';
@@ -67,9 +67,9 @@ export class BaseCarousel extends AMP.BaseElement {
     this.setControlsState();
   }
 
-  /** 
+  /**
    * @param {boolean} inViewport
-   * @private 
+   * @private
    */
   viewportCallback_(inViewport) {
     if (inViewport) {
@@ -189,7 +189,7 @@ export class BaseCarousel extends AMP.BaseElement {
    * Shows the controls and then fades them away.
    */
   hintControls() {
-    if (this.showControls_ || !this.isInViewport()) {
+    if (this.showControls_) {
       return;
     }
     this.getVsync().mutate(() => {
@@ -241,11 +241,11 @@ export class BaseCarousel extends AMP.BaseElement {
 
   /** @override */
   layoutCallback() {
-    observe(this.element, (inViewport) => this.viewportCallback_(inViewport)) 
+    observe(this.element, (inViewport) => this.viewportCallback_(inViewport));
   }
   /** @override */
   unlayoutCallback() {
-    unobserve(this.element); 
+    unobserve(this.element);
     return true;
   }
 

--- a/extensions/amp-carousel/0.1/base-carousel.js
+++ b/extensions/amp-carousel/0.1/base-carousel.js
@@ -72,9 +72,9 @@ export class BaseCarousel extends AMP.BaseElement {
 
   /**
    * @param {boolean} inViewport
-   * @private
+   * @protected
    */
-  viewportCallback_(inViewport) {
+  viewportCallbackTemp(inViewport) {
     if (inViewport) {
       this.hintControls();
     }
@@ -245,7 +245,7 @@ export class BaseCarousel extends AMP.BaseElement {
   /** @override */
   layoutCallback() {
     observeWithSharedInOb(this.element, (inViewport) =>
-      this.viewportCallback_(inViewport)
+      this.viewportCallbackTemp(inViewport)
     );
     return Promise.resolve();
   }

--- a/extensions/amp-carousel/0.1/base-carousel.js
+++ b/extensions/amp-carousel/0.1/base-carousel.js
@@ -16,7 +16,10 @@
 import {Keys} from '../../../src/utils/key-codes';
 import {Services} from '../../../src/services';
 import {isAmp4Email} from '../../../src/format';
-import {observe, unobserve} from '../../../src/viewport-observer';
+import {
+  observeWithSharedInOb,
+  unobserveWithSharedInOb,
+} from '../../../src/viewport-observer';
 import {toggleAttribute} from '../../../src/dom';
 
 const _CONTROL_HIDE_ATTRIBUTE = 'i-amphtml-carousel-hide-buttons';
@@ -241,11 +244,13 @@ export class BaseCarousel extends AMP.BaseElement {
 
   /** @override */
   layoutCallback() {
-    observe(this.element, (inViewport) => this.viewportCallback_(inViewport));
+    observeWithSharedInOb(this.element, (inViewport) =>
+      this.viewportCallback_(inViewport)
+    );
   }
   /** @override */
   unlayoutCallback() {
-    unobserve(this.element);
+    unobserveWithSharedInOb(this.element);
     return true;
   }
 

--- a/extensions/amp-carousel/0.1/base-carousel.js
+++ b/extensions/amp-carousel/0.1/base-carousel.js
@@ -17,6 +17,7 @@ import {Keys} from '../../../src/utils/key-codes';
 import {Services} from '../../../src/services';
 import {isAmp4Email} from '../../../src/format';
 import {toggleAttribute} from '../../../src/dom';
+import {observe, unobserve} from '../../../src/viewport-observer'; 
 
 const _CONTROL_HIDE_ATTRIBUTE = 'i-amphtml-carousel-hide-buttons';
 const _HAS_CONTROL_CLASS = 'i-amphtml-carousel-has-controls';
@@ -66,8 +67,11 @@ export class BaseCarousel extends AMP.BaseElement {
     this.setControlsState();
   }
 
-  /** @override */
-  viewportCallback(inViewport) {
+  /** 
+   * @param {boolean} inViewport
+   * @private 
+   */
+  viewportCallback_(inViewport) {
     if (inViewport) {
       this.hintControls();
     }
@@ -236,7 +240,12 @@ export class BaseCarousel extends AMP.BaseElement {
   }
 
   /** @override */
+  layoutCallback() {
+    observe(this.element, (inViewport) => this.viewportCallback_(inViewport)) 
+  }
+  /** @override */
   unlayoutCallback() {
+    unobserve(this.element); 
     return true;
   }
 

--- a/extensions/amp-carousel/0.1/base-carousel.js
+++ b/extensions/amp-carousel/0.1/base-carousel.js
@@ -70,7 +70,7 @@ export class BaseCarousel extends AMP.BaseElement {
     this.setControlsState();
   }
 
-  // TODO(samouri): rename to viewportCallback once 
+  // TODO(samouri): rename to viewportCallback once
   // BaseElement.viewportCallback is deleted
 
   /**

--- a/extensions/amp-carousel/0.1/base-carousel.js
+++ b/extensions/amp-carousel/0.1/base-carousel.js
@@ -70,6 +70,9 @@ export class BaseCarousel extends AMP.BaseElement {
     this.setControlsState();
   }
 
+  // TODO(samouri): rename to viewportCallback once 
+  // BaseElement.viewportCallback is deleted
+
   /**
    * @param {boolean} inViewport
    * @protected

--- a/extensions/amp-carousel/0.1/base-slides.js
+++ b/extensions/amp-carousel/0.1/base-slides.js
@@ -95,8 +95,8 @@ export class BaseSlides extends BaseCarousel {
   }
 
   /** @override */
-  viewportCallback_(inViewport) {
-    super.viewportCallback_(inViewport);
+  viewportCallbackTemp(inViewport) {
+    super.viewportCallbackTemp(inViewport);
     if (inViewport) {
       this.autoplay_();
     } else {

--- a/extensions/amp-carousel/0.1/base-slides.js
+++ b/extensions/amp-carousel/0.1/base-slides.js
@@ -95,8 +95,8 @@ export class BaseSlides extends BaseCarousel {
   }
 
   /** @override */
-  viewportCallback(inViewport) {
-    super.viewportCallback(inViewport);
+  viewportCallback_(inViewport) {
+    super.viewportCallback_(inViewport);
     if (inViewport) {
       this.autoplay_();
     } else {

--- a/extensions/amp-carousel/0.1/scrollable-carousel.js
+++ b/extensions/amp-carousel/0.1/scrollable-carousel.js
@@ -118,8 +118,8 @@ export class AmpScrollableCarousel extends BaseCarousel {
   }
 
   /** @override */
-  viewportCallback_(inViewport) {
-    super.viewportCallback_(inViewport);
+  viewportCallbackTemp(inViewport) {
+    super.viewportCallbackTemp(inViewport);
     this.updateInViewport_(this.pos_, this.pos_);
   }
 

--- a/extensions/amp-carousel/0.1/scrollable-carousel.js
+++ b/extensions/amp-carousel/0.1/scrollable-carousel.js
@@ -23,6 +23,10 @@ import {dev} from '../../../src/log';
 import {isLayoutSizeFixed} from '../../../src/layout';
 import {listen} from '../../../src/event-helper';
 import {numeric} from '../../../src/transition';
+import {
+  observeWithSharedInOb,
+  unobserveWithSharedInOb,
+} from '../../../src/viewport-observer';
 
 /** @const {string} */
 const TAG = 'amp-scrollable-carousel';
@@ -111,10 +115,20 @@ export class AmpScrollableCarousel extends BaseCarousel {
 
   /** @override */
   layoutCallback() {
+    observeWithSharedInOb(this.element, (inViewport) =>
+      this.viewportCallbackTemp(inViewport)
+    );
+
     this.doLayout_(this.pos_);
     this.preloadNext_(this.pos_, 1);
     this.setControlsState();
     return Promise.resolve();
+  }
+
+  /** @override */
+  unlayoutCallback() {
+    unobserveWithSharedInOb(this.element);
+    return super.unlayoutCallback();
   }
 
   /** @override */

--- a/extensions/amp-carousel/0.1/scrollable-carousel.js
+++ b/extensions/amp-carousel/0.1/scrollable-carousel.js
@@ -118,8 +118,8 @@ export class AmpScrollableCarousel extends BaseCarousel {
   }
 
   /** @override */
-  viewportCallback(inViewport) {
-    super.viewportCallback(inViewport);
+  viewportCallback_(inViewport) {
+    super.viewportCallback_(inViewport);
     this.updateInViewport_(this.pos_, this.pos_);
   }
 

--- a/extensions/amp-carousel/0.1/slidescroll.js
+++ b/extensions/amp-carousel/0.1/slidescroll.js
@@ -29,6 +29,10 @@ import {isExperimentOn} from '../../../src/experiments';
 import {isFiniteNumber} from '../../../src/types';
 import {isLayoutSizeDefined} from '../../../src/layout';
 import {numeric} from '../../../src/transition';
+import {
+  observeWithSharedInOb,
+  unobserveWithSharedInOb,
+} from '../../../src/viewport-observer';
 import {triggerAnalyticsEvent} from '../../../src/analytics';
 
 /** @const {string} */
@@ -309,6 +313,10 @@ export class AmpSlideScroll extends BaseSlides {
 
   /** @override */
   layoutCallback() {
+    observeWithSharedInOb(this.element, (inViewport) =>
+      this.viewportCallbackTemp(inViewport)
+    );
+
     // TODO(sparhami) #19259 Tracks a more generic way to do this. Remove once
     // we have something better.
     const isScaled = closestAncestorElementBySelector(
@@ -345,6 +353,7 @@ export class AmpSlideScroll extends BaseSlides {
 
   /** @override */
   unlayoutCallback() {
+    unobserveWithSharedInOb(this.element);
     this.slideIndex_ = null;
     return super.unlayoutCallback();
   }

--- a/extensions/amp-carousel/0.1/slidescroll.js
+++ b/extensions/amp-carousel/0.1/slidescroll.js
@@ -138,9 +138,6 @@ export class AmpSlideScroll extends BaseSlides {
       : this.isIos_
       ? false
       : !isExperimentOn(this.win, 'amp-carousel-chrome-scroll-snap');
-
-    /** @private {function(boolean)} */
-    this.boundViewportCallback_ = this.viewportCallbackTemp.bind(this);
   }
 
   /** @override */
@@ -316,7 +313,9 @@ export class AmpSlideScroll extends BaseSlides {
 
   /** @override */
   layoutCallback() {
-    observeWithSharedInOb(this.element, this.boundViewportCallback_);
+    observeWithSharedInOb(this.element, (inViewport) =>
+      this.viewportCallbackTemp(inViewport)
+    );
 
     // TODO(sparhami) #19259 Tracks a more generic way to do this. Remove once
     // we have something better.

--- a/extensions/amp-carousel/0.1/slidescroll.js
+++ b/extensions/amp-carousel/0.1/slidescroll.js
@@ -138,6 +138,9 @@ export class AmpSlideScroll extends BaseSlides {
       : this.isIos_
       ? false
       : !isExperimentOn(this.win, 'amp-carousel-chrome-scroll-snap');
+
+    /** @private {function(boolean)} */
+    this.boundViewportCallback_ = this.viewportCallbackTemp.bind(this);
   }
 
   /** @override */
@@ -313,9 +316,7 @@ export class AmpSlideScroll extends BaseSlides {
 
   /** @override */
   layoutCallback() {
-    observeWithSharedInOb(this.element, (inViewport) =>
-      this.viewportCallbackTemp(inViewport)
-    );
+    observeWithSharedInOb(this.element, this.boundViewportCallback_);
 
     // TODO(sparhami) #19259 Tracks a more generic way to do this. Remove once
     // we have something better.

--- a/extensions/amp-carousel/0.1/slidescroll.js
+++ b/extensions/amp-carousel/0.1/slidescroll.js
@@ -350,8 +350,8 @@ export class AmpSlideScroll extends BaseSlides {
   }
 
   /** @override */
-  viewportCallback_(inViewport) {
-    super.viewportCallback_(inViewport);
+  viewportCallbackTemp(inViewport) {
+    super.viewportCallbackTemp(inViewport);
     if (this.slideIndex_ !== null) {
       Services.ownersForDoc(this.element).updateInViewport(
         this.element,

--- a/extensions/amp-carousel/0.1/slidescroll.js
+++ b/extensions/amp-carousel/0.1/slidescroll.js
@@ -350,8 +350,8 @@ export class AmpSlideScroll extends BaseSlides {
   }
 
   /** @override */
-  viewportCallback(inViewport) {
-    super.viewportCallback(inViewport);
+  viewportCallback_(inViewport) {
+    super.viewportCallback_(inViewport);
     if (this.slideIndex_ !== null) {
       Services.ownersForDoc(this.element).updateInViewport(
         this.element,

--- a/extensions/amp-carousel/0.1/test/test-base-slide.js
+++ b/extensions/amp-carousel/0.1/test/test-base-slide.js
@@ -174,7 +174,7 @@ describes.fakeWin('BaseSlides', {amp: true}, (env) => {
       })
     );
 
-    carousel.viewportCallback(true);
+    carousel.viewportCallback_(true);
     expect(viewportCallbackSpy).to.have.been.calledWith(true);
     expect(hintControlsSpy).to.have.been.called;
     expect(autoplaySpy).to.have.been.called;

--- a/extensions/amp-carousel/0.1/test/test-base-slide.js
+++ b/extensions/amp-carousel/0.1/test/test-base-slide.js
@@ -68,7 +68,7 @@ describes.fakeWin('BaseSlides', {amp: true}, (env) => {
     clearAutoplaySpy = env.sandbox.spy(BaseSlides.prototype, 'clearAutoplay');
     viewportCallbackSpy = env.sandbox.spy(
       BaseSlides.prototype,
-      'viewportCallback'
+      'viewportCallbackTemp'
     );
   });
 
@@ -174,7 +174,7 @@ describes.fakeWin('BaseSlides', {amp: true}, (env) => {
       })
     );
 
-    carousel.viewportCallback_(true);
+    carousel.viewportCallbackTemp(true);
     expect(viewportCallbackSpy).to.have.been.calledWith(true);
     expect(hintControlsSpy).to.have.been.called;
     expect(autoplaySpy).to.have.been.called;
@@ -189,7 +189,7 @@ describes.fakeWin('BaseSlides', {amp: true}, (env) => {
       })
     );
 
-    carousel.viewportCallback(false);
+    carousel.viewportCallbackTemp(false);
     expect(viewportCallbackSpy).to.have.been.calledWith(false);
     expect(hintControlsSpy).to.not.have.been.called;
     expect(autoplaySpy).to.not.have.been.called;

--- a/extensions/amp-carousel/0.1/test/test-slidescroll.js
+++ b/extensions/amp-carousel/0.1/test/test-slidescroll.js
@@ -695,16 +695,19 @@ describes.realWin(
       expect(impl.slidesContainer_./*OK*/ scrollLeft).to.equal(200);
 
       // Make sure the scroll position is correct after layoutCallback.
+      await impl.unlayoutCallback(); // cannot call layoutCallback() twice without an unlayout in between.
       await impl.layoutCallback();
+      impl.showSlide_(1);
       expect(impl.slidesContainer_./*OK*/ scrollLeft).to.equal(400);
     });
 
     it('should relayout the current slide on layoutCallback', () => {
-      return getAmpSlideScroll().then((ampSlideScroll) => {
+      return getAmpSlideScroll().then(async (ampSlideScroll) => {
         const impl = ampSlideScroll.implementation_;
         const owners = Services.ownersForDoc(impl.element);
         const scheduleLayoutSpy_ = env.sandbox.spy(owners, 'scheduleLayout');
         impl.slideIndex_ = null;
+        await impl.unlayoutCallback(); // cannot call layoutCallback() twice without an unlayout in between.
         impl.layoutCallback();
         expect(scheduleLayoutSpy_).to.have.been.calledWith(
           impl.element,
@@ -712,6 +715,7 @@ describes.realWin(
         );
 
         impl.showSlide_(1);
+        await impl.unlayoutCallback(); // cannot call layoutCallback() twice without an unlayout in between.
         impl.layoutCallback();
         expect(scheduleLayoutSpy_).to.have.been.calledWith(
           impl.element,

--- a/extensions/amp-delight-player/0.1/amp-delight-player.js
+++ b/extensions/amp-delight-player/0.1/amp-delight-player.js
@@ -95,7 +95,7 @@ class AmpDelightPlayer extends AMP.BaseElement {
     super(element);
 
     /** @private {boolean} */
-    this.inViewport_ = false;
+    this.isInViewport_ = false;
 
     /** @private {string} */
     this.baseURL_ = 'https://players.delight-vr.com';
@@ -179,7 +179,7 @@ class AmpDelightPlayer extends AMP.BaseElement {
   layoutCallback() {
     observeWithSharedInOb(
       this.element,
-      (inViewport) => (this.inViewport_ = inViewport)
+      (isInViewport) => (this.isInViewport_ = isInViewport)
     );
     const src = `${this.baseURL_}/player/${this.contentID_}?amp=1`;
     const iframe = createFrameFor(this, src);
@@ -246,7 +246,7 @@ class AmpDelightPlayer extends AMP.BaseElement {
   firstLayoutCompleted() {
     const el = this.placeholderEl_;
     let promise = null;
-    if (el && this.inViewport_) {
+    if (el && this.isInViewport_) {
       el.classList.add('i-amphtml-delight-player-faded');
       promise = listenOncePromise(el, 'transitionend');
     } else {

--- a/extensions/amp-delight-player/0.1/amp-delight-player.js
+++ b/extensions/amp-delight-player/0.1/amp-delight-player.js
@@ -34,7 +34,10 @@ import {getData, listen, listenOncePromise} from '../../../src/event-helper';
 import {htmlFor} from '../../../src/static-template';
 import {installVideoManagerForDoc} from '../../../src/service/video-manager-impl';
 import {isLayoutSizeDefined} from '../../../src/layout';
-import {observe, unobserve} from '../../../src/viewport-observer';
+import {
+  observeWithSharedInOb,
+  unobserveWithSharedInOb,
+} from '../../../src/viewport-observer';
 import {removeElement} from '../../../src/dom';
 import {setStyle} from '../../../src/style';
 import {userAssert} from '../../../src/log';
@@ -174,7 +177,10 @@ class AmpDelightPlayer extends AMP.BaseElement {
 
   /** @override */
   layoutCallback() {
-    observe(this.element, (inViewport) => (this.inViewport_ = inViewport));
+    observeWithSharedInOb(
+      this.element,
+      (inViewport) => (this.inViewport_ = inViewport)
+    );
     const src = `${this.baseURL_}/player/${this.contentID_}?amp=1`;
     const iframe = createFrameFor(this, src);
 
@@ -210,7 +216,7 @@ class AmpDelightPlayer extends AMP.BaseElement {
     this.playerReadyResolver_ = deferred.resolve;
 
     this.unregisterEventHandlers_();
-    unobserve(this.element);
+    unobserveWithSharedInOb(this.element);
 
     return true;
   }

--- a/extensions/amp-image-slider/0.1/amp-image-slider.js
+++ b/extensions/amp-image-slider/0.1/amp-image-slider.js
@@ -24,7 +24,10 @@ import {clamp} from '../../../src/utils/math';
 import {dev, user, userAssert} from '../../../src/log';
 import {isLayoutSizeDefined} from '../../../src/layout';
 import {listen} from '../../../src/event-helper';
-import {observe, unobserve} from '../../../src/viewport-observer';
+import {
+  observeWithSharedInOb,
+  unobserveWithSharedInOb,
+} from '../../../src/viewport-observer';
 import {setStyles} from '../../../src/style';
 
 export class AmpImageSlider extends AMP.BaseElement {
@@ -715,7 +718,9 @@ export class AmpImageSlider extends AMP.BaseElement {
 
   /** @override */
   layoutCallback() {
-    observe(this.element, (inViewport) => this.viewportCallback_(inViewport));
+    observeWithSharedInOb(this.element, (inViewport) =>
+      this.viewportCallback_(inViewport)
+    );
     // Extensions such as amp-carousel still uses .setOwner()
     // This would break the rendering of the images as carousel
     // will call .scheduleLayout on the slider but not the contents
@@ -759,7 +764,7 @@ export class AmpImageSlider extends AMP.BaseElement {
 
   /** @override */
   unlayoutCallback() {
-    unobserve(this.element);
+    unobserveWithSharedInOb(this.element);
     this.unregisterEvents_();
     return true;
   }

--- a/extensions/amp-image-slider/0.1/amp-image-slider.js
+++ b/extensions/amp-image-slider/0.1/amp-image-slider.js
@@ -24,6 +24,7 @@ import {clamp} from '../../../src/utils/math';
 import {dev, user, userAssert} from '../../../src/log';
 import {isLayoutSizeDefined} from '../../../src/layout';
 import {listen} from '../../../src/event-helper';
+import {observe, unobserve} from '../../../src/viewport-observer';
 import {setStyles} from '../../../src/style';
 
 export class AmpImageSlider extends AMP.BaseElement {
@@ -714,6 +715,7 @@ export class AmpImageSlider extends AMP.BaseElement {
 
   /** @override */
   layoutCallback() {
+    observe(this.element, (inViewport) => this.viewportCallback_(inViewport));
     // Extensions such as amp-carousel still uses .setOwner()
     // This would break the rendering of the images as carousel
     // will call .scheduleLayout on the slider but not the contents
@@ -757,6 +759,7 @@ export class AmpImageSlider extends AMP.BaseElement {
 
   /** @override */
   unlayoutCallback() {
+    unobserve(this.element);
     this.unregisterEvents_();
     return true;
   }
@@ -771,8 +774,11 @@ export class AmpImageSlider extends AMP.BaseElement {
     this.registerEvents_();
   }
 
-  /** @override */
-  viewportCallback(inViewport) {
+  /**
+   * @param {boolean} inViewport
+   * @private
+   */
+  viewportCallback_(inViewport) {
     // Show hint if back into viewport and user does not explicitly
     // disable this
     if (inViewport && this.shouldHintReappear_) {

--- a/extensions/amp-playbuzz/0.1/amp-playbuzz.js
+++ b/extensions/amp-playbuzz/0.1/amp-playbuzz.js
@@ -51,7 +51,10 @@ import {dev, userAssert} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
 import {isExperimentOn} from '../../../src/experiments';
 import {logo, showMoreArrow} from './images';
-import {observe, unobserve} from '../../../src/viewport-observer';
+import {
+  observeWithSharedInOb,
+  unobserveWithSharedInOb,
+} from '../../../src/viewport-observer';
 import {removeElement} from '../../../src/dom';
 
 class AmpPlaybuzz extends AMP.BaseElement {
@@ -185,7 +188,10 @@ class AmpPlaybuzz extends AMP.BaseElement {
 
   /** @override */
   layoutCallback() {
-    observe(this.element, (inViewport) => (this.inViewport_ = inViewport));
+    observeWithSharedInOb(
+      this.element,
+      (inViewport) => (this.inViewport_ = inViewport)
+    );
     const iframe = this.element.ownerDocument.createElement('iframe');
     this.iframe_ = iframe;
     iframe.setAttribute('scrolling', 'no');
@@ -324,7 +330,7 @@ class AmpPlaybuzz extends AMP.BaseElement {
 
   /** @override */
   unlayoutCallback() {
-    unobserve(this.element);
+    unobserveWithSharedInOb(this.element);
     this.unlisteners_.forEach((unlisten) => unlisten());
     this.unlisteners_.length = 0;
 

--- a/extensions/amp-playbuzz/0.1/amp-playbuzz.js
+++ b/extensions/amp-playbuzz/0.1/amp-playbuzz.js
@@ -51,6 +51,7 @@ import {dev, userAssert} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
 import {isExperimentOn} from '../../../src/experiments';
 import {logo, showMoreArrow} from './images';
+import {observe, unobserve} from '../../../src/viewport-observer';
 import {removeElement} from '../../../src/dom';
 
 class AmpPlaybuzz extends AMP.BaseElement {
@@ -78,6 +79,9 @@ class AmpPlaybuzz extends AMP.BaseElement {
 
     /** @private {?boolean} */
     this.iframeLoaded_ = false;
+
+    /** @private {?boolean} */
+    this.inViewport_ = false;
 
     /** @private {Array<Function>} */
     this.unlisteners_ = [];
@@ -181,6 +185,7 @@ class AmpPlaybuzz extends AMP.BaseElement {
 
   /** @override */
   layoutCallback() {
+    observe(this.element, (inViewport) => (this.inViewport_ = inViewport));
     const iframe = this.element.ownerDocument.createElement('iframe');
     this.iframe_ = iframe;
     iframe.setAttribute('scrolling', 'no');
@@ -296,7 +301,7 @@ class AmpPlaybuzz extends AMP.BaseElement {
    * @param {{height: number, left: number, relayoutAll: boolean, top: number, velocity: number, width: number }} changeEvent
    */
   sendScrollDataToItem_(changeEvent) {
-    if (!this.isInViewport()) {
+    if (!this.inViewport_) {
       return;
     }
 
@@ -319,6 +324,7 @@ class AmpPlaybuzz extends AMP.BaseElement {
 
   /** @override */
   unlayoutCallback() {
+    unobserve(this.element);
     this.unlisteners_.forEach((unlisten) => unlisten());
     this.unlisteners_.length = 0;
 

--- a/extensions/amp-timeago/0.1/amp-timeago.js
+++ b/extensions/amp-timeago/0.1/amp-timeago.js
@@ -64,10 +64,10 @@ export class AmpTimeAgo extends AMP.BaseElement {
     this.element.appendChild(this.timeElement_);
   }
 
-  /** 
-   * @param {boolean} inViewport 
+  /**
+   * @param {boolean} inViewport
    * @private
-  */
+   */
   viewportCallback_(inViewport) {
     if (inViewport && !this.cutOffReached_) {
       this.setFuzzyTimestampValue_();

--- a/extensions/amp-timeago/0.1/amp-timeago.js
+++ b/extensions/amp-timeago/0.1/amp-timeago.js
@@ -15,7 +15,10 @@
  */
 
 import {isLayoutSizeDefined} from '../../../src/layout';
-import {observe, unobserve} from '../../../src/viewport-observer';
+import {
+  observeWithSharedInOb,
+  unobserveWithSharedInOb,
+} from '../../../src/viewport-observer';
 import {timeago} from '../../../third_party/timeagojs/timeago';
 import {userAssert} from '../../../src/log';
 
@@ -76,12 +79,14 @@ export class AmpTimeAgo extends AMP.BaseElement {
 
   /** @override */
   layoutCallback() {
-    observe(this.element, (inViewport) => this.viewportCallback_(inViewport));
+    observeWithSharedInOb(this.element, (inViewport) =>
+      this.viewportCallback_(inViewport)
+    );
   }
 
   /** @override */
   unLayoutCallback() {
-    unobserve(this.element);
+    unobserveWithSharedInOb(this.element);
   }
 
   /** @override */

--- a/extensions/amp-timeago/0.1/amp-timeago.js
+++ b/extensions/amp-timeago/0.1/amp-timeago.js
@@ -82,11 +82,13 @@ export class AmpTimeAgo extends AMP.BaseElement {
     observeWithSharedInOb(this.element, (inViewport) =>
       this.viewportCallback_(inViewport)
     );
+    return Promise.resolve();
   }
 
   /** @override */
-  unLayoutCallback() {
+  unlayoutCallback() {
     unobserveWithSharedInOb(this.element);
+    return false;
   }
 
   /** @override */

--- a/extensions/amp-timeago/0.1/amp-timeago.js
+++ b/extensions/amp-timeago/0.1/amp-timeago.js
@@ -15,6 +15,7 @@
  */
 
 import {isLayoutSizeDefined} from '../../../src/layout';
+import {observe, unobserve} from '../../../src/viewport-observer';
 import {timeago} from '../../../third_party/timeagojs/timeago';
 import {userAssert} from '../../../src/log';
 
@@ -63,11 +64,24 @@ export class AmpTimeAgo extends AMP.BaseElement {
     this.element.appendChild(this.timeElement_);
   }
 
-  /** @override */
-  viewportCallback(inViewport) {
+  /** 
+   * @param {boolean} inViewport 
+   * @private
+  */
+  viewportCallback_(inViewport) {
     if (inViewport && !this.cutOffReached_) {
       this.setFuzzyTimestampValue_();
     }
+  }
+
+  /** @override */
+  layoutCallback() {
+    observe(this.element, (inViewport) => this.viewportCallback_(inViewport));
+  }
+
+  /** @override */
+  unLayoutCallback() {
+    unobserve(this.element);
   }
 
   /** @override */

--- a/extensions/amp-timeago/0.1/test/test-amp-timeago.js
+++ b/extensions/amp-timeago/0.1/test/test-amp-timeago.js
@@ -64,7 +64,7 @@ describes.realWin(
       element.textContent = date.toString();
       element.build();
       await timeout(1000);
-      element.viewportCallback(true);
+      (await element.getImpl(true)).viewportCallback_(true);
       const timeElement = element.querySelector('time');
       expect(timeElement.textContent).to.equal('11 seconds ago');
     });

--- a/testing/fake-dom.js
+++ b/testing/fake-dom.js
@@ -68,6 +68,9 @@ export class FakeWindow {
     this./*OK*/ pageYOffset = window./*OK*/ pageYOffset;
 
     /** @const */
+    this.IntersectionObserver = window.IntersectionObserver;
+
+    /** @const */
     this.crypto = window.crypto || window.msCrypto;
 
     // Parent Window points to itself if spec.parent was not passed.


### PR DESCRIPTION
**summary**
Partial for #30620

Included components:

1. 3d-gltf
1. amp-anim
1. apester-media
1. base-carousel 0.1: base-carousel, base-slides, slidescroll, scrollable-carousel.
1. delight-player
1. img-slider 
1. playbuzz
1. timeago


Notes:
- For apester-media, I removed all custom placeholder logic. I couldn't figure out why it existed.