### PR TITLE
Allow more SVG filter primitive elements

### DIFF
--- a/validator/testdata/feature_tests/svg-filter-primitive-elements.html
+++ b/validator/testdata/feature_tests/svg-filter-primitive-elements.html
@@ -1,0 +1,217 @@
+<!--
+  Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS-IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the license.
+-->
+<!--
+  Test Description:
+  Tests SVG filter primitive elements.
+-->
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <link rel="canonical" href="./regular-html-version.html">
+  <meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=1,user-scalable=no,minimal-ui">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+</head>
+<body>
+  <!-- Valid: feBlend -->
+  <svg>
+    <defs>
+      <filter id="spotlight">
+        <feFlood result="floodFill" x="0" y="0" width="100%" height="100%"
+            flood-color="green" flood-opacity="1"/>
+        <feBlend in="SourceGraphic" in2="floodFill" mode="multiply"/>
+      </filter>
+    </defs>
+  </svg>
+
+  <!-- Valid: feComponentTransfer -->
+  <svg>
+    <defs>
+      <filter id="identity" x="0" y="0" width="100%" height="100%">
+        <feComponentTransfer>
+          <feFuncR type="identity"></feFuncR>
+          <feFuncG type="identity"></feFuncG>
+          <feFuncB type="identity"></feFuncB>
+          <feFuncA type="identity"></feFuncA>
+        </feComponentTransfer>
+      </filter>
+      <filter id="table" x="0" y="0" width="100%" height="100%">
+        <feComponentTransfer>
+          <feFuncR type="table" tableValues="0 0 1 1"></feFuncR>
+          <feFuncG type="table" tableValues="1 1 0 0"></feFuncG>
+          <feFuncB type="table" tableValues="0 1 1 0"></feFuncB>
+        </feComponentTransfer>
+      </filter>
+      <filter id="linear" x="0" y="0" width="100%" height="100%">
+        <feComponentTransfer>
+          <feFuncR type="linear" slope="0.5" intercept="0"></feFuncR>
+          <feFuncG type="linear" slope="0.5" intercept="0.25"></feFuncG>
+          <feFuncB type="linear" slope="0.5" intercept="0.5"></feFuncB>
+        </feComponentTransfer>
+      </filter>
+    </defs>
+  </svg>
+
+  <!-- Valid: feConvolveMatrix -->
+  <svg>
+    <defs>
+      <filter id="emboss">
+        <feConvolveMatrix
+            kernelMatrix="3 0 0
+                          0 0 0
+                          0 0 -3"/>
+      </filter>
+    </defs>
+    <image xlink:href="/foo.svg" x="0" y="0"
+        height="200" width="200" style="filter:url(#emboss);" />
+  </svg>
+
+  <!-- Valid: feDiffuseLighting -->
+  <svg>
+    <text text-anchor="middle" x="170" y="22">fePointLight</text>
+    <filter id="lightMe1">
+      <feDiffuseLighting in="SourceGraphic" result="light"
+          lighting-color="white">
+        <fePointLight x="150" y="60" z="20" />
+      </feDiffuseLighting>
+      <feComposite in="SourceGraphic" in2="light"
+                   operator="arithmetic" k1="1" k2="0" k3="0" k4="0"/>
+    </filter>
+    <circle cx="170" cy="80" r="50" fill="green"
+        filter="url(#lightMe1)" />
+  </svg>
+
+  <!-- Valid: feDisplacementMap -->
+  <svg>
+    <filter id="displacementFilter">
+      <feTurbulence type="turbulence" baseFrequency="0.05"
+          numOctaves="2" result="turbulence"/>
+      <feDisplacementMap in2="turbulence" in="SourceGraphic"
+          scale="50" xChannelSelector="R" yChannelSelector="G"/>
+    </filter>
+    <circle cx="100" cy="100" r="100"
+        style="filter: url(#displacementFilter)"/>
+  </svg>
+
+  <!-- Valid: feDropShadow -->
+  <svg>
+    <defs>
+      <filter id="shadow">
+        <feDropShadow dx="0.2" dy="0.4" stdDeviation="0.2"/>
+      </filter>
+    </defs>
+    <circle cx="5" cy="50%" r="4"
+        style="fill:pink; filter:url(#shadow);"/>
+  </svg>
+
+  <!-- Valid: feMorphology -->
+  <svg>
+    <filter id="erode">
+      <feMorphology operator="erode" radius="1"/>
+    </filter>
+    <filter id="dilate">
+      <feMorphology operator="dilate" radius="2"/>
+    </filter>
+    <text y="1em">Normal text</text>
+    <text id="thin" y="2em">Thinned text</text>
+    <text id="thick" y="3em">Fattened text</text>
+  </svg>
+
+  <!-- Valid: fePointLight -->
+  <svg>
+   <defs>
+      <filter id="spotlight">
+        <feSpecularLighting result="spotlight" specularConstant="1.5"
+            specularExponent="80" lighting-color="#FFF">
+          <fePointLight x="50" y="50" z="220"/>
+        </feSpecularLighting>
+        <feComposite in="SourceGraphic" in2="spotlight" operator="arithmetic"
+            k1="0" k2="1" k3="1" k4="0"/>
+      </filter>
+    </defs>
+    <image xlink:href="/foo.png" x="10%" y="10%"
+        width="80%" height="80%" style="filter:url(#spotlight);"/>
+  </svg>
+
+  <!-- Valid: feSpecularLighting -->
+  <svg>
+    <filter id = "filter">
+      <feSpecularLighting result="specOut"
+          specularExponent="20" lighting-color="#bbbbbb">
+        <fePointLight x="50" y="75" z="200"/>
+      </feSpecularLighting>
+      <feComposite in="SourceGraphic" in2="specOut"
+          operator="arithmetic" k1="0" k2="1" k3="1" k4="0"/>
+    </filter>
+    <circle cx="110" cy="110" r="100" style="filter:url(#filter)"/>
+  </svg>
+
+  <!-- Valid: feSpotlight -->
+  <svg>
+    <defs>
+      <filter id="spotlight">
+        <feSpecularLighting result="spotlight" specularConstant="1.5"
+            specularExponent="4" lighting-color="#FFF">
+          <feSpotLight x="600" y="600" z="400" limitingConeAngle="5.5" />
+        </feSpecularLighting>
+        <feComposite in="SourceGraphic" in2="spotlight" operator="out"
+            k1="0" k2="1" k3="1" k4="0"/>
+      </filter>
+    </defs>
+    <image xlink:href="/foo.png" x="10%" y="10%"
+        width="80%" height="80%" style="filter:url(#spotlight);"/>
+  </svg>
+
+  <!-- Valid: feTile -->
+  <svg>
+    <defs>
+      <filter id="tile" x="0" y="0" width="100%" height="100%">
+        <feTile in="SourceGraphic" x="50" y="50"
+            width="100" height="100" />
+        <feTile/>
+      </filter>
+    </defs>
+    <image xlink:href="/foo.png"
+        x="10%" y="10%" width="80%" height="80%"
+        style="filter:url(#tile);"/>
+  </svg>
+
+  <!-- Valid: feTurbulence -->
+  <svg>
+    <filter id="displacementFilter">
+      <feTurbulence type="turbulence" baseFrequency="0.05"
+          numOctaves="2" result="turbulence"/>
+      <feDisplacementMap in2="turbulence" in="SourceGraphic"
+          scale="50" xChannelSelector="R" yChannelSelector="G"/>
+    </filter>
+    <circle cx="100" cy="100" r="100"
+        style="filter: url(#displacementFilter)"/>
+  </svg>
+
+  <!-- Invalid: feImage, due to potentially leaking during prefetch -->
+  <svg>
+    <defs>
+      <filter id="image">
+        <feImage xlink:href="/foo.png"/>
+      </filter>
+    </defs>
+    <rect x="10%" y="10%" width="80%" height="80%"
+        style="filter:url(#image);"/>
+  </svg>
+
+</body>
+</html>

--- a/validator/testdata/feature_tests/svg-filter-primitive-elements.out
+++ b/validator/testdata/feature_tests/svg-filter-primitive-elements.out
@@ -1,0 +1,220 @@
+FAIL
+|  <!--
+|    Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+|
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|
+|        http://www.apache.org/licenses/LICENSE-2.0
+|
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Tests SVG filter primitive elements.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=1,user-scalable=no,minimal-ui">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|  </head>
+|  <body>
+|    <!-- Valid: feBlend -->
+|    <svg>
+|      <defs>
+|        <filter id="spotlight">
+|          <feFlood result="floodFill" x="0" y="0" width="100%" height="100%"
+|              flood-color="green" flood-opacity="1"/>
+|          <feBlend in="SourceGraphic" in2="floodFill" mode="multiply"/>
+|        </filter>
+|      </defs>
+|    </svg>
+|
+|    <!-- Valid: feComponentTransfer -->
+|    <svg>
+|      <defs>
+|        <filter id="identity" x="0" y="0" width="100%" height="100%">
+|          <feComponentTransfer>
+|            <feFuncR type="identity"></feFuncR>
+|            <feFuncG type="identity"></feFuncG>
+|            <feFuncB type="identity"></feFuncB>
+|            <feFuncA type="identity"></feFuncA>
+|          </feComponentTransfer>
+|        </filter>
+|        <filter id="table" x="0" y="0" width="100%" height="100%">
+|          <feComponentTransfer>
+|            <feFuncR type="table" tableValues="0 0 1 1"></feFuncR>
+|            <feFuncG type="table" tableValues="1 1 0 0"></feFuncG>
+|            <feFuncB type="table" tableValues="0 1 1 0"></feFuncB>
+|          </feComponentTransfer>
+|        </filter>
+|        <filter id="linear" x="0" y="0" width="100%" height="100%">
+|          <feComponentTransfer>
+|            <feFuncR type="linear" slope="0.5" intercept="0"></feFuncR>
+|            <feFuncG type="linear" slope="0.5" intercept="0.25"></feFuncG>
+|            <feFuncB type="linear" slope="0.5" intercept="0.5"></feFuncB>
+|          </feComponentTransfer>
+|        </filter>
+|      </defs>
+|    </svg>
+|
+|    <!-- Valid: feConvolveMatrix -->
+|    <svg>
+|      <defs>
+|        <filter id="emboss">
+|          <feConvolveMatrix
+|              kernelMatrix="3 0 0
+|                            0 0 0
+|                            0 0 -3"/>
+|        </filter>
+|      </defs>
+|      <image xlink:href="/foo.svg" x="0" y="0"
+|          height="200" width="200" style="filter:url(#emboss);" />
+|    </svg>
+|
+|    <!-- Valid: feDiffuseLighting -->
+|    <svg>
+|      <text text-anchor="middle" x="170" y="22">fePointLight</text>
+|      <filter id="lightMe1">
+|        <feDiffuseLighting in="SourceGraphic" result="light"
+|            lighting-color="white">
+|          <fePointLight x="150" y="60" z="20" />
+|        </feDiffuseLighting>
+|        <feComposite in="SourceGraphic" in2="light"
+|                     operator="arithmetic" k1="1" k2="0" k3="0" k4="0"/>
+|      </filter>
+|      <circle cx="170" cy="80" r="50" fill="green"
+|          filter="url(#lightMe1)" />
+|    </svg>
+|
+|    <!-- Valid: feDisplacementMap -->
+|    <svg>
+|      <filter id="displacementFilter">
+|        <feTurbulence type="turbulence" baseFrequency="0.05"
+|            numOctaves="2" result="turbulence"/>
+|        <feDisplacementMap in2="turbulence" in="SourceGraphic"
+|            scale="50" xChannelSelector="R" yChannelSelector="G"/>
+|      </filter>
+|      <circle cx="100" cy="100" r="100"
+|          style="filter: url(#displacementFilter)"/>
+|    </svg>
+|
+|    <!-- Valid: feDropShadow -->
+|    <svg>
+|      <defs>
+|        <filter id="shadow">
+|          <feDropShadow dx="0.2" dy="0.4" stdDeviation="0.2"/>
+|        </filter>
+|      </defs>
+|      <circle cx="5" cy="50%" r="4"
+|          style="fill:pink; filter:url(#shadow);"/>
+|    </svg>
+|
+|    <!-- Valid: feMorphology -->
+|    <svg>
+|      <filter id="erode">
+|        <feMorphology operator="erode" radius="1"/>
+|      </filter>
+|      <filter id="dilate">
+|        <feMorphology operator="dilate" radius="2"/>
+|      </filter>
+|      <text y="1em">Normal text</text>
+|      <text id="thin" y="2em">Thinned text</text>
+|      <text id="thick" y="3em">Fattened text</text>
+|    </svg>
+|
+|    <!-- Valid: fePointLight -->
+|    <svg>
+|     <defs>
+|        <filter id="spotlight">
+|          <feSpecularLighting result="spotlight" specularConstant="1.5"
+|              specularExponent="80" lighting-color="#FFF">
+|            <fePointLight x="50" y="50" z="220"/>
+|          </feSpecularLighting>
+|          <feComposite in="SourceGraphic" in2="spotlight" operator="arithmetic"
+|              k1="0" k2="1" k3="1" k4="0"/>
+|        </filter>
+|      </defs>
+|      <image xlink:href="/foo.png" x="10%" y="10%"
+|          width="80%" height="80%" style="filter:url(#spotlight);"/>
+|    </svg>
+|
+|    <!-- Valid: feSpecularLighting -->
+|    <svg>
+|      <filter id = "filter">
+|        <feSpecularLighting result="specOut"
+|            specularExponent="20" lighting-color="#bbbbbb">
+|          <fePointLight x="50" y="75" z="200"/>
+|        </feSpecularLighting>
+|        <feComposite in="SourceGraphic" in2="specOut"
+|            operator="arithmetic" k1="0" k2="1" k3="1" k4="0"/>
+|      </filter>
+|      <circle cx="110" cy="110" r="100" style="filter:url(#filter)"/>
+|    </svg>
+|
+|    <!-- Valid: feSpotlight -->
+|    <svg>
+|      <defs>
+|        <filter id="spotlight">
+|          <feSpecularLighting result="spotlight" specularConstant="1.5"
+|              specularExponent="4" lighting-color="#FFF">
+|            <feSpotLight x="600" y="600" z="400" limitingConeAngle="5.5" />
+|          </feSpecularLighting>
+|          <feComposite in="SourceGraphic" in2="spotlight" operator="out"
+|              k1="0" k2="1" k3="1" k4="0"/>
+|        </filter>
+|      </defs>
+|      <image xlink:href="/foo.png" x="10%" y="10%"
+|          width="80%" height="80%" style="filter:url(#spotlight);"/>
+|    </svg>
+|
+|    <!-- Valid: feTile -->
+|    <svg>
+|      <defs>
+|        <filter id="tile" x="0" y="0" width="100%" height="100%">
+|          <feTile in="SourceGraphic" x="50" y="50"
+|              width="100" height="100" />
+|          <feTile/>
+|        </filter>
+|      </defs>
+|      <image xlink:href="/foo.png"
+|          x="10%" y="10%" width="80%" height="80%"
+|          style="filter:url(#tile);"/>
+|    </svg>
+|
+|    <!-- Valid: feTurbulence -->
+|    <svg>
+|      <filter id="displacementFilter">
+|        <feTurbulence type="turbulence" baseFrequency="0.05"
+|            numOctaves="2" result="turbulence"/>
+|        <feDisplacementMap in2="turbulence" in="SourceGraphic"
+|            scale="50" xChannelSelector="R" yChannelSelector="G"/>
+|      </filter>
+|      <circle cx="100" cy="100" r="100"
+|          style="filter: url(#displacementFilter)"/>
+|    </svg>
+|
+|    <!-- Invalid: feImage, due to potentially leaking during prefetch -->
+|    <svg>
+|      <defs>
+|        <filter id="image">
+|          <feImage xlink:href="/foo.png"/>
+>>         ^~~~~~~~~
+feature_tests/svg-filter-primitive-elements.html:209:8 The tag 'feimage' is disallowed.
+|        </filter>
+|      </defs>
+|      <rect x="10%" y="10%" width="80%" height="80%"
+|          style="filter:url(#image);"/>
+|    </svg>
+|
+|  </body>
+|  </html>

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -26,7 +26,7 @@ min_validator_revision_required: 475
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 1146
+spec_file_revision: 1147
 
 styles_spec_url: "https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages/"
 script_spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/validation-workflow/validation_errors/#custom-javascript-is-not-allowed"

--- a/validator/validator-svg.protoascii
+++ b/validator/validator-svg.protoascii
@@ -113,6 +113,7 @@ attr_lists: {
   attrs: { name: "slope" }
   attrs: { name: "table" }
   attrs: { name: "tablevalues" }
+  attrs: { name: "type" }
 }
 attr_lists: {
   name: "svg-xlink-attributes"
@@ -730,11 +731,36 @@ tags: {
 tags: {
   html_format: AMP
   html_format: AMP4ADS
+  tag_name: "FEBLEND"
+  mandatory_ancestor: "SVG"
+  attrs: { name: "in" }
+  attrs: { name: "in2" }
+  attrs: { name: "mode" }
+  attr_lists: "svg-core-attributes"
+  attr_lists: "svg-filter-primitive-attributes"
+  attr_lists: "svg-presentation-attributes"
+  attr_lists: "svg-style-attr"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
+}
+tags: {
+  html_format: AMP
+  html_format: AMP4ADS
   tag_name: "FECOLORMATRIX"
   mandatory_ancestor: "SVG"
   attrs: { name: "in" }
   attrs: { name: "type" }
   attrs: { name: "values" }
+  attr_lists: "svg-core-attributes"
+  attr_lists: "svg-filter-primitive-attributes"
+  attr_lists: "svg-presentation-attributes"
+  attr_lists: "svg-style-attr"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
+}
+tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  tag_name: "FECOMPONENTTRANSFER"
+  mandatory_ancestor: "SVG"
   attr_lists: "svg-core-attributes"
   attr_lists: "svg-filter-primitive-attributes"
   attr_lists: "svg-presentation-attributes"
@@ -762,12 +788,129 @@ tags: {
 tags: {
   html_format: AMP
   html_format: AMP4ADS
+  tag_name: "FECONVOLVEMATRIX"
+  mandatory_ancestor: "SVG"
+  attrs: { name: "bias" }
+  attrs: { name: "divisor" }
+  attrs: { name: "edgemode" }
+  attrs: { name: "in" }
+  attrs: { name: "kernelmatrix" }
+  attrs: { name: "kernelunitlength" }
+  attrs: { name: "order" }
+  attrs: { name: "preservealpha" }
+  attrs: { name: "targetx" }
+  attrs: { name: "targety" }
+  attr_lists: "svg-core-attributes"
+  attr_lists: "svg-filter-primitive-attributes"
+  attr_lists: "svg-presentation-attributes"
+  attr_lists: "svg-style-attr"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
+}
+tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  tag_name: "FEDIFFUSELIGHTING"
+  mandatory_ancestor: "SVG"
+  attrs: { name: "diffuseconstant" }
+  attrs: { name: "in" }
+  attrs: { name: "kernelunitlength" }
+  attrs: { name: "surfacescale" }
+  attr_lists: "svg-core-attributes"
+  attr_lists: "svg-filter-primitive-attributes"
+  attr_lists: "svg-presentation-attributes"
+  attr_lists: "svg-style-attr"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
+}
+tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  tag_name: "FEDISPLACEMENTMAP"
+  mandatory_ancestor: "SVG"
+  attrs: { name: "in" }
+  attrs: { name: "in2" }
+  attrs: { name: "scale" }
+  attrs: { name: "xchannelselector" }
+  attrs: { name: "ychannelselector" }
+  attr_lists: "svg-core-attributes"
+  attr_lists: "svg-filter-primitive-attributes"
+  attr_lists: "svg-presentation-attributes"
+  attr_lists: "svg-style-attr"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
+}
+tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  tag_name: "FEDISTANTLIGHT"
+  mandatory_ancestor: "SVG"
+  attrs: { name: "azimuth" }
+  attrs: { name: "elevation" }
+  attr_lists: "svg-core-attributes"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
+}
+tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  tag_name: "FEDROPSHADOW"
+  mandatory_ancestor: "SVG"
+  mandatory_parent: "FILTER"
+  attrs: { name: "dx" }
+  attrs: { name: "dy" }
+  attrs: { name: "stddeviation" }
+  attr_lists: "svg-core-attributes"
+  attr_lists: "svg-filter-primitive-attributes"
+  attr_lists: "svg-presentation-attributes"
+  attr_lists: "svg-style-attr"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
+}
+tags: {
+  html_format: AMP
+  html_format: AMP4ADS
   tag_name: "FEFLOOD"
   mandatory_ancestor: "SVG"
   attr_lists: "svg-core-attributes"
   attr_lists: "svg-filter-primitive-attributes"
   attr_lists: "svg-presentation-attributes"
   attr_lists: "svg-style-attr"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
+}
+tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  tag_name: "FEFUNCA"
+  mandatory_ancestor: "SVG"
+  mandatory_parent: "FECOMPONENTTRANSFER"
+  attr_lists: "svg-core-attributes"
+  attr_lists: "svg-transfer-function-attributes"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
+}
+tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  tag_name: "FEFUNCB"
+  mandatory_ancestor: "SVG"
+  mandatory_parent: "FECOMPONENTTRANSFER"
+  attr_lists: "svg-core-attributes"
+  attr_lists: "svg-transfer-function-attributes"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
+}
+tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  tag_name: "FEFUNCG"
+  mandatory_ancestor: "SVG"
+  mandatory_parent: "FECOMPONENTTRANSFER"
+  attr_lists: "svg-core-attributes"
+  attr_lists: "svg-transfer-function-attributes"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
+}
+tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  tag_name: "FEFUNCR"
+  mandatory_ancestor: "SVG"
+  mandatory_parent: "FECOMPONENTTRANSFER"
+  attr_lists: "svg-core-attributes"
+  attr_lists: "svg-transfer-function-attributes"
   spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
 }
 tags: {
@@ -808,11 +951,96 @@ tags: {
 tags: {
   html_format: AMP
   html_format: AMP4ADS
+  tag_name: "FEMORPHOLOGY"
+  mandatory_ancestor: "SVG"
+  attrs: { name: "in" }
+  attrs: { name: "operator" }
+  attrs: { name: "radius" }
+  attr_lists: "svg-core-attributes"
+  attr_lists: "svg-filter-primitive-attributes"
+  attr_lists: "svg-presentation-attributes"
+  attr_lists: "svg-style-attr"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
+}
+tags: {
+  html_format: AMP
+  html_format: AMP4ADS
   tag_name: "FEOFFSET"
   mandatory_ancestor: "SVG"
   attrs: { name: "dx" }
   attrs: { name: "dy" }
   attrs: { name: "in" }
+  attr_lists: "svg-core-attributes"
+  attr_lists: "svg-filter-primitive-attributes"
+  attr_lists: "svg-presentation-attributes"
+  attr_lists: "svg-style-attr"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
+}
+tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  tag_name: "FEPOINTLIGHT"
+  mandatory_ancestor: "SVG"
+  attrs: { name: "x" }
+  attrs: { name: "y" }
+  attrs: { name: "z" }
+  attr_lists: "svg-core-attributes"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
+}
+tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  tag_name: "FESPECULARLIGHTING"
+  mandatory_ancestor: "SVG"
+  attrs: { name: "in" }
+  attrs: { name: "kernelunitlength" }
+  attrs: { name: "specularconstant" }
+  attrs: { name: "specularexponent" }
+  attrs: { name: "surfacescale" }
+  attr_lists: "svg-core-attributes"
+  attr_lists: "svg-filter-primitive-attributes"
+  attr_lists: "svg-presentation-attributes"
+  attr_lists: "svg-style-attr"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
+}
+tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  tag_name: "FESPOTLIGHT"
+  mandatory_ancestor: "SVG"
+  attrs: { name: "limitingconeangle" }
+  attrs: { name: "pointsatx" }
+  attrs: { name: "pointsaty" }
+  attrs: { name: "pointsatz" }
+  attrs: { name: "specularexponent" }
+  attrs: { name: "x" }
+  attrs: { name: "y" }
+  attrs: { name: "z" }
+  attr_lists: "svg-core-attributes"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
+}
+tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  tag_name: "FETILE"
+  mandatory_ancestor: "SVG"
+  attrs: { name: "in" }
+  attr_lists: "svg-core-attributes"
+  attr_lists: "svg-filter-primitive-attributes"
+  attr_lists: "svg-presentation-attributes"
+  attr_lists: "svg-style-attr"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
+}
+tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  tag_name: "FETURBULENCE"
+  mandatory_ancestor: "SVG"
+  attrs: { name: "basefrequency" }
+  attrs: { name: "numoctaves" }
+  attrs: { name: "seed" }
+  attrs: { name: "stitchtiles" }
+  attrs: { name: "type" }
   attr_lists: "svg-core-attributes"
   attr_lists: "svg-filter-primitive-attributes"
   attr_lists: "svg-presentation-attributes"


### PR DESCRIPTION
Fixes #32329.

Allow more SVG filter primitive elements

```
<feBlend>
<feComponentTransfer>
<feConvolveMatrix>
<feDiffuseLighting>
<feDisplacementMap>
<feDistantLight>
<feDropShadow>
<feFuncA>
<feFuncB>
<feFuncG>
<feFuncR>
<feMorphology>
<fePointLight>
<feSpecularLighting>
<feSpotLight>
<feTile>
<feTurbulence>
```