### PR TITLE
jss transform test: unrelated lines unaffected

### DIFF
--- a/build-system/babel-plugins/babel-plugin-transform-jss/test/fixtures/transform-assertions/ignore-unrelated-exports/input.js
+++ b/build-system/babel-plugins/babel-plugin-transform-jss/test/fixtures/transform-assertions/ignore-unrelated-exports/input.js
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {createUseStyles} from 'react-jss';
+
+export const useStyles = createUseStyles({
+  floatLeft: {float: 'left'},
+});
+
+// These next lines should be unaffected by jss transform.
+export const unrelated = 5;
+unrelated + unrelated == unrelated * 2;

--- a/build-system/babel-plugins/babel-plugin-transform-jss/test/fixtures/transform-assertions/ignore-unrelated-exports/options.json
+++ b/build-system/babel-plugins/babel-plugin-transform-jss/test/fixtures/transform-assertions/ignore-unrelated-exports/options.json
@@ -1,0 +1,5 @@
+{
+  "plugins": ["../../../.."],
+  "sourceType": "module",
+  "filename": "component.jss.js"
+}

--- a/build-system/babel-plugins/babel-plugin-transform-jss/test/fixtures/transform-assertions/ignore-unrelated-exports/output.mjs
+++ b/build-system/babel-plugins/babel-plugin-transform-jss/test/fixtures/transform-assertions/ignore-unrelated-exports/output.mjs
@@ -1,0 +1,25 @@
+/** @enum {string}*/
+var _classes = {
+  floatLeft: "float-left-07984bd"
+};
+
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export const useStyles = () => _classes; // These next lines should be unaffected by jss transform.
+
+export const CSS = ".float-left-07984bd{float:left}\n";
+export const unrelated = 5;
+unrelated + unrelated == unrelated * 2;


### PR DESCRIPTION
**summary**
Lines unrelated to `createUseStyles` and the JSS calculation should be unaffected by the transform

Verify / addresses a concern from https://github.com/ampproject/amphtml/pull/32365/files#r569678476