### PR TITLE
🐛 Fix script errors in no signing

### DIFF
--- a/extensions/amp-a4a/0.1/secure-frame.js
+++ b/extensions/amp-a4a/0.1/secure-frame.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import {Services} from '../../../src/services';
 import {createElementWithAttributes, escapeHtml} from '../../../src/dom';
 import {dict} from '../../../src/utils/object';
 
@@ -36,6 +35,7 @@ const sandboxVals =
   'allow-popups ' +
   'allow-popups-to-escape-sandbox ' +
   'allow-same-origin ' +
+  'allow-scripts ' +
   'allow-top-navigation';
 
 export const createSecureDocSkeleton = (url, sanitizedHeadElements, body) =>
@@ -69,10 +69,6 @@ export const createSecureDocSkeleton = (url, sanitizedHeadElements, body) =>
  * @return {!HTMLIFrameElement}
  */
 export function createSecureFrame(win, title, height, width) {
-  const sandbox = Services.platformFor(win).isSafari()
-    ? sandboxVals + ' allow-scripts'
-    : sandboxVals;
-
   const {document} = win;
   const iframe = /** @type {!HTMLIFrameElement} */ (createElementWithAttributes(
     document,
@@ -87,7 +83,7 @@ export function createSecureFrame(win, title, height, width) {
       'allowfullscreen': '',
       'allowtransparency': '',
       'scrolling': 'no',
-      'sandbox': sandbox,
+      'sandbox': sandboxVals,
     })
   ));
   return iframe;

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -96,7 +96,7 @@ if (NO_SIGNING_RTV) {
       const fie = doc.body.querySelector('iframe[srcdoc]');
       expect(fie.getAttribute('sandbox')).to.equal(
         'allow-forms allow-popups allow-popups-to-escape-sandbox ' +
-          'allow-same-origin allow-top-navigation'
+          'allow-same-origin allow-scripts allow-top-navigation'
       );
       const cspMeta = fie.contentDocument.querySelector(
         'meta[http-equiv=Content-Security-Policy]'
@@ -134,18 +134,6 @@ if (NO_SIGNING_RTV) {
       expect(fie.getAttribute('sandbox')).to.equal(
         'allow-forms allow-popups allow-popups-to-escape-sandbox ' +
           'allow-same-origin allow-top-navigation'
-      );
-    });
-
-    it('should add allow-scripts to sandbox in Safari', async () => {
-      env.sandbox.stub(Services.platformFor(env.win), 'isSafari').returns(true);
-      await a4a.buildCallback();
-      a4a.onLayoutMeasure();
-      await a4a.layoutCallback();
-      const fie = doc.body.querySelector('iframe[srcdoc]');
-      expect(fie.getAttribute('sandbox')).to.equal(
-        'allow-forms allow-popups allow-popups-to-escape-sandbox ' +
-          'allow-same-origin allow-top-navigation allow-scripts'
       );
     });
 


### PR DESCRIPTION
<iframe> sandbox without `allow-scripts` keeps breaking in unpredictable ways. The latest version is that references to functions on iframe window (eg `this.win.setTimeout` or `this.win.clearInterval`) will throw errors. This moves all browsers to use the same setup as safari, relying on csp rather than sandbox.