### PR TITLE
🐛 amp-carousel: Fix edge calculations for RTL

### DIFF
--- a/extensions/amp-base-carousel/0.1/carousel.js
+++ b/extensions/amp-base-carousel/0.1/carousel.js
@@ -904,9 +904,7 @@ export class Carousel {
       return false;
     }
 
-    return this.forwards_
-      ? this.isScrollAtRightEdge()
-      : this.isScrollAtLeftEdge();
+    return this.isScrollAtEndingEdge_();
   }
 
   /**
@@ -918,29 +916,38 @@ export class Carousel {
       return false;
     }
 
-    return this.forwards_
-      ? this.isScrollAtLeftEdge()
-      : this.isScrollAtRightEdge();
+    return this.isScrollAtBeginningEdge_();
   }
 
   /**
    * @return {boolean} True if the scrolling is at the right edge of the
-   *    carousel. Note that this ignores RTL, and only checks for the right
-   *    edge.
+   *    carousel in LTR and left edge of the carousel if RTL.
+   * @private
    */
-  isScrollAtRightEdge() {
+  isScrollAtEndingEdge_() {
     const el = this.scrollContainer_;
-    const {width} = el./*OK*/ getBoundingClientRect();
-    return el./*OK*/ scrollLeft + Math.ceil(width) >= el./*OK*/ scrollWidth;
+    const vector =
+      el./*OK*/ getBoundingClientRect().width * (this.forwards_ ? 1 : -1);
+    const roundedVector = this.forwards_
+      ? Math.ceil(vector)
+      : Math.floor(vector);
+    const edgeClosestToEnd = el./*OK*/ scrollLeft + roundedVector;
+    const containerScrollWidth = el./*OK*/ scrollWidth;
+
+    const atEndingEdge = this.forwards_
+      ? edgeClosestToEnd >= containerScrollWidth
+      : edgeClosestToEnd <= -containerScrollWidth;
+    return atEndingEdge;
   }
 
   /**
    * @return {boolean} True if the scrolling is at the left edge of the
-   *    carousel. Note that this ignores RTL, and only checks for the left
-   *    edge.
+   *    carousel for LTR and right edge for RTL.
+   * @private
    */
-  isScrollAtLeftEdge() {
-    return this.scrollContainer_./*OK*/ scrollLeft <= 0;
+  isScrollAtBeginningEdge_() {
+    const currentScrollPos = this.scrollContainer_./*OK*/ scrollLeft;
+    return this.forwards_ ? currentScrollPos <= 0 : currentScrollPos >= 0;
   }
 
   /**

--- a/extensions/amp-base-carousel/0.1/test/test-carousel.js
+++ b/extensions/amp-base-carousel/0.1/test/test-carousel.js
@@ -156,8 +156,7 @@ describes.realWin('carousel implementation', {}, (env) => {
       expect(carousel.isAtEnd()).to.be.true;
     });
 
-    // TODO(#30563): fix and unskip.
-    it.skip('should return false when at not at end for RTL', async () => {
+    it('should return false when at not at end for RTL', async () => {
       setStyle(element, 'width', '299.2px');
       element.setAttribute('dir', 'rtl');
 
@@ -208,8 +207,7 @@ describes.realWin('carousel implementation', {}, (env) => {
       expect(carousel.isAtStart()).to.be.false;
     });
 
-    // TODO(#30563): fix and unskip.
-    it.skip('should return true when at start for RTL', async () => {
+    it('should return true when at start for RTL', async () => {
       setStyle(element, 'width', '299.2px');
       element.setAttribute('dir', 'rtl');
 


### PR DESCRIPTION
Closes: #31054
Unskips: #30563 (related to larger #30661)

Root cause is that [scrollLeft](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollLeft) accounts for RTL; it is negative when scrolling left in RTL and positive when scrolling right in LTR.

Made appropriate changes to our `isScrollAtRightEdge ` and `isScrollAtLeftEdge ` methods.

Edit: This fix only applies to `amp-carousel-0.2` since `amp-carousel-0.1` does not support `dir=rtl` (confirmed with @nainar).