### PR TITLE
🏗 Trigger CircleCI builds only for `ampproject/amphtml`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,17 +54,6 @@ commands:
           key: karma-cache-<<parameters.cache_name>>-{{ checksum ".karma-cache-hash" }}
   setup_vm:
     steps:
-      - run:
-          name: 'Print Pipeline Variables'
-          command: |
-            echo pipeline.id << pipeline.id >>
-            echo pipeline.number << pipeline.number	>>
-            echo pipeline.project.git_url << pipeline.project.git_url >>
-            echo pipeline.project.type << pipeline.project.type >>
-            echo pipeline.git.tag << pipeline.git.tag >>
-            echo pipeline.git.branch << pipeline.git.branch	 >>
-            echo pipeline.git.revision << pipeline.git.revision >>
-            echo pipeline.git.base_revision << pipeline.git.base_revision >>
       - checkout
       - run:
           name: 'Fetch Merge Commit'
@@ -244,6 +233,9 @@ jobs:
 
 workflows:
   'CircleCI':
+    when:
+      equal:
+        [https://github.com/ampproject/amphtml, << pipeline.project.git_url >>]
     jobs:
       - 'Checks':
           <<: *push_and_pr_builds

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,17 @@ commands:
           key: karma-cache-<<parameters.cache_name>>-{{ checksum ".karma-cache-hash" }}
   setup_vm:
     steps:
+      - run:
+          name: 'Print Pipeline Variables'
+          command: |
+            echo pipeline.id << pipeline.id >>
+            echo pipeline.number << pipeline.number	>>
+            echo pipeline.project.git_url << pipeline.project.git_url >>
+            echo pipeline.project.type << pipeline.project.type >>
+            echo pipeline.git.tag << pipeline.git.tag >>
+            echo pipeline.git.branch << pipeline.git.branch	 >>
+            echo pipeline.git.revision << pipeline.git.revision >>
+            echo pipeline.git.base_revision << pipeline.git.base_revision >>
       - checkout
       - run:
           name: 'Fetch Merge Commit'


### PR DESCRIPTION
This PR prevents AMP's CircleCI workflow from running unless the repo URL is `https://github.com/ampproject/amphtml`.

Until CircleCI fixes their bug and stops responding to duplicate webhooks from forks of `ampproject/amphtml`, this should block bogus builds [like this](https://app.circleci.com/pipelines/github/ampproject/amphtml/931/workflows/7b75d63b-bd10-4e1c-8f94-1e07410637c9) from being created (even if they are triggered by webhooks).
**References:**
- https://circleci.com/docs/2.0/pipeline-variables
- https://circleci.com/docs/2.0/pipeline-variables/#conditional-workflows
- https://circleci.com/docs/2.0/configuration-reference/#logic-statements