### PR TITLE
Bento: enable boolean-string values

### DIFF
--- a/extensions/amp-base-carousel/1.0/amp-base-carousel.js
+++ b/extensions/amp-base-carousel/1.0/amp-base-carousel.js
@@ -28,21 +28,6 @@ import {userAssert} from '../../../src/log';
 /** @const {string} */
 const TAG = 'amp-base-carousel';
 
-/**
- * The boolean attribute value as resolved by string equality with "true" or "false".
- * If the attribute is not present, default as given.
- *
- * @param {!Element} element
- * @param {string} attr
- * @param {boolean} defaultValue
- * @return {boolean}
- */
-function parseStrBoolAttr(element, attr, defaultValue) {
-  return element.hasAttribute(attr)
-    ? element.getAttribute(attr) !== 'false'
-    : defaultValue;
-}
-
 /** @extends {PreactBaseElement<BaseCarouselDef.CarouselApi>} */
 class AmpBaseCarousel extends PreactBaseElement {
   /** @override */
@@ -104,15 +89,11 @@ AmpBaseCarousel['children'] = {
 AmpBaseCarousel['props'] = {
   'advanceCount': {attr: 'advance-count', type: 'number', media: true},
   'controls': {attr: 'controls', type: 'string', media: true},
+  'loop': {attr: 'loop', type: 'boolean', media: true},
+  'mixedLength': {attr: 'mixed-length', type: 'boolean', media: true},
+  'outsetArrows': {attr: 'outset-arrows', type: 'boolean', media: true},
+  'snap': {attr: 'snap', type: 'boolean', media: true, default: true},
   'visibleCount': {attr: 'visible-count', type: 'number', media: true},
-  // TODO(#28284): support media queries as well?
-  'loop': {attr: 'loop', type: 'boolean'},
-  'mixedLength': {attr: 'mixed-length', type: 'boolean'},
-  'outsetArrows': {attr: 'outset-arrows', type: 'boolean'},
-  'snap': {
-    attrs: ['snap'],
-    parseAttrs: (element) => parseStrBoolAttr(element, 'snap', true),
-  },
 };
 
 /** @override */

--- a/extensions/amp-base-carousel/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-base-carousel/1.0/storybook/Basic.amp.js
@@ -34,7 +34,7 @@ export const Default = () => {
   const snap = boolean('snap', true);
   const advanceCount = number('advance count', 1, {min: 1});
   const visibleCount = text('visible count', '(min-width: 400px) 2, 1');
-  const outsetArrows = boolean('outset arrows', false);
+  const outsetArrows = text('outset arrows', '(min-width: 400px) true, false');
   const controls = select('show controls', ['auto', 'always', 'never']);
   const slideCount = number('slide count', 5, {min: 0, max: 99});
   const colorIncrement = Math.floor(255 / (slideCount + 1));

--- a/src/dom.js
+++ b/src/dom.js
@@ -927,6 +927,21 @@ export function toggleAttribute(element, name, forced) {
 }
 
 /**
+ * Parses a string as a boolean value using the expanded rules for DOM boolean
+ * attributes:
+ * - a `null` or `undefined` returns `null`;
+ * - an empty string returns `true`;
+ * - a "true" string returns `true`;
+ * - otherwise, `false` is returned.
+ *
+ * @param {?string|undefined} s
+ * @return {?boolean}
+ */
+export function parseBooleanAttribute(s) {
+  return s == null ? null : s === '' || s === 'true';
+}
+
+/**
  * @param {!Window} win
  * @return {number} The width of the vertical scrollbar, in pixels.
  */

--- a/src/dom.js
+++ b/src/dom.js
@@ -931,14 +931,14 @@ export function toggleAttribute(element, name, forced) {
  * attributes:
  * - a `null` or `undefined` returns `null`;
  * - an empty string returns `true`;
- * - a "true" string returns `true`;
- * - otherwise, `false` is returned.
+ * - a "false" string returns `false`;
+ * - otherwise, `true` is returned.
  *
  * @param {?string|undefined} s
- * @return {?boolean}
+ * @return {boolean|undefined}
  */
 export function parseBooleanAttribute(s) {
-  return s == null ? null : s === '' || s === 'true';
+  return s == null ? undefined : s !== 'false';
 }
 
 /**

--- a/src/preact/base-element.js
+++ b/src/preact/base-element.js
@@ -72,11 +72,6 @@ let AmpElementPropDef;
  */
 let ChildDef;
 
-/** @type {!Object<string, *>} */
-const TYPE_DEFAULTS = {
-  'boolean': false,
-};
-
 /** @const {!MutationObserverInit} */
 const CHILDREN_MUTATION_INIT = {
   childList: true,
@@ -787,9 +782,8 @@ function collectProps(Ctor, element, ref, defaultProps, mediaQueryProps) {
       }
     }
     if (value == null) {
-      const defValue = def.default ?? (def.type && TYPE_DEFAULTS[def.type]);
-      if (defValue != null) {
-        props[name] = defValue;
+      if (def.default != null) {
+        props[name] = def.default;
       }
     } else {
       const v =

--- a/test/unit/preact/test-base-element-mapping.js
+++ b/test/unit/preact/test-base-element-mapping.js
@@ -82,6 +82,7 @@ describes.realWin('PreactBaseElement', spec, (env) => {
         'aDate': {attr: 'a-date', type: 'date'},
         'disabled': {attr: 'disabled', type: 'boolean'},
         'enabled': {attr: 'enabled', type: 'boolean'},
+        'boolDefTrue': {attr: 'bool-def-true', type: 'boolean', default: true},
         'combined': {
           attrs: ['part-a', 'part-b'],
           parseAttrs: (e) =>
@@ -128,6 +129,7 @@ describes.realWin('PreactBaseElement', spec, (env) => {
         aDate: DATE,
         disabled: true,
         enabled: false,
+        boolDefTrue: true,
         combined: 'A+B',
       });
       expect(lastProps.params.test).to.equal('helloworld');
@@ -161,6 +163,26 @@ describes.realWin('PreactBaseElement', spec, (env) => {
       expect(lastProps.params.test).to.equal('worldhello');
       expect(lastProps.params.testTwo).to.equal('confirmAgain');
       expect(lastProps).to.not.haveOwnProperty('prefix');
+    });
+
+    it('should accept boolean string values', async () => {
+      element.setAttribute('enabled', 'true');
+      element.setAttribute('bool-def-true', 'true');
+      await waitFor(() => component.callCount > 1, 'component re-rendered');
+      expect(component).to.be.calledTwice;
+      expect(lastProps).to.contain({
+        enabled: true,
+        boolDefTrue: true,
+      });
+
+      element.setAttribute('enabled', 'false');
+      element.setAttribute('bool-def-true', 'false');
+      await waitFor(() => component.callCount > 2, 'component re-rendered');
+      expect(component).to.be.calledThrice;
+      expect(lastProps).to.contain({
+        enabled: false,
+        boolDefTrue: false,
+      });
     });
 
     it('should ignore non-declared attributes', async () => {

--- a/test/unit/preact/test-base-element-mapping.js
+++ b/test/unit/preact/test-base-element-mapping.js
@@ -128,10 +128,10 @@ describes.realWin('PreactBaseElement', spec, (env) => {
         minFontSize: 72,
         aDate: DATE,
         disabled: true,
-        enabled: false,
         boolDefTrue: true,
         combined: 'A+B',
       });
+      expect(lastProps.enabled).to.not.exist;
       expect(lastProps.params.test).to.equal('helloworld');
       expect(lastProps.params.testTwo).to.equal('confirm');
       expect(lastProps).to.not.haveOwnProperty('prefix');
@@ -143,6 +143,7 @@ describes.realWin('PreactBaseElement', spec, (env) => {
       element.setAttribute('a-date', '2018-01-01T08:00:01Z');
       element.setAttribute('enabled', '');
       element.removeAttribute('disabled');
+      element.setAttribute('bool-def-true', 'false');
       element.setAttribute('part-b', 'C');
       element.setAttribute('data-param-test', 'worldhello');
       element.setAttribute('data-param-test-two', 'confirmAgain');
@@ -156,10 +157,11 @@ describes.realWin('PreactBaseElement', spec, (env) => {
         propA: 'B',
         minFontSize: 72.5,
         aDate: DATE + 1000,
-        disabled: false,
         enabled: true,
+        boolDefTrue: false,
         combined: 'A+C',
       });
+      expect(lastProps.disabled).to.not.exist;
       expect(lastProps.params.test).to.equal('worldhello');
       expect(lastProps.params.testTwo).to.equal('confirmAgain');
       expect(lastProps).to.not.haveOwnProperty('prefix');

--- a/test/unit/test-dom.js
+++ b/test/unit/test-dom.js
@@ -1336,8 +1336,8 @@ describes.realWin(
 
     describe('parseBooleanAttribute', () => {
       it('should return null for null/undefined', () => {
-        expect(dom.parseBooleanAttribute(null)).to.be.null;
-        expect(dom.parseBooleanAttribute(undefined)).to.be.null;
+        expect(dom.parseBooleanAttribute(null)).to.be.undefined;
+        expect(dom.parseBooleanAttribute(undefined)).to.be.undefined;
       });
 
       it('should return true for empty string', () => {
@@ -1348,16 +1348,12 @@ describes.realWin(
         expect(dom.parseBooleanAttribute('true')).to.be.true;
       });
 
-      it('should return false for wrong capitalization', () => {
-        expect(dom.parseBooleanAttribute('TRUE')).to.be.false;
-      });
-
       it('should return false for "false" string', () => {
         expect(dom.parseBooleanAttribute('false')).to.be.false;
       });
 
-      it('should return false for a random string', () => {
-        expect(dom.parseBooleanAttribute('a')).to.be.false;
+      it('should return true for a random string', () => {
+        expect(dom.parseBooleanAttribute('a')).to.be.true;
       });
     });
   }

--- a/test/unit/test-dom.js
+++ b/test/unit/test-dom.js
@@ -1333,5 +1333,32 @@ describes.realWin(
         expect(el.getAttribute('foo')).to.equal('asdf');
       });
     });
+
+    describe('parseBooleanAttribute', () => {
+      it('should return null for null/undefined', () => {
+        expect(dom.parseBooleanAttribute(null)).to.be.null;
+        expect(dom.parseBooleanAttribute(undefined)).to.be.null;
+      });
+
+      it('should return true for empty string', () => {
+        expect(dom.parseBooleanAttribute('')).to.be.true;
+      });
+
+      it('should return true for "true" string', () => {
+        expect(dom.parseBooleanAttribute('true')).to.be.true;
+      });
+
+      it('should return false for wrong capitalization', () => {
+        expect(dom.parseBooleanAttribute('TRUE')).to.be.false;
+      });
+
+      it('should return false for "false" string', () => {
+        expect(dom.parseBooleanAttribute('false')).to.be.false;
+      });
+
+      it('should return false for a random string', () => {
+        expect(dom.parseBooleanAttribute('a')).to.be.false;
+      });
+    });
   }
 );


### PR DESCRIPTION
This is somewhat controversial decision, but it also appears to be the best compromise among all other options. See full discussion [here](https://docs.google.com/document/d/1G_WMXyyKGoHHta6iyXr0dF2B-kLGm_cAoArdVcn0VNg/edit#heading=h.t1nypbr9lvgm).

The boolean rules are now as following:

- `<amp-element custom>` -> `true`
- `<amp-element custom="true">` -> `true`
- `<amp-element custom="false">` -> `false`
- `<amp-element custom="(min-width: 360px) true, false">` -> `matchMedia('(min-width:360px)').matches`
- `<amp-element>` -> default value, most commonly `false`.

Partial for #28284