### PR TITLE
amp-video-iframe: use InOb instead of ce.getIntersectionChangeEntry.

### DIFF
--- a/extensions/amp-video-iframe/0.1/amp-video-iframe.js
+++ b/extensions/amp-video-iframe/0.1/amp-video-iframe.js
@@ -360,12 +360,27 @@ class AmpVideoIframe extends AMP.BaseElement {
   }
 
   /**
+   * Creates an IntersectionObserver to fire a single intersection event.
+   *
    * @param {number} messageId
    * @private
    */
   postIntersection_(messageId) {
-    const {time, intersectionRatio} = this.element.getIntersectionChangeEntry();
+    const intersectionObserver = new IntersectionObserver((entries) => {
+      this.intersectionCallback_(messageId, entries);
+      intersectionObserver.disconnect();
+    });
+    intersectionObserver.observe(this.element);
+  }
 
+  /**
+   * @param {number} messageId
+   * @param {Array<IntersectionObserverEntry>} entries
+   * @private
+   */
+  intersectionCallback_(messageId, entries) {
+    const lastEntry = entries[entries.length - 1];
+    const {time, intersectionRatio} = lastEntry;
     // Only post ratio > 0 when in autoplay range to prevent internal autoplay
     // implementations that differ from ours.
     const postedRatio =

--- a/extensions/amp-video-iframe/0.1/amp-video-iframe.js
+++ b/extensions/amp-video-iframe/0.1/amp-video-iframe.js
@@ -282,7 +282,7 @@ class AmpVideoIframe extends AMP.BaseElement {
 
   /**
    * @param {!Event} event
-   * @returns {Promise}
+   * @return {Promise}
    * @private
    */
   onMessage_(event) {

--- a/extensions/amp-video-iframe/0.1/amp-video-iframe.js
+++ b/extensions/amp-video-iframe/0.1/amp-video-iframe.js
@@ -127,12 +127,6 @@ class AmpVideoIframe extends AMP.BaseElement {
      * @private
      */
     this.boundOnMessage_ = (e) => this.onMessage_(e);
-
-    /**
-     * @param {!Element} element
-     * @return {!Promise<IntersectionObserverEntry>} element
-     */
-    this.measureIntersection = (element) => measureIntersection(element);
   }
 
   /** @override */
@@ -282,7 +276,7 @@ class AmpVideoIframe extends AMP.BaseElement {
 
   /**
    * @param {!Event} event
-   * @return {Promise}
+   * @return {!Promise|undefined}
    * @private
    */
   onMessage_(event) {
@@ -310,7 +304,7 @@ class AmpVideoIframe extends AMP.BaseElement {
 
     if (methodReceived) {
       if (methodReceived == 'getIntersection') {
-        return this.measureIntersection(this.element).then((intersection) => {
+        return measureIntersection(this.element).then((intersection) => {
           this.postIntersection_(messageId, intersection);
         });
       }

--- a/extensions/amp-video-iframe/0.1/test/test-amp-video-iframe.js
+++ b/extensions/amp-video-iframe/0.1/test/test-amp-video-iframe.js
@@ -106,13 +106,11 @@ describes.realWin(
       );
     }
 
-    function stubPostIntersection(videoIframe, time, intersectionRatio) {
+    function stubMeasureIntersection(videoIframe, time, intersectionRatio) {
       const entry = {time, intersectionRatio};
       env.sandbox
-        .stub(videoIframe.implementation_, 'postIntersection_')
-        .callsFake((id) => {
-          videoIframe.implementation_.intersectionCallback_(id, [entry]);
-        });
+        .stub(videoIframe.implementation_, 'measureIntersection')
+        .returns(Promise.resolve(entry));
       return entry;
     }
 
@@ -292,10 +290,10 @@ describes.realWin(
 
         const expectedResponseMessage = {
           id,
-          args: stubPostIntersection(videoIframe, time, intersectionRatio),
+          args: stubMeasureIntersection(videoIframe, time, intersectionRatio),
         };
 
-        videoIframe.implementation_.onMessage_(message);
+        await videoIframe.implementation_.onMessage_(message);
 
         expect(postMessage.withArgs(env.sandbox.match(expectedResponseMessage)))
           .to.have.been.calledOnce;
@@ -313,7 +311,7 @@ describes.realWin(
 
         const postMessage = stubPostMessage(videoIframe);
 
-        stubPostIntersection(videoIframe, time, intersectionRatio);
+        stubMeasureIntersection(videoIframe, time, intersectionRatio);
 
         acceptMockedMessages(videoIframe);
 
@@ -327,7 +325,7 @@ describes.realWin(
           },
         };
 
-        videoIframe.implementation_.onMessage_(message);
+        await videoIframe.implementation_.onMessage_(message);
 
         expect(postMessage.withArgs(env.sandbox.match(expectedResponseMessage)))
           .to.have.been.calledOnce;

--- a/extensions/amp-video-iframe/0.1/test/test-amp-video-iframe.js
+++ b/extensions/amp-video-iframe/0.1/test/test-amp-video-iframe.js
@@ -106,12 +106,16 @@ describes.realWin(
       );
     }
 
-    function stubMeasureIntersection(videoIframe, time, intersectionRatio) {
-      const entry = {time, intersectionRatio};
-      env.sandbox
-        .stub(videoIframe.implementation_, 'measureIntersection')
-        .returns(Promise.resolve(entry));
-      return entry;
+    function stubMeasureIntersection(target, time, intersectionRatio) {
+      env.win.IntersectionObserver = (callback) => ({
+        observe() {
+          Promise.resolve().then(() => {
+            callback([{target, time, intersectionRatio}]);
+          });
+        },
+        unobserve() {},
+        disconnect() {},
+      });
     }
 
     describe('#layoutCallback', () => {
@@ -288,10 +292,8 @@ describes.realWin(
 
         const message = getIntersectionMessage(id);
 
-        const expectedResponseMessage = {
-          id,
-          args: stubMeasureIntersection(videoIframe, time, intersectionRatio),
-        };
+        stubMeasureIntersection(videoIframe, time, intersectionRatio);
+        const expectedResponseMessage = {id, args: {time, intersectionRatio}};
 
         await videoIframe.implementation_.onMessage_(message);
 

--- a/extensions/amp-video-iframe/0.1/test/test-amp-video-iframe.js
+++ b/extensions/amp-video-iframe/0.1/test/test-amp-video-iframe.js
@@ -106,11 +106,13 @@ describes.realWin(
       );
     }
 
-    function stubIntersectionEntry(element, time, intersectionRatio) {
+    function stubPostIntersection(videoIframe, time, intersectionRatio) {
       const entry = {time, intersectionRatio};
       env.sandbox
-        ./*OK*/ stub(element, 'getIntersectionChangeEntry')
-        .returns(entry);
+        .stub(videoIframe.implementation_, 'postIntersection_')
+        .callsFake((id) => {
+          videoIframe.implementation_.intersectionCallback_(id, [entry]);
+        });
       return entry;
     }
 
@@ -290,7 +292,7 @@ describes.realWin(
 
         const expectedResponseMessage = {
           id,
-          args: stubIntersectionEntry(videoIframe, time, intersectionRatio),
+          args: stubPostIntersection(videoIframe, time, intersectionRatio),
         };
 
         videoIframe.implementation_.onMessage_(message);
@@ -311,7 +313,7 @@ describes.realWin(
 
         const postMessage = stubPostMessage(videoIframe);
 
-        stubIntersectionEntry(videoIframe, time, intersectionRatio);
+        stubPostIntersection(videoIframe, time, intersectionRatio);
 
         acceptMockedMessages(videoIframe);
 


### PR DESCRIPTION
Partial for https://github.com/ampproject/amphtml/issues/31540

Note: this is [a similar strategy](https://github.com/ampproject/amphtml/pull/31055#discussion_r520958803) being used by the new version of amp-video