### PR TITLE
⏪ Revert "Skip amp-subscriptions-google e2e test (#31399)"

### DIFF
--- a/extensions/amp-subscriptions-google/0.1/test-e2e/test-amp-subscriptions-google.js
+++ b/extensions/amp-subscriptions-google/0.1/test-e2e/test-amp-subscriptions-google.js
@@ -28,7 +28,7 @@ describes.endtoend(
       controller = env.controller;
     });
 
-    it.skip('Subscription offers should render correctly', async () => {
+    it('Subscription offers should render correctly', async () => {
       const btn = await controller.findElement('#swg_button');
       // Wait for button to be rendered and ready to click
       await expect(controller.getElementRect(btn)).to.include({


### PR DESCRIPTION
This reverts commit b2a2e361c55a003eaa36ca4006ceb67a10f7fae0.
Test was skipped due to flakiness, but the error resurfaced in a completely unrelated test (see #31409 ), indicating the test itself was not the source of flakiness. This PR restores/unskips that test.(
