### PR TITLE
🏗 Test new PR / push logic on an outdated fork PR

### DIFF
--- a/.circleci/check_config.sh
+++ b/.circleci/check_config.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+#
+# Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the license.
+#
+# This script checks if a PR branch is using the most recent CircleCI config.
+#
+# Reference: https://circleci.com/docs/2.0/env-vars/#built-in-environment-variables.
+
+set -e
+err=0
+
+GREEN() { echo -e "\n\033[0;32m$1\033[0m"; }
+RED() { echo -e "\n\033[0;31m$1\033[0m"; }
+
+# Push builds are only run against master and amp-release branches.
+if [[ "$CIRCLE_BRANCH" == "master" || "$CIRCLE_BRANCH" =~ ^amp-release-* ]]; then
+  echo $(GREEN "Nothing to do because $CIRCLE_BRANCH is not a PR branch.")
+  exit 0
+fi
+
+# Check if the PR branch contains the most recent revision the CircleCI config.
+CONFIG_REV=`git rev-list master -1 -- .circleci/config.yml`
+(set -x && git merge-base --is-ancestor $CONFIG_REV $CIRCLE_SHA1) || err=$?
+
+if [[ "$err" -ne "0" ]]; then
+  echo $(RED "$CIRCLE_BRANCH is missing the latest CircleCI config revision $CONFIG_REV.")
+  echo $(RED "Please rebase / merge $CIRCLE_BRANCH with master.")
+  exit 1
+fi
+
+echo $(GREEN "$CIRCLE_BRANCH is using the latest CircleCI config.")

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,6 +59,9 @@ commands:
           name: 'Fetch Merge Commit'
           command: ./.circleci/fetch_merge_commit.sh
       - run:
+          name: 'Check Config'
+          command: ./.circleci/check_config.sh
+      - run:
           name: 'Setup Google Cloud Storage'
           command: ./.circleci/setup_storage.sh
       - run:

--- a/.circleci/fetch_merge_commit.sh
+++ b/.circleci/fetch_merge_commit.sh
@@ -23,18 +23,18 @@ set -e
 err=0
 
 GREEN() { echo -e "\n\033[0;32m$1\033[0m"; }
+YELLOW() { echo -e "\n\033[0;33m$1\033[0m"; }
 RED() { echo -e "\n\033[0;31m$1\033[0m"; }
 
-# CIRCLE_PULL_REQUEST is present for PR builds, and absent for push builds.
-if [[ -z "$CIRCLE_PULL_REQUEST" ]]; then
-  echo $(GREEN "Nothing to do because this is not a PR build.")
+# Push builds are only run against master and amp-release branches.
+if [[ "$CIRCLE_BRANCH" == "master" || "$CIRCLE_BRANCH" =~ ^amp-release-* ]]; then
+  echo $(GREEN "Nothing to do because $CIRCLE_BRANCH is not a PR branch.")
+  # Warn if the build is linked to a PR on a different repo (known CircleCI bug).
+  if [[ -n "$CIRCLE_PULL_REQUEST" && ! "$CIRCLE_PULL_REQUEST" =~ ^https://github.com/ampproject/amphtml* ]]; then
+    echo $(YELLOW "WARNING: Build is incorrectly linked to a PR outside ampproject/amphtml:")
+    echo $(YELLOW "$CIRCLE_PULL_REQUEST")
+  fi
   exit 0
-fi
-
-# Make sure the PR is on ampproject/amphtml and not on a fork.
-if [[ ! "$CIRCLE_PULL_REQUEST" =~ ^https://github.com/ampproject/amphtml* ]]; then
-  echo $(RED "This is a PR build, but on a repo other than ampproject/amphtml.")
-  exit 1
 fi
 
 # CIRCLE_PR_NUMBER is present for PRs originating from forks, but absent for PRs
@@ -44,6 +44,14 @@ if [[ "$CIRCLE_PR_NUMBER" ]]; then
   PR_NUMBER=$CIRCLE_PR_NUMBER
 else
   PR_NUMBER=${CIRCLE_PULL_REQUEST#"https://github.com/ampproject/amphtml/pull/"}
+fi
+
+# If neither CIRCLE_PR_NUMBER nor CIRCLE_PULL_REQUEST are available, it's
+# possible this is a PR branch that is yet to be associated with a PR. Exit
+# early becaue there is no merge commit to fetch.
+if [[ -z "$PR_NUMBER" ]]; then
+  echo $(GREEN "Nothing to do because $CIRCLE_BRANCH is not yet linked to a PR.")
+  exit 0
 fi
 
 # GitHub provides refs/pull/<PR_NUMBER>/merge, an up-to-date merge branch for

--- a/build-system/common/ci.js
+++ b/build-system/common/ci.js
@@ -73,6 +73,17 @@ const isGithubActions = isGithubActionsBuild();
 const isCircleci = isCircleciBuild();
 
 /**
+ * Used to filter CircleCI PR branches created directly on the amphtml repo
+ * (e.g.) PRs created from the GitHub web UI. Must match `push_builds_only`
+ * in .circleci/config.yml.
+ * @param {string} branchName
+ * @return {boolean}
+ */
+function isCircleciPushBranch(branchName) {
+  return branchName == 'master' || /^amp-release-.*$/.test(branchName);
+}
+
+/**
  * Returns true if this is a PR build.
  * @return {boolean}
  */
@@ -82,7 +93,7 @@ function isPullRequestBuild() {
     : isGithubActions
     ? env('GITHUB_EVENT_NAME') === 'pull_request'
     : isCircleci
-    ? !!env('CIRCLE_PULL_REQUEST')
+    ? !isCircleciPushBranch(env('CIRCLE_BRANCH_NAME'))
     : false;
 }
 
@@ -96,7 +107,7 @@ function isPushBuild() {
     : isGithubActions
     ? env('GITHUB_EVENT_NAME') === 'push'
     : isCircleci
-    ? !env('CIRCLE_PULL_REQUEST')
+    ? isCircleciPushBranch(env('CIRCLE_BRANCH_NAME'))
     : false;
 }
 


### PR DESCRIPTION
This worked in both cases.

Outdated branch with conflicts: https://app.circleci.com/pipelines/github/ampproject/amphtml/1179/workflows/25b0833d-06e2-420b-a573-7ba707af1f79/jobs/10699

![image](https://user-images.githubusercontent.com/26553114/106832926-95242680-6660-11eb-9bae-d31e043a0f46.png)

After resolving conflicts: https://app.circleci.com/pipelines/github/ampproject/amphtml/1180/workflows/ddf2d89b-c9b7-43b8-ad0f-de9b2cfe398e/jobs/10708

![image](https://user-images.githubusercontent.com/26553114/106832954-a836f680-6660-11eb-969f-fb868012dc2c.png)
