### PR TITLE
Bento Carousel: Various fixes for Thumbnails component

### DIFF
--- a/extensions/amp-base-carousel/1.0/base-carousel.js
+++ b/extensions/amp-base-carousel/1.0/base-carousel.js
@@ -117,6 +117,7 @@ function BaseCarouselWithRef(
   const currentSlideRef = useRef(currentSlide);
 
   useLayoutEffect(() => {
+    // noop if !_thumbnails || !carouselContext.
     setCurrentSlide(globalCurrentSlide);
   }, [globalCurrentSlide, setCurrentSlide]);
 

--- a/extensions/amp-base-carousel/1.0/base-carousel.js
+++ b/extensions/amp-base-carousel/1.0/base-carousel.js
@@ -212,10 +212,24 @@ function BaseCarouselWithRef(
     }
   }, [_thumbnails, childrenArray, setSlides, slides]);
 
-  const disableForDir = (dir) =>
-    !loop &&
-    (currentSlide + dir < 0 ||
-      (!mixedLength && currentSlide + visibleCount + dir > length));
+  const disableForDir = (dir) => {
+    if (_thumbnails) {
+      console.log(currentSlide, dir);
+    }
+    if (loop) {
+      // Arrows always available when looping.
+      return false;
+    }
+    if (currentSlide + dir < 0) {
+      // Can no longer advance backwards.
+      return true;
+    }
+    if (!mixedLength && currentSlide + visibleCount + dir > length) {
+      // Can no longer advance forwards.
+      return true;
+    }
+    return false;
+  };
 
   const interaction = useRef(Interaction.NONE);
   const hideControls = useMemo(() => {

--- a/extensions/amp-base-carousel/1.0/base-carousel.js
+++ b/extensions/amp-base-carousel/1.0/base-carousel.js
@@ -213,9 +213,6 @@ function BaseCarouselWithRef(
   }, [_thumbnails, childrenArray, setSlides, slides]);
 
   const disableForDir = (dir) => {
-    if (_thumbnails) {
-      console.log(currentSlide, dir);
-    }
     if (loop) {
       // Arrows always available when looping.
       return false;

--- a/extensions/amp-base-carousel/1.0/base-carousel.js
+++ b/extensions/amp-base-carousel/1.0/base-carousel.js
@@ -224,7 +224,7 @@ function BaseCarouselWithRef(
       // Can no longer advance backwards.
       return true;
     }
-    if (!mixedLength && currentSlide + visibleCount + dir > length) {
+    if (currentSlide + visibleCount + dir > length) {
       // Can no longer advance forwards.
       return true;
     }

--- a/extensions/amp-base-carousel/1.0/base-carousel.js
+++ b/extensions/amp-base-carousel/1.0/base-carousel.js
@@ -107,10 +107,19 @@ function BaseCarouselWithRef(
   const [currentSlideState, setCurrentSlideState] = useState(
     Math.min(Math.max(defaultSlide, 0), length)
   );
-  const currentSlide = carouselContext.currentSlide ?? currentSlideState;
-  const currentSlideRef = useRef(currentSlide);
-  const setCurrentSlide =
+  const globalCurrentSlide = carouselContext.currentSlide ?? currentSlideState;
+  const setGlobalCurrentSlide =
     carouselContext.setCurrentSlide ?? setCurrentSlideState;
+  const currentSlide = _thumbnails ? currentSlideState : globalCurrentSlide;
+  const setCurrentSlide = _thumbnails
+    ? setCurrentSlideState
+    : setGlobalCurrentSlide;
+  const currentSlideRef = useRef(currentSlide);
+
+  useLayoutEffect(() => {
+    setCurrentSlide(globalCurrentSlide);
+  }, [globalCurrentSlide, setCurrentSlide]);
+
   const {slides, setSlides} = carouselContext;
 
   const scrollRef = useRef(null);

--- a/extensions/amp-base-carousel/1.0/dimensions.js
+++ b/extensions/amp-base-carousel/1.0/dimensions.js
@@ -239,7 +239,8 @@ export function scrollContainerToElement(
     ? getStart(axis, container)
     : getCenter(axis, container);
   const delta = Math.round(snapOffset - scrollOffset - offset * length);
-
+  const oldPosition = getScrollPosition(axis, container);
   updateScrollPosition(axis, container, delta);
-  return !!delta;
+  const newPosition = getScrollPosition(axis, container);
+  return oldPosition !== newPosition;
 }

--- a/extensions/amp-base-carousel/1.0/scroller.js
+++ b/extensions/amp-base-carousel/1.0/scroller.js
@@ -222,9 +222,6 @@ function ScrollerWithRef(
   };
 
   const handleScroll = () => {
-    if (_thumbnails) {
-      return;
-    }
     if (ignoreProgrammaticScrollRef.current) {
       ignoreProgrammaticScrollRef.current = false;
       return;

--- a/extensions/amp-inline-gallery/1.0/storybook/Basic.js
+++ b/extensions/amp-inline-gallery/1.0/storybook/Basic.js
@@ -34,7 +34,7 @@ export const _default = () => {
   const paginationHeight = number('top indicator height', 20);
   const topInset = boolean('top indicator inset?', false);
   const bottomInset = boolean('bottom indicator inset?', false);
-  const autoAdvance = boolean('auto advance', true);
+  const autoAdvance = boolean('auto advance', false);
   const autoAdvanceCount = number('auto advance count', 1);
   const autoAdvanceInterval = number('auto advance interval', 1000);
   const autoAdvanceLoops = number('auto advance loops', 3);

--- a/extensions/amp-inline-gallery/1.0/test/test-inline-gallery.js
+++ b/extensions/amp-inline-gallery/1.0/test/test-inline-gallery.js
@@ -22,51 +22,131 @@ import {Thumbnails} from '../thumbnails';
 import {mount} from 'enzyme';
 
 describes.sandboxed('InlineGallery preact component', {}, () => {
-  it('should render BaseCarousel and Pagination', () => {
-    const jsx = (
-      <InlineGallery>
-        <BaseCarousel>
-          <div>slide 1</div>
-          <div>slide 2</div>
-          <div>slide 3</div>
-        </BaseCarousel>
-        <Pagination />
-      </InlineGallery>
-    );
-    const wrapper = mount(jsx);
-    const carousel = wrapper.find('BaseCarousel');
-    expect(carousel).to.have.lengthOf(1);
-    const slides = carousel.find('[data-slide]');
-    expect(slides).to.have.lengthOf(3);
+  describe('Pagination component', () => {
+    it('should render BaseCarousel and Pagination', () => {
+      const jsx = (
+        <InlineGallery>
+          <BaseCarousel>
+            <div>slide 1</div>
+            <div>slide 2</div>
+            <div>slide 3</div>
+          </BaseCarousel>
+          <Pagination />
+        </InlineGallery>
+      );
+      const wrapper = mount(jsx);
+      const carousel = wrapper.find('BaseCarousel');
+      expect(carousel).to.have.lengthOf(1);
+      const slides = carousel.find('[data-slide]');
+      expect(slides).to.have.lengthOf(3);
 
-    const pagination = wrapper.find('Pagination');
-    expect(pagination).to.have.lengthOf(1);
+      const pagination = wrapper.find('Pagination');
+      expect(pagination).to.have.lengthOf(1);
+    });
   });
 
-  it('should render BaseCarousel and Thumbnails', () => {
-    const jsx = (
-      <InlineGallery>
-        <BaseCarousel>
-          <div>slide 1</div>
-          <div>slide 2</div>
-          <div>slide 3</div>
-        </BaseCarousel>
-        <Thumbnails />
-      </InlineGallery>
-    );
-    const wrapper = mount(jsx);
+  describe('Thumbnail component', () => {
+    it('should render BaseCarousel and Thumbnails', () => {
+      const jsx = (
+        <InlineGallery>
+          <BaseCarousel>
+            <div>slide 1</div>
+            <div>slide 2</div>
+            <div>slide 3</div>
+          </BaseCarousel>
+          <Thumbnails />
+        </InlineGallery>
+      );
+      const wrapper = mount(jsx);
 
-    const carousels = wrapper.find('BaseCarousel');
-    expect(carousels).to.have.lengthOf(2);
-    const slides = carousels.first().find('[data-slide]');
-    expect(slides).to.have.lengthOf(3);
+      const carousels = wrapper.find('BaseCarousel');
+      expect(carousels).to.have.lengthOf(2);
+      const slides = carousels.first().find('[data-slide]');
+      expect(slides).to.have.lengthOf(3);
 
-    const thumbnails = wrapper.find('Thumbnails');
-    expect(thumbnails).to.have.lengthOf(1);
-    const generatedCarousel = thumbnails.find('BaseCarousel');
-    expect(generatedCarousel).to.have.lengthOf(1);
+      const thumbnails = wrapper.find('Thumbnails');
+      expect(thumbnails).to.have.lengthOf(1);
+      const generatedCarousel = thumbnails.find('BaseCarousel');
+      expect(generatedCarousel).to.have.lengthOf(1);
+      expect(generatedCarousel.prop('loop')).to.be.false;
+      expect(generatedCarousel.prop('snapAlign')).to.equal('start');
+      expect(generatedCarousel.prop('outsetArrows')).to.be.true;
 
-    const generatedSlides = generatedCarousel.find('[data-slide]');
-    expect(generatedSlides).to.have.lengthOf(3);
+      const generatedSlides = generatedCarousel.find('[data-slide]');
+      expect(generatedSlides).to.have.lengthOf(3);
+
+      // By default there is no `src`
+      expect(generatedSlides.at(0).find('img').prop('src')).to.be.undefined;
+      expect(generatedSlides.at(1).find('img').prop('src')).to.be.undefined;
+      expect(generatedSlides.at(2).find('img').prop('src')).to.be.undefined;
+    });
+
+    it('should respect thumbnailSrc', () => {
+      const jsx = (
+        <InlineGallery>
+          <BaseCarousel>
+            <div thumbnailSrc="slide1.jpg">slide 1</div>
+            <div thumbnailSrc="slide2.jpg">slide 2</div>
+            <div thumbnailSrc="slide3.jpg">slide 3</div>
+          </BaseCarousel>
+          <Thumbnails />
+        </InlineGallery>
+      );
+      const wrapper = mount(jsx);
+
+      const carousels = wrapper.find('BaseCarousel');
+      expect(carousels).to.have.lengthOf(2);
+      const slides = carousels.first().find('[data-slide]');
+      expect(slides).to.have.lengthOf(3);
+
+      const thumbnails = wrapper.find('Thumbnails');
+      expect(thumbnails).to.have.lengthOf(1);
+      const generatedCarousel = thumbnails.find('BaseCarousel');
+      expect(generatedCarousel).to.have.lengthOf(1);
+      expect(generatedCarousel.prop('loop')).to.be.false;
+      expect(generatedCarousel.prop('snapAlign')).to.equal('start');
+      expect(generatedCarousel.prop('outsetArrows')).to.be.true;
+
+      const generatedSlides = generatedCarousel.find('[data-slide]');
+      expect(generatedSlides).to.have.lengthOf(3);
+
+      // Take from `thumbnailSrc` prop.
+      expect(generatedSlides.at(0).find('img').prop('src')).to.equal(
+        'slide1.jpg'
+      );
+      expect(generatedSlides.at(1).find('img').prop('src')).to.equal(
+        'slide2.jpg'
+      );
+      expect(generatedSlides.at(2).find('img').prop('src')).to.equal(
+        'slide3.jpg'
+      );
+    });
+
+    it('should respect looping with slide alignment', () => {
+      const jsx = (
+        <InlineGallery>
+          <BaseCarousel>
+            <div>slide 1</div>
+            <div>slide 2</div>
+            <div>slide 3</div>
+          </BaseCarousel>
+          <Thumbnails loop />
+        </InlineGallery>
+      );
+      const wrapper = mount(jsx);
+
+      const carousels = wrapper.find('BaseCarousel');
+      expect(carousels).to.have.lengthOf(2);
+      const slides = carousels.first().find('[data-slide]');
+      expect(slides).to.have.lengthOf(3);
+
+      const thumbnails = wrapper.find('Thumbnails');
+      expect(thumbnails).to.have.lengthOf(1);
+      const generatedCarousel = thumbnails.find('BaseCarousel');
+      expect(generatedCarousel).to.have.lengthOf(1);
+      expect(generatedCarousel.prop('loop')).to.be.true;
+      expect(generatedCarousel.prop('snapAlign')).to.equal('center');
+      expect(generatedCarousel.prop('outsetArrows')).to.be.true;
+    });
   });
 });

--- a/extensions/amp-inline-gallery/1.0/thumbnails.js
+++ b/extensions/amp-inline-gallery/1.0/thumbnails.js
@@ -72,7 +72,7 @@ export function Thumbnails({
       className={`${className} ${classes.thumbnails}`}
       mixedLength={true}
       snap={false}
-      snapAlign="center"
+      snapAlign={loop ? 'center' : 'start'}
       controls={pointerFine ? 'always' : 'never'}
       loop={loop}
       ref={ref}

--- a/extensions/amp-inline-gallery/1.0/thumbnails.js
+++ b/extensions/amp-inline-gallery/1.0/thumbnails.js
@@ -76,6 +76,7 @@ export function Thumbnails({
       controls={pointerFine ? 'always' : 'never'}
       loop={loop}
       ref={ref}
+      outsetArrows={true}
       _thumbnails={true}
       {...rest}
     >

--- a/extensions/amp-inline-gallery/1.0/thumbnails.js
+++ b/extensions/amp-inline-gallery/1.0/thumbnails.js
@@ -89,7 +89,7 @@ export function Thumbnails({
               onClick={() => setCurrentSlide(i)}
               loading="lazy"
               role="button"
-              src={thumbnailSrc || false}
+              src={thumbnailSrc || undefined}
               style={{
                 height: px(height),
                 width: aspectRatio ? px(aspectRatio * height) : '',

--- a/extensions/amp-inline-gallery/1.0/thumbnails.js
+++ b/extensions/amp-inline-gallery/1.0/thumbnails.js
@@ -88,7 +88,7 @@ export function Thumbnails({
               onClick={() => setCurrentSlide(i)}
               loading="lazy"
               role="button"
-              src={thumbnailSrc || ''}
+              src={thumbnailSrc || false}
               style={{
                 height: px(height),
                 width: aspectRatio ? px(aspectRatio * height) : '',


### PR DESCRIPTION
Partial for #28284. This PR fixes the following bugs:
- `Thumbnails` component can control a deviant internal state from its primary `BaseCarousel` sibling with the following rules:
  - Internal state is overridden by most recent slide change state on the primary `BaseCarousel` (referenced as the "global state"), including actions via scrolling, its arrows, or `Pagination` interaction
  - Internal state can deviate from the primary `BaseCarousel` if user scrolls directly on the `Thumbnails` component or navigates it using its own rendered arrows.
- `Thumbnails` will default to omit the `src` prop (set to `false` instead of `''`) if `thumbnailSrc` is `undefined` on the cloned slide element.
- `Thumbnails` component will align slides to `"center"` if `loop` and `"start"` otherwise, as the default of `"center"` poses scroll position issues otherwise for leading and ending slides which cannot be centered due to space constraints.
- Renders `Thumbnails` arrows with `outsetArrows={true}` - this is a migration difference from 0.1.
- Re-introduces naive arrow disabling for `mixedLength` carousels based on slide state
- Adds unit tests for the above

TODO (in separate PRs): 
- Disable right and prev arrows for `mixedLength` `BaseCarousel` based on scroll position instead of slide state.
- e2e tests for thumbnail & primary carousel slide state coordination, which do not exist for 0.1
- Shrink thumbnail arrow icons if they are too visually distracting (need to follow up with UX) 