### PR TITLE
🏗🚀 Provide a way to synchronously transform CSS in Babel

### DIFF
--- a/build-system/babel-plugins/babel-plugin-transform-jss/test/fixtures/transform-assertions/ignore-unrelated-exports/output.mjs
+++ b/build-system/babel-plugins/babel-plugin-transform-jss/test/fixtures/transform-assertions/ignore-unrelated-exports/output.mjs
@@ -20,6 +20,6 @@ var _classes = {
  */
 export const useStyles = () => _classes; // These next lines should be unaffected by jss transform.
 
-export const CSS = ".float-left-07984bd{float:left}\n";
+export const CSS = ".float-left-07984bd{float:left}";
 export const unrelated = 5;
 unrelated + unrelated == unrelated * 2;

--- a/build-system/babel-plugins/babel-plugin-transform-jss/test/fixtures/transform-assertions/should-transform-jss-var/output.mjs
+++ b/build-system/babel-plugins/babel-plugin-transform-jss/test/fixtures/transform-assertions/should-transform-jss-var/output.mjs
@@ -24,4 +24,4 @@ const JSS = {
   }
 };
 export const useStyles = () => _classes;
-export const CSS = ".button-21aa4a8{font-size:12px}\n";
+export const CSS = ".button-21aa4a8{font-size:12px}";

--- a/build-system/babel-plugins/babel-plugin-transform-jss/test/fixtures/transform-assertions/should-transform-literal/output.mjs
+++ b/build-system/babel-plugins/babel-plugin-transform-jss/test/fixtures/transform-assertions/should-transform-literal/output.mjs
@@ -20,4 +20,4 @@ var _classes = {
  * limitations under the License.
  */
 export const useStyles = () => _classes;
-export const CSS = ".float-left-a6c6677{float:left;border:1px solid #000}.fill-a6c6677{-ms-flex:1 1 auto;flex:1 1 auto;display:block;position:relative}\n";
+export const CSS = ".float-left-a6c6677{float:left;border:1px solid #000}.fill-a6c6677{-ms-flex:1 1 auto;flex:1 1 auto;display:block;position:relative}";

--- a/build-system/tasks/babel-plugin-tests.js
+++ b/build-system/tasks/babel-plugin-tests.js
@@ -27,6 +27,7 @@ async function babelPluginTests() {
   const options = {
     automock: false,
     coveragePathIgnorePatterns: ['/node_modules/'],
+    detectOpenHandles: true,
     modulePathIgnorePatterns: ['/test/fixtures/', '<rootDir>/build/'],
     reporters: [isCiBuild() ? 'jest-silent-reporter' : 'jest-dot-reporter'],
     setupFiles: ['./build-system/babel-plugins/testSetupFile.js'],

--- a/build-system/tasks/css/index.js
+++ b/build-system/tasks/css/index.js
@@ -23,10 +23,10 @@ const {
   mkdirSync,
   toPromise,
   watchDebounceDelay,
-} = require('./helpers');
-const {buildExtensions} = require('./extension-helpers');
+} = require('../helpers');
+const {buildExtensions} = require('../extension-helpers');
 const {jsifyCssAsync} = require('./jsify-css');
-const {maybeUpdatePackages} = require('./update-packages');
+const {maybeUpdatePackages} = require('../update-packages');
 const {watch} = require('gulp');
 
 /**

--- a/build-system/tasks/css/init-sync.js
+++ b/build-system/tasks/css/init-sync.js
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+const {transformCss} = require('./jsify-css');
+
+/**
+ * Wrapper for the asynchronous transformCss that is used by transformCssSync()
+ * in build-system/tasks/css/jsify-css-sync.js.
+ * @return {!Promise}
+ */
+function init() {
+  return function (cssStr, opt_cssnano, opt_filename) {
+    return Promise.resolve(transformCss(cssStr, opt_cssnano, opt_filename));
+  };
+}
+module.exports = init;

--- a/build-system/tasks/css/jsify-css-sync.js
+++ b/build-system/tasks/css/jsify-css-sync.js
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+/**
+ * Lazily instantiate the transformer.
+ */
+let syncTransformer;
+
+/**
+ * Synchronously transforms a css string using postcss.
+
+ * @param {string} cssStr the css text to transform
+ * @param {!Object=} opt_cssnano cssnano options
+ * @param {!Object=} opt_filename the filename of the file being transformed. Used for sourcemaps generation.
+ * @return {Object} The transformation result
+ */
+function transformCssSync(cssStr, opt_cssnano, opt_filename) {
+  if (!syncTransformer) {
+    syncTransformer = require('sync-rpc')(__dirname + '/init-sync.js');
+  }
+  return syncTransformer(cssStr, opt_cssnano, opt_filename);
+}
+
+module.exports = {
+  transformCssSync,
+};

--- a/build-system/tasks/css/jsify-css.js
+++ b/build-system/tasks/css/jsify-css.js
@@ -20,7 +20,7 @@ const cssnano = require('cssnano');
 const fs = require('fs-extra');
 const postcss = require('postcss');
 const postcssImport = require('postcss-import');
-const {log} = require('../common/logging');
+const {log} = require('../../common/logging');
 const {red} = require('ansi-colors');
 
 // NOTE: see https://github.com/ai/browserslist#queries for `browsers` list

--- a/build-system/tasks/extension-helpers.js
+++ b/build-system/tasks/extension-helpers.js
@@ -26,7 +26,7 @@ const {
 const {analyticsVendorConfigs} = require('./analytics-vendor-configs');
 const {endBuildStep, watchDebounceDelay} = require('./helpers');
 const {isCiBuild} = require('../common/ci');
-const {jsifyCssAsync} = require('./jsify-css');
+const {jsifyCssAsync} = require('./css/jsify-css');
 const {log} = require('../common/logging');
 const {maybeToEsmName, compileJs, mkdirSync} = require('./helpers');
 const {watch} = require('gulp');

--- a/package-lock.json
+++ b/package-lock.json
@@ -30569,6 +30569,23 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true
     },
+    "sync-rpc": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/sync-rpc/-/sync-rpc-1.3.6.tgz",
+      "integrity": "sha512-J8jTXuZzRlvU7HemDgHi3pGnh/rkoqR/OZSjhTyyZrEkkYQbk7Z33AXp37mkPfPpfdOuj7Ex3H/TJM1z48uPQw==",
+      "dev": true,
+      "requires": {
+        "get-port": "^3.1.0"
+      },
+      "dependencies": {
+        "get-port": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/get-port/-/get-port-3.2.0.tgz",
+          "integrity": "sha1-3Xzn3hh8Bsi/NTeWrHHgmfCYDrw=",
+          "dev": true
+        }
+      }
+    },
     "syntax-error": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -181,6 +181,7 @@
     "sinon": "9.2.4",
     "sinon-chai": "3.5.0",
     "sourcemap-codec": "1.4.8",
+    "sync-rpc": "1.3.6",
     "tar": "6.1.0",
     "tcp-port-used": "1.0.2",
     "tempy": "1.0.0",


### PR DESCRIPTION
**Background:**

#30206 added a `babel` plugin for JSS transforms via `postcss`. Since `babel` is sync but `postcss` plugins are async, the PR used a `child_process` hack. See https://github.com/ampproject/amphtml/pull/30206#discussion_r487310574 for the gory details. Under a profiler, each transform takes 2-3s to execute.

**PR highlights:**

This PR adds a [`sync-rpc`](https://www.npmjs.com/package/sync-rpc) wrapper to the transform function. It too uses a `child_process`, but the overhead is paid for just the first call. Every subsequent transform executes in < 50ms. Gains will be higher as the number of JSS transforms increases.

**Time spent by `gulp dist` on transforms:**

**Before:** 8%.

![image](https://user-images.githubusercontent.com/26553114/107155033-21299d00-6944-11eb-9bb3-1a26927c786b.png)

**After:** 1%.

![image](https://user-images.githubusercontent.com/26553114/107155041-2ab30500-6944-11eb-9fca-78893e8a95d3.png)


Addresses https://github.com/ampproject/amphtml/pull/30206#issue-485410038