### PR TITLE
🚮 Clean up additional error info added in #29629

### DIFF
--- a/extensions/amp-analytics/0.1/requests.js
+++ b/extensions/amp-analytics/0.1/requests.js
@@ -19,19 +19,12 @@ import {BatchSegmentDef, defaultSerializer} from './transport-serializer';
 import {ExpansionOptions, variableServiceForDoc} from './variables';
 import {SANDBOX_AVAILABLE_VARS} from './sandbox-vars-allowlist';
 import {Services} from '../../../src/services';
-import {dev, devAssert, userAssert} from '../../../src/log';
+import {devAssert, userAssert} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
 import {getResourceTiming} from './resource-timing';
 import {isArray, isFiniteNumber, isObject} from '../../../src/types';
-import {parseQueryString, parseUrlDeprecated} from '../../../src/url';
 
 const BATCH_INTERVAL_MIN = 200;
-
-// TODO(#29618): Remove after ampim investigation
-const _GOOGLE_ACTIVEVIEW_HOSTNAME = 'pagead2.googlesyndication.com';
-const _GOOGLE_ACTIVEVIEW_REQUEST_ID = 'ampim';
-export const GOOGLE_ACTIVEVIEW_ERROR_TAG = 'active-view-debug';
-export const _GOOGLE_ACTIVEVIEW_ERROR_STATE_NAME = '_avError_';
 
 export class RequestHandler {
   /**
@@ -114,9 +107,6 @@ export class RequestHandler {
     /** @private @const {number} */
     this.startTime_ = Date.now();
 
-    /** @private {*} */
-    this.errorReportingStates_ = null;
-
     this.initReportWindow_();
     this.initBatchInterval_();
   }
@@ -133,13 +123,6 @@ export class RequestHandler {
     if (!this.reportRequest_ && !isImportant) {
       // Ignore non important trigger out reportWindow
       return;
-    }
-
-    if (expansionOption.getVar(_GOOGLE_ACTIVEVIEW_ERROR_STATE_NAME)) {
-      this.errorReportingStates_ = expansionOption.getVar(
-        _GOOGLE_ACTIVEVIEW_ERROR_STATE_NAME
-      );
-      delete expansionOption.vars[_GOOGLE_ACTIVEVIEW_ERROR_STATE_NAME];
     }
 
     this.queueSize_++;
@@ -289,17 +272,6 @@ export class RequestHandler {
       const batchSegments = results[1];
       if (batchSegments.length === 0) {
         return;
-      }
-      // TODO(#29618): Remove after ampim investigation
-      // It's fine to report error without checking segmentPromises
-      // activeview request is not using extraUrlParams
-      if (this.errorReportingStates_) {
-        try {
-          reportErrorTemp(requestUrl, this.errorReportingStates_);
-        } catch (e) {
-          dev().error(GOOGLE_ACTIVEVIEW_ERROR_TAG, e);
-        }
-        this.errorReportingStates_ = null;
       }
 
       // TODO: iframePing will not work with batch. Add a config validation.
@@ -544,62 +516,4 @@ function expandExtraUrlParams(
   }
 
   return Promise.all(requestPromises).then(() => newParams);
-}
-
-/**
- * TODO(#29618): Remove after ampim investigation
- * @param {string} url
- * @param {*} info
- */
-function reportErrorTemp(url, info) {
-  if (!isObject(info)) {
-    return;
-  }
-  const location = parseUrlDeprecated(url);
-  if (location.hostname != _GOOGLE_ACTIVEVIEW_HOSTNAME) {
-    return;
-  }
-  const queryString = parseQueryString(location.search);
-  const requestId = queryString['id'];
-  if (requestId != _GOOGLE_ACTIVEVIEW_REQUEST_ID) {
-    return;
-  }
-  const elementSize = queryString['d'] && queryString['d'].split(',');
-  const viewportSize = queryString['bs'] && queryString['bs'].split(',');
-  const REPORTING_THRESHOLD = 0.1;
-  if (isArray(elementSize)) {
-    const elementWidth = Number(elementSize[0]);
-    const elementHeight = Number(elementSize[1]);
-    if (elementWidth == 0 || elementHeight == 0) {
-      if (Math.random() > REPORTING_THRESHOLD) {
-        return;
-      }
-      dev().expectedError(
-        GOOGLE_ACTIVEVIEW_ERROR_TAG,
-        'Debugging: Activeview request with zero element size',
-        elementWidth,
-        elementHeight,
-        url,
-        JSON.stringify(/** @type {!JsonObject} */ (info))
-      );
-    }
-  }
-  if (isArray(viewportSize)) {
-    const viewportWidth = Number(viewportSize[0]);
-    const viewportHeight = Number(viewportSize[1]);
-
-    if (viewportWidth == 0 || viewportHeight == 0) {
-      if (Math.random() > REPORTING_THRESHOLD) {
-        return;
-      }
-      dev().expectedError(
-        GOOGLE_ACTIVEVIEW_ERROR_TAG,
-        'Debugging: Activeview request with zero viewport size',
-        viewportWidth,
-        viewportHeight,
-        url,
-        JSON.stringify(/** @type {!JsonObject} */ (info))
-      );
-    }
-  }
 }

--- a/extensions/amp-analytics/0.1/visibility-model.js
+++ b/extensions/amp-analytics/0.1/visibility-model.js
@@ -15,9 +15,8 @@
  */
 
 import {Deferred} from '../../../src/utils/promise';
-import {GOOGLE_ACTIVEVIEW_ERROR_TAG} from './requests';
 import {Observable} from '../../../src/observable';
-import {dev, devAssert} from '../../../src/log';
+import {devAssert} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
 
 /**
@@ -29,28 +28,10 @@ export class VisibilityModel {
   /**
    * @param {!JsonObject} spec
    * @param {function():number} calcVisibility
-   * @param {?function():?../../../src/layout-rect.LayoutRectDef} calcLayoutBoxTemp
-   * @param {?function():?../../../src/layout-rect.LayoutRectDef} calcBoundingClientRectTemp
-   * @param {?../../../src/service/viewport/viewport-impl.ViewportImpl} viewportTemp
    */
-  constructor(
-    spec,
-    calcVisibility,
-    calcLayoutBoxTemp = null,
-    calcBoundingClientRectTemp = null,
-    viewportTemp = null
-  ) {
+  constructor(spec, calcVisibility) {
     /** @const @private */
     this.calcVisibility_ = calcVisibility;
-
-    // TODO(#29618): Remove after ampim investigation
-    this.calcLayoutBoxTemp_ = calcLayoutBoxTemp;
-
-    this.calcBoundingClientRectTemp_ = calcBoundingClientRectTemp;
-
-    this.viewportTemp_ = viewportTemp;
-
-    this.errorInfoTemp_ = dict({});
 
     /**
      * Spec parameters.
@@ -322,20 +303,6 @@ export class VisibilityModel {
   }
 
   /**
-   * TODO(#29618): Remove after ampim investigation
-   * Return object
-   * {
-   *   'layoutBoxAtMaxRatio': AMP calculated layout box at max intersect ratio
-   *   'boundingClientRectAtMaxRatio': InOb calculated clientRect at max intersect ratio
-   *   'viewportSizeAtMaxRatio': viewport size at max intersect ratio
-   * }
-   * @return {!JsonObject}
-   */
-  getErrorInfoTemp() {
-    return this.errorInfoTemp_;
-  }
-
-  /**
    * @param {number} visibility
    * @private
    */
@@ -470,29 +437,6 @@ export class VisibilityModel {
         this.minVisiblePercentage_ > 0
           ? Math.min(this.minVisiblePercentage_, visibility)
           : visibility;
-
-      // TODO(#29618): Remove after ampim investigation
-      if (visibility > this.maxVisiblePercentage_) {
-        try {
-          if (this.calcLayoutBoxTemp_) {
-            this.errorInfoTemp_[
-              'layoutBoxAtMaxRatio'
-            ] = this.calcLayoutBoxTemp_();
-          }
-          if (this.calcBoundingClientRectTemp_) {
-            this.errorInfoTemp_[
-              'boundingClientRectAtMaxRatio'
-            ] = this.calcBoundingClientRectTemp_();
-          }
-          if (this.viewportTemp_) {
-            this.errorInfoTemp_[
-              'viewportSizeAtMaxRatio'
-            ] = this.viewportTemp_.getSize();
-          }
-        } catch (e) {
-          dev().error(GOOGLE_ACTIVEVIEW_ERROR_TAG, e);
-        }
-      }
 
       this.maxVisiblePercentage_ = Math.max(
         this.maxVisiblePercentage_,


### PR DESCRIPTION
We have fixed the issue by checking the element size through `IntersectionObserver.boundingClientRect` in addition to `IntersectionObserver.intersectionRatio`. (fixed by #30267)

We no longer see `'Debugging: Activeview request with zero viewport size` error in logs. 

There's still `Debugging: Activeview request with zero element size` error in logs, however with an extremely low frequency. (5/day => 5 / 10% (throttle via code) / 10% (error log throttle) / 10% (expected error throttle) = 5000/day) 
An example error log looks like
```
Activeview request with zero element size 414 0. {"layoutBoxAtMaxRatio":{"left":0,"top":1569,"width":414,"height":0,"bottom":1569,"right":414,"x":0,"y":1569},"boundingClientRectAtMaxRatio":{"left":57,"top":461,"width":300,"height":250,"bottom":711,"right":357,"x":57,"y":461},"viewportSizeAtMaxRatio":{"width":414,"height":724}}
```
where the `boundClientRectAtMaxRatio` measurement is correct. There could be a rare race condition when the element `layoutBox` has not been updated by runtime before activeview ping is sent out. This is expected behavior as AMP states that the cached `layoutBoxRect` value will be sent to improve performance. 

We considered the issue fixed, and this PR cleans up the code. 