### PR TITLE
🏗 SwG Release 0.1.22.139

### DIFF
--- a/third_party/subscriptions-project/config.js
+++ b/third_party/subscriptions-project/config.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/** Version: 0.1.22.138 */
+/** Version: 0.1.22.139 */
 /**
  * Copyright 2018 The Subscribe with Google Authors. All Rights Reserved.
  *

--- a/third_party/subscriptions-project/swg.js
+++ b/third_party/subscriptions-project/swg.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/** Version: 0.1.22.138 */
+/** Version: 0.1.22.139 */
 /**
  * Copyright 2018 The Subscribe with Google Authors. All Rights Reserved.
  *
@@ -52,6 +52,7 @@ const AnalyticsEvent = {
   IMPRESSION_SELECT_OFFER_SWG_BUTTON: 18,
   IMPRESSION_SHOW_CONTRIBUTIONS_SWG_BUTTON: 19,
   IMPRESSION_SELECT_CONTRIBUTION_SWG_BUTTON: 20,
+  IMPRESSION_METER_TOAST: 21,
   ACTION_SUBSCRIBE: 1000,
   ACTION_PAYMENT_COMPLETE: 1001,
   ACTION_ACCOUNT_CREATED: 1002,
@@ -77,6 +78,11 @@ const AnalyticsEvent = {
   ACTION_USER_DENY_DEFERRED_ACCOUNT: 1022,
   ACTION_DEFERRED_ACCOUNT_REDIRECT: 1023,
   ACTION_GET_ENTITLEMENTS: 1024,
+  ACTION_METER_TOAST_SUBSCRIBE_CLICK: 1025,
+  ACTION_METER_TOAST_EXPANDED: 1026,
+  ACTION_METER_TOAST_CLOSED_BY_ARTICLE_INTERACTION: 1027,
+  ACTION_METER_TOAST_CLOSED_BY_SWIPE_DOWN: 1028,
+  ACTION_METER_TOAST_CLOSED_BY_X_CLICKED: 1029,
   EVENT_PAYMENT_FAILED: 2000,
   EVENT_CUSTOM: 3000,
   EVENT_CONFIRM_TX_ID: 3001,
@@ -89,6 +95,7 @@ const AnalyticsEvent = {
   EVENT_UNLOCKED_BY_METER: 3008,
   EVENT_NO_ENTITLEMENTS: 3009,
   EVENT_HAS_METERING_ENTITLEMENTS: 3010,
+  EVENT_OFFERED_METER: 3011,
   EVENT_SUBSCRIPTION_STATE: 4000,
 };
 /** @enum {number} */
@@ -5059,6 +5066,10 @@ class Entitlements {
    */
   getEntitlementFor(product, source) {
     if (!product) {
+      // Require a product ID.
+      log_4(
+        'SwG needs this article to define a product ID (e.g. example.com:premium). Articles can define a product ID using JSON+LD. SwG can check entitlements after this article defines a product ID.'
+      );
       return null;
     }
 
@@ -6079,7 +6090,7 @@ function feCached(url) {
  */
 function feArgs(args) {
   return Object.assign(args, {
-    '_client': 'SwG 0.1.22.138',
+    '_client': 'SwG 0.1.22.139',
   });
 }
 
@@ -7198,7 +7209,7 @@ class ActivityPorts$1 {
         'analyticsContext': context.toArray(),
         'publicationId': pageConfig.getPublicationId(),
         'productId': pageConfig.getProductId(),
-        '_client': 'SwG 0.1.22.138',
+        '_client': 'SwG 0.1.22.139',
         'supportsEventManager': true,
       },
       args || {}
@@ -8047,7 +8058,7 @@ class AnalyticsService {
       context.setTransactionId(getUuid());
     }
     context.setReferringOrigin(parseUrl$1(this.getReferrer_()).origin);
-    context.setClientVersion('SwG 0.1.22.138');
+    context.setClientVersion('SwG 0.1.22.139');
     context.setUrl(getCanonicalUrl(this.doc_));
 
     const utmParams = parseQueryString$1(this.getQueryString_());
@@ -10505,24 +10516,41 @@ class MeterToastApi {
     /** @private @const {!../components/dialog-manager.DialogManager} */
     this.dialogManager_ = deps.dialogManager();
 
+    const iframeArgs = this.activityPorts_.addDefaultArguments({
+      isClosable: true,
+      hasSubscriptionCallback: deps.callbacks().hasSubscribeRequestCallback(),
+    });
     /** @private @const {!ActivityIframeView} */
     this.activityIframeView_ = new ActivityIframeView(
       this.win_,
       this.activityPorts_,
       feUrl('/metertoastiframe'),
-      feArgs({
-        publicationId: deps.pageConfig().getPublicationId(),
-        productId: deps.pageConfig().getProductId(),
-        hasSubscriptionCallback: deps.callbacks().hasSubscribeRequestCallback(),
-      }),
+      iframeArgs,
       /* shouldFadeBody */ false
     );
 
+    /**
+     * Function this class calls when a user dismisses the toast to consume a free read.
+     * @private {?function()}
+     */
+    this.onConsumeCallback_ = null;
+
     /** @private @const {!function()} */
     this.sendCloseRequestFunction_ = () => {
+      this.deps_
+        .eventManager()
+        .logSwgEvent(
+          AnalyticsEvent.ACTION_METER_TOAST_CLOSED_BY_ARTICLE_INTERACTION,
+          true
+        );
       const closeRequest = new ToastCloseRequest();
       closeRequest.setClose(true);
       this.activityIframeView_.execute(closeRequest);
+      this.removeCloseEventListener();
+
+      if (this.onConsumeCallback_) {
+        this.onConsumeCallback_();
+      }
     };
   }
 
@@ -10538,6 +10566,15 @@ class MeterToastApi {
       ViewSubscriptionsResponse,
       this.startNativeFlow_.bind(this)
     );
+    if (!this.deps_.callbacks().hasSubscribeRequestCallback()) {
+      const errorMessage =
+        '[swg.js]: `setOnNativeSubscribeRequest` has not been ' +
+        'set before starting the metering flow, so users will not be able to ' +
+        'subscribe from the metering dialog directly. Please call ' +
+        '`setOnNativeSubscribeRequest` with a subscription flow callback before ' +
+        'starting metering.';
+      log_4(errorMessage);
+    }
     return this.dialogManager_.openView(this.activityIframeView_).then(() => {
       this.setDialogBoxShadow_();
       // Allow closing of the iframe with any scroll or click event.
@@ -10549,15 +10586,19 @@ class MeterToastApi {
       // while swiping on the iframe.
       const $body = this.win_.document.body;
       setStyle($body, 'overflow', 'hidden');
+      this.deps_
+        .eventManager()
+        .logSwgEvent(AnalyticsEvent.IMPRESSION_METER_TOAST);
+      this.deps_.eventManager().logSwgEvent(AnalyticsEvent.EVENT_OFFERED_METER);
     });
   }
 
   /**
-   * Sets a callback function to happen onCancel.
-   * @param {function()} onCancelCallback
+   * Sets a callback function this class calls when a user dismisses the toast to consume a free read.
+   * @param {function()} onConsumeCallback
    */
-  setOnCancelCallback(onCancelCallback) {
-    this.activityIframeView_.onCancel(onCancelCallback);
+  setOnConsumeCallback(onConsumeCallback) {
+    this.onConsumeCallback_ = onConsumeCallback;
   }
 
   /**
@@ -10596,6 +10637,7 @@ class MeterToastApi {
    */
   startNativeFlow_(response) {
     if (response.getNative()) {
+      this.removeCloseEventListener();
       this.deps_.callbacks().triggerSubscribeRequest();
     }
   }
@@ -11255,11 +11297,10 @@ class EntitlementsManager {
   consume_(entitlements, onCloseDialog) {
     if (entitlements.enablesThisWithGoogleMetering()) {
       const meterToastApi = new MeterToastApi(this.deps_);
-      meterToastApi.setOnCancelCallback(() => {
+      meterToastApi.setOnConsumeCallback(() => {
         if (onCloseDialog) {
           onCloseDialog();
         }
-        meterToastApi.removeCloseEventListener();
         this.sendPingback_(entitlements);
       });
       return meterToastApi.start();


### PR DESCRIPTION
## Version: 0.1.22.139

## Previous release: [0.1.22.138](https://github.com/subscriptions-project/swg-js/releases/tag/0.1.22.138)

Remove event listeners on different events in meter toast (#1415)
Docs: Adds a missing word (#1414)
PR Release Checker (#1413)
Update dependency @babel/preset-env to v7.12.11 (#1411)
Add warning in meter toast API on missing subscription callback (#1412)
Adds logging and tests to meter toast iframe (#1408)
Logs: SwG needs this article to define a product ID... (#1410)
Meter Toast: Only call consume() callback when necessary (#1409)
Add new AnalyticsEvents for the Meter Toast iframe (#1401)
Update dependency postcss-import to v14 (#1407)
Update dependency rollup to v2.35.1 (#1406)
Update dependency eslint-plugin-prettier to v3.3.0 (#1405)
Update dependency chromedriver to v87.0.4 (#1403)
Update dependency karma-browserify to v8 (#1404)
Update dependency sinon to v9.2.2 (#1402)
SwG basic runtime and API skeleton. (#1395)
Bump ini from 1.3.5 to 1.3.7 (#1400)
Update babel monorepo to v7.12.10 (#1399)