### PR TITLE
Deflake amp-accordion visual tests

### DIFF
--- a/extensions/amp-accordion/0.1/amp-accordion.js
+++ b/extensions/amp-accordion/0.1/amp-accordion.js
@@ -26,7 +26,6 @@ import {closest, tryFocus} from '../../../src/dom';
 import {createCustomEvent} from '../../../src/event-helper';
 import {dev, devAssert, user, userAssert} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
-import {getMode} from '../../../src/mode';
 import {getStyle, setImportantStyles, setStyles} from '../../../src/style';
 import {isExperimentOn} from '../../../src/experiments';
 import {
@@ -43,12 +42,9 @@ const MIN_TRANSITION_DURATION = 200; // ms
 const EXPAND_CURVE_ = bezierCurve(0.47, 0, 0.745, 0.715);
 const COLLAPSE_CURVE_ = bezierCurve(0.39, 0.575, 0.565, 1);
 
-const isDisplayLockingEnabledForAccordion = (win) => {
-  return (
-    isExperimentOn(win, 'amp-accordion-display-locking') &&
-    (document.body.onbeforematch !== undefined || getMode().test)
-  );
-};
+const isDisplayLockingEnabledForAccordion = (win) =>
+  isExperimentOn(win, 'amp-accordion-display-locking') &&
+  win.document.body.onbeforematch !== undefined;
 
 class AmpAccordion extends AMP.BaseElement {
   /** @param {!AmpElement} element */

--- a/extensions/amp-accordion/0.1/test/test-amp-accordion.js
+++ b/extensions/amp-accordion/0.1/test/test-amp-accordion.js
@@ -242,8 +242,10 @@ describes.realWin(
       });
     });
 
-    it('should expand when rendersubtreeactivation event is triggered on a collapsed section', () => {
+    it('should expand when beforematch event is triggered on a collapsed section', () => {
+      // Enable display locking feature.
       toggleExperiment(win, 'amp-accordion-display-locking', true);
+      doc.body.onbeforematch = null;
       return getAmpAccordion().then(() => {
         const section = doc.querySelector('section:not([expanded])');
         const header = section.firstElementChild;
@@ -253,7 +255,10 @@ describes.realWin(
         content.dispatchEvent(new Event('beforematch'));
         expect(section.hasAttribute('expanded')).to.be.true;
         expect(header.getAttribute('aria-expanded')).to.equal('true');
+
+        // Reset display locking feature
         toggleExperiment(win, 'amp-accordion-display-locking', false);
+        doc.body.onbeforematch = undefined;
       });
     });
 


### PR DESCRIPTION
This PR removes `getMode().test` as away to enable display locking in amp-accordion.

More context: 
The amp-accordion visual tests [fail on Percy](https://percy.io/ampproject/amphtml/builds/7653685?utm_campaign=ampproject&utm_content=amphtml&utm_source=github_status_public) when the `i-amphtml-display-locking` class is attached. This is attached 10% of the time because the experiment is currently at 10%.

The test fails when the class is attached because the experiment is gated on _either_ the availability of `onbeforematch` _or_ the AMP mode being in a testing environment. Given visual tests are run in the testing environment (`gulp dist --fortesting`), the `i-amphtml-display-locking` class is attached in all cases where the experiment is on. In actuality we want our visual diff tests to only enable display locking if in fact `onbeforematch` is available on the document body, which implies also the support for `content-visibility: hidden-matchable`, which is the CSS property that allows the section content to be hidden for visual diff tests. 