### PR TITLE
🐛 Allow `PreactBaseElement` child def wildcard to match text nodes

### DIFF
--- a/src/preact/base-element.js
+++ b/src/preact/base-element.js
@@ -836,13 +836,11 @@ function collectProps(Ctor, element, ref, defaultProps, mediaQueryProps) {
     const children = [];
     props['children'] = children;
 
-    const nodes = element.getRealChildNodes();
+    const nodes = element
+      .getRealChildNodes()
+      .filter((node) => !isEmptyTextNode(node));
     for (let i = 0; i < nodes.length; i++) {
       const childElement = nodes[i];
-      if (isEmptyTextNode(childElement)) {
-        continue;
-      }
-
       const def = matchChild(childElement, childrenDefs);
       if (!def) {
         continue;

--- a/src/preact/slot.js
+++ b/src/preact/slot.js
@@ -22,13 +22,13 @@ import {useAmpContext} from './context';
 import {useEffect, useLayoutEffect, useRef} from './index';
 
 /**
- * @param {!Element} element
+ * @param {!Node} node
  * @param {string} name
  * @param {!Object|undefined} props
  * @return {!PreactDef.VNode}
  */
-export function createSlot(element, name, props) {
-  element.setAttribute('slot', name);
+export function createSlot(node, name, props) {
+  node.setAttribute && node.setAttribute('slot', name);
   return <Slot {...(props || {})} name={name} />;
 }
 

--- a/test/unit/preact/test-base-element-mapping.js
+++ b/test/unit/preact/test-base-element-mapping.js
@@ -483,7 +483,7 @@ describes.realWin('PreactBaseElement', spec, (env) => {
     });
   });
 
-  describe('children mapping', () => {
+  describe.only('children mapping', () => {
     let element;
     const DATE_STRING = '2018-01-01T08:00:00Z';
     const DATE = Date.parse(DATE_STRING);
@@ -563,6 +563,7 @@ describes.realWin('PreactBaseElement', spec, (env) => {
             data-param-test-two="confirm2"
             prefix="pref2"
           ></div>
+          Some text content
           <div cloned id="cloned1"></div>
           <div cloned id="cloned2"></div>
         </amp-preact>
@@ -603,8 +604,8 @@ describes.realWin('PreactBaseElement', spec, (env) => {
 
     it('should pass children as prop slot array and parse attributes', () => {
       const {children} = lastProps;
-      expect(children).to.have.lengthOf(2);
-      const {0: child1, 1: child2} = children;
+      expect(children).to.have.lengthOf(3);
+      const {0: child1, 1: child2, 2: textChild} = children;
       expect(child1.type).to.equal(Slot);
       expect(omit(child1.props, 'name')).to.deep.equal({
         boolDefTrue: true,
@@ -617,10 +618,12 @@ describes.realWin('PreactBaseElement', spec, (env) => {
         combined: 'C+D',
         params: {test: 'helloworld2', testTwo: 'confirm2'},
       });
+      expect(textChild.type).to.equal(Slot);
 
       // Names are random and most importantly not equal to each other.
       expect(child1.props.name).to.match(/i-amphtml-children-\d/);
       expect(child2.props.name).to.match(/i-amphtml-children-\d/);
+      expect(textChild.props.name).to.match(/i-amphtml-children-\d/);
       expect(child1.props.name).to.not.equal(child2.props.name);
       expect(element.querySelector('#child1').slot).to.equal(child1.props.name);
       expect(element.querySelector('#child2').slot).to.equal(child2.props.name);
@@ -629,7 +632,7 @@ describes.realWin('PreactBaseElement', spec, (env) => {
     it('should rerender on new children', async () => {
       await waitFor(() => component.callCount > 0, 'component rendered');
       const {children: prevChildren} = lastProps;
-      expect(prevChildren).to.have.lengthOf(2);
+      expect(prevChildren).to.have.lengthOf(3);
       const {0: prevChild1, 1: prevChild2} = prevChildren;
 
       const newChild = createElementWithAttributes(doc, 'div', {
@@ -643,8 +646,8 @@ describes.realWin('PreactBaseElement', spec, (env) => {
       expect(component).to.be.calledTwice;
 
       const {children} = lastProps;
-      expect(children).to.have.lengthOf(3);
-      const {0: child1, 1: child2, 2: child3} = children;
+      expect(children).to.have.lengthOf(4);
+      const {0: child1, 1: child2, 3: child3} = children;
 
       // New child.
       expect(child3.type).to.equal(Slot);
@@ -679,7 +682,7 @@ describes.realWin('PreactBaseElement', spec, (env) => {
     it('should rerender when children are removed', async () => {
       await waitFor(() => component.callCount > 0, 'component rendered');
       const {children: prevChildren} = lastProps;
-      expect(prevChildren).to.have.lengthOf(2);
+      expect(prevChildren).to.have.lengthOf(3);
       const {1: prevChild2} = prevChildren;
 
       const oldChild = element.querySelector('#child1');
@@ -689,7 +692,7 @@ describes.realWin('PreactBaseElement', spec, (env) => {
       expect(component).to.be.calledTwice;
 
       const {children} = lastProps;
-      expect(children).to.have.lengthOf(1);
+      expect(children).to.have.lengthOf(2);
       const {0: child2} = children;
 
       // No changes.
@@ -708,7 +711,7 @@ describes.realWin('PreactBaseElement', spec, (env) => {
     it('should rerender on reorder', async () => {
       await waitFor(() => component.callCount > 0, 'component rendered');
       const {children: prevChildren} = lastProps;
-      expect(prevChildren).to.have.lengthOf(2);
+      expect(prevChildren).to.have.lengthOf(3);
       const {0: prevChild1, 1: prevChild2} = prevChildren;
 
       element.insertBefore(
@@ -720,7 +723,7 @@ describes.realWin('PreactBaseElement', spec, (env) => {
       expect(component).to.be.calledTwice;
 
       const {children} = lastProps;
-      expect(children).to.have.lengthOf(2);
+      expect(children).to.have.lengthOf(3);
       const {0: child2, 1: child1} = children;
 
       // No changes, except for ordering.

--- a/test/unit/preact/test-base-element-mapping.js
+++ b/test/unit/preact/test-base-element-mapping.js
@@ -483,7 +483,7 @@ describes.realWin('PreactBaseElement', spec, (env) => {
     });
   });
 
-  describe.only('children mapping', () => {
+  describe('children mapping', () => {
     let element;
     const DATE_STRING = '2018-01-01T08:00:00Z';
     const DATE = Date.parse(DATE_STRING);


### PR DESCRIPTION
Since `TextNode` doesn't support methods like `match`, `getAttribute`, `setAttribute`, etc. they get dropped when parsing child definitions for components extending `PreactBaseElement`. This PR:
- Adds a text node to the `test-base-element-mapping` tests
- Fixes `BaseElement#matchChild` to support text nodes (should it also support comments?)
- Modifies `createSlot` helper to accept a `Node` instead of an `Element` (ie. don't explode on `setAttribute`)
The resulting text node is wrapped in a `<Slot />` and provided in the `children` array. 

<!--
# Instructions:

- Pick a meaningful title for your pull request. (Use sentence case.)
  - Prefix the title with an emoji to identify what is being done. (Copy-paste the emoji from the list below.)
  - Do not overuse punctuation in the title (like `(chore):`).
  - If it is helpful, use a simple prefix (like `ProjectX: Implement some feature`).
- Enter a succinct description that says why the PR is necessary, and what it does.
  - Mention the GitHub issue that is being addressed by the pull request.
  - The keywords `Fixes`, `Closes`, or `Resolves` followed the issue number will automatically close the issue.

> NOTE: All non-trivial changes (like introducing new features or components) should have an associated issue or reference an I2I (intent-to-implement: go.amp.dev/i2i). Please read through the contribution process (go.amp.dev/contributing/code) for more information.

# Example of a good description:

- Implement aspect X
- Leave out feature Y because of A
- Improve performance by B
- Improve accessibility by C

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Reverting a previous change
♻️ Refactoring
🚮 Deleting code
🧪 Experimental code
-->
