### PR TITLE
🏗 Check if PR branches contain the latest CircleCI config file

### DIFF
--- a/.circleci/check_config.sh
+++ b/.circleci/check_config.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+#
+# Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the license.
+#
+# This script checks if a PR branch is using the most recent CircleCI config.
+#
+# Reference: https://circleci.com/docs/2.0/env-vars/#built-in-environment-variables.
+
+set -e
+err=0
+
+GREEN() { echo -e "\n\033[0;32m$1\033[0m"; }
+RED() { echo -e "\n\033[0;31m$1\033[0m"; }
+
+# CIRCLE_PULL_REQUEST is present for PR builds, and absent for push builds.
+if [[ -z "$CIRCLE_PULL_REQUEST" ]]; then
+  echo $(GREEN "Nothing to do because this is not a PR build.")
+  exit 0
+fi
+
+# Check if the PR branch contains the most recent revision the CircleCI config.
+CONFIG_REV=`git rev-list master -1 -- .circleci/config.yml`
+(set -x && git merge-base --is-ancestor $CONFIG_REV $CIRCLE_SHA1) || err=$?
+
+if [[ "$err" -ne "0" ]]; then
+  echo $(RED "$CIRCLE_BRANCH is missing the latest CircleCI config revision $CONFIG_REV.")
+  echo $(RED "Please rebase / merge $CIRCLE_BRANCH with master.")
+  exit 1
+fi
+
+echo $(GREEN "$CIRCLE_BRANCH is using the latest CircleCI config.")

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,6 +59,9 @@ commands:
           name: 'Fetch Merge Commit'
           command: ./.circleci/fetch_merge_commit.sh
       - run:
+          name: 'Check Config'
+          command: ./.circleci/check_config.sh
+      - run:
           name: 'Setup Google Cloud Storage'
           command: ./.circleci/setup_storage.sh
       - run:


### PR DESCRIPTION
**Background:**

During CircleCI PR builds, we [fetch the merge commit](https://github.com/ampproject/amphtml/blob/master/.circleci/fetch_merge_commit.sh) of the PR branch with `master` so that code is tested against all recent changes.

However, since the CircleCI config is loaded before the merge commit is fetched, the PR could be using an outdated version of the config file. The risk of allowing the build to proceed is that if a new testing step were added to the config file in an upstream change, it won't be applied to the PR.

Other CI services use the `master` merge commit for PR builds, so they don't have this problem.

**PR highlights:**

- Add a check to make sure that a PR branch contains the latest changes to the CircleCI config file
- If not, print a message asking for the PR branch to be rebased / merged
 
This should be a rare occurrence once our CI transition is complete and the configuration file settles down.

**[Failing case:](https://app.circleci.com/pipelines/github/ampproject/amphtml/1070/workflows/416b7b07-8be1-48d7-a143-02ed5c2d8f5e/jobs/9622)**

![image](https://user-images.githubusercontent.com/26553114/106782059-bf9dc180-6617-11eb-8beb-8ca8248a9927.png)

**[Passing case:](https://app.circleci.com/pipelines/github/ampproject/amphtml/1071/workflows/e3c0fb31-7ac4-4303-a861-19e99f932095/jobs/9634)**

![image](https://user-images.githubusercontent.com/26553114/106782121-cc221a00-6617-11eb-8e04-3e4aad9c8b5c.png)
