### PR TITLE
🐛 Fix onResizeSuccess is undefined issue on ads

### DIFF
--- a/extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js
+++ b/extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js
@@ -458,7 +458,9 @@ export class AmpAdXOriginIframeHandler {
         .updateSize(height, width, iframeHeight, iframeWidth, event)
         .then(
           (info) => {
-            this.baseInstance_.onResizeSuccess();
+            if (this.baseInstance_.onResizeSuccess) {
+              this.baseInstance_.onResizeSuccess();
+            }
             this.sendEmbedSizeResponse_(
               info.success,
               id,


### PR DESCRIPTION
<!--
# Instructions:

- Pick a meaningful title for your pull request. (Use sentence case.)
  - Prefix the title with an emoji to identify what is being done. (Copy-paste the emoji from the list below.)
  - Do not overuse punctuation in the title (like `(chore):`).
  - If it is helpful, use a simple prefix (like `ProjectX: Implement some feature`).
- Enter a succinct description that says why the PR is necessary, and what it does.
  - Mention the GitHub issue that is being addressed by the pull request.
  - The keywords `Fixes`, `Closes`, or `Resolves` followed the issue number will automatically close the issue.

> NOTE: All non-trivial changes (like introducing new features or components) should have an associated issue or reference an I2I (intent-to-implement: go.amp.dev/i2i). Please read through the contribution process (go.amp.dev/contributing/code) for more information.

# Example of a good description:

- Implement aspect X
- Leave out feature Y because of A
- Improve performance by B
- Improve accessibility by C

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Reverting a previous change
♻️ Refactoring
🚮 Deleting code
🧪 Experimental code
-->

```
Error: a.h.onResizeSuccess is not a function. (In 'a.h.onResizeSuccess()', 'a.h.onResizeSuccess' is undefined)
at (https://raw.githubusercontent.com/ampproject/amphtml/2010302236002/extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js:461)
```

In some cases, where the baseInstance is an AmpA4A element, they would not have onResizeSuccess function available. Currently, AmpA4A integrations do not support sticky ad type. We are fixing this first and then address the unavailability of sticky ad on AmpA4A next.
