### PR TITLE
🐛 Fix ESM sourcemaps

### DIFF
--- a/build-system/compile/post-closure-babel.js
+++ b/build-system/compile/post-closure-babel.js
@@ -40,7 +40,7 @@ async function terserMinify(code) {
       comments: /\/*/,
       // eslint-disable-next-line google-camelcase/google-camelcase
       keep_quoted_props: true,
-      preamble: '\n',
+      preamble: ';',
     },
     sourceMap: true,
   });

--- a/build-system/compile/post-closure-babel.js
+++ b/build-system/compile/post-closure-babel.js
@@ -40,6 +40,7 @@ async function terserMinify(code) {
       comments: /\/*/,
       // eslint-disable-next-line google-camelcase/google-camelcase
       keep_quoted_props: true,
+      preamble: '\n',
     },
     sourceMap: true,
   });

--- a/build-system/tasks/check-sourcemaps.js
+++ b/build-system/tasks/check-sourcemaps.js
@@ -144,11 +144,11 @@ function checkSourcemapMappings(sourcemapJson, map) {
   // Zeroth sub-array corresponds to ';' and has no mappings.
   // See https://www.npmjs.com/package/sourcemap-codec#usage
   const firstLineMapping = decode(sourcemapJson.mappings)[1][0];
-  const [, sourceIndex, sourceCodeLine] = firstLineMapping;
+  const [, sourceIndex, sourceCodeLine, sourceCodeColumn] = firstLineMapping;
 
   const firstLineFile = sourcemapJson.sources[sourceIndex];
   const contents = fs.readFileSync(firstLineFile, 'utf8').split('\n');
-  const firstLineCode = contents[sourceCodeLine];
+  const firstLineCode = contents[sourceCodeLine].slice(sourceCodeColumn);
   const helpMessage =
     'If this change is intentional, update the mapping related constants in ' +
     cyan('build-system/tasks/check-sourcemaps.js') +

--- a/build-system/tasks/check-sourcemaps.js
+++ b/build-system/tasks/check-sourcemaps.js
@@ -25,6 +25,9 @@ const {execOrDie} = require('../common/exec');
 // Compile related constants
 const distWithSourcemapsCmd = 'gulp dist --core_runtime_only --full_sourcemaps';
 const v0JsMap = 'dist/v0.js.map';
+const distEsmWithSourcemapsCmd =
+  'gulp dist --core_runtime_only --full_sourcemaps --esm';
+const v0MjsMap = 'dist/v0.mjs.map';
 
 // Sourcemap URL related constants
 const sourcemapUrlMatcher =
@@ -33,7 +36,6 @@ const sourcemapUrlMatcher =
 // Mapping related constants
 const expectedFirstLineFile = 'src/polyfills/abort-controller.js'; // First file that is compiled into v0.js.
 const expectedFirstLineCode = 'class AbortController {'; // First line of code in that file.
-const expectedFirstLineColumn = "'use strict;'".length; // Column at which the first line is found (after an initial 'use strict;')
 
 /**
  * Throws an error with the given message
@@ -53,29 +55,32 @@ function maybeBuild() {
   if (!argv.nobuild) {
     log('Compiling', cyan('v0.js'), 'with full sourcemaps...');
     execOrDie(distWithSourcemapsCmd, {'stdio': 'ignore'});
+    log('Compiling', cyan('v0.mjs'), 'with full sourcemaps...');
+    execOrDie(distEsmWithSourcemapsCmd, {'stdio': 'ignore'});
   }
 }
 
 /**
  * Verifies that the sourcemap file exists, and returns its contents.
- *
+ * @param {string} map The map filepath to check
  * @return {!Object}
  */
-function getSourcemapJson() {
-  if (!fs.existsSync(v0JsMap)) {
-    log(red('ERROR:'), 'Could not find', cyan(v0JsMap));
-    throwError('Could not find sourcemap file');
+function getSourcemapJson(map) {
+  if (!fs.existsSync(map)) {
+    log(red('ERROR:'), 'Could not find', cyan(map));
+    throwError(`Could not find sourcemap file '${map}'`);
   }
-  return JSON.parse(fs.readFileSync(v0JsMap, 'utf8'));
+  return JSON.parse(fs.readFileSync(map, 'utf8'));
 }
 
 /**
  * Verifies that a correctly formatted sourcemap URL is present in v0.js.map.
  *
  * @param {!Object} sourcemapJson
+ * @param {string} map The map filepath to check
  */
-function checkSourcemapUrl(sourcemapJson) {
-  log('Inspecting', cyan('sourceRoot'), 'in', cyan(v0JsMap) + '...');
+function checkSourcemapUrl(sourcemapJson, map) {
+  log('Inspecting', cyan('sourceRoot'), 'in', cyan(map) + '...');
   if (!sourcemapJson.sourceRoot) {
     log(red('ERROR:'), 'Could not find', cyan('sourceRoot'));
     throwError('Could not find sourcemap URL');
@@ -90,9 +95,10 @@ function checkSourcemapUrl(sourcemapJson) {
  * Verifies all the paths in the sources field are as expected.
  *
  * @param {!Object} sourcemapJson
+ * @param {string} map The map filepath to check
  */
-function checkSourcemapSources(sourcemapJson) {
-  log('Inspecting', cyan('sources'), 'in', cyan(v0JsMap) + '...');
+function checkSourcemapSources(sourcemapJson, map) {
+  log('Inspecting', cyan('sources'), 'in', cyan(map) + '...');
   if (!sourcemapJson.sources) {
     log(red('ERROR:'), 'Could not find', cyan('sources'));
     throwError('Could not find sources array');
@@ -126,9 +132,10 @@ function checkSourcemapSources(sourcemapJson) {
  * 5. Check if the filename, line of code, and column match expected sentinel values.
  *
  * @param {!Object} sourcemapJson
+ * @param {string} map The map filepath to check
  */
-function checkSourcemapMappings(sourcemapJson) {
-  log('Inspecting', cyan('mappings'), 'in', cyan(v0JsMap) + '...');
+function checkSourcemapMappings(sourcemapJson, map) {
+  log('Inspecting', cyan('mappings'), 'in', cyan(map) + '...');
   if (!sourcemapJson.mappings) {
     log(red('ERROR:'), 'Could not find', cyan('mappings'));
     throwError('Could not find mappings array');
@@ -137,12 +144,7 @@ function checkSourcemapMappings(sourcemapJson) {
   // Zeroth sub-array corresponds to ';' and has no mappings.
   // See https://www.npmjs.com/package/sourcemap-codec#usage
   const firstLineMapping = decode(sourcemapJson.mappings)[1][0];
-  const [
-    generatedCodeColumn,
-    sourceIndex,
-    sourceCodeLine,
-    sourceCodeColumn,
-  ] = firstLineMapping;
+  const [, sourceIndex, sourceCodeLine] = firstLineMapping;
 
   const firstLineFile = sourcemapJson.sources[sourceIndex];
   const contents = fs.readFileSync(firstLineFile, 'utf8').split('\n');
@@ -165,12 +167,16 @@ function checkSourcemapMappings(sourcemapJson) {
     log(helpMessage);
     throwError('Found mapping for incorrect code');
   }
-  if (generatedCodeColumn != expectedFirstLineColumn || sourceCodeColumn != 0) {
-    log(red('ERROR:'), 'Found mapping for incorrect column.');
-    log('generatedCodeColumn:', cyan(generatedCodeColumn));
-    log('sourceCodeColumn:', cyan(sourceCodeColumn));
-    throwError('Found mapping for incorrect column');
-  }
+}
+
+/**
+ * @param {string} map The map filepath to check
+ */
+function checkSourceMap(map) {
+  const sourcemapJson = getSourcemapJson(map);
+  checkSourcemapUrl(sourcemapJson, map);
+  checkSourcemapSources(sourcemapJson, map);
+  checkSourcemapMappings(sourcemapJson, map);
 }
 
 /**
@@ -179,10 +185,8 @@ function checkSourcemapMappings(sourcemapJson) {
  */
 async function checkSourcemaps() {
   maybeBuild();
-  const sourcemapJson = getSourcemapJson();
-  checkSourcemapUrl(sourcemapJson);
-  checkSourcemapSources(sourcemapJson);
-  checkSourcemapMappings(sourcemapJson);
+  checkSourceMap(v0JsMap);
+  checkSourceMap(v0MjsMap);
   log(green('SUCCESS:'), 'All sourcemaps checks passed.');
 }
 

--- a/build-system/tasks/extension-helpers.js
+++ b/build-system/tasks/extension-helpers.js
@@ -178,6 +178,9 @@ function getExtensionsToBuild(preBuild = false) {
   if (extensionsToBuild) {
     return extensionsToBuild;
   }
+  if (argv.core_runtime_only) {
+    return (extensionsToBuild = []);
+  }
   extensionsToBuild = DEFAULT_EXTENSION_SET;
   if (argv.extensions) {
     if (typeof argv.extensions !== 'string') {
@@ -197,8 +200,7 @@ function getExtensionsToBuild(preBuild = false) {
     !preBuild &&
     !argv.noextensions &&
     !argv.extensions &&
-    !argv.extensions_from &&
-    !argv.core_runtime_only
+    !argv.extensions_from
   ) {
     const allExtensions = [];
     for (const extension in extensions) {


### PR DESCRIPTION
In regular builds, the v0.js file starts with:

```js
var global=self;self.AMP=self.AMP||[];try{(function(_){
```

That's it. It's an effectively "empty" line, and we can freely prepend code to this line without effecting our sourcemaps. As long as the prepended code never includes a newline, the sourcemap will fix itself on the next line.

However in ESM builds, we run terser. Terser will concat lines together, making the first line:

```js
var global=self;self.AMP=self.AMP||[];try{(function(t){var e=class{constructor(){this.Ff=new i}abort(){this.Ff.df=!0}get signal(){return this.Ff}};…snip 11kb…
```

When we prepended our config onto this line, we affected the sourcemap for all of the later code on the line! A simple fix is to just force terser to prepend a newline before any code, so we're again free to prepend our config without direct sourcemap awareness.