### PR TITLE
🏗 Remove project-level code coverage status

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -13,20 +13,13 @@ codecov:
 # See https://docs.codecov.io/docs/pull-request-comments
 comment: false
 
-# Separate PR statuses for project-level and patch-level coverage
+# PR status for patch-level coverage
 # See https://docs.codecov.io/docs/commit-status
 coverage:
   precision: 2
   round: down
   range: '75...100'
   status:
-    project:
-      default:
-        base: auto
-        if_not_found: success
-        only_pulls: true
-        target: 75%
-        threshold: 1%
     patch:
       default:
         base: auto

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -20,6 +20,7 @@ coverage:
   round: down
   range: '75...100'
   status:
+    project: off
     patch:
       default:
         base: auto


### PR DESCRIPTION
We were applying two statuses from Codecov.io for all PRs: project-level and patch-level coverage. The former was meant to be a barometer of overall coverage, but has proved to be noisy and not so useful.

This PR reduces codecov statuses to just patch-level coverage.

Fixes #28212
