### PR TITLE
🏗 Stop running performance tests until they are optimized / fixed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -235,11 +235,12 @@ workflows:
           context: amphtml-context
           requires:
             - 'Nomodule Build'
-      - 'Performance Tests':
-          <<: *skip_pr_branches
-          context: amphtml-context
-          requires:
-            - 'Nomodule Build'
+      # TODO(wg-performance, #12128): This takes 30 mins and fails regularly.
+      # - 'Performance Tests':
+      #     <<: *skip_pr_branches
+      #     context: amphtml-context
+      #     requires:
+      #       - 'Nomodule Build'
       - 'Experiment A Tests':
           <<: *skip_pr_branches
           context: amphtml-context


### PR DESCRIPTION
Performance tests take ~30 mins and regularly fail during CI.

![image](https://user-images.githubusercontent.com/26553114/105397545-34700500-5bef-11eb-8d91-43e342709e51.png)

With this PR, CI round trip time should reduce to ~20 mins. 

Tracking issue: #12128


