### PR TITLE
🏗 Delete swept experiment from opt-in config

### DIFF
--- a/build-system/tasks/sweep-experiments/index.js
+++ b/build-system/tasks/sweep-experiments/index.js
@@ -124,6 +124,14 @@ function removeFromExperimentsConfig(id) {
  */
 function removeFromJsonConfig(config, path, id) {
   delete config[id];
+
+  for (const allowOptInKey of ['allow-doc-opt-in', 'allow-url-opt-in']) {
+    const index = config[allowOptInKey].indexOf(id);
+    if (index > -1) {
+      config[allowOptInKey].splice(index, 1);
+    }
+  }
+
   writeFileSync(path, JSON.stringify(config, null, 2) + '\n');
   return [path];
 }

--- a/build-system/tasks/sweep-experiments/index.js
+++ b/build-system/tasks/sweep-experiments/index.js
@@ -265,7 +265,7 @@ const fileListMarkdown = (files) =>
  * @return {string}
  */
 const readmeMdGithubLink = () =>
-  `https://github.com/ampproject/amphtml/${path.relative(
+  `https://github.com/ampproject/amphtml/blob/master/${path.relative(
     process.cwd(),
     __dirname
   )}/README.md`;


### PR DESCRIPTION
Missed this earlier when merging #31458.

When an experiment launch is removed from config, it should also be removed from the opt-in lists:

```diff
 {
-  "allow-doc-opt-in": ["foo", "removed"],
-  "allow-url-opt-in": ["removed"],
+  "allow-doc-opt-in": ["foo"],
+  "allow-url-opt-in": [],
   "foo": 1,
-  "removed": 1,
 }
```

<!--
# Instructions:

- Pick a meaningful title for your pull request. (Use sentence case.)
  - Prefix the title with an emoji to identify what is being done. (Copy-paste the emoji from the list below.)
  - Do not overuse punctuation in the title (like `(chore):`).
  - If it is helpful, use a simple prefix (like `ProjectX: Implement some feature`).
- Enter a succinct description that says why the PR is necessary, and what it does.
  - Mention the GitHub issue that is being addressed by the pull request.
  - The keywords `Fixes`, `Closes`, or `Resolves` followed the issue number will automatically close the issue.

> NOTE: All non-trivial changes (like introducing new features or components) should have an associated issue or reference an I2I (intent-to-implement: go.amp.dev/i2i). Please read through the contribution process (go.amp.dev/contributing/code) for more information.

# Example of a good description:

- Implement aspect X
- Leave out feature Y because of A
- Improve performance by B
- Improve accessibility by C

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Reverting a previous change
♻️ Refactoring
🚮 Deleting code
🧪 Experimental code
-->
