### PR TITLE
🐛 fix amp-consent content-type

### DIFF
--- a/extensions/amp-consent/0.1/amp-consent.js
+++ b/extensions/amp-consent/0.1/amp-consent.js
@@ -591,6 +591,9 @@ export class AmpConsent extends AMP.BaseElement {
           credentials: 'include',
           method: 'POST',
           body: request,
+          headers: {
+            'Content-Type': 'application/json',
+          },
         };
         const href = this.consentConfig_['checkConsentHref'];
         assertHttpsUrl(href, this.element);


### PR DESCRIPTION
amp-consent `checkConsentHref` sends `Content-Type: text/plain` instead of `application/json`

