### PR TITLE
[amp-story-player] Prerender first story on scroll

### DIFF
--- a/src/amp-story-player/amp-story-component-manager.js
+++ b/src/amp-story-player/amp-story-component-manager.js
@@ -19,12 +19,6 @@ import {AmpStoryPlayer} from './amp-story-player-impl';
 import {AmpStoryPlayerViewportObserver} from './amp-story-player-viewport-observer';
 import {initLogConstructor} from '../log';
 
-/**
- * Minimum amount of viewports away from the player to start prerendering.
- * @const {number}
- */
-const MIN_VIEWPORT_PRERENDER_DISTANCE = 2;
-
 export class AmpStoryComponentManager {
   /**
    * @param {!Window} win
@@ -33,6 +27,9 @@ export class AmpStoryComponentManager {
   constructor(win) {
     /** @private {!Window} */
     this.win_ = win;
+
+    /** @private {?function} */
+    this.scrollHandler_ = null;
   }
 
   /**
@@ -44,9 +41,15 @@ export class AmpStoryComponentManager {
     new AmpStoryPlayerViewportObserver(
       this.win_,
       elImpl.getElement(),
-      elImpl.layoutCallback.bind(elImpl),
-      MIN_VIEWPORT_PRERENDER_DISTANCE
+      elImpl.layoutCallback.bind(elImpl)
     );
+
+    this.scrollHandler_ = () => {
+      elImpl.layoutCallback();
+      this.win_.removeEventListener('scroll', this.scrollHandler_);
+    };
+
+    this.win_.addEventListener('scroll', this.scrollHandler_);
   }
 
   /**

--- a/src/amp-story-player/amp-story-component-manager.js
+++ b/src/amp-story-player/amp-story-component-manager.js
@@ -27,9 +27,6 @@ export class AmpStoryComponentManager {
   constructor(win) {
     /** @private {!Window} */
     this.win_ = win;
-
-    /** @private {?function} */
-    this.scrollHandler_ = null;
   }
 
   /**
@@ -44,12 +41,12 @@ export class AmpStoryComponentManager {
       elImpl.layoutCallback.bind(elImpl)
     );
 
-    this.scrollHandler_ = () => {
+    const scrollHandler = () => {
       elImpl.layoutCallback();
-      this.win_.removeEventListener('scroll', this.scrollHandler_);
+      this.win_.removeEventListener('scroll', scrollHandler);
     };
 
-    this.win_.addEventListener('scroll', this.scrollHandler_);
+    this.win_.addEventListener('scroll', scrollHandler);
   }
 
   /**

--- a/src/amp-story-player/amp-story-player-viewport-observer.js
+++ b/src/amp-story-player/amp-story-player-viewport-observer.js
@@ -28,9 +28,8 @@ export class AmpStoryPlayerViewportObserver {
    * @param {!Window} win
    * @param {!Element} element
    * @param {function} viewportCb
-   * @param {number} distance Minimum of viewports away for triggering viewportCb
    */
-  constructor(win, element, viewportCb, distance = 0) {
+  constructor(win, element, viewportCb) {
     /** @private {!Window} */
     this.win_ = win;
 
@@ -39,9 +38,6 @@ export class AmpStoryPlayerViewportObserver {
 
     /** @private {function} */
     this.cb_ = viewportCb;
-
-    /** @private {number} */
-    this.viewportDistance_ = distance;
 
     /** @private {?function} */
     this.scrollHandler_ = null;
@@ -74,9 +70,7 @@ export class AmpStoryPlayerViewportObserver {
       });
     };
 
-    const observer = new this.win_.IntersectionObserver(inObCallback, {
-      rootMargin: `${this.viewportDistance_ * 100}%`,
-    });
+    const observer = new this.win_.IntersectionObserver(inObCallback);
 
     observer.observe(this.element_);
   }
@@ -106,9 +100,8 @@ export class AmpStoryPlayerViewportObserver {
   checkIfVisibleFallback_() {
     const elTop = this.element_./*OK*/ getBoundingClientRect().top;
     const winInnerHeight = this.win_./*OK*/ innerHeight;
-    const multiplier = this.viewportDistance_ > 0 ? this.viewportDistance_ : 1;
 
-    if (winInnerHeight * multiplier > elTop) {
+    if (winInnerHeight > elTop) {
       this.cb_();
       this.win_.removeEventListener('scroll', this.scrollHandler_);
     }

--- a/test/e2e/test-amp-story-player-prerender.js
+++ b/test/e2e/test-amp-story-player-prerender.js
@@ -44,7 +44,7 @@ describes.endtoend(
       await expect(player);
     });
 
-    it('player builds the shadow DOM container when far from the viewport', async () => {
+    it('when player is not visible in first viewport, it builds the shadow DOM container', async () => {
       const shadowHost = await controller.findElement(
         'div.i-amphtml-story-player-shadow-root-intermediary'
       );
@@ -52,7 +52,7 @@ describes.endtoend(
       await expect(shadowHost);
     });
 
-    it('when player is far from viewport and user has not scrolled, no stories are loaded in the iframes', async () => {
+    it('when player is not visible in first viewport, no stories are loaded or prerendered', async () => {
       const shadowHost = await controller.findElement(
         'div.i-amphtml-story-player-shadow-root-intermediary'
       );
@@ -70,7 +70,7 @@ describes.endtoend(
       await expect(count).to.eql(0);
     });
 
-    it('when user scrolls and player is not in viewport, iframe loads first story in prerender', async () => {
+    it('when player is not visible in first viewport and on first user scroll, iframe loads first story in prerender', async () => {
       const doc = await controller.getDocumentElement();
 
       await controller./*OK*/ scrollTo(doc, {top: 1});
@@ -89,11 +89,10 @@ describes.endtoend(
       );
     });
 
-    it('when user scrolls and player is not in viewport, only one iframe is loaded', async () => {
+    it('when player is not visible in first viewport and on first user scroll, only one story in iframe is loaded', async () => {
       const doc = await controller.getDocumentElement();
-      const playerRect = await controller.getElementRect(player);
 
-      await controller./*OK*/ scrollTo(doc, {top: playerRect.top - 1000});
+      await controller./*OK*/ scrollTo(doc, {top: 1});
 
       const shadowHost = await controller.findElement(
         'div.i-amphtml-story-player-shadow-root-intermediary'
@@ -107,7 +106,7 @@ describes.endtoend(
       await expect(iframeSrc).to.not.exist;
     });
 
-    it('when player becomes visible, first story starts playing', async () => {
+    it('when player becomes visible in viewport, first story starts playing', async () => {
       const doc = await controller.getDocumentElement();
       const playerRect = await controller.getElementRect(player);
 
@@ -130,7 +129,7 @@ describes.endtoend(
       await expect(storyEl).to.exist;
     });
 
-    it('when player becomes visible and first story finishes loading, second story starts preloading', async () => {
+    it('when player becomes visible in viewport and first story finishes loading, second story starts preloading', async () => {
       const doc = await controller.getDocumentElement();
       const playerRect = await controller.getElementRect(player);
 

--- a/test/e2e/test-amp-story-player-prerender.js
+++ b/test/e2e/test-amp-story-player-prerender.js
@@ -70,11 +70,10 @@ describes.endtoend(
       await expect(count).to.eql(0);
     });
 
-    it('when player comes close to the viewport, iframe loads first story in prerender', async () => {
+    it('when user scrolls and player is not in viewport, iframe loads first story in prerender', async () => {
       const doc = await controller.getDocumentElement();
-      const playerRect = await controller.getElementRect(player);
 
-      await controller./*OK*/ scrollTo(doc, {top: playerRect.top - 1000});
+      await controller./*OK*/ scrollTo(doc, {top: 1});
 
       const shadowHost = await controller.findElement(
         'div.i-amphtml-story-player-shadow-root-intermediary'
@@ -90,7 +89,7 @@ describes.endtoend(
       );
     });
 
-    it('when player comes close to the viewport, only one iframe is loaded', async () => {
+    it('when user scrolls and player is not in viewport, only one iframe is loaded', async () => {
       const doc = await controller.getDocumentElement();
       const playerRect = await controller.getElementRect(player);
 

--- a/test/e2e/test-amp-story-player.js
+++ b/test/e2e/test-amp-story-player.js
@@ -38,7 +38,7 @@ describes.endtoend(
       await expect(player);
     });
 
-    it('loads first story in page load', async () => {
+    it('loads and displays first story on page load when player is visible in viewport', async () => {
       const shadowHost = await controller.findElement(
         'div.i-amphtml-story-player-shadow-root-intermediary'
       );

--- a/test/unit/test-amp-story-player-viewport-observer.js
+++ b/test/unit/test-amp-story-player-viewport-observer.js
@@ -62,9 +62,10 @@ describes.realWin('AmpStoryPlayerViewportObserver', {amp: false}, (env) => {
     const noop = () => {};
     new AmpStoryPlayerViewportObserver(win, el, noop);
 
-    expect(inOb).to.have.been.calledWith(env.sandbox.match.any, {
-      rootMargin: '0%',
-    });
+    const inObCallback = env.sandbox.match.any;
+
+    // Initializing InOb with only 1 argument defaults to implicit root.
+    expect(inOb).to.have.been.calledOnceWithExactly(inObCallback);
   });
 
   it('fires callback when element is visible in viewport.', () => {

--- a/test/unit/test-amp-story-player-viewport-observer.js
+++ b/test/unit/test-amp-story-player-viewport-observer.js
@@ -67,15 +67,6 @@ describes.realWin('AmpStoryPlayerViewportObserver', {amp: false}, (env) => {
     });
   });
 
-  it('initializes observer with explicit root', () => {
-    const noop = () => {};
-    new AmpStoryPlayerViewportObserver(win, el, noop, 5);
-
-    expect(inOb).to.have.been.calledWith(env.sandbox.match.any, {
-      rootMargin: '500%',
-    });
-  });
-
   it('fires callback when element is visible in viewport.', () => {
     const cbSpy = env.sandbox.spy();
     new AmpStoryPlayerViewportObserver(win, el, cbSpy);


### PR DESCRIPTION
If Player is not visible in the first viewport, do not load the first story nor prerender it at first so it does NOT impact the LCP.
On first user scroll, prerender the Story, and switch it to visible when it becomes visible in the current viewport


<!--
# Instructions:

- Pick a meaningful title for your pull request. (Use sentence case.)
  - Prefix the title with an emoji to identify what is being done. (Copy-paste the emoji from the list below.)
  - Do not overuse punctuation in the title (like `(chore):`).
  - If it is helpful, use a simple prefix (like `ProjectX: Implement some feature`).
- Enter a succinct description that says why the PR is necessary, and what it does.
  - Mention the GitHub issue that is being addressed by the pull request.
  - The keywords `Fixes`, `Closes`, or `Resolves` followed the issue number will automatically close the issue.

> NOTE: All non-trivial changes (like introducing new features or components) should have an associated issue or reference an I2I (intent-to-implement: go.amp.dev/i2i). Please read through the contribution process (go.amp.dev/contributing/code) for more information.

# Example of a good description:

- Implement aspect X
- Leave out feature Y because of A
- Improve performance by B
- Improve accessibility by C

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Reverting a previous change
♻️ Refactoring
🚮 Deleting code
🧪 Experimental code
-->
