### PR TITLE
🏗 Remove `node_modules` caching on GH Actions

### DIFF
--- a/.github/workflows/cross-browser-tests.yml
+++ b/.github/workflows/cross-browser-tests.yml
@@ -19,11 +19,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Cache Packages
-        uses: actions/cache@v2
-        with:
-          path: node_modules
-          key: node_modules-${{ matrix.platform }}-${{ hashFiles('package-lock.json') }}
       - name: Install Dependencies
         run: bash ./.github/workflows/install_dependencies.sh
       - name: Build and Test


### PR DESCRIPTION
In #32429 and #32439, we tried caching `~/.npm` and `node_modules/` respectively in order to speed up package installation during CI builds. Neither approach really worked (see PRs for details).

As things stand today, running `npm ci` will rewrite `node_modules/` from scratch for each build. This PR removes the unnecessary caching step on GH Actions.

As a follow up, I'll read up some more on whether there's a more effective way of achieving caching without breaking packages (e.g. [this `@babel` error](https://github.com/ampproject/amphtml/pull/32439#issuecomment-773653012)).
