### PR TITLE
✨ [Story devtools] Finalize UI details: dark scrollbar, center devices, change tab order

### DIFF
--- a/extensions/amp-story-dev-tools/0.1/amp-story-dev-tools-tab-logs.css
+++ b/extensions/amp-story-dev-tools/0.1/amp-story-dev-tools-tab-logs.css
@@ -19,6 +19,17 @@ amp-story-dev-tools-tab-logs {
   padding: var(--i-amphtml-story-dev-tools-vertical-spacing) 10% !important;
 }
 
+amp-story-dev-tools-tab-logs::-webkit-scrollbar {
+  width: 8px !important;
+}
+amp-story-dev-tools-tab-logs::-webkit-scrollbar-thumb {
+  background-color: var(--i-amphtml-story-dev-tools-white-transparent-1) !important;
+  border-radius: 3px !important;
+}
+amp-story-dev-tools-tab-logs::-webkit-scrollbar-thumb:hover {
+  background-color: var(--i-amphtml-story-dev-tools-white-transparent-2) !important;
+}
+
 .i-amphtml-story-dev-tools-log-status-title {
   font-size: 16px !important;
   display: flex !important;

--- a/extensions/amp-story-dev-tools/0.1/amp-story-dev-tools-tab-preview.css
+++ b/extensions/amp-story-dev-tools/0.1/amp-story-dev-tools-tab-preview.css
@@ -17,11 +17,13 @@
  amp-story-dev-tools-tab-preview {
   --i-amphtml-story-dev-tools-device-shadow: 0px 11.0046px 27.5114px rgba(0, 0, 0, 0.34), inset 0px 2.20091px 3.30137px rgba(44, 46, 52, 0.6) !important;
   padding: var(--i-amphtml-story-dev-tools-vertical-spacing) 10% !important;
+  padding-bottom: calc(var(--i-amphtml-story-dev-tools-vertical-spacing) + 64px) !important;
 }
 
 .i-amphtml-story-dev-tools-devices-container {
   width: 100% !important;
   height: 100% !important;
+  position: relative;
 }
 
 .i-amphtml-story-dev-tools-device {
@@ -150,7 +152,7 @@ amp-story-player a {
 .i-amphtml-story-dev-tools-device-dialog-container {
   background: black !important;
   width: min(650px, 90%) !important;
-  border-radius: 10px !important;
+  border-radius: 30px !important;
   padding: 40px !important;
   position: relative !important;
   transition: transform 0.2s var(--i-amphtml-story-dev-tools-material-easing-accelerated), opacity 0.2s var(--i-amphtml-story-dev-tools-material-easing-accelerated) !important;
@@ -224,8 +226,8 @@ amp-story-player a {
   width: 40px !important;
   height: 40px !important;
   position: absolute !important;
-  top: 0 !important;
-  right: 0 !important;
+  top: 6px !important;
+  right: 6px !important;
   opacity: .6 !important;
   background: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="white" width="18px" height="18px"><path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"/></svg>') !important;
   background-repeat: no-repeat !important;

--- a/extensions/amp-story-dev-tools/0.1/amp-story-dev-tools-tab-preview.js
+++ b/extensions/amp-story-dev-tools/0.1/amp-story-dev-tools-tab-preview.js
@@ -222,8 +222,6 @@ const buildAddDeviceDialogTemplate = (element) => {
 
 const MAX_DEVICE_SPACES = 4;
 
-const MIN_DEVICE_PADDING_PX = 30;
-
 /**
  * @typedef {{
  *  element: !Element,

--- a/extensions/amp-story-dev-tools/0.1/amp-story-dev-tools-tab-preview.js
+++ b/extensions/amp-story-dev-tools/0.1/amp-story-dev-tools-tab-preview.js
@@ -222,6 +222,8 @@ const buildAddDeviceDialogTemplate = (element) => {
 
 const MAX_DEVICE_SPACES = 4;
 
+const MIN_DEVICE_PADDING_PX = 30;
+
 /**
  * @typedef {{
  *  element: !Element,
@@ -521,25 +523,23 @@ export class AmpStoryDevToolsTabPreview extends AMP.BaseElement {
       (el) => el.hasAttribute('data-action'),
       this.element
     );
-    if (actionElement.hasAttribute('disabled')) {
+    if (!actionElement || actionElement.hasAttribute('disabled')) {
       return;
     }
-    if (actionElement) {
-      switch (actionElement.getAttribute('data-action')) {
-        case PREVIEW_ACTIONS.SHOW_HELP_DIALOG:
-          this.showHelpDialog_();
-          break;
-        case PREVIEW_ACTIONS.SHOW_ADD_DEVICE_DIALIG:
-          this.showAddDeviceDialog_();
-          break;
-        case PREVIEW_ACTIONS.CLOSE_DIALOG:
-          this.hideCurrentDialog_();
-          break;
-        case PREVIEW_ACTIONS.REMOVE_DEVICE:
-        case PREVIEW_ACTIONS.TOGGLE_DEVICE_CHIP:
-          this.onDeviceChipToggled_(actionElement);
-          break;
-      }
+    switch (actionElement.getAttribute('data-action')) {
+      case PREVIEW_ACTIONS.SHOW_HELP_DIALOG:
+        this.showHelpDialog_();
+        break;
+      case PREVIEW_ACTIONS.SHOW_ADD_DEVICE_DIALIG:
+        this.showAddDeviceDialog_();
+        break;
+      case PREVIEW_ACTIONS.CLOSE_DIALOG:
+        this.hideCurrentDialog_();
+        break;
+      case PREVIEW_ACTIONS.REMOVE_DEVICE:
+      case PREVIEW_ACTIONS.TOGGLE_DEVICE_CHIP:
+        this.onDeviceChipToggled_(actionElement);
+        break;
     }
   }
 
@@ -656,9 +656,13 @@ export class AmpStoryDevToolsTabPreview extends AMP.BaseElement {
    * @private
    * */
   repositionDevices_() {
-    const {width: layoutWidth, height} = this.getLayoutSize();
-    const width = layoutWidth * 0.8; // To account for 10% horizontal padding.
-    let sumDeviceWidths = 0;
+    const {
+      offsetWidth: width,
+      offsetHeight: height,
+    } = this.element.querySelector(
+      '.i-amphtml-story-dev-tools-devices-container'
+    );
+    let sumDeviceWidths = MIN_DEVICE_PADDING_PX * this.devices_.length;
     let maxDeviceHeights = 0;
     // Find the sum of the device widths and max of heights since they are horizontally laid out.
     this.devices_.forEach((deviceSpecs) => {

--- a/extensions/amp-story-dev-tools/0.1/amp-story-dev-tools-tab-preview.js
+++ b/extensions/amp-story-dev-tools/0.1/amp-story-dev-tools-tab-preview.js
@@ -660,7 +660,7 @@ export class AmpStoryDevToolsTabPreview extends AMP.BaseElement {
     } = this.element.querySelector(
       '.i-amphtml-story-dev-tools-devices-container'
     );
-    let sumDeviceWidths = MIN_DEVICE_PADDING_PX * this.devices_.length;
+    let sumDeviceWidths = 0;
     let maxDeviceHeights = 0;
     // Find the sum of the device widths and max of heights since they are horizontally laid out.
     this.devices_.forEach((deviceSpecs) => {

--- a/extensions/amp-story-dev-tools/0.1/amp-story-dev-tools.js
+++ b/extensions/amp-story-dev-tools/0.1/amp-story-dev-tools.js
@@ -103,8 +103,8 @@ const buildContainerTemplate = (element) => {
 /** @enum {string} */
 const DevToolsTab = {
   PREVIEW: 'Preview',
-  PAGE_EXPERIENCE: 'Page Experience',
   LOGS: 'Logs',
+  PAGE_EXPERIENCE: 'Page Experience',
 };
 
 export class AmpStoryDevTools extends AMP.BaseElement {


### PR DESCRIPTION
Added changes from @hongcatlover comments:
- Made scrollbar from logs match dark colors
- Moved logs tab to 2nd place (because it's more important than page-experience)
- Centered devices better by improving sizing of devices container
- Increased border radius of dialogs

![image](https://user-images.githubusercontent.com/22420856/105519614-9db34f00-5ca7-11eb-8747-305aaeddbf57.png)
![image](https://user-images.githubusercontent.com/22420856/105519636-a3a93000-5ca7-11eb-9b2a-6989af417a67.png)
![image](https://user-images.githubusercontent.com/22420856/105519666-ae63c500-5ca7-11eb-9ddf-4c26927a5336.png)
