### PR TITLE
🏗 Switch build artifact unique identifier from build ID to commit SHA

### DIFF
--- a/build-system/pr-check/utils.js
+++ b/build-system/pr-check/utils.js
@@ -27,12 +27,12 @@ const {
 const {cyan, green, yellow} = require('ansi-colors');
 const {execOrDie, execOrThrow, execWithError, exec} = require('../common/exec');
 const {getLoggingPrefix, logWithoutTimestamp} = require('../common/logging');
-const {isCiBuild, ciBuildId, ciPullRequestSha} = require('../common/ci');
+const {isCiBuild, ciPullRequestSha} = require('../common/ci');
 const {replaceUrls} = require('../tasks/pr-deploy-bot-utils');
 
-const UNMINIFIED_OUTPUT_FILE = `amp_unminified_${ciBuildId()}.zip`;
-const NOMODULE_OUTPUT_FILE = `amp_nomodule_${ciBuildId()}.zip`;
-const MODULE_OUTPUT_FILE = `amp_module_${ciBuildId()}.zip`;
+const UNMINIFIED_OUTPUT_FILE = `amp_unminified_${ciPullRequestSha()}.zip`;
+const NOMODULE_OUTPUT_FILE = `amp_nomodule_${ciPullRequestSha()}.zip`;
+const MODULE_OUTPUT_FILE = `amp_module_${ciPullRequestSha()}.zip`;
 
 const BUILD_OUTPUT_DIRS = 'build/ dist/ dist.3p/';
 const APP_SERVING_DIRS = 'dist.tools/ examples/ test/manual/';

--- a/build-system/pr-check/utils.js
+++ b/build-system/pr-check/utils.js
@@ -30,9 +30,10 @@ const {getLoggingPrefix, logWithoutTimestamp} = require('../common/logging');
 const {isCiBuild, ciPullRequestSha} = require('../common/ci');
 const {replaceUrls} = require('../tasks/pr-deploy-bot-utils');
 
-const UNMINIFIED_OUTPUT_FILE = `amp_unminified_${ciPullRequestSha()}.zip`;
-const NOMODULE_OUTPUT_FILE = `amp_nomodule_${ciPullRequestSha()}.zip`;
-const MODULE_OUTPUT_FILE = `amp_module_${ciPullRequestSha()}.zip`;
+const SUFFIX = shortSha(ciPullRequestSha());
+const UNMINIFIED_OUTPUT_FILE = `amp_unminified_${SUFFIX}.zip`;
+const NOMODULE_OUTPUT_FILE = `amp_nomodule_${SUFFIX}.zip`;
+const MODULE_OUTPUT_FILE = `amp_module_${SUFFIX}.zip`;
 
 const BUILD_OUTPUT_DIRS = 'build/ dist/ dist.3p/';
 const APP_SERVING_DIRS = 'dist.tools/ examples/ test/manual/';

--- a/build-system/pr-check/utils.js
+++ b/build-system/pr-check/utils.js
@@ -30,10 +30,9 @@ const {getLoggingPrefix, logWithoutTimestamp} = require('../common/logging');
 const {isCiBuild, ciPullRequestSha} = require('../common/ci');
 const {replaceUrls} = require('../tasks/pr-deploy-bot-utils');
 
-const SUFFIX = shortSha(ciPullRequestSha());
-const UNMINIFIED_OUTPUT_FILE = `amp_unminified_${SUFFIX}.zip`;
-const NOMODULE_OUTPUT_FILE = `amp_nomodule_${SUFFIX}.zip`;
-const MODULE_OUTPUT_FILE = `amp_module_${SUFFIX}.zip`;
+const UNMINIFIED_OUTPUT_FILE = `amp_unminified_${ciPullRequestSha()}.zip`;
+const NOMODULE_OUTPUT_FILE = `amp_nomodule_${ciPullRequestSha()}.zip`;
+const MODULE_OUTPUT_FILE = `amp_module_${ciPullRequestSha()}.zip`;
 
 const BUILD_OUTPUT_DIRS = 'build/ dist/ dist.3p/';
 const APP_SERVING_DIRS = 'dist.tools/ examples/ test/manual/';

--- a/build-system/tasks/pr-deploy-bot-utils.js
+++ b/build-system/tasks/pr-deploy-bot-utils.js
@@ -18,7 +18,7 @@
 const fs = require('fs-extra');
 const path = require('path');
 const request = require('request-promise');
-const {ciBuildId, ciPullRequestSha, isCircleciBuild} = require('../common/ci');
+const {ciPullRequestSha, isCircleciBuild} = require('../common/ci');
 const {cyan} = require('ansi-colors');
 const {getLoggingPrefix, logWithoutTimestamp} = require('../common/logging');
 const {replaceUrls: replaceUrlsAppUtil} = require('../server/app-utils');
@@ -81,9 +81,8 @@ async function signalPrDeployUpload(result) {
     'to the pr-deploy GitHub App...'
   );
   const sha = shortSha(ciPullRequestSha());
-  const ciBuild = ciBuildId();
   const baseUrl = 'https://amp-pr-deploy-bot.appspot.com/v0/pr-deploy/';
-  const url = `${baseUrl}cibuilds/${ciBuild}/headshas/${sha}/${result}`;
+  const url = `${baseUrl}headshas/${sha}/${result}`;
   await request.post(url);
 }
 

--- a/build-system/tasks/pr-deploy-bot-utils.js
+++ b/build-system/tasks/pr-deploy-bot-utils.js
@@ -18,10 +18,9 @@
 const fs = require('fs-extra');
 const path = require('path');
 const request = require('request-promise');
-const {ciBuildId} = require('../common/ci');
+const {ciBuildId, ciPullRequestSha, isCircleciBuild} = require('../common/ci');
 const {cyan} = require('ansi-colors');
 const {getLoggingPrefix, logWithoutTimestamp} = require('../common/logging');
-const {gitCommitHash} = require('../common/git');
 const {replaceUrls: replaceUrlsAppUtil} = require('../server/app-utils');
 
 const hostNamePrefix = 'https://storage.googleapis.com/amp-test-website-1';
@@ -42,7 +41,7 @@ async function walk(dest) {
 }
 
 function getBaseUrl() {
-  return `${hostNamePrefix}/amp_nomodule_${ciBuildId()}`;
+  return `${hostNamePrefix}/amp_nomodule_${ciPullRequestSha()}`;
 }
 
 async function replace(filePath) {
@@ -70,13 +69,17 @@ async function replaceUrls(dir) {
 }
 
 async function signalPrDeployUpload(result) {
+  // TODO(rsimha): Remove this check once Travis is shut down.
+  if (!isCircleciBuild()) {
+    return;
+  }
   const loggingPrefix = getLoggingPrefix();
   logWithoutTimestamp(
     `${loggingPrefix} Reporting`,
     cyan(result),
     'to the pr-deploy GitHub App...'
   );
-  const sha = gitCommitHash();
+  const sha = ciPullRequestSha();
   const ciBuild = ciBuildId();
   const baseUrl = 'https://amp-pr-deploy-bot.appspot.com/v0/pr-deploy/';
   const url = `${baseUrl}cibuilds/${ciBuild}/headshas/${sha}/${result}`;

--- a/build-system/tasks/pr-deploy-bot-utils.js
+++ b/build-system/tasks/pr-deploy-bot-utils.js
@@ -22,6 +22,7 @@ const {ciBuildId, ciPullRequestSha, isCircleciBuild} = require('../common/ci');
 const {cyan} = require('ansi-colors');
 const {getLoggingPrefix, logWithoutTimestamp} = require('../common/logging');
 const {replaceUrls: replaceUrlsAppUtil} = require('../server/app-utils');
+const {shortSha} = require('../common/git');
 
 const hostNamePrefix = 'https://storage.googleapis.com/amp-test-website-1';
 
@@ -41,7 +42,7 @@ async function walk(dest) {
 }
 
 function getBaseUrl() {
-  return `${hostNamePrefix}/amp_nomodule_${ciPullRequestSha()}`;
+  return `${hostNamePrefix}/amp_nomodule_${shortSha(ciPullRequestSha())}`;
 }
 
 async function replace(filePath) {
@@ -79,7 +80,7 @@ async function signalPrDeployUpload(result) {
     cyan(result),
     'to the pr-deploy GitHub App...'
   );
-  const sha = ciPullRequestSha();
+  const sha = shortSha(ciPullRequestSha());
   const ciBuild = ciBuildId();
   const baseUrl = 'https://amp-pr-deploy-bot.appspot.com/v0/pr-deploy/';
   const url = `${baseUrl}cibuilds/${ciBuild}/headshas/${sha}/${result}`;

--- a/build-system/tasks/pr-deploy-bot-utils.js
+++ b/build-system/tasks/pr-deploy-bot-utils.js
@@ -18,7 +18,7 @@
 const fs = require('fs-extra');
 const path = require('path');
 const request = require('request-promise');
-const {ciPullRequestSha, isCircleciBuild} = require('../common/ci');
+const {ciPullRequestSha, isTravisBuild} = require('../common/ci');
 const {cyan} = require('ansi-colors');
 const {getLoggingPrefix, logWithoutTimestamp} = require('../common/logging');
 const {replaceUrls: replaceUrlsAppUtil} = require('../server/app-utils');
@@ -71,7 +71,7 @@ async function replaceUrls(dir) {
 
 async function signalPrDeployUpload(result) {
   // TODO(rsimha): Remove this check once Travis is shut down.
-  if (!isCircleciBuild()) {
+  if (!isTravisBuild()) {
     return;
   }
   const loggingPrefix = getLoggingPrefix();

--- a/build-system/tasks/pr-deploy-bot-utils.js
+++ b/build-system/tasks/pr-deploy-bot-utils.js
@@ -22,7 +22,6 @@ const {ciPullRequestSha, isTravisBuild} = require('../common/ci');
 const {cyan} = require('ansi-colors');
 const {getLoggingPrefix, logWithoutTimestamp} = require('../common/logging');
 const {replaceUrls: replaceUrlsAppUtil} = require('../server/app-utils');
-const {shortSha} = require('../common/git');
 
 const hostNamePrefix = 'https://storage.googleapis.com/amp-test-website-1';
 
@@ -42,7 +41,7 @@ async function walk(dest) {
 }
 
 function getBaseUrl() {
-  return `${hostNamePrefix}/amp_nomodule_${shortSha(ciPullRequestSha())}`;
+  return `${hostNamePrefix}/amp_nomodule_${ciPullRequestSha()}`;
 }
 
 async function replace(filePath) {
@@ -80,7 +79,7 @@ async function signalPrDeployUpload(result) {
     cyan(result),
     'to the pr-deploy GitHub App...'
   );
-  const sha = shortSha(ciPullRequestSha());
+  const sha = ciPullRequestSha();
   const baseUrl = 'https://amp-pr-deploy-bot.appspot.com/v0/pr-deploy/';
   const url = `${baseUrl}headshas/${sha}/${result}`;
   await request.post(url);


### PR DESCRIPTION
On CircleCI, restarting a failed job results in a new workflow ID. This breaks binary download because the filename suffix is the old workflow ID. The only way out is to restart the entire workflow. See [this example](https://app.circleci.com/pipelines/github/ampproject/amphtml?branch=pull%2F32073).

**PR highlights:**

- Change filename suffix to `ciPullRequestSha()` (consistent across restarts)
- Update PR Deploy utils with this change
- Execute `signalPrDeployUpload()` only when binaries are built on Travis (until transition is complete)
- Remove build / workflow ID from the reporting URL

Updates to the PR deploy app internals are contained in https://github.com/ampproject/amp-github-apps/pull/1201