### PR TITLE
🏗♻️ Make visual diff code CI service agnostic

### DIFF
--- a/build-system/tasks/visual-diff/snippets/snapshot-error.html
+++ b/build-system/tasks/visual-diff/snippets/snapshot-error.html
@@ -18,7 +18,7 @@
 
 <body>
   <h1>Snapshot error in test <code>__TEST_NAME__</code></h1>
-  <p>Inspect the Travis logs for the full error message</p>
+  <p>Inspect the CI logs for the full error message</p>
   <div>__TEST_ERROR__</div>
   <h2>HTML Snapshot</h2>
   <div class="snapshot">__HTML_SNAPSHOT__</div>


### PR DESCRIPTION
This PR makes `gulp visual-diff` agnostic of the CI service it's running on. This is currently a no-op and doesn't change where the tests are run (coming up in a future PR).

Partial fix for #31416