### PR TITLE
📖  Remove email as supported format of accordion 1.0

### DIFF
--- a/extensions/amp-accordion/amp-accordion.md
+++ b/extensions/amp-accordion/amp-accordion.md
@@ -3,7 +3,6 @@ $category@: layout
 formats:
   - websites
   - ads
-  - email
 teaser:
   text: A stacked list of headers that collapse or expand content sections with user interaction.
 experimental: true

--- a/extensions/amp-accordion/amp-accordion.md
+++ b/extensions/amp-accordion/amp-accordion.md
@@ -2,7 +2,6 @@
 $category@: layout
 formats:
   - websites
-  - ads
 teaser:
   text: A stacked list of headers that collapse or expand content sections with user interaction.
 experimental: true


### PR DESCRIPTION
The current validator rules don't allow new AMP extension versions for
the email format by default.

/to @caroqliu @krdwan