### PR TITLE
✨  Add Quantcast type for amp-consent

### DIFF
--- a/examples/amp-consent/cmp-vendors.amp.html
+++ b/examples/amp-consent/cmp-vendors.amp.html
@@ -103,6 +103,7 @@
           <option>Marfeel</option>
           <option>Ogury</option>
           <option>opencmp</option>
+          <option>quantcast</option>
           <option>sirdata</option>
           <option>SourcePoint</option>
           <option>Usercentrics</option>
@@ -317,6 +318,24 @@
         </div>
       </amp-consent>
       <!-- End opencmp example -->
+
+      <!-- Quantcast Example -->
+      <amp-consent id="quantcast" layout="nodisplay" type="quantcast">
+        <script type="application/json">
+            {
+              "postPromptUI": "quantcast-post-prompt",
+              "clientConfig": {
+                "coreConfig": {
+                  "googleEnabled": false
+                }
+              }
+            }
+          </script>
+          <div id="quantcast-post-prompt">
+            <button on="tap:quantcast.prompt()" role="button">Privacy settings</button>
+          </div>
+      </amp-consent>
+      <!-- End Quantcast example -->
 
       <!-- sirdata example -->
       <amp-consent id="consent" layout="nodisplay" type="sirdata">

--- a/examples/amp-consent/cmp-vendors.amp.html
+++ b/examples/amp-consent/cmp-vendors.amp.html
@@ -332,7 +332,7 @@
             }
           </script>
           <div id="quantcast-post-prompt">
-            <button on="tap:quantcast.prompt()" role="button">Privacy settings</button>
+            <button on="tap:conset.prompt(consent=quantcast)" role="button">Privacy settings</button>
           </div>
       </amp-consent>
       <!-- End Quantcast example -->

--- a/extensions/amp-consent/0.1/cmps.js
+++ b/extensions/amp-consent/0.1/cmps.js
@@ -91,6 +91,12 @@ CMP_CONFIG['opencmp'] = {
   'promptUISrc': 'https://cdn.opencmp.net/tcf-v2/amp/cmp.html',
 };
 
+CMP_CONFIG['quantcast'] = {
+  'consentInstanceId': 'quantcast',
+  'checkConsentHref': 'https://apis.quantcast.mgr.consensu.org/amp/check-consent',
+  'promptUISrc': 'https://quantcast.mgr.consensu.org/tcfv2/amp.html',
+};
+
 CMP_CONFIG['SourcePoint'] = {
   'consentInstanceId': 'SourcePoint',
   'checkConsentHref': 'https://sourcepoint.mgr.consensu.org/consent/v2/amp',

--- a/extensions/amp-consent/0.1/cmps.js
+++ b/extensions/amp-consent/0.1/cmps.js
@@ -93,7 +93,8 @@ CMP_CONFIG['opencmp'] = {
 
 CMP_CONFIG['quantcast'] = {
   'consentInstanceId': 'quantcast',
-  'checkConsentHref': 'https://apis.quantcast.mgr.consensu.org/amp/check-consent',
+  'checkConsentHref':
+    'https://apis.quantcast.mgr.consensu.org/amp/check-consent',
   'promptUISrc': 'https://quantcast.mgr.consensu.org/tcfv2/amp.html',
 };
 

--- a/extensions/amp-consent/amp-consent.md
+++ b/extensions/amp-consent/amp-consent.md
@@ -629,6 +629,7 @@ Join in on the discussion where we are discussing [upcoming potential features](
 - Ogury : [Website](https://www.ogury.com/) - [Documentation](./cmps/ogury.md)
 - OneTrust: [Website](https://www.onetrust.com/) - [Documentation](./cmps/onetrust.md)
 - opencmp : [Documentation](./cmps/opencmp.md)
+- Quantcast : [Website](https://www.quantcast.com) - [Documentation](https://help.quantcast.com/hc/en-us/categories/360002940873-Quantcast-Choice)
 - Sirdata : [Website](http://www.sirdata.com/) - [Documentation](https://cmp.sirdata.com/#/docs)
 - SourcePoint : [Website](https://www.sourcepoint.com/) - [Documentation](./cmps/sourcepoint.md)
 - Usercentrics : [Website](https://www.usercentrics.com/) - [Documentation](./cmps/usercentrics.md)

--- a/extensions/amp-consent/cmps/quantcast.md
+++ b/extensions/amp-consent/cmps/quantcast.md
@@ -31,7 +31,7 @@ limitations under the License.
           }
         </script>
         <div id="quantcast-post-prompt">
-          <button on="tap:quantcast.prompt(consent=quantcast)" role="button">Privacy settings</button>
+          <button on="tap:consent.prompt(consent=quantcast)" role="button">Privacy settings</button>
         </div>
     </amp-consent>
 ```

--- a/extensions/amp-consent/cmps/quantcast.md
+++ b/extensions/amp-consent/cmps/quantcast.md
@@ -1,0 +1,51 @@
+<!---
+Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS-IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# Quantcast
+
+## Example
+
+```html
+    <amp-consent id="quantcast" layout="nodisplay" type="quantcast">
+        <script type="application/json">
+          {
+            "postPromptUI": "quantcast-post-prompt",
+            "clientConfig": {
+              "coreConfig": {
+                "googleEnabled": true
+              }
+            }
+          }
+        </script>
+        <div id="quantcast-post-prompt">
+          <button on="tap:quantcast.prompt(consent=quantcast)" role="button">Privacy settings</button>
+        </div>
+    </amp-consent>
+```
+
+## Notes
+
+### `postPromptUI`
+
+The value of `postPromptUI` should be the id of the html tag in which the consent ui will be attached to. In our example above, the value of `postPromptUI` is `quantcast-post-prompt` since we have a div with that id.
+
+## Configuration
+
+Visit the [Privacy Portal](https://www.quantcast.com/protect/sites) to get a tag with your latest configuration.
+
+## Getting Help
+
+For more information on how to integrate AMP to your page please visit our [help portal](https://help.quantcast.com/hc/en-us/categories/360002940873-Quantcast-Choice) or contact your account manager directly.


### PR DESCRIPTION
Adding Quantcast to the list of registered CMPs.

Added:
- Quantcast CMP config
- Example on cmp-vendors page
- Example documentation.

[Quantcast Choice](https://www.quantcast.com/gdpr/consent-management-solution/) is a consent management provider (CMP) solution built on and registered with the IAB Europe Transparency and Consent framework. 

Additional context
We would like to register Quantcast Choice as a Supported Consent Management Platform for visibility and ease of implementation. 
Context: https://github.com/ampproject/amphtml/blob/master/extensions/amp-consent/integrating-consent.md

cc @ampproject/wg-monetization
