### PR TITLE
amp-carousel-0.2 Fix scroll-snap-align for wrapper slides

### DIFF
--- a/extensions/amp-base-carousel/0.1/carousel.js
+++ b/extensions/amp-base-carousel/0.1/carousel.js
@@ -1035,7 +1035,10 @@ export class Carousel {
       // If an item is at the start of the group, it gets an aligned.
       const shouldSnap = mod(slideIndex, this.snapBy_) === 0;
 
-      setStyles(child, {
+      // If it's a slide, make sure to set the alignment of the element
+      // with the content and not the wrapping div.
+      const element = child.children.length ? child.children[0] : child;
+      setStyles(element, {
         'scroll-snap-align': shouldSnap ? this.alignment_ : 'none',
         'scroll-snap-coordinate': shouldSnap ? coordinate : 'none',
       });

--- a/extensions/amp-carousel/0.2/test/test-type-slides.js
+++ b/extensions/amp-carousel/0.2/test/test-type-slides.js
@@ -156,6 +156,21 @@ describes.realWin(
       expect(slideWrappers[1].getAttribute('aria-hidden')).to.equal('true');
     });
 
+    it('should style snap for container and content correctly', async () => {
+      const carousel = await getCarousel({loop: true});
+      const slideWrappers = getSlideWrappers(carousel);
+      expect(slideWrappers.length).to.equal(5);
+
+      // Ensure that the content has the snap property not wrapper
+      // or else it will break scrolling animation.
+      for (let i = 0; i < slideWrappers.length; i++) {
+        expect(slideWrappers[i].style.scrollSnapAlign).to.equal('');
+        expect(slideWrappers[i].children[0].style.scrollSnapAlign).to.not.equal(
+          ''
+        );
+      }
+    });
+
     it('should show focus outline and border on next and prev buttons', async () => {
       const carousel = await getCarousel({loop: false});
 


### PR DESCRIPTION
Closes #28921

`amp-carousel-0.2` wraps its slides with wrapper `<div>s`, so that it can style/label the wrapper and not the actual content.  

The problem occurs when we loop and create "spacer" slides to help with looping (and autoplay). The spacers and the wrappers are always styled with `scroll-snap-align: this.alignment_`, but the actual content children of the wrappers do not get this style.

B/c the wrapper essentially isn't anything, this messes with `scroll-snap-align` causing the animation to break when you drag.

The fix is to actually apply the `scroll-snap-align`  style to the child content and not the wrapper (if it exists, and it only exists in amp-carousel-0.2).