### PR TITLE
amp-bind: polyfill String.prototype.startsWith for ie11 support.

### DIFF
--- a/src/web-worker/web-worker-polyfills.js
+++ b/src/web-worker/web-worker-polyfills.js
@@ -23,8 +23,10 @@ import {install as installArrayIncludes} from '../polyfills/array-includes';
 import {install as installMathSign} from '../polyfills/math-sign';
 import {install as installObjectAssign} from '../polyfills/object-assign';
 import {install as installObjectValues} from '../polyfills/object-values';
+import {install as installStringStartsWith} from '../polyfills/string-starts-with';
 
 installArrayIncludes(self);
+installMathSign(self);
 installObjectAssign(self);
 installObjectValues(self);
-installMathSign(self);
+installStringStartsWith(self);


### PR DESCRIPTION
Fixes https://github.com/ampproject/amphtml/issues/31466

TODO
- [x] Before merge, verify in ie11.