### PR TITLE
✨ [bento][amp-accordion] Prevent overwrite of existing ids on content and header and add a11y attributes

### DIFF
--- a/extensions/amp-accordion/1.0/accordion.js
+++ b/extensions/amp-accordion/1.0/accordion.js
@@ -35,11 +35,11 @@ import {
 import {useStyles} from './accordion.jss';
 
 const AccordionContext = Preact.createContext(
-  /** @type {AccordionDef.AccordionContextProps} */ ({})
+  /** @type {AccordionDef.AccordionContext} */ ({})
 );
 
 const SectionContext = Preact.createContext(
-  /** @type {AccordionDef.SectionContextProps} */ ({})
+  /** @type {AccordionDef.SectionContext} */ ({})
 );
 
 /** @type {!Object<string, boolean>} */
@@ -207,7 +207,7 @@ function AccordionWithRef(
 
   const context = useMemo(
     () =>
-      /** @type {!AccordionDef.AccordionContextProps} */ ({
+      /** @type {!AccordionDef.AccordionContext} */ ({
         registerSection,
         toggleExpanded,
         isExpanded,
@@ -318,7 +318,7 @@ export function AccordionSection({
 
   const context = useMemo(
     () =>
-      /** @type {AccordionDef.SectionContextProps} */ ({
+      /** @type {AccordionDef.SectionContext} */ ({
         animate,
         contentId,
         headerId,

--- a/extensions/amp-accordion/1.0/accordion.js
+++ b/extensions/amp-accordion/1.0/accordion.js
@@ -37,6 +37,7 @@ import {useStyles} from './accordion.jss';
 const AccordionContext = Preact.createContext(
   /** @type {AccordionDef.AccordionContextProps} */ ({})
 );
+
 const SectionContext = Preact.createContext(
   /** @type {AccordionDef.SectionContextProps} */ ({})
 );
@@ -268,6 +269,8 @@ export function AccordionSection({
   const id = propId || genId;
   const [suffix] = useState(generateRandomId);
   const [expandedState, setExpandedState] = useState(defaultExpanded);
+  const [contentIdState, setContentIdState] = useState(null);
+  const [headerIdState, setHeaderIdState] = useState(null);
 
   const {
     registerSection,
@@ -279,7 +282,9 @@ export function AccordionSection({
 
   const expanded = isExpanded ? isExpanded(id, defaultExpanded) : expandedState;
   const animate = contextAnimate ?? defaultAnimate;
-  const contentId = `${prefix || 'a'}-content-${id}-${suffix}`;
+  const contentId =
+    contentIdState || `${prefix || 'a'}-content-${id}-${suffix}`;
+  const headerId = headerIdState || `${prefix || 'a'}-header-${id}-${suffix}`;
 
   // Storing this state change callback in a ref because this may change
   // frequently and we do not want to trigger a re-register of the section
@@ -316,10 +321,13 @@ export function AccordionSection({
       /** @type {AccordionDef.SectionContextProps} */ ({
         animate,
         contentId,
+        headerId,
         expanded,
         expandHandler,
+        registerContentId: setContentIdState,
+        registerHeaderId: setHeaderIdState,
       }),
-    [animate, contentId, expanded, expandHandler]
+    [animate, contentId, headerId, expanded, expandHandler]
   );
 
   return (
@@ -336,19 +344,33 @@ export function AccordionSection({
  * @return {PreactDef.Renderable}
  */
 export function AccordionHeader({
-  as: Comp = 'header',
+  as: Comp = 'div',
   role = 'button',
   className = '',
   tabIndex = 0,
+  id,
   children,
   ...rest
 }) {
-  const {contentId, expanded, expandHandler} = useContext(SectionContext);
+  const {
+    contentId,
+    headerId,
+    expanded,
+    expandHandler,
+    registerHeaderId,
+  } = useContext(SectionContext);
   const classes = useStyles();
+
+  useLayoutEffect(() => {
+    if (registerHeaderId) {
+      registerHeaderId(id);
+    }
+  }, [registerHeaderId, id]);
 
   return (
     <Comp
       {...rest}
+      id={headerId}
       role={role}
       className={`${className} ${classes.sectionChild} ${classes.header}`}
       tabIndex={tabIndex}
@@ -367,19 +389,33 @@ export function AccordionHeader({
  */
 export function AccordionContent({
   as: Comp = 'div',
+  role = 'region',
   className = '',
+  id,
   children,
   ...rest
 }) {
   const ref = useRef(null);
   const hasMountedRef = useRef(false);
-  const {contentId, expanded, animate} = useContext(SectionContext);
+  const {
+    contentId,
+    headerId,
+    expanded,
+    animate,
+    registerContentId,
+  } = useContext(SectionContext);
   const classes = useStyles();
 
   useEffect(() => {
     hasMountedRef.current = true;
     return () => (hasMountedRef.current = false);
   }, []);
+
+  useLayoutEffect(() => {
+    if (registerContentId) {
+      registerContentId(id);
+    }
+  }, [registerContentId, id]);
 
   useLayoutEffect(() => {
     const hasMounted = hasMountedRef.current;
@@ -396,6 +432,8 @@ export function AccordionContent({
       ref={ref}
       className={`${className} ${classes.sectionChild} ${classes.content}`}
       id={contentId}
+      aria-labelledby={headerId}
+      role={role}
       hidden={!expanded}
     >
       {children}

--- a/extensions/amp-accordion/1.0/accordion.js
+++ b/extensions/amp-accordion/1.0/accordion.js
@@ -324,8 +324,8 @@ export function AccordionSection({
         headerId,
         expanded,
         expandHandler,
-        registerContentId: setContentIdState,
-        registerHeaderId: setHeaderIdState,
+        setContentId: setContentIdState,
+        setHeaderId: setHeaderIdState,
       }),
     [animate, contentId, headerId, expanded, expandHandler]
   );
@@ -357,15 +357,15 @@ export function AccordionHeader({
     headerId,
     expanded,
     expandHandler,
-    registerHeaderId,
+    setHeaderId,
   } = useContext(SectionContext);
   const classes = useStyles();
 
   useLayoutEffect(() => {
-    if (registerHeaderId) {
-      registerHeaderId(id);
+    if (setHeaderId) {
+      setHeaderId(id);
     }
-  }, [registerHeaderId, id]);
+  }, [setHeaderId, id]);
 
   return (
     <Comp
@@ -397,13 +397,9 @@ export function AccordionContent({
 }) {
   const ref = useRef(null);
   const hasMountedRef = useRef(false);
-  const {
-    contentId,
-    headerId,
-    expanded,
-    animate,
-    registerContentId,
-  } = useContext(SectionContext);
+  const {contentId, headerId, expanded, animate, setContentId} = useContext(
+    SectionContext
+  );
   const classes = useStyles();
 
   useEffect(() => {
@@ -412,10 +408,10 @@ export function AccordionContent({
   }, []);
 
   useLayoutEffect(() => {
-    if (registerContentId) {
-      registerContentId(id);
+    if (setContentId) {
+      setContentId(id);
     }
-  }, [registerContentId, id]);
+  }, [setContentId, id]);
 
   useLayoutEffect(() => {
     const hasMounted = hasMountedRef.current;

--- a/extensions/amp-accordion/1.0/accordion.type.js
+++ b/extensions/amp-accordion/1.0/accordion.type.js
@@ -106,8 +106,8 @@ AccordionDef.AccordionContextProps;
  *   headerId: (string),
  *   expanded: (boolean),
  *   expandHandler: (function()),
- *   registerContentId: (function(string)),
- *   registerHeaderId: (function(string)),
+ *   setContentId: (function(string)),
+ *   setHeaderId: (function(string)),
  * }}
  */
 AccordionDef.SectionContextProps;

--- a/extensions/amp-accordion/1.0/accordion.type.js
+++ b/extensions/amp-accordion/1.0/accordion.type.js
@@ -66,6 +66,8 @@ AccordionDef.AccordionHeaderProps;
 AccordionDef.AccordionContentProps;
 
 /**
+ * This is not a public API, it exists to define properties for reference
+ * that are used in the HeaderShim defined in amp-accordion
  * @typedef {{
  *   id: (string),
  *   role: (string),
@@ -76,10 +78,10 @@ AccordionDef.AccordionContentProps;
  * }}
  */
 AccordionDef.HeaderShimProps;
-// AccordionDef.HeaderShimProps is not a public API
-// The definition is included here for completeness
 
 /**
+ * This is not a public API, it exists to define properties for reference
+ * that are used in the ContentShim defined in amp-accordion
  * @typedef {{
  *   id: (string),
  *   role: (string),
@@ -89,8 +91,6 @@ AccordionDef.HeaderShimProps;
  * }}
  */
 AccordionDef.ContentShimProps;
-// AccordionDef.ContentShimProps is not a public API
-// The definition is included here for completeness
 
 /**
  * @typedef {{

--- a/extensions/amp-accordion/1.0/accordion.type.js
+++ b/extensions/amp-accordion/1.0/accordion.type.js
@@ -48,6 +48,7 @@ AccordionDef.AccordionSectionProps;
  *   role: (string|undefined),
  *   className: (string|undefined),
  *   tabIndex: (number|string|undefined),
+ *   id: (string|undefined),
  *   children: (?PreactDef.Renderable|undefined),
  * }}
  */
@@ -56,7 +57,9 @@ AccordionDef.AccordionHeaderProps;
 /**
  * @typedef {{
  *   as: (string|PreactDef.FunctionalComponent|undefined),
+ *   role: (string|undefined)
  *   className: (string|undefined),
+ *   id: (string|undefined),
  *   children: (?PreactDef.Renderable|undefined),
  * }}
  */
@@ -64,8 +67,11 @@ AccordionDef.AccordionContentProps;
 
 /**
  * @typedef {{
- *   role: (string|undefined),
+ *   id: (string),
+ *   role: (string),
  *   onClick: (function()|undefined),
+ *   aria-controls: (string),
+ *   aria-expanded: (string),
  *   children: (?PreactDef.Renderable|undefined),
  * }}
  */
@@ -73,6 +79,9 @@ AccordionDef.HeaderProps;
 
 /**
  * @typedef {{
+ *   id: (string),
+ *   role: (string),
+ *   aria-labelledby: (string),
  *   hidden: (boolean),
  *   children: (?PreactDef.Renderable|undefined),
  * }}
@@ -94,8 +103,11 @@ AccordionDef.AccordionContextProps;
  * @typedef {{
  *   animate: (boolean),
  *   contentId: (string),
+ *   headerId: (string),
  *   expanded: (boolean),
- *   expandHandler: (function():undefined)
+ *   expandHandler: (function()),
+ *   registerContentId: (function(string)),
+ *   registerHeaderId: (function(string)),
  * }}
  */
 AccordionDef.SectionContextProps;

--- a/extensions/amp-accordion/1.0/accordion.type.js
+++ b/extensions/amp-accordion/1.0/accordion.type.js
@@ -75,7 +75,9 @@ AccordionDef.AccordionContentProps;
  *   children: (?PreactDef.Renderable|undefined),
  * }}
  */
-AccordionDef.HeaderProps;
+AccordionDef.HeaderShimProps;
+// AccordionDef.HeaderShimProps is not a public API
+// The definition is included here for completeness
 
 /**
  * @typedef {{
@@ -86,7 +88,9 @@ AccordionDef.HeaderProps;
  *   children: (?PreactDef.Renderable|undefined),
  * }}
  */
-AccordionDef.ContentProps;
+AccordionDef.ContentShimProps;
+// AccordionDef.ContentShimProps is not a public API
+// The definition is included here for completeness
 
 /**
  * @typedef {{
@@ -97,7 +101,7 @@ AccordionDef.ContentProps;
  *   prefix: (string),
  * }}
  */
-AccordionDef.AccordionContextProps;
+AccordionDef.AccordionContext;
 
 /**
  * @typedef {{
@@ -110,7 +114,7 @@ AccordionDef.AccordionContextProps;
  *   setHeaderId: (function(string)),
  * }}
  */
-AccordionDef.SectionContextProps;
+AccordionDef.SectionContext;
 
 /** @interface */
 AccordionDef.AccordionApi = class {

--- a/extensions/amp-accordion/1.0/amp-accordion.js
+++ b/extensions/amp-accordion/1.0/amp-accordion.js
@@ -67,7 +67,7 @@ class AmpAccordion extends PreactBaseElement {
       this.mutateProps(getState(element, mu));
     });
     mu.observe(element, {
-      attributeFilter: ['expanded'],
+      attributeFilter: ['expanded', 'id'],
       subtree: true,
     });
 

--- a/extensions/amp-accordion/1.0/amp-accordion.js
+++ b/extensions/amp-accordion/1.0/amp-accordion.js
@@ -162,7 +162,7 @@ function getExpandStateTrigger(section) {
 
 /**
  * @param {!Element} sectionElement
- * @param {!AccordionDef.SectionProps} props
+ * @param {!AccordionDef.SectionShimProps} props
  * @return {PreactDef.Renderable}
  */
 function SectionShim(sectionElement, {expanded, children}) {
@@ -183,7 +183,7 @@ const bindSectionShimToElement = (element) => SectionShim.bind(null, element);
 
 /**
  * @param {!Element} sectionElement
- * @param {!AccordionDef.HeaderProps} props
+ * @param {!AccordionDef.HeaderShimProps} props
  * @return {PreactDef.Renderable}
  */
 function HeaderShim(

--- a/extensions/amp-accordion/1.0/amp-accordion.js
+++ b/extensions/amp-accordion/1.0/amp-accordion.js
@@ -123,8 +123,14 @@ function getState(element, mu) {
       'id': section.getAttribute('id'),
       'onExpandStateChange': expandStateShim,
     });
-    const headerProps = dict({'as': headerShim});
-    const contentProps = dict({'as': contentShim});
+    const headerProps = dict({
+      'as': headerShim,
+      'id': section.firstElementChild.getAttribute('id'),
+    });
+    const contentProps = dict({
+      'as': contentShim,
+      'id': section.lastElementChild.getAttribute('id'),
+    });
     return (
       <AccordionSection {...sectionProps}>
         <AccordionHeader {...headerProps}></AccordionHeader>
@@ -182,13 +188,20 @@ const bindSectionShimToElement = (element) => SectionShim.bind(null, element);
  */
 function HeaderShim(
   sectionElement,
-  {onClick, 'aria-controls': ariaControls, 'aria-expanded': ariaExpanded}
+  {
+    id,
+    role,
+    onClick,
+    'aria-controls': ariaControls,
+    'aria-expanded': ariaExpanded,
+  }
 ) {
   const headerElement = sectionElement.firstElementChild;
   useLayoutEffect(() => {
     if (!headerElement || !onClick) {
       return;
     }
+    headerElement.setAttribute('id', id);
     headerElement.classList.add('i-amphtml-accordion-header');
     headerElement.addEventListener('click', onClick);
     if (!headerElement.hasAttribute('tabindex')) {
@@ -196,14 +209,22 @@ function HeaderShim(
     }
     headerElement.setAttribute('aria-expanded', ariaExpanded);
     headerElement.setAttribute('aria-controls', ariaControls);
-    headerElement.setAttribute('role', 'button');
+    headerElement.setAttribute('role', role);
     if (sectionElement[SECTION_POST_RENDER]) {
       sectionElement[SECTION_POST_RENDER]();
     }
     return () => {
       headerElement.removeEventListener('click', devAssert(onClick));
     };
-  }, [sectionElement, headerElement, onClick, ariaControls, ariaExpanded]);
+  }, [
+    sectionElement,
+    headerElement,
+    id,
+    role,
+    onClick,
+    ariaControls,
+    ariaExpanded,
+  ]);
   return <header />;
 }
 
@@ -219,7 +240,11 @@ const bindHeaderShimToElement = (element) => HeaderShim.bind(null, element);
  * @param {{current: ?}} ref
  * @return {PreactDef.Renderable}
  */
-function ContentShimWithRef(sectionElement, {hidden, id}, ref) {
+function ContentShimWithRef(
+  sectionElement,
+  {hidden, id, role, 'aria-labelledby': ariaLabelledBy},
+  ref
+) {
   const contentElement = sectionElement.lastElementChild;
   useImperativeHandle(ref, () => contentElement, [contentElement]);
   useLayoutEffect(() => {
@@ -228,11 +253,13 @@ function ContentShimWithRef(sectionElement, {hidden, id}, ref) {
     }
     contentElement.classList.add('i-amphtml-accordion-content');
     contentElement.setAttribute('id', id);
+    contentElement.setAttribute('role', role);
+    contentElement.setAttribute('aria-labelledby', ariaLabelledBy);
     toggleAttribute(contentElement, 'hidden', hidden);
     if (sectionElement[SECTION_POST_RENDER]) {
       sectionElement[SECTION_POST_RENDER]();
     }
-  }, [sectionElement, contentElement, hidden, id]);
+  }, [sectionElement, contentElement, hidden, id, role, ariaLabelledBy]);
   return <div />;
 }
 

--- a/extensions/amp-accordion/1.0/test/test-accordion.js
+++ b/extensions/amp-accordion/1.0/test/test-accordion.js
@@ -42,7 +42,7 @@ describes.sandboxed('Accordion preact component', {}, (env) => {
       expect(dom.children).to.have.lengthOf(2);
 
       const header = dom.children[0];
-      expect(header.localName).to.equal('header');
+      expect(header.localName).to.equal('div');
       expect(header.innerHTML).to.equal('<h1>header1</h1>');
       expect(header.getAttribute('aria-expanded')).to.equal('false');
 
@@ -66,7 +66,7 @@ describes.sandboxed('Accordion preact component', {}, (env) => {
       expect(dom).to.have.attribute('expanded');
 
       const header = dom.children[0];
-      expect(header.localName).to.equal('header');
+      expect(header.localName).to.equal('div');
       expect(header.innerHTML).to.equal('<h1>header1</h1>');
       expect(header.getAttribute('aria-expanded')).to.equal('true');
 
@@ -95,13 +95,13 @@ describes.sandboxed('Accordion preact component', {}, (env) => {
       expect(content.hidden).to.be.true;
 
       // Click on header to expand.
-      wrapper.find('header').simulate('click');
+      wrapper.find('div').at(0).simulate('click');
       expect(dom).to.have.attribute('expanded');
       expect(header.getAttribute('aria-expanded')).to.equal('true');
       expect(content.hidden).to.be.false;
 
       // Click on header again to collapse.
-      wrapper.find('header').simulate('click');
+      wrapper.find('div').at(0).simulate('click');
       expect(dom).to.not.have.attribute('expanded');
       expect(header.getAttribute('aria-expanded')).to.equal('false');
       expect(content.hidden).to.be.true;
@@ -142,12 +142,12 @@ describes.sandboxed('Accordion preact component', {}, (env) => {
       expect(sections.at(1).getDOMNode()).to.not.have.attribute('expanded');
       expect(sections.at(2).getDOMNode()).to.not.have.attribute('expanded');
 
-      const header0 = sections.at(0).find('header').getDOMNode();
-      const header1 = sections.at(1).find('header').getDOMNode();
-      const header2 = sections.at(2).find('header').getDOMNode();
-      const content0 = sections.at(0).find('div').getDOMNode();
-      const content1 = sections.at(1).find('div').getDOMNode();
-      const content2 = sections.at(2).find('div').getDOMNode();
+      const header0 = sections.at(0).find('div').at(0).getDOMNode();
+      const header1 = sections.at(1).find('div').at(0).getDOMNode();
+      const header2 = sections.at(2).find('div').at(0).getDOMNode();
+      const content0 = sections.at(0).find('div').at(1).getDOMNode();
+      const content1 = sections.at(1).find('div').at(1).getDOMNode();
+      const content2 = sections.at(2).find('div').at(1).getDOMNode();
 
       // Headers.
       expect(header0.textContent).to.equal('header1');
@@ -184,41 +184,116 @@ describes.sandboxed('Accordion preact component', {}, (env) => {
       const sections = wrapper.find(AccordionSection);
       expect(sections).to.have.lengthOf(3);
 
-      const header0 = sections.at(0).find('header').getDOMNode();
-      const header1 = sections.at(1).find('header').getDOMNode();
-      const header2 = sections.at(2).find('header').getDOMNode();
-      const content0 = sections.at(0).find('div').getDOMNode();
-      const content1 = sections.at(1).find('div').getDOMNode();
-      const content2 = sections.at(2).find('div').getDOMNode();
+      const header0 = sections.at(0).find('div').at(0).getDOMNode();
+      const header1 = sections.at(1).find('div').at(0).getDOMNode();
+      const header2 = sections.at(2).find('div').at(0).getDOMNode();
+      const content0 = sections.at(0).find('div').at(1).getDOMNode();
+      const content1 = sections.at(1).find('div').at(1).getDOMNode();
+      const content2 = sections.at(2).find('div').at(1).getDOMNode();
 
       expect(header0).to.have.attribute('tabindex');
       expect(header0).to.have.attribute('aria-controls');
       expect(header0).to.have.attribute('role');
       expect(header0).to.have.attribute('aria-expanded');
+      expect(header0).to.have.attribute('id');
       expect(header0.getAttribute('aria-expanded')).to.equal('true');
       expect(content0).to.have.attribute('id');
+      expect(content0).to.have.attribute('aria-labelledby');
+      expect(content0).to.have.attribute('role');
       expect(header0.getAttribute('aria-controls')).to.equal(
         content0.getAttribute('id')
+      );
+      expect(header0.getAttribute('id')).to.equal(
+        content0.getAttribute('aria-labelledby')
       );
 
       expect(header1).to.have.attribute('tabindex');
       expect(header1).to.have.attribute('aria-controls');
       expect(header1).to.have.attribute('role');
       expect(header1).to.have.attribute('aria-expanded');
+      expect(header1).to.have.attribute('id');
       expect(header1.getAttribute('aria-expanded')).to.equal('false');
       expect(content1).to.have.attribute('id');
+      expect(content1).to.have.attribute('aria-labelledby');
+      expect(content1).to.have.attribute('role');
       expect(header1.getAttribute('aria-controls')).to.equal(
         content1.getAttribute('id')
+      );
+      expect(header1.getAttribute('id')).to.equal(
+        content1.getAttribute('aria-labelledby')
       );
 
       expect(header2).to.have.attribute('tabindex');
       expect(header2).to.have.attribute('aria-controls');
       expect(header2).to.have.attribute('role');
       expect(header2).to.have.attribute('aria-expanded');
+      expect(header2).to.have.attribute('id');
       expect(header2.getAttribute('aria-expanded')).to.equal('false');
       expect(content2).to.have.attribute('id');
+      expect(content2).to.have.attribute('aria-labelledby');
+      expect(content2).to.have.attribute('role');
       expect(header2.getAttribute('aria-controls')).to.equal(
         content2.getAttribute('id')
+      );
+      expect(header2.getAttribute('id')).to.equal(
+        content2.getAttribute('aria-labelledby')
+      );
+    });
+
+    it('should not overwrite existing header and content ids', () => {
+      wrapper = mount(
+        <Accordion>
+          <AccordionSection key={1} expanded>
+            <AccordionHeader id="h1">header1</AccordionHeader>
+            <AccordionContent id="c1">content1</AccordionContent>
+          </AccordionSection>
+          <AccordionSection key={2}>
+            <AccordionHeader id="h2">header2</AccordionHeader>
+            <AccordionContent>content2</AccordionContent>
+          </AccordionSection>
+          <AccordionSection key={3}>
+            <AccordionHeader>header3</AccordionHeader>
+            <AccordionContent id="c3">content3</AccordionContent>
+          </AccordionSection>
+        </Accordion>
+      );
+
+      const dom = wrapper.getDOMNode();
+      expect(dom.localName).to.equal('section');
+
+      const sections = wrapper.find(AccordionSection);
+      expect(sections).to.have.lengthOf(3);
+
+      const header0 = sections.at(0).find('div').at(0).getDOMNode();
+      const header1 = sections.at(1).find('div').at(0).getDOMNode();
+      const header2 = sections.at(2).find('div').at(0).getDOMNode();
+      const content0 = sections.at(0).find('div').at(1).getDOMNode();
+      const content1 = sections.at(1).find('div').at(1).getDOMNode();
+      const content2 = sections.at(2).find('div').at(1).getDOMNode();
+
+      expect(header0.getAttribute('id')).to.equal('h1');
+      expect(content0.getAttribute('id')).to.equal('c1');
+      expect(header0.getAttribute('aria-controls')).to.equal(
+        content0.getAttribute('id')
+      );
+      expect(header0.getAttribute('id')).to.equal(
+        content0.getAttribute('aria-labelledby')
+      );
+
+      expect(header1.getAttribute('id')).to.equal('h2');
+      expect(header1.getAttribute('aria-controls')).to.equal(
+        content1.getAttribute('id')
+      );
+      expect(header1.getAttribute('id')).to.equal(
+        content1.getAttribute('aria-labelledby')
+      );
+
+      expect(content2.getAttribute('id')).to.equal('c3');
+      expect(header2.getAttribute('aria-controls')).to.equal(
+        content2.getAttribute('id')
+      );
+      expect(header2.getAttribute('id')).to.equal(
+        content2.getAttribute('aria-labelledby')
       );
     });
 
@@ -230,15 +305,15 @@ describes.sandboxed('Accordion preact component', {}, (env) => {
       expect(sections).to.have.lengthOf(3);
 
       // Click to expand.
-      sections.at(1).find('header').simulate('click');
+      sections.at(1).find('div').at(0).simulate('click');
 
       // Expanded state.
       expect(sections.at(0).getDOMNode()).to.have.attribute('expanded');
       expect(sections.at(1).getDOMNode()).to.have.attribute('expanded');
 
       // Contents.
-      expect(sections.at(0).find('div').getDOMNode().hidden).to.be.false;
-      expect(sections.at(1).find('div').getDOMNode().hidden).to.be.false;
+      expect(sections.at(0).find('div').at(1).getDOMNode().hidden).to.be.false;
+      expect(sections.at(1).find('div').at(1).getDOMNode().hidden).to.be.false;
     });
 
     it('should collapse a section on click', () => {
@@ -249,13 +324,13 @@ describes.sandboxed('Accordion preact component', {}, (env) => {
       expect(sections).to.have.lengthOf(3);
 
       // Click to expand.
-      sections.at(0).find('header').simulate('click');
+      sections.at(0).find('div').at(0).simulate('click');
 
       // Expanded state.
       expect(sections.at(0).getDOMNode()).to.not.have.attribute('expanded');
 
       // Contents.
-      expect(sections.at(0).find('div').getDOMNode().hidden).to.be.true;
+      expect(sections.at(0).find('div').at(1).getDOMNode().hidden).to.be.true;
     });
 
     it('should adjust state when expandSingleSection changes', async () => {
@@ -277,7 +352,7 @@ describes.sandboxed('Accordion preact component', {}, (env) => {
 
       expect(countExpanded()).to.equal(1);
 
-      sections.at(1).find('header').simulate('click');
+      sections.at(1).find('div').at(0).simulate('click');
       expect(countExpanded()).to.equal(2);
 
       await new Promise((resolve) => {
@@ -324,15 +399,15 @@ describes.sandboxed('Accordion preact component', {}, (env) => {
       expect(sections.at(0).getDOMNode()).to.have.attribute('expanded');
 
       // Click to expand.
-      sections.at(1).find('header').simulate('click');
+      sections.at(1).find('div').at(0).simulate('click');
 
       // Expanded state.
       expect(sections.at(0).getDOMNode()).to.not.have.attribute('expanded');
       expect(sections.at(1).getDOMNode()).to.have.attribute('expanded');
 
       // Contents.
-      expect(sections.at(0).find('div').getDOMNode().hidden).to.be.true;
-      expect(sections.at(1).find('div').getDOMNode().hidden).to.be.false;
+      expect(sections.at(0).find('div').at(1).getDOMNode().hidden).to.be.true;
+      expect(sections.at(1).find('div').at(1).getDOMNode().hidden).to.be.false;
     });
 
     it('should collapse a section on click', () => {
@@ -343,13 +418,13 @@ describes.sandboxed('Accordion preact component', {}, (env) => {
       expect(sections).to.have.lengthOf(3);
 
       // Click to expand.
-      sections.at(0).find('header').simulate('click');
+      sections.at(0).find('div').at(0).simulate('click');
 
       // Expanded state.
       expect(sections.at(0).getDOMNode()).to.not.have.attribute('expanded');
 
       // Contents.
-      expect(sections.at(0).find('div').getDOMNode().hidden).to.be.true;
+      expect(sections.at(0).find('div').at(1).getDOMNode().hidden).to.be.true;
     });
   });
 
@@ -383,10 +458,10 @@ describes.sandboxed('Accordion preact component', {}, (env) => {
       animateStub.returns(animation);
       const sections = wrapper.find(AccordionSection);
       const section = sections.at(1);
-      const content = section.find('div').getDOMNode();
+      const content = section.find('div').at(1).getDOMNode();
 
       // Click to expand.
-      section.find('header').simulate('click');
+      section.find('div').at(0).simulate('click');
 
       // The state is immediately reflected.
       expect(section.getDOMNode()).to.have.attribute('expanded');
@@ -413,10 +488,10 @@ describes.sandboxed('Accordion preact component', {}, (env) => {
       animateStub.returns(animation);
       const sections = wrapper.find(AccordionSection);
       const section = sections.at(0);
-      const content = section.find('div').getDOMNode();
+      const content = section.find('div').at(1).getDOMNode();
 
       // Click to expand.
-      section.find('header').simulate('click');
+      section.find('div').at(0).simulate('click');
 
       // The state is NOT immediately reflected: expanded attribute is removed,
       // but `content[hidden]` is deferred until animation is complete.
@@ -451,17 +526,17 @@ describes.sandboxed('Accordion preact component', {}, (env) => {
       animateStub.onFirstCall().returns(animation).onSecondCall().returns({});
       const sections = wrapper.find(AccordionSection);
       const section = sections.at(0);
-      const content = section.find('div').getDOMNode();
+      const content = section.find('div').at(1).getDOMNode();
 
       // Click to expand.
-      section.find('header').simulate('click');
+      section.find('div').at(0).simulate('click');
       expect(animateStub).to.be.calledOnce;
 
       // Hidden is not set yet.
       expect(content.hidden).to.be.false;
 
       // Unclick. This should cancel the previous animation.
-      section.find('header').simulate('click');
+      section.find('div').at(0).simulate('click');
       expect(animateStub).to.be.calledTwice;
 
       expect(animation.cancel).to.be.calledOnce;
@@ -473,11 +548,11 @@ describes.sandboxed('Accordion preact component', {}, (env) => {
       animateStub./*OK*/ restore();
       const sections = wrapper.find(AccordionSection);
       const section = sections.at(0);
-      const content = section.find('div').getDOMNode();
+      const content = section.find('div').at(1).getDOMNode();
       env.sandbox.stub(content, 'animate').value(null);
 
       // Collapse a section.
-      section.find('header').simulate('click');
+      section.find('div').at(0).simulate('click');
 
       // Immediately hidden, which means animation has not been even tried.
       expect(content.hidden).to.be.true;
@@ -520,7 +595,7 @@ describes.sandboxed('Accordion preact component', {}, (env) => {
       const sections = wrapper.find(AccordionSection);
 
       // Expand
-      sections.at(1).find('header').simulate('click');
+      sections.at(1).find('div').at(0).simulate('click');
       await waitFor(
         () => onExpandStateChange.callCount == 1,
         'event callback called'
@@ -529,7 +604,7 @@ describes.sandboxed('Accordion preact component', {}, (env) => {
       expect(onExpandStateChange.args[0][0]).to.be.true;
 
       // Collapse
-      sections.at(1).find('header').simulate('click');
+      sections.at(1).find('div').at(0).simulate('click');
       await waitFor(
         () => onExpandStateChange.callCount == 2,
         'event callback called'
@@ -538,7 +613,7 @@ describes.sandboxed('Accordion preact component', {}, (env) => {
       expect(onExpandStateChange.args[1][0]).to.be.false;
 
       // Expand
-      sections.at(1).find('header').simulate('click');
+      sections.at(1).find('div').at(0).simulate('click');
       await waitFor(
         () => onExpandStateChange.callCount == 3,
         'event callback called'
@@ -547,7 +622,7 @@ describes.sandboxed('Accordion preact component', {}, (env) => {
       expect(onExpandStateChange.args[2][0]).to.be.true;
 
       // Collapse
-      sections.at(1).find('header').simulate('click');
+      sections.at(1).find('div').at(0).simulate('click');
       await waitFor(
         () => onExpandStateChange.callCount == 4,
         'event callback called'

--- a/extensions/amp-accordion/1.0/test/test-amp-accordion.js
+++ b/extensions/amp-accordion/1.0/test/test-amp-accordion.js
@@ -235,30 +235,108 @@ describes.realWin(
       expect(header0).to.have.attribute('aria-controls');
       expect(header0).to.have.attribute('role');
       expect(header0).to.have.attribute('aria-expanded');
+      expect(header0).to.have.attribute('id');
       expect(header0.getAttribute('aria-expanded')).to.equal('true');
       expect(content0).to.have.attribute('id');
+      expect(content0).to.have.attribute('aria-labelledby');
+      expect(content0).to.have.attribute('role');
       expect(header0.getAttribute('aria-controls')).to.equal(
         content0.getAttribute('id')
+      );
+      expect(header0.getAttribute('id')).to.equal(
+        content0.getAttribute('aria-labelledby')
       );
 
       expect(header1).to.have.attribute('tabindex');
       expect(header1).to.have.attribute('aria-controls');
       expect(header1).to.have.attribute('role');
       expect(header1).to.have.attribute('aria-expanded');
+      expect(header1).to.have.attribute('id');
       expect(header1.getAttribute('aria-expanded')).to.equal('false');
       expect(content1).to.have.attribute('id');
+      expect(content1).to.have.attribute('aria-labelledby');
+      expect(content1).to.have.attribute('role');
       expect(header1.getAttribute('aria-controls')).to.equal(
         content1.getAttribute('id')
+      );
+      expect(header1.getAttribute('id')).to.equal(
+        content1.getAttribute('aria-labelledby')
       );
 
       expect(header2).to.have.attribute('tabindex');
       expect(header2).to.have.attribute('aria-controls');
       expect(header2).to.have.attribute('role');
       expect(header2).to.have.attribute('aria-expanded');
+      expect(header2).to.have.attribute('id');
       expect(header2.getAttribute('aria-expanded')).to.equal('false');
       expect(content2).to.have.attribute('id');
+      expect(content2).to.have.attribute('aria-labelledby');
+      expect(content2).to.have.attribute('role');
       expect(header2.getAttribute('aria-controls')).to.equal(
         content2.getAttribute('id')
+      );
+      expect(header2.getAttribute('id')).to.equal(
+        content2.getAttribute('aria-labelledby')
+      );
+    });
+
+    it('should not overwrite existing header and content ids', async () => {
+      element = html`
+        <amp-accordion layout="fixed" width="300" height="200">
+          <section expanded id="section1">
+            <h1 id="h1">header1</h1>
+            <div id="c1">content1</div>
+          </section>
+          <section>
+            <h1 id="h2">header2</h1>
+            <div>content2</div>
+          </section>
+          <section>
+            <h1>header3</h1>
+            <div id="c3">content3</div>
+          </section>
+        </amp-accordion>
+      `;
+      win.document.body.appendChild(element);
+      await element.build();
+
+      const sections = element.children;
+      const {
+        firstElementChild: header0,
+        lastElementChild: content0,
+      } = sections[0];
+      const {
+        firstElementChild: header1,
+        lastElementChild: content1,
+      } = sections[1];
+      const {
+        firstElementChild: header2,
+        lastElementChild: content2,
+      } = sections[2];
+
+      expect(header0.getAttribute('id')).to.equal('h1');
+      expect(content0.getAttribute('id')).to.equal('c1');
+      expect(header0.getAttribute('aria-controls')).to.equal(
+        content0.getAttribute('id')
+      );
+      expect(header0.getAttribute('id')).to.equal(
+        content0.getAttribute('aria-labelledby')
+      );
+
+      expect(header1.getAttribute('id')).to.equal('h2');
+      expect(header1.getAttribute('aria-controls')).to.equal(
+        content1.getAttribute('id')
+      );
+      expect(header1.getAttribute('id')).to.equal(
+        content1.getAttribute('aria-labelledby')
+      );
+
+      expect(content2.getAttribute('id')).to.equal('c3');
+      expect(header2.getAttribute('aria-controls')).to.equal(
+        content2.getAttribute('id')
+      );
+      expect(header2.getAttribute('id')).to.equal(
+        content2.getAttribute('aria-labelledby')
       );
     });
 


### PR DESCRIPTION
Bento Accordion Tracker: https://github.com/ampproject/amphtml/issues/30445

This PR does the following
1. Adds functionality so that an `id` on an existing `header` or `content` section (in either `bento` or `amp`) will not be overwritten by the components internal logic for assigning `ids`
2. Ensures `id` on header is matched with `aria-labelledby` on `content` which fixes https://github.com/ampproject/amphtml/issues/31137
3. Ensures `role` and `aria-labelledby` attributes are on the `content` and `id` is on the `header`
4. Default element tag for `header` updated from `header` to `div`.  This addresses an a11y issue in `storybook` which does not allow for `role="button"` on the `header` tag.