### PR TITLE
🏗  Minor bugfixes for `gulp prettify`

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
 package.json
+package-lock.json

--- a/build-system/tasks/prettify.js
+++ b/build-system/tasks/prettify.js
@@ -31,11 +31,12 @@ const tempy = require('tempy');
 const {
   log,
   logLocalDev,
+  logOnSameLine,
   logOnSameLineLocalDev,
   logWithoutTimestamp,
 } = require('../common/logging');
 const {exec} = require('../common/exec');
-const {getFilesToCheck, logOnSameLine} = require('../common/utils');
+const {getFilesToCheck} = require('../common/utils');
 const {green, cyan, red, yellow} = require('ansi-colors');
 const {maybeUpdatePackages} = require('./update-packages');
 const {prettifyGlobs} = require('../test-configs/config');

--- a/build-system/test-configs/config.js
+++ b/build-system/test-configs/config.js
@@ -164,6 +164,7 @@ const prettifyGlobs = [
   '**/*.json',
   '**/OWNERS',
   '**/*.md',
+  '!**/package*.json',
   '!.github/ISSUE_TEMPLATE/**',
   '!**/{node_modules,build,dist,dist.3p,dist.tools,.karma-cache}/**',
 ];


### PR DESCRIPTION
- Import `logOnSameLine` from correct place
- Exempt `package.json` and `package-lock.json` from prettier checks