### PR TITLE
🏗 Split off unit tests into a separate CI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,6 +117,14 @@ jobs:
       - run:
           name: 'Visual Diff Tests'
           command: node build-system/pr-check/visual-diff-tests.js
+  'Unit Tests':
+    executor:
+      name: amphtml-executor
+    steps:
+      - setup_vm
+      - run:
+          name: 'Unit Tests'
+          command: node build-system/pr-check/unit-tests.js
   'Unminified Tests':
     executor:
       name: amphtml-executor
@@ -204,6 +212,8 @@ workflows:
           context: amphtml-context
           requires:
             - 'Nomodule Build'
+      - 'Unit Tests':
+          context: amphtml-context
       - 'Unminified Tests':
           context: amphtml-context
           requires:

--- a/.travis.yml
+++ b/.travis.yml
@@ -80,6 +80,10 @@ jobs:
       script:
         - unbuffer node build-system/pr-check/visual-diff-tests.js
     - stage: test
+      name: 'Unit Tests'
+      script:
+        - unbuffer node build-system/pr-check/unit-tests.js
+    - stage: test
       name: 'Unminified Tests'
       script:
         - unbuffer node build-system/pr-check/unminified-tests.js

--- a/build-system/tasks/unit.js
+++ b/build-system/tasks/unit.js
@@ -34,11 +34,8 @@ class Runner extends RuntimeTestRunner {
   /** @override */
   async maybeBuild() {
     await vendorConfigs();
-
-    if (!argv.nobuild) {
-      await css();
-      await compileJison();
-    }
+    await css();
+    await compileJison();
   }
 }
 
@@ -74,7 +71,6 @@ unit.flags = {
   'ie': '  Runs tests on IE',
   'local_changes':
     '  Run unit tests directly affected by the files changed in the local branch',
-  'nobuild': '  Skips build step',
   'nohelp': '  Silence help messages that are printed prior to test run',
   'report': '  Write test result report to a local file',
   'safari': '  Runs tests on Safari',


### PR DESCRIPTION
**Current state:**
- Unit tests are run with the unminified integration tests
- They used to need the entire unminified runtime, but no longer do
- They add 7-10 mins of running time to the job

**Changes in this PR:**
- Move unit tests to their own CI job
- Coverage and test case reporting data are uploaded separately
- On CircleCI, run when the job starts (provides an early signal when tests fail)
- On Travis, run in parallel with integration tests (shortens overall CI running time)
- Remove defunct `--nobuild` from `gulp unit` (remaining pre-steps CSS / vendor configs / jison take <1s to run)

**New running times:**

![image](https://user-images.githubusercontent.com/26553114/105254876-7d24b100-5b50-11eb-914d-09590952a7bf.png)
