### PR TITLE
🏗 Add a way to run NPM scripts that live outside `package.json` (via `nps`)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -306,7 +306,7 @@ module.exports = {
       },
     },
     {
-      'files': ['babel.config.js', '**/.eslintrc.js'],
+      'files': ['babel.config.js', '**/.eslintrc.js', 'package-scripts.js'],
       'globals': {
         'module': false,
         'process': false,

--- a/OWNERS
+++ b/OWNERS
@@ -25,7 +25,7 @@
       owners: [{name: 'ampproject/wg-infra'}],
     },
     {
-      pattern: '{babel.config.js,package.json,package-lock.json}',
+      pattern: '{babel.config.js,package.json,package-lock.json,package-scripts.js}',
       owners: [
         {name: 'ampproject/wg-infra'},
         {name: 'ampproject/wg-performance'},

--- a/package-scripts.js
+++ b/package-scripts.js
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+/**
+ * @fileoverview
+ *
+ * - Use this file to store NPM scripts that aid in development but
+ *   are not available via AMP's gulp tasks in build-system/tasks/.
+ * - To use these scripts, first install npm-package-scripts by running
+ *   "npm install --global nps" (or for short, "npm i -g nps").
+ * - Once installed, run any script by calling "nps <scriptname>".
+ * - For more info, see https://www.npmjs.com/package/nps#scripts-1
+ */
+
+module.exports = {
+  scripts: {
+    filesize: 'filesize -c=build-system/tasks/bundle-size/filesize.json',
+  },
+};


### PR DESCRIPTION
This PR introduces a way to run `npm` scripts without adding them to `package.json`. Scripts are defined in `package-scripts.js` and run using [`nps`](https://www.npmjs.com/package/nps) (short for `npm-package-scripts`).

This will prevent us from going back to a situation like this:

https://github.com/ampproject/amphtml/blob/ee2dea74e954ceaf5c284bfbfb2f81416858fa9a/package.json#L17-L26


**Usage:**
```sh
# One-time install of package script runner
npm i -g nps

# Invoke any script
nps filesize
```

**Example:**

![image](https://user-images.githubusercontent.com/26553114/107109352-b9713600-680d-11eb-8eab-b59059beda0c.png)


Addresses https://github.com/ampproject/amphtml/pull/32476#discussion_r571330400