### PR TITLE
Listen for PAUSED and RESUMES Ad Event signals in imaVideo integration

### DIFF
--- a/ads/ads.extern.js
+++ b/ads/ads.extern.js
@@ -256,6 +256,8 @@ google.ima.AdEvent.Type.AD_PROGRESS;
 google.ima.AdEvent.Type.CONTENT_PAUSE_REQUESTED;
 google.ima.AdEvent.Type.CONTENT_RESUME_REQUESTED;
 google.ima.AdEvent.Type.LOADED;
+google.ima.AdEvent.Type.PAUSED;
+google.ima.AdEvent.Type.RESUMED;
 google.ima.AdEvent.Type.ALL_ADS_COMPLETED;
 google.ima.AdsManager;
 google.ima.AdsManager.getRemainingTime;

--- a/ads/google/imaVideo.js
+++ b/ads/google/imaVideo.js
@@ -823,6 +823,14 @@ export function onAdsManagerLoaded(global, adsManagerLoadedEvent) {
   );
   adsManager.addEventListener(global.google.ima.AdEvent.Type.LOADED, onAdLoad);
   adsManager.addEventListener(
+    global.google.ima.AdEvent.Type.PAUSED,
+    onAdPaused
+  );
+  adsManager.addEventListener(
+    global.google.ima.AdEvent.Type.RESUMED,
+    onAdResumed
+  );
+  adsManager.addEventListener(
     global.google.ima.AdEvent.Type.AD_PROGRESS,
     onAdProgress
   );
@@ -959,6 +967,30 @@ export function onContentResumeRequested() {
   }
 
   videoPlayer.addEventListener('ended', onContentEnded);
+}
+
+/**
+ * Called when the IMA SDK emmitts the event: AdEvent.Type.PAUSED.
+ * Sets the (ads) controls to reflect a paused state.
+ * Does not need to set the big play pause since that is handled
+ * by the SDK generally.
+ * @visibleForTesting
+ */
+export function onAdPaused() {
+  // show play button while ad is paused
+  changeIcon(playPauseDiv, 'play');
+}
+
+/**
+ * Called when the IMA SDK emmitts the event: AdEvent.Type.RESUMED.
+ * Sets the (ads) controls to reflect a paused state.
+ * Does not need to set the big play pause since that is handled
+ * by the SDK generally.
+ * @visibleForTesting
+ */
+export function onAdResumed() {
+  // show pause button when ad resumes
+  changeIcon(playPauseDiv, 'pause');
 }
 
 /**
@@ -1524,6 +1556,7 @@ export function getPropertiesForTesting() {
     timeNode,
     uiTicker,
     videoPlayer,
+    icons,
   };
 }
 

--- a/extensions/amp-ima-video/0.1/test/test-amp-ima-video.js
+++ b/extensions/amp-ima-video/0.1/test/test-amp-ima-video.js
@@ -373,6 +373,8 @@ describes.realWin(
       mockGlobal.google.ima.AdEvent = {};
       mockGlobal.google.ima.AdEvent.Type = {
         AD_PROGRESS: 'adprogress',
+        PAUSED: 'paused',
+        RESUMED: 'resumed',
         CONTENT_PAUSE_REQUESTED: 'cpr',
         CONTENT_RESUME_REQUESTED: 'crr',
       };
@@ -404,6 +406,8 @@ describes.realWin(
       );
       expect(addEventListenerSpy).to.be.calledWith('aderror');
       expect(addEventListenerSpy).to.be.calledWith('adprogress');
+      expect(addEventListenerSpy).to.be.calledWith('paused');
+      expect(addEventListenerSpy).to.be.calledWith('resumed');
       expect(addEventListenerSpy).to.be.calledWith('cpr');
       expect(addEventListenerSpy).to.be.calledWith('crr');
       expect(setVolumeSpy).to.be.calledWith(0);
@@ -629,6 +633,49 @@ describes.realWin(
       expect(addEventListenerSpy).to.have.been.calledWith('ended');
       // TODO - Fix when I can spy on internals.
       //expect(playVideoSpy).to.have.been.called;
+    });
+
+    it('changes controls when ad pauses and resumes', () => {
+      // set up test
+      const div = doc.createElement('div');
+      div.setAttribute('id', 'c');
+      doc.body.appendChild(div);
+      imaVideoObj.imaVideo(win, {
+        width: 640,
+        height: 360,
+        src: srcUrl,
+        tag: adTagUrl,
+      });
+      const videoMock = getVideoPlayerMock();
+      //const playVideoSpy = env.sandbox.spy(imaVideoObj, 'playVideo');
+      imaVideoObj.setVideoPlayerForTesting(videoMock);
+      imaVideoObj.setContentCompleteForTesting(false);
+
+      // start ad
+      imaVideoObj.onContentResumeRequested();
+
+      // verify original
+      const {controlsDiv} = imaVideoObj.getPropertiesForTesting();
+      const playPauseDiv = controlsDiv.querySelector('#ima-play-pause');
+      expect(playPauseDiv).to.not.be.null;
+      expect(playPauseDiv.style.display).not.to.eql('none');
+      expect(playPauseDiv.innerHTML).equal(
+        imaVideoObj.getPropertiesForTesting().icons['pause']
+      );
+
+      // run test
+      imaVideoObj.onAdPaused();
+      expect(playPauseDiv.style.display).not.to.eql('none');
+      expect(playPauseDiv.innerHTML).equal(
+        imaVideoObj.getPropertiesForTesting().icons['play']
+      );
+
+      // run test
+      imaVideoObj.onAdResumed();
+      expect(playPauseDiv.style.display).not.to.eql('none');
+      expect(playPauseDiv.innerHTML).equal(
+        imaVideoObj.getPropertiesForTesting().icons['pause']
+      );
     });
 
     it('resumes content with content complete', () => {


### PR DESCRIPTION
Closes #31125
Currently it seems that the ad clicks are handled by the actual IMA video SDK, i.e. when the video ad is clicked, the SDK handles opening the new window with the click-through link. 

In the original issue, the large play button (with a circle outline) is not created by AMP's `imaVideo.js` ad integration, but rather the SDK. The problem was the the SDK was pausing and showing the large play button but we weren't listening for the [`AdEvent.PAUSED`](https://developers.google.com/interactive-media-ads/docs/sdks/html5/client-side/reference/js/google.ima.AdEvent) signal (and adjusting the smaller play/pause button). 

Fix is to listen for these signals and then adjust the play-pause button accordingly. 