### PR TITLE
🏗 Optimize cross-browser test runs on GH actions

### DIFF
--- a/.github/workflows/cross-browser-tests.yml
+++ b/.github/workflows/cross-browser-tests.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Set Up Environment
         if: ${{ matrix.platform == 'macos-latest' || matrix.platform == 'ubuntu-latest'}}
         run: sudo chown -R $(whoami) $(npm config get prefix)/{lib/node_modules,bin,share}

--- a/build-system/common/git.js
+++ b/build-system/common/git.js
@@ -38,7 +38,7 @@ function gitBranchCreationPoint() {
   if (isPullRequestBuild()) {
     const prSha = ciPullRequestSha();
     return getStdout(
-      `git rev-list --boundary ${prSha}...master | grep "^-" | head -n 1 | cut -c2-`
+      `git rev-list --boundary ${prSha}...origin/master | grep "^-" | head -n 1 | cut -c2-`
     ).trim();
   }
   return gitMergeBaseLocalMaster();

--- a/build-system/pr-check/cross-browser-tests.js
+++ b/build-system/pr-check/cross-browser-tests.js
@@ -16,7 +16,17 @@
 'use strict';
 
 const log = require('fancy-log');
-const {red, cyan} = require('ansi-colors');
+const {
+  printChangeSummary,
+  startTimer,
+  stopTimer,
+  stopTimedJob,
+  timedExecOrDie: timedExecOrDieBase,
+} = require('./utils');
+const {determineBuildTargets} = require('./build-targets');
+const {isPullRequestBuild} = require('../common/ci');
+const {red, cyan, bold, yellow} = require('ansi-colors');
+const {runNpmChecks} = require('./npm-checks');
 
 /**
  * @fileoverview
@@ -24,42 +34,100 @@ const {red, cyan} = require('ansi-colors');
  * Windows. This is run on Github Actions CI stage = Cross-Browser Tests.
  */
 
-const {
-  startTimer,
-  stopTimer,
-  timedExecOrDie: timedExecOrDieBase,
-} = require('./utils');
-
 const FILENAME = 'cross-browser-tests.js';
+const FILELOGPREFIX = bold(yellow(`${FILENAME}:`));
 const timedExecOrDie = (cmd) => timedExecOrDieBase(cmd, FILENAME);
 
-async function main() {
-  const startTime = startTimer(FILENAME, FILENAME);
-  timedExecOrDie('gulp update-packages');
-  timedExecOrDie('gulp dist --fortesting');
-
+/**
+ * Helper that runs platform-specific integration tests
+ */
+function runIntegrationTestsForPlatform() {
   switch (process.platform) {
     case 'linux':
-      timedExecOrDie('gulp unit --nobuild --headless --firefox');
       timedExecOrDie(
         'gulp integration --nobuild --compiled --headless --firefox'
       );
       break;
     case 'darwin':
-      timedExecOrDie('gulp unit --nobuild --safari');
       timedExecOrDie('gulp integration --nobuild --compiled --safari');
       break;
     case 'win32':
-      timedExecOrDie('gulp unit --nobuild --headless --edge');
       timedExecOrDie('gulp integration --nobuild --compiled --headless --edge');
       timedExecOrDie('gulp integration --nobuild --compiled --ie');
       break;
     default:
       log(
         red('ERROR:'),
-        'Cannot run cross-browser tests on',
+        'Cannot run cross-browser integration tests on',
         cyan(process.platform) + '.'
       );
+  }
+}
+
+/**
+ * Helper that runs platform-specific unit tests
+ */
+function runUnitTestsForPlatform() {
+  switch (process.platform) {
+    case 'linux':
+      timedExecOrDie('gulp unit --nobuild --headless --firefox');
+      break;
+    case 'darwin':
+      timedExecOrDie('gulp unit --nobuild --safari');
+      break;
+    case 'win32':
+      timedExecOrDie('gulp unit --nobuild --headless --edge');
+      break;
+    default:
+      log(
+        red('ERROR:'),
+        'Cannot run cross-browser unit tests on',
+        cyan(process.platform) + '.'
+      );
+  }
+}
+
+async function main() {
+  const startTime = startTimer(FILENAME, FILENAME);
+  if (!runNpmChecks(FILENAME)) {
+    stopTimedJob(FILENAME, startTime);
+    return;
+  }
+  if (!isPullRequestBuild()) {
+    timedExecOrDie('gulp update-packages');
+    timedExecOrDie('gulp dist --fortesting');
+    runIntegrationTestsForPlatform();
+    runUnitTestsForPlatform();
+  } else {
+    printChangeSummary(FILENAME);
+    const buildTargets = determineBuildTargets(FILENAME);
+    if (
+      !buildTargets.has('RUNTIME') &&
+      !buildTargets.has('FLAG_CONFIG') &&
+      !buildTargets.has('UNIT_TEST') &&
+      !buildTargets.has('INTEGRATION_TEST')
+    ) {
+      console.log(
+        `${FILELOGPREFIX} Skipping`,
+        cyan('Cross-Browser Tests'),
+        'because this commit not affect the runtime, flag configs,',
+        'unit tests, or integration tests.'
+      );
+      stopTimer(FILENAME, FILENAME, startTime);
+      return;
+    }
+    timedExecOrDie('gulp update-packages');
+    if (
+      buildTargets.has('RUNTIME') ||
+      buildTargets.has('FLAG_CONFIG') ||
+      buildTargets.has('INTEGRATION_TEST')
+    ) {
+      timedExecOrDie('gulp dist --fortesting');
+      runIntegrationTestsForPlatform();
+    }
+    if (buildTargets.has('RUNTIME') || buildTargets.has('UNIT_TEST')) {
+      runUnitTestsForPlatform();
+    }
   }
   stopTimer(FILENAME, FILENAME, startTime);
 }

--- a/build-system/tasks/karma.conf.js
+++ b/build-system/tasks/karma.conf.js
@@ -20,8 +20,7 @@ const browserifyPersistFs = require('browserify-persist-fs');
 const crypto = require('crypto');
 const fs = require('fs');
 const globby = require('globby');
-
-const {isCiBuild, isGithubActionsBuild} = require('../common/ci');
+const {isCiBuild} = require('../common/ci');
 
 const TEST_SERVER_PORT = 8081;
 
@@ -112,11 +111,7 @@ module.exports = {
     persistentCache,
   },
 
-  reporters: [
-    // TODO(rsimha): Figure out why super-dots doesn't work on GH actions.
-    isGithubActionsBuild() ? 'dots' : 'super-dots',
-    'karmaSimpleReporter',
-  ],
+  reporters: ['super-dots', 'karmaSimpleReporter'],
 
   superDotsReporter: {
     nbDotsPerLine: 100000,

--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -119,6 +119,7 @@ const forbiddenTerms = {
       'build-system/pr-check/build.js',
       'build-system/pr-check/build-targets.js',
       'build-system/pr-check/checks.js',
+      'build-system/pr-check/cross-browser-tests.js',
       'build-system/pr-check/dist-bundle-size.js',
       'build-system/pr-check/dist-tests.js',
       'build-system/pr-check/module-dist-bundle-size.js',

--- a/build-system/tasks/runtime-test/runtime-test-base.js
+++ b/build-system/tasks/runtime-test/runtime-test-base.js
@@ -27,7 +27,7 @@ const {app} = require('../../server/test-server');
 const {createKarmaServer, getAdTypes} = require('./helpers');
 const {getFilesFromArgv} = require('../../common/utils');
 const {green, yellow, cyan, red} = require('ansi-colors');
-const {isCiBuild, isGithubActionsBuild} = require('../../common/ci');
+const {isCiBuild} = require('../../common/ci');
 const {reportTestStarted} = require('.././report-test-status');
 const {startServer, stopServer} = require('../serve');
 const {unitTestsToRun} = require('./helpers-unit');
@@ -127,7 +127,7 @@ function getFiles(testType) {
       if (argv.files) {
         return files.concat(getFilesFromArgv());
       }
-      if (isGithubActionsBuild()) {
+      if (argv.firefox || argv.safari || argv.edge) {
         return files.concat(testConfig.unitTestCrossBrowserPaths);
       }
       if (argv.local_changes) {


### PR DESCRIPTION
**PR highlights:**
- For PR builds, runs tests based on build-targets (e.g. docs changes will no longer compile code / run tests)
- For push builds, continues to run all platform-specific unit / integration tests
- Adds missing `npm` checks and commit log messages
- Updates `fetch-depth` config for repo checkout so `git` operations can be performed (fetch running time is still ~20s)
- Uses `origin/master` instead of `master` in `gitBranchCreationPoint()` so it works across CI services
- Restores `super-dots` reporter on GH actions (used to be broken, fixed by [this](https://github.blog/2020-09-23-a-better-logs-experience-with-github-actions/) update)
- Modifies `runtime-test-base.js` logic to be flag-based instead of CI-based (addresses https://github.com/ampproject/amphtml/pull/31527#discussion_r540376596)

Meant to do this months ago. Doing now because it has become easier with the `ci` library.

**Coming up:**
- Reduce boilerplate that's copy-pasted across `build-system/pr-check/`
- Try to invoke `node` with `unbuffer` on GH actions (fixes ANSI log-coloring bugs)
