### PR TITLE
🔥 Fix runtime styles in ESM mode

### DIFF
--- a/build-system/babel-config/pre-closure-config.js
+++ b/build-system/babel-config/pre-closure-config.js
@@ -29,16 +29,6 @@ function getPreClosureConfig() {
   const isTestTask = testTasks.some((task) => argv._.includes(task));
   const isFortesting = argv.fortesting || isTestTask;
 
-  const filterImportsPlugin = [
-    'filter-imports',
-    {
-      imports: {
-        // Imports that are not needed for valid transformed documents.
-        '../build/ampshared.css': ['cssText', 'ampSharedCss'],
-        '../build/ampdoc.css': ['cssText', 'ampDocCss'],
-      },
-    },
-  ];
   const reactJsxPlugin = [
     '@babel/plugin-transform-react-jsx',
     {
@@ -76,7 +66,6 @@ function getPreClosureConfig() {
     './build-system/babel-plugins/babel-plugin-transform-default-assignment',
     replacePlugin,
     './build-system/babel-plugins/babel-plugin-transform-amp-asserts',
-    argv.esm || argv.sxg ? filterImportsPlugin : null,
     // TODO(erwinm, #28698): fix this in fixit week
     // argv.esm
     //? './build-system/babel-plugins/babel-plugin-transform-function-declarations'

--- a/build-system/compile/compile.js
+++ b/build-system/compile/compile.js
@@ -172,11 +172,6 @@ function compile(
     if (options.include3pDirectories) {
       srcs.push('3p/**/*.js', 'ads/**/*.js');
     }
-    // For ESM Builds, exclude ampdoc and ampshared css from inclusion.
-    // These styles are guaranteed to already be present on elgible documents.
-    if (options.esmPassCompilation) {
-      srcs.push('!build/ampdoc.css.js', '!build/ampshared.css.js');
-    }
     // Many files include the polyfills, but we only want to deliver them
     // once. Since all files automatically wait for the main binary to load
     // this works fine.

--- a/package-lock.json
+++ b/package-lock.json
@@ -6096,16 +6096,6 @@
         }
       }
     },
-    "babel-plugin-filter-imports": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-filter-imports/-/babel-plugin-filter-imports-4.0.0.tgz",
-      "integrity": "sha512-jDLlxI8QnfKd7PtieH6pl4tZJzymzfCDCPGdTq/grgbiYAikwDPp/oL0IlFJn0HQjLpcLkyYhPKkUVneRESw5w==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "^7.7.2",
-        "lodash": "^4.17.15"
-      }
-    },
     "babel-plugin-istanbul": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "ast-replace": "1.1.3",
     "atob": "2.1.2",
     "autoprefixer": "10.2.1",
-    "babel-plugin-filter-imports": "4.0.0",
     "babel-plugin-istanbul": "6.0.0",
     "babel-plugin-minify-replace": "0.5.0",
     "babelify": "10.0.0",

--- a/src/friendly-iframe-embed.js
+++ b/src/friendly-iframe-embed.js
@@ -756,11 +756,12 @@ export class Installers {
       .then(getDelayPromise)
       .then(() => {
         if (IS_ESM) {
-          const css = parentWin.document.querySelector('style[amp-runtime]')
-            .textContent;
+          // TODO: This is combined (ampdoc + shared), not just shared
+          // const css = parentWin.document.querySelector('style[amp-runtime]')
+          // .textContent;
           installStylesForDoc(
             ampdoc,
-            css,
+            ampSharedCss,
             /* callback */ null,
             /* opt_isRuntimeCss */ true,
             /* opt_ext */ 'amp-runtime'

--- a/src/inabox/amp-inabox.js
+++ b/src/inabox/amp-inabox.js
@@ -84,6 +84,7 @@ startupChunk(self.document, function initial() {
   self.document.documentElement.classList.add('i-amphtml-inabox');
   installStylesForDoc(
     ampdoc,
+    // TODO: Can this be eliminated in ESM mode?
     ampSharedCss +
       'html.i-amphtml-inabox{width:100%!important;height:100%!important}',
     () => {

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -394,7 +394,14 @@ function adoptServicesAndResources(global) {
  */
 function adoptMultiDocDeps(global) {
   global.AMP.installAmpdocServices = installAmpdocServices.bind(null);
-  global.AMP.combinedCss = ampDocCss + ampSharedCss;
+  if (IS_ESM) {
+    // The runtime styles always come before the runtime JS, so this should work.
+    global.AMP.combinedCss = global.document.querySelector(
+      'style[amp-runtime]'
+    ).textContent;
+  } else {
+    global.AMP.combinedCss = ampDocCss + ampSharedCss;
+  }
 }
 
 /**

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -394,7 +394,7 @@ function adoptServicesAndResources(global) {
  */
 function adoptMultiDocDeps(global) {
   global.AMP.installAmpdocServices = installAmpdocServices.bind(null);
-  if (IS_ESM) {
+  if (IS_ESM && getMode().minified) {
     // The runtime styles always come before the runtime JS, so this should work.
     global.AMP.combinedCss = global.document.querySelector(
       'style[amp-runtime]'

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -394,11 +394,9 @@ function adoptServicesAndResources(global) {
  */
 function adoptMultiDocDeps(global) {
   global.AMP.installAmpdocServices = installAmpdocServices.bind(null);
-  if (IS_ESM && getMode().minified) {
-    // The runtime styles always come before the runtime JS, so this should work.
-    global.AMP.combinedCss = global.document.querySelector(
-      'style[amp-runtime]'
-    ).textContent;
+  if (IS_ESM) {
+    const style = global.document.querySelector('style[amp-runtime]');
+    global.AMP.combinedCss = style ? style.textContent : '';
   } else {
     global.AMP.combinedCss = ampDocCss + ampSharedCss;
   }


### PR DESCRIPTION
This fixes several issues:

1. AMP Shadow (amp-next-page) uses `AMP.combinedCss`, which is the combined `ampdoc.css` + `ampshared.css`.
   - In ESM mode, this property was `undefined` because we stripped the imports. It's now the `textContent` of `<style amp-runtime>`.
2. Re-adds `ampshared.css` to inabox
   - The import was removed, so it became just the string `'html.i-amphtml-inabox{width:100%!important;height:100%!important}'`
   - It's unclear whether inabox can run without it.
3. Fixes FIE to only inject `ampshared.css`
   - This was changed in #22418, and we essentially undid it.
   - `<style amp-runtime>` is the **combined** css, not just shared css

And it removes `filter-imports` babel plugin. [Have I mentioned how much I disliked it before](https://github.com/ampproject/amphtml/pull/28825)?