### PR TITLE
🏗 Experiment sweep tool improvements

### DIFF
--- a/build-system/tasks/sweep-experiments/index.js
+++ b/build-system/tasks/sweep-experiments/index.js
@@ -278,11 +278,11 @@ function issueUrlToNumberOrUrl(url) {
 }
 
 /**
- * @param {string} files
+ * @param {string} list
  * @return {string}
  */
-const checkedFileListMarkdown = (files) =>
-  files.map((path) => `- [ ] \`${path}\``).join('\n');
+const checkedListMarkdown = (list) =>
+  list.map((item) => `- [ ] ${item}`).join('\n');
 
 /**
  * @return {string}
@@ -321,12 +321,12 @@ function summaryCommitMessage({
       '---',
       '### Cleanup issues',
       "Close these once they've been addressed and this PR has been merged:",
-      cleanupIssues
-        .map(
+      checkedListMarkdown(
+        cleanupIssues.map(
           ({id, cleanupIssue}) =>
-            `- [ ] \`${id}\`: ${issueUrlToNumberOrUrl(cleanupIssue)}`
+            `\`${id}\`: ${issueUrlToNumberOrUrl(cleanupIssue)}`
         )
-        .join('\n')
+      )
     );
   }
 
@@ -335,7 +335,7 @@ function summaryCommitMessage({
       '---',
       '### ⚠️ Javascript source files require intervention',
       'The following may contain errors and/or require intervention to remove superfluous conditionals:',
-      checkedFileListMarkdown(modifiedSourceFiles),
+      checkedListMarkdown(modifiedSourceFiles.map((file) => `\`${file}\``)),
       `Refer to the removal guide for [suggestions on handling these modified Javascript files.](${readmeMdGithubLink()}#followup)`
     );
   }
@@ -345,7 +345,7 @@ function summaryCommitMessage({
       '---',
       '### ⚠️ HTML files may still contain references',
       'The following HTML files contain references to experiment names which may be stale and should be manually removed:',
-      checkedFileListMarkdown(htmlFilesWithReferences),
+      checkedListMarkdown(htmlFilesWithReferences.map((file) => `\`${file}\``)),
       `Refer to the removal guide for [suggestions on handling these HTML files.](${readmeMdGithubLink()}#followup:html)`
     );
   }

--- a/build-system/tasks/sweep-experiments/index.js
+++ b/build-system/tasks/sweep-experiments/index.js
@@ -336,7 +336,9 @@ function collectWork(
 ) {
   if (removeExperiment) {
     // 0 if not on prodConfig
-    const percentage = Number(prodConfig[removeExperiment]);
+    const percentage = prodConfig[removeExperiment]
+      ? Number(prodConfig[removeExperiment])
+      : 0;
     const previousHistory = findConfigBitCommits(
       cutoffDateFormatted,
       prodConfigPath,
@@ -396,14 +398,14 @@ async function sweepExperiments() {
     argv.experiment
   );
 
-  if (Object.keys(exclude).length > 0) {
+  if (exclude && Object.keys(exclude).length > 0) {
     log(yellow('The following experiments are excluded as they are special:'));
     for (const experiment in exclude) {
       log(readableRemovalId(experiment, exclude[experiment]));
     }
   }
 
-  const total = Object.keys(include).length;
+  const total = include ? Object.keys(include).length : 0;
   if (total === 0) {
     log(cyan('No experiments to remove.'));
     log(`Cutoff at ${cutoffDateFormatted}`);

--- a/build-system/tasks/sweep-experiments/index.js
+++ b/build-system/tasks/sweep-experiments/index.js
@@ -262,21 +262,18 @@ const findConfigBitCommits = (
   });
 
 const issueUrlToNumberRe = new RegExp(
-  `^${
-    // Only use regex groups using parens () for issue number in this list.
-    [
-      'https://github.com/ampproject/amphtml/issues/(\\d+)',
-      'https://github.com/ampproject/amphtml/pull/(\\d+)',
-      'https://go.amp.dev/issue/(\\d+)',
-      'https://go.amp.dev/pr/(\\d+)',
-      '#(\\d+)',
-      '(\\d+)',
-    ].join('|')
-  }$`
+  [
+    '^https://github.com/ampproject/amphtml/issues/(\\d+)',
+    '^https://github.com/ampproject/amphtml/pull/(\\d+)',
+    '^https://go.amp.dev/issue/(\\d+)',
+    '^https://go.amp.dev/pr/(\\d+)',
+    '^#?(\\d+)$',
+  ].join('|')
 );
+
 function issueUrlToNumberOrUrl(url) {
   const match = url.match(issueUrlToNumberRe);
-  const number = match && match[1];
+  const number = match && match.find((group) => /^\d+$/.test(group));
   return number ? `#${number}` : url;
 }
 

--- a/build-system/tasks/sweep-experiments/index.js
+++ b/build-system/tasks/sweep-experiments/index.js
@@ -99,9 +99,13 @@ const getModifiedSourceFiles = (fromHash) =>
  */
 const jscodeshift = (transform, args = []) =>
   getStdoutThrowOnError(
-    'npx jscodeshift ' +
-      ` -t ${__dirname}/jscodeshift/${transform} ` +
-      args.join(' ')
+    [
+      'npx jscodeshift',
+      '--parser babylon',
+      `--parser-config ${__dirname}/jscodeshift/parser-config.json`,
+      `--transform ${__dirname}/jscodeshift/${transform}`,
+      ...args,
+    ].join(' ')
   );
 
 /**

--- a/build-system/tasks/sweep-experiments/index.js
+++ b/build-system/tasks/sweep-experiments/index.js
@@ -281,7 +281,7 @@ function issueUrlToNumberOrUrl(url) {
  * @param {string} list
  * @return {string}
  */
-const checkedListMarkdown = (list) =>
+const checklistMarkdown = (list) =>
   list.map((item) => `- [ ] ${item}`).join('\n');
 
 /**
@@ -321,7 +321,7 @@ function summaryCommitMessage({
       '---',
       '### Cleanup issues',
       "Close these once they've been addressed and this PR has been merged:",
-      checkedListMarkdown(
+      checklistMarkdown(
         cleanupIssues.map(
           ({id, cleanupIssue}) =>
             `\`${id}\`: ${issueUrlToNumberOrUrl(cleanupIssue)}`
@@ -335,7 +335,7 @@ function summaryCommitMessage({
       '---',
       '### ⚠️ Javascript source files require intervention',
       'The following may contain errors and/or require intervention to remove superfluous conditionals:',
-      checkedListMarkdown(modifiedSourceFiles.map((file) => `\`${file}\``)),
+      checklistMarkdown(modifiedSourceFiles.map((file) => `\`${file}\``)),
       `Refer to the removal guide for [suggestions on handling these modified Javascript files.](${readmeMdGithubLink()}#followup)`
     );
   }
@@ -345,7 +345,7 @@ function summaryCommitMessage({
       '---',
       '### ⚠️ HTML files may still contain references',
       'The following HTML files contain references to experiment names which may be stale and should be manually removed:',
-      checkedListMarkdown(htmlFilesWithReferences.map((file) => `\`${file}\``)),
+      checklistMarkdown(htmlFilesWithReferences.map((file) => `\`${file}\``)),
       `Refer to the removal guide for [suggestions on handling these HTML files.](${readmeMdGithubLink()}#followup:html)`
     );
   }

--- a/build-system/tasks/sweep-experiments/index.js
+++ b/build-system/tasks/sweep-experiments/index.js
@@ -262,8 +262,8 @@ const findConfigBitCommits = (
  * @param {string} files
  * @return {string}
  */
-const fileListMarkdown = (files) =>
-  files.map((path) => `- \`${path}\``).join('\n');
+const checkedFileListMarkdown = (files) =>
+  files.map((path) => `- [ ] \`${path}\``).join('\n');
 
 /**
  * @return {string}
@@ -300,7 +300,7 @@ function summaryCommitMessage({
       '---',
       '### ⚠️ Javascript source files require intervention',
       'The following may contain errors and/or require intervention to remove superfluous conditionals:',
-      fileListMarkdown(modifiedSourceFiles),
+      checkedFileListMarkdown(modifiedSourceFiles),
       `Refer to the removal guide for [suggestions on handling these modified Javascript files.](${readmeMdGithubLink()}#followup)`
     );
   }
@@ -310,7 +310,7 @@ function summaryCommitMessage({
       '---',
       '### ⚠️ HTML files may still contain references',
       'The following HTML files contain references to experiment names which may be stale and should be manually removed:',
-      fileListMarkdown(htmlFilesWithReferences),
+      checkedFileListMarkdown(htmlFilesWithReferences),
       `Refer to the removal guide for [suggestions on handling these HTML files.](${readmeMdGithubLink()}#followup:html)`
     );
   }

--- a/build-system/tasks/sweep-experiments/jscodeshift/parser-config.json
+++ b/build-system/tasks/sweep-experiments/jscodeshift/parser-config.json
@@ -1,7 +1,3 @@
 {
-  "sourceType": "module",
-  "plugins": [
-    "jsx",
-    "importAssertions"
-  ]
+  "plugins": ["jsx", "importAssertions"]
 }

--- a/build-system/tasks/sweep-experiments/jscodeshift/parser-config.json
+++ b/build-system/tasks/sweep-experiments/jscodeshift/parser-config.json
@@ -1,0 +1,7 @@
+{
+  "sourceType": "module",
+  "plugins": [
+    "jsx",
+    "importAssertions"
+  ]
+}

--- a/build-system/tasks/sweep-experiments/jscodeshift/remove-experiment-config.js
+++ b/build-system/tasks/sweep-experiments/jscodeshift/remove-experiment-config.js
@@ -46,15 +46,10 @@ export default function transformer(file, api, options) {
   const {experimentId, experimentsRemovedJson} = options;
 
   return j(file.source)
-    .find(j.ObjectExpression)
-    .filter(
-      (path) =>
-        j(path)
-          .find(j.ObjectProperty, {
-            key: {type: 'Identifier', name: 'id'},
-            value: {value: experimentId},
-          })
-          .size() !== 0
+    .find(j.ObjectExpression, (node) =>
+      node.properties.some(
+        ({key, value}) => key.name === 'id' && value.value === experimentId
+      )
     )
     .forEach((path) => {
       if (experimentsRemovedJson) {

--- a/build-system/tasks/sweep-experiments/jscodeshift/remove-experiment-config.js
+++ b/build-system/tasks/sweep-experiments/jscodeshift/remove-experiment-config.js
@@ -50,9 +50,9 @@ export default function transformer(file, api, options) {
     .filter(
       (path) =>
         j(path)
-          .find(j.Property, {
+          .find(j.ObjectProperty, {
             key: {type: 'Identifier', name: 'id'},
-            value: {type: 'Literal', value: experimentId},
+            value: {value: experimentId},
           })
           .size() !== 0
     )
@@ -63,7 +63,11 @@ export default function transformer(file, api, options) {
             j.objectExpression(
               // Only collect literal value properties so we can parse as JSON5
               path.value.properties.filter(
-                ({value}) => value.type === 'Literal'
+                ({value}) =>
+                  value.type === 'Literal' ||
+                  value.type === 'BooleanLiteral' ||
+                  value.type === 'NumericLiteral' ||
+                  value.type === 'StringLiteral'
               )
             )
           ).toSource()

--- a/build-system/tasks/sweep-experiments/jscodeshift/remove-experiment-runtime.js
+++ b/build-system/tasks/sweep-experiments/jscodeshift/remove-experiment-runtime.js
@@ -64,7 +64,8 @@ export default function transformer(file, api, options) {
         node.callee.type === 'Identifier' &&
         (node.callee.name === 'isExperimentOn' ||
           node.callee.name === 'toggleExperiment') &&
-        node.arguments[1].type === 'Literal' &&
+        (node.arguments[1].type === 'Literal' ||
+          node.arguments[1].type === 'StringLiteral') &&
         node.arguments[1].value === isExperimentOnExperiment
     )
     .forEach((path) => {

--- a/build-system/tasks/sweep-experiments/jscodeshift/remove-experiment-runtime.js
+++ b/build-system/tasks/sweep-experiments/jscodeshift/remove-experiment-runtime.js
@@ -64,8 +64,7 @@ export default function transformer(file, api, options) {
         node.callee.type === 'Identifier' &&
         (node.callee.name === 'isExperimentOn' ||
           node.callee.name === 'toggleExperiment') &&
-        (node.arguments[1].type === 'Literal' ||
-          node.arguments[1].type === 'StringLiteral') &&
+        node.arguments[1] &&
         node.arguments[1].value === isExperimentOnExperiment
     )
     .forEach((path) => {

--- a/build-system/tasks/sweep-experiments/jscodeshift/remove-experiment-runtime.js
+++ b/build-system/tasks/sweep-experiments/jscodeshift/remove-experiment-runtime.js
@@ -72,8 +72,9 @@ export default function transformer(file, api, options) {
 
       // remove unused imports
       root
-        .find(j.ImportSpecifier, {imported: {name}})
-        .closest(j.ImportDeclaration)
+        .find(j.ImportDeclaration, ({specifiers}) =>
+          specifiers.some(({imported}) => imported && imported.name === name)
+        )
         .forEach((path) => {
           if (root.find(j.CallExpression, {callee: {name}}).size() > 1) {
             return;
@@ -82,7 +83,7 @@ export default function transformer(file, api, options) {
             path.prune();
           } else {
             path.node.specifiers = path.node.specifiers.filter(
-              (node) => node.imported && node.imported.name !== name
+              ({imported}) => !(imported && imported.name === name)
             );
           }
         });
@@ -110,10 +111,7 @@ export default function transformer(file, api, options) {
             j.unaryExpression('!', isExperimentOnLaunchedLiteral);
       replacement.comments = [
         j.commentBlock(
-          ` ${file.source.substring(
-            path.node.start,
-            path.node.end
-          )} // launched: ${!!isExperimentOnLaunched} `,
+          ` ${j(path).toSource()} // launched: ${!!isExperimentOnLaunched} `,
           /* leading */ true,
           /* trailing */ false
         ),


### PR DESCRIPTION
### Parse with experimental features

Allows `jsx` and `importAssertions` like:

https://github.com/ampproject/amphtml/blob/3514120627396355c4c5974f30ee023f6f51a21f/extensions/amp-story/1.0/amp-story.js#L117

### Checkable markdown lists

Handier to keep track of manual steps:

```diff
- - `file.js`
+ - [ ] `file.js`
```

### Fix select single --experiment

This was previously untested, fixed:
```
gulp sweep-experiments --experiments=my-experiment
```

### Report cleanup issues using removed experiment config

Adds a section:

```markdown
### Cleanup issues

Close these once they've been addressed and this PR has been merged:

- `foo`: #1111
- `bar`: #2222
```