### PR TITLE
♻️ amp-story page distance map

### DIFF
--- a/extensions/amp-story-360/0.1/amp-story-360.js
+++ b/extensions/amp-story-360/0.1/amp-story-360.js
@@ -358,16 +358,16 @@ export class AmpStory360 extends AMP.BaseElement {
     this.applyFillContent(container, /* replacedContent */ true);
 
     // Mutation observer for distance attribute
-    const config = {attributes: true, attributeFilter: ['distance']};
-    const callback = (mutationsList) => {
-      this.distance_ = parseInt(
-        mutationsList[0].target.getAttribute('distance'),
-        10
-      );
-      this.restoreOrLoseGlContext_();
-    };
-    const observer = new MutationObserver(callback);
-    this.getPage_() && observer.observe(this.getPage_(), config);
+    // const config = {attributes: true, attributeFilter: ['distance']};
+    // const callback = (mutationsList) => {
+    //   this.distance_ = parseInt(
+    //     mutationsList[0].target.getAttribute('distance'),
+    //     10
+    //   );
+    //   this.restoreOrLoseGlContext_();
+    // };
+    // const observer = new MutationObserver(callback);
+    // this.getPage_() && observer.observe(this.getPage_(), config);
 
     // Initialize all services before proceeding
     return Promise.all([
@@ -391,6 +391,13 @@ export class AmpStory360 extends AMP.BaseElement {
           this.onPageNavigation_();
           this.maybeShowDiscoveryAnimation_();
         });
+
+        storeService.subscribe(
+          StateProperty.PAGE_DISTANCE_MAP,
+          (pageDistanceMap) => {
+            this.distance_ = pageDistanceMap[this.getPageId_()];
+          }
+        );
 
         this.storeService_.subscribe(StateProperty.PAUSED_STATE, (isPaused) => {
           if (this.isOnActivePage_) {

--- a/extensions/amp-story-360/0.1/amp-story-360.js
+++ b/extensions/amp-story-360/0.1/amp-story-360.js
@@ -513,7 +513,7 @@ export class AmpStory360 extends AMP.BaseElement {
       // Debounce onDeviceOrientation_ to rAF.
       let rafTimeout;
       this.win.addEventListener('deviceorientation', (e) => {
-        if (this.isReady_ && this.distance_ < MIN_WEBGL_DISTANCE) {
+        if (this.isReady_) {
           rafTimeout && this.win.cancelAnimationFrame(rafTimeout);
           rafTimeout = this.win.requestAnimationFrame(() => {
             if (!this.isOnActivePage_) {

--- a/extensions/amp-story-360/0.1/amp-story-360.js
+++ b/extensions/amp-story-360/0.1/amp-story-360.js
@@ -357,18 +357,6 @@ export class AmpStory360 extends AMP.BaseElement {
     container.appendChild(this.canvas_);
     this.applyFillContent(container, /* replacedContent */ true);
 
-    // Mutation observer for distance attribute
-    // const config = {attributes: true, attributeFilter: ['distance']};
-    // const callback = (mutationsList) => {
-    //   this.distance_ = parseInt(
-    //     mutationsList[0].target.getAttribute('distance'),
-    //     10
-    //   );
-    //   this.restoreOrLoseGlContext_();
-    // };
-    // const observer = new MutationObserver(callback);
-    // this.getPage_() && observer.observe(this.getPage_(), config);
-
     // Initialize all services before proceeding
     return Promise.all([
       Services.storyStoreServiceForOrNull(this.win).then((storeService) => {

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -355,6 +355,15 @@ export class AmpStoryPage extends AMP.BaseElement {
       (uiState) => this.onUIStateUpdate_(uiState),
       true /* callToInitialize */
     );
+    this.storeService_.subscribe(
+      StateProperty.PAGE_DISTANCE_MAP,
+      (pageDistanceMap) => {
+        const distance = pageDistanceMap[this.element.id];
+        this.mutateElement(() => {
+          this.setDistance(distance);
+        });
+      }
+    );
     this.setPageDescription_();
     this.element.setAttribute('role', 'region');
     this.initializeImgAltTags_();

--- a/extensions/amp-story/1.0/amp-story-store-service.js
+++ b/extensions/amp-story/1.0/amp-story-store-service.js
@@ -127,7 +127,7 @@ export let InteractiveReactData;
  *    consentId: ?string,
  *    currentPageId: string,
  *    currentPageIndex: number,
- *    pageDistanceMap: !Map<string, !string>,
+ *    pageDistanceMap: !Map<string, !number>,
  *    pageIds: !Array<string>,
  *    newPageAvailableId: string,
  *    pageSize: {width: number, height: number},

--- a/extensions/amp-story/1.0/amp-story-store-service.js
+++ b/extensions/amp-story/1.0/amp-story-store-service.js
@@ -249,6 +249,7 @@ const stateComparisonFunctions = {
      */
     (old, curr) => old.element !== curr.element || old.state !== curr.state,
   [StateProperty.NAVIGATION_PATH]: (old, curr) => old.length !== curr.length,
+  [StateProperty.PAGE_DISTANCE_MAP]: (old, curr) => !deepEquals(old, curr),
   [StateProperty.PAGE_IDS]: (old, curr) => old.length !== curr.length,
   [StateProperty.PAGE_SIZE]: (old, curr) =>
     old === null ||

--- a/extensions/amp-story/1.0/amp-story-store-service.js
+++ b/extensions/amp-story/1.0/amp-story-store-service.js
@@ -127,6 +127,7 @@ export let InteractiveReactData;
  *    consentId: ?string,
  *    currentPageId: string,
  *    currentPageIndex: number,
+ *    pageDistanceMap: !Map<string, !string>,
  *    pageIds: !Array<string>,
  *    newPageAvailableId: string,
  *    pageSize: {width: number, height: number},
@@ -189,6 +190,7 @@ export const StateProperty = {
   ADVANCEMENT_MODE: 'advancementMode',
   NAVIGATION_PATH: 'navigationPath',
   NEW_PAGE_AVAILABLE_ID: 'newPageAvailableId',
+  PAGE_DISTANCE_MAP: 'pageDistanceMap',
   PAGE_IDS: 'pageIds',
   PAGE_SIZE: 'pageSize',
 };
@@ -201,6 +203,7 @@ export const Action = {
   SET_CONSENT_ID: 'setConsentId',
   SET_ADVANCEMENT_MODE: 'setAdvancementMode',
   SET_NAVIGATION_PATH: 'setNavigationPath',
+  SET_PAGE_DISTANCE_MAP: 'setPageDistanceMap',
   SET_PAGE_IDS: 'setPageIds',
   TOGGLE_ACCESS: 'toggleAccess',
   TOGGLE_AD: 'toggleAd',
@@ -473,6 +476,11 @@ const actions = (state, action, data) => {
         ...state,
         [StateProperty.NAVIGATION_PATH]: data,
       });
+    case Action.SET_PAGE_DISTANCE_MAP:
+      return /** @type {!State} */ ({
+        ...state,
+        [StateProperty.PAGE_DISTANCE_MAP]: data,
+      });
     case Action.SET_PAGE_IDS:
       return /** @type {!State} */ ({
         ...state,
@@ -628,6 +636,7 @@ export class AmpStoryStoreService {
       [StateProperty.ADVANCEMENT_MODE]: '',
       [StateProperty.NEW_PAGE_AVAILABLE_ID]: '',
       [StateProperty.NAVIGATION_PATH]: [],
+      [StateProperty.PAGE_DISTANCE_MAP]: {},
       [StateProperty.PAGE_IDS]: [],
       [StateProperty.PAGE_SIZE]: null,
       [StateProperty.PREVIEW_STATE]: false,

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -1520,6 +1520,23 @@ export class AmpStory extends AMP.BaseElement {
           }
         }
 
+        const pagesByDistance = this.getPagesByDistance_();
+
+        const pageDistanceMap = pagesByDistance.reduce(
+          (acc, pageIds, distance) => {
+            pageIds.forEach((pageId) => {
+              acc[pageId] = distance;
+            });
+            return acc;
+          },
+          {}
+        );
+
+        this.storeService_.dispatch(
+          Action.SET_PAGE_DISTANCE_MAP,
+          pageDistanceMap
+        );
+
         this.storeService_.dispatch(Action.CHANGE_PAGE, {
           id: targetPageId,
           index: storePageIndex,
@@ -2267,17 +2284,6 @@ export class AmpStory extends AMP.BaseElement {
       });
       return;
     }
-
-    const pagesByDistance = this.getPagesByDistance_();
-
-    const pageDistanceMap = pagesByDistance.reduce((acc, pageIds, distance) => {
-      pageIds.forEach((pageId) => {
-        acc[pageId] = distance;
-      });
-      return acc;
-    }, {});
-
-    this.storeService_.dispatch(Action.SET_PAGE_DISTANCE_MAP, pageDistanceMap);
   }
 
   /**

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -2270,14 +2270,14 @@ export class AmpStory extends AMP.BaseElement {
 
     const pagesByDistance = this.getPagesByDistance_();
 
-    this.mutateElement(() => {
-      pagesByDistance.forEach((pageIds, distance) => {
-        pageIds.forEach((pageId) => {
-          const page = this.getPageById(pageId);
-          page.setDistance(distance);
-        });
+    const pageDistanceMap = pagesByDistance.reduce((acc, pageIds, distance) => {
+      pageIds.forEach((pageId) => {
+        acc[pageId] = distance;
       });
-    });
+      return acc;
+    }, {});
+
+    this.storeService_.dispatch(Action.SET_PAGE_DISTANCE_MAP, pageDistanceMap);
   }
 
   /**


### PR DESCRIPTION
Allows distance to be retrieved directly from the JS.
Each amp-story-page can listen to this to set distance.

This would also allow components to retrieve this information from the store rather than a mutation observer.
amp-story-360 is in this PR as an example. amp-story-panning-media would also use this.