### PR TITLE
🏗 Print closure concurrency during `gulp dist`

### DIFF
--- a/build-system/compile/compile.js
+++ b/build-system/compile/compile.js
@@ -32,6 +32,8 @@ const {
 const {checkForUnknownDeps} = require('./check-for-unknown-deps');
 const {CLOSURE_SRC_GLOBS} = require('./sources');
 const {cpus} = require('os');
+const {green, cyan} = require('ansi-colors');
+const {log, logLocalDev} = require('../common/logging');
 const {postClosureBabel} = require('./post-closure-babel');
 const {preClosureBabel, handlePreClosureError} = require('./pre-closure-babel');
 const {sanitize} = require('./sanitize');
@@ -47,7 +49,7 @@ const MAX_PARALLEL_CLOSURE_INVOCATIONS =
 // Compiles AMP with the closure compiler. This is intended only for
 // production use. During development we intend to continue using
 // babel, as it has much faster incremental compilation.
-exports.closureCompile = async function (
+async function closureCompile(
   entryModuleFilename,
   outputDir,
   outputFilename,
@@ -85,7 +87,7 @@ exports.closureCompile = async function (
     queue.push(start);
     next();
   });
-};
+}
 
 function cleanupBuildDir() {
   del.sync('build/fake-module');
@@ -95,7 +97,6 @@ function cleanupBuildDir() {
   fs.mkdirsSync('build/fake-module/src/polyfills/');
   fs.mkdirsSync('build/fake-polyfills/src/polyfills');
 }
-exports.cleanupBuildDir = cleanupBuildDir;
 
 function compile(
   entryModuleFilenames,
@@ -372,3 +373,24 @@ function compile(
     }
   });
 }
+
+function printClosureConcurrency() {
+  log(
+    green('Using up to'),
+    cyan(MAX_PARALLEL_CLOSURE_INVOCATIONS),
+    green('concurrent invocations of closure compiler.')
+  );
+  if (!argv.closure_concurrency) {
+    logLocalDev(
+      green('⤷ Use'),
+      cyan('--closure_concurrency=N'),
+      green('to change this number.')
+    );
+  }
+}
+
+module.exports = {
+  cleanupBuildDir,
+  closureCompile,
+  printClosureConcurrency,
+};

--- a/build-system/tasks/dist.js
+++ b/build-system/tasks/dist.js
@@ -31,6 +31,10 @@ const {
   toPromise,
 } = require('./helpers');
 const {
+  cleanupBuildDir,
+  printClosureConcurrency,
+} = require('../compile/compile');
+const {
   createCtrlcHandler,
   exitCtrlcHandler,
 } = require('../common/ctrlcHandler');
@@ -38,7 +42,6 @@ const {
   displayLifecycleDebugging,
 } = require('../compile/debug-compilation-lifecycle');
 const {buildExtensions, parseExtensionFlags} = require('./extension-helpers');
-const {cleanupBuildDir} = require('../compile/compile');
 const {compileCss, cssEntryPoints} = require('./css');
 const {compileJison} = require('./compile-jison');
 const {formatExtractedMessages} = require('../compile/log-messages');
@@ -130,6 +133,7 @@ async function doDist(extraArgs = {}) {
     minify: true,
     watch: argv.watch,
   };
+  printClosureConcurrency();
   printNobuildHelp();
   printDistHelp(options);
   await runPreDistSteps(options);


### PR DESCRIPTION
This should help tweak compilation speed during local development and CI builds.

**Results:**

Travis Linux:
![image](https://user-images.githubusercontent.com/26553114/105516177-912cf780-5ca3-11eb-90c9-115a2b6cea82.png)
![image](https://user-images.githubusercontent.com/26553114/105516798-49f33680-5ca4-11eb-96b8-de8655ca292a.png)

GH Actions Linux:
![image](https://user-images.githubusercontent.com/26553114/105515978-56c35a80-5ca3-11eb-8c11-6b768e21a67c.png)
![image](https://user-images.githubusercontent.com/26553114/105516642-1e704c00-5ca4-11eb-83cc-7def808d8213.png)

GH Actions macOS:
![image](https://user-images.githubusercontent.com/26553114/105516025-65aa0d00-5ca3-11eb-97d2-9e618d17b652.png)
![image](https://user-images.githubusercontent.com/26553114/105516681-29c37780-5ca4-11eb-9892-bf7c643c577c.png)

GH Actions Windows:
![image](https://user-images.githubusercontent.com/26553114/105516064-7195cf00-5ca3-11eb-8f6d-a6a33b3c6d4b.png)
![image](https://user-images.githubusercontent.com/26553114/105516713-347e0c80-5ca4-11eb-8387-1dd5ba5446be.png)

CircleCI Linux (xlarge):
![image](https://user-images.githubusercontent.com/26553114/105516131-84a89f00-5ca3-11eb-95c9-507afa64e185.png)
![image](https://user-images.githubusercontent.com/26553114/105516761-4069ce80-5ca4-11eb-8e8b-a31ac73e64f9.png)
