### PR TITLE
[amp-story-player] 🐛 fix signalReady

### DIFF
--- a/src/amp-story-player/amp-story-player-impl.js
+++ b/src/amp-story-player/amp-story-player-impl.js
@@ -368,7 +368,6 @@ export class AmpStoryPlayer {
     this.readPlayerConfig_();
     this.maybeFetchMoreStories_(this.stories_.length - this.currentIdx_ - 1);
     this.initializeCircularWrapping_();
-    this.signalReady_();
     this.isBuilt_ = true;
   }
 
@@ -725,15 +724,20 @@ export class AmpStoryPlayer {
     this.initializeVisibleIO_();
 
     this.visibleDeferred_.promise.then(() => {
-      if (this.stories_.length > 0) {
-        this.updateVisibilityState_(
-          0 /** iframeIdx */,
-          VisibilityState.VISIBLE
-        );
+      if (this.stories_.length === 0) {
+        this.signalReady_();
+        this.isLaidOut_ = true;
+        return;
       }
-    });
 
-    this.isLaidOut_ = true;
+      this.updateVisibilityState_(
+        0 /** iframeIdx */,
+        VisibilityState.VISIBLE
+      ).then(() => {
+        this.signalReady_();
+        this.isLaidOut_ = true;
+      });
+    });
   }
 
   /**

--- a/src/amp-story-player/amp-story-player-impl.js
+++ b/src/amp-story-player/amp-story-player-impl.js
@@ -723,20 +723,17 @@ export class AmpStoryPlayer {
     this.prerenderStories_();
     this.initializeVisibleIO_();
 
+    this.prerenderFirstStoryDeferred_.promise.then(() => {
+      this.signalReady_();
+      this.isLaidOut_ = true;
+    });
+
     this.visibleDeferred_.promise.then(() => {
       if (this.stories_.length === 0) {
-        this.signalReady_();
-        this.isLaidOut_ = true;
         return;
       }
 
-      this.updateVisibilityState_(
-        0 /** iframeIdx */,
-        VisibilityState.VISIBLE
-      ).then(() => {
-        this.signalReady_();
-        this.isLaidOut_ = true;
-      });
+      this.updateVisibilityState_(0 /** iframeIdx */, VisibilityState.VISIBLE);
     });
   }
 


### PR DESCRIPTION
Details / fixes #31445

When using the player APIs, calling `player.load()` and `player.show()` will cause errors (`reason: TypeError: Cannot read property 'then' of undefined
    at AmpStoryPlayer.waitForStoryToLoadPromise.`) 

This is because we are incorrectly signaling that the player is ready for interaction when it isn't in reality. The signal event and property are dispatched/set BEFORE the `build and layoutCallback()` finish. This causes race conditions when calling e.g. `show()` right after `player.load()` currently:

E.g.

```javascript
player.load();

player.addEventListener("ready", () => {
  show('url'); // this is running before build/layoutCallback() finishes.
});

if (player.isReady) {
  show('url'); // this is running before build/layoutCallback() finishes.
}
```

The proposed change is to wait at least until the first story is prerendered (once everything has been built and setup) before signaling that the player is ready.

<!--
# Instructions:

- Pick a meaningful title for your pull request. (Use sentence case.)
  - Prefix the title with an emoji to identify what is being done. (Copy-paste the emoji from the list below.)
  - Do not overuse punctuation in the title (like `(chore):`).
  - If it is helpful, use a simple prefix (like `ProjectX: Implement some feature`).
- Enter a succinct description that says why the PR is necessary, and what it does.
  - Mention the GitHub issue that is being addressed by the pull request.
  - The keywords `Fixes`, `Closes`, or `Resolves` followed the issue number will automatically close the issue.

> NOTE: All non-trivial changes (like introducing new features or components) should have an associated issue or reference an I2I (intent-to-implement: go.amp.dev/i2i). Please read through the contribution process (go.amp.dev/contributing/code) for more information.

# Example of a good description:

- Implement aspect X
- Leave out feature Y because of A
- Improve performance by B
- Improve accessibility by C

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Reverting a previous change
♻️ Refactoring
🚮 Deleting code
🧪 Experimental code
-->
