### PR TITLE
[amp-consent] Change `transform` rule to a CSS variable

### DIFF
--- a/extensions/amp-consent/0.1/amp-consent.css
+++ b/extensions/amp-consent/0.1/amp-consent.css
@@ -144,6 +144,7 @@ amp-consent.i-amphtml-consent-ui-modal.i-amphtml-consent-ui-border-enabled {
 amp-consent.i-amphtml-consent-ui-iframe-active.i-amphtml-consent-ui-in {
   transition: transform 0.5s ease-out !important;
   /* Initial height transform will be set through styles */
+  transform: var(--i-amphtml-consent-iframe-tranform) !important;
 }
 
 amp-consent.i-amphtml-consent-ui-iframe-active.i-amphtml-consent-ui-in.i-amphtml-consent-ui-iframe-fullscreen {

--- a/extensions/amp-consent/0.1/consent-ui.js
+++ b/extensions/amp-consent/0.1/consent-ui.js
@@ -32,6 +32,7 @@ import {getConsentStateValue} from './consent-info';
 import {getData} from '../../../src/event-helper';
 import {getServicePromiseForDoc} from '../../../src/service';
 import {htmlFor} from '../../../src/static-template';
+import {isExperimentOn} from '../../../src/experiments';
 import {setImportantStyles, setStyles, toggle} from '../../../src/style';
 
 const TAG = 'amp-consent-ui';
@@ -180,6 +181,11 @@ export class ConsentUI {
 
     /** @private {?Promise<string>} */
     this.promptUISrcPromise_ = null;
+
+    this.isTransformExperimentOn_ = isExperimentOn(
+      this.win_,
+      'amp-consent-transform-exp'
+    );
 
     this.init_(config, opt_postPromptUI);
   }
@@ -707,10 +713,18 @@ export class ConsentUI {
         height: this.initialHeight_,
       });
     }
-    setImportantStyles(this.parent_, {
-      transform: `translate3d(0px, calc(100% - ${this.initialHeight_}), 0px)`,
-      '--i-amphtml-modal-height': `${this.initialHeight_}`,
-    });
+    if (this.isTransformExperimentOn_) {
+      setImportantStyles(this.parent_, {
+        '--i-amphtml-consent-iframe-tranform': `translate3d(0px, calc(100% - ${this.initialHeight_}), 0px)`,
+        '--i-amphtml-modal-height': `${this.initialHeight_}`,
+      });
+    } else {
+      setImportantStyles(this.parent_, {
+        transform: `translate3d(0px, calc(100% - ${this.initialHeight_}), 0px)`,
+        '--i-amphtml-modal-height': `${this.initialHeight_}`,
+      });
+    }
+
     // Border is default with modal enabled and option with non-modal
     if (this.borderEnabled_ || this.modalEnabled_) {
       const {classList} = this.parent_;

--- a/extensions/amp-consent/0.1/consent-ui.js
+++ b/extensions/amp-consent/0.1/consent-ui.js
@@ -32,7 +32,6 @@ import {getConsentStateValue} from './consent-info';
 import {getData} from '../../../src/event-helper';
 import {getServicePromiseForDoc} from '../../../src/service';
 import {htmlFor} from '../../../src/static-template';
-import {isExperimentOn} from '../../../src/experiments';
 import {setImportantStyles, setStyles, toggle} from '../../../src/style';
 
 const TAG = 'amp-consent-ui';
@@ -181,11 +180,6 @@ export class ConsentUI {
 
     /** @private {?Promise<string>} */
     this.promptUISrcPromise_ = null;
-
-    this.isTransformExperimentOn_ = isExperimentOn(
-      this.win_,
-      'amp-consent-transform-exp'
-    );
 
     this.init_(config, opt_postPromptUI);
   }
@@ -713,17 +707,10 @@ export class ConsentUI {
         height: this.initialHeight_,
       });
     }
-    if (this.isTransformExperimentOn_) {
-      setImportantStyles(this.parent_, {
-        '--i-amphtml-consent-iframe-tranform': `translate3d(0px, calc(100% - ${this.initialHeight_}), 0px)`,
-        '--i-amphtml-modal-height': `${this.initialHeight_}`,
-      });
-    } else {
-      setImportantStyles(this.parent_, {
-        transform: `translate3d(0px, calc(100% - ${this.initialHeight_}), 0px)`,
-        '--i-amphtml-modal-height': `${this.initialHeight_}`,
-      });
-    }
+    setImportantStyles(this.parent_, {
+      '--i-amphtml-consent-iframe-tranform': `translate3d(0px, calc(100% - ${this.initialHeight_}), 0px)`,
+      '--i-amphtml-modal-height': `${this.initialHeight_}`,
+    });
 
     // Border is default with modal enabled and option with non-modal
     if (this.borderEnabled_ || this.modalEnabled_) {

--- a/extensions/amp-consent/0.1/test/test-consent-ui.js
+++ b/extensions/amp-consent/0.1/test/test-consent-ui.js
@@ -30,6 +30,7 @@ import {
   registerServiceBuilder,
   resetServiceForTesting,
 } from '../../../../src/service';
+import {toggleExperiment} from '../../../../src/experiments';
 import {user} from '../../../../src/log';
 import {whenCalled} from '../../../../testing/test-helper.js';
 
@@ -216,6 +217,39 @@ describes.realWin(
         consentUI.disableScroll_();
         consentUI.hide();
         expect(consentUI.scrollEnabled_).to.be.true;
+      });
+
+      describe('amp-consent-transform-exp', () => {
+        beforeEach(() => {
+          toggleExperiment(win, 'amp-consent-transform-exp', true);
+        });
+
+        afterEach(() => {
+          toggleExperiment(win, 'amp-consent-transform-exp', false);
+        });
+
+        it('should set the correct transform on parent', async () => {
+          const config = dict({
+            'promptUISrc': 'https://promptUISrc',
+          });
+          consentUI = new ConsentUI(mockInstance, config);
+
+          consentUI.show(false);
+          consentUI.handleIframeMessages_({
+            source: consentUI.ui_.contentWindow,
+            data: {
+              type: 'consent-ui',
+              action: 'ready',
+              initialHeight: '80vh',
+            },
+          });
+          await macroTask();
+          expect(
+            consentUI.parent_.style.getPropertyValue(
+              '--i-amphtml-consent-iframe-tranform'
+            )
+          ).to.equal('translate3d(0px, calc(100% - 80vh), 0px)');
+        });
       });
     });
 

--- a/extensions/amp-consent/0.1/test/test-consent-ui.js
+++ b/extensions/amp-consent/0.1/test/test-consent-ui.js
@@ -30,7 +30,6 @@ import {
   registerServiceBuilder,
   resetServiceForTesting,
 } from '../../../../src/service';
-import {toggleExperiment} from '../../../../src/experiments';
 import {user} from '../../../../src/log';
 import {whenCalled} from '../../../../testing/test-helper.js';
 
@@ -219,37 +218,27 @@ describes.realWin(
         expect(consentUI.scrollEnabled_).to.be.true;
       });
 
-      describe('amp-consent-transform-exp', () => {
-        beforeEach(() => {
-          toggleExperiment(win, 'amp-consent-transform-exp', true);
+      it('should set the correct transform on parent', async () => {
+        const config = dict({
+          'promptUISrc': 'https://promptUISrc',
         });
+        consentUI = new ConsentUI(mockInstance, config);
 
-        afterEach(() => {
-          toggleExperiment(win, 'amp-consent-transform-exp', false);
+        consentUI.show(false);
+        consentUI.handleIframeMessages_({
+          source: consentUI.ui_.contentWindow,
+          data: {
+            type: 'consent-ui',
+            action: 'ready',
+            initialHeight: '80vh',
+          },
         });
-
-        it('should set the correct transform on parent', async () => {
-          const config = dict({
-            'promptUISrc': 'https://promptUISrc',
-          });
-          consentUI = new ConsentUI(mockInstance, config);
-
-          consentUI.show(false);
-          consentUI.handleIframeMessages_({
-            source: consentUI.ui_.contentWindow,
-            data: {
-              type: 'consent-ui',
-              action: 'ready',
-              initialHeight: '80vh',
-            },
-          });
-          await macroTask();
-          expect(
-            consentUI.parent_.style.getPropertyValue(
-              '--i-amphtml-consent-iframe-tranform'
-            )
-          ).to.equal('translate3d(0px, calc(100% - 80vh), 0px)');
-        });
+        await macroTask();
+        expect(
+          consentUI.parent_.style.getPropertyValue(
+            '--i-amphtml-consent-iframe-tranform'
+          )
+        ).to.equal('translate3d(0px, calc(100% - 80vh), 0px)');
       });
     });
 

--- a/tools/experiments/experiments-config.js
+++ b/tools/experiments/experiments-config.js
@@ -251,9 +251,4 @@ export const EXPERIMENTS = [
     name: 'To measure the CWV impact of ads idle rendering',
     spec: 'https://github.com/ampproject/amphtml/issues/31436',
   },
-  {
-    id: 'amp-consent-transform-exp',
-    name: 'To test that transform does not get removed by viewer',
-    spec: 'https://github.com/ampproject/amphtml/issues/31580',
-  },
 ];

--- a/tools/experiments/experiments-config.js
+++ b/tools/experiments/experiments-config.js
@@ -251,4 +251,9 @@ export const EXPERIMENTS = [
     name: 'To measure the CWV impact of ads idle rendering',
     spec: 'https://github.com/ampproject/amphtml/issues/31436',
   },
+  {
+    id: 'amp-consent-transform-exp',
+    name: 'To test that transform does not get removed by viewer',
+    spec: 'https://github.com/ampproject/amphtml/issues/31580',
+  },
 ];


### PR DESCRIPTION
For #31580 

When served in a google viewer, the viewer has a top bar. When a user scrolls, the bar shows/hides. For elements tracked by the fixed layer (i.e. amp-consent element), when the bar is shown and hidden, the `transform` style applied to the element's style is eliminated. 

Therefore, when a user scrolls on a doc served in a viewer before the consent iframe loads, the transform style will be removed and no transformation will be applied. 

Since fixed layer only removes `transform` style, we can add it to another class (just need to worry about CSS rule precedence).

/cc @jridgewell 