### PR TITLE
Hide dev expected errors from console

### DIFF
--- a/src/error.js
+++ b/src/error.js
@@ -194,7 +194,10 @@ export function reportError(error, opt_associatedElement) {
     }
 
     // Report to console.
-    if (self.console && (isUserErrorMessage(error.message) || !error.expected)) {
+    if (
+      self.console &&
+      (isUserErrorMessage(error.message) || !error.expected)
+    ) {
       const output = console.error || console.log;
       if (error.messageArray) {
         output.apply(console, error.messageArray);

--- a/src/error.js
+++ b/src/error.js
@@ -196,7 +196,9 @@ export function reportError(error, opt_associatedElement) {
     // Report to console.
     if (
       self.console &&
-      (isUserErrorMessage(error.message) || !error.expected)
+      (isUserErrorMessage(error.message) ||
+        !error.expected ||
+        getMode().localDev)
     ) {
       const output = console.error || console.log;
       if (error.messageArray) {

--- a/src/error.js
+++ b/src/error.js
@@ -194,7 +194,7 @@ export function reportError(error, opt_associatedElement) {
     }
 
     // Report to console.
-    if (self.console) {
+    if (self.console && (isUserErrorMessage(error.message) || !error.expected)) {
       const output = console.error || console.log;
       if (error.messageArray) {
         output.apply(console, error.messageArray);


### PR DESCRIPTION
Dev expected errors are, well, errors we expect to happen. We use them to track overall metrics of errors (to make sure there's no an unexpected spike, meaning something's gone very wrong). But displaying the errors to publishers isn't helpful, and can lead them to believe they have a bug on their pages.