### PR TITLE
✨ Page attachment shows link on hover and long press

### DIFF
--- a/examples/amp-story/attachment.html
+++ b/examples/amp-story/attachment.html
@@ -68,7 +68,6 @@
           <p>
             <span data-text-background-color="crimson">i can fit in that box but inspect anything brought into the house wack the mini furry mouse intently stare at the same spot. Flee in terror at cucumber discovered on floor shake treat bag</span>
           </p>
-          <p><a href="https://google.com" style="color: white">Link to Google.com</a></p>
         </amp-story-grid-layer>
         <amp-story-page-attachment data-title="Link Description" href="https://www.google.com" layout="nodisplay"></amp-story-page-attachment>
       </amp-story-page>

--- a/examples/amp-story/attachment.html
+++ b/examples/amp-story/attachment.html
@@ -68,6 +68,7 @@
           <p>
             <span data-text-background-color="crimson">i can fit in that box but inspect anything brought into the house wack the mini furry mouse intently stare at the same spot. Flee in terror at cucumber discovered on floor shake treat bag</span>
           </p>
+          <p><a href="https://google.com" style="color: white">Link to Google.com</a></p>
         </amp-story-grid-layer>
         <amp-story-page-attachment data-title="Link Description" href="https://www.google.com" layout="nodisplay"></amp-story-page-attachment>
       </amp-story-page>

--- a/extensions/amp-story/1.0/amp-story-page-attachment.css
+++ b/extensions/amp-story/1.0/amp-story-page-attachment.css
@@ -139,7 +139,7 @@ amp-story-page[active] .i-amphtml-story-page-open-attachment {
   pointer-events: none !important;
   z-index: 3 !important;
   animation: open-attachment-fly-in 0.3s cubic-bezier(0.4, 0.0, 0.2, 1) both !important;
-  -webkit-touch-callout: default !important;
+  -webkit-touch-callout: default !important; /* Allow long pressing the button to open context menu in iOS */
 }
 
 amp-story-page .i-amphtml-story-page-open-attachment > * {

--- a/extensions/amp-story/1.0/amp-story-page-attachment.css
+++ b/extensions/amp-story/1.0/amp-story-page-attachment.css
@@ -139,6 +139,7 @@ amp-story-page[active] .i-amphtml-story-page-open-attachment {
   pointer-events: none !important;
   z-index: 3 !important;
   animation: open-attachment-fly-in 0.3s cubic-bezier(0.4, 0.0, 0.2, 1) both !important;
+  -webkit-touch-callout: default !important;
 }
 
 amp-story-page .i-amphtml-story-page-open-attachment > * {

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -169,7 +169,7 @@ const buildErrorMessageElement = (element) =>
  */
 const buildOpenAttachmentElement = (element) =>
   htmlFor(element)`
-      <div class="
+      <a class="
           i-amphtml-story-page-open-attachment i-amphtml-story-system-reset"
           role="button">
         <span class="i-amphtml-story-page-open-attachment-icon">
@@ -177,7 +177,7 @@ const buildOpenAttachmentElement = (element) =>
           <span class="i-amphtml-story-page-open-attachment-bar-right"></span>
         </span>
         <span class="i-amphtml-story-page-open-attachment-label"></span>
-      </div>`;
+      </a>`;
 
 /**
  * amp-story-page states.
@@ -1740,6 +1740,10 @@ export class AmpStoryPage extends AMP.BaseElement {
 
     if (!this.openAttachmentEl_) {
       this.openAttachmentEl_ = buildOpenAttachmentElement(this.element);
+      const attachmentHref = attachmentEl.getAttribute('href');
+      if (attachmentHref) {
+        this.openAttachmentEl_.setAttribute('href', attachmentHref);
+      }
       this.openAttachmentEl_.addEventListener('click', () =>
         this.openAttachment()
       );

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -1740,6 +1740,7 @@ export class AmpStoryPage extends AMP.BaseElement {
 
     if (!this.openAttachmentEl_) {
       this.openAttachmentEl_ = buildOpenAttachmentElement(this.element);
+      // If the attachment is a link, copy href to the element so it can be previewed on hover and long press.
       const attachmentHref = attachmentEl.getAttribute('href');
       if (attachmentHref) {
         this.openAttachmentEl_.setAttribute('href', attachmentHref);

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -800,7 +800,9 @@ export class AmpStory extends AMP.BaseElement {
     this.win.document.addEventListener('contextmenu', (e) => {
       const uiState = this.storeService_.get(StateProperty.UI_STATE);
       if (uiState === UIType.MOBILE) {
-        e.preventDefault();
+        if (!this.allowContextMenuOnMobile_(e.target)) {
+          e.preventDefault();
+        }
         e.stopPropagation();
       }
     });
@@ -2889,6 +2891,21 @@ export class AmpStory extends AMP.BaseElement {
       'amp-story-dev-tools'
     );
     return true;
+  }
+
+  /**
+   * Should enable the context menu (long press) on the element passed.
+   * @private
+   * @param {!Element} element
+   * @return {boolean}
+   */
+  allowContextMenuOnMobile_(element) {
+    // Match page attachments with links.
+    return !!closest(
+      element,
+      (e) => e.matches('a.i-amphtml-story-page-open-attachment[href]'),
+      this.element
+    );
   }
 }
 

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -81,6 +81,7 @@ import {
   closest,
   createElementWithAttributes,
   isRTL,
+  matches,
   scopedQuerySelector,
   scopedQuerySelectorAll,
   whenUpgradedToCustomElement,
@@ -2903,7 +2904,7 @@ export class AmpStory extends AMP.BaseElement {
     // Match page attachments with links.
     return !!closest(
       element,
-      (e) => e.matches('a.i-amphtml-story-page-open-attachment[href]'),
+      (e) => matches(e, 'a.i-amphtml-story-page-open-attachment[href]'),
       this.element
     );
   }


### PR DESCRIPTION
Closes #27941

When hovering on desktop, the page attachment "swipe up" button will behave like an `<a href>` by showing on the bottom left the destination.
When hovering on mobile, it will work with the long press functionality to show the context menu.

Solution: convert page-attachment ui to `a[href]` and only `e.preventDefault` on `addEventListener(contextmenu)` on `amp-story.js` when the item should not show a context menu (for now we just enable context menus on the page-attachment "swipe up" button).

On iOS it's also necessary to add `-webkit-touch-callout: default` so the tag is long pressable (because `amp-story` sets it to `none`). More info [here](https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-touch-callout)

Working screenshot:
<img src="https://user-images.githubusercontent.com/22420856/103779931-5750c580-5002-11eb-8e2e-54b88ca83947.png" width="300">
