### PR TITLE
lightbox-gallery: remove viewport check

### DIFF
--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
@@ -838,34 +838,8 @@ export class AmpLightboxGallery extends AMP.BaseElement {
    */
   shouldAnimateOut_() {
     const target = this.getCurrentElement_().sourceElement;
-    if (!this.transitionTargetIsInViewport_(target)) {
-      return false;
-    }
-    if (!this.elementTypeCanBeAnimated_(target)) {
-      return false;
-    }
-    return true;
-  }
-
-  /**
-   *
-   * @param {!Element} target
-   * @return {boolean}
-   * @private
-   */
-  transitionTargetIsInViewport_(target) {
-    if (target == this.sourceElement_) {
-      return true;
-    }
-    if (target.isInViewport()) {
-      return true;
-    }
-    const parentCarousel = this.getSourceElementParentCarousel_(target);
-    if (parentCarousel && parentCarousel.isInViewport()) {
-      return true;
-    }
-    return false;
-  }
+    return this.elementTypeCanBeAnimated_(target);
+  } 
 
   /**
    * Transitions the sourceElement into the lightbox or the lightbox to the

--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
@@ -177,9 +177,6 @@ export class AmpLightboxGallery extends AMP.BaseElement {
     /** @private {string} */
     this.currentLightboxGroupId_ = 'default';
 
-    /** @private {?Element} */
-    this.sourceElement_ = null;
-
     /**
      * @private {boolean}
      */
@@ -736,7 +733,6 @@ export class AmpLightboxGallery extends AMP.BaseElement {
    * @private
    */
   openLightboxGallery_(element, expandDescription) {
-    this.sourceElement_ = element;
     const lightboxGroupId = element.getAttribute('lightbox') || 'default';
     this.currentLightboxGroupId_ = lightboxGroupId;
     this.hasVerticalScrollbarWidth_ = getVerticalScrollbarWidth(this.win) > 0;
@@ -839,7 +835,7 @@ export class AmpLightboxGallery extends AMP.BaseElement {
   shouldAnimateOut_() {
     const target = this.getCurrentElement_().sourceElement;
     return this.elementTypeCanBeAnimated_(target);
-  } 
+  }
 
   /**
    * Transitions the sourceElement into the lightbox or the lightbox to the


### PR DESCRIPTION
**summary**
We'd like to remove current `isInViewport` knowledge from Runtime. One of the last holdouts is lightbox-gallery and this check for whether or not an elem is worth animating out.

How important is this optimization. Is it okay to just drop it?

Partial for: https://github.com/ampproject/amphtml/issues/30620