### PR TITLE
🚀 Marfeel: update CMP config

### DIFF
--- a/extensions/amp-consent/0.1/cmps.js
+++ b/extensions/amp-consent/0.1/cmps.js
@@ -56,8 +56,8 @@ CMP_CONFIG['sirdata'] = {
 
 CMP_CONFIG['Marfeel'] = {
   'consentInstanceId': 'Marfeel',
-  'checkConsentHref': 'https://live.mrf.io/cmp/consents/amp',
-  'promptUISrc': 'https://marfeel.mgr.consensu.org/amp/index.html',
+  'checkConsentHref': 'https://live.mrf.io/cmp/marfeel/amp/check-consent',
+  'promptUISrc': 'https://live.mrf.io/cmp/marfeel/amp/index.html',
 };
 
 CMP_CONFIG['Ogury'] = {


### PR DESCRIPTION
Update Marfeel's CMP endpoints in config as current ones are deprecated.