### PR TITLE
🏗  Fixes to PR-check logic

### DIFF
--- a/build-system/pr-check/bundle-size.js
+++ b/build-system/pr-check/bundle-size.js
@@ -23,7 +23,7 @@
  */
 
 const {
-  stopTimedJob,
+  abortTimedJob,
   downloadModuleOutput,
   downloadNomoduleOutput,
   printChangeSummary,
@@ -44,7 +44,7 @@ async function main() {
   const startTime = startTimer(jobName);
 
   if (!runNpmChecks()) {
-    return stopTimedJob(jobName, startTime);
+    return abortTimedJob(jobName, startTime);
   }
 
   if (!isPullRequestBuild()) {

--- a/build-system/pr-check/checks.js
+++ b/build-system/pr-check/checks.js
@@ -23,7 +23,7 @@
  */
 
 const {
-  stopTimedJob,
+  abortTimedJob,
   printChangeSummary,
   startTimer,
   stopTimer,
@@ -41,7 +41,7 @@ async function main() {
   setLoggingPrefix(jobName);
   const startTime = startTimer(jobName);
   if (!runNpmChecks()) {
-    return stopTimedJob(jobName, startTime);
+    return abortTimedJob(jobName, startTime);
   }
 
   if (!isPullRequestBuild()) {

--- a/build-system/pr-check/cross-browser-tests.js
+++ b/build-system/pr-check/cross-browser-tests.js
@@ -16,7 +16,7 @@
 'use strict';
 
 const {
-  stopTimedJob,
+  abortTimedJob,
   printChangeSummary,
   printSkipMessage,
   startTimer,
@@ -71,13 +71,13 @@ function runIntegrationTestsForPlatform() {
 function runUnitTestsForPlatform() {
   switch (process.platform) {
     case 'linux':
-      timedExecOrDie('gulp unit --nobuild --headless --firefox');
+      timedExecOrDie('gulp unit --headless --firefox');
       break;
     case 'darwin':
-      timedExecOrDie('gulp unit --nobuild --safari');
+      timedExecOrDie('gulp unit --safari');
       break;
     case 'win32':
-      timedExecOrDie('gulp unit --nobuild --headless --edge');
+      timedExecOrDie('gulp unit --headless --edge');
       break;
     default:
       log(
@@ -92,7 +92,7 @@ async function main() {
   setLoggingPrefix(jobName);
   const startTime = startTimer(jobName);
   if (!runNpmChecks()) {
-    return stopTimedJob(jobName, startTime);
+    return abortTimedJob(jobName, startTime);
   }
   if (!isPullRequestBuild()) {
     timedExecOrDie('gulp update-packages');

--- a/build-system/pr-check/module-build.js
+++ b/build-system/pr-check/module-build.js
@@ -22,7 +22,7 @@
  */
 
 const {
-  stopTimedJob,
+  abortTimedJob,
   printChangeSummary,
   printSkipMessage,
   startTimer,
@@ -41,7 +41,7 @@ function main() {
   setLoggingPrefix(jobName);
   const startTime = startTimer(jobName);
   if (!runNpmChecks()) {
-    return stopTimedJob(jobName, startTime);
+    return abortTimedJob(jobName, startTime);
   }
 
   if (!isPullRequestBuild()) {

--- a/build-system/pr-check/nomodule-tests.js
+++ b/build-system/pr-check/nomodule-tests.js
@@ -60,27 +60,18 @@ function main() {
     printChangeSummary();
     const buildTargets = determineBuildTargets();
     if (
-      !buildTargets.has('RUNTIME') &&
-      !buildTargets.has('FLAG_CONFIG') &&
-      !buildTargets.has('INTEGRATION_TEST')
-    ) {
-      printSkipMessage(
-        jobName,
-        'this PR does not affect the runtime, flag configs, or integration tests'
-      );
-      stopTimer(jobName, startTime);
-      return;
-    }
-
-    downloadNomoduleOutput();
-    timedExecOrDie('gulp update-packages');
-
-    if (
       buildTargets.has('RUNTIME') ||
       buildTargets.has('FLAG_CONFIG') ||
       buildTargets.has('INTEGRATION_TEST')
     ) {
-      timedExecOrDie('gulp integration --nobuild --headless --compiled');
+      downloadNomoduleOutput();
+      timedExecOrDie('gulp update-packages');
+      timedExecOrDie('gulp integration --nobuild --compiled --headless');
+    } else {
+      printSkipMessage(
+        jobName,
+        'this PR does not affect the runtime, flag configs, or integration tests'
+      );
     }
   }
 

--- a/build-system/pr-check/unminified-build.js
+++ b/build-system/pr-check/unminified-build.js
@@ -22,7 +22,7 @@
  */
 
 const {
-  stopTimedJob,
+  abortTimedJob,
   printChangeSummary,
   printSkipMessage,
   startTimer,
@@ -41,7 +41,7 @@ function main() {
   setLoggingPrefix(jobName);
   const startTime = startTimer(jobName);
   if (!runNpmChecks()) {
-    return stopTimedJob(jobName, startTime);
+    return abortTimedJob(jobName, startTime);
   }
 
   if (!isPullRequestBuild()) {
@@ -54,8 +54,7 @@ function main() {
     if (
       buildTargets.has('RUNTIME') ||
       buildTargets.has('FLAG_CONFIG') ||
-      buildTargets.has('INTEGRATION_TEST') ||
-      buildTargets.has('UNIT_TEST')
+      buildTargets.has('INTEGRATION_TEST')
     ) {
       timedExecOrDie('gulp update-packages');
       timedExecOrDie('gulp build --fortesting');

--- a/build-system/pr-check/unminified-tests.js
+++ b/build-system/pr-check/unminified-tests.js
@@ -85,7 +85,7 @@ function main() {
     timedExecOrDie('gulp update-packages');
 
     if (buildTargets.has('RUNTIME') || buildTargets.has('UNIT_TEST')) {
-      timedExecOrDie('gulp unit --nobuild --headless --local_changes');
+      timedExecOrDie('gulp unit --headless --local_changes');
     }
 
     if (
@@ -97,7 +97,7 @@ function main() {
     }
 
     if (buildTargets.has('RUNTIME') || buildTargets.has('UNIT_TEST')) {
-      timedExecOrDie('gulp unit --nobuild --headless --coverage');
+      timedExecOrDie('gulp unit --headless --coverage');
     }
 
     if (buildTargets.has('RUNTIME')) {

--- a/build-system/pr-check/utils.js
+++ b/build-system/pr-check/utils.js
@@ -28,7 +28,7 @@ const {cyan, green, yellow} = require('ansi-colors');
 const {execOrDie, execOrThrow, execWithError, exec} = require('../common/exec');
 const {getLoggingPrefix, logWithoutTimestamp} = require('../common/logging');
 const {isCiBuild, ciBuildId, ciPullRequestSha} = require('../common/ci');
-const {replaceUrls, signalDistUpload} = require('../tasks/pr-deploy-bot-utils');
+const {replaceUrls} = require('../tasks/pr-deploy-bot-utils');
 
 const UNMINIFIED_OUTPUT_FILE = `amp_unminified_${ciBuildId()}.zip`;
 const NOMODULE_OUTPUT_FILE = `amp_nomodule_${ciBuildId()}.zip`;
@@ -154,7 +154,7 @@ function stopTimer(jobNameOrCmd, startTime) {
  * @param {string} jobName
  * @param {startTime} startTime
  */
-function stopTimedJob(jobName, startTime) {
+function abortTimedJob(jobName, startTime) {
   stopTimer(jobName, startTime);
   process.exitCode = 1;
 }
@@ -313,11 +313,10 @@ async function processAndUploadNomoduleOutput() {
   await replaceUrls('test/manual');
   await replaceUrls('examples');
   uploadNomoduleOutput();
-  await signalDistUpload('success');
 }
 
 module.exports = {
-  stopTimedJob,
+  abortTimedJob,
   downloadUnminifiedOutput,
   downloadNomoduleOutput,
   downloadModuleOutput,

--- a/build-system/pr-check/validator-tests.js
+++ b/build-system/pr-check/validator-tests.js
@@ -22,7 +22,7 @@
  */
 
 const {
-  stopTimedJob,
+  abortTimedJob,
   printChangeSummary,
   printSkipMessage,
   startTimer,
@@ -40,7 +40,7 @@ function main() {
   setLoggingPrefix(jobName);
   const startTime = startTimer(jobName);
   if (!runNpmChecks()) {
-    return stopTimedJob(jobName, startTime);
+    return abortTimedJob(jobName, startTime);
   }
 
   if (!isPullRequestBuild()) {

--- a/build-system/tasks/pr-deploy-bot-utils.js
+++ b/build-system/tasks/pr-deploy-bot-utils.js
@@ -69,7 +69,7 @@ async function replaceUrls(dir) {
   await Promise.all(promises);
 }
 
-async function signalDistUpload(result) {
+async function signalPrDeployUpload(result) {
   const loggingPrefix = getLoggingPrefix();
   logWithoutTimestamp(
     `${loggingPrefix} Reporting`,
@@ -87,5 +87,5 @@ async function signalDistUpload(result) {
 module.exports = {
   getBaseUrl,
   replaceUrls,
-  signalDistUpload,
+  signalPrDeployUpload,
 };


### PR DESCRIPTION
Follow up to #32041 and #32044. 

**PR highlights:**

- Rename `stopTimedJob()` to the more appropriate `abortTimedJob()` for early exit on failure
- Rename `signalDistUpload()` to `signalPrDeployUpload()`
- Consolidate calls to `signalPrDeployUpload()` in one place (`nomodule-build.js`)
- Fix bug in `{nomodule|unminified}-build.js` (there's no need to build runtime for unit tests)
- Simplify `if` block in `nomodule-tests.js`

