### PR TITLE
BaseElement: remove expandedCallback

### DIFF
--- a/src/base-element.js
+++ b/src/base-element.js
@@ -927,15 +927,6 @@ export class BaseElement {
   }
 
   /**
-   * Called every time an owned AmpElement expands itself.
-   * See {@link expand}.
-   * @param {!AmpElement} unusedElement Child element that was expanded.
-   */
-  expandedCallback(unusedElement) {
-    // Subclasses may override.
-  }
-
-  /**
    * Called when one or more attributes are mutated.
    * Note:
    * - Must be called inside a mutate context.

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -1367,14 +1367,6 @@ function createBaseCustomElementClass(win) {
     }
 
     /**
-     * Called every time an owned AmpElement expands itself.
-     * @param {!AmpElement} element
-     */
-    expandedCallback(element) {
-      this.implementation_.expandedCallback(element);
-    }
-
-    /**
      * Called when one or more attributes are mutated.
      * Note: Must be called inside a mutate context.
      * Note: Boolean attributes have a value of `true` and `false` when

--- a/src/inabox/inabox-mutator.js
+++ b/src/inabox/inabox-mutator.js
@@ -56,10 +56,6 @@ export class InaboxMutator {
   expandElement(element) {
     const resource = this.resources_.getResourceForElement(element);
     resource.completeExpand();
-    const owner = resource.getOwner();
-    if (owner) {
-      owner.expandedCallback(element);
-    }
     this.resources_./*OK*/ schedulePass();
   }
 

--- a/src/service/mutator-impl.js
+++ b/src/service/mutator-impl.js
@@ -101,12 +101,6 @@ export class MutatorImpl {
   expandElement(element) {
     const resource = Resource.forElement(element);
     resource.completeExpand();
-
-    const owner = resource.getOwner();
-    if (owner) {
-      owner.expandedCallback(element);
-    }
-
     this.resources_.schedulePass(FOUR_FRAME_DELAY_);
   }
 


### PR DESCRIPTION
**summary**
Removes `expandedCallback()`. Doesn't look like its used anywhere.