### PR TITLE
Introduce `measureIntersection` helper for async measures.

### DIFF
--- a/src/utils/intersection.js
+++ b/src/utils/intersection.js
@@ -1,0 +1,94 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {Deferred} from './promise';
+import {createViewportObserver} from '../viewport-observer';
+import {layoutRectFromDomRect} from '../layout-rect';
+import {toWin} from '../types';
+
+/** @type {WeakMap<!Element, Deferred>} */
+let intersectionDeferreds;
+
+/** @type {WeakMap<!Window, IntersectionObserver>} */
+let intersectionObservers;
+
+/**
+ * @param {!Window} win
+ * @return {!IntersectionObserve}
+ */
+function getInOb(win) {
+  if (!intersectionDeferreds) {
+    intersectionDeferreds = new WeakMap();
+    intersectionObservers = new WeakMap();
+  }
+
+  if (!intersectionObservers.has(win)) {
+    const observer = createViewportObserver((entries) => {
+      const seen = new Set();
+      for (let i = entries.length - 1; i >= 0; i--) {
+        const {target} = entries[i];
+        if (seen.has(target)) {
+          continue;
+        }
+        seen.add(target);
+
+        observer.unobserve(target);
+        intersectionDeferreds.get(target).resolve(entries[i]);
+        intersectionDeferreds.delete(target);
+      }
+    }, win);
+    intersectionObservers.set(win, observer);
+    return observer;
+  }
+  return intersectionObservers.get(win);
+}
+
+/**
+ * Returns a promise that resolves with the intersection entry for the given element.
+ *
+ * If multiple measures for the same element occur very quickly, they will
+ * dedupe to the same promise.
+ *
+ * @param {Element} el
+ * @return {!Promise<IntersectionObserverEntry>}
+ */
+export function measureIntersection(el) {
+  if (intersectionDeferreds && intersectionDeferreds.has(el)) {
+    return intersectionDeferreds.get(el).promise;
+  }
+
+  const inOb = getInOb(toWin(el.ownerDocument.defaultView));
+  inOb.observe(el);
+
+  const deferred = new Deferred();
+  intersectionDeferreds.set(el, deferred);
+  return deferred.promise;
+}
+
+/**
+ * Convert an IntersectionObserverEntry to a regular object to make it serializable.
+ *
+ * @param {!IntersectionObserverEntry} entry
+ * @return {!IntersectionObserverEntry}
+ */
+export function intersectionEntryToJson(entry) {
+  return {
+    time: entry.time,
+    rootBounds: layoutRectFromDomRect(entry.rootBounds),
+    boundingClientRect: layoutRectFromDomRect(entry.boundingClientRect),
+    intersectionRect: layoutRectFromDomRect(entry.intersectionRect),
+    intersectionRatio: entry.intersectionRatio,
+  };
+}

--- a/src/viewport-observer.js
+++ b/src/viewport-observer.js
@@ -22,9 +22,6 @@ import {toWin} from './types';
  * Only use this if x-origin iframe rootMargin support is considered nice-to-have,
  * since if not supported this InOb will fallback to one without rootMargin.
  *
- * - If iframed: rootMargin is ignored unless natively supported (Chrome 81+).
- * - If not iframed: all features work properly in both polyfill and built-in.
- *
  * @param {function(!Array<!IntersectionObserverEntry>)} ioCallback
  * @param {!Window} win
  * @param {(number|!Array<number>)=} threshold

--- a/src/viewport-observer.js
+++ b/src/viewport-observer.js
@@ -19,8 +19,6 @@ import {toWin} from './types';
 
 /**
  * Returns an IntersectionObserver tracking the Viewport.
- * Only use this if x-origin iframe rootMargin support is considered nice-to-have,
- * since if not supported this InOb will fallback to one without rootMargin.
  *
  * @param {function(!Array<!IntersectionObserverEntry>)} ioCallback
  * @param {!Window} win

--- a/test/unit/utils/test-intersection.js
+++ b/test/unit/utils/test-intersection.js
@@ -1,0 +1,129 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {measureIntersection} from '../../../src/utils/intersection';
+
+describes.fakeWin('utils/intersection', {}, (env) => {
+  function fireIntersections(entries) {
+    if (entries.length == 0) {
+      return;
+    }
+
+    const win = entries[0].target.ownerDocument.defaultView;
+    const {callback} = win.IntersectionObserver;
+
+    callback(entries);
+  }
+
+  function getInObConstructorStub() {
+    const ctor = (cb) => {
+      if (ctor.callback) {
+        throw new Error('Only a single instance per Window may exist.');
+      }
+      const observedEls = new Set();
+      ctor.callback = (entries) => {
+        if (entries.some((x) => !observedEls.has(x.target))) {
+          throw new Error(
+            'May not fire intersection entry for unobserved element.'
+          );
+        }
+        cb(entries);
+      };
+      return {
+        observe: (e) => observedEls.add(e),
+        unobserve: (e) => observedEls.delete(e),
+        disconnect: () => observedEls.clear(),
+      };
+    };
+    return ctor;
+  }
+
+  let el;
+  beforeEach(() => {
+    env.win.IntersectionObserver = getInObConstructorStub();
+    el = env.win.document.createElement('p');
+    env.win.document.body.appendChild(el);
+  });
+
+  it('should measure intersection for an element', async () => {
+    const intersection = measureIntersection(el);
+    fireIntersections([{x: 100, target: el}]);
+    expect(await intersection).eql({x: 100, target: el});
+  });
+
+  it('should dedupe multiple measures', async () => {
+    const measure1 = measureIntersection(el);
+    const measure2 = measureIntersection(el);
+    expect(measure1).equal(measure2);
+  });
+
+  it('should not dedupe multiple measures with entries in between', async () => {
+    const measure1 = measureIntersection(el);
+    fireIntersections([{x: 100, target: el}]);
+    const measure2 = measureIntersection(el);
+
+    expect(measure1).not.equal(measure2);
+  });
+
+  it('should only use the latest entry', async () => {
+    const intersection = measureIntersection(el);
+    const firstEntry = {x: 0, target: el};
+    const secondEntry = {x: 100, target: el};
+
+    fireIntersections([firstEntry, secondEntry]);
+    expect(await intersection).equal(secondEntry);
+  });
+
+  it('should measure multiple elements', async () => {
+    const el2 = env.win.document.createElement('p');
+    env.win.document.body.appendChild(el2);
+
+    const intersection1 = measureIntersection(el);
+    const intersection2 = measureIntersection(el2);
+
+    const firstEntry = {x: 0, target: el};
+    const secondEntry = {x: 2, target: el2};
+
+    fireIntersections([secondEntry]);
+    fireIntersections([firstEntry]);
+
+    expect(await intersection1).equal(firstEntry);
+    expect(await intersection2).equal(secondEntry);
+  });
+
+  it('should support measuring elements from multiple windows', async () => {
+    const el1 = {
+      ownerDocument: {
+        defaultView: {IntersectionObserver: getInObConstructorStub()},
+      },
+    };
+    const el2 = {
+      ownerDocument: {
+        defaultView: {IntersectionObserver: getInObConstructorStub()},
+      },
+    };
+
+    const intersection1 = measureIntersection(el1);
+    const intersection2 = measureIntersection(el2);
+    const firstEntry = {target: el1};
+    const secondEntry = {target: el2};
+    fireIntersections([firstEntry]);
+    fireIntersections([secondEntry]);
+
+    expect(await intersection1).equal(firstEntry);
+    expect(await intersection2).equal(secondEntry);
+  });
+});

--- a/test/unit/utils/test-intersection.js
+++ b/test/unit/utils/test-intersection.js
@@ -17,27 +17,16 @@
 import {measureIntersection} from '../../../src/utils/intersection';
 
 describes.fakeWin('utils/intersection', {}, (env) => {
-  function fireIntersections(entries) {
-    if (entries.length == 0) {
-      return;
-    }
-
-    const win = entries[0].target.ownerDocument.defaultView;
-    const {callback} = win.IntersectionObserver;
-
-    callback(entries);
-  }
-
   function getInObConstructorStub() {
     const ctor = (cb) => {
       if (ctor.callback) {
-        throw new Error('Only a single instance per Window may exist.');
+        throw new Error('Only a single InOb instance allowed per Window.');
       }
       const observedEls = new Set();
       ctor.callback = (entries) => {
         if (entries.some((x) => !observedEls.has(x.target))) {
           throw new Error(
-            'May not fire intersection entry for unobserved element.'
+            'Attempted to fire intersection for unobserved element.'
           );
         }
         cb(entries);
@@ -49,6 +38,14 @@ describes.fakeWin('utils/intersection', {}, (env) => {
       };
     };
     return ctor;
+  }
+
+  function fireIntersections(entries) {
+    if (entries.length == 0) {
+      return;
+    }
+    const win = entries[0].target.ownerDocument.defaultView;
+    win.IntersectionObserver.callback(entries);
   }
 
   let el;


### PR DESCRIPTION
**summary**
- Split out from https://github.com/ampproject/amphtml/pull/31753 to enable merging the helper before it passes review from ads folks.
- Creates new fn with signature: `measureIntersection(!Element) => !Promise<!IntersectionObserverEntry>`