### PR TITLE
dependencies: remove sleep-promise

### DIFF
--- a/build-system/tasks/visual-diff/helpers.js
+++ b/build-system/tasks/visual-diff/helpers.js
@@ -18,7 +18,6 @@
 const argv = require('minimist')(process.argv.slice(2));
 const colors = require('ansi-colors');
 const fancyLog = require('fancy-log');
-const sleep = (ms) => new Promise((res) => setTimeout(res, ms));
 
 const CSS_SELECTOR_RETRY_MS = 200;
 const CSS_SELECTOR_RETRY_ATTEMPTS = 50;
@@ -260,6 +259,15 @@ async function waitForSelectorExistence(page, selector) {
     attempt++;
   } while (attempt < CSS_SELECTOR_RETRY_ATTEMPTS);
   throw new Error(selector);
+}
+
+/**
+ * Returns a Promise that resolves after the specified number of milliseconds.
+ * @param {number} ms
+ * @return {Promise}
+ */
+async function sleep(ms) {
+  return new Promise((res) => setTimeout(res, ms));
 }
 
 module.exports = {

--- a/build-system/tasks/visual-diff/helpers.js
+++ b/build-system/tasks/visual-diff/helpers.js
@@ -18,7 +18,7 @@
 const argv = require('minimist')(process.argv.slice(2));
 const colors = require('ansi-colors');
 const fancyLog = require('fancy-log');
-const sleep = require('sleep-promise');
+const sleep = (ms) => new Promise((res) => setTimeout(res, ms));
 
 const CSS_SELECTOR_RETRY_MS = 200;
 const CSS_SELECTOR_RETRY_ATTEMPTS = 50;
@@ -265,6 +265,7 @@ async function waitForSelectorExistence(page, selector) {
 module.exports = {
   escapeHtml,
   log,
+  sleep,
   waitForPageLoad,
   verifySelectorsInvisible,
   verifySelectorsVisible,

--- a/build-system/tasks/visual-diff/index.js
+++ b/build-system/tasks/visual-diff/index.js
@@ -20,7 +20,6 @@ const colors = require('ansi-colors');
 const fs = require('fs');
 const JSON5 = require('json5');
 const path = require('path');
-const sleep = require('sleep-promise');
 const {
   createCtrlcHandler,
   exitCtrlcHandler,
@@ -31,6 +30,7 @@ const {
   waitForPageLoad,
   verifySelectorsInvisible,
   verifySelectorsVisible,
+  sleep,
 } = require('./helpers');
 const {
   gitBranchName,

--- a/examples/visual-tests/amphtml-ads/static.js
+++ b/examples/visual-tests/amphtml-ads/static.js
@@ -17,7 +17,7 @@
 'use strict';
 
 const {fillIframeSrcdoc} = require('./helpers');
-const sleep = require('sleep-promise');
+const sleep = (ms) => new Promise(res => setTimeout(res, ms));
 
 /**
  * Percy preserves the DOM object as snapshot so the content of iframe is not

--- a/package-lock.json
+++ b/package-lock.json
@@ -29756,23 +29756,6 @@
       "integrity": "sha512-IifbusYiQBpUxxFJkR3wTU68xzBN0+bxCScEaKMjBvAQERg6FnTTc1F17rseLb1tjmkJ23730AXpFI0c47FgAg==",
       "dev": true
     },
-    "sleep-promise": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/sleep-promise/-/sleep-promise-9.0.0.tgz",
-      "integrity": "sha512-7x3Fra49pMKWs0+jzOXBVR31GkP3NwmFMoxH/irXcUCUyglhPtoQa/XaC7OimjI41YEGP00StD8UlmJL/MBHlw==",
-      "dev": true,
-      "requires": {
-        "core-js": "^3.6.5"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "3.6.5",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
-          "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==",
-          "dev": true
-        }
-      }
-    },
     "slice-ansi": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -180,7 +180,6 @@
     "rocambole": "0.7.0",
     "sinon": "9.2.0",
     "sinon-chai": "3.5.0",
-    "sleep-promise": "9.0.0",
     "sourcemap-codec": "1.4.8",
     "tar": "6.0.5",
     "tcp-port-used": "1.0.1",


### PR DESCRIPTION
**summary**

We have a dependency on [sleep-promise](https://www.npmjs.com/package/sleep-promise). The package provides a very useful utility, but it is also easy to replicate in a single line. There is a cost involved with each dependency we have in our package.json file (repeated downloads, updates, security via malicious uploads to npm, etc.). For a utility this small, I think its better to write it ourself. Also, see [leftpad](https://blog.npmjs.org/post/141577284765/kik-left-pad-and-npm).

```js

// Before
const sleep = require('sleep-promise');

// After
const sleep = (ms) => new Promise((res) => setTimeout(res, ms));
```