### PR TITLE
🏗 Update CI build / job identifiers

### DIFF
--- a/build-system/common/ci.js
+++ b/build-system/common/ci.js
@@ -157,16 +157,16 @@ function ciCommitSha() {
 }
 
 /**
- * Returns the number of the current build.
+ * Returns the ID of the current build.
  * @return {string}
  */
-function ciBuildNumber() {
+function ciBuildId() {
   return isTravis
     ? env('TRAVIS_BUILD_NUMBER')
     : isGithubActions
     ? env('GITHUB_RUN_ID')
     : isCircleci
-    ? env('CIRCLE_BUILD_NUM')
+    ? env('CIRCLE_WORKFLOW_ID')
     : '';
 }
 
@@ -185,10 +185,10 @@ function ciBuildUrl() {
 }
 
 /**
- * Returns the number of the current job.
+ * Returns the ID of the current job.
  * @return {string}
  */
-function ciJobNumber() {
+function ciJobId() {
   return isTravis
     ? env('TRAVIS_JOB_NUMBER')
     : isGithubActions
@@ -228,10 +228,10 @@ function ciRepoSlug() {
 }
 
 module.exports = {
-  ciBuildNumber,
+  ciBuildId,
   ciBuildUrl,
   ciCommitSha,
-  ciJobNumber,
+  ciJobId,
   ciJobUrl,
   ciPullRequestBranch,
   ciPullRequestSha,

--- a/build-system/pr-check/utils.js
+++ b/build-system/pr-check/utils.js
@@ -26,18 +26,12 @@ const {
   shortSha,
 } = require('../common/git');
 const {execOrDie, execOrThrow, execWithError, exec} = require('../common/exec');
-const {isCiBuild, ciBuildNumber, ciPullRequestSha} = require('../common/ci');
+const {isCiBuild, ciBuildId, ciPullRequestSha} = require('../common/ci');
 const {replaceUrls, signalDistUpload} = require('../tasks/pr-deploy-bot-utils');
 
-const UNMINIFIED_OUTPUT_FILE = isCiBuild()
-  ? `amp_unminified_${ciBuildNumber()}.zip`
-  : '';
-const NOMODULE_OUTPUT_FILE = isCiBuild()
-  ? `amp_nomodule_${ciBuildNumber()}.zip`
-  : '';
-const MODULE_OUTPUT_FILE = isCiBuild()
-  ? `amp_module_${ciBuildNumber()}.zip`
-  : '';
+const UNMINIFIED_OUTPUT_FILE = `amp_unminified_${ciBuildId()}.zip`;
+const NOMODULE_OUTPUT_FILE = `amp_nomodule_${ciBuildId()}.zip`;
+const MODULE_OUTPUT_FILE = `amp_module_${ciBuildId()}.zip`;
 
 const BUILD_OUTPUT_DIRS = 'build/ dist/ dist.3p/';
 const APP_SERVING_DIRS = 'dist.tools/ examples/ test/manual/';

--- a/build-system/tasks/pr-deploy-bot-utils.js
+++ b/build-system/tasks/pr-deploy-bot-utils.js
@@ -19,7 +19,7 @@ const fs = require('fs-extra');
 const log = require('fancy-log');
 const path = require('path');
 const request = require('request-promise');
-const {ciBuildNumber} = require('../common/ci');
+const {ciBuildId} = require('../common/ci');
 const {cyan, green} = require('ansi-colors');
 const {gitCommitHash} = require('../common/git');
 const {replaceUrls: replaceUrlsAppUtil} = require('../server/app-utils');
@@ -42,7 +42,7 @@ async function walk(dest) {
 }
 
 function getBaseUrl() {
-  return `${hostNamePrefix}/amp_dist_${ciBuildNumber()}`;
+  return `${hostNamePrefix}/amp_dist_${ciBuildId()}`;
 }
 
 async function replace(filePath) {
@@ -71,7 +71,7 @@ async function replaceUrls(dir) {
 
 async function signalDistUpload(result) {
   const sha = gitCommitHash();
-  const ciBuild = ciBuildNumber();
+  const ciBuild = ciBuildId();
   const baseUrl = 'https://amp-pr-deploy-bot.appspot.com/v0/pr-deploy/';
   // TODO(rsimha, ampproject/amp-github-apps#1110): Update this URL.
   const url = `${baseUrl}travisbuilds/${ciBuild}/headshas/${sha}/${result}`;

--- a/build-system/tasks/test-report-upload.js
+++ b/build-system/tasks/test-report-upload.js
@@ -76,12 +76,12 @@ function addJobAndBuildInfo(testType, reportJson) {
     repository: process.env.GITHUB_REPOSITORY,
     results: reportJson,
     build: {
-      buildNumber: buildId,
+      buildId,
       commitSha,
       url: ciBuildUrl(),
     },
     job: {
-      jobNumber: jobId,
+      jobId,
       testSuiteType: testType,
       url: ciJobUrl(),
     },

--- a/build-system/tasks/test-report-upload.js
+++ b/build-system/tasks/test-report-upload.js
@@ -26,9 +26,9 @@ const fs = require('fs').promises;
 const log = require('fancy-log');
 const path = require('path');
 const {
-  ciBuildNumber,
+  ciBuildId,
   ciBuildUrl,
-  ciJobNumber,
+  ciJobId,
   ciJobUrl,
   ciCommitSha,
 } = require('../common/ci');
@@ -63,11 +63,11 @@ async function getReport(testType) {
  * @return {Object.<string,Object>} Object containing the build, job, and test results.
  */
 function addJobAndBuildInfo(testType, reportJson) {
-  const buildNumber = ciBuildNumber();
+  const buildId = ciBuildId();
   const commitSha = ciCommitSha();
-  const jobNumber = ciJobNumber();
+  const jobId = ciJobId();
 
-  if (!buildNumber || !commitSha || !jobNumber) {
+  if (!buildId || !commitSha || !jobId) {
     throw new ReferenceError('CI fields are not defined.');
   }
 
@@ -75,12 +75,12 @@ function addJobAndBuildInfo(testType, reportJson) {
     repository: process.env.GITHUB_REPOSITORY,
     results: reportJson,
     build: {
-      buildNumber,
+      buildId,
       commitSha,
       url: ciBuildUrl(),
     },
     job: {
-      jobNumber,
+      jobId,
       testSuiteType: testType,
       url: ciJobUrl(),
     },

--- a/build-system/tasks/test-report-upload.js
+++ b/build-system/tasks/test-report-upload.js
@@ -71,16 +71,17 @@ function addJobAndBuildInfo(testType, reportJson) {
     throw new ReferenceError('CI fields are not defined.');
   }
 
+  // (TODO ampproject/amp-github-apps/pull:1194) Update field names in database.
   return {
     repository: process.env.GITHUB_REPOSITORY,
     results: reportJson,
     build: {
-      buildId,
+      buildNumber: buildId,
       commitSha,
       url: ciBuildUrl(),
     },
     job: {
-      jobId,
+      jobNumber: jobId,
       testSuiteType: testType,
       url: ciJobUrl(),
     },


### PR DESCRIPTION
With the impending move from Travis to CircleCI, build and job identifiers are not guaranteed to be numeric values. This PR updates `buildNumber` and `jobNumber` to `buildId` and `jobId` respectively.