### PR TITLE
🐛 Desktop navigation button should show "next" on the last page of a story

### DIFF
--- a/examples/amp-story/player-local-stories.html
+++ b/examples/amp-story/player-local-stories.html
@@ -38,7 +38,7 @@
   <body>
     <h1>This is a NON-AMP page that embeds a story below:</h1>
     <div>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras viverra neque ex, sit amet varius sem maximus sed. Suspendisse potenti. Donec erat purus, sagittis sit amet tincidunt ut, maximus sit amet massa. Maecenas venenatis fringilla dui vitae vestibulum. Fusce imperdiet euismod lobortis. Nullam sagittis nunc at tristique mattis. In sodales consectetur mollis. Maecenas sollicitudin, ex vel tempor rutrum, turpis eros interdum enim, sit amet volutpat tortor dolor at ipsum. Nam posuere velit vel urna vulputate interdum. Aenean eu vulputate lorem. Praesent nec nunc sodales, egestas orci sed, hendrerit mauris. Ut blandit turpis non erat sagittis, quis fermentum odio feugiat.</div>
-    <amp-story-player style="height: 1000px;">
+    <amp-story-player style="width: 360px; height: 600px">
         <a href="./ampconf.html"
             style="--story-player-poster: url('./img/overview.jpg');"
             class="story">

--- a/examples/amp-story/player-local-stories.html
+++ b/examples/amp-story/player-local-stories.html
@@ -38,7 +38,7 @@
   <body>
     <h1>This is a NON-AMP page that embeds a story below:</h1>
     <div>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras viverra neque ex, sit amet varius sem maximus sed. Suspendisse potenti. Donec erat purus, sagittis sit amet tincidunt ut, maximus sit amet massa. Maecenas venenatis fringilla dui vitae vestibulum. Fusce imperdiet euismod lobortis. Nullam sagittis nunc at tristique mattis. In sodales consectetur mollis. Maecenas sollicitudin, ex vel tempor rutrum, turpis eros interdum enim, sit amet volutpat tortor dolor at ipsum. Nam posuere velit vel urna vulputate interdum. Aenean eu vulputate lorem. Praesent nec nunc sodales, egestas orci sed, hendrerit mauris. Ut blandit turpis non erat sagittis, quis fermentum odio feugiat.</div>
-    <amp-story-player style="width: 360px; height: 600px">
+    <amp-story-player style="width: 360px; height: 600px;">
         <a href="./ampconf.html"
             style="--story-player-poster: url('./img/overview.jpg');"
             class="story">

--- a/examples/amp-story/player-local-stories.html
+++ b/examples/amp-story/player-local-stories.html
@@ -38,8 +38,7 @@
   <body>
     <h1>This is a NON-AMP page that embeds a story below:</h1>
     <div>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras viverra neque ex, sit amet varius sem maximus sed. Suspendisse potenti. Donec erat purus, sagittis sit amet tincidunt ut, maximus sit amet massa. Maecenas venenatis fringilla dui vitae vestibulum. Fusce imperdiet euismod lobortis. Nullam sagittis nunc at tristique mattis. In sodales consectetur mollis. Maecenas sollicitudin, ex vel tempor rutrum, turpis eros interdum enim, sit amet volutpat tortor dolor at ipsum. Nam posuere velit vel urna vulputate interdum. Aenean eu vulputate lorem. Praesent nec nunc sodales, egestas orci sed, hendrerit mauris. Ut blandit turpis non erat sagittis, quis fermentum odio feugiat.</div>
-    <!-- TODO: revert before merging. -->
-    <amp-story-player style="height: 1000px;">
+    <amp-story-player style="width: 360px; height: 600px;">
         <a href="./ampconf.html"
             style="--story-player-poster: url('./img/overview.jpg');"
             class="story">

--- a/examples/amp-story/player-local-stories.html
+++ b/examples/amp-story/player-local-stories.html
@@ -39,7 +39,7 @@
     <h1>This is a NON-AMP page that embeds a story below:</h1>
     <div>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras viverra neque ex, sit amet varius sem maximus sed. Suspendisse potenti. Donec erat purus, sagittis sit amet tincidunt ut, maximus sit amet massa. Maecenas venenatis fringilla dui vitae vestibulum. Fusce imperdiet euismod lobortis. Nullam sagittis nunc at tristique mattis. In sodales consectetur mollis. Maecenas sollicitudin, ex vel tempor rutrum, turpis eros interdum enim, sit amet volutpat tortor dolor at ipsum. Nam posuere velit vel urna vulputate interdum. Aenean eu vulputate lorem. Praesent nec nunc sodales, egestas orci sed, hendrerit mauris. Ut blandit turpis non erat sagittis, quis fermentum odio feugiat.</div>
     <!-- TODO: revert before merging. -->
-    <amp-story-player style="width: 360px; height: 600px;">
+    <amp-story-player style="height: 1000px;">
         <a href="./ampconf.html"
             style="--story-player-poster: url('./img/overview.jpg');"
             class="story">

--- a/examples/amp-story/player-local-stories.html
+++ b/examples/amp-story/player-local-stories.html
@@ -38,6 +38,7 @@
   <body>
     <h1>This is a NON-AMP page that embeds a story below:</h1>
     <div>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras viverra neque ex, sit amet varius sem maximus sed. Suspendisse potenti. Donec erat purus, sagittis sit amet tincidunt ut, maximus sit amet massa. Maecenas venenatis fringilla dui vitae vestibulum. Fusce imperdiet euismod lobortis. Nullam sagittis nunc at tristique mattis. In sodales consectetur mollis. Maecenas sollicitudin, ex vel tempor rutrum, turpis eros interdum enim, sit amet volutpat tortor dolor at ipsum. Nam posuere velit vel urna vulputate interdum. Aenean eu vulputate lorem. Praesent nec nunc sodales, egestas orci sed, hendrerit mauris. Ut blandit turpis non erat sagittis, quis fermentum odio feugiat.</div>
+    <!-- TODO: revert before merging. -->
     <amp-story-player style="width: 360px; height: 600px;">
         <a href="./ampconf.html"
             style="--story-player-poster: url('./img/overview.jpg');"

--- a/examples/amp-story/player-local-stories.html
+++ b/examples/amp-story/player-local-stories.html
@@ -38,7 +38,7 @@
   <body>
     <h1>This is a NON-AMP page that embeds a story below:</h1>
     <div>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras viverra neque ex, sit amet varius sem maximus sed. Suspendisse potenti. Donec erat purus, sagittis sit amet tincidunt ut, maximus sit amet massa. Maecenas venenatis fringilla dui vitae vestibulum. Fusce imperdiet euismod lobortis. Nullam sagittis nunc at tristique mattis. In sodales consectetur mollis. Maecenas sollicitudin, ex vel tempor rutrum, turpis eros interdum enim, sit amet volutpat tortor dolor at ipsum. Nam posuere velit vel urna vulputate interdum. Aenean eu vulputate lorem. Praesent nec nunc sodales, egestas orci sed, hendrerit mauris. Ut blandit turpis non erat sagittis, quis fermentum odio feugiat.</div>
-    <amp-story-player style="width: 360px; height: 600px;">
+    <amp-story-player style="height: 1000px;">
         <a href="./ampconf.html"
             style="--story-player-poster: url('./img/overview.jpg');"
             class="story">

--- a/extensions/amp-story/1.0/pagination-buttons.js
+++ b/extensions/amp-story/1.0/pagination-buttons.js
@@ -54,6 +54,11 @@ const ForwardButtonStates = {
     // TODO: Here and other labels: i18n.
     label: 'Next page',
   },
+  NEXT_STORY: {
+    className: 'i-amphtml-story-fwd-next',
+    triggers: EventType.NO_NEXT_PAGE,
+    label: 'Next story',
+  },
   REPLAY: {
     className: 'i-amphtml-story-fwd-replay',
     triggers: EventType.REPLAY,
@@ -330,7 +335,7 @@ export class PaginationButtons {
     if (pageIndex === totalPages - 1) {
       this.ampStory_.hasBookend().then((hasBookend) => {
         if (!hasBookend) {
-          this.forwardButton_.updateState(ForwardButtonStates.REPLAY);
+          this.forwardButton_.updateState(ForwardButtonStates.NEXT_STORY);
         }
       });
     }

--- a/extensions/amp-story/1.0/pagination-buttons.js
+++ b/extensions/amp-story/1.0/pagination-buttons.js
@@ -20,6 +20,7 @@ import {
   getStoreService,
 } from './amp-story-store-service';
 import {AdvancementMode} from './story-analytics';
+import {Services} from '../../../src/services';
 import {CommonSignals} from '../../../src/common-signals';
 import {EventType, dispatch} from './events';
 import {devAssert} from '../../../src/log';
@@ -28,6 +29,9 @@ import {renderAsElement} from './simple-template';
 
 /** @struct @typedef {{className: string, triggers: (string|undefined)}} */
 let ButtonState_1_0_Def; // eslint-disable-line google-camelcase/google-camelcase
+
+/** @private {?../../../src/service/viewer-interface.ViewerInterface} */
+this.viewer_ = null;
 
 /** @const {!Object<string, !ButtonState_1_0_Def>} */
 const BackButtonStates = {
@@ -335,8 +339,15 @@ export class PaginationButtons {
 
     if (pageIndex === totalPages - 1) {
       this.ampStory_.hasBookend().then((hasBookend) => {
+        this.viewer_ = Services.viewerForDoc(this.element);
         if (!hasBookend) {
-          this.forwardButton_.updateState(ForwardButtonStates.NEXT_STORY);
+          if (this.viewer_.hasCapability('swipe')) {
+            console.log("raxsha" + this.viewer_);
+            this.forwardButton_.updateState(ForwardButtonStates.NEXT_STORY);
+          } else {
+            console.log("raxsha" + this.viewer_);
+            this.forwardButton_.updateState(ForwardButtonStates.REPLAY);
+          }
         }
       });
     }

--- a/extensions/amp-story/1.0/pagination-buttons.js
+++ b/extensions/amp-story/1.0/pagination-buttons.js
@@ -57,6 +57,7 @@ const ForwardButtonStates = {
   NEXT_STORY: {
     className: 'i-amphtml-story-fwd-next',
     triggers: EventType.NO_NEXT_PAGE,
+    // i18n
     label: 'Next story',
   },
   REPLAY: {

--- a/extensions/amp-story/1.0/pagination-buttons.js
+++ b/extensions/amp-story/1.0/pagination-buttons.js
@@ -333,10 +333,8 @@ export class PaginationButtons {
         const viewer = Services.viewerForDoc(this.ampStory_.element);
         if (!hasBookend) {
           if (viewer.hasCapability('swipe')) {
-            console.log("raxsha" + viewer);
             this.forwardButton_.updateState(ForwardButtonStates.NEXT_PAGE);
           } else {
-            console.log("raxsha" + viewer);
             this.forwardButton_.updateState(ForwardButtonStates.REPLAY);
           }
         }

--- a/extensions/amp-story/1.0/pagination-buttons.js
+++ b/extensions/amp-story/1.0/pagination-buttons.js
@@ -30,9 +30,6 @@ import {renderAsElement} from './simple-template';
 /** @struct @typedef {{className: string, triggers: (string|undefined)}} */
 let ButtonState_1_0_Def; // eslint-disable-line google-camelcase/google-camelcase
 
-/** @private {?../../../src/service/viewer-interface.ViewerInterface} */
-this.viewer_ = null;
-
 /** @const {!Object<string, !ButtonState_1_0_Def>} */
 const BackButtonStates = {
   CLOSE_BOOKEND: {
@@ -57,12 +54,6 @@ const ForwardButtonStates = {
     triggers: EventType.NEXT_PAGE,
     // TODO: Here and other labels: i18n.
     label: 'Next page',
-  },
-  NEXT_STORY: {
-    className: 'i-amphtml-story-fwd-next',
-    triggers: EventType.NO_NEXT_PAGE,
-    // i18n
-    label: 'Next story',
   },
   REPLAY: {
     className: 'i-amphtml-story-fwd-replay',
@@ -339,13 +330,13 @@ export class PaginationButtons {
 
     if (pageIndex === totalPages - 1) {
       this.ampStory_.hasBookend().then((hasBookend) => {
-        this.viewer_ = Services.viewerForDoc(this.element);
+        const viewer = Services.viewerForDoc(this.ampStory_.element);
         if (!hasBookend) {
-          if (this.viewer_.hasCapability('swipe')) {
-            console.log("raxsha" + this.viewer_);
-            this.forwardButton_.updateState(ForwardButtonStates.NEXT_STORY);
+          if (viewer.hasCapability('swipe')) {
+            console.log("raxsha" + viewer);
+            this.forwardButton_.updateState(ForwardButtonStates.NEXT_PAGE);
           } else {
-            console.log("raxsha" + this.viewer_);
+            console.log("raxsha" + viewer);
             this.forwardButton_.updateState(ForwardButtonStates.REPLAY);
           }
         }

--- a/extensions/amp-story/1.0/pagination-buttons.js
+++ b/extensions/amp-story/1.0/pagination-buttons.js
@@ -20,9 +20,9 @@ import {
   getStoreService,
 } from './amp-story-store-service';
 import {AdvancementMode} from './story-analytics';
-import {Services} from '../../../src/services';
 import {CommonSignals} from '../../../src/common-signals';
 import {EventType, dispatch} from './events';
+import {Services} from '../../../src/services';
 import {devAssert} from '../../../src/log';
 import {dict} from './../../../src/utils/object';
 import {renderAsElement} from './simple-template';


### PR DESCRIPTION
On the last page of a desktop mode story, the navigation button should show "next" instead of "rewind", and navigate to the next story.

Fixes #31207 