### PR TITLE
Rename vendor-configs target to analytics-vendor-configs

### DIFF
--- a/build-system/tasks/analytics-vendor-configs.js
+++ b/build-system/tasks/analytics-vendor-configs.js
@@ -33,7 +33,7 @@ const {watch} = require('gulp');
  * @param {Object=} opt_options
  * @return {!Promise}
  */
-async function vendorConfigs(opt_options) {
+async function analyticsVendorConfigs(opt_options) {
   const options = opt_options || {};
 
   const srcPath = ['extensions/amp-analytics/0.1/vendors/*.json'];
@@ -48,7 +48,7 @@ async function vendorConfigs(opt_options) {
     // Do not set watchers again when we get called by the watcher.
     const copyOptions = {...options, watch: false, calledByWatcher: true};
     const watchFunc = () => {
-      vendorConfigs(copyOptions);
+      analyticsVendorConfigs(copyOptions);
     };
     watch(srcPath).on('change', debounce(watchFunc, watchDebounceDelay));
   }
@@ -86,7 +86,7 @@ async function vendorConfigs(opt_options) {
 }
 
 module.exports = {
-  vendorConfigs,
+  analyticsVendorConfigs,
 };
 
-vendorConfigs.description = 'Compile analytics vendor configs to dist';
+analyticsVendorConfigs.description = 'Compile analytics vendor configs to dist';

--- a/build-system/tasks/extension-helpers.js
+++ b/build-system/tasks/extension-helpers.js
@@ -23,12 +23,12 @@ const {
   extensionBundles,
   verifyExtensionBundles,
 } = require('../compile/bundles.config');
+const {analyticsVendorConfigs} = require('./analytics-vendor-configs');
 const {endBuildStep, watchDebounceDelay} = require('./helpers');
 const {isCiBuild} = require('../common/ci');
 const {jsifyCssAsync} = require('./jsify-css');
 const {log} = require('../common/logging');
 const {maybeToEsmName, compileJs, mkdirSync} = require('./helpers');
-const {vendorConfigs} = require('./vendor-configs');
 const {watch} = require('gulp');
 
 const {green, red, cyan} = colors;
@@ -453,7 +453,7 @@ async function buildExtension(
     }
   }
   if (name === 'amp-analytics') {
-    await vendorConfigs(options);
+    await analyticsVendorConfigs(options);
   }
   await buildExtensionJs(path, name, version, latestVersion, options);
 }

--- a/build-system/tasks/unit.js
+++ b/build-system/tasks/unit.js
@@ -20,11 +20,11 @@ const {
   RuntimeTestRunner,
   RuntimeTestConfig,
 } = require('./runtime-test/runtime-test-base');
+const {analyticsVendorConfigs} = require('./analytics-vendor-configs');
 const {compileJison} = require('./compile-jison');
 const {css} = require('./css');
 const {getUnitTestsToRun} = require('./runtime-test/helpers-unit');
 const {maybePrintArgvMessages} = require('./runtime-test/helpers');
-const {vendorConfigs} = require('./vendor-configs');
 
 class Runner extends RuntimeTestRunner {
   constructor(config) {
@@ -33,7 +33,7 @@ class Runner extends RuntimeTestRunner {
 
   /** @override */
   async maybeBuild() {
-    await vendorConfigs();
+    await analyticsVendorConfigs();
     await css();
     await compileJison();
   }

--- a/extensions/amp-analytics/0.1/test/test-vendors.js
+++ b/extensions/amp-analytics/0.1/test/test-vendors.js
@@ -137,7 +137,7 @@ describes.realWin(
                 'Request for ' +
                   vendor +
                   ' not found. Please make sure you run ' +
-                  '"gulp vendor-configs" or build amp-analytics ' +
+                  '"gulp analytics-vendor-configs" or build amp-analytics ' +
                   'before running the test'
               );
             }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -23,6 +23,9 @@ const {isCiBuild} = require('./build-system/common/ci');
 const {log} = require('./build-system/common/logging');
 
 const {
+  analyticsVendorConfigs,
+} = require('./build-system/tasks/analytics-vendor-configs');
+const {
   checkExactVersions,
 } = require('./build-system/tasks/check-exact-versions');
 const {
@@ -76,7 +79,6 @@ const {todosFindClosed} = require('./build-system/tasks/todos');
 const {unit} = require('./build-system/tasks/unit');
 const {updatePackages} = require('./build-system/tasks/update-packages');
 const {validator, validatorWebui} = require('./build-system/tasks/validator');
-const {vendorConfigs} = require('./build-system/tasks/vendor-configs');
 const {visualDiff} = require('./build-system/tasks/visual-diff');
 
 /**
@@ -181,6 +183,6 @@ createTask('unit', unit);
 createTask('update-packages', updatePackages);
 createTask('validator', validator);
 createTask('validator-webui', validatorWebui);
-createTask('vendor-configs', vendorConfigs);
+createTask('analytics-vendor-configs', analyticsVendorConfigs);
 createTask('visual-diff', visualDiff);
 createTask('watch', watch);


### PR DESCRIPTION
We are adding a vendor config building step for ads, therefore it seems proper to rename the analytics build task to one with analytics name in it.