### PR TITLE
🐛 [amp-base-carousel 0.1] Mixed length carousel disabled arrow calculations

### DIFF
--- a/extensions/amp-base-carousel/0.1/amp-base-carousel.js
+++ b/extensions/amp-base-carousel/0.1/amp-base-carousel.js
@@ -540,14 +540,17 @@ class AmpCarousel extends AMP.BaseElement {
     const index = this.carousel_.getCurrentIndex();
     const loop = this.carousel_.isLooping();
     const visibleCount = this.carousel_.getVisibleCount();
+    const isAtEnd = this.carousel_.isAtEnd();
+    const isAtStart = this.carousel_.isAtStart();
     // TODO(sparhami) for Shadow DOM, we will need to get the assigned nodes
     // instead.
     iterateCursor(this.prevArrowSlot_.children, (child) => {
-      const disabled = !loop && index === 0;
+      const disabled = (!loop && index === 0) || isAtStart;
       toggleAttribute(child, 'disabled', disabled);
     });
     iterateCursor(this.nextArrowSlot_.children, (child) => {
-      const disabled = !loop && index >= this.slides_.length - visibleCount;
+      const disabled =
+        (!loop && index >= this.slides_.length - visibleCount) || isAtEnd;
       toggleAttribute(child, 'disabled', disabled);
     });
     toggleAttribute(

--- a/extensions/amp-base-carousel/0.1/test-e2e/test-mixed-length-arrows.js
+++ b/extensions/amp-base-carousel/0.1/test-e2e/test-mixed-length-arrows.js
@@ -1,0 +1,91 @@
+/**
+ * Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {getNextArrow, getPrevArrow} from './helpers';
+
+describes.endtoend(
+  'amp-base-carousel:0.1 - mixed length carousel arrows',
+  {
+    testUrl:
+      'http://localhost:8000/test/manual/amp-base-carousel/no-arrows.amp.html',
+    environments: ['single'],
+  },
+  async function (env) {
+    let controller;
+    let prevArrow;
+    let nextArrow;
+
+    /**
+     * Attach an event listener to page to capture the 'slideChange' event.
+     * If given a selector, click on it to fire the event being listened for.
+     * @return {!Promise}
+     */
+    function slideChangeEventAfterClicking(opt_selector) {
+      return controller.evaluate((opt_selector) => {
+        return new Promise((resolve) => {
+          document.addEventListener(
+            'slideChange',
+            (e) => resolve(e.data),
+            {once: true} // Remove listener after first invocation
+          );
+          if (opt_selector) {
+            document.querySelector(opt_selector).click();
+          }
+        });
+      }, opt_selector);
+    }
+
+    beforeEach(async () => {
+      controller = env.controller;
+
+      nextArrow = await getNextArrow(controller);
+      prevArrow = await getPrevArrow(controller);
+    });
+
+    it('should not have arrows when at start or end', async () => {
+      await expect(
+        controller.getElementCssValue(prevArrow, 'opacity')
+      ).to.equal('0');
+      await expect(
+        controller.getElementCssValue(nextArrow, 'opacity')
+      ).to.equal('1');
+
+      // click next
+      await slideChangeEventAfterClicking(
+        '.i-amphtml-base-carousel-arrow-next-slot :first-child'
+      );
+
+      await expect(
+        controller.getElementCssValue(prevArrow, 'opacity')
+      ).to.equal('1');
+      await expect(
+        controller.getElementCssValue(nextArrow, 'opacity')
+      ).to.equal('0');
+
+      // click back
+      await slideChangeEventAfterClicking(
+        '.i-amphtml-base-carousel-arrow-prev-slot :first-child'
+      );
+
+      await expect(
+        controller.getElementCssValue(prevArrow, 'opacity')
+      ).to.equal('0');
+      await expect(
+        controller.getElementCssValue(nextArrow, 'opacity')
+      ).to.equal('1');
+    });
+  }
+);

--- a/test/manual/amp-base-carousel/no-arrows.amp.html
+++ b/test/manual/amp-base-carousel/no-arrows.amp.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>No arrows for mixed length</title>
+  <link rel="canonical" href="amps.html" >
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <link href='https://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css'>
+  <script async custom-element="amp-base-carousel" src="https://cdn.ampproject.org/v0/amp-base-carousel-0.1.js"></script>
+  <style amp-custom>
+    body {
+      max-width: 527px;
+    }
+    amp-base-carousel {
+      border: 1px solid #555;
+    }    
+    amp-base-carousel img {
+      object-fit: cover;
+    }
+    .slide {
+      width: 30%;
+      padding: 4px;
+    }
+  </style>
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+</head>
+<body>
+  <amp-base-carousel
+    id="carousel-1"
+    height="200"
+    layout="fixed-height"
+    loop="false"
+    mixed-length="true"
+  >
+    <amp-img class="slide" src="./img/redgradient.png" layout="flex-item"></amp-img>
+    <amp-img class="slide" src="./img/bluegradient.png" layout="flex-item"></amp-img>
+    <amp-img class="slide" src="./img/greengradient.png" layout="flex-item"></amp-img>
+    <amp-img class="slide" src="./img/orangegradient.png" layout="flex-item"></amp-img>
+ </amp-base-carousel>
+</body>
+</html>


### PR DESCRIPTION
Closes #32120

For mixed length carousels, we ignore visible count: https://amp.dev/documentation/components/amp-base-carousel/?format=websites#mixed-length

Therefore, we should not only use `visibleCount` in our arrow disabled calculations. We could eliminate `visibleCount` from our disabled calculations completely, but I think it's safer to keep in, seeing as it's a trivial calculation.