### PR TITLE
Separate the getLayoutSize() from getLayoutBox() API

### DIFF
--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -1192,6 +1192,24 @@ const forbiddenTermsSrcInclusive = {
       'function to build-system/common/ci.js',
   },
   '\\.matches\\(': 'Please use matches() helper in src/dom.js',
+  '\\.getLayoutBox': {
+    message: measurementApiDeprecated,
+    allowlist: [
+      'src/base-element.js',
+      'src/custom-element.js',
+      'src/friendly-iframe-embed.js',
+      'src/service/mutator-impl.js',
+      'src/service/resource.js',
+      'src/service/resources-impl.js',
+      'extensions/amp-ad/0.1/amp-ad-3p-impl.js',
+      'extensions/amp-ad-network-adsense-impl/0.1/responsive-state.js',
+      'extensions/amp-fx-flying-carpet/0.1/amp-fx-flying-carpet.js',
+      'extensions/amp-iframe/0.1/amp-iframe.js',
+      'extensions/amp-next-page/1.0/visibility-observer.js',
+      'extensions/amp-playbuzz/0.1/amp-playbuzz.js',
+      'extensions/amp-story/1.0/page-advancement.js',
+    ],
+  },
   '\\.getIntersectionElementLayoutBox': {
     message: measurementApiDeprecated,
     allowlist: [

--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -922,7 +922,7 @@ const bannedTermsHelpString =
   'if you are unsure and so that it stands out in code reviews.';
 
 const measurementApiDeprecated =
-  'getLayoutWidth/Box APIs are being deprecated. Please contact the' +
+  'getLayoutSize/Box APIs are being deprecated. Please contact the' +
   ' @ampproject/wg-performance for questions.';
 
 const forbiddenTermsSrcInclusive = {
@@ -1192,14 +1192,6 @@ const forbiddenTermsSrcInclusive = {
       'function to build-system/common/ci.js',
   },
   '\\.matches\\(': 'Please use matches() helper in src/dom.js',
-  '\\.getLayoutWidth': {
-    message: measurementApiDeprecated,
-    allowlist: [
-      'builtins/amp-img.js',
-      'src/service/resources-impl.js',
-      'extensions/amp-fx-flying-carpet/0.1/amp-fx-flying-carpet.js',
-    ],
-  },
   '\\.getIntersectionElementLayoutBox': {
     message: measurementApiDeprecated,
     allowlist: [

--- a/builtins/amp-img.js
+++ b/builtins/amp-img.js
@@ -214,7 +214,7 @@ export class AmpImg extends BaseElement {
       return;
     }
 
-    const width = this.element.getLayoutWidth();
+    const {width} = this.element.getLayoutSize();
     if (!this.shouldSetSizes_(width)) {
       return;
     }
@@ -272,7 +272,8 @@ export class AmpImg extends BaseElement {
     const img = dev().assertElement(this.img_);
     this.unlistenLoad_ = listen(img, 'load', () => this.hideFallbackImg_());
     this.unlistenError_ = listen(img, 'error', () => this.onImgLoadingError_());
-    if (this.element.getLayoutWidth() <= 0) {
+    const {width} = this.element.getLayoutSize();
+    if (width <= 0) {
       return Promise.resolve();
     }
     return this.loadPromise(img);

--- a/extensions/amp-3d-gltf/0.1/amp-3d-gltf.js
+++ b/extensions/amp-3d-gltf/0.1/amp-3d-gltf.js
@@ -245,10 +245,10 @@ export class Amp3dGltf extends AMP.BaseElement {
    *
    */
   onLayoutMeasure() {
-    const box = this.getLayoutBox();
+    const {width, height} = this.getLayoutSize();
     this.sendCommandWhenReady_(
       'setSize',
-      dict({'width': box.width, 'height': box.height})
+      dict({'width': width, 'height': height})
     );
   }
 

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -286,7 +286,7 @@ export class AmpA4A extends AMP.BaseElement {
      */
     this.creativeSize_ = null;
 
-    /** @private {?../../../src/layout-rect.LayoutRectDef} */
+    /** @private {?../../../src/layout-rect.LayoutSizeDef} */
     this.originalSlotSize_ = null;
 
     /**
@@ -1373,7 +1373,7 @@ export class AmpA4A extends AMP.BaseElement {
     // Store original size of slot in order to allow re-expansion on
     // unlayoutCallback so that it is reverted to original size in case
     // of resumeCallback.
-    this.originalSlotSize_ = this.originalSlotSize_ || this.getLayoutBox();
+    this.originalSlotSize_ = this.originalSlotSize_ || this.getLayoutSize();
     return super.attemptChangeSize(newHeight, newWidth);
   }
 
@@ -1583,7 +1583,7 @@ export class AmpA4A extends AMP.BaseElement {
     devAssert(this.uiHandler);
     // Store original size to allow for reverting on unlayoutCallback so that
     // subsequent pageview allows for ad request.
-    this.originalSlotSize_ = this.originalSlotSize_ || this.getLayoutBox();
+    this.originalSlotSize_ = this.originalSlotSize_ || this.getLayoutSize();
     this.uiHandler.applyNoContentUI();
     this.isCollapsed_ = true;
   }

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -56,7 +56,7 @@ import {
   incrementLoadingAds,
   is3pThrottled,
 } from '../../../amp-ad/0.1/concurrent-load';
-import {layoutRectLtwh} from '../../../../src/layout-rect';
+import {layoutRectLtwh, layoutSizeFromRect} from '../../../../src/layout-rect';
 import {resetScheduledElementForTesting} from '../../../../src/service/custom-element-registry';
 import {data as testFragments} from './testdata/test_fragments';
 import {data as validCSSAmp} from './testdata/valid_css_at_rules_amp.reserialized';
@@ -283,6 +283,7 @@ describe('amp-a4a', () => {
       'height': opt_rect ? String(opt_rect.height) : '50',
       'type': 'adsense',
     });
+    const layoutBox = opt_rect || layoutRectLtwh(0, 0, 200, 50);
     element.getAmpDoc = () => {
       const ampdocService = Services.ampdocServiceFor(doc.defaultView);
       return ampdocService.getAmpDoc(element);
@@ -290,9 +291,8 @@ describe('amp-a4a', () => {
     element.isBuilt = () => {
       return true;
     };
-    element.getLayoutBox = () => {
-      return opt_rect || layoutRectLtwh(0, 0, 200, 50);
-    };
+    element.getLayoutBox = () => layoutBox;
+    element.getLayoutSize = () => layoutSizeFromRect(layoutBox);
     element.getIntersectionChangeEntry = () => {
       return null;
     };
@@ -1924,7 +1924,7 @@ describe('amp-a4a', () => {
           cleanup: () => {},
         };
         window.sandbox
-          .stub(a4a, 'getLayoutBox')
+          .stub(a4a, 'getLayoutSize')
           .returns({width: 123, height: 456});
         a4a.onLayoutMeasure();
         expect(a4a.adPromise_).to.be.ok;

--- a/extensions/amp-ad/0.1/test/test-amp-ad-3p-impl.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-3p-impl.js
@@ -401,7 +401,8 @@ describes.realWin(
         }
       );
 
-      it('should only allow rendering one ad per second', function* () {
+      it('should only allow rendering one ad per second', async () => {
+        ad3p.getVsync().runScheduledTasks_();
         const clock = lolex.install({
           target: win,
           toFake: ['Date', 'setTimeout', 'clearTimeout'],
@@ -416,10 +417,12 @@ describes.realWin(
 
         // Ad loading should only block 1s.
         clock.tick(999);
-        yield macroTask();
+        await macroTask();
         expect(ad3p2.renderOutsideViewport()).to.equal(false);
         clock.tick(2);
-        yield oneSecPromise;
+        await oneSecPromise;
+        clock.tick(2);
+        await macroTask();
         expect(ad3p2.renderOutsideViewport()).to.equal(3);
       });
 

--- a/extensions/amp-analytics/0.1/test/test-visibility-manager.js
+++ b/extensions/amp-analytics/0.1/test/test-visibility-manager.js
@@ -772,15 +772,9 @@ describes.fakeWin('VisibilityManagerForDoc', {amp: true}, (env) => {
     clock.tick(1);
     const target = win.document.createElement('div');
     target.id = 'targetElementId';
-    const resource = {
-      getLayoutBox() {
-        return {top: 10, left: 11, width: 110, height: 111};
-      },
-    };
-    const resources = win.__AMP_SERVICES.resources.obj;
     env.sandbox
-      .stub(resources, 'getResourceForElementOptional')
-      .callsFake(() => resource);
+      .stub(target, 'getBoundingClientRect')
+      .returns({top: 10, left: 11, width: 110, height: 111});
     const spec = {totalTimeMin: 10};
     root.listenElement(target, spec, null, null, eventResolver);
 
@@ -1122,10 +1116,9 @@ describes.realWin('VisibilityManager integrated', {amp: true}, (env) => {
       startTime = 10000;
       clock.tick(startTime);
 
-      const resource = resources.getResourceForElement(ampElement);
       scrollTop = 10;
       env.sandbox
-        .stub(resource, 'getLayoutBox')
+        .stub(ampElement, 'getBoundingClientRect')
         .callsFake(() => layoutRectLtwh(0, scrollTop, 100, 100));
     });
   });

--- a/extensions/amp-analytics/0.1/visibility-manager.js
+++ b/extensions/amp-analytics/0.1/visibility-manager.js
@@ -123,9 +123,6 @@ export class VisibilityManager {
     /** @const @protected */
     this.ampdoc = ampdoc;
 
-    /** @const @private */
-    this.resources_ = Services.resourcesForDoc(ampdoc);
-
     /** @private {number} */
     this.rootVisibility_ = 0;
 
@@ -499,12 +496,7 @@ export class VisibilityManager {
       if (opt_element) {
         state['elementId'] = opt_element.id;
         state['opacity'] = getMinOpacity(opt_element);
-        const resource = this.resources_.getResourceForElementOptional(
-          opt_element
-        );
-        layoutBox = resource
-          ? resource.getLayoutBox()
-          : viewport.getLayoutRect(opt_element);
+        layoutBox = viewport.getLayoutRect(opt_element);
         const intersectionRatio = this.getElementVisibility(opt_element);
         const intersectionRect = this.getElementIntersectionRect(opt_element);
         Object.assign(

--- a/extensions/amp-auto-lightbox/0.1/amp-auto-lightbox.js
+++ b/extensions/amp-auto-lightbox/0.1/amp-auto-lightbox.js
@@ -159,7 +159,7 @@ export class Criteria {
       dev().assertElement(element.querySelector('img'))
     );
 
-    const {width: renderWidth, height: renderHeight} = element.getLayoutBox();
+    const {width: renderWidth, height: renderHeight} = element.getLayoutSize();
 
     const viewport = Services.viewportForDoc(element);
     const {width: vw, height: vh} = viewport.getSize();

--- a/extensions/amp-connatix-player/0.1/amp-connatix-player.js
+++ b/extensions/amp-connatix-player/0.1/amp-connatix-player.js
@@ -305,7 +305,7 @@ export class AmpConnatixPlayer extends AMP.BaseElement {
     if (!this.iframe_) {
       return;
     }
-    const {width, height} = this.getLayoutBox();
+    const {width, height} = this.getLayoutSize();
     this.sendCommand_('ampResize', {'width': width, 'height': height});
   }
 

--- a/extensions/amp-fx-flying-carpet/0.1/amp-fx-flying-carpet.js
+++ b/extensions/amp-fx-flying-carpet/0.1/amp-fx-flying-carpet.js
@@ -148,7 +148,7 @@ export class AmpFlyingCarpet extends AMP.BaseElement {
       this.initialPositionChecked_ = true;
     }
 
-    const width = this.element.getLayoutWidth();
+    const {width} = this.element.getLayoutSize();
     setStyle(this.container_, 'width', width, 'px');
     Services.ownersForDoc(this.element).scheduleLayout(
       this.element,

--- a/extensions/amp-fx-flying-carpet/0.1/test/test-amp-fx-flying-carpet.js
+++ b/extensions/amp-fx-flying-carpet/0.1/test/test-amp-fx-flying-carpet.js
@@ -146,7 +146,7 @@ describes.realWin(
         impl.mutateElement = function (callback) {
           callback();
         };
-        flyingCarpet.getLayoutWidth = () => width;
+        flyingCarpet.getLayoutSize = () => ({width, height: 100});
 
         impl.layoutCallback();
         expect(container.style.width).to.equal(width + 'px');

--- a/extensions/amp-iframe/0.1/test/test-amp-iframe.js
+++ b/extensions/amp-iframe/0.1/test/test-amp-iframe.js
@@ -873,7 +873,7 @@ describes.realWin(
       it('should correctly classify ads', () => {
         function e(width, height) {
           return {
-            getLayoutBox() {
+            getLayoutSize() {
               return {width, height};
             },
           };

--- a/extensions/amp-ima-video/0.1/amp-ima-video.js
+++ b/extensions/amp-ima-video/0.1/amp-ima-video.js
@@ -228,7 +228,7 @@ class AmpImaVideo extends AMP.BaseElement {
     if (!this.iframe_) {
       return;
     }
-    const {width, height} = this.getLayoutBox();
+    const {width, height} = this.getLayoutSize();
     this.sendCommand_('resize', {'width': width, 'height': height});
   }
 

--- a/extensions/amp-script/0.1/amp-script.js
+++ b/extensions/amp-script/0.1/amp-script.js
@@ -167,7 +167,7 @@ export class AmpScript extends AMP.BaseElement {
       return;
     }
 
-    const {width, height} = this.getLayoutBox();
+    const {width, height} = this.getLayoutSize();
     if (width === 0 && height === 0) {
       user().warn(
         TAG,

--- a/extensions/amp-script/0.1/test/unit/test-amp-script.js
+++ b/extensions/amp-script/0.1/test/unit/test-amp-script.js
@@ -160,14 +160,14 @@ describes.fakeWin('AmpScript', {amp: {runtimeOn: false}}, (env) => {
   describe('Initialization skipped warning due to zero height/width', () => {
     it('should not warn when there is positive width/height', () => {
       const warnStub = env.sandbox.stub(user(), 'warn');
-      env.sandbox.stub(script, 'getLayoutBox').returns({height: 1, width: 1});
+      env.sandbox.stub(script, 'getLayoutSize').returns({height: 1, width: 1});
       script.onMeasureChanged();
       expect(warnStub).to.have.callCount(0);
     });
 
     it('should warn if there is zero width/height', () => {
       const warnStub = env.sandbox.stub(user(), 'warn');
-      env.sandbox.stub(script, 'getLayoutBox').returns({height: 0, width: 0});
+      env.sandbox.stub(script, 'getLayoutSize').returns({height: 0, width: 0});
       script.onMeasureChanged();
 
       expect(warnStub).calledWith(

--- a/extensions/amp-story-dev-tools/0.1/amp-story-dev-tools-tab-preview.js
+++ b/extensions/amp-story-dev-tools/0.1/amp-story-dev-tools-tab-preview.js
@@ -613,8 +613,8 @@ export class AmpStoryDevToolsTabPreview extends AMP.BaseElement {
    * @private
    * */
   repositionDevices_() {
-    const layoutBox = this.getLayoutBox();
-    layoutBox.width *= 0.8; // To account for 10% horizontal padding.
+    const {width: layoutWidth, height} = this.getLayoutSize();
+    const width = layoutWidth * 0.8; // To account for 10% horizontal padding.
     let sumDeviceWidths = 0;
     let maxDeviceHeights = 0;
     // Find the sum of the device widths and max of heights since they are horizontally laid out.
@@ -627,11 +627,11 @@ export class AmpStoryDevToolsTabPreview extends AMP.BaseElement {
     });
     // Find the scale that covers up to 90% of width or 80% of height.
     const scale = Math.min(
-      (layoutBox.width / sumDeviceWidths) * 0.9,
-      (layoutBox.height / maxDeviceHeights) * 0.8
+      (width / sumDeviceWidths) * 0.9,
+      (height / maxDeviceHeights) * 0.8
     );
     const paddingSize =
-      (layoutBox.width - sumDeviceWidths * scale) / (this.devices_.length + 1);
+      (width - sumDeviceWidths * scale) / (this.devices_.length + 1);
     let cumWidthSum = paddingSize;
     this.mutateElement(() => {
       this.devices_.forEach((deviceSpecs) => {

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -293,7 +293,7 @@ export class AmpStoryPage extends AMP.BaseElement {
     /** @private {?Element} */
     this.cssVariablesStyleEl_ = null;
 
-    /** @private {?../../../src/layout-rect.LayoutRectDef} */
+    /** @private {?../../../src/layout-rect.LayoutSizeDef} */
     this.layoutBox_ = null;
 
     /** @private {!Array<function()>} */
@@ -577,7 +577,7 @@ export class AmpStoryPage extends AMP.BaseElement {
   // equality checks.
   /** @override */
   onLayoutMeasure() {
-    const layoutBox = this.getLayoutBox();
+    const layoutBox = this.getLayoutSize();
     // Only measures from the first story page, that always gets built because
     // of the prerendering optimizations in place.
     if (

--- a/extensions/amp-video-iframe/0.1/test/test-amp-video-iframe.js
+++ b/extensions/amp-video-iframe/0.1/test/test-amp-video-iframe.js
@@ -89,10 +89,10 @@ describes.realWin(
 
     async function layoutAndLoad(element) {
       await whenUpgradedToCustomElement(element);
-      // getLayoutBox() affects looksLikeTrackingIframe().
+      // getLayoutSize() affects looksLikeTrackingIframe().
       // Use default width/height of 100 since element is not sized
       // as expected in test fixture.
-      env.sandbox.stub(element, 'getLayoutBox').returns({
+      env.sandbox.stub(element, 'getLayoutSize').returns({
         width: Number(element.getAttribute('width')) || 100,
         height: Number(element.getAttribute('height')) || 100,
       });

--- a/extensions/amp-vk/0.1/test/test-amp-vk.js
+++ b/extensions/amp-vk/0.1/test/test-amp-vk.js
@@ -144,7 +144,7 @@ describes.realWin(
         vkPost.ownerDocument.location.href.replace(/#.*$/, '')
       );
       impl.onLayoutMeasure();
-      const startWidth = vkPost.getLayoutWidth();
+      const startWidth = vkPost.getLayoutSize().width;
       const correctIFrameSrc = `https://vk.com/widget_post.php?app=0&width=100%25&_ver=1&owner_id=1&post_id=45616&hash=Yc8_Z9pnpg8aKMZbVcD-jK45eAk&amp=1&startWidth=${startWidth}&url=${url}&referrer=${referrer}&title=AMP%20Post`;
       expect(iframe).to.not.be.null;
       const timeArgPosition = iframe.src.lastIndexOf('&');

--- a/src/base-element.js
+++ b/src/base-element.js
@@ -206,6 +206,14 @@ export class BaseElement {
   }
 
   /**
+   * Returns a previously measured layout size.
+   * @return {!./layout-rect.LayoutSizeDef}
+   */
+  getLayoutSize() {
+    return this.element.getLayoutSize();
+  }
+
+  /**
    * DO NOT CALL. Retained for backward compat during rollout.
    * @public
    * @return {!Window}

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -156,12 +156,6 @@ function createBaseCustomElementClass(win) {
       this.layout_ = Layout.NODISPLAY;
 
       /** @private {number} */
-      this.layoutWidth_ = -1;
-
-      /** @private {number} */
-      this.layoutHeight_ = -1;
-
-      /** @private {number} */
       this.layoutCount_ = 0;
 
       /** @private {boolean} */
@@ -412,15 +406,6 @@ function createBaseCustomElementClass(win) {
     }
 
     /**
-     * TODO(wg-performance, #25824): Make Resource.getLayoutBox() the source of truth.
-     * @return {number}
-     * @deprecated
-     */
-    getLayoutWidth() {
-      return this.layoutWidth_;
-    }
-
-    /**
      * Get the default action alias.
      * @return {?string}
      */
@@ -553,8 +538,6 @@ function createBaseCustomElementClass(win) {
      * @param {boolean} sizeChanged
      */
     updateLayoutBox(layoutBox, sizeChanged = false) {
-      this.layoutWidth_ = layoutBox.width;
-      this.layoutHeight_ = layoutBox.height;
       if (this.isBuilt()) {
         this.onMeasure(sizeChanged);
       }
@@ -1019,6 +1002,15 @@ function createBaseCustomElementClass(win) {
      */
     getLayoutBox() {
       return this.getResource_().getLayoutBox();
+    }
+
+    /**
+     * Returns a previously measured layout size.
+     * @return {!./layout-rect.LayoutSizeDef}
+     * @final
+     */
+    getLayoutSize() {
+      return this.getResource_().getLayoutSize();
     }
 
     /**

--- a/src/iframe-helper.js
+++ b/src/iframe-helper.js
@@ -511,9 +511,9 @@ export class SubscriptionApi {
  * @return {boolean}
  */
 export function looksLikeTrackingIframe(element) {
-  const box = element.getLayoutBox();
+  const {width, height} = element.getLayoutSize();
   // This heuristic is subject to change.
-  if (box.width > 10 || box.height > 10) {
+  if (width > 10 || height > 10) {
     return false;
   }
   // Iframe is not tracking iframe if open with user interaction
@@ -536,8 +536,7 @@ const adSizes = [
  * @visibleForTesting
  */
 export function isAdLike(element) {
-  const box = element.getLayoutBox();
-  const {height, width} = box;
+  const {width, height} = element.getLayoutSize();
   for (let i = 0; i < adSizes.length; i++) {
     const refWidth = adSizes[i][0];
     const refHeight = adSizes[i][1];

--- a/src/layout-rect.js
+++ b/src/layout-rect.js
@@ -32,6 +32,17 @@
 export let LayoutRectDef;
 
 /**
+ * The structure that contains the size for an element. The exact
+ * interpretation of the size depends on the use case.
+ *
+ * @typedef {{
+ *   width: number,
+ *   height: number,
+ * }}
+ */
+export let LayoutSizeDef;
+
+/**
  * The structure that represents the margins of an Element.
  *
  * @typedef {{
@@ -279,4 +290,13 @@ export function cloneLayoutMarginsChangeDef(marginsChange) {
     left: marginsChange.left,
     right: marginsChange.right,
   };
+}
+
+/**
+ * @param {!LayoutRectDef|!ClientRect|!DOMRect} rect
+ * @return {!LayoutSizeDef}
+ */
+export function layoutSizeFromRect(rect) {
+  const {width, height} = rect;
+  return {width, height};
 }

--- a/src/service/mutator-impl.js
+++ b/src/service/mutator-impl.js
@@ -397,10 +397,10 @@ export class MutatorImpl {
     opt_callback
   ) {
     resource.resetPendingChangeSize();
-    const layoutBox = resource.getLayoutBox();
+    const layoutSize = resource.getLayoutSize();
     if (
-      (newHeight === undefined || newHeight == layoutBox.height) &&
-      (newWidth === undefined || newWidth == layoutBox.width) &&
+      (newHeight === undefined || newHeight == layoutSize.height) &&
+      (newWidth === undefined || newWidth == layoutSize.width) &&
       (marginChange === undefined ||
         !areMarginsChanged(
           marginChange.currentMargins,

--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -23,6 +23,7 @@ import {dev, devAssert} from '../log';
 import {
   layoutRectLtwh,
   layoutRectSizeEquals,
+  layoutSizeFromRect,
   moveLayoutRect,
   rectsOverlap,
 } from '../layout-rect';
@@ -650,6 +651,14 @@ export class Resource {
    */
   requestMeasure() {
     this.isMeasureRequested_ = true;
+  }
+
+  /**
+   * Returns a previously measured layout size.
+   * @return {!../layout-rect.LayoutSizeDef}
+   */
+  getLayoutSize() {
+    return layoutSizeFromRect(this.layoutBox_);
   }
 
   /**

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -1011,7 +1011,7 @@ export class ResourcesImpl {
                 // If the element has siblings, it's possible that a width-expansion will
                 // cause some of them to be pushed down.
                 const parentWidth =
-                  (parent.getLayoutWidth && parent.getLayoutWidth()) ||
+                  (parent.getLayoutSize && parent.getLayoutSize().width) ||
                   parent./*OK*/ offsetWidth;
                 let cumulativeWidth = widthDiff;
                 for (let i = 0; i < parent.childElementCount; i++) {

--- a/src/service/video-manager-impl.js
+++ b/src/service/video-manager-impl.js
@@ -980,7 +980,7 @@ class VideoEntry {
   getAnalyticsDetails() {
     const {video} = this;
     return this.supportsAutoplay_().then((supportsAutoplay) => {
-      const {width, height} = video.element.getLayoutBox();
+      const {width, height} = video.element.getLayoutSize();
       const autoplay = this.hasAutoplay && supportsAutoplay;
       const playedRanges = video.getPlayedRanges();
       const playedTotal = playedRanges.reduce(

--- a/test/unit/test-amp-img.js
+++ b/test/unit/test-amp-img.js
@@ -262,7 +262,7 @@ describes.sandboxed('amp-img', {}, (env) => {
       el.setAttribute('height', 100);
       el.getResources = () => Services.resourcesForDoc(document);
       el.getPlaceholder = sandbox.stub();
-      el.getLayoutWidth = () => 100;
+      el.getLayoutSize = () => ({width: 100, height: 100});
       impl = new AmpImg(el);
       el.toggleFallback = function () {};
       el.togglePlaceholder = function () {};
@@ -416,7 +416,7 @@ describes.sandboxed('amp-img', {}, (env) => {
     el.setAttribute('aria-label', 'Hello');
     el.setAttribute('aria-labelledby', 'id2');
     el.setAttribute('aria-describedby', 'id3');
-    el.getLayoutWidth = () => -1;
+    el.getLayoutSize = () => ({width: 0, height: 0});
 
     el.getPlaceholder = sandbox.stub();
     const impl = new AmpImg(el);
@@ -515,7 +515,7 @@ describes.sandboxed('amp-img', {}, (env) => {
       if (addBlurClass) {
         img.classList.add('i-amphtml-blurry-placeholder');
       }
-      el.getLayoutWidth = () => 200;
+      el.getLayoutSize = () => ({width: 200, height: 100});
       el.appendChild(img);
       el.getResources = () => Services.resourcesForDoc(document);
       const impl = new AmpImg(el);
@@ -612,7 +612,7 @@ describes.sandboxed('amp-img', {}, (env) => {
       }
       el.getResources = () => Services.resourcesForDoc(document);
       el.getPlaceholder = sandbox.stub();
-      el.getLayoutWidth = () => layoutWidth;
+      el.getLayoutSize = () => ({width: layoutWidth, height: 100});
       const impl = new AmpImg(el);
       sandbox.stub(impl, 'getLayout').returns(attributes['layout']);
       el.toggleFallback = function () {};

--- a/test/unit/test-custom-element.js
+++ b/test/unit/test-custom-element.js
@@ -49,6 +49,7 @@ describes.realWin('CustomElement', {amp: true}, (env) => {
       let testElementResumeCallback;
       let testElementAttachedCallback;
       let testElementDetachedCallback;
+      let testOnLayoutMeasureCallback;
 
       class TestElement extends BaseElement {
         isLayoutSupported(unusedLayout) {
@@ -89,6 +90,9 @@ describes.realWin('CustomElement', {amp: true}, (env) => {
         }
         detachedCallback() {
           testElementDetachedCallback();
+        }
+        onLayoutMeasure() {
+          testOnLayoutMeasureCallback();
         }
       }
 
@@ -134,6 +138,7 @@ describes.realWin('CustomElement', {amp: true}, (env) => {
         testElementResumeCallback = env.sandbox.spy();
         testElementAttachedCallback = env.sandbox.spy();
         testElementDetachedCallback = env.sandbox.spy();
+        testOnLayoutMeasureCallback = env.sandbox.spy();
       });
 
       afterEach(() => {
@@ -321,10 +326,15 @@ describes.realWin('CustomElement', {amp: true}, (env) => {
       it('Element - updateLayoutBox', () => {
         const element = new ElementClass();
         container.appendChild(element);
-        expect(element.getLayoutWidth()).to.equal(-1);
+        expect(element.getLayoutSize()).to.deep.equal({width: 0, height: 0});
 
-        element.updateLayoutBox({top: 0, left: 0, width: 111, height: 51});
-        expect(element.getLayoutWidth()).to.equal(111);
+        const rect = {top: 0, left: 0, width: 111, height: 51};
+        element.updateLayoutBox(rect);
+        expect(testOnLayoutMeasureCallback).to.not.be.called;
+
+        env.sandbox.stub(element, 'isBuilt').returns(true);
+        element.updateLayoutBox(rect);
+        expect(testOnLayoutMeasureCallback).to.be.calledOnce;
       });
 
       it('should tolerate errors in onLayoutMeasure', () => {
@@ -342,7 +352,7 @@ describes.realWin('CustomElement', {amp: true}, (env) => {
         return element.buildingPromise_.then(() => {
           allowConsoleError(() => {
             element.updateLayoutBox({top: 0, left: 0, width: 111, height: 51});
-            expect(element.getLayoutWidth()).to.equal(111);
+            expect(element.getLayoutSize()).to.be.ok;
             expect(errorStub).to.be.calledWith(AmpEvents.ERROR, 'intentional');
           });
         });
@@ -363,7 +373,7 @@ describes.realWin('CustomElement', {amp: true}, (env) => {
               {top: 0, left: 0, width: 111, height: 51},
               /* opt_hasMeasurementsChanged */ false
             );
-            expect(element.getLayoutWidth()).to.equal(111);
+            expect(element.getLayoutSize()).to.be.ok;
             expect(onMeasureChangeStub).to.have.not.been.called;
           });
         }
@@ -384,7 +394,7 @@ describes.realWin('CustomElement', {amp: true}, (env) => {
               {top: 0, left: 0, width: 111, height: 51},
               /* opt_hasMeasurementsChanged */ true
             );
-            expect(element.getLayoutWidth()).to.equal(111);
+            expect(element.getLayoutSize()).to.be.ok;
             expect(onMeasureChangeStub).to.have.been.called;
           });
         }

--- a/test/unit/test-mutator.js
+++ b/test/unit/test-mutator.js
@@ -1082,7 +1082,7 @@ describe('mutator changeSize', () => {
       () => {
         const parent = document.createElement('div');
         parent.style.width = '222px';
-        parent.getLayoutWidth = () => 222;
+        parent.getLayoutSize = () => ({width: 222, height: 111});
         const element = document.createElement('div');
         element.overflowCallback = overflowCallbackSpy;
         parent.appendChild(element);
@@ -1132,7 +1132,7 @@ describe('mutator changeSize', () => {
       () => {
         const parent = document.createElement('div');
         parent.style.width = '222px';
-        parent.getLayoutWidth = () => 222;
+        parent.getLayoutSize = () => ({width: 222, height: 111});
         const element = document.createElement('div');
         const sibling = document.createElement('div');
         sibling.style.width = '1px';


### PR DESCRIPTION
Key notes:
- `getLayoutSize()` will now highlight the places where the position (provided by `getLayoutBox()`) is not needed. This will be a refactoring indicator for two classes of cases that can be migrated separately.
- `getLayoutWidth()` API is deduped into `getLayoutSize().width`.
- A special-casing for analytics for an AMP element vs a regular element is removed.

Closes #25824.
Partial for #31540.
Possibly fixes/affects #29618.

TODO:

- [x] Adjust tests
- [x] Adjust deprecation messages
