### PR TITLE
resources-impl: fix resize event race condition.

### DIFF
--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -262,16 +262,14 @@ export class ResourcesImpl {
         this.maybeChangeHeight_ = true;
       }
 
-      // With IntersectionObserver, we only need to handle viewport resize.
-      if (this.relayoutAll_ || !this.intersectionObserver_) {
-        this.schedulePass();
-      }
       // Unfortunately, a viewport size change invalidates all premeasurements.
       if (this.relayoutAll_ && this.intersectionObserver_) {
         this.resources_.forEach((resource) =>
           resource.invalidatePremeasurementAndRequestMeasure()
         );
       }
+
+      this.schedulePass();
     });
     this.viewport_.onScroll(() => {
       this.lastScrollTime_ = Date.now();

--- a/test/unit/test-resources.js
+++ b/test/unit/test-resources.js
@@ -746,6 +746,12 @@ describes.realWin('Resources discoverWork', {amp: true}, (env) => {
       expect(resource1.isMeasureRequested()).true;
     });
 
+    it('should schedule a pass after resize event', () => {
+      const schedulePassStub = sandbox.stub(resources, 'schedulePass');
+      resources.viewport_.changeObservable_.fire({relayoutAll_: false});
+      expect(schedulePassStub).calledOnce;
+    });
+
     it('should applySizesAndMediaQuery on relayout', () => {
       resources.relayoutAll_ = true;
 


### PR DESCRIPTION
**summary**
Context: `b/170491750`, `b/173271514`

There is no guarantee as to when an iframes `resize` event occurs. It can (and sometimes does) happen much later than the causally related IntersectionObserver events. This led to a mismatch between the viewport service's size and InOb. Here is an example sequence of events that occurs in the sample document (given an initial iframe height of 1px):

1. Load begins. iframe height=1
2. `documentHeight` message sent to the Viewer which resizes the iframe. height=104.
3. InOb fires its callbacks/measures since the resource now intersects with the viewport.
4. Resource is determined not to be within viewport since viewport service's size hasn't updated yet.
5. `window.resize` event finally fires and updates the viewport service. no pass is scheduled. img never gets laid out.

**to manually test**
This is somewhat reproducible in a [hosted viewer environment](https://amp-viewer.vercel.app/view?url=https%3A%2F%2Flive-amp-bugs.glitch.me%2Fmargin-layout-viewer.html&height=1). The race condition only occurs when the JS all loads incredibly fast (aka try running the viewer in localhost instead). 

**appendix**
Sample problem document:
```html
<!doctype html>
<html ⚡4email>
<head>
  <meta charset="utf-8">
  <script async src="https://cdn.ampproject.org/v0.js"></script>
  <style amp4email-boilerplate>body{visibility:hidden}</style>
  <style amp-custom>
    amp-img {
      margin: 30px; /* remove this line to stop the issue */
    }
  </style>
</head>
<body>
  <amp-img src="https://fonts.gstatic.com/s/i/googlematerialicons/notifications_off/v6/googblue-48dp/2x/gm_notifications_off_googblue_48dp.png" width="40px" height="40px"></amp-img>
</body>
</html>
```