### PR TITLE
🐛 Overshooting the borders in interactive-quiz made them disappear on iOS

### DIFF
--- a/extensions/amp-story-interactive/0.1/amp-story-interactive-quiz.css
+++ b/extensions/amp-story-interactive/0.1/amp-story-interactive-quiz.css
@@ -38,7 +38,7 @@
   display: flex !important;
   justify-items: start !important;
   align-items: center !important;
-  border-radius: var(1.649em) !important;
+  border-radius: 1.649em !important; /* On iOS inset shadows with border-radius require borders smaller than sides to render correctly */
   padding: 0.5em 1em 0.5em 0.5em !important;
   background-color: var(
     --i-amphtml-interactive-option-background-color

--- a/extensions/amp-story-interactive/0.1/amp-story-interactive-quiz.css
+++ b/extensions/amp-story-interactive/0.1/amp-story-interactive-quiz.css
@@ -38,7 +38,7 @@
   display: flex !important;
   justify-items: start !important;
   align-items: center !important;
-  border-radius: var(--i-amphtml-interactive-chip-radius) !important;
+  border-radius: var(1.649em) !important;
   padding: 0.5em 1em 0.5em 0.5em !important;
   background-color: var(
     --i-amphtml-interactive-option-background-color

--- a/extensions/amp-story-interactive/0.1/amp-story-interactive-quiz.css
+++ b/extensions/amp-story-interactive/0.1/amp-story-interactive-quiz.css
@@ -38,7 +38,7 @@
   display: flex !important;
   justify-items: start !important;
   align-items: center !important;
-  border-radius: 1.649em !important; /* On iOS inset shadows with border-radius require borders smaller than sides to render correctly */
+  border-radius: 1.649em !important; /* On iOS inset shadows with border-radius require borders smaller than sides to render correctly. Issue #31036 */
   padding: 0.5em 1em 0.5em 0.5em !important;
   background-color: var(
     --i-amphtml-interactive-option-background-color


### PR DESCRIPTION
On iOS the quiz options would overshoot the border-radius property beyond 1/2 of the height of the actual option div, which glitches the shadow renderer and doesn't show the borders on the corners. Does not happen consistently across devices, but is consistent on a single device and story. With this change, the border-radius will be slightly smaller than the height and will not overshoot, therefore fixing the bug.

Tested on iOS with web inspector and was able to fix bug with this change.

Height of options div is 3.3em, so half of it is 1.65ems. Had to set border-radius to 1.649 to get rid of this error.

Example of overshooted borders not rendering properly the inset box-shadow:
![image](https://user-images.githubusercontent.com/22420856/98414986-5b845500-204a-11eb-8b59-50979eb4b21a.png)


Fixes #30788