### PR TITLE
🏗 Reorganize browserify caching code

### DIFF
--- a/build-system/common/browserify-cache.js
+++ b/build-system/common/browserify-cache.js
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const browserifyPersistFs = require('browserify-persist-fs');
+const crypto = require('crypto');
+const fs = require('fs-extra');
+const globby = require('globby');
+const {dotWrappingWidth} = require('./logging');
+
+/**
+ * Used for persistent babel caching during tests. Created using a hash object
+ * that includes the repo package lockfile and various parts of the build-system
+ * so that the cache is invalidated if any of them changes, and files are
+ * retransformed.
+ * @return {function}
+ */
+function getPersistentBrowserifyCache() {
+  let wrapCounter = 0;
+  const createHash = (input) =>
+    crypto.createHash('sha1').update(input).digest('hex');
+  const hashObject = {
+    deps: createHash(fs.readFileSync('./package-lock.json')),
+    build: globby
+      .sync([
+        'build-system/**/*.js',
+        '!build-system/eslint-rules',
+        '!**/test/**',
+      ])
+      .map((f) => createHash(fs.readFileSync(f))),
+  };
+  const logger = () => {
+    process.stdout.write('.');
+    if (++wrapCounter >= dotWrappingWidth) {
+      wrapCounter = 0;
+      process.stdout.write('\n');
+    }
+  };
+  const cache = browserifyPersistFs('.karma-cache', hashObject, logger);
+  cache.gc(
+    {maxAge: 1000 * 60 * 60 * 24 * 7}, // Refresh cache if more than a week old
+    () => {} // swallow errors
+  );
+  return cache;
+}
+
+module.exports = {
+  getPersistentBrowserifyCache,
+};

--- a/build-system/common/logging.js
+++ b/build-system/common/logging.js
@@ -20,7 +20,7 @@ const {bold, yellow} = require('ansi-colors');
 const {isCiBuild} = require('./ci');
 
 /**
- * Used by tests to wrap progres dots.
+ * Used by tests to wrap progress dots.
  */
 const dotWrappingWidth = 150;
 

--- a/build-system/common/logging.js
+++ b/build-system/common/logging.js
@@ -19,6 +19,14 @@ const log = require('fancy-log');
 const {bold, yellow} = require('ansi-colors');
 const {isCiBuild} = require('./ci');
 
+/**
+ * Used by tests to wrap progres dots.
+ */
+const dotWrappingWidth = 150;
+
+/**
+ * Used by CI job scripts to print a prefix before top-level logging lines.
+ */
 let loggingPrefix = '';
 
 /**
@@ -89,6 +97,7 @@ function logWithoutTimestampLocalDev(...messages) {
 }
 
 module.exports = {
+  dotWrappingWidth,
   getLoggingPrefix,
   log,
   logLocalDev,

--- a/build-system/tasks/e2e/mocha-dots-reporter.js
+++ b/build-system/tasks/e2e/mocha-dots-reporter.js
@@ -25,8 +25,11 @@ const {
   EVENT_TEST_PENDING,
 } = Mocha.Runner.constants;
 const {Base} = Mocha.reporters;
+const {
+  icon,
+  nbDotsPerLine,
+} = require('../../test-configs/karma.conf').superDotsReporter;
 const {green, red, yellow} = require('ansi-colors');
-const {icon, nbDotsPerLine} = require('../karma.conf').superDotsReporter;
 const {reportTestFinished} = require('../report-test-status');
 
 /**

--- a/build-system/tasks/runtime-test/runtime-test-base.js
+++ b/build-system/tasks/runtime-test/runtime-test-base.js
@@ -16,7 +16,7 @@
 'use strict';
 
 const argv = require('minimist')(process.argv.slice(2));
-const karmaConfig = require('../karma.conf');
+const karmaConfig = require('../../test-configs/karma.conf');
 const testConfig = require('../../test-configs/config');
 const {
   createCtrlcHandler,


### PR DESCRIPTION
Browserify caching was introduced in https://github.com/ampproject/amphtml/pull/28157#issue-412022994. It had to be disabled on Travis in https://github.com/ampproject/amphtml/pull/28834#discussion_r438964074, but was reintroduced on CircleCI in https://github.com/ampproject/amphtml/pull/32295#issue-563733319.

This PR cleans up the caching code and moves it into its own file. It also moves `karma.conf.js` to `build-system/test-configs/`.

