### PR TITLE
🏗 Optimize the running of various checks during local dev and CI builds

### DIFF
--- a/build-system/pr-check/build-targets.js
+++ b/build-system/pr-check/build-targets.js
@@ -116,6 +116,8 @@ function isValidatorFile(file) {
 
 /**
  * A dictionary of functions that match a given file to a given build target.
+ * Owners files are special because they live all over the repo, so most target
+ * matchers must first make sure they're not matching an owners file.
  */
 const targetMatchers = {
   [Targets.AVA]: (file) => {
@@ -197,6 +199,9 @@ const targetMatchers = {
     );
   },
   [Targets.LINT]: (file) => {
+    if (isOwnersFile(file)) {
+      return false;
+    }
     return lintFiles.includes(file);
   },
   [Targets.OWNERS]: (file) => {
@@ -206,9 +211,13 @@ const targetMatchers = {
     return file.endsWith('package.json') || file.endsWith('package-lock.json');
   },
   [Targets.PRESUBMIT]: (file) => {
+    if (isOwnersFile(file)) {
+      return false;
+    }
     return presubmitFiles.includes(file);
   },
   [Targets.PRETTIFY]: (file) => {
+    // OWNERS files can be prettified.
     return prettifyFiles.includes(file);
   },
   [Targets.RENOVATE_CONFIG]: (file) => {

--- a/build-system/pr-check/build-targets.js
+++ b/build-system/pr-check/build-targets.js
@@ -284,7 +284,10 @@ function determineBuildTargets() {
       const matcher = targetMatchers[target];
       if (matcher(file)) {
         buildTargets.add(target);
-        matched = true;
+        // Files that affect these three targets may also affect the runtime.
+        if (!target in [Targets.LINT, Targets.PRESUBMIT, Targets.PRETTIFY]) {
+          matched = true;
+        }
       }
     });
     if (!matched) {

--- a/build-system/pr-check/build-targets.js
+++ b/build-system/pr-check/build-targets.js
@@ -69,15 +69,23 @@ const Targets = {
 };
 
 /**
- * Files matching these targets could also affect the runtime, so we run all
- * the RUNTIME tests. Files matching other targets do not affect the runtime.
+ * Files matching these targets are known not to affect the runtime. For all
+ * other targets, we play safe and default to adding the RUNTIME target, which
+ * will trigger all the runtime tests.
  */
-const targetsThatAffectRuntime = [
-  Targets.BABEL_PLUGIN,
-  Targets.LINT,
-  Targets.PRESUBMIT,
-  Targets.PRETTIFY,
-  Targets.SERVER,
+const nonRuntimeTargets = [
+  Targets.AVA,
+  Targets.CACHES_JSON,
+  Targets.DEV_DASHBOARD,
+  Targets.DOCS,
+  Targets.E2E_TEST,
+  Targets.INTEGRATION_TEST,
+  Targets.OWNERS,
+  Targets.RENOVATE_CONFIG,
+  Targets.UNIT_TEST,
+  Targets.VALIDATOR,
+  Targets.VALIDATOR_WEBUI,
+  Targets.VISUAL_DIFF,
 ];
 
 /**
@@ -284,17 +292,17 @@ function determineBuildTargets() {
   prettifyFiles = globby.sync(config.prettifyGlobs);
   const filesChanged = gitDiffNameOnlyMaster();
   for (const file of filesChanged) {
-    let fileMayAffectRuntime = true;
+    let isRuntimeFile = true;
     Object.keys(targetMatchers).forEach((target) => {
       const matcher = targetMatchers[target];
       if (matcher(file)) {
         buildTargets.add(target);
-        if (!target in targetsThatAffectRuntime) {
-          fileMayAffectRuntime = false;
+        if (target in nonRuntimeTargets) {
+          isRuntimeFile = false;
         }
       }
     });
-    if (fileMayAffectRuntime) {
+    if (isRuntimeFile) {
       buildTargets.add(Targets.RUNTIME);
     }
   }

--- a/build-system/pr-check/bundle-size.js
+++ b/build-system/pr-check/bundle-size.js
@@ -38,7 +38,7 @@ function pushBuildWorkflow() {
 }
 
 function prBuildWorkflow() {
-  if (buildTargetsInclude(Targets.RUNTIME, Targets.FLAG_CONFIG)) {
+  if (buildTargetsInclude(Targets.RUNTIME)) {
     downloadNomoduleOutput();
     downloadModuleOutput();
     timedExecOrDie('gulp bundle-size --on_pr_build');

--- a/build-system/pr-check/checks.js
+++ b/build-system/pr-check/checks.js
@@ -28,14 +28,14 @@ const jobName = 'checks.js';
 
 function pushBuildWorkflow() {
   timedExecOrDie('gulp update-packages');
-  timedExecOrDie('gulp check-exact-versions');
+  timedExecOrDie('gulp presubmit');
   timedExecOrDie('gulp lint');
   timedExecOrDie('gulp prettify');
-  timedExecOrDie('gulp presubmit');
   timedExecOrDie('gulp ava');
   timedExecOrDie('gulp babel-plugin-tests');
   timedExecOrDie('gulp caches-json');
   timedExecOrDie('gulp dev-dashboard-tests');
+  timedExecOrDie('gulp check-exact-versions');
   timedExecOrDie('gulp check-renovate-config');
   timedExecOrDie('gulp server-tests');
   timedExecOrDie('gulp dep-check');
@@ -48,11 +48,17 @@ async function prBuildWorkflow() {
   await reportAllExpectedTests();
   timedExecOrDie('gulp update-packages');
 
-  timedExecOrDie('gulp check-exact-versions');
-  timedExecOrDie('gulp lint');
-  timedExecOrDie('gulp prettify');
-  timedExecOrDie('gulp presubmit');
-  timedExecOrDie('gulp performance-urls');
+  if (buildTargetsInclude(Targets.PRESUBMIT)) {
+    timedExecOrDie('gulp presubmit');
+  }
+
+  if (buildTargetsInclude(Targets.LINT)) {
+    timedExecOrDie('gulp lint');
+  }
+
+  if (buildTargetsInclude(Targets.PRETTIFY)) {
+    timedExecOrDie('gulp prettify');
+  }
 
   if (buildTargetsInclude(Targets.AVA)) {
     timedExecOrDie('gulp ava');
@@ -80,6 +86,10 @@ async function prBuildWorkflow() {
     timedExecOrDie('gulp check-owners --local_changes');
   }
 
+  if (buildTargetsInclude(Targets.PACKAGE_UPGRADE)) {
+    timedExecOrDie('gulp check-exact-versions');
+  }
+
   if (buildTargetsInclude(Targets.RENOVATE_CONFIG)) {
     timedExecOrDie('gulp check-renovate-config');
   }
@@ -92,6 +102,7 @@ async function prBuildWorkflow() {
     timedExecOrDie('gulp dep-check');
     timedExecOrDie('gulp check-types');
     timedExecOrDie('gulp check-sourcemaps');
+    timedExecOrDie('gulp performance-urls');
   }
 }
 

--- a/build-system/pr-check/cross-browser-tests.js
+++ b/build-system/pr-check/cross-browser-tests.js
@@ -91,25 +91,18 @@ async function prBuildWorkflow() {
   if (
     !buildTargetsInclude(
       Targets.RUNTIME,
-      Targets.FLAG_CONFIG,
       Targets.UNIT_TEST,
       Targets.INTEGRATION_TEST
     )
   ) {
     printSkipMessage(
       jobName,
-      'this PR does not affect the runtime, flag configs, unit tests, or integration tests'
+      'this PR does not affect the runtime, unit tests, or integration tests'
     );
     return;
   }
   timedExecOrDie('gulp update-packages');
-  if (
-    buildTargetsInclude(
-      Targets.RUNTIME,
-      Targets.FLAG_CONFIG,
-      Targets.INTEGRATION_TEST
-    )
-  ) {
+  if (buildTargetsInclude(Targets.RUNTIME, Targets.INTEGRATION_TEST)) {
     timedExecOrDie('gulp dist --fortesting');
     runIntegrationTestsForPlatform();
   }

--- a/build-system/pr-check/e2e-tests.js
+++ b/build-system/pr-check/e2e-tests.js
@@ -48,16 +48,14 @@ function pushBuildWorkflow() {
 }
 
 function prBuildWorkflow() {
-  if (
-    buildTargetsInclude(Targets.RUNTIME, Targets.FLAG_CONFIG, Targets.E2E_TEST)
-  ) {
+  if (buildTargetsInclude(Targets.RUNTIME, Targets.E2E_TEST)) {
     downloadNomoduleOutput();
     timedExecOrDie('gulp update-packages');
     timedExecOrDie('gulp e2e --nobuild --headless --compiled');
   } else {
     printSkipMessage(
       jobName,
-      'this PR does not affect the runtime, flag configs, or end-to-end tests'
+      'this PR does not affect the runtime or end-to-end tests'
     );
   }
 }

--- a/build-system/pr-check/module-build.js
+++ b/build-system/pr-check/module-build.js
@@ -39,20 +39,14 @@ function prBuildWorkflow() {
   // TODO(#31102): This list must eventually match the same buildTargets check
   // found in pr-check/nomodule-build.js as we turn on the systems that
   // run against the module build. (ex. visual diffs, e2e, etc.)
-  if (
-    buildTargetsInclude(
-      Targets.RUNTIME,
-      Targets.FLAG_CONFIG,
-      Targets.INTEGRATION_TEST
-    )
-  ) {
+  if (buildTargetsInclude(Targets.RUNTIME, Targets.INTEGRATION_TEST)) {
     timedExecOrDie('gulp update-packages');
     timedExecOrDie('gulp dist --esm --fortesting');
     uploadModuleOutput();
   } else {
     printSkipMessage(
       jobName,
-      'this PR does not affect the runtime, flag configs, or integration tests'
+      'this PR does not affect the runtime or integration tests'
     );
   }
 }

--- a/build-system/pr-check/module-tests.js
+++ b/build-system/pr-check/module-tests.js
@@ -38,13 +38,7 @@ function pushBuildWorkflow() {
 }
 
 function prBuildWorkflow() {
-  if (
-    buildTargetsInclude(
-      Targets.RUNTIME,
-      Targets.FLAG_CONFIG,
-      Targets.INTEGRATION_TEST
-    )
-  ) {
+  if (buildTargetsInclude(Targets.RUNTIME, Targets.INTEGRATION_TEST)) {
     downloadNomoduleOutput();
     downloadModuleOutput();
     timedExecOrDie('gulp update-packages');
@@ -52,7 +46,7 @@ function prBuildWorkflow() {
   } else {
     printSkipMessage(
       jobName,
-      'this PR does not affect the runtime, flag configs, or integration tests'
+      'this PR does not affect the runtime or integration tests'
     );
   }
 }

--- a/build-system/pr-check/nomodule-build.js
+++ b/build-system/pr-check/nomodule-build.js
@@ -47,7 +47,6 @@ async function prBuildWorkflow() {
   if (
     buildTargetsInclude(
       Targets.RUNTIME,
-      Targets.FLAG_CONFIG,
       Targets.INTEGRATION_TEST,
       Targets.E2E_TEST,
       Targets.VISUAL_DIFF
@@ -70,8 +69,7 @@ async function prBuildWorkflow() {
     await signalPrDeployUpload('skipped');
     printSkipMessage(
       jobName,
-      'this PR does not affect the runtime, flag configs, integration ' +
-        'tests, end-to-end tests, or visual diff tests'
+      'this PR does not affect the runtime, integration tests, end-to-end tests, or visual diff tests'
     );
   }
 }

--- a/build-system/pr-check/nomodule-tests.js
+++ b/build-system/pr-check/nomodule-tests.js
@@ -48,20 +48,14 @@ function pushBuildWorkflow() {
 }
 
 function prBuildWorkflow() {
-  if (
-    buildTargetsInclude(
-      Targets.RUNTIME,
-      Targets.FLAG_CONFIG,
-      Targets.INTEGRATION_TEST
-    )
-  ) {
+  if (buildTargetsInclude(Targets.RUNTIME, Targets.INTEGRATION_TEST)) {
     downloadNomoduleOutput();
     timedExecOrDie('gulp update-packages');
     timedExecOrDie('gulp integration --nobuild --compiled --headless');
   } else {
     printSkipMessage(
       jobName,
-      'this PR does not affect the runtime, flag configs, or integration tests'
+      'this PR does not affect the runtime or integration tests'
     );
   }
 }

--- a/build-system/pr-check/unminified-build.js
+++ b/build-system/pr-check/unminified-build.js
@@ -36,20 +36,14 @@ function pushBuildWorkflow() {
 }
 
 function prBuildWorkflow() {
-  if (
-    buildTargetsInclude(
-      Targets.RUNTIME,
-      Targets.FLAG_CONFIG,
-      Targets.INTEGRATION_TEST
-    )
-  ) {
+  if (buildTargetsInclude(Targets.RUNTIME, Targets.INTEGRATION_TEST)) {
     timedExecOrDie('gulp update-packages');
     timedExecOrDie('gulp build --fortesting');
     uploadUnminifiedOutput();
   } else {
     printSkipMessage(
       jobName,
-      'this PR does not affect the runtime, flag configs, or integration tests'
+      'this PR does not affect the runtime or integration tests'
     );
   }
 }

--- a/build-system/pr-check/unminified-tests.js
+++ b/build-system/pr-check/unminified-tests.js
@@ -53,13 +53,7 @@ function pushBuildWorkflow() {
 }
 
 function prBuildWorkflow() {
-  if (
-    buildTargetsInclude(
-      Targets.RUNTIME,
-      Targets.FLAG_CONFIG,
-      Targets.INTEGRATION_TEST
-    )
-  ) {
+  if (buildTargetsInclude(Targets.RUNTIME, Targets.INTEGRATION_TEST)) {
     downloadUnminifiedOutput();
     timedExecOrDie('gulp update-packages');
     timedExecOrDie('gulp integration --nobuild --headless --coverage');
@@ -67,7 +61,7 @@ function prBuildWorkflow() {
   } else {
     printSkipMessage(
       jobName,
-      'this PR does not affect the runtime, flag configs, or integration tests'
+      'this PR does not affect the runtime or integration tests'
     );
   }
 }

--- a/build-system/pr-check/visual-diff-tests.js
+++ b/build-system/pr-check/visual-diff-tests.js
@@ -39,13 +39,7 @@ function pushBuildWorkflow() {
 
 function prBuildWorkflow() {
   process.env['PERCY_TOKEN'] = atob(process.env.PERCY_TOKEN_ENCODED);
-  if (
-    buildTargetsInclude(
-      Targets.RUNTIME,
-      Targets.FLAG_CONFIG,
-      Targets.VISUAL_DIFF
-    )
-  ) {
+  if (buildTargetsInclude(Targets.RUNTIME, Targets.VISUAL_DIFF)) {
     downloadNomoduleOutput();
     timedExecOrDie('gulp update-packages');
     timedExecOrDie('gulp visual-diff --nobuild');
@@ -53,7 +47,7 @@ function prBuildWorkflow() {
     timedExecOrDie('gulp visual-diff --empty');
     printSkipMessage(
       jobName,
-      'this PR does not affect the runtime, flag configs, or visual diff tests'
+      'this PR does not affect the runtime or visual diff tests'
     );
   }
 }

--- a/build-system/tasks/pr-check.js
+++ b/build-system/tasks/pr-check.js
@@ -122,13 +122,7 @@ async function prCheck(cb) {
     runCheck('gulp unit --local_changes --headless');
   }
 
-  if (
-    buildTargetsInclude(
-      Targets.RUNTIME,
-      Targets.FLAG_CONFIG,
-      Targets.INTEGRATION_TEST
-    )
-  ) {
+  if (buildTargetsInclude(Targets.RUNTIME, Targets.INTEGRATION_TEST)) {
     if (!argv.nobuild) {
       runCheck('gulp clean');
       runCheck('gulp dist --fortesting');

--- a/build-system/tasks/pr-check.js
+++ b/build-system/tasks/pr-check.js
@@ -17,17 +17,17 @@
 
 const argv = require('minimist')(process.argv.slice(2));
 const {
-  buildTargetsInclude,
-  determineBuildTargets,
-  Targets,
-} = require('../pr-check/build-targets');
-const {
-  stopTimedJob,
+  abortTimedJob,
   printChangeSummary,
   startTimer,
   stopTimer,
   timedExec,
 } = require('../pr-check/utils');
+const {
+  buildTargetsInclude,
+  determineBuildTargets,
+  Targets,
+} = require('../pr-check/build-targets');
 const {runNpmChecks} = require('../pr-check/npm-checks');
 const {setLoggingPrefix} = require('../common/logging');
 
@@ -57,16 +57,24 @@ async function prCheck(cb) {
 
   const startTime = startTimer(jobName);
   if (!runNpmChecks()) {
-    stopTimedJob(jobName, startTime);
+    abortTimedJob(jobName, startTime);
     failTask();
   }
 
   printChangeSummary();
   determineBuildTargets();
-  runCheck('gulp lint --local_changes');
-  runCheck('gulp prettify --local_changes');
-  runCheck('gulp presubmit');
-  runCheck('gulp check-exact-versions');
+
+  if (buildTargetsInclude(Targets.PRESUBMIT)) {
+    runCheck('gulp presubmit');
+  }
+
+  if (buildTargetsInclude(Targets.LINT)) {
+    runCheck('gulp lint --local_changes');
+  }
+
+  if (buildTargetsInclude(Targets.PRETTIFY)) {
+    runCheck('gulp prettify --local_changes');
+  }
 
   if (buildTargetsInclude(Targets.AVA)) {
     runCheck('gulp ava');
@@ -90,6 +98,10 @@ async function prCheck(cb) {
 
   if (buildTargetsInclude(Targets.OWNERS)) {
     runCheck('gulp check-owners');
+  }
+
+  if (buildTargetsInclude(Targets.PACKAGE_UPGRADE)) {
+    runCheck('gulp check-exact-versions');
   }
 
   if (buildTargetsInclude(Targets.RENOVATE_CONFIG)) {

--- a/build-system/tasks/report-test-status.js
+++ b/build-system/tasks/report-test-status.js
@@ -49,12 +49,9 @@ const TEST_TYPE_SUBTYPES = isGithubActionsBuild()
     ])
   : new Map([]);
 const TEST_TYPE_BUILD_TARGETS = new Map([
-  [
-    'integration',
-    [Targets.RUNTIME, Targets.FLAG_CONFIG, Targets.INTEGRATION_TEST],
-  ],
+  ['integration', [Targets.RUNTIME, Targets.INTEGRATION_TEST]],
   ['unit', [Targets.RUNTIME, Targets.UNIT_TEST]],
-  ['e2e', [Targets.RUNTIME, Targets.FLAG_CONFIG, Targets.E2E_TEST]],
+  ['e2e', [Targets.RUNTIME, Targets.E2E_TEST]],
 ]);
 
 function inferTestType() {


### PR DESCRIPTION
**PR highlights:**

- Add new targets `PRESUBMIT`, `LINT`, and `PRETTIFY` so these checks are run only if necessary
- Remove the obsolete `FLAG_CONFIG` target and roll it into `RUNTIME` (flag config changes will run all runtime tests)
- Add `nonRuntimeTargets` to ensure that the runtime is tested for all files that may affect it (logic is now more transparent)
- Optimize order of checks so that faster running ones run first (fail-fast)
- Add logging to explain that all tests will be run during CI when packages are upgraded
- Fix an old function rename bug in `pr-check.js` (`stopTimedJob` -> `abortTimedJob`)

With these changes, CI will run significantly faster for smaller PRs (e.g. only docs files)