### PR TITLE
✨  Bento Carousel: `snapBy` feature

### DIFF
--- a/extensions/amp-base-carousel/1.0/amp-base-carousel.js
+++ b/extensions/amp-base-carousel/1.0/amp-base-carousel.js
@@ -104,6 +104,7 @@ AmpBaseCarousel['props'] = {
   'mixedLength': {attr: 'mixed-length', type: 'boolean', media: true},
   'outsetArrows': {attr: 'outset-arrows', type: 'boolean', media: true},
   'snap': {attr: 'snap', type: 'boolean', media: true, default: true},
+  'snapBy': {attr: 'snap-by', type: 'number', media: true},
   'visibleCount': {attr: 'visible-count', type: 'number', media: true},
 };
 

--- a/extensions/amp-base-carousel/1.0/base-carousel.js
+++ b/extensions/amp-base-carousel/1.0/base-carousel.js
@@ -77,6 +77,7 @@ function BaseCarouselWithRef(
     onTouchStart,
     outsetArrows,
     snap = true,
+    snapBy = 1,
     visibleCount = 1,
     _thumbnails = false,
     ...rest
@@ -234,6 +235,7 @@ function BaseCarouselWithRef(
         restingIndex={currentSlide}
         setRestingIndex={setRestingIndex}
         snap={snap}
+        snapBy={snapBy}
         ref={scrollRef}
         visibleCount={mixedLength ? 1 : visibleCount}
         _thumbnails={_thumbnails}

--- a/extensions/amp-base-carousel/1.0/base-carousel.type.js
+++ b/extensions/amp-base-carousel/1.0/base-carousel.type.js
@@ -34,6 +34,7 @@ var BaseCarouselDef = {};
  *   mixedLength: (boolean|undefined),
  *   onSlideChange: (function(number):undefined|undefined),
  *   snap: (boolean|undefined),
+ *   snapBy: (number|undefined),
  *   visibleCount: (number|undefined),
  * }}
  */
@@ -48,6 +49,7 @@ BaseCarouselDef.Props;
  *   restingIndex: number,
  *   setRestingIndex: (function(number):undefined),
  *   snap: (boolean|undefined),
+ *   snapBy: (number|undefined),
  *   visibleCount: (number|undefined),
  * }}
  */
@@ -63,6 +65,7 @@ BaseCarouselDef.ScrollerProps;
  *   pivotIndex: number,
  *   restingIndex: number,
  *   snap: (boolean|undefined),
+ *   snapBy: (number|undefined),
  *   src: (string|undefined),
  *   thumbnailSrc: (string|undefined),
  *   visibleCount: (number|undefined),

--- a/extensions/amp-base-carousel/1.0/scroller.js
+++ b/extensions/amp-base-carousel/1.0/scroller.js
@@ -53,6 +53,7 @@ function ScrollerWithRef(
     restingIndex,
     setRestingIndex,
     snap,
+    snapBy = 1,
     visibleCount,
     _thumbnails,
     ...rest
@@ -141,6 +142,7 @@ function ScrollerWithRef(
       pivotIndex,
       restingIndex,
       snap,
+      snapBy,
       visibleCount,
       _thumbnails,
     },
@@ -338,6 +340,7 @@ function renderSlides(
     offsetRef,
     pivotIndex,
     snap,
+    snapBy,
     visibleCount,
     _thumbnails,
   },
@@ -351,7 +354,9 @@ function renderSlides(
         key={key}
         data-slide={index}
         class={`${classes.slideSizing} ${classes.slideElement} ${
-          snap ? classes.enableSnap : classes.disableSnap
+          snap && mod(index, snapBy) === 0
+            ? classes.enableSnap
+            : classes.disableSnap
         } ${_thumbnails ? classes.thumbnails : ''}`}
         style={{flex: mixedLength ? '0 0 auto' : `0 0 ${100 / visibleCount}%`}}
       >

--- a/extensions/amp-base-carousel/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-base-carousel/1.0/storybook/Basic.amp.js
@@ -32,6 +32,7 @@ export default {
 export const Default = () => {
   const loop = boolean('loop', true);
   const snap = boolean('snap', true);
+  const snapBy = number('snap by', 1);
   const advanceCount = number('advance count', 1, {min: 1});
   const autoAdvance = boolean('auto advance', true);
   const autoAdvanceCount = number('auto advance count', 1);
@@ -57,6 +58,7 @@ export const Default = () => {
         width="880"
         height="225"
         snap={String(snap)}
+        snap-by={snapBy}
         loop={loop}
         layout="responsive"
         visible-count={visibleCount}
@@ -99,6 +101,7 @@ export const mixedLength = () => {
   const colorIncrement = Math.floor(255 / (slideCount + 1));
   const loop = boolean('loop', true);
   const snap = boolean('snap', true);
+  const snapBy = number('snap by', 1);
   const mixedLength = boolean('mixed length', true);
   const controls = select('show controls', ['auto', 'always', 'never']);
 
@@ -108,6 +111,7 @@ export const mixedLength = () => {
       mixed-length={mixedLength}
       loop={loop}
       snap={String(snap)}
+      snap-by={snapBy}
       width={width}
       height={height}
     >

--- a/extensions/amp-base-carousel/1.0/storybook/Basic.js
+++ b/extensions/amp-base-carousel/1.0/storybook/Basic.js
@@ -52,6 +52,7 @@ export const _default = () => {
   const height = number('height', 225);
   const slideCount = number('slide count', 5, {min: 0, max: 99});
   const snap = boolean('snap', true);
+  const snapBy = number('snap by', 1);
   const loop = boolean('loop', true);
   const advanceCount = number('advance count', 1, {min: 1});
   const visibleCount = number('visible count', 2, {min: 1});
@@ -65,6 +66,7 @@ export const _default = () => {
       loop={loop}
       outsetArrows={outsetArrows}
       snap={snap}
+      snapBy={snapBy}
       style={{width, height}}
       visibleCount={visibleCount}
     >
@@ -100,6 +102,7 @@ export const mixedLength = () => {
   const autoAdvanceLoops = number('auto advance loops', 3);
   const loop = boolean('loop', true);
   const snap = boolean('snap', true);
+  const snapBy = number('snap by', 1);
   const mixedLength = boolean('mixed length', true);
   const controls = select('show controls', ['auto', 'always', 'never']);
   const randomPreset = [
@@ -118,6 +121,7 @@ export const mixedLength = () => {
       mixedLength={mixedLength}
       loop={loop}
       snap={snap}
+      snapBy={snapBy}
       style={{width, height}}
     >
       {Array.from({length: slideCount}, (x, i) => {
@@ -210,6 +214,7 @@ export const WithCaptions = () => {
 export const AutoAdvance = () => {
   const slideCount = number('slide count', 5, {min: 0, max: 99});
   const snap = boolean('snap', true);
+  const snapBy = number('snap by', 1);
   const loop = boolean('loop', true);
   const autoAdvance = boolean('auto advance', true);
   const autoAdvanceCount = number('auto advance count', 1);
@@ -227,6 +232,7 @@ export const AutoAdvance = () => {
       autoAdvance={autoAdvance}
       loop={loop}
       snap={snap}
+      snapBy={snapBy}
       style={{width: '600px', height: '300px'}}
       visibleCount={visibleCount}
     >

--- a/extensions/amp-base-carousel/1.0/test/test-amp-base-carousel.js
+++ b/extensions/amp-base-carousel/1.0/test/test-amp-base-carousel.js
@@ -20,6 +20,7 @@ import {
   createElementWithAttributes,
   waitForChildPromise,
 } from '../../../../src/dom';
+import {mod} from '../../../../src/utils/math';
 import {setStyles} from '../../../../src/style';
 import {toArray} from '../../../../src/types';
 import {toggleExperiment} from '../../../../src/experiments';
@@ -170,54 +171,76 @@ describes.realWin(
       ).to.deep.equal([userSuppliedChildren[1]]);
     });
 
-    it('should snap to slides by default', async () => {
-      const userSuppliedChildren = setSlides(3);
-      userSuppliedChildren.forEach((child) => element.appendChild(child));
-      win.document.body.appendChild(element);
+    describe('snapping', () => {
+      it('should snap to slides by default', async () => {
+        const userSuppliedChildren = setSlides(3);
+        userSuppliedChildren.forEach((child) => element.appendChild(child));
+        win.document.body.appendChild(element);
 
-      const renderedSlideWrappers = await getSlideWrappersFromShadow();
-      expect(renderedSlideWrappers).to.have.lengthOf(3);
-      renderedSlideWrappers.forEach((slide) => {
-        expect(slide.classList.contains(styles.enableSnap)).to.be.true;
+        const renderedSlideWrappers = await getSlideWrappersFromShadow();
+        expect(renderedSlideWrappers).to.have.lengthOf(3);
+        renderedSlideWrappers.forEach((slide) => {
+          expect(slide.classList.contains(styles.enableSnap)).to.be.true;
+        });
       });
-    });
 
-    it('should snap to slides with snap attribute', async () => {
-      element.setAttribute('snap', '');
-      const userSuppliedChildren = setSlides(3);
-      userSuppliedChildren.forEach((child) => element.appendChild(child));
-      win.document.body.appendChild(element);
+      it('should snap to slides with snap attribute', async () => {
+        element.setAttribute('snap', '');
+        const userSuppliedChildren = setSlides(3);
+        userSuppliedChildren.forEach((child) => element.appendChild(child));
+        win.document.body.appendChild(element);
 
-      const renderedSlideWrappers = await getSlideWrappersFromShadow();
-      expect(renderedSlideWrappers).to.have.lengthOf(3);
-      renderedSlideWrappers.forEach((slide) => {
-        expect(slide.classList.contains(styles.enableSnap)).to.be.true;
+        const renderedSlideWrappers = await getSlideWrappersFromShadow();
+        expect(renderedSlideWrappers).to.have.lengthOf(3);
+        renderedSlideWrappers.forEach((slide) => {
+          expect(slide.classList.contains(styles.enableSnap)).to.be.true;
+        });
       });
-    });
 
-    it('should snap to slides with snap="true"', async () => {
-      element.setAttribute('snap', 'true');
-      const userSuppliedChildren = setSlides(3);
-      userSuppliedChildren.forEach((child) => element.appendChild(child));
-      win.document.body.appendChild(element);
+      it('should snap to slides with snap="true"', async () => {
+        element.setAttribute('snap', 'true');
+        const userSuppliedChildren = setSlides(3);
+        userSuppliedChildren.forEach((child) => element.appendChild(child));
+        win.document.body.appendChild(element);
 
-      const renderedSlideWrappers = await getSlideWrappersFromShadow();
-      expect(renderedSlideWrappers).to.have.lengthOf(3);
-      renderedSlideWrappers.forEach((slide) => {
-        expect(slide.classList.contains(styles.enableSnap)).to.be.true;
+        const renderedSlideWrappers = await getSlideWrappersFromShadow();
+        expect(renderedSlideWrappers).to.have.lengthOf(3);
+        renderedSlideWrappers.forEach((slide) => {
+          expect(slide.classList.contains(styles.enableSnap)).to.be.true;
+        });
       });
-    });
 
-    it('should not snap to slides with snap="false"', async () => {
-      element.setAttribute('snap', 'false');
-      const userSuppliedChildren = setSlides(3);
-      userSuppliedChildren.forEach((child) => element.appendChild(child));
-      win.document.body.appendChild(element);
+      it('should not snap to slides with snap="false"', async () => {
+        element.setAttribute('snap', 'false');
+        const userSuppliedChildren = setSlides(3);
+        userSuppliedChildren.forEach((child) => element.appendChild(child));
+        win.document.body.appendChild(element);
 
-      const renderedSlideWrappers = await getSlideWrappersFromShadow();
-      expect(renderedSlideWrappers).to.have.lengthOf(3);
-      renderedSlideWrappers.forEach((slide) => {
-        expect(slide.classList.contains(styles.disableSnap)).to.be.true;
+        const renderedSlideWrappers = await getSlideWrappersFromShadow();
+        expect(renderedSlideWrappers).to.have.lengthOf(3);
+        renderedSlideWrappers.forEach((slide) => {
+          expect(slide.classList.contains(styles.disableSnap)).to.be.true;
+        });
+      });
+
+      it('should only set snap on slides according to snap-by', async () => {
+        element.setAttribute('snap', '');
+        element.setAttribute('snap-by', '2');
+        const userSuppliedChildren = setSlides(4);
+        userSuppliedChildren.forEach((child) => element.appendChild(child));
+        win.document.body.appendChild(element);
+
+        const renderedSlideWrappers = await getSlideWrappersFromShadow();
+        expect(renderedSlideWrappers).to.have.lengthOf(4);
+        renderedSlideWrappers.forEach((slide, index) => {
+          if (mod(index, 2) === 0) {
+            expect(slide.classList.contains(styles.enableSnap)).to.be.true;
+            expect(slide.classList.contains(styles.disableSnap)).to.be.false;
+          } else {
+            expect(slide.classList.contains(styles.enableSnap)).to.be.false;
+            expect(slide.classList.contains(styles.disableSnap)).to.be.true;
+          }
+        });
       });
     });
 

--- a/extensions/amp-base-carousel/1.0/test/test-base-carousel.js
+++ b/extensions/amp-base-carousel/1.0/test/test-base-carousel.js
@@ -17,8 +17,11 @@
 import * as Preact from '../../../../src/preact';
 import {BaseCarousel} from '../base-carousel';
 import {mount} from 'enzyme';
+import {useStyles} from '../base-carousel.jss';
 
 describes.sandboxed('BaseCarousel preact component', {}, () => {
+  const styles = useStyles();
+
   it('should render Arrows and propagates children to Scroller', () => {
     const wrapper = mount(
       <BaseCarousel>
@@ -98,17 +101,19 @@ describes.sandboxed('BaseCarousel preact component', {}, () => {
       </BaseCarousel>
     );
     expect(wrapper.find(`[snap="true"]`)).not.to.be.null;
+    expect(wrapper.find(`.${styles.enableSnap}`)).to.have.lengthOf(3);
   });
 
-  it('should not snap to slides with snap="false"', () => {
+  it('should not snap to slides with snap={false}', () => {
     const wrapper = mount(
-      <BaseCarousel>
+      <BaseCarousel snap={false}>
         <div>slide 1</div>
         <div>slide 2</div>
         <div>slide 3</div>
       </BaseCarousel>
     );
     expect(wrapper.find(`[snap="false"]`)).not.to.be.null;
+    expect(wrapper.find(`.${styles.disableSnap}`)).to.have.lengthOf(3);
   });
 
   it('should render Arrows with controls=always', () => {
@@ -142,5 +147,20 @@ describes.sandboxed('BaseCarousel preact component', {}, () => {
       </BaseCarousel>
     );
     expect(wrapper.find('Arrow')).to.have.lengthOf(0);
+  });
+
+  it('should respect snap-by if snapping', () => {
+    const wrapper = mount(
+      <BaseCarousel snapBy={2} controls="never">
+        <div>slide 1</div>
+        <div>slide 2</div>
+        <div>slide 3</div>
+        <div>slide 4</div>
+      </BaseCarousel>
+    );
+    const snapEnabledSlides = wrapper.find(`.${styles.enableSnap}`);
+    expect(snapEnabledSlides).to.have.lengthOf(2);
+    expect(snapEnabledSlides.at(0).text()).to.equal('slide 1');
+    expect(snapEnabledSlides.at(1).text()).to.equal('slide 3');
   });
 });


### PR DESCRIPTION
Partial for #28282. This PR introduces `snap-by` to `amp-base-carousel` and `snapBy` to `BaseCarousel`.
- `snap-by`: A number, defaults to `1`. This determines the granularity of snapping and is useful when using `visible-count`.