### PR TITLE
🏗  Fix bug in build target discovery logic

### DIFF
--- a/build-system/pr-check/build-targets.js
+++ b/build-system/pr-check/build-targets.js
@@ -306,7 +306,7 @@ function determineBuildTargets() {
       const matcher = targetMatchers[target];
       if (matcher(file)) {
         buildTargets.add(target);
-        if (target in nonRuntimeTargets) {
+        if (nonRuntimeTargets.includes(target)) {
           isRuntimeFile = false;
         }
       }


### PR DESCRIPTION
Our build-system contains an [optimization](https://github.com/ampproject/amphtml/pull/32257/files#diff-19e974deb1e4e50db022e0a4c6b920052ff4bb12bf4382375fa2387aa012104cR309) to prevent CI builds from running the whole slew of runtime tests against PRs that are known not to affect the runtime. E.g. Docs-only changes.

There's a bug in the optimization due to the use of `element in array` instead of `array.includes(element)`:
```js
// Correct
['foo', 'bar', 'baz'].includes('foo') // true

// Incorrect
'foo' in ['foo', 'bar', 'baz'] // false
```

With this fix, CI will run much faster for PRs like #32304.