### PR TITLE
✨  Add Pubtech type for amp-consent

### DIFF
--- a/examples/amp-consent/cmp-vendors.amp.html
+++ b/examples/amp-consent/cmp-vendors.amp.html
@@ -103,6 +103,7 @@
           <option>Marfeel</option>
           <option>Ogury</option>
           <option>opencmp</option>
+          <option>pubtech</option>
           <option>quantcast</option>
           <option>sirdata</option>
           <option>SourcePoint</option>
@@ -245,7 +246,7 @@
         </div>
       </amp-consent>
       <!-- End LiveRamp example-->
-      
+
       <!-- Marfeel example -->
       <amp-consent id='marfeelConsent' layout='nodisplay' type='Marfeel'>
         <script type="application/json">
@@ -320,6 +321,24 @@
       </amp-consent>
       <!-- End opencmp example -->
 
+  <!-- Pubtech Example -->
+  <amp-consent id="pubtech" layout="nodisplay" type="pubtech">
+    <script type="application/json">
+          {
+            "postPromptUI": "pubtech-post-prompt",
+            "clientConfig": {
+              "privacyUrl": "",
+              "isAmp": true,
+              "websiteName": "Pubtech"
+            }
+          }
+        </script>
+    <div id="pubtech-post-prompt">
+      <button on="tap:consent.prompt(consent=pubtech)" role="button">Privacy settings</button>
+    </div>
+  </amp-consent>
+  <!-- End Pubtech example -->
+
       <!-- Quantcast Example -->
       <amp-consent id="quantcast" layout="nodisplay" type="quantcast">
         <script type="application/json">
@@ -358,7 +377,7 @@
         </div>
       </amp-consent>
       <!-- End sirdata example -->
-      
+
       <!-- SourcePoint example -->
       <amp-consent id='consent' layout='nodisplay' type='SourcePoint'>
         <script type="application/json">

--- a/examples/amp-consent/cmp-vendors.amp.html
+++ b/examples/amp-consent/cmp-vendors.amp.html
@@ -321,23 +321,23 @@
       </amp-consent>
       <!-- End opencmp example -->
 
-  <!-- Pubtech Example -->
-  <amp-consent id="pubtech" layout="nodisplay" type="pubtech">
-    <script type="application/json">
-          {
-            "postPromptUI": "pubtech-post-prompt",
-            "clientConfig": {
-              "privacyUrl": "",
-              "isAmp": true,
-              "websiteName": "Pubtech"
-            }
-          }
-        </script>
-    <div id="pubtech-post-prompt">
-      <button on="tap:consent.prompt(consent=pubtech)" role="button">Privacy settings</button>
-    </div>
-  </amp-consent>
-  <!-- End Pubtech example -->
+      <!-- Pubtech Example -->
+      <amp-consent id="pubtech" layout="nodisplay" type="pubtech">
+        <script type="application/json">
+              {
+                "postPromptUI": "pubtech-post-prompt",
+                "clientConfig": {
+                  "privacyUrl": "",
+                  "isAmp": true,
+                  "websiteName": "Pubtech"
+                }
+              }
+            </script>
+        <div id="pubtech-post-prompt">
+          <button on="tap:consent.prompt(consent=pubtech)" role="button">Privacy settings</button>
+        </div>
+      </amp-consent>
+      <!-- End Pubtech example -->
 
       <!-- Quantcast Example -->
       <amp-consent id="quantcast" layout="nodisplay" type="quantcast">

--- a/examples/amp-consent/cmp-vendors.amp.html
+++ b/examples/amp-consent/cmp-vendors.amp.html
@@ -334,7 +334,7 @@
               }
             </script>
         <div id="pubtech-post-prompt">
-          <button on="tap:consent.prompt(consent=pubtech)" role="button">Privacy settings</button>
+          <button on="tap:pubtech.prompt(consent=pubtech)" role="button">Privacy settings</button>
         </div>
       </amp-consent>
       <!-- End Pubtech example -->

--- a/extensions/amp-consent/0.1/cmps.js
+++ b/extensions/amp-consent/0.1/cmps.js
@@ -91,6 +91,12 @@ CMP_CONFIG['opencmp'] = {
   'promptUISrc': 'https://cdn.opencmp.net/tcf-v2/amp/cmp.html',
 };
 
+CMP_CONFIG['pubtech'] = {
+  'consentInstanceId': 'pubtech',
+  'checkConsentHref': 'https://amp.pubtech.it/cmp-amp-check-consent',
+  'promptUISrc': 'https://cdn.pubtech.ai/amp/index.html',
+};
+
 CMP_CONFIG['quantcast'] = {
   'consentInstanceId': 'quantcast',
   'checkConsentHref':

--- a/extensions/amp-consent/amp-consent.md
+++ b/extensions/amp-consent/amp-consent.md
@@ -629,7 +629,7 @@ Join in on the discussion where we are discussing [upcoming potential features](
 -   Ogury : [Website](https://www.ogury.com/) - [Documentation](./cmps/ogury.md)
 -   OneTrust: [Website](https://www.onetrust.com/) - [Documentation](./cmps/onetrust.md)
 -   opencmp : [Documentation](./cmps/opencmp.md)
--   Pubtech : [Documentation](./cmps/pubtech.md)
+-   Pubtech : [Website](https://www.pubtech.ai/) - [Documentation](./cmps/pubtech.md)
 -   Quantcast : [Website](https://www.quantcast.com) - [Documentation](https://help.quantcast.com/hc/en-us/categories/360002940873-Quantcast-Choice)
 -   Sirdata : [Website](http://www.sirdata.com/) - [Documentation](https://cmp.sirdata.com/#/docs)
 -   SourcePoint : [Website](https://www.sourcepoint.com/) - [Documentation](./cmps/sourcepoint.md)

--- a/extensions/amp-consent/amp-consent.md
+++ b/extensions/amp-consent/amp-consent.md
@@ -629,6 +629,7 @@ Join in on the discussion where we are discussing [upcoming potential features](
 -   Ogury : [Website](https://www.ogury.com/) - [Documentation](./cmps/ogury.md)
 -   OneTrust: [Website](https://www.onetrust.com/) - [Documentation](./cmps/onetrust.md)
 -   opencmp : [Documentation](./cmps/opencmp.md)
+-   Pubtech : [Documentation](./cmps/pubtech.md)
 -   Quantcast : [Website](https://www.quantcast.com) - [Documentation](https://help.quantcast.com/hc/en-us/categories/360002940873-Quantcast-Choice)
 -   Sirdata : [Website](http://www.sirdata.com/) - [Documentation](https://cmp.sirdata.com/#/docs)
 -   SourcePoint : [Website](https://www.sourcepoint.com/) - [Documentation](./cmps/sourcepoint.md)

--- a/extensions/amp-consent/cmps/pubtech.md
+++ b/extensions/amp-consent/cmps/pubtech.md
@@ -1,0 +1,51 @@
+<!---
+Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS-IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# Pubtech
+
+## Example
+
+```html
+    <amp-consent id="pubtech" layout="nodisplay" type="pubtech">
+        <script type="application/json">
+          {
+            "postPromptUI": "pubtech-post-prompt",
+            "clientConfig": {
+              "privacyUrl": "",
+              "isAmp": true,
+              "websiteName": "Pubtech"
+            }
+          }
+        </script>
+        <div id="pubtech-post-prompt">
+          <button on="tap:consent.prompt(consent=pubtech)" role="button">Privacy settings</button>
+        </div>
+    </amp-consent>
+```
+
+## Notes
+
+### `postPromptUI`
+
+The value of `postPromptUI` should be the id of the html tag in which the consent ui will be attached to. In our example above, the value of `postPromptUI` is `pubtech-post-prompt` since we have a div with that id.
+
+## Configuration
+
+Visit the [CMP Section](https://www.pubtech.ai/) to get a full description of our configuration options.
+
+## Getting Help
+
+For more information on how to integrate our CMP AMP to your page please contact your account manager directly.

--- a/extensions/amp-consent/cmps/pubtech.md
+++ b/extensions/amp-consent/cmps/pubtech.md
@@ -1,5 +1,5 @@
 <!---
-Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+Copyright 2021 The AMP HTML Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
Adding Pubtech to the list of registered CMPs.

Added:
- Pubtech CMP config
- Example on cmp-vendors page
- Example documentation.


Pubtech CMP is a consent management provider (CMP) solution built on and registered with the IAB Europe Transparency and Consent framework.

Context: https://github.com/ampproject/amphtml/blob/master/extensions/amp-consent/integrating-consent.md

cc @ampproject/wg-monetization