### PR TITLE
🏗  Replace org-level context with project-level env vars on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -209,65 +209,50 @@ workflows:
     jobs:
       - 'Checks':
           <<: *push_and_pr_builds
-          context: amphtml-context
       - 'Unminified Build':
           <<: *push_and_pr_builds
-          context: amphtml-context
       - 'Nomodule Build':
           <<: *push_and_pr_builds
-          context: amphtml-context
       - 'Module Build':
           <<: *push_and_pr_builds
-          context: amphtml-context
       - 'Bundle Size':
           <<: *push_and_pr_builds
-          context: amphtml-context
           requires:
             - 'Nomodule Build'
             - 'Module Build'
       - 'Validator Tests':
           <<: *push_and_pr_builds
-          context: amphtml-context
       - 'Visual Diff Tests':
           <<: *push_and_pr_builds
-          context: amphtml-context
           requires:
             - 'Nomodule Build'
       - 'Unit Tests':
-          context: amphtml-context
+          <<: *push_and_pr_builds
       - 'Unminified Tests':
           <<: *push_and_pr_builds
-          context: amphtml-context
           requires:
             - 'Unminified Build'
       - 'Nomodule Tests':
           <<: *push_and_pr_builds
-          context: amphtml-context
           requires:
             - 'Nomodule Build'
       - 'Module Tests':
           <<: *push_and_pr_builds
-          context: amphtml-context
           requires:
             - 'Nomodule Build'
             - 'Module Build'
       - 'End-to-End Tests':
           <<: *push_and_pr_builds
-          context: amphtml-context
           requires:
             - 'Nomodule Build'
       # TODO(wg-performance, #12128): This takes 30 mins and fails regularly.
       # - 'Performance Tests':
       #     <<: *push_builds_only
-      #     context: amphtml-context
       #     requires:
       #       - 'Nomodule Build'
       - 'Experiment A Tests':
           <<: *push_builds_only
-          context: amphtml-context
       - 'Experiment B Tests':
           <<: *push_builds_only
-          context: amphtml-context
       - 'Experiment C Tests':
           <<: *push_builds_only
-          context: amphtml-context


### PR DESCRIPTION
CircleCI builds currently use an `ampproject` organization-level [context](https://circleci.com/docs/2.0/contexts/). The downside is that other projects within the org will inherit the same context when builds are enabled for them.

This PR switches the config to implicitly use project-level environment variables (already set) that are locked down to just the [`amphtml`](https://app.circleci.com/pipelines/github/ampproject/amphtml) CircleCI project.
