### PR TITLE
🏗🐛 Fix core_runtime_only with extensions build

### DIFF
--- a/build-system/tasks/extension-helpers.js
+++ b/build-system/tasks/extension-helpers.js
@@ -178,10 +178,7 @@ function getExtensionsToBuild(preBuild = false) {
   if (extensionsToBuild) {
     return extensionsToBuild;
   }
-  if (argv.core_runtime_only) {
-    return (extensionsToBuild = []);
-  }
-  extensionsToBuild = DEFAULT_EXTENSION_SET;
+  extensionsToBuild = argv.core_runtime_only ? [] : DEFAULT_EXTENSION_SET;
   if (argv.extensions) {
     if (typeof argv.extensions !== 'string') {
       log(red('ERROR:'), 'Missing list of extensions.');
@@ -200,7 +197,8 @@ function getExtensionsToBuild(preBuild = false) {
     !preBuild &&
     !argv.noextensions &&
     !argv.extensions &&
-    !argv.extensions_from
+    !argv.extensions_from &&
+    !argv.core_runtime_only
   ) {
     const allExtensions = [];
     for (const extension in extensions) {


### PR DESCRIPTION
The main intention was to not build the default extensions when using `--core_runtime_only`, but I accidentally prevented you from specifying `--extensions=foo`.

Fixes https://github.com/ampproject/amphtml/pull/31602/files/748f5a1b406a6d0723a09355d8868fc6f4735327#r544582134