### PR TITLE
🏗 Add nws ad extension to build

### DIFF
--- a/build-system/compile/bundles.config.js
+++ b/build-system/compile/bundles.config.js
@@ -300,6 +300,12 @@ exports.extensionBundles = [
     type: TYPES.AD,
   },
   {
+    name: 'amp-ad-network-nws-impl',
+    version: '0.1',
+    latestVersion: '0.1',
+    type: TYPES.AD,
+  },
+  {
     name: 'amp-ad-network-fake-impl',
     version: '0.1',
     latestVersion: '0.1',


### PR DESCRIPTION
This was omitted in the original PR.

cc/ @danielstockton @ampproject/wg-monetization 