### PR TITLE
🚀 Improve player loading strategy

### DIFF
--- a/extensions/amp-story-player/0.1/amp-story-player.js
+++ b/extensions/amp-story-player/0.1/amp-story-player.js
@@ -28,11 +28,17 @@ class AmpStoryPlayerWrapper extends AMP.BaseElement {
   /** @override */
   buildCallback() {
     this.player_.buildCallback();
+    this.player_.prerenderCallback();
+  }
+
+  /** @override */
+  renderOutsideViewport() {
+    // Only call layoutCallback() when player is in viewport.
+    return false;
   }
 
   /** @override */
   layoutCallback() {
-    this.player_.prerenderCallback();
     this.player_.layoutCallback();
     return Promise.resolve();
   }

--- a/extensions/amp-story-player/0.1/amp-story-player.js
+++ b/extensions/amp-story-player/0.1/amp-story-player.js
@@ -32,6 +32,7 @@ class AmpStoryPlayerWrapper extends AMP.BaseElement {
 
   /** @override */
   layoutCallback() {
+    this.player_.prerenderCallback();
     this.player_.layoutCallback();
     return Promise.resolve();
   }

--- a/extensions/amp-story-player/0.1/amp-story-player.js
+++ b/extensions/amp-story-player/0.1/amp-story-player.js
@@ -33,8 +33,6 @@ class AmpStoryPlayerWrapper extends AMP.BaseElement {
   /** @override */
   layoutCallback() {
     this.player_.layoutCallback();
-    this.player_.markAsVisible();
-
     return Promise.resolve();
   }
 

--- a/extensions/amp-story-player/0.1/amp-story-player.js
+++ b/extensions/amp-story-player/0.1/amp-story-player.js
@@ -28,19 +28,19 @@ class AmpStoryPlayerWrapper extends AMP.BaseElement {
   /** @override */
   buildCallback() {
     this.player_.buildCallback();
-    this.player_.prerenderCallback();
-  }
-
-  /** @override */
-  renderOutsideViewport() {
-    // Only call layoutCallback() when player is in viewport.
-    return false;
   }
 
   /** @override */
   layoutCallback() {
     this.player_.layoutCallback();
+    this.player_.markAsVisible();
+
     return Promise.resolve();
+  }
+
+  /** @override */
+  prerenderAllowed() {
+    return true;
   }
 
   /** @override */

--- a/src/amp-story-player/amp-story-component-manager.js
+++ b/src/amp-story-player/amp-story-component-manager.js
@@ -67,20 +67,6 @@ export class AmpStoryComponentManager {
       rootMargin: `${MIN_VIEWPORT_PRERENDER_DISTANCE * 100}%`,
     });
     layoutObserver.observe(elImpl.getElement());
-
-    const ioVisibleCb = (entries) => {
-      entries.forEach((entry) => {
-        if (!entry.isIntersecting) {
-          return;
-        }
-        elImpl.markAsVisible();
-
-        visibleObserver.unobserve(elImpl.getElement());
-      });
-    };
-
-    const visibleObserver = new IntersectionObserver(ioVisibleCb);
-    visibleObserver.observe(elImpl.getElement());
   }
 
   /**
@@ -115,9 +101,6 @@ export class AmpStoryComponentManager {
 
     if (winInnerHeight * MIN_VIEWPORT_PRERENDER_DISTANCE > elTop) {
       elImpl.layoutCallback();
-    }
-    if (winInnerHeight > elTop) {
-      elImpl.markAsVisible();
       this.win_.removeEventListener('scroll', this.scrollHandler_);
     }
   }

--- a/src/amp-story-player/amp-story-component-manager.js
+++ b/src/amp-story-player/amp-story-component-manager.js
@@ -66,8 +66,7 @@ export class AmpStoryComponentManager {
       });
     };
 
-    const rootMarginInPercentage =
-      (MIN_VIEWPORT_PRERENDER_DISTANCE * 100).toString() + '%';
+    const rootMarginInPercentage = `${MIN_VIEWPORT_PRERENDER_DISTANCE * 100}%`;
     const prerenderObserver = new IntersectionObserver(ioPrerenderCb, {
       rootMargin: rootMarginInPercentage,
     });

--- a/src/amp-story-player/amp-story-component-manager.js
+++ b/src/amp-story-player/amp-story-component-manager.js
@@ -24,6 +24,7 @@ import {initLogConstructor} from '../log';
  * @const {number}
  */
 const MIN_VIEWPORT_PRERENDER_DISTANCE = 2;
+
 export class AmpStoryComponentManager {
   /**
    * @param {!Window} win

--- a/src/amp-story-player/amp-story-component-manager.js
+++ b/src/amp-story-player/amp-story-component-manager.js
@@ -50,14 +50,14 @@ export class AmpStoryComponentManager {
         }
         elImpl.prerenderCallback();
 
-        observer.unobserve(elImpl.getElement());
+        prerenderObserver.unobserve(elImpl.getElement());
       });
     };
 
-    const observer = new IntersectionObserver(ioPrerenderCb, {
+    const prerenderObserver = new IntersectionObserver(ioPrerenderCb, {
       rootMargin: '200%',
     });
-    observer.observe(elImpl.getElement());
+    prerenderObserver.observe(elImpl.getElement());
 
     const ioLayoutCb = (entries) => {
       entries.forEach((entry) => {
@@ -66,14 +66,14 @@ export class AmpStoryComponentManager {
         }
         elImpl.layoutCallback();
 
-        visible.unobserve(elImpl.getElement());
+        visibleObserver.unobserve(elImpl.getElement());
       });
     };
 
-    const visible = new IntersectionObserver(ioLayoutCb, {
+    const visibleObserver = new IntersectionObserver(ioLayoutCb, {
       threshold: [0.2],
     });
-    visible.observe(elImpl.getElement());
+    visibleObserver.observe(elImpl.getElement());
   }
 
   /**

--- a/src/amp-story-player/amp-story-player-impl.js
+++ b/src/amp-story-player/amp-story-player-impl.js
@@ -700,11 +700,24 @@ export class AmpStoryPlayer {
     }
   }
 
-  /** @public */
-  markAsVisible() {
-    this.prerenderStoriesDeferred_.promise.then(() =>
-      this.visibleDeferred_.resolve()
-    );
+  /** @private */
+  initializeVisibleIO_() {
+    const ioVisibleCb = (entries) => {
+      entries.forEach((entry) => {
+        if (!entry.isIntersecting) {
+          return;
+        }
+
+        this.prerenderStoriesDeferred_.promise.then(() =>
+          this.visibleDeferred_.resolve()
+        );
+
+        visibleObserver.unobserve(this.element_);
+      });
+    };
+
+    const visibleObserver = new IntersectionObserver(ioVisibleCb);
+    visibleObserver.observe(this.element_);
   }
 
   /**
@@ -715,6 +728,7 @@ export class AmpStoryPlayer {
       return;
     }
     this.prerenderStories_();
+    this.initializeVisibleIO_();
 
     this.visibleDeferred_.promise.then(() => {
       if (this.stories_.length > 0) {

--- a/src/amp-story-player/amp-story-player-impl.js
+++ b/src/amp-story-player/amp-story-player-impl.js
@@ -15,6 +15,7 @@
  */
 
 import * as ampToolboxCacheUrl from '@ampproject/toolbox-cache-url';
+import {AmpStoryPlayerViewportObserver} from './amp-story-player-viewport-observer';
 import {Deferred} from '../utils/promise';
 import {IframePool} from './amp-story-player-iframe-pool';
 import {Messaging} from '@ampproject/viewer-messaging';
@@ -702,22 +703,13 @@ export class AmpStoryPlayer {
 
   /** @private */
   initializeVisibleIO_() {
-    const ioVisibleCb = (entries) => {
-      entries.forEach((entry) => {
-        if (!entry.isIntersecting) {
-          return;
-        }
-
-        this.prerenderStoriesDeferred_.promise.then(() =>
-          this.visibleDeferred_.resolve()
-        );
-
-        visibleObserver.unobserve(this.element_);
-      });
+    const cb = () => {
+      this.prerenderStoriesDeferred_.promise.then(() =>
+        this.visibleDeferred_.resolve()
+      );
     };
 
-    const visibleObserver = new IntersectionObserver(ioVisibleCb);
-    visibleObserver.observe(this.element_);
+    new AmpStoryPlayerViewportObserver(this.win_, this.element_, cb.bind(this));
   }
 
   /**

--- a/src/amp-story-player/amp-story-player-impl.js
+++ b/src/amp-story-player/amp-story-player-impl.js
@@ -1156,11 +1156,11 @@ export class AmpStoryPlayer {
           if (this.currentStoryLoadDeferred_) {
             // Cancel previous story load promise.
             this.currentStoryLoadDeferred_.reject(
-              'Cancelling previous prerender promise.'
+              'Cancelling previous story load promise.'
             );
           }
-          this.waitForStoryToLoadPromise_(story.iframeIdx);
           navigationPromise = Promise.resolve();
+          this.waitForStoryToLoadPromise_(story.iframeIdx);
         } else {
           navigationPromise = this.currentStoryLoadDeferred_.promise;
         }

--- a/src/amp-story-player/amp-story-player-impl.js
+++ b/src/amp-story-player/amp-story-player-impl.js
@@ -1151,17 +1151,13 @@ export class AmpStoryPlayer {
   updateIframeSrc_(story, iframe, visibilityState, lifeCycleWaitPromise) {
     return this.maybeGetCacheUrl_(story.href)
       .then((storyUrl) => {
-        if (
-          this.sanitizedUrlsAreEquals_(storyUrl, iframe.src)
-          // && iframe[AMP_VISIBILITY_STATE] === visibilityState
-        ) {
+        if (this.sanitizedUrlsAreEquals_(storyUrl, iframe.src)) {
           return Promise.resolve();
         }
 
         return lifeCycleWaitPromise(story, visibilityState).then(() => {
           const {href} = this.getEncodedLocation_(storyUrl, visibilityState);
           iframe.setAttribute('src', href);
-          // iframe[AMP_VISIBILITY_STATE] = visibilityState;
           if (story.title) {
             iframe.setAttribute('title', story.title);
           }

--- a/src/amp-story-player/amp-story-player-viewport-observer.js
+++ b/src/amp-story-player/amp-story-player-viewport-observer.js
@@ -1,0 +1,117 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {throttle} from '../utils/rate-limit';
+
+/** @const {number} */
+const SCROLL_THROTTLE_MS = 500;
+
+/**
+ * Creates an IntersectionObserver or fallback using scroll events.
+ * Fires viewportCb when criteria is met and unobserves immediately after.
+ */
+export class AmpStoryPlayerViewportObserver {
+  /**
+   * @param {!Window} win
+   * @param {!Element} element
+   * @param {function} viewportCb
+   * @param {number} distance Minimum of viewports away for triggering viewportCb
+   */
+  constructor(win, element, viewportCb, distance = 0) {
+    /** @private {!Window} */
+    this.win_ = win;
+
+    /** @private {!Element} */
+    this.element_ = element;
+
+    /** @private {function} */
+    this.cb_ = viewportCb;
+
+    /** @private {number} */
+    this.viewportDistance_ = distance;
+
+    /** @private {?function} */
+    this.scrollHandler_ = null;
+
+    this.initializeInObOrFallback_();
+  }
+
+  /** @private */
+  initializeInObOrFallback_() {
+    if (!this.win_.IntersectionObserver || this.win_ !== this.win_.parent) {
+      this.createInObFallback_();
+      return;
+    }
+
+    this.createInOb_();
+  }
+
+  /**
+   * Creates an IntersectionObserver.
+   * @private
+   */
+  createInOb_() {
+    const inObCallback = (entries) => {
+      entries.forEach((entry) => {
+        if (!entry.isIntersecting) {
+          return;
+        }
+        this.cb_();
+        observer.unobserve(this.element_);
+      });
+    };
+
+    const observer = new IntersectionObserver(inObCallback, {
+      rootMargin: `${this.viewportDistance_ * 100}%`,
+    });
+
+    observer.observe(this.element_);
+  }
+
+  /**
+   * Fallback for when IntersectionObserver is not supported. Calls
+   * layoutCallback on the element when it is close to the viewport.
+   * @private
+   */
+  createInObFallback_() {
+    this.scrollHandler_ = throttle(
+      this.win_,
+      this.checkIfVisibleFallback_.bind(this),
+      SCROLL_THROTTLE_MS
+    );
+
+    // TODO(Enriqe): pause elements when scrolling away from viewport.
+    this.win_.addEventListener('scroll', this.scrollHandler_);
+
+    this.checkIfVisibleFallback_(this.element_);
+  }
+
+  /**
+   * Checks if element is close to the viewport and calls the callback when it
+   * is.
+   * @private
+   */
+  checkIfVisibleFallback_() {
+    const elTop = this.element_./*OK*/ getBoundingClientRect().top;
+    const winInnerHeight = this.win_./*OK*/ innerHeight;
+    const multiplier = this.viewportDistance_ > 0 ? this.viewportDistance_ : 1;
+
+    if (winInnerHeight * multiplier > elTop) {
+      this.cb_();
+      this.win_.removeEventListener('scroll', this.scrollHandler_);
+    }
+  }
+}

--- a/src/amp-story-player/amp-story-player-viewport-observer.js
+++ b/src/amp-story-player/amp-story-player-viewport-observer.js
@@ -74,7 +74,7 @@ export class AmpStoryPlayerViewportObserver {
       });
     };
 
-    const observer = new IntersectionObserver(inObCallback, {
+    const observer = new this.win_.IntersectionObserver(inObCallback, {
       rootMargin: `${this.viewportDistance_ * 100}%`,
     });
 

--- a/src/amp-story-player/amp-story-player-viewport-observer.js
+++ b/src/amp-story-player/amp-story-player-viewport-observer.js
@@ -93,7 +93,6 @@ export class AmpStoryPlayerViewportObserver {
       SCROLL_THROTTLE_MS
     );
 
-    // TODO(Enriqe): pause elements when scrolling away from viewport.
     this.win_.addEventListener('scroll', this.scrollHandler_);
 
     this.checkIfVisibleFallback_(this.element_);

--- a/test/unit/test-amp-story-player-viewport-observer.js
+++ b/test/unit/test-amp-story-player-viewport-observer.js
@@ -1,0 +1,123 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {AmpStoryPlayerViewportObserver} from '../../src/amp-story-player/amp-story-player-viewport-observer';
+
+describes.realWin('AmpStoryPlayerViewportObserver', {amp: false}, (env) => {
+  let win;
+  let el;
+  let doc;
+  let inOb;
+  let observing;
+
+  beforeEach(() => {
+    observing = new Set();
+    inOb = env.sandbox.stub();
+    inOb.callsFake(() => ({
+      observe: (el) => observing.add(el),
+      unobserve: (el) => observing.delete(el),
+    }));
+
+    win = {
+      document: {},
+      IntersectionObserver: inOb,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      innerHeight: 100,
+    };
+    win.parent = win;
+
+    doc = {defaultView: win};
+    const fakeRect = {top: 0};
+    el = {
+      ownerDocument: doc,
+      getBoundingClientRect: () => fakeRect,
+    };
+  });
+
+  /**
+   * Simulate an IntersectionObserver callback for an element.
+   * @param {!Element} el
+   * @param {boolean} inViewport
+   */
+  function toggleViewport(el, inViewport) {
+    const ioCallback = inOb.getCall(0).args[0];
+    ioCallback([{target: el, isIntersecting: inViewport}]);
+  }
+
+  it('initializes observer with implicit root', () => {
+    const noop = () => {};
+    new AmpStoryPlayerViewportObserver(win, el, noop);
+
+    expect(inOb).to.have.been.calledWith(env.sandbox.match.any, {
+      rootMargin: '0%',
+    });
+  });
+
+  it('initializes observer with explicit root', () => {
+    const noop = () => {};
+    new AmpStoryPlayerViewportObserver(win, el, noop, 5);
+
+    expect(inOb).to.have.been.calledWith(env.sandbox.match.any, {
+      rootMargin: '500%',
+    });
+  });
+
+  it('fires callback when element is visible in viewport.', () => {
+    const cbSpy = env.sandbox.spy();
+    new AmpStoryPlayerViewportObserver(win, el, cbSpy);
+
+    toggleViewport(el, true);
+
+    expect(cbSpy).to.be.calledOnce;
+  });
+
+  it('does not fire callback when element is not visible in viewport.', () => {
+    const cbSpy = env.sandbox.spy();
+    new AmpStoryPlayerViewportObserver(win, el, cbSpy);
+
+    toggleViewport(el, false);
+
+    expect(cbSpy).to.not.be.called;
+  });
+
+  it('once callback is fired, the InOb stops observing', () => {
+    const cb = env.sandbox.spy();
+    new AmpStoryPlayerViewportObserver(win, el, cb);
+
+    toggleViewport(el, true);
+
+    expect(observing.has(el)).to.be.false;
+  });
+
+  it('uses fallback if InOb is not supported', () => {
+    win.IntersectionObserver = null;
+    const scrollSpy = env.sandbox.spy(win, 'addEventListener');
+
+    new AmpStoryPlayerViewportObserver(win, el, () => {});
+
+    expect(scrollSpy).to.be.calledWith('scroll');
+  });
+
+  it('fallback removes event listener once callback is fired', () => {
+    win.IntersectionObserver = null;
+    const removeSpy = env.sandbox.spy(win, 'removeEventListener');
+
+    new AmpStoryPlayerViewportObserver(win, el, () => {});
+
+    expect(removeSpy).to.be.called;
+  });
+});

--- a/test/unit/test-amp-story-player.js
+++ b/test/unit/test-amp-story-player.js
@@ -128,7 +128,7 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
 
     expect(storyIframe.getAttribute('src')).to.equals(
       DEFAULT_CACHE_URL +
-        '?amp_js_v=0.1#visibilityState=visible&origin=http%3A%2F%2Flocalhost%3A9876' +
+        '?amp_js_v=0.1#visibilityState=prerender&origin=http%3A%2F%2Flocalhost%3A9876' +
         '&showStoryUrlInfo=0&storyPlayer=v0&cap=swipe'
     );
   });
@@ -148,20 +148,21 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
         existingQuery +
         '&amp_js_v=0.1' +
         existingHash +
-        '&visibilityState=visible&origin=http%3A%2F%2Flocalhost%3A9876' +
+        '&visibilityState=prerender&origin=http%3A%2F%2Flocalhost%3A9876' +
         '&showStoryUrlInfo=0&storyPlayer=v0&cap=swipe'
     );
   });
 
   it('should set first story as visible', async () => {
+    const sendRequestSpy = env.sandbox.spy(fakeMessaging, 'sendRequest');
+
     buildStoryPlayer(3);
     await manager.loadPlayers();
     await nextTick();
 
-    const storyIframes = playerEl.querySelectorAll('iframe');
-    expect(storyIframes[0].getAttribute('src')).to.include(
-      '#visibilityState=visible'
-    );
+    expect(sendRequestSpy).to.have.been.calledWith('visibilitychange', {
+      'state': 'visible',
+    });
   });
 
   it('should prerender next story after first one is loaded', async () => {
@@ -425,7 +426,7 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
 
       expect(storyIframe.getAttribute('src')).to.equals(
         DEFAULT_CACHE_URL +
-          '?amp_js_v=0.1#visibilityState=visible&origin=http%3A%2F%2Flocalhost%3A9876' +
+          '?amp_js_v=0.1#visibilityState=prerender&origin=http%3A%2F%2Flocalhost%3A9876' +
           '&showStoryUrlInfo=0&storyPlayer=v0&cap=swipe'
       );
     });
@@ -440,7 +441,7 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
 
       expect(storyIframe.getAttribute('src')).to.equals(
         DEFAULT_ORIGIN_URL +
-          '#visibilityState=visible&origin=http%3A%2F%2Flocalhost%3A9876' +
+          '#visibilityState=prerender&origin=http%3A%2F%2Flocalhost%3A9876' +
           '&showStoryUrlInfo=0&storyPlayer=v0&cap=swipe'
       );
     });


### PR DESCRIPTION
Closes #31225
Closes #29798
Closes #31118

<!-- TODO: measure perf improvements, look into prerendering only 2nd one, not 3rd iframe  -->

New logic:

I. When player is outside of viewport, only prerender first story.
II. Once player is visible, switch first story to visible and start prerendering neighboring stories (if any).
III. Increase distance in IntersectionObserver to 2 viewports away (before 1) so we start prerendering stories earlier.

Open questions / discussion points:

1. Is minimum 2 viewports away far enough for prerendering?
2. ~~Is 30% of player visibility in the viewport enough to set the story as visible?~~
    Changed it to make it visible as soon as it hits the viewport, to stick with AMP standards.
3. Alternative strategy ([in first commit](https://github.com/ampproject/amphtml/pull/31305/commits/5483e735ee9099c59cf1cbe6975cf0323047911a)), which I later discarded for this final version: When player is outside of viewport prerender first story, then prerender the next ones (once `prerenderComplete` message is received from first story). I decided to discard this strategy for two reasons: 1. Loading less resources until they are actually needed. 2. We can't reuse the `storyContentLoaded` event and would have to use `prerenderComplete` message, which isn't optimized for our use case.