### PR TITLE
🚮 Sweep experiments (demo)

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -16,7 +16,6 @@
   "doubleclickSraExp": 0.01,
   "doubleclickSraReportExcludedBlock": 0.1,
   "expand-json-targeting": 1,
-  "fixed-elements-in-lightbox": 1,
   "flexAdSlots": 0.05,
   "intersect-resources": 0,
   "ios-fixed-no-transfer": 1,

--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -21,7 +21,6 @@
   "ios-fixed-no-transfer": 1,
   "remove-task-timeout": 0,
   "swg-gpay-api": 1,
-  "swg-gpay-native": 1,
   "amp-ad-no-center-css": 0,
   "render-on-idle-fix": 1,
   "build-in-chunks": 1,

--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -19,7 +19,6 @@
   "flexAdSlots": 0.05,
   "intersect-resources": 0,
   "ios-fixed-no-transfer": 1,
-  "pump-early-frame": 1,
   "remove-task-timeout": 0,
   "swg-gpay-api": 1,
   "swg-gpay-native": 1,

--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -16,7 +16,6 @@
   "doubleclickSraExp": 0.01,
   "doubleclickSraReportExcludedBlock": 0.1,
   "expand-json-targeting": 1,
-  "fix-inconsistent-responsive-height-selection": 0,
   "fixed-elements-in-lightbox": 1,
   "flexAdSlots": 0.05,
   "intersect-resources": 0,

--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -13,7 +13,6 @@
   "amp-ad-ff-adx-ady": 0.01,
   "amp-auto-ads-adsense-holdout": 0.1,
   "ampdoc-fie": 1,
-  "amp-story-responsive-units": 1,
   "amp-story-v1": 1,
   "chunked-amp": 1,
   "doubleclickSraExp": 0.01,

--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -13,7 +13,6 @@
   "amp-ad-ff-adx-ady": 0.01,
   "amp-auto-ads-adsense-holdout": 0.1,
   "ampdoc-fie": 1,
-  "amp-playbuzz": 1,
   "amp-sidebar-swipe-to-dismiss": 1,
   "amp-story-responsive-units": 1,
   "amp-story-v1": 1,

--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -13,7 +13,6 @@
   "amp-ad-ff-adx-ady": 0.01,
   "amp-auto-ads-adsense-holdout": 0.1,
   "ampdoc-fie": 1,
-  "amp-story-v1": 1,
   "chunked-amp": 1,
   "doubleclickSraExp": 0.01,
   "doubleclickSraReportExcludedBlock": 0.1,

--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -13,7 +13,6 @@
   "amp-ad-ff-adx-ady": 0.01,
   "amp-auto-ads-adsense-holdout": 0.1,
   "ampdoc-fie": 1,
-  "chunked-amp": 1,
   "doubleclickSraExp": 0.01,
   "doubleclickSraReportExcludedBlock": 0.1,
   "expand-json-targeting": 1,

--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -13,7 +13,6 @@
   "amp-ad-ff-adx-ady": 0.01,
   "amp-auto-ads-adsense-holdout": 0.1,
   "ampdoc-fie": 1,
-  "amp-nested-menu": 1,
   "amp-playbuzz": 1,
   "amp-sidebar-swipe-to-dismiss": 1,
   "amp-story-responsive-units": 1,

--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -13,7 +13,6 @@
   "amp-ad-ff-adx-ady": 0.01,
   "amp-auto-ads-adsense-holdout": 0.1,
   "ampdoc-fie": 1,
-  "amp-sidebar-swipe-to-dismiss": 1,
   "amp-story-responsive-units": 1,
   "amp-story-v1": 1,
   "chunked-amp": 1,

--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -10,7 +10,6 @@
   "canary": 1,
   "a4aProfilingRate": 0.01,
   "adsense-ad-size-optimization": 0.1,
-  "amp-action-macro": 1,
   "amp-ad-ff-adx-ady": 0.01,
   "amp-auto-ads-adsense-holdout": 0.1,
   "ampdoc-fie": 1,

--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -13,7 +13,6 @@
   "amp-ad-ff-adx-ady": 0.01,
   "amp-auto-ads-adsense-holdout": 0.1,
   "ampdoc-fie": 1,
-  "amp-mega-menu": 1,
   "amp-nested-menu": 1,
   "amp-playbuzz": 1,
   "amp-sidebar-swipe-to-dismiss": 1,

--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -1,11 +1,15 @@
 {
-  "allow-doc-opt-in": ["amp-next-page", "analytics-chunks-inabox"],
-  "allow-url-opt-in": ["pump-early-frame"],
+  "allow-doc-opt-in": [
+    "amp-next-page",
+    "analytics-chunks-inabox"
+  ],
+  "allow-url-opt-in": [
+    "pump-early-frame"
+  ],
   "amp-accordion-display-locking": 1,
   "canary": 1,
   "a4aProfilingRate": 0.01,
   "adsense-ad-size-optimization": 0.1,
-  "amp-access-iframe": 1,
   "amp-action-macro": 1,
   "amp-ad-ff-adx-ady": 0.01,
   "amp-auto-ads-adsense-holdout": 0.1,

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -20,7 +20,6 @@
   "intersect-resources": 0,
   "ios-fixed-no-transfer": 0,
   "swg-gpay-api": 1,
-  "swg-gpay-native": 1,
   "amp-ad-no-center-css": 0,
   "adsense-ptt-exp": 0.1,
   "doubleclick-ptt-exp": 0.1,

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -1,10 +1,14 @@
 {
-  "allow-doc-opt-in": ["amp-next-page", "analytics-chunks-inabox"],
-  "allow-url-opt-in": ["pump-early-frame"],
+  "allow-doc-opt-in": [
+    "amp-next-page",
+    "analytics-chunks-inabox"
+  ],
+  "allow-url-opt-in": [
+    "pump-early-frame"
+  ],
   "canary": 0,
   "a4aProfilingRate": 0.01,
   "adsense-ad-size-optimization": 0.1,
-  "amp-access-iframe": 1,
   "amp-accordion-display-locking": 1,
   "amp-action-macro": 1,
   "amp-ad-ff-adx-ady": 0.01,

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -19,7 +19,6 @@
   "flexAdSlots": 0.05,
   "intersect-resources": 0,
   "ios-fixed-no-transfer": 0,
-  "pump-early-frame": 1,
   "swg-gpay-api": 1,
   "swg-gpay-native": 1,
   "amp-ad-no-center-css": 0,

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -10,7 +10,6 @@
   "a4aProfilingRate": 0.01,
   "adsense-ad-size-optimization": 0.1,
   "amp-accordion-display-locking": 1,
-  "amp-action-macro": 1,
   "amp-ad-ff-adx-ady": 0.01,
   "amp-auto-ads-adsense-holdout": 0.1,
   "ampdoc-fie": 1,

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -16,7 +16,6 @@
   "doubleclickSraExp": 0.01,
   "doubleclickSraReportExcludedBlock": 0.1,
   "expand-json-targeting": 1,
-  "fix-inconsistent-responsive-height-selection": 0,
   "fixed-elements-in-lightbox": 1,
   "flexAdSlots": 0.05,
   "intersect-resources": 0,

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -13,7 +13,6 @@
   "amp-ad-ff-adx-ady": 0.01,
   "amp-auto-ads-adsense-holdout": 0.1,
   "ampdoc-fie": 1,
-  "amp-story-responsive-units": 1,
   "amp-story-v1": 1,
   "chunked-amp": 1,
   "doubleclickSraExp": 0.01,

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -13,7 +13,6 @@
   "amp-ad-ff-adx-ady": 0.01,
   "amp-auto-ads-adsense-holdout": 0.1,
   "ampdoc-fie": 1,
-  "amp-playbuzz": 1,
   "amp-sidebar-swipe-to-dismiss": 1,
   "amp-story-responsive-units": 1,
   "amp-story-v1": 1,

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -13,7 +13,6 @@
   "amp-ad-ff-adx-ady": 0.01,
   "amp-auto-ads-adsense-holdout": 0.1,
   "ampdoc-fie": 1,
-  "amp-story-v1": 1,
   "chunked-amp": 1,
   "doubleclickSraExp": 0.01,
   "doubleclickSraReportExcludedBlock": 0.1,

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -13,7 +13,6 @@
   "amp-ad-ff-adx-ady": 0.01,
   "amp-auto-ads-adsense-holdout": 0.1,
   "ampdoc-fie": 1,
-  "chunked-amp": 1,
   "doubleclickSraExp": 0.01,
   "doubleclickSraReportExcludedBlock": 0.1,
   "expand-json-targeting": 1,

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -13,7 +13,6 @@
   "amp-ad-ff-adx-ady": 0.01,
   "amp-auto-ads-adsense-holdout": 0.1,
   "ampdoc-fie": 1,
-  "amp-nested-menu": 1,
   "amp-playbuzz": 1,
   "amp-sidebar-swipe-to-dismiss": 1,
   "amp-story-responsive-units": 1,

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -13,7 +13,6 @@
   "amp-ad-ff-adx-ady": 0.01,
   "amp-auto-ads-adsense-holdout": 0.1,
   "ampdoc-fie": 1,
-  "amp-sidebar-swipe-to-dismiss": 1,
   "amp-story-responsive-units": 1,
   "amp-story-v1": 1,
   "chunked-amp": 1,

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -13,7 +13,6 @@
   "amp-ad-ff-adx-ady": 0.01,
   "amp-auto-ads-adsense-holdout": 0.1,
   "ampdoc-fie": 1,
-  "amp-mega-menu": 1,
   "amp-nested-menu": 1,
   "amp-playbuzz": 1,
   "amp-sidebar-swipe-to-dismiss": 1,

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -16,7 +16,6 @@
   "doubleclickSraExp": 0.01,
   "doubleclickSraReportExcludedBlock": 0.1,
   "expand-json-targeting": 1,
-  "fixed-elements-in-lightbox": 1,
   "flexAdSlots": 0.05,
   "intersect-resources": 0,
   "ios-fixed-no-transfer": 0,

--- a/extensions/amp-access/0.1/amp-access-source.js
+++ b/extensions/amp-access/0.1/amp-access-source.js
@@ -229,7 +229,7 @@ export class AccessSource {
     }
     if (
       type == AccessType.IFRAME &&
-      !isExperimentOn(this.ampdoc.win, 'amp-access-iframe')
+      !true /* experiment: amp-access-iframe */
     ) {
       user().error(TAG, 'Experiment "amp-access-iframe" is not enabled.');
       type = AccessType.CLIENT;

--- a/extensions/amp-access/0.1/test/test-amp-access-source.js
+++ b/extensions/amp-access/0.1/test/test-amp-access-source.js
@@ -58,7 +58,6 @@ describes.fakeWin(
 
     afterEach(() => {
       toggleExperiment(win, 'amp-access-server', false);
-      toggleExperiment(win, 'amp-access-iframe', false);
     });
 
     function expectSourceType(ampdoc, config, type, adapter) {
@@ -114,7 +113,6 @@ describes.fakeWin(
       allowConsoleError(() => {
         config['type'] = 'iframe';
         expectSourceType(ampdoc, config, 'client', AccessClientAdapter);
-        toggleExperiment(win, 'amp-access-iframe', true);
         expectSourceType(ampdoc, config, 'iframe', AccessIframeAdapter);
       });
 

--- a/extensions/amp-action-macro/0.1/amp-action-macro.js
+++ b/extensions/amp-action-macro/0.1/amp-action-macro.js
@@ -38,10 +38,7 @@ export class AmpActionMacro extends AMP.BaseElement {
 
   /** @override */
   buildCallback() {
-    userAssert(
-      isExperimentOn(this.win, 'amp-action-macro'),
-      'Experiment is off'
-    );
+    userAssert(true /* experiment: amp-action-macro */, 'Experiment is off');
     const {element} = this;
 
     this.actions_ = Services.actionServiceForDoc(element);

--- a/extensions/amp-action-macro/0.1/test/test-amp-action-macro.js
+++ b/extensions/amp-action-macro/0.1/test/test-amp-action-macro.js
@@ -35,8 +35,6 @@ describes.realWin(
     beforeEach(() => {
       win = env.win;
       doc = win.document;
-
-      toggleExperiment(win, 'amp-action-macro', true);
     });
 
     function newActionMacro() {
@@ -60,7 +58,6 @@ describes.realWin(
 
     it('should not build if experiment is off', () => {
       return allowConsoleError(() => {
-        toggleExperiment(env.win, 'amp-action-macro', false);
         return newActionMacro().catch((err) => {
           expect(err.message).to.include('Experiment is off');
         });
@@ -75,8 +72,6 @@ describes.realWin(
       let unreferrableMacro;
       let unreferrableMacroElement;
       beforeEach(() => {
-        toggleExperiment(win, 'amp-action-macro', true);
-
         // This macro is referrable and can be invoked by the macro element(s)
         // defined after it.
         referrableMacroElement = doc.createElement('amp-action-macro');

--- a/extensions/amp-playbuzz/0.1/amp-playbuzz.js
+++ b/extensions/amp-playbuzz/0.1/amp-playbuzz.js
@@ -109,7 +109,7 @@ class AmpPlaybuzz extends AMP.BaseElement {
     // EXPERIMENT
     // AMP.toggleExperiment(EXPERIMENT, true); //for dev
     userAssert(
-      isExperimentOn(this.win, 'amp-playbuzz'),
+      true /* experiment: amp-playbuzz */,
       'Enable amp-playbuzz experiment'
     );
 

--- a/extensions/amp-playbuzz/0.1/test/test-amp-playbuzz.js
+++ b/extensions/amp-playbuzz/0.1/test/test-amp-playbuzz.js
@@ -30,7 +30,6 @@ describes.realWin(
     beforeEach(() => {
       win = env.win;
       doc = win.document;
-      toggleExperiment(win, 'amp-playbuzz', true);
     });
 
     function createOptionalParams(

--- a/extensions/amp-sidebar/0.1/amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/amp-sidebar.js
@@ -573,7 +573,7 @@ export class AmpSidebar extends AMP.BaseElement {
    * @private
    */
   setupGestures_(element) {
-    if (!isExperimentOn(this.win, 'amp-sidebar-swipe-to-dismiss')) {
+    if (!true /* experiment: amp-sidebar-swipe-to-dismiss */) {
       return;
     }
     // stop propagation of swipe event inside amp-viewer

--- a/extensions/amp-sidebar/0.2/amp-sidebar.js
+++ b/extensions/amp-sidebar/0.2/amp-sidebar.js
@@ -574,7 +574,7 @@ export class AmpSidebar extends AMP.BaseElement {
    * @private
    */
   setupGestures_(element) {
-    if (!isExperimentOn(this.win, 'amp-sidebar-swipe-to-dismiss')) {
+    if (!true /* experiment: amp-sidebar-swipe-to-dismiss */) {
       return;
     }
     // stop propagation of swipe event inside amp-viewer

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -586,7 +586,7 @@ export class AmpStory extends AMP.BaseElement {
    * @private
    */
   rewriteStyles_(styleEl) {
-    if (!isExperimentOn(this.win, 'amp-story-responsive-units')) {
+    if (!true /* experiment: amp-story-responsive-units */) {
       return;
     }
 

--- a/extensions/amp-story/1.0/test/test-amp-story.js
+++ b/extensions/amp-story/1.0/test/test-amp-story.js
@@ -1656,13 +1656,9 @@ describes.realWin(
       });
 
       describe('amp-story rewriteStyles', () => {
-        beforeEach(() => {
-          toggleExperiment(win, 'amp-story-responsive-units', true);
-        });
+        beforeEach(() => {});
 
-        afterEach(() => {
-          toggleExperiment(win, 'amp-story-responsive-units', false);
-        });
+        afterEach(() => {});
 
         it('should rewrite vw styles', async () => {
           await createStoryWithPages(1, ['cover']);

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -479,7 +479,7 @@ function maybeLoadCorrectVersion(win, fnOrStruct) {
  *     pumped.
  */
 function maybePumpEarlyFrame(win, cb) {
-  if (!isExperimentOn(win, 'pump-early-frame')) {
+  if (!true /* experiment: pump-early-frame */) {
     cb();
     return;
   }

--- a/test/unit/test-runtime.js
+++ b/test/unit/test-runtime.js
@@ -202,7 +202,6 @@ describes.fakeWin(
     );
 
     it('should not maybePumpEarlyFrame when body not yet present', () => {
-      toggleExperiment(win, 'pump-early-frame', true);
       // Make document.body be null on first invocation to simulate
       // JS executing before the rest of the doc has been parsed.
       const {body} = win.document;
@@ -223,14 +222,12 @@ describes.fakeWin(
       'should not maybePumpEarlyFrame ' +
         'when a renderDelayingExtension is present',
       () => {
-        toggleExperiment(win, 'pump-early-frame', true);
         win.document.body.appendChild(document.createElement('amp-experiment'));
         extensionRegistrationTest();
       }
     );
 
     it('should maybePumpEarlyFrame and delay extension execution', () => {
-      toggleExperiment(win, 'pump-early-frame', true);
       let progress = '';
       const queueExtensions = win.AMP;
       const highPriority = regularExtension((amp) => {


### PR DESCRIPTION
Sweep experiments last flipped globally up to 2019-12-06:

- (2018-07-23, #17012) `amp-access-iframe`: 1
- (2019-10-01, #24810) `amp-action-macro`: 1
- (2019-11-08, #25480) `amp-mega-menu`: 1
- (2019-11-13, #25516) `amp-nested-menu`: 1
- (2017-02-07, #7403) `amp-playbuzz`: 1
- (2019-10-21, #25170) `amp-sidebar-swipe-to-dismiss`: 1
- (2018-11-05, #19140) `amp-story-responsive-units`: 1
- (2018-07-11, #16678) `amp-story-v1`: 1
- (2018-07-11, #16678) `chunked-amp`: 1
- (2019-10-28, #25269) `fix-inconsistent-responsive-height-selection`: 0
- (2019-02-26, #21058) `fixed-elements-in-lightbox`: 1
- (2017-05-16, #9298) `pump-early-frame`: 1
- (2019-11-12, #25512) `swg-gpay-native`: 1

---

**⚠️ This changes Javascript source files**

The following may contain errors and/or require intervention to remove superfluous conditionals:

- `extensions/amp-access/0.1/amp-access-source.js`
- `extensions/amp-access/0.1/test/test-amp-access-source.js`
- `extensions/amp-action-macro/0.1/amp-action-macro.js`
- `extensions/amp-action-macro/0.1/test/test-amp-action-macro.js`
- `extensions/amp-playbuzz/0.1/amp-playbuzz.js`
- `extensions/amp-playbuzz/0.1/test/test-amp-playbuzz.js`
- `extensions/amp-sidebar/0.1/amp-sidebar.js`
- `extensions/amp-sidebar/0.2/amp-sidebar.js`
- `extensions/amp-story/1.0/amp-story.js`
- `extensions/amp-story/1.0/test/test-amp-story.js`
- `src/runtime.js`
- `test/unit/test-runtime.js`

