### PR TITLE
🏗 Updates to VM setup during CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,6 @@ notifications:
     on_success: change
     on_failure: change
 before_install:
-  # Override Xenial's default Java version (github.com/travis-ci/travis-ci/issues/10290)
-  - export PATH=$(echo "$PATH" | sed -e 's/:\/usr\/local\/lib\/jvm\/openjdk11\/bin//')
-  - export JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64
   # Ensure python v2 and v3 are available, and "python" defaults to v3 (docs.travis-ci.com/user/reference/xenial/#python-support)
   - pyenv global 3.6.7 2.7.15
   - python3 --version
@@ -19,6 +16,12 @@ before_install:
   - python --version
   # Xenial's version of python-protobuf is outdated (github.com/ampproject/amphtml/pull/22528)
   - pip3 install --user protobuf
+  # Setup Google Cloud Storage
+  - openssl aes-256-cbc -md sha256 -k $GCP_TOKEN -in build-system/common/sa-travis-key.json.enc -out sa-travis-key.json -d
+  - gcloud auth activate-service-account --key-file=sa-travis-key.json
+  - gcloud config set account sa-travis@amp-travis-build-storage.iam.gserviceaccount.com
+  - gcloud config set pass_credentials_to_gsutil true
+  - gcloud config set project amp-travis-build-storage
 branches:
   only:
     - master

--- a/build-system/pr-check/utils.js
+++ b/build-system/pr-check/utils.js
@@ -43,13 +43,7 @@ const BUILD_OUTPUT_DIRS = 'build/ dist/ dist.3p/';
 const APP_SERVING_DIRS = 'dist.tools/ examples/ test/manual/';
 
 // TODO(rsimha, ampproject/amp-github-apps#1110): Update storage details.
-const OUTPUT_STORAGE_LOCATION = 'gs://amp-travis-builds';
-const OUTPUT_STORAGE_KEY_FILE = 'sa-travis-key.json';
-const OUTPUT_STORAGE_PROJECT_ID = 'amp-travis-build-storage';
-const OUTPUT_STORAGE_SERVICE_ACCOUNT =
-  'sa-travis@amp-travis-build-storage.iam.gserviceaccount.com';
-
-const GCLOUD_LOGGING_FLAGS = '--quiet --verbosity error';
+const GCLOUD_STORAGE_BUCKET = 'gs://amp-travis-builds';
 
 const GIT_BRANCH_URL =
   'https://github.com/ampproject/amphtml/blob/master/contributing/getting-started-e2e.md#create-a-git-branch';
@@ -220,7 +214,7 @@ const timedExecOrThrow = timedExecFn(execOrThrow);
  */
 function downloadOutput_(functionName, outputFileName, outputDirs) {
   const fileLogPrefix = colors.bold(colors.yellow(`${functionName}:`));
-  const buildOutputDownloadUrl = `${OUTPUT_STORAGE_LOCATION}/${outputFileName}`;
+  const buildOutputDownloadUrl = `${GCLOUD_STORAGE_BUCKET}/${outputFileName}`;
   const dirsToUnzip = outputDirs.split(' ');
 
   console.log(
@@ -228,8 +222,7 @@ function downloadOutput_(functionName, outputFileName, outputDirs) {
       colors.cyan(buildOutputDownloadUrl) +
       '...'
   );
-  authenticateWithStorageLocation_();
-  execOrDie(`gsutil cp ${buildOutputDownloadUrl} ${outputFileName}`);
+  execOrDie(`gsutil -q cp ${buildOutputDownloadUrl} ${outputFileName}`);
 
   console.log(
     `${fileLogPrefix} Extracting ` + colors.cyan(outputFileName) + '...'
@@ -264,27 +257,10 @@ function uploadOutput_(functionName, outputFileName, outputDirs) {
     `${fileLogPrefix} Uploading ` +
       colors.cyan(outputFileName) +
       ' to ' +
-      colors.cyan(OUTPUT_STORAGE_LOCATION) +
+      colors.cyan(GCLOUD_STORAGE_BUCKET) +
       '...'
   );
-  authenticateWithStorageLocation_();
-  execOrDie(`gsutil -m cp -r ${outputFileName} ${OUTPUT_STORAGE_LOCATION}`);
-}
-
-function authenticateWithStorageLocation_() {
-  decryptTravisKey_();
-  execOrDie(
-    `gcloud auth activate-service-account --key-file ${OUTPUT_STORAGE_KEY_FILE} ${GCLOUD_LOGGING_FLAGS}`
-  );
-  execOrDie(
-    `gcloud config set account ${OUTPUT_STORAGE_SERVICE_ACCOUNT} ${GCLOUD_LOGGING_FLAGS}`
-  );
-  execOrDie(
-    `gcloud config set pass_credentials_to_gsutil true ${GCLOUD_LOGGING_FLAGS}`
-  );
-  execOrDie(
-    `gcloud config set project ${OUTPUT_STORAGE_PROJECT_ID} ${GCLOUD_LOGGING_FLAGS}`
-  );
+  execOrDie(`gsutil -q -m cp -r ${outputFileName} ${GCLOUD_STORAGE_BUCKET}`);
 }
 
 /**
@@ -347,20 +323,6 @@ async function processAndUploadNomoduleOutput(functionName) {
   await replaceUrls('examples');
   uploadNomoduleOutput(functionName);
   await signalDistUpload('success');
-}
-
-/**
- * Decrypts key used by storage service account
- */
-function decryptTravisKey_() {
-  // -md sha256 is required due to encryption differences between
-  // openssl 1.1.1a, which was used to encrypt the key, and
-  // openssl 1.0.2g, which is used by Travis to decrypt.
-  execOrDie(
-    `openssl aes-256-cbc -md sha256 -k ${process.env.GCP_TOKEN} -in ` +
-      `build-system/common/sa-travis-key.json.enc -out ` +
-      `${OUTPUT_STORAGE_KEY_FILE} -d`
-  );
 }
 
 module.exports = {


### PR DESCRIPTION
A few updates to VM setup in anticipation of the move to CircleCI:

- Move Travis specific steps from `build-system/pr-check/utils.js` to `.travis.yml`
- Remove Java setup steps (no longer needed because we use native closure compiler)
- Make `gsutil` upload / download less verbose with `-q` (the ASCII spinner doesn't work on non-TTY consoles)

This paves the way to setup CircleCI VMs using a different (more streamlined) set of steps, and use a different storage bucket if desired.