### PR TITLE
Bento Carousel: StreamGallery imperative API

### DIFF
--- a/extensions/amp-stream-gallery/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-stream-gallery/1.0/storybook/Basic.amp.js
@@ -50,38 +50,47 @@ export const Default = () => {
   const outsetArrows = boolean('outset arrows', true);
   const colorIncrement = Math.floor(255 / (slideCount + 1));
   return (
-    <amp-stream-gallery
-      width="735"
-      height="225"
-      layout="responsive"
-      extra-space={extraSpace}
-      inset-arrow-visibility={insetArrowVisibility}
-      loop={loop}
-      min-item-width={minItemWidth}
-      max-item-width={maxItemWidth}
-      min-visible-count={minVisibleCount}
-      max-visible-count={maxVisibleCount}
-      outset-arrows={outsetArrows}
-      peek={peek}
-      slide-align={slideAlign}
-      snap={snap}
-    >
-      {Array.from({length: slideCount}, (x, i) => {
-        const v = colorIncrement * (i + 1);
-        return (
-          <amp-layout width="245" height="225" layout="flex-item">
-            <svg viewBox="0 0 440 225">
-              <rect
-                style={{fill: `rgb(${v}, 100, 100)`}}
-                width="440"
-                height="225"
-              />
-              Sorry, your browser does not support inline SVG.
-            </svg>
-          </amp-layout>
-        );
-      })}
-    </amp-stream-gallery>
+    <>
+      <amp-stream-gallery
+        id="carousel"
+        width="735"
+        height="225"
+        layout="responsive"
+        extra-space={extraSpace}
+        inset-arrow-visibility={insetArrowVisibility}
+        loop={loop}
+        min-item-width={minItemWidth}
+        max-item-width={maxItemWidth}
+        min-visible-count={minVisibleCount}
+        max-visible-count={maxVisibleCount}
+        outset-arrows={outsetArrows}
+        peek={peek}
+        slide-align={slideAlign}
+        snap={snap}
+      >
+        {Array.from({length: slideCount}, (x, i) => {
+          const v = colorIncrement * (i + 1);
+          return (
+            <amp-layout width="245" height="225" layout="flex-item">
+              <svg viewBox="0 0 440 225">
+                <rect
+                  style={{fill: `rgb(${v}, 100, 100)`}}
+                  width="440"
+                  height="225"
+                />
+                Sorry, your browser does not support inline SVG.
+              </svg>
+            </amp-layout>
+          );
+        })}
+      </amp-stream-gallery>
+
+      <div class="buttons" style={{marginTop: 8}}>
+        <button on="tap:carousel.goToSlide(index=3)">goToSlide(index=3)</button>
+        <button on="tap:carousel.next">Next</button>
+        <button on="tap:carousel.prev">Prev</button>
+      </div>
+    </>
   );
 };
 

--- a/extensions/amp-stream-gallery/1.0/storybook/Basic.js
+++ b/extensions/amp-stream-gallery/1.0/storybook/Basic.js
@@ -27,6 +27,26 @@ export default {
   decorators: [withA11y, withKnobs],
 };
 
+/**
+ * @param {!Object} props
+ * @return {*}
+ */
+function CarouselWithActions(props) {
+  // TODO(#30447): replace imperative calls with "button" knobs when the
+  // Storybook 6.1 is released.
+  const ref = Preact.useRef();
+  return (
+    <section>
+      <StreamGallery ref={ref} {...props} />
+      <div style={{marginTop: 8}}>
+        <button onClick={() => ref.current.goToSlide(3)}>goToSlide(3)</button>
+        <button onClick={() => ref.current.next()}>next</button>
+        <button onClick={() => ref.current.prev()}>prev</button>
+      </div>
+    </section>
+  );
+}
+
 export const _default = () => {
   const width = number('width', 735);
   const height = number('height', 225);
@@ -48,7 +68,7 @@ export const _default = () => {
   const colorIncrement = Math.floor(255 / (slideCount + 1));
   return (
     <>
-      <StreamGallery
+      <CarouselWithActions
         extraSpace={extraSpace ? 'around' : ''}
         insetArrowVisibility={insetArrowVisibility}
         loop={loop}
@@ -74,7 +94,7 @@ export const _default = () => {
             ></div>
           );
         })}
-      </StreamGallery>
+      </CarouselWithActions>
     </>
   );
 };

--- a/extensions/amp-stream-gallery/1.0/stream-gallery.js
+++ b/extensions/amp-stream-gallery/1.0/stream-gallery.js
@@ -37,8 +37,8 @@ const OUTSET_ARROWS_WIDTH = 100;
  * @param {{current: (!BaseCarouselDef.CarouselApi|null)}} ref
  * @return {PreactDef.Renderable}
  */
-function StreamGalleryWithRef(
-  {
+function StreamGalleryWithRef(props, ref) {
+  const {
     arrowPrev: customArrowPrev,
     arrowNext: customArrowNext,
     children,
@@ -53,9 +53,7 @@ function StreamGalleryWithRef(
     peek = 0,
     slideAlign = 'start',
     ...rest
-  },
-  ref
-) {
+  } = props;
   const classes = useStyles();
   const carouselRef = useRef(null);
   const [visibleCount, setVisibleCount] = useState(DEFAULT_VISIBLE_COUNT);

--- a/extensions/amp-stream-gallery/1.0/stream-gallery.js
+++ b/extensions/amp-stream-gallery/1.0/stream-gallery.js
@@ -34,25 +34,22 @@ const OUTSET_ARROWS_WIDTH = 100;
  * @param {!StreamGalleryDef.Props} props
  * @return {PreactDef.Renderable}
  */
-export function StreamGallery(props) {
-  const {
-    arrowPrev: customArrowPrev,
-    arrowNext: customArrowNext,
-    children,
-    className,
-    extraSpace,
-    insetArrowVisibility,
-    loop,
-    maxItemWidth = Number.MAX_VALUE,
-    minItemWidth = 1,
-    maxVisibleCount = Number.MAX_VALUE,
-    minVisibleCount = 1,
-    outsetArrows,
-    peek = 0,
-    slideAlign = 'start',
-    snap,
-    ...rest
-  } = props;
+export function StreamGallery({
+  arrowPrev: customArrowPrev,
+  arrowNext: customArrowNext,
+  children,
+  className,
+  extraSpace,
+  insetArrowVisibility,
+  maxItemWidth = Number.MAX_VALUE,
+  minItemWidth = 1,
+  maxVisibleCount = Number.MAX_VALUE,
+  minVisibleCount = 1,
+  outsetArrows,
+  peek = 0,
+  slideAlign = 'start',
+  ...rest
+}) {
   const classes = useStyles();
   const ref = useRef(null);
   const [visibleCount, setVisibleCount] = useState(DEFAULT_VISIBLE_COUNT);
@@ -122,9 +119,7 @@ export function StreamGallery(props) {
         extraSpace === 'around' ? classes.extraSpace : ''
       }`}
       controls={insetArrowVisibility}
-      loop={loop}
       outsetArrows={outsetArrows}
-      snap={snap}
       snapAlign={slideAlign}
       ref={ref}
       visibleCount={visibleCount}

--- a/extensions/amp-stream-gallery/1.0/stream-gallery.js
+++ b/extensions/amp-stream-gallery/1.0/stream-gallery.js
@@ -96,9 +96,9 @@ function StreamGalleryWithRef(props, ref) {
     ref,
     () =>
       /** @type {!BaseCarouselDef.CarouselApi} */ ({
-        goToSlide: carouselRef.current.goToSlide,
-        next: carouselRef.current.next,
-        prev: carouselRef.current.prev,
+        goToSlide: (index) => carouselRef.current.goToSlide(index),
+        next: () => carouselRef.current.next(),
+        prev: () => carouselRef.current.prev(),
       }),
     []
   );

--- a/extensions/amp-stream-gallery/1.0/test/test-amp-stream-gallery.js
+++ b/extensions/amp-stream-gallery/1.0/test/test-amp-stream-gallery.js
@@ -15,10 +15,13 @@
  */
 import '../../../amp-base-carousel/1.0/amp-base-carousel';
 import '../amp-stream-gallery';
+import {ActionInvocation} from '../../../../src/service/action-impl';
+import {ActionTrust} from '../../../../src/action-constants';
 import {
   createElementWithAttributes,
   waitForChildPromise,
 } from '../../../../src/dom';
+import {poll} from '../../../../testing/iframe';
 import {setStyles} from '../../../../src/style';
 import {toArray} from '../../../../src/types';
 import {toggleExperiment} from '../../../../src/experiments';
@@ -162,6 +165,72 @@ describes.realWin(
       expect(
         renderedSlideWrappers[2].querySelector('slot').assignedElements()
       ).to.deep.equal([userSuppliedChildren[1]]);
+    });
+
+    describe('imperative api', () => {
+      let scroller;
+
+      beforeEach(async () => {
+        element.setAttribute('max-visible-count', '1');
+        win.document.body.appendChild(element);
+        await getSlidesFromShadow();
+
+        scroller = element.shadowRoot.querySelector(
+          `[class*=${styles.scrollContainer}]`
+        );
+      });
+
+      afterEach(() => {
+        win.document.body.removeChild(element);
+        scroller = null;
+      });
+
+      function invocation(method, args = {}) {
+        const source = null;
+        const caller = null;
+        const event = null;
+        const trust = ActionTrust.DEFAULT;
+        return new ActionInvocation(
+          element,
+          method,
+          args,
+          source,
+          caller,
+          event,
+          trust
+        );
+      }
+
+      it('should execute next and prev actions', async () => {
+        element.enqueAction(invocation('next'));
+        await waitFor(() => scroller.scrollLeft > 0, 'advanced to next slide');
+
+        // Make sure internal state index is updated before attempting to call prev(),
+        // Since this is typically updated automatically on debounce, there is a risk that
+        // the test will call prev() on the slide at the 0th index unless we force is here.
+        element.enqueAction(invocation('goToSlide', {index: 1}));
+        await waitFor(() => scroller.scrollLeft > 0, 'to slide 1');
+
+        element.enqueAction(invocation('prev'));
+        // Wait for a longer timeout than the 200 default in waitFor.
+        await poll(
+          'returned to prev slide',
+          () => scroller.scrollLeft == 0,
+          undefined /* opt_onError */,
+          400 /* opt_timeout */
+        );
+      });
+
+      it('should execute goToSlide action', async () => {
+        element.enqueAction(invocation('goToSlide', {index: 1}));
+        await waitFor(() => scroller.scrollLeft > 0, 'go to slide 1');
+
+        element.enqueAction(invocation('goToSlide', {index: 0}));
+        await waitFor(
+          () => scroller.scrollLeft == 0,
+          'returned to first slide'
+        );
+      });
     });
   }
 );


### PR DESCRIPTION
Partial for #28284

- Adds `next`, `prev`, and `goToSlide` actions to `StreamGallery` and `amp-stream-gallery`
- Exposes `slideChange` event on `amp-stream-gallery`
- Removes passthrough props from `StreamGallery` which are covered via `...rest`
- Unit tests