### PR TITLE
🐛 Align panels desktop pagination panels

### DIFF
--- a/extensions/amp-story/1.0/amp-story-desktop-panels.css
+++ b/extensions/amp-story/1.0/amp-story-desktop-panels.css
@@ -75,12 +75,12 @@ amp-story[standalone].i-amphtml-story-desktop-panels {
 
 .i-amphtml-story-desktop-panels .prev-container,
 [dir=rtl] .i-amphtml-story-desktop-panels .next-container {
-  left: calc(50% - var(--i-amphtml-story-page-50vw, 50%) * var(--i-amphtml-story-inactive-page-scale-factor) * 3 - 64px) !important;
+  left: calc(50% - var(--i-amphtml-story-page-50vw, 50%) * var(--i-amphtml-story-inactive-page-scale-factor) * 3 - 64px * var(--i-amphtml-story-inactive-page-scale-factor)) !important;
 }
 
 .i-amphtml-story-desktop-panels .next-container,
 [dir=rtl] .i-amphtml-story-desktop-panels .prev-container {
-  left: calc(var(--i-amphtml-story-page-50vw, 50%) * var(--i-amphtml-story-inactive-page-scale-factor) + 50% + 64px) !important;
+  left: calc(var(--i-amphtml-story-page-50vw, 50%) * var(--i-amphtml-story-inactive-page-scale-factor) + 50% + 64px * var(--i-amphtml-story-inactive-page-scale-factor)) !important;
 }
 
 .i-amphtml-story-desktop-panels amp-story-page[active] + amp-story-page:not([i-amphtml-desktop-position]):not([distance]), /** Position n+1 page on load, before attributes are set. */


### PR DESCRIPTION
Scales pixel offset by scale factor.

Context / Fixes #31027

before, after screenshot:
<img width="858" alt="Screen Shot 2020-12-16 at 5 18 42 PM" src="https://user-images.githubusercontent.com/3860311/102413372-cff3d180-3fc2-11eb-9647-57d5e742db2e.png">
