### PR TITLE
🔥  Fix height bug

### DIFF
--- a/css/amp-story-player-iframe.css
+++ b/css/amp-story-player-iframe.css
@@ -24,11 +24,6 @@
   position: absolute;
 }
 
-.i-amphtml-story-player-shadow-root-intermediary {
-  width: 100%;
-  height: 100%;
-}
-
 .i-amphtml-story-player-main-container {
   height: 100%;
   position: relative;

--- a/css/amp-story-player.css
+++ b/css/amp-story-player.css
@@ -19,6 +19,11 @@ amp-story-player {
   display: block;
 }
 
+.i-amphtml-story-player-shadow-root-intermediary {
+  width: 100%;
+  height: 100%;
+}
+
 amp-story-player a:first-of-type {
   width: 100%;
   height: 100%;


### PR DESCRIPTION
The `.i-amphtml-story-player-shadow-root-intermediary` class was in the Shadow CSS file, where it should've been in the light DOM. This caused the intermediary element (the element between the `amp-story-player` and the shadow DOM) to not have any height. Breaking the `height` CSS property chain.

We didn't catch this in QA because our docs were not using `<!DOCTYPE html>`: https://stackoverflow.com/questions/1966300/height-100-is-not-working-in-html-when-using-doctype


Closes #30783