### PR TITLE
🐛  fixing storyProgress for case when a story only has 1 page

### DIFF
--- a/extensions/amp-story/1.0/test/test-variable-service.js
+++ b/extensions/amp-story/1.0/test/test-variable-service.js
@@ -58,4 +58,15 @@ describes.fakeWin('amp-story variable service', {}, (env) => {
     const variables = variableService.get();
     expect(variables['storyProgress']).to.equal(0.75);
   });
+
+  it('should calculate storyProgress when a story only has 1 page', () => {
+    storeService.dispatch(Action.SET_PAGE_IDS, ['a']);
+    storeService.dispatch(Action.CHANGE_PAGE, {
+      id: 'a',
+      index: 0,
+    });
+
+    const variables = variableService.get();
+    expect(variables['storyProgress']).to.equal(0);
+  });
 });

--- a/extensions/amp-story/1.0/variable-service.js
+++ b/extensions/amp-story/1.0/variable-service.js
@@ -120,7 +120,7 @@ export class AmpStoryVariableService {
         const numberOfPages = this.storeService_.get(StateProperty.PAGE_IDS)
           .length;
         if (numberOfPages > 0) {
-          if (numberOfPages == 1) {
+          if (numberOfPages === 1) {
             this.variables_[AnalyticsVariable.STORY_PROGRESS] = 0;
           } else {
             this.variables_[AnalyticsVariable.STORY_PROGRESS] =

--- a/extensions/amp-story/1.0/variable-service.js
+++ b/extensions/amp-story/1.0/variable-service.js
@@ -120,8 +120,12 @@ export class AmpStoryVariableService {
         const numberOfPages = this.storeService_.get(StateProperty.PAGE_IDS)
           .length;
         if (numberOfPages > 0) {
-          this.variables_[AnalyticsVariable.STORY_PROGRESS] =
-            pageIndex / (numberOfPages - 1);
+          if (numberOfPages == 1) {
+            this.variables_[AnalyticsVariable.STORY_PROGRESS] = 0;
+          } else {
+            this.variables_[AnalyticsVariable.STORY_PROGRESS] =
+              pageIndex / (numberOfPages - 1);
+          }
         }
       },
       true /* callToInitialize */


### PR DESCRIPTION
Due to recent change, `pageIndex / (numberOfPages - 1)` ( #30821) could have had a divide by 0 error when a story has 1 page. Adding a check for that specific edge case. 