### PR TITLE
✨ [bento][amp-sidebar] Add check for RTL docs for default side

### DIFF
--- a/extensions/amp-sidebar/1.0/sidebar.js
+++ b/extensions/amp-sidebar/1.0/sidebar.js
@@ -18,6 +18,7 @@ import * as Preact from '../../../src/preact';
 import {ContainWrapper} from '../../../src/preact/component';
 import {assertDoesNotContainDisplay, setStyles} from '../../../src/style';
 import {forwardRef} from '../../../src/preact/compat';
+import {isEnumValue} from '../../../src/types';
 import {isRTL} from '../../../src/dom';
 import {
   useCallback,
@@ -139,7 +140,7 @@ function SidebarWithRef(
     }
 
     const document = sidebarElement.ownerDocument;
-    if (side != Side.LEFT && side != Side.RIGHT) {
+    if (!isEnumValue(Side, side)) {
       sideRef.current = isRTL(document) ? Side.RIGHT : Side.LEFT;
     } else {
       sideRef.current = side;

--- a/extensions/amp-sidebar/1.0/test/test-amp-sidebar.js
+++ b/extensions/amp-sidebar/1.0/test/test-amp-sidebar.js
@@ -335,6 +335,72 @@ describes.realWin(
         expect(consoleWarnSpy).to.be.calledOnce;
       });
 
+      it('should default "left" or "right" based on document.dir when side not provided', async () => {
+        const documentDir = win.document.dir;
+
+        /**
+         * document.dir is not 'rtl' and side is not provided to the element
+         * so we should default to 'left'
+         */
+        win.document.dir = 'blah';
+        fullHtml = html`
+          <div>
+            <amp-sidebar id="sidebar2">
+              <div>Hello World!</div>
+            </amp-sidebar>
+            <div id="buttons">
+              <button id="open" on="tap:sidebar2.open()">open</button>
+            </div>
+          </div>
+        `;
+        element = fullHtml.firstElementChild;
+        win.document.body.appendChild(fullHtml);
+        await element.build();
+        container = element.shadowRoot.firstElementChild;
+        openButton = fullHtml.querySelector('#open');
+
+        // open the sidebar
+        openButton.click();
+        await waitForOpen(element, true);
+        expect(element).to.have.attribute('open');
+        let sidebarElement = container.firstElementChild;
+
+        // defaults to left if document is not 'ltr'
+        expect(sidebarElement.className.includes('left')).to.be.true;
+
+        /**
+         * document.dir is 'rtl' and side is not provided to the element
+         * so we should default to 'right'
+         */
+        win.document.dir = 'rtl';
+        fullHtml = html`
+          <div>
+            <amp-sidebar id="sidebar3">
+              <div>Hello World!</div>
+            </amp-sidebar>
+            <div id="buttons">
+              <button id="open" on="tap:sidebar3.open()">open</button>
+            </div>
+          </div>
+        `;
+        element = fullHtml.firstElementChild;
+        win.document.body.appendChild(fullHtml);
+        await element.build();
+        container = element.shadowRoot.firstElementChild;
+        openButton = fullHtml.querySelector('#open');
+
+        // open the sidebar
+        openButton.click();
+        await waitForOpen(element, true);
+        expect(element).to.have.attribute('open');
+        sidebarElement = container.firstElementChild;
+
+        // defaults to right if document is 'rtl'
+        expect(sidebarElement.className.includes('right')).to.be.true;
+
+        win.document.dir = documentDir;
+      });
+
       describe('programatic access to imperative API', () => {
         it('open', async () => {
           // sidebar is initially closed

--- a/extensions/amp-sidebar/1.0/test/test-sidebar.js
+++ b/extensions/amp-sidebar/1.0/test/test-sidebar.js
@@ -185,7 +185,7 @@ describes.sandboxed('Sidebar preact component', {}, (env) => {
       let sidebarNode = sidebar.getDOMNode();
       expect(sidebarNode.className.includes('right')).to.be.true;
 
-      // default the left
+      // default to left
       document.dir = 'ltr';
       ref = Preact.createRef();
       wrapper = mount(

--- a/extensions/amp-sidebar/1.0/test/test-sidebar.js
+++ b/extensions/amp-sidebar/1.0/test/test-sidebar.js
@@ -159,6 +159,58 @@ describes.sandboxed('Sidebar preact component', {}, (env) => {
       expect(sidebarNode.className.includes('right')).to.be.true;
     });
 
+    it('should default "left" or "right" based on document.dir when side not provided', () => {
+      const documentDir = document.dir;
+
+      //default to right
+      document.dir = 'rtl';
+      ref = Preact.createRef();
+      wrapper = mount(
+        <>
+          <Sidebar ref={ref}>
+            <div>Content</div>
+          </Sidebar>
+          <button id="toggle" onClick={() => ref.current.toggle()}></button>
+          <button id="open" onClick={() => ref.current.open()}></button>
+          <button id="close" onClick={() => ref.current.close()}></button>
+        </>
+      );
+
+      sidebar = wrapper.find(Sidebar);
+      openButton = wrapper.find('#open');
+      openButton.getDOMNode().click();
+      wrapper.update();
+      sidebar = wrapper.find(Sidebar);
+
+      let sidebarNode = sidebar.getDOMNode();
+      expect(sidebarNode.className.includes('right')).to.be.true;
+
+      // default the left
+      document.dir = 'ltr';
+      ref = Preact.createRef();
+      wrapper = mount(
+        <>
+          <Sidebar ref={ref}>
+            <div>Content</div>
+          </Sidebar>
+          <button id="toggle" onClick={() => ref.current.toggle()}></button>
+          <button id="open" onClick={() => ref.current.open()}></button>
+          <button id="close" onClick={() => ref.current.close()}></button>
+        </>
+      );
+
+      sidebar = wrapper.find(Sidebar);
+      openButton = wrapper.find('#open');
+      openButton.getDOMNode().click();
+      wrapper.update();
+      sidebar = wrapper.find(Sidebar);
+
+      sidebarNode = sidebar.getDOMNode();
+      expect(sidebarNode.className.includes('left')).to.be.true;
+
+      document.dir = documentDir;
+    });
+
     describe('programatic access to imperative API', () => {
       it('open', () => {
         // Sidebar is initially closed (no rendered nodes)


### PR DESCRIPTION
If `side` attribute / prop is not provided to the `sidebar` component.  The component first checks if the document is an RTL document and if so assigns default side to `right`, otherwise defaults to `left`.

todo: add tests