### PR TITLE
measureIntersection: use root=document

### DIFF
--- a/src/service/video-manager-impl.js
+++ b/src/service/video-manager-impl.js
@@ -206,7 +206,7 @@ export class VideoManager {
       this.viewportObserver_ = createViewportObserver(
         viewportCallback,
         this.ampdoc.win,
-        /* threshold */ MIN_VISIBILITY_RATIO_FOR_AUTOPLAY
+        {threshold: MIN_VISIBILITY_RATIO_FOR_AUTOPLAY}
       );
     }
     this.viewportObserver_.observe(videoBE.element);

--- a/src/utils/intersection.js
+++ b/src/utils/intersection.js
@@ -35,20 +35,24 @@ function getInOb(win) {
   }
 
   if (!intersectionObservers.has(win)) {
-    const observer = createViewportObserver((entries) => {
-      const seen = new Set();
-      for (let i = entries.length - 1; i >= 0; i--) {
-        const {target} = entries[i];
-        if (seen.has(target)) {
-          continue;
-        }
-        seen.add(target);
+    const observer = createViewportObserver(
+      (entries) => {
+        const seen = new Set();
+        for (let i = entries.length - 1; i >= 0; i--) {
+          const {target} = entries[i];
+          if (seen.has(target)) {
+            continue;
+          }
+          seen.add(target);
 
-        observer.unobserve(target);
-        intersectionDeferreds.get(target).resolve(entries[i]);
-        intersectionDeferreds.delete(target);
-      }
-    }, win);
+          observer.unobserve(target);
+          intersectionDeferreds.get(target).resolve(entries[i]);
+          intersectionDeferreds.delete(target);
+        }
+      },
+      win,
+      {needsRootBounds: true}
+    );
     intersectionObservers.set(win, observer);
     return observer;
   }

--- a/src/viewport-observer.js
+++ b/src/viewport-observer.js
@@ -27,11 +27,8 @@ import {toWin} from './types';
  *
  * @return {!IntersectionObserver}
  */
-export function createViewportObserver(
-  ioCallback,
-  win,
-  {threshold, needsRootBounds = false} = {}
-) {
+export function createViewportObserver(ioCallback, win, opts = {}) {
+  const {threshold, needsRootBounds} = opts;
   return new win.IntersectionObserver(ioCallback, {
     threshold,
     root: isIframed(win) && needsRootBounds ? win.document : undefined,

--- a/src/viewport-observer.js
+++ b/src/viewport-observer.js
@@ -22,12 +22,19 @@ import {toWin} from './types';
  *
  * @param {function(!Array<!IntersectionObserverEntry>)} ioCallback
  * @param {!Window} win
- * @param {(number|!Array<number>)=} threshold
+ * @param {{threshold: (number|!Array<number>)=, needsRootBounds: boolean=}=} opts
  *
  * @return {!IntersectionObserver}
  */
-export function createViewportObserver(ioCallback, win, threshold) {
-  return new win.IntersectionObserver(ioCallback, {threshold});
+export function createViewportObserver(
+  ioCallback,
+  win,
+  {threshold, needsRootBounds = false}
+) {
+  return new win.IntersectionObserver(ioCallback, {
+    threshold,
+    root: isIframed(win) && needsRootBounds ? win.document : undefined,
+  });
 }
 
 /** @type {!WeakMap<!Window, !IntersectionObserver>} */

--- a/src/viewport-observer.js
+++ b/src/viewport-observer.js
@@ -15,6 +15,7 @@
  */
 import {devAssert} from '../src/log';
 import {getMode} from './mode';
+import {isIframed} from './dom';
 import {toWin} from './types';
 
 /**
@@ -29,7 +30,7 @@ import {toWin} from './types';
 export function createViewportObserver(
   ioCallback,
   win,
-  {threshold, needsRootBounds = false}
+  {threshold, needsRootBounds = false} = {}
 ) {
   return new win.IntersectionObserver(ioCallback, {
     threshold,

--- a/test/fixtures/3p-ad.html
+++ b/test/fixtures/3p-ad.html
@@ -5,9 +5,6 @@
   <title>We can render an ad</title>
   <link rel="canonical" href="https://www.example.com/doubleclick.html" >
   <style>
-    body {
-      margin: 0;
-    }
     .fill {
       width: 100px;
       min-height: 1000px;

--- a/test/fixtures/3p-ad.html
+++ b/test/fixtures/3p-ad.html
@@ -5,6 +5,9 @@
   <title>We can render an ad</title>
   <link rel="canonical" href="https://www.example.com/doubleclick.html" >
   <style>
+    body {
+      margin: 0;
+    }
     .fill {
       width: 100px;
       min-height: 1000px;

--- a/test/integration/test-amp-ad-3p.js
+++ b/test/integration/test-amp-ad-3p.js
@@ -21,8 +21,13 @@ import {installPlatformService} from '../../src/service/platform-impl';
 import {layoutRectLtwh} from '../../src/layout-rect';
 import {toggleExperiment} from '../../src/experiments';
 
+const IFRAME_HEIGHT = 3000;
 function createFixture() {
-  return createFixtureIframe('test/fixtures/3p-ad.html', 3000, () => {});
+  return createFixtureIframe(
+    'test/fixtures/3p-ad.html',
+    IFRAME_HEIGHT,
+    () => {}
+  );
 }
 
 describe('amp-ad 3P', () => {
@@ -36,7 +41,7 @@ describe('amp-ad 3P', () => {
   });
 
   it('create an iframe with APIs', async function () {
-    toggleExperiment(window, 'ads-initialIntersection', )
+    toggleExperiment(window, 'ads-initialIntersection');
     this.timeout(20000);
     let iframe;
     let lastIO = null;
@@ -96,23 +101,18 @@ describe('amp-ad 3P', () => {
           width: 300,
         });
         const {initialIntersection} = context;
-        console.error(JSON.stringify(initialIntersection.rootBounds));
-        console.error(
-          JSON.stringify(
-            layoutRectLtwh(
-              0,
-              0,
-              window.document.body.clientWidth,
-              window.document.body.clientHeight,
-            )
-          )
-        );
         expect(initialIntersection.rootBounds).to.deep.equal(
           layoutRectLtwh(
             0,
             0,
-            iframe.contentWindow.innerWidth,
-            iframe.contentWindow.innerHeight
+            Math.min(
+              iframe.ownerDocument.body.clientWidth,
+              iframe.ownerDocument.defaultView.innerWidth
+            ),
+            Math.min(
+              iframe.ownerDocument.body.clientHeight,
+              iframe.ownerDocument.defaultView.innerHeight
+            )
           )
         );
 

--- a/test/integration/test-amp-ad-3p.js
+++ b/test/integration/test-amp-ad-3p.js
@@ -36,7 +36,7 @@ describe('amp-ad 3P', () => {
   });
 
   it('create an iframe with APIs', async function () {
-    toggleExperiment(window, 'ads-initialIntersection');
+    toggleExperiment(window, 'ads-initialIntersection', )
     this.timeout(20000);
     let iframe;
     let lastIO = null;
@@ -96,8 +96,24 @@ describe('amp-ad 3P', () => {
           width: 300,
         });
         const {initialIntersection} = context;
+        console.error(JSON.stringify(initialIntersection.rootBounds));
+        console.error(
+          JSON.stringify(
+            layoutRectLtwh(
+              0,
+              0,
+              window.document.body.clientWidth,
+              window.document.body.clientHeight,
+            )
+          )
+        );
         expect(initialIntersection.rootBounds).to.deep.equal(
-          layoutRectLtwh(0, 0, window.innerWidth, window.innerHeight)
+          layoutRectLtwh(
+            0,
+            0,
+            iframe.contentWindow.innerWidth,
+            iframe.contentWindow.innerHeight
+          )
         );
 
         expect(initialIntersection.boundingClientRect).to.deep.equal(

--- a/test/unit/test-viewport-observer.js
+++ b/test/unit/test-viewport-observer.js
@@ -37,12 +37,26 @@ describes.sandboxed('Viewport Observer', {}, (env) => {
 
     it('Uses implicit root.', () => {
       createViewportObserver(noop, win);
-      expect(ctorSpy).calledWith(noop, {threshold: undefined});
+      expect(ctorSpy).calledWith(noop, {threshold: undefined, root: undefined});
     });
 
     it('Pass along threshold argument', () => {
-      createViewportObserver(noop, win, 0.5);
-      expect(ctorSpy).calledWith(noop, {threshold: 0.5});
+      createViewportObserver(noop, win, {threshold: 0.5});
+      expect(ctorSpy).calledWith(noop, {threshold: 0.5, root: undefined});
+    });
+
+    it('Sets document root appropriately', () => {
+      // Implicit root when not iframed.
+      createViewportObserver(noop, win, {needsRootBounds: true});
+      expect(ctorSpy).calledWith(noop, {threshold: undefined, root: undefined});
+
+      // Document root when iframed.
+      win.parent = {};
+      createViewportObserver(noop, win, {needsRootBounds: true});
+      expect(ctorSpy).calledWith(noop, {
+        threshold: undefined,
+        root: win.document,
+      });
     });
   });
 


### PR DESCRIPTION
**summary**
- When iframed we should likely always use `root:document` for InObs. Otherwise rootBounds=null.
- question: should default for `needsRootBounds` be true or false?

I recommend viewing the diff [without whitespace](https://github.com/ampproject/amphtml/pull/32402/files?w=1) changes