### PR TITLE
🏗 Fix bundle-size check for Travis builds

### DIFF
--- a/build-system/pr-check/bundle-size.js
+++ b/build-system/pr-check/bundle-size.js
@@ -53,6 +53,7 @@ async function main() {
       jobName,
       'this is a Travis build. Sizes will be reported from CircleCI'
     );
+    return;
   }
 
   if (!isPullRequestBuild()) {


### PR DESCRIPTION
Turns out that download / comparison of sizes works on CircleCI, but saving of sizes does not.