### PR TITLE
🏗 Clean up CI config files

### DIFF
--- a/.circleci/fetch_merge_commit.sh
+++ b/.circleci/fetch_merge_commit.sh
@@ -15,7 +15,7 @@
 # limitations under the license.
 #
 # This script fetches the merge commit of a PR branch with master to make sure
-# PRs are tested against all the latest changes.
+# PRs are tested against all the latest changes on CircleCI.
 #
 # Reference: https://circleci.com/docs/2.0/env-vars/#built-in-environment-variables.
 

--- a/.circleci/setup_storage.sh
+++ b/.circleci/setup_storage.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the license.
 #
-# Script used by AMP's CI builds to authenticate with their GCP storage bucket.
+# Script used by AMP's CI builds to authenticate with GCP storage on CircleCI.
 # TODO(rsimha, ampproject/amp-github-apps#1110): Update storage details.
 
 set -e

--- a/.github/workflows/cross-browser-tests.yml
+++ b/.github/workflows/cross-browser-tests.yml
@@ -1,4 +1,4 @@
-name: Cross-Browser Tests
+name: GitHub Actions
 on:
   push:
     branches:
@@ -12,19 +12,13 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, macos-latest, windows-latest]
-        node-version: [12.x]
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Set Up Environment
-        if: ${{ matrix.platform == 'macos-latest' || matrix.platform == 'ubuntu-latest'}}
-        run: sudo chown -R $(whoami) $(npm config get prefix)/{lib/node_modules,bin,share}
-      - name: Install Gulp CLI
-        run: npm install --global --force gulp-cli
       - name: Install Dependencies
-        run: npm install
+        run: bash ./.github/workflows/install_dependencies.sh
       - name: Build and Test
         run: node build-system/pr-check/cross-browser-tests.js

--- a/.github/workflows/install_dependencies.sh
+++ b/.github/workflows/install_dependencies.sh
@@ -14,31 +14,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the license.
 #
-# Script used by AMP's CI builds to install project dependencies on CircleCI.
+# Script used by AMP's CI builds to install project dependencies on GH Actions.
 
 set -e
 
 GREEN() { echo -e "\033[0;32m$1\033[0m"; }
 
-echo $(GREEN "Installing NVM...")
-curl https://raw.githubusercontent.com/creationix/nvm/master/install.sh | bash
+if [[ "$OSTYPE" == "linux-gnu"* || "$OSTYPE" == "darwin"* ]]; then
+  echo $(GREEN "Updating npm prefix...")
+  npm config set prefix "$HOME/.npm"
 
-echo $(GREEN "Setting up NVM environment...")
-export NVM_DIR="/opt/circleci/.nvm"
-[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
-[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"
-
-echo $(GREEN "Installing Node LTS...")
-nvm install 'lts/*'
+  echo $(GREEN "Updating PATH...")
+  echo "export PATH=$HOME/.npm/bin:$PATH" >> $GITHUB_ENV && source $GITHUB_ENV # For now
+  echo "$HOME/.npm/bin" >> $GITHUB_PATH # For later
+fi
 
 echo $(GREEN "Installing gulp-cli...")
 npm install --global gulp-cli
 
 echo $(GREEN "Installing dependencies...")
 npm ci
-
-echo $(GREEN "Setting up environment...")
-NPM_BIN_DIR="`npm config get prefix`/bin"
-(set -x && echo "export PATH=$NPM_BIN_DIR:$PATH" >> $BASH_ENV)
 
 echo $(GREEN "Successfully installed all project dependencies.")


### PR DESCRIPTION
**PR Highlights:**

- GH actions environment setup and dependency installation now lives in `workflows/install_dependencies.sh`
- Remove `node-version` from GH Actions config (it's disregarded and LTS is used anyway)
- Shorten GH actions commit status name (so there's more space for details)
- Clean up comments in script files

**References:**
- https://docs.npmjs.com/cli/v6/commands/npm-config
- https://docs.npmjs.com/cli/v6/commands/npm-prefix
- https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#adding-a-system-path
