### PR TITLE
Pre-upgrade CSS for Bento as part of per-element stylesheets

### DIFF
--- a/build-system/compile/bundles.config.extensions.json
+++ b/build-system/compile/bundles.config.extensions.json
@@ -525,7 +525,12 @@
     "options": {"hasCss": true}
   },
   {"name": "amp-video", "version": "0.1", "latestVersion": "0.1"},
-  {"name": "amp-video", "version": "1.0", "latestVersion": "0.1"},
+  {
+    "name": "amp-video",
+    "version": "1.0",
+    "latestVersion": "0.1",
+    "options": {"hasCss": true}
+  },
   {
     "name": "amp-video-docking",
     "version": "0.1",
@@ -568,6 +573,11 @@
   },
   {"name": "amp-wistia-player", "version": "0.1", "latestVersion": "0.1"},
   {"name": "amp-yotpo", "version": "0.1", "latestVersion": "0.1"},
-  {"name": "amp-youtube", "version": "1.0", "latestVersion": "0.1"},
-  {"name": "amp-youtube", "version": "0.1", "latestVersion": "0.1"}
+  {"name": "amp-youtube", "version": "0.1", "latestVersion": "0.1"},
+  {
+    "name": "amp-youtube",
+    "version": "1.0",
+    "latestVersion": "0.1",
+    "options": {"hasCss": true}
+  }
 ]

--- a/build-system/compile/bundles.config.extensions.json
+++ b/build-system/compile/bundles.config.extensions.json
@@ -89,11 +89,10 @@
   },
   {
     "name": "amp-base-carousel",
-    "version": "0.1",
+    "version": ["0.1", "1.0"],
     "latestVersion": "0.1",
     "options": {"hasCss": true}
   },
-  {"name": "amp-base-carousel", "version": "1.0", "latestVersion": "0.1"},
   {"name": "amp-beopinion", "version": "0.1", "latestVersion": "0.1"},
   {"name": "amp-bind", "version": "0.1", "latestVersion": "0.1"},
   {"name": "amp-bodymovin-animation", "version": "0.1", "latestVersion": "0.1"},

--- a/build-system/compile/bundles.config.extensions.json
+++ b/build-system/compile/bundles.config.extensions.json
@@ -152,11 +152,10 @@
   {"name": "amp-facebook-page", "version": "0.1", "latestVersion": "0.1"},
   {
     "name": "amp-fit-text",
-    "version": "0.1",
+    "version": ["0.1", "1.0"],
     "latestVersion": "0.1",
     "options": {"hasCss": true}
   },
-  {"name": "amp-fit-text", "version": "1.0", "latestVersion": "0.1"},
   {"name": "amp-font", "version": "0.1", "latestVersion": "0.1"},
   {
     "name": "amp-form",
@@ -237,11 +236,10 @@
   },
   {
     "name": "amp-instagram",
-    "version": "0.1",
+    "version": ["0.1", "1.0"],
     "latestVersion": "0.1",
     "options": {"hasCss": true}
   },
-  {"name": "amp-instagram", "version": "1.0", "latestVersion": "0.1"},
   {
     "name": "amp-install-serviceworker",
     "version": "0.1",
@@ -257,13 +255,7 @@
   {"name": "amp-kaltura-player", "version": "0.1", "latestVersion": "0.1"},
   {
     "name": "amp-lightbox",
-    "version": "0.1",
-    "latestVersion": "0.1",
-    "options": {"hasCss": true}
-  },
-  {
-    "name": "amp-lightbox",
-    "version": "1.0",
+    "version": ["0.1", "1.0"],
     "latestVersion": "0.1",
     "options": {"hasCss": true}
   },
@@ -499,11 +491,10 @@
   },
   {
     "name": "amp-stream-gallery",
-    "version": "0.1",
+    "version": ["0.1", "1.0"],
     "latestVersion": "0.1",
     "options": {"hasCss": true}
   },
-  {"name": "amp-stream-gallery", "version": "1.0", "latestVersion": "0.1"},
   {
     "name": "amp-subscriptions",
     "version": "0.1",

--- a/examples/bento.amp.html
+++ b/examples/bento.amp.html
@@ -28,6 +28,7 @@
     }
 
     img {
+      display: block;
       width: 100%;
       height: auto;
     }

--- a/examples/bento.amp.html
+++ b/examples/bento.amp.html
@@ -47,7 +47,7 @@
     ></amp-social-share>
   </div>
 
-  <amp-base-carousel id="carousel-1" width="300" height="200" layout="responsive" loop="true">
+  <amp-base-carousel id="carousel-1" width="400" height="300" layout="responsive" loop="true">
     <img src="img/hero@1x.jpg">
     <img src="img/sea@1x.jpg">
   </amp-base-carousel>

--- a/examples/bento.amp.html
+++ b/examples/bento.amp.html
@@ -1,0 +1,78 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>Basic Bento example</title>
+  <link rel="canonical" href="amps.html" >
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <link href='https://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css'>
+  <link rel="stylesheet" type="text/css" href="/build/css/amp-base-carousel-1.0.css">
+  <link rel="stylesheet" type="text/css" href="/build/css/amp-social-share-1.0.css">
+  <link rel="stylesheet" type="text/css" href="/build/css/amp-accordion-1.0.css">
+  <script async custom-element="amp-base-carousel" src="https://cdn.ampproject.org/v0/amp-base-carousel-1.0.js"></script>
+  <script async custom-element="amp-accordion" src="https://cdn.ampproject.org/v0/amp-accordion-1.0.js"></script>
+  <script async custom-element="amp-social-share" src="https://cdn.ampproject.org/v0/amp-social-share-1.0.js"></script>
+  <style amp-custom>
+    body {
+      margin: 0;
+    }
+
+    amp-base-carousel img {
+      object-fit: cover;
+    }
+
+    amp-base-carousel {
+      width: 100%;
+      aspect-ratio: 4/3;
+      border: 1px dotted;
+    }
+
+    img {
+      width: 100%;
+      height: auto;
+    }
+  </style>
+</head>
+<body>
+
+  <nav>
+    <button onclick="runAmp()">Run</button>
+    <input>
+  </nav>
+
+  <div>
+    <amp-social-share
+      type=twitter
+    ></amp-social-share>
+  </div>
+
+  <amp-base-carousel id="carousel-1" width="300" height="200" layout="responsive" loop="true">
+    <img src="img/hero@1x.jpg">
+    <img src="img/sea@1x.jpg">
+  </amp-base-carousel>
+
+  <amp-accordion>
+    <section id="section1" expanded>
+      <h2>Hero</h2>
+      <div>
+        <img src="img/hero@1x.jpg">
+      </div>
+    </section>
+    <section>
+      <h2>Sea</h2>
+      <div>
+        <img src="img/sea@1x.jpg">
+      </div>
+    </section>
+  </amp-accordion>
+
+  <script>
+    function runAmp() {
+      var s = document.createElement('script');
+      s.src = '/dist/amp.js';
+      document.head.appendChild(s);
+    }
+  </script>
+
+</body>
+</html>

--- a/extensions/amp-accordion/1.0/amp-accordion.css
+++ b/extensions/amp-accordion/1.0/amp-accordion.css
@@ -14,6 +14,34 @@
  * limitations under the License.
  */
 
+/*
+ * Pre-upgrade:
+ * - display:block element
+ * - contain:layout element
+ */
+amp-accordion {
+  display: block;
+  contain: layout;
+}
+
+amp-accordion,
+amp-accordion > section,
+amp-accordion > section > :first-child {
+  margin: 0;
+}
+
+amp-accordion > section > :first-child {
+  border: 1px solid transparent;
+}
+
+/* Display the first 2 elements (heading and content) */
+amp-accordion > section > * {
+  display: block;
+  float: none;
+  overflow: hidden; /* clearfix */
+  position: relative;
+}
+
 /* heading
  * TODO(#30445): update these styles after team agrees on styling
  */
@@ -22,13 +50,9 @@
   background-color: #efefef;
   padding-right: 20px;
   border: solid 1px #dfdfdf;
-  margin: 0;
 }
 
-.i-amphtml-accordion-content {
-  margin: 0;
-}
-
+/* Collapse content by default. */
 amp-accordion > section:not([expanded]) > :last-child:not(.i-amphtml-animating),
 amp-accordion
   > section:not([expanded])

--- a/extensions/amp-accordion/1.0/amp-accordion.css
+++ b/extensions/amp-accordion/1.0/amp-accordion.css
@@ -30,16 +30,23 @@ amp-accordion > section > :first-child {
   margin: 0;
 }
 
-amp-accordion > section > :first-child {
-  border: 1px solid transparent;
-}
-
 /* Display the first 2 elements (heading and content) */
 amp-accordion > section > * {
   display: block;
   float: none;
   overflow: hidden; /* clearfix */
   position: relative;
+}
+
+/*
+ * Lowest-specificity UI styles. Mostly duplicated by the
+ * i-amphtml-accordion-header for cross-browser compatibility.
+ */
+:where(amp-accordion > section) > :first-child {
+  cursor: pointer;
+  background-color: #efefef;
+  padding-right: 20px;
+  border: 1px solid #dfdfdf;
 }
 
 /* heading
@@ -49,7 +56,7 @@ amp-accordion > section > * {
   cursor: pointer;
   background-color: #efefef;
   padding-right: 20px;
-  border: solid 1px #dfdfdf;
+  border: 1px solid #dfdfdf;
 }
 
 /* Collapse content by default. */

--- a/extensions/amp-base-carousel/1.0/amp-base-carousel.css
+++ b/extensions/amp-base-carousel/1.0/amp-base-carousel.css
@@ -27,6 +27,6 @@ amp-base-carousel {
 
 /* Pre-upgrade: size-defining element - hide children. */
 amp-base-carousel:not(.i-amphtml-built) > :not([placeholder]) {
-  display: none !important;
-  content-visibility: hidden !important;
+  display: none;
+  content-visibility: hidden;
 }

--- a/extensions/amp-base-carousel/1.0/amp-base-carousel.css
+++ b/extensions/amp-base-carousel/1.0/amp-base-carousel.css
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Pre-upgrade:
+ * - display:block element
+ * - contain:strict element
+ */
+amp-base-carousel {
+  display: block;
+  contain: strict;
+  overflow: hidden;
+  position: relative;
+}
+
+/* Pre-upgrade: size-defining element - hide children until build. */
+amp-base-carousel:not(.i-amphtml-built) > :not([placeholder]) {
+  display: none !important;
+  content-visibility: hidden !important;
+}

--- a/extensions/amp-base-carousel/1.0/amp-base-carousel.css
+++ b/extensions/amp-base-carousel/1.0/amp-base-carousel.css
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ * Copyright 2021 The AMP HTML Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ amp-base-carousel {
   position: relative;
 }
 
-/* Pre-upgrade: size-defining element - hide children until build. */
+/* Pre-upgrade: size-defining element - hide children. */
 amp-base-carousel:not(.i-amphtml-built) > :not([placeholder]) {
   display: none !important;
   content-visibility: hidden !important;

--- a/extensions/amp-base-carousel/1.0/amp-base-carousel.css
+++ b/extensions/amp-base-carousel/1.0/amp-base-carousel.css
@@ -17,11 +17,10 @@
 /*
  * Pre-upgrade:
  * - display:block element
- * - contain:strict element
+ * - size-defined element
  */
 amp-base-carousel {
   display: block;
-  contain: strict;
   overflow: hidden;
   position: relative;
 }

--- a/extensions/amp-base-carousel/1.0/amp-base-carousel.js
+++ b/extensions/amp-base-carousel/1.0/amp-base-carousel.js
@@ -16,7 +16,8 @@
 
 import {ActionTrust} from '../../../src/action-constants';
 import {BaseCarousel} from './base-carousel';
-import {CSS} from './base-carousel.jss';
+import {CSS as COMPONENT_CSS} from './base-carousel.jss';
+import {CSS} from '../../../build/amp-base-carousel-1.0.css';
 import {CarouselContextProp} from './carousel-props';
 import {PreactBaseElement} from '../../../src/preact/base-element';
 import {Services} from '../../../src/services';
@@ -140,7 +141,7 @@ AmpBaseCarousel['props'] = {
 };
 
 /** @override */
-AmpBaseCarousel['shadowCss'] = CSS;
+AmpBaseCarousel['shadowCss'] = COMPONENT_CSS;
 
 /** @override */
 AmpBaseCarousel['useContexts'] = [CarouselContextProp];
@@ -165,5 +166,5 @@ function fireSlideChangeEvent(win, el, index, trust) {
 }
 
 AMP.extension(TAG, '1.0', (AMP) => {
-  AMP.registerElement(TAG, AmpBaseCarousel);
+  AMP.registerElement(TAG, AmpBaseCarousel, CSS);
 });

--- a/extensions/amp-base-carousel/1.0/test-e2e/test-autoadvance.js
+++ b/extensions/amp-base-carousel/1.0/test-e2e/test-autoadvance.js
@@ -27,7 +27,7 @@ describes.endtoend(
       'http://localhost:8000/test/manual/amp-base-carousel/1.0/autoadvance.amp.html',
     experiments: ['bento-carousel'],
     initialRect: {width: pageWidth, height: pageHeight},
-    environments: ['single', 'viewer-demo'],
+    environments: ['single'/*QQQQ , 'viewer-demo' */],
   },
   async (env) => {
     let controller;
@@ -43,8 +43,10 @@ describes.endtoend(
       await controller.switchToShadowRoot(carousel);
     });
 
-    it('should move forwards', async () => {
+    it.only('should move forwards', async () => {
+      debugger;//QQQQQQQ
       const slides = await getSlides(styles, controller);
+      debugger;//QQQQQQQ
 
       await expect(rect(slides[1])).to.include({x: 0});
       await expect(rect(slides[2])).to.include({x: 0});

--- a/extensions/amp-base-carousel/1.0/test-e2e/test-autoadvance.js
+++ b/extensions/amp-base-carousel/1.0/test-e2e/test-autoadvance.js
@@ -27,7 +27,7 @@ describes.endtoend(
       'http://localhost:8000/test/manual/amp-base-carousel/1.0/autoadvance.amp.html',
     experiments: ['bento-carousel'],
     initialRect: {width: pageWidth, height: pageHeight},
-    environments: ['single'/*QQQQ , 'viewer-demo' */],
+    environments: ['single', 'viewer-demo'],
   },
   async (env) => {
     let controller;
@@ -43,10 +43,8 @@ describes.endtoend(
       await controller.switchToShadowRoot(carousel);
     });
 
-    it.only('should move forwards', async () => {
-      debugger;//QQQQQQQ
+    it('should move forwards', async () => {
       const slides = await getSlides(styles, controller);
-      debugger;//QQQQQQQ
 
       await expect(rect(slides[1])).to.include({x: 0});
       await expect(rect(slides[2])).to.include({x: 0});

--- a/extensions/amp-base-carousel/1.0/test-e2e/test-carousel.js
+++ b/extensions/amp-base-carousel/1.0/test-e2e/test-carousel.js
@@ -18,7 +18,7 @@ import {getCarousel, getScrollingElement, getSlide, getSlides} from './helpers';
 import {useStyles} from '../base-carousel.jss';
 
 const pageWidth = 800;
-const pageHeight = 600;
+const pageHeight = 800;
 
 /** Increase timeout for running on CircleCI **/
 const testTimeout = 40000;

--- a/extensions/amp-fit-text/1.0/amp-fit-text.css
+++ b/extensions/amp-fit-text/1.0/amp-fit-text.css
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ * Copyright 2021 The AMP HTML Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,29 +14,25 @@
  * limitations under the License.
  */
 
-/* Pre-upgrade: display:block element */
-amp-inline-gallery,
-amp-inline-gallery-pagination,
-amp-inline-gallery-thumbnails {
+/*
+ * Pre-upgrade:
+ * - display:block element
+ * - contain:strict element
+ */
+amp-fit-text {
   display: block;
-}
-
-/* Pre-upgrade: contain:layout element */
-amp-inline-gallery {
-  contain: layout;
-}
-
-/* Pre-upgrade: contain:strict element */
-amp-inline-gallery-pagination,
-amp-inline-gallery-thumbnails {
   contain: strict;
   overflow: hidden;
   position: relative;
 }
 
+/* Pre-upgrade: size-defining element - hide text. */
+amp-fit-text:not(.i-amphtml-built) {
+  color: transparent !important;
+}
+
 /* Pre-upgrade: size-defining element - hide children. */
-amp-inline-gallery-pagination:not(.i-amphtml-built) > :not([placeholder]),
-amp-inline-gallery-thumbnails:not(.i-amphtml-built) > :not([placeholder]) {
+amp-fit-text:not(.i-amphtml-built) > :not([placeholder]) {
   display: none !important;
   content-visibility: hidden !important;
 }

--- a/extensions/amp-fit-text/1.0/amp-fit-text.css
+++ b/extensions/amp-fit-text/1.0/amp-fit-text.css
@@ -32,6 +32,6 @@ amp-fit-text:not(.i-amphtml-built) {
 
 /* Pre-upgrade: size-defining element - hide children. */
 amp-fit-text:not(.i-amphtml-built) > :not([placeholder]) {
-  display: none !important;
-  content-visibility: hidden !important;
+  display: none;
+  content-visibility: hidden;
 }

--- a/extensions/amp-fit-text/1.0/amp-fit-text.css
+++ b/extensions/amp-fit-text/1.0/amp-fit-text.css
@@ -17,11 +17,10 @@
 /*
  * Pre-upgrade:
  * - display:block element
- * - contain:strict element
+ * - size-defined element
  */
 amp-fit-text {
   display: block;
-  contain: strict;
   overflow: hidden;
   position: relative;
 }

--- a/extensions/amp-fit-text/1.0/amp-fit-text.js
+++ b/extensions/amp-fit-text/1.0/amp-fit-text.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {CSS} from '../../../build/amp-fit-text-1.0.css';
 import {FitText} from './fit-text';
 import {PreactBaseElement} from '../../../src/preact/base-element';
 import {isExperimentOn} from '../../../src/experiments';
@@ -50,5 +51,5 @@ AmpFitText['passthrough'] = true;
 AmpFitText['layoutSizeDefined'] = true;
 
 AMP.extension(TAG, '1.0', (AMP) => {
-  AMP.registerElement(TAG, AmpFitText);
+  AMP.registerElement(TAG, AmpFitText, CSS);
 });

--- a/extensions/amp-inline-gallery/1.0/amp-inline-gallery.css
+++ b/extensions/amp-inline-gallery/1.0/amp-inline-gallery.css
@@ -26,10 +26,9 @@ amp-inline-gallery {
   contain: layout;
 }
 
-/* Pre-upgrade: contain:strict element */
+/* Pre-upgrade: size-defined element */
 amp-inline-gallery-pagination,
 amp-inline-gallery-thumbnails {
-  contain: strict;
   overflow: hidden;
   position: relative;
 }

--- a/extensions/amp-inline-gallery/1.0/amp-inline-gallery.css
+++ b/extensions/amp-inline-gallery/1.0/amp-inline-gallery.css
@@ -36,6 +36,6 @@ amp-inline-gallery-thumbnails {
 /* Pre-upgrade: size-defining element - hide children. */
 amp-inline-gallery-pagination:not(.i-amphtml-built) > :not([placeholder]),
 amp-inline-gallery-thumbnails:not(.i-amphtml-built) > :not([placeholder]) {
-  display: none !important;
-  content-visibility: hidden !important;
+  display: none;
+  content-visibility: hidden;
 }

--- a/extensions/amp-instagram/1.0/amp-instagram.css
+++ b/extensions/amp-instagram/1.0/amp-instagram.css
@@ -17,11 +17,10 @@
 /*
  * Pre-upgrade:
  * - display:block element
- * - contain:strict element
+ * - size-defined element
  */
 amp-instagram {
   display: block;
-  contain: strict;
   overflow: hidden;
   position: relative;
 }

--- a/extensions/amp-instagram/1.0/amp-instagram.css
+++ b/extensions/amp-instagram/1.0/amp-instagram.css
@@ -27,6 +27,6 @@ amp-instagram {
 
 /* Pre-upgrade: size-defining element - hide children. */
 amp-instagram:not(.i-amphtml-built) > :not([placeholder]) {
-  display: none !important;
-  content-visibility: hidden !important;
+  display: none;
+  content-visibility: hidden;
 }

--- a/extensions/amp-instagram/1.0/amp-instagram.css
+++ b/extensions/amp-instagram/1.0/amp-instagram.css
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ * Copyright 2021 The AMP HTML Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,29 +17,11 @@
 /*
  * Pre-upgrade:
  * - display:block element
+ * - contain:strict element
  */
-amp-selector {
+amp-instagram {
   display: block;
-}
-
-amp-selector [option] {
-  cursor: pointer;
-}
-
-amp-selector[multiple] [option][selected] {
-  cursor: pointer;
-  outline: solid 1px rgba(0, 0, 0, 0.7);
-}
-
-amp-selector [option][selected] {
-  cursor: auto;
-  outline: solid 1px rgba(0, 0, 0, 0.7);
-}
-
-amp-selector [disabled][option],
-amp-selector[disabled] [option],
-amp-selector [selected][disabled],
-amp-selector[disabled] [selected] {
-  cursor: auto;
-  outline: none;
+  contain: strict;
+  overflow: hidden;
+  position: relative;
 }

--- a/extensions/amp-instagram/1.0/amp-instagram.js
+++ b/extensions/amp-instagram/1.0/amp-instagram.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {CSS} from '../../../build/amp-instagram-1.0.css';
 import {Instagram} from './instagram';
 import {PreactBaseElement} from '../../../src/preact/base-element';
 import {dict} from '../../../src/utils/object';
@@ -64,5 +65,5 @@ AmpInstagram['props'] = {
 AmpInstagram['layoutSizeDefined'] = true;
 
 AMP.extension(TAG, '1.0', (AMP) => {
-  AMP.registerElement(TAG, AmpInstagram);
+  AMP.registerElement(TAG, AmpInstagram, CSS);
 });

--- a/extensions/amp-lightbox/1.0/amp-lightbox.css
+++ b/extensions/amp-lightbox/1.0/amp-lightbox.css
@@ -14,6 +14,11 @@
  * limitations under the License.
  */
 
+/* Pre-upgrade: not displayed */
+amp-lightbox[hidden] {
+  display: none !important;
+}
+
 amp-lightbox {
   width: 100%;
   height: 100%;
@@ -21,7 +26,7 @@ amp-lightbox {
   box-sizing: border-box;
   background-color: rgba(0, 0, 0, 0.9);
   color: white;
-  /* Note: visibility: hidden is applied to this layer to allow the 
+  /* Note: visibility: hidden is applied to this layer to allow the
      Preact layer to fully control animation transitions. */
   visibility: hidden;
 }
@@ -30,7 +35,7 @@ amp-lightbox::part(lightbox) {
   /* Note: background should be applied/inherited by all elements
     in amp-lightbox > c > [part=lightbox] because:
      - amp-lightbox does not show a background due to visibility: hidden
-     - c does not paint a background due to display: contents 
+     - c does not paint a background due to display: contents
      - therefore only [part] visibly applies the background value */
   background: inherit;
   color: inherit;

--- a/extensions/amp-sidebar/1.0/amp-sidebar.css
+++ b/extensions/amp-sidebar/1.0/amp-sidebar.css
@@ -14,13 +14,18 @@
  * limitations under the License.
  */
 
+/* Pre-upgrade: not displayed */
+amp-sidebar[hidden] {
+  display: none !important;
+}
+
 amp-sidebar {
   color: black;
   background-color: #efefef;
   height: 100vh;
   top: 0;
   max-height: 100vh !important;
-  /** 
+  /**
    * Max width allowed to be configurable by user.  If user wants width to be
    * controlled by content size and max-width, then this property needs to be
    * configurable.
@@ -50,7 +55,7 @@ amp-sidebar::part(sidebar) {
   border: inherit;
 }
 
-/** 
+/**
  * Hide the amp-sidebar and remove from the flow of the page so user applied
  * styling is not shown directly on amp-sidebar element.
  */
@@ -59,9 +64,9 @@ amp-sidebar {
   position: fixed !important;
 }
 
-/** 
+/**
  * The host element, amp-sidebar, is not visible to allow direct styling to be
- * inherited by its children.  Its children should be visible so the styling 
+ * inherited by its children.  Its children should be visible so the styling
  * is displayed.
  */
 amp-sidebar::part(c) {

--- a/extensions/amp-social-share/1.0/amp-social-share.css
+++ b/extensions/amp-social-share/1.0/amp-social-share.css
@@ -17,12 +17,11 @@
 /*
  * Pre-upgrade:
  * - display:inline-block element
- * - contain:strict element
+ * - size-defined element
  * - predefined default size
  */
 amp-social-share {
   display: inline-block;
-  contain: strict;
   overflow: hidden;
   position: relative;
   box-sizing: border-box;

--- a/extensions/amp-social-share/1.0/amp-social-share.css
+++ b/extensions/amp-social-share/1.0/amp-social-share.css
@@ -14,6 +14,28 @@
  * limitations under the License.
  */
 
+/*
+ * Pre-upgrade:
+ * - display:inline-block element
+ * - contain:strict element
+ * - predefined default size
+ */
+amp-social-share {
+  display: inline-block;
+  contain: strict;
+  overflow: hidden;
+  position: relative;
+  box-sizing: border-box;
+  width: 60px;
+  height: 44px;
+}
+
+/* Pre-upgrade: size-defining element - hide children until build. */
+amp-social-share:not(.i-amphtml-built) > :not([placeholder]) {
+  display: none !important;
+  content-visibility: hidden !important;
+}
+
 /**
   * Note: Attribute selectors were used initially here but we switched to using
   * class-based selector to style each type because of a bug on iOS Safari 8.

--- a/extensions/amp-social-share/1.0/amp-social-share.css
+++ b/extensions/amp-social-share/1.0/amp-social-share.css
@@ -31,8 +31,8 @@ amp-social-share {
 
 /* Pre-upgrade: size-defining element - hide children until build. */
 amp-social-share:not(.i-amphtml-built) > :not([placeholder]) {
-  display: none !important;
-  content-visibility: hidden !important;
+  display: none;
+  content-visibility: hidden;
 }
 
 /**

--- a/extensions/amp-stream-gallery/1.0/amp-stream-gallery.css
+++ b/extensions/amp-stream-gallery/1.0/amp-stream-gallery.css
@@ -27,6 +27,6 @@ amp-stream-gallery {
 
 /* Pre-upgrade: size-defining element - hide children. */
 amp-stream-gallery:not(.i-amphtml-built) > :not([placeholder]) {
-  display: none !important;
-  content-visibility: hidden !important;
+  display: none;
+  content-visibility: hidden;
 }

--- a/extensions/amp-stream-gallery/1.0/amp-stream-gallery.css
+++ b/extensions/amp-stream-gallery/1.0/amp-stream-gallery.css
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ * Copyright 2021 The AMP HTML Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,29 +14,20 @@
  * limitations under the License.
  */
 
-/* Pre-upgrade: display:block element */
-amp-inline-gallery,
-amp-inline-gallery-pagination,
-amp-inline-gallery-thumbnails {
+/*
+ * Pre-upgrade:
+ * - display:block element
+ * - contain:strict element
+ */
+amp-stream-gallery {
   display: block;
-}
-
-/* Pre-upgrade: contain:layout element */
-amp-inline-gallery {
-  contain: layout;
-}
-
-/* Pre-upgrade: contain:strict element */
-amp-inline-gallery-pagination,
-amp-inline-gallery-thumbnails {
   contain: strict;
   overflow: hidden;
   position: relative;
 }
 
 /* Pre-upgrade: size-defining element - hide children. */
-amp-inline-gallery-pagination:not(.i-amphtml-built) > :not([placeholder]),
-amp-inline-gallery-thumbnails:not(.i-amphtml-built) > :not([placeholder]) {
+amp-stream-gallery:not(.i-amphtml-built) > :not([placeholder]) {
   display: none !important;
   content-visibility: hidden !important;
 }

--- a/extensions/amp-stream-gallery/1.0/amp-stream-gallery.css
+++ b/extensions/amp-stream-gallery/1.0/amp-stream-gallery.css
@@ -17,11 +17,10 @@
 /*
  * Pre-upgrade:
  * - display:block element
- * - contain:strict element
+ * - size-defined element
  */
 amp-stream-gallery {
   display: block;
-  contain: strict;
   overflow: hidden;
   position: relative;
 }

--- a/extensions/amp-stream-gallery/1.0/amp-stream-gallery.js
+++ b/extensions/amp-stream-gallery/1.0/amp-stream-gallery.js
@@ -16,6 +16,7 @@
 
 import {ActionTrust} from '../../../src/action-constants';
 import {CSS as CAROUSEL_CSS} from '../../amp-base-carousel/1.0/base-carousel.jss';
+import {CSS} from '../../../build/amp-stream-gallery-1.0.css';
 import {CSS as GALLERY_CSS} from './stream-gallery.jss';
 import {PreactBaseElement} from '../../../src/preact/base-element';
 import {Services} from '../../../src/services';
@@ -123,5 +124,5 @@ AmpStreamGallery['props'] = {
 AmpStreamGallery['shadowCss'] = GALLERY_CSS + CAROUSEL_CSS;
 
 AMP.extension(TAG, '1.0', (AMP) => {
-  AMP.registerElement(TAG, AmpStreamGallery);
+  AMP.registerElement(TAG, AmpStreamGallery, CSS);
 });

--- a/extensions/amp-video/1.0/amp-video.css
+++ b/extensions/amp-video/1.0/amp-video.css
@@ -19,7 +19,7 @@
  * - display:block element
  * - contain:strict element
  */
-amp-instagram {
+amp-video {
   display: block;
   contain: strict;
   overflow: hidden;
@@ -27,7 +27,7 @@ amp-instagram {
 }
 
 /* Pre-upgrade: size-defining element - hide children. */
-amp-instagram:not(.i-amphtml-built) > :not([placeholder]) {
+amp-video:not(.i-amphtml-built) > :not([placeholder]) {
   display: none !important;
   content-visibility: hidden !important;
 }

--- a/extensions/amp-video/1.0/amp-video.css
+++ b/extensions/amp-video/1.0/amp-video.css
@@ -27,6 +27,6 @@ amp-video {
 
 /* Pre-upgrade: size-defining element - hide children. */
 amp-video:not(.i-amphtml-built) > :not([placeholder]) {
-  display: none !important;
-  content-visibility: hidden !important;
+  display: none;
+  content-visibility: hidden;
 }

--- a/extensions/amp-video/1.0/amp-video.css
+++ b/extensions/amp-video/1.0/amp-video.css
@@ -17,11 +17,10 @@
 /*
  * Pre-upgrade:
  * - display:block element
- * - contain:strict element
+ * - size-defined element
  */
 amp-video {
   display: block;
-  contain: strict;
   overflow: hidden;
   position: relative;
 }

--- a/extensions/amp-video/1.0/amp-video.js
+++ b/extensions/amp-video/1.0/amp-video.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {CSS} from '../../../build/amp-video-1.0.css';
 import {VideoBaseElement} from './base-element';
 import {isExperimentOn} from '../../../src/experiments';
 import {userAssert} from '../../../src/log';
@@ -34,5 +35,5 @@ class AmpVideo extends VideoBaseElement {
 }
 
 AMP.extension(TAG, '1.0', (AMP) => {
-  AMP.registerElement(TAG, AmpVideo);
+  AMP.registerElement(TAG, AmpVideo, CSS);
 });

--- a/extensions/amp-youtube/1.0/amp-youtube.css
+++ b/extensions/amp-youtube/1.0/amp-youtube.css
@@ -19,7 +19,7 @@
  * - display:block element
  * - contain:strict element
  */
-amp-instagram {
+amp-youtube {
   display: block;
   contain: strict;
   overflow: hidden;
@@ -27,7 +27,7 @@ amp-instagram {
 }
 
 /* Pre-upgrade: size-defining element - hide children. */
-amp-instagram:not(.i-amphtml-built) > :not([placeholder]) {
+amp-youtube:not(.i-amphtml-built) > :not([placeholder]) {
   display: none !important;
   content-visibility: hidden !important;
 }

--- a/extensions/amp-youtube/1.0/amp-youtube.css
+++ b/extensions/amp-youtube/1.0/amp-youtube.css
@@ -27,6 +27,6 @@ amp-youtube {
 
 /* Pre-upgrade: size-defining element - hide children. */
 amp-youtube:not(.i-amphtml-built) > :not([placeholder]) {
-  display: none !important;
-  content-visibility: hidden !important;
+  display: none;
+  content-visibility: hidden;
 }

--- a/extensions/amp-youtube/1.0/amp-youtube.css
+++ b/extensions/amp-youtube/1.0/amp-youtube.css
@@ -17,11 +17,10 @@
 /*
  * Pre-upgrade:
  * - display:block element
- * - contain:strict element
+ * - size-defined element
  */
 amp-youtube {
   display: block;
-  contain: strict;
   overflow: hidden;
   position: relative;
 }

--- a/extensions/amp-youtube/1.0/amp-youtube.js
+++ b/extensions/amp-youtube/1.0/amp-youtube.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {CSS} from '../../../build/amp-youtube-1.0.css';
 import {VideoBaseElement} from '../../amp-video/1.0/base-element';
 import {Youtube} from './youtube';
 import {isExperimentOn} from '../../../src/experiments';
@@ -50,5 +51,5 @@ AmpYoutube['props'] = {
 };
 
 AMP.extension(TAG, '1.0', (AMP) => {
-  AMP.registerElement(TAG, AmpYoutube);
+  AMP.registerElement(TAG, AmpYoutube, CSS);
 });


### PR DESCRIPTION
Partial for #32155.

This is an alternative to the #32157. Unlike the #32157, this pull request places the pre-upgrade CSS in the each element's stylesheet. Thus the use of an element will look like this:

```
<head>
  <link rel="stylesheet" type="text/css" href="https://cdn.ampproject.org/v0/amp-base-carousel-1.0.css">
  <script async custom-element="amp-base-carousel" src="https://cdn.ampproject.org/v0/amp-base-carousel-1.0.js"></script>
</head>
```

One inconvenience - a developer would have to ensure manually that stylesheets are included before any custom styles since order-based specificity is important for something like this.

This solution is pretty economical, you'd notice that the only real "annoying" duplicative piece here is this fragment:

```
amp-foo:not(.i-amphtml-built) > :not([placeholder]) {
  display: none !important;
  content-visibility: hidden !important;
}
```

However, I think it's well justified.
