### PR TITLE
Unmute media after playAllMedia resolves.

### DIFF
--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -535,6 +535,7 @@ export class AmpStoryPage extends AMP.BaseElement {
         this.preloadAllMedia_().then(() => {
           this.startMeasuringAllVideoPerformance_();
           this.startListeningToVideoEvents_();
+          // iOS 14.2 and 14.3 requires play to be called before unmute
           this.playAllMedia_().then(() => {
             if (!this.storeService_.get(StateProperty.MUTED_STATE)) {
               this.unmuteAllMedia();

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -535,10 +535,11 @@ export class AmpStoryPage extends AMP.BaseElement {
         this.preloadAllMedia_().then(() => {
           this.startMeasuringAllVideoPerformance_();
           this.startListeningToVideoEvents_();
-          this.playAllMedia_();
-          if (!this.storeService_.get(StateProperty.MUTED_STATE)) {
-            this.unmuteAllMedia();
-          }
+          this.playAllMedia_().then(() => {
+            if (!this.storeService_.get(StateProperty.MUTED_STATE)) {
+              this.unmuteAllMedia();
+            }
+          });
         });
       });
       this.prefersReducedMotion_()

--- a/extensions/amp-story/1.0/test/test-amp-story-page.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-page.js
@@ -231,6 +231,8 @@ describes.realWin('amp-story-page', {amp: {extensions}}, (env) => {
       .then(() => page.mediaPoolPromise_)
       .then((mediaPool) => {
         mediaPoolMock = env.sandbox.mock(mediaPool);
+        mediaPoolMock.expects('preload').resolves();
+        mediaPoolMock.expects('play').resolves();
         mediaPoolMock.expects('unmute').once();
 
         page.setState(PageState.PLAYING);


### PR DESCRIPTION
Context / Fixes #31911

To consistently keep audio unmuted after auto-play, play needs to be called before unmuting the media on iOS 14.2 and 14.3.

This PR calls `unmuteAllMedia_` after `playAllMedia_` resolves in `amp-story-page`.

[demo](https://stamp-autoplay.web.app/examples/amp-story/ampconf.html)

