### PR TITLE
♻️ Refactor Bento Lightbox animation features

### DIFF
--- a/extensions/amp-lightbox/1.0/amp-lightbox.js
+++ b/extensions/amp-lightbox/1.0/amp-lightbox.js
@@ -101,7 +101,6 @@ AmpLightbox['props'] = {
   'animateIn': {attr: 'animate-in'},
   'scrollable': {attr: 'scrollable', type: 'boolean'},
   'id': {attr: 'id'},
-  'enableAnimation': {attr: 'enable-animation', type: 'boolean'},
 };
 
 /** @override */

--- a/extensions/amp-lightbox/1.0/amp-lightbox.js
+++ b/extensions/amp-lightbox/1.0/amp-lightbox.js
@@ -98,7 +98,7 @@ AmpLightbox['Component'] = Lightbox;
 
 /** @override */
 AmpLightbox['props'] = {
-  'animateIn': {attr: 'animate-in'},
+  'animation': {attr: 'animation'},
   'scrollable': {attr: 'scrollable', type: 'boolean'},
   'id': {attr: 'id'},
 };

--- a/extensions/amp-lightbox/1.0/amp-lightbox.js
+++ b/extensions/amp-lightbox/1.0/amp-lightbox.js
@@ -101,7 +101,6 @@ AmpLightbox['props'] = {
   'animateIn': {attr: 'animate-in'},
   'scrollable': {attr: 'scrollable', type: 'boolean'},
   'id': {attr: 'id'},
-  'closeButtonAriaLabel': {attr: 'data-close-button-aria-label'},
   'enableAnimation': {attr: 'enable-animation', type: 'boolean'},
 };
 

--- a/extensions/amp-lightbox/1.0/lightbox.js
+++ b/extensions/amp-lightbox/1.0/lightbox.js
@@ -66,7 +66,7 @@ function LightboxWithRef(
     children,
     onBeforeOpen,
     onAfterClose,
-    enableAnimation,
+    enableAnimation = true,
     ...rest
   },
   ref

--- a/extensions/amp-lightbox/1.0/lightbox.js
+++ b/extensions/amp-lightbox/1.0/lightbox.js
@@ -61,14 +61,7 @@ function useValueRef(current) {
  * @return {PreactDef.Renderable}
  */
 function LightboxWithRef(
-  {
-    animateIn = 'fade-in',
-    children,
-    onBeforeOpen,
-    onAfterClose,
-    enableAnimation = true,
-    ...rest
-  },
+  {animateIn = 'fade-in', children, onBeforeOpen, onAfterClose, ...rest},
   ref
 ) {
   // There are two phases to open and close.
@@ -86,7 +79,6 @@ function LightboxWithRef(
   const animateInRef = useValueRef(animateIn);
   const onBeforeOpenRef = useValueRef(onBeforeOpen);
   const onAfterCloseRef = useValueRef(onAfterClose);
-  const enableAnimationRef = useValueRef(enableAnimation);
 
   useImperativeHandle(
     ref,
@@ -121,7 +113,7 @@ function LightboxWithRef(
         setStyle(element, 'visibility', 'visible');
         element./*REVIEW*/ focus();
       };
-      if (!element.animate || !enableAnimationRef.current) {
+      if (!element.animate) {
         postVisibleAnim();
         return;
       }
@@ -142,7 +134,7 @@ function LightboxWithRef(
         animation = null;
         setMounted(false);
       };
-      if (!element.animate || !enableAnimationRef.current) {
+      if (!element.animate) {
         postInvisibleAnim();
         return;
       }
@@ -159,7 +151,7 @@ function LightboxWithRef(
         animation.cancel();
       }
     };
-  }, [visible, animateInRef, enableAnimationRef, onAfterCloseRef]);
+  }, [visible, animateInRef, onAfterCloseRef]);
 
   return (
     mounted && (

--- a/extensions/amp-lightbox/1.0/lightbox.js
+++ b/extensions/amp-lightbox/1.0/lightbox.js
@@ -63,7 +63,6 @@ function useValueRef(current) {
 function LightboxWithRef(
   {
     animateIn = 'fade-in',
-    closeButtonAriaLabel = DEFAULT_CLOSE_LABEL,
     children,
     onBeforeOpen,
     onAfterClose,
@@ -184,7 +183,7 @@ function LightboxWithRef(
       >
         {children}
         <button
-          ariaLabel={closeButtonAriaLabel}
+          ariaLabel={DEFAULT_CLOSE_LABEL}
           tabIndex={-1}
           className={classes.closeButton}
           onClick={() => {

--- a/extensions/amp-lightbox/1.0/lightbox.js
+++ b/extensions/amp-lightbox/1.0/lightbox.js
@@ -61,7 +61,7 @@ function useValueRef(current) {
  * @return {PreactDef.Renderable}
  */
 function LightboxWithRef(
-  {animateIn = 'fade-in', children, onBeforeOpen, onAfterClose, ...rest},
+  {animation = 'fade-in', children, onBeforeOpen, onAfterClose, ...rest},
   ref
 ) {
   // There are two phases to open and close.
@@ -76,7 +76,7 @@ function LightboxWithRef(
   // We are using refs here to refer to common strings, objects, and functions used.
   // This is because they are needed within `useEffect` calls below (but are not depended for triggering)
   // We use `useValueRef` for props that might change (user-controlled)
-  const animateInRef = useValueRef(animateIn);
+  const animationRef = useValueRef(animation);
   const onBeforeOpenRef = useValueRef(onBeforeOpen);
   const onAfterCloseRef = useValueRef(onAfterClose);
 
@@ -117,7 +117,7 @@ function LightboxWithRef(
         postVisibleAnim();
         return;
       }
-      animation = element.animate(ANIMATION_PRESETS[animateInRef.current], {
+      animation = element.animate(ANIMATION_PRESETS[animationRef.current], {
         duration: ANIMATION_DURATION,
         fill: 'both',
         easing: 'ease-in',
@@ -138,7 +138,7 @@ function LightboxWithRef(
         postInvisibleAnim();
         return;
       }
-      animation = element.animate(ANIMATION_PRESETS[animateInRef.current], {
+      animation = element.animate(ANIMATION_PRESETS[animationRef.current], {
         duration: ANIMATION_DURATION,
         direction: 'reverse',
         fill: 'both',
@@ -151,7 +151,7 @@ function LightboxWithRef(
         animation.cancel();
       }
     };
-  }, [visible, animateInRef, onAfterCloseRef]);
+  }, [visible, animationRef, onAfterCloseRef]);
 
   return (
     mounted && (

--- a/extensions/amp-lightbox/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-lightbox/1.0/storybook/Basic.amp.js
@@ -34,7 +34,6 @@ export const Default = () => {
     'fly-in-top',
     'fly-in-bottom',
   ]);
-  const enableAnimation = boolean('enable animation', true);
   const backgroundColor = text('background color', '');
   const color = text('font color', '');
   return (
@@ -46,12 +45,7 @@ export const Default = () => {
         }
       `}</style>
       <div style="height: 300px;">
-        <amp-lightbox
-          id="lightbox"
-          layout="nodisplay"
-          animate-in={animateIn}
-          enable-animation={enableAnimation}
-        >
+        <amp-lightbox id="lightbox" layout="nodisplay" animate-in={animateIn}>
           <p>Test</p>
           <button on="tap:lightbox.close">Close</button>
         </amp-lightbox>

--- a/extensions/amp-lightbox/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-lightbox/1.0/storybook/Basic.amp.js
@@ -15,7 +15,7 @@
  */
 
 import * as Preact from '../../../../src/preact';
-import {boolean, select, text, withKnobs} from '@storybook/addon-knobs';
+import {select, text, withKnobs} from '@storybook/addon-knobs';
 import {withA11y} from '@storybook/addon-a11y';
 import {withAmp} from '@ampproject/storybook-addon';
 
@@ -29,7 +29,7 @@ export default {
 };
 
 export const Default = () => {
-  const animateIn = select('animate-in', [
+  const animation = select('animation', [
     'fade-in',
     'fly-in-top',
     'fly-in-bottom',
@@ -45,7 +45,7 @@ export const Default = () => {
         }
       `}</style>
       <div style="height: 300px;">
-        <amp-lightbox id="lightbox" layout="nodisplay" animate-in={animateIn}>
+        <amp-lightbox id="lightbox" layout="nodisplay" animation={animation}>
           <p>Test</p>
           <button on="tap:lightbox.close">Close</button>
         </amp-lightbox>

--- a/extensions/amp-lightbox/1.0/storybook/Basic.js
+++ b/extensions/amp-lightbox/1.0/storybook/Basic.js
@@ -16,7 +16,7 @@
 
 import * as Preact from '../../../../src/preact';
 import {Lightbox} from '../lightbox';
-import {boolean, select, text, withKnobs} from '@storybook/addon-knobs';
+import {select, text, withKnobs} from '@storybook/addon-knobs';
 import {useRef} from '../../../../src/preact';
 import {withA11y} from '@storybook/addon-a11y';
 

--- a/extensions/amp-lightbox/1.0/storybook/Basic.js
+++ b/extensions/amp-lightbox/1.0/storybook/Basic.js
@@ -43,21 +43,19 @@ function LightboxWithActions(props) {
 }
 
 export const _default = () => {
-  const animateIn = select('animateIn', [
+  const animation = select('animation', [
     'fade-in',
     'fly-in-top',
     'fly-in-bottom',
   ]);
-  const enableAnimation = boolean('enable animation', true);
   const backgroundColor = text('background color', '');
   const color = text('font color', '');
   return (
     <div>
       <LightboxWithActions
         id="lightbox"
-        animateIn={animateIn}
+        animation={animation}
         style={{backgroundColor, color}}
-        enableAnimation={enableAnimation}
       >
         <p>
           Lorem <i>ips</i>um dolor sit amet, has nisl nihil convenire et, vim at

--- a/extensions/amp-lightbox/1.0/test/test-amp-lightbox.js
+++ b/extensions/amp-lightbox/1.0/test/test-amp-lightbox.js
@@ -17,8 +17,8 @@ import '../amp-lightbox';
 import {ActionInvocation} from '../../../../src/service/action-impl';
 import {ActionTrust, DEFAULT_ACTION} from '../../../../src/action-constants';
 import {htmlFor} from '../../../../src/static-template';
+import {poll} from '../../../../testing/iframe';
 import {toggleExperiment} from '../../../../src/experiments';
-import {waitFor} from '../../../../testing/test-helper';
 
 describes.realWin(
   'amp-lightbox:1.0',
@@ -34,7 +34,8 @@ describes.realWin(
 
     async function waitForOpen(el, open) {
       const isOpenOrNot = () => el.hasAttribute('open') === open;
-      await waitFor(isOpenOrNot, 'element open updated');
+      // Extend timeout due to animation delay.
+      await poll('element open updated', isOpenOrNot, undefined, 500);
     }
 
     function getContent() {
@@ -54,6 +55,10 @@ describes.realWin(
       `;
       win.document.body.appendChild(element);
       await element.build();
+    });
+
+    afterEach(() => {
+      win.document.body.removeChild(element);
     });
 
     it('should render closed', async () => {


### PR DESCRIPTION
- Remove `data-close-button-aria-label` and hardcode the default. #31052 tracks the separate effort to replace this with `slot="close-button"` support.
- Rename `animate-in`/`animateIn` as `animation`.
- Remove `enable-animation`/`enableAnimation` - This is not present in 0.1, and if feedback is received that this is desired, it should be better as an `animation` option.

Partial for #31052