### PR TITLE
InOb: Force polyfill for WebKit document=root

### DIFF
--- a/src/polyfillstub/intersection-observer-stub.js
+++ b/src/polyfillstub/intersection-observer-stub.js
@@ -45,7 +45,7 @@ export function shouldLoadPolyfill(win) {
 }
 
 /**
- * All current (as of Safari 14.x) {root:document} IntersectionObservers
+ * All current WebIKit (as of Safari 14.x) {root:document} IntersectionObservers
  * will report incorrect rootBounds, intersectionRect, and intersectionRatios
  * and therefore we force the polyfill in this case.
  * See: https://bugs.webkit.org/show_bug.cgi?id=219495.
@@ -54,8 +54,8 @@ export function shouldLoadPolyfill(win) {
  * @return {boolean}
  */
 function isWebkit(win) {
-  const platform = Services.platformFor(win);
-  return platform.isIos() || platform.isSafari();
+  // navigator.vendor is always "Apple Computer, Inc." for all iOS browsers and Mac OS Safari.
+  return /apple/i.test(win.navigator.vendor);
 }
 
 /**

--- a/src/polyfillstub/intersection-observer-stub.js
+++ b/src/polyfillstub/intersection-observer-stub.js
@@ -54,8 +54,8 @@ export function shouldLoadPolyfill(win) {
  * @return {boolean}
  */
 function isWebkit(win) {
-  const ua = win.navigator && win.navigator.userAgent;
-  return /WebKit/.test(ua);
+  const platform = Services.platformFor(win);
+  return platform.isIos() || platform.isSafari();
 }
 
 /**

--- a/src/polyfillstub/intersection-observer-stub.js
+++ b/src/polyfillstub/intersection-observer-stub.js
@@ -45,7 +45,7 @@ export function shouldLoadPolyfill(win) {
 }
 
 /**
- * All current WebIKit (as of Safari 14.x) {root:document} IntersectionObservers
+ * All current WebKit (as of Safari 14.x) {root:document} IntersectionObservers
  * will report incorrect rootBounds, intersectionRect, and intersectionRatios
  * and therefore we force the polyfill in this case.
  * See: https://bugs.webkit.org/show_bug.cgi?id=219495.

--- a/src/polyfillstub/intersection-observer-stub.js
+++ b/src/polyfillstub/intersection-observer-stub.js
@@ -51,6 +51,7 @@ export function shouldLoadPolyfill(win) {
  * See: https://bugs.webkit.org/show_bug.cgi?id=219495.
  *
  * @param {!Window} win
+ * @return {boolean}
  */
 function isWebkit(win) {
   const ua = win.navigator && win.navigator.userAgent;

--- a/src/polyfillstub/intersection-observer-stub.js
+++ b/src/polyfillstub/intersection-observer-stub.js
@@ -39,8 +39,22 @@ export function shouldLoadPolyfill(win) {
     !win.IntersectionObserver ||
     !win.IntersectionObserverEntry ||
     !!win.IntersectionObserver[STUB] ||
-    !supportsDocumentRoot(win)
+    !supportsDocumentRoot(win) ||
+    isWebkit(win)
   );
+}
+
+/**
+ * All current (as of Safari 14.x) {root:document} IntersectionObservers
+ * will report incorrect rootBounds, intersectionRect, and intersectionRatios
+ * and therefore we force the polyfill in this case.
+ * See: https://bugs.webkit.org/show_bug.cgi?id=219495.
+ *
+ * @param {!Window} win
+ */
+function isWebkit(win) {
+  const ua = win.navigator && win.navigator.userAgent;
+  return /WebKit/.test(ua);
 }
 
 /**

--- a/src/service.js
+++ b/src/service.js
@@ -353,7 +353,6 @@ function getAmpdocService(win) {
  * @param {!Object} holder Object holding the service instance.
  * @param {string} id of the service.
  * @return {Object}
- * @template T
  */
 function getServiceInternal(holder, id) {
   devAssert(

--- a/test/unit/polyfills/test-intersection-observer.js
+++ b/test/unit/polyfills/test-intersection-observer.js
@@ -60,6 +60,9 @@ class NativeIntersectionObserverEntry {
   get isIntersecting() {}
 }
 
+const APPLE_NAVIGATOR = {vendor: 'Apple Computer, Inc.'};
+const CHROME_NAVIGATOR = {vendor: 'Google Inc.'};
+
 describes.sandboxed('shouldLoadPolyfill', {}, (env) => {
   let isIos;
   let isSafari;
@@ -74,6 +77,7 @@ describes.sandboxed('shouldLoadPolyfill', {}, (env) => {
     const win = {
       IntersectionObserver: NativeIntersectionObserver,
       IntersectionObserverEntry: NativeIntersectionObserverEntry,
+      navigator: CHROME_NAVIGATOR,
     };
     expect(shouldLoadPolyfill(win)).to.be.false;
   });
@@ -82,19 +86,11 @@ describes.sandboxed('shouldLoadPolyfill', {}, (env) => {
     const win = {
       IntersectionObserver: NativeIntersectionObserver,
       IntersectionObserverEntry: NativeIntersectionObserverEntry,
+      navigator: CHROME_NAVIGATOR,
     };
     expect(shouldLoadPolyfill(win)).to.be.false;
 
-    isIos = true;
-    isSafari = false;
-    expect(shouldLoadPolyfill(win)).to.be.true;
-
-    isIos = false;
-    isSafari = true;
-    expect(shouldLoadPolyfill(win)).to.be.true;
-
-    isIos = true;
-    isSafari = true;
+    win.navigator = APPLE_NAVIGATOR;
     expect(shouldLoadPolyfill(win)).to.be.true;
   });
 
@@ -110,6 +106,7 @@ describes.sandboxed('shouldLoadPolyfill', {}, (env) => {
       IntersectionObserver: NativeNoDocumentRoot,
       IntersectionObserverEntry: NativeIntersectionObserverEntry,
       document: {nodeType: 9},
+      navigator: CHROME_NAVIGATOR,
     };
     expect(shouldLoadPolyfill(win)).to.be.true;
   });
@@ -123,6 +120,7 @@ describes.sandboxed('shouldLoadPolyfill', {}, (env) => {
     const win = {
       IntersectionObserver: IntersectionObserverStub,
       IntersectionObserverEntry: NativeIntersectionObserverEntry,
+      navigator: CHROME_NAVIGATOR,
     };
     installStub(win);
     expect(shouldLoadPolyfill(win)).to.be.true;
@@ -131,6 +129,7 @@ describes.sandboxed('shouldLoadPolyfill', {}, (env) => {
   it('should load when no native entry', () => {
     const win = {
       IntersectionObserver: NativeIntersectionObserver,
+      navigator: CHROME_NAVIGATOR,
     };
     expect(shouldLoadPolyfill(win)).to.be.true;
   });

--- a/test/unit/polyfills/test-intersection-observer.js
+++ b/test/unit/polyfills/test-intersection-observer.js
@@ -21,6 +21,7 @@ import {
   shouldLoadPolyfill,
   upgradePolyfill,
 } from '../../../src/polyfillstub/intersection-observer-stub';
+import {Services} from '../../../src/services';
 import {
   install,
   installForChildWin,
@@ -59,22 +60,41 @@ class NativeIntersectionObserverEntry {
   get isIntersecting() {}
 }
 
-describes.sandboxed('shouldLoadPolyfill', {}, () => {
+describes.sandboxed('shouldLoadPolyfill', {}, (env) => {
+  let isIos;
+  let isSafari;
+  beforeEach(() => {
+    isIos = false;
+    isSafari = false;
+    const platform = {isIos: () => isIos, isSafari: () => isSafari};
+    env.sandbox.stub(Services, 'platformFor').returns(platform);
+  });
+
   it('should not load with native', () => {
     const win = {
       IntersectionObserver: NativeIntersectionObserver,
       IntersectionObserverEntry: NativeIntersectionObserverEntry,
-      navigator: {userAgent: 'Mozilla'},
     };
     expect(shouldLoadPolyfill(win)).to.be.false;
   });
 
-  it('should always load in WebKit', () => {
+  it('should always load in WebKit/Safari', () => {
     const win = {
       IntersectionObserver: NativeIntersectionObserver,
       IntersectionObserverEntry: NativeIntersectionObserverEntry,
-      navigator: {userAgent: 'WebKit'},
     };
+    expect(shouldLoadPolyfill(win)).to.be.false;
+
+    isIos = true;
+    isSafari = false;
+    expect(shouldLoadPolyfill(win)).to.be.true;
+
+    isIos = false;
+    isSafari = true;
+    expect(shouldLoadPolyfill(win)).to.be.true;
+
+    isIos = true;
+    isSafari = true;
     expect(shouldLoadPolyfill(win)).to.be.true;
   });
 

--- a/test/unit/polyfills/test-intersection-observer.js
+++ b/test/unit/polyfills/test-intersection-observer.js
@@ -64,8 +64,18 @@ describes.sandboxed('shouldLoadPolyfill', {}, () => {
     const win = {
       IntersectionObserver: NativeIntersectionObserver,
       IntersectionObserverEntry: NativeIntersectionObserverEntry,
+      navigator: {userAgent: 'Mozilla'},
     };
     expect(shouldLoadPolyfill(win)).to.be.false;
+  });
+
+  it('should always load in WebKit', () => {
+    const win = {
+      IntersectionObserver: NativeIntersectionObserver,
+      IntersectionObserverEntry: NativeIntersectionObserverEntry,
+      navigator: {userAgent: 'WebKit'},
+    };
+    expect(shouldLoadPolyfill(win)).to.be.true;
   });
 
   it('should load when native does not support {root: document}', () => {


### PR DESCRIPTION
**summary**
Due to a InOb WebKit bug (https://bugs.webkit.org/show_bug.cgi?id=219495), we should force the InOb polyfill for all WebKit-based browsers. The polyfill already will choose a Native InOb when available + non-document root is requested on a per-instance basis, which works well for this case.

Note: I've never written UA engine detection code before, so I'm still researching now to ensure `WebKit` is safe as a regex test.