### PR TITLE
🐛 Fix value_regex for decimal option-*-results-threshold attr values

### DIFF
--- a/extensions/amp-story-interactive/validator-amp-story-interactive.protoascii
+++ b/extensions/amp-story-interactive/validator-amp-story-interactive.protoascii
@@ -146,22 +146,22 @@ tags: {  # <amp-story-interactive-results>
   }
   attrs: {
     name: "option-1-results-threshold"
-    value_regex: "\\d+[.\\d+]?"
+    value_regex: "\\d+(\.\\d+)?"
   }
   attrs: {
     name: "option-2-results-threshold"
-    value_regex: "\\d+[.\\d+]?"
+    value_regex: "\\d+(\.\\d+)?"
   }
   attrs: {
     name: "option-3-results-threshold"
-    value_regex: "\\d+[.\\d+]?"
+    value_regex: "\\d+(\.\\d+)?"
     trigger: {
       also_requires_attr: "option-3-results-category"
     }
   }
   attrs: {
     name: "option-4-results-threshold"
-    value_regex: "\\d+[.\\d+]?"
+    value_regex: "\\d+(\.\\d+)?"
     trigger: {
       also_requires_attr: "option-4-results-category"
     }


### PR DESCRIPTION
While importing the validator spec into the AMP-WP plugin (https://github.com/ampproject/amp-wp/pull/5608), I noticed a but with the regex for the `option-*-results-threshold` attributes on the `amp-story-interactive-results` component. Namely, if you provide a decimal value, ten it is flagged as a validation error:

```html
          <amp-story-interactive-results
              prompt-text="Your level is"
              option-1-results-category="Beginner" option-1-image="beginner.png"
              option-1-results-threshold="0.5"
              option-2-results-category="Expert" option-2-image="expert.png"
              option-2-results-threshold="80.5">
          </amp-story-interactive-results>
```

![image](https://user-images.githubusercontent.com/134745/99496120-89aa4480-2928-11eb-8125-eb6a1849539d.png)

If I supply `80.` instead of `80.5` then it passes. Clearly a capture group was intended rather than a character class.