### PR TITLE
[amp-story-player] Forward scrolling touch events to parent window

### DIFF
--- a/examples/amp-story/amp-story-animation.html
+++ b/examples/amp-story/amp-story-animation.html
@@ -15,8 +15,6 @@
       custom-element="amp-story"
       src="https://cdn.ampproject.org/v0/amp-story-1.0.js"
     ></script>
-    <script async src="https://cdn.ampproject.org/v0/amp-viewer-integration-0.1.js"></script>
-    <script async custom-element="amp-animation" src="https://cdn.ampproject.org/v0/amp-animation-0.1.js"></script>
     <style amp-custom>
       body {
         font-family: sans-serif;

--- a/examples/amp-story/amp-story-animation.html
+++ b/examples/amp-story/amp-story-animation.html
@@ -15,6 +15,8 @@
       custom-element="amp-story"
       src="https://cdn.ampproject.org/v0/amp-story-1.0.js"
     ></script>
+    <script async src="https://cdn.ampproject.org/v0/amp-viewer-integration-0.1.js"></script>
+    <script async custom-element="amp-animation" src="https://cdn.ampproject.org/v0/amp-animation-0.1.js"></script>
     <style amp-custom>
       body {
         font-family: sans-serif;

--- a/extensions/amp-story/1.0/amp-story-draggable-drawer.js
+++ b/extensions/amp-story/1.0/amp-story-draggable-drawer.js
@@ -290,8 +290,6 @@ export class DraggableDrawer extends AMP.BaseElement {
       return;
     }
 
-    event.stopPropagation();
-
     if (this.touchEventState_.isSwipeY === null) {
       this.touchEventState_.isSwipeY =
         Math.abs(this.touchEventState_.startY - y) >
@@ -344,6 +342,7 @@ export class DraggableDrawer extends AMP.BaseElement {
     const {data} = gesture;
 
     if (this.ignoreCurrentSwipeYGesture_ === true) {
+      gesture.event.stopPropagation();
       this.ignoreCurrentSwipeYGesture_ = !data.last;
       return;
     }
@@ -367,12 +366,11 @@ export class DraggableDrawer extends AMP.BaseElement {
         (isContentSwipe && deltaY < 0) ||
         (isContentSwipe && deltaY > 0 && this.containerEl_./*OK*/ scrollTop > 0)
       ) {
+        gesture.event.stopPropagation();
         this.ignoreCurrentSwipeYGesture_ = true;
         return;
       }
     }
-
-    gesture.event.preventDefault();
 
     if (data.last === true) {
       if (this.state_ === DrawerState.DRAGGING_TO_CLOSE) {
@@ -399,7 +397,7 @@ export class DraggableDrawer extends AMP.BaseElement {
       return;
     }
 
-    this.drag_(deltaY);
+    this.drag_(deltaY, gesture);
   }
 
   /**
@@ -441,9 +439,10 @@ export class DraggableDrawer extends AMP.BaseElement {
   /**
    * Drags the drawer on the screen upon user interaction.
    * @param {number} deltaY
+   * @param {{event: !Event, data: !Object}} gesture
    * @private
    */
-  drag_(deltaY) {
+  drag_(deltaY, gesture) {
     let translate;
 
     switch (this.state_) {
@@ -451,6 +450,10 @@ export class DraggableDrawer extends AMP.BaseElement {
       case DrawerState.DRAGGING_TO_OPEN:
         if (deltaY > 0) {
           return;
+        }
+        if (this.state_ === DrawerState.DRAGGING_TO_OPEN) {
+          gesture.event.preventDefault();
+          gesture.event.stopPropagation();
         }
         this.state_ = DrawerState.DRAGGING_TO_OPEN;
         const drag = Math.max(deltaY, -this.dragCap_);
@@ -461,6 +464,8 @@ export class DraggableDrawer extends AMP.BaseElement {
         if (deltaY < 0) {
           return;
         }
+        gesture.event.preventDefault();
+        gesture.event.stopPropagation();
         this.state_ = DrawerState.DRAGGING_TO_CLOSE;
         translate = `translate3d(0, ${deltaY}px, 0)`;
         break;

--- a/extensions/amp-story/1.0/amp-story-draggable-drawer.js
+++ b/extensions/amp-story/1.0/amp-story-draggable-drawer.js
@@ -290,6 +290,10 @@ export class DraggableDrawer extends AMP.BaseElement {
       return;
     }
 
+    if (this.state_ === DrawerState.CLOSED && this.touchEventState_.swipingUp) {
+      event.stopPropagation();
+    }
+
     if (this.touchEventState_.isSwipeY === null) {
       this.touchEventState_.isSwipeY =
         Math.abs(this.touchEventState_.startY - y) >

--- a/extensions/amp-story/1.0/amp-story-draggable-drawer.js
+++ b/extensions/amp-story/1.0/amp-story-draggable-drawer.js
@@ -290,7 +290,22 @@ export class DraggableDrawer extends AMP.BaseElement {
       return;
     }
 
-    if (this.state_ === DrawerState.CLOSED && this.touchEventState_.swipingUp) {
+    const gesture = {
+      event,
+      data: {
+        swipingUp: this.touchEventState_.swipingUp,
+        deltaY: y - this.touchEventState_.startY,
+        last: false,
+      },
+    };
+
+    this.setIgnoreCurrentSwipeY_(gesture);
+
+    if (this.shouldPreventDefault_()) {
+      event.preventDefault();
+    }
+
+    if (this.shouldStopPropagation_()) {
       event.stopPropagation();
     }
 
@@ -303,14 +318,32 @@ export class DraggableDrawer extends AMP.BaseElement {
       }
     }
 
-    this.onSwipeY_({
-      event,
-      data: {
-        swipingUp: this.touchEventState_.swipingUp,
-        deltaY: y - this.touchEventState_.startY,
-        last: false,
-      },
-    });
+    this.onSwipeY_(gesture);
+  }
+
+  /**
+   * Checks for when the scroll event should be preventDefaulted.
+   * @return {boolean}
+   * @private
+   */
+  shouldPreventDefault_() {
+    return (
+      this.state_ === DrawerState.DRAGGING_TO_OPEN ||
+      this.state_ === DrawerState.DRAGGING_TO_CLOSE ||
+      (this.state_ === DrawerState.OPEN && !this.ignoreCurrentSwipeYGesture_)
+    );
+  }
+
+  /**
+   * Checks for when scroll event should be stopped from propagating.
+   * @return {boolean}
+   * @private
+   */
+  shouldStopPropagation_() {
+    return (
+      this.state_ !== DrawerState.CLOSED ||
+      (this.state_ === DrawerState.CLOSED && this.touchEventState_.swipingUp)
+    );
   }
 
   /**
@@ -345,36 +378,12 @@ export class DraggableDrawer extends AMP.BaseElement {
   onSwipeY_(gesture) {
     const {data} = gesture;
 
-    if (this.ignoreCurrentSwipeYGesture_ === true) {
-      gesture.event.stopPropagation();
+    if (this.ignoreCurrentSwipeYGesture_) {
       this.ignoreCurrentSwipeYGesture_ = !data.last;
       return;
     }
 
     const {deltaY, swipingUp} = data;
-
-    // If the drawer is open, figure out if the user is trying to scroll the
-    // content, or actually close the drawer.
-    if (this.state_ === DrawerState.OPEN) {
-      const isContentSwipe = this.isDrawerContentDescendant_(
-        dev().assertElement(gesture.event.target)
-      );
-
-      // If user is swiping up, exit so the event bubbles up and maybe scrolls
-      // the drawer content.
-      // If user is swiping down and scrollTop is above zero, exit and let the
-      // user scroll the content.
-      // If user is swiping down and scrollTop is zero, don't exit and start
-      // dragging/closing the drawer.
-      if (
-        (isContentSwipe && deltaY < 0) ||
-        (isContentSwipe && deltaY > 0 && this.containerEl_./*OK*/ scrollTop > 0)
-      ) {
-        gesture.event.stopPropagation();
-        this.ignoreCurrentSwipeYGesture_ = true;
-        return;
-      }
-    }
 
     if (data.last === true) {
       if (this.state_ === DrawerState.DRAGGING_TO_CLOSE) {
@@ -401,7 +410,37 @@ export class DraggableDrawer extends AMP.BaseElement {
       return;
     }
 
-    this.drag_(deltaY, gesture);
+    this.drag_(deltaY);
+  }
+
+  /**
+   * Ignores current vertical swipe when user is scrolling content.
+   * @param {{event: !Event, data: !Object}} gesture
+   * @private
+   */
+  setIgnoreCurrentSwipeY_(gesture) {
+    const {data} = gesture;
+    const {deltaY} = data;
+    // If the drawer is open, figure out if the user is trying to scroll the
+    // content, or actually close the drawer.
+    if (this.state_ === DrawerState.OPEN) {
+      const isContentSwipe = this.isDrawerContentDescendant_(
+        dev().assertElement(gesture.event.target)
+      );
+
+      // If user is swiping up, exit so the event bubbles up and maybe scrolls
+      // the drawer content.
+      // If user is swiping down and scrollTop is above zero, exit and let the
+      // user scroll the content.
+      // If user is swiping down and scrollTop is zero, don't exit and start
+      // dragging/closing the drawer.
+      if (
+        (isContentSwipe && deltaY < 0) ||
+        (isContentSwipe && deltaY > 0 && this.containerEl_./*OK*/ scrollTop > 0)
+      ) {
+        this.ignoreCurrentSwipeYGesture_ = true;
+      }
+    }
   }
 
   /**
@@ -443,10 +482,9 @@ export class DraggableDrawer extends AMP.BaseElement {
   /**
    * Drags the drawer on the screen upon user interaction.
    * @param {number} deltaY
-   * @param {{event: !Event, data: !Object}} gesture
    * @private
    */
-  drag_(deltaY, gesture) {
+  drag_(deltaY) {
     let translate;
 
     switch (this.state_) {
@@ -454,10 +492,6 @@ export class DraggableDrawer extends AMP.BaseElement {
       case DrawerState.DRAGGING_TO_OPEN:
         if (deltaY > 0) {
           return;
-        }
-        if (this.state_ === DrawerState.DRAGGING_TO_OPEN) {
-          gesture.event.preventDefault();
-          gesture.event.stopPropagation();
         }
         this.state_ = DrawerState.DRAGGING_TO_OPEN;
         const drag = Math.max(deltaY, -this.dragCap_);
@@ -468,8 +502,6 @@ export class DraggableDrawer extends AMP.BaseElement {
         if (deltaY < 0) {
           return;
         }
-        gesture.event.preventDefault();
-        gesture.event.stopPropagation();
         this.state_ = DrawerState.DRAGGING_TO_CLOSE;
         translate = `translate3d(0, ${deltaY}px, 0)`;
         break;

--- a/src/amp-story-player/amp-story-player-impl.js
+++ b/src/amp-story-player/amp-story-player-impl.js
@@ -231,6 +231,7 @@ export class AmpStoryPlayer {
       startX: 0,
       startY: 0,
       lastX: 0,
+      startScrollY: 0,
       isSwipeX: null,
     };
 
@@ -1435,20 +1436,22 @@ export class AmpStoryPlayer {
 
     this.touchEventState_.startX = coordinates.x;
     this.touchEventState_.startY = coordinates.y;
+    this.touchEventState_.startScrollY = this.win_.scrollY;
   }
 
   /**
-   * Reacts to touchmove events and handles horizontal swipes.
+   * Reacts to touchmove events.
    * @param {!Event} event
    * @private
    */
   onTouchMove_(event) {
-    if (this.touchEventState_.isSwipeX === false) {
+    const coordinates = this.getClientTouchCoordinates_(event);
+    if (!coordinates) {
       return;
     }
 
-    const coordinates = this.getClientTouchCoordinates_(event);
-    if (!coordinates) {
+    if (this.touchEventState_.isSwipeX === false) {
+      this.forwardScrollingEvent_(coordinates.y);
       return;
     }
 
@@ -1470,6 +1473,15 @@ export class AmpStoryPlayer {
     });
   }
 
+  /**
+   * Forwards scrolling event from iframe to parent window.
+   * @param {number} touchEventY
+   * @private
+   */
+  forwardScrollingEvent_(touchEventY) {
+    const deltaY = touchEventY - this.touchEventState_.startY;
+    this.win_.scroll(0, this.touchEventState_.startScrollY - deltaY);
+  }
   /**
    * Reacts to touchend events. Resets cached touch event states.
    * @private

--- a/src/amp-story-player/amp-story-player-impl.js
+++ b/src/amp-story-player/amp-story-player-impl.js
@@ -1482,6 +1482,7 @@ export class AmpStoryPlayer {
     const deltaY = touchEventY - this.touchEventState_.startY;
     this.win_.scroll(0, this.touchEventState_.startScrollY - deltaY);
   }
+
   /**
    * Reacts to touchend events. Resets cached touch event states.
    * @private

--- a/src/amp-story-player/amp-story-player-impl.js
+++ b/src/amp-story-player/amp-story-player-impl.js
@@ -1437,10 +1437,10 @@ export class AmpStoryPlayer {
       return;
     }
 
-    this.touchEventState_.startX = coordinates.x;
-    this.touchEventState_.startY = coordinates.y;
+    this.touchEventState_.startX = coordinates.screenX;
+    this.touchEventState_.startY = coordinates.screenY;
 
-    this.pageScroller_.onTouchStart(event.timeStamp, coordinates.y);
+    this.pageScroller_.onTouchStart(event.timeStamp, coordinates.clientY);
   }
 
   /**
@@ -1455,24 +1455,24 @@ export class AmpStoryPlayer {
     }
 
     if (this.touchEventState_.isSwipeX === false) {
-      this.pageScroller_.onTouchMove(event.timeStamp, coordinates.y);
+      this.pageScroller_.onTouchMove(event.timeStamp, coordinates.clientY);
       return;
     }
 
-    const {x, y} = coordinates;
-    this.touchEventState_.lastX = x;
+    const {screenX, screenY} = coordinates;
+    this.touchEventState_.lastX = screenX;
 
     if (this.touchEventState_.isSwipeX === null) {
       this.touchEventState_.isSwipeX =
-        Math.abs(this.touchEventState_.startX - x) >
-        Math.abs(this.touchEventState_.startY - y);
+        Math.abs(this.touchEventState_.startX - screenX) >
+        Math.abs(this.touchEventState_.startY - screenY);
       if (!this.touchEventState_.isSwipeX) {
         return;
       }
     }
 
     this.onSwipeX_({
-      deltaX: x - this.touchEventState_.startX,
+      deltaX: screenX - this.touchEventState_.startX,
       last: false,
     });
   }
@@ -1666,7 +1666,7 @@ export class AmpStoryPlayer {
       return null;
     }
 
-    const {screenX: x, screenY: y} = touches[0];
-    return {x, y};
+    const {screenX, screenY, clientX, clientY} = touches[0];
+    return {screenX, screenY, clientX, clientY};
   }
 }

--- a/src/amp-story-player/page-scroller.js
+++ b/src/amp-story-player/page-scroller.js
@@ -1,0 +1,240 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Applies scroll and momentum to window by using touch events.
+ */
+export class PageScroller {
+  /**
+   * @param {!Window} win
+   */
+  constructor(win) {
+    /** @private {!Window} */
+    this.win_ = win;
+
+    /** @private {!Object} */
+    this.touchEventState_ = {
+      startY: 0,
+      lastDelta: 0,
+      touchStartTimeMs: null,
+      touchEndTimeMs: null,
+      touchMoveTimeMs: null,
+    };
+
+    /** @private {!Object} */
+    this.scrollState_ = {
+      startY: 0,
+      isRunning: false,
+      acceleration: 1,
+      speedLimit: 1.2,
+      startTimeMs: null,
+      maxTimeBetweenSwipesMs: 250,
+      moveTimeThresholdMs: 100,
+      durationMs: null,
+      meetsDeltaYThreshold: false,
+      deltaYThresholdPx: 5,
+      deltaY: null,
+      offsetThresholdPx: 30,
+      offsetPx: null,
+      multiplier: 1,
+    };
+  }
+
+  /**
+   * Reacts to onTouchStart events. Applies multiplier if criteria is met.
+   * @param {number} timeStamp
+   * @param {number} startY
+   */
+  onTouchStart(timeStamp, startY) {
+    this.touchEventState_.startY = startY;
+    this.touchEventState_.touchStartTimeMs = timeStamp;
+    this.scrollState_.startY = this.win_.scrollY;
+
+    if (
+      this.scrollState_.isRunning &&
+      this.touchEventState_.touchEndTimeMs -
+        this.touchEventState_.touchStartTimeMs <
+        this.scrollState_.maxTimeBetweenSwipesMs
+    ) {
+      // User swiped while still scrolling, increase the multiplier for the offset.
+      this.scrollState_.multiplier += this.scrollState_.acceleration;
+    } else {
+      this.scrollState_.multiplier = 1;
+    }
+
+    this.scrollState_.isRunning = false;
+  }
+
+  /**
+   * Reacts to onTouchMove events. Scrolls 1:1 if criteria is met.
+   * @param {number} timeStamp
+   * @param {number} currentY
+   */
+  onTouchMove(timeStamp, currentY) {
+    this.touchEventState_.touchMoveTimeMs = timeStamp;
+    currentY += this.scrollState_.deltaY;
+    this.scrollState_.deltaY = currentY - this.touchEventState_.startY;
+
+    this.scrollState_.meetsDeltaYThreshold =
+      Math.abs(this.scrollState_.deltaY) > this.scrollState_.deltaYThresholdPx;
+
+    if (!this.scrollState_.meetsDeltaYThreshold) {
+      return;
+    }
+
+    this.scrollState_.acceleration = Math.abs(
+      this.scrollState_.deltaY /
+        (this.touchEventState_.touchMoveTimeMs -
+          this.touchEventState_.touchStartTimeMs)
+    );
+
+    this.win_.scroll(0, this.scrollState_.startY - this.scrollState_.deltaY);
+  }
+
+  /**
+   * Reacts to touchEnd events. Applies momentum scrolling if criteria is met.
+   * @param {number} timeStamp
+   */
+  onTouchEnd(timeStamp) {
+    this.touchEventState_.touchEndTimeMs = timeStamp;
+
+    if (!this.scrollState_.meetsDeltaYThreshold) {
+      return;
+    }
+
+    const timeFromLastTouchMove =
+      this.touchEventState_.touchEndTimeMs -
+      this.touchEventState_.touchMoveTimeMs;
+
+    this.scrollState_.offsetPx = this.calculateOffset_();
+
+    if (
+      timeFromLastTouchMove < this.scrollState_.moveTimeThresholdMs &&
+      Math.abs(this.scrollState_.offsetPx) > this.scrollState_.offsetThresholdPx
+    ) {
+      // If timefromLastTouchMove is low enough and the offset is above the
+      // threshold, (re)set the scroll parameters to include momentum.
+      this.scrollState_.durationMs = this.win_.innerHeight * 1.2;
+      this.scrollState_.isRunning = true;
+      this.scrollState_.multiplier = 1;
+
+      requestAnimationFrame((timestamp) => {
+        this.scrollState_.startTimeMs = timestamp;
+        this.scrollState_.startY = this.win_.scrollY;
+        this.scrollOnNextTick_(timestamp);
+      });
+    }
+
+    this.touchEventState_.startY = 0;
+    this.scrollState_.deltaY = 0;
+  }
+
+  /**
+   * Calculates pixel offset and direction to be scrolled by getting current
+   * acceleration and preset limits.
+   * @private
+   * @return {number}
+   */
+  calculateOffset_() {
+    const maxOffset = this.win_.innerHeight * this.scrollState_.speedLimit;
+
+    let offset =
+      Math.pow(this.scrollState_.acceleration, 2) * this.win_.innerHeight;
+
+    offset = Math.min(maxOffset, offset);
+
+    offset *=
+      this.scrollState_.deltaY > 0
+        ? -this.scrollState_.multiplier
+        : this.scrollState_.multiplier;
+
+    return offset;
+  }
+
+  /**
+   * Calculates scrolling position at each frame. Stops once durationMs is met
+   * or scrollState stops running.
+   * @param {number} timeStamp
+   * @private
+   */
+  scrollOnNextTick_(timeStamp) {
+    const runTime = timeStamp - this.scrollState_.startTimeMs;
+
+    if (runTime > this.scrollState_.durationMs) {
+      return;
+    }
+
+    const percentageElapsed = runTime / this.scrollState_.durationMs;
+
+    const progress = this.getScrollTo_({
+      percentTimeElapsed: Math.min(percentageElapsed, 1),
+      x1: 0.2,
+      y1: 0.46,
+      x2: 0.5,
+      y2: 0.9,
+    });
+
+    const scrollDelta = progress * this.scrollState_.offsetPx;
+
+    const scrollForThisTick = this.scrollState_.startY + scrollDelta;
+
+    if (!this.scrollState_.isRunning) {
+      cancelAnimationFrame(
+        requestAnimationFrame(this.scrollOnNextTick_.bind(this))
+      );
+    } else {
+      this.win_.scroll(0, scrollForThisTick);
+      requestAnimationFrame(this.scrollOnNextTick_.bind(this));
+    }
+  }
+
+  /**
+   * Uses the cubic bezier function to return scrolling position given percent
+   * of time elapsed and 2 points in the graph.
+   * P0: (0, 0)
+   * P1: (x1, y1)
+   * P2: (x2, y2)
+   * P3: (1, 1)
+   * @param {!Object} cubicBezierParams
+   * @return {number} percentage progress (value between 0 and 1).
+   * @private
+   */
+  getScrollTo_({percentTimeElapsed, x1, y1, x2, y2}) {
+    const B1 = (t) => {
+      return Math.pow(t, 3);
+    };
+
+    const B2 = (t) => {
+      return 3 * t * t * (1 - t);
+    };
+
+    const B3 = (t) => {
+      return 3 * t * Math.pow(1 - t, 2);
+    };
+
+    const B4 = (t) => {
+      return Math.pow(1 - t, 3);
+    };
+
+    return (
+      1 -
+      (x1 * B1(percentTimeElapsed) +
+        y1 * B2(percentTimeElapsed) +
+        x2 * B3(percentTimeElapsed) +
+        y2 * B4(percentTimeElapsed))
+    );
+  }
+}

--- a/src/amp-story-player/page-scroller.js
+++ b/src/amp-story-player/page-scroller.js
@@ -36,9 +36,6 @@ export class PageScroller {
     /** @private {!Window} */
     this.win_ = win;
 
-    /** @private {number} */
-    this.cachedWinHeight_ = null;
-
     /** @private {!Object} */
     this.touchEventState_ = {
       startY: 0,
@@ -77,8 +74,6 @@ export class PageScroller {
     this.touchEventState_.startY = startY;
     this.touchEventState_.touchStartTimeMs = timeStamp;
     this.scrollState_.startY = this.win_./*OK*/ scrollY;
-    this.cachedWinHeight_ =
-      this.cachedWinHeight_ || this.win_./*OK*/ innerHeight;
 
     if (
       this.scrollState_.isRunning &&
@@ -126,7 +121,7 @@ export class PageScroller {
       return;
     }
 
-    this.win_.scrollBy(0, -this.scrollState_.deltaY);
+    this.win_./*OK*/ scrollBy(0, -this.scrollState_.deltaY);
   }
 
   /**
@@ -152,7 +147,7 @@ export class PageScroller {
     ) {
       // If timefromLastTouchMove is low enough and the offset is above the
       // threshold, (re)set the scroll parameters to include momentum.
-      this.scrollState_.durationMs = this.cachedWinHeight_ * 1.2;
+      this.scrollState_.durationMs = this.win_./*OK*/ innerHeight * 1.2;
       this.scrollState_.isRunning = true;
 
       requestAnimationFrame((timestamp) => {
@@ -174,10 +169,12 @@ export class PageScroller {
    * @return {number}
    */
   calculateOffset_() {
-    const maxOffset = this.cachedWinHeight_ * this.scrollState_.speedLimit;
+    const maxOffset =
+      this.win_./*OK*/ innerHeight * this.scrollState_.speedLimit;
 
     let offset =
-      Math.pow(this.scrollState_.acceleration, 2) * this.cachedWinHeight_;
+      Math.pow(this.scrollState_.acceleration, 2) *
+      this.win_./*OK*/ innerHeight;
 
     offset = Math.min(maxOffset, offset);
 

--- a/src/amp-story-player/page-scroller.js
+++ b/src/amp-story-player/page-scroller.js
@@ -141,7 +141,6 @@ export class PageScroller {
       // threshold, (re)set the scroll parameters to include momentum.
       this.scrollState_.durationMs = this.win_.innerHeight * 1.2;
       this.scrollState_.isRunning = true;
-      this.scrollState_.multiplier = 1;
 
       requestAnimationFrame((timestamp) => {
         this.scrollState_.startTimeMs = timestamp;
@@ -150,6 +149,7 @@ export class PageScroller {
       });
     }
 
+    this.scrollState_.multiplier = 1;
     this.touchEventState_.startY = 0;
     this.scrollState_.deltaY = 0;
   }


### PR DESCRIPTION
Closes #28009

Forwards vertical touch events from the iframe into scroll events for the parent window in order to allow scrolling. 

~Works well except that inertia scrolling doesn't really work since we are setting the scrolling coordinates via JS.~
