### PR TITLE
✅ Disable loader animation on visual tests

### DIFF
--- a/build-system/tasks/visual-diff/index.js
+++ b/build-system/tasks/visual-diff/index.js
@@ -777,12 +777,7 @@ function installPercy_() {
   }
 
   puppeteer = require('puppeteer');
-
-  const originalPercySnapshot = require('@percy/puppeteer').percySnapshot;
-  percySnapshot = (page, name, options = {}) =>
-    originalPercySnapshot(page, name, {
-      ...options,
-    });
+  percySnapshot = require('@percy/puppeteer').percySnapshot;
 }
 
 function setupCleanup_() {

--- a/build-system/tasks/visual-diff/index.js
+++ b/build-system/tasks/visual-diff/index.js
@@ -765,7 +765,17 @@ function installPercy_() {
   }
 
   puppeteer = require('puppeteer');
-  percySnapshot = require('@percy/puppeteer').percySnapshot;
+
+  const originalPercySnapshot = require('@percy/puppeteer').percySnapshot;
+  percySnapshot = (page, name, options = {}) =>
+    originalPercySnapshot(page, name, {
+      ...options,
+      percyCss: [
+        // Loader animation may otherwise be captured in slightly different
+        // points, thus causing the test to flake.
+        '.i-amphtml-new-loader { display: none }',
+      ].join('\n'),
+    });
 }
 
 function setupCleanup_() {

--- a/build-system/tasks/visual-diff/index.js
+++ b/build-system/tasks/visual-diff/index.js
@@ -48,9 +48,19 @@ const {waitUntilUsed} = require('tcp-port-used');
 let puppeteer;
 let percySnapshot;
 
+// CSS injected in every page tested.
+// https://docs.percy.io/docs/percy-specific-css
+const percyCss = [
+  // Loader animation may otherwise be captured in slightly different points,
+  // causing the test to flake.
+  '.i-amphtml-new-loader { display: none; }',
+].join('\n');
+
 const SNAPSHOT_SINGLE_BUILD_OPTIONS = {
   widths: [375],
+  percyCss,
 };
+
 const VIEWPORT_WIDTH = 1400;
 const VIEWPORT_HEIGHT = 100000;
 const HOST = 'localhost';
@@ -567,7 +577,9 @@ async function snapshotWebpages(browser, webpages) {
 
         // Create a default set of snapshot options for Percy and modify
         // them based on the test's configuration.
-        const snapshotOptions = {};
+        const snapshotOptions = {
+          percyCss,
+        };
         if (webpage.enable_percy_javascript) {
           snapshotOptions.enableJavaScript = true;
         }
@@ -770,11 +782,6 @@ function installPercy_() {
   percySnapshot = (page, name, options = {}) =>
     originalPercySnapshot(page, name, {
       ...options,
-      percyCss: [
-        // Loader animation may otherwise be captured in slightly different
-        // points, thus causing the test to flake.
-        '.i-amphtml-new-loader { display: none }',
-      ].join('\n'),
     });
 }
 

--- a/build-system/tasks/visual-diff/snippets/iframe-wrapper.js
+++ b/build-system/tasks/visual-diff/snippets/iframe-wrapper.js
@@ -3,7 +3,7 @@
 // tests.
 
 // The following strings will be replaced at execution time:
-// *  __WIDTH__ and __HEIGHT__ with the viewport's size from the visual test's config.
+// * __WIDTH__ and __HEIGHT__ with the viewport's size from the visual test's config.
 // * __PERCY_CSS__ with Percy-specific CSS.
 
 if ('__PERCY_CSS__' !== '__' + 'PERCY_CSS' + '__') {

--- a/build-system/tasks/visual-diff/snippets/iframe-wrapper.js
+++ b/build-system/tasks/visual-diff/snippets/iframe-wrapper.js
@@ -2,8 +2,16 @@
 // with an <iframe>, so that we can perform viewport-constrained visual diff
 // tests.
 
-// The texts __WIDTH__ and __HEIGHT__ will be replaced at execution time with
-// the viewport's size from the visual test's config.
+// The following strings will be replaced at execution time:
+// *  __WIDTH__ and __HEIGHT__ with the viewport's size from the visual test's config.
+// * __PERCY_CSS__ with Percy-specific CSS.
+
+if ('__PERCY_CSS__' !== '__' + 'PERCY_CSS' + '__') {
+  const style = document.createElement('style');
+  style.setAttribute('data-percy-specific-css', '');
+  style.textContent = '__PERCY_CSS__';
+  document.body.appendChild(style);
+}
 
 const pageContents = document.documentElement.outerHTML;
 


### PR DESCRIPTION
Visual diffs tend to flake from loader animation being captured at slightly different points:

![image](https://user-images.githubusercontent.com/254946/98983999-6faad500-24d6-11eb-8c2f-4802e5ceddf1.png)

These diffs are meaningless, so we disable the loader animation.

This change changes every visual diff that includes a loader, as intended.

<!--
# Instructions:

- Pick a meaningful title for your pull request. (Use sentence case.)
  - Prefix the title with an emoji to identify what is being done. (Copy-paste the emoji from the list below.)
  - Do not overuse punctuation in the title (like `(chore):`).
  - If it is helpful, use a simple prefix (like `ProjectX: Implement some feature`).
- Enter a succinct description that says why the PR is necessary, and what it does.
  - Mention the GitHub issue that is being addressed by the pull request.
  - The keywords `Fixes`, `Closes`, or `Resolves` followed the issue number will automatically close the issue.

> NOTE: All non-trivial changes (like introducing new features or components) should have an associated issue or reference an I2I (intent-to-implement: go.amp.dev/i2i). Please read through the contribution process (go.amp.dev/contributing/code) for more information.

# Example of a good description:

- Implement aspect X
- Leave out feature Y because of A
- Improve performance by B
- Improve accessibility by C

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Reverting a previous change
♻️ Refactoring
🚮 Deleting code
🧪 Experimental code
-->
