### PR TITLE
build and upload module build if integration tests are modified

### DIFF
--- a/build-system/pr-check/module-build.js
+++ b/build-system/pr-check/module-build.js
@@ -53,7 +53,7 @@ function main() {
   } else {
     printChangeSummary(FILENAME);
     const buildTargets = determineBuildTargets(FILENAME);
-    // NOTE: This list must eventually match the same buildTargets check
+    // TODO(#31102): This list must eventually match the same buildTargets check
     // found in pr-check/nomodule-build.js as we turn on the systems that
     // run against the module build. (ex. visual diffs, e2e, etc.)
     if (

--- a/build-system/pr-check/module-build.js
+++ b/build-system/pr-check/module-build.js
@@ -53,7 +53,11 @@ function main() {
   } else {
     printChangeSummary(FILENAME);
     const buildTargets = determineBuildTargets(FILENAME);
-    if (buildTargets.has('RUNTIME') || buildTargets.has('FLAG_CONFIG')) {
+    if (
+      buildTargets.has('RUNTIME') ||
+      buildTargets.has('FLAG_CONFIG') ||
+      buildTargets.has('INTEGRATION_TEST')
+    ) {
       timedExecOrDie('gulp update-packages');
       timedExecOrDie('gulp dist --esm --fortesting');
       uploadEsmDistOutput(FILENAME);

--- a/build-system/pr-check/module-build.js
+++ b/build-system/pr-check/module-build.js
@@ -53,6 +53,9 @@ function main() {
   } else {
     printChangeSummary(FILENAME);
     const buildTargets = determineBuildTargets(FILENAME);
+    // NOTE: This list must eventually match the same buildTargets check
+    // found in pr-check/nomodule-build.js as we turn on the systems that
+    // run against the module build. (ex. visual diffs, e2e, etc.)
     if (
       buildTargets.has('RUNTIME') ||
       buildTargets.has('FLAG_CONFIG') ||

--- a/test/integration/test-amp-carousel.js
+++ b/test/integration/test-amp-carousel.js
@@ -327,7 +327,7 @@ t.run('amp-carousel', function () {
         expect(nextBtn).to.be.visible;
       });
 
-      it.skip('should only have the prev button enabled when on last item', () => {
+      it('should only have the prev button enabled when on last item', () => {
         document.body.classList.add('amp-mode-mouse');
         const amp = document.querySelector('#carousel-1');
         const impl = amp.implementation_;

--- a/test/integration/test-amp-carousel.js
+++ b/test/integration/test-amp-carousel.js
@@ -327,7 +327,7 @@ t.run('amp-carousel', function () {
         expect(nextBtn).to.be.visible;
       });
 
-      it('should only have the prev button enabled when on last item', () => {
+      it.skip('should only have the prev button enabled when on last item', () => {
         document.body.classList.add('amp-mode-mouse');
         const amp = document.querySelector('#carousel-1');
         const impl = amp.implementation_;


### PR DESCRIPTION
module-build must build and upload the `dist` build for module if integration tests are modified

The condition list found in `pr-check/module-build.js` must eventually match the same buildTargets check ound in pr-check/nomodule-build.js as we turn on the systems that run against the module build. (ex. visual diffs, e2e, etc.).

unblocks #31029