### PR TITLE
resource: start storing initialIntersection

### DIFF
--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -1219,6 +1219,10 @@ const forbiddenTermsSrcInclusive = {
       'extensions/amp-iframe/0.1/amp-iframe.js',
     ],
   },
+  '\\.getInitialIntersection': {
+    message: measurementApiDeprecated,
+    allowlist: ['src/iframe-attributes.js'],
+  },
 };
 
 // Terms that must appear in a source file.

--- a/src/iframe-attributes.js
+++ b/src/iframe-attributes.js
@@ -94,7 +94,7 @@ export function getContextMetadata(
           'height': layoutRect.height,
         }
       : null,
-    'initialIntersection': element.getIntersectionChangeEntry(),
+    'initialIntersection': element.getResource().getInitialIntersection(),
     'domFingerprint': DomFingerprint.generate(element),
     'experimentToggles': experimentToggles(parentWindow),
     'sentinel': sentinel,

--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -194,6 +194,9 @@ export class Resource {
     /** @private {?../layout-rect.LayoutRectDef} */
     this.initialLayoutBox_ = null;
 
+    /** @private {IntersectionOberverEntry} */
+    this.initialIntersection_ = null;
+
     /** @private {boolean} */
     this.isMeasureRequested_ = false;
 
@@ -454,9 +457,35 @@ export class Resource {
    * Should only be used in IntersectionObserver mode.
    * @param {!ClientRect} clientRect
    */
-  premeasure(clientRect) {
+  premeasure_(clientRect) {
     devAssert(this.intersect_);
     this.premeasuredRect_ = clientRect;
+  }
+
+  /**
+   * Informs a resource that it was just measured via intersection event.
+   *
+   * @param {IntersectionObserverEntry} entry
+   */
+  intersects(entry) {
+    // Strangely, JSC is missing x/y from typedefs of boundingClientRect
+    // despite it being a DOMRectReadOnly (ClientRect) by spec.
+    this.premeasure_(/** @type {!ClientRect} */ (entry.boundingClientRect));
+    if (!this.initialIntersection_) {
+      this.initialIntersection_ = entry;
+    }
+  }
+
+  /**
+   * Returns the value of the first IntersectionObserver entry for this Resource.
+   * Null if the Resource is unmeasured. Therefore this value is useless prior to measure
+   * and should likely not be used outside of `layoutCallback`.
+   *
+   * @deprecated
+   * @return {IntersectionObserverEntry}
+   */
+  getInitialIntersection() {
+    return this.initialIntersection_;
   }
 
   /** Removes the premeasured rect, likely forcing a manual measure. */

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -337,12 +337,8 @@ export class ResourcesImpl {
     this.intersectionObserverCallbackFired_ = true;
 
     entries.forEach((entry) => {
-      const {boundingClientRect, target} = entry;
-
-      const r = Resource.forElement(target);
-      // Strangely, JSC is missing x/y from typedefs of boundingClientRect
-      // despite it being a DOMRectReadOnly (ClientRect) by spec.
-      r.premeasure(/** @type {!ClientRect} */ (boundingClientRect));
+      const r = Resource.forElement(entry.target);
+      r.intersects(entry);
     });
 
     this.schedulePass();

--- a/test/unit/test-resource.js
+++ b/test/unit/test-resource.js
@@ -112,7 +112,7 @@ describes.realWin('Resource', {amp: true}, (env) => {
     });
 
     it('should be ready for layout if measured before build', () => {
-      resource.premeasure({left: 0, top: 0, width: 100, height: 100});
+      resource.intersects({left: 0, top: 0, width: 100, height: 100});
       resource.measure(/* usePremeasuredRect */ true);
       elementMock.expects('isUpgraded').returns(true).atLeast(1);
       elementMock.expects('build').returns(Promise.resolve()).once();
@@ -125,7 +125,7 @@ describes.realWin('Resource', {amp: true}, (env) => {
     it('should remeasure if measured before upgrade and isFixed', () => {
       // First measure
       element.isAlwaysFixed = () => false;
-      resource.premeasure({left: 0, top: 0, width: 100, height: 100});
+      resource.intersects({left: 0, top: 0, width: 100, height: 100});
       resource.measure(/* usePremeasuredRect */ true);
 
       // Now adjust implementation to be alwaysFixed and call build.

--- a/test/unit/test-resources.js
+++ b/test/unit/test-resources.js
@@ -738,7 +738,7 @@ describes.realWin('Resources discoverWork', {amp: true}, (env) => {
     });
 
     it('should invalidate premeasurements after resize event', () => {
-      resource1.premeasure({});
+      resource1.intersects({});
       expect(resource1.hasBeenPremeasured()).true;
       expect(resource1.isMeasureRequested()).false;
       resources.viewport_.changeObservable_.fire({relayoutAll_: true});


### PR DESCRIPTION
**summary**
Ads passes along the `initialIntersection` to iframes on creation. We have 3 options:

1. Start providing `initialIntersection` to layoutCallback
2. Add the field as deprecated to `Resource` (this is the PRs current state)
3. Delay ads rendering (its all happening in promise chains anyway) by however long it takes for a new one-off InOb measurement

Partial for https://github.com/ampproject/amphtml/issues/31540