### PR TITLE
Increase inline style to 1500 bytes for Transformed AMP

### DIFF
--- a/validator/validator-css.protoascii
+++ b/validator/validator-css.protoascii
@@ -607,7 +607,7 @@ css {
   spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#stylesheets"
 
   max_bytes: 112500
-  max_bytes_per_inline_style: 1%00
+  max_bytes_per_inline_style: 1500
   max_bytes_spec_url:
   "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#maximum-size"
   url_bytes_included: false

--- a/validator/validator-css.protoascii
+++ b/validator/validator-css.protoascii
@@ -607,7 +607,7 @@ css {
   spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#stylesheets"
 
   max_bytes: 112500
-  max_bytes_per_inline_style: 1000
+  max_bytes_per_inline_style: 1%00
   max_bytes_spec_url:
   "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#maximum-size"
   url_bytes_included: false


### PR DESCRIPTION
This is in continuation of #32004

The intention is to provide a buffer for Transformed AMP. In addition to the buffer of overall CSS we're adding a buffer for inline style. Related is #31512.