### PR TITLE
Fix null rootBounds for LegacyAdIntersectionObserverHost

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -16,6 +16,6 @@
   "build-in-chunks": 1,
   "visibility-trigger-improvements": 1,
   "fie-resources": 1,
-  "ads-initialIntersection": 1,
+  "ads-initialIntersection": 0,
   "amp-cid-backup": 1
 }

--- a/extensions/amp-ad/0.1/legacy-ad-intersection-observer-host.js
+++ b/extensions/amp-ad/0.1/legacy-ad-intersection-observer-host.js
@@ -221,13 +221,10 @@ export class LegacyAdIntersectionObserverHost {
       this.intersectionObserver_.observe(this.baseElement_.element);
     }
     if (!this.fireInOb_) {
-      this.fireInOb_ = new IntersectionObserver(
-        (entries) => {
-          const lastEntry = entries[entries.length - 1];
-          this.sendElementIntersection_(lastEntry);
-        },
-        {root: this.baseElement_.win.document}
-      );
+      this.fireInOb_ = new IntersectionObserver((entries) => {
+        const lastEntry = entries[entries.length - 1];
+        this.sendElementIntersection_(lastEntry);
+      });
     }
     this.fire();
   }
@@ -272,6 +269,15 @@ export class LegacyAdIntersectionObserverHost {
    */
   sendElementIntersection_(entry) {
     const change = intersectionEntryToJson(entry);
+    // rootBounds is always null in 3p iframe (e.g. Viewer).
+    // See https://github.com/w3c/IntersectionObserver/issues/79
+    //
+    // Since before using a real InOb we used to provide rootBounds,
+    // we are temporarily continuing to do so now.
+    // TODO: determine if consumers rely on this functionality and remove if not.
+    if (change.rootBounds === null) {
+      change.rootBounds = this.baseElement_.getViewport().getRect();
+    }
 
     if (
       this.pendingChanges_.length > 0 &&

--- a/extensions/amp-ad/0.1/legacy-ad-intersection-observer-host.js
+++ b/extensions/amp-ad/0.1/legacy-ad-intersection-observer-host.js
@@ -221,10 +221,13 @@ export class LegacyAdIntersectionObserverHost {
       this.intersectionObserver_.observe(this.baseElement_.element);
     }
     if (!this.fireInOb_) {
-      this.fireInOb_ = new IntersectionObserver((entries) => {
-        const lastEntry = entries[entries.length - 1];
-        this.sendElementIntersection_(lastEntry);
-      });
+      this.fireInOb_ = new IntersectionObserver(
+        (entries) => {
+          const lastEntry = entries[entries.length - 1];
+          this.sendElementIntersection_(lastEntry);
+        },
+        {root: this.baseElement_.win}
+      );
     }
     this.fire();
   }

--- a/extensions/amp-ad/0.1/legacy-ad-intersection-observer-host.js
+++ b/extensions/amp-ad/0.1/legacy-ad-intersection-observer-host.js
@@ -274,11 +274,9 @@ export class LegacyAdIntersectionObserverHost {
     // Since before using a real InOb we used to provide rootBounds,
     // we are temporarily continuing to do so now.
     // TODO: eventually remove this when confident consumers don't rely on it.
-    console.error(JSON.stringify(change));
     if (change.rootBounds === null) {
       change.rootBounds = this.baseElement_.getViewport().getRect();
     }
-    console.error({change});
 
     if (
       this.pendingChanges_.length > 0 &&

--- a/extensions/amp-ad/0.1/legacy-ad-intersection-observer-host.js
+++ b/extensions/amp-ad/0.1/legacy-ad-intersection-observer-host.js
@@ -221,10 +221,13 @@ export class LegacyAdIntersectionObserverHost {
       this.intersectionObserver_.observe(this.baseElement_.element);
     }
     if (!this.fireInOb_) {
-      this.fireInOb_ = new IntersectionObserver((entries) => {
-        const lastEntry = entries[entries.length - 1];
-        this.sendElementIntersection_(lastEntry);
-      });
+      this.fireInOb_ = new IntersectionObserver(
+        (entries) => {
+          const lastEntry = entries[entries.length - 1];
+          this.sendElementIntersection_(lastEntry);
+        },
+        {root: this.baseElement_.win.document}
+      );
     }
     this.fire();
   }
@@ -269,15 +272,7 @@ export class LegacyAdIntersectionObserverHost {
    */
   sendElementIntersection_(entry) {
     const change = intersectionEntryToJson(entry);
-    // rootBounds is always null in 3p iframe (e.g. Viewer).
-    // See https://github.com/w3c/IntersectionObserver/issues/79
-    //
-    // Since before using a real InOb we used to provide rootBounds,
-    // we are temporarily continuing to do so now.
-    // TODO: determine if consumers rely on this functionality and remove if not.
-    if (change.rootBounds === null) {
-      change.rootBounds = this.baseElement_.getViewport().getRect();
-    }
+    console.error({change});
 
     if (
       this.pendingChanges_.length > 0 &&

--- a/extensions/amp-ad/0.1/legacy-ad-intersection-observer-host.js
+++ b/extensions/amp-ad/0.1/legacy-ad-intersection-observer-host.js
@@ -269,11 +269,12 @@ export class LegacyAdIntersectionObserverHost {
    */
   sendElementIntersection_(entry) {
     const change = intersectionEntryToJson(entry);
-    // rootBounds is always null when in viewer due to sec. issues.
+    // rootBounds is always null in 3p iframe (e.g. Viewer).
     // See https://github.com/w3c/IntersectionObserver/issues/79
+    //
     // Since before using a real InOb we used to provide rootBounds,
     // we are temporarily continuing to do so now.
-    // TODO: eventually remove this when confident consumers don't rely on it.
+    // TODO: determine if consumers rely on this functionality and remove if not.
     if (change.rootBounds === null) {
       change.rootBounds = this.baseElement_.getViewport().getRect();
     }

--- a/extensions/amp-ad/0.1/legacy-ad-intersection-observer-host.js
+++ b/extensions/amp-ad/0.1/legacy-ad-intersection-observer-host.js
@@ -272,7 +272,6 @@ export class LegacyAdIntersectionObserverHost {
    */
   sendElementIntersection_(entry) {
     const change = intersectionEntryToJson(entry);
-    console.error({change});
 
     if (
       this.pendingChanges_.length > 0 &&

--- a/src/iframe-attributes.js
+++ b/src/iframe-attributes.js
@@ -73,7 +73,7 @@ export function getContextMetadata(
     'ampcontextVersion': internalRuntimeVersion(),
     'ampcontextFilepath': `${
       urls.thirdParty
-    }/${internalRuntimeVersion()}/ampcontext-v0.js`,
+    }/${'2101200139000'}/ampcontext-v0.js`,
     'sourceUrl': docInfo.sourceUrl,
     'referrer': referrer,
     'canonicalUrl': docInfo.canonicalUrl,

--- a/src/iframe-attributes.js
+++ b/src/iframe-attributes.js
@@ -73,7 +73,7 @@ export function getContextMetadata(
     'ampcontextVersion': internalRuntimeVersion(),
     'ampcontextFilepath': `${
       urls.thirdParty
-    }/${'2101200139000'}/ampcontext-v0.js`,
+    }/${internalRuntimeVersion()}/ampcontext-v0.js`,
     'sourceUrl': docInfo.sourceUrl,
     'referrer': referrer,
     'canonicalUrl': docInfo.canonicalUrl,

--- a/src/utils/intersection.js
+++ b/src/utils/intersection.js
@@ -86,9 +86,20 @@ export function measureIntersection(el) {
 export function intersectionEntryToJson(entry) {
   return {
     time: entry.time,
-    rootBounds: layoutRectFromDomRect(entry.rootBounds),
-    boundingClientRect: layoutRectFromDomRect(entry.boundingClientRect),
-    intersectionRect: layoutRectFromDomRect(entry.intersectionRect),
+    rootBounds: safeLayoutRectFromDomRect(entry.rootBounds),
+    boundingClientRect: safeLayoutRectFromDomRect(entry.boundingClientRect),
+    intersectionRect: safeLayoutRectFromDomRect(entry.intersectionRect),
     intersectionRatio: entry.intersectionRatio,
   };
+}
+
+/**
+ * @param {DOMRect} rect
+ * @return {DOMRect}
+ */
+function safeLayoutRectFromDomRect(rect) {
+  if (rect === null) {
+    return null;
+  }
+  return layoutRectFromDomRect(rect);
 }

--- a/test/unit/utils/test-intersection.js
+++ b/test/unit/utils/test-intersection.js
@@ -15,8 +15,8 @@
  */
 
 import {
-  measureIntersection,
   intersectionEntryToJson,
+  measureIntersection,
 } from '../../../src/utils/intersection';
 
 describes.fakeWin('utils/intersection', {}, (env) => {

--- a/test/unit/utils/test-intersection.js
+++ b/test/unit/utils/test-intersection.js
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-import {measureIntersection} from '../../../src/utils/intersection';
+import {
+  intersectionEntryToJson,
+  measureIntersection,
+} from '../../../src/utils/intersection';
 
 describes.fakeWin('utils/intersection', {}, (env) => {
   function getInObConstructorStub() {
@@ -122,5 +125,43 @@ describes.fakeWin('utils/intersection', {}, (env) => {
 
     expect(await intersection1).equal(firstEntry);
     expect(await intersection2).equal(secondEntry);
+  });
+
+  describe('intersectionEntryToJson', () => {
+    const zeros = {
+      left: 0,
+      right: 0,
+      width: 0,
+      height: 0,
+      top: 0,
+      bottom: 0,
+      x: 0,
+      y: 0,
+    };
+    it('clones an IntersectionObserverEntry', () => {
+      const entry = {
+        time: 0,
+        intersectionRatio: 0,
+        rootBounds: zeros,
+        intersectionRect: zeros,
+        boundingClientRect: zeros,
+      };
+      const json = intersectionEntryToJson(entry);
+      expect(entry).eql(json);
+      expect(entry).not.equal(json);
+    });
+
+    it('clones with null rootBounds', () => {
+      const entry = {
+        time: 0,
+        intersectionRatio: 0,
+        rootBounds: null,
+        intersectionRect: zeros,
+        boundingClientRect: zeros,
+      };
+      const json = intersectionEntryToJson(entry);
+      expect(entry).eql(json);
+      expect(entry).not.equal(json);
+    });
   });
 });

--- a/test/unit/utils/test-intersection.js
+++ b/test/unit/utils/test-intersection.js
@@ -15,8 +15,8 @@
  */
 
 import {
-  intersectionEntryToJson,
   measureIntersection,
+  intersectionEntryToJson,
 } from '../../../src/utils/intersection';
 
 describes.fakeWin('utils/intersection', {}, (env) => {
@@ -138,6 +138,7 @@ describes.fakeWin('utils/intersection', {}, (env) => {
       x: 0,
       y: 0,
     };
+
     it('clones an IntersectionObserverEntry', () => {
       const entry = {
         time: 0,


### PR DESCRIPTION
**summary**

This PR applies two solutions to a newly introduced bug in `LegacyAdIntersectionObserverHost` and the `measureIntersection` helper:

1. Sometimes IntersectionObserverEntry will have null rootBounds. This is especially true when within a crossorigin iframe (e.g. a Viewer). The current [intersectionEntryToJson](https://github.com/ampproject/amphtml/blob/00c6263009a751884aba82fd8abc614c7988eea1/src/utils/intersection.js#L86-L94) function breaks in this case. 
2. A potentially null `rootBounds` (following correct spec) is a breaking change for current 3p consumers of amp-provided intersections (amp-ads). This PR adds in the old behavior of `getViewport.getRect()` for situations with missing rootBounds by setting `root=document` instead.
3. Completely turns off `ads.initialIntersection` experiment

Followups to perform:
- [ ] Figure out what to do for ads.initialIntersection experiment
- [ ] Determine if we can align rootBounds with spec for `LegacyAdIntersectionObserverHost`. Bigger picture: do we want to be blindly passing along an InObEntry? We'd ideally like to be altering it
- [ ] Convert `measureIntersection` to always track doc root instead of window. Also use this helper in LegacyAdIntersectionObserverHost
- [ ] Investigate potential WebKit bug