### PR TITLE
🐛 [amp-consent] Move transform style to class

### DIFF
--- a/extensions/amp-consent/0.1/amp-consent.css
+++ b/extensions/amp-consent/0.1/amp-consent.css
@@ -141,6 +141,10 @@ amp-consent.i-amphtml-consent-ui-modal.i-amphtml-consent-ui-border-enabled {
   box-shadow: 0 0 5px 0 rgba(0,0,0, 0.2) !important;
 }
 
+amp-consent.i-amphtml-consent-ui-iframe-active.i-amphtml-consent-ui-iframe-transfrom {
+  transform: translate3d(0px, calc(100% - var(--i-amphtml-modal-height)), 0px) !important;
+}
+
 amp-consent.i-amphtml-consent-ui-iframe-active.i-amphtml-consent-ui-in {
   transition: transform 0.5s ease-out !important;
   /* Initial height transform will be set through styles */

--- a/extensions/amp-consent/0.1/consent-ui.js
+++ b/extensions/amp-consent/0.1/consent-ui.js
@@ -74,6 +74,7 @@ export const consentUiClasses = {
   mask: 'i-amphtml-consent-ui-mask',
   borderEnabled: 'i-amphtml-consent-ui-border-enabled',
   screenReaderDialog: 'i-amphtml-consent-alertdialog',
+  iframeTransform: 'i-amphtml-consent-ui-iframe-transfrom',
 };
 
 export class ConsentUI {
@@ -701,6 +702,7 @@ export class ConsentUI {
    * Apply styles for ready event
    */
   applyInitialStyles_() {
+    const {classList} = this.parent_;
     // Apply our initial height and border
     if (this.ui_) {
       setStyles(this.ui_, {
@@ -708,12 +710,11 @@ export class ConsentUI {
       });
     }
     setImportantStyles(this.parent_, {
-      transform: `translate3d(0px, calc(100% - ${this.initialHeight_}), 0px)`,
       '--i-amphtml-modal-height': `${this.initialHeight_}`,
     });
+    classList.add(consentUiClasses.iframeTransform);
     // Border is default with modal enabled and option with non-modal
     if (this.borderEnabled_ || this.modalEnabled_) {
-      const {classList} = this.parent_;
       classList.add(consentUiClasses.borderEnabled);
     }
     if (this.modalEnabled_) {

--- a/extensions/amp-consent/0.1/test/test-consent-ui.js
+++ b/extensions/amp-consent/0.1/test/test-consent-ui.js
@@ -217,6 +217,30 @@ describes.realWin(
         consentUI.hide();
         expect(consentUI.scrollEnabled_).to.be.true;
       });
+
+      it('should set the iframe transform class on parent', async () => {
+        const config = dict({
+          'promptUISrc': 'https://promptUISrc',
+        });
+        consentUI = new ConsentUI(mockInstance, config);
+
+        consentUI.show(false);
+        consentUI.handleIframeMessages_({
+          source: consentUI.ui_.contentWindow,
+          data: {
+            type: 'consent-ui',
+            action: 'ready',
+            initialHeight: '80vh',
+          },
+        });
+        await macroTask();
+        expect(
+          consentUI.parent_.style.getPropertyValue('--i-amphtml-modal-height')
+        ).to.equal('80vh');
+        expect(
+          consentUI.parent_.classList.contains(consentUiClasses.iframeTransform)
+        ).to.be.true;
+      });
     });
 
     describe('placeholder', () => {


### PR DESCRIPTION
For #31580 (a safer version of #31660)

When served in a google viewer, the viewer has a top bar. When a user scrolls, the bar shows/hides. When the bar is shown and hidden, the viewer sends this event to AMP. For elements tracked by the fixed layer (i.e. amp-consent element),  this event will trigger the removal of the `transform` style. 

https://github.com/ampproject/amphtml/blob/4e79d3b517641f580d2aeef305d7b7589d1befa8/src/service/fixed-layer.js#L314-L322

Therefore, when a user scrolls on a doc served in a viewer before the consent iframe loads, the transform style will be removed and no transformation will be applied. 

Since fixed layer only removes `transform` style, we can add it to another class (just need to worry about CSS rule precedence).

/cc @jridgewell 