### PR TITLE
❄️ Skip flaky amp-base-carousel e2e tests

### DIFF
--- a/extensions/amp-base-carousel/1.0/test-e2e/helpers.js
+++ b/extensions/amp-base-carousel/1.0/test-e2e/helpers.js
@@ -22,6 +22,9 @@ const NEXT_ARROW_CLASS = 'arrowNext';
 const PREV_ARROW_SLOT_SELECTOR = '[slot="prev-arrow"]';
 const NEXT_ARROW_SLOT_SELECTOR = '[slot="next-arrow"]';
 
+/** Increase element wait timeout for Selenium controller */
+const ELEMENT_WAIT_TIMEOUT = 10000;
+
 export function getCarousel(controller) {
   return controller.findElement(TAG_NAME);
 }
@@ -35,7 +38,10 @@ export async function getSlide(styles, controller, n) {
 }
 
 export async function getScrollingElement(styles, controller) {
-  return controller.findElement(`.${styles[SCROLLER_CLASS]}`);
+  return controller.findElement(
+    `.${styles[SCROLLER_CLASS]}`,
+    ELEMENT_WAIT_TIMEOUT
+  );
 }
 
 export async function getPrevArrowSlot(controller) {
@@ -47,11 +53,17 @@ export async function getNextArrowSlot(controller) {
 }
 
 export async function getPrevArrow(styles, controller) {
-  return controller.findElement(`.${styles[PREV_ARROW_CLASS]}`);
+  return controller.findElement(
+    `.${styles[PREV_ARROW_CLASS]}`,
+    ELEMENT_WAIT_TIMEOUT
+  );
 }
 
 export async function getNextArrow(styles, controller) {
-  return controller.findElement(`.${styles[NEXT_ARROW_CLASS]}`);
+  return controller.findElement(
+    `.${styles[NEXT_ARROW_CLASS]}`,
+    ELEMENT_WAIT_TIMEOUT
+  );
 }
 
 export function sleep(ms) {

--- a/extensions/amp-base-carousel/1.0/test-e2e/test-arrows-non-looping.js
+++ b/extensions/amp-base-carousel/1.0/test-e2e/test-arrows-non-looping.js
@@ -27,9 +27,6 @@ const SLIDE_COUNT = 4;
 const pageWidth = 600;
 const pageHeight = 600;
 
-/** Increase timeout for running on CircleCI **/
-const testTimeout = 40000;
-
 describes.endtoend(
   'amp-base-carousel:1.0 - arrows when non-looping',
   {
@@ -50,7 +47,6 @@ describes.endtoend(
     }
 
     beforeEach(async function () {
-      this.timeout(testTimeout);
       controller = env.controller;
       const carousel = await getCarousel(controller);
       await controller.switchToShadowRoot(carousel);
@@ -59,18 +55,19 @@ describes.endtoend(
       nextArrow = await getNextArrow(styles, controller);
     });
 
-    it('should have the arrows in the correct initial state', async () => {
+    // TODO(wg-bento): getPrevArrow does not always find element in time.
+    it.skip('should have the arrows in the correct initial state', async () => {
       await expect(css(prevArrow, 'opacity')).to.equal('0');
       await expect(css(nextArrow, 'opacity')).to.equal('1');
     });
 
-    it('should show the prev arrow when going to the first slide', async () => {
+    it.skip('should show the prev arrow when going to the first slide', async () => {
       await controller.click(nextArrow);
       await expect(css(prevArrow, 'opacity')).to.equal('1');
       await expect(css(nextArrow, 'opacity')).to.equal('1');
     });
 
-    it('should hide the next arrow when going to the end', async () => {
+    it.skip('should hide the next arrow when going to the end', async () => {
       const el = await getScrollingElement(styles, controller);
       await controller.scrollTo(el, {left: (SLIDE_COUNT - 1) * pageWidth});
 

--- a/extensions/amp-base-carousel/1.0/test-e2e/test-mixed-lengths.js
+++ b/extensions/amp-base-carousel/1.0/test-e2e/test-mixed-lengths.js
@@ -20,9 +20,6 @@ import {useStyles} from '../base-carousel.jss';
 const pageWidth = 800;
 const pageHeight = 600;
 
-/** Increase timeout for running on CircleCI **/
-const testTimeout = 40000;
-
 describes.endtoend(
   'amp-base-carousel:1.0 - mixed length slides',
   {
@@ -52,7 +49,6 @@ describes.endtoend(
       const slideWidth = pageWidth * 0.75;
 
       it('should have the correct initial slide positions', async function () {
-        this.timeout(testTimeout);
         const slideOne = await getSlide(styles, controller, 0);
         const slideTwo = await getSlide(styles, controller, 1);
 
@@ -67,8 +63,8 @@ describes.endtoend(
         });
       });
 
-      it('should snap on the center point', async function () {
-        this.timeout(testTimeout);
+      // TODO(wg-bento): getScrollingElement does not always find element in time.
+      it.skip('should snap on the center point', async function () {
         const el = await getScrollingElement(styles, controller);
         const slideTwo = await getSlide(styles, controller, 1);
         const scrollAmount = 1;

--- a/extensions/amp-base-carousel/1.0/test-e2e/test-vertical.js
+++ b/extensions/amp-base-carousel/1.0/test-e2e/test-vertical.js
@@ -93,7 +93,8 @@ describes.endtoend(
       await expect(prop(el, 'scrollTop')).to.equal(scrollTop);
     });
 
-    describe('looping', () => {
+    // TODO(wg-bento): getScrollingElement does not always find element in time.
+    describe.skip('looping', () => {
       it('should display slides correctly when moving forwards', async () => {
         const el = await getScrollingElement(styles, controller);
         const lastSlide = await getSlide(styles, controller, SLIDE_COUNT - 1);


### PR DESCRIPTION
Since #32113, tests [still appear to be flaking](https://app.circleci.com/pipelines/github/ampproject/amphtml/236/workflows/6bb80f36-96d2-4986-923f-b0c147e08933/jobs/1588) for `amp-base-carousel`.

EDIT: This PR skips existing flaky tests, often those which call `getScrollingElement`, `getPrevArrow`, and `getNextArrow` - we should continue monitoring if others which use these helper functions (whose timeouts I also increased) begin flaking as well.

The timeout message in the above sample test run `Wait timed out after 5063ms` suggests we should not be increasing the full timeouts for the blocks but the default timeouts given to the `controller.findElement` method. Since this and other ([1](https://app.circleci.com/pipelines/github/ampproject/amphtml/223/workflows/a3f401ef-791b-47aa-b1ed-554951bf4d3f/jobs/1448), [2](https://app.circleci.com/pipelines/github/ampproject/amphtml/220/workflows/e3b05883-f754-483a-a23c-e3048fb536ee/jobs/1425), [3](https://app.circleci.com/pipelines/github/ampproject/amphtml/220/workflows/e3b05883-f754-483a-a23c-e3048fb536ee/jobs/1426)) failures show timeouts right around the `5000` mark (Selenium controller), I also bumped up the affected helpers (`getScrollingElement`, `getPrevArrow`, and `getNextArrow`) to pass in a timeout of `10000` to match the default for the puppeteer controller.

https://github.com/ampproject/amphtml/blob/88712baaa691201560fc795a77137bce6eddcdae/build-system/tasks/e2e/selenium-webdriver-controller.js#L30

https://github.com/ampproject/amphtml/blob/88712baaa691201560fc795a77137bce6eddcdae/build-system/tasks/e2e/puppeteer-controller.js#L48

Related to #24195