### PR TITLE
🐛 getUrl fix enabling shadow docs to have access to the article url and name #32188

### DIFF
--- a/examples/amp-smartlinks.html
+++ b/examples/amp-smartlinks.html
@@ -30,14 +30,14 @@
 	<h1>Hello from Narrativ</h1>
 	<amp-smartlinks
 			layout="nodisplay"
-			nrtv-account-name="amppublisher"
+			nrtv-account-name="sisterping"
 			linkmate
 			link-selector="a">
 	</amp-smartlinks>
 
 	<div class="linkmate-eligible-links">
-		<a href="https://www.exampleretailer.com/prod1234">Example Retailer</a>
-		<a href="https://www.exampleretailer.com/prod1234">Duplicate Example Retailer</a>
+		<a href="https://www.dermstore.com/product_PMD+Clean+Body_84631.htm">Example Retailer</a>
+		<a href="https://www.dermstore.com/product_PMD+Clean+Body_84631.htm">Duplicate Example Retailer</a>
 	</div>
 
 	<div class="linkmate-ineligible-links">

--- a/examples/amp-smartlinks.html
+++ b/examples/amp-smartlinks.html
@@ -30,14 +30,14 @@
 	<h1>Hello from Narrativ</h1>
 	<amp-smartlinks
 			layout="nodisplay"
-			nrtv-account-name="sisterping"
+			nrtv-account-name="amppublisher"
 			linkmate
 			link-selector="a">
 	</amp-smartlinks>
 
 	<div class="linkmate-eligible-links">
-		<a href="https://www.dermstore.com/product_PMD+Clean+Body_84631.htm">Example Retailer</a>
-		<a href="https://www.dermstore.com/product_PMD+Clean+Body_84631.htm">Duplicate Example Retailer</a>
+		<a href="https://www.exampleretailer.com/prod1234">Example Retailer</a>
+		<a href="https://www.exampleretailer.com/prod1234">Duplicate Example Retailer</a>
 	</div>
 
 	<div class="linkmate-ineligible-links">

--- a/extensions/amp-smartlinks/0.1/amp-smartlinks.js
+++ b/extensions/amp-smartlinks/0.1/amp-smartlinks.js
@@ -203,7 +203,7 @@ export class AmpSmartlinks extends AMP.BaseElement {
       'organization_type': 'publisher',
       'user': {
         'page_session_uuid': this.generateUUID_(),
-        'source_url': this.ampDoc_.getUrl(),
+        'source_url': window.location.href,
         'previous_url': this.referrer_,
         'user_agent': this.ampDoc_.win.navigator.userAgent,
       },

--- a/extensions/amp-smartlinks/0.1/linkmate.js
+++ b/extensions/amp-smartlinks/0.1/linkmate.js
@@ -165,8 +165,8 @@ export class Linkmate {
    */
   getEditInfo_() {
     return dict({
-      'name': this.rootNode_.title || null,
-      'url': this.ampDoc_.getUrl(),
+      'name': document.getElementsByTagName("title")[0].text || null,
+      'url': window.location.href,
     });
   }
 


### PR DESCRIPTION
@ampproject/wg-components
fixes #32188

'window.location.href' allows you get the url of the current article url, regardless of whether your current article doc is a shadow doc or a single doc. Similarly, 'document.getElementsByTagName("title")[0].text' will grab the title of the current article, regardless of whether your current article doc is a shadow doc or a single doc. 

These changes are needed to correctly populate the payloads for the Linkmate API call and the page impression API call that indicates a page load event has happened. 

In the amp-smartlinks tag on the amp-smartlinks template html page, the 'nrtv-account-name' was updated to 'sisterping', which is an actual QA account registered with Narrativ. Finally, the links on the template page were updated.

/cc @dvoytenko 