### PR TITLE
🏗 Enable `gulp` log coloring during CI

### DIFF
--- a/build-system/pr-check/utils.js
+++ b/build-system/pr-check/utils.js
@@ -167,7 +167,9 @@ function abortTimedJob(jobName, startTime) {
 function timedExecFn(execFn) {
   return (cmd, ...rest) => {
     const startTime = startTimer(cmd);
-    const p = execFn(cmd, ...rest);
+    const cmdToRun =
+      isCiBuild() && cmd.startsWith('gulp ') ? cmd.concat(' --color') : cmd;
+    const p = execFn(cmdToRun, ...rest);
     stopTimer(cmd, startTime);
     return p;
   };

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -19,6 +19,7 @@
 const argv = require('minimist')(process.argv.slice(2));
 const gulp = require('gulp-help')(require('gulp'));
 const {cyan, red} = require('ansi-colors');
+const {isCiBuild} = require('./build-system/common/ci');
 const {log} = require('./build-system/common/logging');
 
 const {
@@ -100,6 +101,9 @@ function checkFlags(name, taskFunc) {
     return; // This isn't the task being run.
   }
   const validFlags = taskFunc.flags ? Object.keys(taskFunc.flags) : [];
+  if (isCiBuild()) {
+    validFlags.push('color'); // Used to enable log coloring during CI.
+  }
   const usedFlags = Object.keys(argv).slice(1); // Skip the '_' argument
   const invalidFlags = [];
   usedFlags.forEach((flag) => {


### PR DESCRIPTION
The `gulp` CLI [disables log coloring](https://github.com/gulpjs/gulp-cli/blob/726c6ed1395a382712fa1f67691ac955a53970b8/lib/shared/ansi.js#L30-L41) by default on most CI services due to [these lines](https://github.com/isaacs/color-support/blob/v1.1.3/index.js#L93-L97) in the [`color-support`](https://www.npmjs.com/package/color-support) library.

This PR enables log coloring by adding the `--color` flag to all `gulp` commands invoked during PR jobs.

**Before:**

![image](https://user-images.githubusercontent.com/26553114/105566088-48535e00-5cf8-11eb-957b-0297e2ff327c.png)

![image](https://user-images.githubusercontent.com/26553114/105566309-77b69a80-5cf9-11eb-9af2-f834a3e33bff.png)

**After:**

![image](https://user-images.githubusercontent.com/26553114/105566096-55704d00-5cf8-11eb-8c52-97ea4aa8c843.png)

![image](https://user-images.githubusercontent.com/26553114/105566299-6c636f00-5cf9-11eb-9989-b567793951c1.png)

