### PR TITLE
[amp-story] Prevent clicks on top 80%

### DIFF
--- a/extensions/amp-story/1.0/page-advancement.js
+++ b/extensions/amp-story/1.0/page-advancement.js
@@ -440,11 +440,12 @@ export class ManualAdvancement extends AdvancementConfig {
    * We want clicks on certain elements to be exempted from normal page
    * navigation
    * @param {!Event} event
+   * @param {!ClientRect} pageRect
    * @return {boolean}
    * @private
    */
-  isProtectedTarget_(event) {
-    return !!closest(
+  isBottomCtaTappableTarget_(event, pageRect) {
+    const target = closest(
       dev().assertElement(event.target),
       (el) => {
         const elementRole = el.getAttribute('role');
@@ -456,6 +457,8 @@ export class ManualAdvancement extends AdvancementConfig {
       },
       /* opt_stopAt */ this.element_
     );
+
+    return !!target && this.isInScreenBottom_(target, pageRect);
   }
 
   /**
@@ -708,8 +711,7 @@ export class ManualAdvancement extends AdvancementConfig {
     if (
       !this.isRunning() ||
       !this.isNavigationalClick_(event) ||
-      (this.isProtectedTarget_(event) &&
-        this.isInScreenBottom_(event.target, pageRect)) ||
+      this.isBottomCtaTappableTarget_(event, pageRect) ||
       !this.shouldHandleEvent_(event)
     ) {
       // If the system doesn't need to handle this click, then we can simply

--- a/extensions/amp-story/1.0/page-advancement.js
+++ b/extensions/amp-story/1.0/page-advancement.js
@@ -708,7 +708,8 @@ export class ManualAdvancement extends AdvancementConfig {
     if (
       !this.isRunning() ||
       !this.isNavigationalClick_(event) ||
-      this.isProtectedTarget_(event) ||
+      (this.isProtectedTarget_(event) &&
+        this.isInScreenBottom_(event.target, pageRect)) ||
       !this.shouldHandleEvent_(event)
     ) {
       // If the system doesn't need to handle this click, then we can simply
@@ -717,6 +718,7 @@ export class ManualAdvancement extends AdvancementConfig {
     }
 
     event.stopPropagation();
+    event.preventDefault();
 
     this.storeService_.dispatch(
       Action.SET_ADVANCEMENT_MODE,


### PR DESCRIPTION
Closes #32258

There are still ways to circumvent the bottom 20% restriction for the amp-story-cta-layer. e.g. using `transform: translateY(-80%);`. 

This PR fixes this by checking if the click was in the bottom of the screen.  

Note that `amp-story-cta` adds `role="link / button"` to links & buttons respectively. So on `page-navigation.js` we currently consider this a "protected target" when checking `isProtectedTarget_()`, which returns early and prevents navigation.  

<!--
# Instructions:

- Pick a meaningful title for your pull request. (Use sentence case.)
  - Prefix the title with an emoji to identify what is being done. (Copy-paste the emoji from the list below.)
  - Do not overuse punctuation in the title (like `(chore):`).
  - If it is helpful, use a simple prefix (like `ProjectX: Implement some feature`).
- Enter a succinct description that says why the PR is necessary, and what it does.
  - Mention the GitHub issue that is being addressed by the pull request.
  - The keywords `Fixes`, `Closes`, or `Resolves` followed the issue number will automatically close the issue.

> NOTE: All non-trivial changes (like introducing new features or components) should have an associated issue or reference an I2I (intent-to-implement: go.amp.dev/i2i). Please read through the contribution process (go.amp.dev/contributing/code) for more information.

# Example of a good description:

- Implement aspect X
- Leave out feature Y because of A
- Improve performance by B
- Improve accessibility by C

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Reverting a previous change
♻️ Refactoring
🚮 Deleting code
🧪 Experimental code
-->
