### PR TITLE
Disable overflow-x:hidden for WebView mode

### DIFF
--- a/css/ampdoc.css
+++ b/css/ampdoc.css
@@ -92,21 +92,6 @@ html.i-amphtml-fie:not(.i-amphtml-inabox) > body {
 
 
 /**
- * Set `body {overflow-x: hidden}` for iOS WebView. This is b/c iOS WebView
- * does NOT respect `html {overflow-x: hidden}`.
- * Note! For all other natural cases body's style is `body {overflow: visible}`
- * to avoid visibility issues with iframes.
- */
-html.i-amphtml-webview > body {
-  overflow-x: hidden !important;
-  overflow-y: visible !important;
-  /* A <body> height of 0 will be hidden due to "overflow-x: hidden". */
-  /* Prevent this by setting min-height to 100vh. See b/74541306. */
-  min-height: 100vh !important;
-}
-
-
-/**
  * iOS-Embed mode (iOS <= 8). The `body` itself is scrollable.
  */
 html.i-amphtml-ios-embed-legacy > body {
@@ -124,7 +109,7 @@ html.i-amphtml-ios-embed {
   position: static;
 }
 
-/** Wrapper for iOS Embed Wrapper mode. */
+/** Wrapper for iOS Embed Wrapper mode (iOS <= 12). */
 #i-amphtml-wrapper {
   overflow-x: hidden !important;
   overflow-y: auto !important;

--- a/test/unit/test-viewport-binding.js
+++ b/test/unit/test-viewport-binding.js
@@ -69,8 +69,8 @@ describes.realWin('ViewportBindingNatural', {ampCss: true}, (env) => {
     binding = new ViewportBindingNatural_(ampdoc);
     const bodyStyles = win.getComputedStyle(win.document.body);
     expect(bodyStyles.position).to.equal('relative');
-    expect(bodyStyles.overflowX).to.equal('hidden');
-    expect(bodyStyles.overflowY).to.not.equal('hidden');
+    expect(bodyStyles.overflowX).to.equal('visible');
+    expect(bodyStyles.overflowY).to.equal('visible');
   });
 
   it('should NOT require fixed layer transferring', () => {


### PR DESCRIPTION
Partial for #31364.

This is an undo of https://github.com/ampproject/amphtml/pull/27319. The reasoning: this is a very heavy-handed fix and possible too risky.