### PR TITLE
📖 amp-base-carousel: Add `controls` attribute to component documentation

### DIFF
--- a/extensions/amp-base-carousel/amp-base-carousel.md
+++ b/extensions/amp-base-carousel/amp-base-carousel.md
@@ -133,7 +133,7 @@ useful when using `visible-count`. This
 Either `"always"`, `"auto"`, or `"never"`, defaults to `"auto"`. This determines if and when prev/next navigational arrows are displayed. Note: When `outset-arrows` is `true`, the arrows are shown `"always"`.
 
 -   `always`: Arrows are always displayed.
--   `auto`: Arrows are displayed when a mouse has interacted with the carousel, and
+-   `auto`: Arrows are displayed when the carousel has most recently received interaction via mouse, and not displayed when the carousel has most recently received interaction via touch. On first load for touch devices, arrows are displayed until first interaction.
 -   `never`: Arrows are never displayed.
 
 ##### slide

--- a/extensions/amp-base-carousel/amp-base-carousel.md
+++ b/extensions/amp-base-carousel/amp-base-carousel.md
@@ -128,6 +128,14 @@ useful when using `visible-count`. This
 
 #### Miscellaneous
 
+##### controls
+
+Either `"always"`, `"auto"`, or `"never"`, defaults to `"auto"`. This determines if and when prev/next navigational arrows are displayed. Note: When `outset-arrows` is `true`, the arrows are shown `"always"`.
+
+-   `always`: Arrows are always displayed.
+-   `auto`: Arrows are displayed when a mouse has interacted with the carousel, and
+-   `never`: Arrows are never displayed.
+
 ##### slide
 
 A number, defaults to `0`. This determines the initial slide shown in the

--- a/extensions/amp-stream-gallery/amp-stream-gallery.md
+++ b/extensions/amp-stream-gallery/amp-stream-gallery.md
@@ -107,7 +107,7 @@ Either `"around"` or undefined. This determines how extra space is allocated aft
 Either `"always"`, `"auto"`, or `"never"`, defaults to `"auto"`. This determines if and when prev/next navigational arrows are displayed. Note: When `outset-arrows` is `true`, the arrows are shown `"always"`.
 
 -   `always`: Arrows are always displayed.
--   `auto`: Arrows are displayed when a mouse has interacted with the carousel, and
+-   `auto`: Arrows are displayed when the carousel has most recently received interaction via mouse, and not displayed when the carousel has most recently received interaction via touch. On first load for touch devices, arrows are displayed until first interaction.
 -   `never`: Arrows are never displayed.
 
 #### loop


### PR DESCRIPTION
Partial for #28284.