### PR TITLE
📖 Fix link to custom search ads in document

### DIFF
--- a/ads/google/adsense.md
+++ b/ads/google/adsense.md
@@ -34,7 +34,7 @@ limitations under the License.
 
 ## Configuration
 
-For semantics of configuration, please see [ad network documentation](https://support.google.com/adsense/answer/7183212?hl=en). For AdSense for Search and AdSense for Shopping, please see the [CSA AMP ad type](https://github.com/ampproject/amphtml/blob/master/ads/google/csa.md).
+For semantics of configuration, please see [ad network documentation](https://support.google.com/adsense/answer/7183212?hl=en). For AdSense for Search and AdSense for Shopping, please see the [CSA AMP ad type](https://github.com/ampproject/amphtml/blob/master/ads/vendors/csa.md).
 
 Supported parameters:
 


### PR DESCRIPTION
The [CSA AMP ad type] link in the documentation had not been updated, so I fixed it.
see: https://github.com/ampproject/amphtml/commit/71ed0fc161cc9f256932ec24cfaf46fabb7b772c#diff-4620745fb7a4065006a431a9475478f212dbe5867f07639fbac1e9f3f1f07986

I looked to check if there were any others, but this was the only one.