### PR TITLE
🐛 [Story Interactive] Two lines on quizzes sometimes make percentages wrap

### DIFF
--- a/extensions/amp-story-interactive/0.1/amp-story-interactive-quiz.css
+++ b/extensions/amp-story-interactive/0.1/amp-story-interactive-quiz.css
@@ -109,6 +109,7 @@
   padding-left: 1em !important;
   margin-left: auto !important;
   visibility: hidden !important;
+  flex-shrink: 0 !important;
 }
 
 .i-amphtml-story-interactive-quiz-option:not(.i-amphtml-story-interactive-option-selected) .i-amphtml-story-interactive-quiz-percentage-text {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/22420856/98594541-d21b8f80-22a2-11eb-836d-c2e1292ee4af.png)

Numbers and percentages could get split into separate lines if the option text has 2 lines on a quiz.

Uses `flex-shring` to enforce the percentage will take as much space as needed.