### PR TITLE
🏗 Test the merge commit with `master` during CircleCI builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,10 @@ commands:
   setup_vm:
     steps:
       - checkout
+      - run:
+          name: 'Fetch Merge Commit'
+          command: |
+            ./.circleci/fetch_merge_commit.sh
       - browser-tools/install-chrome:
           replace-existing: true
       - run:

--- a/.circleci/fetch_merge_commit.sh
+++ b/.circleci/fetch_merge_commit.sh
@@ -24,6 +24,9 @@ if [ -z "$CIRCLE_PR_NUMBER" ]; then
   exit
 fi
 
+# GitHub provides refs/pull/<PR_NUMBER>/merge for every PR branch that can be
+# cleanly merged to `master`. See this discussion for more details:
+# https://discuss.circleci.com/t/show-test-results-for-prospective-merge-of-a-github-pr/1662
 MERGE_BRANCH="refs/pull/$CIRCLE_PR_NUMBER/merge"
 (set -x && git pull --ff-only origin "$MERGE_BRANCH") || err=$?
 

--- a/.circleci/fetch_merge_commit.sh
+++ b/.circleci/fetch_merge_commit.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+#
+# Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the license.
+#
+# This script fetches the merge commit of a PR branch with master.
+
+set -e
+err=0
+
+if [ -z "$CIRCLE_PR_NUMBER" ]; then
+  echo -e "Nothing to do because this is not a PR build."
+  exit
+fi
+
+MERGE_BRANCH="refs/pull/$CIRCLE_PR_NUMBER/merge"
+(set -x && git pull --ff-only origin "$MERGE_BRANCH") || err=$?
+
+if [ "$err" -ne "0" ]; then
+  echo
+  echo -e "ERROR: Detected a merge conflict between $CIRCLE_BRANCH and master."
+  echo -e "Please rebase your PR branch."
+  exit $err
+fi
+
+echo -e "Successfully fetched merge commit of $CIRCLE_BRANCH with master."


### PR DESCRIPTION
Other CI services test the result of merging a PR branch on to `master`, and include recent upstream commits while running tests. CircleCI does not exhibit this behavior by default.

This PR adds a post-checkout step that switches to the well-known Github merge ref `refs/pull/$CIRCLE_PR_NUMBER/merge`.

**Before:**

![image](https://user-images.githubusercontent.com/26553114/105284451-79a91e00-5b80-11eb-8d5f-ac2397d8bfad.png)

**After:**

![image](https://user-images.githubusercontent.com/26553114/105284483-8c235780-5b80-11eb-95e1-c5b4c3850466.png)

**Reference:** https://discuss.circleci.com/t/show-test-results-for-prospective-merge-of-a-github-pr/1662