### PR TITLE
[amp-story-player] Throw error when trying to call load() on player that isn't attached to the DOM

### DIFF
--- a/spec/amp-story-player.md
+++ b/spec/amp-story-player.md
@@ -129,6 +129,8 @@ Call the player's various methods to programmatically control the player. These 
 
 Will initialize the player manually. This can be useful when the player is dynamically.
 
+Note that the element must be connected to the DOM before calling `load()`.
+
 ```javascript
 const playerEl = document.body.querySelector('amp-story-player');
 const player = new AmpStoryPlayer(window, playerEl);

--- a/src/amp-story-player/amp-story-player-impl.js
+++ b/src/amp-story-player/amp-story-player-impl.js
@@ -648,7 +648,7 @@ export class AmpStoryPlayer {
       this.rootEl_.classList.remove(LoadStateClass.LOADING);
       this.rootEl_.classList.add(LoadStateClass.ERROR);
       this.element_.classList.add(LoadStateClass.ERROR);
-      iframeEl.loadDeferred.reject();
+      iframeEl.loadDeferred.reject('Error loading iframe.');
     };
   }
 

--- a/src/amp-story-player/amp-story-player-impl.js
+++ b/src/amp-story-player/amp-story-player-impl.js
@@ -261,7 +261,7 @@ export class AmpStoryPlayer {
    * @public
    */
   load() {
-    if (!this.doc_.querySelector('amp-story-player')) {
+    if (!this.doc_.querySelector(TAG)) {
       throw new Error(
         `[${TAG}] element must be appended to the DOM before calling load().`
       );

--- a/src/amp-story-player/amp-story-player-impl.js
+++ b/src/amp-story-player/amp-story-player-impl.js
@@ -261,9 +261,9 @@ export class AmpStoryPlayer {
    * @public
    */
   load() {
-    if (!this.doc_.querySelector(TAG)) {
+    if (!this.element_.isConnected) {
       throw new Error(
-        `[${TAG}] element must be appended to the DOM before calling load().`
+        `[${TAG}] element must be connected to the DOM before calling load().`
       );
     }
     this.buildCallback();

--- a/test/unit/test-amp-story-player.js
+++ b/test/unit/test-amp-story-player.js
@@ -23,6 +23,7 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
   let playerEl;
   let manager;
   let fakeResponse;
+  const TAG = 'amp-story-player';
 
   const fireHandler = [];
   const DEFAULT_CACHE_URL =
@@ -469,12 +470,13 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
   });
 
   describe('Player API', () => {
-    function appendStoriesToPlayer(playerEl, numStories) {
+    function attachPlayerWithStories(playerEl, numStories) {
       for (let i = 0; i < numStories; i++) {
         const story = win.document.createElement('a');
         story.setAttribute('href', `https://example.com/story${i}.html`);
         playerEl.appendChild(story);
       }
+      win.document.body.appendChild(playerEl);
     }
 
     // Creates an array of story objects with a unique random URL.
@@ -514,11 +516,22 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
       expect(playerEl.isReady).to.be.true;
     });
 
-    it('load callback builds iframe inside the player', async () => {
+    it('load callback throws if player is not appended to the DOM', async () => {
       const playerEl = win.document.createElement('amp-story-player');
       const story = win.document.createElement('a');
       story.setAttribute('href', DEFAULT_CACHE_URL);
       playerEl.appendChild(story);
+
+      const player = new AmpStoryPlayer(win, playerEl);
+
+      return expect(() => player.load()).to.throw(
+        `[${TAG}] element must be appended to the DOM before calling load().`
+      );
+    });
+
+    it('load callback builds iframe inside the player', async () => {
+      const playerEl = win.document.createElement('amp-story-player');
+      attachPlayerWithStories(playerEl, 1);
 
       const player = new AmpStoryPlayer(win, playerEl);
 
@@ -529,7 +542,7 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
 
     it('show callback builds corresponding adjacent iframes', async () => {
       const playerEl = win.document.createElement('amp-story-player');
-      appendStoriesToPlayer(playerEl, 5);
+      attachPlayerWithStories(playerEl, 5);
 
       const player = new AmpStoryPlayer(win, playerEl);
 
@@ -552,7 +565,7 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
 
     it('show() callback should prerender next story after current one is loaded', async () => {
       const playerEl = win.document.createElement('amp-story-player');
-      appendStoriesToPlayer(playerEl, 5);
+      attachPlayerWithStories(playerEl, 5);
 
       const player = new AmpStoryPlayer(win, playerEl);
 
@@ -580,7 +593,7 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
     // TODO(proyectoramirez): delete once add() is implemented.
     it('show callback should throw when story is not found', async () => {
       const playerEl = win.document.createElement('amp-story-player');
-      appendStoriesToPlayer(playerEl, 5);
+      attachPlayerWithStories(playerEl, 5);
 
       const player = new AmpStoryPlayer(win, playerEl);
 
@@ -732,7 +745,7 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
     it('back button should be created and close button should not', async () => {
       const playerEl = win.document.createElement('amp-story-player');
       playerEl.setAttribute('exit-control', 'back-button');
-      appendStoriesToPlayer(playerEl, 5);
+      attachPlayerWithStories(playerEl, 5);
 
       const player = new AmpStoryPlayer(win, playerEl);
 
@@ -747,7 +760,7 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
     it('close button should be created and back button should not', async () => {
       const playerEl = win.document.createElement('amp-story-player');
       playerEl.setAttribute('exit-control', 'close-button');
-      appendStoriesToPlayer(playerEl, 5);
+      attachPlayerWithStories(playerEl, 5);
 
       const player = new AmpStoryPlayer(win, playerEl);
 
@@ -761,7 +774,7 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
     it('no button should be created', async () => {
       const playerEl = win.document.createElement('amp-story-player');
       playerEl.setAttribute('exit-control', 'brokenattribute');
-      appendStoriesToPlayer(playerEl, 5);
+      attachPlayerWithStories(playerEl, 5);
 
       const player = new AmpStoryPlayer(win, playerEl);
 
@@ -776,7 +789,7 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
     it('back button should fire back event once', async () => {
       const playerEl = win.document.createElement('amp-story-player');
       playerEl.setAttribute('exit-control', 'back-button');
-      appendStoriesToPlayer(playerEl, 5);
+      attachPlayerWithStories(playerEl, 5);
 
       const player = new AmpStoryPlayer(win, playerEl);
 
@@ -793,7 +806,7 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
     it('close button should fire close event once', async () => {
       const playerEl = win.document.createElement('amp-story-player');
       playerEl.setAttribute('exit-control', 'close-button');
-      appendStoriesToPlayer(playerEl, 5);
+      attachPlayerWithStories(playerEl, 5);
 
       const player = new AmpStoryPlayer(win, playerEl);
       await player.load();
@@ -824,7 +837,7 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
     it('should display button when page attachment is closed', async () => {
       const playerEl = win.document.createElement('amp-story-player');
       playerEl.setAttribute('exit-control', 'back-button');
-      appendStoriesToPlayer(playerEl, 1);
+      attachPlayerWithStories(playerEl, 1);
 
       const player = new AmpStoryPlayer(win, playerEl);
       await player.load();
@@ -873,7 +886,7 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
 
     it('navigate forward given a positive number in range', async () => {
       const playerEl = win.document.createElement('amp-story-player');
-      appendStoriesToPlayer(playerEl, 5);
+      attachPlayerWithStories(playerEl, 5);
 
       const player = new AmpStoryPlayer(win, playerEl);
 
@@ -896,7 +909,7 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
 
     it('navigate backward given a negative number in range', async () => {
       const playerEl = win.document.createElement('amp-story-player');
-      appendStoriesToPlayer(playerEl, 5);
+      attachPlayerWithStories(playerEl, 5);
 
       const player = new AmpStoryPlayer(win, playerEl);
 
@@ -920,7 +933,7 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
 
     it('not navigate given zero', async () => {
       const playerEl = win.document.createElement('amp-story-player');
-      appendStoriesToPlayer(playerEl, 5);
+      attachPlayerWithStories(playerEl, 5);
 
       const player = new AmpStoryPlayer(win, playerEl);
 
@@ -935,7 +948,7 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
 
     it('go should throw when positive number is out of story range', async () => {
       const playerEl = win.document.createElement('amp-story-player');
-      appendStoriesToPlayer(playerEl, 5);
+      attachPlayerWithStories(playerEl, 5);
 
       const player = new AmpStoryPlayer(win, playerEl);
 
@@ -946,7 +959,7 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
 
     it('go should throw when negative number is out of story range', async () => {
       const playerEl = win.document.createElement('amp-story-player');
-      appendStoriesToPlayer(playerEl, 5);
+      attachPlayerWithStories(playerEl, 5);
 
       const player = new AmpStoryPlayer(win, playerEl);
 
@@ -957,7 +970,7 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
 
     it('go with page delta should change current story page', async () => {
       const playerEl = win.document.createElement('amp-story-player');
-      appendStoriesToPlayer(playerEl, 1);
+      attachPlayerWithStories(playerEl, 1);
 
       const player = new AmpStoryPlayer(win, playerEl);
 
@@ -975,7 +988,7 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
 
     it('navigate to id when calling gotToPageId', async () => {
       const playerEl = win.document.createElement('amp-story-player');
-      appendStoriesToPlayer(playerEl, 1);
+      attachPlayerWithStories(playerEl, 1);
 
       const player = new AmpStoryPlayer(win, playerEl);
 
@@ -995,7 +1008,7 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
 
     it('takes to first story when swiping on the last one with circular wrapping', async () => {
       const playerEl = win.document.createElement('amp-story-player');
-      appendStoriesToPlayer(playerEl, 5);
+      attachPlayerWithStories(playerEl, 5);
       playerEl.appendChild(buildCircularWrappingConfig());
 
       const player = new AmpStoryPlayer(win, playerEl);
@@ -1020,7 +1033,7 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
 
     it('takes to last story when swiping on the first one with circular wrapping', async () => {
       const playerEl = win.document.createElement('amp-story-player');
-      appendStoriesToPlayer(playerEl, 5);
+      attachPlayerWithStories(playerEl, 5);
       playerEl.appendChild(buildCircularWrappingConfig());
 
       const player = new AmpStoryPlayer(win, playerEl);
@@ -1044,7 +1057,7 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
 
     it('navigate to first story when last story is finished', async () => {
       const playerEl = win.document.createElement('amp-story-player');
-      appendStoriesToPlayer(playerEl, 5);
+      attachPlayerWithStories(playerEl, 5);
       playerEl.appendChild(buildCircularWrappingConfig());
 
       const player = new AmpStoryPlayer(win, playerEl);
@@ -1069,7 +1082,7 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
 
     it('navigate to last story when first story is requested to go back', async () => {
       const playerEl = win.document.createElement('amp-story-player');
-      appendStoriesToPlayer(playerEl, 5);
+      attachPlayerWithStories(playerEl, 5);
       playerEl.appendChild(buildCircularWrappingConfig());
 
       const player = new AmpStoryPlayer(win, playerEl);
@@ -1093,7 +1106,7 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
 
     it('should react to CURRENT_PAGE_ID events', async () => {
       const playerEl = win.document.createElement('amp-story-player');
-      appendStoriesToPlayer(playerEl, 1);
+      attachPlayerWithStories(playerEl, 1);
 
       const player = new AmpStoryPlayer(win, playerEl);
 

--- a/test/unit/test-amp-story-player.js
+++ b/test/unit/test-amp-story-player.js
@@ -525,7 +525,7 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
       const player = new AmpStoryPlayer(win, playerEl);
 
       return expect(() => player.load()).to.throw(
-        `[${TAG}] element must be appended to the DOM before calling load().`
+        `[${TAG}] element must be connected to the DOM before calling load().`
       );
     });
 


### PR DESCRIPTION
There will be some cases where publishers will create the player element dynamically and it will start not appended to the DOM. In these cases, when the iframe is not appended to the DOM, it will not have a `iframeEl.contentWindow`, which the messaging library uses to establish the communication.

With this PR, we will throw an error when trying to call `load()` before the player is appended to the DOM.

<!--
# Instructions:

- Pick a meaningful title for your pull request. (Use sentence case.)
  - Prefix the title with an emoji to identify what is being done. (Copy-paste the emoji from the list below.)
  - Do not overuse punctuation in the title (like `(chore):`).
  - If it is helpful, use a simple prefix (like `ProjectX: Implement some feature`).
- Enter a succinct description that says why the PR is necessary, and what it does.
  - Mention the GitHub issue that is being addressed by the pull request.
  - The keywords `Fixes`, `Closes`, or `Resolves` followed the issue number will automatically close the issue.

> NOTE: All non-trivial changes (like introducing new features or components) should have an associated issue or reference an I2I (intent-to-implement: go.amp.dev/i2i). Please read through the contribution process (go.amp.dev/contributing/code) for more information.

# Example of a good description:

- Implement aspect X
- Leave out feature Y because of A
- Improve performance by B
- Improve accessibility by C

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Reverting a previous change
♻️ Refactoring
🚮 Deleting code
🧪 Experimental code
-->
