### PR TITLE
✨ [bento][amp-sidebar] Prevent scrolling in background of sidebar

### DIFF
--- a/extensions/amp-sidebar/1.0/sidebar.js
+++ b/extensions/amp-sidebar/1.0/sidebar.js
@@ -119,7 +119,7 @@ function SidebarWithRef(
           layout={true}
           paint={true}
           part="sidebar"
-          wrapperClassName={`${classes.sidebarClass} ${
+          wrapperClassName={`${classes.sidebar} ${
             classes.defaultSidebarStyles
           } ${side === Side.LEFT ? classes.left : classes.right}`}
           role="menu"
@@ -134,12 +134,12 @@ function SidebarWithRef(
           onClick={() => close()}
           part="backdrop"
           style={backdropStyle}
-          className={`${backdropClassName ?? ''} ${classes.backdropClass} ${
+          className={`${backdropClassName ?? ''} ${classes.backdrop} ${
             classes.defaultBackdropStyles
           }`}
           hidden={!side}
         >
-          <div className={classes.sidebarChildClass}></div>
+          <div className={classes.backdropOverscrollBlocker}></div>
         </div>
       </>
     )

--- a/extensions/amp-sidebar/1.0/sidebar.js
+++ b/extensions/amp-sidebar/1.0/sidebar.js
@@ -138,7 +138,9 @@ function SidebarWithRef(
             classes.defaultBackdropStyles
           }`}
           hidden={!side}
-        ></div>
+        >
+          <div className={classes.sidebarChildClass}></div>
+        </div>
       </>
     )
   );

--- a/extensions/amp-sidebar/1.0/sidebar.jss.js
+++ b/extensions/amp-sidebar/1.0/sidebar.jss.js
@@ -16,7 +16,7 @@
 
 import {createUseStyles} from 'react-jss';
 
-const sidebarClass = {
+const sidebar = {
   position: 'fixed !important',
   overflowX: 'hidden !important',
   overflowY: 'auto !important',
@@ -45,7 +45,7 @@ const right = {
   right: 0,
 };
 
-const backdropClass = {
+const backdrop = {
   position: 'fixed !important',
   top: '0 !important',
   left: '0 !important',
@@ -65,19 +65,19 @@ const defaultBackdropStyles = {
 
 //TODO(#32400): See PR description.  This is a workaround dependent on a
 // a browser bug fix and should be removed when the browser bug is fixed.
-const sidebarChildClass = {
+const backdropOverscrollBlocker = {
   height: '101vh !important',
   width: '0 !important',
 };
 
 const JSS = {
-  sidebarClass,
+  sidebar,
   defaultSidebarStyles,
   left,
   right,
-  backdropClass,
+  backdrop,
   defaultBackdropStyles,
-  sidebarChildClass,
+  backdropOverscrollBlocker,
 };
 
 // useStyles gets replaced for AMP builds via `babel-plugin-transform-jss`.

--- a/extensions/amp-sidebar/1.0/sidebar.jss.js
+++ b/extensions/amp-sidebar/1.0/sidebar.jss.js
@@ -21,6 +21,7 @@ const sidebarClass = {
   overflowX: 'hidden !important',
   overflowY: 'auto !important',
   boxSizing: 'border-box !important',
+  overscrollBehavior: 'none !important',
 };
 
 // User overridable styles
@@ -48,10 +49,12 @@ const backdropClass = {
   position: 'fixed !important',
   top: '0 !important',
   left: '0 !important',
-  width: '100vw !important',
+  width: '120vw !important',
   height: '100vh !important',
+  overflow: 'hidden scroll !important',
   /* Prevent someone from making this a full-sceen image */
   backgroundImage: 'none !important',
+  overscrollBehavior: 'none !important',
   zIndex: 2147483646,
 };
 
@@ -60,13 +63,19 @@ const defaultBackdropStyles = {
   backgroundColor: 'rgba(0, 0, 0, 0.5)',
 };
 
+const sidebarChildClass = {
+  height: '101vh !important',
+  width: '0 !important',
+};
+
 const JSS = {
   sidebarClass,
   defaultSidebarStyles,
-  backdropClass,
-  defaultBackdropStyles,
   left,
   right,
+  backdropClass,
+  defaultBackdropStyles,
+  sidebarChildClass,
 };
 
 // useStyles gets replaced for AMP builds via `babel-plugin-transform-jss`.

--- a/extensions/amp-sidebar/1.0/sidebar.jss.js
+++ b/extensions/amp-sidebar/1.0/sidebar.jss.js
@@ -63,6 +63,8 @@ const defaultBackdropStyles = {
   backgroundColor: 'rgba(0, 0, 0, 0.5)',
 };
 
+//TODO(#32400): See PR description.  This is a workaround dependent on a
+// a browser bug fix and should be removed when the browser bug is fixed.
 const sidebarChildClass = {
   height: '101vh !important',
   width: '0 !important',

--- a/extensions/amp-sidebar/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-sidebar/1.0/storybook/Basic.amp.js
@@ -15,7 +15,14 @@
  */
 
 import * as Preact from '../../../../src/preact';
-import {color, number, select, text, withKnobs} from '@storybook/addon-knobs';
+import {
+  boolean,
+  color,
+  number,
+  select,
+  text,
+  withKnobs,
+} from '@storybook/addon-knobs';
 import {withA11y} from '@storybook/addon-a11y';
 import {withAmp} from '@ampproject/storybook-addon';
 
@@ -135,6 +142,310 @@ export const styles = () => {
         <button on="tap:sidebar.open()">open</button>
         <button on="tap:sidebar.close()">close</button>
       </div>
+    </main>
+  );
+};
+
+export const scroll = () => {
+  const sideConfigurations = ['left', 'right', undefined];
+  const side = select('side', sideConfigurations, sideConfigurations[0]);
+  const foregroundColor = color('color');
+  const backgroundColor = color('background');
+  const backdropColor = color('backdrop color');
+  const moreBackgroundContent = boolean('more background content', false);
+  const moreSidebarContent = boolean('more sidebar content', false);
+
+  return (
+    <main>
+      <style>
+        {`
+          amp-sidebar {
+              color: ${foregroundColor};
+              background-color: ${backgroundColor};
+          }
+          amp-sidebar::part(backdrop) {
+              background-color: ${backdropColor};
+          }
+          `}
+      </style>
+      <amp-sidebar layout="nodisplay" id="sidebar" side={side}>
+        <div style={{margin: 8}}>
+          <span>
+            Lorem ipsum dolor sit amet, has nisl nihil convenire et, vim at
+            aeque inermis reprehendunt.
+          </span>
+          <ul>
+            <li>1</li>
+            <li>2</li>
+            <li>3</li>
+          </ul>
+          <button on="tap:sidebar.toggle()">toggle</button>
+          <button on="tap:sidebar.open()">open</button>
+          <button on="tap:sidebar.close()">close</button>
+          {moreSidebarContent && (
+            <>
+              <p>
+                Dessert tootsie roll marzipan pastry. Powder powder jelly beans
+                chocolate bar candy sugar plum. Jelly-o gummi bears jelly icing
+                cotton candy. Toffee carrot cake ice cream sesame snaps sugar
+                plum gummies. Gummies marshmallow candy chocolate bar ice cream
+                ice cream gummies chocolate cake. Candy ice cream pie danish ice
+                cream cake gingerbread. Muffin cookie marzipan marzipan jelly
+                beans gummies candy muffin dessert. Soufflé chocolate tart
+                tootsie roll tootsie roll gingerbread icing powder. Dessert
+                croissant macaroon candy liquorice. Gingerbread gummi bears
+                croissant wafer cookie cookie bonbon. Marshmallow fruitcake
+                lollipop sweet roll danish dragée cupcake. Tootsie roll cotton
+                candy dragée chocolate bar tootsie roll cheesecake cookie
+                muffin. Toffee sesame snaps gingerbread wafer cotton candy
+                bonbon gingerbread toffee.
+              </p>
+
+              <p>
+                Danish cupcake chocolate candy chocolate bar. Topping brownie
+                toffee oat cake liquorice marzipan cheesecake chupa chups.
+                Pastry carrot cake jelly beans chocolate cake liquorice sesame
+                snaps caramels. Apple pie marshmallow chupa chups lemon drops
+                pudding cotton candy pie apple pie oat cake. Sugar plum halvah
+                cotton candy tiramisu sweet dragée cookie pastry. Macaroon
+                bonbon jujubes. Halvah tiramisu brownie topping donut cookie
+                tart. Jelly lemon drops soufflé pie chocolate bar donut tootsie
+                roll bear claw cake. Chocolate cake powder dessert. Pudding
+                wafer danish chupa chups donut chocolate sweet carrot cake.
+                Sugar plum cheesecake brownie chocolate sweet tart marzipan oat
+                cake dessert. Gummi bears sugar plum bonbon chocolate cake.
+                Croissant marzipan brownie dessert donut cotton candy croissant
+                powder. Chocolate cake tootsie roll sweet roll gummi bears donut
+                fruitcake jelly beans carrot cake.
+              </p>
+
+              <p>
+                Brownie gummies danish lollipop caramels wafer gingerbread
+                macaroon carrot cake. Brownie powder donut gummi bears pudding
+                cupcake. Lemon drops croissant apple pie sesame snaps marzipan.
+                Biscuit chocolate cake jelly-o pie caramels gingerbread caramels
+                chupa chups donut. Sweet roll oat cake cake. Cheesecake candy
+                canes candy canes candy canes topping pastry sweet cheesecake.
+                Jelly-o gummies topping marshmallow dessert tiramisu cake bonbon
+                chupa chups. Chocolate biscuit danish tart bear claw. Tiramisu
+                carrot cake jelly-o pie sweet cake. Sesame snaps lollipop cookie
+                chocolate cake wafer dragée. Powder brownie danish. Pastry
+                chocolate cake sweet roll halvah cupcake dragée.
+              </p>
+
+              <p>
+                Cake carrot cake icing danish biscuit carrot cake marzipan
+                croissant. Cake cake gummi bears fruitcake sweet dessert toffee
+                chocolate cake. Ice cream carrot cake donut jelly beans. Jelly
+                wafer sugar plum sweet icing candy canes. Bonbon marshmallow
+                donut pudding jelly-o tiramisu pastry cake bonbon. Jelly candy
+                canes liquorice cupcake liquorice dessert halvah toffee. Jelly
+                chocolate macaroon topping cupcake tootsie roll liquorice
+                brownie lollipop. Chupa chups wafer cupcake candy cookie oat
+                cake cookie bear claw. Carrot cake pudding biscuit tiramisu ice
+                cream sugar plum. Topping lemon drops dragée cake liquorice
+                apple pie ice cream. Cotton candy lollipop lemon drops apple pie
+                tootsie roll pie marshmallow chocolate jelly-o. Pastry bonbon
+                cupcake dragée candy.
+              </p>
+
+              <p>
+                Ice cream dragée pudding pastry biscuit tart cookie. Oat cake
+                ice cream apple pie oat cake dessert soufflé caramels apple pie.
+                Gummies bear claw powder cake icing jelly beans jelly beans
+                marzipan lollipop. Lollipop brownie jelly beans pudding. Ice
+                cream jelly biscuit pie tiramisu tootsie roll gummies biscuit.
+                Cupcake biscuit biscuit chocolate bar liquorice caramels powder
+                cotton candy muffin. Sesame snaps tiramisu croissant. Soufflé
+                chocolate jelly-o topping. Lemon drops candy canes sweet carrot
+                cake chocolate cake tootsie roll wafer marshmallow. Jelly beans
+                bear claw jelly-o sesame snaps carrot cake. Pudding jelly candy
+                carrot cake fruitcake carrot cake candy canes sesame snaps.
+                Marzipan icing caramels chocolate tart powder cookie halvah.
+                Fruitcake dragée muffin tart. Jelly-o cupcake marshmallow
+                pudding gummies muffin topping caramels.
+              </p>
+
+              <p>
+                Liquorice bear claw marshmallow dessert. Bear claw toffee pastry
+                tiramisu apple pie oat cake. Tiramisu jelly gingerbread cake
+                cake sweet roll cupcake ice cream jelly. Fruitcake jelly beans
+                macaroon soufflé jelly beans marzipan caramels candy. Cheesecake
+                candy canes pudding icing icing. Dragée chocolate bar bear claw
+                dragée donut brownie cake sweet roll. Wafer bear claw dragée
+                icing sesame snaps topping. Cake marzipan bear claw dessert bear
+                claw lollipop halvah wafer halvah. Icing sweet roll toffee sweet
+                powder sesame snaps gummies tart danish. Ice cream toffee
+                caramels danish. Jelly-o lollipop lollipop dessert sesame snaps
+                bear claw gummi bears. Donut sweet roll marzipan fruitcake oat
+                cake cake icing cotton candy oat cake. Gingerbread carrot cake
+                sesame snaps gummies candy dragée lollipop soufflé biscuit.
+                Pudding jujubes chocolate halvah sesame snaps tiramisu sweet
+                marshmallow chocolate bar.
+              </p>
+
+              <p>
+                Donut carrot cake apple pie powder marshmallow sesame snaps
+                tiramisu. Sweet roll powder cookie. Lollipop sugar plum oat
+                cake. Marshmallow wafer danish wafer gingerbread cake muffin
+                candy dragée. Candy cotton candy topping cake cotton candy
+                carrot cake fruitcake brownie. Toffee candy candy canes jelly-o
+                cotton candy gummies. Bonbon bonbon pie sugar plum. Oat cake
+                sesame snaps pudding candy canes gummi bears macaroon jelly
+                beans brownie. Sesame snaps halvah halvah jelly-o dessert.
+                Jelly-o chocolate sweet roll donut candy. Cotton candy halvah
+                macaroon tiramisu tart. Jelly toffee candy pie toffee.
+              </p>
+
+              <p>
+                Powder chupa chups muffin jelly-o soufflé. Lollipop sweet roll
+                sweet roll brownie pastry tootsie roll. Topping cheesecake pie
+                jelly. Donut wafer wafer cake candy canes. Topping chocolate bar
+                cheesecake topping ice cream tiramisu toffee ice cream. Bonbon
+                halvah marshmallow. Marzipan topping chupa chups dessert
+                chocolate chocolate cake gummi bears. Gummi bears caramels sugar
+                plum. Pie donut jelly beans tiramisu soufflé pie powder. Cupcake
+                cookie topping. Tootsie roll candy canes jujubes croissant
+                liquorice ice cream brownie. Topping cookie apple pie gummi
+                bears bear claw jelly-o brownie tart. Marzipan cotton candy
+                gummi bears. Dragée ice cream gummi bears jelly-o carrot cake
+                chocolate bar tiramisu jelly cotton candy.
+              </p>
+            </>
+          )}
+        </div>
+      </amp-sidebar>
+      <div class="buttons" style={{margin: 8}}>
+        <button on="tap:sidebar.toggle()">toggle</button>
+        <button on="tap:sidebar.open()">open</button>
+        <button on="tap:sidebar.close()">close</button>
+      </div>
+      {moreBackgroundContent && (
+        <div style={{margin: 8}}>
+          <p>
+            Dessert tootsie roll marzipan pastry. Powder powder jelly beans
+            chocolate bar candy sugar plum. Jelly-o gummi bears jelly icing
+            cotton candy. Toffee carrot cake ice cream sesame snaps sugar plum
+            gummies. Gummies marshmallow candy chocolate bar ice cream ice cream
+            gummies chocolate cake. Candy ice cream pie danish ice cream cake
+            gingerbread. Muffin cookie marzipan marzipan jelly beans gummies
+            candy muffin dessert. Soufflé chocolate tart tootsie roll tootsie
+            roll gingerbread icing powder. Dessert croissant macaroon candy
+            liquorice. Gingerbread gummi bears croissant wafer cookie cookie
+            bonbon. Marshmallow fruitcake lollipop sweet roll danish dragée
+            cupcake. Tootsie roll cotton candy dragée chocolate bar tootsie roll
+            cheesecake cookie muffin. Toffee sesame snaps gingerbread wafer
+            cotton candy bonbon gingerbread toffee.
+          </p>
+
+          <p>
+            Danish cupcake chocolate candy chocolate bar. Topping brownie toffee
+            oat cake liquorice marzipan cheesecake chupa chups. Pastry carrot
+            cake jelly beans chocolate cake liquorice sesame snaps caramels.
+            Apple pie marshmallow chupa chups lemon drops pudding cotton candy
+            pie apple pie oat cake. Sugar plum halvah cotton candy tiramisu
+            sweet dragée cookie pastry. Macaroon bonbon jujubes. Halvah tiramisu
+            brownie topping donut cookie tart. Jelly lemon drops soufflé pie
+            chocolate bar donut tootsie roll bear claw cake. Chocolate cake
+            powder dessert. Pudding wafer danish chupa chups donut chocolate
+            sweet carrot cake. Sugar plum cheesecake brownie chocolate sweet
+            tart marzipan oat cake dessert. Gummi bears sugar plum bonbon
+            chocolate cake. Croissant marzipan brownie dessert donut cotton
+            candy croissant powder. Chocolate cake tootsie roll sweet roll gummi
+            bears donut fruitcake jelly beans carrot cake.
+          </p>
+
+          <p>
+            Brownie gummies danish lollipop caramels wafer gingerbread macaroon
+            carrot cake. Brownie powder donut gummi bears pudding cupcake. Lemon
+            drops croissant apple pie sesame snaps marzipan. Biscuit chocolate
+            cake jelly-o pie caramels gingerbread caramels chupa chups donut.
+            Sweet roll oat cake cake. Cheesecake candy canes candy canes candy
+            canes topping pastry sweet cheesecake. Jelly-o gummies topping
+            marshmallow dessert tiramisu cake bonbon chupa chups. Chocolate
+            biscuit danish tart bear claw. Tiramisu carrot cake jelly-o pie
+            sweet cake. Sesame snaps lollipop cookie chocolate cake wafer
+            dragée. Powder brownie danish. Pastry chocolate cake sweet roll
+            halvah cupcake dragée.
+          </p>
+
+          <p>
+            Cake carrot cake icing danish biscuit carrot cake marzipan
+            croissant. Cake cake gummi bears fruitcake sweet dessert toffee
+            chocolate cake. Ice cream carrot cake donut jelly beans. Jelly wafer
+            sugar plum sweet icing candy canes. Bonbon marshmallow donut pudding
+            jelly-o tiramisu pastry cake bonbon. Jelly candy canes liquorice
+            cupcake liquorice dessert halvah toffee. Jelly chocolate macaroon
+            topping cupcake tootsie roll liquorice brownie lollipop. Chupa chups
+            wafer cupcake candy cookie oat cake cookie bear claw. Carrot cake
+            pudding biscuit tiramisu ice cream sugar plum. Topping lemon drops
+            dragée cake liquorice apple pie ice cream. Cotton candy lollipop
+            lemon drops apple pie tootsie roll pie marshmallow chocolate
+            jelly-o. Pastry bonbon cupcake dragée candy.
+          </p>
+
+          <p>
+            Ice cream dragée pudding pastry biscuit tart cookie. Oat cake ice
+            cream apple pie oat cake dessert soufflé caramels apple pie. Gummies
+            bear claw powder cake icing jelly beans jelly beans marzipan
+            lollipop. Lollipop brownie jelly beans pudding. Ice cream jelly
+            biscuit pie tiramisu tootsie roll gummies biscuit. Cupcake biscuit
+            biscuit chocolate bar liquorice caramels powder cotton candy muffin.
+            Sesame snaps tiramisu croissant. Soufflé chocolate jelly-o topping.
+            Lemon drops candy canes sweet carrot cake chocolate cake tootsie
+            roll wafer marshmallow. Jelly beans bear claw jelly-o sesame snaps
+            carrot cake. Pudding jelly candy carrot cake fruitcake carrot cake
+            candy canes sesame snaps. Marzipan icing caramels chocolate tart
+            powder cookie halvah. Fruitcake dragée muffin tart. Jelly-o cupcake
+            marshmallow pudding gummies muffin topping caramels.
+          </p>
+
+          <p>
+            Liquorice bear claw marshmallow dessert. Bear claw toffee pastry
+            tiramisu apple pie oat cake. Tiramisu jelly gingerbread cake cake
+            sweet roll cupcake ice cream jelly. Fruitcake jelly beans macaroon
+            soufflé jelly beans marzipan caramels candy. Cheesecake candy canes
+            pudding icing icing. Dragée chocolate bar bear claw dragée donut
+            brownie cake sweet roll. Wafer bear claw dragée icing sesame snaps
+            topping. Cake marzipan bear claw dessert bear claw lollipop halvah
+            wafer halvah. Icing sweet roll toffee sweet powder sesame snaps
+            gummies tart danish. Ice cream toffee caramels danish. Jelly-o
+            lollipop lollipop dessert sesame snaps bear claw gummi bears. Donut
+            sweet roll marzipan fruitcake oat cake cake icing cotton candy oat
+            cake. Gingerbread carrot cake sesame snaps gummies candy dragée
+            lollipop soufflé biscuit. Pudding jujubes chocolate halvah sesame
+            snaps tiramisu sweet marshmallow chocolate bar.
+          </p>
+
+          <p>
+            Donut carrot cake apple pie powder marshmallow sesame snaps
+            tiramisu. Sweet roll powder cookie. Lollipop sugar plum oat cake.
+            Marshmallow wafer danish wafer gingerbread cake muffin candy dragée.
+            Candy cotton candy topping cake cotton candy carrot cake fruitcake
+            brownie. Toffee candy candy canes jelly-o cotton candy gummies.
+            Bonbon bonbon pie sugar plum. Oat cake sesame snaps pudding candy
+            canes gummi bears macaroon jelly beans brownie. Sesame snaps halvah
+            halvah jelly-o dessert. Jelly-o chocolate sweet roll donut candy.
+            Cotton candy halvah macaroon tiramisu tart. Jelly toffee candy pie
+            toffee.
+          </p>
+
+          <p>
+            Powder chupa chups muffin jelly-o soufflé. Lollipop sweet roll sweet
+            roll brownie pastry tootsie roll. Topping cheesecake pie jelly.
+            Donut wafer wafer cake candy canes. Topping chocolate bar cheesecake
+            topping ice cream tiramisu toffee ice cream. Bonbon halvah
+            marshmallow. Marzipan topping chupa chups dessert chocolate
+            chocolate cake gummi bears. Gummi bears caramels sugar plum. Pie
+            donut jelly beans tiramisu soufflé pie powder. Cupcake cookie
+            topping. Tootsie roll candy canes jujubes croissant liquorice ice
+            cream brownie. Topping cookie apple pie gummi bears bear claw
+            jelly-o brownie tart. Marzipan cotton candy gummi bears. Dragée ice
+            cream gummi bears jelly-o carrot cake chocolate bar tiramisu jelly
+            cotton candy.
+          </p>
+        </div>
+      )}
     </main>
   );
 };

--- a/extensions/amp-sidebar/1.0/storybook/Basic.js
+++ b/extensions/amp-sidebar/1.0/storybook/Basic.js
@@ -16,7 +16,7 @@
 
 import * as Preact from '../../../../src/preact';
 import {Sidebar} from '../sidebar';
-import {color, select, withKnobs} from '@storybook/addon-knobs';
+import {boolean, color, select, withKnobs} from '@storybook/addon-knobs';
 import {withA11y} from '@storybook/addon-a11y';
 
 export default {
@@ -49,12 +49,14 @@ function SidebarWithActions(props) {
           <button onClick={() => ref.current.toggle()}>toggle</button>
           <button onClick={() => ref.current.open()}>open</button>
           <button onClick={() => ref.current.close()}>close</button>
+          {props.children}
         </div>
       </Sidebar>
       <div style={{marginTop: 8}}>
         <button onClick={() => ref.current.toggle()}>toggle</button>
         <button onClick={() => ref.current.open()}>open</button>
         <button onClick={() => ref.current.close()}>close</button>
+        {props.moreBackgroundContent}
       </div>
     </>
   );
@@ -74,6 +76,289 @@ export const _default = () => {
         style={{color: foregroundColor, backgroundColor}}
         backdropStyle={{backgroundColor: backdropColor}}
       />
+    </main>
+  );
+};
+
+export const scroll = () => {
+  const sideConfigurations = ['left', 'right', undefined];
+  const side = select('side', sideConfigurations, sideConfigurations[0]);
+  const foregroundColor = color('color');
+  const backgroundColor = color('background');
+  const backdropColor = color('backdrop color');
+  const moreBackgroundContent = boolean('more background content', false);
+  const moreSidebarContent = boolean('more sidebar content', false);
+
+  return (
+    <main>
+      <SidebarWithActions
+        side={side}
+        style={{color: foregroundColor, backgroundColor}}
+        backdropStyle={{backgroundColor: backdropColor}}
+        moreBackgroundContent={
+          moreBackgroundContent && (
+            <>
+              <p>
+                Dessert tootsie roll marzipan pastry. Powder powder jelly beans
+                chocolate bar candy sugar plum. Jelly-o gummi bears jelly icing
+                cotton candy. Toffee carrot cake ice cream sesame snaps sugar
+                plum gummies. Gummies marshmallow candy chocolate bar ice cream
+                ice cream gummies chocolate cake. Candy ice cream pie danish ice
+                cream cake gingerbread. Muffin cookie marzipan marzipan jelly
+                beans gummies candy muffin dessert. Soufflé chocolate tart
+                tootsie roll tootsie roll gingerbread icing powder. Dessert
+                croissant macaroon candy liquorice. Gingerbread gummi bears
+                croissant wafer cookie cookie bonbon. Marshmallow fruitcake
+                lollipop sweet roll danish dragée cupcake. Tootsie roll cotton
+                candy dragée chocolate bar tootsie roll cheesecake cookie
+                muffin. Toffee sesame snaps gingerbread wafer cotton candy
+                bonbon gingerbread toffee.
+              </p>
+
+              <p>
+                Danish cupcake chocolate candy chocolate bar. Topping brownie
+                toffee oat cake liquorice marzipan cheesecake chupa chups.
+                Pastry carrot cake jelly beans chocolate cake liquorice sesame
+                snaps caramels. Apple pie marshmallow chupa chups lemon drops
+                pudding cotton candy pie apple pie oat cake. Sugar plum halvah
+                cotton candy tiramisu sweet dragée cookie pastry. Macaroon
+                bonbon jujubes. Halvah tiramisu brownie topping donut cookie
+                tart. Jelly lemon drops soufflé pie chocolate bar donut tootsie
+                roll bear claw cake. Chocolate cake powder dessert. Pudding
+                wafer danish chupa chups donut chocolate sweet carrot cake.
+                Sugar plum cheesecake brownie chocolate sweet tart marzipan oat
+                cake dessert. Gummi bears sugar plum bonbon chocolate cake.
+                Croissant marzipan brownie dessert donut cotton candy croissant
+                powder. Chocolate cake tootsie roll sweet roll gummi bears donut
+                fruitcake jelly beans carrot cake.
+              </p>
+
+              <p>
+                Brownie gummies danish lollipop caramels wafer gingerbread
+                macaroon carrot cake. Brownie powder donut gummi bears pudding
+                cupcake. Lemon drops croissant apple pie sesame snaps marzipan.
+                Biscuit chocolate cake jelly-o pie caramels gingerbread caramels
+                chupa chups donut. Sweet roll oat cake cake. Cheesecake candy
+                canes candy canes candy canes topping pastry sweet cheesecake.
+                Jelly-o gummies topping marshmallow dessert tiramisu cake bonbon
+                chupa chups. Chocolate biscuit danish tart bear claw. Tiramisu
+                carrot cake jelly-o pie sweet cake. Sesame snaps lollipop cookie
+                chocolate cake wafer dragée. Powder brownie danish. Pastry
+                chocolate cake sweet roll halvah cupcake dragée.
+              </p>
+
+              <p>
+                Cake carrot cake icing danish biscuit carrot cake marzipan
+                croissant. Cake cake gummi bears fruitcake sweet dessert toffee
+                chocolate cake. Ice cream carrot cake donut jelly beans. Jelly
+                wafer sugar plum sweet icing candy canes. Bonbon marshmallow
+                donut pudding jelly-o tiramisu pastry cake bonbon. Jelly candy
+                canes liquorice cupcake liquorice dessert halvah toffee. Jelly
+                chocolate macaroon topping cupcake tootsie roll liquorice
+                brownie lollipop. Chupa chups wafer cupcake candy cookie oat
+                cake cookie bear claw. Carrot cake pudding biscuit tiramisu ice
+                cream sugar plum. Topping lemon drops dragée cake liquorice
+                apple pie ice cream. Cotton candy lollipop lemon drops apple pie
+                tootsie roll pie marshmallow chocolate jelly-o. Pastry bonbon
+                cupcake dragée candy.
+              </p>
+
+              <p>
+                Ice cream dragée pudding pastry biscuit tart cookie. Oat cake
+                ice cream apple pie oat cake dessert soufflé caramels apple pie.
+                Gummies bear claw powder cake icing jelly beans jelly beans
+                marzipan lollipop. Lollipop brownie jelly beans pudding. Ice
+                cream jelly biscuit pie tiramisu tootsie roll gummies biscuit.
+                Cupcake biscuit biscuit chocolate bar liquorice caramels powder
+                cotton candy muffin. Sesame snaps tiramisu croissant. Soufflé
+                chocolate jelly-o topping. Lemon drops candy canes sweet carrot
+                cake chocolate cake tootsie roll wafer marshmallow. Jelly beans
+                bear claw jelly-o sesame snaps carrot cake. Pudding jelly candy
+                carrot cake fruitcake carrot cake candy canes sesame snaps.
+                Marzipan icing caramels chocolate tart powder cookie halvah.
+                Fruitcake dragée muffin tart. Jelly-o cupcake marshmallow
+                pudding gummies muffin topping caramels.
+              </p>
+
+              <p>
+                Liquorice bear claw marshmallow dessert. Bear claw toffee pastry
+                tiramisu apple pie oat cake. Tiramisu jelly gingerbread cake
+                cake sweet roll cupcake ice cream jelly. Fruitcake jelly beans
+                macaroon soufflé jelly beans marzipan caramels candy. Cheesecake
+                candy canes pudding icing icing. Dragée chocolate bar bear claw
+                dragée donut brownie cake sweet roll. Wafer bear claw dragée
+                icing sesame snaps topping. Cake marzipan bear claw dessert bear
+                claw lollipop halvah wafer halvah. Icing sweet roll toffee sweet
+                powder sesame snaps gummies tart danish. Ice cream toffee
+                caramels danish. Jelly-o lollipop lollipop dessert sesame snaps
+                bear claw gummi bears. Donut sweet roll marzipan fruitcake oat
+                cake cake icing cotton candy oat cake. Gingerbread carrot cake
+                sesame snaps gummies candy dragée lollipop soufflé biscuit.
+                Pudding jujubes chocolate halvah sesame snaps tiramisu sweet
+                marshmallow chocolate bar.
+              </p>
+
+              <p>
+                Donut carrot cake apple pie powder marshmallow sesame snaps
+                tiramisu. Sweet roll powder cookie. Lollipop sugar plum oat
+                cake. Marshmallow wafer danish wafer gingerbread cake muffin
+                candy dragée. Candy cotton candy topping cake cotton candy
+                carrot cake fruitcake brownie. Toffee candy candy canes jelly-o
+                cotton candy gummies. Bonbon bonbon pie sugar plum. Oat cake
+                sesame snaps pudding candy canes gummi bears macaroon jelly
+                beans brownie. Sesame snaps halvah halvah jelly-o dessert.
+                Jelly-o chocolate sweet roll donut candy. Cotton candy halvah
+                macaroon tiramisu tart. Jelly toffee candy pie toffee.
+              </p>
+
+              <p>
+                Powder chupa chups muffin jelly-o soufflé. Lollipop sweet roll
+                sweet roll brownie pastry tootsie roll. Topping cheesecake pie
+                jelly. Donut wafer wafer cake candy canes. Topping chocolate bar
+                cheesecake topping ice cream tiramisu toffee ice cream. Bonbon
+                halvah marshmallow. Marzipan topping chupa chups dessert
+                chocolate chocolate cake gummi bears. Gummi bears caramels sugar
+                plum. Pie donut jelly beans tiramisu soufflé pie powder. Cupcake
+                cookie topping. Tootsie roll candy canes jujubes croissant
+                liquorice ice cream brownie. Topping cookie apple pie gummi
+                bears bear claw jelly-o brownie tart. Marzipan cotton candy
+                gummi bears. Dragée ice cream gummi bears jelly-o carrot cake
+                chocolate bar tiramisu jelly cotton candy.
+              </p>
+            </>
+          )
+        }
+      >
+        {moreSidebarContent && (
+          <>
+            <p>
+              Dessert tootsie roll marzipan pastry. Powder powder jelly beans
+              chocolate bar candy sugar plum. Jelly-o gummi bears jelly icing
+              cotton candy. Toffee carrot cake ice cream sesame snaps sugar plum
+              gummies. Gummies marshmallow candy chocolate bar ice cream ice
+              cream gummies chocolate cake. Candy ice cream pie danish ice cream
+              cake gingerbread. Muffin cookie marzipan marzipan jelly beans
+              gummies candy muffin dessert. Soufflé chocolate tart tootsie roll
+              tootsie roll gingerbread icing powder. Dessert croissant macaroon
+              candy liquorice. Gingerbread gummi bears croissant wafer cookie
+              cookie bonbon. Marshmallow fruitcake lollipop sweet roll danish
+              dragée cupcake. Tootsie roll cotton candy dragée chocolate bar
+              tootsie roll cheesecake cookie muffin. Toffee sesame snaps
+              gingerbread wafer cotton candy bonbon gingerbread toffee.
+            </p>
+
+            <p>
+              Danish cupcake chocolate candy chocolate bar. Topping brownie
+              toffee oat cake liquorice marzipan cheesecake chupa chups. Pastry
+              carrot cake jelly beans chocolate cake liquorice sesame snaps
+              caramels. Apple pie marshmallow chupa chups lemon drops pudding
+              cotton candy pie apple pie oat cake. Sugar plum halvah cotton
+              candy tiramisu sweet dragée cookie pastry. Macaroon bonbon
+              jujubes. Halvah tiramisu brownie topping donut cookie tart. Jelly
+              lemon drops soufflé pie chocolate bar donut tootsie roll bear claw
+              cake. Chocolate cake powder dessert. Pudding wafer danish chupa
+              chups donut chocolate sweet carrot cake. Sugar plum cheesecake
+              brownie chocolate sweet tart marzipan oat cake dessert. Gummi
+              bears sugar plum bonbon chocolate cake. Croissant marzipan brownie
+              dessert donut cotton candy croissant powder. Chocolate cake
+              tootsie roll sweet roll gummi bears donut fruitcake jelly beans
+              carrot cake.
+            </p>
+
+            <p>
+              Brownie gummies danish lollipop caramels wafer gingerbread
+              macaroon carrot cake. Brownie powder donut gummi bears pudding
+              cupcake. Lemon drops croissant apple pie sesame snaps marzipan.
+              Biscuit chocolate cake jelly-o pie caramels gingerbread caramels
+              chupa chups donut. Sweet roll oat cake cake. Cheesecake candy
+              canes candy canes candy canes topping pastry sweet cheesecake.
+              Jelly-o gummies topping marshmallow dessert tiramisu cake bonbon
+              chupa chups. Chocolate biscuit danish tart bear claw. Tiramisu
+              carrot cake jelly-o pie sweet cake. Sesame snaps lollipop cookie
+              chocolate cake wafer dragée. Powder brownie danish. Pastry
+              chocolate cake sweet roll halvah cupcake dragée.
+            </p>
+
+            <p>
+              Cake carrot cake icing danish biscuit carrot cake marzipan
+              croissant. Cake cake gummi bears fruitcake sweet dessert toffee
+              chocolate cake. Ice cream carrot cake donut jelly beans. Jelly
+              wafer sugar plum sweet icing candy canes. Bonbon marshmallow donut
+              pudding jelly-o tiramisu pastry cake bonbon. Jelly candy canes
+              liquorice cupcake liquorice dessert halvah toffee. Jelly chocolate
+              macaroon topping cupcake tootsie roll liquorice brownie lollipop.
+              Chupa chups wafer cupcake candy cookie oat cake cookie bear claw.
+              Carrot cake pudding biscuit tiramisu ice cream sugar plum. Topping
+              lemon drops dragée cake liquorice apple pie ice cream. Cotton
+              candy lollipop lemon drops apple pie tootsie roll pie marshmallow
+              chocolate jelly-o. Pastry bonbon cupcake dragée candy.
+            </p>
+
+            <p>
+              Ice cream dragée pudding pastry biscuit tart cookie. Oat cake ice
+              cream apple pie oat cake dessert soufflé caramels apple pie.
+              Gummies bear claw powder cake icing jelly beans jelly beans
+              marzipan lollipop. Lollipop brownie jelly beans pudding. Ice cream
+              jelly biscuit pie tiramisu tootsie roll gummies biscuit. Cupcake
+              biscuit biscuit chocolate bar liquorice caramels powder cotton
+              candy muffin. Sesame snaps tiramisu croissant. Soufflé chocolate
+              jelly-o topping. Lemon drops candy canes sweet carrot cake
+              chocolate cake tootsie roll wafer marshmallow. Jelly beans bear
+              claw jelly-o sesame snaps carrot cake. Pudding jelly candy carrot
+              cake fruitcake carrot cake candy canes sesame snaps. Marzipan
+              icing caramels chocolate tart powder cookie halvah. Fruitcake
+              dragée muffin tart. Jelly-o cupcake marshmallow pudding gummies
+              muffin topping caramels.
+            </p>
+
+            <p>
+              Liquorice bear claw marshmallow dessert. Bear claw toffee pastry
+              tiramisu apple pie oat cake. Tiramisu jelly gingerbread cake cake
+              sweet roll cupcake ice cream jelly. Fruitcake jelly beans macaroon
+              soufflé jelly beans marzipan caramels candy. Cheesecake candy
+              canes pudding icing icing. Dragée chocolate bar bear claw dragée
+              donut brownie cake sweet roll. Wafer bear claw dragée icing sesame
+              snaps topping. Cake marzipan bear claw dessert bear claw lollipop
+              halvah wafer halvah. Icing sweet roll toffee sweet powder sesame
+              snaps gummies tart danish. Ice cream toffee caramels danish.
+              Jelly-o lollipop lollipop dessert sesame snaps bear claw gummi
+              bears. Donut sweet roll marzipan fruitcake oat cake cake icing
+              cotton candy oat cake. Gingerbread carrot cake sesame snaps
+              gummies candy dragée lollipop soufflé biscuit. Pudding jujubes
+              chocolate halvah sesame snaps tiramisu sweet marshmallow chocolate
+              bar.
+            </p>
+
+            <p>
+              Donut carrot cake apple pie powder marshmallow sesame snaps
+              tiramisu. Sweet roll powder cookie. Lollipop sugar plum oat cake.
+              Marshmallow wafer danish wafer gingerbread cake muffin candy
+              dragée. Candy cotton candy topping cake cotton candy carrot cake
+              fruitcake brownie. Toffee candy candy canes jelly-o cotton candy
+              gummies. Bonbon bonbon pie sugar plum. Oat cake sesame snaps
+              pudding candy canes gummi bears macaroon jelly beans brownie.
+              Sesame snaps halvah halvah jelly-o dessert. Jelly-o chocolate
+              sweet roll donut candy. Cotton candy halvah macaroon tiramisu
+              tart. Jelly toffee candy pie toffee.
+            </p>
+
+            <p>
+              Powder chupa chups muffin jelly-o soufflé. Lollipop sweet roll
+              sweet roll brownie pastry tootsie roll. Topping cheesecake pie
+              jelly. Donut wafer wafer cake candy canes. Topping chocolate bar
+              cheesecake topping ice cream tiramisu toffee ice cream. Bonbon
+              halvah marshmallow. Marzipan topping chupa chups dessert chocolate
+              chocolate cake gummi bears. Gummi bears caramels sugar plum. Pie
+              donut jelly beans tiramisu soufflé pie powder. Cupcake cookie
+              topping. Tootsie roll candy canes jujubes croissant liquorice ice
+              cream brownie. Topping cookie apple pie gummi bears bear claw
+              jelly-o brownie tart. Marzipan cotton candy gummi bears. Dragée
+              ice cream gummi bears jelly-o carrot cake chocolate bar tiramisu
+              jelly cotton candy.
+            </p>
+          </>
+        )}
+      </SidebarWithActions>
     </main>
   );
 };

--- a/extensions/amp-sidebar/1.0/test/test-amp-sidebar.js
+++ b/extensions/amp-sidebar/1.0/test/test-amp-sidebar.js
@@ -401,6 +401,25 @@ describes.realWin(
         win.document.dir = documentDir;
       });
 
+      it('should have `overscroll-behavior: none` to prevent background scrolling', async () => {
+        // open the sidebar
+        openButton.click();
+        await waitForOpen(element, true);
+        expect(element).to.have.attribute('open');
+
+        const {
+          firstElementChild: sidebarElement,
+          lastElementChild: backdropElement,
+        } = container;
+
+        expect(
+          win.getComputedStyle(sidebarElement).overscrollBehavior
+        ).to.equal('none');
+        expect(
+          win.getComputedStyle(backdropElement).overscrollBehavior
+        ).to.equal('none');
+      });
+
       describe('programatic access to imperative API', () => {
         it('open', async () => {
           // sidebar is initially closed


### PR DESCRIPTION
Sidebar tracker: https://github.com/ampproject/amphtml/issues/31366

Important Note: This PR represents a workaround to ensure overscroll-behavior works properly.  The workaround includes adding a large element as the child of the backdrop to force the scroll behavior on backdrop.  A bug has been filed with the chrome team here: https://bugs.chromium.org/p/chromium/issues/detail?id=1176733

Once the bug has been fixed in ALL MAJOR BROWSERS, the following fix should be implemented:
1. Set `overscroll-behavior` to `none` and `overflow` to `scroll` on both backdrop and sidebar elements.  Expected behavior is that the background does not scroll when scrolling on the sidebar or backdrop elements.
2. See if the bug fix has other requirements and implement as needed!
******
When inside of the sidebar or the backdrop of the sidebar, scrolling up and down should not cause the underlying content (behind the sidebar and backdrop to scroll up and down).

Covers the following use cases:
1. Scrolling on sidebar when sidebar scrolls
2. Scrolling on sidebar when sidebar does not have enough content to scroll
3. Scrolling on the backdrop

How it works:
1. Create a larger invisible element that is the child of the backdrop.  This forces the backdrop to have scroll behavior.  Backdrop gets `overscroll-behavior: none` so that any scrolls on the child element do no propagate out of the backdrop.  `overscroll-behavior: none` only works when the element actually has scroll behavior.
2. Scroll chaining appears to follow z-index. i.e. since the Sidebar is on top of the backdrop, the Sidebar's scroll chaining goes to the backdrop.  Since backdrop scroll chaining is disabled, we can handle the sidebar case through the backdrop.
3. Sidebar element maintains `overflow: auto` so scroll bar will show up only when there is enough content to scroll.