### PR TITLE
✨[Story layouts] Responsiveness presets for grid-layers

### DIFF
--- a/extensions/amp-story/1.0/amp-story-grid-layer.js
+++ b/extensions/amp-story/1.0/amp-story-grid-layer.js
@@ -86,19 +86,19 @@ const PRESET_ATTRIBUTE_NAME = 'preset';
 /**
  * @typedef {{
  *  aspect-ratio: string,
- * scaling-factor: ?string,
+ *  scaling-factor: ?float,
  * }}
  */
-export let PresetAttributes;
+export let PresetDetails;
 
 /**
  * The attributes that will be applied for each preset.
- * @private @const {!Object<string, !PresetAttributes>}
+ * @private @const {!Object<string, !PresetDetails>}
  */
-const GRID_LAYER_PRESET_ATTRIBUTES = {
+const GRID_LAYER_PRESET_DETAILS = {
   '2021-background': {
     'aspect-ratio': '69:116',
-    'scaling-factor': '1.142',
+    'scaling-factor': 1.142,
   },
   '2021-foreground': {
     'aspect-ratio': '69:116',
@@ -163,11 +163,11 @@ export class AmpStoryGridLayer extends AmpStoryBaseLayer {
       return;
     }
     const preset = this.element.getAttribute(PRESET_ATTRIBUTE_NAME);
-    const presetAttributes = GRID_LAYER_PRESET_ATTRIBUTES[preset];
-    if (!presetAttributes) {
+    const presetDetails = GRID_LAYER_PRESET_DETAILS[preset];
+    if (!presetDetails) {
       return;
     }
-    Object.entries(presetAttributes).forEach((keyValue) =>
+    Object.entries(presetDetails).forEach((keyValue) =>
       this.element.setAttribute(keyValue[0], keyValue[1])
     );
   }

--- a/extensions/amp-story/1.0/amp-story-grid-layer.js
+++ b/extensions/amp-story/1.0/amp-story-grid-layer.js
@@ -135,7 +135,7 @@ export class AmpStoryGridLayer extends AmpStoryBaseLayer {
   /** @override */
   buildCallback() {
     super.buildCallback();
-    this.applyPresets_();
+    this.applyResponsivenessPresets_();
     this.applyTemplateClassName_();
     this.setOwnCssGridStyles_();
     this.setDescendentCssGridStyles_();
@@ -151,7 +151,7 @@ export class AmpStoryGridLayer extends AmpStoryBaseLayer {
    * Applies the attributes to the layer from the preset specified in the [preset] attribute.
    * @private
    */
-  applyPresets_() {
+  applyResponsivenessPresets_() {
     if (!this.element.hasAttribute(PRESET_ATTRIBUTE_NAME)) {
       return;
     }

--- a/extensions/amp-story/1.0/amp-story-grid-layer.js
+++ b/extensions/amp-story/1.0/amp-story-grid-layer.js
@@ -29,6 +29,7 @@
 import {AmpStoryBaseLayer} from './amp-story-base-layer';
 import {StateProperty, getStoreService} from './amp-story-store-service';
 import {assertDoesNotContainDisplay, px, setStyles} from '../../../src/style';
+import {devAssert} from '../../../src/log';
 import {escapeCssSelectorIdent} from '../../../src/css';
 import {parseQueryString} from '../../../src/url';
 import {scopedQuerySelectorAll} from '../../../src/dom';
@@ -78,6 +79,26 @@ export const GRID_LAYER_TEMPLATE_CLASS_NAMES = {
 };
 
 /**
+ * The attribute name for grid layer presets.
+ * @private @const {string}
+ */
+const PRESET_ATTRIBUTE_NAME = 'preset';
+
+/**
+ * The attributes that will be applied for each preset.
+ * @private @const {!Object<string, !Object<string, string>>}
+ */
+const GRID_LAYER_PRESETS_ATTRIBUTES = {
+  '2021-background': {
+    'aspect-ratio': '69:116',
+    'scaling-factor': '1.142',
+  },
+  '2021-foreground': {
+    'aspect-ratio': '69:116',
+  },
+};
+
+/**
  * Grid layer template templating system.
  */
 export class AmpStoryGridLayer extends AmpStoryBaseLayer {
@@ -114,6 +135,7 @@ export class AmpStoryGridLayer extends AmpStoryBaseLayer {
   /** @override */
   buildCallback() {
     super.buildCallback();
+    this.applyPresets_();
     this.applyTemplateClassName_();
     this.setOwnCssGridStyles_();
     this.setDescendentCssGridStyles_();
@@ -123,6 +145,25 @@ export class AmpStoryGridLayer extends AmpStoryBaseLayer {
   /** @override */
   prerenderAllowed() {
     return this.isPrerenderActivePage();
+  }
+
+  /**
+   * Applies the attributes to the layer from the preset specified in the [preset] attribute.
+   * @private
+   */
+  applyPresets_() {
+    if (!this.element.hasAttribute(PRESET_ATTRIBUTE_NAME)) {
+      return;
+    }
+    const preset = this.element.getAttribute(PRESET_ATTRIBUTE_NAME);
+    const presetAttributes = GRID_LAYER_PRESETS_ATTRIBUTES[preset];
+    devAssert(
+      presetAttributes,
+      `Preset not found for amp-story-grid-layer: ${preset}`
+    );
+    Object.entries(presetAttributes).forEach((keyValue) =>
+      this.element.setAttribute(keyValue[0], keyValue[1])
+    );
   }
 
   /** @private */

--- a/extensions/amp-story/1.0/amp-story-grid-layer.js
+++ b/extensions/amp-story/1.0/amp-story-grid-layer.js
@@ -29,7 +29,6 @@
 import {AmpStoryBaseLayer} from './amp-story-base-layer';
 import {StateProperty, getStoreService} from './amp-story-store-service';
 import {assertDoesNotContainDisplay, px, setStyles} from '../../../src/style';
-import {devAssert} from '../../../src/log';
 import {escapeCssSelectorIdent} from '../../../src/css';
 import {parseQueryString} from '../../../src/url';
 import {scopedQuerySelectorAll} from '../../../src/dom';
@@ -85,10 +84,18 @@ export const GRID_LAYER_TEMPLATE_CLASS_NAMES = {
 const PRESET_ATTRIBUTE_NAME = 'preset';
 
 /**
- * The attributes that will be applied for each preset.
- * @private @const {!Object<string, !Object<string, string>>}
+ * @typedef {{
+ *  aspect-ratio: string,
+ * scaling-factor: ?string,
+ * }}
  */
-const GRID_LAYER_PRESETS_ATTRIBUTES = {
+export let PresetAttributes;
+
+/**
+ * The attributes that will be applied for each preset.
+ * @private @const {!Object<string, !PresetAttributes>}
+ */
+const GRID_LAYER_PRESET_ATTRIBUTES = {
   '2021-background': {
     'aspect-ratio': '69:116',
     'scaling-factor': '1.142',
@@ -156,7 +163,7 @@ export class AmpStoryGridLayer extends AmpStoryBaseLayer {
       return;
     }
     const preset = this.element.getAttribute(PRESET_ATTRIBUTE_NAME);
-    const presetAttributes = GRID_LAYER_PRESETS_ATTRIBUTES[preset];
+    const presetAttributes = GRID_LAYER_PRESET_ATTRIBUTES[preset];
     if (!presetAttributes) {
       return;
     }

--- a/extensions/amp-story/1.0/amp-story-grid-layer.js
+++ b/extensions/amp-story/1.0/amp-story-grid-layer.js
@@ -157,10 +157,9 @@ export class AmpStoryGridLayer extends AmpStoryBaseLayer {
     }
     const preset = this.element.getAttribute(PRESET_ATTRIBUTE_NAME);
     const presetAttributes = GRID_LAYER_PRESETS_ATTRIBUTES[preset];
-    devAssert(
-      presetAttributes,
-      `Preset not found for amp-story-grid-layer: ${preset}`
-    );
+    if (!presetAttributes) {
+      return;
+    }
     Object.entries(presetAttributes).forEach((keyValue) =>
       this.element.setAttribute(keyValue[0], keyValue[1])
     );

--- a/extensions/amp-story/1.0/test/test-amp-story-grid-layer.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-grid-layer.js
@@ -126,4 +126,14 @@ describes.realWin('amp-story-grid-layer', {amp: true}, (env) => {
       )
     ).to.equal(562);
   });
+
+  it('should apply the preset attributes', async () => {
+    gridLayerEl.setAttribute('preset', '2021-foreground');
+    await buildGridLayer();
+
+    storeService.dispatch(Action.SET_PAGE_SIZE, {width: 1000, height: 1000});
+
+    expect(gridLayerEl.getAttribute('aspect-ratio')).to.equal('69:116');
+    expect(gridLayerEl).to.have.class('i-amphtml-story-grid-template-aspect');
+  });
 });

--- a/extensions/amp-story/1.0/test/test-amp-story-grid-layer.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-grid-layer.js
@@ -127,13 +127,29 @@ describes.realWin('amp-story-grid-layer', {amp: true}, (env) => {
     ).to.equal(562);
   });
 
-  it('should apply the preset attributes', async () => {
+  it('should apply the aspect-ratio attribute from the responsiveness preset', async () => {
     gridLayerEl.setAttribute('preset', '2021-foreground');
     await buildGridLayer();
 
     storeService.dispatch(Action.SET_PAGE_SIZE, {width: 1000, height: 1000});
 
     expect(gridLayerEl.getAttribute('aspect-ratio')).to.equal('69:116');
+  });
+
+  it('should use the responsiveness preset to change the layer aspect', async () => {
+    gridLayerEl.setAttribute('preset', '2021-foreground');
+    await buildGridLayer();
+
+    storeService.dispatch(Action.SET_PAGE_SIZE, {width: 1000, height: 1000});
+
     expect(gridLayerEl).to.have.class('i-amphtml-story-grid-template-aspect');
+  });
+
+  it('should throw error if preset passed is incorrect', async () => {
+    expectAsyncConsoleError(
+      'Preset not found for amp-story-grid-layer: wrong-preset!'
+    );
+    gridLayerEl.setAttribute('preset', 'wrong-preset!');
+    allowConsoleError(async () => buildGridLayer());
   });
 });

--- a/extensions/amp-story/1.0/test/test-amp-story-grid-layer.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-grid-layer.js
@@ -145,11 +145,10 @@ describes.realWin('amp-story-grid-layer', {amp: true}, (env) => {
     expect(gridLayerEl).to.have.class('i-amphtml-story-grid-template-aspect');
   });
 
-  it('should throw error if preset passed is incorrect', async () => {
-    expectAsyncConsoleError(
-      'Preset not found for amp-story-grid-layer: wrong-preset!'
-    );
-    gridLayerEl.setAttribute('preset', 'wrong-preset!');
-    allowConsoleError(async () => buildGridLayer());
+  it('should not add aspect-ratio attribute if preset passed is incorrect', async () => {
+    gridLayerEl.setAttribute('preset', 'wrong-preset');
+    await buildGridLayer();
+
+    expect(gridLayerEl.hasAttribute('aspect-ratio')).to.be.false;
   });
 });


### PR DESCRIPTION
Added the `preset` attribute to grid-layers with 2 presets:
- **`2021-foreground`**: aspect-ratio of 69:116
- **`2021-background`**: aspect-ratio of 69:116 and scaling-factor of 1.142

Wrote test to ensure presets are applied and aspect-ratio is used.

Attribute does not pass validation yet.

Closes #31283