### PR TITLE
Match docs for pageViewId64

### DIFF
--- a/extensions/amp-analytics/0.1/default-config.js
+++ b/extensions/amp-analytics/0.1/default-config.js
@@ -63,6 +63,7 @@ const defaultConfig = jsonConfiguration({
     'pageDownloadTime': 'PAGE_DOWNLOAD_TIME',
     'pageLoadTime': 'PAGE_LOAD_TIME',
     'pageViewId': 'PAGE_VIEW_ID',
+    'pageViewId64': 'PAGE_VIEW_ID_64',
     'queryParam': 'QUERY_PARAM',
     'random': 'RANDOM',
     'redirectTime': 'REDIRECT_TIME',


### PR DESCRIPTION
🐛 Bug fix

`${pageViewId64}` should be a default variable for `PAGE_VIEW_ID_64`, as per the docs:

https://github.com/ampproject/amphtml/blob/master/spec/amp-var-substitutions.md#page-view-id-64

In November 2019, adding this to the default variables was mentioned by @lannka: https://github.com/ampproject/amphtml/issues/25794#issuecomment-559280932
