### PR TITLE
🏗 Refine PR / push build detection logic for upstream branches

### DIFF
--- a/.circleci/check_config.sh
+++ b/.circleci/check_config.sh
@@ -24,9 +24,9 @@ err=0
 GREEN() { echo -e "\n\033[0;32m$1\033[0m"; }
 RED() { echo -e "\n\033[0;31m$1\033[0m"; }
 
-# CIRCLE_PULL_REQUEST is present for PR builds, and absent for push builds.
-if [[ -z "$CIRCLE_PULL_REQUEST" ]]; then
-  echo $(GREEN "Nothing to do because this is not a PR build.")
+# Push builds are only run against master and amp-release branches.
+if [[ "$CIRCLE_BRANCH" == "master" || "$CIRCLE_BRANCH" =~ ^amp-release-* ]]; then
+  echo $(GREEN "Nothing to do because $CIRCLE_BRANCH is not a PR branch.")
   exit 0
 fi
 

--- a/.circleci/fetch_merge_commit.sh
+++ b/.circleci/fetch_merge_commit.sh
@@ -26,9 +26,9 @@ GREEN() { echo -e "\n\033[0;32m$1\033[0m"; }
 YELLOW() { echo -e "\n\033[0;33m$1\033[0m"; }
 RED() { echo -e "\n\033[0;31m$1\033[0m"; }
 
-# CIRCLE_PR_NUMBER is present for PR builds, and absent for push builds.
-if [[ -z "$CIRCLE_PR_NUMBER" ]]; then
-  echo $(GREEN "Nothing to do because this is not a PR build.")
+# Push builds are only run against master and amp-release branches.
+if [[ "$CIRCLE_BRANCH" == "master" || "$CIRCLE_BRANCH" =~ ^amp-release-* ]]; then
+  echo $(GREEN "Nothing to do because $CIRCLE_BRANCH is not a PR branch.")
   # Warn if the build is linked to a PR on a different repo (known CircleCI bug).
   if [[ -n "$CIRCLE_PULL_REQUEST" && ! "$CIRCLE_PULL_REQUEST" =~ ^https://github.com/ampproject/amphtml* ]]; then
     echo $(YELLOW "WARNING: Build is incorrectly linked to a PR outside ampproject/amphtml:")
@@ -44,6 +44,14 @@ if [[ "$CIRCLE_PR_NUMBER" ]]; then
   PR_NUMBER=$CIRCLE_PR_NUMBER
 else
   PR_NUMBER=${CIRCLE_PULL_REQUEST#"https://github.com/ampproject/amphtml/pull/"}
+fi
+
+# If neither CIRCLE_PR_NUMBER nor CIRCLE_PULL_REQUEST are available, it's
+# possible this is a PR branch that is yet to be associated with a PR. Exit
+# early becaue there is no merge commit to fetch.
+if [[ -z "$PR_NUMBER" ]]; then
+  echo $(GREEN "Nothing to do because $CIRCLE_BRANCH is not yet linked to a PR.")
+  exit 0
 fi
 
 # GitHub provides refs/pull/<PR_NUMBER>/merge, an up-to-date merge branch for

--- a/.circleci/fetch_merge_commit.sh
+++ b/.circleci/fetch_merge_commit.sh
@@ -18,6 +18,7 @@
 # PRs are tested against all the latest changes on CircleCI.
 #
 #
+#
 # Reference: https://circleci.com/docs/2.0/env-vars/#built-in-environment-variables.
 
 set -e

--- a/.circleci/fetch_merge_commit.sh
+++ b/.circleci/fetch_merge_commit.sh
@@ -17,6 +17,7 @@
 # This script fetches the merge commit of a PR branch with master to make sure
 # PRs are tested against all the latest changes on CircleCI.
 #
+#
 # Reference: https://circleci.com/docs/2.0/env-vars/#built-in-environment-variables.
 
 set -e

--- a/.circleci/fetch_merge_commit.sh
+++ b/.circleci/fetch_merge_commit.sh
@@ -17,8 +17,6 @@
 # This script fetches the merge commit of a PR branch with master to make sure
 # PRs are tested against all the latest changes on CircleCI.
 #
-#
-#
 # Reference: https://circleci.com/docs/2.0/env-vars/#built-in-environment-variables.
 
 set -e

--- a/build-system/common/ci.js
+++ b/build-system/common/ci.js
@@ -73,6 +73,17 @@ const isGithubActions = isGithubActionsBuild();
 const isCircleci = isCircleciBuild();
 
 /**
+ * Used to filter CircleCI PR branches created directly on the amphtml repo
+ * (e.g.) PRs created from the GitHub web UI. Must match `push_builds_only`
+ * in .circleci/config.yml.
+ * @param {string} branchName
+ * @return {boolean}
+ */
+function isCircleciPushBranch(branchName) {
+  return branchName == 'master' || /^amp-release-.*$/.test(branchName);
+}
+
+/**
  * Returns true if this is a PR build.
  * @return {boolean}
  */
@@ -82,7 +93,7 @@ function isPullRequestBuild() {
     : isGithubActions
     ? env('GITHUB_EVENT_NAME') === 'pull_request'
     : isCircleci
-    ? !!env('CIRCLE_PR_NUMBER')
+    ? !isCircleciPushBranch(env('CIRCLE_BRANCH_NAME'))
     : false;
 }
 
@@ -96,7 +107,7 @@ function isPushBuild() {
     : isGithubActions
     ? env('GITHUB_EVENT_NAME') === 'push'
     : isCircleci
-    ? !env('CIRCLE_PR_NUMBER')
+    ? isCircleciPushBranch(env('CIRCLE_BRANCH_NAME'))
     : false;
 }
 


### PR DESCRIPTION
CircleCI PR builds for PRs originating from forks have the `CIRCLE_PR_NUMBER` environment variable. However, a PR originating from an upstream branch (directly created on `ampproject/amphtml`) does not. Yet, we want to run a PR build on the branch because it is neither `master` nor `amp-release-*`. We also want to fetch the merge commit for the branch if available.

**PR highlights:**
- Rewrite the push build detection logic in `ci.js` and `fetch_merge_commit.sh` to check for `master` or `amp-release-*`
- Attempt to fetch the merge commit if the upstream branch is linked to a PR (will accurately test older branches)
- If the branch is not yet linked to a PR, test the branch as-is (since it was most likely just created)

**Main use cases:**

**[Upstream PR branch, PR not yet created:](https://app.circleci.com/pipelines/github/ampproject/amphtml/1176/workflows/3ff2c96b-a205-47d3-b019-ea1d23326d3f/jobs/10667)**

![image](https://user-images.githubusercontent.com/26553114/106831571-234add80-665e-11eb-8132-07a35cf011a6.png)

**[Upstream PR branch, PR has been created:](https://app.circleci.com/pipelines/github/ampproject/amphtml/1175/workflows/070ab155-e83f-4ebd-8ab8-7a5d61004379/jobs/10665)**

![image](https://user-images.githubusercontent.com/26553114/106831502-09a99600-665e-11eb-9673-8f461dd63c57.png)

**[Fork PR branch:](https://app.circleci.com/pipelines/github/ampproject/amphtml/1177/workflows/ec81d221-1125-40b9-bc29-3de4cba71160/jobs/10678)**

![image](https://user-images.githubusercontent.com/26553114/106832626-02838780-6660-11eb-98dd-87dbeb0a838d.png)

**Related use cases:**

Fork PR branch (up-to-date config): https://github.com/ampproject/amphtml/pull/32420#issue-567266649
Fork PR branch (with and without merge conflicts): https://github.com/ampproject/amphtml/pull/32421#issue-567268019


This finishes what was started in #32412