### PR TITLE
🏗 Report test statuses from Travis until it is turned off

### DIFF
--- a/build-system/tasks/report-test-status.js
+++ b/build-system/tasks/report-test-status.js
@@ -40,7 +40,8 @@ const TEST_TYPE_SUBTYPES = isGithubActionsBuild()
       ['integration', ['firefox', 'safari', 'edge', 'ie']],
       ['unit', ['firefox', 'safari', 'edge']],
     ])
-  : isCircleciBuild()
+  : // TODO(rsimha): Remove `isTravisBuild()` condition once Travis is shut off.
+  isCircleciBuild() || isTravisBuild()
   ? new Map([
       ['integration', ['unminified', 'nomodule', 'module']],
       ['unit', ['unminified', 'local-changes']],
@@ -90,8 +91,8 @@ function inferTestType() {
 }
 
 async function postReport(type, action) {
-  // TODO(rsimha): Remove `!isTravisBuild()` condition once Travis is shut off.
-  if (type && isPullRequestBuild() && !isTravisBuild()) {
+  // TODO(rsimha): Remove `isTravisBuild()` condition once Travis is shut off.
+  if (type && isPullRequestBuild() && isTravisBuild()) {
     const commitHash = gitCommitHash();
 
     try {


### PR DESCRIPTION
The experimentation we were doing with CircleCI builds is now complete. This PR moves expected-test-status-reporting back to Travis until it is time to fully move off it later this month.
