### PR TITLE
✨ Bento Selector: keyboard-select-mode feature

### DIFF
--- a/extensions/amp-selector/1.0/amp-selector.js
+++ b/extensions/amp-selector/1.0/amp-selector.js
@@ -85,12 +85,7 @@ class AmpSelector extends PreactBaseElement {
       this.mutateProps({children, options});
     });
     mu.observe(element, {
-      attributeFilter: [
-        'option',
-        'selected',
-        'disabled',
-        'keyboard-select-mode',
-      ],
+      attributeFilter: ['option', 'selected', 'disabled'],
       childList: true,
       subtree: true,
     });

--- a/extensions/amp-selector/1.0/amp-selector.js
+++ b/extensions/amp-selector/1.0/amp-selector.js
@@ -142,8 +142,8 @@ function getOptions(element, mu) {
         as: OptionShim,
         option,
         disabled,
+        index,
         onFocus: () => tryFocus(child),
-        order: index,
         role: child.getAttribute('role') || 'option',
         shimDomElement: child,
         // TODO(wg-bento): This implementation causes infinite loops on DOM mutation.

--- a/extensions/amp-selector/1.0/amp-selector.js
+++ b/extensions/amp-selector/1.0/amp-selector.js
@@ -65,24 +65,19 @@ class AmpSelector extends PreactBaseElement {
       this.mutateProps(dict({'value': value}));
     };
 
-    this.registerApiAction('clear', (api) => api./*OK*/ clear());
+    this.registerApiAction('clear', (api) => {
+      api./*OK*/ clear();
+      this.mutateProps(dict({'value': []}));
+    });
     this.registerApiAction('selectUp', (api, invocation) => {
       const {args} = invocation;
       const delta = args && args['delta'] !== undefined ? -args['delta'] : -1;
-      const initialValue = /** @type {!Array<string>} */ (this.getProp(
-        'value',
-        []
-      ));
-      selectByDelta(delta, initialValue, options, api);
+      api./*OK*/ selectBy(delta);
     });
     this.registerApiAction('selectDown', (api, invocation) => {
       const {args} = invocation;
       const delta = args && args['delta'] !== undefined ? args['delta'] : 1;
-      const initialValue = /** @type {!Array<string>} */ (this.getProp(
-        'value',
-        []
-      ));
-      selectByDelta(delta, initialValue, options, api);
+      api./*OK*/ selectBy(delta);
     });
     this.registerApiAction('toggle', (api, invocation) => {
       const {args} = invocation;
@@ -170,6 +165,7 @@ function getOptions(element, mu) {
         as: OptionShim,
         option,
         disabled,
+        order: index,
         role: child.getAttribute('role') || 'option',
         shimDomElement: child,
         // TODO(wg-bento): This implementation causes infinite loops on DOM mutation.
@@ -236,33 +232,6 @@ function callbackByDelta(delta, value, options, cb) {
   const selectUpWhenNoneSelected = previous === -1 && delta < 0;
   const index = selectUpWhenNoneSelected ? delta : previous + delta;
   cb(mod(index, options.length));
-}
-
-/**
- * This method modifies the selected state by at most one value of the
- * current selected state by the given delta.
- * The modification is done in FIFO order. When no values are selected,
- * the new selected state becomes the option at the given delta.
- *
- * ex: (1, [0, 2], [0, 1, 2, 3]) => [2, 1]
- * ex: (-1, [2, 1], [0, 1, 2, 3]) => [1]
- * ex: (2, [2, 1], [0, 1, 2, 3]) => [1, 0]
- * ex: (-1, [], [0, 1, 2, 3]) => [3]
- * @param {number} delta
- * @param {!Array<string>} value
- * @param {Array<string>} options
- * @param {!SelectorDef.SelectorApi} api
- * @return {{value: Array<string>, option: string}|undefined}
- */
-function selectByDelta(delta, value, options, api) {
-  callbackByDelta(delta, value.shift(), options, (index) => {
-    const option = options[index];
-    // Only add option if it is not already selected.
-    if (value.indexOf(option) === -1) {
-      api./*OK */ toggle(option, /* select */ true);
-      value.push(option);
-    }
-  });
 }
 
 /**

--- a/extensions/amp-selector/1.0/selector.js
+++ b/extensions/amp-selector/1.0/selector.js
@@ -19,12 +19,12 @@ import * as Preact from '../../../src/preact';
 import {Keys} from '../../../src/utils/key-codes';
 import {forwardRef} from '../../../src/preact/compat';
 import {mod} from '../../../src/utils/math';
+import {tryFocus} from '../../../src/dom';
 import {
   useCallback,
   useContext,
   useEffect,
   useImperativeHandle,
-  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -33,6 +33,17 @@ import {
 const SelectorContext = Preact.createContext(
   /** @type {SelectorDef.ContextProps} */ ({selected: []})
 );
+
+/**
+ * Set of namespaces that can be set for lifecycle reporters.
+ *
+ * @enum {string}
+ */
+export const KEYBOARD_SELECT_MODE = {
+  NONE: 'none',
+  FOCUS: 'focus',
+  SELECT: 'select',
+};
 
 /**
  * @param {!SelectorDef.Props} props
@@ -44,11 +55,13 @@ function SelectorWithRef(
     as: Comp = 'div',
     disabled,
     defaultValue = [],
+    keyboardSelectMode = KEYBOARD_SELECT_MODE.NONE,
     value,
     multiple,
     onChange,
-    onKeyDown,
+    onKeyDown: customOnKeyDown,
     role = 'listbox',
+    tabIndex,
     children,
     ...rest
   },
@@ -58,8 +71,9 @@ function SelectorWithRef(
     value ? value : defaultValue
   );
   const optionsRef = useRef([]);
-  const selected = value ? value : selectedState;
+  const focusRef = useRef({active: null, focusMap: {}});
 
+  const selected = value ? value : selectedState;
   const selectOption = useCallback(
     (option) => {
       if (!option) {
@@ -86,12 +100,14 @@ function SelectorWithRef(
   const context = useMemo(
     () => ({
       disabled,
+      focusRef,
+      keyboardSelectMode,
       multiple,
       optionsRef,
       selected,
       selectOption,
     }),
-    [disabled, multiple, selected, selectOption]
+    [disabled, focusRef, keyboardSelectMode, multiple, selected, selectOption]
   );
 
   useEffect(() => {
@@ -119,6 +135,40 @@ function SelectorWithRef(
   );
 
   /**
+   * This method uses the given callback on the target index found by
+   * modifying the given value state by the given delta.
+   *
+   * Only meaningful if `order` is provided to `Option` children.
+   *
+   * ex: (1, "a", ["a", "b", "c", "d"]) => cb(1)
+   * ex: (-1, "c", ["a", "b", "c", "d"]) => cb(1)
+   * ex: (2, "c", ["a", "b", "c", "d"]) => cb(1)
+   * ex: (-1, undefined, ["a", "b", "c", "d"]) => cb(2)
+   * @param {number} delta
+   * @param {!Array<string>} value
+   * @param {Array<string>} options
+   * @param {Function} cb
+   * @return {{value: Array<string>, option: string}|undefined}
+   */
+  const callbackByDelta = useCallback((delta, value, cb) => {
+    if (!optionsRef.current.length) {
+      return;
+    }
+    const options = optionsRef.current.filter((v) => v != undefined);
+    if (!options.length) {
+      return;
+    }
+    const previous = options.indexOf(value);
+    // If previousIndex === -1 is true, then a negative delta will be offset
+    // one more than is wanted when looping back around in the options.
+    // This occurs when the given value is undefined.
+    const selectUpWhenNoneSelected = previous === -1 && delta < 0;
+    const index = selectUpWhenNoneSelected ? delta : previous + delta;
+    const option = options[mod(index, options.length)];
+    cb(option);
+  }, []);
+
+  /**
    * This method modifies the selected state by at most one value of the
    * current selected state by the given delta.
    * The modification is done in FIFO order. When no values are selected,
@@ -132,24 +182,19 @@ function SelectorWithRef(
    * ex: (-1, [], [0, 1, 2, 3]) => [3]
    */
   const selectBy = useCallback(
-    (delta) => {
-      if (!optionsRef.current.length) {
-        return;
-      }
-      const options = optionsRef.current.filter((v) => v != undefined);
-      if (!options.length) {
-        return;
-      }
-      const previous = options.indexOf(selected.shift());
-      // If previousIndex === -1 is true, then a negative delta will be offset
-      // one more than is wanted when looping back around in the options.
-      // This occurs when no options are selected and "selectUp" is called.
-      const selectUpWhenNoneSelected = previous === -1 && delta < 0;
-      const index = selectUpWhenNoneSelected ? delta : previous + delta;
-      const option = options[mod(index, options.length)];
-      selectOption(option);
-    },
-    [selected, selectOption]
+    (delta) => callbackByDelta(delta, selected.shift(), selectOption),
+    [callbackByDelta, selected, selectOption]
+  );
+
+  const focusBy = useCallback(
+    (delta) =>
+      callbackByDelta(delta, focusRef.current.active, (option) => {
+        const focus = focusRef.current.focusMap[option];
+        if (focus) {
+          focus();
+        }
+      }),
+    [callbackByDelta]
   );
 
   useImperativeHandle(
@@ -163,6 +208,36 @@ function SelectorWithRef(
     [clear, selectBy, toggle]
   );
 
+  const onKeyDown = useCallback(
+    (e) => {
+      if (customOnKeyDown) {
+        customOnKeyDown(e);
+      }
+      const {key} = e;
+      let dir;
+      switch (key) {
+        case Keys.LEFT_ARROW: // Fallthrough.
+        case Keys.UP_ARROW:
+          dir = -1;
+          break;
+        case Keys.RIGHT_ARROW: // Fallthrough.
+        case Keys.DOWN_ARROW:
+          dir = 1;
+          break;
+        default:
+          break;
+      }
+      if (dir) {
+        if (keyboardSelectMode === KEYBOARD_SELECT_MODE.SELECT) {
+          selectBy(dir);
+        } else if (keyboardSelectMode === KEYBOARD_SELECT_MODE.FOCUS) {
+          focusBy(dir);
+        }
+      }
+    },
+    [customOnKeyDown, keyboardSelectMode, focusBy, selectBy]
+  );
+
   return (
     <Comp
       {...rest}
@@ -170,8 +245,12 @@ function SelectorWithRef(
       aria-disabled={disabled}
       aria-multiselectable={multiple}
       disabled={disabled}
+      keyboardSelectMode={keyboardSelectMode}
       multiple={multiple}
       onKeyDown={onKeyDown}
+      tabIndex={
+        tabIndex ?? keyboardSelectMode === KEYBOARD_SELECT_MODE.SELECT ? 0 : -1
+      }
     >
       <SelectorContext.Provider value={context}>
         {children}
@@ -192,28 +271,60 @@ export function Option({
   as: Comp = 'div',
   disabled = false,
   onClick: customOnClick,
+  onFocus: customOnFocus,
   onKeyDown: customOnKeyDown,
   option,
   order,
   role = 'option',
   style,
-  tabIndex = 0,
+  tabIndex,
   ...rest
 }) {
+  const ref = useRef(null);
   const {
     disabled: selectorDisabled,
+    focusRef,
+    keyboardSelectMode,
     multiple: selectorMultiple,
     optionsRef,
     selected,
     selectOption,
   } = useContext(SelectorContext);
 
-  useLayoutEffect(() => {
-    if (order != undefined) {
-      optionsRef.current[order] = option;
+  const focus = useCallback(
+    (e) => {
+      if (customOnFocus) {
+        customOnFocus(e);
+      }
+      if (ref.current) {
+        tryFocus(ref.current);
+      }
+    },
+    [customOnFocus]
+  );
+
+  useEffect(() => {
+    const refFromContext = optionsRef;
+    if (!refFromContext || !refFromContext.current) {
+      return;
     }
-    return () => delete optionsRef[order];
-  }, [order, option, optionsRef]);
+    if (order != undefined && !disabled) {
+      refFromContext.current[order] = option;
+    }
+    return () => delete refFromContext.current[order];
+  }, [disabled, order, option, optionsRef]);
+
+  useEffect(() => {
+    if (!focusRef) {
+      return;
+    }
+    const refFromContext = focusRef.current;
+    if (!refFromContext || !refFromContext.focusMap) {
+      return;
+    }
+    refFromContext.focusMap[option] = focus;
+    return () => delete refFromContext.focusMap[option];
+  }, [focus, focusRef, option]);
 
   const trySelect = useCallback(() => {
     if (selectorDisabled || disabled) {
@@ -259,13 +370,16 @@ export function Option({
     disabled,
     'aria-disabled': String(disabled),
     onClick,
+    onFocus: () => (focusRef.current.active = option),
     onKeyDown,
     option,
+    ref,
     role,
     selected: isSelected,
     'aria-selected': String(isSelected),
     style: {...statusStyle, ...style},
-    tabIndex,
+    tabIndex:
+      tabIndex ?? keyboardSelectMode === KEYBOARD_SELECT_MODE.SELECT ? -1 : 0,
   };
   return <Comp {...optionProps} />;
 }

--- a/extensions/amp-selector/1.0/selector.js
+++ b/extensions/amp-selector/1.0/selector.js
@@ -138,7 +138,7 @@ function SelectorWithRef(
    * This method uses the given callback on the target index found by
    * modifying the given value state by the given delta.
    *
-   * Only meaningful if `order` is provided to `Option` children.
+   * Only meaningful if `index` is provided to `Option` children.
    *
    * ex: (1, "a", ["a", "b", "c", "d"]) => cb(1)
    * ex: (-1, "c", ["a", "b", "c", "d"]) => cb(1)
@@ -174,7 +174,7 @@ function SelectorWithRef(
    * The modification is done in FIFO order. When no values are selected,
    * the new selected state becomes the option at the given delta.
    *
-   * Only meaningful if `order` is provided to `Option` children.
+   * Only meaningful if `index` is provided to `Option` children.
    *
    * ex: (1, [0, 2], [0, 1, 2, 3]) => [2, 1]
    * ex: (-1, [2, 1], [0, 1, 2, 3]) => [1]
@@ -270,11 +270,11 @@ export {Selector};
 export function Option({
   as: Comp = 'div',
   disabled = false,
+  index,
   onClick: customOnClick,
   onFocus: customOnFocus,
   onKeyDown: customOnKeyDown,
   option,
-  order,
   role = 'option',
   style,
   tabIndex,
@@ -308,11 +308,11 @@ export function Option({
     if (!refFromContext || !refFromContext.current) {
       return;
     }
-    if (order != undefined && !disabled) {
-      refFromContext.current[order] = option;
+    if (index != undefined && !disabled) {
+      refFromContext.current[index] = option;
     }
-    return () => delete refFromContext.current[order];
-  }, [disabled, order, option, optionsRef]);
+    return () => delete refFromContext.current[index];
+  }, [disabled, index, option, optionsRef]);
 
   useEffect(() => {
     if (!focusRef) {

--- a/extensions/amp-selector/1.0/selector.type.js
+++ b/extensions/amp-selector/1.0/selector.type.js
@@ -34,11 +34,15 @@ var SelectorDef = {};
 SelectorDef.Props;
 
 /**
+ * Note: `order` must be a positive integer to use
+ * `selectBy`, otherwise it will be noop.
+ *
  * @typedef {{
  *   as: (string|PreactDef.FunctionalComponent),
  *   option: *,
  *   disabled: (boolean|undefined),
  *   shimDomElement: !Element,
+ *   order: (number|undefined),
  *   onClick: (?function(!Event)|undefined),
  *   role: (string|undefined),
  *   shimSelected: (boolean|undefined),
@@ -66,4 +70,9 @@ SelectorDef.SelectorApi = class {
    * @param {boolean|undefined} value
    */
   toggle(option, value) {}
+
+  /**
+   * @param {number} delta
+   */
+  selectBy(delta) {}
 };

--- a/extensions/amp-selector/1.0/selector.type.js
+++ b/extensions/amp-selector/1.0/selector.type.js
@@ -54,7 +54,10 @@ SelectorDef.OptionProps;
 /**
  * @typedef {{
  *   disabled: (boolean|undefined),
+ *   focusRef: ({current: {active: *, focusMap: !Object}),
+ *   keyboardSelectMode: (string|undefined),
  *   multiple: (boolean|undefined),
+ *   optionsRef: ({current: !Array<*>}),
  *   selected: (!Array|undefined),
  *   selectOption: (function(*):undefined|undefined),
  * }}

--- a/extensions/amp-selector/1.0/selector.type.js
+++ b/extensions/amp-selector/1.0/selector.type.js
@@ -34,7 +34,7 @@ var SelectorDef = {};
 SelectorDef.Props;
 
 /**
- * Note: `order` must be a positive integer to use
+ * Note: `index` must be a positive integer to use
  * `selectBy`, otherwise it will be noop.
  *
  * @typedef {{
@@ -42,7 +42,7 @@ SelectorDef.Props;
  *   option: *,
  *   disabled: (boolean|undefined),
  *   shimDomElement: !Element,
- *   order: (number|undefined),
+ *   index: (number|undefined),
  *   onClick: (?function(!Event)|undefined),
  *   role: (string|undefined),
  *   shimSelected: (boolean|undefined),

--- a/extensions/amp-selector/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-selector/1.0/storybook/Basic.amp.js
@@ -15,9 +15,9 @@
  */
 
 import * as Preact from '../../../../src/preact';
+import {select, withKnobs} from '@storybook/addon-knobs';
 import {withA11y} from '@storybook/addon-a11y';
 import {withAmp} from '@ampproject/storybook-addon';
-import {withKnobs} from '@storybook/addon-knobs';
 
 export default {
   title: 'amp-selector',
@@ -148,4 +148,25 @@ export const Responsive = () => {
 
 Responsive.story = {
   name: 'responsive',
+};
+
+export const keyboardSelectMode = () => {
+  const keyboardSelectMode = select(
+    'keyboard select mode',
+    ['none', 'focus', 'select'],
+    'focus'
+  );
+  return (
+    <amp-selector
+      keyboard-select-mode={keyboardSelectMode}
+      aria-label="Option menu"
+    >
+      <ul>
+        <li option="1">Option 1</li>
+        <li option="2">Option 2</li>
+        <li option="3">Option 3</li>
+        <li option="4">Option 4</li>
+      </ul>
+    </amp-selector>
+  );
 };

--- a/extensions/amp-selector/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-selector/1.0/storybook/Basic.amp.js
@@ -93,12 +93,18 @@ WithUl.story = {
 };
 
 export const Actions = () => {
+  const keyboardSelectMode = select(
+    'keyboard select mode',
+    ['none', 'focus', 'select'],
+    'focus'
+  );
   return (
     <>
       <amp-selector
         id="actionsSample"
         layout="container"
         class="sample-selector"
+        keyboard-select-mode={keyboardSelectMode}
         multiple
       >
         <ul>
@@ -148,25 +154,4 @@ export const Responsive = () => {
 
 Responsive.story = {
   name: 'responsive',
-};
-
-export const keyboardSelectMode = () => {
-  const keyboardSelectMode = select(
-    'keyboard select mode',
-    ['none', 'focus', 'select'],
-    'focus'
-  );
-  return (
-    <amp-selector
-      keyboard-select-mode={keyboardSelectMode}
-      aria-label="Option menu"
-    >
-      <ul>
-        <li option="1">Option 1</li>
-        <li option="2">Option 2</li>
-        <li option="3">Option 3</li>
-        <li option="4">Option 4</li>
-      </ul>
-    </amp-selector>
-  );
 };

--- a/extensions/amp-selector/1.0/storybook/Basic.js
+++ b/extensions/amp-selector/1.0/storybook/Basic.js
@@ -50,7 +50,7 @@ function SelectorWithActions(props) {
       <Selector ref={ref} {...props}>
         {props.children.slice(0, 2)}
         {show && (
-          <Option as="div" option="2.5" order={2}>
+          <Option as="div" option="2.5" index={2}>
             Option 2.5
           </Option>
         )}
@@ -101,7 +101,7 @@ export const actionsAndOrder = () => {
           style={imgStyle}
           src="https://amp.dev/static/samples/img/landscape_sea_300x199.jpg"
           option="1"
-          order={0}
+          index={0}
           disabled
         ></Option>
         <Option
@@ -110,7 +110,7 @@ export const actionsAndOrder = () => {
           style={imgStyle}
           src="https://amp.dev/static/samples/img/landscape_desert_300x200.jpg"
           option="2"
-          order={1}
+          index={1}
         ></Option>
         <br />
         <Option
@@ -119,7 +119,7 @@ export const actionsAndOrder = () => {
           style={imgStyle}
           src="https://amp.dev/static/samples/img/landscape_ship_300x200.jpg"
           option="3"
-          order={3}
+          index={3}
         ></Option>
         <Option
           as="img"
@@ -127,7 +127,7 @@ export const actionsAndOrder = () => {
           style={imgStyle}
           src="https://amp.dev/static/samples/img/landscape_village_300x200.jpg"
           option="4"
-          order={4}
+          index={4}
         ></Option>
       </SelectorWithActions>
     </>

--- a/extensions/amp-selector/1.0/storybook/Basic.js
+++ b/extensions/amp-selector/1.0/storybook/Basic.js
@@ -50,7 +50,7 @@ function SelectorWithActions(props) {
       <Selector ref={ref} {...props}>
         {props.children.slice(0, 2)}
         {show && (
-          <Option as="div" option="2.5">
+          <Option as="div" option="2.5" order={2}>
             Option 2.5
           </Option>
         )}
@@ -70,13 +70,19 @@ function SelectorWithActions(props) {
         <button onClick={() => ref.current./*OK*/ toggle('2', false)}>
           deselect (option "2")
         </button>
+        <button onClick={() => ref.current./*OK*/ selectBy(-2)}>
+          select up by 2
+        </button>
+        <button onClick={() => ref.current./*OK*/ selectBy(1)}>
+          select down by 1
+        </button>
         <button onClick={() => ref.current./*OK*/ clear()}>clear all</button>
       </div>
     </section>
   );
 }
 
-export const listItems = () => {
+export const actionsAndOrder = () => {
   return (
     <>
       <SelectorWithActions multiple aria-label="Image menu">
@@ -86,6 +92,7 @@ export const listItems = () => {
           style={imgStyle}
           src="https://amp.dev/static/samples/img/landscape_sea_300x199.jpg"
           option="1"
+          order={0}
           disabled
         ></Option>
         <Option
@@ -94,6 +101,7 @@ export const listItems = () => {
           style={imgStyle}
           src="https://amp.dev/static/samples/img/landscape_desert_300x200.jpg"
           option="2"
+          order={1}
         ></Option>
         <br />
         <Option
@@ -102,6 +110,7 @@ export const listItems = () => {
           style={imgStyle}
           src="https://amp.dev/static/samples/img/landscape_ship_300x200.jpg"
           option="3"
+          order={3}
         ></Option>
         <Option
           as="img"
@@ -109,6 +118,7 @@ export const listItems = () => {
           style={imgStyle}
           src="https://amp.dev/static/samples/img/landscape_village_300x200.jpg"
           option="4"
+          order={4}
         ></Option>
       </SelectorWithActions>
     </>

--- a/extensions/amp-selector/1.0/storybook/Basic.js
+++ b/extensions/amp-selector/1.0/storybook/Basic.js
@@ -16,9 +16,9 @@
 
 import * as Preact from '../../../../src/preact';
 import {Option, Selector} from '../selector';
+import {select, withKnobs} from '@storybook/addon-knobs';
 import {useState} from '../../../../src/preact';
 import {withA11y} from '@storybook/addon-a11y';
-import {withKnobs} from '@storybook/addon-knobs';
 export default {
   title: 'Selector',
   component: Selector,
@@ -83,9 +83,18 @@ function SelectorWithActions(props) {
 }
 
 export const actionsAndOrder = () => {
+  const keyboardSelectMode = select(
+    'keyboard select mode',
+    ['none', 'focus', 'select'],
+    'select'
+  );
   return (
     <>
-      <SelectorWithActions multiple aria-label="Image menu">
+      <SelectorWithActions
+        keyboardSelectMode={keyboardSelectMode}
+        multiple
+        aria-label="Image menu"
+      >
         <Option
           as="img"
           alt="Sea landscape"

--- a/extensions/amp-selector/1.0/test/test-selector.js
+++ b/extensions/amp-selector/1.0/test/test-selector.js
@@ -240,13 +240,13 @@ describes.sandboxed('Selector preact component', {}, () => {
         ref = Preact.createRef();
         wrapper = mount(
           <Selector ref={ref} multiple defaultValue={['a']}>
-            <Option key={1} option="a" order={1}>
+            <Option key={1} option="a" index={1}>
               option a
             </Option>
-            <Option key={2} option="b" order={2}>
+            <Option key={2} option="b" index={2}>
               option b
             </Option>
-            <Option key={3} option="c" disabled order={3}>
+            <Option key={3} option="c" disabled index={3}>
               option c
             </Option>
           </Selector>
@@ -376,13 +376,13 @@ describes.sandboxed('Selector preact component', {}, () => {
         ref = Preact.useRef();
         wrapper = mount(
           <Selector ref={ref} defaultValue={['a']}>
-            <Option key={1} option="a" order={1}>
+            <Option key={1} option="a" index={1}>
               option a
             </Option>
-            <Option key={2} option="b" order={2}>
+            <Option key={2} option="b" index={2}>
               option b
             </Option>
-            <Option key={3} option="c" disabled order={3}>
+            <Option key={3} option="c" disabled index={3}>
               option c
             </Option>
           </Selector>

--- a/extensions/amp-selector/1.0/test/test-selector.js
+++ b/extensions/amp-selector/1.0/test/test-selector.js
@@ -348,15 +348,15 @@ describes.sandboxed('Selector preact component', {}, () => {
         ref.current.selectBy(1);
         wrapper.update();
 
-        // Try to select next option (disabled).
-        expect(option0).to.not.have.attribute('selected');
+        // Skip next option (disabled) and select the option after that.
+        expect(option0).to.have.attribute('selected');
         expect(option1).to.not.have.attribute('selected');
         expect(disabledOption).to.not.have.attribute('selected');
 
         ref.current.selectBy(-1);
         wrapper.update();
 
-        // Previous option is selected.
+        // Skip previous option (disabled) and select the option before that.
         expect(option0).to.not.have.attribute('selected');
         expect(option1).to.have.attribute('selected');
         expect(disabledOption).to.not.have.attribute('selected');
@@ -484,15 +484,15 @@ describes.sandboxed('Selector preact component', {}, () => {
         ref.current.selectBy(1);
         wrapper.update();
 
-        // Try to select next option (disabled).
-        expect(option0).to.not.have.attribute('selected');
+        // Skip next option (disabled) and select the option after that.
+        expect(option0).to.have.attribute('selected');
         expect(option1).to.not.have.attribute('selected');
         expect(disabledOption).to.not.have.attribute('selected');
 
         ref.current.selectBy(-1);
         wrapper.update();
 
-        // Previous option is selected.
+        // Skip previous option (disabled) and select the option before that.
         expect(option0).to.not.have.attribute('selected');
         expect(option1).to.have.attribute('selected');
         expect(disabledOption).to.not.have.attribute('selected');

--- a/extensions/amp-selector/1.0/test/test-selector.js
+++ b/extensions/amp-selector/1.0/test/test-selector.js
@@ -15,6 +15,7 @@
  */
 
 import * as Preact from '../../../../src/preact';
+import {Keys} from '../../../../src/utils/key-codes';
 import {Option, Selector} from '../selector';
 import {mount} from 'enzyme';
 
@@ -425,6 +426,213 @@ describes.sandboxed('Selector preact component', {}, () => {
         expect(option0).to.not.have.attribute('selected');
         expect(option1).to.not.have.attribute('selected');
         expect(disabledOption).to.not.have.attribute('selected');
+      });
+    });
+  });
+
+  describe('keyboard interactions', () => {
+    let wrapper;
+    let ref;
+
+    let selector;
+    let options;
+    let option0;
+    let option1;
+    let option2;
+
+    describe('multi-select selector', () => {
+      beforeEach(() => {
+        ref = Preact.createRef();
+        wrapper = mount(
+          <Selector ref={ref} multiple>
+            <Option key={1} option="a">
+              option a
+            </Option>
+            <Option key={2} option="b">
+              option b
+            </Option>
+            <Option key={3} option="c">
+              option c
+            </Option>
+          </Selector>
+        );
+
+        selector = wrapper.find('div').first();
+        options = wrapper.find(Option);
+        option0 = options.at(0).getDOMNode();
+        option1 = options.at(1).getDOMNode();
+        option2 = options.at(2).getDOMNode();
+      });
+
+      afterEach(() => {
+        wrapper.unmount();
+      });
+
+      it('navigate by arrows do not change selection state', () => {
+        expect(option0).to.not.have.attribute('selected');
+        expect(option1).to.not.have.attribute('selected');
+        expect(option2).to.not.have.attribute('selected');
+
+        selector.simulate('keydown', {key: Keys.LEFT_ARROW});
+        expect(option0).to.not.have.attribute('selected');
+        expect(option1).to.not.have.attribute('selected');
+        expect(option2).to.not.have.attribute('selected');
+
+        selector.simulate('keydown', {key: Keys.RIGHT_ARROW});
+        expect(option0).to.not.have.attribute('selected');
+        expect(option1).to.not.have.attribute('selected');
+        expect(option2).to.not.have.attribute('selected');
+
+        selector.simulate('keydown', {key: Keys.DOWN_ARROW});
+        expect(option0).to.not.have.attribute('selected');
+        expect(option1).to.not.have.attribute('selected');
+        expect(option2).to.not.have.attribute('selected');
+
+        selector.simulate('keydown', {key: Keys.UP_ARROW});
+        expect(option0).to.not.have.attribute('selected');
+        expect(option1).to.not.have.attribute('selected');
+        expect(option2).to.not.have.attribute('selected');
+      });
+
+      it('Enter to select', () => {
+        options.at(0).find('div').simulate('keydown', {key: Keys.ENTER});
+        expect(option0).to.have.attribute('selected');
+        expect(option1).to.not.have.attribute('selected');
+        expect(option2).to.not.have.attribute('selected');
+
+        // Subsequent Enter will deselect.
+        options.at(0).find('div').simulate('keydown', {key: Keys.ENTER});
+        expect(option0).to.not.have.attribute('selected');
+        expect(option1).to.not.have.attribute('selected');
+        expect(option2).to.not.have.attribute('selected');
+
+        // Select multiple options.
+        options.at(0).find('div').simulate('keydown', {key: Keys.ENTER});
+        expect(option0).to.have.attribute('selected');
+        expect(option1).to.not.have.attribute('selected');
+        expect(option2).to.not.have.attribute('selected');
+
+        options.at(1).find('div').simulate('keydown', {key: Keys.ENTER});
+        expect(option0).to.have.attribute('selected');
+        expect(option1).to.have.attribute('selected');
+        expect(option2).to.not.have.attribute('selected');
+      });
+
+      it('Space to select', () => {
+        options.at(1).find('div').simulate('keydown', {key: Keys.SPACE});
+        expect(option0).to.not.have.attribute('selected');
+        expect(option1).to.have.attribute('selected');
+        expect(option2).to.not.have.attribute('selected');
+
+        // Subsequent Space will deselect.
+        options.at(1).find('div').simulate('keydown', {key: Keys.SPACE});
+        expect(option0).to.not.have.attribute('selected');
+        expect(option1).to.not.have.attribute('selected');
+        expect(option2).to.not.have.attribute('selected');
+
+        // Select multiple options.
+        options.at(0).find('div').simulate('keydown', {key: Keys.SPACE});
+        expect(option0).to.have.attribute('selected');
+        expect(option1).to.not.have.attribute('selected');
+        expect(option2).to.not.have.attribute('selected');
+
+        options.at(1).find('div').simulate('keydown', {key: Keys.SPACE});
+        expect(option0).to.have.attribute('selected');
+        expect(option1).to.have.attribute('selected');
+        expect(option2).to.not.have.attribute('selected');
+      });
+    });
+
+    describe('single-select selector ', () => {
+      beforeEach(() => {
+        ref = Preact.createRef();
+        wrapper = mount(
+          <Selector ref={ref}>
+            <Option key={1} option="a">
+              option a
+            </Option>
+            <Option key={2} option="b">
+              option b
+            </Option>
+            <Option key={3} option="c">
+              option c
+            </Option>
+          </Selector>
+        );
+
+        selector = wrapper.find('div').first();
+        options = wrapper.find(Option);
+        option0 = options.at(0).getDOMNode();
+        option1 = options.at(1).getDOMNode();
+        option2 = options.at(2).getDOMNode();
+      });
+
+      afterEach(() => {
+        wrapper.unmount();
+      });
+
+      it('navigate by arrows do not change selection state', () => {
+        expect(option0).to.not.have.attribute('selected');
+        expect(option1).to.not.have.attribute('selected');
+        expect(option2).to.not.have.attribute('selected');
+
+        selector.simulate('keydown', {key: Keys.LEFT_ARROW});
+        expect(option0).to.not.have.attribute('selected');
+        expect(option1).to.not.have.attribute('selected');
+        expect(option2).to.not.have.attribute('selected');
+
+        selector.simulate('keydown', {key: Keys.RIGHT_ARROW});
+        expect(option0).to.not.have.attribute('selected');
+        expect(option1).to.not.have.attribute('selected');
+        expect(option2).to.not.have.attribute('selected');
+
+        selector.simulate('keydown', {key: Keys.DOWN_ARROW});
+        expect(option0).to.not.have.attribute('selected');
+        expect(option1).to.not.have.attribute('selected');
+        expect(option2).to.not.have.attribute('selected');
+
+        selector.simulate('keydown', {key: Keys.UP_ARROW});
+        expect(option0).to.not.have.attribute('selected');
+        expect(option1).to.not.have.attribute('selected');
+        expect(option2).to.not.have.attribute('selected');
+      });
+
+      it('Enter to select', () => {
+        options.at(0).find('div').simulate('keydown', {key: Keys.ENTER});
+        expect(option0).to.have.attribute('selected');
+        expect(option1).to.not.have.attribute('selected');
+        expect(option2).to.not.have.attribute('selected');
+
+        // Subsequent Enter does nothing.
+        options.at(0).find('div').simulate('keydown', {key: Keys.ENTER});
+        expect(option0).to.have.attribute('selected');
+        expect(option1).to.not.have.attribute('selected');
+        expect(option2).to.not.have.attribute('selected');
+
+        // Select new option deselects the first.
+        options.at(1).find('div').simulate('keydown', {key: Keys.ENTER});
+        expect(option0).to.not.have.attribute('selected');
+        expect(option1).to.have.attribute('selected');
+        expect(option2).to.not.have.attribute('selected');
+      });
+
+      it('Space to select', () => {
+        options.at(1).find('div').simulate('keydown', {key: Keys.SPACE});
+        expect(option0).to.not.have.attribute('selected');
+        expect(option1).to.have.attribute('selected');
+        expect(option2).to.not.have.attribute('selected');
+
+        // Subsequent Space does nothing.
+        options.at(1).find('div').simulate('keydown', {key: Keys.SPACE});
+        expect(option0).to.not.have.attribute('selected');
+        expect(option1).to.have.attribute('selected');
+        expect(option2).to.not.have.attribute('selected');
+
+        // Select new option deselects the first.
+        options.at(1).find('div').simulate('keydown', {key: Keys.SPACE});
+        expect(option0).to.not.have.attribute('selected');
+        expect(option1).to.have.attribute('selected');
+        expect(option2).to.not.have.attribute('selected');
       });
     });
   });

--- a/extensions/amp-selector/1.0/test/test-selector.js
+++ b/extensions/amp-selector/1.0/test/test-selector.js
@@ -240,13 +240,13 @@ describes.sandboxed('Selector preact component', {}, () => {
         ref = Preact.createRef();
         wrapper = mount(
           <Selector ref={ref} multiple defaultValue={['a']}>
-            <Option key={1} option="a">
+            <Option key={1} option="a" order={1}>
               option a
             </Option>
-            <Option key={2} option="b">
+            <Option key={2} option="b" order={2}>
               option b
             </Option>
-            <Option key={3} option="c" disabled>
+            <Option key={3} option="c" disabled order={3}>
               option c
             </Option>
           </Selector>
@@ -328,6 +328,45 @@ describes.sandboxed('Selector preact component', {}, () => {
         // No options are selected.
         expect(option0).to.not.have.attribute('selected');
         expect(option1).to.not.have.attribute('selected');
+        expect(disabledOption).to.not.have.attribute('selected');
+      });
+
+      it('select by delta', async () => {
+        // First option is selected by default.
+        expect(option0).to.have.attribute('selected');
+        expect(option1).to.not.have.attribute('selected');
+        expect(disabledOption).to.not.have.attribute('selected');
+
+        ref.current.selectBy(1);
+        wrapper.update();
+
+        // Next option is selected.
+        expect(option0).to.not.have.attribute('selected');
+        expect(option1).to.have.attribute('selected');
+        expect(disabledOption).to.not.have.attribute('selected');
+
+        ref.current.selectBy(1);
+        wrapper.update();
+
+        // Try to select next option (disabled).
+        expect(option0).to.not.have.attribute('selected');
+        expect(option1).to.not.have.attribute('selected');
+        expect(disabledOption).to.not.have.attribute('selected');
+
+        ref.current.selectBy(-1);
+        wrapper.update();
+
+        // Previous option is selected.
+        expect(option0).to.not.have.attribute('selected');
+        expect(option1).to.have.attribute('selected');
+        expect(disabledOption).to.not.have.attribute('selected');
+
+        ref.current.selectBy(0);
+        wrapper.update();
+
+        // Nothing has changed.
+        expect(option0).to.not.have.attribute('selected');
+        expect(option1).to.have.attribute('selected');
         expect(disabledOption).to.not.have.attribute('selected');
       });
     });
@@ -337,13 +376,13 @@ describes.sandboxed('Selector preact component', {}, () => {
         ref = Preact.useRef();
         wrapper = mount(
           <Selector ref={ref} defaultValue={['a']}>
-            <Option key={1} option="a">
+            <Option key={1} option="a" order={1}>
               option a
             </Option>
-            <Option key={2} option="b">
+            <Option key={2} option="b" order={2}>
               option b
             </Option>
-            <Option key={3} option="c" disabled>
+            <Option key={3} option="c" disabled order={3}>
               option c
             </Option>
           </Selector>
@@ -425,6 +464,45 @@ describes.sandboxed('Selector preact component', {}, () => {
         // No options are selected.
         expect(option0).to.not.have.attribute('selected');
         expect(option1).to.not.have.attribute('selected');
+        expect(disabledOption).to.not.have.attribute('selected');
+      });
+
+      it('select by delta', async () => {
+        // First option is selected by default.
+        expect(option0).to.have.attribute('selected');
+        expect(option1).to.not.have.attribute('selected');
+        expect(disabledOption).to.not.have.attribute('selected');
+
+        ref.current.selectBy(1);
+        wrapper.update();
+
+        // Next option is selected.
+        expect(option0).to.not.have.attribute('selected');
+        expect(option1).to.have.attribute('selected');
+        expect(disabledOption).to.not.have.attribute('selected');
+
+        ref.current.selectBy(1);
+        wrapper.update();
+
+        // Try to select next option (disabled).
+        expect(option0).to.not.have.attribute('selected');
+        expect(option1).to.not.have.attribute('selected');
+        expect(disabledOption).to.not.have.attribute('selected');
+
+        ref.current.selectBy(-1);
+        wrapper.update();
+
+        // Previous option is selected.
+        expect(option0).to.not.have.attribute('selected');
+        expect(option1).to.have.attribute('selected');
+        expect(disabledOption).to.not.have.attribute('selected');
+
+        ref.current.selectBy(0);
+        wrapper.update();
+
+        // Nothing has changed.
+        expect(option0).to.not.have.attribute('selected');
+        expect(option1).to.have.attribute('selected');
         expect(disabledOption).to.not.have.attribute('selected');
       });
     });


### PR DESCRIPTION
Partial for #28282. This PR introduces the following changes:
- `keyboard-select-mode` attribute on `amp-selector` with the following possible configurations:
  - `none`: `Enter` and `Space` selects an `Option` (Default)
  - `focus`: `Enter` and `Space` selects an `Option`, Arrow keys `Left`, `Right`, `Down`, and `Up` navigate focus in DOM order between options, including looping:
![15fa9543-3165-4f0c-ad46-b04173d4824d](https://user-images.githubusercontent.com/10456171/99109950-9db41600-25b7-11eb-8b5b-cca12b09a2f0.gif)
  - `select`: Arrow keys `Left`, `Right`, `Down`, and `Up` navigate selected state on the target element in DOM order between options, including looping.
![6639fd69-71a2-4706-92e4-122c0cea37d5](https://user-images.githubusercontent.com/10456171/99110049-c63c1000-25b7-11eb-9721-8ff25a9d1ba3.gif)
- `Enter` and `Space` selects an `Option` in Preact mode, but no `keyboardSelectMode` prop is used as this requires a defined order of option children. Omitting `keyboardSelectMode` should be fine in this layer, as it is primarily a prop for enhanced configuration of keyboard navigability in the component, however by default the options are already keyboard navigable. If Preact developers hope to add additional keyboard events to change selection state, this is supported via the exposed `toggle` action.

