### PR TITLE
Update amp-jwplayer validator

### DIFF
--- a/extensions/amp-jwplayer/0.1/test/validator-amp-jwplayer.html
+++ b/extensions/amp-jwplayer/0.1/test/validator-amp-jwplayer.html
@@ -42,6 +42,12 @@
       data-playlist-id="482jsTAr"
       width="160" height="90">
   </amp-jwplayer>
+  <!-- Alternate valid example verifying outstream as a valid data-media-id. -->
+  <amp-jwplayer
+      data-player-id="BjcwyK37"
+      data-media-id="outstream"
+      width="160" height="90">
+  </amp-jwplayer>
   <!-- Invalid example missing a player id. -->
   <amp-jwplayer
       data-playerlist-id="482jsTAr"

--- a/extensions/amp-jwplayer/0.1/test/validator-amp-jwplayer.out
+++ b/extensions/amp-jwplayer/0.1/test/validator-amp-jwplayer.out
@@ -43,19 +43,25 @@ FAIL
 |        data-playlist-id="482jsTAr"
 |        width="160" height="90">
 |    </amp-jwplayer>
+|    <!-- Alternate valid example verifying outstream as a valid data-media-id. -->
+|    <amp-jwplayer
+|        data-player-id="BjcwyK37"
+|        data-media-id="outstream"
+|        width="160" height="90">
+|    </amp-jwplayer>
 |    <!-- Invalid example missing a player id. -->
 |    <amp-jwplayer
 >>   ^~~~~~~~~
-amp-jwplayer/0.1/test/validator-amp-jwplayer.html:46:2 The tag 'amp-jwplayer' is missing a mandatory attribute - pick one of ['data-media-id', 'data-playlist-id']. (see https://amp.dev/documentation/components/amp-jwplayer/)
+amp-jwplayer/0.1/test/validator-amp-jwplayer.html:52:2 The tag 'amp-jwplayer' is missing a mandatory attribute - pick one of ['data-media-id', 'data-playlist-id']. (see https://amp.dev/documentation/components/amp-jwplayer/)
 >>   ^~~~~~~~~
-amp-jwplayer/0.1/test/validator-amp-jwplayer.html:46:2 The mandatory attribute 'data-player-id' is missing in tag 'amp-jwplayer'. (see https://amp.dev/documentation/components/amp-jwplayer/)
+amp-jwplayer/0.1/test/validator-amp-jwplayer.html:52:2 The mandatory attribute 'data-player-id' is missing in tag 'amp-jwplayer'. (see https://amp.dev/documentation/components/amp-jwplayer/)
 |        data-playerlist-id="482jsTAr"
 |        width="160" height="90">
 |    </amp-jwplayer>
 |    <!-- Invalid example missing playlist id or media-id. -->
 |    <amp-jwplayer
 >>   ^~~~~~~~~
-amp-jwplayer/0.1/test/validator-amp-jwplayer.html:51:2 The tag 'amp-jwplayer' is missing a mandatory attribute - pick one of ['data-media-id', 'data-playlist-id']. (see https://amp.dev/documentation/components/amp-jwplayer/)
+amp-jwplayer/0.1/test/validator-amp-jwplayer.html:57:2 The tag 'amp-jwplayer' is missing a mandatory attribute - pick one of ['data-media-id', 'data-playlist-id']. (see https://amp.dev/documentation/components/amp-jwplayer/)
 |        data-player-id="BjcwyK37"
 |        width="160" height="90">
 |    </amp-jwplayer>

--- a/extensions/amp-jwplayer/amp-jwplayer.md
+++ b/extensions/amp-jwplayer/amp-jwplayer.md
@@ -64,7 +64,7 @@ Example:
   </tr>
   <tr>
     <td width="40%"><strong>data-media-id</strong></td>
-    <td>The JW Platform media id. This is an 8-digit alphanumeric sequence that can be found in the <a href="https://dashboard.jwplayer.com/#/content">Content</a> section in your JW Player Dashboard. (<strong>Required if <code>data-playlist-id</code> is not defined.</strong>)</td>
+    <td>The JW Platform media id. This is an 8-digit alphanumeric sequence that can be found in the <a href="https://dashboard.jwplayer.com/#/content">Content</a> section in your JW Player Dashboard. (<strong>Required if <code>data-playlist-id</code> is not defined.</strong>). Note: <code>outstream</code> is also a valid value.</td>
   </tr>
   <tr>
     <td width="40%"><strong>data-playlist-id</strong></td>

--- a/extensions/amp-jwplayer/validator-amp-jwplayer.protoascii
+++ b/extensions/amp-jwplayer/validator-amp-jwplayer.protoascii
@@ -37,7 +37,7 @@ tags: {  # <amp-jwplayer>
   attrs: {
     name: "data-media-id"
     mandatory_oneof: "['data-media-id', 'data-playlist-id']"
-    value_regex_casei: "[0-9a-z]{8}"
+    value_regex_casei: "[0-9a-z]{8}|outstream"
   }
   attrs: {
     name: "data-player-id"


### PR DESCRIPTION
This PR updates the spec file for `amp-jwplayer` to allow `outstream` as a valid data-media-id in addition to the existing regex rule. 