### PR TITLE
❄️ Mark visual test `amphtml-ads: friendly iframe static` as flaky

### DIFF
--- a/test/visual-diff/visual-tests
+++ b/test/visual-diff/visual-tests
@@ -724,6 +724,8 @@
       "no_base_test": true
     },
     {
+      // TODO(#28975, @ampproject/wg-monetization): see https://percy.io/ampproject/amphtml/builds-next/8494289/changed/482844300
+      "flaky": true,
       "url": "examples/visual-tests/amphtml-ads/amp-fie-static.html",
       "name": "amphtml-ads: friendly iframe static",
       "interactive_tests": "examples/visual-tests/amphtml-ads/static.js",


### PR DESCRIPTION
This test has been failing repeatedly of late. See https://github.com/ampproject/amphtml/issues/28975#issuecomment-764908430.

/cc @ampproject/build-cop 