### PR TITLE
Move ensureLoaded to CustomElement from owners

### DIFF
--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -589,7 +589,7 @@ const forbiddenTerms = {
   },
   '\\.scheduleLayoutOrPreload\\(': {
     message: 'scheduleLayoutOrPreload is a restricted API.',
-    allowlist: ['src/service/owners-impl.js', 'src/service/resources-impl.js'],
+    allowlist: ['src/custom-element.js', 'src/service/resources-impl.js'],
   },
   '(win|Win)(dow)?(\\(\\))?\\.open\\W': {
     message: 'Use dom.openWindowDialog',

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -56,8 +56,6 @@ const UpgradeState = {
   UPGRADE_IN_PROGRESS: 4,
 };
 
-const EMPTY_FUNC = () => {};
-
 /**
  * Caches whether the template tag is supported to avoid memory allocations.
  * @type {boolean|undefined}
@@ -517,7 +515,7 @@ function createBaseCustomElementClass(win) {
      * @final
      */
     whenLoaded() {
-      return this.signals_.whenSignal(CommonSignals.LOAD_END).then(EMPTY_FUNC);
+      return this.signals_.whenSignal(CommonSignals.LOAD_END);
     }
 
     /**

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -528,7 +528,7 @@ function createBaseCustomElementClass(win) {
     ensureLoaded(opt_parentPriority) {
       return this.whenBuilt().then(() => {
         const resource = this.getResource_();
-        if (this.signals_.get(CommonSignals.LOAD_END)) {
+        if (resource.getState() == ResourceState.LAYOUT_COMPLETE) {
           return this.whenLoaded();
         }
         if (

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -529,7 +529,7 @@ function createBaseCustomElementClass(win) {
       return this.whenBuilt().then(() => {
         const resource = this.getResource_();
         if (resource.getState() == ResourceState.LAYOUT_COMPLETE) {
-          return this.whenLoaded();
+          return;
         }
         if (
           resource.getState() != ResourceState.LAYOUT_SCHEDULED ||

--- a/src/service/owners-impl.js
+++ b/src/service/owners-impl.js
@@ -14,11 +14,8 @@
  * limitations under the License.
  */
 
-// TODO(powerivq)
-// Resource.setOwner, Resource.getOwner should be moved here.
-// ResourceState.NOT_BUILT might not be needed here.
 import {OwnersInterface} from './owners-interface';
-import {Resource, ResourceState} from './resource';
+import {Resource} from './resource';
 import {Services} from '../services';
 import {devAssert} from '../log';
 import {isArray} from '../types';
@@ -104,28 +101,7 @@ export class OwnersImpl {
   requireLayout(element, opt_parentPriority) {
     const promises = [];
     this.discoverResourcesForElement_(element, (resource) => {
-      if (resource.getState() == ResourceState.LAYOUT_COMPLETE) {
-        return;
-      }
-      if (resource.getState() != ResourceState.LAYOUT_SCHEDULED) {
-        promises.push(
-          resource.whenBuilt().then(() => {
-            resource.measure();
-            if (!resource.isDisplayed()) {
-              return;
-            }
-            this.resources_.scheduleLayoutOrPreload(
-              resource,
-              /* layout */ true,
-              opt_parentPriority,
-              /* forceOutsideViewport */ true
-            );
-            return resource.loadedOnce();
-          })
-        );
-      } else if (resource.isDisplayed()) {
-        promises.push(resource.loadedOnce());
-      }
+      promises.push(resource.element.ensureLoaded());
     });
     return Promise.all(promises);
   }
@@ -187,42 +163,8 @@ export class OwnersImpl {
    */
   scheduleLayoutOrPreloadForSubresources_(parentResource, layout, subElements) {
     this.findResourcesInElements_(parentResource, subElements, (resource) => {
-      if (resource.getState() === ResourceState.NOT_BUILT) {
-        resource.whenBuilt().then(() => {
-          this.measureAndTryScheduleLayout_(
-            resource,
-            /* isPreload */ !layout,
-            parentResource.getLayoutPriority()
-          );
-        });
-      } else {
-        this.measureAndTryScheduleLayout_(
-          resource,
-          /* isPreload */ !layout,
-          parentResource.getLayoutPriority()
-        );
-      }
+      resource.element.ensureLoaded(parentResource.getLayoutPriority());
     });
-  }
-
-  /**
-   * @param {!Resource} resource
-   * @param {boolean} isPreload
-   * @param {number=} opt_parentPriority
-   * @private
-   */
-  measureAndTryScheduleLayout_(resource, isPreload, opt_parentPriority) {
-    resource.measure();
-    if (
-      resource.getState() === ResourceState.READY_FOR_LAYOUT &&
-      resource.isDisplayed()
-    ) {
-      this.resources_.scheduleLayoutOrPreload(
-        resource,
-        /* layout */ !isPreload,
-        opt_parentPriority
-      );
-    }
   }
 }
 

--- a/src/service/resources-interface.js
+++ b/src/service/resources-interface.js
@@ -109,7 +109,6 @@ export class ResourcesInterface {
    * @param {boolean} layout
    * @param {number=} opt_parentPriority
    * @param {boolean=} opt_forceOutsideViewport
-   * @package
    */
   scheduleLayoutOrPreload(
     resource,

--- a/test/unit/test-custom-element.js
+++ b/test/unit/test-custom-element.js
@@ -1574,6 +1574,106 @@ describes.realWin('CustomElement', {amp: true}, (env) => {
           expect(element.prerenderAllowed()).to.be.false;
         });
       });
+
+      describe('ensureLoaded', () => {
+        it('should build and load', async () => {
+          const element = new ElementClass();
+          element.setAttribute('layout', 'fixed');
+          element.setAttribute('width', '10');
+          element.setAttribute('height', '10');
+          container.appendChild(element);
+          const resource = element.getResource_();
+
+          expect(element.isBuilt()).to.be.false;
+
+          const parentPriority = 1;
+          resourcesMock
+            .expects('scheduleLayoutOrPreload')
+            .withExactArgs(
+              resource,
+              /* layout */ true,
+              parentPriority,
+              /* forceOutsideViewport */ true
+            )
+            .once();
+
+          const promise = element.ensureLoaded(parentPriority);
+          await element.buildInternal();
+          await element.layoutCallback();
+
+          await promise;
+          expect(element.isBuilt()).to.be.true;
+        });
+
+        it('should load pre-built element', async () => {
+          const element = new ElementClass();
+          element.setAttribute('layout', 'fixed');
+          element.setAttribute('width', '10');
+          element.setAttribute('height', '10');
+          container.appendChild(element);
+          const resource = element.getResource_();
+
+          await element.buildInternal();
+          expect(element.isBuilt()).to.be.true;
+
+          const parentPriority = 1;
+          resourcesMock
+            .expects('scheduleLayoutOrPreload')
+            .withExactArgs(
+              resource,
+              /* layout */ true,
+              parentPriority,
+              /* forceOutsideViewport */ true
+            )
+            .once();
+
+          const promise = element.ensureLoaded(parentPriority);
+          await element.layoutCallback();
+
+          await promise;
+        });
+
+        it('should do nothing for already-loaded element', async () => {
+          const element = new ElementClass();
+          element.setAttribute('layout', 'fixed');
+          element.setAttribute('width', '10');
+          element.setAttribute('height', '10');
+          container.appendChild(element);
+
+          await element.buildInternal();
+          await element.layoutCallback();
+
+          resourcesMock.expects('scheduleLayoutOrPreload').never();
+
+          await element.ensureLoaded();
+        });
+
+        it('should do nothing for a non-displayed element', async () => {
+          const element = new ElementClass();
+          element.setAttribute('layout', 'nodisplay');
+          container.appendChild(element);
+          await element.buildInternal();
+
+          resourcesMock.expects('scheduleLayoutOrPreload').never();
+
+          await element.ensureLoaded();
+        });
+
+        it('should remeasure if needed', async () => {
+          const element = new ElementClass();
+          element.setAttribute('layout', 'nodisplay');
+          container.appendChild(element);
+          const resource = element.getResource_();
+          await element.buildInternal();
+
+          const measureSpy = env.sandbox.spy(resource, 'measure');
+          resourcesMock.expects('scheduleLayoutOrPreload').never();
+
+          resource.requestMeasure();
+          await element.ensureLoaded();
+          expect(measureSpy).to.be.calledOnce;
+        });
+      });
     });
 });
 

--- a/test/unit/test-owners.js
+++ b/test/unit/test-owners.js
@@ -28,7 +28,6 @@ describes.realWin(
     let owners;
     let parent;
     let children;
-    let scheduleLayoutOrPreloadStub;
 
     beforeEach(() => {
       win = env.win;
@@ -54,10 +53,6 @@ describes.realWin(
           children[0].appendChild(children[i]);
         }
       }
-      scheduleLayoutOrPreloadStub = env.sandbox.stub(
-        resources,
-        'scheduleLayoutOrPreload'
-      );
     });
 
     function createElement() {
@@ -184,30 +179,24 @@ describes.realWin(
           children[1],
           ResourceState.READY_FOR_LAYOUT
         );
+        const ensureLoadedStub = env.sandbox
+          .stub(resource1.element, 'ensureLoaded')
+          .resolves();
         owners.scheduleLayout(parent, children[1]);
-        expect(scheduleLayoutOrPreloadStub).to.be.calledWith(
-          resource1,
-          true,
-          parent.getLayoutPriority()
-        );
+        expect(ensureLoadedStub).to.be.calledWith(parent.getLayoutPriority());
       });
 
-      it('should schedule after build', async () => {
+      it('should schedule even when not build', async () => {
         const resource1 = setElementResourceState(
           children[1],
           ResourceState.NOT_BUILT
         );
-        let buildResource;
-        env.sandbox.stub(resource1, 'whenBuilt').returns(
-          new Promise((resolve) => {
-            buildResource = resolve;
-          })
-        );
+        env.sandbox.stub(resource1, 'whenBuilt').returns(new Promise(() => {}));
+        const ensureLoadedStub = env.sandbox
+          .stub(resource1.element, 'ensureLoaded')
+          .resolves();
         owners.scheduleLayout(parent, children[1]);
-        expect(scheduleLayoutOrPreloadStub).to.not.be.called;
-        buildResource();
-        await Promise.resolve();
-        expect(scheduleLayoutOrPreloadStub).to.be.calledWith(resource1, true);
+        expect(ensureLoadedStub).to.be.calledWith(parent.getLayoutPriority());
       });
     });
 
@@ -266,8 +255,19 @@ describes.realWin(
       });
 
       it('should schedule on custom element with multiple children', () => {
+        const ensureLoadedStub1 = env.sandbox
+          .stub(children[1], 'ensureLoaded')
+          .resolves();
+        const ensureLoadedStub2 = env.sandbox
+          .stub(children[2], 'ensureLoaded')
+          .resolves();
         owners.schedulePreload(parent, children);
-        expect(scheduleLayoutOrPreloadStub).to.be.calledTwice;
+        expect(ensureLoadedStub1).to.be.calledOnce.calledWith(
+          parent.getLayoutPriority()
+        );
+        expect(ensureLoadedStub2).to.be.calledOnce.calledWith(
+          parent.getLayoutPriority()
+        );
       });
 
       it('should schedule on nested custom element placeholder', () => {
@@ -283,8 +283,16 @@ describes.realWin(
         );
         children[2].getPlaceholder = () => placeholder2;
 
+        const stub1 = env.sandbox.stub(children[1], 'ensureLoaded');
+        const stub2 = env.sandbox.stub(children[2], 'ensureLoaded');
+        const stub3 = env.sandbox.stub(placeholder1, 'ensureLoaded');
+        const stub4 = env.sandbox.stub(placeholder2, 'ensureLoaded');
+
         owners.schedulePreload(parent, children);
-        expect(scheduleLayoutOrPreloadStub.callCount).to.equal(4);
+        expect(stub1).to.be.calledOnce;
+        expect(stub2).to.be.calledOnce;
+        expect(stub3).to.be.calledOnce;
+        expect(stub4).to.be.calledOnce;
       });
 
       it('should schedule amp-* placeholder inside non-amp element', () => {
@@ -296,8 +304,10 @@ describes.realWin(
         children[0].getElementsByClassName = () => [insidePlaceholder1];
         children[0].getPlaceholder = () => placeholder1;
 
+        const stub1 = env.sandbox.stub(insidePlaceholder1, 'ensureLoaded');
+
         owners.schedulePreload(parent, children);
-        expect(scheduleLayoutOrPreloadStub).to.be.calledThrice;
+        expect(stub1).to.be.calledOnce;
       });
     });
 
@@ -310,57 +320,38 @@ describes.realWin(
           }
           env.sandbox.stub(resource, 'whenBuilt').returns(Promise.resolve());
           env.sandbox.stub(resource, 'loadedOnce').returns(Promise.resolve());
+          env.sandbox.stub(element, 'ensureLoaded').resolves(resource.getId());
         });
       });
 
       it('should layout AMP element itself', async () => {
         setAllResourceState(ResourceState.READY_FOR_LAYOUT);
         const scheduledElements = await owners.requireLayout(parent);
-        expect(scheduledElements).to.have.length(1);
-        expect(scheduleLayoutOrPreloadStub).to.be.calledOnce;
-        expect(scheduleLayoutOrPreloadStub).to.be.calledWith(
-          resources.getResourceForElement(parent),
-          true
-        );
+        expect(scheduledElements).to.deep.equal([0]);
       });
 
       it("should layout non-AMP element's all AMP children", async () => {
         setAllResourceState(ResourceState.READY_FOR_LAYOUT);
         const scheduledElements = await owners.requireLayout(children[0]);
-        expect(scheduledElements).to.have.length(2);
-        expect(scheduleLayoutOrPreloadStub).to.be.calledTwice;
-        expect(scheduleLayoutOrPreloadStub).to.be.calledWith(
-          resources.getResourceForElement(children[3]),
-          true
-        );
-        expect(scheduleLayoutOrPreloadStub).to.be.calledWith(
-          resources.getResourceForElement(children[4]),
-          true
-        );
+        expect(scheduledElements).to.deep.equal([3, 4]);
       });
 
       it('should layout element w/ state=LAYOUT_FAILED', async () => {
-        const resource = setElementResourceState(
-          parent,
-          ResourceState.LAYOUT_FAILED
-        );
-        await owners.requireLayout(parent);
-        expect(scheduleLayoutOrPreloadStub).to.be.calledOnce;
-        expect(scheduleLayoutOrPreloadStub).to.be.calledWith(resource, true);
+        setElementResourceState(parent, ResourceState.LAYOUT_FAILED);
+        const scheduledElements = await owners.requireLayout(parent);
+        expect(scheduledElements).to.deep.equal([0]);
       });
 
-      it('should not layout element w/ state=LAYOUT_COMPLETE', async () => {
+      it('should layout element w/ state=LAYOUT_COMPLETE', async () => {
         setElementResourceState(parent, ResourceState.LAYOUT_COMPLETE);
         const scheduledElements = await owners.requireLayout(parent);
-        expect(scheduledElements).to.have.length(0);
-        expect(scheduleLayoutOrPreloadStub).to.not.be.called;
+        expect(scheduledElements).to.deep.equal([0]);
       });
 
       it('should not double schedule element w/ state=LAYOUT_SCHEDULED', async () => {
         setElementResourceState(parent, ResourceState.LAYOUT_SCHEDULED);
         const scheduledElements = await owners.requireLayout(parent);
-        expect(scheduledElements).to.have.length(1);
-        expect(scheduleLayoutOrPreloadStub).to.not.be.called;
+        expect(scheduledElements).to.deep.equal([0]);
       });
 
       it('should not require layout for undisplayed element', async () => {
@@ -370,8 +361,7 @@ describes.realWin(
         );
         resource.isDisplayedForTesting = false;
         const scheduledElements = await owners.requireLayout(parent);
-        expect(scheduledElements).to.have.length(1);
-        expect(scheduleLayoutOrPreloadStub).to.not.be.called;
+        expect(scheduledElements).to.deep.equal([0]);
       });
     });
   }


### PR DESCRIPTION
Partial for #31915.

The code moved mostly verbatim from the Owners class to the CustomElement. This accomplishes a few objectives:

1. It reduces dependencies on `Owners` service and makes a `CustomElement` more isolated.
2. This makes it `Owners` service more defunct on its way to complete elimination.
3. The `CustomElement` will be able to support separate modes for  `ensureLoaded()` (current and deferred-build).

Alternative considered:
```
class CustomElement {

  set loading(value) {...}
  
}

customElement.loading = 'eager';
```

That would seem like more in-line with the img's `loading` property. However, at this time it's easier to continue refactoring with the promisable function.
