### PR TITLE
🏗  New logging helper for build-system

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -25,7 +25,6 @@
 
 'use strict';
 
-const log = require('fancy-log');
 const {
   getDepCheckConfig,
   getPostClosureConfig,
@@ -35,6 +34,7 @@ const {
   getEslintConfig,
 } = require('./build-system/babel-config');
 const {cyan, yellow} = require('ansi-colors');
+const {log} = require('./build-system/common/logging');
 
 /**
  * Mapping of babel transform callers to their corresponding babel configs.

--- a/build-system/common/ctrlcHandler.js
+++ b/build-system/common/ctrlcHandler.js
@@ -15,9 +15,8 @@
  */
 
 const colors = require('ansi-colors');
-const log = require('fancy-log');
 const {execScriptAsync, exec} = require('./exec');
-const {isCiBuild} = require('./ci');
+const {logLocalDev} = require('./logging');
 
 const {green, cyan} = colors;
 
@@ -32,14 +31,12 @@ const killSuffix = process.platform == 'win32' ? '>NUL' : '';
  * @return {number}
  */
 exports.createCtrlcHandler = function (command) {
-  if (!isCiBuild()) {
-    log(
-      green('Running'),
-      cyan(command) + green('. Press'),
-      cyan('Ctrl + C'),
-      green('to cancel...')
-    );
-  }
+  logLocalDev(
+    green('Running'),
+    cyan(command) + green('. Press'),
+    cyan('Ctrl + C'),
+    green('to cancel...')
+  );
   const killMessage =
     green('\nDetected ') +
     cyan('Ctrl + C') +

--- a/build-system/common/exec.js
+++ b/build-system/common/exec.js
@@ -20,7 +20,7 @@
  */
 
 const childProcess = require('child_process');
-const log = require('fancy-log');
+const {log} = require('./logging');
 const {spawnProcess, getOutput, getStdout, getStderr} = require('./process');
 const {yellow} = require('ansi-colors');
 

--- a/build-system/common/logging.js
+++ b/build-system/common/logging.js
@@ -1,0 +1,100 @@
+/**
+ * Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+const log = require('fancy-log');
+const {bold, yellow} = require('ansi-colors');
+const {isCiBuild} = require('./ci');
+
+let loggingPrefix = '';
+
+/**
+ * Sets the logging prefix for the ongoing PR check job
+ * @param {string} prefix
+ */
+function setLoggingPrefix(prefix) {
+  loggingPrefix = prefix;
+}
+
+/**
+ * Returns the formatted logging prefix for the ongoing PR check job
+ * @return {string}
+ */
+function getLoggingPrefix() {
+  return bold(yellow(loggingPrefix));
+}
+
+/**
+ * Logs messages only during local development
+ * @param  {...string} messages
+ */
+function logLocalDev(...messages) {
+  if (!isCiBuild()) {
+    log(...messages);
+  }
+}
+
+/**
+ * Logs messages on the same line to indicate progress
+ * @param {...string} messages
+ */
+function logOnSameLine(...messages) {
+  if (!isCiBuild() && process.stdout.isTTY) {
+    process.stdout.moveCursor(0, -1);
+    process.stdout.cursorTo(0);
+    process.stdout.clearLine();
+  }
+  log(...messages);
+}
+
+/**
+ * Logs messages on the same line only during local development
+ * @param {...string} messages
+ */
+function logOnSameLineLocalDev(...messages) {
+  if (!isCiBuild()) {
+    logOnSameLine(...messages);
+  }
+}
+
+/**
+ * Logs messages without the fancy-log timestamp
+ * @param {...string} messages
+ */
+function logWithoutTimestamp(...messages) {
+  console.log(...messages);
+}
+
+/**
+ * Logs messages without the fancy-log timestamp only during local development
+ * @param {...string} messages
+ */
+function logWithoutTimestampLocalDev(...messages) {
+  if (!isCiBuild()) {
+    console.log(...messages);
+  }
+}
+
+module.exports = {
+  getLoggingPrefix,
+  log,
+  logLocalDev,
+  logOnSameLine,
+  logOnSameLineLocalDev,
+  logWithoutTimestamp,
+  logWithoutTimestampLocalDev,
+  setLoggingPrefix,
+};

--- a/build-system/common/utils.js
+++ b/build-system/common/utils.js
@@ -17,7 +17,6 @@
 const argv = require('minimist')(process.argv.slice(2));
 const fs = require('fs-extra');
 const globby = require('globby');
-const log = require('fancy-log');
 const path = require('path');
 const {clean} = require('../tasks/clean');
 const {doBuild} = require('../tasks/build');
@@ -25,7 +24,7 @@ const {doDist} = require('../tasks/dist');
 const {execOrDie} = require('./exec');
 const {gitDiffNameOnlyMaster} = require('./git');
 const {green, cyan, yellow} = require('ansi-colors');
-const {isCiBuild} = require('./ci');
+const {log, logLocalDev} = require('./logging');
 
 const ROOT_DIR = path.resolve(__dirname, '../../');
 
@@ -44,20 +43,6 @@ async function buildRuntime(opt_compiled = false) {
   } else {
     await doBuild({fortesting: true});
   }
-}
-
-/**
- * Logs a message on the same line to indicate progress
- *
- * @param {string} message
- */
-function logOnSameLine(message) {
-  if (!isCiBuild() && process.stdout.isTTY) {
-    process.stdout.moveCursor(0, -1);
-    process.stdout.cursorTo(0);
-    process.stdout.clearLine();
-  }
-  log(message);
 }
 
 /**
@@ -81,11 +66,9 @@ function getFilesChanged(globs) {
  * @return {!Array<string>}
  */
 function logFiles(files) {
-  if (!isCiBuild()) {
-    log(green('INFO: ') + 'Checking the following files:');
-    for (const file of files) {
-      log(cyan(file));
-    }
+  logLocalDev(green('INFO: ') + 'Checking the following files:');
+  for (const file of files) {
+    logLocalDev(cyan(file));
   }
   return files;
 }
@@ -180,6 +163,5 @@ module.exports = {
   getFilesFromArgv,
   getFilesToCheck,
   installPackages,
-  logOnSameLine,
   usesFilesOrLocalChanges,
 };

--- a/build-system/compile/bundles.config.js
+++ b/build-system/compile/bundles.config.js
@@ -16,10 +16,10 @@
 'use strict';
 
 const argv = require('minimist')(process.argv.slice(2));
-const colors = require('ansi-colors');
 const extensionBundles = require('./bundles.config.extensions.json');
-const log = require('fancy-log');
 const wrappers = require('./compile-wrappers');
+const {cyan, red} = require('ansi-colors');
+const {log} = require('../common/logging');
 
 const {VERSION: internalRuntimeVersion} = require('./internal-version');
 
@@ -232,13 +232,7 @@ exports.extensionAliasBundles = {
  */
 function verifyBundle_(condition, field, message, name, found) {
   if (!condition) {
-    log(
-      colors.red('ERROR:'),
-      colors.cyan(field),
-      message,
-      colors.cyan(name),
-      '\n' + found
-    );
+    log(red('ERROR:'), cyan(field), message, cyan(name), '\n' + found);
     process.exit(1);
   }
 }

--- a/build-system/compile/check-for-unknown-deps.js
+++ b/build-system/compile/check-for-unknown-deps.js
@@ -15,8 +15,8 @@
  */
 'use strict';
 
-const log = require('fancy-log');
 const through = require('through2');
+const {log} = require('../common/logging');
 const {red, cyan, yellow} = require('ansi-colors');
 
 /**

--- a/build-system/compile/closure-compile.js
+++ b/build-system/compile/closure-compile.js
@@ -16,13 +16,13 @@
 'use strict';
 
 const closureCompiler = require('@ampproject/google-closure-compiler');
-const log = require('fancy-log');
 const path = require('path');
 const pumpify = require('pumpify');
 const sourcemaps = require('gulp-sourcemaps');
 const {cyan, red, yellow} = require('ansi-colors');
 const {EventEmitter} = require('events');
 const {highlight} = require('cli-highlight');
+const {log} = require('../common/logging');
 
 let compilerErrors = '';
 

--- a/build-system/compile/debug-compilation-lifecycle.js
+++ b/build-system/compile/debug-compilation-lifecycle.js
@@ -15,11 +15,11 @@
  */
 'use strict';
 const argv = require('minimist')(process.argv.slice(2));
-const colors = require('ansi-colors');
 const fs = require('fs');
-const log = require('fancy-log');
 const path = require('path');
 const tempy = require('tempy');
+const {cyan, red} = require('ansi-colors');
+const {log} = require('../common/logging');
 
 const logFile = path.resolve(process.cwd(), 'dist', 'debug-compilation.log');
 
@@ -65,7 +65,7 @@ function debug(lifecycle, fullpath, content, sourcemap) {
 
 function displayLifecycleDebugging() {
   if (argv.debug) {
-    log(colors.white('Debug Lifecycles: ') + colors.red(logFile));
+    log(cyan('Debug Lifecycles: ') + red(logFile));
   }
 }
 

--- a/build-system/compile/log-messages.js
+++ b/build-system/compile/log-messages.js
@@ -15,8 +15,8 @@
  */
 const argv = require('minimist')(process.argv.slice(2));
 const fs = require('fs-extra');
-const log = require('fancy-log');
 const {cyan} = require('colors');
+const {log} = require('../common/logging');
 
 const pathPrefix = 'dist/log-messages';
 

--- a/build-system/compile/pre-closure-babel.js
+++ b/build-system/compile/pre-closure-babel.js
@@ -17,12 +17,12 @@
 
 const globby = require('globby');
 const gulpBabel = require('gulp-babel');
-const log = require('fancy-log');
 const path = require('path');
 const through = require('through2');
 const {BABEL_SRC_GLOBS, THIRD_PARTY_TRANSFORM_GLOBS} = require('./sources');
 const {debug, CompilationLifecycles} = require('./debug-compilation-lifecycle');
 const {EventEmitter} = require('events');
+const {log} = require('../common/logging');
 const {red, cyan} = require('ansi-colors');
 
 /**

--- a/build-system/compile/typescript.js
+++ b/build-system/compile/typescript.js
@@ -15,12 +15,12 @@
  */
 'use strict';
 
-const colors = require('ansi-colors');
 const fs = require('fs-extra');
-const log = require('fancy-log');
 const path = require('path');
 const ts = require('typescript');
 const tsickle = require('tsickle');
+const {log} = require('../common/logging');
+const {red} = require('ansi-colors');
 
 /**
  * Given a file path `foo/bar.js`, transpiles the TypeScript entry point of
@@ -41,7 +41,7 @@ exports.transpileTs = async function (srcDir, srcFilename) {
   );
   const tsOptions = tsConfig.options;
   if (tsConfig.errors.length) {
-    log(colors.red('TSickle:'), tsickle.formatDiagnostics(tsConfig.errors));
+    log(red('TSickle:'), tsickle.formatDiagnostics(tsConfig.errors));
   }
 
   const compilerHost = ts.createCompilerHost(tsOptions);
@@ -81,6 +81,6 @@ exports.transpileTs = async function (srcDir, srcFilename) {
     .getPreEmitDiagnostics(program)
     .concat(emitResult.diagnostics);
   if (diagnostics.length) {
-    log(colors.red('TSickle:'), tsickle.formatDiagnostics(diagnostics));
+    log(red('TSickle:'), tsickle.formatDiagnostics(diagnostics));
   }
 };

--- a/build-system/server/app-utils.js
+++ b/build-system/server/app-utils.js
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-const log = require('fancy-log');
 const minimist = require('minimist');
 const {cyan, green} = require('ansi-colors');
+const {log} = require('../common/logging');
 
 let serveMode = 'default';
 

--- a/build-system/server/app.js
+++ b/build-system/server/app.js
@@ -45,6 +45,7 @@ const {
   recaptchaRouter,
 } = require('./recaptcha-router');
 const {getServeMode} = require('./app-utils');
+const {logWithoutTimestamp} = require('../common/logging');
 const {renderShadowViewer} = require('./shadow-viewer');
 const {replaceUrls, isRtvMode} = require('./app-utils');
 
@@ -156,7 +157,7 @@ app.get('/proxy', async (req, res, next) => {
     const proxyUrl = `${modePrefix}/proxy/s/${ampdocUrlSuffix}`;
     res.redirect(proxyUrl);
   } catch ({message}) {
-    console.log(`ERROR: ${message}`);
+    logWithoutTimestamp(`ERROR: ${message}`);
     next();
   }
 });
@@ -170,7 +171,7 @@ app.get('/proxy', async (req, res, next) => {
  */
 function requestAmphtmlDocUrl(urlSuffix, protocol = 'https') {
   const defaultUrl = `${protocol}://${urlSuffix}`;
-  console.log(`Fetching URL: ${defaultUrl}`);
+  logWithoutTimestamp(`Fetching URL: ${defaultUrl}`);
   return new Promise((resolve, reject) => {
     request(defaultUrl, (error, response, body) => {
       if (
@@ -489,7 +490,7 @@ function proxyToAmpProxy(req, res, mode) {
     'https://cdn.ampproject.org/' +
     (req.query['amp_js_v'] ? 'v' : 'c') +
     req.url;
-  console.log('Fetching URL: ' + url);
+  logWithoutTimestamp('Fetching URL: ' + url);
   request(url, function (error, response, body) {
     body = body
       // Unversion URLs.
@@ -555,7 +556,7 @@ app.use('/examples/live-list-update(-reverse)?.amp.html', (req, res, next) => {
   }
   if (!liveListDoc) {
     const liveListUpdateFullPath = `${pc.cwd()}${req.baseUrl}`;
-    console.log('liveListUpdateFullPath', liveListUpdateFullPath);
+    logWithoutTimestamp('liveListUpdateFullPath', liveListUpdateFullPath);
     const liveListFile = fs.readFileSync(liveListUpdateFullPath);
     liveListDoc = liveListDocs[req.baseUrl] = new jsdom.JSDOM(
       liveListFile
@@ -614,7 +615,7 @@ function liveListReplace(item) {
 
 function liveListInsert(liveList, node) {
   const iterCount = Math.floor(Math.random() * 2) + 1;
-  console.log(`inserting ${iterCount} item(s)`);
+  logWithoutTimestamp(`inserting ${iterCount} item(s)`);
   for (let i = 0; i < iterCount; i++) {
     const child = node.cloneNode(true);
     child.setAttribute('id', `list-item-${itemCtr++}`);
@@ -625,7 +626,7 @@ function liveListInsert(liveList, node) {
 
 function liveListTombstone(liveList) {
   const tombstoneId = Math.floor(Math.random() * itemCtr);
-  console.log(`trying to tombstone #list-item-${tombstoneId}`);
+  logWithoutTimestamp(`trying to tombstone #list-item-${tombstoneId}`);
   // We can tombstone any list item except item-1 since we always do a
   // replace example on item-1.
   if (tombstoneId != 1) {

--- a/build-system/server/routes/a4a-envelopes.js
+++ b/build-system/server/routes/a4a-envelopes.js
@@ -16,9 +16,9 @@
 
 const app = require('express').Router();
 const fs = require('fs');
-const log = require('fancy-log');
 const request = require('request');
 const {getServeMode, replaceUrls} = require('../app-utils');
+const {log} = require('../../common/logging');
 const {red} = require('ansi-colors');
 
 // In-a-box envelope.

--- a/build-system/server/typescript-compile.js
+++ b/build-system/server/typescript-compile.js
@@ -13,10 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-const log = require('fancy-log');
 const pathModule = require('path');
 const {cyan, green} = require('ansi-colors');
 const {exec} = require('../common/exec');
+const {log} = require('../common/logging');
 
 const SERVER_TRANSFORM_PATH = 'build-system/server/new-server/transforms';
 

--- a/build-system/tasks/build.js
+++ b/build-system/tasks/build.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-const log = require('fancy-log');
 const {
   bootstrapThirdPartyFrames,
   compileAllJs,
@@ -30,6 +29,7 @@ const {buildExtensions} = require('./extension-helpers');
 const {compileCss} = require('./css');
 const {compileJison} = require('./compile-jison');
 const {cyan, green, yellow} = require('ansi-colors');
+const {log} = require('../common/logging');
 const {maybeUpdatePackages} = require('./update-packages');
 const {parseExtensionFlags} = require('./extension-helpers');
 

--- a/build-system/tasks/bundle-size/index.js
+++ b/build-system/tasks/bundle-size/index.js
@@ -17,7 +17,6 @@
 
 const argv = require('minimist')(process.argv.slice(2));
 const globby = require('globby');
-const log = require('fancy-log');
 const path = require('path');
 const url = require('url');
 const util = require('util');
@@ -36,6 +35,7 @@ const {
   VERSION: internalRuntimeVersion,
 } = require('../../compile/internal-version');
 const {cyan, green, red, yellow} = require('ansi-colors');
+const {log} = require('../../common/logging');
 const {report, Report} = require('@ampproject/filesize');
 
 const requestPost = util.promisify(require('request').post);

--- a/build-system/tasks/caches-json.js
+++ b/build-system/tasks/caches-json.js
@@ -15,10 +15,10 @@
  */
 'use strict';
 
-const colors = require('ansi-colors');
 const gulp = require('gulp');
-const log = require('fancy-log');
 const through2 = require('through2');
+const {log} = require('../common/logging');
+const {red, yellow} = require('ansi-colors');
 
 const expectedCaches = ['google'];
 
@@ -37,7 +37,7 @@ async function cachesJson() {
         obj = JSON.parse(file.contents.toString());
       } catch (e) {
         log(
-          colors.yellow(
+          yellow(
             `Could not parse ${cachesJsonPath}. ` +
               'This is most likely a fatal error that ' +
               'will be found by checkValidJson'
@@ -52,9 +52,7 @@ async function cachesJson() {
       for (const cache of expectedCaches) {
         if (!foundCaches.includes(cache)) {
           log(
-            colors.red(
-              'Missing expected cache "' + cache + `" in ${cachesJsonPath}`
-            )
+            red('Missing expected cache "' + cache + `" in ${cachesJsonPath}`)
           );
           process.exitCode = 1;
         }

--- a/build-system/tasks/check-exact-versions.js
+++ b/build-system/tasks/check-exact-versions.js
@@ -15,11 +15,10 @@
  */
 'use strict';
 
-const colors = require('ansi-colors');
-const log = require('fancy-log');
+const {cyan, green, red} = require('ansi-colors');
 const {getStderr} = require('../common/exec');
 const {gitDiffFileMaster} = require('../common/git');
-const {isCiBuild} = require('../common/ci');
+const {log, logLocalDev, logWithoutTimestamp} = require('../common/logging');
 
 const PACKAGE_JSON_PATHS = [
   'package.json',
@@ -41,22 +40,20 @@ async function checkExactVersions() {
     const err = getStderr(checkerCmd);
     if (err) {
       log(
-        colors.red('ERROR:'),
+        red('ERROR:'),
         'One or more packages in',
-        colors.cyan(file),
+        cyan(file),
         'do not have an exact version.'
       );
-      console.log(gitDiffFileMaster(file));
+      logWithoutTimestamp(gitDiffFileMaster(file));
       success = false;
     } else {
-      if (!isCiBuild()) {
-        log(
-          colors.green('SUCCESS:'),
-          'All packages in',
-          colors.cyan(file),
-          'have exact versions.'
-        );
-      }
+      logLocalDev(
+        green('SUCCESS:'),
+        'All packages in',
+        cyan(file),
+        'have exact versions.'
+      );
     }
   });
   if (success) {

--- a/build-system/tasks/check-links.js
+++ b/build-system/tasks/check-links.js
@@ -16,14 +16,13 @@
 'use strict';
 
 const fs = require('fs-extra');
-const log = require('fancy-log');
 const markdownLinkCheck = require('markdown-link-check');
 const path = require('path');
 const {getFilesToCheck, usesFilesOrLocalChanges} = require('../common/utils');
 const {gitDiffAddedNameOnlyMaster} = require('../common/git');
 const {green, cyan, red, yellow} = require('ansi-colors');
-const {isCiBuild} = require('../common/ci');
 const {linkCheckGlobs} = require('../test-configs/config');
+const {log, logLocalDev} = require('../common/logging');
 const {maybeUpdatePackages} = require('./update-packages');
 
 const LARGE_REFACTOR_THRESHOLD = 20;
@@ -47,9 +46,7 @@ async function checkLinks() {
     log(green('INFO:'), 'Skipping check because this is a large refactor.');
     return;
   }
-  if (!isCiBuild()) {
-    log(green('Starting checks...'));
-  }
+  logLocalDev(green('Starting checks...'));
   filesIntroducedByPr = gitDiffAddedNameOnlyMaster();
   const results = await Promise.all(filesToCheck.map(checkLinksInFile));
   reportResults(results);
@@ -152,14 +149,10 @@ function checkLinksInFile(file) {
         }
         switch (status) {
           case 'alive':
-            if (!isCiBuild()) {
-              log(`[${green('✔')}] ${link}`);
-            }
+            logLocalDev(`[${green('✔')}] ${link}`);
             break;
           case 'ignored':
-            if (!isCiBuild()) {
-              log(`[${yellow('•')}] ${link}`);
-            }
+            logLocalDev(`[${yellow('•')}] ${link}`);
             break;
           case 'dead':
             containsDeadLinks = true;

--- a/build-system/tasks/check-owners.js
+++ b/build-system/tasks/check-owners.js
@@ -24,12 +24,11 @@
 
 const fs = require('fs-extra');
 const JSON5 = require('json5');
-const log = require('fancy-log');
 const request = require('request');
 const util = require('util');
 const {cyan, red, green} = require('ansi-colors');
 const {getFilesToCheck, usesFilesOrLocalChanges} = require('../common/utils');
-const {isCiBuild} = require('../common/ci');
+const {log, logLocalDev} = require('../common/logging');
 
 const requestPost = util.promisify(request.post);
 
@@ -65,9 +64,7 @@ async function checkFile(file) {
   const contents = fs.readFileSync(file, 'utf8').toString();
   try {
     JSON5.parse(contents);
-    if (!isCiBuild()) {
-      log(green('SUCCESS:'), 'No errors in', cyan(file));
-    }
+    logLocalDev(green('SUCCESS:'), 'No errors in', cyan(file));
   } catch {
     log(red('FAILURE:'), 'Found errors in', cyan(file));
     process.exitCode = 1;

--- a/build-system/tasks/check-renovate-config.js
+++ b/build-system/tasks/check-renovate-config.js
@@ -49,9 +49,9 @@
 
 'use strict';
 
-const log = require('fancy-log');
 const {cyan, red, green} = require('ansi-colors');
 const {getOutput} = require('../common/exec');
+const {log} = require('../common/logging');
 
 /**
  * Checks Renovate config for correctness using the validator provided by the

--- a/build-system/tasks/check-sourcemaps.js
+++ b/build-system/tasks/check-sourcemaps.js
@@ -17,10 +17,10 @@
 
 const argv = require('minimist')(process.argv.slice(2));
 const fs = require('fs');
-const log = require('fancy-log');
 const {cyan, green, red} = require('ansi-colors');
 const {decode} = require('sourcemap-codec');
 const {execOrDie} = require('../common/exec');
+const {log} = require('../common/logging');
 
 // Compile related constants
 const distWithSourcemapsCmd = 'gulp dist --core_runtime_only --full_sourcemaps';

--- a/build-system/tasks/check-types.js
+++ b/build-system/tasks/check-types.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-const log = require('fancy-log');
 const {
   createCtrlcHandler,
   exitCtrlcHandler,
@@ -25,6 +24,7 @@ const {
 const {cleanupBuildDir, closureCompile} = require('../compile/compile');
 const {compileCss} = require('./css');
 const {extensions, maybeInitializeExtensions} = require('./extension-helpers');
+const {log} = require('../common/logging');
 const {maybeUpdatePackages} = require('./update-packages');
 
 /**

--- a/build-system/tasks/cherry-pick.js
+++ b/build-system/tasks/cherry-pick.js
@@ -16,9 +16,9 @@
 'use strict';
 
 const argv = require('minimist')(process.argv.slice(2));
-const log = require('fancy-log');
 const {execOrThrow, getOutput} = require('../common/exec');
 const {green, cyan, red, yellow} = require('ansi-colors');
+const {log} = require('../common/logging');
 
 /**
  * Determines the name of the cherry-pick branch.

--- a/build-system/tasks/clean.js
+++ b/build-system/tasks/clean.js
@@ -17,9 +17,9 @@
 
 const argv = require('minimist')(process.argv.slice(2));
 const del = require('del');
-const log = require('fancy-log');
 const path = require('path');
 const {cyan} = require('ansi-colors');
+const {log} = require('../common/logging');
 
 const ROOT_DIR = path.resolve(__dirname, '../../');
 

--- a/build-system/tasks/codecov-upload.js
+++ b/build-system/tasks/codecov-upload.js
@@ -17,7 +17,6 @@
 
 const colors = require('ansi-colors');
 const fs = require('fs-extra');
-const log = require('fancy-log');
 const {
   ciCommitSha,
   ciPullRequestSha,
@@ -25,6 +24,7 @@ const {
   isPullRequestBuild,
 } = require('../common/ci');
 const {getStdout} = require('../common/exec');
+const {log} = require('../common/logging');
 const {shortSha} = require('../common/git');
 
 const {green, yellow, cyan} = colors;

--- a/build-system/tasks/coverage-map/index.js
+++ b/build-system/tasks/coverage-map/index.js
@@ -15,11 +15,11 @@
  */
 const argv = require('minimist')(process.argv.slice(2));
 const fs = require('fs').promises;
-const log = require('fancy-log');
 const {buildNewServer} = require('../../server/typescript-compile');
 const {cyan} = require('ansi-colors');
 const {dist} = require('../dist');
 const {installPackages} = require('../../common/utils');
+const {log} = require('../../common/logging');
 const {startServer, stopServer} = require('../serve');
 
 const coverageJsonName = argv.json || 'coverage.json';

--- a/build-system/tasks/csvify-size/index.js
+++ b/build-system/tasks/csvify-size/index.js
@@ -16,10 +16,10 @@
 'use strict';
 
 const childProcess = require('child_process');
-const colors = require('ansi-colors');
 const fs = require('fs');
-const log = require('fancy-log');
 const util = require('util');
+const {log} = require('../../common/logging');
+const {red} = require('ansi-colors');
 
 const exec = util.promisify(childProcess.exec);
 
@@ -250,7 +250,7 @@ async function serializeCheckout(logs) {
         tables.push([]);
       }
 
-      log(colors.red(e.message));
+      log(red(e.message));
     }
   }
 

--- a/build-system/tasks/default-task.js
+++ b/build-system/tasks/default-task.js
@@ -15,10 +15,10 @@
  */
 
 const argv = require('minimist')(process.argv.slice(2));
-const log = require('fancy-log');
 const {createCtrlcHandler} = require('../common/ctrlcHandler');
 const {cyan, green} = require('ansi-colors');
 const {doServe} = require('./serve');
+const {log} = require('../common/logging');
 const {maybeUpdatePackages} = require('./update-packages');
 const {parseExtensionFlags} = require('./extension-helpers');
 const {printConfigHelp} = require('./helpers');

--- a/build-system/tasks/dep-check.js
+++ b/build-system/tasks/dep-check.js
@@ -20,7 +20,6 @@ const browserify = require('browserify');
 const depCheckConfig = require('../test-configs/dep-check-config');
 const fs = require('fs-extra');
 const gulp = require('gulp');
-const log = require('fancy-log');
 const minimatch = require('minimatch');
 const path = require('path');
 const source = require('vinyl-source-stream');
@@ -32,7 +31,7 @@ const {
 const {compileJison} = require('./compile-jison');
 const {css} = require('./css');
 const {cyan, red, yellow} = require('ansi-colors');
-const {isCiBuild} = require('../common/ci');
+const {log, logLocalDev} = require('../common/logging');
 
 const root = process.cwd();
 const absPathRegExp = new RegExp(`^${root}/`);
@@ -306,9 +305,7 @@ async function depCheck() {
   const handlerProcess = createCtrlcHandler('dep-check');
   await css();
   await compileJison();
-  if (!isCiBuild()) {
-    log('Checking dependencies...');
-  }
+  logLocalDev('Checking dependencies...');
   return getSrcs()
     .then((entryPoints) => {
       // This check is for extension folders that actually dont have

--- a/build-system/tasks/dist.js
+++ b/build-system/tasks/dist.js
@@ -18,7 +18,6 @@ const colors = require('ansi-colors');
 const file = require('gulp-file');
 const fs = require('fs-extra');
 const gulp = require('gulp');
-const log = require('fancy-log');
 const {
   bootstrapThirdPartyFrames,
   compileAllJs,
@@ -43,6 +42,7 @@ const {cleanupBuildDir} = require('../compile/compile');
 const {compileCss, cssEntryPoints} = require('./css');
 const {compileJison} = require('./compile-jison');
 const {formatExtractedMessages} = require('../compile/log-messages');
+const {log} = require('../common/logging');
 const {maybeUpdatePackages} = require('./update-packages');
 const {VERSION} = require('../compile/internal-version');
 

--- a/build-system/tasks/e2e/index.js
+++ b/build-system/tasks/e2e/index.js
@@ -23,7 +23,6 @@ const dotsReporter = require('./mocha-dots-reporter');
 const fs = require('fs');
 const glob = require('glob');
 const http = require('http');
-const log = require('fancy-log');
 const Mocha = require('mocha');
 const path = require('path');
 const {
@@ -35,6 +34,7 @@ const {cyan} = require('ansi-colors');
 const {execOrDie} = require('../../common/exec');
 const {HOST, PORT, startServer, stopServer} = require('../serve');
 const {isCiBuild} = require('../../common/ci');
+const {log} = require('../../common/logging');
 const {maybePrintCoverageMessage} = require('../helpers');
 const {reportTestStarted} = require('../report-test-status');
 const {watch} = require('gulp');

--- a/build-system/tasks/e2e/mocha-dots-reporter.js
+++ b/build-system/tasks/e2e/mocha-dots-reporter.js
@@ -15,8 +15,8 @@
  */
 'use strict';
 
-const log = require('fancy-log');
 const Mocha = require('mocha');
+const {log, logWithoutTimestamp} = require('../../common/logging');
 const {
   EVENT_RUN_BEGIN,
   EVENT_RUN_END,
@@ -63,7 +63,7 @@ class MochaDotsReporter extends Base {
       .once(EVENT_RUN_END, () => {
         Base.list(this.failures);
         const {passes, pending, failures, tests} = runner.stats;
-        console.log(
+        logWithoutTimestamp(
           `Executed ${failures + passes} of ${tests}`,
           `(Skipped ${pending})`,
           failures == 0 ? green('SUCCESS') : red(`${failures} FAILED`)

--- a/build-system/tasks/extension-generator/bento/index.js
+++ b/build-system/tasks/extension-generator/bento/index.js
@@ -23,9 +23,9 @@
 
 const argv = require('minimist')(process.argv.slice(2));
 const fs = require('fs').promises;
-const log = require('fancy-log');
 const path = require('path');
 const {cyan, green, red, yellow} = require('ansi-colors');
+const {log} = require('../../../common/logging');
 
 const EXTENSIONS_DIR = path.join(__dirname, '../../../../extensions');
 const TEMPLATE_DIR = path.join(__dirname, 'amp-__component_name_hyphenated__');

--- a/build-system/tasks/extension-generator/index.js
+++ b/build-system/tasks/extension-generator/index.js
@@ -16,13 +16,13 @@
 'use strict';
 
 const argv = require('minimist')(process.argv.slice(2));
-const colors = require('ansi-colors');
 const fs = require('fs-extra');
-const log = require('fancy-log');
 const path = require('path');
 const {
   insertExtensionBundlesConfig,
 } = require('./insert-extension-bundles-config');
+const {cyan, green, red} = require('ansi-colors');
+const {log} = require('../../common/logging');
 const {makeBentoExtension} = require('./bento');
 
 const year = new Date().getFullYear();
@@ -234,7 +234,7 @@ function getExamplesFile(name) {
 
 async function makeAmpExtension() {
   if (!argv.name) {
-    log(colors.red('Error! Please pass in the "--name" flag with a value'));
+    log(red('Error! Please pass in the "--name" flag with a value'));
   }
   const {name, version = '0.1'} = argv;
   const examplesFile = getExamplesFile(name);
@@ -293,7 +293,7 @@ async function makeExtension() {
 
   // Update bundles.config.js with an entry for the new component
   insertExtensionBundlesConfig(bundleConfig);
-  log(colors.green('SUCCESS:'), 'Wrote', colors.cyan('bundles.config.js'));
+  log(green('SUCCESS:'), 'Wrote', cyan('bundles.config.js'));
 }
 
 module.exports = {

--- a/build-system/tasks/extension-helpers.js
+++ b/build-system/tasks/extension-helpers.js
@@ -17,7 +17,6 @@
 const colors = require('ansi-colors');
 const debounce = require('debounce');
 const fs = require('fs-extra');
-const log = require('fancy-log');
 const wrappers = require('../compile/compile-wrappers');
 const {
   extensionAliasBundles,
@@ -27,6 +26,7 @@ const {
 const {endBuildStep, watchDebounceDelay} = require('./helpers');
 const {isCiBuild} = require('../common/ci');
 const {jsifyCssAsync} = require('./jsify-css');
+const {log} = require('../common/logging');
 const {maybeToEsmName, compileJs, mkdirSync} = require('./helpers');
 const {vendorConfigs} = require('./vendor-configs');
 const {watch} = require('gulp');

--- a/build-system/tasks/firebase.js
+++ b/build-system/tasks/firebase.js
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 const argv = require('minimist')(process.argv.slice(2));
-const colors = require('ansi-colors');
 const fs = require('fs-extra');
-const log = require('fancy-log');
 const path = require('path');
 const {clean} = require('./clean');
 const {doBuild} = require('./build');
 const {doDist} = require('./dist');
+const {green} = require('ansi-colors');
+const {log} = require('../common/logging');
 
 async function walk(dest) {
   const filelist = [];
@@ -58,18 +58,18 @@ async function firebase() {
   }
   await fs.mkdirp('firebase');
   if (argv.file) {
-    log(colors.green(`Processing file: ${argv.file}.`));
-    log(colors.green('Writing file to firebase.index.html.'));
+    log(green(`Processing file: ${argv.file}.`));
+    log(green('Writing file to firebase.index.html.'));
     await fs.copyFile(/*src*/ argv.file, 'firebase/index.html');
     await replaceUrls('firebase/index.html');
   } else {
-    log(colors.green('Copying test/manual and examples folders.'));
+    log(green('Copying test/manual and examples folders.'));
     await Promise.all([
       copyAndReplaceUrls('test/manual', 'firebase/manual'),
       copyAndReplaceUrls('examples', 'firebase/examples'),
     ]);
   }
-  log(colors.green('Copying local amp files from dist folder.'));
+  log(green('Copying local amp files from dist folder.'));
   await Promise.all([
     fs.copy('dist', 'firebase/dist', {overwrite: true}),
     fs.copy('dist.3p/current', 'firebase/dist.3p/current', {overwrite: true}),

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -23,7 +23,6 @@ const del = require('del');
 const file = require('gulp-file');
 const fs = require('fs-extra');
 const gulp = require('gulp');
-const log = require('fancy-log');
 const open = require('open');
 const path = require('path');
 const regexpSourcemaps = require('gulp-regexp-sourcemaps');
@@ -41,6 +40,7 @@ const {EventEmitter} = require('events');
 const {green, red, cyan} = require('ansi-colors');
 const {isCiBuild} = require('../common/ci');
 const {jsBundles} = require('../compile/bundles.config');
+const {log, logLocalDev} = require('../common/logging');
 const {thirdPartyFrames} = require('../test-configs/config');
 const {transpileTs} = require('../compile/typescript');
 const {watch: gulpWatch} = require('gulp');
@@ -502,15 +502,13 @@ function printConfigHelp(command) {
     cyan(argv.config === 'canary' ? 'canary' : 'prod'),
     green('AMP config.')
   );
-  if (!isCiBuild()) {
-    log(
-      green('⤷ Use'),
-      cyan('--config={canary|prod}'),
-      green('with your'),
-      cyan(command),
-      green('command to specify which config to apply.')
-    );
-  }
+  logLocalDev(
+    green('⤷ Use'),
+    cyan('--config={canary|prod}'),
+    green('with your'),
+    cyan(command),
+    green('command to specify which config to apply.')
+  );
 }
 
 /**

--- a/build-system/tasks/integration.js
+++ b/build-system/tasks/integration.js
@@ -18,7 +18,6 @@
 const argv = require('minimist')(process.argv.slice(2));
 const fs = require('fs-extra');
 const globby = require('globby');
-const log = require('fancy-log');
 const pathModule = require('path');
 const {
   RuntimeTestRunner,
@@ -27,6 +26,7 @@ const {
 const {buildNewServer} = require('../server/typescript-compile');
 const {buildRuntime} = require('../common/utils');
 const {cyan, yellow} = require('ansi-colors');
+const {log} = require('../common/logging');
 const {maybePrintArgvMessages} = require('./runtime-test/helpers');
 
 const INTEGRATION_FIXTURES = [

--- a/build-system/tasks/jsify-css.js
+++ b/build-system/tasks/jsify-css.js
@@ -16,12 +16,12 @@
 'use strict';
 
 const autoprefixer = require('autoprefixer');
-const colors = require('ansi-colors');
 const cssnano = require('cssnano');
 const fs = require('fs-extra');
-const log = require('fancy-log');
 const postcss = require('postcss');
 const postcssImport = require('postcss-import');
+const {log} = require('../common/logging');
+const {red} = require('ansi-colors');
 
 // NOTE: see https://github.com/ai/browserslist#queries for `browsers` list
 const cssprefixer = autoprefixer({
@@ -105,7 +105,7 @@ function transformCssFile(filename, opt_cssnano) {
 function jsifyCssAsync(filename) {
   return transformCssFile(filename).then(function (result) {
     result.warnings().forEach(function (warn) {
-      log(colors.red(warn.toString()));
+      log(red(warn.toString()));
     });
     const {css} = result;
     return css + '\n/*# sourceURL=/' + filename + '*/';

--- a/build-system/tasks/lint.js
+++ b/build-system/tasks/lint.js
@@ -16,7 +16,6 @@
 'use strict';
 
 const argv = require('minimist')(process.argv.slice(2));
-const colors = require('ansi-colors');
 const config = require('../test-configs/config');
 const debounce = require('gulp-debounce');
 const eslint = require('gulp-eslint');
@@ -24,16 +23,17 @@ const eslintIfFixed = require('gulp-eslint-if-fixed');
 const globby = require('globby');
 const gulp = require('gulp');
 const lazypipe = require('lazypipe');
-const log = require('fancy-log');
 const path = require('path');
 const watch = require('gulp-watch');
 const {
-  getFilesChanged,
-  getFilesFromArgv,
+  log,
+  logLocalDev,
   logOnSameLine,
-} = require('../common/utils');
+  logOnSameLineLocalDev,
+} = require('../common/logging');
+const {cyan, green, red, yellow} = require('ansi-colors');
+const {getFilesChanged, getFilesFromArgv} = require('../common/utils');
 const {gitDiffNameOnlyMaster} = require('../common/git');
-const {isCiBuild} = require('../common/ci');
 const {maybeUpdatePackages} = require('./update-packages');
 const {watchDebounceDelay} = require('./helpers');
 
@@ -62,9 +62,7 @@ function initializeStream(globs, streamOptions) {
  * @return {boolean}
  */
 function runLinter(stream) {
-  if (!isCiBuild()) {
-    log(colors.green('Starting linter...'));
-  }
+  logLocalDev(green('Starting linter...'));
   const options = {
     fix: argv.fix,
     quiet: argv.quiet,
@@ -81,15 +79,13 @@ function runLinter(stream) {
     .pipe(
       eslint.result(function (result) {
         const relativePath = path.relative(rootDir, result.filePath);
-        if (!isCiBuild()) {
-          logOnSameLine(colors.green('Linted: ') + relativePath);
-        }
+        logOnSameLineLocalDev(green('Linted: ') + relativePath);
         if (options.fix && result.fixed) {
           const status =
             result.errorCount == 0
-              ? colors.green('Fixed: ')
-              : colors.yellow('Partially fixed: ');
-          logOnSameLine(status + colors.cyan(relativePath));
+              ? green('Fixed: ')
+              : yellow('Partially fixed: ');
+          logOnSameLine(status + cyan(relativePath));
           fixedFiles[relativePath] = status;
         }
       })
@@ -97,16 +93,12 @@ function runLinter(stream) {
     .pipe(
       eslint.results(function (results) {
         if (results.errorCount == 0 && results.warningCount == 0) {
-          if (!isCiBuild()) {
-            logOnSameLine(
-              colors.green('SUCCESS: ') + 'No linter warnings or errors.'
-            );
-          }
+          logOnSameLineLocalDev(
+            green('SUCCESS: ') + 'No linter warnings or errors.'
+          );
         } else {
           const prefix =
-            results.errorCount == 0
-              ? colors.yellow('WARNING: ')
-              : colors.red('ERROR: ');
+            results.errorCount == 0 ? yellow('WARNING: ') : red('ERROR: ');
           logOnSameLine(
             prefix +
               'Found ' +
@@ -117,32 +109,32 @@ function runLinter(stream) {
           );
           if (!options.fix) {
             log(
-              colors.yellow('NOTE 1:'),
+              yellow('NOTE 1:'),
               'You may be able to automatically fix some of these warnings ' +
                 '/ errors by running',
-              colors.cyan('gulp lint --local_changes --fix'),
+              cyan('gulp lint --local_changes --fix'),
               'from your local branch.'
             );
             log(
-              colors.yellow('NOTE 2:'),
+              yellow('NOTE 2:'),
               'Since this is a destructive operation (that edits your files',
               'in-place), make sure you commit before running the command.'
             );
             log(
-              colors.yellow('NOTE 3:'),
+              yellow('NOTE 3:'),
               'If you see any',
-              colors.cyan('prettier/prettier'),
+              cyan('prettier/prettier'),
               'errors, read',
-              colors.cyan(
+              cyan(
                 'https://github.com/ampproject/amphtml/blob/master/contributing/getting-started-e2e.md#code-quality-and-style'
               )
             );
           }
         }
         if (options.fix && Object.keys(fixedFiles).length > 0) {
-          log(colors.green('INFO: ') + 'Summary of fixes:');
+          log(green('INFO: ') + 'Summary of fixes:');
           Object.keys(fixedFiles).forEach((file) => {
-            log(fixedFiles[file] + colors.cyan(file));
+            log(fixedFiles[file] + cyan(file));
           });
         }
       })
@@ -175,12 +167,10 @@ function eslintRulesChanged() {
  */
 function getFilesToLint(files) {
   const filesToLint = globby.sync(files, {gitignore: true});
-  if (!isCiBuild()) {
-    log(colors.green('INFO: ') + 'Running lint on the following files:');
-    filesToLint.forEach((file) => {
-      log(colors.cyan(file));
-    });
-  }
+  logLocalDev(green('INFO: ') + 'Running lint on the following files:');
+  filesToLint.forEach((file) => {
+    logLocalDev(cyan(file));
+  });
   return filesToLint;
 }
 
@@ -197,7 +187,7 @@ function lint() {
   } else if (!eslintRulesChanged() && argv.local_changes) {
     const lintableFiles = getFilesChanged(config.lintGlobs);
     if (lintableFiles.length == 0) {
-      log(colors.green('INFO: ') + 'No JS files in this PR');
+      log(green('INFO: ') + 'No JS files in this PR');
       return Promise.resolve();
     }
     filesToLint = getFilesToLint(lintableFiles);

--- a/build-system/tasks/performance-urls.js
+++ b/build-system/tasks/performance-urls.js
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-const colors = require('ansi-colors');
 const fs = require('fs');
 const gulp = require('gulp');
-const log = require('fancy-log');
 const path = require('path');
 const through2 = require('through2');
+const {green, red, yellow} = require('ansi-colors');
+const {log} = require('../common/logging');
 
 const CONFIG_PATH = 'build-system/tasks/performance/config.json';
 const LOCAL_HOST_URL = 'http://localhost:8000/';
@@ -48,7 +48,7 @@ async function performanceUrls() {
       try {
         obj = JSON.parse(file.contents.toString());
       } catch (e) {
-        log(colors.yellow(`Could not parse ${CONFIG_PATH}. `));
+        log(yellow(`Could not parse ${CONFIG_PATH}. `));
         throwError(`Could not parse ${CONFIG_PATH}. `);
         return;
       }
@@ -61,15 +61,12 @@ async function performanceUrls() {
       );
       for (const filepath of filepaths) {
         if (!fs.existsSync(filepath)) {
-          log(colors.red(filepath + ' does not exist.'));
+          log(red(filepath + ' does not exist.'));
           throwError(`${filepath} does not exist.`);
           return;
         }
       }
-      log(
-        colors.green('SUCCESS:'),
-        'All local performance task urls are valid.'
-      );
+      log(green('SUCCESS:'), 'All local performance task urls are valid.');
     })
   );
 }

--- a/build-system/tasks/performance/measure-documents.js
+++ b/build-system/tasks/performance/measure-documents.js
@@ -16,7 +16,6 @@
 
 const argv = require('minimist')(process.argv.slice(2));
 const fs = require('fs');
-const log = require('fancy-log');
 const {
   CDN_URL,
   CONTROL,
@@ -33,6 +32,7 @@ const {
   getAnalyticsMetrics,
 } = require('./analytics-handler');
 const {cyan, green} = require('ansi-colors');
+const {log} = require('../../common/logging');
 const {setupAdRequestHandler} = require('./ads-handler');
 
 // Require Puppeteer dynamically to prevent throwing error during CI

--- a/build-system/tasks/prepend-global/index.js
+++ b/build-system/tasks/prepend-global/index.js
@@ -19,9 +19,9 @@ const argv = require('minimist')(process.argv.slice(2));
 const childProcess = require('child_process');
 const colors = require('ansi-colors');
 const fs = require('fs');
-const log = require('fancy-log');
 const path = require('path');
 const util = require('util');
+const {log} = require('../../common/logging');
 
 const exec = util.promisify(childProcess.exec);
 

--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -15,12 +15,12 @@
  */
 'use strict';
 
-const colors = require('ansi-colors');
 const gulp = require('gulp');
-const log = require('fancy-log');
 const path = require('path');
 const srcGlobs = require('../test-configs/config').presubmitGlobs;
 const through2 = require('through2');
+const {blue, red} = require('ansi-colors');
+const {log} = require('../common/logging');
 
 const dedicatedCopyrightNoteSources = /(\.js|\.css|\.go)$/;
 
@@ -111,11 +111,14 @@ const forbiddenTerms = {
       '  If this is cross domain, overwrite the method directly.',
   },
   'console\\.\\w+\\(': {
-    message:
-      'If you run against this, use console/*OK*/.[log|error] to ' +
-      'allowlist a legit case.',
+    message: String(
+      'console.log is generally forbidden. For the runtime, use ' +
+        'console/*OK*/.[log|error] to allowlist a legit case. ' +
+        'For build-system, use the functions in build-system/common/logging.js.'
+    ),
     allowlist: [
       'build-system/common/check-package-manager.js',
+      'build-system/common/logging.js',
       'build-system/pr-check/build-targets.js',
       'build-system/pr-check/checks.js',
       'build-system/pr-check/cross-browser-tests.js',
@@ -133,18 +136,6 @@ const forbiddenTerms = {
       'build-system/pr-check/utils.js',
       'build-system/pr-check/validator-tests.js',
       'build-system/pr-check/visual-diff-tests.js',
-      'build-system/server/app.js',
-      'build-system/server/amp4test.js',
-      'build-system/tasks/e2e/mocha-dots-reporter.js',
-      'build-system/tasks/build.js',
-      'build-system/tasks/check-exact-versions.js',
-      'build-system/tasks/check-owners.js',
-      'build-system/tasks/check-types.js',
-      'build-system/tasks/dist.js',
-      'build-system/tasks/dns-monitor.js',
-      'build-system/tasks/helpers.js',
-      'build-system/tasks/prettify.js',
-      'build-system/tasks/server-tests.js',
       'src/purifier/noop.js',
       'validator/js/engine/parse-css.js',
       'validator/js/engine/validator-in-browser.js',
@@ -1223,6 +1214,18 @@ const forbiddenTermsSrcInclusive = {
       'extensions/amp-iframe/0.1/amp-iframe.js',
     ],
   },
+  "require\\('fancy-log'\\)": {
+    message:
+      'Instead of fancy-log, use the logging functions in build-system/common/logging.js.',
+    allowlist: [
+      'build-system/common/logging.js',
+      'build-system/pr-check/cross-browser-tests.js',
+      'build-system/pr-check/nomodule-build.js',
+      'build-system/tasks/pr-deploy-bot-utils.js',
+      'build-system/tasks/visual-diff/helpers.js',
+      'validator/js/gulpjs/index.js',
+    ],
+  },
 };
 
 // Terms that must appear in a source file.
@@ -1331,7 +1334,7 @@ function matchTerms(file, terms) {
         }
 
         log(
-          colors.red(
+          red(
             'Found forbidden: "' +
               match[0] +
               '" in ' +
@@ -1350,9 +1353,9 @@ function matchTerms(file, terms) {
 
         // log the possible fix information if provided for the term.
         if (fix) {
-          log(colors.blue(fix));
+          log(blue(fix));
         }
-        log(colors.blue('=========='));
+        log(blue('=========='));
       }
 
       return hasTerm;
@@ -1409,12 +1412,8 @@ function isMissingTerms(file) {
 
       const matches = contents.match(new RegExp(term));
       if (!matches) {
-        log(
-          colors.red(
-            'Did not find required: "' + term + '" in ' + file.relative
-          )
-        );
-        log(colors.blue('=========='));
+        log(red('Did not find required: "' + term + '" in ' + file.relative));
+        log(blue('=========='));
         return true;
       }
       return false;
@@ -1443,15 +1442,11 @@ function presubmit() {
     )
     .on('end', function () {
       if (forbiddenFound) {
-        log(
-          colors.blue(
-            'Please remove these usages or consult with the AMP team.'
-          )
-        );
+        log(blue('Please remove these usages or consult with the AMP team.'));
       }
       if (missingRequirements) {
         log(
-          colors.blue(
+          blue(
             'Adding these terms (e.g. by adding a required LICENSE ' +
               'to the file)'
           )

--- a/build-system/tasks/prettify.js
+++ b/build-system/tasks/prettify.js
@@ -25,14 +25,18 @@
 const argv = require('minimist')(process.argv.slice(2));
 const fs = require('fs-extra');
 const gulp = require('gulp');
-const log = require('fancy-log');
 const path = require('path');
 const prettier = require('gulp-prettier');
 const tempy = require('tempy');
+const {
+  log,
+  logLocalDev,
+  logOnSameLineLocalDev,
+  logWithoutTimestamp,
+} = require('../common/logging');
 const {exec} = require('../common/exec');
 const {getFilesToCheck, logOnSameLine} = require('../common/utils');
 const {green, cyan, red, yellow} = require('ansi-colors');
-const {isCiBuild} = require('../common/ci');
 const {maybeUpdatePackages} = require('./update-packages');
 const {prettifyGlobs} = require('../test-configs/config');
 
@@ -66,7 +70,7 @@ function prettify() {
  * @param {string} file
  */
 function printErrorWithSuggestedFixes(file) {
-  console.log('\n');
+  logWithoutTimestamp('\n');
   log(`Suggested fixes for ${cyan(file)}:`);
   const fixedFile = `${tempDir}/${file}`;
   fs.ensureDirSync(path.dirname(fixedFile));
@@ -82,14 +86,12 @@ function printErrorWithSuggestedFixes(file) {
  * @return {!Promise}
  */
 function runPrettify(filesToCheck) {
-  if (!isCiBuild()) {
-    log(green('Starting checks...'));
-  }
+  logLocalDev(green('Starting checks...'));
   return new Promise((resolve, reject) => {
     const onData = (data) => {
-      if (!isCiBuild()) {
-        logOnSameLine(green('Checked: ') + path.relative(rootDir, data.path));
-      }
+      logOnSameLineLocalDev(
+        green('Checked: ') + path.relative(rootDir, data.path)
+      );
     };
 
     const rejectWithReason = (reasonText) => {
@@ -148,9 +150,9 @@ function runPrettify(filesToCheck) {
     };
 
     const onFinish = () => {
-      if (!isCiBuild()) {
-        logOnSameLine('Checked ' + cyan(filesToCheck.length) + ' file(s)');
-      }
+      logOnSameLineLocalDev(
+        'Checked ' + cyan(filesToCheck.length) + ' file(s)'
+      );
       resolve();
     };
 

--- a/build-system/tasks/process-3p-github-pr.js
+++ b/build-system/tasks/process-3p-github-pr.js
@@ -23,10 +23,10 @@
 'use strict';
 const argv = require('minimist')(process.argv.slice(2));
 const assert = require('assert');
-const colors = require('ansi-colors');
 const extend = require('util')._extend;
-const log = require('fancy-log');
 const util = require('util');
+const {blue, green, red} = require('ansi-colors');
+const {log} = require('../common/logging');
 
 const request = util.promisify(require('request'));
 
@@ -122,9 +122,9 @@ function calculateReviewer() {
  */
 async function process3pGithubPr() {
   if (!GITHUB_ACCESS_TOKEN) {
-    log(colors.red('You have not set the GITHUB_ACCESS_TOKEN env var.'));
+    log(red('You have not set the GITHUB_ACCESS_TOKEN env var.'));
     log(
-      colors.green(
+      green(
         'See https://help.github.com/articles/' +
           'creating-an-access-token-for-command-line-use/ ' +
           'for instructions on how to create a github access token. We only ' +
@@ -145,7 +145,7 @@ async function process3pGithubPr() {
   const allIssues = [].concat.apply([], responses);
   const allTasks = allIssues.map(handleIssue);
   await Promise.all(allTasks);
-  log(colors.blue('auto triaging succeed!'));
+  log(blue('auto triaging succeed!'));
 }
 
 async function handleIssue(issue) {
@@ -289,7 +289,7 @@ async function applyComment(issue, comment) {
     defaultOption
   );
   if (isDryrun) {
-    log(colors.blue(`apply comment to PR #${number}, comment is ${comment}`));
+    log(blue(`apply comment to PR #${number}, comment is ${comment}`));
     return;
   }
   return request(options);
@@ -316,7 +316,7 @@ async function assignIssue(issue, assignees) {
     defaultOption
   );
   if (isDryrun) {
-    log(colors.blue(`assign PR #${number}, to ${assignees}`));
+    log(blue(`assign PR #${number}, to ${assignees}`));
     return;
   }
   return request(options);

--- a/build-system/tasks/release/index.js
+++ b/build-system/tasks/release/index.js
@@ -20,11 +20,11 @@ const experimentsConfig = require('../../global-configs/experiments-config.json'
 const fetch = require('node-fetch');
 const fs = require('fs-extra');
 const klaw = require('klaw');
-const log = require('fancy-log');
 const path = require('path');
 const tar = require('tar');
 const {cyan, green} = require('ansi-colors');
 const {execOrDie} = require('../../common/exec');
+const {log} = require('../../common/logging');
 const {MINIFIED_TARGETS} = require('../helpers');
 const {VERSION} = require('../../compile/internal-version');
 

--- a/build-system/tasks/report-test-status.js
+++ b/build-system/tasks/report-test-status.js
@@ -16,7 +16,6 @@
 'use strict';
 
 const argv = require('minimist')(process.argv.slice(2));
-const log = require('fancy-log');
 const requestPromise = require('request-promise');
 const {
   isPullRequestBuild,
@@ -26,6 +25,7 @@ const {
 const {ciJobUrl} = require('../common/ci');
 const {cyan, green, yellow} = require('ansi-colors');
 const {gitCommitHash} = require('../common/git');
+const {log} = require('../common/logging');
 
 const reportBaseUrl = 'https://amp-test-status-bot.appspot.com/v0/tests';
 

--- a/build-system/tasks/runtime-test/helpers-unit.js
+++ b/build-system/tasks/runtime-test/helpers-unit.js
@@ -18,7 +18,6 @@
 const fs = require('fs');
 const globby = require('globby');
 const listImportsExports = require('list-imports-exports');
-const log = require('fancy-log');
 const minimatch = require('minimatch');
 const path = require('path');
 const testConfig = require('../../test-configs/config');
@@ -27,6 +26,7 @@ const {extensions, maybeInitializeExtensions} = require('../extension-helpers');
 const {gitDiffNameOnlyMaster} = require('../../common/git');
 const {green, cyan} = require('ansi-colors');
 const {isCiBuild} = require('../../common/ci');
+const {log, logLocalDev} = require('../../common/logging');
 const {reportTestSkipped} = require('../report-test-status');
 
 const LARGE_REFACTOR_THRESHOLD = 50;
@@ -206,9 +206,12 @@ function unitTestsToRun() {
 
   filesChanged.forEach((file) => {
     if (!fs.existsSync(file)) {
-      if (!isCiBuild()) {
-        log(green('INFO:'), 'Skipping', cyan(file), 'because it was deleted');
-      }
+      logLocalDev(
+        green('INFO:'),
+        'Skipping',
+        cyan(file),
+        'because it was deleted'
+      );
     } else if (isUnitTest(file)) {
       testsToRun.push(file);
     } else if (path.extname(file) == '.js') {

--- a/build-system/tasks/runtime-test/helpers.js
+++ b/build-system/tasks/runtime-test/helpers.js
@@ -17,10 +17,10 @@
 
 const argv = require('minimist')(process.argv.slice(2));
 const fs = require('fs');
-const log = require('fancy-log');
 const path = require('path');
 const {green, yellow, cyan} = require('ansi-colors');
 const {isCiBuild} = require('../../common/ci');
+const {log} = require('../../common/logging');
 const {maybePrintCoverageMessage} = require('../helpers');
 const {reportTestRunComplete} = require('../report-test-status');
 const {Server} = require('karma');

--- a/build-system/tasks/runtime-test/runtime-test-base.js
+++ b/build-system/tasks/runtime-test/runtime-test-base.js
@@ -17,7 +17,6 @@
 
 const argv = require('minimist')(process.argv.slice(2));
 const karmaConfig = require('../karma.conf');
-const log = require('fancy-log');
 const testConfig = require('../../test-configs/config');
 const {
   createCtrlcHandler,
@@ -28,6 +27,7 @@ const {createKarmaServer, getAdTypes} = require('./helpers');
 const {getFilesFromArgv} = require('../../common/utils');
 const {green, yellow, cyan, red} = require('ansi-colors');
 const {isCiBuild} = require('../../common/ci');
+const {log} = require('../../common/logging');
 const {reportTestStarted} = require('.././report-test-status');
 const {startServer, stopServer} = require('../serve');
 const {unitTestsToRun} = require('./helpers-unit');

--- a/build-system/tasks/serve.js
+++ b/build-system/tasks/serve.js
@@ -19,7 +19,6 @@ const connect = require('gulp-connect');
 const debounce = require('debounce');
 const globby = require('globby');
 const header = require('connect-header');
-const log = require('fancy-log');
 const minimist = require('minimist');
 const morgan = require('morgan');
 const open = require('opn');
@@ -37,6 +36,7 @@ const {
 const {createCtrlcHandler} = require('../common/ctrlcHandler');
 const {cyan, green, red} = require('ansi-colors');
 const {logServeMode, setServeMode} = require('../server/app-utils');
+const {log} = require('../common/logging');
 const {watchDebounceDelay} = require('./helpers');
 const {watch} = require('gulp');
 

--- a/build-system/tasks/server-tests.js
+++ b/build-system/tasks/server-tests.js
@@ -18,13 +18,16 @@ const assert = require('assert');
 const fs = require('fs');
 const globby = require('globby');
 const gulp = require('gulp');
-const log = require('fancy-log');
 const path = require('path');
 const posthtml = require('posthtml');
 const through = require('through2');
+const {
+  log,
+  logWithoutTimestamp,
+  logWithoutTimestampLocalDev,
+} = require('../common/logging');
 const {buildNewServer} = require('../server/typescript-compile');
 const {cyan, green, red} = require('ansi-colors');
-const {isCiBuild} = require('../common/ci');
 
 const transformsDir = path.resolve('build-system/server/new-server/transforms');
 const inputPaths = [`${transformsDir}/**/input.html`];
@@ -145,10 +148,12 @@ function loadOptions(inputFile) {
  */
 function logError(testName, err) {
   const {message} = err;
-  console.log(red('✖'), 'Failed', cyan(testName));
-  console.group();
-  console.log(message.split('\n').splice(3).join('\n'));
-  console.groupEnd();
+  logWithoutTimestamp(red('✖'), 'Failed', cyan(testName));
+  console /*OK*/
+    .group();
+  logWithoutTimestamp(message.split('\n').splice(3).join('\n'));
+  console /*OK*/
+    .groupEnd();
 }
 
 /**
@@ -191,9 +196,7 @@ function runTest() {
       return;
     }
     ++passed;
-    if (!isCiBuild()) {
-      console.log(green('✔'), 'Passed', cyan(testName));
-    }
+    logWithoutTimestampLocalDev(green('✔'), 'Passed', cyan(testName));
     cb();
   });
 }

--- a/build-system/tasks/storybook/index.js
+++ b/build-system/tasks/storybook/index.js
@@ -16,7 +16,6 @@
 'use strict';
 
 const argv = require('minimist')(process.argv.slice(2));
-const log = require('fancy-log');
 const path = require('path');
 const {createCtrlcHandler} = require('../../common/ctrlcHandler');
 const {cyan} = require('ansi-colors');
@@ -26,6 +25,7 @@ const {getBaseUrl} = require('../pr-deploy-bot-utils');
 const {installPackages} = require('../../common/utils');
 const {isCiBuild} = require('../../common/ci');
 const {isPullRequestBuild} = require('../../common/ci');
+const {log} = require('../../common/logging');
 const {writeFileSync} = require('fs-extra');
 
 const ENV_PORTS = {

--- a/build-system/tasks/sweep-experiments/index.js
+++ b/build-system/tasks/sweep-experiments/index.js
@@ -15,11 +15,11 @@
  */
 const argv = require('minimist')(process.argv.slice(2));
 const fastGlob = require('fast-glob');
-const log = require('fancy-log');
 const path = require('path');
 const tempy = require('tempy');
 const {cyan, magenta, yellow} = require('ansi-colors');
 const {getOutput} = require('../../common/process');
+const {log} = require('../../common/logging');
 const {readJsonSync, writeFileSync} = require('fs-extra');
 
 const containRuntimeSource = ['3p', 'ads', 'extensions', 'src', 'test'];

--- a/build-system/tasks/test-report-upload.js
+++ b/build-system/tasks/test-report-upload.js
@@ -23,7 +23,6 @@
 
 const fetch = require('node-fetch');
 const fs = require('fs').promises;
-const log = require('fancy-log');
 const path = require('path');
 const {
   ciBuildId,
@@ -33,6 +32,7 @@ const {
   ciCommitSha,
   ciRepoSlug,
 } = require('../common/ci');
+const {log} = require('../common/logging');
 
 const {cyan, green, red, yellow} = require('ansi-colors');
 

--- a/build-system/tasks/todos.js
+++ b/build-system/tasks/todos.js
@@ -15,12 +15,12 @@
  */
 'use strict';
 
-const colors = require('ansi-colors');
 const gulp = require('gulp');
-const log = require('fancy-log');
 const srcGlobs = require('../test-configs/config').presubmitGlobs;
 const through2 = require('through2');
 const util = require('util');
+const {log} = require('../common/logging');
+const {red} = require('ansi-colors');
 
 const request = util.promisify(require('request'));
 
@@ -64,7 +64,7 @@ async function findClosedTodosInFile(file) {
       return acc + v;
     }, 0);
   } catch (error) {
-    log(colors.red('Failed in', file.path, error, error.stack));
+    log(red('Failed in', file.path, error, error.stack));
     return 0;
   }
 }
@@ -85,7 +85,7 @@ function reportClosedIssue(file, issueId, todo) {
     const issue = JSON.parse(response.body);
     const value = issue.state == 'closed' ? 1 : 0;
     if (value) {
-      log(colors.red(todo, 'in', file.path));
+      log(red(todo, 'in', file.path));
     }
     return value;
   })());
@@ -137,7 +137,7 @@ function todosFindClosed() {
     )
     .on('end', function () {
       if (foundCount > 0) {
-        log(colors.red('Found closed TODOs: ', foundCount));
+        log(red('Found closed TODOs: ', foundCount));
         process.exit(1);
       }
     });

--- a/build-system/tasks/update-packages.js
+++ b/build-system/tasks/update-packages.js
@@ -16,12 +16,12 @@
 'use strict';
 
 const checkDependencies = require('check-dependencies');
-const colors = require('ansi-colors');
 const del = require('del');
 const fs = require('fs-extra');
-const log = require('fancy-log');
+const {cyan, green, yellow} = require('ansi-colors');
 const {execOrDie} = require('../common/exec');
 const {isCiBuild} = require('../common/ci');
+const {log, logLocalDev} = require('../common/logging');
 
 /**
  * Writes the given contents to the patched file if updated
@@ -31,9 +31,7 @@ const {isCiBuild} = require('../common/ci');
 function writeIfUpdated(patchedName, file) {
   if (!fs.existsSync(patchedName) || fs.readFileSync(patchedName) != file) {
     fs.writeFileSync(patchedName, file);
-    if (!isCiBuild()) {
-      log(colors.green('Patched'), colors.cyan(patchedName));
-    }
+    logLocalDev(green('Patched'), cyan(patchedName));
   }
 }
 
@@ -135,9 +133,7 @@ function removeRruleSourcemap() {
   const rruleMapFile = 'node_modules/rrule/dist/es5/rrule.js.map';
   if (fs.existsSync(rruleMapFile)) {
     del.sync(rruleMapFile);
-    if (!isCiBuild()) {
-      log(colors.green('Deleted'), colors.cyan(rruleMapFile));
-    }
+    logLocalDev(green('Deleted'), cyan(rruleMapFile));
   }
 }
 
@@ -152,19 +148,19 @@ function runNpmCheck() {
   });
   if (!results.depsWereOk) {
     log(
-      colors.yellow('WARNING:'),
+      yellow('WARNING:'),
       'The packages in',
-      colors.cyan('node_modules'),
+      cyan('node_modules'),
       'do not match',
-      colors.cyan('package.json') + '.'
+      cyan('package.json') + '.'
     );
-    log('Running', colors.cyan('npm install'), 'to update packages...');
+    log('Running', cyan('npm install'), 'to update packages...');
     execOrDie('npm install');
   } else {
     log(
-      colors.green('All packages in'),
-      colors.cyan('node_modules'),
-      colors.green('are up to date.')
+      green('All packages in'),
+      cyan('node_modules'),
+      green('are up to date.')
     );
   }
 }

--- a/build-system/tasks/visual-diff/helpers.js
+++ b/build-system/tasks/visual-diff/helpers.js
@@ -16,8 +16,8 @@
 'use strict';
 
 const argv = require('minimist')(process.argv.slice(2));
-const colors = require('ansi-colors');
 const fancyLog = require('fancy-log');
+const {cyan, green, red, yellow} = require('ansi-colors');
 
 const CSS_SELECTOR_RETRY_MS = 200;
 const CSS_SELECTOR_RETRY_ATTEMPTS = 50;
@@ -54,21 +54,21 @@ function log(mode, ...messages) {
   switch (mode) {
     case 'verbose':
       if (argv.verbose) {
-        fancyLog.info(colors.green('VERBOSE:'), ...messages);
+        fancyLog.info(green('VERBOSE:'), ...messages);
       }
       break;
     case 'info':
-      fancyLog.info(colors.green('INFO:'), ...messages);
+      fancyLog.info(green('INFO:'), ...messages);
       break;
     case 'warning':
-      fancyLog.warn(colors.yellow('WARNING:'), ...messages);
+      fancyLog.warn(yellow('WARNING:'), ...messages);
       break;
     case 'error':
-      fancyLog.error(colors.red('ERROR:'), ...messages);
+      fancyLog.error(red('ERROR:'), ...messages);
       break;
     case 'fatal':
       process.exitCode = 1;
-      fancyLog.error(colors.red('FATAL:'), ...messages);
+      fancyLog.error(red('FATAL:'), ...messages);
       throw new Error(messages.join(' '));
   }
 }
@@ -86,7 +86,7 @@ async function verifySelectorsInvisible(page, testName, selectors) {
   log(
     'verbose',
     'Waiting for invisibility of all:',
-    colors.cyan(selectors.join(', '))
+    cyan(selectors.join(', '))
   );
   try {
     await Promise.all(
@@ -96,8 +96,8 @@ async function verifySelectorsInvisible(page, testName, selectors) {
     );
   } catch (e) {
     throw new Error(
-      `${colors.cyan(testName)} | An element with the CSS ` +
-        `selector ${colors.cyan(e.message)} is still visible after ` +
+      `${cyan(testName)} | An element with the CSS ` +
+        `selector ${cyan(e.message)} is still visible after ` +
         `${CSS_SELECTOR_TIMEOUT_MS} ms`
     );
   }
@@ -113,27 +113,19 @@ async function verifySelectorsInvisible(page, testName, selectors) {
  * @throws {Error} an encountered error.
  */
 async function verifySelectorsVisible(page, testName, selectors) {
-  log(
-    'verbose',
-    'Waiting for existence of all:',
-    colors.cyan(selectors.join(', '))
-  );
+  log('verbose', 'Waiting for existence of all:', cyan(selectors.join(', ')));
   try {
     await Promise.all(
       selectors.map((selector) => waitForSelectorExistence(page, selector))
     );
   } catch (e) {
     throw new Error(
-      `${colors.cyan(testName)} | The CSS selector ` +
-        `${colors.cyan(e.message)} does not match any elements in the page`
+      `${cyan(testName)} | The CSS selector ` +
+        `${cyan(e.message)} does not match any elements in the page`
     );
   }
 
-  log(
-    'verbose',
-    'Waiting for visibility of all:',
-    colors.cyan(selectors.join(', '))
-  );
+  log('verbose', 'Waiting for visibility of all:', cyan(selectors.join(', ')));
   try {
     await Promise.all(
       selectors.map((selector) =>
@@ -142,8 +134,8 @@ async function verifySelectorsVisible(page, testName, selectors) {
     );
   } catch (e) {
     throw new Error(
-      `${colors.cyan(testName)} | An element with the CSS ` +
-        `selector ${colors.cyan(e.message)} is still invisible after ` +
+      `${cyan(testName)} | An element with the CSS ` +
+        `selector ${cyan(e.message)} is still invisible after ` +
         `${CSS_SELECTOR_TIMEOUT_MS} ms`
     );
   }
@@ -164,7 +156,7 @@ async function waitForPageLoad(page, testName) {
   );
   if (!allLoadersGone) {
     throw new Error(
-      `${colors.cyan(testName)} still has the AMP loader dot ` +
+      `${cyan(testName)} still has the AMP loader dot ` +
         `after ${CSS_SELECTOR_TIMEOUT_MS} ms`
     );
   }
@@ -208,19 +200,19 @@ async function waitForElementVisibility(page, selector, options) {
       log(
         'verbose',
         'Found',
-        colors.cyan(elementsAreVisible.length),
+        cyan(elementsAreVisible.length),
         'element(s) matching the CSS selector',
-        colors.cyan(selector)
+        cyan(selector)
       );
       log(
         'verbose',
         'Expecting all element visibilities to be',
-        colors.cyan(waitForVisible),
+        cyan(waitForVisible),
         '; they are',
-        colors.cyan(elementsAreVisible)
+        cyan(elementsAreVisible)
       );
     } else {
-      log('verbose', 'No', colors.cyan(selector), 'matches found');
+      log('verbose', 'No', cyan(selector), 'matches found');
     }
     // Since we assert that waitForVisible == !waitForHidden, there is no need
     // to check equality to both waitForVisible and waitForHidden.

--- a/build-system/tasks/visual-diff/index.js
+++ b/build-system/tasks/visual-diff/index.js
@@ -16,7 +16,6 @@
 'use strict';
 
 const argv = require('minimist')(process.argv.slice(2));
-const colors = require('ansi-colors');
 const fs = require('fs');
 const JSON5 = require('json5');
 const path = require('path');
@@ -39,6 +38,7 @@ const {
   shortSha,
 } = require('../../common/git');
 const {buildRuntime, installPackages} = require('../../common/utils');
+const {cyan, yellow} = require('ansi-colors');
 const {execScriptAsync} = require('../../common/exec');
 const {isCiBuild} = require('../../common/ci');
 const {startServer, stopServer} = require('../serve');
@@ -236,16 +236,16 @@ async function newPage(browser, viewport = null) {
       log(
         'verbose',
         'Mocked network request for',
-        colors.yellow(requestUrl.href),
+        yellow(requestUrl.href),
         'with file',
-        colors.cyan(mockedFilepath)
+        cyan(mockedFilepath)
       );
       return interceptedRequest.respond(fs.readFileSync(mockedFilepath));
     } else {
       log(
         'verbose',
         'Blocked external network request for',
-        colors.yellow(requestUrl.href)
+        yellow(requestUrl.href)
       );
       return interceptedRequest.abort('blockedbyclient');
     }
@@ -268,9 +268,9 @@ async function resetPage(page, viewport = null) {
   log(
     'verbose',
     'Resetting tab to',
-    colors.yellow('about:blank'),
+    yellow('about:blank'),
     'with size',
-    colors.yellow(`${width}×${height}`)
+    yellow(`${width}×${height}`)
   );
 
   await page.goto('about:blank');
@@ -304,7 +304,7 @@ function logTestError(testError) {
   log(
     'error',
     'Error in test',
-    colors.yellow(testError.name),
+    yellow(testError.name),
     '\n  ',
     testError.message,
     '\n  ',
@@ -313,11 +313,11 @@ function logTestError(testError) {
   if (testError.consoleMessages.length > 0) {
     log(
       'error',
-      colors.cyan(testError.consoleMessages.length),
+      cyan(testError.consoleMessages.length),
       'Console messages in the browser so far:'
     );
     for (const message of testError.consoleMessages) {
-      log('error', colors.cyan(`[console.${message.type()}]`), message.text());
+      log('error', cyan(`[console.${message.type()}]`), message.text());
     }
   }
 }
@@ -334,7 +334,7 @@ async function runVisualTests(webpages) {
     log(
       'info',
       'The Percy build is baselined on top of commit',
-      colors.cyan(shortSha(process.env['PERCY_TARGET_COMMIT']))
+      cyan(shortSha(process.env['PERCY_TARGET_COMMIT']))
     );
   }
 
@@ -356,7 +356,7 @@ async function generateSnapshots(webpages) {
     log(
       'info',
       'Skipping',
-      colors.cyan(numUnfilteredPages - webpages.length),
+      cyan(numUnfilteredPages - webpages.length),
       'flaky pages'
     );
   }
@@ -364,9 +364,9 @@ async function generateSnapshots(webpages) {
     webpages = webpages.filter((webpage) => argv.grep.test(webpage.name));
     log(
       'info',
-      colors.cyan(`--grep ${argv.grep}`),
+      cyan(`--grep ${argv.grep}`),
       'matched',
-      colors.cyan(webpages.length),
+      cyan(webpages.length),
       'pages'
     );
   }
@@ -389,9 +389,9 @@ async function generateSnapshots(webpages) {
         log(
           'fatal',
           'Failed to load interactive test',
-          colors.cyan(webpage.interactive_tests),
+          cyan(webpage.interactive_tests),
           'for test',
-          colors.cyan(webpage.name),
+          cyan(webpage.name),
           '\nError:',
           error
         );
@@ -409,9 +409,9 @@ async function generateSnapshots(webpages) {
     log(
       'info',
       'Executing',
-      colors.cyan(totalTests),
+      cyan(totalTests),
       'visual diff tests on',
-      colors.cyan(webpages.length),
+      cyan(webpages.length),
       'pages'
     );
   }
@@ -444,7 +444,7 @@ async function snapshotWebpages(browser, webpages) {
   const availablePages = [];
   const allPages = [];
 
-  log('verbose', 'Preallocating', colors.cyan(MAX_PARALLEL_TABS), 'tabs...');
+  log('verbose', 'Preallocating', cyan(MAX_PARALLEL_TABS), 'tabs...');
   for (let i = 0; i < MAX_PARALLEL_TABS; i++) {
     const page = await newPage(browser);
     availablePages.push(page);
@@ -473,9 +473,9 @@ async function snapshotWebpages(browser, webpages) {
       log(
         'info',
         'Starting test',
-        colors.yellow(name),
+        yellow(name),
         'on tab',
-        colors.yellow(`#${allPages.indexOf(page) + 1}`)
+        yellow(`#${allPages.indexOf(page) + 1}`)
       );
 
       await resetPage(page, viewport);
@@ -509,17 +509,17 @@ async function snapshotWebpages(browser, webpages) {
               log(
                 'verbose',
                 'Response for url',
-                colors.yellow(response.url()),
+                yellow(response.url()),
                 'with status',
-                colors.cyan(response.status()),
-                colors.cyan(response.statusText())
+                cyan(response.status()),
+                cyan(response.statusText())
               );
               clearTimeout(responseTimeout);
               resolve();
             });
           });
 
-          log('verbose', 'Navigating to page', colors.yellow(webpage.url));
+          log('verbose', 'Navigating to page', yellow(webpage.url));
           await Promise.all([
             responseWatcher,
             page.goto(fullUrl, {waitUntil: 'networkidle2'}),
@@ -528,7 +528,7 @@ async function snapshotWebpages(browser, webpages) {
           log(
             'verbose',
             'Page navigation of test',
-            colors.yellow(name),
+            yellow(name),
             'is done, verifying page'
           );
         } catch (navigationError) {
@@ -572,7 +572,7 @@ async function snapshotWebpages(browser, webpages) {
             log(
               'verbose',
               'Waiting',
-              colors.cyan(`${webpage.loading_complete_delay_ms}ms`),
+              cyan(`${webpage.loading_complete_delay_ms}ms`),
               'for loading to complete'
             );
             await sleep(webpage.loading_complete_delay_ms);
@@ -651,7 +651,7 @@ async function snapshotWebpages(browser, webpages) {
         log(
           hasWarnings ? 'warning' : 'info',
           'Finished test',
-          colors.yellow(name),
+          yellow(name),
           hasWarnings ? 'with warnings' : ''
         );
         page.removeListener('console', consoleLogger);
@@ -664,7 +664,7 @@ async function snapshotWebpages(browser, webpages) {
   await Promise.all(pagePromises);
   if (isCiBuild() && testErrors.length > 0) {
     testErrors.sort((a, b) => a.name.localeCompare(b.name));
-    log('info', colors.yellow('Tests warnings and errors:'));
+    log('info', yellow('Tests warnings and errors:'));
     testErrors.forEach(logTestError);
     return false;
   }
@@ -733,12 +733,7 @@ async function visualDiff() {
 async function performVisualTests() {
   setDebuggingLevel();
   if (!argv.percy_disabled && !process.env.PERCY_TOKEN) {
-    log(
-      'fatal',
-      'Could not find',
-      colors.cyan('PERCY_TOKEN'),
-      'environment variable'
-    );
+    log('fatal', 'Could not find', cyan('PERCY_TOKEN'), 'environment variable');
   } else {
     try {
       await launchPercyAgent();
@@ -781,9 +776,9 @@ async function ensureOrBuildAmpRuntimeInTestMode_() {
       log(
         'fatal',
         'The AMP runtime was not built in test mode. Run',
-        colors.cyan('gulp dist --fortesting'),
+        cyan('gulp dist --fortesting'),
         'or remove the',
-        colors.cyan('--nobuild'),
+        cyan('--nobuild'),
         'option from this command'
       );
     }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -18,8 +18,8 @@
 
 const argv = require('minimist')(process.argv.slice(2));
 const gulp = require('gulp-help')(require('gulp'));
-const log = require('fancy-log');
 const {cyan, red} = require('ansi-colors');
+const {log} = require('./build-system/common/logging');
 
 const {
   checkExactVersions,


### PR DESCRIPTION
This is part 1 of a logging cleanup in anticipation of the move from Travis to CircleCI.

**PR highlights:**

- Logging functions moved to `common/logging.js`
- Abbreviate log-coloring by destructuring `require('ansi-colors')`
- Clean up presubmit `build-system/` allowlist for `console.log`

For easy reviewing, see files one commit at a time.

**Coming up:** More substantial cleanup of the logging in `build-system/pr-check`
