### PR TITLE
🏗  Remove file overwrite option in firebase task

### DIFF
--- a/build-system/tasks/firebase.js
+++ b/build-system/tasks/firebase.js
@@ -60,9 +60,7 @@ async function firebase() {
   if (argv.file) {
     log(colors.green(`Processing file: ${argv.file}.`));
     log(colors.green('Writing file to firebase.index.html.'));
-    await fs.copyFile(/*src*/ argv.file, 'firebase/index.html', {
-      overwrite: true,
-    });
+    await fs.copyFile(/*src*/ argv.file, 'firebase/index.html');
     await replaceUrls('firebase/index.html');
   } else {
     log(colors.green('Copying test/manual and examples folders.'));
@@ -78,9 +76,7 @@ async function firebase() {
   ]);
 
   await Promise.all([
-    fs.copyFile('firebase/dist/ww.max.js', 'firebase/dist/ww.js', {
-      overwrite: true,
-    }),
+    fs.copyFile('firebase/dist/ww.max.js', 'firebase/dist/ww.js'),
   ]);
 }
 


### PR DESCRIPTION
As of node v14.0.0, [`fs.copyFile`](https://nodejs.org/api/fs.html#fs_fs_copyfile_src_dest_mode_callback) enforced stricter type validation on the third parameter (formerly `flags`, now `mode`), causing the `gulp firebase` task to throw the following:
```
[11:04:52] 'firebase' errored after 3.12 s
[11:04:52] TypeError [ERR_INVALID_ARG_TYPE]: The "mode" argument must be integer. Received an instance of Object
    at Object.copyFile (fs.js:1972:10)
    at /Users/carolineliu/amp/amphtml/node_modules/universalify/index.js:8:12
    at new Promise (<anonymous>)
    at Object.copyFile (/Users/carolineliu/amp/amphtml/node_modules/universalify/index.js:7:14)
    at firebase (/Users/carolineliu/amp/amphtml/build-system/tasks/firebase.js:79:8)
```

This PR removes passing the third argument entirely in the firebase task, which defaults to overwrite destination files anyway. 