### PR TITLE
♿ Added titles to internal iframes of AMP components

### DIFF
--- a/extensions/amp-3d-gltf/0.1/amp-3d-gltf.js
+++ b/extensions/amp-3d-gltf/0.1/amp-3d-gltf.js
@@ -151,7 +151,7 @@ export class Amp3dGltf extends AMP.BaseElement {
     }
 
     const iframe = getIframe(this.win, this.element, '3d-gltf', this.context_);
-    iframe.setAttribute('title', 'AMP GLTF 3D model');
+    iframe.setAttribute('title', this.element.title || 'GLTF 3D model');
     this.applyFillContent(iframe, true);
     this.iframe_ = iframe;
     this.unlistenMessage_ = devAssert(this.listenGltfViewerMessages_());

--- a/extensions/amp-3d-gltf/0.1/amp-3d-gltf.js
+++ b/extensions/amp-3d-gltf/0.1/amp-3d-gltf.js
@@ -151,7 +151,7 @@ export class Amp3dGltf extends AMP.BaseElement {
     }
 
     const iframe = getIframe(this.win, this.element, '3d-gltf', this.context_);
-
+    iframe.setAttribute('title', 'AMP GLTF 3D model');
     this.applyFillContent(iframe, true);
     this.iframe_ = iframe;
     this.unlistenMessage_ = devAssert(this.listenGltfViewerMessages_());

--- a/extensions/amp-3d-gltf/0.1/amp-3d-gltf.js
+++ b/extensions/amp-3d-gltf/0.1/amp-3d-gltf.js
@@ -151,7 +151,7 @@ export class Amp3dGltf extends AMP.BaseElement {
     }
 
     const iframe = getIframe(this.win, this.element, '3d-gltf', this.context_);
-    iframe.setAttribute('title', this.element.title || 'GLTF 3D model');
+    iframe.title = this.element.title || 'GLTF 3D model';
     this.applyFillContent(iframe, true);
     this.iframe_ = iframe;
     this.unlistenMessage_ = devAssert(this.listenGltfViewerMessages_());

--- a/extensions/amp-ad/0.1/amp-ad-3p-impl.js
+++ b/extensions/amp-ad/0.1/amp-ad-3p-impl.js
@@ -447,6 +447,7 @@ export class AmpAd3PImpl extends AMP.BaseElement {
         opt_context,
         {disallowCustom: this.config.remoteHTMLDisabled}
       );
+      iframe.setAttribute('title', this.element.title || 'Advertisement');
       this.xOriginIframeHandler_ = new AmpAdXOriginIframeHandler(this);
       return this.xOriginIframeHandler_.init(iframe);
     });

--- a/extensions/amp-ad/0.1/amp-ad-3p-impl.js
+++ b/extensions/amp-ad/0.1/amp-ad-3p-impl.js
@@ -447,7 +447,7 @@ export class AmpAd3PImpl extends AMP.BaseElement {
         opt_context,
         {disallowCustom: this.config.remoteHTMLDisabled}
       );
-      iframe.setAttribute('title', this.element.title || 'Advertisement');
+      iframe.title = this.element.title || 'Advertisement';
       this.xOriginIframeHandler_ = new AmpAdXOriginIframeHandler(this);
       return this.xOriginIframeHandler_.init(iframe);
     });

--- a/extensions/amp-beopinion/0.1/amp-beopinion.js
+++ b/extensions/amp-beopinion/0.1/amp-beopinion.js
@@ -69,6 +69,7 @@ class AmpBeOpinion extends AMP.BaseElement {
   /** @override */
   layoutCallback() {
     const iframe = getIframe(this.win, this.element, 'beopinion');
+    iframe.setAttribute('title', 'AMP BeOpinion content');
     this.applyFillContent(iframe);
     listenFor(
       iframe,

--- a/extensions/amp-beopinion/0.1/amp-beopinion.js
+++ b/extensions/amp-beopinion/0.1/amp-beopinion.js
@@ -69,7 +69,7 @@ class AmpBeOpinion extends AMP.BaseElement {
   /** @override */
   layoutCallback() {
     const iframe = getIframe(this.win, this.element, 'beopinion');
-    iframe.setAttribute('title', 'AMP BeOpinion content');
+    iframe.setAttribute('title', this.element.title || 'BeOpinion content');
     this.applyFillContent(iframe);
     listenFor(
       iframe,

--- a/extensions/amp-beopinion/0.1/amp-beopinion.js
+++ b/extensions/amp-beopinion/0.1/amp-beopinion.js
@@ -69,7 +69,7 @@ class AmpBeOpinion extends AMP.BaseElement {
   /** @override */
   layoutCallback() {
     const iframe = getIframe(this.win, this.element, 'beopinion');
-    iframe.setAttribute('title', this.element.title || 'BeOpinion content');
+    iframe.title = this.element.title || 'BeOpinion content';
     this.applyFillContent(iframe);
     listenFor(
       iframe,

--- a/extensions/amp-bodymovin-animation/0.1/amp-bodymovin-animation.js
+++ b/extensions/amp-bodymovin-animation/0.1/amp-bodymovin-animation.js
@@ -144,7 +144,10 @@ export class AmpBodymovinAnimation extends AMP.BaseElement {
         'bodymovinanimation',
         opt_context
       );
-      iframe.setAttribute('title', 'AMP Airbnb BodyMovin animation');
+      iframe.setAttribute(
+        'title',
+        this.element.title || 'Airbnb BodyMovin animation'
+      );
       return Services.vsyncFor(this.win)
         .mutatePromise(() => {
           this.applyFillContent(iframe);

--- a/extensions/amp-bodymovin-animation/0.1/amp-bodymovin-animation.js
+++ b/extensions/amp-bodymovin-animation/0.1/amp-bodymovin-animation.js
@@ -144,6 +144,7 @@ export class AmpBodymovinAnimation extends AMP.BaseElement {
         'bodymovinanimation',
         opt_context
       );
+      iframe.setAttribute('title', 'AMP Airbnb BodyMovin animation');
       return Services.vsyncFor(this.win)
         .mutatePromise(() => {
           this.applyFillContent(iframe);

--- a/extensions/amp-bodymovin-animation/0.1/amp-bodymovin-animation.js
+++ b/extensions/amp-bodymovin-animation/0.1/amp-bodymovin-animation.js
@@ -144,10 +144,7 @@ export class AmpBodymovinAnimation extends AMP.BaseElement {
         'bodymovinanimation',
         opt_context
       );
-      iframe.setAttribute(
-        'title',
-        this.element.title || 'Airbnb BodyMovin animation'
-      );
+      iframe.title = this.element.title || 'Airbnb BodyMovin animation';
       return Services.vsyncFor(this.win)
         .mutatePromise(() => {
           this.applyFillContent(iframe);

--- a/extensions/amp-embedly-card/0.1/amp-embedly-card-impl.js
+++ b/extensions/amp-embedly-card/0.1/amp-embedly-card-impl.js
@@ -75,6 +75,7 @@ export class AmpEmbedlyCard extends AMP.BaseElement {
     }
 
     const iframe = getIframe(this.win, this.element, 'embedly');
+    iframe.setAttribute('title', 'AMP Embedly card');
 
     const opt_is3P = true;
     listenFor(

--- a/extensions/amp-embedly-card/0.1/amp-embedly-card-impl.js
+++ b/extensions/amp-embedly-card/0.1/amp-embedly-card-impl.js
@@ -75,7 +75,7 @@ export class AmpEmbedlyCard extends AMP.BaseElement {
     }
 
     const iframe = getIframe(this.win, this.element, 'embedly');
-    iframe.setAttribute('title', this.element.title || 'Embedly card');
+    iframe.title = this.element.title || 'Embedly card';
 
     const opt_is3P = true;
     listenFor(

--- a/extensions/amp-embedly-card/0.1/amp-embedly-card-impl.js
+++ b/extensions/amp-embedly-card/0.1/amp-embedly-card-impl.js
@@ -75,7 +75,7 @@ export class AmpEmbedlyCard extends AMP.BaseElement {
     }
 
     const iframe = getIframe(this.win, this.element, 'embedly');
-    iframe.setAttribute('title', 'AMP Embedly card');
+    iframe.setAttribute('title', this.element.title || 'Embedly card');
 
     const opt_is3P = true;
     listenFor(

--- a/extensions/amp-facebook-comments/0.1/amp-facebook-comments.js
+++ b/extensions/amp-facebook-comments/0.1/amp-facebook-comments.js
@@ -74,6 +74,7 @@ class AmpFacebookComments extends AMP.BaseElement {
   /** @override */
   layoutCallback() {
     const iframe = getIframe(this.win, this.element, 'facebook');
+    iframe.setAttribute('title', 'AMP Facebook comments');
     this.applyFillContent(iframe);
     // Triggered by context.updateDimensions() inside the iframe.
     listenFor(

--- a/extensions/amp-facebook-comments/0.1/amp-facebook-comments.js
+++ b/extensions/amp-facebook-comments/0.1/amp-facebook-comments.js
@@ -74,7 +74,7 @@ class AmpFacebookComments extends AMP.BaseElement {
   /** @override */
   layoutCallback() {
     const iframe = getIframe(this.win, this.element, 'facebook');
-    iframe.setAttribute('title', 'AMP Facebook comments');
+    iframe.setAttribute('title', this.element.title || 'Facebook comments');
     this.applyFillContent(iframe);
     // Triggered by context.updateDimensions() inside the iframe.
     listenFor(

--- a/extensions/amp-facebook-comments/0.1/amp-facebook-comments.js
+++ b/extensions/amp-facebook-comments/0.1/amp-facebook-comments.js
@@ -74,7 +74,7 @@ class AmpFacebookComments extends AMP.BaseElement {
   /** @override */
   layoutCallback() {
     const iframe = getIframe(this.win, this.element, 'facebook');
-    iframe.setAttribute('title', this.element.title || 'Facebook comments');
+    iframe.title = this.element.title || 'Facebook comments';
     this.applyFillContent(iframe);
     // Triggered by context.updateDimensions() inside the iframe.
     listenFor(

--- a/extensions/amp-facebook-like/0.1/amp-facebook-like.js
+++ b/extensions/amp-facebook-like/0.1/amp-facebook-like.js
@@ -73,7 +73,7 @@ class AmpFacebookLike extends AMP.BaseElement {
   /** @override */
   layoutCallback() {
     const iframe = getIframe(this.win, this.element, 'facebook');
-    iframe.setAttribute('title', this.element.title || 'Facebook like button');
+    iframe.title = this.element.title || 'Facebook like button';
     this.applyFillContent(iframe);
     // Triggered by context.updateDimensions() inside the iframe.
     listenFor(

--- a/extensions/amp-facebook-like/0.1/amp-facebook-like.js
+++ b/extensions/amp-facebook-like/0.1/amp-facebook-like.js
@@ -73,7 +73,7 @@ class AmpFacebookLike extends AMP.BaseElement {
   /** @override */
   layoutCallback() {
     const iframe = getIframe(this.win, this.element, 'facebook');
-    iframe.setAttribute('title', 'AMP Facebook like button');
+    iframe.setAttribute('title', this.element.title || 'Facebook like button');
     this.applyFillContent(iframe);
     // Triggered by context.updateDimensions() inside the iframe.
     listenFor(

--- a/extensions/amp-facebook-like/0.1/amp-facebook-like.js
+++ b/extensions/amp-facebook-like/0.1/amp-facebook-like.js
@@ -73,6 +73,7 @@ class AmpFacebookLike extends AMP.BaseElement {
   /** @override */
   layoutCallback() {
     const iframe = getIframe(this.win, this.element, 'facebook');
+    iframe.setAttribute('title', 'AMP Facebook like button');
     this.applyFillContent(iframe);
     // Triggered by context.updateDimensions() inside the iframe.
     listenFor(

--- a/extensions/amp-facebook-page/0.1/amp-facebook-page.js
+++ b/extensions/amp-facebook-page/0.1/amp-facebook-page.js
@@ -74,7 +74,7 @@ class AmpFacebookPage extends AMP.BaseElement {
   /** @override */
   layoutCallback() {
     const iframe = getIframe(this.win, this.element, 'facebook');
-    iframe.setAttribute('title', 'AMP Facebook page');
+    iframe.setAttribute('title', this.element.title || 'Facebook page');
     this.applyFillContent(iframe);
     // Triggered by context.updateDimensions() inside the iframe.
     listenFor(

--- a/extensions/amp-facebook-page/0.1/amp-facebook-page.js
+++ b/extensions/amp-facebook-page/0.1/amp-facebook-page.js
@@ -74,7 +74,7 @@ class AmpFacebookPage extends AMP.BaseElement {
   /** @override */
   layoutCallback() {
     const iframe = getIframe(this.win, this.element, 'facebook');
-    iframe.setAttribute('title', this.element.title || 'Facebook page');
+    iframe.title = this.element.title || 'Facebook page';
     this.applyFillContent(iframe);
     // Triggered by context.updateDimensions() inside the iframe.
     listenFor(

--- a/extensions/amp-facebook-page/0.1/amp-facebook-page.js
+++ b/extensions/amp-facebook-page/0.1/amp-facebook-page.js
@@ -74,6 +74,7 @@ class AmpFacebookPage extends AMP.BaseElement {
   /** @override */
   layoutCallback() {
     const iframe = getIframe(this.win, this.element, 'facebook');
+    iframe.setAttribute('title', 'AMP Facebook page');
     this.applyFillContent(iframe);
     // Triggered by context.updateDimensions() inside the iframe.
     listenFor(

--- a/extensions/amp-facebook/0.1/amp-facebook.js
+++ b/extensions/amp-facebook/0.1/amp-facebook.js
@@ -78,6 +78,7 @@ class AmpFacebook extends AMP.BaseElement {
   /** @override */
   layoutCallback() {
     const iframe = getIframe(this.win, this.element, 'facebook');
+    iframe.setAttribute('title', 'AMP Facebook');
     this.applyFillContent(iframe);
     if (this.element.hasAttribute('data-allowfullscreen')) {
       iframe.setAttribute('allowfullscreen', 'true');

--- a/extensions/amp-facebook/0.1/amp-facebook.js
+++ b/extensions/amp-facebook/0.1/amp-facebook.js
@@ -78,7 +78,7 @@ class AmpFacebook extends AMP.BaseElement {
   /** @override */
   layoutCallback() {
     const iframe = getIframe(this.win, this.element, 'facebook');
-    iframe.setAttribute('title', this.element.title || 'Facebook');
+    iframe.title = this.element.title || 'Facebook';
     this.applyFillContent(iframe);
     if (this.element.hasAttribute('data-allowfullscreen')) {
       iframe.setAttribute('allowfullscreen', 'true');

--- a/extensions/amp-facebook/0.1/amp-facebook.js
+++ b/extensions/amp-facebook/0.1/amp-facebook.js
@@ -78,7 +78,7 @@ class AmpFacebook extends AMP.BaseElement {
   /** @override */
   layoutCallback() {
     const iframe = getIframe(this.win, this.element, 'facebook');
-    iframe.setAttribute('title', 'AMP Facebook');
+    iframe.setAttribute('title', this.element.title || 'Facebook');
     this.applyFillContent(iframe);
     if (this.element.hasAttribute('data-allowfullscreen')) {
       iframe.setAttribute('allowfullscreen', 'true');

--- a/extensions/amp-gist/0.1/amp-gist.js
+++ b/extensions/amp-gist/0.1/amp-gist.js
@@ -63,7 +63,7 @@ export class AmpGist extends AMP.BaseElement {
   layoutCallback() {
     /* the third parameter 'github' ties it to the 3p/github.js */
     const iframe = getIframe(this.win, this.element, 'github');
-    iframe.setAttribute('title', 'AMP Github gist');
+    iframe.setAttribute('title', this.element.title || 'Github gist');
     this.applyFillContent(iframe);
     // Triggered by window.context.requestResize() inside the iframe.
     listenFor(

--- a/extensions/amp-gist/0.1/amp-gist.js
+++ b/extensions/amp-gist/0.1/amp-gist.js
@@ -63,7 +63,7 @@ export class AmpGist extends AMP.BaseElement {
   layoutCallback() {
     /* the third parameter 'github' ties it to the 3p/github.js */
     const iframe = getIframe(this.win, this.element, 'github');
-    iframe.setAttribute('title', this.element.title || 'Github gist');
+    iframe.title = this.element.title || 'Github gist';
     this.applyFillContent(iframe);
     // Triggered by window.context.requestResize() inside the iframe.
     listenFor(

--- a/extensions/amp-gist/0.1/amp-gist.js
+++ b/extensions/amp-gist/0.1/amp-gist.js
@@ -63,6 +63,7 @@ export class AmpGist extends AMP.BaseElement {
   layoutCallback() {
     /* the third parameter 'github' ties it to the 3p/github.js */
     const iframe = getIframe(this.win, this.element, 'github');
+    iframe.setAttribute('title', 'AMP Github gist');
     this.applyFillContent(iframe);
     // Triggered by window.context.requestResize() inside the iframe.
     listenFor(

--- a/extensions/amp-ima-video/0.1/amp-ima-video.js
+++ b/extensions/amp-ima-video/0.1/amp-ima-video.js
@@ -179,6 +179,7 @@ class AmpImaVideo extends AMP.BaseElement {
         {initialConsentState},
         {allowFullscreen: true}
       );
+      iframe.setAttribute('title', 'AMP IMA video');
 
       this.applyFillContent(iframe);
 

--- a/extensions/amp-ima-video/0.1/amp-ima-video.js
+++ b/extensions/amp-ima-video/0.1/amp-ima-video.js
@@ -179,7 +179,7 @@ class AmpImaVideo extends AMP.BaseElement {
         {initialConsentState},
         {allowFullscreen: true}
       );
-      iframe.setAttribute('title', 'AMP IMA video');
+      iframe.setAttribute('title', this.element.title || 'IMA video');
 
       this.applyFillContent(iframe);
 

--- a/extensions/amp-ima-video/0.1/amp-ima-video.js
+++ b/extensions/amp-ima-video/0.1/amp-ima-video.js
@@ -179,7 +179,7 @@ class AmpImaVideo extends AMP.BaseElement {
         {initialConsentState},
         {allowFullscreen: true}
       );
-      iframe.setAttribute('title', this.element.title || 'IMA video');
+      iframe.title = this.element.title || 'IMA video';
 
       this.applyFillContent(iframe);
 

--- a/extensions/amp-mathml/0.1/amp-mathml.js
+++ b/extensions/amp-mathml/0.1/amp-mathml.js
@@ -67,6 +67,7 @@ export class AmpMathml extends AMP.BaseElement {
    */
   layoutCallback() {
     const iframe = getIframe(this.win, this.element, 'mathml');
+    iframe.setAttribute('title', 'AMP MathML formula');
     this.applyFillContent(iframe);
     // Triggered by context.updateDimensions() inside the iframe.
     listenFor(

--- a/extensions/amp-mathml/0.1/amp-mathml.js
+++ b/extensions/amp-mathml/0.1/amp-mathml.js
@@ -67,7 +67,7 @@ export class AmpMathml extends AMP.BaseElement {
    */
   layoutCallback() {
     const iframe = getIframe(this.win, this.element, 'mathml');
-    iframe.setAttribute('title', this.element.title || 'MathML formula');
+    iframe.title = this.element.title || 'MathML formula';
     this.applyFillContent(iframe);
     // Triggered by context.updateDimensions() inside the iframe.
     listenFor(

--- a/extensions/amp-mathml/0.1/amp-mathml.js
+++ b/extensions/amp-mathml/0.1/amp-mathml.js
@@ -67,7 +67,7 @@ export class AmpMathml extends AMP.BaseElement {
    */
   layoutCallback() {
     const iframe = getIframe(this.win, this.element, 'mathml');
-    iframe.setAttribute('title', 'AMP MathML formula');
+    iframe.setAttribute('title', this.element.title || 'MathML formula');
     this.applyFillContent(iframe);
     // Triggered by context.updateDimensions() inside the iframe.
     listenFor(

--- a/extensions/amp-reddit/0.1/amp-reddit.js
+++ b/extensions/amp-reddit/0.1/amp-reddit.js
@@ -75,6 +75,7 @@ class AmpReddit extends AMP.BaseElement {
     const iframe = getIframe(this.win, this.element, 'reddit', null, {
       allowFullscreen: true,
     });
+    iframe.setAttribute('title', 'AMP Reddit');
     this.applyFillContent(iframe);
     listenFor(
       iframe,

--- a/extensions/amp-reddit/0.1/amp-reddit.js
+++ b/extensions/amp-reddit/0.1/amp-reddit.js
@@ -75,7 +75,7 @@ class AmpReddit extends AMP.BaseElement {
     const iframe = getIframe(this.win, this.element, 'reddit', null, {
       allowFullscreen: true,
     });
-    iframe.setAttribute('title', this.element.title || 'Reddit');
+    iframe.title = this.element.title || 'Reddit';
     this.applyFillContent(iframe);
     listenFor(
       iframe,

--- a/extensions/amp-reddit/0.1/amp-reddit.js
+++ b/extensions/amp-reddit/0.1/amp-reddit.js
@@ -75,7 +75,7 @@ class AmpReddit extends AMP.BaseElement {
     const iframe = getIframe(this.win, this.element, 'reddit', null, {
       allowFullscreen: true,
     });
-    iframe.setAttribute('title', 'AMP Reddit');
+    iframe.setAttribute('title', this.element.title || 'Reddit');
     this.applyFillContent(iframe);
     listenFor(
       iframe,

--- a/extensions/amp-twitter/0.1/amp-twitter.js
+++ b/extensions/amp-twitter/0.1/amp-twitter.js
@@ -77,7 +77,7 @@ class AmpTwitter extends AMP.BaseElement {
     const iframe = getIframe(this.win, this.element, 'twitter', null, {
       allowFullscreen: true,
     });
-    iframe.setAttribute('title', this.element.title || 'Twitter');
+    iframe.title = this.element.title || 'Twitter';
     this.applyFillContent(iframe);
     this.updateForLoadingState_();
     listenFor(

--- a/extensions/amp-twitter/0.1/amp-twitter.js
+++ b/extensions/amp-twitter/0.1/amp-twitter.js
@@ -77,7 +77,7 @@ class AmpTwitter extends AMP.BaseElement {
     const iframe = getIframe(this.win, this.element, 'twitter', null, {
       allowFullscreen: true,
     });
-    iframe.setAttribute('title', 'AMP Twitter');
+    iframe.setAttribute('title', this.element.title || 'Twitter');
     this.applyFillContent(iframe);
     this.updateForLoadingState_();
     listenFor(

--- a/extensions/amp-twitter/0.1/amp-twitter.js
+++ b/extensions/amp-twitter/0.1/amp-twitter.js
@@ -77,6 +77,7 @@ class AmpTwitter extends AMP.BaseElement {
     const iframe = getIframe(this.win, this.element, 'twitter', null, {
       allowFullscreen: true,
     });
+    iframe.setAttribute('title', 'AMP Twitter');
     this.applyFillContent(iframe);
     this.updateForLoadingState_();
     listenFor(

--- a/extensions/amp-viqeo-player/0.1/amp-viqeo-player.js
+++ b/extensions/amp-viqeo-player/0.1/amp-viqeo-player.js
@@ -139,7 +139,7 @@ class AmpViqeoPlayer extends AMP.BaseElement {
         allowFullscreen: true,
       }
     );
-    iframe.setAttribute('title', 'AMP Viqeo video');
+    iframe.setAttribute('title', this.element.title || 'Viqeo video');
 
     // required to display the user gesture in the iframe
     iframe.setAttribute('allow', 'autoplay');

--- a/extensions/amp-viqeo-player/0.1/amp-viqeo-player.js
+++ b/extensions/amp-viqeo-player/0.1/amp-viqeo-player.js
@@ -139,7 +139,7 @@ class AmpViqeoPlayer extends AMP.BaseElement {
         allowFullscreen: true,
       }
     );
-    iframe.setAttribute('title', this.element.title || 'Viqeo video');
+    iframe.title = this.element.title || 'Viqeo video';
 
     // required to display the user gesture in the iframe
     iframe.setAttribute('allow', 'autoplay');

--- a/extensions/amp-viqeo-player/0.1/amp-viqeo-player.js
+++ b/extensions/amp-viqeo-player/0.1/amp-viqeo-player.js
@@ -139,6 +139,7 @@ class AmpViqeoPlayer extends AMP.BaseElement {
         allowFullscreen: true,
       }
     );
+    iframe.setAttribute('title', 'AMP Viqeo video');
 
     // required to display the user gesture in the iframe
     iframe.setAttribute('allow', 'autoplay');

--- a/extensions/amp-yotpo/0.1/amp-yotpo.js
+++ b/extensions/amp-yotpo/0.1/amp-yotpo.js
@@ -84,6 +84,7 @@ export class AmpYotpo extends AMP.BaseElement {
   /** @override */
   layoutCallback() {
     const iframe = getIframe(this.win, this.element, 'yotpo');
+    iframe.setAttribute('title', 'AMP Yotpo widget');
     this.applyFillContent(iframe);
 
     const unlisten = listenFor(

--- a/extensions/amp-yotpo/0.1/amp-yotpo.js
+++ b/extensions/amp-yotpo/0.1/amp-yotpo.js
@@ -84,7 +84,7 @@ export class AmpYotpo extends AMP.BaseElement {
   /** @override */
   layoutCallback() {
     const iframe = getIframe(this.win, this.element, 'yotpo');
-    iframe.setAttribute('title', 'AMP Yotpo widget');
+    iframe.setAttribute('title', this.element.title || 'Yotpo widget');
     this.applyFillContent(iframe);
 
     const unlisten = listenFor(

--- a/extensions/amp-yotpo/0.1/amp-yotpo.js
+++ b/extensions/amp-yotpo/0.1/amp-yotpo.js
@@ -84,7 +84,7 @@ export class AmpYotpo extends AMP.BaseElement {
   /** @override */
   layoutCallback() {
     const iframe = getIframe(this.win, this.element, 'yotpo');
-    iframe.setAttribute('title', this.element.title || 'Yotpo widget');
+    iframe.title = this.element.title || 'Yotpo widget';
     this.applyFillContent(iframe);
 
     const unlisten = listenFor(

--- a/extensions/amp-youtube/0.1/amp-youtube.js
+++ b/extensions/amp-youtube/0.1/amp-youtube.js
@@ -265,6 +265,7 @@ class AmpYoutube extends AMP.BaseElement {
   layoutCallback() {
     // See https://developers.google.com/youtube/iframe_api_reference
     const iframe = createFrameFor(this, this.getVideoIframeSrc_());
+    iframe.setAttribute('title', 'AMP YouTube video');
 
     // This is temporary until M74 launches.
     // TODO(aghassemi, #21247)


### PR DESCRIPTION
Added basic titles to internal iframes of AMP components. Fixing: https://github.com/ampproject/amphtml/issues/29874

One side-note: I wanted to know if these titles should be more detailed/specific to the component they're representing (like should the `amp-youtube` iframe `title` have a video-id in it for differentiation?). I shied away from this because I'm thinking this would create an ugly experience for screen readers, so a basic descriptive title is better.