### PR TITLE
Optimize CircleCI builds with a mix of `xlarge` and `large` VMs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ executors:
   amphtml-executor:
     machine:
       image: ubuntu-2004:202010-01
-    resource_class: xlarge
+    resource_class: large
 
 commands:
   setup_vm:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,10 +19,14 @@ push_builds_only: &push_builds_only
         - /^amp-release-.*$/
 
 executors:
-  amphtml-executor:
+  amphtml-large-executor:
     machine:
       image: ubuntu-2004:202010-01
     resource_class: large
+  amphtml-xlarge-executor:
+    machine:
+      image: ubuntu-2004:202010-01
+    resource_class: xlarge
 
 commands:
   setup_vm:
@@ -62,7 +66,7 @@ commands:
 jobs:
   'Checks':
     executor:
-      name: amphtml-executor
+      name: amphtml-large-executor
     steps:
       - setup_vm
       - run:
@@ -70,7 +74,7 @@ jobs:
           command: node build-system/pr-check/checks.js
   'Unminified Build':
     executor:
-      name: amphtml-executor
+      name: amphtml-xlarge-executor
     steps:
       - setup_vm
       - run:
@@ -78,7 +82,7 @@ jobs:
           command: node build-system/pr-check/unminified-build.js
   'Nomodule Build':
     executor:
-      name: amphtml-executor
+      name: amphtml-xlarge-executor
     steps:
       - setup_vm
       - run:
@@ -86,7 +90,7 @@ jobs:
           command: node build-system/pr-check/nomodule-build.js
   'Module Build':
     executor:
-      name: amphtml-executor
+      name: amphtml-xlarge-executor
     steps:
       - setup_vm
       - run:
@@ -94,7 +98,7 @@ jobs:
           command: node build-system/pr-check/module-build.js
   'Bundle Size':
     executor:
-      name: amphtml-executor
+      name: amphtml-large-executor
     steps:
       - setup_vm
       - run:
@@ -102,7 +106,7 @@ jobs:
           command: node build-system/pr-check/bundle-size.js
   'Validator Tests':
     executor:
-      name: amphtml-executor
+      name: amphtml-large-executor
     steps:
       - setup_vm
       - run:
@@ -113,7 +117,7 @@ jobs:
           command: node build-system/pr-check/validator-tests.js
   'Visual Diff Tests':
     executor:
-      name: amphtml-executor
+      name: amphtml-large-executor
     steps:
       - setup_vm
       - run:
@@ -121,7 +125,7 @@ jobs:
           command: node build-system/pr-check/visual-diff-tests.js
   'Unit Tests':
     executor:
-      name: amphtml-executor
+      name: amphtml-large-executor
     steps:
       - setup_vm
       - run:
@@ -129,7 +133,7 @@ jobs:
           command: node build-system/pr-check/unit-tests.js
   'Unminified Tests':
     executor:
-      name: amphtml-executor
+      name: amphtml-large-executor
     steps:
       - setup_vm
       - run:
@@ -137,7 +141,7 @@ jobs:
           command: node build-system/pr-check/unminified-tests.js
   'Nomodule Tests':
     executor:
-      name: amphtml-executor
+      name: amphtml-large-executor
     steps:
       - setup_vm
       - run:
@@ -145,7 +149,7 @@ jobs:
           command: node build-system/pr-check/nomodule-tests.js
   'Module Tests':
     executor:
-      name: amphtml-executor
+      name: amphtml-large-executor
     steps:
       - setup_vm
       - run:
@@ -153,7 +157,7 @@ jobs:
           command: node build-system/pr-check/module-tests.js
   'End-to-End Tests':
     executor:
-      name: amphtml-executor
+      name: amphtml-large-executor
     steps:
       - setup_vm
       - run:
@@ -161,7 +165,7 @@ jobs:
           command: node build-system/pr-check/e2e-tests.js
   'Performance Tests':
     executor:
-      name: amphtml-executor
+      name: amphtml-xlarge-executor
     steps:
       - setup_vm
       - run:
@@ -169,7 +173,7 @@ jobs:
           command: node build-system/pr-check/performance-tests.js
   'Experiment A Tests':
     executor:
-      name: amphtml-executor
+      name: amphtml-xlarge-executor
     steps:
       - setup_vm
       - run:
@@ -177,7 +181,7 @@ jobs:
           command: node build-system/pr-check/experiment-tests.js --experiment=experimentA
   'Experiment B Tests':
     executor:
-      name: amphtml-executor
+      name: amphtml-xlarge-executor
     steps:
       - setup_vm
       - run:
@@ -185,7 +189,7 @@ jobs:
           command: node build-system/pr-check/experiment-tests.js --experiment=experimentB
   'Experiment C Tests':
     executor:
-      name: amphtml-executor
+      name: amphtml-xlarge-executor
     steps:
       - setup_vm
       - run:


### PR DESCRIPTION
We currently use `xlarge` CircleCI VMs, which give us a build round trip time of under 20 mins. E.g. [this build](https://app.circleci.com/pipelines/github/ampproject/amphtml/386/workflows/3e1e4878-35f1-4bff-a26a-c11d4a6a8564).

From the [pricing chart](https://circleci.com/pricing/), `xlarge` VMs cost 5x as much per minute as `large` VMs.

<img width="1221" alt="Screen Shot 2021-01-25 at 10 03 59 AM" src="https://user-images.githubusercontent.com/26553114/105723497-d8f68d80-5ef4-11eb-8431-236f3cffb87a.png">

This PR optimizes the price / performance of CircleCI builds by using `xlarge` VMs for jobs that build the AMP runtime (highly parallelized), and `large` VMs for all other jobs that run tests (mostly done serially).