### PR TITLE
🐛 Check active page before pausing or playing 360 element

### DIFF
--- a/extensions/amp-story-360/0.1/amp-story-360.js
+++ b/extensions/amp-story-360/0.1/amp-story-360.js
@@ -390,7 +390,9 @@ export class AmpStory360 extends AMP.BaseElement {
         });
 
         this.storeService_.subscribe(StateProperty.PAUSED_STATE, (isPaused) => {
-          isPaused ? this.pause_() : this.play_();
+          if (this.isOnActivePage_) {
+            isPaused ? this.pause_() : this.play_();
+          }
         });
       }),
 


### PR DESCRIPTION
Check active page before play or pause.
fixes #31121

This might fix or contribute to #31062 since that is related to animating inactive pages.