### PR TITLE
📖 [bento] A placeholder PR to discuss how to document the new `getApi()`

### DIFF
--- a/extensions/amp-accordion/amp-accordion.md
+++ b/extensions/amp-accordion/amp-accordion.md
@@ -267,6 +267,18 @@ it collapses all sections of the accordion. To specify a section, add the
 </button>
 ```
 
+### Actions in Bento Mode
+
+In Bento mode, the above actions can be called via `getApi()`. For example:
+
+```html
+<script>
+  var api = await document.querySelector('#myAccordion').getApi();
+  api.toggle();
+  api.toggle('section1');
+</script>
+```
+
 [/filter] <!-- formats="websites" -->
 
 ## Events


### PR DESCRIPTION
The change shown in this PR, is currently listed in the `accordion` documentation.  But it is actually shared across all bento component.

If we were to want to create a common page for the various component documentation pages to link to.  How could we do this?