### PR TITLE
🚮cleanup analytics-chunks-inabox experiment

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -1,5 +1,5 @@
 {
-  "allow-doc-opt-in": ["amp-next-page", "analytics-chunks-inabox"],
+  "allow-doc-opt-in": ["amp-next-page"],
   "allow-url-opt-in": ["pump-early-frame"],
   "amp-accordion-display-locking": 1,
   "canary": 1,

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -1,5 +1,5 @@
 {
-  "allow-doc-opt-in": ["amp-next-page", "analytics-chunks-inabox"],
+  "allow-doc-opt-in": ["amp-next-page"],
   "allow-url-opt-in": ["pump-early-frame"],
   "canary": 0,
   "a4aProfilingRate": 0.01,

--- a/extensions/amp-analytics/0.1/amp-analytics.js
+++ b/extensions/amp-analytics/0.1/amp-analytics.js
@@ -40,7 +40,6 @@ import {dict, hasOwn} from '../../../src/utils/object';
 import {expandTemplate} from '../../../src/string';
 import {getMode} from '../../../src/mode';
 import {installLinkerReaderService} from './linker-reader';
-import {isAnalyticsChunksExperimentOn} from './analytics-group';
 import {isArray, isEnumValue} from '../../../src/types';
 import {isIframed} from '../../../src/dom';
 import {isInFie} from '../../../src/iframe-helper';
@@ -231,10 +230,11 @@ export class AmpAnalytics extends AMP.BaseElement {
           const configPromise = new AnalyticsConfig(this.element).loadConfig();
           loadConfigDeferred.resolve(configPromise);
         };
-        if (isAnalyticsChunksExperimentOn(this.win)) {
-          chunk(this.element, loadConfigTask, ChunkPriority.HIGH);
-        } else {
+        if (this.isInabox_) {
+          // Chunk in inabox ad leads to activeview regression, handle seperately
           loadConfigTask();
+        } else {
+          chunk(this.element, loadConfigTask, ChunkPriority.HIGH);
         }
         return loadConfigDeferred.promise;
       })
@@ -585,10 +585,11 @@ export class AmpAnalytics extends AMP.BaseElement {
     const linkerTask = () => {
       this.linkerManager_.init();
     };
-    if (isAnalyticsChunksExperimentOn(this.win)) {
-      chunk(this.element, linkerTask, ChunkPriority.LOW);
-    } else {
+    if (this.isInabox_) {
+      // Chunk in inabox ad leads to activeview regression, handle seperately
       linkerTask();
+    } else {
+      chunk(this.element, linkerTask, ChunkPriority.LOW);
     }
   }
 
@@ -724,10 +725,11 @@ export class AmpAnalytics extends AMP.BaseElement {
           .then((digest) => digest * 100 < threshold);
         sampleDeferred.resolve(samplePromise);
       };
-      if (isAnalyticsChunksExperimentOn(this.win)) {
-        chunk(this.element, sampleInTask, ChunkPriority.LOW);
-      } else {
+      if (this.isInabox_) {
+        // Chunk in inabox ad leads to activeview regression, handle seperately
         sampleInTask();
+      } else {
+        chunk(this.element, sampleInTask, ChunkPriority.LOW);
       }
       return sampleDeferred.promise;
     }

--- a/extensions/amp-analytics/0.1/analytics-group.js
+++ b/extensions/amp-analytics/0.1/analytics-group.js
@@ -19,7 +19,6 @@ import {Deferred} from '../../../src/utils/promise';
 import {dev, userAssert} from '../../../src/log';
 import {getMode} from '../../../src/mode';
 import {getTrackerKeyName, getTrackerTypesForParentType} from './events';
-import {isExperimentOn} from '../../../src/experiments';
 import {toWin} from '../../../src/types';
 
 /**
@@ -106,7 +105,7 @@ export class AnalyticsGroup {
     };
     if (
       this.triggerCount_ < IMMEDIATE_TRIGGER_THRES ||
-      !isAnalyticsChunksExperimentOn(this.win_)
+      getMode(this.win_).runtime == 'inabox'
     ) {
       task();
     } else {
@@ -119,16 +118,4 @@ export class AnalyticsGroup {
     this.triggerCount_++;
     return deferred.promise;
   }
-}
-
-/**
- * Determine if the analytics-chunks experiment should be applied
- * @param {!Window} win
- * @return {boolean}
- */
-export function isAnalyticsChunksExperimentOn(win) {
-  if (getMode(win).runtime == 'inabox') {
-    return isExperimentOn(win, 'analytics-chunks-inabox');
-  }
-  return true;
 }

--- a/extensions/amp-analytics/0.1/cookie-writer.js
+++ b/extensions/amp-analytics/0.1/cookie-writer.js
@@ -20,7 +20,6 @@ import {Deferred} from '../../../src/utils/promise';
 import {SameSite, setCookie} from '../../../src/cookies';
 import {Services} from '../../../src/services';
 import {hasOwn} from '../../../src/utils/object';
-import {isAnalyticsChunksExperimentOn} from './analytics-group';
 import {isCookieAllowed} from './cookie-reader';
 import {isObject} from '../../../src/types';
 import {user} from '../../../src/log';
@@ -75,11 +74,8 @@ export class CookieWriter {
       const task = () => {
         this.writeDeferred_.resolve(this.init_());
       };
-      if (isAnalyticsChunksExperimentOn(this.win_)) {
-        chunk(this.element_, task, ChunkPriority.LOW);
-      } else {
-        task();
-      }
+      // CookieWriter is not supported in inabox ad. Always chunk
+      chunk(this.element_, task, ChunkPriority.LOW);
     }
     return this.writeDeferred_.promise;
   }

--- a/tools/experiments/experiments-config.js
+++ b/tools/experiments/experiments-config.js
@@ -210,12 +210,6 @@ export const EXPERIMENTS = [
     cleanupIssue: 'https://github.com/ampproject/amphtml/issues/26823',
   },
   {
-    id: 'analytics-chunks-inabox',
-    name: 'AMP Analytics Break long tasks to chunks (AMP Ads only)',
-    spec: 'https://github.com/ampproject/amphtml/issues/28435',
-    cleanupIssue: 'https://github.com/ampproject/amphtml/issues/28435',
-  },
-  {
     id: 'a4a-no-signing',
     name: 'Remove signing requirement for AMPHTML ads',
     spec: 'https://github.com/ampproject/amphtml/issues/27189',


### PR DESCRIPTION
The experiment leads to inabox ad activeview regression. We think it is because of the delay in the initialization. 
The decision here is to only land the improvement to AMP docs. 