### PR TITLE
Revert "🐛[amp-autocomplete] Move event listeners to buildCallback from layoutCallback"

### DIFF
--- a/extensions/amp-autocomplete/0.1/amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/amp-autocomplete.js
@@ -227,7 +227,7 @@ export class AmpAutocomplete extends AMP.BaseElement {
     * the suggestion container must have a unique ID.
      * In case the autocomplete doesn't have an ID we use a
      * random number to ensure uniqueness.
-     @private {number|string}
+     @private {number|string} 
      */
     this.containerId_ = element.id
       ? element.id
@@ -341,41 +341,7 @@ export class AmpAutocomplete extends AMP.BaseElement {
     this.container_ = this.createContainer_();
     this.element.appendChild(this.container_);
 
-    this.initializeListeners_();
-
     return Promise.resolve();
-  }
-
-  /**
-   * Initializes listeners for keydown, mousedown, focus, etc. events.
-   * @private
-   */
-  initializeListeners_() {
-    this.inputElement_.addEventListener(
-      'touchstart',
-      () => {
-        this.checkFirstInteractionAndMaybeFetchData_();
-      },
-      {passive: true}
-    );
-    this.inputElement_.addEventListener('input', () => {
-      this.inputHandler_();
-    });
-    this.inputElement_.addEventListener('keydown', (e) => {
-      this.keyDownHandler_(e);
-    });
-    this.inputElement_.addEventListener('focus', () => {
-      this.checkFirstInteractionAndMaybeFetchData_().then(() => {
-        const display = this.binding_.shouldShowOnFocus();
-        this.toggleResultsHandler_(display);
-      });
-    });
-    this.inputElement_.addEventListener('blur', () => {
-      this.toggleResultsHandler_(false);
-    });
-    this.container_.addEventListener('mousedown', (e) => {
-      this.selectHandler_(e);
-    });
   }
 
   /**
@@ -532,6 +498,34 @@ export class AmpAutocomplete extends AMP.BaseElement {
   layoutCallback() {
     // Disable autofill in browsers.
     this.inputElement_.setAttribute('autocomplete', 'off');
+
+    // Register event handlers.
+    this.inputElement_.addEventListener(
+      'touchstart',
+      () => {
+        this.checkFirstInteractionAndMaybeFetchData_();
+      },
+      {passive: true}
+    );
+    this.inputElement_.addEventListener('input', () => {
+      this.inputHandler_();
+    });
+    this.inputElement_.addEventListener('keydown', (e) => {
+      this.keyDownHandler_(e);
+    });
+    this.inputElement_.addEventListener('focus', () => {
+      this.checkFirstInteractionAndMaybeFetchData_().then(() => {
+        const display = this.binding_.shouldShowOnFocus();
+        this.toggleResultsHandler_(display);
+      });
+    });
+    this.inputElement_.addEventListener('blur', () => {
+      this.toggleResultsHandler_(false);
+    });
+    this.container_.addEventListener('mousedown', (e) => {
+      this.selectHandler_(e);
+    });
+
     return this.autocomplete_(this.sourceData_, this.userInput_);
   }
 

--- a/extensions/amp-lightbox/0.1/test-e2e/test-amp-lightbox.js
+++ b/extensions/amp-lightbox/0.1/test-e2e/test-amp-lightbox.js
@@ -77,22 +77,5 @@ describes.endtoend(
       await expect(controller.getElementProperty(lightbox, 'hidden')).to.be
         .true;
     });
-
-    it('should show autocomplete options when lightbox opens', async () => {
-      const open = await controller.findElement('#open');
-      await controller.click(open);
-
-      const results = await controller.findElement(
-        '.i-amphtml-autocomplete-results'
-      );
-      await expect(controller.getElementProperty(results, 'hidden')).to.be
-        .false;
-
-      const options = await controller.findElements(
-        '.i-amphtml-autocomplete-item'
-      );
-      // auto-complete options are apple, orange, banana.
-      await expect(options).to.have.lengthOf(3);
-    });
   }
 );

--- a/test/fixtures/e2e/amp-lightbox/amp-lightbox.html
+++ b/test/fixtures/e2e/amp-lightbox/amp-lightbox.html
@@ -8,7 +8,6 @@
     <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
     <script async src="https://cdn.ampproject.org/v0.js"></script>
     <script async custom-element="amp-lightbox" src="https://cdn.ampproject.org/v0/amp-lightbox-0.1.js"></script>
-    <script async custom-element="amp-autocomplete" src="https://cdn.ampproject.org/v0/amp-autocomplete-0.1.js"></script>
     <style amp-custom>
     amp-lightbox {
       background-color: rgba(0, 0, 0, 0.9);
@@ -17,31 +16,16 @@
 </head>
 
 <body>
-  <amp-lightbox id="lightbox" layout="nodisplay" on="lightboxOpen:autocomplete-input.focus">
+  <amp-lightbox id="lightbox" layout="nodisplay">
 
     <button id="close" on="tap:lightbox.close">
       Close Lightbox
     </button>
-    <!-- div to visually separate components and avoid ElementClickInterceptedErrors in e2e tests -->
-    <div>
-      <amp-img
-          id="image"
-          src="/examples/img/sample.jpg"
-          width="641" height="481"
-      ></amp-img>
-    </div>
-
-    <div>
-      <amp-autocomplete min-characters="0" filter="substring">
-        <input id="autocomplete-input">
-        <script type="application/json">
-          {
-            "items": ["apple", "orange", "banana"]
-          }
-        </script>
-      </amp-autocomplete>
-    </div>
-
+    <amp-img
+        id="image"
+        src="/examples/img/sample.jpg"
+        width="641" height="481"
+    ></amp-img>
   </amp-lightbox>
 
   <button id="open" on="tap:lightbox.open">


### PR DESCRIPTION
Reverts ampproject/amphtml#30901

This fails on an experiment branch when merged into master.
Logs here: https://travis-ci.com/github/ampproject/amphtml/builds/198282104

@dmanek  - Can you please take a look?
cc: @estherkim 

