### PR TITLE
🏗 SwG Release Nov. 19, 2020 (0.1.22.133)

### DIFF
--- a/third_party/subscriptions-project/config.js
+++ b/third_party/subscriptions-project/config.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/** Version: 0.1.22.131 */
+/** Version: 0.1.22.133 */
 /**
  * Copyright 2018 The Subscribe with Google Authors. All Rights Reserved.
  *


### PR DESCRIPTION
## Version: 0.1.22.133

## Previous release: [0.1.22.131](https://github.com/subscriptions-project/swg-js/releases/tag/0.1.22.131)

  - Makes init method unblock APIs that don't need a configured runtime (#1366)
  - Update dependency rollup to v2.33.3 (#1365)
  - Update dependency chromedriver to v87 (#1364)
  - Update dependency gzip-size to v6 (#1363)
  - Update dependency rollup to v2.33.2 (#1362)
  - Regwall: i18n (#1361)
  - Adds drop shadow to meter toast iframe on mobile (#1360)
  - Updates dependency versions
  - Allows for Scroll to close Meter Toast iframe (#1355)
  - Update dependency gulp-sourcemaps to v3 (#1359)
  - CI: Cleans up references to Travis (#1358)
  - CI: Adds CodeCov action (#1357)
  - CI: Run on PR events (#1356)
  - Update dependency postcss to v8.1.7 (#1353)
  - Migrates CI to GitHub Actions (#1354)
  - Update dependency autoprefixer to v10.0.2 (#1352)