### PR TITLE
🏗 Upgrade to `dompurify` 2.2.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10667,9 +10667,9 @@
       }
     },
     "dompurify": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.0.7.tgz",
-      "integrity": "sha512-S3O0lk6rFJtO01ZTzMollCOGg+WAtCwS3U5E2WSDY/x/sy7q70RjEC4Dmrih5/UqzLLB9XoKJ8KqwBxaNvBu4A=="
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.2.6.tgz",
+      "integrity": "sha512-7b7ZArhhH0SP6W2R9cqK6RjaU82FZ2UPM7RO8qN1b1wyvC/NY1FNWcX1Pu00fFOAnzEORtwXe4bPaClg6pUybQ=="
     },
     "domutils": {
       "version": "1.7.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@ampproject/toolbox-cache-url": "2.7.2",
     "@ampproject/viewer-messaging": "1.1.0",
     "@ampproject/worker-dom": "0.27.4",
-    "dompurify": "2.0.7",
+    "dompurify": "2.2.6",
     "intersection-observer": "0.12.0",
     "jss": "10.3.0",
     "jss-preset-default": "10.4.0",

--- a/src/purifier/package-lock.json
+++ b/src/purifier/package-lock.json
@@ -1,0 +1,59 @@
+{
+  "name": "@ampproject/purifier",
+  "version": "1.0.2",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@rollup/plugin-alias": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-alias/-/plugin-alias-3.1.1.tgz",
+      "integrity": "sha512-hNcQY4bpBUIvxekd26DBPgF7BT4mKVNDF5tBG4Zi+3IgwLxGYRY0itHs9D0oLVwXM5pvJDWJlBQro+au8WaUWw==",
+      "dev": true,
+      "requires": {
+        "slash": "^3.0.0"
+      }
+    },
+    "@types/dompurify": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-2.2.1.tgz",
+      "integrity": "sha512-3JwbEeRVQ3n6+JgBW/hCdkydRk9/vWT+UEglcXEJqLJEcUganDH37zlfLznxPKTZZfDqA9K229l1qN458ubcOQ==",
+      "optional": true,
+      "requires": {
+        "@types/trusted-types": "*"
+      }
+    },
+    "@types/trusted-types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.0.tgz",
+      "integrity": "sha512-I8MnZqNXsOLHsU111oHbn3khtvKMi5Bn4qVFsIWSJcCP1KKDiXX5AEw8UPk0nSopeC+Hvxt6yAy1/a5PailFqg==",
+      "optional": true
+    },
+    "dompurify": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.2.6.tgz",
+      "integrity": "sha512-7b7ZArhhH0SP6W2R9cqK6RjaU82FZ2UPM7RO8qN1b1wyvC/NY1FNWcX1Pu00fFOAnzEORtwXe4bPaClg6pUybQ=="
+    },
+    "fsevents": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+      "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+      "dev": true,
+      "optional": true
+    },
+    "rollup": {
+      "version": "2.37.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.37.0.tgz",
+      "integrity": "sha512-cbxuxkMGCQV+TnVh+yZSUerbVb5i8soRydbzHYoMNojgt7MMi+jDLLs24U9HHCssKkwkXmsj+LXcOZMldTbz2w==",
+      "dev": true,
+      "requires": {
+        "fsevents": "~2.1.2"
+      }
+    },
+    "slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true
+    }
+  }
+}

--- a/src/purifier/package.json
+++ b/src/purifier/package.json
@@ -7,11 +7,19 @@
   "main": "dist/purifier.js",
   "module": "dist/purifier.mjs",
   "types": "purifier.d.ts",
-  "files": ["dist/*", "purifier.d.ts"],
+  "files": [
+    "dist/*",
+    "purifier.d.ts"
+  ],
   "scripts": {
     "build": "rollup -c rollup.config.js"
   },
-  "keywords": ["amp", "sanitizer", "sanitize", "purify"],
+  "keywords": [
+    "amp",
+    "sanitizer",
+    "sanitize",
+    "purify"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/ampproject/amphtml.git",
@@ -23,7 +31,7 @@
     "rollup": "2.37.0"
   },
   "dependencies": {
-    "dompurify": "2.0.7"
+    "dompurify": "2.2.6"
   },
   "optionalDependencies": {
     "@types/dompurify": "2.2.1"


### PR DESCRIPTION
The runtime uses `dompurify` 2.0.7, which appears to have a security vulnerability. This PR upgrades to the latest version 2.2.6.

![image](https://user-images.githubusercontent.com/26553114/105258927-c547d180-5b58-11eb-924c-db4beba786f7.png)
