### PR TITLE
video-manager-impl: remove usage of getIntersectionChangeEntry

### DIFF
--- a/src/utils/intersection.js
+++ b/src/utils/intersection.js
@@ -71,7 +71,7 @@ export function measureIntersection(el) {
 
   const inOb = getInOb(toWin(el.ownerDocument.defaultView));
   inOb.observe(el);
-
+  
   const deferred = new Deferred();
   intersectionDeferreds.set(el, deferred);
   return deferred.promise;

--- a/src/utils/intersection.js
+++ b/src/utils/intersection.js
@@ -71,7 +71,7 @@ export function measureIntersection(el) {
 
   const inOb = getInOb(toWin(el.ownerDocument.defaultView));
   inOb.observe(el);
-  
+
   const deferred = new Deferred();
   intersectionDeferreds.set(el, deferred);
   return deferred.promise;

--- a/test/unit/test-video-rotate-to-fullscreen.js
+++ b/test/unit/test-video-rotate-to-fullscreen.js
@@ -20,17 +20,16 @@ import {Services} from '../../src/services';
 describes.fakeWin('Rotate-to-fullscreen', {amp: true}, (env) => {
   let ampdoc;
   let autoFullscreenManager;
+  let ioCallback;
 
   function createVideo() {
     const element = env.win.document.createElement('div');
-    const noop = () => {};
-    Object.assign(element, {
-      getIntersectionChangeEntry: noop,
-    });
-    return {
+    const impl = {
       element,
-      signals: () => ({whenSignal: () => ({then: noop})}),
+      signals: () => ({whenSignal: () => ({then: () => {}})}),
     };
+    element.getImpl = () => Promise.resolve(impl);
+    return impl;
   }
 
   function mockCenteredVideo(element) {
@@ -42,10 +41,25 @@ describes.fakeWin('Rotate-to-fullscreen', {amp: true}, (env) => {
     env.win.screen.orientation.type = orientation;
   }
 
+  function fireIntersection({target, boundingClientRect, intersectionRatio}) {
+    ioCallback([
+      {
+        target,
+        boundingClientRect,
+        rootBounds: {},
+        intersectionRatio,
+      },
+    ]);
+  }
+
   beforeEach(() => {
     ampdoc = env.ampdoc;
     autoFullscreenManager = new AutoFullscreenManager(ampdoc);
     env.sandbox.stub(autoFullscreenManager, 'canFullscreen_').returns(true);
+    env.win.IntersectionObserver = (cb) => {
+      ioCallback = cb;
+      return {observe: () => {}, unobserve: () => {}, disconnect: () => {}};
+    };
   });
 
   it('should enter fullscreen if a video is centered in portrait', () => {
@@ -106,7 +120,7 @@ describes.fakeWin('Rotate-to-fullscreen', {amp: true}, (env) => {
     expect(exit).to.not.have.been.called;
   });
 
-  it('selects the only video playing manually amongst visible', () => {
+  it('selects the only video playing manually amongst visible', async () => {
     const video1 = createVideo();
     const video2 = createVideo();
     const video3 = createVideo();
@@ -116,28 +130,9 @@ describes.fakeWin('Rotate-to-fullscreen', {amp: true}, (env) => {
       height: 1000,
     });
 
-    env.sandbox.stub(video1.element, 'getIntersectionChangeEntry').returns({
+    const video3Entry = {
       // Visible:
-      intersectionRatio: 1,
-      boundingClientRect: {
-        top: 0,
-        bottom: 200,
-        width: 300,
-        height: 200,
-      },
-    });
-    env.sandbox.stub(video2.element, 'getIntersectionChangeEntry').returns({
-      // Visible:
-      intersectionRatio: 1,
-      boundingClientRect: {
-        top: 200,
-        bottom: 400,
-        width: 300,
-        height: 200,
-      },
-    });
-    env.sandbox.stub(video3.element, 'getIntersectionChangeEntry').returns({
-      // Visible:
+      target: video3.element,
       intersectionRatio: 1,
       boundingClientRect: {
         top: 400,
@@ -145,7 +140,7 @@ describes.fakeWin('Rotate-to-fullscreen', {amp: true}, (env) => {
         width: 300,
         height: 200,
       },
-    });
+    };
 
     const getPlayingState = env.sandbox.stub(
       autoFullscreenManager,
@@ -160,12 +155,12 @@ describes.fakeWin('Rotate-to-fullscreen', {amp: true}, (env) => {
     autoFullscreenManager.register({video: video2});
     autoFullscreenManager.register({video: video3});
 
-    expect(autoFullscreenManager.selectBestCenteredInPortrait_()).to.equal(
-      video3
-    );
+    const bestCenteredPromise = autoFullscreenManager.selectBestCenteredInPortrait_();
+    fireIntersection(video3Entry);
+    expect(await bestCenteredPromise).equal(video3);
   });
 
-  it('selects center-most video among those visible and playing', () => {
+  it('selects center-most video among those visible and playing', async () => {
     const video1 = createVideo();
     const video2 = createVideo();
     const video3 = createVideo();
@@ -175,8 +170,9 @@ describes.fakeWin('Rotate-to-fullscreen', {amp: true}, (env) => {
       height: 600,
     });
 
-    env.sandbox.stub(video1.element, 'getIntersectionChangeEntry').returns({
+    const video1Entry = {
       // Visible:
+      target: video1.element,
       intersectionRatio: 1,
       boundingClientRect: {
         top: 0,
@@ -184,9 +180,10 @@ describes.fakeWin('Rotate-to-fullscreen', {amp: true}, (env) => {
         width: 300,
         height: 200,
       },
-    });
-    env.sandbox.stub(video2.element, 'getIntersectionChangeEntry').returns({
+    };
+    const video2Entry = {
       // Visible:
+      target: video2.element,
       intersectionRatio: 1,
       boundingClientRect: {
         top: 200,
@@ -194,9 +191,10 @@ describes.fakeWin('Rotate-to-fullscreen', {amp: true}, (env) => {
         width: 300,
         height: 200,
       },
-    });
-    env.sandbox.stub(video3.element, 'getIntersectionChangeEntry').returns({
+    };
+    const video3Entry = {
       // Visible:
+      target: video3.element,
       intersectionRatio: 1,
       boundingClientRect: {
         top: 400,
@@ -204,7 +202,7 @@ describes.fakeWin('Rotate-to-fullscreen', {amp: true}, (env) => {
         width: 300,
         height: 200,
       },
-    });
+    };
 
     const getPlayingState = env.sandbox.stub(
       autoFullscreenManager,
@@ -219,12 +217,12 @@ describes.fakeWin('Rotate-to-fullscreen', {amp: true}, (env) => {
     autoFullscreenManager.register({video: video2});
     autoFullscreenManager.register({video: video3});
 
-    expect(autoFullscreenManager.selectBestCenteredInPortrait_()).to.equal(
-      video2
-    );
+    const bestCenteredPromise = autoFullscreenManager.selectBestCenteredInPortrait_();
+    [video1Entry, video2Entry, video3Entry].forEach(fireIntersection);
+    expect(await bestCenteredPromise).to.equal(video2);
   });
 
-  it('selects top-most video if two videos are equally centered', () => {
+  it('selects top-most video if two videos are equally centered', async () => {
     const video1 = createVideo();
     const video2 = createVideo();
 
@@ -233,8 +231,9 @@ describes.fakeWin('Rotate-to-fullscreen', {amp: true}, (env) => {
       height: 400,
     });
 
-    env.sandbox.stub(video1.element, 'getIntersectionChangeEntry').returns({
+    const video1Entry = {
       // Visible:
+      target: video1.element,
       intersectionRatio: 1,
       boundingClientRect: {
         top: 0,
@@ -242,9 +241,10 @@ describes.fakeWin('Rotate-to-fullscreen', {amp: true}, (env) => {
         width: 300,
         height: 200,
       },
-    });
-    env.sandbox.stub(video2.element, 'getIntersectionChangeEntry').returns({
+    };
+    const video2Entry = {
       // Visible:
+      target: video2.element,
       intersectionRatio: 1,
       boundingClientRect: {
         top: 200,
@@ -252,7 +252,7 @@ describes.fakeWin('Rotate-to-fullscreen', {amp: true}, (env) => {
         width: 300,
         height: 200,
       },
-    });
+    };
 
     const getPlayingState = env.sandbox.stub(
       autoFullscreenManager,
@@ -265,12 +265,12 @@ describes.fakeWin('Rotate-to-fullscreen', {amp: true}, (env) => {
     autoFullscreenManager.register({video: video1});
     autoFullscreenManager.register({video: video2});
 
-    expect(autoFullscreenManager.selectBestCenteredInPortrait_()).to.equal(
-      video1
-    );
+    const bestCenteredPromise = autoFullscreenManager.selectBestCenteredInPortrait_();
+    [video1Entry, video2Entry].forEach(fireIntersection);
+    expect(await bestCenteredPromise).to.equal(video1);
   });
 
-  it('selects the highest intersection ratio if two videos are visible', () => {
+  it('selects the highest intersection ratio if two videos are visible', async () => {
     const video1 = createVideo();
     const video2 = createVideo();
 
@@ -279,7 +279,8 @@ describes.fakeWin('Rotate-to-fullscreen', {amp: true}, (env) => {
       height: 400,
     });
 
-    env.sandbox.stub(video1.element, 'getIntersectionChangeEntry').returns({
+    const video1Entry = {
+      target: video1.element,
       intersectionRatio: 0.9,
       boundingClientRect: {
         top: -30,
@@ -287,9 +288,10 @@ describes.fakeWin('Rotate-to-fullscreen', {amp: true}, (env) => {
         width: 300,
         height: 200,
       },
-    });
-    env.sandbox.stub(video2.element, 'getIntersectionChangeEntry').returns({
+    };
+    const video2Entry = {
       // Visible:
+      target: video2.element,
       intersectionRatio: 1,
       boundingClientRect: {
         top: 200,
@@ -297,7 +299,7 @@ describes.fakeWin('Rotate-to-fullscreen', {amp: true}, (env) => {
         width: 300,
         height: 200,
       },
-    });
+    };
 
     const getPlayingState = env.sandbox.stub(
       autoFullscreenManager,
@@ -310,8 +312,8 @@ describes.fakeWin('Rotate-to-fullscreen', {amp: true}, (env) => {
     autoFullscreenManager.register({video: video1});
     autoFullscreenManager.register({video: video2});
 
-    expect(autoFullscreenManager.selectBestCenteredInPortrait_()).to.equal(
-      video2
-    );
+    const bestCenteredPromise = autoFullscreenManager.selectBestCenteredInPortrait_();
+    [video1Entry, video2Entry].forEach(fireIntersection);
+    expect(await bestCenteredPromise).to.equal(video2);
   });
 });


### PR DESCRIPTION
**summary**
Partial for https://github.com/ampproject/amphtml/issues/31540

- [x] measure in `scrollIntoIfNotVisible_`
- [x] measure for determining most centered video in `selectBestCenteredInPortrait_ `
- [x] Update tests

Note: besides for the ads initialIntersection experiment, this is the last usage of `getIntersectionChangeEntry`