### PR TITLE
♻️ Allowlist <amp-img>, <h1>, <h2>, and <h3> as unescaped HTML within amp-mustache

### DIFF
--- a/examples/amp-list.amp.html
+++ b/examples/amp-list.amp.html
@@ -58,6 +58,15 @@
     </template>
   </amp-list>
 
+  <!-- If the `amp-list` contains unescaped HTML (allow <h1> <h2> <h3> and <amp-img> tags) -->
+  <!-- See: https://github.com/ampproject/amphtml/issues/27344 -->
+  <h3>amp-list with unescaped HTML</h3>
+  <amp-list id="list1" width="auto" height="300" layout="fixed-height" src="list.example.json" class="m1" reset-on-refresh>
+    <template type="amp-mustache" id="amp-template-id">
+      <div>{{{html}}}</div>
+    </template>
+  </amp-list>
+
   <!-- [diffable] -->
   <h3>amp-list[diffable]</h3>
   <amp-list diffable id="list1" width="auto" height="300" layout="fixed-height" src="list.example.json" class="m1" reset-on-refresh>

--- a/examples/list.example.json
+++ b/examples/list.example.json
@@ -19,6 +19,9 @@
       "title": "amp-accordion",
       "url": "/components/amp-accordion/",
       "image": "img/ampicon.png"
+    },
+    {
+      "html": "<h1>Heading 1</h1><h2>Heading 2</h2><h3>Heading 3</h3><amp-img layout=\"responsive\" src=\"img/ampicon.png\" width=\"50\" height=\"50\" alt=\"\"></amp-img>"
     }
   ],
   "next": "./list.example.json"

--- a/extensions/amp-mustache/0.2/test/test-amp-mustache.js
+++ b/extensions/amp-mustache/0.2/test/test-amp-mustache.js
@@ -525,6 +525,24 @@ describes.repeated(
         });
         expect(result.innerHTML).to.equal('value = <a>test</a>');
       });
+
+      it('should not sanitize allowlisted elements', () => {
+        textContentSetup('value = {{{value}}}');
+        template.compileCallback();
+        const result = template.render({
+          value:
+            '<h1>Heading 1</h1>' +
+            '<h2>Heading 2</h2>' +
+            '<h3>Heading 3</h3>' +
+            '<amp-img></amp-img>',
+        });
+        expect(result.innerHTML).to.equal(
+          'value = <h1>Heading 1</h1>' +
+            '<h2>Heading 2</h2>' +
+            '<h3>Heading 3</h3>' +
+            '<amp-img i-amphtml-ignore=""></amp-img>'
+        );
+      });
     });
 
     describe('tables', () => {

--- a/extensions/amp-mustache/amp-mustache.md
+++ b/extensions/amp-mustache/amp-mustache.md
@@ -90,7 +90,7 @@ that among other things, you can't use `amp-mustache` to:
 - Calculate tag name. E.g. `<{{tagName}}>` is not allowed.
 - Calculate attribute name. E.g. `<div {{attrName}}=something>` is not allowed.
 
-The output of "triple-mustache" is sanitized to only allow the following tags: `a`, `b`, `br`, `caption`, `col`, `colgroup`, `code`, `del`, `div`, `em`, `hr`, `i`, `ins`, `li`, `mark`, `ol`, `p`, `q`, `s`, `small`, `span`, `strong`, `sub`, `sup`, `table`, `tbody`, `time`, `td`, `th`, `thead`, `tfoot`, `tr`, `u`, `ul`.
+The output of "triple-mustache" is sanitized to only allow the following tags: `a`, `amp-list`, `b`, `br`, `caption`, `col`, `colgroup`, `code`, `del`, `div`, `em`, `h1`, `h2`, `h3`, `hr`, `i`, `ins`, `li`, `mark`, `ol`, `p`, `q`, `s`, `small`, `span`, `strong`, `sub`, `sup`, `table`, `tbody`, `time`, `td`, `th`, `thead`, `tfoot`, `tr`, `u`, `ul`.
 
 ### Sanitization
 

--- a/src/purifier/sanitation.js
+++ b/src/purifier/sanitation.js
@@ -118,6 +118,7 @@ export const EMAIL_ALLOWLISTED_AMP_TAGS = {
  */
 export const TRIPLE_MUSTACHE_ALLOWLISTED_TAGS = [
   'a',
+  'amp-img',
   'b',
   'br',
   'caption',
@@ -130,6 +131,9 @@ export const TRIPLE_MUSTACHE_ALLOWLISTED_TAGS = [
   'dl',
   'dt',
   'em',
+  'h1',
+  'h2',
+  'h3',
   'hr',
   'i',
   'ins',

--- a/test/unit/test-purifier.js
+++ b/test/unit/test-purifier.js
@@ -519,6 +519,15 @@ describe
         );
       });
 
+      it('should allowlist h1, h2, h3 and amp-img elements', () => {
+        const html =
+          '<h1>Heading 1</h1>' +
+          '<h2>Heading 2</h2>' +
+          '<h3>Heading 3</h3>' +
+          '<amp-img></amp-img>';
+        expect(purifyTripleMustache(html)).to.be.equal(html);
+      });
+
       it('should allowlist table related elements and anchor tags', () => {
         const html =
           '<table class="valid-class">' +


### PR DESCRIPTION
♻️ Allowlist `<amp-img>`, `<h1>`, `<h2>`, and `<h3>` as unescaped HTML with `{{{` amp-mustache.

- Add tags to sanitization.js within `TRIPLE_MUSTACHE_ALLOWLISTED_TAGS`.
- Create an example within `amp-list.amp.html` containing a string of unescaped HTML.
- Add test case expecting tags to be present in rendered template.

Resolves #27344