### PR TITLE
✨ Support enabling Vimeo players do-not-track attribute when using AmpVimeo component 

### DIFF
--- a/extensions/amp-vimeo/0.1/amp-vimeo.js
+++ b/extensions/amp-vimeo/0.1/amp-vimeo.js
@@ -68,6 +68,8 @@ const VIMEO_EVENTS = {
   'volumechange': null,
 };
 
+const DO_NOT_TRACK_ATTRIBUTE = 'do-not-track';
+
 /** @implements {../../../src/video-interface.VideoInterface} */
 class AmpVimeo extends AMP.BaseElement {
   /** @param {!AmpElement} element */
@@ -121,16 +123,17 @@ class AmpVimeo extends AMP.BaseElement {
   /** @override */
   layoutCallback() {
     return this.isAutoplay_().then((isAutoplay) =>
-      this.buildIframe_(isAutoplay)
+      this.buildIframe_(isAutoplay, this.isDoNotTrack_())
     );
   }
 
   /**
    * @param {boolean} isAutoplay
+   * @param {boolean} isDoNotTrack
    * @return {!Promise}
    * @private
    */
-  buildIframe_(isAutoplay) {
+  buildIframe_(isAutoplay, isDoNotTrack) {
     const {element} = this;
     const vidId = userAssert(
       element.getAttribute('data-videoid'),
@@ -147,6 +150,10 @@ class AmpVimeo extends AMP.BaseElement {
       // Only muted videos are allowed to autoplay
       this.muted_ = true;
       src = addParamToUrl(src, 'muted', '1');
+    }
+
+    if (isDoNotTrack) {
+      src = addParamToUrl(src, 'dnt', '1');
     }
 
     const iframe = createFrameFor(this, src);
@@ -187,6 +194,14 @@ class AmpVimeo extends AMP.BaseElement {
     }
     const {win} = this;
     return VideoUtils.isAutoplaySupported(win, getMode(win).lite);
+  }
+
+  /**
+   * @return {boolean}
+   * @private
+   */
+  isDoNotTrack_() {
+    return this.element.hasAttribute(DO_NOT_TRACK_ATTRIBUTE);
   }
 
   /** @private */

--- a/extensions/amp-vimeo/0.1/test/test-amp-vimeo.js
+++ b/extensions/amp-vimeo/0.1/test/test-amp-vimeo.js
@@ -40,7 +40,7 @@ describes.realWin(
         vimeo.setAttribute('layout', 'responsive');
       }
       if (opt_doNotTrack) {
-        vimeo.setAttribute('do-not-track', 'do-not-track');
+        vimeo.setAttribute('do-not-track', '');
       }
       doc.body.appendChild(vimeo);
       await vimeo.build();

--- a/extensions/amp-vimeo/0.1/test/test-amp-vimeo.js
+++ b/extensions/amp-vimeo/0.1/test/test-amp-vimeo.js
@@ -31,13 +31,16 @@ describes.realWin(
       doc = win.document;
     });
 
-    async function getVimeo(videoId, opt_responsive) {
+    async function getVimeo(videoId, opt_responsive, opt_doNotTrack) {
       const vimeo = doc.createElement('amp-vimeo');
       vimeo.setAttribute('data-videoid', videoId);
       vimeo.setAttribute('width', '111');
       vimeo.setAttribute('height', '222');
       if (opt_responsive) {
         vimeo.setAttribute('layout', 'responsive');
+      }
+      if (opt_doNotTrack) {
+        vimeo.setAttribute('do-not-track', 'do-not-track');
       }
       doc.body.appendChild(vimeo);
       await vimeo.build();
@@ -64,6 +67,12 @@ describes.realWin(
       return getVimeo('').should.eventually.be.rejectedWith(
         /The data-videoid attribute is required for/
       );
+    });
+
+    it('renders do-not-track src url', async () => {
+      const vimeo = await getVimeo('2323', false, true);
+      const iframe = vimeo.querySelector('iframe');
+      expect(iframe.src).to.equal('https://player.vimeo.com/video/2323?dnt=1');
     });
   }
 );

--- a/extensions/amp-vimeo/amp-vimeo.md
+++ b/extensions/amp-vimeo/amp-vimeo.md
@@ -52,8 +52,9 @@ to be played, <a href="https://github.com/ampproject/amphtml/blob/master/spec/am
   </tr>
   <tr>
     <td width="40%"><strong>do-not-track</strong></td>
-    <td>If this attribute is present, the player will be prevented from tracking session data, including cookies. For more details see the
-    <a href="https://developer.vimeo.com/api/oembed/videos">Vimeo oEmbed Documentation</a></td>
+    <td>If this attribute is present the player will be blocked from tracking any session data, including all cookies and
+    <a href="https://vimeo.com/stats">stats</a>. (It has the same effect as enabling a Do Not Track setting in your browser).
+    See the 'dnt' parameter in the <a href="https://developer.vimeo.com/api/oembed/videos">Vimeo oEmbed Documentation</a></td>
   </tr>
   <tr>
     <td width="40%"><strong>common attributes</strong></td>

--- a/extensions/amp-vimeo/amp-vimeo.md
+++ b/extensions/amp-vimeo/amp-vimeo.md
@@ -51,6 +51,11 @@ played as soon as it becomes visible. There are some conditions that the compone
 to be played, <a href="https://github.com/ampproject/amphtml/blob/master/spec/amp-video-interface.md#autoplay">which are outlined in the Video in AMP spec</a>.</td>
   </tr>
   <tr>
+    <td width="40%"><strong>do-not-track</strong></td>
+    <td>If this attribute is present, the player will be prevented from tracking session data, including cookies. For more details see the
+    <a href="https://developer.vimeo.com/api/oembed/videos">Vimeo oEmbed Documentation</a></td>
+  </tr>
+  <tr>
     <td width="40%"><strong>common attributes</strong></td>
     <td>This element includes <a href="https://amp.dev/documentation/guides-and-tutorials/learn/common_attributes">common attributes</a> extended to AMP components.</td>
   </tr>


### PR DESCRIPTION
Adding an optional 'do-not-track' attribute to AmpVimeo component that causes the dnt=1
attribute to be appended to the vimeo player iframe src url.

This will "prevent the player from tracking session data, including cookies"
for details see: https://developer.vimeo.com/api/oembed/videos

Issue:  #31384

