### PR TITLE
♿ [bento][social-share] Enable focus highlighting on bento version of component

### DIFF
--- a/extensions/amp-social-share/0.1/amp-social-share.md
+++ b/extensions/amp-social-share/0.1/amp-social-share.md
@@ -268,7 +268,7 @@ amp-social-share:focus {
 }
 ```
 
-The default focus indicator can be overwritten by defining CSS styles for focus and including them within a `style` tag on an AMP HTML page. In the example below, the first CSS rule-set removes the focus indicator on all `amp-social-share` elements by setting the `outline` property to `none`. The second rule-set specifies a red outline (instead of the default blue) and also sets the `outline-offset` to be `3px` for all `amp-social-share` elements with the class `custom-focus`. The user would add the `custom-focus` class to any `amp-social-share` elements he or she wishes to apply this rule-set to.
+The default focus indicator can be overwritten by defining CSS styles for focus and including them within a `style` tag on an AMP HTML page. In the example below, the first CSS rule-set removes the focus indicator on all `amp-social-share` elements by setting the `outline` property to `none`. The second rule-set specifies a red outline (instead of the default blue) and also sets the `outline-offset` to be `3px` for all `amp-social-share` elements with the class `custom-focus`.
 
 ```css
 amp-social-share:focus{

--- a/extensions/amp-social-share/0.1/amp-social-share.md
+++ b/extensions/amp-social-share/0.1/amp-social-share.md
@@ -268,7 +268,7 @@ amp-social-share:focus {
 }
 ```
 
-The default focus indicator can be overwritten by defining CSS styles for focus and including them within a `style` tag on an AMP HTML page. In the example below, the first CSS rule-set removes the focus indicator on all `amp-social-share` elements by setting the `outline` property to `none`. The second rule-set specifies a red outline (instead of the default blue) and also sets the `outline-offset` to be `3px` for all `amp-social-share` elements with the class `custom-focus`.
+The default focus indicator can be overwritten by defining CSS styles for focus and including them within a `style` tag on an AMP HTML page. In the example below, the first CSS rule-set removes the focus indicator on all `amp-social-share` elements by setting the `outline` property to `none`. The second rule-set specifies a red outline (instead of the default blue) and also sets the `outline-offset` to be `3px` for all `amp-social-share` elements with the class `custom-focus`. The user would add the `custom-focus` class to any `amp-social-share` elements he or she wishes to apply this rule-set to.
 
 ```css
 amp-social-share:focus{

--- a/extensions/amp-social-share/1.0/amp-social-share.css
+++ b/extensions/amp-social-share/1.0/amp-social-share.css
@@ -26,8 +26,8 @@ amp-social-share:focus {
 }
 
 amp-social-share::part(button):focus {
-  outline: none;
-  outline-offset: 0;
+  outline: none !important;
+  outline-offset: 0 !important;
 }
 
 /* Twitter Styling */

--- a/extensions/amp-social-share/1.0/amp-social-share.css
+++ b/extensions/amp-social-share/1.0/amp-social-share.css
@@ -20,7 +20,7 @@
   * See https://github.com/ampproject/amphtml/issues/4277 for more details.
   */
 
-amp-social-share:focus-within {
+amp-social-share:focus {
   outline: #0389ff solid 2px;
   outline-offset: 2px;
 }

--- a/extensions/amp-social-share/1.0/amp-social-share.css
+++ b/extensions/amp-social-share/1.0/amp-social-share.css
@@ -20,6 +20,16 @@
   * See https://github.com/ampproject/amphtml/issues/4277 for more details.
   */
 
+amp-social-share:focus-within {
+  outline: #0389ff solid 2px;
+  outline-offset: 2px;
+}
+
+amp-social-share::part(button):focus {
+  outline: none;
+  outline-offset: 0;
+}
+
 /* Twitter Styling */
 .amp-social-share-twitter {
   color: #fff;

--- a/extensions/amp-social-share/1.0/amp-social-share.js
+++ b/extensions/amp-social-share/1.0/amp-social-share.js
@@ -234,6 +234,9 @@ AmpSocialShare['layoutSizeDefined'] = true;
 AmpSocialShare['passthroughNonEmpty'] = true;
 
 /** @override */
+AmpSocialShare['delegatesFocus'] = true;
+
+/** @override */
 AmpSocialShare['props'] = {
   'tabIndex': {attr: 'tabindex'},
   'type': {attr: 'type'},

--- a/extensions/amp-social-share/1.0/social-share.js
+++ b/extensions/amp-social-share/1.0/social-share.js
@@ -86,7 +86,7 @@ export function SocialShare({
         ...style,
       }}
       part="button"
-      wrapperClassName={classes.focus}
+      wrapperClassName={classes.button}
     >
       {processChildren(
         /** @type {string} */ (type),

--- a/extensions/amp-social-share/1.0/social-share.js
+++ b/extensions/amp-social-share/1.0/social-share.js
@@ -24,6 +24,7 @@ import {dict} from '../../../src/utils/object';
 import {getSocialConfig} from './social-share-config';
 import {openWindowDialog} from '../../../src/dom';
 import {useResourcesNotify} from '../../../src/preact/utils';
+import {useStyles} from './social-share.jss';
 
 const NAME = 'SocialShare';
 const DEFAULT_WIDTH = 60;
@@ -50,6 +51,7 @@ export function SocialShare({
   ...rest
 }) {
   useResourcesNotify();
+  const classes = useStyles();
   const checkPropsReturnValue = checkProps(
     type,
     endpoint,
@@ -83,6 +85,8 @@ export function SocialShare({
         height: checkedHeight,
         ...style,
       }}
+      part="button"
+      wrapperClassName={classes.focus}
     >
       {processChildren(
         /** @type {string} */ (type),

--- a/extensions/amp-social-share/1.0/social-share.jss.js
+++ b/extensions/amp-social-share/1.0/social-share.jss.js
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {createUseStyles} from 'react-jss';
+
+const focus = {
+  '&:focus': {
+    outline: '#0389ff solid 2px',
+    outlineOffset: '2px',
+  },
+};
+
+const JSS = {
+  focus,
+};
+
+// useStyles gets replaced for AMP builds via `babel-plugin-transform-jss`.
+// eslint-disable-next-line local/no-export-side-effect
+export const useStyles = createUseStyles(JSS);

--- a/extensions/amp-social-share/1.0/social-share.jss.js
+++ b/extensions/amp-social-share/1.0/social-share.jss.js
@@ -16,7 +16,7 @@
 
 import {createUseStyles} from 'react-jss';
 
-const focus = {
+const button = {
   '&:focus': {
     outline: '#0389ff solid 2px',
     outlineOffset: '2px',
@@ -24,7 +24,7 @@ const focus = {
 };
 
 const JSS = {
-  focus,
+  button,
 };
 
 // useStyles gets replaced for AMP builds via `babel-plugin-transform-jss`.

--- a/extensions/amp-social-share/1.0/test/test-amp-social-share.js
+++ b/extensions/amp-social-share/1.0/test/test-amp-social-share.js
@@ -15,7 +15,6 @@
  */
 
 import '../amp-social-share';
-import {htmlFor} from '../../../../src/static-template';
 import {toggleExperiment} from '../../../../src/experiments';
 import {waitFor, whenCalled} from '../../../../testing/test-helper.js';
 import {waitForChildPromise} from '../../../../src/dom';
@@ -35,7 +34,6 @@ describes.realWin(
   (env) => {
     let win, doc;
     let element;
-    let html;
 
     const waitForRender = async () => {
       await whenCalled(env.sandbox.spy(element, 'attachShadow'));
@@ -59,7 +57,6 @@ describes.realWin(
       doc = win.document;
       doc.title = 'Test Title';
       toggleExperiment(win, 'bento-social-share', true);
-      html = htmlFor(win.document);
     });
 
     it('renders custom endpoint when not using a pre-configured type', async () => {
@@ -229,7 +226,7 @@ describes.realWin(
       ).to.be.equal('inherit');
     });
 
-    it('should show default and custom focus indicator styles', async () => {
+    it('should focus on the host when an element in the shadow DOM receives focus', async () => {
       element = win.document.createElement('amp-social-share');
       element.setAttribute('type', 'email');
       win.document.body.appendChild(element);
@@ -237,39 +234,29 @@ describes.realWin(
 
       // element is not focused and does not have focus indication styles
       expect(win.document.activeElement).to.not.equal(element);
-      expect(win.getComputedStyle(element)['outline']).to.equal(
-        'rgb(255, 255, 255) none 0px'
-      );
-      expect(win.getComputedStyle(element)['outlineOffset']).to.equal('0px');
 
       // focus the button within the shadow DOM
       const button = element.shadowRoot.querySelector("[part='button']");
       button.focus();
 
-      // host receives focus and focus indication styles
+      // host receives focus
       expect(win.document.activeElement).to.equal(element);
-      expect(win.getComputedStyle(element)['outline']).to.equal(
-        'rgb(3, 137, 255) solid 2px'
-      );
-      expect(win.getComputedStyle(element)['outlineOffset']).to.equal('2px');
+    });
 
-      // customize focus indication styles
-      const style = html`
-        <style>
-          amp-social-share:focus {
-            outline: #aaaaaa solid 3px;
-            outline-offset: 3px;
-          }
-        </style>
-      `;
-      win.document.body.appendChild(style);
+    it('should allow focus directly on the host', async () => {
+      element = win.document.createElement('amp-social-share');
+      element.setAttribute('type', 'email');
+      win.document.body.appendChild(element);
+      await waitForRender();
 
-      // updated focus indicator styles
+      // element is not focused and does not have focus indication styles
+      expect(win.document.activeElement).to.not.equal(element);
+
+      // focus the host
+      element.focus();
+
+      // host receives focus
       expect(win.document.activeElement).to.equal(element);
-      expect(win.getComputedStyle(element)['outline']).to.equal(
-        'rgb(170, 170, 170) solid 3px'
-      );
-      expect(win.getComputedStyle(element)['outlineOffset']).to.equal('3px');
     });
 
     describe('dynamically update attributes', () => {

--- a/extensions/amp-social-share/1.0/test/test-social-share.js
+++ b/extensions/amp-social-share/1.0/test/test-social-share.js
@@ -42,4 +42,12 @@ describes.sandboxed('SocialShare 1.0 preact component', {}, () => {
       );
     }
   );
+
+  it('should include the button class for focus styling', () => {
+    const jsx = <SocialShare {...dict({'type': 'email'})} />;
+    const wrapper = mount(jsx);
+
+    const button = wrapper.getDOMNode();
+    expect(button.className.includes('button')).to.be.true;
+  });
 });

--- a/extensions/amp-social-share/amp-social-share.md
+++ b/extensions/amp-social-share/amp-social-share.md
@@ -271,6 +271,34 @@ When customizing the style of an `amp-social-share` icon please ensure that the 
 
 ## Accessibility
 
+### Indication of focus
+
+The `amp-social-share` element defaults to a blue outline as a visible focus indicator. It also defaults `tabindex=0` making it easy for a user to follow along as he or she tabs through multiple `amp-social-share` elements used together on a page.
+
+The default focus indicator is achieved with the following CSS rule-set.
+
+```css
+amp-social-share:focus {
+  outline: #0389ff solid 2px;
+  outline-offset: 2px;
+}
+```
+
+The default focus indicator can be overwritten by defining CSS styles for focus and including them within a `style` tag on an AMP HTML page. In the example below, the first CSS rule-set removes the focus indicator on all `amp-social-share` elements by setting the `outline` property to `none`. The second rule-set specifies a red outline (instead of the default blue) and also sets the `outline-offset` to be `3px` for all `amp-social-share` elements with the class `custom-focus`.
+
+```css
+amp-social-share:focus{
+  outline: none;
+}
+
+amp-social-share.custom-focus:focus {
+  outline: red solid 2px;
+  outline-offset: 3px;
+}
+```
+
+With these CSS rules, `amp-social-share` elements would not show the visible focus indicator unless they included the class `custom-focus` in which case they would have the red outlined indicator.
+
 ### Color contrast
 
 Note that `amp-social-share` with a `type` value of `twitter`, `whatsapp`, or `line` will display a button with a foreground/background color combination that falls below the 3:1 threshold recommended for non-text content defined in [WCAG 2.1 SC 1.4.11 Non-text Contrast](https://www.w3.org/WAI/WCAG21/Understanding/non-text-contrast.html).

--- a/extensions/amp-social-share/amp-social-share.md
+++ b/extensions/amp-social-share/amp-social-share.md
@@ -284,7 +284,7 @@ amp-social-share:focus {
 }
 ```
 
-The default focus indicator can be overwritten by defining CSS styles for focus and including them within a `style` tag on an AMP HTML page. In the example below, the first CSS rule-set removes the focus indicator on all `amp-social-share` elements by setting the `outline` property to `none`. The second rule-set specifies a red outline (instead of the default blue) and also sets the `outline-offset` to be `3px` for all `amp-social-share` elements with the class `custom-focus`. The user would add the `custom-focus` class to any `amp-social-share` elements he or she wishes to apply this rule-set to.
+The default focus indicator can be overwritten by defining CSS styles for focus and including them within a `style` tag on an AMP HTML page. In the example below, the first CSS rule-set removes the focus indicator on all `amp-social-share` elements by setting the `outline` property to `none`. The second rule-set specifies a red outline (instead of the default blue) and also sets the `outline-offset` to be `3px` for all `amp-social-share` elements with the class `custom-focus`.
 
 ```css
 amp-social-share:focus{

--- a/extensions/amp-social-share/amp-social-share.md
+++ b/extensions/amp-social-share/amp-social-share.md
@@ -284,7 +284,7 @@ amp-social-share:focus {
 }
 ```
 
-The default focus indicator can be overwritten by defining CSS styles for focus and including them within a `style` tag on an AMP HTML page. In the example below, the first CSS rule-set removes the focus indicator on all `amp-social-share` elements by setting the `outline` property to `none`. The second rule-set specifies a red outline (instead of the default blue) and also sets the `outline-offset` to be `3px` for all `amp-social-share` elements with the class `custom-focus`.
+The default focus indicator can be overwritten by defining CSS styles for focus and including them within a `style` tag on an AMP HTML page. In the example below, the first CSS rule-set removes the focus indicator on all `amp-social-share` elements by setting the `outline` property to `none`. The second rule-set specifies a red outline (instead of the default blue) and also sets the `outline-offset` to be `3px` for all `amp-social-share` elements with the class `custom-focus`. The user would add the `custom-focus` class to any `amp-social-share` elements he or she wishes to apply this rule-set to.
 
 ```css
 amp-social-share:focus{

--- a/src/preact/base-element.js
+++ b/src/preact/base-element.js
@@ -515,7 +515,7 @@ export class PreactBaseElement extends AMP.BaseElement {
           // Create new shadow root.
           shadowRoot = this.element.attachShadow({
             mode: 'open',
-            delegatesFocus: true,
+            delegatesFocus: Ctor['delegatesFocus'],
           });
 
           // The pre-constructed shadow root is required to have the stylesheet
@@ -864,6 +864,14 @@ PreactBaseElement['shadowCss'] = null;
  * @protected {boolean}
  */
 PreactBaseElement['detached'] = false;
+
+/**
+ * This enables the 'delegatesFocus' option when creating the shadow DOM for
+ * this component.  A key feature of 'delegatesFocus' set to true is that
+ * when elements within the shadow DOM gain focus, the focus is also applied
+ * to the host element.
+ */
+PreactBaseElement['delegatesFocus'] = false;
 
 /**
  * Provides a mapping of Preact prop to AmpElement DOM attributes.

--- a/src/preact/base-element.js
+++ b/src/preact/base-element.js
@@ -513,7 +513,10 @@ export class PreactBaseElement extends AMP.BaseElement {
           this.hydrationPending_ = true;
         } else {
           // Create new shadow root.
-          shadowRoot = this.element.attachShadow({mode: 'open'});
+          shadowRoot = this.element.attachShadow({
+            mode: 'open',
+            delegatesFocus: true,
+          });
 
           // The pre-constructed shadow root is required to have the stylesheet
           // inline. Thus, only the new shadow roots share the stylesheets.

--- a/test/unit/preact/test-base-element-mapping.js
+++ b/test/unit/preact/test-base-element-mapping.js
@@ -967,7 +967,6 @@ describes.realWin('PreactBaseElement', spec, (env) => {
 
   describe('delegatesFocus mapping', () => {
     let element;
-    let style;
 
     beforeEach(async () => {
       Impl['delegatesFocus'] = true;
@@ -975,14 +974,7 @@ describes.realWin('PreactBaseElement', spec, (env) => {
       element = html`
         <amp-preact layout="fixed" width="100" height="100"></amp-preact>
       `;
-
-      style = html`<style>
-        amp-preact:focus {
-          outline: #0389ff solid 2px;
-        }
-      </style>`;
       doc.body.appendChild(element);
-      doc.body.appendChild(style);
       await element.build();
       await waitFor(() => component.callCount > 0, 'component rendered');
     });
@@ -990,9 +982,6 @@ describes.realWin('PreactBaseElement', spec, (env) => {
     it('should focus on the host when an element in the shadow DOM receives focus', async () => {
       // initial focus is not on host
       expect(doc.activeElement).to.not.equal(element);
-      expect(win.getComputedStyle(element)['outline']).to.equal(
-        'rgb(0, 0, 0) none 0px'
-      );
 
       // focus an element within the shadow DOM
       const inner = element.shadowRoot.querySelector('#component');
@@ -1002,9 +991,6 @@ describes.realWin('PreactBaseElement', spec, (env) => {
 
       // host receives focus and custom style for outline
       expect(doc.activeElement).to.equal(element);
-      expect(win.getComputedStyle(element)['outline']).to.equal(
-        'rgb(3, 137, 255) solid 2px'
-      );
     });
   });
 });

--- a/test/unit/preact/test-base-element-mapping.js
+++ b/test/unit/preact/test-base-element-mapping.js
@@ -964,4 +964,47 @@ describes.realWin('PreactBaseElement', spec, (env) => {
       expect(component).to.be.calledTwice;
     });
   });
+
+  describe('delegatesFocus mapping', () => {
+    let element;
+    let style;
+
+    beforeEach(async () => {
+      Impl['delegatesFocus'] = true;
+      Impl['passthroughNonEmpty'] = true;
+      element = html`
+        <amp-preact layout="fixed" width="100" height="100"></amp-preact>
+      `;
+
+      style = html`<style>
+        amp-preact:focus {
+          outline: #0389ff solid 2px;
+        }
+      </style>`;
+      doc.body.appendChild(element);
+      doc.body.appendChild(style);
+      await element.build();
+      await waitFor(() => component.callCount > 0, 'component rendered');
+    });
+
+    it('should focus on the host when an element in the shadow DOM receives focus', async () => {
+      // initial focus is not on host
+      expect(doc.activeElement).to.not.equal(element);
+      expect(win.getComputedStyle(element)['outline']).to.equal(
+        'rgb(0, 0, 0) none 0px'
+      );
+
+      // focus an element within the shadow DOM
+      const inner = element.shadowRoot.querySelector('#component');
+      // required to receive focus
+      inner.setAttribute('tabIndex', 0);
+      inner.focus();
+
+      // host receives focus and custom style for outline
+      expect(doc.activeElement).to.equal(element);
+      expect(win.getComputedStyle(element)['outline']).to.equal(
+        'rgb(3, 137, 255) solid 2px'
+      );
+    });
+  });
 });

--- a/test/unit/preact/test-base-element-mapping.js
+++ b/test/unit/preact/test-base-element-mapping.js
@@ -980,6 +980,9 @@ describes.realWin('PreactBaseElement', spec, (env) => {
     });
 
     it('should focus on the host when an element in the shadow DOM receives focus', async () => {
+      // expect the shadowRoot to have delegatesFocus property set to true
+      expect(element.shadowRoot.delegatesFocus).to.be.true;
+
       // initial focus is not on host
       expect(doc.activeElement).to.not.equal(element);
 


### PR DESCRIPTION
POC - Get Bento version (`1.0`) up to date with (`0.1`) on focus highlighting per: #29561

When the user focuses on the Social Share element, highlight with a blue outline that is highly visible

Can overwrite in amp mode by including the following in the amp-page,

```
amp-social-share:focus-within {
  desired styling...
}
```

Differs slightly from `0.1` which would use an `amp-social-share:focus selector`.  This is because the actual element that gets focus is within the shadow DOM of the `amp-social-share` element (and is not this actual element).  Also considered making the host element the element that receives focus, but then on `keydown` events, the actual button element within the shadow DOM does not receive the event.

Open Question:
1. Not sure how would we overwrite in preact mode?  Inline style does not seem to be able to control :focus pseudo selector - closed (Preact mode users can pass their own class into our component and overwrite with their own style sheet).

Todo:
1. tests - added 1/20
2. can refactor social share to use jss, but did not want to over complicate this POC - not in this PR
3. update docs - added 1/20
