### PR TITLE
🐛 Properly indicate when FIE is done for no-signing

### DIFF
--- a/extensions/amp-animation/0.1/amp-animation.js
+++ b/extensions/amp-animation/0.1/amp-animation.js
@@ -482,7 +482,7 @@ export class AmpAnimation extends AMP.BaseElement {
     const ampdoc = this.getAmpDoc();
     const polyfillPromise = installWebAnimationsIfNecessary(ampdoc);
     const readyPromise = this.embed_
-      ? this.embed_.whenReady()
+      ? this.embed_.whenRenderCompleted()
       : ampdoc.whenReady();
     const hostWin = this.embed_ ? this.embed_.win : this.win;
     const baseUrl = this.embed_ ? this.embed_.getUrl() : ampdoc.getUrl();

--- a/src/friendly-iframe-embed.js
+++ b/src/friendly-iframe-embed.js
@@ -373,7 +373,10 @@ export class FriendlyIframeEmbed {
     this.renderComplete_ = new Deferred();
 
     /** @private @const {!Promise} */
-    this.winLoadedPromise_ = Promise.all([loadedPromise, this.whenReady()]);
+    this.winLoadedPromise_ = Promise.all([
+      loadedPromise,
+      this.whenRenderStarted(),
+    ]);
     if (this.ampdoc) {
       this.whenRenderComplete().then(() => this.ampdoc.setReady());
     }
@@ -418,7 +421,7 @@ export class FriendlyIframeEmbed {
    * Notice that this signal coincides with the embed's `render-start`.
    * @return {!Promise}
    */
-  whenReady() {
+  whenRenderStarted() {
     return this.signals_.whenSignal(CommonSignals.RENDER_START);
   }
 
@@ -522,7 +525,7 @@ export class FriendlyIframeEmbed {
       getExperimentBranch(this.ampdoc.getParent().win, FIE_RESOURCES_EXP.id) ===
         FIE_RESOURCES_EXP.experiment;
     Promise.all([
-      this.whenReady(),
+      this.whenRenderStarted(),
       whenContentIniLoad(
         fieResourcesOn ? this.ampdoc : this.iframe,
         this.win,

--- a/src/friendly-iframe-embed.js
+++ b/src/friendly-iframe-embed.js
@@ -375,11 +375,7 @@ export class FriendlyIframeEmbed {
     /** @private @const {!Promise} */
     this.winLoadedPromise_ = Promise.all([loadedPromise, this.whenReady()]);
     if (this.ampdoc) {
-      // TODO(ccordry): wait for renderComplete after no signing launch.
-      const readyPromise = this.spec.skipHtmlMerge
-        ? this.whenRenderComplete()
-        : this.whenReady();
-      readyPromise.then(() => this.ampdoc.setReady());
+      this.whenRenderComplete().then(() => this.ampdoc.setReady());
     }
 
     this.win.addEventListener('resize', () => this.handleResize_());
@@ -490,6 +486,13 @@ export class FriendlyIframeEmbed {
     } else {
       this.signals_.signal(CommonSignals.RENDER_START);
     }
+
+    // TODO(ccordry): remove when no-signing launched.
+    if (!this.spec.skipHtmlMerge) {
+      // When not streaming renderStart signal is good enough.
+      this.renderComplete_.resolve();
+    }
+
     // Common signal RENDER_START indicates time to toggle visibility
     setStyle(this.iframe, 'visibility', '');
     if (this.win.document && this.win.document.body) {

--- a/src/friendly-iframe-embed.js
+++ b/src/friendly-iframe-embed.js
@@ -443,7 +443,7 @@ export class FriendlyIframeEmbed {
 
   /**
    * Returns a promise that will resolve when all elements have been
-   * transferred into live aembedd DOM.
+   * transferred into live embed DOM.
    * @return {!Promise}
    */
   whenRenderComplete() {

--- a/test/unit/test-friendly-iframe-embed.js
+++ b/test/unit/test-friendly-iframe-embed.js
@@ -422,7 +422,7 @@ describes.realWin('friendly-iframe-embed', {amp: true}, (env) => {
       .once();
 
     env.sandbox
-      .stub(FriendlyIframeEmbed.prototype, 'whenReady')
+      .stub(FriendlyIframeEmbed.prototype, 'whenRenderStarted')
       .returns(Promise.resolve());
 
     const embed = await installFriendlyIframeEmbed(
@@ -525,7 +525,7 @@ describes.realWin('friendly-iframe-embed', {amp: true}, (env) => {
       .once();
 
     env.sandbox
-      .stub(FriendlyIframeEmbed.prototype, 'whenReady')
+      .stub(FriendlyIframeEmbed.prototype, 'whenRenderStarted')
       .returns(Promise.resolve());
 
     const embedPromise = installFriendlyIframeEmbed(

--- a/test/unit/test-friendly-iframe-embed.js
+++ b/test/unit/test-friendly-iframe-embed.js
@@ -223,13 +223,13 @@ describes.realWin('friendly-iframe-embed', {amp: true}, (env) => {
       .returns(Promise.resolve())
       .once();
 
-    let readyResolver = null;
-    const readyPromise = new Promise((resolve) => {
-      readyResolver = resolve;
+    let renderCompleteResolver = null;
+    const renderCompletePromise = new Promise((resolve) => {
+      renderCompleteResolver = resolve;
     });
     env.sandbox
-      .stub(FriendlyIframeEmbed.prototype, 'whenReady')
-      .callsFake(() => readyPromise);
+      .stub(FriendlyIframeEmbed.prototype, 'whenRenderComplete')
+      .callsFake(() => renderCompletePromise);
 
     const embedPromise = installFriendlyIframeEmbed(
       iframe,
@@ -247,8 +247,8 @@ describes.realWin('friendly-iframe-embed', {amp: true}, (env) => {
         expect(ampdoc).to.equal(embed.ampdoc);
         expect(installServicesStub).to.be.calledOnce.calledWith(ampdoc);
         expect(ampdoc.setReady).to.not.be.called;
-        readyResolver();
-        return readyPromise;
+        renderCompleteResolver();
+        return renderCompletePromise;
       })
       .then(() => {
         expect(ampdoc.setReady).to.be.calledOnce;
@@ -310,13 +310,13 @@ describes.realWin('friendly-iframe-embed', {amp: true}, (env) => {
       .returns(Promise.resolve())
       .once();
 
-    let readyResolver = null;
-    const readyPromise = new Promise((resolve) => {
-      readyResolver = resolve;
+    let renderCompleteResolver = null;
+    const renderCompletePromise = new Promise((resolve) => {
+      renderCompleteResolver = resolve;
     });
     env.sandbox
-      .stub(FriendlyIframeEmbed.prototype, 'whenReady')
-      .callsFake(() => readyPromise);
+      .stub(FriendlyIframeEmbed.prototype, 'whenRenderComplete')
+      .callsFake(() => renderCompletePromise);
 
     const embedPromise = installFriendlyIframeEmbed(
       iframe,
@@ -335,8 +335,8 @@ describes.realWin('friendly-iframe-embed', {amp: true}, (env) => {
         expect(ampdoc).to.equal(embed.ampdoc);
         expect(installServicesStub).to.be.calledOnce.calledWith(ampdoc);
         expect(ampdoc.setReady).to.not.be.called;
-        readyResolver();
-        return readyPromise;
+        renderCompleteResolver();
+        return renderCompletePromise;
       })
       .then(() => {
         expect(ampdoc.setReady).to.be.calledOnce;

--- a/test/unit/test-friendly-iframe-embed.js
+++ b/test/unit/test-friendly-iframe-embed.js
@@ -447,6 +447,39 @@ describes.realWin('friendly-iframe-embed', {amp: true}, (env) => {
     );
   });
 
+  it('should signal fie doc ready during install when not streaming', async () => {
+    const setReadySpy = env.sandbox.spy(AmpDocFie.prototype, 'setReady');
+    await installFriendlyIframeEmbed(
+      iframe,
+      document.body,
+      {
+        url: 'https://acme.test/url1',
+        html: '<amp-test></amp-test>',
+        extensionIds: ['amp-test'],
+      },
+      preinstallCallback
+    );
+    expect(setReadySpy).to.be.called;
+  });
+
+  it('should wait complete streaming before signaling fie doc ready', async () => {
+    const setReadySpy = env.sandbox.spy(AmpDocFie.prototype, 'setReady');
+    const fie = await installFriendlyIframeEmbed(
+      iframe,
+      document.body,
+      {
+        url: 'https://acme.test/url1',
+        html: '<amp-test></amp-test>',
+        extensionIds: ['amp-test'],
+        skipHtmlMerge: true,
+      },
+      preinstallCallback
+    );
+    expect(setReadySpy).not.to.be.called;
+    await fie.renderCompleted();
+    expect(setReadySpy).to.be.called;
+  });
+
   it('should dispose ampdoc', () => {
     // AmpDoc is created.
     const ampdocSignals = new Signals();


### PR DESCRIPTION
Tell FIE ampdoc that it is complete only after all elements have been transferred. Tested manually and if I am in no-signing + fie-resources this will solve the malformed json errors. This will probably cost us a bit of speed, but will iterate on fie-resource building logic in follow up. 

Partial #27189