### PR TITLE
✨ Add GDPR consent string to Future PLC vendor

### DIFF
--- a/src/service/real-time-config/callout-vendors.js
+++ b/src/service/real-time-config/callout-vendors.js
@@ -122,8 +122,9 @@ const RTC_VENDORS = jsonConfiguration({
     disableKeyAppend: true,
   },
   future: {
-    url: 'https://ads.servebom.com/amp?adunit=ADUNIT',
-    macros: ['ADUNIT'],
+    url:
+      'https://ads.servebom.com/amp?adunit=ADUNIT&gdpr_consent=CONSENT_STRING',
+    macros: ['ADUNIT', 'CONSENT_STRING'],
     disableKeyAppend: true,
   },
   glxm: {


### PR DESCRIPTION
We want to try using an IAB CMP for GDPR consent, which means we need to pass GDPR consent to our AdServer.