### PR TITLE
🐛  Use anchor tags outside tooltip for linking

### DIFF
--- a/examples/amp-story/analytics.html
+++ b/examples/amp-story/analytics.html
@@ -106,6 +106,16 @@
                 "on": "story-audio-unmuted",
                 "request": "pageView"
               }
+            },
+            "linkers": {
+              "enabled": true,
+              "destinationDomains": ["google.com"],
+              "proxyOnly": false,
+              "linker": {
+                "ids": {
+                  "cid": "CLIENT_ID(cid)"
+                }
+              }
             }
           }
         </script>
@@ -134,10 +144,10 @@
       <amp-story-page id="p3">
         <amp-story-grid-layer template="vertical">
           <h1>Page Three</h1>
-          <a href="google.com">click me</a>
+          <a href="https://google.com">tooltip link</a>
         </amp-story-grid-layer>
         <amp-story-cta-layer>
-          <a>click me</a>
+          <a href="https://google.com">CTA link</a>
         </amp-story-cta-layer>
       </amp-story-page>
 

--- a/extensions/amp-story/1.0/amp-story-embedded-component.js
+++ b/extensions/amp-story/1.0/amp-story-embedded-component.js
@@ -38,7 +38,11 @@ import {
   matches,
   tryFocus,
 } from '../../../src/dom';
-import {createShadowRootWithStyle, getSourceOriginForElement} from './utils';
+import {
+  clickAnchorOnDom,
+  createShadowRootWithStyle,
+  getSourceOriginForElement,
+} from './utils';
 import {dev, devAssert, user, userAssert} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
 import {getAmpdoc} from '../../../src/service';
@@ -1457,16 +1461,13 @@ export class AmpStoryEmbeddedComponent {
   }
 
   /**
-   * Linkers don't work on shadow root elements so we need to create an anchor outside it.
+   * Linkers don't work on shadow root elements so we click a clone of the anchor on the root dom.
    * @param {!Event} event
    * @private
    */
   onAnchorClick_(event) {
     event.preventDefault();
-    const outerAnchor = this.tooltip_.cloneNode();
-    this.storyEl_.appendChild(outerAnchor);
-    outerAnchor.click();
-    outerAnchor.remove();
+    clickAnchorOnDom(this.tooltip_, this.storyEl_);
   }
 
   /**

--- a/extensions/amp-story/1.0/amp-story-embedded-component.js
+++ b/extensions/amp-story/1.0/amp-story-embedded-component.js
@@ -1463,10 +1463,8 @@ export class AmpStoryEmbeddedComponent {
    */
   onAnchorClick_(event) {
     event.preventDefault();
-    const outerAnchor = this.win_.document.createElement('a');
-    outerAnchor.href = this.tooltip_.href;
-    outerAnchor.target = this.tooltip_.target;
-    this.win_.document.appendChild(outerAnchor);
+    const outerAnchor = this.tooltip_.cloneNode();
+    this.storyEl_.appendChild(outerAnchor);
     outerAnchor.click();
     outerAnchor.remove();
   }

--- a/extensions/amp-story/1.0/amp-story-embedded-component.js
+++ b/extensions/amp-story/1.0/amp-story-embedded-component.js
@@ -39,9 +39,9 @@ import {
   tryFocus,
 } from '../../../src/dom';
 import {
-  clickAnchorOnDom,
   createShadowRootWithStyle,
   getSourceOriginForElement,
+  triggerClickFromLightDom,
 } from './utils';
 import {dev, devAssert, user, userAssert} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
@@ -1467,7 +1467,7 @@ export class AmpStoryEmbeddedComponent {
    */
   onAnchorClick_(event) {
     event.preventDefault();
-    clickAnchorOnDom(this.tooltip_, this.storyEl_);
+    triggerClickFromLightDom(this.tooltip_, this.storyEl_);
   }
 
   /**

--- a/extensions/amp-story/1.0/amp-story-embedded-component.js
+++ b/extensions/amp-story/1.0/amp-story-embedded-component.js
@@ -724,6 +724,7 @@ export class AmpStoryEmbeddedComponent {
           StoryAnalyticsEvent.CLICK_THROUGH,
           this.triggeringTarget_
         );
+        this.tooltip_.href && this.onAnchorClick_(event);
       },
       true /** capture */
     );
@@ -1453,6 +1454,21 @@ export class AmpStoryEmbeddedComponent {
       undefined,
       {bubbles: true}
     );
+  }
+
+  /**
+   * Linkers don't work on shadow root elements so we need to create an anchor outside it.
+   * @param {!Event} event
+   * @private
+   */
+  onAnchorClick_(event) {
+    event.preventDefault();
+    const outerAnchor = this.win_.document.createElement('a');
+    outerAnchor.href = this.tooltip_.href;
+    outerAnchor.target = this.tooltip_.target;
+    this.win_.document.appendChild(outerAnchor);
+    outerAnchor.click();
+    outerAnchor.remove();
   }
 
   /**

--- a/extensions/amp-story/1.0/utils.js
+++ b/extensions/amp-story/1.0/utils.js
@@ -26,7 +26,7 @@ import {
   isProxyOrigin,
   resolveRelativeUrl,
 } from '../../../src/url';
-import {setImportantStyles, setStyle, toggle} from '../../../src/style';
+import {setStyle, toggle} from '../../../src/style';
 import {user, userAssert} from '../../../src/log';
 
 /**

--- a/extensions/amp-story/1.0/utils.js
+++ b/extensions/amp-story/1.0/utils.js
@@ -287,12 +287,12 @@ export function setTextBackgroundColor(element) {
 }
 
 /**
- * Click a clone of the anchor passed in the context of the domElement.
- * Used to apply linker logic on shadow-dom anchors
+ * Click a clone of the anchor in the context of the light dom.
+ * Used to apply linker logic on shadow-dom anchors.
  * @param {!Element} anchorElement
- * @param {!Element} domElement
+ * @param {!Element} domElement element from the light dom
  */
-export function clickAnchorOnDom(anchorElement, domElement) {
+export function triggerClickFromLightDom(anchorElement, domElement) {
   const outerAnchor = anchorElement.cloneNode();
   toggle(outerAnchor, false);
   domElement.appendChild(outerAnchor);

--- a/extensions/amp-story/1.0/utils.js
+++ b/extensions/amp-story/1.0/utils.js
@@ -26,7 +26,7 @@ import {
   isProxyOrigin,
   resolveRelativeUrl,
 } from '../../../src/url';
-import {setStyle} from '../../../src/style';
+import {setImportantStyles, setStyle, toggle} from '../../../src/style';
 import {user, userAssert} from '../../../src/log';
 
 /**
@@ -284,4 +284,18 @@ export function setTextBackgroundColor(element) {
     const color = el.getAttribute(TEXT_BACKGROUND_COLOR_ATTRIBUTE_NAME);
     setStyle(el, 'background-color', color);
   });
+}
+
+/**
+ * Click a clone of the anchor passed in the context of the domElement.
+ * Used to apply linker logic on shadow-dom anchors
+ * @param {!Element} anchorElement
+ * @param {!Element} domElement
+ */
+export function clickAnchorOnDom(anchorElement, domElement) {
+  const outerAnchor = anchorElement.cloneNode();
+  toggle(outerAnchor, false);
+  domElement.appendChild(outerAnchor);
+  outerAnchor.click();
+  outerAnchor.remove();
 }


### PR DESCRIPTION
Linker cannot access anchor tag from tooltip since it's inside the shadow dom, so we create an anchor outside the shadow root and click it when the tooltip is clicked. Creating the tag and clicking it is considered a trusted user interaction since it's called inside the original click event listener

Demo at https://stories-demos-matias.web.app/examples/amp-story/analytics.html#page=p3. Clicking on the bottom and top links adds the cid to the url

Closes #32060