### PR TITLE
Revert "🏗 Trigger CircleCI builds only for `ampproject/amphtml`"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -233,9 +233,6 @@ jobs:
 
 workflows:
   'CircleCI':
-    when:
-      equal:
-        [https://github.com/ampproject/amphtml, << pipeline.project.git_url >>]
     jobs:
       - 'Checks':
           <<: *push_and_pr_builds


### PR DESCRIPTION
Reverts ampproject/amphtml#32346

Reason for revert: https://github.com/ampproject/amphtml/pull/32346#issuecomment-771849006