### PR TITLE
❄️  Swipe up visual diff flaky test

### DIFF
--- a/examples/visual-tests/amp-story/amp-story-page-attachment.js
+++ b/examples/visual-tests/amp-story/amp-story-page-attachment.js
@@ -28,6 +28,6 @@ module.exports = {
     const screen = page.touchscreen;
     await screen.tap(200, 240);
     await page.waitFor('amp-story-page#page-2[active]');
-    await page.waitFor(100);
+    await page.waitFor(1600);
    },
 };

--- a/examples/visual-tests/amp-story/amp-story-page-attachment.js
+++ b/examples/visual-tests/amp-story/amp-story-page-attachment.js
@@ -24,14 +24,10 @@ module.exports = {
     await page.tap('.i-amphtml-story-page-open-attachment-label');
     await page.waitFor(410);
   },
-  /**
-   * TODO(@ampproject/wg-stories): fix flaky test:
-   * https://percy.io/ampproject/amphtml/builds-next/8331061/changed/473805330
-   *
-   * 'open attachment UI element with link': async (page, name) => {
-   *   const screen = page.touchscreen;
-   *   await screen.tap(200, 240);
-   *   await page.waitFor('amp-story-page#page-2[active]');
-   * },
-   */
+   'open attachment UI element with link': async (page, name) => {
+    const screen = page.touchscreen;
+    await screen.tap(200, 240);
+    await page.waitFor('amp-story-page#page-2[active]');
+    await page.waitFor(100);
+   },
 };


### PR DESCRIPTION
Make test not flaky.

Swipe-ups are animated, and for that reason the other tests that check for this have a 1600ms delay. Added the same delay on this test.