### PR TITLE
babel json transform: Windows support.

### DIFF
--- a/build-system/babel-plugins/babel-plugin-transform-json-import/index.js
+++ b/build-system/babel-plugins/babel-plugin-transform-json-import/index.js
@@ -15,7 +15,7 @@
  */
 
 const {readFileSync} = require('fs');
-const {resolve, dirname, join, relative} = require('path').posix;
+const {resolve, dirname, join, relative} = require('path');
 
 // Transforms JSON imports into a `JSON.parse` call:
 //
@@ -65,7 +65,7 @@ module.exports = function ({types: t, template}, options) {
 
         const specifier = specifiers[0].local;
         const jsonPath = relative(
-          join(__dirname, '../../../'),
+          join(__dirname, '..', '..', '..'),
           resolve(dirname(this.file.opts.filename), source.value)
         );
         let json;


### PR DESCRIPTION
**summary**
Followup to https://github.com/ampproject/amphtml/pull/31595
Unblocks: https://github.com/ampproject/amphtml/pull/31615/checks?check_run_id=1573479334

The transform was making paths valid only on posix. By changing from `../` --> `..`, and using regular `path` instead of `path.posix`, I was able to make the tests pass on Windows.

Ideally the babel plugin tests would also run on Windows so we'd catch the issue one PR earlier.
cc @rsimha 