### PR TITLE
✨ Bento Lightbox: `scrollable` feature

### DIFF
--- a/extensions/amp-lightbox/1.0/amp-lightbox.css
+++ b/extensions/amp-lightbox/1.0/amp-lightbox.css
@@ -35,3 +35,8 @@ amp-lightbox::part(lightbox) {
   background: inherit;
   color: inherit;
 }
+
+/* Prevent scrolling while lightbox is open */
+amp-lightbox[open]:root {
+  overflow: hidden;
+}

--- a/extensions/amp-lightbox/1.0/amp-lightbox.css
+++ b/extensions/amp-lightbox/1.0/amp-lightbox.css
@@ -35,8 +35,3 @@ amp-lightbox::part(lightbox) {
   background: inherit;
   color: inherit;
 }
-
-/* Prevent scrolling while lightbox is open */
-amp-lightbox[open]:root {
-  overflow: hidden;
-}

--- a/extensions/amp-lightbox/1.0/lightbox.js
+++ b/extensions/amp-lightbox/1.0/lightbox.js
@@ -61,7 +61,14 @@ function useValueRef(current) {
  * @return {PreactDef.Renderable}
  */
 function LightboxWithRef(
-  {animation = 'fade-in', children, onBeforeOpen, onAfterClose, ...rest},
+  {
+    animation = 'fade-in',
+    children,
+    onBeforeOpen,
+    onAfterClose,
+    scrollable = false,
+    ...rest
+  },
   ref
 ) {
   // There are two phases to open and close.
@@ -163,7 +170,13 @@ function LightboxWithRef(
         layout={true}
         paint={true}
         part="lightbox"
-        wrapperClassName={`${classes.defaultStyles} ${classes.wrapper}`}
+        contentClassName={classes.containScroll}
+        contentStyle={{
+          overflow: scrollable ? 'scroll' : 'hidden',
+        }}
+        wrapperClassName={`${classes.defaultStyles} ${classes.wrapper} ${
+          scrollable ? '' : classes.containScroll
+        }`}
         role="dialog"
         tabindex="0"
         onKeyDown={(event) => {

--- a/extensions/amp-lightbox/1.0/lightbox.js
+++ b/extensions/amp-lightbox/1.0/lightbox.js
@@ -170,10 +170,13 @@ function LightboxWithRef(
         layout={true}
         paint={true}
         part="lightbox"
-        contentClassName={classes.containScroll}
-        contentStyle={{
-          overflow: scrollable ? 'scroll' : 'hidden',
-        }}
+        contentStyle={
+          // Prefer style over class to override `ContainWrapper`'s overflow
+          scrollable && {
+            overflow: 'scroll',
+            overscrollBehavior: 'none',
+          }
+        }
         wrapperClassName={`${classes.defaultStyles} ${classes.wrapper} ${
           scrollable ? '' : classes.containScroll
         }`}

--- a/extensions/amp-lightbox/1.0/lightbox.jss.js
+++ b/extensions/amp-lightbox/1.0/lightbox.jss.js
@@ -55,6 +55,12 @@ const defaultStyles = {
   color: '#fff',
 };
 
+/* 
+  overflow: hidden does not trigger overscrollBehavior, so 
+  overflow: scroll is needed even when the lightbox should not be scrollable.
+  We rely instead on the overflow: hidden in ContainWrapper to prevent 
+  scrolling inside the lightbox.
+*/
 const containScroll = {
   overflow: 'scroll',
   overscrollBehavior: 'none',

--- a/extensions/amp-lightbox/1.0/lightbox.jss.js
+++ b/extensions/amp-lightbox/1.0/lightbox.jss.js
@@ -55,10 +55,16 @@ const defaultStyles = {
   color: '#fff',
 };
 
+const containScroll = {
+  overflow: 'scroll',
+  overscrollBehavior: 'none',
+};
+
 const JSS = {
   closeButton,
   wrapper,
   defaultStyles,
+  containScroll,
 };
 
 // useStyles gets replaced for AMP builds via `babel-plugin-transform-jss`.

--- a/extensions/amp-lightbox/1.0/lightbox.jss.js
+++ b/extensions/amp-lightbox/1.0/lightbox.jss.js
@@ -57,13 +57,13 @@ const defaultStyles = {
 
 /* 
   overflow: hidden does not trigger overscrollBehavior, so 
-  overflow: scroll is needed even when the lightbox should not be scrollable.
+  overflow: auto is applied even though the lightbox should not scroll.
   We rely instead on the overflow: hidden in ContainWrapper to prevent 
   scrolling inside the lightbox.
 */
 const containScroll = {
-  overflow: 'scroll',
-  overscrollBehavior: 'none',
+  overflow: 'auto', // Prevent scrolling inside lightbox.
+  overscrollBehavior: 'none', // Prevent scrolling outside lightbox.
 };
 
 const JSS = {

--- a/extensions/amp-lightbox/1.0/lightbox.type.js
+++ b/extensions/amp-lightbox/1.0/lightbox.type.js
@@ -21,13 +21,12 @@ var LightboxDef = {};
 /**
  * @typedef {{
  *   id: (string),
- *   animateIn: (string|undefined),
+ *   animation: (string|undefined),
  *   closeButtonAriaLabel: (string|undefined),
  *   scrollable: (boolean),
  *   initialOpen: (boolean),
  *   onBeforeOpen: (function|undefined),
  *   onAfterClose: (function|undefined),
- *   enableAnimation: (boolean)
  * }}
  */
 LightboxDef.Props;

--- a/extensions/amp-lightbox/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-lightbox/1.0/storybook/Basic.amp.js
@@ -15,7 +15,7 @@
  */
 
 import * as Preact from '../../../../src/preact';
-import {select, text, withKnobs} from '@storybook/addon-knobs';
+import {boolean, select, text, withKnobs} from '@storybook/addon-knobs';
 import {withA11y} from '@storybook/addon-a11y';
 import {withAmp} from '@ampproject/storybook-addon';
 
@@ -52,6 +52,291 @@ export const Default = () => {
         <div class="buttons">
           <button on="tap:lightbox">Open</button>
         </div>
+      </div>
+    </>
+  );
+};
+
+export const scrollable = () => {
+  const animation = select('animation', [
+    'fade-in',
+    'fly-in-top',
+    'fly-in-bottom',
+  ]);
+  const backgroundColor = text('background color', 'rgba(0,0,0,0.5)');
+  const color = text('font color', '');
+  const scrollable = boolean('scrollable', true);
+  const lotsOfText = boolean('lots of text?', true);
+  return (
+    <>
+      <style>{`
+        #lightbox {
+          background-color: ${backgroundColor};
+          color: ${color};
+        }
+      `}</style>
+      <div style="height: 300px;">
+        <amp-lightbox
+          id="lightbox"
+          layout="nodisplay"
+          animation={animation}
+          scrollable={scrollable}
+        >
+          <p>
+            Dessert tootsie roll marzipan pastry. Powder powder jelly beans
+            chocolate bar candy sugar plum. Jelly-o gummi bears jelly icing
+            cotton candy. Toffee carrot cake ice cream sesame snaps sugar plum
+            gummies. Gummies marshmallow candy chocolate bar ice cream ice cream
+            gummies chocolate cake. Candy ice cream pie danish ice cream cake
+            gingerbread. Muffin cookie marzipan marzipan jelly beans gummies
+            candy muffin dessert. Soufflé chocolate tart tootsie roll tootsie
+            roll gingerbread icing powder. Dessert croissant macaroon candy
+            liquorice. Gingerbread gummi bears croissant wafer cookie cookie
+            bonbon. Marshmallow fruitcake lollipop sweet roll danish dragée
+            cupcake. Tootsie roll cotton candy dragée chocolate bar tootsie roll
+            cheesecake cookie muffin. Toffee sesame snaps gingerbread wafer
+            cotton candy bonbon gingerbread toffee.
+          </p>
+
+          {lotsOfText && (
+            <>
+              <p>
+                Danish cupcake chocolate candy chocolate bar. Topping brownie
+                toffee oat cake liquorice marzipan cheesecake chupa chups.
+                Pastry carrot cake jelly beans chocolate cake liquorice sesame
+                snaps caramels. Apple pie marshmallow chupa chups lemon drops
+                pudding cotton candy pie apple pie oat cake. Sugar plum halvah
+                cotton candy tiramisu sweet dragée cookie pastry. Macaroon
+                bonbon jujubes. Halvah tiramisu brownie topping donut cookie
+                tart. Jelly lemon drops soufflé pie chocolate bar donut tootsie
+                roll bear claw cake. Chocolate cake powder dessert. Pudding
+                wafer danish chupa chups donut chocolate sweet carrot cake.
+                Sugar plum cheesecake brownie chocolate sweet tart marzipan oat
+                cake dessert. Gummi bears sugar plum bonbon chocolate cake.
+                Croissant marzipan brownie dessert donut cotton candy croissant
+                powder. Chocolate cake tootsie roll sweet roll gummi bears donut
+                fruitcake jelly beans carrot cake.
+              </p>
+
+              <p>
+                Brownie gummies danish lollipop caramels wafer gingerbread
+                macaroon carrot cake. Brownie powder donut gummi bears pudding
+                cupcake. Lemon drops croissant apple pie sesame snaps marzipan.
+                Biscuit chocolate cake jelly-o pie caramels gingerbread caramels
+                chupa chups donut. Sweet roll oat cake cake. Cheesecake candy
+                canes candy canes candy canes topping pastry sweet cheesecake.
+                Jelly-o gummies topping marshmallow dessert tiramisu cake bonbon
+                chupa chups. Chocolate biscuit danish tart bear claw. Tiramisu
+                carrot cake jelly-o pie sweet cake. Sesame snaps lollipop cookie
+                chocolate cake wafer dragée. Powder brownie danish. Pastry
+                chocolate cake sweet roll halvah cupcake dragée.
+              </p>
+
+              <p>
+                Cake carrot cake icing danish biscuit carrot cake marzipan
+                croissant. Cake cake gummi bears fruitcake sweet dessert toffee
+                chocolate cake. Ice cream carrot cake donut jelly beans. Jelly
+                wafer sugar plum sweet icing candy canes. Bonbon marshmallow
+                donut pudding jelly-o tiramisu pastry cake bonbon. Jelly candy
+                canes liquorice cupcake liquorice dessert halvah toffee. Jelly
+                chocolate macaroon topping cupcake tootsie roll liquorice
+                brownie lollipop. Chupa chups wafer cupcake candy cookie oat
+                cake cookie bear claw. Carrot cake pudding biscuit tiramisu ice
+                cream sugar plum. Topping lemon drops dragée cake liquorice
+                apple pie ice cream. Cotton candy lollipop lemon drops apple pie
+                tootsie roll pie marshmallow chocolate jelly-o. Pastry bonbon
+                cupcake dragée candy.
+              </p>
+
+              <p>
+                Ice cream dragée pudding pastry biscuit tart cookie. Oat cake
+                ice cream apple pie oat cake dessert soufflé caramels apple pie.
+                Gummies bear claw powder cake icing jelly beans jelly beans
+                marzipan lollipop. Lollipop brownie jelly beans pudding. Ice
+                cream jelly biscuit pie tiramisu tootsie roll gummies biscuit.
+                Cupcake biscuit biscuit chocolate bar liquorice caramels powder
+                cotton candy muffin. Sesame snaps tiramisu croissant. Soufflé
+                chocolate jelly-o topping. Lemon drops candy canes sweet carrot
+                cake chocolate cake tootsie roll wafer marshmallow. Jelly beans
+                bear claw jelly-o sesame snaps carrot cake. Pudding jelly candy
+                carrot cake fruitcake carrot cake candy canes sesame snaps.
+                Marzipan icing caramels chocolate tart powder cookie halvah.
+                Fruitcake dragée muffin tart. Jelly-o cupcake marshmallow
+                pudding gummies muffin topping caramels.
+              </p>
+
+              <p>
+                Liquorice bear claw marshmallow dessert. Bear claw toffee pastry
+                tiramisu apple pie oat cake. Tiramisu jelly gingerbread cake
+                cake sweet roll cupcake ice cream jelly. Fruitcake jelly beans
+                macaroon soufflé jelly beans marzipan caramels candy. Cheesecake
+                candy canes pudding icing icing. Dragée chocolate bar bear claw
+                dragée donut brownie cake sweet roll. Wafer bear claw dragée
+                icing sesame snaps topping. Cake marzipan bear claw dessert bear
+                claw lollipop halvah wafer halvah. Icing sweet roll toffee sweet
+                powder sesame snaps gummies tart danish. Ice cream toffee
+                caramels danish. Jelly-o lollipop lollipop dessert sesame snaps
+                bear claw gummi bears. Donut sweet roll marzipan fruitcake oat
+                cake cake icing cotton candy oat cake. Gingerbread carrot cake
+                sesame snaps gummies candy dragée lollipop soufflé biscuit.
+                Pudding jujubes chocolate halvah sesame snaps tiramisu sweet
+                marshmallow chocolate bar.
+              </p>
+
+              <p>
+                Donut carrot cake apple pie powder marshmallow sesame snaps
+                tiramisu. Sweet roll powder cookie. Lollipop sugar plum oat
+                cake. Marshmallow wafer danish wafer gingerbread cake muffin
+                candy dragée. Candy cotton candy topping cake cotton candy
+                carrot cake fruitcake brownie. Toffee candy candy canes jelly-o
+                cotton candy gummies. Bonbon bonbon pie sugar plum. Oat cake
+                sesame snaps pudding candy canes gummi bears macaroon jelly
+                beans brownie. Sesame snaps halvah halvah jelly-o dessert.
+                Jelly-o chocolate sweet roll donut candy. Cotton candy halvah
+                macaroon tiramisu tart. Jelly toffee candy pie toffee.
+              </p>
+
+              <p>
+                Powder chupa chups muffin jelly-o soufflé. Lollipop sweet roll
+                sweet roll brownie pastry tootsie roll. Topping cheesecake pie
+                jelly. Donut wafer wafer cake candy canes. Topping chocolate bar
+                cheesecake topping ice cream tiramisu toffee ice cream. Bonbon
+                halvah marshmallow. Marzipan topping chupa chups dessert
+                chocolate chocolate cake gummi bears. Gummi bears caramels sugar
+                plum. Pie donut jelly beans tiramisu soufflé pie powder. Cupcake
+                cookie topping. Tootsie roll candy canes jujubes croissant
+                liquorice ice cream brownie. Topping cookie apple pie gummi
+                bears bear claw jelly-o brownie tart. Marzipan cotton candy
+                gummi bears. Dragée ice cream gummi bears jelly-o carrot cake
+                chocolate bar tiramisu jelly cotton candy.
+              </p>
+            </>
+          )}
+          <button on="tap:lightbox.close">Close</button>
+        </amp-lightbox>
+        <div class="buttons">
+          <button on="tap:lightbox">Open</button>
+        </div>
+        <p>
+          Dessert tootsie roll marzipan pastry. Powder powder jelly beans
+          chocolate bar candy sugar plum. Jelly-o gummi bears jelly icing cotton
+          candy. Toffee carrot cake ice cream sesame snaps sugar plum gummies.
+          Gummies marshmallow candy chocolate bar ice cream ice cream gummies
+          chocolate cake. Candy ice cream pie danish ice cream cake gingerbread.
+          Muffin cookie marzipan marzipan jelly beans gummies candy muffin
+          dessert. Soufflé chocolate tart tootsie roll tootsie roll gingerbread
+          icing powder. Dessert croissant macaroon candy liquorice. Gingerbread
+          gummi bears croissant wafer cookie cookie bonbon. Marshmallow
+          fruitcake lollipop sweet roll danish dragée cupcake. Tootsie roll
+          cotton candy dragée chocolate bar tootsie roll cheesecake cookie
+          muffin. Toffee sesame snaps gingerbread wafer cotton candy bonbon
+          gingerbread toffee.
+        </p>
+
+        <p>
+          Danish cupcake chocolate candy chocolate bar. Topping brownie toffee
+          oat cake liquorice marzipan cheesecake chupa chups. Pastry carrot cake
+          jelly beans chocolate cake liquorice sesame snaps caramels. Apple pie
+          marshmallow chupa chups lemon drops pudding cotton candy pie apple pie
+          oat cake. Sugar plum halvah cotton candy tiramisu sweet dragée cookie
+          pastry. Macaroon bonbon jujubes. Halvah tiramisu brownie topping donut
+          cookie tart. Jelly lemon drops soufflé pie chocolate bar donut tootsie
+          roll bear claw cake. Chocolate cake powder dessert. Pudding wafer
+          danish chupa chups donut chocolate sweet carrot cake. Sugar plum
+          cheesecake brownie chocolate sweet tart marzipan oat cake dessert.
+          Gummi bears sugar plum bonbon chocolate cake. Croissant marzipan
+          brownie dessert donut cotton candy croissant powder. Chocolate cake
+          tootsie roll sweet roll gummi bears donut fruitcake jelly beans carrot
+          cake.
+        </p>
+
+        <p>
+          Brownie gummies danish lollipop caramels wafer gingerbread macaroon
+          carrot cake. Brownie powder donut gummi bears pudding cupcake. Lemon
+          drops croissant apple pie sesame snaps marzipan. Biscuit chocolate
+          cake jelly-o pie caramels gingerbread caramels chupa chups donut.
+          Sweet roll oat cake cake. Cheesecake candy canes candy canes candy
+          canes topping pastry sweet cheesecake. Jelly-o gummies topping
+          marshmallow dessert tiramisu cake bonbon chupa chups. Chocolate
+          biscuit danish tart bear claw. Tiramisu carrot cake jelly-o pie sweet
+          cake. Sesame snaps lollipop cookie chocolate cake wafer dragée. Powder
+          brownie danish. Pastry chocolate cake sweet roll halvah cupcake
+          dragée.
+        </p>
+
+        <p>
+          Cake carrot cake icing danish biscuit carrot cake marzipan croissant.
+          Cake cake gummi bears fruitcake sweet dessert toffee chocolate cake.
+          Ice cream carrot cake donut jelly beans. Jelly wafer sugar plum sweet
+          icing candy canes. Bonbon marshmallow donut pudding jelly-o tiramisu
+          pastry cake bonbon. Jelly candy canes liquorice cupcake liquorice
+          dessert halvah toffee. Jelly chocolate macaroon topping cupcake
+          tootsie roll liquorice brownie lollipop. Chupa chups wafer cupcake
+          candy cookie oat cake cookie bear claw. Carrot cake pudding biscuit
+          tiramisu ice cream sugar plum. Topping lemon drops dragée cake
+          liquorice apple pie ice cream. Cotton candy lollipop lemon drops apple
+          pie tootsie roll pie marshmallow chocolate jelly-o. Pastry bonbon
+          cupcake dragée candy.
+        </p>
+
+        <p>
+          Ice cream dragée pudding pastry biscuit tart cookie. Oat cake ice
+          cream apple pie oat cake dessert soufflé caramels apple pie. Gummies
+          bear claw powder cake icing jelly beans jelly beans marzipan lollipop.
+          Lollipop brownie jelly beans pudding. Ice cream jelly biscuit pie
+          tiramisu tootsie roll gummies biscuit. Cupcake biscuit biscuit
+          chocolate bar liquorice caramels powder cotton candy muffin. Sesame
+          snaps tiramisu croissant. Soufflé chocolate jelly-o topping. Lemon
+          drops candy canes sweet carrot cake chocolate cake tootsie roll wafer
+          marshmallow. Jelly beans bear claw jelly-o sesame snaps carrot cake.
+          Pudding jelly candy carrot cake fruitcake carrot cake candy canes
+          sesame snaps. Marzipan icing caramels chocolate tart powder cookie
+          halvah. Fruitcake dragée muffin tart. Jelly-o cupcake marshmallow
+          pudding gummies muffin topping caramels.
+        </p>
+
+        <p>
+          Liquorice bear claw marshmallow dessert. Bear claw toffee pastry
+          tiramisu apple pie oat cake. Tiramisu jelly gingerbread cake cake
+          sweet roll cupcake ice cream jelly. Fruitcake jelly beans macaroon
+          soufflé jelly beans marzipan caramels candy. Cheesecake candy canes
+          pudding icing icing. Dragée chocolate bar bear claw dragée donut
+          brownie cake sweet roll. Wafer bear claw dragée icing sesame snaps
+          topping. Cake marzipan bear claw dessert bear claw lollipop halvah
+          wafer halvah. Icing sweet roll toffee sweet powder sesame snaps
+          gummies tart danish. Ice cream toffee caramels danish. Jelly-o
+          lollipop lollipop dessert sesame snaps bear claw gummi bears. Donut
+          sweet roll marzipan fruitcake oat cake cake icing cotton candy oat
+          cake. Gingerbread carrot cake sesame snaps gummies candy dragée
+          lollipop soufflé biscuit. Pudding jujubes chocolate halvah sesame
+          snaps tiramisu sweet marshmallow chocolate bar.
+        </p>
+
+        <p>
+          Donut carrot cake apple pie powder marshmallow sesame snaps tiramisu.
+          Sweet roll powder cookie. Lollipop sugar plum oat cake. Marshmallow
+          wafer danish wafer gingerbread cake muffin candy dragée. Candy cotton
+          candy topping cake cotton candy carrot cake fruitcake brownie. Toffee
+          candy candy canes jelly-o cotton candy gummies. Bonbon bonbon pie
+          sugar plum. Oat cake sesame snaps pudding candy canes gummi bears
+          macaroon jelly beans brownie. Sesame snaps halvah halvah jelly-o
+          dessert. Jelly-o chocolate sweet roll donut candy. Cotton candy halvah
+          macaroon tiramisu tart. Jelly toffee candy pie toffee.
+        </p>
+
+        <p>
+          Powder chupa chups muffin jelly-o soufflé. Lollipop sweet roll sweet
+          roll brownie pastry tootsie roll. Topping cheesecake pie jelly. Donut
+          wafer wafer cake candy canes. Topping chocolate bar cheesecake topping
+          ice cream tiramisu toffee ice cream. Bonbon halvah marshmallow.
+          Marzipan topping chupa chups dessert chocolate chocolate cake gummi
+          bears. Gummi bears caramels sugar plum. Pie donut jelly beans tiramisu
+          soufflé pie powder. Cupcake cookie topping. Tootsie roll candy canes
+          jujubes croissant liquorice ice cream brownie. Topping cookie apple
+          pie gummi bears bear claw jelly-o brownie tart. Marzipan cotton candy
+          gummi bears. Dragée ice cream gummi bears jelly-o carrot cake
+          chocolate bar tiramisu jelly cotton candy.
+        </p>
       </div>
     </>
   );

--- a/extensions/amp-lightbox/1.0/storybook/Basic.js
+++ b/extensions/amp-lightbox/1.0/storybook/Basic.js
@@ -16,7 +16,7 @@
 
 import * as Preact from '../../../../src/preact';
 import {Lightbox} from '../lightbox';
-import {select, text, withKnobs} from '@storybook/addon-knobs';
+import {boolean, select, text, withKnobs} from '@storybook/addon-knobs';
 import {useRef} from '../../../../src/preact';
 import {withA11y} from '@storybook/addon-a11y';
 
@@ -30,14 +30,132 @@ export default {
  * @param {!Object} props
  * @return {*}
  */
-function LightboxWithActions(props) {
+function LightboxWithActions({children, ...rest}) {
   const ref = useRef();
   return (
     <section>
-      <Lightbox ref={ref} {...props} />
+      <Lightbox ref={ref} {...rest}>
+        {children}
+        <button onClick={() => ref.current.close()}>close</button>
+      </Lightbox>
       <div style={{marginTop: 8}}>
         <button onClick={() => ref.current.open()}>open</button>
       </div>
+      <p>
+        Dessert tootsie roll marzipan pastry. Powder powder jelly beans
+        chocolate bar candy sugar plum. Jelly-o gummi bears jelly icing cotton
+        candy. Toffee carrot cake ice cream sesame snaps sugar plum gummies.
+        Gummies marshmallow candy chocolate bar ice cream ice cream gummies
+        chocolate cake. Candy ice cream pie danish ice cream cake gingerbread.
+        Muffin cookie marzipan marzipan jelly beans gummies candy muffin
+        dessert. Soufflé chocolate tart tootsie roll tootsie roll gingerbread
+        icing powder. Dessert croissant macaroon candy liquorice. Gingerbread
+        gummi bears croissant wafer cookie cookie bonbon. Marshmallow fruitcake
+        lollipop sweet roll danish dragée cupcake. Tootsie roll cotton candy
+        dragée chocolate bar tootsie roll cheesecake cookie muffin. Toffee
+        sesame snaps gingerbread wafer cotton candy bonbon gingerbread toffee.
+      </p>
+
+      <p>
+        Danish cupcake chocolate candy chocolate bar. Topping brownie toffee oat
+        cake liquorice marzipan cheesecake chupa chups. Pastry carrot cake jelly
+        beans chocolate cake liquorice sesame snaps caramels. Apple pie
+        marshmallow chupa chups lemon drops pudding cotton candy pie apple pie
+        oat cake. Sugar plum halvah cotton candy tiramisu sweet dragée cookie
+        pastry. Macaroon bonbon jujubes. Halvah tiramisu brownie topping donut
+        cookie tart. Jelly lemon drops soufflé pie chocolate bar donut tootsie
+        roll bear claw cake. Chocolate cake powder dessert. Pudding wafer danish
+        chupa chups donut chocolate sweet carrot cake. Sugar plum cheesecake
+        brownie chocolate sweet tart marzipan oat cake dessert. Gummi bears
+        sugar plum bonbon chocolate cake. Croissant marzipan brownie dessert
+        donut cotton candy croissant powder. Chocolate cake tootsie roll sweet
+        roll gummi bears donut fruitcake jelly beans carrot cake.
+      </p>
+
+      <p>
+        Brownie gummies danish lollipop caramels wafer gingerbread macaroon
+        carrot cake. Brownie powder donut gummi bears pudding cupcake. Lemon
+        drops croissant apple pie sesame snaps marzipan. Biscuit chocolate cake
+        jelly-o pie caramels gingerbread caramels chupa chups donut. Sweet roll
+        oat cake cake. Cheesecake candy canes candy canes candy canes topping
+        pastry sweet cheesecake. Jelly-o gummies topping marshmallow dessert
+        tiramisu cake bonbon chupa chups. Chocolate biscuit danish tart bear
+        claw. Tiramisu carrot cake jelly-o pie sweet cake. Sesame snaps lollipop
+        cookie chocolate cake wafer dragée. Powder brownie danish. Pastry
+        chocolate cake sweet roll halvah cupcake dragée.
+      </p>
+
+      <p>
+        Cake carrot cake icing danish biscuit carrot cake marzipan croissant.
+        Cake cake gummi bears fruitcake sweet dessert toffee chocolate cake. Ice
+        cream carrot cake donut jelly beans. Jelly wafer sugar plum sweet icing
+        candy canes. Bonbon marshmallow donut pudding jelly-o tiramisu pastry
+        cake bonbon. Jelly candy canes liquorice cupcake liquorice dessert
+        halvah toffee. Jelly chocolate macaroon topping cupcake tootsie roll
+        liquorice brownie lollipop. Chupa chups wafer cupcake candy cookie oat
+        cake cookie bear claw. Carrot cake pudding biscuit tiramisu ice cream
+        sugar plum. Topping lemon drops dragée cake liquorice apple pie ice
+        cream. Cotton candy lollipop lemon drops apple pie tootsie roll pie
+        marshmallow chocolate jelly-o. Pastry bonbon cupcake dragée candy.
+      </p>
+
+      <p>
+        Ice cream dragée pudding pastry biscuit tart cookie. Oat cake ice cream
+        apple pie oat cake dessert soufflé caramels apple pie. Gummies bear claw
+        powder cake icing jelly beans jelly beans marzipan lollipop. Lollipop
+        brownie jelly beans pudding. Ice cream jelly biscuit pie tiramisu
+        tootsie roll gummies biscuit. Cupcake biscuit biscuit chocolate bar
+        liquorice caramels powder cotton candy muffin. Sesame snaps tiramisu
+        croissant. Soufflé chocolate jelly-o topping. Lemon drops candy canes
+        sweet carrot cake chocolate cake tootsie roll wafer marshmallow. Jelly
+        beans bear claw jelly-o sesame snaps carrot cake. Pudding jelly candy
+        carrot cake fruitcake carrot cake candy canes sesame snaps. Marzipan
+        icing caramels chocolate tart powder cookie halvah. Fruitcake dragée
+        muffin tart. Jelly-o cupcake marshmallow pudding gummies muffin topping
+        caramels.
+      </p>
+
+      <p>
+        Liquorice bear claw marshmallow dessert. Bear claw toffee pastry
+        tiramisu apple pie oat cake. Tiramisu jelly gingerbread cake cake sweet
+        roll cupcake ice cream jelly. Fruitcake jelly beans macaroon soufflé
+        jelly beans marzipan caramels candy. Cheesecake candy canes pudding
+        icing icing. Dragée chocolate bar bear claw dragée donut brownie cake
+        sweet roll. Wafer bear claw dragée icing sesame snaps topping. Cake
+        marzipan bear claw dessert bear claw lollipop halvah wafer halvah. Icing
+        sweet roll toffee sweet powder sesame snaps gummies tart danish. Ice
+        cream toffee caramels danish. Jelly-o lollipop lollipop dessert sesame
+        snaps bear claw gummi bears. Donut sweet roll marzipan fruitcake oat
+        cake cake icing cotton candy oat cake. Gingerbread carrot cake sesame
+        snaps gummies candy dragée lollipop soufflé biscuit. Pudding jujubes
+        chocolate halvah sesame snaps tiramisu sweet marshmallow chocolate bar.
+      </p>
+
+      <p>
+        Donut carrot cake apple pie powder marshmallow sesame snaps tiramisu.
+        Sweet roll powder cookie. Lollipop sugar plum oat cake. Marshmallow
+        wafer danish wafer gingerbread cake muffin candy dragée. Candy cotton
+        candy topping cake cotton candy carrot cake fruitcake brownie. Toffee
+        candy candy canes jelly-o cotton candy gummies. Bonbon bonbon pie sugar
+        plum. Oat cake sesame snaps pudding candy canes gummi bears macaroon
+        jelly beans brownie. Sesame snaps halvah halvah jelly-o dessert. Jelly-o
+        chocolate sweet roll donut candy. Cotton candy halvah macaroon tiramisu
+        tart. Jelly toffee candy pie toffee.
+      </p>
+
+      <p>
+        Powder chupa chups muffin jelly-o soufflé. Lollipop sweet roll sweet
+        roll brownie pastry tootsie roll. Topping cheesecake pie jelly. Donut
+        wafer wafer cake candy canes. Topping chocolate bar cheesecake topping
+        ice cream tiramisu toffee ice cream. Bonbon halvah marshmallow. Marzipan
+        topping chupa chups dessert chocolate chocolate cake gummi bears. Gummi
+        bears caramels sugar plum. Pie donut jelly beans tiramisu soufflé pie
+        powder. Cupcake cookie topping. Tootsie roll candy canes jujubes
+        croissant liquorice ice cream brownie. Topping cookie apple pie gummi
+        bears bear claw jelly-o brownie tart. Marzipan cotton candy gummi bears.
+        Dragée ice cream gummi bears jelly-o carrot cake chocolate bar tiramisu
+        jelly cotton candy.
+      </p>
     </section>
   );
 }
@@ -61,6 +179,158 @@ export const _default = () => {
           Lorem <i>ips</i>um dolor sit amet, has nisl nihil convenire et, vim at
           aeque inermis reprehendunt.
         </p>
+      </LightboxWithActions>
+    </div>
+  );
+};
+
+export const scrollable = () => {
+  const animation = select('animation', [
+    'fade-in',
+    'fly-in-top',
+    'fly-in-bottom',
+  ]);
+  const backgroundColor = text('background color', 'rgba(0, 0, 0, 0.5)');
+  const color = text('font color', '');
+  const scrollable = boolean('scrollable', true);
+  const lotsOfText = boolean('lots of text?', true);
+  return (
+    <div>
+      <LightboxWithActions
+        id="lightbox"
+        animation={animation}
+        style={{backgroundColor, color}}
+        scrollable={scrollable}
+      >
+        <p>
+          Dessert tootsie roll marzipan pastry. Powder powder jelly beans
+          chocolate bar candy sugar plum. Jelly-o gummi bears jelly icing cotton
+          candy. Toffee carrot cake ice cream sesame snaps sugar plum gummies.
+          Gummies marshmallow candy chocolate bar ice cream ice cream gummies
+          chocolate cake. Candy ice cream pie danish ice cream cake gingerbread.
+          Muffin cookie marzipan marzipan jelly beans gummies candy muffin
+          dessert. Soufflé chocolate tart tootsie roll tootsie roll gingerbread
+          icing powder. Dessert croissant macaroon candy liquorice. Gingerbread
+          gummi bears croissant wafer cookie cookie bonbon. Marshmallow
+          fruitcake lollipop sweet roll danish dragée cupcake. Tootsie roll
+          cotton candy dragée chocolate bar tootsie roll cheesecake cookie
+          muffin. Toffee sesame snaps gingerbread wafer cotton candy bonbon
+          gingerbread toffee.
+        </p>
+
+        {lotsOfText && (
+          <>
+            <p>
+              Danish cupcake chocolate candy chocolate bar. Topping brownie
+              toffee oat cake liquorice marzipan cheesecake chupa chups. Pastry
+              carrot cake jelly beans chocolate cake liquorice sesame snaps
+              caramels. Apple pie marshmallow chupa chups lemon drops pudding
+              cotton candy pie apple pie oat cake. Sugar plum halvah cotton
+              candy tiramisu sweet dragée cookie pastry. Macaroon bonbon
+              jujubes. Halvah tiramisu brownie topping donut cookie tart. Jelly
+              lemon drops soufflé pie chocolate bar donut tootsie roll bear claw
+              cake. Chocolate cake powder dessert. Pudding wafer danish chupa
+              chups donut chocolate sweet carrot cake. Sugar plum cheesecake
+              brownie chocolate sweet tart marzipan oat cake dessert. Gummi
+              bears sugar plum bonbon chocolate cake. Croissant marzipan brownie
+              dessert donut cotton candy croissant powder. Chocolate cake
+              tootsie roll sweet roll gummi bears donut fruitcake jelly beans
+              carrot cake.
+            </p>
+
+            <p>
+              Brownie gummies danish lollipop caramels wafer gingerbread
+              macaroon carrot cake. Brownie powder donut gummi bears pudding
+              cupcake. Lemon drops croissant apple pie sesame snaps marzipan.
+              Biscuit chocolate cake jelly-o pie caramels gingerbread caramels
+              chupa chups donut. Sweet roll oat cake cake. Cheesecake candy
+              canes candy canes candy canes topping pastry sweet cheesecake.
+              Jelly-o gummies topping marshmallow dessert tiramisu cake bonbon
+              chupa chups. Chocolate biscuit danish tart bear claw. Tiramisu
+              carrot cake jelly-o pie sweet cake. Sesame snaps lollipop cookie
+              chocolate cake wafer dragée. Powder brownie danish. Pastry
+              chocolate cake sweet roll halvah cupcake dragée.
+            </p>
+
+            <p>
+              Cake carrot cake icing danish biscuit carrot cake marzipan
+              croissant. Cake cake gummi bears fruitcake sweet dessert toffee
+              chocolate cake. Ice cream carrot cake donut jelly beans. Jelly
+              wafer sugar plum sweet icing candy canes. Bonbon marshmallow donut
+              pudding jelly-o tiramisu pastry cake bonbon. Jelly candy canes
+              liquorice cupcake liquorice dessert halvah toffee. Jelly chocolate
+              macaroon topping cupcake tootsie roll liquorice brownie lollipop.
+              Chupa chups wafer cupcake candy cookie oat cake cookie bear claw.
+              Carrot cake pudding biscuit tiramisu ice cream sugar plum. Topping
+              lemon drops dragée cake liquorice apple pie ice cream. Cotton
+              candy lollipop lemon drops apple pie tootsie roll pie marshmallow
+              chocolate jelly-o. Pastry bonbon cupcake dragée candy.
+            </p>
+
+            <p>
+              Ice cream dragée pudding pastry biscuit tart cookie. Oat cake ice
+              cream apple pie oat cake dessert soufflé caramels apple pie.
+              Gummies bear claw powder cake icing jelly beans jelly beans
+              marzipan lollipop. Lollipop brownie jelly beans pudding. Ice cream
+              jelly biscuit pie tiramisu tootsie roll gummies biscuit. Cupcake
+              biscuit biscuit chocolate bar liquorice caramels powder cotton
+              candy muffin. Sesame snaps tiramisu croissant. Soufflé chocolate
+              jelly-o topping. Lemon drops candy canes sweet carrot cake
+              chocolate cake tootsie roll wafer marshmallow. Jelly beans bear
+              claw jelly-o sesame snaps carrot cake. Pudding jelly candy carrot
+              cake fruitcake carrot cake candy canes sesame snaps. Marzipan
+              icing caramels chocolate tart powder cookie halvah. Fruitcake
+              dragée muffin tart. Jelly-o cupcake marshmallow pudding gummies
+              muffin topping caramels.
+            </p>
+
+            <p>
+              Liquorice bear claw marshmallow dessert. Bear claw toffee pastry
+              tiramisu apple pie oat cake. Tiramisu jelly gingerbread cake cake
+              sweet roll cupcake ice cream jelly. Fruitcake jelly beans macaroon
+              soufflé jelly beans marzipan caramels candy. Cheesecake candy
+              canes pudding icing icing. Dragée chocolate bar bear claw dragée
+              donut brownie cake sweet roll. Wafer bear claw dragée icing sesame
+              snaps topping. Cake marzipan bear claw dessert bear claw lollipop
+              halvah wafer halvah. Icing sweet roll toffee sweet powder sesame
+              snaps gummies tart danish. Ice cream toffee caramels danish.
+              Jelly-o lollipop lollipop dessert sesame snaps bear claw gummi
+              bears. Donut sweet roll marzipan fruitcake oat cake cake icing
+              cotton candy oat cake. Gingerbread carrot cake sesame snaps
+              gummies candy dragée lollipop soufflé biscuit. Pudding jujubes
+              chocolate halvah sesame snaps tiramisu sweet marshmallow chocolate
+              bar.
+            </p>
+
+            <p>
+              Donut carrot cake apple pie powder marshmallow sesame snaps
+              tiramisu. Sweet roll powder cookie. Lollipop sugar plum oat cake.
+              Marshmallow wafer danish wafer gingerbread cake muffin candy
+              dragée. Candy cotton candy topping cake cotton candy carrot cake
+              fruitcake brownie. Toffee candy candy canes jelly-o cotton candy
+              gummies. Bonbon bonbon pie sugar plum. Oat cake sesame snaps
+              pudding candy canes gummi bears macaroon jelly beans brownie.
+              Sesame snaps halvah halvah jelly-o dessert. Jelly-o chocolate
+              sweet roll donut candy. Cotton candy halvah macaroon tiramisu
+              tart. Jelly toffee candy pie toffee.
+            </p>
+
+            <p>
+              Powder chupa chups muffin jelly-o soufflé. Lollipop sweet roll
+              sweet roll brownie pastry tootsie roll. Topping cheesecake pie
+              jelly. Donut wafer wafer cake candy canes. Topping chocolate bar
+              cheesecake topping ice cream tiramisu toffee ice cream. Bonbon
+              halvah marshmallow. Marzipan topping chupa chups dessert chocolate
+              chocolate cake gummi bears. Gummi bears caramels sugar plum. Pie
+              donut jelly beans tiramisu soufflé pie powder. Cupcake cookie
+              topping. Tootsie roll candy canes jujubes croissant liquorice ice
+              cream brownie. Topping cookie apple pie gummi bears bear claw
+              jelly-o brownie tart. Marzipan cotton candy gummi bears. Dragée
+              ice cream gummi bears jelly-o carrot cake chocolate bar tiramisu
+              jelly cotton candy.
+            </p>
+          </>
+        )}
       </LightboxWithActions>
     </div>
   );

--- a/extensions/amp-lightbox/1.0/test/test-lightbox.js
+++ b/extensions/amp-lightbox/1.0/test/test-lightbox.js
@@ -35,6 +35,38 @@ describes.sandboxed('Lightbox preact component v1.0', {}, () => {
 
     // Render provided children
     expect(wrapper.children()).to.have.lengthOf(1);
+    expect(
+      wrapper
+        .find('div[part="lightbox"]')
+        .getDOMNode()
+        .className.includes('contain-scroll')
+    ).to.be.true;
+    expect(
+      wrapper.find('div[part="lightbox"] > div').getDOMNode().style.overflow
+    ).to.equal('hidden');
     expect(wrapper.find('p').text()).to.equal('Hello World');
+  });
+
+  it('Scrollable lightbox', () => {
+    const ref = Preact.createRef();
+    const wrapper = mount(
+      <Lightbox id="lightbox" ref={ref} scrollable>
+        <p>Hello World</p>
+      </Lightbox>
+    );
+
+    ref.current.open();
+    wrapper.update();
+
+    // Render provided children
+    expect(
+      wrapper
+        .find('div[part="lightbox"]')
+        .getDOMNode()
+        .className.includes('contain-scroll')
+    ).to.be.false;
+    expect(
+      wrapper.find('div[part="lightbox"] > div').getDOMNode().style.overflow
+    ).to.equal('scroll');
   });
 });


### PR DESCRIPTION
This PR implements the `scrollable` feature for `Lightbox`/`amp-lightbox`. Related to #31052.

Scrolling is allowed within the `Lightbox` with application of `overflow: scroll` as opposed to `overflow: hidden`. It also prevents scrolling beyond the `Lightbox` in the outer document with application of `overscroll-behavior: none` and `overflow: scroll`. It appears that `overflow: hidden` in combination with `overscroll-behavior: none` does not yield scroll containment due to over-scrolling not being possible given the lack of overflow.

Unfortunately, `overscroll-behavior` is only [partially supported](https://developer.mozilla.org/en-US/docs/Web/CSS/overscroll-behavior#browser_compatibility), so we may need to have more robust approaches such as adding an event listener to the element's root document which calls `preventDefault` on `scroll` when the `Lightbox` is `open`.