### PR TITLE
Bento Lightbox: Various fixes and unit tests

### DIFF
--- a/extensions/amp-lightbox/1.0/amp-lightbox.css
+++ b/extensions/amp-lightbox/1.0/amp-lightbox.css
@@ -15,7 +15,7 @@
  */
 
 amp-lightbox {
-  width: '100%';
-  height: '100%';
-  position: 'fixed';
+  width: 100%;
+  height: 100%;
+  position: fixed;
 }

--- a/extensions/amp-lightbox/1.0/amp-lightbox.js
+++ b/extensions/amp-lightbox/1.0/amp-lightbox.js
@@ -34,7 +34,6 @@ class AmpLightbox extends PreactBaseElement {
     this.registerApiAction('open', (api) => api.open(), ActionTrust.LOW);
     this.registerApiAction('close', (api) => api.close(), ActionTrust.LOW);
     return dict({
-      'initialOpen': false,
       'onBeforeOpen': this.beforeOpen_.bind(this),
       'onAfterClose': this.afterClose_.bind(this),
     });

--- a/extensions/amp-lightbox/1.0/amp-lightbox.js
+++ b/extensions/amp-lightbox/1.0/amp-lightbox.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {ActionTrust} from '../../../src/action-constants';
+import {ActionTrust, DEFAULT_ACTION} from '../../../src/action-constants';
 import {CSS as COMPONENT_CSS} from './lightbox.jss';
 import {CSS} from '../../../build/amp-lightbox-1.0.css';
 import {Lightbox} from './lightbox';
@@ -39,6 +39,11 @@ class AmpLightbox extends PreactBaseElement {
 
   /** @override */
   init() {
+    this.registerApiAction(
+      DEFAULT_ACTION,
+      (api) => api.open(),
+      ActionTrust.LOW
+    );
     this.registerApiAction('open', (api) => api.open(), ActionTrust.LOW);
     this.registerApiAction('close', (api) => api.close(), ActionTrust.LOW);
     return dict({

--- a/extensions/amp-lightbox/1.0/amp-lightbox.js
+++ b/extensions/amp-lightbox/1.0/amp-lightbox.js
@@ -29,6 +29,14 @@ const TAG = 'amp-lightbox';
 
 /** @extends {PreactBaseElement<LightboxDef.Api>} */
 class AmpLightbox extends PreactBaseElement {
+  /** @param {!AmpElement} element */
+  constructor(element) {
+    super(element);
+
+    /** @private {boolean} */
+    this.open_ = false;
+  }
+
   /** @override */
   init() {
     this.registerApiAction('open', (api) => api.open(), ActionTrust.LOW);
@@ -44,7 +52,9 @@ class AmpLightbox extends PreactBaseElement {
    * @private
    */
   beforeOpen_() {
+    this.open_ = true;
     toggle(this.element, true);
+    this.element.setAttribute('open', '');
   }
 
   /**
@@ -52,7 +62,19 @@ class AmpLightbox extends PreactBaseElement {
    * @private
    */
   afterClose_() {
+    this.open_ = false;
     toggle(this.element, false);
+    this.element.removeAttribute('open');
+  }
+
+  /** @override */
+  mutationObserverCallback() {
+    const open = this.element.hasAttribute('open');
+    if (open === this.open_) {
+      return;
+    }
+    this.open_ = open;
+    open ? this.api().open() : this.api().close();
   }
 
   /** @override */
@@ -79,9 +101,6 @@ AmpLightbox['props'] = {
 
 /** @override */
 AmpLightbox['passthrough'] = true;
-
-/** @override */
-AmpLightbox['layoutSizeDefined'] = true;
 
 /** @override */
 AmpLightbox['shadowCss'] = COMPONENT_CSS;

--- a/extensions/amp-lightbox/1.0/amp-lightbox.js
+++ b/extensions/amp-lightbox/1.0/amp-lightbox.js
@@ -74,7 +74,6 @@ AmpLightbox['props'] = {
   'animateIn': {attr: 'animate-in'},
   'scrollable': {attr: 'scrollable', type: 'boolean'},
   'id': {attr: 'id'},
-  'initialOpen': {attr: 'initial-open', type: 'boolean'},
   'closeButtonAriaLabel': {attr: 'data-close-button-aria-label'},
   'enableAnimation': {attr: 'enable-animation', type: 'boolean'},
 };

--- a/extensions/amp-lightbox/1.0/amp-lightbox.js
+++ b/extensions/amp-lightbox/1.0/amp-lightbox.js
@@ -33,7 +33,6 @@ class AmpLightbox extends PreactBaseElement {
   init() {
     this.registerApiAction('open', (api) => api.open(), ActionTrust.LOW);
     this.registerApiAction('close', (api) => api.close(), ActionTrust.LOW);
-    this.element.setAttribute('class', 'amp-lightbox');
     return dict({
       'initialOpen': false,
       'onBeforeOpen': this.beforeOpen_.bind(this),

--- a/extensions/amp-lightbox/1.0/lightbox.js
+++ b/extensions/amp-lightbox/1.0/lightbox.js
@@ -64,7 +64,6 @@ function LightboxWithRef(
     animateIn = 'fade-in',
     closeButtonAriaLabel,
     children,
-    initialOpen,
     onBeforeOpen,
     onAfterClose,
     enableAnimation,
@@ -76,8 +75,8 @@ function LightboxWithRef(
   // To open, we mount and render the contents (invisible), then animate the display (visible).
   // To close, it's the reverse.
   // `mounted` mounts the component. `visible` plays the animation.
-  const [mounted, setMounted] = useState(initialOpen);
-  const [visible, setVisible] = useState(initialOpen);
+  const [mounted, setMounted] = useState(false);
+  const [visible, setVisible] = useState(false);
   const classes = useStyles();
   const lightboxRef = useRef();
 

--- a/extensions/amp-lightbox/1.0/lightbox.js
+++ b/extensions/amp-lightbox/1.0/lightbox.js
@@ -42,6 +42,8 @@ const ANIMATION_PRESETS = {
   ],
 };
 
+const DEFAULT_CLOSE_LABEL = 'Close the modal';
+
 /**
  * @param {T} current
  * @return {{current: T}}
@@ -62,7 +64,7 @@ function LightboxWithRef(
   {
     id,
     animateIn = 'fade-in',
-    closeButtonAriaLabel,
+    closeButtonAriaLabel = DEFAULT_CLOSE_LABEL,
     children,
     onBeforeOpen,
     onAfterClose,

--- a/extensions/amp-lightbox/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-lightbox/1.0/storybook/Basic.amp.js
@@ -36,7 +36,7 @@ export const Default = () => {
   ]);
   const enableAnimation = boolean('enable animation', true);
   return (
-    <main>
+    <div style="height: 300px;">
       <amp-lightbox
         id="lightbox"
         layout="nodisplay"
@@ -46,10 +46,10 @@ export const Default = () => {
         <p>Test</p>
         <button on="tap:lightbox.close">Close</button>
       </amp-lightbox>
-      <div class="buttons" style={{marginTop: 8}}>
+      <div class="buttons">
         <button on="tap:lightbox.open">Open</button>
       </div>
-    </main>
+    </div>
   );
 };
 

--- a/extensions/amp-lightbox/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-lightbox/1.0/storybook/Basic.amp.js
@@ -47,7 +47,7 @@ export const Default = () => {
         <button on="tap:lightbox.close">Close</button>
       </amp-lightbox>
       <div class="buttons">
-        <button on="tap:lightbox.open">Open</button>
+        <button on="tap:lightbox">Open</button>
       </div>
     </div>
   );

--- a/extensions/amp-lightbox/1.0/storybook/Basic.js
+++ b/extensions/amp-lightbox/1.0/storybook/Basic.js
@@ -43,7 +43,6 @@ function LightboxWithActions(props) {
 }
 
 export const _default = () => {
-  const open = boolean('initialOpen', false);
   const animateIn = select('animateIn', [
     'fade-in',
     'fly-in-top',
@@ -54,8 +53,6 @@ export const _default = () => {
     <div>
       <LightboxWithActions
         id="lightbox"
-        layout="nodisplay"
-        initialOpen={open}
         animateIn={animateIn}
         enableAnimation={enableAnimation}
       >

--- a/extensions/amp-lightbox/1.0/test/test-amp-lightbox.js
+++ b/extensions/amp-lightbox/1.0/test/test-amp-lightbox.js
@@ -1,0 +1,124 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import '../amp-lightbox';
+import {ActionInvocation} from '../../../../src/service/action-impl';
+import {ActionTrust, DEFAULT_ACTION} from '../../../../src/action-constants';
+import {htmlFor} from '../../../../src/static-template';
+import {toggleExperiment} from '../../../../src/experiments';
+import {waitFor} from '../../../../testing/test-helper';
+
+describes.realWin(
+  'amp-lightbox:1.0',
+  {
+    amp: {
+      extensions: ['amp-lightbox:1.0'],
+    },
+  },
+  (env) => {
+    let win;
+    let html;
+    let element;
+
+    async function waitForOpen(el, open) {
+      const isOpenOrNot = () => el.hasAttribute('open') === open;
+      await waitFor(isOpenOrNot, 'element open updated');
+    }
+
+    function getContent() {
+      expect(element.shadowRoot).not.to.be.undefined;
+      // Get slot if it exists, or <c> element otherwise.
+      return element.shadowRoot.querySelector('c slot, c:empty');
+    }
+
+    beforeEach(async () => {
+      win = env.win;
+      html = htmlFor(win.document);
+      toggleExperiment(win, 'amp-selector-bento', true, true);
+      element = html`
+        <amp-lightbox layout="nodisplay">
+          <p>Hello World</p>
+        </amp-lightbox>
+      `;
+      win.document.body.appendChild(element);
+      await element.build();
+    });
+
+    it('should render closed', async () => {
+      expect(element.hasAttribute('open')).to.be.false;
+      expect(element.hasAttribute('hidden')).to.be.true;
+      const content = getContent();
+      expect(content.tagName).to.equal('C');
+      expect(content.children).to.have.lengthOf(0);
+    });
+
+    describe('imperative api', () => {
+      function invocation(method, args = {}) {
+        const source = null;
+        const caller = null;
+        const event = null;
+        const trust = ActionTrust.DEFAULT;
+        return new ActionInvocation(
+          element,
+          method,
+          args,
+          source,
+          caller,
+          event,
+          trust
+        );
+      }
+
+      it('should open with default action', async () => {
+        expect(element.hasAttribute('open')).to.be.false;
+        expect(element.hasAttribute('hidden')).to.be.true;
+
+        element.enqueAction(invocation(DEFAULT_ACTION));
+        await waitForOpen(element, true);
+        expect(element.hasAttribute('hidden')).to.be.false;
+
+        const content = getContent();
+        expect(content.tagName).to.equal('SLOT');
+        const contentEls = content.assignedElements();
+        expect(contentEls).to.have.lengthOf(1);
+        expect(contentEls[0].tagName).to.equal('P');
+        expect(contentEls[0].textContent).to.equal('Hello World');
+      });
+
+      it('should open and close', async () => {
+        expect(element.hasAttribute('open')).to.be.false;
+        expect(element.hasAttribute('hidden')).to.be.true;
+
+        element.enqueAction(invocation('open'));
+        await waitForOpen(element, true);
+        expect(element.hasAttribute('hidden')).to.be.false;
+
+        let content = getContent();
+        expect(content.tagName).to.equal('SLOT');
+        const contentEls = content.assignedElements();
+        expect(contentEls).to.have.lengthOf(1);
+        expect(contentEls[0].tagName).to.equal('P');
+        expect(contentEls[0].textContent).to.equal('Hello World');
+
+        element.enqueAction(invocation('close'));
+        await waitForOpen(element, false);
+        expect(element.hasAttribute('hidden')).to.be.true;
+        content = getContent();
+        expect(content.tagName).to.equal('C');
+        expect(content.children).to.have.lengthOf(0);
+      });
+    });
+  }
+);

--- a/extensions/amp-lightbox/1.0/test/test-lightbox.js
+++ b/extensions/amp-lightbox/1.0/test/test-lightbox.js
@@ -20,13 +20,21 @@ import {mount} from 'enzyme';
 
 describes.sandboxed('Lightbox preact component v1.0', {}, () => {
   it('Normal lightbox render', () => {
+    const ref = Preact.createRef();
     const wrapper = mount(
-      <Lightbox id="lightbox" openOnLoad={true}>
-        <div>
-          <p>Hello World</p>
-        </div>
+      <Lightbox id="lightbox" ref={ref}>
+        <p>Hello World</p>
       </Lightbox>
     );
-    expect(wrapper.find('p')).to.exist;
+
+    // Nothing is rendered at first.
+    expect(wrapper.children()).to.have.lengthOf(0);
+
+    ref.current.open();
+    wrapper.update();
+
+    // Render provided children
+    expect(wrapper.children()).to.have.lengthOf(1);
+    expect(wrapper.find('p').text()).to.equal('Hello World');
   });
 });


### PR DESCRIPTION
This PR makes the following changes to `amp-lightbox` and `Lightbox`: 
- remove `initialOpen` from both layers, as a lightbox that is open on page load is an intrusive interstitial
- register `open` as the default AMP action (so users may write `on="tap:my-lightbox"` to mean the equivalent of `on="tap:my-lightbox.open()`)
- make `open` a mutable attribute after component registration
- fix Preact unit tests which were trivially passing and add AMP unit tests
- update storybooks

Subsequent PRs will handle:
- CSS customizability in both layers
- porting e2e tests from 0.1