### PR TITLE
🏗 Switch signaling for bundle-size, test-status, and pr-deploy to CircleCI

### DIFF
--- a/build-system/pr-check/bundle-size.js
+++ b/build-system/pr-check/bundle-size.js
@@ -52,10 +52,10 @@ function prBuildWorkflow() {
 }
 
 // TODO(rsimha): Remove this block once Travis is shut off.
-if (!isTravisBuild()) {
+if (isTravisBuild()) {
   printSkipMessage(
     jobName,
-    'this is a CircleCI build. Sizes will be reported from Travis'
+    'this is a Travis build. Sizes will be reported from CircleCI'
   );
   return;
 }

--- a/build-system/tasks/pr-deploy-bot-utils.js
+++ b/build-system/tasks/pr-deploy-bot-utils.js
@@ -70,7 +70,7 @@ async function replaceUrls(dir) {
 
 async function signalPrDeployUpload(result) {
   // TODO(rsimha): Remove this check once Travis is shut down.
-  if (!isTravisBuild()) {
+  if (isTravisBuild()) {
     return;
   }
   const loggingPrefix = getLoggingPrefix();

--- a/build-system/tasks/report-test-status.js
+++ b/build-system/tasks/report-test-status.js
@@ -40,8 +40,7 @@ const TEST_TYPE_SUBTYPES = isGithubActionsBuild()
       ['integration', ['firefox', 'safari', 'edge', 'ie']],
       ['unit', ['firefox', 'safari', 'edge']],
     ])
-  : // TODO(rsimha): Remove `isTravisBuild()` condition once Travis is shut off.
-  isCircleciBuild() || isTravisBuild()
+  : isCircleciBuild()
   ? new Map([
       ['integration', ['unminified', 'nomodule', 'module']],
       ['unit', ['unminified', 'local-changes']],
@@ -88,8 +87,8 @@ function inferTestType() {
 }
 
 async function postReport(type, action) {
-  // TODO(rsimha): Remove `!isCircleciBuild()` condition once Travis is shut off.
-  if (type && isPullRequestBuild() && !isCircleciBuild()) {
+  // TODO(rsimha): Clean up `!isTravisaBuild()` condition once Travis is shut off.
+  if (type && isPullRequestBuild() && !isTravisBuild()) {
     const commitHash = gitCommitHash();
 
     try {


### PR DESCRIPTION
Signals for bundle-size, test-status, and pr-deploy are sent from Travis but not CircleCI in order to prevent duplication.

This PR switches the signaling to CircleCI. Once we merge and observe for several builds, we can make CircleCI a blocking check.
