### PR TITLE
🐛 amp-carousel-0.2 Fix width for responsive children and position for responsive carousel

### DIFF
--- a/extensions/amp-carousel/0.2/amp-carousel.css
+++ b/extensions/amp-carousel/0.2/amp-carousel.css
@@ -25,12 +25,9 @@ amp-carousel:not([type="slides"]) .i-amphtml-carousel-scroll {
   white-space: nowrap !important;
 }
 
-amp-carousel:not([type="slides"]) .i-amphtml-carousel-content {
-  position: static;
-}
-
 .amp-scrollable-carousel-slide {
   display: inline-block !important;
+  width: 100% !important;
   /*
    * Puts a space between items, for browsers that do not support the
    * properties below.

--- a/extensions/amp-carousel/0.2/test-e2e/helpers.js
+++ b/extensions/amp-carousel/0.2/test-e2e/helpers.js
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const CAROUSEL_SLIDE_CLASS =
+  '.i-amphtml-element.i-amphtml-layout-responsive' +
+  '.i-amphtml-layout-size-defined.i-amphtml-built' +
+  '.amp-carousel-slide.amp-scrollable-carousel-slide' +
+  '.i-amphtml-layout';
+const PREV_ARROW_SELECTOR = `.amp-carousel-button.amp-carousel-button-prev`;
+const NEXT_ARROW_SELECTOR = `.amp-carousel-button.amp-carousel-button-next`;
+
+export function getSlides(controller) {
+  return controller.findElements(CAROUSEL_SLIDE_CLASS);
+}
+
+export function getPrevArrow(controller) {
+  return controller.findElement(PREV_ARROW_SELECTOR);
+}
+
+export function getNextArrow(controller) {
+  return controller.findElement(NEXT_ARROW_SELECTOR);
+}
+
+export function sleep(ms) {
+  return new Promise((res) => setTimeout(res, ms));
+}

--- a/extensions/amp-carousel/0.2/test-e2e/test-responsive-carousel.js
+++ b/extensions/amp-carousel/0.2/test-e2e/test-responsive-carousel.js
@@ -1,0 +1,56 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {getNextArrow, getSlides, sleep} from './helpers';
+
+describes.endtoend(
+  'AMP carousel 0.2 with layout responsive',
+  {
+    testUrl:
+      'http://localhost:8000/test/fixtures/e2e/amp-carousel/0.2/responsive.carousel.amp.html',
+    experiments: ['amp-carousel'],
+    environments: ['single'],
+  },
+  async function (env) {
+    let controller;
+
+    function rect(el) {
+      return controller.getElementRect(el);
+    }
+
+    beforeEach(async () => {
+      controller = env.controller;
+    });
+
+    it('layout properly and show images', async () => {
+      const slides = await getSlides(controller);
+      let slideRect = await rect(slides[0]);
+      const nextArrow = await getNextArrow(controller);
+
+      // Check the size of the image
+      await expect(slideRect['width']).to.be.greaterThan(0);
+      await expect(slideRect['height']).to.be.greaterThan(0);
+
+      await controller.click(nextArrow);
+      await sleep(1000);
+      slideRect = await rect(slides[1]);
+
+      // Check the size of the new image
+      await expect(slideRect['width']).to.be.greaterThan(0);
+      await expect(slideRect['height']).to.be.greaterThan(0);
+    });
+  }
+);

--- a/test/fixtures/e2e/amp-carousel/0.2/responsive.carousel.amp.html
+++ b/test/fixtures/e2e/amp-carousel/0.2/responsive.carousel.amp.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>Responsive Carousel</title>
+  <link rel="canonical" href="amps.html" >
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <link href='https://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css'>
+  <script async custom-element="amp-carousel" src="https://cdn.ampproject.org/v0/amp-carousel-0.2.js"></script>
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+</head>
+<body>
+  <main>
+    <amp-carousel width="412" height="309" layout="responsive" type="carousel">
+      <amp-img width="412" height="309" layout="responsive" src="../img/bluegradient.png">
+      </amp-img>
+      <amp-img width="412" height="309" layout="responsive" src="../img/redgradient.png">
+      </amp-img>
+      <amp-img width="412" height="309" layout="responsive" src="../img/greengradient.png">
+      </amp-img>
+    </amp-carousel> 
+  </main>
+</body>
+</html>


### PR DESCRIPTION
Closes  #31304

Without a set width on the slide element (for `type=carousel`), the spacer (that gets created by runtime for responsive elements) inside the <amp-img> slide will have a height and width set to 0x0. 

When the carousel lays out its children, runtime stops `<amp-img>` layoutCallback() from being called because it has 0 height and width (because spacer is not correctly inflating the element).

The fix is to add `width: 100%` to the slide child. 

Additionally, it doesn't make sense for the carousel to get styled as `position: static`, since the spacer for the carousel (when set to `layout=responsive type=carousel`) will take up the space that the carousel should occupy. 