### PR TITLE
✨ Add Filesize CLI script for easy access locally

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "url": "https://github.com/ampproject/amphtml.git"
   },
   "scripts": {
+    "filesize": "filesize -c=build-system/tasks/bundle-size/filesize.json",
     "preinstall": "node build-system/common/check-package-manager.js"
   },
   "dependencies": {


### PR DESCRIPTION
Introduces a new `npm` script, using the `filesize CLI` directly.

This allows a developer to see the filesizes of the local version of `/dist` using the `filesize` CLI directly.

<img width="661" alt="Screen Shot 2021-02-05 at 3 34 27 PM" src="https://user-images.githubusercontent.com/61764/107099887-b81d1a80-67c7-11eb-83ba-67d72b289ae6.png">
