### PR TITLE
rrule: update to latest + remove hack

### DIFF
--- a/build-system/tasks/update-packages.js
+++ b/build-system/tasks/update-packages.js
@@ -95,29 +95,6 @@ function patchIntersectionObserver() {
 }
 
 /**
- * TODO(samouri): remove this patch when a better fix is upstreamed (https://github.com/jakubroztocil/rrule/pull/410).
- *
- * Patches rrule to remove references to luxon. Even though rrule marks luxon as an optional dependency,
- * it is used as if it's a required one (static import). rrule relies on its consumers either
- * installing luxon or adding it as a webpack-style external. We don't want the former and
- * can't yet do the latter.
- *
- * This function replaces the reference to luxon with a mock that throws (which the code handles well).
- */
-function patchRRule() {
-  const path = 'node_modules/rrule/dist/es5/rrule.min.js';
-  const patchedContents = fs
-    .readFileSync(path)
-    .toString()
-    .replace(
-      /require\("luxon"\)/g,
-      `{ DateTime: { fromJSDate() { throw TypeError() } } }`
-    );
-
-  writeIfUpdated(path, patchedContents);
-}
-
-/**
  * Checks if all packages are current, and if not, runs `npm install`.
  */
 function runNpmCheck() {
@@ -164,7 +141,6 @@ async function updatePackages() {
   }
   patchWebAnimations();
   patchIntersectionObserver();
-  patchRRule();
 }
 
 module.exports = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -28915,9 +28915,9 @@
       }
     },
     "rrule": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/rrule/-/rrule-2.6.4.tgz",
-      "integrity": "sha512-sLdnh4lmjUqq8liFiOUXD5kWp/FcnbDLPwq5YAc/RrN6120XOPb86Ae5zxF7ttBVq8O3LxjjORMEit1baluahA==",
+      "version": "2.6.6",
+      "resolved": "https://registry.npmjs.org/rrule/-/rrule-2.6.6.tgz",
+      "integrity": "sha512-h6tb/hRo9SNv8xKjcvsEfdmhXvElMXsU3Yz0KmqMehUqxP6a4Qjmth2EuL1FsjdawADjajLS0eBbWfsZzn3SIw==",
       "requires": {
         "luxon": "^1.21.3",
         "tslib": "^1.10.0"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "prop-types": "15.7.2",
     "react-dates": "15.5.3",
     "react-jss": "10.3.0",
-    "rrule": "2.6.4",
+    "rrule": "2.6.6",
     "web-activities": "1.13.0",
     "web-animations-js": "2.3.1"
   },


### PR DESCRIPTION
Update to release [2.6.6](https://github.com/jakubroztocil/rrule/releases/tag/v2.6.6) which contains our luxon fix.

Note: I don't expect this to solve https://github.com/ampproject/amphtml/pull/31072