### PR TITLE
🐛  [amp-story-player] Apply display:none to <a> tags under the player once loaded

### DIFF
--- a/css/amp-story-player.css
+++ b/css/amp-story-player.css
@@ -32,11 +32,7 @@ amp-story-player a:first-of-type {
   display: block;
 }
 
-amp-story-player a:not(:first-of-type) {
-  visibility: hidden;
-}
-
-amp-story-player.i-amphtml-story-player-loaded a:first-of-type {
+amp-story-player.i-amphtml-story-player-loaded a {
   display: none;
 }
 


### PR DESCRIPTION
Closes #31419

Hides `<a>` elements under the player by applying `display: none` to them once the player is loaded.
<!--
# Instructions:

- Pick a meaningful title for your pull request. (Use sentence case.)
  - Prefix the title with an emoji to identify what is being done. (Copy-paste the emoji from the list below.)
  - Do not overuse punctuation in the title (like `(chore):`).
  - If it is helpful, use a simple prefix (like `ProjectX: Implement some feature`).
- Enter a succinct description that says why the PR is necessary, and what it does.
  - Mention the GitHub issue that is being addressed by the pull request.
  - The keywords `Fixes`, `Closes`, or `Resolves` followed the issue number will automatically close the issue.

> NOTE: All non-trivial changes (like introducing new features or components) should have an associated issue or reference an I2I (intent-to-implement: go.amp.dev/i2i). Please read through the contribution process (go.amp.dev/contributing/code) for more information.

# Example of a good description:

- Implement aspect X
- Leave out feature Y because of A
- Improve performance by B
- Improve accessibility by C

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Reverting a previous change
♻️ Refactoring
🚮 Deleting code
🧪 Experimental code
-->
