### PR TITLE
♿  remove aria-live=polite from amp-list

### DIFF
--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -265,10 +265,6 @@ export class AmpList extends AMP.BaseElement {
       this.element.appendChild(this.container_);
     }
 
-    if (!this.element.hasAttribute('aria-live')) {
-      this.element.setAttribute('aria-live', 'polite');
-    }
-
     // auto-resize is deprecated and will be removed per deprecation schedule
     // It will relaunched under a new attribute (resizable-children) soon.
     // please see https://github.com/ampproject/amphtml/issues/18849


### PR DESCRIPTION
amp-list fix to #29611 

>We recommend completely removing the aria-live="polite" that is generated by default for <amp-list> To convey that a list has changed, use announcements such as "list updated", "item added", or similar. Don't fire these announcements on page load when the list if first rendered, but reserve these for subsequent changes after the initial render.

- Why not adding the announcements as suggested. 

`<amp-list>` either load more item via the "Load more" manually, or via `load-more=auto`
When load more manually, there's the load more button, we don't need the `list updated` announcements because the load more action is triggered by user.
When load more automatically, we are aiming to provide the infinite scroll behavior. Where one never reach the end of the list. In this case one should be able to navigate the list without the 'list updated' announcements

- Why not removing `aria-live=polite` from `<amp-live-list>`

`<amp-live-list>` requires an update button that will shows up when content content has been fetched. And the list content update is the triggered by user. This is already serves as the 'list updated' announcement as suggested. 
