### PR TITLE
📖  Add imperative API code samples to Bento component documentation

### DIFF
--- a/extensions/amp-inline-gallery/amp-inline-gallery.md
+++ b/extensions/amp-inline-gallery/amp-inline-gallery.md
@@ -202,7 +202,9 @@ amp-inline-gallery-thumbnails {
 }
 ```
 
-Note: Because this component composes with `amp-base-carousel`, be sure to also follow [`amp-base-carousel` styling recommendations](https://amp.dev/documentation/components/amp-base-carousel-v1.0/?format=websites#usage).
+[tip type="note"]
+Because this component composes with `amp-base-carousel`, be sure to also follow [`amp-base-carousel` styling recommendations](https://amp.dev/documentation/components/amp-base-carousel-v1.0/?format=websites#usage).
+[/tip]
 
 ### Include pagination indicators
 

--- a/extensions/amp-inline-gallery/amp-inline-gallery.md
+++ b/extensions/amp-inline-gallery/amp-inline-gallery.md
@@ -71,14 +71,138 @@ The `<amp-inline-gallery>` component uses an `<amp-base-carousel>` to display sl
 
 The above example shows slides using an aspect ratio of 3:2, with 10% of a slide peeking on either side. An aspect ratio of 3.6:2 is used on the `amp-base-carousel` to show 1.2 slides at a time.
 
-### Migrating from 0.1
+### Standalone use outside valid AMP documents
 
-Unlike `0.1`, the experimental `1.0` version of `amp-inline-gallery` includes the following changes:
+Bento AMP allows you to use AMP components in non-AMP pages without needing to commit to fully valid AMP. You can take these components and place them in implementations with frameworks and CMSs that don't support AMP. Read more in our guide `[Use AMP components in non-AMP pages](https://amp.dev/documentation/guides-and-tutorials/start/bento_guide/)`.
 
--   `amp-inline-gallery-pagination` with `inset` attribute positions the element with an overwritable `bottom: 0`.
--   `amp-inline-gallery-thumbnails` takes `data-thumbnail-src` from slide elements (children of the `amp-base-carousel`) instead of `srcset`.
--   `amp-inline-gallery-thumbnails` takes `aspect-ratio` as expressed by `width / height` instead of two separate attributes, `aspect-ratio-width` and `aspect-ratio-height`.
--   `amp-inline-gallery-thumbnails` configuration for `loop` defaults to `"false"`.
+#### Example
+
+The example below demonstrates `amp-inline-gallery` component in standalone use.
+
+[example preview="top-frame" playground="false"]
+
+```
+<head>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <link rel="stylesheet" type="text/css" href="https://cdn.ampproject.org/v0/amp-inline-gallery-1.0.css">
+  <script async custom-element="amp-inline-gallery" src="https://cdn.ampproject.org/v0/amp-inline-gallery-1.0.js"></script>
+  <link rel="stylesheet" type="text/css" href="https://cdn.ampproject.org/v0/amp-base-carousel-1.0.css">
+  <script async custom-element="amp-inline-gallery" src="https://cdn.ampproject.org/v0/amp-base-carousel-1.0.js"></script>
+  <style>
+    amp-base-carousel {
+      aspect-ratio: 3/1;
+    }
+    amp-base-carousel > div {
+      aspect-ratio: 1/1;
+    }
+    amp-inline-gallery-pagination {
+      height: 20px;
+    }
+    .red-gradient {
+      background: brown;
+      background: linear-gradient(90deg, brown 50%, lightsalmon 90%, wheat 100%);
+    }
+    .blue-gradient {
+      background: steelblue;
+      background: linear-gradient(90deg, steelblue 50%, plum 90%, lavender 100%);
+    }
+    .green-gradient {
+      background: seagreen;
+      background: linear-gradient(90deg, seagreen 50%, mediumturquoise 90%, turquoise 100%);
+    }
+    .pink-gradient {
+      background: pink;
+      background: linear-gradient(90deg, pink 50%, lightsalmon 90%, wheat 100%);
+    }
+    .yellow-gradient {
+      background: gold;
+      background: linear-gradient(90deg, gold 50%, goldenrod 90%, darkgoldenrod 100%);
+    }
+    .orange-gradient {
+      background: peru;
+      background: linear-gradient(90deg, peru 50%, chocolate 90%, saddlebrown 100%);
+    }
+    .seafoam-gradient {
+      background: darkseagreen;
+      background: linear-gradient(90deg, darkseagreen 50%, lightseagreen 90%, MediumAquaMarine 100%);
+    }
+    .purple-gradient {
+      background: rebeccapurple;
+      background: linear-gradient(90deg, rebeccapurple 50%, mediumpurple 90%, mediumslateblue 100%);
+    }
+    .cyan-gradient {
+      background: darkcyan;
+      background: linear-gradient(90deg, darkcyan 50%, lightcyan 90%, white 100%);
+    }
+  </style>
+</head>
+<amp-inline-gallery>
+  <amp-base-carousel id="my-carousel">
+    <div class="red-gradient"></div>
+    <div class="blue-gradient"></div>
+    <div class="green-gradient"></div>
+    <div class="pink-gradient"></div>
+    <div class="yellow-gradient"></div>
+    <div class="orange-gradient"></div>
+    <div class="seafoam-gradient"></div>
+    <div class="purple-gradient"></div>
+    <div class="cyan-gradient"></div>
+  </amp-base-carousel>
+  <amp-inline-gallery-pagination>
+</amp-inline-gallery>
+<div class="buttons" style="margin-top: 8px;">
+  <button id='prev-button'>Go to previous page of slides</button>
+  <button id='next-button'>Go to next page of slides</button>
+  <button id='go-to-button'>Go to slide with green gradient</button>
+</div>
+<script>
+  (async () => {
+    const carousel = document.querySelector('#my-carousel');
+    await customElements.whenDefined('amp-base-carousel');
+    const api = await carousel.getApi();
+    // programatically advance to next slide
+    api.next();
+    // set up button actions
+    document.querySelector('#prev-button').onclick = () => api.prev();
+    document.querySelector('#next-button').onclick = () => api.next();
+    document.querySelector('#go-to-button').onclick = () => api.goToSlide(2);
+  })();
+</script>
+```
+
+[/example]
+
+#### Interactivity and API usage
+
+Bento enabled components in standalone use are highly interactive through their API. In Bento standalone use, the element's API replaces AMP Actions and events and [`amp-bind`](https://amp.dev/documentation/components/amp-bind/?format=websites).
+
+The `amp-inline-gallery` component is used in combination with `amp-base-carousel` and should access the [`amp-base-carousel` API](https://amp.dev/documentation/components/amp-base-carousel-v1.0/?format=websites) accordingly.
+
+#### Layout and style
+
+Each Bento component has a small CSS library you must include to guarantee proper loading without [content shifts](https://web.dev/cls/). Because of order-based specificity, you must manually ensure that stylesheets are included before any custom styles.
+
+```
+<link rel="stylesheet" type="text/css" href="https://cdn.ampproject.org/v0/amp-inline-gallery-1.0.css">
+<link rel="stylesheet" type="text/css" href="https://cdn.ampproject.org/v0/amp-base-carousel-1.0.css">
+```
+
+Fully valid AMP pages use the AMP layout system to infer sizing of elements to create a page structure before downloading any remote resources. However, Bento use imports components into less controlled environments and AMP's layout system is inaccessible.
+
+**Container type**
+
+The `amp-inline-gallery-pagination` and `amp-inline-gallery-thumbnails` components have defined layout size types. To ensure the components render correctly, be sure to apply a size to the component and its immediate children (slides) via a desired CSS layout (such as one defined with `height`, `width`, `aspect-ratio`, or other such properties):
+
+```css
+amp-inline-gallery-pagination {
+  height: 20px;
+}
+amp-inline-gallery-thumbnails {
+  aspect-ratio: 4/1
+}
+```
+
+Note: Because this component composes with `amp-base-carousel`, be sure to also follow [`amp-base-carousel` styling recommendations](https://amp.dev/documentation/components/amp-base-carousel-v1.0/?format=websites#usage).
 
 ### Include pagination indicators
 
@@ -275,3 +399,12 @@ The `<amp-inline-gallery-thumbnails>` element includes <a href="https://amp.dev/
 ### common attributes
 
 This element includes <a href="https://amp.dev/documentation/guides-and-tutorials/learn/common_attributes">common attributes</a> extended to AMP components.
+
+## Version notes
+
+Unlike `0.1`, the experimental `1.0` version of `amp-inline-gallery` includes the following changes:
+
+-   `amp-inline-gallery-pagination` with `inset` attribute positions the element with an overwritable `bottom: 0`.
+-   `amp-inline-gallery-thumbnails` takes `data-thumbnail-src` from slide elements (children of the `amp-base-carousel`) instead of `srcset`.
+-   `amp-inline-gallery-thumbnails` takes `aspect-ratio` as expressed by `width / height` instead of two separate attributes, `aspect-ratio-width` and `aspect-ratio-height`.
+-   `amp-inline-gallery-thumbnails` configuration for `loop` defaults to `"false"`.

--- a/extensions/amp-lightbox/amp-lightbox.md
+++ b/extensions/amp-lightbox/amp-lightbox.md
@@ -43,13 +43,100 @@ component. To show a gallery of images in a lightbox, you can use
 
 [/tip]
 
-### Migrating from 0.1
+### Standalone use outside valid AMP documents
 
-The experimental `1.0` version of `amp-lightbox` employs the following differences from version `0.1`:
+Bento AMP allows you to use AMP components in non-AMP pages without needing to commit to fully valid AMP. You can take these components and place them in implementations with frameworks and CMSs that don't support AMP. Read more in our guide [Use AMP components in non-AMP pages](https://amp.dev/documentation/guides-and-tutorials/start/bento_guide/).
 
--   This component does not currently support modifying browser history state.
--   `data-close-button-aria-label` is not supported and will soon be replaced with support for `slot="close-button"`.
--   `animate-in` has been renamed to `animation`.
+#### Example
+
+The example below demonstrates `amp-lightbox` component in standalone use.
+
+[example preview="top-frame" playground="false"]
+
+```html
+<head>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <link rel="stylesheet" type="text/css" href="https://cdn.ampproject.org/v0/amp-lightbox-1.0.css">
+  <script async custom-element="amp-lightbox" src="https://cdn.ampproject.org/v0/amp-lightbox-1.0.js"></script>
+</head>
+<amp-lightbox id="my-lightbox">
+  Lightboxed content
+  <button id='close-button'>Close lightbox</button>
+</amp-lightbox>
+<button id='open-button'>Open lightbox</button>
+<script>
+  (async () => {
+    const lightbox = document.querySelector('#my-lightbox');
+    await customElements.whenDefined('amp-lightbox');
+    const api = await lightbox.getApi();
+
+    // set up button actions
+    document.querySelector('#open-button').onclick = () => api.open();
+    document.querySelector('#close-button').onclick = () => api.close();
+  })();
+</script>
+```
+
+[/example]
+
+#### Interactivity and API usage
+
+Bento enabled components in standalone use are highly interactive through their API. In Bento standalone use, the element's API replaces AMP Actions and events and [`amp-bind`](https://amp.dev/documentation/components/amp-bind/?format=websites).
+
+The `amp-lightbox` component API is accessible by including the following script tag in your document:
+
+```
+await customElements.whenDefined('amp-lightbox');
+const api = await lightbox.getApi();
+```
+
+##### Actions
+
+The `amp-lightbox` API allows you to perform the following actions:
+
+**open()**
+Opens the lightbox.
+
+```
+api.open();
+```
+
+**close()**
+Closes the lightbox.
+
+```
+api.close();
+```
+
+##### Events
+
+The `amp-lightbox` API allows you to register and respond to the following events:
+
+**open**
+
+This event is triggered when the lightbox is opened.
+
+```
+lightbox.addEventListener('open', (e) => console.log(e))
+```
+
+**close**
+
+This event is triggered when the lightbox is closed.
+
+```
+lightbox.addEventListener('close', (e) => console.log(e))
+```
+
+#### Layout and style
+
+Each Bento component has a small CSS library you must include to guarantee proper loading without [content shifts](https://web.dev/cls/). Because of order-based specificity, you must manually ensure that stylesheets are included before any custom styles.
+
+```
+<link rel="stylesheet" type="text/css" href="https://cdn.ampproject.org/v0/amp-lightbox-1.0.css">
+```
+
+Fully valid AMP pages use the AMP layout system to infer sizing of elements to create a page structure before downloading any remote resources. However, Bento use imports components into less controlled environments and AMP's layout system is inaccessible.
 
 ## Attributes
 
@@ -75,6 +162,11 @@ property of the `amp-lightbox` element. Do not rely on transforming the
 nested element instead.
 
 [/tip]
+
+### `scrollable` (optional)
+
+When the `scrollable` attribute is present, the content of the lightbox can
+scroll when overflowing the height of the lightbox.
 
 ## Actions
 
@@ -113,3 +205,11 @@ attribute value, will be created and focused on.
   <button on="tap:quote-lb.close">Nice!</button>
 </amp-lightbox>
 ```
+
+## Version notes
+
+The experimental `1.0` version of `amp-lightbox` employs the following differences from version `0.1`:
+
+-   This component does not currently support modifying browser history state.
+-   `data-close-button-aria-label` is not supported and will soon be replaced with support for `slot="close-button"`.
+-   `animate-in` has been renamed to `animation`.

--- a/extensions/amp-lightbox/amp-lightbox.md
+++ b/extensions/amp-lightbox/amp-lightbox.md
@@ -45,7 +45,7 @@ component. To show a gallery of images in a lightbox, you can use
 
 ### Standalone use outside valid AMP documents
 
-Bento AMP allows you to use AMP components in non-AMP pages without needing to commit to fully valid AMP. You can take these components and place them in implementations with frameworks and CMSs that don't support AMP. Read more in our guide [Use AMP components in non-AMP pages](https://amp.dev/documentation/guides-and-tutorials/start/bento_guide/).
+Bento AMP allows you to use AMP components in non-AMP pages without needing to commit to fully valid AMP. You can take these components and place them in implementations with frameworks and CMSs that don't support AMP. Read more in our guide `[Use AMP components in non-AMP pages](https://amp.dev/documentation/guides-and-tutorials/start/bento_guide/)`.
 
 #### Example
 

--- a/extensions/amp-selector/amp-selector.md
+++ b/extensions/amp-selector/amp-selector.md
@@ -32,9 +32,9 @@ The AMP selector is a control that presents a list of options and lets the user 
 
 -   An `amp-selector` can contain any arbitrary HTML elements or AMP components (e.g., `amp-carousel`, `amp-img`, etc.).
 -   An `amp-selector` cannot contain any nested `amp-selector` controls.
--   Selectable options can be set by adding the `option` attribute to the element and assigning a value to the attribute (e.g., `<li option='value'></li>`).
--   Disabled options can be set by adding the `disabled` attribute to the element (e.g., `<li option='d' disabled></li>`).
--   Preselected options can be set by adding the `selected` attribute to the element (e.g., `<li option='b' selected></li>`).
+-   Selectable options can be set by adding the `option` attribute to the element and assigning a value to the attribute (e.g., `<li option="value"></li>`).
+-   Disabled options can be set by adding the `disabled` attribute to the element (e.g., `<li option="d" disabled></li>`).
+-   Preselected options can be set by adding the `selected` attribute to the element (e.g., `<li option="b" selected></li>`).
 -   To allow for multiple selections, add the `multiple` attribute to the `amp-selector` element. By default, the `amp-selector` allows for one selection at a time.
 -   To disable the entire `amp-selector`, add the `disabled` attribute to the `amp-selector` element.
 -   When an `amp-selector` contains a `name` attribute and the `amp-selector` is inside a `form` tag, if a submit event occurs on the form, the `amp-selector`behaves like a radio-button/checkbox group and submits the selected values (the ones assigned to the option) against the name of the `amp-selector`.
@@ -127,19 +127,19 @@ The example below demonstrates `amp-selector` component in standalone use.
     <li option="6">Option 6</li>
   </ul>
 </amp-selector>
-<button id='select-down-button'>Select next item</button>
-<button id='select-up-button'>Select previous item</button>
-<button id='toggle-button'>Toggle Option 3</button>
+<button id="select-down-button">Select next item</button>
+<button id="select-up-button">Select previous item</button>
+<button id="toggle-button">Toggle Option 3</button>
 <script>
   (async () => {
-    const selector = document.querySelector('#my-selector');
-    await customElements.whenDefined('amp-selector');
+    const selector = document.querySelector("#my-selector");
+    await customElements.whenDefined("amp-selector");
     const api = await selector.getApi();
 
     // set up button actions
-    document.querySelector('#select-down-button').onclick = () => api.selectBy(1);
-    document.querySelector('#select-up-button').onclick = () => api.selectBy(-1);
-    document.querySelector('#toggle-button').onclick = () => api.toggle("3");
+    document.querySelector("#select-down-button").onclick = () => api.selectBy(1);
+    document.querySelector("#select-up-button").onclick = () => api.selectBy(-1);
+    document.querySelector("#toggle-button").onclick = () => api.toggle("3");
   })();
 </script>
 ```
@@ -153,7 +153,7 @@ Bento enabled components in standalone use are highly interactive through their 
 The `amp-selector` component API is accessible by including the following script tag in your document:
 
 ```
-await customElements.whenDefined('amp-selector');
+await customElements.whenDefined("amp-selector");
 const api = await selector.getApi();
 ```
 
@@ -196,7 +196,7 @@ Tapping disabled options does not trigger the `select` event.
 </ul>
 
 ```
-selector.addEventListener('close', (e) => console.log(e.data.targetOption))
+selector.addEventListener("select", (e) => console.log(e.data.targetOption))
 ```
 
 #### Layout and style

--- a/extensions/amp-selector/amp-selector.md
+++ b/extensions/amp-selector/amp-selector.md
@@ -103,7 +103,7 @@ Example:
 
 ### Standalone use outside valid AMP documents
 
-Bento AMP allows you to use AMP components in non-AMP pages without needing to commit to fully valid AMP. You can take these components and place them in implementations with frameworks and CMSs that don't support AMP. Read more in our guide [Use AMP components in non-AMP pages](https://amp.dev/documentation/guides-and-tutorials/start/bento_guide/).
+Bento AMP allows you to use AMP components in non-AMP pages without needing to commit to fully valid AMP. You can take these components and place them in implementations with frameworks and CMSs that don't support AMP. Read more in our guide `[Use AMP components in non-AMP pages](https://amp.dev/documentation/guides-and-tutorials/start/bento_guide/)`.
 
 #### Example
 

--- a/extensions/amp-selector/amp-selector.md
+++ b/extensions/amp-selector/amp-selector.md
@@ -101,6 +101,114 @@ Example:
 </amp-selector>
 ```
 
+### Standalone use outside valid AMP documents
+
+Bento AMP allows you to use AMP components in non-AMP pages without needing to commit to fully valid AMP. You can take these components and place them in implementations with frameworks and CMSs that don't support AMP. Read more in our guide [Use AMP components in non-AMP pages](https://amp.dev/documentation/guides-and-tutorials/start/bento_guide/).
+
+#### Example
+
+The example below demonstrates `amp-selector` component in standalone use.
+
+[example preview="top-frame" playground="false"]
+
+```html
+<head>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <link rel="stylesheet" type="text/css" href="https://cdn.ampproject.org/v0/amp-selector-1.0.css">
+  <script async custom-element="amp-selector" src="https://cdn.ampproject.org/v0/amp-selector-1.0.js"></script>
+</head>
+<amp-selector id="my-selector">
+  <ul>
+    <li option="1">Option 1</li>
+    <li option="2">Option 2</li>
+    <li option="3">Option 3</li>
+    <li option="4">Option 4</li>
+    <li option="5">Option 5</li>
+    <li option="6">Option 6</li>
+  </ul>
+</amp-selector>
+<button id='select-down-button'>Select next item</button>
+<button id='select-up-button'>Select previous item</button>
+<button id='toggle-button'>Toggle Option 3</button>
+<script>
+  (async () => {
+    const selector = document.querySelector('#my-selector');
+    await customElements.whenDefined('amp-selector');
+    const api = await selector.getApi();
+
+    // set up button actions
+    document.querySelector('#select-down-button').onclick = () => api.selectBy(1);
+    document.querySelector('#select-up-button').onclick = () => api.selectBy(-1);
+    document.querySelector('#toggle-button').onclick = () => api.toggle("3");
+  })();
+</script>
+```
+
+[/example]
+
+#### Interactivity and API usage
+
+Bento enabled components in standalone use are highly interactive through their API. In Bento standalone use, the element's API replaces AMP Actions and events and [`amp-bind`](https://amp.dev/documentation/components/amp-bind/?format=websites).
+
+The `amp-selector` component API is accessible by including the following script tag in your document:
+
+```
+await customElements.whenDefined('amp-selector');
+const api = await selector.getApi();
+```
+
+##### Actions
+
+The `amp-selector` API allows you to perform the following actions:
+
+**selectBy(delta: number)**
+Closes the selector.
+
+```
+api.selectBy(1); // Select next option in DOM sequence.
+api.selectBy(-2); // Select the option that is two previous in DOM sequence.
+```
+
+**toggle(optionValue: string, opt_select: boolean|undefined)**
+Toggles the option with the given `optionValue` to be selected or deselected based on `opt_select`. If `opt_select` is not present, then the option will be selected if currently not selected, and deselected if currently selected.
+
+```
+api.toggle("a"); // Toggle the item with the attribute `option="a"`.
+api.toggle("1", true); // Select the item with the attribute `option="1"`.
+```
+
+##### Events
+
+The `amp-selector` API allows you to register and respond to the following events:
+
+**select**
+
+This event is triggered when the user selects an option.
+Multi-selectors and single-selectors fire this when selecting or unselecting options.
+Tapping disabled options does not trigger the `select` event.
+
+<ul>
+  <li>
+  `event.data.targetOption` contains the `option` attribute value of the selected element.</li>
+  <li>
+  `event.data.selectedOptions` contains an array of the `option` attribute values of all selected elements.
+  </li>
+</ul>
+
+```
+selector.addEventListener('close', (e) => console.log(e.data.targetOption))
+```
+
+#### Layout and style
+
+Each Bento component has a small CSS library you must include to guarantee proper loading without [content shifts](https://web.dev/cls/). Because of order-based specificity, you must manually ensure that stylesheets are included before any custom styles.
+
+```
+<link rel="stylesheet" type="text/css" href="https://cdn.ampproject.org/v0/amp-selector-1.0.css">
+```
+
+Fully valid AMP pages use the AMP layout system to infer sizing of elements to create a page structure before downloading any remote resources. However, Bento use imports components into less controlled environments and AMP's layout system is inaccessible.
+
 ### Clearing selections
 
 To clear all selections when an element is tapped or clicked, set the [`on`](../../spec/amp-actions-and-events.md) action attribute on the element, and specify the AMP Selector `id` with the `clear` action method.

--- a/extensions/amp-stream-gallery/amp-stream-gallery.md
+++ b/extensions/amp-stream-gallery/amp-stream-gallery.md
@@ -30,7 +30,7 @@ limitations under the License.
 
 A stream gallery for displaying multiple similar pieces of content at a time along a
 horizontal axis. To implement a more customized UX, see
-[`amp-stream-gallery`](https://amp.dev/documentation/components/amp-stream-gallery/).
+[`amp-base-carousel`](https://amp.dev/documentation/components/amp-base-carousel/).
 
 _Example:_
 

--- a/extensions/amp-stream-gallery/amp-stream-gallery.md
+++ b/extensions/amp-stream-gallery/amp-stream-gallery.md
@@ -30,7 +30,7 @@ limitations under the License.
 
 A stream gallery for displaying multiple similar pieces of content at a time along a
 horizontal axis. To implement a more customized UX, see
-[`amp-base-carousel`](https://amp.dev/documentation/components/amp-base-carousel/).
+[`amp-stream-gallery`](https://amp.dev/documentation/components/amp-stream-gallery/).
 
 _Example:_
 
@@ -59,7 +59,179 @@ navigational arrows to go forward or backwards by a given number of items.
 The gallery advances between items if the user swipes or uses the customizable
 arrow buttons.
 
-### Slide layout
+### Standalone use outside valid AMP documents
+
+Bento AMP allows you to use AMP components in non-AMP pages without needing to commit to fully valid AMP. You can take these components and place them in implementations with frameworks and CMSs that don't support AMP. Read more in our guide `[Use AMP components in non-AMP pages](https://amp.dev/documentation/guides-and-tutorials/start/bento_guide/)`.
+
+#### Example
+
+The example below demonstrates `amp-stream-gallery` component in standalone use.
+
+[example preview="top-frame" playground="false"]
+
+```
+<head>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <link rel="stylesheet" type="text/css" href="https://cdn.ampproject.org/v0/amp-stream-gallery-1.0.css">
+  <script async custom-element="amp-stream-gallery" src="https://cdn.ampproject.org/v0/amp-stream-gallery-1.0.js"></script>
+  <style>
+    amp-stream-gallery {
+      aspect-ratio: 3/1;
+    }
+    amp-stream-gallery > div {
+      aspect-ratio: 1/1;
+    }
+    .red-gradient {
+      background: brown;
+      background: linear-gradient(90deg, brown 50%, lightsalmon 90%, wheat 100%);
+    }
+    .blue-gradient {
+      background: steelblue;
+      background: linear-gradient(90deg, steelblue 50%, plum 90%, lavender 100%);
+    }
+    .green-gradient {
+      background: seagreen;
+      background: linear-gradient(90deg, seagreen 50%, mediumturquoise 90%, turquoise 100%);
+    }
+    .pink-gradient {
+      background: pink;
+      background: linear-gradient(90deg, pink 50%, lightsalmon 90%, wheat 100%);
+    }
+    .yellow-gradient {
+      background: gold;
+      background: linear-gradient(90deg, gold 50%, goldenrod 90%, darkgoldenrod 100%);
+    }
+    .orange-gradient {
+      background: peru;
+      background: linear-gradient(90deg, peru 50%, chocolate 90%, saddlebrown 100%);
+    }
+    .seafoam-gradient {
+      background: darkseagreen;
+      background: linear-gradient(90deg, darkseagreen 50%, lightseagreen 90%, MediumAquaMarine 100%);
+    }
+    .purple-gradient {
+      background: rebeccapurple;
+      background: linear-gradient(90deg, rebeccapurple 50%, mediumpurple 90%, mediumslateblue 100%);
+    }
+    .cyan-gradient {
+      background: darkcyan;
+      background: linear-gradient(90deg, darkcyan 50%, lightcyan 90%, white 100%);
+    }
+  </style>
+</head>
+<amp-stream-gallery id="my-carousel" max-visible-count="3">
+  <div class="red-gradient"></div>
+  <div class="blue-gradient"></div>
+  <div class="green-gradient"></div>
+
+  <div class="pink-gradient"></div>
+  <div class="yellow-gradient"></div>
+  <div class="orange-gradient"></div>
+
+  <div class="seafoam-gradient"></div>
+  <div class="purple-gradient"></div>
+  <div class="cyan-gradient"></div>
+</amp-stream-gallery>
+<div class="buttons" style="margin-top: 8px;">
+  <button id='prev-button'>Go to previous page of slides</button>
+  <button id='next-button'>Go to next page of slides</button>
+  <button id='go-to-button'>Go to slide with green gradient</button>
+</div>
+<script>
+  (async () => {
+    const carousel = document.querySelector('#my-carousel');
+    await customElements.whenDefined('amp-stream-gallery');
+    const api = await carousel.getApi();
+    // programatically advance to next slide
+    api.next();
+    // set up button actions
+    document.querySelector('#prev-button').onclick = () => api.prev();
+    document.querySelector('#next-button').onclick = () => api.next();
+    document.querySelector('#go-to-button').onclick = () => api.goToSlide(2);
+  })();
+</script>
+```
+
+[/example]
+
+#### Interactivity and API usage
+
+Bento enabled components in standalone use are highly interactive through their API. In Bento standalone use, the element's API replaces AMP Actions and events and [`amp-bind`](https://amp.dev/documentation/components/amp-bind/?format=websites).
+
+The `amp-stream-gallery` component API is accessible by including the following script tag in your document:
+
+```
+await customElements.whenDefined('amp-stream-gallery');
+const api = await carousel.getApi();
+```
+
+##### Actions
+
+The `amp-stream-gallery` API allows you to perform the following actions:
+
+**next()**
+Moves the carousel forwards by `advance-count` slides.
+
+```
+api.next();
+```
+
+**prev()**
+Moves the carousel backwards by `advance-count` slides.
+
+```
+api.prev();
+```
+
+**goToSlide(index: number)**
+Moves the carousel to the slide specified by the `index` argument.
+Note: `index` will be normalized to a number greater than or equal to `0` and less than the number of slides given.
+
+```
+api.goToSlide(0); // Advance to first slide.
+api.goToSlide(length - 1); // Advance to last slide.
+```
+
+##### Events
+
+The `amp-stream-gallery` API allows you to register and respond to the following events:
+
+**slideChange**
+
+This event is triggered when the index displayed by the carousel has changed.
+The new index is available via `event.data.index`.
+
+```
+carousel.addEventListener('slideChange', (e) => console.log(e.data.index))
+```
+
+#### Layout and style
+
+Each Bento component has a small CSS library you must include to guarantee proper loading without [content shifts](https://web.dev/cls/). Because of order-based specificity, you must manually ensure that stylesheets are included before any custom styles.
+
+```
+<link rel="stylesheet" type="text/css" href="https://cdn.ampproject.org/v0/amp-stream-gallery-1.0.css">
+```
+
+Fully valid AMP pages use the AMP layout system to infer sizing of elements to create a page structure before downloading any remote resources. However, Bento use imports components into less controlled environments and AMP's layout system is inaccessible.
+
+**Container type**
+
+The `amp-stream-gallery` component has a defined layout size type. To ensure the component renders correctly, be sure to apply a size to the component and its immediate children (slides) via a desired CSS layout (such as one defined with `height`, `width`, `aspect-ratio`, or other such properties):
+
+```css
+amp-stream-gallery {
+  height: 100px;
+  width: 100%;
+}
+amp-stream-gallery > * {
+  aspect-ratio: 4/1
+}
+```
+
+### Behavior users should be aware of
+
+#### Slide layout
 
 Slides are automatically sized by the carousel. You should give the slides `layout="flex-item"`:
 


### PR DESCRIPTION
Incorporate format changes from #31944 to the following Bento components which expose an API:
- `amp-selector`
- `amp-lightbox`
- `amp-inline-gallery`
- `amp-stream-gallery`