### PR TITLE
discussion: can we remove the isInViewport check from isLayoutAllowed

### DIFF
--- a/src/service/owners-impl.js
+++ b/src/service/owners-impl.js
@@ -126,8 +126,7 @@ export class OwnersImpl {
             this.resources_.scheduleLayoutOrPreload(
               resource,
               /* layout */ true,
-              opt_parentPriority,
-              /* forceOutsideViewport */ true
+              opt_parentPriority
             );
             return resource.loadedOnce();
           })

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -1718,16 +1718,6 @@ export class ResourcesImpl {
       }
     }
 
-    // The element has to be in its rendering corridor.
-    if (
-      !forceOutsideViewport &&
-      !resource.isInViewport() &&
-      !resource.renderOutsideViewport() &&
-      !resource.idleRenderOutsideViewport()
-    ) {
-      return false;
-    }
-
     return true;
   }
 

--- a/src/service/resources-interface.js
+++ b/src/service/resources-interface.js
@@ -109,15 +109,9 @@ export class ResourcesInterface {
    * @param {!./resource.Resource} resource
    * @param {boolean} layout
    * @param {number=} opt_parentPriority
-   * @param {boolean=} opt_forceOutsideViewport
    * @package
    */
-  scheduleLayoutOrPreload(
-    resource,
-    layout,
-    opt_parentPriority,
-    opt_forceOutsideViewport
-  ) {}
+  scheduleLayoutOrPreload(resource, layout, opt_parentPriority) {}
 
   /**
    * Schedules the work pass at the latest with the specified delay.

--- a/src/service/task-queue.js
+++ b/src/service/task-queue.js
@@ -22,7 +22,6 @@ import {devAssert} from '../log';
  *   id: string,
  *   resource: !./resource.Resource,
  *   priority: number,
- *   forceOutsideViewport: boolean,
  *   callback: function(),
  *   scheduleTime: time,
  *   startTime: time,


### PR DESCRIPTION
**summary**
We have a function within `resources-impl` that is called numerous times along the way of the resource layout process: `isLayoutAllowed`. It runs through a few checks like: is the element built, are we in prerender and the elem can't be prerendered, and finally: is it in viewport.

https://github.com/ampproject/amphtml/blob/f479ea6d8e7ce704ac59aca8b08bd25e978fcc7f/src/service/resources-impl.js#L1701-L1732


I've had a couple observations about this function, and particuarly the "in viewport" subcheck, that cause me to be suspicious of it:
1. Shouldn't we only call this func once? immediately before scheduling layout as opposed to multiple times. Which invariants do we expect to change in the timespan between schedule and layout? My impression is that this is currently overly protective.
2. The `isInViewport` check looks for if the resource is in the viewportRect as opposed to what you would expect it to be synced up with, the `loadRect` (3x viewport). This means we call schedule for `inLoadRect` but bail out until `inViewportRect`. What is the actual ideal behavior here? I'm slightly concerned that if I remove this check, we could cause a pretty significant shift in (likely accidental) behavior

**why this matters right now**
As part of https://github.com/ampproject/amphtml/issues/30620, I'm attempting to remove this dependency on `resources.isInViewport()`. 

**perf tests on my laptop**
file: examples/runtime/images.html
setup: mac laptop, 6x slowdown, 5 runs. 

LCPs master: 3728, 3483, 3638, 3714, 3739. Avg: 3660
LCPs this branch: 3788, 3436, 3736, 3690,3598. Avg: 3649

Conclusion: for this specific page and with my specific setup: I wasn't able to detect a perf difference.