### PR TITLE
Workspace: deferred build mode

### DIFF
--- a/builtins/amp-img.js
+++ b/builtins/amp-img.js
@@ -48,7 +48,7 @@ const ATTRIBUTES_TO_PROPAGATE = [
 export class AmpImg extends BaseElement {
   /** @override @nocollapse */
   static V1() {
-    return V1_IMG_DEFERRED_BUILD;
+    return true;
   }
 
   /** @override @nocollapse */

--- a/examples/loader-bento.amp.html
+++ b/examples/loader-bento.amp.html
@@ -1,0 +1,94 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Lorem Ipsum | PublisherName</title>
+  <link rel="canonical" href="https://medium.com/p/cb7f223fad86" >
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+  <script>
+    (self.AMP = self.AMP || []).push(function(AMP) {
+      AMP.toggleExperiment('bento', true, true);
+    });
+  </script>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async custom-element="amp-carousel" src="https://cdn.ampproject.org/v0/amp-carousel-0.1.js"></script>
+  <script async custom-element="amp-video" src="https://cdn.ampproject.org/v0/amp-video-1.0.js"></script>
+  <script async custom-element="amp-instagram" src="https://cdn.ampproject.org/v0/amp-instagram-1.0.js"></script>
+
+  <style amp-custom>
+    body {
+      margin: 0;
+      font-family: 'Georgia', Serif;
+      background: white;
+    }
+
+  </style>
+  <link href='https://fonts.googleapis.com/css?family=Georgia|Open+Sans|Roboto' rel='stylesheet' type='text/css'>
+</head>
+<body>
+  <!--
+  <div style="height: 500vh">scroll</div>
+  -->
+
+  <!--
+  -->
+  <amp-img id="hero-img"
+      src="img/hero@1x.jpg"
+      srcset="img/hero@1x.jpg 1x, img/hero@2x.jpg 2x"
+      layout="responsive" width="360"
+      height="216"
+      noprerender>
+    <script>
+      //debugger;//QQQQQQ
+    </script>
+  </amp-img>
+
+  <!--
+  <amp-video id="video1"
+    src="https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerJoyrides.mp4"
+    width="358"
+    height="204"
+    layout="responsive"
+    controls>
+    <script>
+      //debugger;//QQQQQQ
+    </script>
+  </amp-video>
+  -->
+
+  <!--
+  <amp-iframe id="iframe1"
+      width=300 height=300
+      sandbox="allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox"
+      layout="responsive"
+      frameborder="0"
+      src="http://ads.localhost:8000/extensions/amp-iframe/0.1/storybook/iframe.html">
+    <div placeholder></div>
+  </amp-iframe>
+  -->
+
+  <!--
+  <amp-carousel id="carousel1" width=400 height=300 layout=fixed type=slides>
+    <amp-img id="hero-img"
+        src="img/hero@1x.jpg"
+        srcset="img/hero@1x.jpg 1x, img/hero@2x.jpg 2x"
+        layout="responsive" width="360"
+        height="216">
+    </amp-img>
+    <amp-video id="video1"
+      src="https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerJoyrides.mp4"
+      width="358"
+      height="204"
+      layout="responsive"
+      controls></amp-video>
+    <amp-instagram id="insta1"
+        width=300 height=300
+        layout="responsive"
+        data-shortcode="B8QaZW4AQY_">
+    </amp-instagram>
+  </amp-carousel>
+  -->
+
+  <div style="height: 2000vh">scroll</div>
+</body>
+</html>

--- a/examples/loader.amp.html
+++ b/examples/loader.amp.html
@@ -1,0 +1,97 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>Lorem Ipsum | PublisherName</title>
+  <link rel="canonical" href="https://medium.com/p/cb7f223fad86" >
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async custom-element="amp-carousel" src="https://cdn.ampproject.org/v0/amp-carousel-0.1.js"></script>
+  <script async custom-element="amp-video" src="https://cdn.ampproject.org/v0/amp-video-0.1.js"></script>
+  <script async custom-element="amp-iframe" src="https://cdn.ampproject.org/v0/amp-iframe-0.1.js"></script>
+
+  <style amp-custom>
+    body {
+      margin: 0;
+      font-family: 'Georgia', Serif;
+      background: white;
+    }
+
+  </style>
+  <link href='https://fonts.googleapis.com/css?family=Georgia|Open+Sans|Roboto' rel='stylesheet' type='text/css'>
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+</head>
+<body>
+  <!--
+  <div style="height: 500vh">scroll</div>
+  -->
+
+  <!--
+  -->
+  <amp-img id="hero-img"
+      src="img/hero@1x.jpg"
+      srcset="img/hero@1x.jpg 1x, img/hero@2x.jpg 2x"
+      layout="responsive" width="360"
+      height="216"
+      noprerender_>
+    <script>
+      //debugger;//QQQQQQ
+    </script>
+  </amp-img>
+
+  <!--
+  <amp-video id="video1"
+    src="https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerJoyrides.mp4"
+    width="358"
+    height="204"
+    layout="responsive"
+    controls>
+    <script>
+      //debugger;//QQQQQQ
+    </script>
+  </amp-video>
+  -->
+
+  <!--
+  <amp-iframe id="iframe1"
+      width=300 height=100
+      sandbox="allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox"
+      layout="responsive"
+      frameborder="0"
+      src="http://ads.localhost:8000/extensions/amp-iframe/0.1/storybook/iframe.html"
+      resizable>
+    <div placeholder></div>
+    <div overflow>overflow</div>
+  </amp-iframe>
+  -->
+
+  <!--
+  <amp-carousel id="carousel1" width=400 height=300 layout=fixed type=slides>
+    <amp-img id="hero-img"
+        src="img/hero@1x.jpg"
+        srcset="img/hero@1x.jpg 1x, img/hero@2x.jpg 2x"
+        layout="responsive" width="360"
+        height="216">
+    </amp-img>
+    <amp-video id="video1"
+      src="https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerJoyrides.mp4"
+      width="358"
+      height="204"
+      layout="responsive"
+      controls></amp-video>
+    <amp-iframe id="iframe1"
+        width=300 height=300
+        sandbox="allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox"
+        layout="responsive"
+        frameborder="0"
+        src="http://ads.localhost:8000/extensions/amp-iframe/0.1/storybook/iframe.html">
+      <div placeholder></div>
+    </amp-iframe>
+  </amp-carousel>
+  -->
+
+  <!--
+  -->
+  <div style="height: 2000vh">scroll</div>
+</body>
+</html>

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -224,6 +224,16 @@ function createBaseCustomElementClass(win, elementConnectedCallback) {
         Ctor = nonStructThis['implementationClassForTesting'];
       }
 
+      console.log(
+        'CustomElement: new: ',
+        this.id,
+        Ctor ? Ctor.name : 'n/a',
+        'V2:',
+        Ctor ? Ctor.V1() : 'n/a',
+        'deferredBuild:',
+        Ctor ? Ctor.deferredBuild(this) : 'n/a'
+      );
+
       /** @private {?(typeof ../base-element.BaseElement)} */
       this.implClass_ = Ctor === ElementStub ? null : Ctor || null;
 
@@ -349,6 +359,13 @@ function createBaseCustomElementClass(win, elementConnectedCallback) {
      * @final @package
      */
     upgrade(newImplClass) {
+      console.log(
+        'CustomElement: upgraded: ',
+        this.id,
+        newImplClass.name,
+        newImplClass.V1(),
+        newImplClass.deferredBuild(this)
+      );
       if (this.isInTemplate_) {
         return;
       }
@@ -490,6 +507,8 @@ function createBaseCustomElementClass(win, elementConnectedCallback) {
       if (this.buildingPromise_) {
         return this.buildingPromise_;
       }
+
+      console.log('CustomElement: buildInternal:', this.id);
 
       this.setReadyStateInternal(ReadyState.BUILDING);
 
@@ -845,6 +864,13 @@ function createBaseCustomElementClass(win, elementConnectedCallback) {
         return;
       }
 
+      console.log(
+        'CustomElement: setReadyStateInternal:',
+        this.id,
+        state,
+        opt_failure
+      );
+
       this.readyState_ = state;
 
       if (!this.V1()) {
@@ -1130,6 +1156,7 @@ function createBaseCustomElementClass(win, elementConnectedCallback) {
      * @final
      */
     connectedCallback() {
+      console.log('CustomElement: connectedCallback:', this.id);
       if (!isTemplateTagSupported() && this.isInTemplate_ === undefined) {
         this.isInTemplate_ = !!dom.closestAncestorElementBySelector(
           this,
@@ -1293,6 +1320,7 @@ function createBaseCustomElementClass(win, elementConnectedCallback) {
         'Implementation must not be a stub'
       );
 
+      console.log('CustomElement: create: ', this.id, Ctor.name);
       const impl = new Ctor(this);
 
       // The `upgradeCallback` only allows redirect once for the top-level
@@ -1591,6 +1619,9 @@ function createBaseCustomElementClass(win, elementConnectedCallback) {
      * TODO(#31915): remove once V1 migration is complete.
      */
     layoutCallback(signal) {
+      console.log('CustomElement: layoutCallback:', this.id);
+      devAssert(!this.V1(), 'not allowed for V2');
+
       assertNotTemplate(this);
       devAssert(this.isBuilt(), 'Must be built to receive viewport events');
       // A lot of tests call layoutCallback manually, and don't pass a signal.
@@ -2085,6 +2116,7 @@ function createBaseCustomElementClass(win, elementConnectedCallback) {
      * @package @final
      */
     overflowCallback(overflown, requestedHeight, requestedWidth) {
+      console.log('CustomElement: overflowCallback:', overflown);
       this.getOverflowElement();
       if (!this.overflowElement_) {
         if (overflown && this.warnOnMissingOverflow) {

--- a/src/layout.js
+++ b/src/layout.js
@@ -322,7 +322,7 @@ export function isLoadingAllowed(element) {
  */
 export function isIframeVideoPlayerComponent(tagName) {
   if (tagName == 'AMP-VIDEO') {
-    return false;
+    return true; // DO NOT SUBMIT: why was this `false` before?
   }
   return videoPlayerTagNameRe.test(tagName);
 }

--- a/src/service/mutator-impl.js
+++ b/src/service/mutator-impl.js
@@ -16,6 +16,7 @@
 
 import {FocusHistory} from '../focus-history';
 import {MutatorInterface} from './mutator-interface';
+import {ResizerV2} from './resizer-v2';
 import {Resource} from './resource';
 import {Services} from '../services';
 import {areMarginsChanged} from '../layout-rect';
@@ -58,6 +59,9 @@ export class MutatorImpl {
     this.activeHistory_.onFocus((element) => {
       this.checkPendingChangeSize_(element);
     });
+
+    /** @private @const */
+    this.resizer_ = new ResizerV2(ampdoc);
   }
 
   /** @override */
@@ -321,6 +325,18 @@ export class MutatorImpl {
     force,
     opt_callback
   ) {
+    // DO NOT SUBMIT: testing
+    this.resizer_.tryChangeSize(
+      resource.element,
+      newHeight,
+      newWidth,
+      newMargins,
+      event,
+      force,
+      () => {},
+      () => {}
+    );
+
     if (resource.hasBeenMeasured() && !newMargins) {
       this.completeScheduleChangeSize_(
         resource,

--- a/src/service/owners-impl.js
+++ b/src/service/owners-impl.js
@@ -163,6 +163,10 @@ export class OwnersImpl {
    */
   scheduleLayoutOrPreloadForSubresources_(parentResource, layout, subElements) {
     this.findResourcesInElements_(parentResource, subElements, (resource) => {
+      console.log(
+        'OwnersImpl: measureAndTryScheduleLayout_: ',
+        resource.debugid
+      );
       resource.element.ensureLoaded(parentResource.getLayoutPriority());
     });
   }

--- a/src/service/resizer-v2.js
+++ b/src/service/resizer-v2.js
@@ -1,0 +1,339 @@
+/**
+ * Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Deferred} from '../utils/promise';
+import {FocusHistory} from '../focus-history';
+import {Services} from '../services';
+import {computedStyle} from '../style';
+
+const FOCUS_HISTORY_TIMEOUT = 1000 * 60; // 1min
+
+/** @implements {!Disposable} */
+export class ResizerV2 {
+  /**
+   * @param {!./ampdoc-impl.AmpDoc} ampdoc
+   */
+  constructor(ampdoc) {
+    /** @private @const {!./ampdoc-impl.AmpDoc} */
+    this.ampdoc_ = ampdoc;
+
+    const {win} = ampdoc;
+
+    /** @private {!WeakMap<!Element, !Deferred>} */
+    this.measuredElements_ = new WeakMap();
+
+    /** @private @const {!IntersectionObserver} */
+    this.measuringObserver_ = new win.IntersectionObserver(
+      (records) => {
+        for (let i = 0; i < records.length; i++) {
+          const record = records[i];
+          const element = record.target;
+          const deferred = this.measuredElements_.get(element);
+          if (deferred) {
+            deferred.resolve(record);
+            this.measuringObserver_.unobserve(element);
+            this.measuredElements_.delete(element);
+          }
+        }
+      },
+      {root: win.document}
+    );
+
+    /** @private @const {function(!Element):!Promise<!IntersectionObserverEntry>} */
+    this.measure_ = (element) => {
+      let deferred = this.measuredElements_.get(element);
+      if (!deferred) {
+        deferred = new Deferred();
+        this.measuredElements_.set(element, deferred);
+        this.measuringObserver_.observe(element);
+      }
+      return deferred.promise;
+    };
+
+    /** @private @const {!./viewport/viewport-interface.ViewportInterface} */
+    this.viewport_ = Services.viewportForDoc(ampdoc);
+
+    /** @private @const {!FocusHistory} */
+    this.activeHistory_ = new FocusHistory(win, FOCUS_HISTORY_TIMEOUT);
+
+    /** @private {?number} */
+    this.initialContentHeight_ = null;
+  }
+
+  /** @override */
+  dispose() {
+    this.measuringObserver_.disconnect();
+    this.measuredElements_ = null;
+  }
+
+  /* QQQ
+  someCaller() {
+    return new Promise((resolve, reject) => {
+      tryChangeSize_(a, b, c,
+        (newHeight, newWidth, newMargins) => {
+          resource.changeSize(newHeight, newWidth, newMargins);
+          // QQQQ: notify resources
+        },
+        (approved, newHeight, newWidth, newMargins) => {
+          resource.overflowCallback(
+            \* overflown *\ !approved,
+            newHeight,
+            newWidth,
+            newMargins
+          );
+          if (approved) {
+            resolve();
+          } else {
+            reject(new Error('...'));
+          }
+        });
+    });
+  }
+  */
+
+  /**
+   * @param {!Element} element
+   * @param {number|undefined} newHeight
+   * @param {number|undefined} newWidth
+   * @param {!../layout-rect.LayoutMarginsChangeDef|undefined} newMargins
+   * @param {?Event} event
+   * @param {function(number|undefined, number|undefined, !../layout-rect.LayoutMarginsChangeDef|undefined)} onChange
+   * @param {function(boolean, number|undefined, number|undefined, !../layout-rect.LayoutMarginsChangeDef|undefined)} onComplete
+   */
+  tryChangeSize(
+    element,
+    newHeight,
+    newWidth,
+    newMargins,
+    event,
+    onChange,
+    onComplete
+  ) {
+    this.measure_(element).then((intersection) =>
+      this.tryChangeSize_(
+        element,
+        intersection,
+        newHeight,
+        newWidth,
+        newMargins,
+        event,
+        onChange,
+        onComplete
+      )
+    );
+  }
+
+  /**
+   * @param {!Element} element
+   * @param {!IntersectionObserverEntry} intersection
+   * @param {number|undefined} newHeight
+   * @param {number|undefined} newWidth
+   * @param {!../layout-rect.LayoutMarginsChangeDef|undefined} newMargins
+   * @param {?Event} event
+   * @param {function(number|undefined, number|undefined, !../layout-rect.LayoutMarginsChangeDef|undefined)} onChange
+   * @param {function(boolean, number|undefined, number|undefined, !../layout-rect.LayoutMarginsChangeDef|undefined)} onComplete
+   * @private
+   */
+  tryChangeSize_(
+    element,
+    intersection,
+    newHeight,
+    newWidth,
+    newMargins,
+    event,
+    onChange,
+    onComplete
+  ) {
+    const {boundingClientRect, rootBounds} = intersection;
+
+    // The element might no longer be attached to DOM. If so, it can be
+    // resized w/o problems.
+    if (!rootBounds) {
+      onChange(newHeight, newWidth, newMargins);
+      onComplete(true);
+      return;
+    }
+
+    // Measuring from the InOb callback is mostly free.
+    const topOffset = rootBounds.height / 10;
+    const bottomOffset = rootBounds.height / 10;
+    const scrollTop = this.viewport_.getScrollTop();
+
+    const {top, bottom, height, width} = boundingClientRect;
+    let topUnchangedBoundary = top;
+    let bottomDisplacedBoundary = bottom;
+    let topMarginDiff = 0;
+    let bottomMarginDiff = 0;
+    let leftMarginDiff = 0;
+    let rightMarginDiff = 0;
+
+    if (newMargins) {
+      const margins = computeMargins(this.ampdoc_.win, element);
+      if (newMargins.top != undefined) {
+        topMarginDiff = newMargins.top - margins.top;
+      }
+      if (newMargins.bottom != undefined) {
+        bottomMarginDiff = newMargins.bottom - margins.bottom;
+      }
+      if (newMargins.left != undefined) {
+        leftMarginDiff = newMargins.left - margins.left;
+      }
+      if (newMargins.right != undefined) {
+        rightMarginDiff = newMargins.right - margins.right;
+      }
+      if (topMarginDiff) {
+        topUnchangedBoundary -= margins.top;
+      }
+      if (bottomMarginDiff) {
+        // The lowest boundary of the element that would appear to be
+        // resized as a result of this size change. If the bottom margin is
+        // being changed then it is the bottom edge of the margin box,
+        // otherwise it is the bottom edge of the layout box as set above.
+        bottomDisplacedBoundary += margins.bottom;
+      }
+    }
+    const heightDiff = newHeight == null ? 0 : newHeight - height;
+    const widthDiff = newWidth == null ? 0 : newWidth - width;
+
+    const changed = !(
+      heightDiff == 0 &&
+      topMarginDiff == 0 &&
+      bottomMarginDiff == 0 &&
+      widthDiff == 0 &&
+      leftMarginDiff == 0 &&
+      rightMarginDiff == 0
+    );
+    let allow = false;
+    let adjScrollHeight = false;
+    if (!changed) {
+      // 1. Nothing to resize.
+      allow = true;
+    } else if (!this.ampdoc_.isVisible()) {
+      // 2. An immediate execution requested or the document is hidden.
+      allow = true;
+    } else if (
+      this.activeHistory_.hasDescendantsOf(element) ||
+      (event && event.userActivation && event.userActivation.hasBeenActive)
+    ) {
+      // 3. Active elements are immediately resized. The assumption is that
+      // the resize is triggered by the user action or soon after.
+      allow = true;
+    } else if (
+      topUnchangedBoundary >= rootBounds.height - bottomOffset ||
+      (topMarginDiff == 0 &&
+        bottom + Math.min(heightDiff, 0) >= rootBounds.height - bottomOffset)
+    ) {
+      // 4. Elements under viewport are resized immediately, but only if
+      // an element's boundary is not changed above the viewport after
+      // resize.
+      allow = true;
+    } else if (
+      scrollTop > 1 &&
+      bottomDisplacedBoundary <= topOffset &&
+      (heightDiff >= 0 || scrollTop + heightDiff >= 0)
+    ) {
+      // 5. Elements above the viewport can only be resized if we are able
+      // to compensate the height change by setting scrollTop and only if
+      // the page has already been scrolled by some amount (1px due to iOS).
+      // Otherwise the scrolling might move important things like the menu
+      // bar out of the viewport at initial page load.
+      allow = true;
+      adjScrollHeight = true;
+    } else if (this.isNearBottom_(bottom + scrollTop)) {
+      // 6. Elements close to the bottom of the document (not viewport)
+      // are resized immediately.
+      allow = true;
+    } else if (heightDiff < 0 || topMarginDiff < 0 || bottomMarginDiff < 0) {
+      // 7. The new height (or one of the margins) is smaller than the
+      // current one.
+    } else if (heightDiff == 0 && widthDiff != 0) {
+      // 8. Element is in viewport, but this is a width-only expansion.
+      // Check whether this should be reflow-free, in which case,
+      // schedule a size change.
+      const parent = element.parentElement;
+      if (parent) {
+        const parentWidth = parent./*OK*/ offsetWidth;
+        let cumulativeWidth = widthDiff;
+        for (let i = 0; i < parent.childElementCount; i++) {
+          cumulativeWidth += parent.children[i]./*OK*/ offsetWidth;
+          if (cumulativeWidth > parentWidth) {
+            break;
+          }
+        }
+        allow = cumulativeWidth <= parentWidth;
+      }
+    }
+
+    if (allow && changed) {
+      if (adjScrollHeight) {
+        // The browser is normally fully sync'd in a InOb callback, thus reads
+        // would not be blocking.
+        const scrollHeight = this.viewport_.getScrollHeight();
+
+        onChange(newHeight, newWidth, newMargins);
+
+        // This measurement is definitely blocking, but we have to do it sync
+        // to avoid scroll jumps causing FOUC.
+        const newScrollHeight = this.viewport_.getScrollHeight();
+        if (newScrollHeight != scrollHeight) {
+          this.viewport_.setScrollTop(
+            scrollTop + (newScrollHeight - scrollHeight)
+          );
+        }
+      } else {
+        onChange(newHeight, newWidth, newMargins);
+      }
+    }
+
+    onComplete(allow, newHeight, newWidth, newMargins);
+  }
+
+  /**
+   * @param {number} bottom
+   * @return {boolean}
+   * @private
+   */
+  isNearBottom_(bottom) {
+    const contentHeight = this.viewport_.getContentHeight();
+    if (this.initialContentHeight_ == null) {
+      this.initialContentHeight_ = contentHeight;
+    }
+    const minContentHeight = Math.min(
+      contentHeight,
+      this.initialContentHeight_
+    );
+    const threshold = Math.max(
+      minContentHeight * 0.85,
+      minContentHeight - 1000
+    );
+    return bottom >= threshold;
+  }
+}
+
+/**
+ * @param {!Window} win
+ * @param {!Element} element
+ * @return {!../layout-rect.LayoutMarginsChangeDef}
+ */
+function computeMargins(win, element) {
+  const style = computedStyle(win, element);
+  return {
+    top: parseInt(style.marginTop, 10) || 0,
+    right: parseInt(style.marginRight, 10) || 0,
+    bottom: parseInt(style.marginBottom, 10) || 0,
+    left: parseInt(style.marginLeft, 10) || 0,
+  };
+}

--- a/src/service/scheduler.js
+++ b/src/service/scheduler.js
@@ -74,6 +74,12 @@ export class Scheduler {
    * @param {!AmpElement} target
    */
   scheduleAsap(target) {
+    console.log(
+      'Builder: scheduleAsap:',
+      target.id,
+      'mutable:',
+      target.mutable()
+    );
     this.targets_.set(target, {asap: true, isIntersecting: false});
     this.waitParsing_(target);
   }
@@ -110,6 +116,8 @@ export class Scheduler {
     if (!this.targets_.has(target)) {
       return;
     }
+
+    console.log('Builder: unschedule:', target.id);
 
     this.targets_.delete(target);
 
@@ -220,6 +228,14 @@ export class Scheduler {
     if (parsingTargets) {
       for (let i = 0; i < parsingTargets.length; i++) {
         const target = parsingTargets[i];
+        console.log(
+          'Builder: parse complete?:',
+          target.id,
+          'docReady:',
+          documentReady,
+          'hasNext:',
+          hasNextNodeInDocumentOrder(target, this.ampdoc_.getRootNode())
+        );
         if (
           documentReady ||
           hasNextNodeInDocumentOrder(target, this.ampdoc_.getRootNode())
@@ -279,6 +295,12 @@ export class Scheduler {
         vs == VisibilityState.HIDDEN ||
         // Prerender can only proceed when allowed.
         (vs == VisibilityState.PRERENDER && target.prerenderAllowed()));
+    console.log('Builder: build?:', target.id, toBuild, {
+      parsed,
+      isIntersecting,
+      dovVis: this.ampdoc_.getVisibilityState(),
+      prerender: target.prerenderAllowed(),
+    });
     if (!toBuild) {
       return;
     }


### PR DESCRIPTION
Partial for #31915.
Possibly conflicts with #31591.

The key points:
* A custom element has the static layout applied, but it's not constructed or built until later.
* An IntersectionObserver checks an element's parsed state and intersection with 3.5 viewports and builds it then.
* An element can be built manually.
* Prerender mode is supported.
* The current attempt implements "auto-layout". We need to discuss whether this is a good idea or not.
* The `onload/onerror` structure allows to pick up multiple loading events when src changes, an iframe is paused, connect/reconnect happened, etc.
