### PR TITLE
✨ [bento][amp-sidebar] Allow esc key to close sidebar

### DIFF
--- a/extensions/amp-sidebar/1.0/sidebar.js
+++ b/extensions/amp-sidebar/1.0/sidebar.js
@@ -16,11 +16,13 @@
 
 import * as Preact from '../../../src/preact';
 import {ContainWrapper, useValueRef} from '../../../src/preact/component';
+import {Keys} from '../../../src/utils/key-codes';
 import {Side} from './sidebar-config';
 import {forwardRef} from '../../../src/preact/compat';
 import {isRTL} from '../../../src/dom';
 import {
   useCallback,
+  useEffect,
   useImperativeHandle,
   useLayoutEffect,
   useRef,
@@ -108,6 +110,26 @@ function SidebarWithRef(
     backdropRef,
     setMounted
   );
+
+  useEffect(() => {
+    const sidebarElement = sidebarRef.current;
+    const backdropElement = backdropRef.current;
+    if (!sidebarElement || !sidebarElement.ownerDocument || !backdropElement) {
+      return;
+    }
+
+    const document = sidebarElement.ownerDocument;
+    const keydownCallback = (event) => {
+      if (event.key == Keys.ESCAPE) {
+        event.preventDefault();
+        close();
+      }
+    };
+    document.addEventListener('keydown', keydownCallback);
+    return () => {
+      document.removeEventListener('keydown', keydownCallback);
+    };
+  }, [opened, close]);
 
   return (
     mounted && (

--- a/extensions/amp-sidebar/1.0/sidebar.js
+++ b/extensions/amp-sidebar/1.0/sidebar.js
@@ -123,7 +123,7 @@ function SidebarWithRef(
     }
     const keydownCallback = (event) => {
       if (event.key === Keys.ESCAPE) {
-        event.preventDefault();
+        event.stopImmediatePropagation();
         close();
       }
     };

--- a/extensions/amp-sidebar/1.0/sidebar.js
+++ b/extensions/amp-sidebar/1.0/sidebar.js
@@ -114,13 +114,15 @@ function SidebarWithRef(
   useEffect(() => {
     const sidebarElement = sidebarRef.current;
     const backdropElement = backdropRef.current;
-    if (!sidebarElement || !sidebarElement.ownerDocument || !backdropElement) {
+    if (!sidebarElement || !backdropElement) {
       return;
     }
-
     const document = sidebarElement.ownerDocument;
+    if (!document) {
+      return;
+    }
     const keydownCallback = (event) => {
-      if (event.key == Keys.ESCAPE) {
+      if (event.key === Keys.ESCAPE) {
         event.preventDefault();
         close();
       }

--- a/extensions/amp-sidebar/1.0/sidebar.js
+++ b/extensions/amp-sidebar/1.0/sidebar.js
@@ -124,6 +124,7 @@ function SidebarWithRef(
     const keydownCallback = (event) => {
       if (event.key === Keys.ESCAPE) {
         event.stopImmediatePropagation();
+        event.preventDefault();
         close();
       }
     };

--- a/extensions/amp-sidebar/1.0/test/test-amp-sidebar.js
+++ b/extensions/amp-sidebar/1.0/test/test-amp-sidebar.js
@@ -161,6 +161,33 @@ describes.realWin(
         expect(container.children.length).to.equal(0);
       });
 
+      it('should close the sidebar when the esc key is pressed', async () => {
+        element.enqueAction(invocation('open'));
+        await waitForOpen(element, true);
+
+        // sidebar is opened, wait for eventListener to be attached
+        expect(container.children.length).to.equal(2);
+        const sidebar = container.children[0];
+        const doc = sidebar.ownerDocument;
+        const addListenerSpy = env.sandbox.spy(doc, 'addEventListener');
+
+        await waitFor(
+          () => addListenerSpy.callCount > 0,
+          'event listener attached'
+        );
+
+        // dispatch esc key event
+        const documentEl = sidebar.ownerDocument.documentElement;
+        documentEl.dispatchEvent(
+          new KeyboardEvent('keydown', {key: 'Escape', bubbles: true})
+        );
+
+        // verify sidebar is closed
+        await waitForOpen(element, false);
+        expect(element).to.not.have.attribute('open');
+        expect(container.children.length).to.equal(0);
+      });
+
       it('should render all children of the sidebar', async () => {
         // closed sidebar should not render any content
         expect(container.children.length).to.equal(0);

--- a/extensions/amp-sidebar/1.0/test/test-sidebar.js
+++ b/extensions/amp-sidebar/1.0/test/test-sidebar.js
@@ -57,12 +57,42 @@ describes.sandboxed('Sidebar preact component', {}, (env) => {
       openButton.getDOMNode().click();
       wrapper.update();
 
+      // verify sidebar is opened
+      let sidebarElement = wrapper.find(Sidebar).getDOMNode();
+      expect(sidebarElement).to.not.be.null;
+
+      // click on the backdrop
       const backdropElement = wrapper.find(Sidebar).getDOMNode().nextSibling;
       backdropElement.click();
       wrapper.update();
 
+      // verify sidebar closes
+      sidebarElement = wrapper.find(Sidebar).getDOMNode();
+      expect(sidebarElement).to.be.null;
+    });
+
+    it('should close the sidebar when the esc key is pressed', () => {
+      openButton.getDOMNode().click();
+      wrapper.update();
+
+      // verify sidebar is opened
+      let sidebarElement = wrapper.find(Sidebar).getDOMNode();
+      expect(sidebarElement).to.not.be.null;
+
+      // forces flush of effect queue (attaches esc key event listener)
+      wrapper.mount();
+
+      // simulate an 'esc' key press from the documentElement
+      sidebarElement.ownerDocument.documentElement.dispatchEvent(
+        new KeyboardEvent('keydown', {key: 'Escape', bubbles: true})
+      );
+
+      // force rerender
+      wrapper.update();
+
       // Sidebar closes
-      expect(sidebar.getDOMNode()).to.be.null;
+      sidebarElement = wrapper.find(Sidebar).getDOMNode();
+      expect(sidebarElement).to.be.null;
     });
 
     it('should include the content in the sidebar', () => {

--- a/extensions/amp-sidebar/1.0/test/test-sidebar.js
+++ b/extensions/amp-sidebar/1.0/test/test-sidebar.js
@@ -51,6 +51,7 @@ describes.sandboxed('Sidebar preact component', {}, (env) => {
 
     afterEach(() => {
       Element.prototype.animate = animateFunction;
+      wrapper.unmount();
     });
 
     it('close the sidebar when the backdrop is clicked', () => {


### PR DESCRIPTION
Sidebar tracker: https://github.com/ampproject/amphtml/issues/31366
******
Update 2/10
This is dependent on: https://github.com/ampproject/amphtml/pull/32584
On hold until dependency is completed!
******
When sidebar opens, attach an eventListener to check for the 'esc' key being pressed and close the sidebar if it is pressed.

How does this work?
1. `eventListener` gets attached once sidebar element is rendered (done via `useEffect` (async))
2. If it is clicked mid-animation, the `close` api will handle reversing the animation

