### PR TITLE
🐛  amp-access-poool: add missing locale & context config values

### DIFF
--- a/extensions/amp-access-poool/0.1/poool-impl.js
+++ b/extensions/amp-access-poool/0.1/poool-impl.js
@@ -45,6 +45,8 @@ const AUTHORIZATION_TIMEOUT = 3000;
  *   videoClient: (string|null),
  *   customSegment: (string|null),
  *   cookiesEnabled: (boolean),
+ *   locale: (string|null),
+ *   context: (string|null),
  * }}
  */
 let PooolConfigDef;
@@ -205,6 +207,8 @@ export class PooolVendor {
               : getMode().development || getMode().localDev,
           'fw': this.pooolConfig_['forceWidget'],
           'cs': this.pooolConfig_['customSegment'],
+          'lo': this.pooolConfig_['locale'],
+          'co': this.pooolConfig_['context'],
         })
       ),
       false

--- a/extensions/amp-access-poool/amp-access-poool.md
+++ b/extensions/amp-access-poool/amp-access-poool.md
@@ -168,6 +168,16 @@ See [documentation](https://dev.poool.tech/doc/sdk#custom_segment) for more info
 Following latest GDPR requirements, we decided to disable cookies by default inside our paywall. You will have to explicitly set this attribute to reflect the user's consent.
 See [documentation](https://dev.poool.tech/doc/sdk#cookies_enabled) for more information.
 
+### locale
+
+Set default locale for all texts inside the paywall.
+See [documentation](https://dev.poool.tech/doc/sdk#locale) for more information.
+
+### context
+
+Override default or native contexts with a custom context value.
+See [documentation](https://dev.poool.tech/doc/sdk#context) for more information.
+
 ## Validation
 
 See [`amp-access-poool` rules](https://github.com/ampproject/amphtml/blob/master/extensions/amp-access-poool/validator-amp-access-poool.protoascii) in the AMP validator specification.


### PR DESCRIPTION
This PR addresses 2 minor issues for `amp-access-poool`:
- Some users are stuck with the default locale (aka fr) when there's an error trying to show the paywall
- We introduced a "contextual" level over journeys inside Poool, which is missing here and a blocking issue for some users