### PR TITLE
Fix children ID auto-assignment to avoid duplicates

### DIFF
--- a/src/preact/base-element.js
+++ b/src/preact/base-element.js
@@ -46,6 +46,7 @@ import {getDate} from '../utils/date';
 import {getMode} from '../mode';
 import {installShadowStyle} from '../shadow-embed';
 import {isLayoutSizeDefined} from '../layout';
+import {sequentialIdGenerator} from '../utils/id-generator';
 
 /**
  * The following combinations are allowed.
@@ -122,6 +123,8 @@ const UNSLOTTED_GROUP = 'unslotted';
 
 /** @return {boolean} */
 const MATCH_ANY = () => true;
+
+const childIdGenerator = sequentialIdGenerator();
 
 /**
  * Wraps a Preact Component in a BaseElement class.
@@ -854,7 +857,7 @@ function collectProps(Ctor, element, ref, defaultProps, mediaQueryProps) {
             : createSlot(
                 childElement,
                 childElement.getAttribute('slot') ||
-                  `i-amphtml-${name}-${list.length}`,
+                  `i-amphtml-${name}-${childIdGenerator()}`,
                 parsedSlotProps
               )
         );


### PR DESCRIPTION
A typical symptom:

> Prepending a slide doesn't work. The new and old slides are slotted into the first slide. (#28284)