### PR TITLE
🚮 Remove iOS specific unpausable workaround

### DIFF
--- a/css/video-autoplay.css
+++ b/css/video-autoplay.css
@@ -77,12 +77,6 @@ amp-story .amp-video-eq {
 .amp-video-eq-col div {
   animation-play-state: paused;
 }
-[unpausable] .amp-video-eq-col div {
-  animation-name: none;
-}
-[unpausable].amp-video-eq-play .amp-video-eq-col div {
-  animation-name: amp-video-eq-animation;
-}
 .amp-video-eq-play .amp-video-eq-col div {
   animation-play-state: running;
 }

--- a/src/service/video/autoplay.js
+++ b/src/service/video/autoplay.js
@@ -70,10 +70,5 @@ export function renderIcon(win, elOrDoc) {
   // Remove seed column.
   removeElement(firstCol);
 
-  if (Services.platformFor(win).isIos()) {
-    // iOS is unable to pause hardware accelerated animations.
-    icon.setAttribute('unpausable', '');
-  }
-
   return icon;
 }

--- a/src/service/video/autoplay.js
+++ b/src/service/video/autoplay.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import {Services} from '../../services';
 import {dev} from '../../log';
 import {htmlFor} from '../../static-template';
 import {removeElement} from '../../dom';


### PR DESCRIPTION
1. The iOS issue no longer applies to our support matrix.
2. Even if it did, after the `IntersectionObserver` change, videos playing while visible to 0% so we rarely see this state.