### PR TITLE
🏗 Make test status reporting work across CI services

### DIFF
--- a/build-system/common/ci.js
+++ b/build-system/common/ci.js
@@ -108,7 +108,7 @@ function ciPullRequestBranch() {
   return isTravis
     ? env('TRAVIS_PULL_REQUEST_BRANCH')
     : isGithubActions
-    ? env('GITHUB_HEAD_REF') // TODO(rsimha): Truncate if necessary.
+    ? env('GITHUB_HEAD_REF')
     : isCircleci
     ? env('CIRCLE_BRANCH')
     : '';
@@ -122,7 +122,7 @@ function ciPullRequestSha() {
   return isTravis
     ? env('TRAVIS_PULL_REQUEST_SHA')
     : isGithubActions
-    ? env('GITHUB_SHA')
+    ? require(env('GITHUB_EVENT_PATH')).pull_request.head.sha
     : isCircleci
     ? env('CIRCLE_SHA1')
     : '';
@@ -136,7 +136,7 @@ function ciPushBranch() {
   return isTravis
     ? env('TRAVIS_BRANCH')
     : isGithubActions
-    ? env('GITHUB_REF') // TODO(rsimha): Truncate if necessary.
+    ? env('GITHUB_REF')
     : isCircleci
     ? env('CIRCLE_BRANCH')
     : '';

--- a/build-system/common/ci.js
+++ b/build-system/common/ci.js
@@ -206,7 +206,8 @@ function ciJobUrl() {
   return isTravis
     ? env('TRAVIS_JOB_WEB_URL')
     : isGithubActions
-    ? `${env('GITHUB_SERVER_URL')}/${env('GITHUB_REPOSITORY')}/runs/${env('GITHUB_RUN_NUMBER')}` // prettier-ignore
+    ? // TODO(rsimha): Try to reverse engineer the GH Actions job URL from the build URL.
+      `${env('GITHUB_SERVER_URL')}/${env('GITHUB_REPOSITORY')}/actions/runs/${env('GITHUB_RUN_ID')}` // prettier-ignore
     : isCircleci
     ? env('CIRCLE_BUILD_URL') // TODO(rsimha): Test and modify if necessary.
     : '';

--- a/build-system/pr-check/cross-browser-tests.js
+++ b/build-system/pr-check/cross-browser-tests.js
@@ -102,7 +102,9 @@ async function main() {
   } else {
     printChangeSummary(FILENAME);
     const buildTargets = determineBuildTargets(FILENAME);
-    await reportAllExpectedTests(buildTargets);
+    if (process.platform == 'linux') {
+      await reportAllExpectedTests(buildTargets); // Only once is sufficient.
+    }
     if (
       !buildTargets.has('RUNTIME') &&
       !buildTargets.has('FLAG_CONFIG') &&

--- a/build-system/pr-check/cross-browser-tests.js
+++ b/build-system/pr-check/cross-browser-tests.js
@@ -26,6 +26,7 @@ const {
 const {determineBuildTargets} = require('./build-targets');
 const {isPullRequestBuild} = require('../common/ci');
 const {red, cyan, bold, yellow} = require('ansi-colors');
+const {reportAllExpectedTests} = require('../tasks/report-test-status');
 const {runNpmChecks} = require('./npm-checks');
 
 /**
@@ -101,6 +102,7 @@ async function main() {
   } else {
     printChangeSummary(FILENAME);
     const buildTargets = determineBuildTargets(FILENAME);
+    await reportAllExpectedTests(buildTargets);
     if (
       !buildTargets.has('RUNTIME') &&
       !buildTargets.has('FLAG_CONFIG') &&

--- a/build-system/tasks/report-test-status.js
+++ b/build-system/tasks/report-test-status.js
@@ -144,7 +144,6 @@ function reportTestStarted() {
 }
 
 async function reportAllExpectedTests(buildTargets) {
-  log(green('INFO:'), 'Using commit hash:', cyan(gitCommitHash()));
   for (const [type, subTypes] of TEST_TYPE_SUBTYPES) {
     const testTypeBuildTargets = TEST_TYPE_BUILD_TARGETS.get(type);
     const action = testTypeBuildTargets.some((target) =>

--- a/build-system/tasks/report-test-status.js
+++ b/build-system/tasks/report-test-status.js
@@ -85,7 +85,7 @@ function inferTestType() {
 }
 
 async function postReport(type, action) {
-  if (type !== null && isPullRequestBuild()) {
+  if (type && isPullRequestBuild()) {
     const commitHash = gitCommitHash();
 
     try {

--- a/build-system/tasks/report-test-status.js
+++ b/build-system/tasks/report-test-status.js
@@ -18,10 +18,14 @@
 const argv = require('minimist')(process.argv.slice(2));
 const log = require('fancy-log');
 const requestPromise = require('request-promise');
+const {
+  isPullRequestBuild,
+  isGithubActionsBuild,
+  isTravisBuild,
+} = require('../common/ci');
 const {ciJobUrl} = require('../common/ci');
 const {cyan, green, yellow} = require('ansi-colors');
 const {gitCommitHash} = require('../common/git');
-const {isPullRequestBuild, isTravisBuild} = require('../common/ci');
 
 const reportBaseUrl = 'https://amp-test-status-bot.appspot.com/v0/tests';
 
@@ -29,15 +33,18 @@ const IS_GULP_INTEGRATION = argv._[0] === 'integration';
 const IS_GULP_UNIT = argv._[0] === 'unit';
 const IS_GULP_E2E = argv._[0] === 'e2e';
 
-const IS_LOCAL_CHANGES = !!argv.local_changes;
-const IS_DIST = !!argv.compiled;
-const IS_ESM = !!argv.esm;
-
-const TEST_TYPE_SUBTYPES = new Map([
-  ['integration', ['local', 'minified', 'esm']],
-  ['unit', ['local', 'local-changes']],
-  ['e2e', ['local']],
-]);
+const TEST_TYPE_SUBTYPES = isGithubActionsBuild()
+  ? new Map([
+      ['integration', ['firefox', 'safari', 'edge', 'ie']],
+      ['unit', ['firefox', 'safari', 'edge']],
+    ])
+  : isTravisBuild()
+  ? new Map([
+      ['integration', ['unminified', 'minified', 'esm']],
+      ['unit', ['unminified', 'local-changes']],
+      ['e2e', ['minified']],
+    ])
+  : new Map([]);
 const TEST_TYPE_BUILD_TARGETS = new Map([
   ['integration', ['RUNTIME', 'FLAG_CONFIG', 'INTEGRATION_TEST']],
   ['unit', ['RUNTIME', 'UNIT_TEST']],
@@ -45,34 +52,40 @@ const TEST_TYPE_BUILD_TARGETS = new Map([
 ]);
 
 function inferTestType() {
-  if (IS_GULP_E2E) {
-    return 'e2e/local';
-  }
-
-  let type;
-  if (IS_GULP_UNIT) {
-    type = 'unit';
-  } else if (IS_GULP_INTEGRATION) {
-    type = 'integration';
-  } else {
+  // Determine type (early exit if there's no match).
+  const type = IS_GULP_E2E
+    ? 'e2e'
+    : IS_GULP_INTEGRATION
+    ? 'integration'
+    : IS_GULP_UNIT
+    ? 'unit'
+    : null;
+  if (type == null) {
     return null;
   }
 
-  if (IS_LOCAL_CHANGES) {
-    return `${type}/local-changes`;
-  } else if (IS_DIST) {
-    if (IS_ESM) {
-      return `${type}/esm`;
-    }
-    return `${type}/minified`;
-  } else {
-    return `${type}/local`;
-  }
+  // Determine subtype (more specific cases come first).
+  const subtype = argv.local_changes
+    ? 'local-changes'
+    : argv.esm
+    ? 'esm'
+    : argv.firefox
+    ? 'firefox'
+    : argv.safari
+    ? 'safari'
+    : argv.edge
+    ? 'edge'
+    : argv.ie
+    ? 'ie'
+    : argv.compiled
+    ? 'minified'
+    : 'unminified';
+
+  return `${type}/${subtype}`;
 }
 
 async function postReport(type, action) {
-  // TODO(rsimha, ampproject/amp-github-apps#1111) Remove Travis special-case.
-  if (type !== null && isTravisBuild() && isPullRequestBuild()) {
+  if (type !== null && isPullRequestBuild()) {
     const commitHash = gitCommitHash();
 
     try {
@@ -80,8 +93,7 @@ async function postReport(type, action) {
         method: 'POST',
         uri: `${reportBaseUrl}/${commitHash}/${type}/${action}`,
         body: JSON.stringify({
-          // TODO(rsimha, ampproject/amp-github-apps#1111): Change the name of this field.
-          travisJobUrl: ciJobUrl(),
+          ciJobUrl: ciJobUrl(),
         }),
         headers: {
           'Content-Type': 'application/json',

--- a/build-system/tasks/report-test-status.js
+++ b/build-system/tasks/report-test-status.js
@@ -144,6 +144,7 @@ function reportTestStarted() {
 }
 
 async function reportAllExpectedTests(buildTargets) {
+  log(green('INFO:'), 'Using commit hash:', cyan(gitCommitHash()));
   for (const [type, subTypes] of TEST_TYPE_SUBTYPES) {
     const testTypeBuildTargets = TEST_TYPE_BUILD_TARGETS.get(type);
     const action = testTypeBuildTargets.some((target) =>


### PR DESCRIPTION
**PR Highlights:**

- Enables test status reporting across all CI services
- Renames the `travisJobUrl` field to `ciJobUrl` (now that https://github.com/ampproject/amp-github-apps/pull/1139 has been deployed)
- Adds missing subtypes for cross-browser tests
- Replaces the `local` subtype with `minified` or `unminified` (unless a more specific subtype is applicable)
- Simplifies implementation of `inferTestType()`
- Separates `reportAllExpectedTests()` for each CI service
- Extracts `pull_request.head.sha` in `ciPullRequestSha()` for GH Actions

Related to https://github.com/ampproject/amp-github-apps/issues/1111