### PR TITLE
✨[amp-consent] Implement `Ping` command for TCF PostMessage API

### DIFF
--- a/extensions/amp-consent/0.1/consent-info.js
+++ b/extensions/amp-consent/0.1/consent-info.js
@@ -16,9 +16,9 @@
 
 import {CONSENT_STRING_TYPE} from '../../../src/consent-state';
 import {deepEquals} from '../../../src/json';
-import {dev, user} from '../../../src/log';
+import {dev, user, userAssert} from '../../../src/log';
 import {hasOwn, map} from '../../../src/utils/object';
-import {isEnumValue, isObject} from '../../../src/types';
+import {isArray, isEnumValue, isObject} from '../../../src/types';
 
 const TAG = 'amp-consent';
 
@@ -454,4 +454,27 @@ export function assertMetadataValues(metadata) {
       errorFields[i]
     );
   }
+}
+
+/**
+ * Validates the type of the `exposes` field,
+ * as well as the values.
+ * @param {!JsonObject} config
+ * @return {!Array<EXPOSED_CONSENT_API>}
+ */
+export function validateExposesApi(config) {
+  const exposesApis = [];
+  if (config['exposes']) {
+    const apiList = config['exposes'];
+    userAssert(isArray(apiList), `${TAG}: "exposes" expects array`);
+    for (let i = 0; i < apiList.length; i++) {
+      switch (apiList[i]) {
+        case EXPOSED_CONSENT_API.TCF_POST_MESSAGE:
+          exposesApis.push(EXPOSED_CONSENT_API.TCF_POST_MESSAGE);
+        default:
+          continue;
+      }
+    }
+  }
+  return exposesApis;
 }

--- a/extensions/amp-consent/0.1/test/test-amp-consent.js
+++ b/extensions/amp-consent/0.1/test/test-amp-consent.js
@@ -71,6 +71,8 @@ describes.realWin(
         'https://invalid.response.com/': '{"consentRequired": 3}',
         'https://xssi-prefix/': 'while(1){"consentRequired": false}',
         'https://example.test/': '{}',
+        'https://expose1/':
+          '{"consentRequired": true, "exposes": ["tcfPostMessageApi"]}',
       };
 
       xhrServiceMock = {
@@ -939,6 +941,56 @@ describes.realWin(
           expect(listenerSpy).to.be.calledOnce;
           expect(listenerSpy.args[0][0]).to.deep.equals(msg.__tcfapiCall);
         });
+      });
+    });
+
+    describe('exposes api', () => {
+      let ampConsent;
+      let consentElement;
+      let tcfPostMessageSpy;
+
+      afterEach(async () => {
+        doc.body.appendChild(consentElement);
+        ampConsent = new AmpConsent(consentElement);
+        tcfPostMessageSpy = env.sandbox.stub(
+          ampConsent,
+          'setUpTcfPostMessageProxy_'
+        );
+        await ampConsent.buildCallback();
+        await macroTask();
+        expect(tcfPostMessageSpy).to.be.calledOnce;
+      });
+
+      it('shoud use only server exposes', () => {
+        consentElement = createConsentElement(
+          doc,
+          dict({
+            'consentInstanceId': 'abc',
+            'checkConsentHref': 'https://expose1',
+          })
+        );
+      });
+
+      it('shoud use only inline exposes', () => {
+        consentElement = createConsentElement(
+          doc,
+          dict({
+            'consentInstanceId': 'abc',
+            'checkConsentHref': 'https://response1',
+            'exposes': ['tcfPostMessageApi'],
+          })
+        );
+      });
+
+      it('shoud use both server and inline exposes', () => {
+        consentElement = createConsentElement(
+          doc,
+          dict({
+            'consentInstanceId': 'abc',
+            'checkConsentHref': 'https://expose1',
+            'exposes': ['tcfPostMessageApi'],
+          })
+        );
       });
     });
 

--- a/extensions/amp-consent/0.1/test/test-consent-info.js
+++ b/extensions/amp-consent/0.1/test/test-consent-info.js
@@ -16,6 +16,7 @@
 
 import {
   CONSENT_ITEM_STATE,
+  EXPOSED_CONSENT_API,
   METADATA_STORAGE_KEY,
   composeMetadataStoreValue,
   composeStoreValue,
@@ -25,6 +26,7 @@ import {
   getStoredConsentInfo,
   isConsentInfoStoredValueSame,
   recalculateConsentStateValue,
+  validateExposesApi,
 } from '../consent-info';
 import {CONSENT_STRING_TYPE} from '../../../../src/consent-state';
 import {dict} from '../../../../src/utils/object';
@@ -462,6 +464,27 @@ describes.fakeWin('ConsentInfo', {}, () => {
         'gdprApplies': true,
         'purposeOne': true,
       });
+    });
+  });
+
+  describe('exposes validation', () => {
+    it('validates types', () => {
+      let exposes = EXPOSED_CONSENT_API.TCF_POST_MESSAGE;
+      expect(() => validateExposesApi({exposes})).to.throw(
+        /amp-consent: "exposes" expects array/
+      );
+
+      exposes = [EXPOSED_CONSENT_API.TCF_POST_MESSAGE];
+      expect(validateExposesApi({exposes})).to.be.deep.equals([
+        EXPOSED_CONSENT_API.TCF_POST_MESSAGE,
+      ]);
+    });
+
+    it('removes invalid values', () => {
+      const exposes = [EXPOSED_CONSENT_API.TCF_POST_MESSAGE, 'invalidValue'];
+      expect(validateExposesApi({exposes})).to.be.deep.equals([
+        EXPOSED_CONSENT_API.TCF_POST_MESSAGE,
+      ]);
     });
   });
 });


### PR DESCRIPTION
Partial for #30385

Implement Ping command received by 3p iframes through the PostMessage API.

Returns a "minimal" Ping object via PostMessage to the original source: 
```
{
  // Always true, as the command will only be received after amp-consent loads. Assumed that if publisher is using the PostMessage API, then a CMP will be used as well.
  cmpLoaded: boolean, 
  // Stored `gdprApplies` value from ConsentMetadata. 
  gdprApplies: boolean,
}
```
