### PR TITLE
🏗 Run the exact version check on all `package.json` files in the repo

### DIFF
--- a/build-system/pr-check/build-targets.js
+++ b/build-system/pr-check/build-targets.js
@@ -176,7 +176,7 @@ const targetMatchers = {
     return isOwnersFile(file) || file == 'build-system/tasks/check-owners.js';
   },
   [Targets.PACKAGE_UPGRADE]: (file) => {
-    return file == 'package.json' || file == 'package-lock.json';
+    return file.endsWith('package.json') || file.endsWith('package-lock.json');
   },
   [Targets.RENOVATE_CONFIG]: (file) => {
     return (

--- a/build-system/tasks/check-exact-versions.js
+++ b/build-system/tasks/check-exact-versions.js
@@ -15,17 +15,11 @@
  */
 'use strict';
 
+const globby = require('globby');
 const {cyan, green, red} = require('ansi-colors');
 const {getStderr} = require('../common/exec');
 const {gitDiffFileMaster} = require('../common/git');
 const {log, logLocalDev, logWithoutTimestamp} = require('../common/logging');
-
-const PACKAGE_JSON_PATHS = [
-  'package.json',
-  'build-system/tasks/e2e/package.json',
-  'build-system/tasks/visual-diff/package.json',
-  'build-system/tasks/storybook/package.json',
-];
 
 const checkerExecutable = 'npx npm-exact-versions';
 
@@ -35,7 +29,8 @@ const checkerExecutable = 'npx npm-exact-versions';
  */
 async function checkExactVersions() {
   let success = true;
-  PACKAGE_JSON_PATHS.forEach((file) => {
+  const packageJsonFiles = globby.sync(['**/package.json', '!**/node_modules']);
+  packageJsonFiles.forEach((file) => {
     const checkerCmd = `${checkerExecutable} --path ${file}`;
     const err = getStderr(checkerCmd);
     if (err) {
@@ -70,4 +65,4 @@ module.exports = {
 };
 
 checkExactVersions.description =
-  'Checks that all packages in package.json use exact versions.';
+  'Checks that all package.json files in the repo use exact versions.';

--- a/third_party/amp-toolbox-cache-url/package.json
+++ b/third_party/amp-toolbox-cache-url/package.json
@@ -28,8 +28,8 @@
   "homepage": "https://github.com/ampproject/amp-toolbox#readme",
   "files": ["dist", "package.json", "../LICENSE", "README.md"],
   "dependencies": {
-    "punycode": "^2.1.1",
-    "url-parse": "^1.4.3"
+    "punycode": "2.1.1",
+    "url-parse": "1.4.3"
   },
   "devDependencies": {
     "@ampproject/rollup-plugin-closure-compiler": "0.26.0",

--- a/validator/js/webui/package-lock.json
+++ b/validator/js/webui/package-lock.json
@@ -1192,9 +1192,9 @@
       "integrity": "sha1-fDqlOCxerecM0gaIDVajeGljBjg="
     },
     "webcomponents.js": {
-      "version": "0.7.24",
-      "resolved": "https://registry.npmjs.org/webcomponents.js/-/webcomponents.js-0.7.24.tgz",
-      "integrity": "sha1-IRb7+hRo7EFqe+/aozPh0Rj2nAQ="
+      "version": "0.7.22",
+      "resolved": "https://registry.npmjs.org/webcomponents.js/-/webcomponents.js-0.7.22.tgz",
+      "integrity": "sha1-EHt7P9MBYRAOjoXkAMMr7Rvyn+o="
     },
     "widest-line": {
       "version": "1.0.0",

--- a/validator/js/webui/package.json
+++ b/validator/js/webui/package.json
@@ -46,7 +46,7 @@
     "@polymer/polymer": "1.2.5-npm-test.2",
     "codemirror": "5.15.2",
     "vulcanize": "1.14.8",
-    "webcomponents.js": "^0.7.22",
+    "webcomponents.js": "0.7.22",
     "web-animations-js": "2.2.2"
   }
 }


### PR DESCRIPTION
We currently check select `package.json` files in the repo for exact versions in order to streamline version upgrades and make test results predictable.

This PR extends that check to all `package.json` files in the `amphtml` repo and fixes a couple of files with non-exact versions.
