### PR TITLE
🏗 Persist NPM cache across CI builds to speed up installation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,7 @@ commands:
           name: 'Save NPM Cache'
           key: npm-cache-{{ checksum "package-lock.json" }}
           paths:
-            - node_modules
+            - ~/.npm
   install_chrome:
     steps:
       - browser-tools/install-chrome:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,9 +67,19 @@ commands:
       - run:
           name: 'Configure Hosts'
           command: cat ./build-system/test-configs/hosts | sudo tee -a /etc/hosts
+      - restore_cache:
+          name: 'Restore NPM Cache'
+          keys:
+            - npm-cache-{{ checksum "package-lock.json" }}
+            - npm-cache-
       - run:
           name: 'Install Dependencies'
           command: ./.circleci/install_dependencies.sh
+      - save_cache:
+          name: 'Save NPM Cache'
+          key: npm-cache-{{ checksum "package-lock.json" }}
+          paths:
+            - node_modules
   install_chrome:
     steps:
       - browser-tools/install-chrome:

--- a/.circleci/install_dependencies.sh
+++ b/.circleci/install_dependencies.sh
@@ -31,6 +31,9 @@ export NVM_DIR="/opt/circleci/.nvm"
 echo $(GREEN "Installing Node LTS...")
 nvm install 'lts/*'
 
+echo $(GREEN "Updating NPM...")
+npm install --global npm
+
 echo $(GREEN "Installing gulp-cli...")
 npm install --global gulp-cli
 

--- a/.circleci/install_dependencies.sh
+++ b/.circleci/install_dependencies.sh
@@ -34,6 +34,9 @@ nvm install 'lts/*'
 echo $(GREEN "Updating NPM...")
 npm install --global npm
 
+echo $(GREEN "Using NPM cache directory:")
+npm config get cache
+
 echo $(GREEN "Installing gulp-cli...")
 npm install --global gulp-cli
 

--- a/.circleci/install_dependencies.sh
+++ b/.circleci/install_dependencies.sh
@@ -31,6 +31,9 @@ export NVM_DIR="/opt/circleci/.nvm"
 echo $(GREEN "Installing Node LTS...")
 nvm install 'lts/*'
 
+echo $(GREEN "Updating NPM registry URL for faster installs...")
+npm config set registry http://registry.npmjs.org/ --global
+
 echo $(GREEN "Using NPM cache directory:")
 npm config get cache
 

--- a/.circleci/install_dependencies.sh
+++ b/.circleci/install_dependencies.sh
@@ -31,9 +31,6 @@ export NVM_DIR="/opt/circleci/.nvm"
 echo $(GREEN "Installing Node LTS...")
 nvm install 'lts/*'
 
-echo $(GREEN "Updating NPM...")
-npm install --global npm
-
 echo $(GREEN "Using NPM cache directory:")
 npm config get cache
 

--- a/.github/workflows/cross-browser-tests.yml
+++ b/.github/workflows/cross-browser-tests.yml
@@ -19,10 +19,13 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Cache Packages
+      - name: Compute NPM Cache Directory
+        id: npm-cache
+        run: echo "::set-output name=dir::$(npm config get cache)"
+      - name: Cache NPM Packages
         uses: actions/cache@v2
         with:
-          path: ~/.npm
+          path: ${{ steps.npm-cache.outputs.dir }}
           key: npm-cache-${{ matrix.platform }}-${{ hashFiles('package-lock.json') }}
           restore-keys: |
             npm-cache-${{ matrix.platform }}-

--- a/.github/workflows/cross-browser-tests.yml
+++ b/.github/workflows/cross-browser-tests.yml
@@ -22,8 +22,10 @@ jobs:
       - name: Cache Packages
         uses: actions/cache@v2
         with:
-          path: node_modules
-          key: node_modules-${{ matrix.platform }}-${{ hashFiles('package-lock.json') }}
+          path: ~/.npm
+          key: npm-cache-${{ matrix.platform }}-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            npm-cache-${{ matrix.platform }}-
       - name: Install Dependencies
         run: bash ./.github/workflows/install_dependencies.sh
       - name: Build and Test

--- a/.github/workflows/install_dependencies.sh
+++ b/.github/workflows/install_dependencies.sh
@@ -32,6 +32,9 @@ fi
 echo $(GREEN "Updating NPM...")
 npm install --global npm
 
+echo $(GREEN "Using NPM cache directory:")
+npm config get cache
+
 echo $(GREEN "Installing gulp-cli...")
 npm install --global gulp-cli
 

--- a/.github/workflows/install_dependencies.sh
+++ b/.github/workflows/install_dependencies.sh
@@ -29,6 +29,9 @@ if [[ "$OSTYPE" == "linux-gnu"* || "$OSTYPE" == "darwin"* ]]; then
   echo "$HOME/.npm/bin" >> $GITHUB_PATH # For later
 fi
 
+echo $(GREEN "Updating NPM registry URL for faster installs...")
+npm config set registry http://registry.npmjs.org/ --global
+
 echo $(GREEN "Using NPM cache directory:")
 npm config get cache
 

--- a/.github/workflows/install_dependencies.sh
+++ b/.github/workflows/install_dependencies.sh
@@ -29,6 +29,9 @@ if [[ "$OSTYPE" == "linux-gnu"* || "$OSTYPE" == "darwin"* ]]; then
   echo "$HOME/.npm/bin" >> $GITHUB_PATH # For later
 fi
 
+echo $(GREEN "Updating NPM...")
+npm install --global npm
+
 echo $(GREEN "Installing gulp-cli...")
 npm install --global gulp-cli
 

--- a/.github/workflows/install_dependencies.sh
+++ b/.github/workflows/install_dependencies.sh
@@ -29,9 +29,6 @@ if [[ "$OSTYPE" == "linux-gnu"* || "$OSTYPE" == "darwin"* ]]; then
   echo "$HOME/.npm/bin" >> $GITHUB_PATH # For later
 fi
 
-echo $(GREEN "Updating NPM...")
-npm install --global npm
-
 echo $(GREEN "Using NPM cache directory:")
 npm config get cache
 


### PR DESCRIPTION
**Background:**
- `npm ci` (a.k.a. `clean-install`) writes a fresh copy of `node_modules` and doesn't modify `package*.json`
- `npm i` (a.k.a. `install`) reuses the files in `node_modules` and may modify `package*.json`
- `npm ci` is recommended during CI builds, but re-downloading the sources is wasteful
- `npm ci` will skip re-downloading if sources are present in the NPM cache directory

**PR Highlights:**
- Persist the NPM cache directory (instead of `node_modules`) on CircleCI and GH Actions
- Primary key (checksum of `package-lock.json`) will select the copy that matches every single version
- Secondary key will select the next most recent copy (`npm ci` will re-download only those dependencies that changed)

**References:**
- [`npm-ci` docs](https://docs.npmjs.com/cli/v6/commands/npm-ci)
- [Taking advantage of `npm ci`](https://discuss.circleci.com/t/taking-advantage-of-npm-ci/20734)
- [How To Speed Up Continuous Integration Build With New NPM CI And `package-lock.json`](https://medium.com/hackernoon/how-to-speed-up-continuous-integration-build-with-new-npm-ci-and-package-lock-json-7647f91751a)
- [CircleCI: Caching Dependencies](https://circleci.com/docs/2.0/caching/)
- [6 optimization tips for your CI configuration](https://circleci.com/blog/six-optimization-tips-for-your-config/)
- [`actions/cache` : Node NPM Docs](https://github.com/actions/cache/blob/9ab95382c899bf0953a0c6c1374373fc40456ffe/examples.md#node---npm)

