### PR TITLE
🏗  Run E2E tests on Safari and Firefox

### DIFF
--- a/build-system/pr-check/cross-browser-tests.js
+++ b/build-system/pr-check/cross-browser-tests.js
@@ -55,6 +55,28 @@ function runIntegrationTestsForPlatform() {
 }
 
 /**
+ * Helper that runs platform-specific E2E tests
+ */
+function runE2eTestsForPlatform() {
+  switch (process.platform) {
+    case 'linux':
+      timedExecOrDie('gulp e2e --nobuild --compiled --browsers=firefox');
+      break;
+    case 'darwin':
+      timedExecOrDie('gulp e2e --nobuild --compiled --browsers=safari');
+      break;
+    case 'win32':
+      break;
+    default:
+      log(
+        red('ERROR:'),
+        'Cannot run cross-browser E2E tests on',
+        cyan(process.platform) + '.'
+      );
+  }
+}
+
+/**
  * Helper that runs platform-specific unit tests
  */
 function runUnitTestsForPlatform() {
@@ -105,9 +127,20 @@ async function prBuildWorkflow() {
   if (buildTargetsInclude(Targets.RUNTIME, Targets.UNIT_TEST)) {
     runUnitTestsForPlatform();
   }
-  if (buildTargetsInclude(Targets.RUNTIME, Targets.INTEGRATION_TEST)) {
+  if (
+    buildTargetsInclude(
+      Targets.RUNTIME,
+      Targets.INTEGRATION_TEST,
+      Targets.E2E_TEST
+    )
+  ) {
     timedExecOrDie('gulp dist --fortesting');
+  }
+  if (buildTargetsInclude(Targets.RUNTIME, Targets.INTEGRATION_TEST)) {
     runIntegrationTestsForPlatform();
+  }
+  if (buildTargetsInclude(Targets.RUNTIME, Targets.E2E_TEST)) {
+    runE2eTestsForPlatform();
   }
 }
 

--- a/build-system/tasks/report-test-status.js
+++ b/build-system/tasks/report-test-status.js
@@ -39,6 +39,7 @@ const TEST_TYPE_SUBTYPES = isGithubActionsBuild()
   ? new Map([
       ['integration', ['firefox', 'safari', 'edge', 'ie']],
       ['unit', ['firefox', 'safari', 'edge']],
+      ['e2e', ['firefox', 'safari']],
     ])
   : isCircleciBuild()
   ? new Map([
@@ -79,6 +80,10 @@ function inferTestType() {
     ? 'edge'
     : argv.ie
     ? 'ie'
+    : argv.browsers == 'safari'
+    ? 'safari'
+    : argv.browsers == 'firefox'
+    ? 'firefox'
     : argv.compiled
     ? 'nomodule'
     : 'unminified';


### PR DESCRIPTION
This PR runs E2E tests on Safari and Firefox on GH Actions. Trying out the suggestion in https://github.com/ampproject/amphtml/issues/24009#issuecomment-772030645.

We appear to have all-green E2E runs that finish in under a minute, but the really fast running times make me wonder if the tests are actually being executed. **Edit:** They are. The fast tests are all unit tests for the E2E framework.

**Safari:** [169 tests in 50s](https://github.com/ampproject/amphtml/runs/1834887271?check_suite_focus=true#step:5:305)
**Firefox:** [165 tests in 30s](https://github.com/ampproject/amphtml/runs/1834887236?check_suite_focus=true#step:5:314)

Don't know if we actually want to merge this, but I figured it's worth reviewing. **Edit:** Given the fast runs and the fact that we're already building the runtime, I see no harm in running E2E tests on Safari and Firefox.