### PR TITLE
DO NOT MERGE: Ensure ie11 test fails before fix

### DIFF
--- a/test/integration/test-amp-bind.js
+++ b/test/integration/test-amp-bind.js
@@ -21,7 +21,7 @@ const TIMEOUT = 10000;
 // Skip Edge, which throws "Permission denied" errors when inspecting
 // element properties in the testing iframe (Edge 17, Windows 10).
 describe
-  .configure()
+  .configure({enableIe: true})
   .skipEdge()
   .run('amp-bind', function () {
     this.timeout(TIMEOUT);

--- a/test/integration/test-amp-bind.js
+++ b/test/integration/test-amp-bind.js
@@ -21,7 +21,8 @@ const TIMEOUT = 10000;
 // Skip Edge, which throws "Permission denied" errors when inspecting
 // element properties in the testing iframe (Edge 17, Windows 10).
 describe
-  .configure({enableIe: true})
+  .configure()
+  .enableIe()
   .skipEdge()
   .run('amp-bind', function () {
     this.timeout(TIMEOUT);
@@ -40,6 +41,8 @@ describe
       <p class="before_class" [class]="c" [text]="t">before_text</p>
     `,
         extensions: ['amp-bind'],
+        enableIe: true,
+
       },
       (env) => {
         let browser;


### PR DESCRIPTION
Making sure I can make an amp-bind integ test fail for ie11 before merging https://github.com/ampproject/amphtml/pull/31492