### PR TITLE
📖 Update amp-analytics docs on async variable substitution/ CWV metrics

### DIFF
--- a/extensions/amp-analytics/amp-analytics.md
+++ b/extensions/amp-analytics/amp-analytics.md
@@ -476,6 +476,13 @@ In addition, all of the variables supported by
 [AMP HTML Substitutions Guide](../../spec/amp-var-substitutions.md)
 are also supported.
 
+Variables are resolved asynchronously and delay the request until they are
+fulfilled. In the case of some metrics, such as Cumulative Layout Shift and
+Largest Contentful Paint, this is after the page is hidden. For First
+Input Delay, this is after the user interacts with the page. For this reason
+these metrics might not be suitable for use with all triggers (for example,
+on timer or visible).
+
 The `vars` configuration object can be used to define new key-value pairs or
 override existing variables that can be referenced in `request` values. New
 variables are commonly used to specify publisher specific information. Arrays


### PR DESCRIPTION
Addresses https://github.com/ampproject/amphtml/issues/30940 by improving documentation on variables being fulfilled asynchronously, highlighting that this affects CWV metrics and warning against using them with "timer" trigger. 
