### PR TITLE
🏗♻️ Refactor and simplify all CI job executor scripts

### DIFF
--- a/build-system/pr-check/ci-job.js
+++ b/build-system/pr-check/ci-job.js
@@ -1,0 +1,52 @@
+/**
+ * Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+const {
+  abortTimedJob,
+  printChangeSummary,
+  startTimer,
+  stopTimer,
+} = require('./utils');
+const {isPullRequestBuild} = require('../common/ci');
+const {runNpmChecks} = require('./npm-checks');
+const {setLoggingPrefix} = require('../common/logging');
+
+/**
+ * Helper used by all CI job scripts. Runs the PR / push build workflow.
+ * @param {string} jobName
+ * @param {function} pushBuildWorkflow
+ * @param {function} prBuildWorkflow
+ */
+async function runCiJob(jobName, pushBuildWorkflow, prBuildWorkflow) {
+  setLoggingPrefix(jobName);
+  const startTime = startTimer(jobName);
+  if (!runNpmChecks()) {
+    abortTimedJob(jobName, startTime);
+    return;
+  }
+  if (isPullRequestBuild()) {
+    printChangeSummary();
+    await prBuildWorkflow();
+  } else {
+    await pushBuildWorkflow();
+  }
+  stopTimer(jobName, startTime);
+}
+
+module.exports = {
+  runCiJob,
+};

--- a/build-system/pr-check/experiment-tests.js
+++ b/build-system/pr-check/experiment-tests.js
@@ -16,20 +16,13 @@
 'use strict';
 
 /**
- * @fileoverview
- * This script builds an experiment binary and runs local tests.
- * This is run during the CI stage = test; job = experiments tests.
+ * @fileoverview Script that runs the experiment A/B/C tests during CI.
  */
 
 const experimentsConfig = require('../global-configs/experiments-config.json');
-const {
-  printSkipMessage,
-  startTimer,
-  stopTimer,
-  timedExecOrDie,
-} = require('./utils');
 const {experiment} = require('minimist')(process.argv.slice(2));
-const {setLoggingPrefix} = require('../common/logging');
+const {printSkipMessage, timedExecOrDie} = require('./utils');
+const {runCiJob} = require('./ci-job');
 
 const jobName = `${experiment}-tests.js`;
 
@@ -59,9 +52,7 @@ function test_() {
   timedExecOrDie('gulp e2e --nobuild --compiled --headless');
 }
 
-function main() {
-  setLoggingPrefix(jobName);
-  const startTime = startTimer(jobName);
+function pushBuildWorkflow() {
   const config = getConfig_();
   if (config) {
     build_(config);
@@ -72,7 +63,6 @@ function main() {
       `${experiment} is expired, misconfigured, or does not exist`
     );
   }
-  stopTimer(jobName, startTime);
 }
 
-main();
+runCiJob(jobName, pushBuildWorkflow, () => {});

--- a/build-system/pr-check/module-build.js
+++ b/build-system/pr-check/module-build.js
@@ -16,61 +16,44 @@
 'use strict';
 
 /**
- * @fileoverview
- * This script builds the esm minified AMP runtime.
- * This is run during the CI stage = build; job = module build.
+ * @fileoverview Script that builds the module AMP runtime during CI.
  */
 
 const {
-  abortTimedJob,
-  printChangeSummary,
   printSkipMessage,
-  startTimer,
-  stopTimer,
   timedExecOrDie,
   uploadModuleOutput,
 } = require('./utils');
 const {determineBuildTargets} = require('./build-targets');
-const {isPullRequestBuild} = require('../common/ci');
-const {runNpmChecks} = require('./npm-checks');
-const {setLoggingPrefix} = require('../common/logging');
+const {runCiJob} = require('./ci-job');
 
 const jobName = 'module-build.js';
 
-function main() {
-  setLoggingPrefix(jobName);
-  const startTime = startTimer(jobName);
-  if (!runNpmChecks()) {
-    return abortTimedJob(jobName, startTime);
-  }
+function pushBuildWorkflow() {
+  timedExecOrDie('gulp update-packages');
+  timedExecOrDie('gulp dist --esm --fortesting');
+  uploadModuleOutput();
+}
 
-  if (!isPullRequestBuild()) {
+function prBuildWorkflow() {
+  const buildTargets = determineBuildTargets();
+  // TODO(#31102): This list must eventually match the same buildTargets check
+  // found in pr-check/nomodule-build.js as we turn on the systems that
+  // run against the module build. (ex. visual diffs, e2e, etc.)
+  if (
+    buildTargets.has('RUNTIME') ||
+    buildTargets.has('FLAG_CONFIG') ||
+    buildTargets.has('INTEGRATION_TEST')
+  ) {
     timedExecOrDie('gulp update-packages');
     timedExecOrDie('gulp dist --esm --fortesting');
     uploadModuleOutput();
   } else {
-    printChangeSummary();
-    const buildTargets = determineBuildTargets();
-    // TODO(#31102): This list must eventually match the same buildTargets check
-    // found in pr-check/nomodule-build.js as we turn on the systems that
-    // run against the module build. (ex. visual diffs, e2e, etc.)
-    if (
-      buildTargets.has('RUNTIME') ||
-      buildTargets.has('FLAG_CONFIG') ||
-      buildTargets.has('INTEGRATION_TEST')
-    ) {
-      timedExecOrDie('gulp update-packages');
-      timedExecOrDie('gulp dist --esm --fortesting');
-      uploadModuleOutput();
-    } else {
-      printSkipMessage(
-        jobName,
-        'this PR does not affect the runtime, flag configs, or integration tests'
-      );
-    }
+    printSkipMessage(
+      jobName,
+      'this PR does not affect the runtime, flag configs, or integration tests'
+    );
   }
-
-  stopTimer(jobName, startTime);
 }
 
-main();
+runCiJob(jobName, pushBuildWorkflow, prBuildWorkflow);

--- a/build-system/pr-check/module-tests.js
+++ b/build-system/pr-check/module-tests.js
@@ -16,56 +16,44 @@
 'use strict';
 
 /**
- * @fileoverview
- * This script builds and tests the AMP runtime in esm mode.
- * This is run during the CI stage = test; job = module tests.
+ * @fileoverview Script that tests the module AMP runtime during CI.
  */
 
 const {
-  printChangeSummary,
-  printSkipMessage,
-  startTimer,
-  stopTimer,
-  timedExecOrDie,
   downloadModuleOutput,
   downloadNomoduleOutput,
+  printSkipMessage,
+  timedExecOrDie,
 } = require('./utils');
 const {determineBuildTargets} = require('./build-targets');
-const {isPullRequestBuild} = require('../common/ci');
-const {setLoggingPrefix} = require('../common/logging');
+const {runCiJob} = require('./ci-job');
 
 const jobName = 'module-tests.js';
 
-function main() {
-  setLoggingPrefix(jobName);
-  const startTime = startTimer(jobName);
+function pushBuildWorkflow() {
+  downloadNomoduleOutput();
+  downloadModuleOutput();
+  timedExecOrDie('gulp update-packages');
+  timedExecOrDie('gulp integration --nobuild --compiled --headless --esm');
+}
 
-  if (!isPullRequestBuild()) {
+function prBuildWorkflow() {
+  const buildTargets = determineBuildTargets();
+  if (
+    buildTargets.has('RUNTIME') ||
+    buildTargets.has('FLAG_CONFIG') ||
+    buildTargets.has('INTEGRATION_TEST')
+  ) {
     downloadNomoduleOutput();
     downloadModuleOutput();
     timedExecOrDie('gulp update-packages');
     timedExecOrDie('gulp integration --nobuild --compiled --headless --esm');
   } else {
-    printChangeSummary();
-    const buildTargets = determineBuildTargets();
-    if (
-      buildTargets.has('RUNTIME') ||
-      buildTargets.has('FLAG_CONFIG') ||
-      buildTargets.has('INTEGRATION_TEST')
-    ) {
-      downloadNomoduleOutput();
-      downloadModuleOutput();
-      timedExecOrDie('gulp update-packages');
-      timedExecOrDie('gulp integration --nobuild --compiled --headless --esm');
-    } else {
-      printSkipMessage(
-        jobName,
-        'this PR does not affect the runtime, flag configs, or integration tests'
-      );
-    }
+    printSkipMessage(
+      jobName,
+      'this PR does not affect the runtime, flag configs, or integration tests'
+    );
   }
-
-  stopTimer(jobName, startTime);
 }
 
-main();
+runCiJob(jobName, pushBuildWorkflow, prBuildWorkflow);

--- a/build-system/pr-check/performance-tests.js
+++ b/build-system/pr-check/performance-tests.js
@@ -16,30 +16,18 @@
 'use strict';
 
 /**
- * @fileoverview
- * This script runs performance tests.
- * This is run during the CI stage = experiment; job = performance tests.
+ * @fileoverview Script that runs the performance tests during CI.
  */
 
-const {
-  downloadNomoduleOutput,
-  startTimer,
-  stopTimer,
-  timedExecOrDie,
-} = require('./utils');
-const {setLoggingPrefix} = require('../common/logging');
+const {downloadNomoduleOutput, timedExecOrDie} = require('./utils');
+const {runCiJob} = require('./ci-job');
 
 const jobName = 'performance-tests.js';
 
-async function main() {
-  setLoggingPrefix(jobName);
-  const startTime = startTimer(jobName);
-
+function pushBuildWorkflow() {
   downloadNomoduleOutput(jobName);
   timedExecOrDie('gulp update-packages');
   timedExecOrDie('gulp performance --nobuild --quiet --headless');
-
-  stopTimer(jobName, startTime);
 }
 
-main();
+runCiJob(jobName, pushBuildWorkflow, () => {});

--- a/build-system/pr-check/unminified-build.js
+++ b/build-system/pr-check/unminified-build.js
@@ -16,58 +16,41 @@
 'use strict';
 
 /**
- * @fileoverview
- * This script builds the AMP runtime.
- * This is run during the CI stage = build; job = unminified build.
+ * @fileoverview Script that builds the unminified AMP runtime during CI.
  */
 
 const {
-  abortTimedJob,
-  printChangeSummary,
   printSkipMessage,
-  startTimer,
-  stopTimer,
   timedExecOrDie,
   uploadUnminifiedOutput,
 } = require('./utils');
 const {determineBuildTargets} = require('./build-targets');
-const {isPullRequestBuild} = require('../common/ci');
-const {runNpmChecks} = require('./npm-checks');
-const {setLoggingPrefix} = require('../common/logging');
+const {runCiJob} = require('./ci-job');
 
 const jobName = 'unminified-build.js';
 
-function main() {
-  setLoggingPrefix(jobName);
-  const startTime = startTimer(jobName);
-  if (!runNpmChecks()) {
-    return abortTimedJob(jobName, startTime);
-  }
+function pushBuildWorkflow() {
+  timedExecOrDie('gulp update-packages');
+  timedExecOrDie('gulp build --fortesting');
+  uploadUnminifiedOutput();
+}
 
-  if (!isPullRequestBuild()) {
+function prBuildWorkflow() {
+  const buildTargets = determineBuildTargets();
+  if (
+    buildTargets.has('RUNTIME') ||
+    buildTargets.has('FLAG_CONFIG') ||
+    buildTargets.has('INTEGRATION_TEST')
+  ) {
     timedExecOrDie('gulp update-packages');
     timedExecOrDie('gulp build --fortesting');
     uploadUnminifiedOutput();
   } else {
-    printChangeSummary();
-    const buildTargets = determineBuildTargets();
-    if (
-      buildTargets.has('RUNTIME') ||
-      buildTargets.has('FLAG_CONFIG') ||
-      buildTargets.has('INTEGRATION_TEST')
-    ) {
-      timedExecOrDie('gulp update-packages');
-      timedExecOrDie('gulp build --fortesting');
-      uploadUnminifiedOutput();
-    } else {
-      printSkipMessage(
-        jobName,
-        'this PR does not affect the runtime, flag configs, or integration tests'
-      );
-    }
+    printSkipMessage(
+      jobName,
+      'this PR does not affect the runtime, flag configs, or integration tests'
+    );
   }
-
-  stopTimer(jobName, startTime);
 }
 
-main();
+runCiJob(jobName, pushBuildWorkflow, prBuildWorkflow);


### PR DESCRIPTION
As the number of parallel CI jobs has increased, we've accumulated heaps of boilerplate code.

**PR highlights;**
- Standardizes the structure of a CI job script via `runCiJob()` in `ci-job.js`
- Simplifies all CI job scripts using the above function

For easy reviewing, use [this link](https://github.com/ampproject/amphtml/pull/32140/files?w=1) that hides all the whitespace-only changes.