### PR TITLE
IntersectionObserver Polyfill: per-instance impl selection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16076,9 +16076,9 @@
       "dev": true
     },
     "intersection-observer": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/intersection-observer/-/intersection-observer-0.11.0.tgz",
-      "integrity": "sha512-KZArj2QVnmdud9zTpKf279m2bbGfG+4/kn16UU0NL3pTVl52ZHiJ9IRNSsnn6jaHrL9EGLFM5eWjTx2fz/+zoQ=="
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/intersection-observer/-/intersection-observer-0.12.0.tgz",
+      "integrity": "sha512-2Vkz8z46Dv401zTWudDGwO7KiGHNDkMv417T5ItcNYfmvHR/1qCTVBO9vwH8zZmQ0WkA/1ARwpysR9bsnop4NQ=="
     },
     "invert-kv": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@ampproject/viewer-messaging": "1.1.0",
     "@ampproject/worker-dom": "0.27.4",
     "dompurify": "2.0.7",
-    "intersection-observer": "0.11.0",
+    "intersection-observer": "0.12.0",
     "jss": "10.3.0",
     "jss-preset-default": "10.4.0",
     "moment": "2.24.0",

--- a/src/polyfills/intersection-observer.js
+++ b/src/polyfills/intersection-observer.js
@@ -20,8 +20,8 @@
  */
 
 import {
+  installStub,
   shouldLoadPolyfill,
-  installStub
 } from '../polyfillstub/intersection-observer-stub';
 
 /**
@@ -29,11 +29,11 @@ import {
  * - No native support: immediately register a Stub and upgrade lazily once the full polyfill loads.
  * - Partial InOb support: choose between the lazily upgrading Stub and the native InOb on a per-instance basis.
  * - Full InOb support: Don't install anything.
- * 
+ *
  * @param {!Window} win
  */
 export function install(win) {
-  if (shouldLoadPolyfill(win)) { 
+  if (shouldLoadPolyfill(win)) {
     installStub(win);
   }
   fixEntry(win);

--- a/src/polyfills/intersection-observer.js
+++ b/src/polyfills/intersection-observer.js
@@ -19,14 +19,27 @@
  * See https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver.
  */
 
-import {IntersectionObserverStub} from '../polyfillstub/intersection-observer-stub';
+import {
+  IntersectionObserverStub,
+  supportsDocumentRoot,
+} from '../polyfillstub/intersection-observer-stub';
 
 /**
  * @param {!Window} win
  */
 export function install(win) {
-  if (!win.IntersectionObserver) {
+  const NativeIntersectionObserver = win.IntersectionObserver;
+  if (!NativeIntersectionObserver) {
     win.IntersectionObserver = /** @type {typeof IntersectionObserver} */ (IntersectionObserverStub);
+  } else if (!supportsDocumentRoot(win)) {
+    win.IntersectionObserver = function (ioCallback, opts) {
+      if (opts && opts.root && opts.root.nodeType === 9) {
+        return new IntersectionObserverStub(ioCallback, opts);
+      } else {
+        return new NativeIntersectionObserver(ioCallback, opts);
+      }
+    };
+    win.IntersectionObserver.native = NativeIntersectionObserver;
   }
   fixEntry(win);
 }

--- a/src/polyfills/intersection-observer.js
+++ b/src/polyfills/intersection-observer.js
@@ -20,26 +20,21 @@
  */
 
 import {
-  IntersectionObserverStub,
-  supportsDocumentRoot,
+  shouldLoadPolyfill,
+  installStub
 } from '../polyfillstub/intersection-observer-stub';
 
 /**
+ * Installs the IntersectionObserver polyfill. There are a few different modes of operation.
+ * - No native support: immediately register a Stub and upgrade lazily once the full polyfill loads.
+ * - Partial InOb support: choose between the lazily upgrading Stub and the native InOb on a per-instance basis.
+ * - Full InOb support: Don't install anything.
+ * 
  * @param {!Window} win
  */
 export function install(win) {
-  const NativeIntersectionObserver = win.IntersectionObserver;
-  if (!NativeIntersectionObserver) {
-    win.IntersectionObserver = /** @type {typeof IntersectionObserver} */ (IntersectionObserverStub);
-  } else if (!supportsDocumentRoot(win)) {
-    win.IntersectionObserver = function (ioCallback, opts) {
-      if (opts && opts.root && opts.root.nodeType === 9) {
-        return new IntersectionObserverStub(ioCallback, opts);
-      } else {
-        return new NativeIntersectionObserver(ioCallback, opts);
-      }
-    };
-    win.IntersectionObserver.native = NativeIntersectionObserver;
+  if (shouldLoadPolyfill(win)) { 
+    installStub(win);
   }
   fixEntry(win);
 }

--- a/src/polyfillstub/intersection-observer-stub.js
+++ b/src/polyfillstub/intersection-observer-stub.js
@@ -26,8 +26,8 @@
 import {Services} from '../services';
 
 const UPGRADERS = '_upgraders';
-const NATIVE = 'AMP__NATIVE_INOB';
-const STUB = 'AMP_STUB_INOB';
+const NATIVE = '_native';
+const STUB = '_stub';
 
 /**
  * @param {!Window} win

--- a/src/polyfillstub/intersection-observer-stub.js
+++ b/src/polyfillstub/intersection-observer-stub.js
@@ -41,8 +41,8 @@ let PolyfilledIntersectionObserver;
 export function shouldLoadPolyfill(win) {
   return (
     !win.IntersectionObserver ||
-    win.IntersectionObserver === IntersectionObserverStub ||
     !win.IntersectionObserverEntry ||
+    !!PolyfilledIntersectionObserver ||
     !supportsDocumentRoot(win)
   );
 }
@@ -75,6 +75,7 @@ export function installStub(win) {
 }
 
 /**
+ * Returns true if IntersectionObserver supports a document root.
  * @param {!Window} win
  * @return {boolean}
  */

--- a/src/polyfillstub/intersection-observer-stub.js
+++ b/src/polyfillstub/intersection-observer-stub.js
@@ -43,7 +43,11 @@ export function shouldLoadPolyfill(win) {
   );
 }
 
-/** @type {!function(typeof IntersectionObserver, typeof IntersectionObserver): typeof IntersectionObserver} */
+/**
+ * @param {typeof IntersectionObserver} Native
+ * @param {typeof IntersectionObserver} Polyfill
+ * @returns {typeof IntersectionObserver}
+ */
 function getIntersectionObserverDispatcher(Native, Polyfill) {
   return function (ioCallback, opts) {
     if (opts && opts.root && opts.root.nodeType === 9) {

--- a/src/polyfillstub/intersection-observer-stub.js
+++ b/src/polyfillstub/intersection-observer-stub.js
@@ -46,7 +46,7 @@ export function shouldLoadPolyfill(win) {
 /**
  * @param {typeof IntersectionObserver} Native
  * @param {typeof IntersectionObserver} Polyfill
- * @returns {typeof IntersectionObserver}
+ * @return {typeof IntersectionObserver}
  */
 function getIntersectionObserverDispatcher(Native, Polyfill) {
   return function (ioCallback, opts) {

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -237,19 +237,15 @@ export class ResourcesImpl {
       const root = /** @type {?Element} */ (this.ampdoc.isSingleDoc() && iframed
         ? /** @type {*} */ (this.win.document)
         : null);
-      try {
-        this.intersectionObserver_ = new IntersectionObserver(
-          (e) => this.intersect(e),
-          // rootMargin matches size of loadRect: (150vw 300vh) * 1.25.
-          {root, rootMargin: '250% 31.25%'}
-        );
+      this.intersectionObserver_ = new IntersectionObserver(
+        (e) => this.intersect(e),
+        // rootMargin matches size of loadRect: (150vw 300vh) * 1.25.
+        {root, rootMargin: '250% 31.25%'}
+      );
 
-        // Wait for intersection callback instead of measuring all elements
-        // during the first pass.
-        this.relayoutAll_ = false;
-      } catch (e) {
-        dev().warn(TAG_, 'Falling back to classic Resources:', e);
-      }
+      // Wait for intersection callback instead of measuring all elements
+      // during the first pass.
+      this.relayoutAll_ = false;
     }
 
     // When user scrolling stops, run pass to check newly in-viewport elements.

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -234,14 +234,19 @@ export class ResourcesImpl {
       // Classic IntersectionObserver doesn't support viewport tracking and
       // rootMargin in x-origin iframes (#25428). As of 1/2020, only Chrome 81+
       // supports it via {root: document}, which throws on other browsers.
-      const root = /** @type {?Element} */ (this.ampdoc.isSingleDoc() && iframed
-        ? /** @type {*} */ (this.win.document)
-        : null);
-      this.intersectionObserver_ = new IntersectionObserver(
-        (e) => this.intersect(e),
-        // rootMargin matches size of loadRect: (150vw 300vh) * 1.25.
-        {root, rootMargin: '250% 31.25%'}
-      );
+      try {
+        const root = /** @type {?Element} */ (this.ampdoc.isSingleDoc() &&
+        iframed
+          ? /** @type {*} */ (this.win.document)
+          : null);
+        this.intersectionObserver_ = new IntersectionObserver(
+          (e) => this.intersect(e),
+          // rootMargin matches size of loadRect: (150vw 300vh) * 1.25.
+          {root, rootMargin: '250% 31.25%'}
+        );
+      } catch (e) {
+        dev().warn(TAG_, 'Falling back to classic Resources:', e);
+      }
 
       // Wait for intersection callback instead of measuring all elements
       // during the first pass.

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -234,23 +234,22 @@ export class ResourcesImpl {
       // Classic IntersectionObserver doesn't support viewport tracking and
       // rootMargin in x-origin iframes (#25428). As of 1/2020, only Chrome 81+
       // supports it via {root: document}, which throws on other browsers.
+      const root = /** @type {?Element} */ (this.ampdoc.isSingleDoc() && iframed
+        ? /** @type {*} */ (this.win.document)
+        : null);
       try {
-        const root = /** @type {?Element} */ (this.ampdoc.isSingleDoc() &&
-        iframed
-          ? /** @type {*} */ (this.win.document)
-          : null);
         this.intersectionObserver_ = new IntersectionObserver(
           (e) => this.intersect(e),
           // rootMargin matches size of loadRect: (150vw 300vh) * 1.25.
           {root, rootMargin: '250% 31.25%'}
         );
+
+        // Wait for intersection callback instead of measuring all elements
+        // during the first pass.
+        this.relayoutAll_ = false;
       } catch (e) {
         dev().warn(TAG_, 'Falling back to classic Resources:', e);
       }
-
-      // Wait for intersection callback instead of measuring all elements
-      // during the first pass.
-      this.relayoutAll_ = false;
     }
 
     // When user scrolling stops, run pass to check newly in-viewport elements.

--- a/test/unit/polyfills/test-intersection-observer.js
+++ b/test/unit/polyfills/test-intersection-observer.js
@@ -15,8 +15,8 @@
  */
 
 import {
-  installStub,
   IntersectionObserverStub,
+  installStub,
   resetSubsForTesting,
   shouldLoadPolyfill,
   upgradePolyfill,
@@ -70,7 +70,7 @@ describes.sandboxed('shouldLoadPolyfill', {}, () => {
 
   it('should load when native does not support {root: document}', () => {
     class NativeNoDocumentRoot {
-      constructor(cb, opt) {
+      constructor(_unused, opts) {
         if (opts && opts.root && opts.root.nodeType === 9) {
           throw new TypeError();
         }

--- a/test/unit/polyfills/test-intersection-observer.js
+++ b/test/unit/polyfills/test-intersection-observer.js
@@ -313,7 +313,7 @@ describes.fakeWin('upgradePolyfill', {}, (env) => {
     );
   });
 
-  it('should auto-upgrade any stub post install even when native InOb present and continue returning Native for non docroot.', async () => {
+  it('should choose best InOb possible before and after upgrade, as well as upgrade rootdoc stubs.', async () => {
     const {win} = env;
     function NativeInOb(_ioCallback, opts) {
       if (opts && opts.root && opts.root.nodeType === 9) {


### PR DESCRIPTION
### summary

Modifies the `IntersectionObserverStub` and polyfill installer in order to select the best possible IntersectionObserver on a per-instance basis.

- If `win.IntersectionObserver` is undefined --> immediately install the stub, later upgrade to polyfill.
- If IntersectionObserver is present, but it doesn't support document root --> use a dispatcher that returns a stub/polyfill or native InOb depending on the constructor args
- If IntersectionObserver is present and supports all features: just use native.

**also updates polyfill version + resources-impl integration**