### PR TITLE
amp-list: single-item a11y warning.

### DIFF
--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -699,8 +699,16 @@ export class AmpList extends AMP.BaseElement {
       itemsExpr,
       this.element
     );
-    if (this.element.hasAttribute('single-item') && !isArray(items)) {
-      items = [items];
+    if (this.element.hasAttribute('single-item')) {
+      if (!isArray(items)) {
+        items = [items];
+      } else {
+        user().warn(
+          TAG,
+          'items must be a non-array Object if "single-item" is enabled.',
+          this.element
+        );
+      }
     }
     items = user().assertArray(items);
     if (this.element.hasAttribute('max-items')) {

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -705,7 +705,7 @@ export class AmpList extends AMP.BaseElement {
       } else {
         user().warn(
           TAG,
-          'items must be a non-array Object if "single-item" is enabled.',
+          'Expected response to contain a non-array Object due to "single-item" attribute.',
           this.element
         );
       }


### PR DESCRIPTION
**summary**
Addresses: https://github.com/ampproject/amphtml/issues/30261#issuecomment-696982168.

Adds a warning when single-item is used in conjunction with an Array Response. Ideally the developer should remove the `single-item` attribute. I'm unsure how wordy to make the warning. Should I also include instructions to remove the attribute?

![image](https://user-images.githubusercontent.com/4656974/96927260-ce0b0780-1484-11eb-8ef0-1b907892b7a5.png)
