### PR TITLE
✨[Story devtools] Added functionality to block adding devices if no space

### DIFF
--- a/extensions/amp-story-dev-tools/0.1/amp-story-dev-tools-tab-preview.css
+++ b/extensions/amp-story-dev-tools/0.1/amp-story-dev-tools-tab-preview.css
@@ -81,7 +81,13 @@ amp-story-player a {
   margin: 0 5px !important;
   white-space: nowrap !important;
   cursor: pointer !important;
-  outline: none;
+  outline: none !important;
+}
+
+.i-amphtml-story-dev-tools-device-chip[disabled] {
+  pointer-events: none !important;
+  --i-amphtml-story-dev-tools-device-chip-background-hover: var(--i-amphtml-story-dev-tools-device-chip-background) !important;
+  opacity: 0.5 !important;
 }
 
 .i-amphtml-story-dev-tools-device-chip:hover, .i-amphtml-story-dev-tools-device-chip:focus {

--- a/extensions/amp-story-dev-tools/0.1/amp-story-dev-tools-tab-preview.css
+++ b/extensions/amp-story-dev-tools/0.1/amp-story-dev-tools-tab-preview.css
@@ -84,12 +84,6 @@ amp-story-player a {
   outline: none !important;
 }
 
-.i-amphtml-story-dev-tools-device-chip[disabled] {
-  pointer-events: none !important;
-  --i-amphtml-story-dev-tools-device-chip-background-hover: var(--i-amphtml-story-dev-tools-device-chip-background) !important;
-  opacity: 0.5 !important;
-}
-
 .i-amphtml-story-dev-tools-device-chip:hover, .i-amphtml-story-dev-tools-device-chip:focus {
   background: var(--i-amphtml-story-dev-tools-device-chip-background-hover) !important;
 }
@@ -108,6 +102,12 @@ amp-story-player a {
   --i-amphtml-story-dev-tools-device-chip-background-hover: var(--i-amphtml-story-dev-tools-gray-1) !important;
   --i-amphtml-story-dev-tools-device-chip-icon-background: var(--i-amphtml-story-dev-tools-white-transparent-1) !important;
   border: 1px solid var(--i-amphtml-story-dev-tools-device-chip-icon-background) !important;
+}
+
+.i-amphtml-story-dev-tools-device-chip[disabled] {
+  cursor: initial !important;
+  --i-amphtml-story-dev-tools-device-chip-background-hover: var(--i-amphtml-story-dev-tools-device-chip-background) !important;
+  opacity: 0.5 !important;
 }
 
 .i-amphtml-story-dev-tools-device-chip[inactive] svg {

--- a/extensions/amp-story-dev-tools/0.1/amp-story-dev-tools-tab-preview.js
+++ b/extensions/amp-story-dev-tools/0.1/amp-story-dev-tools-tab-preview.js
@@ -727,6 +727,7 @@ export class AmpStoryDevToolsTabPreview extends AMP.BaseElement {
 
   /**
    * Return the number of spaces currently used by the devices on the screen.
+   * @private
    * @return {number}
    */
   getCurrentSpacesSum_() {
@@ -739,6 +740,7 @@ export class AmpStoryDevToolsTabPreview extends AMP.BaseElement {
   /**
    * Disable the chips in the dialog based on whether they have the remaining space available
    * Must be called in a mutate context.
+   * @private
    */
   toggleDeviceChipsWithSpaceAvailable_() {
     const allChips = this.currentDialog_.querySelectorAll(

--- a/extensions/amp-story-dev-tools/0.1/amp-story-dev-tools-tab-preview.js
+++ b/extensions/amp-story-dev-tools/0.1/amp-story-dev-tools-tab-preview.js
@@ -726,7 +726,7 @@ export class AmpStoryDevToolsTabPreview extends AMP.BaseElement {
   }
 
   /**
-   * Return the number of spaces currently used by the devices on the screen.
+   * Return the number of spaces currently being used by the devices on the screen.
    * @private
    * @return {number}
    */

--- a/extensions/amp-story-dev-tools/0.1/amp-story-dev-tools-tab-preview.js
+++ b/extensions/amp-story-dev-tools/0.1/amp-story-dev-tools-tab-preview.js
@@ -198,6 +198,8 @@ const buildAddDeviceDialogTemplate = (element) => {
   `;
 };
 
+const MAX_DEVICE_SPACES = 4;
+
 /**
  * @typedef {{
  *  element: !Element,
@@ -206,9 +208,11 @@ const buildAddDeviceDialogTemplate = (element) => {
  *  width: number,
  *  height: number,
  *  deviceHeight: ?number,
+ *  deviceSpaces: number,
  * }}
  * Contains the data related to the device.
  * Width and height refer to the story viewport, while deviceHeight is the device screen height.
+ * The deviceSpaces refers to the MAX_DEVICE_SPACES, ensuring the devices on screen don't go over the max space set.
  */
 export let DeviceInfo;
 
@@ -220,72 +224,84 @@ const ALL_DEVICES = [
     'width': 411,
     'height': 605,
     'deviceHeight': 731,
+    'deviceSpaces': 1,
   },
   {
     'name': 'Pixel 3',
     'width': 411,
     'height': 686,
     'deviceHeight': 823,
+    'deviceSpaces': 1,
   },
   {
     'name': 'iPhone 8 (Browser)',
     'width': 375,
     'height': 554,
     'deviceHeight': 667,
+    'deviceSpaces': 1,
   },
   {
     'name': 'iPhone 8 (Native)',
     'width': 375,
     'height': 632,
     'deviceHeight': 667,
+    'deviceSpaces': 1,
   },
   {
     'name': 'iPhone 11 (Browser)',
     'width': 414,
     'height': 724,
     'deviceHeight': 896,
+    'deviceSpaces': 1,
   },
   {
     'name': 'iPhone 11 (Native)',
     'width': 414,
     'height': 795,
     'deviceHeight': 896,
+    'deviceSpaces': 1,
   },
   {
     'name': 'iPhone 11 Pro (Browser)',
     'width': 375,
     'height': 635,
     'deviceHeight': 812,
+    'deviceSpaces': 1,
   },
   {
     'name': 'iPhone 11 Pro (Native)',
     'width': 375,
     'height': 713,
     'deviceHeight': 812,
+    'deviceSpaces': 1,
   },
   {
     'name': 'iPad (Browser)',
     'width': 810,
     'height': 1010,
     'deviceHeight': 1080,
+    'deviceSpaces': 2,
   },
   {
     'name': 'OnePlus 5T',
     'width': 455,
     'height': 820,
     'deviceHeight': 910,
+    'deviceSpaces': 1,
   },
   {
     'name': 'OnePlus 7 Pro',
     'width': 412,
     'height': 743,
     'deviceHeight': 892,
+    'deviceSpaces': 1,
   },
   {
     'name': 'Desktop 1080p',
     'width': 1920,
     'height': 1080,
     'deviceHeight': 1080,
+    'deviceSpaces': 2,
   },
 ];
 
@@ -462,6 +478,9 @@ export class AmpStoryDevToolsTabPreview extends AMP.BaseElement {
       (el) => el.hasAttribute('data-action'),
       this.element
     );
+    if (actionElement.hasAttribute('disabled')) {
+      return;
+    }
     if (actionElement) {
       switch (actionElement.getAttribute('data-action')) {
         case PREVIEW_ACTIONS.SHOW_HELP_DIALOG:
@@ -555,9 +574,15 @@ export class AmpStoryDevToolsTabPreview extends AMP.BaseElement {
   onDeviceChipToggled_(chipElement) {
     const deviceName = chipElement.getAttribute('data-device');
     if (this.removeDevice_(deviceName)) {
-      this.mutateElement(() => chipElement.setAttribute('inactive', ''));
+      this.mutateElement(() => {
+        chipElement.setAttribute('inactive', '');
+        this.toggleDeviceChipsWithSpaceAvailable_();
+      });
     } else {
-      this.mutateElement(() => chipElement.removeAttribute('inactive'));
+      this.mutateElement(() => {
+        chipElement.removeAttribute('inactive');
+        this.toggleDeviceChipsWithSpaceAvailable_();
+      });
       this.addDevice_(deviceName);
     }
     this.repositionDevices_();
@@ -645,12 +670,18 @@ export class AmpStoryDevToolsTabPreview extends AMP.BaseElement {
       return obj;
     }, {});
 
+    const currentDeviceSpaces = this.getCurrentSpacesSum_();
+
     // Add a chip for each device on the right category, and mark as inactive if device not selected.
     ALL_DEVICES.forEach((device) => {
       const chip = this.buildDeviceChip_(device.name);
       chip.setAttribute('data-action', PREVIEW_ACTIONS.TOGGLE_DEVICE_CHIP);
+      chip.setAttribute('data-spaces', device.deviceSpaces);
       if (!this.devices_.find((d) => d.name == device.name)) {
         chip.setAttribute('inactive', '');
+        if (currentDeviceSpaces + device.deviceSpaces > MAX_DEVICE_SPACES) {
+          chip.setAttribute('disabled', '');
+        }
       }
       if (device.width / device.height > 1) {
         sections['desktop'].appendChild(chip);
@@ -692,5 +723,35 @@ export class AmpStoryDevToolsTabPreview extends AMP.BaseElement {
       removeAfterTimeout(this, this.currentDialog_, 200);
       this.currentDialog_ = null;
     }
+  }
+
+  /**
+   * Return the number of spaces currently used by the devices on the screen.
+   * @return {number}
+   */
+  getCurrentSpacesSum_() {
+    return this.devices_.reduce(
+      (prev, device) => prev + device.deviceSpaces,
+      0
+    );
+  }
+
+  /**
+   * Disable the chips in the dialog based on whether they have the remaining space available
+   * Must be called in a mutate context.
+   */
+  toggleDeviceChipsWithSpaceAvailable_() {
+    const allChips = this.currentDialog_.querySelectorAll(
+      '.i-amphtml-story-dev-tools-device-chip'
+    );
+    const currentDeviceSpaces = this.getCurrentSpacesSum_();
+    allChips.forEach((chipEl) => {
+      const spaces = parseInt(chipEl.getAttribute('data-spaces'), 10);
+      // Disable the button if there's no space for adding the device and the device is not added already.
+      const isEnabled =
+        (currentDeviceSpaces + spaces <= MAX_DEVICE_SPACES) |
+        !chipEl.hasAttribute('inactive');
+      chipEl.toggleAttribute('disabled', !isEnabled);
+    });
   }
 }


### PR DESCRIPTION
The maximum amount of phones that can be added to the screen is 4, but tablets and desktops will take 2 spaces.

Defined a property `deviceSpaces` on all devices that determines how many spaces a device takes. If the sum of the current device spaces and the device we want to add is larger than 4, then the chip button should be disabled.

The `data-spaces` attribute on chips store how many spaces are required to display a device, and when the AddDeviceDialog is created, it will only set to enabled the devices that have space to be added, or the devices that are added (which are removed when you click on those chips).

If there are 4 spaces occupied already, disable adding any new devices:
![image](https://user-images.githubusercontent.com/22420856/102940265-ed6ee280-447d-11eb-96dd-f209d953c433.png)

If there are 3 spaces occupied, only enable the devices that would occupy 1 space (so desktop is disabled):
![image](https://user-images.githubusercontent.com/22420856/102940310-037ca300-447e-11eb-8206-1f16e32fe601.png)

If there are 2 spaces occupied, enable all the devices to be added:
![image](https://user-images.githubusercontent.com/22420856/102940364-2a3ad980-447e-11eb-92d6-dc8730233534.png)

