### PR TITLE
Create e2e tests for viewers that depend on documentHeight (gmail)

### DIFF
--- a/build-system/tasks/e2e/amp-driver.js
+++ b/build-system/tasks/e2e/amp-driver.js
@@ -18,6 +18,7 @@
 const AmpdocEnvironment = {
   SINGLE: 'single',
   VIEWER_DEMO: 'viewer-demo',
+  EMAIL_DEMO: 'email-demo',
   SHADOW_DEMO: 'shadow-demo',
 
   // AMPHTML ads environments
@@ -49,21 +50,18 @@ const EnvironmentBehaviorMap = {
     },
 
     url(url) {
-      const defaultCaps = [
-        'a2a',
-        'focus-rect',
-        'foo',
-        'keyboard',
-        'swipe',
-        'iframeScroll',
-      ];
-      // Correctly append extra params in original url
-      url = url.replace('#', '&');
-      // TODO(estherkim): somehow allow non-8000 port and domain
-      return (
-        `http://localhost:8000/test/fixtures/e2e/amp-viewer-integration/viewer.html#href=${url}` +
-        `&caps=${defaultCaps.join(',')}`
-      );
+      return getViewerUrl(url);
+    },
+  },
+
+  [AmpdocEnvironment.EMAIL_DEMO]: {
+    ready(controller) {
+      return controller
+        .findElement('#viewer[data-loaded]')
+        .then((frame) => controller.switchToFrame(frame));
+    },
+    url(url) {
+      return getViewerUrl(url, {isEmail: true});
     },
   },
 
@@ -134,6 +132,31 @@ const EnvironmentBehaviorMap = {
     },
   },
 };
+
+/**
+ * @param {string} url
+ * @param {Object=} opts
+ * @param {boolean} opts.isEmail
+ * @return {string}
+ */
+function getViewerUrl(url, {isEmail} = {isEmail: false}) {
+  const defaultCaps = [
+    'a2a',
+    'focus-rect',
+    'foo',
+    'keyboard',
+    'swipe',
+    'iframeScroll',
+  ];
+  // Correctly append extra params in original url
+  url = url.replace('#', '&');
+  // TODO(estherkim): somehow allow non-8000 port and domain
+  return (
+    `http://localhost:8000/test/fixtures/e2e/amp-viewer-integration/viewer.html#href=${url}` +
+    `&caps=${defaultCaps.join(',')}` +
+    `&isEmail=${isEmail}`
+  );
+}
 
 /**
  * Provides AMP-related utilities for E2E Functional Tests.

--- a/build-system/tasks/e2e/describes-e2e.js
+++ b/build-system/tasks/e2e/describes-e2e.js
@@ -254,6 +254,10 @@ const EnvironmentVariantMap = {
     name: 'Viewer environment',
     value: {environment: 'viewer-demo'},
   },
+  [AmpdocEnvironment.EMAIL_DEMO]: {
+    name: 'Email environment (viewer)',
+    value: {environment: 'email-demo'},
+  },
   [AmpdocEnvironment.SHADOW_DEMO]: {
     name: 'Shadow environment',
     value: {environment: 'shadow-demo'},

--- a/test/e2e/test-amp-email.js
+++ b/test/e2e/test-amp-email.js
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+describes.endtoend(
+  'layoutCallback depends on updated viewport size after documentHeight change.',
+  {
+    testUrl:
+      'http://localhost:8000/test/fixtures/e2e/amp4email/viewport-size-race.html',
+    environments: ['email-demo'],
+  },
+  async (env) => {
+    it('Should call amp-img layoutCallback', async () => {
+      const {controller} = env;
+      const imgEl = await controller.findElement('img');
+      await expect(imgEl).ok;
+    });
+  }
+);
+
+describes.endtoend(
+  'layoutCallback depending on element remeasurement after documentHeight change.',
+  {
+    testUrl:
+      'http://localhost:8000/test/fixtures/e2e/amp4email/element-size-race.html',
+    environments: ['email-demo'],
+  },
+  async (env) => {
+    it('Should call amp-list layoutCallback', async () => {
+      const {controller} = env;
+      const ampListChild = await controller.findElement('.fruit');
+      await expect(ampListChild).ok;
+    });
+  }
+);

--- a/test/fixtures/e2e/amp-viewer-integration/viewer.html
+++ b/test/fixtures/e2e/amp-viewer-integration/viewer.html
@@ -9,85 +9,31 @@
     />
     <script src="/dist/v0/examples/amp-viewer-host.max.js"></script>
     <style>
-      html,
-      body {
-        overflow: hidden;
-      }
-      body,
-      viewer {
-        position: absolute;
-        top: 0;
-        left: 0;
-        right: 0;
-        bottom: 0;
-        overflow: hidden;
+      body, #viewer {
         margin: 0;
-        padding: 0;
-      }
-
-      viewer {
-        background: #eee;
-      }
-
-      header {
-        position: absolute;
-        z-index: 1;
-        top: 0;
-        left: 0;
-        right: 0;
-        height: 50px;
-        background: #4285f4;
-        opacity: 0.7;
-        color: #fff;
-        display: flex;
-        flex-direction: row;
-        justify-content: flex-start;
-        align-items: center;
-        padding: 0 8px;
-      }
-      header h1 {
-        font-size: 22px;
-      }
-
-      container {
-        position: absolute;
-        top: 50px;
-        left: 0;
-        right: 0;
-        bottom: 0;
-      }
-
-      container iframe {
         border: 0;
-        margin: 0;
         padding: 0;
-        width: 100%;
-        height: 100%;
       }
-
-      .wait {
+      body,.fill {
         position: absolute;
-        z-index: 3;
-        top: 100px;
-        left: 20px;
-        font-size: 12px;
+        height: 100%;
+        width: 100%;
       }
     </style>
     <script>
       var viewer = null;
-      function Viewer(containerId, id, url, opt_caps) {
-        this.id = id;
+      function Viewer(url, opt_caps, simulateEmail = false) {
+        this.id = 'viewer';
         this.url = url;
-        this.alreadyLoaded_ = false;
         this.stackIndex_ = 0;
         this.prerenderSize_ = 1;
         this.csi_ = 1;
         this.caps_ =
           opt_caps || 'a2a,focus-rect,foo,keyboard,swipe,iframeScroll';
         this.receivedMessages = [];
+        this.simulateEmail = simulateEmail;
 
-        this.viewer = document.querySelector('viewer');
-        this.container = document.getElementById(containerId);
+        this.container = document.body;
         this.iframe = document.createElement('iframe');
         this.iframe.setAttribute('id', this.id);
         this.iframe.setAttribute(
@@ -96,9 +42,13 @@
             ' allow-popups-to-escape-sandbox allow-same-origin'
         );
         this.iframe.setAttribute('scrolling', 'yes');
-        this.iframe.setAttribute('height', '800');
-        this.iframe.setAttribute('width', '1200');
-        this.viewer.classList.add('natural');
+
+        if (simulateEmail) {
+          this.iframe.setAttribute('height', '0');
+          this.iframe.setAttribute('width', '0');
+        } else {
+          this.iframe.classList.add('fill');
+        }
 
         window.addEventListener('resize', this.onResize_.bind(this));
         window.addEventListener('popstate', this.onPopState_.bind(this));
@@ -143,18 +93,9 @@
         );
       };
 
-      Viewer.prototype.loaded_ = function () {
-        if (this.alreadyLoaded_) {
-          return;
-        }
-        log('AMP Loaded');
-        this.iframe.dataset['loaded'] = '';
-        this.alreadyLoaded_ = true;
-      };
-
       Viewer.prototype.documentReady_ = function () {
         log('AMP document ready');
-        this.loaded_();
+        this.iframe.dataset['loaded'] = '';
         return Promise.resolve();
       };
 
@@ -229,7 +170,7 @@
       };
 
       Viewer.prototype.processRequest_ = function (name, data, awaitResponse) {
-        log(this.id + ': Viewer.prototype.processRequest_', name);
+        log('Viewer.prototype.processRequest_', name);
         this.receivedMessages.push({name, data});
         switch (name) {
           case 'documentLoaded':
@@ -238,6 +179,13 @@
             return this.pushHistory_(data.stackIndex);
           case 'popHistory':
             return this.popHistory_(data.stackIndex);
+          case 'documentHeight':
+            if (this.simulateEmail) {
+              const {height} = data;
+              this.iframe.style.height = height + 'px';
+              this.iframe.removeAttribute('width');
+            }
+            return Promise.resolve();
           case 'broadcast':
           case 'bindReady':
           case 'focusin':
@@ -250,7 +198,6 @@
           case 'touchstart':
           case 'touchmove':
           case 'touchend':
-          case 'documentHeight':
           case 'setFlushParams':
           case 'prerenderComplete':
           case 'scroll':
@@ -362,27 +309,16 @@
         const hashParams = parseQueryString(hash);
         const href = hashParams['href'];
         const caps = hashParams['caps'];
+        const isEmail = 'true' === hashParams['isEmail'];
 
         viewer = new Viewer(
-          'viewer-container',
-          'viewer',
           addQueryParam(href, 'amp_js_v', '0.1'),
-          caps
+          caps,
+          isEmail
         );
       }
       window.onload = loadAmpDoc;
     </script>
   </head>
-  <body>
-    <viewer>
-      <header>
-        <h1>Viewer</h1>
-      </header>
-      <container id="viewer-container">
-        <div class="wait">
-          Please wait, the AMP doc will appear here...
-        </div>
-      </container>
-    </viewer>
-  </body>
+  <body></body>
 </html>

--- a/test/fixtures/e2e/amp4email/element-size-race.html
+++ b/test/fixtures/e2e/amp4email/element-size-race.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html amp4email>
+<head>
+  <meta charset="utf-8">
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <style amp4email-boilerplate>body{visibility:hidden}</style>
+  <script async custom-element="amp-list" src="https://cdn.ampproject.org/v0/amp-list-0.1.js"></script>
+  <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.2.js"></script>
+  <script async custom-element="amp-bind" src="https://cdn.ampproject.org/v0/amp-bind-0.1.js"></script>
+</head>
+<body>
+  <amp-state id="fruit">
+    <script type="application/json">{"items": ["apple"] }</script>
+  </amp-state>
+  <amp-list layout="fixed-height" src="amp-state:fruit" height="100px">
+    <template type="amp-mustache"> 
+      <span class="fruit">{{.}}</span>
+    </template>
+  </amp-list>
+</amp-img>
+</body>
+</html>

--- a/test/fixtures/e2e/amp4email/viewport-size-race.html
+++ b/test/fixtures/e2e/amp4email/viewport-size-race.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html amp4email>
+<head>
+  <meta charset="utf-8">
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <style amp4email-boilerplate>body{visibility:hidden}</style>
+  <style amp-custom>
+    amp-img {
+      margin: 30px; /* remove this line to stop the issue */
+    }
+  </style>
+</head>
+<body>
+  <amp-img 
+    width="40px" height="40px"
+    src="https://fonts.gstatic.com/s/i/googlematerialicons/notifications_off/v6/googblue-48dp/2x/gm_notifications_off_googblue_48dp.png" 
+  >
+</amp-img>
+</body>
+</html>


### PR DESCRIPTION
## summary
There's been a recent [uptick in bugs](https://github.com/ampproject/amphtml/issues/31232#issuecomment-739086372) affecting `amp4email`. This PR introduces two new e2e tests meant to increase our confidence in the stability of our viewer support.

### Infra changes
- New e2e test environment named `email-demo`. It simulates gmail viewers by beginning with 0 height and 0 width, and then resizing the iframe based on `documentHeight` events.
- Cleaned up the `viewer.html` fixture by removing unnecessary elements. This is solely meant for automatically running e2e tests, so all the visual aspects were noise.

### New tests
In general, both added tests help with sanity checking. We don't have great e2e testing for the entire flow involving documentHeight -- and these tests should at least check the basics. On top of that, each one tests for a relatively specific bug that has cropped up.

**viewport-size-race.html**
- Ensures that even if an element is initially outside of viewport (via margin-top), it'll still gets laid out. This catches a race condition where the viewport service height and IntersectionObserver reported document height do not match.
- Fixed in: https://github.com/ampproject/amphtml/pull/31376, Proof that this test would fail before that PR: https://github.com/ampproject/amphtml/pull/31529

**element-size-race.html**
- Ensures that an element that depends on its size expanding after a documentHeight change still gets laid out. This catches a race where the IntersectionObserver measures an element while it still has a 0 height/width, and after the documentHeight change we never remeasure.
- Fixed in https://github.com/ampproject/amphtml/pull/30937, Proof that this test would fail before that PR: https://github.com/ampproject/amphtml/pull/31528 
