### PR TITLE
🖍 [bento][amp-sidebar] Allow various CSS properties to be configurable on amp-sidebar

### DIFF
--- a/extensions/amp-sidebar/1.0/amp-sidebar.css
+++ b/extensions/amp-sidebar/1.0/amp-sidebar.css
@@ -20,7 +20,12 @@ amp-sidebar {
   height: 100vh;
   top: 0;
   max-height: 100vh !important;
-  max-width: 80vw !important;
+  /** 
+   * Max width allowed to be configurable by user.  If user wants width to be
+   * controlled by content size and max-width, then this property needs to be
+   * configurable.
+   */
+  max-width: 80vw;
   min-width: 45px !important;
   outline: none;
   z-index: 2147483647;

--- a/extensions/amp-sidebar/1.0/amp-sidebar.css
+++ b/extensions/amp-sidebar/1.0/amp-sidebar.css
@@ -13,3 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+amp-sidebar {
+  color: black;
+  background-color: #efefef;
+}
+
+amp-sidebar::part(sidebar) {
+  color: inherit;
+  background-color: inherit;
+}

--- a/extensions/amp-sidebar/1.0/amp-sidebar.css
+++ b/extensions/amp-sidebar/1.0/amp-sidebar.css
@@ -43,9 +43,6 @@ amp-sidebar::part(sidebar) {
   width: inherit;
   padding: inherit;
   border: inherit;
-
-  /* Children of amp-sidebar should be visible */
-  visibility: visible !important;
 }
 
 /** 
@@ -55,4 +52,13 @@ amp-sidebar::part(sidebar) {
 amp-sidebar {
   visibility: hidden !important;
   position: fixed !important;
+}
+
+/** 
+ * The host element, amp-sidebar, is not visible to allow direct styling to be
+ * inherited by its children.  Its children should be visible so the styling 
+ * is displayed.
+ */
+amp-sidebar::part(c) {
+  visibility: visible !important;
 }

--- a/extensions/amp-sidebar/1.0/amp-sidebar.css
+++ b/extensions/amp-sidebar/1.0/amp-sidebar.css
@@ -18,7 +18,6 @@ amp-sidebar {
   color: black;
   background-color: #efefef;
   height: 100vh;
-  --story-page-vh: 1vh;
   top: 0;
   max-height: 100vh !important;
   max-width: 80vw !important;
@@ -33,7 +32,6 @@ amp-sidebar::part(sidebar) {
   color: inherit;
   background-color: inherit;
   height: inherit;
-  --story-page-vh: inherit;
   top: inherit;
   max-height: inherit;
   max-width: inherit;

--- a/extensions/amp-sidebar/1.0/amp-sidebar.css
+++ b/extensions/amp-sidebar/1.0/amp-sidebar.css
@@ -17,9 +17,44 @@
 amp-sidebar {
   color: black;
   background-color: #efefef;
+  height: 100vh;
+  --story-page-vh: 1vh;
+  top: 0;
+  max-height: 100vh !important;
+  max-width: 80vw !important;
+  min-width: 45px !important;
+  outline: none;
+  z-index: 2147483647;
 }
 
+amp-sidebar::part(c),
 amp-sidebar::part(sidebar) {
+  /* Inherit values specified on amp-sidebar */
   color: inherit;
   background-color: inherit;
+  height: inherit;
+  --story-page-vh: inherit;
+  top: inherit;
+  max-height: inherit;
+  max-width: inherit;
+  min-width: inherit;
+  outline: inherit;
+  z-index: inherit;
+
+  /* Use unspecified default values from amp-sidebar element */
+  width: inherit;
+  padding: inherit;
+  border: inherit;
+
+  /* Children of amp-sidebar should be visible */
+  visibility: visible !important;
+}
+
+/** 
+ * Hide the amp-sidebar and remove from the flow of the page so user applied
+ * styling is not shown directly on amp-sidebar element.
+ */
+amp-sidebar {
+  visibility: hidden !important;
+  position: fixed !important;
 }

--- a/extensions/amp-sidebar/1.0/sidebar.js
+++ b/extensions/amp-sidebar/1.0/sidebar.js
@@ -42,9 +42,9 @@ const ANIMATION_KEYFRAMES_SLIDE_IN_RIGHT = [
 
 const ANIMATION_STYLES_SIDEBAR_LEFT_INIT = {'transform': 'translateX(-100%)'};
 const ANIMATION_STYLES_SIDEBAR_RIGHT_INIT = {'transform': 'translateX(100%)'};
-const ANIMATION_STYLES_MASK_INIT = {'opacity': '0'};
+const ANIMATION_STYLES_BACKDROP_INIT = {'opacity': '0'};
 const ANIMATION_STYLES_SIDEBAR_FINAL = {'transform': ''};
-const ANIMATION_STYLES_MASK_FINAL = {'opacity': ''};
+const ANIMATION_STYLES_BACKDROP_FINAL = {'opacity': ''};
 
 /**
  * @param {T} current
@@ -75,7 +75,8 @@ function SidebarWithRef(
     side = 'left',
     onBeforeOpen,
     onAfterClose,
-    maskStyle,
+    backdropStyle,
+    backdropClassName,
     children,
     ...rest
   },
@@ -89,7 +90,7 @@ function SidebarWithRef(
   const [opened, setOpened] = useState(false);
   const classes = useStyles();
   const sidebarRef = useRef();
-  const maskRef = useRef();
+  const backdropRef = useRef();
 
   // We are using refs here to refer to common strings, objects, and functions used.
   // This is because they are needed within `useEffect` calls below (but are not depended for triggering)
@@ -124,20 +125,20 @@ function SidebarWithRef(
 
   useLayoutEffect(() => {
     const sidebarElement = sidebarRef.current;
-    const maskElement = maskRef.current;
-    if (!sidebarElement || !maskElement) {
+    const backdropElement = backdropRef.current;
+    if (!sidebarElement || !backdropElement) {
       return;
     }
 
     let sidebarAnimation;
-    let maskAnimation;
+    let backdropAnimation;
     // "Make Visible" Animation
     if (opened) {
       const postVisibleAnim = () => {
         safelySetStyles(sidebarElement, ANIMATION_STYLES_SIDEBAR_FINAL);
-        safelySetStyles(maskElement, ANIMATION_STYLES_MASK_FINAL);
+        safelySetStyles(backdropElement, ANIMATION_STYLES_BACKDROP_FINAL);
       };
-      if (!sidebarElement.animate || !maskElement.animate) {
+      if (!sidebarElement.animate || !backdropElement.animate) {
         postVisibleAnim();
         return;
       }
@@ -148,7 +149,7 @@ function SidebarWithRef(
           ? ANIMATION_STYLES_SIDEBAR_LEFT_INIT
           : ANIMATION_STYLES_SIDEBAR_RIGHT_INIT
       );
-      safelySetStyles(maskElement, ANIMATION_STYLES_MASK_INIT);
+      safelySetStyles(backdropElement, ANIMATION_STYLES_BACKDROP_INIT);
       sidebarAnimation = sidebarElement.animate(
         side === 'left'
           ? ANIMATION_KEYFRAMES_SLIDE_IN_LEFT
@@ -160,7 +161,7 @@ function SidebarWithRef(
         }
       );
       sidebarAnimation.onfinish = postVisibleAnim;
-      maskAnimation = maskElement.animate(ANIMATION_KEYFRAMES_FADE_IN, {
+      backdropAnimation = backdropElement.animate(ANIMATION_KEYFRAMES_FADE_IN, {
         duration: ANIMATION_DURATION,
         fill: 'both',
         easing: ANIMATION_EASE_IN,
@@ -172,10 +173,10 @@ function SidebarWithRef(
           onAfterCloseRef.current();
         }
         sidebarAnimation = null;
-        maskAnimation = null;
+        backdropAnimation = null;
         setMounted(false);
       };
-      if (!sidebarElement.animate || !maskElement.animate) {
+      if (!sidebarElement.animate || !backdropElement.animate) {
         postInvisibleAnim();
         return;
       }
@@ -191,7 +192,7 @@ function SidebarWithRef(
         }
       );
       sidebarAnimation.onfinish = postInvisibleAnim;
-      maskAnimation = maskElement.animate(ANIMATION_KEYFRAMES_FADE_IN, {
+      backdropAnimation = backdropElement.animate(ANIMATION_KEYFRAMES_FADE_IN, {
         duration: ANIMATION_DURATION,
         direction: 'reverse',
         fill: 'both',
@@ -202,8 +203,8 @@ function SidebarWithRef(
       if (sidebarAnimation) {
         sidebarAnimation.cancel();
       }
-      if (maskAnimation) {
-        maskAnimation.cancel();
+      if (backdropAnimation) {
+        backdropAnimation.cancel();
       }
     };
   }, [opened, onAfterCloseRef, side]);
@@ -228,11 +229,13 @@ function SidebarWithRef(
           {children}
         </ContainWrapper>
         <div
-          ref={maskRef}
+          ref={backdropRef}
           onClick={() => close()}
-          part="mask"
-          style={maskStyle}
-          className={`${classes.maskClass} ${classes.defaultMaskStyles}`}
+          part="backdrop"
+          style={backdropStyle}
+          className={`${backdropClassName ?? ''} ${classes.backdropClass} ${
+            classes.defaultBackdropStyles
+          }`}
         ></div>
       </>
     )

--- a/extensions/amp-sidebar/1.0/sidebar.js
+++ b/extensions/amp-sidebar/1.0/sidebar.js
@@ -75,6 +75,7 @@ function SidebarWithRef(
     side = 'left',
     onBeforeOpen,
     onAfterClose,
+    maskStyle,
     children,
     ...rest
   },
@@ -216,9 +217,10 @@ function SidebarWithRef(
           size={false}
           layout={true}
           paint={true}
-          className={`${classes.sidebarClass} ${
-            side === 'left' ? classes.left : classes.right
-          }`}
+          part="sidebar"
+          wrapperClassName={`${classes.sidebarClass} ${
+            classes.defaultSidebarStyles
+          } ${side === 'left' ? classes.left : classes.right}`}
           role="menu"
           tabindex="-1"
           {...rest}
@@ -228,7 +230,9 @@ function SidebarWithRef(
         <div
           ref={maskRef}
           onClick={() => close()}
-          className={classes.maskClass}
+          part="mask"
+          style={maskStyle}
+          className={`${classes.maskClass} ${classes.defaultMaskStyles}`}
         ></div>
       </>
     )

--- a/extensions/amp-sidebar/1.0/sidebar.jss.js
+++ b/extensions/amp-sidebar/1.0/sidebar.jss.js
@@ -22,12 +22,17 @@ const sidebarClass = {
   maxHeight: '100vh !important',
   height: '100vh',
   maxWidth: '80vw',
-  backgroundColor: '#efefef',
   minWidth: '45px !important',
   outline: 'none',
   overflowX: 'hidden !important',
   overflowY: 'auto !important',
   zIndex: 2147483647,
+};
+
+// User overridable styles
+const defaultSidebarStyles = {
+  color: '#000000',
+  backgroundColor: '#efefef',
 };
 
 const left = {
@@ -46,13 +51,19 @@ const maskClass = {
   height: '100vh !important',
   /* Prevent someone from making this a full-sceen image */
   backgroundImage: 'none !important',
-  backgroundColor: 'rgba(0, 0, 0, 0.5)',
   zIndex: 2147483646,
+};
+
+// User overridable styles
+const defaultMaskStyles = {
+  backgroundColor: 'rgba(0, 0, 0, 0.5)',
 };
 
 const JSS = {
   sidebarClass,
+  defaultSidebarStyles,
   maskClass,
+  defaultMaskStyles,
   left,
   right,
 };

--- a/extensions/amp-sidebar/1.0/sidebar.jss.js
+++ b/extensions/amp-sidebar/1.0/sidebar.jss.js
@@ -26,6 +26,7 @@ const sidebarClass = {
   outline: 'none',
   overflowX: 'hidden !important',
   overflowY: 'auto !important',
+  boxSizing: 'border-box !important',
   zIndex: 2147483647,
 };
 
@@ -43,7 +44,7 @@ const right = {
   right: 0,
 };
 
-const maskClass = {
+const backdropClass = {
   position: 'fixed !important',
   top: '0 !important',
   left: '0 !important',
@@ -55,15 +56,15 @@ const maskClass = {
 };
 
 // User overridable styles
-const defaultMaskStyles = {
+const defaultBackdropStyles = {
   backgroundColor: 'rgba(0, 0, 0, 0.5)',
 };
 
 const JSS = {
   sidebarClass,
   defaultSidebarStyles,
-  maskClass,
-  defaultMaskStyles,
+  backdropClass,
+  defaultBackdropStyles,
   left,
   right,
 };

--- a/extensions/amp-sidebar/1.0/sidebar.jss.js
+++ b/extensions/amp-sidebar/1.0/sidebar.jss.js
@@ -18,22 +18,22 @@ import {createUseStyles} from 'react-jss';
 
 const sidebarClass = {
   position: 'fixed !important',
-  top: 0,
-  maxHeight: '100vh !important',
-  height: '100vh',
-  maxWidth: '80vw',
-  minWidth: '45px !important',
-  outline: 'none',
   overflowX: 'hidden !important',
   overflowY: 'auto !important',
   boxSizing: 'border-box !important',
-  zIndex: 2147483647,
 };
 
 // User overridable styles
 const defaultSidebarStyles = {
   color: '#000000',
   backgroundColor: '#efefef',
+  height: '100vh',
+  top: 0,
+  maxHeight: '100vh',
+  maxWidth: '80vw',
+  minWidth: '45px',
+  outline: 'none',
+  zIndex: 2147483647,
 };
 
 const left = {

--- a/extensions/amp-sidebar/1.0/sidebar.type.js
+++ b/extensions/amp-sidebar/1.0/sidebar.type.js
@@ -25,7 +25,8 @@ var SidebarDef = {};
  *   side: (string|undefined),
  *   onBeforeOpen: (function|undefined),
  *   onAfterClose: (function|undefined),
- *   maskStyle: (?Object|undefined),
+ *   backdropStyle: (?Object|undefined),
+ *   backdropClassName: (string|undefined),
  *   children: (?PreactDef.Renderable|undefined),
  * }}
  */

--- a/extensions/amp-sidebar/1.0/sidebar.type.js
+++ b/extensions/amp-sidebar/1.0/sidebar.type.js
@@ -25,6 +25,7 @@ var SidebarDef = {};
  *   side: (string|undefined),
  *   onBeforeOpen: (function|undefined),
  *   onAfterClose: (function|undefined),
+ *   maskStyle: (?Object|undefined),
  *   children: (?PreactDef.Renderable|undefined),
  * }}
  */

--- a/extensions/amp-sidebar/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-sidebar/1.0/storybook/Basic.amp.js
@@ -104,7 +104,7 @@ export const styles = () => {
               border: ${border};
               top: ${top};
               max-height: ${maxHeight} !important;
-              max-width: ${maxWidth} !important;
+              max-width: ${maxWidth};
               min-width: ${minWidth} !important;
               outline: ${outline};
               z-index: ${zIndex};

--- a/extensions/amp-sidebar/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-sidebar/1.0/storybook/Basic.amp.js
@@ -34,6 +34,51 @@ export const _default = () => {
   const side = select('side', sideConfigurations, sideConfigurations[0]);
   const foregroundColor = color('color');
   const backgroundColor = color('background');
+  const backdropColor = color('backdrop color');
+
+  return (
+    <main>
+      <style>
+        {`
+          amp-sidebar {
+              color: ${foregroundColor};
+              background-color: ${backgroundColor};
+          }
+          amp-sidebar::part(backdrop) {
+              background-color: ${backdropColor};
+          }
+          `}
+      </style>
+      <amp-sidebar layout="nodisplay" id="sidebar" side={side}>
+        <div style={{margin: 8}}>
+          <span>
+            Lorem ipsum dolor sit amet, has nisl nihil convenire et, vim at
+            aeque inermis reprehendunt.
+          </span>
+          <ul>
+            <li>1</li>
+            <li>2</li>
+            <li>3</li>
+          </ul>
+          <button on="tap:sidebar.toggle()">toggle</button>
+          <button on="tap:sidebar.open()">open</button>
+          <button on="tap:sidebar.close()">close</button>
+        </div>
+      </amp-sidebar>
+      <div class="buttons" style={{margin: 8}}>
+        <button on="tap:sidebar.toggle()">toggle</button>
+        <button on="tap:sidebar.open()">open</button>
+        <button on="tap:sidebar.close()">close</button>
+      </div>
+    </main>
+  );
+};
+
+export const styles = () => {
+  const sideConfigurations = ['left', 'right', undefined];
+  const side = select('side', sideConfigurations, sideConfigurations[0]);
+  const foregroundColor = color('color');
+  const backgroundColor = color('background');
   const height = text('height', null);
   const width = text('width', null);
   const padding = text('padding', null);

--- a/extensions/amp-sidebar/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-sidebar/1.0/storybook/Basic.amp.js
@@ -31,10 +31,10 @@ export default {
 
 export const _default = () => {
   const sideConfigurations = ['left', 'right', undefined];
-  const side = select('type', sideConfigurations, sideConfigurations[0]);
+  const side = select('side', sideConfigurations, sideConfigurations[0]);
   const foregroundColor = color('color');
   const backgroundColor = color('background');
-  const maskBackgroundColor = color('mask color');
+  const backdropColor = color('backdrop color');
   return (
     <main>
       <style>
@@ -43,8 +43,8 @@ export const _default = () => {
               color: ${foregroundColor};
               background-color: ${backgroundColor};
           }
-          amp-sidebar::part(mask) {
-              background-color: ${maskBackgroundColor};
+          amp-sidebar::part(backdrop) {
+              background-color: ${backdropColor};
           }
           `}
       </style>

--- a/extensions/amp-sidebar/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-sidebar/1.0/storybook/Basic.amp.js
@@ -15,7 +15,7 @@
  */
 
 import * as Preact from '../../../../src/preact';
-import {select, withKnobs} from '@storybook/addon-knobs';
+import {color, select, withKnobs} from '@storybook/addon-knobs';
 import {withA11y} from '@storybook/addon-a11y';
 import {withAmp} from '@ampproject/storybook-addon';
 
@@ -32,8 +32,22 @@ export default {
 export const _default = () => {
   const sideConfigurations = ['left', 'right', undefined];
   const side = select('type', sideConfigurations, sideConfigurations[0]);
+  const foregroundColor = color('color');
+  const backgroundColor = color('background');
+  const maskBackgroundColor = color('mask color');
   return (
     <main>
+      <style>
+        {`
+          amp-sidebar {
+              color: ${foregroundColor};
+              background-color: ${backgroundColor};
+          }
+          amp-sidebar::part(mask) {
+              background-color: ${maskBackgroundColor};
+          }
+          `}
+      </style>
       <amp-sidebar id="sidebar" side={side}>
         <div style={{margin: 8}}>
           <span>

--- a/extensions/amp-sidebar/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-sidebar/1.0/storybook/Basic.amp.js
@@ -15,7 +15,7 @@
  */
 
 import * as Preact from '../../../../src/preact';
-import {color, select, withKnobs} from '@storybook/addon-knobs';
+import {color, number, select, text, withKnobs} from '@storybook/addon-knobs';
 import {withA11y} from '@storybook/addon-a11y';
 import {withAmp} from '@ampproject/storybook-addon';
 
@@ -34,7 +34,18 @@ export const _default = () => {
   const side = select('side', sideConfigurations, sideConfigurations[0]);
   const foregroundColor = color('color');
   const backgroundColor = color('background');
+  const height = text('height', null);
+  const width = text('width', null);
+  const padding = text('padding', null);
+  const border = text('border', null);
+  const top = text('top', null);
+  const maxHeight = text('max-height', null);
+  const maxWidth = text('max-width', null);
+  const minWidth = text('min-width', null);
+  const outline = text('outline', null);
+  const zIndex = number('z-index', 2147483647);
   const backdropColor = color('backdrop color');
+
   return (
     <main>
       <style>
@@ -42,13 +53,23 @@ export const _default = () => {
           amp-sidebar {
               color: ${foregroundColor};
               background-color: ${backgroundColor};
+              height: ${height};
+              width: ${width};
+              padding: ${padding};
+              border: ${border};
+              top: ${top};
+              max-height: ${maxHeight} !important;
+              max-width: ${maxWidth} !important;
+              min-width: ${minWidth} !important;
+              outline: ${outline};
+              z-index: ${zIndex};
           }
           amp-sidebar::part(backdrop) {
               background-color: ${backdropColor};
           }
           `}
       </style>
-      <amp-sidebar id="sidebar" side={side}>
+      <amp-sidebar layout="nodisplay" id="sidebar" side={side}>
         <div style={{margin: 8}}>
           <span>
             Lorem ipsum dolor sit amet, has nisl nihil convenire et, vim at

--- a/extensions/amp-sidebar/1.0/storybook/Basic.js
+++ b/extensions/amp-sidebar/1.0/storybook/Basic.js
@@ -16,7 +16,7 @@
 
 import * as Preact from '../../../../src/preact';
 import {Sidebar} from '../sidebar';
-import {select, withKnobs} from '@storybook/addon-knobs';
+import {color, select, withKnobs} from '@storybook/addon-knobs';
 import {withA11y} from '@storybook/addon-a11y';
 
 export default {
@@ -63,9 +63,17 @@ function SidebarWithActions(props) {
 export const _default = () => {
   const sideConfigurations = ['left', 'right', undefined];
   const side = select('type', sideConfigurations, sideConfigurations[0]);
+  const foregroundColor = color('color');
+  const backgroundColor = color('background');
+  const maskBackgroundColor = color('mask color');
+
   return (
     <main>
-      <SidebarWithActions side={side} />
+      <SidebarWithActions
+        side={side}
+        style={{color: foregroundColor, backgroundColor}}
+        maskStyle={{backgroundColor: maskBackgroundColor}}
+      />
     </main>
   );
 };

--- a/extensions/amp-sidebar/1.0/storybook/Basic.js
+++ b/extensions/amp-sidebar/1.0/storybook/Basic.js
@@ -62,17 +62,17 @@ function SidebarWithActions(props) {
 
 export const _default = () => {
   const sideConfigurations = ['left', 'right', undefined];
-  const side = select('type', sideConfigurations, sideConfigurations[0]);
+  const side = select('side', sideConfigurations, sideConfigurations[0]);
   const foregroundColor = color('color');
   const backgroundColor = color('background');
-  const maskBackgroundColor = color('mask color');
+  const backdropColor = color('backdrop color');
 
   return (
     <main>
       <SidebarWithActions
         side={side}
         style={{color: foregroundColor, backgroundColor}}
-        maskStyle={{backgroundColor: maskBackgroundColor}}
+        backdropStyle={{backgroundColor: backdropColor}}
       />
     </main>
   );

--- a/extensions/amp-sidebar/1.0/test/test-amp-sidebar.js
+++ b/extensions/amp-sidebar/1.0/test/test-amp-sidebar.js
@@ -183,6 +183,63 @@ describes.realWin(
         expect(sidebarChildren.lastElementChild.children.length).to.equal(3);
       });
 
+      it('should render with default colors', async () => {
+        // open the sidebar
+        openButton.click();
+        await waitForOpen(element, true);
+        expect(element).to.have.attribute('open');
+
+        const {
+          firstElementChild: sidebarElement,
+          lastElementChild: maskElement,
+        } = container;
+
+        expect(win.getComputedStyle(sidebarElement).color).to.equal(
+          'rgb(0, 0, 0)'
+        );
+        expect(win.getComputedStyle(sidebarElement).backgroundColor).to.equal(
+          'rgb(239, 239, 239)'
+        );
+        expect(win.getComputedStyle(maskElement).backgroundColor).to.equal(
+          'rgba(0, 0, 0, 0.5)'
+        );
+      });
+
+      it('should allow custom colors', async () => {
+        const style = html`
+          <style>
+            amp-sidebar {
+              color: rgb(1, 1, 1);
+              background-color: rgb(2, 2, 2);
+            }
+            amp-sidebar::part(mask) {
+              background-color: rgb(3, 3, 3);
+            }
+          </style>
+        `;
+        fullHtml.appendChild(style);
+
+        // open the sidebar
+        openButton.click();
+        await waitForOpen(element, true);
+        expect(element).to.have.attribute('open');
+
+        const {
+          firstElementChild: sidebarElement,
+          lastElementChild: maskElement,
+        } = container;
+
+        expect(win.getComputedStyle(sidebarElement).color).to.equal(
+          'rgb(1, 1, 1)'
+        );
+        expect(win.getComputedStyle(sidebarElement).backgroundColor).to.equal(
+          'rgb(2, 2, 2)'
+        );
+        expect(win.getComputedStyle(maskElement).backgroundColor).to.equal(
+          'rgb(3, 3, 3)'
+        );
+      });
+
       describe('programatic access to imperative API', () => {
         it('open', async () => {
           // sidebar is initially closed

--- a/extensions/amp-sidebar/1.0/test/test-amp-sidebar.js
+++ b/extensions/amp-sidebar/1.0/test/test-amp-sidebar.js
@@ -291,10 +291,8 @@ describes.realWin(
           `${win.innerHeight}px`
         );
 
-        // maxWidth defaults to 80vw, so should be 80% of viewport width
-        expect(win.getComputedStyle(sidebarElement).maxWidth).to.equal(
-          `${win.innerWidth * 0.8}px`
-        );
+        // maxWidth is not set as !important so is overridable
+        expect(win.getComputedStyle(sidebarElement).maxWidth).to.equal(`600px`);
 
         // 45px is default, user supplied 200px does not overwrite w/o !important
         expect(win.getComputedStyle(sidebarElement).minWidth).to.equal('45px');

--- a/extensions/amp-sidebar/1.0/test/test-amp-sidebar.js
+++ b/extensions/amp-sidebar/1.0/test/test-amp-sidebar.js
@@ -139,13 +139,13 @@ describes.realWin(
         expect(container.children.length).to.equal(0);
       });
 
-      it('should close when the mask is clicked', async () => {
+      it('should close when the backdrop is clicked', async () => {
         element.enqueAction(invocation('open'));
         await waitForOpen(element, true);
 
         expect(container.children.length).to.equal(2);
-        const mask = container.children[1];
-        mask.click();
+        const backdrop = container.children[1];
+        backdrop.click();
 
         await waitForOpen(element, false);
 
@@ -191,7 +191,7 @@ describes.realWin(
 
         const {
           firstElementChild: sidebarElement,
-          lastElementChild: maskElement,
+          lastElementChild: backdropElement,
         } = container;
 
         expect(win.getComputedStyle(sidebarElement).color).to.equal(
@@ -200,19 +200,29 @@ describes.realWin(
         expect(win.getComputedStyle(sidebarElement).backgroundColor).to.equal(
           'rgb(239, 239, 239)'
         );
-        expect(win.getComputedStyle(maskElement).backgroundColor).to.equal(
+        expect(win.getComputedStyle(backdropElement).backgroundColor).to.equal(
           'rgba(0, 0, 0, 0.5)'
         );
       });
 
-      it('should allow custom colors', async () => {
+      it('should reflect user supplied CSS for various properties', async () => {
         const style = html`
           <style>
             amp-sidebar {
               color: rgb(1, 1, 1);
               background-color: rgb(2, 2, 2);
+              height: 300px;
+              width: 301px;
+              padding: 15px;
+              border: solid 1px black;
+              top: 10px;
+              max-height: 500px !important;
+              max-width: 600px !important;
+              min-width: 200px !important;
+              outline: solid 1px red;
+              z-index: 15;
             }
-            amp-sidebar::part(mask) {
+            amp-sidebar::part(backdrop) {
               background-color: rgb(3, 3, 3);
             }
           </style>
@@ -226,7 +236,7 @@ describes.realWin(
 
         const {
           firstElementChild: sidebarElement,
-          lastElementChild: maskElement,
+          lastElementChild: backdropElement,
         } = container;
 
         expect(win.getComputedStyle(sidebarElement).color).to.equal(
@@ -235,9 +245,59 @@ describes.realWin(
         expect(win.getComputedStyle(sidebarElement).backgroundColor).to.equal(
           'rgb(2, 2, 2)'
         );
-        expect(win.getComputedStyle(maskElement).backgroundColor).to.equal(
+        expect(win.getComputedStyle(sidebarElement).height).to.equal('300px');
+        expect(win.getComputedStyle(sidebarElement).width).to.equal('301px');
+        expect(win.getComputedStyle(sidebarElement).padding).to.equal('15px');
+        expect(win.getComputedStyle(sidebarElement).border).to.equal(
+          '1px solid rgb(0, 0, 0)'
+        );
+        expect(win.getComputedStyle(sidebarElement).top).to.equal('10px');
+        expect(win.getComputedStyle(sidebarElement).maxHeight).to.equal(
+          '500px'
+        );
+        expect(win.getComputedStyle(sidebarElement).maxWidth).to.equal('600px');
+        expect(win.getComputedStyle(sidebarElement).minWidth).to.equal('200px');
+        expect(win.getComputedStyle(sidebarElement).outline).to.equal(
+          'rgb(255, 0, 0) solid 1px'
+        );
+        expect(win.getComputedStyle(sidebarElement).zIndex).to.equal('15');
+
+        expect(win.getComputedStyle(backdropElement).backgroundColor).to.equal(
           'rgb(3, 3, 3)'
         );
+      });
+
+      it('should not update some CSS properties w/o !important', async () => {
+        const style = html`
+          <style>
+            amp-sidebar {
+              max-height: 500px;
+              max-width: 600px;
+              min-width: 200px;
+            }
+          </style>
+        `;
+        fullHtml.appendChild(style);
+
+        // open the sidebar
+        openButton.click();
+        await waitForOpen(element, true);
+        expect(element).to.have.attribute('open');
+
+        const {firstElementChild: sidebarElement} = container;
+
+        // maxHeight defaults to 100vh, so should be the same height as viewport
+        expect(win.getComputedStyle(sidebarElement).maxHeight).to.equal(
+          `${win.innerHeight}px`
+        );
+
+        // maxWidth defaults to 80vw, so should be 80% of viewport width
+        expect(win.getComputedStyle(sidebarElement).maxWidth).to.equal(
+          `${win.innerWidth * 0.8}px`
+        );
+
+        // 45px is default, user supplied 200px does not overwrite w/o !important
+        expect(win.getComputedStyle(sidebarElement).minWidth).to.equal('45px');
       });
 
       describe('programatic access to imperative API', () => {
@@ -403,7 +463,7 @@ describes.realWin(
         openButton.click();
         await waitForOpen(element, true);
 
-        // once for mask, once for sidebar
+        // once for backdrop, once for sidebar
         expect(animateStub).to.be.calledTwice;
         animation.onfinish();
 
@@ -432,7 +492,7 @@ describes.realWin(
         closeButton.click();
         await waitFor(() => animateStub.callCount > 0, 'animation started');
 
-        // once for mask, once for sidebar
+        // once for backdrop, once for sidebar
         expect(animateStub).to.be.calledTwice;
 
         // still displayed while animating

--- a/extensions/amp-sidebar/1.0/test/test-sidebar.js
+++ b/extensions/amp-sidebar/1.0/test/test-sidebar.js
@@ -74,6 +74,48 @@ describes.sandboxed('Sidebar preact component', {}, (env) => {
       expect(contentElement.textContent).to.equal('Content');
     });
 
+    it('should render with default colors', () => {
+      openButton.getDOMNode().click();
+      wrapper.update();
+
+      const sidebarElement = wrapper.find(Sidebar).getDOMNode();
+      const maskElement = sidebarElement.nextSibling;
+
+      expect(sidebarElement.className.includes('default')).to.be.true;
+      expect(maskElement.className.includes('default')).to.be.true;
+      expect(sidebarElement.style.color).to.equal('');
+      expect(sidebarElement.style.backgroundColor).to.equal('');
+      expect(maskElement.style.backgroundColor).to.equal('');
+    });
+
+    it('should allow custom colors', () => {
+      wrapper = mount(
+        <>
+          <Sidebar
+            ref={ref}
+            side="left"
+            style={{color: 'rgb(1, 1, 1)', backgroundColor: 'rgb(2, 2, 2)'}}
+            maskStyle={{backgroundColor: 'rgb(3, 3, 3)'}}
+          >
+            <div>Content</div>
+          </Sidebar>
+          <button id="toggle" onClick={() => ref.current.toggle()}></button>
+          <button id="open" onClick={() => ref.current.open()}></button>
+          <button id="close" onClick={() => ref.current.close()}></button>
+        </>
+      );
+      openButton = wrapper.find('#open');
+      openButton.getDOMNode().click();
+      wrapper.update();
+
+      const sidebarElement = wrapper.find(Sidebar).getDOMNode();
+      const maskElement = sidebarElement.nextSibling;
+
+      expect(sidebarElement.style.color).to.equal('rgb(1, 1, 1)');
+      expect(sidebarElement.style.backgroundColor).to.equal('rgb(2, 2, 2)');
+      expect(maskElement.style.backgroundColor).to.equal('rgb(3, 3, 3)');
+    });
+
     it('should allow for the sidebar on the right side', () => {
       ref = Preact.createRef();
       wrapper = mount(

--- a/extensions/amp-sidebar/1.0/test/test-sidebar.js
+++ b/extensions/amp-sidebar/1.0/test/test-sidebar.js
@@ -53,12 +53,12 @@ describes.sandboxed('Sidebar preact component', {}, (env) => {
       Element.prototype.animate = animateFunction;
     });
 
-    it('close the sidebar when the mask is clicked', () => {
+    it('close the sidebar when the backdrop is clicked', () => {
       openButton.getDOMNode().click();
       wrapper.update();
 
-      const maskElement = wrapper.find(Sidebar).getDOMNode().nextSibling;
-      maskElement.click();
+      const backdropElement = wrapper.find(Sidebar).getDOMNode().nextSibling;
+      backdropElement.click();
       wrapper.update();
 
       // Sidebar closes
@@ -79,23 +79,33 @@ describes.sandboxed('Sidebar preact component', {}, (env) => {
       wrapper.update();
 
       const sidebarElement = wrapper.find(Sidebar).getDOMNode();
-      const maskElement = sidebarElement.nextSibling;
+      const backdropElement = sidebarElement.nextSibling;
 
       expect(sidebarElement.className.includes('default')).to.be.true;
-      expect(maskElement.className.includes('default')).to.be.true;
+      expect(backdropElement.className.includes('default')).to.be.true;
       expect(sidebarElement.style.color).to.equal('');
       expect(sidebarElement.style.backgroundColor).to.equal('');
-      expect(maskElement.style.backgroundColor).to.equal('');
+      expect(backdropElement.style.backgroundColor).to.equal('');
     });
 
-    it('should allow custom colors', () => {
+    it('should allow custom CSS', () => {
       wrapper = mount(
         <>
           <Sidebar
             ref={ref}
             side="left"
-            style={{color: 'rgb(1, 1, 1)', backgroundColor: 'rgb(2, 2, 2)'}}
-            maskStyle={{backgroundColor: 'rgb(3, 3, 3)'}}
+            style={{
+              color: 'rgb(1, 1, 1)',
+              backgroundColor: 'rgb(2, 2, 2)',
+              height: '300px',
+              top: '15px',
+              maxHeight: '400px',
+              maxWidth: '500px',
+              minWidth: '200px',
+              outline: '1px solid red',
+              zIndex: 30,
+            }}
+            backdropStyle={{backgroundColor: 'rgb(3, 3, 3)'}}
           >
             <div>Content</div>
           </Sidebar>
@@ -109,11 +119,18 @@ describes.sandboxed('Sidebar preact component', {}, (env) => {
       wrapper.update();
 
       const sidebarElement = wrapper.find(Sidebar).getDOMNode();
-      const maskElement = sidebarElement.nextSibling;
+      const backdropElement = sidebarElement.nextSibling;
 
       expect(sidebarElement.style.color).to.equal('rgb(1, 1, 1)');
       expect(sidebarElement.style.backgroundColor).to.equal('rgb(2, 2, 2)');
-      expect(maskElement.style.backgroundColor).to.equal('rgb(3, 3, 3)');
+      expect(sidebarElement.style.height).to.equal('300px');
+      expect(sidebarElement.style.top).to.equal('15px');
+      expect(sidebarElement.style.maxHeight).to.equal('400px');
+      expect(sidebarElement.style.maxWidth).to.equal('500px');
+      expect(sidebarElement.style.minWidth).to.equal('200px');
+      expect(sidebarElement.style.outline).to.equal('red solid 1px');
+      expect(sidebarElement.style.zIndex).to.equal('30');
+      expect(backdropElement.style.backgroundColor).to.equal('rgb(3, 3, 3)');
     });
 
     it('should allow for the sidebar on the right side', () => {
@@ -325,14 +342,14 @@ describes.sandboxed('Sidebar preact component', {}, (env) => {
       expect(sidebar.getDOMNode()).to.not.be.null;
 
       // Animation has been started
-      // One call each for the mask and the sidebar
+      // One call each for the backdrop and the sidebar
       expect(animateStub).to.be.calledTwice;
 
       const sidebarKeyframes = animateStub.firstCall.firstArg;
-      const maskKeyframes = animateStub.secondCall.firstArg;
+      const backdropKeyframes = animateStub.secondCall.firstArg;
 
       const sidebarOptions = animateStub.firstCall.args[1];
-      const maskOptions = animateStub.secondCall.args[1];
+      const backdropOptions = animateStub.secondCall.args[1];
 
       expect(sidebarKeyframes[0].transform).to.equal('translateX(-100%)');
       expect(sidebarKeyframes[1].transform).to.equal('translateX(0)');
@@ -340,11 +357,11 @@ describes.sandboxed('Sidebar preact component', {}, (env) => {
       expect(sidebarOptions.easing).to.equal('cubic-bezier(0,0,.21,1)');
       expect(sidebarOptions.fill).to.equal('both');
 
-      expect(maskKeyframes[0].opacity).to.equal('0');
-      expect(maskKeyframes[1].opacity).to.equal('1');
-      expect(maskOptions.duration).to.equal(350);
-      expect(maskOptions.easing).to.equal('cubic-bezier(0,0,.21,1)');
-      expect(maskOptions.fill).to.equal('both');
+      expect(backdropKeyframes[0].opacity).to.equal('0');
+      expect(backdropKeyframes[1].opacity).to.equal('1');
+      expect(backdropOptions.duration).to.equal(350);
+      expect(backdropOptions.easing).to.equal('cubic-bezier(0,0,.21,1)');
+      expect(backdropOptions.fill).to.equal('both');
     });
 
     it('should animate when sidebar closes', () => {
@@ -375,14 +392,14 @@ describes.sandboxed('Sidebar preact component', {}, (env) => {
       expect(sidebar.getDOMNode()).to.not.be.null;
 
       // Animation has been started
-      // One call each for the mask and the sidebar
+      // One call each for the backdrop and the sidebar
       expect(animateStub).to.be.calledTwice;
 
       const sidebarKeyframes = animateStub.firstCall.firstArg;
-      const maskKeyframes = animateStub.secondCall.firstArg;
+      const backdropKeyframes = animateStub.secondCall.firstArg;
 
       const sidebarOptions = animateStub.firstCall.args[1];
-      const maskOptions = animateStub.secondCall.args[1];
+      const backdropOptions = animateStub.secondCall.args[1];
 
       expect(sidebarKeyframes[0].transform).to.equal('translateX(-100%)');
       expect(sidebarKeyframes[1].transform).to.equal('translateX(0)');
@@ -391,12 +408,12 @@ describes.sandboxed('Sidebar preact component', {}, (env) => {
       expect(sidebarOptions.easing).to.equal('cubic-bezier(0,0,.21,1)');
       expect(sidebarOptions.fill).to.equal('both');
 
-      expect(maskKeyframes[0].opacity).to.equal('0');
-      expect(maskKeyframes[1].opacity).to.equal('1');
-      expect(maskOptions.direction).to.equal('reverse');
-      expect(maskOptions.duration).to.equal(350);
-      expect(maskOptions.easing).to.equal('cubic-bezier(0,0,.21,1)');
-      expect(maskOptions.fill).to.equal('both');
+      expect(backdropKeyframes[0].opacity).to.equal('0');
+      expect(backdropKeyframes[1].opacity).to.equal('1');
+      expect(backdropOptions.direction).to.equal('reverse');
+      expect(backdropOptions.duration).to.equal(350);
+      expect(backdropOptions.easing).to.equal('cubic-bezier(0,0,.21,1)');
+      expect(backdropOptions.fill).to.equal('both');
 
       // Cleanup the animation.
       animation.onfinish();
@@ -419,13 +436,13 @@ describes.sandboxed('Sidebar preact component', {}, (env) => {
       openButton.simulate('click');
 
       // Animation has been started
-      // One call each for the mask and the sidebar
+      // One call each for the backdrop and the sidebar
       expect(animateStub).to.be.calledTwice;
 
       // Click to close the sidebar and cancel the animation
       closeButton.simulate('click');
 
-      // Expect cancel to be called twice (once for mask and once for sidebar)
+      // Expect cancel to be called twice (once for backdrop and once for sidebar)
       expect(animation.cancel).to.be.calledTwice;
     });
 


### PR DESCRIPTION
1/15

- Added updates to tests

Overview of PR:
1. Have included multiple configurable CSS properties for sidebar listed below:

- color
- background-color
- height
- --story-page-vh
- top
- max-height
- max-width
- min-width
- outline
- z-index
- width
- padding
- border

2. In amp mode these can be directly controlled by user supplied CSS
```
         amp-sidebar {
              color: ${foregroundColor};
              background-color: ${backgroundColor};
          }
          amp-sidebar::part(backdrop) {
              background-color: ${maskBackgroundColor};
          }
```

3. In preact mode pass in a style object as the `style` and `backdropStyle` props.  To have the style included inline in the rendered element.
```
      <Sidebar 
        style={{color: foregroundColor, backgroundColor: someColor}}
        backdropStyle={{backgroundColor: someColor}}
      />
```

*******

12/18
- Added additional styles that user can configure
- Updated amp storybook

To do: 
1. Update Preact storybook
2. Add tests

*******

Add feature to customize colors in amp-sidebar
1. sidebar color - customize the color of text in the sidebar
2. sidebar background - customize the color of the background in the sidebar
3. mask color - customize the mask color

To change these in amp mode include the following css:
```
         amp-sidebar {
              color: ${foregroundColor};
              background-color: ${backgroundColor};
          }
          amp-sidebar::part(mask) {
              background-color: ${maskBackgroundColor};
          }
```

To change these in preact mode include the following props:
```
      <Sidebar 
        style={{color: foregroundColor, backgroundColor: someColor}}
        maskStyle={{backgroundColor: someColor}}
      />
```

Open Questions:
1. Should we make the customizing the mask and sidebar symmetric in amp mode? (same syntax) (i.e. to change sidebar color use a CSS selector like `amp-sidebar::part(sidebar)`)

Answer: no, the current is an existing pattern, see: https://jsbin.com/nawecap/edit?html,css,output