### PR TITLE
🏗♻️ Replace Travis-specific check with a generic CI build check

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -15,7 +15,7 @@
   "prBodyNotes": [
     "<details>",
     "<summary>How to resolve breaking changes</summary>",
-    "This PR may introduce breaking changes that require manual intervention. In such cases, you will need to check out this branch, fix the cause of the breakage, and commit the fix to ensure a green Travis build. To check out and update this PR, follow the steps below:",
+    "This PR may introduce breaking changes that require manual intervention. In such cases, you will need to check out this branch, fix the cause of the breakage, and commit the fix to ensure a green CI build. To check out and update this PR, follow the steps below:",
     "```sh\n# Check out the PR branch (these steps are from GitHub)\ngit checkout -b renovate-bot-{{{branchName}}} master\ngit pull https://github.com/renovate-bot/amphtml.git {{{branchName}}}\n\n# Directly make fixes and commit them\ngulp lint --fix # For lint errors in JS files\ngulp prettify --fix # For prettier errors in non-JS files\n# Edit source code in case of new compiler warnings / errors\n\n# Push the changes to the branch\ngit push git@github.com:renovate-bot/amphtml.git renovate-bot-{{{branchName}}}:{{{branchName}}}\n```",
     "</details>"
   ],

--- a/build-system/common/check-package-manager.js
+++ b/build-system/common/check-package-manager.js
@@ -363,9 +363,8 @@ function checkPythonVersion() {
  * @return {Promise}
  */
 async function main() {
-  // NPM is already used by default on Travis and Github Actions, so there is
-  // nothing more to do.
-  if (process.env.TRAVIS || process.env.GITHUB_ACTIONS) {
+  // NPM is already used by default during CI, so there is nothing more to do.
+  if (process.env.CI) {
     return;
   }
   ensureNpm();

--- a/build-system/common/ci.js
+++ b/build-system/common/ci.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,32 +15,21 @@
  */
 'use strict';
 
-const gulp = require('gulp');
-const gulpAva = require('gulp-ava');
-const {isCiBuild} = require('../common/ci');
+/**
+ * @fileoverview Provides functions that extract various kinds of CI state.
+ */
 
 /**
- * Runs ava tests.
- * @return {!Vinyl}
+ * Returns true if this is a CI build.
+ * @return {boolean}
  */
-async function ava() {
-  return gulp
-    .src([
-      require.resolve('./csvify-size/test.js'),
-      require.resolve('./get-zindex/test.js'),
-      require.resolve('./prepend-global/test.js'),
-    ])
-    .pipe(
-      gulpAva({
-        'concurrency': 5,
-        'failFast': true,
-        'silent': isCiBuild(),
-      })
-    );
+function isCiBuild() {
+  // Travis: https://docs.travis-ci.com/user/environment-variables/#default-environment-variables
+  // GitHub Actions: https://docs.github.com/en/free-pro-team@latest/actions/reference/environment-variables#default-environment-variables
+  // CircleCI: https://circleci.com/docs/2.0/env-vars/#built-in-environment-variables
+  return !!process.env.CI;
 }
 
 module.exports = {
-  ava,
+  isCiBuild,
 };
-
-ava.description = 'Runs ava tests for gulp tasks';

--- a/build-system/common/ctrlcHandler.js
+++ b/build-system/common/ctrlcHandler.js
@@ -17,7 +17,7 @@
 const colors = require('ansi-colors');
 const log = require('fancy-log');
 const {execScriptAsync, exec} = require('./exec');
-const {isTravisBuild} = require('./travis');
+const {isCiBuild} = require('./ci');
 
 const {green, cyan} = colors;
 
@@ -32,7 +32,7 @@ const killSuffix = process.platform == 'win32' ? '>NUL' : '';
  * @return {number}
  */
 exports.createCtrlcHandler = function (command) {
-  if (!isTravisBuild()) {
+  if (!isCiBuild()) {
     log(
       green('Running'),
       cyan(command) + green('. Press'),

--- a/build-system/common/utils.js
+++ b/build-system/common/utils.js
@@ -25,7 +25,7 @@ const {doDist} = require('../tasks/dist');
 const {execOrDie} = require('./exec');
 const {gitDiffNameOnlyMaster} = require('./git');
 const {green, cyan, yellow} = require('ansi-colors');
-const {isTravisBuild} = require('./travis');
+const {isCiBuild} = require('./ci');
 
 const ROOT_DIR = path.resolve(__dirname, '../../');
 
@@ -52,7 +52,7 @@ async function buildRuntime(opt_compiled = false) {
  * @param {string} message
  */
 function logOnSameLine(message) {
-  if (!isTravisBuild() && process.stdout.isTTY) {
+  if (!isCiBuild() && process.stdout.isTTY) {
     process.stdout.moveCursor(0, -1);
     process.stdout.cursorTo(0);
     process.stdout.clearLine();
@@ -81,7 +81,7 @@ function getFilesChanged(globs) {
  * @return {!Array<string>}
  */
 function logFiles(files) {
-  if (!isTravisBuild()) {
+  if (!isCiBuild()) {
     log(green('INFO: ') + 'Checking the following files:');
     for (const file of files) {
       log(cyan(file));

--- a/build-system/compile/compile.js
+++ b/build-system/compile/compile.js
@@ -32,7 +32,7 @@ const {
 const {checkForUnknownDeps} = require('./check-for-unknown-deps');
 const {CLOSURE_SRC_GLOBS} = require('./sources');
 const {cpus} = require('os');
-const {isTravisBuild} = require('../common/travis');
+const {isCiBuild} = require('../common/ci');
 const {postClosureBabel} = require('./post-closure-babel');
 const {preClosureBabel, handlePreClosureError} = require('./pre-closure-babel');
 const {sanitize} = require('./sanitize');
@@ -42,7 +42,7 @@ const {writeSourcemaps} = require('./helpers');
 const queue = [];
 let inProgress = 0;
 
-const MAX_PARALLEL_CLOSURE_INVOCATIONS = isTravisBuild()
+const MAX_PARALLEL_CLOSURE_INVOCATIONS = isCiBuild()
   ? 10
   : parseInt(argv.closure_concurrency, 10) || cpus().length;
 

--- a/build-system/pr-check/build-targets.js
+++ b/build-system/pr-check/build-targets.js
@@ -25,7 +25,7 @@ const config = require('../test-configs/config');
 const minimatch = require('minimatch');
 const path = require('path');
 const {gitDiffNameOnlyMaster} = require('../common/git');
-const {isTravisBuild} = require('../common/travis');
+const {isCiBuild} = require('../common/ci');
 
 /**
  * Checks if the given file is an OWNERS file.
@@ -244,8 +244,8 @@ function determineBuildTargets(fileName = 'build-targets.js') {
   if (buildTargets.has('BABEL_PLUGIN') || buildTargets.has('SERVER')) {
     buildTargets.add('RUNTIME');
   }
-  // Test all targets on Travis during package upgrades.
-  if (isTravisBuild() && buildTargets.has('PACKAGE_UPGRADE')) {
+  // Test all targets during CI builds for package upgrades.
+  if (isCiBuild() && buildTargets.has('PACKAGE_UPGRADE')) {
     const allTargets = Object.keys(targetMatchers);
     allTargets.forEach((target) => buildTargets.add(target));
   }

--- a/build-system/tasks/babel-plugin-tests.js
+++ b/build-system/tasks/babel-plugin-tests.js
@@ -16,7 +16,7 @@
 'use strict';
 
 const jest = require('@jest/core');
-const {isTravisBuild} = require('../common/travis');
+const {isCiBuild} = require('../common/ci');
 
 /**
  * Entry point for `gulp babel-plugin-tests`. Runs the jest-based tests for
@@ -28,7 +28,7 @@ async function babelPluginTests() {
     automock: false,
     coveragePathIgnorePatterns: ['/node_modules/'],
     modulePathIgnorePatterns: ['/test/fixtures/', '<rootDir>/build/'],
-    reporters: [isTravisBuild() ? 'jest-silent-reporter' : 'jest-dot-reporter'],
+    reporters: [isCiBuild() ? 'jest-silent-reporter' : 'jest-dot-reporter'],
     setupFiles: ['./build-system/babel-plugins/testSetupFile.js'],
     testEnvironment: 'node',
     testPathIgnorePatterns: ['/node_modules/'],

--- a/build-system/tasks/check-exact-versions.js
+++ b/build-system/tasks/check-exact-versions.js
@@ -19,7 +19,7 @@ const colors = require('ansi-colors');
 const log = require('fancy-log');
 const {getStderr} = require('../common/exec');
 const {gitDiffFileMaster} = require('../common/git');
-const {isTravisBuild} = require('../common/travis');
+const {isCiBuild} = require('../common/ci');
 
 const PACKAGE_JSON_PATHS = [
   'package.json',
@@ -49,7 +49,7 @@ async function checkExactVersions() {
       console.log(gitDiffFileMaster(file));
       success = false;
     } else {
-      if (!isTravisBuild()) {
+      if (!isCiBuild()) {
         log(
           colors.green('SUCCESS:'),
           'All packages in',

--- a/build-system/tasks/check-links.js
+++ b/build-system/tasks/check-links.js
@@ -22,7 +22,7 @@ const path = require('path');
 const {getFilesToCheck, usesFilesOrLocalChanges} = require('../common/utils');
 const {gitDiffAddedNameOnlyMaster} = require('../common/git');
 const {green, cyan, red, yellow} = require('ansi-colors');
-const {isTravisBuild} = require('../common/travis');
+const {isCiBuild} = require('../common/ci');
 const {linkCheckGlobs} = require('../test-configs/config');
 const {maybeUpdatePackages} = require('./update-packages');
 
@@ -47,7 +47,7 @@ async function checkLinks() {
     log(green('INFO:'), 'Skipping check because this is a large refactor.');
     return;
   }
-  if (!isTravisBuild()) {
+  if (!isCiBuild()) {
     log(green('Starting checks...'));
   }
   filesIntroducedByPr = gitDiffAddedNameOnlyMaster();
@@ -72,7 +72,7 @@ function reportResults(results) {
     );
     log(
       yellow('NOTE 1:'),
-      "Valid links that don't resolve on Travis can be ignored via",
+      "Valid links that don't resolve during CI can be ignored via",
       cyan('ignorePatterns'),
       'in',
       cyan('build-system/tasks/check-links.js') + '.'
@@ -149,12 +149,12 @@ function checkLinksInFile(file) {
         }
         switch (status) {
           case 'alive':
-            if (!isTravisBuild()) {
+            if (!isCiBuild()) {
               log(`[${green('✔')}] ${link}`);
             }
             break;
           case 'ignored':
-            if (!isTravisBuild()) {
+            if (!isCiBuild()) {
               log(`[${yellow('•')}] ${link}`);
             }
             break;

--- a/build-system/tasks/check-owners.js
+++ b/build-system/tasks/check-owners.js
@@ -29,7 +29,7 @@ const request = require('request');
 const util = require('util');
 const {cyan, red, green} = require('ansi-colors');
 const {getFilesToCheck, usesFilesOrLocalChanges} = require('../common/utils');
-const {isTravisBuild} = require('../common/travis');
+const {isCiBuild} = require('../common/ci');
 
 const requestPost = util.promisify(request.post);
 
@@ -65,7 +65,7 @@ async function checkFile(file) {
   const contents = fs.readFileSync(file, 'utf8').toString();
   try {
     JSON5.parse(contents);
-    if (!isTravisBuild()) {
+    if (!isCiBuild()) {
       log(green('SUCCESS:'), 'No errors in', cyan(file));
     }
   } catch {

--- a/build-system/tasks/dep-check.js
+++ b/build-system/tasks/dep-check.js
@@ -32,7 +32,7 @@ const {
 const {compileJison} = require('./compile-jison');
 const {css} = require('./css');
 const {cyan, red, yellow} = require('ansi-colors');
-const {isTravisBuild} = require('../common/travis');
+const {isCiBuild} = require('../common/ci');
 
 const root = process.cwd();
 const absPathRegExp = new RegExp(`^${root}/`);
@@ -208,7 +208,7 @@ function getGraph(entryModule) {
   module.deps = [];
 
   // TODO(erwinm): Try and work this in with `gulp build` so that
-  // we're not running browserify twice on travis.
+  // we're not running browserify twice during CI.
   const bundler = browserify(entryModule, {
     debug: true,
     fast: true,
@@ -306,7 +306,7 @@ async function depCheck() {
   const handlerProcess = createCtrlcHandler('dep-check');
   await css();
   await compileJison();
-  if (!isTravisBuild()) {
+  if (!isCiBuild()) {
     log('Checking dependencies...');
   }
   return getSrcs()

--- a/build-system/tasks/dev-dashboard-tests.js
+++ b/build-system/tasks/dev-dashboard-tests.js
@@ -18,7 +18,7 @@
 const config = require('../test-configs/config');
 const globby = require('globby');
 const Mocha = require('mocha');
-const {isTravisBuild} = require('../common/travis');
+const {isCiBuild} = require('../common/ci');
 
 /**
  * Run all the dev dashboard tests
@@ -26,7 +26,7 @@ const {isTravisBuild} = require('../common/travis');
  */
 async function devDashboardTests() {
   const mocha = new Mocha({
-    reporter: isTravisBuild() ? 'mocha-silent-reporter' : 'spec',
+    reporter: isCiBuild() ? 'mocha-silent-reporter' : 'spec',
   });
 
   // Add our files

--- a/build-system/tasks/e2e/describes-e2e.js
+++ b/build-system/tasks/e2e/describes-e2e.js
@@ -38,7 +38,7 @@ const {AmpDriver, AmpdocEnvironment} = require('./amp-driver');
 const {Builder, Capabilities, logging} = require('selenium-webdriver');
 const {HOST, PORT} = require('../serve');
 const {installRepl, uninstallRepl} = require('./repl');
-const {isTravisBuild} = require('../../common/travis');
+const {isCiBuild} = require('../../common/ci');
 const {PuppeteerController} = require('./puppeteer-controller');
 
 /** Should have something in the name, otherwise nothing is shown. */
@@ -460,7 +460,7 @@ function describeEnv(factory) {
         await fixture.setup(env, browserName, SETUP_RETRIES);
 
         // don't install for CI
-        if (!isTravisBuild()) {
+        if (!isCiBuild()) {
           installRepl(global, env);
         }
       });
@@ -482,7 +482,7 @@ function describeEnv(factory) {
           delete env[key];
         }
 
-        if (!isTravisBuild()) {
+        if (!isCiBuild()) {
           uninstallRepl();
         }
       });

--- a/build-system/tasks/e2e/index.js
+++ b/build-system/tasks/e2e/index.js
@@ -34,13 +34,13 @@ const {
 const {cyan} = require('ansi-colors');
 const {execOrDie} = require('../../common/exec');
 const {HOST, PORT, startServer, stopServer} = require('../serve');
-const {isTravisBuild} = require('../../common/travis');
+const {isCiBuild} = require('../../common/ci');
 const {maybePrintCoverageMessage} = require('../helpers');
 const {reportTestStarted} = require('../report-test-status');
 const {watch} = require('gulp');
 
 const SLOW_TEST_THRESHOLD_MS = 2500;
-const TEST_RETRIES = isTravisBuild() ? 2 : 0;
+const TEST_RETRIES = isCiBuild() ? 2 : 0;
 
 const COV_DOWNLOAD_PATH = '/coverage/download';
 const COV_OUTPUT_DIR = './test/coverage-e2e';

--- a/build-system/tasks/e2e/mocha-dots-reporter.js
+++ b/build-system/tasks/e2e/mocha-dots-reporter.js
@@ -22,7 +22,7 @@ const {symbols} = require('../karma.conf').mochaReporter;
 
 /**
  * Custom Mocha reporter for CI builds.
- * Mimics the style of the Karma reporter on Travis.
+ * Mimics the style of the Karma reporter.
  * @param {*} runner
  */
 function MochaDotsReporter(runner) {

--- a/build-system/tasks/extension-helpers.js
+++ b/build-system/tasks/extension-helpers.js
@@ -25,7 +25,7 @@ const {
   verifyExtensionBundles,
 } = require('../compile/bundles.config');
 const {endBuildStep, watchDebounceDelay} = require('./helpers');
-const {isTravisBuild} = require('../common/travis');
+const {isCiBuild} = require('../common/ci');
 const {jsifyCssAsync} = require('./jsify-css');
 const {maybeToEsmName, compileJs, mkdirSync} = require('./helpers');
 const {vendorConfigs} = require('./vendor-configs');
@@ -217,7 +217,7 @@ function getExtensionsToBuild(preBuild = false) {
  * @param {boolean=} preBuild
  */
 function parseExtensionFlags(preBuild = false) {
-  if (isTravisBuild()) {
+  if (isCiBuild()) {
     return;
   }
 

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -39,7 +39,7 @@ const {applyConfig, removeConfig} = require('./prepend-global/index.js');
 const {closureCompile} = require('../compile/compile');
 const {EventEmitter} = require('events');
 const {green, red, cyan} = require('ansi-colors');
-const {isTravisBuild} = require('../common/travis');
+const {isCiBuild} = require('../common/ci');
 const {jsBundles} = require('../compile/bundles.config');
 const {thirdPartyFrames} = require('../test-configs/config');
 const {transpileTs} = require('../compile/typescript');
@@ -468,8 +468,7 @@ async function compileJs(srcDir, srcFilename, destDir, options) {
 }
 
 /**
- * Stops the timer for the given build step and prints the execution time,
- * unless we are on Travis.
+ * Stops the timer for the given build step and prints the execution time.
  * @param {string} stepName Name of the action, like 'Compiled' or 'Minified'
  * @param {string} targetName Name of the target, like a filename or path
  * @param {DOMHighResTimeStamp} startTime Start time of build step
@@ -503,7 +502,7 @@ function printConfigHelp(command) {
     cyan(argv.config === 'canary' ? 'canary' : 'prod'),
     green('AMP config.')
   );
-  if (!isTravisBuild()) {
+  if (!isCiBuild()) {
     log(
       green('⤷ Use'),
       cyan('--config={canary|prod}'),
@@ -539,7 +538,7 @@ function printNobuildHelp() {
  * @return {!Promise}
  */
 async function maybePrintCoverageMessage(covPath) {
-  if (!argv.coverage || isTravisBuild()) {
+  if (!argv.coverage || isCiBuild()) {
     return;
   }
 

--- a/build-system/tasks/lint.js
+++ b/build-system/tasks/lint.js
@@ -33,7 +33,7 @@ const {
   logOnSameLine,
 } = require('../common/utils');
 const {gitDiffNameOnlyMaster} = require('../common/git');
-const {isTravisBuild} = require('../common/travis');
+const {isCiBuild} = require('../common/ci');
 const {maybeUpdatePackages} = require('./update-packages');
 const {watchDebounceDelay} = require('./helpers');
 
@@ -62,7 +62,7 @@ function initializeStream(globs, streamOptions) {
  * @return {boolean}
  */
 function runLinter(stream) {
-  if (!isTravisBuild()) {
+  if (!isCiBuild()) {
     log(colors.green('Starting linter...'));
   }
   const options = {
@@ -81,7 +81,7 @@ function runLinter(stream) {
     .pipe(
       eslint.result(function (result) {
         const relativePath = path.relative(rootDir, result.filePath);
-        if (!isTravisBuild()) {
+        if (!isCiBuild()) {
           logOnSameLine(colors.green('Linted: ') + relativePath);
         }
         if (options.fix && result.fixed) {
@@ -97,7 +97,7 @@ function runLinter(stream) {
     .pipe(
       eslint.results(function (results) {
         if (results.errorCount == 0 && results.warningCount == 0) {
-          if (!isTravisBuild()) {
+          if (!isCiBuild()) {
             logOnSameLine(
               colors.green('SUCCESS: ') + 'No linter warnings or errors.'
             );
@@ -175,7 +175,7 @@ function eslintRulesChanged() {
  */
 function getFilesToLint(files) {
   const filesToLint = globby.sync(files, {gitignore: true});
-  if (!isTravisBuild()) {
+  if (!isCiBuild()) {
     log(colors.green('INFO: ') + 'Running lint on the following files:');
     filesToLint.forEach((file) => {
       log(colors.cyan(file));

--- a/build-system/tasks/performance/measure-documents.js
+++ b/build-system/tasks/performance/measure-documents.js
@@ -35,7 +35,7 @@ const {
 const {cyan, green} = require('ansi-colors');
 const {setupAdRequestHandler} = require('./ads-handler');
 
-// Require Puppeteer dynamically to prevent throwing error in Travis
+// Require Puppeteer dynamically to prevent throwing error during CI
 let puppeteer;
 
 function requirePuppeteer_() {

--- a/build-system/tasks/pr-check.js
+++ b/build-system/tasks/pr-check.js
@@ -130,8 +130,7 @@ module.exports = {
   prCheck,
 };
 
-prCheck.description =
-  'Runs a subset of the Travis CI checks against local changes.';
+prCheck.description = 'Runs a subset of the CI checks against local changes.';
 prCheck.flags = {
   'nobuild': '  Skips building the runtime via `gulp dist`.',
 };

--- a/build-system/tasks/prettify.js
+++ b/build-system/tasks/prettify.js
@@ -32,7 +32,7 @@ const tempy = require('tempy');
 const {exec} = require('../common/exec');
 const {getFilesToCheck, logOnSameLine} = require('../common/utils');
 const {green, cyan, red, yellow} = require('ansi-colors');
-const {isTravisBuild} = require('../common/travis');
+const {isCiBuild} = require('../common/ci');
 const {maybeUpdatePackages} = require('./update-packages');
 const {prettifyGlobs} = require('../test-configs/config');
 
@@ -82,12 +82,12 @@ function printErrorWithSuggestedFixes(file) {
  * @return {!Promise}
  */
 function runPrettify(filesToCheck) {
-  if (!isTravisBuild()) {
+  if (!isCiBuild()) {
     log(green('Starting checks...'));
   }
   return new Promise((resolve, reject) => {
     const onData = (data) => {
-      if (!isTravisBuild()) {
+      if (!isCiBuild()) {
         logOnSameLine(green('Checked: ') + path.relative(rootDir, data.path));
       }
     };
@@ -148,7 +148,7 @@ function runPrettify(filesToCheck) {
     };
 
     const onFinish = () => {
-      if (!isTravisBuild()) {
+      if (!isCiBuild()) {
         logOnSameLine('Checked ' + cyan(filesToCheck.length) + ' file(s)');
       }
       resolve();

--- a/build-system/tasks/runtime-test/helpers-unit.js
+++ b/build-system/tasks/runtime-test/helpers-unit.js
@@ -26,7 +26,7 @@ const {execOrDie} = require('../../common/exec');
 const {extensions, maybeInitializeExtensions} = require('../extension-helpers');
 const {gitDiffNameOnlyMaster} = require('../../common/git');
 const {green, cyan} = require('ansi-colors');
-const {isTravisBuild} = require('../../common/travis');
+const {isCiBuild} = require('../../common/ci');
 const {reportTestSkipped} = require('../report-test-status');
 
 const LARGE_REFACTOR_THRESHOLD = 50;
@@ -145,7 +145,7 @@ function getUnitTestsToRun() {
     reportTestSkipped();
     return;
   }
-  if (isTravisBuild() && tests.length > TEST_FILE_COUNT_THRESHOLD) {
+  if (isCiBuild() && tests.length > TEST_FILE_COUNT_THRESHOLD) {
     log(
       green('INFO:'),
       'Several tests were affected by local changes. Running all tests below.'
@@ -204,7 +204,7 @@ function unitTestsToRun() {
 
   filesChanged.forEach((file) => {
     if (!fs.existsSync(file)) {
-      if (!isTravisBuild()) {
+      if (!isCiBuild()) {
         log(green('INFO:'), 'Skipping', cyan(file), 'because it was deleted');
       }
     } else if (isUnitTest(file)) {

--- a/build-system/tasks/runtime-test/helpers.js
+++ b/build-system/tasks/runtime-test/helpers.js
@@ -20,7 +20,7 @@ const fs = require('fs');
 const log = require('fancy-log');
 const path = require('path');
 const {green, yellow, cyan} = require('ansi-colors');
-const {isTravisBuild} = require('../../common/travis');
+const {isCiBuild} = require('../../common/ci');
 const {maybePrintCoverageMessage} = require('../helpers');
 const {reportTestRunComplete} = require('../report-test-status');
 const {Server} = require('karma');
@@ -72,7 +72,7 @@ function getAdTypes() {
  * Prints help messages for args if tests are being run for local development.
  */
 function maybePrintArgvMessages() {
-  if (argv.nohelp || isTravisBuild()) {
+  if (argv.nohelp || isCiBuild()) {
     return;
   }
 

--- a/build-system/tasks/runtime-test/runtime-test-base.js
+++ b/build-system/tasks/runtime-test/runtime-test-base.js
@@ -27,8 +27,8 @@ const {app} = require('../../server/test-server');
 const {createKarmaServer, getAdTypes} = require('./helpers');
 const {getFilesFromArgv} = require('../../common/utils');
 const {green, yellow, cyan, red} = require('ansi-colors');
+const {isCiBuild} = require('../../common/ci');
 const {isGithubActionsBuild} = require('../../common/github-actions');
-const {isTravisBuild} = require('../../common/travis');
 const {reportTestStarted} = require('.././report-test-status');
 const {startServer, stopServer} = require('../serve');
 const {unitTestsToRun} = require('./helpers-unit');
@@ -109,7 +109,7 @@ function updateBrowsers(config) {
 
   // Default to Chrome.
   Object.assign(config, {
-    browsers: [isTravisBuild() ? 'Chrome_travis_ci' : 'Chrome_no_extensions'],
+    browsers: [isCiBuild() ? 'Chrome_ci' : 'Chrome_no_extensions'],
   });
 }
 
@@ -159,7 +159,7 @@ function getFiles(testType) {
 function updateReporters(config) {
   if (
     (argv.testnames || argv.local_changes || argv.files || argv.verbose) &&
-    !isTravisBuild()
+    !isCiBuild()
   ) {
     config.reporters = ['mocha'];
   }
@@ -209,9 +209,7 @@ class RuntimeTestConfig {
       this.plugins.push('karma-coverage-istanbul-reporter');
       this.coverageIstanbulReporter = {
         dir: 'test/coverage',
-        reports: isTravisBuild()
-          ? ['lcovonly']
-          : ['html', 'text', 'text-summary'],
+        reports: isCiBuild() ? ['lcovonly'] : ['html', 'text', 'text-summary'],
         'report-config': {lcovonly: {file: `lcov-${testType}.info`}},
       };
     }

--- a/build-system/tasks/server-tests.js
+++ b/build-system/tasks/server-tests.js
@@ -24,7 +24,7 @@ const posthtml = require('posthtml');
 const through = require('through2');
 const {buildNewServer} = require('../server/typescript-compile');
 const {cyan, green, red} = require('ansi-colors');
-const {isTravisBuild} = require('../common/travis');
+const {isCiBuild} = require('../common/ci');
 
 const transformsDir = path.resolve('build-system/server/new-server/transforms');
 const inputPaths = [`${transformsDir}/**/input.html`];
@@ -191,7 +191,7 @@ function runTest() {
       return;
     }
     ++passed;
-    if (!isTravisBuild()) {
+    if (!isCiBuild()) {
       console.log(green('✔'), 'Passed', cyan(testName));
     }
     cb();

--- a/build-system/tasks/update-packages.js
+++ b/build-system/tasks/update-packages.js
@@ -21,7 +21,7 @@ const del = require('del');
 const fs = require('fs-extra');
 const log = require('fancy-log');
 const {execOrDie} = require('../common/exec');
-const {isTravisBuild} = require('../common/travis');
+const {isCiBuild} = require('../common/ci');
 
 /**
  * Writes the given contents to the patched file if updated
@@ -31,7 +31,7 @@ const {isTravisBuild} = require('../common/travis');
 function writeIfUpdated(patchedName, file) {
   if (!fs.existsSync(patchedName) || fs.readFileSync(patchedName) != file) {
     fs.writeFileSync(patchedName, file);
-    if (!isTravisBuild()) {
+    if (!isCiBuild()) {
       log(colors.green('Patched'), colors.cyan(patchedName));
     }
   }
@@ -104,7 +104,9 @@ function removeRruleSourcemap() {
   const rruleMapFile = 'node_modules/rrule/dist/es5/rrule.js.map';
   if (fs.existsSync(rruleMapFile)) {
     del.sync(rruleMapFile);
-    log(colors.green('Deleted'), colors.cyan(rruleMapFile));
+    if (!isCiBuild()) {
+      log(colors.green('Deleted'), colors.cyan(rruleMapFile));
+    }
   }
 }
 
@@ -140,7 +142,7 @@ function runNpmCheck() {
  * Used as a pre-requisite by several gulp tasks.
  */
 function maybeUpdatePackages() {
-  if (!isTravisBuild()) {
+  if (!isCiBuild()) {
     updatePackages();
   }
 }
@@ -150,7 +152,7 @@ function maybeUpdatePackages() {
  * polyfills if necessary.
  */
 async function updatePackages() {
-  if (!isTravisBuild()) {
+  if (!isCiBuild()) {
     runNpmCheck();
   }
   patchWebAnimations();

--- a/validator/build.py
+++ b/validator/build.py
@@ -129,12 +129,12 @@ def InstallNodeDependencies():
   logging.info('installing AMP Validator engine dependencies ...')
   subprocess.check_call(
       ['npm', 'install', '--userconfig', '../.npmrc'],
-      stdout=(open(os.devnull, 'wb') if os.environ.get('TRAVIS') else sys.stdout))
+      stdout=(open(os.devnull, 'wb') if os.environ.get('CI') else sys.stdout))
   logging.info('installing AMP Validator nodejs dependencies ...')
   subprocess.check_call(['npm', 'install', '--userconfig', '../../../.npmrc'],
                         cwd='js/nodejs',
                         stdout=(open(os.devnull, 'wb')
-                                if os.environ.get('TRAVIS') else sys.stdout))
+                                if os.environ.get('CI') else sys.stdout))
   logging.info('... done')
 
 
@@ -586,7 +586,7 @@ def Main(parsed_args):
   """The main method, which executes all build steps and runs the tests."""
   logging.basicConfig(
       format='[[%(filename)s %(funcName)s]] - %(message)s',
-      level=(logging.ERROR if os.environ.get('TRAVIS') else logging.INFO))
+      level=(logging.ERROR if os.environ.get('CI') else logging.INFO))
   EnsureNodeJsIsInstalled()
   CheckPrereqs()
   InstallNodeDependencies()

--- a/validator/js/webui/build.py
+++ b/validator/js/webui/build.py
@@ -97,7 +97,7 @@ def InstallNodeDependencies():
   logging.info('installing AMP Validator webui dependencies ...')
   subprocess.check_call(
       ['npm', 'install', '--userconfig', '../../../.npmrc'],
-      stdout=(open(os.devnull, 'wb') if os.environ.get('TRAVIS') else sys.stdout))
+      stdout=(open(os.devnull, 'wb') if os.environ.get('CI') else sys.stdout))
   logging.info('... done')
 
 
@@ -149,7 +149,7 @@ def Main():
   """The main method, which executes all build steps and runs the tests."""
   logging.basicConfig(
       format='[[%(filename)s %(funcName)s]] - %(message)s',
-      level=(logging.ERROR if os.environ.get('TRAVIS') else logging.INFO))
+      level=(logging.ERROR if os.environ.get('CI') else logging.INFO))
   GetNodeJsCmd()
   CheckPrereqs()
   InstallNodeDependencies()


### PR DESCRIPTION
This PR updates all spots where the question "is this a Travis build" can be reasonably replaced by "is this a CI build". It does so by adding a new function called `isCiBuild()` to replace `isTravisBuild()`.

As written, this should be a no-op for our CI builds. Other changes to follow in subsequent PRs.

**References:**
- https://docs.travis-ci.com/user/environment-variables/#default-environment-variables
- https://docs.github.com/en/free-pro-team@latest/actions/reference/environment-variables#default-environment-variables
- https://circleci.com/docs/2.0/env-vars/#built-in-environment-variables

Partial fix for #31416
