### PR TITLE
♻️ Refactor: remove a4a dependency from real time config manager

### DIFF
--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -2218,11 +2218,15 @@ export class AmpA4A extends AMP.BaseElement {
   tryExecuteRealTimeConfig_(consentState, consentString, consentMetadata) {
     if (!!AMP.RealTimeConfigManager) {
       try {
-        return new AMP.RealTimeConfigManager(this).maybeExecuteRealTimeConfig(
+        return new AMP.RealTimeConfigManager(
+          this.getAmpDoc()
+        ).maybeExecuteRealTimeConfig(
+          this.element,
           this.getCustomRealTimeConfigMacros_(),
           consentState,
           consentString,
-          consentMetadata
+          consentMetadata,
+          this.verifyStillCurrent()
         );
       } catch (err) {
         user().error(TAG, 'Could not perform Real Time Config.', err);

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -1414,7 +1414,16 @@ describe('amp-a4a', () => {
       expect(a4a.isVerifiedAmpCreative()).to.be.true;
       expect(tryExecuteRealTimeConfigSpy.calledOnce).to.be.true;
       expect(maybeExecuteRealTimeConfigStub.calledOnce).to.be.true;
-      expect(maybeExecuteRealTimeConfigStub.calledWith({}, null)).to.be.true;
+      expect(
+        maybeExecuteRealTimeConfigStub.calledWith(
+          a4aElement,
+          {},
+          null,
+          null,
+          null,
+          window.sandbox.match.any
+        )
+      ).to.be.true;
       expect(getAdUrlSpy.calledOnce, 'getAdUrl called exactly once').to.be.true;
       expect(
         getAdUrlSpy.calledWith(


### PR DESCRIPTION
In order for real time config to be shared between A4A and ima-video, we must stop letting it depend on `AmpA4A` element. This PR removes A4A completely from real time config manager.

https://github.com/ampproject/amphtml/issues/20259