### PR TITLE
Revert "📦 Update dependency renovate to v24.34.2"

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -22,80 +22,96 @@
 
   "packageRules": [
     {
+      "paths": ["**/*"],
       "groupName": "subpackage devDependencies",
-      "matchPaths": ["**/*"],
       "major": {
         "groupName": null,
         "additionalBranchPrefix": "subpackage-"
       }
     },
+
     {
-      "groupName": "build system devDependencies",
-      "matchPaths": ["build-system/**"],
+      "paths": ["build-system/**"],
       "labels": ["WG: infra"],
+
+      "groupName": "build system devDependencies",
       "major": {
         "groupName": null,
         "additionalBranchPrefix": "build-system-"
       }
     },
+
     {
-      "groupName": "validator devDependencies",
-      "matchPaths": ["validator/**"],
+      "paths": ["validator/**"],
       "labels": ["WG: caching"],
+
+      "groupName": "validator devDependencies",
       "major": {
         "groupName": null,
         "additionalBranchPrefix": "validator-"
       }
     },
+
     {
+      "paths": ["+(package.json)"],
+
       "groupName": "core devDependencies",
-      "matchPaths": ["+(package.json)"],
       "major": {
         "groupName": null,
         "additionalBranchPrefix": "core-"
       }
     },
+
     {
+      "packagePatterns": ["\\b(prettier|eslint)\\b"],
+
       "groupName": "linting devDependencies",
-      "matchPackagePatterns": ["\\b(prettier|eslint)\\b"],
       "major": {
         "groupName": null,
         "additionalBranchPrefix": "linting-"
       }
     },
+
     {
+      "packagePatterns": ["\\bbabel"],
+
       "groupName": "babel devDependencies",
-      "matchPackagePatterns": ["\\bbabel"],
       "major": {
         "groupName": null,
         "additionalBranchPrefix": "babel-"
       }
     },
+
     {
+      "packagePatterns": ["renovate"],
+      "depTypeList": ["devDependencies"],
       "groupName": "Renovate Bot",
-      "matchPackagePatterns": ["renovate"],
-      "matchDepTypes": ["devDependencies"],
-      "matchUpdateTypes": ["major", "minor"],
+      "updateTypes": ["major", "minor"],
       "extends": ["schedule:weekly"]
     },
+
     {
       "excludePackagePatterns": ["^@ampproject/"],
-      "matchDepTypes": ["dependencies"],
+      "depTypeList": ["dependencies"],
       "enabled": false
     },
+
     {
+      "packagePatterns": ["^@ampproject/"],
+      "depTypeList": ["devDependencies"],
+
       "groupName": "ampproject devDependencies",
-      "matchPackagePatterns": ["^@ampproject/"],
-      "matchDepTypes": ["devDependencies"],
       "major": {
         "groupName": null,
         "additionalBranchPrefix": "ampproject-"
       }
     },
+
     {
+      "packagePatterns": ["^@ampproject/"],
+      "depTypeList": ["dependencies"],
+
       "groupName": "ampproject dependencies",
-      "matchPackagePatterns": ["^@ampproject/"],
-      "matchDepTypes": ["dependencies"],
       "major": {
         "groupName": null,
         "additionalBranchPrefix": "ampproject-"

--- a/package-lock.json
+++ b/package-lock.json
@@ -4940,13 +4940,13 @@
       }
     },
     "@npmcli/move-file": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-1.1.1.tgz",
-      "integrity": "sha512-LtWTicuF2wp7PNTuyCwABx7nNG+DnzSE8gN0iWxkC6mpgm/iOPu0ZMTkXuCxmJxtWFsDxUaixM9COSNJEMUfuQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-1.1.0.tgz",
+      "integrity": "sha512-Iv2iq0JuyYjKeFkSR4LPaCdDZwlGK9X2cP/01nJcp3yMJ1FjNd9vpiEYvLUgzBxKPg2SFmaOhizoQsPc0LWeOQ==",
       "dev": true,
       "requires": {
         "mkdirp": "^1.0.4",
-        "rimraf": "^3.0.2"
+        "rimraf": "^2.7.1"
       },
       "dependencies": {
         "mkdirp": {
@@ -4954,15 +4954,6 @@
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
           "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
           "dev": true
-        },
-        "rimraf": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-          "dev": true,
-          "requires": {
-            "glob": "^7.1.3"
-          }
         }
       }
     },
@@ -14185,13 +14176,13 @@
       }
     },
     "git-raw-commits": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-2.0.10.tgz",
-      "integrity": "sha512-sHhX5lsbG9SOO6yXdlwgEMQ/ljIn7qMpAbJZCGfXX2fq5T8M5SrDnpYk9/4HswTildcIqatsWa91vty6VhWSaQ==",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-2.0.9.tgz",
+      "integrity": "sha512-hSpNpxprVno7IOd4PZ93RQ+gNdzPAIrW0x8av6JQDJGV4k1mR9fE01dl8sEqi2P7aKmmwiGUn1BCPuf16Ae0Qw==",
       "dev": true,
       "requires": {
         "dargs": "^7.0.0",
-        "lodash": "^4.17.15",
+        "lodash.template": "^4.0.2",
         "meow": "^8.0.0",
         "split2": "^3.0.0",
         "through2": "^4.0.0"
@@ -14215,12 +14206,37 @@
           }
         },
         "hosted-git-info": {
-          "version": "3.0.8",
-          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-3.0.8.tgz",
-          "integrity": "sha512-aXpmwoOhRBrw6X3j0h5RloK4x1OzsxMPyxqIHyNfSe2pypkVTZFpEiRoSipPEPlMrh0HW/XsjkJ5WgnCirpNUw==",
+          "version": "3.0.7",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-3.0.7.tgz",
+          "integrity": "sha512-fWqc0IcuXs+BmE9orLDyVykAG9GJtGLGuZAAqgcckPgv5xad4AcXGIv8galtQvlwutxSlaMcdw7BUtq2EIvqCQ==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
+          }
+        },
+        "lodash._reinterpolate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+          "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
+          "dev": true
+        },
+        "lodash.template": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.5.0.tgz",
+          "integrity": "sha512-84vYFxIkmidUiFxidA/KjjH9pAycqW+h980j7Fuz5qxRtO9pgB7MDFTdys1N7A5mcucRiDyEq4fusljItR1T/A==",
+          "dev": true,
+          "requires": {
+            "lodash._reinterpolate": "^3.0.0",
+            "lodash.templatesettings": "^4.0.0"
+          }
+        },
+        "lodash.templatesettings": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.2.0.tgz",
+          "integrity": "sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==",
+          "dev": true,
+          "requires": {
+            "lodash._reinterpolate": "^3.0.0"
           }
         },
         "lru-cache": {
@@ -28156,9 +28172,9 @@
       "dev": true
     },
     "renovate": {
-      "version": "24.34.2",
-      "resolved": "https://registry.npmjs.org/renovate/-/renovate-24.34.2.tgz",
-      "integrity": "sha512-4YpejcF1R2YiVAL+thLoIGRQaRnTn4dUZ2IQLPQ3grM25Bjg9joOgOHno7RuwwzQvenV0Ri/d3wGhcK2BNNlSw==",
+      "version": "24.28.4",
+      "resolved": "https://registry.npmjs.org/renovate/-/renovate-24.28.4.tgz",
+      "integrity": "sha512-VJHRWFfM9PnZylx+I6zsfn75MuLi7hbxqQz+aeIU2VCW7kyQyrYUZGwVgv4mWDnOGM1SpJQTlpJDPXEwri+NFg==",
       "dev": true,
       "requires": {
         "@breejs/later": "4.0.2",
@@ -29883,9 +29899,9 @@
       }
     },
     "ssri": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.1.tgz",
-      "integrity": "sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.0.tgz",
+      "integrity": "sha512-aq/pz989nxVYwn16Tsbj1TqFpD5LLrQxHf5zaHuieFV+R0Bbr4y8qUsOA45hXT/N4/9UNXTarBjnjVmjSOVaAA==",
       "dev": true,
       "requires": {
         "minipass": "^3.1.1"
@@ -31334,9 +31350,9 @@
       }
     },
     "typed-rest-client": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.8.1.tgz",
-      "integrity": "sha512-7JbJFBZZuu3G64u6ksklN1xtVGfqBKiR5MQoTe5oLTi68OyB6pRuuIQCllfK/BdGjQtZYp62rgUOnEYDz4e9Xg==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.8.0.tgz",
+      "integrity": "sha512-Nu1MrdH6ECrRW5gHoRAdubgCs4oH6q5/J76jsEC8bVDfvVoVPkigukPalhMHPwb7ZvpsZqPptd5zpt/QdtrdBw==",
       "dev": true,
       "requires": {
         "qs": "^6.9.1",

--- a/package.json
+++ b/package.json
@@ -175,7 +175,7 @@
     "react-dom": "17.0.1",
     "react-externs": "0.13.6",
     "react-with-direction": "1.3.1",
-    "renovate": "24.34.2",
+    "renovate": "24.28.4",
     "request": "2.88.2",
     "request-promise": "4.2.6",
     "rocambole": "0.7.0",


### PR DESCRIPTION
Reverts ampproject/amphtml#32318

Reason for revert: This may have affected incoming renovate PRs. Will revert this and try https://github.com/ampproject/amphtml/pull/32384.