### PR TITLE
fix overly eager iframe unload() call

### DIFF
--- a/extensions/amp-iframe/0.1/amp-iframe.js
+++ b/extensions/amp-iframe/0.1/amp-iframe.js
@@ -640,7 +640,8 @@ export class AmpIframe extends AMP.BaseElement {
       return;
     }
     this.isDisplayed_ = isDisplayed;
-    if (!isDisplayed && this.iframe_) {
+    const hasOwner = !!this.element.getOwner();
+    if (!isDisplayed && !hasOwner && this.iframe_) {
       this.getVsync().mutate(() => this.unload());
     }
   }

--- a/extensions/amp-iframe/0.1/test/test-amp-iframe.js
+++ b/extensions/amp-iframe/0.1/test/test-amp-iframe.js
@@ -1101,6 +1101,26 @@ describes.realWin(
       expect(impl.unload).to.be.calledOnce;
     });
 
+    it('should not unlayout on pause if has owner', async () => {
+      const ampIframe = createAmpIframe(env, {
+        src: iframeSrc,
+        width: 100,
+        height: 100,
+      });
+      const impl = await ampIframe.getImpl(false);
+      impl.element.getOwner = () => ({});
+      await waitForAmpIframeLayoutPromise(doc, ampIframe);
+      expect(ampIframe.querySelector('iframe')).to.exist;
+      expect(ampIframe.unlayoutOnPause()).to.be.false;
+
+      setDisplay(ampIframe, true);
+      setDisplay(ampIframe, false);
+      env.sandbox.stub(impl, 'unload');
+
+      await new Promise(setTimeout);
+      expect(impl.unload).not.called;
+    });
+
     it('should now need pausing before displayed', async () => {
       const ampIframe = createAmpIframe(env, {
         src: iframeSrc,


### PR DESCRIPTION
**summary**
Should not call unlayout if has owner element has owner.

Fixes: https://github.com/ampproject/amphtml/issues/32449, caused by https://github.com/ampproject/amphtml/pull/31976