### PR TITLE
🏗  Fix RRule usage so it works with module build

### DIFF
--- a/build-system/compile/sources.js
+++ b/build-system/compile/sources.js
@@ -42,7 +42,7 @@ const COMMON_GLOBS = [
   'node_modules/intersection-observer/intersection-observer.install.js',
   'node_modules/promise-pjs/package.json',
   'node_modules/promise-pjs/promise.mjs',
-  'node_modules/rrule/dist/es5/rrule.min.js',
+  'node_modules/rrule/dist/es5/rrule.js',
   'node_modules/web-animations-js/package.json',
   'node_modules/web-animations-js/web-animations.install.js',
   'node_modules/web-activities/package.json',

--- a/build-system/tasks/update-packages.js
+++ b/build-system/tasks/update-packages.js
@@ -17,6 +17,7 @@
 
 const checkDependencies = require('check-dependencies');
 const colors = require('ansi-colors');
+const del = require('del');
 const fs = require('fs-extra');
 const log = require('fancy-log');
 const {execOrDie} = require('../common/exec');
@@ -95,6 +96,19 @@ function patchIntersectionObserver() {
 }
 
 /**
+ * Deletes the map file for rrule, which breaks closure compiler.
+ * TODO(rsimha): Remove this workaround after a fix is merged for
+ * https://github.com/google/closure-compiler/issues/3720.
+ */
+function removeRruleSourcemap() {
+  const rruleMapFile = 'node_modules/rrule/dist/es5/rrule.js.map';
+  if (fs.existsSync(rruleMapFile)) {
+    del.sync(rruleMapFile);
+    log(colors.green('Deleted'), colors.cyan(rruleMapFile));
+  }
+}
+
+/**
  * Checks if all packages are current, and if not, runs `npm install`.
  */
 function runNpmCheck() {
@@ -141,6 +155,7 @@ async function updatePackages() {
   }
   patchWebAnimations();
   patchIntersectionObserver();
+  removeRruleSourcemap();
 }
 
 module.exports = {

--- a/extensions/amp-date-picker/0.1/dates-list.js
+++ b/extensions/amp-date-picker/0.1/dates-list.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as rrule from '../../../node_modules/rrule/dist/es5/rrule.min.js';
+import * as rrule from '../../../node_modules/rrule/dist/es5/rrule.js';
 import {requireExternal} from '../../../src/module';
 
 const rrulestr = rrule.default.rrulestr || rrule.rrulestr; // CC imports into .default, browserify flattens a layer.

--- a/extensions/amp-date-picker/0.1/test/test-dates-list.js
+++ b/extensions/amp-date-picker/0.1/test/test-dates-list.js
@@ -22,7 +22,7 @@ describes.sandboxed('DatesList', {}, () => {
   const moment = requireExternal('moment');
 
   it('should accept date strings and RRule strings', function () {
-    this.timeout(3000);
+    this.timeout(5000);
     const containedDate = '09/04/1998';
     const notContainedDate = '09/03/1998';
     const containedRrule =


### PR DESCRIPTION
Our current usage of the `RRule` library in `amp-date-picker` is via the ES5 minified module. This usage breaks our ESM build with the latest version of Closure compiler, which introduces a new warning about  block-scoped function declarations. See https://github.com/ampproject/amphtml/pull/31072#issuecomment-725014116 for full details.

This PR does two things:
1. Switches to the unminified version of the self-contained RRule library (`node_modules/rrule/dist/es5/rrule.js`) as listed at https://www.npmjs.com/package/rrule#client-side. As a result, we minify the code using Closure instead of relying on a previously minified library.
2. Deletes `node_modules/rrule/dist/es5/rrule.js.map` during compilation as a workaround until https://github.com/google/closure-compiler/issues/3720 is fixed.

With this, I was able to successfully build the module and nomodule versions of `amp-date-picker` and run integration and unit tests. A spot-check of the minified output showed almost identical contents without any significant changes to bundle size.

I'm going to send this out for a full review and test it in conjunction with #31093 and #31072 to make sure everything works.

