### PR TITLE
🚮  Remove build-in-chunks experiment

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -35,7 +35,6 @@
   "amp-ad-no-center-css": 0,
   "analytics-chunks": 1,
   "render-on-idle-fix": 1,
-  "build-in-chunks": 1,
   "visibility-trigger-improvements": 1,
   "adsense-ptt-exp": 0.02,
   "doubleclick-ptt-exp": 0.02


### PR DESCRIPTION
This experiment allowed the initial building of elements to be spread out across multiple passes, which we hoped would improve FID at the expense of LCP, but it didn't make a difference. 
