### PR TITLE
🏗 Replace logging in `gulp bundle-size` with output from `filesize`

### DIFF
--- a/build-system/tasks/bundle-size/index.js
+++ b/build-system/tasks/bundle-size/index.js
@@ -34,9 +34,9 @@ const {
 const {
   VERSION: internalRuntimeVersion,
 } = require('../../compile/internal-version');
-const {cyan, green, red, yellow} = require('ansi-colors');
+const {cyan, red, yellow} = require('ansi-colors');
 const {log} = require('../../common/logging');
-const {report, Report} = require('@ampproject/filesize');
+const {report, NoTTYReport} = require('@ampproject/filesize');
 
 const requestPost = util.promisify(require('request').post);
 
@@ -56,25 +56,18 @@ const replacementExpression = new RegExp(internalRuntimeVersion, 'g');
  */
 async function getBrotliBundleSizes() {
   const bundleSizes = {};
-
-  log(cyan('brotli'), 'bundle sizes are:');
-  await report(
+  const sizes = await report(
     filesizeConfigPath,
     (content) => content.replace(replacementExpression, normalizedRtvNumber),
-    class extends Report {
-      update(context) {
-        const completed = super.getUpdated(context);
-        for (const complete of completed) {
-          const [filePath, sizeMap] = complete;
-          const relativePath = path.relative('.', filePath);
-          const reportedSize = parseFloat((sizeMap[0][0] / 1024).toFixed(2));
-          log(' ', cyan(relativePath) + ':', green(reportedSize + 'KB'));
-          bundleSizes[relativePath] = reportedSize;
-        }
-      }
-    }
+    NoTTYReport,
+    /* silent */ false
   );
-
+  for (const size of sizes) {
+    const [filePath, sizeMap] = size;
+    const relativePath = path.relative('.', filePath);
+    const reportedSize = parseFloat((sizeMap[0][0] / 1024).toFixed(2));
+    bundleSizes[relativePath] = reportedSize;
+  }
   return bundleSizes;
 }
 
@@ -95,7 +88,7 @@ function checkResponse(response, ...successMessages) {
 }
 
 /**
- * Store the bundle size of a commit hash in the build artifacts storage
+ * Store the bundle sizes for a commit hash in the build artifacts storage
  * repository to the passed value.
  */
 async function storeBundleSize() {
@@ -138,7 +131,7 @@ async function storeBundleSize() {
       cyan(shortSha(commitHash)) + '.'
     );
   } catch (error) {
-    log(red('Could not store the bundle size'));
+    log(red('Could not store bundle sizes'));
     log(red(error));
     process.exitCode = 1;
     return;
@@ -201,7 +194,7 @@ async function reportBundleSize() {
         cyan(shortSha(baseSha)) + '.'
       );
     } catch (error) {
-      log(red('Could not report the bundle size of this pull request'));
+      log(red('Could not report the bundle sizes for this pull request'));
       log(red(error));
       process.exitCode = 1;
       return;
@@ -223,7 +216,7 @@ async function getLocalBundleSize() {
     return;
   } else {
     log(
-      'Computing bundle size for version',
+      'Computing bundle sizes for version',
       cyan(internalRuntimeVersion),
       'at commit',
       cyan(shortSha(gitCommitHash())) + '.'
@@ -255,11 +248,11 @@ bundleSize.description =
   'Checks if the minified AMP binary has exceeded its size cap';
 bundleSize.flags = {
   'on_push_build':
-    '  Store bundle size in AMP build artifacts repo ' +
+    '  Store bundle sizes in the AMP build artifacts repo ' +
     '(also implies --on_pr_build)',
-  'on_pr_build': '  Report the bundle size of this pull request to GitHub',
+  'on_pr_build': '  Report the bundle sizes for this pull request to GitHub',
   'on_skipped_build':
     "  Set the status of this pull request's bundle " +
     'size check in GitHub to `skipped`',
-  'on_local_build': '  Compute the bundle size of the locally built runtime',
+  'on_local_build': '  Compute bundle sizes for the locally built runtime',
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -161,16 +161,32 @@
       "integrity": "sha512-Ukegl+czEVP2S6Xd48d8vR/yL1bXd2A2ccUDztW29vVOC7XrJjKSa3bIqecYckuUI+mBfJtzHJKzN6rkscz3jw=="
     },
     "@ampproject/filesize": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@ampproject/filesize/-/filesize-4.2.0.tgz",
-      "integrity": "sha512-Esy8zDHYuXxOjYPkOm7JC6yVs38SAVvWDUq8jMYWVJDi3+cltTdmWyPNB8vDjjKitXfKx6n9bQoeW0hvQ9sH3g==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/filesize/-/filesize-4.3.0.tgz",
+      "integrity": "sha512-ruXED0Xv1gg7STkhs32k+qKFg4eMnnYLjPZ5PhJbYG5Klf9TvcJlVrjjVpbo17gl3pp5mKLSFxbRrI7Le8vaRQ==",
       "dev": true,
       "requires": {
         "@kristoferbaxter/async": "1.0.0",
-        "bytes": "3.1.0",
-        "fast-glob": "3.2.2",
-        "kleur": "3.0.3",
-        "mri": "1.1.5"
+        "@kristoferbaxter/bytes": "0.1.2",
+        "@kristoferbaxter/kleur": "4.0.2",
+        "fast-glob": "3.2.5",
+        "mri": "1.1.6"
+      },
+      "dependencies": {
+        "fast-glob": {
+          "version": "3.2.5",
+          "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.5.tgz",
+          "integrity": "sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==",
+          "dev": true,
+          "requires": {
+            "@nodelib/fs.stat": "^2.0.2",
+            "@nodelib/fs.walk": "^1.2.3",
+            "glob-parent": "^5.1.0",
+            "merge2": "^1.3.0",
+            "micromatch": "^4.0.2",
+            "picomatch": "^2.2.1"
+          }
+        }
       }
     },
     "@ampproject/google-closure-compiler": {
@@ -4907,6 +4923,18 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@kristoferbaxter/async/-/async-1.0.0.tgz",
       "integrity": "sha512-CAQQQ8mUUBKI2P7stYojHwHb+ShdFN8SrC90/96V4m2XlDSctXAA+5PD5CqCICs0o5c/83cYJCeub+FSetKLrw==",
+      "dev": true
+    },
+    "@kristoferbaxter/bytes": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@kristoferbaxter/bytes/-/bytes-0.1.2.tgz",
+      "integrity": "sha512-jEnik0TVc+nxANari0ZQ+4dZYxxA3HTcK9OVglK8kptsczKpW7I7AVCjKcfujTi8V3qrd9oklr8fJAzA4FjWDA==",
+      "dev": true
+    },
+    "@kristoferbaxter/kleur": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@kristoferbaxter/kleur/-/kleur-4.0.2.tgz",
+      "integrity": "sha512-qZzvfOCXECWaCv3GDOd0uw2iqY+/VqMKvrAu1ufwZNjZEVSMjrFWpeQa+8UnezFOtaBF1FxnzN1Y3u42doK01g==",
       "dev": true
     },
     "@kwsites/file-exists": {
@@ -21946,12 +21974,6 @@
         "graceful-fs": "^4.1.9"
       }
     },
-    "kleur": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
-      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
-      "dev": true
-    },
     "labeled-stream-splicer": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-2.0.2.tgz",
@@ -23824,9 +23846,9 @@
       "dev": true
     },
     "mri": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/mri/-/mri-1.1.5.tgz",
-      "integrity": "sha512-d2RKzMD4JNyHMbnbWnznPaa8vbdlq/4pNZ3IgdaGrVbBhebBsGUUE/6qorTMYNS6TwuH3ilfOlD2bf4Igh8CKg==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.1.6.tgz",
+      "integrity": "sha512-oi1b3MfbyGa7FJMP9GmLTttni5JoICpYBRlq+x5V16fZbLsnL9N3wFqqIm/nIG43FjUFkFh9Epzp/kzUGUnJxQ==",
       "dev": true
     },
     "ms": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "0x": "4.10.2",
-    "@ampproject/filesize": "4.2.0",
+    "@ampproject/filesize": "4.3.0",
     "@ampproject/google-closure-compiler": "20210202.0.0",
     "@ampproject/remapping": "1.0.1",
     "@babel/core": "7.12.13",


### PR DESCRIPTION
This PR replaces the custom logging in `gulp bundle-size` with the built-in output from `filesize`. With this, we standardize bundle-size output as follows:

**Local development:**

![image](https://user-images.githubusercontent.com/26553114/107108704-f5090180-6807-11eb-83f8-7728e040e539.png)

**CI builds:**

![image](https://user-images.githubusercontent.com/26553114/107296176-e22c4200-6a3e-11eb-82be-32f58250964f.png)


- [x] TODO: merge and publish https://github.com/ampproject/filesize/pull/127 first, then use the new version of `filesize` in this PR

Companion PR to https://github.com/ampproject/filesize/pull/127
Addresses https://github.com/ampproject/amphtml/pull/32476#discussion_r571330400
