### PR TITLE
Pre-upgrade Bento CSS

### DIFF
--- a/build-system/compile/bundles.config.extensions.json
+++ b/build-system/compile/bundles.config.extensions.json
@@ -94,6 +94,12 @@
     "options": {"hasCss": true}
   },
   {"name": "amp-base-carousel", "version": "1.0", "latestVersion": "0.1"},
+  {
+    "name": "amp-bento",
+    "version": "0.1",
+    "latestVersion": "0.1",
+    "options": {"hasCss": true}
+  },
   {"name": "amp-beopinion", "version": "0.1", "latestVersion": "0.1"},
   {"name": "amp-bind", "version": "0.1", "latestVersion": "0.1"},
   {"name": "amp-bodymovin-animation", "version": "0.1", "latestVersion": "0.1"},

--- a/extensions/amp-bento/0.1/amp-accordion.css
+++ b/extensions/amp-bento/0.1/amp-accordion.css
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* TODO(#32155): organize and import from the extension sources  */
+
+amp-accordion,
+amp-accordion > section,
+amp-accordion > section > :first-child {
+  margin: 0;
+}
+
+amp-accordion > section > :first-child {
+  border: 1px solid transparent;
+}
+
+/* Display the first 2 elements (heading and content) */
+amp-accordion > section > * {
+  display: block;
+  float: none;
+  overflow: hidden; /* clearfix */
+  position: relative;
+}
+
+/* Collapse content by default. */
+amp-accordion:not(.i-amphtml-built) > section:not([expanded]) > :last-child {
+  display: none !important;
+}

--- a/extensions/amp-bento/0.1/amp-bento.css
+++ b/extensions/amp-bento/0.1/amp-bento.css
@@ -1,0 +1,89 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* Special elements that require FOUC. */
+
+@import 'amp-accordion.css';
+@import 'amp-social-share.css';
+
+
+/* Common boilerplate */
+
+/* display:block elements */
+amp-accordion,
+amp-base-carousel,
+amp-fit-text,
+amp-inline-gallery,
+amp-inline-gallery-pagination,
+amp-inline-gallery-thumbnails,
+amp-instagram,
+amp-selector,
+amp-stream-gallery {
+  display: block;
+}
+
+/* display:inline-block elements */
+amp-date-countdown,
+amp-date-display,
+amp-social-share,
+amp-timeago {
+  display: inline-block;
+}
+
+/* contain:layout elements */
+amp-accordion,
+amp-inline-gallery,
+amp-selector {
+  contain: layout;
+}
+
+/* contain:strict elements */
+amp-base-carousel,
+amp-date-countdown,
+amp-date-display,
+amp-fit-text,
+amp-inline-gallery-pagination,
+amp-inline-gallery-thumbnails,
+amp-instagram,
+amp-social-share,
+amp-stream-gallery,
+amp-timeago {
+  contain: strict;
+  overflow: hidden;
+  position: relative;
+}
+
+/* Size-defining elements: hide children until build */
+amp-fit-text:not(.i-amphtml-built) {
+  color: transparent !important;
+}
+
+amp-base-carousel:not(.i-amphtml-built) > :not([placeholder]),
+amp-date-countdown:not(.i-amphtml-built) > :not([placeholder]),
+amp-fit-text:not(.i-amphtml-built) > :not([placeholder]),
+amp-inline-gallery-pagination:not(.i-amphtml-built) > :not([placeholder]),
+amp-inline-gallery-thumbnails:not(.i-amphtml-built) > :not([placeholder]),
+amp-stream-gallery:not(.i-amphtml-built) > :not([placeholder]),
+amp-timeago:not(.i-amphtml-built) > :not([placeholder]) {
+  display: none !important;
+  content-visibility: hidden !important;
+}
+
+/* offscreen */
+amp-lightbox[hidden],
+amp-sidebar[hidden] {
+  display: none !important;
+}

--- a/extensions/amp-bento/0.1/amp-bento.js
+++ b/extensions/amp-bento/0.1/amp-bento.js
@@ -1,0 +1,23 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {CSS} from '../../../build/amp-bento-0.1.css';
+
+class AmpBento extends AMP.BaseElement {}
+
+AMP.extension('amp-bento', '0.1', (AMP) => {
+  AMP.registerElement('amp-bento', AmpBento, CSS);
+});

--- a/extensions/amp-bento/0.1/amp-social-share.css
+++ b/extensions/amp-bento/0.1/amp-social-share.css
@@ -1,0 +1,21 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+amp-social-share {
+  box-sizing: border-box;
+  width: 60px;
+  height: 44px;
+}


### PR DESCRIPTION
Partial for #32155.

Key notes:
* It's an empty extension and not expected to be ever used. But the resulting CSS file will be deployed to https://cdn.ampproject.org/v0/amp-bento-0.1.css.
* Thus, a page would use it as `<link rel="stylesheet" type="text/css" href="https://cdn.ampproject.org/v0/amp-bento-0.1.css">`
* I made a step further and actually enumerated the components since we do not have `class="i-amphtml-element"` before v0.js is loaded. Since there's no boilerplate, I found it the only reasonable way to avoid FOUC. However, the gzipping of this file is very good.
* If we arrange this well, we can let other extensions export "minimum needed" CSS and let this file aggregate and optimize it. See `@import` statements there. Unfortunately post CSS is refusing to optimize the combined stylesheet. But we can probably "teach it".
