### PR TITLE
🐛 Fix transfer of incomplete elements in no signing

### DIFF
--- a/src/utils/dom-tranform-stream.js
+++ b/src/utils/dom-tranform-stream.js
@@ -154,8 +154,8 @@ export class DomTransformStream {
         const targetBody = resolvedElements[0];
         removeNoScriptElements(dev().assertElement(this.detachedBody_));
 
-        // Always leave one element that may get updated on next chunk.
-        while (this.detachedBody_.childElementCount > 1) {
+        // Always leave one node that may get updated on next chunk.
+        while (this.detachedBody_.children.length > 1) {
           targetBody.appendChild(this.detachedBody_.firstChild);
         }
 

--- a/src/utils/dom-tranform-stream.js
+++ b/src/utils/dom-tranform-stream.js
@@ -155,7 +155,7 @@ export class DomTransformStream {
         removeNoScriptElements(dev().assertElement(this.detachedBody_));
 
         // Always leave one node that may get updated on next chunk.
-        while (this.detachedBody_.children.length > 1) {
+        while (this.detachedBody_.childNodes.length > 1) {
           targetBody.appendChild(this.detachedBody_.firstChild);
         }
 

--- a/test/unit/utils/test-dom-transform-stream.js
+++ b/test/unit/utils/test-dom-transform-stream.js
@@ -95,7 +95,7 @@ describes.fakeWin('DomTransformStream', {amp: true}, (env) => {
   });
 
   describe('#transferBody', () => {
-    it('should transfer available chunks only after calling', async () => {
+    it('should transfer available elements (leaving 1) only after calling', async () => {
       const {body} = win.document;
       detachedDoc.write(`
         <!doctype html>
@@ -117,10 +117,10 @@ describes.fakeWin('DomTransformStream', {amp: true}, (env) => {
       await flush();
 
       expect(body.querySelector('child-one')).to.exist;
-      expect(body.querySelector('child-two')).to.exist;
+      expect(body.querySelector('child-two')).not.to.exist;
     });
 
-    it('should keep transferring new chunks after call', async () => {
+    it('should keep transferring new elements (leaving 1) after call', async () => {
       const {body} = win.document;
       detachedDoc.write(`
         <!doctype html>
@@ -137,7 +137,7 @@ describes.fakeWin('DomTransformStream', {amp: true}, (env) => {
       await flush();
 
       expect(body.querySelector('child-one')).to.exist;
-      expect(body.querySelector('child-one')).to.exist;
+      expect(body.querySelector('child-two')).not.to.exist;
 
       detachedDoc.write(`
         <child-three></child-three>
@@ -146,11 +146,12 @@ describes.fakeWin('DomTransformStream', {amp: true}, (env) => {
       transformer.onChunk(detachedDoc);
       await flush();
 
+      expect(body.querySelector('child-two')).to.exist;
       expect(body.querySelector('child-three')).to.exist;
-      expect(body.querySelector('child-four')).to.exist;
+      expect(body.querySelector('child-four')).not.to.exist;
     });
 
-    it('should resolve only after onEnd is called', async () => {
+    it('should resolve and transfer final element only after onEnd is called', async () => {
       const {body} = win.document;
       const tranferCompleteSpy = env.sandbox.spy();
       transformer.transferBody(body /* targetBody */).then(tranferCompleteSpy);


### PR DESCRIPTION
The in-memory document will try to parse partial elements into properly formatted DOM. This is a problem because we transfer all available elements to the target body as soon as they appear, when we should be waiting to see if the next chunk may alter the last element e.g. 

![image](https://user-images.githubusercontent.com/16087874/101422428-85c86d00-38ab-11eb-91c9-2a2035c2ebd5.png)


Partial #27189

 