### PR TITLE
Remove SwG experiments from global config

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -27,8 +27,6 @@
   "ios-fixed-no-transfer": 1,
   "pump-early-frame": 1,
   "remove-task-timeout": 0,
-  "swg-gpay-api": 1,
-  "swg-gpay-native": 1,
   "amp-ad-no-center-css": 0,
   "render-on-idle-fix": 1,
   "build-in-chunks": 1,

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -26,8 +26,6 @@
   "intersect-resources": 0,
   "ios-fixed-no-transfer": 0,
   "pump-early-frame": 1,
-  "swg-gpay-api": 1,
-  "swg-gpay-native": 1,
   "amp-ad-no-center-css": 0,
   "adsense-ptt-exp": 0.1,
   "doubleclick-ptt-exp": 0.1,

--- a/extensions/amp-subscriptions-google/0.1/amp-subscriptions-google.js
+++ b/extensions/amp-subscriptions-google/0.1/amp-subscriptions-google.js
@@ -154,7 +154,9 @@ export class GoogleSubscriptionsPlatform {
       )
       .map((exp) => exp.substring(4));
 
-    const swgConfig = {'experiments': SWG_CONFIG_EXPERIMENTS.concat(ampExperimentsForSwg)};
+    const swgConfig = {
+      'experiments': SWG_CONFIG_EXPERIMENTS.concat(ampExperimentsForSwg)
+    };
     let resolver = null;
     /** @private @const {!ConfiguredRuntime} */
     this.runtime_ = new ConfiguredRuntime(

--- a/extensions/amp-subscriptions-google/0.1/amp-subscriptions-google.js
+++ b/extensions/amp-subscriptions-google/0.1/amp-subscriptions-google.js
@@ -73,6 +73,8 @@ const AMP_ACTION_TO_SWG_EVENT = {
   },
 };
 
+const SWG_CONFIG_EXPERIMENTS = ['gpay-api', 'gpay-native'];
+
 /**
  */
 export class GoogleSubscriptionsPlatformService {
@@ -152,7 +154,7 @@ export class GoogleSubscriptionsPlatform {
       )
       .map((exp) => exp.substring(4));
 
-    const swgConfig = {'experiments': ampExperimentsForSwg};
+    const swgConfig = {'experiments': SWG_CONFIG_EXPERIMENTS.concat(ampExperimentsForSwg)};
     let resolver = null;
     /** @private @const {!ConfiguredRuntime} */
     this.runtime_ = new ConfiguredRuntime(

--- a/extensions/amp-subscriptions-google/0.1/amp-subscriptions-google.js
+++ b/extensions/amp-subscriptions-google/0.1/amp-subscriptions-google.js
@@ -73,8 +73,6 @@ const AMP_ACTION_TO_SWG_EVENT = {
   },
 };
 
-const SWG_CONFIG_EXPERIMENTS = ['gpay-api', 'gpay-native'];
-
 /**
  */
 export class GoogleSubscriptionsPlatformService {
@@ -154,9 +152,7 @@ export class GoogleSubscriptionsPlatform {
       )
       .map((exp) => exp.substring(4));
 
-    const swgConfig = {
-      'experiments': SWG_CONFIG_EXPERIMENTS.concat(ampExperimentsForSwg)
-    };
+    const swgConfig = {'experiments': ampExperimentsForSwg};
     let resolver = null;
     /** @private @const {!ConfiguredRuntime} */
     this.runtime_ = new ConfiguredRuntime(


### PR DESCRIPTION
These have been launched for over a ~year:

- (2019-11-12, 31f7e22) `swg-gpay-native`: 1
- (2019-12-13, ca60fd1) `swg-gpay-api`: 1
---

The motivation of this PR is to prevent these from polluting unrelated files, like `v0`.

Additionally, an automated tool is being created to sweep AMP experiments. The tool assumes that the experiments are handled only inside runtime code and aren't passed through. Removing these special cases helps.

It would be even better if we can remove this AMP experiment-to-SWG experiment mechanism. Experiment flag config is now part of the common release process, so maybe all future experiment flags can be kept locally on `amp-subscriptions-google.js` (as far as I can tell from 31f7e22).

