### PR TITLE
🐛  [Story preload] Fix preloading and specifying page in hashParam

### DIFF
--- a/examples/amp-story/interactives.html
+++ b/examples/amp-story/interactives.html
@@ -51,6 +51,7 @@
                 layout="responsive"
                 height="1600"
                 width="900">
+                <h1 style="position: absolute;top: 0;z-index: 1">Hello!</h1>
             </amp-img>
           </amp-story-grid-layer>
           <amp-story-grid-layer template="center">

--- a/examples/amp-story/interactives.html
+++ b/examples/amp-story/interactives.html
@@ -47,7 +47,7 @@
         <amp-story-page id="quiz-intl">
           <amp-story-grid-layer template="fill">
             <amp-img
-                src="https://images.unsplash.com/photo-1543793804-ace495842b0e?ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw%3D&ixlib=rb-1.2.1&auto=format&fit=crop&w=934&q=80"
+                src="img/roadshow.jpg"
                 layout="responsive"
                 height="1600"
                 width="900">

--- a/examples/amp-story/interactives.html
+++ b/examples/amp-story/interactives.html
@@ -47,7 +47,7 @@
         <amp-story-page id="quiz-intl">
           <amp-story-grid-layer template="fill">
             <amp-img
-                src="img/roadshow.jpg"
+                src="https://images.unsplash.com/photo-1543793804-ace495842b0e?ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw%3D&ixlib=rb-1.2.1&auto=format&fit=crop&w=934&q=80"
                 layout="responsive"
                 height="1600"
                 width="900">

--- a/extensions/amp-story/1.0/amp-story-grid-layer.js
+++ b/extensions/amp-story/1.0/amp-story-grid-layer.js
@@ -89,7 +89,7 @@ export class AmpStoryGridLayer extends AmpStoryBaseLayer {
     this.isFirstPage_ = null;
 
     /** @private {?boolean} */
-    this.isLoadedPage_ = null;
+    this.isActivePage_ = null;
 
     /** @private {?{horiz: number, vert: number}} */
     this.aspectRatio_ = null;
@@ -114,14 +114,16 @@ export class AmpStoryGridLayer extends AmpStoryBaseLayer {
    * @return {boolean}
    */
   isPrerenderActivePage() {
-    if (this.isLoadedPage_ === null) {
+    if (this.isActivePage_ === null) {
       const hashId = parseQueryString(this.win.location.href)['page'];
       const identSelector = `amp-story-page#${escapeCssSelectorIdent(
         hashId
       )} amp-story-grid-layer`;
-      this.isLoadedPage_ = hashId && matches(this.element, identSelector);
+      this.isActivePage_ = hashId
+        ? matches(this.element, identSelector)
+        : this.isFirstPage();
     }
-    return this.isLoadedPage_;
+    return this.isActivePage_;
   }
 
   /** @override */
@@ -135,7 +137,7 @@ export class AmpStoryGridLayer extends AmpStoryBaseLayer {
 
   /** @override */
   prerenderAllowed() {
-    return this.isFirstPage() || this.isPrerenderActivePage();
+    return this.isPrerenderActivePage();
   }
 
   /** @private */

--- a/extensions/amp-story/1.0/amp-story-grid-layer.js
+++ b/extensions/amp-story/1.0/amp-story-grid-layer.js
@@ -106,13 +106,9 @@ export class AmpStoryGridLayer extends AmpStoryBaseLayer {
     if (hashId) {
       selector += `, amp-story-page#${escapeCssSelectorIdent(hashId)}`;
     }
-    const parentPage = closest(
-      this.element,
-      (el) => el.tagName.toLowerCase() === 'amp-story-page'
-    );
+    const selectorNodes = this.win.document.querySelectorAll(selector);
     this.isActivePage_ =
-      toArray(this.win.document.querySelectorAll(selector)).pop() ===
-      parentPage;
+      selectorNodes[selectorNodes.length - 1] === this.element.parentElement;
     return this.isActivePage_;
   }
 

--- a/extensions/amp-story/1.0/amp-story-grid-layer.js
+++ b/extensions/amp-story/1.0/amp-story-grid-layer.js
@@ -113,7 +113,7 @@ export class AmpStoryGridLayer extends AmpStoryBaseLayer {
    * Returns true if the page is in the hashString
    * @return {boolean}
    */
-  isLoadedPage() {
+  isPrerenderActivePage() {
     if (this.isLoadedPage_ === null) {
       const hashId = parseQueryString(this.win.location.href)['page'];
       const identSelector = `amp-story-page#${escapeCssSelectorIdent(
@@ -135,7 +135,7 @@ export class AmpStoryGridLayer extends AmpStoryBaseLayer {
 
   /** @override */
   prerenderAllowed() {
-    return this.isFirstPage() || this.isLoadedPage();
+    return this.isFirstPage() || this.isPrerenderActivePage();
   }
 
   /** @private */

--- a/extensions/amp-story/1.0/amp-story-grid-layer.js
+++ b/extensions/amp-story/1.0/amp-story-grid-layer.js
@@ -86,9 +86,6 @@ export class AmpStoryGridLayer extends AmpStoryBaseLayer {
     super(element);
 
     /** @private {?boolean} */
-    this.isFirstPage_ = null;
-
-    /** @private {?boolean} */
     this.isActivePage_ = null;
 
     /** @private {?{horiz: number, vert: number}} */
@@ -96,33 +93,21 @@ export class AmpStoryGridLayer extends AmpStoryBaseLayer {
   }
 
   /**
-   * Returns true if a child of the first page.
-   * @return {boolean}
-   */
-  isFirstPage() {
-    if (this.isFirstPage_ === null) {
-      this.isFirstPage_ = matches(
-        this.element,
-        'amp-story-page:first-of-type amp-story-grid-layer'
-      );
-    }
-    return this.isFirstPage_;
-  }
-
-  /**
    * Returns true if the page is in the hashString
    * @return {boolean}
    */
   isPrerenderActivePage() {
-    if (this.isActivePage_ === null) {
-      const hashId = parseQueryString(this.win.location.href)['page'];
-      const identSelector = `amp-story-page#${escapeCssSelectorIdent(
+    if (this.isActivePage_ != null) {
+      return this.isActivePage_;
+    }
+    const hashId = parseQueryString(this.win.location.href)['page'];
+    let selector = 'amp-story-page:first-of-type amp-story-grid-layer';
+    if (hashId) {
+      selector += `, amp-story-page#${escapeCssSelectorIdent(
         hashId
       )} amp-story-grid-layer`;
-      this.isActivePage_ = hashId
-        ? matches(this.element, identSelector)
-        : this.isFirstPage();
     }
+    this.isActivePage_ = matches(this.element, selector);
     return this.isActivePage_;
   }
 

--- a/extensions/amp-story/1.0/amp-story-grid-layer.js
+++ b/extensions/amp-story/1.0/amp-story-grid-layer.js
@@ -29,7 +29,9 @@
 import {AmpStoryBaseLayer} from './amp-story-base-layer';
 import {StateProperty, getStoreService} from './amp-story-store-service';
 import {assertDoesNotContainDisplay, px, setStyles} from '../../../src/style';
+import {escapeCssSelectorIdent} from '../../../src/css';
 import {matches, scopedQuerySelectorAll} from '../../../src/dom';
+import {parseQueryString} from '../../../src/url';
 
 /**
  * A mapping of attribute names we support for grid layers to the CSS Grid
@@ -86,6 +88,9 @@ export class AmpStoryGridLayer extends AmpStoryBaseLayer {
     /** @private {?boolean} */
     this.isFirstPage_ = null;
 
+    /** @private {?boolean} */
+    this.isLoadedPage_ = null;
+
     /** @private {?{horiz: number, vert: number}} */
     this.aspectRatio_ = null;
   }
@@ -104,6 +109,21 @@ export class AmpStoryGridLayer extends AmpStoryBaseLayer {
     return this.isFirstPage_;
   }
 
+  /**
+   * Returns true if the page is in the hashString
+   * @return {boolean}
+   */
+  isLoadedPage() {
+    if (this.isLoadedPage_ === null) {
+      const hashId = parseQueryString(this.win.location.href)['page'];
+      const identSelector = `amp-story-page#${escapeCssSelectorIdent(
+        hashId
+      )} amp-story-grid-layer`;
+      this.isLoadedPage_ = hashId && matches(this.element, identSelector);
+    }
+    return this.isLoadedPage_;
+  }
+
   /** @override */
   buildCallback() {
     super.buildCallback();
@@ -115,7 +135,7 @@ export class AmpStoryGridLayer extends AmpStoryBaseLayer {
 
   /** @override */
   prerenderAllowed() {
-    return this.isFirstPage();
+    return this.isFirstPage() || this.isLoadedPage();
   }
 
   /** @private */

--- a/extensions/amp-story/1.0/amp-story-grid-layer.js
+++ b/extensions/amp-story/1.0/amp-story-grid-layer.js
@@ -32,6 +32,7 @@ import {assertDoesNotContainDisplay, px, setStyles} from '../../../src/style';
 import {escapeCssSelectorIdent} from '../../../src/css';
 import {matches, scopedQuerySelectorAll} from '../../../src/dom';
 import {parseQueryString} from '../../../src/url';
+import {toArray} from '../../../src/types';
 
 /**
  * A mapping of attribute names we support for grid layers to the CSS Grid
@@ -93,7 +94,7 @@ export class AmpStoryGridLayer extends AmpStoryBaseLayer {
   }
 
   /**
-   * Returns true if the page is in the hashString
+   * Returns true if the page should be prerendered (for being an active page or first page)
    * @return {boolean}
    */
   isPrerenderActivePage() {
@@ -101,13 +102,13 @@ export class AmpStoryGridLayer extends AmpStoryBaseLayer {
       return this.isActivePage_;
     }
     const hashId = parseQueryString(this.win.location.href)['page'];
-    let selector = 'amp-story-page:first-of-type amp-story-grid-layer';
+    let selector = 'amp-story-page:first-of-type';
     if (hashId) {
-      selector += `, amp-story-page#${escapeCssSelectorIdent(
-        hashId
-      )} amp-story-grid-layer`;
+      selector += `, amp-story-page#${escapeCssSelectorIdent(hashId)}`;
     }
-    this.isActivePage_ = matches(this.element, selector);
+    this.isActivePage_ =
+      toArray(this.win.document.querySelectorAll(selector)).pop() ===
+      this.element.parentElement;
     return this.isActivePage_;
   }
 

--- a/extensions/amp-story/1.0/amp-story-grid-layer.js
+++ b/extensions/amp-story/1.0/amp-story-grid-layer.js
@@ -29,8 +29,8 @@
 import {AmpStoryBaseLayer} from './amp-story-base-layer';
 import {StateProperty, getStoreService} from './amp-story-store-service';
 import {assertDoesNotContainDisplay, px, setStyles} from '../../../src/style';
+import {closest, scopedQuerySelectorAll} from '../../../src/dom';
 import {escapeCssSelectorIdent} from '../../../src/css';
-import {matches, scopedQuerySelectorAll} from '../../../src/dom';
 import {parseQueryString} from '../../../src/url';
 import {toArray} from '../../../src/types';
 
@@ -106,9 +106,13 @@ export class AmpStoryGridLayer extends AmpStoryBaseLayer {
     if (hashId) {
       selector += `, amp-story-page#${escapeCssSelectorIdent(hashId)}`;
     }
+    const parentPage = closest(
+      this.element,
+      (el) => el.tagName.toLowerCase() === 'amp-story-page'
+    );
     this.isActivePage_ =
       toArray(this.win.document.querySelectorAll(selector)).pop() ===
-      this.element.parentElement;
+      parentPage;
     return this.isActivePage_;
   }
 

--- a/extensions/amp-story/1.0/amp-story-grid-layer.js
+++ b/extensions/amp-story/1.0/amp-story-grid-layer.js
@@ -29,10 +29,9 @@
 import {AmpStoryBaseLayer} from './amp-story-base-layer';
 import {StateProperty, getStoreService} from './amp-story-store-service';
 import {assertDoesNotContainDisplay, px, setStyles} from '../../../src/style';
-import {closest, scopedQuerySelectorAll} from '../../../src/dom';
 import {escapeCssSelectorIdent} from '../../../src/css';
 import {parseQueryString} from '../../../src/url';
-import {toArray} from '../../../src/types';
+import {scopedQuerySelectorAll} from '../../../src/dom';
 
 /**
  * A mapping of attribute names we support for grid layers to the CSS Grid

--- a/extensions/amp-story/1.0/amp-story-grid-layer.js
+++ b/extensions/amp-story/1.0/amp-story-grid-layer.js
@@ -86,7 +86,7 @@ export class AmpStoryGridLayer extends AmpStoryBaseLayer {
     super(element);
 
     /** @private {?boolean} */
-    this.isActivePage_ = null;
+    this.isPrerenderActivePage_ = null;
 
     /** @private {?{horiz: number, vert: number}} */
     this.aspectRatio_ = null;
@@ -97,8 +97,8 @@ export class AmpStoryGridLayer extends AmpStoryBaseLayer {
    * @return {boolean}
    */
   isPrerenderActivePage() {
-    if (this.isActivePage_ != null) {
-      return this.isActivePage_;
+    if (this.isPrerenderActivePage_ != null) {
+      return this.isPrerenderActivePage_;
     }
     const hashId = parseQueryString(this.win.location.href)['page'];
     let selector = 'amp-story-page:first-of-type';
@@ -106,9 +106,9 @@ export class AmpStoryGridLayer extends AmpStoryBaseLayer {
       selector += `, amp-story-page#${escapeCssSelectorIdent(hashId)}`;
     }
     const selectorNodes = this.win.document.querySelectorAll(selector);
-    this.isActivePage_ =
+    this.isPrerenderActivePage_ =
       selectorNodes[selectorNodes.length - 1] === this.element.parentElement;
-    return this.isActivePage_;
+    return this.isPrerenderActivePage_;
   }
 
   /** @override */

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -384,17 +384,6 @@ export class AmpStoryPage extends AMP.BaseElement {
   }
 
   /**
-   * Returns true if a child of the first page.
-   * @return {boolean}
-   */
-  isFirstPage() {
-    if (this.isFirstPage_ === null) {
-      this.isFirstPage_ = matches(this.element, 'amp-story-page:first-of-type');
-    }
-    return this.isFirstPage_;
-  }
-
-  /**
    * Returns true if the page should be prerendered (for being an active page or first page)
    * @return {boolean}
    */
@@ -407,7 +396,9 @@ export class AmpStoryPage extends AMP.BaseElement {
     if (hashId) {
       selector += `, amp-story-page#${escapeCssSelectorIdent(hashId)}`;
     }
-    this.isActivePage_ = matches(this.element, selector);
+    this.isActivePage_ =
+      toArray(this.win.document.querySelectorAll(selector)).pop() ===
+      this.element;
     return this.isActivePage_;
   }
 
@@ -594,7 +585,7 @@ export class AmpStoryPage extends AMP.BaseElement {
     // Only measures from the first story page, that always gets built because
     // of the prerendering optimizations in place.
     if (
-      !this.isFirstPage() ||
+      !this.isPrerenderActivePage() ||
       (this.layoutBox_ &&
         this.layoutBox_.width === layoutBox.width &&
         this.layoutBox_.height === layoutBox.height)

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -392,9 +392,9 @@ export class AmpStoryPage extends AMP.BaseElement {
     if (hashId) {
       selector += `, amp-story-page#${escapeCssSelectorIdent(hashId)}`;
     }
+    const selectorNodes = this.win.document.querySelectorAll(selector);
     this.isActivePage_ =
-      toArray(this.win.document.querySelectorAll(selector)).pop() ===
-      this.element;
+      selectorNodes[selectorNodes.length - 1] === this.element;
     return this.isActivePage_;
   }
 

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -64,6 +64,7 @@ import {debounce} from '../../../src/utils/rate-limit';
 import {delegateAutoplay} from '../../../src/video-interface';
 import {dev} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
+import {escapeCssSelectorIdent} from '../../../src/css';
 import {getAmpdoc} from '../../../src/service';
 import {getFriendlyIframeEmbedOptional} from '../../../src/iframe-helper';
 import {getLocalizationService} from './amp-story-localization-service';
@@ -73,6 +74,7 @@ import {getMode} from '../../../src/mode';
 import {htmlFor} from '../../../src/static-template';
 import {isExperimentOn} from '../../../src/experiments';
 import {listen} from '../../../src/event-helper';
+import {parseQueryString} from '../../../src/url';
 import {px, toggle} from '../../../src/style';
 import {renderPageDescription} from './semantic-render';
 import {setTextBackgroundColor} from './utils';
@@ -246,6 +248,9 @@ export class AmpStoryPage extends AMP.BaseElement {
     /** @private {?boolean}  */
     this.isFirstPage_ = null;
 
+    /** @private {?boolean}  */
+    this.isLoadedPage_ = null;
+
     /** @private {?LoadingSpinner} */
     this.loadingSpinner_ = null;
 
@@ -387,6 +392,21 @@ export class AmpStoryPage extends AMP.BaseElement {
       this.isFirstPage_ = matches(this.element, 'amp-story-page:first-of-type');
     }
     return this.isFirstPage_;
+  }
+
+  /**
+   * Returns true if the page is in the hashString
+   * @return {boolean}
+   */
+  isPrerenderActivePage() {
+    if (this.isLoadedPage_ === null) {
+      const hashId = parseQueryString(this.win.location.href)['page'];
+      const identSelector = `amp-story-page#${escapeCssSelectorIdent(hashId)}`;
+      console.log(parseQueryString(this.win.location.href));
+      this.isLoadedPage_ = hashId && matches(this.element, identSelector);
+    }
+    console.log(this.isLoadedPage_);
+    return this.isLoadedPage_;
   }
 
   /**
@@ -823,7 +843,7 @@ export class AmpStoryPage extends AMP.BaseElement {
 
   /** @override */
   prerenderAllowed() {
-    return this.isFirstPage();
+    return this.isFirstPage() || this.isPrerenderActivePage();
   }
 
   /**

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -249,7 +249,7 @@ export class AmpStoryPage extends AMP.BaseElement {
     this.isFirstPage_ = null;
 
     /** @private {?boolean}  */
-    this.isLoadedPage_ = null;
+    this.isActivePage_ = null;
 
     /** @private {?LoadingSpinner} */
     this.loadingSpinner_ = null;
@@ -395,18 +395,20 @@ export class AmpStoryPage extends AMP.BaseElement {
   }
 
   /**
-   * Returns true if the page is in the hashString
+   * Returns true if the page should be prerendered for being an active page
    * @return {boolean}
    */
   isPrerenderActivePage() {
-    if (this.isLoadedPage_ === null) {
+    if (this.isActivePage_ === null) {
       const hashId = parseQueryString(this.win.location.href)['page'];
-      const identSelector = `amp-story-page#${escapeCssSelectorIdent(hashId)}`;
-      console.log(parseQueryString(this.win.location.href));
-      this.isLoadedPage_ = hashId && matches(this.element, identSelector);
+      const pageFromHashSelector = `amp-story-page#${escapeCssSelectorIdent(
+        hashId
+      )}`;
+      this.isActivePage_ = hashId
+        ? matches(this.element, pageFromHashSelector)
+        : this.isFirstPage();
     }
-    console.log(this.isLoadedPage_);
-    return this.isLoadedPage_;
+    return this.isActivePage_;
   }
 
   /**
@@ -843,7 +845,7 @@ export class AmpStoryPage extends AMP.BaseElement {
 
   /** @override */
   prerenderAllowed() {
-    return this.isFirstPage() || this.isPrerenderActivePage();
+    return this.isPrerenderActivePage();
   }
 
   /**

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -245,7 +245,7 @@ export class AmpStoryPage extends AMP.BaseElement {
     );
 
     /** @private {?boolean}  */
-    this.isActivePage_ = null;
+    this.isPrerenderActivePage_ = null;
 
     /** @private {?LoadingSpinner} */
     this.loadingSpinner_ = null;
@@ -384,8 +384,8 @@ export class AmpStoryPage extends AMP.BaseElement {
    * @return {boolean}
    */
   isPrerenderActivePage() {
-    if (this.isActivePage_ != null) {
-      return this.isActivePage_;
+    if (this.isPrerenderActivePage_ != null) {
+      return this.isPrerenderActivePage_;
     }
     const hashId = parseQueryString(this.win.location.href)['page'];
     let selector = 'amp-story-page:first-of-type';
@@ -393,9 +393,9 @@ export class AmpStoryPage extends AMP.BaseElement {
       selector += `, amp-story-page#${escapeCssSelectorIdent(hashId)}`;
     }
     const selectorNodes = this.win.document.querySelectorAll(selector);
-    this.isActivePage_ =
+    this.isPrerenderActivePage_ =
       selectorNodes[selectorNodes.length - 1] === this.element;
-    return this.isActivePage_;
+    return this.isPrerenderActivePage_;
   }
 
   /**

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -56,7 +56,6 @@ import {
   addAttributesToElement,
   closestAncestorElementBySelector,
   iterateCursor,
-  matches,
   scopedQuerySelectorAll,
   whenUpgradedToCustomElement,
 } from '../../../src/dom';
@@ -244,9 +243,6 @@ export class AmpStoryPage extends AMP.BaseElement {
       (isActive) => this.toggleLoadingSpinner_(!!isActive),
       100
     );
-
-    /** @private {?boolean}  */
-    this.isFirstPage_ = null;
 
     /** @private {?boolean}  */
     this.isActivePage_ = null;

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -395,19 +395,19 @@ export class AmpStoryPage extends AMP.BaseElement {
   }
 
   /**
-   * Returns true if the page should be prerendered for being an active page
+   * Returns true if the page should be prerendered (for being an active page or first page)
    * @return {boolean}
    */
   isPrerenderActivePage() {
-    if (this.isActivePage_ === null) {
-      const hashId = parseQueryString(this.win.location.href)['page'];
-      const pageFromHashSelector = `amp-story-page#${escapeCssSelectorIdent(
-        hashId
-      )}`;
-      this.isActivePage_ = hashId
-        ? matches(this.element, pageFromHashSelector)
-        : this.isFirstPage();
+    if (this.isActivePage_ != null) {
+      return this.isActivePage_;
     }
+    const hashId = parseQueryString(this.win.location.href)['page'];
+    let selector = 'amp-story-page:first-of-type';
+    if (hashId) {
+      selector += `, amp-story-page#${escapeCssSelectorIdent(hashId)}`;
+    }
+    this.isActivePage_ = matches(this.element, selector);
     return this.isActivePage_;
   }
 

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -410,10 +410,13 @@ export class AmpStory extends AMP.BaseElement {
     // prerendering, because of a height incorrectly set to 0.
     this.mutateElement(() => {});
 
-    const page = this.element.querySelector(
-      `amp-story-page#${escapeCssSelectorIdent(this.getInitialPageId_())}`
-    );
-    page && page.setAttribute('active', '');
+    const pageId = this.getInitialPageId_();
+    if (pageId) {
+      const page = this.element.querySelector(
+        `amp-story-page#${escapeCssSelectorIdent(pageId)}`
+      );
+      page && page.setAttribute('active', '');
+    }
 
     this.initializeStyles_();
     this.initializeListeners_();
@@ -1096,11 +1099,8 @@ export class AmpStory extends AMP.BaseElement {
       return historyPage;
     }
 
-    const firstPageEl = user().assertElement(
-      this.element.querySelector('amp-story-page'),
-      'Story must have at least one page.'
-    );
-    return firstPageEl.id;
+    const firstPageEl = this.element.querySelector('amp-story-page');
+    return firstPageEl ? firstPageEl.id : null;
   }
 
   /**

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -415,7 +415,7 @@ export class AmpStory extends AMP.BaseElement {
       const page = this.element.querySelector(
         `amp-story-page#${escapeCssSelectorIdent(pageId)}`
       );
-      page && page.setAttribute('active', '');
+      page.setAttribute('active', '');
     }
 
     this.initializeStyles_();
@@ -1081,7 +1081,7 @@ export class AmpStory extends AMP.BaseElement {
    * Retrieves the initial pageId to begin the story with. In order, the
    * initial page for a story should be either a valid page ID in the URL
    * fragment, the page ID in the history, or the first page of the story.
-   * @return {string}
+   * @return {?string}
    * @private
    */
   getInitialPageId_() {

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -92,7 +92,6 @@ import {
   toggle,
 } from '../../../src/style';
 import {createPseudoLocale} from '../../../src/localized-strings';
-import {cssEscape} from '../../../third_party/css-escape/css-escape';
 import {debounce} from '../../../src/utils/rate-limit';
 import {dev, devAssert, user} from '../../../src/log';
 import {dict, map} from '../../../src/utils/object';

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -1040,9 +1040,9 @@ export class AmpStory extends AMP.BaseElement {
     // page is built. Other pages will only build if the document becomes
     // visible.
     if (!this.getAmpDoc().hasBeenVisible()) {
-      return whenUpgradedToCustomElement(firstPageEl).then(() =>
-        firstPageEl.whenBuilt()
-      );
+      return whenUpgradedToCustomElement(firstPageEl).then(() => {
+        return firstPageEl.whenBuilt();
+      });
     }
 
     // Will resolve when all pages are built.

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -410,12 +410,15 @@ export class AmpStory extends AMP.BaseElement {
     // prerendering, because of a height incorrectly set to 0.
     this.mutateElement(() => {});
 
-    const page = this.element.querySelector(
-      `amp-story-page#${escapeCssSelectorIdent(
-        this.getInitialPageId_(this.element.querySelector(`amp-story-page`))
-      )}`
-    );
-    page && page.setAttribute('active', '');
+    const firstPage = this.element.querySelector(`amp-story-page`);
+    const activePage = firstPage
+      ? this.element.querySelector(
+          `amp-story-page#${escapeCssSelectorIdent(
+            this.getInitialPageId_(firstPage)
+          )}`
+        )
+      : null;
+    activePage && activePage.setAttribute('active', '');
 
     this.initializeStyles_();
     this.initializeListeners_();

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -92,6 +92,7 @@ import {
   toggle,
 } from '../../../src/style';
 import {createPseudoLocale} from '../../../src/localized-strings';
+import {cssEscape} from '../../../third_party/css-escape/css-escape';
 import {debounce} from '../../../src/utils/rate-limit';
 import {dev, devAssert, user} from '../../../src/log';
 import {dict, map} from '../../../src/utils/object';
@@ -410,8 +411,17 @@ export class AmpStory extends AMP.BaseElement {
     // prerendering, because of a height incorrectly set to 0.
     this.mutateElement(() => {});
 
-    const pageEl = this.element.querySelector('amp-story-page');
-    pageEl && pageEl.setAttribute('active', '');
+    let page = this.element.querySelector('amp-story-page');
+    const maybePageId = parseQueryString(this.win.location.hash)['page'];
+    const maybePage =
+      maybePageId &&
+      this.element.querySelector(
+        `amp-story-page#${escapeCssSelectorIdent(maybePageId)}`
+      );
+    if (maybePage) {
+      page = maybePage;
+    }
+    page && page.setAttribute('active', '');
 
     this.initializeStyles_();
     this.initializeListeners_();
@@ -1036,9 +1046,9 @@ export class AmpStory extends AMP.BaseElement {
     // page is built. Other pages will only build if the document becomes
     // visible.
     if (!this.getAmpDoc().hasBeenVisible()) {
-      return whenUpgradedToCustomElement(firstPageEl).then(() => {
-        return firstPageEl.whenBuilt();
-      });
+      return whenUpgradedToCustomElement(firstPageEl).then(() =>
+        firstPageEl.whenBuilt()
+      );
     }
 
     // Will resolve when all pages are built.

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -410,16 +410,11 @@ export class AmpStory extends AMP.BaseElement {
     // prerendering, because of a height incorrectly set to 0.
     this.mutateElement(() => {});
 
-    let page = this.element.querySelector('amp-story-page');
-    const maybePageId = parseQueryString(this.win.location.hash)['page'];
-    const maybePage =
-      maybePageId &&
-      this.element.querySelector(
-        `amp-story-page#${escapeCssSelectorIdent(maybePageId)}`
-      );
-    if (maybePage) {
-      page = maybePage;
-    }
+    const page = this.element.querySelector(
+      `amp-story-page#${escapeCssSelectorIdent(
+        this.getInitialPageId_(this.element.querySelector(`amp-story-page`))
+      )}`
+    );
     page && page.setAttribute('active', '');
 
     this.initializeStyles_();

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -410,15 +410,10 @@ export class AmpStory extends AMP.BaseElement {
     // prerendering, because of a height incorrectly set to 0.
     this.mutateElement(() => {});
 
-    const firstPage = this.element.querySelector(`amp-story-page`);
-    const activePage = firstPage
-      ? this.element.querySelector(
-          `amp-story-page#${escapeCssSelectorIdent(
-            this.getInitialPageId_(firstPage)
-          )}`
-        )
-      : null;
-    activePage && activePage.setAttribute('active', '');
+    const page = this.element.querySelector(
+      `amp-story-page#${escapeCssSelectorIdent(this.getInitialPageId_())}`
+    );
+    page && page.setAttribute('active', '');
 
     this.initializeStyles_();
     this.initializeListeners_();
@@ -963,11 +958,7 @@ export class AmpStory extends AMP.BaseElement {
    * @private
    */
   layoutStory_() {
-    const firstPageEl = user().assertElement(
-      this.element.querySelector('amp-story-page'),
-      'Story must have at least one page.'
-    );
-    const initialPageId = this.getInitialPageId_(firstPageEl);
+    const initialPageId = this.getInitialPageId_();
 
     this.buildSystemLayer_(initialPageId);
     this.initializeSidebar_();
@@ -1039,12 +1030,15 @@ export class AmpStory extends AMP.BaseElement {
 
     this.maybeLoadStoryEducation_();
 
-    // Story is being prerendered: resolve the layoutCallback when the first
+    // Story is being prerendered: resolve the layoutCallback when the active
     // page is built. Other pages will only build if the document becomes
     // visible.
+    const initialPageEl = this.element.querySelector(
+      `amp-story-page#${escapeCssSelectorIdent(initialPageId)}`
+    );
     if (!this.getAmpDoc().hasBeenVisible()) {
-      return whenUpgradedToCustomElement(firstPageEl).then(() => {
-        return firstPageEl.whenBuilt();
+      return whenUpgradedToCustomElement(initialPageEl).then(() => {
+        return initialPageEl.whenBuilt();
       });
     }
 
@@ -1084,11 +1078,10 @@ export class AmpStory extends AMP.BaseElement {
    * Retrieves the initial pageId to begin the story with. In order, the
    * initial page for a story should be either a valid page ID in the URL
    * fragment, the page ID in the history, or the first page of the story.
-   * @param {!Element} firstPageEl
    * @return {string}
    * @private
    */
-  getInitialPageId_(firstPageEl) {
+  getInitialPageId_() {
     const maybePageId = parseQueryString(this.win.location.hash)['page'];
     if (maybePageId && this.isActualPage_(maybePageId)) {
       return maybePageId;
@@ -1103,6 +1096,10 @@ export class AmpStory extends AMP.BaseElement {
       return historyPage;
     }
 
+    const firstPageEl = user().assertElement(
+      this.element.querySelector('amp-story-page'),
+      'Story must have at least one page.'
+    );
     return firstPageEl.id;
   }
 


### PR DESCRIPTION
When you specify `#visibilityState=prerender&page=page-id` (example [here](https://www.gstatic.com/amphtml/stamp/qa/branching.html#page=page-2&visibilityState=prerender)) the second page is not loaded / shown, but the first one is. Fixes #29351

Demo: https://stories-demos-matias.web.app/examples/amp-story/interactives.html#visibilityState=prerender&page=quiz-intl

The fix involves 3 things:
- Set the hashParam'ed page as active instead of the first page by default when you pass a page in the hashString.
- Allow prerendering of the hashParam'ed **page** before the visibility changes. This marks the page as built so it updates the classes `i-amphtml-built` (for instance so that the text is not set to transparent) and it also triggers the `buildCallback` of the hashParam'ed page.
- Allow prerendering of the hashParam'ed page **layers** before the visibility changes. This is optional but sets the styles like applying the template classes (vertical, fill, etc) so the prerendered version doesn't look that bad.

Still, the previous page won't be in position, but it does show the correct active page.
![image](https://user-images.githubusercontent.com/22420856/102543874-f0369580-4081-11eb-8cf8-d8566e96b83c.png)
