### PR TITLE
[amp-viewer-integration] Don't import from AMP, use regex as constant

### DIFF
--- a/extensions/amp-viewer-integration/0.1/messaging/messaging.js
+++ b/extensions/amp-viewer-integration/0.1/messaging/messaging.js
@@ -14,7 +14,20 @@
  * limitations under the License.
  */
 
-import {urls} from '../../../../src/config';
+/**
+ * Allows for runtime configuration. Internally, the runtime should
+ * use the src/config.js module for various constants. We can use the
+ * AMP_CONFIG global to translate user-defined configurations to this
+ * module.
+ * @type {!Object<string, string>}
+ */
+const env = self.AMP_CONFIG || {};
+
+const cdnProxyRegex =
+  (typeof env['cdnProxyRegex'] == 'string'
+    ? new RegExp(env['cdnProxyRegex'])
+    : env['cdnProxyRegex']) ||
+  /^https:\/\/([a-zA-Z0-9_-]+\.)?cdn\.ampproject\.org$/;
 
 const TAG = 'amp-viewer-messaging';
 const CHANNEL_OPEN_MSG = 'channelOpen';
@@ -173,7 +186,7 @@ export class Messaging {
           return;
         }
         if (
-          (event.origin == origin || urls.cdnProxyRegex.test(event.origin)) &&
+          (event.origin == origin || cdnProxyRegex.test(event.origin)) &&
           (!event.source || event.source == target) &&
           message.app === APP &&
           message.name === CHANNEL_OPEN_MSG

--- a/extensions/amp-viewer-integration/0.1/messaging/package.json
+++ b/extensions/amp-viewer-integration/0.1/messaging/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ampproject/viewer-messaging",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Messaging between an AMP Doc and a Viewer",
   "author": "The AMP HTML Authors",
   "license": "Apache-2.0",

--- a/src/amp-story-player/amp-story-player-impl.js
+++ b/src/amp-story-player/amp-story-player-impl.js
@@ -42,6 +42,7 @@ import {getMode} from '../../src/mode';
 import {parseJson} from '../json';
 import {resetStyles, setStyle, setStyles} from '../style';
 import {toArray} from '../types';
+import {urls} from '../config';
 
 /** @enum {string} */
 const LoadStateClass = {
@@ -619,7 +620,9 @@ export class AmpStoryPlayer {
       return Messaging.waitForHandshakeFromDocument(
         this.win_,
         iframeEl.contentWindow,
-        this.getEncodedLocation_(url).origin
+        this.getEncodedLocation_(url).origin,
+        /*opt_token*/ null,
+        urls.cdnProxyRegex
       );
     });
   }


### PR DESCRIPTION
Follow up for #32076

We were importing `urls` from AMP, which isn't available when doing npm install. This PR sends the regex as a parameter.

~~Question for @jridgewell : is calling `const env = self.AMP_CONFIG || {};` in the npm package safe?~~
<!--
# Instructions:

- Pick a meaningful title for your pull request. (Use sentence case.)
  - Prefix the title with an emoji to identify what is being done. (Copy-paste the emoji from the list below.)
  - Do not overuse punctuation in the title (like `(chore):`).
  - If it is helpful, use a simple prefix (like `ProjectX: Implement some feature`).
- Enter a succinct description that says why the PR is necessary, and what it does.
  - Mention the GitHub issue that is being addressed by the pull request.
  - The keywords `Fixes`, `Closes`, or `Resolves` followed the issue number will automatically close the issue.

> NOTE: All non-trivial changes (like introducing new features or components) should have an associated issue or reference an I2I (intent-to-implement: go.amp.dev/i2i). Please read through the contribution process (go.amp.dev/contributing/code) for more information.

# Example of a good description:

- Implement aspect X
- Leave out feature Y because of A
- Improve performance by B
- Improve accessibility by C

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Reverting a previous change
♻️ Refactoring
🚮 Deleting code
🧪 Experimental code
-->
