### PR TITLE
✨ [bento][amp-accordion] Restructure section, header, and content components

### DIFF
--- a/extensions/amp-accordion/1.0/accordion.js
+++ b/extensions/amp-accordion/1.0/accordion.js
@@ -35,10 +35,10 @@ import {
 import {useStyles} from './accordion.jss';
 
 const AccordionContext = Preact.createContext(
-  /** @type {AccordionDef.ContextProps} */ ({})
+  /** @type {AccordionDef.AccordionContextProps} */ ({})
 );
 const SectionContext = Preact.createContext(
-  /** @type {AccordionDef.ContextProps} */ ({})
+  /** @type {AccordionDef.SectionContextProps} */ ({})
 );
 
 /** @type {!Object<string, boolean>} */
@@ -51,7 +51,7 @@ const generateSectionId = sequentialIdGenerator();
 const generateRandomId = randomIdGenerator(100000);
 
 /**
- * @param {!AccordionDef.Props} props
+ * @param {!AccordionDef.AccordionProps} props
  * @param {{current: (!AccordionDef.AccordionApi|null)}} ref
  * @return {PreactDef.Renderable}
  */
@@ -206,7 +206,7 @@ function AccordionWithRef(
 
   const context = useMemo(
     () =>
-      /** @type {!AccordionDef.ContextProps} */ ({
+      /** @type {!AccordionDef.AccordionContextProps} */ ({
         registerSection,
         toggleExpanded,
         isExpanded,
@@ -252,7 +252,7 @@ function setExpanded(id, value, expandedMap, expandSingleSection) {
 }
 
 /**
- * @param {!AccordionDef.SectionProps} props
+ * @param {!AccordionDef.AccordionSectionProps} props
  * @return {PreactDef.Renderable}
  */
 export function AccordionSection({
@@ -281,7 +281,7 @@ export function AccordionSection({
   const animate = contextAnimate ?? defaultAnimate;
   const contentId = `${prefix || 'a'}-content-${id}-${suffix}`;
 
-  // Storying this state change callback in a ref because this may change
+  // Storing this state change callback in a ref because this may change
   // frequently and we do not want to trigger a re-register of the section
   // each time  the callback is updated
   const onExpandStateChangeRef = useRef(
@@ -312,12 +312,13 @@ export function AccordionSection({
   }, [id, toggleExpanded]);
 
   const context = useMemo(
-    () => ({
-      animate,
-      contentId,
-      expanded,
-      expandHandler,
-    }),
+    () =>
+      /** @type {AccordionDef.SectionContextProps} */ ({
+        animate,
+        contentId,
+        expanded,
+        expandHandler,
+      }),
     [animate, contentId, expanded, expandHandler]
   );
 
@@ -331,13 +332,13 @@ export function AccordionSection({
 }
 
 /**
- * @param {!AccordionDef.SectionHeaderProps} props
+ * @param {!AccordionDef.AccordionHeaderProps} props
  * @return {PreactDef.Renderable}
  */
-export function AccordionSectionHeader({
+export function AccordionHeader({
   as: Comp = 'header',
   role = 'button',
-  headerClassName = '',
+  className = '',
   tabIndex = 0,
   children,
   ...rest
@@ -349,7 +350,7 @@ export function AccordionSectionHeader({
     <Comp
       {...rest}
       role={role}
-      className={`${headerClassName} ${classes.sectionChild} ${classes.header}`}
+      className={`${className} ${classes.sectionChild} ${classes.header}`}
       tabIndex={tabIndex}
       aria-controls={contentId}
       onClick={expandHandler}
@@ -361,17 +362,17 @@ export function AccordionSectionHeader({
 }
 
 /**
- * @param {!AccordionDef.SectionContentProps} props
+ * @param {!AccordionDef.AccordionContentProps} props
  * @return {PreactDef.Renderable}
  */
-export function AccordionSectionContent({
+export function AccordionContent({
   as: Comp = 'div',
-  contentClassName = '',
+  className = '',
   children,
   ...rest
 }) {
+  const ref = useRef(null);
   const hasMountedRef = useRef(false);
-  const contentRef = useRef(null);
   const {contentId, expanded, animate} = useContext(SectionContext);
   const classes = useStyles();
 
@@ -382,7 +383,7 @@ export function AccordionSectionContent({
 
   useLayoutEffect(() => {
     const hasMounted = hasMountedRef.current;
-    const content = contentRef.current;
+    const content = ref.current;
     if (!animate || !hasMounted || !content || !content.animate) {
       return;
     }
@@ -392,8 +393,8 @@ export function AccordionSectionContent({
   return (
     <Comp
       {...rest}
-      ref={contentRef}
-      className={`${contentClassName} ${classes.sectionChild} ${classes.content}`}
+      ref={ref}
+      className={`${className} ${classes.sectionChild} ${classes.content}`}
       id={contentId}
       hidden={!expanded}
     >

--- a/extensions/amp-accordion/1.0/accordion.type.js
+++ b/extensions/amp-accordion/1.0/accordion.type.js
@@ -24,10 +24,11 @@ var AccordionDef = {};
  *   as: (string|PreactDef.FunctionalComponent|undefined),
  *   expandSingleSection: (boolean|undefined),
  *   animate: (boolean|undefined),
+ *   id: (string|undefined),
  *   children: (?PreactDef.Renderable|undefined),
  * }}
  */
-AccordionDef.Props;
+AccordionDef.AccordionProps;
 
 /**
  * @typedef {{
@@ -39,18 +40,27 @@ AccordionDef.Props;
  *   onExpandStateChange: (function(boolean):undefined|undefined),
  * }}
  */
-AccordionDef.SectionProps;
+AccordionDef.AccordionSectionProps;
 
 /**
  * @typedef {{
  *   as: (string|PreactDef.FunctionalComponent|undefined),
  *   role: (string|undefined),
- *   headerClassName: (string|undefined),
+ *   className: (string|undefined),
  *   tabIndex: (number|string|undefined),
  *   children: (?PreactDef.Renderable|undefined),
  * }}
  */
-AccordionDef.SectionHeaderProps;
+AccordionDef.AccordionHeaderProps;
+
+/**
+ * @typedef {{
+ *   as: (string|PreactDef.FunctionalComponent|undefined),
+ *   className: (string|undefined),
+ *   children: (?PreactDef.Renderable|undefined),
+ * }}
+ */
+AccordionDef.AccordionContentProps;
 
 /**
  * @typedef {{
@@ -60,15 +70,6 @@ AccordionDef.SectionHeaderProps;
  * }}
  */
 AccordionDef.HeaderProps;
-
-/**
- * @typedef {{
- *   as: (string|PreactDef.FunctionalComponent|undefined),
- *   contentClassName: (string|undefined),
- *   children: (?PreactDef.Renderable|undefined),
- * }}
- */
-AccordionDef.SectionContentProps;
 
 /**
  * @typedef {{
@@ -84,9 +85,20 @@ AccordionDef.ContentProps;
  *   isExpanded: (function(string, boolean):boolean),
  *   toggleExpanded: (function(string)|undefined),
  *   animate: (boolean|undefined),
+ *   prefix: (string),
  * }}
  */
-AccordionDef.ContextProps;
+AccordionDef.AccordionContextProps;
+
+/**
+ * @typedef {{
+ *   animate: (boolean),
+ *   contentId: (string),
+ *   expanded: (boolean),
+ *   expandHandler: (function():undefined)
+ * }}
+ */
+AccordionDef.SectionContextProps;
 
 /** @interface */
 AccordionDef.AccordionApi = class {

--- a/extensions/amp-accordion/1.0/accordion.type.js
+++ b/extensions/amp-accordion/1.0/accordion.type.js
@@ -32,18 +32,25 @@ AccordionDef.Props;
 /**
  * @typedef {{
  *   as: (string|PreactDef.FunctionalComponent|undefined),
- *   headerAs: (string|PreactDef.FunctionalComponent|undefined),
- *   contentAs: (string|PreactDef.FunctionalComponent|undefined),
  *   expanded: (boolean|undefined),
  *   animate: (boolean|undefined),
- *   headerClassName: (string|undefined),
- *   contentClassName: (string|undefined),
- *   header: (!PreactDef.Renderable),
+ *   id: (string|undefined),
  *   children: (?PreactDef.Renderable|undefined),
  *   onExpandStateChange: (function(boolean):undefined|undefined),
  * }}
  */
 AccordionDef.SectionProps;
+
+/**
+ * @typedef {{
+ *   as: (string|PreactDef.FunctionalComponent|undefined),
+ *   role: (string|undefined),
+ *   headerClassName: (string|undefined),
+ *   tabIndex: (number|string|undefined),
+ *   children: (?PreactDef.Renderable|undefined),
+ * }}
+ */
+AccordionDef.SectionHeaderProps;
 
 /**
  * @typedef {{
@@ -53,6 +60,15 @@ AccordionDef.SectionProps;
  * }}
  */
 AccordionDef.HeaderProps;
+
+/**
+ * @typedef {{
+ *   as: (string|PreactDef.FunctionalComponent|undefined),
+ *   contentClassName: (string|undefined),
+ *   children: (?PreactDef.Renderable|undefined),
+ * }}
+ */
+AccordionDef.SectionContentProps;
 
 /**
  * @typedef {{

--- a/extensions/amp-accordion/1.0/amp-accordion.js
+++ b/extensions/amp-accordion/1.0/amp-accordion.js
@@ -15,7 +15,12 @@
  */
 
 import * as Preact from '../../../src/preact';
-import {Accordion, AccordionSection} from './accordion';
+import {
+  Accordion,
+  AccordionSection,
+  AccordionSectionContent,
+  AccordionSectionHeader,
+} from './accordion';
 import {ActionTrust} from '../../../src/action-constants';
 import {CSS} from '../../../build/amp-accordion-1.0.css';
 import {PreactBaseElement} from '../../../src/preact/base-element';
@@ -107,16 +112,21 @@ function getState(element, mu) {
       EXPAND_STATE_SHIM_PROP,
       getExpandStateTrigger
     );
-    const props = dict({
+    const sectionProps = dict({
       'key': section,
       'as': sectionShim,
-      'headerAs': headerShim,
-      'contentAs': contentShim,
       'expanded': section.hasAttribute('expanded'),
       'id': section.getAttribute('id'),
       'onExpandStateChange': expandStateShim,
     });
-    return <AccordionSection {...props} />;
+    const headerProps = dict({'as': headerShim});
+    const contentProps = dict({'as': contentShim});
+    return (
+      <AccordionSection {...sectionProps}>
+        <AccordionSectionHeader {...headerProps}></AccordionSectionHeader>
+        <AccordionSectionContent {...contentProps}></AccordionSectionContent>
+      </AccordionSection>
+    );
   });
   return dict({'children': children});
 }

--- a/extensions/amp-accordion/1.0/amp-accordion.js
+++ b/extensions/amp-accordion/1.0/amp-accordion.js
@@ -17,9 +17,9 @@
 import * as Preact from '../../../src/preact';
 import {
   Accordion,
+  AccordionContent,
+  AccordionHeader,
   AccordionSection,
-  AccordionSectionContent,
-  AccordionSectionHeader,
 } from './accordion';
 import {ActionTrust} from '../../../src/action-constants';
 import {CSS} from '../../../build/amp-accordion-1.0.css';
@@ -123,8 +123,8 @@ function getState(element, mu) {
     const contentProps = dict({'as': contentShim});
     return (
       <AccordionSection {...sectionProps}>
-        <AccordionSectionHeader {...headerProps}></AccordionSectionHeader>
-        <AccordionSectionContent {...contentProps}></AccordionSectionContent>
+        <AccordionHeader {...headerProps}></AccordionHeader>
+        <AccordionContent {...contentProps}></AccordionContent>
       </AccordionSection>
     );
   });

--- a/extensions/amp-accordion/1.0/storybook/Basic.js
+++ b/extensions/amp-accordion/1.0/storybook/Basic.js
@@ -69,15 +69,21 @@ export const _default = () => {
         animate={animate}
       >
         <AccordionSection id="section1" key={1}>
-          <AccordionHeader as="h2">Section 1</AccordionHeader>
+          <AccordionHeader>
+            <h2>Section 1</h2>
+          </AccordionHeader>
           <AccordionContent>Content in section 1.</AccordionContent>
         </AccordionSection>
         <AccordionSection key={2}>
-          <AccordionHeader as="h2">Section 2</AccordionHeader>
+          <AccordionHeader>
+            <h2>Section 2</h2>
+          </AccordionHeader>
           <AccordionContent>Content in section 2.</AccordionContent>
         </AccordionSection>
         <AccordionSection key={3} expanded>
-          <AccordionHeader as="h2">Section 3</AccordionHeader>
+          <AccordionHeader>
+            <h2>Section 3</h2>
+          </AccordionHeader>
           <AccordionContent>Content in section 3.</AccordionContent>
         </AccordionSection>
       </AccordionWithActions>
@@ -97,7 +103,9 @@ function AccordionWithEvents(props) {
     <section>
       <Accordion ref={ref} {...props}>
         <AccordionSection id="section1" key={1} expanded>
-          <AccordionHeader as="h2">Section 1</AccordionHeader>
+          <AccordionHeader>
+            <h2>Section 1</h2>
+          </AccordionHeader>
           <AccordionContent>Content in section 1.</AccordionContent>
         </AccordionSection>
         <AccordionSection
@@ -109,7 +117,9 @@ function AccordionWithEvents(props) {
             }
           }}
         >
-          <AccordionHeader as="h2">Section 2</AccordionHeader>
+          <AccordionHeader>
+            <h2>Section 2</h2>
+          </AccordionHeader>
           <AccordionContent>Content in section 1.</AccordionContent>
         </AccordionSection>
         <AccordionSection
@@ -121,7 +131,9 @@ function AccordionWithEvents(props) {
             }
           }}
         >
-          <AccordionHeader as="h2">Section 3</AccordionHeader>
+          <AccordionHeader>
+            <h2>Section 3</h2>
+          </AccordionHeader>
           <AccordionContent>Content in section 3.</AccordionContent>
         </AccordionSection>
       </Accordion>

--- a/extensions/amp-accordion/1.0/storybook/Basic.js
+++ b/extensions/amp-accordion/1.0/storybook/Basic.js
@@ -15,7 +15,12 @@
  */
 
 import * as Preact from '../../../../src/preact';
-import {Accordion, AccordionSection} from '../accordion';
+import {
+  Accordion,
+  AccordionSection,
+  AccordionSectionContent,
+  AccordionSectionHeader,
+} from '../accordion';
 import {boolean, withKnobs} from '@storybook/addon-knobs';
 import {withA11y} from '@storybook/addon-a11y';
 
@@ -77,72 +82,34 @@ export const _default = () => {
   );
 };
 
-/**
- * @param {!Object} props
- * @return {*}
- */
-function AccordionWithEvents(props) {
-  // TODO(#30447): replace imperative calls with "button" knobs when the
-  // Storybook 6.1 is released.
-  const ref = Preact.useRef();
-  return (
-    <section>
-      <Accordion ref={ref} {...props}>
-        <AccordionSection
-          id="section1"
-          key={1}
-          expanded
-          header={<h2>Section 1</h2>}
-        >
-          <p>Content in section 1.</p>
-        </AccordionSection>
-        <AccordionSection
-          id="section2"
-          key={2}
-          header={<h2>Section 2</h2>}
-          onExpandStateChange={(expanded) => {
-            if (expanded) {
-              ref.current.expand('section3');
-            }
-          }}
-        >
-          <div>Content in section 2.</div>
-        </AccordionSection>
-        <AccordionSection
-          id="section3"
-          key={3}
-          header={<h2>Section 3</h2>}
-          onExpandStateChange={(expanded) => {
-            if (!expanded) {
-              ref.current.collapse('section2');
-            }
-          }}
-        >
-          <div>Content in section 3.</div>
-        </AccordionSection>
-      </Accordion>
-      <div style={{marginTop: 8}}>
-        <button onClick={() => ref.current.expand('section2')}>
-          expand(section2)
-        </button>
-        <button onClick={() => ref.current.collapse('section3')}>
-          collapse(section3)
-        </button>
-        <button onClick={() => ref.current.toggle()}>toggle all</button>
-      </div>
-    </section>
-  );
-}
-
-export const events = () => {
+export const restructure = () => {
   const expandSingleSection = boolean('expandSingleSection', false);
   const animate = boolean('animate', false);
   return (
     <main>
-      <AccordionWithEvents
+      <AccordionWithActions
         expandSingleSection={expandSingleSection}
         animate={animate}
-      ></AccordionWithEvents>
+      >
+        <AccordionSection id="section1" key={1} expanded animate>
+          <AccordionSectionHeader>Header 1</AccordionSectionHeader>
+          <AccordionSectionContent>
+            Content in section 1.
+          </AccordionSectionContent>
+        </AccordionSection>
+        <AccordionSection key={2}>
+          <AccordionSectionHeader>Header 2</AccordionSectionHeader>
+          <AccordionSectionContent>
+            Content in section 2.
+          </AccordionSectionContent>
+        </AccordionSection>
+        <AccordionSection key={3} expanded>
+          <AccordionSectionHeader>Header 3</AccordionSectionHeader>
+          <AccordionSectionContent>
+            Content in section 3.
+          </AccordionSectionContent>
+        </AccordionSection>
+      </AccordionWithActions>
     </main>
   );
 };

--- a/extensions/amp-accordion/1.0/storybook/Basic.js
+++ b/extensions/amp-accordion/1.0/storybook/Basic.js
@@ -17,9 +17,9 @@
 import * as Preact from '../../../../src/preact';
 import {
   Accordion,
+  AccordionContent,
+  AccordionHeader,
   AccordionSection,
-  AccordionSectionContent,
-  AccordionSectionHeader,
 } from '../accordion';
 import {boolean, withKnobs} from '@storybook/addon-knobs';
 import {withA11y} from '@storybook/addon-a11y';
@@ -68,14 +68,17 @@ export const _default = () => {
         expandSingleSection={expandSingleSection}
         animate={animate}
       >
-        <AccordionSection id="section1" key={1} header={<h2>Section 1</h2>}>
-          <p>Content in section 1.</p>
+        <AccordionSection id="section1" key={1}>
+          <AccordionHeader as="h2">Section 1</AccordionHeader>
+          <AccordionContent>Content in section 1.</AccordionContent>
         </AccordionSection>
-        <AccordionSection key={2} header={<h2>Section 2</h2>}>
-          <div>Content in section 2.</div>
+        <AccordionSection key={2}>
+          <AccordionHeader as="h2">Section 2</AccordionHeader>
+          <AccordionContent>Content in section 2.</AccordionContent>
         </AccordionSection>
-        <AccordionSection key={3} expanded header={<h2>Section 3</h2>}>
-          <div>Content in section 3.</div>
+        <AccordionSection key={3} expanded>
+          <AccordionHeader as="h2">Section 3</AccordionHeader>
+          <AccordionContent>Content in section 3.</AccordionContent>
         </AccordionSection>
       </AccordionWithActions>
     </main>
@@ -93,37 +96,33 @@ function AccordionWithEvents(props) {
   return (
     <section>
       <Accordion ref={ref} {...props}>
-        <AccordionSection
-          id="section1"
-          key={1}
-          expanded
-          header={<h2>Section 1</h2>}
-        >
-          <p>Content in section 1.</p>
+        <AccordionSection id="section1" key={1} expanded>
+          <AccordionHeader as="h2">Section 1</AccordionHeader>
+          <AccordionContent>Content in section 1.</AccordionContent>
         </AccordionSection>
         <AccordionSection
           id="section2"
           key={2}
-          header={<h2>Section 2</h2>}
           onExpandStateChange={(expanded) => {
             if (expanded) {
               ref.current.expand('section3');
             }
           }}
         >
-          <div>Content in section 2.</div>
+          <AccordionHeader as="h2">Section 2</AccordionHeader>
+          <AccordionContent>Content in section 1.</AccordionContent>
         </AccordionSection>
         <AccordionSection
           id="section3"
           key={3}
-          header={<h2>Section 3</h2>}
           onExpandStateChange={(expanded) => {
             if (!expanded) {
               ref.current.collapse('section2');
             }
           }}
         >
-          <div>Content in section 3.</div>
+          <AccordionHeader as="h2">Section 3</AccordionHeader>
+          <AccordionContent>Content in section 3.</AccordionContent>
         </AccordionSection>
       </Accordion>
       <div style={{marginTop: 8}}>
@@ -148,38 +147,6 @@ export const events = () => {
         expandSingleSection={expandSingleSection}
         animate={animate}
       ></AccordionWithEvents>
-    </main>
-  );
-};
-
-export const restructure = () => {
-  const expandSingleSection = boolean('expandSingleSection', false);
-  const animate = boolean('animate', false);
-  return (
-    <main>
-      <AccordionWithActions
-        expandSingleSection={expandSingleSection}
-        animate={animate}
-      >
-        <AccordionSection id="section1" key={1} expanded animate>
-          <AccordionSectionHeader>Header 1</AccordionSectionHeader>
-          <AccordionSectionContent>
-            Content in section 1.
-          </AccordionSectionContent>
-        </AccordionSection>
-        <AccordionSection key={2}>
-          <AccordionSectionHeader>Header 2</AccordionSectionHeader>
-          <AccordionSectionContent>
-            Content in section 2.
-          </AccordionSectionContent>
-        </AccordionSection>
-        <AccordionSection key={3} expanded>
-          <AccordionSectionHeader>Header 3</AccordionSectionHeader>
-          <AccordionSectionContent>
-            Content in section 3.
-          </AccordionSectionContent>
-        </AccordionSection>
-      </AccordionWithActions>
     </main>
   );
 };

--- a/extensions/amp-accordion/1.0/storybook/Basic.js
+++ b/extensions/amp-accordion/1.0/storybook/Basic.js
@@ -82,6 +82,76 @@ export const _default = () => {
   );
 };
 
+/**
+ * @param {!Object} props
+ * @return {*}
+ */
+function AccordionWithEvents(props) {
+  // TODO(#30447): replace imperative calls with "button" knobs when the
+  // Storybook 6.1 is released.
+  const ref = Preact.useRef();
+  return (
+    <section>
+      <Accordion ref={ref} {...props}>
+        <AccordionSection
+          id="section1"
+          key={1}
+          expanded
+          header={<h2>Section 1</h2>}
+        >
+          <p>Content in section 1.</p>
+        </AccordionSection>
+        <AccordionSection
+          id="section2"
+          key={2}
+          header={<h2>Section 2</h2>}
+          onExpandStateChange={(expanded) => {
+            if (expanded) {
+              ref.current.expand('section3');
+            }
+          }}
+        >
+          <div>Content in section 2.</div>
+        </AccordionSection>
+        <AccordionSection
+          id="section3"
+          key={3}
+          header={<h2>Section 3</h2>}
+          onExpandStateChange={(expanded) => {
+            if (!expanded) {
+              ref.current.collapse('section2');
+            }
+          }}
+        >
+          <div>Content in section 3.</div>
+        </AccordionSection>
+      </Accordion>
+      <div style={{marginTop: 8}}>
+        <button onClick={() => ref.current.expand('section2')}>
+          expand(section2)
+        </button>
+        <button onClick={() => ref.current.collapse('section3')}>
+          collapse(section3)
+        </button>
+        <button onClick={() => ref.current.toggle()}>toggle all</button>
+      </div>
+    </section>
+  );
+}
+
+export const events = () => {
+  const expandSingleSection = boolean('expandSingleSection', false);
+  const animate = boolean('animate', false);
+  return (
+    <main>
+      <AccordionWithEvents
+        expandSingleSection={expandSingleSection}
+        animate={animate}
+      ></AccordionWithEvents>{' '}
+    </main>
+  );
+};
+
 export const restructure = () => {
   const expandSingleSection = boolean('expandSingleSection', false);
   const animate = boolean('animate', false);

--- a/extensions/amp-accordion/1.0/storybook/Basic.js
+++ b/extensions/amp-accordion/1.0/storybook/Basic.js
@@ -147,7 +147,7 @@ export const events = () => {
       <AccordionWithEvents
         expandSingleSection={expandSingleSection}
         animate={animate}
-      ></AccordionWithEvents>{' '}
+      ></AccordionWithEvents>
     </main>
   );
 };

--- a/extensions/amp-accordion/1.0/test/test-accordion.js
+++ b/extensions/amp-accordion/1.0/test/test-accordion.js
@@ -15,7 +15,12 @@
  */
 
 import * as Preact from '../../../../src/preact';
-import {Accordion, AccordionSection} from '../accordion';
+import {
+  Accordion,
+  AccordionContent,
+  AccordionHeader,
+  AccordionSection,
+} from '../accordion';
 import {mount} from 'enzyme';
 import {waitFor} from '../../../../testing/test-helper';
 
@@ -23,7 +28,12 @@ describes.sandboxed('Accordion preact component', {}, (env) => {
   describe('standalone accordion section', () => {
     it('should render a default section', () => {
       const wrapper = mount(
-        <AccordionSection header={<h1>header1</h1>}>content1</AccordionSection>
+        <AccordionSection>
+          <AccordionHeader>
+            <h1>header1</h1>
+          </AccordionHeader>
+          <AccordionContent>content1</AccordionContent>
+        </AccordionSection>
       );
 
       const dom = wrapper.getDOMNode();
@@ -44,8 +54,11 @@ describes.sandboxed('Accordion preact component', {}, (env) => {
 
     it('should render an expanded section', () => {
       const wrapper = mount(
-        <AccordionSection expanded header={<h1>header1</h1>}>
-          content1
+        <AccordionSection expanded>
+          <AccordionHeader>
+            <h1>header1</h1>
+          </AccordionHeader>
+          <AccordionContent>content1</AccordionContent>
         </AccordionSection>
       );
 
@@ -65,7 +78,12 @@ describes.sandboxed('Accordion preact component', {}, (env) => {
 
     it('should toggle expanded state', () => {
       const wrapper = mount(
-        <AccordionSection header={<h1>header1</h1>}>content1</AccordionSection>
+        <AccordionSection>
+          <AccordionHeader>
+            <h1>header1</h1>
+          </AccordionHeader>
+          <AccordionContent>content1</AccordionContent>
+        </AccordionSection>
       );
       const dom = wrapper.getDOMNode();
       const header = dom.children[0];
@@ -96,14 +114,17 @@ describes.sandboxed('Accordion preact component', {}, (env) => {
     beforeEach(() => {
       wrapper = mount(
         <Accordion>
-          <AccordionSection key={1} expanded header="header1">
-            content1
+          <AccordionSection key={1} expanded>
+            <AccordionHeader>header1</AccordionHeader>
+            <AccordionContent>content1</AccordionContent>
           </AccordionSection>
-          <AccordionSection key={2} header="header2">
-            content2
+          <AccordionSection key={2}>
+            <AccordionHeader>header2</AccordionHeader>
+            <AccordionContent>content2</AccordionContent>
           </AccordionSection>
-          <AccordionSection key={3} header="header3">
-            content3
+          <AccordionSection key={3}>
+            <AccordionHeader>header3</AccordionHeader>
+            <AccordionContent>content3</AccordionContent>
           </AccordionSection>
         </Accordion>
       );
@@ -274,14 +295,17 @@ describes.sandboxed('Accordion preact component', {}, (env) => {
     beforeEach(() => {
       wrapper = mount(
         <Accordion expandSingleSection>
-          <AccordionSection key={1} expanded header="header1">
-            content1
+          <AccordionSection key={1} expanded>
+            <AccordionHeader>header1</AccordionHeader>
+            <AccordionContent>content1</AccordionContent>
           </AccordionSection>
-          <AccordionSection key={2} header="header2">
-            content2
+          <AccordionSection key={2}>
+            <AccordionHeader>header2</AccordionHeader>
+            <AccordionContent>content2</AccordionContent>
           </AccordionSection>
-          <AccordionSection key={3} header="header3">
-            content3
+          <AccordionSection key={3}>
+            <AccordionHeader>header3</AccordionHeader>
+            <AccordionContent>content3</AccordionContent>
           </AccordionSection>
         </Accordion>
       );
@@ -337,11 +361,13 @@ describes.sandboxed('Accordion preact component', {}, (env) => {
       animateStub = env.sandbox.stub(Element.prototype, 'animate');
       wrapper = mount(
         <Accordion animate>
-          <AccordionSection key={1} expanded header="header1">
-            content1
+          <AccordionSection key={1} expanded>
+            <AccordionHeader>header1</AccordionHeader>
+            <AccordionContent>content1</AccordionContent>
           </AccordionSection>
-          <AccordionSection key={2} header="header2">
-            content2
+          <AccordionSection key={2}>
+            <AccordionHeader>header2</AccordionHeader>
+            <AccordionContent>content2</AccordionContent>
           </AccordionSection>
         </Accordion>
       );
@@ -469,19 +495,21 @@ describes.sandboxed('Accordion preact component', {}, (env) => {
 
       wrapper = mount(
         <Accordion ref={ref}>
-          <AccordionSection key={1} expanded header="header1">
-            content1
+          <AccordionSection key={1} expanded>
+            <AccordionHeader>header1</AccordionHeader>
+            <AccordionContent>content1</AccordionContent>
           </AccordionSection>
           <AccordionSection
             key={2}
             id="section2"
-            header="header2"
             onExpandStateChange={onExpandStateChange}
           >
-            content2
+            <AccordionHeader>header2</AccordionHeader>
+            <AccordionContent>content2</AccordionContent>
           </AccordionSection>
-          <AccordionSection key={3} header="header3">
-            content3
+          <AccordionSection key={3}>
+            <AccordionHeader>header3</AccordionHeader>
+            <AccordionContent>content3</AccordionContent>
           </AccordionSection>
         </Accordion>
       );
@@ -584,14 +612,17 @@ describes.sandboxed('Accordion preact component', {}, (env) => {
         ref = Preact.createRef();
         wrapper = mount(
           <Accordion ref={ref}>
-            <AccordionSection key={1} expanded header="header1" id="section1">
-              content1
+            <AccordionSection key={1} expanded id="section1">
+              <AccordionHeader>header1</AccordionHeader>
+              <AccordionContent>content1</AccordionContent>
             </AccordionSection>
-            <AccordionSection key={2} header="header2" id="section2">
-              content2
+            <AccordionSection key={2} id="section2">
+              <AccordionHeader>header2</AccordionHeader>
+              <AccordionContent>content2</AccordionContent>
             </AccordionSection>
-            <AccordionSection key={3} header="header3">
-              content3
+            <AccordionSection key={3}>
+              <AccordionHeader>header3</AccordionHeader>
+              <AccordionContent>content3</AccordionContent>
             </AccordionSection>
           </Accordion>
         );


### PR DESCRIPTION
**First pass rough draft** - will flesh out after initial review, and more changes incoming after merging https://github.com/ampproject/amphtml/pull/30976

Restructuring to approach 3 in this doc (titled: `Special-purpose subcomponents for header and content.`): 

https://docs.google.com/document/d/1L5jG0Z81BX-ESs003qvFFVYSEWFZYIgKYrxfKrvXB8U/edit#

Updated one storybook example to show how the things would change on Preact side from user's perspective (no changes on amp-side): https://github.com/ampproject/amphtml/pull/31083/files#diff-ee23fff81349bbe0e67b47387d4bf79e1fbdd4f7f3fa66c8eeb52a800b683462R86

Essentially something like this:
```
<Accordion>
  <AccordionSection>
    <AccordionSectionHeader>Header 1</AccordionSectionHeader>
    <AccordionSectionContent>Content in section 1.</AccordionSectionContent>
  </AccordionSection>
</Accordion>
```
@caroqliu - What do you think of the names of these components?  I was also considering something like `<AccordionHeader/>` and `<AccordionContent/>` instead of `<AccordionSectionHeader/>` and `<AccordionSectionContent/>` since they are less verbose.

Preact output will no longer be wrapped (example):
![image](https://user-images.githubusercontent.com/25626770/98831310-67d12f00-2409-11eb-9721-a3c693add9e5.png)
