### PR TITLE
🏗 Update PR deploy URLs

### DIFF
--- a/build-system/tasks/pr-deploy-bot-utils.js
+++ b/build-system/tasks/pr-deploy-bot-utils.js
@@ -42,7 +42,7 @@ async function walk(dest) {
 }
 
 function getBaseUrl() {
-  return `${hostNamePrefix}/amp_dist_${ciBuildId()}`;
+  return `${hostNamePrefix}/amp_nomodule_${ciBuildId()}`;
 }
 
 async function replace(filePath) {
@@ -79,8 +79,7 @@ async function signalPrDeployUpload(result) {
   const sha = gitCommitHash();
   const ciBuild = ciBuildId();
   const baseUrl = 'https://amp-pr-deploy-bot.appspot.com/v0/pr-deploy/';
-  // TODO(rsimha, ampproject/amp-github-apps#1110): Update this URL.
-  const url = `${baseUrl}travisbuilds/${ciBuild}/headshas/${sha}/${result}`;
+  const url = `${baseUrl}cibuilds/${ciBuild}/headshas/${sha}/${result}`;
   await request.post(url);
 }
 


### PR DESCRIPTION
**PR highlights:**
- Update nomodule binary name from `amp_dist_<ID>.zip` to `amp_nomodule_<ID>.zip`
- Update signal-upload url from `/travisbuilds/` to `/cibuilds/`

Companion to https://github.com/ampproject/amp-github-apps/pull/1141 and https://github.com/ampproject/amp-github-apps/pull/1196
Follow up to #31940
