### PR TITLE
Avoid creation of ElementStub until the upgrade class is available

### DIFF
--- a/build-system/externs/amp.multipass.extern.js
+++ b/build-system/externs/amp.multipass.extern.js
@@ -30,4 +30,4 @@ SomeBaseElementLikeClass.prototype.defaultActionAlias_;
 
 // Externed explicitly because this private property is read across
 // binaries.
-Element.prototype.implementation_ = {};
+Element.prototype.impl_ = {};

--- a/extensions/amp-facebook/0.1/test/test-amp-facebook.js
+++ b/extensions/amp-facebook/0.1/test/test-amp-facebook.js
@@ -262,8 +262,9 @@ describes.realWin(
           resetServiceForTesting(win, 'bootstrapBaseUrl');
           setDefaultBootstrapBaseUrlForTesting(iframeSrc);
           const ampFB = await getAmpFacebook(fbPostHref);
+          const impl = await ampFB.getImpl(false);
           return new Promise((resolve, unusedReject) => {
-            const {firstChild: iframe, implementation_: impl} = ampFB;
+            const {firstChild: iframe} = ampFB;
             impl.forceChangeHeight = (newHeight) => {
               expect(newHeight).to.equal(666);
               resolve(ampFB);

--- a/extensions/amp-image-lightbox/0.1/test/test-amp-image-lightbox.js
+++ b/extensions/amp-image-lightbox/0.1/test/test-amp-image-lightbox.js
@@ -318,7 +318,7 @@ describes.realWin(
         return undefined;
       },
       hasAttribute: () => undefined,
-      getImpl: () => Promise.resolve(sourceElement.implementation_),
+      getImpl: () => Promise.resolve({}),
     };
 
     beforeEach(() => {

--- a/extensions/amp-video/0.1/test/test-amp-video.js
+++ b/extensions/amp-video/0.1/test/test-amp-video.js
@@ -1272,14 +1272,13 @@ describes.realWin(
               height: 90,
             },
             /* children */ null,
-            (element) => {
-              const {implementation_} = element;
-              const {video_} = implementation_;
+            (element, impl) => {
+              const {video_} = impl;
 
               expect(video_.currentTime).to.equal(0);
 
               [20, 100, 0, 50, 22].forEach((timeSeconds) => {
-                implementation_.seekTo(timeSeconds);
+                impl.seekTo(timeSeconds);
                 expect(video_.currentTime).to.equal(timeSeconds);
               });
 

--- a/src/common-signals.js
+++ b/src/common-signals.js
@@ -20,6 +20,11 @@
  */
 export const CommonSignals = {
   /**
+   * The element's implementation has been registered and ready for upgrade.
+   */
+  READY_TO_UPGRADE: 'ready-upgrade',
+
+  /**
    * The element has been upgraded from ElementStub to its real implementation.
    */
   UPGRADED: 'upgraded',

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -61,6 +61,9 @@ const UpgradeState = {
  */
 let templateTagSupported;
 
+/** @type {!Array} */
+export const stubbedElements = [];
+
 /**
  * Whether this platform supports template tags.
  * @return {boolean}
@@ -192,15 +195,23 @@ function createBaseCustomElementClass(win) {
       const nonStructThis = /** @type {!Object} */ (this);
 
       // `opt_implementationClass` is only used for tests.
+      /** @type {?(typeof ../base-element.BaseElement)} */
       let Ctor =
         win.__AMP_EXTENDED_ELEMENTS &&
         win.__AMP_EXTENDED_ELEMENTS[this.localName];
       if (getMode().test && nonStructThis['implementationClassForTesting']) {
         Ctor = nonStructThis['implementationClassForTesting'];
       }
-      devAssert(Ctor);
-      /** @private {!./base-element.BaseElement} */
-      this.implementation_ = new Ctor(this);
+
+      /** @private {?(typeof ../base-element.BaseElement)} */
+      this.implClass_ = Ctor === ElementStub ? null : Ctor || null;
+
+      if (!this.implClass_) {
+        stubbedElements.push(this);
+      }
+
+      /** @private {?./base-element.BaseElement} */
+      this.impl_ = null;
 
       /**
        * An element always starts in a unupgraded state until it's added to DOM
@@ -235,6 +246,10 @@ function createBaseCustomElementClass(win) {
 
       /** @private @const */
       this.signals_ = new Signals();
+
+      if (this.implClass_) {
+        this.signals_.signal(CommonSignals.READY_TO_UPGRADE);
+      }
 
       const perf = Services.performanceForOrNull(win);
       /** @private {boolean} */
@@ -315,7 +330,9 @@ function createBaseCustomElementClass(win) {
         // Already upgraded or in progress or failed.
         return;
       }
-      this.implementation_ = new newImplClass(this);
+
+      this.implClass_ = newImplClass;
+      this.signals_.signal(CommonSignals.READY_TO_UPGRADE);
       if (this.everAttached) {
         // Usually, we do an implementation upgrade when the element is
         // attached to the DOM. But, if it hadn't yet upgraded from
@@ -343,7 +360,7 @@ function createBaseCustomElementClass(win) {
     completeUpgrade_(newImpl, upgradeStartTime) {
       this.upgradeDelayMs_ = win.Date.now() - upgradeStartTime;
       this.upgradeState_ = UpgradeState.UPGRADED;
-      this.implementation_ = newImpl;
+      this.impl_ = newImpl;
       this.classList.remove('amp-unresolved');
       this.classList.remove('i-amphtml-unresolved');
       this.assertLayout_();
@@ -356,7 +373,8 @@ function createBaseCustomElementClass(win) {
     assertLayout_() {
       if (
         this.layout_ != Layout.NODISPLAY &&
-        !this.implementation_.isLayoutSupported(this.layout_)
+        this.impl_ &&
+        !this.impl_.isLayoutSupported(this.layout_)
       ) {
         userAssert(
           this.getAttribute('layout'),
@@ -394,7 +412,7 @@ function createBaseCustomElementClass(win) {
      */
     getLayoutPriority() {
       devAssert(this.isUpgraded(), 'Cannot get priority of unupgraded element');
-      return this.implementation_.getLayoutPriority();
+      return this.impl_.getLayoutPriority();
     }
 
     /**
@@ -406,7 +424,7 @@ function createBaseCustomElementClass(win) {
         this.isUpgraded(),
         'Cannot get default action alias of unupgraded element'
       );
-      return this.implementation_.getDefaultActionAlias();
+      return this.impl_.getDefaultActionAlias();
     }
 
     /** @return {boolean} */
@@ -431,9 +449,10 @@ function createBaseCustomElementClass(win) {
         return this.buildingPromise_;
       }
       return (this.buildingPromise_ = new Promise((resolve, reject) => {
+        const impl = this.impl_;
         const policyId = this.getConsentPolicy_();
         if (!policyId) {
-          resolve(this.implementation_.buildCallback());
+          resolve(impl.buildCallback());
         } else {
           Services.consentPolicyServiceForDocOrNull(this)
             .then((policy) => {
@@ -444,7 +463,7 @@ function createBaseCustomElementClass(win) {
             })
             .then((shouldUnblock) => {
               if (shouldUnblock) {
-                resolve(this.implementation_.buildCallback());
+                resolve(impl.buildCallback());
               } else {
                 reject(blockedByConsentError());
               }
@@ -495,22 +514,18 @@ function createBaseCustomElementClass(win) {
      * @param {boolean} onLayout Whether this was called after a layout.
      */
     preconnect(onLayout) {
+      devAssert(this.isUpgraded());
       if (onLayout) {
-        this.implementation_.preconnectCallback(onLayout);
+        this.impl_.preconnectCallback(onLayout);
       } else {
         // If we do early preconnects we delay them a bit. This is kind of
         // an unfortunate trade off, but it seems faster, because the DOM
         // operations themselves are not free and might delay
         startupChunk(this.getAmpDoc(), () => {
-          const TAG = this.tagName;
-          if (!this.ownerDocument) {
-            dev().error(TAG, 'preconnect without ownerDocument');
-            return;
-          } else if (!this.ownerDocument.defaultView) {
-            dev().error(TAG, 'preconnect without defaultView');
+          if (!this.ownerDocument || !this.ownerDocument.defaultView) {
             return;
           }
-          this.implementation_.preconnectCallback(onLayout);
+          this.impl_.preconnectCallback(onLayout);
         });
       }
     }
@@ -520,7 +535,7 @@ function createBaseCustomElementClass(win) {
      * @return {boolean}
      */
     isAlwaysFixed() {
-      return this.implementation_.isAlwaysFixed();
+      return this.impl_ ? this.impl_.isAlwaysFixed() : false;
     }
 
     /**
@@ -542,7 +557,7 @@ function createBaseCustomElementClass(win) {
     onMeasure() {
       devAssert(this.isBuilt());
       try {
-        this.implementation_.onLayoutMeasure();
+        this.impl_.onLayoutMeasure();
       } catch (e) {
         reportError(e, this);
       }
@@ -748,10 +763,7 @@ function createBaseCustomElementClass(win) {
         this.ampdoc_ = ampdoc;
         // Load the pre-stubbed extension if needed.
         const extensionId = this.tagName.toLowerCase();
-        if (
-          isStub(this.implementation_) &&
-          !ampdoc.declaresExtension(extensionId)
-        ) {
+        if (!this.implClass_ && !ampdoc.declaresExtension(extensionId)) {
           Services.extensionsFor(win).installExtensionForDoc(
             ampdoc,
             extensionId
@@ -788,7 +800,7 @@ function createBaseCustomElementClass(win) {
         } catch (e) {
           reportError(e, this);
         }
-        if (!isStub(this.implementation_)) {
+        if (this.implClass_) {
           this.tryUpgrade_();
         }
         if (!this.isUpgraded()) {
@@ -818,15 +830,23 @@ function createBaseCustomElementClass(win) {
 
     /**
      * Try to upgrade the element with the provided implementation.
+     * @return {!Promise|undefined}
      * @private @final
      */
     tryUpgrade_() {
-      const impl = this.implementation_;
-      devAssert(!isStub(impl), 'Implementation must not be a stub');
+      if (this.isInTemplate_) {
+        return;
+      }
       if (this.upgradeState_ != UpgradeState.NOT_UPGRADED) {
         // Already upgraded or in progress or failed.
         return;
       }
+
+      const Ctor = devAssert(
+        this.implClass_,
+        'Implementation must not be a stub'
+      );
+      const impl = new Ctor(this);
 
       // The `upgradeCallback` only allows redirect once for the top-level
       // non-stub class. We may allow nested upgrades later, but they will
@@ -839,7 +859,7 @@ function createBaseCustomElementClass(win) {
         this.completeUpgrade_(impl, startTime);
       } else if (typeof res.then == 'function') {
         // It's a promise: wait until it's done.
-        res
+        return res
           .then((upgrade) => {
             this.completeUpgrade_(upgrade || impl, startTime);
           })
@@ -868,7 +888,7 @@ function createBaseCustomElementClass(win) {
     /** @private */
     connected_() {
       if (this.built_) {
-        this.implementation_.attachedCallback();
+        this.impl_.attachedCallback();
       }
     }
 
@@ -903,7 +923,9 @@ function createBaseCustomElementClass(win) {
 
       this.isConnected_ = false;
       this.getResources().remove(this);
-      this.implementation_.detachedCallback();
+      if (this.impl_) {
+        this.impl_.detachedCallback();
+      }
       this.toggleLoading(false);
       this.disposeMediaAttrs_();
     }
@@ -928,7 +950,7 @@ function createBaseCustomElementClass(win) {
      * @final
      */
     prerenderAllowed() {
-      return this.implementation_.prerenderAllowed();
+      return this.impl_ ? this.impl_.prerenderAllowed() : false;
     }
 
     /**
@@ -937,7 +959,7 @@ function createBaseCustomElementClass(win) {
      * @final
      */
     isBuildRenderBlocking() {
-      return this.implementation_.isBuildRenderBlocking();
+      return this.impl_ ? this.impl_.isBuildRenderBlocking() : false;
     }
 
     /**
@@ -946,7 +968,7 @@ function createBaseCustomElementClass(win) {
      * @final
      */
     createPlaceholder() {
-      return this.implementation_.createPlaceholderCallback();
+      return this.impl_ ? this.impl_.createPlaceholderCallback() : null;
     }
 
     /**
@@ -958,7 +980,7 @@ function createBaseCustomElementClass(win) {
      * @final
      */
     createLoaderLogo() {
-      return this.implementation_.createLoaderLogoCallback();
+      return this.impl_ ? this.impl_.createLoaderLogoCallback() : {};
     }
 
     /**
@@ -967,7 +989,7 @@ function createBaseCustomElementClass(win) {
      * @final
      */
     renderOutsideViewport() {
-      return this.implementation_.renderOutsideViewport();
+      return this.impl_ ? this.impl_.renderOutsideViewport() : false;
     }
 
     /**
@@ -977,7 +999,7 @@ function createBaseCustomElementClass(win) {
      * @final
      */
     idleRenderOutsideViewport() {
-      return this.implementation_.idleRenderOutsideViewport();
+      return this.impl_ ? this.impl_.idleRenderOutsideViewport() : false;
     }
 
     /**
@@ -1011,13 +1033,16 @@ function createBaseCustomElementClass(win) {
     /**
      * Returns a change entry for that should be compatible with
      * IntersectionObserverEntry.
-     * @return {!IntersectionObserverEntry} A change entry.
+     * @return {?IntersectionObserverEntry} A change entry.
      * @final
      */
     getIntersectionChangeEntry() {
-      const box = this.implementation_.getIntersectionElementLayoutBox();
+      const box = this.impl_
+        ? this.impl_.getIntersectionElementLayoutBox()
+        : this.getLayoutBox();
       const owner = this.getOwner();
-      const viewportBox = this.implementation_.getViewport().getRect();
+      const viewport = Services.viewportForDoc(this.getAmpDoc());
+      const viewportBox = viewport.getRect();
       // TODO(jridgewell, #4826): We may need to make this recursive.
       const ownerBox = owner && owner.getLayoutBox();
       return getIntersectionChangeEntry(box, ownerBox, viewportBox);
@@ -1047,7 +1072,7 @@ function createBaseCustomElementClass(win) {
      * @package @final
      */
     isRelayoutNeeded() {
-      return this.implementation_.isRelayoutNeeded();
+      return this.impl_ ? this.impl_.isRelayoutNeeded() : false;
     }
 
     /**
@@ -1058,7 +1083,7 @@ function createBaseCustomElementClass(win) {
      */
     getImpl(waitForBuild = true) {
       const waitFor = waitForBuild ? this.whenBuilt() : this.whenUpgraded();
-      return waitFor.then(() => this.implementation_);
+      return waitFor.then(() => this.impl_);
     }
 
     /**
@@ -1113,7 +1138,7 @@ function createBaseCustomElementClass(win) {
       // Potentially start the loading indicator.
       this.toggleLoading(true);
 
-      const promise = tryResolve(() => this.implementation_.layoutCallback());
+      const promise = tryResolve(() => this.impl_.layoutCallback());
       this.preconnect(/* onLayout */ true);
       this.classList.add('i-amphtml-layout');
 
@@ -1131,7 +1156,7 @@ function createBaseCustomElementClass(win) {
           // Check if this is the first success layout that needs
           // to call firstLayoutCompleted.
           if (!this.isFirstLayoutCompleted_) {
-            this.implementation_.firstLayoutCompleted();
+            this.impl_.firstLayoutCompleted();
             this.isFirstLayoutCompleted_ = true;
             this.dispatchCustomEventForTesting(AmpEvents.LOAD_END);
           }
@@ -1177,7 +1202,7 @@ function createBaseCustomElementClass(win) {
       }
       this.paused_ = true;
       if (this.isBuilt()) {
-        this.implementation_.pauseCallback();
+        this.impl_.pauseCallback();
       }
     }
 
@@ -1196,7 +1221,7 @@ function createBaseCustomElementClass(win) {
       }
       this.paused_ = false;
       if (this.isBuilt()) {
-        this.implementation_.resumeCallback();
+        this.impl_.resumeCallback();
       }
     }
 
@@ -1215,7 +1240,7 @@ function createBaseCustomElementClass(win) {
         return false;
       }
       this.signals_.signal(CommonSignals.UNLOAD);
-      const isReLayoutNeeded = this.implementation_.unlayoutCallback();
+      const isReLayoutNeeded = this.impl_.unlayoutCallback();
       if (isReLayoutNeeded) {
         this.reset_();
       }
@@ -1242,7 +1267,7 @@ function createBaseCustomElementClass(win) {
      * @package @final
      */
     unlayoutOnPause() {
-      return this.implementation_.unlayoutOnPause();
+      return this.impl_ ? this.impl_.unlayoutOnPause() : false;
     }
 
     /**
@@ -1254,7 +1279,7 @@ function createBaseCustomElementClass(win) {
      * @package @final
      */
     reconstructWhenReparented() {
-      return this.implementation_.reconstructWhenReparented();
+      return this.impl_ ? this.impl_.reconstructWhenReparented() : false;
     }
 
     /**
@@ -1262,7 +1287,9 @@ function createBaseCustomElementClass(win) {
      * element is no longer present.
      */
     collapse() {
-      this.implementation_./*OK*/ collapse();
+      if (this.impl_) {
+        this.impl_./*OK*/ collapse();
+      }
     }
 
     /**
@@ -1270,7 +1297,9 @@ function createBaseCustomElementClass(win) {
      * @param {!AmpElement} element
      */
     collapsedCallback(element) {
-      this.implementation_.collapsedCallback(element);
+      if (this.impl_) {
+        this.impl_.collapsedCallback(element);
+      }
     }
 
     /**
@@ -1278,7 +1307,9 @@ function createBaseCustomElementClass(win) {
      * element is now present.
      */
     expand() {
-      this.implementation_./*OK*/ expand();
+      if (this.impl_) {
+        this.impl_./*OK*/ expand();
+      }
     }
 
     /**
@@ -1289,7 +1320,9 @@ function createBaseCustomElementClass(win) {
      * @param {!JsonObject<string, (null|boolean|string|number|Array|Object)>} mutations
      */
     mutatedAttributesCallback(mutations) {
-      this.implementation_.mutatedAttributesCallback(mutations);
+      if (this.impl_) {
+        this.impl_.mutatedAttributesCallback(mutations);
+      }
     }
 
     /**
@@ -1340,7 +1373,7 @@ function createBaseCustomElementClass(win) {
      */
     executionAction_(invocation, deferred) {
       try {
-        this.implementation_.executeAction(invocation, deferred);
+        this.impl_.executeAction(invocation, deferred);
       } catch (e) {
         rethrowAsync(
           'Action execution failed:',
@@ -1366,11 +1399,11 @@ function createBaseCustomElementClass(win) {
           return null;
         }
       }
-      if (policyId == '' || policyId == 'default') {
+      if ((policyId == '' || policyId == 'default') && this.impl_) {
         // data-block-on-consent value not set, up to individual element
         // Note: data-block-on-consent and data-block-on-consent='default' is
         // treated exactly the same
-        return this.implementation_.getConsentPolicy();
+        return this.impl_.getConsentPolicy();
       }
       return policyId;
     }
@@ -1650,15 +1683,6 @@ function assertNotTemplate(element) {
 }
 
 /**
- * Whether the implementation is a stub.
- * @param {?./base-element.BaseElement} impl
- * @return {boolean}
- */
-function isStub(impl) {
-  return impl instanceof ElementStub;
-}
-
-/**
  * Returns "true" for internal AMP nodes or for placeholder elements.
  * @param {!Node} node
  * @return {boolean}
@@ -1684,6 +1708,7 @@ function isInternalOrServiceNode(node) {
  * @param {!Window} win The window in which to register the custom element.
  * @param {(typeof ./base-element.BaseElement)=} opt_implementationClass For testing only.
  * @return {!Object} Prototype of element.
+ * @visibleForTesting
  */
 export function createAmpElementForTesting(win, opt_implementationClass) {
   const Element = createCustomElementClass(win);
@@ -1691,4 +1716,20 @@ export function createAmpElementForTesting(win, opt_implementationClass) {
     Element.prototype.implementationClassForTesting = opt_implementationClass;
   }
   return Element;
+}
+
+/**
+ * @visibleForTesting
+ */
+export function resetStubsForTesting() {
+  stubbedElements.length = 0;
+}
+
+/**
+ * @param {!AmpElement} element
+ * @return {!BaseElement}
+ * @visibleForTesting
+ */
+export function getImplSyncForTesting(element) {
+  return element.impl_;
 }

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -20,6 +20,7 @@ import {CommonSignals} from './common-signals';
 import {ElementStub} from './element-stub';
 import {
   Layout,
+  LayoutPriority,
   applyStaticLayout,
   isInternalElement,
   isLoadingAllowed,
@@ -358,9 +359,9 @@ function createBaseCustomElementClass(win) {
      * @final @private
      */
     completeUpgrade_(newImpl, upgradeStartTime) {
+      this.impl_ = newImpl;
       this.upgradeDelayMs_ = win.Date.now() - upgradeStartTime;
       this.upgradeState_ = UpgradeState.UPGRADED;
-      this.impl_ = newImpl;
       this.classList.remove('amp-unresolved');
       this.classList.remove('i-amphtml-unresolved');
       this.assertLayout_();
@@ -411,8 +412,9 @@ function createBaseCustomElementClass(win) {
      * @return {number}
      */
     getLayoutPriority() {
-      devAssert(this.isUpgraded(), 'Cannot get priority of unupgraded element');
-      return this.impl_.getLayoutPriority();
+      return this.impl_
+        ? this.impl_.getLayoutPriority()
+        : LayoutPriority.BACKGROUND;
     }
 
     /**

--- a/src/element-stub.js
+++ b/src/element-stub.js
@@ -15,33 +15,6 @@
  */
 
 import {BaseElement} from './base-element';
-import {devAssert} from './log';
 
-/** @type {!Array} */
-export const stubbedElements = [];
-
-export class ElementStub extends BaseElement {
-  /** @param {!AmpElement} element */
-  constructor(element) {
-    super(element);
-    stubbedElements.push(this);
-  }
-
-  /** @override */
-  getLayoutPriority() {
-    return devAssert(0, 'Cannot get priority of stubbed element');
-  }
-
-  /** @override */
-  isLayoutSupported(unusedLayout) {
-    // Always returns true and will eventually call this method on the actual
-    // element.
-    return true;
-  }
-
-  /** @override */
-  reconstructWhenReparented() {
-    // No real state so no reason to reconstruct.
-    return false;
-  }
-}
+// TODO(#31915): completely eliminate this class.
+export class ElementStub extends BaseElement {}

--- a/src/service/custom-element-registry.js
+++ b/src/service/custom-element-registry.js
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import {ElementStub, stubbedElements} from '../element-stub';
-import {createCustomElementClass} from '../custom-element';
+import {ElementStub} from '../element-stub';
+import {createCustomElementClass, stubbedElements} from '../custom-element';
 import {extensionScriptsInNode} from '../element-service';
 import {reportError} from '../error';
 import {userAssert} from '../log';
@@ -56,7 +56,7 @@ export function upgradeOrRegisterElement(win, name, toClass) {
   );
   knownElements[name] = toClass;
   for (let i = 0; i < stubbedElements.length; i++) {
-    const stub = stubbedElements[i];
+    const element = stubbedElements[i];
     // There are 3 possible states here:
     // 1. We never made the stub because the extended impl. loaded first.
     //    In that case the element won't be in the array.
@@ -65,7 +65,6 @@ export function upgradeOrRegisterElement(win, name, toClass) {
     //    implementation.
     // 3. A stub was attached. We upgrade which means we replay the
     //    implementation.
-    const {element} = stub;
     if (
       element.tagName.toLowerCase() == name &&
       element.ownerDocument.defaultView == win

--- a/test/unit/test-custom-element-registry.js
+++ b/test/unit/test-custom-element-registry.js
@@ -27,6 +27,7 @@ import {
   upgradeOrRegisterElement,
 } from '../../src/service/custom-element-registry';
 import {createElementWithAttributes} from '../../src/dom';
+import {getImplSyncForTesting} from '../../src/custom-element';
 
 describes.realWin('CustomElement register', {amp: true}, (env) => {
   class ConcreteElement extends BaseElement {}
@@ -63,19 +64,20 @@ describes.realWin('CustomElement register', {amp: true}, (env) => {
     const element1 = doc.createElement('amp-element1');
     element1.setAttribute('layout', 'nodisplay');
     doc.body.appendChild(element1);
-    expect(element1.implementation_).to.be.instanceOf(ElementStub);
+    expect(getImplSyncForTesting(element1)).to.be.null;
 
     // Post-download, elements are upgraded.
     upgradeOrRegisterElement(win, 'amp-element1', ConcreteElement);
     expect(getElementClassForTesting(win, 'amp-element1')).to.equal(
       ConcreteElement
     );
-    expect(element1.implementation_).to.be.instanceOf(ConcreteElement);
+    expect(getImplSyncForTesting(element1)).to.be.instanceOf(ConcreteElement);
 
     // Elements created post-download and immediately upgraded.
     const element2 = doc.createElement('amp-element1');
-    doc.body.appendChild(element1);
-    expect(element2.implementation_).to.be.instanceOf(ConcreteElement);
+    element2.setAttribute('layout', 'nodisplay');
+    doc.body.appendChild(element2);
+    expect(getImplSyncForTesting(element2)).to.be.instanceOf(ConcreteElement);
   });
 
   it('should mark stubbed element as declared', () => {

--- a/test/unit/test-custom-element.js
+++ b/test/unit/test-custom-element.js
@@ -23,7 +23,10 @@ import {LOADING_ELEMENTS_, Layout} from '../../src/layout';
 import {Resource, ResourceState} from '../../src/service/resource';
 import {Services} from '../../src/services';
 import {chunkInstanceForTesting} from '../../src/chunk';
-import {createAmpElementForTesting} from '../../src/custom-element';
+import {
+  createAmpElementForTesting,
+  getImplSyncForTesting,
+} from '../../src/custom-element';
 
 describes.realWin('CustomElement', {amp: true}, (env) => {
   // TODO(dvoytenko, #11827): Make this test work on Safari.
@@ -37,7 +40,7 @@ describes.realWin('CustomElement', {amp: true}, (env) => {
       let clock;
       let testElementGetInsersectionElementLayoutBox;
       let container;
-      let ElementClass, StubElementClass;
+      let ElementClass, StubElementClass, ElementClassWithReUpgrade;
 
       let testElementPreconnectCallback;
       let testElementBuildCallback;
@@ -52,6 +55,11 @@ describes.realWin('CustomElement', {amp: true}, (env) => {
       let testOnLayoutMeasureCallback;
 
       class TestElement extends BaseElement {
+        constructor(element, source) {
+          super(element);
+          this.source = source;
+        }
+
         isLayoutSupported(unusedLayout) {
           return true;
         }
@@ -101,7 +109,7 @@ describes.realWin('CustomElement', {amp: true}, (env) => {
           return true;
         }
         upgradeCallback() {
-          return new TestElement(this.element);
+          return new TestElement(this.element, 're-upgrade');
         }
       }
 
@@ -121,12 +129,23 @@ describes.realWin('CustomElement', {amp: true}, (env) => {
 
         ElementClass = createAmpElementForTesting(win, TestElement);
         StubElementClass = createAmpElementForTesting(win, ElementStub);
+        ElementClassWithReUpgrade = createAmpElementForTesting(
+          win,
+          TestElementWithReUpgrade
+        );
 
         win.customElements.define('amp-test', ElementClass);
         win.customElements.define('amp-stub', StubElementClass);
+        win.customElements.define(
+          'amp-test-with-re-upgrade',
+          ElementClassWithReUpgrade
+        );
 
         win.__AMP_EXTENDED_ELEMENTS['amp-test'] = TestElement;
         win.__AMP_EXTENDED_ELEMENTS['amp-stub'] = ElementStub;
+        win.__AMP_EXTENDED_ELEMENTS[
+          'amp-test-with-re-upgrade'
+        ] = TestElementWithReUpgrade;
         ampdoc.declareExtension('amp-stub');
 
         testElementPreconnectCallback = env.sandbox.spy();
@@ -147,6 +166,10 @@ describes.realWin('CustomElement', {amp: true}, (env) => {
         clock.uninstall();
         resourcesMock.verify();
       });
+
+      function skipMicroTask() {
+        return new Promise((resolve) => resolve(Promise.resolve()));
+      }
 
       it('should initialize ampdoc and resources on attach only', () => {
         const element = new ElementClass();
@@ -342,7 +365,7 @@ describes.realWin('CustomElement', {amp: true}, (env) => {
       it('should tolerate errors in onLayoutMeasure', () => {
         const element = new ElementClass();
         env.sandbox
-          .stub(element.implementation_, 'onLayoutMeasure')
+          .stub(TestElement.prototype, 'onLayoutMeasure')
           .callsFake(() => {
             throw new Error('intentional');
           });
@@ -363,6 +386,7 @@ describes.realWin('CustomElement', {amp: true}, (env) => {
       it('StubElement - upgrade after attached', () => {
         const element = new StubElementClass();
         expect(element.isUpgraded()).to.equal(false);
+        expect(getImplSyncForTesting(element)).to.be.null;
 
         element.setAttribute('layout', 'fill');
         element.updateLayoutBox({top: 0, left: 0, width: 111, height: 51});
@@ -372,14 +396,16 @@ describes.realWin('CustomElement', {amp: true}, (env) => {
         element.upgrade(TestElement);
 
         expect(element.isUpgraded()).to.equal(true);
-        expect(element.implementation_).to.be.instanceOf(TestElement);
-        expect(element.implementation_.getLayout()).to.equal(Layout.FILL);
+        const impl = getImplSyncForTesting(element);
+        expect(impl).to.be.instanceOf(TestElement);
+        expect(impl.getLayout()).to.equal(Layout.FILL);
         expect(element.isBuilt()).to.equal(false);
       });
 
-      it('StubElement - upgrade before attached', () => {
+      it('StubElement - should not upgrade before attached', () => {
         const element = new StubElementClass();
         expect(element.isUpgraded()).to.equal(false);
+        expect(getImplSyncForTesting(element)).to.be.null;
 
         element.setAttribute('layout', 'fill');
         element.updateLayoutBox({top: 0, left: 0, width: 111, height: 51});
@@ -388,7 +414,28 @@ describes.realWin('CustomElement', {amp: true}, (env) => {
         element.upgrade(TestElement);
 
         expect(element.isUpgraded()).to.equal(false);
-        expect(element.implementation_).to.be.instanceOf(TestElement);
+        expect(getImplSyncForTesting(element)).to.be.null;
+        expect(element.isBuilt()).to.equal(false);
+      });
+
+      it('StubElement - upgrade if ever attached', () => {
+        const element = new StubElementClass();
+        expect(element.isUpgraded()).to.equal(false);
+        expect(getImplSyncForTesting(element)).to.be.null;
+
+        element.setAttribute('layout', 'fill');
+        element.updateLayoutBox({top: 0, left: 0, width: 111, height: 51});
+
+        // Attach once and remove.
+        container.appendChild(element);
+        container.removeChild(element);
+
+        resourcesMock.expects('upgraded').withExactArgs(element).once();
+
+        element.upgrade(TestElement);
+
+        expect(element.isUpgraded()).to.equal(true);
+        expect(getImplSyncForTesting(element)).to.be.instanceOf(TestElement);
         expect(element.isBuilt()).to.equal(false);
       });
 
@@ -405,94 +452,74 @@ describes.realWin('CustomElement', {amp: true}, (env) => {
       });
 
       it('Element - re-upgrade to new direct instance', () => {
-        const element = new ElementClass();
+        const element = new ElementClassWithReUpgrade();
         expect(element.isUpgraded()).to.equal(false);
-        const newImpl = new TestElement(element);
-        element.implementation_.upgradeCallback = () => newImpl;
 
         container.appendChild(element);
         expect(element.isUpgraded()).to.equal(true);
-        expect(element.implementation_).to.equal(newImpl);
+
+        const impl = getImplSyncForTesting(element);
+        expect(impl).to.be.instanceOf(TestElement);
+        expect(impl.source).to.equal('re-upgrade');
         expect(element.upgradeDelayMs_).to.equal(0);
       });
 
-      it('Element - re-upgrade to new promised instance', () => {
-        const element = new ElementClass();
-        expect(element.isUpgraded()).to.equal(false);
-        const oldImpl = element.implementation_;
-        const newImpl = new TestElement(element);
-        const promise = Services.timerFor(win)
-          .promise(10)
-          .then(() => newImpl);
-        oldImpl.upgradeCallback = () => promise;
+      it('Element - re-upgrade to new promised instance', async () => {
+        let promise;
+        env.sandbox
+          .stub(TestElementWithReUpgrade.prototype, 'upgradeCallback')
+          .callsFake(function () {
+            promise = Promise.resolve(
+              new TestElement(this.element, 're-upgrade-with-promise')
+            );
+            return promise;
+          });
 
+        const element = new ElementClassWithReUpgrade();
+        expect(element.isUpgraded()).to.equal(false);
         container.appendChild(element);
-        expect(element.implementation_).to.equal(oldImpl);
+
+        expect(getImplSyncForTesting(element)).to.be.null;
         expect(element.isUpgraded()).to.equal(false);
         expect(element.upgradeState_).to.equal(/* UPGRADE_IN_PROGRESS */ 4);
-        clock.tick(10);
-        return promise
-          .then(() => {
-            // Skip a microtask.
-          })
-          .then(() => {
-            expect(element.implementation_).to.equal(newImpl);
-            expect(element.isUpgraded()).to.equal(true);
-            expect(element.upgradeState_).to.equal(/* UPGRADED */ 2);
-            expect(element.upgradeDelayMs_).to.be.equal(10);
-          });
+        expect(promise).to.exist;
+
+        await promise;
+        await skipMicroTask();
+        expect(element.isUpgraded()).to.equal(true);
+        expect(element.upgradeState_).to.equal(/* UPGRADED */ 2);
+
+        const impl = getImplSyncForTesting(element);
+        expect(impl).to.be.instanceOf(TestElement);
+        expect(impl.source).to.equal('re-upgrade-with-promise');
       });
 
-      it('Element - re-upgrade to new promised null', () => {
-        const element = new ElementClass();
-        expect(element.isUpgraded()).to.equal(false);
-        const oldImpl = element.implementation_;
-        const promise = Promise.resolve(null);
-        oldImpl.upgradeCallback = () => promise;
-
-        container.appendChild(element);
-        expect(element.implementation_).to.equal(oldImpl);
-        expect(element.isUpgraded()).to.equal(false);
-        expect(element.upgradeState_).to.equal(/* UPGRADE_IN_PROGRESS */ 4);
-        return promise
-          .then(() => {
-            // Skip a microtask.
-          })
-          .then(() => {
-            expect(element.implementation_).to.equal(oldImpl);
-            expect(element.isUpgraded()).to.equal(true);
-            expect(element.upgradeState_).to.equal(/* UPGRADED */ 2);
+      it('Element - re-upgrade to new promised null', async () => {
+        let promise;
+        env.sandbox
+          .stub(TestElementWithReUpgrade.prototype, 'upgradeCallback')
+          .callsFake(function () {
+            promise = Promise.resolve(null);
+            return promise;
           });
-      });
 
-      it('Element - can only re-upgrade once', () => {
-        const element = new ElementClass();
+        const element = new ElementClassWithReUpgrade();
         expect(element.isUpgraded()).to.equal(false);
-        const oldImpl = element.implementation_;
-        const newImpl = new TestElement(element);
-        const newImpl2 = new TestElement(element);
-        const promise = Promise.resolve(newImpl);
-        oldImpl.upgradeCallback = () => promise;
-
         container.appendChild(element);
-        expect(element.implementation_).to.equal(oldImpl);
+
+        expect(getImplSyncForTesting(element)).to.be.null;
         expect(element.isUpgraded()).to.equal(false);
         expect(element.upgradeState_).to.equal(/* UPGRADE_IN_PROGRESS */ 4);
+        expect(promise).to.exist;
 
-        oldImpl.upgradeCallback = () => newImpl2;
-        container.appendChild(element);
-        expect(element.implementation_).to.equal(oldImpl);
-        expect(element.isUpgraded()).to.equal(false);
-        expect(element.upgradeState_).to.equal(/* UPGRADE_IN_PROGRESS */ 4);
-        return promise
-          .then(() => {
-            // Skip a microtask.
-          })
-          .then(() => {
-            expect(element.implementation_).to.equal(newImpl);
-            expect(element.isUpgraded()).to.equal(true);
-            expect(element.upgradeState_).to.equal(/* UPGRADED */ 2);
-          });
+        await promise;
+        await skipMicroTask();
+
+        expect(element.isUpgraded()).to.equal(true);
+        expect(element.upgradeState_).to.equal(/* UPGRADED */ 2);
+
+        const impl = getImplSyncForTesting(element);
+        expect(impl).to.be.instanceOf(TestElementWithReUpgrade);
       });
 
       it('StubElement - re-upgrade', () => {
@@ -598,9 +625,7 @@ describes.realWin('CustomElement', {amp: true}, (env) => {
 
       it('should respect user specified consent policy', () => {
         const element = new ElementClass();
-        element.getAmpDoc = () => {
-          return env.ampdoc;
-        };
+        container.appendChild(element);
         expect(element.getConsentPolicy_()).to.equal(null);
         element.setAttribute('data-block-on-consent', '');
         expect(element.getConsentPolicy_()).to.equal('default');
@@ -614,20 +639,18 @@ describes.realWin('CustomElement', {amp: true}, (env) => {
         meta.setAttribute('content', 'amp-test');
         doc.head.appendChild(meta);
         const element = new ElementClass();
-        element.getAmpDoc = () => {
-          return env.ampdoc;
-        };
+        container.appendChild(element);
         expect(element.getConsentPolicy_()).to.equal('default');
         expect(element.getAttribute('data-block-on-consent')).to.equal(
           'default'
         );
       });
 
-      it('should anticipate build errors', () => {
+      it('should anticipate sync build errors', () => {
         expectAsyncConsoleError(/intentional/, 2);
         const element = new ElementClass();
         env.sandbox
-          .stub(element.implementation_, 'buildCallback')
+          .stub(TestElement.prototype, 'buildCallback')
           .callsFake(() => {
             throw new Error('intentional');
           });
@@ -731,6 +754,7 @@ describes.realWin('CustomElement', {amp: true}, (env) => {
 
       it('Element - createPlaceholder', () => {
         const element = new ElementClass();
+        container.appendChild(element);
         element.createPlaceholder();
         expect(testElementCreatePlaceholderCallback).to.be.calledOnce;
       });
@@ -747,7 +771,10 @@ describes.realWin('CustomElement', {amp: true}, (env) => {
 
         expect(element.everAttached).to.equal(true);
         expect(element.getLayout()).to.equal(Layout.FILL);
-        expect(element.implementation_.getLayout()).to.equal(Layout.FILL);
+        expect(element.getLayout()).to.equal(Layout.FILL);
+        expect(getImplSyncForTesting(element).getLayout()).to.equal(
+          Layout.FILL
+        );
       });
 
       it('StubElement - attachedCallback', () => {
@@ -770,7 +797,11 @@ describes.realWin('CustomElement', {amp: true}, (env) => {
         element.upgrade(TestElement);
 
         expect(element.getLayout()).to.equal(Layout.FILL);
-        expect(element.implementation_.getLayout()).to.equal(Layout.FILL);
+        expect(element.getLayout()).to.equal(Layout.FILL);
+        expect(getImplSyncForTesting(element).getLayout()).to.equal(
+          Layout.FILL
+        );
+
         // Now it's called.
         expect(element).to.not.have.class('amp-unresolved');
         expect(element).to.not.have.class('i-amphtml-unresolved');
@@ -791,7 +822,9 @@ describes.realWin('CustomElement', {amp: true}, (env) => {
 
         expect(element.everAttached).to.equal(true);
         expect(element.getLayout()).to.equal(Layout.FILL);
-        expect(element.implementation_.getLayout()).to.equal(Layout.FILL);
+        expect(getImplSyncForTesting(element).getLayout()).to.equal(
+          Layout.FILL
+        );
       });
 
       it('Element - handles async detachedCallback when connected', () => {
@@ -812,7 +845,9 @@ describes.realWin('CustomElement', {amp: true}, (env) => {
 
         expect(element.everAttached).to.equal(true);
         expect(element.getLayout()).to.equal(Layout.FILL);
-        expect(element.implementation_.getLayout()).to.equal(Layout.FILL);
+        expect(getImplSyncForTesting(element).getLayout()).to.equal(
+          Layout.FILL
+        );
       });
 
       it('Element - layoutCallback before build', () => {
@@ -914,7 +949,7 @@ describes.realWin('CustomElement', {amp: true}, (env) => {
 
           const controller = new AbortController();
           const stub = env.sandbox
-            .stub(element.implementation_, 'layoutCallback')
+            .stub(TestElement.prototype, 'layoutCallback')
             .callsFake(() => {
               controller.abort();
             });
@@ -943,7 +978,7 @@ describes.realWin('CustomElement', {amp: true}, (env) => {
 
           const controller = new AbortController();
           const stub = env.sandbox
-            .stub(element.implementation_, 'layoutCallback')
+            .stub(TestElement.prototype, 'layoutCallback')
             .callsFake(() => {
               controller.abort();
               throw new Error('throwaway');
@@ -1046,8 +1081,12 @@ describes.realWin('CustomElement', {amp: true}, (env) => {
 
       it('should enqueue actions until built', () => {
         const element = new ElementClass();
-        const handler = env.sandbox.spy();
-        element.implementation_.executeAction = handler;
+        const handler = env.sandbox.stub(
+          TestElement.prototype,
+          'executeAction'
+        );
+
+        container.appendChild(element);
         expect(element.actionQueue_).to.not.equal(null);
 
         const inv = {};
@@ -1059,8 +1098,10 @@ describes.realWin('CustomElement', {amp: true}, (env) => {
 
       it('should execute action immediately after built', () => {
         const element = new ElementClass();
-        const handler = env.sandbox.spy();
-        element.implementation_.executeAction = handler;
+        const handler = env.sandbox.stub(
+          TestElement.prototype,
+          'executeAction'
+        );
         container.appendChild(element);
         return element.buildInternal().then(() => {
           const inv = {};
@@ -1073,8 +1114,10 @@ describes.realWin('CustomElement', {amp: true}, (env) => {
 
       it('should dequeue all actions after build', () => {
         const element = new ElementClass();
-        const handler = env.sandbox.spy();
-        element.implementation_.executeAction = handler;
+        const handler = env.sandbox.stub(
+          TestElement.prototype,
+          'executeAction'
+        );
 
         const inv1 = {};
         const inv2 = {};
@@ -1099,8 +1142,6 @@ describes.realWin('CustomElement', {amp: true}, (env) => {
 
       it('should NOT enqueue actions when in template', () => {
         const element = new ElementClass();
-        const handler = env.sandbox.spy();
-        element.implementation_.executeAction = handler;
         expect(element.actionQueue_).to.not.equal(null);
 
         const inv = {};
@@ -1362,16 +1403,20 @@ describes.realWin('CustomElement', {amp: true}, (env) => {
           element.unlayoutCallback();
           expect(testElementUnlayoutCallback).to.have.not.been.called;
 
-          element.implementation_.layoutCallback = () => {
-            testElementLayoutCallback();
-            element.layoutCount_++;
-            return Promise.resolve();
-          };
+          env.sandbox
+            .stub(TestElement.prototype, 'layoutCallback')
+            .callsFake(() => {
+              testElementLayoutCallback();
+              element.layoutCount_++;
+              return Promise.resolve();
+            });
 
-          element.implementation_.unlayoutCallback = () => {
-            testElementUnlayoutCallback();
-            return true;
-          };
+          env.sandbox
+            .stub(TestElement.prototype, 'unlayoutCallback')
+            .callsFake(() => {
+              testElementUnlayoutCallback();
+              return true;
+            });
 
           // Built element receives unlayoutCallback.
           container.appendChild(element);
@@ -1384,15 +1429,22 @@ describes.realWin('CustomElement', {amp: true}, (env) => {
 
         it('should not reset layoutCount if relayout not requested', () => {
           const element = new ElementClass();
-          element.implementation_.layoutCallback = () => {
-            testElementLayoutCallback();
-            element.layoutCount_++;
-            return Promise.resolve();
-          };
-          element.implementation_.unlayoutCallback = () => {
-            testElementUnlayoutCallback();
-            return false;
-          };
+
+          env.sandbox
+            .stub(TestElement.prototype, 'layoutCallback')
+            .callsFake(() => {
+              testElementLayoutCallback();
+              element.layoutCount_++;
+              return Promise.resolve();
+            });
+
+          env.sandbox
+            .stub(TestElement.prototype, 'unlayoutCallback')
+            .callsFake(() => {
+              testElementUnlayoutCallback();
+              return false;
+            });
+
           container.appendChild(element);
           return element.buildingPromise_.then(() => {
             element.layoutCallback();
@@ -1802,7 +1854,7 @@ describes.realWin('CustomElement', {amp: true}, (env) => {
 
         it('should toggle loading off after layout failed', () => {
           env.sandbox
-            .stub(element.implementation_, 'layoutCallback')
+            .stub(TestElement.prototype, 'layoutCallback')
             .returns(Promise.reject());
           element.setAttribute('height', '10');
           element.setAttribute('width', '10');
@@ -1826,7 +1878,7 @@ describes.realWin('CustomElement', {amp: true}, (env) => {
 
         it('should disable toggle loading on after layout failed', () => {
           env.sandbox
-            .stub(element.implementation_, 'layoutCallback')
+            .stub(TestElement.prototype, 'layoutCallback')
             .returns(Promise.reject());
           element.setAttribute('height', '10');
           element.setAttribute('width', '10');

--- a/test/unit/test-friendly-iframe-embed.js
+++ b/test/unit/test-friendly-iframe-embed.js
@@ -1294,9 +1294,7 @@ describes.realWin('installExtensionsInEmbed', {amp: true}, (env) => {
 
     // Must be stubbed already.
     expect(iframeWin.__AMP_EXTENDED_ELEMENTS['amp-test']).to.equal(ElementStub);
-    expect(
-      iframeWin.document.createElement('amp-test').implementation_
-    ).to.be.instanceOf(ElementStub);
+    expect(iframeWin.document.createElement('amp-test').implClass_).to.be.null;
     expect(iframeWin.__AMP_EXTENDED_ELEMENTS['amp-test-sub']).to.be.undefined;
     // Resolve the promise.
     extensions.registerExtension(
@@ -1318,9 +1316,9 @@ describes.realWin('installExtensionsInEmbed', {amp: true}, (env) => {
     expect(iframeWin.document.querySelector('style[amp-extension=amp-test]')).to
       .exist;
     // Must be upgraded already.
-    expect(
-      iframeWin.document.createElement('amp-test').implementation_
-    ).to.be.instanceOf(AmpTest);
+    expect(iframeWin.document.createElement('amp-test').implClass_).to.equal(
+      AmpTest
+    );
 
     // Secondary extension.
     expect(parentWin.__AMP_EXTENDED_ELEMENTS['amp-test-sub']).to.be.undefined;
@@ -1332,8 +1330,8 @@ describes.realWin('installExtensionsInEmbed', {amp: true}, (env) => {
     ).to.not.exist;
     // Must be upgraded already.
     expect(
-      iframeWin.document.createElement('amp-test-sub').implementation_
-    ).to.be.instanceOf(AmpTestSub);
+      iframeWin.document.createElement('amp-test-sub').implClass_
+    ).to.equal(AmpTestSub);
   });
 
   it('should adopt extension services', async () => {


### PR DESCRIPTION
Partial for #31915.

This is a fragment of the #32002 refactoring. The `ElementStub` is no longer created until upgraded class is available.
