### PR TITLE
🐛Fix typo in slot value for amp-truncate-text

### DIFF
--- a/extensions/amp-truncate-text/0.1/amp-truncate-text.css
+++ b/extensions/amp-truncate-text/0.1/amp-truncate-text.css
@@ -42,7 +42,7 @@ amp-truncate-text:not([i-amphtml-truncate-expanded]) .i-amphtml-truncate-expande
   right: 0 !important;
 }
 
-.i-amphtml-truncate-content [slot="expand"] {
+.i-amphtml-truncate-content [slot="expanded"] {
   margin: 0 !important;
   white-space: nowrap !important;
 }


### PR DESCRIPTION
From what I see, the acceptable `slot` values are `expanded`/`collapsed`/`persistent`, but the CSS rule here looks for `slot="expand"` (unless I'm missing something). I'm guessing this rule was minor enough that the typo may have had minimal effect.