### PR TITLE
✨ 🐛 [amp-sidebar] Fix gestures in amp-sidebar

### DIFF
--- a/extensions/amp-sidebar/0.1/amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/amp-sidebar.js
@@ -67,9 +67,6 @@ const SidebarEvents = {
   CLOSE: 'sidebarClose',
 };
 
-/** @private @const {Object<string, Object<string, Array<string>>>} */
-const EXCLUDE_FROM_SWIPE_CLOSE = {'input': {'type': ['range']}};
-
 /**
  * @extends {AMP.BaseElement}
  */
@@ -592,8 +589,11 @@ export class AmpSidebar extends AMP.BaseElement {
       /* shouldNotPreventDefault */ true,
       /* shouldStopPropagation */ true
     );
-    gestures.onGesture(SwipeXRecognizer, (e) => {
-      const {data, event} = e;
+    // The onGesture method has a recognizer and a handler argument
+    // The handler takes a gesture object as an argument which
+    // includes data and event properties
+    gestures.onGesture(SwipeXRecognizer, (gesture) => {
+      const {data, event} = gesture;
       this.handleSwipe_(data, event);
     });
   }
@@ -735,17 +735,11 @@ AMP.extension('amp-sidebar', '0.1', (AMP) => {
 });
 
 /**
- * @param {Element} element
+ * @param {!Element} element
  * @return {boolean}
  */
 function excludeFromSwipeClose(element) {
-  const excludeData = EXCLUDE_FROM_SWIPE_CLOSE[element.localName];
-  if (excludeData) {
-    for (const k in excludeData) {
-      if (excludeData[k].includes(element[k])) {
-        return true;
-      }
-    }
-  }
-  return false;
+  return (
+    element.nodeName === 'INPUT' && element.getAttribute('type') === 'range'
+  );
 }

--- a/extensions/amp-sidebar/0.1/amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/amp-sidebar.js
@@ -740,6 +740,7 @@ AMP.extension('amp-sidebar', '0.1', (AMP) => {
  */
 function excludeFromSwipeClose(element) {
   return (
-    element.nodeName === 'INPUT' && element.getAttribute('type') === 'range'
+    element.nodeName.toLowerCase() === 'input' &&
+    element.getAttribute('type') === 'range'
   );
 }

--- a/extensions/amp-sidebar/0.1/amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/amp-sidebar.js
@@ -67,8 +67,8 @@ const SidebarEvents = {
   CLOSE: 'sidebarClose',
 };
 
-/** @private @const {!Array<string>} */
-const EXCLUDE_FROM_SWIPE_CLOSE = ['input'];
+/** @private @const {Object<string, Object<string, Array<string>>>} */
+const EXCLUDE_FROM_SWIPE_CLOSE = {'input': {'type': ['range']}};
 
 /**
  * @extends {AMP.BaseElement}
@@ -621,11 +621,7 @@ export class AmpSidebar extends AMP.BaseElement {
       return;
     }
 
-    if (
-      event &&
-      event.target &&
-      !EXCLUDE_FROM_SWIPE_CLOSE.includes(event.target.localName)
-    ) {
+    if (event && event.target && !excludeFromSwipeClose(event.target)) {
       this.currentSwipeForThisElement_ = true;
       this.swipeToDismiss_.swipeMove(data);
     }
@@ -737,3 +733,19 @@ export class AmpSidebar extends AMP.BaseElement {
 AMP.extension('amp-sidebar', '0.1', (AMP) => {
   AMP.registerElement('amp-sidebar', AmpSidebar, CSS);
 });
+
+/**
+ * @param {Element} element
+ * @return {boolean}
+ */
+function excludeFromSwipeClose(element) {
+  const excludeData = EXCLUDE_FROM_SWIPE_CLOSE[element.localName];
+  if (excludeData) {
+    for (const k in excludeData) {
+      if (excludeData[k].includes(element[k])) {
+        return true;
+      }
+    }
+  }
+  return false;
+}

--- a/extensions/amp-sidebar/0.1/amp-sidebar.md
+++ b/extensions/amp-sidebar/0.1/amp-sidebar.md
@@ -336,6 +336,10 @@ This attribute is present on child `<nav toolbar="(media-query)" toolbar-target=
 
 This attribute is present on child `<nav toolbar="(media-query)" toolbar-target="elementID">`, and accepts an id of an element on the page. The `toolbar-target` attribute will place the toolbar into the specified id of the element on the page, without the default toolbar styling. See the [Toolbar](#toolbar) section for more information on using toolbars.
 
+##### data-disable-swipe-close
+
+Including this attribute on `amp-sidebar` disables swipe to close. When using a mobile device or other touch enabled device, swiping to close the sidebar will be disabled.
+
 ##### common attributes<a name="common"></a>
 
 This element includes [common attributes](https://amp.dev/documentation/guides-and-tutorials/learn/common_attributes) extended to AMP components.

--- a/extensions/amp-sidebar/0.1/test/test-amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/test/test-amp-sidebar.js
@@ -694,6 +694,30 @@ describes.realWin(
           expect(impl.disableSwipeClose_).to.be.true;
         });
       });
+
+      it('should not allow swipe on input range (slider) element', () => {
+        return getAmpSidebar().then((sidebarElement) => {
+          const impl = sidebarElement.implementation_;
+
+          const swipeMoveStub = env.sandbox.stub(
+            impl.swipeToDismiss_,
+            'swipeMove'
+          );
+
+          // Do not trigger swipeMove when swiping on an input range element
+          const slider = document.createElement('input');
+          slider.setAttribute('type', 'range');
+          const fakeEvent = {target: slider};
+          impl.handleSwipe_({}, fakeEvent);
+          expect(swipeMoveStub).to.not.be.called;
+
+          // Call swipeMove when swiping on any other type of element
+          const input = document.createElement('input');
+          const fakeEvent2 = {target: input};
+          impl.handleSwipe_({}, fakeEvent2);
+          expect(swipeMoveStub).to.be.called.calledOnce;
+        });
+      });
     });
 
     describe('amp-sidebar - toolbars in amp-sidebar', () => {

--- a/extensions/amp-sidebar/0.1/test/test-amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/test/test-amp-sidebar.js
@@ -82,6 +82,9 @@ describes.realWin(
       if (options.side) {
         ampSidebar.setAttribute('side', options.side);
       }
+      if (options.disableSwipe) {
+        ampSidebar.setAttribute('data-disable-swipe-close', '');
+      }
       if (options.closeText) {
         ampSidebar.setAttribute(
           'data-close-button-aria-label',
@@ -682,6 +685,13 @@ describes.realWin(
             env.sandbox.match.any,
             /* trust */ 456
           );
+        });
+      });
+
+      it('should disable swipe to close when attribute specified', () => {
+        return getAmpSidebar({disableSwipe: true}).then((sidebarElement) => {
+          const impl = sidebarElement.implementation_;
+          expect(impl.disableSwipeClose_).to.be.true;
         });
       });
     });


### PR DESCRIPTION
Fixes: https://github.com/ampproject/amphtml/issues/28902
Fixes: https://github.com/ampproject/amphtml/issues/31326

This PR updates Gestures behavior in amp-sidebar with three main changes to address the two bugs above:
1. **Bug Fix** (https://github.com/ampproject/amphtml/issues/28902) - Passive event listeners do not allow prevent.default().  So we have to remove the prevent.default() or have a bunch of console errors when we get the `touchmove` event (from swiping).  This optimization improves performance for `touchmove` events [more info](https://medium.com/@Esakkimuthu/passive-event-listeners-5dbb1b011fb1#:~:text=Passive%20event%20listeners%20are%20an%20emerging%20web%20standard%2C%20new%20feature,touch%20and%20wheel%20event%20listeners.) by improving the default scroll behavior of the `touchmove` event.  This is not a problem for sidebar since we only register the `touchmove` events when the sidebar is active which is a static screen with half the page covered by the sidebar and the other half masked off.

2. **Bug Fix** (https://github.com/ampproject/amphtml/issues/31326) - On a mobile device with Gestures (swiping) enabled, the amp-sidebar can be swiped to close.  The current behavior registers the swipe anywhere on the page.  However, there could be other elements (such as a slider) which should register the swipe.  This PR allows a whitelist of elements that when swiped on do not cause the amp-sidebar to be closed, but instead interacts with that element.

3. **New Feature** (https://github.com/ampproject/amphtml/issues/31326) - Add a new attribute `data-disable-swipe-close`.  When this attribute exists on the amp-sidebar, the amp-sidebar will not respond to swiping to close.  (User can still tap to close the sidebar).

Example: https://output.jsbin.com/fihuwon
Go to the example site and change to iphone emulator 
1. Open the sidebar and drag mouse around, you will see a bunch of console errors in old code.
2. Drag the input slider to the left.  The sidebar will close and the input cannot be updated (in old code).
3. Add `data-disable-swipe-close` attribute.  Open the sidebar and see that it cannot be closed by swiping (in new code).

to do:
tests, storybook