### PR TITLE
✨ Bento Carousel: snap-align feature

### DIFF
--- a/extensions/amp-base-carousel/1.0/amp-base-carousel.js
+++ b/extensions/amp-base-carousel/1.0/amp-base-carousel.js
@@ -105,6 +105,7 @@ AmpBaseCarousel['props'] = {
   'outsetArrows': {attr: 'outset-arrows', type: 'boolean', media: true},
   'snap': {attr: 'snap', type: 'boolean', media: true, default: true},
   'snapBy': {attr: 'snap-by', type: 'number', media: true},
+  'snapAlign': {attr: 'snap-align', type: 'string', media: true},
   'visibleCount': {attr: 'visible-count', type: 'number', media: true},
 };
 

--- a/extensions/amp-base-carousel/1.0/base-carousel.js
+++ b/extensions/amp-base-carousel/1.0/base-carousel.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import * as Preact from '../../../src/preact';
+import {Alignment} from './dimensions';
 import {Arrow} from './arrow';
 import {CarouselContext} from './carousel-context';
 import {ContainWrapper} from '../../../src/preact/component';
@@ -77,6 +78,7 @@ function BaseCarouselWithRef(
     onTouchStart,
     outsetArrows,
     snap = true,
+    snapAlign = Alignment.START,
     snapBy = 1,
     visibleCount = 1,
     _thumbnails = false,
@@ -229,6 +231,7 @@ function BaseCarouselWithRef(
       )}
       <Scroller
         advanceCount={advanceCount}
+        alignment={snapAlign}
         autoAdvanceCount={autoAdvanceCount}
         loop={loop}
         mixedLength={mixedLength}

--- a/extensions/amp-base-carousel/1.0/base-carousel.type.js
+++ b/extensions/amp-base-carousel/1.0/base-carousel.type.js
@@ -77,15 +77,6 @@ BaseCarouselDef.SlideProps;
 
 /**
  * @typedef {{
- *   start: number,
- *   end: number,
- *   length: number,
- * }}
- */
-BaseCarouselDef.DimensionDef;
-
-/**
- * @typedef {{
  *   advance: (function():undefined|undefined),
  *   customArrow: (PreactDef.VNode|undefined),
  *   by: number,

--- a/extensions/amp-base-carousel/1.0/base-carousel.type.js
+++ b/extensions/amp-base-carousel/1.0/base-carousel.type.js
@@ -34,6 +34,7 @@ var BaseCarouselDef = {};
  *   mixedLength: (boolean|undefined),
  *   onSlideChange: (function(number):undefined|undefined),
  *   snap: (boolean|undefined),
+ *   snapAlign: (string|undefined),
  *   snapBy: (number|undefined),
  *   visibleCount: (number|undefined),
  * }}
@@ -49,6 +50,7 @@ BaseCarouselDef.Props;
  *   restingIndex: number,
  *   setRestingIndex: (function(number):undefined),
  *   snap: (boolean|undefined),
+ *   snapAlign: (string|undefined),
  *   snapBy: (number|undefined),
  *   visibleCount: (number|undefined),
  * }}
@@ -72,6 +74,15 @@ BaseCarouselDef.ScrollerProps;
  * }}
  */
 BaseCarouselDef.SlideProps;
+
+/**
+ * @typedef {{
+ *   start: number,
+ *   end: number,
+ *   length: number,
+ * }}
+ */
+BaseCarouselDef.DimensionDef;
 
 /**
  * @typedef {{

--- a/extensions/amp-base-carousel/1.0/dimensions.js
+++ b/extensions/amp-base-carousel/1.0/dimensions.js
@@ -1,0 +1,226 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {mod} from '../../../src/utils/math';
+
+/**
+ * @enum {number}
+ */
+export const Axis = {
+  X: 0,
+  Y: 1,
+};
+
+/**
+ * @enum {string}
+ */
+export const Alignment = {
+  START: 'start',
+  CENTER: 'center',
+};
+
+/**
+ * @param {!Axis} axis The Axis to get the Dimension for.
+ * @param {*} el The Element to get the Dimension For.
+ * @return {!BaseCarouselDef.DimensionDef} The dimension for the Element along the given Axis.
+ */
+export function getDimension(axis, el) {
+  const {
+    top,
+    bottom,
+    height,
+    left,
+    right,
+    width,
+  } = el./*OK*/ getBoundingClientRect();
+
+  return {
+    start: axis == Axis.X ? left : top,
+    end: axis == Axis.X ? right : bottom,
+    length: axis == Axis.X ? width : height,
+  };
+}
+
+/**
+ * @param {!Axis} axis The axis to get the center point for.
+ * @param {!Element} el The Element to get the center point for.
+ * @return {number} The center point.
+ */
+export function getCenter(axis, el) {
+  const {start, end} = getDimension(axis, el);
+  return (start + end) / 2;
+}
+
+/**
+ * @param {!Axis} axis The axis to get the start point for.
+ * @param {!Element} el The Element to get the start point for.
+ * @return {number} The start point.
+ */
+export function getStart(axis, el) {
+  const {start} = getDimension(axis, el);
+  return start;
+}
+
+/**
+ * @param {!Axis} axis The Axis to get the position for.
+ * @param {!Alignment} alignment The Alignment to get the position for.
+ * @param {!Element} el The Element to get the position for.
+ * @return {number} The position for the given Element along the given axis for
+ *    the given alignment.
+ */
+export function getPosition(axis, alignment, el) {
+  return alignment == Alignment.START
+    ? getStart(axis, el)
+    : getCenter(axis, el);
+}
+
+/**
+ * @param {!Axis} axis The axis to check for overlap.
+ * @param {!Element} el The Element to check for overlap.
+ * @param {number} position A position to check.
+ * @return {boolean} If the element overlaps the position along the given axis.
+ */
+export function overlaps(axis, el, position) {
+  const {start, end} = getDimension(axis, el);
+  // Ignore the end point, since that is shared with the adjacent Element.
+  return start <= position && position < end;
+}
+
+/**
+ * @param {!Axis} axis The axis to align on.
+ * @param {!Alignment} alignment The desired alignment.
+ * @param {!Element} container The container to align against.
+ * @param {!Element} el The Element get the offset for.
+ * @return {number} How far el is from alignment, as a percentage of its length.
+ */
+export function getPercentageOffsetFromAlignment(
+  axis,
+  alignment,
+  container,
+  el
+) {
+  const elPos = getPosition(axis, alignment, el);
+  const containerPos = getPosition(axis, alignment, container);
+  const {length: elLength} = getDimension(axis, el);
+  return (elPos - containerPos) / elLength;
+}
+
+/**
+ * Finds the index of a child that overlaps a point within the parent,
+ * determined by an axis and alignment. A startIndex is used to look at the
+ * children that are more likely to overlap first.
+ * @param {!Axis} axis The axis to look along.
+ * @param {!Alignment} alignment The alignment to look for within the parent
+ *    container.
+ * @param {!Element} container  The parent container to look in.
+ * @param {!Array<!Element>} children The children to look among.
+ * @param {number} startIndex The index to start looking at.
+ * @return {number|undefined} The overlapping index, if one exists.
+ */
+export function findOverlappingIndex(
+  axis,
+  alignment,
+  container,
+  children,
+  startIndex
+) {
+  const pos = getPosition(axis, alignment, container);
+
+  // First look at the start index, since is the most likely to overlap.
+  if (overlaps(axis, children[startIndex], pos)) {
+    return startIndex;
+  }
+
+  // Move outwards, since the closer indicies are more likely to overlap.
+  for (let i = 1; i <= children.length / 2; i++) {
+    const nextIndex = mod(startIndex + i, children.length);
+    const prevIndex = mod(startIndex - i, children.length);
+
+    if (overlaps(axis, children[nextIndex], pos)) {
+      return nextIndex;
+    }
+
+    if (overlaps(axis, children[prevIndex], pos)) {
+      return prevIndex;
+    }
+  }
+}
+
+/**
+ * Gets the current scroll position for an element along a given axis.
+ * @param {!Axis} axis The axis to set the scroll position for.
+ * @param {!Element} el The Element to set the scroll position for.
+ * @return {number} The scroll position.
+ */
+export function getScrollPosition(axis, el) {
+  if (axis == Axis.X) {
+    return el./*OK*/ scrollLeft;
+  }
+
+  return el./*OK*/ scrollTop;
+}
+
+/**
+ * Sets the scroll position for an element along a given axis.
+ * @param {!Axis} axis The axis to set the scroll position for.
+ * @param {!Element} el The Element to set the scroll position for.
+ * @param {number} position The scroll position.
+ */
+export function setScrollPosition(axis, el, position) {
+  if (axis == Axis.X) {
+    el./*OK*/ scrollLeft = position;
+  } else {
+    el./*OK*/ scrollTop = position;
+  }
+}
+
+/**
+ * Updates the scroll position for an element along a given axis.
+ * @param {!Axis} axis The axis to set the scroll position for.
+ * @param {!Element} el The Element to set the scroll position for.
+ * @param {number} delta The scroll delta.
+ */
+export function updateScrollPosition(axis, el, delta) {
+  setScrollPosition(axis, el, getScrollPosition(axis, el) + delta);
+}
+
+/**
+ * Scrolls the position within a scrolling container to an Element. Unlike
+ * `scrollIntoView`, this function does not scroll the container itself into
+ * view.
+ * @param {!Axis} axis The axis to scroll along.
+ * @param {!Alignment} alignment How to align the element within the container.
+ * @param {!Element} container The scrolling container.
+ * @param {!Element} el The Element to scroll to.
+ * @param {number} offset A percentage offset within the element to scroll to.
+ */
+export function scrollContainerToElement(
+  axis,
+  alignment,
+  container,
+  el,
+  offset = 0
+) {
+  const startAligned = alignment == Alignment.START;
+  const {length} = getDimension(axis, el);
+  const snapOffset = startAligned ? getStart(axis, el) : getCenter(axis, el);
+  const scrollOffset = startAligned
+    ? getStart(axis, container)
+    : getCenter(axis, container);
+  const delta = snapOffset - scrollOffset - offset * length;
+
+  updateScrollPosition(axis, container, delta);
+}

--- a/extensions/amp-base-carousel/1.0/dimensions.js
+++ b/extensions/amp-base-carousel/1.0/dimensions.js
@@ -206,6 +206,7 @@ export function updateScrollPosition(axis, el, delta) {
  * @param {!Element} container The scrolling container.
  * @param {!Element} el The Element to scroll to.
  * @param {number} offset A percentage offset within the element to scroll to.
+ * @return {boolean} Whether not scrolling was performed.
  */
 export function scrollContainerToElement(
   axis,
@@ -223,4 +224,5 @@ export function scrollContainerToElement(
   const delta = snapOffset - scrollOffset - offset * length;
 
   updateScrollPosition(axis, container, delta);
+  return !!delta;
 }

--- a/extensions/amp-base-carousel/1.0/dimensions.js
+++ b/extensions/amp-base-carousel/1.0/dimensions.js
@@ -146,7 +146,6 @@ export function findOverlappingIndex(
 
   // Move outwards, since the closer indicies are more likely to overlap.
   for (let i = 1; i <= children.length / 2; i++) {
-    console.log('for loop');
     const nextIndex = mod(startIndex + i, children.length);
     const prevIndex = mod(startIndex - i, children.length);
 

--- a/extensions/amp-base-carousel/1.0/dimensions.js
+++ b/extensions/amp-base-carousel/1.0/dimensions.js
@@ -35,7 +35,7 @@ export const Alignment = {
 /**
  * @param {!Axis} axis The Axis to get the Dimension for.
  * @param {*} el The Element to get the Dimension For.
- * @return {!BaseCarouselDef.DimensionDef} The dimension for the Element along the given Axis.
+ * @return {!DimensionDef} The dimension for the Element along the given Axis.
  */
 export function getDimension(axis, el) {
   const {
@@ -126,7 +126,7 @@ export function getPercentageOffsetFromAlignment(
  * @param {!Alignment} alignment The alignment to look for within the parent
  *    container.
  * @param {!Element} container  The parent container to look in.
- * @param {!Array<!Element>} children The children to look among.
+ * @param {!HTMLCollection} children The children to look among.
  * @param {number} startIndex The index to start looking at.
  * @return {number|undefined} The overlapping index, if one exists.
  */
@@ -146,6 +146,7 @@ export function findOverlappingIndex(
 
   // Move outwards, since the closer indicies are more likely to overlap.
   for (let i = 1; i <= children.length / 2; i++) {
+    console.log('for loop');
     const nextIndex = mod(startIndex + i, children.length);
     const prevIndex = mod(startIndex - i, children.length);
 

--- a/extensions/amp-base-carousel/1.0/dimensions.js
+++ b/extensions/amp-base-carousel/1.0/dimensions.js
@@ -33,9 +33,18 @@ export const Alignment = {
 };
 
 /**
+ * @typedef {{
+ *   start: number,
+ *   end: number,
+ *   length: number,
+ * }}
+ */
+let BaseCarouselDimensionDef;
+
+/**
  * @param {!Axis} axis The Axis to get the Dimension for.
  * @param {*} el The Element to get the Dimension For.
- * @return {!DimensionDef} The dimension for the Element along the given Axis.
+ * @return {!BaseCarouselDimensionDef} The dimension for the Element along the given Axis.
  */
 export function getDimension(axis, el) {
   const {

--- a/extensions/amp-base-carousel/1.0/scroller.js
+++ b/extensions/amp-base-carousel/1.0/scroller.js
@@ -31,6 +31,7 @@ import {
   useLayoutEffect,
   useMemo,
   useRef,
+  useState,
 } from '../../../src/preact';
 import {useStyles} from './base-carousel.jss';
 
@@ -70,7 +71,7 @@ function ScrollerWithRef(
 ) {
   // We still need our own ref that we can always rely on to be there.
   const containerRef = useRef(null);
-  const axis = useMemo(() => Axis.X, []);
+  const [axis] = useState(Axis.X);
 
   /**
    * The number of slides we want to place before the reference or resting index.

--- a/extensions/amp-base-carousel/1.0/scroller.js
+++ b/extensions/amp-base-carousel/1.0/scroller.js
@@ -223,6 +223,10 @@ function ScrollerWithRef(
   };
 
   const handleScroll = () => {
+    if (ignoreProgrammaticScrollRef.current) {
+      ignoreProgrammaticScrollRef.current = false;
+      return;
+    }
     updateCurrentIndex();
     debouncedResetScrollReferencePoint();
   };

--- a/extensions/amp-base-carousel/1.0/scroller.js
+++ b/extensions/amp-base-carousel/1.0/scroller.js
@@ -92,15 +92,21 @@ function ScrollerWithRef(
       if (!container) {
         return;
       }
-      scrollContainerToElement(
+      // Smooth scrolling is preferred to `setRestingIndex` whenever possible.
+      // Note: `setRestingIndex` will still be called on debounce by scroll handler.
+      currentIndex.current = mod(currentIndex.current + by, children.length);
+      const didScroll = scrollContainerToElement(
         axis,
         alignment,
         container,
         container.children[mod(pivotIndex + by, container.children.length)],
         scrollOffset.current
       );
+      if (!didScroll) {
+        setRestingIndex(currentIndex.current);
+      }
     },
-    [alignment, axis, pivotIndex]
+    [alignment, axis, children.length, pivotIndex, setRestingIndex]
   );
   useImperativeHandle(
     ref,

--- a/extensions/amp-base-carousel/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-base-carousel/1.0/storybook/Basic.amp.js
@@ -32,6 +32,7 @@ export default {
 export const Default = () => {
   const loop = boolean('loop', true);
   const snap = boolean('snap', true);
+  const snapAlign = select('snap alignment', ['start', 'center'], 'start');
   const snapBy = number('snap by', 1);
   const advanceCount = number('advance count', 1, {min: 1});
   const autoAdvance = boolean('auto advance', true);
@@ -58,6 +59,7 @@ export const Default = () => {
         width="880"
         height="225"
         snap={String(snap)}
+        snap-align={snapAlign}
         snap-by={snapBy}
         loop={loop}
         layout="responsive"
@@ -101,6 +103,7 @@ export const mixedLength = () => {
   const colorIncrement = Math.floor(255 / (slideCount + 1));
   const loop = boolean('loop', true);
   const snap = boolean('snap', true);
+  const snapAlign = select('snap alignment', ['start', 'center'], 'start');
   const snapBy = number('snap by', 1);
   const mixedLength = boolean('mixed length', true);
   const controls = select('show controls', ['auto', 'always', 'never']);
@@ -111,6 +114,7 @@ export const mixedLength = () => {
       mixed-length={mixedLength}
       loop={loop}
       snap={String(snap)}
+      snap-align={snapAlign}
       snap-by={snapBy}
       width={width}
       height={height}

--- a/extensions/amp-base-carousel/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-base-carousel/1.0/storybook/Basic.amp.js
@@ -107,6 +107,12 @@ export const mixedLength = () => {
   const snapBy = number('snap by', 1);
   const mixedLength = boolean('mixed length', true);
   const controls = select('show controls', ['auto', 'always', 'never']);
+  const randomPreset = [
+    [143, 245, 289, 232, 280, 233, 182, 155, 114, 269, 242, 196, 249, 265, 241],
+    [225, 158, 201, 205, 230, 233, 231, 255, 143, 264, 227, 157, 120, 203, 144],
+    [252, 113, 115, 186, 248, 188, 162, 104, 100, 109, 175, 227, 143, 249, 280],
+  ];
+  const preset = select('random preset', [1, 2, 3]);
 
   return (
     <amp-base-carousel
@@ -125,8 +131,9 @@ export const mixedLength = () => {
           <div
             style={{
               backgroundColor: `rgb(${v}, 100, 100)`,
-              width: `${Math.floor(Math.random() * 200 + 100)}px`,
-              height: `${Math.floor(Math.random() * 100 + 100)}px`,
+              border: 'solid white 1px',
+              width: `${randomPreset[preset - 1 || 0][i]}px`,
+              height: `100px`,
             }}
           ></div>
         );

--- a/extensions/amp-base-carousel/1.0/storybook/Basic.js
+++ b/extensions/amp-base-carousel/1.0/storybook/Basic.js
@@ -20,6 +20,7 @@ import {boolean, number, select, withKnobs} from '@storybook/addon-knobs';
 import {withA11y} from '@storybook/addon-a11y';
 
 const CONTROLS = ['auto', 'always', 'never'];
+const SNAP_ALIGN = ['start', 'center'];
 
 export default {
   title: 'BaseCarousel',
@@ -52,6 +53,7 @@ export const _default = () => {
   const height = number('height', 225);
   const slideCount = number('slide count', 5, {min: 0, max: 99});
   const snap = boolean('snap', true);
+  const snapAlign = select('snap alignment', SNAP_ALIGN, 'start');
   const snapBy = number('snap by', 1);
   const loop = boolean('loop', true);
   const advanceCount = number('advance count', 1, {min: 1});
@@ -66,6 +68,7 @@ export const _default = () => {
       loop={loop}
       outsetArrows={outsetArrows}
       snap={snap}
+      snapAlign={snapAlign}
       snapBy={snapBy}
       style={{width, height}}
       visibleCount={visibleCount}
@@ -102,6 +105,7 @@ export const mixedLength = () => {
   const autoAdvanceLoops = number('auto advance loops', 3);
   const loop = boolean('loop', true);
   const snap = boolean('snap', true);
+  const snapAlign = select('snap alignment', SNAP_ALIGN, 'start');
   const snapBy = number('snap by', 1);
   const mixedLength = boolean('mixed length', true);
   const controls = select('show controls', ['auto', 'always', 'never']);
@@ -121,6 +125,7 @@ export const mixedLength = () => {
       mixedLength={mixedLength}
       loop={loop}
       snap={snap}
+      snapAlign={snapAlign}
       snapBy={snapBy}
       style={{width, height}}
     >
@@ -214,6 +219,7 @@ export const WithCaptions = () => {
 export const AutoAdvance = () => {
   const slideCount = number('slide count', 5, {min: 0, max: 99});
   const snap = boolean('snap', true);
+  const snapAlign = select('snap alignment', SNAP_ALIGN, 'start');
   const snapBy = number('snap by', 1);
   const loop = boolean('loop', true);
   const autoAdvance = boolean('auto advance', true);
@@ -232,6 +238,7 @@ export const AutoAdvance = () => {
       autoAdvance={autoAdvance}
       loop={loop}
       snap={snap}
+      snapAlign={snapAlign}
       snapBy={snapBy}
       style={{width: '600px', height: '300px'}}
       visibleCount={visibleCount}

--- a/extensions/amp-base-carousel/1.0/test/test-amp-base-carousel.js
+++ b/extensions/amp-base-carousel/1.0/test/test-amp-base-carousel.js
@@ -278,6 +278,12 @@ describes.realWin(
         element.enqueAction(invocation('next'));
         await waitFor(() => scroller.scrollLeft > 0, 'advanced to next slide');
 
+        // Make sure internal state index is updated before attempting to call prev(),
+        // Since this is typically updated automatically on debounce, there is a risk that
+        // the test will call prev() on the slide at the 0th index unless we force i here.
+        element.enqueAction(invocation('goToSlide', {index: 1}));
+        await waitFor(() => scroller.scrollLeft > 0, 'to slide 1');
+
         element.enqueAction(invocation('prev'));
         await waitFor(() => scroller.scrollLeft == 0, 'returned to prev slide');
       });

--- a/extensions/amp-base-carousel/1.0/test/test-amp-base-carousel.js
+++ b/extensions/amp-base-carousel/1.0/test/test-amp-base-carousel.js
@@ -21,6 +21,7 @@ import {
   waitForChildPromise,
 } from '../../../../src/dom';
 import {mod} from '../../../../src/utils/math';
+import {poll} from '../../../../testing/iframe';
 import {setStyles} from '../../../../src/style';
 import {toArray} from '../../../../src/types';
 import {toggleExperiment} from '../../../../src/experiments';
@@ -285,7 +286,13 @@ describes.realWin(
         await waitFor(() => scroller.scrollLeft > 0, 'to slide 1');
 
         element.enqueAction(invocation('prev'));
-        await waitFor(() => scroller.scrollLeft == 0, 'returned to prev slide');
+        // Wait for a longer timeout than the 200 default in waitFor.
+        await poll(
+          'returned to prev slide',
+          () => scroller.scrollLeft == 0,
+          undefined /* opt_onError */,
+          400 /* opt_timeout */
+        );
       });
 
       it('should execute goToSlide action', async () => {

--- a/extensions/amp-base-carousel/1.0/test/test-amp-base-carousel.js
+++ b/extensions/amp-base-carousel/1.0/test/test-amp-base-carousel.js
@@ -280,7 +280,7 @@ describes.realWin(
 
         // Make sure internal state index is updated before attempting to call prev(),
         // Since this is typically updated automatically on debounce, there is a risk that
-        // the test will call prev() on the slide at the 0th index unless we force i here.
+        // the test will call prev() on the slide at the 0th index unless we force is here.
         element.enqueAction(invocation('goToSlide', {index: 1}));
         await waitFor(() => scroller.scrollLeft > 0, 'to slide 1');
 

--- a/extensions/amp-inline-gallery/1.0/thumbnails.js
+++ b/extensions/amp-inline-gallery/1.0/thumbnails.js
@@ -72,6 +72,7 @@ export function Thumbnails({
       className={`${className} ${classes.thumbnails}`}
       mixedLength={true}
       snap={false}
+      snapAlign="center"
       controls={pointerFine ? 'always' : 'never'}
       loop={loop}
       ref={ref}

--- a/extensions/amp-stream-gallery/1.0/stream-gallery.js
+++ b/extensions/amp-stream-gallery/1.0/stream-gallery.js
@@ -49,6 +49,7 @@ export function StreamGallery(props) {
     minVisibleCount = 1,
     outsetArrows,
     peek = 0,
+    slideAlign = 'start',
     snap,
     ...rest
   } = props;
@@ -124,6 +125,7 @@ export function StreamGallery(props) {
       loop={loop}
       outsetArrows={outsetArrows}
       snap={snap}
+      snapAlign={slideAlign}
       ref={ref}
       visibleCount={visibleCount}
       {...rest}


### PR DESCRIPTION
Partial for #28284. This PR introduces the following `snapAlign` feature in various forms to different carousels:
- `snap-align` to `amp-base-carousel` and `snapAlign` to `BaseCarousel`
- Use `snapSlign` in `Thumbnails` (`amp-inline-gallery-thumbnails`)
- `slide-align` to `amp-stream-gallery` and `slideAlign` to `StreamGallery`: Note this is consistent with 0.1 but can be renamed since `StreamGallery` is not yet launched.

`snap-align`: Either `"start"` or `"center"`. When `"start"` aligning, the start of a slide (e.g. the left edge, when horizontal aligning) is aligned with the start of a carousel. When `"center"` aligning, the center of a slide is aligned with the center of a carousel. 
- `"start"` on first render of a looping 8-slide carousel:
![image](https://user-images.githubusercontent.com/10456171/99400122-99884100-28b4-11eb-883f-266bec770439.png)
- `"center"` on first render of a looping 8-slide carousel:
![image](https://user-images.githubusercontent.com/10456171/99400162-a3aa3f80-28b4-11eb-9fef-6ab0ec982a97.png)

 