### PR TITLE
🐛 [Story devtools] Fix player loop with timestamp

### DIFF
--- a/extensions/amp-story-dev-tools/0.1/amp-story-dev-tools-tab-preview.js
+++ b/extensions/amp-story-dev-tools/0.1/amp-story-dev-tools-tab-preview.js
@@ -570,8 +570,14 @@ export class AmpStoryDevToolsTabPreview extends AMP.BaseElement {
    *
    * A navigation event from a player can come from a user interaction or a previous programmatic call.
    * Expected navigation events from programmatic calls are stored in `this.expectedNavigationEvents_`,
-   * so they should not be propagated (but deleted from the list of expected events). If an event was not
-   * expected, it means it was user navigation and should be propagated to other players.
+   * so they should not be propagated (but deleted from the list of expected events).
+   *
+   * Behavior of expectedNavigationEvents:
+   * - If an event was not expected, it means it was user navigation and should be propagated to other players.
+   * - If an event was expected, sync the expected list up to that page by removing all the pages expected
+   * up to the one received in the navigation event. This clears any events that could be dispatched when the story
+   * was loading and never were executed.
+   *
    * @param {!Event} event
    * @param {!DeviceInfo} deviceSpecs
    * @private

--- a/extensions/amp-story-dev-tools/0.1/amp-story-dev-tools-tab-preview.js
+++ b/extensions/amp-story-dev-tools/0.1/amp-story-dev-tools-tab-preview.js
@@ -578,17 +578,20 @@ export class AmpStoryDevToolsTabPreview extends AMP.BaseElement {
    */
   onPlayerNavigation_(event, deviceSpecs) {
     const {pageId} = event.detail;
-    const pageIndex = this.expectedNavigationEvents_[
+    const pageIndexInExpectedList = this.expectedNavigationEvents_[
       deviceSpecs.name
     ].lastIndexOf(pageId);
-    if (pageIndex > -1) {
+    if (pageIndexInExpectedList > -1) {
       // Remove the expected events up to the most recently received event if it was in the list.
-      this.expectedNavigationEvents_[deviceSpecs.name].splice(0, pageIndex + 1);
+      this.expectedNavigationEvents_[deviceSpecs.name].splice(
+        0,
+        pageIndexInExpectedList + 1
+      );
       return;
     }
     this.devices_.forEach((d) => {
       if (d != deviceSpecs) {
-        d.player.show(null, event.detail.pageId);
+        d.player.show(/* storyUrl */ null, event.detail.pageId);
         this.expectedNavigationEvents_[d.name].push(pageId);
       }
     });

--- a/extensions/amp-story-dev-tools/0.1/amp-story-dev-tools-tab-preview.js
+++ b/extensions/amp-story-dev-tools/0.1/amp-story-dev-tools-tab-preview.js
@@ -571,7 +571,7 @@ export class AmpStoryDevToolsTabPreview extends AMP.BaseElement {
    * A navigation event from a player can come from a user interaction or a previous programmatic call.
    * Expected navigation events from programmatic calls are stored in `this.expectedNavigationEvents_`,
    * so they should not be propagated (but deleted from the list of expected events). If an event was not
-   * expected, it means it was user navigation and should be propagated to other players. Context #32189
+   * expected, it means it was user navigation and should be propagated to other players.
    * @param {!Event} event
    * @param {!DeviceInfo} deviceSpecs
    * @private


### PR DESCRIPTION
Closes #32106:
If you navigate fast on a player on the dev-tools, a second navigation on user input might get reported before a first navigation on the other players due to the programmatic navigation, so the programmatic advancement can trigger an endless loop of players updating each other between those two pages.

**Fix:** Skip the navigation events that are expected from when an API call was made. Each player will have a list of the navigation calls done that were not surfaced yet, adding a pageId to the list when calling `.show` and removing the pageId when receiving the `storyNavigation` event. If an event is not in the list, it must be a user interaction, so we propagate it to the other players.

Edge cases: If an unloaded player receives a `.show` event but is not ready to pass to the story, it will stay in the list indefinitely. To solve that, when receiving an expected event, we delete all the previous events to it (meaning that the player is synced up to the event received) instead of just removing the received event and keep any unmatched events.