### PR TITLE
🏗 Expose and fix silent failure in ava tests

### DIFF
--- a/build-system/tasks/ava.js
+++ b/build-system/tasks/ava.js
@@ -17,13 +17,12 @@
 
 const gulp = require('gulp');
 const gulpAva = require('gulp-ava');
-const {isCiBuild} = require('../common/ci');
 
 /**
  * Runs ava tests.
  * @return {!Vinyl}
  */
-async function ava() {
+function ava() {
   return gulp
     .src([
       require.resolve('./csvify-size/test.js'),
@@ -34,7 +33,6 @@ async function ava() {
       gulpAva({
         'concurrency': 5,
         'failFast': true,
-        'silent': isCiBuild(),
       })
     );
 }

--- a/build-system/tasks/get-zindex/test-2.css
+++ b/build-system/tasks/get-zindex/test-2.css
@@ -28,3 +28,11 @@
 .selector-4 {
   z-index: 80;
 }
+
+.selector-5 {
+  z-index: initial;
+}
+
+.selector-6 {
+  z-index: auto;
+}


### PR DESCRIPTION
**PR highlights:**

- Fixes bug due to transitive dependency (gulp 3 -> 4) of the gulp-ava plugin (the task should no longer be `async`)
- Exposes and fixes a test failure introduced by #29275

![image](https://user-images.githubusercontent.com/26553114/104825017-20aa5480-5825-11eb-9f95-346fc4000149.png)

