### PR TITLE
✨ [bento][amp-date-countdown] countUp feature for date-countdown component

### DIFF
--- a/extensions/amp-date-countdown/0.1/amp-date-countdown.md
+++ b/extensions/amp-date-countdown/0.1/amp-date-countdown.md
@@ -165,7 +165,7 @@ on the specified `biggest-unit` value. For example, assume there are `50 days 10
 
 ### data-count-up (optional)
 
-Include this attribute to reverse the direction of the countdown to count up instead. Useful to display the time elapsed since a target date in the past. To continue the countdown when the target date is in the past, be sure to include the `when-ended` attribute with the `continue` value. If the target date is in the future, `amp-date-countdown` will display a decrementing (toward 0) negative value.
+Include this attribute to reverse the direction of the countdown to count up instead. This is useful to display the time elapsed since a target date in the past. To continue the countdown when the target date is in the past, be sure to include the `when-ended` attribute with the `continue` value. If the target date is in the future, `amp-date-countdown` will display a decrementing (toward 0) negative value.
 
 ## Events
 

--- a/extensions/amp-date-countdown/1.0/amp-date-countdown.js
+++ b/extensions/amp-date-countdown/1.0/amp-date-countdown.js
@@ -120,6 +120,10 @@ AmpDateCountdown['props'] = {
   'whenEnded': {attr: 'when-ended', type: 'string'},
   'locale': {attr: 'locale', type: 'string'},
   'biggestUnit': {attr: 'biggest-unit', type: 'string'},
+  'countUp': {
+    attrs: ['data-count-up'],
+    parseAttrs: (el) => el.hasAttribute('data-count-up'),
+  },
 };
 
 /**

--- a/extensions/amp-date-countdown/1.0/amp-date-countdown.js
+++ b/extensions/amp-date-countdown/1.0/amp-date-countdown.js
@@ -120,10 +120,7 @@ AmpDateCountdown['props'] = {
   'whenEnded': {attr: 'when-ended', type: 'string'},
   'locale': {attr: 'locale', type: 'string'},
   'biggestUnit': {attr: 'biggest-unit', type: 'string'},
-  'countUp': {
-    attrs: ['data-count-up'],
-    parseAttrs: (el) => el.hasAttribute('data-count-up'),
-  },
+  'countUp': {attr: 'data-count-up', type: 'boolean'},
 };
 
 /**

--- a/extensions/amp-date-countdown/1.0/date-countdown.js
+++ b/extensions/amp-date-countdown/1.0/date-countdown.js
@@ -53,6 +53,7 @@ const TimeUnit = {
 const DEFAULT_LOCALE = 'en';
 const DEFAULT_WHEN_ENDED = 'stop';
 const DEFAULT_BIGGEST_UNIT = 'DAYS';
+const DEFAULT_COUNT_UP = false;
 
 /**
  * @param {!JsonObject} data
@@ -73,6 +74,7 @@ export function DateCountdown({
   whenEnded = DEFAULT_WHEN_ENDED,
   locale = DEFAULT_LOCALE,
   biggestUnit = DEFAULT_BIGGEST_UNIT,
+  countUp = DEFAULT_COUNT_UP,
   render = DEFAULT_RENDER,
   ...rest
 }) {
@@ -92,8 +94,8 @@ export function DateCountdown({
   // Only update data when timeleft (or other dependencies) are updated
   // Does not update on 2nd render triggered by useRenderer
   const data = useMemo(
-    () => getDataForTemplate(timeleft, biggestUnit, localeStrings),
-    [timeleft, biggestUnit, localeStrings]
+    () => getDataForTemplate(timeleft, biggestUnit, localeStrings, countUp),
+    [timeleft, biggestUnit, localeStrings, countUp]
   );
 
   // Reference to DOM element to get access to correct window
@@ -133,11 +135,12 @@ export function DateCountdown({
  * @param {number} timeleft
  * @param {string|undefined} biggestUnit
  * @param {!JsonObject} localeStrings
+ * @param {boolean} countUp
  * @return {!JsonObject}
  */
-function getDataForTemplate(timeleft, biggestUnit, localeStrings) {
+function getDataForTemplate(timeleft, biggestUnit, localeStrings, countUp) {
   return /** @type {!JsonObject} */ ({
-    ...getYDHMSFromMs(timeleft, /** @type {string} */ (biggestUnit)),
+    ...getYDHMSFromMs(timeleft, /** @type {string} */ (biggestUnit), countUp),
     ...localeStrings,
   });
 }
@@ -171,9 +174,17 @@ function getLocaleWord(locale) {
  * days, hours, minutes, etc. and returns formatted strings in an object.
  * @param {number} ms
  * @param {string} biggestUnit
+ * @param {boolean} countUp
  * @return {JsonObject}
  */
-function getYDHMSFromMs(ms, biggestUnit) {
+function getYDHMSFromMs(ms, biggestUnit, countUp) {
+  // If 'count-up' prop is true, we return the negative of what
+  // we would originally return since we are counting time-elapsed from a
+  // set time instead of time until that time
+  if (countUp) {
+    ms *= -1;
+  }
+
   //Math.trunc is used instead of Math.floor to support negative past date
   const d =
     TimeUnit[biggestUnit] == TimeUnit.DAYS

--- a/extensions/amp-date-countdown/1.0/date-countdown.type.js
+++ b/extensions/amp-date-countdown/1.0/date-countdown.type.js
@@ -22,6 +22,7 @@
  *   whenEnded: (string|undefined),
  *   locale: (string|undefined),
  *   biggestUnit: (string|undefined),
+ *   countUp: (boolean|undefined),
  *   render: (?RendererFunctionType|undefined),
  * }}
  */

--- a/extensions/amp-date-countdown/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-date-countdown/1.0/storybook/Basic.amp.js
@@ -15,7 +15,7 @@
  */
 
 import * as Preact from '../../../../src/preact';
-import {date, select, text, withKnobs} from '@storybook/addon-knobs';
+import {boolean, date, select, text, withKnobs} from '@storybook/addon-knobs';
 import {withA11y} from '@storybook/addon-a11y';
 import {withAmp} from '@ampproject/storybook-addon';
 
@@ -99,6 +99,7 @@ export const Default = () => {
     BIGGEST_UNIT_CONFIGURATIONS,
     BIGGEST_UNIT_CONFIGURATIONS[0]
   );
+  const countUp = boolean('data-count-up', false);
 
   return (
     <amp-date-countdown
@@ -112,6 +113,7 @@ export const Default = () => {
       locale={locale}
       when-ended={whenEnded}
       biggest-unit={biggestUnit}
+      data-count-up={countUp}
       layout="fixed-height"
       height="100"
     >
@@ -164,6 +166,7 @@ export const DefaultRenderer = () => {
     BIGGEST_UNIT_CONFIGURATIONS,
     BIGGEST_UNIT_CONFIGURATIONS[0]
   );
+  const countUp = boolean('data-count-up', false);
 
   return (
     <amp-date-countdown
@@ -177,6 +180,7 @@ export const DefaultRenderer = () => {
       locale={locale}
       when-ended={whenEnded}
       biggest-unit={biggestUnit}
+      data-count-up={countUp}
       layout="fixed-height"
       height="100"
     ></amp-date-countdown>
@@ -218,6 +222,7 @@ export const ExternalTemplate = () => {
     BIGGEST_UNIT_CONFIGURATIONS,
     BIGGEST_UNIT_CONFIGURATIONS[0]
   );
+  const countUp = boolean('data-count-up', false);
 
   return (
     <div>
@@ -246,6 +251,7 @@ export const ExternalTemplate = () => {
         locale={locale}
         when-ended={whenEnded}
         biggest-unit={biggestUnit}
+        data-count-up={countUp}
         template={template}
         layout="fixed-height"
         height="100"

--- a/extensions/amp-date-countdown/1.0/storybook/Basic.js
+++ b/extensions/amp-date-countdown/1.0/storybook/Basic.js
@@ -16,7 +16,7 @@
 
 import * as Preact from '../../../../src/preact';
 import {DateCountdown} from '../date-countdown';
-import {date, select, withKnobs} from '@storybook/addon-knobs';
+import {boolean, date, select, withKnobs} from '@storybook/addon-knobs';
 import {withA11y} from '@storybook/addon-a11y';
 
 export default {
@@ -72,6 +72,7 @@ export const _default = () => {
     BIGGEST_UNIT_CONFIGURATIONS,
     BIGGEST_UNIT_CONFIGURATIONS[0]
   );
+  const countUp = boolean('countUp', false);
 
   return (
     <div>
@@ -80,6 +81,7 @@ export const _default = () => {
         locale={locale}
         whenEnded={whenEnded}
         biggestUnit={biggestUnit}
+        countUp={countUp}
         render={(data) => (
           <div>
             <span>{`${data.days} ${data.dd} ${data.d}`}</span>
@@ -113,6 +115,7 @@ export const defaultRenderer = () => {
     BIGGEST_UNIT_CONFIGURATIONS,
     BIGGEST_UNIT_CONFIGURATIONS[0]
   );
+  const countUp = boolean('countUp', false);
 
   return (
     <div>
@@ -121,6 +124,7 @@ export const defaultRenderer = () => {
         locale={locale}
         whenEnded={whenEnded}
         biggestUnit={biggestUnit}
+        countUp={countUp}
       ></DateCountdown>
     </div>
   );

--- a/extensions/amp-date-countdown/1.0/test/test-date-countdown.js
+++ b/extensions/amp-date-countdown/1.0/test/test-date-countdown.js
@@ -205,6 +205,80 @@ describes.sandboxed('DateCountdown 1.0 preact component', {}, (env) => {
     wrapper.unmount();
   });
 
+  it('should count up when countUp prop is set to "true"', () => {
+    // Reference date is 2018-01-01T08:00:00Z
+    // Timer should have -10 seconds on it
+    const props = {
+      render,
+      datetime: Date.parse('2018-01-01T08:00:10Z'),
+      countUp: true,
+    };
+    const wrapper = mount(<DateCountdown {...props} />);
+    let data = JSON.parse(wrapper.text());
+
+    // Count up 7 seconds
+    clock.tick(7000);
+    wrapper.update();
+    data = JSON.parse(wrapper.text());
+
+    // -3 seconds left on the clock
+    expect(data['d']).to.equal('0');
+    expect(data['dd']).to.equal('00');
+    expect(data['h']).to.equal('0');
+    expect(data['hh']).to.equal('00');
+    expect(data['m']).to.equal('0');
+    expect(data['mm']).to.equal('00');
+    expect(data['s']).to.equal('-3');
+    expect(data['ss']).to.equal('-03');
+
+    // Count up 10 more seconds
+    clock.tick(10000);
+    wrapper.update();
+    data = JSON.parse(wrapper.text());
+
+    // 0 seconds left on the clock (does not continue past 0)
+    expect(data['d']).to.equal('0');
+    expect(data['dd']).to.equal('00');
+    expect(data['h']).to.equal('0');
+    expect(data['hh']).to.equal('00');
+    expect(data['m']).to.equal('0');
+    expect(data['mm']).to.equal('00');
+    expect(data['s']).to.equal('0');
+    expect(data['ss']).to.equal('00');
+
+    wrapper.unmount();
+  });
+
+  it('should count up past 0 when whenEnded prop is set to "continue"', () => {
+    // Reference date is 2018-01-01T08:00:00Z
+    // Timer should have -10 seconds on it
+    const props = {
+      render,
+      datetime: Date.parse('2018-01-01T08:00:10Z'),
+      countUp: true,
+      whenEnded: 'continue',
+    };
+    const wrapper = mount(<DateCountdown {...props} />);
+    let data = JSON.parse(wrapper.text());
+
+    // Count up 15 seconds
+    clock.tick(15000);
+    wrapper.update();
+    data = JSON.parse(wrapper.text());
+
+    // 4 seconds on the clock counting upwards (has an extra second at 0)
+    expect(data['d']).to.equal('0');
+    expect(data['dd']).to.equal('00');
+    expect(data['h']).to.equal('0');
+    expect(data['hh']).to.equal('00');
+    expect(data['m']).to.equal('0');
+    expect(data['mm']).to.equal('00');
+    expect(data['s']).to.equal('4');
+    expect(data['ss']).to.equal('04');
+
+    wrapper.unmount();
+  });
+
   it('should display biggest unit as "days" by default', () => {
     // Reference date is 2018-01-01T08:00:00Z
     // Timer should have 1 day and 10 seconds on it

--- a/extensions/amp-date-countdown/amp-date-countdown.md
+++ b/extensions/amp-date-countdown/amp-date-countdown.md
@@ -169,6 +169,10 @@ on the specified `biggest-unit` value. For example, assume there are `50 days 10
 -   Supported values: `days`, `hours`, `minutes`, `seconds`
 -   Default: `days`
 
+### data-count-up (optional)
+
+Include this attribute to reverse the direction of the countdown to count up instead. This is useful to display the time elapsed since a target date in the past. To continue the countdown when the target date is in the past, be sure to include the `when-ended` attribute with the `continue` value. If the target date is in the future, `amp-date-countdown` will display a decrementing (toward 0) negative value.
+
 ## Events
 
 The `amp-date-countdown` component exposes the following event that you can use


### PR DESCRIPTION
Update the `1.0` bento component to match the `0.1` component which currently includes the `countUp` feature.

The countUp feature allows the date-countdown component to count upwards instead.  (Time elapsed since a particular date/time).

Related bug: https://github.com/ampproject/amphtml/issues/30197


todo:
- validator and amp side - added 1/21
- storybooks - added 1/21
- tests - added 1/21
- documentation - added 1/21