### PR TITLE
SwG  Release 0.1.22.138

### DIFF
--- a/third_party/subscriptions-project/config.js
+++ b/third_party/subscriptions-project/config.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/** Version: 0.1.22.133 */
+/** Version: 0.1.22.138 */
 /**
  * Copyright 2018 The Subscribe with Google Authors. All Rights Reserved.
  *

--- a/third_party/subscriptions-project/swg.js
+++ b/third_party/subscriptions-project/swg.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/** Version: 0.1.22.133 */
+/** Version: 0.1.22.138 */
 /**
  * Copyright 2018 The Subscribe with Google Authors. All Rights Reserved.
  *
@@ -6079,7 +6079,7 @@ function feCached(url) {
  */
 function feArgs(args) {
   return Object.assign(args, {
-    '_client': 'SwG 0.1.22.133',
+    '_client': 'SwG 0.1.22.138',
   });
 }
 
@@ -7198,7 +7198,7 @@ class ActivityPorts$1 {
         'analyticsContext': context.toArray(),
         'publicationId': pageConfig.getPublicationId(),
         'productId': pageConfig.getProductId(),
-        '_client': 'SwG 0.1.22.133',
+        '_client': 'SwG 0.1.22.138',
         'supportsEventManager': true,
       },
       args || {}
@@ -8047,7 +8047,7 @@ class AnalyticsService {
       context.setTransactionId(getUuid());
     }
     context.setReferringOrigin(parseUrl$1(this.getReferrer_()).origin);
-    context.setClientVersion('SwG 0.1.22.133');
+    context.setClientVersion('SwG 0.1.22.138');
     context.setUrl(getCanonicalUrl(this.doc_));
 
     const utmParams = parseQueryString$1(this.getQueryString_());
@@ -17385,6 +17385,11 @@ class ConfiguredRuntime {
   /** @override */
   getLogger() {
     return Promise.resolve(this.logger_);
+  }
+
+  /** @override */
+  setShowcaseEntitlement(unusedEntitlement) {
+    // TODO
   }
 }
 


### PR DESCRIPTION
## Version: 0.1.22.138

## Previous release: [0.1.22.136](https://github.com/subscriptions-project/swg-js/releases/tag/0.1.22.136)

  - Update dependency postcss to v8.2.1 (#1398)
  - Update dependency autoprefixer to v10.1.0 (#1396)
  - Update dependency postcss to v8.2.0 (#1397)
  - Update dependency eslint to v7.15.0 (#1393)
  - Update dependency rollup to v2.34.2 (#1394)
  - Update dependency chromedriver to v87.0.2 (#1392)
  - Update dependency postcss to v8.1.14 (#1391)
  - Regwall: Only render if URL has fresh GAA URL params (#1390)
  - Update dependency chromedriver to v87.0.1 (#1385)
  - Update dependency postcss to v8.1.13 (#1387)
  - Update dependency rollup to v2.34.1 (#1388)
  - Update dependency eslint-plugin-prettier to v3.2.0 (#1389)