### PR TITLE
Expose consentMetadata to 3p ad iframes

### DIFF
--- a/3p/ampcontext.js
+++ b/3p/ampcontext.js
@@ -79,6 +79,9 @@ export class AbstractAmpContext {
     this.initialConsentValue = null;
 
     /** @type {?Object} */
+    this.initialConsentMetadata = null;
+
+    /** @type {?Object} */
     this.initialLayoutRect = null;
 
     /** @type {?Object} */
@@ -355,6 +358,7 @@ export class AbstractAmpContext {
     this.hidden = context.hidden;
     this.initialConsentState = context.initialConsentState;
     this.initialConsentValue = context.initialConsentValue;
+    this.initialConsentMetadata = context.initialConsentMetadata;
     this.initialLayoutRect = context.initialLayoutRect;
     this.initialIntersection = context.initialIntersection;
     this.location = parseUrlDeprecated(context.location.href);

--- a/ads/README.md
+++ b/ads/README.md
@@ -247,6 +247,16 @@ AMP runtime provides the following `window.context` APIs for ad network to acces
     Provides additional user privacy related data retrieved from publishers.
     See <a href="https://github.com/ampproject/amphtml/blob/master/extensions/amp-consent/amp-consent.md#response">here</a> for details.
   </dd>
+  <dt><code>window.context.initialConsentState</code></dt>
+  <dd>
+    Provides the initial consent string when the ad is unblocked.
+    See <a href="https://github.com/ampproject/amphtml/blob/master/extensions/amp-consent/customizing-extension-behaviors-on-consent.md#on-consent-string">here</a> for details.
+  </dd>
+  <dt><code>window.context.initialConsentMetadata</code></dt>
+  <dd>
+    Provides initial consent metadata when the ad is unblocked.
+    See <a href="https://github.com/ampproject/amphtml/blob/master/extensions/amp-consent/customizing-extension-behaviors-on-consent.md#on-consent-metadata">here</a> for details.
+  </dd>
 </dl>
 
 After overriding the default consent handling behavior, don't forget to update your publisher facing

--- a/ads/_ping_.js
+++ b/ads/_ping_.js
@@ -89,6 +89,10 @@ export function _ping_(global, data) {
       const TAG = 'consentStringValue';
       dev().info(TAG, global.context.initialConsentValue);
     }
+    if (global.context.initialConsentMetadata) {
+      const TAG = 'consentMetadata';
+      dev().info(TAG, global.context.initialConsentMetadata);
+    }
   } else {
     global.setTimeout(() => {
       global.context.noContentAvailable();

--- a/extensions/amp-ad/0.1/amp-ad-3p-impl.js
+++ b/extensions/amp-ad/0.1/amp-ad-3p-impl.js
@@ -43,6 +43,7 @@ import {
   is3pThrottled,
 } from './concurrent-load';
 import {
+  getConsentMetadata,
   getConsentPolicyInfo,
   getConsentPolicySharedData,
   getConsentPolicyState,
@@ -399,6 +400,9 @@ export class AmpAd3PImpl extends AMP.BaseElement {
     const consentStringPromise = consentPolicyId
       ? getConsentPolicyInfo(this.element, consentPolicyId)
       : Promise.resolve(null);
+    const consentMetadataPromise = consentPolicyId
+      ? getConsentMetadata(this.element, consentPolicyId)
+      : Promise.resolve(null);
     const sharedDataPromise = consentPolicyId
       ? getConsentPolicySharedData(this.element, consentPolicyId)
       : Promise.resolve(null);
@@ -418,6 +422,7 @@ export class AmpAd3PImpl extends AMP.BaseElement {
       consentPromise,
       sharedDataPromise,
       consentStringPromise,
+      consentMetadataPromise,
       scrollPromise,
     ]).then((consents) => {
       // Use JsonObject to preserve field names so that ampContext can access
@@ -433,8 +438,9 @@ export class AmpAd3PImpl extends AMP.BaseElement {
         'container': this.container_,
         'initialConsentState': consents[1],
         'consentSharedData': consents[2],
+        'initialConsentValue': consents[3],
+        'initialConsentMetadata': consents[4],
       });
-      opt_context['initialConsentValue'] = consents[3];
 
       // In this path, the request and render start events are entangled,
       // because both happen inside a cross-domain iframe.  Separating them

--- a/extensions/amp-ad/0.1/test/test-amp-ad-3p-impl.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-3p-impl.js
@@ -146,7 +146,7 @@ describes.realWin(
         });
       });
 
-      it('should propagate consent state to ad iframe', () => {
+      it('should propagate consent values to ad iframe', () => {
         ad3p.element.setAttribute('data-block-on-consent', '');
         env.sandbox
           .stub(consent, 'getConsentPolicyState')
@@ -154,6 +154,9 @@ describes.realWin(
         env.sandbox
           .stub(consent, 'getConsentPolicySharedData')
           .resolves({a: 1, b: 2});
+        env.sandbox
+          .stub(consent, 'getConsentMetadata')
+          .resolves({consentStringType: 2, gdprApplies: true});
 
         return ad3p.layoutCallback().then(() => {
           const frame = ad3p.element.querySelector('iframe[src]');
@@ -165,6 +168,10 @@ describes.realWin(
             CONSENT_POLICY_STATE.SUFFICIENT
           );
           expect(data._context.consentSharedData).to.deep.equal({a: 1, b: 2});
+          expect(data._context.initialConsentMetadata).to.deep.equal({
+            consentStringType: 2,
+            gdprApplies: true,
+          });
         });
       });
 


### PR DESCRIPTION
Closes #30786

Expose consentMetadata collected from amp-consent to 3p ad iframes through `window.context` as we already expose `consentString`, `consentState`, and `sharedData` in this way.