### PR TITLE
resources: incorrect var name

### DIFF
--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -463,7 +463,7 @@ export class Resource {
   }
 
   /** Removes the premeasured rect, likely forcing a manual measure. */
-  invalidatePremeasurement() {
+  invalidatePremeasurementAndRequestMeasure() {
     this.premeasuredRect_ = null;
     this.requestMeasure();
   }

--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -465,6 +465,7 @@ export class Resource {
   /** Removes the premeasured rect, likely forcing a manual measure. */
   invalidatePremeasurement() {
     this.premeasuredRect_ = null;
+    this.requestMeasure();
   }
 
   /**

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -258,7 +258,7 @@ export class ResourcesImpl {
       // Unfortunately, a viewport size change invalidates all premeasurements.
       if (this.relayoutAll_ && this.intersectionObserver_) {
         this.resources_.forEach((resource) =>
-          resource.invalidatePremeasurement()
+          resource.invalidatePremeasurementAndRequestMeasure()
         );
       }
     });

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -1241,7 +1241,7 @@ export class ResourcesImpl {
         const expediteFirstMeasure =
           !r.hasBeenMeasured() && r.element.tagName == 'AMP-AD';
         const needsMeasure =
-          premeasured || requested || this.relayoutAll_ || expediteFirstMeasure;
+          premeasured || requested || relayoutAll || expediteFirstMeasure;
         if (needsMeasure) {
           const isDisplayed = this.measureResource_(
             r,

--- a/test/unit/test-resources.js
+++ b/test/unit/test-resources.js
@@ -740,6 +740,7 @@ describes.realWin('Resources discoverWork', {amp: true}, (env) => {
     it('should invalidate premeasurements after resize event', () => {
       resource1.premeasure({});
       expect(resource1.hasBeenPremeasured()).true;
+      expect(resource1.isMeasureRequested()).false;
       resources.viewport_.changeObservable_.fire({relayoutAll_: true});
       expect(resource1.hasBeenPremeasured()).false;
       expect(resource1.isMeasureRequested()).true;

--- a/test/unit/test-resources.js
+++ b/test/unit/test-resources.js
@@ -742,6 +742,7 @@ describes.realWin('Resources discoverWork', {amp: true}, (env) => {
       expect(resource1.hasBeenPremeasured()).true;
       resources.viewport_.changeObservable_.fire({relayoutAll_: true});
       expect(resource1.hasBeenPremeasured()).false;
+      expect(resource1.isMeasureRequested()).true;
     });
 
     it('should applySizesAndMediaQuery on relayout', () => {


### PR DESCRIPTION
**summary**
context: `b/173209780`
Followup to https://github.com/ampproject/amphtml/pull/30937.

I believe there was an accidental usage of `this.relayoutAll_` instead of `relayoutAll`. Especially considering the ivar will always be false. This essentially means that even though _everything_ was supposed to be remeasured, many things ended up ignored.

Note: I also added a `requestMeasure()` to invalidatePremeasurement as a safeguard. At the moment it won't change behavior. But if we were to start calling invalidatePremeasurement in a new location instead of just during a relayoutAll, then this could cause bugs if we don't also force remeasurement.