### PR TITLE
🐛 Fix video pausing itself after second layout

### DIFF
--- a/src/service/video-manager-impl.js
+++ b/src/service/video-manager-impl.js
@@ -275,9 +275,9 @@ export class VideoManager {
 
   /**
    * Returns the entry in the video manager corresponding to the video or
-   * element provided
+   * element provided, or null if unavailable.
    * @param {!../video-interface.VideoOrBaseElementDef|!Element} videoOrElement
-   * @return {VideoEntry} entry
+   * @return {?VideoEntry} entry
    */
   getEntryOrNull_(videoOrElement) {
     if (isEntryFor(this.lastFoundEntry_, videoOrElement)) {

--- a/src/service/video-manager-impl.js
+++ b/src/service/video-manager-impl.js
@@ -188,6 +188,13 @@ export class VideoManager {
     if (!video.supportsPlatform()) {
       return;
     }
+
+    this.entries_ = this.entries_ || [];
+
+    if (this.getEntryOrNull_(video)) {
+      return;
+    }
+
     if (!this.viewportObserver_) {
       const viewportCallback = (
         /** @type {!Array<!IntersectionObserverEntry>} */ records
@@ -205,12 +212,6 @@ export class VideoManager {
     }
     this.viewportObserver_.observe(videoBE.element);
     listen(videoBE.element, VideoEvents.RELOAD, () => entry.videoLoaded());
-
-    this.entries_ = this.entries_ || [];
-
-    if (this.getEntryOrNull_(video)) {
-      return;
-    }
 
     const entry = new VideoEntry(this, video);
     this.entries_.push(entry);

--- a/src/service/video-manager-impl.js
+++ b/src/service/video-manager-impl.js
@@ -189,9 +189,8 @@ export class VideoManager {
       return;
     }
 
-    this.entries_ = this.entries_ || [];
-
     if (this.getEntryOrNull_(video)) {
+      // already registered
       return;
     }
 
@@ -213,6 +212,7 @@ export class VideoManager {
     this.viewportObserver_.observe(videoBE.element);
     listen(videoBE.element, VideoEvents.RELOAD, () => entry.videoLoaded());
 
+    this.entries_ = this.entries_ || [];
     const entry = new VideoEntry(this, video);
     this.entries_.push(entry);
 
@@ -285,7 +285,7 @@ export class VideoManager {
       return this.lastFoundEntry_;
     }
 
-    for (let i = 0; i < this.entries_.length; i++) {
+    for (let i = 0; this.entries_ && i < this.entries_.length; i++) {
       const entry = this.entries_[i];
       if (isEntryFor(entry, videoOrElement)) {
         this.lastFoundEntry_ = entry;

--- a/src/service/video-manager-impl.js
+++ b/src/service/video-manager-impl.js
@@ -207,6 +207,11 @@ export class VideoManager {
     listen(videoBE.element, VideoEvents.RELOAD, () => entry.videoLoaded());
 
     this.entries_ = this.entries_ || [];
+
+    if (this.getEntryOrNull_(video)) {
+      return;
+    }
+
     const entry = new VideoEntry(this, video);
     this.entries_.push(entry);
 
@@ -274,7 +279,7 @@ export class VideoManager {
    * @param {!../video-interface.VideoOrBaseElementDef|!Element} videoOrElement
    * @return {VideoEntry} entry
    */
-  getEntry_(videoOrElement) {
+  getEntryOrNull_(videoOrElement) {
     if (isEntryFor(this.lastFoundEntry_, videoOrElement)) {
       return this.lastFoundEntry_;
     }
@@ -287,8 +292,18 @@ export class VideoManager {
       }
     }
 
+    return null;
+  }
+
+  /**
+   * Returns the entry in the video manager corresponding to the video or
+   * element provided
+   * @param {!../video-interface.VideoOrBaseElementDef|!Element} videoOrElement
+   * @return {VideoEntry} entry
+   */
+  getEntry_(videoOrElement) {
     return devAssert(
-      null,
+      this.getEntryOrNull_(videoOrElement),
       '%s not registered to VideoManager',
       videoOrElement.element || videoOrElement
     );

--- a/test/integration/test-video-manager.js
+++ b/test/integration/test-video-manager.js
@@ -61,6 +61,13 @@ describe
         let video;
         let impl;
 
+        it('should not duplicate entries if laid out twice', async () => {
+          videoManager.register(impl);
+          expect(videoManager.entries_).to.have.length(1);
+          videoManager.register(impl);
+          expect(videoManager.entries_).to.have.length(1);
+        });
+
         it('should receive i-amphtml-video-interface class when registered', () => {
           const expectedClass = 'i-amphtml-video-interface';
           expect(toArray(video.classList)).to.not.contain(expectedClass);


### PR DESCRIPTION
Fixes #32173

1. When closing a container lightbox, the `<amp-youtube>` element is unlaid out. 
2. When opening the lightbox a second time, the `<amp-youtube>` element is laid out again.

The `VideoManager` then incorrectly stores two entries. When playing for a second time it will `pauseOtherVideos()`, incorrectly pausing itself—so the video never plays.

The reused `VideoEntry` maintains its listeners at the e.g. `<amp-video>` level, so they continue to work.

<!--
# Instructions:

- Pick a meaningful title for your pull request. (Use sentence case.)
  - Prefix the title with an emoji to identify what is being done. (Copy-paste the emoji from the list below.)
  - Do not overuse punctuation in the title (like `(chore):`).
  - If it is helpful, use a simple prefix (like `ProjectX: Implement some feature`).
- Enter a succinct description that says why the PR is necessary, and what it does.
  - Mention the GitHub issue that is being addressed by the pull request.
  - The keywords `Fixes`, `Closes`, or `Resolves` followed the issue number will automatically close the issue.

> NOTE: All non-trivial changes (like introducing new features or components) should have an associated issue or reference an I2I (intent-to-implement: go.amp.dev/i2i). Please read through the contribution process (go.amp.dev/contributing/code) for more information.

# Example of a good description:

- Implement aspect X
- Leave out feature Y because of A
- Improve performance by B
- Improve accessibility by C

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Reverting a previous change
♻️ Refactoring
🚮 Deleting code
🧪 Experimental code
-->
