### PR TITLE
Allow `exposes` API in amp-consent 

### DIFF
--- a/extensions/amp-consent/0.1/consent-info.js
+++ b/extensions/amp-consent/0.1/consent-info.js
@@ -16,9 +16,9 @@
 
 import {CONSENT_STRING_TYPE} from '../../../src/consent-state';
 import {deepEquals} from '../../../src/json';
-import {dev, user} from '../../../src/log';
+import {dev, user, userAssert} from '../../../src/log';
 import {hasOwn, map} from '../../../src/utils/object';
-import {isEnumValue, isObject} from '../../../src/types';
+import {isArray, isEnumValue, isObject} from '../../../src/types';
 
 const TAG = 'amp-consent';
 
@@ -61,6 +61,14 @@ export const CONSENT_ITEM_STATE = {
   // TODO(@zhouyx): Seperate UI state from consent state. Add consent
   // requirement state ui_state = {pending, active, complete} consent_state =
   // {unknown, accepted, rejected}
+};
+
+/**
+ * @enum {string}
+ * @visibleForTesting
+ */
+export const EXPOSED_CONSENT_API = {
+  TCF_POST_MESSAGE: 'tcfPostMessageApi',
 };
 
 /**
@@ -428,4 +436,27 @@ export function assertMetadataValues(metadata) {
       errorFields[i]
     );
   }
+}
+
+/**
+ * Validates the type of the `exposes` field,
+ * as well as the values.
+ * @param {!JsonObject} config
+ * @return {!Array<EXPOSED_CONSENT_API>}
+ */
+export function validateExposesApi(config) {
+  const exposesApis = [];
+  if (config['exposes']) {
+    const apiList = config['exposes'];
+    userAssert(isArray(apiList), `${TAG}: "exposes" expects array`);
+    for (let i = 0; i < apiList.length; i++) {
+      switch (apiList[i]) {
+        case EXPOSED_CONSENT_API.TCF_POST_MESSAGE:
+          exposesApis.push(EXPOSED_CONSENT_API.TCF_POST_MESSAGE);
+        default:
+          continue;
+      }
+    }
+  }
+  return exposesApis;
 }

--- a/extensions/amp-consent/0.1/test/test-amp-consent.js
+++ b/extensions/amp-consent/0.1/test/test-amp-consent.js
@@ -69,6 +69,8 @@ describes.realWin(
         'https://invalid.response.com/': '{"consentRequired": 3}',
         'https://xssi-prefix/': 'while(1){"consentRequired": false}',
         'https://example.test/': '{}',
+        'https://expose1/':
+          '{"consentRequired": true, "exposes": ["tcfPostMessageApi"]}',
       };
 
       xhrServiceMock = {
@@ -830,6 +832,56 @@ describes.realWin(
           /Consent metadata value "%s" is invalid./
         );
         expect(spy.args[0][2]).to.match(/gdprApplies/);
+      });
+    });
+
+    describe('exposes api', () => {
+      let ampConsent;
+      let consentElement;
+      let tcfPostMessageSpy;
+
+      afterEach(async () => {
+        doc.body.appendChild(consentElement);
+        ampConsent = new AmpConsent(consentElement);
+        tcfPostMessageSpy = env.sandbox.stub(
+          ampConsent,
+          'setUpTcfPostMessageProxy_'
+        );
+        await ampConsent.buildCallback();
+        await macroTask();
+        expect(tcfPostMessageSpy).to.be.calledOnce;
+      });
+
+      it('shoud use only server exposes', () => {
+        consentElement = createConsentElement(
+          doc,
+          dict({
+            'consentInstanceId': 'abc',
+            'checkConsentHref': 'https://expose1',
+          })
+        );
+      });
+
+      it('shoud use only inline exposes', () => {
+        consentElement = createConsentElement(
+          doc,
+          dict({
+            'consentInstanceId': 'abc',
+            'checkConsentHref': 'https://response1',
+            'exposes': ['tcfPostMessageApi'],
+          })
+        );
+      });
+
+      it('shoud use both server and inline exposes', () => {
+        consentElement = createConsentElement(
+          doc,
+          dict({
+            'consentInstanceId': 'abc',
+            'checkConsentHref': 'https://expose1',
+            'exposes': ['tcfPostMessageApi'],
+          })
+        );
       });
     });
 

--- a/extensions/amp-consent/0.1/test/test-consent-info.js
+++ b/extensions/amp-consent/0.1/test/test-consent-info.js
@@ -16,6 +16,7 @@
 
 import {
   CONSENT_ITEM_STATE,
+  EXPOSED_CONSENT_API,
   METADATA_STORAGE_KEY,
   composeMetadataStoreValue,
   composeStoreValue,
@@ -25,6 +26,7 @@ import {
   getStoredConsentInfo,
   isConsentInfoStoredValueSame,
   recalculateConsentStateValue,
+  validateExposesApi,
 } from '../consent-info';
 import {CONSENT_STRING_TYPE} from '../../../../src/consent-state';
 import {dict} from '../../../../src/utils/object';
@@ -449,6 +451,27 @@ describes.fakeWin('ConsentInfo', {}, () => {
         'additionalConsent': '1~1.35.41.101',
         'gdprApplies': true,
       });
+    });
+  });
+
+  describe('exposes validation', () => {
+    it('validates types', () => {
+      let exposes = EXPOSED_CONSENT_API.TCF_POST_MESSAGE;
+      expect(() => validateExposesApi({exposes})).to.throw(
+        /amp-consent: "exposes" expects array/
+      );
+
+      exposes = [EXPOSED_CONSENT_API.TCF_POST_MESSAGE];
+      expect(validateExposesApi({exposes})).to.be.deep.equals([
+        EXPOSED_CONSENT_API.TCF_POST_MESSAGE,
+      ]);
+    });
+
+    it('removes invalid values', () => {
+      const exposes = [EXPOSED_CONSENT_API.TCF_POST_MESSAGE, 'invalidValue'];
+      expect(validateExposesApi({exposes})).to.be.deep.equals([
+        EXPOSED_CONSENT_API.TCF_POST_MESSAGE,
+      ]);
     });
   });
 });


### PR DESCRIPTION
Partial for #30385

Expose the `exposes` API within `amp-consent`'s inline config and `checkConsentHref` response. 

Both publishers and CMPs should be able to tell AMP that they expect their vendors to use the TCF v2 Post Message API. 

The `exposes` API is generic in the sense that it can be expended in the future to support other APIs.  