### PR TITLE
🏗 Report bundle-size / PR-deploy from Travis until the switch to CircleCI actually happens

### DIFF
--- a/build-system/pr-check/bundle-size.js
+++ b/build-system/pr-check/bundle-size.js
@@ -52,10 +52,10 @@ function prBuildWorkflow() {
 }
 
 // TODO(rsimha): Remove this block once Travis is shut off.
-if (isTravisBuild()) {
+if (!isTravisBuild()) {
   printSkipMessage(
     jobName,
-    'this is a Travis build. Sizes will be reported from CircleCI'
+    'this is a CircleCI build. Sizes will be reported from Travis'
   );
   return;
 }

--- a/build-system/tasks/pr-deploy-bot-utils.js
+++ b/build-system/tasks/pr-deploy-bot-utils.js
@@ -70,7 +70,7 @@ async function replaceUrls(dir) {
 
 async function signalPrDeployUpload(result) {
   // TODO(rsimha): Remove this check once Travis is shut down.
-  if (isTravisBuild()) {
+  if (!isTravisBuild()) {
     return;
   }
   const loggingPrefix = getLoggingPrefix();


### PR DESCRIPTION
All experimentation with CircleCI is now complete. We will fully switch from Travis later this week. Until then, let's do all signaling of bundle-size / PR-deploy from Travis, since that's the blocking check.

