### PR TITLE
amp-auto-ads: FirstImpression.io additional debug parameters

### DIFF
--- a/extensions/amp-auto-ads/0.1/firstimpression.io-network-config.js
+++ b/extensions/amp-auto-ads/0.1/firstimpression.io-network-config.js
@@ -49,8 +49,11 @@ export class FirstImpressionIoConfig {
   getConfigUrl() {
     let previewId = 0;
 
-    const {host, pathname, hash} = window.location;
-    const hashParams = parseQueryString(hash);
+    const {host, pathname, hash, search} = window.location;
+    const hashParams = Object.assign(
+      parseQueryString(hash),
+      parseQueryString(search)
+    );
     const docInfo = Services.documentInfoForDoc(this.autoAmpAdsElement_);
 
     const previewFlowRegex = /amp\/fi\/(\d+)\//;
@@ -62,6 +65,7 @@ export class FirstImpressionIoConfig {
     const fiReveal = hashParams['fi_reveal'];
     const fiDemand = hashParams['fi_demand'];
     const fiGeo = hashParams['fi_geo'];
+    const fiDisable = hashParams['disable_fi'];
 
     const cdnHost =
       hashParams['fi_cdnhost'] || (previewId ? host : 'cdn.firstimpression.io');
@@ -90,6 +94,9 @@ export class FirstImpressionIoConfig {
     }
     if (fiGeo) {
       queryParams['fi_geo'] = fiGeo;
+    }
+    if (fiDisable) {
+      queryParams['disable_fi'] = fiDisable;
     }
     if (previewId) {
       queryParams['preview_id'] = previewId;


### PR DESCRIPTION
A few additional parameters that can be passed as both hash parameters or query parameters to debug FirstImpresion.io setup of `amp-auto-ads`