### PR TITLE
🏗 Test the merge commit with `master` during CircleCI builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ version: 2.1
 
 orbs:
   browser-tools: circleci/browser-tools@1.1.1
+  build-tools: circleci/build-tools@2.7.1
 
 skip_pr_branches: &skip_pr_branches
   filters:
@@ -18,6 +19,7 @@ commands:
   setup_vm:
     steps:
       - checkout
+      - build-tools/merge-with-parent
       - browser-tools/install-chrome:
           replace-existing: true
       - run:


### PR DESCRIPTION
Other CI services test the result of merging a PR branch on to `master`, and include recent upstream commits while running tests. CircleCI does not exhibit this behavior by default.

This PR enables merge commit testing using the `merge-with-parent` command from the official [`circleci/build-tools`](https://circleci.com/developer/orbs/orb/circleci/build-tools#usage-merge-with-parent) orb.
