### PR TITLE
docs: 📖 remove amp by example, since it deprecated/dead.

### DIFF
--- a/contributing/building-an-amp-extension.md
+++ b/contributing/building-an-amp-extension.md
@@ -747,6 +747,10 @@ HTML document and use your element in it by creating a file in the
 name. Browse that directory to see examples for other elements and
 extensions.
 
+Also consider contributing an example to
+[amp.dev](https://amp.dev/) on
+[GitHub](https://github.com/ampproject/amp.dev).
+
 ## Updating build configs
 
 In order for your element to build correctly you would need to make few

--- a/contributing/building-an-amp-extension.md
+++ b/contributing/building-an-amp-extension.md
@@ -747,10 +747,6 @@ HTML document and use your element in it by creating a file in the
 name. Browse that directory to see examples for other elements and
 extensions.
 
-Also consider contributing to
-[ampbyexample.com](https://ampbyexample.com/) on
-[GitHub](https://github.com/ampproject/amp-by-example).
-
 ## Updating build configs
 
 In order for your element to build correctly you would need to make few


### PR DESCRIPTION
Two options:
1. delete
2. change to indicate folks may consider adding examples to amp.dev

Sound off in the comments below.