### PR TITLE
🔥 [amp-video] Don't update isPlaying if managed by stories

### DIFF
--- a/extensions/amp-video/0.1/amp-video.js
+++ b/extensions/amp-video/0.1/amp-video.js
@@ -248,9 +248,9 @@ class AmpVideo extends AMP.BaseElement {
   }
 
   /** @override */
-  detachedCallback() {
-    this.updateIsPlaying_(false);
-  }
+  // detachedCallback() {
+  //   this.updateIsPlaying_(false);
+  // }
 
   /** @private */
   configure_() {
@@ -604,16 +604,16 @@ class AmpVideo extends AMP.BaseElement {
       })
     );
 
-    ['play', 'pause', 'ended'].forEach((type) => {
-      this.unlisteners_.push(
-        listen(video, type, () => this.updateIsPlaying_(type == 'play'))
-      );
-    });
+    // ['play', 'pause', 'ended'].forEach((type) => {
+    //   this.unlisteners_.push(
+    //     listen(video, type, () => this.updateIsPlaying_(type == 'play'))
+    //   );
+    // });
   }
 
   /** @private */
   uninstallEventHandlers_() {
-    this.updateIsPlaying_(false);
+    // this.updateIsPlaying_(false);
     while (this.unlisteners_.length) {
       this.unlisteners_.pop().call();
     }

--- a/extensions/amp-video/0.1/amp-video.js
+++ b/extensions/amp-video/0.1/amp-video.js
@@ -248,9 +248,9 @@ class AmpVideo extends AMP.BaseElement {
   }
 
   /** @override */
-  // detachedCallback() {
-  //   this.updateIsPlaying_(false);
-  // }
+  detachedCallback() {
+    this.updateIsPlaying_(false);
+  }
 
   /** @private */
   configure_() {
@@ -604,16 +604,16 @@ class AmpVideo extends AMP.BaseElement {
       })
     );
 
-    // ['play', 'pause', 'ended'].forEach((type) => {
-    //   this.unlisteners_.push(
-    //     listen(video, type, () => this.updateIsPlaying_(type == 'play'))
-    //   );
-    // });
+    ['play', 'pause', 'ended'].forEach((type) => {
+      this.unlisteners_.push(
+        listen(video, type, () => this.updateIsPlaying_(type == 'play'))
+      );
+    });
   }
 
   /** @private */
   uninstallEventHandlers_() {
-    // this.updateIsPlaying_(false);
+    this.updateIsPlaying_(false);
     while (this.unlisteners_.length) {
       this.unlisteners_.pop().call();
     }
@@ -643,6 +643,9 @@ class AmpVideo extends AMP.BaseElement {
 
   /** @private */
   updateIsPlaying_(isPlaying) {
+    if (this.isManagedByPool_()) {
+      return;
+    }
     if (isPlaying === this.isPlaying_) {
       return;
     }


### PR DESCRIPTION
Context #32323

In a story with more than 8 videos, the next videos won't play. 

This bug was introduced in #31976, where `amp-video` introduces a `detachedCallback()` which calls `this.updateIsPlaying_(false)`;

In stories the media pool recycles videos (detaches and re-attaches same video elements in the DOM), which means that whenever a video is detached from the DOM it will call `this.updateIsPlaying_(false)` and `unobserveDisplay()`. This last one is causing videos to not play.


<!--
# Instructions:

- Pick a meaningful title for your pull request. (Use sentence case.)
  - Prefix the title with an emoji to identify what is being done. (Copy-paste the emoji from the list below.)
  - Do not overuse punctuation in the title (like `(chore):`).
  - If it is helpful, use a simple prefix (like `ProjectX: Implement some feature`).
- Enter a succinct description that says why the PR is necessary, and what it does.
  - Mention the GitHub issue that is being addressed by the pull request.
  - The keywords `Fixes`, `Closes`, or `Resolves` followed the issue number will automatically close the issue.

> NOTE: All non-trivial changes (like introducing new features or components) should have an associated issue or reference an I2I (intent-to-implement: go.amp.dev/i2i). Please read through the contribution process (go.amp.dev/contributing/code) for more information.

# Example of a good description:

- Implement aspect X
- Leave out feature Y because of A
- Improve performance by B
- Improve accessibility by C

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Reverting a previous change
♻️ Refactoring
🚮 Deleting code
🧪 Experimental code
-->
