### PR TITLE
Replace getIntersectionElementLayoutBox with getLayoutBox

### DIFF
--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -1217,17 +1217,6 @@ const forbiddenTermsSrcInclusive = {
       'ads/google/a4a/utils.js',
     ],
   },
-  '\\.getIntersectionElementLayoutBox': {
-    message: measurementApiDeprecated,
-    allowlist: [
-      'src/custom-element.js',
-      'extensions/amp-a4a/0.1/amp-a4a.js',
-      'extensions/amp-ad/0.1/amp-ad-3p-impl.js',
-      'extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js',
-      'extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js',
-      'extensions/amp-iframe/0.1/amp-iframe.js',
-    ],
-  },
 };
 
 // Terms that must appear in a source file.

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -594,7 +594,7 @@ export class AmpA4A extends AMP.BaseElement {
    * @private
    */
   shouldInitializePromiseChain_() {
-    const slotRect = this.getIntersectionElementLayoutBox();
+    const slotRect = this.getLayoutBox();
     const fixedSizeZeroHeightOrWidth =
       this.getLayout() != Layout.FLUID &&
       (slotRect.height == 0 || slotRect.width == 0);

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -78,7 +78,7 @@ if (NO_SIGNING_RTV) {
       doc.body.appendChild(element);
       a4a = new AmpA4A(element);
       // Make the ad think it has size.
-      env.sandbox.stub(a4a, 'getIntersectionElementLayoutBox').returns({
+      env.sandbox.stub(a4a, 'getLayoutBox').returns({
         height: 250,
         width: 300,
       });

--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -320,7 +320,7 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
     ) {
       this.size_ = {width, height};
     } else {
-      this.size_ = this.getIntersectionElementLayoutBox();
+      this.size_ = this.getLayoutBox();
     }
 
     const sizeToSend = this.isSinglePageStoryAd

--- a/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
@@ -97,18 +97,16 @@ describes.realWin(
           return Promise.reject(new Error('No token'));
         },
       });
-      env.sandbox
-        .stub(impl, 'getIntersectionElementLayoutBox')
-        .callsFake(() => {
-          return {
-            top: 0,
-            bottom: 0,
-            left: 0,
-            right: 0,
-            width: 320,
-            height: 50,
-          };
-        });
+      env.sandbox.stub(impl, 'getLayoutBox').callsFake(() => {
+        return {
+          top: 0,
+          bottom: 0,
+          left: 0,
+          right: 0,
+          width: 320,
+          height: 50,
+        };
+      });
     });
 
     /**

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -730,7 +730,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
       : width && height
       ? // width/height could be 'auto' in which case we fallback to measured.
         {width, height}
-      : this.getIntersectionElementLayoutBox();
+      : this.getLayoutBox();
     this.jsonTargeting = tryParseJson(this.element.getAttribute('json')) || {};
     this.adKey = this.generateAdKey_(
       `${this.initialSize_.width}x${this.initialSize_.height}`
@@ -1101,7 +1101,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
   /**
    * Returns the width and height of the slot as defined by the width and height
    * attributes, or the dimensions as computed by
-   * getIntersectionElementLayoutBox.
+   * getLayoutBox.
    * @return {!LayoutRectOrDimsDef}
    */
   getSlotSize() {
@@ -1109,7 +1109,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
     return width && height
       ? {width, height}
       : // width/height could be 'auto' in which case we fallback to measured.
-        this.getIntersectionElementLayoutBox();
+        this.getLayoutBox();
   }
 
   /**

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -454,18 +454,16 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, (env) => {
       impl.size_ = {width: 200, height: 50};
       impl.iframe = impl.win.document.createElement('iframe');
       // Temporary fix for local test failure.
-      env.sandbox
-        .stub(impl, 'getIntersectionElementLayoutBox')
-        .callsFake(() => {
-          return {
-            top: 0,
-            bottom: 0,
-            left: 0,
-            right: 0,
-            width: 320,
-            height: 50,
-          };
-        });
+      env.sandbox.stub(impl, 'getLayoutBox').callsFake(() => {
+        return {
+          top: 0,
+          bottom: 0,
+          left: 0,
+          right: 0,
+          width: 320,
+          height: 50,
+        };
+      });
     });
 
     [true, false].forEach((exp) => {
@@ -631,18 +629,16 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, (env) => {
       doc.body.appendChild(element);
       impl = new AmpAdNetworkDoubleclickImpl(element);
       // Temporary fix for local test failure.
-      window.sandbox
-        .stub(impl, 'getIntersectionElementLayoutBox')
-        .callsFake(() => {
-          return {
-            top: 0,
-            bottom: 0,
-            left: 0,
-            right: 0,
-            width: 320,
-            height: 50,
-          };
-        });
+      window.sandbox.stub(impl, 'getLayoutBox').callsFake(() => {
+        return {
+          top: 0,
+          bottom: 0,
+          left: 0,
+          right: 0,
+          width: 320,
+          height: 50,
+        };
+      });
 
       // Reproduced from noopMethods in ads/google/a4a/test/test-utils.js,
       // to fix failures when this is run after 'gulp build', without a 'dist'.

--- a/extensions/amp-ad/0.1/amp-ad-3p-impl.js
+++ b/extensions/amp-ad/0.1/amp-ad-3p-impl.js
@@ -333,9 +333,9 @@ export class AmpAd3PImpl extends AMP.BaseElement {
   /**
    * @override
    */
-  getIntersectionElementLayoutBox() {
+  getLayoutBox() {
     if (!this.xOriginIframeHandler_ || !this.xOriginIframeHandler_.iframe) {
-      return super.getIntersectionElementLayoutBox();
+      return super.getLayoutBox();
     }
     const box = this.getLayoutBox();
     if (!this.iframeLayoutBox_) {

--- a/extensions/amp-ad/0.1/test/test-amp-ad-3p-impl.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-3p-impl.js
@@ -438,7 +438,7 @@ describes.realWin(
       });
     });
 
-    describe('#getIntersectionElementLayoutBox', () => {
+    describe('#getLayoutBox', () => {
       it('should not cache intersection box', () => {
         return ad3p.layoutCallback().then(() => {
           const iframe = ad3p.element.querySelector('iframe');
@@ -462,13 +462,13 @@ describes.realWin(
           stub.returns(box);
 
           ad3p.onLayoutMeasure();
-          const intersection = ad3p.getIntersectionElementLayoutBox();
+          const intersection = ad3p.getLayoutBox();
 
           // Simulate a fixed position element "moving" 100px by scrolling down
           // the page.
           box.top += 100;
           box.bottom += 100;
-          const newIntersection = ad3p.getIntersectionElementLayoutBox();
+          const newIntersection = ad3p.getLayoutBox();
           expect(newIntersection).not.to.deep.equal(intersection);
           expect(newIntersection.top).to.equal(intersection.top + 100);
           expect(newIntersection.width).to.equal(300);

--- a/extensions/amp-iframe/0.1/amp-iframe.js
+++ b/extensions/amp-iframe/0.1/amp-iframe.js
@@ -348,9 +348,9 @@ export class AmpIframe extends AMP.BaseElement {
   }
 
   /** @override */
-  getIntersectionElementLayoutBox() {
+  getLayoutBox() {
     if (!this.iframe_) {
-      return super.getIntersectionElementLayoutBox();
+      return super.getLayoutBox();
     }
     const box = this.getLayoutBox();
     if (!this.iframeLayoutBox_) {

--- a/extensions/amp-iframe/0.1/test/test-amp-iframe.js
+++ b/extensions/amp-iframe/0.1/test/test-amp-iframe.js
@@ -924,12 +924,12 @@ describes.realWin(
         stub.returns(box);
 
         impl.onLayoutMeasure();
-        const intersection = impl.getIntersectionElementLayoutBox();
+        const intersection = impl.getLayoutBox();
         // Simulate a fixed position element "moving" 100px by scrolling down
         // the page.
         box.top += 100;
         box.bottom += 100;
-        const newIntersection = impl.getIntersectionElementLayoutBox();
+        const newIntersection = impl.getLayoutBox();
         expect(newIntersection).not.to.deep.equal(intersection);
         expect(newIntersection.top).to.equal(intersection.top + 100);
         expect(newIntersection.width).to.equal(300);

--- a/src/base-element.js
+++ b/src/base-element.js
@@ -743,15 +743,6 @@ export class BaseElement {
   }
 
   /**
-   * Returns the layout rectangle used for when calculating this element's
-   * intersection with the viewport.
-   * @return {!./layout-rect.LayoutRectDef}
-   */
-  getIntersectionElementLayoutBox() {
-    return this.getLayoutBox();
-  }
-
-  /**
    * Collapses the element, setting it to `display: none`, and notifies its
    * owner (if there is one) through {@link collapsedCallback} that the element
    * is no longer visible.

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -1046,7 +1046,7 @@ function createBaseCustomElementClass(win) {
      * @final
      */
     getIntersectionChangeEntry() {
-      const box = this.implementation_.getIntersectionElementLayoutBox();
+      const box = this.implementation_.getLayoutBox();
       const owner = this.getOwner();
       const viewportBox = this.implementation_.getViewport().getRect();
       // TODO(jridgewell, #4826): We may need to make this recursive.

--- a/test/unit/test-custom-element.js
+++ b/test/unit/test-custom-element.js
@@ -35,7 +35,7 @@ describes.realWin('CustomElement', {amp: true}, (env) => {
       let resources;
       let resourcesMock;
       let clock;
-      let testElementGetInsersectionElementLayoutBox;
+      let testElementGetLayoutBox;
       let container;
       let ElementClass, StubElementClass;
 
@@ -70,8 +70,8 @@ describes.realWin('CustomElement', {amp: true}, (env) => {
         firstLayoutCompleted() {
           testElementFirstLayoutCompleted();
         }
-        getIntersectionElementLayoutBox() {
-          testElementGetInsersectionElementLayoutBox();
+        getLayoutBox() {
+          testElementGetLayoutBox();
           return {top: 10, left: 10, width: 11, height: 1};
         }
         unlayoutCallback() {
@@ -128,7 +128,7 @@ describes.realWin('CustomElement', {amp: true}, (env) => {
         testElementCreatePlaceholderCallback = env.sandbox.spy();
         testElementLayoutCallback = env.sandbox.spy();
         testElementFirstLayoutCompleted = env.sandbox.spy();
-        testElementGetInsersectionElementLayoutBox = env.sandbox.spy();
+        testElementGetLayoutBox = env.sandbox.spy();
         testElementUnlayoutCallback = env.sandbox.spy();
         testElementPauseCallback = env.sandbox.spy();
         testElementResumeCallback = env.sandbox.spy();
@@ -315,7 +315,7 @@ describes.realWin('CustomElement', {amp: true}, (env) => {
         container.appendChild(element);
         element.updateLayoutBox({top: 0, left: 0, width: 111, height: 51});
         element.getIntersectionChangeEntry();
-        expect(testElementGetInsersectionElementLayoutBox).to.be.calledOnce;
+        expect(testElementGetLayoutBox).to.be.calledOnce;
       });
 
       it('Element - updateLayoutBox', () => {


### PR DESCRIPTION
Followup to https://github.com/ampproject/amphtml/pull/5533.

Seeing as the current implementation for `getIntersectionElementLayoutBox` just points to `getLayoutBox`, why not remove the former?
One aspect I found confusing in this change is that both `<amp-iframe>` and  `<amp-ad>` override the fn. still need to figure out why they are doing that + if renaming those are fine.