### PR TITLE
Prevent :where selector from being optimized with other selectors

### DIFF
--- a/extensions/amp-accordion/1.0/amp-accordion.css
+++ b/extensions/amp-accordion/1.0/amp-accordion.css
@@ -42,12 +42,17 @@ amp-accordion > section > * {
  * Note! This is a new CSS incompatible with older browsers. It provides
  * low-specificity UI styles. The same styles are later set for older browsers
  * via the `i-amphtml-accordion-header` class.
+ *
+ * TODO(#32155): Use instead `supports selector(:where(A))` when the
+ * https://github.com/postcss/postcss/issues/1520 is fixed.
  */
-:where(amp-accordion > section) > :first-child {
-  cursor: pointer;
-  background-color: #efefef;
-  padding-right: 20px;
-  border: 1px solid #dfdfdf;
+@media (min-width: 1px) {
+  :where(amp-accordion > section) > :first-child {
+    cursor: pointer;
+    background-color: #efefef;
+    padding-right: 20px;
+    border: 1px solid #dfdfdf;
+  }
 }
 
 /* heading


### PR DESCRIPTION
Partial for #32155.

A bit of a hack, but it works. The goal is to disallow `:where()` selector to be combined with other selectors, which breaks some older browsers. A better solution would have been to use `@supports selector`, but it's not yet supported by PostCSS. See https://github.com/postcss/postcss/issues/1520