### PR TITLE
Require a minimal threshold for an animation to play

### DIFF
--- a/extensions/amp-animation/0.1/amp-animation.js
+++ b/extensions/amp-animation/0.1/amp-animation.js
@@ -116,10 +116,14 @@ export class AmpAnimation extends AMP.BaseElement {
         this.setVisible_(this.isIntersecting_ && ampdoc.isVisible());
       })
     );
-    const io = new ampdoc.win.IntersectionObserver((records) => {
-      this.isIntersecting_ = records[records.length - 1].isIntersecting;
-      this.setVisible_(this.isIntersecting_ && ampdoc.isVisible());
-    });
+    const io = new ampdoc.win.IntersectionObserver(
+      (records) => {
+        const {isIntersecting} = records[records.length - 1];
+        this.isIntersecting_ = isIntersecting;
+        this.setVisible_(this.isIntersecting_ && ampdoc.isVisible());
+      },
+      {threshold: 0.001}
+    );
     io.observe(dev().assertElement(this.element.parentElement));
     this.cleanups_.push(() => io.disconnect());
 

--- a/extensions/amp-animation/0.1/test/test-amp-animation.js
+++ b/extensions/amp-animation/0.1/test/test-amp-animation.js
@@ -34,10 +34,14 @@ describes.sandboxed('AmpAnimation', {}, (env) => {
         ioCallbacks.push(callback);
       }
       observe(target) {
+        const isIntersecting = (config && config.isIntersecting) ?? true;
+        const intersectionRatio =
+          (config && config.intersectionRatio) ?? (isIntersecting ? 1 : 0);
         ioCallback([
           {
             target,
-            isIntersecting: (config && config.isIntersecting) ?? true,
+            isIntersecting,
+            intersectionRatio,
             boundingClientRect: target.getBoundingClientRect(),
           },
         ]);
@@ -69,12 +73,13 @@ describes.sandboxed('AmpAnimation', {}, (env) => {
     return element.build().then(() => element.implementation_);
   }
 
-  function updateIntersection(target, isIntersecting) {
+  function updateIntersection(target, intersectionRatio) {
     ioCallbacks.forEach((callback) => {
       callback([
         {
           target,
-          isIntersecting,
+          isIntersecting: intersectionRatio > 0,
+          intersectionRatio,
           boundingClientRect: target.getBoundingClientRect(),
         },
       ]);
@@ -186,7 +191,7 @@ describes.sandboxed('AmpAnimation', {}, (env) => {
         viewer.setVisibilityState_('visible');
         expect(anim.visible_).to.be.false;
 
-        updateIntersection(anim.element.parentElement, true);
+        updateIntersection(anim.element.parentElement, 1);
         expect(anim.visible_).to.be.true;
       });
 


### PR DESCRIPTION
Partial for #28284

For some components 1-pixel intersections are very common, such as the next slide in the carousel. Thus the minimum threshold is needed to allow animation to play.

The symptom is:

> animations do not pause. note: a different reason than video pausing.