### PR TITLE
🐛 [amp-base-carousel 0.1] Observe amp elements from child layout manager

### DIFF
--- a/extensions/amp-base-carousel/0.1/child-layout-manager.js
+++ b/extensions/amp-base-carousel/0.1/child-layout-manager.js
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import { isAmpElement } from '../../../src/dom';
 import {Services} from '../../../src/services';
+import {isAmpElement} from '../../../src/dom';
 
 /**
  * Used for tracking whether or not an item is near the viewport. This is set
@@ -268,7 +268,7 @@ export class ChildLayoutManager {
       })
       .forEach((entry) => {
         let {target} = entry;
-        // Change the flag for the parent if it's the first time 
+        // Change the flag for the parent if it's the first time
         // the underlying AMP element is nearing viewport & unobserve.
         if (
           target.hasAttribute(SLIDE_ID) &&
@@ -300,13 +300,8 @@ export class ChildLayoutManager {
         return !isIntersecting;
       })
       .forEach((entry) => {
-        let {target} = entry;
-        if (
-          !target.hasAttribute(SLIDE_ID) ||
-          !this.underlyingAmpElementParent_[target.getAttribute(SLIDE_ID)]
-        ) {
-          target[NEAR_VIEWPORT_FLAG] = ViewportChangeState.LEAVE;
-        }
+        const {target} = entry;
+        target[NEAR_VIEWPORT_FLAG] = ViewportChangeState.LEAVE;
       });
 
     if (!this.queueChanges_) {
@@ -439,7 +434,7 @@ export class ChildLayoutManager {
 
   /**
    * @param {Element} element
-   * @param {boolean} opt_onlyNearingViewport
+   * @param {boolean=} opt_onlyNearingViewport
    */
   observeElement_(element, opt_onlyNearingViewport = false) {
     this.nearingViewportObserver_.observe(element);

--- a/extensions/amp-base-carousel/0.1/child-layout-manager.js
+++ b/extensions/amp-base-carousel/0.1/child-layout-manager.js
@@ -169,7 +169,7 @@ export class ChildLayoutManager {
     this.inViewportObserver_ = null;
 
     /** @private {!JsonObject<string, Element>} */
-    this.underlyingAmpElementParent_ = {};
+    this.slideElementMap_ = {};
 
     /** @private {boolean} */
     this.laidOut_ = false;
@@ -268,15 +268,18 @@ export class ChildLayoutManager {
       })
       .forEach((entry) => {
         let {target} = entry;
-        // Change the flag for the parent if it's the first time
-        // the underlying AMP element is nearing viewport & unobserve.
+        // Check if the target is an AMP element--the child of a slide.
+        // If it is an AMP element, then make sure the nearing viewport 
+        // flag for the parent is on. 
+        // Then unobserve the AMP element.
+        // Otherwise, mark the slide as nearing the viewport.
         if (
           target.hasAttribute(SLIDE_ID) &&
-          this.underlyingAmpElementParent_[target.getAttribute(SLIDE_ID)] &&
+          this.slideElementMap_[target.getAttribute(SLIDE_ID)] &&
           isAmpElement(target)
         ) {
           this.nearingViewportObserver_.unobserve(target);
-          target = this.underlyingAmpElementParent_[
+          target = this.slideElementMap_[
             target.getAttribute(SLIDE_ID)
           ];
         }
@@ -416,7 +419,7 @@ export class ChildLayoutManager {
           }
           const id = child.getAttribute(SLIDE_ID);
           ampElement.setAttribute(SLIDE_ID, id);
-          this.underlyingAmpElementParent_[id] = child;
+          this.slideElementMap_[id] = child;
           // Only need to observe nearing AMP elements whose layout
           // may not have been scheduled initially (otherwise,
           // slide child will not be scheduled).
@@ -456,7 +459,7 @@ export class ChildLayoutManager {
       return;
     }
 
-    this.underlyingAmpElementParent_ = {};
+    this.slideElementMap_ = {};
     for (let i = 0; i < this.children_.length; i++) {
       this.children_[i].setAttribute(SLIDE_ID, `${i}`);
       this.owners_.setOwner(this.children_[i], this.ampElement_.element);

--- a/extensions/amp-base-carousel/0.1/test-e2e/test-observe-amp-elements.js
+++ b/extensions/amp-base-carousel/0.1/test-e2e/test-observe-amp-elements.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {getNextArrow, getPrevArrow, getSlideChild, sleep} from './helpers';
+import {sleep} from './helpers';
 
 const pageWidth = 600;
 const pageHeight = 800;
@@ -35,7 +35,9 @@ describes.endtoend(
     });
 
     it('should render image after resize', async () => {
-      const imageOne = await controller.findElement('amp-img#slide-1-desktop-image');
+      const imageOne = await controller.findElement(
+        'amp-img#slide-1-desktop-image'
+      );
       let imageOneRect = await controller.getElementRect(imageOne);
 
       // Assert image not seen
@@ -54,13 +56,19 @@ describes.endtoend(
     });
 
     // Test slide 2 (go back)
-    it.only('should swap between images on resize', async () => {
-      const ampCarouselNextButton = await controller.findElement('.amp-carousel-button.amp-carousel-button-next');
+    it('should swap between images on resize', async () => {
+      const ampCarouselNextButton = await controller.findElement(
+        '.amp-carousel-button.amp-carousel-button-next'
+      );
       await controller.click(ampCarouselNextButton);
       await sleep(500);
 
-      const imageOne = await controller.findElement('amp-img#slide-2-desktop-image');
-      const imageTwo = await controller.findElement('amp-img#slide-2-mobile-image');
+      const imageOne = await controller.findElement(
+        'amp-img#slide-2-desktop-image'
+      );
+      const imageTwo = await controller.findElement(
+        'amp-img#slide-2-mobile-image'
+      );
       let imageOneRect = await controller.getElementRect(imageOne);
       let imageTwoRect = await controller.getElementRect(imageTwo);
 

--- a/extensions/amp-base-carousel/0.1/test-e2e/test-observe-amp-elements.js
+++ b/extensions/amp-base-carousel/0.1/test-e2e/test-observe-amp-elements.js
@@ -1,0 +1,86 @@
+/**
+ * Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {getNextArrow, getPrevArrow, getSlideChild, sleep} from './helpers';
+
+const pageWidth = 600;
+const pageHeight = 800;
+
+describes.endtoend(
+  'AMP carousel observe AMP elements',
+  {
+    testUrl:
+      'http://localhost:8000/test/manual/amp-base-carousel/mediaQueryAmpElements.amp.html',
+    environments: ['single'],
+    initialRect: {width: pageWidth, height: pageHeight},
+  },
+  async (env) => {
+    let controller;
+
+    beforeEach(async () => {
+      controller = env.controller;
+    });
+
+    it('should render image after resize', async () => {
+      const imageOne = await controller.findElement('amp-img#slide-1-desktop-image');
+      let imageOneRect = await controller.getElementRect(imageOne);
+
+      // Assert image not seen
+      await expect(imageOneRect['width']).to.equal(0);
+
+      await controller.setWindowRect({
+        width: 800,
+        height: 600,
+      });
+
+      await sleep(500);
+
+      // Assert image seen
+      imageOneRect = await controller.getElementRect(imageOne);
+      await expect(imageOneRect['width']).to.be.greaterThan(0);
+    });
+
+    // Test slide 2 (go back)
+    it.only('should swap between images on resize', async () => {
+      const ampCarouselNextButton = await controller.findElement('.amp-carousel-button.amp-carousel-button-next');
+      await controller.click(ampCarouselNextButton);
+      await sleep(500);
+
+      const imageOne = await controller.findElement('amp-img#slide-2-desktop-image');
+      const imageTwo = await controller.findElement('amp-img#slide-2-mobile-image');
+      let imageOneRect = await controller.getElementRect(imageOne);
+      let imageTwoRect = await controller.getElementRect(imageTwo);
+
+      // Assert mobile seen, not desktop
+      await expect(imageOneRect['width']).to.equal(0);
+      await expect(imageTwoRect['width']).to.greaterThan(0);
+
+      // Resize
+      await controller.setWindowRect({
+        width: 800,
+        height: 600,
+      });
+
+      // Assert desktop seen, not mobile
+      await sleep(500);
+      imageOneRect = await controller.getElementRect(imageOne);
+      imageTwoRect = await controller.getElementRect(imageTwo);
+
+      await expect(imageOneRect['width']).to.greaterThan(0);
+      await expect(imageTwoRect['width']).to.equal(0);
+    });
+  }
+);

--- a/extensions/amp-base-carousel/0.1/test/test-child-layout-manager.js
+++ b/extensions/amp-base-carousel/0.1/test/test-child-layout-manager.js
@@ -174,7 +174,7 @@ describes.realWin('child layout manager', {}, (env) => {
     return el.children;
   }
 
-    /**
+  /**
    *
    * @param {!Element} el
    * @param {number} childCount

--- a/extensions/amp-base-carousel/0.1/test/test-child-layout-manager.js
+++ b/extensions/amp-base-carousel/0.1/test/test-child-layout-manager.js
@@ -386,7 +386,6 @@ describes.realWin('child layout manager', {}, (env) => {
       clm.wasLaidOut();
       await afterRenderPromise();
 
-      console.debug(observeElementSpy.args);
       expect(observeElementSpy.args.length).to.equal(5 + 2 + 3 + 3);
 
       // Expect first 3 args to be the nested amp-elements

--- a/src/service/owners-impl.js
+++ b/src/service/owners-impl.js
@@ -144,18 +144,17 @@ export class OwnersImpl {
     });
   }
 
-  /**
-   * @param {!Element} element
-   * @param {function(!Resource)} callback
-   */
-  discoverResourcesForElement_(element, callback) {
+  /** @override */
+  findClosestAmpElements(element, callback, findPlaceholder) {
     // Breadth-first search.
     if (element.classList.contains('i-amphtml-element')) {
-      callback(this.resources_.getResourceForElement(element));
+      callback(element);
       // Also schedule amp-element that is a placeholder for the element.
-      const placeholder = element.getPlaceholder();
-      if (placeholder) {
-        this.discoverResourcesForElement_(placeholder, callback);
+      if (findPlaceholder) {
+        const placeholder = element.getPlaceholder();
+        if (placeholder) {
+          this.findClosestAmpElements(placeholder, callback, findPlaceholder);
+        }
       }
     } else {
       const ampElements = element.getElementsByClassName('i-amphtml-element');
@@ -171,10 +170,23 @@ export class OwnersImpl {
         }
         if (!covered) {
           seen.push(ampElement);
-          callback(this.resources_.getResourceForElement(ampElement));
+          callback(ampElement);
         }
       }
     }
+  }
+
+  /**
+   * @param {!Element} element
+   * @param {function(!Resource)} callback
+   */
+  discoverResourcesForElement_(element, callback) {
+    this.findClosestAmpElements(
+      element,
+      (ampElement) =>
+        callback(this.resources_.getResourceForElement(ampElement)),
+      true
+    );
   }
 
   /**

--- a/src/service/owners-interface.js
+++ b/src/service/owners-interface.js
@@ -84,5 +84,13 @@ export class OwnersInterface {
    * @return {!Promise}
    */
   requireLayout(element, opt_parentPriority) {}
+
+  /**
+   * Finds closest underlying AMP elements and executes the callback.
+   * @param {!Element} element
+   * @param {function(!AmpElement)} callback
+   * @param {boolean} findPlaceholder
+   */
+  findClosestAmpElements(element, callback, findPlaceholder) {}
 }
 /* eslint-enable no-unused-vars */

--- a/test/manual/amp-base-carousel/mediaQueryAmpElements.amp.html
+++ b/test/manual/amp-base-carousel/mediaQueryAmpElements.amp.html
@@ -20,6 +20,12 @@
     <div id="slide-3">
       <amp-img id="slide-3-both-image" src="./img/bluegradient.png" layout="fill"></amp-img>
     </div>
+    <amp-img id="slide-4-desktop-image" media="(min-width:650px)" src="./img/tealgradient.png" layout="fill"></amp-img>
+    <div id="slide-5">
+      <!-- first should show on mobile, second image should show on desktop -->
+      <amp-img id="slide-5-desktop-image" media="(min-width:650px)" src="./img/redgradient.png" layout="fill"></amp-img>
+      <amp-img id="slide-5-mobile-image" media="(max-width:649px)" src="./img/greengradient.png" layout="fill"></amp-img>
+    </div>
   </amp-carousel>
 </body>
 </html>

--- a/test/manual/amp-base-carousel/mediaQueryAmpElements.amp.html
+++ b/test/manual/amp-base-carousel/mediaQueryAmpElements.amp.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>My AMP Page</title>
+  <link rel="canonical" href="self.html" />
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async custom-element="amp-carousel" src="https://cdn.ampproject.org/v0/amp-carousel-0.2.js"></script>
+</head>
+<body>  
+  <amp-carousel controls width="450" height="300" type="slides" role="region" aria-label="Basic carousel">
+    <amp-img id="slide-1-desktop-image" media="(min-width:650px)" src="./img/tealgradient.png" layout="fill"></amp-img>
+    <div id="slide-2">
+      <!-- first should show on mobile, second image should show on desktop -->
+      <amp-img id="slide-2-desktop-image" media="(min-width:650px)" src="./img/redgradient.png" layout="fill"></amp-img>
+      <amp-img id="slide-2-mobile-image" media="(max-width:649px)" src="./img/greengradient.png" layout="fill"></amp-img>
+    </div>
+    <div id="slide-3">
+      <amp-img id="slide-3-both-image" src="./img/bluegradient.png" layout="fill"></amp-img>
+    </div>
+  </amp-carousel>
+</body>
+</html>

--- a/test/unit/test-owners.js
+++ b/test/unit/test-owners.js
@@ -60,8 +60,9 @@ describes.realWin(
       );
     });
 
-    function createElement() {
+    function createElement(id) {
       const element = env.createAmpElement('amp-test');
+      element.id = id;
       env.sandbox.stub(element, 'isUpgraded').returns(true);
       return element;
     }
@@ -70,7 +71,7 @@ describes.realWin(
       id,
       state = ResourceState.LAYOUT_COMPLETE
     ) {
-      const element = createElement();
+      const element = createElement(id);
       const resource = new Resource(id, element, resources);
       resource.state_ = state;
       env.sandbox.stub(resource, 'measure').callsFake(() => {
@@ -372,6 +373,30 @@ describes.realWin(
         const scheduledElements = await owners.requireLayout(parent);
         expect(scheduledElements).to.have.length(1);
         expect(scheduleLayoutOrPreloadStub).to.not.be.called;
+      });
+    });
+
+    describe('findClosestAmpElements', () => {
+      it('should find all closest AMP elements', async () => {
+        const callbackSpy = env.sandbox.spy();
+        const newParent = doc.createElement('div');
+
+        owners.findClosestAmpElements(parent, callbackSpy);
+        expect(callbackSpy).to.be.calledOnce;
+        expect(callbackSpy.args[0][0]).to.equal(parent);
+        callbackSpy.resetHistory();
+
+        newParent.appendChild(parent);
+        owners.findClosestAmpElements(newParent, callbackSpy);
+        expect(callbackSpy).to.be.calledOnce;
+        expect(callbackSpy.args[0][0]).to.equal(parent);
+        callbackSpy.resetHistory();
+
+        // <div>
+        owners.findClosestAmpElements(children[0], callbackSpy);
+        expect(callbackSpy).to.be.calledTwice;
+        expect(callbackSpy.args[0][0]).to.equal(children[3]);
+        expect(callbackSpy.args[1][0]).to.equal(children[4]);
       });
     });
   }


### PR DESCRIPTION
Closes #30719

For amp elements whose layout is not initially scheduled by `amp-base-carousel`, due to media query, when the carousel is resized, the amp element does not get laid out due to the IntersectionObserver observing the parent wrapper, rather than the amp element itself.

To fix this, we will now observe the nearest amp element in the slide for when it is "nearing" the viewport. If the InOb fires, we we schedule the layout for that parent wrapper (and thus the underlying amp element). Then we stop observing the amp element (as to not continually schedule layouts). 

We are adding extra work for the nearing observer, but only once--we are not adding any duplicate layout scheduling. 

/cc @caroqliu For bento carousel