### PR TITLE
🐛 Remove story error pollution from inabox.

### DIFF
--- a/extensions/amp-story-auto-ads/0.1/story-ad-ui.js
+++ b/extensions/amp-story-auto-ads/0.1/story-ad-ui.js
@@ -125,12 +125,16 @@ export function localizeCtaText(ctaType, localizationService) {
 /**
  * Returns a boolean indicating if there is sufficent metadata to render CTA.
  * @param {!StoryAdUIMetadata} metadata
+ * @param {=boolean} opt_inabox
  * @return {boolean}
  */
-export function validateCtaMetadata(metadata) {
+export function validateCtaMetadata(metadata, opt_inabox) {
   // If making a CTA layer we need a button name & outlink url.
   if (!metadata[A4AVarNames.CTA_TYPE] || !metadata[A4AVarNames.CTA_URL]) {
-    user().error(TAG, 'Both CTA Type & CTA Url are required in ad response.');
+    // Don't polute inabox logs, as we don't know when this is intended to
+    // be a story ad.
+    !opt_inabox &&
+      user().error(TAG, 'Both CTA Type & CTA Url are required in ad response.');
     return false;
   }
   return true;

--- a/extensions/amp-story-auto-ads/0.1/test/test-story-ad-ui.js
+++ b/extensions/amp-story-auto-ads/0.1/test/test-story-ad-ui.js
@@ -95,6 +95,13 @@ describes.realWin('story-ad-ui', {amp: true}, (env) => {
       });
     });
 
+    it('returns false without error in inabox', () => {
+      const metadata = {
+        'cta-url': 'https://www.kittens.com',
+      };
+      expect(validateCtaMetadata(metadata, true /* opt_inabox */)).to.be.false;
+    });
+
     it('returns false if no cta url', () => {
       const metadata = {
         'cta-type': 'SHOP',

--- a/src/inabox/inabox-story-ad.js
+++ b/src/inabox/inabox-story-ad.js
@@ -33,7 +33,7 @@ export function maybeRenderInaboxAsStoryAd(ampdoc) {
   const {win} = ampdoc;
   const doc = win.document;
   const storyAdMetadata = getStoryAdMetadataFromDoc(doc);
-  if (!validateCtaMetadata(storyAdMetadata)) {
+  if (!validateCtaMetadata(storyAdMetadata, true /* opt_inabox */)) {
     return;
   }
   installStylesForDoc(ampdoc, sharedCSS + inaboxCSS, () => {});


### PR DESCRIPTION
We should not throw an error in normal inabox rendering. This does not affect the ad, but pollutes logs.

cc/ @jeffkaufman 