### PR TITLE
🏗 Update toolbox-cache-url dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@ampproject/animations": "0.2.2",
-    "@ampproject/toolbox-cache-url": "2.5.4",
+    "@ampproject/toolbox-cache-url": "2.7.2",
     "@ampproject/viewer-messaging": "1.1.0",
     "@ampproject/worker-dom": "0.27.4",
     "dompurify": "2.0.7",


### PR DESCRIPTION
Update [`toolbox-cache-url`](https://www.npmjs.com/package/@ampproject/toolbox-cache-url) dependency to include the fixes for #31473 