### PR TITLE
🐛 Fix typo s/GetAttribute/getAttribute/

### DIFF
--- a/validator/js/chromeextension/content_script.js
+++ b/validator/js/chromeextension/content_script.js
@@ -71,7 +71,7 @@ function getAmpHtmlLinkHref() {
           link.hasAttribute('rel') &&
           globals.amphtmlRegex.test(link.getAttribute('rel')) &&
           link.hasAttribute('href') &&
-          validUrlPrefixRe.test(link.GetAttribute('href'))) {
+          validUrlPrefixRe.test(link.getAttribute('href'))) {
         ampHtmlLinkHref = link.getAttribute('href');
         break;
       }


### PR DESCRIPTION
Fixes typo introduced in #31867 via 2f605e2.

I noticed via a console error today:

![image](https://user-images.githubusercontent.com/134745/104233295-7e463780-5406-11eb-9062-3554436187fa.png)