### PR TITLE
🐛 amp-bind: Dispatch FORM_VALUE_CHANGE on [disabled] changes

### DIFF
--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -68,6 +68,12 @@ const FORM_VALUE_PROPERTIES = {
   },
   'TEXTAREA': {
     'text': true,
+    // amp-form relies on FORM_VALUE_CHANGE to update form validity state due
+    // to value changes from amp-bind. However, disabled form elements always
+    // report "valid" even if they have invalid values! A consequence is that
+    // toggling `disabled` via amp-bind may affect validity, so we need to
+    // inform amp-form about these too.
+    'disabled': true,
   },
 };
 


### PR DESCRIPTION
Follow-up to #26137. Also tracked in `b/159464750#comment12`:

> The fix linked to that issue was necessary but missed an interesting edge case.
> 
> 1. Form valid/invalid events toggle the disabled state of the "Reply" button (via amp-bind)
> 2. With `diffable`, the `<form>` is no longer destroyed and re-rendered so its validation state must be manually reset to avoid staleness problems
> 3. On reply, the form clears the comment `<textarea>` (also via amp-bind) but doesn't reset its validation state
> 4. Bug: the stale validation state causes the "Reply" button to get stuck in the disabled state
> 
> **Original fix:** resolve (3) by adding behavior to make sure we check form validity when the comment `<textarea>` is cleared
> 
> **Edge case:** form validity unexpectedly returns `true`, despite the `<textarea>` being empty. TIL this is because `checkValidity()` always returns `true` for `disabled` elements, regardless if it has a custom validation message set! 
> 
> There are a few ways to fix this edge case -- a (hopefully) low-risk solution could be to clear the cached form validation state when transitioning from "enabled" to "disabled" state and vice versa. Going to ponder this a bit.
