### PR TITLE
🏗 Cache `node_modules` during CI to speed up installs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,9 +67,19 @@ commands:
       - run:
           name: 'Configure Hosts'
           command: cat ./build-system/test-configs/hosts | sudo tee -a /etc/hosts
+      - restore_cache:
+          name: 'Restore Node Modules'
+          keys:
+            - node-modules-cache-{{ checksum "package-lock.json" }}
+            - node-modules-cache-
       - run:
           name: 'Install Dependencies'
           command: ./.circleci/install_dependencies.sh
+      - save_cache:
+          name: 'Save Node Modules'
+          key: node-modules-cache-{{ checksum "package-lock.json" }}
+          paths:
+            - node_modules
   install_chrome:
     steps:
       - browser-tools/install-chrome:

--- a/.circleci/install_dependencies.sh
+++ b/.circleci/install_dependencies.sh
@@ -35,7 +35,7 @@ echo $(GREEN "Installing gulp-cli...")
 npm install --global gulp-cli
 
 echo $(GREEN "Installing dependencies...")
-npm ci
+npm install
 
 echo $(GREEN "Setting up environment...")
 NPM_BIN_DIR="`npm config get prefix`/bin"

--- a/.github/workflows/cross-browser-tests.yml
+++ b/.github/workflows/cross-browser-tests.yml
@@ -23,7 +23,9 @@ jobs:
         uses: actions/cache@v2
         with:
           path: node_modules
-          key: node_modules-${{ matrix.platform }}-${{ hashFiles('package-lock.json') }}
+          key: node-modules-cache-${{ matrix.platform }}-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            node-modules-cache-${{ matrix.platform }}-
       - name: Install Dependencies
         run: bash ./.github/workflows/install_dependencies.sh
       - name: Build and Test

--- a/.github/workflows/install_dependencies.sh
+++ b/.github/workflows/install_dependencies.sh
@@ -33,6 +33,6 @@ echo $(GREEN "Installing gulp-cli...")
 npm install --global gulp-cli
 
 echo $(GREEN "Installing dependencies...")
-npm ci
+npm install
 
 echo $(GREEN "Successfully installed all project dependencies.")


### PR DESCRIPTION
**Background:**

Package installation during CI has gotten slower over time, especially on Windows and macOS. Reducing the number of dependencies will need careful rewriting of code. Meanwhile, we can experiment with caching.

#32429 tried to persist the NPM cache directory (typically localted at `~/.npm`) so that `npm ci` (a.k.a. `clean-install`) could use it to freshly recreate `node_modules`. Speeds either remained stagnant or [became worse](https://github.com/ampproject/amphtml/pull/32429#issuecomment-773583411).

**PR Highlights:**

- Instead of `~/.npm`, we cache `node_modules`
- `npm install` will overwrite only what has changed in `node_modules`
- Primary key is a known prefix + a hash of `package-lock.json` (exact match => all cached packages are fresh)
- Secondary key is just the known prefix (slightly older cache => `npm install` will refresh what has changed)

**Results:**

| **VM / Install time** | **CircleCI Linux (L)** | **GH Actions Linux** | **GH Actions macOS** | **GH Actions Windows** |
| --- | ---  |--- | --- |--- |
| **Cold cache** | [1m 41s](https://app.circleci.com/pipelines/github/ampproject/amphtml/1292/workflows/34980c82-70a3-4bed-999d-fd3d36c88e93/jobs/11977) | [1m 26s](https://github.com/ampproject/amphtml/runs/1834510931?check_suite_focus=true) | [3m 26s](https://github.com/ampproject/amphtml/runs/1834510950?check_suite_focus=true) | [4m 34s](https://github.com/ampproject/amphtml/runs/1834510973?check_suite_focus=true) |
| **Warm cache** | [41s](https://app.circleci.com/pipelines/github/ampproject/amphtml/1295/workflows/cf57693f-906e-4c29-bb1e-f0df0a99ad6b/jobs/12034) | [43s](https://github.com/ampproject/amphtml/runs/1834698035?check_suite_focus=true) | [38s](https://github.com/ampproject/amphtml/runs/1834698050?check_suite_focus=true) | [4m 15s](https://github.com/ampproject/amphtml/runs/1834698068?check_suite_focus=true) |

**Update:** Abandoned because of https://github.com/ampproject/amphtml/pull/32439#issuecomment-773653012.