### PR TITLE
🐛 Spread data object in navigator.share

### DIFF
--- a/extensions/amp-social-share/0.1/amp-social-share.js
+++ b/extensions/amp-social-share/0.1/amp-social-share.js
@@ -201,6 +201,7 @@ class AmpSocialShare extends AMP.BaseElement {
       const dataStr = href.substr(href.indexOf('?'));
       const data = parseQueryString(dataStr);
       // Spreading data into an Object since Chrome uses the Object prototype.
+      // TODO:(crbug.com/1123689): Remove this workaround once WebKit fix is released.
       navigator.share({...data}).catch((e) => {
         user().warn(TAG, e.message, dataStr);
       });

--- a/extensions/amp-social-share/0.1/amp-social-share.js
+++ b/extensions/amp-social-share/0.1/amp-social-share.js
@@ -200,7 +200,7 @@ class AmpSocialShare extends AMP.BaseElement {
       devAssert(navigator.share);
       const dataStr = href.substr(href.indexOf('?'));
       const data = parseQueryString(dataStr);
-      navigator.share(data).catch((e) => {
+      navigator.share({...data}).catch((e) => {
         user().warn(TAG, e.message, dataStr);
       });
     } else {

--- a/extensions/amp-social-share/0.1/amp-social-share.js
+++ b/extensions/amp-social-share/0.1/amp-social-share.js
@@ -200,6 +200,7 @@ class AmpSocialShare extends AMP.BaseElement {
       devAssert(navigator.share);
       const dataStr = href.substr(href.indexOf('?'));
       const data = parseQueryString(dataStr);
+      // Spreading data into an object since Chrome uses the Object prototype.
       navigator.share({...data}).catch((e) => {
         user().warn(TAG, e.message, dataStr);
       });

--- a/extensions/amp-social-share/0.1/amp-social-share.js
+++ b/extensions/amp-social-share/0.1/amp-social-share.js
@@ -200,7 +200,7 @@ class AmpSocialShare extends AMP.BaseElement {
       devAssert(navigator.share);
       const dataStr = href.substr(href.indexOf('?'));
       const data = parseQueryString(dataStr);
-      // Spreading data into an object since Chrome uses the Object prototype.
+      // Spreading data into an Object since Chrome uses the Object prototype.
       navigator.share({...data}).catch((e) => {
         user().warn(TAG, e.message, dataStr);
       });


### PR DESCRIPTION
Chrome appears to use stuff from the Object prototype, which isn't present in the JsonObject returned from `parseQueryString_`. 


Context / Fixes #30302 