### PR TITLE
🏗 Cache Karma's babel transforms during CircleCI builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,24 @@ executors:
     resource_class: xlarge
 
 commands:
+  save_karma_cache:
+    parameters:
+      cache_name:
+        type: string
+    steps:
+      - save_cache:
+          name: 'Save Karma Cache'
+          key: karma-cache-<<parameters.cache_name>>-{{ checksum "package-lock.json" }}
+          paths:
+            - .karma-cache
+  restore_karma_cache:
+    parameters:
+      cache_name:
+        type: string
+    steps:
+      - restore_cache:
+          name: 'Restore Karma Cache'
+          key: karma-cache-<<parameters.cache_name>>-{{ checksum "package-lock.json" }}
   setup_vm:
     steps:
       - checkout
@@ -126,33 +144,49 @@ jobs:
       name: amphtml-large-executor
     steps:
       - setup_vm
+      - restore_karma_cache:
+          cache_name: unit
       - run:
           name: 'Unit Tests'
           command: node build-system/pr-check/unit-tests.js
+      - save_karma_cache:
+          cache_name: unit
   'Unminified Tests':
     executor:
       name: amphtml-large-executor
     steps:
       - setup_vm
+      - restore_karma_cache:
+          cache_name: unminified
       - run:
           name: 'Unminified Tests'
           command: node build-system/pr-check/unminified-tests.js
+      - save_karma_cache:
+          cache_name: unminified
   'Nomodule Tests':
     executor:
       name: amphtml-large-executor
     steps:
       - setup_vm
+      - restore_karma_cache:
+          cache_name: nomodule
       - run:
           name: 'Nomodule Tests'
           command: node build-system/pr-check/nomodule-tests.js
+      - save_karma_cache:
+          cache_name: nomodule
   'Module Tests':
     executor:
       name: amphtml-large-executor
     steps:
       - setup_vm
+      - restore_karma_cache:
+          cache_name: module
       - run:
           name: 'Module Tests'
           command: node build-system/pr-check/module-tests.js
+      - save_karma_cache:
+          cache_name: module
   'End-to-End Tests':
     executor:
       name: amphtml-large-executor


### PR DESCRIPTION
AMP's Karma tests persist their babel transforms in `.karma-cache`. We lost the ability to cache the directory on Travis due to https://github.com/ampproject/amphtml/pull/28834#discussion_r438964074. This PR reintroduces caching for the directory on CircleCI.

Results are great. We shave off ~30 secs from integration test runs, and ~5 mins from unit test runs. 

**[Cold cache:](https://app.circleci.com/pipelines/github/ampproject/amphtml/780/workflows/6b19ea42-a351-4109-8179-70b1349757f8)**
![image](https://user-images.githubusercontent.com/26553114/106235186-39711d80-61c8-11eb-855a-91baee1cf623.png)

**[Warm cache:](https://app.circleci.com/pipelines/github/ampproject/amphtml/780/workflows/fe50f44f-7da5-4aa9-8b58-a3a9760c584c)**
![image](https://user-images.githubusercontent.com/26553114/106235944-d54f5900-61c9-11eb-8320-2735247276b6.png)


**Coming up:** Caching for babel transforms in end-to-end tests.