### PR TITLE
[amp-story] Prerender API

### DIFF
--- a/spec/amp-story-player.md
+++ b/spec/amp-story-player.md
@@ -214,11 +214,10 @@ player.pause();
 
 -   string: the URL of the story to prerender.
 
-Will start loading and prerendering the story on the player. The story will remain in prerender mode and won't be ready for consumption until you call [play()](#play/pause) on the player.
+Will start loading and prerendering the story on the player.
 
 ```javascript
 player.prerender('cool-story.html'); // Will load and prerender cool-story.html
-player.play(); // play() must be called to start playing the story.
 ```
 
 #### getStoryState

--- a/spec/amp-story-player.md
+++ b/spec/amp-story-player.md
@@ -208,6 +208,19 @@ player.play();
 player.pause();
 ```
 
+#### prerender
+
+**Parameters**
+
+-   string: the URL of the story to prerender.
+
+Will start loading and prerendering the story on the player. The story will remain in prerender mode and won't be ready for consumption until you call [play()](#play/pause) on the player.
+
+```javascript
+player.prerender('cool-story.html'); // Will load and prerender cool-story.html
+player.play(); // play() must be called to start playing the story.
+```
+
 #### getStoryState
 
 **Parameters**

--- a/src/amp-story-player/amp-story-player-impl.js
+++ b/src/amp-story-player/amp-story-player-impl.js
@@ -309,8 +309,11 @@ export class AmpStoryPlayer {
    * @public
    */
   prerender(storyUrl) {
+    const storedAutoplay = this.autoplay_;
+
+    // Turning off autoplay will prevent story from being set as visible.
     this.autoplay_ = false;
-    this.show(storyUrl).then(() => (this.autoplay_ = true));
+    this.show(storyUrl).then(() => (this.autoplay_ = storedAutoplay));
   }
 
   /**

--- a/src/amp-story-player/amp-story-player-impl.js
+++ b/src/amp-story-player/amp-story-player-impl.js
@@ -278,7 +278,6 @@ export class AmpStoryPlayer {
    * Adds stories to the player. Additionally, creates or assigns
    * iframes to those that are close to the current playing story.
    * @param {!Array<!{href: string, title: ?string, posterImage: ?string}>} newStories
-   * @return {!Promise}
    * @public
    */
   add(newStories) {
@@ -301,7 +300,7 @@ export class AmpStoryPlayer {
       this.build_(story);
     }
 
-    return this.render_(renderStartingIdx);
+    this.render_(renderStartingIdx);
   }
 
   /**
@@ -743,16 +742,15 @@ export class AmpStoryPlayer {
    */
   show(storyUrl, pageId = null) {
     // TODO(enriqe): sanitize URLs for matching.
-    let storyIdx = storyUrl
+    const storyIdx = storyUrl
       ? findIndex(this.stories_, ({href}) => href === storyUrl)
       : this.currentIdx_;
 
-    let renderPromise = Promise.resolve();
     if (!this.stories_[storyIdx]) {
-      renderPromise = this.add([{href: storyUrl}]);
-      storyIdx = this.stories_.length - 1;
+      throw new Error(`Story URL not found in the player: ${storyUrl}`);
     }
 
+    let renderPromise = Promise.resolve();
     if (storyIdx !== this.currentIdx_) {
       this.currentIdx_ = storyIdx;
 

--- a/src/amp-story-player/amp-story-player-impl.js
+++ b/src/amp-story-player/amp-story-player-impl.js
@@ -257,6 +257,7 @@ export class AmpStoryPlayer {
     this.element_.mute = this.mute.bind(this);
     this.element_.unmute = this.unmute.bind(this);
     this.element_.getStoryState = this.getStoryState.bind(this);
+    this.element_.prerender = this.prerender.bind(this);
   }
 
   /**
@@ -300,6 +301,16 @@ export class AmpStoryPlayer {
     }
 
     this.render_(renderStartingIdx);
+  }
+
+  /**
+   * Prerenders the provided story in the player.
+   * @param {string} storyUrl
+   * @public
+   */
+  prerender(storyUrl) {
+    this.autoplay_ = false;
+    this.show(storyUrl).then(() => (this.autoplay_ = true));
   }
 
   /**
@@ -728,13 +739,13 @@ export class AmpStoryPlayer {
    */
   show(storyUrl, pageId = null) {
     // TODO(enriqe): sanitize URLs for matching.
-    const storyIdx = storyUrl
+    let storyIdx = storyUrl
       ? findIndex(this.stories_, ({href}) => href === storyUrl)
       : this.currentIdx_;
 
-    // TODO(#28987): replace for add() once implemented.
     if (!this.stories_[storyIdx]) {
-      throw new Error(`Story URL not found in the player: ${storyUrl}`);
+      this.add([{href: storyUrl}]);
+      storyIdx = this.stories_.length - 1;
     }
 
     let renderPromise = Promise.resolve();

--- a/src/amp-story-player/amp-story-player-impl.js
+++ b/src/amp-story-player/amp-story-player-impl.js
@@ -278,6 +278,7 @@ export class AmpStoryPlayer {
    * Adds stories to the player. Additionally, creates or assigns
    * iframes to those that are close to the current playing story.
    * @param {!Array<!{href: string, title: ?string, posterImage: ?string}>} newStories
+   * @return {!Promise}
    * @public
    */
   add(newStories) {
@@ -300,7 +301,7 @@ export class AmpStoryPlayer {
       this.build_(story);
     }
 
-    this.render_(renderStartingIdx);
+    return this.render_(renderStartingIdx);
   }
 
   /**
@@ -746,12 +747,12 @@ export class AmpStoryPlayer {
       ? findIndex(this.stories_, ({href}) => href === storyUrl)
       : this.currentIdx_;
 
+    let renderPromise = Promise.resolve();
     if (!this.stories_[storyIdx]) {
-      this.add([{href: storyUrl}]);
+      renderPromise = this.add([{href: storyUrl}]);
       storyIdx = this.stories_.length - 1;
     }
 
-    let renderPromise = Promise.resolve();
     if (storyIdx !== this.currentIdx_) {
       this.currentIdx_ = storyIdx;
 

--- a/test/unit/test-amp-story-player.js
+++ b/test/unit/test-amp-story-player.js
@@ -663,8 +663,9 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
       );
     });
 
-    it('prerender() callback does NOT set story as visible', async () => {
+    it('prerender() callback does NOT set story as visible when autoplay is off', async () => {
       const playerEl = win.document.createElement('amp-story-player');
+      playerEl.appendChild(buildAutoplayConfig(/* autoplay */ false));
       const sendRequestSpy = env.sandbox.spy(fakeMessaging, 'sendRequest');
       attachPlayerWithStories(playerEl, 0);
 
@@ -678,6 +679,24 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
       expect(sendRequestSpy).to.not.have.been.calledWith('visibilitychange', {
         'state': 'visible',
       });
+    });
+
+    it('prerender() callback prerenders a story even if it is not a neighbor of the current story', async () => {
+      const playerEl = win.document.createElement('amp-story-player');
+      attachPlayerWithStories(playerEl, 5);
+
+      const player = new AmpStoryPlayer(win, playerEl);
+
+      await player.load();
+
+      player.prerender('https://example.com/story4.html');
+      await nextTick();
+
+      const storyIframes = playerEl.querySelectorAll('iframe');
+
+      expect(storyIframes[2].getAttribute('src')).to.include(
+        'https://example.com/story4.html#visibilityState=prerender'
+      );
     });
 
     it('adds stories programmatically', async () => {

--- a/test/unit/test-amp-story-player.js
+++ b/test/unit/test-amp-story-player.js
@@ -682,7 +682,6 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
 
     it('prerender() callback adds story to the player if the story has not been added yet', async () => {
       const playerEl = win.document.createElement('amp-story-player');
-      const sendRequestSpy = env.sandbox.spy(fakeMessaging, 'sendRequest');
       attachPlayerWithStories(playerEl, 0);
 
       const player = new AmpStoryPlayer(win, playerEl);
@@ -692,9 +691,11 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
       player.prerender('https://example.com/new-story.html');
       await nextTick();
 
-      expect(sendRequestSpy).to.have.been.calledWith('visibilitychange', {
-        'state': 'visible',
-      });
+      const storyIframes = playerEl.querySelectorAll('iframe');
+
+      expect(storyIframes[0].getAttribute('src')).to.include(
+        'https://example.com/new-story.html#visibilityState=prerender'
+      );
     });
 
     it('prerender() callback does NOT set story as visible', async () => {
@@ -709,7 +710,7 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
       player.prerender('https://example.com/new-story.html');
       await nextTick();
 
-      expect(sendRequestSpy).to.have.been.calledWith('visibilitychange', {
+      expect(sendRequestSpy).to.not.have.been.calledWith('visibilitychange', {
         'state': 'visible',
       });
     });

--- a/test/unit/test-amp-story-player.js
+++ b/test/unit/test-amp-story-player.js
@@ -645,20 +645,73 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
       );
     });
 
-    // TODO(proyectoramirez): delete once add() is implemented.
-    it('show callback should throw when story is not found', async () => {
+    it('show() callback adds story to the player if the story has not been added yet', async () => {
       const playerEl = win.document.createElement('amp-story-player');
-      attachPlayerWithStories(playerEl, 5);
+      attachPlayerWithStories(playerEl, 0);
 
       const player = new AmpStoryPlayer(win, playerEl);
 
       await player.load();
 
-      return expect(() =>
-        player.show('https://example.com/story6.html')
-      ).to.throw(
-        'Story URL not found in the player: https://example.com/story6.html'
+      player.show('https://example.com/new-story.html');
+      await nextTick();
+
+      const storyIframes = playerEl.querySelectorAll('iframe');
+
+      expect(storyIframes[0].getAttribute('src')).to.include(
+        'https://example.com/new-story.html#visibilityState=prerender'
       );
+    });
+
+    it('show() callback adds story to the player if the story has not been added yet and starts playing it', async () => {
+      const playerEl = win.document.createElement('amp-story-player');
+      const sendRequestSpy = env.sandbox.spy(fakeMessaging, 'sendRequest');
+      attachPlayerWithStories(playerEl, 0);
+
+      const player = new AmpStoryPlayer(win, playerEl);
+
+      await player.load();
+
+      player.show('https://example.com/new-story.html');
+      await nextTick();
+
+      expect(sendRequestSpy).to.have.been.calledWith('visibilitychange', {
+        'state': 'visible',
+      });
+    });
+
+    it('prerender() callback adds story to the player if the story has not been added yet', async () => {
+      const playerEl = win.document.createElement('amp-story-player');
+      const sendRequestSpy = env.sandbox.spy(fakeMessaging, 'sendRequest');
+      attachPlayerWithStories(playerEl, 0);
+
+      const player = new AmpStoryPlayer(win, playerEl);
+
+      await player.load();
+
+      player.prerender('https://example.com/new-story.html');
+      await nextTick();
+
+      expect(sendRequestSpy).to.have.been.calledWith('visibilitychange', {
+        'state': 'visible',
+      });
+    });
+
+    it('prerender() callback does NOT set story as visible', async () => {
+      const playerEl = win.document.createElement('amp-story-player');
+      const sendRequestSpy = env.sandbox.spy(fakeMessaging, 'sendRequest');
+      attachPlayerWithStories(playerEl, 0);
+
+      const player = new AmpStoryPlayer(win, playerEl);
+
+      await player.load();
+
+      player.prerender('https://example.com/new-story.html');
+      await nextTick();
+
+      expect(sendRequestSpy).to.have.been.calledWith('visibilitychange', {
+        'state': 'visible',
+      });
     });
 
     it('adds stories programmatically', async () => {

--- a/test/unit/test-amp-story-player.js
+++ b/test/unit/test-amp-story-player.js
@@ -645,41 +645,6 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
       );
     });
 
-    it('show() callback adds story to the player if the story has not been added yet', async () => {
-      const playerEl = win.document.createElement('amp-story-player');
-      attachPlayerWithStories(playerEl, 0);
-
-      const player = new AmpStoryPlayer(win, playerEl);
-
-      await player.load();
-
-      player.show('https://example.com/new-story.html');
-      await nextTick();
-
-      const storyIframes = playerEl.querySelectorAll('iframe');
-
-      expect(storyIframes[0].getAttribute('src')).to.include(
-        'https://example.com/new-story.html#visibilityState=prerender'
-      );
-    });
-
-    it('show() callback adds story to the player if the story has not been added yet and starts playing it', async () => {
-      const playerEl = win.document.createElement('amp-story-player');
-      const sendRequestSpy = env.sandbox.spy(fakeMessaging, 'sendRequest');
-      attachPlayerWithStories(playerEl, 0);
-
-      const player = new AmpStoryPlayer(win, playerEl);
-
-      await player.load();
-
-      player.show('https://example.com/new-story.html');
-      await nextTick();
-
-      expect(sendRequestSpy).to.have.been.calledWith('visibilitychange', {
-        'state': 'visible',
-      });
-    });
-
     it('prerender() callback adds story to the player if the story has not been added yet', async () => {
       const playerEl = win.document.createElement('amp-story-player');
       attachPlayerWithStories(playerEl, 0);


### PR DESCRIPTION
Closes #31900
Closes #30513

Exposes a method which can be used to prerender a story. When desired, `play()` can be called to start playing the story.


It also adds stories to the player if they are missing from when calling `show()`
<!--
# Instructions:

- Pick a meaningful title for your pull request. (Use sentence case.)
  - Prefix the title with an emoji to identify what is being done. (Copy-paste the emoji from the list below.)
  - Do not overuse punctuation in the title (like `(chore):`).
  - If it is helpful, use a simple prefix (like `ProjectX: Implement some feature`).
- Enter a succinct description that says why the PR is necessary, and what it does.
  - Mention the GitHub issue that is being addressed by the pull request.
  - The keywords `Fixes`, `Closes`, or `Resolves` followed the issue number will automatically close the issue.

> NOTE: All non-trivial changes (like introducing new features or components) should have an associated issue or reference an I2I (intent-to-implement: go.amp.dev/i2i). Please read through the contribution process (go.amp.dev/contributing/code) for more information.

# Example of a good description:

- Implement aspect X
- Leave out feature Y because of A
- Improve performance by B
- Improve accessibility by C

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Reverting a previous change
♻️ Refactoring
🚮 Deleting code
🧪 Experimental code
-->
