### PR TITLE
🏗 Enable AMP Storybook on PR deploys

### DIFF
--- a/build-system/tasks/pr-deploy-bot-utils.js
+++ b/build-system/tasks/pr-deploy-bot-utils.js
@@ -41,9 +41,13 @@ async function walk(dest) {
   return filelist;
 }
 
+function getBaseUrl() {
+  return `${hostNamePrefix}/amp_dist_${travisBuildNumber()}`;
+}
+
 async function replace(filePath) {
   const data = await fs.readFile(filePath, 'utf8');
-  const hostName = `${hostNamePrefix}/amp_dist_${travisBuildNumber()}`;
+  const hostName = getBaseUrl();
   const inabox = false;
   const storyV1 = true;
   const result = replaceUrlsAppUtil(
@@ -81,6 +85,7 @@ async function signalDistUpload(result) {
 }
 
 module.exports = {
+  getBaseUrl,
   replaceUrls,
   signalDistUpload,
 };

--- a/build-system/tasks/storybook/index.js
+++ b/build-system/tasks/storybook/index.js
@@ -70,7 +70,9 @@ function buildEnv(env) {
     // Allows PR deploys to reference built binaries.
     writeFileSync(
       `${__dirname}/${env}-env/preview.js`,
-      `// DO NOT${' '}SUBMIT.  
+      // If you change this JS template, make sure to JSON.stringify every
+      // dynamic value so it's safe from XSS and other types of garbling.
+      `// DO NOT${' '}SUBMIT.
        // This preview.js file was generated for a specific PR build.
        import {addParameters} from '@storybook/preact';
        addParameters(${JSON.stringify({

--- a/build-system/tasks/storybook/index.js
+++ b/build-system/tasks/storybook/index.js
@@ -70,7 +70,7 @@ function buildEnv(env) {
     // Allows PR deploys to reference built binaries.
     writeFileSync(
       `${__dirname}/${env}-env/preview.js`,
-      `// DO NOT SUBMIT.  
+      `// DO NOT${' '}SUBMIT.  
        // This preview.js file was generated for a specific PR build.
        import {addParameters} from '@storybook/preact';
        addParameters(${JSON.stringify({

--- a/build-system/tasks/storybook/index.js
+++ b/build-system/tasks/storybook/index.js
@@ -71,7 +71,7 @@ function buildEnv(env) {
     writeFileSync(
       `${__dirname}/${env}-env/preview.js`,
       `// DO NOT SUBMIT.  
-       // This file was generated with gulp storybook --build.
+       // This preview.js file was generated with for a specific PR build.
        import {addParameters} from '@storybook/preact';
        addParameters(${JSON.stringify({
          ampBaseUrlOptions: [`${getBaseUrl()}/dist`],

--- a/build-system/tasks/storybook/index.js
+++ b/build-system/tasks/storybook/index.js
@@ -16,13 +16,13 @@
 'use strict';
 
 const argv = require('minimist')(process.argv.slice(2));
-const fs = require('fs-extra');
 const {createCtrlcHandler} = require('../../common/ctrlcHandler');
 const {defaultTask: runAmpDevBuildServer} = require('../default-task');
 const {execScriptAsync} = require('../../common/exec');
 const {getBaseUrl} = require('../pr-deploy-bot-utils');
 const {installPackages} = require('../../common/utils');
 const {isTravisPullRequestBuild} = require('../../common/travis');
+const {writeFileSync} = require('fs-extra');
 
 const ENV_PORTS = {
   amp: 9001,
@@ -68,7 +68,7 @@ function launchEnv(env) {
 function buildEnv(env) {
   if (env === 'amp' && isTravisPullRequestBuild()) {
     // Allows PR deploys to reference built binaries.
-    fs.writeFileSync(
+    writeFileSync(
       `${__dirname}/${env}-env/preview.js`,
       `// DO NOT SUBMIT.  
        // This file was generated with gulp storybook --build.

--- a/build-system/tasks/storybook/index.js
+++ b/build-system/tasks/storybook/index.js
@@ -71,7 +71,7 @@ function buildEnv(env) {
     writeFileSync(
       `${__dirname}/${env}-env/preview.js`,
       // If you change this JS template, make sure to JSON.stringify every
-      // dynamic value so it's safe from XSS and other types of garbling.
+      // dynamic value. This prevents XSS and other types of garbling.
       `// DO NOT${' '}SUBMIT.
        // This preview.js file was generated for a specific PR build.
        import {addParameters} from '@storybook/preact';

--- a/build-system/tasks/storybook/index.js
+++ b/build-system/tasks/storybook/index.js
@@ -71,7 +71,7 @@ function buildEnv(env) {
     writeFileSync(
       `${__dirname}/${env}-env/preview.js`,
       `// DO NOT SUBMIT.  
-       // This preview.js file was generated with for a specific PR build.
+       // This preview.js file was generated for a specific PR build.
        import {addParameters} from '@storybook/preact';
        addParameters(${JSON.stringify({
          ampBaseUrlOptions: [`${getBaseUrl()}/dist`],

--- a/build-system/tasks/storybook/package-lock.json
+++ b/build-system/tasks/storybook/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@ampproject/storybook-addon": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@ampproject/storybook-addon/-/storybook-addon-1.1.4.tgz",
-      "integrity": "sha512-njlq6Lh8oFSJRvGmE4a+ucmZpDP6qFtFku9VFR6AiktKjSdx4BkZ1Y16CPUE4ccaHy76utH3oBF/ewczfMEamQ==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@ampproject/storybook-addon/-/storybook-addon-1.1.5.tgz",
+      "integrity": "sha512-7sPXVFLWrBROzpXbVauBxkUKVLLfeORfrzknH4O3WYBjti0STjUV8GUZduBoxrKbJ35qutdwQp3ZxGFQNpcePg==",
       "requires": {
         "@storybook/client-api": "^5.3.19",
         "@types/styled-jsx": "^2.2.8",

--- a/build-system/tasks/storybook/package.json
+++ b/build-system/tasks/storybook/package.json
@@ -4,7 +4,7 @@
   "description": "Gulp storybook tasks",
   "main": "index.js",
   "dependencies": {
-    "@ampproject/storybook-addon": "1.1.4",
+    "@ampproject/storybook-addon": "1.1.5",
     "@babel/core": "7.9.0",
     "@babel/preset-react": "7.9.4",
     "@babel/runtime-corejs3": "7.9.2",


### PR DESCRIPTION
### This change
Enables [`examples/storybook/amp`](https://storage.googleapis.com/amp-test-website-1/amp_dist_83181/examples/storybook/amp/index.html?path=/story/amp-video-1-0--default) on PR build deploys.

### Later
Slightly awkward that the binary source for the PR's build has to be picked manually. The Storybook addon could default to the custom URL instead.

<img width="502" src="https://user-images.githubusercontent.com/254946/98289672-64e3c380-1f5d-11eb-96ba-b32e7d38e572.png" />

