### PR TITLE
Relax layout restrictions for Bento components

### DIFF
--- a/extensions/amp-inline-gallery/1.0/amp-inline-gallery-pagination.js
+++ b/extensions/amp-inline-gallery/1.0/amp-inline-gallery-pagination.js
@@ -16,7 +16,6 @@
 
 import {CSS} from './pagination.jss';
 import {CarouselContextProp} from '../../amp-base-carousel/1.0/carousel-props';
-import {Layout} from '../../../src/layout';
 import {Pagination} from './pagination';
 import {PreactBaseElement} from '../../../src/preact/base-element';
 import {isExperimentOn} from '../../../src/experiments';
@@ -34,7 +33,9 @@ export class AmpInlineGalleryPagination extends PreactBaseElement {
         isExperimentOn(this.win, 'bento-inline-gallery'),
       'expected global "bento" or specific "bento-inline-gallery" experiment to be enabled'
     );
-    return layout == Layout.FIXED_HEIGHT;
+    // Any layout is allowed for Bento, but "fixed-height" is the recommend
+    // layout for AMP.
+    return super.isLayoutSupported(layout);
   }
 }
 

--- a/extensions/amp-inline-gallery/1.0/amp-inline-gallery-thumbnails.js
+++ b/extensions/amp-inline-gallery/1.0/amp-inline-gallery-thumbnails.js
@@ -16,7 +16,6 @@
 
 import {CSS as CAROUSEL_CSS} from '../../amp-base-carousel/1.0/base-carousel.jss';
 import {CarouselContextProp} from '../../amp-base-carousel/1.0/carousel-props';
-import {Layout} from '../../../src/layout';
 import {PreactBaseElement} from '../../../src/preact/base-element';
 import {CSS as THUMBNAIL_CSS} from './thumbnails.jss';
 import {Thumbnails} from './thumbnails';
@@ -35,7 +34,9 @@ export class AmpInlineGalleryThumbnails extends PreactBaseElement {
         isExperimentOn(this.win, 'bento-inline-gallery'),
       'expected global "bento" or specific "bento-inline-gallery" experiment to be enabled'
     );
-    return layout == Layout.FIXED_HEIGHT;
+    // Any layout is allowed for Bento, but "fixed-height" is the recommend
+    // layout for AMP.
+    return super.isLayoutSupported(layout);
   }
 }
 

--- a/extensions/amp-stream-gallery/1.0/amp-stream-gallery.js
+++ b/extensions/amp-stream-gallery/1.0/amp-stream-gallery.js
@@ -23,7 +23,6 @@ import {StreamGallery} from './stream-gallery';
 import {createCustomEvent} from '../../../src/event-helper';
 import {dict} from '../../../src/utils/object';
 import {isExperimentOn} from '../../../src/experiments';
-import {isLayoutSizeDefined} from '../../../src/layout';
 import {userAssert} from '../../../src/log';
 
 /** @const {string} */
@@ -57,7 +56,7 @@ class AmpStreamGallery extends PreactBaseElement {
       isExperimentOn(this.win, 'bento-stream-gallery'),
       'expected global "bento" or specific "bento-stream-gallery" experiment to be enabled'
     );
-    return isLayoutSizeDefined(layout);
+    return super.isLayoutSupported(layout);
   }
 }
 

--- a/extensions/amp-video/1.0/base-element.js
+++ b/extensions/amp-video/1.0/base-element.js
@@ -57,11 +57,6 @@ export class VideoBaseElement extends PreactBaseElement {
       minTrust
     );
   }
-
-  /** @override */
-  isLayoutSupported(layout) {
-    return super.isLayoutSupported(layout);
-  }
 }
 
 /** @override */

--- a/extensions/amp-video/1.0/base-element.js
+++ b/extensions/amp-video/1.0/base-element.js
@@ -17,7 +17,6 @@ import {ActionTrust} from '../../../src/action-constants';
 import {CSS} from './autoplay.jss';
 import {PreactBaseElement} from '../../../src/preact/base-element';
 import {VideoWrapper} from './video-wrapper';
-import {isLayoutSizeDefined} from '../../../src/layout';
 
 /** @extends {PreactBaseElement<VideoWrapperDef.Api>} */
 export class VideoBaseElement extends PreactBaseElement {
@@ -61,7 +60,7 @@ export class VideoBaseElement extends PreactBaseElement {
 
   /** @override */
   isLayoutSupported(layout) {
-    return isLayoutSizeDefined(layout);
+    return super.isLayoutSupported(layout);
   }
 }
 

--- a/src/preact/base-element.js
+++ b/src/preact/base-element.js
@@ -19,6 +19,7 @@ import {ActionTrust} from '../action-constants';
 import {AmpEvents} from '../amp-events';
 import {CanPlay, CanRender, LoadingProp} from '../contextprops';
 import {Deferred} from '../utils/promise';
+import {Layout, isLayoutSizeDefined} from '../layout';
 import {Loading} from '../loading';
 import {MediaQueryProps} from './media-query-props';
 import {Slot, createSlot} from './slot';
@@ -45,7 +46,6 @@ import {dict, hasOwn} from '../utils/object';
 import {getDate} from '../utils/date';
 import {getMode} from '../mode';
 import {installShadowStyle} from '../shadow-embed';
-import {isLayoutSizeDefined} from '../layout';
 import {sequentialIdGenerator} from '../utils/id-generator';
 
 /**
@@ -209,7 +209,20 @@ export class PreactBaseElement extends AMP.BaseElement {
   isLayoutSupported(layout) {
     const Ctor = this.constructor;
     if (Ctor['layoutSizeDefined']) {
-      return isLayoutSizeDefined(layout);
+      return (
+        isLayoutSizeDefined(layout) ||
+        // This allows a developer to specify the component's size using the
+        // user stylesheet without the help of AMP's static layout rules.
+        // Bento components use `ContainWrapper` with `contain:strict`, thus
+        // if a user stylesheet doesn't provide for the appropriate size, the
+        // element's size will be 0. The user stylesheet CSS can use
+        // fixed `width`/`height`, `aspect-ratio`, `flex`, `grid`, or any
+        // other CSS layouts coupled with `@media` queries and other CSS tools.
+        // Besides normal benefits of using plain CSS, an important feature of
+        // using this layout is that AMP does not add "sizer" elements thus
+        // keeping the user DOM clean.
+        layout == Layout.CONTAINER
+      );
     }
     return super.isLayoutSupported(layout);
   }


### PR DESCRIPTION
This is a controversial step, but I'd like to try it under our "bento" experiment. The new design of Bento components ensures that for a `layoutSizeDefined` component the user can do either:

1. Specify classic `layout=fixed|responsive|etc` with `width`, `height`, and other static layout attributes.
2. Not specify any layout (which defaults to "container") and our `contain:strict` will guarantee 0-size for the element. AMP will not try to load this element. And it will look like an obvious error with the expectation that a user would naturally fix by providing the size via CSS. All CSS tools are available in that case, including flex/grid/aspect-ratio/fixed CSS layouts.

The main reason for this is to avoid changing the user DOM by adding internal sizer elements, etc.

