### PR TITLE
viewportObserver: Fix case of quick observe and unobserve that both occur before the io callback

### DIFF
--- a/src/viewport-observer.js
+++ b/src/viewport-observer.js
@@ -92,6 +92,8 @@ function ioCallback(entries) {
   for (let i = 0; i < entries.length; i++) {
     const {isIntersecting, target} = entries[i];
     const viewportCallback = viewportCallbacks.get(target);
-    viewportCallback(isIntersecting);
+    if (viewportCallback) {
+      viewportCallback(isIntersecting);
+    }
   }
 }

--- a/test/unit/test-viewport-observer.js
+++ b/test/unit/test-viewport-observer.js
@@ -77,9 +77,7 @@ describes.sandboxed('Viewport Observer', {}, (env) => {
       const win = el.ownerDocument.defaultView;
       // Grabs the IO Callback shared by all the viewport observers.
       const ioCallback = win.IntersectionObserver.getCall(0).args[0];
-      if (tracked.has(el)) {
-        ioCallback([{target: el, isIntersecting: inViewport}]);
-      }
+      ioCallback([{target: el, isIntersecting: inViewport}]);
     }
 
     it('observed element should have its callback fired each time it enters/exist the viewport.', () => {
@@ -130,6 +128,15 @@ describes.sandboxed('Viewport Observer', {}, (env) => {
           'Assertion failed'
         );
       });
+    });
+
+    it('A quick observe and unobserve pair should not cause an error or fire the callback', () => {
+      const spy = env.sandbox.spy();
+      observeWithSharedInOb(el1, spy);
+      unobserveWithSharedInOb(el1);
+      toggleViewport(el1, true);
+
+      expect(spy).not.called;
     });
   });
 });


### PR DESCRIPTION
Should fix https://github.com/ampproject/error-reporting/issues/27