### PR TITLE
🏗 Build static Storybook on PR deploy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ build-system/global-configs/custom-config.json
 export
 validator/export
 result-reports/**
+
+# This is generated with `gulp storybook --build`
+examples/storybook

--- a/build-system/pr-check/dist-bundle-size.js
+++ b/build-system/pr-check/dist-bundle-size.js
@@ -76,6 +76,7 @@ async function main() {
       }
 
       timedExecOrDie('gulp bundle-size --on_pr_build');
+      timedExecOrDie('gulp storybook --build');
       await processAndUploadDistOutput(FILENAME);
     } else {
       timedExecOrDie('gulp bundle-size --on_skipped_build');

--- a/build-system/tasks/storybook/amp-env/main.js
+++ b/build-system/tasks/storybook/amp-env/main.js
@@ -25,4 +25,9 @@ module.exports = {
     '@storybook/addon-knobs',
     '@ampproject/storybook-addon',
   ],
+  webpackFinal: async (config) => {
+    // Disable entry point size warnings.
+    config.performance.hints = false;
+    return config;
+  },
 };

--- a/build-system/tasks/storybook/index.js
+++ b/build-system/tasks/storybook/index.js
@@ -94,15 +94,8 @@ async function storybook() {
   return Promise.all(envs.map(build ? buildEnv : launchEnv));
 }
 
-function buildStorybook(env = 'amp,preact') {
-  const envs = env.split(',');
-  installPackages(__dirname);
-  return Promise.all(envs.map(buildEnv));
-}
-
 module.exports = {
   storybook,
-  buildStorybook,
 };
 
 storybook.description = 'Isolated testing and development for AMP components.';

--- a/build-system/tasks/storybook/index.js
+++ b/build-system/tasks/storybook/index.js
@@ -85,11 +85,10 @@ async function storybook() {
   }
   installPackages(__dirname);
   const ctrlcHandler = createCtrlcHandler('storybook');
-  return Promise.all(envs.map(build ? buildEnv : launchEnv)).then(() => {
-    if (build) {
-      exitCtrlcHandler(ctrlcHandler);
-    }
-  });
+  await Promise.all(envs.map(build ? buildEnv : launchEnv));
+  if (build) {
+    exitCtrlcHandler(ctrlcHandler);
+  }
 }
 
 module.exports = {

--- a/build-system/tasks/storybook/index.js
+++ b/build-system/tasks/storybook/index.js
@@ -94,8 +94,15 @@ async function storybook() {
   return Promise.all(envs.map(build ? buildEnv : launchEnv));
 }
 
+function buildStorybook(env = 'amp,preact') {
+  const envs = env.split(',');
+  installPackages(__dirname);
+  return Promise.all(envs.map(buildEnv));
+}
+
 module.exports = {
   storybook,
+  buildStorybook,
 };
 
 storybook.description = 'Isolated testing and development for AMP components.';

--- a/build-system/tasks/storybook/index.js
+++ b/build-system/tasks/storybook/index.js
@@ -16,10 +16,12 @@
 'use strict';
 
 const argv = require('minimist')(process.argv.slice(2));
+const log = require('fancy-log');
 const {createCtrlcHandler} = require('../../common/ctrlcHandler');
 const {defaultTask: runAmpDevBuildServer} = require('../default-task');
 const {execScriptAsync} = require('../../common/exec');
 const {installPackages} = require('../../common/utils');
+const {yellow} = require('ansi-colors');
 
 const ENV_PORTS = {
   amp: 9001,
@@ -64,9 +66,14 @@ function launchEnv(env) {
  */
 function buildEnv(env) {
   if (env === 'amp') {
-    // TODO: This environment needs access to binaries from `gulp build`.
+    log(
+      yellow(
+        'WARNING: --build does not work with the `storybook/amp` environment.'
+      )
+    );
     return null;
   }
+  log(yellow('Building `storybook/preact` only.'));
   return execStorybookScriptAsync(
     'build-storybook',
     env,

--- a/build-system/tasks/storybook/index.js
+++ b/build-system/tasks/storybook/index.js
@@ -16,7 +16,10 @@
 'use strict';
 
 const argv = require('minimist')(process.argv.slice(2));
-const {createCtrlcHandler} = require('../../common/ctrlcHandler');
+const {
+  createCtrlcHandler,
+  exitCtrlcHandler,
+} = require('../../common/ctrlcHandler');
 const {defaultTask: runAmpDevBuildServer} = require('../default-task');
 const {execScriptAsync} = require('../../common/exec');
 const {installPackages} = require('../../common/utils');
@@ -27,37 +30,66 @@ const ENV_PORTS = {
 };
 
 /**
+ * @param {string} bin
  * @param {string} env 'amp' or 'preact'
+ * @param {...string} args
  * @return {!ChildProcess}
  */
-function launchEnv(env) {
-  const {ci, 'storybook_port': storybookPort = ENV_PORTS[env]} = argv;
-  return execScriptAsync(
-    [
-      './node_modules/.bin/start-storybook',
-      '--quiet',
-      '-s ../../../',
-      `-c ./${env}-env`,
-      `-p ${storybookPort}`,
-      ci ? '--ci' : '',
-    ].join(' '),
+const execStorybookScriptAsync = (bin, env, ...args) =>
+  execScriptAsync(
+    `./node_modules/.bin/${bin} --config-dir ./${env}-env ${args.join(' ')}`,
     {
       stdio: [null, process.stdout, process.stderr],
       cwd: __dirname,
       env: process.env,
     }
   );
+
+/**
+ * @param {string} env 'amp' or 'preact'
+ * @return {!ChildProcess}
+ */
+function launchEnv(env) {
+  const {ci, 'storybook_port': storybookPort = ENV_PORTS[env]} = argv;
+  return execStorybookScriptAsync(
+    'start-storybook',
+    env,
+    '--quiet',
+    '--static-dir ../../../',
+    `--port ${storybookPort}`,
+    ci ? '--ci' : ''
+  );
+}
+
+/**
+ * @param {string} env 'amp' or 'preact'
+ * @return {?ChildProcess}
+ */
+function buildEnv(env) {
+  if (env === 'amp') {
+    // TODO: This environment needs access to binaries from `gulp build`.
+    return null;
+  }
+  return execStorybookScriptAsync(
+    'build-storybook',
+    env,
+    `--output-dir ../../../examples/storybook/${env}`
+  );
 }
 
 async function storybook() {
-  const {'storybook_env': env = 'amp,preact'} = argv;
+  const {'storybook_env': env = 'amp,preact', build = false} = argv;
   const envs = env.split(',');
-  if (envs.includes('amp')) {
+  if (!build && envs.includes('amp')) {
     await runAmpDevBuildServer();
   }
   installPackages(__dirname);
-  createCtrlcHandler('storybook');
-  return Promise.all(envs.map(launchEnv));
+  const ctrlcHandler = createCtrlcHandler('storybook');
+  return Promise.all(envs.map(build ? buildEnv : launchEnv)).then(() => {
+    if (build) {
+      exitCtrlcHandler(ctrlcHandler);
+    }
+  });
 }
 
 module.exports = {
@@ -67,6 +99,8 @@ module.exports = {
 storybook.description = 'Isolated testing and development for AMP components.';
 
 storybook.flags = {
+  'build':
+    '  Builds a static web application, as described in https://storybook.js.org/docs/react/workflows/publish-storybook',
   'storybook_env':
     "  Set environment(s) to run Storybook, either 'amp', 'preact' or a list as 'amp,preact'",
   'storybook_port': '  Set port from which to run the Storybook dashboard.',

--- a/build-system/tasks/storybook/index.js
+++ b/build-system/tasks/storybook/index.js
@@ -16,10 +16,7 @@
 'use strict';
 
 const argv = require('minimist')(process.argv.slice(2));
-const {
-  createCtrlcHandler,
-  exitCtrlcHandler,
-} = require('../../common/ctrlcHandler');
+const {createCtrlcHandler} = require('../../common/ctrlcHandler');
 const {defaultTask: runAmpDevBuildServer} = require('../default-task');
 const {execScriptAsync} = require('../../common/exec');
 const {installPackages} = require('../../common/utils');
@@ -84,11 +81,10 @@ async function storybook() {
     await runAmpDevBuildServer();
   }
   installPackages(__dirname);
-  const ctrlcHandler = createCtrlcHandler('storybook');
-  await Promise.all(envs.map(build ? buildEnv : launchEnv));
-  if (build) {
-    exitCtrlcHandler(ctrlcHandler);
+  if (!build) {
+    createCtrlcHandler('storybook');
   }
+  return Promise.all(envs.map(build ? buildEnv : launchEnv));
 }
 
 module.exports = {

--- a/build-system/tasks/storybook/preact-env/main.js
+++ b/build-system/tasks/storybook/preact-env/main.js
@@ -24,4 +24,9 @@ module.exports = {
     '@storybook/addon-viewport/register',
     '@storybook/addon-knobs/register',
   ],
+  webpackFinal: async (config) => {
+    // Disable entry point size warnings.
+    config.performance.hints = false;
+    return config;
+  },
 };

--- a/extensions/amp-video/1.0/video-wrapper.js
+++ b/extensions/amp-video/1.0/video-wrapper.js
@@ -203,7 +203,6 @@ function VideoWrapperWithRef(
         onPlaying={() => setPlaying(true)}
         onPause={() => setPlaying(false)}
         style={fillStretch}
-        data-test-change
       >
         {sources}
       </Component>

--- a/extensions/amp-video/1.0/video-wrapper.js
+++ b/extensions/amp-video/1.0/video-wrapper.js
@@ -203,6 +203,7 @@ function VideoWrapperWithRef(
         onPlaying={() => setPlaying(true)}
         onPause={() => setPlaying(false)}
         style={fillStretch}
+        data-test-change
       >
         {sources}
       </Component>


### PR DESCRIPTION
Publish a [static Storybook](https://storybook.js.org/docs/react/workflows/publish-storybook) alongside public directories consumed by the PR deploy bot. This allows reviewers to live-test Bento/Preact components as we go along.

## This change

1) Provides `gulp storybook --build`.
    (This only works for `preact` mode for now.)

2) Runs Storybook build task as part of CI.
    By putting the generated files inside `examples/`, the deploy bot already [picks them up.](https://storage.googleapis.com/amp-test-website-1/amp_dist_82967/examples/storybook/preact/index.html)
    (This takes [about one minute on Travis.](https://travis-ci.com/github/ampproject/amphtml/jobs/422916229#L850))

## Later

3) Add support for `amp` mode by referencing the same binaries as created with `gulp dist`.
     `@ampproject/storybook-addon` needs to take a custom binary URL prefix, like
     `https://storage.googleapis.com/amp-test-website-1/amp_dist_000000/`