### PR TITLE
🐛 Remove RESPONSIVE from amp-story-360 validator

### DIFF
--- a/extensions/amp-story-360/validator-amp-story-360.protoascii
+++ b/extensions/amp-story-360/validator-amp-story-360.protoascii
@@ -85,6 +85,5 @@ tags: {  # <amp-story-360>
     supported_layouts: FIXED_HEIGHT
     supported_layouts: FLEX_ITEM
     supported_layouts: NODISPLAY
-    supported_layouts: RESPONSIVE
   }
 }


### PR DESCRIPTION
`layout=responsive` is incompatible with the component.
This appears to be due to the use of `applyFillContent` to the wrapper of the canvas element.

cc @ampproject/wg-stories