### PR TITLE
 🏗   ✅  🐛  Add safari web driver builder

### DIFF
--- a/build-system/tasks/e2e/describes-e2e.js
+++ b/build-system/tasks/e2e/describes-e2e.js
@@ -189,6 +189,8 @@ function createDriver(browserName, args, deviceName) {
       //which is also when `Server terminated early with status 1` began appearing. Coincidence? Maybe.
       driver.onQuit = null;
       return driver;
+    case 'safari':
+      return new Builder().forBrowser(browserName).build();
   }
 }
 


### PR DESCRIPTION
When attempting to run the e2e tests using safari the driver was never being constructed so the tests would not run.

Unfortunately safari does not support arguments like firefox and chrome, but the tests do run and pass now.

`gulp e2e --browsers=safari`

Fixes #24009 