### PR TITLE
🏗 Refactor and simplify build target logic during CI builds

### DIFF
--- a/build-system/pr-check/bundle-size.js
+++ b/build-system/pr-check/bundle-size.js
@@ -25,7 +25,7 @@ const {
   printSkipMessage,
   timedExecOrDie,
 } = require('./utils');
-const {determineBuildTargets} = require('./build-targets');
+const {buildTargetsInclude, Targets} = require('./build-targets');
 const {isTravisBuild} = require('../common/ci');
 const {runCiJob} = require('./ci-job');
 
@@ -38,8 +38,7 @@ function pushBuildWorkflow() {
 }
 
 function prBuildWorkflow() {
-  const buildTargets = determineBuildTargets();
-  if (buildTargets.has('RUNTIME') || buildTargets.has('FLAG_CONFIG')) {
+  if (buildTargetsInclude(Targets.RUNTIME, Targets.FLAG_CONFIG)) {
     downloadNomoduleOutput();
     downloadModuleOutput();
     timedExecOrDie('gulp bundle-size --on_pr_build');

--- a/build-system/pr-check/checks.js
+++ b/build-system/pr-check/checks.js
@@ -19,7 +19,7 @@
  * @fileoverview Script that runs various checks during CI.
  */
 
-const {determineBuildTargets} = require('./build-targets');
+const {buildTargetsInclude, Targets} = require('./build-targets');
 const {reportAllExpectedTests} = require('../tasks/report-test-status');
 const {runCiJob} = require('./ci-job');
 const {timedExecOrDie} = require('./utils');
@@ -45,8 +45,7 @@ function pushBuildWorkflow() {
 }
 
 async function prBuildWorkflow() {
-  const buildTargets = determineBuildTargets();
-  await reportAllExpectedTests(buildTargets);
+  await reportAllExpectedTests();
   timedExecOrDie('gulp update-packages');
 
   timedExecOrDie('gulp check-exact-versions');
@@ -55,41 +54,41 @@ async function prBuildWorkflow() {
   timedExecOrDie('gulp presubmit');
   timedExecOrDie('gulp performance-urls');
 
-  if (buildTargets.has('AVA')) {
+  if (buildTargetsInclude(Targets.AVA)) {
     timedExecOrDie('gulp ava');
   }
 
-  if (buildTargets.has('BABEL_PLUGIN')) {
+  if (buildTargetsInclude(Targets.BABEL_PLUGIN)) {
     timedExecOrDie('gulp babel-plugin-tests');
   }
 
-  if (buildTargets.has('CACHES_JSON')) {
+  if (buildTargetsInclude(Targets.CACHES_JSON)) {
     timedExecOrDie('gulp caches-json');
   }
 
   // Check document links only for PR builds.
-  if (buildTargets.has('DOCS')) {
+  if (buildTargetsInclude(Targets.DOCS)) {
     timedExecOrDie('gulp check-links --local_changes');
   }
 
-  if (buildTargets.has('DEV_DASHBOARD')) {
+  if (buildTargetsInclude(Targets.DEV_DASHBOARD)) {
     timedExecOrDie('gulp dev-dashboard-tests');
   }
 
   // Validate owners syntax only for PR builds.
-  if (buildTargets.has('OWNERS')) {
+  if (buildTargetsInclude(Targets.OWNERS)) {
     timedExecOrDie('gulp check-owners --local_changes');
   }
 
-  if (buildTargets.has('RENOVATE_CONFIG')) {
+  if (buildTargetsInclude(Targets.RENOVATE_CONFIG)) {
     timedExecOrDie('gulp check-renovate-config');
   }
 
-  if (buildTargets.has('SERVER')) {
+  if (buildTargetsInclude(Targets.SERVER)) {
     timedExecOrDie('gulp server-tests');
   }
 
-  if (buildTargets.has('RUNTIME')) {
+  if (buildTargetsInclude(Targets.RUNTIME)) {
     timedExecOrDie('gulp dep-check');
     timedExecOrDie('gulp check-types');
     timedExecOrDie('gulp check-sourcemaps');

--- a/build-system/pr-check/ci-job.js
+++ b/build-system/pr-check/ci-job.js
@@ -21,6 +21,7 @@ const {
   startTimer,
   stopTimer,
 } = require('./utils');
+const {determineBuildTargets} = require('./build-targets');
 const {isPullRequestBuild} = require('../common/ci');
 const {runNpmChecks} = require('./npm-checks');
 const {setLoggingPrefix} = require('../common/logging');
@@ -40,6 +41,7 @@ async function runCiJob(jobName, pushBuildWorkflow, prBuildWorkflow) {
   }
   if (isPullRequestBuild()) {
     printChangeSummary();
+    determineBuildTargets();
     await prBuildWorkflow();
   } else {
     await pushBuildWorkflow();

--- a/build-system/pr-check/cross-browser-tests.js
+++ b/build-system/pr-check/cross-browser-tests.js
@@ -19,7 +19,7 @@
  * @fileoverview Script that builds and tests on Linux, macOS, and Windows during CI.
  */
 
-const {determineBuildTargets} = require('./build-targets');
+const {buildTargetsInclude, Targets} = require('./build-targets');
 const {log} = require('../common/logging');
 const {printSkipMessage, timedExecOrDie} = require('./utils');
 const {red, cyan} = require('ansi-colors');
@@ -85,15 +85,16 @@ function pushBuildWorkflow() {
 }
 
 async function prBuildWorkflow() {
-  const buildTargets = determineBuildTargets();
   if (process.platform == 'linux') {
-    await reportAllExpectedTests(buildTargets); // Only once is sufficient.
+    await reportAllExpectedTests(); // Only once is sufficient.
   }
   if (
-    !buildTargets.has('RUNTIME') &&
-    !buildTargets.has('FLAG_CONFIG') &&
-    !buildTargets.has('UNIT_TEST') &&
-    !buildTargets.has('INTEGRATION_TEST')
+    !buildTargetsInclude(
+      Targets.RUNTIME,
+      Targets.FLAG_CONFIG,
+      Targets.UNIT_TEST,
+      Targets.INTEGRATION_TEST
+    )
   ) {
     printSkipMessage(
       jobName,
@@ -103,14 +104,16 @@ async function prBuildWorkflow() {
   }
   timedExecOrDie('gulp update-packages');
   if (
-    buildTargets.has('RUNTIME') ||
-    buildTargets.has('FLAG_CONFIG') ||
-    buildTargets.has('INTEGRATION_TEST')
+    buildTargetsInclude(
+      Targets.RUNTIME,
+      Targets.FLAG_CONFIG,
+      Targets.INTEGRATION_TEST
+    )
   ) {
     timedExecOrDie('gulp dist --fortesting');
     runIntegrationTestsForPlatform();
   }
-  if (buildTargets.has('RUNTIME') || buildTargets.has('UNIT_TEST')) {
+  if (buildTargetsInclude(Targets.RUNTIME, Targets.UNIT_TEST)) {
     runUnitTestsForPlatform();
   }
 }

--- a/build-system/pr-check/e2e-tests.js
+++ b/build-system/pr-check/e2e-tests.js
@@ -25,7 +25,7 @@ const {
   timedExecOrDie,
   timedExecOrThrow,
 } = require('./utils');
-const {determineBuildTargets} = require('./build-targets');
+const {buildTargetsInclude, Targets} = require('./build-targets');
 const {runCiJob} = require('./ci-job');
 
 const jobName = 'e2e-tests.js';
@@ -48,11 +48,8 @@ function pushBuildWorkflow() {
 }
 
 function prBuildWorkflow() {
-  const buildTargets = determineBuildTargets();
   if (
-    buildTargets.has('RUNTIME') ||
-    buildTargets.has('FLAG_CONFIG') ||
-    buildTargets.has('E2E_TEST')
+    buildTargetsInclude(Targets.RUNTIME, Targets.FLAG_CONFIG, Targets.E2E_TEST)
   ) {
     downloadNomoduleOutput();
     timedExecOrDie('gulp update-packages');
@@ -64,5 +61,4 @@ function prBuildWorkflow() {
     );
   }
 }
-
 runCiJob(jobName, pushBuildWorkflow, prBuildWorkflow);

--- a/build-system/pr-check/module-build.js
+++ b/build-system/pr-check/module-build.js
@@ -24,7 +24,7 @@ const {
   timedExecOrDie,
   uploadModuleOutput,
 } = require('./utils');
-const {determineBuildTargets} = require('./build-targets');
+const {buildTargetsInclude, Targets} = require('./build-targets');
 const {runCiJob} = require('./ci-job');
 
 const jobName = 'module-build.js';
@@ -36,14 +36,15 @@ function pushBuildWorkflow() {
 }
 
 function prBuildWorkflow() {
-  const buildTargets = determineBuildTargets();
   // TODO(#31102): This list must eventually match the same buildTargets check
   // found in pr-check/nomodule-build.js as we turn on the systems that
   // run against the module build. (ex. visual diffs, e2e, etc.)
   if (
-    buildTargets.has('RUNTIME') ||
-    buildTargets.has('FLAG_CONFIG') ||
-    buildTargets.has('INTEGRATION_TEST')
+    buildTargetsInclude(
+      Targets.RUNTIME,
+      Targets.FLAG_CONFIG,
+      Targets.INTEGRATION_TEST
+    )
   ) {
     timedExecOrDie('gulp update-packages');
     timedExecOrDie('gulp dist --esm --fortesting');

--- a/build-system/pr-check/module-tests.js
+++ b/build-system/pr-check/module-tests.js
@@ -25,7 +25,7 @@ const {
   printSkipMessage,
   timedExecOrDie,
 } = require('./utils');
-const {determineBuildTargets} = require('./build-targets');
+const {buildTargetsInclude, Targets} = require('./build-targets');
 const {runCiJob} = require('./ci-job');
 
 const jobName = 'module-tests.js';
@@ -38,11 +38,12 @@ function pushBuildWorkflow() {
 }
 
 function prBuildWorkflow() {
-  const buildTargets = determineBuildTargets();
   if (
-    buildTargets.has('RUNTIME') ||
-    buildTargets.has('FLAG_CONFIG') ||
-    buildTargets.has('INTEGRATION_TEST')
+    buildTargetsInclude(
+      Targets.RUNTIME,
+      Targets.FLAG_CONFIG,
+      Targets.INTEGRATION_TEST
+    )
   ) {
     downloadNomoduleOutput();
     downloadModuleOutput();

--- a/build-system/pr-check/nomodule-build.js
+++ b/build-system/pr-check/nomodule-build.js
@@ -28,7 +28,7 @@ const {
   timedExecOrDie,
   uploadNomoduleOutput,
 } = require('./utils');
-const {determineBuildTargets} = require('./build-targets');
+const {buildTargetsInclude, Targets} = require('./build-targets');
 const {log} = require('../common/logging');
 const {red, yellow} = require('ansi-colors');
 const {runCiJob} = require('./ci-job');
@@ -44,13 +44,14 @@ function pushBuildWorkflow() {
 
 async function prBuildWorkflow() {
   const startTime = startTimer(jobName);
-  const buildTargets = determineBuildTargets();
   if (
-    buildTargets.has('RUNTIME') ||
-    buildTargets.has('FLAG_CONFIG') ||
-    buildTargets.has('INTEGRATION_TEST') ||
-    buildTargets.has('E2E_TEST') ||
-    buildTargets.has('VISUAL_DIFF')
+    buildTargetsInclude(
+      Targets.RUNTIME,
+      Targets.FLAG_CONFIG,
+      Targets.INTEGRATION_TEST,
+      Targets.E2E_TEST,
+      Targets.VISUAL_DIFF
+    )
   ) {
     timedExecOrDie('gulp update-packages');
     const process = timedExecWithError('gulp dist --fortesting');

--- a/build-system/pr-check/nomodule-tests.js
+++ b/build-system/pr-check/nomodule-tests.js
@@ -25,7 +25,7 @@ const {
   timedExecOrDie,
   timedExecOrThrow,
 } = require('./utils');
-const {determineBuildTargets} = require('./build-targets');
+const {buildTargetsInclude, Targets} = require('./build-targets');
 const {runCiJob} = require('./ci-job');
 
 const jobName = 'nomodule-tests.js';
@@ -48,11 +48,12 @@ function pushBuildWorkflow() {
 }
 
 function prBuildWorkflow() {
-  const buildTargets = determineBuildTargets();
   if (
-    buildTargets.has('RUNTIME') ||
-    buildTargets.has('FLAG_CONFIG') ||
-    buildTargets.has('INTEGRATION_TEST')
+    buildTargetsInclude(
+      Targets.RUNTIME,
+      Targets.FLAG_CONFIG,
+      Targets.INTEGRATION_TEST
+    )
   ) {
     downloadNomoduleOutput();
     timedExecOrDie('gulp update-packages');

--- a/build-system/pr-check/unit-tests.js
+++ b/build-system/pr-check/unit-tests.js
@@ -19,7 +19,7 @@
  * @fileoverview Script that runs the unit tests during CI.
  */
 
-const {determineBuildTargets} = require('./build-targets');
+const {buildTargetsInclude, Targets} = require('./build-targets');
 const {printSkipMessage, timedExecOrDie, timedExecOrThrow} = require('./utils');
 const {runCiJob} = require('./ci-job');
 
@@ -46,8 +46,7 @@ function pushBuildWorkflow() {
 }
 
 function prBuildWorkflow() {
-  const buildTargets = determineBuildTargets();
-  if (buildTargets.has('RUNTIME') || buildTargets.has('UNIT_TEST')) {
+  if (buildTargetsInclude(Targets.RUNTIME, Targets.UNIT_TEST)) {
     timedExecOrDie('gulp update-packages');
     timedExecOrDie('gulp unit --headless --local_changes');
     timedExecOrDie('gulp unit --headless --coverage');

--- a/build-system/pr-check/unminified-build.js
+++ b/build-system/pr-check/unminified-build.js
@@ -24,7 +24,7 @@ const {
   timedExecOrDie,
   uploadUnminifiedOutput,
 } = require('./utils');
-const {determineBuildTargets} = require('./build-targets');
+const {buildTargetsInclude, Targets} = require('./build-targets');
 const {runCiJob} = require('./ci-job');
 
 const jobName = 'unminified-build.js';
@@ -36,11 +36,12 @@ function pushBuildWorkflow() {
 }
 
 function prBuildWorkflow() {
-  const buildTargets = determineBuildTargets();
   if (
-    buildTargets.has('RUNTIME') ||
-    buildTargets.has('FLAG_CONFIG') ||
-    buildTargets.has('INTEGRATION_TEST')
+    buildTargetsInclude(
+      Targets.RUNTIME,
+      Targets.FLAG_CONFIG,
+      Targets.INTEGRATION_TEST
+    )
   ) {
     timedExecOrDie('gulp update-packages');
     timedExecOrDie('gulp build --fortesting');

--- a/build-system/pr-check/unminified-tests.js
+++ b/build-system/pr-check/unminified-tests.js
@@ -25,7 +25,7 @@ const {
   timedExecOrDie,
   timedExecOrThrow,
 } = require('./utils');
-const {determineBuildTargets} = require('./build-targets');
+const {buildTargetsInclude, Targets} = require('./build-targets');
 const {runCiJob} = require('./ci-job');
 
 const jobName = 'unminified-tests.js';
@@ -53,11 +53,12 @@ function pushBuildWorkflow() {
 }
 
 function prBuildWorkflow() {
-  const buildTargets = determineBuildTargets();
   if (
-    buildTargets.has('RUNTIME') ||
-    buildTargets.has('FLAG_CONFIG') ||
-    buildTargets.has('INTEGRATION_TEST')
+    buildTargetsInclude(
+      Targets.RUNTIME,
+      Targets.FLAG_CONFIG,
+      Targets.INTEGRATION_TEST
+    )
   ) {
     downloadUnminifiedOutput();
     timedExecOrDie('gulp update-packages');

--- a/build-system/pr-check/validator-tests.js
+++ b/build-system/pr-check/validator-tests.js
@@ -19,7 +19,7 @@
  * @fileoverview Script that runs the validator tests during CI.
  */
 
-const {determineBuildTargets} = require('./build-targets');
+const {buildTargetsInclude, Targets} = require('./build-targets');
 const {printSkipMessage, timedExecOrDie} = require('./utils');
 const {runCiJob} = require('./ci-job');
 
@@ -31,12 +31,12 @@ function pushBuildWorkflow() {
 }
 
 function prBuildWorkflow() {
-  const buildTargets = determineBuildTargets();
   if (
-    !buildTargets.has('RUNTIME') &&
-    !buildTargets.has('VALIDATOR') &&
-    !buildTargets.has('VALIDATOR_WEBUI') &&
-    !buildTargets.has('VALIDATOR_JAVA')
+    !buildTargetsInclude(
+      Targets.RUNTIME,
+      Targets.VALIDATOR,
+      Targets.VALIDATOR_WEBUI
+    )
   ) {
     printSkipMessage(
       jobName,
@@ -45,11 +45,11 @@ function prBuildWorkflow() {
     return;
   }
 
-  if (buildTargets.has('RUNTIME') || buildTargets.has('VALIDATOR')) {
+  if (buildTargetsInclude(Targets.RUNTIME, Targets.VALIDATOR)) {
     timedExecOrDie('gulp validator');
   }
 
-  if (buildTargets.has('VALIDATOR_WEBUI')) {
+  if (buildTargetsInclude(Targets.VALIDATOR_WEBUI)) {
     timedExecOrDie('gulp validator-webui');
   }
 }

--- a/build-system/pr-check/visual-diff-tests.js
+++ b/build-system/pr-check/visual-diff-tests.js
@@ -25,7 +25,7 @@ const {
   printSkipMessage,
   timedExecOrDie,
 } = require('./utils');
-const {determineBuildTargets} = require('./build-targets');
+const {buildTargetsInclude, Targets} = require('./build-targets');
 const {runCiJob} = require('./ci-job');
 
 const jobName = 'visual-diff-tests.js';
@@ -38,12 +38,13 @@ function pushBuildWorkflow() {
 }
 
 function prBuildWorkflow() {
-  const buildTargets = determineBuildTargets();
   process.env['PERCY_TOKEN'] = atob(process.env.PERCY_TOKEN_ENCODED);
   if (
-    buildTargets.has('RUNTIME') ||
-    buildTargets.has('FLAG_CONFIG') ||
-    buildTargets.has('VISUAL_DIFF')
+    buildTargetsInclude(
+      Targets.RUNTIME,
+      Targets.FLAG_CONFIG,
+      Targets.VISUAL_DIFF
+    )
   ) {
     downloadNomoduleOutput();
     timedExecOrDie('gulp update-packages');

--- a/build-system/tasks/pr-check.js
+++ b/build-system/tasks/pr-check.js
@@ -17,13 +17,17 @@
 
 const argv = require('minimist')(process.argv.slice(2));
 const {
+  buildTargetsInclude,
+  determineBuildTargets,
+  Targets,
+} = require('../pr-check/build-targets');
+const {
   stopTimedJob,
   printChangeSummary,
   startTimer,
   stopTimer,
   timedExec,
 } = require('../pr-check/utils');
-const {determineBuildTargets} = require('../pr-check/build-targets');
 const {runNpmChecks} = require('../pr-check/npm-checks');
 const {setLoggingPrefix} = require('../common/logging');
 
@@ -58,58 +62,60 @@ async function prCheck(cb) {
   }
 
   printChangeSummary();
-  const buildTargets = determineBuildTargets();
+  determineBuildTargets();
   runCheck('gulp lint --local_changes');
   runCheck('gulp prettify --local_changes');
   runCheck('gulp presubmit');
   runCheck('gulp check-exact-versions');
 
-  if (buildTargets.has('AVA')) {
+  if (buildTargetsInclude(Targets.AVA)) {
     runCheck('gulp ava');
   }
 
-  if (buildTargets.has('BABEL_PLUGIN')) {
+  if (buildTargetsInclude(Targets.BABEL_PLUGIN)) {
     runCheck('gulp babel-plugin-tests');
   }
 
-  if (buildTargets.has('CACHES_JSON')) {
+  if (buildTargetsInclude(Targets.CACHES_JSON)) {
     runCheck('gulp caches-json');
   }
 
-  if (buildTargets.has('DOCS')) {
+  if (buildTargetsInclude(Targets.DOCS)) {
     runCheck('gulp check-links --local_changes');
   }
 
-  if (buildTargets.has('DEV_DASHBOARD')) {
+  if (buildTargetsInclude(Targets.DEV_DASHBOARD)) {
     runCheck('gulp dev-dashboard-tests');
   }
 
-  if (buildTargets.has('OWNERS')) {
+  if (buildTargetsInclude(Targets.OWNERS)) {
     runCheck('gulp check-owners');
   }
 
-  if (buildTargets.has('RENOVATE_CONFIG')) {
+  if (buildTargetsInclude(Targets.RENOVATE_CONFIG)) {
     runCheck('gulp check-renovate-config');
   }
 
-  if (buildTargets.has('SERVER')) {
+  if (buildTargetsInclude(Targets.SERVER)) {
     runCheck('gulp server-tests');
   }
 
-  if (buildTargets.has('RUNTIME')) {
+  if (buildTargetsInclude(Targets.RUNTIME)) {
     runCheck('gulp dep-check');
     runCheck('gulp check-types');
     runCheck('gulp check-sourcemaps');
   }
 
-  if (buildTargets.has('RUNTIME') || buildTargets.has('UNIT_TEST')) {
+  if (buildTargetsInclude(Targets.RUNTIME, Targets.UNIT_TEST)) {
     runCheck('gulp unit --local_changes --headless');
   }
 
   if (
-    buildTargets.has('RUNTIME') ||
-    buildTargets.has('FLAG_CONFIG') ||
-    buildTargets.has('INTEGRATION_TEST')
+    buildTargetsInclude(
+      Targets.RUNTIME,
+      Targets.FLAG_CONFIG,
+      Targets.INTEGRATION_TEST
+    )
   ) {
     if (!argv.nobuild) {
       runCheck('gulp clean');
@@ -118,11 +124,11 @@ async function prCheck(cb) {
     runCheck('gulp integration --nobuild --compiled --headless');
   }
 
-  if (buildTargets.has('RUNTIME') || buildTargets.has('VALIDATOR')) {
+  if (buildTargetsInclude(Targets.RUNTIME, Targets.VALIDATOR)) {
     runCheck('gulp validator');
   }
 
-  if (buildTargets.has('VALIDATOR_WEBUI')) {
+  if (buildTargetsInclude(Targets.VALIDATOR_WEBUI)) {
     runCheck('gulp validator-webui');
   }
 

--- a/build-system/tasks/report-test-status.js
+++ b/build-system/tasks/report-test-status.js
@@ -25,6 +25,7 @@ const {
 } = require('../common/ci');
 const {ciJobUrl} = require('../common/ci');
 const {cyan, green, yellow} = require('ansi-colors');
+const {determineBuildTargets, Targets} = require('../pr-check/build-targets');
 const {gitCommitHash} = require('../common/git');
 const {log} = require('../common/logging');
 
@@ -47,9 +48,12 @@ const TEST_TYPE_SUBTYPES = isGithubActionsBuild()
     ])
   : new Map([]);
 const TEST_TYPE_BUILD_TARGETS = new Map([
-  ['integration', ['RUNTIME', 'FLAG_CONFIG', 'INTEGRATION_TEST']],
-  ['unit', ['RUNTIME', 'UNIT_TEST']],
-  ['e2e', ['RUNTIME', 'FLAG_CONFIG', 'E2E_TEST']],
+  [
+    'integration',
+    [Targets.RUNTIME, Targets.FLAG_CONFIG, Targets.INTEGRATION_TEST],
+  ],
+  ['unit', [Targets.RUNTIME, Targets.UNIT_TEST]],
+  ['e2e', [Targets.RUNTIME, Targets.FLAG_CONFIG, Targets.E2E_TEST]],
 ]);
 
 function inferTestType() {
@@ -145,7 +149,8 @@ function reportTestStarted() {
   return postReport(inferTestType(), 'started');
 }
 
-async function reportAllExpectedTests(buildTargets) {
+async function reportAllExpectedTests() {
+  const buildTargets = determineBuildTargets();
   for (const [type, subTypes] of TEST_TYPE_SUBTYPES) {
     const testTypeBuildTargets = TEST_TYPE_BUILD_TARGETS.get(type);
     const action = testTypeBuildTargets.some((target) =>


### PR DESCRIPTION
**PR highlights:**

- Add the `Targets` enum to `build-targets.js`
- Add `buildTargetsInclude()` to check if a PR's build targets include the given target(s)
- Cache the set of build targets once they have initially been determined
- Eliminate the hundreds of spots where build targets are referenced by name
- Modify `reportAllExpectedTests()` to use the previously computed build targets
- Fix bug where a nonexistent target was still being checked (`VALIDATOR_JAVA` no longer exists)