### PR TITLE
🏗 Add an owners file for `.circleci/`

### DIFF
--- a/.circleci/OWNERS
+++ b/.circleci/OWNERS
@@ -1,0 +1,10 @@
+// For an explanation of the OWNERS rules and syntax, see:
+// https://github.com/ampproject/amp-github-apps/blob/master/owners/OWNERS.example
+
+{
+  rules: [
+    {
+      owners: [{name: 'ampproject/wg-infra'}, {name: 'rsimha', notify: true}],
+    },
+  ],
+}


### PR DESCRIPTION
This is a new directory, and (intentionally) isn't captured by the dotfile glob in the root `OWNERS` file.