### PR TITLE
Remove the file extension for script tags in spec_names/messages

### DIFF
--- a/extensions/amp-ad-custom/validator-amp-ad-custom.protoascii
+++ b/extensions/amp-ad-custom/validator-amp-ad-custom.protoascii
@@ -16,6 +16,7 @@
 tags: {  # amp-ad-custom
   html_format: AMP  # AMP only as ads are not allowed inside AMP Ads
   tag_name: "SCRIPT"
+  spec_name: "amp-ad-custom extension script"
   extension_spec: {
     name: "amp-ad-custom"
     version: "0.1"

--- a/extensions/amp-ad-custom/validator-amp-ad-custom.protoascii
+++ b/extensions/amp-ad-custom/validator-amp-ad-custom.protoascii
@@ -16,7 +16,6 @@
 tags: {  # amp-ad-custom
   html_format: AMP  # AMP only as ads are not allowed inside AMP Ads
   tag_name: "SCRIPT"
-  spec_name: "amp-ad-custom extension script"
   extension_spec: {
     name: "amp-ad-custom"
     version: "0.1"

--- a/extensions/amp-ad/validator-amp-ad.protoascii
+++ b/extensions/amp-ad/validator-amp-ad.protoascii
@@ -33,7 +33,7 @@ tags: {  # amp-ad
   # Typically the extension_spec takes care of this, but we have
   # a unique situation where we need to refer to this earlier in
   # the rules processing for the also_requires_tag_warning below.
-  spec_name: "amp-ad extension .js script"
+  spec_name: "amp-ad extension script"
   extension_spec: {
     name: "amp-ad"
     version: "0.1"
@@ -47,7 +47,7 @@ tags: {  # <amp-ad>
   html_format: AMP  # Ads are not allowed inside ads
   tag_name: "AMP-AD"
   requires_extension: "amp-ad"  # See note at top of file
-  also_requires_tag_warning: "amp-ad extension .js script"
+  also_requires_tag_warning: "amp-ad extension script"
   # If modifying disallowed_ancestors, then please also edit
   # extensions/amp-auto-ads/*/placement.js
   disallowed_ancestor: "AMP-APP-BANNER"
@@ -83,7 +83,7 @@ tags: {  # <amp-ad type="custom">
   tag_name: "AMP-AD"
   spec_name: "amp-ad with type=custom"
   requires_extension: "amp-ad"  # See note at top of file
-  also_requires_tag_warning: "amp-ad extension .js script"
+  also_requires_tag_warning: "amp-ad extension script"
   # If modifying disallowed_ancestors, then please also edit
   # extensions/amp-auto-ads/*/placement.js
   disallowed_ancestor: "AMP-APP-BANNER"
@@ -119,7 +119,7 @@ tags: {  # <amp-ad data-multi-size>
   tag_name: "AMP-AD"
   spec_name: "amp-ad with data-multi-size attribute"
   requires_extension: "amp-ad"  # See note at top of file
-  also_requires_tag_warning: "amp-ad extension .js script"
+  also_requires_tag_warning: "amp-ad extension script"
   # If modifying disallowed_ancestors, then please also edit
   # extensions/amp-auto-ads/*/placement.js
   disallowed_ancestor: "AMP-APP-BANNER"
@@ -166,7 +166,7 @@ tags: {  # <amp-ad data-enable-refresh>
   tag_name: "AMP-AD"
   spec_name: "amp-ad with data-enable-refresh attribute"
   requires_extension: "amp-ad"  # See note at top of file
-  also_requires_tag_warning: "amp-ad extension .js script"
+  also_requires_tag_warning: "amp-ad extension script"
   # If modifying disallowed_ancestors, then please also edit
   # extensions/amp-auto-ads/*/placement.js
   disallowed_ancestor: "AMP-APP-BANNER"
@@ -209,7 +209,7 @@ tags: {  # <amp-embed>
   html_format: AMP
   tag_name: "AMP-EMBED"
   requires_extension: "amp-ad"  # See note at top of file
-  also_requires_tag_warning: "amp-ad extension .js script"
+  also_requires_tag_warning: "amp-ad extension script"
   disallowed_ancestor: "AMP-APP-BANNER"
   attrs: { name: "alt" }
   attrs: { name: "json" }
@@ -241,7 +241,7 @@ tags: {  # <amp-embed data-multi-size>
   tag_name: "AMP-EMBED"
   spec_name: "amp-embed with data-multi-size attribute"
   requires_extension: "amp-ad"  # See note at top of file
-  also_requires_tag_warning: "amp-ad extension .js script"
+  also_requires_tag_warning: "amp-ad extension script"
   disallowed_ancestor: "AMP-APP-BANNER"
   # amp-embed elements cannot be both children of an amp ad container and have
   # data-multi-size attribute.

--- a/extensions/amp-anim/validator-amp-anim.protoascii
+++ b/extensions/amp-anim/validator-amp-anim.protoascii
@@ -30,7 +30,7 @@ tags: {  # amp-anim
 tags: {  # amp-anim
   html_format: AMP4EMAIL
   tag_name: "SCRIPT"
-  spec_name: "amp-anim extension .js script (AMP4EMAIL)"
+  spec_name: "amp-anim extension script (AMP4EMAIL)"
   extension_spec: {
     name: "amp-anim"
     # AMP4EMAIL doesn't allow version: "latest".

--- a/extensions/amp-link-rewriter/0.1/test/validator-amp-link-rewriter-exclude.out
+++ b/extensions/amp-link-rewriter/0.1/test/validator-amp-link-rewriter-exclude.out
@@ -60,14 +60,14 @@ FAIL
 |  </body>
 |  </html>
 >>       ^~~~~~~~~
-amp-link-rewriter/0.1/test/validator-amp-link-rewriter-exclude.html:60:6 The tag 'amp-link-rewriter extension .js script' is present, but is excluded by the presence of 'amp-skimlinks'. (see https://amp.dev/documentation/components/amp-link-rewriter)
+amp-link-rewriter/0.1/test/validator-amp-link-rewriter-exclude.html:60:6 The tag 'amp-link-rewriter extension script' is present, but is excluded by the presence of 'amp-skimlinks'. (see https://amp.dev/documentation/components/amp-link-rewriter)
 >>       ^~~~~~~~~
-amp-link-rewriter/0.1/test/validator-amp-link-rewriter-exclude.html:60:6 The tag 'amp-link-rewriter extension .js script' is present, but is excluded by the presence of 'amp-smartlinks'. (see https://amp.dev/documentation/components/amp-link-rewriter)
+amp-link-rewriter/0.1/test/validator-amp-link-rewriter-exclude.html:60:6 The tag 'amp-link-rewriter extension script' is present, but is excluded by the presence of 'amp-smartlinks'. (see https://amp.dev/documentation/components/amp-link-rewriter)
 >>       ^~~~~~~~~
-amp-link-rewriter/0.1/test/validator-amp-link-rewriter-exclude.html:60:6 The tag 'amp-skimlinks extension .js script' is present, but is excluded by the presence of 'amp-link-rewriter'. (see https://amp.dev/documentation/components/amp-skimlinks)
+amp-link-rewriter/0.1/test/validator-amp-link-rewriter-exclude.html:60:6 The tag 'amp-skimlinks extension script' is present, but is excluded by the presence of 'amp-link-rewriter'. (see https://amp.dev/documentation/components/amp-skimlinks)
 >>       ^~~~~~~~~
-amp-link-rewriter/0.1/test/validator-amp-link-rewriter-exclude.html:60:6 The tag 'amp-skimlinks extension .js script' is present, but is excluded by the presence of 'amp-smartlinks'. (see https://amp.dev/documentation/components/amp-skimlinks)
+amp-link-rewriter/0.1/test/validator-amp-link-rewriter-exclude.html:60:6 The tag 'amp-skimlinks extension script' is present, but is excluded by the presence of 'amp-smartlinks'. (see https://amp.dev/documentation/components/amp-skimlinks)
 >>       ^~~~~~~~~
-amp-link-rewriter/0.1/test/validator-amp-link-rewriter-exclude.html:60:6 The tag 'amp-smartlinks extension .js script' is present, but is excluded by the presence of 'amp-link-rewriter'. (see https://amp.dev/documentation/components/amp-smartlinks)
+amp-link-rewriter/0.1/test/validator-amp-link-rewriter-exclude.html:60:6 The tag 'amp-smartlinks extension script' is present, but is excluded by the presence of 'amp-link-rewriter'. (see https://amp.dev/documentation/components/amp-smartlinks)
 >>       ^~~~~~~~~
-amp-link-rewriter/0.1/test/validator-amp-link-rewriter-exclude.html:60:6 The tag 'amp-smartlinks extension .js script' is present, but is excluded by the presence of 'amp-skimlinks'. (see https://amp.dev/documentation/components/amp-smartlinks)
+amp-link-rewriter/0.1/test/validator-amp-link-rewriter-exclude.html:60:6 The tag 'amp-smartlinks extension script' is present, but is excluded by the presence of 'amp-skimlinks'. (see https://amp.dev/documentation/components/amp-smartlinks)

--- a/extensions/amp-mraid/0.1/test/validator-amp4ads-amp-mraid-no-fallback-typo.out
+++ b/extensions/amp-mraid/0.1/test/validator-amp4ads-amp-mraid-no-fallback-typo.out
@@ -25,7 +25,7 @@ FAIL
 |    <!-- Invalid: no-falback is a typo for no-fallback. -->
 |    <script async host-service="amp-mraid" src="https://cdn.ampproject.org/v0/amp-mraid-0.1.js" no-falback></script>
 >>   ^~~~~~~~~
-amp-mraid/0.1/test/validator-amp4ads-amp-mraid-no-fallback-typo.html:25:2 The attribute 'no-falback' may not appear in tag 'amp-mraid extension .js script'. (see https://amp.dev/documentation/components/amp-mraid)
+amp-mraid/0.1/test/validator-amp4ads-amp-mraid-no-fallback-typo.html:25:2 The attribute 'no-falback' may not appear in tag 'amp-mraid extension script'. (see https://amp.dev/documentation/components/amp-mraid)
 |    <script async src="https://cdn.ampproject.org/amp4ads-v0.js"></script>
 |  </head>
 |  <body>

--- a/extensions/amp-mustache/0.1/test/validator-amp-mustache-version.out
+++ b/extensions/amp-mustache/0.1/test/validator-amp-mustache-version.out
@@ -31,7 +31,7 @@ PASS
 amp-mustache/0.1/test/validator-amp-mustache-version.html:28:2 The extension 'amp-mustache' is referenced at version '0.1' which is a deprecated version. Please use a more recent version of this extension. This may become an error in the future. (see https://amp.dev/documentation/components/amp-mustache)
 |    <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-latest.js"></script>
 >>   ^~~~~~~~~
-amp-mustache/0.1/test/validator-amp-mustache-version.html:29:2 The tag 'amp-mustache extension .js script' appears more than once in the document. This will soon be an error. (see https://amp.dev/documentation/components/amp-mustache)
+amp-mustache/0.1/test/validator-amp-mustache-version.html:29:2 The tag 'amp-mustache extension script' appears more than once in the document. This will soon be an error. (see https://amp.dev/documentation/components/amp-mustache)
 |  </head>
 |  <body>
 |  </body>

--- a/extensions/amp-mustache/0.2/test/validator-amp-mustache-version.out
+++ b/extensions/amp-mustache/0.2/test/validator-amp-mustache-version.out
@@ -29,7 +29,7 @@ PASS
 |    <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.2.js"></script>
 |    <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-latest.js"></script>
 >>   ^~~~~~~~~
-amp-mustache/0.2/test/validator-amp-mustache-version.html:29:2 The tag 'amp-mustache extension .js script' appears more than once in the document. This will soon be an error. (see https://amp.dev/documentation/components/amp-mustache)
+amp-mustache/0.2/test/validator-amp-mustache-version.html:29:2 The tag 'amp-mustache extension script' appears more than once in the document. This will soon be an error. (see https://amp.dev/documentation/components/amp-mustache)
 |  </head>
 |  <body>
 |  </body>

--- a/extensions/amp-sticky-ad/0.1/test/validator-amp-sticky-ad.out
+++ b/extensions/amp-sticky-ad/0.1/test/validator-amp-sticky-ad.out
@@ -42,4 +42,4 @@ amp-sticky-ad/0.1/test/validator-amp-sticky-ad.html:28:2 The extension 'amp-stic
 |  </body>
 |  </html>
 >>       ^~~~~~~~~
-amp-sticky-ad/0.1/test/validator-amp-sticky-ad.html:40:6 The tag 'amp-ad extension .js script' is missing or incorrect, but required by 'amp-ad'. This will soon be an error. (see https://amp.dev/documentation/components/amp-ad/)
+amp-sticky-ad/0.1/test/validator-amp-sticky-ad.html:40:6 The tag 'amp-ad extension script' is missing or incorrect, but required by 'amp-ad'. This will soon be an error. (see https://amp.dev/documentation/components/amp-ad/)

--- a/extensions/amp-sticky-ad/1.0/test/validator-amp-sticky-ad.out
+++ b/extensions/amp-sticky-ad/1.0/test/validator-amp-sticky-ad.out
@@ -40,4 +40,4 @@ PASS
 |  </body>
 |  </html>
 >>       ^~~~~~~~~
-amp-sticky-ad/1.0/test/validator-amp-sticky-ad.html:40:6 The tag 'amp-ad extension .js script' is missing or incorrect, but required by 'amp-ad'. This will soon be an error. (see https://amp.dev/documentation/components/amp-ad/)
+amp-sticky-ad/1.0/test/validator-amp-sticky-ad.html:40:6 The tag 'amp-ad extension script' is missing or incorrect, but required by 'amp-ad'. This will soon be an error. (see https://amp.dev/documentation/components/amp-ad/)

--- a/extensions/amp-story/1.0/test/validator-amp-story-deprecated.out
+++ b/extensions/amp-story/1.0/test/validator-amp-story-deprecated.out
@@ -29,7 +29,7 @@ FAIL
 |    <script async src="https://cdn.ampproject.org/v0.js"></script>
 |    <script async custom-element="amp-story" src="https://cdn.ampproject.org/v0/amp-story-0.1.js"></script>
 >>   ^~~~~~~~~
-amp-story/1.0/test/validator-amp-story-deprecated.html:29:2 The attribute 'src' in tag 'amp-story extension .js script' is set to the invalid value 'https://cdn.ampproject.org/v0/amp-story-0.1.js'. (see https://amp.dev/documentation/components/amp-story)
+amp-story/1.0/test/validator-amp-story-deprecated.html:29:2 The attribute 'src' in tag 'amp-story extension script' is set to the invalid value 'https://cdn.ampproject.org/v0/amp-story-0.1.js'. (see https://amp.dev/documentation/components/amp-story)
 |  </head>
 |  <body>
 |    <amp-story standalone bookend-config-src="./bookend-config-src.json" background-audio="path/to/my.mp3">

--- a/extensions/amp-video/validator-amp-video.protoascii
+++ b/extensions/amp-video/validator-amp-video.protoascii
@@ -21,7 +21,7 @@ tags: {  # amp-video
   # Typically the extension_spec takes care of this, but we have
   # a unique situation where we need to refer to this earlier in
   # the rules processing for the also_requires_tag_warning below.
-  spec_name: "amp-video extension .js script"
+  spec_name: "amp-video extension script"
   extension_spec: {
     name: "amp-video"
     version: "0.1"
@@ -114,7 +114,7 @@ tags: {  # <amp-video> not in amp-story.
   # Typically we'd require the extension j/s, but for historical reasons
   # many pages don't have it, so it ends up late loaded and we warn, instead
   # of making this a validation error.
-  also_requires_tag_warning: "amp-video extension .js script"
+  also_requires_tag_warning: "amp-video extension script"
   attrs: { name: "poster" }
   attr_lists: "extended-amp-global"
   attr_lists: "amp-video-common"
@@ -125,7 +125,6 @@ tags: {  # <amp-video> not in amp-story.
     supported_layouts: FIXED
     supported_layouts: FIXED_HEIGHT
     supported_layouts: FLEX_ITEM
-    supported_layouts: INTRINSIC
     supported_layouts: NODISPLAY
     supported_layouts: RESPONSIVE
   }
@@ -137,7 +136,7 @@ tags: {  # <amp-video> in amp-story-page-attachment (same rules as regular AMPHT
   tag_name: "AMP-VIDEO"
   spec_name: "amp-story >> amp-story-page-attachment >> amp-video"
   mandatory_ancestor: "AMP-STORY-PAGE-ATTACHMENT"
-  also_requires_tag_warning: "amp-video extension .js script"
+  also_requires_tag_warning: "amp-video extension script"
   attrs: { name: "poster" }
   attr_lists: "extended-amp-global"
   attr_lists: "amp-video-common"
@@ -148,7 +147,6 @@ tags: {  # <amp-video> in amp-story-page-attachment (same rules as regular AMPHT
     supported_layouts: FIXED
     supported_layouts: FIXED_HEIGHT
     supported_layouts: FLEX_ITEM
-    supported_layouts: INTRINSIC
     supported_layouts: NODISPLAY
     supported_layouts: RESPONSIVE
   }

--- a/extensions/amp-video/validator-amp-video.protoascii
+++ b/extensions/amp-video/validator-amp-video.protoascii
@@ -21,6 +21,7 @@ tags: {  # amp-video
   # Typically the extension_spec takes care of this, but we have
   # a unique situation where we need to refer to this earlier in
   # the rules processing for the also_requires_tag_warning below.
+  spec_name: "amp-video extension script"
   extension_spec: {
     name: "amp-video"
     version: "0.1"

--- a/extensions/amp-video/validator-amp-video.protoascii
+++ b/extensions/amp-video/validator-amp-video.protoascii
@@ -21,7 +21,6 @@ tags: {  # amp-video
   # Typically the extension_spec takes care of this, but we have
   # a unique situation where we need to refer to this earlier in
   # the rules processing for the also_requires_tag_warning below.
-  spec_name: "amp-video extension script"
   extension_spec: {
     name: "amp-video"
     version: "0.1"

--- a/validator/js/engine/validator.js
+++ b/validator/js/engine/validator.js
@@ -5940,7 +5940,7 @@ class ParsedValidatorRules {
         if (tagSpec.extensionSpec == null) continue;
         if (tagSpec.specName === null)
           tagSpec.specName =
-              tagSpec.extensionSpec.name + ' extension .js script';
+              tagSpec.extensionSpec.name + ' extension script';
         if (tagSpec.descriptiveName === null)
           tagSpec.descriptiveName = tagSpec.specName;
         tagSpec.mandatoryParent = 'HEAD';

--- a/validator/js/engine/validator_test.js
+++ b/validator/js/engine/validator_test.js
@@ -1492,7 +1492,7 @@ describe('ValidatorRulesMakeSense', () => {
         expect(specNameIsUnique.hasOwnProperty(tagSpec.specName)).toBe(false);
         specNameIsUnique[tagSpec.specName] = 0;
       } else if (tagSpec.extensionSpec !== null) {
-        const specName = tagSpec.extensionSpec.name + ' extension .js script';
+        const specName = tagSpec.extensionSpec.name + ' extension script';
 
         expect(specNameIsUnique.hasOwnProperty(specName)).toBe(false);
         specNameIsUnique[specName] = 0;

--- a/validator/testdata/amp4email_feature_tests/amp_img.out
+++ b/validator/testdata/amp4email_feature_tests/amp_img.out
@@ -26,7 +26,7 @@ FAIL
 |    <script async src="https://cdn.ampproject.org/v0.js"></script>
 |    <script async custom-element="amp-anim" src="https://cdn.ampproject.org/v0/amp-form-0.1.js"></script>
 >>   ^~~~~~~~~
-amp4email_feature_tests/amp_img.html:26:2 The attribute 'src' in tag 'amp-anim extension .js script (AMP4EMAIL)' is set to the invalid value 'https://cdn.ampproject.org/v0/amp-form-0.1.js'. (see https://amp.dev/documentation/components/amp-anim)
+amp4email_feature_tests/amp_img.html:26:2 The attribute 'src' in tag 'amp-anim extension script (AMP4EMAIL)' is set to the invalid value 'https://cdn.ampproject.org/v0/amp-form-0.1.js'. (see https://amp.dev/documentation/components/amp-anim)
 |    <script async custom-template="amp-mustache"
 |        src="https://cdn.ampproject.org/v0/amp-mustache-0.2.js"></script>
 |  </head>

--- a/validator/testdata/amp4email_feature_tests/no_latest_extensions.out
+++ b/validator/testdata/amp4email_feature_tests/no_latest_extensions.out
@@ -29,7 +29,7 @@ FAIL
 amp4email_feature_tests/no_latest_extensions.html:26:2 The attribute 'src' in tag 'SCRIPT[custom-element=amp-accordion] (AMP4EMAIL)' is set to the invalid value 'https://cdn.ampproject.org/v0/amp-accordion-latest.js'. (see https://amp.dev/documentation/components/amp-accordion)
 |    <script async custom-element="amp-anim" src="https://cdn.ampproject.org/v0/amp-anim-latest.js"></script>
 >>   ^~~~~~~~~
-amp4email_feature_tests/no_latest_extensions.html:27:2 The attribute 'src' in tag 'amp-anim extension .js script (AMP4EMAIL)' is set to the invalid value 'https://cdn.ampproject.org/v0/amp-anim-latest.js'. (see https://amp.dev/documentation/components/amp-anim)
+amp4email_feature_tests/no_latest_extensions.html:27:2 The attribute 'src' in tag 'amp-anim extension script (AMP4EMAIL)' is set to the invalid value 'https://cdn.ampproject.org/v0/amp-anim-latest.js'. (see https://amp.dev/documentation/components/amp-anim)
 |    <script async custom-element="amp-bind" src="https://cdn.ampproject.org/v0/amp-bind-latest.js"></script>
 >>   ^~~~~~~~~
 amp4email_feature_tests/no_latest_extensions.html:28:2 The attribute 'src' in tag 'SCRIPT[custom-element=amp-bind] (AMP4EMAIL)' is set to the invalid value 'https://cdn.ampproject.org/v0/amp-bind-latest.js'. (see https://amp.dev/documentation/components/amp-bind)

--- a/validator/testdata/amp4email_feature_tests/nonce_disallowed.out
+++ b/validator/testdata/amp4email_feature_tests/nonce_disallowed.out
@@ -26,7 +26,7 @@ FAIL
 |    <style amp4email-boilerplate>body{visibility:hidden}</style>
 |    <script async src="https://cdn.ampproject.org/v0.js" nonce="disallowed"></script>
 >>   ^~~~~~~~~
-amp4email_feature_tests/nonce_disallowed.html:26:2 The attribute 'nonce' may not appear in tag 'amphtml engine v0.js script'. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#required-markup)
+amp4email_feature_tests/nonce_disallowed.html:26:2 The attribute 'nonce' may not appear in tag 'amphtml engine script'. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#required-markup)
 |  </head>
 |  <body>
 |  Hello, world.

--- a/validator/testdata/feature_tests/article.out
+++ b/validator/testdata/feature_tests/article.out
@@ -500,4 +500,4 @@ feature_tests/article.html:287:2 The tag 'content' is disallowed.
 |  </body>
 |  </html>
 >>       ^~~~~~~~~
-feature_tests/article.html:498:6 The tag 'amp-video extension .js script' is missing or incorrect, but required by 'amp-video'. This will soon be an error. (see https://amp.dev/documentation/components/amp-video/)
+feature_tests/article.html:498:6 The tag 'amp-video extension script' is missing or incorrect, but required by 'amp-video'. This will soon be an error. (see https://amp.dev/documentation/components/amp-video/)

--- a/validator/testdata/feature_tests/custom_element_case.out
+++ b/validator/testdata/feature_tests/custom_element_case.out
@@ -30,7 +30,7 @@ FAIL
 |    <!-- Invalid: custom-element value is case-sensitive -->
 |    <script async custom-element='Amp-Analytics'
 >>   ^~~~~~~~~
-feature_tests/custom_element_case.html:30:2 The attribute 'custom-element' may not appear in tag 'amp-analytics extension .js script'. (see https://amp.dev/documentation/components/amp-analytics)
+feature_tests/custom_element_case.html:30:2 The attribute 'custom-element' may not appear in tag 'amp-analytics extension script'. (see https://amp.dev/documentation/components/amp-analytics)
 |       src='https://cdn.ampproject.org/v0/amp-analytics-0.1.js'></script>
 |
 |  </runhead>

--- a/validator/testdata/feature_tests/duplicate_attribute.out.cpponly
+++ b/validator/testdata/feature_tests/duplicate_attribute.out.cpponly
@@ -35,7 +35,7 @@ feature_tests/duplicate_attribute.html:30:2 The tag 'script' contains the attrib
 >>   ^~~~~~~~~
 feature_tests/duplicate_attribute.html:31:2 The tag 'script' contains the attribute 'custom-element' repeated multiple times.
 >>   ^~~~~~~~~
-feature_tests/duplicate_attribute.html:31:2 The attribute 'custom-element' may not appear in tag 'amp-youtube extension .js script'. (see https://amp.dev/documentation/components/amp-youtube)
+feature_tests/duplicate_attribute.html:31:2 The attribute 'custom-element' may not appear in tag 'amp-youtube extension script'. (see https://amp.dev/documentation/components/amp-youtube)
 |
 |  </head>
 |  <body>

--- a/validator/testdata/feature_tests/empty.out
+++ b/validator/testdata/feature_tests/empty.out
@@ -21,4 +21,4 @@ feature_tests/empty.html:1:0 The mandatory tag 'head > style[amp-boilerplate]' i
 >> ^~~~~~~~~
 feature_tests/empty.html:1:0 The mandatory tag 'noscript > style[amp-boilerplate]' is missing or incorrect. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amp-boilerplate/?format=websites)
 >> ^~~~~~~~~
-feature_tests/empty.html:1:0 The mandatory tag 'amphtml engine v0.js script' is missing or incorrect. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#required-markup)
+feature_tests/empty.html:1:0 The mandatory tag 'amphtml engine script' is missing or incorrect. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#required-markup)

--- a/validator/testdata/feature_tests/empty.out.cpponly
+++ b/validator/testdata/feature_tests/empty.out.cpponly
@@ -21,4 +21,4 @@ feature_tests/empty.html:1:0 The mandatory tag 'head > style[amp-boilerplate]' i
 >> ^~~~~~~~~
 feature_tests/empty.html:1:0 The mandatory tag 'noscript > style[amp-boilerplate]' is missing or incorrect. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amp-boilerplate/?format=websites)
 >> ^~~~~~~~~
-feature_tests/empty.html:1:0 The mandatory tag 'amphtml engine v0.js script' is missing or incorrect. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#required-markup)
+feature_tests/empty.html:1:0 The mandatory tag 'amphtml engine script' is missing or incorrect. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#required-markup)

--- a/validator/testdata/feature_tests/mandatory_dimensions.out
+++ b/validator/testdata/feature_tests/mandatory_dimensions.out
@@ -248,6 +248,6 @@ feature_tests/mandatory_dimensions.html:146:4 The attribute 'foo' may not appear
 |  </body>
 |  </html>
 >>       ^~~~~~~~~
-feature_tests/mandatory_dimensions.html:150:6 The tag 'amp-ad extension .js script' is missing or incorrect, but required by 'amp-ad'. This will soon be an error. (see https://amp.dev/documentation/components/amp-ad/)
+feature_tests/mandatory_dimensions.html:150:6 The tag 'amp-ad extension script' is missing or incorrect, but required by 'amp-ad'. This will soon be an error. (see https://amp.dev/documentation/components/amp-ad/)
 >>       ^~~~~~~~~
-feature_tests/mandatory_dimensions.html:150:6 The tag 'amp-video extension .js script' is missing or incorrect, but required by 'amp-video'. This will soon be an error. (see https://amp.dev/documentation/components/amp-video/)
+feature_tests/mandatory_dimensions.html:150:6 The tag 'amp-video extension script' is missing or incorrect, but required by 'amp-video'. This will soon be an error. (see https://amp.dev/documentation/components/amp-video/)

--- a/validator/testdata/feature_tests/manufactured_body_whitespace.out.cpponly
+++ b/validator/testdata/feature_tests/manufactured_body_whitespace.out.cpponly
@@ -37,7 +37,7 @@ feature_tests/manufactured_body_whitespace.html:28:2 The parent tag of tag 'styl
 feature_tests/manufactured_body_whitespace.html:28:641 The tag 'noscript > style[amp-boilerplate]' may only appear as a descendant of tag 'head'. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amp-boilerplate/?format=websites)
 |    <script async src="https://cdn.ampproject.org/v0.js"></script>
 >>   ^~~~~~~~~
-feature_tests/manufactured_body_whitespace.html:29:2 The parent tag of tag 'amphtml engine v0.js script' is 'body', but it can only be 'head'. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#required-markup)
+feature_tests/manufactured_body_whitespace.html:29:2 The parent tag of tag 'amphtml engine script' is 'body', but it can only be 'head'. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#required-markup)
 |  </head>
 |  <body>
 |  Hello, world.

--- a/validator/testdata/feature_tests/multiple_body_tags_3.out
+++ b/validator/testdata/feature_tests/multiple_body_tags_3.out
@@ -42,7 +42,7 @@ feature_tests/multiple_body_tags_3.html:33:2 The parent tag of tag 'style amp-cu
 feature_tests/multiple_body_tags_3.html:33:641 The tag 'noscript > style[amp-boilerplate]' may only appear as a descendant of tag 'head'. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amp-boilerplate/?format=websites)
 |    <script async src="https://cdn.ampproject.org/v0.js"></script>
 >>   ^~~~~~~~~
-feature_tests/multiple_body_tags_3.html:34:2 The parent tag of tag 'amphtml engine v0.js script' is 'body', but it can only be 'head'. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#required-markup)
+feature_tests/multiple_body_tags_3.html:34:2 The parent tag of tag 'amphtml engine script' is 'body', but it can only be 'head'. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#required-markup)
 |  </head>
 |  <body class="foo">
 |    <!-- You might think there's only one body in this doc, but this is

--- a/validator/testdata/feature_tests/multiple_body_tags_3.out.cpponly
+++ b/validator/testdata/feature_tests/multiple_body_tags_3.out.cpponly
@@ -40,7 +40,7 @@ feature_tests/multiple_body_tags_3.html:33:2 The parent tag of tag 'style amp-cu
 feature_tests/multiple_body_tags_3.html:33:641 The tag 'noscript > style[amp-boilerplate]' may only appear as a descendant of tag 'head'. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amp-boilerplate/?format=websites)
 |    <script async src="https://cdn.ampproject.org/v0.js"></script>
 >>   ^~~~~~~~~
-feature_tests/multiple_body_tags_3.html:34:2 The parent tag of tag 'amphtml engine v0.js script' is 'body', but it can only be 'head'. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#required-markup)
+feature_tests/multiple_body_tags_3.html:34:2 The parent tag of tag 'amphtml engine script' is 'body', but it can only be 'head'. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#required-markup)
 |  </head>
 |  <body class="foo">
 |    <!-- You might think there's only one body in this doc, but this is

--- a/validator/testdata/feature_tests/not_amp.out
+++ b/validator/testdata/feature_tests/not_amp.out
@@ -40,4 +40,4 @@ feature_tests/not_amp.html:28:6 The mandatory tag 'head > style[amp-boilerplate]
 >>       ^~~~~~~~~
 feature_tests/not_amp.html:28:6 The mandatory tag 'noscript > style[amp-boilerplate]' is missing or incorrect. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amp-boilerplate/?format=websites)
 >>       ^~~~~~~~~
-feature_tests/not_amp.html:28:6 The mandatory tag 'amphtml engine v0.js script' is missing or incorrect. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#required-markup)
+feature_tests/not_amp.html:28:6 The mandatory tag 'amphtml engine script' is missing or incorrect. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#required-markup)

--- a/validator/testdata/feature_tests/regexps.out
+++ b/validator/testdata/feature_tests/regexps.out
@@ -38,13 +38,13 @@ feature_tests/regexps.html:27:2 The mandatory attribute 'amp-custom' is missing 
 |    <script async custom-element="amp-vine" src="https://cdn.ampproject.org/v0/amp-vine-latest.js"> </script>
 |    <script async custom-element="amp-vine" src="https://cdn.ampproject.org/v0/amp-vine-0.1.js?foobar"></script>
 >>   ^~~~~~~~~
-feature_tests/regexps.html:36:2 The attribute 'src' in tag 'amp-vine extension .js script' is set to the invalid value 'https://cdn.ampproject.org/v0/amp-vine-0.1.js?foobar'. (see https://amp.dev/documentation/components/amp-vine)
+feature_tests/regexps.html:36:2 The attribute 'src' in tag 'amp-vine extension script' is set to the invalid value 'https://cdn.ampproject.org/v0/amp-vine-0.1.js?foobar'. (see https://amp.dev/documentation/components/amp-vine)
 |    <script async custom-element="amp-vine" src="http://xss.com/https://cdn.ampproject.org/v0/amp-vine-0.1.js?foobar"></script>
 >>   ^~~~~~~~~
-feature_tests/regexps.html:37:2 The attribute 'src' in tag 'amp-vine extension .js script' is set to the invalid value 'http://xss.com/https://cdn.ampproject.org/v0/amp-vine-0.1.js?foobar'. (see https://amp.dev/documentation/components/amp-vine)
+feature_tests/regexps.html:37:2 The attribute 'src' in tag 'amp-vine extension script' is set to the invalid value 'http://xss.com/https://cdn.ampproject.org/v0/amp-vine-0.1.js?foobar'. (see https://amp.dev/documentation/components/amp-vine)
 |    <script async custom-element="amp-hulu" src="https://cdn.ampproject.org/v0/amp-hulu-latest.js"> Only whitespace is allowed here. </script>
 >>   ^~~~~~~~~
-feature_tests/regexps.html:38:2 The tag 'amp-hulu extension .js script' contains text, which is disallowed. (see https://amp.dev/documentation/components/amp-hulu)
+feature_tests/regexps.html:38:2 The tag 'amp-hulu extension script' contains text, which is disallowed. (see https://amp.dev/documentation/components/amp-hulu)
 |
 |    <!--
 |    href value_regex: "https://cdn\\.materialdesignicons\\.com/([0-9]+\\.?)+/css/materialdesignicons\\.min\\.css"

--- a/validator/testdata/feature_tests/runtime_in_body.out
+++ b/validator/testdata/feature_tests/runtime_in_body.out
@@ -40,7 +40,7 @@ FAIL
 |
 |    <script async src="https://cdn.ampproject.org/v0.js"></script>
 >>   ^~~~~~~~~
-feature_tests/runtime_in_body.html:40:2 The parent tag of tag 'amphtml engine v0.js script' is 'body', but it can only be 'head'. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#required-markup)
+feature_tests/runtime_in_body.html:40:2 The parent tag of tag 'amphtml engine script' is 'body', but it can only be 'head'. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#required-markup)
 |
 |  </body>
 |  </html>

--- a/validator/testdata/feature_tests/several_errors.out
+++ b/validator/testdata/feature_tests/several_errors.out
@@ -57,6 +57,6 @@ feature_tests/several_errors.html:40:2 The attribute 'height' in tag 'amp-ad' is
 >>       ^~~~~~~~~
 feature_tests/several_errors.html:43:6 The mandatory tag 'meta name=viewport' is missing or incorrect. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#required-markup)
 >>       ^~~~~~~~~
-feature_tests/several_errors.html:43:6 The tag 'amp-ad extension .js script' is missing or incorrect, but required by 'amp-ad'. This will soon be an error. (see https://amp.dev/documentation/components/amp-ad/)
+feature_tests/several_errors.html:43:6 The tag 'amp-ad extension script' is missing or incorrect, but required by 'amp-ad'. This will soon be an error. (see https://amp.dev/documentation/components/amp-ad/)
 >>       ^~~~~~~~~
-feature_tests/several_errors.html:43:6 The mandatory tag 'amphtml engine v0.js script' is missing or incorrect. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#required-markup)
+feature_tests/several_errors.html:43:6 The mandatory tag 'amphtml engine script' is missing or incorrect. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#required-markup)

--- a/validator/testdata/feature_tests/spec_example.out
+++ b/validator/testdata/feature_tests/spec_example.out
@@ -59,4 +59,4 @@ PASS
 |    </body>
 |  </html>
 >>       ^~~~~~~~~
-feature_tests/spec_example.html:59:6 The tag 'amp-ad extension .js script' is missing or incorrect, but required by 'amp-ad'. This will soon be an error. (see https://amp.dev/documentation/components/amp-ad/)
+feature_tests/spec_example.html:59:6 The tag 'amp-ad extension script' is missing or incorrect, but required by 'amp-ad'. This will soon be an error. (see https://amp.dev/documentation/components/amp-ad/)

--- a/validator/testdata/feature_tests/track_tag.out
+++ b/validator/testdata/feature_tests/track_tag.out
@@ -73,4 +73,4 @@ feature_tests/track_tag.html:59:4 The mandatory attribute 'srclang' is missing i
 |  </body>
 |  </html>
 >>       ^~~~~~~~~
-feature_tests/track_tag.html:63:6 The tag 'amp-video extension .js script' is missing or incorrect, but required by 'amp-video'. This will soon be an error. (see https://amp.dev/documentation/components/amp-video/)
+feature_tests/track_tag.html:63:6 The tag 'amp-video extension script' is missing or incorrect, but required by 'amp-video'. This will soon be an error. (see https://amp.dev/documentation/components/amp-video/)

--- a/validator/testdata/feature_tests/unprintable_chars.out
+++ b/validator/testdata/feature_tests/unprintable_chars.out
@@ -54,7 +54,7 @@ feature_tests/unprintable_chars.html:35:2 The parent tag of tag 'style amp-custo
 feature_tests/unprintable_chars.html:35:641 The tag 'noscript > style[amp-boilerplate]' may only appear as a descendant of tag 'head'. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amp-boilerplate/?format=websites)
 |    <script async src="https://cdn.ampproject.org/v0.js"></script>
 >>   ^~~~~~~~~
-feature_tests/unprintable_chars.html:36:2 The parent tag of tag 'amphtml engine v0.js script' is 'body', but it can only be 'head'. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#required-markup)
+feature_tests/unprintable_chars.html:36:2 The parent tag of tag 'amphtml engine script' is 'body', but it can only be 'head'. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#required-markup)
 |  </head>
 |  <body data-foo>
 |  Hello, world.

--- a/validator/testdata/feature_tests/unprintable_chars.out.cpponly
+++ b/validator/testdata/feature_tests/unprintable_chars.out.cpponly
@@ -50,7 +50,7 @@ feature_tests/unprintable_chars.html:35:2 The parent tag of tag 'style amp-custo
 feature_tests/unprintable_chars.html:35:641 The tag 'noscript > style[amp-boilerplate]' may only appear as a descendant of tag 'head'. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amp-boilerplate/?format=websites)
 |    <script async src="https://cdn.ampproject.org/v0.js"></script>
 >>   ^~~~~~~~~
-feature_tests/unprintable_chars.html:36:2 The parent tag of tag 'amphtml engine v0.js script' is 'body', but it can only be 'head'. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#required-markup)
+feature_tests/unprintable_chars.html:36:2 The parent tag of tag 'amphtml engine script' is 'body', but it can only be 'head'. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#required-markup)
 |  </head>
 |  <body data-foo>
 |  Hello, world.

--- a/validator/testdata/feature_tests/urls.out
+++ b/validator/testdata/feature_tests/urls.out
@@ -217,6 +217,6 @@ feature_tests/urls.html:114:2 The attribute 'src' in tag 'amp-video' is set to t
 |  </body>
 |  </html>
 >>       ^~~~~~~~~
-feature_tests/urls.html:117:6 The tag 'amp-ad extension .js script' is missing or incorrect, but required by 'amp-ad'. This will soon be an error. (see https://amp.dev/documentation/components/amp-ad/)
+feature_tests/urls.html:117:6 The tag 'amp-ad extension script' is missing or incorrect, but required by 'amp-ad'. This will soon be an error. (see https://amp.dev/documentation/components/amp-ad/)
 >>       ^~~~~~~~~
-feature_tests/urls.html:117:6 The tag 'amp-video extension .js script' is missing or incorrect, but required by 'amp-video'. This will soon be an error. (see https://amp.dev/documentation/components/amp-video/)
+feature_tests/urls.html:117:6 The tag 'amp-video extension script' is missing or incorrect, but required by 'amp-video'. This will soon be an error. (see https://amp.dev/documentation/components/amp-video/)

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -3835,7 +3835,7 @@ tags: {
 # Note that the type TEXT/PLAIN description is define in
 # validator-amp-mustache.protoascii.
 
-# The three tagspecs below all handle the runtime engine v0.js script. They
+# The three tagspecs below all handle the runtime engine script. They
 # enforce that exactly one runtime script must be included. This tagspec is
 # for the standard runtime, while the one below it is an identical spec but for
 # the LTS runtime, with the only difference being the src attribute. The third
@@ -3859,9 +3859,9 @@ attr_lists: {
 tags: {
   html_format: AMP
   tag_name: "SCRIPT"
-  spec_name: "amphtml engine v0.js script"
-  descriptive_name: "amphtml engine v0.js script"
-  mandatory_alternatives: "amphtml engine v0.js script"
+  spec_name: "amphtml engine script"
+  descriptive_name: "amphtml engine script"
+  mandatory_alternatives: "amphtml engine script"
   unique: true
   mandatory_parent: "HEAD"
   attr_lists: "nonce-attr"
@@ -3883,9 +3883,9 @@ tags: {
 tags: {
   html_format: AMP
   tag_name: "SCRIPT"
-  spec_name: "amphtml engine v0.js lts script"
-  descriptive_name: "amphtml engine v0.js script"
-  mandatory_alternatives: "amphtml engine v0.js script"
+  spec_name: "amphtml engine lts script"
+  descriptive_name: "amphtml engine script"
+  mandatory_alternatives: "amphtml engine script"
   unique: true
   mandatory_parent: "HEAD"
   attr_lists: "nonce-attr"
@@ -3907,8 +3907,8 @@ tags: {
 tags: {
   html_format: AMP4EMAIL
   tag_name: "SCRIPT"
-  spec_name: "amphtml engine v0.js script [AMP4EMAIL]"
-  descriptive_name: "amphtml engine v0.js script"
+  spec_name: "amphtml engine script [AMP4EMAIL]"
+  descriptive_name: "amphtml engine script"
   mandatory: true
   unique: true
   mandatory_parent: "HEAD"
@@ -3931,8 +3931,8 @@ tags: {
 tags: {
   html_format: AMP4ADS
   tag_name: "SCRIPT"
-  spec_name: "amp4ads engine amp4ads-v0.js script"
-  descriptive_name: "amphtml engine amp4ads-v0.js script"
+  spec_name: "amp4ads engine script"
+  descriptive_name: "amphtml engine script"
   mandatory: true
   unique: true
   mandatory_parent: "HEAD"


### PR DESCRIPTION
Incorporates cl/339147096.

This changes:

`amp-extname extension .js script` to `amp-extname extension script`
`amphtml engine v0.js script` to `amphtml engine script`