### PR TITLE
✨ Dynamically insert amp-analytics based on ad response headers

### DIFF
--- a/extensions/amp-ad-network-nws-impl/0.1/amp-ad-network-nws-impl.js
+++ b/extensions/amp-ad-network-nws-impl/0.1/amp-ad-network-nws-impl.js
@@ -15,18 +15,106 @@
  */
 
 import {AmpA4A} from '../../amp-a4a/0.1/amp-a4a';
+import {dev, devAssert} from '../../../src/log';
+import {insertAnalyticsElement} from '../../../src/extension-analytics';
+import {parseJson} from '../../../src/json';
+import {removeElement} from '../../../src/dom';
 
 const URL = 'https://svr.nws.ai/a4a';
+
+const NWS_HEADER = 'X-NWS';
 
 /**
  *  Fast Fetch implementation for Newsroom AI
  */
 export class AmpAdNetworkNwsImpl extends AmpA4A {
+  /**
+   * @param {!Element} element
+   */
+  constructor(element) {
+    super(element);
+
+    /**
+     * Config to generate amp-analytics element for active view reporting.
+     * @type {?JsonObject}
+     * @private
+     */
+    this.ampAnalyticsConfig_ = null;
+
+    /** @private {?Element} */
+    this.ampAnalyticsElement_ = null;
+  }
+
+  /**
+   * Extracts configuration used to build amp-analytics element for active view
+   * and begin to render.
+   *
+   * @param {!Headers} responseHeaders
+   *   XHR service FetchResponseHeaders object containing the response
+   *   headers.
+   * @return {?JsonObject} config or null if invalid/missing.
+   */
+  extractAmpAnalyticsConfig(responseHeaders) {
+    if (!responseHeaders.has(NWS_HEADER)) {
+      return null;
+    }
+    try {
+      const responseConfig = parseJson(responseHeaders.get(NWS_HEADER));
+      const analyticsConfig = responseConfig['ampAnalytics'];
+      const config = {
+        'transport': {'beacon': true, 'xhrpost': true, 'image': true},
+        'requests': {},
+        'triggers': {},
+      };
+      Object.assign(config, analyticsConfig);
+
+      return config;
+    } catch (err) {
+      dev().error(
+        'AMP-A4A',
+        'Invalid analytics',
+        err,
+        responseHeaders.get(NWS_HEADER)
+      );
+    }
+  }
+
   /** @override */
   getAdUrl(unusedConsentState, opt_rtcResponsesPromise) {
     const dataSlot = this.element.getAttribute('data-slot');
     const url = `${URL}?slot=${encodeURIComponent(dataSlot)}`;
     return url;
+  }
+
+  /** @override */
+  extractSize(responseHeaders) {
+    this.ampAnalyticsConfig_ = this.extractAmpAnalyticsConfig(responseHeaders);
+    const size = super.extractSize(responseHeaders);
+    return size;
+  }
+
+  /** @override */
+  tearDownSlot() {
+    super.tearDownSlot();
+    if (this.ampAnalyticsElement_) {
+      removeElement(this.ampAnalyticsElement_);
+      this.ampAnalyticsElement_ = null;
+    }
+    this.ampAnalyticsConfig_ = null;
+  }
+
+  /** @override */
+  onCreativeRender(creativeMetaData, opt_onLoadPromise) {
+    super.onCreativeRender(creativeMetaData);
+    devAssert(!this.ampAnalyticsElement_);
+    if (this.ampAnalyticsConfig_) {
+      this.ampAnalyticsElement_ = insertAnalyticsElement(
+        this.element,
+        this.ampAnalyticsConfig_,
+        /*loadAnalytics*/ true,
+        false
+      );
+    }
   }
 }
 

--- a/extensions/amp-ad-network-nws-impl/0.1/test/test-nws-a4a-config.js
+++ b/extensions/amp-ad-network-nws-impl/0.1/test/test-nws-a4a-config.js
@@ -14,11 +14,19 @@
  * limitations under the License.
  */
 
+// These two are required for reasons internal to AMP
+import '../../../../extensions/amp-ad/0.1/amp-ad-ui';
+import '../../../../extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler';
+
 import {AmpAdNetworkNwsImpl} from '../amp-ad-network-nws-impl';
 import {createElementWithAttributes} from '../../../../src/dom';
+// There seems to be a conflict between import none syntax
+// and alphabetical sorting.
+// eslint-disable-next-line, sort-imports-es6
+import {Services} from '../../../../src/services';
 
 describes.fakeWin('amp-ad-network-nws-impl', {amp: true}, (env) => {
-  let win, doc, element, impl;
+  let win, doc, element, impl, preloadExtensionSpy;
 
   beforeEach(() => {
     win = env.win;
@@ -29,6 +37,8 @@ describes.fakeWin('amp-ad-network-nws-impl', {amp: true}, (env) => {
     });
     doc.body.appendChild(element);
     impl = new AmpAdNetworkNwsImpl(element);
+    const extensions = Services.extensionsFor(impl.win);
+    preloadExtensionSpy = env.sandbox.spy(extensions, 'preloadExtension');
   });
 
   describe('#getAdUrl', () => {
@@ -38,6 +48,36 @@ describes.fakeWin('amp-ad-network-nws-impl', {amp: true}, (env) => {
       expect(impl.getAdUrl()).to.equal(
         `https://svr.nws.ai/a4a?slot=${encodeURIComponent(dataSlot)}`
       );
+    });
+  });
+
+  describe('#extractSize', () => {
+    it('should not load amp-analytics without header', () => {
+      impl.extractSize({
+        get() {
+          return undefined;
+        },
+        has() {
+          return false;
+        },
+      });
+      expect(preloadExtensionSpy.withArgs('amp-analytics')).to.not.be.called;
+    });
+    it('should load amp-analytics with header', () => {
+      impl.extractSize({
+        get(name) {
+          switch (name) {
+            case 'X-NWS':
+              return '{"ampAnalytics": {}}';
+            default:
+              return undefined;
+          }
+        },
+        has(name) {
+          return !!this.get(name);
+        },
+      });
+      expect(preloadExtensionSpy.withArgs('amp-analytics')).to.not.be.called;
     });
   });
 });


### PR DESCRIPTION
We need to be able to dynamically insert tracking URLs for analytics.
This PR allows us to do that, by returning the necessary config encoded as json in an X-NWS header in the ad response.