### PR TITLE
🏗 Example of dispersing the build targets

### DIFF
--- a/build-system/pr-check/build-targets/ava.js
+++ b/build-system/pr-check/build-targets/ava.js
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const {isOwnersFile} = require('./owners.js');
+
+/**
+ * Checks if the given file should be considered during PRs.
+ *
+ * @param {string} file
+ * @return {boolean}
+ */
+function matchPredicate(file) {
+  if (isOwnersFile(file)) {
+    return false;
+  }
+  return (
+    file == 'build-system/tasks/ava.js' ||
+    file.startsWith('build-system/tasks/csvify-size/') ||
+    file.startsWith('build-system/tasks/get-zindex/') ||
+    file.startsWith('build-system/tasks/prepend-global/')
+  );
+}
+
+module.exports = {
+  name: 'AVA',
+  matchPredicate,
+};

--- a/build-system/pr-check/build-targets/babel-plugin.js
+++ b/build-system/pr-check/build-targets/babel-plugin.js
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const {isOwnersFile} = require('./owners.js');
+
+/**
+ * Checks if the given file should be considered during PRs.
+ *
+ * @param {string} file
+ * @return {boolean}
+ */
+function matchPredicate(file) {
+  if (isOwnersFile(file)) {
+    return false;
+  }
+  return (
+    file == 'build-system/babel-plugins/log-module-metadata.js' ||
+    file == 'build-system/babel-plugins/static-template-metadata.js' ||
+    file == 'build-system/compile/internal-version.js' ||
+    file == 'build-system/compile/log-messages.js' ||
+    file == 'build-system/tasks/babel-plugin-tests.js' ||
+    file == 'babel.config.js' ||
+    file.startsWith('build-system/babel-plugins/') ||
+    file.startsWith('build-system/babel-config/')
+  );
+}
+
+module.exports = {
+  name: 'BABEL_PLUGIN',
+  matchPredicate,
+};

--- a/build-system/pr-check/build-targets/caches-json.js
+++ b/build-system/pr-check/build-targets/caches-json.js
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Checks if the given file should be considered during PRs.
+ *
+ * @param {string} file
+ * @return {boolean}
+ */
+function matchPredicate(file) {
+  return (
+    file == 'build-system/tasks/caches-json.js' ||
+    file == 'build-system/global-configs/caches.json'
+  );
+}
+
+module.exports = {
+  name: 'CACHES_JSON',
+  matchPredicate,
+};

--- a/build-system/pr-check/build-targets/dev-dashboard.js
+++ b/build-system/pr-check/build-targets/dev-dashboard.js
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const {isOwnersFile} = require('./owners.js');
+
+/**
+ * Checks if the given file should be considered during PRs.
+ *
+ * @param {string} file
+ * @return {boolean}
+ */
+function matchPredicate(file) {
+  if (isOwnersFile(file)) {
+    return false;
+  }
+  return (
+    file == 'build-system/tasks/dev-dashboard-tests.js' ||
+    file == 'build-system/server/app.js' ||
+    file.startsWith('build-system/server/app-index/')
+  );
+}
+
+module.exports = {
+  name: 'DEV_DASHBOARD',
+  matchPredicate,
+};

--- a/build-system/pr-check/build-targets/docs.js
+++ b/build-system/pr-check/build-targets/docs.js
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const path = require('path');
+const {isOwnersFile} = require('./owners.js');
+
+/**
+ * Checks if the given file should be considered during PRs.
+ *
+ * @param {string} file
+ * @return {boolean}
+ */
+function matchPredicate(file) {
+  if (isOwnersFile(file)) {
+    return false;
+  }
+  return (
+    file == 'build-system/tasks/check-links.js' ||
+    (path.extname(file) == '.md' && !file.startsWith('examples/'))
+  );
+}
+
+module.exports = {
+  name: 'DOCS',
+  matchPredicate,
+};

--- a/build-system/pr-check/build-targets/owners.js
+++ b/build-system/pr-check/build-targets/owners.js
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Checks if the given file is an OWNERS file.
+ *
+ * @param {string} file
+ * @return {boolean}
+ */
+function isOwnersFile(file) {
+  return file.endsWith('OWNERS');
+}
+
+/**
+ * Checks if the given file should be considered during PRs.
+ *
+ * @param {string} file
+ * @return {boolean}
+ */
+function matchPredicate(file) {
+  return isOwnersFile(file) || file == 'build-system/tasks/check-owners.js';
+}
+
+module.exports = {
+  name: 'OWNERS',
+  matchPredicate,
+  isOwnersFile,
+};


### PR DESCRIPTION
This is likely not a good idea, but the build-targets are starting to look a lot more like configuration inlined into a single location.

This PR separates them to units of code to be composed by the build-system.