### PR TITLE
bump worker-dom to 27.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@ampproject/animations": "0.2.2",
     "@ampproject/toolbox-cache-url": "2.5.4",
     "@ampproject/viewer-messaging": "1.1.0",
-    "@ampproject/worker-dom": "0.27.3",
+    "@ampproject/worker-dom": "0.27.4",
     "dompurify": "2.0.7",
     "intersection-observer": "0.11.0",
     "jss": "10.3.0",


### PR DESCRIPTION
**summary**
Bumps `worker-dom` to 27.4.  
Expected to fix two bugs:
1. https://github.com/ampproject/amphtml/issues/30691
2. https://github.com/ampproject/amphtml/issues/30548