### PR TITLE
🏗 Modernize / fix test logging during CI builds

### DIFF
--- a/build-system/tasks/e2e/index.js
+++ b/build-system/tasks/e2e/index.js
@@ -163,7 +163,6 @@ async function runTests_() {
     });
   }
 
-  log('Running tests...');
   await reportTestStarted();
 
   // return promise to gulp that resolves when there's an error.
@@ -190,7 +189,6 @@ async function runWatch_() {
   log('Watching', cyan(filesToWatch), 'for changes...');
   watch(filesToWatch).on('change', (file) => {
     log('Detected a change in', cyan(file));
-    log('Running tests...');
     const mocha = createMocha_();
     addMochaFile_(mocha, file);
     mocha.run();

--- a/build-system/tasks/e2e/mocha-dots-reporter.js
+++ b/build-system/tasks/e2e/mocha-dots-reporter.js
@@ -39,7 +39,8 @@ class MochaDotsReporter extends Base {
     super(runner);
 
     let wrapCounter = 0;
-    const wrapIfNecessary = () => {
+    const printDot = (dot) => {
+      process.stdout.write(dot);
       if (++wrapCounter >= nbDotsPerLine) {
         wrapCounter = 0;
         process.stdout.write('\n');
@@ -51,16 +52,13 @@ class MochaDotsReporter extends Base {
         log('Running tests...');
       })
       .on(EVENT_TEST_PASS, () => {
-        process.stdout.write(green(icon.success));
-        wrapIfNecessary();
+        printDot(green(icon.success));
       })
       .on(EVENT_TEST_FAIL, () => {
-        process.stdout.write(red(icon.failure));
-        wrapIfNecessary();
+        printDot(red(icon.failure));
       })
       .on(EVENT_TEST_PENDING, () => {
-        process.stdout.write(yellow(icon.ignore));
-        wrapIfNecessary();
+        printDot(yellow(icon.ignore));
       })
       .once(EVENT_RUN_END, () => {
         Base.list(this.failures);

--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -134,6 +134,7 @@ const forbiddenTerms = {
       'build-system/pr-check/visual-diff-tests.js',
       'build-system/server/app.js',
       'build-system/server/amp4test.js',
+      'build-system/tasks/e2e/mocha-dots-reporter.js',
       'build-system/tasks/build.js',
       'build-system/tasks/check-exact-versions.js',
       'build-system/tasks/check-owners.js',


### PR DESCRIPTION
During the migration to CircleCI, I discovered two problems:
- CircleCI doesn't wrap its logs, resulting in ~10k dots on one line during unit tests for example.
- New versions of Mocha have changed the reporter API, causing E2E test logging to break on CircleCI and [stall the job](https://app.circleci.com/pipelines/github/rsimha/amphtml/141/workflows/554d9f08-3e5a-4841-95b6-d29ca47561fc/jobs/539).

**This PR does two things:**
- Wraps all test logging to 150 dots per line
- Modernizes the custom reporter for e2e tests based on the latest mocha dev docs

**Passing result:** 

![image](https://user-images.githubusercontent.com/26553114/104498437-af12a200-55a9-11eb-908d-7261b376434f.png)

Also tested on CircleCI [here](https://app.circleci.com/pipelines/github/rsimha/amphtml/149/workflows/ae42212b-07e7-4c91-b7fa-f5fbaf7fb6b3/jobs/548/parallel-runs/0/steps/0-107)

**Reference:** https://mochajs.org/api/tutorial-custom-reporter.html
