### PR TITLE
🏗♻️  Refactor most checks for PR and push builds

### DIFF
--- a/build-system/common/ci.js
+++ b/build-system/common/ci.js
@@ -36,51 +36,27 @@ const {
  */
 
 /**
- * The full set of available CI services.
- * @enum {string}
- **/
-const ciService = {
-  TRAVIS: 'travis',
-  GITHUB_ACTIONS: 'github_actions',
-  CIRCLECI: 'circleci',
-  NONE: 'none',
-};
-
-/**
- * Determines the service on which CI is being run, if any.
- * @return {string}
+ * Maps generic CI functions to those that must be run on the current service.
  */
-function getCiService() {
-  return isTravisBuild()
-    ? ciService.TRAVIS
-    : isGithubActionsBuild()
-    ? ciService.GITHUB_ACTIONS
-    : isCircleciBuild()
-    ? ciService.GITHUB_ACTIONS
-    : ciService.NONE;
-}
-
-/**
- * Mapping of generic CI functions to service-specific functions.
- */
-const serviceFunctionMap = {
-  'travis': {
-    'isPullRequestBuild': isTravisPullRequestBuild,
-    'isPushBuild': isTravisPushBuild,
-  },
-  'github_actions': {
-    'isPullRequestBuild': isGithubActionsPullRequestBuild,
-    'isPushBuild': isGithubActionsPushBuild,
-  },
-  'circleci': {
-    'isPullRequestBuild': isCircleciPullRequestBuild,
-    'isPushBuild': isCircleciPushBuild,
-  },
-  'none': {
-    'isPullRequestBuild': () => false,
-    'isPushBuild': () => false,
-  },
-};
+const serviceFunctionMap = isTravisBuild()
+  ? {
+      'isPullRequestBuild': isTravisPullRequestBuild,
+      'isPushBuild': isTravisPushBuild,
+    }
+  : isGithubActionsBuild()
+  ? {
+      'isPullRequestBuild': isGithubActionsPullRequestBuild,
+      'isPushBuild': isGithubActionsPushBuild,
+    }
+  : isCircleciBuild()
+  ? {
+      'isPullRequestBuild': isCircleciPullRequestBuild,
+      'isPushBuild': isCircleciPushBuild,
+    }
+  : {
+      'isPullRequestBuild': () => false,
+      'isPushBuild': () => false,
+    };
 
 /**
  * Returns true if this is a CI build.
@@ -98,7 +74,7 @@ function isCiBuild() {
  * @return {boolean}
  */
 function isPullRequestBuild() {
-  return serviceFunctionMap[getCiService()]['isPullRequestBuild']();
+  return serviceFunctionMap['isPullRequestBuild']();
 }
 
 /**
@@ -106,7 +82,7 @@ function isPullRequestBuild() {
  * @return {boolean}
  */
 function isPushBuild() {
-  return serviceFunctionMap[getCiService()]['isPushBuild']();
+  return serviceFunctionMap['isPushBuild']();
 }
 
 module.exports = {

--- a/build-system/common/circleci.js
+++ b/build-system/common/circleci.js
@@ -33,7 +33,7 @@ function isCircleciBuild() {
  * @return {boolean}
  */
 function isCircleciPullRequestBuild() {
-  return isCircleciBuild() && !!process.env.CIRCLE_PULL_REQUEST;
+  return !!process.env.CIRCLE_PULL_REQUEST;
 }
 
 /**
@@ -41,7 +41,7 @@ function isCircleciPullRequestBuild() {
  * @return {boolean}
  */
 function isCircleciPushBuild() {
-  return isCircleciBuild() && !process.env.CIRCLE_PULL_REQUEST;
+  return !process.env.CIRCLE_PULL_REQUEST;
 }
 
 module.exports = {

--- a/build-system/common/circleci.js
+++ b/build-system/common/circleci.js
@@ -16,38 +16,36 @@
 'use strict';
 
 /**
- * @fileoverview Provides various kinds of GitHub Actions state. Reference:
- * https://docs.github.com/en/free-pro-team@latest/actions/reference/environment-variables#default-environment-variables
+ * @fileoverview Provides various kinds of CircleCI state. Reference:
+ * Reference: https://circleci.com/docs/2.0/env-vars/#built-in-environment-variables
  */
 
 /**
- * Returns true if this is a GitHub Actions build.
+ * Returns true if this is a CircleCI build.
  * @return {boolean}
  */
-function isGithubActionsBuild() {
-  return !!process.env.GITHUB_ACTIONS;
+function isCircleciBuild() {
+  return !!process.env.CIRCLECI;
 }
 
 /**
  * Returns true if this is a PR build.
  * @return {boolean}
  */
-function isGithubActionsPullRequestBuild() {
-  return (
-    isGithubActionsBuild() && process.env.GITHUB_EVENT_NAME === 'pull_request'
-  );
+function isCircleciPullRequestBuild() {
+  return isCircleciBuild() && !!process.env.CIRCLE_PULL_REQUEST;
 }
 
 /**
  * Returns true if this is a Push build.
  * @return {boolean}
  */
-function isGithubActionsPushBuild() {
-  return isGithubActionsBuild() && process.env.GITHUB_EVENT_NAME === 'push';
+function isCircleciPushBuild() {
+  return isCircleciBuild() && !process.env.CIRCLE_PULL_REQUEST;
 }
 
 module.exports = {
-  isGithubActionsBuild,
-  isGithubActionsPullRequestBuild,
-  isGithubActionsPushBuild,
+  isCircleciBuild,
+  isCircleciPullRequestBuild,
+  isCircleciPushBuild,
 };

--- a/build-system/common/github-actions.js
+++ b/build-system/common/github-actions.js
@@ -33,9 +33,7 @@ function isGithubActionsBuild() {
  * @return {boolean}
  */
 function isGithubActionsPullRequestBuild() {
-  return (
-    isGithubActionsBuild() && process.env.GITHUB_EVENT_NAME === 'pull_request'
-  );
+  return process.env.GITHUB_EVENT_NAME === 'pull_request';
 }
 
 /**
@@ -43,7 +41,7 @@ function isGithubActionsPullRequestBuild() {
  * @return {boolean}
  */
 function isGithubActionsPushBuild() {
-  return isGithubActionsBuild() && process.env.GITHUB_EVENT_NAME === 'push';
+  return process.env.GITHUB_EVENT_NAME === 'push';
 }
 
 module.exports = {

--- a/build-system/common/travis.js
+++ b/build-system/common/travis.js
@@ -21,7 +21,8 @@ const log = require('fancy-log');
 const {red, cyan} = colors;
 
 /**
- * @fileoverview Provides functions that extract various kinds of Travis state.
+ * @fileoverview Provides various kinds of Travis state. Reference:
+ * https://docs.travis-ci.com/user/environment-variables/#default-environment-variables
  */
 
 /**

--- a/build-system/common/travis.js
+++ b/build-system/common/travis.js
@@ -38,7 +38,7 @@ function isTravisBuild() {
  * @return {boolean}
  */
 function isTravisPullRequestBuild() {
-  return isTravisBuild() && process.env.TRAVIS_EVENT_TYPE === 'pull_request';
+  return process.env.TRAVIS_EVENT_TYPE === 'pull_request';
 }
 
 /**
@@ -46,7 +46,7 @@ function isTravisPullRequestBuild() {
  * @return {boolean}
  */
 function isTravisPushBuild() {
-  return isTravisBuild() && process.env.TRAVIS_EVENT_TYPE === 'push';
+  return process.env.TRAVIS_EVENT_TYPE === 'push';
 }
 
 /**

--- a/build-system/pr-check/bundle-size.js
+++ b/build-system/pr-check/bundle-size.js
@@ -34,7 +34,7 @@ const {
   timedExecOrDie: timedExecOrDieBase,
 } = require('./utils');
 const {determineBuildTargets} = require('./build-targets');
-const {isTravisPullRequestBuild} = require('../common/travis');
+const {isPullRequestBuild} = require('../common/ci');
 const {runNpmChecks} = require('./npm-checks');
 
 const FILENAME = 'bundle-size.js';
@@ -48,7 +48,7 @@ async function main() {
     return;
   }
 
-  if (!isTravisPullRequestBuild()) {
+  if (!isPullRequestBuild()) {
     downloadDistOutput(FILENAME);
     downloadEsmDistOutput(FILENAME);
     timedExecOrDie('gulp bundle-size --on_push_build');

--- a/build-system/pr-check/checks.js
+++ b/build-system/pr-check/checks.js
@@ -30,7 +30,7 @@ const {
   timedExecOrDie: timedExecOrDieBase,
 } = require('./utils');
 const {determineBuildTargets} = require('./build-targets');
-const {isTravisPullRequestBuild} = require('../common/travis');
+const {isPullRequestBuild} = require('../common/ci');
 const {reportAllExpectedTests} = require('../tasks/report-test-status');
 const {runNpmChecks} = require('./npm-checks');
 
@@ -44,7 +44,7 @@ async function main() {
     return;
   }
 
-  if (!isTravisPullRequestBuild()) {
+  if (!isPullRequestBuild()) {
     timedExecOrDie('gulp update-packages');
     timedExecOrDie('gulp check-exact-versions');
     timedExecOrDie('gulp lint');

--- a/build-system/pr-check/e2e-tests.js
+++ b/build-system/pr-check/e2e-tests.js
@@ -31,7 +31,7 @@ const {
   timedExecOrThrow: timedExecOrThrowBase,
 } = require('./utils');
 const {determineBuildTargets} = require('./build-targets');
-const {isTravisPullRequestBuild} = require('../common/travis');
+const {isPullRequestBuild} = require('../common/ci');
 
 const FILENAME = 'e2e-tests.js';
 const FILELOGPREFIX = colors.bold(colors.yellow(`${FILENAME}:`));
@@ -41,7 +41,7 @@ const timedExecOrThrow = (cmd, msg) => timedExecOrThrowBase(cmd, FILENAME, msg);
 async function main() {
   const startTime = startTimer(FILENAME, FILENAME);
 
-  if (!isTravisPullRequestBuild()) {
+  if (!isPullRequestBuild()) {
     downloadDistOutput(FILENAME);
     timedExecOrDie('gulp update-packages');
 

--- a/build-system/pr-check/esm-tests.js
+++ b/build-system/pr-check/esm-tests.js
@@ -31,7 +31,7 @@ const {
   downloadDistOutput,
 } = require('./utils');
 const {determineBuildTargets} = require('./build-targets');
-const {isTravisPullRequestBuild} = require('../common/travis');
+const {isPullRequestBuild} = require('../common/ci');
 
 const FILENAME = 'esm-tests.js';
 const FILELOGPREFIX = colors.bold(colors.yellow(`${FILENAME}:`));
@@ -41,7 +41,7 @@ const timedExecOrDie = (cmd, unusedFileName) =>
 function main() {
   const startTime = startTimer(FILENAME, FILENAME);
 
-  if (!isTravisPullRequestBuild()) {
+  if (!isPullRequestBuild()) {
     downloadDistOutput(FILENAME);
     downloadEsmDistOutput(FILENAME);
     timedExecOrDie('gulp update-packages');

--- a/build-system/pr-check/local-tests.js
+++ b/build-system/pr-check/local-tests.js
@@ -17,7 +17,7 @@
 
 /**
  * @fileoverview
- *This script runs the unit and integration tests on a local Travis VM.
+ * This script runs the unit and integration tests locally on a VM.
  * This is run during the CI stage = test; job = local tests.
  */
 
@@ -31,7 +31,7 @@ const {
   timedExecOrThrow: timedExecOrThrowBase,
 } = require('./utils');
 const {determineBuildTargets} = require('./build-targets');
-const {isTravisPullRequestBuild} = require('../common/travis');
+const {isPullRequestBuild} = require('../common/ci');
 
 const FILENAME = 'local-tests.js';
 const FILELOGPREFIX = colors.bold(colors.yellow(`${FILENAME}:`));
@@ -41,7 +41,7 @@ const timedExecOrThrow = (cmd, msg) => timedExecOrThrowBase(cmd, FILENAME, msg);
 function main() {
   const startTime = startTimer(FILENAME, FILENAME);
 
-  if (!isTravisPullRequestBuild()) {
+  if (!isPullRequestBuild()) {
     downloadBuildOutput(FILENAME);
     timedExecOrDie('gulp update-packages');
 

--- a/build-system/pr-check/module-build.js
+++ b/build-system/pr-check/module-build.js
@@ -32,7 +32,7 @@ const {
   uploadEsmDistOutput,
 } = require('./utils');
 const {determineBuildTargets} = require('./build-targets');
-const {isTravisPullRequestBuild} = require('../common/travis');
+const {isPullRequestBuild} = require('../common/ci');
 const {runNpmChecks} = require('./npm-checks');
 
 const FILENAME = 'module-build.js';
@@ -46,7 +46,7 @@ function main() {
     return;
   }
 
-  if (!isTravisPullRequestBuild()) {
+  if (!isPullRequestBuild()) {
     timedExecOrDie('gulp update-packages');
     timedExecOrDie('gulp dist --esm --fortesting');
     uploadEsmDistOutput(FILENAME);

--- a/build-system/pr-check/nomodule-build.js
+++ b/build-system/pr-check/nomodule-build.js
@@ -34,7 +34,7 @@ const {
   uploadDistOutput,
 } = require('./utils');
 const {determineBuildTargets} = require('./build-targets');
-const {isTravisPullRequestBuild} = require('../common/travis');
+const {isPullRequestBuild} = require('../common/ci');
 const {runNpmChecks} = require('./npm-checks');
 const {signalDistUpload} = require('../tasks/pr-deploy-bot-utils');
 
@@ -49,7 +49,7 @@ async function main() {
     return;
   }
 
-  if (!isTravisPullRequestBuild()) {
+  if (!isPullRequestBuild()) {
     timedExecOrDie('gulp update-packages');
     timedExecOrDie('gulp dist --fortesting');
     uploadDistOutput(FILENAME);

--- a/build-system/pr-check/unminified-build.js
+++ b/build-system/pr-check/unminified-build.js
@@ -32,7 +32,7 @@ const {
   uploadBuildOutput,
 } = require('./utils');
 const {determineBuildTargets} = require('./build-targets');
-const {isTravisPullRequestBuild} = require('../common/travis');
+const {isPullRequestBuild} = require('../common/ci');
 const {runNpmChecks} = require('./npm-checks');
 
 const FILENAME = 'unminified-build.js';
@@ -46,7 +46,7 @@ function main() {
     return;
   }
 
-  if (!isTravisPullRequestBuild()) {
+  if (!isPullRequestBuild()) {
     timedExecOrDie('gulp update-packages');
     timedExecOrDie('gulp build --fortesting');
     uploadBuildOutput(FILENAME);

--- a/build-system/pr-check/validator-tests.js
+++ b/build-system/pr-check/validator-tests.js
@@ -30,7 +30,7 @@ const {
   timedExecOrDie: timedExecOrDieBase,
 } = require('./utils');
 const {determineBuildTargets} = require('./build-targets');
-const {isTravisPullRequestBuild} = require('../common/travis');
+const {isPullRequestBuild} = require('../common/ci');
 const {runNpmChecks} = require('./npm-checks');
 
 const FILENAME = 'validator-tests.js';
@@ -44,7 +44,7 @@ function main() {
     return;
   }
 
-  if (!isTravisPullRequestBuild()) {
+  if (!isPullRequestBuild()) {
     timedExecOrDie('gulp validator');
     timedExecOrDie('gulp validator-webui');
   } else {

--- a/build-system/pr-check/visual-diff-tests.js
+++ b/build-system/pr-check/visual-diff-tests.js
@@ -31,7 +31,7 @@ const {
   timedExecOrDie: timedExecOrDieBase,
 } = require('./utils');
 const {determineBuildTargets} = require('./build-targets');
-const {isTravisPullRequestBuild} = require('../common/travis');
+const {isPullRequestBuild} = require('../common/ci');
 
 const FILENAME = 'visual-diff-tests.js';
 const FILELOGPREFIX = colors.bold(colors.yellow(`${FILENAME}:`));
@@ -40,7 +40,7 @@ const timedExecOrDie = (cmd) => timedExecOrDieBase(cmd, FILENAME);
 function main() {
   const startTime = startTimer(FILENAME, FILENAME);
 
-  if (!isTravisPullRequestBuild()) {
+  if (!isPullRequestBuild()) {
     downloadDistOutput(FILENAME);
     timedExecOrDie('gulp update-packages');
     process.env['PERCY_TOKEN'] = atob(process.env.PERCY_TOKEN_ENCODED);


### PR DESCRIPTION
This PR updates all spots where the question "is this a Travis PR / push build" can be reasonably replaced by "is this a PR / push build". It does so by adding new service-agnostic functions to `ci.js` along with a service-to-function mapping to determine which service-specific function to call.

This should be a no-op for existing CI builds.

Partial fix for #31416

