### PR TITLE
Attempt to fix Circle push builds

### DIFF
--- a/.circleci/fetch_merge_commit.sh
+++ b/.circleci/fetch_merge_commit.sh
@@ -25,17 +25,17 @@ err=0
 GREEN() { echo -e "\n\033[0;32m$1\033[0m"; }
 RED() { echo -e "\n\033[0;31m$1\033[0m"; }
 
-# CIRCLE_PULL_REQUEST is present for PR builds, and absent for push builds.
-if [[ -z "$CIRCLE_PULL_REQUEST" ]]; then
+# CIRCLE_PR_NUMBER is present for PR builds, and absent for push builds.
+if [[ -z "$CIRCLE_PR_NUMBER" ]]; then
   echo $(GREEN "Nothing to do because this is not a PR build.")
   exit 0
 fi
 
 # Make sure the PR is on ampproject/amphtml and not on a fork.
-if [[ ! "$CIRCLE_PULL_REQUEST" =~ ^https://github.com/ampproject/amphtml* ]]; then
-  echo $(RED "This is a PR build, but on a repo other than ampproject/amphtml.")
-  exit 1
-fi
+# if [[ ! "$CIRCLE_PULL_REQUEST" =~ ^https://github.com/ampproject/amphtml* ]]; then
+  # echo $(RED "This is a PR build, but on a repo other than ampproject/amphtml.")
+  # exit 1
+# fi
 
 # CIRCLE_PR_NUMBER is present for PRs originating from forks, but absent for PRs
 # originating from a branch on the main repo. In such cases, extract the PR

--- a/.circleci/fetch_merge_commit.sh
+++ b/.circleci/fetch_merge_commit.sh
@@ -23,6 +23,7 @@ set -e
 err=0
 
 GREEN() { echo -e "\n\033[0;32m$1\033[0m"; }
+YELLOW() { echo -e "\033[0;33m$1\033[0m"; }
 RED() { echo -e "\n\033[0;31m$1\033[0m"; }
 
 # CIRCLE_PR_NUMBER is present for PR builds, and absent for push builds.
@@ -32,10 +33,9 @@ if [[ -z "$CIRCLE_PR_NUMBER" ]]; then
 fi
 
 # Make sure the PR is on ampproject/amphtml and not on a fork.
-# if [[ ! "$CIRCLE_PULL_REQUEST" =~ ^https://github.com/ampproject/amphtml* ]]; then
-  # echo $(RED "This is a PR build, but on a repo other than ampproject/amphtml.")
-  # exit 1
-# fi
+if [[ ! "$CIRCLE_PULL_REQUEST" =~ ^https://github.com/ampproject/amphtml* ]]; then
+  echo $(YELLOW "This build is linked to a repo other than ampproject/amphtml.")
+fi
 
 # CIRCLE_PR_NUMBER is present for PRs originating from forks, but absent for PRs
 # originating from a branch on the main repo. In such cases, extract the PR

--- a/.circleci/fetch_merge_commit.sh
+++ b/.circleci/fetch_merge_commit.sh
@@ -29,12 +29,12 @@ RED() { echo -e "\n\033[0;31m$1\033[0m"; }
 # CIRCLE_PR_NUMBER is present for PR builds, and absent for push builds.
 if [[ -z "$CIRCLE_PR_NUMBER" ]]; then
   echo $(GREEN "Nothing to do because this is not a PR build.")
+  # Warn if the build is linked to a PR on a different repo (known CircleCI bug).
+  if [[ -n "$CIRCLE_PULL_REQUEST" && ! "$CIRCLE_PULL_REQUEST" =~ ^https://github.com/ampproject/amphtml* ]]; then
+    echo $(YELLOW "WARNING: Build is incorrectly linked to a PR outside ampproject/amphtml:")
+    echo $(YELLOW "$CIRCLE_PULL_REQUEST")
+  fi
   exit 0
-fi
-
-# Make sure the PR is on ampproject/amphtml and not on a fork.
-if [[ ! "$CIRCLE_PULL_REQUEST" =~ ^https://github.com/ampproject/amphtml* ]]; then
-  echo $(YELLOW "This build is linked to a repo other than ampproject/amphtml.")
 fi
 
 # CIRCLE_PR_NUMBER is present for PRs originating from forks, but absent for PRs

--- a/.circleci/fetch_merge_commit.sh
+++ b/.circleci/fetch_merge_commit.sh
@@ -23,7 +23,7 @@ set -e
 err=0
 
 GREEN() { echo -e "\n\033[0;32m$1\033[0m"; }
-YELLOW() { echo -e "\033[0;33m$1\033[0m"; }
+YELLOW() { echo -e "\n\033[0;33m$1\033[0m"; }
 RED() { echo -e "\n\033[0;31m$1\033[0m"; }
 
 # CIRCLE_PR_NUMBER is present for PR builds, and absent for push builds.

--- a/build-system/common/ci.js
+++ b/build-system/common/ci.js
@@ -82,7 +82,7 @@ function isPullRequestBuild() {
     : isGithubActions
     ? env('GITHUB_EVENT_NAME') === 'pull_request'
     : isCircleci
-    ? !!env('CIRCLE_PULL_REQUEST')
+    ? !!env('CIRCLE_PR_NUMBER')
     : false;
 }
 
@@ -96,7 +96,7 @@ function isPushBuild() {
     : isGithubActions
     ? env('GITHUB_EVENT_NAME') === 'push'
     : isCircleci
-    ? !env('CIRCLE_PULL_REQUEST')
+    ? !env('CIRCLE_PR_NUMBER')
     : false;
 }
 


### PR DESCRIPTION
**Description edited by `rsimha`:**

CircleCI's PR builds have the `CIRCLE_PULL_REQUEST` and `CIRCLE_PR_NUMBER` env vars set, while push builds are supposed to have neither.

![image](https://user-images.githubusercontent.com/26553114/106824106-17581f00-6650-11eb-9cbd-aa60fe723116.png)

AMP's push builds are incorrectly getting the `CIRCLE_PULL_REQUEST` env var set due to a bug in CircleCI's use of APIs.

![image](https://user-images.githubusercontent.com/26553114/106823777-8123f900-664f-11eb-8395-1f67bf78e3ab.png)

This PR switches our PR build detection code to using `CIRCLE_PR_NUMBER`, which isn't being erroneously set. With this, our `master` commits should actually build fully while CircleCI fixes the API bug on their side. The builds could still be linked to a PR on an external fork if it references the commit (something that CircleCI is working on fixing).