### PR TITLE
🖍🚀 Alternate `position: fixed/absolute` when docking/undocking

### DIFF
--- a/build-system/test-configs/dep-check-config.js
+++ b/build-system/test-configs/dep-check-config.js
@@ -361,10 +361,6 @@ exports.rules = [
         'src/service/position-observer/position-observer-impl.js',
       'extensions/amp-fx-collection/0.1/providers/fx-provider.js->' +
         'src/service/position-observer/position-observer-worker.js',
-      'extensions/amp-video-docking/0.1/amp-video-docking.js->' +
-        'src/service/position-observer/position-observer-impl.js',
-      'extensions/amp-video-docking/0.1/amp-video-docking.js->' +
-        'src/service/position-observer/position-observer-worker.js',
       'extensions/amp-analytics/0.1/cookie-writer.js->' +
         'src/service/cid-impl.js',
       'extensions/amp-next-page/0.1/next-page-service.js->' +

--- a/extensions/amp-video-docking/0.1/amp-video-docking.css
+++ b/extensions/amp-video-docking/0.1/amp-video-docking.css
@@ -180,8 +180,8 @@
 .amp-video-docked-controls,
 .i-amphtml-video-docked,
 .i-amphtml-video-docked-overlay {
-  top: 0;
-  left: 0;
+  top: 0 !important;
+  left: 0 !important;
   right: auto !important;
   bottom: auto !important;
   padding: 0 !important;

--- a/extensions/amp-video-docking/0.1/amp-video-docking.css
+++ b/extensions/amp-video-docking/0.1/amp-video-docking.css
@@ -116,6 +116,7 @@
 
 .amp-video-docked-shadow {
   box-shadow: 0px 0 20px 6px rgba(0, 0, 0, 0.2);
+  transition-property: opacity, transition !important;
 }
 
 .amp-video-docked-controls-bg {

--- a/extensions/amp-video-docking/0.1/amp-video-docking.css
+++ b/extensions/amp-video-docking/0.1/amp-video-docking.css
@@ -179,9 +179,8 @@
 .amp-video-docked-controls,
 .i-amphtml-video-docked,
 .i-amphtml-video-docked-overlay {
-  position: fixed !important;
-  top: 0 !important;
-  left: 0 !important;
+  top: 0;
+  left: 0;
   right: auto !important;
   bottom: auto !important;
   padding: 0 !important;
@@ -194,6 +193,10 @@
   transform-origin: left top !important;
 
   will-change: width, height, transition, transform, opacity;
+}
+
+.amp-video-docked-controls {
+  position: fixed !important;
 }
 
 .i-amphtml-video-docked-overlay {

--- a/extensions/amp-video-docking/0.1/amp-video-docking.css
+++ b/extensions/amp-video-docking/0.1/amp-video-docking.css
@@ -200,10 +200,6 @@
   transition: 0.05s transform;
 }
 
-.amp-video-docked-controls {
-  position: fixed !important;
-}
-
 .i-amphtml-video-docked-overlay {
   opacity: 0;
   transition: 0.3s opacity ease;

--- a/extensions/amp-video-docking/0.1/amp-video-docking.css
+++ b/extensions/amp-video-docking/0.1/amp-video-docking.css
@@ -116,7 +116,7 @@
 
 .amp-video-docked-shadow {
   box-shadow: 0px 0 20px 6px rgba(0, 0, 0, 0.2);
-  transition-property: opacity, transition !important;
+  transition-property: transform, opacity !important;
 }
 
 .amp-video-docked-controls-bg {
@@ -180,6 +180,7 @@
 .amp-video-docked-controls,
 .i-amphtml-video-docked,
 .i-amphtml-video-docked-overlay {
+  position: fixed !important;
   top: 0 !important;
   left: 0 !important;
   right: auto !important;
@@ -194,6 +195,9 @@
   transform-origin: left top !important;
 
   will-change: width, height, transition, transform, opacity;
+
+  /* Needs an arbitrary transition by default so browser won't glitch/jump. */
+  transition: 0.05s transform;
 }
 
 .amp-video-docked-controls {

--- a/extensions/amp-video-docking/0.1/amp-video-docking.js
+++ b/extensions/amp-video-docking/0.1/amp-video-docking.js
@@ -1050,6 +1050,7 @@ export class VideoDocking {
       // Since the AMP element container is position: relative, the media
       // element is relative to AMP element corner when position: absolute, so
       // we need to offset it by outer container's position.
+      // TODO: DO NOT SUBMIT. This is buggy
       const offset = position === 'absolute' ? clientRect : {left: 0, top: 0};
 
       this.getElementsOnDockArea_(video).forEach((el) => {

--- a/extensions/amp-video-docking/0.1/amp-video-docking.js
+++ b/extensions/amp-video-docking/0.1/amp-video-docking.js
@@ -726,46 +726,33 @@ export class VideoDocking {
       return;
     }
 
-    this.dockInTransferLayerStep_(
-      video,
-      target,
-      /* step */ 0.1,
-      opt_inlineRect
-    );
+    this.dockInTransferLayerStep_(video, target, opt_inlineRect);
   }
 
   /**
+   * Dock this in a two-step process due to a browser quirk in transferring
+   * layers to GPU.
    * @param {!VideoOrBaseElementDef} video
    * @param {!DockTargetDef} target
-   * @param {number} step
    * @param {!RectDef=} opt_inlineRect
    * @return {!Promise}
    * @private
    */
-  dockInTransferLayerStep_(video, target, step, opt_inlineRect) {
-    // Do this in a multi-step process due to a browser quirk in transferring
-    // layers to GPU.
-    // This cutoff is arbitrary and may be dependant on performance.
-    if (step > 0.3) {
-      return this.dock_(video, target, /* step */ 1, opt_inlineRect);
-    }
+  dockInTransferLayerStep_(video, target, opt_inlineRect) {
     const isTransferLayerStep = true;
     return this.dock_(
       video,
       target,
-      step,
+      /* step */ 0.05,
       opt_inlineRect,
       isTransferLayerStep
     ).then(
       () =>
         new Promise((resolve) => {
           this.raf_(() => {
-            this.dockInTransferLayerStep_(
-              video,
-              target,
-              step + 0.1,
-              opt_inlineRect
-            ).then(resolve);
+            this.dock_(video, target, /* step */ 1, opt_inlineRect).then(
+              resolve
+            );
           });
         })
     );

--- a/extensions/amp-video-docking/0.1/amp-video-docking.js
+++ b/extensions/amp-video-docking/0.1/amp-video-docking.js
@@ -1049,7 +1049,7 @@ export class VideoDocking {
 
       // Since the AMP element container is position: relative, the media
       // element is relative to AMP element corner when position: absolute, so
-      // we need to offset it by outer contianer's position.
+      // we need to offset it by outer container's position.
       const offset = position === 'absolute' ? clientRect : {left: 0, top: 0};
 
       this.getElementsOnDockArea_(video).forEach((el) => {

--- a/extensions/amp-video-docking/0.1/amp-video-docking.js
+++ b/extensions/amp-video-docking/0.1/amp-video-docking.js
@@ -454,11 +454,18 @@ export class VideoDocking {
     if (!this.intersectionObserver_) {
       this.intersectionObserver_ = new IntersectionObserver(
         (entries) => {
-          entries.forEach((entry) => {
-            entry.target.getImpl().then((video) => {
-              this.updateOnPositionChange_(video, entry.boundingClientRect);
-            });
-          });
+          // Multiple entries could belong to the same element, use only the
+          // most recent.
+          const handled = [];
+          for (let i = entries.length - 1; i >= 0; i--) {
+            const {target, boundingClientRect} = entries[i];
+            if (handled.indexOf(target) < 0) {
+              target.getImpl().then((video) => {
+                this.updateOnPositionChange_(video, boundingClientRect);
+              });
+              handled.push(target);
+            }
+          }
         },
         {threshold: [0, 0.1, 0.2, 0.8, 0.9, 1]}
       );

--- a/extensions/amp-video-docking/0.1/amp-video-docking.js
+++ b/extensions/amp-video-docking/0.1/amp-video-docking.js
@@ -460,10 +460,7 @@ export class VideoDocking {
             });
           });
         },
-        {
-          root: this.doc_,
-          threshold: [0, 0.1, 0.2, 0.8, 0.9, 1],
-        }
+        {threshold: [0, 0.1, 0.2, 0.8, 0.9, 1]}
       );
     }
 

--- a/extensions/amp-video-docking/0.1/amp-video-docking.js
+++ b/extensions/amp-video-docking/0.1/amp-video-docking.js
@@ -648,9 +648,10 @@ export class VideoDocking {
       if (!this.currentlyDocked_) {
         return;
       }
-      const video = this.getDockedVideo_();
-      if (this.isVisible_(video, REVERT_TO_INLINE_RATIO, opt_clientRect)) {
-        this.undock_(video, /* opt_reconciled */ false, opt_clientRect);
+      if (video === this.getDockedVideo_()) {
+        if (this.isVisible_(video, REVERT_TO_INLINE_RATIO, opt_inlineRect)) {
+          this.undock_(video, /* opt_reconciled */ false, opt_inlineRect);
+        }
       }
     }
   }

--- a/extensions/amp-video-docking/0.1/amp-video-docking.js
+++ b/extensions/amp-video-docking/0.1/amp-video-docking.js
@@ -1050,10 +1050,7 @@ export class VideoDocking {
       // Since the AMP element container is position: relative, the media
       // element is relative to AMP element corner when position: absolute, so
       // we need to offset it by outer contianer's position.
-      let offset = {left: 0, top: 0};
-      if (position === 'absolute') {
-        offset = clientRect;
-      }
+      const offset = position === 'absolute' ? clientRect : {left: 0, top: 0};
 
       this.getElementsOnDockArea_(video).forEach((el) => {
         setImportantStyles(el, {

--- a/extensions/amp-video-docking/0.1/amp-video-docking.js
+++ b/extensions/amp-video-docking/0.1/amp-video-docking.js
@@ -1048,23 +1048,24 @@ export class VideoDocking {
       let offsetLeft = 0;
       let offsetTop = 0;
 
-      // Detached body-level elements, like the shadow layer, need to be offset
-      // in addition by the inline element's position relative to the body.
-      let detachedOffsetLeft = 0;
-      let detachedOffsetTop = 0;
+      // Body-level elements that do not descend from the <amp-video> element,
+      // like the shadow layer, need to be additionally offset by the inline
+      // element's position relative to the body.
+      let bodyLevelOffsetLeft = 0;
+      let bodyLevelOffsetTop = 0;
 
       if (position === 'absolute') {
         offsetLeft = inlineRect.left;
         offsetTop = inlineRect.top;
-        detachedOffsetLeft = element./*OK*/ offsetLeft;
-        detachedOffsetTop = element./*OK*/ offsetTop;
+        bodyLevelOffsetLeft = element./*OK*/ offsetLeft;
+        bodyLevelOffsetTop = element./*OK*/ offsetTop;
       }
 
       this.getElementsOnDockArea_(video).forEach((element) => {
-        const detachedOffsetFactor = Number(element !== internalElement);
+        const bodyLevelOffsetFactor = Number(element !== internalElement);
 
-        const left = detachedOffsetFactor * detachedOffsetLeft - offsetLeft;
-        const top = detachedOffsetFactor * detachedOffsetTop - offsetTop;
+        const left = bodyLevelOffsetFactor * bodyLevelOffsetLeft - offsetLeft;
+        const top = bodyLevelOffsetFactor * bodyLevelOffsetTop - offsetTop;
 
         setImportantStyles(element, {
           'position': position,

--- a/extensions/amp-video-docking/0.1/def.js
+++ b/extensions/amp-video-docking/0.1/def.js
@@ -14,6 +14,12 @@
  * limitations under the License.
  */
 
+/**
+ * These are interchangeable.
+ * @typedef {!ClientRect|!../../../src/layout-rect.LayoutRectDef}
+ */
+export let RectDef;
+
 /** @enum {string} */
 export const DirectionX = {LEFT: 'left', RIGHT: 'right'};
 

--- a/extensions/amp-video-docking/0.1/math.js
+++ b/extensions/amp-video-docking/0.1/math.js
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {DirectionX} from './def';
-import {LayoutRectDef, layoutRectLtwh} from '../../../src/layout-rect';
+import {DirectionX, RectDef} from './def';
+import {layoutRectLtwh} from '../../../src/layout-rect';
 import {mapRange} from '../../../src/utils/math.js';
 
 /**
@@ -76,8 +76,8 @@ const mapStep = (step, min, max) => mapRange(step, 0, 1, min, max);
 
 /**
  * Provides offset coords to interpolate `from` rect `to` rect.
- * @param {!LayoutRectDef} from
- * @param {!LayoutRectDef} to
+ * @param {!RectDef} from
+ * @param {!RectDef} to
  * @param {number=} step  in [0..1]
  * @return {{x: number, y: number, scale: number, relativeX: !DirectionX}}
  *  - x is offset from the original box in pixels.
@@ -95,9 +95,9 @@ export function interpolatedBoxesTransform(from, to, step = 1) {
 
 /**
  * Scales, fits and centers `original` into `container`.
- * @param {!LayoutRectDef} original
- * @param {!LayoutRectDef} container
- * @return {!LayoutRectDef}
+ * @param {!RectDef} original
+ * @param {!RectDef} container
+ * @return {!RectDef}
  */
 export function letterboxRect(original, container) {
   const {width, height} = original;
@@ -122,14 +122,14 @@ export function letterboxRect(original, container) {
 }
 
 /**
- * @param {!LayoutRectDef} original
- * @param {!LayoutRectDef} container
+ * @param {!RectDef} original
+ * @param {!RectDef} container
  * @param {DirectionX} horizontalEdge
  * @param {number} widthRatio
  * @param {number} widthMin
  * @param {number} marginRatio
  * @param {number} marginMax
- * @return {!LayoutRectDef}
+ * @return {!RectDef}
  */
 export function topCornerRect(
   original,
@@ -166,7 +166,7 @@ export const isVisibleBySize = (element) =>
   isSizedRect(element./*OK*/ getBoundingClientRect());
 
 /**
- * @param {!LayoutRectDef|!ClientRect|!DOMRect} rect
+ * @param {!RectDef} rect
  * @return {boolean}
  */
 export const isSizedRect = (rect) => rect.width > 0 && rect.height > 0;

--- a/extensions/amp-video-docking/0.1/test/test-amp-video-docking.js
+++ b/extensions/amp-video-docking/0.1/test/test-amp-video-docking.js
@@ -188,9 +188,7 @@ describes.realWin('video docking', {amp: true}, (env) => {
     env.sandbox.stub(Services, 'viewportForDoc').returns(viewport);
     env.sandbox.stub(Services, 'videoManagerForDoc').returns(manager);
 
-    const positionObserverMock = {};
-
-    docking = new VideoDocking(ampdoc, positionObserverMock);
+    docking = new VideoDocking(ampdoc);
 
     env.sandbox.stub(docking, 'getTimer_').returns({
       promise: () => Promise.resolve(),

--- a/extensions/amp-video-docking/0.1/test/test-amp-video-docking.js
+++ b/extensions/amp-video-docking/0.1/test/test-amp-video-docking.js
@@ -522,6 +522,85 @@ describes.realWin('video docking', {amp: true}, (env) => {
           expect(computedStyle['transform']).to.equal(expectedTransformMatrix);
         });
       });
+
+      it('sets position', async () => {
+        stubControls();
+        enableComputedStyle(video.element);
+
+        const offsetLeft = 12;
+        const offsetTop = 24;
+
+        placeElementLtwh(video, offsetLeft, offsetTop, width, 200);
+
+        await docking.placeAt_(
+          video,
+          /* x */ 52,
+          /* y */ 10,
+          /* scale */ 0.5,
+          /* step */ 0,
+          /* transitionDurationMs */ 300,
+          DirectionX.RIGHT,
+          /* opt_clientRect */ undefined,
+          'sticky'
+        );
+
+        const computedStyle = getComputedStyle(internalElement);
+        expect(computedStyle['position']).to.equal('sticky');
+      });
+
+      it('offsets position: absolute elements', async () => {
+        stubControls();
+        enableComputedStyle(video.element);
+
+        const offsetLeft = 12;
+        const offsetTop = 24;
+
+        placeElementLtwh(video, offsetLeft, offsetTop, width, 200);
+
+        await docking.placeAt_(
+          video,
+          /* x */ 52,
+          /* y */ 10,
+          /* scale */ 0.5,
+          /* step */ 0,
+          /* transitionDurationMs */ 300,
+          DirectionX.RIGHT,
+          /* opt_clientRect */ undefined,
+          'absolute'
+        );
+
+        const computedStyle = getComputedStyle(internalElement);
+        expect(computedStyle['position']).to.equal('absolute');
+        expect(computedStyle['left']).to.equal(`${-offsetLeft}px`);
+        expect(computedStyle['top']).to.equal(`${-offsetTop}px`);
+      });
+
+      it('does not offset position: fixed elements', async () => {
+        stubControls();
+        enableComputedStyle(video.element);
+
+        const offsetLeft = 12;
+        const offsetTop = 24;
+
+        placeElementLtwh(video, offsetLeft, offsetTop, width, 200);
+
+        await docking.placeAt_(
+          video,
+          /* x */ 52,
+          /* y */ 10,
+          /* scale */ 0.5,
+          /* step */ 0,
+          /* transitionDurationMs */ 300,
+          DirectionX.RIGHT,
+          /* opt_clientRect */ undefined,
+          'fixed'
+        );
+
+        const computedStyle = getComputedStyle(internalElement);
+        expect(computedStyle['position']).to.equal('fixed');
+        expect(computedStyle['left']).to.equal('0px');
+        expect(computedStyle['top']).to.equal('0px');
+      });
     });
 
     [
@@ -1102,7 +1181,6 @@ describes.realWin('video docking', {amp: true}, (env) => {
     let trigger;
     let resetOnUndock;
     let placeAt;
-    let maybeUpdateStaleYAfterScroll;
 
     const targetDims = {x: 20, y: 10, scale: 0.5, relativeX: DirectionX.RIGHT};
 
@@ -1113,9 +1191,6 @@ describes.realWin('video docking', {amp: true}, (env) => {
 
       trigger = env.sandbox.stub(docking, 'trigger_');
       resetOnUndock = env.sandbox.stub(docking, 'resetOnUndock_');
-      maybeUpdateStaleYAfterScroll = env.sandbox
-        .stub(docking, 'maybeUpdateStaleYAfterScroll_')
-        .returns(Promise.resolve());
 
       placeAt = env.sandbox
         .stub(docking, 'placeAt_')
@@ -1137,22 +1212,21 @@ describes.realWin('video docking', {amp: true}, (env) => {
       expect(trigger.withArgs(Actions.UNDOCK)).to.have.been.calledOnce;
     });
 
-    it('updates stale Y after undock', async () => {
-      const {promise, resolve} = new Deferred();
-
-      placeAt.returns(promise);
-
-      const done = docking.undock_(video);
-
-      expect(maybeUpdateStaleYAfterScroll.withArgs(video)).to.not.have.been
-        .called;
-
-      resolve();
-
-      await done;
-
-      expect(maybeUpdateStaleYAfterScroll.withArgs(video)).to.have.been
-        .calledOnce;
+    it('sets position: absolute on undock', async () => {
+      await docking.undock_(video);
+      expect(
+        placeAt.withArgs(
+          video,
+          env.sandbox.match.any,
+          env.sandbox.match.any,
+          env.sandbox.match.any,
+          env.sandbox.match.any,
+          env.sandbox.match.any,
+          env.sandbox.match.any,
+          env.sandbox.match.any,
+          'absolute'
+        )
+      ).to.have.been.calledOnce;
     });
 
     it('resets after undock', async () => {


### PR DESCRIPTION
- 🖍   Previously the video element would lag behind when using `position: fixed` at undock. `position: absolute` follows the video as it scrolls, eliminating the lag.  (This was backported from Bento version.)

- 🚀  Use existing `clientRect` where possible to prevent `getBoundingClientRect()` calls.

- 🚀  Migrates to `IntersectionObserver`.

---

**Before / after** (at 0.75 speed)

https://user-images.githubusercontent.com/254946/106031359-0756a300-6084-11eb-8bab-7cbe1f769313.mp4

(Tip: right click > `Loop`)

