### PR TITLE
🏗 Standardize interface for CI modules

### DIFF
--- a/build-system/common/circleci.js
+++ b/build-system/common/circleci.js
@@ -21,18 +21,10 @@
  */
 
 /**
- * Returns true if this is a CircleCI build.
- * @return {boolean}
- */
-function isCircleciBuild() {
-  return !!process.env.CIRCLECI;
-}
-
-/**
  * Returns true if this is a PR build.
  * @return {boolean}
  */
-function isCircleciPullRequestBuild() {
+function isPullRequestBuild() {
   return !!process.env.CIRCLE_PULL_REQUEST;
 }
 
@@ -40,7 +32,7 @@ function isCircleciPullRequestBuild() {
  * Returns true if this is a Push build.
  * @return {boolean}
  */
-function isCircleciPushBuild() {
+function isPushBuild() {
   return !process.env.CIRCLE_PULL_REQUEST;
 }
 
@@ -48,7 +40,7 @@ function isCircleciPushBuild() {
  * Returns the name of the branch being tested by the ongoing CircleCI PR build.
  * @return {string}
  */
-function circleciPullRequestBranch() {
+function pullRequestBranch() {
   return process.env['CIRCLE_BRANCH'];
 }
 
@@ -56,14 +48,14 @@ function circleciPullRequestBranch() {
  * Returns the commit SHA being tested by the ongoing CircleCI PR build.
  * @return {string}
  */
-function circleciPullRequestSha() {
+function pullRequestSha() {
   return process.env['CIRCLE_SHA1'];
 }
 
 module.exports = {
-  circleciPullRequestBranch,
-  circleciPullRequestSha,
-  isCircleciBuild,
-  isCircleciPullRequestBuild,
-  isCircleciPushBuild,
+  buildType: 'circleci',
+  pullRequestBranch,
+  pullRequestSha,
+  isPullRequestBuild,
+  isPushBuild,
 };

--- a/build-system/common/github-actions.js
+++ b/build-system/common/github-actions.js
@@ -21,18 +21,10 @@
  */
 
 /**
- * Returns true if this is a GitHub Actions build.
- * @return {boolean}
- */
-function isGithubActionsBuild() {
-  return !!process.env.GITHUB_ACTIONS;
-}
-
-/**
  * Returns true if this is a PR build.
  * @return {boolean}
  */
-function isGithubActionsPullRequestBuild() {
+function isPullRequestBuild() {
   return process.env.GITHUB_EVENT_NAME === 'pull_request';
 }
 
@@ -40,7 +32,7 @@ function isGithubActionsPullRequestBuild() {
  * Returns true if this is a Push build.
  * @return {boolean}
  */
-function isGithubActionsPushBuild() {
+function isPushBuild() {
   return process.env.GITHUB_EVENT_NAME === 'push';
 }
 
@@ -48,7 +40,7 @@ function isGithubActionsPushBuild() {
  * Returns the name of the branch being tested by the ongoing Github Actions PR build.
  * @return {string}
  */
-function githubActionsPullRequestBranch() {
+function pullRequestBranch() {
   return process.env['GITHUB_REF'];
 }
 
@@ -56,14 +48,14 @@ function githubActionsPullRequestBranch() {
  * Returns the commit SHA being tested by the ongoing Github Actions PR build.
  * @return {string}
  */
-function githubActionsPullRequestSha() {
+function pullRequestSha() {
   return process.env['GITHUB_SHA'];
 }
 
 module.exports = {
-  githubActionsPullRequestBranch,
-  githubActionsPullRequestSha,
-  isGithubActionsBuild,
-  isGithubActionsPullRequestBuild,
-  isGithubActionsPushBuild,
+  buildType: 'github-actions',
+  pullRequestBranch,
+  pullRequestSha,
+  isPullRequestBuild,
+  isPushBuild,
 };

--- a/build-system/common/travis.js
+++ b/build-system/common/travis.js
@@ -21,18 +21,10 @@
  */
 
 /**
- * Returns true if this is a Travis build.
- * @return {boolean}
- */
-function isTravisBuild() {
-  return !!process.env.TRAVIS;
-}
-
-/**
  * Returns true if this is a Travis PR build.
  * @return {boolean}
  */
-function isTravisPullRequestBuild() {
+function isPullRequestBuild() {
   return process.env.TRAVIS_EVENT_TYPE === 'pull_request';
 }
 
@@ -40,8 +32,24 @@ function isTravisPullRequestBuild() {
  * Returns true if this is a Travis Push build.
  * @return {boolean}
  */
-function isTravisPushBuild() {
+function isPushBuild() {
   return process.env.TRAVIS_EVENT_TYPE === 'push';
+}
+
+/**
+ * Returns the commit SHA being tested by the ongoing Travis PR build.
+ * @return {string}
+ */
+function pullRequestSha() {
+  return process.env['TRAVIS_PULL_REQUEST_SHA'];
+}
+
+/**
+ * Returns the name of the branch being tested by the ongoing Travis PR build.
+ * @return {string}
+ */
+function pullRequestBranch() {
+  return process.env['TRAVIS_PULL_REQUEST_BRANCH'];
 }
 
 /**
@@ -85,22 +93,6 @@ function travisRepoSlug() {
 }
 
 /**
- * Returns the commit SHA being tested by the ongoing Travis PR build.
- * @return {string}
- */
-function travisPullRequestSha() {
-  return process.env['TRAVIS_PULL_REQUEST_SHA'];
-}
-
-/**
- * Returns the name of the branch being tested by the ongoing Travis PR build.
- * @return {string}
- */
-function travisPullRequestBranch() {
-  return process.env['TRAVIS_PULL_REQUEST_BRANCH'];
-}
-
-/**
  * Returns the Travis branch for push builds.
  * @return {string}
  */
@@ -117,16 +109,17 @@ function travisCommitSha() {
 }
 
 module.exports = {
-  isTravisBuild,
-  isTravisPullRequestBuild,
-  isTravisPushBuild,
+  buildType: 'travis',
+  isPullRequestBuild,
+  isPushBuild,
+  pullRequestBranch,
+  pullRequestSha,
+
   travisBuildNumber,
   travisBuildUrl,
   travisCommitSha,
   travisJobNumber,
   travisJobUrl,
-  travisPullRequestBranch,
-  travisPullRequestSha,
   travisPushBranch,
   travisRepoSlug,
 };


### PR DESCRIPTION
I came across these files in a PR review (turns out the diff was a mistake based on rebasing, so they weren't part of the PR) but noticed a chance to unify some of the CI types here. I didn't realize it was a mistake until after I'd commented and thought about it a bit, so I figured it was worth putting in a PR for you to peek at

This standardizes the common function names across CI types (`isPushBuild`, `isPullRequestBuild`, `pullRequestBranch`, and `pullRequestSha` with the goals of a) calling code more general to allow easier transition between CI and b) simplify shared logic within ci.js. I haven't updated any calling code, but PTAL and let me know what you think of this structure.