### PR TITLE
✅ Unflake test-amp-delight-player by embedding a blank page

### DIFF
--- a/extensions/amp-delight-player/0.1/test/test-amp-delight-player.js
+++ b/extensions/amp-delight-player/0.1/test/test-amp-delight-player.js
@@ -50,6 +50,10 @@ describes.realWin(
       delight.setAttribute('height', '360');
       delight.setAttribute('layout', 'responsive');
       doc.body.appendChild(delight);
+      delight.implementation_.baseURL_ =
+        // Serve a blank page, since these tests don't require an actual page.
+        // hash # at the end so path is not affected by param concat
+        `http://localhost:${location.port}/test/fixtures/served/blank.html#`;
       return delight
         .build()
         .then(() => delight.layoutCallback())
@@ -64,7 +68,7 @@ describes.realWin(
         expect(iframe).to.not.be.null;
         expect(iframe.tagName).to.equal('IFRAME');
         expect(iframe.src).to.equal(
-          'https://players.delight-vr.com/player/-LLoCCZqWi18O73b6M0w?amp=1'
+          `${delight.implementation_.baseURL_}/player/-LLoCCZqWi18O73b6M0w?amp=1`
         );
         expect(iframe.allow).to.equal('vr');
         expect(iframe.className).to.match(/i-amphtml-fill-content/);


### PR DESCRIPTION
I've been seeing [this flake](https://travis-ci.com/github/ampproject/amphtml/jobs/447001971#L2165) a lot lately:

```
DESCRIBE => amp-delight-player
  DESCRIBE =>  
    IT => renders
      ✗ Error: Timeout of 4000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves.
●●
    IT => should forward events
      ✗ Error: Timeout of 4000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves.
```

The tests work fine with a locally served blank page, which would prevent this timeout due to lack of response from the external server.