### PR TITLE
Bento: expose Imperative API object

### DIFF
--- a/build-system/eslint-rules/no-array-destructuring.js
+++ b/build-system/eslint-rules/no-array-destructuring.js
@@ -49,7 +49,10 @@ module.exports = function (context) {
       if (computed) {
         return false;
       }
-      if (object.type !== 'Identifier' || object.name !== 'preact') {
+      if (
+        object.type !== 'Identifier' ||
+        object.name.toLowerCase() !== 'preact'
+      ) {
         return false;
       }
       if (property.type !== 'Identifier' || !property.name.startsWith('use')) {

--- a/src/base-element.js
+++ b/src/base-element.js
@@ -960,7 +960,7 @@ export class BaseElement {
    * imperative API object, since this is where we define the element's custom
    * APIs.
    *
-   * @return {!Promise<!./base-element.BaseElement>}
+   * @return {!Promise<!Object>}
    */
   getApi() {
     return this;

--- a/src/base-element.js
+++ b/src/base-element.js
@@ -954,4 +954,15 @@ export class BaseElement {
   user() {
     return user(this.element);
   }
+
+  /**
+   * Returns this BaseElement instance. This is equivalent to Bento's
+   * imperative API object, since this is where we define the element's custom
+   * APIs.
+   *
+   * @return {!Promise<!./base-element.BaseElement>}
+   */
+  getApi() {
+    return this;
+  }
 }

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -1075,6 +1075,17 @@ function createBaseCustomElementClass(win) {
     }
 
     /**
+     * Returns the object which holds the API surface (the thing we add the
+     * custom methods/properties onto). In Bento, this is the imperative API
+     * object. In AMP, this is the BaseElement instance.
+     *
+     * @return {!Promise<!Object>}
+     */
+    getApi() {
+      return this.getImpl().then((impl) => impl.getApi());
+    }
+
+    /**
      * Returns the layout of the element.
      * @return {!Layout}
      */

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -303,7 +303,7 @@ function createBaseCustomElementClass(win) {
 
     /** @return {!Promise<!Object>} */
     whenUpgraded() {
-      return this.signals_.whenSignal(CommonSignals.UPGRADED).then(() => {});
+      return this.signals_.whenSignal(CommonSignals.UPGRADED);
     }
 
     /**
@@ -1072,6 +1072,14 @@ function createBaseCustomElementClass(win) {
     getImpl(waitForBuild = true) {
       const waitFor = waitForBuild ? this.whenBuilt() : this.whenUpgraded();
       return waitFor.then(() => this.implementation_);
+    }
+
+    /**
+     * Returns reference to upgraded implementation, where imperative APIs are placed.
+     * @return {!Promise<!./base-element.BaseElement>}
+     */
+    getApi() {
+      return this.getImpl();
     }
 
     /**

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -1075,14 +1075,6 @@ function createBaseCustomElementClass(win) {
     }
 
     /**
-     * Returns reference to upgraded implementation, where imperative APIs are placed.
-     * @return {!Promise<!./base-element.BaseElement>}
-     */
-    getApi() {
-      return this.getImpl();
-    }
-
-    /**
      * Returns the layout of the element.
      * @return {!Layout}
      */

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -301,7 +301,7 @@ function createBaseCustomElementClass(win) {
       return this.upgradeState_ == UpgradeState.UPGRADED;
     }
 
-    /** @return {!Promise<!Object>} */
+    /** @return {!Promise} */
     whenUpgraded() {
       return this.signals_.whenSignal(CommonSignals.UPGRADED);
     }

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -301,9 +301,9 @@ function createBaseCustomElementClass(win) {
       return this.upgradeState_ == UpgradeState.UPGRADED;
     }
 
-    /** @return {!Promise} */
+    /** @return {!Promise<!Object>} */
     whenUpgraded() {
-      return this.signals_.whenSignal(CommonSignals.UPGRADED);
+      return this.signals_.whenSignal(CommonSignals.UPGRADED).then(() => {});
     }
 
     /**

--- a/src/preact/base-element.js
+++ b/src/preact/base-element.js
@@ -39,7 +39,7 @@ import {
   parseBooleanAttribute,
 } from '../dom';
 import {dashToCamelCase} from '../string';
-import {dev, devAssert} from '../log';
+import {devAssert} from '../log';
 import {dict, hasOwn, map} from '../utils/object';
 import {getDate} from '../utils/date';
 import {getMode} from '../mode';
@@ -694,7 +694,7 @@ export class PreactBaseElement extends AMP.BaseElement {
     const newKeys = Object.keys(current);
     for (let i = 0; i < newKeys.length; i++) {
       const key = newKeys[i];
-      dev().assert(
+      devAssert(
         hasOwn(api, key),
         'Inconsistent Bento API shape: imperative API gained a "%s" key for %s',
         key,
@@ -704,7 +704,7 @@ export class PreactBaseElement extends AMP.BaseElement {
     const oldKeys = Object.keys(api);
     for (let i = 0; i < oldKeys.length; i++) {
       const key = oldKeys[i];
-      dev().assert(
+      devAssert(
         hasOwn(current, key),
         'Inconsistent Bento API shape: imperative API lost a "%s" key for %s',
         key,

--- a/src/preact/base-element.js
+++ b/src/preact/base-element.js
@@ -175,10 +175,6 @@ export class PreactBaseElement extends AMP.BaseElement {
       } else {
         this.initApiWrapper_(ref);
       }
-      if (this.deferredApi_) {
-        this.deferredApi_.resolve(ref);
-        this.deferredApi_ = null;
-      }
       this.ref_.current = ref;
     };
 
@@ -682,6 +678,10 @@ export class PreactBaseElement extends AMP.BaseElement {
       });
     }
     this.apiWrapper_ = api;
+    if (this.deferredApi_) {
+      this.deferredApi_.resolve(api);
+      this.deferredApi_ = null;
+    }
   }
 
   /**

--- a/src/preact/base-element.js
+++ b/src/preact/base-element.js
@@ -39,7 +39,7 @@ import {
   parseBooleanAttribute,
 } from '../dom';
 import {dashToCamelCase} from '../string';
-import {devAssert} from '../log';
+import {dev, devAssert} from '../log';
 import {dict, hasOwn, map} from '../utils/object';
 import {getDate} from '../utils/date';
 import {getMode} from '../mode';
@@ -694,20 +694,22 @@ export class PreactBaseElement extends AMP.BaseElement {
     const newKeys = Object.keys(current);
     for (let i = 0; i < newKeys.length; i++) {
       const key = newKeys[i];
-      if (!hasOwn(api, key)) {
-        throw new Error(
-          `Inconsistent Bento API shape: imperative API gained a "${key}" key`
-        );
-      }
+      dev().assert(
+        hasOwn(api, key),
+        'Inconsistent Bento API shape: imperative API gained a "%s" key for %s',
+        key,
+        this.element
+      );
     }
     const oldKeys = Object.keys(api);
     for (let i = 0; i < oldKeys.length; i++) {
       const key = oldKeys[i];
-      if (!hasOwn(current, key)) {
-        throw new Error(
-          `Inconsistent Bento API shape: imperative API lost a "${key}" key`
-        );
-      }
+      dev().assert(
+        hasOwn(current, key),
+        'Inconsistent Bento API shape: imperative API lost a "%s" key for %s',
+        key,
+        this.element
+      );
     }
   }
 }

--- a/src/preact/base-element.js
+++ b/src/preact/base-element.js
@@ -655,7 +655,7 @@ export class PreactBaseElement extends AMP.BaseElement {
 
   /**
    * Creates a wrapper around a Preact ref. The API surface exposed by this ref
-   * **should** be consistent accross all rerenders.
+   * **must** be consistent accross all rerenders.
    *
    * This wrapper is necessary because every time React rerenders, it creates
    * (depending on deps checking) a new imperative handle and sets that to
@@ -687,19 +687,26 @@ export class PreactBaseElement extends AMP.BaseElement {
    * @private
    */
   checkApiWrapper_(current) {
+    if (!getMode().localDev) {
+      return;
+    }
     const api = this.apiWrapper_;
     const newKeys = Object.keys(current);
     for (let i = 0; i < newKeys.length; i++) {
       const key = newKeys[i];
       if (!hasOwn(api, key)) {
-        wrapRefProperty(this, api, key);
+        throw new Error(
+          `Inconsistent Bento API shape: imperative API gained a "${key}" key`
+        );
       }
     }
     const oldKeys = Object.keys(api);
     for (let i = 0; i < oldKeys.length; i++) {
       const key = oldKeys[i];
       if (!hasOwn(current, key)) {
-        delete api[key];
+        throw new Error(
+          `Inconsistent Bento API shape: imperative API lost a "${key}" key`
+        );
       }
     }
   }

--- a/src/preact/base-element.js
+++ b/src/preact/base-element.js
@@ -640,7 +640,9 @@ export class PreactBaseElement extends AMP.BaseElement {
   /**
    * Returns reference to upgraded imperative API object, as in React's
    * useImperativeHandle.
+   *
    * @return {!Promise<!API_TYPE>}
+   * @override
    */
   getApi() {
     const api = this.apiWrapper_;

--- a/src/preact/base-element.js
+++ b/src/preact/base-element.js
@@ -644,7 +644,7 @@ export class PreactBaseElement extends AMP.BaseElement {
    * useImperativeHandle.
    * @return {!Promise<!API_TYPE>}
    */
-  getImpl() {
+  getApi() {
     const api = this.apiWrapper_;
     if (api) {
       return Promise.resolve(api);
@@ -718,9 +718,10 @@ export class PreactBaseElement extends AMP.BaseElement {
  * @return {!Promise<!Object>}
  */
 export function whenUpgraded(el) {
-  return customElements.whenDefined(el.localName).then(() => {
-    return el.getImpl();
-  });
+  return customElements
+    .whenDefined(el.localName)
+    .then(() => el.getImpl())
+    .then((impl) => impl.getApi());
 }
 
 // Ideally, these would be Static Class Fields. But Closure can't even.

--- a/src/preact/base-element.js
+++ b/src/preact/base-element.js
@@ -663,6 +663,7 @@ export class PreactBaseElement extends AMP.BaseElement {
    * stale by the time its actually used.
    *
    * @param {!API_TYPE} current
+   * @private
    */
   initApiWrapper_(current) {
     const api = map();
@@ -683,6 +684,7 @@ export class PreactBaseElement extends AMP.BaseElement {
    * If it does not, the API wrapper is syncrhonized.
    *
    * @param {!API_TYPE} current
+   * @private
    */
   checkApiWrapper_(current) {
     const api = this.apiWrapper_;

--- a/src/preact/base-element.js
+++ b/src/preact/base-element.js
@@ -713,8 +713,7 @@ export class PreactBaseElement extends AMP.BaseElement {
 }
 
 /**
- * @param {tyepof PreactBaseElement} } ref
- * @param baseElement
+ * @param {tyepof PreactBaseElement} baseElement
  * @param {!Object} api
  * @param {string} key
  */

--- a/src/preact/index.js
+++ b/src/preact/index.js
@@ -83,7 +83,7 @@ export function createContext(value) {
 }
 
 // Defines the type interfaces for the approved Preact Hooks APIs.
-// TODO: useReducer, useImperativeHandle, useDebugValue, useErrorBoundary
+// TODO: useReducer, useDebugValue, useErrorBoundary
 
 /**
  * @param {S|function():S} initial

--- a/test/unit/preact/test-base-element-runtime.js
+++ b/test/unit/preact/test-base-element-runtime.js
@@ -16,8 +16,12 @@
 
 import * as Preact from '../../../src/preact/index';
 import {CanRender} from '../../../src/contextprops';
-import {PreactBaseElement} from '../../../src/preact/base-element';
+import {
+  PreactBaseElement,
+  whenUpgraded,
+} from '../../../src/preact/base-element';
 import {Slot} from '../../../src/preact/slot';
+import {forwardRef} from '../../../src/preact/compat';
 import {htmlFor} from '../../../src/static-template';
 import {removeElement} from '../../../src/dom';
 import {subscribe} from '../../../src/context';
@@ -204,5 +208,132 @@ describes.realWin('PreactBaseElement', {amp: true}, (env) => {
       doc.body.appendChild(element);
       await waitFor(() => getSlot(), 'content rerendered');
     });
+  });
+});
+
+describes.realWin.only('whenUpgraded', {amp: true}, (env) => {
+  let win;
+  let doc;
+  let Impl;
+  let Component;
+
+  beforeEach(() => {
+    win = env.win;
+    doc = win.document;
+
+    Impl = class extends PreactBaseElement {
+      isLayoutSupported() {
+        return true;
+      }
+    };
+    Component = (props, ref) => {
+      Preact.useImperativeHandle(ref, () => {
+        return {key: true};
+      });
+    };
+    Impl['Component'] = forwardRef(Component);
+    Impl['children'] = {};
+    Impl['loadable'] = true;
+  });
+
+  it('waits for CE definition', async () => {
+    const el = doc.createElement('amp-preact');
+    doc.body.appendChild(el);
+    const p = whenUpgraded(el);
+    upgradeOrRegisterElement(win, 'amp-preact', Impl);
+    el.build();
+
+    const api = await p;
+    expect(api.key).to.be.true;
+  });
+
+  it('waits for build', async () => {
+    const el = doc.createElement('amp-preact');
+    doc.body.appendChild(el);
+    upgradeOrRegisterElement(win, 'amp-preact', Impl);
+    const p = whenUpgraded(el);
+    el.build();
+
+    const api = await p;
+    expect(api.key).to.be.true;
+  });
+
+  it('resolves after mount', async () => {
+    const el = doc.createElement('amp-preact');
+    doc.body.appendChild(el);
+    upgradeOrRegisterElement(win, 'amp-preact', Impl);
+    await el.build();
+    const p = whenUpgraded(el);
+
+    const api = await p;
+    expect(api.key).to.be.true;
+  });
+
+  it('wraps API to preserve object identity accross rerenders', async () => {
+    let imperativeApi;
+    let setState;
+    Component = env.sandbox.stub().callsFake((props, ref) => {
+      const [state, set] = Preact.useState(0);
+      setState = set;
+      Preact.useImperativeHandle(ref, () => {
+        return (imperativeApi = {state});
+      });
+    });
+    Impl['Component'] = forwardRef(Component);
+    const el = doc.createElement('amp-preact');
+    doc.body.appendChild(el);
+    upgradeOrRegisterElement(win, 'amp-preact', Impl);
+    const p = whenUpgraded(el);
+    el.build();
+
+    const api = await p;
+    expect(api).not.to.equal(imperativeApi);
+    expect(api.state).to.equal(0);
+
+    const current = Component.callCount;
+    setState(1);
+    await waitFor(
+      () => Component.callCount > current,
+      'rerender after setState'
+    );
+
+    const api2 = await whenUpgraded(el);
+    expect(api2).to.equal(api);
+    expect(api.state).to.equal(1);
+  });
+
+  it('synchronizes API surface after rerender', async () => {
+    let setState;
+    Component = env.sandbox.stub().callsFake((props, ref) => {
+      const [api, set] = Preact.useState({
+        first: true,
+      });
+      setState = set;
+      Preact.useImperativeHandle(ref, () => {
+        return api;
+      });
+    });
+    Impl['Component'] = forwardRef(Component);
+    const el = doc.createElement('amp-preact');
+    doc.body.appendChild(el);
+    upgradeOrRegisterElement(win, 'amp-preact', Impl);
+    const p = whenUpgraded(el);
+    el.build();
+
+    const api = await p;
+    expect(api.first).to.be.true;
+    expect(api.second).to.be.undefined;
+
+    const current = Component.callCount;
+    setState({
+      second: true,
+    });
+    await waitFor(
+      () => Component.callCount > current,
+      'rerender after setState'
+    );
+
+    expect(api.first).to.be.undefined;
+    expect(api.second).to.be.true;
   });
 });

--- a/test/unit/preact/test-base-element-runtime.js
+++ b/test/unit/preact/test-base-element-runtime.js
@@ -302,7 +302,7 @@ describes.realWin('whenUpgraded', {amp: true}, (env) => {
     expect(api.state).to.equal(1);
   });
 
-  it('synchronizes API surface after rerender', async () => {
+  it('throws when API surface changes after rerender', async () => {
     let setState;
     Component = env.sandbox.stub().callsFake((props, ref) => {
       const [api, set] = Preact.useState({
@@ -322,7 +322,7 @@ describes.realWin('whenUpgraded', {amp: true}, (env) => {
 
     const api = await p;
     expect(api.first).to.be.true;
-    expect(api.second).to.be.undefined;
+    expect(el).not.to.have.display('none');
 
     const current = Component.callCount;
     setState({
@@ -333,7 +333,6 @@ describes.realWin('whenUpgraded', {amp: true}, (env) => {
       'rerender after setState'
     );
 
-    expect(api.first).to.be.undefined;
-    expect(api.second).to.be.true;
+    expect(el).to.have.class('i-amphtml-error');
   });
 });

--- a/test/unit/preact/test-base-element-runtime.js
+++ b/test/unit/preact/test-base-element-runtime.js
@@ -211,7 +211,7 @@ describes.realWin('PreactBaseElement', {amp: true}, (env) => {
   });
 });
 
-describes.realWin.only('whenUpgraded', {amp: true}, (env) => {
+describes.realWin('whenUpgraded', {amp: true}, (env) => {
   let win;
   let doc;
   let Impl;


### PR DESCRIPTION
Implements `whenUpgraded` for Bento Imperative APIs, which exposes the API object from `Preact`'s `useImperativeHandle`. The API is wrapped an API wrapper, so that the object can be shared across rerenders (get the API once, instead of calling `whenUpgraded` multiple times).