### PR TITLE
✨[no-signing] Allow creatives to opt out of client side validation

### DIFF
--- a/build-system/test-configs/dep-check-config.js
+++ b/build-system/test-configs/dep-check-config.js
@@ -200,7 +200,7 @@ exports.rules = [
 
       // A4A impls importing amp fast fetch header name
       'extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js->extensions/amp-a4a/0.1/signature-verifier.js',
-      'extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-doubleclick-impl.js->extensions/amp-a4a/0.1/signature-verifier.js',
+      'extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js->extensions/amp-a4a/0.1/signature-verifier.js',
 
       // And a few mrore things depend on a4a.
       'extensions/amp-ad-custom/0.1/amp-ad-custom.js->extensions/amp-a4a/0.1/amp-ad-network-base.js',

--- a/build-system/test-configs/dep-check-config.js
+++ b/build-system/test-configs/dep-check-config.js
@@ -198,6 +198,10 @@ exports.rules = [
       'extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js->extensions/amp-a4a/0.1/amp-a4a.js',
       'extensions/amp-ad-network-oblivki-impl/0.1/amp-ad-network-oblivki-impl.js->extensions/amp-a4a/0.1/amp-a4a.js',
 
+      // A4A impls importing amp fast fetch header name
+      'extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js->extensions/amp-a4a/0.1/signature-verifier.js',
+      'extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-doubleclick-impl.js->extensions/amp-a4a/0.1/signature-verifier.js',
+
       // And a few mrore things depend on a4a.
       'extensions/amp-ad-custom/0.1/amp-ad-custom.js->extensions/amp-a4a/0.1/amp-ad-network-base.js',
       'extensions/amp-ad-custom/0.1/amp-ad-custom.js->extensions/amp-a4a/0.1/amp-ad-type-defs.js',

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -913,6 +913,17 @@ export class AmpA4A extends AMP.BaseElement {
   }
 
   /**
+   * Allow subclasses to skip client side validation of non-amp creatives
+   * based on http headers for perfomance. When true, ads will fall back to
+   * x-domain earlier.
+   * @param {!Headers} unusedHeaders
+   * @return {boolean}
+   */
+  skipClientSideValidation(unusedHeaders) {
+    return false;
+  }
+
+  /**
    * Start streaming response into the detached document.
    * @param {!Response} httpResponse
    * @param {function()} checkStillCurrent
@@ -922,6 +933,10 @@ export class AmpA4A extends AMP.BaseElement {
     if (httpResponse.status === 204) {
       this.forceCollapse();
       return Promise.reject(NO_CONTENT_RESPONSE);
+    }
+
+    if (this.skipClientSideValidation(httpResponse.headers)) {
+      return this.handleFallback_(httpResponse, checkStillCurrent);
     }
 
     // Duplicating httpResponse stream as safeframe/nameframe rending will need the

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -190,6 +190,24 @@ if (NO_SIGNING_RTV) {
       await a4a.layoutCallback();
       expect(iframe3pInit).to.be.called;
     });
+
+    it('should not try to validate if #skipClientSideValidation', async () => {
+      const fallbackSpy = env.sandbox.spy(a4a, 'handleFallback_');
+      env.sandbox.stub(a4a, 'skipClientSideValidation').returns(true);
+      await a4a.buildCallback();
+      a4a.onLayoutMeasure();
+      await a4a.adPromise_;
+      expect(fallbackSpy).to.be.called;
+    });
+
+    it('should validate if #skipClientSideValidation == false', async () => {
+      const fallbackSpy = env.sandbox.spy(a4a, 'handleFallback_');
+      env.sandbox.stub(a4a, 'skipClientSideValidation').returns(false);
+      await a4a.buildCallback();
+      await a4a.onLayoutMeasure();
+      await a4a.adPromise_;
+      expect(fallbackSpy).not.to.be.called;
+    });
   });
 }
 

--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -20,6 +20,7 @@
 // Most other ad networks will want to put their A4A code entirely in the
 // extensions/amp-ad-network-${NETWORK_NAME}-impl directory.
 
+import {AMP_SIGNATURE_HEADER} from '../../amp-a4a/0.1/signature-verifier';
 import {AdsenseSharedState} from './adsense-shared-state';
 import {AmpA4A} from '../../amp-a4a/0.1/amp-a4a';
 import {CONSENT_POLICY_STATE} from '../../../src/consent-state';
@@ -451,6 +452,13 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
       );
     }
     return this.size_;
+  }
+
+  /**
+   * @override
+   */
+  skipClientSideValidation(headers) {
+    return headers && !headers.has(AMP_SIGNATURE_HEADER);
   }
 
   /**

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -109,6 +109,7 @@ import {getMultiSizeDimensions} from '../../../ads/google/utils';
 
 import {getOrCreateAdCid} from '../../../src/ad-cid';
 
+import {AMP_SIGNATURE_HEADER} from '../../amp-a4a/0.1/signature-verifier';
 import {getPageLayoutBoxBlocking} from '../../../src/utils/page-layout-box';
 import {insertAnalyticsElement} from '../../../src/extension-analytics';
 import {isArray} from '../../../src/types';
@@ -645,6 +646,13 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
       'gdpr': gdprApplies === true ? '1' : gdprApplies === false ? '0' : null,
       'gdpr_consent': consentString,
     };
+  }
+
+  /**
+   * @override
+   */
+  skipClientSideValidation(headers) {
+    return headers && !headers.has(AMP_SIGNATURE_HEADER);
   }
 
   /**


### PR DESCRIPTION
Introduces a new method `skipClientSideValidation(headers)` that ad networks can override with whatever header they choose to fall back to x-domain without trying to validate.

Changes doubleclick and adsense impls to only try validation if `AMP-Fast-Fetch-Signature` header exists.