### PR TITLE
🏗♻️ Make all utilities in `build-system/common/git.js` CI-service-agnostic

### DIFF
--- a/build-system/common/ci.js
+++ b/build-system/common/ci.js
@@ -15,12 +15,19 @@
  */
 'use strict';
 
+const log = require('fancy-log');
+const {red} = require('ansi-colors');
+
 const {
+  circleciPullRequestBranch,
+  circleciPullRequestSha,
   isCircleciBuild,
   isCircleciPullRequestBuild,
   isCircleciPushBuild,
 } = require('./circleci');
 const {
+  githubActionsPullRequestBranch,
+  githubActionsPullRequestSha,
   isGithubActionsBuild,
   isGithubActionsPullRequestBuild,
   isGithubActionsPushBuild,
@@ -29,6 +36,8 @@ const {
   isTravisBuild,
   isTravisPullRequestBuild,
   isTravisPushBuild,
+  travisPullRequestBranch,
+  travisPullRequestSha,
 } = require('./travis');
 
 /**
@@ -40,20 +49,28 @@ const {
  */
 const serviceFunctionMap = isTravisBuild()
   ? {
+      'ciPullRequestBranch': travisPullRequestBranch,
+      'ciPullRequestSha': travisPullRequestSha,
       'isPullRequestBuild': isTravisPullRequestBuild,
       'isPushBuild': isTravisPushBuild,
     }
   : isGithubActionsBuild()
   ? {
+      'ciPullRequestBranch': githubActionsPullRequestBranch,
+      'ciPullRequestSha': githubActionsPullRequestSha,
       'isPullRequestBuild': isGithubActionsPullRequestBuild,
       'isPushBuild': isGithubActionsPushBuild,
     }
   : isCircleciBuild()
   ? {
+      'ciPullRequestBranch': circleciPullRequestBranch,
+      'ciPullRequestSha': circleciPullRequestSha,
       'isPullRequestBuild': isCircleciPullRequestBuild,
       'isPushBuild': isCircleciPushBuild,
     }
   : {
+      'ciPullRequestBranch': () => '',
+      'ciPullRequestSha': () => '',
       'isPullRequestBuild': () => false,
       'isPushBuild': () => false,
     };
@@ -85,7 +102,33 @@ function isPushBuild() {
   return serviceFunctionMap['isPushBuild']();
 }
 
+/**
+ * Returns the name of the PR branch.
+ * @return {string}
+ */
+function ciPullRequestBranch() {
+  if (!isPullRequestBuild()) {
+    log(red('ERROR:'), 'Not a PR build, PR branch is undefined.');
+    return '';
+  }
+  return serviceFunctionMap['ciPullRequestBranch']();
+}
+
+/**
+ * Returns the commit SHA being tested by the PR build.
+ * @return {string}
+ */
+function ciPullRequestSha() {
+  if (!isPullRequestBuild()) {
+    log(red('ERROR:'), 'Not a PR build, PR SHA is undefined.');
+    return '';
+  }
+  return serviceFunctionMap['ciPullRequestSha']();
+}
+
 module.exports = {
+  ciPullRequestBranch,
+  ciPullRequestSha,
   isCiBuild,
   isPullRequestBuild,
   isPushBuild,

--- a/build-system/common/circleci.js
+++ b/build-system/common/circleci.js
@@ -44,7 +44,25 @@ function isCircleciPushBuild() {
   return !process.env.CIRCLE_PULL_REQUEST;
 }
 
+/**
+ * Returns the name of the branch being tested by the ongoing CircleCI PR build.
+ * @return {string}
+ */
+function circleciPullRequestBranch() {
+  return process.env['CIRCLE_BRANCH'];
+}
+
+/**
+ * Returns the commit SHA being tested by the ongoing CircleCI PR build.
+ * @return {string}
+ */
+function circleciPullRequestSha() {
+  return process.env['CIRCLE_SHA1'];
+}
+
 module.exports = {
+  circleciPullRequestBranch,
+  circleciPullRequestSha,
   isCircleciBuild,
   isCircleciPullRequestBuild,
   isCircleciPushBuild,

--- a/build-system/common/github-actions.js
+++ b/build-system/common/github-actions.js
@@ -44,7 +44,25 @@ function isGithubActionsPushBuild() {
   return process.env.GITHUB_EVENT_NAME === 'push';
 }
 
+/**
+ * Returns the name of the branch being tested by the ongoing Github Actions PR build.
+ * @return {string}
+ */
+function githubActionsPullRequestBranch() {
+  return process.env['GITHUB_REF'];
+}
+
+/**
+ * Returns the commit SHA being tested by the ongoing Github Actions PR build.
+ * @return {string}
+ */
+function githubActionsPullRequestSha() {
+  return process.env['GITHUB_SHA'];
+}
+
 module.exports = {
+  githubActionsPullRequestBranch,
+  githubActionsPullRequestSha,
   isGithubActionsBuild,
   isGithubActionsPullRequestBuild,
   isGithubActionsPushBuild,

--- a/build-system/common/travis.js
+++ b/build-system/common/travis.js
@@ -15,11 +15,6 @@
  */
 'use strict';
 
-const colors = require('ansi-colors');
-const log = require('fancy-log');
-
-const {red, cyan} = colors;
-
 /**
  * @fileoverview Provides various kinds of Travis state. Reference:
  * https://docs.travis-ci.com/user/environment-variables/#default-environment-variables
@@ -50,99 +45,76 @@ function isTravisPushBuild() {
 }
 
 /**
- * Returns a function to test the environment and look up a Travis environment
- * variable
- * @param {function():boolean} testFn
- * @param {string} errorMsg
- * @param {string} envKey
- * @return {function():string}
- */
-function travisEnv(testFn, errorMsg, envKey) {
-  return function () {
-    if (!testFn()) {
-      log(red('ERROR:'), errorMsg, 'Cannot get', cyan(`process.env.${envKey}`));
-    }
-    return process.env[envKey];
-  };
-}
-
-const travisBuildEnv = (envKey) =>
-  travisEnv(isTravisBuild, 'This is not a Travis build.', envKey);
-
-/**
  * Returns the build number of the ongoing Travis build.
- * @function
  * @return {string}
  */
-const travisBuildNumber = travisBuildEnv('TRAVIS_BUILD_NUMBER');
+function travisBuildNumber() {
+  return process.env['TRAVIS_BUILD_NUMBER'];
+}
 
 /**
  * Return the build URL of the ongoing Travis build.
- * @function
  * @return {string}
  */
-const travisBuildUrl = travisBuildEnv('TRAVIS_BUILD_WEB_URL');
+function travisBuildUrl() {
+  return process.env['TRAVIS_BUILD_WEB_URL'];
+}
 
 /**
  * Returns the job number of the ongoing Travis job.
- * @function
  * @return {string}
  */
-const travisJobNumber = travisBuildEnv('TRAVIS_JOB_NUMBER');
+function travisJobNumber() {
+  return process.env['TRAVIS_JOB_NUMBER'];
+}
 
 /**
  * Return the job URL of the ongoing Travis job.
- * @function
  * @return {string}
  */
-const travisJobUrl = travisBuildEnv('TRAVIS_JOB_WEB_URL');
+function travisJobUrl() {
+  return process.env['TRAVIS_JOB_WEB_URL'];
+}
 
 /**
  * Returns the repo slug associated with the ongoing Travis build.
- * @function
  * @return {string}
  */
-const travisRepoSlug = travisBuildEnv('TRAVIS_REPO_SLUG');
+function travisRepoSlug() {
+  return process.env['TRAVIS_REPO_SLUG'];
+}
 
 /**
  * Returns the commit SHA being tested by the ongoing Travis PR build.
- * @function
  * @return {string}
  */
-const travisPullRequestSha = travisEnv(
-  isTravisPullRequestBuild,
-  'This is not a Travis PR build.',
-  'TRAVIS_PULL_REQUEST_SHA'
-);
+function travisPullRequestSha() {
+  return process.env['TRAVIS_PULL_REQUEST_SHA'];
+}
 
 /**
  * Returns the name of the branch being tested by the ongoing Travis PR build.
- * @function
  * @return {string}
  */
-const travisPullRequestBranch = travisEnv(
-  isTravisPullRequestBuild,
-  'This is not a Travis PR build.',
-  'TRAVIS_PULL_REQUEST_BRANCH'
-);
+function travisPullRequestBranch() {
+  return process.env['TRAVIS_PULL_REQUEST_BRANCH'];
+}
 
 /**
  * Returns the Travis branch for push builds.
- * @function
  * @return {string}
  */
-const travisPushBranch = travisEnv(
-  isTravisPushBuild,
-  'This is not a Travis push build.',
-  'TRAVIS_BRANCH'
-);
+function travisPushBranch() {
+  return process.env['TRAVIS_BRANCH'];
+}
 
 /**
  * Returns the commit SHA being tested by the ongoing Travis build.
- * @function
  * @return {string}
  */
-const travisCommitSha = travisBuildEnv('TRAVIS_COMMIT');
+function travisCommitSha() {
+  return process.env['TRAVIS_COMMIT'];
+}
 
 module.exports = {
   isTravisBuild,

--- a/build-system/pr-check/utils.js
+++ b/build-system/pr-check/utils.js
@@ -22,7 +22,7 @@ const {
   gitCommitHash,
   gitDiffCommitLog,
   gitDiffStatMaster,
-  gitTravisMasterBaseline,
+  gitCiMasterBaseline,
   shortSha,
 } = require('../common/git');
 const {
@@ -66,7 +66,7 @@ function printChangeSummary(fileName) {
   if (isTravisBuild()) {
     console.log(
       `${fileLogPrefix} Latest commit from ${colors.cyan('master')} included ` +
-        `in this build: ${colors.cyan(shortSha(gitTravisMasterBaseline()))}`
+        `in this build: ${colors.cyan(shortSha(gitCiMasterBaseline()))}`
     );
     commitSha = travisPullRequestSha();
   } else {

--- a/build-system/tasks/bundle-size/index.js
+++ b/build-system/tasks/bundle-size/index.js
@@ -23,7 +23,7 @@ const url = require('url');
 const util = require('util');
 const {
   gitCommitHash,
-  gitTravisMasterBaseline,
+  gitCiMasterBaseline,
   shortSha,
 } = require('../../common/git');
 const {
@@ -168,7 +168,7 @@ async function skipBundleSize() {
  */
 async function reportBundleSize() {
   if (isTravisPullRequestBuild()) {
-    const baseSha = gitTravisMasterBaseline();
+    const baseSha = gitCiMasterBaseline();
     const commitHash = gitCommitHash();
     try {
       const response = await requestPost({

--- a/build-system/tasks/visual-diff/index.js
+++ b/build-system/tasks/visual-diff/index.js
@@ -35,7 +35,7 @@ const {
 const {
   gitBranchName,
   gitCommitterEmail,
-  gitTravisMasterBaseline,
+  gitCiMasterBaseline,
   shortSha,
 } = require('../../common/git');
 const {buildRuntime, installPackages} = require('../../common/utils');
@@ -136,7 +136,7 @@ function setPercyBranch() {
  */
 function setPercyTargetCommit() {
   if (isTravisBuild() && !argv.master) {
-    process.env['PERCY_TARGET_COMMIT'] = gitTravisMasterBaseline();
+    process.env['PERCY_TARGET_COMMIT'] = gitCiMasterBaseline();
   }
 }
 


### PR DESCRIPTION
**PR highlights:**

- Replaces Travis-specific code-paths in `git.js` with service-agnostic equivalents
- Updates call-sites (mostly internal to `git.js`)
- Cleans up unnecessary boilerplate checks in `travis.js` and makes code more readable

Partial fix for #31416


