### PR TITLE
🏗 Optimize GitHub Actions jobs

### DIFF
--- a/.github/workflows/cross-browser-tests.yml
+++ b/.github/workflows/cross-browser-tests.yml
@@ -18,6 +18,11 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+      - name: Cache Packages
+        uses: actions/cache@v2
+        with:
+          path: node_modules
+          key: node_modules-${{ matrix.platform }}-${{ hashFiles('package-lock.json') }}
       - name: Install Dependencies
         run: bash ./.github/workflows/install_dependencies.sh
       - name: Build and Test

--- a/build-system/pr-check/cross-browser-tests.js
+++ b/build-system/pr-check/cross-browser-tests.js
@@ -79,9 +79,9 @@ function runUnitTestsForPlatform() {
 
 function pushBuildWorkflow() {
   timedExecOrDie('gulp update-packages');
+  runUnitTestsForPlatform();
   timedExecOrDie('gulp dist --fortesting');
   runIntegrationTestsForPlatform();
-  runUnitTestsForPlatform();
 }
 
 async function prBuildWorkflow() {
@@ -102,12 +102,12 @@ async function prBuildWorkflow() {
     return;
   }
   timedExecOrDie('gulp update-packages');
+  if (buildTargetsInclude(Targets.RUNTIME, Targets.UNIT_TEST)) {
+    runUnitTestsForPlatform();
+  }
   if (buildTargetsInclude(Targets.RUNTIME, Targets.INTEGRATION_TEST)) {
     timedExecOrDie('gulp dist --fortesting');
     runIntegrationTestsForPlatform();
-  }
-  if (buildTargetsInclude(Targets.RUNTIME, Targets.UNIT_TEST)) {
-    runUnitTestsForPlatform();
   }
 }
 

--- a/build-system/tasks/report-test-status.js
+++ b/build-system/tasks/report-test-status.js
@@ -88,8 +88,8 @@ function inferTestType() {
 }
 
 async function postReport(type, action) {
-  // TODO(rsimha): Remove `isTravisBuild()` condition once Travis is shut off.
-  if (type && isPullRequestBuild() && isTravisBuild()) {
+  // TODO(rsimha): Remove `!isCircleciBuild()` condition once Travis is shut off.
+  if (type && isPullRequestBuild() && !isCircleciBuild()) {
     const commitHash = gitCommitHash();
 
     try {


### PR DESCRIPTION
**Three things that need to be fixed in our GH Actions jobs:**

- Installing dependencies can be slow (e.g. it took >5 mins during [this Windows job](https://github.com/ampproject/amphtml/pull/32176/checks?check_run_id=1809656940))
- We build the runtime, then run integration tests, and only then unit tests (simple test failures are slow to surface)
- CircleCI jobs aren't pre-reporting expected test statuses, which is currently gated on `isTravisBuild()` 

**PR highlights:**
- Add a caching step for dependency installation
- Reorder steps to first run unit tests, then build the runtime, then run integration tests (fail-fast)
- Gate pre-reporting of test statuses on `!isCircleciBuild()` so it works on GH actions and Travis

**Results:** Seeing some decent gains in installation time. For example:

**[Cold cache:](https://github.com/ampproject/amphtml/runs/1810045585?check_suite_focus=true)**
![image](https://user-images.githubusercontent.com/26553114/106524496-ab8b8000-64b0-11eb-900a-e2679d8983e1.png)

**[Warm cache:](https://github.com/ampproject/amphtml/runs/1810185453?check_suite_focus=true)**
![image](https://user-images.githubusercontent.com/26553114/106524539-b3e3bb00-64b0-11eb-93d0-d9b2e4990019.png)

**Future work:** Audit dev dependencies, see if there are any particularly large / slow ones.