### PR TITLE
✨ Implement sticky ad bottom type ad on amp-ad

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -22,5 +22,6 @@
   "build-in-chunks": 1,
   "visibility-trigger-improvements": 1,
   "fie-resources": 1,
-  "amp-cid-backup": 1
+  "amp-cid-backup": 1,
+  "sticky-ad-transition": 0.1
 }

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -18,5 +18,6 @@
   "ios-fixed-no-transfer": 0,
   "pump-early-frame": 1,
   "fie-resources": 0.1,
-  "visibility-trigger-improvements": 1
+  "visibility-trigger-improvements": 1,
+  "sticky-ad-transition": 0.1
 }

--- a/build-system/tasks/runtime-test/helpers-unit.js
+++ b/build-system/tasks/runtime-test/helpers-unit.js
@@ -87,7 +87,9 @@ function extractCssJsFileMap() {
  */
 function getImports(jsFile) {
   const jsFileContents = fs.readFileSync(jsFile, 'utf8');
-  const {imports} = listImportsExports.parse(jsFileContents, ['importAssertions']);
+  const {imports} = listImportsExports.parse(jsFileContents, [
+    'importAssertions',
+  ]);
   const files = [];
   const jsFileDir = path.dirname(jsFile);
   imports.forEach(function (file) {

--- a/build-system/tasks/runtime-test/helpers-unit.js
+++ b/build-system/tasks/runtime-test/helpers-unit.js
@@ -87,7 +87,7 @@ function extractCssJsFileMap() {
  */
 function getImports(jsFile) {
   const jsFileContents = fs.readFileSync(jsFile, 'utf8');
-  const {imports} = listImportsExports.parse(jsFileContents);
+  const {imports} = listImportsExports.parse(jsFileContents, ['importAssertions']);
   const files = [];
   const jsFileDir = path.dirname(jsFile);
   imports.forEach(function (file) {

--- a/examples/sticky.ads.amp.html
+++ b/examples/sticky.ads.amp.html
@@ -208,14 +208,26 @@
   </header>
   <main role="main">
 
+  <amp-user-notification
+          layout=nodisplay
+          id="amp-user-notification6"
+          data-persist-dismissal="false">
+    This notification should ALSO ALWAYS show.
+    <a href="#learn-more">Learn more.</a>
+    <button on="tap:amp-user-notification6.dismiss" role="button" tabindex="5">Dismiss</button>
+  </amp-user-notification>
+
+
+  <amp-sticky-ad layout="nodisplay">
     <amp-ad width=300 height=50
-        sticky=bottom
+        data-consent-notification-id="amp-user-notification6"
         type="_ping_"
         data-url='https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w400-h300-no-n'
         data-valid='true'
         data-ad-width=300
         data-ad-height=50>
     </amp-ad>
+  </amp-sticky-ad>
     <article>
 
 

--- a/examples/sticky.ads.amp.html
+++ b/examples/sticky.ads.amp.html
@@ -208,26 +208,14 @@
   </header>
   <main role="main">
 
-  <amp-user-notification
-          layout=nodisplay
-          id="amp-user-notification6"
-          data-persist-dismissal="false">
-    This notification should ALSO ALWAYS show.
-    <a href="#learn-more">Learn more.</a>
-    <button on="tap:amp-user-notification6.dismiss" role="button" tabindex="5">Dismiss</button>
-  </amp-user-notification>
-
-
-  <amp-sticky-ad layout="nodisplay">
     <amp-ad width=300 height=50
-        data-consent-notification-id="amp-user-notification6"
+        sticky=bottom
         type="_ping_"
         data-url='https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w400-h300-no-n'
         data-valid='true'
         data-ad-width=300
         data-ad-height=50>
     </amp-ad>
-  </amp-sticky-ad>
     <article>
 
 

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -21,6 +21,10 @@ import {DetachedDomStream} from '../../../src/utils/detached-dom-stream';
 import {DomTransformStream} from '../../../src/utils/dom-tranform-stream';
 import {GEO_IN_GROUP} from '../../amp-geo/0.1/amp-geo-in-group';
 import {Layout, LayoutPriority, isLayoutSizeDefined} from '../../../src/layout';
+import {
+  STICKY_AD_TRANSITION_EXP,
+  divertStickyAdTransition,
+} from '../../../src/experiments/sticky-ad-transition-exp';
 import {Services} from '../../../src/services';
 import {SignatureVerifier, VerificationStatus} from './signature-verifier';
 import {
@@ -51,6 +55,7 @@ import {
   getConsentPolicyState,
 } from '../../../src/consent';
 import {getContextMetadata} from '../../../src/iframe-attributes';
+import {getExperimentBranch} from '../../../src/experiments';
 import {getMode} from '../../../src/mode';
 import {insertAnalyticsElement} from '../../../src/extension-analytics';
 import {
@@ -1759,7 +1764,6 @@ export class AmpA4A extends AMP.BaseElement {
       height,
       width
     );
-    this.applyFillContent(this.iframe);
 
     let body = '';
     const transferComplete = new Deferred();
@@ -1848,7 +1852,13 @@ export class AmpA4A extends AMP.BaseElement {
         'title': this.getIframeTitle(),
       })
     ));
-    this.applyFillContent(this.iframe);
+    divertStickyAdTransition(this.win);
+    if (
+      getExperimentBranch(this.win, STICKY_AD_TRANSITION_EXP.id) !==
+      STICKY_AD_TRANSITION_EXP.experiment
+    ) {
+      this.applyFillContent(this.iframe);
+    }
     const fontsArray = [];
     if (creativeMetaData.customStylesheets) {
       creativeMetaData.customStylesheets.forEach((s) => {

--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -44,6 +44,7 @@ import {
   maybeAppendErrorParameter,
 } from '../../../ads/google/a4a/utils';
 import {ResponsiveState} from './responsive-state';
+import {STICKY_AD_TRANSITION_EXP} from '../../../src/experiments/sticky-ad-transition-exp';
 import {Services} from '../../../src/services';
 import {
   addAmpExperimentIdToElement,
@@ -226,7 +227,16 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
    * @visibleForTesting
    */
   divertExperiments() {
-    const experimentInfoList = /** @type {!Array<!../../../src/experiments.ExperimentInfo>} */ ([]);
+    const experimentInfoList = /** @type {!Array<!../../../src/experiments.ExperimentInfo>} */ ([
+      {
+        experimentId: STICKY_AD_TRANSITION_EXP.id,
+        isTrafficEligible: () => true,
+        branches: [
+          STICKY_AD_TRANSITION_EXP.control,
+          STICKY_AD_TRANSITION_EXP.experiment,
+        ],
+      },
+    ]);
     const setExps = randomlySelectUnsetExperiments(
       this.win,
       experimentInfoList

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -64,6 +64,7 @@ import {
   RefreshManager, // eslint-disable-line no-unused-vars
   getRefreshManager,
 } from '../../amp-a4a/0.1/refresh-manager';
+import {STICKY_AD_TRANSITION_EXP} from '../../../src/experiments/sticky-ad-transition-exp';
 import {SafeframeHostApi} from './safeframe-host';
 import {Services} from '../../../src/services';
 import {
@@ -106,6 +107,7 @@ import {
 } from '../../../src/experiments';
 import {getMode} from '../../../src/mode';
 import {getMultiSizeDimensions} from '../../../ads/google/utils';
+
 import {getOrCreateAdCid} from '../../../src/ad-cid';
 
 import {getPageLayoutBoxBlocking} from '../../../src/utils/page-layout-box';
@@ -482,6 +484,14 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
           );
         },
         branches: Object.values(IDLE_CWV_EXP_BRANCHES),
+      },
+      {
+        experimentId: STICKY_AD_TRANSITION_EXP.id,
+        isTrafficEligible: () => true,
+        branches: [
+          STICKY_AD_TRANSITION_EXP.control,
+          STICKY_AD_TRANSITION_EXP.experiment,
+        ],
       },
     ]);
     const setExps = this.randomlySelectUnsetExperiments_(experimentInfoList);

--- a/extensions/amp-ad/0.1/amp-ad-ui.js
+++ b/extensions/amp-ad/0.1/amp-ad-ui.js
@@ -30,7 +30,7 @@ import {getExperimentBranch} from '../../../src/experiments';
 
 import {getAdContainer} from '../../../src/ad-helper';
 import {listen} from '../../../src/event-helper';
-import {setStyle} from '../../../src/style';
+import {setStyle, setStyles} from '../../../src/style';
 
 const STICKY_AD_MAX_SIZE_LIMIT = 0.2;
 const STICKY_AD_MAX_HEIGHT_LIMIT = 0.5;
@@ -371,8 +371,10 @@ export class AmpAdUIHandler {
    * @param {number} newWidth
    */
   setSize_(element, newHeight, newWidth) {
-    setStyle(element, 'height', newHeight, 'px');
-    setStyle(element, 'width', newWidth, 'px');
+    setStyles(element, {
+      'height': `${newHeight}px`,
+      'width': `${newWidth}px`,
+    });
   }
 
   /**

--- a/extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js
+++ b/extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js
@@ -100,7 +100,6 @@ export class AmpAdXOriginIframeHandler {
     devAssert(!this.iframe, 'multiple invocations of init without destroy!');
     this.iframe = iframe;
     this.iframe.setAttribute('scrolling', 'no');
-    this.baseInstance_.applyFillContent(this.iframe);
     const timer = Services.timerFor(this.baseInstance_.win);
 
     // Init the legacy observeInterection API service.

--- a/extensions/amp-ad/0.1/amp-ad.css
+++ b/extensions/amp-ad/0.1/amp-ad.css
@@ -55,11 +55,6 @@ amp-ad[sticky] {
   align-items: center;
 }
 
-amp-ad[amp-story] iframe {
-  width: 100%;
-  height: 100%;
-}
-
 amp-ad[type='adsense'],
 amp-ad[type='doubleclick'] {
   direction: ltr;

--- a/extensions/amp-ad/0.1/amp-ad.css
+++ b/extensions/amp-ad/0.1/amp-ad.css
@@ -52,6 +52,12 @@ amp-embed iframe {
 
 amp-ad[sticky] {
   visibility: hidden;
+  align-items: center;
+}
+
+amp-ad[amp-story] iframe {
+  width: 100%;
+  height: 100%;
 }
 
 amp-ad[type='adsense'],
@@ -116,12 +122,26 @@ amp-ad .amp-ad-close-button:before {
   left: 0;
 }
 
+amp-ad-sticky-padding {
+  display: block;
+  width: 100% !important;
+  background: #fff;
+  height: 4px;
+  max-height: 5px !important;
+  overflow-x: hidden;
+  overflow-y: hidden;
+  /** Must be above the dismiss button to cover bottom shadow */
+  z-index: 12;
+}
+
 amp-ad[sticky] {
   z-index: 11;
   position: fixed;
   overflow: visible !important;
   padding-bottom: env(safe-area-inset-bottom, 0px);
   box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.2) !important;
+  display: flex;
+  flex-direction: column;
 }
 
 amp-ad[sticky='top'] {

--- a/extensions/amp-ad/0.1/amp-ad.css
+++ b/extensions/amp-ad/0.1/amp-ad.css
@@ -76,10 +76,6 @@ amp-ad[data-a4a-upgrade-type='amp-ad-network-doubleclick-impl'][height='fluid'] 
   width: 100% !important;
 }
 
-amp-ad.i-amphtml-amp-ad-sticky-layout {
-  overflow: visible !important;
-}
-
 amp-ad .amp-ad-close-button {
   position: absolute;
   visibility: visible;
@@ -118,4 +114,29 @@ amp-ad .amp-ad-close-button:before {
 [dir='rtl'] amp-ad .amp-ad-close-button:before {
   right: -20px;
   left: 0;
+}
+
+amp-ad[sticky] {
+  z-index: 11;
+  position: fixed;
+  overflow: visible !important;
+  padding-bottom: env(safe-area-inset-bottom, 0px);
+  box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.2) !important;
+}
+
+amp-ad[sticky='top'] {
+  width: 100% !important;
+  background: #fff;
+  top: 0;
+}
+
+amp-ad[sticky='bottom'] {
+  width: 100% !important;
+  background: #fff;
+  bottom: 0;
+}
+
+amp-ad[sticky='bottom-right'] {
+  bottom: 0;
+  right: 0;
 }

--- a/extensions/amp-ad/0.1/test/test-amp-ad-3p-impl.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-3p-impl.js
@@ -289,7 +289,7 @@ describes.realWin(
 
       describe('during layout', () => {
         it('sticky ad: should not layout w/o scroll', () => {
-          ad3p.uiHandler.isStickyAd_ = true;
+          ad3p.uiHandler.stickyAdPosition_ = 'bottom';
           expect(ad3p.xOriginIframeHandler_).to.be.null;
           const layoutPromise = ad3p.layoutCallback();
           return Promise.race([macroTask(), layoutPromise])

--- a/extensions/amp-ad/0.1/test/test-amp-ad-ui.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-ui.js
@@ -325,7 +325,7 @@ describes.realWin(
     describe('sticky ads', () => {
       it('should render close buttons on render once', () => {
         expect(uiHandler.unlisteners_).to.be.empty;
-        uiHandler.isStickyAd_ = true;
+        uiHandler.stickyAdPosition_ = 'bottom';
         uiHandler.onResizeSuccess();
         expect(uiHandler.closeButtonRendered_).to.be.true;
         expect(uiHandler.unlisteners_.length).to.equal(1);

--- a/extensions/amp-ad/0.1/test/test-amp-ad-ui.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-ui.js
@@ -245,6 +245,7 @@ describes.realWin(
             height: '50px',
           });
           env.win.document.body.appendChild(adElement);
+          env.sandbox.stub(uiHandler, 'setSize_');
           env.sandbox
             .stub(adImpl, 'attemptChangeSize')
             .callsFake((height, width) => {
@@ -262,6 +263,7 @@ describes.realWin(
         });
 
         it('should tolerate string input', () => {
+          env.sandbox.stub(uiHandler, 'setSize_');
           env.sandbox
             .stub(adImpl, 'attemptChangeSize')
             .callsFake((height, width) => {

--- a/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.css
+++ b/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.css
@@ -14,6 +14,11 @@
  * limitations under the License.
  */
 
+amp-ad[amp-story] iframe {
+  width: 100%;
+  height: 100%;
+}
+
 .i-amphtml-story-desktop-panels amp-story-page[i-amphtml-loading][ad] {
   /* Move below viewport so that ad preloads */
   transform: scale(1) translateX(-100%) translateY(200%) !important;

--- a/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.css
+++ b/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.css
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
- .i-amphtml-story-desktop-panels amp-story-page[i-amphtml-loading][ad] {
+.i-amphtml-story-desktop-panels amp-story-page[i-amphtml-loading][ad] {
   /* Move below viewport so that ad preloads */
-  transform: scale(1.0) translateX(-100%) translateY(200%) !important;
+  transform: scale(1) translateX(-100%) translateY(200%) !important;
 }
 
 .i-amphtml-cta-container {
@@ -43,21 +43,23 @@ amp-story-page[xdomain-ad] .i-amphtml-glass-pane {
 }
 
 /* TODO(ccordry): refactor centering logic in amp-ad.css and remove this hack.  */
-amp-story-page amp-ad[data-a4a-upgrade-type="amp-ad-network-doubleclick-impl"] > iframe,
-amp-story-page amp-ad[type="adsense"] > iframe {
+amp-story-page amp-ad[data-a4a-upgrade-type='amp-ad-network-doubleclick-impl'],
+amp-story-page amp-ad[type='adsense'] {
   top: 0 !important;
   left: 0 !important;
   transform: translate(0) !important;
 }
 
 /* TODO(ccordry) allow advertisers to opt-in to fullscreen ads. */
-.i-amphtml-story-desktop-fullbleed .i-amphtml-story-grid-template-fill > amp-ad > iframe {
+.i-amphtml-story-desktop-fullbleed
+  .i-amphtml-story-grid-template-fill
+  > amp-ad {
   left: 50% !important;
   right: auto !important;
   margin: auto !important;
   min-height: 75vh !important;
   max-height: 75vh !important;
-  min-width: calc(3/5 * 75vh) !important;
-  max-width: calc(3/5 * 75vh) !important;
+  min-width: calc(3 / 5 * 75vh) !important;
+  max-width: calc(3 / 5 * 75vh) !important;
   transform: translateX(-50%) !important;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -936,9 +936,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.11.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.5.tgz",
-      "integrity": "sha512-X9rD8qqm695vgmeaQ4fvz/o3+Wk4ZzQvSHkDBgpYKxpD4qTAUm88ZKtHkVqIOsYFFbIQ6wQYhC6q7pjqVK0E0Q==",
+      "version": "7.12.10",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.10.tgz",
+      "integrity": "sha512-PJdRPwyoOqFAWfLytxrWwGrAxghCgh/yTNCYciOz8QgjflA7aZhECPZAa2VUedKg2+QMWkI0L9lynh2SNmNEgA==",
       "dev": true
     },
     "@babel/plugin-proposal-async-generator-functions": {

--- a/src/experiments/sticky-ad-transition-exp.js
+++ b/src/experiments/sticky-ad-transition-exp.js
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {randomlySelectUnsetExperiments} from '../experiments';
+
+/** @const @enum{string} */
+export const STICKY_AD_TRANSITION_EXP = {
+  id: 'sticky-ad-transition',
+  control: '21069722',
+  experiment: '21069723',
+};
+
+/**
+ * Select exp vs control for sticky-ad-transition.
+ * @param {!Window} win
+ */
+export function divertStickyAdTransition(win) {
+  const expInfoList = /** @type {!Array<!../experiments.ExperimentInfo>} */ ([
+    {
+      experimentId: STICKY_AD_TRANSITION_EXP.id,
+      isTrafficEligible: () => true,
+      branches: [
+        STICKY_AD_TRANSITION_EXP.control,
+        STICKY_AD_TRANSITION_EXP.experiment,
+      ],
+    },
+  ]);
+  randomlySelectUnsetExperiments(win, expInfoList);
+}


### PR DESCRIPTION
Add a white background and shadow css, so that the amp-ad sticky ad looks much more like amp-sticky-ad. Ensure resizing works on both amp-ad scenarios.

