### PR TITLE
🐛 getUrl fix enabling shadow docs to have access to the article url and name #32188

### DIFF
--- a/extensions/amp-smartlinks/0.1/amp-smartlinks.js
+++ b/extensions/amp-smartlinks/0.1/amp-smartlinks.js
@@ -203,7 +203,7 @@ export class AmpSmartlinks extends AMP.BaseElement {
       'organization_type': 'publisher',
       'user': {
         'page_session_uuid': this.generateUUID_(),
-        'source_url': this.ampDoc_.getUrl(),
+        'source_url': window.location.href,
         'previous_url': this.referrer_,
         'user_agent': this.ampDoc_.win.navigator.userAgent,
       },

--- a/extensions/amp-smartlinks/0.1/linkmate.js
+++ b/extensions/amp-smartlinks/0.1/linkmate.js
@@ -165,8 +165,8 @@ export class Linkmate {
    */
   getEditInfo_() {
     return dict({
-      'name': this.rootNode_.title || null,
-      'url': this.ampDoc_.getUrl(),
+      'name': document.getElementsByTagName('title')[0].text || null,
+      'url': window.location.href,
     });
   }
 


### PR DESCRIPTION
@ampproject/wg-components
fixes #32188

'window.location.href' allows you get the url of the current article url, regardless of whether your current article doc is a shadow doc or a single doc. Similarly, 'document.getElementsByTagName("title")[0].text' will grab the title of the current article, regardless of whether your current article doc is a shadow doc or a single doc.

These changes are needed to correctly populate the payloads for the Linkmate API call and the page impression API call that indicates a page load event has happened.

/cc @dvoytenko