### PR TITLE
🖍 Bento: Move amp-fit-text to shadowCss

### DIFF
--- a/extensions/amp-fit-text/1.0/base-element.js
+++ b/extensions/amp-fit-text/1.0/base-element.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {CSS} from './component.jss';
 import {FitText} from './component';
 import {PreactBaseElement} from '../../../src/preact/base-element';
 
@@ -33,3 +34,6 @@ BaseElement['passthrough'] = true;
 
 /** @override */
 BaseElement['layoutSizeDefined'] = true;
+
+/** @override */
+BaseElement['shadowCss'] = CSS;

--- a/extensions/amp-fit-text/1.0/component.js
+++ b/extensions/amp-fit-text/1.0/component.js
@@ -15,13 +15,11 @@
  */
 
 import * as Preact from '../../../src/preact';
-import * as styles from './component.css';
 import {ContainWrapper} from '../../../src/preact/component';
+import {LINE_HEIGHT_EM_, useStyles} from './component.jss';
 import {px, resetStyles, setStyle, setStyles} from '../../../src/style';
 import {toWin} from '../../../src/types';
 import {useCallback, useLayoutEffect, useRef} from '../../../src/preact';
-
-const {LINE_HEIGHT_EM_} = styles;
 
 /**
  * @param {!FitTextProps} props
@@ -33,6 +31,7 @@ export function FitText({
   maxFontSize = 72,
   ...rest
 }) {
+  const classes = useStyles();
   const containerRef = useRef(null);
   const measurerRef = useRef(null);
   const heightRef = useRef(null);
@@ -76,12 +75,12 @@ export function FitText({
       layout={true}
       paint={true}
       ref={containerRef}
-      wrapperStyle={styles.fitTextContentWrapper}
+      wrapperClassName={classes.fitTextContentWrapper}
       contentRef={measurerRef}
-      contentStyle={styles.fitTextContent}
+      contentClassName={classes.fitTextContent}
       {...rest}
     >
-      <div ref={heightRef} style={styles.minContentHeight}>
+      <div ref={heightRef} className={classes.minContentHeight}>
         {children}
       </div>
     </ContainWrapper>

--- a/extensions/amp-fit-text/1.0/component.jss.js
+++ b/extensions/amp-fit-text/1.0/component.jss.js
@@ -14,9 +14,11 @@
  * limitations under the License.
  */
 
+import {createUseStyles} from 'react-jss';
+
 export const LINE_HEIGHT_EM_ = 1.15;
 
-export const fitTextContentWrapper = {
+const fitTextContentWrapper = {
   'display': 'flex',
   'flexDirection': 'column',
   'flexWrap': 'nowrap',
@@ -25,7 +27,7 @@ export const fitTextContentWrapper = {
 
 /* Legacy comment: We have to use the old-style flex box with line clamping. It will only
     work in WebKit, but unfortunately there's no alternative. */
-export const fitTextContent = {
+const fitTextContent = {
   lineHeight: `${LINE_HEIGHT_EM_}em`,
   'display': '-webkit-box',
   '-webkit-box-orient': 'vertical',
@@ -33,6 +35,16 @@ export const fitTextContent = {
   'textOverflow': 'ellipsis',
 };
 
-export const minContentHeight = {
+const minContentHeight = {
   'height': 'min-content',
 };
+
+const JSS = {
+  fitTextContentWrapper,
+  fitTextContent,
+  minContentHeight,
+};
+
+// useStyles gets replaced for AMP builds via `babel-plugin-transform-jss`.
+// eslint-disable-next-line local/no-export-side-effect
+export const useStyles = createUseStyles(JSS);


### PR DESCRIPTION
We moved to JSS after this component was implemented, so this PR brings the style-setting process up to date for this component. Partial for #28281