### PR TITLE
Remove internal CE API usage from tests

### DIFF
--- a/extensions/amp-3d-gltf/0.1/test/test-amp-3d-gltf.js
+++ b/extensions/amp-3d-gltf/0.1/test/test-amp-3d-gltf.js
@@ -59,7 +59,7 @@ describes.realWin(
       doc.body.appendChild(amp3dGltfEl);
       await amp3dGltfEl.build();
 
-      const amp3dGltf = amp3dGltfEl.implementation_;
+      const amp3dGltf = await amp3dGltfEl.getImpl();
       env.sandbox
         .stub(amp3dGltf, 'iframe_')
         .get(() => iframe)

--- a/extensions/amp-3q-player/0.1/test/test-amp-3q-player.js
+++ b/extensions/amp-3q-player/0.1/test/test-amp-3q-player.js
@@ -50,7 +50,8 @@ describes.realWin(
       await player.build();
       player.layoutCallback();
       const iframe = player.querySelector('iframe');
-      player.implementation_.sdnBridge_({
+      const impl = await player.getImpl();
+      impl.sdnBridge_({
         source: iframe.contentWindow,
         data: JSON.stringify({data: 'ready'}),
       });
@@ -76,25 +77,26 @@ describes.realWin(
 
     it('should forward events from amp-3q-player to the amp element', async () => {
       const player = await get3QElement('c8dbe7f4-7f7f-11e6-a407-0cc47a188158');
+      const impl = await player.getImpl();
       const iframe = player.querySelector('iframe');
       await Promise.resolve();
       const p1 = listenOncePromise(player, VideoEvents.MUTED);
-      sendFakeMessage(player, iframe, 'muted');
+      sendFakeMessage(impl, iframe, 'muted');
       await p1;
       const p2 = listenOncePromise(player, VideoEvents.PLAYING);
-      sendFakeMessage(player, iframe, 'playing');
+      sendFakeMessage(impl, iframe, 'playing');
       await p2;
       const p3 = listenOncePromise(player, VideoEvents.PAUSE);
-      sendFakeMessage(player, iframe, 'paused');
+      sendFakeMessage(impl, iframe, 'paused');
       await p3;
       const p4 = listenOncePromise(player, VideoEvents.UNMUTED);
-      sendFakeMessage(player, iframe, 'unmuted');
+      sendFakeMessage(impl, iframe, 'unmuted');
       const successTimeout = timer.promise(10);
       return Promise.race([p4, successTimeout]);
     });
 
-    function sendFakeMessage(player, iframe, command) {
-      player.implementation_.sdnBridge_({
+    function sendFakeMessage(impl, iframe, command) {
+      impl.sdnBridge_({
         source: iframe.contentWindow,
         data: JSON.stringify({data: command}),
       });

--- a/extensions/amp-accordion/0.1/test/test-amp-accordion.js
+++ b/extensions/amp-accordion/0.1/test/test-amp-accordion.js
@@ -65,8 +65,9 @@ describes.realWin(
       doc.body.appendChild(ampAccordion);
       return ampAccordion
         .build()
-        .then(() => {
-          ampAccordion.implementation_.mutateElement = (fn) =>
+        .then(() => ampAccordion.getImpl())
+        .then((impl) => {
+          impl.mutateElement = (fn) =>
             new Promise(() => {
               fn();
             });
@@ -99,270 +100,215 @@ describes.realWin(
       impl.executeAction(invocation);
     }
 
-    it('should expand when high trust toggle action is triggered on a collapsed section', () => {
-      return getAmpAccordion().then((ampAccordion) => {
-        const impl = ampAccordion.implementation_;
-        const headerElements = doc.querySelectorAll('section > *:first-child');
-        expect(headerElements[0].parentNode.hasAttribute('expanded')).to.be
-          .false;
-        expect(headerElements[0].getAttribute('aria-expanded')).to.equal(
-          'false'
-        );
-        impl.toggle_(headerElements[0].parentNode, ActionTrust.HIGH);
-        expect(headerElements[0].parentNode.hasAttribute('expanded')).to.be
-          .true;
-        expect(headerElements[0].getAttribute('aria-expanded')).to.equal(
-          'true'
-        );
-      });
+    it('should expand when high trust toggle action is triggered on a collapsed section', async () => {
+      const ampAccordion = await getAmpAccordion();
+      const impl = await ampAccordion.getImpl();
+      const headerElements = doc.querySelectorAll('section > *:first-child');
+      expect(headerElements[0].parentNode.hasAttribute('expanded')).to.be.false;
+      expect(headerElements[0].getAttribute('aria-expanded')).to.equal('false');
+      impl.toggle_(headerElements[0].parentNode, ActionTrust.HIGH);
+      expect(headerElements[0].parentNode.hasAttribute('expanded')).to.be.true;
+      expect(headerElements[0].getAttribute('aria-expanded')).to.equal('true');
     });
 
-    it('multiple accordions should not have the same IDs on content', () => {
-      return getAmpAccordion().then(() => {
-        return getAmpAccordion().then(() => {
-          const contentElements = doc.getElementsByClassName(
-            'i-amphtml-accordion-content'
-          );
-          for (let i = 0; i < contentElements.length; i++) {
-            expect(contentElements[i].id.startsWith('_AMP_content_')).to.be
-              .false;
-          }
-        });
-      });
+    it('multiple accordions should not have the same IDs on content', async () => {
+      await getAmpAccordion();
+      const contentElements = doc.getElementsByClassName(
+        'i-amphtml-accordion-content'
+      );
+      for (let i = 0; i < contentElements.length; i++) {
+        expect(contentElements[i].id.startsWith('_AMP_content_')).to.be.false;
+      }
     });
 
-    it('should collapse when high trust toggle action is triggered on a expanded section', () => {
-      return getAmpAccordion().then((ampAccordion) => {
-        const impl = ampAccordion.implementation_;
-        const headerElements = doc.querySelectorAll('section > *:first-child');
-        expect(headerElements[1].parentNode.hasAttribute('expanded')).to.be
-          .true;
-        expect(headerElements[1].getAttribute('aria-expanded')).to.equal(
-          'true'
-        );
+    it('should collapse when high trust toggle action is triggered on a expanded section', async () => {
+      const ampAccordion = await getAmpAccordion();
+      const impl = await ampAccordion.getImpl();
+      const headerElements = doc.querySelectorAll('section > *:first-child');
+      expect(headerElements[1].parentNode.hasAttribute('expanded')).to.be.true;
+      expect(headerElements[1].getAttribute('aria-expanded')).to.equal('true');
 
-        impl.toggle_(headerElements[1].parentNode, ActionTrust.HIGH);
+      impl.toggle_(headerElements[1].parentNode, ActionTrust.HIGH);
 
-        expect(headerElements[1].parentNode.hasAttribute('expanded')).to.be
-          .false;
-        expect(headerElements[1].getAttribute('aria-expanded')).to.equal(
-          'false'
-        );
-      });
+      expect(headerElements[1].parentNode.hasAttribute('expanded')).to.be.false;
+      expect(headerElements[1].getAttribute('aria-expanded')).to.equal('false');
     });
 
-    it('should expand when expand action is triggered on a collapsed section', () => {
-      return getAmpAccordion().then((ampAccordion) => {
-        const impl = ampAccordion.implementation_;
-        const headerElements = doc.querySelectorAll('section > *:first-child');
-        expect(headerElements[0].parentNode.hasAttribute('expanded')).to.be
-          .false;
-        expect(headerElements[0].getAttribute('aria-expanded')).to.equal(
-          'false'
-        );
-        impl.toggle_(headerElements[0].parentNode, ActionTrust.HIGH, true);
-        expect(headerElements[0].parentNode.hasAttribute('expanded')).to.be
-          .true;
-        expect(headerElements[0].getAttribute('aria-expanded')).to.equal(
-          'true'
-        );
-      });
+    it('should expand when expand action is triggered on a collapsed section', async () => {
+      const ampAccordion = await getAmpAccordion();
+      const impl = await ampAccordion.getImpl();
+      const headerElements = doc.querySelectorAll('section > *:first-child');
+      expect(headerElements[0].parentNode.hasAttribute('expanded')).to.be.false;
+      expect(headerElements[0].getAttribute('aria-expanded')).to.equal('false');
+      impl.toggle_(headerElements[0].parentNode, ActionTrust.HIGH, true);
+      expect(headerElements[0].parentNode.hasAttribute('expanded')).to.be.true;
+      expect(headerElements[0].getAttribute('aria-expanded')).to.equal('true');
     });
 
     it(
       'should collapse other sections when expand action is triggered on a ' +
         'collapsed section if expand-single-section attribute is set',
-      () => {
-        return getAmpAccordion().then((ampAccordion) => {
-          ampAccordion.setAttribute('expand-single-section', '');
-          expect(ampAccordion.hasAttribute('expand-single-section')).to.be.true;
-          const impl = ampAccordion.implementation_;
-          const headerElements = doc.querySelectorAll(
-            'section > *:first-child'
-          );
-          // second section is expanded by default
-          expect(headerElements[1].parentNode.hasAttribute('expanded')).to.be
-            .true;
-          expect(headerElements[1].getAttribute('aria-expanded')).to.equal(
-            'true'
-          );
-          // expand the first section
-          impl.toggle_(headerElements[0].parentNode, ActionTrust.HIGH, true);
-          // we expect the first section to be expanded
-          expect(headerElements[0].parentNode.hasAttribute('expanded')).to.be
-            .true;
-          expect(headerElements[0].getAttribute('aria-expanded')).to.equal(
-            'true'
-          );
-          // we expect the second section to be collapsed
-          expect(headerElements[1].parentNode.hasAttribute('expanded')).to.be
-            .false;
-          expect(headerElements[1].getAttribute('aria-expanded')).to.equal(
-            'false'
-          );
-        });
+      async () => {
+        const ampAccordion = await getAmpAccordion();
+        const impl = await ampAccordion.getImpl();
+        ampAccordion.setAttribute('expand-single-section', '');
+        expect(ampAccordion.hasAttribute('expand-single-section')).to.be.true;
+        const headerElements = doc.querySelectorAll('section > *:first-child');
+        // second section is expanded by default
+        expect(headerElements[1].parentNode.hasAttribute('expanded')).to.be
+          .true;
+        expect(headerElements[1].getAttribute('aria-expanded')).to.equal(
+          'true'
+        );
+        // expand the first section
+        impl.toggle_(headerElements[0].parentNode, ActionTrust.HIGH, true);
+        // we expect the first section to be expanded
+        expect(headerElements[0].parentNode.hasAttribute('expanded')).to.be
+          .true;
+        expect(headerElements[0].getAttribute('aria-expanded')).to.equal(
+          'true'
+        );
+        // we expect the second section to be collapsed
+        expect(headerElements[1].parentNode.hasAttribute('expanded')).to.be
+          .false;
+        expect(headerElements[1].getAttribute('aria-expanded')).to.equal(
+          'false'
+        );
       }
     );
 
-    it('should expand when low trust toggle action is triggered on a collapsed section', () => {
-      return getAmpAccordion().then((ampAccordion) => {
-        const impl = ampAccordion.implementation_;
-        const headerElements = doc.querySelectorAll('section > *:first-child');
-        expect(headerElements[0].parentNode.hasAttribute('expanded')).to.be
-          .false;
-        expect(headerElements[0].getAttribute('aria-expanded')).to.equal(
-          'false'
-        );
-        impl.toggle_(headerElements[0].parentNode, ActionTrust.LOW);
-        expect(headerElements[0].parentNode.hasAttribute('expanded')).to.be
-          .true;
-        expect(headerElements[0].getAttribute('aria-expanded')).to.equal(
-          'true'
-        );
-      });
+    it('should expand when low trust toggle action is triggered on a collapsed section', async () => {
+      const ampAccordion = await getAmpAccordion();
+      const impl = await ampAccordion.getImpl();
+      const headerElements = doc.querySelectorAll('section > *:first-child');
+      expect(headerElements[0].parentNode.hasAttribute('expanded')).to.be.false;
+      expect(headerElements[0].getAttribute('aria-expanded')).to.equal('false');
+      impl.toggle_(headerElements[0].parentNode, ActionTrust.LOW);
+      expect(headerElements[0].parentNode.hasAttribute('expanded')).to.be.true;
+      expect(headerElements[0].getAttribute('aria-expanded')).to.equal('true');
     });
 
-    it('should collapse when low trust toggle action is triggered on an expanded section', () => {
-      return getAmpAccordion().then((ampAccordion) => {
-        const impl = ampAccordion.implementation_;
-        const headerElements = doc.querySelectorAll('section > *:first-child');
-        expect(headerElements[1].parentNode.hasAttribute('expanded')).to.be
-          .true;
-        expect(headerElements[1].getAttribute('aria-expanded')).to.equal(
-          'true'
-        );
+    it('should collapse when low trust toggle action is triggered on an expanded section', async () => {
+      const ampAccordion = await getAmpAccordion();
+      const impl = await ampAccordion.getImpl();
+      const headerElements = doc.querySelectorAll('section > *:first-child');
+      expect(headerElements[1].parentNode.hasAttribute('expanded')).to.be.true;
+      expect(headerElements[1].getAttribute('aria-expanded')).to.equal('true');
 
-        impl.toggle_(headerElements[1].parentNode, ActionTrust.LOW);
+      impl.toggle_(headerElements[1].parentNode, ActionTrust.LOW);
 
-        expect(headerElements[1].parentNode.hasAttribute('expanded')).to.be
-          .false;
-        expect(headerElements[1].getAttribute('aria-expanded')).to.equal(
-          'false'
-        );
-      });
+      expect(headerElements[1].parentNode.hasAttribute('expanded')).to.be.false;
+      expect(headerElements[1].getAttribute('aria-expanded')).to.equal('false');
     });
 
-    it('should expand when beforematch event is triggered on a collapsed section', () => {
+    it('should expand when beforematch event is triggered on a collapsed section', async () => {
       // Enable display locking feature.
       toggleExperiment(win, 'amp-accordion-display-locking', true);
       doc.body.onbeforematch = null;
-      return getAmpAccordion().then(() => {
-        const section = doc.querySelector('section:not([expanded])');
-        const header = section.firstElementChild;
-        const content = section.children[1];
-        expect(section.hasAttribute('expanded')).to.be.false;
-        expect(header.getAttribute('aria-expanded')).to.equal('false');
-        content.dispatchEvent(new Event('beforematch'));
-        expect(section.hasAttribute('expanded')).to.be.true;
-        expect(header.getAttribute('aria-expanded')).to.equal('true');
+      await getAmpAccordion();
+      const section = doc.querySelector('section:not([expanded])');
+      const header = section.firstElementChild;
+      const content = section.children[1];
+      expect(section.hasAttribute('expanded')).to.be.false;
+      expect(header.getAttribute('aria-expanded')).to.equal('false');
+      content.dispatchEvent(new Event('beforematch'));
+      expect(section.hasAttribute('expanded')).to.be.true;
+      expect(header.getAttribute('aria-expanded')).to.equal('true');
 
-        // Reset display locking feature
-        toggleExperiment(win, 'amp-accordion-display-locking', false);
-        doc.body.onbeforematch = undefined;
-      });
+      // Reset display locking feature
+      toggleExperiment(win, 'amp-accordion-display-locking', false);
+      doc.body.onbeforematch = undefined;
     });
 
     it(
       "should trigger a section's expand event the section is expanded " +
         'without animation',
-      () => {
-        let impl;
-        return getAmpAccordion(true)
-          .then((ampAccordion) => {
-            impl = ampAccordion.implementation_;
-            impl.sections_[0].setAttribute(
-              'on',
-              `expand:acc${counter}.expand(section='acc${counter}sec${2}')`
-            );
-            expect(impl.sections_[2].hasAttribute('expanded')).to.be.false;
-            impl.toggle_(impl.sections_[0], ActionTrust.HIGH, true);
-            return poll('wait for first section to expand', () =>
-              impl.sections_[0].hasAttribute('expanded')
-            );
-          })
-          .then(() => {
-            expect(impl.sections_[2].hasAttribute('expanded')).to.be.true;
-          });
+      async () => {
+        const ampAccordion = await getAmpAccordion(true);
+        const impl = await ampAccordion.getImpl();
+
+        impl.sections_[0].setAttribute(
+          'on',
+          `expand:acc${counter}.expand(section='acc${counter}sec${2}')`
+        );
+        expect(impl.sections_[2].hasAttribute('expanded')).to.be.false;
+        impl.toggle_(impl.sections_[0], ActionTrust.HIGH, true);
+
+        await poll('wait for first section to expand', () =>
+          impl.sections_[0].hasAttribute('expanded')
+        );
+        expect(impl.sections_[2].hasAttribute('expanded')).to.be.true;
       }
     );
 
     it(
       "should trigger a section's collapse event the section is expanded " +
         'without animation',
-      () => {
-        let impl;
-        return getAmpAccordion(true)
-          .then((ampAccordion) => {
-            impl = ampAccordion.implementation_;
-            impl.sections_[1].setAttribute(
-              'on',
-              `collapse:acc${counter}.expand(section='acc${counter}sec${2}')`
-            );
-            expect(impl.sections_[2].hasAttribute('expanded')).to.be.false;
-            impl.toggle_(impl.sections_[1], ActionTrust.HIGH, false);
-            return poll(
-              'wait for first section to expand',
-              () => !impl.sections_[1].hasAttribute('expanded')
-            );
-          })
-          .then(() => {
-            expect(impl.sections_[2].hasAttribute('expanded')).to.be.true;
-          });
+      async () => {
+        const ampAccordion = await getAmpAccordion(true);
+        const impl = await ampAccordion.getImpl();
+
+        impl.sections_[1].setAttribute(
+          'on',
+          `collapse:acc${counter}.expand(section='acc${counter}sec${2}')`
+        );
+        expect(impl.sections_[2].hasAttribute('expanded')).to.be.false;
+        impl.toggle_(impl.sections_[1], ActionTrust.HIGH, false);
+
+        await poll(
+          'wait for first section to expand',
+          () => !impl.sections_[1].hasAttribute('expanded')
+        );
+        expect(impl.sections_[2].hasAttribute('expanded')).to.be.true;
       }
     );
 
     it(
       "should trigger a section's expand event the section is expanded " +
         'with animation',
-      () => {
-        let impl;
-        return getAmpAccordion(true)
-          .then((ampAccordion) => {
-            ampAccordion.setAttribute('animate', '');
-            impl = ampAccordion.implementation_;
-            impl.sections_[0].setAttribute(
-              'on',
-              `expand:acc${counter}.expand(section='acc${counter}sec${2}')`
-            );
-            expect(impl.sections_[2].hasAttribute('expanded')).to.be.false;
-            impl.toggle_(impl.sections_[0], ActionTrust.HIGH, true);
-            return poll('wait for first section to expand', () =>
-              impl.sections_[0].hasAttribute('expanded')
-            );
-          })
-          .then(() => {
-            return poll('wait for second section to expand', () =>
-              impl.sections_[2].hasAttribute('expanded')
-            );
-          });
+      async () => {
+        const ampAccordion = await getAmpAccordion(true);
+        const impl = await ampAccordion.getImpl();
+
+        ampAccordion.setAttribute('animate', '');
+        impl.sections_[0].setAttribute(
+          'on',
+          `expand:acc${counter}.expand(section='acc${counter}sec${2}')`
+        );
+        expect(impl.sections_[2].hasAttribute('expanded')).to.be.false;
+        impl.toggle_(impl.sections_[0], ActionTrust.HIGH, true);
+
+        await poll('wait for first section to expand', () =>
+          impl.sections_[0].hasAttribute('expanded')
+        );
+        await poll('wait for second section to expand', () =>
+          impl.sections_[2].hasAttribute('expanded')
+        );
       }
     );
 
     it(
       "should trigger a section's collapse event the section is expanded " +
         'with animation',
-      () => {
-        let impl;
-        return getAmpAccordion(true)
-          .then((ampAccordion) => {
-            ampAccordion.setAttribute('animate', '');
-            impl = ampAccordion.implementation_;
-            impl.sections_[1].setAttribute(
-              'on',
-              `collapse:acc${counter}.expand(section='acc${counter}sec${2}')`
-            );
-            expect(impl.sections_[2].hasAttribute('expanded')).to.be.false;
-            impl.toggle_(impl.sections_[1], ActionTrust.HIGH, false);
-            return poll(
-              'wait for first section to expand',
-              () => !impl.sections_[1].hasAttribute('expanded')
-            );
-          })
-          .then(() => {
-            return poll('wait for second section to expand', () =>
-              impl.sections_[2].hasAttribute('expanded')
-            );
-          });
+      async () => {
+        const ampAccordion = await getAmpAccordion(true);
+        const impl = await ampAccordion.getImpl();
+
+        ampAccordion.setAttribute('animate', '');
+        impl.sections_[1].setAttribute(
+          'on',
+          `collapse:acc${counter}.expand(section='acc${counter}sec${2}')`
+        );
+        expect(impl.sections_[2].hasAttribute('expanded')).to.be.false;
+        impl.toggle_(impl.sections_[1], ActionTrust.HIGH, false);
+
+        await poll(
+          'wait for first section to expand',
+          () => !impl.sections_[1].hasAttribute('expanded')
+        );
+        await poll('wait for second section to expand', () =>
+          impl.sections_[2].hasAttribute('expanded')
+        );
       }
     );
 
@@ -374,7 +320,7 @@ describes.realWin(
     `,
       ];
       const ampAccordion = await getAmpAccordionWithContents(contents, true);
-      const impl = ampAccordion.implementation_;
+      const impl = await ampAccordion.getImpl();
       const firstSection = impl.sections_[0];
       const content = firstSection.querySelector('amp-layout');
 
@@ -402,7 +348,7 @@ describes.realWin(
     `,
       ];
       const ampAccordion = await getAmpAccordionWithContents(contents, true);
-      const impl = ampAccordion.implementation_;
+      const impl = await ampAccordion.getImpl();
       const firstSection = impl.sections_[0];
       const content = firstSection.querySelector('amp-layout');
 
@@ -422,64 +368,117 @@ describes.realWin(
       });
     });
 
-    it('should stay expanded on the expand action when expanded', () => {
-      return getAmpAccordion().then((ampAccordion) => {
-        const impl = ampAccordion.implementation_;
-        const headerElements = doc.querySelectorAll('section > *:first-child');
-        expect(headerElements[1].parentNode.hasAttribute('expanded')).to.be
-          .true;
-        expect(headerElements[1].getAttribute('aria-expanded')).to.equal(
-          'true'
-        );
-        impl.toggle_(headerElements[1].parentNode, ActionTrust.HIGH, true);
-        expect(headerElements[1].parentNode.hasAttribute('expanded')).to.be
-          .true;
-        expect(headerElements[1].getAttribute('aria-expanded')).to.equal(
-          'true'
-        );
-      });
+    it('should stay expanded on the expand action when expanded', async () => {
+      const ampAccordion = await getAmpAccordion();
+      const impl = await ampAccordion.getImpl();
+      const headerElements = doc.querySelectorAll('section > *:first-child');
+      expect(headerElements[1].parentNode.hasAttribute('expanded')).to.be.true;
+      expect(headerElements[1].getAttribute('aria-expanded')).to.equal('true');
+      impl.toggle_(headerElements[1].parentNode, ActionTrust.HIGH, true);
+      expect(headerElements[1].parentNode.hasAttribute('expanded')).to.be.true;
+      expect(headerElements[1].getAttribute('aria-expanded')).to.equal('true');
     });
 
-    it('should collapse on the collapse action when expanded', () => {
-      return getAmpAccordion().then((ampAccordion) => {
-        const impl = ampAccordion.implementation_;
-        const headerElements = doc.querySelectorAll('section > *:first-child');
-        expect(headerElements[1].parentNode.hasAttribute('expanded')).to.be
-          .true;
-        expect(headerElements[1].getAttribute('aria-expanded')).to.equal(
-          'true'
-        );
-        impl.toggle_(headerElements[1].parentNode, ActionTrust.HIGH, false);
-        expect(headerElements[1].parentNode.hasAttribute('expanded')).to.be
-          .false;
-        expect(headerElements[1].getAttribute('aria-expanded')).to.equal(
-          'false'
-        );
-      });
+    it('should collapse on the collapse action when expanded', async () => {
+      const ampAccordion = await getAmpAccordion();
+      const impl = await ampAccordion.getImpl();
+      const headerElements = doc.querySelectorAll('section > *:first-child');
+      expect(headerElements[1].parentNode.hasAttribute('expanded')).to.be.true;
+      expect(headerElements[1].getAttribute('aria-expanded')).to.equal('true');
+      impl.toggle_(headerElements[1].parentNode, ActionTrust.HIGH, false);
+      expect(headerElements[1].parentNode.hasAttribute('expanded')).to.be.false;
+      expect(headerElements[1].getAttribute('aria-expanded')).to.equal('false');
     });
 
-    it('should stay collapsed on the collapse action when collapsed', () => {
-      return getAmpAccordion().then((ampAccordion) => {
-        const impl = ampAccordion.implementation_;
-        const headerElements = doc.querySelectorAll('section > *:first-child');
-        expect(headerElements[0].parentNode.hasAttribute('expanded')).to.be
-          .false;
-        expect(headerElements[0].getAttribute('aria-expanded')).to.equal(
-          'false'
-        );
-        impl.toggle_(headerElements[0].parentNode, ActionTrust.HIGH, false);
-        expect(headerElements[0].parentNode.hasAttribute('expanded')).to.be
-          .false;
-        expect(headerElements[0].getAttribute('aria-expanded')).to.equal(
-          'false'
-        );
-      });
+    it('should stay collapsed on the collapse action when collapsed', async () => {
+      const ampAccordion = await getAmpAccordion();
+      const impl = await ampAccordion.getImpl();
+      const headerElements = doc.querySelectorAll('section > *:first-child');
+      expect(headerElements[0].parentNode.hasAttribute('expanded')).to.be.false;
+      expect(headerElements[0].getAttribute('aria-expanded')).to.equal('false');
+      impl.toggle_(headerElements[0].parentNode, ActionTrust.HIGH, false);
+      expect(headerElements[0].parentNode.hasAttribute('expanded')).to.be.false;
+      expect(headerElements[0].getAttribute('aria-expanded')).to.equal('false');
     });
 
-    it('should expand when header of a collapsed section is clicked', () => {
-      return getAmpAccordion().then((ampAccordion) => {
+    it('should expand when header of a collapsed section is clicked', async () => {
+      const ampAccordion = await getAmpAccordion();
+      const impl = await ampAccordion.getImpl();
+      const headerElements = doc.querySelectorAll('section > *:first-child');
+      const clickEvent = {
+        target: headerElements[0],
+        currentTarget: headerElements[0],
+        preventDefault: env.sandbox.spy(),
+      };
+      expect(headerElements[0].parentNode.hasAttribute('expanded')).to.be.false;
+      expect(headerElements[0].getAttribute('aria-expanded')).to.equal('false');
+      impl.onHeaderPicked_(clickEvent);
+      expect(headerElements[0].parentNode.hasAttribute('expanded')).to.be.true;
+      expect(headerElements[0].getAttribute('aria-expanded')).to.equal('true');
+      expect(clickEvent.preventDefault.called).to.be.true;
+    });
+
+    it("should expand section when header's child is clicked", async () => {
+      const ampAccordion = await getAmpAccordion();
+      const impl = await ampAccordion.getImpl();
+      const headerElements = doc.querySelectorAll('section > *:first-child');
+      const header = headerElements[0];
+      const child = doc.createElement('div');
+      header.appendChild(child);
+      const clickEvent = {
+        target: child,
+        currentTarget: header,
+        preventDefault: env.sandbox.spy(),
+      };
+      expect(header.parentNode.hasAttribute('expanded')).to.be.false;
+      expect(header.getAttribute('aria-expanded')).to.equal('false');
+      impl.onHeaderPicked_(clickEvent);
+      expect(header.parentNode.hasAttribute('expanded')).to.be.true;
+      expect(header.getAttribute('aria-expanded')).to.equal('true');
+      expect(clickEvent.preventDefault).to.have.been.called;
+    });
+
+    it('should collapse when header of an expanded section is clicked', async () => {
+      const ampAccordion = await getAmpAccordion();
+      const impl = await ampAccordion.getImpl();
+      const headerElements = doc.querySelectorAll('section > *:first-child');
+      const clickEvent = {
+        target: headerElements[1],
+        currentTarget: headerElements[1],
+        preventDefault: env.sandbox.spy(),
+      };
+      expect(headerElements[1].parentNode.hasAttribute('expanded')).to.be.true;
+      expect(headerElements[1].getAttribute('aria-expanded')).to.equal('true');
+      impl.onHeaderPicked_(clickEvent);
+      expect(headerElements[1].parentNode.hasAttribute('expanded')).to.be.false;
+      expect(headerElements[1].getAttribute('aria-expanded')).to.equal('false');
+      expect(clickEvent.preventDefault).to.have.been.called;
+    });
+
+    it('should allow for clickable links in header', async () => {
+      const ampAccordion = await getAmpAccordion();
+      const impl = await ampAccordion.getImpl();
+      const headerElements = doc.querySelectorAll('section > *:first-child');
+      const a = doc.createElement('a');
+      headerElements[0].appendChild(a);
+      const aClickEvent = {
+        target: a,
+        currentTarget: headerElements[0],
+        preventDefault: env.sandbox.spy(),
+      };
+      impl.clickHandler_(aClickEvent);
+      expect(aClickEvent.preventDefault).to.not.have.been.called;
+    });
+
+    it(
+      'should expand when header of a collapsed section is ' +
+        'activated via keyboard',
+      async () => {
+        const ampAccordion = await getAmpAccordion();
+        const impl = await ampAccordion.getImpl();
         const headerElements = doc.querySelectorAll('section > *:first-child');
-        const clickEvent = {
+        const keyDownEvent = {
+          key: Keys.SPACE,
           target: headerElements[0],
           currentTarget: headerElements[0],
           preventDefault: env.sandbox.spy(),
@@ -489,446 +488,319 @@ describes.realWin(
         expect(headerElements[0].getAttribute('aria-expanded')).to.equal(
           'false'
         );
-        ampAccordion.implementation_.onHeaderPicked_(clickEvent);
+        impl.keyDownHandler_(keyDownEvent);
         expect(headerElements[0].parentNode.hasAttribute('expanded')).to.be
           .true;
         expect(headerElements[0].getAttribute('aria-expanded')).to.equal(
           'true'
         );
-        expect(clickEvent.preventDefault.called).to.be.true;
-      });
-    });
-
-    it("should expand section when header's child is clicked", () => {
-      return getAmpAccordion().then((ampAccordion) => {
-        const headerElements = doc.querySelectorAll('section > *:first-child');
-        const header = headerElements[0];
-        const child = doc.createElement('div');
-        header.appendChild(child);
-        const clickEvent = {
-          target: child,
-          currentTarget: header,
-          preventDefault: env.sandbox.spy(),
-        };
-        expect(header.parentNode.hasAttribute('expanded')).to.be.false;
-        expect(header.getAttribute('aria-expanded')).to.equal('false');
-        ampAccordion.implementation_.onHeaderPicked_(clickEvent);
-        expect(header.parentNode.hasAttribute('expanded')).to.be.true;
-        expect(header.getAttribute('aria-expanded')).to.equal('true');
-        expect(clickEvent.preventDefault).to.have.been.called;
-      });
-    });
-
-    it('should collapse when header of an expanded section is clicked', () => {
-      return getAmpAccordion().then((ampAccordion) => {
-        const headerElements = doc.querySelectorAll('section > *:first-child');
-        const clickEvent = {
-          target: headerElements[1],
-          currentTarget: headerElements[1],
-          preventDefault: env.sandbox.spy(),
-        };
-        expect(headerElements[1].parentNode.hasAttribute('expanded')).to.be
-          .true;
-        expect(headerElements[1].getAttribute('aria-expanded')).to.equal(
-          'true'
-        );
-        ampAccordion.implementation_.onHeaderPicked_(clickEvent);
-        expect(headerElements[1].parentNode.hasAttribute('expanded')).to.be
-          .false;
-        expect(headerElements[1].getAttribute('aria-expanded')).to.equal(
-          'false'
-        );
-        expect(clickEvent.preventDefault).to.have.been.called;
-      });
-    });
-
-    it('should allow for clickable links in header', () => {
-      return getAmpAccordion().then((ampAccordion) => {
-        const headerElements = doc.querySelectorAll('section > *:first-child');
-        const a = doc.createElement('a');
-        headerElements[0].appendChild(a);
-        const aClickEvent = {
-          target: a,
-          currentTarget: headerElements[0],
-          preventDefault: env.sandbox.spy(),
-        };
-        ampAccordion.implementation_.clickHandler_(aClickEvent);
-        expect(aClickEvent.preventDefault).to.not.have.been.called;
-      });
-    });
-
-    it(
-      'should expand when header of a collapsed section is ' +
-        'activated via keyboard',
-      () => {
-        return getAmpAccordion().then((ampAccordion) => {
-          const headerElements = doc.querySelectorAll(
-            'section > *:first-child'
-          );
-          const keyDownEvent = {
-            key: Keys.SPACE,
-            target: headerElements[0],
-            currentTarget: headerElements[0],
-            preventDefault: env.sandbox.spy(),
-          };
-          expect(headerElements[0].parentNode.hasAttribute('expanded')).to.be
-            .false;
-          expect(headerElements[0].getAttribute('aria-expanded')).to.equal(
-            'false'
-          );
-          ampAccordion.implementation_.keyDownHandler_(keyDownEvent);
-          expect(headerElements[0].parentNode.hasAttribute('expanded')).to.be
-            .true;
-          expect(headerElements[0].getAttribute('aria-expanded')).to.equal(
-            'true'
-          );
-          expect(keyDownEvent.preventDefault.called).to.be.true;
-        });
+        expect(keyDownEvent.preventDefault.called).to.be.true;
       }
     );
 
     it(
       "should NOT expand section when header's child is " +
         'activated via keyboard',
-      () => {
-        return getAmpAccordion().then((ampAccordion) => {
-          const headerElements = doc.querySelectorAll(
-            'section > *:first-child'
-          );
-          const child = doc.createElement('div');
-          headerElements[0].appendChild(child);
-          const keyDownEvent = {
-            key: Keys.ENTER,
-            target: child,
-            currentTarget: headerElements[0],
-            preventDefault: env.sandbox.spy(),
-          };
-          expect(headerElements[0].parentNode.hasAttribute('expanded')).to.be
-            .false;
-          expect(headerElements[0].getAttribute('aria-expanded')).to.equal(
-            'false'
-          );
-          ampAccordion.implementation_.keyDownHandler_(keyDownEvent);
-          expect(headerElements[0].parentNode.hasAttribute('expanded')).to.be
-            .false;
-          expect(headerElements[0].getAttribute('aria-expanded')).to.equal(
-            'false'
-          );
-          expect(keyDownEvent.preventDefault.called).to.be.false;
-        });
+      async () => {
+        const ampAccordion = await getAmpAccordion();
+        const impl = await ampAccordion.getImpl();
+        const headerElements = doc.querySelectorAll('section > *:first-child');
+        const child = doc.createElement('div');
+        headerElements[0].appendChild(child);
+        const keyDownEvent = {
+          key: Keys.ENTER,
+          target: child,
+          currentTarget: headerElements[0],
+          preventDefault: env.sandbox.spy(),
+        };
+        expect(headerElements[0].parentNode.hasAttribute('expanded')).to.be
+          .false;
+        expect(headerElements[0].getAttribute('aria-expanded')).to.equal(
+          'false'
+        );
+        impl.keyDownHandler_(keyDownEvent);
+        expect(headerElements[0].parentNode.hasAttribute('expanded')).to.be
+          .false;
+        expect(headerElements[0].getAttribute('aria-expanded')).to.equal(
+          'false'
+        );
+        expect(keyDownEvent.preventDefault.called).to.be.false;
       }
     );
 
     it(
       'should collapse when header of an expanded section is ' +
         'activated via keyboard',
-      () => {
-        return getAmpAccordion().then((ampAccordion) => {
-          const headerElements = doc.querySelectorAll(
-            'section > *:first-child'
-          );
-          const keyDownEvent = {
-            key: Keys.ENTER,
-            target: headerElements[1],
-            currentTarget: headerElements[1],
-            preventDefault: env.sandbox.spy(),
-          };
-          expect(headerElements[1].parentNode.hasAttribute('expanded')).to.be
-            .true;
-          expect(headerElements[1].getAttribute('aria-expanded')).to.equal(
-            'true'
-          );
-          ampAccordion.implementation_.keyDownHandler_(keyDownEvent);
-          expect(headerElements[1].parentNode.hasAttribute('expanded')).to.be
-            .false;
-          expect(headerElements[1].getAttribute('aria-expanded')).to.equal(
-            'false'
-          );
-          expect(keyDownEvent.preventDefault.called).to.be.true;
-        });
+      async () => {
+        const ampAccordion = await getAmpAccordion();
+        const impl = await ampAccordion.getImpl();
+        const headerElements = doc.querySelectorAll('section > *:first-child');
+        const keyDownEvent = {
+          key: Keys.ENTER,
+          target: headerElements[1],
+          currentTarget: headerElements[1],
+          preventDefault: env.sandbox.spy(),
+        };
+        expect(headerElements[1].parentNode.hasAttribute('expanded')).to.be
+          .true;
+        expect(headerElements[1].getAttribute('aria-expanded')).to.equal(
+          'true'
+        );
+        impl.keyDownHandler_(keyDownEvent);
+        expect(headerElements[1].parentNode.hasAttribute('expanded')).to.be
+          .false;
+        expect(headerElements[1].getAttribute('aria-expanded')).to.equal(
+          'false'
+        );
+        expect(keyDownEvent.preventDefault.called).to.be.true;
       }
     );
 
     it(
       'should be navigable by up and down arrow keys when ' +
         'any header has focus',
-      () => {
-        return getAmpAccordion().then((ampAccordion) => {
-          const headerElements = doc.querySelectorAll(
-            'section > *:first-child'
-          );
-          // Focus the first header,
-          tryFocus(headerElements[0]);
-          expect(doc.activeElement).to.equal(headerElements[0]);
-          const upArrowEvent = {
-            key: Keys.UP_ARROW,
-            target: headerElements[0],
-            currentTarget: headerElements[0],
-            preventDefault: env.sandbox.spy(),
-          };
-          ampAccordion.implementation_.keyDownHandler_(upArrowEvent);
-          expect(doc.activeElement).to.equal(
-            headerElements[headerElements.length - 1]
-          );
-          const downArrowEvent = {
-            key: Keys.DOWN_ARROW,
-            target: headerElements[headerElements.length - 1],
-            currentTarget: headerElements[headerElements.length - 1],
-            preventDefault: env.sandbox.spy(),
-          };
-          ampAccordion.implementation_.keyDownHandler_(downArrowEvent);
-          expect(doc.activeElement).to.equal(headerElements[0]);
-        });
+      async () => {
+        const ampAccordion = await getAmpAccordion();
+        const impl = await ampAccordion.getImpl();
+        const headerElements = doc.querySelectorAll('section > *:first-child');
+        // Focus the first header,
+        tryFocus(headerElements[0]);
+        expect(doc.activeElement).to.equal(headerElements[0]);
+        const upArrowEvent = {
+          key: Keys.UP_ARROW,
+          target: headerElements[0],
+          currentTarget: headerElements[0],
+          preventDefault: env.sandbox.spy(),
+        };
+        impl.keyDownHandler_(upArrowEvent);
+        expect(doc.activeElement).to.equal(
+          headerElements[headerElements.length - 1]
+        );
+        const downArrowEvent = {
+          key: Keys.DOWN_ARROW,
+          target: headerElements[headerElements.length - 1],
+          currentTarget: headerElements[headerElements.length - 1],
+          preventDefault: env.sandbox.spy(),
+        };
+        impl.keyDownHandler_(downArrowEvent);
+        expect(doc.activeElement).to.equal(headerElements[0]);
       }
     );
 
-    it('should return correct sessionStorageKey', () => {
-      return getAmpAccordion().then((ampAccordion) => {
-        const impl = ampAccordion.implementation_;
-        const url = win.location.href;
-        impl.element.id = '321';
-        const id = impl.getSessionStorageKey_();
-        const correctId = 'amp-321-' + url;
-        expect(id).to.be.equal(correctId);
-      });
+    it('should return correct sessionStorageKey', async () => {
+      const ampAccordion = await getAmpAccordion();
+      const impl = await ampAccordion.getImpl();
+      const url = win.location.href;
+      impl.element.id = '321';
+      const id = impl.getSessionStorageKey_();
+      const correctId = 'amp-321-' + url;
+      expect(id).to.be.equal(correctId);
     });
 
-    it('should set sessionStorage on change in expansion', () => {
-      return getAmpAccordion().then((ampAccordion) => {
-        const impl = ampAccordion.implementation_;
-        const headerElements = doc.querySelectorAll('section > *:first-child');
-        const clickEventExpandElement = {
-          target: headerElements[0],
-          currentTarget: headerElements[0],
-          preventDefault: env.sandbox.spy(),
-        };
-        const clickEventCollapseElement = {
-          target: headerElements[1],
-          currentTarget: headerElements[1],
-          preventDefault: env.sandbox.spy(),
-        };
-        expect(Object.keys(impl.currentState_)).to.have.length(0);
-        impl.onHeaderPicked_(clickEventExpandElement);
-        expect(Object.keys(impl.currentState_)).to.have.length(1);
-        expect(impl.currentState_['test0']).to.be.true;
-        impl.onHeaderPicked_(clickEventCollapseElement);
-        expect(Object.keys(impl.currentState_)).to.have.length(2);
-        expect(impl.currentState_['test0']).to.be.true;
-        expect(impl.currentState_['test1']).to.be.false;
-      });
+    it('should set sessionStorage on change in expansion', async () => {
+      const ampAccordion = await getAmpAccordion();
+      const impl = await ampAccordion.getImpl();
+      const headerElements = doc.querySelectorAll('section > *:first-child');
+      const clickEventExpandElement = {
+        target: headerElements[0],
+        currentTarget: headerElements[0],
+        preventDefault: env.sandbox.spy(),
+      };
+      const clickEventCollapseElement = {
+        target: headerElements[1],
+        currentTarget: headerElements[1],
+        preventDefault: env.sandbox.spy(),
+      };
+      expect(Object.keys(impl.currentState_)).to.have.length(0);
+      impl.onHeaderPicked_(clickEventExpandElement);
+      expect(Object.keys(impl.currentState_)).to.have.length(1);
+      expect(impl.currentState_['test0']).to.be.true;
+      impl.onHeaderPicked_(clickEventCollapseElement);
+      expect(Object.keys(impl.currentState_)).to.have.length(2);
+      expect(impl.currentState_['test0']).to.be.true;
+      expect(impl.currentState_['test1']).to.be.false;
     });
 
-    it('should respect session states and expand/collapse', () => {
-      return getAmpAccordion().then((ampAccordion) => {
-        const impl = ampAccordion.implementation_;
-        let headerElements = doc.querySelectorAll('section > *:first-child');
-        expect(headerElements[0].parentNode.hasAttribute('expanded')).to.be
-          .false;
-        expect(headerElements[0].getAttribute('aria-expanded')).to.equal(
-          'false'
-        );
-        expect(headerElements[1].parentNode.hasAttribute('expanded')).to.be
-          .true;
-        expect(headerElements[2].parentNode.hasAttribute('expanded')).to.be
-          .false;
-        impl.getSessionState_ = function () {
-          return {
-            'test0': true,
-          };
+    it('should respect session states and expand/collapse', async () => {
+      const ampAccordion = await getAmpAccordion();
+      const impl = await ampAccordion.getImpl();
+      let headerElements = doc.querySelectorAll('section > *:first-child');
+      expect(headerElements[0].parentNode.hasAttribute('expanded')).to.be.false;
+      expect(headerElements[0].getAttribute('aria-expanded')).to.equal('false');
+      expect(headerElements[1].parentNode.hasAttribute('expanded')).to.be.true;
+      expect(headerElements[2].parentNode.hasAttribute('expanded')).to.be.false;
+      impl.getSessionState_ = function () {
+        return {
+          'test0': true,
         };
-        impl.buildCallback();
-        headerElements = doc.querySelectorAll('section > *:first-child');
-        expect(headerElements[0].parentNode.hasAttribute('expanded')).to.be
-          .true;
-        expect(headerElements[0].getAttribute('aria-expanded')).to.equal(
-          'true'
-        );
-        expect(headerElements[1].parentNode.hasAttribute('expanded')).to.be
-          .true;
-        expect(headerElements[2].parentNode.hasAttribute('expanded')).to.be
-          .false;
-        impl.getSessionState_ = function () {
-          return {
-            'test0': true,
-            'test1': false,
-          };
+      };
+      impl.buildCallback();
+      headerElements = doc.querySelectorAll('section > *:first-child');
+      expect(headerElements[0].parentNode.hasAttribute('expanded')).to.be.true;
+      expect(headerElements[0].getAttribute('aria-expanded')).to.equal('true');
+      expect(headerElements[1].parentNode.hasAttribute('expanded')).to.be.true;
+      expect(headerElements[2].parentNode.hasAttribute('expanded')).to.be.false;
+      impl.getSessionState_ = function () {
+        return {
+          'test0': true,
+          'test1': false,
         };
-        impl.buildCallback();
-        headerElements = doc.querySelectorAll('section > *:first-child');
-        expect(headerElements[0].parentNode.hasAttribute('expanded')).to.be
-          .true;
-        expect(headerElements[0].getAttribute('aria-expanded')).to.equal(
-          'true'
-        );
-        expect(headerElements[1].parentNode.hasAttribute('expanded')).to.be
-          .false;
-        expect(headerElements[2].parentNode.hasAttribute('expanded')).to.be
-          .false;
-      });
+      };
+      impl.buildCallback();
+      headerElements = doc.querySelectorAll('section > *:first-child');
+      expect(headerElements[0].parentNode.hasAttribute('expanded')).to.be.true;
+      expect(headerElements[0].getAttribute('aria-expanded')).to.equal('true');
+      expect(headerElements[1].parentNode.hasAttribute('expanded')).to.be.false;
+      expect(headerElements[2].parentNode.hasAttribute('expanded')).to.be.false;
     });
 
-    it('should disable sessionStorage when opt-out', () => {
-      return getAmpAccordion().then((ampAccordion) => {
-        const impl = ampAccordion.implementation_;
-        const setSessionStateSpy = env.sandbox.spy();
-        const getSessionStateSpy = env.sandbox.spy();
-        impl.win.sessionStorage.setItem = function () {
-          setSessionStateSpy();
-        };
-        impl.win.sessionStorage.getItem = function () {
-          getSessionStateSpy();
-        };
+    it('should disable sessionStorage when opt-out', async () => {
+      const ampAccordion = await getAmpAccordion();
+      const impl = await ampAccordion.getImpl();
+      const setSessionStateSpy = env.sandbox.spy();
+      const getSessionStateSpy = env.sandbox.spy();
+      impl.win.sessionStorage.setItem = function () {
+        setSessionStateSpy();
+      };
+      impl.win.sessionStorage.getItem = function () {
+        getSessionStateSpy();
+      };
 
-        ampAccordion.setAttribute('disable-session-states', null);
-        impl.buildCallback();
-        expect(Object.keys(impl.currentState_)).to.have.length(0);
-        const headerElements = doc.querySelectorAll('section > *:first-child');
-        const clickEventExpandElement = {
-          target: headerElements[0],
-          currentTarget: headerElements[0],
-          preventDefault: env.sandbox.spy(),
-        };
-        impl.onHeaderPicked_(clickEventExpandElement);
-        expect(getSessionStateSpy).to.not.have.been.called;
-        expect(setSessionStateSpy).to.not.have.been.called;
-        expect(Object.keys(impl.currentState_)).to.have.length(1);
-      });
+      ampAccordion.setAttribute('disable-session-states', null);
+      impl.buildCallback();
+      expect(Object.keys(impl.currentState_)).to.have.length(0);
+      const headerElements = doc.querySelectorAll('section > *:first-child');
+      const clickEventExpandElement = {
+        target: headerElements[0],
+        currentTarget: headerElements[0],
+        preventDefault: env.sandbox.spy(),
+      };
+      impl.onHeaderPicked_(clickEventExpandElement);
+      expect(getSessionStateSpy).to.not.have.been.called;
+      expect(setSessionStateSpy).to.not.have.been.called;
+      expect(Object.keys(impl.currentState_)).to.have.length(1);
     });
 
-    it('two accordions should not affect each other', () => {
-      return getAmpAccordion().then((ampAccordion) => {
-        const ampAccordion1 = ampAccordion;
-        const ampAccordion2 = doc.createElement('amp-accordion');
-        for (let i = 0; i < 3; i++) {
-          const section = doc.createElement('section');
-          section.innerHTML =
-            '<h2>Section ' +
-            i +
-            "<span>nested stuff<span></h2><div id='test" +
-            i +
-            "'>Loreum ipsum</div>";
-          ampAccordion2.appendChild(section);
-        }
-        doc.body.appendChild(ampAccordion2);
-        return ampAccordion2
-          .build()
-          .then(() => {
-            ampAccordion.implementation_.mutateElement = (fn) => fn();
-            return ampAccordion.layoutCallback();
-          })
-          .then(() => {
-            const headerElements1 = ampAccordion1.querySelectorAll(
-              'section > *:first-child'
-            );
-            const clickEventElement = {
-              target: headerElements1[0],
-              currentTarget: headerElements1[0],
-              preventDefault: env.sandbox.spy(),
-            };
-            ampAccordion1.implementation_.onHeaderPicked_(clickEventElement);
-            const headerElements2 = ampAccordion2.querySelectorAll(
-              'section > *:first-child'
-            );
-            expect(headerElements1[0].parentNode.hasAttribute('expanded')).to.be
-              .true;
-            expect(headerElements2[0].parentNode.hasAttribute('expanded')).to.be
-              .false;
-          });
-      });
+    it('two accordions should not affect each other', async () => {
+      const ampAccordion = await getAmpAccordion();
+      const impl = await ampAccordion.getImpl();
+      const ampAccordion1 = ampAccordion;
+      const ampAccordion2 = doc.createElement('amp-accordion');
+      for (let i = 0; i < 3; i++) {
+        const section = doc.createElement('section');
+        section.innerHTML =
+          '<h2>Section ' +
+          i +
+          "<span>nested stuff<span></h2><div id='test" +
+          i +
+          "'>Loreum ipsum</div>";
+        ampAccordion2.appendChild(section);
+      }
+      doc.body.appendChild(ampAccordion2);
+      await ampAccordion2.build();
+
+      impl.mutateElement = (fn) => fn();
+      await ampAccordion.layoutCallback();
+
+      const headerElements1 = ampAccordion1.querySelectorAll(
+        'section > *:first-child'
+      );
+      const clickEventElement = {
+        target: headerElements1[0],
+        currentTarget: headerElements1[0],
+        preventDefault: env.sandbox.spy(),
+      };
+      impl.onHeaderPicked_(clickEventElement);
+      const headerElements2 = ampAccordion2.querySelectorAll(
+        'section > *:first-child'
+      );
+      expect(headerElements1[0].parentNode.hasAttribute('expanded')).to.be.true;
+      expect(headerElements2[0].parentNode.hasAttribute('expanded')).to.be
+        .false;
     });
 
-    it('should trigger expand/collapse events', () => {
-      return getAmpAccordion(true).then((ampAccordion) => {
-        const impl = ampAccordion.implementation_;
+    it('should trigger expand/collapse events', async () => {
+      const ampAccordion = await getAmpAccordion(true);
+      const impl = await ampAccordion.getImpl();
 
-        const actions = impl.getActionServiceForTesting();
-        env.sandbox.stub(actions, 'trigger');
+      const actions = impl.getActionServiceForTesting();
+      env.sandbox.stub(actions, 'trigger');
 
-        execute(impl, 'collapse', 123, `acc${counter}sec1`);
+      execute(impl, 'collapse', 123, `acc${counter}sec1`);
 
-        expect(actions.trigger).to.be.calledOnce;
-        expect(actions.trigger.getCall(0)).to.be.calledWith(
-          /* element */ env.sandbox.match.has('tagName'),
-          'collapse',
-          /* event */ env.sandbox.match.has('detail'),
-          /* trust */ 123
-        );
+      expect(actions.trigger).to.be.calledOnce;
+      expect(actions.trigger.getCall(0)).to.be.calledWith(
+        /* element */ env.sandbox.match.has('tagName'),
+        'collapse',
+        /* event */ env.sandbox.match.has('detail'),
+        /* trust */ 123
+      );
 
-        execute(impl, 'expand', 456, `acc${counter}sec1`);
+      execute(impl, 'expand', 456, `acc${counter}sec1`);
 
-        expect(actions.trigger).to.be.calledTwice;
-        expect(actions.trigger.getCall(1)).to.be.calledWith(
-          /* element */ env.sandbox.match.has('tagName'),
-          'expand',
-          /* event */ env.sandbox.match.has('detail'),
-          /* trust */ 456
-        );
-      });
+      expect(actions.trigger).to.be.calledTwice;
+      expect(actions.trigger.getCall(1)).to.be.calledWith(
+        /* element */ env.sandbox.match.has('tagName'),
+        'expand',
+        /* event */ env.sandbox.match.has('detail'),
+        /* trust */ 456
+      );
     });
 
-    it('should include a11y related attributes', () => {
-      return getAmpAccordion().then(() => {
-        const sectionElements = doc.querySelectorAll('section');
-        expect(sectionElements.length).to.equal(3);
+    it('should include a11y related attributes', async () => {
+      await getAmpAccordion();
 
-        const section0 = sectionElements[0];
-        const section1 = sectionElements[1];
-        const section2 = sectionElements[2];
-        const {
-          firstElementChild: header0,
-          lastElementChild: content0,
-        } = section0;
-        const {
-          firstElementChild: header1,
-          lastElementChild: content1,
-        } = section1;
-        const {
-          firstElementChild: header2,
-          lastElementChild: content2,
-        } = section2;
+      const sectionElements = doc.querySelectorAll('section');
+      expect(sectionElements.length).to.equal(3);
 
-        expect(header0).to.have.attribute('id');
-        expect(header0.getAttribute('aria-controls')).to.equal('test0');
-        expect(header0.getAttribute('tabindex')).to.equal('0');
-        expect(header0.getAttribute('role')).to.equal('button');
-        expect(content0).to.have.attribute('aria-labelledby');
-        expect(content0.getAttribute('id')).to.equal('test0');
-        expect(content0.getAttribute('role')).to.equal('region');
-        expect(header0.getAttribute('aria-controls')).to.equal(
-          content0.getAttribute('id')
-        );
-        expect(header0.getAttribute('id')).to.equal(
-          content0.getAttribute('aria-labelledby')
-        );
+      const section0 = sectionElements[0];
+      const section1 = sectionElements[1];
+      const section2 = sectionElements[2];
+      const {firstElementChild: header0, lastElementChild: content0} = section0;
+      const {firstElementChild: header1, lastElementChild: content1} = section1;
+      const {firstElementChild: header2, lastElementChild: content2} = section2;
 
-        expect(header1).to.have.attribute('id');
-        expect(header1.getAttribute('aria-controls')).to.equal('test1');
-        expect(header1.getAttribute('tabindex')).to.equal('0');
-        expect(header1.getAttribute('role')).to.equal('button');
-        expect(content1).to.have.attribute('aria-labelledby');
-        expect(content1.getAttribute('id')).to.equal('test1');
-        expect(content1.getAttribute('role')).to.equal('region');
-        expect(header1.getAttribute('aria-controls')).to.equal(
-          content1.getAttribute('id')
-        );
-        expect(header1.getAttribute('id')).to.equal(
-          content1.getAttribute('aria-labelledby')
-        );
+      expect(header0).to.have.attribute('id');
+      expect(header0.getAttribute('aria-controls')).to.equal('test0');
+      expect(header0.getAttribute('tabindex')).to.equal('0');
+      expect(header0.getAttribute('role')).to.equal('button');
+      expect(content0).to.have.attribute('aria-labelledby');
+      expect(content0.getAttribute('id')).to.equal('test0');
+      expect(content0.getAttribute('role')).to.equal('region');
+      expect(header0.getAttribute('aria-controls')).to.equal(
+        content0.getAttribute('id')
+      );
+      expect(header0.getAttribute('id')).to.equal(
+        content0.getAttribute('aria-labelledby')
+      );
 
-        expect(header2).to.have.attribute('id');
-        expect(header2.getAttribute('aria-controls')).to.equal('test2');
-        expect(header2.getAttribute('tabindex')).to.equal('0');
-        expect(header2.getAttribute('role')).to.equal('button');
-        expect(content2).to.have.attribute('aria-labelledby');
-        expect(content2.getAttribute('id')).to.equal('test2');
-        expect(content2.getAttribute('role')).to.equal('region');
-        expect(header2.getAttribute('aria-controls')).to.equal(
-          content2.getAttribute('id')
-        );
-        expect(header2.getAttribute('id')).to.equal(
-          content2.getAttribute('aria-labelledby')
-        );
-      });
+      expect(header1).to.have.attribute('id');
+      expect(header1.getAttribute('aria-controls')).to.equal('test1');
+      expect(header1.getAttribute('tabindex')).to.equal('0');
+      expect(header1.getAttribute('role')).to.equal('button');
+      expect(content1).to.have.attribute('aria-labelledby');
+      expect(content1.getAttribute('id')).to.equal('test1');
+      expect(content1.getAttribute('role')).to.equal('region');
+      expect(header1.getAttribute('aria-controls')).to.equal(
+        content1.getAttribute('id')
+      );
+      expect(header1.getAttribute('id')).to.equal(
+        content1.getAttribute('aria-labelledby')
+      );
+
+      expect(header2).to.have.attribute('id');
+      expect(header2.getAttribute('aria-controls')).to.equal('test2');
+      expect(header2.getAttribute('tabindex')).to.equal('0');
+      expect(header2.getAttribute('role')).to.equal('button');
+      expect(content2).to.have.attribute('aria-labelledby');
+      expect(content2.getAttribute('id')).to.equal('test2');
+      expect(content2.getAttribute('role')).to.equal('region');
+      expect(header2.getAttribute('aria-controls')).to.equal(
+        content2.getAttribute('id')
+      );
+      expect(header2.getAttribute('id')).to.equal(
+        content2.getAttribute('aria-labelledby')
+      );
     });
   }
 );

--- a/extensions/amp-ad-exit/0.1/test/test-amp-ad-exit.js
+++ b/extensions/amp-ad-exit/0.1/test/test-amp-ad-exit.js
@@ -175,16 +175,18 @@ describes.realWin(
       win.document.body.appendChild(adDiv);
     }
 
-    function pointTo(target) {
-      element.implementation_.executeAction({
+    async function pointTo(target) {
+      const impl = await element.getImpl();
+      impl.executeAction({
         method: 'setVariable',
         args: {name: 'indirect', target},
         satisfiesTrust: () => true,
       });
     }
 
-    function exitIndirect() {
-      element.implementation_.executeAction({
+    async function exitIndirect() {
+      const impl = await element.getImpl();
+      impl.executeAction({
         method: 'exit',
         args: {variable: 'indirect', default: 'simple'},
         event: makeClickEvent(1001),
@@ -222,11 +224,12 @@ describes.realWin(
       return promise.should.be.rejectedWith(/application\/json/);
     });
 
-    it('should do nothing for missing targets', () => {
+    it('should do nothing for missing targets', async () => {
       const open = env.sandbox.stub(win, 'open');
+      const impl = await element.getImpl();
       try {
         allowConsoleError(() =>
-          element.implementation_.executeAction({
+          impl.executeAction({
             method: 'exit',
             args: {target: 'not-a-real-target'},
             event: makeClickEvent(1001),
@@ -237,9 +240,10 @@ describes.realWin(
       } catch (expected) {}
     });
 
-    it('should stop event propagation', () => {
+    it('should stop event propagation', async () => {
       const event = makeClickEvent(1001);
-      element.implementation_.executeAction({
+      const impl = await element.getImpl();
+      impl.executeAction({
         method: 'exit',
         args: {target: 'twoSecondDelay'},
         event,
@@ -248,17 +252,18 @@ describes.realWin(
       expect(event.preventDefault).to.have.been.called;
     });
 
-    it('should reject fast clicks', () => {
+    it('should reject fast clicks', async () => {
       const open = env.sandbox.stub(win, 'open');
+      const impl = await element.getImpl();
 
-      element.implementation_.executeAction({
+      impl.executeAction({
         method: 'exit',
         args: {target: 'simple'},
         event: makeClickEvent(999),
         satisfiesTrust: () => true,
       });
 
-      element.implementation_.executeAction({
+      impl.executeAction({
         method: 'exit',
         args: {target: 'twoSecondDelay'},
         event: makeClickEvent(1000), // 1000 ms + 999 from the previous exit.
@@ -268,8 +273,8 @@ describes.realWin(
       expect(open).to.not.have.been.called;
     });
 
-    it('should use options.startTimingEvent', () => {
-      return makeElementWithConfig({
+    it('should use options.startTimingEvent', async () => {
+      const el = await makeElementWithConfig({
         targets: {
           navStart: {
             'finalUrl': 'http://localhost:8000/simple',
@@ -283,24 +288,25 @@ describes.realWin(
             delay: 2000,
           },
         },
-      }).then((el) => {
-        expect(el.implementation_.defaultFilters_.length).to.equal(2);
-        let clickFilter = el.implementation_.defaultFilters_[0];
-        expect(clickFilter.spec.type).to.equal(FilterType.CLICK_DELAY);
-        expect(clickFilter.spec.startTimingEvent).to.equal('navigationStart');
-        clickFilter = el.implementation_.userFilters_['twoSecond'];
-        expect(clickFilter).to.be.ok;
-        expect(clickFilter.spec.type).to.equal(FilterType.CLICK_DELAY);
-        expect(clickFilter.spec.startTimingEvent).to.equal('navigationStart');
       });
+      const impl = await el.getImpl();
+      expect(impl.defaultFilters_.length).to.equal(2);
+      let clickFilter = impl.defaultFilters_[0];
+      expect(clickFilter.spec.type).to.equal(FilterType.CLICK_DELAY);
+      expect(clickFilter.spec.startTimingEvent).to.equal('navigationStart');
+      clickFilter = impl.userFilters_['twoSecond'];
+      expect(clickFilter).to.be.ok;
+      expect(clickFilter.spec.type).to.equal(FilterType.CLICK_DELAY);
+      expect(clickFilter.spec.startTimingEvent).to.equal('navigationStart');
     });
 
-    it('should attempt new-tab navigation', () => {
+    it('should attempt new-tab navigation', async () => {
       const open = env.sandbox.stub(win, 'open').callsFake(() => {
         return {name: 'fakeWin'};
       });
+      const impl = await element.getImpl();
 
-      element.implementation_.executeAction({
+      impl.executeAction({
         method: 'exit',
         args: {target: 'simple'},
         event: makeClickEvent(1001),
@@ -314,10 +320,11 @@ describes.realWin(
       );
     });
 
-    it('should fall back to top navigation', () => {
+    it('should fall back to top navigation', async () => {
       const open = env.sandbox.stub(win, 'open').callsFake(() => null);
+      const impl = await element.getImpl();
 
-      element.implementation_.executeAction({
+      impl.executeAction({
         method: 'exit',
         args: {target: 'simple'},
         event: makeClickEvent(1001),
@@ -335,12 +342,13 @@ describes.realWin(
       );
     });
 
-    it('should attempt same-tab navigation', () => {
+    it('should attempt same-tab navigation', async () => {
       const open = env.sandbox.stub(win, 'open').callsFake(() => {
         return {name: 'fakeWin'};
       });
+      const impl = await element.getImpl();
 
-      element.implementation_.executeAction({
+      impl.executeAction({
         method: 'exit',
         args: {target: 'clickTargetTest'},
         event: makeClickEvent(1001),
@@ -354,15 +362,16 @@ describes.realWin(
       );
     });
 
-    it('should ping tracking URLs with sendBeacon', () => {
+    it('should ping tracking URLs with sendBeacon', async () => {
       const open = env.sandbox.stub(win, 'open').callsFake(() => {
         return {name: 'fakeWin'};
       });
       const sendBeacon = env.sandbox
         .stub(win.navigator, 'sendBeacon')
         .callsFake(() => true);
+      const impl = await element.getImpl();
 
-      element.implementation_.executeAction({
+      impl.executeAction({
         method: 'exit',
         args: {target: 'tracking'},
         event: makeClickEvent(1001),
@@ -385,10 +394,11 @@ describes.realWin(
       );
     });
 
-    it('should ping tracking URLs with image requests (no sendBeacon)', () => {
+    it('should ping tracking URLs with image requests (no sendBeacon)', async () => {
       const open = env.sandbox.stub(win, 'open').callsFake(() => {
         return {name: 'fakeWin'};
       });
+      const impl = await element.getImpl();
 
       let sendBeacon;
       if (win.navigator.sendBeacon) {
@@ -399,7 +409,7 @@ describes.realWin(
       const {createElement} = win.document;
       createElement.resetHistory();
 
-      element.implementation_.executeAction({
+      impl.executeAction({
         method: 'exit',
         args: {target: 'tracking'},
         event: makeClickEvent(1001),
@@ -418,10 +428,11 @@ describes.realWin(
       }
     });
 
-    it('should ping tracking URLs with image requests (sendBeacon fails)', () => {
+    it('should ping tracking URLs with image requests (sendBeacon fails)', async () => {
       const open = env.sandbox.stub(win, 'open').callsFake(() => {
         return {name: 'fakeWin'};
       });
+      const impl = await element.getImpl();
 
       const sendBeacon = env.sandbox
         .stub(win.navigator, 'sendBeacon')
@@ -429,7 +440,7 @@ describes.realWin(
       const {createElement} = win.document;
       createElement.resetHistory();
 
-      element.implementation_.executeAction({
+      impl.executeAction({
         method: 'exit',
         args: {target: 'tracking'},
         event: makeClickEvent(1001),
@@ -445,7 +456,7 @@ describes.realWin(
       expect(imgs[2].src).to.equal('http://localhost:8000/tracking?3');
     });
 
-    it('should ping tracking URLs with image requests (transport)', () => {
+    it('should ping tracking URLs with image requests (transport)', async () => {
       const config = {
         targets: EXIT_CONFIG.targets,
         filters: EXIT_CONFIG.filters,
@@ -453,38 +464,39 @@ describes.realWin(
           beacon: false,
         },
       };
-      return makeElementWithConfig(config).then((el) => {
-        const open = env.sandbox.stub(win, 'open').callsFake(() => {
-          return {name: 'fakeWin'};
-        });
-
-        const sendBeacon = env.sandbox
-          .stub(win.navigator, 'sendBeacon')
-          .callsFake(() => true);
-        const {createElement} = win.document;
-        createElement.resetHistory();
-
-        el.implementation_.executeAction({
-          method: 'exit',
-          args: {target: 'tracking'},
-          event: makeClickEvent(1001),
-          satisfiesTrust: () => true,
-        });
-
-        expect(open).to.have.been.calledOnce;
-        expect(sendBeacon).to.not.have.been.called;
-        expect(createElement.withArgs('img')).to.have.been.calledThrice;
-        const imgs = createElement.withArgs('img').returnValues;
-        expect(imgs[0].src).to.equal('http://localhost:8000/tracking?1');
-        expect(imgs[1].src).to.equal('http://localhost:8000/tracking?2');
-        expect(imgs[2].src).to.equal('http://localhost:8000/tracking?3');
-      });
-    });
-
-    it('should replace standard URL variables', () => {
+      const el = await makeElementWithConfig(config);
+      const impl = await el.getImpl();
       const open = env.sandbox.stub(win, 'open').callsFake(() => {
         return {name: 'fakeWin'};
       });
+
+      const sendBeacon = env.sandbox
+        .stub(win.navigator, 'sendBeacon')
+        .callsFake(() => true);
+      const {createElement} = win.document;
+      createElement.resetHistory();
+
+      impl.executeAction({
+        method: 'exit',
+        args: {target: 'tracking'},
+        event: makeClickEvent(1001),
+        satisfiesTrust: () => true,
+      });
+
+      expect(open).to.have.been.calledOnce;
+      expect(sendBeacon).to.not.have.been.called;
+      expect(createElement.withArgs('img')).to.have.been.calledThrice;
+      const imgs = createElement.withArgs('img').returnValues;
+      expect(imgs[0].src).to.equal('http://localhost:8000/tracking?1');
+      expect(imgs[1].src).to.equal('http://localhost:8000/tracking?2');
+      expect(imgs[2].src).to.equal('http://localhost:8000/tracking?3');
+    });
+
+    it('should replace standard URL variables', async () => {
+      const open = env.sandbox.stub(win, 'open').callsFake(() => {
+        return {name: 'fakeWin'};
+      });
+      const impl = await element.getImpl();
 
       if (!win.navigator) {
         win.navigator = {sendBeacon: () => false};
@@ -493,7 +505,7 @@ describes.realWin(
         .stub(win.navigator, 'sendBeacon')
         .callsFake(() => true);
 
-      element.implementation_.executeAction({
+      impl.executeAction({
         method: 'exit',
         args: {target: 'variables'},
         event: makeClickEvent(1001, 101, 102),
@@ -514,10 +526,11 @@ describes.realWin(
       expect(sendBeacon).to.have.been.calledWith(trackingMatcher, '');
     });
 
-    it('should replace custom URL variables with vars', () => {
+    it('should replace custom URL variables with vars', async () => {
       const open = env.sandbox.stub(win, 'open').callsFake(() => {
         return {name: 'fakeWin'};
       });
+      const impl = await element.getImpl();
 
       if (!win.navigator) {
         win.navigator = {sendBeacon: () => false};
@@ -526,7 +539,7 @@ describes.realWin(
         .stub(win.navigator, 'sendBeacon')
         .callsFake(() => true);
 
-      element.implementation_.executeAction({
+      impl.executeAction({
         method: 'exit',
         args: {
           target: 'customVars',
@@ -553,21 +566,22 @@ describes.realWin(
       );
     });
 
-    it('border protection', () => {
+    it('border protection', async () => {
       const open = env.sandbox.stub(win, 'open').callsFake(() => {
         return {name: 'fakeWin'};
       });
+      const impl = await element.getImpl();
 
       win.innerWidth = 1000;
       win.innerHeight = 2000;
       // Replace the getVsync function so that the measure can happen at once.
-      element.implementation_.getVsync = () => {
+      impl.getVsync = () => {
         return {measure: (callback) => callback()};
       };
-      element.implementation_.onLayoutMeasure();
+      impl.onLayoutMeasure();
 
       // The click is within the top border.
-      element.implementation_.executeAction({
+      impl.executeAction({
         method: 'exit',
         args: {target: 'borderProtection'},
         event: makeClickEvent(1001, 500, 8),
@@ -575,7 +589,7 @@ describes.realWin(
       });
 
       // The click is within the right border.
-      element.implementation_.executeAction({
+      impl.executeAction({
         method: 'exit',
         args: {target: 'borderProtection'},
         event: makeClickEvent(1001, 993, 500),
@@ -583,7 +597,7 @@ describes.realWin(
       });
 
       // The click is within the bottom border.
-      element.implementation_.executeAction({
+      impl.executeAction({
         method: 'exit',
         args: {target: 'borderProtection'},
         event: makeClickEvent(1001, 500, 1992),
@@ -594,7 +608,7 @@ describes.realWin(
 
       // The click is within the left border but left border protection is not
       // set.
-      element.implementation_.executeAction({
+      impl.executeAction({
         method: 'exit',
         args: {target: 'borderProtection'},
         event: makeClickEvent(1001, 8, 500),
@@ -602,7 +616,7 @@ describes.realWin(
       });
 
       // THe click is not within the border area.
-      element.implementation_.executeAction({
+      impl.executeAction({
         method: 'exit',
         args: {target: 'borderProtection'},
         event: makeClickEvent(1001, 500, 500),
@@ -615,19 +629,20 @@ describes.realWin(
       );
     });
 
-    it('border protection relative to div', () => {
+    it('border protection relative to div', async () => {
       const open = env.sandbox.stub(win, 'open').callsFake(() => {
         return {name: 'fakeWin'};
       });
+      const impl = await element.getImpl();
 
       // Replace the getVsync function so that the measure can happen at once.
-      element.implementation_.getVsync = () => {
+      impl.getVsync = () => {
         return {measure: (callback) => callback()};
       };
-      element.implementation_.onLayoutMeasure();
+      impl.onLayoutMeasure();
 
       // The click is within the top border.
-      element.implementation_.executeAction({
+      impl.executeAction({
         method: 'exit',
         args: {target: 'borderProtectionRelativeTo'},
         event: makeClickEvent(1001, 200, 208),
@@ -635,7 +650,7 @@ describes.realWin(
       });
 
       // The click is within the right border.
-      element.implementation_.executeAction({
+      impl.executeAction({
         method: 'exit',
         args: {target: 'borderProtectionRelativeTo'},
         event: makeClickEvent(1001, 293, 300),
@@ -643,7 +658,7 @@ describes.realWin(
       });
 
       // The click is within the bottom border.
-      element.implementation_.executeAction({
+      impl.executeAction({
         method: 'exit',
         args: {target: 'borderProtectionRelativeTo'},
         event: makeClickEvent(1001, 200, 392),
@@ -654,7 +669,7 @@ describes.realWin(
 
       // The click is within the left border but left border protection is not
       // set.
-      element.implementation_.executeAction({
+      impl.executeAction({
         method: 'exit',
         args: {target: 'borderProtectionRelativeTo'},
         event: makeClickEvent(1001, 103, 300),
@@ -662,7 +677,7 @@ describes.realWin(
       });
 
       // THe click is not within the border area.
-      element.implementation_.executeAction({
+      impl.executeAction({
         method: 'exit',
         args: {target: 'borderProtectionRelativeTo'},
         event: makeClickEvent(1001, 200, 300),
@@ -675,11 +690,12 @@ describes.realWin(
       );
     });
 
-    it('should not trigger for amp-carousel buttons', () => {
+    it('should not trigger for amp-carousel buttons', async () => {
       const open = env.sandbox.stub(win, 'open');
+      const impl = await element.getImpl();
       const fakeCarouselButton = document.createElement('div');
       fakeCarouselButton.classList.add('amp-carousel-button');
-      element.implementation_.executeAction({
+      impl.executeAction({
         method: 'exit',
         args: {target: 'simple'},
         event: makeClickEvent(1001, 200, 300, fakeCarouselButton),
@@ -688,18 +704,19 @@ describes.realWin(
       expect(open).to.not.have.been.called;
     });
 
-    it('should not trigger for elements matching InactiveElementFilter', () => {
+    it('should not trigger for elements matching InactiveElementFilter', async () => {
       const open = env.sandbox.stub(win, 'open');
+      const impl = await element.getImpl();
       const unclickable = document.createElement('span');
       unclickable.id = 'unclickable';
-      element.implementation_.executeAction({
+      impl.executeAction({
         method: 'exit',
         args: {target: 'inactiveElementTest'},
         event: makeClickEvent(1001, 200, 300, unclickable),
         satisfiesTrust: () => true,
       });
       expect(open).to.not.have.been.called;
-      element.implementation_.executeAction({
+      impl.executeAction({
         method: 'exit',
         args: {target: 'inactiveElementTest'},
         event: makeClickEvent(1001, 200, 300, win.document.body),
@@ -708,10 +725,11 @@ describes.realWin(
       expect(open).to.have.been.called;
     });
 
-    it('should replace custom URL variables with 3P Analytics defaults', () => {
+    it('should replace custom URL variables with 3P Analytics defaults', async () => {
       const open = env.sandbox.stub(win, 'open').returns({name: 'fakeWin'});
+      const impl = await element.getImpl();
 
-      element.implementation_.executeAction({
+      impl.executeAction({
         method: 'exit',
         args: {target: 'variableFrom3pAnalytics'},
         event: makeClickEvent(1004),
@@ -724,17 +742,18 @@ describes.realWin(
       );
     });
 
-    it('should replace custom URL variables with 3P Analytics signals', () => {
+    it('should replace custom URL variables with 3P Analytics signals', async () => {
       const open = env.sandbox.stub(win, 'open').callsFake(() => {
         return {name: 'fakeWin'};
       });
+      const impl = await element.getImpl();
 
-      element.implementation_.vendorResponses_[TEST_3P_VENDOR] = {
+      impl.vendorResponses_[TEST_3P_VENDOR] = {
         'unused': 'unused',
         'collected-data': 'abc123',
       };
 
-      element.implementation_.executeAction({
+      impl.executeAction({
         method: 'exit',
         args: {target: 'variableFrom3pAnalytics'},
         event: makeClickEvent(1005),
@@ -778,11 +797,11 @@ describes.realWin(
       );
     });
 
-    it('should exit to the default target if varible target is never set', () => {
+    it('should exit to the default target if varible target is never set', async () => {
       const open = env.sandbox.stub(win, 'open').callsFake(() => {
         return {name: 'fakeWin'};
       });
-      exitIndirect();
+      await exitIndirect();
       expect(open).to.have.been.calledOnce;
       expect(open).to.have.been.calledWith(
         EXIT_CONFIG.targets.simple.finalUrl,
@@ -790,10 +809,11 @@ describes.realWin(
       );
     });
 
-    it('should cause error when variable target is never set and default value is not provided', () => {
+    it('should cause error when variable target is never set and default value is not provided', async () => {
+      const impl = await element.getImpl();
       try {
         allowConsoleError(() => {
-          element.implementation_.executeAction({
+          impl.executeAction({
             method: 'exit',
             args: {
               variable: 'indirect',
@@ -808,10 +828,15 @@ describes.realWin(
       expect.fail();
     });
 
-    it('should cause error when variable target was pointed to an invalid target', () => {
+    it('should cause error when variable target was pointed to an invalid target', async () => {
+      const impl = await element.getImpl();
       try {
         allowConsoleError(() => {
-          pointTo('not-a-real-target');
+          impl.executeAction({
+            method: 'setVariable',
+            args: {name: 'indirect', target: 'not-a-real-target'},
+            satisfiesTrust: () => true,
+          });
         });
       } catch (expected) {
         return;
@@ -819,10 +844,11 @@ describes.realWin(
       expect.fail();
     });
 
-    it('should cause error when exiting to an invalid variable target', () => {
+    it('should cause error when exiting to an invalid variable target', async () => {
+      const impl = await element.getImpl();
       try {
         allowConsoleError(() => {
-          element.implementation_.executeAction({
+          impl.executeAction({
             method: 'exit',
             args: {variable: 'not-a-real-target', default: 'not-a-real-target'},
             event: makeClickEvent(1001),
@@ -835,10 +861,11 @@ describes.realWin(
       expect.fail();
     });
 
-    it('should cause error when neither "target" nor "variable" is provided in arguments', () => {
+    it('should cause error when neither "target" nor "variable" is provided in arguments', async () => {
+      const impl = await element.getImpl();
       try {
         allowConsoleError(() => {
-          element.implementation_.executeAction({
+          impl.executeAction({
             method: 'exit',
             args: {},
             event: makeClickEvent(1001),
@@ -851,10 +878,11 @@ describes.realWin(
       expect.fail();
     });
 
-    it('should cause error when both "target" and "variable" are provided in arguments', () => {
+    it('should cause error when both "target" and "variable" are provided in arguments', async () => {
+      const impl = await element.getImpl();
       try {
         allowConsoleError(() => {
-          element.implementation_.executeAction({
+          impl.executeAction({
             method: 'exit',
             args: {
               target: 'customVars',
@@ -871,10 +899,11 @@ describes.realWin(
       expect.fail();
     });
 
-    it('should exit to the pointed-to target and work with custom URL variables', () => {
+    it('should exit to the pointed-to target and work with custom URL variables', async () => {
       const open = env.sandbox.stub(win, 'open').callsFake(() => {
         return {name: 'fakeWin'};
       });
+      const impl = await element.getImpl();
       if (!win.navigator) {
         win.navigator = {sendBeacon: () => false};
       }
@@ -882,16 +911,16 @@ describes.realWin(
         .stub(win.navigator, 'sendBeacon')
         .callsFake(() => true);
 
-      pointTo('clickTargetTest');
-      exitIndirect();
+      await pointTo('clickTargetTest');
+      await exitIndirect();
       expect(open).to.have.been.calledOnce;
       expect(open).to.have.been.calledWith(
         EXIT_CONFIG.targets.clickTargetTest.finalUrl,
         '_top'
       );
 
-      pointTo('customVars');
-      element.implementation_.executeAction({
+      await pointTo('customVars');
+      impl.executeAction({
         method: 'exit',
         args: {
           variable: 'indirect',

--- a/extensions/amp-addthis/0.1/test/test-amp-addthis.js
+++ b/extensions/amp-addthis/0.1/test/test-amp-addthis.js
@@ -196,14 +196,13 @@ describes.realWin(
       ).to.not.equal(void 0);
     });
 
-    it('removes the iframe after unlayoutCallback', () => {
-      return getAT({pubId, widgetId}).then(({at}) => {
-        const obj = at.implementation_;
-        testIframe(at.querySelector('iframe'));
-        obj.unlayoutCallback();
-        expect(at.querySelector('iframe')).to.equal(null);
-        expect(obj.iframe_).to.equal(null);
-      });
+    it('removes the iframe after unlayoutCallback', async () => {
+      const {at} = await getAT({pubId, widgetId});
+      const obj = await at.getImpl();
+      testIframe(at.querySelector('iframe'));
+      obj.unlayoutCallback();
+      expect(at.querySelector('iframe')).to.equal(null);
+      expect(obj.iframe_).to.equal(null);
     });
 
     it('registers the frame with the configManager on layout', () => {
@@ -212,13 +211,12 @@ describes.realWin(
       });
     });
 
-    it('unregisters the frame with the configManager on unlayoutCallback', () => {
-      return getAT({pubId, widgetId}).then(({at}) => {
-        const obj = at.implementation_;
-        obj.unlayoutCallback();
+    it('unregisters the frame with the configManager on unlayoutCallback', async () => {
+      const {at} = await getAT({pubId, widgetId});
+      const obj = await at.getImpl();
+      obj.unlayoutCallback();
 
-        expect(unregisterStub.calledOnce).to.equal(true);
-      });
+      expect(unregisterStub.calledOnce).to.equal(true);
     });
 
     it('accepts and stores shareConfig data via custom attributes', () => {
@@ -239,13 +237,12 @@ describes.realWin(
       });
     });
 
-    it("defaults to sharing ownerDocument's title and url", () => {
-      return getAT({pubId, widgetId}).then(({at}) => {
-        const obj = at.implementation_;
-        const {shareConfig_} = obj;
-        expect(shareConfig_.title).to.equal(doc.title);
-        expect(shareConfig_.url).to.equal(doc.location.href);
-      });
+    it("defaults to sharing ownerDocument's title and url", async () => {
+      const {at} = await getAT({pubId, widgetId});
+      const obj = await at.getImpl();
+      const {shareConfig_} = obj;
+      expect(shareConfig_.title).to.equal(doc.title);
+      expect(shareConfig_.url).to.equal(doc.location.href);
     });
 
     it('registers a view at most once per "session"', (done) => {

--- a/extensions/amp-animation/0.1/test/test-amp-animation.js
+++ b/extensions/amp-animation/0.1/test/test-amp-animation.js
@@ -70,7 +70,7 @@ describes.sandboxed('AmpAnimation', {}, (env) => {
     }
 
     win.document.body.appendChild(element);
-    return element.build().then(() => element.implementation_);
+    return element.build().then(() => element.getImpl());
   }
 
   function updateIntersection(target, intersectionRatio) {
@@ -173,8 +173,8 @@ describes.sandboxed('AmpAnimation', {}, (env) => {
         );
       });
 
-      it('should update visibility from viewer', function* () {
-        const anim = yield createAnim({}, {duration: 1001});
+      it('should update visibility from viewer', async () => {
+        const anim = await createAnim({}, {duration: 1001});
         expect(anim.visible_).to.be.false;
 
         viewer.setVisibilityState_('visible');

--- a/extensions/amp-animation/0.1/test/test-web-animations.js
+++ b/extensions/amp-animation/0.1/test/test-web-animations.js
@@ -1064,8 +1064,9 @@ describes.realWin('MeasureScanner', {amp: 1}, (env) => {
     beforeEach(() => {
       animation2Spec = {};
       animation2 = env.createAmpElement('amp-animation');
-      animation2.implementation_.getAnimationSpec = () => animation2Spec;
-      animation2.signals().signal('built');
+      env.sandbox.stub(animation2, 'getImpl').resolves({
+        getAnimationSpec: () => animation2Spec,
+      });
       animation2.id = 'animation2';
       doc.body.appendChild(animation2);
 

--- a/extensions/amp-apester-media/0.1/test/test-amp-apester-media.js
+++ b/extensions/amp-apester-media/0.1/test/test-amp-apester-media.js
@@ -40,7 +40,7 @@ describes.realWin(
       }
     });
 
-    function getApester(attributes, opt_responsive) {
+    async function getApester(attributes, opt_responsive) {
       const media = doc.createElement('amp-apester-media');
       const regularResponse = {
         status: 200,
@@ -81,14 +81,6 @@ describes.realWin(
           ? playlistResponse
           : regularResponse;
 
-      changeSizeSpy = env.sandbox.spy(
-        media.implementation_,
-        'forceChangeHeight'
-      );
-      attemptChangeSizeSpy = env.sandbox.spy(
-        media.implementation_,
-        'attemptChangeHeight'
-      );
       xhrMock = env.sandbox.mock(Services.xhrFor(win));
       if (attributes) {
         xhrMock.expects('fetchJson').returns(
@@ -112,12 +104,14 @@ describes.realWin(
         media.setAttribute('layout', 'responsive');
       }
       doc.body.appendChild(media);
-      return media
-        .build()
-        .then(() => {
-          return media.layoutCallback();
-        })
-        .then(() => media);
+      await media.build();
+
+      const impl = await media.getImpl();
+      changeSizeSpy = env.sandbox.spy(impl, 'forceChangeHeight');
+      attemptChangeSizeSpy = env.sandbox.spy(impl, 'attemptChangeHeight');
+
+      await media.layoutCallback();
+      return media;
     }
 
     it('renders', () => {
@@ -186,21 +180,20 @@ describes.realWin(
       });
     });
 
-    it('removes iframe after unlayoutCallback', () => {
-      return getApester({
+    it('removes iframe after unlayoutCallback', async () => {
+      const ape = await getApester({
         'data-apester-media-id': '5aaa70c79aaf0c5443078d31',
-      }).then((ape) => {
-        const iframe = ape.querySelector('iframe');
-        expect(iframe).to.not.be.null;
-        expect(iframe.src).not.to.be.null;
-        const url = new URL(iframe.src);
-        expect(url.hostname).to.equal('renderer.apester.com');
-        expect(url.pathname).to.equal('/interaction/5aaa70c79aaf0c5443078d31');
-        const tag = ape.implementation_;
-        tag.unlayoutCallback();
-        expect(ape.querySelector('iframe')).to.be.null;
-        expect(tag.iframe_).to.be.null;
       });
+      const tag = await ape.getImpl();
+      const iframe = ape.querySelector('iframe');
+      expect(iframe).to.not.be.null;
+      expect(iframe.src).not.to.be.null;
+      const url = new URL(iframe.src);
+      expect(url.hostname).to.equal('renderer.apester.com');
+      expect(url.pathname).to.equal('/interaction/5aaa70c79aaf0c5443078d31');
+      tag.unlayoutCallback();
+      expect(ape.querySelector('iframe')).to.be.null;
+      expect(tag.iframe_).to.be.null;
     });
 
     it('requires media-id or channel-token', () => {

--- a/extensions/amp-app-banner/0.1/test/test-amp-app-banner.js
+++ b/extensions/amp-app-banner/0.1/test/test-amp-app-banner.js
@@ -69,7 +69,7 @@ describes.realWin(
       }
     }
 
-    function getAppBanner(config = {}) {
+    async function getAppBanner(config = {}) {
       if (config.iosMeta) {
         const meta = doc.createElement('meta');
         meta.setAttribute('name', 'apple-itunes-app');
@@ -106,27 +106,24 @@ describes.realWin(
 
       banner.id = 'banner0';
       doc.body.appendChild(banner);
-      return banner
-        .build()
-        .then(() => banner.layoutCallback())
-        .then(() => banner);
+      await banner.build();
+      await banner.layoutCallback();
+      return banner;
     }
 
-    function testSetupAndShowBanner() {
-      return getAppBanner({iosMeta, androidManifest}).then((banner) => {
-        return banner.implementation_.isDismissed().then(() => {
-          expect(banner.parentElement).to.not.be.null;
-          expect(banner).to.not.have.display('none');
-          const bannerTop = banner.querySelector(
-            'i-amphtml-app-banner-top-padding'
-          );
-          expect(bannerTop).to.exist;
-          const dismissBtn = banner.querySelector(
-            '.amp-app-banner-dismiss-button'
-          );
-          expect(dismissBtn).to.exist;
-        });
-      });
+    async function testSetupAndShowBanner() {
+      const banner = await getAppBanner({iosMeta, androidManifest});
+      const impl = await banner.getImpl();
+      await impl.isDismissed();
+
+      expect(banner.parentElement).to.not.be.null;
+      expect(banner).to.not.have.display('none');
+      const bannerTop = banner.querySelector(
+        'i-amphtml-app-banner-top-padding'
+      );
+      expect(bannerTop).to.exist;
+      const dismissBtn = banner.querySelector('.amp-app-banner-dismiss-button');
+      expect(dismissBtn).to.exist;
     }
 
     function testRemoveBanner(config = {iosMeta, androidManifest}) {
@@ -157,19 +154,18 @@ describes.realWin(
     }
 
     function testSuiteIos() {
-      it('should preconnect to app store', () => {
-        return getAppBanner({iosMeta}).then((banner) => {
-          const preconnect = Services.preconnectFor(win);
-          env.sandbox.stub(preconnect, 'url');
+      it('should preconnect to app store', async () => {
+        const banner = await getAppBanner({iosMeta});
+        const preconnect = Services.preconnectFor(win);
+        env.sandbox.stub(preconnect, 'url');
 
-          const impl = banner.implementation_;
-          impl.preconnectCallback(true);
-          expect(preconnect.url).to.be.calledOnce;
-          expect(preconnect.url).to.have.been.calledWith(
-            env.sandbox.match.object, // AmpDoc
-            'https://itunes.apple.com'
-          );
-        });
+        const impl = await banner.getImpl();
+        impl.preconnectCallback(true);
+        expect(preconnect.url).to.be.calledOnce;
+        expect(preconnect.url).to.have.been.calledWith(
+          env.sandbox.match.object, // AmpDoc
+          'https://itunes.apple.com'
+        );
       });
 
       // TODO(alanorozco, #15844): Unskip.
@@ -242,48 +238,44 @@ describes.realWin(
     }
 
     function testSuiteAndroid() {
-      it('should preconnect to play store and preload manifest', () => {
-        return getAppBanner({androidManifest}).then((banner) => {
-          const preconnect = Services.preconnectFor(win);
-          env.sandbox.stub(preconnect, 'url');
-          env.sandbox.stub(preconnect, 'preload');
+      it('should preconnect to play store and preload manifest', async () => {
+        const banner = await getAppBanner({androidManifest});
+        const preconnect = Services.preconnectFor(win);
+        env.sandbox.stub(preconnect, 'url');
+        env.sandbox.stub(preconnect, 'preload');
 
-          const impl = banner.implementation_;
-          impl.preconnectCallback(true);
-          expect(preconnect.url).to.have.been.calledOnce;
-          expect(preconnect.url).to.have.been.calledWith(
-            env.sandbox.match.object, // AmpDoc
-            'https://play.google.com'
-          );
+        const impl = await banner.getImpl();
+        impl.preconnectCallback(true);
+        expect(preconnect.url).to.have.been.calledOnce;
+        expect(preconnect.url).to.have.been.calledWith(
+          env.sandbox.match.object, // AmpDoc
+          'https://play.google.com'
+        );
 
-          expect(preconnect.preload).to.be.calledOnce;
-          expect(preconnect.preload).to.have.been.calledWith(
-            env.sandbox.match.object, // AmpDoc
-            'https://example.com/manifest.json'
-          );
-        });
+        expect(preconnect.preload).to.be.calledOnce;
+        expect(preconnect.preload).to.have.been.calledWith(
+          env.sandbox.match.object, // AmpDoc
+          'https://example.com/manifest.json'
+        );
       });
 
-      it('should preconnect to play store and preload origin-manifest', () => {
-        return getAppBanner({originManifest: androidManifest}).then(
-          (banner) => {
-            const preconnect = Services.preconnectFor(win);
-            env.sandbox.stub(preconnect, 'url');
-            env.sandbox.stub(preconnect, 'preload');
+      it('should preconnect to play store and preload origin-manifest', async () => {
+        const banner = await getAppBanner({originManifest: androidManifest});
+        const preconnect = Services.preconnectFor(win);
+        env.sandbox.stub(preconnect, 'url');
+        env.sandbox.stub(preconnect, 'preload');
 
-            const impl = banner.implementation_;
-            impl.preconnectCallback(true);
-            expect(preconnect.url).to.have.been.calledOnce;
-            expect(preconnect.url).to.have.been.calledWith(
-              env.sandbox.match.object, // AmpDoc
-              'https://play.google.com'
-            );
-            expect(preconnect.preload).to.be.calledOnce;
-            expect(preconnect.preload).to.have.been.calledWith(
-              env.sandbox.match.object, // AmpDoc
-              'https://example.com/manifest.json'
-            );
-          }
+        const impl = await banner.getImpl();
+        impl.preconnectCallback(true);
+        expect(preconnect.url).to.have.been.calledOnce;
+        expect(preconnect.url).to.have.been.calledWith(
+          env.sandbox.match.object, // AmpDoc
+          'https://play.google.com'
+        );
+        expect(preconnect.preload).to.be.calledOnce;
+        expect(preconnect.preload).to.have.been.calledWith(
+          env.sandbox.match.object, // AmpDoc
+          'https://example.com/manifest.json'
         );
       });
 
@@ -363,26 +355,26 @@ describes.realWin(
     });
 
     describe('Choosing platform', () => {
-      it('should upgrade to AmpIosAppBanner on iOS', () => {
+      it('should upgrade to AmpIosAppBanner on iOS', async () => {
         isIos = true;
-        return getAppBanner({iosMeta, androidManifest}).then((banner) => {
-          expect(banner.implementation_).to.be.instanceof(AmpIosAppBanner);
-        });
+        const banner = await getAppBanner({iosMeta, androidManifest});
+        const impl = await banner.getImpl();
+        expect(impl).to.be.instanceof(AmpIosAppBanner);
       });
 
-      it('should upgrade to AmpAndroidAppBanner on Android', () => {
+      it('should upgrade to AmpAndroidAppBanner on Android', async () => {
         isAndroid = true;
-        return getAppBanner({iosMeta, androidManifest}).then((banner) => {
-          expect(banner.implementation_).to.be.instanceof(AmpAndroidAppBanner);
-        });
+        const banner = await getAppBanner({iosMeta, androidManifest});
+        const impl = await banner.getImpl();
+        expect(impl).to.be.instanceof(AmpAndroidAppBanner);
       });
 
-      it('should not upgrade if platform not supported', () => {
+      it('should not upgrade if platform not supported', async () => {
         isEdge = true;
-        return getAppBanner({iosMeta, androidManifest}).then((banner) => {
-          expect(banner.implementation_).to.be.instanceof(AmpAppBanner);
-          expect(banner.implementation_.upgradeCallback()).to.be.null;
-        });
+        const banner = await getAppBanner({iosMeta, androidManifest});
+        const impl = await banner.getImpl();
+        expect(impl).to.be.instanceof(AmpAppBanner);
+        expect(impl.upgradeCallback()).to.be.null;
       });
     });
 

--- a/extensions/amp-audio/0.1/test/test-amp-audio.js
+++ b/extensions/amp-audio/0.1/test/test-amp-audio.js
@@ -135,22 +135,22 @@ describes.realWin(
     it(
       'should attach `<audio>` element and execute relevant actions for ' +
         'layout="nodisplay"',
-      () => {
-        return attachAndRun({
+      async () => {
+        const ampAudio = await attachAndRun({
           src: 'audio.mp3',
           preload: 'none',
           layout: 'nodisplay',
-        }).then((ampAudio) => {
-          const audio = ampAudio.querySelector('audio');
-          expect(audio).to.not.be.null;
-
-          const impl = ampAudio.implementation_;
-          impl.executeAction({method: 'play', satisfiesTrust: () => true});
-          expect(impl.isPlaying).to.be.true;
-
-          impl.executeAction({method: 'pause', satisfiesTrust: () => true});
-          expect(impl.isPlaying).to.be.false;
         });
+        const impl = await ampAudio.getImpl();
+
+        const audio = ampAudio.querySelector('audio');
+        expect(audio).to.not.be.null;
+
+        impl.executeAction({method: 'play', satisfiesTrust: () => true});
+        expect(impl.isPlaying).to.be.true;
+
+        impl.executeAction({method: 'pause', satisfiesTrust: () => true});
+        expect(impl.isPlaying).to.be.false;
       }
     );
 
@@ -251,35 +251,35 @@ describes.realWin(
       });
     });
 
-    it('should play/pause when `play`/`pause` actions are called', () => {
-      return attachAndRun({
+    it('should play/pause when `play`/`pause` actions are called', async () => {
+      const ampAudio = await attachAndRun({
         'width': '500',
         src: 'audio.mp3',
-      }).then((ampAudio) => {
-        const impl = ampAudio.implementation_;
-        impl.executeAction({method: 'play', satisfiesTrust: () => true});
-        expect(impl.isPlaying).to.be.true;
-
-        impl.executeAction({method: 'pause', satisfiesTrust: () => true});
-        expect(impl.isPlaying).to.be.false;
       });
+      const impl = await ampAudio.getImpl();
+
+      impl.executeAction({method: 'play', satisfiesTrust: () => true});
+      expect(impl.isPlaying).to.be.true;
+
+      impl.executeAction({method: 'pause', satisfiesTrust: () => true});
+      expect(impl.isPlaying).to.be.false;
     });
 
     it(
       'should not play/pause when `amp-audio` is a direct descendant ' +
         'of `amp-story`',
-      () => {
-        return attachToAmpStoryAndRun({
+      async () => {
+        const ampAudio = await attachToAmpStoryAndRun({
           'width': '500',
           src: 'audio.mp3',
-        }).then((ampAudio) => {
-          const impl = ampAudio.implementation_;
-          impl.executeAction({method: 'play', satisfiesTrust: () => true});
-          expect(impl.isPlaying).to.be.false;
-
-          impl.executeAction({method: 'pause', satisfiesTrust: () => true});
-          expect(impl.isPlaying).to.be.false;
         });
+        const impl = await ampAudio.getImpl();
+
+        impl.executeAction({method: 'play', satisfiesTrust: () => true});
+        expect(impl.isPlaying).to.be.false;
+
+        impl.executeAction({method: 'pause', satisfiesTrust: () => true});
+        expect(impl.isPlaying).to.be.false;
       }
     );
   }

--- a/extensions/amp-autocomplete/0.1/test/test-amp-autocomplete-init.js
+++ b/extensions/amp-autocomplete/0.1/test/test-amp-autocomplete-init.js
@@ -77,103 +77,93 @@ describes.realWin(
       return ampAutocomplete.build().then(() => ampAutocomplete);
     }
 
-    it('should build with "inline" and "query" when specified', () => {
-      return getAutocomplete({
+    it('should build with "inline" and "query" when specified', async () => {
+      const ampAutocomplete = await getAutocomplete({
         'filter': 'substring',
         'query': 'q',
-      }).then((ampAutocomplete) => {
-        const impl = ampAutocomplete.implementation_;
-        expect(impl.queryKey_).to.equal('q');
       });
+      const impl = await ampAutocomplete.getImpl();
+      expect(impl.queryKey_).to.equal('q');
     });
 
-    it('should layout', () => {
-      let impl, autocompleteSpy, clearAllSpy, filterSpy, renderSpy;
-      return getAutocomplete({
+    it('should layout', async () => {
+      const ampAutocomplete = await getAutocomplete({
         'filter': 'substring',
-      })
-        .then((ampAutocomplete) => {
-          impl = ampAutocomplete.implementation_;
-          const expectedItems = ['apple', 'banana', 'orange'];
-          expect(impl.sourceData_).to.have.ordered.members(expectedItems);
-          expect(impl.inputElement_).not.to.be.null;
-          expect(impl.container_).not.to.be.null;
-          expect(impl.filter_).to.equal('substring');
-          autocompleteSpy = env.sandbox.spy(impl, 'autocomplete_');
-          clearAllSpy = env.sandbox.spy(impl, 'clearAllItems_');
-          filterSpy = env.sandbox.spy(impl, 'filterData_');
-          renderSpy = env.sandbox.spy(impl, 'renderResults_');
-          return ampAutocomplete.layoutCallback();
-        })
-        .then(() => {
-          expect(impl.inputElement_.hasAttribute('autocomplete')).to.be.true;
-          expect(autocompleteSpy).to.have.been.calledOnce;
-          expect(clearAllSpy).to.have.been.calledOnce;
-          expect(filterSpy).not.to.have.been.called;
-          expect(renderSpy).not.to.have.been.called;
-        });
+      });
+      const impl = await ampAutocomplete.getImpl();
+
+      const expectedItems = ['apple', 'banana', 'orange'];
+      expect(impl.sourceData_).to.have.ordered.members(expectedItems);
+      expect(impl.inputElement_).not.to.be.null;
+      expect(impl.container_).not.to.be.null;
+      expect(impl.filter_).to.equal('substring');
+      const autocompleteSpy = env.sandbox.spy(impl, 'autocomplete_');
+      const clearAllSpy = env.sandbox.spy(impl, 'clearAllItems_');
+      const filterSpy = env.sandbox.spy(impl, 'filterData_');
+      const renderSpy = env.sandbox.spy(impl, 'renderResults_');
+
+      await ampAutocomplete.layoutCallback();
+      expect(impl.inputElement_.hasAttribute('autocomplete')).to.be.true;
+      expect(autocompleteSpy).to.have.been.calledOnce;
+      expect(clearAllSpy).to.have.been.calledOnce;
+      expect(filterSpy).not.to.have.been.called;
+      expect(renderSpy).not.to.have.been.called;
     });
 
-    it('should render inline data before first user interaction', () => {
-      let impl, filterAndRenderSpy, clearAllSpy, filterSpy, renderSpy;
-      return getAutocomplete({
+    it('should render inline data before first user interaction', async () => {
+      const ampAutocomplete = await getAutocomplete({
         'filter': 'substring',
         'min-characters': '0',
-      })
-        .then((ampAutocomplete) => {
-          impl = ampAutocomplete.implementation_;
-          const expectedItems = ['apple', 'banana', 'orange'];
-          expect(impl.sourceData_).to.have.ordered.members(expectedItems);
-          expect(impl.inputElement_).not.to.be.null;
-          expect(impl.container_).not.to.be.null;
-          expect(impl.filter_).to.equal('substring');
-          filterAndRenderSpy = env.sandbox.spy(
-            impl,
-            'filterDataAndRenderResults_'
-          );
-          clearAllSpy = env.sandbox.spy(impl, 'clearAllItems_');
-          filterSpy = env.sandbox.spy(impl, 'filterData_');
-          renderSpy = env.sandbox.spy(impl, 'renderResults_');
-          return ampAutocomplete.layoutCallback();
-        })
-        .then(() => {
-          expect(impl.inputElement_.hasAttribute('autocomplete')).to.be.true;
-          expect(filterAndRenderSpy).to.have.been.calledOnce;
-          expect(clearAllSpy).to.have.been.calledOnce;
-          expect(filterSpy).to.have.been.called;
-          expect(renderSpy).to.have.been.called;
-        });
+      });
+      const impl = await ampAutocomplete.getImpl();
+
+      const expectedItems = ['apple', 'banana', 'orange'];
+      expect(impl.sourceData_).to.have.ordered.members(expectedItems);
+      expect(impl.inputElement_).not.to.be.null;
+      expect(impl.container_).not.to.be.null;
+      expect(impl.filter_).to.equal('substring');
+      const filterAndRenderSpy = env.sandbox.spy(
+        impl,
+        'filterDataAndRenderResults_'
+      );
+      const clearAllSpy = env.sandbox.spy(impl, 'clearAllItems_');
+      const filterSpy = env.sandbox.spy(impl, 'filterData_');
+      const renderSpy = env.sandbox.spy(impl, 'renderResults_');
+
+      await ampAutocomplete.layoutCallback();
+      expect(impl.inputElement_.hasAttribute('autocomplete')).to.be.true;
+      expect(filterAndRenderSpy).to.have.been.calledOnce;
+      expect(clearAllSpy).to.have.been.calledOnce;
+      expect(filterSpy).to.have.been.called;
+      expect(renderSpy).to.have.been.called;
     });
 
-    it('should not render remote data before first user interaction', () => {
-      let impl, autocompleteSpy, clearAllSpy, filterSpy, renderSpy;
-      return getAutocomplete(
+    it('should not render remote data before first user interaction', async () => {
+      const ampAutocomplete = await getAutocomplete(
         {
           'filter': 'substring',
           'min-characters': '0',
         },
         '{ "items" : ["apple", "banana", "orange"] }',
         false
-      )
-        .then((ampAutocomplete) => {
-          impl = ampAutocomplete.implementation_;
-          expect(impl.sourceData_).to.be.null;
-          expect(impl.inputElement_).not.to.be.null;
-          expect(impl.container_).not.to.be.null;
-          expect(impl.filter_).to.equal('substring');
-          autocompleteSpy = env.sandbox.spy(impl, 'autocomplete_');
-          clearAllSpy = env.sandbox.spy(impl, 'clearAllItems_');
-          filterSpy = env.sandbox.spy(impl, 'filterData_');
-          renderSpy = env.sandbox.spy(impl, 'renderResults_');
-          return ampAutocomplete.layoutCallback();
-        })
-        .then(() => {
-          expect(impl.inputElement_.hasAttribute('autocomplete')).to.be.true;
-          expect(autocompleteSpy).to.have.been.calledOnce;
-          expect(clearAllSpy).to.have.been.calledOnce;
-          expect(filterSpy).not.to.have.been.called;
-          expect(renderSpy).not.to.have.been.called;
-        });
+      );
+      const impl = await ampAutocomplete.getImpl();
+
+      expect(impl.sourceData_).to.be.null;
+      expect(impl.inputElement_).not.to.be.null;
+      expect(impl.container_).not.to.be.null;
+      expect(impl.filter_).to.equal('substring');
+      const autocompleteSpy = env.sandbox.spy(impl, 'autocomplete_');
+      const clearAllSpy = env.sandbox.spy(impl, 'clearAllItems_');
+      const filterSpy = env.sandbox.spy(impl, 'filterData_');
+      const renderSpy = env.sandbox.spy(impl, 'renderResults_');
+
+      await ampAutocomplete.layoutCallback();
+      expect(impl.inputElement_.hasAttribute('autocomplete')).to.be.true;
+      expect(autocompleteSpy).to.have.been.calledOnce;
+      expect(clearAllSpy).to.have.been.calledOnce;
+      expect(filterSpy).not.to.have.been.called;
+      expect(renderSpy).not.to.have.been.called;
     });
 
     it('should require valid filter attribute', () => {
@@ -186,31 +176,31 @@ describes.realWin(
       });
     });
 
-    it('should render with min-characters passed', () => {
-      return getAutocomplete({
+    it('should render with min-characters passed', async () => {
+      const ampAutocomplete = await getAutocomplete({
         'filter': 'substring',
         'min-characters': '3',
-      }).then((ampAutocomplete) => {
-        expect(ampAutocomplete.implementation_.minChars_).to.equal(3);
       });
+      const impl = await ampAutocomplete.getImpl();
+      expect(impl.minChars_).to.equal(3);
     });
 
-    it('should render with max-entries passed', () => {
-      return getAutocomplete({
+    it('should render with max-entries passed', async () => {
+      const ampAutocomplete = await getAutocomplete({
         'filter': 'substring',
         'max-entries': '10',
-      }).then((ampAutocomplete) => {
-        expect(ampAutocomplete.implementation_.maxItems_).to.equal(10);
       });
+      const impl = await ampAutocomplete.getImpl();
+      expect(impl.maxItems_).to.equal(10);
     });
 
-    it('should render with max-items passed', () => {
-      return getAutocomplete({
+    it('should render with max-items passed', async () => {
+      const ampAutocomplete = await getAutocomplete({
         'filter': 'substring',
         'max-items': '10',
-      }).then((ampAutocomplete) => {
-        expect(ampAutocomplete.implementation_.maxItems_).to.equal(10);
       });
+      const impl = await ampAutocomplete.getImpl();
+      expect(impl.maxItems_).to.equal(10);
     });
     it('should error with invalid JSON script', () => {
       expectAsyncConsoleError(
@@ -226,48 +216,45 @@ describes.realWin(
       ).to.be.rejectedWith('Unexpected token o in JSON at position 32');
     });
 
-    it('should accept empty JSON script', () => {
-      return getAutocomplete(
+    it('should accept empty JSON script', async () => {
+      const ampAutocomplete = await getAutocomplete(
         {
           'filter': 'substring',
         },
         '{}'
-      ).then((ampAutocomplete) => {
-        const impl = ampAutocomplete.implementation_;
-        expect(impl.sourceData_).to.be.an('array').that.is.empty;
-      });
+      );
+      const impl = await ampAutocomplete.getImpl();
+      expect(impl.sourceData_).to.be.an('array').that.is.empty;
     });
 
-    it('should accept empty items JSON script', () => {
-      return getAutocomplete(
+    it('should accept empty items JSON script', async () => {
+      const ampAutocomplete = await getAutocomplete(
         {
           'filter': 'substring',
         },
         '{ "items" : [] }'
-      ).then((ampAutocomplete) => {
-        const impl = ampAutocomplete.implementation_;
-        expect(impl.sourceData_).to.be.an('array').that.is.empty;
-      });
+      );
+      const impl = await ampAutocomplete.getImpl();
+      expect(impl.sourceData_).to.be.an('array').that.is.empty;
     });
 
-    it('should accept different item property from JSON script', () => {
-      return getAutocomplete(
+    it('should accept different item property from JSON script', async () => {
+      const ampAutocomplete = await getAutocomplete(
         {
           'filter': 'substring',
           'items': 'fruit',
         },
         '{ "fruit" : [ "apples", "bananas", "pears" ] }'
-      ).then((ampAutocomplete) => {
-        const impl = ampAutocomplete.implementation_;
-        expect(impl.sourceData_).to.have.ordered.members([
-          'apples',
-          'bananas',
-          'pears',
-        ]);
-      });
+      );
+      const impl = await ampAutocomplete.getImpl();
+      expect(impl.sourceData_).to.have.ordered.members([
+        'apples',
+        'bananas',
+        'pears',
+      ]);
     });
 
-    it('should not fetch remote data when specified in src before first user interaction', () => {
+    it('should not fetch remote data when specified in src before first user interaction', async () => {
       const data = {
         items: [
           'Albany, New York',
@@ -277,22 +264,19 @@ describes.realWin(
           'Austin, Texas',
         ],
       };
-      return getAutocomplete(
+      const ampAutocomplete = await getAutocomplete(
         {
           'filter': 'substring',
           'src': 'https://examples.com/json',
         },
         data,
         false
-      ).then((ampAutocomplete) => {
-        ampAutocomplete.layoutCallback().then(() => {
-          const impl = ampAutocomplete.implementation_;
-          expect(impl.sourceData_).to.be.null;
-        });
-      });
+      );
+      const impl = await ampAutocomplete.getImpl();
+      expect(impl.sourceData_).to.be.null;
     });
 
-    it('should not fetch remote data when specified in src and using items property before first user interaction', () => {
+    it('should not fetch remote data when specified in src and using items property before first user interaction', async () => {
       const data = {
         cities: [
           'Albany, New York',
@@ -302,7 +286,7 @@ describes.realWin(
           'Austin, Texas',
         ],
       };
-      return getAutocomplete(
+      const ampAutocomplete = await getAutocomplete(
         {
           'filter': 'substring',
           'src': 'https://examples.com/json',
@@ -310,17 +294,13 @@ describes.realWin(
         },
         data,
         false
-      ).then((ampAutocomplete) => {
-        ampAutocomplete.layoutCallback().then(() => {
-          const impl = ampAutocomplete.implementation_;
-          expect(impl.sourceData_).to.be.null;
-        });
-      });
+      );
+      const impl = await ampAutocomplete.getImpl();
+      expect(impl.sourceData_).to.be.null;
     });
 
-    it('should prefetch remote data if prefetch attribute is specified', () => {
-      let impl;
-      return getAutocomplete(
+    it('should prefetch remote data if prefetch attribute is specified', async () => {
+      const ampAutocomplete = await getAutocomplete(
         {
           'prefetch': '', // boolean attribute, presence means prefetch is enabled.
           'src': 'https://examples.com/json',
@@ -328,18 +308,15 @@ describes.realWin(
         },
         '{}',
         false
-      )
-        .then((ampAutocomplete) => {
-          impl = ampAutocomplete.implementation_;
-          expect(impl.hasFetchedInitialData_).to.be.false;
-          return ampAutocomplete.layoutCallback();
-        })
-        .then(() => {
-          expect(impl.hasFetchedInitialData_).to.be.true;
-        });
+      );
+      const impl = await ampAutocomplete.getImpl();
+      expect(impl.hasFetchedInitialData_).to.be.false;
+
+      await ampAutocomplete.layoutCallback();
+      expect(impl.hasFetchedInitialData_).to.be.true;
     });
 
-    it('should not fetch remote data when specified in src and using nested items property before first user interactino', () => {
+    it('should not fetch remote data when specified in src and using nested items property before first user interactino', async () => {
       const data = {
         deeply: {
           nested: {
@@ -353,7 +330,7 @@ describes.realWin(
           },
         },
       };
-      return getAutocomplete(
+      const ampAutocomplete = await getAutocomplete(
         {
           'filter': 'substring',
           'src': 'https://examples.com/json',
@@ -361,12 +338,10 @@ describes.realWin(
         },
         data,
         false
-      ).then((ampAutocomplete) => {
-        ampAutocomplete.layoutCallback().then(() => {
-          const impl = ampAutocomplete.implementation_;
-          expect(impl.sourceData_).be.null;
-        });
-      });
+      );
+      const impl = await ampAutocomplete.getImpl();
+      await ampAutocomplete.layoutCallback();
+      expect(impl.sourceData_).be.null;
     });
 
     it('should not require a form ancestor', () => {
@@ -375,31 +350,32 @@ describes.realWin(
       return expect(autocomplete.build()).to.be.fulfilled;
     });
 
-    it('should read the autocomplete attribute on the form as null', () => {
-      return getAutocomplete({'filter': 'substring'}).then(
-        (ampAutocomplete) => {
-          const impl = ampAutocomplete.implementation_;
-          expect(impl.initialAutocompleteAttr_).to.be.null;
-        }
-      );
+    it('should read the autocomplete attribute on the form as null', async () => {
+      const ampAutocomplete = await getAutocomplete({'filter': 'substring'});
+      const impl = await ampAutocomplete.getImpl();
+      expect(impl.initialAutocompleteAttr_).to.be.null;
     });
 
-    it('should read the autocomplete attribute on the form as on', () => {
-      return getAutocomplete({'filter': 'substring'}, '{}', true, 'on').then(
-        (ampAutocomplete) => {
-          const impl = ampAutocomplete.implementation_;
-          expect(impl.initialAutocompleteAttr_).to.equal('on');
-        }
+    it('should read the autocomplete attribute on the form as on', async () => {
+      const ampAutocomplete = await getAutocomplete(
+        {'filter': 'substring'},
+        '{}',
+        true,
+        'on'
       );
+      const impl = await ampAutocomplete.getImpl();
+      expect(impl.initialAutocompleteAttr_).to.equal('on');
     });
 
-    it('should read the autocomplete attribute on the form as off', () => {
-      return getAutocomplete({'filter': 'substring'}, '{}', true, 'off').then(
-        (ampAutocomplete) => {
-          const impl = ampAutocomplete.implementation_;
-          expect(impl.initialAutocompleteAttr_).to.equal('off');
-        }
+    it('should read the autocomplete attribute on the form as off', async () => {
+      const ampAutocomplete = await getAutocomplete(
+        {'filter': 'substring'},
+        '{}',
+        true,
+        'off'
       );
+      const impl = await ampAutocomplete.getImpl();
+      expect(impl.initialAutocompleteAttr_).to.equal('off');
     });
   }
 );

--- a/extensions/amp-beopinion/0.1/test/test-amp-beopinion.js
+++ b/extensions/amp-beopinion/0.1/test/test-amp-beopinion.js
@@ -77,16 +77,16 @@ describes.realWin(
       expect(content).not.to.be.undefined;
     });
 
-    it('removes iframe after unlayoutCallback', () => {
-      return getAmpBeOpinion(accountId).then((ampBeOpinion) => {
-        const iframe = ampBeOpinion.querySelector('iframe');
-        expect(iframe).to.not.be.null;
-        const obj = ampBeOpinion.implementation_;
-        obj.unlayoutCallback();
-        expect(ampBeOpinion.querySelector('iframe')).to.be.null;
-        expect(obj.iframe_).to.be.null;
-        expect(obj.unlayoutOnPause()).to.be.true;
-      });
+    it('removes iframe after unlayoutCallback', async () => {
+      const ampBeOpinion = await getAmpBeOpinion(accountId);
+      const obj = await ampBeOpinion.getImpl();
+
+      const iframe = ampBeOpinion.querySelector('iframe');
+      expect(iframe).to.not.be.null;
+      obj.unlayoutCallback();
+      expect(ampBeOpinion.querySelector('iframe')).to.be.null;
+      expect(obj.iframe_).to.be.null;
+      expect(obj.unlayoutOnPause()).to.be.true;
     });
   }
 );

--- a/extensions/amp-bind/0.1/test/test-amp-state.js
+++ b/extensions/amp-bind/0.1/test/test-amp-state.js
@@ -47,7 +47,7 @@ describes.realWin(
       return el;
     }
 
-    beforeEach(() => {
+    beforeEach(async () => {
       ({win, ampdoc} = env);
 
       whenFirstVisiblePromise = new Promise((resolve, reject) => {
@@ -60,7 +60,7 @@ describes.realWin(
       env.sandbox.stub(ampdoc, 'hasBeenVisible').returns(false);
 
       element = getAmpState();
-      ampState = element.implementation_;
+      ampState = await element.getImpl(false);
 
       // TODO(choumx): Remove stubbing of private function fetch_() once
       // batchFetchJsonFor() is easily stub-able.

--- a/extensions/amp-brid-player/0.1/test/test-amp-brid-player.js
+++ b/extensions/amp-brid-player/0.1/test/test-amp-brid-player.js
@@ -49,15 +49,18 @@ describes.realWin(
       }
 
       // see yt test implementation
-      timer.promise(50).then(() => {
-        const bridTimerIframe = bc.querySelector('iframe');
+      timer
+        .promise(50)
+        .then(() => bc.getImpl())
+        .then((impl) => {
+          const bridTimerIframe = bc.querySelector('iframe');
 
-        bc.implementation_.handleBridMessage_({
-          origin: 'https://services.brid.tv',
-          source: bridTimerIframe.contentWindow,
-          data: 'Brid|0|trigger|ready',
+          impl.handleBridMessage_({
+            origin: 'https://services.brid.tv',
+            source: bridTimerIframe.contentWindow,
+            data: 'Brid|0|trigger|ready',
+          });
         });
-      });
       doc.body.appendChild(bc);
       return bc
         .build()
@@ -119,43 +122,43 @@ describes.realWin(
       });
     });
 
-    it('should forward events from brid-player to the amp element', () => {
-      return getBridPlayer(
+    it('should forward events from brid-player to the amp element', async () => {
+      const bc = await getBridPlayer(
         {
           'data-partner': '1177',
           'data-player': '979',
           'data-video': '5204',
         },
         true
-      ).then((bc) => {
-        const iframe = bc.querySelector('iframe');
+      );
+      const impl = await bc.getImpl();
 
-        return Promise.resolve()
-          .then(() => {
-            const p = listenOncePromise(bc, VideoEvents.PLAYING);
-            sendFakeMessage(bc, iframe, 'trigger|play');
-            return p;
-          })
-          .then(() => {
-            const p = listenOncePromise(bc, VideoEvents.MUTED);
-            sendFakeMessage(bc, iframe, 'volume|0');
-            return p;
-          })
-          .then(() => {
-            const p = listenOncePromise(bc, VideoEvents.PAUSE);
-            sendFakeMessage(bc, iframe, 'trigger|pause');
-            return p;
-          })
-          .then(() => {
-            const p = listenOncePromise(bc, VideoEvents.UNMUTED);
-            sendFakeMessage(bc, iframe, 'volume|1');
-            return p;
-          });
-      });
+      const iframe = bc.querySelector('iframe');
+      return Promise.resolve()
+        .then(() => {
+          const p = listenOncePromise(bc, VideoEvents.PLAYING);
+          sendFakeMessage(impl, iframe, 'trigger|play');
+          return p;
+        })
+        .then(() => {
+          const p = listenOncePromise(bc, VideoEvents.MUTED);
+          sendFakeMessage(impl, iframe, 'volume|0');
+          return p;
+        })
+        .then(() => {
+          const p = listenOncePromise(bc, VideoEvents.PAUSE);
+          sendFakeMessage(impl, iframe, 'trigger|pause');
+          return p;
+        })
+        .then(() => {
+          const p = listenOncePromise(bc, VideoEvents.UNMUTED);
+          sendFakeMessage(impl, iframe, 'volume|1');
+          return p;
+        });
     });
 
-    function sendFakeMessage(bc, iframe, command) {
-      bc.implementation_.handleBridMessage_({
+    function sendFakeMessage(impl, iframe, command) {
+      impl.handleBridMessage_({
         origin: 'https://services.brid.tv',
         source: iframe.contentWindow,
         data: 'Brid|0|' + command,

--- a/extensions/amp-byside-content/0.1/test/test-amp-byside-content.js
+++ b/extensions/amp-byside-content/0.1/test/test-amp-byside-content.js
@@ -52,9 +52,10 @@ describes.realWin(
       doc.body.appendChild(elem);
       return elem
         .build()
-        .then(() => {
+        .then(() => elem.getImpl())
+        .then((impl) => {
           urlMock.expandUrlAsync
-            .returns(Promise.resolve(elem.implementation_.baseUrl_))
+            .returns(Promise.resolve(impl.baseUrl_))
             .withArgs(env.sandbox.match.any);
           if (opt_beforeLayoutCallback) {
             opt_beforeLayoutCallback(elem);
@@ -65,23 +66,23 @@ describes.realWin(
         .then(() => elem);
     }
 
-    function testIframe(elem) {
+    function testIframe(elem, impl) {
       const iframe = elem.querySelector('iframe');
       expect(iframe).to.not.be.null;
       expect(iframe.getAttribute('frameborder')).to.equal('0');
       expect(iframe.className).to.match(/i-amphtml-fill-content/);
       expect(iframe.fakeSrc).to.satisfy((src) => {
-        return src.startsWith(elem.implementation_.baseUrl_);
+        return src.startsWith(impl.baseUrl_);
       });
     }
 
-    it('renders', () => {
-      return getElement({
+    it('renders', async () => {
+      const elem = await getElement({
         'data-webcare-id': 'D6604AE5D0',
         'data-label': 'amp-simple',
-      }).then((elem) => {
-        testIframe(elem);
       });
+      const impl = await elem.getImpl();
+      testIframe(elem, impl);
     });
 
     it('requires data-label', () => {
@@ -104,29 +105,25 @@ describes.realWin(
       });
     });
 
-    it('generates correct default origin', () => {
-      return getElement({
+    it('generates correct default origin', async () => {
+      const elem = await getElement({
         'data-webcare-id': 'D6604AE5D0',
         'data-label': 'placeholder-label',
-      }).then((elem) => {
-        expect(elem.implementation_.origin_).to.equal(
-          'https://webcare.byside.com'
-        );
       });
+      const impl = await elem.getImpl();
+      expect(impl.origin_).to.equal('https://webcare.byside.com');
     });
 
-    it('generates correct provided webcare zone', () => {
+    it('generates correct provided webcare zone', async () => {
       const webcareZone = 'sa1';
 
-      return getElement({
+      const elem = await getElement({
         'data-webcare-id': 'D6604AE5D0',
         'data-label': 'placeholder-label',
         'data-webcare-zone': webcareZone,
-      }).then((elem) => {
-        expect(elem.implementation_.origin_).to.equal(
-          'https://' + webcareZone + '.byside.com'
-        );
       });
+      const impl = await elem.getImpl();
+      expect(impl.origin_).to.equal('https://' + webcareZone + '.byside.com');
     });
 
     it('should create a loading animation', () => {
@@ -141,33 +138,31 @@ describes.realWin(
       });
     });
 
-    it('builds a placeholder loading animation without inserting iframe', () => {
+    it('builds a placeholder loading animation without inserting iframe', async () => {
       const attributes = {
         'data-webcare-id': 'D6604AE5D0',
         'data-label': 'placeholder-label',
       };
 
-      return getElement(attributes, true, (elem) => {
+      const elem = await getElement(attributes, true, (elem) => {
         const placeholder = elem.querySelector('[placeholder]');
         const iframe = elem.querySelector('iframe');
         expect(iframe).to.be.null;
         expect(placeholder).to.not.have.display('none');
-      }).then((elem) => {
-        const placeholder = elem.querySelector('[placeholder]');
-        elem.getVsync = () => {
-          return {
-            mutate: (fn) => fn(),
-          };
-        };
-
-        // test iframe
-        testIframe(elem);
-
-        // test placeholder too
-        elem.implementation_.iframePromise_.then(() => {
-          expect(placeholder).to.have.display('none');
-        });
       });
+      const impl = await elem.getImpl();
+
+      elem.getVsync = () => {
+        return {
+          mutate: (fn) => fn(),
+        };
+      };
+
+      // test iframe
+      testIframe(elem, impl);
+
+      // test placeholder too
+      await impl.iframePromise_;
     });
 
     it('passes down sandbox attribute to iframe', () => {

--- a/extensions/amp-carousel/0.1/test/test-scrollable-carousel.js
+++ b/extensions/amp-carousel/0.1/test/test-scrollable-carousel.js
@@ -90,167 +90,158 @@ describes.realWin(
     it(
       'should initialize correctly: create container, build initial slides ' +
         'and show control buttons',
-      () => {
-        return getAmpScrollableCarousel().then((carousel) => {
-          const impl = carousel.implementation_;
+      async () => {
+        const carousel = await getAmpScrollableCarousel();
+        const impl = await carousel.getImpl();
 
-          // create container
-          expect(
-            carousel.getElementsByClassName(
-              'i-amphtml-scrollable-carousel-container'
-            ).length
-          ).to.equal(1);
-          const container = carousel.getElementsByClassName(
+        // create container
+        expect(
+          carousel.getElementsByClassName(
             'i-amphtml-scrollable-carousel-container'
-          )[0];
-          const containerStyle = win.getComputedStyle(container, null);
-
-          expect(containerStyle.getPropertyValue('overflow-x')).to.equal(
-            'auto'
-          );
-          expect(containerStyle.getPropertyValue('overflow-y')).to.equal(
-            'hidden'
-          );
-          expect(containerStyle.getPropertyValue('white-space')).to.equal(
-            'nowrap'
-          );
-
-          // build child slides
-          const carouselSlideEls = container.getElementsByClassName(
-            'amp-carousel-slide'
-          );
-          expect(carouselSlideEls.length).to.equal(7);
-          expect(carouselSlideEls[0]).to.have.display('inline-block');
-
-          // show control buttons correctly
-          expect(impl.hasPrev()).to.be.false;
-          expect(impl.hasNext()).to.be.true;
-          expect(impl.prevButton_.classList.contains('amp-disabled')).to.be
-            .true;
-          expect(impl.nextButton_.classList.contains('amp-disabled')).to.be
-            .false;
-          // Controls are hidden from screen readers as they do not provide
-          // any functionality for scrollable carousel.
-          // ATs see this is a scrolling div and can scroll it as user navigates
-          // items just fine (unlike type=slide which requires next/prev)
-          expect(impl.nextButton_.getAttribute('role')).equal('presentation');
-          expect(impl.prevButton_.getAttribute('role')).equal('presentation');
-        });
-      }
-    );
-
-    it('should properly style controls; focusable but not visible', () => {
-      return getAmpScrollableCarousel().then((carousel) => {
-        const impl = carousel.implementation_;
+          ).length
+        ).to.equal(1);
         const container = carousel.getElementsByClassName(
           'i-amphtml-scrollable-carousel-container'
         )[0];
+        const containerStyle = win.getComputedStyle(container, null);
+
+        expect(containerStyle.getPropertyValue('overflow-x')).to.equal('auto');
+        expect(containerStyle.getPropertyValue('overflow-y')).to.equal(
+          'hidden'
+        );
+        expect(containerStyle.getPropertyValue('white-space')).to.equal(
+          'nowrap'
+        );
+
+        // build child slides
         const carouselSlideEls = container.getElementsByClassName(
           'amp-carousel-slide'
         );
+        expect(carouselSlideEls.length).to.equal(7);
+        expect(carouselSlideEls[0]).to.have.display('inline-block');
 
         // show control buttons correctly
+        expect(impl.hasPrev()).to.be.false;
+        expect(impl.hasNext()).to.be.true;
         expect(impl.prevButton_.classList.contains('amp-disabled')).to.be.true;
         expect(impl.nextButton_.classList.contains('amp-disabled')).to.be.false;
-        // Explicitly check if buttons don't have visibility hidden or display none
-        expect(impl.prevButton_.tabIndex).to.equal(-1);
-        expect(impl.nextButton_.tabIndex).to.equal(0);
-        expect(isScreenReaderHidden(impl.prevButton_)).to.be.false;
-        expect(isScreenReaderHidden(impl.nextButton_)).to.be.false;
+        // Controls are hidden from screen readers as they do not provide
+        // any functionality for scrollable carousel.
+        // ATs see this is a scrolling div and can scroll it as user navigates
+        // items just fine (unlike type=slide which requires next/prev)
+        expect(impl.nextButton_.getAttribute('role')).equal('presentation');
+        expect(impl.prevButton_.getAttribute('role')).equal('presentation');
+      }
+    );
 
-        impl.nextButton_.focus();
-        expect(doc.activeElement).to.equal(impl.nextButton_);
+    it('should properly style controls; focusable but not visible', async () => {
+      const carousel = await getAmpScrollableCarousel();
+      const impl = await carousel.getImpl();
+      const container = carousel.getElementsByClassName(
+        'i-amphtml-scrollable-carousel-container'
+      )[0];
+      const carouselSlideEls = container.getElementsByClassName(
+        'amp-carousel-slide'
+      );
 
-        // Scroll to end
-        for (let i = 0; i < carouselSlideEls.length - 1; i++) {
-          impl.goCallback(1, /*animate*/ false);
-        }
-        // Explicitly check if buttons don't have visibility hidden or display none
-        expect(impl.prevButton_.classList.contains('amp-disabled')).to.be.false;
-        expect(impl.nextButton_.classList.contains('amp-disabled')).to.be.true;
-        expect(impl.prevButton_.tabIndex).to.equal(0);
-        expect(impl.nextButton_.tabIndex).to.equal(-1);
-        expect(isScreenReaderHidden(impl.prevButton_)).to.be.false;
-        expect(isScreenReaderHidden(impl.nextButton_)).to.be.false;
-        expect(doc.activeElement).to.equal(impl.nextButton_);
+      // show control buttons correctly
+      expect(impl.prevButton_.classList.contains('amp-disabled')).to.be.true;
+      expect(impl.nextButton_.classList.contains('amp-disabled')).to.be.false;
+      // Explicitly check if buttons don't have visibility hidden or display none
+      expect(impl.prevButton_.tabIndex).to.equal(-1);
+      expect(impl.nextButton_.tabIndex).to.equal(0);
+      expect(isScreenReaderHidden(impl.prevButton_)).to.be.false;
+      expect(isScreenReaderHidden(impl.nextButton_)).to.be.false;
 
-        impl.prevButton_.focus();
+      impl.nextButton_.focus();
+      expect(doc.activeElement).to.equal(impl.nextButton_);
 
-        for (let i = 0; i < carouselSlideEls.length - 1; i++) {
-          impl.goCallback(-1, /*animate*/ false);
-        }
-        // Explicitly check if buttons don't have visibility hidden or display none
-        expect(impl.prevButton_.classList.contains('amp-disabled')).to.be.true;
-        expect(impl.nextButton_.classList.contains('amp-disabled')).to.be.false;
-        expect(impl.prevButton_.tabIndex).to.equal(-1);
-        expect(impl.nextButton_.tabIndex).to.equal(0);
-        expect(isScreenReaderHidden(impl.prevButton_)).to.be.false;
-        expect(isScreenReaderHidden(impl.nextButton_)).to.be.false;
-        expect(doc.activeElement).to.equal(impl.prevButton_);
-      });
+      // Scroll to end
+      for (let i = 0; i < carouselSlideEls.length - 1; i++) {
+        impl.goCallback(1, /*animate*/ false);
+      }
+      // Explicitly check if buttons don't have visibility hidden or display none
+      expect(impl.prevButton_.classList.contains('amp-disabled')).to.be.false;
+      expect(impl.nextButton_.classList.contains('amp-disabled')).to.be.true;
+      expect(impl.prevButton_.tabIndex).to.equal(0);
+      expect(impl.nextButton_.tabIndex).to.equal(-1);
+      expect(isScreenReaderHidden(impl.prevButton_)).to.be.false;
+      expect(isScreenReaderHidden(impl.nextButton_)).to.be.false;
+      expect(doc.activeElement).to.equal(impl.nextButton_);
+
+      impl.prevButton_.focus();
+
+      for (let i = 0; i < carouselSlideEls.length - 1; i++) {
+        impl.goCallback(-1, /*animate*/ false);
+      }
+      // Explicitly check if buttons don't have visibility hidden or display none
+      expect(impl.prevButton_.classList.contains('amp-disabled')).to.be.true;
+      expect(impl.nextButton_.classList.contains('amp-disabled')).to.be.false;
+      expect(impl.prevButton_.tabIndex).to.equal(-1);
+      expect(impl.nextButton_.tabIndex).to.equal(0);
+      expect(isScreenReaderHidden(impl.prevButton_)).to.be.false;
+      expect(isScreenReaderHidden(impl.nextButton_)).to.be.false;
+      expect(doc.activeElement).to.equal(impl.prevButton_);
     });
 
     // TODO(#17197): This test triggers sinonjs/sinon issues 1709 and 1321.
     it.skip(
       'should behave correctly when clicking on next button and the ' +
         'space to the right is MORE than containerWidth',
-      () => {
-        return getAmpScrollableCarousel().then((carousel) => {
-          const impl = carousel.implementation_;
+      async () => {
+        const carousel = await getAmpScrollableCarousel();
+        const impl = await carousel.getImpl();
 
-          // click on the next button
-          impl.goCallback(1, /*animate*/ false);
+        // click on the next button
+        impl.goCallback(1, /*animate*/ false);
 
-          // scroll to the correct position
-          expect(impl.container_./*OK*/ scrollLeft).to.equal(300);
+        // scroll to the correct position
+        expect(impl.container_./*OK*/ scrollLeft).to.equal(300);
 
-          expect(schedulePauseSpy).to.have.been.calledWith(
-            impl.element,
-            impl.cells_[0]
-          );
-          expect(schedulePauseSpy).to.have.been.calledWith(
-            impl.element,
-            impl.cells_[1]
-          );
+        expect(schedulePauseSpy).to.have.been.calledWith(
+          impl.element,
+          impl.cells_[0]
+        );
+        expect(schedulePauseSpy).to.have.been.calledWith(
+          impl.element,
+          impl.cells_[1]
+        );
 
-          // schedule layout for new slides
-          expect(scheduleLayoutSpy).to.have.callCount(3);
-          expect(scheduleLayoutSpy).to.have.been.calledWith(
-            impl.element,
-            impl.cells_[2]
-          );
-          expect(scheduleLayoutSpy).to.have.been.calledWith(
-            impl.element,
-            impl.cells_[3]
-          );
-          expect(scheduleLayoutSpy).to.have.been.calledWith(
-            impl.element,
-            impl.cells_[4]
-          );
+        // schedule layout for new slides
+        expect(scheduleLayoutSpy).to.have.callCount(3);
+        expect(scheduleLayoutSpy).to.have.been.calledWith(
+          impl.element,
+          impl.cells_[2]
+        );
+        expect(scheduleLayoutSpy).to.have.been.calledWith(
+          impl.element,
+          impl.cells_[3]
+        );
+        expect(scheduleLayoutSpy).to.have.been.calledWith(
+          impl.element,
+          impl.cells_[4]
+        );
 
-          // preload slides in viewport
-          expect(schedulePreloadSpy).to.have.callCount(3);
-          expect(schedulePreloadSpy).to.have.been.calledWith(
-            impl.element,
-            impl.cells_[4]
-          );
-          expect(schedulePreloadSpy).to.have.been.calledWith(
-            impl.element,
-            impl.cells_[5]
-          );
-          expect(schedulePreloadSpy).to.have.been.calledWith(
-            impl.element,
-            impl.cells_[6]
-          );
+        // preload slides in viewport
+        expect(schedulePreloadSpy).to.have.callCount(3);
+        expect(schedulePreloadSpy).to.have.been.calledWith(
+          impl.element,
+          impl.cells_[4]
+        );
+        expect(schedulePreloadSpy).to.have.been.calledWith(
+          impl.element,
+          impl.cells_[5]
+        );
+        expect(schedulePreloadSpy).to.have.been.calledWith(
+          impl.element,
+          impl.cells_[6]
+        );
 
-          // set control buttons correctly
-          expect(impl.hasPrev()).to.be.true;
-          expect(impl.hasNext()).to.be.true;
-          expect(impl.prevButton_.classList.contains('amp-disabled')).to.be
-            .false;
-          expect(impl.nextButton_.classList.contains('amp-disabled')).to.be
-            .false;
-        });
+        // set control buttons correctly
+        expect(impl.hasPrev()).to.be.true;
+        expect(impl.hasNext()).to.be.true;
+        expect(impl.prevButton_.classList.contains('amp-disabled')).to.be.false;
+        expect(impl.nextButton_.classList.contains('amp-disabled')).to.be.false;
       }
     );
 
@@ -258,55 +249,52 @@ describes.realWin(
     it.skip(
       'should behave correctly when clicking on next button and the ' +
         'space to the right is LESS than containerWidth',
-      () => {
-        return getAmpScrollableCarousel().then((carousel) => {
-          const impl = carousel.implementation_;
+      async () => {
+        const carousel = await getAmpScrollableCarousel();
+        const impl = await carousel.getImpl();
 
-          // click on the next button the first time
-          impl.goCallback(1, /*animate*/ false);
+        // click on the next button the first time
+        impl.goCallback(1, /*animate*/ false);
 
-          // click on the next button the second time
-          impl.goCallback(1, /*animate*/ false);
+        // click on the next button the second time
+        impl.goCallback(1, /*animate*/ false);
 
-          // scroll to the correct position
-          // note the correct scrollLeft is not 600 (300 * 2) but 588 (888 - 300)
-          expect(impl.container_./*OK*/ scrollLeft).to.equal(588);
+        // scroll to the correct position
+        // note the correct scrollLeft is not 600 (300 * 2) but 588 (888 - 300)
+        expect(impl.container_./*OK*/ scrollLeft).to.equal(588);
 
-          expect(schedulePauseSpy).to.have.been.calledWith(
-            impl.element,
-            impl.cells_[2]
-          );
-          expect(schedulePauseSpy).to.have.been.calledWith(
-            impl.element,
-            impl.cells_[3]
-          );
+        expect(schedulePauseSpy).to.have.been.calledWith(
+          impl.element,
+          impl.cells_[2]
+        );
+        expect(schedulePauseSpy).to.have.been.calledWith(
+          impl.element,
+          impl.cells_[3]
+        );
 
-          // schedule layout for new slides
-          expect(scheduleLayoutSpy).to.have.callCount(3);
-          expect(scheduleLayoutSpy).to.have.been.calledWith(
-            impl.element,
-            impl.cells_[4]
-          );
-          expect(scheduleLayoutSpy).to.have.been.calledWith(
-            impl.element,
-            impl.cells_[5]
-          );
-          expect(scheduleLayoutSpy).to.have.been.calledWith(
-            impl.element,
-            impl.cells_[6]
-          );
+        // schedule layout for new slides
+        expect(scheduleLayoutSpy).to.have.callCount(3);
+        expect(scheduleLayoutSpy).to.have.been.calledWith(
+          impl.element,
+          impl.cells_[4]
+        );
+        expect(scheduleLayoutSpy).to.have.been.calledWith(
+          impl.element,
+          impl.cells_[5]
+        );
+        expect(scheduleLayoutSpy).to.have.been.calledWith(
+          impl.element,
+          impl.cells_[6]
+        );
 
-          // preload slides in viewport
-          expect(schedulePreloadSpy).to.have.not.been.called;
+        // preload slides in viewport
+        expect(schedulePreloadSpy).to.have.not.been.called;
 
-          // set control buttons correctly
-          expect(impl.hasPrev()).to.be.true;
-          expect(impl.hasNext()).to.be.false;
-          expect(impl.prevButton_.classList.contains('amp-disabled')).to.be
-            .false;
-          expect(impl.nextButton_.classList.contains('amp-disabled')).to.be
-            .true;
-        });
+        // set control buttons correctly
+        expect(impl.hasPrev()).to.be.true;
+        expect(impl.hasNext()).to.be.false;
+        expect(impl.prevButton_.classList.contains('amp-disabled')).to.be.false;
+        expect(impl.nextButton_.classList.contains('amp-disabled')).to.be.true;
       }
     );
 
@@ -314,68 +302,65 @@ describes.realWin(
     it.skip(
       'should behave correctly when clicking on previous button and the ' +
         'space to the left is MORE than containerWidth',
-      () => {
-        return getAmpScrollableCarousel().then((carousel) => {
-          const impl = carousel.implementation_;
+      async () => {
+        const carousel = await getAmpScrollableCarousel();
+        const impl = await carousel.getImpl();
 
-          // click on the next button twice to reach the right end
-          // scrollLeft after second click is 588
-          impl.goCallback(1, /*animate*/ false);
-          impl.goCallback(1, /*animate*/ false);
+        // click on the next button twice to reach the right end
+        // scrollLeft after second click is 588
+        impl.goCallback(1, /*animate*/ false);
+        impl.goCallback(1, /*animate*/ false);
 
-          // click on the previous button
-          impl.goCallback(-1, /*animate*/ false);
+        // click on the previous button
+        impl.goCallback(-1, /*animate*/ false);
 
-          // scroll to the correct position
-          expect(impl.container_./*OK*/ scrollLeft).to.equal(288);
+        // scroll to the correct position
+        expect(impl.container_./*OK*/ scrollLeft).to.equal(288);
 
-          expect(schedulePauseSpy).to.have.been.calledWith(
-            impl.element,
-            impl.cells_[5]
-          );
-          expect(schedulePauseSpy).to.have.been.calledWith(
-            impl.element,
-            impl.cells_[6]
-          );
+        expect(schedulePauseSpy).to.have.been.calledWith(
+          impl.element,
+          impl.cells_[5]
+        );
+        expect(schedulePauseSpy).to.have.been.calledWith(
+          impl.element,
+          impl.cells_[6]
+        );
 
-          // schedule layout for new slides
-          expect(scheduleLayoutSpy).to.have.callCount(3);
-          expect(scheduleLayoutSpy).to.have.been.calledWith(
-            impl.element,
-            impl.cells_[2]
-          );
-          expect(scheduleLayoutSpy).to.have.been.calledWith(
-            impl.element,
-            impl.cells_[3]
-          );
-          expect(scheduleLayoutSpy).to.have.been.calledWith(
-            impl.element,
-            impl.cells_[4]
-          );
+        // schedule layout for new slides
+        expect(scheduleLayoutSpy).to.have.callCount(3);
+        expect(scheduleLayoutSpy).to.have.been.calledWith(
+          impl.element,
+          impl.cells_[2]
+        );
+        expect(scheduleLayoutSpy).to.have.been.calledWith(
+          impl.element,
+          impl.cells_[3]
+        );
+        expect(scheduleLayoutSpy).to.have.been.calledWith(
+          impl.element,
+          impl.cells_[4]
+        );
 
-          // preload slides in viewport
-          expect(schedulePreloadSpy).to.have.callCount(3);
-          expect(schedulePreloadSpy).to.have.been.calledWith(
-            impl.element,
-            impl.cells_[0]
-          );
-          expect(schedulePreloadSpy).to.have.been.calledWith(
-            impl.element,
-            impl.cells_[1]
-          );
-          expect(schedulePreloadSpy).to.have.been.calledWith(
-            impl.element,
-            impl.cells_[2]
-          );
+        // preload slides in viewport
+        expect(schedulePreloadSpy).to.have.callCount(3);
+        expect(schedulePreloadSpy).to.have.been.calledWith(
+          impl.element,
+          impl.cells_[0]
+        );
+        expect(schedulePreloadSpy).to.have.been.calledWith(
+          impl.element,
+          impl.cells_[1]
+        );
+        expect(schedulePreloadSpy).to.have.been.calledWith(
+          impl.element,
+          impl.cells_[2]
+        );
 
-          // set control buttons correctly
-          expect(impl.hasPrev()).to.be.true;
-          expect(impl.hasNext()).to.be.true;
-          expect(impl.prevButton_.classList.contains('amp-disabled')).to.be
-            .false;
-          expect(impl.nextButton_.classList.contains('amp-disabled')).to.be
-            .false;
-        });
+        // set control buttons correctly
+        expect(impl.hasPrev()).to.be.true;
+        expect(impl.hasNext()).to.be.true;
+        expect(impl.prevButton_.classList.contains('amp-disabled')).to.be.false;
+        expect(impl.nextButton_.classList.contains('amp-disabled')).to.be.false;
       }
     );
 
@@ -383,57 +368,54 @@ describes.realWin(
     it.skip(
       'should behave correctly when clicking on previous button and the ' +
         'space to the left is LESS than containerWidth',
-      () => {
-        return getAmpScrollableCarousel().then((carousel) => {
-          const impl = carousel.implementation_;
+      async () => {
+        const carousel = await getAmpScrollableCarousel();
+        const impl = await carousel.getImpl();
 
-          // click on the next button twice to reach the right end and click on
-          // the previous button once, scrollLeft after third click is 288
-          impl.goCallback(1, /*animate*/ false);
-          impl.goCallback(1, /*animate*/ false);
-          impl.goCallback(-1, /*animate*/ false);
+        // click on the next button twice to reach the right end and click on
+        // the previous button once, scrollLeft after third click is 288
+        impl.goCallback(1, /*animate*/ false);
+        impl.goCallback(1, /*animate*/ false);
+        impl.goCallback(-1, /*animate*/ false);
 
-          // click on the previous button
-          impl.goCallback(-1, /*animate*/ false);
+        // click on the previous button
+        impl.goCallback(-1, /*animate*/ false);
 
-          // scroll to the correct position
-          expect(impl.container_./*OK*/ scrollLeft).to.equal(0);
+        // scroll to the correct position
+        expect(impl.container_./*OK*/ scrollLeft).to.equal(0);
 
-          expect(schedulePauseSpy).to.have.been.calledWith(
-            impl.element,
-            impl.cells_[3]
-          );
-          expect(schedulePauseSpy).to.have.been.calledWith(
-            impl.element,
-            impl.cells_[4]
-          );
+        expect(schedulePauseSpy).to.have.been.calledWith(
+          impl.element,
+          impl.cells_[3]
+        );
+        expect(schedulePauseSpy).to.have.been.calledWith(
+          impl.element,
+          impl.cells_[4]
+        );
 
-          // schedule layout for new slides
-          expect(scheduleLayoutSpy).to.have.callCount(3);
-          expect(scheduleLayoutSpy).to.have.been.calledWith(
-            impl.element,
-            impl.cells_[0]
-          );
-          expect(scheduleLayoutSpy).to.have.been.calledWith(
-            impl.element,
-            impl.cells_[1]
-          );
-          expect(scheduleLayoutSpy).to.have.been.calledWith(
-            impl.element,
-            impl.cells_[2]
-          );
+        // schedule layout for new slides
+        expect(scheduleLayoutSpy).to.have.callCount(3);
+        expect(scheduleLayoutSpy).to.have.been.calledWith(
+          impl.element,
+          impl.cells_[0]
+        );
+        expect(scheduleLayoutSpy).to.have.been.calledWith(
+          impl.element,
+          impl.cells_[1]
+        );
+        expect(scheduleLayoutSpy).to.have.been.calledWith(
+          impl.element,
+          impl.cells_[2]
+        );
 
-          // preload slides in viewport
-          expect(schedulePreloadSpy).to.have.not.been.called;
+        // preload slides in viewport
+        expect(schedulePreloadSpy).to.have.not.been.called;
 
-          // set control buttons correctly
-          expect(impl.hasPrev()).to.be.false;
-          expect(impl.hasNext()).to.be.true;
-          expect(impl.prevButton_.classList.contains('amp-disabled')).to.be
-            .true;
-          expect(impl.nextButton_.classList.contains('amp-disabled')).to.be
-            .false;
-        });
+        // set control buttons correctly
+        expect(impl.hasPrev()).to.be.false;
+        expect(impl.hasNext()).to.be.true;
+        expect(impl.prevButton_.classList.contains('amp-disabled')).to.be.true;
+        expect(impl.nextButton_.classList.contains('amp-disabled')).to.be.false;
       }
     );
 

--- a/extensions/amp-carousel/0.1/test/test-slidescroll.js
+++ b/extensions/amp-carousel/0.1/test/test-slidescroll.js
@@ -101,57 +101,596 @@ describes.realWin(
       return Promise.resolve(ampSlideScroll);
     }
 
-    it('should create container and wrappers and show initial slides', () => {
-      return getAmpSlideScroll().then((ampSlideScroll) => {
-        expect(
-          ampSlideScroll.getElementsByClassName('i-amphtml-slides-container')
-            .length
-        ).to.equal(1);
-        expect(
-          ampSlideScroll.querySelectorAll(
-            '.i-amphtml-slides-container > .i-amphtml-slide-item'
-          ).length
-        ).to.equal(5);
-        expect(
-          ampSlideScroll.getElementsByClassName('amp-carousel-slide').length
-        ).to.equal(5);
-        expect(
-          ampSlideScroll
-            .querySelector('.i-amphtml-slides-container')
-            .getAttribute('aria-live')
-        ).to.equal('polite');
-        const impl = ampSlideScroll.implementation_;
+    it('should create container and wrappers and show initial slides', async () => {
+      const ampSlideScroll = await getAmpSlideScroll();
+      const impl = await ampSlideScroll.getImpl();
+      expect(
+        ampSlideScroll.getElementsByClassName('i-amphtml-slides-container')
+          .length
+      ).to.equal(1);
+      expect(
+        ampSlideScroll.querySelectorAll(
+          '.i-amphtml-slides-container > .i-amphtml-slide-item'
+        ).length
+      ).to.equal(5);
+      expect(
+        ampSlideScroll.getElementsByClassName('amp-carousel-slide').length
+      ).to.equal(5);
+      expect(
+        ampSlideScroll
+          .querySelector('.i-amphtml-slides-container')
+          .getAttribute('aria-live')
+      ).to.equal('polite');
+      expect(impl.slideWrappers_[0].classList.contains(SHOW_CLASS)).to.be.true;
+      expect(impl.slideWrappers_[1].classList.contains(SHOW_CLASS)).to.be.true;
+      expect(impl.slides_[0].getAttribute('aria-hidden')).to.equal('false');
+      expect(impl.slides_[1].getAttribute('aria-hidden')).to.equal('true');
+    });
+
+    it('should go to the correct slide on button click', async () => {
+      const ampSlideScroll = await getAmpSlideScroll();
+      const impl = await ampSlideScroll.getImpl();
+
+      const showSlideSpy = env.sandbox.spy(impl, 'showSlide_');
+
+      impl.goCallback(1);
+      expect(showSlideSpy).to.have.been.calledWith(1);
+      expect(showSlideSpy).to.be.calledOnce;
+
+      impl.goCallback(-1);
+      expect(showSlideSpy).to.have.been.calledWith(0);
+      expect(showSlideSpy).to.have.callCount(2);
+
+      impl.goCallback(0);
+      expect(showSlideSpy).to.have.callCount(2);
+    });
+
+    // TODO(#17197): This test triggers sinonjs/sinon issues 1709 and 1321.
+    it.skip('should show the correct slide', async () => {
+      const ampSlideScroll = await getAmpSlideScroll();
+      const impl = await ampSlideScroll.getImpl();
+
+      const owners = Services.ownersForDoc(impl.element);
+      const scheduleLayoutSpy = env.sandbox.spy(owners, 'scheduleLayout');
+      const schedulePreloadSpy = env.sandbox.spy(owners, 'schedulePreload');
+      const hideRestOfTheSlidesSpy = env.sandbox.spy(
+        impl,
+        'hideRestOfTheSlides_'
+      );
+      const setControlsStateSpy = env.sandbox.spy(impl, 'setControlsState');
+      const analyticsEventSpy = env.sandbox.spy(impl, 'analyticsEvent_');
+
+      expect(impl.showSlide_(-1)).to.be.false;
+      expect(scheduleLayoutSpy).to.not.have.been.called;
+      expect(schedulePreloadSpy).to.not.have.been.called;
+      expect(hideRestOfTheSlidesSpy).to.not.have.been.called;
+      expect(setControlsStateSpy).to.not.have.been.called;
+      expect(analyticsEventSpy).to.not.have.been.called;
+
+      expect(impl.showSlide_(5)).to.be.false;
+      expect(scheduleLayoutSpy).to.not.have.been.called;
+      expect(schedulePreloadSpy).to.not.have.been.called;
+      expect(hideRestOfTheSlidesSpy).to.not.have.been.called;
+      expect(setControlsStateSpy).to.not.have.been.called;
+      expect(analyticsEventSpy).to.not.have.been.called;
+
+      expect(impl.showSlide_(impl.slideIndex_)).to.be.false;
+      expect(scheduleLayoutSpy).to.not.have.been.called;
+      expect(schedulePreloadSpy).to.not.have.been.called;
+      expect(hideRestOfTheSlidesSpy).to.not.have.been.called;
+      expect(setControlsStateSpy).to.not.have.been.called;
+      expect(analyticsEventSpy).to.not.have.been.called;
+
+      expect(impl.showSlide_(1)).to.be.true;
+      expect(impl.slideWrappers_[0].classList.contains(SHOW_CLASS)).to.be.true;
+      expect(impl.slideWrappers_[1].classList.contains(SHOW_CLASS)).to.be.true;
+      expect(impl.slideWrappers_[2].classList.contains(SHOW_CLASS)).to.be.true;
+      expect(schedulePreloadSpy).to.have.been.calledWith(
+        impl.element,
+        impl.slides_[0]
+      );
+      expect(scheduleLayoutSpy).to.have.been.calledWith(
+        impl.element,
+        impl.slides_[1]
+      );
+      expect(schedulePreloadSpy).to.have.been.calledWith(
+        impl.element,
+        impl.slides_[2]
+      );
+      expect(scheduleLayoutSpy).to.be.calledOnce;
+      expect(schedulePreloadSpy).to.have.callCount(2);
+      expect(impl.slideIndex_).to.equal(1);
+      expect(impl.slidesContainer_./*OK*/ scrollLeft).to.equal(
+        impl.slideWidth_
+      );
+      expect(hideRestOfTheSlidesSpy).to.have.been.calledWith([0, 1, 2]);
+      expect(hideRestOfTheSlidesSpy).to.be.calledOnce;
+      expect(setControlsStateSpy).to.be.calledOnce;
+      expect(analyticsEventSpy).to.have.callCount(2);
+      expect(analyticsEventSpy).to.have.been.calledWith('amp-carousel-next', {
+        'fromSlide': 'slide-id',
+        'toSlide': '1',
+      });
+      expect(analyticsEventSpy).to.have.been.calledWith('amp-carousel-change', {
+        'fromSlide': 'slide-id',
+        'toSlide': '1',
+      });
+      expect(impl.slides_[0].getAttribute('aria-hidden')).to.equal('true');
+      expect(impl.slides_[1].getAttribute('aria-hidden')).to.equal('false');
+      expect(impl.slides_[2].getAttribute('aria-hidden')).to.equal('true');
+
+      expect(impl.showSlide_(0)).to.be.true;
+      expect(impl.slideWrappers_[0].classList.contains(SHOW_CLASS)).to.be.true;
+      expect(impl.slideWrappers_[1].classList.contains(SHOW_CLASS)).to.be.true;
+      expect(impl.slideWrappers_[2].classList.contains(SHOW_CLASS)).to.be.false;
+      expect(scheduleLayoutSpy).to.have.been.calledWith(
+        impl.element,
+        impl.slides_[0]
+      );
+      expect(schedulePreloadSpy).to.have.been.calledWith(
+        impl.element,
+        impl.slides_[1]
+      );
+      expect(scheduleLayoutSpy).to.have.callCount(2);
+      expect(schedulePreloadSpy).to.have.callCount(3);
+      expect(impl.slideIndex_).to.equal(0);
+      expect(impl.slidesContainer_./*OK*/ scrollLeft).to.equal(0);
+      expect(hideRestOfTheSlidesSpy).to.have.been.calledWith([0, 1]);
+      expect(hideRestOfTheSlidesSpy).to.have.callCount(2);
+      expect(setControlsStateSpy).to.have.callCount(2);
+      expect(analyticsEventSpy).to.have.callCount(4);
+      expect(analyticsEventSpy).to.have.been.calledWith('amp-carousel-prev', {
+        'fromSlide': '1',
+        'toSlide': 'slide-id',
+      });
+      expect(analyticsEventSpy).to.have.been.calledWith('amp-carousel-change', {
+        'fromSlide': '1',
+        'toSlide': 'slide-id',
+      });
+      expect(impl.slides_[0].getAttribute('aria-hidden')).to.equal('false');
+      expect(impl.slides_[1].getAttribute('aria-hidden')).to.equal('true');
+
+      expect(impl.showSlide_(4)).to.be.true;
+      expect(impl.slideWrappers_[3].classList.contains(SHOW_CLASS)).to.be.true;
+      expect(impl.slideWrappers_[4].classList.contains(SHOW_CLASS)).to.be.true;
+      expect(schedulePreloadSpy).to.have.been.calledWith(
+        impl.element,
+        impl.slides_[3]
+      );
+      expect(scheduleLayoutSpy).to.have.been.calledWith(
+        impl.element,
+        impl.slides_[4]
+      );
+      expect(scheduleLayoutSpy).to.have.callCount(3);
+      expect(schedulePreloadSpy).to.have.callCount(4);
+      expect(impl.slideIndex_).to.equal(4);
+      expect(impl.slidesContainer_./*OK*/ scrollLeft).to.equal(
+        impl.slideWidth_
+      );
+      expect(hideRestOfTheSlidesSpy).to.have.been.calledWith([3, 4]);
+      expect(hideRestOfTheSlidesSpy).to.have.callCount(3);
+      expect(setControlsStateSpy).to.have.callCount(3);
+      expect(analyticsEventSpy).to.have.callCount(6);
+      expect(analyticsEventSpy).to.have.been.calledWith('amp-carousel-prev', {
+        'fromSlide': 'slide-id',
+        'toSlide': '4',
+      });
+      expect(analyticsEventSpy).to.have.been.calledWith('amp-carousel-change', {
+        'fromSlide': 'slide-id',
+        'toSlide': '4',
+      });
+      expect(impl.slides_[3].getAttribute('aria-hidden')).to.equal('true');
+      expect(impl.slides_[4].getAttribute('aria-hidden')).to.equal('false');
+      expect(impl.slides_[0].getAttribute('aria-hidden')).to.equal(null);
+    });
+
+    // TODO(#17197): This test triggers sinonjs/sinon issues 1709 and 1321.
+    it.skip('should hide the unwanted slides', async () => {
+      const ampSlideScroll = await getAmpSlideScroll();
+      const impl = await ampSlideScroll.getImpl();
+
+      const owners = Services.ownersForDoc(impl.element);
+      const schedulePauseSpy = env.sandbox.spy(owners, 'schedulePause');
+      const hideRestOfTheSlidesSpy = env.sandbox.spy(
+        impl,
+        'hideRestOfTheSlides_'
+      );
+
+      impl.showSlide_(1);
+
+      expect(hideRestOfTheSlidesSpy).to.have.been.calledWith([0, 1, 2]);
+      expect(impl.slideWrappers_[0].classList.contains(SHOW_CLASS)).to.be.true;
+      expect(impl.slideWrappers_[1].classList.contains(SHOW_CLASS)).to.be.true;
+      expect(impl.slideWrappers_[2].classList.contains(SHOW_CLASS)).to.be.true;
+      expect(impl.slideWrappers_[3].classList.contains(SHOW_CLASS)).to.be.false;
+      expect(impl.slideWrappers_[4].classList.contains(SHOW_CLASS)).to.be.false;
+      expect(schedulePauseSpy).to.have.been.calledWith(
+        impl.element,
+        impl.slides_[0]
+      );
+      expect(schedulePauseSpy).to.have.been.calledWith(
+        impl.element,
+        impl.slides_[2]
+      );
+      expect(schedulePauseSpy).to.have.callCount(2);
+
+      impl.showSlide_(0);
+
+      expect(hideRestOfTheSlidesSpy).to.have.been.calledWith([0, 1]);
+      expect(impl.slideWrappers_[0].classList.contains(SHOW_CLASS)).to.be.true;
+      expect(impl.slideWrappers_[1].classList.contains(SHOW_CLASS)).to.be.true;
+      expect(impl.slideWrappers_[2].classList.contains(SHOW_CLASS)).to.be.false;
+      expect(impl.slideWrappers_[3].classList.contains(SHOW_CLASS)).to.be.false;
+      expect(impl.slideWrappers_[4].classList.contains(SHOW_CLASS)).to.be.false;
+      expect(schedulePauseSpy).to.have.been.calledWith(
+        impl.element,
+        impl.slides_[1]
+      );
+      expect(schedulePauseSpy).to.have.been.calledWith(
+        impl.element,
+        impl.slides_[2]
+      );
+      expect(schedulePauseSpy).to.have.callCount(4);
+
+      impl.showSlide_(4);
+
+      expect(hideRestOfTheSlidesSpy).to.have.been.calledWith([3, 4]);
+
+      expect(impl.slideWrappers_[0].classList.contains(SHOW_CLASS)).to.be.false;
+      expect(impl.slideWrappers_[1].classList.contains(SHOW_CLASS)).to.be.false;
+      expect(impl.slideWrappers_[2].classList.contains(SHOW_CLASS)).to.be.false;
+      expect(impl.slideWrappers_[3].classList.contains(SHOW_CLASS)).to.be.true;
+      expect(impl.slideWrappers_[4].classList.contains(SHOW_CLASS)).to.be.true;
+      expect(schedulePauseSpy).to.have.been.calledWith(
+        impl.element,
+        impl.slides_[0]
+      );
+      expect(schedulePauseSpy).to.have.been.calledWith(
+        impl.element,
+        impl.slides_[1]
+      );
+      expect(schedulePauseSpy).to.have.been.calledWith(
+        impl.element,
+        impl.slides_[3]
+      );
+      expect(schedulePauseSpy).to.have.callCount(7);
+    });
+
+    it('should show/hide the correct controls', async () => {
+      const ampSlideScroll = await getAmpSlideScroll();
+      const impl = await ampSlideScroll.getImpl();
+
+      impl.showSlide_(1);
+      expect(impl.hasNext()).to.be.true;
+      expect(impl.hasPrev()).to.be.true;
+      expect(impl.nextButton_.classList.contains('amp-disabled')).to.be.false;
+      expect(impl.prevButton_.classList.contains('amp-disabled')).to.be.false;
+
+      impl.showSlide_(0);
+      expect(impl.hasNext()).to.be.true;
+      expect(impl.hasPrev()).to.be.false;
+      expect(impl.nextButton_.classList.contains('amp-disabled')).to.be.false;
+      expect(impl.prevButton_.classList.contains('amp-disabled')).to.be.true;
+
+      impl.showSlide_(4);
+      expect(impl.hasNext()).to.be.false;
+      expect(impl.hasPrev()).to.be.true;
+      expect(impl.nextButton_.classList.contains('amp-disabled')).to.be.true;
+      expect(impl.prevButton_.classList.contains('amp-disabled')).to.be.false;
+
+      // Verify aria roles for the button
+      expect(impl.nextButton_.getAttribute('role')).equal('button');
+      expect(impl.prevButton_.getAttribute('role')).equal('button');
+    });
+
+    it('should properly style controls; focusable but not visible', async () => {
+      const ampSlideScroll = await getAmpSlideScroll();
+      const impl = await ampSlideScroll.getImpl();
+
+      impl.showSlide_(0);
+      expect(impl.nextButton_.classList.contains('amp-disabled')).to.be.false;
+      expect(impl.prevButton_.classList.contains('amp-disabled')).to.be.true;
+      expect(impl.prevButton_.tabIndex).to.equal(-1);
+      expect(impl.nextButton_.tabIndex).to.equal(0);
+      expect(isScreenReaderHidden(impl.prevButton_)).to.be.false;
+      expect(isScreenReaderHidden(impl.nextButton_)).to.be.false;
+
+      impl.nextButton_.focus();
+      expect(doc.activeElement).to.equal(impl.nextButton_);
+
+      impl.showSlide_(4);
+      expect(impl.nextButton_.classList.contains('amp-disabled')).to.be.true;
+      expect(impl.prevButton_.classList.contains('amp-disabled')).to.be.false;
+      expect(impl.prevButton_.tabIndex).to.equal(0);
+      expect(impl.nextButton_.tabIndex).to.equal(-1);
+      expect(isScreenReaderHidden(impl.prevButton_)).to.be.false;
+      expect(isScreenReaderHidden(impl.nextButton_)).to.be.false;
+      expect(doc.activeElement).to.equal(impl.nextButton_);
+    });
+
+    it('should show focus outline and border on next and prev buttons', async () => {
+      const ampSlideScroll = await getAmpSlideScroll();
+      const impl = await ampSlideScroll.getImpl();
+
+      impl.showSlide_(1);
+
+      impl.prevButton_.focus();
+      expect(doc.activeElement).to.equal(impl.prevButton_);
+      expect(win.getComputedStyle(impl.prevButton_).outline).to.equal(
+        'rgb(255, 255, 255) solid 1px'
+      );
+      expect(win.getComputedStyle(impl.prevButton_).border).to.equal(
+        '1px solid rgb(0, 0, 0)'
+      );
+
+      impl.nextButton_.focus();
+      expect(doc.activeElement).to.equal(impl.nextButton_);
+      expect(win.getComputedStyle(impl.nextButton_).outline).to.equal(
+        'rgb(255, 255, 255) solid 1px'
+      );
+      expect(win.getComputedStyle(impl.nextButton_).border).to.equal(
+        '1px solid rgb(0, 0, 0)'
+      );
+    });
+
+    it('should set the correct scrollLeft when there is only one slide', async () => {
+      const ampSlideScroll = await getAmpSlideScroll();
+      const impl = await ampSlideScroll.getImpl();
+
+      impl.noOfSlides_ = 1;
+      impl.showSlide_(0);
+      expect(impl.slidesContainer_./*OK*/ scrollLeft).to.equal(0);
+    });
+
+    it('should update to the right slide on scroll', async () => {
+      const ampSlideScroll = await getAmpSlideScroll();
+      const impl = await ampSlideScroll.getImpl();
+
+      const showSlideSpy = env.sandbox.spy(impl, 'showSlide_');
+
+      impl.vsync_ = {
+        mutatePromise: (cb) => {
+          cb();
+          return {
+            then: (cb2) => {
+              cb2();
+            },
+          };
+        },
+        mutate: (cb) => {
+          cb();
+        },
+      };
+
+      // Move to slide 1 (from slide 0).
+      impl.showSlide_(1);
+      expect(showSlideSpy).to.be.calledWith(1);
+      expect(impl.snappingInProgress_).to.be.false;
+
+      //Move to slide 0 - via scrolling back.
+      impl.updateOnScroll_(1);
+      expect(showSlideSpy).to.be.calledWith(0);
+      expect(impl.slideIndex_).to.equal(0);
+
+      // Try scrolling Fwd and move to slide 1.
+      impl.updateOnScroll_(401);
+      expect(showSlideSpy).to.be.calledWith(1);
+      expect(impl.slideIndex_).to.equal(1);
+
+      impl.updateOnScroll_(700);
+      expect(showSlideSpy).to.be.calledWith(2);
+      expect(impl.slideIndex_).to.equal(2);
+
+      impl.showSlide_(4);
+      impl.updateOnScroll_(700);
+      expect(showSlideSpy).to.be.calledWith(4);
+      expect(impl.slideIndex_).to.equal(4);
+    });
+
+    it('should get the correct next slide index for a scrollLeft', async () => {
+      const ampSlideScroll = await getAmpSlideScroll();
+      const impl = await ampSlideScroll.getImpl();
+
+      // Already at slide 0;
+      expect(impl.getNextSlideIndex_(0)).to.equal(0);
+      expect(impl.getNextSlideIndex_(100)).to.equal(0);
+      expect(impl.getNextSlideIndex_(200)).to.equal(1);
+      expect(impl.getNextSlideIndex_(400)).to.equal(1);
+
+      impl.showSlide_(3);
+
+      expect(impl.getNextSlideIndex_(0)).to.equal(2);
+      expect(impl.getNextSlideIndex_(100)).to.equal(2);
+      expect(impl.getNextSlideIndex_(200)).to.equal(3);
+      expect(impl.getNextSlideIndex_(400)).to.equal(3);
+      expect(impl.getNextSlideIndex_(500)).to.equal(3);
+      expect(impl.getNextSlideIndex_(600)).to.equal(4);
+      expect(impl.getNextSlideIndex_(800)).to.equal(4);
+
+      impl.showSlide_(4);
+      expect(impl.getNextSlideIndex_(0)).to.equal(3);
+      expect(impl.getNextSlideIndex_(100)).to.equal(3);
+      expect(impl.getNextSlideIndex_(200)).to.equal(4);
+      expect(impl.getNextSlideIndex_(400)).to.equal(4);
+    });
+
+    it('should custom snap to the correct slide', async () => {
+      const ampSlideScroll = await getAmpSlideScroll();
+      const impl = await ampSlideScroll.getImpl();
+
+      const animateScrollLeftSpy = env.sandbox.spy(impl, 'animateScrollLeft_');
+
+      impl.customSnap_(0);
+      expect(animateScrollLeftSpy).to.have.been.calledWith(0, 0);
+      impl.customSnap_(100);
+      expect(animateScrollLeftSpy).to.have.been.calledWith(100, 0);
+      impl.customSnap_(200);
+      expect(animateScrollLeftSpy).to.have.been.calledWith(200, 400);
+      impl.customSnap_(400);
+      expect(animateScrollLeftSpy).to.have.been.calledWith(400, 400);
+
+      impl.showSlide_(3);
+
+      impl.customSnap_(0);
+      expect(animateScrollLeftSpy).to.have.been.calledWith(0, 0);
+      impl.customSnap_(100);
+      expect(animateScrollLeftSpy).to.have.been.calledWith(100, 0);
+      impl.customSnap_(200);
+      expect(animateScrollLeftSpy).to.have.been.calledWith(200, 400);
+      impl.customSnap_(400);
+      expect(animateScrollLeftSpy).to.have.been.calledWith(400, 400);
+      impl.customSnap_(500);
+      expect(animateScrollLeftSpy).to.have.been.calledWith(500, 400);
+      impl.customSnap_(600);
+      expect(animateScrollLeftSpy).to.have.been.calledWith(600, 800);
+      impl.customSnap_(800);
+      expect(animateScrollLeftSpy).to.have.been.calledWith(800, 800);
+
+      impl.showSlide_(4);
+
+      impl.customSnap_(0);
+      expect(animateScrollLeftSpy).to.have.been.calledWith(0, 0);
+      impl.customSnap_(100);
+      expect(animateScrollLeftSpy).to.have.been.calledWith(100, 0);
+      impl.customSnap_(200);
+      expect(animateScrollLeftSpy).to.have.been.calledWith(200, 400);
+      impl.customSnap_(400);
+      expect(animateScrollLeftSpy).to.have.been.calledWith(400, 400);
+
+      impl.showSlide_(0);
+
+      impl.customSnap_(0, -1);
+      expect(animateScrollLeftSpy).to.have.been.calledWith(0, 0);
+      impl.customSnap_(0, 1);
+      expect(animateScrollLeftSpy).to.have.been.calledWith(0, 400);
+
+      impl.showSlide_(3);
+
+      impl.customSnap_(400, -1);
+      expect(animateScrollLeftSpy).to.have.been.calledWith(400, 0);
+      impl.customSnap_(400, 1);
+      expect(animateScrollLeftSpy).to.have.been.calledWith(0, 400);
+
+      impl.showSlide_(4);
+
+      impl.customSnap_(400, -1);
+      expect(animateScrollLeftSpy).to.have.been.calledWith(400, 0);
+      impl.customSnap_(400, 1);
+      expect(animateScrollLeftSpy).to.have.been.calledWith(400, 400);
+    });
+
+    it('should custom snap to the correct slide - special case', async () => {
+      const ampSlideScroll = await getAmpSlideScroll(null, 2);
+      const impl = await ampSlideScroll.getImpl();
+
+      const animateScrollLeftSpy = env.sandbox.spy(impl, 'animateScrollLeft_');
+
+      impl.customSnap_(0, 1);
+      expect(animateScrollLeftSpy).to.have.been.calledWith(0, 400);
+
+      impl.showSlide_(1);
+
+      impl.customSnap_(400, -1);
+      expect(animateScrollLeftSpy).to.have.been.calledWith(400, 0);
+    });
+
+    it('should handle custom elastic scroll', async () => {
+      const ampSlideScroll = await getAmpSlideScroll();
+      const impl = await ampSlideScroll.getImpl();
+
+      const customSnapSpy = env.sandbox
+        .stub(impl, 'customSnap_')
+        .callsFake(() => {
+          return {
+            then: (cb) => {
+              cb();
+            },
+          };
+        });
+
+      impl.handleCustomElasticScroll_(-10);
+      expect(impl.elasticScrollState_).to.equal(-1);
+      impl.previousScrollLeft_ = -10;
+      impl.handleCustomElasticScroll_(-5);
+      expect(customSnapSpy).to.have.been.calledWith(-5);
+
+      impl.previousScrollLeft_ = null;
+
+      impl.handleCustomElasticScroll_(410);
+      expect(impl.elasticScrollState_).to.equal(1);
+      impl.previousScrollLeft_ = 410;
+      impl.handleCustomElasticScroll_(405);
+      expect(customSnapSpy).to.have.been.calledWith(405);
+    });
+
+    it('should handle layout measures (orientation changes)', async () => {
+      const ampSlideScroll = await getAmpSlideScroll();
+      const impl = await ampSlideScroll.getImpl();
+
+      const offsetWidthStub = env.sandbox.stub(ampSlideScroll, 'offsetWidth');
+
+      offsetWidthStub.value(200);
+      impl.onLayoutMeasure();
+      expect(impl.slideWidth_).to.equal(200);
+
+      // Show the first slide, make sure the scroll position is correct.
+      impl.showSlide_(1);
+      expect(impl.slidesContainer_./*OK*/ scrollLeft).to.equal(200);
+
+      // Now do a layout measure letting the component know it changed size.
+      offsetWidthStub.value(400);
+      impl.onLayoutMeasure();
+      expect(impl.slideWidth_).to.equal(400);
+      expect(impl.slidesContainer_./*OK*/ scrollLeft).to.equal(200);
+
+      // Make sure the scroll position is correct after layoutCallback.
+      await impl.unlayoutCallback(); // cannot call layoutCallback() twice without an unlayout in between.
+      await impl.layoutCallback();
+      impl.showSlide_(1);
+      expect(impl.slidesContainer_./*OK*/ scrollLeft).to.equal(400);
+    });
+
+    it('should relayout the current slide on layoutCallback', async () => {
+      const ampSlideScroll = await getAmpSlideScroll();
+      const impl = await ampSlideScroll.getImpl();
+
+      const owners = Services.ownersForDoc(impl.element);
+      const scheduleLayoutSpy_ = env.sandbox.spy(owners, 'scheduleLayout');
+      impl.slideIndex_ = null;
+      await impl.unlayoutCallback(); // cannot call layoutCallback() twice without an unlayout in between.
+      impl.layoutCallback();
+      expect(scheduleLayoutSpy_).to.have.been.calledWith(
+        impl.element,
+        impl.slides_[0]
+      );
+
+      impl.showSlide_(1);
+      await impl.unlayoutCallback(); // cannot call layoutCallback() twice without an unlayout in between.
+      impl.layoutCallback();
+      expect(scheduleLayoutSpy_).to.have.been.calledWith(
+        impl.element,
+        impl.slides_[1]
+      );
+    });
+
+    describe('Looping', () => {
+      it('should create container and wrappers and show initial slides', async () => {
+        const ampSlideScroll = await getAmpSlideScroll(true);
+        const impl = await ampSlideScroll.getImpl();
+
+        expect(impl.slideWrappers_[4].classList.contains(SHOW_CLASS)).to.be
+          .true;
         expect(impl.slideWrappers_[0].classList.contains(SHOW_CLASS)).to.be
           .true;
         expect(impl.slideWrappers_[1].classList.contains(SHOW_CLASS)).to.be
           .true;
-        expect(impl.slides_[0].getAttribute('aria-hidden')).to.equal('false');
-        expect(impl.slides_[1].getAttribute('aria-hidden')).to.equal('true');
       });
-    });
 
-    it('should go to the correct slide on button click', () => {
-      return getAmpSlideScroll().then((ampSlideScroll) => {
-        const impl = ampSlideScroll.implementation_;
-        const showSlideSpy = env.sandbox.spy(impl, 'showSlide_');
+      // TODO(#17197): This test triggers sinonjs/sinon issues 1709 and 1321.
+      it.skip('should show the correct slides when looping', async () => {
+        const ampSlideScroll = await getAmpSlideScroll(true);
+        const impl = await ampSlideScroll.getImpl();
 
-        impl.goCallback(1);
-        expect(showSlideSpy).to.have.been.calledWith(1);
-        expect(showSlideSpy).to.be.calledOnce;
-
-        impl.goCallback(-1);
-        expect(showSlideSpy).to.have.been.calledWith(0);
-        expect(showSlideSpy).to.have.callCount(2);
-
-        impl.goCallback(0);
-        expect(showSlideSpy).to.have.callCount(2);
-      });
-    });
-
-    // TODO(#17197): This test triggers sinonjs/sinon issues 1709 and 1321.
-    it.skip('should show the correct slide', () => {
-      return getAmpSlideScroll().then((ampSlideScroll) => {
-        const impl = ampSlideScroll.implementation_;
         const owners = Services.ownersForDoc(impl.element);
         const scheduleLayoutSpy = env.sandbox.spy(owners, 'scheduleLayout');
         const schedulePreloadSpy = env.sandbox.spy(owners, 'schedulePreload');
@@ -160,30 +699,13 @@ describes.realWin(
           'hideRestOfTheSlides_'
         );
         const setControlsStateSpy = env.sandbox.spy(impl, 'setControlsState');
-        const analyticsEventSpy = env.sandbox.spy(impl, 'analyticsEvent_');
 
-        expect(impl.showSlide_(-1)).to.be.false;
-        expect(scheduleLayoutSpy).to.not.have.been.called;
-        expect(schedulePreloadSpy).to.not.have.been.called;
-        expect(hideRestOfTheSlidesSpy).to.not.have.been.called;
-        expect(setControlsStateSpy).to.not.have.been.called;
-        expect(analyticsEventSpy).to.not.have.been.called;
+        expect(impl.slides_[4].getAttribute('aria-hidden')).to.equal('true');
+        expect(impl.slides_[0].getAttribute('aria-hidden')).to.equal('false');
+        expect(impl.slides_[1].getAttribute('aria-hidden')).to.equal('true');
 
-        expect(impl.showSlide_(5)).to.be.false;
-        expect(scheduleLayoutSpy).to.not.have.been.called;
-        expect(schedulePreloadSpy).to.not.have.been.called;
-        expect(hideRestOfTheSlidesSpy).to.not.have.been.called;
-        expect(setControlsStateSpy).to.not.have.been.called;
-        expect(analyticsEventSpy).to.not.have.been.called;
+        impl.showSlide_(1);
 
-        expect(impl.showSlide_(impl.slideIndex_)).to.be.false;
-        expect(scheduleLayoutSpy).to.not.have.been.called;
-        expect(schedulePreloadSpy).to.not.have.been.called;
-        expect(hideRestOfTheSlidesSpy).to.not.have.been.called;
-        expect(setControlsStateSpy).to.not.have.been.called;
-        expect(analyticsEventSpy).to.not.have.been.called;
-
-        expect(impl.showSlide_(1)).to.be.true;
         expect(impl.slideWrappers_[0].classList.contains(SHOW_CLASS)).to.be
           .true;
         expect(impl.slideWrappers_[1].classList.contains(SHOW_CLASS)).to.be
@@ -211,20 +733,14 @@ describes.realWin(
         expect(hideRestOfTheSlidesSpy).to.have.been.calledWith([0, 1, 2]);
         expect(hideRestOfTheSlidesSpy).to.be.calledOnce;
         expect(setControlsStateSpy).to.be.calledOnce;
-        expect(analyticsEventSpy).to.have.callCount(2);
-        expect(analyticsEventSpy).to.have.been.calledWith('amp-carousel-next', {
-          'fromSlide': 'slide-id',
-          'toSlide': '1',
-        });
-        expect(analyticsEventSpy).to.have.been.calledWith(
-          'amp-carousel-change',
-          {'fromSlide': 'slide-id', 'toSlide': '1'}
-        );
         expect(impl.slides_[0].getAttribute('aria-hidden')).to.equal('true');
         expect(impl.slides_[1].getAttribute('aria-hidden')).to.equal('false');
         expect(impl.slides_[2].getAttribute('aria-hidden')).to.equal('true');
 
-        expect(impl.showSlide_(0)).to.be.true;
+        impl.showSlide_(0);
+
+        expect(impl.slideWrappers_[4].classList.contains(SHOW_CLASS)).to.be
+          .true;
         expect(impl.slideWrappers_[0].classList.contains(SHOW_CLASS)).to.be
           .true;
         expect(impl.slideWrappers_[1].classList.contains(SHOW_CLASS)).to.be
@@ -239,66 +755,149 @@ describes.realWin(
           impl.element,
           impl.slides_[1]
         );
+        expect(schedulePreloadSpy).to.have.been.calledWith(
+          impl.element,
+          impl.slides_[4]
+        );
         expect(scheduleLayoutSpy).to.have.callCount(2);
-        expect(schedulePreloadSpy).to.have.callCount(3);
+        expect(schedulePreloadSpy).to.have.callCount(4);
         expect(impl.slideIndex_).to.equal(0);
-        expect(impl.slidesContainer_./*OK*/ scrollLeft).to.equal(0);
-        expect(hideRestOfTheSlidesSpy).to.have.been.calledWith([0, 1]);
+        expect(impl.slidesContainer_./*OK*/ scrollLeft).to.equal(400);
+        expect(hideRestOfTheSlidesSpy).to.have.been.calledWith([4, 0, 1]);
         expect(hideRestOfTheSlidesSpy).to.have.callCount(2);
         expect(setControlsStateSpy).to.have.callCount(2);
-        expect(analyticsEventSpy).to.have.callCount(4);
-        expect(analyticsEventSpy).to.have.been.calledWith('amp-carousel-prev', {
-          'fromSlide': '1',
-          'toSlide': 'slide-id',
-        });
-        expect(analyticsEventSpy).to.have.been.calledWith(
-          'amp-carousel-change',
-          {'fromSlide': '1', 'toSlide': 'slide-id'}
-        );
+        expect(impl.slides_[4].getAttribute('aria-hidden')).to.equal('true');
         expect(impl.slides_[0].getAttribute('aria-hidden')).to.equal('false');
         expect(impl.slides_[1].getAttribute('aria-hidden')).to.equal('true');
 
-        expect(impl.showSlide_(4)).to.be.true;
+        impl.showSlide_(4);
+
         expect(impl.slideWrappers_[3].classList.contains(SHOW_CLASS)).to.be
           .true;
         expect(impl.slideWrappers_[4].classList.contains(SHOW_CLASS)).to.be
           .true;
+        expect(impl.slideWrappers_[0].classList.contains(SHOW_CLASS)).to.be
+          .true;
         expect(schedulePreloadSpy).to.have.been.calledWith(
           impl.element,
           impl.slides_[3]
+        );
+        expect(schedulePreloadSpy).to.have.been.calledWith(
+          impl.element,
+          impl.slides_[0]
         );
         expect(scheduleLayoutSpy).to.have.been.calledWith(
           impl.element,
           impl.slides_[4]
         );
         expect(scheduleLayoutSpy).to.have.callCount(3);
-        expect(schedulePreloadSpy).to.have.callCount(4);
+        expect(schedulePreloadSpy).to.have.callCount(6);
         expect(impl.slideIndex_).to.equal(4);
         expect(impl.slidesContainer_./*OK*/ scrollLeft).to.equal(
           impl.slideWidth_
         );
-        expect(hideRestOfTheSlidesSpy).to.have.been.calledWith([3, 4]);
+        expect(hideRestOfTheSlidesSpy).to.have.been.calledWith([3, 4, 0]);
         expect(hideRestOfTheSlidesSpy).to.have.callCount(3);
         expect(setControlsStateSpy).to.have.callCount(3);
-        expect(analyticsEventSpy).to.have.callCount(6);
-        expect(analyticsEventSpy).to.have.been.calledWith('amp-carousel-prev', {
-          'fromSlide': 'slide-id',
-          'toSlide': '4',
-        });
-        expect(analyticsEventSpy).to.have.been.calledWith(
-          'amp-carousel-change',
-          {'fromSlide': 'slide-id', 'toSlide': '4'}
-        );
         expect(impl.slides_[3].getAttribute('aria-hidden')).to.equal('true');
         expect(impl.slides_[4].getAttribute('aria-hidden')).to.equal('false');
-        expect(impl.slides_[0].getAttribute('aria-hidden')).to.equal(null);
+        expect(impl.slides_[0].getAttribute('aria-hidden')).to.equal('true');
       });
-    });
 
-    // TODO(#17197): This test triggers sinonjs/sinon issues 1709 and 1321.
-    it.skip('should hide the unwanted slides', () => {
-      return getAmpSlideScroll().then((ampSlideScroll) => {
-        const impl = ampSlideScroll.implementation_;
+      it('show correct slides when looping with `autoplay` for 2 slides', async () => {
+        const ampSlideScroll = await getAmpSlideScroll(true, 2);
+        const impl = await ampSlideScroll.getImpl();
+
+        const owners = Services.ownersForDoc(impl.element);
+        const scheduleLayoutSpy = env.sandbox.spy(owners, 'scheduleLayout');
+        const schedulePreloadSpy = env.sandbox.spy(owners, 'schedulePreload');
+        const hideRestOfTheSlidesSpy = env.sandbox.spy(
+          impl,
+          'hideRestOfTheSlides_'
+        );
+        const setControlsStateSpy = env.sandbox.spy(impl, 'setControlsState');
+
+        expect(impl.slides_[0].getAttribute('aria-hidden')).to.equal('false');
+        expect(impl.slides_[1].getAttribute('aria-hidden')).to.equal('true');
+
+        impl.showSlide_(1);
+
+        expect(impl.slideWrappers_[0].classList.contains(SHOW_CLASS)).to.be
+          .true;
+        expect(impl.slideWrappers_[1].classList.contains(SHOW_CLASS)).to.be
+          .true;
+        expect(schedulePreloadSpy).to.have.been.calledWith(
+          impl.element,
+          impl.slides_[0]
+        );
+        expect(scheduleLayoutSpy).to.have.been.calledWith(
+          impl.element,
+          impl.slides_[1]
+        );
+        expect(scheduleLayoutSpy).to.be.calledOnce;
+        expect(schedulePreloadSpy).to.have.callCount(1);
+        expect(impl.slideIndex_).to.equal(1);
+        expect(impl.slidesContainer_./*OK*/ scrollLeft).to.equal(
+          impl.slideWidth_
+        );
+        expect(hideRestOfTheSlidesSpy).to.have.been.calledWith([0, 1]);
+        expect(hideRestOfTheSlidesSpy).to.be.calledOnce;
+        expect(setControlsStateSpy).to.be.calledOnce;
+        expect(impl.slides_[0].getAttribute('aria-hidden')).to.equal('true');
+        expect(impl.slides_[1].getAttribute('aria-hidden')).to.equal('false');
+
+        impl.showSlide_(0);
+
+        expect(impl.slideWrappers_[0].classList.contains(SHOW_CLASS)).to.be
+          .true;
+        expect(impl.slideWrappers_[1].classList.contains(SHOW_CLASS)).to.be
+          .true;
+        expect(scheduleLayoutSpy).to.have.been.calledWith(
+          impl.element,
+          impl.slides_[0]
+        );
+        expect(schedulePreloadSpy).to.have.been.calledWith(
+          impl.element,
+          impl.slides_[1]
+        );
+        expect(scheduleLayoutSpy).to.have.callCount(2);
+        expect(schedulePreloadSpy).to.have.callCount(2);
+        expect(impl.slideIndex_).to.equal(0);
+        expect(hideRestOfTheSlidesSpy).to.have.been.calledWith([0, 1]);
+        expect(hideRestOfTheSlidesSpy).to.have.callCount(2);
+        expect(setControlsStateSpy).to.have.callCount(2);
+        expect(impl.slides_[0].getAttribute('aria-hidden')).to.equal('false');
+        expect(impl.slides_[1].getAttribute('aria-hidden')).to.equal('true');
+      });
+
+      it('do not set `autoplay` status if `autoplay=0` specified', async () => {
+        const ampSlideScroll = await getAmpSlideScroll(false, 3, true, true, 0);
+        const impl = await ampSlideScroll.getImpl();
+        const setupAutoplaySpy = env.sandbox.spy(impl, 'setupAutoplay_');
+        expect(setupAutoplaySpy).to.not.have.been.called;
+      });
+
+      it('removes `autoplay` status after provided loops are made', async () => {
+        const ampSlideScroll = await getAmpSlideScroll(false, 3, true, true, 2);
+        const impl = await ampSlideScroll.getImpl();
+
+        const removeAutoplaySpy = env.sandbox.spy(impl, 'removeAutoplay');
+        impl.showSlide_(1);
+        impl.showSlide_(2);
+        expect(impl.loopsMade_).to.equal(1);
+        impl.showSlide_(0);
+        impl.showSlide_(1);
+        impl.showSlide_(2);
+        expect(impl.loopsMade_).to.equal(2);
+        expect(removeAutoplaySpy).to.have.been.called;
+        expect(ampSlideScroll.hasAttribute('loop')).to.be.false;
+      });
+
+      // TODO(#17197): This test triggers sinonjs/sinon issues 1709 and 1321.
+      it.skip('should hide unwanted slides when looping', async () => {
+        const ampSlideScroll = await getAmpSlideScroll(true);
+        const impl = await ampSlideScroll.getImpl();
+
         const owners = Services.ownersForDoc(impl.element);
         const schedulePauseSpy = env.sandbox.spy(owners, 'schedulePause');
         const hideRestOfTheSlidesSpy = env.sandbox.spy(
@@ -319,6 +918,17 @@ describes.realWin(
           .false;
         expect(impl.slideWrappers_[4].classList.contains(SHOW_CLASS)).to.be
           .false;
+
+        expect(impl.slideWrappers_[0].style.order).to.equal('1');
+        expect(impl.slideWrappers_[1].style.order).to.equal('2');
+        expect(impl.slideWrappers_[2].style.order).to.equal('3');
+        expect(impl.slideWrappers_[3].style.order).to.equal('');
+        expect(impl.slideWrappers_[4].style.order).to.equal('');
+
+        expect(schedulePauseSpy).to.have.been.calledWith(
+          impl.element,
+          impl.slides_[4]
+        );
         expect(schedulePauseSpy).to.have.been.calledWith(
           impl.element,
           impl.slides_[0]
@@ -327,11 +937,12 @@ describes.realWin(
           impl.element,
           impl.slides_[2]
         );
-        expect(schedulePauseSpy).to.have.callCount(2);
+        expect(schedulePauseSpy).to.have.callCount(3);
 
         impl.showSlide_(0);
 
-        expect(hideRestOfTheSlidesSpy).to.have.been.calledWith([0, 1]);
+        expect(hideRestOfTheSlidesSpy).to.have.been.calledWith([4, 0, 1]);
+
         expect(impl.slideWrappers_[0].classList.contains(SHOW_CLASS)).to.be
           .true;
         expect(impl.slideWrappers_[1].classList.contains(SHOW_CLASS)).to.be
@@ -341,23 +952,32 @@ describes.realWin(
         expect(impl.slideWrappers_[3].classList.contains(SHOW_CLASS)).to.be
           .false;
         expect(impl.slideWrappers_[4].classList.contains(SHOW_CLASS)).to.be
-          .false;
-        expect(schedulePauseSpy).to.have.been.calledWith(
-          impl.element,
-          impl.slides_[1]
-        );
+          .true;
+        expect(impl.slideWrappers_[0].style.order).to.equal('2');
+        expect(impl.slideWrappers_[1].style.order).to.equal('3');
+        expect(impl.slideWrappers_[2].style.order).to.equal('');
+        expect(impl.slideWrappers_[3].style.order).to.equal('');
+        expect(impl.slideWrappers_[4].style.order).to.equal('1');
         expect(schedulePauseSpy).to.have.been.calledWith(
           impl.element,
           impl.slides_[2]
         );
-        expect(schedulePauseSpy).to.have.callCount(4);
+        expect(schedulePauseSpy).to.have.been.calledWith(
+          impl.element,
+          impl.slides_[4]
+        );
+        expect(schedulePauseSpy).to.have.been.calledWith(
+          impl.element,
+          impl.slides_[1]
+        );
+        expect(schedulePauseSpy).to.have.callCount(6);
 
         impl.showSlide_(4);
 
-        expect(hideRestOfTheSlidesSpy).to.have.been.calledWith([3, 4]);
+        expect(hideRestOfTheSlidesSpy).to.have.been.calledWith([3, 4, 0]);
 
         expect(impl.slideWrappers_[0].classList.contains(SHOW_CLASS)).to.be
-          .false;
+          .true;
         expect(impl.slideWrappers_[1].classList.contains(SHOW_CLASS)).to.be
           .false;
         expect(impl.slideWrappers_[2].classList.contains(SHOW_CLASS)).to.be
@@ -366,25 +986,29 @@ describes.realWin(
           .true;
         expect(impl.slideWrappers_[4].classList.contains(SHOW_CLASS)).to.be
           .true;
-        expect(schedulePauseSpy).to.have.been.calledWith(
-          impl.element,
-          impl.slides_[0]
-        );
-        expect(schedulePauseSpy).to.have.been.calledWith(
-          impl.element,
-          impl.slides_[1]
-        );
+        expect(impl.slideWrappers_[0].style.order).to.equal('3');
+        expect(impl.slideWrappers_[1].style.order).to.equal('');
+        expect(impl.slideWrappers_[2].style.order).to.equal('');
+        expect(impl.slideWrappers_[3].style.order).to.equal('1');
+        expect(impl.slideWrappers_[4].style.order).to.equal('2');
         expect(schedulePauseSpy).to.have.been.calledWith(
           impl.element,
           impl.slides_[3]
         );
-        expect(schedulePauseSpy).to.have.callCount(7);
+        expect(schedulePauseSpy).to.have.been.calledWith(
+          impl.element,
+          impl.slides_[0]
+        );
+        expect(schedulePauseSpy).to.have.been.calledWith(
+          impl.element,
+          impl.slides_[1]
+        );
+        expect(schedulePauseSpy).to.have.callCount(9);
       });
-    });
 
-    it('should show/hide the correct controls', () => {
-      return getAmpSlideScroll().then((ampSlideScroll) => {
-        const impl = ampSlideScroll.implementation_;
+      it('should show/hide the correct controls when looping', async () => {
+        const ampSlideScroll = await getAmpSlideScroll(true);
+        const impl = await ampSlideScroll.getImpl();
 
         impl.showSlide_(1);
         expect(impl.hasNext()).to.be.true;
@@ -394,97 +1018,33 @@ describes.realWin(
 
         impl.showSlide_(0);
         expect(impl.hasNext()).to.be.true;
-        expect(impl.hasPrev()).to.be.false;
-        expect(impl.nextButton_.classList.contains('amp-disabled')).to.be.false;
-        expect(impl.prevButton_.classList.contains('amp-disabled')).to.be.true;
-
-        impl.showSlide_(4);
-        expect(impl.hasNext()).to.be.false;
         expect(impl.hasPrev()).to.be.true;
-        expect(impl.nextButton_.classList.contains('amp-disabled')).to.be.true;
-        expect(impl.prevButton_.classList.contains('amp-disabled')).to.be.false;
-
-        // Verify aria roles for the button
-        expect(impl.nextButton_.getAttribute('role')).equal('button');
-        expect(impl.prevButton_.getAttribute('role')).equal('button');
-      });
-    });
-
-    it('should properly style controls; focusable but not visible', () => {
-      return getAmpSlideScroll().then((ampSlideScroll) => {
-        const impl = ampSlideScroll.implementation_;
-
-        impl.showSlide_(0);
         expect(impl.nextButton_.classList.contains('amp-disabled')).to.be.false;
-        expect(impl.prevButton_.classList.contains('amp-disabled')).to.be.true;
-        expect(impl.prevButton_.tabIndex).to.equal(-1);
-        expect(impl.nextButton_.tabIndex).to.equal(0);
-        expect(isScreenReaderHidden(impl.prevButton_)).to.be.false;
-        expect(isScreenReaderHidden(impl.nextButton_)).to.be.false;
-
-        impl.nextButton_.focus();
-        expect(doc.activeElement).to.equal(impl.nextButton_);
+        expect(impl.prevButton_.classList.contains('amp-disabled')).to.be.false;
 
         impl.showSlide_(4);
-        expect(impl.nextButton_.classList.contains('amp-disabled')).to.be.true;
+        expect(impl.hasNext()).to.be.true;
+        expect(impl.hasPrev()).to.be.true;
+        expect(impl.nextButton_.classList.contains('amp-disabled')).to.be.false;
         expect(impl.prevButton_.classList.contains('amp-disabled')).to.be.false;
-        expect(impl.prevButton_.tabIndex).to.equal(0);
-        expect(impl.nextButton_.tabIndex).to.equal(-1);
-        expect(isScreenReaderHidden(impl.prevButton_)).to.be.false;
-        expect(isScreenReaderHidden(impl.nextButton_)).to.be.false;
-        expect(doc.activeElement).to.equal(impl.nextButton_);
       });
-    });
 
-    it('should show focus outline and border on next and prev buttons', () => {
-      return getAmpSlideScroll().then((ampSlideScroll) => {
-        const impl = ampSlideScroll.implementation_;
-        impl.showSlide_(1);
-
-        impl.prevButton_.focus();
-        expect(doc.activeElement).to.equal(impl.prevButton_);
-        expect(win.getComputedStyle(impl.prevButton_).outline).to.equal(
-          'rgb(255, 255, 255) solid 1px'
-        );
-        expect(win.getComputedStyle(impl.prevButton_).border).to.equal(
-          '1px solid rgb(0, 0, 0)'
-        );
-
-        impl.nextButton_.focus();
-        expect(doc.activeElement).to.equal(impl.nextButton_);
-        expect(win.getComputedStyle(impl.nextButton_).outline).to.equal(
-          'rgb(255, 255, 255) solid 1px'
-        );
-        expect(win.getComputedStyle(impl.nextButton_).border).to.equal(
-          '1px solid rgb(0, 0, 0)'
-        );
-      });
-    });
-
-    it('should set the correct scrollLeft when there is only one slide', () => {
-      return getAmpSlideScroll().then((ampSlideScroll) => {
-        const impl = ampSlideScroll.implementation_;
+      it('should set the correct scrollLeft when there is only one slide', async () => {
+        const ampSlideScroll = await getAmpSlideScroll(true, 1);
+        const impl = await ampSlideScroll.getImpl();
 
         impl.noOfSlides_ = 1;
         impl.showSlide_(0);
         expect(impl.slidesContainer_./*OK*/ scrollLeft).to.equal(0);
       });
-    });
 
-    it('should update to the right slide on scroll', () => {
-      return getAmpSlideScroll().then((ampSlideScroll) => {
-        const impl = ampSlideScroll.implementation_;
+      it('should update to the right slide on scroll', async () => {
+        const ampSlideScroll = await getAmpSlideScroll(true);
+        const impl = await ampSlideScroll.getImpl();
+
         const showSlideSpy = env.sandbox.spy(impl, 'showSlide_');
 
         impl.vsync_ = {
-          mutatePromise: (cb) => {
-            cb();
-            return {
-              then: (cb2) => {
-                cb2();
-              },
-            };
-          },
           mutate: (cb) => {
             cb();
           },
@@ -500,31 +1060,38 @@ describes.realWin(
         expect(showSlideSpy).to.be.calledWith(0);
         expect(impl.slideIndex_).to.equal(0);
 
-        // Try scrolling Fwd and move to slide 1.
+        // Try scrolling Fwd and move a little fwd to stay in the same slide.
         impl.updateOnScroll_(401);
+        expect(showSlideSpy).to.be.calledWith(0);
+        expect(impl.slideIndex_).to.equal(0);
+
+        impl.updateOnScroll_(700);
         expect(showSlideSpy).to.be.calledWith(1);
         expect(impl.slideIndex_).to.equal(1);
 
-        impl.updateOnScroll_(700);
-        expect(showSlideSpy).to.be.calledWith(2);
-        expect(impl.slideIndex_).to.equal(2);
-
         impl.showSlide_(4);
         impl.updateOnScroll_(700);
+        expect(showSlideSpy).to.be.calledWith(0);
+        expect(impl.slideIndex_).to.equal(0);
+
+        impl.updateOnScroll_(1);
         expect(showSlideSpy).to.be.calledWith(4);
         expect(impl.slideIndex_).to.equal(4);
       });
-    });
 
-    it('should get the correct next slide index for a scrollLeft', () => {
-      return getAmpSlideScroll().then((ampSlideScroll) => {
-        const impl = ampSlideScroll.implementation_;
+      it('should get the correct next slide index for a scrollLeft', async () => {
+        const ampSlideScroll = await getAmpSlideScroll(true);
+        const impl = await ampSlideScroll.getImpl();
 
         // Already at slide 0;
-        expect(impl.getNextSlideIndex_(0)).to.equal(0);
-        expect(impl.getNextSlideIndex_(100)).to.equal(0);
-        expect(impl.getNextSlideIndex_(200)).to.equal(1);
-        expect(impl.getNextSlideIndex_(400)).to.equal(1);
+
+        expect(impl.getNextSlideIndex_(0)).to.equal(4);
+        expect(impl.getNextSlideIndex_(100)).to.equal(4);
+        expect(impl.getNextSlideIndex_(200)).to.equal(0);
+        expect(impl.getNextSlideIndex_(400)).to.equal(0);
+        expect(impl.getNextSlideIndex_(500)).to.equal(0);
+        expect(impl.getNextSlideIndex_(600)).to.equal(1);
+        expect(impl.getNextSlideIndex_(800)).to.equal(1);
 
         impl.showSlide_(3);
 
@@ -541,27 +1108,19 @@ describes.realWin(
         expect(impl.getNextSlideIndex_(100)).to.equal(3);
         expect(impl.getNextSlideIndex_(200)).to.equal(4);
         expect(impl.getNextSlideIndex_(400)).to.equal(4);
+        expect(impl.getNextSlideIndex_(500)).to.equal(4);
+        expect(impl.getNextSlideIndex_(600)).to.equal(0);
+        expect(impl.getNextSlideIndex_(800)).to.equal(0);
       });
-    });
 
-    it('should custom snap to the correct slide', () => {
-      return getAmpSlideScroll().then((ampSlideScroll) => {
-        const impl = ampSlideScroll.implementation_;
+      it('should custom snap to the correct slide', async () => {
+        const ampSlideScroll = await getAmpSlideScroll(true);
+        const impl = await ampSlideScroll.getImpl();
+
         const animateScrollLeftSpy = env.sandbox.spy(
           impl,
           'animateScrollLeft_'
         );
-
-        impl.customSnap_(0);
-        expect(animateScrollLeftSpy).to.have.been.calledWith(0, 0);
-        impl.customSnap_(100);
-        expect(animateScrollLeftSpy).to.have.been.calledWith(100, 0);
-        impl.customSnap_(200);
-        expect(animateScrollLeftSpy).to.have.been.calledWith(200, 400);
-        impl.customSnap_(400);
-        expect(animateScrollLeftSpy).to.have.been.calledWith(400, 400);
-
-        impl.showSlide_(3);
 
         impl.customSnap_(0);
         expect(animateScrollLeftSpy).to.have.been.calledWith(0, 0);
@@ -578,802 +1137,195 @@ describes.realWin(
         impl.customSnap_(800);
         expect(animateScrollLeftSpy).to.have.been.calledWith(800, 800);
 
-        impl.showSlide_(4);
-
-        impl.customSnap_(0);
-        expect(animateScrollLeftSpy).to.have.been.calledWith(0, 0);
-        impl.customSnap_(100);
-        expect(animateScrollLeftSpy).to.have.been.calledWith(100, 0);
-        impl.customSnap_(200);
-        expect(animateScrollLeftSpy).to.have.been.calledWith(200, 400);
-        impl.customSnap_(400);
-        expect(animateScrollLeftSpy).to.have.been.calledWith(400, 400);
-
-        impl.showSlide_(0);
-
-        impl.customSnap_(0, -1);
-        expect(animateScrollLeftSpy).to.have.been.calledWith(0, 0);
-        impl.customSnap_(0, 1);
-        expect(animateScrollLeftSpy).to.have.been.calledWith(0, 400);
-
-        impl.showSlide_(3);
-
         impl.customSnap_(400, -1);
         expect(animateScrollLeftSpy).to.have.been.calledWith(400, 0);
         impl.customSnap_(400, 1);
-        expect(animateScrollLeftSpy).to.have.been.calledWith(0, 400);
-
-        impl.showSlide_(4);
-
-        impl.customSnap_(400, -1);
-        expect(animateScrollLeftSpy).to.have.been.calledWith(400, 0);
-        impl.customSnap_(400, 1);
-        expect(animateScrollLeftSpy).to.have.been.calledWith(400, 400);
+        expect(animateScrollLeftSpy).to.have.been.calledWith(400, 800);
       });
-    });
 
-    it('should custom snap to the correct slide - special case', () => {
-      return getAmpSlideScroll(null, 2).then((ampSlideScroll) => {
-        const impl = ampSlideScroll.implementation_;
-        const animateScrollLeftSpy = env.sandbox.spy(
-          impl,
-          'animateScrollLeft_'
-        );
+      it('should go to the correct slide on button click', async () => {
+        const ampSlideScroll = await getAmpSlideScroll(true);
+        const impl = await ampSlideScroll.getImpl();
 
-        impl.customSnap_(0, 1);
-        expect(animateScrollLeftSpy).to.have.been.calledWith(0, 400);
+        const showSlideSpy = env.sandbox.spy(impl, 'showSlide_');
 
-        impl.showSlide_(1);
+        impl.goCallback(-1);
+        expect(showSlideSpy).to.have.been.calledWith(4);
+        expect(showSlideSpy).to.be.calledOnce;
 
-        impl.customSnap_(400, -1);
-        expect(animateScrollLeftSpy).to.have.been.calledWith(400, 0);
-      });
-    });
+        impl.goCallback(1);
+        expect(showSlideSpy).to.have.been.calledWith(0);
+        expect(showSlideSpy).to.have.callCount(2);
 
-    it('should handle custom elastic scroll', () => {
-      return getAmpSlideScroll().then((ampSlideScroll) => {
-        const impl = ampSlideScroll.implementation_;
-        const customSnapSpy = env.sandbox
-          .stub(impl, 'customSnap_')
-          .callsFake(() => {
-            return {
-              then: (cb) => {
-                cb();
-              },
-            };
-          });
-
-        impl.handleCustomElasticScroll_(-10);
-        expect(impl.elasticScrollState_).to.equal(-1);
-        impl.previousScrollLeft_ = -10;
-        impl.handleCustomElasticScroll_(-5);
-        expect(customSnapSpy).to.have.been.calledWith(-5);
-
-        impl.previousScrollLeft_ = null;
-
-        impl.handleCustomElasticScroll_(410);
-        expect(impl.elasticScrollState_).to.equal(1);
-        impl.previousScrollLeft_ = 410;
-        impl.handleCustomElasticScroll_(405);
-        expect(customSnapSpy).to.have.been.calledWith(405);
-      });
-    });
-
-    it('should handle layout measures (orientation changes)', async () => {
-      const ampSlideScroll = await getAmpSlideScroll();
-      const impl = ampSlideScroll.implementation_;
-      const offsetWidthStub = env.sandbox.stub(ampSlideScroll, 'offsetWidth');
-
-      offsetWidthStub.value(200);
-      impl.onLayoutMeasure();
-      expect(impl.slideWidth_).to.equal(200);
-
-      // Show the first slide, make sure the scroll position is correct.
-      impl.showSlide_(1);
-      expect(impl.slidesContainer_./*OK*/ scrollLeft).to.equal(200);
-
-      // Now do a layout measure letting the component know it changed size.
-      offsetWidthStub.value(400);
-      impl.onLayoutMeasure();
-      expect(impl.slideWidth_).to.equal(400);
-      expect(impl.slidesContainer_./*OK*/ scrollLeft).to.equal(200);
-
-      // Make sure the scroll position is correct after layoutCallback.
-      await impl.unlayoutCallback(); // cannot call layoutCallback() twice without an unlayout in between.
-      await impl.layoutCallback();
-      impl.showSlide_(1);
-      expect(impl.slidesContainer_./*OK*/ scrollLeft).to.equal(400);
-    });
-
-    it('should relayout the current slide on layoutCallback', () => {
-      return getAmpSlideScroll().then(async (ampSlideScroll) => {
-        const impl = ampSlideScroll.implementation_;
-        const owners = Services.ownersForDoc(impl.element);
-        const scheduleLayoutSpy_ = env.sandbox.spy(owners, 'scheduleLayout');
-        impl.slideIndex_ = null;
-        await impl.unlayoutCallback(); // cannot call layoutCallback() twice without an unlayout in between.
-        impl.layoutCallback();
-        expect(scheduleLayoutSpy_).to.have.been.calledWith(
-          impl.element,
-          impl.slides_[0]
-        );
-
-        impl.showSlide_(1);
-        await impl.unlayoutCallback(); // cannot call layoutCallback() twice without an unlayout in between.
-        impl.layoutCallback();
-        expect(scheduleLayoutSpy_).to.have.been.calledWith(
-          impl.element,
-          impl.slides_[1]
-        );
-      });
-    });
-
-    describe('Looping', () => {
-      it('should create container and wrappers and show initial slides', () => {
-        return getAmpSlideScroll(true).then((ampSlideScroll) => {
-          const impl = ampSlideScroll.implementation_;
-          expect(impl.slideWrappers_[4].classList.contains(SHOW_CLASS)).to.be
-            .true;
-          expect(impl.slideWrappers_[0].classList.contains(SHOW_CLASS)).to.be
-            .true;
-          expect(impl.slideWrappers_[1].classList.contains(SHOW_CLASS)).to.be
-            .true;
-        });
+        impl.goCallback(1);
+        expect(showSlideSpy).to.have.been.calledWith(1);
+        expect(showSlideSpy).to.have.callCount(3);
       });
 
       // TODO(#17197): This test triggers sinonjs/sinon issues 1709 and 1321.
-      it.skip('should show the correct slides when looping', () => {
-        return getAmpSlideScroll(true).then((ampSlideScroll) => {
-          const impl = ampSlideScroll.implementation_;
-          const owners = Services.ownersForDoc(impl.element);
-          const scheduleLayoutSpy = env.sandbox.spy(owners, 'scheduleLayout');
-          const schedulePreloadSpy = env.sandbox.spy(owners, 'schedulePreload');
-          const hideRestOfTheSlidesSpy = env.sandbox.spy(
-            impl,
-            'hideRestOfTheSlides_'
-          );
-          const setControlsStateSpy = env.sandbox.spy(impl, 'setControlsState');
+      it.skip('should update slide when `slide` attribute is mutated', async () => {
+        const ampSlideScroll = await getAmpSlideScroll(true);
+        const impl = await ampSlideScroll.getImpl();
+        expectAsyncConsoleError(/Invalid \[slide\] value:/, 1);
 
-          expect(impl.slides_[4].getAttribute('aria-hidden')).to.equal('true');
-          expect(impl.slides_[0].getAttribute('aria-hidden')).to.equal('false');
-          expect(impl.slides_[1].getAttribute('aria-hidden')).to.equal('true');
+        const showSlideSpy = env.sandbox.spy(impl, 'showSlide_');
 
-          impl.showSlide_(1);
+        impl.mutatedAttributesCallback({slide: 2});
+        expect(showSlideSpy).to.have.been.calledWith(2);
 
-          expect(impl.slideWrappers_[0].classList.contains(SHOW_CLASS)).to.be
-            .true;
-          expect(impl.slideWrappers_[1].classList.contains(SHOW_CLASS)).to.be
-            .true;
-          expect(impl.slideWrappers_[2].classList.contains(SHOW_CLASS)).to.be
-            .true;
-          expect(schedulePreloadSpy).to.have.been.calledWith(
-            impl.element,
-            impl.slides_[0]
-          );
-          expect(scheduleLayoutSpy).to.have.been.calledWith(
-            impl.element,
-            impl.slides_[1]
-          );
-          expect(schedulePreloadSpy).to.have.been.calledWith(
-            impl.element,
-            impl.slides_[2]
-          );
-          expect(scheduleLayoutSpy).to.be.calledOnce;
-          expect(schedulePreloadSpy).to.have.callCount(2);
-          expect(impl.slideIndex_).to.equal(1);
-          expect(impl.slidesContainer_./*OK*/ scrollLeft).to.equal(
-            impl.slideWidth_
-          );
-          expect(hideRestOfTheSlidesSpy).to.have.been.calledWith([0, 1, 2]);
-          expect(hideRestOfTheSlidesSpy).to.be.calledOnce;
-          expect(setControlsStateSpy).to.be.calledOnce;
-          expect(impl.slides_[0].getAttribute('aria-hidden')).to.equal('true');
-          expect(impl.slides_[1].getAttribute('aria-hidden')).to.equal('false');
-          expect(impl.slides_[2].getAttribute('aria-hidden')).to.equal('true');
+        impl.mutatedAttributesCallback({slide: 0});
+        expect(showSlideSpy).to.have.been.calledWith(0);
 
-          impl.showSlide_(0);
-
-          expect(impl.slideWrappers_[4].classList.contains(SHOW_CLASS)).to.be
-            .true;
-          expect(impl.slideWrappers_[0].classList.contains(SHOW_CLASS)).to.be
-            .true;
-          expect(impl.slideWrappers_[1].classList.contains(SHOW_CLASS)).to.be
-            .true;
-          expect(impl.slideWrappers_[2].classList.contains(SHOW_CLASS)).to.be
-            .false;
-          expect(scheduleLayoutSpy).to.have.been.calledWith(
-            impl.element,
-            impl.slides_[0]
-          );
-          expect(schedulePreloadSpy).to.have.been.calledWith(
-            impl.element,
-            impl.slides_[1]
-          );
-          expect(schedulePreloadSpy).to.have.been.calledWith(
-            impl.element,
-            impl.slides_[4]
-          );
-          expect(scheduleLayoutSpy).to.have.callCount(2);
-          expect(schedulePreloadSpy).to.have.callCount(4);
-          expect(impl.slideIndex_).to.equal(0);
-          expect(impl.slidesContainer_./*OK*/ scrollLeft).to.equal(400);
-          expect(hideRestOfTheSlidesSpy).to.have.been.calledWith([4, 0, 1]);
-          expect(hideRestOfTheSlidesSpy).to.have.callCount(2);
-          expect(setControlsStateSpy).to.have.callCount(2);
-          expect(impl.slides_[4].getAttribute('aria-hidden')).to.equal('true');
-          expect(impl.slides_[0].getAttribute('aria-hidden')).to.equal('false');
-          expect(impl.slides_[1].getAttribute('aria-hidden')).to.equal('true');
-
-          impl.showSlide_(4);
-
-          expect(impl.slideWrappers_[3].classList.contains(SHOW_CLASS)).to.be
-            .true;
-          expect(impl.slideWrappers_[4].classList.contains(SHOW_CLASS)).to.be
-            .true;
-          expect(impl.slideWrappers_[0].classList.contains(SHOW_CLASS)).to.be
-            .true;
-          expect(schedulePreloadSpy).to.have.been.calledWith(
-            impl.element,
-            impl.slides_[3]
-          );
-          expect(schedulePreloadSpy).to.have.been.calledWith(
-            impl.element,
-            impl.slides_[0]
-          );
-          expect(scheduleLayoutSpy).to.have.been.calledWith(
-            impl.element,
-            impl.slides_[4]
-          );
-          expect(scheduleLayoutSpy).to.have.callCount(3);
-          expect(schedulePreloadSpy).to.have.callCount(6);
-          expect(impl.slideIndex_).to.equal(4);
-          expect(impl.slidesContainer_./*OK*/ scrollLeft).to.equal(
-            impl.slideWidth_
-          );
-          expect(hideRestOfTheSlidesSpy).to.have.been.calledWith([3, 4, 0]);
-          expect(hideRestOfTheSlidesSpy).to.have.callCount(3);
-          expect(setControlsStateSpy).to.have.callCount(3);
-          expect(impl.slides_[3].getAttribute('aria-hidden')).to.equal('true');
-          expect(impl.slides_[4].getAttribute('aria-hidden')).to.equal('false');
-          expect(impl.slides_[0].getAttribute('aria-hidden')).to.equal('true');
-        });
+        // Don't call showSlide_() if slide is not finite.
+        showSlideSpy.resetHistory();
+        impl.mutatedAttributesCallback({slide: Number.POSITIVE_INFINITY});
+        expect(showSlideSpy.called).to.be.false;
       });
 
-      it('show correct slides when looping with `autoplay` for 2 slides', () => {
-        return getAmpSlideScroll(true, 2).then((ampSlideScroll) => {
-          const impl = ampSlideScroll.implementation_;
-          const owners = Services.ownersForDoc(impl.element);
-          const scheduleLayoutSpy = env.sandbox.spy(owners, 'scheduleLayout');
-          const schedulePreloadSpy = env.sandbox.spy(owners, 'schedulePreload');
-          const hideRestOfTheSlidesSpy = env.sandbox.spy(
-            impl,
-            'hideRestOfTheSlides_'
-          );
-          const setControlsStateSpy = env.sandbox.spy(impl, 'setControlsState');
+      it('should trigger `slideChange` action when user changes slides', async () => {
+        const ampSlideScroll = await getAmpSlideScroll(true);
+        const impl = await ampSlideScroll.getImpl();
 
-          expect(impl.slides_[0].getAttribute('aria-hidden')).to.equal('false');
-          expect(impl.slides_[1].getAttribute('aria-hidden')).to.equal('true');
+        const triggerSpy = env.sandbox.spy(impl.action_, 'trigger');
 
-          impl.showSlide_(1);
+        impl.goCallback(-1, /* animate */ false);
+        expect(triggerSpy).to.have.been.calledWith(
+          ampSlideScroll,
+          'slideChange',
+          /* CustomEvent */ env.sandbox.match.has('detail', {index: 4}),
+          ActionTrust.HIGH
+        );
 
-          expect(impl.slideWrappers_[0].classList.contains(SHOW_CLASS)).to.be
-            .true;
-          expect(impl.slideWrappers_[1].classList.contains(SHOW_CLASS)).to.be
-            .true;
-          expect(schedulePreloadSpy).to.have.been.calledWith(
-            impl.element,
-            impl.slides_[0]
-          );
-          expect(scheduleLayoutSpy).to.have.been.calledWith(
-            impl.element,
-            impl.slides_[1]
-          );
-          expect(scheduleLayoutSpy).to.be.calledOnce;
-          expect(schedulePreloadSpy).to.have.callCount(1);
-          expect(impl.slideIndex_).to.equal(1);
-          expect(impl.slidesContainer_./*OK*/ scrollLeft).to.equal(
-            impl.slideWidth_
-          );
-          expect(hideRestOfTheSlidesSpy).to.have.been.calledWith([0, 1]);
-          expect(hideRestOfTheSlidesSpy).to.be.calledOnce;
-          expect(setControlsStateSpy).to.be.calledOnce;
-          expect(impl.slides_[0].getAttribute('aria-hidden')).to.equal('true');
-          expect(impl.slides_[1].getAttribute('aria-hidden')).to.equal('false');
-
-          impl.showSlide_(0);
-
-          expect(impl.slideWrappers_[0].classList.contains(SHOW_CLASS)).to.be
-            .true;
-          expect(impl.slideWrappers_[1].classList.contains(SHOW_CLASS)).to.be
-            .true;
-          expect(scheduleLayoutSpy).to.have.been.calledWith(
-            impl.element,
-            impl.slides_[0]
-          );
-          expect(schedulePreloadSpy).to.have.been.calledWith(
-            impl.element,
-            impl.slides_[1]
-          );
-          expect(scheduleLayoutSpy).to.have.callCount(2);
-          expect(schedulePreloadSpy).to.have.callCount(2);
-          expect(impl.slideIndex_).to.equal(0);
-          expect(hideRestOfTheSlidesSpy).to.have.been.calledWith([0, 1]);
-          expect(hideRestOfTheSlidesSpy).to.have.callCount(2);
-          expect(setControlsStateSpy).to.have.callCount(2);
-          expect(impl.slides_[0].getAttribute('aria-hidden')).to.equal('false');
-          expect(impl.slides_[1].getAttribute('aria-hidden')).to.equal('true');
-        });
-      });
-
-      it('do not set `autoplay` status if `autoplay=0` specified', () => {
-        return getAmpSlideScroll(false, 3, true, true, 0).then(
-          (ampSlideScroll) => {
-            const impl = ampSlideScroll.implementation_;
-            const setupAutoplaySpy = env.sandbox.spy(impl, 'setupAutoplay_');
-            expect(setupAutoplaySpy).to.not.have.been.called;
-          }
+        impl.goCallback(1, /* animate */ false);
+        expect(triggerSpy).to.have.been.calledWith(
+          ampSlideScroll,
+          'slideChange',
+          /* CustomEvent */ env.sandbox.match.has('detail', {index: 0}),
+          ActionTrust.HIGH
         );
       });
 
-      it('removes `autoplay` status after provided loops are made', () => {
-        return getAmpSlideScroll(false, 3, true, true, 2).then(
-          (ampSlideScroll) => {
-            const impl = ampSlideScroll.implementation_;
-            const removeAutoplaySpy = env.sandbox.spy(impl, 'removeAutoplay');
-            impl.showSlide_(1);
-            impl.showSlide_(2);
-            expect(impl.loopsMade_).to.equal(1);
-            impl.showSlide_(0);
-            impl.showSlide_(1);
-            impl.showSlide_(2);
-            expect(impl.loopsMade_).to.equal(2);
-            expect(removeAutoplaySpy).to.have.been.called;
-            expect(ampSlideScroll.hasAttribute('loop')).to.be.false;
-          }
+      it('should fire `slideChange` DOM event with high trust when user changes slides', async () => {
+        const ampSlideScroll = await getAmpSlideScroll(true);
+        const impl = await ampSlideScroll.getImpl();
+
+        let event;
+        win.document.addEventListener('slideChange', (e) => (event = e));
+
+        impl.goCallback(-1, /* animate */ false);
+        expect(win.document.eventListeners.count('slideChange')).to.equal(1);
+        expect(event.data.index).to.equal(4);
+        expect(event.data.actionTrust).to.equal(ActionTrust.HIGH);
+
+        impl.goCallback(1, /* animate */ false);
+        expect(win.document.eventListeners.count('slideChange')).to.equal(1);
+        expect(event.data.index).to.equal(0);
+        expect(event.data.actionTrust).to.equal(ActionTrust.HIGH);
+      });
+
+      it('should goToSlide on action', async () => {
+        const ampSlideScroll = await getAmpSlideScroll(true);
+        const impl = await ampSlideScroll.getImpl();
+
+        expectAsyncConsoleError(/Invalid \[slide\] value:/, 4);
+
+        const showSlideSpy = env.sandbox.spy(impl, 'showSlide_');
+        const satisfiesTrust = () => true;
+
+        let args = {'index': '123'};
+        impl.executeAction({method: 'goToSlide', args, satisfiesTrust});
+        expect(showSlideSpy).to.not.have.been.called;
+
+        args = {'index': '5'};
+        impl.executeAction({method: 'goToSlide', args, satisfiesTrust});
+        expect(showSlideSpy).to.not.have.been.called;
+
+        args = {'index': 'ssds11'};
+        impl.executeAction({method: 'goToSlide', args, satisfiesTrust});
+        expect(showSlideSpy).to.not.have.been.called;
+
+        args = {'index': '-1'};
+        impl.executeAction({method: 'goToSlide', args, satisfiesTrust});
+        expect(showSlideSpy).to.not.have.been.called;
+
+        args = {'index': '0'};
+        impl.executeAction({method: 'goToSlide', args, satisfiesTrust});
+        expect(showSlideSpy).to.have.been.calledWith(0);
+
+        args = {'index': '4'};
+        impl.executeAction({method: 'goToSlide', args, satisfiesTrust});
+        expect(showSlideSpy).to.have.been.calledWith(4);
+      });
+
+      it('should NOT call showSlide_ before layout', async () => {
+        const ampSlideScroll = await getAmpSlideScroll(
+          true,
+          5,
+          /* opt_attachToDom */ false
         );
+
+        // Layout happens asynchronously after attaching to DOM, so we can
+        // test pre-layoutCallback logic now.
+        doc.body.appendChild(ampSlideScroll);
+        await ampSlideScroll.build();
+
+        const impl = await ampSlideScroll.getImpl();
+        const showSlideSpy = env.sandbox.spy(impl, 'showSlide_');
+        const satisfiesTrust = () => true;
+
+        const args = {'index': '3'};
+        impl.executeAction({method: 'goToSlide', args, satisfiesTrust});
+        expect(showSlideSpy).to.not.have.been.called;
+
+        impl.mutatedAttributesCallback({slide: 2});
+        expect(showSlideSpy).to.not.have.been.called;
+
+        impl.onLayoutMeasure();
+        ampSlideScroll.layoutCallback();
+
+        // Should show the last slide index requested before layout.
+        expect(showSlideSpy).to.have.been.calledWith(2);
+        expect(showSlideSpy).to.be.calledOnce;
       });
 
-      // TODO(#17197): This test triggers sinonjs/sinon issues 1709 and 1321.
-      it.skip('should hide unwanted slides when looping', () => {
-        return getAmpSlideScroll(true).then((ampSlideScroll) => {
-          const impl = ampSlideScroll.implementation_;
-          const owners = Services.ownersForDoc(impl.element);
-          const schedulePauseSpy = env.sandbox.spy(owners, 'schedulePause');
-          const hideRestOfTheSlidesSpy = env.sandbox.spy(
-            impl,
-            'hideRestOfTheSlides_'
-          );
-
-          impl.showSlide_(1);
-
-          expect(hideRestOfTheSlidesSpy).to.have.been.calledWith([0, 1, 2]);
-          expect(impl.slideWrappers_[0].classList.contains(SHOW_CLASS)).to.be
-            .true;
-          expect(impl.slideWrappers_[1].classList.contains(SHOW_CLASS)).to.be
-            .true;
-          expect(impl.slideWrappers_[2].classList.contains(SHOW_CLASS)).to.be
-            .true;
-          expect(impl.slideWrappers_[3].classList.contains(SHOW_CLASS)).to.be
-            .false;
-          expect(impl.slideWrappers_[4].classList.contains(SHOW_CLASS)).to.be
-            .false;
-
-          expect(impl.slideWrappers_[0].style.order).to.equal('1');
-          expect(impl.slideWrappers_[1].style.order).to.equal('2');
-          expect(impl.slideWrappers_[2].style.order).to.equal('3');
-          expect(impl.slideWrappers_[3].style.order).to.equal('');
-          expect(impl.slideWrappers_[4].style.order).to.equal('');
-
-          expect(schedulePauseSpy).to.have.been.calledWith(
-            impl.element,
-            impl.slides_[4]
-          );
-          expect(schedulePauseSpy).to.have.been.calledWith(
-            impl.element,
-            impl.slides_[0]
-          );
-          expect(schedulePauseSpy).to.have.been.calledWith(
-            impl.element,
-            impl.slides_[2]
-          );
-          expect(schedulePauseSpy).to.have.callCount(3);
-
-          impl.showSlide_(0);
-
-          expect(hideRestOfTheSlidesSpy).to.have.been.calledWith([4, 0, 1]);
-
-          expect(impl.slideWrappers_[0].classList.contains(SHOW_CLASS)).to.be
-            .true;
-          expect(impl.slideWrappers_[1].classList.contains(SHOW_CLASS)).to.be
-            .true;
-          expect(impl.slideWrappers_[2].classList.contains(SHOW_CLASS)).to.be
-            .false;
-          expect(impl.slideWrappers_[3].classList.contains(SHOW_CLASS)).to.be
-            .false;
-          expect(impl.slideWrappers_[4].classList.contains(SHOW_CLASS)).to.be
-            .true;
-          expect(impl.slideWrappers_[0].style.order).to.equal('2');
-          expect(impl.slideWrappers_[1].style.order).to.equal('3');
-          expect(impl.slideWrappers_[2].style.order).to.equal('');
-          expect(impl.slideWrappers_[3].style.order).to.equal('');
-          expect(impl.slideWrappers_[4].style.order).to.equal('1');
-          expect(schedulePauseSpy).to.have.been.calledWith(
-            impl.element,
-            impl.slides_[2]
-          );
-          expect(schedulePauseSpy).to.have.been.calledWith(
-            impl.element,
-            impl.slides_[4]
-          );
-          expect(schedulePauseSpy).to.have.been.calledWith(
-            impl.element,
-            impl.slides_[1]
-          );
-          expect(schedulePauseSpy).to.have.callCount(6);
-
-          impl.showSlide_(4);
-
-          expect(hideRestOfTheSlidesSpy).to.have.been.calledWith([3, 4, 0]);
-
-          expect(impl.slideWrappers_[0].classList.contains(SHOW_CLASS)).to.be
-            .true;
-          expect(impl.slideWrappers_[1].classList.contains(SHOW_CLASS)).to.be
-            .false;
-          expect(impl.slideWrappers_[2].classList.contains(SHOW_CLASS)).to.be
-            .false;
-          expect(impl.slideWrappers_[3].classList.contains(SHOW_CLASS)).to.be
-            .true;
-          expect(impl.slideWrappers_[4].classList.contains(SHOW_CLASS)).to.be
-            .true;
-          expect(impl.slideWrappers_[0].style.order).to.equal('3');
-          expect(impl.slideWrappers_[1].style.order).to.equal('');
-          expect(impl.slideWrappers_[2].style.order).to.equal('');
-          expect(impl.slideWrappers_[3].style.order).to.equal('1');
-          expect(impl.slideWrappers_[4].style.order).to.equal('2');
-          expect(schedulePauseSpy).to.have.been.calledWith(
-            impl.element,
-            impl.slides_[3]
-          );
-          expect(schedulePauseSpy).to.have.been.calledWith(
-            impl.element,
-            impl.slides_[0]
-          );
-          expect(schedulePauseSpy).to.have.been.calledWith(
-            impl.element,
-            impl.slides_[1]
-          );
-          expect(schedulePauseSpy).to.have.callCount(9);
-        });
-      });
-
-      it('should show/hide the correct controls when looping', () => {
-        return getAmpSlideScroll(true).then((ampSlideScroll) => {
-          const impl = ampSlideScroll.implementation_;
-
-          impl.showSlide_(1);
-          expect(impl.hasNext()).to.be.true;
-          expect(impl.hasPrev()).to.be.true;
-          expect(impl.nextButton_.classList.contains('amp-disabled')).to.be
-            .false;
-          expect(impl.prevButton_.classList.contains('amp-disabled')).to.be
-            .false;
-
-          impl.showSlide_(0);
-          expect(impl.hasNext()).to.be.true;
-          expect(impl.hasPrev()).to.be.true;
-          expect(impl.nextButton_.classList.contains('amp-disabled')).to.be
-            .false;
-          expect(impl.prevButton_.classList.contains('amp-disabled')).to.be
-            .false;
-
-          impl.showSlide_(4);
-          expect(impl.hasNext()).to.be.true;
-          expect(impl.hasPrev()).to.be.true;
-          expect(impl.nextButton_.classList.contains('amp-disabled')).to.be
-            .false;
-          expect(impl.prevButton_.classList.contains('amp-disabled')).to.be
-            .false;
-        });
-      });
-
-      it('should set the correct scrollLeft when there is only one slide', () => {
-        return getAmpSlideScroll(true, 1).then((ampSlideScroll) => {
-          const impl = ampSlideScroll.implementation_;
-
-          impl.noOfSlides_ = 1;
-          impl.showSlide_(0);
-          expect(impl.slidesContainer_./*OK*/ scrollLeft).to.equal(0);
-        });
-      });
-
-      it('should update to the right slide on scroll', () => {
-        return getAmpSlideScroll(true).then((ampSlideScroll) => {
-          const impl = ampSlideScroll.implementation_;
-          const showSlideSpy = env.sandbox.spy(impl, 'showSlide_');
-
-          impl.vsync_ = {
-            mutate: (cb) => {
-              cb();
-            },
-          };
-
-          // Move to slide 1 (from slide 0).
-          impl.showSlide_(1);
-          expect(showSlideSpy).to.be.calledWith(1);
-          expect(impl.snappingInProgress_).to.be.false;
-
-          //Move to slide 0 - via scrolling back.
-          impl.updateOnScroll_(1);
-          expect(showSlideSpy).to.be.calledWith(0);
-          expect(impl.slideIndex_).to.equal(0);
-
-          // Try scrolling Fwd and move a little fwd to stay in the same slide.
-          impl.updateOnScroll_(401);
-          expect(showSlideSpy).to.be.calledWith(0);
-          expect(impl.slideIndex_).to.equal(0);
-
-          impl.updateOnScroll_(700);
-          expect(showSlideSpy).to.be.calledWith(1);
-          expect(impl.slideIndex_).to.equal(1);
-
-          impl.showSlide_(4);
-          impl.updateOnScroll_(700);
-          expect(showSlideSpy).to.be.calledWith(0);
-          expect(impl.slideIndex_).to.equal(0);
-
-          impl.updateOnScroll_(1);
-          expect(showSlideSpy).to.be.calledWith(4);
-          expect(impl.slideIndex_).to.equal(4);
-        });
-      });
-
-      it('should get the correct next slide index for a scrollLeft', () => {
-        return getAmpSlideScroll(true).then((ampSlideScroll) => {
-          const impl = ampSlideScroll.implementation_;
-
-          // Already at slide 0;
-
-          expect(impl.getNextSlideIndex_(0)).to.equal(4);
-          expect(impl.getNextSlideIndex_(100)).to.equal(4);
-          expect(impl.getNextSlideIndex_(200)).to.equal(0);
-          expect(impl.getNextSlideIndex_(400)).to.equal(0);
-          expect(impl.getNextSlideIndex_(500)).to.equal(0);
-          expect(impl.getNextSlideIndex_(600)).to.equal(1);
-          expect(impl.getNextSlideIndex_(800)).to.equal(1);
-
-          impl.showSlide_(3);
-
-          expect(impl.getNextSlideIndex_(0)).to.equal(2);
-          expect(impl.getNextSlideIndex_(100)).to.equal(2);
-          expect(impl.getNextSlideIndex_(200)).to.equal(3);
-          expect(impl.getNextSlideIndex_(400)).to.equal(3);
-          expect(impl.getNextSlideIndex_(500)).to.equal(3);
-          expect(impl.getNextSlideIndex_(600)).to.equal(4);
-          expect(impl.getNextSlideIndex_(800)).to.equal(4);
-
-          impl.showSlide_(4);
-          expect(impl.getNextSlideIndex_(0)).to.equal(3);
-          expect(impl.getNextSlideIndex_(100)).to.equal(3);
-          expect(impl.getNextSlideIndex_(200)).to.equal(4);
-          expect(impl.getNextSlideIndex_(400)).to.equal(4);
-          expect(impl.getNextSlideIndex_(500)).to.equal(4);
-          expect(impl.getNextSlideIndex_(600)).to.equal(0);
-          expect(impl.getNextSlideIndex_(800)).to.equal(0);
-        });
-      });
-
-      it('should custom snap to the correct slide', () => {
-        return getAmpSlideScroll(true).then((ampSlideScroll) => {
-          const impl = ampSlideScroll.implementation_;
-          const animateScrollLeftSpy = env.sandbox.spy(
-            impl,
-            'animateScrollLeft_'
-          );
-
-          impl.customSnap_(0);
-          expect(animateScrollLeftSpy).to.have.been.calledWith(0, 0);
-          impl.customSnap_(100);
-          expect(animateScrollLeftSpy).to.have.been.calledWith(100, 0);
-          impl.customSnap_(200);
-          expect(animateScrollLeftSpy).to.have.been.calledWith(200, 400);
-          impl.customSnap_(400);
-          expect(animateScrollLeftSpy).to.have.been.calledWith(400, 400);
-          impl.customSnap_(500);
-          expect(animateScrollLeftSpy).to.have.been.calledWith(500, 400);
-          impl.customSnap_(600);
-          expect(animateScrollLeftSpy).to.have.been.calledWith(600, 800);
-          impl.customSnap_(800);
-          expect(animateScrollLeftSpy).to.have.been.calledWith(800, 800);
-
-          impl.customSnap_(400, -1);
-          expect(animateScrollLeftSpy).to.have.been.calledWith(400, 0);
-          impl.customSnap_(400, 1);
-          expect(animateScrollLeftSpy).to.have.been.calledWith(400, 800);
-        });
-      });
-
-      it('should go to the correct slide on button click', () => {
-        return getAmpSlideScroll(true).then((ampSlideScroll) => {
-          const impl = ampSlideScroll.implementation_;
-          const showSlideSpy = env.sandbox.spy(impl, 'showSlide_');
-
-          impl.goCallback(-1);
-          expect(showSlideSpy).to.have.been.calledWith(4);
-          expect(showSlideSpy).to.be.calledOnce;
-
-          impl.goCallback(1);
-          expect(showSlideSpy).to.have.been.calledWith(0);
-          expect(showSlideSpy).to.have.callCount(2);
-
-          impl.goCallback(1);
-          expect(showSlideSpy).to.have.been.calledWith(1);
-          expect(showSlideSpy).to.have.callCount(3);
-        });
-      });
-
-      // TODO(#17197): This test triggers sinonjs/sinon issues 1709 and 1321.
-      it.skip('should update slide when `slide` attribute is mutated', () => {
-        return getAmpSlideScroll(true).then((ampSlideScroll) => {
-          expectAsyncConsoleError(/Invalid \[slide\] value:/, 1);
-
-          const impl = ampSlideScroll.implementation_;
-          const showSlideSpy = env.sandbox.spy(impl, 'showSlide_');
-
-          impl.mutatedAttributesCallback({slide: 2});
-          expect(showSlideSpy).to.have.been.calledWith(2);
-
-          impl.mutatedAttributesCallback({slide: 0});
-          expect(showSlideSpy).to.have.been.calledWith(0);
-
-          // Don't call showSlide_() if slide is not finite.
-          showSlideSpy.resetHistory();
-          impl.mutatedAttributesCallback({slide: Number.POSITIVE_INFINITY});
-          expect(showSlideSpy.called).to.be.false;
-        });
-      });
-
-      it('should trigger `slideChange` action when user changes slides', () => {
-        return getAmpSlideScroll(true).then((ampSlideScroll) => {
-          const impl = ampSlideScroll.implementation_;
-          const triggerSpy = env.sandbox.spy(impl.action_, 'trigger');
-
-          impl.goCallback(-1, /* animate */ false);
-          expect(triggerSpy).to.have.been.calledWith(
-            ampSlideScroll,
-            'slideChange',
-            /* CustomEvent */ env.sandbox.match.has('detail', {index: 4}),
-            ActionTrust.HIGH
-          );
-
-          impl.goCallback(1, /* animate */ false);
-          expect(triggerSpy).to.have.been.calledWith(
-            ampSlideScroll,
-            'slideChange',
-            /* CustomEvent */ env.sandbox.match.has('detail', {index: 0}),
-            ActionTrust.HIGH
-          );
-        });
-      });
-
-      it('should fire `slideChange` DOM event with high trust when user changes slides', () => {
-        return getAmpSlideScroll(true).then((ampSlideScroll) => {
-          let event;
-          win.document.addEventListener('slideChange', (e) => (event = e));
-          const impl = ampSlideScroll.implementation_;
-
-          impl.goCallback(-1, /* animate */ false);
-          expect(win.document.eventListeners.count('slideChange')).to.equal(1);
-          expect(event.data.index).to.equal(4);
-          expect(event.data.actionTrust).to.equal(ActionTrust.HIGH);
-
-          impl.goCallback(1, /* animate */ false);
-          expect(win.document.eventListeners.count('slideChange')).to.equal(1);
-          expect(event.data.index).to.equal(0);
-          expect(event.data.actionTrust).to.equal(ActionTrust.HIGH);
-        });
-      });
-
-      it('should goToSlide on action', () => {
-        return getAmpSlideScroll(true).then((ampSlideScroll) => {
-          expectAsyncConsoleError(/Invalid \[slide\] value:/, 4);
-
-          const impl = ampSlideScroll.implementation_;
-          const showSlideSpy = env.sandbox.spy(impl, 'showSlide_');
-          const satisfiesTrust = () => true;
-
-          let args = {'index': '123'};
-          impl.executeAction({method: 'goToSlide', args, satisfiesTrust});
-          expect(showSlideSpy).to.not.have.been.called;
-
-          args = {'index': '5'};
-          impl.executeAction({method: 'goToSlide', args, satisfiesTrust});
-          expect(showSlideSpy).to.not.have.been.called;
-
-          args = {'index': 'ssds11'};
-          impl.executeAction({method: 'goToSlide', args, satisfiesTrust});
-          expect(showSlideSpy).to.not.have.been.called;
-
-          args = {'index': '-1'};
-          impl.executeAction({method: 'goToSlide', args, satisfiesTrust});
-          expect(showSlideSpy).to.not.have.been.called;
-
-          args = {'index': '0'};
-          impl.executeAction({method: 'goToSlide', args, satisfiesTrust});
-          expect(showSlideSpy).to.have.been.calledWith(0);
-
-          args = {'index': '4'};
-          impl.executeAction({method: 'goToSlide', args, satisfiesTrust});
-          expect(showSlideSpy).to.have.been.calledWith(4);
-        });
-      });
-
-      it('should NOT call showSlide_ before layout', () => {
-        const promise = getAmpSlideScroll(true, 5, /* opt_attachToDom */ false);
-        return promise.then((ampSlideScroll) => {
-          // Layout happens asynchronously after attaching to DOM, so we can
-          // test pre-layoutCallback logic now.
-          doc.body.appendChild(ampSlideScroll);
-          return ampSlideScroll.build().then(() => {
-            const impl = ampSlideScroll.implementation_;
-            const showSlideSpy = env.sandbox.spy(impl, 'showSlide_');
-            const satisfiesTrust = () => true;
-
-            const args = {'index': '3'};
-            impl.executeAction({method: 'goToSlide', args, satisfiesTrust});
-            expect(showSlideSpy).to.not.have.been.called;
-
-            impl.mutatedAttributesCallback({slide: 2});
-            expect(showSlideSpy).to.not.have.been.called;
-
-            impl.onLayoutMeasure();
-            ampSlideScroll.layoutCallback();
-
-            // Should show the last slide index requested before layout.
-            expect(showSlideSpy).to.have.been.calledWith(2);
-            expect(showSlideSpy).to.be.calledOnce;
-          });
-        });
-      });
-
-      it('should NOT call showSlide_ before re-layout', () => {
-        return getAmpSlideScroll(false, 5, false).then((ampSlideScroll) => {
-          doc.body.appendChild(ampSlideScroll);
-          return ampSlideScroll.build().then(() => {
-            const impl = ampSlideScroll.implementation_;
-            const showSlideSpy = env.sandbox.spy(impl, 'showSlide_');
-            const satisfiesTrust = () => true;
-
-            // Test that showSlide_ due to goToSlide(index=1) is not called before
-            // layout.
-            let args = {'index': '1'};
-            impl.executeAction({method: 'goToSlide', args, satisfiesTrust});
-            expect(showSlideSpy).to.not.have.been.called;
-
-            // Test that showSlide_ is called after layout.
-            impl.onLayoutMeasure();
-            ampSlideScroll.layoutCallback();
-
-            expect(showSlideSpy).to.have.been.calledWith(1);
-            expect(showSlideSpy).to.be.calledOnce;
-
-            // Unlayout
-            showSlideSpy.resetHistory();
-            impl.unlayoutCallback();
-
-            // Test that showSlide_ due to goToSlide(index=4) is not called before
-            // layout.
-            args = {'index': '4'};
-            impl.executeAction({method: 'goToSlide', args, satisfiesTrust});
-            expect(showSlideSpy).to.not.have.been.called;
-
-            // Test that showSlide_ is called after layout.
-            impl.onLayoutMeasure();
-            ampSlideScroll.layoutCallback();
-
-            expect(showSlideSpy).to.have.been.calledWith(4);
-            expect(showSlideSpy).to.be.calledOnce;
-          });
-        });
+      it('should NOT call showSlide_ before re-layout', async () => {
+        const ampSlideScroll = await getAmpSlideScroll(false, 5, false);
+        doc.body.appendChild(ampSlideScroll);
+        await ampSlideScroll.build();
+
+        const impl = await ampSlideScroll.getImpl();
+        const showSlideSpy = env.sandbox.spy(impl, 'showSlide_');
+        const satisfiesTrust = () => true;
+
+        // Test that showSlide_ due to goToSlide(index=1) is not called before
+        // layout.
+        let args = {'index': '1'};
+        impl.executeAction({method: 'goToSlide', args, satisfiesTrust});
+        expect(showSlideSpy).to.not.have.been.called;
+
+        // Test that showSlide_ is called after layout.
+        impl.onLayoutMeasure();
+        ampSlideScroll.layoutCallback();
+
+        expect(showSlideSpy).to.have.been.calledWith(1);
+        expect(showSlideSpy).to.be.calledOnce;
+
+        // Unlayout
+        showSlideSpy.resetHistory();
+        impl.unlayoutCallback();
+
+        // Test that showSlide_ due to goToSlide(index=4) is not called before
+        // layout.
+        args = {'index': '4'};
+        impl.executeAction({method: 'goToSlide', args, satisfiesTrust});
+        expect(showSlideSpy).to.not.have.been.called;
+
+        // Test that showSlide_ is called after layout.
+        impl.onLayoutMeasure();
+        ampSlideScroll.layoutCallback();
+
+        expect(showSlideSpy).to.have.been.calledWith(4);
+        expect(showSlideSpy).to.be.calledOnce;
       });
     });
 
@@ -1399,9 +1351,10 @@ describes.realWin(
           expect(getNextTitle(el)).to.equal('Next item in carousel (2 of 3)');
         });
 
-        it('should have the correct values on the last index', function* () {
-          const el = yield getAmpSlideScroll(false, 3);
-          el.implementation_.showSlide_(2);
+        it('should have the correct values on the last index', async () => {
+          const el = await getAmpSlideScroll(false, 3);
+          const impl = await el.getImpl();
+          impl.showSlide_(2);
           expect(getPrevTitle(el)).to.equal(
             'Previous item in carousel (2 of 3)'
           );
@@ -1418,9 +1371,10 @@ describes.realWin(
           expect(getNextTitle(el)).to.equal('Next item in carousel (2 of 3)');
         });
 
-        it('should have the correct values on the last index', function* () {
-          const el = yield getAmpSlideScroll(true, 3);
-          el.implementation_.showSlide_(2);
+        it('should have the correct values on the last index', async () => {
+          const el = await getAmpSlideScroll(true, 3);
+          const impl = await el.getImpl();
+          impl.showSlide_(2);
           expect(getPrevTitle(el)).to.equal(
             'Previous item in carousel (2 of 3)'
           );

--- a/extensions/amp-carousel/0.2/test/test-type-slides.js
+++ b/extensions/amp-carousel/0.2/test/test-type-slides.js
@@ -32,8 +32,9 @@ import {getDetail, listenOncePromise} from '../../../../src/event-helper';
  */
 async function afterIndexUpdate(el, index) {
   const event = await listenOncePromise(el, CarouselEvents.INDEX_CHANGE);
-  await el.implementation_.mutateElement(() => {});
-  await el.implementation_.mutateElement(() => {});
+  const impl = await el.getImpl(false);
+  await impl.mutateElement(() => {});
+  await impl.mutateElement(() => {});
 
   if (index != undefined && getDetail(event)['index'] != index) {
     return afterIndexUpdate(el, index);
@@ -187,11 +188,11 @@ describes.realWin(
 
     it('should show focus outline and border on next and prev buttons', async () => {
       const carousel = await getCarousel({loop: false});
+      const impl = await carousel.getImpl();
 
-      carousel.implementation_.interactionNext();
+      impl.interactionNext();
       await afterIndexUpdate(carousel);
 
-      const impl = carousel.implementation_;
       impl.prevButton_.focus();
       expect(doc.activeElement).to.equal(impl.prevButton_);
       expect(win.getComputedStyle(impl.prevButton_).outline).to.equal(
@@ -246,8 +247,9 @@ describes.realWin(
 
       it('should disable the next button when at the end', async () => {
         const carousel = await getCarousel({loop: false});
+        const impl = await carousel.getImpl();
 
-        carousel.implementation_.goToSlide(4);
+        impl.goToSlide(4);
         await afterIndexUpdate(carousel);
 
         expect(getNextButton(carousel).getAttribute('aria-disabled')).to.equal(
@@ -257,9 +259,10 @@ describes.realWin(
 
       it('should correctly style controls; focusable but not visible', async () => {
         const carousel = await getCarousel({loop: false});
+        const impl = await carousel.getImpl();
 
         getNextButton(carousel).focus();
-        carousel.implementation_.goToSlide(4);
+        impl.goToSlide(4);
         await afterIndexUpdate(carousel);
         expect(getNextButton(carousel).getAttribute('tabIndex')).to.equal('-1');
         expect(getPrevButton(carousel).getAttribute('tabIndex')).to.equal('0');
@@ -268,7 +271,7 @@ describes.realWin(
         expect(doc.activeElement).to.equal(getNextButton(carousel));
 
         getPrevButton(carousel).focus();
-        carousel.implementation_.goToSlide(0);
+        impl.goToSlide(0);
         await afterIndexUpdate(carousel);
         expect(getNextButton(carousel).getAttribute('tabIndex')).to.equal('0');
         expect(getPrevButton(carousel).getAttribute('tabIndex')).to.equal('-1');
@@ -294,8 +297,9 @@ describes.realWin(
           event = e;
         });
         const carousel = await getCarousel({loop: false});
+        const impl = await carousel.getImpl();
 
-        carousel.implementation_.interactionNext();
+        impl.interactionNext();
         await afterIndexUpdate(carousel);
 
         expect(event.data.index).to.equal(1);
@@ -306,7 +310,7 @@ describes.realWin(
     describe('goToSlide action', () => {
       it('should propagate high trust', async () => {
         const carousel = await getCarousel({loop: false});
-        const impl = carousel.implementation_;
+        const impl = await carousel.getImpl();
         const triggerSpy = env.sandbox.spy(impl.action_, 'trigger');
 
         impl.executeAction({
@@ -327,7 +331,7 @@ describes.realWin(
 
       it('should propagate low trust', async () => {
         const carousel = await getCarousel({loop: false});
-        const impl = carousel.implementation_;
+        const impl = await carousel.getImpl();
         const triggerSpy = env.sandbox.spy(impl.action_, 'trigger');
 
         impl.executeAction({
@@ -348,7 +352,7 @@ describes.realWin(
 
       it('should allow string-valued index', async () => {
         const carousel = await getCarousel({loop: false});
-        const impl = carousel.implementation_;
+        const impl = await carousel.getImpl();
         const triggerSpy = env.sandbox.spy(impl.action_, 'trigger');
 
         impl.executeAction({
@@ -369,7 +373,7 @@ describes.realWin(
 
       it('should cause error with invalid index', async () => {
         const carousel = await getCarousel({loop: false});
-        const impl = carousel.implementation_;
+        const impl = await carousel.getImpl();
         const triggerSpy = env.sandbox.spy(impl.action_, 'trigger');
 
         try {
@@ -483,8 +487,9 @@ describes.realWin(
 
         it('should have the correct values on the last index', async () => {
           const carousel = await getCarousel({loop: false, slideCount: 3});
+          const impl = await carousel.getImpl();
 
-          carousel.implementation_.goToSlide(2);
+          impl.goToSlide(2);
           await afterIndexUpdate(carousel);
 
           expect(getPrevTitle(carousel)).to.equal(
@@ -510,8 +515,9 @@ describes.realWin(
 
         it('should have the correct values on the last index', async () => {
           const carousel = await getCarousel({loop: true, slideCount: 3});
+          const impl = await carousel.getImpl();
 
-          carousel.implementation_.goToSlide(2);
+          impl.goToSlide(2);
           await afterIndexUpdate(carousel);
 
           expect(getPrevTitle(carousel)).to.equal(

--- a/extensions/amp-connatix-player/0.1/test/test-amp-connatix-player.js
+++ b/extensions/amp-connatix-player/0.1/test/test-amp-connatix-player.js
@@ -88,9 +88,9 @@ describes.realWin(
       const cnx = await getConnatixPlayer({
         'data-player-id': 'f721b0d8-7a79-42b6-b637-fa4e86138ed9',
       });
+      const obj = await cnx.getImpl();
       const iframe = cnx.querySelector('iframe');
       expect(iframe).to.not.be.null;
-      const obj = cnx.implementation_;
       obj.unlayoutCallback();
       expect(cnx.querySelector('iframe')).to.be.null;
       expect(obj.iframe_).to.be.null;

--- a/extensions/amp-date-countdown/0.1/test/test-amp-date-countdown.js
+++ b/extensions/amp-date-countdown/0.1/test/test-amp-date-countdown.js
@@ -32,14 +32,14 @@ describes.realWin(
     const endDate = new Date(ISOEndDate);
     const twoDaysBeforeEndDate = new Date(endDate - 86400000 * 2); //substract 2 days
 
-    beforeEach(() => {
+    beforeEach(async () => {
       ({win /*, sandbox*/} = env);
 
       element = win.document.createElement('amp-date-countdown');
       element.setAttribute('end-date', ISOEndDate);
       element.setAttribute('layout', 'responsive');
       win.document.body.appendChild(element);
-      impl = element.implementation_;
+      impl = await element.getImpl(false);
     });
 
     it(

--- a/extensions/amp-date-display/0.1/test/test-amp-date-display.js
+++ b/extensions/amp-date-display/0.1/test/test-amp-date-display.js
@@ -31,7 +31,7 @@ describes.realWin(
     let impl;
     let clock;
 
-    beforeEach(() => {
+    beforeEach(async () => {
       win = env.win;
       clock = fakeTimers.withGlobal(win).install({
         now: new Date('2018-01-01T08:00:00Z'),
@@ -39,8 +39,11 @@ describes.realWin(
 
       toggleExperiment(win, 'amp-date-display', true);
       element = win.document.createElement('amp-date-display');
+      element.setAttribute('layout', 'fixed');
+      element.setAttribute('width', '300');
+      element.setAttribute('height', '100');
       win.document.body.appendChild(element);
-      impl = element.implementation_;
+      impl = await element.getImpl(false);
       env.sandbox.stub(impl.templates_, 'findAndRenderTemplate').resolves();
       env.sandbox.stub(impl, 'boundRendered_');
     });

--- a/extensions/amp-date-picker/0.1/test/integration/test-integration-maximum-nights.js
+++ b/extensions/amp-date-picker/0.1/test/integration/test-integration-maximum-nights.js
@@ -41,7 +41,7 @@ config.run('amp-date-picker', function () {
       let doc;
       let clock;
 
-      beforeEach(() => {
+      beforeEach(async () => {
         win = env.win;
         doc = env.win.document;
         clock = fakeTimers.withGlobal(win).install({
@@ -61,9 +61,9 @@ config.run('amp-date-picker', function () {
         ></amp-date-picker>
       </div>`);
         const picker = doc.getElementById('picker');
-        return picker.implementation_
-          .buildCallback()
-          .then(() => picker.implementation_.layoutCallback());
+        const impl = await picker.getImpl(false);
+        await impl.buildCallback();
+        await impl.layoutCallback();
       });
 
       afterEach(() => {

--- a/extensions/amp-delight-player/0.1/test/test-amp-delight-player.js
+++ b/extensions/amp-delight-player/0.1/test/test-amp-delight-player.js
@@ -34,14 +34,15 @@ describes.realWin(
       doc = win.document;
     });
 
-    function fakePostMessage(delightElement, info) {
-      delightElement.implementation_.handleDelightMessage_({
+    async function fakePostMessage(delightElement, info) {
+      const impl = await delightElement.getImpl(false);
+      impl.handleDelightMessage_({
         source: delightElement.querySelector('iframe').contentWindow,
         data: {source: 'DelightPlayer', ...info},
       });
     }
 
-    function getDelightPlayer(attributes) {
+    async function getDelightPlayer(attributes) {
       const delight = doc.createElement('amp-delight-player');
       for (const key in attributes) {
         delight.setAttribute(key, attributes[key]);
@@ -50,7 +51,8 @@ describes.realWin(
       delight.setAttribute('height', '360');
       delight.setAttribute('layout', 'responsive');
       doc.body.appendChild(delight);
-      delight.implementation_.baseURL_ =
+      const impl = await delight.getImpl(false);
+      impl.baseURL_ =
         // Serve a blank page, since these tests don't require an actual page.
         // hash # at the end so path is not affected by param concat
         `http://localhost:${location.port}/test/fixtures/served/blank.html#`;
@@ -63,12 +65,13 @@ describes.realWin(
     it('renders', () => {
       return getDelightPlayer({
         'data-content-id': '-LLoCCZqWi18O73b6M0w',
-      }).then((delight) => {
+      }).then(async (delight) => {
+        const impl = await delight.getImpl(false);
         const iframe = delight.querySelector('iframe');
         expect(iframe).to.not.be.null;
         expect(iframe.tagName).to.equal('IFRAME');
         expect(iframe.src).to.equal(
-          `${delight.implementation_.baseURL_}/player/-LLoCCZqWi18O73b6M0w?amp=1`
+          `${impl.baseURL_}/player/-LLoCCZqWi18O73b6M0w?amp=1`
         );
         expect(iframe.allow).to.equal('vr');
         expect(iframe.className).to.match(/i-amphtml-fill-content/);
@@ -90,65 +93,65 @@ describes.realWin(
         'data-content-id': '-LLoCCZqWi18O73b6M0w',
       }).then((delight) => {
         return Promise.resolve()
-          .then(() => {
+          .then(async () => {
             const p = listenOncePromise(delight, VideoEvents.LOAD);
-            fakePostMessage(delight, {
+            await fakePostMessage(delight, {
               type: 'x-dl8-to-parent-ready',
               payload: {},
             });
             return p;
           })
-          .then(() => {
+          .then(async () => {
             const p = listenOncePromise(delight, VideoEvents.PLAYING);
-            fakePostMessage(delight, {
+            await fakePostMessage(delight, {
               type: 'x-dl8-to-parent-playing',
               payload: {},
             });
             return p;
           })
-          .then(() => {
+          .then(async () => {
             const p = listenOncePromise(delight, VideoEvents.PAUSE);
-            fakePostMessage(delight, {
+            await fakePostMessage(delight, {
               type: 'x-dl8-to-parent-paused',
               payload: {},
             });
             return p;
           })
-          .then(() => {
+          .then(async () => {
             const p = listenOncePromise(delight, VideoEvents.MUTED);
-            fakePostMessage(delight, {
+            await fakePostMessage(delight, {
               type: 'x-dl8-to-parent-muted',
               payload: {},
             });
             return p;
           })
-          .then(() => {
+          .then(async () => {
             const p = listenOncePromise(delight, VideoEvents.UNMUTED);
-            fakePostMessage(delight, {
+            await fakePostMessage(delight, {
               type: 'x-dl8-to-parent-unmuted',
               payload: {},
             });
             return p;
           })
-          .then(() => {
+          .then(async () => {
             const p = listenOncePromise(delight, VideoEvents.ENDED);
-            fakePostMessage(delight, {
+            await fakePostMessage(delight, {
               type: 'x-dl8-to-parent-ended',
               payload: {},
             });
             return p;
           })
-          .then(() => {
+          .then(async () => {
             const p = listenOncePromise(delight, VideoEvents.AD_START);
-            fakePostMessage(delight, {
+            await fakePostMessage(delight, {
               type: 'x-dl8-to-parent-amp-ad-start',
               payload: {},
             });
             return p;
           })
-          .then(() => {
+          .then(async () => {
             const p = listenOncePromise(delight, VideoEvents.AD_END);
-            fakePostMessage(delight, {
+            await fakePostMessage(delight, {
               type: 'x-dl8-to-parent-amp-ad-end',
               payload: {},
             });
@@ -156,7 +159,7 @@ describes.realWin(
           })
           .then(async () => {
             const p = listenOncePromise(delight, VideoEvents.CUSTOM_TICK);
-            fakePostMessage(delight, {
+            await fakePostMessage(delight, {
               type: 'x-dl8-to-parent-amp-custom-tick',
               payload: {
                 type: 'delight-test-event',

--- a/extensions/amp-embedly-card/0.1/test/test-amp-embedly-card.js
+++ b/extensions/amp-embedly-card/0.1/test/test-amp-embedly-card.js
@@ -25,16 +25,14 @@ describes.realWin(
   },
   (env) => {
     let win;
-    let element;
 
     beforeEach(() => {
       win = env.win;
-      element = win.document.createElement('amp-embedly-card');
-      win.document.body.appendChild(element);
     });
 
     function createEmbedlyCard(dataUrl) {
       const element = win.document.createElement('amp-embedly-card');
+      element.setAttribute('layout', 'nodisplay');
 
       element.setAttribute('data-url', dataUrl);
       element.setAttribute('height', '100');
@@ -66,21 +64,17 @@ describes.realWin(
       );
     });
 
-    it('removes iframe after unlayoutCallback', () => {
-      return createEmbedlyCard('https://twitter.com/AMPhtml').then(
-        (element) => {
-          const iframe = element.querySelector('iframe');
+    it('removes iframe after unlayoutCallback', async () => {
+      const element = await createEmbedlyCard('https://twitter.com/AMPhtml');
+      const instance = await element.getImpl();
 
-          expect(iframe).to.not.be.null;
+      const iframe = element.querySelector('iframe');
+      expect(iframe).to.not.be.null;
 
-          const instance = element.implementation_;
+      instance.unlayoutCallback();
 
-          instance.unlayoutCallback();
-
-          expect(element.querySelector('iframe')).to.be.null;
-          expect(instance.iframe_).to.be.null;
-        }
-      );
+      expect(element.querySelector('iframe')).to.be.null;
+      expect(instance.iframe_).to.be.null;
     });
   }
 );

--- a/extensions/amp-sidebar/0.1/test/integration/test-amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/test/integration/test-amp-sidebar.js
@@ -87,10 +87,11 @@ describe
         it.configure()
           .skipIfPropertiesObfuscated()
           .skipFirefox()
-          .run('should not change scroll position after close', () => {
+          .run('should not change scroll position after close', async () => {
             const openerButton = win.document.getElementById('sidebarOpener');
             const sidebar = win.document.getElementById('sidebar1');
-            const viewport = sidebar.implementation_.getViewport();
+            const impl = await sidebar.getImpl(false);
+            const viewport = impl.getViewport();
             const openedPromise = waitForSidebarOpen(win.document);
             openerButton.click();
             expect(viewport.getScrollTop()).to.equal(0);

--- a/extensions/amp-sidebar/0.2/test/integration/test-amp-sidebar.js
+++ b/extensions/amp-sidebar/0.2/test/integration/test-amp-sidebar.js
@@ -87,10 +87,11 @@ describe
         it.configure()
           .skipIfPropertiesObfuscated()
           .skipFirefox()
-          .run('should not change scroll position after close', () => {
+          .run('should not change scroll position after close', async () => {
             const openerButton = win.document.getElementById('sidebarOpener');
             const sidebar = win.document.getElementById('sidebar1');
-            const viewport = sidebar.implementation_.getViewport();
+            const impl = await sidebar.getImpl(false);
+            const viewport = impl.getViewport();
             const openedPromise = waitForSidebarOpen(win.document);
             openerButton.click();
             expect(viewport.getScrollTop()).to.equal(0);

--- a/test/e2e/test-amp-bind-live-list.js
+++ b/test/e2e/test-amp-bind-live-list.js
@@ -67,7 +67,7 @@ describes.endtoend(
         );
 
         // The test server should handle this
-        // const impl = liveList.implementation_;
+        // const impl = await liveList.getImpl(false);
         // const update = document.createElement('div');
         // update.innerHTML =
         //     '<div items>' +

--- a/test/integration/test-amp-carousel.js
+++ b/test/integration/test-amp-carousel.js
@@ -161,10 +161,10 @@ t.run('amp-carousel', function () {
         expect(nextBtn).to.be.visible;
       });
 
-      it('should not be able to go past the first or last item', () => {
+      it('should not be able to go past the first or last item', async () => {
         document.body.classList.add('amp-mode-mouse');
         const amp = document.querySelector('#carousel-1');
-        const impl = amp.implementation_;
+        const impl = await amp.getImpl();
         const prevBtn = amp.querySelector('.amp-carousel-button-prev');
         const nextBtn = amp.querySelector('.amp-carousel-button-next');
         expect(prevBtn).to.have.class('amp-disabled');
@@ -181,10 +181,10 @@ t.run('amp-carousel', function () {
         expect(prevBtn).to.have.class('amp-disabled');
       });
 
-      it('should only have the prev button enabled when on last item', () => {
+      it('should only have the prev button enabled when on last item', async () => {
         document.body.classList.add('amp-mode-mouse');
         const amp = document.querySelector('#carousel-1');
-        const impl = amp.implementation_;
+        const impl = await amp.getImpl();
         const prevBtn = amp.querySelector('.amp-carousel-button-prev');
         const nextBtn = amp.querySelector('.amp-carousel-button-next');
         expect(prevBtn).to.have.class('amp-disabled');
@@ -327,10 +327,10 @@ t.run('amp-carousel', function () {
         expect(nextBtn).to.be.visible;
       });
 
-      it('should only have the prev button enabled when on last item', () => {
+      it('should only have the prev button enabled when on last item', async () => {
         document.body.classList.add('amp-mode-mouse');
         const amp = document.querySelector('#carousel-1');
-        const impl = amp.implementation_;
+        const impl = await amp.getImpl();
         const prevBtn = amp.querySelector('.amp-carousel-button-prev');
         const nextBtn = amp.querySelector('.amp-carousel-button-next');
         expect(prevBtn).to.have.class('amp-disabled');

--- a/test/integration/test-video-manager.js
+++ b/test/integration/test-video-manager.js
@@ -61,6 +61,19 @@ describe
         let video;
         let impl;
 
+        beforeEach(async () => {
+          klass = createFakeVideoPlayerClass(env.win);
+          video = env.createAmpElement('amp-test-fake-videoplayer', klass);
+          video.setAttribute('layout', 'fixed');
+          video.setAttribute('width', '400');
+          video.setAttribute('height', '300');
+          env.win.document.body.appendChild(video);
+          video.connectedCallback();
+          impl = await video.getImpl(false);
+          installVideoManagerForDoc(env.ampdoc);
+          videoManager = Services.videoManagerForDoc(env.ampdoc);
+        });
+
         it('should not duplicate entries if laid out twice', async () => {
           videoManager.register(impl);
           expect(videoManager.entries_).to.have.length(1);
@@ -260,15 +273,6 @@ describe
             const curState = videoManager.getPlayingState(impl);
             expect(curState).to.equal(PlayingStates.PLAYING_MANUAL);
           });
-        });
-
-        beforeEach(() => {
-          klass = createFakeVideoPlayerClass(env.win);
-          video = env.createAmpElement('amp-test-fake-videoplayer', klass);
-          env.win.document.body.appendChild(video);
-          impl = video.implementation_;
-          installVideoManagerForDoc(env.ampdoc);
-          videoManager = Services.videoManagerForDoc(env.ampdoc);
         });
       }
     );

--- a/test/integration/test-video-players-helper.js
+++ b/test/integration/test-video-players-helper.js
@@ -71,9 +71,11 @@ export function runVideoPlayerIntegrationTests(
 
       it('should override the video interface methods', function () {
         this.timeout(TIMEOUT);
-        return getVideoPlayer({outsideView: false, autoplay: true}).then(
-          (r) => {
-            const impl = r.video.implementation_;
+        return getVideoPlayer({outsideView: false, autoplay: true})
+          .then((r) => {
+            return r.video.getImpl(false);
+          })
+          .then((impl) => {
             const methods = Object.getOwnPropertyNames(
               Object.getPrototypeOf(new VideoInterface())
             );
@@ -83,8 +85,7 @@ export function runVideoPlayerIntegrationTests(
               const methodName = methods[i];
               expect(impl[methodName]).to.exist;
             }
-          }
-        );
+          });
       });
 
       afterEach(cleanUp);
@@ -161,10 +162,11 @@ export function runVideoPlayerIntegrationTests(
           outsideView: true,
           autoplay: false,
         })
-          .then((r) => {
+          .then(async (r) => {
             video = r.video;
             playButton = createButton(r, 'play');
-            const viewport = video.implementation_.getViewport();
+            const impl = await video.getImpl(false);
+            const viewport = impl.getViewport();
             const promise = listenOncePromise(video, VideoEvents.LOAD);
             viewport.scrollIntoView(video);
             return promise;
@@ -228,9 +230,10 @@ export function runVideoPlayerIntegrationTests(
           outsideView: true,
           autoplay: true,
         })
-          .then((r) => {
+          .then(async (r) => {
             video = r.video;
-            viewport = video.implementation_.getViewport();
+            const impl = await video.getImpl(false);
+            viewport = impl.getViewport();
             // scroll to the bottom, make video fully visible
             viewport.scrollIntoView(video);
             return listenOncePromise(video, VideoEvents.PLAYING);
@@ -321,7 +324,7 @@ export function runVideoPlayerIntegrationTests(
           autoplay: true,
         })
           .then((r) => {
-            timer = Services.timerFor(r.video.implementation_.win);
+            timer = Services.timerFor(r.video.ownerDocument.defaultView);
             video = r.video;
             pauseButton = createButton(r, 'pause');
             playButton = createButton(r, 'play');
@@ -333,8 +336,9 @@ export function runVideoPlayerIntegrationTests(
               timer.promise(2000),
             ]);
           })
-          .then(() => {
-            const viewport = video.implementation_.getViewport();
+          .then(async () => {
+            const impl = await video.getImpl(false);
+            const viewport = impl.getViewport();
             viewport.scrollIntoView(video);
             return listenOncePromise(
               video,
@@ -384,7 +388,7 @@ export function runVideoPlayerIntegrationTests(
 
       it('should not play when initially outside viewport', () => {
         return getVideoPlayer({outsideView: true, autoplay: true}).then((r) => {
-          const timer = Services.timerFor(r.video.implementation_.win);
+          const timer = Services.timerFor(r.video.ownerDocument.defaultView);
           const p = listenOncePromise(r.video, VideoEvents.PLAYING).then(() => {
             return Promise.reject('should not have autoplayed');
           });
@@ -399,9 +403,10 @@ export function runVideoPlayerIntegrationTests(
         let video;
         let viewport;
         return getVideoPlayer({outsideView: true, autoplay: true})
-          .then((r) => {
+          .then(async (r) => {
             video = r.video;
-            viewport = video.implementation_.getViewport();
+            const impl = await video.getImpl(false);
+            viewport = impl.getViewport();
 
             // scroll to the bottom, make video fully visible
             const p = listenOncePromise(video, VideoEvents.PLAYING);
@@ -430,13 +435,14 @@ export function runVideoPlayerIntegrationTests(
               return !!video.querySelector('i-amphtml-video-eq');
             });
           })
-          .then(() => {
+          .then(async () => {
             icon = video.querySelector('i-amphtml-video-eq');
             expect(icon).to.exist;
             // animation should be paused since video is not played yet
             expect(isAnimationPaused(icon)).to.be.true;
 
-            viewport = video.implementation_.getViewport();
+            const impl = await video.getImpl(false);
+            viewport = impl.getViewport();
             // scroll to the bottom, make video fully visible so it autoplays
             viewport.scrollIntoView(video);
 
@@ -511,12 +517,13 @@ export function runVideoPlayerIntegrationTests(
           outsideView: true,
           'rotate-to-fullscreen': true,
         })
-          .then((r) => {
+          .then(async (r) => {
             video = r.video;
             playButton = createButton(r, 'play');
             mockLandscape(false);
             const whenLoaded = listenOncePromise(video, VideoEvents.LOAD);
-            const viewport = video.implementation_.getViewport();
+            const impl = await video.getImpl(false);
+            const viewport = impl.getViewport();
             viewport.scrollIntoView(video);
             return whenLoaded;
           })
@@ -525,11 +532,9 @@ export function runVideoPlayerIntegrationTests(
             playButton.click();
             return whenPlaying;
           })
-          .then(() => {
-            const enter = window.sandbox.stub(
-              video.implementation_,
-              'fullscreenEnter'
-            );
+          .then(async () => {
+            const impl = await video.getImpl(false);
+            const enter = window.sandbox.stub(impl, 'fullscreenEnter');
             mockLandscape(true);
             autoFullscreen.onRotation_();
             return poll('fullscreen enter', () => enter.called);

--- a/test/integration/test-visibility-states.js
+++ b/test/integration/test-visibility-states.js
@@ -153,32 +153,16 @@ t.run('Viewer Visibility State', () => {
             return whenUpgradedToCustomElement(img);
           })
           .then((img) => {
-            layoutCallback = env.sandbox.stub(
-              img.implementation_,
-              'layoutCallback'
-            );
-            unlayoutCallback = env.sandbox.stub(
-              img.implementation_,
-              'unlayoutCallback'
-            );
-            pauseCallback = env.sandbox.stub(
-              img.implementation_,
-              'pauseCallback'
-            );
-            resumeCallback = env.sandbox.stub(
-              img.implementation_,
-              'resumeCallback'
-            );
-            prerenderAllowed = env.sandbox.stub(
-              img.implementation_,
-              'prerenderAllowed'
-            );
-            env.sandbox
-              .stub(img.implementation_, 'isRelayoutNeeded')
-              .callsFake(() => true);
-            env.sandbox
-              .stub(img.implementation_, 'isLayoutSupported')
-              .callsFake(() => true);
+            return img.getImpl(false);
+          })
+          .then((impl) => {
+            layoutCallback = env.sandbox.stub(impl, 'layoutCallback');
+            unlayoutCallback = env.sandbox.stub(impl, 'unlayoutCallback');
+            pauseCallback = env.sandbox.stub(impl, 'pauseCallback');
+            resumeCallback = env.sandbox.stub(impl, 'resumeCallback');
+            prerenderAllowed = env.sandbox.stub(impl, 'prerenderAllowed');
+            env.sandbox.stub(impl, 'isRelayoutNeeded').callsFake(() => true);
+            env.sandbox.stub(impl, 'isLayoutSupported').callsFake(() => true);
 
             layoutCallback.returns(Promise.resolve());
             unlayoutCallback.returns(true);

--- a/test/unit/preact/test-base-element-mapping.js
+++ b/test/unit/preact/test-base-element-mapping.js
@@ -399,7 +399,8 @@ describes.realWin('PreactBaseElement', spec, (env) => {
 
       it('should rerender after SSR hydration', async () => {
         // Only rendering updates attributes.
-        element.implementation_.mutateProps({name: 'A'});
+        const impl = await element.getImpl();
+        impl.mutateProps({name: 'A'});
         await waitFor(() => component.callCount > 1, 'component rendered');
         expect(component).to.be.calledTwice;
         expect(componentEl.getAttribute('data-name')).to.equal('A');

--- a/test/unit/test-amp-pixel.js
+++ b/test/unit/test-amp-pixel.js
@@ -23,7 +23,6 @@ describes.realWin('amp-pixel', {amp: true}, (env) => {
   let win;
   let whenFirstVisiblePromise, whenFirstVisibleResolver;
   let pixel;
-  let implementation;
 
   beforeEach(() => {
     win = env.win;
@@ -43,9 +42,7 @@ describes.realWin('amp-pixel', {amp: true}, (env) => {
       pixel.setAttribute('referrerpolicy', referrerPolicy);
     }
     win.document.body.appendChild(pixel);
-    const buildPromise = pixel.build();
-    implementation = pixel.implementation_;
-    return buildPromise;
+    return pixel.build();
   }
 
   /**
@@ -57,10 +54,14 @@ describes.realWin('amp-pixel', {amp: true}, (env) => {
       pixel.setAttribute('src', opt_src);
     }
     whenFirstVisibleResolver();
-    return whenFirstVisiblePromise.then(() => {
-      expect(implementation.triggerPromise_).to.be.not.null;
-      return implementation.triggerPromise_;
-    });
+    return whenFirstVisiblePromise
+      .then(() => {
+        return pixel.getImpl(false);
+      })
+      .then((impl) => {
+        expect(impl.triggerPromise_).to.be.not.null;
+        return impl.triggerPromise_;
+      });
   }
 
   it('should be non-displayed', () => {
@@ -70,7 +71,8 @@ describes.realWin('amp-pixel', {amp: true}, (env) => {
     expect(pixel).to.have.display('none');
   });
 
-  it('should NOT trigger when src is empty', () => {
+  it('should NOT trigger when src is empty', async () => {
+    const implementation = await pixel.getImpl(false);
     expect(pixel.children).to.have.length(0);
     expect(implementation.triggerPromise_).to.be.null;
     return trigger('').then((img) => {
@@ -79,7 +81,8 @@ describes.realWin('amp-pixel', {amp: true}, (env) => {
     });
   });
 
-  it('should trigger when doc becomes visible', () => {
+  it('should trigger when doc becomes visible', async () => {
+    const implementation = await pixel.getImpl(false);
     expect(pixel.children).to.have.length(0);
     expect(implementation.triggerPromise_).to.be.null;
     return trigger().then((img) => {
@@ -167,7 +170,7 @@ describes.realWin(
     let pixel;
     let implementation;
 
-    beforeEach(() => {
+    beforeEach(async () => {
       win = env.win;
 
       whenFirstVisiblePromise = new Promise((resolve) => {
@@ -185,8 +188,8 @@ describes.realWin(
         'https://pubads.g.doubleclick.net/activity;dc_iu=1/abc;ord=1?'
       );
       win.document.body.appendChild(pixel);
-      pixel.build();
-      implementation = pixel.implementation_;
+      await pixel.build();
+      implementation = await pixel.getImpl();
     });
 
     /**


### PR DESCRIPTION
Partial for #31915.

This only affects tests. No code changes. Most of changes are replacing `x.implementation_` with `await x.getImpl()`. 

However, there's an important purpose for this change: the tests no longer rely here on the implementation being immediately available when a DOM element is created. This is a big downpayment for the remainder of the refactoring.