### PR TITLE
🏗 Prepare to move AMP's CI off Travis

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -2,8 +2,6 @@
 # See https://docs.codecov.io/docs/codecovyml-reference
 codecov:
   bot: 'amp-coverage-bot'
-  ci:
-    - 'travis.com'
   max_report_age: 24
   require_ci_to_pass: no
   notify:

--- a/.prettierrc
+++ b/.prettierrc
@@ -28,6 +28,7 @@
     },
     {
       "files": [
+        ".circleci/config.yml",
         ".codecov.yml",
         ".github/workflows/continuous-integration-workflow.yml",
         ".lando.yml",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,6 +10,7 @@
     ".renovaterc.json": "json",
 
     // Enable YAML auto-formatting for these files.
+    ".circleci/config.yml": "yaml",
     ".codecov.yml": "yaml",
     ".github/workflows/continuous-integration-workflow.yml": "yaml",
     ".lando.yml": "yaml",

--- a/METRICS.md
+++ b/METRICS.md
@@ -6,12 +6,6 @@ Test coverage for the repository as computed by CodeCov
 
 ![Absolute Code Coverage](https://amp-project-metrics.appspot.com/api/plot/AbsoluteCoverageMetric.png)
 
-## Presubmit Latency
-
-Average Travis build time over the last 90 days
-
-![Presubmit Latency](https://amp-project-metrics.appspot.com/api/plot/PresubmitLatencyMetric.png)
-
 ## Cherrypick Issue Count
 
 Number of cherry-pick issues in the last 90 days
@@ -23,15 +17,3 @@ Number of cherry-pick issues in the last 90 days
 Average commits per release over the last 90 days
 
 ![Release Granularity](https://amp-project-metrics.appspot.com/api/plot/ReleaseGranularityMetric.png)
-
-## Travis Greenness
-
-Percentage of green Travis builds over the last 90 days
-
-![Travis Greenness](https://amp-project-metrics.appspot.com/api/plot/TravisGreennessMetric.png)
-
-## Travis Flakiness
-
-Percentage of flaky Travis builds over the last 90 days
-
-![Travis Flakiness](https://amp-project-metrics.appspot.com/api/plot/TravisFlakinessMetric.png)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Do you build things with AMP? If you do, please fill out the new [AMP Developer 
 
 ⚡⚡⚡
 
-[![Build Status](https://img.shields.io/travis/ampproject/amphtml/master.svg?logo=Travis%20CI&logoColor=white&style=flat-square 'Build Status')](https://travis-ci.com/ampproject/amphtml/builds)
+[![Build Status](https://img.shields.io/circleci/build/github/ampproject/amphtml/master 'Build Status')](https://app.circleci.com/pipelines/github/ampproject/amphtml?branch=master)
 [![GitHub Release](https://img.shields.io/github/release/ampproject/amphtml.svg?logo=GitHub&style=flat-square 'GitHub Release')](https://github.com/ampproject/amphtml/releases/latest)
 [![Commits](https://img.shields.io/github/commit-activity/m/ampproject/amphtml.svg?logo=GitHub&style=flat-square 'Commits')](https://github.com/ampproject/amphtml/pulse/monthly)
 [![Badges](https://img.shields.io/badge/badges-16-brightgreen?logo=GitHub&style=flat-square)](#)
@@ -18,11 +18,8 @@ Metrics
 </summary>
 
 [![Absolute Code Coverage](https://img.shields.io/endpoint.svg?logo=Codecov&logoColor=white&style=flat-square&url=https%3A%2F%2Famp-project-metrics.appspot.com%2Fapi%2Fbadge%2FAbsoluteCoverageMetric 'Test coverage for the repository as computed by CodeCov')](https://codecov.io/gh/ampproject/amphtml/)
-[![Presubmit Latency](https://img.shields.io/endpoint.svg?logo=Travis%20CI&logoColor=white&style=flat-square&url=https%3A%2F%2Famp-project-metrics.appspot.com%2Fapi%2Fbadge%2FPresubmitLatencyMetric 'Average Travis build time over the last 90 days')](https://travis-ci.com/ampproject/amphtml/builds)
 [![Cherrypick Issue Count](https://img.shields.io/endpoint.svg?logo=GitHub&logoColor=white&style=flat-square&url=https%3A%2F%2Famp-project-metrics.appspot.com%2Fapi%2Fbadge%2FCherrypickIssueCountMetric 'Number of cherry-pick issues in the last 90 days')](https://github.com/ampproject/amphtml/issues?utf8=%E2%9C%93&q=is%3Aissue+title%3A+%22Cherry-pick%22)
 [![Release Granularity](https://img.shields.io/endpoint.svg?logo=GitHub&logoColor=white&style=flat-square&url=https%3A%2F%2Famp-project-metrics.appspot.com%2Fapi%2Fbadge%2FReleaseGranularityMetric 'Average commits per release over the last 90 days')](https://github.com/ampproject/amphtml/releases)
-[![Travis Greenness](https://img.shields.io/endpoint.svg?logo=Travis%20CI&logoColor=white&style=flat-square&url=https%3A%2F%2Famp-project-metrics.appspot.com%2Fapi%2Fbadge%2FTravisGreennessMetric 'Percentage of green Travis builds over the last 90 days')](https://travis-ci.com/ampproject/amphtml/builds)
-[![Travis Flakiness](https://img.shields.io/endpoint.svg?logo=Travis%20CI&logoColor=white&style=flat-square&url=https%3A%2F%2Famp-project-metrics.appspot.com%2Fapi%2Fbadge%2FTravisFlakinessMetric 'Percentage of flaky Travis builds over the last 90 days')](https://travis-ci.com/ampproject/amphtml/builds)
 
 </details>
 

--- a/build-system/server/app-index/header-links.js
+++ b/build-system/server/app-index/header-links.js
@@ -35,8 +35,9 @@ module.exports = [
     'href': 'https://github.com/ampproject/amphtml/find/master',
   },
   {
-    'name': 'Travis',
-    'href': 'https://travis-ci.com/ampproject/amphtml',
+    'name': 'CircleCI',
+    'href':
+      'https://app.circleci.com/pipelines/github/ampproject/amphtml?branch=master',
   },
   {
     'name': 'Percy',

--- a/build-system/tasks/pr-deploy-bot-utils.js
+++ b/build-system/tasks/pr-deploy-bot-utils.js
@@ -70,7 +70,7 @@ async function replaceUrls(dir) {
 
 async function signalPrDeployUpload(result) {
   // TODO(rsimha): Remove this check once Travis is shut down.
-  if (!isTravisBuild()) {
+  if (isTravisBuild()) {
     return;
   }
   const loggingPrefix = getLoggingPrefix();

--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -1163,7 +1163,7 @@ const forbiddenTermsSrcInclusive = {
     message: 'Unsupported on IE; use trim() or a helper instead.',
     allowlist: ['validator/js/engine/validator.js'],
   },
-  "process\\.env(\\.|\\[\\')(TRAVIS|GITHUB_ACTIONS|CIRCLECI)": {
+  "process\\.env(\\.|\\[\\')(GITHUB_ACTIONS|CIRCLECI)": {
     message:
       'Do not directly use CI-specific environment vars. Instead, add a ' +
       'function to build-system/common/ci.js',

--- a/build-system/test-configs/config.js
+++ b/build-system/test-configs/config.js
@@ -152,6 +152,7 @@ const presubmitGlobs = [
  * 2. Make sure it is listed in .vscode/settings.json (for auto-fix-on-save)
  */
 const prettifyGlobs = [
+  '.circleci/config.yml',
   '.codecov.yml',
   '.lando.yml',
   '.lgtm.yml',

--- a/contributing/DEVELOPING.md
+++ b/contributing/DEVELOPING.md
@@ -90,7 +90,7 @@ We also recommend scanning the [spec](../spec/). The non-element part should hel
 
 ## Builds and releases
 
--   The [AMP buildcop](buildcop.md) helps ensure that AMP's builds remain green (i.e. everything builds and all of the tests pass). If you run into issues with builds that seem unrelated to your changes see if the issue is present on [Travis](https://travis-ci.com/ampproject/amphtml/builds) and send a message to the [#contributing](https://amphtml.slack.com/messages/C9HRJ1GPN) channel on Slack ([sign up for Slack](https://bit.ly/amp-slack-signup)).
+-   The [AMP buildcop](buildcop.md) helps ensure that AMP's builds remain green (i.e. everything builds and all of the tests pass). If you run into issues with builds that seem unrelated to your changes see if the issue is present on [CircleCI](https://app.circleci.com/pipelines/github/ampproject/amphtml?branch=master) and send a message to the [#contributing](https://amphtml.slack.com/messages/C9HRJ1GPN) channel on Slack ([sign up for Slack](https://bit.ly/amp-slack-signup)).
 -   Understanding the [AMP release process](release-schedule.md) is useful for understanding when a change in AMP will make it into production and what to do if things go wrong during the rollout of a change.
 
 ### Opting in to pre-release channels

--- a/contributing/TESTING.md
+++ b/contributing/TESTING.md
@@ -82,9 +82,9 @@ Before running these commands, make sure you have Node.js and Gulp installed. Fo
 | `gulp clean`                                              | Removes build output.                                                                                                                                                                                                                                  |
 | `gulp css`                                                | Recompiles css to the build directory and builds the embedded css into js files for the AMP library.                                                                                                                                                   |
 | `gulp compile-jison`                                      | Compiles jison parsers for extensions to build directory.                                                                                                                                                                                              |
-| `gulp pr-check`                                           | Runs all the Travis CI checks locally.                                                                                                                                                                                                                 |
-| `gulp pr-check --nobuild`                                 | Runs all the Travis CI checks locally, but skips the `gulp build` step.                                                                                                                                                                                |
-| `gulp pr-check --files=<test-files-path-glob>`            | Runs all the Travis CI checks locally, and restricts tests to the files provided.                                                                                                                                                                      |
+| `gulp pr-check`                                           | Runs all the CircleCI checks locally.                                                                                                                                                                                                                  |
+| `gulp pr-check --nobuild`                                 | Runs all the CircleCI checks locally, but skips the `gulp build` step.                                                                                                                                                                                 |
+| `gulp pr-check --files=<test-files-path-glob>`            | Runs all the CircleCI checks locally, and restricts tests to the files provided.                                                                                                                                                                       |
 | `gulp unit`                                               | Runs the unit tests in Chrome (doesn't require the AMP library to be built).                                                                                                                                                                           |
 | `gulp unit --local_changes`                               | Runs the unit tests directly affected by the files changed in the local branch in Chrome.                                                                                                                                                              |
 | `gulp integration`                                        | Runs the integration tests in Chrome after building the unminified runtime with the `prod` version of `AMP_CONFIG`.                                                                                                                                    |
@@ -233,7 +233,7 @@ For testing documents on arbitrary URLs with your current local version of the A
 
 ## Visual Diff Tests
 
-In addition to building the AMP runtime and running `gulp [unit|integration]`, the automatic test run on Travis includes a set of visual diff tests to make sure a new commit to `master` does not result in unintended changes to how pages are rendered. The tests load a few well-known pages in a browser and compare the results with known good versions of the same pages.
+In addition to building the AMP runtime and running `gulp [unit|integration]`, the automatic test run on CircleCI includes a set of visual diff tests to make sure a new commit to `master` does not result in unintended changes to how pages are rendered. The tests load a few well-known pages in a browser and compare the results with known good versions of the same pages.
 
 The technology stack used is:
 
@@ -242,7 +242,7 @@ The technology stack used is:
 -   [Percy-Puppeteer](https://github.com/percy/percy-puppeteer), a framework that integrates Puppeteer with Percy
 -   [Headless Chrome](https://chromium.googlesource.com/chromium/src/+/lkgr/headless/README.md), the Chrome/Chromium browser in headless mode
 
-The [`ampproject/amphtml`](https://github.com/ampproject/amphtml) repository on GitHub is linked to the [Percy project](https://percy.io/ampproject/amphtml) of the same name. All PRs will show a check called `percy/amphtml` in addition to the `continuous-integration/travis-ci/pr` check. If your PR results in visual diff(s), clicking on the `details` link will show you the snapshots with the diffs highlighted.
+The [`ampproject/amphtml`](https://github.com/ampproject/amphtml) repository on GitHub is linked to the [Percy project](https://percy.io/ampproject/amphtml) of the same name. You will see a check called `percy/amphtml` on your PR. If your PR results in visual diff(s), clicking on the `details` link will show you the snapshots with the diffs highlighted.
 
 ### Failing Tests
 
@@ -250,7 +250,7 @@ When a test run fails due to visual diffs being present, click the `details` lin
 
 ### Flaky Tests
 
-If a Percy test flakes and you would like to trigger a rerun, you can't do that from within Percy. Instead, from your PR on GitHub open up the "Details" for the `continuous-integration/travis-ci/pr` check to load the Travis run for your PR. There you should see a "passed" test shard labeled "Visual Diff Tests". Click the "Restart Job" icon on just that shard to trigger a rerun on Percy.
+If a Percy test flakes and you would like to trigger a rerun, you can't do that from within Percy. Instead, from your PR on GitHub, click on the `details` link next to `CircleCI PR Check` and then click on `Visual Diff Tests` to load the CircleCI run for your PR. On the job page, click the `Rerun workflow from start` button to rerun just that job, which will generate a fresh visual diff build on Percy.
 
 ### How Are Tests Executed
 

--- a/contributing/buildcop.md
+++ b/contributing/buildcop.md
@@ -1,6 +1,6 @@
 # AMP Buildcop
 
-The AMP buildcop is responsible for ensuring that the [master build](https://travis-ci.com/ampproject/amphtml/branches) remains green. The AMP buildcop responsibility rotates between members of the community.
+The AMP buildcop is responsible for ensuring that the [master build](https://app.circleci.com/pipelines/github/ampproject/amphtml?branch=master) remains green. The AMP buildcop responsibility rotates between members of the community.
 
 Make sure you are a member of the [#contributing](https://amphtml.slack.com/messages/C9HRJ1GPN) channel on Slack while you are buildcop.
 
@@ -9,7 +9,7 @@ Make sure you are a member of the [#contributing](https://amphtml.slack.com/mess
 
 ## Buildcop Tasks
 
-1. Ensure the [master build](https://travis-ci.com/ampproject/amphtml/branches) remains green. Your goal is to keep the build from being red for more than an hour.
+1. Ensure the [master build](https://app.circleci.com/pipelines/github/ampproject/amphtml?branch=master) remains green. Your goal is to keep the build from being red for more than an hour.
     1. Note that yellow builds are in the process of being created/tested so you do not need to do anything special with them.
     2. Keep an eye out for emails sent to an address starting with amp-build-cop. **You are encouraged to set up a filter so that these emails will stand out to you.**
     3. You will need to investigate whether a red build is due to a flake or due to a real issue.
@@ -18,14 +18,16 @@ Make sure you are a member of the [#contributing](https://amphtml.slack.com/mess
             - If needed, send a PR to disable the flaky test:
                 - For a normal `describe` test add [`.skip()`](https://mochajs.org/#inclusive-tests)
                 - For an integration test failing on a specific browser, add the corresponding `skip` function (e.g. `skipEdge()`). See the `skipXXX` functions in [\_init_tests.js](https://github.com/ampproject/amphtml/blob/master/test/_init_tests.js) for details.
-            - Restart the build on Travis by clicking the "Restart build" button on the build page (you must be signed into GitHub).
+            - Restart the failing parts of the build build on CircleCI by clicking the `Rerun workflow from failed` button on the build page (you must be signed into GitHub).
         - If the issue is due to a real breakage, work with the appropriate owner to rollback the offending PR. Rollbacks are preferable to fixes because fixes can often cause their own breakages.
 2. Keep an eye on incoming [Renovate PRs](https://github.com/ampproject/amphtml/pulls/renovate-bot), which result from an automated process to update our dependencies.
     1. Make sure that the PR updates both package.json and package-lock.json
-    2. Check the Travis logs for the PR for any new failures or unexpected results
-        - If there’s a failure due to a flaky test, try restarting the shard that failed
-        - If that doesn’t work, try syncing the branch to HEAD (tests will automatically be re-run)
-        - If neither of the above works, it’s possible that the package update is a breaking change. Assign the PR to someone who can look at what changed and determine how to fix it.
-    3. Assuming Travis was green, make sure there are no diffs in the Percy build.
+    2. Check the CircleCI logs for the PR for any new failures or unexpected results
+        - If there’s a failure due to a flaky test, try restarting the job that failed
+        - If that doesn’t work, try syncing the branch to HEAD by checking the `rebase/retry` checkbox in the PR description (tests will automatically be re-run)
+        - If neither of the above works, it’s possible that the package update is a breaking change.
+            - If you know how to fix the breaking change, follow the instructions by expanding the `How to resolve breaking changes` section of the PR description.
+            - If not, assign the PR to someone who can look at what changed and determine how to fix it.
+    3. Assuming the CircleCI build was green, make sure there are no diffs in the Percy build.
         - If there are diffs that look like flakes, click “Approve” on the Percy build to unblock the PR (and ping @danielrozenberg as an FYI).
     4. Approve and merge the PR.

--- a/contributing/getting-started-e2e.md
+++ b/contributing/getting-started-e2e.md
@@ -38,7 +38,7 @@ If you do not yet have a specific code contribution project in mind as you go th
     -   [Code quality and style](#code-quality-and-style)
 -   [Testing your changes](#testing-your-changes)
     -   [Running tests locally](#running-tests-locally)
-    -   [Running all the Travis CI checks locally](#running-all-the-travis-ci-checks-locally)
+    -   [Running all the CircleCI checks locally](#running-all-the-circleci-checks-locally)
     -   [Adding tests for your change](#adding-tests-for-your-change)
 -   [Push your changes to your GitHub fork](#push-your-changes-to-your-github-fork)
 -   [Send a Pull Request (i.e. request a code review)](#send-a-pull-request-ie-request-a-code-review)
@@ -416,9 +416,9 @@ By default, all tests are run on Chrome. Pass one of the following flags to run 
 
 If you need help with fixing failing tests, please ask on the GitHub issue you're working on or reach out to the community as described in [How to get help](#how-to-get-help).
 
-## Running Travis CI checks locally
+## Running all the CircleCI checks locally
 
-To avoid repeatedly waiting for Travis to run all pull-request checks, you can run them locally:
+To avoid repeatedly waiting for CircleCI to run all pull-request checks, you can run them locally:
 
 ```sh
 gulp pr-check
@@ -427,7 +427,7 @@ gulp pr-check
 Notes:
 
 -   This will force a clean build and run all the PR checks one by one.
--   Just like on Travis, a failing check will prevent subsequent checks from being run.
+-   Just like on CircleCI, a failing check will prevent subsequent checks from being run.
 -   The `gulp visual-diff` check will be skipped unless you have set up a Percy account as described in the [Testing](TESTING.md#running-visual-diff-tests-locally) guide.
 -   Unit and integration tests will be run on local Chrome.
 
@@ -532,13 +532,13 @@ When you're done click "Create pull request." This will bring you to your Pull R
 
 On the Pull Request page you can see that a few checks are running:
 
--   The tests are being run on [Travis](https://travis-ci.com/ampproject/amphtml/pull_requests)
+-   The tests are being run on [CircleCI](https://app.circleci.com/pipelines/github/ampproject/amphtml)
 
 -   The system is verifying that you have signed a CLA (Contributor License Agreement). If this is your first time submitting a Pull Request for AMP on GitHub you'll need to sign a CLA. (Make sure the email address you use to sign the CLA is the same one that you configured Git with.) See details in the [Contributing code](../CONTRIBUTING.md#contributing-code) documentation.
 
 -   Your code is going through static analysis by [LGTM](https://lgtm.com/projects/g/ampproject/amphtml/).
 
--   Visual diff tests that are run on Travis are being analyzed by [Percy](http://percy.io/ampproject/amphtml).
+-   Visual diff tests that are run on CircleCI are being analyzed by [Percy](http://percy.io/ampproject/amphtml).
 
 If you don't hear back from your reviewer within 2 business days, feel free to ping the pull request by adding a comment.
 

--- a/contributing/release-schedule.md
+++ b/contributing/release-schedule.md
@@ -85,7 +85,8 @@ After considering all of these factors, we have arrived at the 1-2 week push cyc
 
 We try to stick to this schedule as closely as possible, though complications may cause delays. You can track the latest status about any release in the [_Type: Release_ GitHub issues](https://github.com/ampproject/amphtml/labels/Type%3A%20Release) and the [AMP Slack #release channel](https://amphtml.slack.com/messages/C4NVAR0H3/) ([sign up for Slack](https://bit.ly/amp-slack-signup)).
 
--   Tuesday @ [11am Pacific](https://www.google.com/search?q=11am+pacific+in+current+time+zone): new **experimental** and **beta** release builds are created from the [latest master build that passes all of our tests](https://travis-ci.com/ampproject/amphtml/branches) and are pushed to users who opted into the [AMP Experimental Channel](#amp-experimental-and-beta-channels) or [AMP Beta Channel](#amp-experimental-and-beta-channels), respectively.
+-   Every weeknight: a new **nightly** build is automatically cut and released to the [AMP Nightly Channel](#nightly).
+-   Tuesday @ [11am Pacific](https://www.google.com/search?q=11am+pacific+in+current+time+zone): new **experimental** and **beta** release builds are created from a recent known-good nightly channel release and are pushed to users who opted into the [AMP Experimental Channel](#amp-experimental-and-beta-channels) or [AMP Beta Channel](#amp-experimental-and-beta-channels), respectively.
 -   Wednesday: we check bug reports for _Experimental Channel_ and _Beta Channel_ users and if everything looks fine, we push the **beta** to 1% of AMP pages
 -   Thursday-Monday: we continue to monitor error rates and bug reports for _Experimental Channel_ and _Beta Channel_ users and the 1% of pages with the **experimental**/**beta** builds
 -   Tuesday the following week: the **beta** build is fully promoted to **stable** (i.e. all AMP pages will now use this build)

--- a/extensions/amp-3d-gltf/0.1/test/test-amp-3d-gltf.js
+++ b/extensions/amp-3d-gltf/0.1/test/test-amp-3d-gltf.js
@@ -80,7 +80,7 @@ describes.realWin(
       expect(!!doc.body.querySelector('amp-3d-gltf > iframe')).to.be.true;
     });
 
-    // TODO (#16080): this test times out on Travis. Re-enable when fixed.
+    // TODO (#16080): this test times out on CI. Re-enable when fixed.
     it.skip('sends toggleAmpViewport(false) when exiting viewport', async () => {
       const amp3dGltf = await createElement();
 
@@ -94,7 +94,7 @@ describes.realWin(
       expect(postMessageSpy.firstCall.args[1].args).to.be.false;
     });
 
-    // TODO (#16080): this test times out on Travis. Re-enable when fixed.
+    // TODO (#16080): this test times out on CI. Re-enable when fixed.
     it.skip('sends toggleAmpViewport(true) when entering viewport', async () => {
       const amp3dGltf = await createElement();
       const postMessageSpy = env.sandbox.spy(amp3dGltf, 'postMessage_');

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -931,7 +931,7 @@ describe('amp-a4a', () => {
 
       ['', 'client_cache', 'safeframe', 'some_random_thing'].forEach(
         (headerVal) => {
-          // TODO(wg-monetization, #25690): Fails on Travis.
+          // TODO(wg-monetization, #25690): Fails on CI.
           it.skip(`should not attach a NameFrame when header is ${headerVal}`, async () => {
             const devStub = window.sandbox.stub(dev(), 'error');
             // Make sure there's no signature, so that we go down the 3p

--- a/extensions/amp-base-carousel/0.1/test-e2e/test-carousel.js
+++ b/extensions/amp-base-carousel/0.1/test-e2e/test-carousel.js
@@ -19,7 +19,7 @@ import {getScrollingElement, getSlide, waitForCarouselImg} from './helpers';
 const pageWidth = 800;
 const pageHeight = 600;
 
-/** Increase timeout for running on Travis macOS **/
+/** Increase timeout for running on macOS **/
 const testTimeout = 20000;
 
 describes.endtoend(

--- a/extensions/amp-iframe/0.1/amp-iframe.js
+++ b/extensions/amp-iframe/0.1/amp-iframe.js
@@ -627,7 +627,6 @@ export class AmpIframe extends AMP.BaseElement {
     }
     if (this.iframe_ && mutations['title']) {
       // only propagating title because propagating all causes e2e error:
-      // See <https://travis-ci.com/ampproject/amphtml/jobs/657440421>
       this.propagateAttributes(['title'], this.iframe_);
     }
   }

--- a/test/integration/test-amphtml-ads.js
+++ b/test/integration/test-amphtml-ads.js
@@ -76,7 +76,7 @@ t.run('AMPHTML ad on AMP Page', () => {
         return RequestBank.tearDown();
       });
 
-      // TODO(#24657): Flaky on Travis.
+      // TODO(#24657): Flaky on CI.
       it.skip('should layout amp-img, amp-pixel, amp-analytics', () => {
         // Open http://ads.localhost:9876/amp4test/a4a/12345 to see ad content
         return testAmpComponentsBTF(env.win);

--- a/test/unit/test-mutator.js
+++ b/test/unit/test-mutator.js
@@ -975,7 +975,7 @@ describes.realWin('mutator changeSize', {amp: true}, (env) => {
       expect(overflowCallbackSpy).to.not.been.called;
     });
 
-    // TODO(#25518): investigate failure on Travis Safari
+    // TODO(#25518): investigate failure on Safari
     it.configure().skipSafari(
       'in viewport should change size if in the last 15% and ' +
         'in the last 1000px',


### PR DESCRIPTION
This PR makes it possible to fully stop Travis builds, but does not actually do so.

**PR highlights:**

- Enable auto-formatting for CircleCI's config file
- Clean up unused configs pertaining to Travis
- Report PR deploy success from CircleCI builds so it no longer relies on Travis
- Remove Travis badges on AMP's readme and metrics pages
- Update CI link on AMP's dev server to CircleCI
- Update AMP dev docs with CircleCI-specific links and text
- Clean up mentions of Travis in test file comments

**Coming up next week:**

- [ ] Make sure CircleCI builds are reliable and green
- [ ] Make the CircleCI commit status a blocking check for PRs
- [ ] Shut off Travis builds for `ampproject/amphtml`
- [ ] Delete remaining Travis-specific code / config 
