### PR TITLE
🐛 Move ampDoc references into amp-story buildCallback

### DIFF
--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -327,13 +327,13 @@ export class AmpStory extends AMP.BaseElement {
     /** @private @const {!../../../src/service/platform-impl.Platform} */
     this.platform_ = Services.platformFor(this.win);
 
-    /** @private @const {!../../../src/service/viewer-interface.ViewerInterface} */
-    this.viewer_ = Services.viewerForDoc(this.element);
+    // /** @private @const {!../../../src/service/viewer-interface.ViewerInterface} */
+    // this.viewer_ = Services.viewerForDoc(this.element);
 
-    /** @private @const {?AmpStoryViewerMessagingHandler} */
-    this.viewerMessagingHandler_ = this.viewer_.isEmbedded()
-      ? new AmpStoryViewerMessagingHandler(this.win, this.viewer_)
-      : null;
+    // /** @private @const {?AmpStoryViewerMessagingHandler} */
+    // this.viewerMessagingHandler_ = this.viewer_.isEmbedded()
+    //   ? new AmpStoryViewerMessagingHandler(this.win, this.viewer_)
+    //   : null;
 
     /**
      * Store the current paused state, to make sure the story does not play on
@@ -353,6 +353,17 @@ export class AmpStory extends AMP.BaseElement {
 
     /** @private {?LiveStoryManager} */
     this.liveStoryManager_ = null;
+  }
+
+  /** @override */
+  buildCallback() {
+    /** @private @const {!../../../src/service/viewer-interface.ViewerInterface} */
+    this.viewer_ = Services.viewerForDoc(this.element);
+
+    /** @private @const {?AmpStoryViewerMessagingHandler} */
+    this.viewerMessagingHandler_ = this.viewer_.isEmbedded()
+      ? new AmpStoryViewerMessagingHandler(this.win, this.viewer_)
+      : null;
 
     /** @private @const {!../../../src/service/localization.LocalizationService} */
     this.localizationService_ = getLocalizationService(this.element);
@@ -389,10 +400,7 @@ export class AmpStory extends AMP.BaseElement {
       'en-xa',
       enXaPseudoLocaleBundle
     );
-  }
 
-  /** @override */
-  buildCallback() {
     if (this.isStandalone_()) {
       this.initializeStandaloneStory_();
     }
@@ -2023,7 +2031,7 @@ export class AmpStory extends AMP.BaseElement {
           );
         }
       });
-      this.maskElement_ = maskEl;
+      thizs.maskElement_ = maskEl;
       this.mutateElement(() => {
         this.element.appendChild(this.maskElement_);
         toggle(dev().assertElement(this.maskElement_), /* display */ false);

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -327,13 +327,14 @@ export class AmpStory extends AMP.BaseElement {
     /** @private @const {!../../../src/service/platform-impl.Platform} */
     this.platform_ = Services.platformFor(this.win);
 
-    // /** @private @const {!../../../src/service/viewer-interface.ViewerInterface} */
-    // this.viewer_ = Services.viewerForDoc(this.element);
+    /** @private @const {?../../../src/service/viewer-interface.ViewerInterface} */
+    this.viewer_ = null
 
-    // /** @private @const {?AmpStoryViewerMessagingHandler} */
-    // this.viewerMessagingHandler_ = this.viewer_.isEmbedded()
-    //   ? new AmpStoryViewerMessagingHandler(this.win, this.viewer_)
-    //   : null;
+    /** @private @const {?AmpStoryViewerMessagingHandler} */
+    this.viewerMessagingHandler_ = null
+
+    /** @private @const {?../../../src/service/localization.LocalizationService} */
+    this.localizationService_ = null;
 
     /**
      * Store the current paused state, to make sure the story does not play on
@@ -357,15 +358,12 @@ export class AmpStory extends AMP.BaseElement {
 
   /** @override */
   buildCallback() {
-    /** @private @const {!../../../src/service/viewer-interface.ViewerInterface} */
     this.viewer_ = Services.viewerForDoc(this.element);
 
-    /** @private @const {?AmpStoryViewerMessagingHandler} */
     this.viewerMessagingHandler_ = this.viewer_.isEmbedded()
       ? new AmpStoryViewerMessagingHandler(this.win, this.viewer_)
       : null;
 
-    /** @private @const {!../../../src/service/localization.LocalizationService} */
     this.localizationService_ = getLocalizationService(this.element);
 
     this.localizationService_

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -328,10 +328,10 @@ export class AmpStory extends AMP.BaseElement {
     this.platform_ = Services.platformFor(this.win);
 
     /** @private {?../../../src/service/viewer-interface.ViewerInterface} */
-    this.viewer_ = null
+    this.viewer_ = null;
 
     /** @private {?AmpStoryViewerMessagingHandler} */
-    this.viewerMessagingHandler_ = null
+    this.viewerMessagingHandler_ = null;
 
     /** @private {?../../../src/service/localization.LocalizationService} */
     this.localizationService_ = null;
@@ -1009,7 +1009,7 @@ export class AmpStory extends AMP.BaseElement {
         // Preloads and prerenders the share menu.
         this.shareMenu_.build();
 
-        const infoDialog = this.viewer_ && shouldShowStoryUrlInfo(this.viewer_)
+        const infoDialog = shouldShowStoryUrlInfo(devAssert(this.viewer_))
           ? new InfoDialog(this.win, this.element)
           : null;
         if (infoDialog) {

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -327,13 +327,13 @@ export class AmpStory extends AMP.BaseElement {
     /** @private @const {!../../../src/service/platform-impl.Platform} */
     this.platform_ = Services.platformFor(this.win);
 
-    /** @private @const {?../../../src/service/viewer-interface.ViewerInterface} */
+    /** @private {?../../../src/service/viewer-interface.ViewerInterface} */
     this.viewer_ = null
 
-    /** @private @const {?AmpStoryViewerMessagingHandler} */
+    /** @private {?AmpStoryViewerMessagingHandler} */
     this.viewerMessagingHandler_ = null
 
-    /** @private @const {?../../../src/service/localization.LocalizationService} */
+    /** @private {?../../../src/service/localization.LocalizationService} */
     this.localizationService_ = null;
 
     /**

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -1009,7 +1009,7 @@ export class AmpStory extends AMP.BaseElement {
         // Preloads and prerenders the share menu.
         this.shareMenu_.build();
 
-        const infoDialog = shouldShowStoryUrlInfo(this.viewer_)
+        const infoDialog = this.viewer_ && shouldShowStoryUrlInfo(this.viewer_)
           ? new InfoDialog(this.win, this.element)
           : null;
         if (infoDialog) {
@@ -2029,7 +2029,7 @@ export class AmpStory extends AMP.BaseElement {
           );
         }
       });
-      thizs.maskElement_ = maskEl;
+      this.maskElement_ = maskEl;
       this.mutateElement(() => {
         this.element.appendChild(this.maskElement_);
         toggle(dev().assertElement(this.maskElement_), /* display */ false);


### PR DESCRIPTION
> The code tries to access the ampdoc before it's available and everything fails. This is caused by the service getters in amp-story.constructor() that use this.element as a parameter. The ones using this.win are fine.
These service getters need to be moved to amp-story.buildCallback().
https://github.com/ampproject/amphtml/issues/30798#issuecomment-721332274

context / fixes #30798