### PR TITLE
🐛 Bento Carousel: Conditionally render wraparound slides when looping

### DIFF
--- a/extensions/amp-base-carousel/1.0/base-carousel.js
+++ b/extensions/amp-base-carousel/1.0/base-carousel.js
@@ -29,6 +29,7 @@ import {Scroller} from './scroller';
 import {WithAmpContext} from '../../../src/preact/context';
 import {forwardRef} from '../../../src/preact/compat';
 import {isRTL} from '../../../src/dom';
+import {mod} from '../../../src/utils/math';
 import {
   toChildArray,
   useCallback,
@@ -353,7 +354,12 @@ function BaseCarouselWithRef(
           and next viewport.
         */}
         {childrenArray.map((child, index) =>
-          Math.abs(index - currentSlide) < visibleCount * 3 || mixedLength ? (
+          Math.min(
+            // Distance from currentSlide.
+            Math.abs(index - currentSlide),
+            // Account for wraparound when looping.
+            loop ? mod(length + currentSlide - index, length) : length
+          ) < Math.ceil(visibleCount * 3) || mixedLength ? (
             <WithAmpContext
               key={index}
               renderable={index == currentSlide}


### PR DESCRIPTION
The experimental logic to only show a subset of slides depending on their distance from the `currentSlide` should account for when the carousel is looping. For instance, if you have slides `[0][1][2][3][4][5][6][7][8]`, rearranged as `[5][6][7][8][0][1][2][3][4]`(centered around `0`), we currently render `[0][1][2][3]`. This PR adds logic so also render `[6][7][8]` in that case.

This is particularly important when we have `snap-align="center"` and `visible-count > 1`, as prior to this change we would see nothing rendered in that partial spot where the last slide should be visible.

We could alternatively measure slides and render those that are within a certain threshold of the carousel viewport, as that would generically support all cases (looping, non-looping, mixed-length) and be a bit more readable.

Related to #28284