### PR TITLE
🏗 Remove circular dependency between `helpers.js` and `typescript.js`

### DIFF
--- a/build-system/compile/typescript.js
+++ b/build-system/compile/typescript.js
@@ -21,7 +21,6 @@ const log = require('fancy-log');
 const path = require('path');
 const ts = require('typescript');
 const tsickle = require('tsickle');
-const {endBuildStep} = require('../tasks/helpers');
 
 /**
  * Given a file path `foo/bar.js`, transpiles the TypeScript entry point of
@@ -32,7 +31,6 @@ const {endBuildStep} = require('../tasks/helpers');
  * @return {!Promise}
  */
 exports.transpileTs = async function (srcDir, srcFilename) {
-  const startTime = Date.now();
   const tsEntry = path.join(srcDir, srcFilename).replace(/\.js$/, '.ts');
   const tsConfig = ts.convertCompilerOptionsFromJson(
     {
@@ -85,5 +83,4 @@ exports.transpileTs = async function (srcDir, srcFilename) {
   if (diagnostics.length) {
     log(colors.red('TSickle:'), tsickle.formatDiagnostics(diagnostics));
   }
-  endBuildStep('Transpiled', srcFilename, startTime);
 };

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -442,7 +442,9 @@ function compileUnminifiedJs(srcDir, srcFilename, destDir, options) {
  */
 async function compileTs(srcDir, srcFilename, destDir, options) {
   options = options || {};
+  const startTime = Date.now();
   await transpileTs(srcDir, srcFilename);
+  endBuildStep('Transpiled', srcFilename, startTime);
   await compileJs(srcDir, srcFilename, destDir, options);
   del.sync(path.join(srcDir, '**/*.js'));
 }


### PR DESCRIPTION
There's a circular dependency bug in `build-system` where `helpers.js` and `typescript.js` depend on each other for `endBuildStep()` and `transpileTs()`. This is currently benign because we don't actually invoke `transpileTs()` during builds. With node v14, there's a new warning for circular dependencies:

![image](https://user-images.githubusercontent.com/26553114/98853009-8265d100-2426-11eb-91db-7d6e23ef0d2d.png)

This PR eliminates the bug by moving the call to `endBuildStep()` from `transpileTs()` in `typescript.js` to `compileTs()` in `helpers.js`.

![image](https://user-images.githubusercontent.com/26553114/98853526-41ba8780-2427-11eb-9f4e-8682683c8dcb.png)
