### PR TITLE
✨  [Story devtools] Sync players on navigation

### DIFF
--- a/examples/amp-story/interactives.html
+++ b/examples/amp-story/interactives.html
@@ -18,7 +18,6 @@
     <script async custom-element="amp-story" src="https://cdn.ampproject.org/v0/amp-story-1.0.js"></script>
     <script async custom-element="amp-story-dev-tools" src="https://cdn.ampproject.org/v0/amp-story-dev-tools-0.1.js"></script>
     <script async custom-element="amp-story-interactive" src="https://cdn.ampproject.org/v0/amp-story-interactive-0.1.js"></script>
-    <script async custom-element="amp-story-dev-tools" src="https://cdn.ampproject.org/v0/amp-story-dev-tools-0.1.js"></script>
     <script async custom-element="amp-video" src="https://cdn.ampproject.org/v0/amp-video-0.1.js"></script>
     <link href="https://fonts.googleapis.com/css2?family=Rubik:wght@400;700&display=swap" rel="stylesheet">
   </head>

--- a/extensions/amp-story-dev-tools/0.1/amp-story-dev-tools-tab-preview.js
+++ b/extensions/amp-story-dev-tools/0.1/amp-story-dev-tools-tab-preview.js
@@ -440,6 +440,14 @@ export class AmpStoryDevToolsTabPreview extends AMP.BaseElement {
       width: device.width + 'px',
       height: device.height + 'px',
     });
+    devicePlayer.addEventListener('storyNavigation', (event) => {
+      console.log(event.detail);
+      this.devices_.forEach((d) => {
+        if (d != device) {
+          d.player.show(null, event.detail.pageId);
+        }
+      });
+    });
     const playerImpl = new AmpStoryPlayer(this.win, devicePlayer);
     playerImpl.load();
     setStyles(
@@ -450,7 +458,7 @@ export class AmpStoryDevToolsTabPreview extends AMP.BaseElement {
           : 'fit-content',
       }
     );
-    device.player = devicePlayer;
+    device.player = playerImpl;
     return deviceLayout;
   }
 

--- a/extensions/amp-story-dev-tools/0.1/amp-story-dev-tools-tab-preview.js
+++ b/extensions/amp-story-dev-tools/0.1/amp-story-dev-tools-tab-preview.js
@@ -440,16 +440,6 @@ export class AmpStoryDevToolsTabPreview extends AMP.BaseElement {
       width: device.width + 'px',
       height: device.height + 'px',
     });
-    devicePlayer.addEventListener('storyNavigation', (event) => {
-      console.log(event.detail);
-      this.devices_.forEach((d) => {
-        if (d != device) {
-          d.player.show(null, event.detail.pageId);
-        }
-      });
-    });
-    const playerImpl = new AmpStoryPlayer(this.win, devicePlayer);
-    playerImpl.load();
     setStyles(
       deviceLayout.querySelector('.i-amphtml-story-dev-tools-device-screen'),
       {
@@ -458,7 +448,7 @@ export class AmpStoryDevToolsTabPreview extends AMP.BaseElement {
           : 'fit-content',
       }
     );
-    device.player = playerImpl;
+    device.player = new AmpStoryPlayer(this.win, devicePlayer);
     return deviceLayout;
   }
 
@@ -508,6 +498,17 @@ export class AmpStoryDevToolsTabPreview extends AMP.BaseElement {
       this.element
         .querySelector('.i-amphtml-story-dev-tools-device-chips')
         .appendChild(deviceSpecs.chip);
+    }).then(() => {
+      deviceSpecs.player.load();
+      deviceSpecs.player
+        .getElement()
+        .addEventListener('storyNavigation', (event) => {
+          this.devices_.forEach((d) => {
+            if (d != deviceSpecs) {
+              d.player.show(null, event.detail.pageId);
+            }
+          });
+        });
     });
     this.devices_.push(deviceSpecs);
     this.updateDevicesInHash_();

--- a/extensions/amp-story-dev-tools/0.1/amp-story-dev-tools-tab-preview.js
+++ b/extensions/amp-story-dev-tools/0.1/amp-story-dev-tools-tab-preview.js
@@ -499,7 +499,6 @@ export class AmpStoryDevToolsTabPreview extends AMP.BaseElement {
         .querySelector('.i-amphtml-story-dev-tools-device-chips')
         .appendChild(deviceSpecs.chip);
     }).then(() => {
-      deviceSpecs.player.load();
       deviceSpecs.player
         .getElement()
         .addEventListener('storyNavigation', (event) => {
@@ -509,6 +508,7 @@ export class AmpStoryDevToolsTabPreview extends AMP.BaseElement {
             }
           });
         });
+      deviceSpecs.player.load();
     });
     this.devices_.push(deviceSpecs);
     this.updateDevicesInHash_();

--- a/extensions/amp-story-dev-tools/0.1/amp-story-dev-tools.js
+++ b/extensions/amp-story-dev-tools/0.1/amp-story-dev-tools.js
@@ -220,6 +220,7 @@ export class AmpStoryDevTools extends AMP.BaseElement {
       DevToolsTab.LOGS
     );
     Object.values(this.tabContents_).forEach((tabContent) => {
+      tabContent.setAttribute('layout', 'container');
       toggle(tabContent, false);
       container.appendChild(tabContent);
     });


### PR DESCRIPTION
Make all the story players sync when you navigate on one of them.

Also: removed duplicate import of extension on demo story, set tabs to container because AMP complains if they don't have a layout type.

Closes #31442 