### PR TITLE
✨ CONSENT_STRING macro available through in amp-analytics

### DIFF
--- a/examples/amp-consent/amp-consent-geo.html
+++ b/examples/amp-consent/amp-consent-geo.html
@@ -121,11 +121,11 @@
 <main role="main">
   <p>This example tests amp-consent with amp-geo using 'geoOverride' to prompt different UIs</p>
   <h3>Image that is blocked by '_till_responded' consent</h3>
-  <amp-analytics type="_ping_">
+  <amp-analytics>
     <script type="application/json">
       {
         "requests": {
-          "old": "https://fake.com/analytics?consent=CONSENT_STATE"
+          "old": "https://fake.com/analytics?consent=CONSENT_STATE&consentString=${consentString}"
         },
         "vars": {
           "abc": "${timestamp}.${requestCount}"
@@ -177,9 +177,8 @@
       {
         "ISOCountryGroups": {
           "na": ["ca", "mx", "us"],
-          "eea": ["preset-eea"],
-          "row": ["unknown"],
-          "useIframe": ["fake"]
+          "eea": ["preset-eea", "unknown"],
+          "usePromptUi": ["fake"]
         }
       }
     </script>
@@ -198,7 +197,8 @@
       "geoOverride": {
         "na": {
           "checkConsentHref": "/check-consent?consentRequired=true&consentStateValue=unknown&consentRequired=true",
-          "consentRequired": "remote"
+          "consentRequired": "remote",
+          "monetization-type": "npa"
         },
         "eea": {
           "promptUI": null,
@@ -214,7 +214,7 @@
           "checkConsentHref": "/check-consent?consentRequired=true&expireCache=true",
           "consentRequired": true
         },
-        "useIframe": {
+        "usePromptUi": {
           "consentRequired": true,
           "promptUI": "ui2"
         }

--- a/examples/amp-consent/diy-consent.html
+++ b/examples/amp-consent/diy-consent.html
@@ -140,21 +140,6 @@ if (window && window.name) {
   }
 }
 
-
-window.addEventListener('message', (event) => {
-  const data = event.data;
-  if (data.reqestType === 'enter-fullscreen' && data.state === 'error') {
-    console.log('Could not complete fullscreen request:', data.message);
-  }
-  else if (data.reqestType === 'enter-fullscreen' && data.state === 'success') {
-    console.log('Fullscreen command successfuly sent:', data.message);
-  }
-  else {
-    console.log('Unknown request type:', data.reqestType);
-  }
-});
-
-
 // Add event listener for focus for a11y
 window.addEventListener('focus', () => {
   const headerElement = document.querySelector('h1');
@@ -205,18 +190,6 @@ setTimeout(() => {
 
   parent.postMessage(readyObject, '*');
 }, 2000);
-
-// Send fullscreen request every 2.5 seconds
-setInterval(() => {
-
-  // Our fullscreen object
-  const fullscreenObject = {
-    type: 'consent-ui',
-    action: 'enter-fullscreen'
-  };
-
-  parent.postMessage(fullscreenObject, '*');
-}, 2500);
 
 function registerClickConsentMessage(querySelector, type, action, info, consentMetadata, timeout) {
   document.querySelector(querySelector).onclick = function () {

--- a/extensions/amp-analytics/0.1/default-config.js
+++ b/extensions/amp-analytics/0.1/default-config.js
@@ -39,6 +39,7 @@ const defaultConfig = jsonConfiguration({
     'canonicalUrl': 'CANONICAL_URL',
     'clientId': 'CLIENT_ID',
     'consentState': 'CONSENT_STATE',
+    'consentString': 'CONSENT_STRING',
     'contentLoadTime': 'CONTENT_LOAD_TIME',
     'cookie': 'COOKIE',
     'counter': 'COUNTER',

--- a/extensions/amp-analytics/0.1/test/test-variables.js
+++ b/extensions/amp-analytics/0.1/test/test-variables.js
@@ -448,11 +448,11 @@ describes.fakeWin('amp-analytics.VariableService', {amp: true}, (env) => {
       window.sandbox.stub(Services, 'consentPolicyServiceForDocOrNull').returns(
         Promise.resolve({
           getConsentMetadataInfo: () => {
-            return {
+            return Promise.resolve({
               'gdprApplies': true,
               'additionalConsent': 'abc123',
               'consentStringType': 1,
-            };
+            });
           },
         })
       );
@@ -461,6 +461,18 @@ describes.fakeWin('amp-analytics.VariableService', {amp: true}, (env) => {
         'CONSENT_METADATA(gdprApplies)&CONSENT_METADATA(additionalConsent)&CONSENT_METADATA(consentStringType)&CONSENT_METADATA(invalid_key)',
         'true&abc123&1&'
       );
+    });
+
+    it('replaces CONSENT_STRING', () => {
+      window.sandbox.stub(Services, 'consentPolicyServiceForDocOrNull').returns(
+        Promise.resolve({
+          getConsentStringInfo: () => {
+            return Promise.resolve('userConsentString');
+          },
+        })
+      );
+
+      return check('a=CONSENT_STRING', 'a=userConsentString');
     });
 
     it('"COOKIE" resolves cookie value', async () => {

--- a/extensions/amp-analytics/0.1/test/test-vendors.js
+++ b/extensions/amp-analytics/0.1/test/test-vendors.js
@@ -51,6 +51,7 @@ describes.realWin(
       elementMacros = {
         'COOKIE': null,
         'CONSENT_STATE': null,
+        'CONSENT_STRING': null,
         'CONSENT_METADATA': null,
       };
     });

--- a/extensions/amp-analytics/0.1/variables.js
+++ b/extensions/amp-analytics/0.1/variables.js
@@ -25,7 +25,11 @@ import {
   getActiveExperimentBranches,
   getExperimentBranch,
 } from '../../../src/experiments';
-import {getConsentMetadata, getConsentPolicyState} from '../../../src/consent';
+import {
+  getConsentMetadata,
+  getConsentPolicyInfo,
+  getConsentPolicyState,
+} from '../../../src/consent';
 import {
   getServiceForDoc,
   getServicePromiseForDoc,
@@ -278,6 +282,7 @@ export class VariableService {
       'COOKIE': (name) =>
         cookieReader(this.ampdoc_.win, dev().assertElement(element), name),
       'CONSENT_STATE': getConsentStateStr(element),
+      'CONSENT_STRING': getConsentPolicyInfo(element),
       'CONSENT_METADATA': (key) =>
         getConsentMetadataValue(
           element,

--- a/extensions/amp-consent/customizing-extension-behaviors-on-consent.md
+++ b/extensions/amp-consent/customizing-extension-behaviors-on-consent.md
@@ -63,7 +63,9 @@ AMP will always pass the local stored consent string if there's one. Update to t
 
 Use the `getConsentPolicyInfo` API. `getConsentPolicyInfo` returns a promise with the raw consent string value.
 
-Ways to get the consent string for ad/analytics vendors coming soon.
+#### If you integrate with AMP as an analytics vendor
+
+Get the value using `CONSENT_STRING` macro, or `${consentString}`. A request with the varaible will only be sent out after the consent policy has resolved and the stored consent string (if any) will be returned.
 
 ### On Related Information
 

--- a/src/consent.js
+++ b/src/consent.js
@@ -59,10 +59,10 @@ export function getConsentPolicySharedData(element, policyId) {
 
 /**
  * @param {!Element|!ShadowRoot} element
- * @param {string} policyId
+ * @param {string=} policyId
  * @return {!Promise<string>}
  */
-export function getConsentPolicyInfo(element, policyId) {
+export function getConsentPolicyInfo(element, policyId = 'default') {
   // Return the stored consent string.
   return Services.consentPolicyServiceForDocOrNull(element).then(
     (consentPolicy) => {


### PR DESCRIPTION
Closes #30979
- Added CONSENT_STRING macro (also accessible via ${consentString}) as a variable substitution within amp-analytics
- A little clean up on `examples/amp-consent/amp-consent-geo.html` and `examples/amp-consent/diy-consent.html` (for manual testing)
- Tests and documentation
- policyId will be set to default just like in CONSENT_STATE macro