### PR TITLE
🐛 Fixing bug where getLayoutBox was erroneously used in a call for isInStoryPageSideEdge

### DIFF
--- a/extensions/amp-story/1.0/page-advancement.js
+++ b/extensions/amp-story/1.0/page-advancement.js
@@ -711,7 +711,7 @@ export class ManualAdvancement extends AdvancementConfig {
   /**
    * Calculates the pageRect based on the UIType.
    * We can an use LayoutBox for mobile since the story page occupies entire screen.
-   * Desktop UI needs to use the higher latency getBoundingClientRect function.
+   * Desktop UI needs the most recent value from the getBoundingClientRect function.
    * @return {DOMRect | LayoutBox}
    * @private
    */

--- a/extensions/amp-story/1.0/page-advancement.js
+++ b/extensions/amp-story/1.0/page-advancement.js
@@ -472,7 +472,7 @@ export class ManualAdvancement extends AdvancementConfig {
 
         if (
           tagName.startsWith('amp-story-interactive-') &&
-          !this.isInStoryPageSideEdge_(event, this.element_.getLayoutBox())
+          !this.isInStoryPageSideEdge_(event, this.getStoryPageRect_())
         ) {
           shouldHandleEvent = false;
           return true;
@@ -647,18 +647,7 @@ export class ManualAdvancement extends AdvancementConfig {
   maybePerformNavigation_(event) {
     const target = dev().assertElement(event.target);
 
-    // Can use LayoutBox for mobile since the story page occupies entire screen.
-    // Desktop UI needs to use the getBoundingClientRect.
-    let pageRect;
-    if (
-      this.storeService_.get(StateProperty.UI_STATE) !== UIType.DESKTOP_PANELS
-    ) {
-      pageRect = this.element_.getLayoutBox();
-    } else {
-      pageRect = this.element_
-        .querySelector('amp-story-page[active]')
-        ./*OK*/ getBoundingClientRect();
-    }
+    const pageRect = this.getStoryPageRect_();
 
     if (this.isHandledByEmbeddedComponent_(event, pageRect)) {
       event.stopPropagation();
@@ -717,6 +706,25 @@ export class ManualAdvancement extends AdvancementConfig {
     };
 
     this.onTapNavigation(this.getTapDirection_(page));
+  }
+
+  /**
+   * Calculates the pageRect based on the UIType.
+   * We can an use LayoutBox for mobile since the story page occupies entire screen.
+   * Desktop UI needs to use the higher latency getBoundingClientRect function.
+   * @return {DOMRect | LayoutBox}
+   * @private
+   */
+  getStoryPageRect_() {
+    if (
+      this.storeService_.get(StateProperty.UI_STATE) !== UIType.DESKTOP_PANELS
+    ) {
+      return this.element_.getLayoutBox();
+    } else {
+      return this.element_
+        .querySelector('amp-story-page[active]')
+        ./*OK*/ getBoundingClientRect();
+    }
   }
 
   /**


### PR DESCRIPTION
Fixing bug where `getLayoutBox` was still used in one call for `isInStoryPageSideEdge`. Wrote new function `getStoryPageRect_` that can be used every time this value needs to be calculated.

Fixes #30825