### PR TITLE
✨ [bento][amp-accordion] Fire events on amp-accordion expand and collapse (2nd version)

### DIFF
--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -1343,7 +1343,8 @@ function hasAnyTerms(file) {
   const isTestFile =
     /^test-/.test(basename) ||
     /^_init_tests/.test(basename) ||
-    /_test\.js$/.test(basename);
+    /_test\.js$/.test(basename) ||
+    /storybook\/[^/]+\.js$/.test(pathname);
   if (!isTestFile) {
     hasSrcInclusiveTerms = matchTerms(file, forbiddenTermsSrcInclusive);
   }

--- a/extensions/amp-accordion/1.0/accordion.js
+++ b/extensions/amp-accordion/1.0/accordion.js
@@ -61,7 +61,7 @@ function AccordionWithRef(
   ref
 ) {
   const [expandedMap, setExpandedMap] = useState(EMPTY_EXPANDED_MAP);
-  const eventMap = useRef({});
+  const eventMap = useRef(/** @type {!Object} */ ({}));
   const [randomPrefix] = useState(generateRandomId);
   const prefix = id || `a${randomPrefix}`;
 
@@ -274,7 +274,9 @@ export function AccordionSection({
     return () => (hasMountedRef.current = false);
   }, []);
 
-  const sectionPropsRef = useRef();
+  const sectionPropsRef = useRef(
+    /** @type {?AccordionDef.SectionPropsRef} */ (null)
+  );
   sectionPropsRef.current = {onExpandStateChange};
   useLayoutEffect(() => {
     if (registerSection) {

--- a/extensions/amp-accordion/1.0/accordion.type.js
+++ b/extensions/amp-accordion/1.0/accordion.type.js
@@ -40,6 +40,8 @@ AccordionDef.Props;
  *   contentClassName: (string|undefined),
  *   header: (!PreactDef.Renderable),
  *   children: (?PreactDef.Renderable|undefined),
+ *   onExpand: (function():undefined|undefined),
+ *   onCollapse: (function():undefined|undefined),
  * }}
  */
 AccordionDef.SectionProps;

--- a/extensions/amp-accordion/1.0/accordion.type.js
+++ b/extensions/amp-accordion/1.0/accordion.type.js
@@ -40,11 +40,17 @@ AccordionDef.Props;
  *   contentClassName: (string|undefined),
  *   header: (!PreactDef.Renderable),
  *   children: (?PreactDef.Renderable|undefined),
- *   onExpand: (function():undefined|undefined),
- *   onCollapse: (function():undefined|undefined),
+ *   onExpandStateChange: (function(boolean):undefined|undefined),
  * }}
  */
 AccordionDef.SectionProps;
+
+/**
+ * @typedef {{
+ *   onExpandStateChange: (function(boolean):undefined|undefined),
+ * }}
+ */
+AccordionDef.SectionPropsRef;
 
 /**
  * @typedef {{

--- a/extensions/amp-accordion/1.0/accordion.type.js
+++ b/extensions/amp-accordion/1.0/accordion.type.js
@@ -47,13 +47,6 @@ AccordionDef.SectionProps;
 
 /**
  * @typedef {{
- *   onExpandStateChange: (function(boolean):undefined|undefined),
- * }}
- */
-AccordionDef.SectionPropsRef;
-
-/**
- * @typedef {{
  *   role: (string|undefined),
  *   onClick: (function()|undefined),
  *   children: (?PreactDef.Renderable|undefined),

--- a/extensions/amp-accordion/1.0/amp-accordion.js
+++ b/extensions/amp-accordion/1.0/amp-accordion.js
@@ -105,7 +105,7 @@ function getState(element, mu) {
     const expandStateShim = memo(
       section,
       EXPAND_STATE_SHIM_PROP,
-      getExpandStateTrigger.bind(null, element, ActionTrust.HIGH)
+      getExpandStateTrigger
     );
     const props = dict({
       'key': section,
@@ -122,13 +122,14 @@ function getState(element, mu) {
 }
 
 /**
- * @param {!Element} element
- * @param {!ActionTrust} trust
  * @param {!Element} section
  * @return {Function}
  */
-function getExpandStateTrigger(element, trust, section) {
-  const action = Services.actionServiceForDoc(element);
+function getExpandStateTrigger(section) {
+  const element = section.parentElement;
+  const action = Services.actionServiceForDoc(
+    /** @type {!Element|!ShadowRoot} */ (element)
+  );
   const triggerEvent = (expanded) => {
     const eventName = expanded ? 'expand' : 'collapse';
     const event = createCustomEvent(
@@ -136,7 +137,7 @@ function getExpandStateTrigger(element, trust, section) {
       `accordionSection.${eventName}`,
       dict({})
     );
-    action.trigger(section, eventName, event, trust);
+    action.trigger(section, eventName, event, ActionTrust.HIGH);
     element.dispatchCustomEvent(name);
   };
   return triggerEvent;

--- a/extensions/amp-accordion/1.0/amp-accordion.js
+++ b/extensions/amp-accordion/1.0/amp-accordion.js
@@ -135,7 +135,7 @@ function getExpandStateTrigger(section) {
     const event = createCustomEvent(
       toWin(element.ownerDocument.defaultView),
       `accordionSection.${eventName}`,
-      dict({})
+      dict()
     );
     action.trigger(section, eventName, event, ActionTrust.HIGH);
     element.dispatchCustomEvent(name);

--- a/extensions/amp-accordion/1.0/amp-accordion.js
+++ b/extensions/amp-accordion/1.0/amp-accordion.js
@@ -131,7 +131,7 @@ function getState(element, mu) {
       'expanded': expanded,
       'id': section.getAttribute('id'),
       'onExpand': getTrigger(element, 'expand', section, ActionTrust.HIGH),
-      'onCollapse': getTrigger(element, 'collpase', section, ActionTrust.HIGH),
+      'onCollapse': getTrigger(element, 'collapse', section, ActionTrust.HIGH),
     });
     return <AccordionSection {...props} />;
   });

--- a/extensions/amp-accordion/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-accordion/1.0/storybook/Basic.amp.js
@@ -109,6 +109,7 @@ export const events = () => {
         <button on={createApiString('collapse', 'section3')}>
           collapse(section3)
         </button>
+        <button on={createApiString('toggle')}>toggle all</button>
       </div>
     </main>
   );

--- a/extensions/amp-accordion/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-accordion/1.0/storybook/Basic.amp.js
@@ -32,8 +32,8 @@ export default {
 export const _default = () => {
   const expandSingleSection = boolean('expandSingleSection', false);
   const animate = boolean('animate', false);
-  const createApiString = (action, section) =>
-    `tap:accordion.${action}(${section ? `section='${section}'` : ''})`;
+  const createApiString = (on, action, section) =>
+    `${on}:accordion.${action}(${section ? `section='${section}'` : ''})`;
   return (
     <main>
       <amp-accordion
@@ -56,18 +56,18 @@ export const _default = () => {
       </amp-accordion>
 
       <div class="buttons" style={{marginTop: 8}}>
-        <button on={createApiString('toggle', 'section1')}>
+        <button on={createApiString('tap', 'toggle', 'section1')}>
           toggle(section1)
         </button>
-        <button on={createApiString('toggle')}>toggle all</button>
-        <button on={createApiString('expand', 'section1')}>
+        <button on={createApiString('tap', 'toggle')}>toggle all</button>
+        <button on={createApiString('tap', 'expand', 'section1')}>
           expand(section1)
         </button>
-        <button on={createApiString('expand')}>expand all</button>
-        <button on={createApiString('collapse', 'section1')}>
+        <button on={createApiString('tap', 'expand')}>expand all</button>
+        <button on={createApiString('tap', 'collapse', 'section1')}>
           collapse(section1)
         </button>
-        <button on={createApiString('collapse')}>collapse all</button>
+        <button on={createApiString('tap', 'collapse')}>collapse all</button>
       </div>
     </main>
   );
@@ -76,8 +76,8 @@ export const _default = () => {
 export const events = () => {
   const expandSingleSection = boolean('expandSingleSection', false);
   const animate = boolean('animate', false);
-  const createApiString = (action, section) =>
-    `tap:accordion.${action}(${section ? `section='${section}'` : ''})`;
+  const createApiString = (on, action, section) =>
+    `${on}:accordion.${action}(${section ? `section='${section}'` : ''})`;
   return (
     <main>
       <amp-accordion
@@ -89,13 +89,16 @@ export const events = () => {
           <h2>Section 1</h2>
           <p>Content in section 1.</p>
         </section>
-        <section id="section2" on="expand:accordion.expand(section='section3')">
+        <section
+          id="section2"
+          on={createApiString('expand', 'expand', 'section3')}
+        >
           <h2>Section 2</h2>
           <div>Content in section 2.</div>
         </section>
         <section
           id="section3"
-          on="collapse:accordion.collapse(section='section2')"
+          on={createApiString('collapse', 'collapse', 'section2')}
         >
           <h2>Section 3</h2>
           <div>Content in section 3.</div>
@@ -103,13 +106,13 @@ export const events = () => {
       </amp-accordion>
 
       <div class="buttons" style={{marginTop: 8}}>
-        <button on={createApiString('expand', 'section2')}>
+        <button on={createApiString('tap', 'expand', 'section2')}>
           expand(section2)
         </button>
-        <button on={createApiString('collapse', 'section3')}>
+        <button on={createApiString('tap', 'collapse', 'section3')}>
           collapse(section3)
         </button>
-        <button on={createApiString('toggle')}>toggle all</button>
+        <button on={createApiString('tap', 'toggle')}>toggle all</button>
       </div>
     </main>
   );

--- a/extensions/amp-accordion/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-accordion/1.0/storybook/Basic.amp.js
@@ -72,3 +72,44 @@ export const _default = () => {
     </main>
   );
 };
+
+export const events = () => {
+  const expandSingleSection = boolean('expandSingleSection', false);
+  const animate = boolean('animate', false);
+  const createApiString = (action, section) =>
+    `tap:accordion.${action}(${section ? `section='${section}'` : ''})`;
+  return (
+    <main>
+      <amp-accordion
+        id="accordion"
+        expand-single-section={expandSingleSection}
+        animate={animate}
+      >
+        <section id="section1">
+          <h2>Section 1</h2>
+          <p>Content in section 1.</p>
+        </section>
+        <section id="section2" on="expand:accordion.expand(section='section3')">
+          <h2>Section 2</h2>
+          <div>Content in section 2.</div>
+        </section>
+        <section
+          id="section3"
+          on="collapse:accordion.collapse(section='section2')"
+        >
+          <h2>Section 3</h2>
+          <div>Content in section 3.</div>
+        </section>
+      </amp-accordion>
+
+      <div class="buttons" style={{marginTop: 8}}>
+        <button on={createApiString('expand', 'section2')}>
+          expand(section2)
+        </button>
+        <button on={createApiString('collapse', 'section3')}>
+          collapse(section3)
+        </button>
+      </div>
+    </main>
+  );
+};

--- a/extensions/amp-accordion/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-accordion/1.0/storybook/Basic.amp.js
@@ -54,18 +54,18 @@ export const _default = () => {
       </amp-accordion>
 
       <div class="buttons" style={{marginTop: 8}}>
-        <button on={"tap:accordion.toggle(section='section1')"}>
+        <button on="tap:accordion.toggle(section='section1')">
           toggle(section1)
         </button>
-        <button on={'tap:accordion.toggle()'}>toggle all</button>
-        <button on={"tap:accordion.expand(section='section1')"}>
+        <button on="tap:accordion.toggle()">toggle all</button>
+        <button on="tap:accordion.expand(section='section1')">
           expand(section1)
         </button>
-        <button on={'tap:accordion.expand()'}>expand all</button>
-        <button on={"tap:accordion.collapse(section='section1')"}>
+        <button on="tap:accordion.expand()">expand all</button>
+        <button on="tap:accordion.collapse(section='section1')">
           collapse(section1)
         </button>
-        <button on={'tap:accordion.collapse()'}>collapse all</button>
+        <button on="tap:accordion.collapse()">collapse all</button>
       </div>
     </main>
   );
@@ -85,16 +85,13 @@ export const events = () => {
           <h2>Section 1</h2>
           <p>Content in section 1.</p>
         </section>
-        <section
-          id="section2"
-          on={"expand:accordion.expand(section='section3')"}
-        >
+        <section id="section2" on="expand:accordion.expand(section='section3')">
           <h2>Section 2</h2>
           <div>Content in section 2.</div>
         </section>
         <section
           id="section3"
-          on={"collapse:accordion.collapse(section='section2')"}
+          on="collapse:accordion.collapse(section='section2')"
         >
           <h2>Section 3</h2>
           <div>Content in section 3.</div>
@@ -102,13 +99,13 @@ export const events = () => {
       </amp-accordion>
 
       <div class="buttons" style={{marginTop: 8}}>
-        <button on={"tap:accordion.expand(section='section2')"}>
+        <button on="tap:accordion.expand(section='section2')">
           expand(section2)
         </button>
-        <button on={"tap:accordion.collapse(section='section3')"}>
+        <button on="tap:accordion.collapse(section='section3')">
           collapse(section3)
         </button>
-        <button on={'tap:accordion.toggle()'}>toggle all</button>
+        <button on="tap:accordion.toggle()">toggle all</button>
       </div>
     </main>
   );

--- a/extensions/amp-accordion/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-accordion/1.0/storybook/Basic.amp.js
@@ -32,8 +32,6 @@ export default {
 export const _default = () => {
   const expandSingleSection = boolean('expandSingleSection', false);
   const animate = boolean('animate', false);
-  const createApiString = (on, action, section) =>
-    `${on}:accordion.${action}(${section ? `section='${section}'` : ''})`;
   return (
     <main>
       <amp-accordion
@@ -56,18 +54,18 @@ export const _default = () => {
       </amp-accordion>
 
       <div class="buttons" style={{marginTop: 8}}>
-        <button on={createApiString('tap', 'toggle', 'section1')}>
+        <button on={"tap:accordion.toggle(section='section1')"}>
           toggle(section1)
         </button>
-        <button on={createApiString('tap', 'toggle')}>toggle all</button>
-        <button on={createApiString('tap', 'expand', 'section1')}>
+        <button on={'tap:accordion.toggle()'}>toggle all</button>
+        <button on={"tap:accordion.expand(section='section1')"}>
           expand(section1)
         </button>
-        <button on={createApiString('tap', 'expand')}>expand all</button>
-        <button on={createApiString('tap', 'collapse', 'section1')}>
+        <button on={'tap:accordion.expand()'}>expand all</button>
+        <button on={"tap:accordion.collapse(section='section1')"}>
           collapse(section1)
         </button>
-        <button on={createApiString('tap', 'collapse')}>collapse all</button>
+        <button on={'tap:accordion.collapse()'}>collapse all</button>
       </div>
     </main>
   );
@@ -76,8 +74,6 @@ export const _default = () => {
 export const events = () => {
   const expandSingleSection = boolean('expandSingleSection', false);
   const animate = boolean('animate', false);
-  const createApiString = (on, action, section) =>
-    `${on}:accordion.${action}(${section ? `section='${section}'` : ''})`;
   return (
     <main>
       <amp-accordion
@@ -91,14 +87,14 @@ export const events = () => {
         </section>
         <section
           id="section2"
-          on={createApiString('expand', 'expand', 'section3')}
+          on={"expand:accordion.expand(section='section3')"}
         >
           <h2>Section 2</h2>
           <div>Content in section 2.</div>
         </section>
         <section
           id="section3"
-          on={createApiString('collapse', 'collapse', 'section2')}
+          on={"collapse:accordion.collapse(section='section2')"}
         >
           <h2>Section 3</h2>
           <div>Content in section 3.</div>
@@ -106,13 +102,13 @@ export const events = () => {
       </amp-accordion>
 
       <div class="buttons" style={{marginTop: 8}}>
-        <button on={createApiString('tap', 'expand', 'section2')}>
+        <button on={"tap:accordion.expand(section='section2')"}>
           expand(section2)
         </button>
-        <button on={createApiString('tap', 'collapse', 'section3')}>
+        <button on={"tap:accordion.collapse(section='section3')"}>
           collapse(section3)
         </button>
-        <button on={createApiString('tap', 'toggle')}>toggle all</button>
+        <button on={'tap:accordion.toggle()'}>toggle all</button>
       </div>
     </main>
   );

--- a/extensions/amp-accordion/1.0/storybook/Basic.js
+++ b/extensions/amp-accordion/1.0/storybook/Basic.js
@@ -72,9 +72,70 @@ export const _default = () => {
           <div>Content in section 2.</div>
         </AccordionSection>
         <AccordionSection key={3} expanded header={<h2>Section 3</h2>}>
-          <div>Content in section 2.</div>
+          <div>Content in section 3.</div>
         </AccordionSection>
       </AccordionWithActions>
+    </main>
+  );
+};
+
+/**
+ * @param {!Object} props
+ * @return {*}
+ */
+function AccordionWithEvents(props) {
+  // TODO(#30447): replace imperative calls with "button" knobs when the
+  // Storybook 6.1 is released.
+  const ref = Preact.useRef();
+  return (
+    <section>
+      <Accordion ref={ref} {...props}>
+        <AccordionSection
+          id="section1"
+          key={1}
+          expanded
+          header={<h2>Section 1</h2>}
+        >
+          <p>Content in section 1.</p>
+        </AccordionSection>
+        <AccordionSection
+          id="section2"
+          key={2}
+          header={<h2>Section 2</h2>}
+          onExpand={() => ref.current./*OK*/ expand('section3')}
+        >
+          <div>Content in section 2.</div>
+        </AccordionSection>
+        <AccordionSection
+          id="section3"
+          key={3}
+          header={<h2>Section 3</h2>}
+          onCollapse={() => ref.current./*OK*/ collapse('section2')}
+        >
+          <div>Content in section 3.</div>
+        </AccordionSection>
+      </Accordion>
+      <div style={{marginTop: 8}}>
+        <button onClick={() => ref.current./*OK*/ expand('section2')}>
+          expand(section2)
+        </button>
+        <button onClick={() => ref.current./*OK*/ collapse('section3')}>
+          collapse(section3)
+        </button>
+      </div>
+    </section>
+  );
+}
+
+export const events = () => {
+  const expandSingleSection = boolean('expandSingleSection', false);
+  const animate = boolean('animate', false);
+  return (
+    <main>
+      <AccordionWithEvents
+        expandSingleSection={expandSingleSection}
+        animate={animate}
+      ></AccordionWithEvents>
     </main>
   );
 };

--- a/extensions/amp-accordion/1.0/storybook/Basic.js
+++ b/extensions/amp-accordion/1.0/storybook/Basic.js
@@ -130,6 +130,7 @@ function AccordionWithEvents(props) {
         <button onClick={() => ref.current./*OK*/ collapse('section3')}>
           collapse(section3)
         </button>
+        <button onClick={() => ref.current./*OK*/ toggle()}>toggle all</button>
       </div>
     </section>
   );

--- a/extensions/amp-accordion/1.0/storybook/Basic.js
+++ b/extensions/amp-accordion/1.0/storybook/Basic.js
@@ -102,7 +102,11 @@ function AccordionWithEvents(props) {
           id="section2"
           key={2}
           header={<h2>Section 2</h2>}
-          onExpand={() => ref.current./*OK*/ expand('section3')}
+          onExpandStateChange={(expanded) => {
+            if (expanded) {
+              ref.current./*OK*/ expand('section3');
+            }
+          }}
         >
           <div>Content in section 2.</div>
         </AccordionSection>
@@ -110,7 +114,11 @@ function AccordionWithEvents(props) {
           id="section3"
           key={3}
           header={<h2>Section 3</h2>}
-          onCollapse={() => ref.current./*OK*/ collapse('section2')}
+          onExpandStateChange={(expanded) => {
+            if (!expanded) {
+              ref.current./*OK*/ collapse('section2');
+            }
+          }}
         >
           <div>Content in section 3.</div>
         </AccordionSection>

--- a/extensions/amp-accordion/1.0/storybook/Basic.js
+++ b/extensions/amp-accordion/1.0/storybook/Basic.js
@@ -37,20 +37,18 @@ function AccordionWithActions(props) {
     <section>
       <Accordion ref={ref} {...props} />
       <div style={{marginTop: 8}}>
-        <button onClick={() => ref.current./*OK*/ toggle('section1')}>
+        <button onClick={() => ref.current.toggle('section1')}>
           toggle(section1)
         </button>
-        <button onClick={() => ref.current./*OK*/ toggle()}>toggle all</button>
-        <button onClick={() => ref.current./*OK*/ expand('section1')}>
+        <button onClick={() => ref.current.toggle()}>toggle all</button>
+        <button onClick={() => ref.current.expand('section1')}>
           expand(section1)
         </button>
-        <button onClick={() => ref.current./*OK*/ expand()}>expand all</button>
-        <button onClick={() => ref.current./*OK*/ collapse('section1')}>
+        <button onClick={() => ref.current.expand()}>expand all</button>
+        <button onClick={() => ref.current.collapse('section1')}>
           collapse(section1)
         </button>
-        <button onClick={() => ref.current./*OK*/ collapse()}>
-          collapse all
-        </button>
+        <button onClick={() => ref.current.collapse()}>collapse all</button>
       </div>
     </section>
   );
@@ -104,7 +102,7 @@ function AccordionWithEvents(props) {
           header={<h2>Section 2</h2>}
           onExpandStateChange={(expanded) => {
             if (expanded) {
-              ref.current./*OK*/ expand('section3');
+              ref.current.expand('section3');
             }
           }}
         >
@@ -116,7 +114,7 @@ function AccordionWithEvents(props) {
           header={<h2>Section 3</h2>}
           onExpandStateChange={(expanded) => {
             if (!expanded) {
-              ref.current./*OK*/ collapse('section2');
+              ref.current.collapse('section2');
             }
           }}
         >
@@ -124,13 +122,13 @@ function AccordionWithEvents(props) {
         </AccordionSection>
       </Accordion>
       <div style={{marginTop: 8}}>
-        <button onClick={() => ref.current./*OK*/ expand('section2')}>
+        <button onClick={() => ref.current.expand('section2')}>
           expand(section2)
         </button>
-        <button onClick={() => ref.current./*OK*/ collapse('section3')}>
+        <button onClick={() => ref.current.collapse('section3')}>
           collapse(section3)
         </button>
-        <button onClick={() => ref.current./*OK*/ toggle()}>toggle all</button>
+        <button onClick={() => ref.current.toggle()}>toggle all</button>
       </div>
     </section>
   );

--- a/extensions/amp-accordion/1.0/test/test-accordion.js
+++ b/extensions/amp-accordion/1.0/test/test-accordion.js
@@ -17,6 +17,7 @@
 import * as Preact from '../../../../src/preact';
 import {Accordion, AccordionSection} from '../accordion';
 import {mount} from 'enzyme';
+import {waitFor} from '../../../../testing/test-helper';
 
 describes.sandboxed('Accordion preact component', {}, (env) => {
   describe('standalone accordion section', () => {
@@ -492,21 +493,37 @@ describes.sandboxed('Accordion preact component', {}, (env) => {
 
       // Expand
       sections.at(1).find('header').simulate('click');
+      await waitFor(
+        () => onExpandStateChange.callCount == 1,
+        'event callback called'
+      );
       expect(onExpandStateChange.callCount).to.equal(1);
       expect(onExpandStateChange.args[0][0]).to.be.true;
 
       // Collapse
       sections.at(1).find('header').simulate('click');
+      await waitFor(
+        () => onExpandStateChange.callCount == 2,
+        'event callback called'
+      );
       expect(onExpandStateChange.callCount).to.equal(2);
       expect(onExpandStateChange.args[1][0]).to.be.false;
 
       // Expand
       sections.at(1).find('header').simulate('click');
+      await waitFor(
+        () => onExpandStateChange.callCount == 3,
+        'event callback called'
+      );
       expect(onExpandStateChange.callCount).to.equal(3);
       expect(onExpandStateChange.args[2][0]).to.be.true;
 
       // Collapse
       sections.at(1).find('header').simulate('click');
+      await waitFor(
+        () => onExpandStateChange.callCount == 4,
+        'event callback called'
+      );
       expect(onExpandStateChange.callCount).to.equal(4);
       expect(onExpandStateChange.args[3][0]).to.be.false;
     });
@@ -515,24 +532,40 @@ describes.sandboxed('Accordion preact component', {}, (env) => {
       // Expand All
       ref.current.toggle();
       wrapper.update();
+      await waitFor(
+        () => onExpandStateChange.callCount == 1,
+        'event callback called'
+      );
       expect(onExpandStateChange.callCount).to.equal(1);
       expect(onExpandStateChange.args[0][0]).to.be.true;
 
       // Collapse All
       ref.current.collapse();
       wrapper.update();
+      await waitFor(
+        () => onExpandStateChange.callCount == 2,
+        'event callback called'
+      );
       expect(onExpandStateChange.callCount).to.equal(2);
       expect(onExpandStateChange.args[1][0]).to.be.false;
 
       // Collapsing an already collapsed section should do nothing
       ref.current.collapse('section2');
       wrapper.update();
+      await waitFor(
+        () => onExpandStateChange.callCount == 2,
+        'event callback called'
+      );
       expect(onExpandStateChange.callCount).to.equal(2);
       expect(onExpandStateChange.args[1][0]).to.be.false;
 
       // Expand All
       ref.current.expand();
       wrapper.update();
+      await waitFor(
+        () => onExpandStateChange.callCount == 3,
+        'event callback called'
+      );
       expect(onExpandStateChange.callCount).to.equal(3);
       expect(onExpandStateChange.args[2][0]).to.be.true;
     });

--- a/extensions/amp-accordion/1.0/test/test-accordion.js
+++ b/extensions/amp-accordion/1.0/test/test-accordion.js
@@ -460,12 +460,10 @@ describes.sandboxed('Accordion preact component', {}, (env) => {
   describe('fire events on expand and collapse', () => {
     let wrapper;
     let ref;
-    let onExpand;
-    let onCollapse;
+    let onExpandStateChange;
 
     beforeEach(() => {
-      onExpand = env.sandbox.spy();
-      onCollapse = env.sandbox.spy();
+      onExpandStateChange = env.sandbox.spy();
       ref = Preact.useRef();
 
       wrapper = mount(
@@ -477,8 +475,7 @@ describes.sandboxed('Accordion preact component', {}, (env) => {
             key={2}
             id="section2"
             header="header2"
-            onExpand={onExpand}
-            onCollapse={onCollapse}
+            onExpandStateChange={onExpandStateChange}
           >
             content2
           </AccordionSection>
@@ -495,49 +492,49 @@ describes.sandboxed('Accordion preact component', {}, (env) => {
 
       // Expand
       sections.at(1).find('header').simulate('click');
-      expect(onExpand).to.be.calledOnce;
-      expect(onCollapse).not.to.be.called;
+      expect(onExpandStateChange.callCount).to.equal(1);
+      expect(onExpandStateChange.args[0][0]).to.be.true;
 
       // Collapse
       sections.at(1).find('header').simulate('click');
-      expect(onExpand).to.be.calledOnce;
-      expect(onCollapse).to.be.calledOnce;
+      expect(onExpandStateChange.callCount).to.equal(2);
+      expect(onExpandStateChange.args[1][0]).to.be.false;
 
       // Expand
       sections.at(1).find('header').simulate('click');
-      expect(onExpand).to.be.calledTwice;
-      expect(onCollapse).to.be.calledOnce;
+      expect(onExpandStateChange.callCount).to.equal(3);
+      expect(onExpandStateChange.args[2][0]).to.be.true;
 
       // Collapse
       sections.at(1).find('header').simulate('click');
-      expect(onExpand).to.be.calledTwice;
-      expect(onCollapse).to.be.calledTwice;
+      expect(onExpandStateChange.callCount).to.equal(4);
+      expect(onExpandStateChange.args[3][0]).to.be.false;
     });
 
     it('should fire events on API toggle', async () => {
       // Expand All
       ref.current.toggle();
       wrapper.update();
-      expect(onExpand).to.be.calledOnce;
-      expect(onCollapse).not.to.be.called;
+      expect(onExpandStateChange.callCount).to.equal(1);
+      expect(onExpandStateChange.args[0][0]).to.be.true;
 
       // Collapse All
       ref.current.collapse();
       wrapper.update();
-      expect(onExpand).to.be.calledOnce;
-      expect(onCollapse).to.be.calledOnce;
+      expect(onExpandStateChange.callCount).to.equal(2);
+      expect(onExpandStateChange.args[1][0]).to.be.false;
 
       // Collapsing an already collapsed section should do nothing
       ref.current.collapse('section2');
       wrapper.update();
-      expect(onExpand).to.be.calledOnce;
-      expect(onCollapse).to.be.calledOnce;
+      expect(onExpandStateChange.callCount).to.equal(2);
+      expect(onExpandStateChange.args[1][0]).to.be.false;
 
       // Expand All
       ref.current.expand();
       wrapper.update();
-      expect(onExpand).to.be.calledTwice;
-      expect(onCollapse).to.be.calledOnce;
+      expect(onExpandStateChange.callCount).to.equal(3);
+      expect(onExpandStateChange.args[2][0]).to.be.true;
     });
   });
 

--- a/extensions/amp-accordion/1.0/test/test-accordion.js
+++ b/extensions/amp-accordion/1.0/test/test-accordion.js
@@ -457,6 +457,90 @@ describes.sandboxed('Accordion preact component', {}, (env) => {
     });
   });
 
+  describe('fire events on expand and collapse', () => {
+    let wrapper;
+    let ref;
+    let onExpand;
+    let onCollapse;
+
+    beforeEach(() => {
+      onExpand = env.sandbox.spy();
+      onCollapse = env.sandbox.spy();
+      ref = Preact.useRef();
+
+      wrapper = mount(
+        <Accordion ref={ref}>
+          <AccordionSection key={1} expanded header="header1">
+            content1
+          </AccordionSection>
+          <AccordionSection
+            key={2}
+            id="section2"
+            header="header2"
+            onExpand={onExpand}
+            onCollapse={onCollapse}
+          >
+            content2
+          </AccordionSection>
+          <AccordionSection key={3} header="header3">
+            content3
+          </AccordionSection>
+        </Accordion>
+      );
+      document.body.appendChild(wrapper.getDOMNode());
+    });
+
+    it('should fire events on click', async () => {
+      const sections = wrapper.find(AccordionSection);
+
+      // Expand
+      sections.at(1).find('header').simulate('click');
+      expect(onExpand).to.be.calledOnce;
+      expect(onCollapse).not.to.be.called;
+
+      // Collapse
+      sections.at(1).find('header').simulate('click');
+      expect(onExpand).to.be.calledOnce;
+      expect(onCollapse).to.be.calledOnce;
+
+      // Expand
+      sections.at(1).find('header').simulate('click');
+      expect(onExpand).to.be.calledTwice;
+      expect(onCollapse).to.be.calledOnce;
+
+      // Collapse
+      sections.at(1).find('header').simulate('click');
+      expect(onExpand).to.be.calledTwice;
+      expect(onCollapse).to.be.calledTwice;
+    });
+
+    it('should fire events on API toggle', async () => {
+      // Expand All
+      ref.current.toggle();
+      wrapper.update();
+      expect(onExpand).to.be.calledOnce;
+      expect(onCollapse).not.to.be.called;
+
+      // Collapse All
+      ref.current.collapse();
+      wrapper.update();
+      expect(onExpand).to.be.calledOnce;
+      expect(onCollapse).to.be.calledOnce;
+
+      // Collapsing an already collapsed section should do nothing
+      ref.current.collapse('section2');
+      wrapper.update();
+      expect(onExpand).to.be.calledOnce;
+      expect(onCollapse).to.be.calledOnce;
+
+      // Expand All
+      ref.current.expand();
+      wrapper.update();
+      expect(onExpand).to.be.calledTwice;
+      expect(onCollapse).to.be.calledOnce;
+    });
+  });
+
   describe('imperative api', () => {
     let wrapper;
     let ref;

--- a/extensions/amp-accordion/1.0/test/test-amp-accordion.js
+++ b/extensions/amp-accordion/1.0/test/test-amp-accordion.js
@@ -307,7 +307,6 @@ describes.realWin(
       }
 
       it('should fire events on click', async () => {
-        //const sections = element.children;
         const section1 = element.children[0];
         const section2 = element.children[1];
         const section3 = element.children[2];
@@ -334,7 +333,6 @@ describes.realWin(
       });
 
       it('should fire events on API toggle', async () => {
-        //const sections = element.children;
         const section1 = element.children[0];
         const section2 = element.children[1];
         const section3 = element.children[2];
@@ -370,11 +368,12 @@ describes.realWin(
         element.enqueAction(invocation('toggle'));
         await waitForExpanded(section1, true);
 
-        // Toggle all toggles all sections
-        // TODO: Confirm this behavior
+        // Section 3 closed on initial toggle
+        // Then section 3 opened based on section 2 opening
+        // Then section 2 closed based on section 3's initial close
         expect(section1).to.have.attribute('expanded');
-        expect(section2).to.have.attribute('expanded');
-        expect(section3).to.not.have.attribute('expanded');
+        expect(section2).to.not.have.attribute('expanded');
+        expect(section3).to.have.attribute('expanded');
       });
     });
 


### PR DESCRIPTION
2nd POC of triggering events in bento accordion

`amp-accordion` will fire an `expand` and `collapse` event on each of these respective actions.

The `preact` version of the component is expanded to take in props for `onExpandStateChange` so the user can specify and specific type of action to be used here.