### PR TITLE
🐛 [Story interactive] Prevent translations on the ABCD on quizzes

### DIFF
--- a/extensions/amp-story-interactive/0.1/amp-story-interactive-quiz.js
+++ b/extensions/amp-story-interactive/0.1/amp-story-interactive-quiz.js
@@ -52,7 +52,9 @@ const buildOptionTemplate = (option) => {
     <span
       class="i-amphtml-story-interactive-quiz-option i-amphtml-story-interactive-option"
     >
-      <span class="i-amphtml-story-interactive-quiz-answer-choice"></span>
+      <span
+        class="i-amphtml-story-interactive-quiz-answer-choice notranslate"
+      ></span>
     </span>
   `;
 };


### PR DESCRIPTION
Set the answer choices on quizzes to not translate since we want to translate them on our localizedStrings if anything.

Fixes #31610