### PR TITLE
✨ [bento] Preact version of amp-sidebar

### DIFF
--- a/extensions/amp-sidebar/1.0/sidebar.js
+++ b/extensions/amp-sidebar/1.0/sidebar.js
@@ -1,0 +1,210 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as Preact from '../../../src/preact';
+import {ContainWrapper} from '../../../src/preact/component';
+import {forwardRef} from '../../../src/preact/compat';
+import {
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from '../../../src/preact';
+import {useStyles} from './sidebar.jss';
+
+const ANIMATION_DURATION = 350;
+const ANIMATION_PRESETS = {
+  fadeIn: [{opacity: 0}, {opacity: 1}],
+  slideInLeft: [{transform: 'translateX(-100%)'}, {transform: 'translateX(0)'}],
+  slideInRight: [{transform: 'translateX(100%)'}, {transform: 'translateX(0)'}],
+};
+
+const ANIMATION_EASE_IN = 'cubic-bezier(0,0,.21,1)';
+
+/**
+ * @param {T} current
+ * @return {{current: T}}
+ * @template T
+ */
+function useValueRef(current) {
+  const valueRef = useRef(null);
+  valueRef.current = current;
+  return valueRef;
+}
+
+/**
+ * @param {!AccordionDef.Props} props //TODO: will update
+ * @param ref
+ * @return {PreactDef.Renderable}
+ */
+function SidebarWithRef(
+  {
+    as: Comp = 'div',
+    side = 'left',
+    onBeforeOpen,
+    onAfterClose,
+    children,
+    ...rest
+  },
+  ref
+) {
+  // There are two phases to open and close.
+  // To open, we mount and render the contents (invisible), then animate the display (visible).
+  // To close, it's the reverse.
+  // `mounted` mounts the component. `opened` plays the animation.
+  const initialOpen = false;
+  const [mounted, setMounted] = useState(initialOpen);
+  const [opened, setOpened] = useState(initialOpen);
+  const classes = useStyles();
+  const sidebarRef = useRef();
+  const maskRef = useRef();
+
+  // We are using refs here to refer to common strings, objects, and functions used.
+  // This is because they are needed within `useEffect` calls below (but are not depended for triggering)
+  // We use `useValueRef` for props that might change (user-controlled)
+  const onBeforeOpenRef = useValueRef(onBeforeOpen);
+  const onAfterCloseRef = useValueRef(onAfterClose);
+
+  const open = useCallback(() => {
+    if (onBeforeOpenRef.current) {
+      onBeforeOpenRef.current();
+    }
+    setMounted(true);
+    setOpened(true);
+  }, [onBeforeOpenRef]);
+  const close = useCallback(() => setOpened(false), []);
+  const toggle = useCallback(() => {
+    if (opened) {
+      close();
+    } else {
+      open();
+    }
+  }, [opened, open, close]);
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      open,
+      close,
+      toggle,
+    }),
+    [open, close, toggle]
+  );
+
+  useEffect(() => {
+    const sidebarElement = sidebarRef.current;
+    const maskElement = maskRef.current;
+    if (sidebarElement == undefined || maskElement == undefined) {
+      return;
+    }
+
+    let animation;
+    // "Make Visible" Animation
+    if (opened) {
+      const postVisibleAnim = () => {
+        sidebarElement./*REVIEW*/ focus();
+      };
+      if (!sidebarElement.animate || !maskElement.animate) {
+        postVisibleAnim();
+        return;
+      }
+      animation = sidebarElement.animate(
+        ANIMATION_PRESETS[side === 'left' ? 'slideInLeft' : 'slideInRight'],
+        {
+          duration: ANIMATION_DURATION,
+          fill: 'both',
+          easing: ANIMATION_EASE_IN,
+        }
+      );
+      animation.onfinish = postVisibleAnim;
+      maskElement.animate(ANIMATION_PRESETS.fadeIn, {
+        duration: ANIMATION_DURATION,
+        fill: 'both',
+        easing: ANIMATION_EASE_IN,
+      });
+    } else {
+      // "Make Invisible" Animation
+      const postInvisibleAnim = () => {
+        if (onAfterCloseRef.current) {
+          onAfterCloseRef.current();
+        }
+        animation = null;
+        setMounted(false);
+      };
+      if (!sidebarElement.animate || !maskElement.animate) {
+        postInvisibleAnim();
+        return;
+      }
+      animation = sidebarElement.animate(
+        ANIMATION_PRESETS[side === 'left' ? 'slideInLeft' : 'slideInRight'],
+        {
+          duration: ANIMATION_DURATION,
+          direction: 'reverse',
+          fill: 'both',
+          easing: ANIMATION_EASE_IN,
+        }
+      );
+      animation.onfinish = postInvisibleAnim;
+      maskElement.animate(ANIMATION_PRESETS.fadeIn, {
+        duration: ANIMATION_DURATION,
+        direction: 'reverse',
+        fill: 'both',
+        easing: ANIMATION_EASE_IN,
+      });
+    }
+    return () => {
+      if (animation) {
+        animation.cancel();
+      }
+    };
+  }, [opened, onAfterCloseRef, side]);
+
+  return (
+    mounted && (
+      <>
+        <ContainWrapper
+          as={Comp}
+          ref={(r) => {
+            sidebarRef.current = r;
+          }}
+          size={false}
+          layout={true}
+          paint={true}
+          className={`${classes.baseClass} ${
+            side === 'left' ? classes.left : classes.right
+          }`}
+          role="menu"
+          tabindex="-1"
+          {...rest}
+        >
+          {children}
+        </ContainWrapper>
+        <div
+          ref={(r) => {
+            maskRef.current = r;
+          }}
+          onClick={() => close()}
+          className={`${classes.maskClass}`}
+        ></div>
+      </>
+    )
+  );
+}
+
+const Sidebar = forwardRef(SidebarWithRef);
+Sidebar.displayName = 'Sidebar'; // Make findable for tests.
+export {Sidebar};

--- a/extensions/amp-sidebar/1.0/sidebar.js
+++ b/extensions/amp-sidebar/1.0/sidebar.js
@@ -84,9 +84,8 @@ function SidebarWithRef(
   // To open, we mount and render the contents (invisible), then animate the display (visible).
   // To close, it's the reverse.
   // `mounted` mounts the component. `opened` plays the animation.
-  const initialOpen = false;
-  const [mounted, setMounted] = useState(initialOpen);
-  const [opened, setOpened] = useState(initialOpen);
+  const [mounted, setMounted] = useState(false);
+  const [opened, setOpened] = useState(false);
   const classes = useStyles();
   const sidebarRef = useRef();
   const maskRef = useRef();

--- a/extensions/amp-sidebar/1.0/sidebar.js
+++ b/extensions/amp-sidebar/1.0/sidebar.js
@@ -17,6 +17,7 @@
 import * as Preact from '../../../src/preact';
 import {ContainWrapper} from '../../../src/preact/component';
 import {forwardRef} from '../../../src/preact/compat';
+import {setStyle} from '../../../src/style';
 import {
   useCallback,
   useEffect,
@@ -116,6 +117,8 @@ function SidebarWithRef(
     // "Make Visible" Animation
     if (opened) {
       const postVisibleAnim = () => {
+        setStyle(sidebarElement, 'transform', 'translateX(0)');
+        setStyle(maskElement, 'opacity', 1);
         sidebarElement./*REVIEW*/ focus();
       };
       if (!sidebarElement.animate || !maskElement.animate) {

--- a/extensions/amp-sidebar/1.0/sidebar.js
+++ b/extensions/amp-sidebar/1.0/sidebar.js
@@ -65,8 +65,8 @@ function safelySetStyles(element, styles) {
 }
 
 /**
- * @param {!AccordionDef.Props} props //TODO: will update
- * @param ref
+ * @param {!SidebarDef.Props} props
+ * @param {{current: (!SidebarDef.SidebarApi|null)}} ref
  * @return {PreactDef.Renderable}
  */
 function SidebarWithRef(
@@ -113,11 +113,12 @@ function SidebarWithRef(
 
   useImperativeHandle(
     ref,
-    () => ({
-      open,
-      close,
-      toggle,
-    }),
+    () =>
+      /** @type {!SidebarDef.SidebarApi} */ ({
+        open,
+        close,
+        toggle,
+      }),
     [open, close, toggle]
   );
 

--- a/extensions/amp-sidebar/1.0/sidebar.js
+++ b/extensions/amp-sidebar/1.0/sidebar.js
@@ -44,7 +44,7 @@ const ANIMATION_STYLES_SIDEBAR_LEFT_INIT = {'transform': 'translateX(-100%)'};
 const ANIMATION_STYLES_SIDEBAR_RIGHT_INIT = {'transform': 'translateX(100%)'};
 const ANIMATION_STYLES_MASK_INIT = {'opacity': '0'};
 const ANIMATION_STYLES_SIDEBAR_FINAL = {'transform': ''};
-const ANIMATION_STYLES_MASK_FINAL = {'opacity': '1'};
+const ANIMATION_STYLES_MASK_FINAL = {'opacity': ''};
 
 /**
  * @param {T} current
@@ -228,7 +228,7 @@ function SidebarWithRef(
         <div
           ref={maskRef}
           onClick={() => close()}
-          className={`${classes.maskClass}`}
+          className={classes.maskClass}
         ></div>
       </>
     )

--- a/extensions/amp-sidebar/1.0/sidebar.js
+++ b/extensions/amp-sidebar/1.0/sidebar.js
@@ -111,7 +111,8 @@ function SidebarWithRef(
       return;
     }
 
-    let animation;
+    let sidebarAnimation;
+    let maskAnimation;
     // "Make Visible" Animation
     if (opened) {
       const postVisibleAnim = () => {
@@ -123,7 +124,7 @@ function SidebarWithRef(
         postVisibleAnim();
         return;
       }
-      animation = sidebarElement.animate(
+      sidebarAnimation = sidebarElement.animate(
         ANIMATION_PRESETS[side === 'left' ? 'slideInLeft' : 'slideInRight'],
         {
           duration: ANIMATION_DURATION,
@@ -131,8 +132,8 @@ function SidebarWithRef(
           easing: ANIMATION_EASE_IN,
         }
       );
-      animation.onfinish = postVisibleAnim;
-      maskElement.animate(ANIMATION_PRESETS.fadeIn, {
+      sidebarAnimation.onfinish = postVisibleAnim;
+      maskAnimation = maskElement.animate(ANIMATION_PRESETS.fadeIn, {
         duration: ANIMATION_DURATION,
         fill: 'both',
         easing: ANIMATION_EASE_IN,
@@ -143,14 +144,15 @@ function SidebarWithRef(
         if (onAfterCloseRef.current) {
           onAfterCloseRef.current();
         }
-        animation = null;
+        sidebarAnimation = null;
+        maskAnimation = null;
         setMounted(false);
       };
       if (!sidebarElement.animate || !maskElement.animate) {
         postInvisibleAnim();
         return;
       }
-      animation = sidebarElement.animate(
+      sidebarAnimation = sidebarElement.animate(
         ANIMATION_PRESETS[side === 'left' ? 'slideInLeft' : 'slideInRight'],
         {
           duration: ANIMATION_DURATION,
@@ -159,8 +161,8 @@ function SidebarWithRef(
           easing: ANIMATION_EASE_IN,
         }
       );
-      animation.onfinish = postInvisibleAnim;
-      maskElement.animate(ANIMATION_PRESETS.fadeIn, {
+      sidebarAnimation.onfinish = postInvisibleAnim;
+      maskAnimation = maskElement.animate(ANIMATION_PRESETS.fadeIn, {
         duration: ANIMATION_DURATION,
         direction: 'reverse',
         fill: 'both',
@@ -168,8 +170,11 @@ function SidebarWithRef(
       });
     }
     return () => {
-      if (animation) {
-        animation.cancel();
+      if (sidebarAnimation) {
+        sidebarAnimation.cancel();
+      }
+      if (maskAnimation) {
+        maskAnimation.cancel();
       }
     };
   }, [opened, onAfterCloseRef, side]);

--- a/extensions/amp-sidebar/1.0/sidebar.js
+++ b/extensions/amp-sidebar/1.0/sidebar.js
@@ -88,13 +88,11 @@ function SidebarWithRef(
     setOpened(true);
   }, [onBeforeOpenRef]);
   const close = useCallback(() => setOpened(false), []);
-  const toggle = useCallback(() => {
-    if (opened) {
-      close();
-    } else {
-      open();
-    }
-  }, [opened, open, close]);
+  const toggle = useCallback(() => (opened ? close() : open()), [
+    opened,
+    open,
+    close,
+  ]);
 
   useImperativeHandle(
     ref,

--- a/extensions/amp-sidebar/1.0/sidebar.js
+++ b/extensions/amp-sidebar/1.0/sidebar.js
@@ -28,12 +28,15 @@ import {
 import {useStyles} from './sidebar.jss';
 
 const ANIMATION_DURATION = 350;
-const ANIMATION_PRESETS = {
-  fadeIn: [{opacity: 0}, {opacity: 1}],
-  slideInLeft: [{transform: 'translateX(-100%)'}, {transform: 'translateX(0)'}],
-  slideInRight: [{transform: 'translateX(100%)'}, {transform: 'translateX(0)'}],
-};
-
+const ANIMATION_FADE_IN = [{opacity: 0}, {opacity: 1}];
+const ANIMATION_SLIDE_IN_LEFT = [
+  {transform: 'translateX(-100%)'},
+  {transform: 'translateX(0)'},
+];
+const ANIMATION_SLIDE_IN_RIGHT = [
+  {transform: 'translateX(100%)'},
+  {transform: 'translateX(0)'},
+];
 const ANIMATION_EASE_IN = 'cubic-bezier(0,0,.21,1)';
 
 /**
@@ -107,7 +110,7 @@ function SidebarWithRef(
   useEffect(() => {
     const sidebarElement = sidebarRef.current;
     const maskElement = maskRef.current;
-    if (sidebarElement == undefined || maskElement == undefined) {
+    if (sidebarElement == null || maskElement == null) {
       return;
     }
 
@@ -118,14 +121,13 @@ function SidebarWithRef(
       const postVisibleAnim = () => {
         setStyle(sidebarElement, 'transform', 'translateX(0)');
         setStyle(maskElement, 'opacity', 1);
-        sidebarElement./*REVIEW*/ focus();
       };
       if (!sidebarElement.animate || !maskElement.animate) {
         postVisibleAnim();
         return;
       }
       sidebarAnimation = sidebarElement.animate(
-        ANIMATION_PRESETS[side === 'left' ? 'slideInLeft' : 'slideInRight'],
+        side === 'left' ? ANIMATION_SLIDE_IN_LEFT : ANIMATION_SLIDE_IN_RIGHT,
         {
           duration: ANIMATION_DURATION,
           fill: 'both',
@@ -133,7 +135,7 @@ function SidebarWithRef(
         }
       );
       sidebarAnimation.onfinish = postVisibleAnim;
-      maskAnimation = maskElement.animate(ANIMATION_PRESETS.fadeIn, {
+      maskAnimation = maskElement.animate(ANIMATION_FADE_IN, {
         duration: ANIMATION_DURATION,
         fill: 'both',
         easing: ANIMATION_EASE_IN,
@@ -153,7 +155,7 @@ function SidebarWithRef(
         return;
       }
       sidebarAnimation = sidebarElement.animate(
-        ANIMATION_PRESETS[side === 'left' ? 'slideInLeft' : 'slideInRight'],
+        side === 'left' ? ANIMATION_SLIDE_IN_LEFT : ANIMATION_SLIDE_IN_RIGHT,
         {
           duration: ANIMATION_DURATION,
           direction: 'reverse',
@@ -162,7 +164,7 @@ function SidebarWithRef(
         }
       );
       sidebarAnimation.onfinish = postInvisibleAnim;
-      maskAnimation = maskElement.animate(ANIMATION_PRESETS.fadeIn, {
+      maskAnimation = maskElement.animate(ANIMATION_FADE_IN, {
         duration: ANIMATION_DURATION,
         direction: 'reverse',
         fill: 'both',
@@ -190,7 +192,7 @@ function SidebarWithRef(
           size={false}
           layout={true}
           paint={true}
-          className={`${classes.baseClass} ${
+          className={`${classes.sidebarClass} ${
             side === 'left' ? classes.left : classes.right
           }`}
           role="menu"
@@ -200,9 +202,7 @@ function SidebarWithRef(
           {children}
         </ContainWrapper>
         <div
-          ref={(r) => {
-            maskRef.current = r;
-          }}
+          ref={maskRef}
           onClick={() => close()}
           className={`${classes.maskClass}`}
         ></div>

--- a/extensions/amp-sidebar/1.0/sidebar.jss.js
+++ b/extensions/amp-sidebar/1.0/sidebar.jss.js
@@ -1,0 +1,65 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {createUseStyles} from 'react-jss';
+
+const baseClass = {
+  position: 'fixed !important',
+  top: 0,
+  maxHeight: '100vh !important',
+  height: '100vh',
+  maxWidth: '80vw',
+  backgroundColor: '#efefef',
+  minWidth: '45px !important',
+  outline: 'none',
+  overflowX: 'hidden !important',
+  overflowY: 'auto !important',
+  zIndex: 2147483647,
+};
+
+const left = {
+  left: 0,
+  transform: 'translateX(-100%)',
+};
+
+const right = {
+  right: 0,
+  transform: 'translateX(100%)',
+};
+
+const maskClass = {
+  position: 'fixed !important',
+  top: '0 !important',
+  left: '0 !important',
+  width: '100vw !important',
+  height: '100vh !important',
+  /* Prevent someone from making this a full-sceen image */
+  backgroundImage: 'none !important',
+  backgroundColor: 'rgba(0, 0, 0, 0.5)',
+  zIndex: 2147483646,
+  opacity: 0,
+};
+
+const JSS = {
+  baseClass,
+  maskClass,
+  left,
+  right,
+};
+
+// useStyles gets replaced for AMP builds via `babel-plugin-transform-jss`.
+// eslint-disable-next-line local/no-export-side-effect
+export const useStyles = createUseStyles(JSS);

--- a/extensions/amp-sidebar/1.0/sidebar.jss.js
+++ b/extensions/amp-sidebar/1.0/sidebar.jss.js
@@ -32,12 +32,10 @@ const sidebarClass = {
 
 const left = {
   left: 0,
-  transform: 'translateX(-100%)',
 };
 
 const right = {
   right: 0,
-  transform: 'translateX(100%)',
 };
 
 const maskClass = {
@@ -50,7 +48,6 @@ const maskClass = {
   backgroundImage: 'none !important',
   backgroundColor: 'rgba(0, 0, 0, 0.5)',
   zIndex: 2147483646,
-  opacity: 0,
 };
 
 const JSS = {

--- a/extensions/amp-sidebar/1.0/sidebar.jss.js
+++ b/extensions/amp-sidebar/1.0/sidebar.jss.js
@@ -16,7 +16,7 @@
 
 import {createUseStyles} from 'react-jss';
 
-const baseClass = {
+const sidebarClass = {
   position: 'fixed !important',
   top: 0,
   maxHeight: '100vh !important',
@@ -54,7 +54,7 @@ const maskClass = {
 };
 
 const JSS = {
-  baseClass,
+  sidebarClass,
   maskClass,
   left,
   right,

--- a/extensions/amp-sidebar/1.0/sidebar.type.js
+++ b/extensions/amp-sidebar/1.0/sidebar.type.js
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** @externs */
+
+/** @const */
+var SidebarDef = {};
+
+/**
+ * @typedef {{
+ *   as: (string|PreactDef.FunctionalComponent|undefined),
+ *   side: (string|undefined),
+ *   onBeforeOpen: (function|undefined),
+ *   onAfterClose: (function|undefined),
+ *   children: (?PreactDef.Renderable|undefined),
+ * }}
+ */
+SidebarDef.Props;
+
+/** @interface */
+SidebarDef.SidebarApi = class {
+  /** Open the sidebar */
+  open() {}
+
+  /** Close the sidebar */
+  close() {}
+
+  /** Toggle the sidebar open or closed */
+  toggle() {}
+};

--- a/extensions/amp-sidebar/1.0/storybook/Basic.js
+++ b/extensions/amp-sidebar/1.0/storybook/Basic.js
@@ -54,7 +54,7 @@ export const _default = () => {
       <SidebarWithActions side={side}>
         Content
         <br />
-        Very Wide content ------------------------------!
+        Very Wide content -------------------------------!
         <ul>
           <li>1</li>
           <li>2</li>

--- a/extensions/amp-sidebar/1.0/storybook/Basic.js
+++ b/extensions/amp-sidebar/1.0/storybook/Basic.js
@@ -34,15 +34,30 @@ function SidebarWithActions(props) {
   // Storybook 6.1 is released.
   const ref = Preact.useRef();
   return (
-    <section>
-      <Sidebar ref={ref} {...props} />
+    <>
+      <Sidebar ref={ref} {...props}>
+        <div style={{margin: 8}}>
+          <span>
+            Lorem ipsum dolor sit amet, has nisl nihil convenire et, vim at
+            aeque inermis reprehendunt.
+          </span>
+          <ul>
+            <li>1</li>
+            <li>2</li>
+            <li>3</li>
+          </ul>
+          <button onClick={() => ref.current.toggle()}>toggle</button>
+          <button onClick={() => ref.current.open()}>open</button>
+          <button onClick={() => ref.current.close()}>close</button>
+        </div>
+      </Sidebar>
       <div style={{marginTop: 8}}>
         <br />
         <button onClick={() => ref.current.toggle()}>toggle</button>
         <button onClick={() => ref.current.open()}>open</button>
         <button onClick={() => ref.current.close()}>close</button>
       </div>
-    </section>
+    </>
   );
 }
 
@@ -51,19 +66,7 @@ export const _default = () => {
   const side = select('type', sideConfigurations, sideConfigurations[0]);
   return (
     <main>
-      <SidebarWithActions side={side}>
-        Content
-        <br />
-        Very Wide content -------------------------------!
-        <ul>
-          <li>1</li>
-          <li>2</li>
-          <li>3</li>
-        </ul>
-      </SidebarWithActions>
-      <div style="background-color: yellow; margin-top: 15px">
-        Background Stripe
-      </div>
+      <SidebarWithActions side={side} />
     </main>
   );
 };

--- a/extensions/amp-sidebar/1.0/storybook/Basic.js
+++ b/extensions/amp-sidebar/1.0/storybook/Basic.js
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as Preact from '../../../../src/preact';
+import {Sidebar} from '../sidebar';
+import {select, withKnobs} from '@storybook/addon-knobs';
+import {withA11y} from '@storybook/addon-a11y';
+
+export default {
+  title: 'Sidebar',
+  component: Sidebar,
+  decorators: [withA11y, withKnobs],
+};
+
+/**
+ * @param {!Object} props
+ * @return {*}
+ */
+function SidebarWithActions(props) {
+  // TODO(#30447): replace imperative calls with "button" knobs when the
+  // Storybook 6.1 is released.
+  const ref = Preact.useRef();
+  return (
+    <section>
+      <Sidebar ref={ref} {...props} />
+      <div style={{marginTop: 8}}>
+        <br />
+        <button onClick={() => ref.current.toggle()}>toggle</button>
+        <button onClick={() => ref.current.open()}>open</button>
+        <button onClick={() => ref.current.close()}>close</button>
+      </div>
+    </section>
+  );
+}
+
+export const _default = () => {
+  const sideConfigurations = ['left', 'right', undefined];
+  const side = select('type', sideConfigurations, sideConfigurations[0]);
+  return (
+    <main>
+      <SidebarWithActions side={side}>
+        Content
+        <br />
+        Very Wide content ------------------------------!
+        <ul>
+          <li>1</li>
+          <li>2</li>
+          <li>3</li>
+        </ul>
+      </SidebarWithActions>
+      <div style="background-color: yellow; margin-top: 15px">
+        Background Stripe
+      </div>
+    </main>
+  );
+};

--- a/extensions/amp-sidebar/1.0/test/test-sidebar.js
+++ b/extensions/amp-sidebar/1.0/test/test-sidebar.js
@@ -1,0 +1,415 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as Preact from '../../../../src/preact';
+import {Sidebar} from '../sidebar';
+import {mount} from 'enzyme';
+
+describes.sandboxed('Sidebar preact component', {}, (env) => {
+  describe('basic actions', () => {
+    let wrapper;
+    let ref;
+    let sidebar;
+    let animateFunction;
+    let openButton;
+    let closeButton;
+    let toggleButton;
+
+    beforeEach(() => {
+      animateFunction = Element.prototype.animate;
+      Element.prototype.animate = null;
+      ref = Preact.createRef();
+      wrapper = mount(
+        <>
+          <Sidebar ref={ref} side="left">
+            <div>Content</div>
+          </Sidebar>
+          <button id="toggle" onClick={() => ref.current.toggle()}></button>
+          <button id="open" onClick={() => ref.current.open()}></button>
+          <button id="close" onClick={() => ref.current.close()}></button>
+        </>
+      );
+
+      sidebar = wrapper.find(Sidebar);
+      openButton = wrapper.find('#open');
+      closeButton = wrapper.find('#close');
+      toggleButton = wrapper.find('#toggle');
+    });
+
+    afterEach(() => {
+      Element.prototype.animate = animateFunction;
+    });
+
+    it('close the sidebar when the mask is clicked', () => {
+      openButton.getDOMNode().click();
+      wrapper.update();
+
+      const maskElement = wrapper.find(Sidebar).getDOMNode().nextSibling;
+      maskElement.click();
+      wrapper.update();
+
+      // Sidebar closes
+      expect(sidebar.getDOMNode()).to.be.null;
+    });
+
+    it('should include the content in the sidebar', () => {
+      openButton.getDOMNode().click();
+      wrapper.update();
+
+      const contentElement = wrapper.find(Sidebar).getDOMNode()
+        .firstElementChild.firstElementChild;
+      expect(contentElement.textContent).to.equal('Content');
+    });
+
+    it('should allow for the sidebar on the right side', () => {
+      ref = Preact.createRef();
+      wrapper = mount(
+        <>
+          <Sidebar ref={ref} side="right">
+            <div>Content</div>
+          </Sidebar>
+          <button id="toggle" onClick={() => ref.current.toggle()}></button>
+          <button id="open" onClick={() => ref.current.open()}></button>
+          <button id="close" onClick={() => ref.current.close()}></button>
+        </>
+      );
+
+      sidebar = wrapper.find(Sidebar);
+      openButton = wrapper.find('#open');
+      closeButton = wrapper.find('#close');
+      toggleButton = wrapper.find('#toggle');
+
+      openButton.getDOMNode().click();
+      wrapper.update();
+      sidebar = wrapper.find(Sidebar);
+
+      const sidebarNode = sidebar.getDOMNode();
+      expect(sidebarNode.className.includes('right')).to.be.true;
+    });
+
+    describe('programatic access to imperative API', () => {
+      it('open', () => {
+        // Sidebar is initially closed (no rendered nodes)
+        expect(sidebar.getDOMNode()).to.be.null;
+
+        ref.current.open();
+        wrapper.update();
+        sidebar = wrapper.find(Sidebar);
+
+        // Sidebar opens
+        expect(sidebar.getDOMNode()).to.not.be.null;
+
+        ref.current.open();
+        wrapper.update();
+        sidebar = wrapper.find(Sidebar);
+
+        // Sidebar remains opens
+        expect(sidebar.getDOMNode()).to.not.be.null;
+      });
+
+      it('close', () => {
+        // Sidebar is initially closed (no rendered nodes)
+        expect(sidebar.getDOMNode()).to.be.null;
+
+        ref.current.open();
+        wrapper.update();
+        sidebar = wrapper.find(Sidebar);
+
+        // Sidebar opens
+        expect(sidebar.getDOMNode()).to.not.be.null;
+
+        ref.current.close();
+        wrapper.update();
+        sidebar = wrapper.find(Sidebar);
+
+        // Sidebar closes
+        expect(sidebar.getDOMNode()).to.be.null;
+
+        ref.current.close();
+        wrapper.update();
+        sidebar = wrapper.find(Sidebar);
+
+        // Sidebar remains closed
+        expect(sidebar.getDOMNode()).to.be.null;
+      });
+
+      it('toggle', () => {
+        // Sidebar is initially closed (no rendered nodes)
+        expect(sidebar.getDOMNode()).to.be.null;
+
+        ref.current.toggle();
+        wrapper.update();
+        sidebar = wrapper.find(Sidebar);
+
+        // Sidebar opens
+        expect(sidebar.getDOMNode()).to.not.be.null;
+
+        ref.current.toggle();
+        wrapper.update();
+        sidebar = wrapper.find(Sidebar);
+
+        // Sidebar closes
+        expect(sidebar.getDOMNode()).to.be.null;
+      });
+    });
+
+    describe('click button to access imperative API', () => {
+      it('open', () => {
+        // Sidebar is initially closed (no rendered nodes)
+        expect(sidebar.getDOMNode()).to.be.null;
+
+        openButton.getDOMNode().click();
+        wrapper.update();
+        sidebar = wrapper.find(Sidebar);
+
+        // Sidebar opens
+        expect(sidebar.getDOMNode()).to.not.be.null;
+
+        openButton.getDOMNode().click();
+        wrapper.update();
+        sidebar = wrapper.find(Sidebar);
+
+        // Sidebar remains opens
+        expect(sidebar.getDOMNode()).to.not.be.null;
+      });
+
+      it('close', () => {
+        // Sidebar is initially closed (no rendered nodes)
+        expect(sidebar.getDOMNode()).to.be.null;
+
+        openButton.getDOMNode().click();
+        wrapper.update();
+        sidebar = wrapper.find(Sidebar);
+
+        // Sidebar opens
+        expect(sidebar.getDOMNode()).to.not.be.null;
+
+        closeButton.getDOMNode().click();
+        wrapper.update();
+        sidebar = wrapper.find(Sidebar);
+
+        // Sidebar closes
+        expect(sidebar.getDOMNode()).to.be.null;
+
+        closeButton.getDOMNode().click();
+        wrapper.update();
+        sidebar = wrapper.find(Sidebar);
+
+        // Sidebar remains closed
+        expect(sidebar.getDOMNode()).to.be.null;
+      });
+
+      it('toggle', () => {
+        // Sidebar is initially closed (no rendered nodes)
+        expect(sidebar.getDOMNode()).to.be.null;
+
+        toggleButton.getDOMNode().click();
+        wrapper.update();
+        sidebar = wrapper.find(Sidebar);
+
+        // Sidebar opens
+        expect(sidebar.getDOMNode()).to.not.be.null;
+
+        toggleButton.getDOMNode().click();
+        wrapper.update();
+        sidebar = wrapper.find(Sidebar);
+
+        // Sidebar closes
+        expect(sidebar.getDOMNode()).to.be.null;
+      });
+    });
+  });
+
+  describe('animations', () => {
+    let wrapper;
+    let ref;
+    let sidebar;
+    let animateStub;
+    let animateFunction;
+    let openButton;
+    let closeButton;
+
+    beforeEach(() => {
+      ref = Preact.createRef();
+      wrapper = mount(
+        <>
+          <Sidebar ref={ref} side="left">
+            <div>Content</div>
+          </Sidebar>
+          <button id="toggle" onClick={() => ref.current.toggle()}></button>
+          <button id="open" onClick={() => ref.current.open()}></button>
+          <button id="close" onClick={() => ref.current.close()}></button>
+        </>
+      );
+
+      sidebar = wrapper.find(Sidebar);
+      openButton = wrapper.find('#open');
+      closeButton = wrapper.find('#close');
+    });
+
+    afterEach(() => {});
+
+    it('should not animate on mount', () => {
+      animateStub = env.sandbox.stub(Element.prototype, 'animate');
+      expect(animateStub).to.not.be.called;
+    });
+
+    it('should animate when sidebar opens', () => {
+      animateStub = env.sandbox.stub(Element.prototype, 'animate');
+      const animation = {};
+      animateStub.returns(animation);
+
+      // Sidebar is closed
+      expect(sidebar.getDOMNode()).to.be.null;
+
+      // Click to open the sidebar
+      openButton.simulate('click');
+
+      // Sidebar immediately begins to open
+      sidebar = wrapper.find(Sidebar);
+      expect(sidebar.getDOMNode()).to.not.be.null;
+
+      // Animation has been started
+      // One call each for the mask and the sidebar
+      expect(animateStub).to.be.calledTwice;
+
+      const sidebarKeyframes = animateStub.firstCall.firstArg;
+      const maskKeyframes = animateStub.secondCall.firstArg;
+
+      const sidebarOptions = animateStub.firstCall.args[1];
+      const maskOptions = animateStub.secondCall.args[1];
+
+      expect(sidebarKeyframes[0].transform).to.equal('translateX(-100%)');
+      expect(sidebarKeyframes[1].transform).to.equal('translateX(0)');
+      expect(sidebarOptions.duration).to.equal(350);
+      expect(sidebarOptions.easing).to.equal('cubic-bezier(0,0,.21,1)');
+      expect(sidebarOptions.fill).to.equal('both');
+
+      expect(maskKeyframes[0].opacity).to.equal('0');
+      expect(maskKeyframes[1].opacity).to.equal('1');
+      expect(maskOptions.duration).to.equal(350);
+      expect(maskOptions.easing).to.equal('cubic-bezier(0,0,.21,1)');
+      expect(maskOptions.fill).to.equal('both');
+    });
+
+    it('should animate when sidebar closes', () => {
+      animateFunction = Element.prototype.animate;
+      Element.prototype.animate = null;
+
+      // Sidebar is closed
+      expect(sidebar.getDOMNode()).to.be.null;
+
+      // Click to open the sidebar
+      openButton.simulate('click');
+
+      // Synchronously open the sidebar
+      sidebar = wrapper.find(Sidebar);
+      expect(sidebar.getDOMNode()).to.not.be.null;
+
+      // Turn on animations after Sidebar is opened
+      Element.prototype.animate = animateFunction;
+      animateStub = env.sandbox.stub(Element.prototype, 'animate');
+      const animation = {};
+      animateStub.returns(animation);
+
+      // Close the sidebar
+      closeButton.simulate('click');
+
+      // Sidebar begins to close but is not immediately closed
+      sidebar = wrapper.find(Sidebar);
+      expect(sidebar.getDOMNode()).to.not.be.null;
+
+      // Animation has been started
+      // One call each for the mask and the sidebar
+      expect(animateStub).to.be.calledTwice;
+
+      const sidebarKeyframes = animateStub.firstCall.firstArg;
+      const maskKeyframes = animateStub.secondCall.firstArg;
+
+      const sidebarOptions = animateStub.firstCall.args[1];
+      const maskOptions = animateStub.secondCall.args[1];
+
+      expect(sidebarKeyframes[0].transform).to.equal('translateX(-100%)');
+      expect(sidebarKeyframes[1].transform).to.equal('translateX(0)');
+      expect(sidebarOptions.direction).to.equal('reverse');
+      expect(sidebarOptions.duration).to.equal(350);
+      expect(sidebarOptions.easing).to.equal('cubic-bezier(0,0,.21,1)');
+      expect(sidebarOptions.fill).to.equal('both');
+
+      expect(maskKeyframes[0].opacity).to.equal('0');
+      expect(maskKeyframes[1].opacity).to.equal('1');
+      expect(maskOptions.direction).to.equal('reverse');
+      expect(maskOptions.duration).to.equal(350);
+      expect(maskOptions.easing).to.equal('cubic-bezier(0,0,.21,1)');
+      expect(maskOptions.fill).to.equal('both');
+
+      // Cleanup the animation.
+      animation.onfinish();
+      wrapper.update();
+      sidebar = wrapper.find(Sidebar);
+      expect(sidebar.getDOMNode()).to.be.null;
+    });
+
+    it('should make animations cancelable', () => {
+      animateStub = env.sandbox.stub(Element.prototype, 'animate');
+      const animation = {
+        cancel: env.sandbox.spy(),
+      };
+      animateStub.returns(animation);
+
+      // Sidebar is closed
+      expect(sidebar.getDOMNode()).to.be.null;
+
+      // Click to open the sidebar
+      openButton.simulate('click');
+
+      // Animation has been started
+      // One call each for the mask and the sidebar
+      expect(animateStub).to.be.calledTwice;
+
+      // Click to close the sidebar and cancel the animation
+      closeButton.simulate('click');
+
+      // Expect cancel to be called twice (once for mask and once for sidebar)
+      expect(animation.cancel).to.be.calledTwice;
+    });
+
+    it('should ignore animations if not available on the platform', () => {
+      animateFunction = Element.prototype.animate;
+      Element.prototype.animate = null;
+
+      // Sidebar is closed
+      expect(sidebar.getDOMNode()).to.be.null;
+
+      // Click to open the sidebar
+      openButton.simulate('click');
+
+      // Immediately opens the sidebar
+      sidebar = wrapper.find(Sidebar);
+      expect(sidebar.getDOMNode()).to.not.be.null;
+
+      // Click to close the sidebar
+      closeButton.simulate('click');
+
+      // Immediately closes the sidebar
+      sidebar = wrapper.find(Sidebar);
+      expect(sidebar.getDOMNode()).to.be.null;
+
+      // Restore animatinos to the system
+      Element.prototype.animate = animateFunction;
+    });
+  });
+});


### PR DESCRIPTION
First draft of Preact amp-sidebar component for initial review

12/11 - Update
1. Added unit tests - 
- imperative API
- click to open, close, toggle
- click mask to close 
- left and right sides
- animations
2. Updated storybook
- removed background content
- add buttons to open, close, toggle to within sidebar
3. Added type definition file
