### PR TITLE
✨ [bento][amp-accordion] Add display-locking feature to bento accordion

### DIFF
--- a/extensions/amp-accordion/1.0/accordion.js
+++ b/extensions/amp-accordion/1.0/accordion.js
@@ -499,7 +499,6 @@ export function AccordionContent({
       id={contentId}
       aria-labelledby={headerId}
       role={role}
-      aria-hidden={String(!expanded)}
     >
       {children}
     </Comp>

--- a/extensions/amp-accordion/1.0/accordion.js
+++ b/extensions/amp-accordion/1.0/accordion.js
@@ -489,7 +489,7 @@ export function AccordionContent({
       id={contentId}
       aria-labelledby={headerId}
       role={role}
-      aria-hidden={!expanded}
+      aria-hidden={String(!expanded)}
     >
       {children}
     </Comp>

--- a/extensions/amp-accordion/1.0/accordion.js
+++ b/extensions/amp-accordion/1.0/accordion.js
@@ -468,7 +468,7 @@ export function AccordionContent({
     }
 
     const beforeMatchHandler = () => {
-      toggleHandler(true);
+      toggleHandler(/* force expand */ true);
     };
     element.addEventListener('beforematch', beforeMatchHandler);
     return () => element.removeEventListener('beforematch', beforeMatchHandler);
@@ -493,8 +493,8 @@ export function AccordionContent({
     <Comp
       {...rest}
       ref={ref}
-      className={`${className} ${classes.sectionChild} ${classes.content} ${
-        !expanded ? hiddenClass : ''
+      className={`${className} ${classes.sectionChild} ${
+        expanded ? '' : hiddenClass
       }`}
       id={contentId}
       aria-labelledby={headerId}

--- a/extensions/amp-accordion/1.0/accordion.js
+++ b/extensions/amp-accordion/1.0/accordion.js
@@ -425,8 +425,11 @@ export function AccordionContent({
     experimentDisplayLocking,
   } = useContext(SectionContext);
   const classes = useStyles();
-  const [contentVisibility, setContentVisibility] = useState(false);
-  const enableDisplayLocking = contentVisibility && experimentDisplayLocking;
+  const [supportsContentVisibility, setSupportsContentVisibility] = useState(
+    false
+  );
+  const enableDisplayLocking =
+    supportsContentVisibility && experimentDisplayLocking;
 
   useEffect(() => {
     hasMountedRef.current = true;
@@ -444,17 +447,17 @@ export function AccordionContent({
       return;
     }
 
-    const supportsContentVisibility = win.CSS.supports(
+    const newSupportsContentVisibility = win.CSS.supports(
       'content-visibility',
       'hidden-matchable'
     );
-    setContentVisibility(supportsContentVisibility);
-    if (!experimentDisplayLocking || !supportsContentVisibility) {
+    setSupportsContentVisibility(newSupportsContentVisibility);
+    if (!experimentDisplayLocking || !newSupportsContentVisibility) {
       return;
     }
 
     const beforeMatchHandler = () => {
-      if (!element.parentElement.hasAttribute('expanded')) {
+      if (element.getAttribute('aria-hidden') === 'true') {
         expandHandler();
       }
     };
@@ -482,9 +485,11 @@ export function AccordionContent({
       {...rest}
       ref={ref}
       className={`${className} ${classes.sectionChild} ${classes.content} ${
-        !expanded ? classes.contentHidden : ''
-      } ${
-        !expanded && enableDisplayLocking ? classes.contentHiddenMatchable : ''
+        !expanded
+          ? enableDisplayLocking
+            ? classes.contentHiddenMatchable
+            : classes.contentHidden
+          : ''
       }`}
       id={contentId}
       aria-labelledby={headerId}

--- a/extensions/amp-accordion/1.0/accordion.js
+++ b/extensions/amp-accordion/1.0/accordion.js
@@ -430,6 +430,9 @@ export function AccordionContent({
   );
   const enableDisplayLocking =
     supportsContentVisibility && experimentDisplayLocking;
+  const hiddenClass = enableDisplayLocking
+    ? classes.contentHiddenMatchable
+    : classes.contentHidden;
 
   useEffect(() => {
     hasMountedRef.current = true;
@@ -485,11 +488,7 @@ export function AccordionContent({
       {...rest}
       ref={ref}
       className={`${className} ${classes.sectionChild} ${classes.content} ${
-        !expanded
-          ? enableDisplayLocking
-            ? classes.contentHiddenMatchable
-            : classes.contentHidden
-          : ''
+        !expanded ? hiddenClass : ''
       }`}
       id={contentId}
       aria-labelledby={headerId}

--- a/extensions/amp-accordion/1.0/accordion.js
+++ b/extensions/amp-accordion/1.0/accordion.js
@@ -489,6 +489,7 @@ export function AccordionContent({
       id={contentId}
       aria-labelledby={headerId}
       role={role}
+      aria-hidden={!expanded}
     >
       {children}
     </Comp>

--- a/extensions/amp-accordion/1.0/accordion.js
+++ b/extensions/amp-accordion/1.0/accordion.js
@@ -112,7 +112,7 @@ function AccordionWithRef(
   const toggleExpanded = useCallback(
     (id, opt_expand) => {
       setExpandedMap((expandedMap) => {
-        const newExpanded = opt_expand || !expandedMap[id];
+        const newExpanded = opt_expand ?? !expandedMap[id];
         const newExpandedMap = setExpanded(
           id,
           newExpanded,
@@ -316,7 +316,7 @@ export function AccordionSection({
         toggleExpanded(id, opt_expand);
       } else {
         setExpandedState((prev) => {
-          const newValue = opt_expand || !prev;
+          const newValue = opt_expand ?? !prev;
           Promise.resolve().then(() => {
             const onExpandStateChange = onExpandStateChangeRef.current;
             if (onExpandStateChange) {
@@ -444,6 +444,10 @@ export function AccordionContent({
   }, []);
 
   useEffect(() => {
+    if (!experimentDisplayLocking) {
+      return;
+    }
+
     const element = ref.current;
     if (!element) {
       return;
@@ -459,7 +463,7 @@ export function AccordionContent({
       'hidden-matchable'
     );
     setSupportsContentVisibility(newSupportsContentVisibility);
-    if (!experimentDisplayLocking || !newSupportsContentVisibility) {
+    if (!newSupportsContentVisibility) {
       return;
     }
 

--- a/extensions/amp-accordion/1.0/accordion.js
+++ b/extensions/amp-accordion/1.0/accordion.js
@@ -426,7 +426,7 @@ export function AccordionContent({
   } = useContext(SectionContext);
   const classes = useStyles();
   const [contentVisibility, setContentVisibility] = useState(false);
-  const useDisplayLocking = contentVisibility && experimentDisplayLocking;
+  const enableDisplayLocking = contentVisibility && experimentDisplayLocking;
 
   useEffect(() => {
     hasMountedRef.current = true;
@@ -437,8 +437,13 @@ export function AccordionContent({
     if (!ref.current) {
       return;
     }
+
     const element = ref.current;
     const win = element.ownerDocument.defaultView;
+    if (!win) {
+      return;
+    }
+
     const supportsContentVisibility = win.CSS.supports(
       'content-visibility',
       'hidden-matchable'
@@ -447,8 +452,9 @@ export function AccordionContent({
     if (!experimentDisplayLocking || !supportsContentVisibility) {
       return;
     }
+
     const beforeMatchHandler = () => {
-      if (element.hasAttribute('hidden')) {
+      if (!element.parentElement.hasAttribute('expanded')) {
         expandHandler();
       }
     };
@@ -476,12 +482,13 @@ export function AccordionContent({
       {...rest}
       ref={ref}
       className={`${className} ${classes.sectionChild} ${classes.content} ${
-        !expanded && useDisplayLocking ? classes.contentHiddenMatchable : ''
+        !expanded ? classes.contentHidden : ''
+      } ${
+        !expanded && enableDisplayLocking ? classes.contentHiddenMatchable : ''
       }`}
       id={contentId}
       aria-labelledby={headerId}
       role={role}
-      hidden={!expanded}
     >
       {children}
     </Comp>

--- a/extensions/amp-accordion/1.0/accordion.jss.js
+++ b/extensions/amp-accordion/1.0/accordion.jss.js
@@ -35,7 +35,7 @@ const header = {
 };
 
 const content = {
-  display: 'block !important',
+  display: 'block',
 };
 
 const contentHidden = {

--- a/extensions/amp-accordion/1.0/accordion.jss.js
+++ b/extensions/amp-accordion/1.0/accordion.jss.js
@@ -39,10 +39,16 @@ const header = {
 // or delete if not used
 const content = {};
 
+const contentHiddenMatchable = {
+  'content-visibility': 'hidden-matchable !important',
+  display: 'block !important',
+};
+
 const JSS = {
   sectionChild,
   header,
   content,
+  contentHiddenMatchable,
 };
 
 // useStyles gets replaced for AMP builds via `babel-plugin-transform-jss`.

--- a/extensions/amp-accordion/1.0/accordion.jss.js
+++ b/extensions/amp-accordion/1.0/accordion.jss.js
@@ -40,12 +40,16 @@ const header = {
 const content = {};
 
 const contentHidden = {
-  display: 'none !important',
+  '&:not(.i-amphtml-animating)': {
+    display: 'none !important',
+  },
 };
 
 const contentHiddenMatchable = {
-  contentVisibility: 'hidden-matchable !important',
-  display: 'block !important',
+  '&:not(.i-amphtml-animating)': {
+    contentVisibility: 'hidden-matchable !important',
+    display: 'block !important',
+  },
 };
 
 const JSS = {

--- a/extensions/amp-accordion/1.0/accordion.jss.js
+++ b/extensions/amp-accordion/1.0/accordion.jss.js
@@ -39,8 +39,12 @@ const header = {
 // or delete if not used
 const content = {};
 
+const contentHidden = {
+  display: 'none !important',
+};
+
 const contentHiddenMatchable = {
-  'content-visibility': 'hidden-matchable !important',
+  contentVisibility: 'hidden-matchable !important',
   display: 'block !important',
 };
 
@@ -48,6 +52,7 @@ const JSS = {
   sectionChild,
   header,
   content,
+  contentHidden,
   contentHiddenMatchable,
 };
 

--- a/extensions/amp-accordion/1.0/accordion.jss.js
+++ b/extensions/amp-accordion/1.0/accordion.jss.js
@@ -34,10 +34,6 @@ const header = {
   border: 'solid 1px #dfdfdf',
 };
 
-const content = {
-  display: 'block',
-};
-
 const contentHidden = {
   '&:not(.i-amphtml-animating)': {
     display: 'none !important',
@@ -53,7 +49,6 @@ const contentHiddenMatchable = {
 const JSS = {
   sectionChild,
   header,
-  content,
   contentHidden,
   contentHiddenMatchable,
 };

--- a/extensions/amp-accordion/1.0/accordion.jss.js
+++ b/extensions/amp-accordion/1.0/accordion.jss.js
@@ -35,7 +35,7 @@ const header = {
 };
 
 const content = {
-  display: 'block',
+  display: 'block !important',
 };
 
 const contentHidden = {
@@ -47,7 +47,6 @@ const contentHidden = {
 const contentHiddenMatchable = {
   '&:not(.i-amphtml-animating)': {
     contentVisibility: 'hidden-matchable !important',
-    display: 'block !important',
   },
 };
 

--- a/extensions/amp-accordion/1.0/accordion.jss.js
+++ b/extensions/amp-accordion/1.0/accordion.jss.js
@@ -27,7 +27,6 @@ const sectionChild = {
   position: 'relative !important',
 };
 
-// TODO(#30445): update these styles after team agrees on styling
 const header = {
   cursor: 'pointer',
   backgroundColor: '#efefef',
@@ -35,9 +34,9 @@ const header = {
   border: 'solid 1px #dfdfdf',
 };
 
-// TODO(#30445): update these styles after team agrees on styling
-// or delete if not used
-const content = {};
+const content = {
+  display: 'block',
+};
 
 const contentHidden = {
   '&:not(.i-amphtml-animating)': {

--- a/extensions/amp-accordion/1.0/accordion.type.js
+++ b/extensions/amp-accordion/1.0/accordion.type.js
@@ -87,7 +87,6 @@ AccordionDef.HeaderShimProps;
  *   id: (string),
  *   role: (string),
  *   aria-labelledby: (string),
- *   hidden: (boolean),
  *   children: (?PreactDef.Renderable|undefined),
  * }}
  */

--- a/extensions/amp-accordion/1.0/accordion.type.js
+++ b/extensions/amp-accordion/1.0/accordion.type.js
@@ -87,7 +87,6 @@ AccordionDef.HeaderShimProps;
  *   id: (string),
  *   role: (string),
  *   aria-labelledby: (string),
- *   aria-hidden: (string),
  *   children: (?PreactDef.Renderable|undefined),
  * }}
  */

--- a/extensions/amp-accordion/1.0/accordion.type.js
+++ b/extensions/amp-accordion/1.0/accordion.type.js
@@ -87,7 +87,7 @@ AccordionDef.HeaderShimProps;
  *   id: (string),
  *   role: (string),
  *   aria-labelledby: (string),
- *   aria-hidden: (boolean),
+ *   aria-hidden: (string),
  *   children: (?PreactDef.Renderable|undefined),
  * }}
  */

--- a/extensions/amp-accordion/1.0/accordion.type.js
+++ b/extensions/amp-accordion/1.0/accordion.type.js
@@ -24,6 +24,7 @@ var AccordionDef = {};
  *   as: (string|PreactDef.FunctionalComponent|undefined),
  *   expandSingleSection: (boolean|undefined),
  *   animate: (boolean|undefined),
+ *   experimentDisplayLocking: (boolean|undefined),
  *   id: (string|undefined),
  *   children: (?PreactDef.Renderable|undefined),
  * }}
@@ -99,6 +100,7 @@ AccordionDef.ContentShimProps;
  *   toggleExpanded: (function(string)|undefined),
  *   animate: (boolean|undefined),
  *   prefix: (string),
+ *   experimentDisplayLocking: (boolean),
  * }}
  */
 AccordionDef.AccordionContext;
@@ -112,6 +114,7 @@ AccordionDef.AccordionContext;
  *   expandHandler: (function()),
  *   setContentId: (function(string)),
  *   setHeaderId: (function(string)),
+ *   experimentDisplayLocking: (boolean),
  * }}
  */
 AccordionDef.SectionContext;

--- a/extensions/amp-accordion/1.0/accordion.type.js
+++ b/extensions/amp-accordion/1.0/accordion.type.js
@@ -87,6 +87,7 @@ AccordionDef.HeaderShimProps;
  *   id: (string),
  *   role: (string),
  *   aria-labelledby: (string),
+ *   aria-hidden: (boolean),
  *   children: (?PreactDef.Renderable|undefined),
  * }}
  */

--- a/extensions/amp-accordion/1.0/amp-accordion.css
+++ b/extensions/amp-accordion/1.0/amp-accordion.css
@@ -15,9 +15,13 @@
  */
 
 /* heading/content */
-.i-amphtml-accordion-header,
+.i-amphtml-accordion-header {
+  margin: 0;
+}
+
 .i-amphtml-accordion-content {
   margin: 0;
+  display: block;
 }
 
 /* heading

--- a/extensions/amp-accordion/1.0/amp-accordion.css
+++ b/extensions/amp-accordion/1.0/amp-accordion.css
@@ -27,7 +27,6 @@
 
 .i-amphtml-accordion-content {
   margin: 0;
-  display: block;
 }
 
 amp-accordion > section:not([expanded]) > :last-child:not(.i-amphtml-animating),

--- a/extensions/amp-accordion/1.0/amp-accordion.css
+++ b/extensions/amp-accordion/1.0/amp-accordion.css
@@ -29,3 +29,12 @@
   padding-right: 20px;
   border: solid 1px #dfdfdf;
 }
+
+amp-accordion.i-amphtml-display-locking > section:not([expanded]) > :last-child,
+amp-accordion.i-amphtml-display-locking
+  > section:not([expanded])
+  > :last-child
+  * {
+  content-visibility: hidden-matchable !important;
+  display: block !important;
+}

--- a/extensions/amp-accordion/1.0/amp-accordion.css
+++ b/extensions/amp-accordion/1.0/amp-accordion.css
@@ -33,16 +33,21 @@
 /* TODO: This CSS is duplicated from ./accordion.jss.js for purposes of display
  * locking.  Look into de-duping once experiment is launched.
  */
-amp-accordion.i-amphtml-display-locking > section:not([expanded]) > :last-child,
 amp-accordion.i-amphtml-display-locking
   > section:not([expanded])
-  > :last-child
+  > :last-child:not(.i-amphtml-animating),
+amp-accordion.i-amphtml-display-locking
+  > section:not([expanded])
+  > :last-child:not(.i-amphtml-animating)
   * {
   content-visibility: hidden-matchable !important;
   display: block !important;
 }
 
-amp-accordion > section:not([expanded]) > :last-child,
-amp-accordion > section:not([expanded]) > :last-child * {
+amp-accordion > section:not([expanded]) > :last-child:not(.i-amphtml-animating),
+amp-accordion
+  > section:not([expanded])
+  > :last-child:not(.i-amphtml-animating)
+  * {
   display: none !important;
 }

--- a/extensions/amp-accordion/1.0/amp-accordion.css
+++ b/extensions/amp-accordion/1.0/amp-accordion.css
@@ -14,16 +14,6 @@
  * limitations under the License.
  */
 
-/* heading/content */
-.i-amphtml-accordion-header {
-  margin: 0;
-}
-
-.i-amphtml-accordion-content {
-  margin: 0;
-  display: block !important;
-}
-
 /* heading
  * TODO(#30445): update these styles after team agrees on styling
  */
@@ -32,6 +22,20 @@
   background-color: #efefef;
   padding-right: 20px;
   border: solid 1px #dfdfdf;
+  margin: 0;
+}
+
+.i-amphtml-accordion-content {
+  margin: 0;
+  display: block;
+}
+
+amp-accordion > section:not([expanded]) > :last-child:not(.i-amphtml-animating),
+amp-accordion
+  > section:not([expanded])
+  > :last-child:not(.i-amphtml-animating)
+  * {
+  display: none !important;
 }
 
 /* TODO: This CSS is duplicated from ./accordion.jss.js for purposes of display
@@ -46,12 +50,4 @@ amp-accordion.i-amphtml-display-locking
   * {
   content-visibility: hidden-matchable !important;
   display: block !important;
-}
-
-amp-accordion > section:not([expanded]) > :last-child:not(.i-amphtml-animating),
-amp-accordion
-  > section:not([expanded])
-  > :last-child:not(.i-amphtml-animating)
-  * {
-  display: none !important;
 }

--- a/extensions/amp-accordion/1.0/amp-accordion.css
+++ b/extensions/amp-accordion/1.0/amp-accordion.css
@@ -21,7 +21,7 @@
 
 .i-amphtml-accordion-content {
   margin: 0;
-  display: block;
+  display: block !important;
 }
 
 /* heading

--- a/extensions/amp-accordion/1.0/amp-accordion.css
+++ b/extensions/amp-accordion/1.0/amp-accordion.css
@@ -30,6 +30,9 @@
   border: solid 1px #dfdfdf;
 }
 
+/* TODO: This CSS is duplicated from ./accordion.jss.js for purposes of display
+ * locking.  Look into de-duping once experiment is launched.
+ */
 amp-accordion.i-amphtml-display-locking > section:not([expanded]) > :last-child,
 amp-accordion.i-amphtml-display-locking
   > section:not([expanded])
@@ -37,4 +40,9 @@ amp-accordion.i-amphtml-display-locking
   * {
   content-visibility: hidden-matchable !important;
   display: block !important;
+}
+
+amp-accordion > section:not([expanded]) > :last-child,
+amp-accordion > section:not([expanded]) > :last-child * {
+  display: none !important;
 }

--- a/extensions/amp-accordion/1.0/amp-accordion.js
+++ b/extensions/amp-accordion/1.0/amp-accordion.js
@@ -47,6 +47,10 @@ const CONTENT_SHIM_PROP = '__AMP_C_SHIM';
 const SECTION_POST_RENDER = '__AMP_PR';
 const EXPAND_STATE_SHIM_PROP = '__AMP_EXPAND_STATE_SHIM';
 
+const isDisplayLockingEnabledForAccordion = (win) =>
+  isExperimentOn(win, 'amp-accordion-display-locking') &&
+  win.document.body.onbeforematch !== undefined;
+
 /** @extends {PreactBaseElement<AccordionDef.AccordionApi>} */
 class AmpAccordion extends PreactBaseElement {
   /** @override */
@@ -62,6 +66,12 @@ class AmpAccordion extends PreactBaseElement {
     );
 
     const {element} = this;
+    const experimentDisplayLocking = isDisplayLockingEnabledForAccordion(
+      this.win
+    );
+    if (experimentDisplayLocking) {
+      element.classList.add('i-amphtml-display-locking');
+    }
 
     const mu = new MutationObserver(() => {
       this.mutateProps(getState(element, mu));
@@ -72,7 +82,10 @@ class AmpAccordion extends PreactBaseElement {
     });
 
     const {'children': children} = getState(element, mu);
-    return dict({'children': children});
+    return dict({
+      'experimentDisplayLocking': experimentDisplayLocking,
+      'children': children,
+    });
   }
 
   /** @override */

--- a/extensions/amp-accordion/1.0/amp-accordion.js
+++ b/extensions/amp-accordion/1.0/amp-accordion.js
@@ -255,7 +255,7 @@ const bindHeaderShimToElement = (element) => HeaderShim.bind(null, element);
  */
 function ContentShimWithRef(
   sectionElement,
-  {hidden, id, role, 'aria-labelledby': ariaLabelledBy},
+  {id, role, 'aria-labelledby': ariaLabelledBy},
   ref
 ) {
   const contentElement = sectionElement.lastElementChild;
@@ -268,11 +268,10 @@ function ContentShimWithRef(
     contentElement.setAttribute('id', id);
     contentElement.setAttribute('role', role);
     contentElement.setAttribute('aria-labelledby', ariaLabelledBy);
-    toggleAttribute(contentElement, 'hidden', hidden);
     if (sectionElement[SECTION_POST_RENDER]) {
       sectionElement[SECTION_POST_RENDER]();
     }
-  }, [sectionElement, contentElement, hidden, id, role, ariaLabelledBy]);
+  }, [sectionElement, contentElement, id, role, ariaLabelledBy]);
   return <div />;
 }
 

--- a/extensions/amp-accordion/1.0/amp-accordion.js
+++ b/extensions/amp-accordion/1.0/amp-accordion.js
@@ -249,13 +249,13 @@ const bindHeaderShimToElement = (element) => HeaderShim.bind(null, element);
 
 /**
  * @param {!Element} sectionElement
- * @param {!AccordionDef.ContentProps} props
+ * @param {!AccordionDef.ContentShimProps} props
  * @param {{current: ?}} ref
  * @return {PreactDef.Renderable}
  */
 function ContentShimWithRef(
   sectionElement,
-  {id, role, 'aria-labelledby': ariaLabelledBy, 'aria-hidden': ariaHidden},
+  {id, role, 'aria-labelledby': ariaLabelledBy},
   ref
 ) {
   const contentElement = sectionElement.lastElementChild;
@@ -268,11 +268,10 @@ function ContentShimWithRef(
     contentElement.setAttribute('id', id);
     contentElement.setAttribute('role', role);
     contentElement.setAttribute('aria-labelledby', ariaLabelledBy);
-    contentElement.setAttribute('aria-hidden', ariaHidden);
     if (sectionElement[SECTION_POST_RENDER]) {
       sectionElement[SECTION_POST_RENDER]();
     }
-  }, [sectionElement, contentElement, id, role, ariaLabelledBy, ariaHidden]);
+  }, [sectionElement, contentElement, id, role, ariaLabelledBy]);
   return <div />;
 }
 

--- a/extensions/amp-accordion/1.0/amp-accordion.js
+++ b/extensions/amp-accordion/1.0/amp-accordion.js
@@ -255,7 +255,7 @@ const bindHeaderShimToElement = (element) => HeaderShim.bind(null, element);
  */
 function ContentShimWithRef(
   sectionElement,
-  {id, role, 'aria-labelledby': ariaLabelledBy},
+  {id, role, 'aria-labelledby': ariaLabelledBy, 'aria-hidden': ariaHidden},
   ref
 ) {
   const contentElement = sectionElement.lastElementChild;
@@ -268,10 +268,11 @@ function ContentShimWithRef(
     contentElement.setAttribute('id', id);
     contentElement.setAttribute('role', role);
     contentElement.setAttribute('aria-labelledby', ariaLabelledBy);
+    contentElement.setAttribute('aria-hidden', ariaHidden);
     if (sectionElement[SECTION_POST_RENDER]) {
       sectionElement[SECTION_POST_RENDER]();
     }
-  }, [sectionElement, contentElement, id, role, ariaLabelledBy]);
+  }, [sectionElement, contentElement, id, role, ariaLabelledBy, ariaHidden]);
   return <div />;
 }
 

--- a/extensions/amp-accordion/1.0/animations.js
+++ b/extensions/amp-accordion/1.0/animations.js
@@ -26,57 +26,50 @@ const COLLAPSE_CURVE = 'cubic-bezier(0.39, 0.575, 0.565, 1)';
  * @return {!UnlistenDef}
  */
 export function animateExpand(content) {
-  return animate(
-    content,
-    () => {
-      const oldHeight = getStyle(content, 'height');
-      const oldOpacity = getStyle(content, 'opacity');
-      const oldOverflowY = getStyle(content, 'overflowY');
+  return animate(content, () => {
+    const oldHeight = getStyle(content, 'height');
+    const oldOpacity = getStyle(content, 'opacity');
+    const oldOverflowY = getStyle(content, 'overflowY');
 
-      // Measure the expanded height. This is relatively heavy with a sync
-      // layout. But no way around it. The hope that the `commitStyles` API
-      // may eventually make this unneeded.
-      setStyles(content, {
-        height: 0,
-        opacity: 0,
-        overflowY: 'auto',
-      });
-      content.classList.add('i-amphtml-animating');
-      const targetHeight = content./*OK*/ scrollHeight;
+    // Measure the expanded height. This is relatively heavy with a sync
+    // layout. But no way around it. The hope that the `commitStyles` API
+    // may eventually make this unneeded.
+    setStyles(content, {
+      height: 0,
+      opacity: 0,
+      overflowY: 'auto',
+    });
+    const targetHeight = content./*OK*/ scrollHeight;
 
-      // Reset back. The animation will take care of these properties
-      // going forward.
-      setStyles(content, {
-        height: oldHeight,
-        opacity: oldOpacity,
-        overflowY: oldOverflowY,
-      });
+    // Reset back. The animation will take care of these properties
+    // going forward.
+    setStyles(content, {
+      height: oldHeight,
+      opacity: oldOpacity,
+      overflowY: oldOverflowY,
+    });
 
-      const duration = getTransitionDuration(targetHeight);
+    const duration = getTransitionDuration(targetHeight);
 
-      return content.animate(
-        [
-          {
-            height: 0,
-            opacity: 0,
-            overflowY: 'hidden',
-          },
-          {
-            height: targetHeight + 'px',
-            opacity: 1,
-            overflowY: 'hidden',
-          },
-        ],
+    return content.animate(
+      [
         {
-          easing: EXPAND_CURVE,
-          duration,
-        }
-      );
-    },
-    () => {
-      content.classList.remove('i-amphtml-animating');
-    }
-  );
+          height: 0,
+          opacity: 0,
+          overflowY: 'hidden',
+        },
+        {
+          height: targetHeight + 'px',
+          opacity: 1,
+          overflowY: 'hidden',
+        },
+      ],
+      {
+        easing: EXPAND_CURVE,
+        duration,
+      }
+    );
+  });
 }
 
 /**
@@ -84,37 +77,29 @@ export function animateExpand(content) {
  * @return {!UnlistenDef}
  */
 export function animateCollapse(content) {
-  return animate(
-    content,
-    () => {
-      content.classList.add('i-amphtml-animating');
-      const startHeight = content./*OK*/ offsetHeight;
+  return animate(content, () => {
+    const startHeight = content./*OK*/ offsetHeight;
+    const duration = getTransitionDuration(startHeight);
 
-      const duration = getTransitionDuration(startHeight);
-
-      return content.animate(
-        [
-          {
-            height: startHeight + 'px',
-            opacity: 1,
-            overflowY: 'hidden',
-          },
-          {
-            height: '0',
-            opacity: 0,
-            overflowY: 'hidden',
-          },
-        ],
+    return content.animate(
+      [
         {
-          easing: COLLAPSE_CURVE,
-          duration,
-        }
-      );
-    },
-    () => {
-      content.classList.remove('i-amphtml-animating');
-    }
-  );
+          height: startHeight + 'px',
+          opacity: 1,
+          overflowY: 'hidden',
+        },
+        {
+          height: '0',
+          opacity: 0,
+          overflowY: 'hidden',
+        },
+      ],
+      {
+        easing: COLLAPSE_CURVE,
+        duration,
+      }
+    );
+  });
 }
 
 /**
@@ -124,12 +109,14 @@ export function animateCollapse(content) {
  * @return {!UnlistenDef}
  */
 function animate(element, prepare, cleanup = undefined) {
+  element.classList.add('i-amphtml-animating');
   let player = prepare();
   player.onfinish = player.oncancel = () => {
     player = null;
     if (cleanup) {
       cleanup();
     }
+    element.classList.remove('i-amphtml-animating');
   };
   return () => {
     if (player) {

--- a/extensions/amp-accordion/1.0/animations.js
+++ b/extensions/amp-accordion/1.0/animations.js
@@ -41,7 +41,6 @@ export function animateExpand(content) {
         opacity: 0,
         overflowY: 'auto',
       });
-      content.hidden = false;
       content.classList.add('i-amphtml-animating');
       const targetHeight = content./*OK*/ scrollHeight;
 
@@ -88,12 +87,6 @@ export function animateCollapse(content) {
   return animate(
     content,
     () => {
-      // Measure the starting height.
-      // This looks ugly, but avoids weird `hidden` state management in the
-      // component itself. Most importantly, this has no performance issues
-      // by itself b/c flipping `hidden` back and forth before measure has
-      // no effect - the `useLayoutEffect` assures this.
-      content.hidden = false;
       content.classList.add('i-amphtml-animating');
       const startHeight = content./*OK*/ offsetHeight;
 
@@ -119,8 +112,6 @@ export function animateCollapse(content) {
       );
     },
     () => {
-      // Undo the `content.hidden = true` above.
-      content.hidden = true;
       content.classList.remove('i-amphtml-animating');
     }
   );

--- a/extensions/amp-accordion/1.0/animations.js
+++ b/extensions/amp-accordion/1.0/animations.js
@@ -26,51 +26,58 @@ const COLLAPSE_CURVE = 'cubic-bezier(0.39, 0.575, 0.565, 1)';
  * @return {!UnlistenDef}
  */
 export function animateExpand(content) {
-  return animate(content, () => {
-    const oldHeight = getStyle(content, 'height');
-    const oldOpacity = getStyle(content, 'opacity');
-    const oldOverflowY = getStyle(content, 'overflowY');
+  return animate(
+    content,
+    () => {
+      const oldHeight = getStyle(content, 'height');
+      const oldOpacity = getStyle(content, 'opacity');
+      const oldOverflowY = getStyle(content, 'overflowY');
 
-    // Measure the expanded height. This is relatively heavy with a sync
-    // layout. But no way around it. The hope that the `commitStyles` API
-    // may eventually make this unneeded.
-    setStyles(content, {
-      height: 0,
-      opacity: 0,
-      overflowY: 'auto',
-    });
-    content.hidden = false;
-    const targetHeight = content./*OK*/ scrollHeight;
+      // Measure the expanded height. This is relatively heavy with a sync
+      // layout. But no way around it. The hope that the `commitStyles` API
+      // may eventually make this unneeded.
+      setStyles(content, {
+        height: 0,
+        opacity: 0,
+        overflowY: 'auto',
+      });
+      content.hidden = false;
+      content.classList.add('i-amphtml-animating');
+      const targetHeight = content./*OK*/ scrollHeight;
 
-    // Reset back. The animation will take care of these properties
-    // going forward.
-    setStyles(content, {
-      height: oldHeight,
-      opacity: oldOpacity,
-      overflowY: oldOverflowY,
-    });
+      // Reset back. The animation will take care of these properties
+      // going forward.
+      setStyles(content, {
+        height: oldHeight,
+        opacity: oldOpacity,
+        overflowY: oldOverflowY,
+      });
 
-    const duration = getTransitionDuration(targetHeight);
+      const duration = getTransitionDuration(targetHeight);
 
-    return content.animate(
-      [
+      return content.animate(
+        [
+          {
+            height: 0,
+            opacity: 0,
+            overflowY: 'hidden',
+          },
+          {
+            height: targetHeight + 'px',
+            opacity: 1,
+            overflowY: 'hidden',
+          },
+        ],
         {
-          height: 0,
-          opacity: 0,
-          overflowY: 'hidden',
-        },
-        {
-          height: targetHeight + 'px',
-          opacity: 1,
-          overflowY: 'hidden',
-        },
-      ],
-      {
-        easing: EXPAND_CURVE,
-        duration,
-      }
-    );
-  });
+          easing: EXPAND_CURVE,
+          duration,
+        }
+      );
+    },
+    () => {
+      content.classList.remove('i-amphtml-animating');
+    }
+  );
 }
 
 /**
@@ -87,6 +94,7 @@ export function animateCollapse(content) {
       // by itself b/c flipping `hidden` back and forth before measure has
       // no effect - the `useLayoutEffect` assures this.
       content.hidden = false;
+      content.classList.add('i-amphtml-animating');
       const startHeight = content./*OK*/ offsetHeight;
 
       const duration = getTransitionDuration(startHeight);
@@ -113,6 +121,7 @@ export function animateCollapse(content) {
     () => {
       // Undo the `content.hidden = true` above.
       content.hidden = true;
+      content.classList.remove('i-amphtml-animating');
     }
   );
 }

--- a/extensions/amp-accordion/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-accordion/1.0/storybook/Basic.amp.js
@@ -41,7 +41,7 @@ export const _default = () => {
       >
         <section id="section1">
           <h2>Section 1</h2>
-          <p>Puppies are cute.</p>
+          <div>Puppies are cute.</div>
         </section>
         <section>
           <h2>Section 2</h2>
@@ -83,7 +83,7 @@ export const events = () => {
       >
         <section id="section1">
           <h2>Section 1</h2>
-          <p>Puppies are cute.</p>
+          <div>Puppies are cute.</div>
         </section>
         <section id="section2" on="expand:accordion.expand(section='section3')">
           <h2>Section 2</h2>

--- a/extensions/amp-accordion/1.0/storybook/Basic.js
+++ b/extensions/amp-accordion/1.0/storybook/Basic.js
@@ -62,29 +62,31 @@ function AccordionWithActions(props) {
 export const _default = () => {
   const expandSingleSection = boolean('expandSingleSection', false);
   const animate = boolean('animate', false);
+  const experimentDisplayLocking = boolean('experimentDisplayLocking', false);
   return (
     <main>
       <AccordionWithActions
         expandSingleSection={expandSingleSection}
         animate={animate}
+        experimentDisplayLocking={experimentDisplayLocking}
       >
         <AccordionSection id="section1" key={1}>
           <AccordionHeader>
             <h2>Section 1</h2>
           </AccordionHeader>
-          <AccordionContent>Content in section 1.</AccordionContent>
+          <AccordionContent>Puppies are cute.</AccordionContent>
         </AccordionSection>
         <AccordionSection key={2}>
           <AccordionHeader>
             <h2>Section 2</h2>
           </AccordionHeader>
-          <AccordionContent>Content in section 2.</AccordionContent>
+          <AccordionContent>Kittens are furry.</AccordionContent>
         </AccordionSection>
         <AccordionSection key={3} expanded>
           <AccordionHeader>
             <h2>Section 3</h2>
           </AccordionHeader>
-          <AccordionContent>Content in section 3.</AccordionContent>
+          <AccordionContent>Elephants have great memory.</AccordionContent>
         </AccordionSection>
       </AccordionWithActions>
     </main>
@@ -106,7 +108,7 @@ function AccordionWithEvents(props) {
           <AccordionHeader>
             <h2>Section 1</h2>
           </AccordionHeader>
-          <AccordionContent>Content in section 1.</AccordionContent>
+          <AccordionContent>Puppies are cute.</AccordionContent>
         </AccordionSection>
         <AccordionSection
           id="section2"
@@ -120,7 +122,7 @@ function AccordionWithEvents(props) {
           <AccordionHeader>
             <h2>Section 2</h2>
           </AccordionHeader>
-          <AccordionContent>Content in section 1.</AccordionContent>
+          <AccordionContent>Kittens are furry.</AccordionContent>
         </AccordionSection>
         <AccordionSection
           id="section3"
@@ -134,7 +136,7 @@ function AccordionWithEvents(props) {
           <AccordionHeader>
             <h2>Section 3</h2>
           </AccordionHeader>
-          <AccordionContent>Content in section 3.</AccordionContent>
+          <AccordionContent>Elephants have great memory.</AccordionContent>
         </AccordionSection>
       </Accordion>
       <div style={{marginTop: 8}}>
@@ -153,11 +155,13 @@ function AccordionWithEvents(props) {
 export const events = () => {
   const expandSingleSection = boolean('expandSingleSection', false);
   const animate = boolean('animate', false);
+  const experimentDisplayLocking = boolean('experimentDisplayLocking', false);
   return (
     <main>
       <AccordionWithEvents
         expandSingleSection={expandSingleSection}
         animate={animate}
+        experimentDisplayLocking={experimentDisplayLocking}
       ></AccordionWithEvents>
     </main>
   );

--- a/extensions/amp-accordion/1.0/storybook/Bind.amp.js
+++ b/extensions/amp-accordion/1.0/storybook/Bind.amp.js
@@ -43,7 +43,7 @@ export const withAmpBind = () => {
       >
         <section data-amp-bind-expanded="section1">
           <h2>Section 1</h2>
-          <p>Puppies are cute.</p>
+          <div>Puppies are cute.</div>
         </section>
         <section data-amp-bind-expanded="section2">
           <h2>Section 2</h2>

--- a/extensions/amp-accordion/1.0/storybook/Bind.amp.js
+++ b/extensions/amp-accordion/1.0/storybook/Bind.amp.js
@@ -43,15 +43,15 @@ export const withAmpBind = () => {
       >
         <section data-amp-bind-expanded="section1">
           <h2>Section 1</h2>
-          <p>Content in section 1.</p>
+          <p>Puppies are cute.</p>
         </section>
         <section data-amp-bind-expanded="section2">
           <h2>Section 2</h2>
-          <div>Content in section 2.</div>
+          <div>Kittens are furry.</div>
         </section>
         <section expanded data-amp-bind-expanded="section3">
           <h2>Section 3</h2>
-          <div>Content in section 3.</div>
+          <div>Elephants have great memory.</div>
         </section>
       </amp-accordion>
 

--- a/extensions/amp-accordion/1.0/storybook/DisplayLocking.amp.js
+++ b/extensions/amp-accordion/1.0/storybook/DisplayLocking.amp.js
@@ -41,7 +41,7 @@ export const withDisplayLocking = () => {
       >
         <section id="section1">
           <h2>Section 1</h2>
-          <p>Puppies are cute.</p>
+          <div>Puppies are cute.</div>
         </section>
         <section>
           <h2>Section 2</h2>

--- a/extensions/amp-accordion/1.0/storybook/DisplayLocking.amp.js
+++ b/extensions/amp-accordion/1.0/storybook/DisplayLocking.amp.js
@@ -25,11 +25,11 @@ export default {
 
   parameters: {
     extensions: [{name: 'amp-accordion', version: '1.0'}],
-    experiments: ['amp-accordion-bento'],
+    experiments: ['amp-accordion-bento', 'amp-accordion-display-locking'],
   },
 };
 
-export const _default = () => {
+export const withDisplayLocking = () => {
   const expandSingleSection = boolean('expandSingleSection', false);
   const animate = boolean('animate', false);
   return (
@@ -66,46 +66,6 @@ export const _default = () => {
           collapse(section1)
         </button>
         <button on="tap:accordion.collapse()">collapse all</button>
-      </div>
-    </main>
-  );
-};
-
-export const events = () => {
-  const expandSingleSection = boolean('expandSingleSection', false);
-  const animate = boolean('animate', false);
-  return (
-    <main>
-      <amp-accordion
-        id="accordion"
-        expand-single-section={expandSingleSection}
-        animate={animate}
-      >
-        <section id="section1">
-          <h2>Section 1</h2>
-          <p>Puppies are cute.</p>
-        </section>
-        <section id="section2" on="expand:accordion.expand(section='section3')">
-          <h2>Section 2</h2>
-          <div>Kittens are furry.</div>
-        </section>
-        <section
-          id="section3"
-          on="collapse:accordion.collapse(section='section2')"
-        >
-          <h2>Section 3</h2>
-          <div>Elephants have great memory.</div>
-        </section>
-      </amp-accordion>
-
-      <div class="buttons" style={{marginTop: 8}}>
-        <button on="tap:accordion.expand(section='section2')">
-          expand(section2)
-        </button>
-        <button on="tap:accordion.collapse(section='section3')">
-          collapse(section3)
-        </button>
-        <button on="tap:accordion.toggle()">toggle all</button>
       </div>
     </main>
   );

--- a/extensions/amp-accordion/1.0/test/test-accordion.js
+++ b/extensions/amp-accordion/1.0/test/test-accordion.js
@@ -49,7 +49,7 @@ describes.sandboxed('Accordion preact component', {}, (env) => {
       const content = dom.children[1];
       expect(content.localName).to.equal('div');
       expect(content.innerHTML).to.equal('content1');
-      expect(content.getAttribute('aria-hidden')).to.equal('true');
+      expect(content.className.includes('content-hidden')).to.be.true;
     });
 
     it('should render an expanded section', () => {
@@ -73,7 +73,7 @@ describes.sandboxed('Accordion preact component', {}, (env) => {
       const content = dom.children[1];
       expect(content.localName).to.equal('div');
       expect(content.innerHTML).to.equal('content1');
-      expect(content.getAttribute('aria-hidden')).to.equal('false');
+      expect(content.className.includes('content-hidden')).to.be.false;
     });
 
     it('should toggle expanded state', () => {
@@ -92,19 +92,19 @@ describes.sandboxed('Accordion preact component', {}, (env) => {
       // Start unexpanded.
       expect(dom).to.not.have.attribute('expanded');
       expect(header.getAttribute('aria-expanded')).to.equal('false');
-      expect(content.getAttribute('aria-hidden')).to.equal('true');
+      expect(content.className.includes('content-hidden')).to.be.true;
 
       // Click on header to expand.
       wrapper.find('div').at(0).simulate('click');
       expect(dom).to.have.attribute('expanded');
       expect(header.getAttribute('aria-expanded')).to.equal('true');
-      expect(content.getAttribute('aria-hidden')).to.equal('false');
+      expect(content.className.includes('content-hidden')).to.be.false;
 
       // Click on header again to collapse.
       wrapper.find('div').at(0).simulate('click');
       expect(dom).to.not.have.attribute('expanded');
       expect(header.getAttribute('aria-expanded')).to.equal('false');
-      expect(content.getAttribute('aria-hidden')).to.equal('true');
+      expect(content.className.includes('content-hidden')).to.be.true;
     });
   });
 
@@ -158,9 +158,9 @@ describes.sandboxed('Accordion preact component', {}, (env) => {
       expect(content0.textContent).to.equal('content1');
       expect(content1.textContent).to.equal('content2');
       expect(content2.textContent).to.equal('content3');
-      expect(content0.getAttribute('aria-hidden')).to.equal('false');
-      expect(content1.getAttribute('aria-hidden')).to.equal('true');
-      expect(content2.getAttribute('aria-hidden')).to.equal('true');
+      expect(content0.className.includes('content-hidden')).to.be.false;
+      expect(content1.className.includes('content-hidden')).to.be.true;
+      expect(content2.className.includes('content-hidden')).to.be.true;
 
       // Styling.
       expect(header0.className.includes('section-child')).to.be.true;
@@ -170,11 +170,8 @@ describes.sandboxed('Accordion preact component', {}, (env) => {
       expect(header2.className.includes('section-child')).to.be.true;
       expect(header2.className.includes('header')).to.be.true;
       expect(content0.className.includes('section-child')).to.be.true;
-      expect(content0.className.includes('content')).to.be.true;
       expect(content1.className.includes('section-child')).to.be.true;
-      expect(content1.className.includes('content')).to.be.true;
       expect(content2.className.includes('section-child')).to.be.true;
-      expect(content2.className.includes('content')).to.be.true;
     });
 
     it('should include a11y related attributes', () => {
@@ -336,8 +333,8 @@ describes.sandboxed('Accordion preact component', {}, (env) => {
           .find('div')
           .at(1)
           .getDOMNode()
-          .getAttribute('aria-hidden')
-      ).to.equal('true');
+          .className.includes('content-hidden')
+      ).to.be.true;
     });
 
     it('should adjust state when expandSingleSection changes', async () => {
@@ -419,16 +416,16 @@ describes.sandboxed('Accordion preact component', {}, (env) => {
           .find('div')
           .at(1)
           .getDOMNode()
-          .getAttribute('aria-hidden')
-      ).to.equal('true');
+          .className.includes('content-hidden')
+      ).to.be.true;
       expect(
         sections
           .at(1)
           .find('div')
           .at(1)
           .getDOMNode()
-          .getAttribute('aria-hidden')
-      ).to.equal('false');
+          .className.includes('content-hidden')
+      ).to.be.false;
     });
 
     it('should collapse a section on click', () => {
@@ -451,8 +448,8 @@ describes.sandboxed('Accordion preact component', {}, (env) => {
           .find('div')
           .at(1)
           .getDOMNode()
-          .getAttribute('aria-hidden')
-      ).to.equal('true');
+          .className.includes('content-hidden')
+      ).to.be.true;
     });
   });
 
@@ -583,7 +580,7 @@ describes.sandboxed('Accordion preact component', {}, (env) => {
       section.find('div').at(0).simulate('click');
 
       // Immediately hidden, which means animation has not been even tried.
-      expect(content.getAttribute('aria-hidden')).to.equal('true');
+      expect(content.className.includes('content-hidden')).to.be.true;
     });
   });
 

--- a/extensions/amp-accordion/1.0/test/test-accordion.js
+++ b/extensions/amp-accordion/1.0/test/test-accordion.js
@@ -524,7 +524,7 @@ describes.sandboxed('Accordion preact component', {}, (env) => {
       // The state is NOT immediately reflected: expanded attribute is removed,
       // but `content[hidden]` is deferred until animation is complete.
       expect(section.getDOMNode()).to.not.have.attribute('expanded');
-      expect(content.hidden).to.be.false;
+      expect(content.className.includes('i-amphtml-animating')).to.be.true;
       expect(content).to.have.display('block');
 
       // Animation has been started.
@@ -543,8 +543,8 @@ describes.sandboxed('Accordion preact component', {}, (env) => {
 
       // Cleanup the animation.
       animation.onfinish();
-      expect(content.hidden).to.be.true;
-      expect(content).to.have.display('none');
+      expect(content.className.includes('i-amphtml-animating')).to.be.false;
+      expect(content.className.includes('content-hidden')).to.be.true;
     });
 
     it('should make animations cancelable', () => {
@@ -560,8 +560,8 @@ describes.sandboxed('Accordion preact component', {}, (env) => {
       section.find('div').at(0).simulate('click');
       expect(animateStub).to.be.calledOnce;
 
-      // Hidden is not set yet.
-      expect(content.hidden).to.be.false;
+      // Currently animating
+      expect(content.className.includes('i-amphtml-animating')).to.be.true;
 
       // Unclick. This should cancel the previous animation.
       section.find('div').at(0).simulate('click');
@@ -569,7 +569,7 @@ describes.sandboxed('Accordion preact component', {}, (env) => {
 
       expect(animation.cancel).to.be.calledOnce;
       animation.oncancel();
-      expect(content.hidden).to.be.true;
+      expect(content.className.includes('i-amphtml-animating')).to.be.false;
     });
 
     it('should ignore animations if not available on the platform', () => {

--- a/extensions/amp-accordion/1.0/test/test-accordion.js
+++ b/extensions/amp-accordion/1.0/test/test-accordion.js
@@ -49,7 +49,7 @@ describes.sandboxed('Accordion preact component', {}, (env) => {
       const content = dom.children[1];
       expect(content.localName).to.equal('div');
       expect(content.innerHTML).to.equal('content1');
-      expect(content.hidden).to.be.true;
+      expect(content.getAttribute('aria-hidden')).to.equal('true');
     });
 
     it('should render an expanded section', () => {
@@ -73,7 +73,7 @@ describes.sandboxed('Accordion preact component', {}, (env) => {
       const content = dom.children[1];
       expect(content.localName).to.equal('div');
       expect(content.innerHTML).to.equal('content1');
-      expect(content.hidden).to.be.false;
+      expect(content.getAttribute('aria-hidden')).to.equal('false');
     });
 
     it('should toggle expanded state', () => {
@@ -92,19 +92,19 @@ describes.sandboxed('Accordion preact component', {}, (env) => {
       // Start unexpanded.
       expect(dom).to.not.have.attribute('expanded');
       expect(header.getAttribute('aria-expanded')).to.equal('false');
-      expect(content.hidden).to.be.true;
+      expect(content.getAttribute('aria-hidden')).to.equal('true');
 
       // Click on header to expand.
       wrapper.find('div').at(0).simulate('click');
       expect(dom).to.have.attribute('expanded');
       expect(header.getAttribute('aria-expanded')).to.equal('true');
-      expect(content.hidden).to.be.false;
+      expect(content.getAttribute('aria-hidden')).to.equal('false');
 
       // Click on header again to collapse.
       wrapper.find('div').at(0).simulate('click');
       expect(dom).to.not.have.attribute('expanded');
       expect(header.getAttribute('aria-expanded')).to.equal('false');
-      expect(content.hidden).to.be.true;
+      expect(content.getAttribute('aria-hidden')).to.equal('true');
     });
   });
 
@@ -158,9 +158,9 @@ describes.sandboxed('Accordion preact component', {}, (env) => {
       expect(content0.textContent).to.equal('content1');
       expect(content1.textContent).to.equal('content2');
       expect(content2.textContent).to.equal('content3');
-      expect(content0.hidden).to.be.false;
-      expect(content1.hidden).to.be.true;
-      expect(content2.hidden).to.be.true;
+      expect(content0.getAttribute('aria-hidden')).to.equal('false');
+      expect(content1.getAttribute('aria-hidden')).to.equal('true');
+      expect(content2.getAttribute('aria-hidden')).to.equal('true');
 
       // Styling.
       expect(header0.className.includes('section-child')).to.be.true;
@@ -330,7 +330,14 @@ describes.sandboxed('Accordion preact component', {}, (env) => {
       expect(sections.at(0).getDOMNode()).to.not.have.attribute('expanded');
 
       // Contents.
-      expect(sections.at(0).find('div').at(1).getDOMNode().hidden).to.be.true;
+      expect(
+        sections
+          .at(0)
+          .find('div')
+          .at(1)
+          .getDOMNode()
+          .getAttribute('aria-hidden')
+      ).to.equal('true');
     });
 
     it('should adjust state when expandSingleSection changes', async () => {
@@ -406,8 +413,22 @@ describes.sandboxed('Accordion preact component', {}, (env) => {
       expect(sections.at(1).getDOMNode()).to.have.attribute('expanded');
 
       // Contents.
-      expect(sections.at(0).find('div').at(1).getDOMNode().hidden).to.be.true;
-      expect(sections.at(1).find('div').at(1).getDOMNode().hidden).to.be.false;
+      expect(
+        sections
+          .at(0)
+          .find('div')
+          .at(1)
+          .getDOMNode()
+          .getAttribute('aria-hidden')
+      ).to.equal('true');
+      expect(
+        sections
+          .at(1)
+          .find('div')
+          .at(1)
+          .getDOMNode()
+          .getAttribute('aria-hidden')
+      ).to.equal('false');
     });
 
     it('should collapse a section on click', () => {
@@ -424,7 +445,14 @@ describes.sandboxed('Accordion preact component', {}, (env) => {
       expect(sections.at(0).getDOMNode()).to.not.have.attribute('expanded');
 
       // Contents.
-      expect(sections.at(0).find('div').at(1).getDOMNode().hidden).to.be.true;
+      expect(
+        sections
+          .at(0)
+          .find('div')
+          .at(1)
+          .getDOMNode()
+          .getAttribute('aria-hidden')
+      ).to.equal('true');
     });
   });
 
@@ -555,7 +583,7 @@ describes.sandboxed('Accordion preact component', {}, (env) => {
       section.find('div').at(0).simulate('click');
 
       // Immediately hidden, which means animation has not been even tried.
-      expect(content.hidden).to.be.true;
+      expect(content.getAttribute('aria-hidden')).to.equal('true');
     });
   });
 
@@ -671,6 +699,99 @@ describes.sandboxed('Accordion preact component', {}, (env) => {
       );
       expect(onExpandStateChange.callCount).to.equal(3);
       expect(onExpandStateChange.args[2][0]).to.be.true;
+    });
+  });
+
+  describe('display locking', () => {
+    let wrapper;
+    let cssSupports;
+    let getJsx;
+    let experimentDisplayLocking;
+
+    beforeEach(() => {
+      cssSupports = window.CSS.supports;
+      getJsx = (experimentDisplayLocking) => (
+        <Accordion experimentDisplayLocking={experimentDisplayLocking}>
+          <AccordionSection key={1} expanded>
+            <AccordionHeader>header1</AccordionHeader>
+            <AccordionContent>Puppies are cute.</AccordionContent>
+          </AccordionSection>
+          <AccordionSection key={2}>
+            <AccordionHeader>header2</AccordionHeader>
+            <AccordionContent>Kittens are furry.</AccordionContent>
+          </AccordionSection>
+          <AccordionSection key={3}>
+            <AccordionHeader>header3</AccordionHeader>
+            <AccordionContent>Elephants have great memory.</AccordionContent>
+          </AccordionSection>
+        </Accordion>
+      );
+    });
+
+    afterEach(() => {
+      window.CSS.supports = cssSupports;
+    });
+
+    it('should expand based on beforematch event', async () => {
+      // Mock environment to support 'content-visibility'
+      // Turn on the experimentDisplayLocking prop
+      window.CSS.supports = () => true;
+      experimentDisplayLocking = true;
+      wrapper = mount(getJsx(experimentDisplayLocking));
+      document.body.appendChild(wrapper.getDOMNode());
+
+      const sections = wrapper.find(AccordionSection);
+      const section2 = sections.at(1).getDOMNode();
+      const content2 = sections.at(1).find('div').at(1).getDOMNode();
+
+      // Expand a collapsed section
+      expect(section2).to.not.have.attribute('expanded');
+      content2.dispatchEvent(new Event('beforematch'));
+      wrapper.update();
+      expect(section2).to.have.attribute('expanded');
+
+      // Expanded section should not collapse
+      content2.dispatchEvent(new Event('beforematch'));
+      wrapper.update();
+      expect(section2).to.have.attribute('expanded');
+    });
+
+    it('should not expand if "content-visibility" not supported', async () => {
+      // Mock environment to NOT support 'content-visibility'
+      // Turn on the experimentDisplayLocking prop
+      window.CSS.supports = (selector) => selector !== 'content-visibility';
+      experimentDisplayLocking = true;
+      wrapper = mount(getJsx(experimentDisplayLocking));
+      document.body.appendChild(wrapper.getDOMNode());
+
+      const sections = wrapper.find(AccordionSection);
+      const section2 = sections.at(1).getDOMNode();
+      const content2 = sections.at(1).find('div').at(1).getDOMNode();
+
+      // Section should not expand
+      expect(section2).to.not.have.attribute('expanded');
+      content2.dispatchEvent(new Event('beforematch'));
+      wrapper.update();
+      expect(section2).to.not.have.attribute('expanded');
+    });
+
+    it('should not expand if experimentDisplayLocking prop is "false"', async () => {
+      // Mock environment to support 'content-visibility'
+      // Turn OFF the experimentDisplayLocking prop
+      window.CSS.supports = () => true;
+      experimentDisplayLocking = false;
+      wrapper = mount(getJsx(experimentDisplayLocking));
+      document.body.appendChild(wrapper.getDOMNode());
+
+      const sections = wrapper.find(AccordionSection);
+      const section2 = sections.at(1).getDOMNode();
+      const content2 = sections.at(1).find('div').at(1).getDOMNode();
+
+      // Section should not expand
+      expect(section2).to.not.have.attribute('expanded');
+      content2.dispatchEvent(new Event('beforematch'));
+      wrapper.update();
+      expect(section2).to.not.have.attribute('expanded');
     });
   });
 

--- a/extensions/amp-accordion/1.0/test/test-amp-accordion.js
+++ b/extensions/amp-accordion/1.0/test/test-amp-accordion.js
@@ -35,7 +35,7 @@ describes.realWin(
     async function waitForExpanded(el, expanded) {
       const isExpandedOrNot = () =>
         el.hasAttribute('expanded') === expanded &&
-        el.lastElementChild.getAttribute('aria-hidden') === String(!expanded);
+        el.firstElementChild.getAttribute('aria-expanded') === String(expanded);
       await waitFor(isExpandedOrNot, 'element expanded updated');
     }
 

--- a/extensions/amp-accordion/1.0/test/test-amp-accordion.js
+++ b/extensions/amp-accordion/1.0/test/test-amp-accordion.js
@@ -546,6 +546,7 @@ describes.realWin(
       afterEach(() => {
         win.CSS.supports = defaultCssSupports;
         win.document.body.onbeforematch = defaultBeforeMatch;
+        toggleExperiment(win, 'amp-accordion-display-locking', false);
       });
 
       it('should expand collpased section with beforematch event', async () => {

--- a/extensions/amp-accordion/1.0/test/test-amp-accordion.js
+++ b/extensions/amp-accordion/1.0/test/test-amp-accordion.js
@@ -35,7 +35,7 @@ describes.realWin(
     async function waitForExpanded(el, expanded) {
       const isExpandedOrNot = () =>
         el.hasAttribute('expanded') === expanded &&
-        el.lastElementChild.hidden === !expanded;
+        el.lastElementChild.getAttribute('aria-hidden') === String(!expanded);
       await waitFor(isExpandedOrNot, 'element expanded updated');
     }
 
@@ -43,6 +43,7 @@ describes.realWin(
       win = env.win;
       html = htmlFor(win.document);
       toggleExperiment(win, 'amp-accordion-bento', true, true);
+      toggleExperiment(win, 'amp-accordion-display-locking', true, true);
       element = html`
         <amp-accordion layout="fixed" width="300" height="200">
           <section expanded id="section1">
@@ -513,6 +514,94 @@ describes.realWin(
         animation.onfinish();
         await waitForExpanded(sections[0], false);
         expect(section.lastElementChild).to.have.display('none');
+      });
+    });
+
+    describe('display locking', () => {
+      let defaultCssSupports;
+      let defaultBeforeMatch;
+
+      beforeEach(async () => {
+        toggleExperiment(win, 'amp-accordion-display-locking', true);
+        element = html`
+          <amp-accordion>
+            <section>
+              <h2>Section 1</h2>
+              <div>Puppies are cute.</div>
+            </section>
+            <section expanded>
+              <h2>Section 2</h2>
+              <div>Kittens are furry.</div>
+            </section>
+            <section expanded>
+              <h2>Section 3</h2>
+              <div>Elephants have great memory.</div>
+            </section>
+          </amp-accordion>
+        `;
+        defaultCssSupports = win.CSS.supports;
+        defaultBeforeMatch = win.document.body.onbeforematch;
+      });
+
+      afterEach(() => {
+        win.CSS.supports = defaultCssSupports;
+        win.document.body.onbeforematch = defaultBeforeMatch;
+      });
+
+      it('should expand collpased section with beforematch event', async () => {
+        win.document.body.appendChild(element);
+        win.CSS.supports = () => true;
+        win.document.body.onbeforematch = null;
+        await element.build();
+
+        const section1 = element.children[0];
+        const content1 = section1.lastElementChild;
+
+        expect(win.AMP.isExperimentOn('amp-accordion-display-locking')).to.be
+          .true;
+        expect(section1).not.to.have.attribute('expanded');
+        content1.dispatchEvent(new Event('beforematch'));
+        await waitForExpanded(section1, true);
+        expect(section1).to.have.attribute('expanded');
+      });
+
+      it('should not expand already expanded section', async () => {
+        win.document.body.appendChild(element);
+        win.CSS.supports = () => true;
+        win.document.body.onbeforematch = null;
+        await element.build();
+
+        const section2 = element.children[1];
+        const content2 = section2.lastElementChild;
+
+        expect(win.AMP.isExperimentOn('amp-accordion-display-locking')).to.be
+          .true;
+        expect(section2).to.have.attribute('expanded');
+        content2.dispatchEvent(new Event('beforematch'));
+
+        // Section should is already expanded and stays expanded
+        await waitForExpanded(section2, true);
+        expect(section2).to.have.attribute('expanded');
+      });
+
+      it('should not toggle section with two synchronous beforematch events', async () => {
+        win.document.body.appendChild(element);
+        win.CSS.supports = () => true;
+        win.document.body.onbeforematch = null;
+        await element.build();
+
+        const section1 = element.children[0];
+        const content1 = section1.lastElementChild;
+
+        expect(win.AMP.isExperimentOn('amp-accordion-display-locking')).to.be
+          .true;
+        expect(section1).not.to.have.attribute('expanded');
+        content1.dispatchEvent(new Event('beforematch'));
+        content1.dispatchEvent(new Event('beforematch'));
+
+        // Section should be expanded (not toggled opened then closed)
+        await waitForExpanded(section1, true);
+        expect(section1).to.have.attribute('expanded');
       });
     });
 

--- a/extensions/amp-accordion/1.0/test/test-amp-accordion.js
+++ b/extensions/amp-accordion/1.0/test/test-amp-accordion.js
@@ -558,8 +558,6 @@ describes.realWin(
         const section1 = element.children[0];
         const content1 = section1.lastElementChild;
 
-        expect(win.AMP.isExperimentOn('amp-accordion-display-locking')).to.be
-          .true;
         expect(section1).not.to.have.attribute('expanded');
         content1.dispatchEvent(new Event('beforematch'));
         await waitForExpanded(section1, true);
@@ -575,8 +573,6 @@ describes.realWin(
         const section2 = element.children[1];
         const content2 = section2.lastElementChild;
 
-        expect(win.AMP.isExperimentOn('amp-accordion-display-locking')).to.be
-          .true;
         expect(section2).to.have.attribute('expanded');
         content2.dispatchEvent(new Event('beforematch'));
 
@@ -594,8 +590,6 @@ describes.realWin(
         const section1 = element.children[0];
         const content1 = section1.lastElementChild;
 
-        expect(win.AMP.isExperimentOn('amp-accordion-display-locking')).to.be
-          .true;
         expect(section1).not.to.have.attribute('expanded');
         content1.dispatchEvent(new Event('beforematch'));
         content1.dispatchEvent(new Event('beforematch'));


### PR DESCRIPTION
Add new display locking feature to [bento][accordion].  This supports `ctrl + f` finding of content that is in a collapsed accordion section.  If the content is found, the accordion section will expand.

This only works for new Chromium Canary browser.  To check if the browser supports this, type this in the console: `CSS.supports("content-visibility","hidden-matchable")` (must return true)

API -
AMP - The experiment `amp-accordion-display-locking` must be set to `true`
Preact - The top-level Accordion component must have prop `experimentDisplayLocking` set to `true`
(additionally in both cases, the above CSS property must be supported by the browser)

Implemented by including the following CSS properties on a collapsed content section.
```
content-visibility: hidden-matchable !important;
display: block !important;
```

11/18 - Storybooks added
11/19 - Removed `hidden` attribute
11/19 - Tests in progress