### PR TITLE
🐛 Fix broken Exp B (story ad inabox)

### DIFF
--- a/build-system/compile/sources.js
+++ b/build-system/compile/sources.js
@@ -119,6 +119,8 @@ const CLOSURE_SRC_GLOBS = [
   'extensions/amp-access/**/*.js',
   // Needed for AmpStoryVariableService
   'extensions/amp-story/**/*.js',
+  // Needed for story ad inabox
+  'extensions/amp-story-auto-ads/**/*.js',
   // Needed for SubscriptionsService
   'extensions/amp-subscriptions/**/*.js',
   // Needed to access UserNotificationManager from other extensions


### PR DESCRIPTION
Could not compile without changes to `sources.js`