### PR TITLE
✅ Deflake: Use local iframe URL on (two) 3p video player tests

### DIFF
--- a/extensions/amp-mowplayer/0.1/amp-mowplayer.js
+++ b/extensions/amp-mowplayer/0.1/amp-mowplayer.js
@@ -77,6 +77,12 @@ class AmpMowplayer extends AMP.BaseElement {
 
     /** @private {?Function} */
     this.unlistenMessage_ = null;
+
+    /**
+     * Prefix to embed URLs. Overridden on tests.
+     * @private @const {string}
+     */
+    this.baseUrl_ = 'https://mowplayer.com/watch/';
   }
 
   /**
@@ -121,7 +127,7 @@ class AmpMowplayer extends AMP.BaseElement {
     }
 
     return (this.videoIframeSrc_ =
-      'https://mowplayer.com/watch/' + this.mediaid_);
+      this.baseUrl_ + encodeURIComponent(this.mediaid_));
   }
 
   /** @override */

--- a/extensions/amp-mowplayer/0.1/test/test-amp-mowplayer.js
+++ b/extensions/amp-mowplayer/0.1/test/test-amp-mowplayer.js
@@ -41,15 +41,12 @@ describes.realWin(
       timer = Services.timerFor(win);
     });
 
-    function getMowPlayer(attributes, opt_responsive) {
+    function getMowPlayer(attributes) {
       const element = createElementWithAttributes(doc, 'amp-mowplayer', {
-        ...attributes,
         width: 250,
         height: 180,
+        ...attributes,
       });
-      if (opt_responsive) {
-        element.setAttribute('layout', 'responsive');
-      }
       doc.body.appendChild(element);
       element.implementation_.baseURL_ =
         // Use a blank page, since these tests don't require an actual page.
@@ -79,15 +76,12 @@ describes.realWin(
      * @param {string} datasource
      */
     function runTestsForDatasource(datasource) {
-      it('renders', () => {
-        return getMowPlayer({'data-mediaid': EXAMPLE_VIDEOID}, true).then(
-          (mp) => {
-            const iframe = mp.querySelector('iframe');
-            expect(iframe).to.not.be.null;
-            expect(iframe.tagName).to.equal('IFRAME');
-            expect(iframe.src).to.equal(EXAMPLE_VIDEOID_URL);
-          }
-        );
+      it('renders', async () => {
+        const element = await getMowPlayer({'data-mediaid': EXAMPLE_VIDEOID});
+        const iframe = element.querySelector('iframe');
+        expect(iframe).to.not.be.null;
+        expect(iframe.tagName).to.equal('IFRAME');
+        expect(iframe.src).to.equal(EXAMPLE_VIDEOID_URL);
       });
 
       it('requires data-mediaid', () =>

--- a/extensions/amp-mowplayer/0.1/test/test-amp-mowplayer.js
+++ b/extensions/amp-mowplayer/0.1/test/test-amp-mowplayer.js
@@ -40,11 +40,7 @@ describes.realWin(
       timer = Services.timerFor(win);
     });
 
-    function getMowPlayer(
-      attributes,
-      opt_responsive,
-      opt_beforeLayoutCallback
-    ) {
+    function getMowPlayer(attributes, opt_responsive) {
       const mp = doc.createElement('amp-mowplayer');
       for (const key in attributes) {
         mp.setAttribute(key, attributes[key]);
@@ -55,14 +51,13 @@ describes.realWin(
         mp.setAttribute('layout', 'responsive');
       }
       doc.body.appendChild(mp);
+      mp.implementation_.baseURL_ =
+        // Use a blank page, since these tests don't require an actual page.
+        // hash # at the end so path is not affected by param concat
+        `http://localhost:${location.port}/test/fixtures/served/blank.html#`;
       return mp
         .build()
-        .then(() => {
-          if (opt_beforeLayoutCallback) {
-            opt_beforeLayoutCallback(mp);
-          }
-          return mp.layoutCallback();
-        })
+        .then(() => mp.layoutCallback())
         .then(() => {
           const mpIframe = mp.querySelector('iframe');
           mp.implementation_.handleMowMessage_({

--- a/extensions/amp-mowplayer/0.1/test/test-amp-mowplayer.js
+++ b/extensions/amp-mowplayer/0.1/test/test-amp-mowplayer.js
@@ -62,8 +62,8 @@ describes.realWin(
             source: iframe.contentWindow,
             data: JSON.stringify({event: 'onReady'}),
           });
-        })
-        .then(() => element);
+          return element;
+        });
     }
 
     describe('with data-mediaid', function () {

--- a/extensions/amp-mowplayer/0.1/test/test-amp-mowplayer.js
+++ b/extensions/amp-mowplayer/0.1/test/test-amp-mowplayer.js
@@ -17,6 +17,7 @@
 import '../amp-mowplayer';
 import {Services} from '../../../../src/services';
 import {VideoEvents} from '../../../../src/video-interface';
+import {createElementWithAttributes} from '../../../../src/dom';
 import {listenOncePromise} from '../../../../src/event-helper';
 
 const EXAMPLE_VIDEOID = 'v-myfwarfx4tb';
@@ -41,32 +42,31 @@ describes.realWin(
     });
 
     function getMowPlayer(attributes, opt_responsive) {
-      const mp = doc.createElement('amp-mowplayer');
-      for (const key in attributes) {
-        mp.setAttribute(key, attributes[key]);
-      }
-      mp.setAttribute('width', '250');
-      mp.setAttribute('height', '180');
+      const element = createElementWithAttributes(doc, 'amp-mowplayer', {
+        ...attributes,
+        width: 250,
+        height: 180,
+      });
       if (opt_responsive) {
-        mp.setAttribute('layout', 'responsive');
+        element.setAttribute('layout', 'responsive');
       }
-      doc.body.appendChild(mp);
-      mp.implementation_.baseURL_ =
+      doc.body.appendChild(element);
+      element.implementation_.baseURL_ =
         // Use a blank page, since these tests don't require an actual page.
         // hash # at the end so path is not affected by param concat
         `http://localhost:${location.port}/test/fixtures/served/blank.html#`;
-      return mp
+      return element
         .build()
-        .then(() => mp.layoutCallback())
+        .then(() => element.layoutCallback())
         .then(() => {
-          const mpIframe = mp.querySelector('iframe');
-          mp.implementation_.handleMowMessage_({
+          const iframe = element.querySelector('iframe');
+          element.implementation_.handleMowMessage_({
             origin: 'https://mowplayer.com',
-            source: mpIframe.contentWindow,
+            source: iframe.contentWindow,
             data: JSON.stringify({event: 'onReady'}),
           });
         })
-        .then(() => mp);
+        .then(() => element);
     }
 
     describe('with data-mediaid', function () {

--- a/extensions/amp-nexxtv-player/0.1/test/test-amp-nexxtv-player.js
+++ b/extensions/amp-nexxtv-player/0.1/test/test-amp-nexxtv-player.js
@@ -34,32 +34,29 @@ describes.realWin(
       doc = win.document;
     });
 
-    async function getNexxtv(attributes, opt_responsive) {
-      const nexxtv = createElementWithAttributes(doc, 'amp-nexxtv-player', {
-        ...attributes,
+    async function getNexxtvPlayer(attributes) {
+      const element = createElementWithAttributes(doc, 'amp-nexxtv-player', {
         width: 111,
         height: 222,
+        ...attributes,
         // Use a blank page, since these tests don't require an actual page.
         // hash # at the end so path is not affected by param concat
         'data-origin': `http://localhost:${location.port}/test/fixtures/served/blank.html#`,
       });
-      if (opt_responsive) {
-        nexxtv.setAttribute('layout', 'responsive');
-      }
-      doc.body.appendChild(nexxtv);
-      await nexxtv.build();
-      await nexxtv.layoutCallback();
-      const nexxTimerIframe = nexxtv.querySelector('iframe');
-      nexxtv.implementation_.handleNexxMessage_({
+      doc.body.appendChild(element);
+      await element.build();
+      await element.layoutCallback();
+      const iframe = element.querySelector('iframe');
+      element.implementation_.handleNexxMessage_({
         origin: 'https://embed.nexx.cloud',
-        source: nexxTimerIframe.contentWindow,
+        source: iframe.contentWindow,
         data: JSON.stringify({cmd: 'onload'}),
       });
-      return nexxtv;
+      return element;
     }
 
     it('renders nexxtv video player', async () => {
-      const element = await getNexxtv({
+      const element = await getNexxtvPlayer({
         'data-mediaid': '71QQG852413DU7J',
         'data-client': '761',
       });
@@ -79,7 +76,7 @@ describes.realWin(
     });
 
     it('renders player responsive', async () => {
-      const nexxtv = await getNexxtv({
+      const nexxtv = await getNexxtvPlayer({
         'data-mediaid': '71QQG852413DU7J',
         'data-client': '761',
       });
@@ -89,7 +86,7 @@ describes.realWin(
     });
 
     it('removes iframe after unlayoutCallback', async () => {
-      const nexxtv = await getNexxtv({
+      const nexxtv = await getNexxtvPlayer({
         'data-mediaid': '71QQG852413DU7J',
         'data-client': '761',
       });
@@ -103,7 +100,7 @@ describes.realWin(
     });
 
     it('should forward events from nexxtv-player to the amp element', async () => {
-      const nexxtv = await getNexxtv({
+      const nexxtv = await getNexxtvPlayer({
         'data-mediaid': '71QQG852413DU7J',
         'data-client': '761',
       });

--- a/extensions/amp-nexxtv-player/0.1/test/test-amp-nexxtv-player.js
+++ b/extensions/amp-nexxtv-player/0.1/test/test-amp-nexxtv-player.js
@@ -16,6 +16,7 @@
 
 import '../amp-nexxtv-player';
 import {VideoEvents} from '../../../../src/video-interface';
+import {createElementWithAttributes} from '../../../../src/dom';
 import {listenOncePromise} from '../../../../src/event-helper';
 
 describes.realWin(
@@ -34,13 +35,14 @@ describes.realWin(
     });
 
     async function getNexxtv(attributes, opt_responsive) {
-      const nexxtv = doc.createElement('amp-nexxtv-player');
-
-      for (const key in attributes) {
-        nexxtv.setAttribute(key, attributes[key]);
-      }
-      nexxtv.setAttribute('width', '111');
-      nexxtv.setAttribute('height', '222');
+      const nexxtv = createElementWithAttributes(doc, 'amp-nexxtv-player', {
+        ...attributes,
+        width: 111,
+        height: 222,
+        // Use a blank page, since these tests don't require an actual page.
+        // hash # at the end so path is not affected by param concat
+        'data-origin': `http://localhost:${location.port}/test/fixtures/served/blank.html#`,
+      });
       if (opt_responsive) {
         nexxtv.setAttribute('layout', 'responsive');
       }
@@ -57,16 +59,23 @@ describes.realWin(
     }
 
     it('renders nexxtv video player', async () => {
-      const nexxtv = await getNexxtv({
+      const element = await getNexxtv({
         'data-mediaid': '71QQG852413DU7J',
         'data-client': '761',
       });
-      const playerIframe = nexxtv.querySelector('iframe');
+      const playerIframe = element.querySelector('iframe');
       expect(playerIframe).to.not.be.null;
-      expect(playerIframe.src).to.equal(
-        'https://embed.nexx.cloud/761/video/' +
-          '71QQG852413DU7J?dataMode=static&platform=amp'
-      );
+      expect(playerIframe.src)
+        .to.be.a('string')
+        .and.match(
+          new RegExp(
+            element.getAttribute('data-client') +
+              '/video/' +
+              element.getAttribute('data-mediaid') +
+              '\\?dataMode=static&platform=amp' +
+              '$' // suffix
+          )
+        );
     });
 
     it('renders player responsive', async () => {

--- a/extensions/amp-nexxtv-player/0.1/test/test-amp-nexxtv-player.js
+++ b/extensions/amp-nexxtv-player/0.1/test/test-amp-nexxtv-player.js
@@ -75,16 +75,6 @@ describes.realWin(
         );
     });
 
-    it('renders player responsive', async () => {
-      const nexxtv = await getNexxtvPlayer({
-        'data-mediaid': '71QQG852413DU7J',
-        'data-client': '761',
-      });
-      const playerIframe = nexxtv.querySelector('iframe');
-      expect(playerIframe).to.not.be.null;
-      expect(playerIframe.className).to.match(/i-amphtml-fill-content/);
-    });
-
     it('removes iframe after unlayoutCallback', async () => {
       const nexxtv = await getNexxtvPlayer({
         'data-mediaid': '71QQG852413DU7J',


### PR DESCRIPTION
Tracking for all players on #31785

Fixing these two initially since [they seem to be flaking a significant amount](http://amp-test-cases.appspot.com/test-cases/stats/fail):

![image](https://user-images.githubusercontent.com/254946/103567435-ac60d000-4e78-11eb-8906-c5c4784510a9.png)
