### PR TITLE
resources: relayoutAll should invalidate premeasurements

### DIFF
--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -458,6 +458,11 @@ export class Resource {
     this.premeasuredRect_ = clientRect;
   }
 
+  /** Removes the premeasured rect, likely forcing a manual measure. */
+  invalidatePremeasurement() {
+    this.premeasuredRect_ = null;
+  }
+
   /**
    * Measures the resource's boundaries. An upgraded element will be
    * transitioned to the "ready for layout" state.

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -256,7 +256,6 @@ export class ResourcesImpl {
     // When user scrolling stops, run pass to check newly in-viewport elements.
     // When viewport is resized, we have to re-measure everything.
     this.viewport_.onChanged((event) => {
-      console.error('EVNET FIRED')
       this.lastScrollTime_ = Date.now();
       this.lastVelocity_ = event.velocity;
       if (event.relayoutAll) {

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -256,6 +256,7 @@ export class ResourcesImpl {
     // When user scrolling stops, run pass to check newly in-viewport elements.
     // When viewport is resized, we have to re-measure everything.
     this.viewport_.onChanged((event) => {
+      console.error('EVNET FIRED')
       this.lastScrollTime_ = Date.now();
       this.lastVelocity_ = event.velocity;
       if (event.relayoutAll) {

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -262,15 +262,16 @@ export class ResourcesImpl {
         this.relayoutAll_ = true;
         this.maybeChangeHeight_ = true;
       }
+
       // With IntersectionObserver, we only need to handle viewport resize.
       if (this.relayoutAll_ || !this.intersectionObserver_) {
-        // Unfortunately, a viewport size change invalidates all premeasurements.
-        if (this.intersectionObserver_) {
-          this.resources_.forEach((resource) =>
-            resource.invalidatePremeasurement()
-          );
-        }
         this.schedulePass();
+      }
+      // Unfortunately, a viewport size change invalidates all premeasurements.
+      if (this.relayoutAll_ && this.intersectionObserver_) {
+        this.resources_.forEach((resource) =>
+          resource.invalidatePremeasurement()
+        );
       }
     });
     this.viewport_.onScroll(() => {

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -264,6 +264,10 @@ export class ResourcesImpl {
       }
       // With IntersectionObserver, we only need to handle viewport resize.
       if (this.relayoutAll_ || !this.intersectionObserver_) {
+        // Unfortunately, a viewport size change invalidates all premeasurements.
+        if (this.intersectionObserver_) {
+          this.resources_.forEach((r) => r.invalidatePremeasurement());
+        }
         this.schedulePass();
       }
     });

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -266,7 +266,9 @@ export class ResourcesImpl {
       if (this.relayoutAll_ || !this.intersectionObserver_) {
         // Unfortunately, a viewport size change invalidates all premeasurements.
         if (this.intersectionObserver_) {
-          this.resources_.forEach((r) => r.invalidatePremeasurement());
+          this.resources_.forEach((resource) =>
+            resource.invalidatePremeasurement()
+          );
         }
         this.schedulePass();
       }

--- a/src/web-worker/amp-worker.js
+++ b/src/web-worker/amp-worker.js
@@ -85,8 +85,6 @@ class AmpWorker {
     const useLocal = getMode().localDev || getMode().test;
     const useRtvVersion = !useLocal;
 
-    // TODO: remove when done testing.
-    // to test, locally switch the url to: "http://localhost:8000/dist/ww.max.js"
     const url = calculateEntryPointScriptUrl(
       loc,
       'ww',

--- a/src/web-worker/amp-worker.js
+++ b/src/web-worker/amp-worker.js
@@ -84,7 +84,6 @@ class AmpWorker {
     // Use RTV to make sure we fetch prod/canary/experiment correctly.
     const useLocal = getMode().localDev || getMode().test;
     const useRtvVersion = !useLocal;
-
     const url = calculateEntryPointScriptUrl(
       loc,
       'ww',

--- a/src/web-worker/amp-worker.js
+++ b/src/web-worker/amp-worker.js
@@ -84,6 +84,9 @@ class AmpWorker {
     // Use RTV to make sure we fetch prod/canary/experiment correctly.
     const useLocal = getMode().localDev || getMode().test;
     const useRtvVersion = !useLocal;
+
+    // TODO: remove when done testing.
+    // to test, locally switch the url to: "http://localhost:8000/dist/ww.max.js"
     const url = calculateEntryPointScriptUrl(
       loc,
       'ww',

--- a/test/unit/test-resources.js
+++ b/test/unit/test-resources.js
@@ -775,7 +775,7 @@ describes.realWin('Resources discoverWork', {amp: true}, (env) => {
       expect(resource2.applySizesAndMediaQuery).to.not.be.called;
     });
 
-    it.only('should invalidate premeasurements after resize event', () => {
+    it('should invalidate premeasurements after resize event', () => {
       resource1.premeasure({});
       expect(resource1.hasBeenPremeasured()).true;
       resources.viewport_.changeObservable_.fire({relayoutAll_: true});

--- a/test/unit/test-resources.js
+++ b/test/unit/test-resources.js
@@ -775,6 +775,13 @@ describes.realWin('Resources discoverWork', {amp: true}, (env) => {
       expect(resource2.applySizesAndMediaQuery).to.not.be.called;
     });
 
+    it.only('should invalidate premeasurements after resize event', () => {
+      resource1.premeasure({});
+      expect(resource1.hasBeenPremeasured()).true;
+      resources.viewport_.changeObservable_.fire({relayoutAll_: true});
+      expect(resource1.hasBeenPremeasured()).false;
+    });
+
     it('should applySizesAndMediaQuery on relayout', () => {
       resources.relayoutAll_ = true;
 


### PR DESCRIPTION
**summary**
Context: `b/170538870`, `b/169596105`, and maybe but unlikely this one as well `b/150231440`.

If the viewport size changes after an InOb premeasurement, then we need to invalidate the premeasurement as a viewport size change is likely to change the size of elements. This is especially true for elements that expand to the space given (e.g. fixed in only one dimension, or layout=container).

---

_bigger picture_: I didn't do an exhaustive check of whether there are more events which should invalidate a premeasure. two ways we could design the architecture to be more resilient are:
1. don't have a delay between when measurement is taken and applied. this is done today so that the diff between experiement on and off is reduced. after removing the experiment we can work to remove this racy time window
2. stop relying on our measurements for determining whether to layout. only rely on intersects + ! display:none