### PR TITLE
🏗 Fix commit SHA retrieval for push and PR builds on all CI services

### DIFF
--- a/build-system/common/ci.js
+++ b/build-system/common/ci.js
@@ -227,8 +227,17 @@ function ciRepoSlug() {
     : '';
 }
 
+/**
+ * Returns the commit SHA being tested by a push or PR build.
+ * @return {string}
+ */
+function ciBuildSha() {
+  return isPullRequestBuild() ? ciPullRequestSha() : ciCommitSha();
+}
+
 module.exports = {
   ciBuildId,
+  ciBuildSha,
   ciBuildUrl,
   ciCommitSha,
   ciJobId,

--- a/build-system/pr-check/utils.js
+++ b/build-system/pr-check/utils.js
@@ -24,15 +24,15 @@ const {
   gitCiMasterBaseline,
   shortSha,
 } = require('../common/git');
+const {ciBuildSha, ciPullRequestSha, isCiBuild} = require('../common/ci');
 const {cyan, green, yellow} = require('ansi-colors');
 const {execOrDie, execOrThrow, execWithError, exec} = require('../common/exec');
 const {getLoggingPrefix, logWithoutTimestamp} = require('../common/logging');
-const {isCiBuild, ciPullRequestSha} = require('../common/ci');
 const {replaceUrls} = require('../tasks/pr-deploy-bot-utils');
 
-const UNMINIFIED_OUTPUT_FILE = `amp_unminified_${ciPullRequestSha()}.zip`;
-const NOMODULE_OUTPUT_FILE = `amp_nomodule_${ciPullRequestSha()}.zip`;
-const MODULE_OUTPUT_FILE = `amp_module_${ciPullRequestSha()}.zip`;
+const UNMINIFIED_OUTPUT_FILE = `amp_unminified_${ciBuildSha()}.zip`;
+const NOMODULE_OUTPUT_FILE = `amp_nomodule_${ciBuildSha()}.zip`;
+const MODULE_OUTPUT_FILE = `amp_module_${ciBuildSha()}.zip`;
 
 const BUILD_OUTPUT_DIRS = 'build/ dist/ dist.3p/';
 const APP_SERVING_DIRS = 'dist.tools/ examples/ test/manual/';

--- a/build-system/tasks/codecov-upload.js
+++ b/build-system/tasks/codecov-upload.js
@@ -17,12 +17,7 @@
 
 const colors = require('ansi-colors');
 const fs = require('fs-extra');
-const {
-  ciCommitSha,
-  ciPullRequestSha,
-  isCiBuild,
-  isPullRequestBuild,
-} = require('../common/ci');
+const {ciBuildSha, isCiBuild} = require('../common/ci');
 const {getStdout} = require('../common/exec');
 const {log} = require('../common/logging');
 const {shortSha} = require('../common/git');
@@ -68,9 +63,7 @@ async function codecovUpload() {
     return;
   }
 
-  const commitSha = shortSha(
-    isPullRequestBuild() ? ciPullRequestSha() : ciCommitSha()
-  );
+  const commitSha = shortSha(ciBuildSha());
   log(
     green('INFO:'),
     'Uploading coverage reports to',

--- a/build-system/tasks/pr-deploy-bot-utils.js
+++ b/build-system/tasks/pr-deploy-bot-utils.js
@@ -18,7 +18,7 @@
 const fs = require('fs-extra');
 const path = require('path');
 const request = require('request-promise');
-const {ciPullRequestSha, isTravisBuild} = require('../common/ci');
+const {ciBuildSha, isTravisBuild} = require('../common/ci');
 const {cyan} = require('ansi-colors');
 const {getLoggingPrefix, logWithoutTimestamp} = require('../common/logging');
 const {replaceUrls: replaceUrlsAppUtil} = require('../server/app-utils');
@@ -41,7 +41,7 @@ async function walk(dest) {
 }
 
 function getBaseUrl() {
-  return `${hostNamePrefix}/amp_nomodule_${ciPullRequestSha()}`;
+  return `${hostNamePrefix}/amp_nomodule_${ciBuildSha()}`;
 }
 
 async function replace(filePath) {
@@ -79,7 +79,7 @@ async function signalPrDeployUpload(result) {
     cyan(result),
     'to the pr-deploy GitHub App...'
   );
-  const sha = ciPullRequestSha();
+  const sha = ciBuildSha();
   const baseUrl = 'https://amp-pr-deploy-bot.appspot.com/v0/pr-deploy/';
   const url = `${baseUrl}headshas/${sha}/${result}`;
   await request.post(url);


### PR DESCRIPTION
This PR fixes a bug in #32083, where the commit SHA wasn't being fetched correctly during push builds. (The SHA is used to name the zip file containing build artifacts passed between the build and test stages of CI).