### PR TITLE
[Story Player] Allow no initial stories

### DIFF
--- a/src/amp-story-player/amp-story-player-impl.js
+++ b/src/amp-story-player/amp-story-player-impl.js
@@ -173,11 +173,6 @@ export class AmpStoryPlayer {
    * @param {!Element} element
    */
   constructor(win, element) {
-    console./*OK*/ assert(
-      element.childElementCount > 0,
-      'Missing configuration.'
-    );
-
     /** @private {!Window} */
     this.win_ = win;
 


### PR DESCRIPTION
With the new Story Player methods to programmatically add Stories, or fetch them from a backend on initial load, we don't need to throw an error if no Stories were configured.