### PR TITLE
Handles argv.files better for runtime tests.

### DIFF
--- a/build-system/common/utils.js
+++ b/build-system/common/utils.js
@@ -101,8 +101,7 @@ function getFilesFromArgv() {
   const toPosix = (str) => str.replace(/\\\\?/g, '/');
   return argv.files
     ? globby.sync(
-        argv.files
-          .split(',')
+        (Array.isArray(argv.files) ? argv.files : argv.files.split(','))
           .map((s) => s.trim())
           .map(toPosix)
       )


### PR DESCRIPTION
The following command trips up:
gulp unit --watch --nobuild --files=test/unit/{test-ads-config.js,test-integration.js}

In argv.files, that's already an Array, not a string to be split.

<!--
# Instructions:

- Pick a meaningful title for your pull request. (Use sentence case.)
  - Prefix the title with an emoji to identify what is being done. (Copy-paste the emoji from the list below.)
  - Do not overuse punctuation in the title (like `(chore):`).
  - If it is helpful, use a simple prefix (like `ProjectX: Implement some feature`).
- Enter a succinct description that says why the PR is necessary, and what it does.
  - Mention the GitHub issue that is being addressed by the pull request.
  - The keywords `Fixes`, `Closes`, or `Resolves` followed the issue number will automatically close the issue.

> NOTE: All non-trivial changes (like introducing new features or components) should have an associated issue or reference an I2I (intent-to-implement: go.amp.dev/i2i). Please read through the contribution process (go.amp.dev/contributing/code) for more information.

# Example of a good description:

- Implement aspect X
- Leave out feature Y because of A
- Improve performance by B
- Improve accessibility by C

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Reverting a previous change
♻️ Refactoring
🚮 Deleting code
🧪 Experimental code
-->
