### PR TITLE
📖 Add syntax highlighting in Bento documentation code snippets

### DIFF
--- a/extensions/amp-date-countdown/amp-date-countdown.md
+++ b/extensions/amp-date-countdown/amp-date-countdown.md
@@ -107,7 +107,7 @@ The example below demonstrates `amp-date-countdown` component in standalone use.
 
 [example preview="top-frame" playground="false"]
 
-```
+```html
 <head>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <link rel="stylesheet" type="text/css" href="https://cdn.ampproject.org/v0/amp-date-countdown.css">
@@ -152,7 +152,7 @@ The example below demonstrates `amp-date-countdown` component in standalone use.
 
 Each Bento component has a small CSS library you must include to guarantee proper loading without [content shifts](https://web.dev/cls/). Because of order-based specificity, you must manually ensure that stylesheets are included before any custom styles.
 
-```
+```html
 <link rel="stylesheet" type="text/css" href="https://cdn.ampproject.org/v0/amp-date-countdown-1.0.css">
 ```
 

--- a/extensions/amp-fit-text/amp-fit-text.md
+++ b/extensions/amp-fit-text/amp-fit-text.md
@@ -76,7 +76,7 @@ The example below demonstrates `amp-fit-text` component in standalone use.
 
 [example preview="top-frame" playground="false"]
 
-```
+```html
 <head>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <link rel="stylesheet" type="text/css" href="https://cdn.ampproject.org/v0/amp-fit-text-1.0.css">
@@ -114,7 +114,7 @@ The example below demonstrates `amp-fit-text` component in standalone use.
 
 Each Bento component has a small CSS library you must include to guarantee proper loading without [content shifts](https://web.dev/cls/). Because of order-based specificity, you must manually ensure that stylesheets are included before any custom styles.
 
-```
+```html
 <link rel="stylesheet" type="text/css" href="https://cdn.ampproject.org/v0/amp-fit-text-1.0.css">
 ```
 

--- a/extensions/amp-inline-gallery/amp-inline-gallery.md
+++ b/extensions/amp-inline-gallery/amp-inline-gallery.md
@@ -81,7 +81,7 @@ The example below demonstrates `amp-inline-gallery` component in standalone use.
 
 [example preview="top-frame" playground="false"]
 
-```
+```html
 <head>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <link rel="stylesheet" type="text/css" href="https://cdn.ampproject.org/v0/amp-inline-gallery-1.0.css">
@@ -182,7 +182,7 @@ The `amp-inline-gallery` component is used in combination with `amp-base-carouse
 
 Each Bento component has a small CSS library you must include to guarantee proper loading without [content shifts](https://web.dev/cls/). Because of order-based specificity, you must manually ensure that stylesheets are included before any custom styles.
 
-```
+```html
 <link rel="stylesheet" type="text/css" href="https://cdn.ampproject.org/v0/amp-inline-gallery-1.0.css">
 <link rel="stylesheet" type="text/css" href="https://cdn.ampproject.org/v0/amp-base-carousel-1.0.css">
 ```

--- a/extensions/amp-instagram/amp-instagram.md
+++ b/extensions/amp-instagram/amp-instagram.md
@@ -61,7 +61,7 @@ The example below demonstrates `amp-instagram` component in standalone use.
 
 [example preview="top-frame" playground="false"]
 
-```
+```html
 <head>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <link rel="stylesheet" type="text/css" href="https://cdn.ampproject.org/v0/amp-instagram-1.0.css">
@@ -81,7 +81,7 @@ The example below demonstrates `amp-instagram` component in standalone use.
 
 Each Bento component has a small CSS library you must include to guarantee proper loading without [content shifts](https://web.dev/cls/). Because of order-based specificity, you must manually ensure that stylesheets are included before any custom styles.
 
-```
+```html
 <link rel="stylesheet" type="text/css" href="https://cdn.ampproject.org/v0/amp-instagram-1.0.css">
 ```
 

--- a/extensions/amp-lightbox/amp-lightbox.md
+++ b/extensions/amp-lightbox/amp-lightbox.md
@@ -85,7 +85,7 @@ Bento enabled components in standalone use are highly interactive through their 
 
 The `amp-lightbox` component API is accessible by including the following script tag in your document:
 
-```
+```js
 await customElements.whenDefined('amp-lightbox');
 const api = await lightbox.getApi();
 ```
@@ -97,14 +97,14 @@ The `amp-lightbox` API allows you to perform the following actions:
 **open()**
 Opens the lightbox.
 
-```
+```js
 api.open();
 ```
 
 **close()**
 Closes the lightbox.
 
-```
+```js
 api.close();
 ```
 
@@ -116,7 +116,7 @@ The `amp-lightbox` API allows you to register and respond to the following event
 
 This event is triggered when the lightbox is opened.
 
-```
+```js
 lightbox.addEventListener('open', (e) => console.log(e))
 ```
 
@@ -124,7 +124,7 @@ lightbox.addEventListener('open', (e) => console.log(e))
 
 This event is triggered when the lightbox is closed.
 
-```
+```js
 lightbox.addEventListener('close', (e) => console.log(e))
 ```
 
@@ -132,7 +132,7 @@ lightbox.addEventListener('close', (e) => console.log(e))
 
 Each Bento component has a small CSS library you must include to guarantee proper loading without [content shifts](https://web.dev/cls/). Because of order-based specificity, you must manually ensure that stylesheets are included before any custom styles.
 
-```
+```html
 <link rel="stylesheet" type="text/css" href="https://cdn.ampproject.org/v0/amp-lightbox-1.0.css">
 ```
 

--- a/extensions/amp-selector/amp-selector.md
+++ b/extensions/amp-selector/amp-selector.md
@@ -152,7 +152,7 @@ Bento enabled components in standalone use are highly interactive through their 
 
 The `amp-selector` component API is accessible by including the following script tag in your document:
 
-```
+```js
 await customElements.whenDefined("amp-selector");
 const api = await selector.getApi();
 ```
@@ -164,7 +164,7 @@ The `amp-selector` API allows you to perform the following actions:
 **selectBy(delta: number)**
 Closes the selector.
 
-```
+```js
 api.selectBy(1); // Select next option in DOM sequence.
 api.selectBy(-2); // Select the option that is two previous in DOM sequence.
 ```
@@ -172,7 +172,7 @@ api.selectBy(-2); // Select the option that is two previous in DOM sequence.
 **toggle(optionValue: string, opt_select: boolean|undefined)**
 Toggles the option with the given `optionValue` to be selected or deselected based on `opt_select`. If `opt_select` is not present, then the option will be selected if currently not selected, and deselected if currently selected.
 
-```
+```js
 api.toggle("a"); // Toggle the item with the attribute `option="a"`.
 api.toggle("1", true); // Select the item with the attribute `option="1"`.
 ```
@@ -195,7 +195,7 @@ Tapping disabled options does not trigger the `select` event.
   </li>
 </ul>
 
-```
+```js
 selector.addEventListener("select", (e) => console.log(e.data.targetOption))
 ```
 
@@ -203,7 +203,7 @@ selector.addEventListener("select", (e) => console.log(e.data.targetOption))
 
 Each Bento component has a small CSS library you must include to guarantee proper loading without [content shifts](https://web.dev/cls/). Because of order-based specificity, you must manually ensure that stylesheets are included before any custom styles.
 
-```
+```html
 <link rel="stylesheet" type="text/css" href="https://cdn.ampproject.org/v0/amp-selector-1.0.css">
 ```
 

--- a/extensions/amp-stream-gallery/amp-stream-gallery.md
+++ b/extensions/amp-stream-gallery/amp-stream-gallery.md
@@ -69,7 +69,7 @@ The example below demonstrates `amp-stream-gallery` component in standalone use.
 
 [example preview="top-frame" playground="false"]
 
-```
+```html
 <head>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <link rel="stylesheet" type="text/css" href="https://cdn.ampproject.org/v0/amp-stream-gallery-1.0.css">
@@ -160,7 +160,7 @@ Bento enabled components in standalone use are highly interactive through their 
 
 The `amp-stream-gallery` component API is accessible by including the following script tag in your document:
 
-```
+```js
 await customElements.whenDefined('amp-stream-gallery');
 const api = await carousel.getApi();
 ```
@@ -172,14 +172,14 @@ The `amp-stream-gallery` API allows you to perform the following actions:
 **next()**
 Moves the carousel forwards by `advance-count` slides.
 
-```
+```js
 api.next();
 ```
 
 **prev()**
 Moves the carousel backwards by `advance-count` slides.
 
-```
+```js
 api.prev();
 ```
 
@@ -187,7 +187,7 @@ api.prev();
 Moves the carousel to the slide specified by the `index` argument.
 Note: `index` will be normalized to a number greater than or equal to `0` and less than the number of slides given.
 
-```
+```js
 api.goToSlide(0); // Advance to first slide.
 api.goToSlide(length - 1); // Advance to last slide.
 ```
@@ -201,7 +201,7 @@ The `amp-stream-gallery` API allows you to register and respond to the following
 This event is triggered when the index displayed by the carousel has changed.
 The new index is available via `event.data.index`.
 
-```
+```js
 carousel.addEventListener('slideChange', (e) => console.log(e.data.index))
 ```
 
@@ -209,7 +209,7 @@ carousel.addEventListener('slideChange', (e) => console.log(e.data.index))
 
 Each Bento component has a small CSS library you must include to guarantee proper loading without [content shifts](https://web.dev/cls/). Because of order-based specificity, you must manually ensure that stylesheets are included before any custom styles.
 
-```
+```html
 <link rel="stylesheet" type="text/css" href="https://cdn.ampproject.org/v0/amp-stream-gallery-1.0.css">
 ```
 

--- a/extensions/amp-timeago/amp-timeago.md
+++ b/extensions/amp-timeago/amp-timeago.md
@@ -62,7 +62,7 @@ The example below demonstrates `amp-timeago` component in standalone use.
 
 [example preview="top-frame" playground="false"]
 
-```
+```html
 <head>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <link rel="stylesheet" type="text/css" href="https://cdn.ampproject.org/v0/amp-timeago-1.0.css">
@@ -101,7 +101,7 @@ The example below demonstrates `amp-timeago` component in standalone use.
 
 Each Bento component has a small CSS library you must include to guarantee proper loading without [content shifts](https://web.dev/cls/). Because of order-based specificity, you must manually ensure that stylesheets are included before any custom styles.
 
-```
+```html
 <link rel="stylesheet" type="text/css" href="https://cdn.ampproject.org/v0/amp-timeago-1.0.css">
 ```
 

--- a/extensions/amp-video/amp-video.md
+++ b/extensions/amp-video/amp-video.md
@@ -113,7 +113,7 @@ Bento enabled components in standalone use are highly interactive through their 
 
 The `amp-video` component API is accessible by including the following script tag in your document:
 
-```
+```js
 await customElements.whenDefined('amp-video');
 const videoHandle = await video.getApi();
 ```
@@ -126,7 +126,7 @@ The `amp-video` API allows you to perform the following actions:
 
 Plays the video.
 
-```
+```js
 videoHandle.play();
 ```
 
@@ -134,7 +134,7 @@ videoHandle.play();
 
 Pauses the video.
 
-```
+```js
 videoHandle.pause();
 ```
 
@@ -142,7 +142,7 @@ videoHandle.pause();
 
 Mutes the video.
 
-```
+```js
 videoHandle.mute();
 ```
 
@@ -150,7 +150,7 @@ videoHandle.mute();
 
 Unmutes the video.
 
-```
+```js
 videoHandle.unmute();
 ```
 
@@ -158,7 +158,7 @@ videoHandle.unmute();
 
 Expands the video to fullscreen when possible.
 
-```
+```js
 videoHandle.requestFullscreen();
 ```
 
@@ -170,7 +170,7 @@ It also exposes the following read-only properties:
 
 The current playback time in seconds.
 
-```
+```js
 console.log(videoHandle.currentTime);
 ```
 
@@ -178,7 +178,7 @@ console.log(videoHandle.currentTime);
 
 The video's duration in seconds, when it's known (e.g. is not a livestream).
 
-```
+```js
 console.log(videoHandle.duration);
 ```
 
@@ -186,7 +186,7 @@ console.log(videoHandle.duration);
 
 Whether the video autoplays.
 
-```
+```js
 console.log(videoHandle.autoplay);
 ```
 
@@ -194,7 +194,7 @@ console.log(videoHandle.autoplay);
 
 Whether the video shows controls.
 
-```
+```js
 console.log(videoHandle.controls);
 ```
 
@@ -202,7 +202,7 @@ console.log(videoHandle.controls);
 
 Whether the video loops.
 
-```
+```js
 console.log(videoHandle.loop);
 ```
 

--- a/extensions/amp-youtube/amp-youtube.md
+++ b/extensions/amp-youtube/amp-youtube.md
@@ -109,7 +109,7 @@ Bento enabled components in standalone use are highly interactive through their 
 
 The `amp-youtube` component API is accessible by including the following script tag in your document:
 
-```
+```js
 await customElements.whenDefined('amp-youtube');
 const videoHandle = await video.getApi();
 ```
@@ -122,7 +122,7 @@ The `amp-youtube` API allows you to perform the following actions:
 
 Plays the video.
 
-```
+```js
 videoHandle.play();
 ```
 
@@ -130,7 +130,7 @@ videoHandle.play();
 
 Pauses the video.
 
-```
+```js
 videoHandle.pause();
 ```
 
@@ -138,7 +138,7 @@ videoHandle.pause();
 
 Mutes the video.
 
-```
+```js
 videoHandle.mute();
 ```
 
@@ -146,7 +146,7 @@ videoHandle.mute();
 
 Unmutes the video.
 
-```
+```js
 videoHandle.unmute();
 ```
 
@@ -154,7 +154,7 @@ videoHandle.unmute();
 
 Expands the video to fullscreen when possible.
 
-```
+```js
 videoHandle.requestFullscreen();
 ```
 
@@ -166,7 +166,7 @@ It also exposes the following read-only properties:
 
 The current playback time in seconds.
 
-```
+```js
 console.log(videoHandle.currentTime);
 ```
 
@@ -174,7 +174,7 @@ console.log(videoHandle.currentTime);
 
 The video's duration in seconds, when it's known (e.g. is not a livestream).
 
-```
+```js
 console.log(videoHandle.duration);
 ```
 
@@ -182,7 +182,7 @@ console.log(videoHandle.duration);
 
 Whether the video autoplays.
 
-```
+```js
 console.log(videoHandle.autoplay);
 ```
 
@@ -190,7 +190,7 @@ console.log(videoHandle.autoplay);
 
 Whether the video shows controls.
 
-```
+```js
 console.log(videoHandle.controls);
 ```
 
@@ -198,7 +198,7 @@ console.log(videoHandle.controls);
 
 Whether the video loops.
 
-```
+```js
 console.log(videoHandle.loop);
 ```
 


### PR DESCRIPTION
In addition to helping code snippets be more readable in their language, I assume this change will help that some of the code snippets are not correctly escaping, like this `[/example]` here: https://amp.dev/documentation/components/amp-inline-gallery-v1.0/?format=websites#example

This assumption is based off of #32285 fixing the above problem for `amp-base-carousel`.

![image](https://user-images.githubusercontent.com/10456171/106653965-7ab95280-6565-11eb-956d-eaefa3fe7524.png)
 