### PR TITLE
❄️  amp-base-carousel e2e test modifications

### DIFF
--- a/extensions/amp-base-carousel/0.1/test-e2e/test-advance.js
+++ b/extensions/amp-base-carousel/0.1/test-e2e/test-advance.js
@@ -20,7 +20,7 @@ const pageWidth = 500;
 const pageHeight = 800;
 
 describes.endtoend(
-  'AMP carousel advance',
+  'amp-base-carousel:0.1 - advance',
   {
     testUrl:
       'http://localhost:8000/test/manual/amp-base-carousel/advance.amp.html',

--- a/extensions/amp-base-carousel/0.1/test-e2e/test-arrows-non-looping.js
+++ b/extensions/amp-base-carousel/0.1/test-e2e/test-arrows-non-looping.js
@@ -22,7 +22,7 @@ const pageWidth = 600;
 const pageHeight = 600;
 
 describes.endtoend(
-  'AMP carousel arrows when non-looping',
+  'amp-base-carousel:0.1 - arrows when non-looping',
   {
     testUrl:
       'http://localhost:8000/test/manual/amp-base-carousel/non-looping.amp.html',

--- a/extensions/amp-base-carousel/0.1/test-e2e/test-arrows.js
+++ b/extensions/amp-base-carousel/0.1/test-e2e/test-arrows.js
@@ -20,7 +20,7 @@ import {getNextArrow, getPrevArrow, getSlide} from './helpers';
 const SLIDE_COUNT = 7;
 
 describes.endtoend(
-  'AMP carousel arrows with custom arrows',
+  'amp-base-carousel:0.1 - arrows with custom arrows',
   {
     testUrl:
       'http://localhost:8000/test/manual/amp-base-carousel/custom-arrows.amp.html',

--- a/extensions/amp-base-carousel/0.1/test-e2e/test-autoadvance.js
+++ b/extensions/amp-base-carousel/0.1/test-e2e/test-autoadvance.js
@@ -20,7 +20,7 @@ const pageWidth = 800;
 const pageHeight = 600;
 
 describes.endtoend(
-  'AMP carousel autoadvance',
+  'amp-base-carousel:0.1 - autoadvance',
   {
     testUrl:
       'http://localhost:8000/test/manual/amp-base-carousel/autoadvance.amp.html',

--- a/extensions/amp-base-carousel/0.1/test-e2e/test-carousel.js
+++ b/extensions/amp-base-carousel/0.1/test-e2e/test-carousel.js
@@ -23,7 +23,7 @@ const pageHeight = 600;
 const testTimeout = 20000;
 
 describes.endtoend(
-  'AMP carousel',
+  'amp-base-carousel:0.1 - basic functionality',
   {
     testUrl:
       'http://localhost:8000/test/manual/amp-base-carousel/basic.amp.html',

--- a/extensions/amp-base-carousel/0.1/test-e2e/test-default-attributes.js
+++ b/extensions/amp-base-carousel/0.1/test-e2e/test-default-attributes.js
@@ -18,7 +18,7 @@ const pageWidth = 800;
 const pageHeight = 800;
 
 describes.endtoend(
-  'AMP carousel test default attributes',
+  'amp-base-carousel:0.1 - default attributes',
   {
     testUrl:
       'http://localhost:8000/test/manual/amp-base-carousel/default-attributes.amp.html',

--- a/extensions/amp-base-carousel/0.1/test-e2e/test-grouping.js
+++ b/extensions/amp-base-carousel/0.1/test-e2e/test-grouping.js
@@ -20,7 +20,7 @@ const pageWidth = 800;
 const pageHeight = 600;
 
 describes.endtoend(
-  'AMP carousel grouping',
+  'amp-base-carousel:0.1 - grouping',
   {
     testUrl:
       'http://localhost:8000/test/manual/amp-base-carousel/' +

--- a/extensions/amp-base-carousel/0.1/test-e2e/test-hidden-controls.js
+++ b/extensions/amp-base-carousel/0.1/test-e2e/test-hidden-controls.js
@@ -17,7 +17,7 @@
 import {getNextArrow} from './helpers';
 
 describes.endtoend(
-  'AMP carousel arrows with hidden controls',
+  'amp-base-carousel:0.1 - arrows with hidden controls',
   {
     testUrl:
       'http://localhost:8000/test/manual/amp-base-carousel/hidden-controls.amp.html',

--- a/extensions/amp-base-carousel/0.1/test-e2e/test-initial-slide.js
+++ b/extensions/amp-base-carousel/0.1/test-e2e/test-initial-slide.js
@@ -20,7 +20,7 @@ const pageWidth = 600;
 const pageHeight = 600;
 
 describes.endtoend(
-  'AMP carousel',
+  'amp-base-carousel:0.1 - initial slide',
   {
     testUrl:
       'http://localhost:8000/test/manual/amp-base-carousel/' +

--- a/extensions/amp-base-carousel/0.1/test-e2e/test-mixed-lengths-no-snap.js
+++ b/extensions/amp-base-carousel/0.1/test-e2e/test-mixed-lengths-no-snap.js
@@ -20,7 +20,7 @@ const pageWidth = 800;
 const pageHeight = 600;
 
 describes.endtoend(
-  'AMP carousel mixed length slides',
+  'amp-base-carousel:0.1 - mixed length slides without snapping',
   {
     testUrl:
       'http://localhost:8000/test/manual/amp-base-carousel/' +

--- a/extensions/amp-base-carousel/0.1/test-e2e/test-mixed-lengths.js
+++ b/extensions/amp-base-carousel/0.1/test-e2e/test-mixed-lengths.js
@@ -20,7 +20,7 @@ const pageWidth = 800;
 const pageHeight = 600;
 
 describes.endtoend(
-  'AMP carousel mixed length slides',
+  'amp-base-carousel:0.1 - mixed length slides',
   {
     testUrl:
       'http://localhost:8000/test/manual/amp-base-carousel/' +

--- a/extensions/amp-base-carousel/0.1/test-e2e/test-multi-visible-single-advance.js
+++ b/extensions/amp-base-carousel/0.1/test-e2e/test-multi-visible-single-advance.js
@@ -17,7 +17,7 @@
 import {getNextArrow, getPrevArrow, getSlides, sleep} from './helpers';
 
 describes.endtoend(
-  'AMP carousel advancing with multiple visible',
+  'amp-base-carousel:0.1 - advancing with multiple visible slides',
   {
     testUrl:
       'http://localhost:8000/test/manual/amp-base-carousel/multi-visible-single-advance.amp.html',

--- a/extensions/amp-base-carousel/0.1/test-e2e/test-non-looping.js
+++ b/extensions/amp-base-carousel/0.1/test-e2e/test-non-looping.js
@@ -20,7 +20,7 @@ const pageWidth = 800;
 const pageHeight = 600;
 
 describes.endtoend(
-  'Non-looping AMP carousel',
+  'amp-base-carousel:0.1 - non-looping',
   {
     testUrl:
       'http://localhost:8000/test/manual/amp-base-carousel/' +

--- a/extensions/amp-base-carousel/0.1/test-e2e/test-responsive.js
+++ b/extensions/amp-base-carousel/0.1/test-e2e/test-responsive.js
@@ -20,7 +20,7 @@ const pageWidth = 1000;
 const pageHeight = 600;
 
 describes.endtoend(
-  'AMP Carousel responsive attributes',
+  'amp-base-carousel:0.1 - responsive attributes',
   {
     testUrl:
       'http://localhost:8000/test/manual/amp-base-carousel/' +

--- a/extensions/amp-base-carousel/0.1/test-e2e/test-rtl.js
+++ b/extensions/amp-base-carousel/0.1/test-e2e/test-rtl.js
@@ -21,7 +21,7 @@ const pageHeight = 600;
 const arrowMargin = 12;
 
 describes.endtoend(
-  'AMP carousel rtl',
+  'amp-base-carousel:0.1 - rtl',
   {
     testUrl:
       'http://localhost:8000/test/manual/amp-base-carousel/basic-rtl.amp.html',

--- a/extensions/amp-base-carousel/0.1/test-e2e/test-snap-property.js
+++ b/extensions/amp-base-carousel/0.1/test-e2e/test-snap-property.js
@@ -17,7 +17,7 @@
 import {getSlides, getSpacers} from './helpers';
 
 describes.endtoend(
-  'amp-base-carousel test snap property',
+  'amp-base-carousel:0.1 - snap property',
   {
     testUrl:
       'http://localhost:8000/test/manual/amp-base-carousel/snap-property.amp.html',

--- a/extensions/amp-base-carousel/0.1/test-e2e/test-vertical.js
+++ b/extensions/amp-base-carousel/0.1/test-e2e/test-vertical.js
@@ -20,7 +20,7 @@ const pageWidth = 800;
 const pageHeight = 600;
 
 describes.endtoend(
-  'Vertical AMP carousel',
+  'amp-base-carousel:0.1 - vertical orientation',
   {
     testUrl:
       'http://localhost:8000/test/manual/amp-base-carousel/' +

--- a/extensions/amp-base-carousel/1.0/test-e2e/test-advance.js
+++ b/extensions/amp-base-carousel/1.0/test-e2e/test-advance.js
@@ -27,7 +27,7 @@ const pageWidth = 500;
 const pageHeight = 800;
 
 describes.endtoend(
-  'AMP carousel advance',
+  'amp-base-carousel:1.0 - advance',
   {
     testUrl:
       'http://localhost:8000/test/manual/amp-base-carousel/1.0/advance.amp.html',

--- a/extensions/amp-base-carousel/1.0/test-e2e/test-arrows-non-looping.js
+++ b/extensions/amp-base-carousel/1.0/test-e2e/test-arrows-non-looping.js
@@ -27,6 +27,9 @@ const SLIDE_COUNT = 4;
 const pageWidth = 600;
 const pageHeight = 600;
 
+/** Increase timeout for running on CircleCI **/
+const testTimeout = 40000;
+
 describes.endtoend(
   'amp-base-carousel:1.0 - arrows when non-looping',
   {
@@ -47,6 +50,7 @@ describes.endtoend(
     }
 
     beforeEach(async () => {
+      this.timeout(testTimeout);
       controller = env.controller;
       const carousel = await getCarousel(controller);
       await controller.switchToShadowRoot(carousel);

--- a/extensions/amp-base-carousel/1.0/test-e2e/test-arrows-non-looping.js
+++ b/extensions/amp-base-carousel/1.0/test-e2e/test-arrows-non-looping.js
@@ -49,7 +49,7 @@ describes.endtoend(
       return controller.getElementCssValue(handle, name);
     }
 
-    beforeEach(async () => {
+    beforeEach(async function () {
       this.timeout(testTimeout);
       controller = env.controller;
       const carousel = await getCarousel(controller);

--- a/extensions/amp-base-carousel/1.0/test-e2e/test-arrows-non-looping.js
+++ b/extensions/amp-base-carousel/1.0/test-e2e/test-arrows-non-looping.js
@@ -28,7 +28,7 @@ const pageWidth = 600;
 const pageHeight = 600;
 
 describes.endtoend(
-  'AMP carousel arrows when non-looping',
+  'amp-base-carousel:1.0 - arrows when non-looping',
   {
     testUrl:
       'http://localhost:8000/test/manual/amp-base-carousel/1.0/non-looping.amp.html',

--- a/extensions/amp-base-carousel/1.0/test-e2e/test-arrows.js
+++ b/extensions/amp-base-carousel/1.0/test-e2e/test-arrows.js
@@ -26,7 +26,7 @@ import {useStyles} from '../base-carousel.jss';
 const SLIDE_COUNT = 7;
 
 describes.endtoend(
-  'AMP carousel arrows with custom arrows',
+  'amp-base-carousel:1.0 - arrows with custom arrows',
   {
     testUrl:
       'http://localhost:8000/test/manual/amp-base-carousel/1.0/custom-arrows.amp.html',

--- a/extensions/amp-base-carousel/1.0/test-e2e/test-autoadvance.js
+++ b/extensions/amp-base-carousel/1.0/test-e2e/test-autoadvance.js
@@ -21,7 +21,7 @@ const pageWidth = 800;
 const pageHeight = 600;
 
 describes.endtoend(
-  'AMP carousel autoadvance',
+  'amp-base-carousel:1.0 - autoadvance',
   {
     testUrl:
       'http://localhost:8000/test/manual/amp-base-carousel/1.0/autoadvance.amp.html',

--- a/extensions/amp-base-carousel/1.0/test-e2e/test-carousel.js
+++ b/extensions/amp-base-carousel/1.0/test-e2e/test-carousel.js
@@ -24,7 +24,7 @@ const pageHeight = 600;
 const testTimeout = 30000;
 
 describes.endtoend(
-  'AMP carousel',
+  'amp-base-carousel:1.0 - basic functionality',
   {
     testUrl:
       'http://localhost:8000/test/manual/amp-base-carousel/1.0/basic.amp.html',

--- a/extensions/amp-base-carousel/1.0/test-e2e/test-carousel.js
+++ b/extensions/amp-base-carousel/1.0/test-e2e/test-carousel.js
@@ -20,8 +20,8 @@ import {useStyles} from '../base-carousel.jss';
 const pageWidth = 800;
 const pageHeight = 600;
 
-/** Increase timeout for running on Travis macOS **/
-const testTimeout = 30000;
+/** Increase timeout for running on CircleCI **/
+const testTimeout = 40000;
 
 describes.endtoend(
   'amp-base-carousel:1.0 - basic functionality',

--- a/extensions/amp-base-carousel/1.0/test-e2e/test-grouping.js
+++ b/extensions/amp-base-carousel/1.0/test-e2e/test-grouping.js
@@ -25,7 +25,7 @@ const pivotIndex = Math.floor(slideCount / 2);
 const expectedScrollPosition = (pageWidth / advanceCount) * pivotIndex;
 
 describes.endtoend(
-  'AMP carousel grouping',
+  'amp-base-carousel:1.0 - grouping',
   {
     testUrl:
       'http://localhost:8000/test/manual/amp-base-carousel/1.0/' +

--- a/extensions/amp-base-carousel/1.0/test-e2e/test-mixed-lengths-no-snap.js
+++ b/extensions/amp-base-carousel/1.0/test-e2e/test-mixed-lengths-no-snap.js
@@ -21,7 +21,7 @@ const pageWidth = 800;
 const pageHeight = 600;
 
 describes.endtoend(
-  'AMP carousel mixed length slides',
+  'amp-base-carousel:1.0 - mixed length slides without snapping',
   {
     testUrl:
       'http://localhost:8000/test/manual/amp-base-carousel/1.0/' +

--- a/extensions/amp-base-carousel/1.0/test-e2e/test-mixed-lengths.js
+++ b/extensions/amp-base-carousel/1.0/test-e2e/test-mixed-lengths.js
@@ -20,6 +20,9 @@ import {useStyles} from '../base-carousel.jss';
 const pageWidth = 800;
 const pageHeight = 600;
 
+/** Increase timeout for running on CircleCI **/
+const testTimeout = 40000;
+
 describes.endtoend(
   'amp-base-carousel:1.0 - mixed length slides',
   {
@@ -49,6 +52,7 @@ describes.endtoend(
       const slideWidth = pageWidth * 0.75;
 
       it('should have the correct initial slide positions', async () => {
+        this.timeout(testTimeout);
         const slideOne = await getSlide(styles, controller, 0);
         const slideTwo = await getSlide(styles, controller, 1);
 
@@ -64,6 +68,7 @@ describes.endtoend(
       });
 
       it('should snap on the center point', async () => {
+        this.timeout(testTimeout);
         const el = await getScrollingElement(styles, controller);
         const slideTwo = await getSlide(styles, controller, 1);
         const scrollAmount = 1;

--- a/extensions/amp-base-carousel/1.0/test-e2e/test-mixed-lengths.js
+++ b/extensions/amp-base-carousel/1.0/test-e2e/test-mixed-lengths.js
@@ -21,7 +21,7 @@ const pageWidth = 800;
 const pageHeight = 600;
 
 describes.endtoend(
-  'AMP carousel mixed length slides',
+  'amp-base-carousel:1.0 - mixed length slides',
   {
     testUrl:
       'http://localhost:8000/test/manual/amp-base-carousel/1.0/' +

--- a/extensions/amp-base-carousel/1.0/test-e2e/test-mixed-lengths.js
+++ b/extensions/amp-base-carousel/1.0/test-e2e/test-mixed-lengths.js
@@ -51,7 +51,7 @@ describes.endtoend(
     describe('snap', () => {
       const slideWidth = pageWidth * 0.75;
 
-      it('should have the correct initial slide positions', async () => {
+      it('should have the correct initial slide positions', async function () {
         this.timeout(testTimeout);
         const slideOne = await getSlide(styles, controller, 0);
         const slideTwo = await getSlide(styles, controller, 1);
@@ -67,7 +67,7 @@ describes.endtoend(
         });
       });
 
-      it('should snap on the center point', async () => {
+      it('should snap on the center point', async function () {
         this.timeout(testTimeout);
         const el = await getScrollingElement(styles, controller);
         const slideTwo = await getSlide(styles, controller, 1);

--- a/extensions/amp-base-carousel/1.0/test-e2e/test-non-looping.js
+++ b/extensions/amp-base-carousel/1.0/test-e2e/test-non-looping.js
@@ -21,7 +21,7 @@ const pageWidth = 800;
 const pageHeight = 600;
 
 describes.endtoend(
-  'Non-looping AMP carousel',
+  'amp-base-carousel:1.0 - non-looping',
   {
     testUrl:
       'http://localhost:8000/test/manual/amp-base-carousel/1.0/' +

--- a/extensions/amp-base-carousel/1.0/test-e2e/test-responsive.js
+++ b/extensions/amp-base-carousel/1.0/test-e2e/test-responsive.js
@@ -21,7 +21,7 @@ const pageWidth = 1000;
 const pageHeight = 600;
 
 describes.endtoend(
-  'AMP Carousel responsive attributes',
+  'amp-base-carousel:1.0 - responsive attributes',
   {
     testUrl:
       'http://localhost:8000/test/manual/amp-base-carousel/1.0/' +

--- a/extensions/amp-base-carousel/1.0/test-e2e/test-rtl.js
+++ b/extensions/amp-base-carousel/1.0/test-e2e/test-rtl.js
@@ -21,7 +21,7 @@ const pageWidth = 800;
 const pageHeight = 600;
 
 describes.endtoend(
-  'AMP carousel rtl',
+  'amp-base-carousel:1.0 - rtl',
   {
     testUrl:
       'http://localhost:8000/test/manual/amp-base-carousel/1.0/basic-rtl.amp.html',

--- a/extensions/amp-base-carousel/1.0/test-e2e/test-vertical.js
+++ b/extensions/amp-base-carousel/1.0/test-e2e/test-vertical.js
@@ -21,7 +21,7 @@ const pageWidth = 600;
 const pageHeight = 600;
 
 describes.endtoend(
-  'Vertical AMP carousel',
+  'amp-base-carousel:1.0 - vertical orientation',
   {
     testUrl:
       'http://localhost:8000/test/manual/amp-base-carousel/1.0/' +

--- a/extensions/amp-base-carousel/1.0/test/test-amp-base-carousel.js
+++ b/extensions/amp-base-carousel/1.0/test/test-amp-base-carousel.js
@@ -28,7 +28,7 @@ import {useStyles} from '../base-carousel.jss';
 import {waitFor, whenCalled} from '../../../../testing/test-helper';
 
 describes.realWin(
-  'amp-base-carousel',
+  'amp-base-carousel:1.0',
   {
     amp: {
       runtimeOn: true,


### PR DESCRIPTION
Related to #24195 
- Rename e2e test files to include the version number for easier debugging
- Increase the test timeouts for some 1.0 files to see if this gets us anywhere with CircleCI. Another PR should follow up to skip these tomorrow if we find that this is not the case.