### PR TITLE
🚀 Use native URL() on module builds

### DIFF
--- a/src/url.js
+++ b/src/url.js
@@ -92,9 +92,14 @@ export function getWinOrigin(win) {
  * testing by freezing the object.
  * @param {string} url
  * @param {boolean=} opt_nocache
+ *   Cache is altogether ignored on ESM builds, since an <a> is not used.
  * @return {!Location}
  */
 export function parseUrlDeprecated(url, opt_nocache) {
+  if (IS_ESM) {
+    return /** @type {!Location} */ (new URL(url));
+  }
+
   if (!a) {
     a = /** @type {!HTMLAnchorElement} */ (self.document.createElement('a'));
     cache = self.__AMP_URL_CACHE || (self.__AMP_URL_CACHE = new LruCache(100));
@@ -111,10 +116,15 @@ export function parseUrlDeprecated(url, opt_nocache) {
  * @param {!HTMLAnchorElement} a
  * @param {string} url
  * @param {LruCache=} opt_cache
+ *   Cache is altogether ignored on ESM builds, since an <a> is not used.
  * @return {!Location}
  * @restricted
  */
 export function parseUrlWithA(a, url, opt_cache) {
+  if (IS_ESM) {
+    return /** @type {!Location} */ (new URL(url));
+  }
+
   if (opt_cache && opt_cache.has(url)) {
     return opt_cache.get(url);
   }


### PR DESCRIPTION
For ESM builds that use `parseUrl()` & friends:

1. Use [native `new URL()`](https://caniesm.vercel.app/?search=URL) instead of a live `<a>` element to parse.
2. Don't use `LruCache` for as it has little benefit when using `URL()`.

This benefits runtime performance and bundle size.

## Performance

Native `URL` _without_ cache performs **better or similarly** than using an `<a>` _with_ cache:

[**Low hit-rate** : 1500 items, 300 unique (100 cache size)](https://jsbench.me/dpkioyt4zt)

| | | cache | | |
|-|-|-|-|-|
| | `<a>` | no | | 39.96 ops/s ± 1.46%<br>_44.19 % slower_
| current | `<a>` | yes | | 27.44 ops/s ± 1.66%<br>_61.68 % slower_
| proposed | `URL()` 👈 | no | 🐇 | 71.6 ops/s ± 0.93%<br>**Fastest** 
| | `URL()` | yes | | 36.92 ops/s ± 1.38%<br>_48.43 % slower_

[**High hit-rate**: 1500 items, 100 unique (100 cache size)](https://jsbench.me/53kip2viug)

| | | cache | | |
|-|-|-|-|-|
| | `<a>` | no | | 29.85 ops/s ± 42.42%<br>_63.35 % slower_
| current | `<a>` | yes | | 70.38 ops/s ± 0.75%<br>_13.57 % slower_
| proposed | `URL()`  👈| no | | 70.28 ops/s ± 0.99%<br>_13.69 % slower_
| | `URL()` | yes | 🐇 | 81.43 ops/s ± 1.31%<br>**Fastest**

## Bundle size

Consider a common case (`assertHttpsUrl`) in a minimal representation:

```js
import {assertHttpsUrl} from '../../../src/url';

AMP.extension('amp-assertHttpsUrl', '0.1', () => {
  assertHttpsUrl('https://amp.dev', AMP.ampdoc.getBody());
});
```

Its compiled output blows up by about 120 lines from the inclusion of `assertHttpsUrl`.

**With this change**, this reduces the amount of included code by about ~50% (`-510 B` minified brotli):

<a  href="https://user-images.githubusercontent.com/254946/102140536-35559000-3e14-11eb-9f10-cc97c565c881.png"><img src="https://user-images.githubusercontent.com/254946/102140536-35559000-3e14-11eb-9f10-cc97c565c881.png" alt="assertHttpsUrl-compare" width=580></a>


