### PR TITLE
[bento][bug-bash][amp-social-share] Update social share to respond on attribute changes

### DIFF
--- a/extensions/amp-social-share/1.0/amp-social-share.js
+++ b/extensions/amp-social-share/1.0/amp-social-share.js
@@ -82,7 +82,7 @@ const systemShareSupported = (viewer, platform) => {
 /**
  * @private
  * @param {!Element} element
- * @param {Array<MutationRecord>} mutations
+ * @param {!Array<MutationRecord>} mutations
  * @param {string} prevTypeValue
  * @return {!JsonObject|undefined}
  */
@@ -93,9 +93,9 @@ const updateTypeConfig = (element, mutations, prevTypeValue) => {
   // Check all mutations since we want to catch any 'data-param-*' attributes
   mutations.forEach((mutation) => {
     if (
-      ['type', 'data-target', 'data-share-endpoint'].includes(
-        mutation.attributeName
-      ) ||
+      mutation.attributeName === 'type' ||
+      mutation.attributeName === 'data-target' ||
+      mutation.attributeName === 'data-share-endpoint' ||
       (mutation.attributeName && mutation.attributeName.includes('data-param-'))
     ) {
       mutatedEligibleAttribute = true;

--- a/extensions/amp-social-share/1.0/amp-social-share.js
+++ b/extensions/amp-social-share/1.0/amp-social-share.js
@@ -134,17 +134,6 @@ class AmpSocialShare extends PreactBaseElement {
       `amp-social-share-${this.element.getAttribute('type')}`
     );
 
-    const mu = new MutationObserver((mutations) => {
-      const typeConfig = updateTypeConfig(this.element, mutations);
-      if (typeConfig) {
-        this.renderWithHrefAndTarget_(typeConfig);
-      }
-    });
-    mu.observe(this.element, {
-      attributes: true,
-      attributeOldValue: true,
-    });
-
     this.renderWithHrefAndTarget_(typeConfig);
     const responsive =
       this.element.getAttribute('layout') === Layout.RESPONSIVE && '100%';
@@ -154,6 +143,19 @@ class AmpSocialShare extends PreactBaseElement {
       'color': 'currentColor',
       'background': 'inherit',
     });
+  }
+
+  /** @override */
+  mutationObserverCallback(mutations) {
+    const typeConfig = updateTypeConfig(this.element, mutations);
+    if (typeConfig) {
+      this.renderWithHrefAndTarget_(typeConfig);
+    }
+  }
+
+  /** @override */
+  getAdditionalMutationObserverInitProperties() {
+    return {attributeOldValue: true};
   }
 
   /** @override */
@@ -191,6 +193,7 @@ class AmpSocialShare extends PreactBaseElement {
       .then((expandedUrl) => {
         const {search} = Services.urlForDoc(this.element).parse(expandedUrl);
         const target = this.element.getAttribute('data-target') || '_blank';
+        console.log(search);
 
         if (customEndpoint) {
           this.mutateProps(

--- a/extensions/amp-social-share/1.0/amp-social-share.js
+++ b/extensions/amp-social-share/1.0/amp-social-share.js
@@ -193,7 +193,6 @@ class AmpSocialShare extends PreactBaseElement {
       .then((expandedUrl) => {
         const {search} = Services.urlForDoc(this.element).parse(expandedUrl);
         const target = this.element.getAttribute('data-target') || '_blank';
-        console.log(search);
 
         if (customEndpoint) {
           this.mutateProps(

--- a/extensions/amp-social-share/1.0/test/test-amp-social-share.js
+++ b/extensions/amp-social-share/1.0/test/test-amp-social-share.js
@@ -16,8 +16,8 @@
 
 import '../amp-social-share';
 import {toggleExperiment} from '../../../../src/experiments';
+import {waitFor, whenCalled} from '../../../../testing/test-helper.js';
 import {waitForChildPromise} from '../../../../src/dom';
-import {whenCalled} from '../../../../testing/test-helper.js';
 
 const BUTTON_SELECTOR = 'div[role="button"]';
 const WINDOW_FEATURES = 'resizable,scrollbars,width=640,height=480';
@@ -41,6 +41,15 @@ describes.realWin(
       await waitForChildPromise(shadow, (shadow) => {
         return shadow.querySelector(BUTTON_SELECTOR);
       });
+    };
+
+    // Should be called after waitForRender (assumes shadow already attached)
+    // Waits for the type change to propagate to within the shadowDOM
+    const waitForTypeChange = async (el, type) => {
+      await waitFor(
+        () => el.shadowRoot.querySelector('svg').getAttribute('type') === type,
+        'type attribute is updated'
+      );
     };
 
     beforeEach(() => {
@@ -215,6 +224,103 @@ describes.realWin(
       expect(
         element.shadowRoot.querySelector('svg').style.backgroundColor
       ).to.be.equal('inherit');
+    });
+
+    describe('dynamically update attributes', () => {
+      it('updates default url and css class when "type" attribute is updated', async () => {
+        element = win.document.createElement('amp-social-share');
+        element.setAttribute('type', 'email');
+        win.document.body.appendChild(element);
+        await waitForRender();
+
+        // Has email class (for css) and does not have facebook class
+        expect(element.className).to.include('amp-social-share-email');
+        expect(element.className).to.not.include('amp-social-share-facebook');
+
+        element.setAttribute('type', 'facebook');
+        await waitForTypeChange(element, 'FACEBOOK');
+
+        const openWindowDialogStub = env.sandbox.stub(window, 'open');
+        element.shadowRoot.querySelector(BUTTON_SELECTOR).click();
+
+        // Verify that the facebook default URL is used instead of email
+        expect(openWindowDialogStub).to.be.calledWithExactly(
+          'https://www.facebook.com/dialog/share?' +
+            'href=https%3A%2F%2Fcanonicalexample.com%2F',
+          '_blank',
+          WINDOW_FEATURES
+        );
+
+        // Has facebook class (for css) and does not have email class
+        expect(element.className).to.include('amp-social-share-facebook');
+        expect(element.className).to.not.include('amp-social-share-email');
+      });
+
+      it('updates target when "data-target" attribute is updated', async () => {
+        element = win.document.createElement('amp-social-share');
+        element.setAttribute('type', 'email');
+        win.document.body.appendChild(element);
+        await waitForRender();
+
+        element.setAttribute('type', 'facebook');
+        element.setAttribute('data-target', 'test-value');
+        await waitForTypeChange(element, 'FACEBOOK');
+
+        const openWindowDialogStub = env.sandbox.stub(window, 'open');
+        element.shadowRoot.querySelector(BUTTON_SELECTOR).click();
+
+        // Verify that target is updated to the "test-value"
+        expect(openWindowDialogStub).to.be.calledWithExactly(
+          'https://www.facebook.com/dialog/share?' +
+            'href=https%3A%2F%2Fcanonicalexample.com%2F',
+          'test-value',
+          WINDOW_FEATURES
+        );
+      });
+
+      it('updates endpoint when "data-share-endpoint" attribute is updated', async () => {
+        element = win.document.createElement('amp-social-share');
+        element.setAttribute('type', 'email');
+        win.document.body.appendChild(element);
+        await waitForRender();
+
+        element.setAttribute('type', 'custom');
+        element.setAttribute('data-share-endpoint', 'test-value');
+        await waitForTypeChange(element, 'CUSTOM');
+
+        const openWindowDialogStub = env.sandbox.stub(window, 'open');
+        element.shadowRoot.querySelector(BUTTON_SELECTOR).click();
+
+        // Verify that the endpoint is updated to the "test-value"
+        expect(openWindowDialogStub).to.be.calledWithExactly(
+          'test-value',
+          '_blank',
+          WINDOW_FEATURES
+        );
+      });
+
+      it('updates params when "data-param-*" attributes are added', async () => {
+        element = win.document.createElement('amp-social-share');
+        element.setAttribute('type', 'email');
+        win.document.body.appendChild(element);
+        await waitForRender();
+
+        element.setAttribute('type', 'custom');
+        element.setAttribute('data-share-endpoint', 'test-value');
+        element.setAttribute('data-param-cat', 'meow');
+        element.setAttribute('data-param-dog', 'woof');
+        await waitForTypeChange(element, 'CUSTOM');
+
+        const openWindowDialogStub = env.sandbox.stub(window, 'open');
+        element.shadowRoot.querySelector(BUTTON_SELECTOR).click();
+
+        // Verify that the "cat" and "dog" params are appended to the endpoint
+        expect(openWindowDialogStub).to.be.calledWithExactly(
+          'test-value?cat=meow&dog=woof',
+          '_blank',
+          WINDOW_FEATURES
+        );
+      });
     });
   }
 );

--- a/src/preact/base-element.js
+++ b/src/preact/base-element.js
@@ -369,7 +369,7 @@ export class PreactBaseElement extends AMP.BaseElement {
    * A callback called immediately after mutations have been observed on a
    * component. This differs from `checkPropsPostMutations` in that it is
    * called in all cases of mutation.
-   * @param {Array<MutationRecord>} unusedRecords
+   * @param {!Array<MutationRecord>} unusedRecords
    * @protected
    */
   mutationObserverCallback(unusedRecords) {}

--- a/src/preact/base-element.js
+++ b/src/preact/base-element.js
@@ -369,11 +369,10 @@ export class PreactBaseElement extends AMP.BaseElement {
    * A callback called immediately after mutations have been observed on a
    * component. This differs from `checkPropsPostMutations` in that it is
    * called in all cases of mutation.
-   * @param {Array<MutationRecord>} records
+   * @param {Array<MutationRecord>} unusedRecords
    * @protected
    */
-  // eslint-disable-next-line
-  mutationObserverCallback(records) {}
+  mutationObserverCallback(unusedRecords) {}
 
   /**
    * A callback called immediately after mutations have been observed on a

--- a/src/preact/base-element.js
+++ b/src/preact/base-element.js
@@ -222,7 +222,6 @@ export class PreactBaseElement extends AMP.BaseElement {
       ...childrenInit,
       ...passthroughInit,
       ...templatesInit,
-      ...this.getAdditionalMutationObserverInitProperties(),
     });
 
     this.mediaQueryProps_ = hasMediaQueryProps(Ctor)
@@ -373,16 +372,6 @@ export class PreactBaseElement extends AMP.BaseElement {
    * @protected
    */
   mutationObserverCallback() {}
-
-  /**
-   * A callback that allows the user to specify additional init properties
-   * to the Mutation Observer.
-   * @protected
-   * @return {!MutationObserverInit}
-   */
-  getAdditionalMutationObserverInitProperties() {
-    return {};
-  }
 
   /**
    * A callback called immediately after mutations have been observed on a

--- a/src/preact/base-element.js
+++ b/src/preact/base-element.js
@@ -369,9 +369,11 @@ export class PreactBaseElement extends AMP.BaseElement {
    * A callback called immediately after mutations have been observed on a
    * component. This differs from `checkPropsPostMutations` in that it is
    * called in all cases of mutation.
+   * @param {Array<MutationRecord>} records
    * @protected
    */
-  mutationObserverCallback() {}
+  // eslint-disable-next-line
+  mutationObserverCallback(records) {}
 
   /**
    * A callback called immediately after mutations have been observed on a

--- a/src/preact/base-element.js
+++ b/src/preact/base-element.js
@@ -222,6 +222,7 @@ export class PreactBaseElement extends AMP.BaseElement {
       ...childrenInit,
       ...passthroughInit,
       ...templatesInit,
+      ...this.getAdditionalMutationObserverInitProperties(),
     });
 
     this.mediaQueryProps_ = hasMediaQueryProps(Ctor)
@@ -374,6 +375,16 @@ export class PreactBaseElement extends AMP.BaseElement {
   mutationObserverCallback() {}
 
   /**
+   * A callback that allows the user to specify additional init properties
+   * to the Mutation Observer.
+   * @protected
+   * @return {!MutationObserverInit}
+   */
+  getAdditionalMutationObserverInitProperties() {
+    return {};
+  }
+
+  /**
    * A callback called immediately after mutations have been observed on a
    * component's defined props. The implementation can verify if any
    * additional properties need to be mutated via `mutateProps()` API.
@@ -406,7 +417,7 @@ export class PreactBaseElement extends AMP.BaseElement {
    */
   checkMutations_(records) {
     const Ctor = this.constructor;
-    this.mutationObserverCallback();
+    this.mutationObserverCallback(records);
     const rerender = records.some((m) => shouldMutationBeRerendered(Ctor, m));
     if (rerender) {
       this.checkPropsPostMutations();


### PR DESCRIPTION
Update amp-social-share to respond to attribute changes for the following attributes:

1. type
2. data-target
3. data-share-endpoint
4. data-param-*

Updates the URL if any of these are changed after initial render (in amp-mode).  If type is changed, updates the CSS class to update the icon colors and also updates the icon image.  If type is changed to something not supported, hide the element.

-------

Added tests for `amp-social-share` (component)