### PR TITLE
🏗  Run GH actions workflow only for `ampproject/amphtml` PRs and pushes

### DIFF
--- a/.github/workflows/cross-browser-tests.yml
+++ b/.github/workflows/cross-browser-tests.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   build:
+    if: github.repository == 'ampproject/amphtml'
     strategy:
       matrix:
         platform: [ubuntu-latest, macos-latest, windows-latest]


### PR DESCRIPTION
AMP's GitHub actions workflow is designed to run on PRs and pushes _to_ `ampproject/amphtml`. However, it isn't designed to run for PRs _from_ `ampproject/amphtml` to other forks. Doing so can mess with our custom apps. Example: [this build](https://github.com/ConnectionMaster/amphtml/runs/1816726939?check_suite_focus=true#step:5:1010) on some other fork.

This PR adds a rule so the workflow only runs for PRs and pushes to our repo.

**References:**
- https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions
- https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#github-context
