### PR TITLE
🏗  CircleCI config fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,10 +6,8 @@ orbs:
 push_and_pr_builds: &push_and_pr_builds
   filters:
     branches:
-      only:
-        - master
-        - /^amp-release-.*$/
-        - /^pull\/.*$/
+      ignore:
+        - nightly
 
 push_builds_only: &push_builds_only
   filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -197,7 +197,7 @@ jobs:
           command: node build-system/pr-check/experiment-tests.js --experiment=experimentC
 
 workflows:
-  'CircleCI PR Check':
+  'CircleCI':
     jobs:
       - 'Checks':
           <<: *push_and_pr_builds

--- a/.circleci/fetch_merge_commit.sh
+++ b/.circleci/fetch_merge_commit.sh
@@ -16,12 +16,13 @@
 #
 # This script fetches the merge commit of a PR branch with master to make sure
 # PRs are tested against all the latest changes.
+#
+# Reference: https://circleci.com/docs/2.0/env-vars/#built-in-environment-variables.
 
 set -e
 err=0
 
 # CIRCLE_PULL_REQUEST is present for PR builds, and absent for push builds.
-# See https://circleci.com/docs/2.0/env-vars/#built-in-environment-variables.
 if [[ -z "$CIRCLE_PULL_REQUEST" ]]; then
   echo -e "Nothing to do because this is not a PR build."
   exit 0
@@ -34,8 +35,8 @@ if [[ ! "$CIRCLE_PULL_REQUEST" =~ ^https://github.com/ampproject/amphtml* ]]; th
 fi
 
 # CIRCLE_PR_NUMBER is present for PRs originating from forks, but absent for PRs
-# originating from a branch on the main repo. In such cases, extract it from
-# $CIRCLE_PULL_REQUEST
+# originating from a branch on the main repo. In such cases, extract the PR
+# number from CIRCLE_PULL_REQUEST.
 if [[ -z "$CIRCLE_PR_NUMBER" ]]; then
   CIRCLE_PR_NUMBER=${CIRCLE_PULL_REQUEST#"https://github.com/ampproject/amphtml/pull/"}
 fi

--- a/.circleci/fetch_merge_commit.sh
+++ b/.circleci/fetch_merge_commit.sh
@@ -37,14 +37,16 @@ fi
 # CIRCLE_PR_NUMBER is present for PRs originating from forks, but absent for PRs
 # originating from a branch on the main repo. In such cases, extract the PR
 # number from CIRCLE_PULL_REQUEST.
-if [[ -z "$CIRCLE_PR_NUMBER" ]]; then
-  CIRCLE_PR_NUMBER=${CIRCLE_PULL_REQUEST#"https://github.com/ampproject/amphtml/pull/"}
+if [[ "$CIRCLE_PR_NUMBER" ]]; then
+  PR_NUMBER=$CIRCLE_PR_NUMBER
+else
+  PR_NUMBER=${CIRCLE_PULL_REQUEST#"https://github.com/ampproject/amphtml/pull/"}
 fi
 
 # GitHub provides refs/pull/<PR_NUMBER>/merge, an up-to-date merge branch for
 # every PR branch that can be cleanly merged to master. For more details, see:
 # https://discuss.circleci.com/t/show-test-results-for-prospective-merge-of-a-github-pr/1662
-MERGE_BRANCH="refs/pull/$CIRCLE_PR_NUMBER/merge"
+MERGE_BRANCH="refs/pull/$PR_NUMBER/merge"
 (set -x && git pull --ff-only origin "$MERGE_BRANCH") || err=$?
 
 

--- a/.circleci/fetch_merge_commit.sh
+++ b/.circleci/fetch_merge_commit.sh
@@ -33,6 +33,13 @@ if [[ ! "$CIRCLE_PULL_REQUEST" =~ ^https://github.com/ampproject/amphtml* ]]; th
   exit 1
 fi
 
+# CIRCLE_PR_NUMBER is present for PRs originating from forks, but absent for PRs
+# originating from a branch on the main repo.
+if [[ -z "$CIRCLE_PR_NUMBER" ]]; then
+  echo -e "Nothing to do because this is not a PR from a fork."
+  exit 0
+fi
+
 # GitHub provides refs/pull/<PR_NUMBER>/merge, an up-to-date merge branch for
 # every PR branch that can be cleanly merged to master. For more details, see:
 # https://discuss.circleci.com/t/show-test-results-for-prospective-merge-of-a-github-pr/1662

--- a/.circleci/fetch_merge_commit.sh
+++ b/.circleci/fetch_merge_commit.sh
@@ -35,17 +35,22 @@ fi
 
 # CIRCLE_PR_NUMBER is present for PRs originating from forks, but absent for PRs
 # originating from a branch on the main repo.
-if [[ -z "$CIRCLE_PR_NUMBER" ]]; then
-  echo -e "Nothing to do because this is not a PR from a fork."
-  exit 0
+if [[ "$CIRCLE_PR_NUMBER" ]]; then
+  # For PRs originating from forks, GitHub provides refs/pull/<PR_NUMBER>/merge,
+  # an up-to-date merge branch for every PR branch that can be cleanly merged to
+  # master. For more details, see:
+  # https://discuss.circleci.com/t/show-test-results-for-prospective-merge-of-a-github-pr/1662
+  MERGE_BRANCH="refs/pull/$CIRCLE_PR_NUMBER/merge"
+  (set -x && git pull --ff-only origin "$MERGE_BRANCH") || err=$?
+else
+  # For PRs originating from a branch on the main repo, we attempt to merge
+  # the PR branch into master.
+  (set -x && git checkout master) || err=$?
+  (set -x && git merge --commit --no-edit "$CIRCLE_BRANCH") || err=$?
 fi
 
-# GitHub provides refs/pull/<PR_NUMBER>/merge, an up-to-date merge branch for
-# every PR branch that can be cleanly merged to master. For more details, see:
-# https://discuss.circleci.com/t/show-test-results-for-prospective-merge-of-a-github-pr/1662
-MERGE_BRANCH="refs/pull/$CIRCLE_PR_NUMBER/merge"
-(set -x && git pull --ff-only origin "$MERGE_BRANCH") || err=$?
-
+# If a clean merge is not possible, do not proceed with the build. GitHub's UI
+# will show an error indicating there was a merge conflict.
 if [[ "$err" -ne "0" ]]; then
   echo
   echo -e "ERROR: Detected a merge conflict between $CIRCLE_BRANCH and master."


### PR DESCRIPTION
**PR highlights:**

- **Fix CircleCI workflow name:** Not all workflows are PR builds (some are push builds), so remove the suffix from the name. This also saves space on the GH commit status message.
- **Fix branch filtering for PR builds:** Not all branches are of the form `pull/12345`. Some are of the form `foo-patch-1`, etc. Instead of an include list, simply ignore the `nightly` branch and build all other branches. (`nightly` always reuses existing `master` commits, so we don't want a new build when it's updated.)
- **Fix merge commit fetching logic:** For PRs originating from branches on the main repo (e.g. `foo-patch-1`), extract the PR number from an env var before fetching the merge commit.

Follow up to #32095