### PR TITLE
Turn on amp-backup-cid experiment in canary

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -39,5 +39,6 @@
   "build-in-chunks": 1,
   "visibility-trigger-improvements": 1,
   "adsense-ptt-exp": 0.1,
-  "doubleclick-ptt-exp": 0.1
+  "doubleclick-ptt-exp": 0.1,
+  "amp-cid-backup": 1
 }


### PR DESCRIPTION
Turn on `amp-backup-cid` experiment (#30375) in canary.

To be merged after Wednesday, after the release freeze ends.

Turn on in prod the following week. 