### PR TITLE
🐛 getUrl fix enabling shadow docs to have access to the article url and name #32188

### DIFF
--- a/extensions/amp-smartlinks/0.1/amp-smartlinks.js
+++ b/extensions/amp-smartlinks/0.1/amp-smartlinks.js
@@ -203,7 +203,7 @@ export class AmpSmartlinks extends AMP.BaseElement {
       'organization_type': 'publisher',
       'user': {
         'page_session_uuid': this.generateUUID_(),
-        'source_url': this.ampDoc_.getUrl(),
+        'source_url': window.location.href,
         'previous_url': this.referrer_,
         'user_agent': this.ampDoc_.win.navigator.userAgent,
       },

--- a/extensions/amp-smartlinks/0.1/amp-smartlinks.js
+++ b/extensions/amp-smartlinks/0.1/amp-smartlinks.js
@@ -102,7 +102,9 @@ export class AmpSmartlinks extends AMP.BaseElement {
         /** @type {!../../../src/service/xhr-impl.Xhr} */
         (this.xhr_),
         /** @type {!Object} */
-        (this.linkmateOptions_)
+        (this.linkmateOptions_),
+        /** @type {!Object} */
+        (this.win)
       );
       this.smartLinkRewriter_ = this.initLinkRewriter_();
 
@@ -203,11 +205,20 @@ export class AmpSmartlinks extends AMP.BaseElement {
       'organization_type': 'publisher',
       'user': {
         'page_session_uuid': this.generateUUID_(),
-        'source_url': window.location.href,
+        'source_url': this.getLocationHref_(),
         'previous_url': this.referrer_,
         'user_agent': this.ampDoc_.win.navigator.userAgent,
       },
     }));
+  }
+
+  /**
+   * Retrieve url of the current doc.
+   * @return {string}
+   * @private
+   */
+  getLocationHref_() {
+    return this.win.location.href;
   }
 
   /**

--- a/extensions/amp-smartlinks/0.1/linkmate.js
+++ b/extensions/amp-smartlinks/0.1/linkmate.js
@@ -165,8 +165,8 @@ export class Linkmate {
    */
   getEditInfo_() {
     return dict({
-      'name': this.rootNode_.title || null,
-      'url': this.ampDoc_.getUrl(),
+      'name': document.getElementsByTagName("title")[0].text || null,
+      'url': window.location.href,
     });
   }
 

--- a/extensions/amp-smartlinks/0.1/linkmate.js
+++ b/extensions/amp-smartlinks/0.1/linkmate.js
@@ -43,9 +43,6 @@ export class Linkmate {
     /** @private {string} */
     this.linkAttribute_ = linkmateOptions.linkAttribute;
 
-    /** @private {!Document|!ShadowRoot} */
-    this.rootNode_ = this.ampDoc_.getRootNode();
-
     /** @private {?Array<!HTMLElement>} */
     this.anchorList_ = null;
 
@@ -165,7 +162,7 @@ export class Linkmate {
    */
   getEditInfo_() {
     return dict({
-      'name': document.getElementsByTagName("title")[0].text || null,
+      'name': document.getElementsByTagName('title')[0].text || null,
       'url': window.location.href,
     });
   }

--- a/extensions/amp-smartlinks/0.1/linkmate.js
+++ b/extensions/amp-smartlinks/0.1/linkmate.js
@@ -26,11 +26,9 @@ export class Linkmate {
    * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampDoc
    * @param {!../../../src/service/xhr-impl.Xhr} xhr
    * @param {!Object} linkmateOptions
+   * @param {!Object} win
    */
-  constructor(ampDoc, xhr, linkmateOptions) {
-    /** @private {!../../../src/service/ampdoc-impl.AmpDoc} */
-    this.ampDoc_ = ampDoc;
-
+  constructor(ampDoc, xhr, linkmateOptions, win) {
     /** @private {!../../../src/service/xhr-impl.Xhr} */
     this.xhr_ = xhr;
 
@@ -48,6 +46,9 @@ export class Linkmate {
 
     /** @private {?Array<JsonObject>}*/
     this.linkmateResponse_ = null;
+
+    /** @private {?Array<JsonObject>}*/
+    this.win_ = win;
   }
 
   /**
@@ -162,9 +163,31 @@ export class Linkmate {
    */
   getEditInfo_() {
     return dict({
-      'name': document.getElementsByTagName('title')[0].text || null,
-      'url': window.location.href,
+      'name': this.getEditName_(),
+      'url': this.getLocationHref_(),
     });
+  }
+
+  /**
+   * Retrieve edit name.
+   * @return {string}
+   * @private
+   */
+  getEditName_() {
+    let editName = null;
+    if (this.win_.document.getElementsByTagName('title').length > 0) {
+      editName = this.win_.document.getElementsByTagName('title')[0].text;
+    }
+    return editName;
+  }
+
+  /**
+   * Retrieve url of the current doc.
+   * @return {string}
+   * @private
+   */
+  getLocationHref_() {
+    return this.win_.location.href;
   }
 
   /**

--- a/extensions/amp-smartlinks/0.1/test/test-amp-smartlinks.js
+++ b/extensions/amp-smartlinks/0.1/test/test-amp-smartlinks.js
@@ -187,7 +187,6 @@ describes.fakeWin(
           'linkmate': '',
           'exclusive-links': '',
         };
-
         ampSmartlinks = helpers.createAmpSmartlinks(options);
       });
 
@@ -198,7 +197,7 @@ describes.fakeWin(
           .stub(ampSmartlinks, 'generateUUID_')
           .returns('acbacc4b-e171-4869-b32a-921f48659624');
         env.sandbox
-          .stub(env.ampdoc, 'getUrl')
+          .stub(ampSmartlinks, 'getLocationHref_')
           .returns('http://fakewebsite.example/');
 
         const mockPub = 999;

--- a/extensions/amp-smartlinks/0.1/test/test-linkmate.js
+++ b/extensions/amp-smartlinks/0.1/test/test-linkmate.js
@@ -73,7 +73,7 @@ describes.fakeWin(
           publisherID: 999,
           linkAttribute: 'href',
         };
-        linkmate = new Linkmate(env.ampdoc, xhr, linkmateOptions);
+        linkmate = new Linkmate(env.ampdoc, xhr, linkmateOptions, env.win);
         anchorList = [
           {attributeName: 'href', link: 'http://fakelink.example'},
           {attributeName: 'href', link: 'http://fakelink2.example'},
@@ -408,12 +408,12 @@ describes.fakeWin(
           publisherID: 999,
           linkAttribute: 'href',
         };
-        linkmate = new Linkmate(env.ampdoc, xhr, linkmateOptions);
-        const envRoot = env.ampdoc.getRootNode();
-        envRoot.title = 'Fake Website Title';
-
+        linkmate = new Linkmate(env.ampdoc, xhr, linkmateOptions, env.win);
         env.sandbox
-          .stub(env.ampdoc, 'getUrl')
+          .stub(linkmate, 'getEditName_')
+          .returns('Fake Website Title');
+        env.sandbox
+          .stub(linkmate, 'getLocationHref_')
           .returns('http://fakewebsite.example/');
         env.sandbox.spy(linkmate, 'getEditInfo_');
 


### PR DESCRIPTION
@ampproject/wg-components fixes #32188
'window.location.href' allows you get the url of the current article url, regardless of whether your current article doc is a shadow doc or a single doc. Similarly, 'document.getElementsByTagName("title")[0].text' will grab the title of the current article, regardless of whether your current article doc is a shadow doc or a single doc.
These changes are needed to correctly populate the payloads for the Linkmate API call and the page impression API call that indicates a page load event has happened.
/cc @dvoytenko