### PR TITLE
✅ Clean up e2e test fixture urls

### DIFF
--- a/build-system/tasks/e2e/describes-e2e.js
+++ b/build-system/tasks/e2e/describes-e2e.js
@@ -531,7 +531,12 @@ function describeEnv(factory) {
     if (!versions) {
       // If a version is provided, add a prefix to the test suite name.
       const {version} = spec;
-      templateFunc(version ? `[v{version} ${name}` : name, spec, fn, describe);
+      templateFunc(
+        version ? `[v${version}] ${name}` : name,
+        spec,
+        fn,
+        describe
+      );
     } else {
       // A root `describes.endtoend` spec may contain a `versions` object, where
       // the key represents the version number and the value is an object with
@@ -587,6 +592,7 @@ class EndToEndFixture {
     const ampDriver = new AmpDriver(controller);
     env.controller = controller;
     env.ampDriver = ampDriver;
+    env.version = this.spec.version;
 
     installBrowserAssertions(controller.networkLogger);
 

--- a/build-system/tasks/e2e/describes-e2e.js
+++ b/build-system/tasks/e2e/describes-e2e.js
@@ -230,7 +230,7 @@ function getFirefoxArgs(config) {
  * @typedef {{
  *  browsers: (!Array<string>|undefined),
  *  environments: (!Array<!AmpdocEnvironment>|undefined),
- *  testUrl: string,
+ *  testUrl: string|undefined,
  *  fixture: string,
  *  manualFixture: string,
  *  initialRect: ({{width: number, height:number}}|undefined),
@@ -244,7 +244,7 @@ let TestSpec;
  * @typedef {{
  *  browsers: (!Array<string>|undefined),
  *  environments: (!Array<!AmpdocEnvironment>|undefined),
- *  testUrl: string,
+ *  testUrl: string|undefined,
  *  fixture: string,
  *  manualFixture: string,
  *  initialRect: ({{width: number, height:number}}|undefined),
@@ -628,10 +628,13 @@ class EndToEndFixture {
     // eventually be removed entirely.
     let {testUrl} = spec;
     const {fixture, manualFixture} = spec;
-    if (!!testUrl + !!fixture + !!manualFixture > 1) {
+    if (testUrl) {
       throw new Error(
-        'Only one of [testUrl, fixture, manualFixture] may be specified'
+        'Setting `testUrl` directly is no longer permitted in e2e tests; please use `fixture` instead'
       );
+    }
+    if (fixture && manualFixture) {
+      throw new Error('Only one of [fixture, manualFixture] may be specified');
     }
 
     if (fixture) {

--- a/extensions/amp-ad-exit/0.1/test-e2e/test-amp-ad-exit.js
+++ b/extensions/amp-ad-exit/0.1/test-e2e/test-amp-ad-exit.js
@@ -17,8 +17,7 @@
 describes.endtoend(
   'amp-ad-exit',
   {
-    testUrl:
-      'http://localhost:8000/test/fixtures/e2e/amphtml-ads/amp-ad-exit.amp.html',
+    fixture: 'amphtml-ads/amp-ad-exit.amp.html',
     environments: 'amp4ads-preset',
   },
   (env) => {

--- a/extensions/amp-analytics/0.1/test-e2e/test-iframe-transport.js
+++ b/extensions/amp-analytics/0.1/test-e2e/test-iframe-transport.js
@@ -17,8 +17,7 @@
 describes.endtoend(
   'amp-analytics iframe transport',
   {
-    testUrl:
-      'http://localhost:8000/test/fixtures/e2e/amphtml-ads/botguard.a4a.html',
+    fixture: 'amphtml-ads/botguard.a4a.html',
     environments: ['a4a-fie'],
   },
   (env) => {

--- a/extensions/amp-animation/0.1/test-e2e/test-amp-animation.js
+++ b/extensions/amp-animation/0.1/test-e2e/test-amp-animation.js
@@ -17,8 +17,7 @@
 describes.endtoend(
   'amp-animation',
   {
-    testUrl:
-      'http://localhost:8000/test/fixtures/e2e/amp-animation/simple.html',
+    fixture: 'amp-animation/simple.html',
     // TODO(powerivq): Reenable for all environments
     environments: 'amp4ads-preset',
   },

--- a/extensions/amp-auto-lightbox/0.1/test-e2e/test-amp-auto-lightbox.js
+++ b/extensions/amp-auto-lightbox/0.1/test-e2e/test-amp-auto-lightbox.js
@@ -17,8 +17,7 @@
 describes.endtoend(
   'amp-auto-lightbox e2e',
   {
-    testUrl:
-      'http://localhost:8000/test/fixtures/e2e/amp-auto-lightbox/amp-auto-lightbox.html',
+    fixture: 'amp-auto-lightbox/amp-auto-lightbox.html',
     initialRect: {width: 600, height: 600},
     environments: ['single'],
     browsers: ['chrome'],

--- a/extensions/amp-autocomplete/0.1/test-e2e/test-amp-autocomplete-inline.js
+++ b/extensions/amp-autocomplete/0.1/test-e2e/test-amp-autocomplete-inline.js
@@ -17,8 +17,7 @@
 describes.endtoend(
   'amp-autocomplete',
   {
-    testUrl:
-      'http://localhost:8000/test/fixtures/e2e/amp-autocomplete/amp-autocomplete-inline.amp.html',
+    fixture: 'amp-autocomplete/amp-autocomplete-inline.amp.html',
     // TODO: Restore 'environments' to default after supporting fourth test in
     // shadow environment.
     environments: ['single', 'viewer-demo'],

--- a/extensions/amp-autocomplete/0.1/test-e2e/test-amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/test-e2e/test-amp-autocomplete.js
@@ -17,8 +17,7 @@
 describes.endtoend(
   'amp-autocomplete',
   {
-    testUrl:
-      'http://localhost:8000/test/fixtures/e2e/amp-autocomplete/amp-autocomplete.amp.html',
+    fixture: 'amp-autocomplete/amp-autocomplete.amp.html',
     // TODO: Restore 'environments' to default after supporting fourth test in
     // shadow environment.
     environments: ['single', 'viewer-demo'],

--- a/extensions/amp-base-carousel/0.1/test-e2e/test-advance.js
+++ b/extensions/amp-base-carousel/0.1/test-e2e/test-advance.js
@@ -22,8 +22,7 @@ const pageHeight = 800;
 describes.endtoend(
   'amp-base-carousel:0.1 - advance',
   {
-    testUrl:
-      'http://localhost:8000/test/manual/amp-base-carousel/advance.amp.html',
+    manualFixture: 'amp-base-carousel/advance.amp.html',
     experiments: ['amp-base-carousel'],
     environments: ['single'],
     initialRect: {width: pageWidth, height: pageHeight},

--- a/extensions/amp-base-carousel/0.1/test-e2e/test-arrows-non-looping.js
+++ b/extensions/amp-base-carousel/0.1/test-e2e/test-arrows-non-looping.js
@@ -24,8 +24,7 @@ const pageHeight = 600;
 describes.endtoend(
   'amp-base-carousel:0.1 - arrows when non-looping',
   {
-    testUrl:
-      'http://localhost:8000/test/manual/amp-base-carousel/non-looping.amp.html',
+    manualFixture: 'amp-base-carousel/non-looping.amp.html',
     experiments: ['amp-base-carousel', 'layers'],
     initialRect: {width: pageWidth, height: pageHeight},
     //TODO(spaharmi): fails on shadow demo

--- a/extensions/amp-base-carousel/0.1/test-e2e/test-arrows.js
+++ b/extensions/amp-base-carousel/0.1/test-e2e/test-arrows.js
@@ -22,8 +22,7 @@ const SLIDE_COUNT = 7;
 describes.endtoend(
   'amp-base-carousel:0.1 - arrows with custom arrows',
   {
-    testUrl:
-      'http://localhost:8000/test/manual/amp-base-carousel/custom-arrows.amp.html',
+    manualFixture: 'amp-base-carousel/custom-arrows.amp.html',
     experiments: [
       'amp-base-carousel',
       'layers',

--- a/extensions/amp-base-carousel/0.1/test-e2e/test-autoadvance.js
+++ b/extensions/amp-base-carousel/0.1/test-e2e/test-autoadvance.js
@@ -22,8 +22,7 @@ const pageHeight = 600;
 describes.endtoend(
   'amp-base-carousel:0.1 - autoadvance',
   {
-    testUrl:
-      'http://localhost:8000/test/manual/amp-base-carousel/autoadvance.amp.html',
+    manualFixture: 'amp-base-carousel/autoadvance.amp.html',
     experiments: ['amp-base-carousel', 'layers'],
     initialRect: {width: pageWidth, height: pageHeight},
   },

--- a/extensions/amp-base-carousel/0.1/test-e2e/test-carousel.js
+++ b/extensions/amp-base-carousel/0.1/test-e2e/test-carousel.js
@@ -25,8 +25,7 @@ const testTimeout = 20000;
 describes.endtoend(
   'amp-base-carousel:0.1 - basic functionality',
   {
-    testUrl:
-      'http://localhost:8000/test/manual/amp-base-carousel/basic.amp.html',
+    manualFixture: 'amp-base-carousel/basic.amp.html',
     experiments: [
       'amp-base-carousel',
       'amp-lightbox-gallery-base-carousel',

--- a/extensions/amp-base-carousel/0.1/test-e2e/test-default-attributes.js
+++ b/extensions/amp-base-carousel/0.1/test-e2e/test-default-attributes.js
@@ -20,8 +20,7 @@ const pageHeight = 800;
 describes.endtoend(
   'amp-base-carousel:0.1 - default attributes',
   {
-    testUrl:
-      'http://localhost:8000/test/manual/amp-base-carousel/default-attributes.amp.html',
+    manualFixture: 'amp-base-carousel/default-attributes.amp.html',
     // TODO (micajuineho): Add viewer-demo support.
     environments: ['single'],
     initialRect: {width: pageWidth, height: pageHeight},

--- a/extensions/amp-base-carousel/0.1/test-e2e/test-grouping.js
+++ b/extensions/amp-base-carousel/0.1/test-e2e/test-grouping.js
@@ -22,9 +22,7 @@ const pageHeight = 600;
 describes.endtoend(
   'amp-base-carousel:0.1 - grouping',
   {
-    testUrl:
-      'http://localhost:8000/test/manual/amp-base-carousel/' +
-      'grouping-move-by-2.amp.html',
+    manualFixture: 'amp-base-carousel/grouping-move-by-2.amp.html',
     experiments: ['amp-base-carousel', 'layers'],
     initialRect: {width: pageWidth, height: pageHeight},
   },

--- a/extensions/amp-base-carousel/0.1/test-e2e/test-hidden-controls.js
+++ b/extensions/amp-base-carousel/0.1/test-e2e/test-hidden-controls.js
@@ -19,8 +19,7 @@ import {getNextArrow} from './helpers';
 describes.endtoend(
   'amp-base-carousel:0.1 - arrows with hidden controls',
   {
-    testUrl:
-      'http://localhost:8000/test/manual/amp-base-carousel/hidden-controls.amp.html',
+    manualFixture: 'amp-base-carousel/hidden-controls.amp.html',
     experiments: ['amp-base-carousel'],
     environments: ['single'],
   },

--- a/extensions/amp-base-carousel/0.1/test-e2e/test-initial-slide.js
+++ b/extensions/amp-base-carousel/0.1/test-e2e/test-initial-slide.js
@@ -22,9 +22,7 @@ const pageHeight = 600;
 describes.endtoend(
   'amp-base-carousel:0.1 - initial slide',
   {
-    testUrl:
-      'http://localhost:8000/test/manual/amp-base-carousel/' +
-      'initial-slide.amp.html',
+    manualFixture: 'amp-base-carousel/initial-slide.amp.html',
     experiments: ['amp-base-carousel', 'layers'],
     initialRect: {width: pageWidth, height: pageHeight},
   },

--- a/extensions/amp-base-carousel/0.1/test-e2e/test-mixed-length-arrows.js
+++ b/extensions/amp-base-carousel/0.1/test-e2e/test-mixed-length-arrows.js
@@ -19,8 +19,7 @@ import {getNextArrow, getPrevArrow} from './helpers';
 describes.endtoend(
   'amp-base-carousel:0.1 - mixed length carousel arrows',
   {
-    testUrl:
-      'http://localhost:8000/test/manual/amp-base-carousel/no-arrows.amp.html',
+    manualFixture: 'amp-base-carousel/no-arrows.amp.html',
     environments: ['single'],
   },
   async function (env) {

--- a/extensions/amp-base-carousel/0.1/test-e2e/test-mixed-lengths-no-snap.js
+++ b/extensions/amp-base-carousel/0.1/test-e2e/test-mixed-lengths-no-snap.js
@@ -22,9 +22,7 @@ const pageHeight = 600;
 describes.endtoend(
   'amp-base-carousel:0.1 - mixed length slides without snapping',
   {
-    testUrl:
-      'http://localhost:8000/test/manual/amp-base-carousel/' +
-      'mixed-lengths-no-snap.amp.html',
+    manualFixture: 'amp-base-carousel/mixed-lengths-no-snap.amp.html',
     experiments: ['amp-base-carousel', 'layers'],
     initialRect: {width: pageWidth, height: pageHeight},
     //TODO(spaharmi): fails on viewer and shadow demo

--- a/extensions/amp-base-carousel/0.1/test-e2e/test-mixed-lengths.js
+++ b/extensions/amp-base-carousel/0.1/test-e2e/test-mixed-lengths.js
@@ -22,9 +22,7 @@ const pageHeight = 600;
 describes.endtoend(
   'amp-base-carousel:0.1 - mixed length slides',
   {
-    testUrl:
-      'http://localhost:8000/test/manual/amp-base-carousel/' +
-      'mixed-lengths.amp.html',
+    manualFixture: 'amp-base-carousel/mixed-lengths.amp.html',
     experiments: ['amp-base-carousel', 'layers'],
     initialRect: {width: pageWidth, height: pageHeight},
   },

--- a/extensions/amp-base-carousel/0.1/test-e2e/test-multi-visible-single-advance.js
+++ b/extensions/amp-base-carousel/0.1/test-e2e/test-multi-visible-single-advance.js
@@ -19,8 +19,7 @@ import {getNextArrow, getPrevArrow, getSlides, sleep} from './helpers';
 describes.endtoend(
   'amp-base-carousel:0.1 - advancing with multiple visible slides',
   {
-    testUrl:
-      'http://localhost:8000/test/manual/amp-base-carousel/multi-visible-single-advance.amp.html',
+    manualFixture: 'amp-base-carousel/multi-visible-single-advance.amp.html',
     environments: ['single'],
   },
   async function (env) {

--- a/extensions/amp-base-carousel/0.1/test-e2e/test-non-looping.js
+++ b/extensions/amp-base-carousel/0.1/test-e2e/test-non-looping.js
@@ -22,9 +22,7 @@ const pageHeight = 600;
 describes.endtoend(
   'amp-base-carousel:0.1 - non-looping',
   {
-    testUrl:
-      'http://localhost:8000/test/manual/amp-base-carousel/' +
-      'non-looping.amp.html',
+    manualFixture: 'amp-base-carousel/non-looping.amp.html',
     experiments: ['amp-base-carousel', 'layers'],
     initialRect: {width: pageWidth, height: pageHeight},
   },

--- a/extensions/amp-base-carousel/0.1/test-e2e/test-responsive.js
+++ b/extensions/amp-base-carousel/0.1/test-e2e/test-responsive.js
@@ -22,9 +22,7 @@ const pageHeight = 600;
 describes.endtoend(
   'amp-base-carousel:0.1 - responsive attributes',
   {
-    testUrl:
-      'http://localhost:8000/test/manual/amp-base-carousel/' +
-      'responsive.amp.html',
+    manualFixture: 'amp-base-carousel/responsive.amp.html',
     experiments: ['amp-base-carousel', 'layers'],
     initialRect: {width: pageWidth, height: pageHeight},
     //TODO(spaharmi): fails on shadow demo

--- a/extensions/amp-base-carousel/0.1/test-e2e/test-rtl.js
+++ b/extensions/amp-base-carousel/0.1/test-e2e/test-rtl.js
@@ -23,8 +23,7 @@ const arrowMargin = 12;
 describes.endtoend(
   'amp-base-carousel:0.1 - rtl',
   {
-    testUrl:
-      'http://localhost:8000/test/manual/amp-base-carousel/basic-rtl.amp.html',
+    manualFixture: 'amp-base-carousel/basic-rtl.amp.html',
     experiments: ['amp-base-carousel', 'layers'],
     initialRect: {width: pageWidth, height: pageHeight},
     // TODO(sparhami) Make other environments work too

--- a/extensions/amp-base-carousel/0.1/test-e2e/test-snap-property.js
+++ b/extensions/amp-base-carousel/0.1/test-e2e/test-snap-property.js
@@ -19,8 +19,7 @@ import {getSlides, getSpacers} from './helpers';
 describes.endtoend(
   'amp-base-carousel:0.1 - snap property',
   {
-    testUrl:
-      'http://localhost:8000/test/manual/amp-base-carousel/snap-property.amp.html',
+    manualFixture: 'amp-base-carousel/snap-property.amp.html',
     environments: ['single'],
   },
   async function (env) {

--- a/extensions/amp-base-carousel/0.1/test-e2e/test-vertical.js
+++ b/extensions/amp-base-carousel/0.1/test-e2e/test-vertical.js
@@ -22,9 +22,7 @@ const pageHeight = 600;
 describes.endtoend(
   'amp-base-carousel:0.1 - vertical orientation',
   {
-    testUrl:
-      'http://localhost:8000/test/manual/amp-base-carousel/' +
-      'vertical.amp.html',
+    manualFixture: 'amp-base-carousel/vertical.amp.html',
     experiments: ['amp-base-carousel', 'layers'],
     initialRect: {width: pageWidth, height: pageHeight},
   },

--- a/extensions/amp-base-carousel/1.0/test-e2e/test-advance.js
+++ b/extensions/amp-base-carousel/1.0/test-e2e/test-advance.js
@@ -29,8 +29,7 @@ const pageHeight = 800;
 describes.endtoend(
   'amp-base-carousel:1.0 - advance',
   {
-    testUrl:
-      'http://localhost:8000/test/manual/amp-base-carousel/1.0/advance.amp.html',
+    manualFixture: 'amp-base-carousel/1.0/advance.amp.html',
     experiments: ['bento-carousel'],
     environments: ['single'],
     initialRect: {width: pageWidth, height: pageHeight},

--- a/extensions/amp-base-carousel/1.0/test-e2e/test-arrows-non-looping.js
+++ b/extensions/amp-base-carousel/1.0/test-e2e/test-arrows-non-looping.js
@@ -30,8 +30,7 @@ const pageHeight = 600;
 describes.endtoend(
   'amp-base-carousel:1.0 - arrows when non-looping',
   {
-    testUrl:
-      'http://localhost:8000/test/manual/amp-base-carousel/1.0/non-looping.amp.html',
+    manualFixture: 'amp-base-carousel/1.0/non-looping.amp.html',
     experiments: ['bento-carousel'],
     initialRect: {width: pageWidth, height: pageHeight},
     environments: ['single', 'viewer-demo'],

--- a/extensions/amp-base-carousel/1.0/test-e2e/test-arrows.js
+++ b/extensions/amp-base-carousel/1.0/test-e2e/test-arrows.js
@@ -28,8 +28,7 @@ const SLIDE_COUNT = 7;
 describes.endtoend(
   'amp-base-carousel:1.0 - arrows with custom arrows',
   {
-    testUrl:
-      'http://localhost:8000/test/manual/amp-base-carousel/1.0/custom-arrows.amp.html',
+    manualFixture: 'amp-base-carousel/1.0/custom-arrows.amp.html',
     experiments: ['bento-carousel'],
     environments: ['single', 'viewer-demo'],
   },

--- a/extensions/amp-base-carousel/1.0/test-e2e/test-autoadvance.js
+++ b/extensions/amp-base-carousel/1.0/test-e2e/test-autoadvance.js
@@ -23,8 +23,7 @@ const pageHeight = 600;
 describes.endtoend(
   'amp-base-carousel:1.0 - autoadvance',
   {
-    testUrl:
-      'http://localhost:8000/test/manual/amp-base-carousel/1.0/autoadvance.amp.html',
+    manualFixture: 'amp-base-carousel/1.0/autoadvance.amp.html',
     experiments: ['bento-carousel'],
     initialRect: {width: pageWidth, height: pageHeight},
     environments: ['single', 'viewer-demo'],

--- a/extensions/amp-base-carousel/1.0/test-e2e/test-carousel.js
+++ b/extensions/amp-base-carousel/1.0/test-e2e/test-carousel.js
@@ -26,8 +26,7 @@ const testTimeout = 40000;
 describes.endtoend(
   'amp-base-carousel:1.0 - basic functionality',
   {
-    testUrl:
-      'http://localhost:8000/test/manual/amp-base-carousel/1.0/basic.amp.html',
+    manualFixture: 'amp-base-carousel/1.0/basic.amp.html',
     experiments: ['bento-carousel'],
     initialRect: {width: pageWidth, height: pageHeight},
     environments: ['single', 'viewer-demo'],

--- a/extensions/amp-base-carousel/1.0/test-e2e/test-grouping.js
+++ b/extensions/amp-base-carousel/1.0/test-e2e/test-grouping.js
@@ -27,7 +27,7 @@ const expectedScrollPosition = (pageWidth / advanceCount) * pivotIndex;
 describes.endtoend(
   'amp-base-carousel:1.0 - grouping',
   {
-    manualFixture: 'amp-base-carousel/1.0/' + 'grouping-move-by-2.amp.html',
+    manualFixture: 'amp-base-carousel/1.0/grouping-move-by-2.amp.html',
     experiments: ['bento-carousel'],
     initialRect: {width: pageWidth, height: pageHeight},
     environments: ['single'],

--- a/extensions/amp-base-carousel/1.0/test-e2e/test-grouping.js
+++ b/extensions/amp-base-carousel/1.0/test-e2e/test-grouping.js
@@ -27,9 +27,7 @@ const expectedScrollPosition = (pageWidth / advanceCount) * pivotIndex;
 describes.endtoend(
   'amp-base-carousel:1.0 - grouping',
   {
-    testUrl:
-      'http://localhost:8000/test/manual/amp-base-carousel/1.0/' +
-      'grouping-move-by-2.amp.html',
+    manualFixture: 'amp-base-carousel/1.0/' + 'grouping-move-by-2.amp.html',
     experiments: ['bento-carousel'],
     initialRect: {width: pageWidth, height: pageHeight},
     environments: ['single'],

--- a/extensions/amp-base-carousel/1.0/test-e2e/test-mixed-lengths-no-snap.js
+++ b/extensions/amp-base-carousel/1.0/test-e2e/test-mixed-lengths-no-snap.js
@@ -23,7 +23,7 @@ const pageHeight = 600;
 describes.endtoend(
   'amp-base-carousel:1.0 - mixed length slides without snapping',
   {
-    manualFixture: 'amp-base-carousel/1.0/' + 'mixed-lengths-no-snap.amp.html',
+    manualFixture: 'amp-base-carousel/1.0/mixed-lengths-no-snap.amp.html',
     experiments: ['bento-carousel'],
     initialRect: {width: pageWidth, height: pageHeight},
     environments: ['single', 'viewer-demo'],

--- a/extensions/amp-base-carousel/1.0/test-e2e/test-mixed-lengths-no-snap.js
+++ b/extensions/amp-base-carousel/1.0/test-e2e/test-mixed-lengths-no-snap.js
@@ -23,9 +23,7 @@ const pageHeight = 600;
 describes.endtoend(
   'amp-base-carousel:1.0 - mixed length slides without snapping',
   {
-    testUrl:
-      'http://localhost:8000/test/manual/amp-base-carousel/1.0/' +
-      'mixed-lengths-no-snap.amp.html',
+    manualFixture: 'amp-base-carousel/1.0/' + 'mixed-lengths-no-snap.amp.html',
     experiments: ['bento-carousel'],
     initialRect: {width: pageWidth, height: pageHeight},
     environments: ['single', 'viewer-demo'],

--- a/extensions/amp-base-carousel/1.0/test-e2e/test-mixed-lengths.js
+++ b/extensions/amp-base-carousel/1.0/test-e2e/test-mixed-lengths.js
@@ -23,9 +23,7 @@ const pageHeight = 600;
 describes.endtoend(
   'amp-base-carousel:1.0 - mixed length slides',
   {
-    testUrl:
-      'http://localhost:8000/test/manual/amp-base-carousel/1.0/' +
-      'mixed-lengths.amp.html',
+    manualFixture: 'amp-base-carousel/1.0/' + 'mixed-lengths.amp.html',
     experiments: ['bento-carousel'],
     environments: ['single', 'viewer-demo'],
     initialRect: {width: pageWidth, height: pageHeight},

--- a/extensions/amp-base-carousel/1.0/test-e2e/test-mixed-lengths.js
+++ b/extensions/amp-base-carousel/1.0/test-e2e/test-mixed-lengths.js
@@ -23,7 +23,7 @@ const pageHeight = 600;
 describes.endtoend(
   'amp-base-carousel:1.0 - mixed length slides',
   {
-    manualFixture: 'amp-base-carousel/1.0/' + 'mixed-lengths.amp.html',
+    manualFixture: 'amp-base-carousel/1.0/mixed-lengths.amp.html',
     experiments: ['bento-carousel'],
     environments: ['single', 'viewer-demo'],
     initialRect: {width: pageWidth, height: pageHeight},

--- a/extensions/amp-base-carousel/1.0/test-e2e/test-non-looping.js
+++ b/extensions/amp-base-carousel/1.0/test-e2e/test-non-looping.js
@@ -23,7 +23,7 @@ const pageHeight = 600;
 describes.endtoend(
   'amp-base-carousel:1.0 - non-looping',
   {
-    manualFixture: 'amp-base-carousel/1.0/' + 'non-looping.amp.html',
+    manualFixture: 'amp-base-carousel/1.0/non-looping.amp.html',
     experiments: ['bento-carousel'],
     environments: ['single', 'viewer-demo'],
     initialRect: {width: pageWidth, height: pageHeight},

--- a/extensions/amp-base-carousel/1.0/test-e2e/test-non-looping.js
+++ b/extensions/amp-base-carousel/1.0/test-e2e/test-non-looping.js
@@ -23,9 +23,7 @@ const pageHeight = 600;
 describes.endtoend(
   'amp-base-carousel:1.0 - non-looping',
   {
-    testUrl:
-      'http://localhost:8000/test/manual/amp-base-carousel/1.0/' +
-      'non-looping.amp.html',
+    manualFixture: 'amp-base-carousel/1.0/' + 'non-looping.amp.html',
     experiments: ['bento-carousel'],
     environments: ['single', 'viewer-demo'],
     initialRect: {width: pageWidth, height: pageHeight},

--- a/extensions/amp-base-carousel/1.0/test-e2e/test-responsive.js
+++ b/extensions/amp-base-carousel/1.0/test-e2e/test-responsive.js
@@ -23,9 +23,7 @@ const pageHeight = 600;
 describes.endtoend(
   'amp-base-carousel:1.0 - responsive attributes',
   {
-    testUrl:
-      'http://localhost:8000/test/manual/amp-base-carousel/1.0/' +
-      'responsive.amp.html',
+    manualFixture: 'amp-base-carousel/1.0/responsive.amp.html',
     experiments: ['bento-carousel'],
     initialRect: {width: pageWidth, height: pageHeight},
     environments: ['single', 'viewer-demo'],

--- a/extensions/amp-base-carousel/1.0/test-e2e/test-rtl.js
+++ b/extensions/amp-base-carousel/1.0/test-e2e/test-rtl.js
@@ -23,8 +23,7 @@ const pageHeight = 600;
 describes.endtoend(
   'amp-base-carousel:1.0 - rtl',
   {
-    testUrl:
-      'http://localhost:8000/test/manual/amp-base-carousel/1.0/basic-rtl.amp.html',
+    manualFixture: 'amp-base-carousel/1.0/basic-rtl.amp.html',
     experiments: ['bento-carousel'],
     initialRect: {width: pageWidth, height: pageHeight},
     environments: ['single'],

--- a/extensions/amp-base-carousel/1.0/test-e2e/test-vertical.js
+++ b/extensions/amp-base-carousel/1.0/test-e2e/test-vertical.js
@@ -23,9 +23,7 @@ const pageHeight = 600;
 describes.endtoend(
   'amp-base-carousel:1.0 - vertical orientation',
   {
-    testUrl:
-      'http://localhost:8000/test/manual/amp-base-carousel/1.0/' +
-      'vertical.amp.html',
+    manualFixture: 'amp-base-carousel/1.0/vertical.amp.html',
     experiments: ['bento-carousel'],
     initialRect: {width: pageWidth, height: pageHeight},
     environments: ['single', 'viewer-demo'],

--- a/extensions/amp-carousel/0.1/test-e2e/test-hidden-controls.js
+++ b/extensions/amp-carousel/0.1/test-e2e/test-hidden-controls.js
@@ -17,7 +17,7 @@
 describes.endtoend(
   'AMP carousel 0.1 buttons with hidden controls',
   {
-    manualFixture: 'amp-carousel/0.1/hidden-controls.amp.html',
+    fixture: 'amp-carousel/0.1/hidden-controls.amp.html',
     experiments: ['amp-carousel'],
     environments: ['single'],
   },

--- a/extensions/amp-carousel/0.1/test-e2e/test-hidden-controls.js
+++ b/extensions/amp-carousel/0.1/test-e2e/test-hidden-controls.js
@@ -17,8 +17,7 @@
 describes.endtoend(
   'AMP carousel 0.1 buttons with hidden controls',
   {
-    testUrl:
-      'http://localhost:8000/test/fixtures/e2e/amp-carousel/0.1/hidden-controls.amp.html',
+    manualFixture: 'amp-carousel/0.1/hidden-controls.amp.html',
     experiments: ['amp-carousel'],
     environments: ['single'],
   },

--- a/extensions/amp-carousel/0.1/test-e2e/test-slidescroll-autoplay.js
+++ b/extensions/amp-carousel/0.1/test-e2e/test-slidescroll-autoplay.js
@@ -17,8 +17,7 @@
 describes.endtoend(
   'AMP carousel 0.1 slideChange on type="slide" with autoplay',
   {
-    testUrl:
-      'http://localhost:8000/test/fixtures/e2e/amp-carousel/0.1/slidescroll-autoplay.html',
+    fixture: 'amp-carousel/0.1/slidescroll-autoplay.html',
     environments: ['single'],
   },
   async function (env) {

--- a/extensions/amp-carousel/0.2/test/test-e2e/test-repsonsive-slides.js
+++ b/extensions/amp-carousel/0.2/test/test-e2e/test-repsonsive-slides.js
@@ -19,8 +19,7 @@ import {getNextArrow, getSlides, sleep} from './helpers';
 describes.endtoend(
   'AMP carousel 0.2 with responsive slides',
   {
-    testUrl:
-      'http://localhost:8000/test/fixtures/e2e/amp-carousel/0.2/responsive-slides.amp.html',
+    fixture: 'amp-carousel/0.2/responsive-slides.amp.html',
     experiments: ['amp-carousel'],
     environments: ['single'],
   },

--- a/extensions/amp-consent/0.1/test-e2e/test-amp-consent-client-side.js
+++ b/extensions/amp-consent/0.1/test-e2e/test-amp-consent-client-side.js
@@ -25,8 +25,7 @@ import {
 describes.endtoend(
   'amp-consent',
   {
-    testUrl:
-      'http://localhost:8000/test/fixtures/e2e/amp-consent/amp-consent-basic-uses.amp.html#amp-geo=de',
+    fixture: 'amp-consent/amp-consent-basic-uses.amp.html#amp-geo=de',
     // TODO (micajuineho): Add shadow-demo after #25985 is fixed and viewer-demo when...
     environments: ['single'],
   },

--- a/extensions/amp-consent/0.1/test-e2e/test-amp-consent-server-side-expire-cache.js
+++ b/extensions/amp-consent/0.1/test-e2e/test-amp-consent-server-side-expire-cache.js
@@ -25,8 +25,7 @@ import {
 describes.endtoend(
   'amp-consent',
   {
-    testUrl:
-      'http://localhost:8000/test/fixtures/e2e/amp-consent/amp-consent-basic-uses.amp.html#amp-geo=mx',
+    fixture: 'amp-consent/amp-consent-basic-uses.amp.html#amp-geo=mx',
     // TODO (micajuineho): Add shadow-demo after #25985 is fixed, and viewer-demo when...
     environments: ['single'],
   },

--- a/extensions/amp-consent/0.1/test-e2e/test-amp-consent-server-side.js
+++ b/extensions/amp-consent/0.1/test-e2e/test-amp-consent-server-side.js
@@ -25,8 +25,7 @@ import {
 describes.endtoend(
   'amp-consent',
   {
-    testUrl:
-      'http://localhost:8000/test/fixtures/e2e/amp-consent/amp-consent-basic-uses.amp.html#amp-geo=us',
+    fixture: 'amp-consent/amp-consent-basic-uses.amp.html#amp-geo=us',
     // TODO (micajuineho): Add shadow-demo after #25985 is fixed and viewer-demo when...
     environments: ['single'],
   },

--- a/extensions/amp-consent/0.1/test-e2e/test-cmp-ui-interaction.js
+++ b/extensions/amp-consent/0.1/test-e2e/test-cmp-ui-interaction.js
@@ -19,8 +19,7 @@ import {sleep} from './common';
 describes.endtoend(
   'amp-consent',
   {
-    testUrl:
-      'http://localhost:8000/test/fixtures/e2e/amp-consent/cmp-interaction.html',
+    fixture: 'amp-consent/cmp-interaction.html',
     environments: ['single'],
   },
   (env) => {

--- a/extensions/amp-date-picker/0.1/test-e2e/test-blocked-dates.js
+++ b/extensions/amp-date-picker/0.1/test-e2e/test-blocked-dates.js
@@ -19,8 +19,7 @@ import {Key} from '../../../../build-system/tasks/e2e/functional-test-controller
 describes.endtoend(
   'amp-date-picker',
   {
-    testUrl:
-      'http://localhost:8000/test/fixtures/e2e/amp-date-picker/blocked-dates.html',
+    fixture: 'amp-date-picker/blocked-dates.html',
     environments: ['single', 'viewer-demo'],
   },
   async (env) => {

--- a/extensions/amp-fit-text/0.1/test-e2e/test-amp-fit-text.js
+++ b/extensions/amp-fit-text/0.1/test-e2e/test-amp-fit-text.js
@@ -17,8 +17,7 @@
 describes.endtoend(
   'amp-fit-text',
   {
-    testUrl:
-      'http://localhost:8000/test/fixtures/e2e/amp-fit-text/0.1/amp-fit-text.html',
+    fixture: 'amp-fit-text/0.1/amp-fit-text.html',
     environments: 'ampdoc-amp4ads-preset',
   },
   (env) => {

--- a/extensions/amp-fit-text/1.0/test-e2e/test-amp-fit-text.js
+++ b/extensions/amp-fit-text/1.0/test-e2e/test-amp-fit-text.js
@@ -23,8 +23,7 @@ const testTimeout = 11500;
 describes.endtoend(
   'amp-fit-text',
   {
-    testUrl:
-      'http://localhost:8000/test/fixtures/e2e/amp-fit-text/1.0/amp-fit-text.html',
+    fixture: 'amp-fit-text/1.0/amp-fit-text.html',
     environments: 'ampdoc-preset',
     experiments: ['amp-fit-text-v2'],
   },

--- a/extensions/amp-form/0.1/test-e2e/test-ssr.js
+++ b/extensions/amp-form/0.1/test-e2e/test-ssr.js
@@ -17,7 +17,7 @@
 describes.endtoend(
   'amp-form',
   {
-    testUrl: 'http://localhost:8000/test/fixtures/e2e/amp-form/amp-form.html',
+    fixture: 'amp-form/amp-form.html',
     environments: ['single'],
   },
   async (env) => {
@@ -50,7 +50,7 @@ describes.endtoend(
 describes.endtoend(
   'amp-form SSR templates',
   {
-    testUrl: 'http://localhost:8000/test/fixtures/e2e/amp-form/amp-form.html',
+    fixture: 'amp-form/amp-form.html',
     environments: ['viewer-demo'],
   },
   async (env) => {

--- a/extensions/amp-lightbox-gallery/0.1/test-e2e/test-open-close.js
+++ b/extensions/amp-lightbox-gallery/0.1/test-e2e/test-open-close.js
@@ -20,8 +20,7 @@ const pageHeight = 600;
 describes.endtoend(
   'AMP Lightbox Gallery Open/Close',
   {
-    testUrl:
-      'http://localhost:8000/test/fixtures/e2e/amp-lightbox/amp-lightbox-gallery-launch.amp.html',
+    fixture: 'amp-lightbox-gallery-launch.amp.html',
     initialRect: {width: pageWidth, height: pageHeight},
     // TODO(sparhami) Get this working in other environments.
     environments: ['single'],

--- a/extensions/amp-list/0.1/test-e2e/test-function-src.js
+++ b/extensions/amp-list/0.1/test-e2e/test-function-src.js
@@ -17,8 +17,7 @@
 describes.endtoend(
   'amp-list "amp-script:" uri',
   {
-    testUrl:
-      'http://localhost:8000/test/fixtures/e2e/amp-list/amp-list-function-src.html',
+    fixture: 'amp-list/amp-list-function-src.html',
     environments: ['single'],
   },
   async (env) => {
@@ -42,8 +41,7 @@ describes.endtoend(
 describes.endtoend(
   'amp-list "amp-script:" with load-more',
   {
-    testUrl:
-      'http://localhost:8000/test/fixtures/e2e/amp-list/amp-list-function-load-more.html',
+    fixture: 'amp-list/amp-list-function-load-more.html',
     environments: ['single'],
   },
   async (env) => {

--- a/extensions/amp-list/0.1/test-e2e/test-load-more-auto.js
+++ b/extensions/amp-list/0.1/test-e2e/test-load-more-auto.js
@@ -20,8 +20,7 @@ const pageHeight = 420; // unusually small to force a scrollbar
 describes.endtoend(
   'AMP list load-more=auto',
   {
-    testUrl:
-      'http://localhost:8000/test/fixtures/e2e/amp-list/load-more-auto.amp.html',
+    fixture: 'amp-list/load-more-auto.amp.html',
     initialRect: {width: pageWidth, height: pageHeight},
     // TODO(cathyxz, cvializ): figure out why 'viewer' only shows 'FALLBACK'
     // TODO(cathyxz): figure out why shadow-demo doesn't work

--- a/extensions/amp-list/0.1/test-e2e/test-load-more-manual.js
+++ b/extensions/amp-list/0.1/test-e2e/test-load-more-manual.js
@@ -20,7 +20,7 @@ const pageHeight = 600;
 describes.endtoend(
   'AMP list load-more=manual',
   {
-    manualFixture: 'amp-list/load-more-manual.amp.html',
+    fixture: 'amp-list/load-more-manual.amp.html',
     initialRect: {width: pageWidth, height: pageHeight},
     // TODO(cathyxz, cvializ): figure out why 'viewer-demo' only shows 'FALLBACK'
     environments: ['single'],

--- a/extensions/amp-list/0.1/test-e2e/test-load-more-manual.js
+++ b/extensions/amp-list/0.1/test-e2e/test-load-more-manual.js
@@ -20,9 +20,7 @@ const pageHeight = 600;
 describes.endtoend(
   'AMP list load-more=manual',
   {
-    testUrl:
-      'http://localhost:8000/test/fixtures/e2e/amp-list/' +
-      'load-more-manual.amp.html',
+    manualFixture: 'amp-list/load-more-manual.amp.html',
     initialRect: {width: pageWidth, height: pageHeight},
     // TODO(cathyxz, cvializ): figure out why 'viewer-demo' only shows 'FALLBACK'
     environments: ['single'],

--- a/extensions/amp-list/0.1/test-e2e/test-ssr.js
+++ b/extensions/amp-list/0.1/test-e2e/test-ssr.js
@@ -17,7 +17,7 @@
 describes.endtoend(
   'amp-list SSR templates',
   {
-    testUrl: 'http://localhost:8000/test/fixtures/e2e/amp-list/amp-list.html',
+    fixture: 'amp-list/amp-list.html',
     environments: ['viewer-demo'],
   },
   async (env) => {
@@ -49,7 +49,7 @@ describes.endtoend(
 describes.endtoend(
   'amp-list',
   {
-    testUrl: 'http://localhost:8000/test/fixtures/e2e/amp-list/amp-list.html',
+    fixture: 'amp-list/amp-list.html',
     environments: ['single'],
   },
   async (env) => {

--- a/extensions/amp-position-observer/0.1/test-e2e/test-scrollbound-animation.js
+++ b/extensions/amp-position-observer/0.1/test-e2e/test-scrollbound-animation.js
@@ -17,8 +17,7 @@
 describes.endtoend(
   'amp-position-observer in AMPHTML ad',
   {
-    testUrl:
-      'http://localhost:8000/test/fixtures/e2e/amp-position-observer/scrollbound-animation.html',
+    fixture: 'amp-position-observer/scrollbound-animation.html',
     environments: 'amp4ads-preset',
     initialRect: {width: 800, height: 600},
   },

--- a/extensions/amp-position-observer/0.1/test-e2e/test-target-id.js
+++ b/extensions/amp-position-observer/0.1/test-e2e/test-target-id.js
@@ -17,8 +17,7 @@
 describes.endtoend(
   'amp-position-observer target in AMPHTML ad',
   {
-    testUrl:
-      'http://localhost:8000/test/fixtures/e2e/amp-position-observer/target-id.html',
+    fixture: 'amp-position-observer/target-id.html',
     environments: 'amp4ads-preset',
     initialRect: {width: 800, height: 600},
   },

--- a/extensions/amp-script/0.1/test-e2e/test-amp-script.js
+++ b/extensions/amp-script/0.1/test-e2e/test-amp-script.js
@@ -17,8 +17,7 @@
 describes.endtoend(
   'amp-script e2e',
   {
-    testUrl:
-      'http://localhost:8000/test/fixtures/e2e/amp-script/basic.amp.html',
+    fixture: 'amp-script/basic.amp.html',
     initialRect: {width: 600, height: 600},
     environments: ['single'],
     browsers: ['chrome', 'safari'],

--- a/extensions/amp-sidebar/0.1/test-e2e/test-amp-sidebar-toolbar.js
+++ b/extensions/amp-sidebar/0.1/test-e2e/test-amp-sidebar-toolbar.js
@@ -17,8 +17,7 @@
 describes.endtoend(
   'amp-sidebar with toolbar',
   {
-    testUrl:
-      'http://localhost:8000/test/fixtures/e2e/amp-sidebar/amp-sidebar-toolbar.html',
+    fixture: 'amp-sidebar/amp-sidebar-toolbar.html',
     environments: ['single', 'viewer-demo'],
   },
   async (env) => {

--- a/extensions/amp-sidebar/0.1/test-e2e/test-amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/test-e2e/test-amp-sidebar.js
@@ -19,8 +19,7 @@ import {Key} from '../../../../build-system/tasks/e2e/functional-test-controller
 describes.endtoend(
   'amp-sidebar',
   {
-    testUrl:
-      'http://localhost:8000/test/fixtures/e2e/amp-sidebar/amp-sidebar.html',
+    fixture: 'amp-sidebar/amp-sidebar.html',
     environments: ['single', 'viewer-demo'],
   },
   async (env) => {

--- a/extensions/amp-sidebar/0.2/test-e2e/test-amp-sidebar.js
+++ b/extensions/amp-sidebar/0.2/test-e2e/test-amp-sidebar.js
@@ -19,8 +19,7 @@ import {Key} from '../../../../build-system/tasks/e2e/functional-test-controller
 describes.endtoend(
   'amp-sidebar',
   {
-    testUrl:
-      'http://localhost:8000/test/fixtures/e2e/amp-sidebar/amp-sidebar.html',
+    fixture: 'amp-sidebar/amp-sidebar.html',
     environments: ['single', 'viewer-demo'],
   },
   async (env) => {

--- a/extensions/amp-story-auto-ads/0.1/test-e2e/test-amp-story-auto-ads-fullbleed.js
+++ b/extensions/amp-story-auto-ads/0.1/test-e2e/test-amp-story-auto-ads-fullbleed.js
@@ -27,8 +27,7 @@ const viewport = {
 describes.endtoend(
   'amp-story-auto-ads:fullbleed',
   {
-    testUrl:
-      'http://localhost:8000/test/fixtures/e2e/amp-story-auto-ads/fullbleed.html',
+    fixture: 'amp-story-auto-ads/fullbleed.html',
     initialRect: {width: viewport.WIDTH, height: viewport.HEIGHT},
     // TODO(ccordry): re-enable viewer-demo that should handle the 64px
     // offset set by the viewer header.

--- a/extensions/amp-story-auto-ads/0.1/test-e2e/test-amp-story-auto-ads.js
+++ b/extensions/amp-story-auto-ads/0.1/test-e2e/test-amp-story-auto-ads.js
@@ -27,8 +27,7 @@ const viewport = {
 describes.endtoend(
   'amp-story-auto-ads:basic',
   {
-    testUrl:
-      'http://localhost:8000/test/fixtures/e2e/amp-story-auto-ads/basic.html',
+    fixture: 'amp-story-auto-ads/basic.html',
     initialRect: {width: viewport.WIDTH, height: viewport.HEIGHT},
     // TODO(ccordry): reenable shadow demo? fails while waiting for
     // .amp-doc-host[style="visibility: visible;"]
@@ -72,8 +71,7 @@ describes.endtoend(
 describes.endtoend(
   'amp-story-auto-ads:dv3',
   {
-    testUrl:
-      'http://localhost:8000/test/fixtures/e2e/amp-story-auto-ads/dv3-request.html',
+    fixture: 'amp-story-auto-ads/dv3-request.html',
     initialRect: {width: viewport.WIDTH, height: viewport.HEIGHT},
     // TODO(ccordry): re-enable viewer-demo that should handle the 64px
     // offset set by the viewer header.

--- a/extensions/amp-story/1.0/test-e2e/test-amp-story-bookend.js
+++ b/extensions/amp-story/1.0/test-e2e/test-amp-story-bookend.js
@@ -19,8 +19,7 @@ import {Key} from '../../../../build-system/tasks/e2e/functional-test-controller
 describes.endtoend(
   'amp story bookend',
   {
-    testUrl:
-      'http://localhost:8000/test/fixtures/e2e/amp-story/amp-story.amp.html',
+    fixture: 'amp-story/amp-story.amp.html',
     // TODO(estherkim): implement mobile emulation on Firefox when available on geckodriver
     browsers: ['chrome'],
     environments: ['single'],

--- a/extensions/amp-story/1.0/test-e2e/test-amp-story-share-menu.js
+++ b/extensions/amp-story/1.0/test-e2e/test-amp-story-share-menu.js
@@ -19,8 +19,7 @@ import {Key} from '../../../../build-system/tasks/e2e/functional-test-controller
 describes.endtoend(
   'amp story share menu',
   {
-    testUrl:
-      'http://localhost:8000/test/fixtures/e2e/amp-story/amp-story.amp.html',
+    fixture: 'amp-story/amp-story.amp.html',
     browsers: ['chrome'],
     environments: ['single'],
     deviceName: 'iPhone X',

--- a/extensions/amp-subscriptions-google/0.1/test-e2e/test-amp-subscriptions-google.js
+++ b/extensions/amp-subscriptions-google/0.1/test-e2e/test-amp-subscriptions-google.js
@@ -17,8 +17,7 @@
 describes.endtoend(
   'amp-subscriptions-google',
   {
-    testUrl:
-      'http://localhost:8000/test/fixtures/e2e/amp-subscriptions-google/swg.amp.html',
+    fixture: 'amp-subscriptions-google/swg.amp.html',
     environments: ['single'],
   },
   (env) => {

--- a/extensions/amp-video/0.1/test-e2e/test-amp-video-analytics.js
+++ b/extensions/amp-video/0.1/test-e2e/test-amp-video-analytics.js
@@ -17,8 +17,7 @@
 describes.endtoend(
   'amp-video with video analytics',
   {
-    testUrl:
-      'http://localhost:8000/test/fixtures/e2e/amp-video/analytics-triggers.html',
+    fixture: 'amp-video/analytics-triggers.html',
     environments: ['single'],
   },
   (env) => {

--- a/extensions/amp-video/0.1/test-e2e/test-amp-video.js
+++ b/extensions/amp-video/0.1/test-e2e/test-amp-video.js
@@ -17,7 +17,7 @@
 describes.endtoend(
   'amp-video autoplay with control',
   {
-    testUrl: 'http://localhost:8000/test/fixtures/e2e/amp-video/autoplay.html',
+    fixture: 'amp-video/autoplay.html',
     environments: 'amp4ads-preset',
   },
   (env) => {

--- a/test/e2e/test-adchoices.js
+++ b/test/e2e/test-adchoices.js
@@ -17,7 +17,7 @@
 describes.endtoend(
   'ad choices',
   {
-    testUrl: 'http://localhost:8000/test/fixtures/e2e/amphtml-ads/text.html',
+    fixture: 'amphtml-ads/text.html',
     environments: 'amp4ads-preset',
   },
   (env) => {

--- a/test/e2e/test-amp-bind-brightcove.js
+++ b/test/e2e/test-amp-bind-brightcove.js
@@ -17,9 +17,7 @@
 describes.endtoend(
   'amp-bind',
   {
-    testUrl:
-      'http://localhost:8000/test/fixtures/e2e/amp-bind/' +
-      'bind-brightcove.html',
+    fixture: 'amp-bind/bind-brightcove.html',
   },
   async (env) => {
     let controller;

--- a/test/e2e/test-amp-bind-email.js
+++ b/test/e2e/test-amp-bind-email.js
@@ -17,9 +17,7 @@
 describes.endtoend(
   'amp-bind',
   {
-    testUrl:
-      'http://localhost:8000/test/fixtures/e2e/amp-bind/' +
-      'bind-amp4email.html',
+    fixture: 'amp-bind/bind-amp4email.html',
   },
   async (env) => {
     let controller;

--- a/test/e2e/test-amp-bind-form.js
+++ b/test/e2e/test-amp-bind-form.js
@@ -17,7 +17,7 @@
 describes.endtoend(
   'amp-bind',
   {
-    testUrl: 'http://localhost:8000/test/fixtures/e2e/amp-bind/bind-form.html',
+    fixture: 'amp-bind/bind-form.html',
   },
   async (env) => {
     let controller;

--- a/test/e2e/test-amp-bind-iframe.js
+++ b/test/e2e/test-amp-bind-iframe.js
@@ -17,8 +17,7 @@
 describes.endtoend(
   'amp-bind',
   {
-    testUrl:
-      'http://localhost:8000/test/fixtures/e2e/amp-bind/bind-iframe.html',
+    fixture: 'amp-bind/bind-iframe.html',
   },
   async (env) => {
     let controller;

--- a/test/e2e/test-amp-bind-live-list.js
+++ b/test/e2e/test-amp-bind-live-list.js
@@ -17,9 +17,7 @@
 describes.endtoend(
   'amp-bind',
   {
-    testUrl:
-      'http://localhost:8000/test/fixtures/e2e/amp-bind/' +
-      'bind-live-list.html',
+    fixture: 'amp-bind/bind-live-list.html',
   },
   async (env) => {
     let controller;

--- a/test/e2e/test-amp-bind-state.js
+++ b/test/e2e/test-amp-bind-state.js
@@ -17,7 +17,7 @@
 describes.endtoend(
   'amp-bind',
   {
-    testUrl: 'http://localhost:8000/test/fixtures/e2e/amp-bind/bind-basic.html',
+    fixture: 'amp-bind/bind-basic.html',
     environments: 'ampdoc-amp4ads-preset',
   },
   async (env) => {

--- a/test/e2e/test-amp-bind-video.js
+++ b/test/e2e/test-amp-bind-video.js
@@ -17,7 +17,7 @@
 describes.endtoend(
   'amp-bind with <amp-video>',
   {
-    testUrl: 'http://localhost:8000/test/fixtures/e2e/amp-bind/bind-video.html',
+    fixture: 'amp-bind/bind-video.html',
     environments: 'ampdoc-amp4ads-preset',
   },
   async (env) => {

--- a/test/e2e/test-amp-bind-youtube.js
+++ b/test/e2e/test-amp-bind-youtube.js
@@ -17,8 +17,7 @@
 describes.endtoend(
   'amp-bind',
   {
-    testUrl:
-      'http://localhost:8000/test/fixtures/e2e/amp-bind/bind-youtube.html',
+    fixture: 'amp-bind/bind-youtube.html',
   },
   async (env) => {
     let controller;

--- a/test/e2e/test-amp-email.js
+++ b/test/e2e/test-amp-email.js
@@ -17,8 +17,7 @@
 describes.endtoend(
   'layoutCallback depends on updated viewport size after documentHeight change.',
   {
-    testUrl:
-      'http://localhost:8000/test/fixtures/e2e/amp4email/viewport-size-race.html',
+    fixture: 'amp4email/viewport-size-race.html',
     environments: ['email-demo'],
   },
   async (env) => {
@@ -33,8 +32,7 @@ describes.endtoend(
 describes.endtoend(
   'layoutCallback depending on element remeasurement after documentHeight change.',
   {
-    testUrl:
-      'http://localhost:8000/test/fixtures/e2e/amp4email/element-size-race.html',
+    fixture: 'amp4email/element-size-race.html',
     environments: ['email-demo'],
   },
   async (env) => {

--- a/test/e2e/test-amp-story-player-navigation.js
+++ b/test/e2e/test-amp-story-player-navigation.js
@@ -30,8 +30,7 @@ function timeout(ms) {
 describes.endtoend(
   'story player navigation',
   {
-    testUrl:
-      'http://localhost:8000/test/fixtures/e2e/amp-story-player/navigation.html',
+    fixture: 'amp-story-player/navigation.html',
     initialRect: {width: VIEWPORT.WIDTH, height: VIEWPORT.HEIGHT},
     environments: ['single'],
   },

--- a/test/e2e/test-amp-story-player-prerender.js
+++ b/test/e2e/test-amp-story-player-prerender.js
@@ -30,8 +30,7 @@ function timeout(ms) {
 describes.endtoend(
   'player prerendering',
   {
-    testUrl:
-      'http://localhost:8000/test/fixtures/e2e/amp-story-player/pre-rendering.html',
+    fixture: 'amp-story-player/pre-rendering.html',
     initialRect: {width: VIEWPORT.WIDTH, height: VIEWPORT.HEIGHT},
     environments: ['single'],
   },

--- a/test/e2e/test-amp-story-player.js
+++ b/test/e2e/test-amp-story-player.js
@@ -22,8 +22,7 @@ const VIEWPORT = {
 describes.endtoend(
   'player prerendering',
   {
-    testUrl:
-      'http://localhost:8000/test/fixtures/e2e/amp-story-player/basic.html',
+    fixture: 'amp-story-player/basic.html',
     initialRect: {width: VIEWPORT.WIDTH, height: VIEWPORT.HEIGHT},
     environments: ['single'],
   },

--- a/test/e2e/test-document-height.js
+++ b/test/e2e/test-document-height.js
@@ -17,8 +17,7 @@
 describes.endtoend(
   'documentHeight',
   {
-    testUrl:
-      'http://localhost:8000/test/fixtures/e2e/amp-carousel/0.1/document-height.html',
+    fixture: 'amp-carousel/0.1/document-height.html',
     environments: ['viewer-demo'],
   },
   async (env) => {


### PR DESCRIPTION
Builds on #32176 by migrating all existing e2e tests from specifying the absolute `testUrl` to the relative `fixture` or `manualFixture` path. Drops support for explicit `testUrl` (nothing needs it). Only tests now using `manualFixture` are for `amp-base-carousel`. Once those test fixtures can be moved, `manualFixture` can be dropped entirely.