### PR TITLE
🐛 Fixing storyProgress calculation so that values are [0,1]

### DIFF
--- a/extensions/amp-story/1.0/test/test-amp-story-viewer-messaging-handler.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-viewer-messaging-handler.js
@@ -108,7 +108,7 @@ describes.fakeWin('amp-story-viewer-messaging-handler', {}, (env) => {
     });
 
     it('should return the STORY_PROGRESS', async () => {
-      storeService.dispatch(Action.SET_PAGE_IDS, [1, 2, 3, 4]);
+      storeService.dispatch(Action.SET_PAGE_IDS, [1, 2, 3, 4, 5]);
       storeService.dispatch(Action.CHANGE_PAGE, {id: 3, index: 2});
       const response = await fakeViewerService.receiveMessage(
         'getDocumentState',

--- a/extensions/amp-story/1.0/test/test-variable-service.js
+++ b/extensions/amp-story/1.0/test/test-variable-service.js
@@ -47,4 +47,15 @@ describes.fakeWin('amp-story variable service', {}, (env) => {
     const variables = variableService.get();
     expect(variables['storyAdvancementMode']).to.equal('manualAdvance');
   });
+
+  it('should calculate storyProgress correctly on change', () => {
+    storeService.dispatch(Action.SET_PAGE_IDS, ['a', 'b', 'c', 'd', 'e']);
+    storeService.dispatch(Action.CHANGE_PAGE, {
+      id: 'd',
+      index: 3,
+    });
+
+    const variables = variableService.get();
+    expect(variables['storyProgress']).to.equal(0.75);
+  });
 });

--- a/extensions/amp-story/1.0/variable-service.js
+++ b/extensions/amp-story/1.0/variable-service.js
@@ -121,7 +121,7 @@ export class AmpStoryVariableService {
           .length;
         if (numberOfPages > 0) {
           this.variables_[AnalyticsVariable.STORY_PROGRESS] =
-            pageIndex / numberOfPages;
+            pageIndex / (numberOfPages - 1);
         }
       },
       true /* callToInitialize */


### PR DESCRIPTION
Resolving open issue: #30821

`storyProgress` is currently calculated with `currentPageIndex / totalPages`, but in order for completed stories to correctly record a value of 1, `storyProgress` should be calculated with `currentPageIndex / (totalPages - 1)`.