### PR TITLE
Remove polyfills from webworker for esm builds.

### DIFF
--- a/src/web-worker/web-worker-polyfills.js
+++ b/src/web-worker/web-worker-polyfills.js
@@ -25,8 +25,10 @@ import {install as installObjectAssign} from '../polyfills/object-assign';
 import {install as installObjectValues} from '../polyfills/object-values';
 import {install as installStringStartsWith} from '../polyfills/string-starts-with';
 
-installArrayIncludes(self);
-installMathSign(self);
-installObjectAssign(self);
-installObjectValues(self);
-installStringStartsWith(self);
+if (!IS_ESM) {
+  installArrayIncludes(self);
+  installObjectAssign(self);
+  installObjectValues(self);
+  installMathSign(self);
+  installStringStartsWith(self);
+}


### PR DESCRIPTION
**summary**
Context: https://github.com/ampproject/amphtml/pull/31492#pullrequestreview-547388939

All of these are already excluded from v0, so we should probably do the same for ww.

https://github.com/ampproject/amphtml/blob/0006e2f21f93fdb03a4108b2ccc7a61cc18d173c/src/polyfills.js#L36-L47

**size difference**
```
- dist/ww.js:  Δ -0.01KB
- dist/ww.mjs: Δ -0.32KB
```