### PR TITLE
✨ [amp-date-countdown] Add count-up feature in amp-date-countdown component

### DIFF
--- a/extensions/amp-date-countdown/0.1/amp-date-countdown.js
+++ b/extensions/amp-date-countdown/0.1/amp-date-countdown.js
@@ -158,7 +158,7 @@ export class AmpDateCountdown extends AMP.BaseElement {
     this.localeWordList_ = this.getLocaleWord_(this.locale_);
 
     /** @private {boolean} */
-    this.countUp_ = this.element.hasAttribute('count-up');
+    this.countUp_ = this.element.hasAttribute('data-count-up');
 
     this.getAmpDoc()
       .whenFirstVisible()

--- a/extensions/amp-date-countdown/0.1/amp-date-countdown.js
+++ b/extensions/amp-date-countdown/0.1/amp-date-countdown.js
@@ -108,6 +108,9 @@ export class AmpDateCountdown extends AMP.BaseElement {
 
     /** @private {?number} */
     this.countDownTimer_ = null;
+
+    /** @private {boolean} */
+    this.countUp_ = false;
   }
 
   /** @override */
@@ -154,6 +157,9 @@ export class AmpDateCountdown extends AMP.BaseElement {
     /** @private {!Object|null} */
     this.localeWordList_ = this.getLocaleWord_(this.locale_);
 
+    /** @private {boolean} */
+    this.countUp_ = this.element.hasAttribute('count-up');
+
     this.getAmpDoc()
       .whenFirstVisible()
       .then(() => {
@@ -195,7 +201,7 @@ export class AmpDateCountdown extends AMP.BaseElement {
    */
   tickCountDown_(differentBetween) {
     const items = /** @type {!JsonObject} */ ({});
-    const DIFF = this.getYDHMSFromMs_(differentBetween) || {};
+    const DIFF = this.getYDHMSFromMs_(differentBetween, this.countUp_) || {};
     if (this.whenEnded_ === 'stop' && differentBetween < 1000) {
       Services.actionServiceForDoc(this.element).trigger(
         this.element,
@@ -260,10 +266,11 @@ export class AmpDateCountdown extends AMP.BaseElement {
 
   /**
    * @param {number} ms
+   * @param {boolean} countUp
    * @return {Object}
    * @private
    */
-  getYDHMSFromMs_(ms) {
+  getYDHMSFromMs_(ms, countUp) {
     /** @enum {number} */
     const TimeUnit = {
       DAYS: 1,
@@ -271,6 +278,14 @@ export class AmpDateCountdown extends AMP.BaseElement {
       MINUTES: 3,
       SECONDS: 4,
     };
+
+    // If user supplies 'count-up' attribute, we return the negative of what
+    // we would originally return since we are counting time-elapsed from a
+    // set time instead of time until that time
+    if (countUp) {
+      ms *= -1;
+    }
+
     //Math.trunc is used instead of Math.floor to support negative past date
     const d =
       TimeUnit[this.biggestUnit_] == TimeUnit.DAYS

--- a/extensions/amp-date-countdown/0.1/test/test-amp-date-countdown.js
+++ b/extensions/amp-date-countdown/0.1/test/test-amp-date-countdown.js
@@ -37,6 +37,7 @@ describes.realWin(
 
       element = win.document.createElement('amp-date-countdown');
       element.setAttribute('end-date', ISOEndDate);
+      element.setAttribute('layout', 'responsive');
       win.document.body.appendChild(element);
       impl = element.implementation_;
     });
@@ -216,5 +217,91 @@ describes.realWin(
         '1 Days 0 Hours 0 Minutes 0 Seconds'
       );
     });
+
+    it(
+      'should calculate a negative time when target is in future ' +
+        'when using the "count-up" attribute',
+      () => {
+        const countUp = true;
+        element.setAttribute('count-up', '');
+        element.setAttribute('when-ended', 'continue');
+        element.build();
+        const timeObj = Object.assign(
+          impl.getYDHMSFromMs_(
+            endDate -
+              twoDaysBeforeEndDate - //two days in future
+              24 * 60 * 60 * 1000 - //minus 1 day
+              60 * 60 * 1000 - //minus 1 hour
+              60 * 1000 - //minus 1 minute
+              1000, //minus 1 second
+            countUp
+          ), // hours * minutes * seconds * ms
+          impl.getLocaleWord_('en')
+        ); // English
+        const itemElement = win.document.createElement('div');
+        itemElement.textContent =
+          timeObj.d +
+          ' ' +
+          timeObj.days +
+          ' ' +
+          timeObj.h +
+          ' ' +
+          timeObj.hours +
+          ' ' +
+          timeObj.m +
+          ' ' +
+          timeObj.minutes +
+          ' ' +
+          timeObj.s +
+          ' ' +
+          timeObj.seconds;
+        expect(itemElement.textContent).to.equal(
+          '0 Days -22 Hours -58 Minutes -58 Seconds'
+        );
+      }
+    );
+
+    it(
+      'should calculate a positive time when target is in past ' +
+        'when using the "count-up" attribute',
+      () => {
+        const countUp = true;
+        element.setAttribute('count-up', '');
+        element.setAttribute('when-ended', 'continue');
+        element.build();
+        const timeObj = Object.assign(
+          impl.getYDHMSFromMs_(
+            twoDaysBeforeEndDate -
+              endDate + //two days in past
+              24 * 60 * 60 * 1000 + //plus 1 day
+              60 * 60 * 1000 + //plus 1 hour
+              60 * 1000 + //plus 1 minute
+              1000, //plus 1 second
+            countUp
+          ), // hours * minutes * seconds * ms
+          impl.getLocaleWord_('en')
+        ); // English
+        const itemElement = win.document.createElement('div');
+        itemElement.textContent =
+          timeObj.d +
+          ' ' +
+          timeObj.days +
+          ' ' +
+          timeObj.h +
+          ' ' +
+          timeObj.hours +
+          ' ' +
+          timeObj.m +
+          ' ' +
+          timeObj.minutes +
+          ' ' +
+          timeObj.s +
+          ' ' +
+          timeObj.seconds;
+        expect(itemElement.textContent).to.equal(
+          '0 Days 22 Hours 58 Minutes 59 Seconds'
+        );
+      }
+    );
   }
 );

--- a/extensions/amp-date-countdown/0.1/test/test-amp-date-countdown.js
+++ b/extensions/amp-date-countdown/0.1/test/test-amp-date-countdown.js
@@ -220,10 +220,10 @@ describes.realWin(
 
     it(
       'should calculate a negative time when target is in future ' +
-        'when using the "count-up" attribute',
+        'when using the "data-count-up" attribute',
       () => {
         const countUp = true;
-        element.setAttribute('count-up', '');
+        element.setAttribute('data-count-up', '');
         element.setAttribute('when-ended', 'continue');
         element.build();
         const timeObj = Object.assign(
@@ -263,10 +263,10 @@ describes.realWin(
 
     it(
       'should calculate a positive time when target is in past ' +
-        'when using the "count-up" attribute',
+        'when using the "data-count-up" attribute',
       () => {
         const countUp = true;
-        element.setAttribute('count-up', '');
+        element.setAttribute('data-count-up', '');
         element.setAttribute('when-ended', 'continue');
         element.build();
         const timeObj = Object.assign(

--- a/extensions/amp-date-countdown/0.1/test/validator-amp-date-countdown.html
+++ b/extensions/amp-date-countdown/0.1/test/validator-amp-date-countdown.html
@@ -161,12 +161,9 @@
   <amp-date-countdown timestamp-ms="1521880470000" offset-seconds="1521880470" when-ended="stop" locale='zh-tw' height="50" width="360" template="notMyTemplate">
   </amp-date-countdown>
 
-  <!-- Should allow `count-up` attribute. -->
-  <amp-date-countdown count-up timestamp-seconds="1521880470" offset-seconds="1521880470" when-ended="continue" locale='de' height="50" width="360" template="myTemplate">
+  <!-- Should allow `data-count-up` attribute. -->
+  <amp-date-countdown data-count-up timestamp-seconds="1521880470" offset-seconds="1521880470" when-ended="continue" locale='de' height="50" width="360" template="myTemplate">
   </amp-date-countdown>
 
-  <!-- Should error if the `count-up` attribute has a non-empty value. -->
-  <amp-date-countdown count-up="true" timestamp-seconds="1521880470" offset-seconds="1521880470" when-ended="continue" locale='de' height="50" width="360" template="myTemplate">
-  </amp-date-countdown>
 </body>
 </html>

--- a/extensions/amp-date-countdown/0.1/test/validator-amp-date-countdown.html
+++ b/extensions/amp-date-countdown/0.1/test/validator-amp-date-countdown.html
@@ -165,5 +165,9 @@
   <amp-date-countdown data-count-up timestamp-seconds="1521880470" offset-seconds="1521880470" when-ended="continue" locale='de' height="50" width="360" template="myTemplate">
   </amp-date-countdown>
 
+  <!-- Should error if `data-count-up` attribute is given a non-empty value. -->
+  <amp-date-countdown data-count-up="true" timestamp-seconds="1521880470" offset-seconds="1521880470" when-ended="continue" locale='de' height="50" width="360" template="myTemplate">
+  </amp-date-countdown>
+
 </body>
 </html>

--- a/extensions/amp-date-countdown/0.1/test/validator-amp-date-countdown.html
+++ b/extensions/amp-date-countdown/0.1/test/validator-amp-date-countdown.html
@@ -160,5 +160,13 @@
   <!-- Should error if the `template` referent is missing. -->
   <amp-date-countdown timestamp-ms="1521880470000" offset-seconds="1521880470" when-ended="stop" locale='zh-tw' height="50" width="360" template="notMyTemplate">
   </amp-date-countdown>
+
+  <!-- Should allow `count-up` attribute. -->
+  <amp-date-countdown count-up timestamp-seconds="1521880470" offset-seconds="1521880470" when-ended="continue" locale='de' height="50" width="360" template="myTemplate">
+  </amp-date-countdown>
+
+  <!-- Should error if the `count-up` attribute has a non-empty value. -->
+  <amp-date-countdown count-up="true" timestamp-seconds="1521880470" offset-seconds="1521880470" when-ended="continue" locale='de' height="50" width="360" template="myTemplate">
+  </amp-date-countdown>
 </body>
 </html>

--- a/extensions/amp-date-countdown/0.1/test/validator-amp-date-countdown.out
+++ b/extensions/amp-date-countdown/0.1/test/validator-amp-date-countdown.out
@@ -164,14 +164,9 @@ FAIL
 amp-date-countdown/0.1/test/validator-amp-date-countdown.html:161:2 Attribute 'template' in tag 'amp-date-countdown' contains a value that does not match any other tags on the page. (see https://amp.dev/documentation/components/amp-date-countdown)
 |    </amp-date-countdown>
 |
-|    <!-- Should allow `count-up` attribute. -->
-|    <amp-date-countdown count-up timestamp-seconds="1521880470" offset-seconds="1521880470" when-ended="continue" locale='de' height="50" width="360" template="myTemplate">
+|    <!-- Should allow `data-count-up` attribute. -->
+|    <amp-date-countdown data-count-up timestamp-seconds="1521880470" offset-seconds="1521880470" when-ended="continue" locale='de' height="50" width="360" template="myTemplate">
 |    </amp-date-countdown>
 |
-|    <!-- Should error if the `count-up` attribute has a non-empty value. -->
-|    <amp-date-countdown count-up="true" timestamp-seconds="1521880470" offset-seconds="1521880470" when-ended="continue" locale='de' height="50" width="360" template="myTemplate">
->>   ^~~~~~~~~
-amp-date-countdown/0.1/test/validator-amp-date-countdown.html:169:2 The attribute 'count-up' in tag 'amp-date-countdown' is set to the invalid value 'true'. (see https://amp.dev/documentation/components/amp-date-countdown)
-|    </amp-date-countdown>
 |  </body>
 |  </html>

--- a/extensions/amp-date-countdown/0.1/test/validator-amp-date-countdown.out
+++ b/extensions/amp-date-countdown/0.1/test/validator-amp-date-countdown.out
@@ -163,5 +163,15 @@ FAIL
 >>   ^~~~~~~~~
 amp-date-countdown/0.1/test/validator-amp-date-countdown.html:161:2 Attribute 'template' in tag 'amp-date-countdown' contains a value that does not match any other tags on the page. (see https://amp.dev/documentation/components/amp-date-countdown)
 |    </amp-date-countdown>
+|
+|    <!-- Should allow `count-up` attribute. -->
+|    <amp-date-countdown count-up timestamp-seconds="1521880470" offset-seconds="1521880470" when-ended="continue" locale='de' height="50" width="360" template="myTemplate">
+|    </amp-date-countdown>
+|
+|    <!-- Should error if the `count-up` attribute has a non-empty value. -->
+|    <amp-date-countdown count-up="true" timestamp-seconds="1521880470" offset-seconds="1521880470" when-ended="continue" locale='de' height="50" width="360" template="myTemplate">
+>>   ^~~~~~~~~
+amp-date-countdown/0.1/test/validator-amp-date-countdown.html:169:2 The attribute 'count-up' in tag 'amp-date-countdown' is set to the invalid value 'true'. (see https://amp.dev/documentation/components/amp-date-countdown)
+|    </amp-date-countdown>
 |  </body>
 |  </html>

--- a/extensions/amp-date-countdown/0.1/test/validator-amp-date-countdown.out
+++ b/extensions/amp-date-countdown/0.1/test/validator-amp-date-countdown.out
@@ -168,5 +168,11 @@ amp-date-countdown/0.1/test/validator-amp-date-countdown.html:161:2 Attribute 't
 |    <amp-date-countdown data-count-up timestamp-seconds="1521880470" offset-seconds="1521880470" when-ended="continue" locale='de' height="50" width="360" template="myTemplate">
 |    </amp-date-countdown>
 |
+|    <!-- Should error if `data-count-up` attribute is given a non-empty value. -->
+|    <amp-date-countdown data-count-up="true" timestamp-seconds="1521880470" offset-seconds="1521880470" when-ended="continue" locale='de' height="50" width="360" template="myTemplate">
+>>   ^~~~~~~~~
+amp-date-countdown/0.1/test/validator-amp-date-countdown.html:169:2 The attribute 'data-count-up' in tag 'amp-date-countdown' is set to the invalid value 'true'. (see https://amp.dev/documentation/components/amp-date-countdown)
+|    </amp-date-countdown>
+|
 |  </body>
 |  </html>

--- a/extensions/amp-date-countdown/amp-date-countdown.md
+++ b/extensions/amp-date-countdown/amp-date-countdown.md
@@ -163,6 +163,10 @@ on the specified `biggest-unit` value. For example, assume there are `50 days 10
 - Supported values: `days`, `hours`, `minutes`, `seconds`
 - Default: `days`
 
+### count-up (optional)
+
+Include this attribute to reverse the direction of the countdown to count up instead. Useful to display the time elapsed since a target date in the past. To continue the countdown when the target date is in the past, be sure to include the `when-ended` attribute with the `continue` value. If the target date is in the future, `amp-date-countdown` will display a decrementing (toward 0) negative value.
+
 ## Events
 
 The `amp-date-countdown` component exposes the following event that you can use

--- a/extensions/amp-date-countdown/amp-date-countdown.md
+++ b/extensions/amp-date-countdown/amp-date-countdown.md
@@ -163,7 +163,7 @@ on the specified `biggest-unit` value. For example, assume there are `50 days 10
 - Supported values: `days`, `hours`, `minutes`, `seconds`
 - Default: `days`
 
-### count-up (optional)
+### data-count-up (optional)
 
 Include this attribute to reverse the direction of the countdown to count up instead. Useful to display the time elapsed since a target date in the past. To continue the countdown when the target date is in the past, be sure to include the `when-ended` attribute with the `continue` value. If the target date is in the future, `amp-date-countdown` will display a decrementing (toward 0) negative value.
 

--- a/extensions/amp-date-countdown/validator-amp-date-countdown.protoascii
+++ b/extensions/amp-date-countdown/validator-amp-date-countdown.protoascii
@@ -36,6 +36,10 @@ tags: {  # <amp-date-countdown>
     value_casei: "minutes"
     value_casei: "seconds"
   }
+  attrs {
+    name: "data-count-up"
+    value: ""
+  }
   attrs: {
     name: "end-date"
     mandatory_oneof: "['end-date', 'timeleft-ms', 'timestamp-ms', 'timestamp-seconds']"

--- a/extensions/amp-date-countdown/validator-amp-date-countdown.protoascii
+++ b/extensions/amp-date-countdown/validator-amp-date-countdown.protoascii
@@ -88,6 +88,9 @@ tags: {  # <amp-date-countdown>
     value_casei: "continue"
     value_casei: "stop"
   }
+  attrs: {
+    name: "count-up" value: ""
+  }
   attr_lists: "extended-amp-global"
   amp_layout: {
     supported_layouts: FILL

--- a/extensions/amp-date-countdown/validator-amp-date-countdown.protoascii
+++ b/extensions/amp-date-countdown/validator-amp-date-countdown.protoascii
@@ -37,6 +37,10 @@ tags: {  # <amp-date-countdown>
     value_casei: "seconds"
   }
   attrs: {
+    name: "count-up" 
+    value: ""
+  }
+  attrs: {
     name: "end-date"
     mandatory_oneof: "['end-date', 'timeleft-ms', 'timestamp-ms', 'timestamp-seconds']"
     value_regex: "\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d(:[0-5]\\d(\\.\\d+)?)?(Z|[+-][0-1][0-9]:[0-5][0-9])"
@@ -87,9 +91,6 @@ tags: {  # <amp-date-countdown>
     name: "when-ended"
     value_casei: "continue"
     value_casei: "stop"
-  }
-  attrs: {
-    name: "count-up" value: ""
   }
   attr_lists: "extended-amp-global"
   amp_layout: {

--- a/extensions/amp-date-countdown/validator-amp-date-countdown.protoascii
+++ b/extensions/amp-date-countdown/validator-amp-date-countdown.protoascii
@@ -37,10 +37,6 @@ tags: {  # <amp-date-countdown>
     value_casei: "seconds"
   }
   attrs: {
-    name: "count-up" 
-    value: ""
-  }
-  attrs: {
     name: "end-date"
     mandatory_oneof: "['end-date', 'timeleft-ms', 'timestamp-ms', 'timestamp-seconds']"
     value_regex: "\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d(:[0-5]\\d(\\.\\d+)?)?(Z|[+-][0-1][0-9]:[0-5][0-9])"


### PR DESCRIPTION
Address this feature request: https://github.com/ampproject/amphtml/issues/30197

Add a new feature that allows the user to specify an attribute `count-up` which makes it so that the `amp-date-countdown` component counts upward instead.  This is useful when the user wants to display how much time has elapsed since the target time.  This is a feature request from a user.