### PR TITLE
Low-hanging fruit replacements for getLayoutWidth/Box uses and deprecate some measurement APIs

### DIFF
--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -920,6 +920,10 @@ const bannedTermsHelpString =
   'forbidden property/method or mark it with `object./*REVIEW*/property` ' +
   'if you are unsure and so that it stands out in code reviews.';
 
+const measurementApiDeprecated =
+  'getLayoutWidth/Box APIs are being deprecated. Please contact the' +
+  ' @ampproject/wg-performance for questions.';
+
 const forbiddenTermsSrcInclusive = {
   '\\.innerHTML(?!_)': bannedTermsHelpString,
   '\\.outerHTML(?!_)': bannedTermsHelpString,
@@ -1190,6 +1194,43 @@ const forbiddenTermsSrcInclusive = {
     ],
   },
   '\\.matches\\(': 'Please use matches() helper in src/dom.js',
+  '\\.getLayoutWidth': {
+    message: measurementApiDeprecated,
+    allowlist: [
+      'builtins/amp-img.js',
+      'src/service/resources-impl.js',
+      'extensions/amp-fx-flying-carpet/0.1/amp-fx-flying-carpet.js',
+    ],
+  },
+  '\\.getPageLayoutBox': {
+    message: measurementApiDeprecated,
+    allowlist: [
+      'src/base-element.js',
+      'src/custom-element.js',
+      'src/iframe-attributes.js',
+      'src/ini-load.js',
+      'src/service/mutator-impl.js',
+      'src/service/resource.js',
+      'extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js',
+      'extensions/amp-ad-network-doubleclick-impl/0.1/safeframe-host.js',
+      'extensions/amp-ad-network-doubleclick-impl/0.1/sra-utils.js',
+      'extensions/amp-auto-ads/0.1/utils.js',
+      'extensions/amp-video-docking/0.1/amp-video-docking.js',
+      'extensions/amp-video-docking/0.1/math.js',
+      'ads/google/a4a/utils.js',
+    ],
+  },
+  '\\.getIntersectionElementLayoutBox': {
+    message: measurementApiDeprecated,
+    allowlist: [
+      'src/custom-element.js',
+      'extensions/amp-a4a/0.1/amp-a4a.js',
+      'extensions/amp-ad/0.1/amp-ad-3p-impl.js',
+      'extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js',
+      'extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js',
+      'extensions/amp-iframe/0.1/amp-iframe.js',
+    ],
+  },
 };
 
 // Terms that must appear in a source file.

--- a/examples/carousel.amp.html
+++ b/examples/carousel.amp.html
@@ -20,7 +20,7 @@
   <script async custom-element="amp-audio" src="https://cdn.ampproject.org/v0/amp-audio-0.1.js"></script>
   <script async custom-element="amp-soundcloud" src="https://cdn.ampproject.org/v0/amp-soundcloud-0.1.js"></script>
   <script async custom-element="amp-anim" src="https://cdn.ampproject.org/v0/amp-anim-0.1.js"></script>
-  <script async custom-element="amp-carousel" src="https://cdn.ampproject.org/v0/amp-carousel-0.2.js"></script>
+  <script async custom-element="amp-carousel" src="https://cdn.ampproject.org/v0/amp-carousel-0.1.js"></script>
   <script async custom-element="amp-youtube" src="https://cdn.ampproject.org/v0/amp-youtube-0.1.js"></script>
   <script async custom-element="amp-video" src="https://cdn.ampproject.org/v0/amp-video-0.1.js"></script>
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>

--- a/extensions/amp-carousel/0.1/scrollable-carousel.js
+++ b/extensions/amp-carousel/0.1/scrollable-carousel.js
@@ -321,7 +321,7 @@ export class AmpScrollableCarousel extends BaseCarousel {
    * @private
    */
   withinWindow_(pos, callback) {
-    const containerWidth = this.element.getLayoutWidth();
+    const containerWidth = this.element./*OK*/ offsetWidth;
     for (let i = 0; i < this.cells_.length; i++) {
       const cell = this.cells_[i];
       if (
@@ -384,7 +384,7 @@ export class AmpScrollableCarousel extends BaseCarousel {
 
   /** @override */
   hasNext() {
-    const containerWidth = this.element.getLayoutWidth();
+    const containerWidth = this.element./*OK*/ offsetWidth;
     const scrollWidth = this.container_./*OK*/ scrollWidth;
     const maxPos = Math.max(scrollWidth - containerWidth, 0);
     return this.pos_ != maxPos;

--- a/extensions/amp-carousel/0.1/slidescroll.js
+++ b/extensions/amp-carousel/0.1/slidescroll.js
@@ -311,7 +311,7 @@ export class AmpSlideScroll extends BaseSlides {
 
   /** @override */
   onLayoutMeasure() {
-    this.slideWidth_ = this.element.getLayoutWidth();
+    this.slideWidth_ = this.element./*OK*/ offsetWidth;
   }
 
   /** @override */

--- a/extensions/amp-carousel/0.1/test/test-slidescroll.js
+++ b/extensions/amp-carousel/0.1/test/test-slidescroll.js
@@ -661,15 +661,11 @@ describes.realWin(
 
     it('should handle layout measures (orientation changes)', async () => {
       const ampSlideScroll = await getAmpSlideScroll();
-      const getLayoutWidthStub = env.sandbox.stub(
-        ampSlideScroll,
-        'getLayoutWidth'
-      );
       const impl = ampSlideScroll.implementation_;
+      const offsetWidthStub = env.sandbox.stub(ampSlideScroll, 'offsetWidth');
 
-      getLayoutWidthStub.returns(200);
+      offsetWidthStub.value(200);
       impl.onLayoutMeasure();
-      expect(getLayoutWidthStub).to.have.been.calledOnce;
       expect(impl.slideWidth_).to.equal(200);
 
       // Show the first slide, make sure the scroll position is correct.
@@ -677,9 +673,8 @@ describes.realWin(
       expect(impl.slidesContainer_./*OK*/ scrollLeft).to.equal(200);
 
       // Now do a layout measure letting the component know it changed size.
-      getLayoutWidthStub.returns(400);
+      offsetWidthStub.value(400);
       impl.onLayoutMeasure();
-      expect(getLayoutWidthStub).to.have.callCount(2);
       expect(impl.slideWidth_).to.equal(400);
       expect(impl.slidesContainer_./*OK*/ scrollLeft).to.equal(200);
 

--- a/extensions/amp-image-slider/0.1/amp-image-slider.js
+++ b/extensions/amp-image-slider/0.1/amp-image-slider.js
@@ -372,7 +372,7 @@ export class AmpImageSlider extends AMP.BaseElement {
 
     this.gestures_.onPointerDown((e) => {
       // Ensure touchstart changes slider position
-      this.pointerMoveX_(e.touches[0].pageX, true);
+      this.pointerMoveX_(e.touches[0].pageX);
       this.animateHideHint_();
     });
   }
@@ -420,7 +420,7 @@ export class AmpImageSlider extends AMP.BaseElement {
    */
   onMouseDown_(e) {
     e.preventDefault();
-    this.pointerMoveX_(e.pageX, true);
+    this.pointerMoveX_(e.pageX);
 
     // In case, clear up remnants
     // This is to prevent right mouse button down when left still down
@@ -562,7 +562,10 @@ export class AmpImageSlider extends AMP.BaseElement {
    */
   getCurrentSliderPercentage_() {
     const {left: barLeft} = this.bar_./*OK*/ getBoundingClientRect();
-    const {left: boxLeft, width: boxWidth} = this.getLayoutBox();
+    const {
+      left: boxLeft,
+      width: boxWidth,
+    } = this.element./*OK*/ getBoundingClientRect();
     return (barLeft - boxLeft) / boxWidth;
   }
 
@@ -632,40 +635,26 @@ export class AmpImageSlider extends AMP.BaseElement {
    * Move slider based on given pointer x position
    * Do NOT wrap this in mutateElement!
    * @param {number} pointerX
-   * @param {boolean} opt_recal recalibrate rect
    * @private
    */
-  pointerMoveX_(pointerX, opt_recal = false) {
+  pointerMoveX_(pointerX) {
     let width, left, right;
-    if (!opt_recal) {
-      const layoutBox = this.getLayoutBox();
-      width = layoutBox.width;
-      left = layoutBox.left;
-      right = layoutBox.right;
-      const newPos = clamp(pointerX, left, right);
-      const newPercentage = (newPos - left) / width;
-      this.mutateElement(() => {
+    // This is to address the "snap to leftmost" bug that occurs on
+    // pointer down after scrolling away and back 3+ slides
+    // layoutBox is not updated correctly when first landed on page
+    this.measureMutateElement(
+      () => {
+        const rect = this.element./*OK*/ getBoundingClientRect();
+        width = rect.width;
+        left = rect.left;
+        right = rect.right;
+      },
+      () => {
+        const newPos = clamp(pointerX, left, right);
+        const newPercentage = (newPos - left) / width;
         this.updatePositions_(newPercentage);
-      });
-    } else {
-      // Fix cases where getLayoutBox() cannot be trusted (when in carousel)!
-      // This is to address the "snap to leftmost" bug that occurs on
-      // pointer down after scrolling away and back 3+ slides
-      // layoutBox is not updated correctly when first landed on page
-      this.measureMutateElement(
-        () => {
-          const rect = this.element./*OK*/ getBoundingClientRect();
-          width = rect.width;
-          left = rect.left;
-          right = rect.right;
-        },
-        () => {
-          const newPos = clamp(pointerX, left, right);
-          const newPercentage = (newPos - left) / width;
-          this.updatePositions_(newPercentage);
-        }
-      );
-    }
+      }
+    );
   }
 
   /**

--- a/extensions/amp-viz-vega/0.1/amp-viz-vega.js
+++ b/extensions/amp-viz-vega/0.1/amp-viz-vega.js
@@ -114,7 +114,7 @@ export class AmpVizVega extends AMP.BaseElement {
 
   /** @override */
   onLayoutMeasure() {
-    const box = this.getLayoutBox();
+    const box = this./*OK*/ getBoundingClientRect();
     if (
       this.measuredWidth_ == box.width &&
       this.measuredHeight_ == box.height


### PR DESCRIPTION
Mostly replaced `getLayoutBox/getLayoutWidth` with a direct measurement where the old code is doing additional measurements anyway.