### PR TITLE
Fix <textarea> scrollHeight calculation

### DIFF
--- a/extensions/amp-form/0.1/amp-form-textarea.js
+++ b/extensions/amp-form/0.1/amp-form-textarea.js
@@ -295,7 +295,13 @@ export function maybeResizeTextarea(element) {
         // Prevent the textarea from shrinking if it has not yet expanded.
         const hasExpanded =
           AMP_FORM_TEXTAREA_HAS_EXPANDED_DATA in element.dataset;
-        const shouldResize = hasExpanded || scrollHeight <= minScrollHeight;
+        
+        // There is super specific a bug in Chrome affecting scrollHeight calculation
+        // for textareas with padding when the document is zoomed in.
+        // It makes the scrollHeight calculation off by ~1px.
+        // This is why we have the +3 magic number.
+        // TODO: Fix when chrome bug is resolved: https://github.com/ampproject/amphtml/issues/32291.
+        const shouldResize = hasExpanded || scrollHeight <= minScrollHeight + 3;
 
         if (shouldResize) {
           element.dataset[AMP_FORM_TEXTAREA_HAS_EXPANDED_DATA] = '';

--- a/extensions/amp-form/0.1/amp-form-textarea.js
+++ b/extensions/amp-form/0.1/amp-form-textarea.js
@@ -295,13 +295,15 @@ export function maybeResizeTextarea(element) {
         // Prevent the textarea from shrinking if it has not yet expanded.
         const hasExpanded =
           AMP_FORM_TEXTAREA_HAS_EXPANDED_DATA in element.dataset;
-        
+
         // There is super specific a bug in Chrome affecting scrollHeight calculation
         // for textareas with padding when the document is zoomed in.
         // It makes the scrollHeight calculation off by ~1px.
-        // This is why we have the +3 magic number.
-        // TODO: Fix when chrome bug is resolved: https://github.com/ampproject/amphtml/issues/32291.
-        const shouldResize = hasExpanded || scrollHeight <= minScrollHeight + 3;
+        // This is why we have a small error margin.
+        // TODO: Remove error margin when chrome bug is resolved (https://bugs.chromium.org/p/chromium/issues/detail?id=1171989).
+        const errorMargin = /google/i.test(win.navigator.vendor) ? 3 : 0;
+        const shouldResize =
+          hasExpanded || scrollHeight <= minScrollHeight + errorMargin;
 
         if (shouldResize) {
           element.dataset[AMP_FORM_TEXTAREA_HAS_EXPANDED_DATA] = '';


### PR DESCRIPTION
Fixes https://github.com/ampproject/amphtml/issues/32291 and `b/150231440`

Related: https://bugs.chromium.org/p/chromium/issues/detail?id=1171989